### PR TITLE
chore(website): strip comments from the LTX 2.5 launch page

### DIFF
--- a/apps/website/e2e/ltx-2.5.spec.ts
+++ b/apps/website/e2e/ltx-2.5.spec.ts
@@ -14,8 +14,6 @@ const REVIEWS_HEADING = t('ltx.reviews.heading', 'en')
 const HIGHLIGHT_CTA = t('ltx.reviews.highlightCta', 'en')
 const MCP_ROUTE = getRoutes('en').mcp
 const FIRST_REVIEW = creatorReviews[0]
-// The launch template the "RUN LTX 2.5" button must open. Pinned as a literal so
-// repointing the CTA back at the generic hub fails here, not just in review.
 const LTX_RUN_TEMPLATE = 'https://cloud.comfy.org/?template=video_ltx2_5_i2v'
 
 test.describe('LTX 2.5 page — desktop @smoke', () => {

--- a/apps/website/src/data/ltx.ts
+++ b/apps/website/src/data/ltx.ts
@@ -5,17 +5,11 @@ import type {
 
 import { externalLinks } from '../config/routes'
 
-// Image-to-video is the LTX workflow people reach for first, so the hero and the
-// free cards open that template on Cloud. The premium (pay-as-you-go) cards open
-// the partner-API first-last-frame template instead.
 const ltxLinks = {
   cloudRun: 'https://cloud.comfy.org/?template=video_ltx2_5_i2v',
   cloudRunPremium: 'https://cloud.comfy.org/?template=api_ltx2_5_flf2v'
 } as const
 
-// LTX 2.5 clips, encoded to the site's web video profile (VP9 webm, 1200px wide,
-// muted) and served from media.comfy.org. Posters are not published yet, so the
-// gallery opens on an empty frame until each clip loads, as /flux-3 does.
 const media = {
   hero: {
     kind: 'video',
@@ -155,7 +149,6 @@ export const ltxPage: ModelLaunchPage = {
     ]
   },
   pricing: {
-    // Opens on monthly, as /minimax and /flux-3 do.
     defaultBillingCycle: 'monthly',
     banner: {
       titleKey: 'ltx.pricing.banner.title',

--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -4816,8 +4816,6 @@ const translations = {
     'zh-CN': '最新发布'
   },
 
-  // LTX 2.5 SEO page (/ltx-2.5). zh-CN hand-translated. Copy transcribed from the
-  // Figma launch frame; hero labels list four per review direction.
   'ltx.meta.title': {
     en: 'LTX 2.5 on Comfy — Open-Source AI Video Model',
     'zh-CN': 'Comfy 上的 LTX 2.5 — 开源 AI 视频模型'


### PR DESCRIPTION
## Summary

Removes the code comments from the LTX 2.5 launch files. No behavioral change.

## Changes

- **What**: Strips comments from `data/ltx.ts`, `e2e/ltx-2.5.spec.ts`, and the LTX block in `i18n/translations.ts`.

## Review Focus

- Follow-up to #15109, kept separate so that PR stays as approved. Stacked on its branch so this is a clean comments-only diff; merge after #15109 lands and the base retargets to `main`.