### PR TITLE
[backport cloud/1.49] fix(first-run-tour): read Anti-prompt as the negative prompt

### DIFF
--- a/src/renderer/extensions/firstRunTour/roles/heuristicRoles.test.ts
+++ b/src/renderer/extensions/firstRunTour/roles/heuristicRoles.test.ts
@@ -330,7 +330,12 @@ describe('heuristicRoles', () => {
     'negatives',
     'NEGATIVEPROMPT',
     'Undesired content',
-    'Things to avoid'
+    'Things to avoid',
+    'Anti-prompt',
+    'anti prompt',
+    'AntiPrompt',
+    'ANTIPROMPT',
+    'anti_prompts'
   ])('reads %s as a negative prompt rather than the prompt', (title) => {
     const graph = createTestRootGraph()
     addWiredSink(graph)
@@ -342,7 +347,54 @@ describe('heuristicRoles', () => {
     ).toBeNull()
   })
 
-  it.for(['Antique portrait', 'Negro', 'negate mask', 'anti_aliasing'])(
+  it('reads a widget named anti_prompt as a negative prompt', () => {
+    const graph = createTestRootGraph()
+    addWiredSink(graph)
+    addNode(graph, 'CustomEncode', { prompts: ['anti_prompt'] })
+
+    expect(
+      heuristicRoles(graph)?.prompt,
+      'the widget name names the box just as the node title does'
+    ).toBeNull()
+  })
+
+  it('reads the anti_prompt input a box feeds as a negative prompt', () => {
+    const graph = createTestRootGraph()
+    addWiredSink(graph)
+    const text = addNode(graph, 'CLIPTextEncode', {
+      prompts: ['text'],
+      outputs: ['CONDITIONING']
+    })
+    const sampler = addNode(graph, 'CustomSampler', {
+      inputs: ['anti_prompt'],
+      inputType: 'CONDITIONING'
+    })
+    text.connect(0, sampler, 0)
+
+    expect(
+      heuristicRoles(graph)?.prompt,
+      'the input a box feeds names it, the same as its own title would'
+    ).toBeNull()
+  })
+
+  it('reads a subgraph port named Anti-Prompt as a negative prompt', () => {
+    const graph = createTestRootGraph()
+    addWiredSink(graph)
+    addExposedPrompt(graph, 'Anti-Prompt')
+
+    expect(
+      heuristicRoles(graph)?.prompt,
+      'the exposed port is the only label on an interior node titled nothing useful'
+    ).toBeNull()
+  })
+
+  it.for([
+    'Antique portrait',
+    'Negro',
+    'negate mask',
+    'anti_aliasing',
+    'antialiasing strength'
+  ])(
     'still offers %s as the prompt, since only its spelling looks negative',
     (title) => {
       const graph = createTestRootGraph()

--- a/src/renderer/extensions/firstRunTour/roles/heuristicRoles.ts
+++ b/src/renderer/extensions/firstRunTour/roles/heuristicRoles.ts
@@ -28,8 +28,18 @@ const MEDIA_KIND_BY_SLOT_TYPE: Partial<Record<string, TourMediaKind>> = {
  * `negate`, `negligible` and Spanish `negro` disqualify a real prompt. */
 const DISQUALIFYING = ['negative', 'neg', 'system', 'undesired', 'avoid']
 
+/** `anti` names the negative box only next to the noun — `Anti-prompt`,
+ * `AntiPrompt`, `ANTIPROMPT` — since `anti_aliasing` and `antique` are ordinary
+ * words a real prompt carries. Read off the normalised label, not its words, so
+ * the pair survives the separator and camelCase spellings alike. */
+const ANTI_PROMPT = /\banti ?prompts?\b/
+
 function disqualified(word: string): boolean {
   return DISQUALIFYING.includes(word) || word.startsWith('negative')
+}
+
+function readsAsAntiPrompt(label: string | undefined): boolean {
+  return ANTI_PROMPT.test(labelWords(label).join(' '))
 }
 
 /** Real templates ship nodes with no title and widgets with no name. */
@@ -95,6 +105,7 @@ function promptScore(labels: string[], fedInputNames: string[]): number {
   const fed = fedInputNames.flatMap(labelWords)
 
   if ([...words, ...fed].some(disqualified)) return -1
+  if ([...labels, ...fedInputNames].some(readsAsAntiPrompt)) return -1
   if (fed.includes('positive')) return 3
   if (words.includes('positive')) return 2
   if (words.includes('prompt')) return 1


### PR DESCRIPTION
Manual backport of #14669 (`b2540ac0767`) — **the label-driven bot did not fire.**

#14669 merged carrying `core/1.49` and `cloud/1.49`, applied *before* the merge
(so this is not the after-the-fact labelling that silently skipped #14683). No
backport PR was created. Verified by content rather than by the bot's silence:

```
$ git grep -c "Anti-prompt" origin/<branch> -- src/renderer/extensions/firstRunTour/
  main       2 files
  core/1.49  0 files
  cloud/1.49 0 files
```

So the fix is on the dev line only and the 1.49 RC still reads `Anti-prompt` as
the *positive* prompt — the tour spotlights the wrong node.

Cherry-picked with `-x`, clean, no conflicts, identical to main's commit
(2 files, +65/-2). `heuristicRoles.test.ts` passes **49/49** on this branch.

> Second silent skip of this bot in this effort. Raising it separately — a
> backport bot that no-ops without complaining is indistinguishable from one
> that succeeded, which is how #14683 shipped the dead template to both release
> branches.
