### PR TITLE
fix: correct tailwind class order in website components

### DIFF
--- a/apps/website/src/components/blocks/FeaturedCarousel01.vue
+++ b/apps/website/src/components/blocks/FeaturedCarousel01.vue
@@ -141,7 +141,7 @@ useCarouselAutoplay({
   <div class="w-full px-6 lg:px-14">
     <div
       ref="rootEl"
-      class="border-primary-warm-gray relative mx-auto max-w-[1446px] rounded-[38px] border p-1.5 lg:p-5"
+      class="relative mx-auto max-w-[1446px] rounded-[38px] border border-primary-warm-gray p-1.5 lg:p-5"
     >
       <div class="relative overflow-clip rounded-4xl lg:rounded-[38px]">
         <div
@@ -230,7 +230,7 @@ useCarouselAutoplay({
           <IconButton
             variant="ghost"
             size="lg"
-            class="text-primary-warm-white rounded-full bg-white/20 backdrop-blur-sm hover:bg-white/30"
+            class="rounded-full bg-white/20 text-primary-warm-white backdrop-blur-sm hover:bg-white/30"
             :aria-label="prevLabel"
             @click="goTo(activeIndex - 1)"
           >
@@ -239,7 +239,7 @@ useCarouselAutoplay({
           <IconButton
             variant="ghost"
             size="lg"
-            class="text-primary-warm-white rounded-full bg-white/20 backdrop-blur-sm hover:bg-white/30"
+            class="rounded-full bg-white/20 text-primary-warm-white backdrop-blur-sm hover:bg-white/30"
             :aria-label="nextLabel"
             @click="goTo(activeIndex + 1)"
           >

--- a/apps/website/src/components/blocks/WatchAuthorCard.vue
+++ b/apps/website/src/components/blocks/WatchAuthorCard.vue
@@ -28,13 +28,13 @@ const {
     />
     <div class="flex flex-col gap-2">
       <p
-        class="text-primary-warm-white text-sm font-extrabold tracking-wider uppercase"
+        class="text-sm font-extrabold tracking-wider text-primary-warm-white uppercase"
       >
         {{ name }}
       </p>
       <p
         v-if="detail"
-        class="text-primary-warm-gray text-sm font-extrabold tracking-wider uppercase"
+        class="text-sm font-extrabold tracking-wider text-primary-warm-gray uppercase"
       >
         {{ detail }}
       </p>

--- a/apps/website/src/components/blocks/WatchPageLayout.vue
+++ b/apps/website/src/components/blocks/WatchPageLayout.vue
@@ -53,7 +53,7 @@ useResizeObserver(descriptionEl, updateClamped)
   <section :class="cn('max-w-9xl mx-auto px-6 pt-8 pb-16 lg:pb-24', className)">
     <nav v-if="breadcrumbs.length" :aria-label="breadcrumbsLabel" class="mb-6">
       <ol
-        class="text-primary-warm-gray flex flex-wrap items-center gap-2 text-sm font-light"
+        class="flex flex-wrap items-center gap-2 text-sm font-light text-primary-warm-gray"
       >
         <li
           v-for="(crumb, index) in breadcrumbs"
@@ -103,7 +103,7 @@ useResizeObserver(descriptionEl, updateClamped)
             ref="descriptionEl"
             :class="
               cn(
-                'text-primary-warm-gray text-lg/relaxed font-light',
+                'text-lg/relaxed font-light text-primary-warm-gray',
                 !expanded && 'line-clamp-4'
               )
             "
@@ -115,7 +115,7 @@ useResizeObserver(descriptionEl, updateClamped)
             type="button"
             :aria-expanded="expanded"
             :aria-controls="descriptionId"
-            class="text-primary-warm-white mt-2 cursor-pointer text-lg font-light hover:underline"
+            class="mt-2 cursor-pointer text-lg font-light text-primary-warm-white hover:underline"
             @click="expanded = !expanded"
           >
             {{ expanded ? (readLessLabel ?? readMoreLabel) : readMoreLabel }}

--- a/apps/website/src/components/blocks/WatchRelatedCard.vue
+++ b/apps/website/src/components/blocks/WatchRelatedCard.vue
@@ -39,7 +39,7 @@ const { item, class: className } = defineProps<{
       class="size-full object-cover transition-transform duration-500 ease-out group-hover:scale-105"
     />
     <PlayOverlay size="sm" class="text-white" />
-    <span class="text-primary-warm-white absolute bottom-2 left-3 text-xs">
+    <span class="absolute bottom-2 left-3 text-xs text-primary-warm-white">
       {{ item.label }}
     </span>
   </a>

--- a/apps/website/src/components/blocks/WatchRelatedStrip.vue
+++ b/apps/website/src/components/blocks/WatchRelatedStrip.vue
@@ -20,7 +20,7 @@ const {
 <template>
   <div v-if="items.length" :class="cn(className)">
     <h2
-      class="text-primary-warm-white text-sm font-extrabold tracking-wider uppercase"
+      class="text-sm font-extrabold tracking-wider text-primary-warm-white uppercase"
     >
       {{ heading }}
     </h2>

--- a/apps/website/src/components/learning/LearningWatchPage.vue
+++ b/apps/website/src/components/learning/LearningWatchPage.vue
@@ -106,7 +106,7 @@ const recommended = recommendedFor(tutorial).map((item) => ({
     </template>
 
     <template v-if="recommended.length" #sidebar>
-      <h2 class="text-primary-warm-gray font-medium">
+      <h2 class="font-medium text-primary-warm-gray">
         {{ t('learning.watch.recommended', locale) }}
       </h2>
       <div class="mt-4 flex flex-col gap-10">

--- a/apps/website/src/templates/events/UpcomingEventsSection.vue
+++ b/apps/website/src/templates/events/UpcomingEventsSection.vue
@@ -56,7 +56,7 @@ const events = computed(() =>
           >
             <div class="min-w-0">
               <h3
-                class="text-primary-warm-white text-lg font-medium md:text-xl"
+                class="text-lg font-medium text-primary-warm-white md:text-xl"
               >
                 {{ event.title[locale] }}
               </h3>


### PR DESCRIPTION
## Summary

Applies eslint's `better-tailwindcss/enforce-consistent-class-order` autofix to 7 `apps/website` components that violate it on `main`.

## Changes

- **What**: 12 lines reordered across 7 `.vue` files. Class sets are unchanged — only ordering differs. `eslint` reports 12 errors on the current versions and 0 after.

## Review Focus

The rule applies to `apps/website`, but nothing runs it there:

- `pnpm lint` is `stylelint && oxlint src browser_tests && eslint src --cache` — eslint only sees `src`
- `apps/website` has no lint script of its own

The only thing enforcing it is the lint-staged pre-commit hook, which passes staged paths directly and so bypasses that `src` scoping. Consequence: any PR that incidentally stages a website `.vue` picks up a drive-by autofix, and cannot revert it — the hook re-applies the fix on the way back in. That is how these 12 lines ended up in an unrelated E2E branch, which is what prompted this PR.

~65-79 website files are in violation on `main`. This PR fixes only the 7 needed to unblock that branch, to keep conflicts with in-flight website work minimal. Bringing `apps/website` under `pnpm lint` and fixing the rest is worth a follow-up.