### PR TITLE
feat(settings): bring the V1 Plan & Credits tabs to local

### DIFF
--- a/src/components/dialog/content/setting/CreditsPanel.vue
+++ b/src/components/dialog/content/setting/CreditsPanel.vue
@@ -34,7 +34,8 @@
 
     <UsageLogsTable v-if="!embedded" ref="usageLogsTableRef" />
 
-    <div class="flex flex-row gap-2">
+    <SubscriptionFooterLinks v-if="embedded" :show-invoice-history="false" />
+    <div v-else class="flex flex-row gap-2">
       <Button variant="muted-textonly" @click="handleFaqClick">
         <i class="pi pi-question-circle" />
         {{ $t('credits.faqs') }}
@@ -57,6 +58,7 @@ import { ref, watch } from 'vue'
 
 import UsageLogsTable from '@/components/dialog/content/setting/UsageLogsTable.vue'
 import Button from '@/components/ui/button/Button.vue'
+import SubscriptionFooterLinks from '@/platform/cloud/subscription/components/SubscriptionFooterLinks.vue'
 import { useAuthActions } from '@/composables/auth/useAuthActions'
 import { useExternalLink } from '@/composables/useExternalLink'
 import CreditsTile from '@/platform/cloud/subscription/components/CreditsTile.vue'

--- a/src/components/dialog/content/setting/CreditsPanel.vue
+++ b/src/components/dialog/content/setting/CreditsPanel.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="credits-container flex h-full flex-col gap-4">
-    <div>
+    <div v-if="!embedded">
       <h2 class="mb-2 text-2xl font-bold">
         {{ $t('credits.credits') }}
       </h2>
@@ -9,7 +9,7 @@
 
     <CreditsTile />
 
-    <div class="flex items-center justify-between">
+    <div v-if="!embedded" class="flex items-center justify-between">
       <h3 class="m-0">{{ $t('credits.activity') }}</h3>
       <Button variant="muted-textonly" @click="handleCreditsHistoryClick">
         <i class="pi pi-arrow-up-right" />
@@ -17,9 +17,17 @@
       </Button>
     </div>
 
-    <UsageLogsTable ref="usageLogsTableRef" />
+    <UsageLogsTable v-if="!embedded" ref="usageLogsTableRef" />
 
     <div class="flex flex-row gap-2">
+      <Button
+        v-if="embedded"
+        variant="muted-textonly"
+        @click="handleCreditsHistoryClick"
+      >
+        <i class="pi pi-arrow-up-right" />
+        {{ $t('credits.invoiceHistory') }}
+      </Button>
       <Button variant="muted-textonly" @click="handleFaqClick">
         <i class="pi pi-question-circle" />
         {{ $t('credits.faqs') }}
@@ -48,6 +56,8 @@ import CreditsTile from '@/platform/cloud/subscription/components/CreditsTile.vu
 import { useTelemetry } from '@/platform/telemetry'
 import { useAuthStore } from '@/stores/authStore'
 import { useCommandStore } from '@/stores/commandStore'
+
+const { embedded = false } = defineProps<{ embedded?: boolean }>()
 
 const { buildDocsUrl, docsPaths } = useExternalLink()
 const authStore = useAuthStore()

--- a/src/components/dialog/content/setting/CreditsPanel.vue
+++ b/src/components/dialog/content/setting/CreditsPanel.vue
@@ -1,5 +1,12 @@
 <template>
-  <div class="credits-container flex h-full flex-col gap-4">
+  <div
+    :class="
+      cn(
+        'credits-container flex flex-col gap-4',
+        embedded ? 'min-h-0 flex-1 overflow-y-auto' : 'h-full'
+      )
+    "
+  >
     <div v-if="!embedded">
       <h2 class="mb-2 text-2xl font-bold">
         {{ $t('credits.credits') }}
@@ -34,7 +41,11 @@
 
     <UsageLogsTable v-if="!embedded" ref="usageLogsTableRef" />
 
-    <SubscriptionFooterLinks v-if="embedded" :show-invoice-history="false" />
+    <SubscriptionFooterLinks
+      v-if="embedded"
+      class="mt-auto"
+      :show-invoice-history="false"
+    />
     <div v-else class="flex flex-row gap-2">
       <Button variant="muted-textonly" @click="handleFaqClick">
         <i class="pi pi-question-circle" />
