### PR TITLE
perf: cull links by node bounds before computing slot positions

### DIFF
--- a/src/lib/litegraph/src/LGraphCanvas.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.ts
@@ -81,6 +81,7 @@ import type {
 import { LiteGraph } from './litegraph'
 import {
   containsRect,
+  couldLinkBeVisible,
   createBounds,
   distance,
   isInRect,
@@ -6093,13 +6094,27 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
         const link = graph._links.get(link_id)
         if (!link) continue
 
-        const endPos: Point = LiteGraph.vueNodesMode // TODO: still use LG get pos if vue nodes is off until stable
-          ? getSlotPosition(node, i, true)
-          : node.getInputPos(i)
-
         // find link info
         const start_node = graph.getNodeById(link.origin_id)
         if (start_node == null) continue
+
+        // Reject links that cannot reach the screen before computing either
+        // slot position, which is the most expensive part of this loop. Skipped
+        // for reroutes, whose waypoints this test does not account for.
+        if (
+          link.parentId === undefined &&
+          !couldLinkBeVisible(
+            start_node.boundingRect,
+            node.boundingRect,
+            margin_area
+          )
+        ) {
+          continue
+        }
+
+        const endPos: Point = LiteGraph.vueNodesMode // TODO: still use LG get pos if vue nodes is off until stable
+          ? getSlotPosition(node, i, true)
+          : node.getInputPos(i)
 
         const outputId = link.origin_slot
         const startPos: Point =

--- a/src/lib/litegraph/src/linkCulling.test.ts
+++ b/src/lib/litegraph/src/linkCulling.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest'
+
+import type { Rect } from '@/lib/litegraph/src/interfaces'
+import {
+  couldLinkBeVisible,
+  overlapBounding
+} from '@/lib/litegraph/src/measure'
+
+const SCREEN: Rect = [0, 0, 1000, 800]
+
+describe('couldLinkBeVisible', () => {
+  it('keeps a link whose endpoints straddle the screen', () => {
+    // The case that makes endpoint-only culling wrong: neither node is on
+    // screen, but the link between them crosses it.
+    const left: Rect = [-5000, 400, 200, 100]
+    const right: Rect = [5000, 400, 200, 100]
+
+    expect(couldLinkBeVisible(left, right, SCREEN)).toBe(true)
+  })
+
+  it('keeps a link between two nodes that vertically straddle the screen', () => {
+    const above: Rect = [500, -4000, 200, 100]
+    const below: Rect = [500, 4000, 200, 100]
+
+    expect(couldLinkBeVisible(above, below, SCREEN)).toBe(true)
+  })
+
+  it('rejects a link with both nodes off the same side', () => {
+    const farLeft: Rect = [-5000, 400, 200, 100]
+    const alsoFarLeft: Rect = [-4000, 400, 200, 100]
+
+    expect(couldLinkBeVisible(farLeft, alsoFarLeft, SCREEN)).toBe(false)
+  })
+
+  it('keeps a link when only one node is on screen', () => {
+    const onScreen: Rect = [400, 300, 200, 100]
+    const offScreen: Rect = [-5000, 300, 200, 100]
+
+    expect(couldLinkBeVisible(onScreen, offScreen, SCREEN)).toBe(true)
+  })
+
+  it('keeps a node pair touching the screen edge, matching overlapBounding', () => {
+    // overlapBounding treats edge contact as overlap, so this must too or the
+    // two tests disagree at the boundary.
+    const touching: Rect = [-200, 300, 200, 100]
+
+    expect(couldLinkBeVisible(touching, touching, SCREEN)).toBe(true)
+  })
+})
+
+/**
+ * The property the optimisation rests on. `drawConnections` culls against the
+ * box spanning the two slot positions; this test must never exclude a link that
+ * box would have kept, or links vanish from the canvas.
+ */
+describe('couldLinkBeVisible never hides a link the exact test would draw', () => {
+  // Deterministic LCG - a flake here is a rendering bug, so the failing case
+  // has to be reproducible.
+  function makeRandom(seed: number): () => number {
+    let state = seed
+    return () => {
+      state = (Math.imul(state, 1664525) + 1013904223) >>> 0
+      return state / 0x1_0000_0000
+    }
+  }
+
+  it('holds across randomised node placements', () => {
+    const random = makeRandom(20260814)
+    const spread = (): number => (random() - 0.5) * 6000
+    const nodeRect = (): Rect => [
+      spread(),
+      spread(),
+      40 + random() * 400,
+      30 + random() * 300
+    ]
+
+    for (let i = 0; i < 20_000; i++) {
+      const start = nodeRect()
+      const end = nodeRect()
+
+      // Slot positions lie somewhere within their node's bounding rect.
+      const startX = start[0] + random() * start[2]
+      const startY = start[1] + random() * start[3]
+      const endX = end[0] + random() * end[2]
+      const endY = end[1] + random() * end[3]
+
+      const exact: Rect = [
+        Math.min(startX, endX),
+        Math.min(startY, endY),
+        Math.abs(endX - startX),
+        Math.abs(endY - startY)
+      ]
+
+      if (!overlapBounding(exact, SCREEN)) continue
+
+      expect(
+        couldLinkBeVisible(start, end, SCREEN),
+        `hid a visible link: start=${JSON.stringify(start)} end=${JSON.stringify(end)}`
+      ).toBe(true)
+    }
+  })
+})

--- a/src/lib/litegraph/src/measure.ts
+++ b/src/lib/litegraph/src/measure.ts
@@ -110,6 +110,52 @@ export function isInsideRectangle(
 }
 
 /**
+ * Whether a link between two nodes could intersect {@link renderArea}, decided
+ * without computing either slot position.
+ *
+ * `drawConnections` already culls links against the axis-aligned box of their
+ * endpoints, but only after computing both, which is the dominant per-frame
+ * cost on a large graph. Every slot lies within its node's bounding rect, so
+ * the box spanning the two node rects contains that endpoint box, and a miss
+ * here implies a miss there.
+ *
+ * Conservative in one direction only. It may report a link as possibly visible
+ * when it is not - a diagonally separated pair spans a far larger box than the
+ * link between them - which costs only the exact test that would have run
+ * regardless. It never reports a visible link as hidden.
+ *
+ * Not valid for links with reroutes, whose waypoints can sit outside both node
+ * rects and extend the exact box beyond this one.
+ *
+ * @param startBounds Bounding rect of the originating node
+ * @param endBounds Bounding rect of the terminating node
+ * @param renderArea Area being drawn, as `x, y, width, height`
+ */
+export function couldLinkBeVisible(
+  startBounds: ReadOnlyRect,
+  endBounds: ReadOnlyRect,
+  renderArea: ReadOnlyRect
+): boolean {
+  const left = Math.min(startBounds[0], endBounds[0])
+  const top = Math.min(startBounds[1], endBounds[1])
+  const right = Math.max(
+    startBounds[0] + startBounds[2],
+    endBounds[0] + endBounds[2]
+  )
+  const bottom = Math.max(
+    startBounds[1] + startBounds[3],
+    endBounds[1] + endBounds[3]
+  )
+
+  return !(
+    left > renderArea[0] + renderArea[2] ||
+    top > renderArea[1] + renderArea[3] ||
+    right < renderArea[0] ||
+    bottom < renderArea[1]
+  )
+}
+
+/**
  * Determines if two rectangles have any overlap
  * @param a Rectangle A as `x, y, width, height`
  * @param b Rectangle B as `x, y, width, height`


### PR DESCRIPTION
`drawConnections` computes both slot positions for every link in the graph, then discards the link if the box spanning those positions misses the render area. On a large graph that discarded work dominates the frame — `getSlotPosition` was the hottest non-idle frame in a CPU profile of *both* renderers.

Every slot lies within its node's bounding rect, so the box spanning the two node rects contains the endpoint box the existing test already uses:

```
union(nodeA.boundingRect, nodeB.boundingRect) ⊇ AABB(startPos, endPos) = link_bounding
```

A miss on the cheap box therefore implies a miss on the exact one. Rendering is unchanged — this only skips work already destined to be thrown away. `boundingRect` is a cached field recalculated once per frame, so the test costs two field reads and four comparisons.

Links with reroutes keep the old path: a waypoint can sit outside both node rects and extend the exact box past the cheap one.

## Results

Production build, litegraph renderer, 1960 nodes, 100 frames:

| | baseline | this PR |
|---|---|---|
| pan — `getSlotPosition` | 108ms, 89ms | **absent** |
| pan — idle | 88ms, 175ms (8%, 15%) | **399ms, 347ms (37%, 32%)** |
| zoom — `getSlotPosition` | 134ms, 116ms | **21ms, 20ms** |
| zoom — `_renderAllLinkSegments` | 70ms, 69ms | **absent** |

Roughly 3x the per-frame headroom during pan. Benefits both renderers; the Vue path gains more because it resolves slot positions through the layout store.

No measurable change on a 100-node graph fully on screen, where nothing is culled (1312/1231ms vs 1233/1314ms — noise).

## Why it can't hide a visible link

A link whose endpoints are both off-screen can still cross the screen, so the test has to be a conservative over-approximation. It is: the cheap box is a strict superset of the exact one, and the existing test is itself only an AABB of the endpoints (it already clips bezier overshoot, per the comment at the cull site), so no new false negatives are introduced. Diagonally separated pairs produce false *positives*, which cost only the exact test that would have run anyway.

`getSlotPosition` is a pure read of the layout store, so skipping it loses no side effect.

`linkCulling.test.ts` covers the straddling cases plus a 20,000-case randomised invariant: any link the exact test would draw must be kept. Mutating the union away fails it with a reproducible counterexample.

## Testing

- 1026 litegraph tests pass; 16,060 unit tests pass
- Verified in a production build, not just dev — see note below