### PR TITLE
feat(website): add a Run Workflow CTA to the MiniMax Music 3 page

### DIFF
--- a/apps/website/src/data/minimaxMusic3.ts
+++ b/apps/website/src/data/minimaxMusic3.ts
@@ -118,6 +118,8 @@ const howToPromptAnswerZh = `该模型接受两种互补的输入：
 const TUTORIAL_HREF =
   'https://docs.comfy.org/tutorials/audio/minimax/minimax-music-3#minimax-music-3-in-comfyui-ai-music-generation'
 
+const CLOUD_RUN_HREF = 'https://cloud.comfy.org/?template=audio_minimax_music_3'
+
 export const minimaxMusic3Page: ModelLaunchPage = {
   metaTitleKey: 'minimaxMusic3.meta.title',
   metaDescriptionKey: 'minimaxMusic3.meta.description',
@@ -129,6 +131,11 @@ export const minimaxMusic3Page: ModelLaunchPage = {
     descriptionKey: 'minimaxMusic3.hero.description',
     primaryCta: {
       labelKey: 'minimaxMusic3.hero.primaryCta',
+      href: CLOUD_RUN_HREF,
+      target: '_blank'
+    },
+    secondaryCta: {
+      labelKey: 'minimaxMusic3.hero.secondaryCta',
       href: TUTORIAL_HREF,
       target: '_blank'
     },
@@ -295,6 +302,11 @@ export const minimaxMusic3Page: ModelLaunchPage = {
     stepLabelKey: 'minimaxMusic3.steps.step',
     primaryCta: {
       labelKey: 'minimaxMusic3.steps.primaryCta',
+      href: CLOUD_RUN_HREF,
+      target: '_blank'
+    },
+    secondaryCta: {
+      labelKey: 'minimaxMusic3.steps.secondaryCta',
       href: TUTORIAL_HREF,
       target: '_blank'
     },

--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -5518,6 +5518,10 @@ const translations = {
     'zh-CN': '文本生成音频'
   },
   'minimaxMusic3.hero.primaryCta': {
+    en: 'RUN WORKFLOW',
+    'zh-CN': '运行工作流'
+  },
+  'minimaxMusic3.hero.secondaryCta': {
     en: 'LEARN MORE',
     'zh-CN': '了解更多'
   },
@@ -5540,6 +5544,10 @@ const translations = {
   },
   'minimaxMusic3.steps.step': { en: 'Step', 'zh-CN': '步骤' },
   'minimaxMusic3.steps.primaryCta': {
+    en: 'RUN WORKFLOW',
+    'zh-CN': '运行工作流'
+  },
+  'minimaxMusic3.steps.secondaryCta': {
     en: 'LEARN MORE',
     'zh-CN': '了解更多'
   },


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

Points `/minimax-music-3` at Comfy Cloud. Requested in #gtm-minimax: "can we update the landing page to point to cloud" + "add a Run Workflow CTA button next to documentation".

## Changes

`apps/website/src/data/minimaxMusic3.ts` — added `CLOUD_RUN_HREF` (`https://cloud.comfy.org/?template=audio_minimax_music_3`) and paired it with the existing tutorial link on both CTA rows:

| Section | Primary (solid) | Secondary (outline) |
| --- | --- | --- |
| Hero | RUN WORKFLOW → cloud template | LEARN MORE → docs tutorial |
| "Make your first song" steps | RUN WORKFLOW → cloud template | LEARN MORE → docs tutorial |

`apps/website/src/i18n/translations.ts` — `minimaxMusic3.hero.primaryCta` / `.steps.primaryCta` become RUN WORKFLOW (运行工作流); new `.hero.secondaryCta` / `.steps.secondaryCta` keys carry the existing LEARN MORE (了解更多) copy. Both locales.

No component changes — `ModelLaunchHeroCtaButtons` and `ModelLaunchStepsSection` already render a secondary CTA.

## Notes for review

- **Cloud run is the primary (solid) button, docs is now the secondary (outline).** This matches `/ltx-2.5`, `/seedance-2.5` and `/wan-animate-2`, which all lead with the cloud run; MiniMax Music 3 was the only launch page whose primary CTA went to docs. Swapping the two `href`s back is a one-line change if you'd rather keep docs primary.
- **The steps section got the same pair, not just the hero.** The page had two "LEARN MORE" buttons; leaving the second one docs-only seemed to miss the intent of "point the landing page to cloud". Happy to drop that half if you want the hero only.
- **Label is "RUN WORKFLOW"** as literally requested. Sibling pages use `RUN <MODEL>` (e.g. "RUN LTX 2.5"), so "RUN MINIMAX MUSIC 3" is the house style if you prefer consistency.
- **Reviewers still need to be named.** The original Slack message asked to cc two people for merge approval, but the @-mentions did not render in the text relayed to me, so I could not identify them. Please add the intended approvers.

## Verification

- `pnpm test:unit` (apps/website): 423 passed. `modelLaunchPages.test.ts` already asserts both locales translate every CTA key and that every CTA href is absolute, so the new keys and links are covered without new tests.
- `pnpm typecheck` + `pnpm typecheck:website`: 0 errors.
- oxfmt / oxlint / eslint: clean.
- Rendered against `astro dev` and checked in a real browser at 1440px and 390px, both `en` and `zh-CN`: both CTA rows present with the correct hrefs, no console errors, buttons stack full-width on mobile, and the Chinese labels do not clip.


## Screenshots

![Hero CTA row: RUN WORKFLOW (solid yellow) next to LEARN MORE (outline)](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/a13091baab9481cb02e081c3b58f38a262729f256ce85dab8e164ea616d053cc/pr-images/1786668330653-c44d98b1-8c50-41c5-94f6-d5469d648df7.png)

![Make your first song steps section with the RUN WORKFLOW and LEARN MORE CTA pair](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/a13091baab9481cb02e081c3b58f38a262729f256ce85dab8e164ea616d053cc/pr-images/1786668330991-1630b9f6-1653-4794-80db-145ae31662f5.png)

![zh-CN hero CTA row with the localized labels](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/a13091baab9481cb02e081c3b58f38a262729f256ce85dab8e164ea616d053cc/pr-images/1786668331357-206cc507-4139-48da-9987-31de01736c4b.png)

![Mobile 390px viewport: both CTAs stack full width](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/a13091baab9481cb02e081c3b58f38a262729f256ce85dab8e164ea616d053cc/pr-images/1786668331827-f6252520-4c94-4df4-9d84-c8f561926421.png)