### PR TITLE
test(custom-nodes): AudioConcatenate cannot run alone on Cloud

### DIFF
--- a/browser_tests/fixtures/data/cloud/cloudCannotRunAlone.json
+++ b/browser_tests/fixtures/data/cloud/cloudCannotRunAlone.json
@@ -117,6 +117,7 @@
   ],
   "ComfyUI_AudioTools": [
     "AudioBPMDetector",
+    "AudioConcatenate",
     "AudioReverb",
     "AudioVocalCompressor"
   ],

--- a/browser_tests/fixtures/data/customNodeManifest.cloud.json
+++ b/browser_tests/fixtures/data/customNodeManifest.cloud.json
@@ -550,6 +550,7 @@
       "timeoutMs": 30000,
       "cannotRunAlone": [
         "AudioBPMDetector",
+        "AudioConcatenate",
         "AudioReverb",
         "AudioVocalCompressor"
       ]


### PR DESCRIPTION
The only failure in [run 31553987373](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/31553987373) (this branch's last completed cloud run): `AudioConcatenate` rejects with 400 `required_input_missing` for `audio1`, `audio2`, and `direction` - it needs two wired audio inputs and belongs in `cannotRunAlone`. Two-line ledger addition (both cloud ledger files), mirroring the conclusion already reached independently on the tier-isolation branch.

- `pnpm exec playwright test manifest.pure --project=chromium`: 15 passed
- Green-candidate evidence run dispatched from this branch: [31651305020](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/31651305020)