### PR TITLE
feat(website): link LTX 2.5 from the nav and footer, and serve its posters

### DIFF
--- a/apps/website/e2e/ltx-2.5.spec.ts
+++ b/apps/website/e2e/ltx-2.5.spec.ts
@@ -1,12 +1,13 @@
 import { expect } from '@playwright/test'
 
-import { externalLinks, getRoutes } from '../src/config/routes'
+import { getRoutes } from '../src/config/routes'
 import { creatorReviews } from '../src/data/creatorReviews'
 import { ltxPage } from '../src/data/ltx'
 import { t } from '../src/i18n/translations'
 import { test } from './fixtures/blockExternalMedia'
 
 const PATH = '/ltx-2.5'
+const ZH_PATH = '/zh-CN/ltx-2.5'
 const HERO_TITLE = t('ltx.hero.title', 'en')
 const MODELS_HEADING = t('ltx.models.heading', 'en')
 const MODELS_ROUTE = getRoutes('en').models
@@ -15,6 +16,12 @@ const HIGHLIGHT_CTA = t('ltx.reviews.highlightCta', 'en')
 const MCP_ROUTE = getRoutes('en').mcp
 const FIRST_REVIEW = creatorReviews[0]
 const LTX_RUN_TEMPLATE = 'https://cloud.comfy.org/?template=video_ltx2_5_i2v'
