### PR TITLE
fix(billing): open the billing portal on OUTSTANDING_PAYMENT_REQUIRED

### DIFF
--- a/src/platform/workspace/composables/useSubscriptionCheckout.test.ts
+++ b/src/platform/workspace/composables/useSubscriptionCheckout.test.ts
@@ -450,6 +450,7 @@ describe('useSubscriptionCheckout', () => {
 
     it.for([
       ['SUBSCRIPTION_PAYMENT_REQUIRED', null],
+      ['OUTSTANDING_PAYMENT_REQUIRED', null],
       ['TRANSITION_NOT_ALLOWED', 'payment_failed']
     ] as const)(
       'routes %s previews to the billing portal',

--- a/src/platform/workspace/composables/useSubscriptionCheckout.ts
+++ b/src/platform/workspace/composables/useSubscriptionCheckout.ts
@@ -300,7 +300,9 @@ export function useSubscriptionCheckout(
     error: unknown,
     isCurrent: () => boolean = () => true
   ) {
-    let requiresRecovery = hasErrorCode(error, 'SUBSCRIPTION_PAYMENT_REQUIRED')
+    let requiresRecovery =
+      hasErrorCode(error, 'SUBSCRIPTION_PAYMENT_REQUIRED') ||
+      hasErrorCode(error, 'OUTSTANDING_PAYMENT_REQUIRED')
     if (!requiresRecovery && hasErrorCode(error, 'TRANSITION_NOT_ALLOWED')) {
       try {
         requiresRecovery =


### PR DESCRIPTION
The subscribe API now returns a distinct `OUTSTANDING_PAYMENT_REQUIRED` code when an unpaid invoice blocks a plan change. Previously that case came back as the generic `TRANSITION_NOT_ALLOWED`, so the client had to guess whether it was a payment problem by making a second call to `getBillingStatus()` and checking for `payment_failed`. That probe is unreliable — `billing_status` is not populated for every billing configuration, and when it isn't, the user is shown a bare error message with no way to act on it.

```mermaid
flowchart LR
  subgraph after ["after"]
    A2[OUTSTANDING_<br/>PAYMENT_REQUIRED] --> B2[open billing portal]
    C2[TRANSITION_NOT_ALLOWED] --> D2{"probe<br/>billing_status"} --> E2[portal, or plain error]
  end
  subgraph before ["before"]
    A1[unpaid invoice<br/>blocks plan change] --> B1[TRANSITION_NOT_ALLOWED]
    B1 --> C1{"probe<br/>billing_status"}
    C1 -->|populated| D1[open billing portal]
    C1 -->|not populated| E1[plain error,<br/>no action offered]
  end
```

### Change

`recoverOutstandingPayment` treats the new code as a direct trigger, short-circuiting before the probe runs.

### Deliberately additive

Both existing paths are untouched:

- The `SUBSCRIPTION_PAYMENT_REQUIRED` check stays — it is referenced across many existing tests.
- The `TRANSITION_NOT_ALLOWED` + `getBillingStatus()` fallback stays — it works correctly wherever `billing_status` *is* populated, and it covers the window while the backend change rolls out. Removing it would fix one set of accounts by breaking another.

### Test

One row added to the existing table test. It asserts the portal opens **and** that `getBillingStatus()` is called zero times — skipping that probe is the point of the new code, so the test pins it. Reverting the source change fails this test.

`npx vitest run --coverage src/platform/workspace/composables/useSubscriptionCheckout.test.ts` → 102 passed. Run with `--coverage` to match CI, since coverage instrumentation catches mock-hoisting failures a plain run does not.
