### PR TITLE
fix(featureFlags): resolve nodeLibraryEssentialsEnabled through resolveFlag

### DIFF
--- a/src/composables/useFeatureFlags.test.ts
+++ b/src/composables/useFeatureFlags.test.ts
@@ -183,6 +183,48 @@ describe('useFeatureFlags', () => {
     })
   })
 
+  describe('nodeLibraryEssentialsEnabled', () => {
+    beforeEach(() => {
+      vi.mocked(distributionTypes).isNightly = true
+    })
+
+    afterEach(() => {
+      vi.mocked(distributionTypes).isNightly = false
+      remoteConfig.value = {}
+    })
+
+    it('defaults on when nightly serves no value for the flag', () => {
+      vi.mocked(api.getServerFeature).mockImplementation(
+        (_path, defaultValue) => defaultValue
+      )
+
+      const { flags } = useFeatureFlags()
+      expect(flags.nodeLibraryEssentialsEnabled).toBe(true)
+    })
+
+    it('lets a remote config false turn off the nightly default', () => {
+      remoteConfig.value = { node_library_essentials_enabled: false }
+      vi.mocked(api.getServerFeature).mockImplementation(
+        (_path, defaultValue) => defaultValue
+      )
+
+      const { flags } = useFeatureFlags()
+      expect(flags.nodeLibraryEssentialsEnabled).toBe(false)
+    })
+
+    it('lets a served server false turn off the nightly default', () => {
+      vi.mocked(api.getServerFeature).mockImplementation(
+        (path, defaultValue) =>
+          path === ServerFeatureFlag.NODE_LIBRARY_ESSENTIALS_ENABLED
+            ? false
+            : defaultValue
+      )
+
+      const { flags } = useFeatureFlags()
+      expect(flags.nodeLibraryEssentialsEnabled).toBe(false)
+    })
+  })
+
   describe('partnerNodeGovernanceEnabled', () => {
     afterEach(() => {
       remoteConfig.value = {}

--- a/src/composables/useFeatureFlags.test.ts
+++ b/src/composables/useFeatureFlags.test.ts
@@ -512,6 +512,19 @@ describe('useFeatureFlags', () => {
       expect(flags.workflowSharingEnabled).toBe(false)
     })
 
+    it('turns the node library essentials tab off against an enabled remote config', () => {
+      vi.mocked(getSessionOverride).mockImplementation((flagKey) =>
+        flagKey === ServerFeatureFlag.NODE_LIBRARY_ESSENTIALS_ENABLED
+          ? false
+          : undefined
+      )
+      remoteConfig.value = { node_library_essentials_enabled: true }
+      vi.mocked(api.getServerFeature).mockReturnValue(true)
+
+      const { flags } = useFeatureFlags()
+      expect(flags.nodeLibraryEssentialsEnabled).toBe(false)
+    })
+
     it('beats the auth-window fallback on auth-gated flags', () => {
       vi.mocked(distributionTypes).isCloud = true
       remoteConfigState.value = 'unloaded'

--- a/src/composables/useFeatureFlags.ts
+++ b/src/composables/useFeatureFlags.ts
@@ -151,14 +151,10 @@ export function useFeatureFlags() {
       return api.getServerFeature(ServerFeatureFlag.NODE_REPLACEMENTS, false)
     },
     get nodeLibraryEssentialsEnabled() {
-      if (isNightly || import.meta.env.DEV) return true
-
-      return (
-        remoteConfig.value.node_library_essentials_enabled ??
-        api.getServerFeature(
-          ServerFeatureFlag.NODE_LIBRARY_ESSENTIALS_ENABLED,
-          false
-        )
+      return resolveFlag(
+        ServerFeatureFlag.NODE_LIBRARY_ESSENTIALS_ENABLED,
+        remoteConfig.value.node_library_essentials_enabled,
+        isNightly || import.meta.env.DEV
       )
     },
     get workflowSharingEnabled() {


### PR DESCRIPTION
## Summary

`nodeLibraryEssentialsEnabled` hand-rolled its own resolution and read remote config *before* the override layers, so `?ff=node_library_essentials_enabled:false` and the `ff:` localStorage dev override were both silently ignored — this getter now goes through the shared `resolveFlag` helper like every other remote-config-backed flag.

## Changes

- **What**: `nodeLibraryEssentialsEnabled` now calls `resolveFlag(...)`, so precedence is session override → dev override → remote config → server value, matching every other flag in `useFeatureFlags`. The nightly/dev default-on moves *below* the override lookup: `isNightly || import.meta.env.DEV` becomes `resolveFlag`'s `defaultValue` instead of an unconditional early `return true`.
- **Behavior**: on a stable/production build nothing changes (`isNightly || DEV` is `false` there, which is the default the old code already passed). Two deltas, both intentional: (1) an employee `?ff=` link or an `ff:` dev override now actually changes the Essentials tab, and (2) on nightly and local dev builds an explicitly-served value (`/features` remote config or the server feature flag) now wins over the built-in on — previously nothing could turn the Essentials tab off locally, which is half of the reported bug.
- **Tests**: one case in the existing `session override precedence` block asserting a `false` session override beats a `true` remote-config value, plus a `nodeLibraryEssentialsEnabled` block covering the nightly axis — nightly + nothing served → on, nightly + remote-config `false` → off, nightly + served server `false` → off. All three `false` cases are red on `main` (it returns `true`) and green with the fix.

## Review Focus

- Chesterton's fence on the early return: `git log -L` shows the getter arrived in #9067, whose description states the intent as *"Defaults to `true` in dev/nightly builds, `false` in production. Overridable via remote config or server feature flags"* — i.e. dev/nightly was always meant as a **default**, and the early return only reads as a hard override because the `?ff=` session layer (#15033) landed ~6 months later and this getter never opted in. Making it `resolveFlag`'s `defaultValue` is the shape that commit describes.
- The one visible change beyond override precedence is nightly/dev now honoring an explicitly-served `false` (item 2 above). Flagging it explicitly rather than burying it: it is the intended semantics, but it is a behavior change for anyone on nightly whose `/features` endpoint serves this flag. The cursor-review panel raised this; it is now pinned by the `nodeLibraryEssentialsEnabled` test block.
- `linearToggleEnabled` has the same `if (isNightly) return true` short-circuit above its `resolveFlag` call and is un-overridable on nightly for the same reason. Deliberately left alone here to keep this diff to one getter; worth a separate change.

## Test Plan

- `pnpm exec vitest run src/composables/useFeatureFlags.test.ts src/components/sidebar/tabs/NodeLibrarySidebarTabV2.test.ts src/components/searchbox/v2/NodeSearchContent.test.ts` — 79 passed (the two component specs are the flag's consumers).
- `pnpm typecheck` — clean. `oxfmt --check` and `eslint` on both changed files — clean.

