### PR TITLE
fix: restore body pointer-events when stacked dismissable layers close

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -322,8 +322,8 @@ catalogs:
       specifier: 4.2.5
       version: 4.2.5
     reka-ui:
-      specifier: 2.5.0
-      version: 2.5.0
+      specifier: 2.6.2
+      version: 2.6.2
     rollup-plugin-visualizer:
       specifier: ^6.0.4
       version: 6.0.11
@@ -610,7 +610,7 @@ importers:
         version: 4.2.5(vue@3.5.41(typescript@6.0.3))
       reka-ui:
         specifier: 'catalog:'
-        version: 2.5.0(typescript@6.0.3)(vue@3.5.41(typescript@6.0.3))
+        version: 2.6.2(typescript@6.0.3)(vue@3.5.41(typescript@6.0.3))
       semver:
         specifier: ^7.7.2
         version: 7.8.5
@@ -996,7 +996,7 @@ importers:
         version: 1.402.3
       reka-ui:
         specifier: 'catalog:'
-        version: 2.5.0(typescript@6.0.3)(vue@3.5.41(typescript@6.0.3))
+        version: 2.6.2(typescript@6.0.3)(vue@3.5.41(typescript@6.0.3))
       three:
         specifier: 'catalog:'
         version: 0.184.0
@@ -8138,8 +8138,8 @@ packages:
   rehype@13.0.2:
     resolution: {integrity: sha512-j31mdaRFrwFRUIlxGeuPXXKWQxet52RBQRvCmzl5eCefn/KGbomK5GMHNMsOJf55fgo3qw5tST5neDuarDYR2A==}
 
-  reka-ui@2.5.0:
-    resolution: {integrity: sha512-81aMAmJeVCy2k0E6x7n1kypDY6aM1ldLis5+zcdV1/JtoAlSDck5OBsyLRJU9CfgbrQp1ImnRnBSmC4fZ2fkZQ==}
+  reka-ui@2.6.2:
+    resolution: {integrity: sha512-aHyL22Eeb29WRt0MQwDmWSXLTnH7qIxrFexye8Ge/mKW0kymwaJrYDLMEEhlQ7G2PT/jJZtuldHCXjbVQIn0sA==}
     peerDependencies:
       vue: '>= 3.2.0'
 
@@ -17564,7 +17564,7 @@ snapshots:
       rehype-stringify: 10.0.1
       unified: 11.0.5
 
-  reka-ui@2.5.0(typescript@6.0.3)(vue@3.5.41(typescript@6.0.3)):
+  reka-ui@2.6.2(typescript@6.0.3)(vue@3.5.41(typescript@6.0.3)):
     dependencies:
       '@floating-ui/dom': 1.8.0
       '@floating-ui/vue': 1.1.11(vue@3.5.41(typescript@6.0.3))

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -116,7 +116,7 @@ catalog:
   pretty-bytes: ^7.1.0
   primeicons: ^7.0.0
   primevue: 4.2.5
-  reka-ui: 2.5.0
+  reka-ui: 2.6.2
   rollup-plugin-visualizer: ^6.0.4
   storybook: ^10.5.6
   stylelint: ^17.14.0

--- a/src/components/dialog/bodyPointerEventsRestore.test.ts
+++ b/src/components/dialog/bodyPointerEventsRestore.test.ts
@@ -1,0 +1,115 @@
+import { render } from '@testing-library/vue'
+import PrimeVue from 'primevue/config'
+import {
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuPortal,
+  DropdownMenuRoot,
+  DropdownMenuTrigger
+} from 'reka-ui'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { defineComponent, h, ref } from 'vue'
+import { createI18n } from 'vue-i18n'
+
+import GlobalDialog from '@/components/dialog/GlobalDialog.vue'
+import { useDialogStore } from '@/stores/dialogStore'
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: {
+    en: { g: { cancel: 'Cancel', close: 'Close', maximizeDialog: 'Maximize' } }
+  },
+  missingWarn: false,
+  fallbackWarn: false
+})
+
+const Body = defineComponent({
+  name: 'Body',
+  setup: () => () => h('p', 'body content')
+})
+
+const menuOpen = ref(false)
+
+const BodyWithMenu = defineComponent({
+  name: 'BodyWithMenu',
+  setup: () => () =>
+    h(
+      DropdownMenuRoot,
+      {
+        open: menuOpen.value,
+        'onUpdate:open': (open: boolean) => (menuOpen.value = open)
+      },
+      () => [
+        h(DropdownMenuTrigger, null, () => 'open menu'),
+        h(DropdownMenuPortal, null, () =>
+          h(DropdownMenuContent, null, () =>
+            h(DropdownMenuItem, null, () => 'item')
+          )
+        )
+      ]
+    )
+})
+
+const settle = () => new Promise<void>((resolve) => setTimeout(resolve, 0))
+
+function mountDialogHost() {
+  render(GlobalDialog, { global: { plugins: [PrimeVue, i18n] } })
+  return useDialogStore()
+}
+
+function openModal(
+  store: ReturnType<typeof useDialogStore>,
+  key: string,
+  component = Body
+) {
+  store.showDialog({
+    key,
+    title: key,
+    component,
+    dialogComponentProps: { renderer: 'reka', modal: true }
+  })
+}
+
+describe('body pointer-events after modal dialogs close', () => {
+  beforeEach(() => {
+    document.body.style.pointerEvents = ''
+    menuOpen.value = false
+  })
+
+  it('restores interactivity when the lower of two stacked dialogs closes first', async () => {
+    const store = mountDialogHost()
+
+    openModal(store, 'lower')
+    await settle()
+    openModal(store, 'upper')
+    await settle()
+    expect(document.body.style.pointerEvents).toBe('none')
+
+    store.closeDialog({ key: 'lower' })
+    await settle()
+    store.closeDialog({ key: 'upper' })
+    await settle()
+
+    expect(store.dialogStack).toHaveLength(0)
+    expect(document.body.style.pointerEvents).toBe('')
+  })
+
+  it('restores interactivity when a dialog closes while its menu is open', async () => {
+    const store = mountDialogHost()
+
+    openModal(store, 'dialog-with-menu', BodyWithMenu)
+    await settle()
+    menuOpen.value = true
+    await settle()
+    await settle()
+    expect(document.body.style.pointerEvents).toBe('none')
+
+    store.closeDialog({ key: 'dialog-with-menu' })
+    await settle()
+    await settle()
+
+    expect(store.dialogStack).toHaveLength(0)
+    expect(document.body.style.pointerEvents).toBe('')
+  })
+})


