### PR TITLE
ci(e2e): record new cloud-only specs under the cloud project

### DIFF
--- a/.github/workflows/ci-tests-e2e.yaml
+++ b/.github/workflows/ci-tests-e2e.yaml
@@ -253,7 +253,10 @@ jobs:
 
           # The chromium project grep-excludes @cloud, and a cloud spec needs
           # the cloud build to run at all, so record those under `cloud`.
-          CLOUD_FILES=$(echo "$NEW_FILES" | xargs -r grep -l '@cloud' || true)
+          CLOUD_FILES=$(echo "$NEW_FILES" | while read -r spec; do
+            [ -n "$spec" ] || continue
+            if grep -q '@cloud' "$spec"; then echo "$spec"; fi
+          done)
           if [ -n "$CLOUD_FILES" ]; then
             RUN_FILES="$CLOUD_FILES"
             echo "project=cloud" >> "$GITHUB_OUTPUT"
@@ -276,7 +279,7 @@ jobs:
           echo "${RUN_FILES:-<none>}"
           if [ -n "$NEW_FILES" ] && [ "$NEW_FILES" != "$RUN_FILES" ]; then
             echo "Not recorded, since one run serves a single build:"
-            comm -23 <(echo "$NEW_FILES" | sort) <(echo "$RUN_FILES" | sort)
+            echo "$NEW_FILES" | grep -vxF "$RUN_FILES" || true
           fi
 
       - name: Download built frontend

--- a/.github/workflows/ci-tests-e2e.yaml
+++ b/.github/workflows/ci-tests-e2e.yaml
@@ -251,20 +251,39 @@ jobs:
             echo "has-new-tests=true" >> "$GITHUB_OUTPUT"
           fi
 
+          # The chromium project grep-excludes @cloud, and a cloud spec needs
+          # the cloud build to run at all, so record those under `cloud`.
+          CLOUD_FILES=$(echo "$NEW_FILES" | xargs -r grep -l '@cloud' || true)
+          if [ -n "$CLOUD_FILES" ]; then
+            RUN_FILES="$CLOUD_FILES"
+            echo "project=cloud" >> "$GITHUB_OUTPUT"
+            echo "dist=frontend-dist-cloud" >> "$GITHUB_OUTPUT"
+          else
+            RUN_FILES="$NEW_FILES"
+            echo "project=chromium" >> "$GITHUB_OUTPUT"
+            echo "dist=frontend-dist" >> "$GITHUB_OUTPUT"
+          fi
+
           {
             echo "files<<EOF_NEW_SPEC_FILES"
-            echo "$NEW_FILES"
+            echo "$RUN_FILES"
             echo "EOF_NEW_SPEC_FILES"
           } >> "$GITHUB_OUTPUT"
 
           echo "Newly-added spec files:"
           echo "${NEW_FILES:-<none>}"
+          echo "Recording:"
+          echo "${RUN_FILES:-<none>}"
+          if [ -n "$NEW_FILES" ] && [ "$NEW_FILES" != "$RUN_FILES" ]; then
+            echo "Not recorded, since one run serves a single build:"
+            comm -23 <(echo "$NEW_FILES" | sort) <(echo "$RUN_FILES" | sort)
+          fi
 
       - name: Download built frontend
         if: steps.detect.outputs.has-new-tests == 'true'
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: frontend-dist
+          name: ${{ steps.detect.outputs.dist }}
           path: dist/
 
       - name: Start ComfyUI server
@@ -283,7 +302,7 @@ jobs:
           NEW_SPEC_FILES: ${{ steps.detect.outputs.files }}
         run: |
           FILES=$(echo "$NEW_SPEC_FILES" | tr '\n' ' ')
-          pnpm exec playwright test --project=chromium $FILES
+          pnpm exec playwright test --project=${{ steps.detect.outputs.project }} $FILES
 
       - name: Upload new-test report (with embedded video)
         if: ${{ !cancelled() && steps.detect.outputs.has-new-tests == 'true' }}

--- a/.github/workflows/ci-tests-e2e.yaml
+++ b/.github/workflows/ci-tests-e2e.yaml
@@ -304,10 +304,15 @@ jobs:
           SLOW_MO: '1000'
           NEW_SPEC_FILES: ${{ steps.detect.outputs.files }}
         run: |
-          FILES=$(echo "$NEW_SPEC_FILES" | tr '\n' ' ')
+          set --
+          while IFS= read -r spec; do
+            if [ -n "$spec" ]; then set -- "$@" "$spec"; fi
+          done <<EOF_SPECS
+          $NEW_SPEC_FILES
+          EOF_SPECS
           # A spec whose tags match no project in this run records nothing.
           # This job is a reviewing aid, so that must not fail the PR.
-          pnpm exec playwright test --project=${{ steps.detect.outputs.project }} --pass-with-no-tests $FILES
+          pnpm exec playwright test --project=${{ steps.detect.outputs.project }} --pass-with-no-tests "$@"
 
       - name: Upload new-test report (with embedded video)
         if: ${{ !cancelled() && steps.detect.outputs.has-new-tests == 'true' }}

--- a/.github/workflows/ci-tests-e2e.yaml
+++ b/.github/workflows/ci-tests-e2e.yaml
@@ -305,7 +305,9 @@ jobs:
           NEW_SPEC_FILES: ${{ steps.detect.outputs.files }}
         run: |
           FILES=$(echo "$NEW_SPEC_FILES" | tr '\n' ' ')
-          pnpm exec playwright test --project=${{ steps.detect.outputs.project }} $FILES
+          # A spec whose tags match no project in this run records nothing.
+          # This job is a reviewing aid, so that must not fail the PR.
+          pnpm exec playwright test --project=${{ steps.detect.outputs.project }} --pass-with-no-tests $FILES
 
       - name: Upload new-test report (with embedded video)
         if: ${{ !cancelled() && steps.detect.outputs.has-new-tests == 'true' }}


### PR DESCRIPTION
`playwright-video-new-tests` runs newly-added specs with `--project=chromium`. That project grep-excludes `@cloud`, so a new cloud-only spec resolves to zero tests and Playwright exits with `Error: No tests found`, failing the job on every such PR. A cloud spec also needs the cloud build to run at all — the OSS `frontend-dist` never starts the first-run tour.

The detect step now reads the tags on the new specs and picks the project and the matching dist artifact. One run serves a single build, so a PR adding both cloud and OSS specs records the cloud ones and logs by name which were not recorded, rather than dropping them silently.

Surfaced by #15092, which is red on this job for exactly this reason.

## Verification

Detect-step logic exercised locally over all four inputs (none / OSS-only / cloud-only / mixed); each selects the expected project, dist, and skip list.