### PR TITLE
test: fail error surfaces with their visible text, not a bare count

### DIFF
--- a/browser_tests/fixtures/utils/errorSurfaces.ts
+++ b/browser_tests/fixtures/utils/errorSurfaces.ts
@@ -20,8 +20,12 @@ export function errorSurfaces(page: Page): Record<string, Locator> {
 // of reporting a bare element count (the cloud gate's dominant failure class
 // was 12x "at startup: errorToasts" with no text - run 31541231667). A read
 // that races a boot navigation returns a sentinel rather than throwing, so
-// the poll below keeps retrying exactly like toHaveCount(0) did.
+// the poll below keeps retrying exactly like toHaveCount(0) did - but a
+// CLOSED target is not a race: rethrow immediately so the real reason
+// surfaces in milliseconds instead of a full poll window ending in a
+// sentinel that claims a surface is present on a page that is gone.
 async function surfaceTexts(
+  page: Page,
   surface: string,
   locator: Locator
 ): Promise<string[]> {
@@ -30,6 +34,7 @@ async function surfaceTexts(
       text.replace(/\s+/g, ' ').trim().slice(0, 300)
     )
   } catch (error) {
+    if (page.isClosed() || /has been closed/.test(String(error))) throw error
     return [`${surface} present but unreadable mid-poll: ${String(error)}`]
   }
 }
