### PR TITLE
fix: make locale planning and validation explicit

### DIFF
--- a/scripts/i18n/config.ts
+++ b/scripts/i18n/config.ts
@@ -28,6 +28,13 @@ const glossary = `Keep these names untranslated: flux, photomaker, clip, vae, cf
 'latent' is the short form of 'latent space'.
 'mask' is in the context of image processing.`
 
+const quoteCharacters = `['"“”‘’«»‹›„‚「」『』]`
+export const protectedLiteralPatterns = [
+  /<(?:Picture|Video|Audio) [A-Za-z0-9]+>/g,
+  /\b\d+k\+\d+\b/g,
+  new RegExp(`(?<=${quoteCharacters})(?:match|max)(?=${quoteCharacters})`, 'g')
+]
+
 const chineseSimplifiedGuidance = `Use ONLY Simplified Chinese characters (简体中文). Common examples: 节点 (not 節點), 画布 (not 畫布), 图像 (not 圖像), 选择 (not 選擇), 减小 (not 減小). NEVER mix Simplified and Traditional Chinese characters.`
 
 const chineseTraditionalGuidance = `Use ONLY Traditional Chinese characters (繁體中文) with Taiwan-specific terminology. NEVER mix Simplified and Traditional Chinese characters.`
@@ -51,7 +58,7 @@ export const translationPipelineConfig: TranslationPipelineConfig = {
   stateConcurrency: 3,
   requestConcurrency: 2,
   maxTranslationRounds: 3,
-  pruneCountFloor: 25,
+  pruneCountFloor: 5,
   pruneRatioLimit: 0.02,
   glossary,
   outputLocales: [

--- a/scripts/i18n/locale-tree.ts
+++ b/scripts/i18n/locale-tree.ts
@@ -19,6 +19,10 @@ export interface LocaleLeafEntry {
   value: LocaleTrackedLeaf
 }
 
+export interface PendingLocaleLeaf extends LocaleLeafEntry {
+  reason: 'invalidated' | 'shape'
+}
+
 function isLocaleValue(value: unknown): value is LocaleValue {
   if (
     typeof value === 'boolean' ||
@@ -160,25 +164,18 @@ export function isTranslatableLeaf(value: LocaleTrackedLeaf): boolean {
 export function collectPendingLeaves(
   source: LocaleObject,
   existing: LocaleObject,
-  invalidated: ReadonlySet<string>,
-  leafCorrupted?: (
-    source: LocaleTrackedLeaf,
-    target: LocaleTrackedLeaf
-  ) => boolean
-): LocaleLeafEntry[] {
-  const pending: LocaleLeafEntry[] = []
+  invalidated: ReadonlySet<string>
+): PendingLocaleLeaf[] {
+  const pending: PendingLocaleLeaf[] = []
   for (const [key, leaf] of collectLeaves(source)) {
     if (!isTranslatableLeaf(leaf.value)) continue
     const existingLeaf = getLeaf(existing, leaf.path)
-    if (
-      invalidated.has(key) ||
-      !leafShapeMatches(leaf.value, existingLeaf) ||
-      (existingLeaf !== undefined &&
-        leafCorrupted !== undefined &&
-        leafCorrupted(leaf.value, existingLeaf))
-    ) {
-      pending.push(leaf)
-    }
+    const reason = invalidated.has(key)
+      ? 'invalidated'
+      : !leafShapeMatches(leaf.value, existingLeaf)
+        ? 'shape'
+        : undefined
+    if (reason) pending.push({ ...leaf, reason })
   }
   return pending
 }

--- a/scripts/i18n/protected-tokens.ts
+++ b/scripts/i18n/protected-tokens.ts
@@ -1,18 +1,14 @@
+import { protectedLiteralPatterns } from './config'
 import type { LocaleChanges, LocaleObject, LocaleValue } from './locale-tree'
 import { collectLeaves, getLeaf, pathKey } from './locale-tree'
 
-const quoteCharacters = `['"“”‘’«»‹›„‚「」『』]`
-const protectedLiteralPatterns = [
-  /<(?:Picture|Video|Audio) [A-Za-z0-9]+>/g,
-  /\b\d+k\+\d+\b/g,
-  new RegExp(`(?<=${quoteCharacters})(?:match|max)(?=${quoteCharacters})`, 'g')
-]
 // Named ({name}), positional list ({0}), and literal ({'@'}) interpolation
 const interpolationPattern = /\{(?:[A-Za-z][A-Za-z0-9_.-]*|\d+|'[^']*')\}/g
 // vue-i18n message syntax the model must not introduce: | separates plural
 // forms, @:key / @.modifier:key are linked messages
 const pluralSeparatorPattern = /\|/
-const linkedMessagePattern = /@[.:]/
+const linkedMessagePattern =
+  /@(?:\.[A-Za-z][A-Za-z0-9_-]*)?:(?:[^\s@|(){}]+|\{(?:[A-Za-z][A-Za-z0-9_.-]*|'[^']*')\})/g
 
 function uniqueMatches(value: string, pattern: RegExp): string[] {
   return [...new Set(value.match(pattern) ?? [])].sort()
@@ -28,6 +24,7 @@ export function protectedTokens(
   if (includeInterpolation) {
     tokens.push(...uniqueMatches(value, interpolationPattern))
   }
+  tokens.push(...uniqueMatches(value, linkedMessagePattern))
   return [...new Set(tokens)].sort()
 }
 
@@ -38,6 +35,7 @@ export function tokenErrors(
 ): string[] {
   const sourceTokens = protectedTokens(source, includeInterpolation)
   const targetTokens = protectedTokens(target, includeInterpolation)
+  const targetPluralForms = target.split('|')
   const missing = sourceTokens.filter((token) => !targetTokens.includes(token))
   const added = targetTokens.filter((token) => !sourceTokens.includes(token))
   return [
@@ -50,8 +48,9 @@ export function tokenErrors(
     !pluralSeparatorPattern.test(source)
       ? ['added plural separator |']
       : []),
-    ...(linkedMessagePattern.test(target) && !linkedMessagePattern.test(source)
-      ? ['added linked message @']
+    ...(targetPluralForms.length > 1 &&
+    targetPluralForms.some((form) => form.trim().length === 0)
+      ? ['empty plural form']
       : [])
   ]
 }
@@ -77,13 +76,6 @@ function leafTokenErrors(
   return JSON.stringify(source) === JSON.stringify(target)
     ? []
     : [`${label}: leaf value changed`]
-}
-
-export function leafTokensDiffer(
-  source: LocaleValue,
-  target: LocaleValue | undefined
-): boolean {
-  return leafTokenErrors(source, target, 'leaf').length > 0
 }
 
 export function validateLocale(

--- a/scripts/i18n/translate.ts
+++ b/scripts/i18n/translate.ts
@@ -87,7 +87,8 @@ Rules:
 - Respond with a JSON object that maps every item "id" to its translated string — every id, no other keys, no commentary.
 - Every substring listed in an item's "preserve" array must appear in the translation exactly as written, byte for byte. Never translate, transliterate, or renumber them.
 - Interpolation placeholders such as {name} stay exactly as written.
-- The | character separates plural forms. Keep the same number of forms and translate each form.
+- The | character separates plural forms. Use the target locale's appropriate number of forms and translate each form.
+- If an item has a "retryNote", correct every reported issue in the next translation.
 - The "context" field is the JSON path of the string in the UI resources; use it to resolve ambiguity. Keep values that are technical identifiers (node type names, parameter names, file names) unchanged when translating them would break meaning.
 - Match the brevity and professional tone of the source.
 

--- a/scripts/i18n/update-locales.test.ts
+++ b/scripts/i18n/update-locales.test.ts
@@ -15,7 +15,7 @@ import {
   pathKey,
   rebuildLocale
 } from './locale-tree'
-import { leafTokensDiffer, validateLocale } from './protected-tokens'
+import { auditProtectedLiterals, validateLocale } from './protected-tokens'
 import type { TranslateBatch, TranslationItem } from './translate'
 import {
   chunkItems,
@@ -26,7 +26,8 @@ import {
 import {
   assembleLeafTranslations,
   buildTranslationItems,
-  exceedsPruneThreshold
+  exceedsPruneThreshold,
+  readManifestSource
 } from './update-locales'
 
 const locale: OutputLocale = { code: 'xx', name: 'Test Language' }
@@ -55,12 +56,7 @@ async function updateLocaleFile(
   const invalidated = new Set(
     [...changes.added, ...changes.modified].map(pathKey)
   )
-  const pendingLeaves = collectPendingLeaves(
-    source,
-    existing,
-    invalidated,
-    leafTokensDiffer
-  )
+  const pendingLeaves = collectPendingLeaves(source, existing, invalidated)
   const plan = buildTranslationItems('main.json', pendingLeaves)
   const translations =
     plan.items.length > 0
@@ -119,6 +115,24 @@ describe('locale file update', () => {
     stray: 'no longer in source'
   }
 
+  it('reports why each leaf is queued for translation', () => {
+    const invalidated = new Set([pathKey(['changed'])])
+    expect(
+      collectPendingLeaves(
+        { changed: 'New source', missing: 'Missing translation' },
+        { changed: 'Existing translation' },
+        invalidated
+      )
+    ).toEqual([
+      { path: ['changed'], reason: 'invalidated', value: 'New source' },
+      {
+        path: ['missing'],
+        reason: 'shape',
+        value: 'Missing translation'
+      }
+    ])
+  })
+
   it('translates added, modified, and missing values; prunes deleted and stray keys; keeps valid translations', async () => {
     const { output, translatedCount } = await updateLocaleFile(
       source,
@@ -140,7 +154,7 @@ describe('locale file update', () => {
     expect(Object.keys(output)).toEqual([...Object.keys(output)].sort())
   })
 
-  it('retranslates existing translations that were corrupted or blanked', async () => {
+  it('reports unchanged corrupted translations without replacing them', () => {
     const parity = {
       blanked: 'Save',
       farewell: 'Goodbye',
@@ -153,19 +167,15 @@ describe('locale file update', () => {
       greeting: 'Bonjour nom',
       intact: 'translated {docs}'
     }
-    const { output, translatedCount } = await updateLocaleFile(
-      parity,
-      parity,
-      corrupted,
-      echoTranslator
+    expect(collectPendingLeaves(parity, corrupted, new Set())).toEqual([])
+    expect(auditProtectedLiterals(parity, corrupted, new Set())).toEqual([
+      'blanked: empty translation',
+      'farewell: added {count}',
+      'greeting: missing {name}'
+    ])
+    expect(rebuildLocale(parity, corrupted, new Set(), new Map())).toEqual(
+      corrupted
     )
-    expect(output).toEqual({
-      blanked: 'xx: Save',
-      farewell: 'xx: Goodbye',
-      greeting: 'xx: Hello {name}',
-      intact: 'translated {docs}'
-    })
-    expect(translatedCount).toBe(3)
   })
 
   it('preserves keys named __proto__', async () => {
@@ -468,7 +478,25 @@ describe('validateLocale', () => {
         { scale: source.scale, send: 'Enviar @:g.cancel' },
         changes
       )
-    ).toEqual(['send: added linked message @'])
+    ).toEqual(['send: added @:g.cancel'])
+  })
+
+  it('protects linked message keys and modifiers', () => {
+    const source = {
+      link: 'Open @:menu.save or @.lower:menu.cancel'
+    }
+    const changes = diffLocaleSources({}, source)
+    expect(validateLocale(source, source, changes)).toEqual([])
+    expect(
+      validateLocale(
+        source,
+        { link: 'Open @:menu.open or @.upper:menu.cancel' },
+        changes
+      )
+    ).toEqual([
+      'link: missing @.lower:menu.cancel, @:menu.save',
+      'link: added @.upper:menu.cancel, @:menu.open'
+    ])
   })
 
   it('compares placeholder names as a set across plural forms', () => {
@@ -485,15 +513,41 @@ describe('validateLocale', () => {
       validateLocale(source, { count: 'None | {total} many' }, changes)
     ).toEqual(['count: missing {count}', 'count: added {total}'])
   })
+
+  it('allows locale-specific plural counts and rejects empty forms', () => {
+    const source = { count: 'No items | {count} item | {count} items' }
+    const changes = diffLocaleSources({}, source)
+    expect(validateLocale(source, { count: '{count} items' }, changes)).toEqual(
+      []
+    )
+    expect(
+      validateLocale(source, { count: 'None | | {count} items' }, changes)
+    ).toEqual(['count: empty plural form'])
+  })
 })
 
 describe('exceedsPruneThreshold', () => {
   it('permits small cleanups and refuses large shrinks', () => {
     expect(exceedsPruneThreshold(0, 0)).toBe(false)
     expect(exceedsPruneThreshold(79, 13557)).toBe(false)
-    expect(exceedsPruneThreshold(25, 100)).toBe(false)
+    expect(exceedsPruneThreshold(5, 124)).toBe(false)
+    expect(exceedsPruneThreshold(6, 124)).toBe(true)
+    expect(exceedsPruneThreshold(5, 234)).toBe(false)
+    expect(exceedsPruneThreshold(6, 234)).toBe(true)
     expect(exceedsPruneThreshold(62, 124)).toBe(true)
     expect(exceedsPruneThreshold(500, 9082)).toBe(true)
+  })
+})
+
+describe('readManifestSource', () => {
+  it('fails when the recorded source blob is unavailable', () => {
+    expect(() =>
+      readManifestSource(
+        process.cwd(),
+        'main.json',
+        '0000000000000000000000000000000000000000'
+      )
+    ).toThrow('Cannot read the recorded English source for main.json')
   })
 })
 

--- a/scripts/i18n/update-locales.ts
+++ b/scripts/i18n/update-locales.ts
@@ -18,7 +18,8 @@ import type {
   LocaleLeafEntry,
   LocaleObject,
   LocaleTrackedLeaf,
-  LocaleValue
+  LocaleValue,
+  PendingLocaleLeaf
 } from './locale-tree'
 import {
   collectLeaves,
@@ -32,7 +33,6 @@ import {
 } from './locale-tree'
 import {
   auditProtectedLiterals,
-  leafTokensDiffer,
   protectedTokens,
   validateLocale
 } from './protected-tokens'
@@ -55,7 +55,6 @@ interface SourcePlan {
   changes: LocaleChanges
   invalidated: Set<string>
   previousLeafCount: number
-  degraded: boolean
 }
 
 interface LocaleFileState {
@@ -63,7 +62,8 @@ interface LocaleFileState {
   plan: SourcePlan
   outputFile: string
   existing: LocaleObject
-  pendingLeaves: LocaleLeafEntry[]
+  pendingLeaves: PendingLocaleLeaf[]
+  auditErrors: string[]
   strayPaths: string[][]
 }
 
@@ -187,20 +187,24 @@ function loadManifest(filename: string): SourceManifest {
   return manifest as SourceManifest
 }
 
-function readManifestSource(
+export function readManifestSource(
   repoRoot: string,
   filename: string,
   hash: string
-): LocaleObject | undefined {
+): LocaleObject {
   let content: string
   try {
     content = execFileSync('git', ['cat-file', 'blob', hash], {
       cwd: repoRoot,
       encoding: 'utf8',
-      maxBuffer: 64 * 1024 * 1024
+      maxBuffer: 64 * 1024 * 1024,
+      stdio: ['ignore', 'pipe', 'pipe']
     })
-  } catch {
-    return undefined
+  } catch (error) {
+    throw new Error(
+      `Cannot read the recorded English source for ${filename} (${hash}). Run from a clone with full history (a blobless partial clone works: fetch-depth: 0 with filter: blob:none, which lazily fetches the blob over the network).`,
+      { cause: error }
+    )
   }
   try {
     return parseLocale(content, `${filename}@${hash}`)
@@ -297,8 +301,12 @@ function loadLocaleFileStates(
         pendingLeaves: collectPendingLeaves(
           plan.source,
           existing,
-          plan.invalidated,
-          leafTokensDiffer
+          plan.invalidated
+        ),
+        auditErrors: auditProtectedLiterals(
+          plan.source,
+          existing,
+          plan.invalidated
         ),
         strayPaths
       }
@@ -319,13 +327,11 @@ function reportCheck(states: readonly LocaleFileState[]): number {
     const label = `${state.locale.code}/${state.plan.filename}`
     if (state.pendingLeaves.length > 0) {
       pendingTotal += state.pendingLeaves.length
-      const examples = state.pendingLeaves
-        .slice(0, 5)
-        .map((leaf) => leaf.path.join('.'))
-        .join(', ')
-      print(
-        `${label}: ${state.pendingLeaves.length} strings need translation (${examples}${state.pendingLeaves.length > 5 ? ', …' : ''})`
-      )
+      for (const leaf of state.pendingLeaves) {
+        print(
+          `${label}: ${leaf.path.join('.')}: translation required (${leaf.reason})`
+        )
+      }
     }
     if (state.strayPaths.length > 0) {
       strayTotal += state.strayPaths.length
@@ -333,16 +339,7 @@ function reportCheck(states: readonly LocaleFileState[]): number {
         `${label}: ${state.strayPaths.length} keys no longer exist in the English source and will be pruned`
       )
     }
-    // Skip keys queued because the English source changed (comparing an old
-    // translation against new English is meaningless). Degraded plans
-    // (recorded source unavailable) cannot tell staleness from corruption, so
-    // they skip the audit.
-    if (state.plan.degraded) continue
-    for (const error of auditProtectedLiterals(
-      state.plan.source,
-      state.existing,
-      state.plan.invalidated
-    )) {
+    for (const error of state.auditErrors) {
       auditErrors.push(`${label}: ${error}`)
     }
   }
@@ -380,17 +377,7 @@ async function run(argv: readonly string[]): Promise<void> {
     if (!check && raw !== canonical) writeFileSync(entryFile, canonical)
     const hash = manifest.files[filename]
     const recorded = hash ? readManifestSource(repoRoot, filename, hash) : {}
-    if (recorded === undefined && !check) {
-      throw new Error(
-        `Cannot read the recorded English source for ${filename} (${hash}). Run from a clone with full history (a blobless partial clone works: fetch-depth: 0 with filter: blob:none, which lazily fetches the blob over the network).`
-      )
-    }
-    if (recorded === undefined) {
-      print(
-        `WARNING: ${filename}: the recorded English source (${hash}) is unavailable in this clone; changed-string detection is skipped for this check.`
-      )
-    }
-    const previous = recorded ?? source
+    const previous = recorded
     const changes = diffLocaleSources(previous, source)
     return {
       filename,
@@ -399,8 +386,7 @@ async function run(argv: readonly string[]): Promise<void> {
       invalidated: new Set(
         [...changes.added, ...changes.modified].map(pathKey)
       ),
-      previousLeafCount: collectLeaves(previous).size,
-      degraded: recorded === undefined
+      previousLeafCount: collectLeaves(previous).size
     }
   })
 
@@ -435,6 +421,24 @@ async function run(argv: readonly string[]): Promise<void> {
     }
     process.exitCode = reportCheck(states)
     return
+  }
+
+  const auditFailures = states.flatMap((state) =>
+    state.auditErrors.map(
+      (error) => `${state.locale.code}/${state.plan.filename}: ${error}`
+    )
+  )
+  if (auditFailures.length > 0) {
+    throw new Error(
+      `Refusing to overwrite unchanged translations with protected-token violations:\n${auditFailures.join('\n')}`
+    )
+  }
+
+  for (const state of states) {
+    const label = `${state.locale.code}/${state.plan.filename}`
+    for (const leaf of state.pendingLeaves) {
+      print(`${label}: ${leaf.path.join('.')}: queued (${leaf.reason})`)
+    }
   }
 
   const translationPlans = new Map(
@@ -575,7 +579,8 @@ async function run(argv: readonly string[]): Promise<void> {
 
   // Persist per entry file: locale outputs and the manifest entry advance only
   // for entry files whose every locale translated and validated, so one
-  // failure does not discard the completed work of the other files
+  // failure does not discard the completed work of the other files. A crash
+  // before the manifest write can repeat work, but cannot advance provenance.
   const completedFilenames = new Set(
     filenames.filter((filename) => !failuresByFile.has(filename))
   )
@@ -606,6 +611,15 @@ async function run(argv: readonly string[]): Promise<void> {
       })
     )
   )
+
+  for (const state of states) {
+    if (!completedFilenames.has(state.plan.filename)) continue
+    for (const path of state.strayPaths) {
+      print(
+        `${state.locale.code}/${state.plan.filename}: pruned ${path.join('.')}`
+      )
+    }
+  }
 
   if (usage.requests > 0) {
     print(

--- a/src/locales/CONTRIBUTING.md
+++ b/src/locales/CONTRIBUTING.md
@@ -113,21 +113,27 @@ last translated in `src/locales/.source-manifest.json`. On each run it
 retranslates strings whose English text changed, backfills missing keys, prunes
 keys removed from English (deleting whole locale files whose English source
 file was removed), and validates that interpolation placeholders and protected
-literals (e.g. `<Picture N>`, `17k+5`) survive translation exactly. Existing
-translations whose placeholders no longer match the English source are
-re-queued for translation, so corrupted strings heal on the next run. Results
-persist per entry file: a failure translating one file does not discard the
-completed, validated work of the others — those are written and their manifest
-entries advance, and only the failed files retry on the next run. Runs that
-would delete an implausibly large share of a file's keys abort that file
+literals (e.g. `<Picture N>`, `17k+5`) survive translation exactly. A
+hand-authored translation is preserved verbatim while its English source and
+value shape remain unchanged. If its placeholders or protected literals drift,
+checks and generation fail with the affected path instead of overwriting the
+manual translation; correct that translation before rerunning the pipeline.
+Results persist per entry file: a failure translating one file does not discard
+the completed, validated work of the others — those are written and their
+manifest entries advance, and only the failed files retry on the next run. Runs
+that would delete an implausibly large share of a file's keys abort that file
 without writing — that usually means `collect-i18n` observed a partial app;
 rerun with `--allow-prune` (or the `allow_prune` input on the manual workflow
 dispatch) only after confirming the English sources are complete.
 `pnpm locale:check` runs offline in CI: it reports pending work and fails on
 protected-token violations that are not already queued for retranslation
-because the English source changed. oxfmt ignores `src/locales/**/*.json` — the
-pipeline is the sole writer of those bytes, which keeps the manifest's recorded
-blob hashes valid.
+because the English source changed.
+
+Manual translation edits are supported. Locale JSON uses the pipeline's
+canonical format: recursively sorted object keys, two-space indentation, and a
+trailing newline. oxfmt ignores `src/locales/**/*.json`, so avoid editor-driven
+reformatting; the next successful `pnpm locale` run will restore the canonical
+format while preserving unchanged translation values.
 
 ### Manual Translation Updates
 


### PR DESCRIPTION
Stacked on #15230. This PR is retained for the planning/validation unit so its existing review history remains available.

## Summary

Make locale preserve/regenerate planning, provenance, pruning, protected-token validation, final validation, and operator reporting explicit.

## Changes

- **What**: Record per-leaf queue reasons, preserve unchanged hand-authored translations, fail on unreadable provenance, tighten prune protection, validate protected literals and rebuilt locales, report queued/pruned paths, and document canonical locale behavior.

## Review Focus

The pending planner redesign is intentionally not implemented here. The next design decision is an authoritative plan that classifies every leaf as **preserve** or **regenerate**, audits only preserved leaves before generation, and validates the entire rebuilt locale without exclusions before writes or provenance advancement.

Existing substantive review threads remain for reviewer follow-up, including the shape-pending preflight concern and escaped interpolation behavior. The unresolved non-string retry policy now belongs to #15229 and remains linked there.

Validation:

- top tree is equivalent to the original #15178 head except `gpt-5.6-sol` → `gpt-5.6-terra` and deletion of stale `knownViolations` documentation
- `mise exec -- pnpm test:unit scripts/i18n/update-locales.test.ts --run` (29 passed)
- `mise exec -- pnpm locale:check` (exit 0; 0 protected-token violations)
- `mise exec -- pnpm typecheck:scripts`
- `mise exec -- pnpm typecheck`
- `mise exec -- pnpm lint`
- `mise exec -- pnpm knip`
- `mise exec -- pnpm format:check`