### PR DESCRIPTION
Root cause of the long-session "the app suddenly stops responding until I refresh" reports (FE-1594).

## What breaks

`reka-ui` <= 2.6.1 `DismissableLayer` saves the pre-lock `document.body.style.pointerEvents` in a **per-component-instance** variable, assigned only by the layer that observes an empty layer set:

```js
let originalBodyPointerEvents;                     // per instance, undefined by default
if (context.layersWithOutsidePointerEventsDisabled.size === 0) {
  originalBodyPointerEvents = body.style.pointerEvents;   // only the FIRST layer assigns
  body.style.pointerEvents = "none";
}
...
cleanupFn(() => {
  if (props.disableOutsidePointerEvents && context.layersWithOutsidePointerEventsDisabled.size === 1)
    body.style.pointerEvents = originalBodyPointerEvents;  // whichever layer teardown sees size === 1
});
```

With two layers, the one that assigned the value is not the one that restores it, so the restore assigns `undefined`. `body.style.pointerEvents = undefined` stringifies to `"undefined"`, which is not valid CSS — and per CSSOM an invalid value is a **no-op**, so the declaration keeps its previous value. Verified in Chromium 149:

```
body.style.pointerEvents = 'none'       -> "none"
body.style.pointerEvents = undefined    -> "none"   (computed: "none")
body.style.pointerEvents = ''           -> ""
```

`document.body { pointer-events: none }` then survives for the rest of the session. Nothing in the app ever clears it; only a reload does.

## What the user sees

Measured against the running app: with `body { pointer-events: none }`, `canvas#graph-canvas` computes to `pointer-events: none` and stops being the hit target (`document.elementFromPoint` over the graph returns `<html>`). Every node and every widget drawn on the canvas goes dead — including the LoadAudio "choose file to upload" button, which is why this surfaces as "it suddenly doesn't let me upload audio files".

The left sidebar is unaffected: `.side-bar-panel` sets `pointer-events-auto` (`LiteGraphCanvasSplitterOverlay.vue:38`), so it keeps hit-testing. The separately reported "sidebar stops being scrollable" symptom is therefore **not** this bug and is still open.

## Reachable how

Two layers with `disableOutsidePointerEvents` have to be alive at once, and the first-registered one has to tear down first. Both tests here are real flows:

- close a modal dialog while a menu/select/popover inside it is still open (the nested layer's cleanup runs after the dialog's);
- `dialogStore` stacks up to 10 dialogs and `closeDialog({ key })` closes any of them, so closing the lower one first is enough.

## Fix

Bump `reka-ui` 2.5.0 -> 2.6.2. Upstream fixed it in 2.6.2 by moving the saved value onto the shared layer context, moving the restore into the per-layer cleanup, and guarding it against a nullish value. 2.5.0 and 2.6.1 are affected; 2.6.2 through 2.10.3 are not.

## Verification

- Both new tests are red on 2.5.0 (`expected 'undefined' to be ''`) and green on 2.6.2 — the first commit is test-only for that reason.
- Full unit suite on 2.6.2: 1161 files, 15928 passed / 8 skipped, 0 failed.

- Fixes FE-1594 (partially: the canvas/upload half)

### No bespoke e2e, deliberately

The unrecoverable part of this bug is real-browser CSSOM behaviour, so an e2e would be the ideal home for it — but there is no stable handle on `dialogStore` from `browser_tests` (`comfyAPIPlugin` only shims `src/scripts` and `src/extensions/core`), and no existing spec opens a modal dialog containing a menu. Rather than build a flaky bespoke flow, the browser-side evidence is the Chromium measurement above, and the regression guard is the unit test plus the existing 16-shard Playwright suite, which exercises reka dialogs and menus broadly and runs against the bumped version on this PR.
