### PR TITLE
ci: reuse merge queue E2E results on push

### DIFF
--- a/.github/workflows/ci-tests-e2e-coverage.yaml
+++ b/.github/workflows/ci-tests-e2e-coverage.yaml
@@ -11,23 +11,52 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
+  actions: read
   contents: read
 
 jobs:
   merge:
     if: >
       github.repository == 'Comfy-Org/ComfyUI_frontend' &&
-      github.event.workflow_run.conclusion == 'success'
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event != 'merge_group'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     outputs:
       has-coverage: ${{ steps.coverage-shards.outputs.has-coverage }}
 
     steps:
+      - name: Select E2E run with coverage
+        id: coverage-run
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          TRIGGERING_EVENT: ${{ github.event.workflow_run.event }}
+          TRIGGERING_RUN_ID: ${{ github.event.workflow_run.id }}
+        run: |
+          run_id="$TRIGGERING_RUN_ID"
+          if [[ "$TRIGGERING_EVENT" == "push" ]]; then
+            if merge_queue_run_id=$(gh api --method GET \
+              "repos/${GH_REPO}/actions/workflows/ci-tests-e2e.yaml/runs" \
+              -f event=merge_group \
+              -f head_sha="$HEAD_SHA" \
+              -f status=success \
+              -F per_page=1 \
+              --jq '.workflow_runs[0].id // empty'); then
+              if [[ -n "$merge_queue_run_id" ]]; then
+                run_id="$merge_queue_run_id"
+              fi
+            else
+              echo "::warning::Could not check prior merge queue runs; using the triggering run"
+            fi
+          fi
+          echo "run-id=$run_id" >> "$GITHUB_OUTPUT"
+
       - name: Download all shard coverage data
         uses: dawidd6/action-download-artifact@0bd50d53a6d7fb5cb921e607957e9cc12b4ce392 # v12
         with:
-          run_id: ${{ github.event.workflow_run.id }}
+          run_id: ${{ steps.coverage-run.outputs.run-id }}
           name: e2e-coverage-shard-.*
           name_is_regexp: true
           path: temp/coverage-shards

--- a/.github/workflows/ci-tests-e2e-coverage.yaml
+++ b/.github/workflows/ci-tests-e2e-coverage.yaml
@@ -24,12 +24,6 @@ jobs:
       has-coverage: ${{ steps.coverage-shards.outputs.has-coverage }}
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v7
-
-      - name: Setup frontend
-        uses: ./.github/actions/setup-frontend
-
       - name: Download all shard coverage data
         uses: dawidd6/action-download-artifact@0bd50d53a6d7fb5cb921e607957e9cc12b4ce392 # v12
         with:

--- a/.github/workflows/ci-tests-e2e.yaml
+++ b/.github/workflows/ci-tests-e2e.yaml
@@ -17,12 +17,37 @@ jobs:
   changes:
     runs-on: ubuntu-latest
     permissions:
+      actions: read
       contents: read
     outputs:
-      should-run: ${{ steps.changes.outputs.should-run }}
+      merge-queue-run-id: ${{ steps.merge-queue-run.outputs.run-id }}
+      should-run: ${{ steps.merge-queue-run.outputs.run-id == '' && steps.changes.outputs.should-run == 'true' }}
     steps:
+      - name: Find successful merge queue run for this commit
+        id: merge-queue-run
+        if: github.event_name == 'push'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.sha }}
+        run: |
+          if run_id=$(gh api --method GET \
+            "repos/${GH_REPO}/actions/workflows/ci-tests-e2e.yaml/runs" \
+            -f event=merge_group \
+            -f head_sha="$HEAD_SHA" \
+            -f status=success \
+            -F per_page=1 \
+            --jq '.workflow_runs[0].id // empty'); then
+            echo "run-id=$run_id" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::Could not check prior merge queue runs; running E2E"
+            echo "run-id=" >> "$GITHUB_OUTPUT"
+          fi
+
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        if: steps.merge-queue-run.outputs.run-id == ''
       - id: changes
+        if: steps.merge-queue-run.outputs.run-id == ''
         uses: ./.github/actions/changes-filter
 
   setup:
@@ -208,10 +233,12 @@ jobs:
     steps:
       - name: Check E2E results
         env:
+          MERGE_QUEUE_RUN_ID: ${{ needs.changes.outputs.merge-queue-run-id }}
           SHOULD_RUN: ${{ needs.changes.outputs.should-run }}
           SHARDED: ${{ needs.playwright-tests-chromium-sharded.result }}
           BROWSERS: ${{ needs.playwright-tests.result }}
         run: |
+          [[ -n "$MERGE_QUEUE_RUN_ID" ]] && echo "E2E passed in merge queue run $MERGE_QUEUE_RUN_ID" && exit 0
           [[ "$SHOULD_RUN" != "true" ]] && echo "E2E skipped" && exit 0
           [[ "$SHARDED" != "success" || "$BROWSERS" != "success" ]] && echo "E2E failed" && exit 1
           echo "E2E passed"


### PR DESCRIPTION
## Summary

Reuse successful merge-queue E2E results when the same commit is subsequently pushed to its target branch.

## Changes

- **What**: Before a push run starts the E2E matrix, look for a successful `merge_group` run of this workflow at the exact same commit.
- **Coverage**: On the push event, merge and publish the matching merge-queue run's coverage artifacts instead of rebuilding them; merge-queue events no longer merge coverage preemptively.
- **Safety**: Direct pushes and unsuccessful or unavailable lookups continue through the existing full E2E path.
- **Stack**: Based on #15232 so its independent coverage-setup cleanup is excluded from this PR's diff.
- **Validation**: Both workflow files pass the repository's yamllint configuration. The lookup returned merge-queue run `29796883149` for known duplicate SHA `24d928409605c3a01c0fb9857d024c7bb1572597` and no result for an unmatched SHA.

## Review Focus

`push` remains enabled so direct pushes retain E2E coverage. Only a successful `merge_group` run from this workflow at the exact pushed SHA is reusable, and the required `e2e-status` check identifies the reused run.