@@ -46,7 +51,7 @@ export async function expectNoVisibleErrors(
 ): Promise<void> {
   for (const [surface, locator] of Object.entries(errorSurfaces(page)))
     await expect
-      .poll(() => surfaceTexts(surface, locator), {
+      .poll(() => surfaceTexts(page, surface, locator), {
         message: `${context}: ${surface}`
       })
       .toEqual([])

--- a/browser_tests/fixtures/utils/errorSurfaces.ts
+++ b/browser_tests/fixtures/utils/errorSurfaces.ts
@@ -16,13 +16,38 @@ export function errorSurfaces(page: Page): Record<string, Locator> {
   }
 }
 
+// What a non-empty surface actually says, so a red names the error instead
+// of reporting a bare element count (the cloud gate's dominant failure class
+// was 12x "at startup: errorToasts" with no text - run 31541231667). A read
+// that races a boot navigation returns a sentinel rather than throwing, so
+// the poll below keeps retrying exactly like toHaveCount(0) did.
+async function surfaceTexts(
+  surface: string,
+  locator: Locator
+): Promise<string[]> {
+  try {
+    return (await locator.allInnerTexts()).map((text) =>
+      text.replace(/\s+/g, ' ').trim().slice(0, 300)
+    )
+  } catch (error) {
+    return [`${surface} present but unreadable mid-poll: ${String(error)}`]
+  }
+}
+
 // The suite's central invariant: a regression run is green only if every
 // user-visible error surface is empty. Kept here (single source) so a new
-// surface added above is enforced everywhere at once.
+// surface added above is enforced everywhere at once. Polling toEqual([])
+// keeps toHaveCount(0)'s tolerance - a transient surface that clears within
+// the expect timeout still passes - while a persistent one fails with its
+// visible text as the last polled value.
 export async function expectNoVisibleErrors(
   page: Page,
   context: string
 ): Promise<void> {
   for (const [surface, locator] of Object.entries(errorSurfaces(page)))
-    await expect(locator, `${context}: ${surface}`).toHaveCount(0)
+    await expect
+      .poll(() => surfaceTexts(surface, locator), {
+        message: `${context}: ${surface}`
+      })
+      .toEqual([])
 }

--- a/browser_tests/tests/customNodes/errorSurfaces.pure.spec.ts
+++ b/browser_tests/tests/customNodes/errorSurfaces.pure.spec.ts
@@ -1,0 +1,47 @@
+import {
+  comfyExpect as expect,
+  comfyPageFixture as test
+} from '@e2e/fixtures/ComfyPage'
+import { expectNoVisibleErrors } from '@e2e/fixtures/utils/errorSurfaces'
+
+// expectNoVisibleErrors is the single enforcement point for every
+// user-visible error surface; these pin its three behaviors: clean passes,
+// a persistent surface fails NAMING its visible text (the cloud gate's
+// dominant failure class was 12x "at startup: errorToasts" with no text -
+// run 31541231667), and toHaveCount(0)'s transient tolerance is preserved.
+test('a clean page passes every surface', async ({ page }) => {
+  await page.setContent('<main>no errors here</main>')
+  await expect(expectNoVisibleErrors(page, 'clean')).resolves.toBeUndefined()
+})
+
+test('a persistent error toast fails carrying its visible text', async ({
+  page
+}) => {
+  await page.setContent(
+    '<div class="p-toast-message-error">Failed to load workspace: HTTP 502</div>' +
+      '<div class="p-toast-message-error">Settings seed rejected</div>'
+  )
+  const failure = await expectNoVisibleErrors(page, 'at startup').then(
+    () => undefined,
+    (error: unknown) => error
+  )
+  expect(failure).toBeInstanceOf(Error)
+  const message = (failure as Error).message
+  // The class-stable context label the detection proof greps for...
+  expect(message).toContain('at startup: errorToasts')
+  // ...and the diagnostic the bare count never carried.
+  expect(message).toContain('Failed to load workspace: HTTP 502')
+  expect(message).toContain('Settings seed rejected')
+})
+
+test('a transient toast that clears within the window still passes', async ({
+  page
+}) => {
+  await page.setContent(
+    '<div id="t" class="p-toast-message-error">momentary</div>' +
+      '<script>setTimeout(() => document.getElementById("t").remove(), 800)</script>'
+  )
+  await expect(
+    expectNoVisibleErrors(page, 'transient')
+  ).resolves.toBeUndefined()
+})

--- a/browser_tests/tests/customNodes/errorSurfaces.pure.spec.ts
+++ b/browser_tests/tests/customNodes/errorSurfaces.pure.spec.ts
@@ -34,6 +34,19 @@ test('a persistent error toast fails carrying its visible text', async ({
   expect(message).toContain('Settings seed rejected')
 })
 
+test('a closed page fails immediately with the real reason, not the sentinel', async ({
+  page
+}) => {
+  await page.setContent('<main></main>')
+  await page.close()
+  const failure = await expectNoVisibleErrors(page, 'after close').then(
+    () => undefined,
+    (error: unknown) => error
+  )
+  expect(String(failure)).toMatch(/has been closed/)
+  expect(String(failure)).not.toContain('unreadable mid-poll')
+})
+
 test('a transient toast that clears within the window still passes', async ({
   page
 }) => {


### PR DESCRIPTION
## Summary

The cloud gate's dominant remaining failure class - 12x `at startup: errorToasts` in the serialized measurement ([run 31541231667](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/31541231667)) - reports a bare element count, so testcloud-health noise and real frontend errors are indistinguishable without a trace dive. Every red on these surfaces now carries the surface's visible text.

## Changes

- **What**: `expectNoVisibleErrors` polls the surface's inner texts to `[]` instead of `toHaveCount(0)`. Semantics preserved: a transient surface that clears within the expect window still passes (proved by the pure spec's 999ms transient case vs 5.0s persistent case); a persistent one fails with its texts as the last polled value; the class-stable `<context>: <surface>` label survives in the failure message for the detection-proof greps; a mid-poll read race returns a sentinel rather than throwing, so the poll retries exactly where `toHaveCount` would have.
- New `errorSurfaces.pure.spec.ts` pins all three behaviors with a real page and no backend; red-green proven - against the previous fixture the text assertions fail (`toHaveCount` output carries no toast text).

## Review Focus

- Single enforcement point: every caller (startup checks, curated runs, all four surfaces) inherits the diagnostics at once. With this in place, the 12-failure class becomes one-glance triage: a wall of `HTTP 502`-flavored toasts is a testcloud ticket, anything else is ours.