+const LTX_HUB_MODEL = 'https://comfy.org/workflows/model/ltx'
+
+const BADGE_KEYS = ltxPage.hero.badgeKeys ?? []
+
+const GALLERY = ltxPage.gallery
+if (!GALLERY) throw new Error('ltxPage must configure a gallery')
 
 test.describe('LTX 2.5 page — desktop @smoke', () => {
   test.beforeEach(async ({ page }) => {
@@ -36,6 +43,16 @@ test.describe('LTX 2.5 page — desktop @smoke', () => {
     })
     await heading.scrollIntoViewIfNeeded()
     await expect(heading).toBeVisible()
+  })
+
+  test('renders every configured hero badge', async ({ page }) => {
+    const hero = page.locator('section').filter({
+      has: page.getByRole('heading', { level: 1, name: HERO_TITLE })
+    })
+
+    for (const key of BADGE_KEYS) {
+      await expect(hero.getByText(t(key, 'en'), { exact: true })).toBeVisible()
+    }
   })
 
   test('renders the reviews section heading and first quote', async ({
@@ -76,9 +93,14 @@ test.describe('LTX 2.5 page — link targets', () => {
     await expect(runCta).toHaveAttribute('href', LTX_RUN_TEMPLATE)
     await expect(runCta).toHaveAttribute('target', '_blank')
 
-    await expect(
-      hero.getByRole('link', { name: t('ltx.hero.secondaryCta', 'en') })
-    ).toHaveAttribute('href', externalLinks.workflows)
+    const secondary = hero.getByRole('link', {
+      name: t('ltx.hero.secondaryCta', 'en')
+    })
+    await expect(secondary).toHaveAttribute(
+      'href',
+      ltxPage.hero.secondaryCta?.href ?? ''
+    )
+    await expect(secondary).toHaveAttribute('href', LTX_HUB_MODEL)
   })
 
   test('MCP highlight card CTA links to the MCP page', async ({ page }) => {
@@ -91,6 +113,65 @@ test.describe('LTX 2.5 page — link targets', () => {
   })
 })
 
+test.describe('LTX 2.5 gallery', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(PATH)
+    await page
+      .getByRole('heading', { level: 2, name: MODELS_HEADING })
+      .scrollIntoViewIfNeeded()
+  })
+
+  test('ships every card, titled as the Figma titles it', async ({ page }) => {
+    // Scoped to the gallery: the testimonial carousel below also uses <article>.
+    const gallery = page.locator('section').filter({
+      has: page.getByRole('heading', { level: 2, name: MODELS_HEADING })
+    })
+    await expect(gallery.locator('article')).toHaveCount(GALLERY.cards.length)
+
+    for (const card of GALLERY.cards) {
+      await expect(
+        gallery.getByText(card.description.en, { exact: true })
+      ).toBeVisible()
+    }
+  })
+
+  test('every gallery clip carries a poster', async ({ page }) => {
+    const gallery = page.locator('section').filter({
+      has: page.getByRole('heading', { level: 2, name: MODELS_HEADING })
+    })
+    const videos = gallery.locator('video')
+    await expect(videos).toHaveCount(GALLERY.cards.length)
+
+    for (const card of GALLERY.cards) {
+      if (card.media.kind !== 'video') continue
+      expect(card.media.posterSrc, `${card.id} needs a poster`).toBeTruthy()
+      await expect(
+        gallery.locator(`video[poster="${card.media.posterSrc}"]`)
+      ).toHaveCount(1)
+    }
+  })
+})
+
+test.describe('LTX 2.5 page — zh-CN', () => {
+  test('renders the localized hero and reviews', async ({ page }) => {
+    await page.goto(ZH_PATH)
+
+    await expect(
+      page.getByRole('heading', {
+        level: 1,
+        name: t('ltx.hero.title', 'zh-CN')
+      })
+    ).toBeVisible()
+
+    const reviews = page.getByRole('heading', {
+      level: 2,
+      name: t('ltx.reviews.heading', 'zh-CN')
+    })
+    await reviews.scrollIntoViewIfNeeded()
+    await expect(reviews).toBeVisible()
+  })
+})
+
 test.describe('LTX 2.5 page — mobile @mobile', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto(PATH)
@@ -100,5 +181,25 @@ test.describe('LTX 2.5 page — mobile @mobile', () => {
     await expect(
       page.getByRole('heading', { level: 1, name: HERO_TITLE })
     ).toBeVisible()
+  })
+
+  test('hero CTA stays inside the viewport', async ({ page }) => {
+    const cta = page
+      .locator('section')
+      .filter({
+        has: page.getByRole('heading', { level: 1, name: HERO_TITLE })
+      })
+      .getByRole('link', { name: t('ltx.hero.primaryCta', 'en') })
+
+    await expect(cta).toBeVisible()
+
+    const box = await cta.boundingBox()
+    const viewport = page.viewportSize()
+    if (!box || !viewport) throw new Error('hero CTA has no layout box')
+
+    // Both edges, so a CTA overflowing left cannot pass. One pixel of tolerance
+    // for subpixel rounding.
+    expect(box.x).toBeGreaterThanOrEqual(-1)
+    expect(box.x + box.width).toBeLessThanOrEqual(viewport.width + 1)
   })
 })

--- a/apps/website/e2e/ltx-2.5.spec.ts
+++ b/apps/website/e2e/ltx-2.5.spec.ts
@@ -18,6 +18,11 @@ const FIRST_REVIEW = creatorReviews[0]
 const LTX_RUN_TEMPLATE = 'https://cloud.comfy.org/?template=video_ltx2_5_i2v'
 const LTX_HUB_MODEL = 'https://comfy.org/workflows/model/ltx'
 
+// Counts are fixed rather than read off the config: four labels and six cards are
+// the launch requirement, and deriving them would let a dropped one pass.
+const REQUIRED_BADGES = 4
+const REQUIRED_CARDS = 6
+
 const BADGE_KEYS = ltxPage.hero.badgeKeys ?? []
 
 const GALLERY = ltxPage.gallery
@@ -45,7 +50,9 @@ test.describe('LTX 2.5 page — desktop @smoke', () => {
     await expect(heading).toBeVisible()
   })
 
-  test('renders every configured hero badge', async ({ page }) => {
+  test('renders all four hero badges', async ({ page }) => {
+    expect(BADGE_KEYS).toHaveLength(REQUIRED_BADGES)
+
     const hero = page.locator('section').filter({
       has: page.getByRole('heading', { level: 1, name: HERO_TITLE })
     })
@@ -121,12 +128,14 @@ test.describe('LTX 2.5 gallery', () => {
       .scrollIntoViewIfNeeded()
   })
 
-  test('ships every card, titled as the Figma titles it', async ({ page }) => {
+  test('ships all six cards, titled as the Figma titles them', async ({
+    page
+  }) => {
     // Scoped to the gallery: the testimonial carousel below also uses <article>.
     const gallery = page.locator('section').filter({
       has: page.getByRole('heading', { level: 2, name: MODELS_HEADING })
     })
-    await expect(gallery.locator('article')).toHaveCount(GALLERY.cards.length)
+    await expect(gallery.locator('article')).toHaveCount(REQUIRED_CARDS)
 
     for (const card of GALLERY.cards) {
       await expect(
@@ -140,7 +149,7 @@ test.describe('LTX 2.5 gallery', () => {
       has: page.getByRole('heading', { level: 2, name: MODELS_HEADING })
     })
     const videos = gallery.locator('video')
-    await expect(videos).toHaveCount(GALLERY.cards.length)
+    await expect(videos).toHaveCount(REQUIRED_CARDS)
 
     for (const card of GALLERY.cards) {
       if (card.media.kind !== 'video') continue
@@ -156,12 +165,12 @@ test.describe('LTX 2.5 page — zh-CN', () => {
   test('renders the localized hero and reviews', async ({ page }) => {
     await page.goto(ZH_PATH)
 
-    await expect(
-      page.getByRole('heading', {
-        level: 1,
-        name: t('ltx.hero.title', 'zh-CN')
-      })
-    ).toBeVisible()
+    const heading = page.getByRole('heading', { level: 1 })
+    await expect(heading).toBeVisible()
+    // Chinese present and the English title absent, so serving the en copy under
+    // the zh route fails here rather than passing on a key lookup.
+    await expect(heading).toContainText(/[一-鿿]/)
+    await expect(heading).not.toHaveText(HERO_TITLE)
 
     const reviews = page.getByRole('heading', {
       level: 2,
@@ -183,7 +192,7 @@ test.describe('LTX 2.5 page — mobile @mobile', () => {
     ).toBeVisible()
   })
 
-  test('hero CTA stays inside the viewport', async ({ page }) => {
+  test('hero CTA stays within the viewport width', async ({ page }) => {
     const cta = page
       .locator('section')
       .filter({
@@ -198,7 +207,8 @@ test.describe('LTX 2.5 page — mobile @mobile', () => {
     if (!box || !viewport) throw new Error('hero CTA has no layout box')
 
     // Both edges, so a CTA overflowing left cannot pass. One pixel of tolerance
-    // for subpixel rounding.
+    // for subpixel rounding. Vertical position is not asserted: the hero leads
+    // with the video, so the CTA sits below the fold by design.
     expect(box.x).toBeGreaterThanOrEqual(-1)
     expect(box.x + box.width).toBeLessThanOrEqual(viewport.width + 1)
   })

--- a/apps/website/src/components/common/SiteFooter.vue
+++ b/apps/website/src/components/common/SiteFooter.vue
@@ -42,7 +42,8 @@ const topColumns: { title: string; links: FooterLink[] }[] = [
       { label: t('nav.supportedModels', locale), href: routes.models },
       { label: t('footer.minimaxH3', locale), href: routes.minimax },
       { label: t('footer.seedance', locale), href: routes.seedance },
-      { label: t('footer.wanAnimate2', locale), href: routes.wanAnimate2 }
+      { label: t('footer.wanAnimate2', locale), href: routes.wanAnimate2 },
+      { label: t('footer.ltx', locale), href: routes.ltx }
     ]
   },
   {

--- a/apps/website/src/data/ltx.ts
+++ b/apps/website/src/data/ltx.ts
@@ -7,37 +7,45 @@ import { externalLinks } from '../config/routes'
 
 const ltxLinks = {
   cloudRun: 'https://cloud.comfy.org/?template=video_ltx2_5_i2v',
-  cloudRunPremium: 'https://cloud.comfy.org/?template=api_ltx2_5_flf2v'
+  cloudRunPremium: 'https://cloud.comfy.org/?template=api_ltx2_5_flf2v',
+  hubModel: `${externalLinks.workflows}/model/ltx`
 } as const
 
 const media = {
   hero: {
     kind: 'video',
-    src: 'https://media.comfy.org/website/ltx-2.5/hero.mp4'
+    src: 'https://media.comfy.org/website/ltx-2.5/hero.mp4',
+    posterSrc: 'https://media.comfy.org/website/ltx-2.5/hero-poster.webp'
   },
   blackbird: {
     kind: 'video',
-    src: 'https://media.comfy.org/website/ltx-2.5/card-1.webm'
+    src: 'https://media.comfy.org/website/ltx-2.5/card-1.webm',
+    posterSrc: 'https://media.comfy.org/website/ltx-2.5/card-1.webp'
   },
   circuitry: {
     kind: 'video',
-    src: 'https://media.comfy.org/website/ltx-2.5/card-2.webm'
+    src: 'https://media.comfy.org/website/ltx-2.5/card-2.webm',
+    posterSrc: 'https://media.comfy.org/website/ltx-2.5/card-2.webp'
   },
   portrait: {
     kind: 'video',
-    src: 'https://media.comfy.org/website/ltx-2.5/card-3.webm'
+    src: 'https://media.comfy.org/website/ltx-2.5/card-3.webm',
+    posterSrc: 'https://media.comfy.org/website/ltx-2.5/card-3.webp'
   },
   drones: {
     kind: 'video',
-    src: 'https://media.comfy.org/website/ltx-2.5/card-4.webm'
+    src: 'https://media.comfy.org/website/ltx-2.5/card-4.webm',
+    posterSrc: 'https://media.comfy.org/website/ltx-2.5/card-4.webp'
   },
   astronaut: {
     kind: 'video',
-    src: 'https://media.comfy.org/website/ltx-2.5/card-5.webm'
+    src: 'https://media.comfy.org/website/ltx-2.5/card-5.webm',
+    posterSrc: 'https://media.comfy.org/website/ltx-2.5/card-5.webp'
   },
   horseman: {
     kind: 'video',
-    src: 'https://media.comfy.org/website/ltx-2.5/card-6.webm'
+    src: 'https://media.comfy.org/website/ltx-2.5/card-6.webm',
+    posterSrc: 'https://media.comfy.org/website/ltx-2.5/card-6.webp'
   }
 } as const satisfies Record<string, ModelLaunchMedia>
 
@@ -52,6 +60,7 @@ export const ltxPage: ModelLaunchPage = {
   breadcrumbUpdatedKey: 'ltx.breadcrumb.updated',
   hero: {
     videoSrc: media.hero.src,
+    posterSrc: media.hero.posterSrc,
     titleKey: 'ltx.hero.title',
     descriptionKey: 'ltx.hero.description',
     primaryCta: {
@@ -61,7 +70,7 @@ export const ltxPage: ModelLaunchPage = {
     },
     secondaryCta: {
       labelKey: 'ltx.hero.secondaryCta',
-      href: externalLinks.workflows,
+      href: ltxLinks.hubModel,
       target: '_blank'
     },
     badgeKeys: [

--- a/apps/website/src/data/mainNavigation.ts
+++ b/apps/website/src/data/mainNavigation.ts
@@ -48,13 +48,13 @@ export function getMainNavigation(locale: Locale): NavItem[] {
       label: t('nav.products', locale),
       badge: 'new',
       featured: {
-        imageSrc: 'https://media.comfy.org/website/nav/minimax-card.webp',
+        imageSrc: 'https://media.comfy.org/website/nav/ltx-card.webp',
         imageAlt: t('nav.featuredProductsAlt', locale),
         title: t('nav.featuredProductsTitle', locale),
         cta: {
           label: t('nav.featuredProductsCta', locale),
           ariaLabel: t('nav.featuredProductsCtaAria', locale),
-          href: routes.minimax
+          href: routes.ltx
         }
       },
       columns: [

--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -2563,20 +2563,20 @@ const translations = {
   // Featured dropdown cards — keys are keyed by parent nav item, not card content,
   // so the copy can be swapped without renaming the key.
   'nav.featuredProductsTitle': {
-    en: 'NEW RELEASE: MINIMAX H3',
-    'zh-CN': '全新发布：MiniMax H3'
+    en: 'NEW RELEASE: LTX 2.5',
+    'zh-CN': '全新发布：LTX 2.5'
   },
   'nav.featuredProductsAlt': {
-    en: 'MiniMax H3 feature image',
-    'zh-CN': 'MiniMax H3 精选图片'
+    en: 'LTX 2.5 feature image',
+    'zh-CN': 'LTX 2.5 精选图片'
   },
   'nav.featuredProductsCta': {
     en: 'TRY WORKFLOW',
     'zh-CN': '试用工作流'
   },
   'nav.featuredProductsCtaAria': {
-    en: 'Try the MiniMax H3 workflow',
-    'zh-CN': '试用 MiniMax H3 工作流'
+    en: 'Try the LTX 2.5 workflow',
+    'zh-CN': '试用 LTX 2.5 工作流'
   },
   'nav.featuredCommunityTitle': {
     en: 'Sky Replacement',
@@ -5402,6 +5402,7 @@ const translations = {
     'zh-CN': '开始使用'
   },
   'footer.wanAnimate2': { en: 'Wan Animate 2', 'zh-CN': 'Wan Animate 2' },
+  'footer.ltx': { en: 'LTX 2.5', 'zh-CN': 'LTX 2.5' },
   'modelLaunch.copyPrompt': { en: 'Copy prompt', 'zh-CN': '复制提示词' },
   'minimax.meta.title': {
     en: 'MiniMax H3 on Comfy — Open-Weight Video Model',


### PR DESCRIPTION
## Summary

Follow-up to #15109. Links the new `/ltx-2.5` page from the site, serves posters for its clips, and points the secondary hero CTA at a page that actually surfaces LTX workflows.

Stacked on `deepme987/website/ltx-2.5-launch`; retarget to `main` once #15109 merges.

## Changes

- **Nav + footer**: the Products dropdown featured card moves from MiniMax H3 to `NEW RELEASE: LTX 2.5`, and `/ltx-2.5` joins the footer Products column after Wan Animate 2. The featured-card keys are named after the nav item, not the card content, so only the values change. Card art is `nav/ltx-card.webp`, cropped to the slot's 4:3 at 744x558 to match `minimax-card.webp`.
- **Posters**: `hero-poster.webp` and `card-1..6.webp` were already on the CDN but unused, so the hero and all six gallery cards painted as empty boxes until ~8MB of video arrived. Wired as `posterSrc`, per the `ModelLaunchMedia` guidance that only `/flux-3` should omit them.
- **Try Workflows**: the secondary CTA pointed at the generic hub, where LTX 2.5 is not findable. Now `comfy.org/workflows/model/ltx`, matching the `hubSlug` pattern in `model-metadata.ts`. The LTX 2.5 workflow slugs still 404 on the hub, so this is the live target that also picks them up automatically once the hub redeploys.

## Review Focus

- The hub target is the model page, not an individual workflow. `/workflows/video_ltx2_5_i2v` is still a 404, so linking it directly would ship a dead CTA.
- Restores e2e coverage the launch PR did not carry: the zh-CN page had none.

## Verification

- `astro check`: 0 errors
- `vitest`: 394 pass
- `playwright e2e/ltx-2.5.spec.ts`: 12 pass; `navigation.spec.ts` + `wan-animate-2.spec.ts`: 27 pass
- Mutation-checked the two new assertions: dropping one card's `posterSrc` and reverting the CTA fails exactly those two tests
- Built output carries 7 `poster` attributes and no remaining `minimax-card.webp`
