### PR TITLE
test: share slider component automock

### DIFF
--- a/src/components/load3d/controls/AnimationControls.test.ts
+++ b/src/components/load3d/controls/AnimationControls.test.ts
@@ -6,24 +6,7 @@ import { createI18n } from 'vue-i18n'
 
 import AnimationControls from '@/components/load3d/controls/AnimationControls.vue'
 
-vi.mock('@/components/ui/slider/Slider.vue', () => ({
-  default: {
-    name: 'UiSlider',
-    props: ['modelValue', 'min', 'max', 'step'],
-    emits: ['update:modelValue'],
-    template: `
-      <input
-        type="range"
-        role="slider"
-        :value="Array.isArray(modelValue) ? modelValue[0] : modelValue"
-        :min="min"
-        :max="max"
-        :step="step"
-        @input="$emit('update:modelValue', [Number($event.target.value)])"
-      />
-    `
-  }
-}))
+vi.mock('@/components/ui/slider/Slider.vue')
 
 const i18n = createI18n({
   legacy: false,

--- a/src/components/load3d/controls/LightControls.test.ts
+++ b/src/components/load3d/controls/LightControls.test.ts
@@ -26,24 +26,7 @@ vi.mock('@/composables/useDismissableOverlay', () => ({
   useDismissableOverlay: vi.fn()
 }))
 
-vi.mock('@/components/ui/slider/Slider.vue', () => ({
-  default: {
-    name: 'UiSlider',
-    props: ['modelValue', 'min', 'max', 'step'],
-    emits: ['update:modelValue'],
-    template: `
-      <input
-        type="range"
-        role="slider"
-        :value="Array.isArray(modelValue) ? modelValue[0] : modelValue"
-        :min="min"
-        :max="max"
-        :step="step"
-        @input="$emit('update:modelValue', [Number($event.target.value)])"
-      />
-    `
-  }
-}))
+vi.mock('@/components/ui/slider/Slider.vue')
 
 const i18n = createI18n({
   legacy: false,

--- a/src/components/load3d/controls/PopupSlider.test.ts
+++ b/src/components/load3d/controls/PopupSlider.test.ts
@@ -5,24 +5,7 @@ import { ref } from 'vue'
 
 import PopupSlider from '@/components/load3d/controls/PopupSlider.vue'
 
-vi.mock('@/components/ui/slider/Slider.vue', () => ({
-  default: {
-    name: 'UiSlider',
-    props: ['modelValue', 'min', 'max', 'step'],
-    emits: ['update:modelValue'],
-    template: `
-      <input
-        type="range"
-        role="slider"
-        :value="Array.isArray(modelValue) ? modelValue[0] : modelValue"
-        :min="min"
-        :max="max"
-        :step="step"
-        @input="$emit('update:modelValue', [Number($event.target.value)])"
-      />
-    `
-  }
-}))
+vi.mock('@/components/ui/slider/Slider.vue')
 
 function renderComponent(
   props: {

--- a/src/components/load3d/controls/viewer/ViewerCameraControls.test.ts
+++ b/src/components/load3d/controls/viewer/ViewerCameraControls.test.ts
@@ -13,24 +13,7 @@ vi.mock('@/components/ui/select/SelectItem.vue')
 vi.mock('@/components/ui/select/SelectTrigger.vue')
 vi.mock('@/components/ui/select/SelectValue.vue')
 
-vi.mock('@/components/ui/slider/Slider.vue', () => ({
-  default: {
-    name: 'UiSlider',
-    props: ['modelValue', 'min', 'max', 'step'],
-    emits: ['update:modelValue'],
-    template: `
-      <input
-        type="range"
-        role="slider"
-        :value="Array.isArray(modelValue) ? modelValue[0] : modelValue"
-        :min="min"
-        :max="max"
-        :step="step"
-        @input="$emit('update:modelValue', [Number($event.target.value)])"
-      />
-    `
-  }
-}))
+vi.mock('@/components/ui/slider/Slider.vue')
 
 const i18n = createI18n({
   legacy: false,

--- a/src/components/load3d/controls/viewer/ViewerLightControls.test.ts
+++ b/src/components/load3d/controls/viewer/ViewerLightControls.test.ts
@@ -17,24 +17,7 @@ vi.mock('@/platform/settings/settingStore', () => ({
   })
 }))
 
-vi.mock('@/components/ui/slider/Slider.vue', () => ({
-  default: {
-    name: 'UiSlider',
-    props: ['modelValue', 'min', 'max', 'step'],
-    emits: ['update:modelValue'],
-    template: `
-      <input
-        type="range"
-        role="slider"
-        :value="Array.isArray(modelValue) ? modelValue[0] : modelValue"
-        :min="min"
-        :max="max"
-        :step="step"
-        @input="$emit('update:modelValue', [Number($event.target.value)])"
-      />
-    `
-  }
-}))
+vi.mock('@/components/ui/slider/Slider.vue')
 
 const i18n = createI18n({
   legacy: false,

--- a/src/components/ui/slider/__mocks__/Slider.vue
+++ b/src/components/ui/slider/__mocks__/Slider.vue
@@ -1,0 +1,30 @@
+<script setup lang="ts">
+const { modelValue, min, max, step } = defineProps<{
+  modelValue: number | number[]
+  min?: number
+  max?: number
+  step?: number
+}>()
+
+const emit = defineEmits<{
+  'update:modelValue': [value: number[]]
+}>()
+
+const onInput = (event: Event) => {
+  if (event.target instanceof HTMLInputElement) {
+    emit('update:modelValue', [Number(event.target.value)])
+  }
+}
+</script>
+
+<template>
+  <input
+    type="range"
+    role="slider"
+    :value="Array.isArray(modelValue) ? modelValue[0] : modelValue"
+    :min
+    :max
+    :step
+    @input="onInput"
+  />
+</template>


### PR DESCRIPTION
## Summary

Replace five copies of the same native range-input test double with a colocated Vitest manual automock.

## Changes

- **What**: Adds the shared `Slider.vue` automock and replaces each inline factory with an opt-in `vi.mock()` call.
- **Scope**: Five Load3D control suites; 55 net lines removed.

## Review Focus

The shared mock preserves the existing accessible slider role, numeric value conversion, bounds, step, and array-valued `v-model` contract.

## Validation

- 5 affected files: 31 tests passed
- Typecheck, ESLint, Stylelint, Oxfmt, Oxlint, and commit hooks