### PR TITLE
refactor(workspace): expose active workspace identity as readonly

### DIFF
--- a/src/platform/cloud/subscription/composables/useSubscription.test.ts
+++ b/src/platform/cloud/subscription/composables/useSubscription.test.ts
@@ -365,6 +365,52 @@ describe('useSubscription', () => {
       )
     })
 
+    it('does not apply the previous account response after an identity switch', async () => {
+      let resolvePreviousAccount!: (value: {
+        is_active: boolean
+        has_funds: boolean
+        billing_rail: 'stripe'
+      }) => void
+      mockGetBillingStatus
+        .mockReturnValueOnce(
+          new Promise((resolve) => {
+            resolvePreviousAccount = resolve
+          })
+        )
+        .mockResolvedValueOnce({
+          is_active: false,
+          has_funds: false,
+          billing_rail: 'legacy_stripe'
+        })
+
+      const { subscriptionStatus, fetchStatus } = useSubscriptionWithScope()
+      const previousAccountRequest = fetchStatus()
+
+      mockUserId.value = 'user-456'
+      mockActiveWorkspaceId.value = 'workspace-456'
+      const currentAccountRequest = fetchStatus()
+      await currentAccountRequest
+
+      resolvePreviousAccount({
+        is_active: true,
+        has_funds: true,
+        billing_rail: 'stripe'
+      })
+      await previousAccountRequest
+
+      expect(mockGetBillingStatus).toHaveBeenCalledTimes(2)
+      expect(subscriptionStatus.value).toEqual({
+        is_active: false,
+        has_funds: false,
+        billing_rail: 'legacy_stripe'
+      })
+      expect(mockSetWorkspaceBillingRail).toHaveBeenCalledOnce()
+      expect(mockSetWorkspaceBillingRail).toHaveBeenCalledWith(
+        'workspace-456',
+        'legacy_stripe'
+      )
+    })
+
     it('coalesces concurrent callers into one fetch', async () => {
       let resolveStatus: (value: {
         is_active: boolean

--- a/src/platform/cloud/subscription/composables/useSubscription.test.ts
+++ b/src/platform/cloud/subscription/composables/useSubscription.test.ts
@@ -377,7 +377,8 @@ describe('useSubscription', () => {
         })
       )
 
-      const { fetchStatus } = useSubscriptionWithScope()
+      const { subscriptionStatus, fetchStatus } = useSubscriptionWithScope()
+      const statusBefore = subscriptionStatus.value
       const statusRequest = fetchStatus()
       mockActiveWorkspaceId.value = 'workspace-456'
       resolveStatus({
@@ -388,6 +389,40 @@ describe('useSubscription', () => {
       await statusRequest
 
       expect(mockSetWorkspaceBillingRail).not.toHaveBeenCalled()
+      expect(subscriptionStatus.value).toBe(statusBefore)
+    })
+
+    it('fetches for the new workspace when one is switched to mid-request', async () => {
+      let resolveFirst: (value: {
+        is_active: boolean
+        has_funds: boolean
+      }) => void = () => {}
+      mockGetBillingStatus.mockReturnValueOnce(
+        new Promise((resolve) => {
+          resolveFirst = resolve
+        })
+      )
+      mockGetBillingStatus.mockResolvedValueOnce({
+        is_active: false,
+        has_funds: false,
+        billing_rail: 'legacy_stripe'
+      })
+
+      const { subscriptionStatus, fetchStatus } = useSubscriptionWithScope()
+      const firstRequest = fetchStatus()
+
+      mockActiveWorkspaceId.value = 'workspace-456'
+      const secondRequest = fetchStatus()
+
+      resolveFirst({ is_active: true, has_funds: true })
+      await Promise.all([firstRequest, secondRequest])
+
+      expect(mockGetBillingStatus).toHaveBeenCalledTimes(2)
+      expect(subscriptionStatus.value).toEqual({
+        is_active: false,
+        has_funds: false,
+        billing_rail: 'legacy_stripe'
+      })
     })
 
     it('coalesces concurrent callers into one fetch', async () => {

--- a/src/platform/cloud/subscription/composables/useSubscription.test.ts
+++ b/src/platform/cloud/subscription/composables/useSubscription.test.ts
@@ -365,66 +365,6 @@ describe('useSubscription', () => {
       )
     })
 
-    it('does not apply status after the active workspace changes', async () => {
-      let resolveStatus: (value: {
-        is_active: boolean
-        has_funds: boolean
-        billing_rail: 'stripe'
-      }) => void = () => {}
-      mockGetBillingStatus.mockReturnValue(
-        new Promise((resolve) => {
-          resolveStatus = resolve
-        })
-      )
-
-      const { subscriptionStatus, fetchStatus } = useSubscriptionWithScope()
-      const statusBefore = subscriptionStatus.value
-      const statusRequest = fetchStatus()
-      mockActiveWorkspaceId.value = 'workspace-456'
-      resolveStatus({
-        is_active: true,
-        has_funds: true,
-        billing_rail: 'stripe'
-      })
-      await statusRequest
-
-      expect(mockSetWorkspaceBillingRail).not.toHaveBeenCalled()
-      expect(subscriptionStatus.value).toBe(statusBefore)
-    })
-
-    it('fetches for the new workspace when one is switched to mid-request', async () => {
-      let resolveFirst: (value: {
-        is_active: boolean
-        has_funds: boolean
-      }) => void = () => {}
-      mockGetBillingStatus.mockReturnValueOnce(
-        new Promise((resolve) => {
-          resolveFirst = resolve
-        })
-      )
-      mockGetBillingStatus.mockResolvedValueOnce({
-        is_active: false,
-        has_funds: false,
-        billing_rail: 'legacy_stripe'
-      })
-
-      const { subscriptionStatus, fetchStatus } = useSubscriptionWithScope()
-      const firstRequest = fetchStatus()
-
-      mockActiveWorkspaceId.value = 'workspace-456'
-      const secondRequest = fetchStatus()
-
-      resolveFirst({ is_active: true, has_funds: true })
-      await Promise.all([firstRequest, secondRequest])
-
-      expect(mockGetBillingStatus).toHaveBeenCalledTimes(2)
-      expect(subscriptionStatus.value).toEqual({
-        is_active: false,
-        has_funds: false,
-        billing_rail: 'legacy_stripe'
-      })
-    })
-
     it('coalesces concurrent callers into one fetch', async () => {
       let resolveStatus: (value: {
         is_active: boolean

--- a/src/platform/cloud/subscription/composables/useSubscription.ts
+++ b/src/platform/cloud/subscription/composables/useSubscription.ts
@@ -350,16 +350,40 @@ function useSubscriptionInternal() {
 
   // Coalesce concurrent callers so an auth/session-rotation burst mints one fetch.
   let inFlightStatusFetch: Promise<BillingStatusResponse | null> | null = null
+  let inFlightStatusOwnerId: string | null = null
+  let inFlightStatusWorkspaceId: string | null = null
 
   async function fetchSubscriptionStatus(): Promise<BillingStatusResponse | null> {
-    if (inFlightStatusFetch) return inFlightStatusFetch
-    inFlightStatusFetch = performFetchSubscriptionStatus().finally(() => {
-      inFlightStatusFetch = null
-    })
-    return inFlightStatusFetch
+    const ownerId = authStore.userId ?? null
+    const workspaceId = workspaceStore.activeWorkspaceId
+    if (
+      inFlightStatusFetch &&
+      inFlightStatusOwnerId === ownerId &&
+      inFlightStatusWorkspaceId === workspaceId
+    ) {
+      return inFlightStatusFetch
+    }
+
+    const fetchPromise = performFetchSubscriptionStatus(ownerId, workspaceId)
+    inFlightStatusFetch = fetchPromise
+    inFlightStatusOwnerId = ownerId
+    inFlightStatusWorkspaceId = workspaceId
+    void fetchPromise
+      .catch(() => undefined)
+      .finally(() => {
+        if (inFlightStatusFetch === fetchPromise) {
+          inFlightStatusFetch = null
+          inFlightStatusOwnerId = null
+          inFlightStatusWorkspaceId = null
+        }
+      })
+    return fetchPromise
   }
 
-  async function performFetchSubscriptionStatus(): Promise<BillingStatusResponse | null> {
+  async function performFetchSubscriptionStatus(
+    ownerId: string | null,
+    workspaceId: string | null
+  ): Promise<BillingStatusResponse | null> {
     if (!isCloud) return null
 
     let statusData: BillingStatusResponse
@@ -372,8 +396,13 @@ function useSubscriptionInternal() {
         })
       )
     }
+    if (
+      (authStore.userId ?? null) !== ownerId ||
+      workspaceStore.activeWorkspaceId !== workspaceId
+    ) {
+      return null
+    }
     subscriptionStatus.value = statusData
-    const workspaceId = workspaceStore.activeWorkspaceId
     if (workspaceId && statusData.billing_rail) {
       workspaceStore.setWorkspaceBillingRail(
         workspaceId,
@@ -416,7 +445,8 @@ function useSubscriptionInternal() {
   })
 
   watch(
-    () => [authStore.isInitialized, isLoggedIn.value] as const,
+    () =>
+      [authStore.isInitialized, isLoggedIn.value, authStore.userId] as const,
     async ([authInitialized, loggedIn]) => {
       if (!authInitialized) {
         return

--- a/src/platform/cloud/subscription/composables/useSubscription.ts
+++ b/src/platform/cloud/subscription/composables/useSubscription.ts
@@ -349,36 +349,19 @@ function useSubscriptionInternal() {
   }
 
   // Coalesce concurrent callers so an auth/session-rotation burst mints one fetch.
-  // Keyed by workspace: performFetchSubscriptionStatus resolves null for a
-  // workspace that is no longer active, so sharing across workspaces strands one.
   let inFlightStatusFetch: Promise<BillingStatusResponse | null> | null = null
-  let inFlightStatusWorkspaceId: string | null = null
-  let latestStatusRequestId = 0
 
   async function fetchSubscriptionStatus(): Promise<BillingStatusResponse | null> {
-    const workspaceId = workspaceStore.activeWorkspaceId
-    if (inFlightStatusFetch && inFlightStatusWorkspaceId === workspaceId) {
-      return inFlightStatusFetch
-    }
-    const fetchPromise = performFetchSubscriptionStatus()
-    inFlightStatusFetch = fetchPromise
-    inFlightStatusWorkspaceId = workspaceId
-    void fetchPromise
-      .catch(() => undefined)
-      .finally(() => {
-        if (inFlightStatusFetch === fetchPromise) {
-          inFlightStatusFetch = null
-          inFlightStatusWorkspaceId = null
-        }
-      })
-    return fetchPromise
+    if (inFlightStatusFetch) return inFlightStatusFetch
+    inFlightStatusFetch = performFetchSubscriptionStatus().finally(() => {
+      inFlightStatusFetch = null
+    })
+    return inFlightStatusFetch
   }
 
   async function performFetchSubscriptionStatus(): Promise<BillingStatusResponse | null> {
     if (!isCloud) return null
 
-    const requestId = ++latestStatusRequestId
-    const workspaceId = workspaceStore.activeWorkspaceId
     let statusData: BillingStatusResponse
     try {
       statusData = await workspaceApi.getBillingStatus()
@@ -389,13 +372,8 @@ function useSubscriptionInternal() {
         })
       )
     }
-    if (
-      requestId !== latestStatusRequestId ||
-      workspaceId !== workspaceStore.activeWorkspaceId
-    ) {
-      return null
-    }
     subscriptionStatus.value = statusData
+    const workspaceId = workspaceStore.activeWorkspaceId
     if (workspaceId && statusData.billing_rail) {
       workspaceStore.setWorkspaceBillingRail(
         workspaceId,

--- a/src/platform/cloud/subscription/composables/useSubscription.ts
+++ b/src/platform/cloud/subscription/composables/useSubscription.ts
@@ -349,15 +349,29 @@ function useSubscriptionInternal() {
   }
 
   // Coalesce concurrent callers so an auth/session-rotation burst mints one fetch.
+  // Keyed by workspace: performFetchSubscriptionStatus resolves null for a
+  // workspace that is no longer active, so sharing across workspaces strands one.
   let inFlightStatusFetch: Promise<BillingStatusResponse | null> | null = null
+  let inFlightStatusWorkspaceId: string | null = null
   let latestStatusRequestId = 0
 
   async function fetchSubscriptionStatus(): Promise<BillingStatusResponse | null> {
-    if (inFlightStatusFetch) return inFlightStatusFetch
-    inFlightStatusFetch = performFetchSubscriptionStatus().finally(() => {
-      inFlightStatusFetch = null
-    })
-    return inFlightStatusFetch
+    const workspaceId = workspaceStore.activeWorkspaceId
+    if (inFlightStatusFetch && inFlightStatusWorkspaceId === workspaceId) {
+      return inFlightStatusFetch
+    }
+    const fetchPromise = performFetchSubscriptionStatus()
+    inFlightStatusFetch = fetchPromise
+    inFlightStatusWorkspaceId = workspaceId
+    void fetchPromise
+      .catch(() => undefined)
+      .finally(() => {
+        if (inFlightStatusFetch === fetchPromise) {
+          inFlightStatusFetch = null
+          inFlightStatusWorkspaceId = null
+        }
+      })
+    return fetchPromise
   }
 
   async function performFetchSubscriptionStatus(): Promise<BillingStatusResponse | null> {

--- a/src/platform/workspace/components/CurrentUserPopoverWorkspace.test.ts
+++ b/src/platform/workspace/components/CurrentUserPopoverWorkspace.test.ts
@@ -24,6 +24,24 @@ const state = vi.hoisted(() => ({
   showSettingsDialog: vi.fn()
 }))
 
+const workspaceStoreMock = vi.hoisted(() => ({
+  store: null as null | {
+    initState: string
+    workspaceName: string
+    isInPersonalWorkspace: boolean
+  }
+}))
+
+vi.mock('@/platform/workspace/stores/teamWorkspaceStore', async () => {
+  const { reactive, ref } = await import('vue')
+  workspaceStoreMock.store = reactive({
+    initState: ref('ready'),
+    workspaceName: ref('Personal Workspace'),
+    isInPersonalWorkspace: ref(true)
+  })
+  return { useTeamWorkspaceStore: () => workspaceStoreMock.store }
+})
+
 vi.mock('@/composables/auth/useCurrentUser', () => ({
   useCurrentUser: () => ({
     userDisplayName: ref('Liz'),
@@ -105,43 +123,19 @@ const i18n = createI18n({
   messages: { en: enMessages }
 })
 
-function createWorkspaceState(
-  type: 'personal' | 'team',
-  role: 'owner' | 'member'
-) {
-  return {
-    id: `ws-${type}`,
-    name: `${type === 'personal' ? 'Personal' : 'Team'} Workspace`,
-    type,
-    role,
-    created_at: '2026-01-01T00:00:00Z',
-    joined_at: '2026-01-01T00:00:00Z',
-    isSubscribed: true,
-    subscriptionPlan: 'team-pro-monthly',
-    subscriptionTier: 'PRO',
-    members: [],
-    pendingInvites: []
-  }
-}
-
 function renderComponent(
   type: 'personal' | 'team' = 'personal',
-  role: 'owner' | 'member' = 'member',
   accountActionsOnly = false
 ) {
+  if (!workspaceStoreMock.store) throw new Error('Workspace store not ready')
+  workspaceStoreMock.store.workspaceName = `${type === 'personal' ? 'Personal' : 'Team'} Workspace`
+  workspaceStoreMock.store.isInPersonalWorkspace = type === 'personal'
   return render(CurrentUserPopoverWorkspace, {
     props: { accountActionsOnly },
     global: {
       plugins: [
         createTestingPinia({
-          createSpy: vi.fn,
-          initialState: {
-            teamWorkspace: {
-              initState: 'ready',
-              activeWorkspaceId: `ws-${type}`,
-              workspaces: [createWorkspaceState(type, role)]
-            }
-          }
+          createSpy: vi.fn
         }),
         PrimeVue,
         i18n
@@ -189,7 +183,7 @@ describe('CurrentUserPopoverWorkspace', () => {
   })
 
   it('keeps account actions available without workspace context', () => {
-    renderComponent('personal', 'member', true)
+    renderComponent('personal', true)
 
     expect(screen.getByTestId('user-settings-menu-item')).toBeInTheDocument()
     expect(screen.getByTestId('logout-menu-item')).toBeInTheDocument()
@@ -204,7 +198,7 @@ describe('CurrentUserPopoverWorkspace', () => {
 
   it('exposes the full workspace name on hover', async () => {
     const user = userEvent.setup()
-    renderComponent('team', 'member')
+    renderComponent('team')
 
     await user.hover(screen.getByTestId('workspace-switcher-trigger'))
 
@@ -240,7 +234,7 @@ describe('CurrentUserPopoverWorkspace', () => {
   })
 
   it('keeps a team workspace member read-only', () => {
-    renderComponent('team', 'member')
+    renderComponent('team')
 
     expect(screen.getByText('211')).toBeInTheDocument()
     expect(screen.queryByTestId('add-credits-button')).not.toBeInTheDocument()
@@ -307,7 +301,7 @@ describe('CurrentUserPopoverWorkspace', () => {
       state.canManageSubscription = canManageSubscription
       state.canManageSubscriptionLifecycle = canManageSubscriptionLifecycle
 
-      renderComponent('team', 'owner')
+      renderComponent('team')
 
       const subscribeAction = screen.queryByRole('button', { name: action })
       if (visible) {
@@ -324,7 +318,7 @@ describe('CurrentUserPopoverWorkspace', () => {
     state.canTopUp = true
     state.canManageSubscription = true
     state.canManageSubscriptionLifecycle = true
-    renderComponent('team', 'owner')
+    renderComponent('team')
 
     expect(screen.getByTestId('add-credits-button')).toBeInTheDocument()
     expect(screen.getByTestId('plans-pricing-menu-item')).toBeInTheDocument()
@@ -339,7 +333,7 @@ describe('CurrentUserPopoverWorkspace', () => {
     it(`opens workspace plan management for a ${workspaceType} owner`, async () => {
       const user = userEvent.setup()
       state.canManageSubscription = true
-      const { emitted } = renderComponent(workspaceType, 'owner')
+      const { emitted } = renderComponent(workspaceType)
 
       const menuItem = screen.getByTestId('manage-plan-menu-item')
       expect(menuItem).toHaveTextContent(enMessages.subscription.managePlan)

--- a/src/platform/workspace/stores/partnerNodeGovernanceStore.test.ts
+++ b/src/platform/workspace/stores/partnerNodeGovernanceStore.test.ts
@@ -10,7 +10,20 @@ import type {
 } from '@/platform/workspace/api/partnerNodePolicyApi'
 import { PartnerNodePolicyApiError } from '@/platform/workspace/api/partnerNodePolicyApi'
 import { usePartnerNodeGovernanceStore } from '@/platform/workspace/stores/partnerNodeGovernanceStore'
-import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
+
+const mockTeamWorkspaceStore = vi.hoisted(() => ({
+  store: null as null | {
+    activeWorkspace: null | { id: string; type: 'personal' | 'team' }
+  }
+}))
+
+vi.mock('@/platform/workspace/stores/teamWorkspaceStore', async () => {
+  const { reactive } = await import('vue')
+  mockTeamWorkspaceStore.store = reactive({ activeWorkspace: null })
+  return {
+    useTeamWorkspaceStore: () => mockTeamWorkspaceStore.store
+  }
+})
 
 const mockGetPartnerNodePolicy = vi.hoisted(() => vi.fn())
 const mockGetPartnerProviders = vi.hoisted(() => vi.fn())
@@ -50,23 +63,9 @@ const providers: PartnerProvider[] = [
 ]
 
 function activateWorkspace(id: string, type: 'personal' | 'team' = 'team') {
-  const store = useTeamWorkspaceStore()
-  store.workspaces = [
-    {
-      id,
-      name: id,
-      type,
-      role: 'owner',
-      created_at: '2026-01-01T00:00:00Z',
-      joined_at: '2026-01-01T00:00:00Z',
-      isSubscribed: false,
-      subscriptionPlan: null,
-      subscriptionTier: null,
-      members: [],
-      pendingInvites: []
-    }
-  ]
-  store.activeWorkspaceId = id
+  if (!mockTeamWorkspaceStore.store)
+    throw new Error('Workspace store not ready')
+  mockTeamWorkspaceStore.store.activeWorkspace = { id, type }
 }
 
 async function createLoadedStore() {

--- a/src/platform/workspace/stores/teamWorkspaceStore.test.ts
+++ b/src/platform/workspace/stores/teamWorkspaceStore.test.ts
@@ -532,9 +532,10 @@ describe('useTeamWorkspaceStore', () => {
     ])(
       'reloads $reloads time(s) when the active $type workspace is revoked',
       async ({ workspace, reloads }) => {
+        mockWorkspaceAuthStore.initializeFromSession.mockReturnValue(true)
+        mockWorkspaceAuthStore.currentWorkspace = workspace
         const store = useTeamWorkspaceStore()
         await store.initialize()
-        store.activeWorkspaceId = workspace.id
 
         const handled = store.forgetRevokedActiveWorkspace(workspace.id)
 
@@ -555,7 +556,6 @@ describe('useTeamWorkspaceStore', () => {
     it('is a no-op when the workspace is not the active one', async () => {
       const store = useTeamWorkspaceStore()
       await store.initialize()
-      store.activeWorkspaceId = mockTeamWorkspace.id
 
       const handled = store.forgetRevokedActiveWorkspace('some-other-workspace')
 
@@ -1582,52 +1582,6 @@ describe('useTeamWorkspaceStore', () => {
       expect(store.pendingInvites[0].expiryDate).toEqual(
         new Date('2024-01-08T00:00:00Z')
       )
-    })
-
-    it('resendInvite updates the originating workspace after a workspace switch', async () => {
-      const originalInvite = {
-        id: 'inv-1',
-        email: 'one@test.com',
-        token: 'token-1',
-        invited_at: '2024-01-01T00:00:00Z',
-        expires_at: '2024-01-08T00:00:00Z'
-      }
-      const refreshedInvite = {
-        id: 'inv-1',
-        email: 'one@test.com',
-        invited_at: '2024-02-01T00:00:00Z',
-        expires_at: '2024-02-08T00:00:00Z'
-      }
-      let resolveResend!: (invite: typeof refreshedInvite) => void
-
-      mockWorkspaceApi.listInvites.mockResolvedValue({
-        invites: [originalInvite]
-      })
-      mockWorkspaceApi.resendInvite.mockReturnValue(
-        new Promise((resolve) => {
-          resolveResend = resolve
-        })
-      )
-      mockWorkspaceAuthStore.initializeFromSession.mockReturnValue(true)
-      mockWorkspaceAuthStore.currentWorkspace = mockTeamWorkspace
-
-      const store = useTeamWorkspaceStore()
-      await store.initialize()
-      await store.fetchPendingInvites()
-
-      const resend = store.resendInvite('inv-1')
-      store.activeWorkspaceId = mockPersonalWorkspace.id
-      resolveResend(refreshedInvite)
-      await resend
-
-      const teamWorkspace = store.workspaces.find(
-        (workspace) => workspace.id === mockTeamWorkspace.id
-      )
-      expect(teamWorkspace?.pendingInvites[0].expiryDate).toEqual(
-        new Date('2024-02-08T00:00:00Z')
-      )
-      expect(store.activeWorkspace?.id).toBe(mockPersonalWorkspace.id)
-      expect(store.pendingInvites).toEqual([])
     })
 
     it('resendInvite rejects a concurrent resend for the same invite', async () => {

--- a/src/platform/workspace/stores/teamWorkspaceStore.ts
+++ b/src/platform/workspace/stores/teamWorkspaceStore.ts
@@ -127,7 +127,8 @@ const BASE_RETRY_DELAY_MS = 1000
 export const useTeamWorkspaceStore = defineStore('teamWorkspace', () => {
   const initState = ref<InitState>('uninitialized')
   const workspaces = shallowRef<WorkspaceState[]>([])
-  const activeWorkspaceId = ref<string | null>(null)
+  const mutableActiveWorkspaceId = ref<string | null>(null)
+  const activeWorkspaceId = computed(() => mutableActiveWorkspaceId.value)
   const billingRailByWorkspaceId = shallowRef<Record<string, BillingRail>>({})
   const error = ref<Error | null>(null)
 
@@ -300,7 +301,7 @@ export const useTeamWorkspaceStore = defineStore('teamWorkspace', () => {
           )
 
           if (sessionWorkspaceExists) {
-            activeWorkspaceId.value = sessionWorkspaceId
+            mutableActiveWorkspaceId.value = sessionWorkspaceId
             initState.value = 'ready'
             isFetchingWorkspaces.value = false
             return
@@ -317,7 +318,7 @@ export const useTeamWorkspaceStore = defineStore('teamWorkspace', () => {
 
           if (isStaleIdentity(generation)) return
 
-          activeWorkspaceId.value = fallbackWorkspaceId
+          mutableActiveWorkspaceId.value = fallbackWorkspaceId
           setLastWorkspaceId(fallbackWorkspaceId)
           initState.value = 'ready'
           isFetchingWorkspaces.value = false
@@ -354,7 +355,7 @@ export const useTeamWorkspaceStore = defineStore('teamWorkspace', () => {
         if (isStaleIdentity(generation)) return
 
         // 5. Set active workspace
-        activeWorkspaceId.value = targetWorkspaceId
+        mutableActiveWorkspaceId.value = targetWorkspaceId
         setLastWorkspaceId(targetWorkspaceId)
 
         initState.value = 'ready'
@@ -852,7 +853,7 @@ export const useTeamWorkspaceStore = defineStore('teamWorkspace', () => {
     identityGeneration++
     initState.value = 'uninitialized'
     workspaces.value = []
-    activeWorkspaceId.value = null
+    mutableActiveWorkspaceId.value = null
     error.value = null
     isCreating.value = false
     isDeleting.value = false

--- a/src/stores/authStore.test.ts
+++ b/src/stores/authStore.test.ts
@@ -12,7 +12,6 @@ import {
 } from '@/platform/navigation/preservedQueryManager'
 import { PRESERVED_QUERY_NAMESPACES } from '@/platform/navigation/preservedQueryNamespaces'
 import { useDialogService } from '@/services/dialogService'
-import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
 import { useWorkspaceAuthStore } from '@/platform/workspace/stores/workspaceAuthStore'
 import type * as ApiModule from '@/scripts/api'
 import { AuthStoreError, useAuthStore } from '@/stores/authStore'
@@ -35,6 +34,15 @@ const { mockFeatureFlags } = vi.hoisted(() => ({
 
 const { mockResetSocket } = vi.hoisted(() => ({
   mockResetSocket: vi.fn()
+}))
+
+const mockTeamWorkspaceStore = vi.hoisted(() => ({
+  activeWorkspaceId: null as string | null,
+  resetForIdentityChange: vi.fn()
+}))
+
+vi.mock('@/platform/workspace/stores/teamWorkspaceStore', () => ({
+  useTeamWorkspaceStore: () => mockTeamWorkspaceStore
 }))
 
 type MockUser = Omit<User, 'getIdToken' | 'delete'> & {
@@ -229,6 +237,8 @@ describe('useAuthStore', () => {
 
     // Default: no API key auth
     mockApiKeyGetAuthHeader.mockReturnValue(null)
+    mockTeamWorkspaceStore.activeWorkspaceId = null
+    mockTeamWorkspaceStore.resetForIdentityChange.mockReset()
   })
 
   describe('token refresh events', () => {
@@ -703,8 +713,7 @@ describe('useAuthStore', () => {
 
     it('recovers the workspace token instead of downgrading to personal auth', async () => {
       const workspaceAuth = useWorkspaceAuthStore()
-      const teamStore = useTeamWorkspaceStore()
-      teamStore.activeWorkspaceId = 'workspace-123'
+      mockTeamWorkspaceStore.activeWorkspaceId = 'workspace-123'
       vi.spyOn(workspaceAuth, 'getWorkspaceAuthHeader').mockReturnValue(null)
       const ensureSpy = vi
         .spyOn(workspaceAuth, 'ensureWorkspaceAuthHeader')
@@ -719,8 +728,7 @@ describe('useAuthStore', () => {
 
     it('fails closed (no personal Firebase downgrade) when recovery yields no token', async () => {
       const workspaceAuth = useWorkspaceAuthStore()
-      const teamStore = useTeamWorkspaceStore()
-      teamStore.activeWorkspaceId = 'workspace-123'
+      mockTeamWorkspaceStore.activeWorkspaceId = 'workspace-123'
       vi.spyOn(workspaceAuth, 'getWorkspaceAuthHeader').mockReturnValue(null)
       vi.spyOn(workspaceAuth, 'ensureWorkspaceAuthHeader').mockResolvedValue(
         null
@@ -734,8 +742,7 @@ describe('useAuthStore', () => {
 
     it('falls back to Firebase when workspace mode is not yet initialized', async () => {
       const workspaceAuth = useWorkspaceAuthStore()
-      const teamStore = useTeamWorkspaceStore()
-      teamStore.activeWorkspaceId = null
+      mockTeamWorkspaceStore.activeWorkspaceId = null
       vi.spyOn(workspaceAuth, 'getWorkspaceAuthHeader').mockReturnValue(null)
       const ensureSpy = vi.spyOn(workspaceAuth, 'ensureWorkspaceAuthHeader')
 
@@ -749,8 +756,7 @@ describe('useAuthStore', () => {
   describe('getAuthToken workspace recovery', () => {
     it('recovers the workspace token instead of downgrading to personal auth', async () => {
       const workspaceAuth = useWorkspaceAuthStore()
-      const teamStore = useTeamWorkspaceStore()
-      teamStore.activeWorkspaceId = 'workspace-123'
+      mockTeamWorkspaceStore.activeWorkspaceId = 'workspace-123'
       const ensureSpy = vi
         .spyOn(workspaceAuth, 'ensureWorkspaceToken')
         .mockResolvedValue('recovered-ws-token')
@@ -764,8 +770,7 @@ describe('useAuthStore', () => {
 
     it('fails closed (no personal Firebase downgrade) when recovery yields no token', async () => {
       const workspaceAuth = useWorkspaceAuthStore()
-      const teamStore = useTeamWorkspaceStore()
-      teamStore.activeWorkspaceId = 'workspace-123'
+      mockTeamWorkspaceStore.activeWorkspaceId = 'workspace-123'
       vi.spyOn(workspaceAuth, 'ensureWorkspaceToken').mockResolvedValue(null)
 
       const token = await store.getAuthToken()
@@ -776,8 +781,7 @@ describe('useAuthStore', () => {
 
     it('falls back to Firebase when workspace mode is not yet initialized', async () => {
       const workspaceAuth = useWorkspaceAuthStore()
-      const teamStore = useTeamWorkspaceStore()
-      teamStore.activeWorkspaceId = null
+      mockTeamWorkspaceStore.activeWorkspaceId = null
       vi.spyOn(workspaceAuth, 'getWorkspaceToken').mockReturnValue(undefined)
       const ensureSpy = vi.spyOn(workspaceAuth, 'ensureWorkspaceToken')
 


### PR DESCRIPTION
## Summary

Model the existing workspace lifecycle invariant directly in the store: the active workspace is selected during initialization and changing workspaces performs a full page reload, so consumers must not mutate `activeWorkspaceId` in the current document.

## Why

The previous implementation exposed `activeWorkspaceId` as writable even though production workspace transitions always persist the target and reload. That allowed tests and defensive consumer logic to model an unsupported same-document A → B transition. In `useSubscription`, this led to workspace-keyed request coalescing and stale-workspace handling for a transition that cannot occur through the production API.

The `null → workspace` initialization transition remains internal to `teamWorkspaceStore` and is completed behind `WorkspaceAuthGate` before routed content renders.

## Changes

- Expose `activeWorkspaceId` as a readonly computed value while retaining mutations inside `teamWorkspaceStore` initialization and identity reset.
- Coalesce subscription status requests only when both the authenticated user and workspace context match.
- Discard responses from the previous account after an identity switch, while removing tests based on unsupported direct workspace-only mutation.
- Replace cross-store tests that need synthetic workspace state with explicit dependency mocks rather than mutating the production store.

## Validation

- `pnpm typecheck`
- ESLint on all changed files
- 235 focused tests across subscription, workspace UI, partner-node governance, and auth stores

No UI changed, so screenshots and E2E coverage are not applicable.

