### PR TITLE
fix: a malformed MatchType spec no longer deletes the input

### DIFF
--- a/src/core/graph/widgets/dynamicWidgets.ts
+++ b/src/core/graph/widgets/dynamicWidgets.ts
@@ -348,8 +348,16 @@ function withComfyMatchType(node: LGraphNode): asserts node is MatchTypeNode {
 function applyMatchType(node: LGraphNode, inputSpec: InputSpecV2) {
   const { addNodeInput } = useLitegraphService()
   const name = inputSpec.name
-  const matchTypeSpec = zMatchTypeOptions.safeParse(inputSpec).data
-  if (!matchTypeSpec) return
+  const parseResult = zMatchTypeOptions.safeParse(inputSpec)
+  if (!parseResult.success) {
+    console.warn(
+      `Unparseable COMFY_MATCHTYPE_V3 spec for input "${name}"; falling back to a wildcard socket.`,
+      parseResult.error.issues
+    )
+    addNodeInput(node, { ...inputSpec, type: '*' })
+    return
+  }
+  const matchTypeSpec = parseResult.data
 
   const { allowed_types, template_id } = matchTypeSpec.template
   const typedSpec = { ...inputSpec, type: allowed_types }

--- a/src/core/graph/widgets/matchTypeFallback.test.ts
+++ b/src/core/graph/widgets/matchTypeFallback.test.ts
@@ -1,0 +1,37 @@
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
+import { describe, expect, it, vi } from 'vitest'
+
+import { LGraphNode } from '@/lib/litegraph/src/litegraph'
+import { transformInputSpecV1ToV2 } from '@/schemas/nodeDef/migration'
+import type { InputSpec } from '@/schemas/nodeDefSchema'
+import { useLitegraphService } from '@/services/litegraphService'
+
+setActivePinia(createTestingPinia())
+
+function testNode() {
+  const node = new LGraphNode('test')
+  node.widgets = []
+  return node as LGraphNode & Required<Pick<LGraphNode, 'widgets'>>
+}
+
+describe('malformed COMFY_MATCHTYPE_V3 spec', () => {
+  it('still exposes the input instead of dropping it silently', () => {
+    const { addNodeInput } = useLitegraphService()
+    const node = testNode()
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const malformed: InputSpec = [
+      'COMFY_MATCHTYPE_V3',
+      { template: { allowed_types: 'IMAGE' } }
+    ]
+    addNodeInput(
+      node,
+      transformInputSpecV1ToV2(malformed, { name: 'value', isOptional: false })
+    )
+
+    expect(node.inputs.map((i) => i.name)).toEqual(['value'])
+    expect(warn).toHaveBeenCalled()
+    warn.mockRestore()
+  })
+})

--- a/src/core/graph/widgets/matchTypeFallback.test.ts
+++ b/src/core/graph/widgets/matchTypeFallback.test.ts
@@ -2,7 +2,7 @@ import { createTestingPinia } from '@pinia/testing'
 import { setActivePinia } from 'pinia'
 import { describe, expect, it, vi } from 'vitest'
 
-import { LGraphNode } from '@/lib/litegraph/src/litegraph'
+import { LGraph, LGraphNode } from '@/lib/litegraph/src/litegraph'
 import { transformInputSpecV1ToV2 } from '@/schemas/nodeDef/migration'
 import type { InputSpec } from '@/schemas/nodeDefSchema'
 import { useLitegraphService } from '@/services/litegraphService'
@@ -18,7 +18,9 @@ function testNode() {
 describe('malformed COMFY_MATCHTYPE_V3 spec', () => {
   it('still exposes the input instead of dropping it silently', () => {
     const { addNodeInput } = useLitegraphService()
+    const graph = new LGraph()
     const node = testNode()
+    graph.add(node)
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
     const malformed: InputSpec = [
@@ -31,7 +33,18 @@ describe('malformed COMFY_MATCHTYPE_V3 spec', () => {
     )
 
     expect(node.inputs.map((i) => i.name)).toEqual(['value'])
-    expect(warn).toHaveBeenCalled()
+    expect(node.inputs[0].type).toBe('*')
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('COMFY_MATCHTYPE_V3 spec for input "value"'),
+      expect.anything()
+    )
+
+    const source = testNode()
+    source.addOutput('out', 'IMAGE')
+    graph.add(source)
+    source.connect(0, node, 0)
+
+    expect(node.inputs[0].link).not.toBeNull()
     warn.mockRestore()
   })
 })


### PR DESCRIPTION
## Summary

A `COMFY_MATCHTYPE_V3` spec the frontend cannot parse currently makes the input disappear from the node entirely, with no socket, no widget and no console output.

## Changes

- **What**: `applyMatchType` warns and falls back to a wildcard socket instead of returning early.
- **Breaking**: none.

`applyDynamicInputs` returns `true` for any type present in its table, and `addInputSocket` early-returns on that result, so the early return in `applyMatchType` meant nothing was ever added. The two sibling controls (`dynamicComboWidget`, `applyAutogrow`) both `throw` on the equivalent failure; throwing here would fail construction of the whole node, so this degrades instead. `*` matches how a MatchType *output* already degrades in `litegraphService`.

## Review Focus

- The fallback re-enters `addNodeInput` with `type: '*'`, which is not in the dynamic table, so there is no recursion.
- The added test asserts the input is present. Before this change it asserts `[]`, i.e. silent data loss.

Found while reviewing https://github.com/Comfy-Org/ComfyUI_frontend/pull/15142. Not linked to a specific report, though it matches the shape of https://github.com/Comfy-Org/ComfyUI_frontend/issues/7469.
