### PR TITLE
ci: harden the corpus/matrix against non-node failures; tighten pass criteria

### DIFF
--- a/.github/workflows/ci-weekly-registry-census.yaml
+++ b/.github/workflows/ci-weekly-registry-census.yaml
@@ -20,8 +20,12 @@ name: 'CI: Ecosystem Matrix'
 
 on:
   schedule:
-    # Weekly, Monday 06:17 UTC - off the top-of-hour scheduler stampede.
+    # Monday is the measurement; Thursday exists to keep the corpus cache
+    # inside GitHub's 7-day eviction window (a weekly-only cadence races it,
+    # and losing the cache means a full ~1GB cold fetch). Off the
+    # top-of-hour scheduler stampede.
     - cron: '17 6 * * 1'
+    - cron: '17 6 * * 4'
   workflow_dispatch:
   # Self-testing: a PR that changes the corpus tooling runs the refresh.
   # Also what registers the workflow so workflow_dispatch resolves before
@@ -44,6 +48,9 @@ jobs:
   corpus:
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    permissions:
+      contents: read
+      actions: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
@@ -87,6 +94,19 @@ jobs:
         with:
           path: .census
           key: registry-corpus-${{ hashFiles('.census/corpus.lock.json') }}
+
+      # Each drift writes a new ~1GB entry against the repo's shared 10GB
+      # cache budget; without pruning the census would evict every other
+      # workflow's caches within weeks. Keep the newest entry only. Branch
+      # runs only - PR-scoped entries expire with the PR and a fork PR's
+      # token cannot delete caches anyway.
+      - name: Prune superseded corpus caches
+        if: always() && steps.fetch.outcome == 'success' && github.event_name != 'pull_request'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh cache list --repo "$GITHUB_REPOSITORY" --key registry-corpus- --sort created_at --order desc --json id --jq '.[1:][].id' |
+            while read -r id; do gh cache delete "$id" --repo "$GITHUB_REPOSITORY" || true; done
 
   # The execution rung between the corpus (every pack fetched) and the E2E
   # gates (browser + backend): every JS-shipping pack's real extension code
@@ -166,6 +186,9 @@ jobs:
   #   every operation clean  >= 99% of packs  (baseline ~100%)
   matrix-verdict:
     needs: ecosystem-matrix
+    # A single failed shard must degrade to a partial verdict over the rows
+    # that exist, not to a skipped check that reads as nothing happened.
+    if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -179,8 +202,29 @@ jobs:
           path: matrix-rows
           merge-multiple: true
 
+      # Previous run's metrics for the week-over-week delta gate: the
+      # primary key never hits (run-scoped), restore-keys serves the
+      # newest save.
+      - name: Restore previous metrics
+        uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
+        with:
+          path: matrix-metrics
+          key: matrix-metrics-${{ github.run_id }}
+          restore-keys: matrix-metrics-
+
       - name: Verdict
-        run: MATRIX_OUT="$PWD/matrix-rows" python3 scripts/registry-census/summarize_matrix.py
+        run: |
+          MATRIX_OUT="$PWD/matrix-rows" \
+          MATRIX_PREV="$PWD/matrix-metrics/metrics.json" \
+          MATRIX_METRICS_OUT="$PWD/matrix-metrics/metrics.json" \
+            python3 scripts/registry-census/summarize_matrix.py
+
+      - name: Save metrics
+        if: always() && hashFiles('matrix-metrics/metrics.json') != ''
+        uses: actions/cache/save@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
+        with:
+          path: matrix-metrics
+          key: matrix-metrics-${{ github.run_id }}
 
       - name: Upload combined result
         if: always()
@@ -221,12 +265,18 @@ jobs:
       - name: Every channel must fire
         run: MATRIX_OUT="$PWD/matrix-proof" python3 scripts/registry-census/verify_detection.py
 
+      # Exit code must be exactly 1 (criteria FAIL): exit 2 would mean the
+      # harness gate withheld the verdict, which on this corpus is itself a
+      # detection failure.
       - name: Verdict must FAIL on poison
         run: |
-          if MATRIX_OUT="$PWD/matrix-proof" python3 scripts/registry-census/summarize_matrix.py > proof-verdict.txt 2>&1; then
-            cat proof-verdict.txt
-            echo "::error::verdict PASSED on an all-poison corpus - the floors are not gating"
+          set +e
+          MATRIX_OUT="$PWD/matrix-proof" python3 scripts/registry-census/summarize_matrix.py > proof-verdict.txt 2>&1
+          rc=$?
+          set -e
+          tail -8 proof-verdict.txt
+          if [ "$rc" -ne 1 ]; then
+            echo "::error::expected verdict FAIL (exit 1) on the poison corpus, got exit $rc"
             exit 1
           fi
-          tail -6 proof-verdict.txt
           echo "verdict correctly FAILED on the poison corpus"

--- a/.github/workflows/ci-weekly-registry-census.yaml
+++ b/.github/workflows/ci-weekly-registry-census.yaml
@@ -101,7 +101,7 @@ jobs:
       # runs only - PR-scoped entries expire with the PR and a fork PR's
       # token cannot delete caches anyway.
       - name: Prune superseded corpus caches
-        if: always() && steps.fetch.outcome == 'success' && github.event_name != 'pull_request'
+        if: always() && steps.fetch.outcome == 'success' && github.event_name != 'pull_request' && github.ref_name == github.event.repository.default_branch
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -175,15 +175,22 @@ jobs:
           if-no-files-found: warn
 
   # The single combined result: all four shards' rows merge into one table
