### PR TITLE
ci: remove unused frontend setup from E2E coverage merge

### DIFF
--- a/.github/workflows/ci-tests-e2e-coverage.yaml
+++ b/.github/workflows/ci-tests-e2e-coverage.yaml
@@ -24,11 +24,12 @@ jobs:
       has-coverage: ${{ steps.coverage-shards.outputs.has-coverage }}
 
     steps:
-      - name: Checkout repository
+      - name: Checkout sources for genhtml
         uses: actions/checkout@v7
-
-      - name: Setup frontend
-        uses: ./.github/actions/setup-frontend
+        with:
+          sparse-checkout: |
+            src
+            packages
 
       - name: Download all shard coverage data
         uses: dawidd6/action-download-artifact@0bd50d53a6d7fb5cb921e607957e9cc12b4ce392 # v12


### PR DESCRIPTION
## Summary

Drop the `setup-frontend` step from the E2E coverage merge job. Nothing in that job invokes node or pnpm — the merge steps are `lcov`/`genhtml`, shell builtins, and artifact actions.

## Changes

- **What**: Remove `setup-frontend`. Keep the checkout, scoped to `src` and `packages` via sparse-checkout.
- **Why keep the checkout**: `genhtml` reads those trees to embed source in the HTML report deployed to Pages. `--ignore-errors source --synthesize-missing` means a missing checkout does not fail the job, it silently renders every file as placeholder lines.
- **Validation**: `yaml-lint` on the workflow.

## Impact

~30s off a ~100s job, ~214 runs/day. No dollar cost (public repo, free standard runners) and nothing waits on this job — it runs on `workflow_run` after E2E finishes and is not a required check. This is a legibility fix: `setup-frontend` in a job that never touches the frontend toolchain implies a dependency that is not there.

## Review Focus

Sparse paths match what survives the strip step — the `Assert coverage was mapped back to source` step greps `^SF:(src|packages)/`, and everything else is removed before `genhtml` runs.
