### PR TITLE
fix(api): report embeddings connectivity failures without discarding A1111 imports

### DIFF
--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2363,6 +2363,7 @@
     "exportSuccess": "Successfully exported model as {format}",
     "fileLoadError": "Unable to find workflow in {fileName}",
     "a1111CoreNodesUnavailable": "Could not load the workflow because this ComfyUI installation is missing core nodes. Check that the backend started correctly.",
+    "a1111EmbeddingsUnavailable": "Could not load embeddings from the server.",
     "dropFileError": "Unable to process dropped item: {error}",
     "missingMediaVerificationFailed": "Failed to verify missing media. Some inputs may not be shown in the Errors tab.",
     "missingModelVerificationFailed": "Failed to verify missing models. Some models may not be shown in the Errors tab.",

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2363,7 +2363,7 @@
     "exportSuccess": "Successfully exported model as {format}",
     "fileLoadError": "Unable to find workflow in {fileName}",
     "a1111CoreNodesUnavailable": "Could not load the workflow because this ComfyUI installation is missing core nodes. Check that the backend started correctly.",
-    "a1111EmbeddingsUnavailable": "Could not load embeddings from the server.",
+    "a1111EmbeddingsUnavailable": "Embeddings could not be loaded from the server. The workflow was imported, but embedding names were left as plain text.",
     "dropFileError": "Unable to process dropped item: {error}",
     "missingMediaVerificationFailed": "Failed to verify missing media. Some inputs may not be shown in the Errors tab.",
     "missingModelVerificationFailed": "Failed to verify missing models. Some models may not be shown in the Errors tab.",

--- a/src/schemas/apiSchema.ts
+++ b/src/schemas/apiSchema.ts
@@ -195,7 +195,7 @@ export type NotificationWsMessage = z.infer<typeof zNotificationWsMessage>
 export const zTaskOutput = z.record(zNodeId, zOutputs)
 export type TaskOutput = z.infer<typeof zTaskOutput>
 
-const zEmbeddingsResponse = z.array(z.string())
+export const zEmbeddingsResponse = z.array(z.string())
 const zExtensionsResponse = z.array(z.string())
 const zError = z.object({
   type: z.string(),

--- a/src/scripts/api.getEmbeddings.test.ts
+++ b/src/scripts/api.getEmbeddings.test.ts
@@ -1,0 +1,49 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { EmbeddingsApiError, api } from '@/scripts/api'
+
+describe('api.getEmbeddings', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn())
+  })
+
+  it('returns the parsed embeddings', async () => {
+    vi.mocked(global.fetch).mockResolvedValue(
+      new Response(JSON.stringify(['embedding-a', 'embedding-b']), {
+        status: 200
+      })
+    )
+
+    await expect(api.getEmbeddings()).resolves.toEqual([
+      'embedding-a',
+      'embedding-b'
+    ])
+  })
+
+  it('throws EmbeddingsApiError for a failed JSON response', async () => {
+    vi.mocked(global.fetch).mockResolvedValue(
+      new Response(JSON.stringify({ error: 'Internal Server Error' }), {
+        status: 500
+      })
+    )
+
+    const request = api.getEmbeddings()
+
+    await expect(request).rejects.toBeInstanceOf(EmbeddingsApiError)
+    await expect(request).rejects.toHaveProperty('status', 500)
+  })
+
+  it('throws EmbeddingsApiError for a failed HTML response', async () => {
+    vi.mocked(global.fetch).mockResolvedValue(
+      new Response('<html>Internal Server Error</html>', {
+        status: 500,
+        headers: { 'Content-Type': 'text/html' }
+      })
+    )
+
+    const request = api.getEmbeddings()
+
+    await expect(request).rejects.toBeInstanceOf(EmbeddingsApiError)
+    await expect(request).rejects.toHaveProperty('status', 500)
+  })
+})

