### PR TITLE
chore: update Ingest API types from cloud

### DIFF
--- a/packages/ingest-types/src/types.gen.ts
+++ b/packages/ingest-types/src/types.gen.ts
@@ -2103,6 +2103,10 @@ export type JobEntry = {
     [key: string]: unknown
   }
   /**
+   * Count of outputs classified as previewable media types (images, video, audio, 3D, text) — a subset of outputs_count (omitted for non-terminal states)
+   */
+  previewable_outputs_count?: number
+  /**
    * User-friendly job status
    */
   status: 'pending' | 'in_progress' | 'completed' | 'failed' | 'cancelled'
@@ -2277,6 +2281,10 @@ export type JobDetailResponse = {
   preview_output?: {
     [key: string]: unknown
   }
+  /**
+   * Count of outputs classified as previewable media types (images, video, audio, 3D, text) — a subset of outputs_count (omitted for non-terminal states)
+   */
+  previewable_outputs_count?: number
   /**
    * User-friendly job status
    */
@@ -3368,7 +3376,7 @@ export type CancelSubscriptionResponse = {
    */
   billing_op_id: string
   /**
-   * The date when the subscription will end (end of current billing period)
+   * The terminal cancellation time for a delinquent Stripe subscription, otherwise the end of the current billing period
    */
   cancel_at: string
 }
@@ -3401,8 +3409,8 @@ export type BulkRevokeApiKeysResponse = {
 export type BillingStatusResponse = {
   /**
    * Present when the pending operation cannot proceed without the
-   * customer. Today this is a Stripe-hosted payment page for a
-   * subscription whose first invoice needs authentication (SCA/3DS);
+   * customer. Today this is a Stripe-hosted payment page for an invoice
+   * needing authentication (SCA/3DS);
    * send the customer there to complete payment. Mirrors the field of
    * the same name on BillingOpStatusResponse.
    *
@@ -3438,10 +3446,21 @@ export type BillingStatusResponse = {
    * client recover a payment it has lost the local reference to — a
    * cleared browser, or simply a different device from the one that
    * started it — by polling /billing/ops/{id} without having stored the
-   * id. Absent when no operation is pending.
+   * id. Absent when no operation is pending, and for non-owners, who
+   * cannot act on one.
    *
    */
   pending_billing_op_id?: string
+  /**
+   * How the client should resume `pending_billing_op_id`, not the
+   * internal operation type: a plan change reports `subscription`,
+   * because it resumes exactly like one. A top-up resumes with a
+   * different timeout and completion path, so the two cannot be
+   * told apart by the client. Present whenever
+   * `pending_billing_op_id` is.
+   *
+   */
+  pending_billing_op_type?: 'subscription' | 'topup'
   /**
    * Plan identifier (e.g., standard-monthly, team-pro-annual)
    */
@@ -4581,13 +4600,55 @@ export type ListAssetsData = {
   path?: never
   query?: {
     /**
-     * Filter assets that have ALL of these tags
+     * Deprecated alias for `tags_all`, kept permanently for existing
+     * callers. Filter assets that have ALL of these tags. Combining it
+     * with `tags_all`, or exceeding 100 tags (counted after removing
+     * empty values and duplicates), returns 400 `INVALID_TAG_FILTER`.
+     *
+     *
+     * @deprecated
      */
     include_tags?: Array<string>
     /**
-     * Exclude assets that have ANY of these tags
+     * Deprecated alias for `tags_none`, kept permanently for existing
+     * callers. Exclude assets that have ANY of these tags. Combining it
+     * with `tags_none`, or exceeding 100 tags (counted after removing
+     * empty values and duplicates), returns 400 `INVALID_TAG_FILTER`.
+     *
+     *
+     * @deprecated
      */
     exclude_tags?: Array<string>
+    /**
+     * Filter assets that have ALL of these tags. Tag values are opaque
+     * byte-strings compared exactly and case-sensitively; unknown tags
+     * are not an error — they simply match nothing. Replaces the
+     * deprecated `include_tags`. Sending both spellings, listing the
+     * same tag here and in `tags_none`, or exceeding 100 tags per list
+     * (counted after removing empty values and duplicates) returns 400
+     * `INVALID_TAG_FILTER`.
+     *
+     */
+    tags_all?: Array<string>
+    /**
+     * Filter assets that have AT LEAST ONE of these tags. Combines with
+     * `tags_all`/`tags_none` by intersection (`tags_none` always wins;
+     * overlap with `tags_none` is allowed and leaves a dead term).
+     * Supplying a positive tag filter (`tags_any`, `tags_all`, or
+     * `include_tags`) replaces the default category filter that is
+     * otherwise applied. Lists over 100 tags (counted after removing
+     * empty values and duplicates) return 400 `INVALID_TAG_FILTER`.
+     *
+     */
+    tags_any?: Array<string>
+    /**
+     * Exclude assets that have ANY of these tags. Replaces the
+     * deprecated `exclude_tags`. Sending both spellings, or exceeding
+     * 100 tags per list (counted after removing empty values and
+     * duplicates), returns 400 `INVALID_TAG_FILTER`.
+     *
+     */
+    tags_none?: Array<string>
     /**
      * Filter assets where name contains this substring (case-insensitive)
      */
@@ -5545,13 +5606,47 @@ export type GetAssetTagHistogramData = {
   path?: never
   query?: {
     /**
-     * Filter assets that have ALL of these tags
+     * Deprecated alias for `tags_all`, kept permanently for existing
+     * callers. Filter assets that have ALL of these tags. The same
+     * combination and list-size rules as on `/api/assets` apply
+     * (400 `INVALID_TAG_FILTER`).
+     *
+     *
+     * @deprecated
      */
     include_tags?: Array<string>
     /**
-     * Exclude assets that have ANY of these tags
+     * Deprecated alias for `tags_none`, kept permanently for existing
+     * callers. Exclude assets that have ANY of these tags. The same
+     * combination and list-size rules as on `/api/assets` apply
+     * (400 `INVALID_TAG_FILTER`).
+     *
+     *
+     * @deprecated
      */
     exclude_tags?: Array<string>
+    /**
+     * Filter assets that have ALL of these tags. Replaces the deprecated
+     * `include_tags`. The same combination and list-size rules as on
+     * `/api/assets` apply (400 `INVALID_TAG_FILTER`).
+     *
+     */
+    tags_all?: Array<string>
+    /**
+     * Filter assets that have AT LEAST ONE of these tags. Combines with
+     * `tags_all`/`tags_none` by intersection (`tags_none` always wins).
+     * The same combination and list-size rules as on `/api/assets` apply
+     * (400 `INVALID_TAG_FILTER`).
+     *
+     */
+    tags_any?: Array<string>
+    /**
+     * Exclude assets that have ANY of these tags. Replaces the deprecated
+     * `exclude_tags`. The same combination and list-size rules as on
+     * `/api/assets` apply (400 `INVALID_TAG_FILTER`).
+     *
+     */
+    tags_none?: Array<string>
     /**
      * Filter assets where name contains this substring (case-insensitive)
      */
@@ -6163,7 +6258,7 @@ export type CancelSubscriptionData = {
 
 export type CancelSubscriptionErrors = {
   /**
-   * Invalid request (e.g., no active subscription)
+   * Invalid request (for example, no active subscription). Ambiguous legacy Stripe state uses code BILLING_RECONCILIATION_REQUIRED.
    */
   400: ErrorResponse
   /**
@@ -7915,7 +8010,7 @@ export type ExecutePromptErrors = {
    */
   402: PromptErrorResponse
   /**
-   * Workspace governance policy blocks one or more partner providers (error.type PARTNER_NODE_DISABLED; error.class_types lists the offending nodes, error.providers the disabled providers)
+   * Workspace governance policy blocks one or more partner providers (error.type PARTNER_NODE_DISABLED; node_errors identifies each denied prompt node, capped at 100 occurrences; error.class_types and error.providers summarize the denied node types and providers)
    */
   403: PromptErrorResponse
   /**
@@ -9966,7 +10061,12 @@ export type CreateWorkflowUploadUrlResponse =
 export type ListWorkspaceApiKeysData = {
   body?: never
   path?: never
-  query?: never
+  query?: {
+    /**
+     * Include revoked API keys in the response
+     */
+    include_revoked?: boolean
+  }
   url: '/api/workspace/api-keys'
 }
 

--- a/packages/ingest-types/src/zod.gen.ts
+++ b/packages/ingest-types/src/zod.gen.ts
@@ -1254,6 +1254,7 @@ export const zJobEntry = z.object({
   id: z.string().uuid(),
   outputs_count: z.number().int().optional(),
   preview_output: z.record(z.unknown()).optional(),
+  previewable_outputs_count: z.number().int().optional(),
   status: z.enum([
     'pending',
     'in_progress',
@@ -1374,6 +1375,7 @@ export const zJobDetailResponse = z.object({
   outputs: z.record(z.unknown()).optional(),
   outputs_count: z.number().int().optional(),
   preview_output: z.record(z.unknown()).optional(),
+  previewable_outputs_count: z.number().int().optional(),
   status: z.enum([
     'pending',
     'in_progress',
@@ -2057,6 +2059,7 @@ export const zBillingStatusResponse = z.object({
   max_seats: z.number().int(),
   occupied_seats: z.number().int(),
   pending_billing_op_id: z.string().optional(),
+  pending_billing_op_type: z.enum(['subscription', 'topup']).optional(),
   plan_slug: z.string().optional(),
   renewal_date: z.string().datetime().optional(),
   subscription_duration: zSubscriptionDuration.optional(),
@@ -2533,6 +2536,9 @@ export const zListAssetsData = z.object({
     .object({
       include_tags: z.array(z.string()).optional(),
       exclude_tags: z.array(z.string()).optional(),
+      tags_all: z.array(z.string()).optional(),
+      tags_any: z.array(z.string()).optional(),
+      tags_none: z.array(z.string()).optional(),
       name_contains: z.string().optional(),
       metadata_filter: z.string().optional(),
       limit: z.number().int().gte(1).lte(500).optional().default(20),
@@ -2841,6 +2847,9 @@ export const zGetAssetTagHistogramData = z.object({
     .object({
       include_tags: z.array(z.string()).optional(),
       exclude_tags: z.array(z.string()).optional(),
+      tags_all: z.array(z.string()).optional(),
+      tags_any: z.array(z.string()).optional(),
+      tags_none: z.array(z.string()).optional(),
       name_contains: z.string().optional(),
       metadata_filter: z.string().optional(),
       limit: z.number().int().gte(1).lte(1000).optional().default(100),
@@ -4309,7 +4318,11 @@ export const zCreateWorkflowUploadUrlResponse = zUploadGrantResponse
 export const zListWorkspaceApiKeysData = z.object({
   body: z.never().optional(),
   path: z.never().optional(),
-  query: z.never().optional()
+  query: z
+    .object({
+      include_revoked: z.boolean().optional().default(false)
+    })
+    .optional()
 })
 
 /**


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

Requested by @synap5e on [Comfy-Org/cloud#6312](https://github.com/Comfy-Org/cloud/pull/6312) ("update ingest types").

Regenerated `@comfyorg/ingest-types` from the current cloud ingest spec using the same pipeline as the post-merge automation (`push-ingest-types-to-frontend.yml`): `openapi-project -fe` to strip cloud's `x-internal` / M2M surface, then `pnpm generate`, then oxfmt.

## The governance change is documentation only

cloud#6312 adds `node_errors` to the `/api/prompt` 403 body so a partner-provider policy denial routes to the Errors panel instead of the legacy "Access Restricted" modal. But `PromptErrorResponse` is an open object (`additionalProperties: true`), so the only generated change is the 403's description:

```diff
-  * ... (error.type PARTNER_NODE_DISABLED; error.class_types lists the offending nodes, error.providers the disabled providers)
+  * ... (error.type PARTNER_NODE_DISABLED; node_errors identifies each denied prompt node, capped at 100 occurrences; error.class_types and error.providers summarize the denied node types and providers)
```

No type or schema change, and nothing in `src/` needs to change — the consuming code (`app.ts`, `executionErrorUtil.ts`, the `PARTNER_NODE_DISABLED` catalog entry) already handles this shape.

## The rest is accumulated drift

The package had fallen behind several merged cloud specs. All additive and optional:

- `previewable_outputs_count` on `JobEntry` / `JobDetailResponse`
- `tags_all` / `tags_any` / `tags_none` on `/api/assets` and the tag histogram; `include_tags` / `exclude_tags` now carry `@deprecated` as permanent aliases
- `pending_billing_op_type` (`'subscription' | 'topup'`) on `BillingStatusResponse`
- `include_revoked` on the workspace API keys list query
- reworded `cancel_at` (delinquent Stripe cancellation) and SCA/3DS descriptions

I included these rather than hand-editing a generated file down to just my one line — a partial regen would leave the package inconsistent with its own spec, and this is the same output the automation produces.

## Verification

`pnpm typecheck`, `pnpm lint`, `pnpm format:check` all exit 0. `app.test.ts`, `executionErrorUtil.test.ts` and the `errorCatalog` suite pass (169 tests). Pre-commit hooks (oxfmt / oxlint / eslint / typecheck) ran clean on both files.

## Note on ordering

This can merge before or after cloud#6312 — the change is a doc comment on an open object, so it's inert either way.

Worth flagging separately: the drift above suggests `push-ingest-types-to-frontend.yml` hasn't been landing its chore PRs. Also, a plain `pnpm generate` in this package produces ~11k lines of formatting churn because the workflow commits raw generator output with `HUSKY: '0'` while the committed files are oxfmt-formatted; running oxfmt afterwards collapses it. Might be worth adding the format step to the workflow.
