### PR TITLE
feat(website): add the LTX 2.5 launch page

### DIFF
--- a/apps/website/e2e/ltx-2.5.spec.ts
+++ b/apps/website/e2e/ltx-2.5.spec.ts
@@ -14,8 +14,6 @@ const REVIEWS_HEADING = t('ltx.reviews.heading', 'en')
 const HIGHLIGHT_CTA = t('ltx.reviews.highlightCta', 'en')
 const MCP_ROUTE = getRoutes('en').mcp
 const FIRST_REVIEW = creatorReviews[0]
-// The launch template the "RUN LTX 2.5" button must open. Pinned as a literal so
-// repointing the CTA back at the generic hub fails here, not just in review.
 const LTX_RUN_TEMPLATE = 'https://cloud.comfy.org/?template=video_ltx2_5_i2v'
 
 test.describe('LTX 2.5 page — desktop @smoke', () => {

--- a/apps/website/e2e/ltx-2.5.spec.ts
+++ b/apps/website/e2e/ltx-2.5.spec.ts
@@ -1,0 +1,106 @@
+import { expect } from '@playwright/test'
+
+import { externalLinks, getRoutes } from '../src/config/routes'
+import { creatorReviews } from '../src/data/creatorReviews'
+import { ltxPage } from '../src/data/ltx'
+import { t } from '../src/i18n/translations'
+import { test } from './fixtures/blockExternalMedia'
+
+const PATH = '/ltx-2.5'
+const HERO_TITLE = t('ltx.hero.title', 'en')
+const MODELS_HEADING = t('ltx.models.heading', 'en')
+const MODELS_ROUTE = getRoutes('en').models
+const REVIEWS_HEADING = t('ltx.reviews.heading', 'en')
+const HIGHLIGHT_CTA = t('ltx.reviews.highlightCta', 'en')
+const MCP_ROUTE = getRoutes('en').mcp
+const FIRST_REVIEW = creatorReviews[0]
+// The launch template the "RUN LTX 2.5" button must open. Pinned as a literal so
+// repointing the CTA back at the generic hub fails here, not just in review.
+const LTX_RUN_TEMPLATE = 'https://cloud.comfy.org/?template=video_ltx2_5_i2v'
+
+test.describe('LTX 2.5 page — desktop @smoke', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(PATH)
+  })
+
+  test('renders the hero heading and is indexable', async ({ page }) => {
+    await expect(
+      page.getByRole('heading', { level: 1, name: HERO_TITLE })
+    ).toBeVisible()
+
+    await expect(page.locator('meta[name="robots"]')).toHaveCount(0)
+  })
+
+  test('renders the models section heading', async ({ page }) => {
+    const heading = page.getByRole('heading', {
+      level: 2,
+      name: MODELS_HEADING
+    })
+    await heading.scrollIntoViewIfNeeded()
+    await expect(heading).toBeVisible()
+  })
+
+  test('renders the reviews section heading and first quote', async ({
+    page
+  }) => {
+    const heading = page.getByRole('heading', {
+      level: 2,
+      name: REVIEWS_HEADING
+    })
+    await heading.scrollIntoViewIfNeeded()
+    await expect(heading).toBeVisible()
+    await expect(page.getByText(FIRST_REVIEW.name)).toBeVisible()
+  })
+})
+
+test.describe('LTX 2.5 page — link targets', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(PATH)
+  })
+
+  test('breadcrumb trail links to the models catalog', async ({ page }) => {
+    const modelsCrumb = page
+      .getByRole('navigation', { name: t('ui.breadcrumb', 'en') })
+      .getByRole('link', { name: t('models.breadcrumb.models', 'en') })
+    await expect(modelsCrumb).toHaveAttribute('href', MODELS_ROUTE)
+  })
+
+  test('the hero run CTA opens the LTX 2.5 launch template', async ({
+    page
+  }) => {
+    const hero = page.locator('section').filter({
+      has: page.getByRole('heading', { level: 1, name: HERO_TITLE })
+    })
+    const runCta = hero.getByRole('link', {
+      name: t('ltx.hero.primaryCta', 'en')
+    })
+    await expect(runCta).toHaveAttribute('href', ltxPage.hero.primaryCta.href)
+    await expect(runCta).toHaveAttribute('href', LTX_RUN_TEMPLATE)
+    await expect(runCta).toHaveAttribute('target', '_blank')
+
+    await expect(
+      hero.getByRole('link', { name: t('ltx.hero.secondaryCta', 'en') })
+    ).toHaveAttribute('href', externalLinks.workflows)
+  })
+
+  test('MCP highlight card CTA links to the MCP page', async ({ page }) => {
+    const reviewsSection = page.locator('section').filter({
+      has: page.getByRole('heading', { level: 2, name: REVIEWS_HEADING })
+    })
+    const cta = reviewsSection.getByRole('link', { name: HIGHLIGHT_CTA })
+    await cta.scrollIntoViewIfNeeded()
+    await expect(cta).toHaveAttribute('href', MCP_ROUTE)
+  })
+})
+
+test.describe('LTX 2.5 page — mobile @mobile', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(PATH)
+  })
+
+  test('renders the hero heading at narrow viewports', async ({ page }) => {
+    await expect(
+      page.getByRole('heading', { level: 1, name: HERO_TITLE })
+    ).toBeVisible()
+  })
+})

