### PR TITLE
test: cover space pan regressions

### DIFF
--- a/browser_tests/tests/vueNodes/interactions/canvas/pan.spec.ts
+++ b/browser_tests/tests/vueNodes/interactions/canvas/pan.spec.ts
@@ -71,6 +71,83 @@ test.describe('Vue Nodes Canvas Pan', { tag: '@vue-nodes' }, () => {
   })
 
   test(
+    'Space in a focused text widget does not start canvas panning',
+    { tag: ['@canvas', '@widget'] },
+    async ({ comfyPage }) => {
+      await comfyPage.workflow.loadWorkflow('inputs/string_input')
+      const input = comfyPage.vueNodes
+        .getWidgetByName('Node With String Input', 'string_input')
+        .first()
+
+      await input.focus()
+      await input.press('Space')
+
+      await expect
+        .poll(async () => [
+          await input.inputValue(),
+          await comfyPage.canvasOps.isReadOnly()
+        ])
+        .toEqual([' ', false])
+    }
+  )
+
+  test(
+    'releasing the pointer during Space-pan ends the node drag',
+    { tag: ['@canvas', '@node'] },
+    async ({ comfyPage }) => {
+      await comfyPage.workflow.loadWorkflow('vueNodes/simple-triple')
+      const node = await comfyPage.vueNodes.getFixtureByTitle('KSampler')
+      const [nodeRef] = await comfyPage.nodeOps.getNodeRefsByTitle('KSampler')
+      const headerBox = await node.header.boundingBox()
+      if (!nodeRef || !headerBox) throw new Error('KSampler is not rendered')
+      const start = {
+        x: headerBox.x + headerBox.width / 2,
+        y: headerBox.y + headerBox.height / 2
+      }
+      let mouseDown = false
+      let spaceDown = false
+
+      try {
+        await comfyPage.page.mouse.move(start.x, start.y)
+        await comfyPage.page.mouse.down()
+        mouseDown = true
+        await comfyPage.page.mouse.move(start.x + 40, start.y + 40, {
+          steps: 5
+        })
+        await comfyPage.page.keyboard.down('Space')
+        spaceDown = true
+        await comfyPage.page.mouse.move(start.x + 80, start.y + 80, {
+          steps: 5
+        })
+        await comfyPage.page.mouse.up()
+        mouseDown = false
+        await comfyPage.page.keyboard.up('Space')
+        spaceDown = false
+
+        const positionAfterRelease = [
+          ...(await nodeRef.getProperty<[number, number]>('pos'))
+        ]
+        const headerAfterRelease = await node.header.boundingBox()
+        if (!headerAfterRelease) throw new Error('KSampler is not rendered')
+        await comfyPage.page.mouse.move(
+          headerAfterRelease.x + 5,
+          headerAfterRelease.y + 5
+        )
+        await comfyPage.nextFrame()
+
+        await expect
+          .poll(async () => [
+            ...(await nodeRef.getProperty<[number, number]>('pos'))
+          ])
+          .toEqual(positionAfterRelease)
+      } finally {
+        if (mouseDown) await comfyPage.page.mouse.up()
+        if (spaceDown) await comfyPage.page.keyboard.up('Space')
+      }
+    }
+  )
+
+  test(
     '@mobile Can pan with touch',
     { tag: '@screenshot' },
     async ({ comfyPage }) => {

--- a/browser_tests/tests/vueNodes/interactions/canvas/pan.spec.ts
+++ b/browser_tests/tests/vueNodes/interactions/canvas/pan.spec.ts
@@ -116,6 +116,7 @@ test.describe('Vue Nodes Canvas Pan', { tag: '@vue-nodes' }, () => {
         })
         await comfyPage.page.keyboard.down('Space')
         spaceDown = true
+        await expect.poll(() => comfyPage.canvasOps.isReadOnly()).toBe(true)
         await comfyPage.page.mouse.move(start.x + 80, start.y + 80, {
           steps: 5
         })

--- a/src/components/graph/GraphCanvas.vue
+++ b/src/components/graph/GraphCanvas.vue
@@ -624,7 +624,7 @@ function forwardSpaceKeyEvent(e: KeyboardEvent) {
   if (shouldIgnoreCopyPaste(e.target) && document.activeElement === e.target)
     return
 
-  canvasInteractions.forwardEventToCanvas(e)
+  comfyApp.canvas?.processKey(e)
 }
 
 function forwardPanEvent(

--- a/src/components/graph/GraphCanvas.vue
+++ b/src/components/graph/GraphCanvas.vue
@@ -70,7 +70,7 @@
     @pointerdown.capture="forwardPointerDownPanEvent"
     @pointerup.capture="forwardPointerUpPanEvent"
     @pointermove.capture="forwardPointerMovePanEvent"
-    @keydown.space="canvasInteractions.forwardEventToCanvas"
+    @keydown.space="forwardSpaceKeyEvent"
   >
     <!-- Vue nodes rendered based on graph nodes -->
     <LGraphNode
@@ -618,6 +618,13 @@ function forwardPointerMovePanEvent(e: PointerEvent) {
 
 function forwardPointerUpPanEvent(e: PointerEvent) {
   forwardPanEvent(e, isMiddleButtonEvent)
+}
+
+function forwardSpaceKeyEvent(e: KeyboardEvent) {
+  if (shouldIgnoreCopyPaste(e.target) && document.activeElement === e.target)
+    return
+
+  canvasInteractions.forwardEventToCanvas(e)
 }
 
 function forwardPanEvent(

--- a/src/renderer/core/canvas/useCanvasInteractions.ts
+++ b/src/renderer/core/canvas/useCanvasInteractions.ts
@@ -148,13 +148,17 @@ export function useCanvasInteractions() {
       return
     }
 
-    // Create new event with same properties
-    const EventConstructor = event.constructor as
-      | typeof MouseEvent
-      | typeof PointerEvent
-      | typeof KeyboardEvent
-    const newEvent = new EventConstructor(event.type, event)
-    canvasEl.dispatchEvent(newEvent)
+    if (event instanceof PointerEvent) {
+      canvasEl.dispatchEvent(new PointerEvent(event.type, event))
+      return
+    }
+
+    if (event instanceof KeyboardEvent) {
+      canvasEl.dispatchEvent(new KeyboardEvent(event.type, event))
+      return
+    }
+
+    canvasEl.dispatchEvent(new MouseEvent(event.type, event))
   }
 
   return {

--- a/src/renderer/core/canvas/useCanvasInteractions.ts
+++ b/src/renderer/core/canvas/useCanvasInteractions.ts
@@ -121,7 +121,7 @@ export function useCanvasInteractions() {
    * Forwards an event to the LiteGraph canvas
    */
   const forwardEventToCanvas = (
-    event: WheelEvent | PointerEvent | MouseEvent | KeyboardEvent
+    event: WheelEvent | PointerEvent | MouseEvent
   ) => {
     // Honor wheel capture only when the element is focused
     if (event instanceof WheelEvent && !shouldForwardWheelEvent(event)) return
@@ -150,11 +150,6 @@ export function useCanvasInteractions() {
 
     if (event instanceof PointerEvent) {
       canvasEl.dispatchEvent(new PointerEvent(event.type, event))
-      return
-    }
-
-    if (event instanceof KeyboardEvent) {
-      canvasEl.dispatchEvent(new KeyboardEvent(event.type, event))
       return
     }
 

--- a/src/renderer/core/canvas/useCanvasInteractions.ts
+++ b/src/renderer/core/canvas/useCanvasInteractions.ts
@@ -121,7 +121,7 @@ export function useCanvasInteractions() {
    * Forwards an event to the LiteGraph canvas
    */
   const forwardEventToCanvas = (
-    event: WheelEvent | PointerEvent | MouseEvent
+    event: WheelEvent | PointerEvent | MouseEvent | KeyboardEvent
   ) => {
     // Honor wheel capture only when the element is focused
     if (event instanceof WheelEvent && !shouldForwardWheelEvent(event)) return
@@ -152,6 +152,7 @@ export function useCanvasInteractions() {
     const EventConstructor = event.constructor as
       | typeof MouseEvent
       | typeof PointerEvent
+      | typeof KeyboardEvent
     const newEvent = new EventConstructor(event.type, event)
     canvasEl.dispatchEvent(newEvent)
   }

--- a/src/renderer/extensions/vueNodes/composables/useNodePointerInteractions.ts
+++ b/src/renderer/extensions/vueNodes/composables/useNodePointerInteractions.ts
@@ -142,6 +142,9 @@ export function useNodePointerInteractions(
     const canHandlePointer = shouldHandleNodePointerEvents.value
     if (!canHandlePointer) {
       forwardEventToCanvas(event)
+      if (hasDraggingStarted || layoutStore.isDraggingVueNodes.value) {
+        safeDragEnd(event)
+      }
       return
     }
     const wasDragging = layoutStore.isDraggingVueNodes.value


### PR DESCRIPTION
## Summary

Adds Playwright coverage and minimal fixes for two Space-pan regressions in the parent PR.

## Changes

- **What**: Keep Space input in focused text widgets instead of forwarding it to canvas panning.
- **What**: End the active Vue node drag when pointerup occurs during Space-pan.
- **Tests**: Cover focused text input and pointer-release behavior.

## Review Focus

The first commit contains the failing regression tests. The second commit contains the production fixes that make them pass.