### PR TITLE
FE-1585 fix(billing): refresh stale Run entitlement on app return

### DIFF
--- a/browser_tests/tests/subscription.spec.ts
+++ b/browser_tests/tests/subscription.spec.ts
@@ -126,6 +126,31 @@ unsubscribedTest.describe(
     )
 
     unsubscribedTest(
+      'App focus refreshes stale subscription state and restores Run',
+      async ({ comfyPage, subscriptionHelper }) => {
+        await expect(
+          comfyPage.page.getByTestId(TestIds.topbar.subscribeToRunButton)
+        ).toBeVisible()
+
+        subscriptionHelper.setStatus({
+          is_active: true,
+          subscription_tier: 'STANDARD',
+          subscription_duration: 'MONTHLY'
+        })
+        await comfyPage.page.evaluate(() => {
+          window.dispatchEvent(new Event('focus'))
+        })
+
+        await expect(
+          comfyPage.page.getByTestId(TestIds.topbar.queueButton)
+        ).toBeVisible()
+        await expect(
+          comfyPage.page.getByTestId(TestIds.topbar.subscribeToRunButton)
+        ).toBeHidden()
+      }
+    )
+
+    unsubscribedTest(
       'Cleanup prevents stale subscription state after dialog close',
       async ({ comfyPage, subscriptionHelper }) => {
         await subscriptionHelper.clickPopoverSubscribe()

--- a/src/components/actionbar/ComfyRunButton/CloudRunButtonWrapper.test.ts
+++ b/src/components/actionbar/ComfyRunButton/CloudRunButtonWrapper.test.ts
@@ -153,17 +153,25 @@ describe('CloudRunButtonWrapper', () => {
     const visibilityState = vi
       .spyOn(document, 'visibilityState', 'get')
       .mockReturnValue('visible')
-    mockCanRunWorkflows.value = false
-    mockBillingStatus.value = 'inactive'
-    renderWrapper()
+    try {
+      mockCanRunWorkflows.value = false
+      mockBillingStatus.value = 'inactive'
+      state.fetchStatus.mockImplementationOnce(async () => {
+        mockBillingStatus.value = 'paid'
+        mockCanRunWorkflows.value = true
+      })
+      renderWrapper()
 
-    document.dispatchEvent(new Event('visibilitychange'))
+      document.dispatchEvent(new Event('visibilitychange'))
 
-    await waitFor(() => {
-      expect(state.fetchStatus).toHaveBeenCalledOnce()
-      expect(state.fetchBalance).toHaveBeenCalledOnce()
-    })
-    visibilityState.mockRestore()
+      await waitFor(() => {
+        expect(state.fetchStatus).toHaveBeenCalledOnce()
+        expect(state.fetchBalance).toHaveBeenCalledOnce()
+        expect(screen.getByRole('button', { name: 'Run' })).toBeInTheDocument()
+      })
+    } finally {
+      visibilityState.mockRestore()
+    }
   })
 
   it('deduplicates simultaneous focus and visibility refreshes', async () => {
@@ -174,21 +182,70 @@ describe('CloudRunButtonWrapper', () => {
     const visibilityState = vi
       .spyOn(document, 'visibilityState', 'get')
       .mockReturnValue('visible')
-    mockCanRunWorkflows.value = false
-    mockBillingStatus.value = 'inactive'
-    state.fetchStatus.mockReturnValueOnce(refresh)
-    state.fetchBalance.mockReturnValueOnce(refresh)
+    try {
+      mockCanRunWorkflows.value = false
+      mockBillingStatus.value = 'inactive'
+      state.fetchStatus.mockReturnValueOnce(refresh)
+      state.fetchBalance.mockReturnValueOnce(refresh)
+      renderWrapper()
+
+      window.dispatchEvent(new Event('focus'))
+      document.dispatchEvent(new Event('visibilitychange'))
+
+      expect(state.fetchStatus).toHaveBeenCalledOnce()
+      expect(state.fetchBalance).toHaveBeenCalledOnce()
+
+      resolveRefresh()
+      await refresh
+    } finally {
+      visibilityState.mockRestore()
+    }
+  })
+
+  it('does not refresh billing while Run is already available', () => {
     renderWrapper()
 
     window.dispatchEvent(new Event('focus'))
-    document.dispatchEvent(new Event('visibilitychange'))
 
-    expect(state.fetchStatus).toHaveBeenCalledOnce()
-    expect(state.fetchBalance).toHaveBeenCalledOnce()
+    expect(state.fetchStatus).not.toHaveBeenCalled()
+    expect(state.fetchBalance).not.toHaveBeenCalled()
+  })
 
-    resolveRefresh()
-    await refresh
-    visibilityState.mockRestore()
+  it('ignores visibility changes while the app remains hidden', () => {
+    const visibilityState = vi
+      .spyOn(document, 'visibilityState', 'get')
+      .mockReturnValue('hidden')
+    try {
+      mockCanRunWorkflows.value = false
+      mockBillingStatus.value = 'inactive'
+      renderWrapper()
+
+      document.dispatchEvent(new Event('visibilitychange'))
+
+      expect(state.fetchStatus).not.toHaveBeenCalled()
+      expect(state.fetchBalance).not.toHaveBeenCalled()
+    } finally {
+      visibilityState.mockRestore()
+    }
+  })
+
+  it('retries a failed stale billing refresh on the next focus', async () => {
+    mockCanRunWorkflows.value = false
+    mockBillingStatus.value = 'inactive'
+    state.fetchStatus.mockRejectedValueOnce(new Error('Status unavailable'))
+    state.fetchBalance.mockRejectedValueOnce(new Error('Balance unavailable'))
+    renderWrapper()
+
+    window.dispatchEvent(new Event('focus'))
+    await waitFor(() => expect(state.fetchStatus).toHaveBeenCalledOnce())
+    await new Promise((resolve) => setTimeout(resolve))
+
+    window.dispatchEvent(new Event('focus'))
+
+    await waitFor(() => {
+      expect(state.fetchStatus).toHaveBeenCalledTimes(2)
+      expect(state.fetchBalance).toHaveBeenCalledTimes(2)
+    })
   })
 
   it('unlocks the run button once the subscription becomes active again', async () => {
@@ -231,6 +288,17 @@ describe('CloudRunButtonWrapper', () => {
       key: 'subscription-paused'
     })
     expect(state.manageSubscription).toHaveBeenCalledOnce()
+  })
+
+  it('does not refresh paused billing before the recovery portal is opened', () => {
+    mockCanRunWorkflows.value = false
+    mockBillingStatus.value = 'paused'
+    renderWrapper()
+
+    window.dispatchEvent(new Event('focus'))
+
+    expect(state.fetchStatus).not.toHaveBeenCalled()
+    expect(state.fetchBalance).not.toHaveBeenCalled()
   })
 
   it('keeps recovery open and surfaces portal failures', async () => {

--- a/src/components/actionbar/ComfyRunButton/CloudRunButtonWrapper.test.ts
+++ b/src/components/actionbar/ComfyRunButton/CloudRunButtonWrapper.test.ts
@@ -131,6 +131,66 @@ describe('CloudRunButtonWrapper', () => {
     expect(screen.queryByTestId('queue-button')).not.toBeInTheDocument()
   })
 
+  it('refreshes stale billing state on focus and restores Run', async () => {
+    mockCanRunWorkflows.value = false
+    mockBillingStatus.value = 'inactive'
+    state.fetchStatus.mockImplementationOnce(async () => {
+      mockBillingStatus.value = 'paid'
+      mockCanRunWorkflows.value = true
+    })
+    renderWrapper()
+
+    window.dispatchEvent(new Event('focus'))
+
+    await waitFor(() => {
+      expect(state.fetchStatus).toHaveBeenCalledOnce()
+      expect(state.fetchBalance).toHaveBeenCalledOnce()
+      expect(screen.getByRole('button', { name: 'Run' })).toBeInTheDocument()
+    })
+  })
+
+  it('refreshes stale billing state when the app becomes visible', async () => {
+    const visibilityState = vi
+      .spyOn(document, 'visibilityState', 'get')
+      .mockReturnValue('visible')
+    mockCanRunWorkflows.value = false
+    mockBillingStatus.value = 'inactive'
+    renderWrapper()
+
+    document.dispatchEvent(new Event('visibilitychange'))
+
+    await waitFor(() => {
+      expect(state.fetchStatus).toHaveBeenCalledOnce()
+      expect(state.fetchBalance).toHaveBeenCalledOnce()
+    })
+    visibilityState.mockRestore()
+  })
+
+  it('deduplicates simultaneous focus and visibility refreshes', async () => {
+    let resolveRefresh!: () => void
+    const refresh = new Promise<void>((resolve) => {
+      resolveRefresh = resolve
+    })
+    const visibilityState = vi
+      .spyOn(document, 'visibilityState', 'get')
+      .mockReturnValue('visible')
+    mockCanRunWorkflows.value = false
+    mockBillingStatus.value = 'inactive'
+    state.fetchStatus.mockReturnValueOnce(refresh)
+    state.fetchBalance.mockReturnValueOnce(refresh)
+    renderWrapper()
+
+    window.dispatchEvent(new Event('focus'))
+    document.dispatchEvent(new Event('visibilitychange'))
+
+    expect(state.fetchStatus).toHaveBeenCalledOnce()
+    expect(state.fetchBalance).toHaveBeenCalledOnce()
+
+    resolveRefresh()
+    await refresh
+    visibilityState.mockRestore()
+  })
+
   it('unlocks the run button once the subscription becomes active again', async () => {
     mockCanRunWorkflows.value = false
     renderWrapper()

--- a/src/components/actionbar/ComfyRunButton/CloudRunButtonWrapper.vue
+++ b/src/components/actionbar/ComfyRunButton/CloudRunButtonWrapper.vue
@@ -35,6 +35,7 @@ const dialogStore = useDialogStore()
 const { toastErrorHandler } = useErrorHandling()
 const isUpdatingPayment = ref(false)
 let paymentPortalRequest: Promise<void> | null = null
+let billingRefreshRequest: Promise<void> | null = null
 let isUnmounted = false
 let refreshBillingOnFocus = false
 
@@ -42,10 +43,27 @@ onUnmounted(() => {
   isUnmounted = true
 })
 
-useEventListener(window, 'focus', () => {
-  if (!refreshBillingOnFocus) return
+function refreshStaleBillingState() {
+  if (
+    billingRefreshRequest ||
+    (!refreshBillingOnFocus && !showsSubscribeToRunPrompt.value)
+  ) {
+    return
+  }
+
   refreshBillingOnFocus = false
-  void Promise.allSettled([fetchStatus(), fetchBalance()])
+  billingRefreshRequest = Promise.allSettled([
+    fetchStatus(),
+    fetchBalance()
+  ]).then(() => undefined)
+  void billingRefreshRequest.finally(() => {
+    billingRefreshRequest = null
+  })
+}
+
+useEventListener(window, 'focus', refreshStaleBillingState)
+useEventListener(document, 'visibilitychange', () => {
+  if (document.visibilityState === 'visible') refreshStaleBillingState()
 })
 
 const paymentRecoveryLock = computed<'owner' | 'member' | null>(() =>

--- a/src/components/actionbar/ComfyRunButton/CloudRunButtonWrapper.vue
+++ b/src/components/actionbar/ComfyRunButton/CloudRunButtonWrapper.vue
@@ -43,10 +43,19 @@ onUnmounted(() => {
   isUnmounted = true
 })
 
+const paymentRecoveryLock = computed<'owner' | 'member' | null>(() =>
+  flags.v1PaymentRecovery && billingStatus.value === 'paused'
+    ? permissions.value.canManageSubscription
+      ? 'owner'
+      : 'member'
+    : null
+)
+
 function refreshStaleBillingState() {
   if (
     billingRefreshRequest ||
-    (!refreshBillingOnFocus && !showsSubscribeToRunPrompt.value)
+    (!refreshBillingOnFocus &&
+      (!showsSubscribeToRunPrompt.value || paymentRecoveryLock.value))
   ) {
     return
   }
@@ -65,14 +74,6 @@ useEventListener(window, 'focus', refreshStaleBillingState)
 useEventListener(document, 'visibilitychange', () => {
   if (document.visibilityState === 'visible') refreshStaleBillingState()
 })
-
-const paymentRecoveryLock = computed<'owner' | 'member' | null>(() =>
-  flags.v1PaymentRecovery && billingStatus.value === 'paused'
-    ? permissions.value.canManageSubscription
-      ? 'owner'
-      : 'member'
-    : null
-)
 
 function closePaymentRecoveryDialog() {
   dialogStore.closeDialog({ key: DIALOG_KEY })


### PR DESCRIPTION
## Why

FE-1540 is only partially fixed by #14965. The Run surface no longer shows a paywall before billing initializes, but a successful `inactive` response remains cached when the authoritative subscription changes outside the open app—for example after returning from Stripe Portal, another tab, a delayed webhook, or a support action.

`CloudRunButtonWrapper` previously refreshed on focus only when its own paused-payment recovery flow set `refreshBillingOnFocus`. A plain `Subscribe to Run` state had no focus/visibility recovery, so the user needed a manual page reload even after the server became `active`.

## AS IS

```mermaid
sequenceDiagram
  participant FE as Open editor
  participant API as Billing API
  participant Provider as Stripe / webhook

  FE->>API: Fetch billing status
  API-->>FE: inactive
  Note over FE: Show Subscribe to Run
  Provider->>API: Subscription becomes active
  Note over FE,API: No pending BillingOp and no general refetch
  Note over FE: Cached inactive state remains until reload
```

## TO BE

```mermaid
sequenceDiagram
  participant User
  participant FE as CloudRunButtonWrapper
  participant Context as useBillingContext
  participant API as Authoritative billing API

  User->>FE: Return to app (focus / visible)
  FE->>FE: Confirm Subscribe to Run is displayed
  FE->>Context: fetchStatus + fetchBalance
  alt legacy billing rail
    Context->>API: Legacy billing reads
  else workspace billing rail
    Context->>API: Workspace billing reads
  end
  API-->>Context: active + current balance
  Context-->>FE: Reactive billing state updates
  Note over FE: Subscribe to Run becomes Run
```

## Change

- Revalidate status and balance when an app showing `Subscribe to Run` regains focus or becomes visible.
- Route through `useBillingContext`, so the active legacy or workspace billing adapter remains authoritative.
- Deduplicate overlapping `focus` and `visibilitychange` refreshes.
- Preserve the existing paused-payment portal recovery behavior.
- Do not add continuous polling: known new-billing checkouts retain BillingOp polling, while this is a bounded recovery trigger for changes outside that flow.

## Scope

This PR does **not** infer subscription state in the frontend and does not attempt to prevent or resolve duplicate Stripe subscriptions. Provider subscription integrity remains a backend responsibility; the frontend only re-reads the server-authored state.

## Testing

- `pnpm test:unit src/components/actionbar/ComfyRunButton/CloudRunButtonWrapper.test.ts` — 15 passed
- `pnpm typecheck` — passed
- changed-file ESLint, type-aware oxlint, and formatting checks — passed
- `pnpm knip` — blocked by two existing unused devDependencies on `main` (`@storybook/addon-mcp`, `lint-staged`); this PR does not change package or knip configuration

The component regression covers the observable AS IS → TO BE transition: stale `inactive`/Subscribe state, app focus, authoritative refresh, and restored Run button. No visual styling changes.

Linear: FE-1540