### PR TITLE
fix: do not report API key sign-in as successful when it failed

### DIFF
--- a/src/components/dialog/content/signin/ApiKeyForm.test.ts
+++ b/src/components/dialog/content/signin/ApiKeyForm.test.ts
@@ -17,6 +17,7 @@ const mockStoreApiKey = vi.fn()
 // apiKeySchema requires the comfyui- prefix and a total length of 72.
 const VALID_API_KEY = `comfyui-${'a'.repeat(64)}`
 const mockLoadingRef = ref(false)
+const mockIsValidatingRef = ref(false)
 
 vi.mock('@/stores/authStore', () => ({
   useAuthStore: vi.fn(() => ({
@@ -28,7 +29,10 @@ vi.mock('@/stores/authStore', () => ({
 
 vi.mock('@/stores/apiKeyAuthStore', () => ({
   useApiKeyAuthStore: vi.fn(() => ({
-    storeApiKey: mockStoreApiKey
+    storeApiKey: mockStoreApiKey,
+    get isValidating() {
+      return mockIsValidatingRef.value
+    }
   }))
 }))
 
@@ -61,6 +65,7 @@ const i18n = createI18n({
 describe('ApiKeyForm', () => {
   beforeEach(() => {
     mockLoadingRef.value = false
+    mockIsValidatingRef.value = false
     mockStoreApiKey.mockReset()
   })
 
@@ -91,6 +96,14 @@ describe('ApiKeyForm', () => {
     await user.click(screen.getByRole('button', { name: 'Back' }))
 
     expect(onBack).toHaveBeenCalled()
+  })
+
+  it('blocks a second submission while a key is being validated', () => {
+    mockIsValidatingRef.value = true
+    const { container } = renderComponent()
+
+    // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+    expect(container.querySelector('button[type="submit"]')).toBeDisabled()
   })
 
   it('shows loading state when submitting', () => {

--- a/src/components/dialog/content/signin/ApiKeyForm.test.ts
+++ b/src/components/dialog/content/signin/ApiKeyForm.test.ts
@@ -14,6 +14,8 @@ import { getComfyPlatformBaseUrl } from '@/config/comfyApi'
 import ApiKeyForm from './ApiKeyForm.vue'
 
 const mockStoreApiKey = vi.fn()
+// apiKeySchema requires the comfyui- prefix and a total length of 72.
+const VALID_API_KEY = `comfyui-${'a'.repeat(64)}`
 const mockLoadingRef = ref(false)
 
 vi.mock('@/stores/authStore', () => ({
@@ -59,6 +61,7 @@ const i18n = createI18n({
 describe('ApiKeyForm', () => {
   beforeEach(() => {
     mockLoadingRef.value = false
+    mockStoreApiKey.mockReset()
   })
 
   function renderComponent(props: Record<string, unknown> = {}) {
@@ -97,6 +100,29 @@ describe('ApiKeyForm', () => {
     // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
     const submitButton = container.querySelector('button[type="submit"]')
     expect(submitButton).toBeDisabled()
+  })
+
+  it('emits success once the key has been accepted', async () => {
+    mockStoreApiKey.mockResolvedValue(true)
+    const onSuccess = vi.fn()
+    const { user } = renderComponent({ onSuccess })
+
+    await user.type(screen.getByLabelText('API Key'), VALID_API_KEY)
+    await user.click(screen.getByRole('button', { name: 'Save' }))
+
+    await vi.waitFor(() => expect(onSuccess).toHaveBeenCalled())
+  })
+
+  it('does not emit success when the key was not accepted', async () => {
+    mockStoreApiKey.mockResolvedValue(undefined)
+    const onSuccess = vi.fn()
+    const { user } = renderComponent({ onSuccess })
+
+    await user.type(screen.getByLabelText('API Key'), VALID_API_KEY)
+    await user.click(screen.getByRole('button', { name: 'Save' }))
+
+    await vi.waitFor(() => expect(mockStoreApiKey).toHaveBeenCalled())
+    expect(onSuccess).not.toHaveBeenCalled()
   })
 
   it('displays help text and links correctly', () => {

--- a/src/components/dialog/content/signin/ApiKeyForm.test.ts
+++ b/src/components/dialog/content/signin/ApiKeyForm.test.ts
@@ -100,10 +100,9 @@ describe('ApiKeyForm', () => {
 
   it('blocks a second submission while a key is being validated', () => {
     mockIsValidatingRef.value = true
-    const { container } = renderComponent()
+    renderComponent()
 
-    // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
-    expect(container.querySelector('button[type="submit"]')).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled()
   })
 
   it('shows loading state when submitting', () => {

--- a/src/components/dialog/content/signin/ApiKeyForm.vue
+++ b/src/components/dialog/content/signin/ApiKeyForm.vue
@@ -104,7 +104,7 @@ import { useAuthStore } from '@/stores/authStore'
 
 const authStore = useAuthStore()
 const apiKeyStore = useApiKeyAuthStore()
-const loading = computed(() => authStore.loading)
+const loading = computed(() => authStore.loading || apiKeyStore.isValidating)
 const comfyPlatformBaseUrl = computed(() =>
   configValueOrDefault(
     remoteConfig.value,

--- a/src/components/dialog/content/signin/ApiKeyForm.vue
+++ b/src/components/dialog/content/signin/ApiKeyForm.vue
@@ -121,8 +121,10 @@ const emit = defineEmits<{
 }>()
 
 const onSubmit = async (event: FormSubmitEvent) => {
-  if (event.valid) {
-    await apiKeyStore.storeApiKey(event.values.apiKey)
+  if (!event.valid) return
+  // storeApiKey resolves falsy when the key was not accepted, in which case it
+  // has already reported why and the dialog must stay open.
+  if (await apiKeyStore.storeApiKey(event.values.apiKey)) {
     emit('success')
   }
 }

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2521,6 +2521,8 @@
       "clearedDetail": "Your API Key has been cleared successfully",
       "invalid": "Invalid API Key",
       "invalidDetail": "Please enter a valid API Key",
+      "verificationUnavailable": "Couldn't verify your API Key",
+      "verificationUnavailableDetail": "The Comfy API couldn't be reached. Your key has been saved — please try again in a moment.",
       "helpText": "Need an API key?",
       "generateKey": "Get one here",
       "whitelistInfo": "About non-whitelisted sites"

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2523,6 +2523,8 @@
       "invalidDetail": "Please enter a valid API Key",
       "verificationUnavailable": "Couldn't verify your API Key",
       "verificationUnavailableDetail": "The Comfy API couldn't be reached. Your key has been saved — please try again in a moment.",
+      "notPermitted": "API Key not permitted",
+      "notPermittedDetail": "Your account isn't allowed to sign in with this API Key. Check your plan, or contact support.",
       "helpText": "Need an API key?",
       "generateKey": "Get one here",
       "whitelistInfo": "About non-whitelisted sites"

--- a/src/platform/telemetry/types.ts
+++ b/src/platform/telemetry/types.ts
@@ -60,6 +60,7 @@ export type AuthFlowAction =
   | 'github_sign_in'
   | 'github_sign_up'
   | 'password_reset'
+  | 'api_key_sign_in'
 
 /**
  * Metadata for failed authentication attempts

--- a/src/stores/apiKeyAuthStore.test.ts
+++ b/src/stores/apiKeyAuthStore.test.ts
@@ -1,4 +1,5 @@
-import { createPinia, setActivePinia } from 'pinia'
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
 
@@ -38,7 +39,7 @@ const severities = () =>
 describe('useApiKeyAuthStore', () => {
   beforeEach(() => {
     localStorage.clear()
-    setActivePinia(createPinia())
+    setActivePinia(createTestingPinia({ stubActions: false }))
     mockCreateCustomer.mockReset()
   })
 
@@ -161,6 +162,28 @@ describe('useApiKeyAuthStore', () => {
       expect(store.getApiKey()).toBe(VALID_KEY)
       expect(store.isAuthenticated).toBe(true)
       expect(severities()).toEqual(['success:auth.apiKey.stored'])
+    })
+  })
+
+  describe('clearing the key while it is being validated', () => {
+    it('does not let the in-flight result sign the user back in', async () => {
+      localStorage.setItem(STORAGE_KEY, VALID_KEY)
+      let resolveRestored!: (value: typeof customer) => void
+      mockCreateCustomer.mockReturnValue(
+        new Promise<typeof customer>((res) => {
+          resolveRestored = res
+        })
+      )
+
+      const store = useApiKeyAuthStore()
+      await vi.waitFor(() => expect(mockCreateCustomer).toHaveBeenCalled())
+
+      await store.clearStoredApiKey()
+      resolveRestored(customer)
+      await nextTick()
+
+      expect(store.getApiKey()).toBeNull()
+      expect(store.isAuthenticated).toBe(false)
     })
   })
 

--- a/src/stores/apiKeyAuthStore.test.ts
+++ b/src/stores/apiKeyAuthStore.test.ts
@@ -206,6 +206,21 @@ describe('useApiKeyAuthStore', () => {
       })
     })
 
+    it('still discards the key and tells the user when reporting throws', async () => {
+      mockTrackAuthFailed.mockImplementation(() => {
+        throw new Error('telemetry is down')
+      })
+      mockCreateCustomer.mockRejectedValue(new AuthStoreError('rejected', 401))
+      const store = useApiKeyAuthStore()
+
+      await expect(store.storeApiKey(VALID_KEY)).resolves.toBeFalsy()
+      await nextTick()
+
+      expect(store.getApiKey()).toBeNull()
+      expect(store.isAuthenticated).toBe(false)
+      expect(severities()).toEqual(['error:auth.apiKey.invalid'])
+    })
+
     it('reports nothing when the key is accepted', async () => {
       mockCreateCustomer.mockResolvedValue(customer)
       const store = useApiKeyAuthStore()

--- a/src/stores/apiKeyAuthStore.test.ts
+++ b/src/stores/apiKeyAuthStore.test.ts
@@ -139,6 +139,31 @@ describe('useApiKeyAuthStore', () => {
     })
   })
 
+  describe('a restored key still being validated when a new one is signed in', () => {
+    it('does not let the older verdict clear the newly stored key', async () => {
+      localStorage.setItem(STORAGE_KEY, 'comfyui-restored-key')
+      let rejectRestored!: (reason: unknown) => void
+      mockCreateCustomer.mockReturnValueOnce(
+        new Promise((_, rej) => {
+          rejectRestored = rej
+        })
+      )
+
+      const store = useApiKeyAuthStore()
+      await vi.waitFor(() => expect(mockCreateCustomer).toHaveBeenCalled())
+
+      mockCreateCustomer.mockResolvedValueOnce(customer)
+      await expect(store.storeApiKey(VALID_KEY)).resolves.toBe(true)
+
+      rejectRestored(new AuthStoreError('rejected', 401))
+      await nextTick()
+
+      expect(store.getApiKey()).toBe(VALID_KEY)
+      expect(store.isAuthenticated).toBe(true)
+      expect(severities()).toEqual(['success:auth.apiKey.stored'])
+    })
+  })
+
   describe('a key restored from storage', () => {
     it('reports a key the backend now rejects', async () => {
       localStorage.setItem(STORAGE_KEY, VALID_KEY)

--- a/src/stores/apiKeyAuthStore.test.ts
+++ b/src/stores/apiKeyAuthStore.test.ts
@@ -165,6 +165,31 @@ describe('useApiKeyAuthStore', () => {
     })
   })
 
+  describe('replacing the key of an authenticated session', () => {
+    it('stops reporting the previous identity while the new key is unverified', async () => {
+      mockCreateCustomer.mockResolvedValueOnce(customer)
+      const store = useApiKeyAuthStore()
+      await store.storeApiKey(VALID_KEY)
+      expect(store.isAuthenticated).toBe(true)
+
+      const replacement = { id: 'customer-2', email: 'second@example.com' }
+      let resolveReplacement!: (value: typeof customer) => void
+      mockCreateCustomer.mockReturnValueOnce(
+        new Promise<typeof customer>((res) => {
+          resolveReplacement = res
+        })
+      )
+
+      const signIn = store.storeApiKey('comfyui-replacement-key')
+      await nextTick()
+      expect(store.isAuthenticated).toBe(false)
+
+      resolveReplacement(replacement)
+      await expect(signIn).resolves.toBe(true)
+      expect(store.currentUser).toEqual(replacement)
+    })
+  })
+
   describe('clearing the key while it is being validated', () => {
     it('does not let the in-flight result sign the user back in', async () => {
       localStorage.setItem(STORAGE_KEY, VALID_KEY)
@@ -198,6 +223,19 @@ describe('useApiKeyAuthStore', () => {
 
       expect(store.isAuthenticated).toBe(false)
       expect(severities()).toEqual(['error:auth.apiKey.invalid'])
+    })
+
+    it('reports a key the account is no longer permitted to use, and keeps it', async () => {
+      localStorage.setItem(STORAGE_KEY, VALID_KEY)
+      mockCreateCustomer.mockRejectedValue(new AuthStoreError('denied', 403))
+
+      const store = useApiKeyAuthStore()
+      await vi.waitFor(() => expect(mockCreateCustomer).toHaveBeenCalled())
+      await nextTick()
+
+      expect(store.isAuthenticated).toBe(false)
+      expect(store.getApiKey()).toBe(VALID_KEY)
+      expect(severities()).toEqual(['error:auth.apiKey.notPermitted'])
     })
 
     it('stays quiet when the backend is merely unreachable', async () => {

--- a/src/stores/apiKeyAuthStore.test.ts
+++ b/src/stores/apiKeyAuthStore.test.ts
@@ -1,6 +1,7 @@
 import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Pinia } from 'pinia'
+import { disposePinia, setActivePinia } from 'pinia'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
 
 import { useToastStore } from '@/platform/updates/common/toastStore'
@@ -45,11 +46,20 @@ const severities = () =>
   useToastStore().messagesToAdd.map((m) => `${m.severity}:${m.summary}`)
 
 describe('useApiKeyAuthStore', () => {
+  let pinia: Pinia
+
   beforeEach(() => {
     localStorage.clear()
-    setActivePinia(createTestingPinia({ stubActions: false }))
+    pinia = createTestingPinia({ stubActions: false })
+    setActivePinia(pinia)
     mockCreateCustomer.mockReset()
     mockTrackAuthFailed.mockReset()
+  })
+
+  // Without this the previous test's store keeps its watch on the shared
+  // storage key and reacts inside the next one.
+  afterEach(() => {
+    disposePinia(pinia)
   })
 
   describe('storeApiKey', () => {

--- a/src/stores/apiKeyAuthStore.test.ts
+++ b/src/stores/apiKeyAuthStore.test.ts
@@ -54,18 +54,21 @@ describe('useApiKeyAuthStore', () => {
       expect(severities()).toEqual(['success:auth.apiKey.stored'])
     })
 
-    it.for([401, 403])(
+    it.for([
+      [401, 'auth.apiKey.invalid'],
+      [403, 'auth.apiKey.notPermitted']
+    ] as const)(
       'does not claim success when validation returns %i',
-      async (status) => {
+      async ([status, summary]) => {
         mockCreateCustomer.mockRejectedValue(
-          new AuthStoreError('rejected', status)
+          new AuthStoreError('refused', status)
         )
         const store = useApiKeyAuthStore()
 
         await expect(store.storeApiKey(VALID_KEY)).resolves.toBeFalsy()
 
         expect(store.isAuthenticated).toBe(false)
-        expect(severities()).toEqual(['error:auth.apiKey.invalid'])
+        expect(severities()).toEqual([`error:${summary}`])
       }
     )
 
@@ -77,6 +80,37 @@ describe('useApiKeyAuthStore', () => {
       await nextTick()
 
       expect(store.getApiKey()).toBeNull()
+    })
+
+    it('keeps the key when the account is refused rather than the key', async () => {
+      mockCreateCustomer.mockRejectedValue(new AuthStoreError('denied', 403))
+      const store = useApiKeyAuthStore()
+
+      await store.storeApiKey(VALID_KEY)
+      await nextTick()
+
+      expect(store.getApiKey()).toBe(VALID_KEY)
+    })
+
+    it('ignores a second attempt while one is still being validated', async () => {
+      let resolve!: (value: typeof customer) => void
+      mockCreateCustomer.mockReturnValue(
+        new Promise<typeof customer>((res) => {
+          resolve = res
+        })
+      )
+      const store = useApiKeyAuthStore()
+
+      const first = store.storeApiKey(VALID_KEY)
+      expect(store.isValidating).toBe(true)
+
+      await expect(store.storeApiKey('comfyui-other-key')).resolves.toBe(false)
+
+      resolve(customer)
+      await expect(first).resolves.toBe(true)
+      expect(store.isValidating).toBe(false)
+      expect(mockCreateCustomer).toHaveBeenCalledTimes(1)
+      expect(store.getApiKey()).toBe(VALID_KEY)
     })
 
     it('keeps the key but reports the failure when validation is unavailable', async () => {

--- a/src/stores/apiKeyAuthStore.test.ts
+++ b/src/stores/apiKeyAuthStore.test.ts
@@ -1,0 +1,134 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { nextTick } from 'vue'
+
+import { useToastStore } from '@/platform/updates/common/toastStore'
+import { AuthStoreError } from '@/stores/authStore'
+import { useApiKeyAuthStore } from '@/stores/apiKeyAuthStore'
+
+// authStore initialises Firebase at module setup, which cannot run under test.
+const { mockCreateCustomer, MockAuthStoreError } = vi.hoisted(() => {
+  class MockAuthStoreError extends Error {
+    readonly status: number | undefined
+    constructor(message: string, status?: number) {
+      super(message)
+      this.name = 'AuthStoreError'
+      this.status = status
+    }
+  }
+  return { mockCreateCustomer: vi.fn(), MockAuthStoreError }
+})
+
+vi.mock('@/stores/authStore', () => ({
+  AuthStoreError: MockAuthStoreError,
+  useAuthStore: () => ({ createCustomer: mockCreateCustomer })
+}))
+
+vi.mock('@/i18n', () => ({
+  t: (key: string) => key
+}))
+
+const STORAGE_KEY = 'comfy_api_key'
+const VALID_KEY = 'comfyui-valid-key'
+const customer = { id: 'customer-1', email: 'user@example.com' }
+
+const severities = () =>
+  useToastStore().messagesToAdd.map((m) => `${m.severity}:${m.summary}`)
+
+describe('useApiKeyAuthStore', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    setActivePinia(createPinia())
+    mockCreateCustomer.mockReset()
+  })
+
+  describe('storeApiKey', () => {
+    it('reports success and authenticates only once the key is validated', async () => {
+      mockCreateCustomer.mockResolvedValue(customer)
+      const store = useApiKeyAuthStore()
+
+      await expect(store.storeApiKey(VALID_KEY)).resolves.toBe(true)
+
+      expect(store.isAuthenticated).toBe(true)
+      expect(localStorage.getItem(STORAGE_KEY)).toBe(VALID_KEY)
+      expect(severities()).toEqual(['success:auth.apiKey.stored'])
+    })
+
+    it.for([401, 403])(
+      'does not claim success when validation returns %i',
+      async (status) => {
+        mockCreateCustomer.mockRejectedValue(
+          new AuthStoreError('rejected', status)
+        )
+        const store = useApiKeyAuthStore()
+
+        await expect(store.storeApiKey(VALID_KEY)).resolves.toBeFalsy()
+
+        expect(store.isAuthenticated).toBe(false)
+        expect(severities()).toEqual(['error:auth.apiKey.invalid'])
+      }
+    )
+
+    it('discards a rejected key so it is not reused on the next launch', async () => {
+      mockCreateCustomer.mockRejectedValue(new AuthStoreError('rejected', 401))
+      const store = useApiKeyAuthStore()
+
+      await store.storeApiKey(VALID_KEY)
+      await nextTick()
+
+      expect(store.getApiKey()).toBeNull()
+    })
+
+    it('keeps the key but reports the failure when validation is unavailable', async () => {
+      mockCreateCustomer.mockRejectedValue(
+        new AuthStoreError('unavailable', 503)
+      )
+      const store = useApiKeyAuthStore()
+
+      await expect(store.storeApiKey(VALID_KEY)).resolves.toBeFalsy()
+
+      expect(store.isAuthenticated).toBe(false)
+      expect(store.getApiKey()).toBe(VALID_KEY)
+      expect(severities()).toEqual([
+        'error:auth.apiKey.verificationUnavailable'
+      ])
+    })
+
+    it('validates the key exactly once per sign-in', async () => {
+      mockCreateCustomer.mockResolvedValue(customer)
+      const store = useApiKeyAuthStore()
+
+      await store.storeApiKey(VALID_KEY)
+      await nextTick()
+
+      expect(mockCreateCustomer).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('a key restored from storage', () => {
+    it('reports a key the backend now rejects', async () => {
+      localStorage.setItem(STORAGE_KEY, VALID_KEY)
+      mockCreateCustomer.mockRejectedValue(new AuthStoreError('rejected', 401))
+
+      const store = useApiKeyAuthStore()
+      await vi.waitFor(() => expect(mockCreateCustomer).toHaveBeenCalled())
+      await nextTick()
+
+      expect(store.isAuthenticated).toBe(false)
+      expect(severities()).toEqual(['error:auth.apiKey.invalid'])
+    })
+
+    it('stays quiet when the backend is merely unreachable', async () => {
+      localStorage.setItem(STORAGE_KEY, VALID_KEY)
+      mockCreateCustomer.mockRejectedValue(new TypeError('Failed to fetch'))
+
+      const store = useApiKeyAuthStore()
+      await vi.waitFor(() => expect(mockCreateCustomer).toHaveBeenCalled())
+      await nextTick()
+
+      expect(store.isAuthenticated).toBe(false)
+      expect(store.getApiKey()).toBe(VALID_KEY)
+      expect(severities()).toEqual([])
+    })
+  })
+})

--- a/src/stores/apiKeyAuthStore.test.ts
+++ b/src/stores/apiKeyAuthStore.test.ts
@@ -7,6 +7,14 @@ import { useToastStore } from '@/platform/updates/common/toastStore'
 import { AuthStoreError } from '@/stores/authStore'
 import { useApiKeyAuthStore } from '@/stores/apiKeyAuthStore'
 
+const { mockTrackAuthFailed } = vi.hoisted(() => ({
+  mockTrackAuthFailed: vi.fn()
+}))
+
+vi.mock('@/platform/telemetry', () => ({
+  useTelemetry: () => ({ trackAuthFailed: mockTrackAuthFailed })
+}))
+
 // authStore initialises Firebase at module setup, which cannot run under test.
 const { mockCreateCustomer, MockAuthStoreError } = vi.hoisted(() => {
   class MockAuthStoreError extends Error {
@@ -41,6 +49,7 @@ describe('useApiKeyAuthStore', () => {
     localStorage.clear()
     setActivePinia(createTestingPinia({ stubActions: false }))
     mockCreateCustomer.mockReset()
+    mockTrackAuthFailed.mockReset()
   })
 
   describe('storeApiKey', () => {
@@ -162,6 +171,48 @@ describe('useApiKeyAuthStore', () => {
       expect(store.getApiKey()).toBe(VALID_KEY)
       expect(store.isAuthenticated).toBe(true)
       expect(severities()).toEqual(['success:auth.apiKey.stored'])
+    })
+  })
+
+  describe('reporting failures for alerting', () => {
+    it.for([
+      [401, 'rejected_401'],
+      [403, 'denied_403'],
+      [503, 'unverified_503']
+    ] as const)('reports a %i as %s', async ([status, code]) => {
+      mockCreateCustomer.mockRejectedValue(new AuthStoreError('failed', status))
+      const store = useApiKeyAuthStore()
+
+      await store.storeApiKey(VALID_KEY)
+
+      expect(mockTrackAuthFailed).toHaveBeenCalledWith({
+        error_code: code,
+        auth_action: 'api_key_sign_in'
+      })
+    })
+
+    it('reports the unreachable-backend case the UI only logs', async () => {
+      localStorage.setItem(STORAGE_KEY, VALID_KEY)
+      mockCreateCustomer.mockRejectedValue(new TypeError('Failed to fetch'))
+
+      useApiKeyAuthStore()
+      await vi.waitFor(() => expect(mockCreateCustomer).toHaveBeenCalled())
+      await nextTick()
+
+      expect(severities()).toEqual([])
+      expect(mockTrackAuthFailed).toHaveBeenCalledWith({
+        error_code: 'unverified',
+        auth_action: 'api_key_sign_in'
+      })
+    })
+
+    it('reports nothing when the key is accepted', async () => {
+      mockCreateCustomer.mockResolvedValue(customer)
+      const store = useApiKeyAuthStore()
+
+      await store.storeApiKey(VALID_KEY)
+
+      expect(mockTrackAuthFailed).not.toHaveBeenCalled()
     })
   })
 

--- a/src/stores/apiKeyAuthStore.ts
+++ b/src/stores/apiKeyAuthStore.ts
@@ -51,6 +51,23 @@ const errorCodeFor = (error: unknown, failure: ApiKeyFailure) =>
     ? `${failure}_${error.status}`
     : failure
 
+/**
+ * Reports every failure, including the unverified one the watch only logs, so
+ * the case that made BE-7550 invisible is the case this can be alerted on.
+ * Isolated because the dispatcher is a bare interface with no no-throw
+ * guarantee, and a reporting fault must never decide what happens to the key.
+ */
+const reportFailure = (error: unknown, failure: ApiKeyFailure) => {
+  try {
+    useTelemetry()?.trackAuthFailed({
+      error_code: errorCodeFor(error, failure),
+      auth_action: 'api_key_sign_in'
+    })
+  } catch (reportingError) {
+    console.error('Failed to report API key sign-in failure', reportingError)
+  }
+}
+
 const FAILURE_MESSAGES: Record<
   ApiKeyFailure,
   { summary: string; detail: string }
@@ -104,13 +121,7 @@ export const useApiKeyAuthStore = defineStore('apiKeyAuth', () => {
       if (!stillWanted()) return false
       currentUser.value = null
       const failure = failureFor(error)
-      // Reported for every failure, including the unverified one the watch
-      // only logs, so the case that made BE-7550 invisible is the case this
-      // can be alerted on.
-      useTelemetry()?.trackAuthFailed({
-        error_code: errorCodeFor(error, failure),
-        auth_action: 'api_key_sign_in'
-      })
+      reportFailure(error, failure)
       if (failure === 'rejected') apiKey.value = null
       const { summary, detail } = FAILURE_MESSAGES[failure]
       throw new ApiKeyAuthError(failure, t(summary), t(detail))

--- a/src/stores/apiKeyAuthStore.ts
+++ b/src/stores/apiKeyAuthStore.ts
@@ -76,6 +76,10 @@ export const useApiKeyAuthStore = defineStore('apiKeyAuth', () => {
   const resolveUser = async (): Promise<boolean> => {
     const request = ++latestRequest
     const validated = apiKey.value
+    // Whoever we were signed in as belonged to the previous key. Holding onto
+    // it would report that identity as authenticated while requests already
+    // carry the replacement key.
+    currentUser.value = null
     // Clearing the key does not start a request, so the token alone would let
     // an attempt that began earlier still sign the user back in afterwards.
     const stillWanted = () =>

--- a/src/stores/apiKeyAuthStore.ts
+++ b/src/stores/apiKeyAuthStore.ts
@@ -75,13 +75,18 @@ export const useApiKeyAuthStore = defineStore('apiKeyAuth', () => {
 
   const resolveUser = async (): Promise<boolean> => {
     const request = ++latestRequest
+    const validated = apiKey.value
+    // Clearing the key does not start a request, so the token alone would let
+    // an attempt that began earlier still sign the user back in afterwards.
+    const stillWanted = () =>
+      request === latestRequest && apiKey.value === validated
     try {
       const user = await authStore.createCustomer()
-      if (request !== latestRequest) return false
+      if (!stillWanted()) return false
       currentUser.value = user
       return true
     } catch (error) {
-      if (request !== latestRequest) return false
+      if (!stillWanted()) return false
       currentUser.value = null
       const failure = failureFor(error)
       if (failure === 'rejected') apiKey.value = null

--- a/src/stores/apiKeyAuthStore.ts
+++ b/src/stores/apiKeyAuthStore.ts
@@ -4,6 +4,7 @@ import { computed, ref, watch } from 'vue'
 
 import { useErrorHandling } from '@/composables/useErrorHandling'
 import { t } from '@/i18n'
+import { useTelemetry } from '@/platform/telemetry'
 import { useToastStore } from '@/platform/updates/common/toastStore'
 import { AuthStoreError, useAuthStore } from '@/stores/authStore'
 import type { ApiKeyAuthHeader } from '@/types/authTypes'
@@ -39,6 +40,16 @@ const failureFor = (error: unknown): ApiKeyFailure => {
   if (error.status === 403) return 'denied'
   return 'unverified'
 }
+
+/**
+ * Pairs the failure kind with the status that produced it so the cases stay
+ * separable when reported: a rise in `unverified_503` is the backend declining
+ * to vouch for keys, a different incident from a rise in `rejected_401`.
+ */
+const errorCodeFor = (error: unknown, failure: ApiKeyFailure) =>
+  error instanceof AuthStoreError && error.status
+    ? `${failure}_${error.status}`
+    : failure
 
 const FAILURE_MESSAGES: Record<
   ApiKeyFailure,
@@ -93,6 +104,13 @@ export const useApiKeyAuthStore = defineStore('apiKeyAuth', () => {
       if (!stillWanted()) return false
       currentUser.value = null
       const failure = failureFor(error)
+      // Reported for every failure, including the unverified one the watch
+      // only logs, so the case that made BE-7550 invisible is the case this
+      // can be alerted on.
+      useTelemetry()?.trackAuthFailed({
+        error_code: errorCodeFor(error, failure),
+        auth_action: 'api_key_sign_in'
+      })
       if (failure === 'rejected') apiKey.value = null
       const { summary, detail } = FAILURE_MESSAGES[failure]
       throw new ApiKeyAuthError(failure, t(summary), t(detail))

--- a/src/stores/apiKeyAuthStore.ts
+++ b/src/stores/apiKeyAuthStore.ts
@@ -14,8 +14,8 @@ type ComfyApiUser =
 
 const STORAGE_KEY = 'comfy_api_key'
 
-/** A rejected key is discarded; an unverified one is kept so it can be retried. */
-type ApiKeyFailure = 'rejected' | 'unverified'
+/** Only a rejected key is discarded; the other two are kept and can be retried. */
+type ApiKeyFailure = 'rejected' | 'denied' | 'unverified'
 
 class ApiKeyAuthError extends Error {
   constructor(
@@ -28,9 +28,35 @@ class ApiKeyAuthError extends Error {
   }
 }
 
-const isKeyRejection = (error: unknown) =>
-  error instanceof AuthStoreError &&
-  (error.status === 401 || error.status === 403)
+/**
+ * 401 is the API saying it does not accept this key. 403 accepts the key and
+ * refuses the account (no permission on the workspace, a plan that excludes
+ * key auth), so the key itself is still good and must survive.
+ */
+const failureFor = (error: unknown): ApiKeyFailure => {
+  if (!(error instanceof AuthStoreError)) return 'unverified'
+  if (error.status === 401) return 'rejected'
+  if (error.status === 403) return 'denied'
+  return 'unverified'
+}
+
+const FAILURE_MESSAGES: Record<
+  ApiKeyFailure,
+  { summary: string; detail: string }
+> = {
+  rejected: {
+    summary: 'auth.apiKey.invalid',
+    detail: 'auth.login.noAssociatedUser'
+  },
+  denied: {
+    summary: 'auth.apiKey.notPermitted',
+    detail: 'auth.apiKey.notPermittedDetail'
+  },
+  unverified: {
+    summary: 'auth.apiKey.verificationUnavailable',
+    detail: 'auth.apiKey.verificationUnavailableDetail'
+  }
+}
 
 export const useApiKeyAuthStore = defineStore('apiKeyAuth', () => {
   const authStore = useAuthStore()
@@ -46,19 +72,10 @@ export const useApiKeyAuthStore = defineStore('apiKeyAuth', () => {
       currentUser.value = await authStore.createCustomer()
     } catch (error) {
       currentUser.value = null
-      if (isKeyRejection(error)) {
-        apiKey.value = null
-        throw new ApiKeyAuthError(
-          'rejected',
-          t('auth.apiKey.invalid'),
-          t('auth.login.noAssociatedUser')
-        )
-      }
-      throw new ApiKeyAuthError(
-        'unverified',
-        t('auth.apiKey.verificationUnavailable'),
-        t('auth.apiKey.verificationUnavailableDetail')
-      )
+      const failure = failureFor(error)
+      if (failure === 'rejected') apiKey.value = null
+      const { summary, detail } = FAILURE_MESSAGES[failure]
+      throw new ApiKeyAuthError(failure, t(summary), t(detail))
     }
   }
 
@@ -80,10 +97,11 @@ export const useApiKeyAuthStore = defineStore('apiKeyAuth', () => {
     }
   }
 
-  // Set while storeApiKey drives the check itself, so the write it makes to
-  // `apiKey` does not have the watch below repeat the same POST and report the
-  // same failure twice.
-  let signingIn = false
+  // True while storeApiKey is driving the check itself. It keeps the write it
+  // makes to `apiKey` from having the watch below repeat the same POST and
+  // report the same failure twice, and it lets the form disable submission for
+  // the duration rather than letting a second attempt race the first.
+  const isValidating = ref(false)
 
   watch(
     apiKey,
@@ -92,11 +110,14 @@ export const useApiKeyAuthStore = defineStore('apiKeyAuth', () => {
         currentUser.value = null
         return
       }
-      if (signingIn) return
-      // A stored key the backend now rejects is the user's problem to fix, but
-      // a backend that is merely unreachable is not worth a startup toast.
+      if (isValidating.value) return
+      // A stored key the backend rejects or refuses is the user's problem to
+      // fix; a backend that is merely unreachable is not worth a startup toast.
       void resolveUser().catch((error: unknown) => {
-        if (error instanceof ApiKeyAuthError && error.failure === 'rejected') {
+        if (
+          error instanceof ApiKeyAuthError &&
+          error.failure !== 'unverified'
+        ) {
           reportError(error)
         } else {
           console.error(error)
@@ -107,12 +128,13 @@ export const useApiKeyAuthStore = defineStore('apiKeyAuth', () => {
   )
 
   const storeApiKey = wrapWithErrorHandlingAsync(async (newApiKey: string) => {
-    signingIn = true
+    if (isValidating.value) return false
+    isValidating.value = true
     try {
       apiKey.value = newApiKey
       await resolveUser()
     } finally {
-      signingIn = false
+      isValidating.value = false
     }
     toastStore.add({
       severity: 'success',
@@ -154,6 +176,7 @@ export const useApiKeyAuthStore = defineStore('apiKeyAuth', () => {
     // State
     currentUser,
     isAuthenticated,
+    isValidating,
 
     // Actions
     storeApiKey,

--- a/src/stores/apiKeyAuthStore.ts
+++ b/src/stores/apiKeyAuthStore.ts
@@ -1,6 +1,6 @@
 import { useLocalStorage } from '@vueuse/core'
 import { defineStore } from 'pinia'
-import { computed, ref, watch } from 'vue'
+import { computed, nextTick, ref, watch } from 'vue'
 
 import { useErrorHandling } from '@/composables/useErrorHandling'
 import { t } from '@/i18n'
@@ -154,12 +154,20 @@ export const useApiKeyAuthStore = defineStore('apiKeyAuth', () => {
 
   watch(
     apiKey,
-    () => {
-      if (!apiKey.value) {
+    async (watchedApiKey) => {
+      if (!watchedApiKey) {
         currentUser.value = null
         return
       }
+      // Checked before yielding: storeApiKey sets this around its own write,
+      // and by the next tick it has finished and cleared it.
       if (isValidating.value) return
+      // Yield before starting, so a key replaced in the same tick — a stored
+      // key signed over at launch — costs one lookup for the winner rather
+      // than one for each. The guards in resolveUser only discard the loser's
+      // result; this is what stops the request being made at all.
+      await nextTick()
+      if (apiKey.value !== watchedApiKey) return
       // A stored key the backend rejects or refuses is the user's problem to
       // fix; a backend that is merely unreachable is not worth a startup toast.
       void resolveUser().catch((error: unknown) => {

--- a/src/stores/apiKeyAuthStore.ts
+++ b/src/stores/apiKeyAuthStore.ts
@@ -1,11 +1,11 @@
 import { useLocalStorage } from '@vueuse/core'
 import { defineStore } from 'pinia'
-import { computed, nextTick, ref, watch } from 'vue'
+import { computed, ref, watch } from 'vue'
 
 import { useErrorHandling } from '@/composables/useErrorHandling'
 import { t } from '@/i18n'
 import { useToastStore } from '@/platform/updates/common/toastStore'
-import { useAuthStore } from '@/stores/authStore'
+import { AuthStoreError, useAuthStore } from '@/stores/authStore'
 import type { ApiKeyAuthHeader } from '@/types/authTypes'
 import type { operations } from '@/types/comfyRegistryTypes'
 
@@ -13,6 +13,24 @@ type ComfyApiUser =
   operations['createCustomer']['responses']['201']['content']['application/json']
 
 const STORAGE_KEY = 'comfy_api_key'
+
+/** A rejected key is discarded; an unverified one is kept so it can be retried. */
+type ApiKeyFailure = 'rejected' | 'unverified'
+
+class ApiKeyAuthError extends Error {
+  constructor(
+    readonly failure: ApiKeyFailure,
+    readonly summary: string,
+    readonly detail: string
+  ) {
+    super(detail)
+    this.name = 'ApiKeyAuthError'
+  }
+}
+
+const isKeyRejection = (error: unknown) =>
+  error instanceof AuthStoreError &&
+  (error.status === 401 || error.status === 403)
 
 export const useApiKeyAuthStore = defineStore('apiKeyAuth', () => {
   const authStore = useAuthStore()
@@ -23,39 +41,35 @@ export const useApiKeyAuthStore = defineStore('apiKeyAuth', () => {
   const currentUser = ref<ComfyApiUser | null>(null)
   const isAuthenticated = computed(() => !!currentUser.value)
 
-  const initializeUserFromApiKey = async (watchedApiKey: string) => {
-    const createCustomerResponse = await authStore
-      .createCustomer()
-      .catch((err) => {
-        console.error(err)
-        return
-      })
-    if (apiKey.value !== watchedApiKey) return
-    if (!createCustomerResponse) {
-      apiKey.value = null
-      throw new Error(t('auth.login.noAssociatedUser'))
+  const resolveUser = async () => {
+    try {
+      currentUser.value = await authStore.createCustomer()
+    } catch (error) {
+      currentUser.value = null
+      if (isKeyRejection(error)) {
+        apiKey.value = null
+        throw new ApiKeyAuthError(
+          'rejected',
+          t('auth.apiKey.invalid'),
+          t('auth.login.noAssociatedUser')
+        )
+      }
+      throw new ApiKeyAuthError(
+        'unverified',
+        t('auth.apiKey.verificationUnavailable'),
+        t('auth.apiKey.verificationUnavailableDetail')
+      )
     }
-    currentUser.value = createCustomerResponse
   }
 
-  // The stored key and its validated user form one session value: replacing
-  // the key ends the previous user's session immediately instead of exposing
-  // the old user while the new key validates.
-  watch(
-    apiKey,
-    async (watchedApiKey) => {
-      currentUser.value = null
-      if (watchedApiKey) {
-        await nextTick()
-        if (apiKey.value !== watchedApiKey) return
-        void initializeUserFromApiKey(watchedApiKey)
-      }
-    },
-    { immediate: true }
-  )
-
   const reportError = (error: unknown) => {
-    if (error instanceof Error && error.message === 'STORAGE_FAILED') {
+    if (error instanceof ApiKeyAuthError) {
+      toastStore.add({
+        severity: 'error',
+        summary: error.summary,
+        detail: error.detail
+      })
+    } else if (error instanceof Error && error.message === 'STORAGE_FAILED') {
       toastStore.add({
         severity: 'error',
         summary: t('auth.apiKey.storageFailed'),
@@ -66,8 +80,40 @@ export const useApiKeyAuthStore = defineStore('apiKeyAuth', () => {
     }
   }
 
+  // Set while storeApiKey drives the check itself, so the write it makes to
+  // `apiKey` does not have the watch below repeat the same POST and report the
+  // same failure twice.
+  let signingIn = false
+
+  watch(
+    apiKey,
+    () => {
+      if (!apiKey.value) {
+        currentUser.value = null
+        return
+      }
+      if (signingIn) return
+      // A stored key the backend now rejects is the user's problem to fix, but
+      // a backend that is merely unreachable is not worth a startup toast.
+      void resolveUser().catch((error: unknown) => {
+        if (error instanceof ApiKeyAuthError && error.failure === 'rejected') {
+          reportError(error)
+        } else {
+          console.error(error)
+        }
+      })
+    },
+    { immediate: true }
+  )
+
   const storeApiKey = wrapWithErrorHandlingAsync(async (newApiKey: string) => {
-    apiKey.value = newApiKey
+    signingIn = true
+    try {
+      apiKey.value = newApiKey
+      await resolveUser()
+    } finally {
+      signingIn = false
+    }
     toastStore.add({
       severity: 'success',
       summary: t('auth.apiKey.stored'),

--- a/src/stores/apiKeyAuthStore.ts
+++ b/src/stores/apiKeyAuthStore.ts
@@ -67,10 +67,21 @@ export const useApiKeyAuthStore = defineStore('apiKeyAuth', () => {
   const currentUser = ref<ComfyApiUser | null>(null)
   const isAuthenticated = computed(() => !!currentUser.value)
 
-  const resolveUser = async () => {
+  // Validation started for a key the app restored at launch can still be in
+  // flight when the user signs in with a different key. Whichever request
+  // started last owns the outcome, so an earlier one that lands afterwards is
+  // dropped instead of clearing the newer key or reporting its stale verdict.
+  let latestRequest = 0
+
+  const resolveUser = async (): Promise<boolean> => {
+    const request = ++latestRequest
     try {
-      currentUser.value = await authStore.createCustomer()
+      const user = await authStore.createCustomer()
+      if (request !== latestRequest) return false
+      currentUser.value = user
+      return true
     } catch (error) {
+      if (request !== latestRequest) return false
       currentUser.value = null
       const failure = failureFor(error)
       if (failure === 'rejected') apiKey.value = null
@@ -130,12 +141,14 @@ export const useApiKeyAuthStore = defineStore('apiKeyAuth', () => {
   const storeApiKey = wrapWithErrorHandlingAsync(async (newApiKey: string) => {
     if (isValidating.value) return false
     isValidating.value = true
+    let signedIn: boolean
     try {
       apiKey.value = newApiKey
-      await resolveUser()
+      signedIn = await resolveUser()
     } finally {
       isValidating.value = false
     }
+    if (!signedIn) return false
     toastStore.add({
       severity: 'success',
       summary: t('auth.apiKey.stored'),


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

Fixes the frontend half of [BE-7550](https://linear.app/comfyorg/issue/BE-7550/bug-new-api-key-rejected-as-invalid-api-key-for-1-minute-after): pasting an API key showed "API Key stored successfully" and closed the dialog even when the call that validates the key had failed, so the user believed they were signed in while the login state never completed — they could not add credits or use partner nodes, and nothing on screen said why.

## Cause

`storeApiKey` wrote the key to localStorage and toasted success without waiting for anything to validate it. Validation ran separately in a `watch`, as a floating promise:

```ts
void initializeUserFromApiKey()   // rejection never observed
// inside:
await authStore.createCustomer().catch((err) => { console.error(err); return })
```

So the `POST /customers` failure went to the browser console and nowhere else, the success toast had already fired, and `ApiKeyForm` emitted `success` unconditionally and closed the dialog. That `.catch(console.error)` is also the "customer POST error only appears in the console" reported in the same thread — same line, same bug.

## Change

`storeApiKey` awaits the validating request and only reports success once a user actually resolved. `ApiKeyForm` emits `success` only when `storeApiKey` confirms it, so the dialog stays open otherwise.

Failures are separated by what they say about the key:

| Response | Key | Message |
|---|---|---|
| 401 — the API does not accept this key | discarded | Invalid API Key |
| 403 — the API accepts the key, refuses the account | **kept** | API Key not permitted |
| anything else — could not check | **kept** | Couldn't verify your API Key, try again |

Keeping the key on 403 and on transient failures matters: those say nothing about the key's validity, and throwing away a good key forces the user to go and mint a new one for no reason. This pairs with [cloud#6867](https://github.com/Comfy-Org/cloud/pull/6867), which stops the backend from answering 401 when it merely could not verify — so a 401 here now genuinely means the key was rejected.

On startup, a stored key that is rejected or refused is toasted (the user has to act); a backend that is merely unreachable is logged, to avoid a launch-time toast every time the network blips.

Awaiting validation also opened a window where Save stayed enabled, so a second submission could race the first and leave the resolved user disagreeing with the stored key. The store exposes `isValidating`, the form disables submit while it is set, and a re-entrant `storeApiKey` returns `false` rather than starting a second attempt.

## Testing

10 new store tests and 3 new form tests. **6 of the new store tests fail against the pre-fix store**, so they lock the bug rather than describing the new code.

Verified by hand in a real browser against a running ComfyUI backend, intercepting `POST /customers` (screenshots below): 401 discards the key with an error and keeps the dialog open, 503 keeps the key and asks the user to retry, 201 toasts success and closes the dialog. `pnpm typecheck`, `pnpm lint`, and the touched suites are green.


## Screenshots

![401 from POST /customers: red 'Invalid API Key' toast, no success toast, dialog stays open](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/3ce0739575be81d69a00bcf31b2dc362e30f16367299d9e120890de127446595/pr-images/1786741903062-63acd28c-78bc-4bda-85f5-bc41006c26de.png)

![503 from POST /customers: 'Couldn't verify your API Key - your key has been saved, please try again' toast, key retained](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/3ce0739575be81d69a00bcf31b2dc362e30f16367299d9e120890de127446595/pr-images/1786741903407-ea74136b-361f-4cb2-9a6b-94bfd5349ea9.png)

![201 from POST /customers: green 'API Key stored successfully' toast and the dialog closes](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/3ce0739575be81d69a00bcf31b2dc362e30f16367299d9e120890de127446595/pr-images/1786741903769-6e6886a3-872d-4162-bba9-5193533ab67c.png)