### PR TITLE
feat(website): add Comfy SDK CTA to the /api page

### DIFF
--- a/apps/website/e2e/api.spec.ts
+++ b/apps/website/e2e/api.spec.ts
@@ -1,0 +1,31 @@
+import { expect } from '@playwright/test'
+
+import { test } from './fixtures/blockExternalMedia'
+
+const SDK_DOCS = 'https://docs.comfy.org/development/api-development/sdks'
+
+test.describe('API page @smoke', () => {
+  test('SDK CTAs link to the SDK docs from the integration card and the steps row', async ({
+    page
+  }) => {
+    await page.goto('/api')
+
+    const sdkLinks = page.getByRole('link', { name: 'TRY THE COMFY SDK' })
+    await expect(sdkLinks).toHaveCount(2)
+    for (const link of await sdkLinks.all()) {
+      await expect(link).toHaveAttribute('href', SDK_DOCS)
+    }
+  })
+
+  test('localized SDK CTAs are translated and keep the same docs target', async ({
+    page
+  }) => {
+    await page.goto('/zh-CN/api')
+
+    const sdkLinks = page.getByRole('link', { name: '试用 Comfy SDK' })
+    await expect(sdkLinks).toHaveCount(2)
+    for (const link of await sdkLinks.all()) {
+      await expect(link).toHaveAttribute('href', SDK_DOCS)
+    }
+  })
+})

--- a/apps/website/e2e/api.spec.ts
+++ b/apps/website/e2e/api.spec.ts
@@ -1,31 +1,53 @@
+import type { Page } from '@playwright/test'
 import { expect } from '@playwright/test'
 
 import { test } from './fixtures/blockExternalMedia'
 
 const SDK_DOCS = 'https://docs.comfy.org/development/api-development/sdks'
 
