### PR TITLE
feat(telemetry): split nudge events by how the tour ended

### DIFF
--- a/src/platform/telemetry/types.ts
+++ b/src/platform/telemetry/types.ts
@@ -156,6 +156,13 @@ export interface OnboardingTourStepMetadata {
 /** The nudge is post-tour, so it reports no step and no count. */
 export interface OnboardingTourNudgeMetadata {
   tour: string
+  /**
+   * Whether the tour was walked to the end. Without it `nudge_shown` and
+   * `explore_templates_clicked` cannot be split by how the tour ended, so a
+   * conversion from a completed tour and one from a tour that never started
+   * land in the same bucket.
+   */
+  tour_completed?: boolean
 }
 
 export type OnboardingTourMetadata =

--- a/src/renderer/extensions/firstRunTour/nudge/FirstRunTourNudge.test.ts
+++ b/src/renderer/extensions/firstRunTour/nudge/FirstRunTourNudge.test.ts
@@ -94,7 +94,8 @@ describe('FirstRunTourNudge', () => {
       'a nudge armed before this mounted still has to appear'
     ).not.toBeNull()
     expect(mocks.trackOnboardingTour).toHaveBeenCalledWith('nudge_shown', {
-      tour: 'firstRun'
+      tour: 'firstRun',
+      tour_completed: true
     })
   })
 
@@ -230,7 +231,29 @@ describe('FirstRunTourNudge', () => {
     expect(mocks.dismissNudge).toHaveBeenCalled()
     expect(mocks.trackOnboardingTour).toHaveBeenCalledWith(
       'explore_templates_clicked',
-      { tour: 'firstRun' }
+      { tour: 'firstRun', tour_completed: true }
+    )
+  })
+
+  it('separates a conversion from a completed tour from one that never ran', async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+    mocks.tourWasCompleted.value = false
+    mocks.nudgeArmed.value = true
+    renderNudge()
+    await vi.advanceTimersByTimeAsync(APPEAR_DELAY_MS)
+
+    await user.click(screen.getByTestId('first-run-nudge-explore'))
+
+    // Both events carry it, so the funnel can be read end to end: without it
+    // a conversion from a finished tour and one from a tour that never
+    // started are indistinguishable.
+    expect(mocks.trackOnboardingTour).toHaveBeenCalledWith('nudge_shown', {
+      tour: 'firstRun',
+      tour_completed: false
+    })
+    expect(mocks.trackOnboardingTour).toHaveBeenCalledWith(
+      'explore_templates_clicked',
+      { tour: 'firstRun', tour_completed: false }
     )
   })
 })

--- a/src/renderer/extensions/firstRunTour/nudge/FirstRunTourNudge.vue
+++ b/src/renderer/extensions/firstRunTour/nudge/FirstRunTourNudge.vue
@@ -90,7 +90,10 @@ const { start: scheduleAppearance, stop: cancelAppearance } = useTimeoutFn(
     onScreen.value = true
     if (reported) return
     reported = true
-    telemetry?.trackOnboardingTour('nudge_shown', { tour: 'firstRun' })
+    telemetry?.trackOnboardingTour('nudge_shown', {
+      tour: 'firstRun',
+      tour_completed: tourWasCompleted.value
+    })
   },
   APPEAR_DELAY_MS,
   { immediate: false }
@@ -117,7 +120,8 @@ watch(
 function onExplore() {
   useWorkflowTemplateSelectorDialog().show('first_run_nudge')
   telemetry?.trackOnboardingTour('explore_templates_clicked', {
-    tour: 'firstRun'
+    tour: 'firstRun',
+    tour_completed: tourWasCompleted.value
   })
   dismissNudge()
 }


### PR DESCRIPTION
@MaanilVerma — **your call entirely; close it if you'd rather not.** I owe you
context on why it's arriving as a PR eight days late rather than as a question.

## The gap

`OnboardingTourNudgeMetadata` is `{ tour }` only, so `nudge_shown` and
`explore_templates_clicked` cannot be split by how the tour ended.

That matters more here than it would elsewhere, because **every ending arms the
nudge** — deliberately, per your call in #14144: *"a user who saw no tour is the
one who most needs somewhere to go next."* So the nudge's audience is
deliberately a mix of *finished the tour* and *never saw one*, and right now the
funnel cannot tell those two apart. A conversion from someone who completed the
walkthrough and one from someone the tour never started for land in the same
bucket.

## The change

`tourWasCompleted` is already in scope in the component — it picks the copy one
line above the telemetry call. This carries the same value onto both events:

```ts
telemetry?.trackOnboardingTour('nudge_shown', {
  tour: 'firstRun',
  tour_completed: tourWasCompleted.value
})
```

Optional field, no new event, **no visibility rule changed**, nothing added to
any other event.

## Verification

`FirstRunTourNudge.test.ts` **12/12**. The two existing assertions pinned the
exact metadata shape, so they failed until updated — which is the suite working.
Added one case asserting both events carry `false` when the tour did not
complete.

Mutation-checked: hard-coding `tour_completed: true` fails exactly that new
case, 11 others still pass. `typecheck` and `format:check` clean.

## Why it's late

I drafted this as part of a Slack reply to you on **2026-08-04** and never sent
it, so you have never actually seen the offer. That's the failure, not the
telemetry. It was the one item in that draft still worth acting on — the rest
of it has since been overtaken (the nudge copy landed in #14677, and you've
since settled the OG image on #14957).

If you'd rather have the *full* ending instead of a boolean — `completed` vs
`skipped` with its `skipReason` — say so and I'll rework it; the controller has
`engine.lastEnding` and only exposes the boolean today. I went with the boolean
because it needed no change to the controller's surface.
