### PR TITLE
fix(billing): reach the member-removal dialog when the downgrade preview is rejected

### DIFF
--- a/src/platform/workspace/composables/useDowngradeToPersonal.test.ts
+++ b/src/platform/workspace/composables/useDowngradeToPersonal.test.ts
@@ -5,6 +5,7 @@ import { WorkspaceApiError } from '@/platform/workspace/api/workspaceApi'
 import type { WorkspaceMember } from '@/platform/workspace/stores/teamWorkspaceStore'
 
 import {
+  DowngradeNotAllowedError,
   ReactivationConfirmationRequiredError,
   useDowngradeToPersonal
 } from './useDowngradeToPersonal'
@@ -857,17 +858,31 @@ describe('useDowngradeToPersonal', () => {
       expect(result.requiresReactivationConfirmation).toBe(true)
     })
 
-    it('throws the BE reason without removing members when the transition is disallowed', async () => {
+    it('throws a typed refusal carrying the priced preview when the transition is disallowed', async () => {
       mockSubscription.value = { isCancelled: true }
       mockPreviewSubscribe.mockResolvedValue({
         allowed: false,
-        reason: 'Outstanding balance'
+        reason: 'Requested seats exceed maximum allowed for this plan',
+        transition_type: 'downgrade',
+        cost_today_cents: 1500
       })
       const { previewDowngrade } = useDowngradeToPersonal()
 
-      await expect(previewDowngrade('founder-monthly')).rejects.toThrow(
-        'Outstanding balance'
+      const error = await previewDowngrade('founder-monthly').then(
+        () => {
+          throw new Error('expected previewDowngrade to reject')
+        },
+        (thrown: unknown) => thrown
       )
+
+      expect(error).toBeInstanceOf(DowngradeNotAllowedError)
+      const refusal = error as DowngradeNotAllowedError
+      expect(refusal.message).toBe(
+        'Requested seats exceed maximum allowed for this plan'
+      )
+      expect(refusal.details.preview.cost_today_cents).toBe(1500)
+      expect(refusal.details.requiresReactivationConfirmation).toBe(true)
+      expect(mockRemoveMember).not.toHaveBeenCalled()
     })
 
     it('reports the cancellation discovered by refreshing status, not the stale cached read', async () => {

--- a/src/platform/workspace/composables/useDowngradeToPersonal.ts
+++ b/src/platform/workspace/composables/useDowngradeToPersonal.ts
@@ -31,6 +31,17 @@ export interface DowngradePreview {
   requiresReactivationConfirmation: boolean
 }
 
+/** Thrown by `previewDowngrade` when the billing authority answers the
+ *  preview with `allowed: false`. Carries the server's full priced preview
+ *  (the response includes it even when disallowed), so a caller resolving the
+ *  refusal — e.g. by removing members — can show the server's own numbers
+ *  instead of inventing any. */
+export class DowngradeNotAllowedError extends Error {
+  constructor(public readonly details: DowngradePreview) {
+    super(details.preview.reason || t('subscription.downgrade.notAllowed'))
+  }
+}
+
 /** Thrown by `downgradeToPersonal` when the billing authority requires
  *  reactivation consent, so the still-open confirmation can collect it and
  *  retry with `confirmReactivation: true`. */
@@ -121,19 +132,23 @@ export function useDowngradeToPersonal() {
   async function previewDowngrade(planSlug: string): Promise<DowngradePreview> {
     ensureCanDowngrade()
     const preview = await previewSubscribe(planSlug)
-    if (!preview?.allowed) {
-      throw new Error(preview?.reason || t('subscription.downgrade.notAllowed'))
+    if (!preview) {
+      throw new Error(t('subscription.downgrade.notAllowed'))
     }
     ensureCanDowngrade()
     // `subscription` is a cached snapshot from the last billing-context load,
     // which can predate a cancellation; refresh it before reading isCancelled
     // so this decision reflects the current server state, not a stale one.
     await fetchStatus()
-    return {
+    const details: DowngradePreview = {
       preview,
       requiresReactivationConfirmation:
         requiresReactivationConfirmation(preview)
     }
+    if (!preview.allowed) {
+      throw new DowngradeNotAllowedError(details)
+    }
+    return details
   }
 
   async function downgradeToPersonal(

--- a/src/services/dialogService.downgrade.test.ts
+++ b/src/services/dialogService.downgrade.test.ts
@@ -25,11 +25,11 @@ const {
   class DowngradeNotAllowedError extends Error {
     constructor(
       public details: {
-        preview: { cost_today_cents: number }
+        preview: { cost_today_cents: number; reason?: string }
         requiresReactivationConfirmation: boolean
       }
     ) {
-      super('downgrade not allowed')
+      super(details.preview.reason ?? 'downgrade not allowed')
     }
   }
   class ReactivationConfirmationRequiredError extends Error {
@@ -438,6 +438,32 @@ describe('showDowngradeToPersonalDialog', () => {
 
     args.dialogComponentProps.onClose()
     await expect(resultPromise).resolves.toBeNull()
+  })
+
+  // Un-skip once PreviewSubscribeResponse carries a machine-readable
+  // reason_code: today every server refusal throws the same
+  // DowngradeNotAllowedError, so the FE cannot tell a refusal member
+  // removal would fix (seats) from one it would not (e.g. outstanding
+  // balance) and this destructive-path guard is not yet enforceable.
+  it.skip('does not offer member removal when the refusal is unrelated to seats', async () => {
+    hasOtherMembers.value = true
+    previewDowngrade.mockRejectedValue(
+      new DowngradeNotAllowedError({
+        preview: { cost_today_cents: 0, reason: 'Outstanding balance' },
+        requiresReactivationConfirmation: false
+      })
+    )
+
+    await useDialogService().showDowngradeToPersonalDialog(options)
+
+    expect(toastAdd).toHaveBeenCalledWith(
+      expect.objectContaining({
+        severity: 'error',
+        detail: 'Outstanding balance'
+      })
+    )
+    expect(showDialog).not.toHaveBeenCalled()
+    expect(downgradeToPersonal).not.toHaveBeenCalled()
   })
 
   it('toasts instead of opening the dialog when the preview fails for any other reason, even with members', async () => {

--- a/src/services/dialogService.downgrade.test.ts
+++ b/src/services/dialogService.downgrade.test.ts
@@ -18,9 +18,20 @@ const hasOtherMembers = vi.hoisted(() => ({ value: false }))
 const openDialogKeys = ref<string[]>([])
 
 const {
+  DowngradeNotAllowedError,
   ReactivationConfirmationRequiredError,
   ReactivationAmountChangedError
 } = vi.hoisted(() => {
+  class DowngradeNotAllowedError extends Error {
+    constructor(
+      public details: {
+        preview: { cost_today_cents: number }
+        requiresReactivationConfirmation: boolean
+      }
+    ) {
+      super('downgrade not allowed')
+    }
+  }
   class ReactivationConfirmationRequiredError extends Error {
     constructor(public preview: { cost_today_cents: number }) {
       super('reactivation confirmation required')
@@ -32,6 +43,7 @@ const {
     }
   }
   return {
+    DowngradeNotAllowedError,
     ReactivationConfirmationRequiredError,
     ReactivationAmountChangedError
   }
@@ -77,6 +89,7 @@ vi.mock('@/platform/workspace/composables/useDowngradeToPersonal', () => ({
     previewDowngrade,
     downgradeToPersonal
   }),
+  DowngradeNotAllowedError,
   ReactivationConfirmationRequiredError,
   ReactivationAmountChangedError
 }))
@@ -404,10 +417,13 @@ describe('showDowngradeToPersonalDialog', () => {
     expect(downgradeToPersonal).not.toHaveBeenCalled()
   })
 
-  it('still offers member removal when the preview is rejected because members exist', async () => {
+  it('still offers member removal when the BE refuses the preview, using its priced numbers', async () => {
     hasOtherMembers.value = true
     previewDowngrade.mockRejectedValue(
-      new Error('Requested seats exceed maximum allowed for this plan')
+      new DowngradeNotAllowedError({
+        preview: { cost_today_cents: 1500 },
+        requiresReactivationConfirmation: true
+      })
     )
 
     const resultPromise =
@@ -417,8 +433,26 @@ describe('showDowngradeToPersonalDialog', () => {
     expect(toastAdd).not.toHaveBeenCalled()
     const [args] = showDialog.mock.calls[0]
     expect(args.props.requiresRemoval).toBe(true)
+    expect(args.props.requiresReactivation).toBe(true)
+    expect(args.props.chargeCents).toBe(1500)
 
     args.dialogComponentProps.onClose()
     await expect(resultPromise).resolves.toBeNull()
+  })
+
+  it('toasts instead of opening the dialog when the preview fails for any other reason, even with members', async () => {
+    hasOtherMembers.value = true
+    previewDowngrade.mockRejectedValue(new Error('Network request failed'))
+
+    await useDialogService().showDowngradeToPersonalDialog(options)
+
+    expect(toastAdd).toHaveBeenCalledWith(
+      expect.objectContaining({
+        severity: 'error',
+        detail: 'Network request failed'
+      })
+    )
+    expect(showDialog).not.toHaveBeenCalled()
+    expect(downgradeToPersonal).not.toHaveBeenCalled()
   })
 })

--- a/src/services/dialogService.downgrade.test.ts
+++ b/src/services/dialogService.downgrade.test.ts
@@ -389,7 +389,7 @@ describe('showDowngradeToPersonalDialog', () => {
     expect(downgradeToPersonal).not.toHaveBeenCalled()
   })
 
-  it('toasts and aborts when the preview fails', async () => {
+  it('toasts and aborts when the preview fails with no other members', async () => {
     previewDowngrade.mockRejectedValue(new Error('Outstanding balance'))
 
     await useDialogService().showDowngradeToPersonalDialog(options)
@@ -402,5 +402,23 @@ describe('showDowngradeToPersonalDialog', () => {
     )
     expect(showDialog).not.toHaveBeenCalled()
     expect(downgradeToPersonal).not.toHaveBeenCalled()
+  })
+
+  it('still offers member removal when the preview is rejected because members exist', async () => {
+    hasOtherMembers.value = true
+    previewDowngrade.mockRejectedValue(
+      new Error('Requested seats exceed maximum allowed for this plan')
+    )
+
+    const resultPromise =
+      useDialogService().showDowngradeToPersonalDialog(options)
+    await vi.waitFor(() => expect(showDialog).toHaveBeenCalledOnce())
+
+    expect(toastAdd).not.toHaveBeenCalled()
+    const [args] = showDialog.mock.calls[0]
+    expect(args.props.requiresRemoval).toBe(true)
+
+    args.dialogComponentProps.onClose()
+    await expect(resultPromise).resolves.toBeNull()
   })
 })

--- a/src/services/dialogService.ts
+++ b/src/services/dialogService.ts
@@ -695,6 +695,7 @@ export const useDialogService = () => {
   }): Promise<DowngradeToPersonalResult | null> {
     const {
       useDowngradeToPersonal,
+      DowngradeNotAllowedError,
       ReactivationConfirmationRequiredError,
       ReactivationAmountChangedError
     } = await import('@/platform/workspace/composables/useDowngradeToPersonal')
@@ -726,10 +727,13 @@ export const useDialogService = () => {
         return await downgradeToPersonal(options.planSlug)
       }
     } catch (error) {
-      // The backend rejects a downgrade preview while the workspace still has
-      // other members — the very case this dialog exists to resolve — so fall
-      // through to it rather than surfacing the rejection as a dead end.
-      if (!hasOtherMembers.value) {
+      // A typed refusal on a still-populated workspace is the very case this
+      // dialog exists to resolve: fall through carrying the server's own
+      // priced preview. Anything else stays a dead end.
+      if (
+        !(error instanceof DowngradeNotAllowedError) ||
+        !hasOtherMembers.value
+      ) {
         useToastStore().add({
           severity: 'error',
           summary: t('subscription.downgrade.failed'),
@@ -737,6 +741,8 @@ export const useDialogService = () => {
         })
         return null
       }
+      requiresReactivation = error.details.requiresReactivationConfirmation
+      chargeCents = error.details.preview.cost_today_cents
     }
 
     const { default: component } =

--- a/src/services/dialogService.ts
+++ b/src/services/dialogService.ts
@@ -709,12 +709,6 @@ export const useDialogService = () => {
     let chargeCents = 0
     try {
       await refreshMembers()
-      const preview = await previewDowngrade(options.planSlug)
-      requiresReactivation = preview.requiresReactivationConfirmation
-      chargeCents = preview.preview.cost_today_cents
-      if (!hasOtherMembers.value && !requiresReactivation) {
-        return await downgradeToPersonal(options.planSlug)
-      }
     } catch (error) {
       useToastStore().add({
         severity: 'error',
@@ -722,6 +716,27 @@ export const useDialogService = () => {
         detail: error instanceof Error ? error.message : t('g.unknownError')
       })
       return null
+    }
+
+    try {
+      const preview = await previewDowngrade(options.planSlug)
+      requiresReactivation = preview.requiresReactivationConfirmation
+      chargeCents = preview.preview.cost_today_cents
+      if (!hasOtherMembers.value && !requiresReactivation) {
+        return await downgradeToPersonal(options.planSlug)
+      }
+    } catch (error) {
+      // The backend rejects a downgrade preview while the workspace still has
+      // other members — the very case this dialog exists to resolve — so fall
+      // through to it rather than surfacing the rejection as a dead end.
+      if (!hasOtherMembers.value) {
+        useToastStore().add({
+          severity: 'error',
+          summary: t('subscription.downgrade.failed'),
+          detail: error instanceof Error ? error.message : t('g.unknownError')
+        })
+        return null
+      }
     }
 
     const { default: component } =


### PR DESCRIPTION
Draft for @dante01yoon — found while reproducing a team→personal downgrade on production. Handing over rather than pushing it through, since this is your area.

## What the user sees

Downgrading from a team plan to a personal plan while the workspace still has members produces an error toast:

> **Failed to change plan**
> Requested seats exceed maximum allowed for this plan

The flow then dead-ends. There is no way forward from the toast.

## What should happen

`DowngradeRemoveMembersDialogContent` already exists for exactly this case — it confirms the change and removes the other members as part of it. The user never reaches it.

## Why

`showDowngradeToPersonalDialog` in `dialogService.ts` awaited the member refresh and the downgrade preview inside one `try`:

```ts
try {
  await refreshMembers()
  const preview = await previewDowngrade(options.planSlug)
  ...
  if (!hasOtherMembers.value && !requiresReactivation) {
    return await downgradeToPersonal(options.planSlug)
  }
} catch (error) {
  toast({ summary: t('subscription.downgrade.failed'), detail: error.message })
  return null
}
```

The backend rejects the **preview** while other members exist, so the `catch` fires, prints the raw backend string, and `return null` kills the flow before the dialog can render. The precondition the dialog is built to resolve is the same one that prevents it opening.

## Change

Split the two awaits. A member-refresh failure still aborts. A preview rejection falls through to the dialog when other members exist, and still toasts when they don't.

The dialog's required props are `planName`, `planSlug`, and `onConfirm`; `requiresRemoval` comes from `refreshMembers()`, not the preview — so it renders correctly without preview data.

## Open questions for you

1. **Discrimination.** This treats *any* preview rejection as the members case when members exist. A backend error code would let us narrow it — the frontend already matches `TRANSITION_NOT_ALLOWED`, `PRORATION_QUOTE_EXPIRED`, `SUBSCRIPTION_PAYMENT_REQUIRED` and `REACTIVATION_CONFIRMATION_REQUIRED` via `hasErrorCode`, so a `SEATS_EXCEED_PLAN_MAXIMUM` (or similar) would slot straight in. Worth asking BE for?
2. **Cancelled subscriptions.** Without a preview we don't know `requiresReactivation` or `chargeCents`, so the dialog can't disclose the reactivation charge in this path. The backend then rejects with `REACTIVATION_CONFIRMATION_REQUIRED`, which `useDowngradeToPersonal` already throws as `ReactivationConfirmationRequiredError`. It recovers, but the user sees a second step. Cleaner if the preview succeeded.
3. **Or fix it backend-side** — if the preview returned a result describing what must be removed instead of rejecting, none of this would be needed.

## Alternative, if you'd rather not change the flow

Keep the toast and make it actionable. Proposed copy, matching the register of its neighbours in `subscription.downgrade`:

> **Failed to change plan**
> Personal plans are for individual use only — remove the other members from this workspace first.

That reuses the phrasing already on the pricing dialog ("Personal plans are for individual use only"). Note "all members" would be inaccurate — the owner stays.

## Validation

- `pnpm test:unit` on `dialogService.downgrade` — 13 passed, including a new case asserting the dialog opens (and no toast fires) when the preview is rejected with members present
- `useSubscriptionCheckout` + `DowngradeRemoveMembersDialogContent` — 110 passed
- `pnpm typecheck`, `pnpm format` clean

Not verified end-to-end against a real backend — the reproduction was on production and I did not want to exercise a live plan change.