### PR TITLE
fix: show complete workspace member list

### DIFF
--- a/src/platform/workspace/stores/teamWorkspaceStore.test.ts
+++ b/src/platform/workspace/stores/teamWorkspaceStore.test.ts
@@ -876,64 +876,7 @@ describe('useTeamWorkspaceStore', () => {
       expect(store.members[0].monthlyCreditLimit).toBeNull()
       expect(store.members[1].creditsUsedThisMonth).toBeUndefined()
       expect(store.members[1].monthlyCreditLimit).toBeUndefined()
-    })
-
-    it('fetchMembers loads every page', async () => {
-      const firstPage = [
-        {
-          id: 'user-1',
-          name: 'User One',
-          email: 'one@test.com',
-          joined_at: '2024-01-01T00:00:00Z',
-          role: 'member' as const
-        }
-      ]
-      const secondPage = [
-        {
-          id: 'user-2',
-          name: 'User Two',
-          email: 'two@test.com',
-          joined_at: '2024-01-02T00:00:00Z',
-          role: 'member' as const
-        }
-      ]
-      mockWorkspaceApi.listMembers
-        .mockResolvedValueOnce({
-          members: firstPage,
-          pagination: {
-            offset: 0,
-            limit: 100,
-            total: 2,
-            has_more: true
-          }
-        })
-        .mockResolvedValueOnce({
-          members: secondPage,
-          pagination: {
-            offset: 1,
-            limit: 100,
-            total: 2,
-            has_more: false
-          }
-        })
-      mockWorkspaceAuthStore.initializeFromSession.mockReturnValue(true)
-      mockWorkspaceAuthStore.currentWorkspace = mockTeamWorkspace
-
-      const store = useTeamWorkspaceStore()
-      await store.initialize()
-
-      const result = await store.fetchMembers()
-
-      expect(mockWorkspaceApi.listMembers).toHaveBeenNthCalledWith(1, {
-        offset: 0,
-        limit: 100
-      })
-      expect(mockWorkspaceApi.listMembers).toHaveBeenNthCalledWith(2, {
-        offset: 1,
-        limit: 100
-      })
-      expect(result.map(({ id }) => id)).toEqual(['user-1', 'user-2'])
-      expect(store.members.map(({ id }) => id)).toEqual(['user-1', 'user-2'])
+      expect(mockWorkspaceApi.listMembers).toHaveBeenCalledWith({ limit: 100 })
     })
 
     it('fetchMembers supports a personal workspace with Team entitlement', async () => {

--- a/src/platform/workspace/stores/teamWorkspaceStore.test.ts
+++ b/src/platform/workspace/stores/teamWorkspaceStore.test.ts
@@ -893,6 +893,12 @@ describe('useTeamWorkspaceStore', () => {
         offset: 20
       })
 
+      await store.fetchMembers({ offset: 20, limit: undefined })
+      expect(mockWorkspaceApi.listMembers).toHaveBeenLastCalledWith({
+        limit: 100,
+        offset: 20
+      })
+
       await store.fetchMembers({ offset: 20, limit: 25 })
       expect(mockWorkspaceApi.listMembers).toHaveBeenLastCalledWith({
         limit: 25,

--- a/src/platform/workspace/stores/teamWorkspaceStore.test.ts
+++ b/src/platform/workspace/stores/teamWorkspaceStore.test.ts
@@ -878,6 +878,64 @@ describe('useTeamWorkspaceStore', () => {
       expect(store.members[1].monthlyCreditLimit).toBeUndefined()
     })
 
+    it('fetchMembers loads every page', async () => {
+      const firstPage = [
+        {
+          id: 'user-1',
+          name: 'User One',
+          email: 'one@test.com',
+          joined_at: '2024-01-01T00:00:00Z',
+          role: 'member' as const
+        }
+      ]
+      const secondPage = [
+        {
+          id: 'user-2',
+          name: 'User Two',
+          email: 'two@test.com',
+          joined_at: '2024-01-02T00:00:00Z',
+          role: 'member' as const
+        }
+      ]
+      mockWorkspaceApi.listMembers
+        .mockResolvedValueOnce({
+          members: firstPage,
+          pagination: {
+            offset: 0,
+            limit: 100,
+            total: 2,
+            has_more: true
+          }
+        })
+        .mockResolvedValueOnce({
+          members: secondPage,
+          pagination: {
+            offset: 1,
+            limit: 100,
+            total: 2,
+            has_more: false
+          }
+        })
+      mockWorkspaceAuthStore.initializeFromSession.mockReturnValue(true)
+      mockWorkspaceAuthStore.currentWorkspace = mockTeamWorkspace
+
+      const store = useTeamWorkspaceStore()
+      await store.initialize()
+
+      const result = await store.fetchMembers()
+
+      expect(mockWorkspaceApi.listMembers).toHaveBeenNthCalledWith(1, {
+        offset: 0,
+        limit: 100
+      })
+      expect(mockWorkspaceApi.listMembers).toHaveBeenNthCalledWith(2, {
+        offset: 1,
+        limit: 100
+      })
+      expect(result.map(({ id }) => id)).toEqual(['user-1', 'user-2'])
+      expect(store.members.map(({ id }) => id)).toEqual(['user-1', 'user-2'])
+    })
+
     it('fetchMembers supports a personal workspace with Team entitlement', async () => {
       mockWorkspaceApi.listMembers.mockResolvedValue({
         members: [],

--- a/src/platform/workspace/stores/teamWorkspaceStore.test.ts
+++ b/src/platform/workspace/stores/teamWorkspaceStore.test.ts
@@ -879,6 +879,27 @@ describe('useTeamWorkspaceStore', () => {
       expect(mockWorkspaceApi.listMembers).toHaveBeenCalledWith({ limit: 100 })
     })
 
+    it('fetchMembers applies the default limit to partial parameters', async () => {
+      mockWorkspaceApi.listMembers.mockResolvedValue({
+        members: [],
+        pagination: { offset: 20, limit: 100, total: 0 }
+      })
+      const store = useTeamWorkspaceStore()
+      await store.initialize()
+
+      await store.fetchMembers({ offset: 20 })
+      expect(mockWorkspaceApi.listMembers).toHaveBeenLastCalledWith({
+        limit: 100,
+        offset: 20
+      })
+
+      await store.fetchMembers({ offset: 20, limit: 25 })
+      expect(mockWorkspaceApi.listMembers).toHaveBeenLastCalledWith({
+        limit: 25,
+        offset: 20
+      })
+    })
+
     it('fetchMembers supports a personal workspace with Team entitlement', async () => {
       mockWorkspaceApi.listMembers.mockResolvedValue({
         members: [],

--- a/src/platform/workspace/stores/teamWorkspaceStore.ts
+++ b/src/platform/workspace/stores/teamWorkspaceStore.ts
@@ -602,17 +602,8 @@ export const useTeamWorkspaceStore = defineStore('teamWorkspace', () => {
     const workspaceId = activeWorkspaceId.value
     if (!workspaceId) return []
 
-    const members: WorkspaceMember[] = []
-    let offset = 0
-
-    while (true) {
-      const response = await workspaceApi.listMembers({ offset, limit: 100 })
-      const page = response.members.map(mapApiMemberToWorkspaceMember)
-      members.push(...page)
-      if (!response.pagination.has_more || page.length === 0) break
-      offset = response.pagination.offset + page.length
-    }
-
+    const response = await workspaceApi.listMembers({ limit: 100 })
+    const members = response.members.map(mapApiMemberToWorkspaceMember)
     if (!isStaleWorkspace(generation, workspaceId)) {
       updateWorkspace(workspaceId, { members })
     }

--- a/src/platform/workspace/stores/teamWorkspaceStore.ts
+++ b/src/platform/workspace/stores/teamWorkspaceStore.ts
@@ -13,7 +13,6 @@ import { useWorkspaceAuthStore } from '@/platform/workspace/stores/workspaceAuth
 
 import type {
   BillingRail,
-  ListMembersParams,
   Member,
   PendingInvite as ApiPendingInvite,
   SubscriptionTier,
@@ -598,15 +597,22 @@ export const useTeamWorkspaceStore = defineStore('teamWorkspace', () => {
   /**
    * Fetch members for the current workspace.
    */
-  async function fetchMembers(
-    params?: ListMembersParams
-  ): Promise<WorkspaceMember[]> {
+  async function fetchMembers(): Promise<WorkspaceMember[]> {
     const generation = identityGeneration
     const workspaceId = activeWorkspaceId.value
     if (!workspaceId) return []
 
-    const response = await workspaceApi.listMembers(params)
-    const members = response.members.map(mapApiMemberToWorkspaceMember)
+    const members: WorkspaceMember[] = []
+    let offset = 0
+
+    while (true) {
+      const response = await workspaceApi.listMembers({ offset, limit: 100 })
+      const page = response.members.map(mapApiMemberToWorkspaceMember)
+      members.push(...page)
+      if (!response.pagination.has_more || page.length === 0) break
+      offset = response.pagination.offset + page.length
+    }
+
     if (!isStaleWorkspace(generation, workspaceId)) {
       updateWorkspace(workspaceId, { members })
     }

--- a/src/platform/workspace/stores/teamWorkspaceStore.ts
+++ b/src/platform/workspace/stores/teamWorkspaceStore.ts
@@ -599,13 +599,13 @@ export const useTeamWorkspaceStore = defineStore('teamWorkspace', () => {
    * Fetch members for the current workspace.
    */
   async function fetchMembers(
-    params: ListMembersParams = { limit: 100 }
+    params: ListMembersParams = {}
   ): Promise<WorkspaceMember[]> {
     const generation = identityGeneration
     const workspaceId = activeWorkspaceId.value
     if (!workspaceId) return []
 
-    const response = await workspaceApi.listMembers(params)
+    const response = await workspaceApi.listMembers({ limit: 100, ...params })
     const members = response.members.map(mapApiMemberToWorkspaceMember)
     if (!isStaleWorkspace(generation, workspaceId)) {
       updateWorkspace(workspaceId, { members })

--- a/src/platform/workspace/stores/teamWorkspaceStore.ts
+++ b/src/platform/workspace/stores/teamWorkspaceStore.ts
@@ -605,7 +605,10 @@ export const useTeamWorkspaceStore = defineStore('teamWorkspace', () => {
     const workspaceId = activeWorkspaceId.value
     if (!workspaceId) return []
 
-    const response = await workspaceApi.listMembers({ limit: 100, ...params })
+    const response = await workspaceApi.listMembers({
+      ...params,
+      limit: params.limit ?? 100
+    })
     const members = response.members.map(mapApiMemberToWorkspaceMember)
     if (!isStaleWorkspace(generation, workspaceId)) {
       updateWorkspace(workspaceId, { members })

--- a/src/platform/workspace/stores/teamWorkspaceStore.ts
+++ b/src/platform/workspace/stores/teamWorkspaceStore.ts
@@ -13,6 +13,7 @@ import { useWorkspaceAuthStore } from '@/platform/workspace/stores/workspaceAuth
 
 import type {
   BillingRail,
+  ListMembersParams,
   Member,
   PendingInvite as ApiPendingInvite,
   SubscriptionTier,
@@ -597,12 +598,14 @@ export const useTeamWorkspaceStore = defineStore('teamWorkspace', () => {
   /**
    * Fetch members for the current workspace.
    */
-  async function fetchMembers(): Promise<WorkspaceMember[]> {
+  async function fetchMembers(
+    params: ListMembersParams = { limit: 100 }
+  ): Promise<WorkspaceMember[]> {
     const generation = identityGeneration
     const workspaceId = activeWorkspaceId.value
     if (!workspaceId) return []
 
-    const response = await workspaceApi.listMembers({ limit: 100 })
+    const response = await workspaceApi.listMembers(params)
     const members = response.members.map(mapApiMemberToWorkspaceMember)
     if (!isStaleWorkspace(generation, workspaceId)) {
       updateWorkspace(workspaceId, { members })


### PR DESCRIPTION
## Summary

Request the API's maximum 100-member page so every current workspace displays its complete membership list instead of the default first 20.

## Changes

- **What**: Fetch one bounded page with `limit=100`; no pagination loop or unbounded prefetching.
- **Tests**: Added regression coverage for the requested member limit; ran the targeted store suite, typecheck, lint, formatting, and knip.

## Review Focus

The production frontend is on `cloud/1.49`; this PR is marked for backport to `cloud/1.49` and subsequent `cloud/1.50`.