### PR TITLE
test(custom-nodes): allow Cloud Whisper PARTIAL instead of pinning it

### DIFF
--- a/browser_tests/fixtures/customNode/autoRun.ts
+++ b/browser_tests/fixtures/customNode/autoRun.ts
@@ -258,6 +258,13 @@ export const AUTO_RUN_ALLOWED_FAILURES: Record<
       'checkpoint'
     )
   },
+  ComfyUI_AudioTools: {
+    AudioSpeechToTextWhisper: {
+      outcomes: ['PARTIAL'],
+      reason:
+        'Cloud model-cache state varies: a cold Whisper fetch read PARTIAL on run 31581284699 while runs 31553987373 and 31601564531 ran the identical node clean, so a strict cannotRunAlone entry reds in one direction or the other on every cache flip'
+    }
+  },
   ComfyUI_LayerStyle_Advance: {
     'LayerMask: ObjectDetectorYOLO8': {
       outcomes: [

--- a/browser_tests/tests/customNodes/autoRun.pure.spec.ts
+++ b/browser_tests/tests/customNodes/autoRun.pure.spec.ts
@@ -522,5 +522,29 @@ test.describe('autoRun classifier', () => {
         )
       ).toBe(false)
     }
+
+    const partialCases = Object.entries(AUTO_RUN_ALLOWED_FAILURES).flatMap(
+      ([pack, nodes]) =>
+        Object.entries(nodes).flatMap(([node, allowed]) =>
+          allowed.outcomes.includes('PARTIAL')
+            ? [{ key: `${pack}/${node}`, allowed }]
+            : []
+        )
+    )
+    expect(partialCases.map(({ key }) => key)).toEqual([
+      'ComfyUI_AudioTools/AudioSpeechToTextWhisper'
+    ])
+    for (const { allowed } of partialCases) {
+      expect(allowed.requireFailure).toBeUndefined()
+      expect(matchesAllowedAutoRunOutcome('PARTIAL', allowed.outcomes)).toBe(
+        true
+      )
+      expect(
+        matchesAllowedAutoRunOutcome('PARTIAL extra', allowed.outcomes)
+      ).toBe(false)
+      expect(matchesAllowedAutoRunOutcome('TIMEOUT', allowed.outcomes)).toBe(
+        false
+      )
+    }
   })
 })

--- a/browser_tests/tests/customNodes/autoRun.pure.spec.ts
+++ b/browser_tests/tests/customNodes/autoRun.pure.spec.ts
@@ -514,7 +514,8 @@ test.describe('autoRun classifier', () => {
       expect(matchesAllowedAutoRunOutcome('TIMEOUT extra', outcomes)).toBe(
         false
       )
-      expect(matchesAllowedAutoRunOutcome('PARTIAL', outcomes)).toBe(false)
+      if (!outcomes.includes('PARTIAL'))
+        expect(matchesAllowedAutoRunOutcome('PARTIAL', outcomes)).toBe(false)
       expect(
         matchesAllowedAutoRunOutcome(
           'EXECUTION_ERROR (Something else broke)',
@@ -531,7 +532,7 @@ test.describe('autoRun classifier', () => {
             : []
         )
     )
-    expect(partialCases.map(({ key }) => key)).toEqual([
+    expect(partialCases.map(({ key }) => key).sort()).toEqual([
       'ComfyUI_AudioTools/AudioSpeechToTextWhisper'
     ])
     for (const { allowed } of partialCases) {
@@ -542,9 +543,10 @@ test.describe('autoRun classifier', () => {
       expect(
         matchesAllowedAutoRunOutcome('PARTIAL extra', allowed.outcomes)
       ).toBe(false)
-      expect(matchesAllowedAutoRunOutcome('TIMEOUT', allowed.outcomes)).toBe(
-        false
-      )
+      if (!allowed.outcomes.includes('TIMEOUT'))
+        expect(matchesAllowedAutoRunOutcome('TIMEOUT', allowed.outcomes)).toBe(
+          false
+        )
     }
   })
 })


### PR DESCRIPTION
AudioSpeechToTextWhisper flips with Cloud model-cache state, and a strict binary ledger reds on every flip:

| run | ledger | Whisper outcome | result |
|---|---|---|---|
| [31553987373](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/31553987373) | not listed | clean | fine |
| [31581284699](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/31581284699) | not listed | PARTIAL | red: "not in cannotRunAlone" |
| [31601564531](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/31601564531) | in cannotRunAlone (3c0bd99's parent) | clean | red: "stale entry" |

3c0bd99 removed the cannotRunAlone entry, which stays green only until the next cold-cache PARTIAL. This adds the durable half: a non-required `AUTO_RUN_ALLOWED_FAILURES` entry (`outcomes: ['PARTIAL']`) that tolerates PARTIAL without demanding it - same pattern as `LoadUpscalerTensorrtModel`'s cold/warm TIMEOUT allowance. Clean passes, PARTIAL is allowed, the flip-flop ends.

Pure-spec pins mirror the existing timeoutCases block: exact population of PARTIAL-bearing entries, matcher exactness, and `requireFailure` unset.

- `pnpm exec playwright test autoRun.pure --project=chromium`: 17 passed