### PR TITLE
fix: harden OpenAI translation requests

### DIFF
--- a/scripts/i18n/config.ts
+++ b/scripts/i18n/config.ts
@@ -1,25 +1,21 @@
+import type { OpenAI } from 'openai'
+
 export interface OutputLocale {
   code: string
   name: string
   guidance?: string
 }
 
-export type ReasoningEffort =
-  | 'none'
-  | 'low'
-  | 'medium'
-  | 'high'
-  | 'xhigh'
-  | 'max'
-
 export interface TranslationPipelineConfig {
   entry: string
   output: string
   model: string
-  reasoningEffort: ReasoningEffort
+  reasoningEffort: NonNullable<
+    OpenAI.ChatCompletionCreateParams['reasoning_effort']
+  >
   maxItemsPerRequest: number
   maxSourceCharsPerRequest: number
-  localeConcurrency: number
+  stateConcurrency: number
   requestConcurrency: number
   maxTranslationRounds: number
   glossary: string
@@ -55,7 +51,7 @@ export const translationPipelineConfig: TranslationPipelineConfig = {
   reasoningEffort: 'high',
   maxItemsPerRequest: 40,
   maxSourceCharsPerRequest: 6000,
-  localeConcurrency: 3,
+  stateConcurrency: 3,
   requestConcurrency: 2,
   maxTranslationRounds: 3,
   glossary,

--- a/scripts/i18n/config.ts
+++ b/scripts/i18n/config.ts
@@ -10,14 +10,14 @@ export interface TranslationPipelineConfig {
   entry: string
   output: string
   model: string
-  reasoningEffort: NonNullable<
-    OpenAI.ChatCompletionCreateParams['reasoning_effort']
-  >
+  reasoningEffort: NonNullable<OpenAI.ChatCompletionReasoningEffort>
   maxItemsPerRequest: number
   maxSourceCharsPerRequest: number
-  stateConcurrency: number
+  maxTruncationSplitDepth: number
+  localeFileConcurrency: number
   requestConcurrency: number
   maxTranslationRounds: number
+  requestBudgetMultiplier: number
   glossary: string
   outputLocales: OutputLocale[]
 }
@@ -51,9 +51,11 @@ export const translationPipelineConfig: TranslationPipelineConfig = {
   reasoningEffort: 'high',
   maxItemsPerRequest: 40,
   maxSourceCharsPerRequest: 6000,
-  stateConcurrency: 3,
+  maxTruncationSplitDepth: 3,
+  localeFileConcurrency: 3,
   requestConcurrency: 2,
   maxTranslationRounds: 3,
+  requestBudgetMultiplier: 12,
   glossary,
   outputLocales: [
     {

--- a/scripts/i18n/config.ts
+++ b/scripts/i18n/config.ts
@@ -17,7 +17,6 @@ export interface TranslationPipelineConfig {
   localeFileConcurrency: number
   requestConcurrency: number
   maxTranslationRounds: number
-  requestBudgetMultiplier: number
   glossary: string
   outputLocales: OutputLocale[]
 }
@@ -55,7 +54,6 @@ export const translationPipelineConfig: TranslationPipelineConfig = {
   localeFileConcurrency: 3,
   requestConcurrency: 2,
   maxTranslationRounds: 3,
-  requestBudgetMultiplier: 12,
   glossary,
   outputLocales: [
     {

--- a/scripts/i18n/translate.ts
+++ b/scripts/i18n/translate.ts
@@ -1,10 +1,6 @@
 import OpenAI from 'openai'
 
-import type {
-  OutputLocale,
-  ReasoningEffort,
-  TranslationPipelineConfig
-} from './config'
+import type { OutputLocale, TranslationPipelineConfig } from './config'
 import { tokenErrors } from './protected-tokens'
 
 export interface TranslationItem {
@@ -58,6 +54,8 @@ export function chunkItems(
   maxItems: number,
   maxSourceChars: number
 ): TranslationItem[][] {
+  // Character count is an initial batching heuristic; truncated responses are
+  // recursively split before the translation run fails.
   const chunks: TranslationItem[][] = []
   let chunk: TranslationItem[] = []
   let chunkChars = 0
@@ -103,8 +101,18 @@ function parseBatchResponse(content: string): Record<string, string> {
     throw new Error('translation response is not a JSON object')
   }
   const record: Record<string, string> = {}
+  const invalidIds: string[] = []
   for (const [key, value] of Object.entries(parsed)) {
-    if (typeof value === 'string') record[key] = value
+    if (typeof value === 'string') {
+      record[key] = value
+    } else {
+      invalidIds.push(key)
+    }
+  }
+  if (invalidIds.length > 0) {
+    throw new Error(
+      `translation response has non-string values for ids: ${invalidIds.join(', ')}`
+    )
   }
   return record
 }
@@ -112,9 +120,10 @@ function parseBatchResponse(content: string): Record<string, string> {
 interface OpenAiTranslatorOptions {
   apiKey: string
   model: string
-  reasoningEffort: ReasoningEffort
+  reasoningEffort: TranslationPipelineConfig['reasoningEffort']
   glossary: string
   fetchFn?: typeof fetch
+  onCompletion?: (completion: OpenAI.ChatCompletion) => void
   requestTimeoutMs?: number
 }
 
@@ -127,7 +136,11 @@ export function createOpenAiTranslator(
     timeout: options.requestTimeoutMs ?? defaultRequestTimeoutMs,
     maxRetries: maxNetworkRetries
   })
-  return async (locale, items) => {
+
+  async function translateBatch(
+    locale: OutputLocale,
+    items: TranslationItem[]
+  ): Promise<Record<string, string>> {
     let lastError = new Error('translation request was not attempted')
     for (let attempt = 0; attempt <= maxMalformedResponseRetries; attempt++) {
       const completion = await client.chat.completions.create({
@@ -142,12 +155,18 @@ export function createOpenAiTranslator(
           { role: 'user', content: JSON.stringify({ items }) }
         ]
       })
+      options.onCompletion?.(completion)
       const choice = completion.choices[0]
       if (choice?.finish_reason === 'length') {
-        lastError = new Error(
-          'OpenAI response was truncated (finish_reason "length"); lower maxItemsPerRequest or maxSourceCharsPerRequest'
-        )
-        continue
+        if (items.length === 1) {
+          throw new Error(
+            'OpenAI response was truncated (finish_reason "length"); lower maxItemsPerRequest or maxSourceCharsPerRequest'
+          )
+        }
+        const splitIndex = Math.ceil(items.length / 2)
+        const first = await translateBatch(locale, items.slice(0, splitIndex))
+        const second = await translateBatch(locale, items.slice(splitIndex))
+        return { ...first, ...second }
       }
       const content = choice?.message.content
       if (typeof content !== 'string') {
@@ -162,6 +181,8 @@ export function createOpenAiTranslator(
     }
     throw lastError
   }
+
+  return translateBatch
 }
 
 export async function translateLocaleItems(

--- a/scripts/i18n/translate.ts
+++ b/scripts/i18n/translate.ts
@@ -105,6 +105,39 @@ function parseBatchResponse(content: string): Record<string, string> {
   return record
 }
 
+export interface RequestBudget {
+  fetch: typeof fetch
+  signal: AbortSignal
+  requestCount: () => number
+}
+
+// The SDK retries a fetch that throws, so counting alone cannot hold a ceiling:
+// the request admitted at the boundary would still spend maxNetworkRetries more
+// attempts. Aborting the signal makes the rejection terminal, because the SDK
+// checks signal.aborted before both the send and the retry
+export function createRequestBudget(
+  maxRequests: number,
+  stopMessage: string,
+  fetchFn: typeof fetch = globalThis.fetch
+): RequestBudget {
+  const controller = new AbortController()
+  let requests = 0
+  const budgetedFetch: typeof fetch = async (input, init) => {
+    if (requests >= maxRequests) {
+      const stop = new Error(stopMessage)
+      controller.abort(stop)
+      throw stop
+    }
+    requests++
+    return fetchFn(input, init)
+  }
+  return {
+    fetch: budgetedFetch,
+    signal: controller.signal,
+    requestCount: () => requests
+  }
+}
+
 interface OpenAiTranslatorOptions {
   apiKey: string
   model: string
@@ -112,9 +145,7 @@ interface OpenAiTranslatorOptions {
   glossary: string
   maxTruncationSplitDepth: number
   fetchFn?: typeof fetch
-  // Throwing here aborts before the request is sent; a fetchFn that throws is
-  // wrapped as a connection error and retried by the SDK
-  onRequest?: () => void
+  signal?: AbortSignal
   onCompletion?: (completion: OpenAI.ChatCompletion) => void
   requestTimeoutMs?: number
 }
@@ -137,19 +168,26 @@ export function createOpenAiTranslator(
     if (items.length === 0) return {}
     let lastError = new Error('translation request was not attempted')
     for (let attempt = 0; attempt <= maxMalformedResponseRetries; attempt++) {
-      options.onRequest?.()
-      const completion = await client.chat.completions.create({
-        model: options.model,
-        reasoning_effort: options.reasoningEffort,
-        response_format: { type: 'json_object' },
-        messages: [
+      const completion = await client.chat.completions
+        .create(
           {
-            role: 'system',
-            content: buildSystemPrompt(locale, options.glossary)
+            model: options.model,
+            reasoning_effort: options.reasoningEffort,
+            response_format: { type: 'json_object' },
+            messages: [
+              {
+                role: 'system',
+                content: buildSystemPrompt(locale, options.glossary)
+              },
+              { role: 'user', content: JSON.stringify({ items }) }
+            ]
           },
-          { role: 'user', content: JSON.stringify({ items }) }
-        ]
-      })
+          { signal: options.signal }
+        )
+        .catch((error: unknown) => {
+          if (options.signal?.aborted) throw options.signal.reason
+          throw error
+        })
       options.onCompletion?.(completion)
       const choice = completion.choices[0]
       if (choice?.finish_reason === 'length') {

--- a/scripts/i18n/translate.ts
+++ b/scripts/i18n/translate.ts
@@ -22,7 +22,8 @@ const maxMalformedResponseRetries = 1
 
 // Unlike es-toolkit's mapAsync, which dispatches every item up front, this
 // pool stops dispatching once any task fails so a fatal error does not keep
-// spending API requests whose results nobody will consume
+// spending API requests whose results nobody will consume; in-flight tasks
+// settle before the first failure is rethrown so no work outlives the call
 export async function mapWithConcurrency<T, R>(
   items: readonly T[],
   concurrency: number,
@@ -30,22 +31,22 @@ export async function mapWithConcurrency<T, R>(
 ): Promise<R[]> {
   const results: R[] = new Array(items.length)
   let next = 0
-  let failed = false
+  let firstFailure: { reason: unknown } | undefined
   const workers = Array.from(
     { length: Math.min(concurrency, items.length) },
     async () => {
-      while (!failed && next < items.length) {
+      while (!firstFailure && next < items.length) {
         const index = next++
         try {
           results[index] = await task(items[index])
         } catch (error) {
-          failed = true
-          throw error
+          firstFailure ??= { reason: error }
         }
       }
     }
   )
   await Promise.all(workers)
+  if (firstFailure) throw firstFailure.reason
   return results
 }
 
@@ -108,37 +109,29 @@ function parseBatchResponse(
   return record
 }
 
-export interface RequestBudget {
+export interface RequestCounter {
   fetch: typeof fetch
-  signal: AbortSignal
   requestCount: () => number
 }
 
-// The SDK retries a fetch that throws, so counting alone cannot hold a ceiling:
-// the request admitted at the boundary would still spend maxNetworkRetries more
-// attempts. Aborting the signal makes the rejection terminal, because the SDK
-// checks signal.aborted before both the send and the retry
-export function createRequestBudget(
-  maxRequests: number,
-  stopMessage: string,
+export function createRequestCounter(
   fetchFn: typeof fetch = globalThis.fetch
-): RequestBudget {
-  const controller = new AbortController()
+): RequestCounter {
   let requests = 0
-  const budgetedFetch: typeof fetch = async (input, init) => {
-    if (requests >= maxRequests) {
-      const stop = new Error(stopMessage)
-      controller.abort(stop)
-      throw stop
-    }
+  const countingFetch: typeof fetch = async (input, init) => {
     requests++
     return fetchFn(input, init)
   }
-  return {
-    fetch: budgetedFetch,
-    signal: controller.signal,
-    requestCount: () => requests
-  }
+  return { fetch: countingFetch, requestCount: () => requests }
+}
+
+function splitTruncatedBatch(items: TranslationItem[]): TranslationItem[][] {
+  const totalChars = items.reduce((sum, item) => sum + item.source.length, 0)
+  return chunkItems(
+    items,
+    Math.ceil(items.length / 2),
+    Math.ceil(totalChars / 2)
+  )
 }
 
 interface OpenAiTranslatorOptions {
@@ -148,7 +141,6 @@ interface OpenAiTranslatorOptions {
   glossary: string
   maxTruncationSplitDepth: number
   fetchFn?: typeof fetch
-  signal?: AbortSignal
   onCompletion?: (completion: OpenAI.ChatCompletion) => void
   requestTimeoutMs?: number
 }
@@ -170,67 +162,58 @@ export function createOpenAiTranslator(
   ): Promise<Record<string, string>> {
     if (items.length === 0) return {}
     const requestedIds = new Set(items.map((item) => item.id))
-    let lastError = new Error('translation request was not attempted')
+    let deferralReason = 'the request was not attempted'
     for (let attempt = 0; attempt <= maxMalformedResponseRetries; attempt++) {
-      const completion = await client.chat.completions
-        .create(
+      const completion = await client.chat.completions.create({
+        model: options.model,
+        reasoning_effort: options.reasoningEffort,
+        response_format: { type: 'json_object' },
+        messages: [
           {
-            model: options.model,
-            reasoning_effort: options.reasoningEffort,
-            response_format: { type: 'json_object' },
-            messages: [
-              {
-                role: 'system',
-                content: buildSystemPrompt(locale, options.glossary)
-              },
-              { role: 'user', content: JSON.stringify({ items }) }
-            ]
+            role: 'system',
+            content: buildSystemPrompt(locale, options.glossary)
           },
-          { signal: options.signal }
-        )
-        .catch((error: unknown) => {
-          if (options.signal?.aborted) throw options.signal.reason
-          throw error
-        })
+          { role: 'user', content: JSON.stringify({ items }) }
+        ]
+      })
       options.onCompletion?.(completion)
       const choice = completion.choices[0]
       if (choice?.finish_reason === 'length') {
         if (items.length === 1) {
-          throw new Error(
-            `OpenAI response was truncated (finish_reason "length") for a single string (${items[0].context}), which cannot be split further`
-          )
+          deferralReason = `the response was truncated (finish_reason "length") for the single string ${items[0].context}`
+          continue
         }
         if (splitDepth >= options.maxTruncationSplitDepth) {
-          throw new Error(
-            `OpenAI response was truncated (finish_reason "length") and ${items.length} strings still do not fit at maxTruncationSplitDepth ${options.maxTruncationSplitDepth}; lower maxItemsPerRequest or maxSourceCharsPerRequest`
-          )
+          deferralReason = `${items.length} strings were still truncated (finish_reason "length") at maxTruncationSplitDepth ${options.maxTruncationSplitDepth}`
+          break
         }
-        const splitIndex = Math.ceil(items.length / 2)
-        const nextDepth = splitDepth + 1
-        const first = await translateBatch(
-          locale,
-          items.slice(0, splitIndex),
-          nextDepth
+        const settled = await Promise.allSettled(
+          splitTruncatedBatch(items).map((chunk) =>
+            translateBatch(locale, chunk, splitDepth + 1)
+          )
         )
-        const second = await translateBatch(
-          locale,
-          items.slice(splitIndex),
-          nextDepth
-        )
-        return { ...first, ...second }
+        const merged: Record<string, string> = {}
+        for (const result of settled) {
+          if (result.status === 'rejected') throw result.reason
+          Object.assign(merged, result.value)
+        }
+        return merged
       }
-      const content = choice?.message.content
+      const content = choice?.message?.content
       if (typeof content !== 'string') {
-        lastError = new Error('OpenAI response has no message content')
+        deferralReason = 'the response has no message content'
         continue
       }
       try {
         return parseBatchResponse(content, requestedIds)
       } catch (error) {
-        lastError = error instanceof Error ? error : new Error(String(error))
+        deferralReason = error instanceof Error ? error.message : String(error)
       }
     }
-    throw lastError
+    console.warn(
+      `${locale.code}: deferring ${items.length} strings for retry: ${deferralReason}`
+    )
+    return {}
   }
 
   return (locale, items) => translateBatch(locale, items, 0)

--- a/scripts/i18n/translate.ts
+++ b/scripts/i18n/translate.ts
@@ -18,7 +18,7 @@ export type TranslateBatch = (
 
 const defaultRequestTimeoutMs = 120_000
 const maxNetworkRetries = 3
-const maxMalformedResponseRetries = 3
+const maxMalformedResponseRetries = 1
 
 // Unlike es-toolkit's mapAsync, which dispatches every item up front, this
 // pool stops dispatching once any task fails so a fatal error does not keep
@@ -54,8 +54,6 @@ export function chunkItems(
   maxItems: number,
   maxSourceChars: number
 ): TranslationItem[][] {
-  // Character count is an initial batching heuristic; truncated responses are
-  // recursively split before the translation run fails.
   const chunks: TranslationItem[][] = []
   let chunk: TranslationItem[] = []
   let chunkChars = 0
@@ -101,18 +99,8 @@ function parseBatchResponse(content: string): Record<string, string> {
     throw new Error('translation response is not a JSON object')
   }
   const record: Record<string, string> = {}
-  const invalidIds: string[] = []
   for (const [key, value] of Object.entries(parsed)) {
-    if (typeof value === 'string') {
-      record[key] = value
-    } else {
-      invalidIds.push(key)
-    }
-  }
-  if (invalidIds.length > 0) {
-    throw new Error(
-      `translation response has non-string values for ids: ${invalidIds.join(', ')}`
-    )
+    if (typeof value === 'string') record[key] = value
   }
   return record
 }

--- a/scripts/i18n/translate.ts
+++ b/scripts/i18n/translate.ts
@@ -110,7 +110,11 @@ interface OpenAiTranslatorOptions {
   model: string
   reasoningEffort: TranslationPipelineConfig['reasoningEffort']
   glossary: string
+  maxTruncationSplitDepth: number
   fetchFn?: typeof fetch
+  // Throwing here aborts before the request is sent; a fetchFn that throws is
+  // wrapped as a connection error and retried by the SDK
+  onRequest?: () => void
   onCompletion?: (completion: OpenAI.ChatCompletion) => void
   requestTimeoutMs?: number
 }
@@ -127,10 +131,13 @@ export function createOpenAiTranslator(
 
   async function translateBatch(
     locale: OutputLocale,
-    items: TranslationItem[]
+    items: TranslationItem[],
+    splitDepth: number
   ): Promise<Record<string, string>> {
+    if (items.length === 0) return {}
     let lastError = new Error('translation request was not attempted')
     for (let attempt = 0; attempt <= maxMalformedResponseRetries; attempt++) {
+      options.onRequest?.()
       const completion = await client.chat.completions.create({
         model: options.model,
         reasoning_effort: options.reasoningEffort,
@@ -148,12 +155,26 @@ export function createOpenAiTranslator(
       if (choice?.finish_reason === 'length') {
         if (items.length === 1) {
           throw new Error(
-            'OpenAI response was truncated (finish_reason "length"); lower maxItemsPerRequest or maxSourceCharsPerRequest'
+            `OpenAI response was truncated (finish_reason "length") for a single string (${items[0].context}), which cannot be split further`
+          )
+        }
+        if (splitDepth >= options.maxTruncationSplitDepth) {
+          throw new Error(
+            `OpenAI response was truncated (finish_reason "length") and ${items.length} strings still do not fit at maxTruncationSplitDepth ${options.maxTruncationSplitDepth}; lower maxItemsPerRequest or maxSourceCharsPerRequest`
           )
         }
         const splitIndex = Math.ceil(items.length / 2)
-        const first = await translateBatch(locale, items.slice(0, splitIndex))
-        const second = await translateBatch(locale, items.slice(splitIndex))
+        const nextDepth = splitDepth + 1
+        const first = await translateBatch(
+          locale,
+          items.slice(0, splitIndex),
+          nextDepth
+        )
+        const second = await translateBatch(
+          locale,
+          items.slice(splitIndex),
+          nextDepth
+        )
         return { ...first, ...second }
       }
       const content = choice?.message.content
@@ -170,7 +191,7 @@ export function createOpenAiTranslator(
     throw lastError
   }
 
-  return translateBatch
+  return (locale, items) => translateBatch(locale, items, 0)
 }
 
 export async function translateLocaleItems(

--- a/scripts/i18n/translate.ts
+++ b/scripts/i18n/translate.ts
@@ -93,14 +93,17 @@ ${glossary}
 ${locale.guidance ? `\n${locale.name} guidelines:\n${locale.guidance}\n` : ''}`
 }
 
-function parseBatchResponse(content: string): Record<string, string> {
+function parseBatchResponse(
+  content: string,
+  requestedIds: ReadonlySet<string>
+): Record<string, string> {
   const parsed: unknown = JSON.parse(content)
   if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
     throw new Error('translation response is not a JSON object')
   }
   const record: Record<string, string> = {}
   for (const [key, value] of Object.entries(parsed)) {
-    if (typeof value === 'string') record[key] = value
+    if (typeof value === 'string' && requestedIds.has(key)) record[key] = value
   }
   return record
 }
@@ -166,6 +169,7 @@ export function createOpenAiTranslator(
     splitDepth: number
   ): Promise<Record<string, string>> {
     if (items.length === 0) return {}
+    const requestedIds = new Set(items.map((item) => item.id))
     let lastError = new Error('translation request was not attempted')
     for (let attempt = 0; attempt <= maxMalformedResponseRetries; attempt++) {
       const completion = await client.chat.completions
@@ -221,7 +225,7 @@ export function createOpenAiTranslator(
         continue
       }
       try {
-        return parseBatchResponse(content)
+        return parseBatchResponse(content, requestedIds)
       } catch (error) {
         lastError = error instanceof Error ? error : new Error(String(error))
       }

--- a/scripts/i18n/update-locales.test.ts
+++ b/scripts/i18n/update-locales.test.ts
@@ -3,6 +3,7 @@
  * (happy-dom defines window/navigator), and nothing here needs a DOM.
  * @vitest-environment node
  */
+import type { OpenAI } from 'openai'
 import { describe, expect, it, vi } from 'vitest'
 
 import type { OutputLocale } from './config'
@@ -505,20 +506,39 @@ describe('createOpenAiTranslator', () => {
       context: 'main.json: greeting',
       source: 'Hello {name}',
       preserve: ['{name}']
+    },
+    {
+      id: '2',
+      context: 'main.json: farewell',
+      source: 'Goodbye {name}',
+      preserve: ['{name}']
     }
   ]
 
-  const completion = (content: string, finishReason = 'stop') =>
+  const completion = (
+    content: string,
+    finishReason = 'stop',
+    usage?: OpenAI.CompletionUsage
+  ) =>
     new Response(
       JSON.stringify({
-        choices: [{ finish_reason: finishReason, message: { content } }]
+        choices: [{ finish_reason: finishReason, message: { content } }],
+        usage
       }),
       { status: 200, headers: { 'content-type': 'application/json' } }
     )
 
-  function translatorFor(responses: Response[]) {
+  function translatorFor(
+    responses: Response[],
+    onCompletion?: (completion: OpenAI.ChatCompletion) => void
+  ) {
     let calls = 0
-    const fetchFn: typeof fetch = async () => {
+    const requestBodies: string[] = []
+    const fetchFn: typeof fetch = async (_input, init) => {
+      if (typeof init?.body !== 'string') {
+        throw new Error('expected a JSON request body')
+      }
+      requestBodies.push(init.body)
       calls++
       return responses[calls - 1]
     }
@@ -527,20 +547,83 @@ describe('createOpenAiTranslator', () => {
       model: 'test-model',
       reasoningEffort: 'low',
       glossary: '',
-      fetchFn
+      fetchFn,
+      onCompletion
     })
-    return { translate, callCount: () => calls }
+    return { translate, callCount: () => calls, requestBodies }
   }
 
-  it('retries truncated responses instead of failing on the partial JSON', async () => {
-    const { translate, callCount } = translatorFor([
+  it('splits a truncated batch instead of retrying it unchanged', async () => {
+    const { translate, callCount, requestBodies } = translatorFor([
       completion('{"1": "Bonj', 'length'),
-      completion('{"1": "Bonjour {name}"}')
+      completion('{"1": "Bonjour {name}"}'),
+      completion('{"2": "Au revoir {name}"}')
     ])
     await expect(translate(locale, items)).resolves.toEqual({
-      '1': 'Bonjour {name}'
+      '1': 'Bonjour {name}',
+      '2': 'Au revoir {name}'
     })
-    expect(callCount()).toBe(2)
+    expect(callCount()).toBe(3)
+    expect(requestBodies[1].length).toBeLessThan(requestBodies[0].length)
+    expect(requestBodies[2].length).toBeLessThan(requestBodies[0].length)
+    expect(requestBodies[1]).toContain('main.json: greeting')
+    expect(requestBodies[1]).not.toContain('main.json: farewell')
+    expect(requestBodies[2]).not.toContain('main.json: greeting')
+    expect(requestBodies[2]).toContain('main.json: farewell')
+  })
+
+  it('does not retry a truncated single-item batch', async () => {
+    const { translate, callCount } = translatorFor([
+      completion('{"1": "Bonj', 'length')
+    ])
+    await expect(translate(locale, items.slice(0, 1))).rejects.toThrow(
+      'OpenAI response was truncated'
+    )
+    expect(callCount()).toBe(1)
+  })
+
+  it('reports non-string response values with their ids', async () => {
+    const malformed = () => completion('{"1": {"text": "Bonjour"}, "2": 42}')
+    const { translate, callCount } = translatorFor([
+      malformed(),
+      malformed(),
+      malformed(),
+      malformed()
+    ])
+    await expect(translate(locale, items)).rejects.toThrow(
+      'translation response has non-string values for ids: 1, 2'
+    )
+    expect(callCount()).toBe(4)
+  })
+
+  it('reports usage for every completed API request', async () => {
+    const totalTokens: number[] = []
+    const onCompletion = vi.fn((response: OpenAI.ChatCompletion) => {
+      if (response.usage) totalTokens.push(response.usage.total_tokens)
+    })
+    const { translate } = translatorFor(
+      [
+        completion('{"1": "Bonj', 'length', {
+          completion_tokens: 4,
+          prompt_tokens: 10,
+          total_tokens: 14
+        }),
+        completion('{"1": "Bonjour {name}"}', 'stop', {
+          completion_tokens: 5,
+          prompt_tokens: 7,
+          total_tokens: 12
+        }),
+        completion('{"2": "Au revoir {name}"}', 'stop', {
+          completion_tokens: 6,
+          prompt_tokens: 8,
+          total_tokens: 14
+        })
+      ],
+      onCompletion
+    )
+    await translate(locale, items)
+    expect(onCompletion).toHaveBeenCalledTimes(3)
+    expect(totalTokens).toEqual([14, 12, 14])
   })
 
   it('fails immediately on non-retryable statuses', async () => {

--- a/scripts/i18n/update-locales.test.ts
+++ b/scripts/i18n/update-locales.test.ts
@@ -20,6 +20,7 @@ import type { TranslateBatch, TranslationItem } from './translate'
 import {
   chunkItems,
   createOpenAiTranslator,
+  createRequestBudget,
   mapWithConcurrency,
   translateLocaleItems
 } from './translate'
@@ -533,7 +534,7 @@ describe('createOpenAiTranslator', () => {
     overrides: Partial<
       Pick<
         Parameters<typeof createOpenAiTranslator>[0],
-        'maxTruncationSplitDepth' | 'onCompletion' | 'onRequest'
+        'maxTruncationSplitDepth' | 'onCompletion'
       >
     > = {}
   ) {
@@ -609,19 +610,32 @@ describe('createOpenAiTranslator', () => {
     expect(callCount()).toBe(0)
   })
 
-  it('does not send a request once onRequest rejects the spend', async () => {
-    const { translate, callCount } = translatorFor(
-      [completion('{"1": "Bonjour {name}"}')],
-      {
-        onRequest: () => {
-          throw new Error('request budget exhausted')
-        }
+  it('holds the request budget across the SDK network retries', async () => {
+    let networkCalls = 0
+    const budget = createRequestBudget(
+      1,
+      'over the request budget',
+      async () => {
+        networkCalls++
+        throw new Error('socket hang up')
       }
     )
+    const translate = createOpenAiTranslator({
+      apiKey: 'key',
+      model: 'test-model',
+      reasoningEffort: 'low',
+      glossary: '',
+      maxTruncationSplitDepth: 3,
+      fetchFn: budget.fetch,
+      signal: budget.signal
+    })
+    // Without the abort the SDK retries the attempt admitted at the boundary,
+    // spending maxNetworkRetries more requests past the ceiling
     await expect(translate(locale, items)).rejects.toThrow(
-      'request budget exhausted'
+      'over the request budget'
     )
-    expect(callCount()).toBe(0)
+    expect(budget.requestCount()).toBe(1)
+    expect(networkCalls).toBe(1)
   })
 
   it('drops non-string values instead of failing the whole batch', async () => {

--- a/scripts/i18n/update-locales.test.ts
+++ b/scripts/i18n/update-locales.test.ts
@@ -582,18 +582,23 @@ describe('createOpenAiTranslator', () => {
     expect(callCount()).toBe(1)
   })
 
-  it('reports non-string response values with their ids', async () => {
-    const malformed = () => completion('{"1": {"text": "Bonjour"}, "2": 42}')
+  it('drops non-string values instead of failing the whole batch', async () => {
     const { translate, callCount } = translatorFor([
-      malformed(),
-      malformed(),
-      malformed(),
-      malformed()
+      completion('{"1": "Bonjour {name}", "2": 42}')
     ])
-    await expect(translate(locale, items)).rejects.toThrow(
-      'translation response has non-string values for ids: 1, 2'
-    )
-    expect(callCount()).toBe(4)
+    await expect(translate(locale, items)).resolves.toEqual({
+      '1': 'Bonjour {name}'
+    })
+    expect(callCount()).toBe(1)
+  })
+
+  it('stops after one retry on a malformed response', async () => {
+    const { translate, callCount } = translatorFor([
+      completion('not json'),
+      completion('not json')
+    ])
+    await expect(translate(locale, items)).rejects.toThrow()
+    expect(callCount()).toBe(2)
   })
 
   it('reports usage for every completed API request', async () => {

--- a/scripts/i18n/update-locales.test.ts
+++ b/scripts/i18n/update-locales.test.ts
@@ -530,7 +530,12 @@ describe('createOpenAiTranslator', () => {
 
   function translatorFor(
     responses: Response[],
-    onCompletion?: (completion: OpenAI.ChatCompletion) => void
+    overrides: Partial<
+      Pick<
+        Parameters<typeof createOpenAiTranslator>[0],
+        'maxTruncationSplitDepth' | 'onCompletion' | 'onRequest'
+      >
+    > = {}
   ) {
     let calls = 0
     const requestBodies: string[] = []
@@ -547,8 +552,9 @@ describe('createOpenAiTranslator', () => {
       model: 'test-model',
       reasoningEffort: 'low',
       glossary: '',
+      maxTruncationSplitDepth: 3,
       fetchFn,
-      onCompletion
+      ...overrides
     })
     return { translate, callCount: () => calls, requestBodies }
   }
@@ -564,22 +570,58 @@ describe('createOpenAiTranslator', () => {
       '2': 'Au revoir {name}'
     })
     expect(callCount()).toBe(3)
-    expect(requestBodies[1].length).toBeLessThan(requestBodies[0].length)
-    expect(requestBodies[2].length).toBeLessThan(requestBodies[0].length)
     expect(requestBodies[1]).toContain('main.json: greeting')
     expect(requestBodies[1]).not.toContain('main.json: farewell')
     expect(requestBodies[2]).not.toContain('main.json: greeting')
     expect(requestBodies[2]).toContain('main.json: farewell')
   })
 
-  it('does not retry a truncated single-item batch', async () => {
+  it('names the string that a truncated single-item batch could not fit', async () => {
     const { translate, callCount } = translatorFor([
       completion('{"1": "Bonj', 'length')
     ])
     await expect(translate(locale, items.slice(0, 1))).rejects.toThrow(
-      'OpenAI response was truncated'
+      'main.json: greeting'
     )
     expect(callCount()).toBe(1)
+  })
+
+  it('stops splitting a batch that keeps truncating at the split depth', async () => {
+    const wide = ['a', 'b', 'c', 'd'].map((name, index) => ({
+      id: String(index),
+      context: `main.json: ${name}`,
+      source: name,
+      preserve: []
+    }))
+    const { translate, callCount } = translatorFor(
+      Array.from({ length: 8 }, () => completion('{"0": "Bonj', 'length')),
+      { maxTruncationSplitDepth: 1 }
+    )
+    await expect(translate(locale, wide)).rejects.toThrow(
+      '2 strings still do not fit at maxTruncationSplitDepth 1'
+    )
+    expect(callCount()).toBe(2)
+  })
+
+  it('translates an empty batch without calling the API', async () => {
+    const { translate, callCount } = translatorFor([])
+    await expect(translate(locale, [])).resolves.toEqual({})
+    expect(callCount()).toBe(0)
+  })
+
+  it('does not send a request once onRequest rejects the spend', async () => {
+    const { translate, callCount } = translatorFor(
+      [completion('{"1": "Bonjour {name}"}')],
+      {
+        onRequest: () => {
+          throw new Error('request budget exhausted')
+        }
+      }
+    )
+    await expect(translate(locale, items)).rejects.toThrow(
+      'request budget exhausted'
+    )
+    expect(callCount()).toBe(0)
   })
 
   it('drops non-string values instead of failing the whole batch', async () => {
@@ -624,7 +666,7 @@ describe('createOpenAiTranslator', () => {
           total_tokens: 14
         })
       ],
-      onCompletion
+      { onCompletion }
     )
     await translate(locale, items)
     expect(onCompletion).toHaveBeenCalledTimes(3)

--- a/scripts/i18n/update-locales.test.ts
+++ b/scripts/i18n/update-locales.test.ts
@@ -577,6 +577,18 @@ describe('createOpenAiTranslator', () => {
     expect(requestBodies[2]).toContain('main.json: farewell')
   })
 
+  it('drops a sibling id leaked into a split response', async () => {
+    const { translate, callCount } = translatorFor([
+      completion('{"1": "Bonj', 'length'),
+      completion('{"1": "Bonjour {name}", "2": "stray"}'),
+      completion('{}')
+    ])
+    await expect(translate(locale, items)).resolves.toEqual({
+      '1': 'Bonjour {name}'
+    })
+    expect(callCount()).toBe(3)
+  })
+
   it('names the string that a truncated single-item batch could not fit', async () => {
     const { translate, callCount } = translatorFor([
       completion('{"1": "Bonj', 'length')

--- a/scripts/i18n/update-locales.test.ts
+++ b/scripts/i18n/update-locales.test.ts
@@ -4,7 +4,7 @@
  * @vitest-environment node
  */
 import type { OpenAI } from 'openai'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { OutputLocale } from './config'
 import type { LocaleObject } from './locale-tree'
@@ -20,14 +20,15 @@ import type { TranslateBatch, TranslationItem } from './translate'
 import {
   chunkItems,
   createOpenAiTranslator,
-  createRequestBudget,
+  createRequestCounter,
   mapWithConcurrency,
   translateLocaleItems
 } from './translate'
 import {
   assembleLeafTranslations,
   buildTranslationItems,
-  formatPruneSummary
+  formatPruneSummary,
+  formatUsageSummary
 } from './update-locales'
 
 const locale: OutputLocale = { code: 'xx', name: 'Test Language' }
@@ -500,6 +501,28 @@ describe('formatPruneSummary', () => {
   })
 })
 
+describe('formatUsageSummary', () => {
+  it('sums usage across completions and tolerates missing fields', () => {
+    expect(
+      formatUsageSummary(
+        [
+          {
+            prompt_tokens: 10,
+            completion_tokens: 4,
+            total_tokens: 14,
+            completion_tokens_details: { reasoning_tokens: 2 }
+          },
+          undefined,
+          { total_tokens: 100 }
+        ],
+        7
+      )
+    ).toBe(
+      'OpenAI usage: 7 HTTP requests for 3 completions; 10 input, 4 output (2 reasoning), 114 total tokens.'
+    )
+  })
+})
+
 describe('createOpenAiTranslator', () => {
   const items: TranslationItem[] = [
     {
@@ -529,8 +552,12 @@ describe('createOpenAiTranslator', () => {
       { status: 200, headers: { 'content-type': 'application/json' } }
     )
 
+  beforeEach(() => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
   function translatorFor(
-    responses: Response[],
+    respond: Response[] | ((body: string, call: number) => Response),
     overrides: Partial<
       Pick<
         Parameters<typeof createOpenAiTranslator>[0],
@@ -546,7 +573,13 @@ describe('createOpenAiTranslator', () => {
       }
       requestBodies.push(init.body)
       calls++
-      return responses[calls - 1]
+      const response = Array.isArray(respond)
+        ? respond[calls - 1]
+        : respond(init.body, calls)
+      if (!response) {
+        throw new Error(`no scripted response for request ${calls}`)
+      }
+      return response
     }
     const translate = createOpenAiTranslator({
       apiKey: 'key',
@@ -560,46 +593,50 @@ describe('createOpenAiTranslator', () => {
     return { translate, callCount: () => calls, requestBodies }
   }
 
-  it('splits a truncated batch instead of retrying it unchanged', async () => {
-    const { translate, callCount, requestBodies } = translatorFor([
-      completion('{"1": "Bonj', 'length'),
-      completion('{"1": "Bonjour {name}"}'),
-      completion('{"2": "Au revoir {name}"}')
-    ])
+  it('splits a truncated batch and scopes each half to its own items', async () => {
+    const { translate, callCount, requestBodies } = translatorFor(
+      (body, call) => {
+        if (call === 1) return completion('{"1": "Bonj', 'length')
+        return body.includes('main.json: greeting')
+          ? completion('{"1": "Bonjour {name}", "2": "stray"}')
+          : completion('{"2": "Au revoir {name}"}')
+      }
+    )
     await expect(translate(locale, items)).resolves.toEqual({
       '1': 'Bonjour {name}',
       '2': 'Au revoir {name}'
     })
     expect(callCount()).toBe(3)
-    expect(requestBodies[1]).toContain('main.json: greeting')
-    expect(requestBodies[1]).not.toContain('main.json: farewell')
-    expect(requestBodies[2]).not.toContain('main.json: greeting')
-    expect(requestBodies[2]).toContain('main.json: farewell')
+    const halves = requestBodies.slice(1)
+    expect(
+      halves.some(
+        (body) =>
+          body.includes('main.json: greeting') &&
+          !body.includes('main.json: farewell')
+      )
+    ).toBe(true)
+    expect(
+      halves.some(
+        (body) =>
+          body.includes('main.json: farewell') &&
+          !body.includes('main.json: greeting')
+      )
+    ).toBe(true)
   })
 
-  it('drops a sibling id leaked into a split response', async () => {
+  it('defers a single string whose translation keeps truncating', async () => {
     const { translate, callCount } = translatorFor([
       completion('{"1": "Bonj', 'length'),
-      completion('{"1": "Bonjour {name}", "2": "stray"}'),
-      completion('{}')
-    ])
-    await expect(translate(locale, items)).resolves.toEqual({
-      '1': 'Bonjour {name}'
-    })
-    expect(callCount()).toBe(3)
-  })
-
-  it('names the string that a truncated single-item batch could not fit', async () => {
-    const { translate, callCount } = translatorFor([
       completion('{"1": "Bonj', 'length')
     ])
-    await expect(translate(locale, items.slice(0, 1))).rejects.toThrow(
-      'main.json: greeting'
+    await expect(translate(locale, items.slice(0, 1))).resolves.toEqual({})
+    expect(callCount()).toBe(2)
+    expect(console.warn).toHaveBeenCalledWith(
+      expect.stringContaining('main.json: greeting')
     )
-    expect(callCount()).toBe(1)
   })
 
-  it('stops splitting a batch that keeps truncating at the split depth', async () => {
+  it('defers a batch that keeps truncating at the split depth', async () => {
     const wide = ['a', 'b', 'c', 'd'].map((name, index) => ({
       id: String(index),
       context: `main.json: ${name}`,
@@ -610,44 +647,18 @@ describe('createOpenAiTranslator', () => {
       Array.from({ length: 8 }, () => completion('{"0": "Bonj', 'length')),
       { maxTruncationSplitDepth: 1 }
     )
-    await expect(translate(locale, wide)).rejects.toThrow(
-      '2 strings still do not fit at maxTruncationSplitDepth 1'
+    await expect(translate(locale, wide)).resolves.toEqual({})
+    expect(callCount()).toBe(3)
+    expect(console.warn).toHaveBeenCalledWith(
+      expect.stringContaining('maxTruncationSplitDepth 1')
     )
-    expect(callCount()).toBe(2)
   })
 
-  it('translates an empty batch without calling the API', async () => {
-    const { translate, callCount } = translatorFor([])
-    await expect(translate(locale, [])).resolves.toEqual({})
-    expect(callCount()).toBe(0)
-  })
-
-  it('holds the request budget across the SDK network retries', async () => {
-    let networkCalls = 0
-    const budget = createRequestBudget(
-      1,
-      'over the request budget',
-      async () => {
-        networkCalls++
-        throw new Error('socket hang up')
-      }
-    )
-    const translate = createOpenAiTranslator({
-      apiKey: 'key',
-      model: 'test-model',
-      reasoningEffort: 'low',
-      glossary: '',
-      maxTruncationSplitDepth: 3,
-      fetchFn: budget.fetch,
-      signal: budget.signal
-    })
-    // Without the abort the SDK retries the attempt admitted at the boundary,
-    // spending maxNetworkRetries more requests past the ceiling
-    await expect(translate(locale, items)).rejects.toThrow(
-      'over the request budget'
-    )
-    expect(budget.requestCount()).toBe(1)
-    expect(networkCalls).toBe(1)
+  it('counts every request made through the counting fetch', async () => {
+    const counter = createRequestCounter(async () => completion('{}'))
+    await counter.fetch('https://example.test')
+    await counter.fetch('https://example.test')
+    expect(counter.requestCount()).toBe(2)
   })
 
   it('drops non-string values instead of failing the whole batch', async () => {
@@ -660,13 +671,16 @@ describe('createOpenAiTranslator', () => {
     expect(callCount()).toBe(1)
   })
 
-  it('stops after one retry on a malformed response', async () => {
+  it('defers the batch after one retry on a malformed response', async () => {
     const { translate, callCount } = translatorFor([
       completion('not json'),
       completion('not json')
     ])
-    await expect(translate(locale, items)).rejects.toThrow()
+    await expect(translate(locale, items)).resolves.toEqual({})
     expect(callCount()).toBe(2)
+    expect(console.warn).toHaveBeenCalledWith(
+      expect.stringContaining('not valid JSON')
+    )
   })
 
   it('reports usage for every completed API request', async () => {
@@ -675,28 +689,31 @@ describe('createOpenAiTranslator', () => {
       if (response.usage) totalTokens.push(response.usage.total_tokens)
     })
     const { translate } = translatorFor(
-      [
-        completion('{"1": "Bonj', 'length', {
-          completion_tokens: 4,
-          prompt_tokens: 10,
-          total_tokens: 14
-        }),
-        completion('{"1": "Bonjour {name}"}', 'stop', {
-          completion_tokens: 5,
-          prompt_tokens: 7,
-          total_tokens: 12
-        }),
-        completion('{"2": "Au revoir {name}"}', 'stop', {
-          completion_tokens: 6,
-          prompt_tokens: 8,
-          total_tokens: 14
-        })
-      ],
+      (body, call) => {
+        if (call === 1)
+          return completion('{"1": "Bonj', 'length', {
+            completion_tokens: 4,
+            prompt_tokens: 10,
+            total_tokens: 14
+          })
+        return body.includes('main.json: greeting')
+          ? completion('{"1": "Bonjour {name}"}', 'stop', {
+              completion_tokens: 5,
+              prompt_tokens: 7,
+              total_tokens: 12
+            })
+          : completion('{"2": "Au revoir {name}"}', 'stop', {
+              completion_tokens: 6,
+              prompt_tokens: 8,
+              total_tokens: 14
+            })
+      },
       { onCompletion }
     )
     await translate(locale, items)
     expect(onCompletion).toHaveBeenCalledTimes(3)
-    expect(totalTokens).toEqual([14, 12, 14])
+    expect(totalTokens[0]).toBe(14)
+    expect(totalTokens.slice(1).sort((a, b) => a - b)).toEqual([12, 14])
   })
 
   it('fails immediately on non-retryable statuses', async () => {

--- a/scripts/i18n/update-locales.ts
+++ b/scripts/i18n/update-locales.ts
@@ -11,6 +11,8 @@ import {
 import { dirname, join, relative, resolve } from 'node:path'
 import { fileURLToPath, pathToFileURL } from 'node:url'
 
+import type { OpenAI } from 'openai'
+
 import type { OutputLocale, TranslationPipelineConfig } from './config'
 import { translationPipelineConfig } from './config'
 import type {
@@ -40,7 +42,7 @@ import type { TranslateBatch, TranslationItem } from './translate'
 import {
   chunkItems,
   createOpenAiTranslator,
-  createRequestBudget,
+  createRequestCounter,
   mapWithConcurrency,
   translateLocaleItems
 } from './translate'
@@ -329,6 +331,24 @@ function print(line: string): void {
   process.stdout.write(`${line}\n`)
 }
 
+export function formatUsageSummary(
+  usages: ReadonlyArray<Partial<OpenAI.CompletionUsage> | undefined>,
+  requestCount: number
+): string {
+  let promptTokens = 0
+  let completionTokens = 0
+  let reasoningTokens = 0
+  let totalTokens = 0
+  for (const usage of usages) {
+    if (!usage) continue
+    promptTokens += usage.prompt_tokens ?? 0
+    completionTokens += usage.completion_tokens ?? 0
+    reasoningTokens += usage.completion_tokens_details?.reasoning_tokens ?? 0
+    totalTokens += usage.total_tokens ?? 0
+  }
+  return `OpenAI usage: ${requestCount} HTTP requests for ${usages.length} completions; ${promptTokens} input, ${completionTokens} output (${reasoningTokens} reasoning), ${totalTokens} total tokens.`
+}
+
 function reportCheck(states: readonly LocaleFileState[]): number {
   let pendingTotal = 0
   let strayTotal = 0
@@ -437,16 +457,6 @@ async function run(argv: readonly string[]): Promise<void> {
   const states = loadLocaleFileStates(config, outputDir, plans)
   const orphans = orphanedOutputFiles(outputDir, config, filenames)
 
-  if (check) {
-    for (const orphan of orphans) {
-      print(
-        `${relative(repoRoot, orphan)}: the English source file was removed; this locale file will be deleted`
-      )
-    }
-    process.exitCode = reportCheck(states)
-    return
-  }
-
   const translationPlans = new Map(
     states.map((state) => [
       state,
@@ -479,41 +489,34 @@ async function run(argv: readonly string[]): Promise<void> {
     )
   }
 
+  if (check) {
+    for (const orphan of orphans) {
+      print(
+        `${relative(repoRoot, orphan)}: the English source file was removed; this locale file will be deleted`
+      )
+    }
+    process.exitCode = reportCheck(states)
+    return
+  }
+
   const apiKey = process.env.OPENAI_API_KEY
   if (pendingTotal > 0 && !apiKey) {
     throw new Error(
       `${pendingTotal} strings need translation but OPENAI_API_KEY is not set.`
     )
   }
-  const usage = {
-    completions: 0,
-    completionTokens: 0,
-    promptTokens: 0,
-    reasoningTokens: 0,
-    totalTokens: 0
-  }
-  const maxRequests = initialBatchCount * config.requestBudgetMultiplier
-  const budget = createRequestBudget(
-    maxRequests,
-    `Stopped at the budget of ${maxRequests} HTTP requests for ${initialBatchCount} initial batches (requestBudgetMultiplier ${config.requestBudgetMultiplier}); raise it, or lower maxItemsPerRequest so batches translate without splitting.`
-  )
+  const completionUsages: (OpenAI.CompletionUsage | undefined)[] = []
+  const counter = createRequestCounter()
   const translateBatch: TranslateBatch = apiKey
     ? createOpenAiTranslator({
         apiKey,
-        fetchFn: budget.fetch,
-        signal: budget.signal,
+        fetchFn: counter.fetch,
         model: config.model,
         reasoningEffort: config.reasoningEffort,
         glossary: config.glossary,
         maxTruncationSplitDepth: config.maxTruncationSplitDepth,
         onCompletion: (completion) => {
-          usage.completions++
-          if (!completion.usage) return
-          usage.completionTokens += completion.usage.completion_tokens
-          usage.promptTokens += completion.usage.prompt_tokens
-          usage.reasoningTokens +=
-            completion.usage.completion_tokens_details?.reasoning_tokens ?? 0
-          usage.totalTokens += completion.usage.total_tokens
+          completionUsages.push(completion.usage)
         }
       })
     : async () => {
@@ -562,10 +565,8 @@ async function run(argv: readonly string[]): Promise<void> {
     }
   )
 
-  if (budget.requestCount() > 0) {
-    print(
-      `OpenAI usage: ${budget.requestCount()} HTTP requests for ${usage.completions} completions; ${usage.promptTokens} input, ${usage.completionTokens} output (${usage.reasoningTokens} reasoning), ${usage.totalTokens} total tokens.`
-    )
+  if (counter.requestCount() > 0) {
+    print(formatUsageSummary(completionUsages, counter.requestCount()))
   }
 
   const failuresByFile = new Map<string, string[]>()

--- a/scripts/i18n/update-locales.ts
+++ b/scripts/i18n/update-locales.ts
@@ -38,6 +38,7 @@ import {
 } from './protected-tokens'
 import type { TranslateBatch, TranslationItem } from './translate'
 import {
+  chunkItems,
   createOpenAiTranslator,
   mapWithConcurrency,
   translateLocaleItems
@@ -455,6 +456,21 @@ async function run(argv: readonly string[]): Promise<void> {
     (count, plan) => count + plan.items.length,
     0
   )
+  const initialBatchCount = [...translationPlans.values()].reduce(
+    (count, plan) =>
+      count +
+      chunkItems(
+        plan.items,
+        config.maxItemsPerRequest,
+        config.maxSourceCharsPerRequest
+      ).length,
+    0
+  )
+  if (pendingTotal > 0) {
+    print(
+      `Translation preflight: ${pendingTotal} strings in ${initialBatchCount} initial batches across ${config.outputLocales.length} locales; retries and truncation splits can add requests.`
+    )
+  }
 
   const apiKey = process.env.OPENAI_API_KEY
   if (pendingTotal > 0 && !apiKey) {
@@ -462,12 +478,32 @@ async function run(argv: readonly string[]): Promise<void> {
       `${pendingTotal} strings need translation but OPENAI_API_KEY is not set.`
     )
   }
+  const usage = {
+    completionTokens: 0,
+    promptTokens: 0,
+    reasoningTokens: 0,
+    requests: 0,
+    totalTokens: 0
+  }
+  const countedFetch: typeof fetch = async (input, init) => {
+    usage.requests++
+    return fetch(input, init)
+  }
   const translateBatch: TranslateBatch = apiKey
     ? createOpenAiTranslator({
         apiKey,
+        fetchFn: countedFetch,
         model: config.model,
         reasoningEffort: config.reasoningEffort,
-        glossary: config.glossary
+        glossary: config.glossary,
+        onCompletion: (completion) => {
+          if (!completion.usage) return
+          usage.completionTokens += completion.usage.completion_tokens
+          usage.promptTokens += completion.usage.prompt_tokens
+          usage.reasoningTokens +=
+            completion.usage.completion_tokens_details?.reasoning_tokens ?? 0
+          usage.totalTokens += completion.usage.total_tokens
+        }
       })
     : async () => {
         throw new Error('No translator available')
@@ -475,7 +511,7 @@ async function run(argv: readonly string[]): Promise<void> {
 
   const outcomes = await mapWithConcurrency(
     states,
-    config.localeConcurrency,
+    config.stateConcurrency,
     async (
       state
     ): Promise<
@@ -588,6 +624,12 @@ async function run(argv: readonly string[]): Promise<void> {
       })
     )
   )
+
+  if (usage.requests > 0) {
+    print(
+      `OpenAI usage: ${usage.requests} HTTP requests; ${usage.promptTokens} input, ${usage.completionTokens} output (${usage.reasoningTokens} reasoning), ${usage.totalTokens} total tokens.`
+    )
+  }
 
   if (failuresByFile.size > 0) {
     const details = [...failuresByFile.values()].flat()

--- a/scripts/i18n/update-locales.ts
+++ b/scripts/i18n/update-locales.ts
@@ -456,8 +456,11 @@ async function run(argv: readonly string[]): Promise<void> {
     (count, plan) => count + plan.items.length,
     0
   )
-  const initialBatchCount = [...translationPlans.values()].reduce(
-    (count, plan) =>
+  const pendingPlans = [...translationPlans].filter(
+    ([, plan]) => plan.items.length > 0
+  )
+  const initialBatchCount = pendingPlans.reduce(
+    (count, [, plan]) =>
       count +
       chunkItems(
         plan.items,
@@ -466,9 +469,12 @@ async function run(argv: readonly string[]): Promise<void> {
       ).length,
     0
   )
+  const pendingLocaleCount = new Set(
+    pendingPlans.map(([state]) => state.locale.code)
+  ).size
   if (pendingTotal > 0) {
     print(
-      `Translation preflight: ${pendingTotal} strings in ${initialBatchCount} initial batches across ${config.outputLocales.length} locales; retries and truncation splits can add requests.`
+      `Translation preflight: ${pendingTotal} strings in ${initialBatchCount} initial batches across ${pendingLocaleCount} locales; retries and truncation splits can add requests.`
     )
   }
 

--- a/scripts/i18n/update-locales.ts
+++ b/scripts/i18n/update-locales.ts
@@ -40,6 +40,7 @@ import type { TranslateBatch, TranslationItem } from './translate'
 import {
   chunkItems,
   createOpenAiTranslator,
+  createRequestBudget,
   mapWithConcurrency,
   translateLocaleItems
 } from './translate'
@@ -489,28 +490,22 @@ async function run(argv: readonly string[]): Promise<void> {
     completionTokens: 0,
     promptTokens: 0,
     reasoningTokens: 0,
-    requests: 0,
     totalTokens: 0
   }
-  const requestBudget = initialBatchCount * config.requestBudgetMultiplier
-  const countedFetch: typeof fetch = async (input, init) => {
-    usage.requests++
-    return fetch(input, init)
-  }
+  const maxRequests = initialBatchCount * config.requestBudgetMultiplier
+  const budget = createRequestBudget(
+    maxRequests,
+    `Stopped at the budget of ${maxRequests} HTTP requests for ${initialBatchCount} initial batches (requestBudgetMultiplier ${config.requestBudgetMultiplier}); raise it, or lower maxItemsPerRequest so batches translate without splitting.`
+  )
   const translateBatch: TranslateBatch = apiKey
     ? createOpenAiTranslator({
         apiKey,
-        fetchFn: countedFetch,
+        fetchFn: budget.fetch,
+        signal: budget.signal,
         model: config.model,
         reasoningEffort: config.reasoningEffort,
         glossary: config.glossary,
         maxTruncationSplitDepth: config.maxTruncationSplitDepth,
-        onRequest: () => {
-          if (usage.requests < requestBudget) return
-          throw new Error(
-            `Stopped after ${usage.requests} HTTP requests, the budget for ${initialBatchCount} initial batches (requestBudgetMultiplier ${config.requestBudgetMultiplier}). Raise it, or lower maxItemsPerRequest so batches translate without splitting.`
-          )
-        },
         onCompletion: (completion) => {
           usage.completions++
           if (!completion.usage) return
@@ -567,9 +562,9 @@ async function run(argv: readonly string[]): Promise<void> {
     }
   )
 
-  if (usage.requests > 0) {
+  if (budget.requestCount() > 0) {
     print(
-      `OpenAI usage: ${usage.requests} HTTP requests for ${usage.completions} completions; ${usage.promptTokens} input, ${usage.completionTokens} output (${usage.reasoningTokens} reasoning), ${usage.totalTokens} total tokens.`
+      `OpenAI usage: ${budget.requestCount()} HTTP requests for ${usage.completions} completions; ${usage.promptTokens} input, ${usage.completionTokens} output (${usage.reasoningTokens} reasoning), ${usage.totalTokens} total tokens.`
     )
   }
 

--- a/scripts/i18n/update-locales.ts
+++ b/scripts/i18n/update-locales.ts
@@ -485,12 +485,14 @@ async function run(argv: readonly string[]): Promise<void> {
     )
   }
   const usage = {
+    completions: 0,
     completionTokens: 0,
     promptTokens: 0,
     reasoningTokens: 0,
     requests: 0,
     totalTokens: 0
   }
+  const requestBudget = initialBatchCount * config.requestBudgetMultiplier
   const countedFetch: typeof fetch = async (input, init) => {
     usage.requests++
     return fetch(input, init)
@@ -502,7 +504,15 @@ async function run(argv: readonly string[]): Promise<void> {
         model: config.model,
         reasoningEffort: config.reasoningEffort,
         glossary: config.glossary,
+        maxTruncationSplitDepth: config.maxTruncationSplitDepth,
+        onRequest: () => {
+          if (usage.requests < requestBudget) return
+          throw new Error(
+            `Stopped after ${usage.requests} HTTP requests, the budget for ${initialBatchCount} initial batches (requestBudgetMultiplier ${config.requestBudgetMultiplier}). Raise it, or lower maxItemsPerRequest so batches translate without splitting.`
+          )
+        },
         onCompletion: (completion) => {
+          usage.completions++
           if (!completion.usage) return
           usage.completionTokens += completion.usage.completion_tokens
           usage.promptTokens += completion.usage.prompt_tokens
@@ -517,7 +527,7 @@ async function run(argv: readonly string[]): Promise<void> {
 
   const outcomes = await mapWithConcurrency(
     states,
-    config.stateConcurrency,
+    config.localeFileConcurrency,
     async (
       state
     ): Promise<
@@ -556,6 +566,12 @@ async function run(argv: readonly string[]): Promise<void> {
       }
     }
   )
+
+  if (usage.requests > 0) {
+    print(
+      `OpenAI usage: ${usage.requests} HTTP requests for ${usage.completions} completions; ${usage.promptTokens} input, ${usage.completionTokens} output (${usage.reasoningTokens} reasoning), ${usage.totalTokens} total tokens.`
+    )
+  }
 
   const failuresByFile = new Map<string, string[]>()
   function addFailure(filename: string, message: string): void {
@@ -630,12 +646,6 @@ async function run(argv: readonly string[]): Promise<void> {
       })
     )
   )
-
-  if (usage.requests > 0) {
-    print(
-      `OpenAI usage: ${usage.requests} HTTP requests; ${usage.promptTokens} input, ${usage.completionTokens} output (${usage.reasoningTokens} reasoning), ${usage.totalTokens} total tokens.`
-    )
-  }
 
   if (failuresByFile.size > 0) {
     const details = [...failuresByFile.values()].flat()


### PR DESCRIPTION
## Summary

Harden the OpenAI translation client contract: recover from truncated batches by splitting instead of resending, defer content-level failures to the retry rounds instead of failing the locale file, and report actual request/token usage.

## Changes

- **What**: Derive reasoning effort from the SDK, split truncated batches by size and retry deferred items through the round loop, and report initial batches, HTTP requests, completions, and token usage.

Truncated batches (`finish_reason: "length"`) split by both item count and source characters (`chunkItems` with halved limits), so one oversized string is isolated in a single level instead of surviving repeated blind halvings. The halves translate concurrently, and every response is parsed against the ids its request actually carried, so a half that echoes a sibling's id cannot smuggle in a translation produced without that sibling's source.

Content-level failures defer instead of throwing. A single string that keeps truncating, a batch still truncating at `maxTruncationSplitDepth` (3), and malformed responses (unparseable JSON, missing message content) come back as missing items; `translateLocaleItems` re-sends them on the next of its `maxTranslationRounds` (3) rounds — re-chunked, with fresh split depth — and a `console.warn` names what was deferred and why. A string that never fits fails its locale after the rounds with its context in the error. Transport and API errors (401, timeouts, exhausted network retries) still throw and fail fast. Spend is bounded structurally by rounds × attempts × split fan-out, so no separate request budget is needed: an earlier revision held a ceiling by aborting a signal shared across the whole run, which meant one over-budget batch could discard every locale's completed work and rewrite unrelated errors into the budget message — that mechanism is gone.

`mapWithConcurrency` stops dispatching on the first failure, and now also settles every in-flight task before rethrowing it, so no request outlives the pool and the usage line prints only after all spend has landed.

Malformed-response retries drop from 3 to 1. That inner loop re-sends a byte-identical prompt, so repeats past the first are unlikely to change the outcome; every content failure now also gets the round loop's feedback-carrying re-sends, which the previous throw paths bypassed. SDK network retries stay at 3, where retrying an identical request is correct.

The translation preflight (pending strings, initial batches, locales with pending items) prints in `--check` too, so batch counts are reviewable offline before the paid run. The usage line prints right after the translation phase via `formatUsageSummary`, a pure function that tolerates partial usage objects from OpenAI-compatible proxies, and reports completions alongside HTTP requests (counted per attempt by a counting `fetch`) to make SDK retry overhead visible.

`localeConcurrency` is renamed `localeFileConcurrency` after the `LocaleFileState` list it actually maps over.

`parseBatchResponse` keeping valid strings when a response contains a non-string value is unchanged from `main` — the affected ids fall through as missing and are re-sent with a `retryNote` by the existing `translateLocaleItems` rounds: `response_format: { type: 'json_object' }` guarantees parseable JSON, not schema adherence, so `null` and numeric echoes remain possible and that behavior is worth pinning.

Validation:

- `mise exec -- pnpm test:unit scripts/i18n/update-locales.test.ts --run` (29 passed)
- `mise exec -- pnpm typecheck:scripts`
- `mise exec -- pnpm typecheck`
- `mise exec -- pnpm lint`
- `mise exec -- pnpm knip`
- `mise exec -- pnpm format:check`