@@ -54,6 +65,7 @@
 
 <script setup lang="ts">
 import Divider from 'primevue/divider'
+import { cn } from '@comfyorg/tailwind-utils'
 import { ref, watch } from 'vue'
 
 import UsageLogsTable from '@/components/dialog/content/setting/UsageLogsTable.vue'

--- a/src/components/dialog/content/setting/CreditsPanel.vue
+++ b/src/components/dialog/content/setting/CreditsPanel.vue
@@ -7,7 +7,22 @@
       <Divider />
     </div>
 
-    <CreditsTile />
+    <div v-if="embedded" class="rounded-2xl border border-interface-stroke p-6">
+      <div class="mb-4 flex items-center justify-between">
+        <h3 class="m-0 text-base font-semibold">
+          {{ $t('credits.workspaceCredits') }}
+        </h3>
+        <Button
+          variant="secondary"
+          size="lg"
+          @click="handleCreditsHistoryClick"
+        >
+          {{ $t('subscription.manageBilling') }}
+        </Button>
+      </div>
+      <CreditsTile class="max-w-md" />
+    </div>
+    <CreditsTile v-else />
 
     <div v-if="!embedded" class="flex items-center justify-between">
       <h3 class="m-0">{{ $t('credits.activity') }}</h3>
@@ -20,14 +35,6 @@
     <UsageLogsTable v-if="!embedded" ref="usageLogsTableRef" />
 
     <div class="flex flex-row gap-2">
-      <Button
-        v-if="embedded"
-        variant="muted-textonly"
-        @click="handleCreditsHistoryClick"
-      >
-        <i class="pi pi-arrow-up-right" />
-        {{ $t('credits.invoiceHistory') }}
-      </Button>
       <Button variant="muted-textonly" @click="handleFaqClick">
         <i class="pi pi-question-circle" />
         {{ $t('credits.faqs') }}

--- a/src/components/dialog/content/setting/UsageLogsTable.vue
+++ b/src/components/dialog/content/setting/UsageLogsTable.vue
@@ -1,5 +1,8 @@
 <template>
-  <div>
+  <div
+    ref="rootContainer"
+    :class="cn(fitContainer && 'min-h-0 flex-1 overflow-y-auto')"
+  >
     <div v-if="loading" class="flex items-center justify-center p-8">
       <ProgressSpinner />
     </div>
@@ -102,12 +105,16 @@ import { useI18n } from 'vue-i18n'
 import Button from '@/components/ui/button/Button.vue'
 import { useBillingRouting } from '@/composables/billing/useBillingRouting'
 import { useTelemetry } from '@/platform/telemetry'
+import { useAutoPageSize } from '@/platform/workspace/composables/useAutoPageSize'
 import { workspaceApi } from '@/platform/workspace/api/workspaceApi'
 import type { AuditLog } from '@/services/customerEventsService'
 import {
   EventType,
   useCustomerEventsService
 } from '@/services/customerEventsService'
+import { cn } from '@comfyorg/tailwind-utils'
+
+const { fitContainer = false } = defineProps<{ fitContainer?: boolean }>()
 
 const { t } = useI18n()
 