--- a/apps/website/src/config/routes.test.ts
+++ b/apps/website/src/config/routes.test.ts
@@ -38,6 +38,16 @@ describe('getRoutes seedance', () => {
   })
 })
 
+describe('getRoutes ltx', () => {
+  it('serves the ltx page at its canonical path for en', () => {
+    expect(getRoutes('en').ltx).toBe('/ltx-2.5')
+  })
+
+  it('serves a localized ltx path for zh-CN', () => {
+    expect(getRoutes('zh-CN').ltx).toBe('/zh-CN/ltx-2.5')
+  })
+})
+
 describe('getRoutes minimax', () => {
   it('serves the minimax page at its canonical path for en', () => {
     expect(getRoutes('en').minimax).toBe('/minimax-h3')

--- a/apps/website/src/config/routes.ts
+++ b/apps/website/src/config/routes.ts
@@ -26,6 +26,7 @@ const baseRoutes = {
   minimax: '/minimax-h3',
   flux3: '/flux-3',
   seedance: '/seedance-2.5',
+  ltx: '/ltx-2.5',
   wanAnimate2: '/wan-animate-2',
   brand: '/brand'
 } as const

--- a/apps/website/src/data/ltx.ts
+++ b/apps/website/src/data/ltx.ts
@@ -5,10 +5,12 @@ import type {
 
 import { externalLinks } from '../config/routes'
 
-// Image-to-video is the LTX workflow people reach for first, so every "run LTX"
-// CTA opens that template on Cloud.
+// Image-to-video is the LTX workflow people reach for first, so the hero and the
+// free cards open that template on Cloud. The premium (pay-as-you-go) cards open
+// the partner-API first-last-frame template instead.
 const ltxLinks = {
-  cloudRun: 'https://cloud.comfy.org/?template=video_ltx2_5_i2v'
+  cloudRun: 'https://cloud.comfy.org/?template=video_ltx2_5_i2v',
+  cloudRunPremium: 'https://cloud.comfy.org/?template=api_ltx2_5_flf2v'
 } as const
 
 // LTX 2.5 clips, encoded to the site's web video profile (VP9 webm, 1200px wide,
@@ -136,7 +138,7 @@ export const ltxPage: ModelLaunchPage = {
           'zh-CN': '覆霜的宇航员仰望极光。'
         },
         media: media.astronaut,
-        href: ltxLinks.cloudRun
+        href: ltxLinks.cloudRunPremium
       },
       {
         id: 'horseman',
@@ -148,7 +150,7 @@ export const ltxPage: ModelLaunchPage = {
           'zh-CN': '身披长衣的骑手与马伫立云端，俯瞰地球。'
         },
         media: media.horseman,
-        href: ltxLinks.cloudRun
+        href: ltxLinks.cloudRunPremium
       }
     ]
   },

--- a/apps/website/src/data/ltx.ts
+++ b/apps/website/src/data/ltx.ts
@@ -1,0 +1,181 @@
+import type {
+  ModelLaunchMedia,
+  ModelLaunchPage
+} from '../templates/model-launch/types'
+
+import { externalLinks } from '../config/routes'
+
+// Image-to-video is the LTX workflow people reach for first, so every "run LTX"
+// CTA opens that template on Cloud.
+const ltxLinks = {
+  cloudRun: 'https://cloud.comfy.org/?template=video_ltx2_5_i2v'
+} as const
+
+// LTX 2.5 clips, encoded to the site's web video profile (VP9 webm, 1200px wide,
+// muted) and served from media.comfy.org. Posters are not published yet, so the
+// gallery opens on an empty frame until each clip loads, as /flux-3 does.
+const media = {
+  hero: {
+    kind: 'video',
+    src: 'https://media.comfy.org/website/ltx-2.5/hero.mp4'
+  },
+  blackbird: {
+    kind: 'video',
+    src: 'https://media.comfy.org/website/ltx-2.5/card-1.webm'
+  },
+  circuitry: {
+    kind: 'video',
+    src: 'https://media.comfy.org/website/ltx-2.5/card-2.webm'
+  },
+  portrait: {
+    kind: 'video',
+    src: 'https://media.comfy.org/website/ltx-2.5/card-3.webm'
+  },
+  drones: {
+    kind: 'video',
+    src: 'https://media.comfy.org/website/ltx-2.5/card-4.webm'
+  },
+  astronaut: {
+    kind: 'video',
+    src: 'https://media.comfy.org/website/ltx-2.5/card-5.webm'
+  },
+  horseman: {
+    kind: 'video',
+    src: 'https://media.comfy.org/website/ltx-2.5/card-6.webm'
+  }
+} as const satisfies Record<string, ModelLaunchMedia>
+
+const freeNote = { en: 'Included free', 'zh-CN': '免费包含' }
+const premiumNote = { en: 'Pay-as-you-go', 'zh-CN': '按量付费' }
+const modelName = { en: 'LTX 2.5', 'zh-CN': 'LTX 2.5' }
+
+export const ltxPage: ModelLaunchPage = {
+  metaTitleKey: 'ltx.meta.title',
+  metaDescriptionKey: 'ltx.meta.description',
+  breadcrumbLabelKey: 'ltx.breadcrumb.model',
+  breadcrumbUpdatedKey: 'ltx.breadcrumb.updated',
+  hero: {
+    videoSrc: media.hero.src,
+    titleKey: 'ltx.hero.title',
+    descriptionKey: 'ltx.hero.description',
+    primaryCta: {
+      labelKey: 'ltx.hero.primaryCta',
+      href: ltxLinks.cloudRun,
+      target: '_blank'
+    },
+    secondaryCta: {
+      labelKey: 'ltx.hero.secondaryCta',
+      href: externalLinks.workflows,
+      target: '_blank'
+    },
+    badgeKeys: [
+      'ltx.hero.tagOpenSource',
+      'ltx.hero.tagImageToVideo',
+      'ltx.hero.tagTextToVideo',
+      'ltx.hero.tagPartnerNode'
+    ]
+  },
+  gallery: {
+    headingKey: 'ltx.models.heading',
+    cards: [
+      {
+        id: 'blackbird',
+        name: modelName,
+        tier: 'free',
+        note: freeNote,
+        description: {
+          en: 'A fighter jet banks hard over a stormy, moonlit sea.',
+          'zh-CN': '战斗机在月光下的风暴海面上急转倾斜。'
+        },
+        media: media.blackbird,
+        href: ltxLinks.cloudRun
+      },
+      {
+        id: 'circuitry',
+        name: modelName,
+        tier: 'free',
+        note: freeNote,
+        description: {
+          en: 'Luminous figure drinks from a flower-filled glass.',
+          'zh-CN': '发光的人像举起插着白花的玻璃杯饮下。'
+        },
+        media: media.circuitry,
+        href: ltxLinks.cloudRun
+      },
+      {
+        id: 'portrait',
+        name: modelName,
+        tier: 'free',
+        note: freeNote,
+        description: {
+          en: 'A weathered face stares out from deep shadow.',
+          'zh-CN': '饱经风霜的面孔从深深的阴影中凝视。'
+        },
+        media: media.portrait,
+        href: ltxLinks.cloudRun
+      },
+      {
+        id: 'drones',
+        name: modelName,
+        tier: 'free',
+        note: freeNote,
+        description: {
+          en: 'Heavy-lift drones haul goats across a misty mountain range.',
+          'zh-CN': '重型无人机吊运山羊飞越雾气缭绕的山脉。'
+        },
+        media: media.drones,
+        href: ltxLinks.cloudRun
+      },
+      {
+        id: 'astronaut',
+        name: modelName,
+        tier: 'premium',
+        note: premiumNote,
+        description: {
+          en: 'A frost-covered astronaut gazes up at the aurora.',
+          'zh-CN': '覆霜的宇航员仰望极光。'
+        },
+        media: media.astronaut,
+        href: ltxLinks.cloudRun
+      },
+      {
+        id: 'horseman',
+        name: modelName,
+        tier: 'premium',
+        note: premiumNote,
+        description: {
+          en: 'A coated rider and horse stand atop the clouds above Earth.',
+          'zh-CN': '身披长衣的骑手与马伫立云端，俯瞰地球。'
+        },
+        media: media.horseman,
+        href: ltxLinks.cloudRun
+      }
+    ]
+  },
+  pricing: {
+    // Opens on monthly, as /minimax and /flux-3 do.
+    defaultBillingCycle: 'monthly',
+    banner: {
+      titleKey: 'ltx.pricing.banner.title',
+      subtitleKey: 'ltx.pricing.banner.subtitle',
+      cta: {
+        labelKey: 'ltx.pricing.banner.cta',
+        href: externalLinks.cloud,
+        target: '_blank'
+      }
+    }
+  },
+  runOptions: {
+    headingKey: 'ltx.runOptions.heading',
+    subtitleKey: 'ltx.runOptions.subtitle',
+    ctaKey: 'ltx.runOptions.cta'
+  },
+  reviews: {
+    headingKey: 'ltx.reviews.heading',
+    highlight: {
+      titleKey: 'ltx.reviews.highlightTitle',
+      descriptionKey: 'ltx.reviews.highlightDescription',
+      ctaKey: 'ltx.reviews.highlightCta'
+    }
+  }
+}

--- a/apps/website/src/data/ltx.ts
+++ b/apps/website/src/data/ltx.ts
@@ -5,17 +5,11 @@ import type {
 
 import { externalLinks } from '../config/routes'
 
-// Image-to-video is the LTX workflow people reach for first, so the hero and the
-// free cards open that template on Cloud. The premium (pay-as-you-go) cards open
-// the partner-API first-last-frame template instead.
 const ltxLinks = {
   cloudRun: 'https://cloud.comfy.org/?template=video_ltx2_5_i2v',
   cloudRunPremium: 'https://cloud.comfy.org/?template=api_ltx2_5_flf2v'
 } as const
 
-// LTX 2.5 clips, encoded to the site's web video profile (VP9 webm, 1200px wide,
-// muted) and served from media.comfy.org. Posters are not published yet, so the
-// gallery opens on an empty frame until each clip loads, as /flux-3 does.
 const media = {
   hero: {
     kind: 'video',
@@ -155,7 +149,6 @@ export const ltxPage: ModelLaunchPage = {
     ]
   },
   pricing: {
-    // Opens on monthly, as /minimax and /flux-3 do.
     defaultBillingCycle: 'monthly',
     banner: {
       titleKey: 'ltx.pricing.banner.title',

--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -4816,8 +4816,6 @@ const translations = {
     'zh-CN': '最新发布'
   },
 
-  // LTX 2.5 SEO page (/ltx-2.5). zh-CN hand-translated. Copy transcribed from the
-  // Figma launch frame; hero labels list four per review direction.
   'ltx.meta.title': {
     en: 'LTX 2.5 on Comfy — Open-Source AI Video Model',
     'zh-CN': 'Comfy 上的 LTX 2.5 — 开源 AI 视频模型'

--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -4816,6 +4816,80 @@ const translations = {
     'zh-CN': '最新发布'
   },
 
+  // LTX 2.5 SEO page (/ltx-2.5). zh-CN hand-translated. Copy transcribed from the
+  // Figma launch frame; hero labels list four per review direction.
+  'ltx.meta.title': {
+    en: 'LTX 2.5 on Comfy — Open-Source AI Video Model',
+    'zh-CN': 'Comfy 上的 LTX 2.5 — 开源 AI 视频模型'
+  },
+  'ltx.meta.description': {
+    en: 'Run LTX 2.5 on Comfy. Open weights, directed on the canvas alongside every other model, on Comfy Cloud or your own GPU.',
+    'zh-CN':
+      '在 Comfy 上运行 LTX 2.5。开放权重，可在画布上与其他所有模型一同执导，支持 Comfy Cloud 或你自己的 GPU。'
+  },
+  'ltx.breadcrumb.model': { en: 'LTX 2.5', 'zh-CN': 'LTX 2.5' },
+  'ltx.breadcrumb.updated': {
+    en: 'Updated August 2026',
+    'zh-CN': '更新于 2026 年 8 月'
+  },
+  'ltx.hero.title': {
+    en: 'LTX 2.5 is here',
+    'zh-CN': 'LTX 2.5 已上线'
+  },
+  'ltx.hero.description': {
+    en: 'LTX is the fastest video generation model on the planet, and this version sharpens prompt adherence, visuals, and audio quality across the board. With a new Diffusion Fidelity Rendering capability, fine textures, faces, and complex shots hold up at cinematic-grade detail.',
+    'zh-CN':
+      'LTX 是全球最快的视频生成模型，这一版本全面提升了提示词遵循度、画面表现与音频质量。凭借全新的 Diffusion Fidelity Rendering 能力，细腻的纹理、人物面部与复杂镜头都能保持电影级的细节。'
+  },
+  'ltx.hero.tagOpenSource': { en: 'Open Source', 'zh-CN': '开源' },
+  'ltx.hero.tagPartnerNode': { en: 'Partner Node', 'zh-CN': '合作伙伴节点' },
+  'ltx.hero.tagImageToVideo': { en: 'Image to Video', 'zh-CN': '图像转视频' },
+  'ltx.hero.tagTextToVideo': { en: 'Text to Video', 'zh-CN': '文本转视频' },
+  'ltx.models.heading': {
+    en: 'Made with LTX 2.5',
+    'zh-CN': '用 LTX 2.5 制作'
+  },
+  'ltx.hero.primaryCta': {
+    en: 'RUN LTX 2.5',
+    'zh-CN': '运行 LTX 2.5'
+  },
+  'ltx.hero.secondaryCta': { en: 'TRY WORKFLOWS', 'zh-CN': '试用工作流' },
+  'ltx.pricing.banner.title': {
+    en: "Start Comfy Cloud for free. Upgrade when you're ready.",
+    'zh-CN': '免费开始使用 Comfy Cloud，准备好了再升级。'
+  },
+  'ltx.pricing.banner.subtitle': {
+    en: '5 free runs on real GPUs — no credit card required.',
+    'zh-CN': '在真实 GPU 上免费运行 5 次 — 无需信用卡。'
+  },
+  'ltx.pricing.banner.cta': { en: 'TRY FREE', 'zh-CN': '免费试用' },
+  'ltx.runOptions.heading': {
+    en: 'One engine, every way to run it',
+    'zh-CN': '同一引擎，多种运行方式'
+  },
+  'ltx.runOptions.subtitle': {
+    en: 'Run LTX 2.5 in the browser today. Batch campaigns with the API, or bring it in-house.',
+    'zh-CN': '今天就在浏览器中运行 LTX 2.5。用 API 批量制作，或部署到自有环境。'
+  },
+  'ltx.runOptions.cta': {
+    en: 'LEARN MORE',
+    'zh-CN': '了解更多'
+  },
+  'ltx.reviews.heading': {
+    en: '4+ million Comfy creators say',
+    'zh-CN': '400 万+ Comfy 创作者这样说'
+  },
+  'ltx.reviews.highlightTitle': {
+    en: 'Comfy MCP: now turn your agent into a creative technologist.',
+    'zh-CN': 'Comfy MCP：让你的智能体成为创意技术专家。'
+  },
+  'ltx.reviews.highlightDescription': {
+    en: 'Your AI assistant can access the ecosystem, build workflows, and generate images, video, audio, or 3D.',
+    'zh-CN':
+      '你的 AI 助手可以接入整个生态、构建工作流，并生成图像、视频、音频或 3D 内容。'
+  },
+  'ltx.reviews.highlightCta': { en: 'GET STARTED', 'zh-CN': '开始使用' },
+
   // Seedance 2.5 SEO page (/seedance-2.5). zh-CN hand-translated; some body
   // copy carries placeholder intent from Figma and may change (June, CRE-145).
   'seedance.meta.title': {

--- a/apps/website/src/pages/ltx-2.5.astro
+++ b/apps/website/src/pages/ltx-2.5.astro
@@ -1,0 +1,6 @@
+---
+import ModelLaunchPage from '../templates/model-launch/ModelLaunchPage.astro'
+import { ltxPage } from '../data/ltx'
+---
+
+<ModelLaunchPage page={ltxPage} />

--- a/apps/website/src/pages/zh-CN/ltx-2.5.astro
+++ b/apps/website/src/pages/zh-CN/ltx-2.5.astro
@@ -1,0 +1,6 @@
+---
+import ModelLaunchPage from '../../templates/model-launch/ModelLaunchPage.astro'
+import { ltxPage } from '../../data/ltx'
+---
+
+<ModelLaunchPage page={ltxPage} />

--- a/apps/website/src/templates/model-launch/modelLaunchPages.test.ts
+++ b/apps/website/src/templates/model-launch/modelLaunchPages.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import { flux3Page } from '../../data/flux3'
+import { ltxPage } from '../../data/ltx'
 import { minimaxPage } from '../../data/minimax'
 import { seedancePage } from '../../data/seedance'
 import { wanAnimate2Page } from '../../data/wanAnimate2'
@@ -13,6 +14,7 @@ const pages: { name: string; page: ModelLaunchPage }[] = [
   { name: 'minimax', page: minimaxPage },
   { name: 'flux3', page: flux3Page },
   { name: 'seedance', page: seedancePage },
+  { name: 'ltx', page: ltxPage },
   { name: 'wanAnimate2', page: wanAnimate2Page }
 ]
 


### PR DESCRIPTION
## Summary

Adds `/ltx-2.5` and `/zh-CN/ltx-2.5` on the existing model-launch template, data-only, and wires the primary "RUN LTX 2.5" CTA to the launch template on Cloud.

## Changes

- **What**: New `data/ltx.ts` config + two page stubs, wired through the existing `ModelLaunchPage` template (no new components). Route + `ltx.*` translation keys (en / zh-CN). The primary hero CTA and every gallery card deep-link `https://cloud.comfy.org/?template=video_ltx2_5_i2v`, the way Seedance opens its run workflow. Secondary CTA keeps the workflows hub; the pricing banner keeps the free-tier Cloud entry. Four hero labels (Open Source, Image to Video, Text to Video, Partner Node), six gallery cards (four free, two premium). Media served from `media.comfy.org/website/ltx-2.5/` (`hero.mp4` + `card-1..6.webm`, all confirmed live).
- **Dependencies**: none

## Review Focus

- The one behavioral choice worth a look: the CTA target. `video_ltx2_5_i2v` now exists, so the primary CTA **and the gallery cards** point at it (matching Seedance). If you want only the hero button repointed and the cards left on the workflows hub, that is a one-line-per-card change.
- Gallery cards follow the `media: { kind, src }` model; this page ships no prompt boxes, so it reuses the existing template untouched.
- No posters yet for the gallery clips, so cards open on an empty frame until each webm loads (same as `/flux-3`); can follow up when posters reach the CDN.

## Verification

- `astro check`: 0 errors
- `vitest`: 38 tests pass (route + every-launch-page config checks, incl. the new LTX config: unique card ids, both-locale copy, absolute hrefs, media URL shape)
- `oxfmt --check` and `oxlint`: clean
- e2e (`e2e/ltx-2.5.spec.ts`): pins the "RUN LTX 2.5" CTA to the template URL (literal + config-derived), secondary → workflows, breadcrumb → catalog, MCP highlight → /mcp