### PR TITLE
fix: replace script type suppressions

### DIFF
--- a/scripts/collect-i18n-general.ts
+++ b/scripts/collect-i18n-general.ts
@@ -12,12 +12,27 @@ import {
 } from '@comfyorg/shared-frontend-utils/formatUtil'
 import { CORE_MENU_COMMANDS } from '../src/constants/coreMenuCommands'
 import { SERVER_CONFIG_ITEMS } from '../src/constants/serverConfig'
-import type { SettingParams } from '../src/platform/settings/types'
-import type { ComfyCommandImpl } from '../src/stores/commandStore'
 
 const localePath = './src/locales/en/main.json'
 const commandsPath = './src/locales/en/commands.json'
 const settingsPath = './src/locales/en/settings.json'
+
+function getSettingOptionLabels(options: unknown): string[] | undefined {
+  if (!Array.isArray(options)) return undefined
+
+  return options.flatMap((option: unknown) => {
+    if (typeof option === 'string') return option
+    if (
+      typeof option === 'object' &&
+      option !== null &&
+      'text' in option &&
+      typeof option.text === 'string'
+    ) {
+      return option.text
+    }
+    return []
+  })
+}
 
 const extractMenuCommandLocaleStrings = (): Set<string> => {
   const labels = new Set<string>()
@@ -30,15 +45,23 @@ const extractMenuCommandLocaleStrings = (): Set<string> => {
 test('collect-i18n-general', async ({ comfyPage }) => {
   const commands = (
     await comfyPage.page.evaluate(() => {
-      // @ts-expect-error - app is dynamically added to window
-      const workspace = window['app'].extensionManager
-      const commands = workspace.command.commands as ComfyCommandImpl[]
-      return commands.map((command) => ({
-        id: command.id,
-        label: command.label,
-        menubarLabel: command.menubarLabel,
-        tooltip: command.tooltip
-      }))
+      const app = window.app
+      if (!app) throw new Error('ComfyUI app is not initialized')
+
+      return app.extensionManager.command.commands.map((command) => {
+        const label =
+          typeof command.label === 'function' ? command.label() : command.label
+        const menubarLabel =
+          typeof command.menubarLabel === 'function'
+            ? command.menubarLabel()
+            : command.menubarLabel
+        const tooltip =
+          typeof command.tooltip === 'function'
+            ? command.tooltip()
+            : command.tooltip
+
+        return { id: command.id, label, menubarLabel, tooltip }
+      })
     })
   ).sort((a, b) => a.id.localeCompare(b.id))
 
@@ -67,49 +90,48 @@ test('collect-i18n-general', async ({ comfyPage }) => {
   )
 
   // Settings
-  const settings = await comfyPage.page.evaluate(() => {
-    // @ts-expect-error - app is dynamically added to window
-    const workspace = window['app'].extensionManager
-    // @ts-expect-error - settings is not on the public setting store type
-    const settings = workspace.setting.settings as Record<string, SettingParams>
-    return Object.values(settings)
+  const settings = await comfyPage.page.evaluate(async () => {
+    const { useSettingStore } =
+      await import('../src/platform/settings/settingStore')
+    return Object.values(useSettingStore().settingsById)
       .sort((a, b) => a.id.localeCompare(b.id))
       .filter((setting) => setting.type !== 'hidden')
-      .map((setting) => ({
-        id: setting.id,
-        name: setting.name,
-        tooltip: setting.tooltip,
-        category: setting.category,
-        options:
-          typeof setting.options === 'function'
-            ? // @ts-expect-error: Audit and deprecate usage of legacy options type:
-              // (value) => [string | {text: string, value: string}]
-              setting.options(setting.defaultValue ?? '')
-            : setting.options
-      }))
+      .map((setting) => {
+        const options: unknown = Reflect.get(setting, 'options')
+        const resolvedOptions: unknown =
+          typeof options === 'function'
+            ? Reflect.apply(options, undefined, [setting.defaultValue ?? ''])
+            : options
+
+        return {
+          id: setting.id,
+          name: setting.name,
+          tooltip: setting.tooltip,
+          category: setting.category,
+          options: resolvedOptions
+        }
+      })
   })
 
   const allSettingsLocale = Object.fromEntries(
-    settings.map((setting) => [
-      normalizeI18nKey(setting.id),
-      {
-        name: setting.name,
-        tooltip: setting.tooltip,
-        // Don't translate the locale options as each option is in its own language.
-        // e.g. "English", "中文", "Русский", "日本語", "한국어"
-        options:
-          setting.options && setting.id !== 'Comfy.Locale'
-            ? Object.fromEntries(
-                // @ts-expect-error - option is untyped in SettingParams
-                setting.options.map((option) => {
-                  const optionLabel =
-                    typeof option === 'string' ? option : option.text
-                  return [normalizeI18nKey(optionLabel), optionLabel]
-                })
-              )
-            : undefined
-      }
-    ])
+    settings.map((setting) => {
+      const optionLabels = getSettingOptionLabels(setting.options)
+      return [
+        normalizeI18nKey(setting.id),
+        {
+          name: setting.name,
+          tooltip: setting.tooltip,
+          // Don't translate the locale options as each option is in its own language.
+          // e.g. "English", "中文", "Русский", "日本語", "한국어"
+          options:
+            optionLabels && setting.id !== 'Comfy.Locale'
+              ? Object.fromEntries(
+                  optionLabels.map((label) => [normalizeI18nKey(label), label])
+                )
+              : undefined
+        }
+      ]
+    })
   )
 
   const allSettingCategoriesLocale = Object.fromEntries(
@@ -145,9 +167,8 @@ test('collect-i18n-general', async ({ comfyPage }) => {
 
   // Desktop Dialogs
   const allDesktopDialogsLocale = Object.fromEntries(
-    Object.values(DESKTOP_DIALOGS).map((dialog) => [
-      // @ts-expect-error - not every DESKTOP_DIALOGS entry declares an id
-      normalizeI18nKey(dialog.id),
+    Object.entries(DESKTOP_DIALOGS).map(([id, dialog]) => [
+      normalizeI18nKey(id),
       {
         title: dialog.title,
         message: dialog.message,

--- a/scripts/collect-i18n-general.ts
+++ b/scripts/collect-i18n-general.ts
@@ -98,9 +98,13 @@ test('collect-i18n-general', async ({ comfyPage }) => {
       .filter((setting) => setting.type !== 'hidden')
       .map((setting) => {
         const options: unknown = Reflect.get(setting, 'options')
+        const defaultValue =
+          typeof setting.defaultValue === 'function'
+            ? setting.defaultValue()
+            : setting.defaultValue
         const resolvedOptions: unknown =
           typeof options === 'function'
-            ? Reflect.apply(options, undefined, [setting.defaultValue ?? ''])
+            ? Reflect.apply(options, undefined, [defaultValue ?? ''])
             : options
 
         return {

--- a/scripts/collect-i18n-node-defs.ts
+++ b/scripts/collect-i18n-node-defs.ts
@@ -10,11 +10,6 @@ import { serializeNodeDefLocales } from './nodeDefLocaleSerializer'
 const localePath = './src/locales/en/main.json'
 const nodeDefsPath = './src/locales/en/nodeDefs.json'
 
-interface WidgetInfo {
-  name?: string
-  label?: string
-}
-
 test('collect-i18n-node-defs', async ({ comfyPage }) => {
   // Mock view route
   await comfyPage.page.route('**/view**', async (route) => {
@@ -27,9 +22,10 @@ test('collect-i18n-node-defs', async ({ comfyPage }) => {
 
   const nodeDefs: ComfyNodeDefImpl[] = await comfyPage.page.evaluate(
     async () => {
-      // @ts-expect-error - app is dynamically added to window
-      const api = window['app'].api
-      const rawNodeDefs = await api.getNodeDefs()
+      const app = window.app
+      if (!app) throw new Error('ComfyUI app is not initialized')
+
+      const rawNodeDefs = await app.api.getNodeDefs()
       const { ComfyNodeDefImpl } = await import('../src/stores/nodeDefStore')
 
       return (
@@ -45,30 +41,33 @@ test('collect-i18n-node-defs', async ({ comfyPage }) => {
     const nodeLabels: WidgetLabels = {}
 
     for (const nodeDef of nodeDefs) {
-      const inputNames = Object.values(nodeDef.inputs).map(
-        (input) => input.name
+      const inputNames = Object.values(nodeDef.inputs).flatMap(
+        (input): string[] =>
+          typeof input.name === 'string' ? [input.name] : input.name
       )
 
       if (!inputNames.length) continue
 
       try {
         const widgetsMappings = await comfyPage.page.evaluate(
-          (args) => {
-            const [nodeName, displayName, inputNames] = args
-            // @ts-expect-error - LiteGraph is dynamically added to window
-            const node = window['LiteGraph'].createNode(nodeName, displayName)
-            // @ts-expect-error - createNode is null for unregistered types
-            if (!node.widgets?.length) return {}
+          (args): Record<string, string | undefined> => {
+            const { nodeName, displayName, inputNames } = args
+            const liteGraph = window.LiteGraph
+            if (!liteGraph) throw new Error('LiteGraph is not initialized')
+
+            const node = liteGraph.createNode(nodeName, displayName)
+            if (!node?.widgets?.length) return {}
             return Object.fromEntries(
-              // @ts-expect-error - createNode is null for unregistered types
               node.widgets
-                .filter(
-                  (w: WidgetInfo) => w?.name && !inputNames.includes(w.name)
-                )
-                .map((w: WidgetInfo) => [w.name, w.label])
+                .filter((widget) => !inputNames.includes(widget.name))
+                .map((widget) => [widget.name, widget.label])
             )
           },
-          [nodeDef.name, nodeDef.display_name, inputNames]
+          {
+            nodeName: nodeDef.name,
+            displayName: nodeDef.display_name,
+            inputNames
+          }
         )
 
         const runtimeWidgets = Object.fromEntries(
@@ -78,7 +77,6 @@ test('collect-i18n-node-defs', async ({ comfyPage }) => {
         )
 
         if (Object.keys(runtimeWidgets).length > 0) {
-          // @ts-expect-error - evaluate() erases the widget label types
           nodeLabels[nodeDef.name] = runtimeWidgets
         }
       } catch (error) {

--- a/scripts/collect-i18n-node-defs.ts
+++ b/scripts/collect-i18n-node-defs.ts
@@ -59,7 +59,9 @@ test('collect-i18n-node-defs', async ({ comfyPage }) => {
             if (!node?.widgets?.length) return {}
             return Object.fromEntries(
               node.widgets
-                .filter((widget) => !inputNames.includes(widget.name))
+                .filter(
+                  (widget) => widget?.name && !inputNames.includes(widget.name)
+                )
                 .map((widget) => [widget.name, widget.label])
             )
           },

--- a/scripts/nodeDefLocaleSerializer.test.ts
+++ b/scripts/nodeDefLocaleSerializer.test.ts
@@ -49,26 +49,32 @@ describe('serializeNodeDefLocales', () => {
         }
       })
     const serializedNode = nodeDefinitions.Test_Node
+    if (
+      !serializedNode.inputs ||
+      !serializedNode.outputs ||
+      !serializedNode.description
+    ) {
+      throw new Error('Expected serialized node labels')
+    }
     const serializedInput =
-      // @ts-expect-error - serialized inputs are optional in the node type
       serializedNode.inputs['Input @ $ {value} | 50%{done}']
-    // @ts-expect-error - serialized outputs are optional in the node type
     const serializedOutput = serializedNode.outputs['0']
+    const serializedWidget = serializedNode.inputs.Runtime_Widget
+    if (
+      !serializedInput.name ||
+      !serializedOutput.name ||
+      !serializedWidget.name
+    ) {
+      throw new Error('Expected serialized field names')
+    }
 
     expect(render(serializedNode.display_name)).toBe(nodeDef.display_name)
-    // @ts-expect-error - description is string | undefined
     expect(render(serializedNode.description)).toBe(nodeDef.description)
-    // @ts-expect-error - name is string | undefined
     expect(render(serializedInput.name)).toBe(inputName)
-    // @ts-expect-error - name is string | undefined
     expect(render(serializedOutput.name)).toBe(outputName)
-    // @ts-expect-error - serialized inputs are optional in the node type
-    expect(render(serializedNode.inputs.Runtime_Widget.name)).toBe(
-      `Widget ${syntax}`
-    )
+    expect(render(serializedWidget.name)).toBe(`Widget ${syntax}`)
     expect(render(dataTypes[dataType])).toBe(dataType)
     expect(render(nodeCategories[category])).toBe(category)
-    // @ts-expect-error - tooltip is absent on the widget-only input variant
     expect(serializedInput.tooltip).toBe(nodeDef.inputs.input.tooltip)
     expect(serializedOutput.tooltip).toBe(nodeDef.outputs[0].tooltip)
   })

--- a/scripts/nodeDefLocaleSerializer.ts
+++ b/scripts/nodeDefLocaleSerializer.ts
@@ -21,6 +21,18 @@ interface LocalizableNodeDef {
   display_name?: string
 }
 
+interface SerializedLabel {
+  name?: string
+  tooltip?: string
+}
+
+interface SerializedNodeDef {
+  display_name: string
+  description?: string
+  inputs?: Record<string, SerializedLabel>
+  outputs?: Record<string, SerializedLabel>
+}
+
 export type WidgetLabels = Record<
   string,
   Record<string, { name: string | undefined }>
@@ -90,7 +102,7 @@ export function serializeNodeDefLocales(
     )
   }
 
-  const nodeDefinitions = Object.fromEntries(
+  const nodeDefinitions: Record<string, SerializedNodeDef> = Object.fromEntries(
     [...nodeDefs]
       .sort((a, b) => a.name.localeCompare(b.name))
       .map((nodeDef) => {

--- a/scripts/perf-report.ts
+++ b/scripts/perf-report.ts
@@ -90,9 +90,7 @@ const REPORTED_METRICS: MetricDef[] = [
   { key: 'eventListeners', label: 'event listeners', unit: '', minAbsDelta: 5 }
 ]
 
-/** Target: P5 FPS ≥ 52 → P95 frame time ≤ 19.2ms */
-// @ts-expect-error - unused, kept to document the frame-time target
-const TARGET_P95_FRAME_MS = 19.2
+/** Target: P5 FPS ≥ 52 */
 const TARGET_P5_FPS = 52
 
 function groupByName(

--- a/scripts/vite-define-shim.ts
+++ b/scripts/vite-define-shim.ts
@@ -31,8 +31,7 @@ globalWithDefines.__IS_NIGHTLY__ = false
 // Provide a minimal window shim for Node environment
 // This is needed for code that checks window existence during imports
 if (typeof window === 'undefined') {
-  // @ts-expect-error - a bare object stands in for Window in Node
-  globalWithDefines.window = {}
+  Object.assign(globalWithDefines, { window: {} })
 }
 
 export {}


### PR DESCRIPTION
## Summary

Replace the script typecheck suppressions introduced in #15170 with type-safe narrowing and explicit contracts.

## Changes

- **What**: Narrows browser globals and legacy setting options, preserves Playwright argument types, models serialized locale output, and removes unused suppressed state.

## Review Focus

Confirm the locale collection scripts preserve existing output while compiling without `@ts-expect-error` additions or new type assertions.

## Recipe Book

Basic recipes for repairing similar script typecheck failures without suppressions or casts.

### 1. Optional browser global

**Symptom:** `window.app`, `window.LiteGraph`, or another runtime-installed global is possibly undefined.

```ts
const app = window.app
if (!app) throw new Error('ComfyUI app is not initialized')

app.api.getNodeDefs()
```

Copy the property to a local variable and guard it. TypeScript control-flow analysis then keeps it narrowed. The failure is also explicit if initialization order changes.

### 2. Public facade does not expose internal state

**Symptom:** Runtime state exists, but its public extension interface intentionally omits it.

```ts
const { useSettingStore } = await import(
  '../src/platform/settings/settingStore'
)
const settings = useSettingStore().settingsById
```

Use the store that owns the data instead of casting the public facade to an internal shape. This preserves the public API boundary and obtains the canonical type.

### 3. Value or value-producing callback

**Symptom:** A field such as a command label is `string | (() => string)`.

```ts
const label =
  typeof command.label === 'function' ? command.label() : command.label
```

Narrow the union and resolve both supported forms. Do not cast the command to a concrete implementation merely because that implementation currently exposes a getter.

### 4. Legacy or dynamically supplied data

**Symptom:** JavaScript extensions may provide a historical shape that the current TypeScript contract no longer declares.

```ts
const options: unknown = Reflect.get(setting, 'options')
const defaultValue =
  typeof setting.defaultValue === 'function'
    ? setting.defaultValue()
    : setting.defaultValue
const resolved: unknown =
  typeof options === 'function'
    ? Reflect.apply(options, undefined, [defaultValue ?? ''])
    : options
```

Keep the compatibility boundary as `unknown`, then narrow its output with `Array.isArray`, `typeof`, property checks, and null checks. Never let `any` escape into the typed pipeline.

### 5. Map key mistaken for an object property

**Symptom:** Entries are keyed by ID, but individual values do not contain an `id` field.

```ts
Object.entries(DESKTOP_DIALOGS).map(([id, dialog]) => [
  normalizeI18nKey(id),
  dialog
])
```

Read both parts from `Object.entries` instead of asserting that every value duplicates its map key.

### 6. Nullable factory result

**Symptom:** A factory returns `T | null` for unknown or unregistered types.

```ts
const node = liteGraph.createNode(nodeName, displayName)
if (!node?.widgets?.length) return {}
```

Handle the documented failure result before dereferencing it. Optional chaining is concise when null and an empty collection share the same outcome.

### 7. Tuple-like callback argument loses positional types

**Symptom:** An array passed to `page.evaluate` is inferred as `(A | B | C)[]`, so every destructured item receives the whole union.

```ts
await page.evaluate(
  ({ nodeName, displayName, inputNames }) => {
    // Each property retains its own type.
  },
  { nodeName, displayName, inputNames }
)
```

Use a named object payload when positions have different types. It is self-documenting and avoids tuple assertions.

### 8. Serialization erases useful inferred types

**Symptom:** `Object.fromEntries` produces broad records or unions where common optional fields disappear.

```ts
interface SerializedLabel {
  name?: string
  tooltip?: string
}

const nodes: Record<string, SerializedNode> = Object.fromEntries(entries)
```

Declare the domain result shape at the serialization boundary. This checks every produced entry and gives consumers one stable contract without casting.

### 9. Test accesses optional output

**Symptom:** The production return type correctly marks fields optional, but a fixture guarantees their presence.

```ts
if (!node.inputs || !node.outputs || !node.description) {
  throw new Error('Expected serialized node labels')
}

expect(render(node.description)).toBe(expected)
```

Narrow with a runtime guard. The test now reports a useful behavioral failure if the fixture stops producing the expected shape.

### 10. Unused constant kept only as documentation

**Symptom:** `noUnusedLocals` rejects a constant that is never read.

```ts
/** Target: P5 FPS ≥ 52 */
const TARGET_P5_FPS = 52
```

Delete the unused duplicate and put the useful context on the value the implementation actually checks. A suppression should not preserve dead code.

### 11. Minimal Node shim conflicts with the DOM `Window` type

**Symptom:** A Node test only needs `window` to exist, but assigning `{}` is rejected because it is not a complete DOM `Window`.

```ts
if (typeof window === 'undefined') {
  Object.assign(globalWithDefines, { window: {} })
}
```

Install the runtime shim as a property on the test host object instead of claiming that the bare object structurally implements the browser `Window` interface.


## Browser Coverage Decision

The locale collectors are already Playwright tests selected by `playwright.i18n.config.ts` and run through `pnpm collect-i18n`. Their `page.evaluate` callbacks are inline inside scripts that write the canonical locale files; the node collector also requires a live ComfyUI backend and registered runtime nodes. A separate `browser_tests` spec could only duplicate those callbacks, so it would test a copy rather than the changed production path and could drift independently. The serializer output remains covered by `scripts/nodeDefLocaleSerializer.test.ts`, while the actual browser collector paths remain covered by the existing i18n Playwright jobs. No duplicate browser spec was added.
