### PR TITLE
test: centralize unit test isolation and shared automocks

### DIFF
--- a/apps/website/src/components/pricing/CloudPricingSection.test.ts
+++ b/apps/website/src/components/pricing/CloudPricingSection.test.ts
@@ -1,12 +1,8 @@
 // @vitest-environment happy-dom
-import { cleanup, render, screen } from '@testing-library/vue'
-import { afterEach, describe, expect, it } from 'vitest'
+import { render, screen } from '@testing-library/vue'
+import { describe, expect, it } from 'vitest'
 
 import CloudPricingSection from './CloudPricingSection.vue'
-
-afterEach(() => {
-  cleanup()
-})
 
 function isBefore(first: Element, second: Element) {
   return Boolean(

--- a/apps/website/src/components/pricing/PricingFreeBanner.test.ts
+++ b/apps/website/src/components/pricing/PricingFreeBanner.test.ts
@@ -1,13 +1,9 @@
 // @vitest-environment happy-dom
-import { cleanup, render, screen } from '@testing-library/vue'
-import { afterEach, describe, expect, it } from 'vitest'
+import { render, screen } from '@testing-library/vue'
+import { describe, expect, it } from 'vitest'
 import type { ComponentProps } from 'vue-component-type-helpers'
 
 import PricingFreeBanner from './PricingFreeBanner.vue'
-
-afterEach(() => {
-  cleanup()
-})
 
 type BannerProps = ComponentProps<typeof PricingFreeBanner>
 

--- a/apps/website/src/components/product/local/MobileDownloadEmailForm.test.ts
+++ b/apps/website/src/components/product/local/MobileDownloadEmailForm.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment happy-dom
 import userEvent from '@testing-library/user-event'
-import { cleanup, fireEvent, render, screen } from '@testing-library/vue'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen } from '@testing-library/vue'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import MobileDownloadEmailForm from './MobileDownloadEmailForm.vue'
 
@@ -33,10 +33,6 @@ describe('MobileDownloadEmailForm', () => {
   beforeEach(() => {
     hoisted.isEnabled = true
     hoisted.isMobileUa = true
-  })
-
-  afterEach(() => {
-    cleanup()
   })
 
   it('renders nothing when the write key is not configured', () => {

--- a/apps/website/src/templates/model-launch/ModelLaunchHeroCtaButtons.test.ts
+++ b/apps/website/src/templates/model-launch/ModelLaunchHeroCtaButtons.test.ts
@@ -1,12 +1,8 @@
 // @vitest-environment happy-dom
-import { cleanup, render, screen } from '@testing-library/vue'
-import { afterEach, describe, expect, it } from 'vitest'
+import { render, screen } from '@testing-library/vue'
+import { describe, expect, it } from 'vitest'
 
 import ModelLaunchHeroCtaButtons from './ModelLaunchHeroCtaButtons.vue'
-
-afterEach(() => {
-  cleanup()
-})
 
 describe('ModelLaunchHeroCtaButtons', () => {
   it('renders only the primary CTA when no secondary CTA is given', () => {

--- a/apps/website/src/templates/model-launch/ModelLaunchPricingSection.test.ts
+++ b/apps/website/src/templates/model-launch/ModelLaunchPricingSection.test.ts
@@ -1,13 +1,9 @@
 // @vitest-environment happy-dom
-import { cleanup, render, screen } from '@testing-library/vue'
-import { afterEach, describe, expect, it } from 'vitest'
+import { render, screen } from '@testing-library/vue'
+import { describe, expect, it } from 'vitest'
 
 import { minimaxPage } from '../../data/minimax'
 import ModelLaunchPricingSection from './ModelLaunchPricingSection.vue'
-
-afterEach(() => {
-  cleanup()
-})
 
 // The live /minimax config, so a refactor of the shared banner cannot quietly
 // change what that page ships. `pricing` is optional on a launch page, so fail

--- a/apps/website/src/test/setup.ts
+++ b/apps/website/src/test/setup.ts
@@ -1,0 +1,4 @@
+import { cleanup } from '@testing-library/vue'
+import { afterEach } from 'vitest'
+
+afterEach(cleanup)

--- a/apps/website/src/utils/cloudNodes.build.test.ts
+++ b/apps/website/src/utils/cloudNodes.build.test.ts
@@ -35,8 +35,6 @@ describe('loadPacksForBuild', () => {
   const savedVercelEnv = process.env.VERCEL_ENV
 
   beforeEach(() => {
-    fetchCloudNodesMock.mockReset()
-    reportCloudNodesOutcomeMock.mockReset()
     delete process.env.VERCEL_ENV
   })
 

--- a/apps/website/src/utils/cloudNodes.test.ts
+++ b/apps/website/src/utils/cloudNodes.test.ts
@@ -94,9 +94,7 @@ describe('fetchCloudNodesForBuild', () => {
 
   beforeEach(() => {
     resetCloudNodesFetcherForTests()
-    fetchRegistryPacksWithNodesMock.mockReset()
     fetchRegistryPacksWithNodesMock.mockResolvedValue(new Map())
-    sanitizeCallSpy.mockReset()
     delete process.env.WEBSITE_CLOUD_API_KEY
   })
 

--- a/apps/website/vitest.config.ts
+++ b/apps/website/vitest.config.ts
@@ -18,6 +18,6 @@ export default defineConfig({
     environment: 'node',
     include: ['src/**/*.{test,spec}.ts'],
     globals: false,
-    setupFiles: ['../../vitest.timer.setup.ts']
+    setupFiles: ['../../vitest.timer.setup.ts', './src/test/setup.ts']
   }
 })

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -70,7 +70,7 @@ const config: KnipConfig = {
     config: ['vitest?(.*).config.ts'],
     entry: [
       '**/*.{bench,test,test-d,spec}.?(c|m)[jt]s?(x)',
-      '**/__mocks__/**/*.[jt]s?(x)'
+      '**/__mocks__/**/*.{js,ts,vue}'
     ]
   },
   playwright: {

--- a/src/components/bottomPanel/tabs/shortcuts/EssentialsPanel.test.ts
+++ b/src/components/bottomPanel/tabs/shortcuts/EssentialsPanel.test.ts
@@ -1,6 +1,5 @@
 import { render, screen } from '@testing-library/vue'
-import { createPinia, setActivePinia } from 'pinia'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import type { ComfyCommandImpl } from '@/stores/commandStore'
 
@@ -50,10 +49,6 @@ vi.mock('@/stores/commandStore', () => ({
 }))
 
 describe('EssentialsPanel', () => {
-  beforeEach(() => {
-    setActivePinia(createPinia())
-  })
-
   it('should render ShortcutsList with essentials commands', async () => {
     const { default: EssentialsPanel } =
       await import('@/components/bottomPanel/tabs/shortcuts/EssentialsPanel.vue')

--- a/src/components/boundingBoxes/WidgetBoundingBoxes.test.ts
+++ b/src/components/boundingBoxes/WidgetBoundingBoxes.test.ts
@@ -1,7 +1,6 @@
 /* eslint-disable testing-library/no-container, testing-library/no-node-access, testing-library/prefer-user-event */
 import { fireEvent, render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
-import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createI18n } from 'vue-i18n'
 
@@ -98,7 +97,6 @@ const lastBoxes = (emitted: () => Record<string, unknown[][]>) => {
 }
 
 beforeEach(() => {
-  setActivePinia(createPinia())
   appState.node = {
     widgets: [
       { name: 'width', value: 512 },

--- a/src/components/builder/BuilderFooterToolbar.test.ts
+++ b/src/components/builder/BuilderFooterToolbar.test.ts
@@ -1,6 +1,5 @@
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
-import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { computed, ref } from 'vue'
 import { createI18n } from 'vue-i18n'
@@ -99,7 +98,6 @@ const i18n = createI18n({
 
 describe('BuilderFooterToolbar', () => {
   beforeEach(() => {
-    setActivePinia(createPinia())
     mockState.mode = 'builder:inputs'
     mockHasOutputs.value = true
     mockActiveWorkflow.value = { isTemporary: true, initialMode: 'app' }

--- a/src/components/dialog/GlobalDialog.test.ts
+++ b/src/components/dialog/GlobalDialog.test.ts
@@ -1,7 +1,7 @@
-import { cleanup, render, screen, waitFor } from '@testing-library/vue'
+import { render, screen, waitFor } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import PrimeVue from 'primevue/config'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { defineComponent, h, nextTick } from 'vue'
 import { createI18n } from 'vue-i18n'
 
@@ -103,10 +103,6 @@ function mountDialog() {
 }
 
 describe('GlobalDialog renderer branching', () => {
-  afterEach(() => {
-    cleanup()
-  })
-
   it('renders the Reka branch when renderer is omitted (default)', async () => {
     mountDialog()
     const store = useDialogStore()
@@ -171,10 +167,6 @@ describe('GlobalDialog renderer branching', () => {
 })
 
 describe('GlobalDialog Reka parity with PrimeVue', () => {
-  afterEach(() => {
-    cleanup()
-  })
-
   it('omits the close button when closable is false', async () => {
     mountDialog()
     const store = useDialogStore()
@@ -358,10 +350,6 @@ describe('GlobalDialog Reka parity with PrimeVue', () => {
 })
 
 describe('GlobalDialog Reka overlay scrim', () => {
-  afterEach(() => {
-    cleanup()
-  })
-
   it('renders a backdrop scrim for modal Reka dialogs', async () => {
     mountDialog()
     const store = useDialogStore()
@@ -476,10 +464,6 @@ describe('GlobalDialog Reka overlay scrim', () => {
 })
 
 describe('GlobalDialog Reka focus-outside binding', () => {
-  afterEach(() => {
-    cleanup()
-  })
-
   // Reka's DismissableLayer fires focus-outside off a real focus transition
   // (blur inside the layer, then focusin on the new target), so drive the
   // mounted binding by moving focus to a fresh element outside the dialog

--- a/src/components/dialog/confirm/confirmDialog.test.ts
+++ b/src/components/dialog/confirm/confirmDialog.test.ts
@@ -4,7 +4,7 @@
  * Confirm* sections carry their own). Catches accidental reverts of the
  * Phase 6 renderer flip.
  */
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 const showDialog = vi.hoisted(() => vi.fn())
 
@@ -18,10 +18,6 @@ import ConfirmHeader from '@/components/dialog/confirm/ConfirmHeader.vue'
 import { showConfirmDialog } from '@/components/dialog/confirm/confirmDialog'
 
 describe('showConfirmDialog Reka renderer opt-in', () => {
-  beforeEach(() => {
-    showDialog.mockReset()
-  })
-
   it("sets renderer 'reka' with size 'md' and zeroed section padding", () => {
     showConfirmDialog()
 

--- a/src/components/dialog/content/ConfirmationDialogContent.test.ts
+++ b/src/components/dialog/content/ConfirmationDialogContent.test.ts
@@ -1,7 +1,6 @@
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
-import { createPinia, setActivePinia } from 'pinia'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import type { ComponentProps } from 'vue-component-type-helpers'
 import { createI18n } from 'vue-i18n'
 
@@ -35,10 +34,6 @@ const i18n = createI18n({
 })
 
 describe('ConfirmationDialogContent', () => {
-  beforeEach(() => {
-    setActivePinia(createPinia())
-  })
-
   function renderComponent(props: Partial<Props> = {}) {
     const user = userEvent.setup()
     render(ConfirmationDialogContent, {

--- a/src/components/dialog/content/PromptDialogContent.test.ts
+++ b/src/components/dialog/content/PromptDialogContent.test.ts
@@ -1,7 +1,6 @@
 import { fireEvent, render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
-import { createPinia, setActivePinia } from 'pinia'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import type { ComponentProps } from 'vue-component-type-helpers'
 import { createI18n } from 'vue-i18n'
 
@@ -19,10 +18,6 @@ const i18n = createI18n({
 })
 
 describe('PromptDialogContent', () => {
-  beforeEach(() => {
-    setActivePinia(createPinia())
-  })
-
   function renderComponent(props: Partial<Props> = {}) {
     const user = userEvent.setup()
     render(PromptDialogContent, {

--- a/src/components/dialog/content/signin/ApiKeyForm.test.ts
+++ b/src/components/dialog/content/signin/ApiKeyForm.test.ts
@@ -58,7 +58,6 @@ const i18n = createI18n({
 
 describe('ApiKeyForm', () => {
   beforeEach(() => {
-    mockStoreApiKey.mockReset()
     mockLoadingRef.value = false
   })
 

--- a/src/components/dialog/content/signin/SignInForm.test.ts
+++ b/src/components/dialog/content/signin/SignInForm.test.ts
@@ -61,8 +61,6 @@ const loginButtonText = enMessages.auth.login.loginButton
 
 describe('SignInForm', () => {
   beforeEach(() => {
-    mockSendPasswordReset.mockReset()
-    mockToastAdd.mockReset()
     mockLoadingRef.value = false
   })
 

--- a/src/components/dialog/content/signin/SignUpForm.test.ts
+++ b/src/components/dialog/content/signin/SignUpForm.test.ts
@@ -108,7 +108,6 @@ describe('SignUpForm', () => {
     mockTurnstileEnabled.value = false
     mockTurnstileToken.value = ''
     mockTurnstileUnavailable.value = false
-    mockReset.mockClear()
     emitTurnstileToken = undefined
     emitTurnstileUnavailable = undefined
   })

--- a/src/components/error/ErrorOverlay.test.ts
+++ b/src/components/error/ErrorOverlay.test.ts
@@ -125,11 +125,9 @@ describe('ErrorOverlay', () => {
     mockErrorGroups.missingModelGroups.value = []
     mockErrorGroups.missingMediaGroups.value = []
     mockErrorGroups.swapNodeGroups.value = []
-    mockOpenPanel.mockClear()
     mockCanvasStore.linearMode = false
     mockCanvasStore.canvas = null
     mockCanvasStore.currentGraph = null
-    mockCanvasStore.updateSelectedItems.mockClear()
   })
 
   it('renders a single overlay message without list markup', async () => {

--- a/src/components/graph/NodeTooltip.test.ts
+++ b/src/components/graph/NodeTooltip.test.ts
@@ -1,4 +1,4 @@
-import { cleanup, render, screen } from '@testing-library/vue'
+import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import { nextTick } from 'vue'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -174,7 +174,6 @@ describe('NodeTooltip', () => {
 
   afterEach(() => {
     mergeOutputTooltipMessage(null)
-    cleanup()
   })
 
   it('shows input slot JSON tooltips without i18n placeholder errors', async () => {

--- a/src/components/graph/SelectionRectangle.test.ts
+++ b/src/components/graph/SelectionRectangle.test.ts
@@ -50,7 +50,6 @@ describe('SelectionRectangle', () => {
   afterEach(() => {
     rafCallbacks.length = 0
     mockCanvas.value = null
-    document.body.replaceChildren()
   })
 
   it('clips the rectangle to the canvas panel when dragged over the sidebar', async () => {

--- a/src/components/graph/selectionToolbox/BypassButton.test.ts
+++ b/src/components/graph/selectionToolbox/BypassButton.test.ts
@@ -1,4 +1,3 @@
-import { createPinia, setActivePinia } from 'pinia'
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import PrimeVue from 'primevue/config'
@@ -41,7 +40,6 @@ describe('BypassButton', () => {
   })
 
   beforeEach(() => {
-    setActivePinia(createPinia())
     canvasStore = useCanvasStore()
     commandStore = useCommandStore()
   })

--- a/src/components/graph/selectionToolbox/ColorPickerButton.test.ts
+++ b/src/components/graph/selectionToolbox/ColorPickerButton.test.ts
@@ -1,7 +1,6 @@
 import type { Mock } from 'vitest'
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
-import { createPinia, setActivePinia } from 'pinia'
 import PrimeVue from 'primevue/config'
 import Tooltip from 'primevue/tooltip'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -95,7 +94,6 @@ describe('ColorPickerButton', () => {
   })
 
   beforeEach(() => {
-    setActivePinia(createPinia())
     canvasStore = useCanvasStore()
     workflowStore = useWorkflowStore()
 

--- a/src/components/helpcenter/HelpCenterMenuContent.test.ts
+++ b/src/components/helpcenter/HelpCenterMenuContent.test.ts
@@ -1,4 +1,4 @@
-import { cleanup, render, screen } from '@testing-library/vue'
+import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { defineComponent, h } from 'vue'
@@ -125,7 +125,6 @@ describe('HelpCenterMenuContent feedback item', () => {
 
   afterEach(() => {
     openSpy.mockRestore()
-    cleanup()
   })
 
   it('opens the Typeform survey tagged with help-center source on Cloud', async () => {
@@ -178,7 +177,6 @@ describe('HelpCenterMenuContent system status item', () => {
 
   afterEach(() => {
     openSpy.mockRestore()
-    cleanup()
   })
 
   it('opens the status page on Cloud', async () => {

--- a/src/components/helpcenter/HelpCenterMenuContent.test.ts
+++ b/src/components/helpcenter/HelpCenterMenuContent.test.ts
@@ -120,7 +120,6 @@ describe('HelpCenterMenuContent feedback item', () => {
     distribution.isCloud = false
     distribution.isDesktop = false
     distribution.isNightly = false
-    commandStoreExecute.mockReset()
     openSpy = vi.spyOn(window, 'open').mockReturnValue(null)
   })
 

--- a/src/components/honeyToast/HoneyToast.test.ts
+++ b/src/components/honeyToast/HoneyToast.test.ts
@@ -1,15 +1,11 @@
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
-import { beforeEach, describe, expect, it } from 'vitest'
+import { describe, expect, it } from 'vitest'
 import { defineComponent, h, nextTick, ref } from 'vue'
 
 import HoneyToast from './HoneyToast.vue'
 
 describe('HoneyToast', () => {
-  beforeEach(() => {
-    document.body.innerHTML = ''
-  })
-
   function renderComponent(
     props: { visible: boolean; expanded?: boolean } = { visible: true }
   ) {

--- a/src/components/load3d/Load3DScene.test.ts
+++ b/src/components/load3d/Load3DScene.test.ts
@@ -74,9 +74,6 @@ describe('Load3DScene', () => {
   beforeEach(() => {
     dragState.isDragging = ref(false)
     dragState.dragMessage = ref('')
-    dragState.handleDragOver.mockReset()
-    dragState.handleDragLeave.mockReset()
-    dragState.handleDrop.mockReset()
     dragState.capturedOptions = null
   })
 

--- a/src/components/load3d/controls/AnimationControls.test.ts
+++ b/src/components/load3d/controls/AnimationControls.test.ts
@@ -6,24 +6,7 @@ import { createI18n } from 'vue-i18n'
 
 import AnimationControls from '@/components/load3d/controls/AnimationControls.vue'
 
-vi.mock('@/components/ui/slider/Slider.vue', () => ({
-  default: {
-    name: 'UiSlider',
-    props: ['modelValue', 'min', 'max', 'step'],
-    emits: ['update:modelValue'],
-    template: `
-      <input
-        type="range"
-        role="slider"
-        :value="Array.isArray(modelValue) ? modelValue[0] : modelValue"
-        :min="min"
-        :max="max"
-        :step="step"
-        @input="$emit('update:modelValue', [Number($event.target.value)])"
-      />
-    `
-  }
-}))
+vi.mock('@/components/ui/slider/Slider.vue')
 
 const i18n = createI18n({
   legacy: false,

--- a/src/components/load3d/controls/ExportControls.test.ts
+++ b/src/components/load3d/controls/ExportControls.test.ts
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { createI18n } from 'vue-i18n'
 
 import ExportControls from '@/components/load3d/controls/ExportControls.vue'
@@ -28,10 +28,6 @@ function renderComponent(
 }
 
 describe('ExportControls', () => {
-  afterEach(() => {
-    document.body.innerHTML = ''
-  })
-
   it('renders the trigger button without exposing the format list initially', () => {
     renderComponent()
 

--- a/src/components/load3d/controls/HDRIControls.test.ts
+++ b/src/components/load3d/controls/HDRIControls.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable testing-library/no-container, testing-library/no-node-access -- hidden file input has no role/label, queried by selector */
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { ref } from 'vue'
 import { createI18n } from 'vue-i18n'
 
@@ -67,10 +67,6 @@ function renderComponent(opts: RenderOpts = {}) {
 }
 
 describe('HDRIControls', () => {
-  afterEach(() => {
-    document.body.innerHTML = ''
-  })
-
   describe('initial render', () => {
     it('renders the upload button when no HDRI is loaded', () => {
       renderComponent()

--- a/src/components/load3d/controls/HDRIControls.test.ts
+++ b/src/components/load3d/controls/HDRIControls.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable testing-library/no-container, testing-library/no-node-access -- hidden file input has no role/label, queried by selector */
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { ref } from 'vue'
 import { createI18n } from 'vue-i18n'
 
@@ -67,10 +67,6 @@ function renderComponent(opts: RenderOpts = {}) {
 }
 
 describe('HDRIControls', () => {
-  beforeEach(() => {
-    addAlert.mockClear()
-  })
-
   afterEach(() => {
     document.body.innerHTML = ''
   })

--- a/src/components/load3d/controls/LightControls.test.ts
+++ b/src/components/load3d/controls/LightControls.test.ts
@@ -26,24 +26,7 @@ vi.mock('@/composables/useDismissableOverlay', () => ({
   useDismissableOverlay: vi.fn()
 }))
 
-vi.mock('@/components/ui/slider/Slider.vue', () => ({
-  default: {
-    name: 'UiSlider',
-    props: ['modelValue', 'min', 'max', 'step'],
-    emits: ['update:modelValue'],
-    template: `
-      <input
-        type="range"
-        role="slider"
-        :value="Array.isArray(modelValue) ? modelValue[0] : modelValue"
-        :min="min"
-        :max="max"
-        :step="step"
-        @input="$emit('update:modelValue', [Number($event.target.value)])"
-      />
-    `
-  }
-}))
+vi.mock('@/components/ui/slider/Slider.vue')
 
 const i18n = createI18n({
   legacy: false,

--- a/src/components/load3d/controls/LightControls.test.ts
+++ b/src/components/load3d/controls/LightControls.test.ts
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { ref } from 'vue'
 import { createI18n } from 'vue-i18n'
 
@@ -94,10 +94,6 @@ function renderComponent(opts: RenderOpts = {}) {
 }
 
 describe('LightControls', () => {
-  afterEach(() => {
-    document.body.innerHTML = ''
-  })
-
   describe('material mode gating', () => {
     it('renders the intensity control when materialMode is original', () => {
       renderComponent({ materialMode: 'original' })

--- a/src/components/load3d/controls/ModelControls.test.ts
+++ b/src/components/load3d/controls/ModelControls.test.ts
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
-import { afterEach, describe, expect, it } from 'vitest'
+import { describe, expect, it } from 'vitest'
 import { ref } from 'vue'
 import { createI18n } from 'vue-i18n'
 
@@ -77,10 +77,6 @@ function renderComponent(opts: RenderOpts = {}) {
 }
 
 describe('ModelControls', () => {
-  afterEach(() => {
-    document.body.innerHTML = ''
-  })
-
   describe('up direction', () => {
     it('renders the up-direction trigger and opens the popup with all 7 directions', async () => {
       const { user } = renderComponent()

--- a/src/components/load3d/controls/PopupSlider.test.ts
+++ b/src/components/load3d/controls/PopupSlider.test.ts
@@ -5,24 +5,7 @@ import { ref } from 'vue'
 
 import PopupSlider from '@/components/load3d/controls/PopupSlider.vue'
 
-vi.mock('@/components/ui/slider/Slider.vue', () => ({
-  default: {
-    name: 'UiSlider',
-    props: ['modelValue', 'min', 'max', 'step'],
-    emits: ['update:modelValue'],
-    template: `
-      <input
-        type="range"
-        role="slider"
-        :value="Array.isArray(modelValue) ? modelValue[0] : modelValue"
-        :min="min"
-        :max="max"
-        :step="step"
-        @input="$emit('update:modelValue', [Number($event.target.value)])"
-      />
-    `
-  }
-}))
+vi.mock('@/components/ui/slider/Slider.vue')
 
 function renderComponent(
   props: {

--- a/src/components/load3d/controls/PopupSlider.test.ts
+++ b/src/components/load3d/controls/PopupSlider.test.ts
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { ref } from 'vue'
 
 import PopupSlider from '@/components/load3d/controls/PopupSlider.vue'
@@ -55,10 +55,6 @@ function renderComponent(
 }
 
 describe('PopupSlider', () => {
-  afterEach(() => {
-    document.body.innerHTML = ''
-  })
-
   it('keeps the slider hidden from the accessibility tree until the trigger is clicked', () => {
     renderComponent({ tooltipText: 'FOV' })
 

--- a/src/components/load3d/controls/ViewerControls.test.ts
+++ b/src/components/load3d/controls/ViewerControls.test.ts
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { createI18n } from 'vue-i18n'
 
 import ViewerControls from '@/components/load3d/controls/ViewerControls.vue'
@@ -37,11 +37,6 @@ const i18n = createI18n({
 const mockNode = createMockLGraphNode({ id: 'node-1' })
 
 describe('ViewerControls', () => {
-  beforeEach(() => {
-    showDialog.mockClear()
-    handleViewerClose.mockClear()
-  })
-
   it('renders the open-in-viewer button labeled by the localized aria-label', () => {
     render(ViewerControls, {
       props: { node: mockNode },

--- a/src/components/load3d/controls/viewer/ViewerCameraControls.test.ts
+++ b/src/components/load3d/controls/viewer/ViewerCameraControls.test.ts
@@ -7,66 +7,11 @@ import { createI18n } from 'vue-i18n'
 import ViewerCameraControls from '@/components/load3d/controls/viewer/ViewerCameraControls.vue'
 import type { CameraType } from '@/extensions/core/load3d/interfaces'
 
-vi.mock('@/components/ui/select/Select.vue', async () => {
-  const { provide } = await import('vue')
-  return {
-    default: {
-      name: 'Select',
-      props: ['modelValue'],
-      emits: ['update:modelValue'],
-      setup(
-        props: { modelValue: string },
-        { emit }: { emit: (event: string, value: string) => void }
-      ) {
-        provide('selectModelValue', (): string => props.modelValue)
-        provide('selectUpdate', (v: string): void =>
-          emit('update:modelValue', v)
-        )
-      },
-      template: '<div><slot /></div>'
-    }
-  }
-})
-
-vi.mock('@/components/ui/select/SelectContent.vue', async () => {
-  const { inject, ref, onMounted } = await import('vue')
-  return {
-    default: {
-      name: 'SelectContent',
-      setup() {
-        const selectModelValue = inject<() => string>('selectModelValue')
-        const selectUpdate = inject<(v: string) => void>('selectUpdate')
-        const el = ref<HTMLSelectElement | null>(null)
-        onMounted(() => {
-          if (el.value) el.value.value = selectModelValue?.() ?? ''
-        })
-        return {
-          el,
-          onChange: (e: Event) => {
-            selectUpdate?.((e.target as HTMLSelectElement).value)
-          }
-        }
-      },
-      template: '<select ref="el" @change="onChange"><slot /></select>'
-    }
-  }
-})
-
-vi.mock('@/components/ui/select/SelectItem.vue', () => ({
-  default: {
-    name: 'SelectItem',
-    props: ['value'],
-    template: '<option :value="value"><slot /></option>'
-  }
-}))
-
-vi.mock('@/components/ui/select/SelectTrigger.vue', () => ({
-  default: { name: 'SelectTrigger', template: '<span />' }
-}))
-
-vi.mock('@/components/ui/select/SelectValue.vue', () => ({
-  default: { name: 'SelectValue', template: '<span />' }
-}))
+vi.mock('@/components/ui/select/Select.vue')
+vi.mock('@/components/ui/select/SelectContent.vue')
+vi.mock('@/components/ui/select/SelectItem.vue')
+vi.mock('@/components/ui/select/SelectTrigger.vue')
+vi.mock('@/components/ui/select/SelectValue.vue')
 
 vi.mock('@/components/ui/slider/Slider.vue', () => ({
   default: {

--- a/src/components/load3d/controls/viewer/ViewerCameraControls.test.ts
+++ b/src/components/load3d/controls/viewer/ViewerCameraControls.test.ts
@@ -13,24 +13,7 @@ vi.mock('@/components/ui/select/SelectItem.vue')
 vi.mock('@/components/ui/select/SelectTrigger.vue')
 vi.mock('@/components/ui/select/SelectValue.vue')
 
-vi.mock('@/components/ui/slider/Slider.vue', () => ({
-  default: {
-    name: 'UiSlider',
-    props: ['modelValue', 'min', 'max', 'step'],
-    emits: ['update:modelValue'],
-    template: `
-      <input
-        type="range"
-        role="slider"
-        :value="Array.isArray(modelValue) ? modelValue[0] : modelValue"
-        :min="min"
-        :max="max"
-        :step="step"
-        @input="$emit('update:modelValue', [Number($event.target.value)])"
-      />
-    `
-  }
-}))
+vi.mock('@/components/ui/slider/Slider.vue')
 
 const i18n = createI18n({
   legacy: false,

--- a/src/components/load3d/controls/viewer/ViewerExportControls.test.ts
+++ b/src/components/load3d/controls/viewer/ViewerExportControls.test.ts
@@ -5,66 +5,11 @@ import { createI18n } from 'vue-i18n'
 
 import ViewerExportControls from '@/components/load3d/controls/viewer/ViewerExportControls.vue'
 
-vi.mock('@/components/ui/select/Select.vue', async () => {
-  const { provide } = await import('vue')
-  return {
-    default: {
-      name: 'Select',
-      props: ['modelValue'],
-      emits: ['update:modelValue'],
-      setup(
-        props: { modelValue: string },
-        { emit }: { emit: (event: string, value: string) => void }
-      ) {
-        provide('selectModelValue', (): string => props.modelValue)
-        provide('selectUpdate', (v: string): void =>
-          emit('update:modelValue', v)
-        )
-      },
-      template: '<div><slot /></div>'
-    }
-  }
-})
-
-vi.mock('@/components/ui/select/SelectContent.vue', async () => {
-  const { inject, ref, onMounted } = await import('vue')
-  return {
-    default: {
-      name: 'SelectContent',
-      setup() {
-        const selectModelValue = inject<() => string>('selectModelValue')
-        const selectUpdate = inject<(v: string) => void>('selectUpdate')
-        const el = ref<HTMLSelectElement | null>(null)
-        onMounted(() => {
-          if (el.value) el.value.value = selectModelValue?.() ?? ''
-        })
-        return {
-          el,
-          onChange: (e: Event) => {
-            selectUpdate?.((e.target as HTMLSelectElement).value)
-          }
-        }
-      },
-      template: '<select ref="el" @change="onChange"><slot /></select>'
-    }
-  }
-})
-
-vi.mock('@/components/ui/select/SelectItem.vue', () => ({
-  default: {
-    name: 'SelectItem',
-    props: ['value'],
-    template: '<option :value="value"><slot /></option>'
-  }
-}))
-
-vi.mock('@/components/ui/select/SelectTrigger.vue', () => ({
-  default: { name: 'SelectTrigger', template: '<span />' }
-}))
-
-vi.mock('@/components/ui/select/SelectValue.vue', () => ({
-  default: { name: 'SelectValue', template: '<span />' }
-}))
+vi.mock('@/components/ui/select/Select.vue')
+vi.mock('@/components/ui/select/SelectContent.vue')
+vi.mock('@/components/ui/select/SelectItem.vue')
+vi.mock('@/components/ui/select/SelectTrigger.vue')
+vi.mock('@/components/ui/select/SelectValue.vue')
 
 const i18n = createI18n({
   legacy: false,

--- a/src/components/load3d/controls/viewer/ViewerLightControls.test.ts
+++ b/src/components/load3d/controls/viewer/ViewerLightControls.test.ts
@@ -17,24 +17,7 @@ vi.mock('@/platform/settings/settingStore', () => ({
   })
 }))
 
-vi.mock('@/components/ui/slider/Slider.vue', () => ({
-  default: {
-    name: 'UiSlider',
-    props: ['modelValue', 'min', 'max', 'step'],
-    emits: ['update:modelValue'],
-    template: `
-      <input
-        type="range"
-        role="slider"
-        :value="Array.isArray(modelValue) ? modelValue[0] : modelValue"
-        :min="min"
-        :max="max"
-        :step="step"
-        @input="$emit('update:modelValue', [Number($event.target.value)])"
-      />
-    `
-  }
-}))
+vi.mock('@/components/ui/slider/Slider.vue')
 
 const i18n = createI18n({
   legacy: false,

--- a/src/components/load3d/controls/viewer/ViewerModelControls.test.ts
+++ b/src/components/load3d/controls/viewer/ViewerModelControls.test.ts
@@ -9,66 +9,11 @@ import type {
   UpDirection
 } from '@/extensions/core/load3d/interfaces'
 
-vi.mock('@/components/ui/select/Select.vue', async () => {
-  const { provide } = await import('vue')
-  return {
-    default: {
-      name: 'Select',
-      props: ['modelValue'],
-      emits: ['update:modelValue'],
-      setup(
-        props: { modelValue: string },
-        { emit }: { emit: (event: string, value: string) => void }
-      ) {
-        provide('selectModelValue', (): string => props.modelValue)
-        provide('selectUpdate', (v: string): void =>
-          emit('update:modelValue', v)
-        )
-      },
-      template: '<div><slot /></div>'
-    }
-  }
-})
-
-vi.mock('@/components/ui/select/SelectContent.vue', async () => {
-  const { inject, ref, onMounted } = await import('vue')
-  return {
-    default: {
-      name: 'SelectContent',
-      setup() {
-        const selectModelValue = inject<() => string>('selectModelValue')
-        const selectUpdate = inject<(v: string) => void>('selectUpdate')
-        const el = ref<HTMLSelectElement | null>(null)
-        onMounted(() => {
-          if (el.value) el.value.value = selectModelValue?.() ?? ''
-        })
-        return {
-          el,
-          onChange: (e: Event) => {
-            selectUpdate?.((e.target as HTMLSelectElement).value)
-          }
-        }
-      },
-      template: '<select ref="el" @change="onChange"><slot /></select>'
-    }
-  }
-})
-
-vi.mock('@/components/ui/select/SelectItem.vue', () => ({
-  default: {
-    name: 'SelectItem',
-    props: ['value'],
-    template: '<option :value="value"><slot /></option>'
-  }
-}))
-
-vi.mock('@/components/ui/select/SelectTrigger.vue', () => ({
-  default: { name: 'SelectTrigger', template: '<span />' }
-}))
-
-vi.mock('@/components/ui/select/SelectValue.vue', () => ({
-  default: { name: 'SelectValue', template: '<span />' }
-}))
+vi.mock('@/components/ui/select/Select.vue')
+vi.mock('@/components/ui/select/SelectContent.vue')
+vi.mock('@/components/ui/select/SelectItem.vue')
+vi.mock('@/components/ui/select/SelectTrigger.vue')
+vi.mock('@/components/ui/select/SelectValue.vue')
 
 const i18n = createI18n({
   legacy: false,

--- a/src/components/maskeditor/BrushCursor.test.ts
+++ b/src/components/maskeditor/BrushCursor.test.ts
@@ -41,7 +41,6 @@ const getGradientEl = (): HTMLElement =>
 
 describe('BrushCursor', () => {
   beforeEach(() => {
-    document.body.innerHTML = ''
     mockStore = initialMock()
   })
 

--- a/src/components/queue/JobHistoryActionsMenu.test.ts
+++ b/src/components/queue/JobHistoryActionsMenu.test.ts
@@ -1,29 +1,11 @@
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { defineComponent, h } from 'vue'
 
+import { popoverCloseSpy } from '@/components/ui/__mocks__/popoverMockState'
 import { i18n } from '@/i18n'
 
-const popoverCloseSpy = vi.fn()
-
-vi.mock('@/components/ui/Popover.vue', () => {
-  const PopoverStub = defineComponent({
-    name: 'Popover',
-    setup(_, { slots }) {
-      return () =>
-        h('div', [
-          slots.button?.(),
-          slots.default?.({
-            close: () => {
-              popoverCloseSpy()
-            }
-          })
-        ])
-    }
-  })
-  return { default: PopoverStub }
-})
+vi.mock('@/components/ui/Popover.vue')
 
 vi.mock('@/platform/distribution/types', () => ({
   isCloud: false

--- a/src/components/queue/JobHistoryActionsMenu.test.ts
+++ b/src/components/queue/JobHistoryActionsMenu.test.ts
@@ -65,9 +65,6 @@ const renderMenu = () =>
 describe('JobHistoryActionsMenu', () => {
   beforeEach(() => {
     i18n.global.locale.value = 'en'
-    popoverCloseSpy.mockClear()
-    mockSetSetting.mockClear()
-    mockSetMany.mockClear()
     mockSidebarTabStore.activeSidebarTabId = null
     mockGetSetting.mockImplementation((key: string) =>
       key === 'Comfy.Queue.QPOV2' || key === 'Comfy.Queue.ShowRunProgressBar'

--- a/src/components/queue/QueueOverlayHeader.test.ts
+++ b/src/components/queue/QueueOverlayHeader.test.ts
@@ -72,9 +72,6 @@ const renderHeader = (props = {}) =>
 describe('QueueOverlayHeader', () => {
   beforeEach(() => {
     i18n.global.locale.value = 'en'
-    popoverCloseSpy.mockClear()
-    mockSetSetting.mockClear()
-    mockSetMany.mockClear()
     mockSidebarTabStore.activeSidebarTabId = null
     mockGetSetting.mockImplementation((key: string) =>
       key === 'Comfy.Queue.QPOV2' ? true : undefined

--- a/src/components/queue/QueueOverlayHeader.test.ts
+++ b/src/components/queue/QueueOverlayHeader.test.ts
@@ -1,29 +1,11 @@
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { defineComponent, h } from 'vue'
 
+import { popoverCloseSpy } from '@/components/ui/__mocks__/popoverMockState'
 import { i18n } from '@/i18n'
 
-const popoverCloseSpy = vi.fn()
-
-vi.mock('@/components/ui/Popover.vue', () => {
-  const PopoverStub = defineComponent({
-    name: 'Popover',
-    setup(_, { slots }) {
-      return () =>
-        h('div', [
-          slots.button?.(),
-          slots.default?.({
-            close: () => {
-              popoverCloseSpy()
-            }
-          })
-        ])
-    }
-  })
-  return { default: PopoverStub }
-})
+vi.mock('@/components/ui/Popover.vue')
 
 const mockGetSetting = vi.fn<(key: string) => boolean | undefined>((key) =>
   key === 'Comfy.Queue.QPOV2' || key === 'Comfy.Queue.ShowRunProgressBar'

--- a/src/components/queue/job/JobContextMenu.test.ts
+++ b/src/components/queue/job/JobContextMenu.test.ts
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { defineComponent, nextTick, ref } from 'vue'
 
 import JobContextMenu from '@/components/queue/job/JobContextMenu.vue'
@@ -115,10 +115,6 @@ async function openMenu(
   await nextTick()
   return trigger
 }
-
-afterEach(() => {
-  document.body.innerHTML = ''
-})
 
 describe('JobContextMenu', () => {
   it('passes disabled state to action buttons', async () => {

--- a/src/components/rightSidePanel/errors/MissingNodeCard.test.ts
+++ b/src/components/rightSidePanel/errors/MissingNodeCard.test.ts
@@ -143,8 +143,6 @@ function renderCard(
 
 describe('MissingNodeCard', () => {
   beforeEach(() => {
-    mockApplyChanges.mockClear()
-    mockIsPackInstalled.mockReset()
     mockIsPackInstalled.mockReturnValue(false)
     mockIsCloud.value = false
     mockShouldShowManagerButtons.value = false

--- a/src/components/rightSidePanel/errors/MissingPackGroupRow.test.ts
+++ b/src/components/rightSidePanel/errors/MissingPackGroupRow.test.ts
@@ -127,9 +127,6 @@ function renderRow(
 
 describe('MissingPackGroupRow', () => {
   beforeEach(() => {
-    mockInstallAllPacks.mockClear()
-    mockOpenManager.mockClear()
-    mockIsPackInstalled.mockReset()
     mockIsPackInstalled.mockReturnValue(false)
     mockShouldShowManagerButtons.value = false
     mockIsInstalling.value = false

--- a/src/components/rightSidePanel/errors/swapNodeGroups.test.ts
+++ b/src/components/rightSidePanel/errors/swapNodeGroups.test.ts
@@ -1,7 +1,6 @@
 import { fromAny } from '@total-typescript/shoehorn'
-import { createPinia, setActivePinia } from 'pinia'
 import { nextTick, ref } from 'vue'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import type { MissingNodeType } from '@/types/comfy'
 
@@ -74,10 +73,6 @@ function makeMissingNodeType(
 }
 
 describe('swapNodeGroups computed', () => {
-  beforeEach(() => {
-    setActivePinia(createPinia())
-  })
-
   function getSwapNodeGroups(nodeTypes: MissingNodeType[]) {
     useMissingNodesErrorStore().surfaceMissingNodes(nodeTypes)
 

--- a/src/components/rightSidePanel/errors/useErrorActions.test.ts
+++ b/src/components/rightSidePanel/errors/useErrorActions.test.ts
@@ -39,9 +39,6 @@ describe('useErrorActions', () => {
       trackUiButtonClicked: mocks.trackUiButtonClicked,
       trackHelpResourceClicked: mocks.trackHelpResourceClicked
     }
-    mocks.trackUiButtonClicked.mockReset()
-    mocks.trackHelpResourceClicked.mockReset()
-    mocks.execute.mockReset()
     windowOpenSpy = vi
       .spyOn(window, 'open')
       .mockImplementation(() => null as unknown as Window)

--- a/src/components/rightSidePanel/errors/useErrorGroups.test.ts
+++ b/src/components/rightSidePanel/errors/useErrorGroups.test.ts
@@ -1,5 +1,4 @@
 import { fromAny } from '@total-typescript/shoehorn'
-import { createPinia, setActivePinia } from 'pinia'
 import { nextTick, ref } from 'vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -213,7 +212,6 @@ function createErrorGroups() {
 
 describe('useErrorGroups', () => {
   beforeEach(() => {
-    setActivePinia(createPinia())
     mockIsCloud.value = false
     vi.mocked(isLGraphNode).mockReturnValue(false)
   })

--- a/src/components/rightSidePanel/errors/useErrorGroups.test.ts
+++ b/src/components/rightSidePanel/errors/useErrorGroups.test.ts
@@ -216,7 +216,6 @@ describe('useErrorGroups', () => {
     setActivePinia(createPinia())
     mockIsCloud.value = false
     vi.mocked(isLGraphNode).mockReturnValue(false)
-    vi.mocked(getNodeByExecutionId).mockReset()
   })
 
   describe('missingPackGroups', () => {

--- a/src/components/rightSidePanel/errors/useErrorReport.test.ts
+++ b/src/components/rightSidePanel/errors/useErrorReport.test.ts
@@ -115,10 +115,6 @@ describe('useErrorReport', () => {
   let warnSpy: ReturnType<typeof vi.spyOn>
 
   beforeEach(async () => {
-    mocks.getLogs.mockReset()
-    mocks.serialize.mockReset()
-    mocks.refetchSystemStats.mockReset()
-    mocks.generateErrorReport.mockReset()
     storeState.systemStats = null
     storeState.isLoading = false
     const store = await getStore()

--- a/src/components/rightSidePanel/parameters/SectionWidgets.test.ts
+++ b/src/components/rightSidePanel/parameters/SectionWidgets.test.ts
@@ -135,11 +135,6 @@ function createHostWithPromotedModel(): {
 
 describe('SectionWidgets', () => {
   beforeEach(() => {
-    setDirty.mockClear()
-    getNodeById.mockReset()
-    animateToBounds.mockClear()
-    mockGetInputSpecForWidget.mockReset()
-    mockTrackUiButtonClicked.mockClear()
     selectedItems.length = 0
   })
 

--- a/src/components/rightSidePanel/rightSidePanelTabTelemetry.test.ts
+++ b/src/components/rightSidePanel/rightSidePanelTabTelemetry.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 const { mockTrackUiButtonClicked } = vi.hoisted(() => ({
   mockTrackUiButtonClicked: vi.fn()
@@ -13,10 +13,6 @@ vi.mock('@/platform/telemetry', () => ({
 import { trackRightSidePanelTabOpened } from './rightSidePanelTabTelemetry'
 
 describe('trackRightSidePanelTabOpened', () => {
-  beforeEach(() => {
-    mockTrackUiButtonClicked.mockClear()
-  })
-
   it('tracks opening the settings tab', () => {
     trackRightSidePanelTabOpened('settings')
 

--- a/src/components/searchbox/NodeSearchBoxPopover.test.ts
+++ b/src/components/searchbox/NodeSearchBoxPopover.test.ts
@@ -127,7 +127,6 @@ describe('NodeSearchBoxPopover', () => {
   }
 
   beforeEach(() => {
-    addNodeOnGraph.mockReset()
     addNodeOnGraph.mockReturnValue(null)
   })
 

--- a/src/components/sidebar/tabs/NodeLibrarySidebarTabV2.test.ts
+++ b/src/components/sidebar/tabs/NodeLibrarySidebarTabV2.test.ts
@@ -91,7 +91,6 @@ const i18n = createI18n({
 
 describe('NodeLibrarySidebarTabV2', () => {
   beforeEach(() => {
-    hoisted.mockSearchNode.mockReset()
     hoisted.mockSearchNode.mockReturnValue([])
   })
 

--- a/src/components/sidebar/tabs/nodeLibrary/EssentialNodeCard.test.ts
+++ b/src/components/sidebar/tabs/nodeLibrary/EssentialNodeCard.test.ts
@@ -1,6 +1,5 @@
 import userEvent from '@testing-library/user-event'
 import { fireEvent, render, screen } from '@testing-library/vue'
-import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createI18n } from 'vue-i18n'
 
@@ -74,7 +73,6 @@ const UNRESOLVED_TILE: EssentialTile = {
 
 describe('EssentialNodeCard', () => {
   beforeEach(() => {
-    setActivePinia(createPinia())
     useNodeDefStore().updateNodeDefs([createNodeDef('LoadImage')])
   })
 

--- a/src/components/sidebar/tabs/queue/MediaLightbox.test.ts
+++ b/src/components/sidebar/tabs/queue/MediaLightbox.test.ts
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
 import { createI18n } from 'vue-i18n'
 
@@ -96,10 +96,6 @@ describe('MediaLightbox', () => {
       id: '3'
     }
   ]
-
-  beforeEach(() => {
-    document.body.innerHTML = ''
-  })
 
   const renderGallery = (props = {}) => {
     const onUpdateActiveIndex = vi.fn()

--- a/src/components/topbar/WorkflowTab.test.ts
+++ b/src/components/topbar/WorkflowTab.test.ts
@@ -208,10 +208,6 @@ describe('WorkflowTab - workflow status indicator', () => {
 })
 
 describe('WorkflowTab - close button', () => {
-  beforeEach(() => {
-    mockCloseWorkflow.mockClear()
-  })
-
   it('delegates close to workflow service with the tab workflow', async () => {
     renderTab()
     const user = userEvent.setup()

--- a/src/components/topbar/WorkflowTabs.test.ts
+++ b/src/components/topbar/WorkflowTabs.test.ts
@@ -141,7 +141,6 @@ describe('WorkflowTabs feedback button', () => {
     distribution.isDesktop = false
     distribution.isNightly = false
     tabBarLayout.value = 'Default'
-    openFeedbackDialog.mockReset()
   })
 
   it('opens the feedback dialog tagged with topbar source when clicked', async () => {

--- a/src/components/ui/__mocks__/Popover.vue
+++ b/src/components/ui/__mocks__/Popover.vue
@@ -1,0 +1,10 @@
+<script setup lang="ts">
+import { popoverCloseSpy } from './popoverMockState'
+</script>
+
+<template>
+  <div>
+    <slot name="button" />
+    <slot :close="popoverCloseSpy" />
+  </div>
+</template>

--- a/src/components/ui/__mocks__/popoverMockState.ts
+++ b/src/components/ui/__mocks__/popoverMockState.ts
@@ -1,0 +1,3 @@
+import { vi } from 'vitest'
+
+export const popoverCloseSpy = vi.fn()

--- a/src/components/ui/select/__mocks__/Select.vue
+++ b/src/components/ui/select/__mocks__/Select.vue
@@ -1,0 +1,14 @@
+<script setup lang="ts">
+import { provide } from 'vue'
+
+const modelValue = defineModel<string>()
+
+provide('selectModelValue', () => modelValue.value)
+provide('selectUpdate', (value: string) => {
+  modelValue.value = value
+})
+</script>
+
+<template>
+  <div><slot /></div>
+</template>

--- a/src/components/ui/select/__mocks__/SelectContent.vue
+++ b/src/components/ui/select/__mocks__/SelectContent.vue
@@ -1,0 +1,23 @@
+<script setup lang="ts">
+import { inject, onMounted, ref } from 'vue'
+
+const selectModelValue = inject<() => string | undefined>('selectModelValue')
+const selectUpdate = inject<(value: string) => void>('selectUpdate')
+const element = ref<HTMLSelectElement | null>(null)
+
+onMounted(() => {
+  if (element.value) element.value.value = selectModelValue?.() ?? ''
+})
+
+const onChange = (event: Event) => {
+  if (event.target instanceof HTMLSelectElement) {
+    selectUpdate?.(event.target.value)
+  }
+}
+</script>
+
+<template>
+  <select ref="element" @change="onChange">
+    <slot />
+  </select>
+</template>

--- a/src/components/ui/select/__mocks__/SelectItem.vue
+++ b/src/components/ui/select/__mocks__/SelectItem.vue
@@ -1,0 +1,9 @@
+<script setup lang="ts">
+defineProps<{
+  value: string
+}>()
+</script>
+
+<template>
+  <option :value><slot /></option>
+</template>

--- a/src/components/ui/select/__mocks__/SelectTrigger.vue
+++ b/src/components/ui/select/__mocks__/SelectTrigger.vue
@@ -1,0 +1,3 @@
+<template>
+  <span />
+</template>

--- a/src/components/ui/select/__mocks__/SelectValue.vue
+++ b/src/components/ui/select/__mocks__/SelectValue.vue
@@ -1,0 +1,3 @@
+<template>
+  <span />
+</template>

--- a/src/components/ui/slider/__mocks__/Slider.vue
+++ b/src/components/ui/slider/__mocks__/Slider.vue
@@ -1,0 +1,30 @@
+<script setup lang="ts">
+const { modelValue, min, max, step } = defineProps<{
+  modelValue: number | number[]
+  min?: number
+  max?: number
+  step?: number
+}>()
+
+const emit = defineEmits<{
+  'update:modelValue': [value: number[]]
+}>()
+
+const onInput = (event: Event) => {
+  if (event.target instanceof HTMLInputElement) {
+    emit('update:modelValue', [Number(event.target.value)])
+  }
+}
+</script>
+
+<template>
+  <input
+    type="range"
+    role="slider"
+    :value="Array.isArray(modelValue) ? modelValue[0] : modelValue"
+    :min
+    :max
+    :step
+    @input="onInput"
+  />
+</template>

--- a/src/components/videoEdit/WidgetVideoEdit.test.ts
+++ b/src/components/videoEdit/WidgetVideoEdit.test.ts
@@ -146,8 +146,6 @@ describe('WidgetVideoEdit', () => {
     recorded.props = undefined
     mocks.resolvedSource = undefined
     mocks.filmstripError.value = null
-    mocks.filmstripRetry.mockClear()
-    mocks.getNodeByLocatorId.mockReset()
   })
 
   it('resolves the source from the host node when no locator is present', () => {

--- a/src/composables/auth/useAuthActions.test.ts
+++ b/src/composables/auth/useAuthActions.test.ts
@@ -1,5 +1,4 @@
 import { FirebaseError } from 'firebase/app'
-import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { useAuthActions } from '@/composables/auth/useAuthActions'
@@ -137,7 +136,6 @@ beforeEach(() => {
 
 describe('useAuthActions.purchaseCreditsDirect', () => {
   beforeEach(() => {
-    setActivePinia(createPinia())
     mockBillingState.canAccessSubscriptionFeatures = true
   })
 
@@ -181,7 +179,6 @@ describe('useAuthActions.purchaseCreditsDirect', () => {
 
 describe('useAuthActions.logout', () => {
   beforeEach(() => {
-    setActivePinia(createPinia())
     mockDistributionState.isCloud = true
     mockWorkflowStore.modifiedWorkflows = []
   })
@@ -339,7 +336,6 @@ describe('useAuthActions.logout', () => {
 
 describe('useAuthActions auth flow error telemetry', () => {
   beforeEach(() => {
-    setActivePinia(createPinia())
     mockWorkflowStore.modifiedWorkflows = []
   })
 
@@ -416,10 +412,6 @@ describe('useAuthActions auth flow error telemetry', () => {
 })
 
 describe('useAuthActions.reportError', () => {
-  beforeEach(() => {
-    setActivePinia(createPinia())
-  })
-
   it('shows the friendly message for a known Firebase auth code', () => {
     const { reportError } = useAuthActions()
 

--- a/src/composables/billing/useBillingContext.test.ts
+++ b/src/composables/billing/useBillingContext.test.ts
@@ -1,4 +1,3 @@
-import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
 
@@ -173,7 +172,6 @@ vi.mock('@/platform/workspace/api/workspaceApi', () => ({
 
 describe('useBillingContext', () => {
   beforeEach(() => {
-    setActivePinia(createPinia())
     mockIsPersonal.value = true
     mockBillingRail.value = undefined
     mockSetWorkspaceBillingRail.mockImplementation(

--- a/src/composables/billing/useLegacyBilling.test.ts
+++ b/src/composables/billing/useLegacyBilling.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import { useLegacyBilling } from './useLegacyBilling'
 
@@ -31,10 +31,6 @@ vi.mock('@/stores/authStore', () => ({
 }))
 
 describe('useLegacyBilling', () => {
-  beforeEach(() => {
-    vi.clearAllMocks()
-  })
-
   describe('resubscribe', () => {
     it('performs the checkout via the unwrapped subscribeDirect', async () => {
       mockSubscribeDirect.mockResolvedValue(undefined)

--- a/src/composables/boundingBoxes/useBoundingBoxes.test.ts
+++ b/src/composables/boundingBoxes/useBoundingBoxes.test.ts
@@ -1,5 +1,4 @@
 import { render } from '@testing-library/vue'
-import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { Ref, ShallowRef } from 'vue'
 import { defineComponent, h, nextTick, ref, shallowRef } from 'vue'
@@ -175,7 +174,6 @@ function makeConnectedNode(): MockNode {
 }
 
 beforeEach(() => {
-  setActivePinia(createPinia())
   appState.node = makeNode()
   outputState.outputs = undefined
   if (outputState.nodeOutputs) outputState.nodeOutputs.value = {}

--- a/src/composables/canvas/useSelectedLiteGraphItems.test.ts
+++ b/src/composables/canvas/useSelectedLiteGraphItems.test.ts
@@ -1,4 +1,3 @@
-import { createPinia, setActivePinia } from 'pinia'
 import { markRaw } from 'vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -101,7 +100,6 @@ describe('useSelectedLiteGraphItems', () => {
   let mockCanvas: { selectedItems: Set<Positionable> }
 
   beforeEach(() => {
-    setActivePinia(createPinia())
     canvasStore = useCanvasStore()
     mockApp.canvas.selected_nodes = null
 

--- a/src/composables/canvas/useSelectionToolboxPosition.test.ts
+++ b/src/composables/canvas/useSelectionToolboxPosition.test.ts
@@ -1,5 +1,4 @@
 import { render } from '@testing-library/vue'
-import { createPinia, setActivePinia } from 'pinia'
 import { defineComponent, h, markRaw, ref } from 'vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -30,7 +29,6 @@ describe('useSelectionToolboxPosition', () => {
   let canvasStore: ReturnType<typeof useCanvasStore>
 
   beforeEach(() => {
-    setActivePinia(createPinia())
     canvasStore = useCanvasStore()
   })
 

--- a/src/composables/graph/useArrangeSession.test.ts
+++ b/src/composables/graph/useArrangeSession.test.ts
@@ -20,7 +20,6 @@ describe('useArrangeSession', () => {
   let nextHandle: number
 
   beforeEach(() => {
-    mockArrangeNodes.mockReset()
     frameCallbacks = []
     nextHandle = 1
     vi.spyOn(globalThis, 'requestAnimationFrame').mockImplementation(

--- a/src/composables/graph/useGroupMenuOptions.test.ts
+++ b/src/composables/graph/useGroupMenuOptions.test.ts
@@ -1,8 +1,7 @@
 import { render } from '@testing-library/vue'
-import { createPinia, setActivePinia } from 'pinia'
 import { defineComponent } from 'vue'
 import { createI18n } from 'vue-i18n'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import { useGroupMenuOptions } from '@/composables/graph/useGroupMenuOptions'
 import { LGraphCanvas, LGraphGroup } from '@/lib/litegraph/src/litegraph'
@@ -23,10 +22,6 @@ const i18n = createI18n({
 })
 
 describe('useGroupMenuOptions.getGroupColorOptions', () => {
-  beforeEach(() => {
-    setActivePinia(createPinia())
-  })
-
   it('applies the same colour as the circle-swatch picker (LGraphCanvas.node_colors groupcolor)', () => {
     const group = new LGraphGroup('Test Group')
     const canvasStore = useCanvasStore()

--- a/src/composables/graph/useNodeMenuOptions.test.ts
+++ b/src/composables/graph/useNodeMenuOptions.test.ts
@@ -1,8 +1,7 @@
 import { render } from '@testing-library/vue'
-import { createPinia, setActivePinia } from 'pinia'
 import { defineComponent } from 'vue'
 import { createI18n } from 'vue-i18n'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import { useNodeMenuOptions } from '@/composables/graph/useNodeMenuOptions'
 import type { Positionable } from '@/lib/litegraph/src/litegraph'
@@ -70,10 +69,6 @@ const getBypassLabel = (selected: LGraphNode[]): string => {
 }
 
 describe('useNodeMenuOptions.getBypassOption', () => {
-  beforeEach(() => {
-    setActivePinia(createPinia())
-  })
-
   it('labels as "Bypass" when no node is bypassed', () => {
     expect(getBypassLabel([nodeWithMode(LGraphEventMode.ALWAYS, 1)])).toBe(
       'contextMenu.Bypass'

--- a/src/composables/maskeditor/useKeyboard.test.ts
+++ b/src/composables/maskeditor/useKeyboard.test.ts
@@ -44,7 +44,6 @@ describe('useKeyboard', () => {
   let keyboard: ReturnType<typeof useKeyboard>
 
   beforeEach(() => {
-    document.body.innerHTML = ''
     keyboard = useKeyboard()
     keyboard.addListeners()
   })

--- a/src/composables/queue/useResultGallery.test.ts
+++ b/src/composables/queue/useResultGallery.test.ts
@@ -1,5 +1,4 @@
-import { createPinia, setActivePinia } from 'pinia'
-import { beforeEach, describe, expect, it } from 'vitest'
+import { describe, expect, it } from 'vitest'
 
 import { useResultGallery } from '@/composables/queue/useResultGallery'
 import type { JobListItem as JobListViewItem } from '@/composables/queue/useJobList'
@@ -59,10 +58,6 @@ const createJobViewItem = (
   }) as JobListViewItem
 
 describe('useResultGallery', () => {
-  beforeEach(() => {
-    setActivePinia(createPinia())
-  })
-
   it('collects only previewable outputs and preserves their order', async () => {
     const previewable = [createResultItem('p-1'), createResultItem('p-2')]
     const nonPreviewable = createResultItem('skip-me', false)

--- a/src/composables/useCopy.test.ts
+++ b/src/composables/useCopy.test.ts
@@ -67,7 +67,6 @@ function readSerializedClipboardMetadata(dataTransfer: DataTransfer): string {
 describe('useCopy', () => {
   beforeEach(() => {
     copyMocks.copyHandler = undefined
-    copyMocks.canvas.copyToClipboard.mockReset()
   })
 
   it('should write large serialized node data to clipboard metadata', () => {

--- a/src/composables/useCoreCommands.test.ts
+++ b/src/composables/useCoreCommands.test.ts
@@ -1,4 +1,3 @@
-import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { ref } from 'vue'
 
@@ -306,9 +305,6 @@ describe('useCoreCommands', () => {
     vi.mocked(app.refreshComboInNodes).mockResolvedValue(undefined)
     mockModelStoreRefresh.mockResolvedValue(undefined)
     mockMissingModelStoreRefresh.mockResolvedValue(undefined)
-
-    // Set up Pinia
-    setActivePinia(createPinia())
 
     // Reset app state
     app.canvas.subgraph = undefined

--- a/src/composables/useCoreCommands.test.ts
+++ b/src/composables/useCoreCommands.test.ts
@@ -389,9 +389,6 @@ describe('useCoreCommands', () => {
 
     beforeEach(() => {
       app.canvas.selectedItems = new Set()
-      vi.mocked(app.canvas.copyToClipboard).mockClear()
-      vi.mocked(app.canvas.pasteFromClipboard).mockClear()
-      vi.mocked(app.canvas.selectItems).mockClear()
     })
 
     it('should copy selected items when selection exists', async () => {

--- a/src/composables/useCurveEditor.test.ts
+++ b/src/composables/useCurveEditor.test.ts
@@ -107,7 +107,6 @@ describe('useCurveEditor', () => {
 
   afterEach(() => {
     harness?.unmount()
-    document.body.innerHTML = ''
   })
 
   describe('curvePath', () => {

--- a/src/composables/useCurveEditor.test.ts
+++ b/src/composables/useCurveEditor.test.ts
@@ -103,7 +103,6 @@ describe('useCurveEditor', () => {
   beforeEach(() => {
     ensureMatrixTransformPolyfill()
     harness = undefined
-    mockCreateInterpolator.mockClear()
   })
 
   afterEach(() => {

--- a/src/composables/useDismissableOverlay.test.ts
+++ b/src/composables/useDismissableOverlay.test.ts
@@ -45,7 +45,6 @@ describe('useDismissableOverlay', () => {
   afterEach(() => {
     scope?.stop()
     scope = undefined
-    document.body.innerHTML = ''
   })
 
   it('dismisses on outside pointerdown', () => {

--- a/src/composables/useNewMenuItemIndicator.test.ts
+++ b/src/composables/useNewMenuItemIndicator.test.ts
@@ -1,4 +1,3 @@
-import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { useNewMenuItemIndicator } from '@/composables/useNewMenuItemIndicator'
@@ -26,7 +25,6 @@ function createItems(...ids: string[]): WorkflowMenuItem[] {
 
 describe('useNewMenuItemIndicator', () => {
   beforeEach(() => {
-    setActivePinia(createPinia())
     mockSettingStore.get.mockReturnValue([])
   })
 

--- a/src/composables/useNodeHelpContent.test.ts
+++ b/src/composables/useNodeHelpContent.test.ts
@@ -70,7 +70,6 @@ describe('useNodeHelpContent', () => {
   const mockFetch = vi.fn()
 
   beforeEach(() => {
-    mockFetch.mockReset()
     vi.stubGlobal('fetch', mockFetch)
   })
 

--- a/src/composables/usePopoverSizing.test.ts
+++ b/src/composables/usePopoverSizing.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it } from 'vitest'
 import { effectScope } from 'vue'
 import type { EffectScope } from 'vue'
 
@@ -22,14 +22,9 @@ describe('usePrimeVueOverlayChildStyle', () => {
     return composable
   }
 
-  beforeEach(() => {
-    document.body.innerHTML = ''
-  })
-
   afterEach(() => {
     scope?.stop()
     scope = undefined
-    document.body.innerHTML = ''
   })
 
   it('preserves existing stacking when there is no PrimeVue parent overlay', () => {

--- a/src/composables/useRangeEditor.test.ts
+++ b/src/composables/useRangeEditor.test.ts
@@ -115,7 +115,6 @@ describe('useRangeEditor', () => {
 
   afterEach(() => {
     harness?.unmount()
-    document.body.innerHTML = ''
   })
 
   it('does nothing when trackRef is null', () => {

--- a/src/composables/useRunButtonTelemetry.test.ts
+++ b/src/composables/useRunButtonTelemetry.test.ts
@@ -45,7 +45,6 @@ import {
 
 describe('useRunButtonTelemetry', () => {
   beforeEach(() => {
-    state.telemetry.trackRunButton.mockClear()
     state.mode.value = 'graph'
     state.isAppMode.value = false
     state.executionContextError = null

--- a/src/composables/useTemplateFiltering.test.ts
+++ b/src/composables/useTemplateFiltering.test.ts
@@ -1,4 +1,3 @@
-import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick, ref } from 'vue'
 
@@ -64,7 +63,6 @@ vi.mock('@/platform/telemetry/searchQuery/useSearchQueryTracking', () => ({
 
 describe('useTemplateFiltering', () => {
   beforeEach(() => {
-    setActivePinia(createPinia())
     vi.stubGlobal('__DISTRIBUTION__', 'localhost')
     mockSystemStatsStore.systemStats.system.os = 'linux'
   })

--- a/src/composables/useViewErrorsInGraph.test.ts
+++ b/src/composables/useViewErrorsInGraph.test.ts
@@ -1,4 +1,3 @@
-import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
@@ -59,7 +58,6 @@ function createSelectedCanvas() {
 
 describe('useViewErrorsInGraph', () => {
   beforeEach(() => {
-    setActivePinia(createPinia())
     apiMock.getSettings.mockResolvedValue({})
     apiMock.storeSetting.mockResolvedValue(undefined)
     apiMock.storeSettings.mockResolvedValue(undefined)

--- a/src/composables/useWorkflowActionsMenu.test.ts
+++ b/src/composables/useWorkflowActionsMenu.test.ts
@@ -1,4 +1,3 @@
-import { createPinia, setActivePinia } from 'pinia'
 import { ref } from 'vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -112,7 +111,6 @@ function findItem(items: MenuItems, label: string): WorkflowMenuAction {
 
 describe('useWorkflowActionsMenu', () => {
   beforeEach(() => {
-    setActivePinia(createPinia())
     mockBookmarkStore.isBookmarked.mockReturnValue(false)
     mockSubgraphStore.isSubgraphBlueprint.mockReturnValue(false)
     mockMenuItemStore.hasSeenLinear = false

--- a/src/core/graph/subgraph/promotionUtils.test.ts
+++ b/src/core/graph/subgraph/promotionUtils.test.ts
@@ -1,5 +1,5 @@
 import { fromPartial } from '@total-typescript/shoehorn'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import { promotedInputWidget } from '@/core/graph/subgraph/promotedInputWidget'
 import { LGraphNode } from '@/lib/litegraph/src/litegraph'
@@ -294,10 +294,6 @@ describe('getPromotableWidgets', () => {
 })
 
 describe('promoteRecommendedWidgets', () => {
-  beforeEach(() => {
-    updatePreviewsMock.mockReset()
-  })
-
   it('promotes recommended value widgets through linked subgraph inputs', () => {
     const subgraph = createTestSubgraph()
     const subgraphNode = createTestSubgraphNode(subgraph)
@@ -406,10 +402,6 @@ describe('promoteRecommendedWidgets', () => {
 })
 
 describe('autoExposeKnownPreviewNodes', () => {
-  beforeEach(() => {
-    updatePreviewsMock.mockReset()
-  })
-
   it('auto-exposes previews when host has no persisted previewExposures property', () => {
     const subgraph = createTestSubgraph()
     const subgraphNode = createTestSubgraphNode(subgraph)

--- a/src/extensions/core/cloudFeedbackTopbarButton.test.ts
+++ b/src/extensions/core/cloudFeedbackTopbarButton.test.ts
@@ -30,8 +30,6 @@ vi.mock('@/platform/support/feedbackDialog', () => ({
 describe('cloudFeedbackTopbarButton', () => {
   beforeEach(() => {
     vi.resetModules()
-    registerExtension.mockReset()
-    openFeedbackDialog.mockReset()
   })
 
   function getRegisteredButtons(): ActionBarButton[] {

--- a/src/extensions/core/load3d/Load3DConfiguration.test.ts
+++ b/src/extensions/core/load3d/Load3DConfiguration.test.ts
@@ -357,10 +357,6 @@ describe('parseAnnotatedFilename', () => {
 })
 
 describe('Load3DConfiguration.loadSceneConfig', () => {
-  beforeEach(() => {
-    settingsGetMock.mockReset()
-  })
-
   it('returns the persisted Scene Config when present, ignoring settings', () => {
     const stored: SceneConfig = {
       showGrid: false,
@@ -394,10 +390,6 @@ describe('Load3DConfiguration.loadSceneConfig', () => {
 })
 
 describe('Load3DConfiguration.loadCameraConfig', () => {
-  beforeEach(() => {
-    settingsGetMock.mockReset()
-  })
-
   it('returns the persisted Camera Config when present', () => {
     const stored: CameraConfig = {
       cameraType: 'orthographic',
@@ -423,10 +415,6 @@ describe('Load3DConfiguration.loadCameraConfig', () => {
 })
 
 describe('Load3DConfiguration.loadLightConfig', () => {
-  beforeEach(() => {
-    settingsGetMock.mockReset()
-  })
-
   it('falls back to settings with default hdri when nothing is persisted', () => {
     stubSettings({ 'Comfy.Load3D.LightIntensity': 4 })
 
@@ -511,7 +499,6 @@ describe('Load3DConfiguration.configure forwards persisted + settings to load3d'
   }
 
   beforeEach(() => {
-    settingsGetMock.mockReset()
     load3d = makeLoad3dMock()
     vi.mocked(Load3dUtils.splitFilePath).mockReturnValue(['', 'model.glb'])
     vi.mocked(Load3dUtils.getResourceURL).mockReturnValue('/view')

--- a/src/extensions/core/load3d/Load3d.test.ts
+++ b/src/extensions/core/load3d/Load3d.test.ts
@@ -1145,14 +1145,6 @@ describe('Load3d', () => {
   })
 
   describe('exportModel', () => {
-    beforeEach(() => {
-      cloneSkinnedMock.mockReset()
-      exportGLBMock.mockReset()
-      exportOBJMock.mockReset()
-      exportSTLMock.mockReset()
-      exportFBXMock.mockReset()
-    })
-
     function setupForExport(overrides: {
       currentModel: THREE.Object3D | null
       originalModel?: THREE.Object3D | null

--- a/src/extensions/core/load3d/ModelAdapter.test.ts
+++ b/src/extensions/core/load3d/ModelAdapter.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import { api } from '@/scripts/api'
 
@@ -28,10 +28,6 @@ describe('DEFAULT_MODEL_CAPABILITIES', () => {
 
 describe('fetchModelData', () => {
   const mockFetchApi = vi.mocked(api.fetchApi)
-
-  beforeEach(() => {
-    mockFetchApi.mockReset()
-  })
 
   it('returns the arrayBuffer on a successful response', async () => {
     const buf = new ArrayBuffer(8)

--- a/src/extensions/core/load3d/PointCloudModelAdapter.test.ts
+++ b/src/extensions/core/load3d/PointCloudModelAdapter.test.ts
@@ -64,10 +64,6 @@ function makeContext(
 }
 
 describe('PointCloudModelAdapter', () => {
-  beforeEach(() => {
-    mockSettingGet.mockReset()
-  })
-
   describe('identity', () => {
     it('handles the ply extension', () => {
       const adapter = new PointCloudModelAdapter()

--- a/src/extensions/core/load3d/SplatModelAdapter.test.ts
+++ b/src/extensions/core/load3d/SplatModelAdapter.test.ts
@@ -50,10 +50,6 @@ function makeContext(): ModelLoadContext {
 
 describe('SplatModelAdapter', () => {
   beforeEach(() => {
-    splatMeshSpies.ctor.mockClear()
-    splatMeshSpies.dispose.mockClear()
-    splatMeshSpies.getBoundingBox.mockClear()
-    splatMeshSpies.updateWorldMatrix.mockClear()
     vi.spyOn(ModelAdapterModule, 'fetchModelData').mockResolvedValue(
       new ArrayBuffer(8)
     )

--- a/src/lib/litegraph/src/LGraphNode.namedValuesShadowDiff.test.ts
+++ b/src/lib/litegraph/src/LGraphNode.namedValuesShadowDiff.test.ts
@@ -49,8 +49,6 @@ describe('LGraphNode configure named values shadow diff', () => {
   let node: LGraphNode
 
   beforeEach(() => {
-    trackNamedValuesShadowDiffMismatch.mockClear()
-    trackNamedValuesShadowDiffSummary.mockClear()
     node = new LGraphNode('TestNode')
     node.addWidget('number', 'steps', 0, null, {})
     node.addWidget('number', 'seed', 0, null, {})

--- a/src/lib/litegraph/src/utils/namedValuesShadowDiffTelemetry.test.ts
+++ b/src/lib/litegraph/src/utils/namedValuesShadowDiffTelemetry.test.ts
@@ -33,8 +33,6 @@ function fakeNode(className: string, hooks: NodeHooks = {}): LGraphNode {
 
 describe('reportNamedValuesShadowDiff', () => {
   beforeEach(() => {
-    trackNamedValuesShadowDiffMismatch.mockClear()
-    trackNamedValuesShadowDiffSummary.mockClear()
     getCnrIdFromNode.mockReset().mockReturnValue(undefined)
   })
 
@@ -97,8 +95,6 @@ describe('reportNamedValuesShadowDiff', () => {
 
 describe('named values shadow diff load aggregation', () => {
   beforeEach(() => {
-    trackNamedValuesShadowDiffMismatch.mockClear()
-    trackNamedValuesShadowDiffSummary.mockClear()
     getCnrIdFromNode.mockReset().mockReturnValue(undefined)
   })
 

--- a/src/platform/assets/components/ActiveMediaAssetCard.test.ts
+++ b/src/platform/assets/components/ActiveMediaAssetCard.test.ts
@@ -77,8 +77,6 @@ describe('ActiveJobCard', () => {
   beforeEach(() => {
     mockCanCancelJob.value = false
     mockCanDeleteJob.value = false
-    mockRunCancelJob.mockReset()
-    mockRunDeleteJob.mockReset()
   })
 
   it('displays percentage and progress bar when job is running', () => {

--- a/src/platform/assets/components/AssetCard.test.ts
+++ b/src/platform/assets/components/AssetCard.test.ts
@@ -1,7 +1,6 @@
 import { fromPartial } from '@total-typescript/shoehorn'
 
 import { render, screen } from '@testing-library/vue'
-import { createPinia, setActivePinia } from 'pinia'
 import { describe, expect, it, vi } from 'vitest'
 import { createI18n } from 'vue-i18n'
 
@@ -67,7 +66,6 @@ function createDisplayAsset(
 }
 
 function renderCard(asset: AssetDisplayItem) {
-  setActivePinia(createPinia())
   const i18n = createI18n({
     legacy: false,
     locale: 'en',

--- a/src/platform/assets/components/MediaAssetContextMenu.test.ts
+++ b/src/platform/assets/components/MediaAssetContextMenu.test.ts
@@ -143,7 +143,6 @@ async function showMenu(container: Element): Promise<HTMLElement> {
 afterEach(() => {
   capturedRef = null
   capturedMenu.model = []
-  document.body.innerHTML = ''
 })
 
 type MenuItemWithCommand = MenuItem & {

--- a/src/platform/assets/composables/useAssetBrowser.perf.test.ts
+++ b/src/platform/assets/composables/useAssetBrowser.perf.test.ts
@@ -1,5 +1,4 @@
-import { createPinia, setActivePinia } from 'pinia'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { nextTick, ref } from 'vue'
 
 import { useAssetBrowser } from '@/platform/assets/composables/useAssetBrowser'
@@ -38,10 +37,6 @@ function makeAsset(index: number): AssetItem {
 }
 
 describe('useAssetBrowser - filter tab switching perf (FE-229)', () => {
-  beforeEach(() => {
-    setActivePinia(createPinia())
-  })
-
   it('does not re-transform every asset on each filter tab switch', async () => {
     const assets = Array.from({ length: ASSET_COUNT }, (_, i) => makeAsset(i))
     const filenameSpy = vi.spyOn(assetMetadataUtils, 'getAssetFilename')

--- a/src/platform/assets/composables/useAssetBrowser.test.ts
+++ b/src/platform/assets/composables/useAssetBrowser.test.ts
@@ -1,4 +1,3 @@
-import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick, ref } from 'vue'
 
@@ -38,7 +37,6 @@ vi.mock('@/composables/useFeatureFlags', () => ({
 
 describe('useAssetBrowser', () => {
   beforeEach(() => {
-    setActivePinia(createPinia())
     mockSupportsModelTypeTags.value = false
   })
 

--- a/src/platform/assets/composables/useAssetSelection.property.test.ts
+++ b/src/platform/assets/composables/useAssetSelection.property.test.ts
@@ -41,7 +41,6 @@ function arbAssets(minLength = 1, maxLength = 20): fc.Arbitrary<AssetItem[]> {
 
 describe('useAssetSelection properties', () => {
   beforeEach(() => {
-    setActivePinia(createPinia())
     mockShiftKey.value = false
     mockCtrlKey.value = false
     mockMetaKey.value = false

--- a/src/platform/assets/composables/useAssetSelection.test.ts
+++ b/src/platform/assets/composables/useAssetSelection.test.ts
@@ -1,6 +1,5 @@
 import { fromPartial } from '@total-typescript/shoehorn'
 
-import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { ref } from 'vue'
 
@@ -44,7 +43,6 @@ function createMockAssets(count: number): AssetItem[] {
 
 describe('useAssetSelection', () => {
   beforeEach(() => {
-    setActivePinia(createPinia())
     mockShiftKey.value = false
     mockCtrlKey.value = false
     mockMetaKey.value = false

--- a/src/platform/assets/composables/useAssetSelectionStore.test.ts
+++ b/src/platform/assets/composables/useAssetSelectionStore.test.ts
@@ -1,13 +1,8 @@
-import { createPinia, setActivePinia } from 'pinia'
-import { beforeEach, describe, expect, it } from 'vitest'
+import { describe, expect, it } from 'vitest'
 
 import { useAssetSelectionStore } from './useAssetSelectionStore'
 
 describe('useAssetSelectionStore', () => {
-  beforeEach(() => {
-    setActivePinia(createPinia())
-  })
-
   describe('addToSelection', () => {
     it('adds an asset ID to the selection', () => {
       const store = useAssetSelectionStore()

--- a/src/platform/assets/composables/useMediaAssetActions.test.ts
+++ b/src/platform/assets/composables/useMediaAssetActions.test.ts
@@ -300,11 +300,8 @@ describe('useMediaAssetActions', () => {
     mockIsCloud.value = false
     litegraphServiceMock.addNodeOnGraph.mockImplementation(createLoadImageNode)
     litegraphServiceMock.getCanvasCenter.mockReturnValue([100, 100])
-    mockGetOutputAssetMetadata.mockReset()
     mockGetOutputAssetMetadata.mockReturnValue(null)
-    mockGetAssetType.mockReset()
     mockGetAssetType.mockReturnValue('input')
-    mockResolveOutputAssetItems.mockReset()
     mockResolveOutputAssetItems.mockResolvedValue([])
   })
 
@@ -859,8 +856,6 @@ describe('useMediaAssetActions', () => {
   describe('downloadAssets - cloud zip filters', () => {
     beforeEach(() => {
       mockIsCloud.value = true
-      mockCreateAssetExport.mockClear()
-      mockTrackExport.mockClear()
       mockGetAssetType.mockReturnValue('output')
       mockGetOutputAssetMetadata.mockImplementation(
         (meta: Record<string, unknown> | undefined) =>
@@ -1034,7 +1029,6 @@ describe('useMediaAssetActions', () => {
   describe('downloadAssets - export toast file count', () => {
     beforeEach(() => {
       mockIsCloud.value = true
-      mockCreateAssetExport.mockClear()
       mockGetAssetType.mockReturnValue('output')
       mockGetOutputAssetMetadata.mockImplementation(
         (meta: Record<string, unknown> | undefined) =>
@@ -1124,11 +1118,6 @@ describe('useMediaAssetActions', () => {
       mockIsCloud.value = true
       mockGetAssetType.mockReturnValue('input')
       mockDeleteAsset.mockResolvedValue(undefined)
-      mockInvalidateModelsForCategory.mockClear()
-      mockSetAssetDeleting.mockClear()
-      mockUpdateHistory.mockClear()
-      mockUpdateInputs.mockClear()
-      mockHasCategory.mockClear()
       // By default, hasCategory returns true for model categories
       mockHasCategory.mockImplementation(
         (tag: string) => tag === 'checkpoints' || tag === 'loras'
@@ -1233,7 +1222,6 @@ describe('useMediaAssetActions', () => {
     beforeEach(() => {
       mockIsCloud.value = true
       mockGetAssetType.mockReturnValue('output')
-      mockShowDialog.mockReset()
     })
 
     it('should show user_metadata display names instead of hash filenames', () => {
@@ -1319,7 +1307,6 @@ describe('useMediaAssetActions', () => {
     beforeEach(() => {
       mockIsCloud.value = true
       mockGetAssetType.mockReturnValue('input')
-      mockDeleteAsset.mockReset()
       mockShowDialog.mockImplementation(
         (opts: {
           props: {

--- a/src/platform/assets/composables/useMediaAssetFiltering.test.ts
+++ b/src/platform/assets/composables/useMediaAssetFiltering.test.ts
@@ -1,7 +1,6 @@
 import { fromPartial } from '@total-typescript/shoehorn'
 
-import { createPinia, setActivePinia } from 'pinia'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { effectScope, ref } from 'vue'
 
 import { useMediaAssetFiltering } from '@/platform/assets/composables/useMediaAssetFiltering'
@@ -43,10 +42,6 @@ function ids(assets: AssetItem[]): string[] {
 }
 
 describe('useMediaAssetFiltering', () => {
-  beforeEach(() => {
-    setActivePinia(createPinia())
-  })
-
   describe('media-type filter', () => {
     it('returns all assets when no filters are selected', () => {
       const assets = ref<AssetItem[]>([

--- a/src/platform/assets/composables/useMediaAssetGalleryStore.test.ts
+++ b/src/platform/assets/composables/useMediaAssetGalleryStore.test.ts
@@ -1,6 +1,5 @@
 import { fromPartial } from '@total-typescript/shoehorn'
 
-import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { ResultItemImpl } from '@/stores/queueStore'
@@ -20,7 +19,6 @@ describe('useMediaAssetGalleryStore', () => {
         url: ''
       })
     })
-    setActivePinia(createPinia())
   })
 
   describe('openSingle', () => {

--- a/src/platform/assets/utils/markDeletedAssetsAsMissingMedia.test.ts
+++ b/src/platform/assets/utils/markDeletedAssetsAsMissingMedia.test.ts
@@ -32,7 +32,6 @@ describe('FE-230 markDeletedAssetsAsMissingMedia', () => {
   beforeEach(() => {
     setActivePinia(createPinia())
     seedMediaNodeDefs()
-    mockScanNodeMediaCandidates.mockReset()
     mockScanNodeMediaCandidates.mockReturnValue([])
   })
 

--- a/src/platform/assets/utils/markDeletedAssetsAsMissingMedia.test.ts
+++ b/src/platform/assets/utils/markDeletedAssetsAsMissingMedia.test.ts
@@ -1,4 +1,3 @@
-import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { LGraph } from '@/lib/litegraph/src/litegraph'
@@ -30,7 +29,6 @@ function makeGraph(nodes: unknown[]): LGraph {
 
 describe('FE-230 markDeletedAssetsAsMissingMedia', () => {
   beforeEach(() => {
-    setActivePinia(createPinia())
     seedMediaNodeDefs()
     mockScanNodeMediaCandidates.mockReturnValue([])
   })

--- a/src/platform/auth/session/useSessionCookie.test.ts
+++ b/src/platform/auth/session/useSessionCookie.test.ts
@@ -30,8 +30,6 @@ vi.mock('@/scripts/api', () => ({
 describe('useSessionCookie', () => {
   beforeEach(() => {
     vi.resetModules()
-    mockGetIdToken.mockReset()
-    mockGetAuthHeader.mockReset()
     mockAuthState.currentUser = { uid: 'user-a' }
     globalThis.fetch = vi.fn()
   })

--- a/src/platform/auth/unified/remintRetry.test.ts
+++ b/src/platform/auth/unified/remintRetry.test.ts
@@ -43,8 +43,6 @@ describe('fetchWithUnifiedRemint', () => {
   let mockFetch: ReturnType<typeof vi.fn>
 
   beforeEach(() => {
-    mockRemint.mockReset()
-    mockTrackUnifiedAuthRetry.mockReset()
     flagState.unifiedCloudAuthEnabled = true
     mockFetch = vi.fn()
     vi.stubGlobal('fetch', mockFetch)
@@ -292,8 +290,6 @@ describe('fetchWithUnifiedRemint', () => {
 
 describe('attachUnifiedRemintInterceptor', () => {
   beforeEach(() => {
-    mockRemint.mockReset()
-    mockTrackUnifiedAuthRetry.mockReset()
     flagState.unifiedCloudAuthEnabled = true
   })
 

--- a/src/platform/cloud/oauth/oauthState.test.ts
+++ b/src/platform/cloud/oauth/oauthState.test.ts
@@ -8,7 +8,6 @@ import {
 
 describe('oauthState', () => {
   beforeEach(() => {
-    sessionStorage.clear()
     clearOAuthRequestId()
   })
 

--- a/src/platform/cloud/oauth/useOAuthPostLoginRedirect.test.ts
+++ b/src/platform/cloud/oauth/useOAuthPostLoginRedirect.test.ts
@@ -44,7 +44,6 @@ function mountRedirect() {
 
 describe('useOAuthPostLoginRedirect', () => {
   beforeEach(() => {
-    sessionStorage.clear()
     createSessionOrThrow.mockReset().mockResolvedValue(undefined)
   })
 

--- a/src/platform/cloud/oauth/useOAuthPostLoginRedirect.test.ts
+++ b/src/platform/cloud/oauth/useOAuthPostLoginRedirect.test.ts
@@ -45,7 +45,6 @@ function mountRedirect() {
 describe('useOAuthPostLoginRedirect', () => {
   beforeEach(() => {
     sessionStorage.clear()
-    routerPush.mockClear()
     createSessionOrThrow.mockReset().mockResolvedValue(undefined)
   })
 

--- a/src/platform/cloud/onboarding/auth.test.ts
+++ b/src/platform/cloud/onboarding/auth.test.ts
@@ -1,5 +1,5 @@
 import { fromPartial } from '@total-typescript/shoehorn'
-import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { describe, expect, test, vi } from 'vitest'
 
 import { getSurveyCompletedStatus } from './auth'
 
@@ -34,10 +34,6 @@ function mockResponse({
 }
 
 describe('getSurveyCompletedStatus', () => {
-  beforeEach(() => {
-    fetchApi.mockReset()
-  })
-
   test('200 with non-empty value → true', async () => {
     fetchApi.mockResolvedValueOnce(
       mockResponse({ ok: true, status: 200, body: { value: { q1: 'a' } } })

--- a/src/platform/cloud/onboarding/desktopLoginRedemption.test.ts
+++ b/src/platform/cloud/onboarding/desktopLoginRedemption.test.ts
@@ -128,7 +128,6 @@ async function setup(
 describe('installDesktopLoginRedemption', () => {
   beforeEach(() => {
     vi.resetModules()
-    sessionStorage.clear()
     vi.stubGlobal('fetch', mockFetch)
     vi.spyOn(console, 'warn').mockImplementation(() => {})
     mockConfirm.mockResolvedValue(true)

--- a/src/platform/cloud/onboarding/desktopLoginRedemption.test.ts
+++ b/src/platform/cloud/onboarding/desktopLoginRedemption.test.ts
@@ -131,7 +131,6 @@ describe('installDesktopLoginRedemption', () => {
     sessionStorage.clear()
     vi.stubGlobal('fetch', mockFetch)
     vi.spyOn(console, 'warn').mockImplementation(() => {})
-    mockFetch.mockReset()
     mockConfirm.mockResolvedValue(true)
     mockUserGetIdToken.mockResolvedValue('firebase-id-token')
     mockAuthStore = reactive({

--- a/src/platform/cloud/subscription/components/FreeTierQuota.test.ts
+++ b/src/platform/cloud/subscription/components/FreeTierQuota.test.ts
@@ -41,7 +41,6 @@ describe('FreeTierQuota', () => {
   beforeEach(() => {
     mockIsFreeTier.value = true
     mockAvailable.value = 3
-    mockShowSubscriptionDialog.mockClear()
   })
 
   it('hides the displayed quota when the user leaves the free tier', async () => {

--- a/src/platform/cloud/subscription/components/PricingTable.test.ts
+++ b/src/platform/cloud/subscription/components/PricingTable.test.ts
@@ -245,9 +245,7 @@ describe('PricingTable', () => {
     mockSubscriptionTier.value = null
     mockSubscriptionDuration.value = 'MONTHLY'
     mockUserId.value = 'user-123'
-    mockAccessBillingPortal.mockReset()
     mockAccessBillingPortal.mockResolvedValue(true)
-    mockTrackBeginCheckout.mockReset()
     mockLocalStorage.__reset()
     vi.mocked(global.fetch).mockResolvedValue({
       ok: true,

--- a/src/platform/cloud/subscription/composables/useBillingPlans.test.ts
+++ b/src/platform/cloud/subscription/composables/useBillingPlans.test.ts
@@ -39,7 +39,6 @@ describe('useBillingPlans', () => {
 
   beforeEach(() => {
     vi.resetModules()
-    mockGetBillingPlans.mockReset()
     consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
   })
 

--- a/src/platform/cloud/subscription/composables/useSubscription.test.ts
+++ b/src/platform/cloud/subscription/composables/useSubscription.test.ts
@@ -195,11 +195,6 @@ describe('useSubscription', () => {
 
     mockLocalStorage.__reset()
     mockIsLoggedIn.value = false
-    mockTelemetry.trackSubscription.mockReset()
-    mockTelemetry.trackMonthlySubscriptionSucceeded.mockReset()
-    mockTelemetry.trackMonthlySubscriptionCancelled.mockReset()
-    mockTelemetry.trackBillingEvent.mockReset()
-    mockAccessBillingPortal.mockReset()
     mockAccessBillingPortal.mockResolvedValue(true)
     mockUserId.value = 'user-123'
     mockIsCloud.value = true

--- a/src/platform/cloud/subscription/composables/useSubscriptionCancellationWatcher.test.ts
+++ b/src/platform/cloud/subscription/composables/useSubscriptionCancellationWatcher.test.ts
@@ -47,7 +47,6 @@ describe('useSubscriptionCancellationWatcher', () => {
   }
 
   beforeEach(() => {
-    trackMonthlySubscriptionCancelled.mockReset()
     subscriptionStatus.value = { ...baseStatus }
     isActive.value = true
     shouldWatch = true

--- a/src/platform/cloud/subscription/composables/useSubscriptionDialog.test.ts
+++ b/src/platform/cloud/subscription/composables/useSubscriptionDialog.test.ts
@@ -117,12 +117,6 @@ describe('useSubscriptionDialog', () => {
     mockIsTeamPlan.value = false
     mockCurrentPlanSlug.value = null
     mockCanManageSubscription.value = true
-
-    try {
-      sessionStorage.clear()
-    } catch {
-      // noop
-    }
   })
 
   describe('showPricingTable', () => {

--- a/src/platform/keybindings/keybindingService.dialog.test.ts
+++ b/src/platform/keybindings/keybindingService.dialog.test.ts
@@ -1,4 +1,3 @@
-import { createPinia, setActivePinia } from 'pinia'
 import { markRaw, reactive } from 'vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -46,8 +45,6 @@ describe('keybindingService - dialog gate', () => {
   let mockCommandExecute: ReturnType<typeof useCommandStore>['execute']
 
   beforeEach(() => {
-    setActivePinia(createPinia())
-
     const commandStore = useCommandStore()
     mockCommandExecute = vi.fn()
     commandStore.execute = mockCommandExecute

--- a/src/platform/keybindings/keybindingService.escape.test.ts
+++ b/src/platform/keybindings/keybindingService.escape.test.ts
@@ -50,8 +50,6 @@ describe('keybindingService - Escape key handling', () => {
   let mockCommandExecute: ReturnType<typeof useCommandStore>['execute']
 
   beforeEach(() => {
-    setActivePinia(createPinia())
-
     const commandStore = useCommandStore()
     mockCommandExecute = vi.fn()
     commandStore.execute = mockCommandExecute

--- a/src/platform/missingMedia/missingMediaStore.test.ts
+++ b/src/platform/missingMedia/missingMediaStore.test.ts
@@ -1,5 +1,4 @@
-import { createPinia, setActivePinia } from 'pinia'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import { createNodeExecutionId } from '@/types/nodeIdentification'
 
@@ -39,10 +38,6 @@ function makeCandidate(
 }
 
 describe('useMissingMediaStore', () => {
-  beforeEach(() => {
-    setActivePinia(createPinia())
-  })
-
   it('starts with no missing media', () => {
     const store = useMissingMediaStore()
     expect(store.missingMediaCandidates).toBeNull()

--- a/src/platform/missingModel/components/MissingModelRow.test.ts
+++ b/src/platform/missingModel/components/MissingModelRow.test.ts
@@ -187,7 +187,6 @@ describe('MissingModelRow', () => {
     mockIsDesktop.value = false
     mockRootGraph.value = null
     mockApiListeners.clear()
-    mockGetNodeByExecutionId.mockReset()
     mockUploadContext.resolver = undefined
     mockUploadCallbacks.onUploadSuccess = undefined
     mockFetchModelMetadata.mockResolvedValue({

--- a/src/platform/missingModel/composables/useMissingModelInteractions.test.ts
+++ b/src/platform/missingModel/composables/useMissingModelInteractions.test.ts
@@ -1,4 +1,3 @@
-import { createPinia, setActivePinia } from 'pinia'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createApp } from 'vue'
 import type { App } from 'vue'
@@ -121,7 +120,6 @@ describe('useMissingModelInteractions', () => {
   }
 
   beforeEach(() => {
-    setActivePinia(createPinia())
     mockDownloadList.mockImplementation(
       (): Array<{ taskId: string; status: string }> => []
     )

--- a/src/platform/missingModel/missingModelStore.test.ts
+++ b/src/platform/missingModel/missingModelStore.test.ts
@@ -1,4 +1,3 @@
-import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { NodeExecutionId } from '@/types/nodeIdentification'
@@ -58,7 +57,6 @@ function makeModelCandidate(
 
 describe('missingModelStore', () => {
   beforeEach(() => {
-    setActivePinia(createPinia())
     mockNodeLocatorIdToNodeExecutionId.mockImplementation(
       (nodeLocatorId: string) => nodeLocatorId
     )

--- a/src/platform/navigation/preservedQueryManager.test.ts
+++ b/src/platform/navigation/preservedQueryManager.test.ts
@@ -13,7 +13,6 @@ const NAMESPACE = PRESERVED_QUERY_NAMESPACES.TEMPLATE
 
 describe('preservedQueryManager', () => {
   beforeEach(() => {
-    sessionStorage.clear()
     clearPreservedQuery(NAMESPACE)
   })
 

--- a/src/platform/navigation/preservedQueryTracker.test.ts
+++ b/src/platform/navigation/preservedQueryTracker.test.ts
@@ -40,7 +40,6 @@ function createTestRouter(
 
 describe('installPreservedQueryTracker', () => {
   beforeEach(() => {
-    sessionStorage.clear()
     clearPreservedQuery(STRIPPED_NAMESPACE)
     clearPreservedQuery(SECOND_STRIPPED_NAMESPACE)
     clearPreservedQuery(PLAIN_NAMESPACE)

--- a/src/platform/nodeReplacement/missingNodeScan.test.ts
+++ b/src/platform/nodeReplacement/missingNodeScan.test.ts
@@ -1,5 +1,4 @@
 import { fromAny, fromPartial } from '@total-typescript/shoehorn'
-import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { LGraph, LGraphNode } from '@/lib/litegraph/src/litegraph'
@@ -77,7 +76,6 @@ function getMissingNodesError(
 
 describe('scanMissingNodes (via rescanAndSurfaceMissingNodes)', () => {
   beforeEach(() => {
-    setActivePinia(createPinia())
     // Reset registered_node_types
     const reg = LiteGraph.registered_node_types as Record<string, unknown>
     for (const key of Object.keys(reg)) {

--- a/src/platform/nodeReplacement/missingNodesErrorStore.test.ts
+++ b/src/platform/nodeReplacement/missingNodesErrorStore.test.ts
@@ -1,5 +1,4 @@
-import { createPinia, setActivePinia } from 'pinia'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import type { MissingNodeType } from '@/types/comfy'
 
@@ -22,10 +21,6 @@ vi.mock('@/platform/settings/settingStore', () => ({
 import { useMissingNodesErrorStore } from './missingNodesErrorStore'
 
 describe('missingNodesErrorStore', () => {
-  beforeEach(() => {
-    setActivePinia(createPinia())
-  })
-
   describe('setMissingNodeTypes', () => {
     it('sets missingNodesError with provided types', () => {
       const store = useMissingNodesErrorStore()

--- a/src/platform/nodeReplacement/nodeReplacementStore.test.ts
+++ b/src/platform/nodeReplacement/nodeReplacementStore.test.ts
@@ -209,10 +209,6 @@ describe('useNodeReplacementStore', () => {
       ]
     }
 
-    beforeEach(() => {
-      vi.mocked(fetchNodeReplacements).mockReset()
-    })
-
     it('should fetch and assign replacements on successful load', async () => {
       vi.mocked(fetchNodeReplacements).mockResolvedValue(mockReplacements)
       store = createStore()

--- a/src/platform/nodeReplacement/useNodeReplacement.test.ts
+++ b/src/platform/nodeReplacement/useNodeReplacement.test.ts
@@ -1,6 +1,5 @@
 import { fromAny } from '@total-typescript/shoehorn'
-import { createPinia, setActivePinia } from 'pinia'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import type { LGraph, LGraphNode } from '@/lib/litegraph/src/litegraph'
 import { LiteGraph } from '@/lib/litegraph/src/litegraph'
@@ -169,10 +168,6 @@ function makeMissingNodeType(
 }
 
 describe('useNodeReplacement', () => {
-  beforeEach(() => {
-    setActivePinia(createPinia())
-  })
-
   describe('replaceNodesInPlace', () => {
     it('should return empty array when no placeholders exist', () => {
       const graph = createMockGraph([])

--- a/src/platform/onboarding/CoachmarkCard.test.ts
+++ b/src/platform/onboarding/CoachmarkCard.test.ts
@@ -1,10 +1,8 @@
-import { cleanup, render, screen } from '@testing-library/vue'
-import { afterEach, describe, expect, it } from 'vitest'
+import { render, screen } from '@testing-library/vue'
+import { describe, expect, it } from 'vitest'
 import { h } from 'vue'
 
 import CoachmarkCard from './CoachmarkCard.vue'
-
-afterEach(cleanup)
 
 describe('CoachmarkCard', () => {
   it('renders the title, message and subtitle', () => {

--- a/src/platform/onboarding/CoachmarkLanding.test.ts
+++ b/src/platform/onboarding/CoachmarkLanding.test.ts
@@ -1,6 +1,6 @@
-import { cleanup, render, screen } from '@testing-library/vue'
+import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
-import { afterEach, describe, expect, it } from 'vitest'
+import { describe, expect, it } from 'vitest'
 import { createI18n } from 'vue-i18n'
 
 import enMessages from '@/locales/en/main.json' with { type: 'json' }
@@ -27,8 +27,6 @@ function renderLanding() {
 }
 
 describe('CoachmarkLanding', () => {
-  afterEach(cleanup)
-
   it('renders a modal backdrop behind the landing card', async () => {
     renderLanding()
     expect(await screen.findByTestId('coach-landing-overlay')).toBeTruthy()

--- a/src/platform/onboarding/TourOverlay.test.ts
+++ b/src/platform/onboarding/TourOverlay.test.ts
@@ -1,7 +1,7 @@
 import { fromPartial } from '@total-typescript/shoehorn'
-import { cleanup, render, screen } from '@testing-library/vue'
+import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { defineComponent, h, reactive, ref } from 'vue'
 import { createI18n } from 'vue-i18n'
 
@@ -74,8 +74,6 @@ describe('TourOverlay', () => {
     s = makeTourState()
     vi.mocked(useOnboardingTourStore).mockReturnValue(fromPartial(reactive(s)))
   })
-
-  afterEach(cleanup)
 
   it('renders nothing when no tour step is active', () => {
     renderOverlay()

--- a/src/platform/onboarding/TourSpotlight.interactive.test.ts
+++ b/src/platform/onboarding/TourSpotlight.interactive.test.ts
@@ -60,7 +60,6 @@ describe('TourSpotlight interactive and masked steps', () => {
   afterEach(() => {
     cleanup()
     clearCoachmarks()
-    document.body.replaceChildren()
   })
 
   it('keeps the blocking scrim and no hit region on a plain step', () => {

--- a/src/platform/onboarding/TourSpotlight.interactive.test.ts
+++ b/src/platform/onboarding/TourSpotlight.interactive.test.ts
@@ -1,5 +1,5 @@
 import userEvent from '@testing-library/user-event'
-import { cleanup, render, screen } from '@testing-library/vue'
+import { render, screen } from '@testing-library/vue'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
 import type { ComponentProps } from 'vue-component-type-helpers'
@@ -58,7 +58,6 @@ function renderSpotlight(
 
 describe('TourSpotlight interactive and masked steps', () => {
   afterEach(() => {
-    cleanup()
     clearCoachmarks()
   })
 

--- a/src/platform/onboarding/TourSpotlight.test.ts
+++ b/src/platform/onboarding/TourSpotlight.test.ts
@@ -53,7 +53,6 @@ describe('TourSpotlight', () => {
   afterEach(() => {
     cleanup()
     clearCoachmarks()
-    document.body.replaceChildren()
   })
 
   it('renders the spotlight and card for a step', () => {

--- a/src/platform/onboarding/TourSpotlight.test.ts
+++ b/src/platform/onboarding/TourSpotlight.test.ts
@@ -1,4 +1,4 @@
-import { cleanup, render, screen } from '@testing-library/vue'
+import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { nextTick, ref } from 'vue'
@@ -51,7 +51,6 @@ function renderSpotlight(
 
 describe('TourSpotlight', () => {
   afterEach(() => {
-    cleanup()
     clearCoachmarks()
   })
 

--- a/src/platform/onboarding/coachmarkRegistry.test.ts
+++ b/src/platform/onboarding/coachmarkRegistry.test.ts
@@ -35,7 +35,6 @@ describe('coachmarkRegistry', () => {
 describe('targetMounted', () => {
   afterEach(() => {
     clearCoachmarks()
-    document.body.replaceChildren()
   })
 
   it('is true once a laid-out element is registered', () => {
@@ -64,7 +63,6 @@ describe('targetMounted', () => {
 describe('waitForTarget', () => {
   afterEach(() => {
     clearCoachmarks()
-    document.body.replaceChildren()
   })
 
   /** Lets the poll sample once, and the resulting promise settle. */

--- a/src/platform/onboarding/useCoachmarkTarget.test.ts
+++ b/src/platform/onboarding/useCoachmarkTarget.test.ts
@@ -20,7 +20,6 @@ function step(coachId: CoachId): SpotlightStep {
 describe('useCoachmarkTarget', () => {
   afterEach(() => {
     clearCoachmarks()
-    document.body.replaceChildren()
   })
 
   function setup(coachId: CoachId) {

--- a/src/platform/onboarding/vCoachmark.test.ts
+++ b/src/platform/onboarding/vCoachmark.test.ts
@@ -1,5 +1,5 @@
-import { cleanup, render } from '@testing-library/vue'
-import { afterEach, describe, expect, it } from 'vitest'
+import { render } from '@testing-library/vue'
+import { describe, expect, it } from 'vitest'
 import { defineComponent, h, nextTick, ref, withDirectives } from 'vue'
 
 import { coachmarkElements } from './coachmarkRegistry'
@@ -31,8 +31,6 @@ function mountHost(initial: CoachId | null) {
 }
 
 describe('vCoachmark', () => {
-  afterEach(cleanup)
-
   it('registers the element and mirrors the id to data-coach-id on mount', () => {
     const { getByTestId } = mountHost('app-run-button')
     const host = getByTestId('host')

--- a/src/platform/remote/comfyui/useQueuePolling.test.ts
+++ b/src/platform/remote/comfyui/useQueuePolling.test.ts
@@ -41,7 +41,6 @@ describe('useQueuePolling', () => {
   beforeEach(() => {
     store.activeJobsCount = 0
     store.isLoading = false
-    store.update.mockReset()
   })
 
   it('does not call update on creation', () => {

--- a/src/platform/secrets/components/SecretFormDialog.zindex.test.ts
+++ b/src/platform/secrets/components/SecretFormDialog.zindex.test.ts
@@ -1,7 +1,7 @@
 import { ZIndex } from '@primeuix/utils/zindex'
-import { cleanup, render, screen } from '@testing-library/vue'
+import { render, screen } from '@testing-library/vue'
 import PrimeVue from 'primevue/config'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { ref } from 'vue'
 import { createI18n } from 'vue-i18n'
 
@@ -59,10 +59,6 @@ const i18n = createI18n({
 })
 
 describe('SecretFormDialog z-index stacking', () => {
-  afterEach(() => {
-    cleanup()
-  })
-
   let openModalZIndex: number
 
   beforeEach(() => {

--- a/src/platform/secrets/components/SecretsPanel.test.ts
+++ b/src/platform/secrets/components/SecretsPanel.test.ts
@@ -1,6 +1,5 @@
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
-import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { ref } from 'vue'
 import { createI18n } from 'vue-i18n'
@@ -87,7 +86,6 @@ const i18n = createI18n({
 })
 
 function renderPanel() {
-  setActivePinia(createPinia())
   return render(SecretsPanel, {
     global: {
       plugins: [i18n],

--- a/src/platform/settings/components/SettingDialog.test.ts
+++ b/src/platform/settings/components/SettingDialog.test.ts
@@ -88,7 +88,6 @@ beforeEach(() => {
   searchMocks.matchedNavItemKeys = ref(new Set<string>())
   searchMocks.searchQuery = ref('')
   searchMocks.searchResultsCategories = ref(new Set<string>())
-  mockFetchBalance.mockReset()
 })
 
 it('falls back when the active navigation item becomes unavailable', async () => {

--- a/src/platform/settings/composables/useSettingSearch.test.ts
+++ b/src/platform/settings/composables/useSettingSearch.test.ts
@@ -1,4 +1,3 @@
-import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
 
@@ -35,8 +34,6 @@ describe('useSettingSearch', () => {
   let mockSettings: Record<string, MockSettingParams>
 
   beforeEach(() => {
-    setActivePinia(createPinia())
-
     // Mock settings data
     mockSettings = {
       'Category.Setting1': {

--- a/src/platform/settings/composables/useSettingsDialog.test.ts
+++ b/src/platform/settings/composables/useSettingsDialog.test.ts
@@ -37,7 +37,6 @@ import { useSettingsDialog } from '@/platform/settings/composables/useSettingsDi
 
 describe('useSettingsDialog', () => {
   beforeEach(() => {
-    showDialog.mockReset()
     isCloudRef.value = false
   })
 

--- a/src/platform/surveys/ErrorPanelSurveyCta.test.ts
+++ b/src/platform/surveys/ErrorPanelSurveyCta.test.ts
@@ -83,7 +83,6 @@ describe('ErrorPanelSurveyCta', () => {
 
   beforeEach(() => {
     vi.resetModules()
-    mockOpen.mockReset()
 
     mockIsNightly.value = true
     mockIsCloud.value = false

--- a/src/platform/surveys/openTypeformDialog.test.ts
+++ b/src/platform/surveys/openTypeformDialog.test.ts
@@ -1,5 +1,4 @@
-import { createPinia, setActivePinia } from 'pinia'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import { useDialogStore } from '@/stores/dialogStore'
 
@@ -7,10 +6,6 @@ import TypeformDialogContent from './TypeformDialogContent.vue'
 import { openTypeformDialog } from './openTypeformDialog'
 
 describe('openTypeformDialog', () => {
-  beforeEach(() => {
-    setActivePinia(createPinia())
-  })
-
   it('opens the form embed in a Reka dialog with the given id and hidden fields', () => {
     const showDialog = vi.spyOn(useDialogStore(), 'showDialog')
 

--- a/src/platform/surveys/useErrorSurveyTracking.test.ts
+++ b/src/platform/surveys/useErrorSurveyTracking.test.ts
@@ -1,4 +1,4 @@
-import { createPinia, defineStore, setActivePinia } from 'pinia'
+import { defineStore } from 'pinia'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { effectScope, nextTick, ref } from 'vue'
 
@@ -32,7 +32,6 @@ describe('useErrorSurveyTracking', () => {
   }
 
   beforeEach(() => {
-    setActivePinia(createPinia())
     store = useFakeExecutionErrorStore()
   })
 

--- a/src/platform/surveys/useErrorSurveyTracking.test.ts
+++ b/src/platform/surveys/useErrorSurveyTracking.test.ts
@@ -32,7 +32,6 @@ describe('useErrorSurveyTracking', () => {
   }
 
   beforeEach(() => {
-    trackFeatureUsed.mockReset()
     setActivePinia(createPinia())
     store = useFakeExecutionErrorStore()
   })

--- a/src/platform/surveys/useSurveyFeatureTracking.test.ts
+++ b/src/platform/surveys/useSurveyFeatureTracking.test.ts
@@ -11,7 +11,6 @@ vi.mock('./surveyRegistry', () => ({
 describe('useSurveyFeatureTracking', () => {
   beforeEach(() => {
     vi.resetModules()
-    getSurveyConfig.mockReset()
   })
 
   it('tracks usage when config is enabled', async () => {

--- a/src/platform/telemetry/nodeAdded/installNodeAddedTelemetry.test.ts
+++ b/src/platform/telemetry/nodeAdded/installNodeAddedTelemetry.test.ts
@@ -22,7 +22,6 @@ function fakeNode(type: string): LGraphNode {
 
 describe('installNodeAddedTelemetry', () => {
   beforeEach(() => {
-    trackNodeAdded.mockClear()
     ChangeTracker.isLoadingGraph = false
   })
 

--- a/src/platform/telemetry/providers/cloud/ImpactTelemetryProvider.test.ts
+++ b/src/platform/telemetry/providers/cloud/ImpactTelemetryProvider.test.ts
@@ -62,9 +62,6 @@ function toUint8Array(data: BufferSource): Uint8Array {
 
 describe('ImpactTelemetryProvider', () => {
   beforeEach(() => {
-    mockCaptureCheckoutAttributionFromSearch.mockReset()
-    mockUseApiKeyAuthStore.mockReset()
-    mockUseAuthStore.mockReset()
     mockApiKeyAuthStore.isAuthenticated = false
     mockApiKeyAuthStore.currentUser = null
     mockAuthStore.currentUser = null

--- a/src/platform/telemetry/providers/host/HostTelemetrySink.test.ts
+++ b/src/platform/telemetry/providers/host/HostTelemetrySink.test.ts
@@ -10,7 +10,6 @@ const state = vi.hoisted(() => ({
 
 describe('HostTelemetrySink', () => {
   beforeEach(() => {
-    state.capture.mockClear()
     window.__comfyDesktop2 = {
       isRemote: () => false,
       Telemetry: {

--- a/src/platform/telemetry/searchQuery/useSearchQueryTracking.test.ts
+++ b/src/platform/telemetry/searchQuery/useSearchQueryTracking.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { EffectScope, Ref } from 'vue'
 import { effectScope, ref } from 'vue'
 
@@ -29,10 +29,6 @@ describe('useSearchQueryTracking', () => {
     scopes.push(scope)
     return scope
   }
-
-  beforeEach(() => {
-    hoisted.trackSearchQuery.mockClear()
-  })
 
   afterEach(() => {
     scopes.forEach((s) => s.stop())

--- a/src/platform/telemetry/utils/__tests__/checkoutAttribution.test.ts
+++ b/src/platform/telemetry/utils/__tests__/checkoutAttribution.test.ts
@@ -15,7 +15,6 @@ describe('getCheckoutAttribution', () => {
     window.ire = undefined
     window.rewardful = undefined
     window.Rewardful = undefined
-    window.history.pushState({}, '', '/')
   })
 
   it('reads GA identity and URL attribution, and prefers generated click id', async () => {

--- a/src/platform/updates/common/useFrontendVersionMismatchWarning.test.ts
+++ b/src/platform/updates/common/useFrontendVersionMismatchWarning.test.ts
@@ -1,5 +1,4 @@
-import { createPinia, setActivePinia } from 'pinia'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
 
 import { useToastStore } from '@/platform/updates/common/toastStore'
@@ -84,10 +83,6 @@ vi.mock('vue', async () => {
 })
 
 describe('useFrontendVersionMismatchWarning', () => {
-  beforeEach(() => {
-    setActivePinia(createPinia())
-  })
-
   it('should not show warning when there is no version mismatch', () => {
     const toastStore = useToastStore()
     const versionStore = useVersionCompatibilityStore()

--- a/src/platform/workflow/core/services/workflowService.test.ts
+++ b/src/platform/workflow/core/services/workflowService.test.ts
@@ -939,7 +939,6 @@ describe('useWorkflowService', () => {
       service = useWorkflowService()
       vi.spyOn(workflowStore, 'saveWorkflow').mockResolvedValue()
       vi.spyOn(workflowStore, 'renameWorkflow').mockResolvedValue()
-      mockTrackWorkflowSaved.mockClear()
       app.rootGraph.extra = {}
     })
 

--- a/src/platform/workflow/management/stores/workflowStore.test.ts
+++ b/src/platform/workflow/management/stores/workflowStore.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { fromAny, fromPartial } from '@total-typescript/shoehorn'
 import { nextTick } from 'vue'
 
@@ -97,7 +97,6 @@ describe('useWorkflowStore', () => {
   }
 
   beforeEach(() => {
-    sessionStorage.clear()
     store = useWorkflowStore()
     bookmarkStore = useWorkflowBookmarkStore()
 
@@ -109,10 +108,6 @@ describe('useWorkflowStore', () => {
     vi.mocked(api.storeUserData).mockResolvedValue({
       status: 200
     } as Response)
-  })
-
-  afterEach(() => {
-    sessionStorage.clear()
   })
 
   describe('syncWorkflows', () => {

--- a/src/platform/workflow/persistence/base/storageIO.test.ts
+++ b/src/platform/workflow/persistence/base/storageIO.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { DraftIndexV2, DraftPayloadV2 } from './draftTypes'
 import {
@@ -21,12 +21,7 @@ import {
 
 describe('storageIO', () => {
   beforeEach(() => {
-    sessionStorage.clear()
     vi.resetModules()
-  })
-
-  afterEach(() => {
-    sessionStorage.clear()
   })
 
   describe('index operations', () => {

--- a/src/platform/workflow/persistence/base/storageKeys.test.ts
+++ b/src/platform/workflow/persistence/base/storageKeys.test.ts
@@ -3,7 +3,6 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 describe('storageKeys', () => {
   beforeEach(() => {
     vi.resetModules()
-    sessionStorage.clear()
   })
 
   describe('getWorkspaceId', () => {

--- a/src/platform/workflow/persistence/composables/useWorkflowPersistenceV2.test.ts
+++ b/src/platform/workflow/persistence/composables/useWorkflowPersistenceV2.test.ts
@@ -190,7 +190,6 @@ describe('useWorkflowPersistenceV2', () => {
     mocks.state.graphChangedHandler = null
     mocks.state.currentGraph = { initial: true }
     mocks.serializeMock.mockImplementation(() => mocks.state.currentGraph)
-    mocks.loadGraphDataMock.mockReset()
     mocks.apiMock.clientId = 'test-client'
     mocks.apiMock.initialClientId = 'test-client'
     mocks.apiMock.addEventListener.mockImplementation(
@@ -201,9 +200,6 @@ describe('useWorkflowPersistenceV2', () => {
       }
     )
     mocks.apiMock.removeEventListener.mockImplementation(() => {})
-    openWorkflowMock.mockReset()
-    loadBlankWorkflowMock.mockReset()
-    commandStoreMocks.execute.mockReset()
     routeMocks.query = {}
     preservedQueryMocks.payloads = {}
   })

--- a/src/platform/workflow/persistence/composables/useWorkflowPersistenceV2.test.ts
+++ b/src/platform/workflow/persistence/composables/useWorkflowPersistenceV2.test.ts
@@ -184,7 +184,6 @@ describe('useWorkflowPersistenceV2', () => {
   }> = []
 
   beforeEach(() => {
-    sessionStorage.clear()
     settingMocks.persistRef!.value = true
     settingMocks.values = {}
     mocks.state.graphChangedHandler = null

--- a/src/platform/workflow/persistence/composables/useWorkflowTabState.test.ts
+++ b/src/platform/workflow/persistence/composables/useWorkflowTabState.test.ts
@@ -10,7 +10,6 @@ vi.mock('@/scripts/api', () => ({
 describe('useWorkflowTabState', () => {
   beforeEach(() => {
     vi.resetModules()
-    sessionStorage.clear()
   })
 
   describe('activePath', () => {

--- a/src/platform/workflow/persistence/migration/migrateV1toV2.test.ts
+++ b/src/platform/workflow/persistence/migration/migrateV1toV2.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { hashPath } from '../base/hashUtil'
 import { readOpenPaths } from '../base/storageIO'
@@ -14,11 +14,6 @@ describe('migrateV1toV2', () => {
 
   beforeEach(() => {
     vi.resetModules()
-    sessionStorage.clear()
-  })
-
-  afterEach(() => {
-    sessionStorage.clear()
   })
 
   function setV1Data(

--- a/src/platform/workflow/persistence/stores/workflowDraftStoreV2.fsm.test.ts
+++ b/src/platform/workflow/persistence/stores/workflowDraftStoreV2.fsm.test.ts
@@ -3,7 +3,7 @@ import type { Command } from 'fast-check'
 
 import { createTestingPinia } from '@pinia/testing'
 import { setActivePinia } from 'pinia'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import { MAX_DRAFTS } from '../base/draftTypes'
 import { useWorkflowDraftStoreV2 } from './workflowDraftStoreV2'
@@ -301,14 +301,6 @@ class StoreResetCommand implements Command<PersistenceModel, PersistenceReal> {
 // ── Test Suite ──────────────────────────────────────────────────────
 
 describe('workflowDraftStoreV2 FSM', () => {
-  beforeEach(() => {
-    sessionStorage.clear()
-  })
-
-  afterEach(() => {
-    sessionStorage.clear()
-  })
-
   // 33+ unique paths to exceed MAX_DRAFTS (32) and exercise LRU eviction
   const pathPool = fc.constantFrom(
     ...Array.from({ length: 35 }, (_, i) => `workflows/${i}.json`)

--- a/src/platform/workflow/persistence/stores/workflowDraftStoreV2.test.ts
+++ b/src/platform/workflow/persistence/stores/workflowDraftStoreV2.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import { MAX_DRAFTS } from '../base/draftTypes'
 import { StorageKeys } from '../base/storageKeys'
@@ -18,14 +18,6 @@ vi.mock('@/scripts/app', () => ({
 }))
 
 describe('workflowDraftStoreV2', () => {
-  beforeEach(() => {
-    sessionStorage.clear()
-  })
-
-  afterEach(() => {
-    sessionStorage.clear()
-  })
-
   describe('saveDraft', () => {
     it('saves draft to localStorage with separate payload', () => {
       const store = useWorkflowDraftStoreV2()

--- a/src/platform/workflow/sharing/components/ShareWorkflowDialogContent.test.ts
+++ b/src/platform/workflow/sharing/components/ShareWorkflowDialogContent.test.ts
@@ -151,8 +151,6 @@ describe('ShareWorkflowDialogContent', () => {
   const onClose = vi.fn()
 
   beforeEach(() => {
-    mockPublishWorkflow.mockReset()
-    mockGetShareableAssets.mockReset()
     mockWorkflowStore.activeWorkflow = {
       path: 'workflows/test.json',
       directory: 'workflows',

--- a/src/platform/workflow/sharing/services/workflowShareService.test.ts
+++ b/src/platform/workflow/sharing/services/workflowShareService.test.ts
@@ -66,7 +66,6 @@ describe(useWorkflowShareService, () => {
 
   beforeEach(() => {
     mockApp.rootGraph = {}
-    window.history.replaceState({}, '', '/')
   })
 
   it('returns unpublished status for unknown workflow', async () => {

--- a/src/platform/workflow/sharing/utils/shareAuthAttribution.test.ts
+++ b/src/platform/workflow/sharing/utils/shareAuthAttribution.test.ts
@@ -23,7 +23,6 @@ const invalidShareQueries: Array<{ name: string; query: LocationQuery }> = [
 describe('shareAuthAttribution', () => {
   beforeEach(() => {
     clearPreservedQuery(SHARE_AUTH_NAMESPACE)
-    sessionStorage.clear()
   })
 
   it('preserves a valid share id for logged-out users', () => {

--- a/src/platform/workflow/templates/composables/useTemplateWorkflows.test.ts
+++ b/src/platform/workflow/templates/composables/useTemplateWorkflows.test.ts
@@ -70,7 +70,6 @@ describe('useTemplateWorkflows', () => {
 
   beforeEach(() => {
     mockIsCloud.value = true
-    mockTrackTemplate.mockClear()
 
     mockWorkflowTemplatesStore = {
       isLoaded: false,

--- a/src/platform/workspace/components/SubscriptionSuccessWorkspace.test.ts
+++ b/src/platform/workspace/components/SubscriptionSuccessWorkspace.test.ts
@@ -1,6 +1,6 @@
 import userEvent from '@testing-library/user-event'
-import { cleanup, render, screen } from '@testing-library/vue'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { render, screen } from '@testing-library/vue'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { PreviewSubscribeResponse } from '@/platform/workspace/api/workspaceApi'
 import SubscriptionSuccessWorkspace from './SubscriptionSuccessWorkspace.vue'
@@ -114,10 +114,6 @@ describe('SubscriptionSuccessWorkspace', () => {
     mockPendingInvites.length = 0
     mockMaxSeats.value = 73
     mockOccupiedSeats.value = 1
-  })
-
-  afterEach(() => {
-    cleanup()
   })
 
   it('renders the all-set heading and plan price', () => {

--- a/src/platform/workspace/components/dialogs/settings/MembersPanelContent.test.ts
+++ b/src/platform/workspace/components/dialogs/settings/MembersPanelContent.test.ts
@@ -1,6 +1,6 @@
-import { cleanup, render, screen, within } from '@testing-library/vue'
+import { render, screen, within } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { Slots } from 'vue'
 import { computed, h, ref } from 'vue'
 import { createI18n } from 'vue-i18n'
@@ -18,8 +18,6 @@ const mockMemberMenuItems = vi.fn(() => [])
 const mockShowTeamPlans = vi.fn()
 const mockToggleSort = vi.fn()
 const mockHandleInviteMember = vi.fn()
-
-afterEach(cleanup)
 
 const {
   mockMembers,

--- a/src/platform/workspace/composables/useAutoPageSize.test.ts
+++ b/src/platform/workspace/composables/useAutoPageSize.test.ts
@@ -65,8 +65,6 @@ function runInScope(container: Ref<HTMLElement | null>, min?: number) {
 describe('useAutoPageSize', () => {
   beforeEach(() => {
     resizeObserverState.callback = null
-    resizeObserverState.observe.mockClear()
-    resizeObserverState.disconnect.mockClear()
   })
 
   it('fits as many whole rows as the container height allows', () => {

--- a/src/platform/workspace/composables/useBillingBanner.test.ts
+++ b/src/platform/workspace/composables/useBillingBanner.test.ts
@@ -74,8 +74,6 @@ describe('useBillingBanner', () => {
     b.subscription.value = { hasFunds: true }
     mocks.billingControlEnabled!.value = true
     mocks.v1PaymentRecovery!.value = true
-    b.fetchStatus.mockClear()
-    b.fetchBalance.mockClear()
   })
 
   it('suppresses the banner entirely when billing control is rolled back', async () => {

--- a/src/platform/workspace/stores/partnerNodeGovernanceStore.test.ts
+++ b/src/platform/workspace/stores/partnerNodeGovernanceStore.test.ts
@@ -77,7 +77,6 @@ describe('partnerNodeGovernanceStore', () => {
   let store: ReturnType<typeof usePartnerNodeGovernanceStore> | undefined
 
   beforeEach(() => {
-    mockUpdatePartnerNodePolicy.mockReset()
     mockFlags.partnerNodeGovernanceEnabled = true
     mockGetPartnerProviders.mockResolvedValue(providers)
     mockGetPartnerNodePolicy.mockResolvedValue(null)

--- a/src/platform/workspace/stores/teamWorkspaceStore.test.ts
+++ b/src/platform/workspace/stores/teamWorkspaceStore.test.ts
@@ -158,7 +158,6 @@ function expectCleanupBeforeContextAndReload(): void {
 describe('useTeamWorkspaceStore', () => {
   beforeEach(() => {
     vi.stubGlobal('localStorage', mockLocalStorage)
-    sessionStorage.clear()
     mockCurrentUser.userEmail.value = null
 
     // Reset workspaceAuthStore mock state

--- a/src/platform/workspace/stores/useWorkspaceAuth.test.ts
+++ b/src/platform/workspace/stores/useWorkspaceAuth.test.ts
@@ -1,4 +1,4 @@
-import { createPinia, setActivePinia, storeToRefs } from 'pinia'
+import { storeToRefs } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
@@ -106,7 +106,6 @@ describe('useWorkspaceAuthStore', () => {
       reload: mockReload,
       origin: 'http://localhost'
     })
-    setActivePinia(createPinia())
     vi.useFakeTimers({ shouldAdvanceTime: false })
     mockUnifiedCloudAuthEnabled.value = false
     mockCurrentUser.value = { uid: 'user-a' }

--- a/src/platform/workspace/stores/useWorkspaceAuth.test.ts
+++ b/src/platform/workspace/stores/useWorkspaceAuth.test.ts
@@ -108,7 +108,6 @@ describe('useWorkspaceAuthStore', () => {
     })
     setActivePinia(createPinia())
     vi.useFakeTimers({ shouldAdvanceTime: false })
-    sessionStorage.clear()
     mockUnifiedCloudAuthEnabled.value = false
     mockCurrentUser.value = { uid: 'user-a' }
     mockEnsureSessionCookie.mockResolvedValue(undefined)

--- a/src/renderer/core/canvas/links/linkDropOrchestrator.test.ts
+++ b/src/renderer/core/canvas/links/linkDropOrchestrator.test.ts
@@ -52,7 +52,6 @@ function createAdapter() {
 
 describe('resolveSlotTargetCandidate', () => {
   beforeEach(() => {
-    document.body.innerHTML = ''
     layoutStore.initializeFromLiteGraph([])
     useSlotLinkDragUIState().clearCompatible()
   })

--- a/src/renderer/core/layout/sync/useLayoutSync.test.ts
+++ b/src/renderer/core/layout/sync/useLayoutSync.test.ts
@@ -55,10 +55,8 @@ describe('useLayoutSync', () => {
   beforeEach(() => {
     testState.listener = null
     testState.layoutByNodeId.clear()
-    testState.unsubscribe.mockReset()
     testState.rafCallback = null
     testState.microtaskCallback = null
-    testState.cancelAnimationFrame.mockReset()
 
     vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
       testState.rafCallback = cb

--- a/src/renderer/core/thumbnail/useWorkflowThumbnail.test.ts
+++ b/src/renderer/core/thumbnail/useWorkflowThumbnail.test.ts
@@ -1,4 +1,3 @@
-import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { ComfyWorkflow } from '@/platform/workflow/management/stores/workflowStore'
@@ -26,7 +25,6 @@ describe('useWorkflowThumbnail', () => {
   let workflowStore: ReturnType<typeof useWorkflowStore>
 
   beforeEach(() => {
-    setActivePinia(createPinia())
     workflowStore = useWorkflowStore()
 
     // Clear any existing thumbnails from previous tests BEFORE mocking

--- a/src/renderer/extensions/compositor/composables/compositorSave.test.ts
+++ b/src/renderer/extensions/compositor/composables/compositorSave.test.ts
@@ -69,7 +69,6 @@ function widgetValue(widget: IBaseWidget): CompositorLayerState {
 const cacheNode = { id: toNodeId(7) } as unknown as LGraphNode
 
 beforeEach(() => {
-  vi.clearAllMocks()
   clearCompositorLayers(cacheNode)
 })
 

--- a/src/renderer/extensions/compositor/composables/compositorSession.test.ts
+++ b/src/renderer/extensions/compositor/composables/compositorSession.test.ts
@@ -56,7 +56,6 @@ const fallbackName = (i: number) => `Layer ${i + 1}`
 
 describe('loadCompositorSession', () => {
   beforeEach(() => {
-    vi.clearAllMocks()
     getCompositorLayers.mockReturnValue([])
     resolveInitialLayerState.mockReturnValue(null)
   })

--- a/src/renderer/extensions/compositor/composables/useCompositorEditor.test.ts
+++ b/src/renderer/extensions/compositor/composables/useCompositorEditor.test.ts
@@ -32,7 +32,6 @@ describe('useCompositorEditor', () => {
   const node = { id: toNodeId(1) } as unknown as LGraphNode
 
   beforeEach(() => {
-    vi.clearAllMocks()
     clearCompositorLayers(node)
   })
 

--- a/src/renderer/extensions/compositor/composables/useCompositorPsdDownload.test.ts
+++ b/src/renderer/extensions/compositor/composables/useCompositorPsdDownload.test.ts
@@ -47,7 +47,6 @@ const node = { id: toNodeId(5) } as unknown as LGraphNode
 
 describe('useCompositorPsdDownload', () => {
   beforeEach(() => {
-    vi.clearAllMocks()
     loadCompositorSession.mockResolvedValue(0)
     buildSessionPsdBlob.mockResolvedValue(new Blob(['psd']))
   })

--- a/src/renderer/extensions/firstRunTour/gettingStarted/GettingStartedScreen.test.ts
+++ b/src/renderer/extensions/firstRunTour/gettingStarted/GettingStartedScreen.test.ts
@@ -1,6 +1,6 @@
 import userEvent from '@testing-library/user-event'
-import { cleanup, render, screen, waitFor } from '@testing-library/vue'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/vue'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createI18n } from 'vue-i18n'
 
 import enMessages from '@/locales/en/main.json' with { type: 'json' }
@@ -83,10 +83,6 @@ describe('GettingStartedScreen', () => {
     mocks.loadCatalog.mockResolvedValue(undefined)
     mocks.beginTour.mockResolvedValue(true)
     mocks.loadingTemplateId.value = null
-  })
-
-  afterEach(() => {
-    cleanup()
   })
 
   async function pickFirstTemplate() {

--- a/src/renderer/extensions/firstRunTour/gettingStarted/GettingStartedScreen.test.ts
+++ b/src/renderer/extensions/firstRunTour/gettingStarted/GettingStartedScreen.test.ts
@@ -87,7 +87,6 @@ describe('GettingStartedScreen', () => {
 
   afterEach(() => {
     cleanup()
-    document.body.replaceChildren()
   })
 
   async function pickFirstTemplate() {

--- a/src/renderer/extensions/firstRunTour/nudge/FirstRunTourNudge.test.ts
+++ b/src/renderer/extensions/firstRunTour/nudge/FirstRunTourNudge.test.ts
@@ -1,6 +1,6 @@
 import userEvent from '@testing-library/user-event'
-import { cleanup, render, screen } from '@testing-library/vue'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { render, screen } from '@testing-library/vue'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createI18n } from 'vue-i18n'
 
 import enMessages from '@/locales/en/main.json' with { type: 'json' }
@@ -68,10 +68,6 @@ describe('FirstRunTourNudge', () => {
     mocks.nudgeArmed.value = false
     mocks.tourWasCompleted.value = true
     mocks.openDialogs.value = []
-  })
-
-  afterEach(() => {
-    cleanup()
   })
 
   it('shows a nudge that came due before it mounted', async () => {

--- a/src/renderer/extensions/firstRunTour/roles/heuristicRoles.test.ts
+++ b/src/renderer/extensions/firstRunTour/roles/heuristicRoles.test.ts
@@ -1,5 +1,4 @@
-import { createPinia, setActivePinia } from 'pinia'
-import { beforeEach, describe, expect, it } from 'vitest'
+import { describe, expect, it } from 'vitest'
 
 import { LGraphNode } from '@/lib/litegraph/src/litegraph'
 import type { LGraph, Subgraph } from '@/lib/litegraph/src/litegraph'
@@ -101,8 +100,6 @@ function addExposedPrompt(root: LGraph, portName: string) {
 }
 
 describe('heuristicRoles', () => {
-  beforeEach(() => setActivePinia(createPinia()))
-
   it('takes the prompt wired to positive when negative comes first', () => {
     const graph = createTestRootGraph()
     addWiredSink(graph)

--- a/src/renderer/extensions/firstRunTour/roles/resolveTourRoles.test.ts
+++ b/src/renderer/extensions/firstRunTour/roles/resolveTourRoles.test.ts
@@ -1,5 +1,4 @@
-import { createPinia, setActivePinia } from 'pinia'
-import { beforeEach, describe, expect, it } from 'vitest'
+import { describe, expect, it } from 'vitest'
 
 import { LGraphNode } from '@/lib/litegraph/src/litegraph'
 import type { LGraph, Subgraph } from '@/lib/litegraph/src/litegraph'
@@ -44,8 +43,6 @@ function addHostedSubgraph(root: LGraph, parent: LGraph | Subgraph = root) {
 }
 
 describe('resolveTourRoles', () => {
-  beforeEach(() => setActivePinia(createPinia()))
-
   it('spotlights a prompt pinned inside a subgraph through its root-graph host', () => {
     const root = createTestRootGraph()
     const { subgraph, host } = addHostedSubgraph(root)

--- a/src/renderer/extensions/firstRunTour/tour/firstRunTourDefinition.test.ts
+++ b/src/renderer/extensions/firstRunTour/tour/firstRunTourDefinition.test.ts
@@ -1,5 +1,4 @@
-import { createPinia, setActivePinia } from 'pinia'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { ref } from 'vue'
 
 import { DragAndScale } from '@/lib/litegraph/src/DragAndScale'
@@ -101,10 +100,6 @@ function loadTemplate(templateId: keyof typeof TOUR_ROLE_PINS): LGraph {
 }
 
 describe('firstRunTourSteps', () => {
-  beforeEach(() => {
-    setActivePinia(createPinia())
-  })
-
   afterEach(() => {
     releaseFirstRunTargets()
     clearCoachmarks()

--- a/src/renderer/extensions/firstRunTour/tour/firstRunTourDefinition.test.ts
+++ b/src/renderer/extensions/firstRunTour/tour/firstRunTourDefinition.test.ts
@@ -103,7 +103,6 @@ function loadTemplate(templateId: keyof typeof TOUR_ROLE_PINS): LGraph {
 describe('firstRunTourSteps', () => {
   beforeEach(() => {
     setActivePinia(createPinia())
-    disposals.spy.mockClear()
   })
 
   afterEach(() => {

--- a/src/renderer/extensions/firstRunTour/tour/firstRunTourDefinition.test.ts
+++ b/src/renderer/extensions/firstRunTour/tour/firstRunTourDefinition.test.ts
@@ -103,7 +103,6 @@ describe('firstRunTourSteps', () => {
   afterEach(() => {
     releaseFirstRunTargets()
     clearCoachmarks()
-    document.body.replaceChildren()
     appState.graph = undefined
     runState.value = 'idle'
     framings.length = 0

--- a/src/renderer/extensions/firstRunTour/tour/useFirstRunTourController.test.ts
+++ b/src/renderer/extensions/firstRunTour/tour/useFirstRunTourController.test.ts
@@ -245,7 +245,6 @@ describe('useFirstRunTourController', () => {
   afterEach(() => {
     controllerScope?.stop()
     controllerScope = undefined
-    document.body.innerHTML = ''
     setViewportWidth(1280)
   })
 

--- a/src/renderer/extensions/layerEditor/components/LayerEditorContent.test.ts
+++ b/src/renderer/extensions/layerEditor/components/LayerEditorContent.test.ts
@@ -135,7 +135,6 @@ async function waitForAutoSaveStart() {
 
 describe('LayerEditorContent', () => {
   beforeEach(() => {
-    vi.clearAllMocks()
     session.canUndo.value = false
     session.loadImages.mockResolvedValue(0)
     loadCompositorSession.mockResolvedValue(0)

--- a/src/renderer/extensions/layerEditor/composables/useLayerEditor.test.ts
+++ b/src/renderer/extensions/layerEditor/composables/useLayerEditor.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
 
@@ -17,10 +17,6 @@ vi.mock('@/stores/nodeOutputStore', () => ({
 }))
 
 describe('useLayerEditor', () => {
-  beforeEach(() => {
-    vi.clearAllMocks()
-  })
-
   it('does nothing without a node', () => {
     useLayerEditor().openLayerEditor(null as unknown as LGraphNode)
     expect(showDialog).not.toHaveBeenCalled()

--- a/src/renderer/extensions/layerEditor/composables/useLayerEditorExport.test.ts
+++ b/src/renderer/extensions/layerEditor/composables/useLayerEditorExport.test.ts
@@ -54,7 +54,6 @@ function stubContext(canvas: HTMLCanvasElement): CanvasRenderingContext2D {
 const origGetContext = HTMLCanvasElement.prototype.getContext
 
 beforeEach(() => {
-  vi.clearAllMocks()
   registerBuiltinKinds()
   HTMLCanvasElement.prototype.getContext = function (
     this: HTMLCanvasElement,

--- a/src/renderer/extensions/linearMode/LinearRunErrorWarning.test.ts
+++ b/src/renderer/extensions/linearMode/LinearRunErrorWarning.test.ts
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import { createI18n } from 'vue-i18n'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import LinearRunErrorWarning from '@/renderer/extensions/linearMode/LinearRunErrorWarning.vue'
 import { LINEAR_RUN_ERROR_WARNING_DESCRIPTION_ID } from '@/renderer/extensions/linearMode/linearRunErrorWarningIds'
@@ -49,10 +49,6 @@ function renderWarning() {
 }
 
 describe('LinearRunErrorWarning', () => {
-  beforeEach(() => {
-    mocks.viewErrorsInGraph.mockReset()
-  })
-
   it('shows the current error overlay title and message without a close action', () => {
     renderWarning()
 

--- a/src/renderer/extensions/linearMode/linearOutputStore.test.ts
+++ b/src/renderer/extensions/linearMode/linearOutputStore.test.ts
@@ -1,4 +1,3 @@
-import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { ref } from 'vue'
 
@@ -104,7 +103,6 @@ function makeExecutedDetail(
 
 describe('linearOutputStore', () => {
   beforeEach(() => {
-    setActivePinia(createPinia())
     activeJobIdRef.value = null
     previewsRef.value = {}
     isAppModeRef.value = true

--- a/src/renderer/extensions/linearMode/useOutputHistory.test.ts
+++ b/src/renderer/extensions/linearMode/useOutputHistory.test.ts
@@ -1,6 +1,5 @@
 import { fromPartial } from '@total-typescript/shoehorn'
 
-import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick, ref } from 'vue'
 
@@ -152,7 +151,6 @@ function makeResult(filename: string, nodeId: string = '1'): ResultItemImpl {
 
 describe(useOutputHistory, () => {
   beforeEach(() => {
-    setActivePinia(createPinia())
     mediaRef.value = []
     pendingResolveRef.value = new Set()
     inProgressItemsRef.value = []

--- a/src/renderer/extensions/linearMode/useOutputHistory.test.ts
+++ b/src/renderer/extensions/linearMode/useOutputHistory.test.ts
@@ -165,8 +165,6 @@ describe(useOutputHistory, () => {
     pendingTasksRef.value = []
     resolvedOutputsCacheRef.clear()
     jobDetailResults.clear()
-    selectAsLatestFn.mockReset()
-    resolveIfReadyFn.mockReset()
   })
 
   describe('sessionMedia filtering', () => {

--- a/src/renderer/extensions/minimap/composables/useMinimap.test.ts
+++ b/src/renderer/extensions/minimap/composables/useMinimap.test.ts
@@ -236,9 +236,6 @@ describe('useMinimap', () => {
   }
 
   beforeEach(() => {
-    mockPause.mockClear()
-    mockResume.mockClear()
-
     mockContext2D = createMockCanvas2DContext()
 
     moduleMockCanvasElement = createMockMinimapCanvas({

--- a/src/renderer/extensions/vueNodes/composables/useSlotElementTracking.test.ts
+++ b/src/renderer/extensions/vueNodes/composables/useSlotElementTracking.test.ts
@@ -130,7 +130,6 @@ describe('useSlotElementTracking', () => {
     })
     mockGraph._nodes = [{ id: 1 }]
     mockCanvasState.canvas = {}
-    mockClientPosToCanvasPos.mockClear()
   })
 
   it.for([

--- a/src/renderer/extensions/vueNodes/composables/useSlotElementTracking.test.ts
+++ b/src/renderer/extensions/vueNodes/composables/useSlotElementTracking.test.ts
@@ -110,7 +110,6 @@ async function mountAndRegisterSlot(type: 'input' | 'output') {
 
 describe('useSlotElementTracking', () => {
   beforeEach(() => {
-    document.body.innerHTML = ''
     layoutStore.initializeFromLiteGraph([])
     layoutStore.applyOperation({
       type: 'createNode',

--- a/src/renderer/extensions/vueNodes/composables/useSlotLinkInteraction.autoPan.test.ts
+++ b/src/renderer/extensions/vueNodes/composables/useSlotLinkInteraction.autoPan.test.ts
@@ -245,8 +245,6 @@ describe('useSlotLinkInteraction auto-pan', () => {
     }
     mockDs.offset = [0, 0]
     mockDs.scale = 1
-    mockSetDirty.mockClear()
-    mockAdapter.beginFromOutput.mockClear()
     mockLinkConnector.state.snapLinksPos = null
   })
 

--- a/src/renderer/extensions/vueNodes/composables/useVueNodeResizeTracking.test.ts
+++ b/src/renderer/extensions/vueNodes/composables/useVueNodeResizeTracking.test.ts
@@ -160,13 +160,6 @@ describe('useVueNodeResizeTracking', () => {
   beforeEach(() => {
     testState.linearMode = false
     testState.nodeLayouts.clear()
-    testState.batchUpdateNodeBounds.mockReset()
-    testState.setSource.mockReset()
-    testState.syncNodeSlotLayoutsFromDOM.mockReset()
-    testState.scheduleSlotLayoutSync.mockReset()
-    resizeObserverState.observe.mockReset()
-    resizeObserverState.unobserve.mockReset()
-    resizeObserverState.disconnect.mockReset()
   })
 
   it('skips repeated no-op resize entries after first measurement', () => {

--- a/src/renderer/extensions/vueNodes/layout/useNodeDrag.test.ts
+++ b/src/renderer/extensions/vueNodes/layout/useNodeDrag.test.ts
@@ -135,17 +135,10 @@ describe('useNodeDrag', () => {
     testState.selectedNodeIds = ref(new Set<NodeId>())
     testState.selectedItems = ref<unknown[]>([])
     testState.nodeLayouts.clear()
-    testState.mutationFns.setSource.mockReset()
-    testState.mutationFns.moveNode.mockReset()
-    testState.mutationFns.batchMoveNodes.mockReset()
-    testState.batchUpdateNodeBounds.mockReset()
-    testState.nodeSnap.shouldSnap.mockReset()
     testState.nodeSnap.shouldSnap.mockReturnValue(false)
-    testState.nodeSnap.applySnapToPosition.mockReset()
     testState.nodeSnap.applySnapToPosition.mockImplementation(
       (pos: { x: number; y: number }) => pos
     )
-    testState.cancelAnimationFrame.mockReset()
     testState.requestAnimationFrameCallback = null
     testState.capturedOnPan.current = null
     testState.capturedAutoPanInstance.current = null
@@ -252,17 +245,10 @@ describe('useNodeDrag auto-pan', () => {
       position: { x: 300, y: 400 },
       size: { width: 200, height: 100 }
     })
-    testState.mutationFns.setSource.mockReset()
-    testState.mutationFns.moveNode.mockReset()
-    testState.mutationFns.batchMoveNodes.mockReset()
-    testState.batchUpdateNodeBounds.mockReset()
-    testState.nodeSnap.shouldSnap.mockReset()
     testState.nodeSnap.shouldSnap.mockReturnValue(false)
-    testState.nodeSnap.applySnapToPosition.mockReset()
     testState.nodeSnap.applySnapToPosition.mockImplementation(
       (pos: { x: number; y: number }) => pos
     )
-    testState.cancelAnimationFrame.mockReset()
     testState.requestAnimationFrameCallback = null
     testState.capturedOnPan.current = null
     testState.capturedAutoPanInstance.current = null

--- a/src/renderer/extensions/vueNodes/widgets/components/ValueControlPopover.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/components/ValueControlPopover.test.ts
@@ -77,7 +77,6 @@ function renderPopover(modelValue: ControlOptions = 'randomize') {
 
 describe('ValueControlPopover', () => {
   beforeEach(() => {
-    mockGet.mockReset()
     mockGet.mockReturnValue('after')
   })
 

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetDOM.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetDOM.test.ts
@@ -34,9 +34,6 @@ import { createMockWidget } from './widgetTestUtils'
 
 describe('WidgetDOM', () => {
   beforeEach(() => {
-    canvasMocks.canvas.graph.getNodeById.mockReset()
-    resolveMock.mockReset()
-    isDOMWidgetMock.mockReset()
     isDOMWidgetMock.mockReturnValue(true)
   })
 

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetRecordAudio.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetRecordAudio.test.ts
@@ -134,21 +134,12 @@ describe('WidgetRecordAudio', () => {
     recorder.isRecording.value = false
     recorder.recordedURL.value = null
     recorder.mediaRecorder.value = null
-    recorder.startRecording.mockClear()
-    recorder.stopRecording.mockClear()
-    recorder.dispose.mockClear()
 
     playback.isPlaying.value = false
     playback.audioElementKey.value = 0
     playback.playbackTimerInterval.value = null
-    playback.play.mockClear()
-    playback.stop.mockClear()
 
     waveform.waveformBars.value = []
-
-    useAudioRecorderMock.mockClear()
-    useAudioPlaybackMock.mockClear()
-    useAudioWaveformMock.mockClear()
 
     appMock.app.canvas.graph.getNodeById.mockReset().mockReturnValue(null)
     isDOMWidgetMock.mockReset().mockReturnValue(false)

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetSelectDropdown.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetSelectDropdown.test.ts
@@ -139,13 +139,10 @@ const i18n = createI18n({
 describe('WidgetSelectDropdown', () => {
   beforeEach(() => {
     mockMediaAssets.media.value = []
-    mockCheckState.mockClear()
     mockAssetsData.items = []
     mockItemsRef.value = []
     mockSelectedSetRef.value = new Set()
     mockFilterSelectedRef.value = 'all'
-    mockUpdateSelectedItems.mockClear()
-    mockHandleFilesUpdate.mockClear()
   })
 
   function renderComponent(

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetTextPreview.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetTextPreview.test.ts
@@ -2,7 +2,7 @@ import { fromPartial } from '@total-typescript/shoehorn'
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import { createPinia, setActivePinia } from 'pinia'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import type { NodeOutputWith, ResultItem } from '@/schemas/apiSchema'
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
@@ -93,11 +93,6 @@ function renderPreview(
 }
 
 describe('WidgetTextPreview', () => {
-  beforeEach(() => {
-    downloadFileMock.mockClear()
-    copyMock.mockClear()
-  })
-
   it('renders plaintext in a textarea by default', () => {
     renderPreview('# not rendered')
 

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetTextarea.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetTextarea.test.ts
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import type { SimplifiedWidget } from '@/types/simplifiedWidget'
 
@@ -192,10 +192,6 @@ describe('WidgetTextarea Value Binding', () => {
     })
   })
   describe('Copy Button Behavior', () => {
-    beforeEach(() => {
-      mockCopyToClipboard.mockClear()
-    })
-
     it('hides copy button when not read-only', async () => {
       const widget = createTextareaWidget('test')
       renderComponent(widget, 'test')

--- a/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdownMenuActions.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdownMenuActions.test.ts
@@ -1,6 +1,6 @@
 import { render, screen, within } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { defineComponent, ref } from 'vue'
 import { createI18n } from 'vue-i18n'
 
@@ -148,10 +148,6 @@ async function openPopover(user: TestUser, triggerName: string) {
 }
 
 describe('FormDropdownMenuActions', () => {
-  beforeEach(() => {
-    popoverHide.mockClear()
-  })
-
   describe('Search', () => {
     it('binds search input to v-model on initial render', () => {
       renderMenu({ searchQuery: 'seed' })

--- a/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdownMenuFilter.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdownMenuFilter.test.ts
@@ -76,7 +76,6 @@ describe('FormDropdownMenuFilter', () => {
   beforeEach(() => {
     const upload = getUploadMock()
     upload.isUploadButtonEnabled.value = false
-    upload.showUploadDialog.mockReset()
   })
 
   describe('Filter options', () => {

--- a/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdownMenuItem.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdownMenuItem.test.ts
@@ -82,7 +82,6 @@ async function flushPromises() {
 describe('FormDropdownMenuItem', () => {
   beforeEach(() => {
     intersectionCallbacks.length = 0
-    mockFindServerPreviewUrl.mockReset()
     mockIsAssetPreviewSupported.mockReset().mockReturnValue(true)
   })
 

--- a/src/renderer/extensions/vueNodes/widgets/composables/audio/useAudioRecorder.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/audio/useAudioRecorder.test.ts
@@ -48,7 +48,6 @@ describe('useAudioRecorder', () => {
     vi.stubGlobal('navigator', {
       mediaDevices: { getUserMedia: mockGetUserMedia }
     })
-    MockMediaRecorder.mockClear()
     mockGetUserMedia.mockResolvedValue(createMockStream())
   })
 

--- a/src/renderer/extensions/vueNodes/widgets/composables/useDismissOnCanvasGesture.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useDismissOnCanvasGesture.test.ts
@@ -1,4 +1,3 @@
-import { createPinia, setActivePinia } from 'pinia'
 import { effectScope, nextTick, ref } from 'vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -28,7 +27,6 @@ function nextFrame() {
 
 describe('useDismissOnCanvasGesture', () => {
   beforeEach(() => {
-    setActivePinia(createPinia())
     panCanvasTo(0, 0)
   })
 

--- a/src/renderer/extensions/vueNodes/widgets/composables/useRemoteWidget.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useRemoteWidget.test.ts
@@ -1,5 +1,5 @@
 import axios from 'axios'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import type { IWidget } from '@/lib/litegraph/src/litegraph'
 import { api } from '@/scripts/api'
@@ -106,15 +106,6 @@ async function getResolvedValue(hook: ReturnType<typeof useRemoteWidget>) {
 }
 
 describe('useRemoteWidget', () => {
-  beforeEach(() => {
-    // Reset mocks
-    vi.mocked(axios.get).mockReset()
-    // Reset cache between tests
-    vi.spyOn(Map.prototype, 'get').mockClear()
-    vi.spyOn(Map.prototype, 'set').mockClear()
-    vi.spyOn(Map.prototype, 'delete').mockClear()
-  })
-
   describe('initialization', () => {
     it('should create hook with default values', () => {
       const hook = useRemoteWidget(createMockOptions())

--- a/src/renderer/extensions/vueNodes/widgets/composables/useWidgetSelectActions.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useWidgetSelectActions.test.ts
@@ -1,6 +1,6 @@
 import { fromPartial } from '@total-typescript/shoehorn'
 import { computed, ref } from 'vue'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import type { FormDropdownItem } from '@/renderer/extensions/vueNodes/widgets/components/form/dropdown/types'
 import { useWidgetSelectActions } from '@/renderer/extensions/vueNodes/widgets/composables/useWidgetSelectActions'
@@ -44,10 +44,6 @@ function createItems(...names: string[]): FormDropdownItem[] {
 }
 
 describe('useWidgetSelectActions', () => {
-  beforeEach(() => {
-    mockCaptureCanvasState.mockClear()
-  })
-
   describe('updateSelectedItems', () => {
     it('sets modelValue to the selected item name', () => {
       const modelValue = ref<string | undefined>('img_001.png')

--- a/src/renderer/extensions/vueNodes/widgets/composables/useWidgetSelectItems.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useWidgetSelectItems.test.ts
@@ -130,7 +130,6 @@ describe('display label behavior', () => {
 describe('useWidgetSelectItems', () => {
   beforeEach(() => {
     mockMediaAssets = createMockMediaAssets()
-    mockResolveOutputAssetItems.mockReset()
     mockAssetsData.items = []
   })
 

--- a/src/renderer/glsl/glslPreviewStoreContract.test.ts
+++ b/src/renderer/glsl/glslPreviewStoreContract.test.ts
@@ -1,5 +1,4 @@
 import { fromAny } from '@total-typescript/shoehorn'
-import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick, reactive, shallowRef } from 'vue'
 
@@ -101,7 +100,6 @@ function createGLSLNode(nodeId: number): LGraphNode {
 
 describe('GLSL live preview reads the shader written by the customtext widget', () => {
   beforeEach(() => {
-    setActivePinia(createPinia())
     for (const key of Object.keys(nodeOutputs)) delete nodeOutputs[key]
   })
 

--- a/src/renderer/glsl/useGLSLPreview.test.ts
+++ b/src/renderer/glsl/useGLSLPreview.test.ts
@@ -1,5 +1,4 @@
 import { fromAny } from '@total-typescript/shoehorn'
-import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick, reactive, ref, shallowRef } from 'vue'
 import type { MaybeRefOrGetter } from 'vue'
@@ -129,7 +128,6 @@ function wrapNode(
 
 describe('useGLSLPreview', () => {
   beforeEach(() => {
-    setActivePinia(createPinia())
     mockRendererFactory.lastConfig.value = undefined
     globalThis.URL.createObjectURL = vi.fn(() => 'blob:test')
     globalThis.URL.revokeObjectURL = vi.fn()

--- a/src/renderer/glsl/useGLSLUniforms.promotedRead.test.ts
+++ b/src/renderer/glsl/useGLSLUniforms.promotedRead.test.ts
@@ -1,6 +1,5 @@
-import { createPinia, setActivePinia } from 'pinia'
 import { computed } from 'vue'
-import { beforeEach, describe, expect, it } from 'vitest'
+import { describe, expect, it } from 'vitest'
 
 import type { CurveData } from '@/components/curve/types'
 import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
@@ -60,10 +59,6 @@ function runUniforms(sources: UniformSources) {
 }
 
 describe('useGLSLUniforms reads promoted widget values from the host key', () => {
-  beforeEach(() => {
-    setActivePinia(createPinia())
-  })
-
   it('curveValues reflects the edited host curve, not the stale interior curve', () => {
     const staleCurve: CurveData = {
       points: [

--- a/src/renderer/three/RendererView.test.ts
+++ b/src/renderer/three/RendererView.test.ts
@@ -30,7 +30,6 @@ vi.mock('three', async (importOriginal) => {
 const drawImage = vi.fn()
 
 beforeEach(() => {
-  drawImage.mockClear()
   vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue({
     drawImage,
     globalCompositeOperation: 'source-over'

--- a/src/scripts/api.featureFlags.test.ts
+++ b/src/scripts/api.featureFlags.test.ts
@@ -427,12 +427,10 @@ describe('API Feature Flags', () => {
    */
   describe('characterization: resolution with no override present', () => {
     beforeEach(() => {
-      sessionStorage.clear()
       window.history.replaceState({}, '', '/')
     })
 
     afterEach(() => {
-      sessionStorage.clear()
       window.history.replaceState({}, '', '/')
     })
 

--- a/src/scripts/api.featureFlags.test.ts
+++ b/src/scripts/api.featureFlags.test.ts
@@ -426,14 +426,6 @@ describe('API Feature Flags', () => {
    * how server values, falsy values, nested paths or defaults resolve.
    */
   describe('characterization: resolution with no override present', () => {
-    beforeEach(() => {
-      window.history.replaceState({}, '', '/')
-    })
-
-    afterEach(() => {
-      window.history.replaceState({}, '', '/')
-    })
-
     it('returns the server value verbatim', () => {
       api.serverFeatureFlags.value = { some_flag: 'server_value' }
 

--- a/src/scripts/api.sessionOverride.test.ts
+++ b/src/scripts/api.sessionOverride.test.ts
@@ -30,13 +30,11 @@ describe('api.getServerFeature session override outside component setup', () => 
     mockDistribution.isCloud = true
     mockCurrentUser.value = { email: 'dev@comfy.org', emailVerified: true }
     api.serverFeatureFlags.value = {}
-    sessionStorage.clear()
   })
 
   afterEach(() => {
     window.history.replaceState({}, '', '/')
     api.serverFeatureFlags.value = {}
-    sessionStorage.clear()
     vi.restoreAllMocks()
   })
 

--- a/src/scripts/api.sessionOverride.test.ts
+++ b/src/scripts/api.sessionOverride.test.ts
@@ -33,7 +33,6 @@ describe('api.getServerFeature session override outside component setup', () => 
   })
 
   afterEach(() => {
-    window.history.replaceState({}, '', '/')
     api.serverFeatureFlags.value = {}
     vi.restoreAllMocks()
   })

--- a/src/scripts/changeTracker.test.ts
+++ b/src/scripts/changeTracker.test.ts
@@ -216,14 +216,12 @@ function omitOptionalSubgraphCollections(state: ComfyWorkflowJSON) {
 
 describe('ChangeTracker', () => {
   beforeEach(() => {
-    vi.mocked(api.dispatchCustomEvent).mockReset()
     resetSubgraphFixtureState()
     nodeIdCounter = 0
     ChangeTracker.isLoadingGraph = false
     ChangeTracker.resetCheckStateWarningForTest()
     mockWorkflowStore.activeWorkflow = null
     mockWorkflowStore.getWorkflowByPath.mockReturnValue(null)
-    vi.mocked(app.rootGraph.serialize).mockReset()
     mockCanvasState(createState())
     useQueueSettingsStore().mode = 'change'
     app.ui.autoQueueEnabled = false

--- a/src/scripts/ui.test.ts
+++ b/src/scripts/ui.test.ts
@@ -48,8 +48,6 @@ describe('ComfyUI file input', () => {
         unobserve = vi.fn()
       }
     )
-    mockApp.handleFile.mockReset()
-    mockApp.showErrorOnFileLoad.mockReset()
   })
 
   afterEach(() => {

--- a/src/scripts/ui.test.ts
+++ b/src/scripts/ui.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { ComfyUI } from './ui'
 
@@ -48,10 +48,6 @@ describe('ComfyUI file input', () => {
         unobserve = vi.fn()
       }
     )
-  })
-
-  afterEach(() => {
-    document.body.replaceChildren()
   })
 
   it('reports rejected imports and resets the selected file', async () => {

--- a/src/services/dialogService.renderer.test.ts
+++ b/src/services/dialogService.renderer.test.ts
@@ -3,7 +3,7 @@
  * Reka-migrated dialog, the dialog stack item must carry `renderer: 'reka'`.
  * Catches accidental reverts of the Reka renderer flip.
  */
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 const showDialog = vi.hoisted(() => vi.fn())
 
@@ -35,10 +35,6 @@ vi.mock('@/composables/billing/useBillingContext', () => ({
 import { useDialogService } from '@/services/dialogService'
 
 describe('dialogService Reka renderer opt-in', () => {
-  beforeEach(() => {
-    showDialog.mockReset()
-  })
-
   it("prompt() sets renderer 'reka' and size 'md'", () => {
     void useDialogService().prompt({ title: 'T', message: 'M' })
     const [args] = showDialog.mock.calls[0]

--- a/src/services/useNewUserService.test.ts
+++ b/src/services/useNewUserService.test.ts
@@ -29,8 +29,6 @@ describe('useNewUserService', () => {
 
   beforeEach(() => {
     mockSettingStore.settingValues = {}
-    mockSettingStore.get.mockReset()
-    mockSettingStore.set.mockReset()
 
     service = useNewUserService()
     service.reset()

--- a/src/stores/authStore.test.ts
+++ b/src/stores/authStore.test.ts
@@ -222,7 +222,6 @@ describe('useAuthStore', () => {
     store = useAuthStore()
 
     // Reset and set up getIdToken mock
-    mockUser.getIdToken.mockReset()
     mockUser.getIdToken.mockResolvedValue('mock-id-token')
 
     // Default: no API key auth

--- a/src/stores/authStore.test.ts
+++ b/src/stores/authStore.test.ts
@@ -174,7 +174,6 @@ describe('useAuthStore', () => {
 
   beforeEach(() => {
     vi.stubGlobal('fetch', mockFetch)
-    sessionStorage.clear()
     clearPreservedQuery(PRESERVED_QUERY_NAMESPACES.SHARE_AUTH)
 
     mockFeatureFlags.unifiedCloudAuthEnabled = false

--- a/src/stores/executionErrorStore.test.ts
+++ b/src/stores/executionErrorStore.test.ts
@@ -53,10 +53,6 @@ function mockGraphReady(rootGraph: typeof app.rootGraph) {
 }
 
 describe('executionErrorStore — node error operations', () => {
-  beforeEach(() => {
-    setActivePinia(createPinia())
-  })
-
   describe('clearSimpleNodeErrors', () => {
     it('does nothing if lastNodeErrors is null', () => {
       const store = useExecutionErrorStore()
@@ -628,7 +624,6 @@ describe('executionErrorStore — node error operations', () => {
 
 describe('surfaceMissingModels — silent option', () => {
   beforeEach(() => {
-    setActivePinia(createPinia())
     mockShowErrorsTab.value = true
   })
 
@@ -696,7 +691,6 @@ describe('surfaceMissingModels — silent option', () => {
 
 describe('surfaceMissingMedia — silent option', () => {
   beforeEach(() => {
-    setActivePinia(createPinia())
     mockShowErrorsTab.value = true
   })
 
@@ -763,10 +757,6 @@ describe('surfaceMissingMedia — silent option', () => {
 })
 
 describe('recordNodeErrors', () => {
-  beforeEach(() => {
-    setActivePinia(createPinia())
-  })
-
   it('normalizes an empty error record to null', () => {
     const store = useExecutionErrorStore()
 
@@ -785,10 +775,6 @@ describe('recordNodeErrors', () => {
 })
 
 describe('hasMissingError', () => {
-  beforeEach(() => {
-    setActivePinia(createPinia())
-  })
-
   it.for([
     {
       type: 'nodes',

--- a/src/stores/executionStore.test.ts
+++ b/src/stores/executionStore.test.ts
@@ -187,9 +187,6 @@ describe('useExecutionStore - NodeLocatorId conversions', () => {
 
   beforeEach(() => {
     // Reset mock implementations
-    mockNodeIdToNodeLocatorId.mockReset()
-    mockNodeLocatorIdToNodeExecutionId.mockReset()
-    mockExecutionIdToCurrentId.mockReset()
 
     store = useExecutionStore()
   })
@@ -272,10 +269,6 @@ describe('useExecutionStore - nodeLocationProgressStates caching', () => {
   let store: ReturnType<typeof useExecutionStore>
 
   beforeEach(() => {
-    mockNodeIdToNodeLocatorId.mockReset()
-    mockNodeLocatorIdToNodeExecutionId.mockReset()
-    mockExecutionIdToCurrentId.mockReset()
-
     store = useExecutionStore()
   })
 
@@ -1469,7 +1462,6 @@ describe('useExecutionStore - RAF batching', () => {
   }
 
   beforeEach(() => {
-    vi.clearAllMocks()
     store = useExecutionStore()
     store.bindExecutionEvents()
   })

--- a/src/stores/jobPreviewStore.test.ts
+++ b/src/stores/jobPreviewStore.test.ts
@@ -1,4 +1,3 @@
-import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { ref } from 'vue'
 
@@ -23,7 +22,6 @@ vi.mock('@/utils/objectUrlUtil', () => ({
 
 describe('jobPreviewStore', () => {
   beforeEach(() => {
-    setActivePinia(createPinia())
     previewMethodRef.value = 'latent2rgb'
   })
 

--- a/src/stores/missingMediaPreviewRegression.test.ts
+++ b/src/stores/missingMediaPreviewRegression.test.ts
@@ -1,4 +1,3 @@
-import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
 
@@ -56,7 +55,6 @@ function makeNodeWithPreview(id: number): LGraphNode {
 
 describe('FE-230 regression — workflow-load missing-media flagging must not wipe node previews', () => {
   beforeEach(() => {
-    setActivePinia(createPinia())
     mockApp.isGraphReady = true
     mockApp.rootGraph = { nodes: [], _nodes: [] } as unknown as LGraph
   })

--- a/src/stores/missingMediaPreviewRegression.test.ts
+++ b/src/stores/missingMediaPreviewRegression.test.ts
@@ -59,8 +59,6 @@ describe('FE-230 regression — workflow-load missing-media flagging must not wi
     setActivePinia(createPinia())
     mockApp.isGraphReady = true
     mockApp.rootGraph = { nodes: [], _nodes: [] } as unknown as LGraph
-    mockRemoveNodeOutputs.mockReset()
-    mockGetNodeByExecutionId.mockReset()
   })
 
   it('does not clear node.imgs when verification flags a Load Image as missing on workflow load (e.g. mask-editor saved value)', async () => {

--- a/src/stores/subgraphNavigationStore.viewport.test.ts
+++ b/src/stores/subgraphNavigationStore.viewport.test.ts
@@ -91,9 +91,6 @@ describe('useSubgraphNavigationStore - Viewport Persistence', () => {
     mockCanvas.ds.offset = [0, 0]
     mockCanvas.ds.state.scale = 1
     mockCanvas.ds.state.offset = [0, 0]
-    mockSetDirty.mockClear()
-    mockFitView.mockClear()
-    mockRequestSlotSyncAll.mockClear()
   })
 
   describe('cache key isolation', () => {

--- a/src/stores/userStore.test.ts
+++ b/src/stores/userStore.test.ts
@@ -14,7 +14,6 @@ vi.mock('@/scripts/api', () => ({
 describe('userStore', () => {
   beforeEach(() => {
     setActivePinia(createPinia())
-    getUserConfig.mockReset()
   })
 
   describe('initialize', () => {

--- a/src/stores/userStore.test.ts
+++ b/src/stores/userStore.test.ts
@@ -1,5 +1,4 @@
-import { createPinia, setActivePinia } from 'pinia'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import { useUserStore } from './userStore'
 
@@ -12,10 +11,6 @@ vi.mock('@/scripts/api', () => ({
 }))
 
 describe('userStore', () => {
-  beforeEach(() => {
-    setActivePinia(createPinia())
-  })
-
   describe('initialize', () => {
     it('fetches user config on first call', async () => {
       getUserConfig.mockResolvedValue({})

--- a/src/stores/workspace/sidebarTabStore.test.ts
+++ b/src/stores/workspace/sidebarTabStore.test.ts
@@ -105,10 +105,6 @@ vi.mock('@/platform/workflow/management/composables/useAppsSidebarTab', () => ({
 
 describe('useSidebarTabStore', () => {
   beforeEach(() => {
-    mockGetSetting.mockReset()
-    mockRegisterCommand.mockClear()
-    mockRegisterCommands.mockClear()
-    mockBrowseModelAssets.mockClear()
     registeredCommands.length = 0
     commandStoreCommands.length = 0
   })

--- a/src/utils/litegraphUtil.test.ts
+++ b/src/utils/litegraphUtil.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { fromAny, fromPartial } from '@total-typescript/shoehorn'
 
 import type { LGraphCanvas } from '@/lib/litegraph/src/litegraph'
@@ -91,10 +91,6 @@ describe('createNode', () => {
       graph_mouse: [100, 200]
     })
   }
-
-  beforeEach(() => {
-    mockBringNodeToFront.mockClear()
-  })
 
   it('returns null when name is empty', async () => {
     const result = await createNode(makeCanvas(new LGraph()), '')

--- a/src/utils/sessionFeatureFlagOverride.test.ts
+++ b/src/utils/sessionFeatureFlagOverride.test.ts
@@ -28,7 +28,6 @@ describe('getSessionOverride', () => {
   beforeEach(() => {
     mockDistribution.isCloud = true
     mockCurrentUser.value = COMFY_EMPLOYEE
-    sessionStorage.clear()
   })
 
   afterEach(() => {

--- a/src/utils/sessionFeatureFlagOverride.test.ts
+++ b/src/utils/sessionFeatureFlagOverride.test.ts
@@ -31,7 +31,6 @@ describe('getSessionOverride', () => {
   })
 
   afterEach(() => {
-    window.history.replaceState({}, '', '/')
     vi.restoreAllMocks()
   })
 

--- a/src/workbench/extensions/manager/components/manager/PackVersionBadge.test.ts
+++ b/src/workbench/extensions/manager/components/manager/PackVersionBadge.test.ts
@@ -77,8 +77,6 @@ const PackVersionSelectorPopoverStub = {
 
 describe('PackVersionBadge', () => {
   beforeEach(() => {
-    mockToggle.mockReset()
-    mockHide.mockReset()
     mockIsPackEnabled.mockReturnValue(true)
   })
 

--- a/src/workbench/extensions/manager/components/manager/PackVersionSelectorPopover.test.ts
+++ b/src/workbench/extensions/manager/components/manager/PackVersionSelectorPopover.test.ts
@@ -91,7 +91,6 @@ const waitForPromises = async () => {
 
 describe('PackVersionSelectorPopover', () => {
   beforeEach(() => {
-    mockGetPackVersions.mockReset()
     mockInstallPack.mockReset().mockResolvedValue(undefined)
     mockCheckNodeCompatibility
       .mockReset()

--- a/src/workbench/extensions/manager/components/manager/button/PackEnableToggle.test.ts
+++ b/src/workbench/extensions/manager/components/manager/button/PackEnableToggle.test.ts
@@ -96,7 +96,6 @@ describe('PackEnableToggle', () => {
   const user = userEvent.setup()
 
   beforeEach(() => {
-    mockIsPackEnabled.mockReset()
     mockEnablePack.mockReset().mockResolvedValue(undefined)
     mockDisablePack.mockReset().mockResolvedValue(undefined)
     mockGetConflictsForPackageByID.mockReset().mockReturnValue(undefined)

--- a/src/workbench/extensions/manager/components/manager/packCard/PackCardFooter.test.ts
+++ b/src/workbench/extensions/manager/components/manager/packCard/PackCardFooter.test.ts
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/vue'
 import { createTestingPinia } from '@pinia/testing'
 import PrimeVue from 'primevue/config'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { ref } from 'vue'
 import { createI18n } from 'vue-i18n'
 
@@ -51,11 +51,6 @@ const mockNodePack = {
 }
 
 describe('PackCardFooter', () => {
-  beforeEach(() => {
-    mockIsPackInstalled.mockReset()
-    mockCheckNodeCompatibility.mockReset()
-  })
-
   function renderComponent(props = {}) {
     const i18n = createI18n({
       legacy: false,

--- a/src/workbench/extensions/manager/composables/useManagerDialog.test.ts
+++ b/src/workbench/extensions/manager/composables/useManagerDialog.test.ts
@@ -4,7 +4,7 @@
  * max-width × 80vh, expanding at 3000px). Catches accidental reverts of the
  * Phase 4 renderer flip.
  */
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 const showDialog = vi.hoisted(() => vi.fn())
 const closeDialog = vi.hoisted(() => vi.fn())
@@ -17,11 +17,6 @@ import { ManagerTab } from '@/workbench/extensions/manager/types/comfyManagerTyp
 import { useManagerDialog } from '@/workbench/extensions/manager/composables/useManagerDialog'
 
 describe('useManagerDialog', () => {
-  beforeEach(() => {
-    showDialog.mockReset()
-    closeDialog.mockReset()
-  })
-
   it("show() opens the Reka renderer with size 'full' and Manager content sizing", () => {
     useManagerDialog().show()
     const [args] = showDialog.mock.calls[0]

--- a/src/workbench/extensions/manager/composables/useManagerSurveyDialog.test.ts
+++ b/src/workbench/extensions/manager/composables/useManagerSurveyDialog.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 const showDialog = vi.hoisted(() => vi.fn())
 const closeDialog = vi.hoisted(() => vi.fn())
@@ -10,11 +10,6 @@ vi.mock('@/stores/dialogStore', () => ({
 import { useManagerSurveyDialog } from '@/workbench/extensions/manager/composables/useManagerSurveyDialog'
 
 describe('useManagerSurveyDialog', () => {
-  beforeEach(() => {
-    showDialog.mockReset()
-    closeDialog.mockReset()
-  })
-
   it('show() opens the survey dialog under its own key via the Reka layout renderer', () => {
     useManagerSurveyDialog().show()
     const [args] = showDialog.mock.calls[0]

--- a/vitest.timer.setup.ts
+++ b/vitest.timer.setup.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, vi } from 'vitest'
 
 beforeEach(() => {
   globalThis.localStorage?.clear()
+  globalThis.sessionStorage?.clear()
   vi.useFakeTimers()
 })
 

--- a/vitest.timer.setup.ts
+++ b/vitest.timer.setup.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, vi } from 'vitest'
 
 beforeEach(() => {
+  globalThis.document?.body.replaceChildren()
   globalThis.localStorage?.clear()
   globalThis.sessionStorage?.clear()
   vi.useFakeTimers()

--- a/vitest.timer.setup.ts
+++ b/vitest.timer.setup.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, vi } from 'vitest'
 
 beforeEach(() => {
   globalThis.document?.body.replaceChildren()
+  globalThis.window?.history.replaceState({}, '', '/')
   globalThis.localStorage?.clear()
   globalThis.sessionStorage?.clear()
   vi.useFakeTimers()


### PR DESCRIPTION
## Summary

Combine the test-isolation cleanup and shared component automocks from the stacked PR series into one merge. The aggregate removes redundant per-suite setup while preserving within-test resets and behavior-specific cleanup.

## Constituent changes

- #15072 — remove 249 redundant `mockReset()`, `mockClear()`, and `vi.clearAllMocks()` calls across 120 files, relying on Vitest's configured `mockReset` and `restoreMocks` behavior.
- #15074 — clear `sessionStorage` in the shared Vitest `beforeEach` and remove 28 redundant cleanup calls across 21 suites, retaining the fast-check iteration reset.
- #15075 — rely on the shared testing Pinia and remove 67 redundant `setActivePinia(createPinia())` calls across 60 files, retaining deliberate within-test and independent-store resets.
- #15082 — clear `document.body` in the shared Vitest setup and remove 28 redundant body resets across 26 suites, preserving behavior-specific DOM replacement.
- #15084 — centralize Testing Library cleanup, including scoped website cleanup for its `globals: false` project, and remove 23 redundant lifecycle registrations while preserving mid-test cleanup.
- #15090 — reset browser history to `/` in the shared Vitest setup and remove five suite-local URL resets while retaining URL mutations used as test inputs.
- #15100 — replace three inline Select test doubles with opt-in colocated Vitest automocks for the Select component family and include Vue manual mocks in Knip's Vitest entry pattern.
- #15101 — replace five inline Slider factories with an opt-in colocated range-input automock that preserves accessibility, numeric conversion, bounds, step, and array-valued `v-model` behavior.
- #15104 — replace two queue-menu Popover factories with an opt-in colocated automock and shared close spy, reset by Vitest's configured `mockReset` behavior.

## Verification

- root unit suite: 1,160 files passed; 15,926 tests passed, 8 skipped
- `pnpm lint`
- `pnpm typecheck`
- `pnpm format:check`
- `pnpm knip`