### PR TITLE
fix: stop relaying Desktop execution starts

### DIFF
--- a/src/platform/telemetry/providers/host/HostTelemetrySink.ts
+++ b/src/platform/telemetry/providers/host/HostTelemetrySink.ts
@@ -291,10 +291,6 @@ export class HostTelemetrySink implements TelemetryProvider {
     this.capture(TelemetryEvents.WORKFLOW_CREATED, metadata)
   }
 
-  trackWorkflowExecution(): void {
-    this.capture(TelemetryEvents.EXECUTION_START)
-  }
-
   trackExecutionError(metadata: ExecutionErrorMetadata): void {
     this.capture(TelemetryEvents.EXECUTION_ERROR, metadata)
   }


### PR DESCRIPTION
## Summary

Stop relaying the generic `execution_start` event from the hosted frontend into Desktop PostHog after migrating its saved Desktop consumers to `app:run_button_click`.

## Changes

- **What**: Remove `HostTelemetrySink.trackWorkflowExecution()` while preserving the shared telemetry-registry callback and all Cloud providers.
- **Impact**: Eliminates approximately 23.94M redundant Desktop events per measured 28 days; `app:run_button_click` remains as the one-to-one, richer run-intent event.
- **Analytics migration**: Updated and successfully ran all 19 saved insights that explicitly filtered `execution_start` to `client=desktop` and `deployment=local`. No explicitly Desktop-local saved insight still references the event.
- **Unchanged**: Desktop execution success/error telemetry, session summaries, first-completion activation, Cloud PostHog, Customer.io, GTM, and Sentry paths.

## Review Focus

Confirm the deletion stays scoped to the Desktop host sink; the optional `TelemetryProvider.trackWorkflowExecution` contract must remain for Cloud providers.

## Validation

- `mise exec -- pnpm test:unit src/platform/telemetry/providers/host/HostTelemetrySink.test.ts`
- `mise exec -- pnpm typecheck`
- `mise exec -- pnpm lint`
- `mise exec -- pnpm knip`
- `mise exec -- pnpm exec oxfmt --check src/platform/telemetry/providers/host/HostTelemetrySink.ts`

## Screenshots (if applicable)

Not applicable; telemetry-only change.