### PR TITLE
feat(billing): link to platform usage from the subscription footer

### DIFF
--- a/browser_tests/tests/dialogs/creditsTile.spec.ts
+++ b/browser_tests/tests/dialogs/creditsTile.spec.ts
@@ -301,9 +301,9 @@ test.describe('Credits tile (Plan & Credits)', { tag: '@cloud' }, () => {
       content.getByRole('tab', { name: 'Plan & Credits' })
     ).toBeVisible()
     await expect(content.getByRole('tab', { name: 'Members' })).toBeVisible()
-    await expect(content.getByRole('button', { name: 'Activity' })).toHaveCount(
-      0
-    )
+    await expect(
+      content.getByRole('button', { name: 'Activity', exact: true })
+    ).toHaveCount(0)
   })
 
   test('renders the unified tile with breakdown and add-credits', async ({

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2852,6 +2852,7 @@
     "tierNameYearly": "{name} Yearly",
     "messageSupport": "Message support",
     "invoiceHistory": "Invoice history",
+    "fullUsageActivity": "Full usage activity",
     "refreshCredits": "Refresh credits",
     "benefits": {
       "benefit1": "Monthly credits for Partner Nodes — top up when needed",

--- a/src/platform/cloud/subscription/components/SubscriptionFooterLinks.test.ts
+++ b/src/platform/cloud/subscription/components/SubscriptionFooterLinks.test.ts
@@ -2,6 +2,7 @@ import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { ref } from 'vue'
+import type { ComponentProps } from 'vue-component-type-helpers'
 import { createI18n } from 'vue-i18n'
 
 import SubscriptionFooterLinks from './SubscriptionFooterLinks.vue'
@@ -63,7 +64,9 @@ const i18n = createI18n({
   }
 })
 
-function renderComponent(props: Record<string, boolean> = {}) {
+function renderComponent(
+  props: Partial<ComponentProps<typeof SubscriptionFooterLinks>> = {}
+) {
   return render(SubscriptionFooterLinks, {
     props,
     global: {
@@ -148,7 +151,8 @@ describe('SubscriptionFooterLinks', () => {
 
     expect(openSpy).toHaveBeenCalledWith(
       'https://platform.comfy.org/profile/usage',
-      '_blank'
+      '_blank',
+      'noopener'
     )
   })
 

--- a/src/platform/cloud/subscription/components/SubscriptionFooterLinks.test.ts
+++ b/src/platform/cloud/subscription/components/SubscriptionFooterLinks.test.ts
@@ -1,14 +1,13 @@
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { computed, ref } from 'vue'
+import { ref } from 'vue'
 import { createI18n } from 'vue-i18n'
 
 import SubscriptionFooterLinks from './SubscriptionFooterLinks.vue'
 
 const state = vi.hoisted(() => ({
   isCloud: true,
-  workspaceRole: 'owner' as 'owner' | 'member',
   manageSubscription: vi.fn(),
   handleLearnMoreClick: vi.fn(),
   handleMessageSupport: vi.fn()
@@ -16,12 +15,6 @@ const state = vi.hoisted(() => ({
 
 vi.mock('@/config/comfyApi', () => ({
   getComfyPlatformBaseUrl: () => 'https://platform.comfy.org'
-}))
-
-vi.mock('@/platform/workspace/composables/useWorkspaceUI', () => ({
-  useWorkspaceUI: () => ({
-    workspaceRole: computed(() => state.workspaceRole)
-  })
 }))
 
 vi.mock('@/platform/distribution/types', () => ({
@@ -70,9 +63,9 @@ const i18n = createI18n({
   }
 })
 
-function renderComponent(showInvoiceHistory?: boolean) {
+function renderComponent(props: Record<string, boolean> = {}) {
   return render(SubscriptionFooterLinks, {
-    props: showInvoiceHistory === undefined ? {} : { showInvoiceHistory },
+    props,
     global: {
       plugins: [i18n],
       stubs: {
@@ -89,7 +82,6 @@ function renderComponent(showInvoiceHistory?: boolean) {
 describe('SubscriptionFooterLinks', () => {
   beforeEach(() => {
     state.isCloud = true
-    state.workspaceRole = 'owner'
   })
 
   it('renders working support links without a duplicate invoice action', async () => {
@@ -137,7 +129,7 @@ describe('SubscriptionFooterLinks', () => {
 
   it('hides Invoice history from local users without billing permission', () => {
     state.isCloud = false
-    renderComponent(false)
+    renderComponent({ showInvoiceHistory: false })
 
     expect(
       screen.queryByRole('button', { name: 'Invoice history' })
@@ -145,7 +137,7 @@ describe('SubscriptionFooterLinks', () => {
     expect(state.manageSubscription).not.toHaveBeenCalled()
   })
 
-  it('opens the platform usage page for workspace owners', async () => {
+  it('opens the platform usage page', async () => {
     const user = userEvent.setup()
     const openSpy = vi.spyOn(window, 'open').mockReturnValue(null)
     renderComponent()
@@ -160,9 +152,8 @@ describe('SubscriptionFooterLinks', () => {
     )
   })
 
-  it('hides Full usage activity from workspace members', () => {
-    state.workspaceRole = 'member'
-    renderComponent()
+  it('hides Full usage activity when the caller opts out', () => {
+    renderComponent({ showUsageActivity: false })
 
     expect(
       screen.queryByRole('button', { name: 'Full usage activity' })

--- a/src/platform/cloud/subscription/components/SubscriptionFooterLinks.test.ts
+++ b/src/platform/cloud/subscription/components/SubscriptionFooterLinks.test.ts
@@ -1,16 +1,27 @@
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { ref } from 'vue'
+import { computed, ref } from 'vue'
 import { createI18n } from 'vue-i18n'
 
 import SubscriptionFooterLinks from './SubscriptionFooterLinks.vue'
 
 const state = vi.hoisted(() => ({
   isCloud: true,
+  workspaceRole: 'owner' as 'owner' | 'member',
   manageSubscription: vi.fn(),
   handleLearnMoreClick: vi.fn(),
   handleMessageSupport: vi.fn()
+}))
+
+vi.mock('@/config/comfyApi', () => ({
+  getComfyPlatformBaseUrl: () => 'https://platform.comfy.org'
+}))
+
+vi.mock('@/platform/workspace/composables/useWorkspaceUI', () => ({
+  useWorkspaceUI: () => ({
+    workspaceRole: computed(() => state.workspaceRole)
+  })
 }))
 
 vi.mock('@/platform/distribution/types', () => ({
@@ -52,7 +63,8 @@ const i18n = createI18n({
         learnMore: 'Learn more',
         partnerNodesPricingTable: 'Partner Nodes pricing',
         messageSupport: 'Message support',
-        invoiceHistory: 'Invoice history'
+        invoiceHistory: 'Invoice history',
+        fullUsageActivity: 'Full usage activity'
       }
     }
   }
@@ -77,6 +89,7 @@ function renderComponent(showInvoiceHistory?: boolean) {
 describe('SubscriptionFooterLinks', () => {
   beforeEach(() => {
     state.isCloud = true
+    state.workspaceRole = 'owner'
   })
 
   it('renders working support links without a duplicate invoice action', async () => {
@@ -130,5 +143,29 @@ describe('SubscriptionFooterLinks', () => {
       screen.queryByRole('button', { name: 'Invoice history' })
     ).not.toBeInTheDocument()
     expect(state.manageSubscription).not.toHaveBeenCalled()
+  })
+
+  it('opens the platform usage page for workspace owners', async () => {
+    const user = userEvent.setup()
+    const openSpy = vi.spyOn(window, 'open').mockReturnValue(null)
+    renderComponent()
+
+    await user.click(
+      screen.getByRole('button', { name: 'Full usage activity' })
+    )
+
+    expect(openSpy).toHaveBeenCalledWith(
+      'https://platform.comfy.org/profile/usage',
+      '_blank'
+    )
+  })
+
+  it('hides Full usage activity from workspace members', () => {
+    state.workspaceRole = 'member'
+    renderComponent()
+
+    expect(
+      screen.queryByRole('button', { name: 'Full usage activity' })
+    ).not.toBeInTheDocument()
   })
 })

--- a/src/platform/cloud/subscription/components/SubscriptionFooterLinks.vue
+++ b/src/platform/cloud/subscription/components/SubscriptionFooterLinks.vue
@@ -4,7 +4,7 @@
   >
     <div class="flex gap-2">
       <Button
-        v-if="isWorkspaceOwner"
+        v-if="showUsageActivity"
         variant="muted-textonly"
         class="text-xs text-text-secondary"
         @click="handleFullUsageActivity"
@@ -52,26 +52,19 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
-
 import Button from '@/components/ui/button/Button.vue'
 import { useBillingContext } from '@/composables/billing/useBillingContext'
 import { useExternalLink } from '@/composables/useExternalLink'
 import { getComfyPlatformBaseUrl } from '@/config/comfyApi'
 import { useSubscriptionActions } from '@/platform/cloud/subscription/composables/useSubscriptionActions'
 import { isCloud } from '@/platform/distribution/types'
-import { useWorkspaceUI } from '@/platform/workspace/composables/useWorkspaceUI'
 
-const { showInvoiceHistory = true } = defineProps<{
+const { showInvoiceHistory = true, showUsageActivity = true } = defineProps<{
   showInvoiceHistory?: boolean
+  showUsageActivity?: boolean
 }>()
 
 const { buildDocsUrl, docsPaths } = useExternalLink()
-
-const { workspaceRole } = useWorkspaceUI()
-
-// Personal workspaces resolve to 'owner', so this covers both plan types.
-const isWorkspaceOwner = computed(() => workspaceRole.value === 'owner')
 
 const { manageSubscription } = useBillingContext()
 

--- a/src/platform/cloud/subscription/components/SubscriptionFooterLinks.vue
+++ b/src/platform/cloud/subscription/components/SubscriptionFooterLinks.vue
@@ -4,6 +4,15 @@
   >
     <div class="flex gap-2">
       <Button
+        v-if="isWorkspaceOwner"
+        variant="muted-textonly"
+        class="text-xs text-text-secondary"
+        @click="handleFullUsageActivity"
+      >
+        <i class="pi pi-external-link text-xs text-text-secondary" />
+        {{ $t('subscription.fullUsageActivity') }}
+      </Button>
+      <Button
         variant="muted-textonly"
         class="text-xs text-text-secondary"
         @click="handleLearnMoreClick"
@@ -43,17 +52,26 @@
 </template>
 
 <script setup lang="ts">
+import { computed } from 'vue'
+
 import Button from '@/components/ui/button/Button.vue'
 import { useBillingContext } from '@/composables/billing/useBillingContext'
 import { useExternalLink } from '@/composables/useExternalLink'
+import { getComfyPlatformBaseUrl } from '@/config/comfyApi'
 import { useSubscriptionActions } from '@/platform/cloud/subscription/composables/useSubscriptionActions'
 import { isCloud } from '@/platform/distribution/types'
+import { useWorkspaceUI } from '@/platform/workspace/composables/useWorkspaceUI'
 
 const { showInvoiceHistory = true } = defineProps<{
   showInvoiceHistory?: boolean
 }>()
 
 const { buildDocsUrl, docsPaths } = useExternalLink()
+
+const { workspaceRole } = useWorkspaceUI()
+
+// Personal workspaces resolve to 'owner', so this covers both plan types.
+const isWorkspaceOwner = computed(() => workspaceRole.value === 'owner')
 
 const { manageSubscription } = useBillingContext()
 
@@ -63,6 +81,10 @@ const { isLoadingSupport, handleMessageSupport, handleLearnMoreClick } =
 async function handleInvoiceHistory() {
   if (!showInvoiceHistory) return
   await manageSubscription()
+}
+
+function handleFullUsageActivity() {
+  window.open(`${getComfyPlatformBaseUrl()}/profile/usage`, '_blank')
 }
 
 function handleOpenPartnerNodesInfo() {

--- a/src/platform/cloud/subscription/components/SubscriptionFooterLinks.vue
+++ b/src/platform/cloud/subscription/components/SubscriptionFooterLinks.vue
@@ -77,7 +77,11 @@ async function handleInvoiceHistory() {
 }
 
 function handleFullUsageActivity() {
-  window.open(`${getComfyPlatformBaseUrl()}/profile/usage`, '_blank')
+  window.open(
+    `${getComfyPlatformBaseUrl()}/profile/usage`,
+    '_blank',
+    'noopener'
+  )
 }
 
 function handleOpenPartnerNodesInfo() {

--- a/src/platform/workspace/components/SubscriptionPanelContentWorkspace.vue
+++ b/src/platform/workspace/components/SubscriptionPanelContentWorkspace.vue
@@ -399,6 +399,7 @@
       <SubscriptionFooterLinks
         class="mt-auto pt-6"
         :show-invoice-history="permissions.canManageSubscription"
+        :show-usage-activity="workspaceRole === 'owner'"
       />
     </template>
   </div>
@@ -435,7 +436,7 @@ import {
 const workspaceStore = useTeamWorkspaceStore()
 const { isWorkspaceSubscribed, isInPersonalWorkspace } =
   storeToRefs(workspaceStore)
-const { permissions, isSubscriptionCancelled } = useWorkspaceUI()
+const { permissions, isSubscriptionCancelled, workspaceRole } = useWorkspaceUI()
 const { maxAvailable: freeRunsAllowance, quotaEnabled: freeRunsQuotaEnabled } =
   useFreeTierQuota()
 const { t, n, locale } = useI18n()


### PR DESCRIPTION
## Summary

Adds a `Full usage activity` link to the subscription settings footer, opening `platform.comfy.org/profile/usage` in a new tab.

## Why

The only existing route to the platform usage view is the `Full activity` link in the workspace **Activity** tab, which is gated behind `billing_control_enabled` and — more importantly — is not usable yet: `useWorkspaceActivity` defaults to an empty result, and the issue that would wire real data (FE-1249) is in Backlog with both of its PRs closed as drafts ([#13734](https://github.com/Comfy-Org/ComfyUI_frontend/pull/13734), cloud [#5136](https://github.com/Comfy-Org/cloud/pull/5136)).

This gives users a working route to their usage history without waiting on that, and without needing the flag flipped.

## Changes

- `SubscriptionFooterLinks.vue` — new leading link in the left group, reusing the existing `getComfyPlatformBaseUrl()` helper
- `subscription.fullUsageActivity` in `en/main.json`
- Two test cases: opens the correct URL for owners, hidden for members

## Gating

Owner-only, via `workspaceRole === 'owner'`. That single check covers both plan types on purpose — `useWorkspaceUI` resolves `workspaceRole` as `store.activeWorkspace?.role ?? 'owner'`, so a personal subscriber (no active team workspace) is an owner and sees the link, while a team **member** does not. This matches the existing scoping on the Activity tab's own link.

Expressed as one check inside the component rather than a prop threaded through both call sites, since it is one rule; `useSubscriptionDialog.ts` sets the precedent for importing `useWorkspaceUI` from this folder.

## Notes for review

- Uses `pi pi-external-link` to match the three sibling links in this component. Repo guidance prefers `icon-[lucide--*]`, but mixing icon sets within one row would look wrong — the whole footer is worth a separate lucide sweep.
- English only; the other 13 locales fall back until the next translation pass.
- When the Activity tab does ship, its footer already has a `Full activity` link to this same URL. Two near-identically-labelled links in one dialog will need reconciling — either drop one or differentiate the labels.

## Validation

- `pnpm test:unit` on `SubscriptionFooterLinks` — 5 passed
- `pnpm typecheck`, `pnpm format`, `pnpm knip` clean; `pnpm lint` warnings are all pre-existing in unrelated files

Linear: DES-479 · FE-1247 (related)

## Screenshots
<img width="756" height="194" alt="image" src="https://github.com/user-attachments/assets/610de256-a923-439b-b79c-2fd8147896fc" />