-test.describe('API page @smoke', () => {
-  test('SDK CTAs link to the SDK docs from the integration card and the steps row', async ({
-    page
-  }) => {
-    await page.goto('/api')
+const locales = [
+  {
+    name: 'en',
+    path: '/api',
+    ctaLabel: 'TRY THE COMFY SDK',
+    integrationHeading: 'Integrate ComfyUI into the rest of your stack',
+    stepsHeading: 'Three steps to production'
+  },
+  {
+    name: 'zh-CN',
+    path: '/zh-CN/api',
+    ctaLabel: '试用 Comfy SDK',
+    integrationHeading: '将 ComfyUI 集成到你的技术栈中',
+    stepsHeading: '三步进入生产'
+  }
+] as const
 
-    const sdkLinks = page.getByRole('link', { name: 'TRY THE COMFY SDK' })
-    await expect(sdkLinks).toHaveCount(2)
-    for (const link of await sdkLinks.all()) {
-      await expect(link).toHaveAttribute('href', SDK_DOCS)
-    }
+function sectionWithHeading(page: Page, heading: string) {
+  return page
+    .locator('section')
+    .filter({ has: page.getByRole('heading', { name: heading }) })
+}
+
+for (const locale of locales) {
+  test.describe(`API page — ${locale.name} @smoke`, () => {
+    test('the integration card and the steps row each own one SDK CTA', async ({
+      page
+    }) => {
+      await page.goto(locale.path)
+
+      const integrationCta = sectionWithHeading(
+        page,
+        locale.integrationHeading
+      ).getByRole('link', { name: locale.ctaLabel })
+      const stepsCta = sectionWithHeading(page, locale.stepsHeading).getByRole(
+        'link',
+        { name: locale.ctaLabel }
+      )
+
+      await expect(integrationCta).toHaveCount(1)
+      await expect(stepsCta).toHaveCount(1)
+      await expect(integrationCta).toHaveAttribute('href', SDK_DOCS)
+      await expect(stepsCta).toHaveAttribute('href', SDK_DOCS)
+    })
   })
-
-  test('localized SDK CTAs are translated and keep the same docs target', async ({
-    page
-  }) => {
-    await page.goto('/zh-CN/api')
-
-    const sdkLinks = page.getByRole('link', { name: '试用 Comfy SDK' })
-    await expect(sdkLinks).toHaveCount(2)
-    for (const link of await sdkLinks.all()) {
-      await expect(link).toHaveAttribute('href', SDK_DOCS)
-    }
-  })
-})
+}

--- a/apps/website/src/components/product/api/AutomationSection.vue
+++ b/apps/website/src/components/product/api/AutomationSection.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import type { Locale } from '../../../i18n/translations'
 
+import { externalLinks } from '../../../config/routes'
 import { t } from '../../../i18n/translations'
 import FeatureShowcaseSection from '../shared/FeatureShowcaseSection.vue'
 
@@ -22,7 +23,9 @@ const features = [
   {
     title: t('api.automation.feature3.title', locale),
     description: t('api.automation.feature3.description', locale),
-    image: 'https://media.comfy.org/website/api/precision-tools.webp'
+    image: 'https://media.comfy.org/website/api/precision-tools.webp',
+    ctaText: t('api.sdk.cta', locale),
+    ctaHref: externalLinks.docsSdks
   }
 ]
 </script>

--- a/apps/website/src/components/product/api/StepsSection.vue
+++ b/apps/website/src/components/product/api/StepsSection.vue
@@ -35,7 +35,7 @@ const steps = [
     <div
       v-for="step in steps"
       :key="step.number"
-      class="bg-primary-comfy-ink flex flex-col justify-between rounded-3xl border border-white/10"
+      class="flex flex-col justify-between rounded-3xl border border-white/10 bg-primary-comfy-ink"
     >
       <img
         :src="step.image"
@@ -46,7 +46,7 @@ const steps = [
         <p class="text-primary-comfy-yellow text-sm font-bold tracking-wider">
           {{ step.number }}
         </p>
-        <h3 class="text-primary-comfy-canvas mt-2 text-3xl font-medium">
+        <h3 class="mt-2 text-3xl font-medium text-primary-comfy-canvas">
           {{ t(step.titleKey, locale) }}
         </h3>
         <p class="mt-3 text-sm text-smoke-700">
@@ -67,6 +67,14 @@ const steps = [
           class="w-full text-center lg:w-auto lg:min-w-48"
         >
           {{ t('api.hero.getApiKeys', locale) }}
+        </BrandButton>
+        <BrandButton
+          :href="externalLinks.docsSdks"
+          variant="outline"
+          size="lg"
+          class="w-full text-center lg:w-auto lg:min-w-48"
+        >
+          {{ t('api.sdk.cta', locale) }}
         </BrandButton>
         <BrandButton
           :href="externalLinks.docsApi"

--- a/apps/website/src/config/routes.ts
+++ b/apps/website/src/config/routes.ts
@@ -96,6 +96,7 @@ export const externalLinks = {
   docs: 'https://docs.comfy.org/',
   docsApi: 'https://docs.comfy.org/development/cloud/overview#quick-start',
   docsMcp: 'https://docs.comfy.org/agent-tools/cloud',
+  docsSdks: 'https://docs.comfy.org/development/api-development/sdks',
   docsSubscription: 'https://docs.comfy.org/support/subscription/subscribing',
   g2ComfyUi: 'https://www.g2.com/products/comfyui',
   github: 'https://github.com/Comfy-Org/ComfyUI',

--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -593,6 +593,10 @@ const translations = {
     en: 'Track progress in real time over WebSocket. Download the finished output when the job completes.',
     'zh-CN': '通过 WebSocket 实时跟踪进度。作业完成后下载最终输出。'
   },
+  'api.sdk.cta': {
+    en: 'TRY THE COMFY SDK',
+    'zh-CN': '试用 Comfy SDK'
+  },
 
   // API – AutomationSection
   'api.automation.heading': {


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

Adds a discoverable "Try the Comfy SDK" CTA to `/api`, linking to https://docs.comfy.org/development/api-development/sdks. Requested in #website-updates.

## Placement

Two touchpoints at different scroll depths, no change to the hero's existing conversion hierarchy:

1. **"Integrate ComfyUI into the rest of your stack" feature card** (mid-page, `AutomationSection`) — inline solid CTA under the copy. This card already describes the exact SDK use case ("Fetch input from S3, call the ComfyUI API, post-process the result…"), so the button lands where the reader is already thinking about wiring ComfyUI into their own code. Uses `FeatureShowcaseSection`'s existing `ctaText`/`ctaHref` support, so no new UI pattern.
2. **"Three steps to production" action row** (`StepsSection`) — third button between `GET API KEYS` and `VIEW DOCS`, directly under step 02 "Submit via API". This is the page's dedicated action row and the natural "now go build it" moment.

The hero was deliberately left alone: a third `lg:min-w-60` button overflows the hero text column at 1440px, and it would dilute `GET API KEYS` as the primary CTA.

## Changes

- `config/routes.ts` — new `externalLinks.docsSdks`
- `i18n/translations.ts` — new `api.sdk.cta` key (en + zh-CN)
- `product/api/AutomationSection.vue` — inline CTA on feature 3
- `product/api/StepsSection.vue` — third button in the footer CTA row
- `e2e/api.spec.ts` — new smoke spec asserting both CTAs resolve to the SDK docs, in en and zh-CN

The two-line class-order change in `StepsSection.vue` on lines I didn't otherwise touch was applied automatically by the `lint-staged` ESLint hook (pre-existing `better-tailwindcss/enforce-consistent-class-order` violations).

## Verification

- `pnpm --filter @comfyorg/website typecheck` — 0 errors
- `pnpm --filter @comfyorg/website test:unit` — 401 passed
- `pnpm --filter @comfyorg/website build` — 593 pages built
- `pnpm exec playwright test --project=desktop` — 258 passed, 1 pre-existing flake (`download.spec.ts` FAQ accordion, passes in isolation, unrelated)
- Manually verified in the browser at 1440px and 390px, en and zh-CN


## Screenshots

![Placement 1 - inline TRY THE COMFY SDK CTA on the 'Integrate ComfyUI into the rest of your stack' feature card](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/6b3d2bfd04fbb0cf428bea61db2e81f2c8760689e6c257cdc05c461d5edec98a/pr-images/1786653583928-5bd7cc6e-665e-4e71-bf44-3dc6d765d066.png)

![Placement 2 - TRY THE COMFY SDK as the middle button in the 'Three steps to production' action row](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/6b3d2bfd04fbb0cf428bea61db2e81f2c8760689e6c257cdc05c461d5edec98a/pr-images/1786653584732-4071d174-9a2e-421a-b6a0-a1e90e2716ef.png)

![Mobile 390px - CTA row stacks full width, SDK button between GET API KEYS and VIEW DOCS](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/6b3d2bfd04fbb0cf428bea61db2e81f2c8760689e6c257cdc05c461d5edec98a/pr-images/1786653585045-d53b7623-280f-40cc-90b0-1f090220a613.png)

![zh-CN - localized label in the steps action row](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/6b3d2bfd04fbb0cf428bea61db2e81f2c8760689e6c257cdc05c461d5edec98a/pr-images/1786653585348-7b49fbdd-6652-4bf5-9cfc-c5f2c10ac3ca.png)