### PR TITLE
fix(workspace): cap the invite field height so the dialog footer stays put

### DIFF
--- a/src/platform/workspace/components/InviteMembersForm.vue
+++ b/src/platform/workspace/components/InviteMembersForm.vue
@@ -7,7 +7,7 @@
       :delimiter="EMAIL_DELIMITER"
       :convert-value="normalizeEmail"
       :model-value="emails"
-      :class="tagsInputClass"
+      :class="cn('max-h-48 overflow-y-auto', tagsInputClass)"
       @update:model-value="onEmailsUpdate"
     >
       <TagsInputItem


### PR DESCRIPTION
## Summary

The invite dialog's email field grows without limit, so a full batch pushes Cancel and Invite off screen. Caps the field and scrolls it internally.

## What's wrong

`tagsInputClass` is `min-h-10 w-full …` — a minimum with no maximum and no `overflow`. Every chip row makes the field taller and the dialog taller with it.

At the batch ceiling (`MAX_INVITES_PER_BATCH = 30`) the chips occupy roughly 15 rows, and the footer leaves the viewport. That is worst at exactly the wrong moment: the seat-overage state asks the owner to *remove* addresses, and the button they need is no longer reachable.

## Change

One line, on the component rather than the prop:

```diff
-      :class="tagsInputClass"
+      :class="cn('max-h-48 overflow-y-auto', tagsInputClass)"
```

`max-h-48` is 192px, about 6 rows or 12 chips — enough to review a normal batch without the field dominating the dialog.

Applied to the component on purpose. `tagsInputClass` is a prop, and `InviteMemberDialogContent.vue` overrides it (`min-h-10 w-full bg-secondary-background`), so capping the prop default alone would leave that dialog — the one this was reported from — unfixed. Callers still control the field's colours; the component owns its own overflow. `cn()` keeps a deliberate override possible.

## Validation

Measured in the running app with 30 chips entered, 720px viewport:

| | field height | Invite button y |
| --- | --- | --- |
| capped | 192px | 488 — on screen |

Before the change there was no maximum at all, so the field's height simply tracked its content.

- `pnpm typecheck`, `pnpm format` clean
- `pnpm test:unit` on `InviteMembersForm` — 10 passed

## Notes

Found while capturing the FE-1607 states from #15253. Independent of that work — this is on `main` and reproduces without it — but the overage state introduced there is where it bites hardest, so they are worth looking at together.

The cap is a judgement call. Happy to take a different number, or make it viewport-relative if it should adapt to short windows; this dialog also renders in the post-checkout success screen where the available space differs.

## Screenshot
<img width="512" height="370" alt="image" src="https://github.com/user-attachments/assets/342cba22-8921-49de-aab6-586c7af0c64f" />
