### PR TITLE
feat: Add Credits Run button state for partner nodes (local/desktop)

### DIFF
--- a/browser_tests/fixtures/selectors.ts
+++ b/browser_tests/fixtures/selectors.ts
@@ -116,6 +116,7 @@ export const TestIds = {
   },
   partnerNodes: {
     signInToRunButton: 'partner-sign-in-to-run-button',
+    addCreditsButton: 'partner-add-credits-button',
     runGateCaption: 'partner-run-gate-caption',
     educationCard: 'partner-nodes-education-card',
     educationCardGotIt: 'partner-nodes-education-got-it',

--- a/browser_tests/tests/actionbar/partnerRunGate.spec.ts
+++ b/browser_tests/tests/actionbar/partnerRunGate.spec.ts
@@ -1,6 +1,9 @@
 import { expect } from '@playwright/test'
 
 import { comfyPageFixture as test } from '@e2e/fixtures/ComfyPage'
+import { TopUpCreditsDialog } from '@e2e/fixtures/components/TopUpCreditsDialog'
+import { jsonRoute } from '@e2e/fixtures/utils/jsonRoute'
+import { localAuthFixture } from '@e2e/fixtures/localAuthFixture'
 import { TestIds } from '@e2e/fixtures/selectors'
 
 /**
@@ -14,8 +17,8 @@ const PARTNER_NODE_DISPLAY_NAME = 'Flux 1.1 [pro] Ultra Image'
 /**
  * Local/desktop-only run gating: the Run button is replaced when the graph
  * contains partner (api_node) nodes the user cannot run yet. Cloud has its
- * own subscription-driven gating covered by @cloud specs, so this spec
- * intentionally carries no @cloud tag and runs in the default local project.
+ * own subscription-driven gating covered by @cloud specs, so these specs
+ * intentionally carry no @cloud tag and run in the default local project.
  */
 test.describe('Partner nodes run gate (local, signed out)', () => {
   test('replaces Run with "Sign in to run" and opens the partner sign-in dialog', async ({
@@ -49,4 +52,42 @@ test.describe('Partner nodes run gate (local, signed out)', () => {
     await expect(page.getByTestId(TestIds.topbar.queueButton)).toBeVisible()
     await expect(signInButton).toHaveCount(0)
   })
+})
+
+localAuthFixture.describe('Partner nodes run gate (local, signed in)', () => {
+  localAuthFixture(
+    'gates on "Add Credits" with zero balance and recovers after top-up',
+    async ({ comfyPage }) => {
+      const page = comfyPage.page
+
+      await comfyPage.workflow.loadWorkflow(PARTNER_WORKFLOW)
+
+      const addCreditsButton = page.getByTestId(
+        TestIds.partnerNodes.addCreditsButton
+      )
+      await expect(addCreditsButton).toBeVisible()
+      await expect(page.getByTestId(TestIds.topbar.queueButton)).toHaveCount(0)
+      await expect(
+        page.getByTestId(TestIds.partnerNodes.runGateCaption)
+      ).toContainText('Partner nodes need credits')
+
+      const topUpDialog = new TopUpCreditsDialog(page)
+      await addCreditsButton.click()
+      await expect(topUpDialog.heading).toBeVisible()
+      await topUpDialog.close()
+
+      // Simulate returning from an external Stripe top-up: the balance
+      // endpoint now reports funds and the gate refetches on window focus.
+      await page.route('**/customers/balance', (r) =>
+        r.fulfill(jsonRoute({ amount_micros: 5_000_000, currency: 'usd' }))
+      )
+      await page.evaluate(() => window.dispatchEvent(new Event('focus')))
+
+      await expect(page.getByTestId(TestIds.topbar.queueButton)).toBeVisible()
+      await expect(addCreditsButton).toHaveCount(0)
+      await expect(
+        page.getByTestId(TestIds.partnerNodes.runGateCaption)
+      ).toHaveCount(0)
+    }
+  )
 })

--- a/browser_tests/tests/actionbar/partnerRunGate.spec.ts
+++ b/browser_tests/tests/actionbar/partnerRunGate.spec.ts
@@ -2,6 +2,7 @@ import { expect } from '@playwright/test'
 
 import { comfyPageFixture as test } from '@e2e/fixtures/ComfyPage'
 import { TopUpCreditsDialog } from '@e2e/fixtures/components/TopUpCreditsDialog'
+import { createBalance } from '@e2e/fixtures/data/subscriptionFixtures'
 import { jsonRoute } from '@e2e/fixtures/utils/jsonRoute'
 import { localAuthFixture } from '@e2e/fixtures/localAuthFixture'
 import { TestIds } from '@e2e/fixtures/selectors'
@@ -79,7 +80,14 @@ localAuthFixture.describe('Partner nodes run gate (local, signed in)', () => {
       // Simulate returning from an external Stripe top-up: the balance
       // endpoint now reports funds and the gate refetches on window focus.
       await page.route('**/customers/balance', (r) =>
-        r.fulfill(jsonRoute({ amount_micros: 5_000_000, currency: 'usd' }))
+        r.fulfill(
+          jsonRoute(
+            createBalance({
+              amount_micros: 5_000_000,
+              effective_balance_micros: 5_000_000
+            })
+          )
+        )
       )
       await page.evaluate(() => window.dispatchEvent(new Event('focus')))
 

--- a/src/components/TopMenuSection.test.ts
+++ b/src/components/TopMenuSection.test.ts
@@ -29,7 +29,10 @@ const mockData = vi.hoisted(() => ({
 vi.mock('@/composables/auth/useCurrentUser', () => ({
   useCurrentUser: () => {
     return {
-      isLoggedIn: computed(() => mockData.isLoggedIn)
+      isLoggedIn: computed(() => mockData.isLoggedIn),
+      resolvedUserInfo: computed(() =>
+        mockData.isLoggedIn ? { id: 'test-user' } : null
+      )
     }
   }
 }))

--- a/src/components/actionbar/ComfyRunButton/LocalRunButtonWrapper.test.ts
+++ b/src/components/actionbar/ComfyRunButton/LocalRunButtonWrapper.test.ts
@@ -3,6 +3,8 @@ import { render, screen, waitFor } from '@testing-library/vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createI18n } from 'vue-i18n'
 
+import enMessages from '@/locales/en/main.json' with { type: 'json' }
+
 import LocalRunButtonWrapper from './LocalRunButtonWrapper.vue'
 
 type PartnerNode = { nodeName: string; displayName: string }
@@ -71,10 +73,7 @@ const i18n = createI18n({
   messages: {
     en: {
       actionbar: {
-        partnerRunGate: {
-          signInToRun: 'Sign in to run',
-          addCredits: 'Add Credits'
-        }
+        partnerRunGate: enMessages.actionbar.partnerRunGate
       }
     }
   }
@@ -91,6 +90,8 @@ describe('LocalRunButtonWrapper', () => {
     gateState.gate.value = 'none'
     gateState.partnerNodes.value = []
     __setQueueMode('instant')
+    showApiNodesSignInDialog.mockClear()
+    showTopUpCreditsDialog.mockClear()
   })
 
   it('renders the normal queue button when not gated, leaving queue mode alone', () => {
@@ -124,7 +125,7 @@ describe('LocalRunButtonWrapper', () => {
     expect(__getQueueMode()).toBe('disabled')
     await userEvent.click(screen.getByRole('button', { name: 'Add Credits' }))
 
-    expect(showTopUpCreditsDialog).toHaveBeenCalledWith({
+    expect(showTopUpCreditsDialog).toHaveBeenCalledExactlyOnceWith({
       isInsufficientCredits: true
     })
   })
@@ -165,7 +166,7 @@ describe('LocalRunButtonWrapper', () => {
       screen.getByRole('button', { name: 'Sign in to run' })
     )
 
-    expect(showApiNodesSignInDialog).toHaveBeenCalledWith([
+    expect(showApiNodesSignInDialog).toHaveBeenCalledExactlyOnceWith([
       'Partner A',
       'Partner B'
     ])

--- a/src/components/actionbar/ComfyRunButton/LocalRunButtonWrapper.test.ts
+++ b/src/components/actionbar/ComfyRunButton/LocalRunButtonWrapper.test.ts
@@ -9,14 +9,11 @@ import LocalRunButtonWrapper from './LocalRunButtonWrapper.vue'
 
 type PartnerNode = { nodeName: string; displayName: string }
 
+type PartnerRunGate = 'sign-in' | 'add-credits' | 'none'
+
 const gateState = vi.hoisted(() => ({
-<<<<<<< HEAD
-  gate: undefined as unknown as { value: 'sign-in' | 'none' },
+  gate: undefined as unknown as { value: PartnerRunGate },
   partnerNodes: undefined as unknown as { value: PartnerNode[] }
-=======
-  gate: 'none' as 'sign-in' | 'add-credits' | 'none',
-  partnerNodes: [] as { nodeName: string; displayName: string }[]
->>>>>>> bb518643d9 (feat: gate Run button on credits for partner nodes on local/desktop)
 }))
 
 const showApiNodesSignInDialog = vi.hoisted(() =>
@@ -26,7 +23,7 @@ const showTopUpCreditsDialog = vi.hoisted(() => vi.fn(() => Promise.resolve()))
 
 vi.mock('@/composables/billing/usePartnerNodesRunGate', async () => {
   const { ref } = await import('vue')
-  gateState.gate = ref<'sign-in' | 'none'>('none')
+  gateState.gate = ref<PartnerRunGate>('none')
   gateState.partnerNodes = ref<PartnerNode[]>([])
   return {
     usePartnerNodesRunGate: () => ({
@@ -103,22 +100,18 @@ describe('LocalRunButtonWrapper', () => {
     expect(__getQueueMode()).toBe('instant')
   })
 
-<<<<<<< HEAD
   it('replaces the queue button and disables auto-queue when gated', () => {
     gateState.gate.value = 'sign-in'
-=======
-  it('replaces the queue button with sign-in when gated', () => {
-    gateState.gate = 'sign-in'
->>>>>>> bb518643d9 (feat: gate Run button on credits for partner nodes on local/desktop)
     renderWrapper()
     expect(screen.queryByTestId('queue-button')).not.toBeInTheDocument()
     expect(
       screen.getByRole('button', { name: 'Sign in to run' })
     ).toBeInTheDocument()
+    expect(__getQueueMode()).toBe('disabled')
   })
 
   it('shows Add Credits, opens the top-up dialog, and disables auto-queue when gated', async () => {
-    gateState.gate = 'add-credits'
+    gateState.gate.value = 'add-credits'
     renderWrapper()
 
     expect(screen.queryByTestId('queue-button')).not.toBeInTheDocument()
@@ -130,13 +123,20 @@ describe('LocalRunButtonWrapper', () => {
     })
   })
 
-  it('points the gated button at the caption explaining why it is gated', () => {
+  it('points the gated buttons at the caption explaining why they are gated', () => {
     gateState.gate.value = 'sign-in'
-    renderWrapper()
-
+    const { unmount } = renderWrapper()
     expect(
       screen.getByRole('button', { name: 'Sign in to run' })
     ).toHaveAttribute('aria-describedby', 'partner-run-gate-caption')
+    unmount()
+
+    gateState.gate.value = 'add-credits'
+    renderWrapper()
+    expect(screen.getByRole('button', { name: 'Add Credits' })).toHaveAttribute(
+      'aria-describedby',
+      'partner-run-gate-caption'
+    )
   })
 
   it('moves focus to the queue button when signing in unmounts the gated button', async () => {

--- a/src/components/actionbar/ComfyRunButton/LocalRunButtonWrapper.test.ts
+++ b/src/components/actionbar/ComfyRunButton/LocalRunButtonWrapper.test.ts
@@ -8,13 +8,19 @@ import LocalRunButtonWrapper from './LocalRunButtonWrapper.vue'
 type PartnerNode = { nodeName: string; displayName: string }
 
 const gateState = vi.hoisted(() => ({
+<<<<<<< HEAD
   gate: undefined as unknown as { value: 'sign-in' | 'none' },
   partnerNodes: undefined as unknown as { value: PartnerNode[] }
+=======
+  gate: 'none' as 'sign-in' | 'add-credits' | 'none',
+  partnerNodes: [] as { nodeName: string; displayName: string }[]
+>>>>>>> bb518643d9 (feat: gate Run button on credits for partner nodes on local/desktop)
 }))
 
 const showApiNodesSignInDialog = vi.hoisted(() =>
   vi.fn(() => Promise.resolve(false))
 )
+const showTopUpCreditsDialog = vi.hoisted(() => vi.fn(() => Promise.resolve()))
 
 vi.mock('@/composables/billing/usePartnerNodesRunGate', async () => {
   const { ref } = await import('vue')
@@ -29,14 +35,7 @@ vi.mock('@/composables/billing/usePartnerNodesRunGate', async () => {
 })
 
 vi.mock('@/services/dialogService', () => ({
-  useDialogService: () => ({ showApiNodesSignInDialog })
-}))
-
-vi.mock('@/components/actionbar/ComfyRunButton/ComfyQueueButton.vue', () => ({
-  default: {
-    name: 'ComfyQueueButton',
-    template: '<button data-testid="queue-button" />'
-  }
+  useDialogService: () => ({ showApiNodesSignInDialog, showTopUpCreditsDialog })
 }))
 
 vi.mock('@/stores/queueSettingsStore', async () => {
@@ -59,6 +58,13 @@ const { __setQueueMode, __getQueueMode } =
     __getQueueMode: () => string
   }
 
+vi.mock('@/components/actionbar/ComfyRunButton/ComfyQueueButton.vue', () => ({
+  default: {
+    name: 'ComfyQueueButton',
+    template: '<button data-testid="queue-button" />'
+  }
+}))
+
 const i18n = createI18n({
   legacy: false,
   locale: 'en',
@@ -67,7 +73,7 @@ const i18n = createI18n({
       actionbar: {
         partnerRunGate: {
           signInToRun: 'Sign in to run',
-          signInCaption: 'Partner nodes require an account'
+          addCredits: 'Add Credits'
         }
       }
     }
@@ -96,14 +102,31 @@ describe('LocalRunButtonWrapper', () => {
     expect(__getQueueMode()).toBe('instant')
   })
 
+<<<<<<< HEAD
   it('replaces the queue button and disables auto-queue when gated', () => {
     gateState.gate.value = 'sign-in'
+=======
+  it('replaces the queue button with sign-in when gated', () => {
+    gateState.gate = 'sign-in'
+>>>>>>> bb518643d9 (feat: gate Run button on credits for partner nodes on local/desktop)
     renderWrapper()
     expect(screen.queryByTestId('queue-button')).not.toBeInTheDocument()
     expect(
       screen.getByRole('button', { name: 'Sign in to run' })
     ).toBeInTheDocument()
+  })
+
+  it('shows Add Credits, opens the top-up dialog, and disables auto-queue when gated', async () => {
+    gateState.gate = 'add-credits'
+    renderWrapper()
+
+    expect(screen.queryByTestId('queue-button')).not.toBeInTheDocument()
     expect(__getQueueMode()).toBe('disabled')
+    await userEvent.click(screen.getByRole('button', { name: 'Add Credits' }))
+
+    expect(showTopUpCreditsDialog).toHaveBeenCalledWith({
+      isInsufficientCredits: true
+    })
   })
 
   it('points the gated button at the caption explaining why it is gated', () => {

--- a/src/components/actionbar/ComfyRunButton/LocalRunButtonWrapper.vue
+++ b/src/components/actionbar/ComfyRunButton/LocalRunButtonWrapper.vue
@@ -2,7 +2,7 @@
   <div ref="root" class="contents">
     <ComfyQueueButton v-if="gate === 'none'" />
     <Button
-      v-else
+      v-else-if="gate === 'sign-in'"
       v-tooltip.bottom="{
         value: t('actionbar.partnerRunGate.signInCaption'),
         showDelay: 600
@@ -16,6 +16,22 @@
     >
       <i class="icon-[lucide--log-in] size-4" aria-hidden="true" />
       {{ t('actionbar.partnerRunGate.signInToRun') }}
+    </Button>
+    <Button
+      v-else
+      v-tooltip.bottom="{
+        value: t('actionbar.partnerRunGate.creditsCaption'),
+        showDelay: 600
+      }"
+      variant="subscribe"
+      size="unset"
+      class="h-8 gap-1.5 rounded-lg px-4 whitespace-nowrap"
+      data-testid="partner-add-credits-button"
+      aria-describedby="partner-run-gate-caption"
+      @click="openTopUpCreditsDialog"
+    >
+      <i class="icon-[tabler--crown-filled] size-4" aria-hidden="true" />
+      {{ t('actionbar.partnerRunGate.addCredits') }}
     </Button>
   </div>
 </template>
@@ -60,5 +76,9 @@ function openPartnerSignInDialog() {
   void dialogService.showApiNodesSignInDialog(
     partnerNodes.value.map((node) => node.displayName)
   )
+}
+
+function openTopUpCreditsDialog() {
+  void dialogService.showTopUpCreditsDialog({ isInsufficientCredits: true })
 }
 </script>

--- a/src/components/actionbar/PartnerNodesRunCaption.vue
+++ b/src/components/actionbar/PartnerNodesRunCaption.vue
@@ -8,10 +8,21 @@
     >
       <div class="flex w-full items-center justify-center gap-2">
         <i
-          class="icon-[lucide--info] size-4 text-muted-foreground"
+          :class="
+            cn(
+              'size-4',
+              gate === 'add-credits'
+                ? 'icon-[comfy--credits] bg-credit'
+                : 'icon-[lucide--info] text-muted-foreground'
+            )
+          "
           aria-hidden="true"
         />
-        {{ t('actionbar.partnerRunGate.signInCaption') }}
+        {{
+          gate === 'add-credits'
+            ? t('actionbar.partnerRunGate.creditsCaption')
+            : t('actionbar.partnerRunGate.signInCaption')
+        }}
       </div>
     </div>
   </div>
@@ -20,6 +31,7 @@
 <script setup lang="ts">
 import { useI18n } from 'vue-i18n'
 
+import { cn } from '@comfyorg/tailwind-utils'
 import { usePartnerNodesRunGate } from '@/composables/billing/usePartnerNodesRunGate'
 
 const { t } = useI18n()

--- a/src/composables/billing/usePartnerNodesRunGate.test.ts
+++ b/src/composables/billing/usePartnerNodesRunGate.test.ts
@@ -56,7 +56,11 @@ vi.mock('@/stores/authStore', async () => {
       get balance() {
         return balance.value
       },
-      fetchBalance: mockFetchBalance
+      fetchBalance: async () => {
+        const result = await mockFetchBalance()
+        if (result !== null) balance.value = result
+        return result
+      }
     }),
     __setBalance: (value: { amount_micros?: number } | null) => {
       balance.value = value
@@ -189,6 +193,19 @@ describe('usePartnerNodesRunGate', () => {
     expect(gate.value).toBe('none')
   })
 
+  it('trusts an already-fetched store balance without probing again', async () => {
+    state.hasPartnerNodes = true
+    __setLoggedIn(true)
+    __setUserId('user-a')
+    __setBalance({ amount_micros: 0 })
+
+    const { gate } = setup()
+    await flushPromises()
+
+    expect(gate.value).toBe('add-credits')
+    expect(mockFetchBalance).not.toHaveBeenCalled()
+  })
+
   it('prefers the live store balance over the probe result', async () => {
     state.hasPartnerNodes = true
     __setLoggedIn(true)
@@ -222,14 +239,32 @@ describe('usePartnerNodesRunGate', () => {
     const { gate } = setup()
     expect(gate.value).toBe('none')
 
+    mockFetchBalance.mockResolvedValue({ amount_micros: 0 })
+    __setUserId('user-b')
+    await nextTick()
+    await flushPromises()
+    expect(gate.value).toBe('add-credits')
+
+    resolveStaleProbe(null)
+    await flushPromises()
+    expect(gate.value).toBe('add-credits')
+  })
+
+  it('re-probes instead of trusting a balance left behind by the previous account', async () => {
+    state.hasPartnerNodes = true
+    __setLoggedIn(true)
+    __setUserId('user-a')
+    __setBalance({ amount_micros: 0 })
+
+    const { gate } = setup()
+    await flushPromises()
+    expect(gate.value).toBe('add-credits')
+
     mockFetchBalance.mockResolvedValue({ amount_micros: 5_000_000 })
     __setUserId('user-b')
     await nextTick()
     await flushPromises()
-    expect(gate.value).toBe('none')
 
-    resolveStaleProbe(null)
-    await flushPromises()
     expect(gate.value).toBe('none')
   })
 

--- a/src/composables/billing/usePartnerNodesRunGate.test.ts
+++ b/src/composables/billing/usePartnerNodesRunGate.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { effectScope, nextTick } from 'vue'
 import type { EffectScope } from 'vue'
 
+import * as authStoreModule from '@/stores/authStore'
 import * as currentUserModule from '@/composables/auth/useCurrentUser'
 
 import { usePartnerNodesRunGate } from './usePartnerNodesRunGate'
@@ -10,6 +11,12 @@ const state = vi.hoisted(() => ({
   hasPartnerNodes: false,
   partnerNodes: [] as { nodeName: string; displayName: string }[]
 }))
+
+const mockFetchBalance = vi.hoisted(() =>
+  vi.fn<() => Promise<{ amount_micros?: number } | null>>(() =>
+    Promise.resolve(null)
+  )
+)
 
 vi.mock('@/composables/node/usePartnerNodesInGraph', async () => {
   const { computed } = await import('vue')
@@ -24,18 +31,52 @@ vi.mock('@/composables/node/usePartnerNodesInGraph', async () => {
 vi.mock('@/composables/auth/useCurrentUser', async () => {
   const { computed, ref } = await import('vue')
   const loggedIn = ref(false)
+  const userId = ref<string | null>(null)
   return {
     useCurrentUser: () => ({
-      isLoggedIn: computed(() => loggedIn.value)
+      isLoggedIn: computed(() => loggedIn.value),
+      resolvedUserInfo: computed(() =>
+        userId.value ? { id: userId.value } : null
+      )
     }),
     __setLoggedIn: (value: boolean) => {
       loggedIn.value = value
+    },
+    __setUserId: (value: string | null) => {
+      userId.value = value
     }
   }
 })
 
-const { __setLoggedIn } = currentUserModule as typeof currentUserModule & {
-  __setLoggedIn: (value: boolean) => void
+vi.mock('@/stores/authStore', async () => {
+  const { ref } = await import('vue')
+  const balance = ref<{ amount_micros?: number } | null>(null)
+  return {
+    useAuthStore: () => ({
+      get balance() {
+        return balance.value
+      },
+      fetchBalance: mockFetchBalance
+    }),
+    __setBalance: (value: { amount_micros?: number } | null) => {
+      balance.value = value
+    }
+  }
+})
+
+const { __setLoggedIn, __setUserId } =
+  currentUserModule as typeof currentUserModule & {
+    __setLoggedIn: (value: boolean) => void
+    __setUserId: (value: string | null) => void
+  }
+const { __setBalance } = authStoreModule as typeof authStoreModule & {
+  __setBalance: (value: { amount_micros?: number } | null) => void
+}
+
+async function flushPromises() {
+  await Promise.resolve()
+  await Promise.resolve()
+  await Promise.resolve()
 }
 
 let scope: EffectScope
@@ -50,36 +91,156 @@ describe('usePartnerNodesRunGate', () => {
     state.hasPartnerNodes = false
     state.partnerNodes = []
     __setLoggedIn(false)
+    __setUserId(null)
+    __setBalance(null)
+    mockFetchBalance.mockReset()
+    mockFetchBalance.mockImplementation(() => Promise.resolve(null))
   })
 
   afterEach(() => {
     scope.stop()
   })
 
-  it('resolves none without partner nodes', () => {
+  it('resolves none without partner nodes and never fetches balance', async () => {
     __setLoggedIn(true)
     const { gate } = setup()
+    await flushPromises()
+
+    expect(gate.value).toBe('none')
+    expect(mockFetchBalance).not.toHaveBeenCalled()
+  })
+
+  it('gates on sign-in when signed out, without fetching balance', () => {
+    state.hasPartnerNodes = true
+    const { gate } = setup()
+
+    expect(gate.value).toBe('sign-in')
+    expect(mockFetchBalance).not.toHaveBeenCalled()
+  })
+
+  it('gates on add-credits when the probe finds a zero balance', async () => {
+    state.hasPartnerNodes = true
+    __setLoggedIn(true)
+    mockFetchBalance.mockResolvedValue({ amount_micros: 0 })
+
+    const { gate } = setup()
+    await flushPromises()
+
+    expect(gate.value).toBe('add-credits')
+  })
+
+  it('treats the 404 new-customer null as no credits', async () => {
+    state.hasPartnerNodes = true
+    __setLoggedIn(true)
+    mockFetchBalance.mockResolvedValue(null)
+
+    const { gate } = setup()
+    await flushPromises()
+
+    expect(gate.value).toBe('add-credits')
+  })
+
+  it('fails open while the probe is pending and when it errors', async () => {
+    state.hasPartnerNodes = true
+    __setLoggedIn(true)
+    let rejectProbe!: (reason: Error) => void
+    mockFetchBalance.mockImplementation(
+      () =>
+        new Promise((_resolve, reject) => {
+          rejectProbe = reject
+        })
+    )
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const { gate } = setup()
+    expect(gate.value).toBe('none')
+
+    rejectProbe(new Error('offline'))
+    await flushPromises()
+    expect(gate.value).toBe('none')
+    expect(warnSpy).toHaveBeenCalled()
+  })
+
+  it('retries a failed probe on window focus', async () => {
+    state.hasPartnerNodes = true
+    __setLoggedIn(true)
+    mockFetchBalance.mockRejectedValueOnce(new Error('offline'))
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const { gate } = setup()
+    await flushPromises()
+    expect(gate.value).toBe('none')
+
+    mockFetchBalance.mockResolvedValue({ amount_micros: 0 })
+    window.dispatchEvent(new Event('focus'))
+    await flushPromises()
+
+    expect(gate.value).toBe('add-credits')
+  })
+
+  it('resolves none when the probe finds funds', async () => {
+    state.hasPartnerNodes = true
+    __setLoggedIn(true)
+    mockFetchBalance.mockResolvedValue({ amount_micros: 5_000_000 })
+
+    const { gate } = setup()
+    await flushPromises()
+
     expect(gate.value).toBe('none')
   })
 
-  it('gates on sign-in when signed out with partner nodes', () => {
-    state.hasPartnerNodes = true
-    const { gate } = setup()
-    expect(gate.value).toBe('sign-in')
-  })
-
-  it('resolves none when signed in', () => {
+  it('prefers the live store balance over the probe result', async () => {
     state.hasPartnerNodes = true
     __setLoggedIn(true)
+    mockFetchBalance.mockResolvedValue(null)
+
     const { gate } = setup()
+    await flushPromises()
+    expect(gate.value).toBe('add-credits')
+
+    __setBalance({ amount_micros: 2_000_000 })
+    await nextTick()
+    expect(gate.value).toBe('none')
+
+    __setBalance({ amount_micros: 0 })
+    await nextTick()
+    expect(gate.value).toBe('add-credits')
+  })
+
+  it('discards a stale probe that resolves after an account switch', async () => {
+    state.hasPartnerNodes = true
+    __setLoggedIn(true)
+    __setUserId('user-a')
+    let resolveStaleProbe!: (value: null) => void
+    mockFetchBalance.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveStaleProbe = resolve
+        })
+    )
+
+    const { gate } = setup()
+    expect(gate.value).toBe('none')
+
+    mockFetchBalance.mockResolvedValue({ amount_micros: 5_000_000 })
+    __setUserId('user-b')
+    await nextTick()
+    await flushPromises()
+    expect(gate.value).toBe('none')
+
+    resolveStaleProbe(null)
+    await flushPromises()
     expect(gate.value).toBe('none')
   })
 
   it('flips to sign-in when the user signs out mid-session', async () => {
     state.hasPartnerNodes = true
     __setLoggedIn(true)
+    mockFetchBalance.mockResolvedValue({ amount_micros: 0 })
+
     const { gate } = setup()
-    expect(gate.value).toBe('none')
+    await flushPromises()
+    expect(gate.value).toBe('add-credits')
 
     __setLoggedIn(false)
     await nextTick()

--- a/src/composables/billing/usePartnerNodesRunGate.test.ts
+++ b/src/composables/billing/usePartnerNodesRunGate.test.ts
@@ -1,16 +1,19 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { effectScope, nextTick } from 'vue'
-import type { EffectScope } from 'vue'
+import { effectScope, nextTick, ref } from 'vue'
+import type { EffectScope, Ref } from 'vue'
 
 import * as authStoreModule from '@/stores/authStore'
 import * as currentUserModule from '@/composables/auth/useCurrentUser'
 
 import { usePartnerNodesRunGate } from './usePartnerNodesRunGate'
 
-const state = vi.hoisted(() => ({
-  hasPartnerNodes: false,
-  partnerNodes: [] as { nodeName: string; displayName: string }[]
-}))
+const state = vi.hoisted(
+  () =>
+    ({}) as {
+      hasPartnerNodes: Ref<boolean>
+      partnerNodes: Ref<{ nodeName: string; displayName: string }[]>
+    }
+)
 
 const mockFetchBalance = vi.hoisted(() =>
   vi.fn<() => Promise<{ amount_micros?: number } | null>>(() =>
@@ -22,8 +25,8 @@ vi.mock('@/composables/node/usePartnerNodesInGraph', async () => {
   const { computed } = await import('vue')
   return {
     usePartnerNodesInGraph: () => ({
-      partnerNodes: computed(() => state.partnerNodes),
-      hasPartnerNodes: computed(() => state.hasPartnerNodes)
+      partnerNodes: computed(() => state.partnerNodes.value),
+      hasPartnerNodes: computed(() => state.hasPartnerNodes.value)
     })
   }
 })
@@ -92,8 +95,8 @@ function setup() {
 
 describe('usePartnerNodesRunGate', () => {
   beforeEach(() => {
-    state.hasPartnerNodes = false
-    state.partnerNodes = []
+    state.hasPartnerNodes = ref(false)
+    state.partnerNodes = ref([])
     __setLoggedIn(false)
     __setUserId(null)
     __setBalance(null)
@@ -115,7 +118,7 @@ describe('usePartnerNodesRunGate', () => {
   })
 
   it('gates on sign-in when signed out, without fetching balance', () => {
-    state.hasPartnerNodes = true
+    state.hasPartnerNodes.value = true
     const { gate } = setup()
 
     expect(gate.value).toBe('sign-in')
@@ -123,7 +126,7 @@ describe('usePartnerNodesRunGate', () => {
   })
 
   it('gates on add-credits when the probe finds a zero balance', async () => {
-    state.hasPartnerNodes = true
+    state.hasPartnerNodes.value = true
     __setLoggedIn(true)
     mockFetchBalance.mockResolvedValue({ amount_micros: 0 })
 
@@ -134,7 +137,7 @@ describe('usePartnerNodesRunGate', () => {
   })
 
   it('treats the 404 new-customer null as no credits', async () => {
-    state.hasPartnerNodes = true
+    state.hasPartnerNodes.value = true
     __setLoggedIn(true)
     mockFetchBalance.mockResolvedValue(null)
 
@@ -145,7 +148,7 @@ describe('usePartnerNodesRunGate', () => {
   })
 
   it('fails open while the probe is pending and when it errors', async () => {
-    state.hasPartnerNodes = true
+    state.hasPartnerNodes.value = true
     __setLoggedIn(true)
     let rejectProbe!: (reason: Error) => void
     mockFetchBalance.mockImplementation(
@@ -166,7 +169,7 @@ describe('usePartnerNodesRunGate', () => {
   })
 
   it('retries a failed probe on window focus', async () => {
-    state.hasPartnerNodes = true
+    state.hasPartnerNodes.value = true
     __setLoggedIn(true)
     mockFetchBalance.mockRejectedValueOnce(new Error('offline'))
     vi.spyOn(console, 'warn').mockImplementation(() => {})
@@ -182,8 +185,27 @@ describe('usePartnerNodesRunGate', () => {
     expect(gate.value).toBe('add-credits')
   })
 
+  it('stops retrying a failed probe on focus once the partner nodes are gone', async () => {
+    state.hasPartnerNodes.value = true
+    __setLoggedIn(true)
+    mockFetchBalance.mockRejectedValue(new Error('offline'))
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    setup()
+    await flushPromises()
+
+    state.hasPartnerNodes.value = false
+    await nextTick()
+    mockFetchBalance.mockClear()
+
+    window.dispatchEvent(new Event('focus'))
+    await flushPromises()
+
+    expect(mockFetchBalance).not.toHaveBeenCalled()
+  })
+
   it('resolves none when the probe finds funds', async () => {
-    state.hasPartnerNodes = true
+    state.hasPartnerNodes.value = true
     __setLoggedIn(true)
     mockFetchBalance.mockResolvedValue({ amount_micros: 5_000_000 })
 
@@ -194,7 +216,7 @@ describe('usePartnerNodesRunGate', () => {
   })
 
   it('trusts an already-fetched store balance without probing again', async () => {
-    state.hasPartnerNodes = true
+    state.hasPartnerNodes.value = true
     __setLoggedIn(true)
     __setUserId('user-a')
     __setBalance({ amount_micros: 0 })
@@ -207,7 +229,7 @@ describe('usePartnerNodesRunGate', () => {
   })
 
   it('prefers the live store balance over the probe result', async () => {
-    state.hasPartnerNodes = true
+    state.hasPartnerNodes.value = true
     __setLoggedIn(true)
     mockFetchBalance.mockResolvedValue(null)
 
@@ -225,7 +247,7 @@ describe('usePartnerNodesRunGate', () => {
   })
 
   it('discards a stale probe that resolves after an account switch', async () => {
-    state.hasPartnerNodes = true
+    state.hasPartnerNodes.value = true
     __setLoggedIn(true)
     __setUserId('user-a')
     let resolveStaleProbe!: (value: null) => void
@@ -251,7 +273,7 @@ describe('usePartnerNodesRunGate', () => {
   })
 
   it('re-probes instead of trusting a balance left behind by the previous account', async () => {
-    state.hasPartnerNodes = true
+    state.hasPartnerNodes.value = true
     __setLoggedIn(true)
     __setUserId('user-a')
     __setBalance({ amount_micros: 0 })
@@ -269,7 +291,7 @@ describe('usePartnerNodesRunGate', () => {
   })
 
   it('flips to sign-in when the user signs out mid-session', async () => {
-    state.hasPartnerNodes = true
+    state.hasPartnerNodes.value = true
     __setLoggedIn(true)
     mockFetchBalance.mockResolvedValue({ amount_micros: 0 })
 

--- a/src/composables/billing/usePartnerNodesRunGate.ts
+++ b/src/composables/billing/usePartnerNodesRunGate.ts
@@ -1,13 +1,23 @@
-import { createSharedComposable } from '@vueuse/core'
-import { computed } from 'vue'
+import { createSharedComposable, useEventListener } from '@vueuse/core'
+import { computed, ref, watch } from 'vue'
 
 import { useCurrentUser } from '@/composables/auth/useCurrentUser'
 import { usePartnerNodesInGraph } from '@/composables/node/usePartnerNodesInGraph'
 import { isCloud } from '@/platform/distribution/types'
+import { useAuthStore } from '@/stores/authStore'
 
 import type { PartnerNodeInfo } from '@/composables/node/usePartnerNodesInGraph'
 
-type PartnerRunGate = 'sign-in' | 'none'
+type PartnerRunGate = 'sign-in' | 'add-credits' | 'none'
+
+/**
+ * fetchBalance resolves null for 404 "new customer" without writing
+ * authStore.balance, so the store alone cannot distinguish "known zero"
+ * from "never fetched". The probe owns that distinction; 'unknown'
+ * (network failure) fails open and is retried on the next trigger
+ * (server errors remain the backstop).
+ */
+type BalanceProbe = 'idle' | 'pending' | 'zero' | 'positive' | 'unknown'
 
 /**
  * Decides whether the local/desktop Run button must be replaced because the
@@ -23,11 +33,78 @@ export const usePartnerNodesRunGate = createSharedComposable(() => {
   }
 
   const { partnerNodes, hasPartnerNodes } = usePartnerNodesInGraph()
-  const { isLoggedIn } = useCurrentUser()
+  const { isLoggedIn, resolvedUserInfo } = useCurrentUser()
+  const authStore = useAuthStore()
 
-  const gate = computed<PartnerRunGate>(() =>
-    hasPartnerNodes.value && !isLoggedIn.value ? 'sign-in' : 'none'
+  // Covers both auth modes: Firebase uid and API-key user id.
+  const userId = computed(() => resolvedUserInfo.value?.id)
+
+  const probe = ref<BalanceProbe>('idle')
+  let probeGeneration = 0
+
+  const probeBalance = async () => {
+    const generation = ++probeGeneration
+    const requestUserId = userId.value
+    probe.value = 'pending'
+    let result: BalanceProbe
+    try {
+      const balance = await authStore.fetchBalance()
+      const micros = balance?.amount_micros
+      result =
+        typeof micros === 'number' && Number.isFinite(micros) && micros > 0
+          ? 'positive'
+          : 'zero'
+    } catch (error) {
+      console.warn('[partnerNodesRunGate] balance probe failed', error)
+      result = 'unknown'
+    }
+    // A newer probe or an identity switch owns the state now.
+    if (generation !== probeGeneration || userId.value !== requestUserId) {
+      return
+    }
+    probe.value = result
+  }
+
+  watch(
+    [isLoggedIn, hasPartnerNodes, userId],
+    ([loggedIn, hasNodes, id], previous) => {
+      if (!loggedIn || (previous && id !== previous[2])) {
+        probe.value = 'idle'
+      }
+      if (
+        loggedIn &&
+        hasNodes &&
+        (probe.value === 'idle' || probe.value === 'unknown') &&
+        authStore.balance === null
+      ) {
+        void probeBalance()
+      }
+    },
+    { immediate: true }
   )
+
+  const hasNoCredits = computed(() => {
+    // Safe against account switches: authStore nulls balance synchronously
+    // with currentUser in onAuthStateChanged.
+    if (authStore.balance !== null) {
+      return (authStore.balance.amount_micros ?? 0) <= 0
+    }
+    return probe.value === 'zero'
+  })
+
+  const gate = computed<PartnerRunGate>(() => {
+    if (!hasPartnerNodes.value) return 'none'
+    if (!isLoggedIn.value) return 'sign-in'
+    return hasNoCredits.value ? 'add-credits' : 'none'
+  })
+
+  // Top-up happens in an external Stripe tab; refresh when the user returns.
+  // Also retries a probe that previously failed ('unknown').
+  useEventListener(window, 'focus', () => {
+    if (gate.value === 'add-credits' || probe.value === 'unknown') {
+      void probeBalance()
+    }
+  })
 
   return { gate, partnerNodes }
 })

--- a/src/composables/billing/usePartnerNodesRunGate.ts
+++ b/src/composables/billing/usePartnerNodesRunGate.ts
@@ -42,6 +42,13 @@ export const usePartnerNodesRunGate = createSharedComposable(() => {
   const probe = ref<BalanceProbe>('idle')
   let probeGeneration = 0
 
+  /** Only Firebase sign-in nulls authStore.balance; after an API-key switch it still holds the previous user's figure. */
+  const isStoreBalanceStale = ref(false)
+
+  const isStoreBalanceTrusted = computed(
+    () => authStore.balance !== null && !isStoreBalanceStale.value
+  )
+
   const probeBalance = async () => {
     const generation = ++probeGeneration
     const requestUserId = userId.value
@@ -63,19 +70,24 @@ export const usePartnerNodesRunGate = createSharedComposable(() => {
       return
     }
     probe.value = result
+    if (result !== 'unknown') isStoreBalanceStale.value = false
   }
 
   watch(
     [isLoggedIn, hasPartnerNodes, userId],
     ([loggedIn, hasNodes, id], previous) => {
-      if (!loggedIn || (previous && id !== previous[2])) {
+      // The immediate run reports previous as [], which is not an identity change.
+      const switchedIdentity = previous.length > 0 && id !== previous[2]
+      if (!loggedIn || switchedIdentity) {
         probe.value = 'idle'
+        // Only an identity change can leave another account's balance behind.
+        if (switchedIdentity) isStoreBalanceStale.value = true
       }
       if (
         loggedIn &&
         hasNodes &&
         (probe.value === 'idle' || probe.value === 'unknown') &&
-        authStore.balance === null
+        !isStoreBalanceTrusted.value
       ) {
         void probeBalance()
       }
@@ -84,10 +96,8 @@ export const usePartnerNodesRunGate = createSharedComposable(() => {
   )
 
   const hasNoCredits = computed(() => {
-    // Safe against account switches: authStore nulls balance synchronously
-    // with currentUser in onAuthStateChanged.
-    if (authStore.balance !== null) {
-      return (authStore.balance.amount_micros ?? 0) <= 0
+    if (isStoreBalanceTrusted.value) {
+      return (authStore.balance?.amount_micros ?? 0) <= 0
     }
     return probe.value === 'zero'
   })
@@ -101,6 +111,7 @@ export const usePartnerNodesRunGate = createSharedComposable(() => {
   // Top-up happens in an external Stripe tab; refresh when the user returns.
   // Also retries a probe that previously failed ('unknown').
   useEventListener(window, 'focus', () => {
+    if (!isLoggedIn.value || !hasPartnerNodes.value) return
     if (gate.value === 'add-credits' || probe.value === 'unknown') {
       void probeBalance()
     }

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -3860,6 +3860,8 @@
     "freeTierRuns": "{available} / {MAX_AVAILABLE} runs left",
     "freeTierPartner": "Partner nodes need a paid plan",
     "partnerRunGate": {
+      "addCredits": "Add Credits",
+      "creditsCaption": "Partner nodes need credits",
       "signInCaption": "Partner nodes require an account",
       "signInToRun": "Sign in to run"
     },


### PR DESCRIPTION
## Summary

Signed in with zero credits, a partner-node workflow still gave you a normal Run button — click, 402 from the server, top-up dialog. This adds the third gate state: a yellow "Add Credits" button with the caption "Partner nodes need credits", opening the top-up dialog directly.

## Stack

Four PRs, all local/desktop only. Merge bottom-up.

| | PR | What it does |
|---|---|---|
| 1 | #15248 | Run button becomes "Sign in to run" when signed out with partner nodes in the graph |
| 2 | #15249 | Education card on paid template load, explaining what partner nodes cost |
| **3** | **this PR** | Run button becomes "Add Credits" when signed in with no credits |
| 4 | #15251 | Partner sign-in dialog redesign |

Genuinely builds on #15248 — same gate, one more state.

## Changes

- **What**: `usePartnerNodesRunGate` grows an `'add-credits'` state backed by a balance probe. `LocalRunButtonWrapper` gets the yellow crown button, `PartnerNodesRunCaption` the matching caption. Returning from an external Stripe top-up refetches on window focus.
- **Breaking**: none. Cloud still early-returns.

## Review Focus

- **Why a probe and not just `authStore.balance`.** `fetchBalance` returns `null` for a 404 "new customer" *without* writing the store, so the store alone can't tell "known zero" from "never fetched". The gate owns that distinction. `fetchBalance` semantics are untouched — other consumers depend on null-means-untouched.
- **Account switches.** Only Firebase sign-in nulls `authStore.balance`; an API-key switch leaves the previous user's figure sitting there. The gate now distrusts the store across an identity change and re-probes, so a funded user can't inherit the previous account's zero. This is the subtlest part of the PR.
- **Fail-open.** Pending or failed probe means the normal Run button. A zero-credit user gets one clickable Run for the probe duration; the server backstop covers it.
- **Balance is only ever read.** No writes to billing state from here.

## Testing

`pnpm test:unit` covers zero, the 404-new-customer path, funded, pending, network failure, the store-precedence guard, the account-switch re-probe, stale in-flight probes resolving late, and the focus retry stopping once partner nodes are gone. E2E walks zero → top-up → recovered against a real backend.

## Screenshots

The button is the yellow crown variant next to the same caption strip shown in #15248; the credits caption reads "Partner nodes need credits".


## Manual QA

Local and desktop. You need **two accounts**: one with credits, one with zero. The zero-credit cases are the whole point of this PR.

1. Sign in with a **zero-credit** account, open a partner workflow → yellow **"Add Credits"** button with a crown, caption "Partner nodes need credits".
2. Click it → the top-up dialog opens. Nothing is queued.
3. Sign in with a **funded** account instead → normal white Run.
4. Actually buy credits in the Stripe tab, come back to the ComfyUI tab → within a moment of the window regaining focus the button returns to normal Run.

**Account switching** — the part most worth your attention:

5. Zero-credit account → sign out → sign in with a **funded** account, same workflow → normal white Run. If it still says "Add Credits", that's the bug this PR fixes.
6. Reverse: funded → sign out → sign in zero-credit → "Add Credits". It must not leave you a white Run that queues and fails.
7. Both directions again using **API-key** sign-in rather than Google/email. This is the path that was broken.

**Edge cases**

8. Turn off wifi, then open a partner workflow while signed in → normal Run button. We deliberately fail open rather than block you on a network hiccup; the server still rejects if you run it.
9. Zero-credit + partner workflow, then delete the partner node → back to normal Run.

**Cloud:** unaffected — cloud keeps its own subscription gating.
