### PR TITLE
feat(website): add the local connection to the Comfy MCP page

### DIFF
--- a/apps/website/e2e/mcp.spec.ts
+++ b/apps/website/e2e/mcp.spec.ts
@@ -152,12 +152,22 @@ test.describe('MCP page @smoke', () => {
     await expect(
       setup.getByRole('link', { name: 'open source on GitHub' })
     ).toHaveAttribute('href', 'https://github.com/Comfy-Org/comfy-mcp')
+    await expect(
+      setup.getByRole('link', { name: 'subscription of any tier' })
+    ).toHaveCount(0)
 
     // Client tabs inside the local panel swap the per-client instructions.
     await selectClientTab(setup, 'Cursor')
     await expect(
       setup.locator('[role="tabpanel"][data-state="active"]').last()
     ).toContainText('.cursor/mcp.json')
+
+    // Switching back to cloud restores the subscription note and endpoint.
+    await setup.getByRole('tab', { name: /Comfy Cloud/ }).click()
+    await expect(
+      setup.getByRole('link', { name: 'subscription of any tier' })
+    ).toBeVisible()
+    await expect(setup.getByText(MCP_ENDPOINT, { exact: true })).toBeVisible()
   })
 
   test('capabilities section shows all six tool cards', async ({ page }) => {

--- a/apps/website/e2e/mcp.spec.ts
+++ b/apps/website/e2e/mcp.spec.ts
@@ -175,12 +175,12 @@ test.describe('MCP page @smoke', () => {
     }
   })
 
-  test('FAQ lists twelve questions and autolinks the server URL', async ({
+  test('FAQ lists nine questions and autolinks the server URL', async ({
     page
   }) => {
     const triggers = page.locator('[id^="faq-trigger-"]')
     await triggers.first().scrollIntoViewIfNeeded()
-    await expect(triggers).toHaveCount(12)
+    await expect(triggers).toHaveCount(9)
 
     const question = page.getByRole('button', {
       name: "What's the server URL?"

--- a/apps/website/e2e/mcp.spec.ts
+++ b/apps/website/e2e/mcp.spec.ts
@@ -31,11 +31,14 @@ test.describe('MCP page @smoke', () => {
     }
   })
 
-  test('Claude Desktop is the default tab and shows only the connector card', async ({
+  test('cloud is the default connection with Claude Desktop active', async ({
     page
   }) => {
     const setup = page.locator('#setup')
     await setup.scrollIntoViewIfNeeded()
+    await expect(
+      setup.getByRole('tab', { name: /Comfy Cloud/ })
+    ).toHaveAttribute('data-state', 'active')
     await expect(
       setup.getByRole('tab', { name: 'Claude Desktop' })
     ).toHaveAttribute('data-state', 'active')
@@ -56,7 +59,11 @@ test.describe('MCP page @smoke', () => {
   }) => {
     const setup = page.locator('#setup')
     await setup.scrollIntoViewIfNeeded()
-    const activePanel = setup.locator('[role="tabpanel"][data-state="active"]')
+    // Nested tabs: the connection panel and the client panel are both active,
+    // so target the innermost (client) panel.
+    const activePanel = setup
+      .locator('[role="tabpanel"][data-state="active"]')
+      .last()
     const agentHeading = setup.getByRole('heading', {
       name: 'Ask your agent to install Comfy MCP'
     })
@@ -110,6 +117,49 @@ test.describe('MCP page @smoke', () => {
     ).toHaveAttribute('href', 'https://github.com/Comfy-Org/comfy-skills')
   })
 
+  test('local connection tab swaps in the open-source install flow', async ({
+    page
+  }) => {
+    const setup = page.locator('#setup')
+    await setup.scrollIntoViewIfNeeded()
+
+    const localTab = setup.getByRole('tab', { name: /Local ComfyUI/ })
+    await expect(async () => {
+      await localTab.click()
+      await expect(localTab).toHaveAttribute('data-state', 'active', {
+        timeout: 500
+      })
+    }).toPass()
+
+    await expect(
+      setup.getByRole('heading', { name: 'Install the server' })
+    ).toBeVisible()
+    await expect(
+      setup.getByText('pip install comfy-mcp', { exact: true })
+    ).toBeVisible()
+
+    // Claude Code is the default local client and pairs with the agent card.
+    await expect(
+      setup.getByText('claude mcp add comfy-mcp -- comfy-mcp', { exact: true })
+    ).toBeVisible()
+    await expect(
+      setup.getByRole('heading', {
+        name: 'Ask your agent to install Comfy MCP'
+      })
+    ).toBeVisible()
+
+    // The open-source requirement line replaces the subscription note.
+    await expect(
+      setup.getByRole('link', { name: 'open source on GitHub' })
+    ).toHaveAttribute('href', 'https://github.com/Comfy-Org/comfy-mcp')
+
+    // Client tabs inside the local panel swap the per-client instructions.
+    await selectClientTab(setup, 'Cursor')
+    await expect(
+      setup.locator('[role="tabpanel"][data-state="active"]').last()
+    ).toContainText('.cursor/mcp.json')
+  })
+
   test('capabilities section shows all six tool cards', async ({ page }) => {
     for (const title of [
       'Generate anything',
@@ -125,12 +175,12 @@ test.describe('MCP page @smoke', () => {
     }
   })
 
-  test('FAQ lists nine questions and autolinks the server URL', async ({
+  test('FAQ lists twelve questions and autolinks the server URL', async ({
     page
   }) => {
     const triggers = page.locator('[id^="faq-trigger-"]')
     await triggers.first().scrollIntoViewIfNeeded()
-    await expect(triggers).toHaveCount(9)
+    await expect(triggers).toHaveCount(12)
 
     const question = page.getByRole('button', {
       name: "What's the server URL?"

--- a/apps/website/src/config/routes.ts
+++ b/apps/website/src/config/routes.ts
@@ -96,7 +96,10 @@ export const externalLinks = {
   discord: 'https://discord.com/invite/comfyorg',
   docs: 'https://docs.comfy.org/',
   docsApi: 'https://docs.comfy.org/development/cloud/overview#quick-start',
-  docsMcp: 'https://docs.comfy.org/agent-tools/cloud',
+  comfyMcpRepo: 'https://github.com/Comfy-Org/comfy-mcp',
+  docsMcp: 'https://docs.comfy.org/agent-tools/mcp',
+  docsMcpLocal:
+    'https://docs.comfy.org/agent-tools/mcp#local-comfy-mcp-connection',
   docsSdk: 'https://docs.comfy.org/development/api-development/sdks',
   docsSubscription: 'https://docs.comfy.org/support/subscription/subscribing',
   g2ComfyUi: 'https://www.g2.com/products/comfyui',

--- a/apps/website/src/config/routes.ts
+++ b/apps/website/src/config/routes.ts
@@ -100,6 +100,11 @@ export const externalLinks = {
   docsMcp: 'https://docs.comfy.org/agent-tools/mcp',
   docsMcpLocal:
     'https://docs.comfy.org/agent-tools/mcp#local-comfy-mcp-connection',
+  // Markdown variants handed to agents in the "ask your agent" cards: agents
+  // fetch the .md URL and get readable markdown instead of the HTML shell.
+  docsMcpMd: 'https://docs.comfy.org/agent-tools/mcp.md',
+  docsMcpLocalMd:
+    'https://docs.comfy.org/agent-tools/mcp.md#local-comfy-mcp-connection',
   docsSdk: 'https://docs.comfy.org/development/api-development/sdks',
   docsSubscription: 'https://docs.comfy.org/support/subscription/subscribing',
   g2ComfyUi: 'https://www.g2.com/products/comfyui',

--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -2420,9 +2420,9 @@ const translations = {
     'zh-CN': '直接调用任意模型'
   },
   'mcp.tools.4.description': {
-    en: 'Kling, Veo, Seedance, Flux, GPT-Image, Nano Banana, and ElevenLabs. Closed partner APIs and open-source models, reached through one set of tools.',
+    en: 'MiniMax H3, Seedance, Flux, GPT-Image, Nano Banana, Kling, Z-Image, ElevenLabs, HY3D, and more. Closed partner APIs and open-source models, reached through one set of tools.',
     'zh-CN':
-      'Kling、Veo、Seedance、Flux、GPT-Image、Nano Banana 和 ElevenLabs。封闭的合作伙伴 API 与开源模型，通过同一套工具即可调用。'
+      'MiniMax H3、Seedance、Flux、GPT-Image、Nano Banana、Kling、Z-Image、ElevenLabs、HY3D 等。封闭的合作伙伴 API 与开源模型，通过同一套工具即可调用。'
   },
   'mcp.tools.4.alt': {
     en: 'Comfy MCP directing closed partner APIs and open-source models through one set of tools',

--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -2528,9 +2528,9 @@ const translations = {
     'zh-CN': '可以同时使用两种连接吗？'
   },
   'mcp.faq.4.a': {
-    en: 'Yes. Most clients happily run two MCP servers side by side. They sign in to the same Comfy account, but separately — one sign-in does not cover the other. Prototype free on your own GPU, then send the heavy batch to cloud GPUs from the same chat.',
+    en: 'Yes. Most clients happily run two MCP servers side by side, and they authenticate independently: the cloud connection signs in to your Comfy account, while the local one needs no sign-in at all until you run partner models. Prototype free on your own GPU, then send the heavy batch to cloud GPUs from the same chat.',
     'zh-CN':
-      '可以。大多数客户端可以同时运行两个 MCP 服务器。它们登录同一个 Comfy 账户，但各自独立——登录其中一个并不覆盖另一个。你可以先在自己的 GPU 上免费打样，再在同一个对话里把大批量任务发到云端 GPU。'
+      '可以。大多数客户端可以同时运行两个 MCP 服务器，且各自独立认证：云端连接登录你的 Comfy 账户，本地连接在运行合作伙伴模型之前完全不需要登录。你可以先在自己的 GPU 上免费打样，再在同一个对话里把大批量任务发到云端 GPU。'
   },
   'mcp.faq.5.q': {
     en: 'Do I need an API key?',
@@ -2564,9 +2564,9 @@ const translations = {
     'zh-CN': '连接后我的智能体能做什么？'
   },
   'mcp.faq.8.a': {
-    en: "• Generate images, video, audio, and 3D — including all open-source workflows and partner models like Seedance, GPT-Image, Nano Banana, and Kling\n• Build, edit, and run workflows; save and re-run workflows\n• Run and read in large batches\n• Search models, nodes, and template workflows\n• Read and execute shared workflow URLs\n• Upload and download assets for you\n\nEverything is now in natural language. No nodes, no downloads, no GPU, no node graphs if you don't want them.",
+    en: "• Generate images, video, audio, and 3D — including all open-source workflows and partner models like Seedance, GPT-Image, Nano Banana, and Kling\n• Build, edit, and run workflows; save and re-run workflows\n• Run and read in large batches\n• Search models, nodes, and template workflows\n• Read and execute shared workflow URLs\n• Upload and download assets for you\n\nEverything is in natural language, with no nodes or node graphs if you don't want them. On the cloud connection there is nothing to download and no GPU needed; the local connection drives the ComfyUI already installed on your machine.",
     'zh-CN':
-      '• 生成图像、视频、音频和 3D——包括所有开源工作流以及 Seedance、GPT-Image、Nano Banana 和 Kling 等合作伙伴模型\n• 构建、编辑和运行工作流；保存并重新运行工作流\n• 大批量运行和读取\n• 搜索模型、节点和模板工作流\n• 读取并执行分享的工作流链接\n• 为你上传和下载资产\n\n现在一切都用自然语言完成。如果你愿意，无需节点、无需下载、无需 GPU、无需节点图。'
+      '• 生成图像、视频、音频和 3D——包括所有开源工作流以及 Seedance、GPT-Image、Nano Banana 和 Kling 等合作伙伴模型\n• 构建、编辑和运行工作流；保存并重新运行工作流\n• 大批量运行和读取\n• 搜索模型、节点和模板工作流\n• 读取并执行分享的工作流链接\n• 为你上传和下载资产\n\n一切都用自然语言完成，如果你愿意，无需节点、无需节点图。云端连接无需下载、无需 GPU；本地连接则驱动你机器上已安装的 ComfyUI。'
   },
   'mcp.faq.9.q': {
     en: 'Where do my outputs go?',

--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -2041,9 +2041,9 @@ const translations = {
     'zh-CN': '让任何 AI 智能体\n驱动 ComfyUI，\n本地或云端。'
   },
   'mcp.hero.subtitle': {
-    en: 'Connect any AI agent to ComfyUI on Comfy Cloud GPUs or on your own machine. Generate images, video, audio and 3D, search models, nodes and templates, and run real workflows.',
+    en: 'Turn your agent into a creative technologist. Generate images, video, audio and 3D, search models, nodes and templates, and run real workflows. Built for reproducibility and teamwork.',
     'zh-CN':
-      '将任意 AI 智能体连接到 Comfy Cloud GPU 或本机上的 ComfyUI。生成图像、视频、音频和 3D，搜索模型、节点与模板，并运行真实工作流。'
+      '让你的智能体成为创意技术专家。生成图像、视频、音频和 3D，搜索模型、节点与模板，并运行真实工作流。为可复现性与团队协作而打造。'
   },
   'mcp.hero.demoPromptKeyframeBoard': {
     en: 'board the launch film — 8 key frames from the brief',

--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -2407,9 +2407,9 @@ const translations = {
     'zh-CN': '运行真实工作流'
   },
   'mcp.tools.3.description': {
-    en: 'Submit graphs, track jobs, and pull outputs back. Save and share workflows, reuse a saved one, or open any run on the ComfyUI canvas — the full engine, driven by tool calls.',
+    en: 'Submit graphs, track jobs, and pull outputs back. It reads the workflows you already have, so you start where you are: save, share, and reuse them, or open any run on the ComfyUI canvas — the full engine, driven by tool calls.',
     'zh-CN':
-      '提交计算图、跟踪任务并取回输出。保存和分享工作流，复用已保存的工作流，或在 ComfyUI 画布上打开任意运行——完整的引擎，由工具调用驱动。'
+      '提交计算图、跟踪任务并取回输出。它能读取你已有的工作流，让你从现有基础直接开始：保存、分享、复用，或在 ComfyUI 画布上打开任意运行——完整的引擎，由工具调用驱动。'
   },
   'mcp.tools.3.alt': {
     en: 'Comfy MCP running a ComfyUI workflow as a callable tool from a chat',

--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -2518,9 +2518,9 @@ const translations = {
     'zh-CN': '云端连接和本地连接有什么区别？'
   },
   'mcp.faq.3.a': {
-    en: 'The cloud connection is hosted: one URL, nothing to install, and workflows run on Comfy Cloud GPUs with our model catalog. The local connection is open source: your client launches the comfy-mcp server on your machine, and it drives your own ComfyUI — your models, your custom nodes, your GPU. Not sure? Start with cloud.',
+    en: "The cloud connection is hosted: one URL, nothing to install, and workflows run on Comfy Cloud GPUs with our model catalog. The local connection is open source: your client launches the comfy-mcp server on your machine, and it drives your own ComfyUI — your models, your custom nodes, your GPU.\nWhich one to choose: new users should start with cloud — it is the simplest setup, and the more compatible choice for claude.ai, ChatGPT, and Claude Desktop. Pick local if you already run ComfyUI on your machine or work mostly in a coding agent like Claude Code, Cursor, or Codex. One caveat for Mac users: today's big open-weight models will not run at a workable speed on the Apple GPU, so run those on cloud.",
     'zh-CN':
-      '云端连接是托管服务：一个 URL，无需安装，工作流在 Comfy Cloud 的 GPU 上运行，并可使用我们的模型目录。本地连接是开源的：客户端在你的机器上启动 comfy-mcp 服务器，驱动你自己的 ComfyUI——你的模型、你的自定义节点、你的 GPU。拿不准？从云端开始。'
+      '云端连接是托管服务：一个 URL，无需安装，工作流在 Comfy Cloud 的 GPU 上运行，并可使用我们的模型目录。本地连接是开源的：客户端在你的机器上启动 comfy-mcp 服务器，驱动你自己的 ComfyUI——你的模型、你的自定义节点、你的 GPU。\n如何选择：新用户建议从云端开始——配置最简单，对 claude.ai、ChatGPT 和 Claude Desktop 的兼容性也更好。如果你已经在本机运行 ComfyUI，或主要在 Claude Code、Cursor、Codex 等编程智能体中工作，选本地。Mac 用户注意：如今的大型开源权重模型在 Apple GPU 上跑不出实用的速度，请在云端运行。'
   },
   'mcp.faq.4.q': {
     en: 'Can I use both connections at once?',

--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -2536,9 +2536,9 @@ const translations = {
     'zh-CN': '我需要 API 密钥吗？'
   },
   'mcp.faq.5.a': {
-    en: 'On the local connection, driving your own ComfyUI needs no key and no account. You only sign in when you run partner models: through comfy-cli with a browser sign-in, or with a Comfy API key. On the cloud connection, Claude Code, Claude Desktop, Codex, and OpenClaw sign in with OAuth; Cursor and Hermes need a Comfy API key for now. Just copy https://docs.comfy.org/agent-tools/mcp.md and your agent will figure out the installation for you.',
+    en: 'In short, no. On the local connection, driving your own ComfyUI needs no key and no account. You only sign in when you run partner models: through comfy-cli with a browser sign-in, or with a Comfy API key. On the cloud connection, Claude Code, Claude Desktop, Codex, and OpenClaw sign in with OAuth; Cursor and Hermes need a Comfy API key for now. Just copy https://docs.comfy.org/agent-tools/mcp.md and your agent will figure out the installation for you.',
     'zh-CN':
-      '本地连接方面，驱动你自己的 ComfyUI 不需要密钥，也不需要账户。只有在运行合作伙伴模型时才需要登录：通过 comfy-cli 在浏览器中登录，或使用 Comfy API 密钥。云端连接方面，Claude Code、Claude Desktop、Codex 和 OpenClaw 通过 OAuth 登录；Cursor 和 Hermes 目前需要 Comfy API 密钥。只需复制 https://docs.comfy.org/agent-tools/mcp.md，你的智能体就会为你完成安装。'
+      '简而言之，不需要。本地连接方面，驱动你自己的 ComfyUI 不需要密钥，也不需要账户。只有在运行合作伙伴模型时才需要登录：通过 comfy-cli 在浏览器中登录，或使用 Comfy API 密钥。云端连接方面，Claude Code、Claude Desktop、Codex 和 OpenClaw 通过 OAuth 登录；Cursor 和 Hermes 目前需要 Comfy API 密钥。只需复制 https://docs.comfy.org/agent-tools/mcp.md，你的智能体就会为你完成安装。'
   },
   'mcp.faq.6.q': {
     en: 'Does it cost anything?',

--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -2496,8 +2496,8 @@ const translations = {
     'zh-CN': '常见问答'
   },
   'mcp.faq.1.q': {
-    en: 'Which clients are supported?',
-    'zh-CN': '支持哪些客户端？'
+    en: 'Which agents are supported?',
+    'zh-CN': '支持哪些智能体？'
   },
   'mcp.faq.1.a': {
     en: 'Any MCP-compatible client. For the cloud connection, add https://cloud.comfy.org/mcp as a custom connector or remote MCP server, then sign in when prompted. For the local connection, your client launches the open-source comfy-mcp server: Claude Code, Claude Desktop, Cursor, and any client that supports stdio servers. Send the docs https://docs.comfy.org/agent-tools/mcp.md to your agent and it will figure out the installation for you.',

--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -2332,44 +2332,45 @@ const translations = {
     'zh-CN': 'Comfy MCP？'
   },
   'mcp.why.subtitle': {
-    en: 'A trusted infrastructure that lets engineers and professionals ship faster.',
-    'zh-CN': '一套值得信赖的基础设施，让工程师和专业人士交付更快。'
+    en: 'The first MCP built for production pipelines: trusted infrastructure that lets engineers and professionals ship faster.',
+    'zh-CN':
+      '首个为生产管线打造的 MCP：值得信赖的基础设施，让工程师和专业人士交付更快。'
   },
   'mcp.why.1.title': {
     en: 'Open protocol,\nany client.',
     'zh-CN': '开放协议，\n任意客户端。'
   },
   'mcp.why.1.description': {
-    en: 'MCP is an open standard, so any MCP-compatible client can connect. Claude Code, Claude Desktop, and Codex sign in with OAuth; every other agent connects with an API key.',
+    en: 'MCP is an open standard, so any MCP-compatible client can connect: Claude Code, Claude Desktop, Codex, Cursor, and more. Sign in with OAuth or an API key on cloud; local runs need no account at all.',
     'zh-CN':
-      'MCP 是开放标准，因此任何兼容 MCP 的客户端都能接入。Claude Code、Claude Desktop 和 Codex 通过 OAuth 登录，其他智能体使用 API 密钥连接。'
+      'MCP 是开放标准，任何兼容 MCP 的客户端都能接入：Claude Code、Claude Desktop、Codex、Cursor 等。云端通过 OAuth 或 API 密钥登录；本地运行完全不需要账户。'
   },
   'mcp.why.2.title': {
     en: 'The full engine,\nnot a sandbox.',
     'zh-CN': '完整引擎，\n非沙箱环境。'
   },
   'mcp.why.2.description': {
-    en: 'Same tool your team uses. Fully connected multi-step, multi-GPU workflows. Everything available now and in the future.',
+    en: 'Same tool your team uses. Fully connected multi-step, multi-GPU workflows, with best-practice templates that update as the ecosystem moves. Everything available now and in the future.',
     'zh-CN':
-      '与你团队使用的相同工具。完整连接的多步骤、多 GPU 工作流。当前及未来的所有功能均可使用。'
+      '与你团队使用的相同工具。完整连接的多步骤、多 GPU 工作流，以及随生态更新的最佳实践模板。当前及未来的所有功能均可使用。'
   },
   'mcp.why.3.title': {
-    en: 'Outputs you keep.',
-    'zh-CN': '输出归你所有。'
+    en: 'Reproducible\nby design.',
+    'zh-CN': '为可复现性\n而设计。'
   },
   'mcp.why.3.description': {
-    en: 'Downloads go to your Comfy library — store, reuse, remix, and share without leaving the ecosystem.',
+    en: 'Every generation is a workflow: rerun it, share it by URL, hand it to a teammate. Made for long-term projects, not one-off generations. Outputs land in your Comfy library to store, reuse, and remix.',
     'zh-CN':
-      '下载内容保存到你的 Comfy 库——在生态系统内存储、复用、二次创作和分享。'
+      '每次生成都是一个工作流：可以重跑、通过 URL 分享、交给队友。为长期项目而生，而非一次性生成。输出保存到你的 Comfy 库，随时存储、复用和二次创作。'
   },
   'mcp.why.4.title': {
     en: 'Your GPUs,\nor ours.',
     'zh-CN': '你的 GPU，\n或我们的。'
   },
   'mcp.why.4.description': {
-    en: 'Run without a local GPU on Comfy Cloud infrastructure, or keep everything on your own machine with the open-source local server. Same tools, same client, your choice.',
+    en: 'Run without a GPU on Comfy Cloud, or go local and let the agent do the hard part: it reads your machine (models, custom nodes, VRAM), untangles complex open-source workflows, and builds ones your hardware can actually run.',
     'zh-CN':
-      '无需本地 GPU，在 Comfy Cloud 基础设施上运行；或使用开源本地服务器，让一切都留在你自己的机器上。同样的工具，同样的客户端，由你选择。'
+      '无需 GPU，在 Comfy Cloud 上运行；或选择本地，把难题交给智能体：它了解你的机器（模型、自定义节点、显存），理清复杂的开源工作流，构建你的硬件真正跑得动的工作流。'
   },
 
   // MCP – ToolsSection

--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -2030,9 +2030,9 @@ const translations = {
     'zh-CN': 'Comfy MCP - 让任何 AI 智能体驱动 ComfyUI'
   },
   'mcp.meta.description': {
-    en: 'Comfy MCP exposes the full ComfyUI engine over the Model Context Protocol. Generate images, video, audio, and 3D from Claude Code, Claude Desktop, and any MCP-compatible client.',
+    en: 'Comfy MCP exposes the full ComfyUI engine over the Model Context Protocol. Generate images, video, audio, and 3D from Claude Code, Claude Desktop, and any MCP-compatible client. On Comfy Cloud GPUs, or on your own machine.',
     'zh-CN':
-      'Comfy MCP 通过模型上下文协议暴露完整的 ComfyUI 引擎，可在 Claude Code、Claude Desktop 及任何兼容 MCP 的客户端中生成图像、视频、音频和 3D 内容。'
+      'Comfy MCP 通过模型上下文协议暴露完整的 ComfyUI 引擎，可在 Claude Code、Claude Desktop 及任何兼容 MCP 的客户端中生成图像、视频、音频和 3D 内容。在 Comfy Cloud 的 GPU 上运行，或就在你自己的机器上。'
   },
 
   // MCP – HeroSection
@@ -2041,9 +2041,9 @@ const translations = {
     'zh-CN': '让任何 AI 智能体\n驱动 ComfyUI。'
   },
   'mcp.hero.subtitle': {
-    en: 'Comfy MCP exposes the full ComfyUI engine over the Model Context Protocol — so your assistant can access the ecosystem, build workflows, and generate images, video, audio, or 3D.',
+    en: 'Comfy MCP exposes the full ComfyUI engine over the Model Context Protocol — so your assistant can access the ecosystem, build workflows, and generate images, video, audio, or 3D. On Comfy Cloud GPUs, or on your own machine.',
     'zh-CN':
-      'Comfy MCP 通过模型上下文协议暴露完整的 ComfyUI 引擎——让你的助手能够接入生态系统、构建工作流，并生成图像、视频、音频或 3D 内容。'
+      'Comfy MCP 通过模型上下文协议暴露完整的 ComfyUI 引擎——让你的助手能够接入生态系统、构建工作流，并生成图像、视频、音频或 3D 内容。在 Comfy Cloud 的 GPU 上运行，或就在你自己的机器上。'
   },
   'mcp.hero.demoPromptKeyframeBoard': {
     en: 'board the launch film — 8 key frames from the brief',
@@ -2152,9 +2152,29 @@ const translations = {
     'zh-CN': '配置 Comfy MCP'
   },
   'mcp.setup.subtitle': {
-    en: 'Two ways to connect: add the server yourself, or ask your agent to install it. Sign in once, and the full ComfyUI toolset is available right in your chat.',
+    en: 'First pick where it runs: on Comfy Cloud GPUs, or on the ComfyUI on your own machine. Then add the server yourself, or ask your agent to install it. Either way, the full ComfyUI toolset lands right in your chat.',
     'zh-CN':
-      '两种接入方式：自行添加服务器，或让你的智能体自动安装。登录一次，ComfyUI 全套工具即可直接在对话中使用。'
+      '先选择运行位置：Comfy Cloud 的 GPU，或你自己机器上的 ComfyUI。然后自行添加服务器，或让你的智能体代劳。无论哪种方式，ComfyUI 全套工具都会直接进入你的对话。'
+  },
+  'mcp.setup.connections.tabsLabel': {
+    en: 'Pick your connection',
+    'zh-CN': '选择你的连接方式'
+  },
+  'mcp.setup.connections.cloud.name': {
+    en: 'Comfy Cloud',
+    'zh-CN': 'Comfy Cloud'
+  },
+  'mcp.setup.connections.cloud.tagline': {
+    en: 'Nothing to install. Runs on Comfy Cloud GPUs.',
+    'zh-CN': '无需安装。在 Comfy Cloud 的 GPU 上运行。'
+  },
+  'mcp.setup.connections.local.name': {
+    en: 'Local ComfyUI',
+    'zh-CN': '本地 ComfyUI'
+  },
+  'mcp.setup.connections.local.tagline': {
+    en: 'Open source. Runs free on your own machine.',
+    'zh-CN': '开源。在你自己的机器上免费运行。'
   },
   'mcp.setup.requirementPrefix': {
     en: 'To use Comfy Cloud via MCP, you need a ',
@@ -2253,6 +2273,54 @@ const translations = {
     en: 'View on GitHub',
     'zh-CN': '在 GitHub 上查看'
   },
+  'mcp.setup.local.requirementPrefix': {
+    en: 'The local connection runs free on your own hardware, and the server is ',
+    'zh-CN': '本地连接在你自己的硬件上免费运行，服务器'
+  },
+  'mcp.setup.local.requirementLinkLabel': {
+    en: 'open source on GitHub',
+    'zh-CN': '在 GitHub 上开源'
+  },
+  'mcp.setup.local.requirementSuffix': {
+    en: '.',
+    'zh-CN': '。'
+  },
+  'mcp.setup.local.requirementFootnote': {
+    en: ' It needs Python 3.10+, comfy-cli, and a ComfyUI install on your machine.',
+    'zh-CN': '它需要你的机器上安装 Python 3.10+、comfy-cli 和 ComfyUI。'
+  },
+  'mcp.setup.local.manual.title': {
+    en: 'Install the server',
+    'zh-CN': '安装服务器'
+  },
+  'mcp.setup.local.manual.description': {
+    en: 'Install comfy-mcp from PyPI with the command above, then register it in your client. Your client launches the server, and the server drives the ComfyUI on your machine.',
+    'zh-CN':
+      '使用上方命令从 PyPI 安装 comfy-mcp，然后在客户端中注册。客户端会启动服务器，服务器驱动你机器上的 ComfyUI。'
+  },
+  'mcp.setup.local.agent.command': {
+    en: 'Help me set up the local Comfy MCP connection.\nFollow the setup guide at {url}',
+    'zh-CN': '帮我配置本地 Comfy MCP 连接。\n请按照 {url} 上的设置指南操作。'
+  },
+  'mcp.setup.local.clients.claudeCode.step': {
+    en: 'Run this in your terminal, then restart Claude Code so the tools appear.',
+    'zh-CN': '在终端运行以下命令，然后重启 Claude Code 以加载工具。'
+  },
+  'mcp.setup.local.clients.claudeDesktop.step': {
+    en: 'Open Settings, choose Developer, then Edit Config, add this to claude_desktop_config.json, and restart Claude Desktop.',
+    'zh-CN':
+      '打开 Settings，选择 Developer，点击 Edit Config，将以下内容添加到 claude_desktop_config.json，然后重启 Claude Desktop。'
+  },
+  'mcp.setup.local.clients.cursor.step': {
+    en: 'Add this to ~/.cursor/mcp.json, or to .cursor/mcp.json inside a project.',
+    'zh-CN':
+      '将以下内容添加到 ~/.cursor/mcp.json，或项目内的 .cursor/mcp.json。'
+  },
+  'mcp.setup.local.clients.other.step': {
+    en: 'Any client that can launch a stdio MCP server works: point it at the comfy-mcp command. Full walkthroughs live in the ',
+    'zh-CN':
+      '任何能启动 stdio MCP 服务器的客户端都可以：将其指向 comfy-mcp 命令即可。完整教程见'
+  },
 
   // MCP – WhyBuildSection
   'mcp.why.heading': {
@@ -2295,12 +2363,13 @@ const translations = {
       '下载内容保存到你的 Comfy 库——在生态系统内存储、复用、二次创作和分享。'
   },
   'mcp.why.4.title': {
-    en: 'Powered by\nComfy Cloud.',
-    'zh-CN': '由 Comfy Cloud\n提供支持。'
+    en: 'Your GPUs,\nor ours.',
+    'zh-CN': '你的 GPU，\n或我们的。'
   },
   'mcp.why.4.description': {
-    en: 'Run without a local GPU through the same infrastructure your team already trusts.',
-    'zh-CN': '无需本地 GPU，通过你团队信赖的相同基础设施运行。'
+    en: 'Run without a local GPU on Comfy Cloud infrastructure, or keep everything on your own machine with the open-source local server. Same tools, same client, your choice.',
+    'zh-CN':
+      '无需本地 GPU，在 Comfy Cloud 基础设施上运行；或使用开源本地服务器，让一切都留在你自己的机器上。同样的工具，同样的客户端，由你选择。'
   },
 
   // MCP – ToolsSection
@@ -2397,9 +2466,9 @@ const translations = {
     'zh-CN': '连接'
   },
   'mcp.howItWorks.step1.description': {
-    en: 'Add the Comfy Cloud MCP server to Claude Code or Claude Desktop and sign in once with OAuth. No API keys to manage.',
+    en: 'Connect the cloud server with one URL and an OAuth sign-in, or pip install the open-source local server. Most clients happily run both.',
     'zh-CN':
-      '将 Comfy Cloud MCP 服务器添加到 Claude Code 或 Claude Desktop，通过 OAuth 一次性登录。无需管理 API 密钥。'
+      '通过一个 URL 和 OAuth 登录连接云端服务器，或用 pip 安装开源本地服务器。大多数客户端可以同时运行两者。'
   },
   'mcp.howItWorks.step2.number': { en: '02', 'zh-CN': '02' },
   'mcp.howItWorks.step2.title': {
@@ -2431,81 +2500,108 @@ const translations = {
     'zh-CN': '支持哪些客户端？'
   },
   'mcp.faq.1.a': {
-    en: "For Claude Code, Claude Desktop, or Codex, add https://cloud.comfy.org/mcp as a custom connector or remote MCP server in any client, then sign in when prompted.\nFor clients that don't support OAuth, connect with a Comfy API key. Send the docs https://docs.comfy.org/agent-tools/cloud to your agent and it will figure out the installation for you.",
+    en: 'Any MCP-compatible client. For the cloud connection, add https://cloud.comfy.org/mcp as a custom connector or remote MCP server, then sign in when prompted. For the local connection, your client launches the open-source comfy-mcp server: Claude Code, Claude Desktop, Cursor, and any client that supports stdio servers. Send the docs https://docs.comfy.org/agent-tools/mcp to your agent and it will figure out the installation for you.',
     'zh-CN':
-      '对于 Claude Code、Claude Desktop 或 Codex，在任意客户端中将 https://cloud.comfy.org/mcp 添加为自定义连接器或远程 MCP 服务器，然后在提示时登录。\n对于不支持 OAuth 的客户端，请使用 Comfy API 密钥连接。将文档 https://docs.comfy.org/agent-tools/cloud 发送给你的智能体，它会为你完成安装。'
+      '任何兼容 MCP 的客户端。云端连接：将 https://cloud.comfy.org/mcp 添加为自定义连接器或远程 MCP 服务器，然后在提示时登录。本地连接：由客户端启动开源的 comfy-mcp 服务器，支持 Claude Code、Claude Desktop、Cursor 以及任何支持 stdio 服务器的客户端。将文档 https://docs.comfy.org/agent-tools/mcp 发送给你的智能体，它会为你完成安装。'
   },
   'mcp.faq.2.q': {
     en: "What's the server URL?",
     'zh-CN': '服务器 URL 是什么？'
   },
   'mcp.faq.2.a': {
-    en: 'https://cloud.comfy.org/mcp — add it as a custom connector or remote MCP server in any client, then sign in when prompted.',
+    en: 'For the cloud connection: https://cloud.comfy.org/mcp — add it as a custom connector or remote MCP server in any client, then sign in when prompted. The local connection has no URL: your client launches the comfy-mcp command directly and talks to it over stdio.',
     'zh-CN':
-      'https://cloud.comfy.org/mcp——在任意客户端中将它添加为自定义连接器或远程 MCP 服务器，然后在提示时登录。'
+      '云端连接：https://cloud.comfy.org/mcp——在任意客户端中将它添加为自定义连接器或远程 MCP 服务器，然后在提示时登录。本地连接没有 URL：客户端直接启动 comfy-mcp 命令，通过 stdio 与它通信。'
   },
   'mcp.faq.3.q': {
-    en: 'Do I need an API key?',
-    'zh-CN': '我需要 API 密钥吗？'
+    en: "What's the difference between the cloud and local connections?",
+    'zh-CN': '云端连接和本地连接有什么区别？'
   },
   'mcp.faq.3.a': {
-    en: 'Not for Claude Code, Claude Desktop, Codex, or OpenClaw. You need a Comfy API key for Cursor and Hermes for now. Just copy https://docs.comfy.org/agent-tools/cloud and your agent will figure out the installation for you.',
+    en: 'The cloud connection is hosted: one URL, nothing to install, and workflows run on Comfy Cloud GPUs with our model catalog. The local connection is open source: your client launches the comfy-mcp server on your machine, and it drives your own ComfyUI — your models, your custom nodes, your GPU. Not sure? Start with cloud.',
     'zh-CN':
-      'Claude Code、Claude Desktop、Codex 和 OpenClaw 不需要。Cursor 和 Hermes 目前需要 Comfy API 密钥。只需复制 https://docs.comfy.org/agent-tools/cloud，你的智能体就会为你完成安装。'
+      '云端连接是托管服务：一个 URL，无需安装，工作流在 Comfy Cloud 的 GPU 上运行，并可使用我们的模型目录。本地连接是开源的：客户端在你的机器上启动 comfy-mcp 服务器，驱动你自己的 ComfyUI——你的模型、你的自定义节点、你的 GPU。拿不准？从云端开始。'
   },
   'mcp.faq.4.q': {
-    en: 'Does it cost anything?',
-    'zh-CN': '需要付费吗？'
-  },
-  'mcp.faq.4.a': {
-    en: "Connecting is free with a Comfy account, and searching models, nodes, and templates doesn't cost credits. Running a generation uses Comfy Cloud credits. To use Comfy Cloud via MCP, you need a [subscription of any tier](https://comfy.org/cloud/pricing) — a credit top-up alone isn't enough. Your agent confirms with you before it spends.",
-    'zh-CN':
-      '使用 Comfy 账户连接是免费的，搜索模型、节点和模板也不消耗积分。运行生成会使用 Comfy Cloud 积分。如需通过 MCP 使用 Comfy Cloud，你需要[任意套餐的订阅](https://comfy.org/cloud/pricing)——仅充值积分是不够的。智能体在消费前会先与你确认。'
-  },
-  'mcp.faq.5.q': {
     en: 'Can I use it with my local ComfyUI?',
     'zh-CN': '可以配合我的本地 ComfyUI 使用吗？'
   },
-  'mcp.faq.5.a': {
-    en: 'Coming soon. Today, to drive a local ComfyUI, you can use comfy-cli: https://github.com/Comfy-Org/comfy-cli',
+  'mcp.faq.4.a': {
+    en: "Yes — that's the local connection. Install it with pip install comfy-mcp and point your client at the comfy-mcp command. It runs the ComfyUI on your own machine, with your models and custom nodes. Setup guide: https://docs.comfy.org/agent-tools/mcp",
     'zh-CN':
-      '即将推出。目前，若要操作本地 ComfyUI，你可以使用 comfy-cli：https://github.com/Comfy-Org/comfy-cli'
+      '可以——这正是本地连接。运行 pip install comfy-mcp 安装，然后让客户端指向 comfy-mcp 命令即可。它驱动你自己机器上的 ComfyUI，使用你的模型和自定义节点。设置指南：https://docs.comfy.org/agent-tools/mcp'
+  },
+  'mcp.faq.5.q': {
+    en: 'Can I use both connections at once?',
+    'zh-CN': '可以同时使用两种连接吗？'
+  },
+  'mcp.faq.5.a': {
+    en: 'Yes. Most clients happily run two MCP servers side by side. They sign in to the same Comfy account, but separately — one sign-in does not cover the other. Prototype free on your own GPU, then send the heavy batch to cloud GPUs from the same chat.',
+    'zh-CN':
+      '可以。大多数客户端可以同时运行两个 MCP 服务器。它们登录同一个 Comfy 账户，但各自独立——登录其中一个并不覆盖另一个。你可以先在自己的 GPU 上免费打样，再在同一个对话里把大批量任务发到云端 GPU。'
   },
   'mcp.faq.6.q': {
+    en: 'Do I need an API key?',
+    'zh-CN': '我需要 API 密钥吗？'
+  },
+  'mcp.faq.6.a': {
+    en: 'The local connection never needs one. On the cloud connection, Claude Code, Claude Desktop, Codex, and OpenClaw sign in with OAuth; Cursor and Hermes need a Comfy API key for now. Just copy https://docs.comfy.org/agent-tools/mcp and your agent will figure out the installation for you.',
+    'zh-CN':
+      '本地连接完全不需要。云端连接方面，Claude Code、Claude Desktop、Codex 和 OpenClaw 通过 OAuth 登录；Cursor 和 Hermes 目前需要 Comfy API 密钥。只需复制 https://docs.comfy.org/agent-tools/mcp，你的智能体就会为你完成安装。'
+  },
+  'mcp.faq.7.q': {
+    en: 'Does it cost anything?',
+    'zh-CN': '需要付费吗？'
+  },
+  'mcp.faq.7.a': {
+    en: "The local connection is free: runs happen on your own hardware, and the server is open source. The one exception is partner models, which run on partner infrastructure and use credits. On the cloud connection, connecting and searching are free, and running a generation uses Comfy Cloud credits — you need a [subscription of any tier](https://comfy.org/cloud/pricing); a credit top-up alone isn't enough. Your agent confirms with you before it spends.",
+    'zh-CN':
+      '本地连接是免费的：生成在你自己的硬件上运行，服务器也是开源的。唯一的例外是合作伙伴模型，它们在合作伙伴的基础设施上运行并消耗积分。云端连接方面，连接和搜索免费，运行生成会使用 Comfy Cloud 积分——你需要[任意套餐的订阅](https://comfy.org/cloud/pricing)，仅充值积分是不够的。智能体在消费前会先与你确认。'
+  },
+  'mcp.faq.8.q': {
+    en: 'Is Comfy MCP open source?',
+    'zh-CN': 'Comfy MCP 开源吗？'
+  },
+  'mcp.faq.8.a': {
+    en: 'The local connection is: comfy-mcp lives at https://github.com/Comfy-Org/comfy-mcp and installs from PyPI with pip install comfy-mcp. The cloud connection is a hosted service in front of Comfy Cloud.',
+    'zh-CN':
+      '本地连接是开源的：comfy-mcp 的代码在 https://github.com/Comfy-Org/comfy-mcp，可通过 pip install comfy-mcp 从 PyPI 安装。云端连接是构建在 Comfy Cloud 之上的托管服务。'
+  },
+  'mcp.faq.9.q': {
     en: 'What can my agent do once connected?',
     'zh-CN': '连接后我的智能体能做什么？'
   },
-  'mcp.faq.6.a': {
+  'mcp.faq.9.a': {
     en: "• Generate images, video, audio, and 3D — including all open-source workflows and partner models like Seedance, GPT-Image, Nano Banana, and Kling\n• Build, edit, and run workflows; save and re-run workflows\n• Run and read in large batches\n• Search models, nodes, and template workflows\n• Read and execute shared workflow URLs\n• Upload and download assets for you\n\nEverything is now in natural language. No nodes, no downloads, no GPU, no node graphs if you don't want them.",
     'zh-CN':
       '• 生成图像、视频、音频和 3D——包括所有开源工作流以及 Seedance、GPT-Image、Nano Banana 和 Kling 等合作伙伴模型\n• 构建、编辑和运行工作流；保存并重新运行工作流\n• 大批量运行和读取\n• 搜索模型、节点和模板工作流\n• 读取并执行分享的工作流链接\n• 为你上传和下载资产\n\n现在一切都用自然语言完成。如果你愿意，无需节点、无需下载、无需 GPU、无需节点图。'
   },
-  'mcp.faq.7.q': {
+  'mcp.faq.10.q': {
     en: 'Where do my outputs go?',
     'zh-CN': '我的输出会保存到哪里？'
   },
-  'mcp.faq.7.a': {
-    en: 'Into your Comfy Cloud asset library, so you can reuse, remix, and share them — and open any run on the canvas to keep editing. You can also ask your agent to download the assets locally for you.',
+  'mcp.faq.10.a': {
+    en: 'On the cloud connection, into your Comfy Cloud asset library, so you can reuse, remix, and share them — and open any run on the canvas to keep editing. You can also ask your agent to download the assets locally for you. On the local connection, outputs land in your ComfyUI output folder, and your agent can copy them anywhere you name.',
     'zh-CN':
-      '保存到你的 Comfy Cloud 资产库，你可以复用、二次创作和分享——还能在画布上打开任意运行继续编辑。你也可以让智能体把资产下载到本地。'
+      '云端连接：保存到你的 Comfy Cloud 资产库，你可以复用、二次创作和分享——还能在画布上打开任意运行继续编辑。你也可以让智能体把资产下载到本地。本地连接：输出保存在你的 ComfyUI 输出文件夹中，智能体可以把它们复制到你指定的任何位置。'
   },
-  'mcp.faq.8.q': {
+  'mcp.faq.11.q': {
     en: 'Do slash commands work in Claude Desktop?',
     'zh-CN': '斜杠命令在 Claude Desktop 中可以使用吗？'
   },
-  'mcp.faq.8.a': {
+  'mcp.faq.11.a': {
     en: 'No. They ship with the Claude Code comfy-cloud plugin. Desktop connects to the same MCP server, so every tool works; just ask in plain language.',
     'zh-CN':
       '不可以。斜杠命令随 Claude Code 的 comfy-cloud 插件一起提供。Claude Desktop 连接的是同一个 MCP 服务器，因此所有工具都能使用；直接用自然语言提问即可。'
   },
-  'mcp.faq.9.q': {
+  'mcp.faq.12.q': {
     en: 'Is it generally available?',
     'zh-CN': '现已正式发布了吗？'
   },
-  'mcp.faq.9.a': {
-    en: 'Yes. Comfy Cloud MCP is in open beta and available to everyone with a Comfy account.',
+  'mcp.faq.12.a': {
+    en: 'The cloud connection is in open beta and available to everyone with a Comfy account. The local connection is released and open source — install it today with pip install comfy-mcp.',
     'zh-CN':
-      '是的。Comfy Cloud MCP 目前处于公开测试阶段，任何拥有 Comfy 账户的人都可以使用。'
+      '云端连接目前处于公开测试阶段，任何拥有 Comfy 账户的人都可以使用。本地连接已正式发布并开源——现在就可以通过 pip install comfy-mcp 安装。'
   },
 
   // SiteNav

--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -2041,9 +2041,9 @@ const translations = {
     'zh-CN': '让任何 AI 智能体\n驱动 ComfyUI。'
   },
   'mcp.hero.subtitle': {
-    en: 'Comfy MCP exposes the full ComfyUI engine over the Model Context Protocol — so your assistant can access the ecosystem, build workflows, and generate images, video, audio, or 3D. On Comfy Cloud GPUs, or on your own machine.',
+    en: 'Connect any AI agent to ComfyUI on Comfy Cloud GPUs or on your own machine. Generate images, video, audio and 3D, search models, nodes and templates, and run real workflows.',
     'zh-CN':
-      'Comfy MCP 通过模型上下文协议暴露完整的 ComfyUI 引擎——让你的助手能够接入生态系统、构建工作流，并生成图像、视频、音频或 3D 内容。在 Comfy Cloud 的 GPU 上运行，或就在你自己的机器上。'
+      '将任意 AI 智能体连接到 Comfy Cloud GPU 或本机上的 ComfyUI。生成图像、视频、音频和 3D，搜索模型、节点与模板，并运行真实工作流。'
   },
   'mcp.hero.demoPromptKeyframeBoard': {
     en: 'board the launch film — 8 key frames from the brief',
@@ -2274,8 +2274,8 @@ const translations = {
     'zh-CN': '在 GitHub 上查看'
   },
   'mcp.setup.local.requirementPrefix': {
-    en: 'The local connection runs free on your own hardware, and the server is ',
-    'zh-CN': '本地连接在你自己的硬件上免费运行，服务器'
+    en: 'The local ComfyUI connection runs free on your own hardware, and the MCP is ',
+    'zh-CN': '本地 ComfyUI 连接在你自己的硬件上免费运行，MCP '
   },
   'mcp.setup.local.requirementLinkLabel': {
     en: 'open source on GitHub',
@@ -2284,10 +2284,6 @@ const translations = {
   'mcp.setup.local.requirementSuffix': {
     en: '.',
     'zh-CN': '。'
-  },
-  'mcp.setup.local.requirementFootnote': {
-    en: ' It needs Python 3.10+, comfy-cli, and a ComfyUI install on your machine.',
-    'zh-CN': '它需要你的机器上安装 Python 3.10+、comfy-cli 和 ComfyUI。'
   },
   'mcp.setup.local.manual.title': {
     en: 'Install the server',

--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -2209,6 +2209,10 @@ const translations = {
     en: 'Ask your agent to install Comfy MCP',
     'zh-CN': '让你的智能体安装 Comfy MCP'
   },
+  'mcp.setup.agent.recommended': {
+    en: 'Recommended',
+    'zh-CN': '推荐'
+  },
   'mcp.setup.agent.command': {
     en: 'Help me install Comfy MCP.\nFollow the setup guide at {url}',
     'zh-CN': '帮我安装 Comfy MCP。\n请按照 {url} 上的设置指南操作。'

--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -2523,85 +2523,58 @@ const translations = {
       '云端连接是托管服务：一个 URL，无需安装，工作流在 Comfy Cloud 的 GPU 上运行，并可使用我们的模型目录。本地连接是开源的：客户端在你的机器上启动 comfy-mcp 服务器，驱动你自己的 ComfyUI——你的模型、你的自定义节点、你的 GPU。拿不准？从云端开始。'
   },
   'mcp.faq.4.q': {
-    en: 'Can I use it with my local ComfyUI?',
-    'zh-CN': '可以配合我的本地 ComfyUI 使用吗？'
-  },
-  'mcp.faq.4.a': {
-    en: "Yes — that's the local connection. Install it with pip install comfy-mcp and point your client at the comfy-mcp command. It runs the ComfyUI on your own machine, with your models and custom nodes. Setup guide: https://docs.comfy.org/agent-tools/mcp",
-    'zh-CN':
-      '可以——这正是本地连接。运行 pip install comfy-mcp 安装，然后让客户端指向 comfy-mcp 命令即可。它驱动你自己机器上的 ComfyUI，使用你的模型和自定义节点。设置指南：https://docs.comfy.org/agent-tools/mcp'
-  },
-  'mcp.faq.5.q': {
     en: 'Can I use both connections at once?',
     'zh-CN': '可以同时使用两种连接吗？'
   },
-  'mcp.faq.5.a': {
+  'mcp.faq.4.a': {
     en: 'Yes. Most clients happily run two MCP servers side by side. They sign in to the same Comfy account, but separately — one sign-in does not cover the other. Prototype free on your own GPU, then send the heavy batch to cloud GPUs from the same chat.',
     'zh-CN':
       '可以。大多数客户端可以同时运行两个 MCP 服务器。它们登录同一个 Comfy 账户，但各自独立——登录其中一个并不覆盖另一个。你可以先在自己的 GPU 上免费打样，再在同一个对话里把大批量任务发到云端 GPU。'
   },
-  'mcp.faq.6.q': {
+  'mcp.faq.5.q': {
     en: 'Do I need an API key?',
     'zh-CN': '我需要 API 密钥吗？'
   },
-  'mcp.faq.6.a': {
-    en: 'The local connection never needs one. On the cloud connection, Claude Code, Claude Desktop, Codex, and OpenClaw sign in with OAuth; Cursor and Hermes need a Comfy API key for now. Just copy https://docs.comfy.org/agent-tools/mcp and your agent will figure out the installation for you.',
+  'mcp.faq.5.a': {
+    en: 'On the local connection, driving your own ComfyUI needs no key and no account. You only sign in when you run partner models: through comfy-cli with a browser sign-in, or with a Comfy API key. On the cloud connection, Claude Code, Claude Desktop, Codex, and OpenClaw sign in with OAuth; Cursor and Hermes need a Comfy API key for now. Just copy https://docs.comfy.org/agent-tools/mcp and your agent will figure out the installation for you.',
     'zh-CN':
-      '本地连接完全不需要。云端连接方面，Claude Code、Claude Desktop、Codex 和 OpenClaw 通过 OAuth 登录；Cursor 和 Hermes 目前需要 Comfy API 密钥。只需复制 https://docs.comfy.org/agent-tools/mcp，你的智能体就会为你完成安装。'
+      '本地连接方面，驱动你自己的 ComfyUI 不需要密钥，也不需要账户。只有在运行合作伙伴模型时才需要登录：通过 comfy-cli 在浏览器中登录，或使用 Comfy API 密钥。云端连接方面，Claude Code、Claude Desktop、Codex 和 OpenClaw 通过 OAuth 登录；Cursor 和 Hermes 目前需要 Comfy API 密钥。只需复制 https://docs.comfy.org/agent-tools/mcp，你的智能体就会为你完成安装。'
   },
-  'mcp.faq.7.q': {
+  'mcp.faq.6.q': {
     en: 'Does it cost anything?',
     'zh-CN': '需要付费吗？'
   },
-  'mcp.faq.7.a': {
-    en: "The local connection is free: runs happen on your own hardware, and the server is open source. The one exception is partner models, which run on partner infrastructure and use credits. On the cloud connection, connecting and searching are free, and running a generation uses Comfy Cloud credits — you need a [subscription of any tier](https://comfy.org/cloud/pricing); a credit top-up alone isn't enough. Your agent confirms with you before it spends.",
+  'mcp.faq.6.a': {
+    en: "On the local connection, runs on your own hardware are free, and the server is open source. Partner models are the exception: they run on partner infrastructure and spend Comfy credits from your account, so you sign in before using them. On the cloud connection, connecting and searching are free, and running a generation uses Comfy Cloud credits — you need a [subscription of any tier](https://comfy.org/cloud/pricing); a credit top-up alone isn't enough. Either way, your agent confirms with you before it spends.",
     'zh-CN':
-      '本地连接是免费的：生成在你自己的硬件上运行，服务器也是开源的。唯一的例外是合作伙伴模型，它们在合作伙伴的基础设施上运行并消耗积分。云端连接方面，连接和搜索免费，运行生成会使用 Comfy Cloud 积分——你需要[任意套餐的订阅](https://comfy.org/cloud/pricing)，仅充值积分是不够的。智能体在消费前会先与你确认。'
+      '本地连接方面，在你自己硬件上的生成是免费的，服务器也是开源的。合作伙伴模型是例外：它们在合作伙伴的基础设施上运行，消耗你 Comfy 账户中的积分，因此使用前需要登录。云端连接方面，连接和搜索免费，运行生成会使用 Comfy Cloud 积分——你需要[任意套餐的订阅](https://comfy.org/cloud/pricing)，仅充值积分是不够的。无论哪种方式，智能体在消费前都会先与你确认。'
   },
-  'mcp.faq.8.q': {
+  'mcp.faq.7.q': {
     en: 'Is Comfy MCP open source?',
     'zh-CN': 'Comfy MCP 开源吗？'
   },
-  'mcp.faq.8.a': {
+  'mcp.faq.7.a': {
     en: 'The local connection is: comfy-mcp lives at https://github.com/Comfy-Org/comfy-mcp and installs from PyPI with pip install comfy-mcp. The cloud connection is a hosted service in front of Comfy Cloud.',
     'zh-CN':
       '本地连接是开源的：comfy-mcp 的代码在 https://github.com/Comfy-Org/comfy-mcp，可通过 pip install comfy-mcp 从 PyPI 安装。云端连接是构建在 Comfy Cloud 之上的托管服务。'
   },
-  'mcp.faq.9.q': {
+  'mcp.faq.8.q': {
     en: 'What can my agent do once connected?',
     'zh-CN': '连接后我的智能体能做什么？'
   },
-  'mcp.faq.9.a': {
+  'mcp.faq.8.a': {
     en: "• Generate images, video, audio, and 3D — including all open-source workflows and partner models like Seedance, GPT-Image, Nano Banana, and Kling\n• Build, edit, and run workflows; save and re-run workflows\n• Run and read in large batches\n• Search models, nodes, and template workflows\n• Read and execute shared workflow URLs\n• Upload and download assets for you\n\nEverything is now in natural language. No nodes, no downloads, no GPU, no node graphs if you don't want them.",
     'zh-CN':
       '• 生成图像、视频、音频和 3D——包括所有开源工作流以及 Seedance、GPT-Image、Nano Banana 和 Kling 等合作伙伴模型\n• 构建、编辑和运行工作流；保存并重新运行工作流\n• 大批量运行和读取\n• 搜索模型、节点和模板工作流\n• 读取并执行分享的工作流链接\n• 为你上传和下载资产\n\n现在一切都用自然语言完成。如果你愿意，无需节点、无需下载、无需 GPU、无需节点图。'
   },
-  'mcp.faq.10.q': {
+  'mcp.faq.9.q': {
     en: 'Where do my outputs go?',
     'zh-CN': '我的输出会保存到哪里？'
   },
-  'mcp.faq.10.a': {
+  'mcp.faq.9.a': {
     en: 'On the cloud connection, into your Comfy Cloud asset library, so you can reuse, remix, and share them — and open any run on the canvas to keep editing. You can also ask your agent to download the assets locally for you. On the local connection, outputs land in your ComfyUI output folder, and your agent can copy them anywhere you name.',
     'zh-CN':
       '云端连接：保存到你的 Comfy Cloud 资产库，你可以复用、二次创作和分享——还能在画布上打开任意运行继续编辑。你也可以让智能体把资产下载到本地。本地连接：输出保存在你的 ComfyUI 输出文件夹中，智能体可以把它们复制到你指定的任何位置。'
-  },
-  'mcp.faq.11.q': {
-    en: 'Do slash commands work in Claude Desktop?',
-    'zh-CN': '斜杠命令在 Claude Desktop 中可以使用吗？'
-  },
-  'mcp.faq.11.a': {
-    en: 'No. They ship with the Claude Code comfy-cloud plugin. Desktop connects to the same MCP server, so every tool works; just ask in plain language.',
-    'zh-CN':
-      '不可以。斜杠命令随 Claude Code 的 comfy-cloud 插件一起提供。Claude Desktop 连接的是同一个 MCP 服务器，因此所有工具都能使用；直接用自然语言提问即可。'
-  },
-  'mcp.faq.12.q': {
-    en: 'Is it generally available?',
-    'zh-CN': '现已正式发布了吗？'
-  },
-  'mcp.faq.12.a': {
-    en: 'The cloud connection is in open beta and available to everyone with a Comfy account. The local connection is released and open source — install it today with pip install comfy-mcp.',
-    'zh-CN':
-      '云端连接目前处于公开测试阶段，任何拥有 Comfy 账户的人都可以使用。本地连接已正式发布并开源——现在就可以通过 pip install comfy-mcp 安装。'
   },
 
   // SiteNav

--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -2037,8 +2037,8 @@ const translations = {
 
   // MCP – HeroSection
   'mcp.hero.heading': {
-    en: 'Drive ComfyUI from\nany AI agent.',
-    'zh-CN': '让任何 AI 智能体\n驱动 ComfyUI。'
+    en: 'Drive ComfyUI from\nany AI agent,\nlocal or cloud.',
+    'zh-CN': '让任何 AI 智能体\n驱动 ComfyUI，\n本地或云端。'
   },
   'mcp.hero.subtitle': {
     en: 'Connect any AI agent to ComfyUI on Comfy Cloud GPUs or on your own machine. Generate images, video, audio and 3D, search models, nodes and templates, and run real workflows.',

--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -2500,9 +2500,9 @@ const translations = {
     'zh-CN': '支持哪些客户端？'
   },
   'mcp.faq.1.a': {
-    en: 'Any MCP-compatible client. For the cloud connection, add https://cloud.comfy.org/mcp as a custom connector or remote MCP server, then sign in when prompted. For the local connection, your client launches the open-source comfy-mcp server: Claude Code, Claude Desktop, Cursor, and any client that supports stdio servers. Send the docs https://docs.comfy.org/agent-tools/mcp to your agent and it will figure out the installation for you.',
+    en: 'Any MCP-compatible client. For the cloud connection, add https://cloud.comfy.org/mcp as a custom connector or remote MCP server, then sign in when prompted. For the local connection, your client launches the open-source comfy-mcp server: Claude Code, Claude Desktop, Cursor, and any client that supports stdio servers. Send the docs https://docs.comfy.org/agent-tools/mcp.md to your agent and it will figure out the installation for you.',
     'zh-CN':
-      '任何兼容 MCP 的客户端。云端连接：将 https://cloud.comfy.org/mcp 添加为自定义连接器或远程 MCP 服务器，然后在提示时登录。本地连接：由客户端启动开源的 comfy-mcp 服务器，支持 Claude Code、Claude Desktop、Cursor 以及任何支持 stdio 服务器的客户端。将文档 https://docs.comfy.org/agent-tools/mcp 发送给你的智能体，它会为你完成安装。'
+      '任何兼容 MCP 的客户端。云端连接：将 https://cloud.comfy.org/mcp 添加为自定义连接器或远程 MCP 服务器，然后在提示时登录。本地连接：由客户端启动开源的 comfy-mcp 服务器，支持 Claude Code、Claude Desktop、Cursor 以及任何支持 stdio 服务器的客户端。将文档 https://docs.comfy.org/agent-tools/mcp.md 发送给你的智能体，它会为你完成安装。'
   },
   'mcp.faq.2.q': {
     en: "What's the server URL?",
@@ -2536,9 +2536,9 @@ const translations = {
     'zh-CN': '我需要 API 密钥吗？'
   },
   'mcp.faq.5.a': {
-    en: 'On the local connection, driving your own ComfyUI needs no key and no account. You only sign in when you run partner models: through comfy-cli with a browser sign-in, or with a Comfy API key. On the cloud connection, Claude Code, Claude Desktop, Codex, and OpenClaw sign in with OAuth; Cursor and Hermes need a Comfy API key for now. Just copy https://docs.comfy.org/agent-tools/mcp and your agent will figure out the installation for you.',
+    en: 'On the local connection, driving your own ComfyUI needs no key and no account. You only sign in when you run partner models: through comfy-cli with a browser sign-in, or with a Comfy API key. On the cloud connection, Claude Code, Claude Desktop, Codex, and OpenClaw sign in with OAuth; Cursor and Hermes need a Comfy API key for now. Just copy https://docs.comfy.org/agent-tools/mcp.md and your agent will figure out the installation for you.',
     'zh-CN':
-      '本地连接方面，驱动你自己的 ComfyUI 不需要密钥，也不需要账户。只有在运行合作伙伴模型时才需要登录：通过 comfy-cli 在浏览器中登录，或使用 Comfy API 密钥。云端连接方面，Claude Code、Claude Desktop、Codex 和 OpenClaw 通过 OAuth 登录；Cursor 和 Hermes 目前需要 Comfy API 密钥。只需复制 https://docs.comfy.org/agent-tools/mcp，你的智能体就会为你完成安装。'
+      '本地连接方面，驱动你自己的 ComfyUI 不需要密钥，也不需要账户。只有在运行合作伙伴模型时才需要登录：通过 comfy-cli 在浏览器中登录，或使用 Comfy API 密钥。云端连接方面，Claude Code、Claude Desktop、Codex 和 OpenClaw 通过 OAuth 登录；Cursor 和 Hermes 目前需要 Comfy API 密钥。只需复制 https://docs.comfy.org/agent-tools/mcp.md，你的智能体就会为你完成安装。'
   },
   'mcp.faq.6.q': {
     en: 'Does it cost anything?',

--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -2041,9 +2041,9 @@ const translations = {
     'zh-CN': '让任何 AI 智能体\n驱动 ComfyUI，\n本地或云端。'
   },
   'mcp.hero.subtitle': {
-    en: 'Turn your agent into a creative technologist. Generate images, video, audio and 3D, search models, nodes and templates, and run real workflows. Built for reproducibility and teamwork.',
+    en: 'Turn your agent into a creative technologist. Generate images, video, audio and 3D, search models, nodes and templates, and run real workflows. Built for batch generation, reproducibility and teamwork.',
     'zh-CN':
-      '让你的智能体成为创意技术专家。生成图像、视频、音频和 3D，搜索模型、节点与模板，并运行真实工作流。为可复现性与团队协作而打造。'
+      '让你的智能体成为创意技术专家。生成图像、视频、音频和 3D，搜索模型、节点与模板，并运行真实工作流。为批量生成、可复现性与团队协作而打造。'
   },
   'mcp.hero.demoPromptKeyframeBoard': {
     en: 'board the launch film — 8 key frames from the brief',

--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -2152,9 +2152,9 @@ const translations = {
     'zh-CN': '配置 Comfy MCP'
   },
   'mcp.setup.subtitle': {
-    en: 'First pick where it runs: on Comfy Cloud GPUs, or on the ComfyUI on your own machine. Then add the server yourself, or ask your agent to install it. Either way, the full ComfyUI toolset lands right in your chat.',
+    en: 'Pick where it runs: Comfy Cloud GPUs, or your own machine. Add the server yourself or ask your agent to install it, and the full ComfyUI toolset lands in your chat.',
     'zh-CN':
-      '先选择运行位置：Comfy Cloud 的 GPU，或你自己机器上的 ComfyUI。然后自行添加服务器，或让你的智能体代劳。无论哪种方式，ComfyUI 全套工具都会直接进入你的对话。'
+      '选择运行位置：Comfy Cloud 的 GPU，或你自己的机器。自行添加服务器，或让智能体代劳，ComfyUI 全套工具即可进入你的对话。'
   },
   'mcp.setup.connections.tabsLabel': {
     en: 'Pick your connection',

--- a/apps/website/src/pages/mcp.astro
+++ b/apps/website/src/pages/mcp.astro
@@ -16,8 +16,8 @@ import { t } from '../i18n/translations'
 >
   <HeroSection locale="en" client:load />
   <SetupSection locale="en" client:visible />
-  <WhySection locale="en" />
   <ToolsSection locale="en" />
+  <WhySection locale="en" />
   <HowItWorksSection locale="en" />
   <ProductCardsSection locale="en" label-key="products.labelProducts" />
   <FAQSection client:visible locale="en" />

--- a/apps/website/src/pages/zh-CN/mcp.astro
+++ b/apps/website/src/pages/zh-CN/mcp.astro
@@ -16,8 +16,8 @@ import { t } from '../../i18n/translations'
 >
   <HeroSection locale="zh-CN" client:load />
   <SetupSection locale="zh-CN" client:visible />
-  <WhySection locale="zh-CN" />
   <ToolsSection locale="zh-CN" />
+  <WhySection locale="zh-CN" />
   <HowItWorksSection locale="zh-CN" />
   <ProductCardsSection locale="zh-CN" label-key="products.labelProducts" />
   <FAQSection client:visible locale="zh-CN" />

--- a/apps/website/src/scripts/posthog.ts
+++ b/apps/website/src/scripts/posthog.ts
@@ -50,6 +50,15 @@ export function captureDownloadClick(platform: Platform) {
   }
 }
 
+export function captureMcpConnectionTabClick(connection: string) {
+  if (!initialized) return
+  try {
+    posthog.capture('website:mcp_connection_tab_clicked', { connection })
+  } catch (error) {
+    console.error('PostHog MCP connection tab capture failed', error)
+  }
+}
+
 export function captureMcpClientTabClick(client: string) {
   if (!initialized) return
   try {

--- a/apps/website/src/templates/mcp/FAQSection.vue
+++ b/apps/website/src/templates/mcp/FAQSection.vue
@@ -5,7 +5,7 @@ import { t } from '../../i18n/translations'
 
 const { locale = 'en' } = defineProps<{ locale?: Locale }>()
 
-const faqNumbers = [1, 2, 3, 4, 5, 6, 7, 8, 9] as const
+const faqNumbers = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12] as const
 
 const faqs = faqNumbers.map((n) => ({
   id: String(n),

--- a/apps/website/src/templates/mcp/FAQSection.vue
+++ b/apps/website/src/templates/mcp/FAQSection.vue
@@ -5,7 +5,7 @@ import { t } from '../../i18n/translations'
 
 const { locale = 'en' } = defineProps<{ locale?: Locale }>()
 
-const faqNumbers = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12] as const
+const faqNumbers = [1, 2, 3, 4, 5, 6, 7, 8, 9] as const
 
 const faqs = faqNumbers.map((n) => ({
   id: String(n),

--- a/apps/website/src/templates/mcp/SetupSection.test.ts
+++ b/apps/website/src/templates/mcp/SetupSection.test.ts
@@ -1,0 +1,114 @@
+// @vitest-environment happy-dom
+import userEvent from '@testing-library/user-event'
+import { render, screen } from '@testing-library/vue'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import SetupSection from './SetupSection.vue'
+
+const { connectionSpy, clientSpy } = vi.hoisted(() => ({
+  connectionSpy: vi.fn(),
+  clientSpy: vi.fn()
+}))
+
+vi.mock('../../scripts/posthog', () => ({
+  captureMcpConnectionTabClick: connectionSpy,
+  captureMcpClientTabClick: clientSpy
+}))
+
+const MCP_ENDPOINT = 'https://cloud.comfy.org/mcp'
+
+function renderSetup() {
+  return render(SetupSection, {
+    props: { locale: 'en' },
+    // The walkthrough clip is irrelevant here and <video> is inert in
+    // happy-dom, so stub it out.
+    global: { stubs: { VideoPlayer: true } }
+  })
+}
+
+// reka-ui tab triggers activate on the pointer sequence, not a bare synthetic
+// click, so drive them through userEvent.
+async function selectTab(name: RegExp | string) {
+  await userEvent.click(screen.getByRole('tab', { name }))
+}
+
+describe('SetupSection', () => {
+  beforeEach(() => {
+    connectionSpy.mockClear()
+    clientSpy.mockClear()
+  })
+
+  it('defaults to the cloud connection with the endpoint URL and subscription note', () => {
+    renderSetup()
+
+    expect(screen.getByText(MCP_ENDPOINT)).toBeTruthy()
+    expect(
+      screen.getByRole('link', { name: 'subscription of any tier' })
+    ).toBeTruthy()
+    // Local-only content stays unmounted until the local tab is selected.
+    expect(screen.queryByText('pip install comfy-mcp')).toBeNull()
+    expect(screen.queryByText('Recommended')).toBeNull()
+  })
+
+  it('swaps in the open-source install flow when local is selected', async () => {
+    renderSetup()
+    await selectTab(/Local ComfyUI/)
+
+    expect(screen.getByText('pip install comfy-mcp')).toBeTruthy()
+    expect(
+      screen.getByText('claude mcp add comfy-mcp -- comfy-mcp')
+    ).toBeTruthy()
+    expect(screen.getByText('Recommended')).toBeTruthy()
+    expect(
+      screen
+        .getByRole('link', { name: 'open source on GitHub' })
+        .getAttribute('href')
+    ).toBe('https://github.com/Comfy-Org/comfy-mcp')
+    // The cloud-only subscription note is replaced, not shown alongside.
+    expect(
+      screen.queryByRole('link', { name: 'subscription of any tier' })
+    ).toBeNull()
+  })
+
+  it('restores the cloud panel when switching back', async () => {
+    renderSetup()
+    await selectTab(/Local ComfyUI/)
+    await selectTab(/Comfy Cloud/)
+
+    expect(screen.getByText(MCP_ENDPOINT)).toBeTruthy()
+    expect(
+      screen.getByRole('link', { name: 'subscription of any tier' })
+    ).toBeTruthy()
+    expect(screen.queryByText('pip install comfy-mcp')).toBeNull()
+  })
+
+  it('hands agents the markdown docs URLs in the ask-your-agent commands', async () => {
+    renderSetup()
+
+    // Cloud: the agent card appears on clients without a walkthrough clip.
+    await selectTab('Claude Code Terminal')
+    expect(
+      screen.getByText(/docs\.comfy\.org\/agent-tools\/mcp\.md$/m)
+    ).toBeTruthy()
+
+    // Local: the default client pairs with the agent card and the local anchor.
+    await selectTab(/Local ComfyUI/)
+    expect(
+      screen.getByText(
+        /docs\.comfy\.org\/agent-tools\/mcp\.md#local-comfy-mcp-connection/
+      )
+    ).toBeTruthy()
+  })
+
+  it('captures analytics once per tab change, deduping re-clicks', async () => {
+    renderSetup()
+
+    await selectTab(/Local ComfyUI/)
+    await selectTab(/Local ComfyUI/)
+    expect(connectionSpy).toHaveBeenCalledTimes(1)
+    expect(connectionSpy).toHaveBeenCalledWith('local')
+
+    await selectTab('Cursor')
+    expect(clientSpy).toHaveBeenCalledWith('local-cursor')
+  })
+})

--- a/apps/website/src/templates/mcp/SetupSection.vue
+++ b/apps/website/src/templates/mcp/SetupSection.vue
@@ -253,8 +253,7 @@ const copiedLabel = t('ui.copied', locale)
             rel="noopener noreferrer"
             class="focus-visible:ring-primary-comfy-yellow/50 rounded-sm text-primary-comfy-canvas underline underline-offset-4 focus-visible:ring-2 focus-visible:outline-none"
             >{{ t('mcp.setup.local.requirementLinkLabel', locale) }}</a
-          >{{ t('mcp.setup.local.requirementSuffix', locale)
-          }}{{ t('mcp.setup.local.requirementFootnote', locale) }}
+          >{{ t('mcp.setup.local.requirementSuffix', locale) }}
         </p>
       </template>
     </SectionHeader>

--- a/apps/website/src/templates/mcp/SetupSection.vue
+++ b/apps/website/src/templates/mcp/SetupSection.vue
@@ -8,14 +8,12 @@ import CopyableField from '../../components/ui/copyable-field/CopyableField.vue'
 import { externalLinks, getRoutes } from '../../config/routes'
 import type { Locale } from '../../i18n/translations'
 import { t } from '../../i18n/translations'
-import { captureMcpClientTabClick } from '../../scripts/posthog'
+import {
+  captureMcpClientTabClick,
+  captureMcpConnectionTabClick
+} from '../../scripts/posthog'
 
 const { locale = 'en' } = defineProps<{ locale?: Locale }>()
-
-const agentCommand = t('mcp.setup.agent.command', locale).replace(
-  '{url}',
-  externalLinks.docsMcp
-)
 
 interface McpClient {
   id: string
@@ -29,7 +27,21 @@ interface McpClient {
   video?: string
 }
 
-const clients: McpClient[] = [
+interface McpConnection {
+  id: 'cloud' | 'local'
+  name: string
+  tagline: string
+  /** Value surfaced in the manual card's copy field (server URL or install command). */
+  copyValue: string
+  manualTitle: string
+  manualDescription: string
+  agentCommand: string
+  /** The comfy-skills plugin ships cloud slash commands only. */
+  showSkillsNote: boolean
+  clients: McpClient[]
+}
+
+const cloudClients: McpClient[] = [
   {
     id: 'claude-desktop',
     name: 'Claude Desktop',
@@ -82,17 +94,110 @@ const clients: McpClient[] = [
   }
 ]
 
-const activeClientId = ref(clients[0].id)
-const activeClient = computed(
+// Same stdio registration for every JSON-config client (source:
+// docs.comfy.org/agent-tools/mcp#manual-configuration).
+const LOCAL_CONFIG_SNIPPET =
+  '{ "mcpServers": { "comfy-mcp": { "command": "comfy-mcp" } } }'
+
+const localClients: McpClient[] = [
+  {
+    id: 'local-claude-code',
+    name: 'Claude Code Terminal',
+    step: t('mcp.setup.local.clients.claudeCode.step', locale),
+    command: 'claude mcp add comfy-mcp -- comfy-mcp',
+    showAgentCard: true
+  },
+  {
+    id: 'local-claude-desktop',
+    name: 'Claude Desktop',
+    step: t('mcp.setup.local.clients.claudeDesktop.step', locale),
+    command: LOCAL_CONFIG_SNIPPET,
+    showAgentCard: true
+  },
+  {
+    id: 'local-cursor',
+    name: 'Cursor',
+    step: t('mcp.setup.local.clients.cursor.step', locale),
+    command: LOCAL_CONFIG_SNIPPET,
+    showAgentCard: true
+  },
+  {
+    id: 'local-other',
+    name: t('mcp.setup.clients.other.name', locale),
+    step: t('mcp.setup.local.clients.other.step', locale),
+    link: {
+      label: t('mcp.setup.clients.other.linkLabel', locale),
+      href: externalLinks.docsMcpLocal
+    },
+    showAgentCard: true
+  }
+]
+
+const connections: McpConnection[] = [
+  {
+    id: 'cloud',
+    name: t('mcp.setup.connections.cloud.name', locale),
+    tagline: t('mcp.setup.connections.cloud.tagline', locale),
+    copyValue: externalLinks.mcpEndpoint,
+    manualTitle: t('mcp.setup.manual.title', locale),
+    manualDescription: t('mcp.setup.manual.description', locale),
+    agentCommand: t('mcp.setup.agent.command', locale).replace(
+      '{url}',
+      externalLinks.docsMcp
+    ),
+    showSkillsNote: true,
+    clients: cloudClients
+  },
+  {
+    id: 'local',
+    name: t('mcp.setup.connections.local.name', locale),
+    tagline: t('mcp.setup.connections.local.tagline', locale),
+    copyValue: 'pip install comfy-mcp',
+    manualTitle: t('mcp.setup.local.manual.title', locale),
+    manualDescription: t('mcp.setup.local.manual.description', locale),
+    agentCommand: t('mcp.setup.local.agent.command', locale).replace(
+      '{url}',
+      externalLinks.docsMcpLocal
+    ),
+    showSkillsNote: false,
+    clients: localClients
+  }
+]
+
+const activeConnectionId = ref<string>(connections[0].id)
+const activeConnection = computed(
   () =>
-    clients.find((client) => client.id === activeClientId.value) ?? clients[0]
+    connections.find((conn) => conn.id === activeConnectionId.value) ??
+    connections[0]
 )
-const manualTitle = computed(
-  () => activeClient.value.manualTitle ?? t('mcp.setup.manual.title', locale)
+
+const activeClientIds = ref<Record<string, string>>(
+  Object.fromEntries(connections.map((conn) => [conn.id, conn.clients[0].id]))
 )
+
+function activeClientFor(conn: McpConnection): McpClient {
+  return (
+    conn.clients.find(
+      (client) => client.id === activeClientIds.value[conn.id]
+    ) ?? conn.clients[0]
+  )
+}
+
+function manualTitleFor(conn: McpConnection): string {
+  return activeClientFor(conn).manualTitle ?? conn.manualTitle
+}
 
 // reka-ui re-emits update:modelValue even when the value is unchanged
 // (re-clicking the active tab), so dedupe before capturing.
+let lastTrackedConnectionId: string | undefined
+function onConnectionTabChange(value: string | number | undefined) {
+  if (!value) return
+  const id = String(value)
+  if (id === lastTrackedConnectionId) return
+  lastTrackedConnectionId = id
+  captureMcpConnectionTabClick(id)
+}
+
 let lastTrackedClientId: string | undefined
 function onClientTabChange(value: string | number | undefined) {
   if (!value) return
@@ -102,12 +207,12 @@ function onClientTabChange(value: string | number | undefined) {
   captureMcpClientTabClick(id)
 }
 
-const walkthroughLabel = computed(() =>
-  t('mcp.setup.walkthroughAlt', locale).replace(
+function walkthroughLabelFor(conn: McpConnection): string {
+  return t('mcp.setup.walkthroughAlt', locale).replace(
     '{client}',
-    activeClient.value.name
+    activeClientFor(conn).name
   )
-)
+}
 
 const copyLabel = t('ui.copy', locale)
 const copiedLabel = t('ui.copied', locale)
@@ -128,7 +233,10 @@ const copiedLabel = t('ui.copied', locale)
         <p class="mt-4 max-w-xl text-sm text-smoke-700 lg:text-base">
           {{ t('mcp.setup.subtitle', locale) }}
         </p>
-        <p class="mt-4 max-w-xl text-xs text-primary-warm-gray">
+        <p
+          v-if="activeConnection.id === 'cloud'"
+          class="mt-4 max-w-xl text-xs text-primary-warm-gray"
+        >
           {{ t('mcp.setup.requirementPrefix', locale)
           }}<a
             :href="getRoutes(locale).cloudPricing"
@@ -137,121 +245,172 @@ const copiedLabel = t('ui.copied', locale)
           >{{ t('mcp.setup.requirementSuffix', locale)
           }}{{ t('mcp.setup.requirementFootnote', locale) }}
         </p>
+        <p v-else class="mt-4 max-w-xl text-xs text-primary-warm-gray">
+          {{ t('mcp.setup.local.requirementPrefix', locale)
+          }}<a
+            :href="externalLinks.comfyMcpRepo"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="focus-visible:ring-primary-comfy-yellow/50 rounded-sm text-primary-comfy-canvas underline underline-offset-4 focus-visible:ring-2 focus-visible:outline-none"
+            >{{ t('mcp.setup.local.requirementLinkLabel', locale) }}</a
+          >{{ t('mcp.setup.local.requirementSuffix', locale)
+          }}{{ t('mcp.setup.local.requirementFootnote', locale) }}
+        </p>
       </template>
     </SectionHeader>
 
     <TabsRoot
-      v-model="activeClientId"
+      v-model="activeConnectionId"
       activation-mode="manual"
       class="mt-10 block"
-      @update:model-value="onClientTabChange"
+      @update:model-value="onConnectionTabChange"
     >
       <TabsList
-        :aria-label="t('mcp.setup.manual.tabsLabel', locale)"
-        class="grid grid-cols-1 gap-px rounded-2xl border border-white/15 bg-primary-comfy-ink p-1 min-[360px]:grid-cols-2 lg:inline-flex lg:flex-nowrap"
+        :aria-label="t('mcp.setup.connections.tabsLabel', locale)"
+        class="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:max-w-3xl"
       >
         <TabsTrigger
-          v-for="client in clients"
-          :key="client.id"
-          :value="client.id"
-          class="focus-visible:ring-primary-comfy-yellow/50 data-[state=active]:bg-primary-comfy-yellow shrink-0 cursor-pointer rounded-lg bg-white/8 px-2 py-2.5 text-[10px] font-bold tracking-wider whitespace-nowrap text-smoke-700 uppercase transition-colors hover:text-primary-comfy-canvas focus-visible:ring-2 focus-visible:outline-none data-[state=active]:text-primary-comfy-ink lg:rounded-none lg:px-6 lg:text-xs lg:first:rounded-l-xl lg:last:rounded-r-xl"
+          v-for="conn in connections"
+          :key="conn.id"
+          :value="conn.id"
+          class="focus-visible:ring-primary-comfy-yellow/50 data-[state=active]:border-primary-comfy-yellow cursor-pointer rounded-2xl border border-white/15 bg-white/4 p-5 text-left transition-colors hover:bg-white/8 focus-visible:ring-2 focus-visible:outline-none data-[state=active]:bg-white/8"
         >
-          {{ client.name }}
+          <span
+            class="block text-sm font-bold tracking-wider text-primary-comfy-canvas uppercase"
+          >
+            {{ conn.name }}
+          </span>
+          <span class="mt-1.5 block text-xs text-smoke-700">
+            {{ conn.tagline }}
+          </span>
         </TabsTrigger>
       </TabsList>
 
-      <div class="mt-10 grid grid-cols-1 gap-6 lg:grid-cols-2">
-        <div
-          class="bg-transparency-white-t4 flex flex-col rounded-3xl p-6 lg:p-8"
+      <TabsContent
+        v-for="conn in connections"
+        :key="conn.id"
+        :value="conn.id"
+        class="mt-10 block"
+      >
+        <TabsRoot
+          v-model="activeClientIds[conn.id]"
+          activation-mode="manual"
+          class="block"
+          @update:model-value="onClientTabChange"
         >
-          <h3 class="text-xl font-light text-primary-comfy-canvas lg:text-2xl">
-            {{ manualTitle }}
-          </h3>
-          <p class="mt-3 text-sm text-smoke-700">
-            {{ t('mcp.setup.manual.description', locale) }}
-          </p>
-          <div class="mt-6">
-            <CopyableField
-              :value="externalLinks.mcpEndpoint"
-              :copy-label="copyLabel"
-              :copied-label="copiedLabel"
-            />
-          </div>
-          <TabsContent
-            v-for="client in clients"
-            :key="client.id"
-            :value="client.id"
-            class="mt-6 flex min-h-36 flex-col gap-3"
+          <TabsList
+            :aria-label="t('mcp.setup.manual.tabsLabel', locale)"
+            class="grid grid-cols-1 gap-px rounded-2xl border border-white/15 bg-primary-comfy-ink p-1 min-[360px]:grid-cols-2 lg:inline-flex lg:flex-nowrap"
           >
-            <p class="text-sm text-smoke-700">
-              {{ client.step
-              }}<a
-                v-if="client.link"
-                :href="client.link.href"
-                target="_blank"
-                rel="noopener noreferrer"
-                class="focus-visible:ring-primary-comfy-yellow/50 rounded-sm text-primary-comfy-canvas underline underline-offset-4 focus-visible:ring-2 focus-visible:outline-none"
-                >{{ client.link.label }}</a
-              >
-            </p>
-            <CopyableField
-              v-if="client.command"
-              :value="client.command"
-              :copy-label="copyLabel"
-              :copied-label="copiedLabel"
-            />
-          </TabsContent>
-        </div>
-
-        <div
-          class="bg-transparency-white-t4 flex flex-col rounded-3xl"
-          :class="
-            activeClient.showAgentCard
-              ? 'p-6 lg:p-8'
-              : 'relative overflow-hidden max-lg:aspect-video'
-          "
-        >
-          <template v-if="activeClient.showAgentCard">
-            <h3
-              class="text-xl font-light text-primary-comfy-canvas lg:text-2xl"
+            <TabsTrigger
+              v-for="client in conn.clients"
+              :key="client.id"
+              :value="client.id"
+              class="focus-visible:ring-primary-comfy-yellow/50 data-[state=active]:bg-primary-comfy-yellow shrink-0 cursor-pointer rounded-lg bg-white/8 px-2 py-2.5 text-[10px] font-bold tracking-wider whitespace-nowrap text-smoke-700 uppercase transition-colors hover:text-primary-comfy-canvas focus-visible:ring-2 focus-visible:outline-none data-[state=active]:text-primary-comfy-ink lg:rounded-none lg:px-6 lg:text-xs lg:first:rounded-l-xl lg:last:rounded-r-xl"
             >
-              {{ t('mcp.setup.agent.title', locale) }}
-            </h3>
-            <p class="mt-3 text-sm text-smoke-700">
-              {{ t('mcp.setup.agent.description', locale) }}
-            </p>
-            <div class="mt-6">
-              <CopyableField
-                :value="agentCommand"
-                :copy-label="copyLabel"
-                :copied-label="copiedLabel"
+              {{ client.name }}
+            </TabsTrigger>
+          </TabsList>
+
+          <div class="mt-10 grid grid-cols-1 gap-6 lg:grid-cols-2">
+            <div
+              class="bg-transparency-white-t4 flex flex-col rounded-3xl p-6 lg:p-8"
+            >
+              <h3
+                class="text-xl font-light text-primary-comfy-canvas lg:text-2xl"
+              >
+                {{ manualTitleFor(conn) }}
+              </h3>
+              <p class="mt-3 text-sm text-smoke-700">
+                {{ conn.manualDescription }}
+              </p>
+              <div class="mt-6">
+                <CopyableField
+                  :value="conn.copyValue"
+                  :copy-label="copyLabel"
+                  :copied-label="copiedLabel"
+                />
+              </div>
+              <TabsContent
+                v-for="client in conn.clients"
+                :key="client.id"
+                :value="client.id"
+                class="mt-6 flex min-h-36 flex-col gap-3"
+              >
+                <p class="text-sm text-smoke-700">
+                  {{ client.step
+                  }}<a
+                    v-if="client.link"
+                    :href="client.link.href"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    class="focus-visible:ring-primary-comfy-yellow/50 rounded-sm text-primary-comfy-canvas underline underline-offset-4 focus-visible:ring-2 focus-visible:outline-none"
+                    >{{ client.link.label }}</a
+                  >
+                </p>
+                <CopyableField
+                  v-if="client.command"
+                  :value="client.command"
+                  :copy-label="copyLabel"
+                  :copied-label="copiedLabel"
+                />
+              </TabsContent>
+            </div>
+
+            <div
+              class="bg-transparency-white-t4 flex flex-col rounded-3xl"
+              :class="
+                activeClientFor(conn).showAgentCard
+                  ? 'p-6 lg:p-8'
+                  : 'relative overflow-hidden max-lg:aspect-video'
+              "
+            >
+              <template v-if="activeClientFor(conn).showAgentCard">
+                <h3
+                  class="text-xl font-light text-primary-comfy-canvas lg:text-2xl"
+                >
+                  {{ t('mcp.setup.agent.title', locale) }}
+                </h3>
+                <p class="mt-3 text-sm text-smoke-700">
+                  {{ t('mcp.setup.agent.description', locale) }}
+                </p>
+                <div class="mt-6">
+                  <CopyableField
+                    :value="conn.agentCommand"
+                    :copy-label="copyLabel"
+                    :copied-label="copiedLabel"
+                  />
+                </div>
+                <p
+                  v-if="conn.showSkillsNote"
+                  class="mt-6 text-sm text-smoke-700"
+                >
+                  {{ t('mcp.setup.skillsNote', locale)
+                  }}<a
+                    :href="externalLinks.mcpSkills"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    class="focus-visible:ring-primary-comfy-yellow/50 rounded-sm text-primary-comfy-canvas underline underline-offset-4 focus-visible:ring-2 focus-visible:outline-none"
+                    >{{ t('mcp.setup.skillsLink', locale) }}</a
+                  >
+                </p>
+              </template>
+              <VideoPlayer
+                v-else-if="activeClientFor(conn).video"
+                :key="activeClientFor(conn).id"
+                :locale="locale"
+                :aria-label="walkthroughLabelFor(conn)"
+                :src="activeClientFor(conn).video"
+                autoplay
+                loop
+                hide-controls
+                fit="contain"
+                class="absolute inset-0 size-full bg-transparent"
               />
             </div>
-            <p class="mt-6 text-sm text-smoke-700">
-              {{ t('mcp.setup.skillsNote', locale)
-              }}<a
-                :href="externalLinks.mcpSkills"
-                target="_blank"
-                rel="noopener noreferrer"
-                class="focus-visible:ring-primary-comfy-yellow/50 rounded-sm text-primary-comfy-canvas underline underline-offset-4 focus-visible:ring-2 focus-visible:outline-none"
-                >{{ t('mcp.setup.skillsLink', locale) }}</a
-              >
-            </p>
-          </template>
-          <VideoPlayer
-            v-else-if="activeClient.video"
-            :key="activeClient.id"
-            :locale="locale"
-            :aria-label="walkthroughLabel"
-            :src="activeClient.video"
-            autoplay
-            loop
-            hide-controls
-            fit="contain"
-            class="absolute inset-0 size-full bg-transparent"
-          />
-        </div>
-      </div>
+          </div>
+        </TabsRoot>
+      </TabsContent>
     </TabsRoot>
   </section>
 </template>

--- a/apps/website/src/templates/mcp/SetupSection.vue
+++ b/apps/website/src/templates/mcp/SetupSection.vue
@@ -36,6 +36,8 @@ interface McpConnection {
   manualTitle: string
   manualDescription: string
   agentCommand: string
+  /** Badge the agent card as the recommended path (local setup is fiddlier by hand). */
+  agentRecommended: boolean
   /** The comfy-skills plugin ships cloud slash commands only. */
   showSkillsNote: boolean
   clients: McpClient[]
@@ -145,6 +147,7 @@ const connections: McpConnection[] = [
       '{url}',
       externalLinks.docsMcpMd
     ),
+    agentRecommended: false,
     showSkillsNote: true,
     clients: cloudClients
   },
@@ -159,6 +162,7 @@ const connections: McpConnection[] = [
       '{url}',
       externalLinks.docsMcpLocalMd
     ),
+    agentRecommended: true,
     showSkillsNote: false,
     clients: localClients
   }
@@ -366,9 +370,15 @@ const copiedLabel = t('ui.copied', locale)
             >
               <template v-if="activeClientFor(conn).showAgentCard">
                 <h3
-                  class="text-xl font-light text-primary-comfy-canvas lg:text-2xl"
+                  class="flex flex-wrap items-center gap-2.5 text-xl font-light text-primary-comfy-canvas lg:text-2xl"
                 >
                   {{ t('mcp.setup.agent.title', locale) }}
+                  <span
+                    v-if="conn.agentRecommended"
+                    class="bg-primary-comfy-yellow rounded-md px-2 py-1 text-[10px] font-bold tracking-wider text-primary-comfy-ink uppercase"
+                  >
+                    {{ t('mcp.setup.agent.recommended', locale) }}
+                  </span>
                 </h3>
                 <p class="mt-3 text-sm text-smoke-700">
                   {{ t('mcp.setup.agent.description', locale) }}

--- a/apps/website/src/templates/mcp/SetupSection.vue
+++ b/apps/website/src/templates/mcp/SetupSection.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { cn } from '@comfyorg/tailwind-utils'
 import { TabsContent, TabsList, TabsRoot, TabsTrigger } from 'reka-ui'
-import { computed, ref } from 'vue'
+import { ref } from 'vue'
 
 import SectionHeader from '../../components/common/SectionHeader.vue'
 import VideoPlayer from '../../components/common/VideoPlayer.vue'
@@ -16,8 +16,9 @@ import {
 
 const { locale = 'en' } = defineProps<{ locale?: Locale }>()
 
+type ConnectionId = 'cloud' | 'local'
+
 interface McpClient {
-  id: string
   name: string
   step: string
   command?: string
@@ -29,7 +30,6 @@ interface McpClient {
 }
 
 interface McpConnection {
-  id: 'cloud' | 'local'
   name: string
   tagline: string
   /** Value surfaced in the manual card's copy field (server URL or install command). */
@@ -41,35 +41,32 @@ interface McpConnection {
   agentRecommended: boolean
   /** The comfy-skills plugin ships cloud slash commands only. */
   showSkillsNote: boolean
-  clients: McpClient[]
+  /** Client id → client; insertion order is the tab order. */
+  clients: Record<string, McpClient>
 }
 
-const cloudClients: McpClient[] = [
-  {
-    id: 'claude-desktop',
+const cloudClients: Record<string, McpClient> = {
+  'claude-desktop': {
     name: 'Claude Desktop',
     step: t('mcp.setup.clients.claudeDesktop.step', locale),
     manualTitle: t('mcp.setup.clients.claudeDesktop.manualTitle', locale),
     showAgentCard: false,
     video: 'https://media.comfy.org/website/mcp/setup-claude-desktop-v2.mp4'
   },
-  {
-    id: 'claude-code',
+  'claude-code': {
     name: 'Claude Code Terminal',
     step: t('mcp.setup.clients.claudeCode.step', locale),
     command: `claude mcp add --transport http comfy-cloud ${externalLinks.mcpEndpoint}`,
     showAgentCard: true
   },
-  {
-    id: 'codex',
+  codex: {
     name: 'Codex',
     step: t('mcp.setup.clients.codex.step', locale),
     command: `codex mcp add comfy-cloud --url ${externalLinks.mcpEndpoint}`,
     showAgentCard: false,
     video: 'https://media.comfy.org/website/mcp/setup-codex-oauth-v2.mp4'
   },
-  {
-    id: 'cursor',
+  cursor: {
     name: 'Cursor',
     step: t('mcp.setup.clients.cursor.step', locale),
     link: {
@@ -78,15 +75,13 @@ const cloudClients: McpClient[] = [
     },
     showAgentCard: true
   },
-  {
-    id: 'openclaw',
+  openclaw: {
     name: 'OpenClaw',
     step: t('mcp.setup.clients.openclaw.step', locale),
     command: `openclaw skills install @comfy-org/comfy\nopenclaw mcp set comfy '{"url":"${externalLinks.mcpEndpoint}","transport":"streamable-http","auth":"oauth"}'`,
     showAgentCard: true
   },
-  {
-    id: 'other',
+  other: {
     name: t('mcp.setup.clients.other.name', locale),
     step: t('mcp.setup.clients.other.step', locale),
     link: {
@@ -95,37 +90,33 @@ const cloudClients: McpClient[] = [
     },
     showAgentCard: true
   }
-]
+}
 
 // Same stdio registration for every JSON-config client (source:
 // docs.comfy.org/agent-tools/mcp#manual-configuration).
 const LOCAL_CONFIG_SNIPPET =
   '{ "mcpServers": { "comfy-mcp": { "command": "comfy-mcp" } } }'
 
-const localClients: McpClient[] = [
-  {
-    id: 'local-claude-code',
+const localClients: Record<string, McpClient> = {
+  'local-claude-code': {
     name: 'Claude Code Terminal',
     step: t('mcp.setup.local.clients.claudeCode.step', locale),
     command: 'claude mcp add comfy-mcp -- comfy-mcp',
     showAgentCard: true
   },
-  {
-    id: 'local-claude-desktop',
+  'local-claude-desktop': {
     name: 'Claude Desktop',
     step: t('mcp.setup.local.clients.claudeDesktop.step', locale),
     command: LOCAL_CONFIG_SNIPPET,
     showAgentCard: true
   },
-  {
-    id: 'local-cursor',
+  'local-cursor': {
     name: 'Cursor',
     step: t('mcp.setup.local.clients.cursor.step', locale),
     command: LOCAL_CONFIG_SNIPPET,
     showAgentCard: true
   },
-  {
-    id: 'local-other',
+  'local-other': {
     name: t('mcp.setup.clients.other.name', locale),
     step: t('mcp.setup.local.clients.other.step', locale),
     link: {
@@ -134,11 +125,10 @@ const localClients: McpClient[] = [
     },
     showAgentCard: true
   }
-]
+}
 
-const connections: McpConnection[] = [
-  {
-    id: 'cloud',
+const connections: Record<ConnectionId, McpConnection> = {
+  cloud: {
     name: t('mcp.setup.connections.cloud.name', locale),
     tagline: t('mcp.setup.connections.cloud.tagline', locale),
     copyValue: externalLinks.mcpEndpoint,
@@ -152,8 +142,7 @@ const connections: McpConnection[] = [
     showSkillsNote: true,
     clients: cloudClients
   },
-  {
-    id: 'local',
+  local: {
     name: t('mcp.setup.connections.local.name', locale),
     tagline: t('mcp.setup.connections.local.tagline', locale),
     copyValue: 'pip install comfy-mcp',
@@ -167,32 +156,28 @@ const connections: McpConnection[] = [
     showSkillsNote: false,
     clients: localClients
   }
-]
+}
 
-type ConnectionId = McpConnection['id']
+const DEFAULT_CLIENT_IDS: Record<ConnectionId, string> = {
+  cloud: 'claude-desktop',
+  local: 'local-claude-code'
+}
 
-const activeConnectionId = ref<ConnectionId>(connections[0].id)
-const activeConnection = computed(
-  () =>
-    connections.find((conn) => conn.id === activeConnectionId.value) ??
-    connections[0]
-)
-
+const activeConnectionId = ref<ConnectionId>('cloud')
 const activeClientIds = ref<Record<ConnectionId, string>>({
-  cloud: cloudClients[0].id,
-  local: localClients[0].id
+  ...DEFAULT_CLIENT_IDS
 })
 
-function activeClientFor(conn: McpConnection): McpClient {
+function activeClientFor(connId: ConnectionId): McpClient {
+  const conn = connections[connId]
   return (
-    conn.clients.find(
-      (client) => client.id === activeClientIds.value[conn.id]
-    ) ?? conn.clients[0]
+    conn.clients[activeClientIds.value[connId]] ??
+    conn.clients[DEFAULT_CLIENT_IDS[connId]]
   )
 }
 
-function manualTitleFor(conn: McpConnection): string {
-  return activeClientFor(conn).manualTitle ?? conn.manualTitle
+function manualTitleFor(connId: ConnectionId): string {
+  return activeClientFor(connId).manualTitle ?? connections[connId].manualTitle
 }
 
 // reka-ui re-emits update:modelValue even when the value is unchanged
@@ -215,10 +200,10 @@ function onClientTabChange(value: string | number | undefined) {
   captureMcpClientTabClick(id)
 }
 
-function walkthroughLabelFor(conn: McpConnection): string {
+function walkthroughLabelFor(connId: ConnectionId): string {
   return t('mcp.setup.walkthroughAlt', locale).replace(
     '{client}',
-    activeClientFor(conn).name
+    activeClientFor(connId).name
   )
 }
 
@@ -242,7 +227,7 @@ const copiedLabel = t('ui.copied', locale)
           {{ t('mcp.setup.subtitle', locale) }}
         </p>
         <p
-          v-if="activeConnection.id === 'cloud'"
+          v-if="activeConnectionId === 'cloud'"
           class="mt-4 max-w-xl text-xs text-primary-warm-gray"
         >
           {{ t('mcp.setup.requirementPrefix', locale)
@@ -277,9 +262,9 @@ const copiedLabel = t('ui.copied', locale)
         class="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:max-w-3xl"
       >
         <TabsTrigger
-          v-for="conn in connections"
-          :key="conn.id"
-          :value="conn.id"
+          v-for="(conn, connId) in connections"
+          :key="connId"
+          :value="connId"
           class="focus-visible:ring-primary-comfy-yellow/50 data-[state=active]:border-primary-comfy-yellow cursor-pointer rounded-2xl border border-white/15 bg-white/4 p-5 text-left transition-colors hover:bg-white/8 focus-visible:ring-2 focus-visible:outline-none data-[state=active]:bg-white/8"
         >
           <span
@@ -294,13 +279,13 @@ const copiedLabel = t('ui.copied', locale)
       </TabsList>
 
       <TabsContent
-        v-for="conn in connections"
-        :key="conn.id"
-        :value="conn.id"
+        v-for="(conn, connId) in connections"
+        :key="connId"
+        :value="connId"
         class="mt-10 block"
       >
         <TabsRoot
-          v-model="activeClientIds[conn.id]"
+          v-model="activeClientIds[connId]"
           activation-mode="manual"
           class="block"
           @update:model-value="onClientTabChange"
@@ -310,9 +295,9 @@ const copiedLabel = t('ui.copied', locale)
             class="grid grid-cols-1 gap-px rounded-2xl border border-white/15 bg-primary-comfy-ink p-1 min-[360px]:grid-cols-2 lg:inline-flex lg:flex-nowrap"
           >
             <TabsTrigger
-              v-for="client in conn.clients"
-              :key="client.id"
-              :value="client.id"
+              v-for="(client, clientId) in conn.clients"
+              :key="clientId"
+              :value="clientId"
               class="focus-visible:ring-primary-comfy-yellow/50 data-[state=active]:bg-primary-comfy-yellow shrink-0 cursor-pointer rounded-lg bg-white/8 px-2 py-2.5 text-[10px] font-bold tracking-wider whitespace-nowrap text-smoke-700 uppercase transition-colors hover:text-primary-comfy-canvas focus-visible:ring-2 focus-visible:outline-none data-[state=active]:text-primary-comfy-ink lg:rounded-none lg:px-6 lg:text-xs lg:first:rounded-l-xl lg:last:rounded-r-xl"
             >
               {{ client.name }}
@@ -326,7 +311,7 @@ const copiedLabel = t('ui.copied', locale)
               <h3
                 class="text-xl font-light text-primary-comfy-canvas lg:text-2xl"
               >
-                {{ manualTitleFor(conn) }}
+                {{ manualTitleFor(connId) }}
               </h3>
               <p class="mt-3 text-sm text-smoke-700">
                 {{ conn.manualDescription }}
@@ -339,9 +324,9 @@ const copiedLabel = t('ui.copied', locale)
                 />
               </div>
               <TabsContent
-                v-for="client in conn.clients"
-                :key="client.id"
-                :value="client.id"
+                v-for="(client, clientId) in conn.clients"
+                :key="clientId"
+                :value="clientId"
                 class="mt-6 flex min-h-36 flex-col gap-3"
               >
                 <p class="text-sm text-smoke-700">
@@ -368,13 +353,13 @@ const copiedLabel = t('ui.copied', locale)
               :class="
                 cn(
                   'bg-transparency-white-t4 flex flex-col rounded-3xl',
-                  activeClientFor(conn).showAgentCard
+                  activeClientFor(connId).showAgentCard
                     ? 'p-6 lg:p-8'
                     : 'relative overflow-hidden max-lg:aspect-video'
                 )
               "
             >
-              <template v-if="activeClientFor(conn).showAgentCard">
+              <template v-if="activeClientFor(connId).showAgentCard">
                 <h3
                   class="flex flex-wrap items-center gap-2.5 text-xl font-light text-primary-comfy-canvas lg:text-2xl"
                 >
@@ -411,11 +396,11 @@ const copiedLabel = t('ui.copied', locale)
                 </p>
               </template>
               <VideoPlayer
-                v-else-if="activeClientFor(conn).video"
-                :key="activeClientFor(conn).id"
+                v-else-if="activeClientFor(connId).video"
+                :key="activeClientIds[connId]"
                 :locale="locale"
-                :aria-label="walkthroughLabelFor(conn)"
-                :src="activeClientFor(conn).video"
+                :aria-label="walkthroughLabelFor(connId)"
+                :src="activeClientFor(connId).video"
                 autoplay
                 loop
                 hide-controls

--- a/apps/website/src/templates/mcp/SetupSection.vue
+++ b/apps/website/src/templates/mcp/SetupSection.vue
@@ -143,7 +143,7 @@ const connections: McpConnection[] = [
     manualDescription: t('mcp.setup.manual.description', locale),
     agentCommand: t('mcp.setup.agent.command', locale).replace(
       '{url}',
-      externalLinks.docsMcp
+      externalLinks.docsMcpMd
     ),
     showSkillsNote: true,
     clients: cloudClients
@@ -157,7 +157,7 @@ const connections: McpConnection[] = [
     manualDescription: t('mcp.setup.local.manual.description', locale),
     agentCommand: t('mcp.setup.local.agent.command', locale).replace(
       '{url}',
-      externalLinks.docsMcpLocal
+      externalLinks.docsMcpLocalMd
     ),
     showSkillsNote: false,
     clients: localClients

--- a/apps/website/src/templates/mcp/SetupSection.vue
+++ b/apps/website/src/templates/mcp/SetupSection.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { cn } from '@comfyorg/tailwind-utils'
 import { TabsContent, TabsList, TabsRoot, TabsTrigger } from 'reka-ui'
 import { computed, ref } from 'vue'
 
@@ -168,16 +169,19 @@ const connections: McpConnection[] = [
   }
 ]
 
-const activeConnectionId = ref<string>(connections[0].id)
+type ConnectionId = McpConnection['id']
+
+const activeConnectionId = ref<ConnectionId>(connections[0].id)
 const activeConnection = computed(
   () =>
     connections.find((conn) => conn.id === activeConnectionId.value) ??
     connections[0]
 )
 
-const activeClientIds = ref<Record<string, string>>(
-  Object.fromEntries(connections.map((conn) => [conn.id, conn.clients[0].id]))
-)
+const activeClientIds = ref<Record<ConnectionId, string>>({
+  cloud: cloudClients[0].id,
+  local: localClients[0].id
+})
 
 function activeClientFor(conn: McpConnection): McpClient {
   return (
@@ -361,11 +365,13 @@ const copiedLabel = t('ui.copied', locale)
             </div>
 
             <div
-              class="bg-transparency-white-t4 flex flex-col rounded-3xl"
               :class="
-                activeClientFor(conn).showAgentCard
-                  ? 'p-6 lg:p-8'
-                  : 'relative overflow-hidden max-lg:aspect-video'
+                cn(
+                  'bg-transparency-white-t4 flex flex-col rounded-3xl',
+                  activeClientFor(conn).showAgentCard
+                    ? 'p-6 lg:p-8'
+                    : 'relative overflow-hidden max-lg:aspect-video'
+                )
               "
             >
               <template v-if="activeClientFor(conn).showAgentCard">


### PR DESCRIPTION
## What

comfy.org/mcp was cloud-only; its FAQ answered *"Can I use it with my local ComfyUI?"* with *"Coming soon"*. The open-source local server ([comfy-mcp](https://github.com/Comfy-Org/comfy-mcp)) is released on PyPI, so the page now sells both halves of Comfy MCP, with messaging aligned to the [launch blog](https://blog.comfy.org/p/comfy-mcp-turn-your-agent-into-a).

## Changes

**Hero.** Heading: *"Drive ComfyUI from any AI agent, local or cloud."* Subtitle: *"Turn your agent into a creative technologist… Built for batch generation, reproducibility and teamwork."*

**Setup section.** `Comfy Cloud | Local ComfyUI` connection toggle above the client tabs. Cloud panel unchanged. Local panel: `pip install comfy-mcp`, per-client stdio registration (Claude Code / Claude Desktop / Cursor / Others), an ask-your-agent card badged **Recommended**, and an open-source requirement line replacing the subscription note. Agent-paste commands use the `.md` docs URLs (agents get raw markdown, not the HTML shell); human links stay extensionless.

**Section order.** Tools (capabilities) now come before Why-build on both locales.

**Why-build rework** (from the blog, no em dashes): *"first MCP built for production pipelines"* subtitle; **Reproducible by design** replaces Outputs-you-keep (outputs folded in); auth line corrected (local needs no account); full-engine card mentions auto-updating templates; your-GPUs card sells the hardware-aware local agent (reads models, custom nodes, VRAM; untangles complex open-source workflows).

**Capabilities copy.** Run-real-workflows reads your existing workflows ("start where you are"); model list refreshed (MiniMax H3, Seedance, Flux, GPT-Image, Nano Banana, Kling, Z-Image, ElevenLabs, HY3D, and more).

**FAQ (nine questions).** New: cloud-vs-local difference (with which-one-to-choose routing + Apple-GPU caveat), both-at-once, open source. Corrected: local partner models sign in via comfy-cli (browser or API key) and spend credits; everyday local use needs no key. Removed: local-ComfyUI ("Coming soon"), Claude Desktop slash commands, GA. "Which agents are supported?" replaces "clients".

**Links & analytics.** `docsMcp` → merged docs IA (`agent-tools/mcp`); new `docsMcpMd`/`docsMcpLocalMd`/`comfyMcpRepo`. New `website:mcp_connection_tab_clicked` PostHog event; client tabs emit `local-*` ids in the local panel.

Both locales covered (en + zh-CN) for every change.

## Testing

- `pnpm --filter @comfyorg/website typecheck` — 0 errors
- `pnpm --filter @comfyorg/website test:unit` — 423 passed
- `pnpm exec playwright test e2e/mcp.spec.ts` — 10/10 (specs updated: connection toggle, local install flow, nested-tabs strict-mode, FAQ count)
- `pnpm build` — clean