@@ -214,6 +221,23 @@ const refresh = async () => {
 
 watch(shouldUseWorkspaceBilling, () => {
   refresh().catch((error) => {
+    console.error('Error loading events:', error)
+  })
+})
+
+const rootContainer = ref<HTMLElement | null>(null)
+const { pageSize } = useAutoPageSize(
+  rootContainer,
+  7,
+  (container) =>
+    container.querySelector('.p-paginator')?.getBoundingClientRect().height ??
+    56
+)
+watch(pageSize, (size) => {
+  if (!fitContainer || size === pagination.value.limit) return
+  pagination.value.limit = size
+  pagination.value.page = 1
+  loadEvents().catch((error) => {
     console.error('Error loading events:', error)
   })
 })

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2625,6 +2625,7 @@
   },
   "credits": {
     "activity": "Activity",
+    "workspaceCredits": "Workspace credits",
     "insufficient": {
       "memberTitle": "This workspace is out of credits",
       "memberDescription": "Your team has used all its credits. Your workspace admins need to add more credits to run workflows.",

--- a/src/platform/cloud/subscription/components/SubscriptionFooterLinks.vue
+++ b/src/platform/cloud/subscription/components/SubscriptionFooterLinks.vue
@@ -1,7 +1,5 @@
 <template>
-  <div
-    class="flex items-center justify-between border-t border-interface-stroke pt-3"
-  >
+  <div class="flex items-center justify-between pt-3">
     <div class="flex gap-2">
       <Button
         variant="muted-textonly"

--- a/src/platform/settings/composables/useSettingUI.ts
+++ b/src/platform/settings/composables/useSettingUI.ts
@@ -31,6 +31,7 @@ const CATEGORY_ICONS: Record<string, string> = {
   'Mask Editor': 'icon-[lucide--pen-tool]',
   Members: 'icon-[lucide--users]',
   Other: 'icon-[lucide--ellipsis]',
+  'plan-credits': 'icon-[lucide--coins]',
   PlanCredits: 'icon-[lucide--receipt-text]',
   secrets: 'icon-[lucide--key-round]',
   'server-config': 'icon-[lucide--server]',
@@ -182,7 +183,7 @@ export function useSettingUI(
   const localPlanCreditsPanel: SettingPanelItem = {
     node: {
       key: 'plan-credits',
-      label: 'PlanCredits',
+      label: 'Credits',
       children: []
     },
     component: defineAsyncComponent(

--- a/src/platform/settings/composables/useSettingUI.ts
+++ b/src/platform/settings/composables/useSettingUI.ts
@@ -188,7 +188,8 @@ export function useSettingUI(
     component: defineAsyncComponent(
       () =>
         import('@/platform/workspace/components/dialogs/settings/PlanCreditsPanelContent.vue')
-    )
+    ),
+    props: { class: 'size-full' }
   }
 
   const membersPanel: SettingPanelItem = {

--- a/src/platform/settings/composables/useSettingUI.ts
+++ b/src/platform/settings/composables/useSettingUI.ts
@@ -177,6 +177,20 @@ export function useSettingUI(
     props: { section: 'planCredits' }
   }
 
+  // Local has no workspace context, so it mounts the Plan & Credits tab shell
+  // directly instead of the workspace-header wrapper the cloud entry uses.
+  const localPlanCreditsPanel: SettingPanelItem = {
+    node: {
+      key: 'plan-credits',
+      label: 'PlanCredits',
+      children: []
+    },
+    component: defineAsyncComponent(
+      () =>
+        import('@/platform/workspace/components/dialogs/settings/PlanCreditsPanelContent.vue')
+    )
+  }
+
   const membersPanel: SettingPanelItem = {
     node: {
       key: 'workspace-members',
@@ -273,6 +287,7 @@ export function useSettingUI(
       creditsPanel,
       userPanel,
       ...visibleWorkspacePanels.value,
+      ...(!isCloud && isLoggedIn.value ? [localPlanCreditsPanel] : []),
       keybindingPanel,
       extensionPanel,
       ...(isDesktop ? [serverConfigPanel] : []),
@@ -367,10 +382,7 @@ export function useSettingUI(
       children: [
         userPanel.node,
         ...(shouldShowSecretsPanel.value ? [secretsPanel.node] : []),
-        ...(isLoggedIn.value &&
-        !(isCloud && window.__CONFIG__?.subscription_required)
-          ? [creditsPanel.node]
-          : [])
+        ...(isLoggedIn.value ? [localPlanCreditsPanel.node] : [])
       ].map(translateCategory)
     },
     // Normal settings stored in the settingStore

--- a/src/platform/settings/composables/useSettingUI.ts
+++ b/src/platform/settings/composables/useSettingUI.ts
@@ -327,24 +327,9 @@ export function useSettingUI(
     )
   })
 
-  // Cloud workspace sidebar structure
-  const workspaceMenuTreeNodes = computed<SettingTreeNode[]>(() => [
-    // Workspace settings
-    translateCategory({
-      key: 'workspace',
-      label: 'Workspace',
-      children: [
-        ...visibleWorkspacePanels.value.map((panel) => panel.node),
-        // The legacy per-account Credits panel is redundant once the workspace
-        // Plan & Credits panel is present, which now owns the credit balance.
-        ...(!billingControlsEnabled.value &&
-        isLoggedIn.value &&
-        !(isCloud && window.__CONFIG__?.subscription_required)
-          ? [creditsPanel.node]
-          : [])
-      ].map(translateCategory)
-    }),
-    // General settings - Profile + all core settings + special panels
+  // Shared groups — both distributions render the same grammar:
+  // Workspace / General / Other. Only the Workspace entries differ.
+  const generalMenuGroup = computed<SettingTreeNode>(() =>
     translateCategory({
       key: 'general',
       label: 'General',
@@ -360,9 +345,11 @@ export function useSettingUI(
         translateCategory(aboutPanel.node),
         ...(isDesktop ? [translateCategory(serverConfigPanel.node)] : [])
       ]
-    }),
-    // Custom node settings (only shown if custom nodes have registered settings)
-    ...(customNodeSettingCategories.value.length > 0
+    })
+  )
+
+  const otherMenuGroups = computed<SettingTreeNode[]>(() =>
+    customNodeSettingCategories.value.length > 0
       ? [
           translateCategory({
             key: 'other',
@@ -370,38 +357,40 @@ export function useSettingUI(
             children: customNodeSettingCategories.value.map(translateCategory)
           })
         ]
-      : [])
+      : []
+  )
+
+  const workspaceMenuTreeNodes = computed<SettingTreeNode[]>(() => [
+    translateCategory({
+      key: 'workspace',
+      label: 'Workspace',
+      children: [
+        ...visibleWorkspacePanels.value.map((panel) => panel.node),
+        // The legacy per-account Credits panel is redundant once the workspace
+        // Plan & Credits panel is present, which now owns the credit balance.
+        ...(!billingControlsEnabled.value &&
+        isLoggedIn.value &&
+        !(isCloud && window.__CONFIG__?.subscription_required)
+          ? [creditsPanel.node]
+          : [])
+      ].map(translateCategory)
+    }),
+    generalMenuGroup.value,
+    ...otherMenuGroups.value
   ])
 
-  // OSS legacy sidebar structure
   const legacyMenuTreeNodes = computed<SettingTreeNode[]>(() => [
-    // Account settings - show different panels based on distribution and auth state
-    {
-      key: 'account',
-      label: 'Account',
-      children: [
-        userPanel.node,
-        ...(shouldShowSecretsPanel.value ? [secretsPanel.node] : []),
-        ...(isLoggedIn.value ? [localPlanCreditsPanel.node] : [])
-      ].map(translateCategory)
-    },
-    // Normal settings stored in the settingStore
-    {
-      key: 'settings',
-      label: 'Application Settings',
-      children: settingCategories.value.map(translateCategory)
-    },
-    // Special settings such as about, keybinding, extension, server-config
-    {
-      key: 'specialSettings',
-      label: 'Special Settings',
-      children: [
-        keybindingPanel.node,
-        extensionPanel.node,
-        aboutPanel.node,
-        ...(isDesktop ? [serverConfigPanel.node] : [])
-      ].map(translateCategory)
-    }
+    ...(isLoggedIn.value
+      ? [
+          translateCategory({
+            key: 'workspace',
+            label: 'Workspace',
+            children: [localPlanCreditsPanel.node].map(translateCategory)
+          })
+        ]
+      : []),
+    generalMenuGroup.value,
+    ...otherMenuGroups.value
   ])
 
   const groupedMenuTreeNodes = computed<SettingTreeNode[]>(() =>

--- a/src/platform/workspace/components/dialogs/settings/PlanCreditsPanelContent.test.ts
+++ b/src/platform/workspace/components/dialogs/settings/PlanCreditsPanelContent.test.ts
@@ -8,11 +8,22 @@ import enMessages from '@/locales/en/main.json'
 
 import PlanCreditsPanelContent from './PlanCreditsPanelContent.vue'
 
+const mockDistribution = vi.hoisted(() => ({ cloud: true }))
+vi.mock('@/platform/distribution/types', () => ({
+  get isCloud() {
+    return mockDistribution.cloud
+  }
+}))
+
 const refreshSpy = vi.fn()
 
 const stubs = {
   SubscriptionPanelContentWorkspace: {
-    template: '<div data-testid="credits-body" />'
+    template: '<div data-testid="workspace-credits-body" />'
+  },
+  CreditsPanel: {
+    props: ['embedded'],
+    template: '<div data-testid="legacy-credits-body" />'
   },
   UsageLogsTable: {
     template: '<div data-testid="usage-logs" />',
@@ -22,7 +33,8 @@ const stubs = {
   }
 }
 
-function renderPanel() {
+function renderPanel({ cloud = true } = {}) {
+  mockDistribution.cloud = cloud
   const i18n = createI18n({
     legacy: false,
     locale: 'en',
@@ -32,12 +44,18 @@ function renderPanel() {
 }
 
 describe('PlanCreditsPanelContent', () => {
-  it('shows Credits and Activity tabs with Credits active by default', () => {
+  it('shows Credits and Activity tabs with the workspace overview by default on cloud', () => {
     renderPanel()
     expect(screen.getByRole('button', { name: 'Credits' })).toBeTruthy()
     expect(screen.getByRole('button', { name: 'Activity' })).toBeTruthy()
-    expect(screen.getByTestId('credits-body')).toBeTruthy()
+    expect(screen.getByTestId('workspace-credits-body')).toBeTruthy()
     expect(screen.queryByTestId('usage-logs')).toBeNull()
+  })
+
+  it('shows the embedded legacy credits body on local', () => {
+    renderPanel({ cloud: false })
+    expect(screen.getByTestId('legacy-credits-body')).toBeTruthy()
+    expect(screen.queryByTestId('workspace-credits-body')).toBeNull()
   })
 
   it('shows the usage-log table on the Activity tab and loads it', async () => {
@@ -45,7 +63,7 @@ describe('PlanCreditsPanelContent', () => {
     renderPanel()
     await userEvent.click(screen.getByRole('button', { name: 'Activity' }))
     expect(screen.getByTestId('usage-logs')).toBeTruthy()
-    expect(screen.queryByTestId('credits-body')).toBeNull()
+    expect(screen.queryByTestId('workspace-credits-body')).toBeNull()
     await waitFor(() => expect(refreshSpy).toHaveBeenCalledTimes(1))
   })
 

--- a/src/platform/workspace/components/dialogs/settings/PlanCreditsPanelContent.vue
+++ b/src/platform/workspace/components/dialogs/settings/PlanCreditsPanelContent.vue
@@ -20,7 +20,19 @@
       <SubscriptionPanelContentWorkspace v-if="isCloud" />
       <CreditsPanel v-else embedded />
     </template>
-    <UsageLogsTable v-else ref="usageLogsTable" />
+    <template v-else>
+      <UsageLogsTable ref="usageLogsTable" fit-container />
+      <div class="flex items-center pt-3">
+        <Button
+          variant="muted-textonly"
+          class="text-xs text-text-secondary"
+          @click="openFullActivity"
+        >
+          {{ $t('workspacePanel.activity.fullActivity') }}
+          <i class="pi pi-external-link text-xs text-text-secondary" />
+        </Button>
+      </div>
+    </template>
   </div>
 </template>
 
@@ -31,6 +43,7 @@ import { useI18n } from 'vue-i18n'
 import CreditsPanel from '@/components/dialog/content/setting/CreditsPanel.vue'
 import UsageLogsTable from '@/components/dialog/content/setting/UsageLogsTable.vue'
 import Button from '@/components/ui/button/Button.vue'
+import { getComfyPlatformBaseUrl } from '@/config/comfyApi'
 import { isCloud } from '@/platform/distribution/types'
 import SubscriptionPanelContentWorkspace from '@/platform/workspace/components/SubscriptionPanelContentWorkspace.vue'
 
@@ -49,6 +62,12 @@ const tabs = computed<{ key: View; label: string }[]>(() => [
 ])
 
 const activeView = ref<View>('overview')
+
+const fullActivityUrl = `${getComfyPlatformBaseUrl()}/profile/usage`
+
+function openFullActivity() {
+  window.open(fullActivityUrl, '_blank', 'noopener,noreferrer')
+}
 
 const usageLogsTable = useTemplateRef('usageLogsTable')
 watch(usageLogsTable, (table) => {

--- a/src/platform/workspace/components/dialogs/settings/PlanCreditsPanelContent.vue
+++ b/src/platform/workspace/components/dialogs/settings/PlanCreditsPanelContent.vue
@@ -16,7 +16,10 @@
       </div>
     </div>
 
-    <SubscriptionPanelContentWorkspace v-if="activeView === 'overview'" />
+    <template v-if="activeView === 'overview'">
+      <SubscriptionPanelContentWorkspace v-if="isCloud" />
+      <CreditsPanel v-else embedded />
+    </template>
     <UsageLogsTable v-else ref="usageLogsTable" />
   </div>
 </template>
@@ -25,8 +28,10 @@
 import { computed, ref, useTemplateRef, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 
+import CreditsPanel from '@/components/dialog/content/setting/CreditsPanel.vue'
 import UsageLogsTable from '@/components/dialog/content/setting/UsageLogsTable.vue'
 import Button from '@/components/ui/button/Button.vue'
+import { isCloud } from '@/platform/distribution/types'
 import SubscriptionPanelContentWorkspace from '@/platform/workspace/components/SubscriptionPanelContentWorkspace.vue'
 
 type View = 'overview' | 'activity'

--- a/src/platform/workspace/composables/useAutoPageSize.ts
+++ b/src/platform/workspace/composables/useAutoPageSize.ts
@@ -11,7 +11,8 @@ const MIN_ROWS = 5
  */
 export function useAutoPageSize(
   containerRef: Ref<HTMLElement | null>,
-  min: number = MIN_ROWS
+  min: number = MIN_ROWS,
+  reserved: (container: HTMLElement) => number = () => 0
 ) {
   const pageSize = ref(min)
 
@@ -28,7 +29,9 @@ export function useAutoPageSize(
     const headerHeight =
       container.querySelector<HTMLElement>('thead')?.getBoundingClientRect()
         .height ?? 0
-    const fit = Math.floor((container.clientHeight - headerHeight) / rowHeight)
+    const fit = Math.floor(
+      (container.clientHeight - headerHeight - reserved(container)) / rowHeight
+    )
     pageSize.value = Math.max(min, fit)
   }
 


### PR DESCRIPTION
Stacked on #15206. Brings the V1 Plan & Credits tab organization to local and converges the settings sidebar grammar, as part of the local/cloud UI consolidation. Follow-ups tracked as FE-1619 (post-switcher: header, Members, workspace overview, state-dependent label) and FE-1618 (credits-tile no-plan state).

**1. Local gets the shared tab shell.** The sidebar entry "Credits" (coins icon; "Plan & Credits" arrives with real plan state, FE-1619) mounts the shared `PlanCreditsPanelContent`:
- **Credits tab (local)**: the legacy credits body wrapped in the designed "Workspace credits" card with a Manage billing button (legacy portal). `CreditsPanel` gains an `embedded` prop; the workspace plan card is not used off-cloud — it renders misleading data against the legacy balance shape.
- **Activity tab (local)**: the same `UsageLogsTable` (`useBillingRouting` returns `legacy` off-cloud → `/customers/events`), plus a "Full activity ↗" footer button to platform.comfy.org/profile/usage.
- The table sizes rows-per-page to the dialog via `useAutoPageSize`, extended with a reserved-height hook because this table's paginator sits inside the measured container. Approximate with mixed row heights; opening the tab issues two fetches (initial + fitted size), deduped by the existing load token.

**2. One sidebar grammar.** Local's ACCOUNT / APPLICATION SETTINGS / SPECIAL SETTINGS groups are replaced with cloud's Workspace / General / Other; the General and Other groups are now shared computeds consumed by both trees (User under General on both platforms, custom-node settings under Other, desktop Server Config at the end of General). Billing belongs to the workspace on the backend, so the group is named Workspace; it becomes navigable with #15164.

**3. Footers unified.** Both tabs end in `SubscriptionFooterLinks`; the embedded credits body drops its bespoke FAQs row. **Note for reviewers: the footer's top divider is removed globally (design call), so the cloud subscription overview loses the line too — intentional, not incidental.**

Cloud behavior is otherwise unchanged (the Credits tab body forks on `isCloud`; flag-off is untouched). Coordination: #14811/#14813 and #15151 touch the same panel/rail seams — merge order decides who rebases.

- Verified: unit tests covering the tab fork per distribution; typecheck + lint via hooks; mocked-boot Playwright rigs in OSS and cloud modes; live passes on testcloud (`?ff=billing_control_enabled`) and local (OSS backend) by @comfydesigner.
