### PR TITLE
test: pin that script src loads never reach the network

### DIFF
--- a/docs/guidance/vitest.md
+++ b/docs/guidance/vitest.md
@@ -51,15 +51,6 @@ hook, another test tidying up after itself, or enabling the `unstubGlobals`
 config option - drops it and puts the real `fetch` back without failing
 anything.
 
-A test that inserts a `<script src>` (the GTM provider tests, for example)
-prints a stack trace on stderr: `DOMException [NotSupportedError]: Failed to
-load script "...". JavaScript file loading is disabled.` This is the guard
-working, not a failure - the element fires its `error` event synchronously and
-nothing reaches the network. The noise cannot be silenced from test code
-because happy-dom writes through the worker's original console, which sits
-underneath vitest's console interception. When a run is red, these traces are
-not what made it red; look for the `Unhandled Errors` section instead.
-
 ## Component Testing
 
 - Use `@testing-library/vue` with `@testing-library/user-event` for component tests (an ESLint rule bans `@vue/test-utils` in new tests)

--- a/docs/guidance/vitest.md
+++ b/docs/guidance/vitest.md
@@ -51,6 +51,15 @@ hook, another test tidying up after itself, or enabling the `unstubGlobals`
 config option - drops it and puts the real `fetch` back without failing
 anything.
 
+A test that inserts a `<script src>` (the GTM provider tests, for example)
+prints a stack trace on stderr: `DOMException [NotSupportedError]: Failed to
+load script "...". JavaScript file loading is disabled.` This is the guard
+working, not a failure - the element fires its `error` event synchronously and
+nothing reaches the network. The noise cannot be silenced from test code
+because happy-dom writes through the worker's original console, which sits
+underneath vitest's console interception. When a run is red, these traces are
+not what made it red; look for the `Unhandled Errors` section instead.
+
 ## Component Testing
 
 - Use `@testing-library/vue` with `@testing-library/user-event` for component tests (an ESLint rule bans `@vue/test-utils` in new tests)

--- a/src/vitestSetup.test.ts
+++ b/src/vitestSetup.test.ts
@@ -63,4 +63,20 @@ describe('unit test network guard', () => {
       /Blocked a real network request/
     )
   })
+
+  it('errors a <script src> synchronously instead of fetching it', () => {
+    // Subresource loads bypass the fetch guard: happy-dom fetches them
+    // through its own pipeline. Disabled loading errors the element
+    // synchronously; anything async means scripts reach the network again.
+    const script = document.createElement('script')
+    const events: string[] = []
+    script.addEventListener('error', () => events.push('error'))
+    script.addEventListener('load', () => events.push('load'))
+    script.async = true
+    script.src = 'https://example.com/external.js'
+    document.head.appendChild(script)
+    script.remove()
+
+    expect(events).toEqual(['error'])
+  })
 })


### PR DESCRIPTION
## Summary

Pins the external-script vector from #14828 with a regression test and documents the benign `NotSupportedError` stderr traces, closing out the issue whose job-failing root cause (leaked unit-test fetches) was fixed by #14687.

## Changes

- **What**: Adds a guard test to `src/vitestSetup.test.ts` asserting a `<script src>` errors synchronously instead of fetching. The #14687 fetch guard cannot see subresource loads (happy-dom fetches them through its own pipeline); today scripts stay offline because JavaScript evaluation is disabled by default in happy-dom 20 and `disableJavaScriptFileLoading` is set, and this test fails if both guards are ever lost (verified by mutation: enabling evaluation and file loading turns exactly this test red). Also documents in `docs/guidance/vitest.md` that the `DOMException [NotSupportedError]: Failed to load script` stderr traces from script-inserting tests are the guard working, cannot be silenced from test code (happy-dom writes through the worker's original console, beneath vitest's interception), and are never what made a red run red.

## Review Focus

- Diagnosis: the ECONNREFUSED job failures in #14828 came from leaked `fetch` calls (fixed in #14687), not from script loaders — under happy-dom 20 (in use since before the observed failures) a `<script src>` never fetched. The script-loader stack frames in the issue's log were these benign `NotSupportedError` traces printed adjacent to the real failure. Verified on current main: full suite runs with zero unhandled errors and zero ECONNREFUSED.

Fixes #14828
