### PR TITLE
test: share select component automocks

### DIFF
--- a/knip.config.ts
+++ b/knip.config.ts
@@ -70,7 +70,7 @@ const config: KnipConfig = {
     config: ['vitest?(.*).config.ts'],
     entry: [
       '**/*.{bench,test,test-d,spec}.?(c|m)[jt]s?(x)',
-      '**/__mocks__/**/*.[jt]s?(x)'
+      '**/__mocks__/**/*.{js,ts,vue}'
     ]
   },
   playwright: {

--- a/src/components/load3d/controls/viewer/ViewerCameraControls.test.ts
+++ b/src/components/load3d/controls/viewer/ViewerCameraControls.test.ts
@@ -7,66 +7,11 @@ import { createI18n } from 'vue-i18n'
 import ViewerCameraControls from '@/components/load3d/controls/viewer/ViewerCameraControls.vue'
 import type { CameraType } from '@/extensions/core/load3d/interfaces'
 
-vi.mock('@/components/ui/select/Select.vue', async () => {
-  const { provide } = await import('vue')
-  return {
-    default: {
-      name: 'Select',
-      props: ['modelValue'],
-      emits: ['update:modelValue'],
-      setup(
-        props: { modelValue: string },
-        { emit }: { emit: (event: string, value: string) => void }
-      ) {
-        provide('selectModelValue', (): string => props.modelValue)
-        provide('selectUpdate', (v: string): void =>
-          emit('update:modelValue', v)
-        )
-      },
-      template: '<div><slot /></div>'
-    }
-  }
-})
-
-vi.mock('@/components/ui/select/SelectContent.vue', async () => {
-  const { inject, ref, onMounted } = await import('vue')
-  return {
-    default: {
-      name: 'SelectContent',
-      setup() {
-        const selectModelValue = inject<() => string>('selectModelValue')
-        const selectUpdate = inject<(v: string) => void>('selectUpdate')
-        const el = ref<HTMLSelectElement | null>(null)
-        onMounted(() => {
-          if (el.value) el.value.value = selectModelValue?.() ?? ''
-        })
-        return {
-          el,
-          onChange: (e: Event) => {
-            selectUpdate?.((e.target as HTMLSelectElement).value)
-          }
-        }
-      },
-      template: '<select ref="el" @change="onChange"><slot /></select>'
-    }
-  }
-})
-
-vi.mock('@/components/ui/select/SelectItem.vue', () => ({
-  default: {
-    name: 'SelectItem',
-    props: ['value'],
-    template: '<option :value="value"><slot /></option>'
-  }
-}))
-
-vi.mock('@/components/ui/select/SelectTrigger.vue', () => ({
-  default: { name: 'SelectTrigger', template: '<span />' }
-}))
-
-vi.mock('@/components/ui/select/SelectValue.vue', () => ({
-  default: { name: 'SelectValue', template: '<span />' }
-}))
+vi.mock('@/components/ui/select/Select.vue')
+vi.mock('@/components/ui/select/SelectContent.vue')
+vi.mock('@/components/ui/select/SelectItem.vue')
+vi.mock('@/components/ui/select/SelectTrigger.vue')
+vi.mock('@/components/ui/select/SelectValue.vue')
 
 vi.mock('@/components/ui/slider/Slider.vue', () => ({
   default: {

--- a/src/components/load3d/controls/viewer/ViewerExportControls.test.ts
+++ b/src/components/load3d/controls/viewer/ViewerExportControls.test.ts
@@ -5,66 +5,11 @@ import { createI18n } from 'vue-i18n'
 
 import ViewerExportControls from '@/components/load3d/controls/viewer/ViewerExportControls.vue'
 
-vi.mock('@/components/ui/select/Select.vue', async () => {
-  const { provide } = await import('vue')
-  return {
-    default: {
-      name: 'Select',
-      props: ['modelValue'],
-      emits: ['update:modelValue'],
-      setup(
-        props: { modelValue: string },
-        { emit }: { emit: (event: string, value: string) => void }
-      ) {
-        provide('selectModelValue', (): string => props.modelValue)
-        provide('selectUpdate', (v: string): void =>
-          emit('update:modelValue', v)
-        )
-      },
-      template: '<div><slot /></div>'
-    }
-  }
-})
-
-vi.mock('@/components/ui/select/SelectContent.vue', async () => {
-  const { inject, ref, onMounted } = await import('vue')
-  return {
-    default: {
-      name: 'SelectContent',
-      setup() {
-        const selectModelValue = inject<() => string>('selectModelValue')
-        const selectUpdate = inject<(v: string) => void>('selectUpdate')
-        const el = ref<HTMLSelectElement | null>(null)
-        onMounted(() => {
-          if (el.value) el.value.value = selectModelValue?.() ?? ''
-        })
-        return {
-          el,
-          onChange: (e: Event) => {
-            selectUpdate?.((e.target as HTMLSelectElement).value)
-          }
-        }
-      },
-      template: '<select ref="el" @change="onChange"><slot /></select>'
-    }
-  }
-})
-
-vi.mock('@/components/ui/select/SelectItem.vue', () => ({
-  default: {
-    name: 'SelectItem',
-    props: ['value'],
-    template: '<option :value="value"><slot /></option>'
-  }
-}))
-
-vi.mock('@/components/ui/select/SelectTrigger.vue', () => ({
-  default: { name: 'SelectTrigger', template: '<span />' }
-}))
-
-vi.mock('@/components/ui/select/SelectValue.vue', () => ({
-  default: { name: 'SelectValue', template: '<span />' }
-}))
+vi.mock('@/components/ui/select/Select.vue')
+vi.mock('@/components/ui/select/SelectContent.vue')
+vi.mock('@/components/ui/select/SelectItem.vue')
+vi.mock('@/components/ui/select/SelectTrigger.vue')
+vi.mock('@/components/ui/select/SelectValue.vue')
 
 const i18n = createI18n({
   legacy: false,

--- a/src/components/load3d/controls/viewer/ViewerModelControls.test.ts
+++ b/src/components/load3d/controls/viewer/ViewerModelControls.test.ts
@@ -9,66 +9,11 @@ import type {
   UpDirection
 } from '@/extensions/core/load3d/interfaces'
 
-vi.mock('@/components/ui/select/Select.vue', async () => {
-  const { provide } = await import('vue')
-  return {
-    default: {
-      name: 'Select',
-      props: ['modelValue'],
-      emits: ['update:modelValue'],
-      setup(
-        props: { modelValue: string },
-        { emit }: { emit: (event: string, value: string) => void }
-      ) {
-        provide('selectModelValue', (): string => props.modelValue)
-        provide('selectUpdate', (v: string): void =>
-          emit('update:modelValue', v)
-        )
-      },
-      template: '<div><slot /></div>'
-    }
-  }
-})
-
-vi.mock('@/components/ui/select/SelectContent.vue', async () => {
-  const { inject, ref, onMounted } = await import('vue')
-  return {
-    default: {
-      name: 'SelectContent',
-      setup() {
-        const selectModelValue = inject<() => string>('selectModelValue')
-        const selectUpdate = inject<(v: string) => void>('selectUpdate')
-        const el = ref<HTMLSelectElement | null>(null)
-        onMounted(() => {
-          if (el.value) el.value.value = selectModelValue?.() ?? ''
-        })
-        return {
-          el,
-          onChange: (e: Event) => {
-            selectUpdate?.((e.target as HTMLSelectElement).value)
-          }
-        }
-      },
-      template: '<select ref="el" @change="onChange"><slot /></select>'
-    }
-  }
-})
-
-vi.mock('@/components/ui/select/SelectItem.vue', () => ({
-  default: {
-    name: 'SelectItem',
-    props: ['value'],
-    template: '<option :value="value"><slot /></option>'
-  }
-}))
-
-vi.mock('@/components/ui/select/SelectTrigger.vue', () => ({
-  default: { name: 'SelectTrigger', template: '<span />' }
-}))
-
-vi.mock('@/components/ui/select/SelectValue.vue', () => ({
-  default: { name: 'SelectValue', template: '<span />' }
-}))
+vi.mock('@/components/ui/select/Select.vue')
+vi.mock('@/components/ui/select/SelectContent.vue')
+vi.mock('@/components/ui/select/SelectItem.vue')
+vi.mock('@/components/ui/select/SelectTrigger.vue')
+vi.mock('@/components/ui/select/SelectValue.vue')
 
 const i18n = createI18n({
   legacy: false,

--- a/src/components/ui/select/__mocks__/Select.vue
+++ b/src/components/ui/select/__mocks__/Select.vue
@@ -1,0 +1,14 @@
+<script setup lang="ts">
+import { provide } from 'vue'
+
+const modelValue = defineModel<string>()
+
+provide('selectModelValue', () => modelValue.value)
+provide('selectUpdate', (value: string) => {
+  modelValue.value = value
+})
+</script>
+
+<template>
+  <div><slot /></div>
+</template>

--- a/src/components/ui/select/__mocks__/SelectContent.vue
+++ b/src/components/ui/select/__mocks__/SelectContent.vue
@@ -1,0 +1,23 @@
+<script setup lang="ts">
+import { inject, onMounted, ref } from 'vue'
+
+const selectModelValue = inject<() => string | undefined>('selectModelValue')
+const selectUpdate = inject<(value: string) => void>('selectUpdate')
+const element = ref<HTMLSelectElement | null>(null)
+
+onMounted(() => {
+  if (element.value) element.value.value = selectModelValue?.() ?? ''
+})
+
+const onChange = (event: Event) => {
+  if (event.target instanceof HTMLSelectElement) {
+    selectUpdate?.(event.target.value)
+  }
+}
+</script>
+
+<template>
+  <select ref="element" @change="onChange">
+    <slot />
+  </select>
+</template>

--- a/src/components/ui/select/__mocks__/SelectItem.vue
+++ b/src/components/ui/select/__mocks__/SelectItem.vue
@@ -1,0 +1,9 @@
+<script setup lang="ts">
+defineProps<{
+  value: string
+}>()
+</script>
+
+<template>
+  <option :value><slot /></option>
+</template>

--- a/src/components/ui/select/__mocks__/SelectTrigger.vue
+++ b/src/components/ui/select/__mocks__/SelectTrigger.vue
@@ -1,0 +1,3 @@
+<template>
+  <span />
+</template>

--- a/src/components/ui/select/__mocks__/SelectValue.vue
+++ b/src/components/ui/select/__mocks__/SelectValue.vue
@@ -1,0 +1,3 @@
+<template>
+  <span />
+</template>


### PR DESCRIPTION
## Summary

Replace three copies of the same native Select test double with Vitest manual automocks colocated beside the Select components.

## Changes

- **What**: Adds shared automocks for `Select`, `SelectContent`, `SelectItem`, `SelectTrigger`, and `SelectValue`; each consuming suite now opts in with factory-free `vi.mock()` calls.
- **Tooling**: Includes Vue manual mocks in Knip's Vitest entry pattern.
- **Scope**: Three Load3D viewer suites; 113 net lines removed.

## Review Focus

This establishes the repository's first colocated `__mocks__` convention. The mocks preserve the existing native `<select>` behavior and remain opt-in—no global setup registration.

## Validation

- 3 affected files: 22 tests passed
- `pnpm typecheck`
- `pnpm knip`
- ESLint, Stylelint, Oxfmt, Oxlint, and commit hooks