### PR TITLE
feat(website): add the Q&A section to the LTX 2.5 page

### DIFF
--- a/apps/website/e2e/ltx-2.5.spec.ts
+++ b/apps/website/e2e/ltx-2.5.spec.ts
@@ -5,6 +5,7 @@ import { creatorReviews } from '../src/data/creatorReviews'
 import { ltxPage } from '../src/data/ltx'
 import { t } from '../src/i18n/translations'
 import { test } from './fixtures/blockExternalMedia'
+import { waitForIsland } from './fixtures/islands'
 
 const PATH = '/ltx-2.5'
 const ZH_PATH = '/zh-CN/ltx-2.5'
@@ -24,6 +25,13 @@ const REQUIRED_BADGES = 4
 const REQUIRED_CARDS = 6
 
 const BADGE_KEYS = ltxPage.hero.badgeKeys ?? []
+
+// `faq` is optional on the template, but this page must have it, so fail loudly
+// rather than silently testing nothing.
+const FAQ_SECTION = ltxPage.faq
+if (!FAQ_SECTION) throw new Error('ltxPage must configure a FAQ section')
+const FAQS = FAQ_SECTION.items
+const FIRST_FAQ = FAQS[0]
 
 const GALLERY = ltxPage.gallery
 if (!GALLERY) throw new Error('ltxPage must configure a gallery')
@@ -158,6 +166,70 @@ test.describe('LTX 2.5 gallery', () => {
         gallery.locator(`video[poster="${card.media.posterSrc}"]`)
       ).toHaveCount(1)
     }
+  })
+})
+
+test.describe('LTX 2.5 Q&A', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(PATH)
+  })
+
+  test('emits FAQPage structured data with one entry per FAQ', async ({
+    page
+  }) => {
+    const faqJsonLd = await page.evaluate(() => {
+      const scripts = Array.from(
+        document.querySelectorAll<HTMLScriptElement>(
+          'script[type="application/ld+json"]'
+        )
+      )
+      return (
+        scripts.find((s) => (s.textContent ?? '').includes('FAQPage'))
+          ?.textContent ?? null
+      )
+    })
+    expect(faqJsonLd, 'FAQ JSON-LD script').not.toBeNull()
+    const graph = JSON.parse(faqJsonLd!)['@graph'] as {
+      '@type': string
+      mainEntity?: unknown[]
+    }[]
+    const faqPage = graph.find((node) => node['@type'] === 'FAQPage')
+    expect(faqPage, 'FAQPage node in @graph').toBeDefined()
+    expect(faqPage!.mainEntity!.length).toBe(FAQS.length)
+  })
+
+  test('FAQ items toggle open and closed on click', async ({ page }) => {
+    const firstQuestion = page.getByRole('button', {
+      name: FIRST_FAQ.question.en
+    })
+    await waitForIsland(page, firstQuestion)
+    await expect(firstQuestion).toHaveAttribute('aria-expanded', 'false')
+
+    await firstQuestion.click()
+    await expect(firstQuestion).toHaveAttribute('aria-expanded', 'true')
+    await expect(page.getByText(FIRST_FAQ.answer.en)).toBeVisible()
+
+    await firstQuestion.click()
+    await expect(firstQuestion).toHaveAttribute('aria-expanded', 'false')
+  })
+
+  // The weights link is the only markup the answer parser supports, so it is
+  // worth proving it renders as an anchor rather than literal markdown.
+  test('renders the weights link inside an answer as a real link', async ({
+    page
+  }) => {
+    const faq = FAQS.find((item) => item.id === 'run-in-comfyui')
+    if (!faq) throw new Error('the run-in-comfyui FAQ carries the link')
+
+    const question = page.getByRole('button', { name: faq.question.en })
+    await waitForIsland(page, question)
+    await question.click()
+
+    const link = page.getByRole('link', { name: 'LTX 2.5 weights' })
+    await expect(link).toHaveAttribute(
+      'href',
+      'https://huggingface.co/Lightricks/LTX-2.5'
+    )
   })
 })
 