--- a/src/scripts/api.getEmbeddings.test.ts
+++ b/src/scripts/api.getEmbeddings.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { EmbeddingsApiError, api } from '@/scripts/api'
+import { api } from '@/scripts/api'
 
 describe('api.getEmbeddings', () => {
   beforeEach(() => {
@@ -20,30 +20,38 @@ describe('api.getEmbeddings', () => {
     ])
   })
 
-  it('throws EmbeddingsApiError for a failed JSON response', async () => {
+  it('rejects a non-OK response with the route and status', async () => {
     vi.mocked(global.fetch).mockResolvedValue(
       new Response(JSON.stringify({ error: 'Internal Server Error' }), {
         status: 500
       })
     )
 
-    const request = api.getEmbeddings()
-
-    await expect(request).rejects.toBeInstanceOf(EmbeddingsApiError)
-    await expect(request).rejects.toHaveProperty('status', 500)
+    await expect(api.getEmbeddings()).rejects.toThrow(
+      'Failed to fetch /embeddings: 500'
+    )
   })
 
-  it('throws EmbeddingsApiError for a failed HTML response', async () => {
+  it('rejects a successful response with a non-JSON body', async () => {
     vi.mocked(global.fetch).mockResolvedValue(
       new Response('<html>Internal Server Error</html>', {
-        status: 500,
+        status: 200,
         headers: { 'Content-Type': 'text/html' }
       })
     )
 
-    const request = api.getEmbeddings()
+    await expect(api.getEmbeddings()).rejects.toBeInstanceOf(SyntaxError)
+  })
 
-    await expect(request).rejects.toBeInstanceOf(EmbeddingsApiError)
-    await expect(request).rejects.toHaveProperty('status', 500)
+  it('rejects a successful response with the wrong shape', async () => {
+    vi.mocked(global.fetch).mockResolvedValue(
+      new Response(JSON.stringify({ embeddings: ['embedding-a'] }), {
+        status: 200
+      })
+    )
+
+    await expect(api.getEmbeddings()).rejects.toMatchObject({
+      name: 'ZodError'
+    })
   })
 })

--- a/src/scripts/api.ts
+++ b/src/scripts/api.ts
@@ -19,7 +19,10 @@ import type {
 import { isCloud } from '@/platform/distribution/types'
 import { useToastStore } from '@/platform/updates/common/toastStore'
 import type { ShareableAssetsResponse } from '@/schemas/apiSchema'
-import { zShareableAssetsResponse } from '@/schemas/apiSchema'
+import {
+  zEmbeddingsResponse,
+  zShareableAssetsResponse
+} from '@/schemas/apiSchema'
 import type {
   TemplateIncludeOnDistributionEnum,
   WorkflowTemplates
@@ -209,13 +212,6 @@ interface ApiMessage<T extends keyof ApiCalls> {
 }
 
 export class UnauthorizedError extends Error {}
-
-export class EmbeddingsApiError extends Error {
-  constructor(readonly status: number) {
-    super(`Failed to load embeddings: ${status}`)
-    this.name = 'EmbeddingsApiError'
-  }
-}
 
 /** Ensures workers get a fair shake. */
 type Unionize<T> = T[keyof T]
@@ -1013,9 +1009,9 @@ export class ComfyApi extends EventTarget {
   async getEmbeddings(): Promise<EmbeddingsResponse> {
     const resp = await this.fetchApi('/embeddings', { cache: 'no-store' })
     if (!resp.ok) {
-      throw new EmbeddingsApiError(resp.status)
+      throw new Error(`Failed to fetch /embeddings: ${resp.status}`)
     }
-    return await resp.json()
+    return zEmbeddingsResponse.parse(await resp.json())
   }
 
   /**

--- a/src/scripts/api.ts
+++ b/src/scripts/api.ts
@@ -210,6 +210,13 @@ interface ApiMessage<T extends keyof ApiCalls> {
 
 export class UnauthorizedError extends Error {}
 
+export class EmbeddingsApiError extends Error {
+  constructor(readonly status: number) {
+    super(`Failed to load embeddings: ${status}`)
+    this.name = 'EmbeddingsApiError'
+  }
+}
+
 /** Ensures workers get a fair shake. */
 type Unionize<T> = T[keyof T]
 
@@ -1005,6 +1012,9 @@ export class ComfyApi extends EventTarget {
    */
   async getEmbeddings(): Promise<EmbeddingsResponse> {
     const resp = await this.fetchApi('/embeddings', { cache: 'no-store' })
+    if (!resp.ok) {
+      throw new EmbeddingsApiError(resp.status)
+    }
     return await resp.json()
   }
 

--- a/src/scripts/api.ts
+++ b/src/scripts/api.ts
@@ -1005,6 +1005,7 @@ export class ComfyApi extends EventTarget {
 
   /**
    * Gets a list of embedding names
+   * @throws When the request fails or the response does not match the schema
    */
   async getEmbeddings(): Promise<EmbeddingsResponse> {
     const resp = await this.fetchApi('/embeddings', { cache: 'no-store' })

--- a/src/scripts/app.test.ts
+++ b/src/scripts/app.test.ts
@@ -1598,6 +1598,23 @@ describe('ComfyApp', () => {
       expect(mockWorkflowService.afterLoadNewGraph).not.toHaveBeenCalled()
     })
 
+    it('shows a server error when A1111 embeddings are unavailable', async () => {
+      const graph = new LGraph()
+      const parameters = 'positive\nNegative prompt: negative\nSteps: 20'
+      Reflect.set(app, 'rootGraphInternal', graph)
+      vi.mocked(getWorkflowDataFromFile).mockResolvedValue({ parameters })
+      mockImportA1111.mockResolvedValue('embeddings-unavailable')
+
+      await app.handleFile(createTestFile('a1111.png', 'image/png'))
+
+      expect(mockToastStore.addAlert).toHaveBeenCalledOnce()
+      expect(mockToastStore.addAlert).toHaveBeenCalledWith(
+        'Could not load embeddings from the server.'
+      )
+      expect(mockWorkflowService.beforeLoadNewGraph).not.toHaveBeenCalled()
+      expect(mockWorkflowService.afterLoadNewGraph).not.toHaveBeenCalled()
+    })
+
     it('awaits persistence and orders its clear callback before setGraph', async () => {
       const graph = new LGraph()
       const parameters = 'positive\nNegative prompt: negative\nSteps: 20'

--- a/src/scripts/app.test.ts
+++ b/src/scripts/app.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { t } from '@/i18n'
 import { LGraph, LGraphNode, LiteGraph } from '@/lib/litegraph/src/litegraph'
 import type { LGraphCanvas } from '@/lib/litegraph/src/litegraph'
 import type {
@@ -1563,14 +1564,15 @@ describe('ComfyApp', () => {
         outcome: 'core-nodes-unavailable' as const,
         fileName: 'a1111.png',
         toastMethod: 'addAlert' as const,
-        expectedToast:
-          'Could not load the workflow because this ComfyUI installation is missing core nodes. Check that the backend started correctly.'
+        expectedToast: t('toastMessages.a1111CoreNodesUnavailable')
       },
       {
         outcome: 'not-a1111' as const,
         fileName: 'parameters.png',
         toastMethod: 'addAlert' as const,
-        expectedToast: 'Unable to find workflow in parameters.png'
+        expectedToast: t('toastMessages.fileLoadError', {
+          fileName: 'parameters.png'
+        })
       },
       {
         outcome: 'imported-without-embeddings' as const,
@@ -1578,9 +1580,8 @@ describe('ComfyApp', () => {
         toastMethod: 'add' as const,
         expectedToast: {
           severity: 'warn',
-          summary: 'Warning',
-          detail:
-            'Embeddings could not be loaded from the server. The workflow was imported, but embedding names were left as plain text.'
+          summary: t('g.warning'),
+          detail: t('toastMessages.a1111EmbeddingsUnavailable')
         }
       }
     ])('maps $outcome to its message', async (testCase) => {

--- a/src/scripts/app.test.ts
+++ b/src/scripts/app.test.ts
@@ -1558,61 +1558,52 @@ describe('ComfyApp', () => {
       consoleError.mockRestore()
     })
 
-    it('preserves the current graph when A1111 core nodes are unavailable', async () => {
+    it.for([
+      {
+        outcome: 'core-nodes-unavailable' as const,
+        fileName: 'a1111.png',
+        toastMethod: 'addAlert' as const,
+        expectedToast:
+          'Could not load the workflow because this ComfyUI installation is missing core nodes. Check that the backend started correctly.'
+      },
+      {
+        outcome: 'not-a1111' as const,
+        fileName: 'parameters.png',
+        toastMethod: 'addAlert' as const,
+        expectedToast: 'Unable to find workflow in parameters.png'
+      },
+      {
+        outcome: 'imported-without-embeddings' as const,
+        fileName: 'a1111.png',
+        toastMethod: 'add' as const,
+        expectedToast: {
+          severity: 'warn',
+          summary: 'Warning',
+          detail:
+            'Embeddings could not be loaded from the server. The workflow was imported, but embedding names were left as plain text.'
+        }
+      }
+    ])('maps $outcome to its message', async (testCase) => {
       const graph = new LGraph()
       const parameters = 'positive\nNegative prompt: negative\nSteps: 20'
       Reflect.set(app, 'rootGraphInternal', graph)
       vi.mocked(getWorkflowDataFromFile).mockResolvedValue({ parameters })
-      mockImportA1111.mockResolvedValue('core-nodes-unavailable')
+      mockImportA1111.mockResolvedValue(testCase.outcome)
 
-      await app.handleFile(createTestFile('a1111.png', 'image/png'))
+      await app.handleFile(createTestFile(testCase.fileName, 'image/png'))
 
       expect(mockImportA1111).toHaveBeenCalledWith(
         graph,
         parameters,
         expect.any(Function)
       )
-      expect(mockCanvas.setGraph).not.toHaveBeenCalled()
-      expect(mockWorkflowService.beforeLoadNewGraph).not.toHaveBeenCalled()
-      expect(mockWorkflowService.afterLoadNewGraph).not.toHaveBeenCalled()
-      expect(mockToastStore.addAlert).toHaveBeenCalledOnce()
-      expect(mockToastStore.addAlert).toHaveBeenCalledWith(
-        'Could not load the workflow because this ComfyUI installation is missing core nodes. Check that the backend started correctly.'
+      expect(mockToastStore[testCase.toastMethod]).toHaveBeenCalledOnce()
+      expect(mockToastStore[testCase.toastMethod]).toHaveBeenCalledWith(
+        testCase.expectedToast
       )
-    })
-
-    it('shows one file-load error when parameters are not A1111-shaped', async () => {
-      const graph = new LGraph()
-      const parameters = 'positive\nSteps: 20'
-      Reflect.set(app, 'rootGraphInternal', graph)
-      vi.mocked(getWorkflowDataFromFile).mockResolvedValue({ parameters })
-      mockImportA1111.mockResolvedValue('not-a1111')
-
-      await app.handleFile(createTestFile('parameters.png', 'image/png'))
-
-      expect(mockToastStore.addAlert).toHaveBeenCalledOnce()
-      expect(mockToastStore.addAlert).toHaveBeenCalledWith(
-        'Unable to find workflow in parameters.png'
-      )
-      expect(mockWorkflowService.beforeLoadNewGraph).not.toHaveBeenCalled()
-      expect(mockWorkflowService.afterLoadNewGraph).not.toHaveBeenCalled()
-    })
-
-    it('shows a server error when A1111 embeddings are unavailable', async () => {
-      const graph = new LGraph()
-      const parameters = 'positive\nNegative prompt: negative\nSteps: 20'
-      Reflect.set(app, 'rootGraphInternal', graph)
-      vi.mocked(getWorkflowDataFromFile).mockResolvedValue({ parameters })
-      mockImportA1111.mockResolvedValue('embeddings-unavailable')
-
-      await app.handleFile(createTestFile('a1111.png', 'image/png'))
-
-      expect(mockToastStore.addAlert).toHaveBeenCalledOnce()
-      expect(mockToastStore.addAlert).toHaveBeenCalledWith(
-        'Could not load embeddings from the server.'
-      )
-      expect(mockWorkflowService.beforeLoadNewGraph).not.toHaveBeenCalled()
-      expect(mockWorkflowService.afterLoadNewGraph).not.toHaveBeenCalled()
+      if (testCase.outcome === 'imported-without-embeddings') {
+        expect(mockWorkflowService.afterLoadNewGraph).toHaveBeenCalledOnce()
+      }
     })
 
     it('awaits persistence and orders its clear callback before setGraph', async () => {

--- a/src/scripts/app.test.ts
+++ b/src/scripts/app.test.ts
@@ -1604,6 +1604,8 @@ describe('ComfyApp', () => {
       )
       if (testCase.outcome === 'imported-without-embeddings') {
         expect(mockWorkflowService.afterLoadNewGraph).toHaveBeenCalledOnce()
+      } else {
+        expect(mockWorkflowService.afterLoadNewGraph).not.toHaveBeenCalled()
       }
     })
 

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -2026,6 +2026,10 @@ export class ComfyApp {
         useToastStore().addAlert(t('toastMessages.a1111CoreNodesUnavailable'))
         return
       }
+      if (outcome === 'embeddings-unavailable') {
+        useToastStore().addAlert(t('toastMessages.a1111EmbeddingsUnavailable'))
+        return
+      }
       if (outcome === 'not-a1111') {
         this.showErrorOnFileLoad(file)
         return

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -2022,17 +2022,28 @@ export class ComfyApp {
         useWorkflowService().beforeLoadNewGraph()
         this.canvas.setGraph(this.rootGraph)
       })
-      if (outcome === 'core-nodes-unavailable') {
-        useToastStore().addAlert(t('toastMessages.a1111CoreNodesUnavailable'))
-        return
-      }
-      if (outcome === 'embeddings-unavailable') {
-        useToastStore().addAlert(t('toastMessages.a1111EmbeddingsUnavailable'))
-        return
-      }
-      if (outcome === 'not-a1111') {
-        this.showErrorOnFileLoad(file)
-        return
+      switch (outcome) {
+        case 'core-nodes-unavailable':
+          useToastStore().addAlert(t('toastMessages.a1111CoreNodesUnavailable'))
+          return
+        case 'not-a1111':
+          this.showErrorOnFileLoad(file)
+          return
+        case 'imported-without-embeddings':
+          useToastStore().add({
+            severity: 'warn',
+            summary: t('g.warning'),
+            detail: t('toastMessages.a1111EmbeddingsUnavailable')
+          })
+          break
+        case 'imported':
+          break
+        default: {
+          const unexpectedOutcome: never = outcome
+          throw new Error(
+            `Unhandled A1111 import outcome: ${unexpectedOutcome}`
+          )
+        }
       }
       await useWorkflowService().afterLoadNewGraph(
         fileName,

--- a/src/scripts/pnginfo.test.ts
+++ b/src/scripts/pnginfo.test.ts
@@ -344,4 +344,24 @@ describe('importA1111', () => {
         .map((node) => node?.widgets?.[0].value)
     ).toEqual(['positive', expectedNegativePrompt])
   })
+
+  it('prefixes known embedding names in prompts', async () => {
+    const graph = new LGraph()
+    vi.mocked(api.getEmbeddings).mockResolvedValue(['easynegative'])
+    mockAvailableCoreNodes(graph)
+
+    const imported = await importA1111(
+      graph,
+      'masterpiece\nNegative prompt: EasyNegative, blurry\nSteps: 20'
+    )
+
+    expect(imported).toBe('imported')
+    expect(
+      vi
+        .mocked(LiteGraph.createNode)
+        .mock.results.map(({ value }) => value)
+        .filter((node) => node?.type === 'CLIPTextEncode')
+        .map((node) => node?.widgets?.[0].value)
+    ).toEqual(['masterpiece', 'embedding:EasyNegative, blurry'])
+  })
 })

--- a/src/scripts/pnginfo.test.ts
+++ b/src/scripts/pnginfo.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it, vi } from 'vitest'
 
 import { LGraph, LGraphNode, LiteGraph } from '@/lib/litegraph/src/litegraph'
 
-import { EmbeddingsApiError, api } from './api'
+import { api } from './api'
 import { getFromAvifFile } from './metadata/avif'
 import { getFromFlacFile } from './metadata/flac'
 import { getFromPngFile } from './metadata/png'
@@ -17,12 +17,8 @@ import {
   importA1111
 } from './pnginfo'
 
-vi.mock('./api', () => ({
-  EmbeddingsApiError: class EmbeddingsApiError extends Error {
-    constructor(readonly status: number) {
-      super(`Failed to load embeddings: ${status}`)
-    }
-  },
+vi.mock('./api', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('./api')>()),
   api: {
     getEmbeddings: vi.fn()
   }
@@ -254,53 +250,7 @@ describe('importA1111', () => {
   const parametersWithoutNegativePrompt =
     'positive\nSteps: 20, Sampler: Euler, CFG scale: 7, Seed: 1, Size: 512x512, Model: model.safetensors'
 
-  it.each([
-    ['has no steps', 'positive'],
-    ['has no options', 'positive\nNegative prompt: negative\nSteps:']
-  ])('returns not-a1111 when parameters %s', async (_case, input) => {
-    const graph = new LGraph()
-    const beforeGraphClear = vi.fn()
-    vi.mocked(api.getEmbeddings).mockResolvedValue([])
-
-    const imported = await importA1111(graph, input, beforeGraphClear)
-
-    expect(imported).toBe('not-a1111')
-    expect(beforeGraphClear).not.toHaveBeenCalled()
-  })
-
-  it('returns core-nodes-unavailable without clearing the graph', async () => {
-    const graph = new LGraph()
-    const clear = vi.spyOn(graph, 'clear')
-    const beforeGraphClear = vi.fn()
-    vi.mocked(api.getEmbeddings).mockResolvedValue([])
-    vi.spyOn(LiteGraph, 'createNode').mockReturnValue(null)
-
-    const imported = await importA1111(graph, parameters, beforeGraphClear)
-
-    expect(imported).toBe('core-nodes-unavailable')
-    expect(beforeGraphClear).not.toHaveBeenCalled()
-    expect(clear).not.toHaveBeenCalled()
-  })
-
-  it('returns embeddings-unavailable when loading embeddings fails', async () => {
-    const graph = new LGraph()
-    const beforeGraphClear = vi.fn()
-    vi.mocked(api.getEmbeddings).mockRejectedValue(new EmbeddingsApiError(500))
-
-    const imported = await importA1111(graph, parameters, beforeGraphClear)
-
-    expect(imported).toBe('embeddings-unavailable')
-    expect(beforeGraphClear).not.toHaveBeenCalled()
-  })
-
-  it.each([
-    ['with a negative prompt', parameters, 'negative'],
-    ['without a negative prompt', parametersWithoutNegativePrompt, '']
-  ])('imports parameters %s', async (_case, input, expectedNegativePrompt) => {
-    const graph = new LGraph()
-    const clear = vi.spyOn(graph, 'clear')
-    const beforeGraphClear = vi.fn()
-    vi.mocked(api.getEmbeddings).mockResolvedValue([])
+  function mockAvailableCoreNodes(graph: LGraph) {
     vi.spyOn(console, 'warn').mockImplementation(() => {})
     vi.spyOn(graph, 'arrange').mockImplementation(() => {})
     vi.spyOn(LiteGraph, 'createNode').mockImplementation((type) => {
@@ -312,6 +262,72 @@ describe('importA1111', () => {
       vi.spyOn(node, 'connect').mockReturnValue(null)
       return node
     })
+  }
+
+  it.each([
+    ['has no steps', 'positive'],
+    ['has no options', 'positive\nNegative prompt: negative\nSteps:']
+  ])('does not load embeddings when parameters %s', async (_case, input) => {
+    const graph = new LGraph()
+    const beforeGraphClear = vi.fn()
+    vi.mocked(api.getEmbeddings).mockRejectedValue(
+      new TypeError('Failed to fetch')
+    )
+
+    const imported = await importA1111(graph, input, beforeGraphClear)
+
+    expect(imported).toBe('not-a1111')
+    expect(api.getEmbeddings).not.toHaveBeenCalled()
+    expect(beforeGraphClear).not.toHaveBeenCalled()
+  })
+
+  it('returns core-nodes-unavailable without clearing the graph', async () => {
+    const graph = new LGraph()
+    const clear = vi.spyOn(graph, 'clear')
+    const beforeGraphClear = vi.fn()
+    vi.mocked(api.getEmbeddings).mockRejectedValue(
+      new TypeError('Failed to fetch')
+    )
+    vi.spyOn(LiteGraph, 'createNode').mockReturnValue(null)
+
+    const imported = await importA1111(graph, parameters, beforeGraphClear)
+
+    expect(imported).toBe('core-nodes-unavailable')
+    expect(api.getEmbeddings).not.toHaveBeenCalled()
+    expect(beforeGraphClear).not.toHaveBeenCalled()
+    expect(clear).not.toHaveBeenCalled()
+  })
+
+  it('imports without embedding substitution when loading embeddings fails', async () => {
+    const graph = new LGraph()
+    const clear = vi.spyOn(graph, 'clear')
+    const beforeGraphClear = vi.fn()
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    vi.mocked(api.getEmbeddings).mockRejectedValue(
+      new TypeError('Failed to fetch')
+    )
+    mockAvailableCoreNodes(graph)
+
+    const imported = await importA1111(graph, parameters, beforeGraphClear)
+
+    expect(imported).toBe('imported-without-embeddings')
+    expect(beforeGraphClear).toHaveBeenCalledOnce()
+    expect(clear).toHaveBeenCalledOnce()
+    expect(consoleError).toHaveBeenCalledWith(
+      'Failed to load embeddings for A1111 import:',
+      expect.any(TypeError)
+    )
+  })
+
+  it.each([
+    ['with a negative prompt', parameters, 'negative'],
+    ['without a negative prompt', parametersWithoutNegativePrompt, '']
+  ])('imports parameters %s', async (_case, input, expectedNegativePrompt) => {
+    const graph = new LGraph()
+    const clear = vi.spyOn(graph, 'clear')
+    const beforeGraphClear = vi.fn()
+    vi.mocked(api.getEmbeddings).mockResolvedValue([])
+    mockAvailableCoreNodes(graph)
 
     const imported = await importA1111(graph, input, beforeGraphClear)
 

--- a/src/scripts/pnginfo.test.ts
+++ b/src/scripts/pnginfo.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it, vi } from 'vitest'
 
 import { LGraph, LGraphNode, LiteGraph } from '@/lib/litegraph/src/litegraph'
 
-import { api } from './api'
+import { EmbeddingsApiError, api } from './api'
 import { getFromAvifFile } from './metadata/avif'
 import { getFromFlacFile } from './metadata/flac'
 import { getFromPngFile } from './metadata/png'
@@ -18,6 +18,11 @@ import {
 } from './pnginfo'
 
 vi.mock('./api', () => ({
+  EmbeddingsApiError: class EmbeddingsApiError extends Error {
+    constructor(readonly status: number) {
+      super(`Failed to load embeddings: ${status}`)
+    }
+  },
   api: {
     getEmbeddings: vi.fn()
   }
@@ -275,6 +280,17 @@ describe('importA1111', () => {
     expect(imported).toBe('core-nodes-unavailable')
     expect(beforeGraphClear).not.toHaveBeenCalled()
     expect(clear).not.toHaveBeenCalled()
+  })
+
+  it('returns embeddings-unavailable when loading embeddings fails', async () => {
+    const graph = new LGraph()
+    const beforeGraphClear = vi.fn()
+    vi.mocked(api.getEmbeddings).mockRejectedValue(new EmbeddingsApiError(500))
+
+    const imported = await importA1111(graph, parameters, beforeGraphClear)
+
+    expect(imported).toBe('embeddings-unavailable')
+    expect(beforeGraphClear).not.toHaveBeenCalled()
   })
 
   it.each([

--- a/src/scripts/pnginfo.ts
+++ b/src/scripts/pnginfo.ts
@@ -1,7 +1,8 @@
 import { LGraph, LGraphNode, LiteGraph } from '@/lib/litegraph/src/litegraph'
 import type { IBaseWidget } from '@/lib/litegraph/src/types/widgets'
+import type { EmbeddingsResponse } from '@/schemas/apiSchema'
 
-import { api } from './api'
+import { EmbeddingsApiError, api } from './api'
 import { getFromAvifFile } from './metadata/avif'
 import { getFromFlacFile } from './metadata/flac'
 import { getFromPngFile } from './metadata/png'
@@ -198,6 +199,7 @@ export type A1111ImportOutcome =
   | 'imported'
   | 'not-a1111'
   | 'core-nodes-unavailable'
+  | 'embeddings-unavailable'
 
 export async function importA1111(
   graph: LGraph,
@@ -207,7 +209,15 @@ export async function importA1111(
   const normalizedParameters = normalizeA1111Parameters(parameters)
   const p = normalizedParameters.lastIndexOf('\nSteps:')
   if (p > -1) {
-    const embeddings = await api.getEmbeddings()
+    let embeddings: EmbeddingsResponse
+    try {
+      embeddings = await api.getEmbeddings()
+    } catch (error) {
+      if (error instanceof EmbeddingsApiError) {
+        return 'embeddings-unavailable'
+      }
+      throw error
+    }
     const matchResult = normalizedParameters
       .substr(p)
       .split('\n')[1]

--- a/src/scripts/pnginfo.ts
+++ b/src/scripts/pnginfo.ts
@@ -1,8 +1,7 @@
 import { LGraph, LGraphNode, LiteGraph } from '@/lib/litegraph/src/litegraph'
 import type { IBaseWidget } from '@/lib/litegraph/src/types/widgets'
-import type { EmbeddingsResponse } from '@/schemas/apiSchema'
 
-import { EmbeddingsApiError, api } from './api'
+import { api } from './api'
 import { getFromAvifFile } from './metadata/avif'
 import { getFromFlacFile } from './metadata/flac'
 import { getFromPngFile } from './metadata/png'
@@ -197,9 +196,9 @@ function normalizeA1111Parameters(parameters: string): string {
 
 export type A1111ImportOutcome =
   | 'imported'
+  | 'imported-without-embeddings'
   | 'not-a1111'
   | 'core-nodes-unavailable'
-  | 'embeddings-unavailable'
 
 export async function importA1111(
   graph: LGraph,
@@ -209,15 +208,6 @@ export async function importA1111(
   const normalizedParameters = normalizeA1111Parameters(parameters)
   const p = normalizedParameters.lastIndexOf('\nSteps:')
   if (p > -1) {
-    let embeddings: EmbeddingsResponse
-    try {
-      embeddings = await api.getEmbeddings()
-    } catch (error) {
-      if (error instanceof EmbeddingsApiError) {
-        return 'embeddings-unavailable'
-      }
-      throw error
-    }
     const matchResult = normalizedParameters
       .substr(p)
       .split('\n')[1]
@@ -363,6 +353,14 @@ export async function importA1111(
         delete opts[name]
         return v
       }
+
+      const { embeddings, embeddingsLoaded } = await api
+        .getEmbeddings()
+        .then((embeddings) => ({ embeddings, embeddingsLoaded: true }))
+        .catch((error: unknown) => {
+          console.error('Failed to load embeddings for A1111 import:', error)
+          return { embeddings: [], embeddingsLoaded: false }
+        })
 
       beforeGraphClear?.()
       graph.clear()
@@ -587,7 +585,7 @@ export async function importA1111(
       if (Object.keys(opts).length) {
         console.warn('Unhandled parameters:', opts)
       }
-      return 'imported'
+      return embeddingsLoaded ? 'imported' : 'imported-without-embeddings'
     }
   }
   return 'not-a1111'


### PR DESCRIPTION
## ELI5

When the server cannot provide the embeddings list during an A1111 image import, the app used to blame the file ("Unable to find workflow in …"). Now it reports the real problem — and still imports the workflow, just without embedding-name substitution.

## Motivation

#14655 — `api.getEmbeddings()` ignored `resp.ok`. A 500 with a JSON body silently produced an empty embeddings list; a 500 with an HTML body threw `SyntaxError`, which surfaced as "Unable to find workflow". An adversarial review round of the first pass showed the most common failure — backend down, `fetch` rejecting with `TypeError` — was still uncovered, so the design moved from typed-error catching to a resilient degrade path at the single consumer.

## Provenance

- **Authored by:** `interactive session`
- **From:** #14655 — getEmbeddings ignores resp.ok, so server errors surface as "Unable to find workflow"
- **Verified:** Targeted Vitest suites (73 tests) across two review rounds incl. a multi-lane adversarial pass; `pnpm typecheck`, `pnpm lint`, `pnpm knip`, `pnpm format:check`, `git diff --check` passed. Coverage proof: reverting the degrade catch fails the `TypeError` regression test.

## Summary

- `getEmbeddings` rejects on non-ok responses (route + status in the message) and parses the body with `zEmbeddingsResponse` instead of resolving with an unchecked cast.
- The A1111 import fetches embeddings only for actual A1111 files, directly before its single consumer — so a dead backend surfaces the more actionable `core-nodes-unavailable` message instead.
- Any embeddings failure (HTTP error, invalid body, network rejection) logs and degrades to an empty list; the import completes with a new `'imported-without-embeddings'` outcome shown as a warning toast.
- The outcome dispatch in `handleFile` is an exhaustive `switch`, so the compiler flags future unhandled outcomes.

## Compatibility note

`getEmbeddings` on the supported `window.comfyAPI` surface now rejects on non-ok or invalid responses instead of resolving with an unusable value.

## Test plan

- [x] Non-ok JSON, non-JSON body, and wrong-shape 200 responses each reject via a distinct branch.
- [x] `TypeError` from fetch degrades the import instead of aborting; warning toast shown; regression test proven red without the fix.
- [x] Non-A1111 files never trigger the embeddings request.
- [x] Full targeted suites and static gates pass.

Fixes #14655
