### PR TITLE
ci(pr-risk): grant checks: write ahead of the next grader pin bump

### DIFF
--- a/.github/workflows/ci-pr-risk.yml
+++ b/.github/workflows/ci-pr-risk.yml
@@ -43,12 +43,17 @@ jobs:
       contents: read # the .github/risk.json override, read from the BASE ref
       issues: write # create the risk:* labels repo-side on first use
       pull-requests: write # the label write rides pull-requests, not issues
-      checks: read # the check rollup the reversibility axis reads
+      # write, not read: newer upstream pins declare `checks: write` on their
+      # opt-in publish-check job, and GitHub validates every nested job's
+      # declaration against this block at startup — even jobs an `if:` skips.
+      # A read grant startup-fails every run the moment the pin moves forward.
+      checks: write # the rollup read + the opt-in Check Run publish
       actions: read # CheckRun -> checkSuite -> workflowRun for self-exclusion
       statuses: read
     # Pinned to github-workflows main (e4a8f7c); keep workflows_ref in
     # lock-step so the grader + risk map schema load from the same commit.
-    # This permissions block must stay a superset of the reusable job's.
+    # This permissions block must stay a superset of the UNION of every job
+    # the reusable workflow declares, including jobs whose `if:` skips them.
     uses: Comfy-Org/github-workflows/.github/workflows/pr-risk.yml@e4a8f7cd4a073da082b03950136530d4df50738f # github-workflows main (e4a8f7c)
     with:
       workflows_ref: e4a8f7cd4a073da082b03950136530d4df50738f


### PR DESCRIPTION
## ELI5
The PR risk grader borrows this repo's keycard when it runs, and newer versions of the grader come with a (normally dormant) task that needs one extra door on that card. GitHub inspects the whole keycard at the front door — before anything runs — so a card missing that permission gets the entire run turned away silently: no red check, no label, just nothing. This grants the permission now, while it's a harmless no-op, so the next grader version bump can't silently kill grading.

## Motivation
Newer pins of the shared [Comfy-Org/github-workflows `pr-risk.yml`](https://github.com/Comfy-Org/github-workflows/blob/main/.github/workflows/pr-risk.yml) (from `7f7c9bf` on) added an opt-in `publish-check` job that declares `checks: write`. GitHub validates the declared permissions of every job in a called reusable workflow against the caller's grant at startup — including jobs whose `if:` skips them — so a caller granting only `checks: read` startup-fails every run the moment its pin moves forward. Startup failures register no check on the PR, which makes the breakage invisible. Another enrolled repo in this org hit exactly that on its pin bump: every grading run failed silently for nine days before anyone noticed. This repo's caller still grants `checks: read` on the pre-`publish-check` pin `e4a8f7c`, so it is one routine pin bump away from the same failure. The upstream header's caller contract now says to grant `checks: write` regardless of whether Check Run publishing is opted in.

## Provenance
- **Authored by:** interactive session
- **Verified:** `actionlint .github/workflows/ci-pr-risk.yml`: pass. At the current pin the widened grant is validated but unused — the grader's `grade` job declares and receives `checks: read`, and `e4a8f7c` has no `publish-check` job — so grading behavior is unchanged.

## Reviewer context
- **Type:** CI hygiene — two-line preventive permission grant in the risk-grader caller, plus comment corrections
- **Slots into:** the org-wide advisory PR risk shadow check (label-only; nothing gates on it)
- **Not in scope:** the pin bump itself — this PR deliberately keeps `e4a8f7c` so the diff is a pure permissions change; the bump can then land as a pure pin move

## Summary
- Grant `checks: write` (was `checks: read`) in the `pr-risk` job's permissions block. A caller may grant more than the called workflow uses (the call only narrows the token), so this is a no-op at the current pin and becomes load-bearing on the next bump.
- Correct the adjacent comment: the caller block must cover the union of every nested job's declaration, not just the running job's.

## Test plan
- [ ] This PR's own `CI - PR Risk Grade` check completes and syncs one `risk:*` label (no behavior change at the current pin)
- [ ] The next `pr-risk` pin bump PR needs no permissions edit to keep grading alive