--- a/apps/website/e2e/ltx-2.5.spec.ts
+++ b/apps/website/e2e/ltx-2.5.spec.ts
@@ -19,10 +19,11 @@ const FIRST_REVIEW = creatorReviews[0]
 const LTX_RUN_TEMPLATE = 'https://cloud.comfy.org/?template=video_ltx2_5_i2v'
 const LTX_HUB_MODEL = 'https://comfy.org/workflows/model/ltx'
 
-// Counts are fixed rather than read off the config: four labels and six cards are
-// the launch requirement, and deriving them would let a dropped one pass.
+// Counts are the launch requirement, not a snapshot of the config: deriving them
+// would let a dropped badge, card or Q&A entry pass.
 const REQUIRED_BADGES = 4
 const REQUIRED_CARDS = 6
+const REQUIRED_FAQS = 9
 
 const BADGE_KEYS = ltxPage.hero.badgeKeys ?? []
 
@@ -195,7 +196,7 @@ test.describe('LTX 2.5 Q&A', () => {
     }[]
     const faqPage = graph.find((node) => node['@type'] === 'FAQPage')
     expect(faqPage, 'FAQPage node in @graph').toBeDefined()
-    expect(faqPage!.mainEntity!.length).toBe(FAQS.length)
+    expect(faqPage!.mainEntity!.length).toBe(REQUIRED_FAQS)
   })
 
   test('FAQ items toggle open and closed on click', async ({ page }) => {

--- a/apps/website/src/data/ltx.ts
+++ b/apps/website/src/data/ltx.ts
@@ -169,6 +169,119 @@ export const ltxPage: ModelLaunchPage = {
       }
     }
   },
