### PR TITLE
feat(billing): Plan & Credits Activity tab reuses the usage-log table

### DIFF
--- a/src/platform/workspace/components/dialogs/settings/PlanCreditsPanelContent.test.ts
+++ b/src/platform/workspace/components/dialogs/settings/PlanCreditsPanelContent.test.ts
@@ -8,16 +8,7 @@ import enMessages from '@/locales/en/main.json'
 
 import PlanCreditsPanelContent from './PlanCreditsPanelContent.vue'
 
-const mockWorkspaceState = vi.hoisted(() => ({ personal: true }))
-vi.mock('@/platform/workspace/stores/teamWorkspaceStore', () => ({
-  useTeamWorkspaceStore: () => ({
-    get isInPersonalWorkspace() {
-      return mockWorkspaceState.personal
-    }
-  })
-}))
-
-const refreshSpy = vi.hoisted(() => vi.fn())
+const refreshSpy = vi.fn()
 
 const stubs = {
   SubscriptionPanelContentWorkspace: {
@@ -31,8 +22,7 @@ const stubs = {
   }
 }
 
-function renderPanel({ personal = true } = {}) {
-  mockWorkspaceState.personal = personal
+function renderPanel() {
   const i18n = createI18n({
     legacy: false,
     locale: 'en',
@@ -59,10 +49,13 @@ describe('PlanCreditsPanelContent', () => {
     await waitFor(() => expect(refreshSpy).toHaveBeenCalledTimes(1))
   })
 
-  it('hides the Activity tab for team workspaces', () => {
-    renderPanel({ personal: false })
-    expect(screen.getByRole('button', { name: 'Credits' })).toBeTruthy()
-    expect(screen.queryByRole('button', { name: 'Activity' })).toBeNull()
-    expect(screen.getByTestId('credits-body')).toBeTruthy()
+  it('reloads the table each time the Activity tab is reopened', async () => {
+    refreshSpy.mockClear()
+    renderPanel()
+    await userEvent.click(screen.getByRole('button', { name: 'Activity' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Credits' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Activity' }))
+    await waitFor(() => expect(refreshSpy).toHaveBeenCalledTimes(2))
+    expect(screen.getByTestId('usage-logs')).toBeTruthy()
   })
 })

--- a/src/platform/workspace/components/dialogs/settings/PlanCreditsPanelContent.test.ts
+++ b/src/platform/workspace/components/dialogs/settings/PlanCreditsPanelContent.test.ts
@@ -1,23 +1,38 @@
-import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { createI18n } from 'vue-i18n'
+
+import { render, screen, waitFor } from '@testing-library/vue'
 
 import enMessages from '@/locales/en/main.json'
 
 import PlanCreditsPanelContent from './PlanCreditsPanelContent.vue'
 
+const mockWorkspaceState = vi.hoisted(() => ({ personal: true }))
+vi.mock('@/platform/workspace/stores/teamWorkspaceStore', () => ({
+  useTeamWorkspaceStore: () => ({
+    get isInPersonalWorkspace() {
+      return mockWorkspaceState.personal
+    }
+  })
+}))
+
+const refreshSpy = vi.hoisted(() => vi.fn())
+
 const stubs = {
   SubscriptionPanelContentWorkspace: {
     template: '<div data-testid="credits-body" />'
   },
-  WorkspaceActivityContent: {
-    props: ['search'],
-    template: '<div data-testid="activity-body">{{ search }}</div>'
+  UsageLogsTable: {
+    template: '<div data-testid="usage-logs" />',
+    methods: {
+      refresh: refreshSpy
+    }
   }
 }
 
-function renderPanel() {
+function renderPanel({ personal = true } = {}) {
+  mockWorkspaceState.personal = personal
   const i18n = createI18n({
     legacy: false,
     locale: 'en',
@@ -32,32 +47,22 @@ describe('PlanCreditsPanelContent', () => {
     expect(screen.getByRole('button', { name: 'Credits' })).toBeTruthy()
     expect(screen.getByRole('button', { name: 'Activity' })).toBeTruthy()
     expect(screen.getByTestId('credits-body')).toBeTruthy()
-    expect(screen.queryByTestId('activity-body')).toBeNull()
+    expect(screen.queryByTestId('usage-logs')).toBeNull()
   })
 
-  it('shows the search box only on the Activity tab', async () => {
+  it('shows the usage-log table on the Activity tab and loads it', async () => {
+    refreshSpy.mockClear()
     renderPanel()
-    expect(screen.queryByPlaceholderText('Search')).toBeNull()
-
     await userEvent.click(screen.getByRole('button', { name: 'Activity' }))
-    expect(screen.getByTestId('activity-body')).toBeTruthy()
+    expect(screen.getByTestId('usage-logs')).toBeTruthy()
     expect(screen.queryByTestId('credits-body')).toBeNull()
-    expect(screen.getByPlaceholderText('Search')).toBeTruthy()
+    await waitFor(() => expect(refreshSpy).toHaveBeenCalledTimes(1))
   })
 
-  it('passes the search query to the Activity tab and clears it on tab change', async () => {
-    renderPanel()
-    await userEvent.click(screen.getByRole('button', { name: 'Activity' }))
-    await userEvent.type(screen.getByPlaceholderText('Search'), 'flux')
-    expect(screen.getByTestId('activity-body').textContent).toContain('flux')
-
-    await userEvent.click(screen.getByRole('button', { name: 'Credits' }))
-    await userEvent.click(screen.getByRole('button', { name: 'Activity' }))
-    expect(screen.getByTestId('activity-body').textContent).not.toContain(
-      'flux'
-    )
-    expect(
-      (screen.getByPlaceholderText('Search') as HTMLInputElement).value
-    ).toBe('')
+  it('hides the Activity tab for team workspaces', () => {
+    renderPanel({ personal: false })
+    expect(screen.getByRole('button', { name: 'Credits' })).toBeTruthy()
+    expect(screen.queryByRole('button', { name: 'Activity' })).toBeNull()
+    expect(screen.getByTestId('credits-body')).toBeTruthy()
   })
 })

--- a/src/platform/workspace/components/dialogs/settings/PlanCreditsPanelContent.vue
+++ b/src/platform/workspace/components/dialogs/settings/PlanCreditsPanelContent.vue
@@ -9,7 +9,7 @@
           :key="tab.key"
           :variant="activeView === tab.key ? 'secondary' : 'muted-textonly'"
           size="lg"
-          @click="requestedView = tab.key"
+          @click="activeView = tab.key"
         >
           {{ tab.label }}
         </Button>
@@ -28,36 +28,22 @@ import { useI18n } from 'vue-i18n'
 import UsageLogsTable from '@/components/dialog/content/setting/UsageLogsTable.vue'
 import Button from '@/components/ui/button/Button.vue'
 import SubscriptionPanelContentWorkspace from '@/platform/workspace/components/SubscriptionPanelContentWorkspace.vue'
-import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
 
 type View = 'overview' | 'activity'
 
 const { t } = useI18n()
 
-const workspaceStore = useTeamWorkspaceStore()
-
-// Stopgap until FE-1249 wires the per-workspace usage API: personal
-// workspaces reuse the usage-log table local users already have, and team
-// workspaces hide the tab instead of showing the designed ledger empty
-// (WorkspaceActivityContent returns with the real data).
+// Stopgap until FE-1249 wires the per-workspace usage API: the Activity tab
+// reuses the usage-log table local users already have (WorkspaceActivityContent
+// returns with the real ledger data).
 // The owner-only Invoices tab is added by FE-1245, which owns the
 // next-invoice banner + Stripe portal link that fill it.
 const tabs = computed<{ key: View; label: string }[]>(() => [
   { key: 'overview', label: t('workspacePanel.planCredits.tabs.overview') },
-  ...(workspaceStore.isInPersonalWorkspace
-    ? [
-        {
-          key: 'activity' as View,
-          label: t('workspacePanel.planCredits.tabs.activity')
-        }
-      ]
-    : [])
+  { key: 'activity', label: t('workspacePanel.planCredits.tabs.activity') }
 ])
 
-const requestedView = ref<View>('overview')
-const activeView = computed<View>(() =>
-  workspaceStore.isInPersonalWorkspace ? requestedView.value : 'overview'
-)
+const activeView = ref<View>('overview')
 
 const usageLogsTable = useTemplateRef('usageLogsTable')
 watch(usageLogsTable, (table) => {

--- a/src/platform/workspace/components/dialogs/settings/PlanCreditsPanelContent.vue
+++ b/src/platform/workspace/components/dialogs/settings/PlanCreditsPanelContent.vue
@@ -9,50 +9,58 @@
           :key="tab.key"
           :variant="activeView === tab.key ? 'secondary' : 'muted-textonly'"
           size="lg"
-          @click="setView(tab.key)"
+          @click="requestedView = tab.key"
         >
           {{ tab.label }}
         </Button>
       </div>
-      <SearchInput
-        v-if="activeView === 'activity'"
-        v-model="searchQuery"
-        :placeholder="$t('g.search')"
-        size="lg"
-        class="w-full @2xl:w-64"
-      />
     </div>
 
     <SubscriptionPanelContentWorkspace v-if="activeView === 'overview'" />
-    <WorkspaceActivityContent v-else :search="searchQuery" />
+    <UsageLogsTable v-else ref="usageLogsTable" />
   </div>
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { computed, ref, useTemplateRef, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 
+import UsageLogsTable from '@/components/dialog/content/setting/UsageLogsTable.vue'
 import Button from '@/components/ui/button/Button.vue'
-import SearchInput from '@/components/ui/search-input/SearchInput.vue'
 import SubscriptionPanelContentWorkspace from '@/platform/workspace/components/SubscriptionPanelContentWorkspace.vue'
-import WorkspaceActivityContent from '@/platform/workspace/components/dialogs/settings/WorkspaceActivityContent.vue'
+import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
 
 type View = 'overview' | 'activity'
 
 const { t } = useI18n()
 
+const workspaceStore = useTeamWorkspaceStore()
+
+// Stopgap until FE-1249 wires the per-workspace usage API: personal
+// workspaces reuse the usage-log table local users already have, and team
+// workspaces hide the tab instead of showing the designed ledger empty
+// (WorkspaceActivityContent returns with the real data).
 // The owner-only Invoices tab is added by FE-1245, which owns the
 // next-invoice banner + Stripe portal link that fill it.
 const tabs = computed<{ key: View; label: string }[]>(() => [
   { key: 'overview', label: t('workspacePanel.planCredits.tabs.overview') },
-  { key: 'activity', label: t('workspacePanel.planCredits.tabs.activity') }
+  ...(workspaceStore.isInPersonalWorkspace
+    ? [
+        {
+          key: 'activity' as View,
+          label: t('workspacePanel.planCredits.tabs.activity')
+        }
+      ]
+    : [])
 ])
 
-const activeView = ref<View>('overview')
-const searchQuery = ref('')
+const requestedView = ref<View>('overview')
+const activeView = computed<View>(() =>
+  workspaceStore.isInPersonalWorkspace ? requestedView.value : 'overview'
+)
 
-function setView(view: View) {
-  activeView.value = view
-  searchQuery.value = ''
-}
+const usageLogsTable = useTemplateRef('usageLogsTable')
+watch(usageLogsTable, (table) => {
+  if (table) void table.refresh()
+})
 </script>


### PR DESCRIPTION
Stopgap for workspace Activity until FE-1249 lands the per-workspace usage API.

Cloud users lost the usage-log table when the legacy Credits panel was replaced by the V1 Plan & Credits shell — the designed Activity ledger currently mounts with no data. Local users have had this table the whole time. This restores parity inside the V1 tab organization so future dev work aligns on the new structure.

- The Activity tab now renders `UsageLogsTable` (same component local users see; it already routes to `/api/billing/events` via `useBillingRouting`). BE confirmed the events feed serves team workspaces as well as personal, so both get the tab — no type distinction.
- The tab mounts the table with an explicit `refresh()` — the table never self-loads, which is also why it could spin forever when neither the legacy balance-refresh nor a billing-route flip fired.
- The Activity search input is removed with it (it only fed the designed ledger). `WorkspaceActivityContent` is unchanged and returns when FE-1249 wires real data.

Known rough edges, kept out of scope: `cloud_workflow_executed` events fall through `formatEventType` unmapped (raw badge) and render an empty Details cell — needs the workspace event vocabulary + whatever `params` carries per event, tracked for follow-up.

- Verified: unit tests for the panel + `UsageLogsTable`, typecheck, lint; mocked-boot Playwright run against a dev build for personal and team workspaces.
