### PR TITLE
fix(website): align slider tick labels to their tick

### DIFF
--- a/apps/website/src/components/ui/slider/Slider.vue
+++ b/apps/website/src/components/ui/slider/Slider.vue
@@ -92,11 +92,11 @@ function isTickFilled(
 
     <SliderTrack
       data-slot="slider-track"
-      class="bg-primary-warm-gray relative grow overflow-hidden rounded-full data-[orientation=horizontal]:h-1.5 data-[orientation=horizontal]:w-full"
+      class="relative grow overflow-hidden rounded-full bg-primary-warm-gray data-[orientation=horizontal]:h-1.5 data-[orientation=horizontal]:w-full"
     >
       <SliderRange
         data-slot="slider-range"
-        class="bg-primary-warm-white absolute data-[orientation=horizontal]:h-full"
+        class="absolute bg-primary-warm-white data-[orientation=horizontal]:h-full"
       />
     </SliderTrack>
 
@@ -106,7 +106,7 @@ function isTickFilled(
       data-slot="slider-thumb"
       :aria-label="thumbLabel"
       :aria-valuetext="thumbValueText"
-      class="bg-primary-warm-white border-primary-comfy-yellow ring-primary-comfy-yellow/50 block size-4 shrink-0 rounded-full border shadow-sm transition-[color,box-shadow] hover:ring-4 focus-visible:ring-4 focus-visible:outline-hidden disabled:pointer-events-none disabled:opacity-50"
+      class="border-primary-comfy-yellow ring-primary-comfy-yellow/50 block size-4 shrink-0 rounded-full border bg-primary-warm-white shadow-sm transition-[color,box-shadow] hover:ring-4 focus-visible:ring-4 focus-visible:outline-hidden disabled:pointer-events-none disabled:opacity-50"
     />
   </SliderRoot>
 
@@ -114,7 +114,7 @@ function isTickFilled(
     <div
       v-for="i in ticks"
       :key="i"
-      class="absolute top-0 inline-flex -translate-x-1/2 items-center gap-1.5"
+      class="absolute top-0 inline-flex -translate-x-2 items-center gap-1.5"
       :style="{ left: tickLeft(i) }"
     >
       <slot name="tick" :index="i - 1" :active="isTickActive(i)" />


### PR DESCRIPTION
## Summary

The team credit slider's tick labels were centred on their tick, so the first one straddled the track start and overhung the card. Left-aligns every label to its tick instead, with the credits icon centred on the tick dot.

## Why

`Slider.vue` positions each tick label at `left: calc(8px + ratio * (100% - 16px))` and centred it with `-translate-x-1/2`. For the first tick that put the label's *centre* 8px from the edge, so half of it — icon included — rendered outside the card. The row's left edge is flush with the card's 32px padding, so there was nowhere for it to go.

Pre-existing; not introduced by the icon change in #15156.

## Approach

One uniform rule rather than special-casing the ends: offset every label by half the icon (`-translate-x-2`) so each label's icon sits centred on its tick dot and the text flows right. Labels then read as "from this stop onward", which suits a tiered credit slider.

An earlier revision anchored the first and last labels to the track ends and left the middle ones centred. That kept everything inside the row but produced three different alignment behaviours in one row, which read as the edge labels being squeezed in.

Measured on `/cloud/pricing`, icon centres now land exactly on the tick dots:

| | tick dot | icon centre |
| --- | --- | --- |
| 1 | 8px | 8px |
| 2 | 148px | 148px |
| 3 | 288px | 288px |
| 4 | 428px | 428px |
| 5 | 568px | 568px |

The first label sits flush at 0 instead of 24px outside the card.

## Trade-off worth knowing

The last label now extends past the *label row* rather than being pulled inside it. Where that lands, measured against the card:

| viewport | last label vs card edge | icon |
| --- | --- | --- |
| desktop | 425px inside — extends into the grid gap, ~24px clear of the next column | centred on tick |
| tablet (768) | 2px past, i.e. it consumes the card's 32px padding | hidden below `lg` |
| mobile (375) | 12px inside | hidden below `lg` |

No horizontal document scroll at any width. The 2px at tablet is the only spill; pulling it back in would mean reintroducing a per-edge exception, which is the thing this revision removes.

## Note on the diff

Only the tick-label line is a behaviour change. The other three lines are `eslint --fix` normalizing Tailwind class order on the track, range and thumb — its class-order rule disagrees with main's order, and since it only runs on staged files, main was never normalized. Verified: reverting those lines and re-running the pre-commit fixers puts them straight back.

## Validation

- `pnpm --filter website test:unit` — 396 passed
- `astro check` — 0 errors, 0 warnings
- `pnpm format:check` clean
- Label and icon positions measured in the running dev server at desktop, tablet and mobile

The 4 `pricing-tiers-*-visual-linux.png` baselines will shift. They're Linux-rendered, so regenerating on macOS would produce wrong files — leaving that to CI.