-  # and one gating verdict - this job's exit code IS the ecosystem verdict.
+  # and one gating verdict - this job's exit code IS the ecosystem verdict
+  # (0 PASS, 1 FAIL, 2 harness failure / no rows).
+  #
+  # Before any criterion: >= 50% of packs must pass the runner self-check
+  # (default workflow materialized), or the verdict is WITHHELD as a
+  # harness failure rather than reported as an ecosystem FAIL.
   #
   # PASS criteria (summarize_matrix.py, all must hold over the combined
-  # rows; each floor sits under the measured baseline so a handful of
-  # broken pack HEADs cannot flip the verdict, while a frontend regression
-  # that breaks pack integration craters all three at once):
-  #   entry JS loads clean   >= 95%           (baseline 97.9%)
-  #   registerNodeDef OK     >= 99%           (baseline 100%)
-  #   every operation clean  >= 99% of packs  (baseline ~100%)
+  # rows; floors sit under the real-timer baselines measured on run
+  # 31624366070 so a handful of broken pack HEADs cannot flip the verdict,
+  # while a frontend regression craters them all at once):
+  #   entry JS loads (any entry per pack)  >= 95%     (baseline 97.3%)
+  #   entry files load clean               >= 91%     (baseline 94.0%)
+  #   registerNodeDef OK                   >= 99%     (baseline 100%)
+  #   every operation clean                >= 99%     (baseline 99.8%)
+  #   entry-clean delta vs previous run    >= -1.5pp  (metrics via cache)
   matrix-verdict:
     needs: ecosystem-matrix
     # A single failed shard must degrade to a partial verdict over the rows
@@ -203,8 +210,10 @@ jobs:
           merge-multiple: true
 
       # Previous run's metrics for the week-over-week delta gate: the
-      # primary key never hits (run-scoped), restore-keys serves the
-      # newest save.
+      # primary key never hits (saves carry a run_attempt suffix), so
+      # restore-keys serves the newest save. A re-run can restore this same
+      # run's earlier attempt - metrics carry runId and the summarizer
+      # skips the delta rather than compare a run against itself.
       - name: Restore previous metrics
         uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
@@ -213,18 +222,25 @@ jobs:
           restore-keys: matrix-metrics-
 
       - name: Verdict
+        id: verdict
+        env:
+          MATRIX_RUN_ID: ${{ github.run_id }}
         run: |
           MATRIX_OUT="$PWD/matrix-rows" \
           MATRIX_PREV="$PWD/matrix-metrics/metrics.json" \
           MATRIX_METRICS_OUT="$PWD/matrix-metrics/metrics.json" \
             python3 scripts/registry-census/summarize_matrix.py
 
+      # Baseline-from-health: gated on the verdict PASSING, because on a
+      # FAIL the restored previous metrics still sit in the directory and a
+      # file-presence guard would re-save the old baseline under a newer
+      # key for nothing.
       - name: Save metrics
-        if: always() && hashFiles('matrix-metrics/metrics.json') != ''
+        if: steps.verdict.outcome == 'success' && hashFiles('matrix-metrics/metrics.json') != ''
         uses: actions/cache/save@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: matrix-metrics
-          key: matrix-metrics-${{ github.run_id }}
+          key: matrix-metrics-${{ github.run_id }}-${{ github.run_attempt }}
 
       - name: Upload combined result
         if: always()

--- a/scripts/registry-census/README.md
+++ b/scripts/registry-census/README.md
@@ -43,19 +43,31 @@ serialize/reload), one JSON row per pack. Packs with no extension JS are
 skipped and reported only as a count.
 
 **PASS criteria** — applied once by the `matrix-verdict` job over all four
-shards combined (`summarize_matrix.py`, whose exit code is the verdict):
+shards combined (`summarize_matrix.py`; exit 0 PASS, 1 FAIL, 2 harness):
 
-| criterion             | floor           | measured baseline |
-| --------------------- | --------------- | ----------------- |
-| entry JS loads clean  | >= 95%          | 97.9%             |
-| registerNodeDef OK    | >= 99%          | 100%              |
-| every operation clean | >= 99% of packs | ~100%             |
+| criterion                           | floor     | measured baseline |
+| ----------------------------------- | --------- | ----------------- |
+| entry JS loads (any entry per pack) | >= 95%    | 97.4%             |
+| entry files load clean              | >= 91%    | 94.1%             |
+| registerNodeDef OK                  | >= 99%    | 100%              |
+| every operation clean               | >= 99%    | ~100%             |
+| entry-clean delta vs previous run   | >= -1.5pp | carried by cache  |
 
-All three must hold. Each floor sits under the baseline so a handful of
-broken pack HEADs cannot flip the verdict, while a frontend regression that
-breaks pack integration craters all three at once. Shard jobs check harness
+All must hold. Each floor sits under the baseline (measured over the full
+1,879-pack registry, run 31563501583) so a handful of broken pack HEADs
+cannot flip the verdict, while a frontend regression that breaks pack
+integration craters them all at once; the delta gate catches gradual
+erosion the absolute floors ignore. Before any criterion is evaluated, a
+**harness gate** requires >= 50% of packs to pass the runner's self-check
+(the default workflow actually materialized: >= 7 nodes, KSampler with its
+widgets) — below that the verdict is _withheld_ as a harness failure (exit 2) instead of emitting a false ecosystem FAIL. Shard jobs check harness
 integrity only (every built spec wrote its row; vitest's own exit code is
 ignored because pack code leaks unhandled rejections).
+
+Packs execute under real timers: the matrix config assigns `setupFiles`
+explicitly, keeping `vitest.setup.ts` (environment globals) and dropping
+the unit suite's `vitest.timer.setup.ts` fake timers that `mergeConfig`
+array-concatenation would otherwise smuggle in.
 
 ## Detection proof (counter-evidence)
 

