### PR TITLE
fix(templates): keep filter bar visible when an extension defines .hidden

### DIFF
--- a/browser_tests/tests/templates.spec.ts
+++ b/browser_tests/tests/templates.spec.ts
@@ -280,6 +280,28 @@ test.describe('Templates', { tag: ['@slow', '@workflow'] }, () => {
     }
   )
 
+  // Extension stylesheets are unlayered, and unlayered rules outrank every
+  // rule in a cascade layer, so a bare `.hidden` from a custom node beats our
+  // layered Tailwind display variants.
+  test('filter controls survive an extension stylesheet that defines .hidden', async ({
+    comfyPage
+  }) => {
+    await comfyPage.page.setViewportSize({ width: 1440, height: 900 })
+    await comfyPage.page.addStyleTag({ content: '.hidden { display: none }' })
+
+    await comfyPage.command.executeCommand('Comfy.BrowseTemplates')
+    await expect(comfyPage.templates.content).toBeVisible()
+
+    await expect(comfyPage.templatesDialog.modelFilter).toBeVisible()
+    await expect(comfyPage.templatesDialog.mobileFiltersToggle).toBeHidden()
+    await expect(
+      comfyPage.templatesDialog.root.getByRole('heading', {
+        name: 'All Templates',
+        exact: true
+      })
+    ).toBeVisible()
+  })
+
   test(
     'template cards display overlay tags correctly',
     { tag: '@screenshot' },

--- a/src/components/custom/widget/WorkflowTemplateSelectorDialog.vue
+++ b/src/components/custom/widget/WorkflowTemplateSelectorDialog.vue
@@ -17,7 +17,7 @@
     <template #header>
       <div class="flex min-w-0 flex-1 items-center gap-2">
         <h2
-          class="text-neutral m-0 hidden shrink-0 truncate text-base font-medium min-[880px]:block"
+          class="text-neutral m-0 shrink-0 truncate text-base font-medium max-[880px]:hidden min-[880px]:block"
         >
           {{ pageTitle }}
         </h2>
@@ -62,7 +62,7 @@
           </div>
 
           <div
-            class="ml-auto hidden min-w-0 shrink items-center justify-end gap-2 @[58rem]/filters:flex"
+            class="ml-auto min-w-0 shrink items-center justify-end gap-2 @max-[58rem]/filters:hidden @[58rem]/filters:flex"
           >
             <TemplateFilterControls
               v-bind="filterControlBindings"


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

## Summary

The Templates browser lost its whole filter row (Model Filter / Tasks / Runs on / sort) on local installs because a custom node stylesheet defining `.hidden { display: none }` outranks our layered Tailwind display variants; this drives the affected elements from mutually exclusive variants so no bare display utility is left to clobber.

Reported on Discord and confirmed as unintentional by the team — Linear **FE-1605**.

## Root cause

Two elements in `WorkflowTemplateSelectorDialog.vue` relied on a bare `hidden` class being *overridden* by a display variant:

```
h2          class="... hidden ... min-[880px]:block"
filter row  class="... hidden ... @[58rem]/filters:flex"
```

Tailwind v4 emits every utility inside `@layer utilities`. **Unlayered CSS beats any layered rule regardless of specificity or source order**, so a single unlayered `.hidden { display: none }` from an extension stylesheet pins both elements to `display: none` — the variants can never win.

This also explains the otherwise-confusing symptom that there was no fallback: the container query itself still matched, so the narrow-width `Filters` toggle (`@[58rem]/filters:hidden`) correctly hid itself, and the bar vanished entirely with nothing in its place. The missing "All Templates" page title in the same screenshot is the same bug — and the search box staying right-aligned/narrow (`min-[880px]:ml-auto`, `min-[880px]:max-w-96` live in that *same* media block) proves the media query was matching and only the `display` declaration was being lost.

Cloud is unaffected because it doesn't load custom node extension CSS.

Verified the shipped `comfyui-frontend-package==1.48.7` bundle: it declares `@layer theme, base, primevue, components` then `@layer utilities { … .hidden{display:none} … }`, and both `.min-[880px]:block` and `.@[58rem]/filters:flex` are emitted *after* `.hidden`. First-party CSS ordering is correct — the clobber can only come from outside.

## Changes

- **What**: replace the base `hidden` on the filter row and the page title with the complementary variant (`@max-[58rem]/filters:hidden`, `max-[880px]:hidden`). The two variants are mutually exclusive and exhaustive, so behaviour is identical while neither element carries a bare `display` utility any more.
- **Test**: E2E regression test that injects an unlayered `.hidden { display: none }` — simulating the extension — and asserts the controls still render.

```diff
-class="text-neutral m-0 hidden shrink-0 truncate ... min-[880px]:block"
+class="text-neutral m-0 shrink-0 truncate ... max-[880px]:hidden min-[880px]:block"

-class="ml-auto hidden min-w-0 shrink ... @[58rem]/filters:flex"
+class="ml-auto min-w-0 shrink ... @max-[58rem]/filters:hidden @[58rem]/filters:flex"
```

## Review Focus

- **Culprit extension not pinned down.** I checked ComfyUI-Manager 4.2.2, rgthree-comfy 1.0.2606200020 and ComfyUI-Easy-Use v1.3.4 at their exact reported versions; none ships a bare `.hidden{display:none}`. Easy-Use's v2 bundle is the closest structural match (genuinely unlayered Tailwind-v3-style CSS, zero `@layer`, and it *does* emit unlayered `.md\:hidden`/`.lg\:hidden`/`.xl\:hidden`) but not the unprefixed rule. The mechanism is proven regardless, and the fix doesn't depend on which extension it is.
- **Same pattern exists elsewhere.** 16 occurrences of base `hidden` + display-variant across 7 files (`AssetBrowserModal.vue`, `KeybindingList.vue`, `CoachmarkLanding.vue`, `CreditsTile.vue`, `PartnerNodeAccessPanel.vue`, `StepLabel.vue`). All are vulnerable to the same clobber. Left out to keep this PR scoped to FE-1605 — happy to do a follow-up sweep if you'd prefer.
- The reverse pattern (base `inline-flex` from `buttonVariants` + `@[58rem]/filters:hidden` on the Filters toggle) remains theoretically clobberable by an extension shipping an unlayered `.inline-flex`. Not fixable from this component, and not what users are hitting.

## Verification

Reproduced against the **exact** build the reporter runs (`comfyui-frontend-package==1.48.7`, served by a local ComfyUI): injecting one unlayered `.hidden{display:none}` reproduces the reported screenshot exactly — no filter controls, no `Filters` fallback button, no page title.

With the fix, measured `getComputedStyle().display` across widths **with the hostile rule still applied**:

| viewport | filter row | Filters toggle | page title |
|---|---|---|---|
| 1600 / 1400 / 1340 | `flex` (4 controls) | `none` | `block` |
| 1300 / 1200 / 1000 | `none` | `flex` | `block` |
| 860 | `none` | `flex` | `none` |

Responsive collapse and the mobile filter panel (4 controls) both still work.

- `pnpm lint` exit 0 (only pre-existing warnings in unrelated files)
- `pnpm typecheck` exit 0
- `pnpm test:unit` — 1162 files, 15955 passed
- New E2E test: **fails without the fix** (`expect(modelFilter).toBeVisible()` → element not found), **passes with it**
- `select components in filter bar render correctly` shows an 11-pixel (0.01%) screenshot diff — confirmed **pre-existing**: identical diff on unmodified `main` in this environment.

## Screenshots

Before vs after, both at 1600px with the hostile `.hidden` rule applied.


## Screenshots

![Before: templates browser with filter bar, Filters toggle and page title all missing](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/f26d8ea7466c19c487767a39aea96e64b9e5e5a5cde66fcf9bdfb110c6191a23/pr-images/1786608089406-8c85f23e-49aa-4b53-817c-668ff2759e97.png)

![After: Model Filter, Tasks, Runs on and sort controls plus the All Templates title render correctly](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/f26d8ea7466c19c487767a39aea96e64b9e5e5a5cde66fcf9bdfb110c6191a23/pr-images/1786608089852-50f143e3-acce-47aa-8890-85bb04a17deb.png)

![After: below the container breakpoint the controls still collapse into the Filters panel](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/f26d8ea7466c19c487767a39aea96e64b9e5e5a5cde66fcf9bdfb110c6191a23/pr-images/1786608090255-29ae1b3f-faba-457b-8307-8940646c38bc.png)