+  faq: {
+    headingKey: 'ltx.faq.heading',
+    items: [
+      {
+        id: 'what-is-ltx',
+        question: {
+          en: 'What is LTX 2.5?',
+          'zh-CN': 'LTX 2.5 是什么？'
+        },
+        answer: {
+          en: "LTX 2.5 is the newest version of LTX's open video model, with day-0 support in ComfyUI. Weights are downloadable, and it runs fast on local GPUs. Native 4K, synchronized audio and video, and frame rates up to 50fps.",
+          'zh-CN':
+            'LTX 2.5 是 LTX 开源视频模型的最新版本，在 ComfyUI 中提供首日支持。权重可下载，在本地 GPU 上运行速度很快。原生 4K、音视频同步，帧率最高 50fps。'
+        }
+      },
+      {
+        id: 'whats-new-in-25',
+        question: {
+          en: "What's new in LTX 2.5 vs LTX 2.3?",
+          'zh-CN': 'LTX 2.5 相比 LTX 2.3 有哪些新变化？'
+        },
+        answer: {
+          en: 'LTX 2.5 improves the full generation stack rather than a single stage. New in this release: Diffusion Fidelity Rendering, a diffusion video decoder, a custom text encoder, a reworked distilled variant, a prompt enhancer, and a base checkpoint built for adaptation. Native 4K, synchronized audio, and up to 50fps carry over from 2.3.',
+          'zh-CN':
+            'LTX 2.5 改进的是整个生成流程，而不是单一环节。本次发布的新内容包括：Diffusion Fidelity Rendering、扩散视频解码器、自定义文本编码器、重新设计的蒸馏版本、提示词增强器，以及为适配训练打造的基础检查点。原生 4K、音视频同步与最高 50fps 由 2.3 延续而来。'
+        }
+      },
+      {
+        id: 'diffusion-fidelity-rendering',
+        question: {
+          en: 'What is Diffusion Fidelity Rendering?',
+          'zh-CN': '什么是 Diffusion Fidelity Rendering？'
+        },
+        answer: {
+          en: 'The core change in this release. Instead of spending compute evenly across a scene, the model allocates it by complexity. Structure comes first: motion, composition, and framing generate in an 8x temporally compressed latent space, alongside a set of high-fidelity keyframes, more for complex scenes and fewer for simple ones.\n\nA dedicated pixel-diffusion stage then renders the final video from structure and keyframes together. Textures, materials, intricate objects, and faces resolve with pixel-level precision, and busy shots draw more rendering compute than static ones.',
+          'zh-CN':
+            '这是本次发布的核心变化。模型不再把算力均匀分配到整个画面，而是按复杂度分配。先生成结构：运动、构图与取景在 8 倍时间压缩的潜空间中生成，同时产出一组高保真关键帧，复杂镜头多一些，简单镜头少一些。\n\n随后由专门的像素扩散阶段，结合结构与关键帧渲染出最终视频。纹理、材质、精细物体与人物面部都能达到像素级精度，画面越繁复，分配到的渲染算力就越多。'
+        }
+      },
+      {
+        id: 'which-variant',
+        question: {
+          en: 'Which LTX 2.5 variant should I use?',
+          'zh-CN': '我应该使用哪个 LTX 2.5 版本？'
+        },
+        answer: {
+          en: 'Open weights you run yourself. LTX 2.5 dev is the main model. LTX 2.5 distilled is a smaller, faster variant that now carries more quality, prompt adherence, and motion than earlier distilled releases.\n\nThrough Partner Nodes. LTX 2.5 (Fast) covers the wider envelope at 2 to 20 seconds, 720p through 4K, landscape or portrait, at 24, 25, 48, or 50fps. LTX 2.5 (Pro) runs 2 to 10 seconds at 720p or 1080p, at 24, 25, or 50fps.',
+          'zh-CN':
+            '自行运行的开放权重。LTX 2.5 dev 是主力模型。LTX 2.5 distilled 是体积更小、速度更快的版本，在画质、提示词遵循度与运动表现上都优于此前的蒸馏版本。\n\n通过合作伙伴节点运行。LTX 2.5 (Fast) 覆盖更宽的范围：2 到 20 秒，720p 至 4K，横屏或竖屏，帧率 24、25、48 或 50fps。LTX 2.5 (Pro) 支持 2 到 10 秒，720p 或 1080p，帧率 24、25 或 50fps。'
+        }
+      },
+      {
+        id: 'run-in-comfyui',
+        question: {
+          en: 'How do I run LTX 2.5 in ComfyUI?',
+          'zh-CN': '如何在 ComfyUI 中运行 LTX 2.5？'
+        },
+        answer: {
+          en: '1. Update ComfyUI to 0.32.0, or open Comfy Cloud.\n2. Download the [LTX 2.5 weights](https://huggingface.co/Lightricks/LTX-2.5) from Hugging Face and place them in your models directory.\n3. Load the LTX 2.5 template from the Templates panel: T2V, I2V, or FLF2V.\n4. Add your prompt and input images, then run.',
+          'zh-CN':
+            '1. 将 ComfyUI 更新到 0.32.0，或打开 Comfy Cloud。\n2. 从 Hugging Face 下载 [LTX 2.5 权重](https://huggingface.co/Lightricks/LTX-2.5)，放入你的模型目录。\n3. 在模板面板中加载 LTX 2.5 模板：T2V、I2V 或 FLF2V。\n4. 填入提示词和输入图像，然后运行。'
+        }
+      },
+      {
+        id: 'clip-length',
+        question: {
+          en: 'How long can LTX 2.5 videos be?',
+          'zh-CN': 'LTX 2.5 能生成多长的视频？'
+        },
+        answer: {
+          en: 'Through Partner Nodes, Fast runs 2 to 20 seconds, with clips over 10 seconds capped at 720p or 1080p and 24 or 25fps. Pro runs 2 to 10 seconds. LTX 2.5 also ships an experimental duration head that reads the action in your prompt and sets clip length before diffusion starts.',
+          'zh-CN':
+            '通过合作伙伴节点，Fast 支持 2 到 20 秒，超过 10 秒的片段上限为 720p 或 1080p、24 或 25fps。Pro 支持 2 到 10 秒。LTX 2.5 还提供一个实验性的时长预测模块，它会读取提示词中的动作，在扩散开始前确定片段长度。'
+        }
+      },
+      {
+        id: 'native-audio',
+        question: {
+          en: 'Does LTX 2.5 generate audio?',
+          'zh-CN': 'LTX 2.5 会生成音频吗？'
+        },
+        answer: {
+          en: 'Yes. Synchronized audio and video carry over from LTX 2.3, and multi-shot generations hold voice across cuts.',
+          'zh-CN':
+            '会。音视频同步由 LTX 2.3 延续而来，多镜头生成还能在镜头切换之间保持人物声音一致。'
+        }
+      },
+      {
+        id: 'multi-shot',
+        question: {
+          en: 'Can LTX 2.5 generate more than one shot?',
+          'zh-CN': 'LTX 2.5 能生成多个镜头吗？'
+        },
+        answer: {
+          en: 'Yes. One generation produces multiple connected shots, holding character, environment, lighting, voice, and style across the cuts. You get a sequence from a single run instead of matching separate generations afterward.',
+          'zh-CN':
+            '可以。一次生成即可产出多个连贯镜头，并在镜头切换之间保持人物、环境、光线、声音与风格一致。你只需运行一次就能得到完整段落，无需事后手动匹配多次生成的结果。'
+        }
+      },
+      {
+        id: 'is-it-free',
+        question: {
+          en: 'Is LTX 2.5 free to use?',
+          'zh-CN': 'LTX 2.5 可以免费使用吗？'
+        },
+        answer: {
+          en: 'Open weights are free to download and run on your own hardware. Running LTX 2.5 through Partner Nodes is pay-as-you-go and uses credits.',
+          'zh-CN':
+            '开放权重可免费下载并在你自己的硬件上运行。通过合作伙伴节点运行 LTX 2.5 为按量付费，消耗额度。'
+        }
+      }
+    ]
+  },
   runOptions: {
     headingKey: 'ltx.runOptions.heading',
     subtitleKey: 'ltx.runOptions.subtitle',

--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -4855,6 +4855,10 @@ const translations = {
     en: 'Made with LTX 2.5',
     'zh-CN': '用 LTX 2.5 制作'
   },
+  'ltx.faq.heading': {
+    en: 'Q&A',
+    'zh-CN': '问答'
+  },
   'ltx.hero.primaryCta': {
     en: 'RUN LTX 2.5',
     'zh-CN': '运行 LTX 2.5'


### PR DESCRIPTION
## Summary

Adds the Q&A section to `/ltx-2.5`. It was held back at launch because the copy was not ready; the copy now exists, so the page gets the same FAQ module every other model page uses.

## Changes

- `data/ltx.ts` — a `faq` section with nine entries, English and hand-translated zh-CN. Renders through the existing `ModelLaunchFaqSection` and `FAQSplit01`; no new components and no template changes.
- `i18n/translations.ts` — `ltx.faq.heading` (`Q&A` / `问答`), matching `seedance.faq.heading`.
- `e2e/ltx-2.5.spec.ts` — FAQPage structured data count, accordion open/close, and the weights link.

Content is transcribed from the approved draft. Source for the copy is the [LTX 2.5 day-0 blog post](https://blog.comfy.org/p/ltx-25-day-0-support-in-comfyui).

## Review focus

- **Naming normalised.** The draft wrote `LTX-2.5` and `LTX-2.3` with hyphens; the rest of this page (hero, breadcrumb, cards, nav, footer) uses `LTX 2.5`. Transcribed to the page's convention so the same page does not use both. The Hugging Face URL keeps its own hyphen, since that is a real path.
- **Two answers needed reshaping**, because `parseFaqAnswer` supports `[label](url)` links and nothing else. The "how do I run" answer's `<ol>` became four numbered lines, and the `<strong>` labels in "which variant" became plain topic sentences. `whitespace-pre-line` on the answer means the line and paragraph breaks survive. No markup was invented.
- The section lands between pricing and Run Options, which is where the template renders it.

## Verification

- `astro check` 0 errors, `vitest` 396 pass, `playwright e2e/ltx-2.5.spec.ts` 15 pass
- `validate:jsonld` passes across 596 pages, and the FAQPage node carries 9 entries with the link flattened to its anchor text rather than raw markdown
- Rendered both locales: heading, all nine questions, paragraph breaks, the numbered list, and the weights link as a real anchor
