### PR TITLE
fix: unblock locale-only commits in the pre-commit hook

### DIFF
--- a/lint-staged.config.ts
+++ b/lint-staged.config.ts
@@ -23,7 +23,10 @@ export default function lintStaged(stagedFiles: string[]) {
   )
 
   return [
-    ...commandsWithFiles(formattableFiles, 'pnpm exec oxfmt --write'),
+    ...commandsWithFiles(
+      formattableFiles,
+      'pnpm exec oxfmt --write --no-error-on-unmatched-pattern'
+    ),
     ...lintCommands(codeFiles, styleFiles),
     ...typecheckCommands(typecheckFiles)
   ]


### PR DESCRIPTION
## Summary

Stop the pre-commit hook from rejecting commits that only touch locale JSON.

## Changes

- **What**: Pass `--no-error-on-unmatched-pattern` to `oxfmt` in `lint-staged.config.ts`, matching the existing `oxlint` invocation.

`src/locales/**/*.json` is in `ignorePatterns` in `.oxfmtrc.json`, so a commit containing only locale files leaves oxfmt with nothing to format and it exits 2:

```
Expected at least one target file. All matched files may have been excluded by ignore rules.
```

That fails husky, which fails `git commit`, which fails the `i18n: Update Core` workflow's commit step — every locale regeneration run hits it. Observed on the `version-bump-main-1.51.4` run:

https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/31756563930

## Review Focus

The pre-commit path for a locale-only staged set. `oxfmt` still errors on genuinely bad input; this flag only suppresses the empty-match case.

Validation:

- `pnpm exec oxfmt --write "src/locales/zh/main.json"` reproduces exit 2; with the flag it exits 0
- `mise exec -- pnpm typecheck:scripts`
- `mise exec -- pnpm lint`
- `mise exec -- pnpm knip`
- `mise exec -- pnpm format:check`
