### PR TITLE
feat(website): link the Flux 3 page from the footer

### DIFF
--- a/apps/website/e2e/flux-3.spec.ts
+++ b/apps/website/e2e/flux-3.spec.ts
@@ -44,6 +44,13 @@ test.describe('Flux 3 page @smoke', () => {
     await expect(modelsCrumb).toHaveAttribute('href', MODELS_ROUTE)
   })
 
+  test('footer links back to this page', async ({ page }) => {
+    const footerLink = page
+      .locator('footer')
+      .getByRole('link', { name: t('footer.flux3', 'en') })
+    await expect(footerLink).toHaveAttribute('href', getRoutes('en').flux3)
+  })
+
   test('renders pricing and run options', async ({ page }) => {
     const runOptions = page.getByRole('heading', {
       level: 2,

--- a/apps/website/src/components/common/SiteFooter.vue
+++ b/apps/website/src/components/common/SiteFooter.vue
@@ -48,7 +48,8 @@ const topColumns: { title: string; links: FooterLink[] }[] = [
       { label: t('footer.seedance', locale), href: routes.seedance },
       { label: t('footer.wanAnimate2', locale), href: routes.wanAnimate2 },
       { label: t('footer.ltx', locale), href: routes.ltx },
-      { label: t('footer.wan3', locale), href: routes.wan3 }
+      { label: t('footer.wan3', locale), href: routes.wan3 },
+      { label: t('footer.flux3', locale), href: routes.flux3 }
     ]
   },
   {

--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -5341,6 +5341,7 @@ const translations = {
       '你的 AI 助手可以接入整个生态、构建工作流，并生成图像、视频、音频或 3D 内容。'
   },
   'flux3.reviews.highlightCta': { en: 'GET STARTED', 'zh-CN': '开始使用' },
+  'footer.flux3': { en: 'Flux 3', 'zh-CN': 'Flux 3' },
   // Wan Animate 2 model page (/wan-animate-2)
   'wanAnimate2.meta.title': {
     en: 'Wan Animate 2 on Comfy — Open-Source Character Animation',


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

## Summary

`/flux-3` shipped without anything on the site linking to it, so the landing page is only reachable by typing the URL — this adds it to the footer Products column.

## Changes

- **What**: `{ label: t('footer.flux3', locale), href: routes.flux3 }` appended to the footer Products column in `SiteFooter.vue`, plus the `footer.flux3` label (en + zh-CN) in `translations.ts`. The `flux3: '/flux-3'` route already existed, so no routing change was needed.
- **Tests**: `footer links back to this page` in the existing `flux-3.spec.ts` smoke block, matching the equivalent cases in `wan-3.0.spec.ts` and `wan-animate-2.spec.ts`.

## Review Focus

- **Position**: appended after Wan 3.0, following how every model launch page since MiniMax H3 has been added to this column.
- **Label key**: `footer.flux3` placed at the end of the `flux3.*` block, matching `footer.wan3` / `footer.wanAnimate2` placement. Value is "Flux 3" in both locales, matching `flux3.breadcrumb.model`.
- **Localization**: `flux3` is not locale-invariant and `src/pages/zh-CN/flux-3.astro` exists, so `getRoutes('zh-CN')` resolves to a real page rather than a dead `/zh-CN/` link. Verified in the build output and in the browser (second screenshot). `routes.test.ts` already covers both locales, so the new E2E case is English-only rather than adding a zh-CN describe block for one assertion.

## Verification

- `pnpm --filter @comfyorg/website build` — 595 pages; `href="/flux-3"` appears twice in `dist/index.html` and `href="/zh-CN/flux-3"` twice in `dist/zh-CN/index.html`, matching the sibling Wan 3.0 counts (the footer renders a mobile and a desktop variant).
- E2E `flux-3.spec.ts` + `navigation.spec.ts` — 20 passed. Mutation-checked: dropping the footer entry and rebuilding fails exactly the new assertion.
- `typecheck` + `typecheck:website` — 0 errors. `check-unused-i18n-keys` clean. oxfmt/stylelint/oxlint/eslint clean (pre-commit hooks ran, not bypassed).
- `test:unit` — 422 passed, 1 failed: `modelLaunchPages.test.ts:125` rejects MiniMax Music 3's `.jpeg` poster against the `webp|png|jpg` pattern. Pre-existing from #15201, reproduced on a clean tree, untouched by this PR.
- Browser: clicked the new link in both locales — lands on `/flux-3` and `/zh-CN/flux-3`, no console errors.

## Screenshots


## Screenshots

![Desktop site footer with the new Flux 3 link at the bottom of the Products column, after Wan 3.0](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/d8ce1da96948aab110e90a10bdeee018d34e977282947ca2e838a46f62a3bd95/pr-images/1786731702465-2bfb78f5-2655-47a4-9049-cff6cfde395b.png)

![zh-CN footer at a mobile viewport showing Flux 3 at the bottom of the localized 产品 column](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/d8ce1da96948aab110e90a10bdeee018d34e977282947ca2e838a46f62a3bd95/pr-images/1786731703083-fd953df1-34c7-4897-9847-ad2a480bb8a6.png)

![The Flux 3 landing page reached by clicking the new footer link](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/d8ce1da96948aab110e90a10bdeee018d34e977282947ca2e838a46f62a3bd95/pr-images/1786731703472-5b0e838b-9f74-4c8b-a437-d20f6acd2063.png)