### PR TITLE
refactor(telemetry): add reportError to the registry and route all diagnostic reporting through it

### DIFF
--- a/src/base/assert.ts
+++ b/src/base/assert.ts
@@ -17,6 +17,10 @@ export function setAssertReporter(fn: AssertReporter | null): void {
  * - Always: console.error
  * - DEV: throws (surfaces bugs immediately)
  * - Otherwise: delegates to registered reporter (Sentry, toast, etc.)
+ *
+ * Reporters forward `message` to external telemetry, so it must be a static
+ * description of the invariant. Never interpolate user data (workflow names,
+ * paths, prompts) into it.
  */
 export function assert(condition: unknown, message: string): asserts condition {
   if (condition) return

--- a/src/main.ts
+++ b/src/main.ts
@@ -23,6 +23,7 @@ import {
   configValueOrDefault,
   remoteConfig
 } from '@/platform/remoteConfig/remoteConfig'
+import { reportAssertFailure } from '@/platform/telemetry/assertFailureReporter'
 import { syncHostUserIdWithFirebaseAuth } from '@/platform/telemetry/hostUserIdSync'
 import { flushErrorReports } from '@/platform/telemetry/reportError'
 import '@/lib/litegraph/public/css/litegraph.css'
@@ -115,6 +116,9 @@ flushErrorReports()
 setAssertReporter((message) => {
   if (isDesktop) {
     captureMessage(message, { level: 'warning' })
+  }
+  if (isCloud) {
+    reportAssertFailure(message)
   }
   if (isNightly) {
     useToastStore(pinia).add({

--- a/src/platform/navigation/unmatchedRoute.test.ts
+++ b/src/platform/navigation/unmatchedRoute.test.ts
@@ -39,4 +39,11 @@ describe('unmatchedRouteRedirect', () => {
       }
     )
   })
+
+  it('truncates an unbounded attacker-supplied path', () => {
+    unmatchedRouteRedirect({ path: `/${'a'.repeat(5000)}` } as RouteLocation)
+
+    const { context } = mockReportError.mock.calls[0][1]
+    expect(context.path).toHaveLength(128)
+  })
 })

--- a/src/platform/navigation/unmatchedRoute.test.ts
+++ b/src/platform/navigation/unmatchedRoute.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createMemoryHistory, createRouter } from 'vue-router'
+import type { RouteLocation } from 'vue-router'
+
+import { unmatchedRouteRedirect } from '@/platform/navigation/unmatchedRoute'
+
+const mockReportError = vi.hoisted(() => vi.fn())
+vi.mock('@/platform/telemetry', () => ({
+  useTelemetry: () => ({ reportError: mockReportError })
+}))
+
+const Blank = { template: '<div />' }
+
+describe('unmatchedRouteRedirect', () => {
+  it('sends unknown paths to root', async () => {
+    const router = createRouter({
+      history: createMemoryHistory(),
+      routes: [
+        { path: '/', name: 'root', component: Blank },
+        { path: '/:pathMatch(.*)*', redirect: unmatchedRouteRedirect }
+      ]
+    })
+
+    await router.push('/woiadawd')
+
+    expect(router.currentRoute.value.path).toBe('/')
+    expect(router.currentRoute.value.name).toBe('root')
+  })
+
+  it('reports the unmatched path as a warning under a static message', () => {
+    unmatchedRouteRedirect({ path: '/woiadawd' } as RouteLocation)
+
+    expect(mockReportError).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({ message: 'Unmatched route' }),
+      {
+        error_type: 'unmatched_route',
+        level: 'warning',
+        context: { path: '/woiadawd' }
+      }
+    )
+  })
+})

--- a/src/platform/navigation/unmatchedRoute.test.ts
+++ b/src/platform/navigation/unmatchedRoute.test.ts
@@ -5,8 +5,8 @@ import type { RouteLocation } from 'vue-router'
 import { unmatchedRouteRedirect } from '@/platform/navigation/unmatchedRoute'
 
 const mockReportError = vi.hoisted(() => vi.fn())
-vi.mock('@/platform/telemetry', () => ({
-  useTelemetry: () => ({ reportError: mockReportError })
+vi.mock('@/platform/telemetry/reportError', () => ({
+  reportError: mockReportError
 }))
 
 const Blank = { template: '<div />' }
@@ -33,7 +33,7 @@ describe('unmatchedRouteRedirect', () => {
     expect(mockReportError).toHaveBeenCalledExactlyOnceWith(
       expect.objectContaining({ message: 'Unmatched route' }),
       {
-        error_type: 'unmatched_route',
+        errorType: 'unmatched_route',
         level: 'warning',
         context: { path: '/woiadawd' }
       }

--- a/src/platform/navigation/unmatchedRoute.ts
+++ b/src/platform/navigation/unmatchedRoute.ts
@@ -1,6 +1,6 @@
 import type { RouteLocation, RouteLocationRaw } from 'vue-router'
 
-import { useTelemetry } from '@/platform/telemetry'
+import { reportError } from '@/platform/telemetry/reportError'
 
 /**
  * An unmatched path is attacker-supplied and unbounded, so it is truncated
@@ -21,8 +21,8 @@ const MAX_REPORTED_PATH_LENGTH = 128
  * cheap and a spike is still attributable.
  */
 export function unmatchedRouteRedirect(to: RouteLocation): RouteLocationRaw {
-  useTelemetry()?.reportError(new Error('Unmatched route'), {
-    error_type: 'unmatched_route',
+  reportError(new Error('Unmatched route'), {
+    errorType: 'unmatched_route',
     level: 'warning',
     context: { path: to.path.slice(0, MAX_REPORTED_PATH_LENGTH) }
   })

--- a/src/platform/navigation/unmatchedRoute.ts
+++ b/src/platform/navigation/unmatchedRoute.ts
@@ -3,6 +3,15 @@ import type { RouteLocation, RouteLocationRaw } from 'vue-router'
 import { useTelemetry } from '@/platform/telemetry'
 
 /**
+ * An unmatched path is attacker-supplied and unbounded, so it is truncated
+ * before it reaches telemetry. It is not redacted: every route in this app is
+ * a static literal with no parameter segments, and OAuth/share state travels
+ * in the query string, which `to.path` excludes — so a path segment carries no
+ * secret material, and the specific bad URL is the whole diagnostic value.
+ */
+const MAX_REPORTED_PATH_LENGTH = 128
+
+/**
  * Unknown paths redirect to root rather than hanging on the splash screen with
  * no route match. The global auth guard then routes unauthenticated users to
  * /cloud/login as normal.
@@ -15,7 +24,7 @@ export function unmatchedRouteRedirect(to: RouteLocation): RouteLocationRaw {
   useTelemetry()?.reportError(new Error('Unmatched route'), {
     error_type: 'unmatched_route',
     level: 'warning',
-    context: { path: to.path }
+    context: { path: to.path.slice(0, MAX_REPORTED_PATH_LENGTH) }
   })
 
   return '/'

--- a/src/platform/navigation/unmatchedRoute.ts
+++ b/src/platform/navigation/unmatchedRoute.ts
@@ -1,0 +1,22 @@
+import type { RouteLocation, RouteLocationRaw } from 'vue-router'
+
+import { useTelemetry } from '@/platform/telemetry'
+
+/**
+ * Unknown paths redirect to root rather than hanging on the splash screen with
+ * no route match. The global auth guard then routes unauthenticated users to
+ * /cloud/login as normal.
+ *
+ * The Error message is deliberately static so every unmatched path groups into
+ * one issue; the path itself rides along as context, where high cardinality is
+ * cheap and a spike is still attributable.
+ */
+export function unmatchedRouteRedirect(to: RouteLocation): RouteLocationRaw {
+  useTelemetry()?.reportError(new Error('Unmatched route'), {
+    error_type: 'unmatched_route',
+    level: 'warning',
+    context: { path: to.path }
+  })
+
+  return '/'
+}

--- a/src/platform/telemetry/assertFailureReporter.test.ts
+++ b/src/platform/telemetry/assertFailureReporter.test.ts
@@ -1,0 +1,48 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockReportError = vi.hoisted(() => vi.fn())
+vi.mock('./index', () => ({
+  useTelemetry: () => ({ reportError: mockReportError })
+}))
+
+async function loadReporter() {
+  vi.resetModules()
+  return (await import('./assertFailureReporter')).reportAssertFailure
+}
+
+describe('reportAssertFailure', () => {
+  beforeEach(() => {
+    mockReportError.mockClear()
+  })
+
+  it('reports an assertion failure as an invariant error', async () => {
+    const reportAssertFailure = await loadReporter()
+
+    reportAssertFailure('[Assertion failed]: graph must exist')
+
+    expect(mockReportError).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({
+        message: '[Assertion failed]: graph must exist'
+      }),
+      { error_type: 'invariant_assert' }
+    )
+  })
+
+  it('deduplicates repeats so a render-loop invariant reports once', async () => {
+    const reportAssertFailure = await loadReporter()
+
+    reportAssertFailure('same message')
+    reportAssertFailure('same message')
+    reportAssertFailure('same message')
+
+    expect(mockReportError).toHaveBeenCalledOnce()
+  })
+
+  it('caps distinct reports per session', async () => {
+    const reportAssertFailure = await loadReporter()
+
+    for (let i = 0; i < 25; i++) reportAssertFailure(`message ${i}`)
+
+    expect(mockReportError).toHaveBeenCalledTimes(20)
+  })
+})

--- a/src/platform/telemetry/assertFailureReporter.test.ts
+++ b/src/platform/telemetry/assertFailureReporter.test.ts
@@ -1,8 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mockReportError = vi.hoisted(() => vi.fn())
-vi.mock('./index', () => ({
-  useTelemetry: () => ({ reportError: mockReportError })
+vi.mock('./reportError', () => ({
+  reportError: mockReportError
 }))
 
 async function loadReporter() {
@@ -24,7 +24,7 @@ describe('reportAssertFailure', () => {
       expect.objectContaining({
         message: '[Assertion failed]: graph must exist'
       }),
-      { error_type: 'invariant_assert' }
+      { errorType: 'invariant_assert' }
     )
   })
 

--- a/src/platform/telemetry/assertFailureReporter.ts
+++ b/src/platform/telemetry/assertFailureReporter.ts
@@ -1,0 +1,21 @@
+import { useTelemetry } from './index'
+
+const MAX_REPORTS_PER_SESSION = 20
+
+const reportedMessages = new Set<string>()
+
+/**
+ * Send an assertion failure to diagnostic error reporting.
+ *
+ * Invariants can fire from render loops, so reports are deduplicated by exact
+ * message and capped per session.
+ */
+export function reportAssertFailure(message: string): void {
+  if (reportedMessages.has(message)) return
+  if (reportedMessages.size >= MAX_REPORTS_PER_SESSION) return
+  reportedMessages.add(message)
+
+  useTelemetry()?.reportError(new Error(message), {
+    error_type: 'invariant_assert'
+  })
+}

--- a/src/platform/telemetry/assertFailureReporter.ts
+++ b/src/platform/telemetry/assertFailureReporter.ts
@@ -1,4 +1,4 @@
-import { useTelemetry } from './index'
+import { reportError } from './reportError'
 
 const MAX_REPORTS_PER_SESSION = 20
 
@@ -15,7 +15,7 @@ export function reportAssertFailure(message: string): void {
   if (reportedMessages.size >= MAX_REPORTS_PER_SESSION) return
   reportedMessages.add(message)
 
-  useTelemetry()?.reportError(new Error(message), {
-    error_type: 'invariant_assert'
+  reportError(new Error(message), {
+    errorType: 'invariant_assert'
   })
 }

--- a/src/router.ts
+++ b/src/router.ts
@@ -19,6 +19,7 @@ import { captureOAuthRequestId } from '@/platform/cloud/oauth/oauthState'
 import { installDesktopLoginRedemption } from '@/platform/cloud/onboarding/desktopLoginRedemption'
 import { installPreservedQueryTracker } from '@/platform/navigation/preservedQueryTracker'
 import { PRESERVED_QUERY_NAMESPACES } from '@/platform/navigation/preservedQueryNamespaces'
+import { unmatchedRouteRedirect } from '@/platform/navigation/unmatchedRoute'
 import { preserveLoggedOutShareAuthAttribution } from '@/platform/workflow/sharing/utils/shareAuthAttribution'
 
 const cloudOnboardingRoutes = isCloud
@@ -84,10 +85,7 @@ const router = createRouter({
         }
       ]
     },
-    // Catch-all: unknown paths redirect to root rather than hanging on the
-    // splash screen with no route match. The global auth guard then routes
-    // unauthenticated users to /cloud/login as normal.
-    { path: '/:pathMatch(.*)*', redirect: '/' }
+    { path: '/:pathMatch(.*)*', redirect: unmatchedRouteRedirect }
   ],
 
   scrollBehavior(_to, _from, savedPosition) {


### PR DESCRIPTION
## Summary

Follow-up to #15063 review comments: give diagnostic error reporting a home in the telemetry layer so vendor SDKs stop leaking into feature code.

## Changes

- **What**:
  - `reportError(error, metadata)` added to `TelemetryProvider` / `TelemetryRegistry`. Because `TelemetryDispatcher = Required<TelemetryProvider>`, the registry is forced to implement it. `error_type` is a closed union so reports stay low-cardinality and groupable.
  - `DatadogRumTelemetryProvider` → `addError`. `SentryTelemetryProvider` → `captureException` at `error` level, `addBreadcrumb` at `warning` level.
  - `bootstrapStore` drops its hand-rolled Sentry + Datadog fan-out (addresses https://github.com/Comfy-Org/ComfyUI_frontend/pull/15063#discussion_r3763272057).
  - Unmatched routes now report, so spikes are alertable (addresses https://github.com/Comfy-Org/ComfyUI_frontend/pull/15063#discussion_r3770774243). The catch-all redirect moved to `src/platform/navigation/unmatchedRoute.ts` — unit-testing it in place would mean importing `src/router.ts` and with it the whole view tree.
  - `assert()` failures report through the registry, superseding #14254.

After this, **no file outside `src/platform/telemetry/` imports `@datadog/browser-rum`.** Sentry still has 6 direct importers; those predate this PR and are deliberately left alone.

## Review Focus

- **Unmatched routes report at `warning`, not `error`.** They are user- and bot-triggered and unbounded, and we have been actively cutting this class of noise (#14503, #14507). Warning level puts them in Datadog for spike alerting while leaving Sentry a breadcrumb rather than an issue. The `Error` message is static so every path groups into one issue; the path itself travels as context, where cardinality is cheap.
- **The desktop assert path is deliberately untouched.** `initTelemetry()` is cloud-gated, so folding all of `setAssertReporter` into the registry would have silently dropped the existing `isDesktop` → `Sentry.captureMessage` reporting. Only the cloud branch was added. #14254's dedup-by-message and 20-per-session cap are preserved; its lazy SDK import is no longer needed because the provider is only constructed on cloud.
- `assertRumReporter.ts` from #14254 is renamed `assertFailureReporter.ts` — it is no longer RUM-specific.

## Test Plan

- `pnpm test:unit` — 1163 files, 15941 passed, 0 failed
- `pnpm typecheck`, `pnpm lint`, `pnpm knip`, `pnpm format` — clean
