### PR TITLE
test(website): guard the upcoming-events e2e when none are upcoming

### DIFF
--- a/apps/website/e2e/events.spec.ts
+++ b/apps/website/e2e/events.spec.ts
@@ -309,6 +309,7 @@ test.describe('Events page — mobile @mobile', () => {
   })
 
   test('upcoming event rows stay within viewport width', async ({ page }) => {
+    test.skip(upcomingEvents.length === 0, 'needs an upcoming event')
     await page.goto(PATH_EN)
     const section = upcomingSection(page, 'en')
     const firstRow = section.locator('li').first()


### PR DESCRIPTION
## Summary

Fixes a time-bomb in the website events e2e that has been failing every `website-e2e` run since ~2026-08-12 11:00 PDT, independent of the PR under test.

## Root cause

The events page derives its upcoming list at build time from the real clock (`BUILD_NOW = new Date()`, `EVENT_DURATION_MS = 1h`). The newest configured event ends `2026-08-12T11:00 PDT`; once that passed, `upcomingEvents` became empty, so the "Upcoming events" section renders no rows.

`upcoming event rows stay within viewport width` then times out on `section.locator('li').first().scrollIntoViewIfNeeded()`. It was the only upcoming-events test without an empty guard — the livestream test already does `test.skip(!event, ...)`, and the count-based assertions already scale to zero.

## Changes

- **What**: `test.skip(upcomingEvents.length === 0, 'needs an upcoming event')` at the top of that one test, matching the existing guard idiom in the file. No production code touched.

## Review Focus

- This is the layout/overflow check; with zero upcoming rows there is nothing to measure, so skipping is correct rather than asserting an empty section.
- Separate concern (not fixed here): the live events page now genuinely shows no upcoming events. That is a content refresh for the events owner, not a test change.