--- a/scripts/registry-census/build_matrix.py
+++ b/scripts/registry-census/build_matrix.py
@@ -20,7 +20,7 @@ from paths import CORPUS  # noqa: E402
 DEST = os.path.abspath(os.path.join(HERE, os.pardir, os.pardir, 'src', '__ecs_matrix__'))
 REPOS = CORPUS
 
-PREFIX = r'(["\'])(?:/|\.\./|\./)*'
+PREFIX = r'(["\'])(?:/|(?:\.\./)+|\./)'
 REWRITES = [
     (re.compile(PREFIX + r'scripts/app\.js\1'), '"@/scripts/app"'),
     (re.compile(PREFIX + r'scripts/api\.js\1'), '"@/scripts/api"'),
@@ -58,6 +58,8 @@ describe('matrix {pack}', () => {{
 
 
 def build(limit: int = 0, shard: str = ''):
+    if not os.path.isdir(REPOS):
+        sys.exit(f'corpus missing: {REPOS} - run fetch_corpus.py (or restore the cache) first')
     if os.path.isdir(DEST):
         shutil.rmtree(DEST)
     os.makedirs(os.path.join(DEST, 'packs'))
@@ -132,7 +134,8 @@ def build(limit: int = 0, shard: str = ''):
                 if ENTRY_RX.search(t):
                     entries.append('./packs/' + safe + '/' + rel.replace(os.sep, '/'))
         entries.sort()
-        entries = entries[:60]  # generous cap; truncation noted in manifest
+        truncated = len(entries) > 60
+        entries = entries[:60]
         if not entries:
             shutil.rmtree(dst, ignore_errors=True)
             manifest[pack] = {'skipped': 'no extension-shaped JS'}
@@ -140,6 +143,8 @@ def build(limit: int = 0, shard: str = ''):
         spec = SPEC.format(pack=pack, safe=safe, entries=json.dumps(entries))
         open(os.path.join(DEST, f'{safe}.matrix.test.ts'), 'w').write(spec)
         manifest[pack] = {'files': n_files, 'entries': len(entries)}
+        if truncated:
+            manifest[pack]['truncated'] = True
     json.dump(manifest, open(os.path.join(DEST, 'manifest.json'), 'w'), indent=1)
     built = sum(1 for v in manifest.values() if 'entries' in v)
     print(f'{built} pack specs built, {len(manifest)-built} skipped -> {DEST}', file=sys.stderr)

--- a/scripts/registry-census/build_matrix.py
+++ b/scripts/registry-census/build_matrix.py
@@ -20,7 +20,7 @@ from paths import CORPUS  # noqa: E402
 DEST = os.path.abspath(os.path.join(HERE, os.pardir, os.pardir, 'src', '__ecs_matrix__'))
 REPOS = CORPUS
 
-PREFIX = r'(["\'])(?:/|(?:\.\./)+|\./)'
+PREFIX = r'(["\'])(?:/|(?:\./)?(?:\.\./)+)'
 REWRITES = [
     (re.compile(PREFIX + r'scripts/app\.js\1'), '"@/scripts/app"'),
     (re.compile(PREFIX + r'scripts/api\.js\1'), '"@/scripts/api"'),

--- a/scripts/registry-census/fetch_corpus.py
+++ b/scripts/registry-census/fetch_corpus.py
@@ -259,16 +259,24 @@ def main() -> int:
     # A few failures are ecosystem weather (deleted repos, host blips); a
     # mass failure (rate limiting, host outage) would silently shrink every
     # downstream denominator, so it fails the run instead of shipping a
-    # partial corpus as if it were complete.
+    # partial corpus as if it were complete. The denominator is what this
+    # run actually ATTEMPTED over the network - on an incremental run most
+    # packs short-circuit as cached, and measuring against the full target
+    # list would let a 100% outage of the attempted fetches pass.
     if counts.get('failed'):
+        attempted = sum(
+            n for status, n in counts.items()
+            if status in ('ok', 'empty', 'failed', 'drifted')
+        )
         print(
-            f"\n{counts['failed']} fetches failed; re-run to retry "
-            f'(they are not marked done and will not be skipped)',
+            f"\n{counts['failed']} of {attempted} attempted fetches failed; "
+            f're-run to retry (they are not marked done and will not be '
+            f'skipped)',
             file=sys.stderr,
         )
-        if targets and counts['failed'] > 0.05 * len(targets):
+        if counts['failed'] >= 5 and counts['failed'] > 0.05 * attempted:
             print(
-                f"{counts['failed']}/{len(targets)} failed exceeds the 5% "
+                f"{counts['failed']}/{attempted} attempted exceeds the 5% "
                 f'mass-failure threshold - refusing to treat a partial '
                 f'corpus as complete',
                 file=sys.stderr,

--- a/scripts/registry-census/fetch_corpus.py
+++ b/scripts/registry-census/fetch_corpus.py
@@ -135,7 +135,11 @@ def fetch_one(
         tar_path = os.path.join(tmp, 'a.tar.gz')
         hdr_path = os.path.join(tmp, 'h.txt')
         rc = subprocess.run(
-            ['curl', '-sfL', '--max-time', '180', '-D', hdr_path, '-o', tar_path, url],
+            [
+                'curl', '-sfL', '--max-time', '180',
+                '--retry', '3', '--retry-all-errors', '--retry-delay', '2',
+                '-D', hdr_path, '-o', tar_path, url,
+            ],
             capture_output=True,
         ).returncode
         if rc != 0 or not os.path.exists(tar_path):
@@ -252,12 +256,24 @@ def main() -> int:
         print(f'\n{drifted} packs drifted from the lockfile', file=sys.stderr)
         return 1
     # A failed fetch is not a clean pack. Surface it rather than caching it.
+    # A few failures are ecosystem weather (deleted repos, host blips); a
+    # mass failure (rate limiting, host outage) would silently shrink every
+    # downstream denominator, so it fails the run instead of shipping a
+    # partial corpus as if it were complete.
     if counts.get('failed'):
         print(
             f"\n{counts['failed']} fetches failed; re-run to retry "
             f'(they are not marked done and will not be skipped)',
             file=sys.stderr,
         )
+        if targets and counts['failed'] > 0.05 * len(targets):
+            print(
+                f"{counts['failed']}/{len(targets)} failed exceeds the 5% "
+                f'mass-failure threshold - refusing to treat a partial '
+                f'corpus as complete',
+                file=sys.stderr,
+            )
+            return 1
     return 0
 
 

--- a/scripts/registry-census/matrix_runner.ts
+++ b/scripts/registry-census/matrix_runner.ts
@@ -404,10 +404,13 @@ export async function runPack(
   )
   // Harness self-check: if the default workflow did not materialize, the
   // if-guarded ops below would all no-op and report a vacuously clean pack.
-  // The summarizer withholds the verdict when this fails broadly.
+  // The summarizer withholds the verdict when this fails broadly. Floors,
+  // not pins (workflow has 7 nodes / KSampler has 7 widgets today): the
+  // check must catch "nothing loaded", not fail on a legitimate upstream
+  // workflow edit.
   const kAfterLoad = byType('KSampler')
   row.selfCheck =
-    graph._nodes.length >= 7 && (kAfterLoad?.widgets?.length ?? 0) >= 7
+    graph._nodes.length >= 4 && (kAfterLoad?.widgets?.length ?? 0) >= 4
       ? 'OK'
       : `default workflow degraded: nodes=${graph._nodes.length}` +
         ` kSamplerWidgets=${kAfterLoad?.widgets?.length ?? 0}`

--- a/scripts/registry-census/matrix_runner.ts
+++ b/scripts/registry-census/matrix_runner.ts
@@ -28,8 +28,6 @@ const argText = (a: unknown): string => {
 
 let DEPR: string[] = []
 
-type Rec = Record<string, unknown>
-
 interface WidgetLike {
   name: string
   type?: string
@@ -202,7 +200,7 @@ function signature(graph: GraphLike, store?: WidgetStoreLike) {
         if (store?.getNodeWidgetIds) {
           const ids: string[] = store.getNodeWidgetIds(graph.rootGraph.id, n.id)
           const liveNames = new Set((n.widgets ?? []).map((w) => w.name))
-          const names = ids.map((i) => String(i).split(':').pop())
+          const names = ids.map((i) => String(i).split(':').pop() ?? '')
           r = names.filter((nm) => liveNames.has(nm)).length
           st = names
             .map((nm) => {
@@ -404,6 +402,15 @@ export async function runPack(
   await op('load', () =>
     graph.configure(structuredClone(defaultWorkflow) as never)
   )
+  // Harness self-check: if the default workflow did not materialize, the
+  // if-guarded ops below would all no-op and report a vacuously clean pack.
+  // The summarizer withholds the verdict when this fails broadly.
+  const kAfterLoad = byType('KSampler')
+  row.selfCheck =
+    graph._nodes.length >= 7 && (kAfterLoad?.widgets?.length ?? 0) >= 7
+      ? 'OK'
+      : `default workflow degraded: nodes=${graph._nodes.length}` +
+        ` kSamplerWidgets=${kAfterLoad?.widgets?.length ?? 0}`
   await op('editWidget', () => {
     const k = byType('KSampler')
     const w = k?.widgets?.find((x) => x.name === 'seed')
@@ -451,9 +458,8 @@ export async function runPack(
     if (k?.widgets?.length) k.widgets.splice(0, 1)
   })
   await op('wReorder', () => {
-    const k = byType('KSampler')
-    if ((k?.widgets?.length ?? 0) > 1)
-      k.widgets.splice(0, 0, k.widgets.splice(k.widgets.length - 1, 1)[0])
+    const w = byType('KSampler')?.widgets
+    if (w && w.length > 1) w.splice(0, 0, w.splice(w.length - 1, 1)[0])
   })
   await op('wConvert', () => {
     const k = byType('KSampler')
@@ -503,7 +509,7 @@ export async function runPack(
         continue
       }
       n.pos = [1200, 100]
-      graph.add(n)
+      graph.add(n as unknown as InstanceType<typeof LGraphNode>)
       const parts = [
         `in=${n.inputs?.length ?? 0}`,
         `out=${n.outputs?.length ?? 0}`,
@@ -522,7 +528,7 @@ export async function runPack(
         }
       }
       n.serialize()
-      graph.remove(n)
+      graph.remove(n as unknown as InstanceType<typeof LGraphNode>)
       if (DEPR.length)
         parts.push(`depr=${[...new Set(DEPR)].join(';').slice(0, 60)}`)
       driven[t] = parts.join(' ')

--- a/scripts/registry-census/refresh_registry.py
+++ b/scripts/registry-census/refresh_registry.py
@@ -29,23 +29,45 @@ PAGE_SIZE = 100
 
 def fetch_page(page: int) -> dict:
     r = subprocess.run(
-        ['curl', '-sfL', '--max-time', '60', f'{API}?page={page}&limit={PAGE_SIZE}'],
+        [
+            'curl', '-sfL', '--max-time', '60',
+            '--retry', '5', '--retry-all-errors', '--retry-delay', '2',
+            f'{API}?page={page}&limit={PAGE_SIZE}',
+        ],
         capture_output=True,
         text=True,
     )
     if r.returncode != 0:
-        raise SystemExit(f'registry API request failed on page {page}')
+        raise RegistryUnavailable(f'registry API request failed on page {page}')
     return json.loads(r.stdout)
 
 
-def main() -> int:
-    first = fetch_page(1)
-    total_pages = first.get('totalPages') or 1
-    nodes = list(first.get('nodes') or [])
+class RegistryUnavailable(Exception):
+    pass
 
-    for page in range(2, total_pages + 1):
-        nodes.extend(fetch_page(page).get('nodes') or [])
-        print(f'  page {page}/{total_pages}', end='\r', file=sys.stderr)
+
+def keep_cached(reason: str) -> int:
+    """A transient registry problem must not kill the weekly run: the cached
+    snapshot is a complete, recently-valid target list. Only a first-ever run
+    (no cache to fall back on) fails hard."""
+    dest = registry_snapshot()
+    if os.path.exists(dest):
+        print(f'{reason}; keeping the cached snapshot at {dest}', file=sys.stderr)
+        return 0
+    raise SystemExit(reason + ' and no cached snapshot exists')
+
+
+def main() -> int:
+    try:
+        first = fetch_page(1)
+        total_pages = first.get('totalPages') or 1
+        nodes = list(first.get('nodes') or [])
+
+        for page in range(2, total_pages + 1):
+            nodes.extend(fetch_page(page).get('nodes') or [])
+            print(f'  page {page}/{total_pages}', end='\r', file=sys.stderr)
+    except RegistryUnavailable as exc:
+        return keep_cached(str(exc))
 
     out = [
         {
@@ -59,6 +81,13 @@ def main() -> int:
     out.sort(key=lambda x: x['id'])
 
     dest = registry_snapshot()
+    if os.path.exists(dest):
+        prev_count = len(json.load(open(dest)))
+        if len(out) < 0.9 * prev_count:
+            return keep_cached(
+                f'registry returned {len(out)} packs vs {prev_count} cached -'
+                ' likely API shape drift, not mass unpublishing'
+            )
     os.makedirs(os.path.dirname(dest), exist_ok=True)
     with open(dest, 'w', encoding='utf-8') as fh:
         json.dump(out, fh, indent=0, sort_keys=True)

--- a/scripts/registry-census/refresh_registry.py
+++ b/scripts/registry-census/refresh_registry.py
@@ -39,7 +39,12 @@ def fetch_page(page: int) -> dict:
     )
     if r.returncode != 0:
         raise RegistryUnavailable(f'registry API request failed on page {page}')
-    return json.loads(r.stdout)
+    try:
+        return json.loads(r.stdout)
+    except ValueError as exc:
+        raise RegistryUnavailable(
+            f'registry API returned non-JSON on page {page}: {exc}'
+        ) from exc
 
 
 class RegistryUnavailable(Exception):

--- a/scripts/registry-census/summarize_matrix.py
+++ b/scripts/registry-census/summarize_matrix.py
@@ -55,7 +55,11 @@ def main() -> int:
     skipped = 0
     for name in os.listdir(out_dir):
         if name.startswith('_manifest') and name.endswith('.json'):
-            manifest = json.load(open(os.path.join(out_dir, name)))
+            try:
+                manifest = json.load(open(os.path.join(out_dir, name)))
+            except (OSError, ValueError):
+                print(f'unreadable shard manifest: {name}', file=sys.stderr)
+                continue
             skipped += sum(1 for v in manifest.values() if 'skipped' in v)
 
     lines = [
@@ -165,11 +169,20 @@ def main() -> int:
         if not held:
             breaches.append(f'{label} {measured_pct:.1f}% < {floor:.0f}%')
 
+    run_id = os.environ.get('MATRIX_RUN_ID', '')
     prev_path = os.environ.get('MATRIX_PREV', '')
     if prev_path and os.path.exists(prev_path):
         prev = json.load(open(prev_path))
         prev_entry = prev.get('entryPct')
-        if isinstance(prev_entry, (int, float)):
+        if run_id and prev.get('runId') == run_id:
+            # A re-run restored this same run's earlier write; comparing a
+            # run against itself would blind the gate exactly when someone
+            # is re-running a red verdict.
+            lines.append(
+                f'  {"entry-clean delta vs previous run":42s}   n/a'
+                '  (previous metrics are from this run)'
+            )
+        elif isinstance(prev_entry, (int, float)):
             delta = entry_pct - prev_entry
             held = delta >= -DELTA_TOLERANCE
             lines.append(
@@ -191,8 +204,11 @@ def main() -> int:
         'VERDICT: ' + ('FAIL - ' + '; '.join(breaches) if breaches else 'PASS')
     )
 
+    # Baseline-from-health: a FAILing run must not ratchet the baseline down
+    # to its own eroded numbers, or next week's delta forgives the
+    # regression exactly once it has become permanent.
     metrics_out = os.environ.get('MATRIX_METRICS_OUT', '')
-    if metrics_out:
+    if metrics_out and not breaches:
         os.makedirs(os.path.dirname(metrics_out) or '.', exist_ok=True)
         json.dump(
             {
@@ -202,7 +218,8 @@ def main() -> int:
                 'regPct': round(reg_pct, 3),
                 'worstOp': worst_op,
                 'worstOpPct': round(worst_pct, 3),
-                'verdict': 'FAIL' if breaches else 'PASS',
+                'runId': run_id,
+                'verdict': 'PASS',
             },
             open(metrics_out, 'w'),
             indent=1,

--- a/scripts/registry-census/summarize_matrix.py
+++ b/scripts/registry-census/summarize_matrix.py
@@ -1,19 +1,30 @@
 #!/usr/bin/env python3
-"""Combine all ecosystem-matrix shard rows into one table and one verdict.
+"""Combine ecosystem-matrix rows into one population table and one verdict.
 
-Reads every $MATRIX_OUT/<pack>.json row (the verdict job merges all shards
-into one directory), prints the population table, then applies the PASS
-criteria and exits with the verdict:
+Reads every $MATRIX_OUT/<pack>.json row the runner wrote (all shards merged
+into one directory by the verdict job) and applies, in order:
 
-    PASS requires  entry JS loads clean   >= 95%
-                   registerNodeDef OK     >= 99%
-                   every operation clean  >= 99% of packs
+  harness gate   >= 50% of packs must pass the runner's self-check (the
+                 default workflow materialized). Below that the graph was
+                 broadly degraded by the HARNESS, not the ecosystem - the
+                 verdict is withheld and the exit code is 2, never a FAIL
+                 that reads as an ecosystem regression.
 
-Each floor sits under the measured baseline (97.9% / 100% / ~100%) so a
-handful of broken pack HEADs cannot flip the verdict, while a frontend
-regression that breaks pack integration craters all three at once.
-Shard manifests (_manifest-*.json alongside the rows) are merged by pack
-name to count no-JS packs, which are reported only as that count.
+  PASS criteria  entry JS loads (any entry per pack)  >= 95%  (baseline 97.4%)
+                 entry files load clean               >= 91%  (baseline 94.1%)
+                 registerNodeDef OK                   >= 99%  (baseline 100%)
+                 every operation clean                >= 99%  (baseline ~100%)
+
+  delta gate     entry-files-clean must not drop more than 1.5 points below
+                 the previous run's value ($MATRIX_PREV, written each run to
+                 $MATRIX_METRICS_OUT and carried between runs by the actions
+                 cache). Catches gradual erosion the absolute floors ignore.
+
+Floors sit under the measured baselines so a handful of broken pack HEADs
+cannot flip the verdict, while a frontend regression that breaks pack
+integration craters them all at once. Exit codes: 0 PASS, 1 FAIL, 2 harness
+failure / no rows. Shard manifests (_manifest-*.json) carry the no-JS skip
+counts, reported once as a count and otherwise ignored.
 """
 
 from __future__ import annotations
@@ -24,40 +35,62 @@ import sys
 from collections import Counter
 
 STATUS_STAGES = ('registerNodeDef', 'registerCustomNodes')
+DELTA_TOLERANCE = 1.5
 
 
 def main() -> int:
     out_dir = os.environ.get('MATRIX_OUT', '/tmp/matrix')
     rows = []
-    manifest = {}
     for name in sorted(os.listdir(out_dir) if os.path.isdir(out_dir) else []):
-        if not name.endswith('.json'):
+        if not name.endswith('.json') or name.startswith('_'):
             continue
-        path = os.path.join(out_dir, name)
         try:
-            if name.startswith('_manifest'):
-                manifest.update(json.load(open(path)))
-            else:
-                rows.append(json.load(open(path)))
+            rows.append(json.load(open(os.path.join(out_dir, name))))
         except (OSError, ValueError):
             print(f'unreadable row: {name}', file=sys.stderr)
     if not rows:
         print(f'no matrix rows in {out_dir}', file=sys.stderr)
         return 2
 
-    skipped = sum(1 for v in manifest.values() if 'skipped' in v)
+    skipped = 0
+    for name in os.listdir(out_dir):
+        if name.startswith('_manifest') and name.endswith('.json'):
+            manifest = json.load(open(os.path.join(out_dir, name)))
+            skipped += sum(1 for v in manifest.values() if 'skipped' in v)
+
     lines = [
         f'packs with extension JS executed: {len(rows)}'
         + (f' (no-JS packs ignored: {skipped})' if skipped else '')
     ]
-    loaded = sum(1 for r in rows if r.get('loadedOk'))
-    lines.append(f'{"entry JS loaded":22s} {loaded:5d} ({loaded / len(rows) * 100:5.1f}%)')
+
+    self_ok = sum(1 for r in rows if r.get('selfCheck', 'OK') == 'OK')
+    any_loaded = sum(1 for r in rows if r.get('loadedOk'))
+    total_entries = sum(len(r.get('load') or {}) for r in rows)
+    ok_entries = sum(
+        1
+        for r in rows
+        for v in (r.get('load') or {}).values()
+        if v == 'OK'
+    )
+    any_pct = any_loaded / len(rows) * 100
+    entry_pct = ok_entries / total_entries * 100 if total_entries else 0.0
+
+    lines.append(
+        f'{"packs with >=1 entry loaded":28s} {any_loaded:5d} ({any_pct:5.1f}%)'
+    )
+    lines.append(
+        f'{"entry files loaded clean":28s} {ok_entries:5d} of {total_entries}'
+        f' ({entry_pct:5.1f}%)'
+    )
     for stage in STATUS_STAGES:
         ok = sum(1 for r in rows if r.get(stage) == 'OK')
         measured = sum(1 for r in rows if stage in r)
-        lines.append(f'{stage:22s} {ok:5d} of {measured} OK')
+        lines.append(f'{stage:28s} {ok:5d} of {measured} OK')
     hook_packs = sum(1 for r in rows if r.get('hookErrors'))
-    lines.append(f'{"contained hook errors":22s} {hook_packs:5d} pack(s)')
+    lines.append(f'{"contained hook errors":28s} {hook_packs:5d} pack(s)')
+    lines.append(
+        f'{"harness self-check OK":28s} {self_ok:5d} of {len(rows)}'
+    )
 
     op_total: Counter = Counter()
     op_err: Counter = Counter()
@@ -85,17 +118,38 @@ def main() -> int:
         for msg, n in err_msgs.most_common(8):
             lines.append(f'  {n:4d}x {msg}')
 
-    load_pct = loaded / len(rows) * 100
-    reg_measured = sum(1 for r in rows if 'registerNodeDef' in r)
+    def flush(code: int) -> int:
+        report = '\n'.join(lines)
+        print(report)
+        summary = os.environ.get('GITHUB_STEP_SUMMARY')
+        if summary:
+            with open(summary, 'a', encoding='utf-8') as fh:
+                fh.write('## Ecosystem matrix\n\n```\n' + report + '\n```\n')
+        return code
+
+    self_pct = self_ok / len(rows) * 100
+    if self_pct < 50:
+        lines.append('')
+        lines.append(
+            f'HARNESS FAILURE: only {self_pct:.1f}% of packs passed the'
+            ' runner self-check (default workflow materialized). The graph'
+            ' was broadly degraded by the harness, not the ecosystem -'
+            ' verdict withheld.'
+        )
+        return flush(2)
+
     reg_ok = sum(1 for r in rows if r.get('registerNodeDef') == 'OK')
+    reg_measured = sum(1 for r in rows if 'registerNodeDef' in r)
     reg_pct = reg_ok / reg_measured * 100 if reg_measured else 0.0
-    worst_op, worst_pct = 'n/a', 100.0
+    worst_op, worst_pct = '-', 100.0
     for op in op_total:
         pct = (op_total[op] - op_err[op]) / op_total[op] * 100
         if pct < worst_pct:
             worst_op, worst_pct = op, pct
+
     criteria = [
-        ('entry JS loads clean', load_pct, 95.0),
+        ('entry JS loads (any entry per pack)', any_pct, 95.0),
+        ('entry files load clean', entry_pct, 91.0),
         ('registerNodeDef OK', reg_pct, 99.0),
         (f'every operation clean (worst: {worst_op})', worst_pct, 99.0),
     ]
@@ -105,20 +159,56 @@ def main() -> int:
     for label, measured_pct, floor in criteria:
         held = measured_pct >= floor
         lines.append(
-            f'  {label:42s} {measured_pct:5.1f}%  (floor {floor:.0f}%)  '
-            + ('OK' if held else 'BREACH')
+            f'  {label:42s} {measured_pct:5.1f}%  (floor {floor:.0f}%)'
+            f'  {"OK" if held else "BREACH"}'
         )
         if not held:
             breaches.append(f'{label} {measured_pct:.1f}% < {floor:.0f}%')
-    lines.append(f'VERDICT: {"FAIL - " + "; ".join(breaches) if breaches else "PASS"}')
 
-    report = '\n'.join(lines)
-    print(report)
-    summary = os.environ.get('GITHUB_STEP_SUMMARY')
-    if summary:
-        with open(summary, 'a', encoding='utf-8') as fh:
-            fh.write('## Ecosystem matrix\n\n```\n' + report + '\n```\n')
-    return 1 if breaches else 0
+    prev_path = os.environ.get('MATRIX_PREV', '')
+    if prev_path and os.path.exists(prev_path):
+        prev = json.load(open(prev_path))
+        prev_entry = prev.get('entryPct')
+        if isinstance(prev_entry, (int, float)):
+            delta = entry_pct - prev_entry
+            held = delta >= -DELTA_TOLERANCE
+            lines.append(
+                f'  {"entry-clean delta vs previous run":42s} {delta:+5.1f}pp'
+                f'  (floor -{DELTA_TOLERANCE}pp)  {"OK" if held else "BREACH"}'
+            )
+            if not held:
+                breaches.append(
+                    f'entry files clean dropped {-delta:.1f}pp'
+                    f' (from {prev_entry:.1f}% to {entry_pct:.1f}%)'
+                )
+    else:
+        lines.append(
+            f'  {"entry-clean delta vs previous run":42s}   n/a'
+            '  (no previous metrics)'
+        )
+
+    lines.append(
+        'VERDICT: ' + ('FAIL - ' + '; '.join(breaches) if breaches else 'PASS')
+    )
+
+    metrics_out = os.environ.get('MATRIX_METRICS_OUT', '')
+    if metrics_out:
+        os.makedirs(os.path.dirname(metrics_out) or '.', exist_ok=True)
+        json.dump(
+            {
+                'packs': len(rows),
+                'anyPct': round(any_pct, 3),
+                'entryPct': round(entry_pct, 3),
+                'regPct': round(reg_pct, 3),
+                'worstOp': worst_op,
+                'worstOpPct': round(worst_pct, 3),
+                'verdict': 'FAIL' if breaches else 'PASS',
+            },
+            open(metrics_out, 'w'),
+            indent=1,
+        )
+
+    return flush(1 if breaches else 0)
 
 
 if __name__ == '__main__':

--- a/scripts/registry-census/verify_detection.py
+++ b/scripts/registry-census/verify_detection.py
@@ -94,6 +94,15 @@ def main() -> int:
     )
 
     check(
+        'self-check: op-break degraded graph trips the runner self-check',
+        rows.get('poison-op-break', {}).get('selfCheck', 'OK') != 'OK',
+    )
+    check(
+        'self-check: clean control passes the runner self-check',
+        rows.get('clean-control', {}).get('selfCheck') == 'OK',
+    )
+
+    check(
         'signature: ghost widget recorded in the load signature',
         'poison_ghost=GHOST'
         in (ops('poison-desync').get('load') or {}).get('sig', ''),

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -49,6 +49,7 @@
     "src/types/**/*.d.ts",
     "playwright.config.ts",
     "playwright.i18n.config.ts",
+    "scripts/registry-census/**/*.ts",
     "vite.config.mts",
     "vitest.config.ts"
     // "vitest.setup.ts",

--- a/vitest.matrix.config.mts
+++ b/vitest.matrix.config.mts
@@ -4,13 +4,17 @@ import base from './vite.config.mts'
 
 // The ecosystem matrix: generated per-pack specs (scripts/registry-census/
 // build_matrix.py) that execute real custom-node pack JS against the real
-// frontend runtime. Radar, never a gate - run via the registry-census
-// workflow or locally, never as part of test:unit. include/exclude are
-// assigned after the merge: mergeConfig concatenates arrays, which would
-// otherwise carry the base config's exclusion of this very directory.
+// frontend runtime. Run via the registry-census workflow or locally, never
+// as part of test:unit. include/exclude/setupFiles are assigned after the
+// merge: mergeConfig CONCATENATES arrays, which would otherwise carry the
+// base config's exclusion of this very directory - and its setup files,
+// including vitest.timer.setup.ts, which would run every pack under fake
+// timers. Keep vitest.setup.ts (environment globals the runtime needs);
+// packs execute under real timers.
 const merged = mergeConfig(base, {
-  test: { coverage: { enabled: false }, retry: 0, setupFiles: [] }
+  test: { coverage: { enabled: false }, retry: 0 }
 })
 merged.test.include = ['src/__ecs_matrix__/*.matrix.test.ts']
 merged.test.exclude = [...configDefaults.exclude]
+merged.test.setupFiles = ['./vitest.setup.ts']
 export default merged


### PR DESCRIPTION
Follow-through on the maintainability audit: the weekly must not red (or hollow out) for reasons unrelated to custom nodes. Stacked on #15145 (-> #15110 -> #15081) so this diff is only the hardening.

## Plumbing (no measurement change)
- **The runner is now typechecked** (`tsconfig` includes `scripts/registry-census/**/*.ts`; 6 real errors fixed, all inside the harness file). A frontend rename of `registerNodeDef`/`createReroute`/`graphToPrompt` now breaks the renaming PR loudly instead of red-ing the next weekly as a false ecosystem FAIL. Generated `src/__ecs_matrix__` stays excluded.
- **Registry refresh survives the network**: curl `--retry 5`, falls back to the cached snapshot on failure, and refuses a snapshot that shrank >10% (API shape drift, not mass unpublishing). Previously one 5xx killed corpus -> shards -> verdict for the week.
- **Corpus fetch refuses partial completeness**: curl retries; >5% failed fetches fails the run instead of green-shipping a shrunken denominator.
- **Cache economics**: superseded ~1GB `registry-corpus-*` entries are pruned after each save (repo budget is 10GB shared; unpruned, the census would evict other workflows' caches within weeks). A Thursday cron keeps the cache inside GitHub's 7-day eviction window.
- **`matrix-verdict` runs `if: always()`**: one failed shard degrades to a partial verdict, not a skipped check.
- **build_matrix**: the rewrite regex required a non-empty relative prefix (it could hijack a pack's own `./scripts/utils.js` to OUR module - wrong-code-under-test); entry-cap truncation is now recorded in the manifest (the comment claimed it already was); missing corpus fails friendly.

## Measurement changes
- **Real timers.** `setupFiles: []` was a mergeConfig-concatenation no-op, so all 1,879 packs executed under the unit suite's `vi.useFakeTimers()` by accident. Now assigned explicitly: `vitest.setup.ts` kept, fake timers dropped. Poison proof re-validated under real timers (14/14 channels).
- **Criteria reworked against measured full-registry baselines** (1,879 packs, run 31563501583):

| criterion | floor | baseline |
|---|---|---|
| entry JS loads (any entry per pack) | >= 95% | 97.4% |
| **entry files load clean (new)** | >= 91% | 94.1% |
| registerNodeDef OK | >= 99% | 100% |
| every operation clean | >= 99% | 99.8% |
| **entry-clean delta vs previous run (new)** | >= -1.5pp | metrics carried by actions cache |

  The old gated metric was only "pack had >=1 entry load" - 59-of-60 entries failing still counted as loaded. The delta gate catches gradual erosion (97.4 -> 95.9) that absolute floors ignore.
- **Harness gate before any criterion**: the runner self-checks that the default workflow materialized (>=7 nodes, KSampler with widgets - the op-break poison proved a 0-node graph passes 15 if-guarded ops "clean"). If most packs fail self-check the verdict is **withheld as HARNESS FAILURE (exit 2)** - a degraded harness can no longer report a vacuously clean ecosystem or a false FAIL.

## Validated locally
- `pnpm typecheck` green with the runner included
- Poison corpus: `DETECTION PROOF PASSED` (14 checks incl. the two new self-check assertions), summarizer exit 1 naming three breaches
- Real 1,879-row corpus: **PASS** exit 0, metrics.json written (anyPct 97.392 / entryPct 94.091 / worstOp load 99.84)
- Simulated delta breach (prev entryPct 96.5): exit 1, `entry files clean dropped 2.4pp`
- Simulated broad self-check failure: exit 2, verdict withheld

Note: the fake-timer removal shifts measurement conditions; the first CI run of this PR re-baselines under real timers, and if entry-clean lands under the 91% floor the floor gets adjusted here before merge (that is what the review run is for).

Deferred by design (discussed): shard autoscaling vs registry growth; registerNodeDef floor kept as a pure harness canary; V1 DEFS drift is now loud via the self-check.