### PR TITLE
fix(agent): node selection mode — chip/canvas sync, basket ownership, graph framing (FE-1325)

### DIFF
--- a/src/assets/css/style.css
+++ b/src/assets/css/style.css
@@ -1,6 +1,15 @@
 @import '@comfyorg/design-system/css/style.css';
 @import '../../workbench/extensions/agent/agentTheme.css';
 
+/* Node selection mode clears the canvas of everything but the graph and its own
+   banner. PrimeVue teleports every `<Toast>` container to <body>, out of reach
+   of any wrapper element, and several components mount their own groups, so the
+   whole toast layer is hidden from the root. The mode's banner is not a toast
+   and is unaffected. Toggled by GlobalToast.vue. */
+.node-selection-active .p-toast {
+  display: none;
+}
+
 /* Use 0.001ms instead of 0s so transitionend/animationend events still fire
    and JS listeners aren't broken. */
 .disable-animations *,

--- a/src/components/builder/VueNodeSwitchPopup.vue
+++ b/src/components/builder/VueNodeSwitchPopup.vue
@@ -1,6 +1,8 @@
 <template>
   <NotificationPopup
-    v-if="appModeStore.showVueNodeSwitchPopup"
+    v-if="
+      appModeStore.showVueNodeSwitchPopup && !agentNodeSelectionStore.isActive
+    "
     data-testid="linear-vue-node-switch-popup"
     :title="$t('appBuilder.vueNodeSwitch.title')"
     show-close
@@ -43,9 +45,13 @@ import { ref } from 'vue'
 import NotificationPopup from '@/components/common/NotificationPopup.vue'
 import Button from '@/components/ui/button/Button.vue'
 import { useSettingStore } from '@/platform/settings/settingStore'
+import { useAgentNodeSelectionStore } from '@/stores/agentNodeSelectionStore'
 import { useAppModeStore } from '@/stores/appModeStore'
 
 const appModeStore = useAppModeStore()
+// Node selection mode keeps the canvas clear of everything but the graph and
+// its own banner, so this popup steps aside for the duration and returns after.
+const agentNodeSelectionStore = useAgentNodeSelectionStore()
 const settingStore = useSettingStore()
 const dontShowAgain = ref(false)
 

--- a/src/components/graph/GraphCanvas.vue
+++ b/src/components/graph/GraphCanvas.vue
@@ -52,15 +52,18 @@
         v-if="canvasMenuEnabled && !isBuilderMode"
         class="pointer-events-auto"
       />
+      <!-- Fades with the rest of the chrome during node selection rather than
+           popping. Gated on `isActionBarsHidden` so it leaves and returns on the
+           same beat as the top bars and side toolbar. -->
       <MiniMap
         v-if="
-          comfyAppReady &&
-          minimapEnabled &&
-          betaMenuEnabled &&
-          !isBuilderMode &&
-          !agentNodeSelectionStore.isActive
+          comfyAppReady && minimapEnabled && betaMenuEnabled && !isBuilderMode
         "
-        class="pointer-events-auto"
+        :class="[
+          'pointer-events-auto transition-opacity duration-300 ease-in-out',
+          agentNodeSelectionStore.isActionBarsHidden &&
+            'pointer-events-none opacity-0'
+        ]"
       />
       <NodeSelectionModeBanner />
     </template>

--- a/src/components/toast/GlobalToast.test.ts
+++ b/src/components/toast/GlobalToast.test.ts
@@ -5,6 +5,7 @@ import { nextTick } from 'vue'
 
 import GlobalToast from '@/components/toast/GlobalToast.vue'
 import { useToastStore } from '@/platform/updates/common/toastStore'
+import { useAgentNodeSelectionStore } from '@/stores/agentNodeSelectionStore'
 
 const toastService = vi.hoisted(() => ({
   add: vi.fn(),
@@ -64,5 +65,95 @@ describe('GlobalToast', () => {
 
     expect(toastService.removeAllGroups).toHaveBeenCalledOnce()
     expect(toastStore.removeAllRequested).toBe(false)
+  })
+
+  // PrimeVue teleports each `<Toast>` container to `<body>`, so the layer is
+  // hidden by a root class rather than by a wrapper element - asserting on a
+  // wrapper would pass against the stub while proving nothing about the real
+  // toasts.
+  it('marks the root while node selection mode is active', async () => {
+    renderToast()
+    const nodeSelectionStore = useAgentNodeSelectionStore()
+
+    expect(document.body).not.toHaveClass('node-selection-active')
+
+    nodeSelectionStore.isActive = true
+    await nextTick()
+
+    expect(document.body).toHaveClass('node-selection-active')
+
+    nodeSelectionStore.isActive = false
+    await nextTick()
+
+    expect(document.body).not.toHaveClass('node-selection-active')
+  })
+
+  it('clears the root marker when unmounted mid-mode', async () => {
+    const { unmount } = renderToast()
+    const nodeSelectionStore = useAgentNodeSelectionStore()
+
+    nodeSelectionStore.isActive = true
+    await nextTick()
+    expect(document.body).toHaveClass('node-selection-active')
+
+    unmount()
+
+    expect(document.body).not.toHaveClass('node-selection-active')
+  })
+
+  it('holds messages raised during node selection mode until it exits', async () => {
+    renderToast()
+    const toastStore = useToastStore()
+    const nodeSelectionStore = useAgentNodeSelectionStore()
+    const message = { severity: 'error' as const, summary: 'Failed' }
+
+    nodeSelectionStore.isActive = true
+    await nextTick()
+
+    toastStore.messagesToAdd = [message]
+    await nextTick()
+
+    // Held back rather than added to a hidden layer, where a message carrying
+    // a `life` would expire unseen.
+    expect(toastService.add).not.toHaveBeenCalled()
+    expect(toastStore.messagesToAdd).toEqual([])
+
+    nodeSelectionStore.isActive = false
+    await nextTick()
+
+    expect(toastService.add).toHaveBeenCalledWith(message)
+  })
+
+  it('replays held messages in the order they were raised', async () => {
+    renderToast()
+    const toastStore = useToastStore()
+    const nodeSelectionStore = useAgentNodeSelectionStore()
+    const first = { severity: 'error' as const, summary: 'First' }
+    const second = { severity: 'error' as const, summary: 'Second' }
+
+    nodeSelectionStore.isActive = true
+    await nextTick()
+
+    toastStore.messagesToAdd = [first]
+    await nextTick()
+    toastStore.messagesToAdd = [second]
+    await nextTick()
+
+    nodeSelectionStore.isActive = false
+    await nextTick()
+
+    expect(toastService.add.mock.calls).toEqual([[first], [second]])
+  })
+
+  it('does not replay anything when nothing was raised during the mode', async () => {
+    renderToast()
+    const nodeSelectionStore = useAgentNodeSelectionStore()
+
+    nodeSelectionStore.isActive = true
+    await nextTick()
+    nodeSelectionStore.isActive = false
+    await nextTick()
+
+    expect(toastService.add).not.toHaveBeenCalled()
   })
 })

--- a/src/components/toast/GlobalToast.vue
+++ b/src/components/toast/GlobalToast.vue
@@ -26,13 +26,27 @@
 
 <script setup lang="ts">
 import Toast from 'primevue/toast'
+import type { ToastMessageOptions } from 'primevue/toast'
 import { useToast } from 'primevue/usetoast'
-import { watch } from 'vue'
+import { computed, onScopeDispose, ref, watch } from 'vue'
 
 import { useToastStore } from '@/platform/updates/common/toastStore'
+import { useAgentNodeSelectionStore } from '@/stores/agentNodeSelectionStore'
+
+/** Paired with the `.p-toast` rule in `src/assets/css/style.css`. */
+const NODE_SELECTION_CLASS = 'node-selection-active'
 
 const toast = useToast()
 const toastStore = useToastStore()
+const agentNodeSelectionStore = useAgentNodeSelectionStore()
+const isNodeSelectionActive = computed(() => agentNodeSelectionStore.isActive)
+
+/**
+ * Messages raised while node selection mode is active. Adding them straight to
+ * a hidden toast layer would let anything carrying a `life` expire unseen, so
+ * they are held here and replayed once the mode exits.
+ */
+const deferredMessages = ref<ToastMessageOptions[]>([])
 
 watch(
   () => toastStore.messagesToAdd,
@@ -42,12 +56,47 @@ watch(
     }
 
     newMessages.forEach((message) => {
-      toast.add(message)
+      if (isNodeSelectionActive.value) {
+        deferredMessages.value.push(message)
+      } else {
+        toast.add(message)
+      }
     })
     toastStore.messagesToAdd = []
   },
   { deep: true }
 )
+
+/**
+ * PrimeVue teleports every `<Toast>` container to `<body>`, so no wrapper here
+ * can hide them - and other components mount their own `<Toast>` groups too.
+ * The whole layer is hidden from the root instead (see `style.css`). Messages
+ * without a `life` are sticky in PrimeVue, so errors already on screen survive
+ * the hide and are still there on exit.
+ */
+watch(
+  isNodeSelectionActive,
+  (active) => {
+    document.body.classList.toggle(NODE_SELECTION_CLASS, active)
+  },
+  { immediate: true }
+)
+
+onScopeDispose(() => {
+  document.body.classList.remove(NODE_SELECTION_CLASS)
+})
+
+watch(isNodeSelectionActive, (active) => {
+  if (active || deferredMessages.value.length === 0) {
+    return
+  }
+
+  const pending = deferredMessages.value
+  deferredMessages.value = []
+  pending.forEach((message) => {
+    toast.add(message)
+  })
+})
 
 watch(
   () => toastStore.messagesToRemove,

--- a/src/composables/canvas/useFocusNode.ts
+++ b/src/composables/canvas/useFocusNode.ts
@@ -1,5 +1,6 @@
 import { nextTick } from 'vue'
 
+import { visibleCanvasViewport } from '@/composables/canvas/visibleCanvasViewport'
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import { app } from '@/scripts/app'
 import type {
@@ -32,6 +33,17 @@ async function navigateToGraph(targetGraph: LGraph) {
 export function useFocusNode() {
   const canvasStore = useCanvasStore()
 
+  /* Focus a known node instance, navigating to its owning graph first. */
+  async function focusNodeInstance(node: LGraphNode) {
+    const canvas = canvasStore.canvas
+    if (!canvas || !node.graph) return
+
+    await navigateToGraph(node.graph as LGraph)
+    canvas.animateToBounds(node.boundingRect, {
+      viewport: visibleCanvasViewport(canvas)
+    })
+  }
+
   /* Locate and focus a node on the canvas by its execution ID. */
   async function focusNode(
     nodeId: string,
@@ -44,11 +56,11 @@ export function useFocusNode() {
       : getNodeByExecutionId(app.rootGraph, nodeId)
     if (!graphNode?.graph) return
 
-    await navigateToGraph(graphNode.graph as LGraph)
-    canvasStore.canvas?.animateToBounds(graphNode.boundingRect)
+    await focusNodeInstance(graphNode)
   }
 
   return {
-    focusNode
+    focusNode,
+    focusNodeInstance
   }
 }

--- a/src/composables/canvas/visibleCanvasViewport.ts
+++ b/src/composables/canvas/visibleCanvasViewport.ts
@@ -1,0 +1,22 @@
+import type { ReadOnlyRect } from '@/lib/litegraph/src/interfaces'
+import type { LGraphCanvas } from '@/lib/litegraph/src/litegraph'
+import { useAgentPanelStore } from '@/workbench/extensions/agent/stores/agent/agentPanelStore'
+
+/**
+ * The region of the canvas the user can actually see, excluding the width the
+ * docked agent panel covers. Framing against this rather than the full canvas
+ * keeps nodes from landing behind the panel while it is open.
+ *
+ * Kept apart from `useFocusNode` so callers that only need the viewport - the
+ * node selection store among them - don't transitively pull in `@/scripts/app`.
+ */
+export function visibleCanvasViewport(canvas: LGraphCanvas): ReadOnlyRect {
+  const agentPanelStore = useAgentPanelStore()
+  const width = canvas.canvas.width / window.devicePixelRatio
+  const height = canvas.canvas.height / window.devicePixelRatio
+  const coveredWidth =
+    agentPanelStore.enabled && agentPanelStore.isOpen
+      ? agentPanelStore.width
+      : 0
+  return [0, 0, Math.max(width - coveredWidth, 0), height]
+}

--- a/src/composables/useCoreCommands.ts
+++ b/src/composables/useCoreCommands.ts
@@ -1,6 +1,7 @@
 import { useCurrentUser } from '@/composables/auth/useCurrentUser'
 import { useAuthActions } from '@/composables/auth/useAuthActions'
 import { useSelectedLiteGraphItems } from '@/composables/canvas/useSelectedLiteGraphItems'
+import { visibleCanvasViewport } from '@/composables/canvas/visibleCanvasViewport'
 import { useSubgraphOperations } from '@/composables/graph/useSubgraphOperations'
 import { startModelNodeDragFromAsset } from '@/composables/node/startModelNodeDragFromAsset'
 import { useExternalLink } from '@/composables/useExternalLink'
@@ -409,7 +410,12 @@ export function useCoreCommands(): ComfyCommand[] {
           })
           return
         }
-        app.canvas.fitViewToSelectionAnimated()
+        // Frame within the region the docked agent panel doesn't cover, or the
+        // nodes being fitted land underneath it. This resolves to the full
+        // canvas whenever the panel is closed.
+        app.canvas.fitViewToSelectionAnimated({
+          viewport: visibleCanvasViewport(app.canvas)
+        })
       }
     },
     {

--- a/src/lib/litegraph/src/DragAndScale.animateToBounds.test.ts
+++ b/src/lib/litegraph/src/DragAndScale.animateToBounds.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { DragAndScale } from '@/lib/litegraph/src/DragAndScale'
+
+type Bounds = [number, number, number, number]
+
+/**
+ * Frames are captured rather than run inline: `animate` closes over the
+ * `animationId` that `requestAnimationFrame` returns, so invoking the callback
+ * synchronously from the stub would hit the temporal dead zone.
+ */
+let pendingFrame: ((timestamp: number) => void) | null = null
+
+function createDragAndScale(width: number, height: number) {
+  return new DragAndScale({ width, height } as HTMLCanvasElement)
+}
+
+/** Run the animation through to its end state. */
+function settle() {
+  const frame = pendingFrame
+  pendingFrame = null
+  frame?.(performance.now() + 10_000)
+}
+
+/** Screen-space X of the center of a `[x, y, width, height]` bounds rect. */
+function screenCenterX(ds: DragAndScale, bounds: Bounds) {
+  return (bounds[0] + bounds[2] * 0.5 + ds.offset[0]) * ds.scale
+}
+
+describe('DragAndScale.animateToBounds', () => {
+  beforeEach(() => {
+    pendingFrame = null
+    vi.stubGlobal('devicePixelRatio', 1)
+    vi.stubGlobal(
+      'requestAnimationFrame',
+      (callback: (timestamp: number) => void) => {
+        pendingFrame = callback
+        return 1
+      }
+    )
+    vi.stubGlobal('cancelAnimationFrame', vi.fn())
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('centers the bounds on the full canvas by default', () => {
+    const ds = createDragAndScale(1600, 900)
+    const bounds: Bounds = [0, 0, 100, 100]
+
+    ds.animateToBounds(bounds, vi.fn(), { zoom: 0 })
+    settle()
+
+    expect(screenCenterX(ds, bounds)).toBeCloseTo(800)
+  })
+
+  it('centers the bounds within a narrower viewport instead of the full canvas', () => {
+    const ds = createDragAndScale(1600, 900)
+    const bounds: Bounds = [0, 0, 100, 100]
+
+    // Simulates an agent panel covering the right 500px of the canvas.
+    ds.animateToBounds(bounds, vi.fn(), {
+      zoom: 0,
+      viewport: [0, 0, 1100, 900]
+    })
+    settle()
+
+    expect(screenCenterX(ds, bounds)).toBeCloseTo(550)
+  })
+
+  it('fits the zoom to the viewport size rather than the full canvas', () => {
+    const ds = createDragAndScale(1600, 900)
+    const bounds: Bounds = [0, 0, 100, 100]
+
+    ds.animateToBounds(bounds, vi.fn(), {
+      zoom: 0.75,
+      viewport: [0, 0, 1100, 900]
+    })
+    settle()
+
+    // min((0.75 * 1100) / 300, (0.75 * 900) / 300) = min(2.75, 2.25)
+    expect(ds.scale).toBeCloseTo(2.25)
+  })
+})

--- a/src/lib/litegraph/src/DragAndScale.ts
+++ b/src/lib/litegraph/src/DragAndScale.ts
@@ -18,6 +18,14 @@ export type AnimationOptions = {
   zoom?: number
   /** The animation easing function (curve) */
   easing?: EaseFunction
+  /**
+   * The region of the canvas element (in CSS pixels, relative to its top-left
+   * corner) to fit and center the bounds within. Defaults to the full canvas.
+   * Use this when part of the canvas is visually covered by an overlaid panel,
+   * so the bounds are centered in the area that's actually visible rather than
+   * in the full canvas element.
+   */
+  viewport?: ReadOnlyRect
 }
 
 export class DragAndScale {
@@ -234,7 +242,8 @@ export class DragAndScale {
     {
       duration = 350,
       zoom = 0.75,
-      easing = EaseFunction.EASE_IN_OUT_QUAD
+      easing = EaseFunction.EASE_IN_OUT_QUAD,
+      viewport
     }: AnimationOptions = {}
   ) {
     if (!(duration > 0)) throw new RangeError('Duration must be greater than 0')
@@ -250,6 +259,7 @@ export class DragAndScale {
     const startTimestamp = performance.now()
     const cw = this.element.width / window.devicePixelRatio
     const ch = this.element.height / window.devicePixelRatio
+    const [vx, vy, vw, vh] = viewport ?? [0, 0, cw, ch]
     const startX = this.offset[0]
     const startY = this.offset[1]
     const startX2 = startX - cw / this.scale
@@ -258,8 +268,8 @@ export class DragAndScale {
     let targetScale = startScale
 
     if (zoom > 0) {
-      const targetScaleX = (zoom * cw) / Math.max(bounds[2], 300)
-      const targetScaleY = (zoom * ch) / Math.max(bounds[3], 300)
+      const targetScaleX = (zoom * vw) / Math.max(bounds[2], 300)
+      const targetScaleY = (zoom * vh) / Math.max(bounds[3], 300)
 
       // Choose the smaller scale to ensure the node fits into the viewport
       // Ensure we don't go over the max scale
@@ -268,8 +278,13 @@ export class DragAndScale {
     const scaledWidth = cw / targetScale
     const scaledHeight = ch / targetScale
 
-    const targetX = -bounds[0] - bounds[2] * 0.5 + scaledWidth * 0.5
-    const targetY = -bounds[1] - bounds[3] * 0.5 + scaledHeight * 0.5
+    // Center the bounds within the given viewport (defaults to the full
+    // canvas), while keeping the corner spacing tied to the full canvas size
+    // so the scale calculated during the animation loop stays correct.
+    const targetCenterX = vx + vw * 0.5
+    const targetCenterY = vy + vh * 0.5
+    const targetX = targetCenterX / targetScale - bounds[0] - bounds[2] * 0.5
+    const targetY = targetCenterY / targetScale - bounds[1] - bounds[3] * 0.5
     const targetX2 = targetX - scaledWidth
     const targetY2 = targetY - scaledHeight
 

--- a/src/lib/litegraph/src/LGraphCanvas.deleteSelected.test.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.deleteSelected.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+
+import { LGraphCanvas } from '@/lib/litegraph/src/LGraphCanvas'
+
+/**
+ * `selectOnly` marks the canvas as a picking surface rather than an editing one
+ * - the agent's node selection mode sets it. Deleting is an edit, and every
+ * delete path (the command, the keybinding and the selection toolbox) funnels
+ * through `deleteSelected`, so the guard belongs here rather than at each call
+ * site.
+ *
+ * A graph-less canvas is the probe: without the guard the method reaches
+ * `NullGraphError`, so "did not throw" proves it returned early.
+ */
+function deleteSelectedOn(selectOnly: boolean) {
+  const canvas = { selectOnly, graph: null }
+  return () => LGraphCanvas.prototype.deleteSelected.call(canvas as never)
+}
+
+describe('LGraphCanvas.deleteSelected', () => {
+  it('does nothing while the canvas is in select-only mode', () => {
+    expect(deleteSelectedOn(true)).not.toThrow()
+  })
+
+  it('still proceeds when the canvas is editable', () => {
+    expect(deleteSelectedOn(false)).toThrow()
+  })
+})

--- a/src/lib/litegraph/src/LGraphCanvas.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.ts
@@ -4887,6 +4887,11 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
    * @todo Refactor deletion task to LGraph.  Selection is a canvas property, delete is a graph action.
    */
   deleteSelected(): void {
+    // `selectOnly` means the canvas is being used to pick items rather than
+    // edit them. Deleting is an edit, and every delete path - the command, the
+    // node context menu and the keybinding - funnels through here.
+    if (this.selectOnly) return
+
     const { graph } = this
     if (!graph) throw new NullGraphError()
 

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -4964,6 +4964,7 @@
     "copy": "Copy",
     "copied": "Copied!",
     "remove": "Remove",
+    "focusNode": "Show on canvas",
     "uploading": "Uploading",
     "noNodesToMention": "No nodes in this workflow",
     "friend": "there",

--- a/src/platform/settings/composables/useLitegraphSettings.test.ts
+++ b/src/platform/settings/composables/useLitegraphSettings.test.ts
@@ -1,0 +1,97 @@
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { effectScope, nextTick, ref } from 'vue'
+
+import { useLitegraphSettings } from '@/platform/settings/composables/useLitegraphSettings'
+import { useSettingStore } from '@/platform/settings/settingStore'
+// Mirrors the exemption in the composable under test.
+// eslint-disable-next-line import-x/no-restricted-paths
+import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
+import { useAgentNodeSelectionStore } from '@/stores/agentNodeSelectionStore'
+
+// The composable drives many settings off one canvas; only `show_info` matters
+// here, the rest are present so the other effects don't throw.
+const canvas = {
+  show_info: false,
+  zoom_speed: 1,
+  auto_pan_speed: 1,
+  links_render_mode: 0,
+  min_font_size_for_lod: 0,
+  draw: vi.fn(),
+  setDirty: vi.fn()
+}
+
+const settings = ref<Record<string, unknown>>({})
+
+vi.mock('@/platform/settings/settingStore', () => ({
+  useSettingStore: vi.fn(() => ({
+    get: (key: string) => settings.value[key]
+  }))
+}))
+
+function run() {
+  const scope = effectScope()
+  scope.run(() => useLitegraphSettings())
+  return scope
+}
+
+describe('useLitegraphSettings', () => {
+  beforeEach(() => {
+    setActivePinia(createTestingPinia({ stubActions: false }))
+    settings.value = {
+      'Comfy.Graph.CanvasInfo': true,
+      'Comfy.Graph.ZoomSpeed': 1,
+      'Comfy.Graph.AutoPanSpeed': 1
+    }
+    canvas.show_info = false
+    vi.mocked(useSettingStore).mockClear()
+    useCanvasStore().canvas = canvas as never
+  })
+
+  it('applies the canvas info setting', () => {
+    run()
+
+    expect(canvas.show_info).toBe(true)
+  })
+
+  // The overlay is drawn onto the canvas rather than composed in the DOM, so it
+  // cannot be hidden with CSS alongside the rest of the chrome.
+  it('suppresses the canvas info overlay during node selection mode', async () => {
+    const nodeSelectionStore = useAgentNodeSelectionStore()
+    run()
+    expect(canvas.show_info).toBe(true)
+
+    nodeSelectionStore.isActive = true
+    await nextTick()
+
+    expect(canvas.show_info).toBe(false)
+  })
+
+  it('restores the overlay on exit without touching the user setting', async () => {
+    const nodeSelectionStore = useAgentNodeSelectionStore()
+    run()
+
+    nodeSelectionStore.isActive = true
+    await nextTick()
+    nodeSelectionStore.isActive = false
+    await nextTick()
+
+    expect(canvas.show_info).toBe(true)
+    expect(settings.value['Comfy.Graph.CanvasInfo']).toBe(true)
+  })
+
+  it('leaves the overlay off during the mode when the setting is disabled', async () => {
+    const nodeSelectionStore = useAgentNodeSelectionStore()
+    settings.value['Comfy.Graph.CanvasInfo'] = false
+    run()
+
+    nodeSelectionStore.isActive = true
+    await nextTick()
+    expect(canvas.show_info).toBe(false)
+
+    nodeSelectionStore.isActive = false
+    await nextTick()
+    expect(canvas.show_info).toBe(false)
+  })
+})

--- a/src/platform/settings/composables/useLitegraphSettings.ts
+++ b/src/platform/settings/composables/useLitegraphSettings.ts
@@ -8,6 +8,7 @@ import {
 import { useSettingStore } from '@/platform/settings/settingStore'
 // eslint-disable-next-line import-x/no-restricted-paths
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
+import { useAgentNodeSelectionStore } from '@/stores/agentNodeSelectionStore'
 
 /**
  * Watch for changes in the setting store and update the LiteGraph settings accordingly.
@@ -15,11 +16,18 @@ import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 export const useLitegraphSettings = () => {
   const settingStore = useSettingStore()
   const canvasStore = useCanvasStore()
+  const agentNodeSelectionStore = useAgentNodeSelectionStore()
 
   watchEffect(() => {
     const canvasInfoEnabled = settingStore.get('Comfy.Graph.CanvasInfo')
+    // Node selection mode clears the canvas of everything but the graph and its
+    // own banner. This overlay is drawn onto the canvas rather than composed in
+    // the DOM, so it can't be hidden with CSS like the rest of the chrome. The
+    // user's setting is left untouched and takes effect again on exit.
+    const suppressedForNodeSelection = agentNodeSelectionStore.isActive
     if (canvasStore.canvas) {
-      canvasStore.canvas.show_info = canvasInfoEnabled
+      canvasStore.canvas.show_info =
+        canvasInfoEnabled && !suppressedForNodeSelection
       canvasStore.canvas.draw(false, true)
     }
   })

--- a/src/platform/updates/components/ReleaseNotificationToast.test.ts
+++ b/src/platform/updates/components/ReleaseNotificationToast.test.ts
@@ -3,6 +3,8 @@ import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
 
+import { useAgentNodeSelectionStore } from '@/stores/agentNodeSelectionStore'
+
 import type { ReleaseNote } from '../common/releaseService'
 import ReleaseNotificationToast from './ReleaseNotificationToast.vue'
 
@@ -129,6 +131,17 @@ describe('ReleaseNotificationToast', () => {
 
     renderComponent()
     expect(screen.getByText('New update is out!')).toBeInTheDocument()
+  })
+
+  it('stays hidden while node selection mode is active', () => {
+    mockReleaseStore.recentRelease = {
+      version: '1.2.3',
+      content: '# Test Release\n\nSome content'
+    } as ReleaseNote
+    useAgentNodeSelectionStore().isActive = true
+
+    renderComponent()
+    expect(screen.queryByText('New update is out!')).not.toBeInTheDocument()
   })
 
   it('displays rocket icon', () => {

--- a/src/platform/updates/components/ReleaseNotificationToast.vue
+++ b/src/platform/updates/components/ReleaseNotificationToast.vue
@@ -55,6 +55,7 @@ import NotificationPopup from '@/components/common/NotificationPopup.vue'
 import Button from '@/components/ui/button/Button.vue'
 import { useErrorHandling } from '@/composables/useErrorHandling'
 import { useExternalLink } from '@/composables/useExternalLink'
+import { useAgentNodeSelectionStore } from '@/stores/agentNodeSelectionStore'
 import { useCommandStore } from '@/stores/commandStore'
 import { isDesktop } from '@/platform/distribution/types'
 import { formatVersionAnchor } from '@/utils/formatUtil'
@@ -70,6 +71,7 @@ const { position = 'bottom-left' } = defineProps<{
 const { buildDocsUrl } = useExternalLink()
 const { toastErrorHandler } = useErrorHandling()
 const releaseStore = useReleaseStore()
+const agentNodeSelectionStore = useAgentNodeSelectionStore()
 const { t } = useI18n()
 
 // Local state for dismissed status
@@ -81,8 +83,13 @@ const latestRelease = computed<ReleaseNote | null>(() => {
 })
 
 // Show toast when new version available and not dismissed
+// Node selection mode keeps the canvas clear of everything but the graph and
+// its own banner, so this popup steps aside for the duration and returns after.
 const shouldShow = computed(
-  () => releaseStore.shouldShowToast && !isDismissed.value
+  () =>
+    releaseStore.shouldShowToast &&
+    !isDismissed.value &&
+    !agentNodeSelectionStore.isActive
 )
 
 // Generate changelog URL with version anchor (language-aware)

--- a/src/stores/agentNodeSelectionStore.test.ts
+++ b/src/stores/agentNodeSelectionStore.test.ts
@@ -24,15 +24,19 @@ function graphNode(
   return { id, pos, size, boundingRect: new Float64Array(4) }
 }
 
-/** The minimum canvas surface the fit-to-view path touches. */
-function stubCanvas(nodes: unknown[]) {
+/** The minimum canvas surface entering and leaving the mode touches. */
+function stubCanvas(nodes: unknown[], selected: unknown[] = []) {
   const animateToBounds = vi.fn()
+  const selectedItems = new Set(selected)
+  const deselectAll = vi.fn(() => selectedItems.clear())
   useCanvasStore().canvas = {
     graph: { nodes },
+    selectedItems,
+    deselectAll,
     animateToBounds,
     canvas: { width: 1600, height: 900 }
   } as never
-  return { animateToBounds }
+  return { animateToBounds, deselectAll, selectedItems }
 }
 
 describe('agentNodeSelectionStore', () => {
@@ -88,6 +92,45 @@ describe('agentNodeSelectionStore', () => {
     useAgentNodeSelectionStore().enter()
 
     expect(animateToBounds).not.toHaveBeenCalled()
+  })
+
+  // Picking is finished, but the references stay in the composer - so the
+  // canvas goes back to looking untouched while the basket keeps its chips.
+  it('clears the canvas selection on exit', () => {
+    const node = graphNode(1, [0, 0], [100, 100])
+    const { deselectAll, selectedItems } = stubCanvas([node], [node])
+    const store = useAgentNodeSelectionStore()
+
+    store.enter()
+    store.exit()
+
+    expect(deselectAll).toHaveBeenCalledOnce()
+    expect(selectedItems.size).toBe(0)
+  })
+
+  it('leaves the canvas alone on exit when nothing was selected', () => {
+    const { deselectAll } = stubCanvas([graphNode(1, [0, 0], [100, 100])])
+    const store = useAgentNodeSelectionStore()
+
+    store.enter()
+    store.exit()
+
+    expect(deselectAll).not.toHaveBeenCalled()
+  })
+
+  // Entering with a selection means the user already knows which nodes they
+  // care about; framing the whole graph would zoom away from them.
+  it('frames the selection when entering with nodes already selected', () => {
+    const selected = graphNode(2, [1000, 800], [200, 100])
+    const { animateToBounds } = stubCanvas(
+      [graphNode(1, [0, 0], [100, 100]), selected],
+      [selected]
+    )
+
+    useAgentNodeSelectionStore().enter()
+
+    const [bounds] = animateToBounds.mock.calls[0]
+    expect(bounds).toEqual([960, 760, 280, 180])
   })
 
   it('does not frame the graph on exit', () => {

--- a/src/stores/agentNodeSelectionStore.test.ts
+++ b/src/stores/agentNodeSelectionStore.test.ts
@@ -2,6 +2,7 @@ import { createPinia, setActivePinia } from 'pinia'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
 
+import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import { useAgentNodeSelectionStore } from '@/stores/agentNodeSelectionStore'
 import { useSidebarTabStore } from '@/stores/workspace/sidebarTabStore'
 
@@ -10,6 +11,29 @@ const dialogStack = vi.hoisted(() => [] as unknown[])
 vi.mock('@/stores/dialogStore', () => ({
   useDialogStore: () => ({ dialogStack })
 }))
+
+/**
+ * Real nodes carry `pos`/`size`; `boundingRect` is litegraph-renderer cache that
+ * stays zeroed under Vue nodes, so the fit deliberately ignores it.
+ */
+function graphNode(
+  id: number,
+  pos?: [number, number],
+  size?: [number, number]
+) {
+  return { id, pos, size, boundingRect: new Float64Array(4) }
+}
+
+/** The minimum canvas surface the fit-to-view path touches. */
+function stubCanvas(nodes: unknown[]) {
+  const animateToBounds = vi.fn()
+  useCanvasStore().canvas = {
+    graph: { nodes },
+    animateToBounds,
+    canvas: { width: 1600, height: 900 }
+  } as never
+  return { animateToBounds }
+}
 
 describe('agentNodeSelectionStore', () => {
   beforeEach(() => {
@@ -20,6 +44,61 @@ describe('agentNodeSelectionStore', () => {
 
   afterEach(() => {
     vi.useRealTimers()
+  })
+
+  it('frames the graph on entering, whatever opened the mode', () => {
+    const { animateToBounds } = stubCanvas([
+      graphNode(1, [0, 0], [100, 100]),
+      graphNode(2, [500, 300], [100, 100])
+    ])
+
+    useAgentNodeSelectionStore().enter()
+
+    expect(animateToBounds).toHaveBeenCalledOnce()
+    const [bounds, options] = animateToBounds.mock.calls[0]
+    // Encloses both nodes (0,0 to 600,400), plus 40 units of padding each side.
+    expect(bounds).toEqual([-40, -40, 680, 480])
+    expect(options.viewport).toEqual([0, 0, 1600, 900])
+  })
+
+  // Under Vue nodes `boundingRect` is all zeroes, so a fit driven off it would
+  // frame a degenerate rect at the origin instead of the graph.
+  it('frames from pos/size, not the zeroed litegraph boundingRect', () => {
+    const { animateToBounds } = stubCanvas([
+      graphNode(1, [1000, 800], [200, 100])
+    ])
+
+    useAgentNodeSelectionStore().enter()
+
+    const [bounds] = animateToBounds.mock.calls[0]
+    expect(bounds).toEqual([960, 760, 280, 180])
+  })
+
+  it('leaves the camera alone when nothing is positioned yet', () => {
+    const { animateToBounds } = stubCanvas([graphNode(1), graphNode(2)])
+
+    useAgentNodeSelectionStore().enter()
+
+    expect(animateToBounds).not.toHaveBeenCalled()
+  })
+
+  it('leaves the camera alone on an empty graph', () => {
+    const { animateToBounds } = stubCanvas([])
+
+    useAgentNodeSelectionStore().enter()
+
+    expect(animateToBounds).not.toHaveBeenCalled()
+  })
+
+  it('does not frame the graph on exit', () => {
+    const { animateToBounds } = stubCanvas([graphNode(1, [0, 0], [100, 100])])
+    const store = useAgentNodeSelectionStore()
+
+    store.enter()
+    animateToBounds.mockClear()
+    store.exit()
+
+    expect(animateToBounds).not.toHaveBeenCalled()
   })
 
   it('sequences selection chrome and restores the open sidebar', async () => {

--- a/src/stores/agentNodeSelectionStore.test.ts
+++ b/src/stores/agentNodeSelectionStore.test.ts
@@ -126,10 +126,25 @@ describe('agentNodeSelectionStore', () => {
     expect(store.isActive).toBe(false)
     expect(store.isBannerVisible).toBe(false)
     expect(store.isActionBarsHidden).toBe(true)
-    expect(sidebar.activeSidebarTabId).toBe('assets')
+    // Staged like the entry side: still closed while the banner retracts.
+    expect(sidebar.activeSidebarTabId).toBeNull()
 
     vi.advanceTimersByTime(150)
     expect(store.isActionBarsHidden).toBe(false)
+    expect(sidebar.activeSidebarTabId).toBe('assets')
+  })
+
+  it('does not reopen a sidebar the user never had open', () => {
+    const sidebar = useSidebarTabStore()
+    sidebar.activeSidebarTabId = null
+    const store = useAgentNodeSelectionStore()
+
+    store.enter()
+    vi.advanceTimersByTime(200)
+    store.exit()
+    vi.advanceTimersByTime(150)
+
+    expect(sidebar.activeSidebarTabId).toBeNull()
   })
 
   it('exits on Escape unless a dialog is open', async () => {

--- a/src/stores/agentNodeSelectionStore.ts
+++ b/src/stores/agentNodeSelectionStore.ts
@@ -120,7 +120,16 @@ export const useAgentNodeSelectionStore = defineStore(
       const canvas = canvasStore.canvas
       if (!canvas) return
 
-      const bounds = graphBounds(canvas.graph?.nodes ?? [])
+      // Frame what the user is already referencing when there is a selection,
+      // and fall back to the whole graph when there isn't. Entering with a
+      // selection means they know which nodes they care about; framing
+      // everything would zoom away from them.
+      const selected = [...canvas.selectedItems].filter(
+        (item): item is LGraphNode => 'pos' in item && 'size' in item
+      )
+      const bounds = graphBounds(
+        selected.length ? selected : (canvas.graph?.nodes ?? [])
+      )
       if (!bounds) return
 
       canvas.animateToBounds(bounds, {
@@ -134,7 +143,16 @@ export const useAgentNodeSelectionStore = defineStore(
     }
 
     function exit(): void {
+      // Order matters: dropping out of the mode first stops the basket
+      // mirroring the canvas, so clearing the selection below leaves the
+      // staged chips intact. Picking is finished - the references stay in the
+      // composer, but the graph goes back to looking untouched.
       isActive.value = false
+
+      const canvas = canvasStore.canvas
+      if (!canvas?.selectedItems.size) return
+      canvas.deselectAll()
+      canvasStore.updateSelectedItems()
     }
 
     function saveNodeIds(

--- a/src/stores/agentNodeSelectionStore.ts
+++ b/src/stores/agentNodeSelectionStore.ts
@@ -98,9 +98,15 @@ export const useAgentNodeSelectionStore = defineStore(
         isActionBarsHidden.value = false
       }, BANNER_TRANSITION_MS)
 
+      // Staged like the entry side rather than snapping back: the panel
+      // reappears with the action bars, once the banner has retracted, so the
+      // two never animate over each other.
       if (restoreSidebarTabId) {
-        sidebarTabStore.activeSidebarTabId = restoreSidebarTabId
+        const tabId = restoreSidebarTabId
         restoreSidebarTabId = null
+        sidebarTimeoutId = setTimeout(() => {
+          sidebarTabStore.activeSidebarTabId = tabId
+        }, BANNER_TRANSITION_MS)
       }
     })
 

--- a/src/stores/agentNodeSelectionStore.ts
+++ b/src/stores/agentNodeSelectionStore.ts
@@ -2,18 +2,68 @@ import { useEventListener } from '@vueuse/core'
 import { defineStore } from 'pinia'
 import { ref, watch } from 'vue'
 
+import { visibleCanvasViewport } from '@/composables/canvas/visibleCanvasViewport'
+import type { ReadOnlyRect } from '@/lib/litegraph/src/interfaces'
+import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
+import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import { useDialogStore } from '@/stores/dialogStore'
 import { useSidebarTabStore } from '@/stores/workspace/sidebarTabStore'
 
 const ACTION_BARS_TRANSITION_MS = 300
 const BANNER_TRANSITION_MS = 150
 const SIDEBAR_PANEL_TRANSITION_MS = 200
+/** Breathing room around the framed graph, in graph units. */
+const FIT_PADDING = 40
+
+/**
+ * Bounding box enclosing every node, or null when nothing is positioned yet.
+ *
+ * Derived from `pos`/`size` rather than litegraph's `boundingRect`: the latter
+ * is cached geometry that only the litegraph renderer maintains, so with Vue
+ * nodes it stays `[0, 0, 0, 0]` and would frame a degenerate rect at the origin.
+ */
+function graphBounds(nodes: LGraphNode[]): ReadOnlyRect | null {
+  let minX = Infinity
+  let minY = Infinity
+  let maxX = -Infinity
+  let maxY = -Infinity
+
+  for (const node of nodes) {
+    const x = node.pos?.[0]
+    const y = node.pos?.[1]
+    const width = node.size?.[0]
+    const height = node.size?.[1]
+    if (
+      !Number.isFinite(x) ||
+      !Number.isFinite(y) ||
+      !Number.isFinite(width) ||
+      !Number.isFinite(height)
+    ) {
+      continue
+    }
+
+    minX = Math.min(minX, x)
+    minY = Math.min(minY, y)
+    maxX = Math.max(maxX, x + width)
+    maxY = Math.max(maxY, y + height)
+  }
+
+  if (!Number.isFinite(minX) || !Number.isFinite(minY)) return null
+
+  return [
+    minX - FIT_PADDING,
+    minY - FIT_PADDING,
+    maxX - minX + FIT_PADDING * 2,
+    maxY - minY + FIT_PADDING * 2
+  ]
+}
 
 export const useAgentNodeSelectionStore = defineStore(
   'agentNodeSelection',
   () => {
     const dialogStore = useDialogStore()
     const sidebarTabStore = useSidebarTabStore()
+    const canvasStore = useCanvasStore()
     const isActive = ref(false)
     const isActionBarsHidden = ref(false)
     const isBannerVisible = ref(false)
@@ -54,8 +104,27 @@ export const useAgentNodeSelectionStore = defineStore(
       }
     })
 
+    /**
+     * Frame the whole graph so nodes that were off screen can be picked without
+     * panning first. Framed against the region the agent panel doesn't cover.
+     * Lives here rather than at the call site so every way into the mode gets
+     * it, not just the composer control.
+     */
+    function fitGraphToView(): void {
+      const canvas = canvasStore.canvas
+      if (!canvas) return
+
+      const bounds = graphBounds(canvas.graph?.nodes ?? [])
+      if (!bounds) return
+
+      canvas.animateToBounds(bounds, {
+        viewport: visibleCanvasViewport(canvas)
+      })
+    }
+
     function enter(): void {
       isActive.value = true
+      fitGraphToView()
     }
 
     function exit(): void {

--- a/src/workbench/extensions/agent/AgentPanelRoot.test.ts
+++ b/src/workbench/extensions/agent/AgentPanelRoot.test.ts
@@ -492,6 +492,16 @@ async function enterNodeSelectionMode(): Promise<void> {
   )
 }
 
+/**
+ * The basket only mirrors the canvas while picking, so anything asserting on
+ * staged chips has to be in the mode first. Set directly rather than driving the
+ * composer control: these tests are about what gets staged, not about how the
+ * mode is entered.
+ */
+function startPicking(): void {
+  useAgentNodeSelectionStore().isActive = true
+}
+
 async function startVueNodeSelection() {
   const state = setupNodeSelectionCanvas()
   const collapseToClickedNode = vi.fn((node: SelectionTestNode) => {
@@ -3590,6 +3600,7 @@ describe('AgentPanelRoot workflow binding', () => {
     render(AgentPanelRoot, { global: { plugins: [i18n] } })
 
     useAgentPanelStore().isOpen = true
+    startPicking()
     hostStores.canvas.selectedItems = [
       { isNodeFake: true, id: 7, title: 'KSampler' }
     ]
@@ -3722,6 +3733,7 @@ describe('AgentPanelRoot workflow binding', () => {
 
     render(AgentPanelRoot, { global: { plugins: [i18n] } })
     useAgentPanelStore().isOpen = true
+    startPicking()
 
     hostStores.canvas.selectedItems = [
       { isNodeFake: true, id: 5, title: 'KSampler' },
@@ -3755,6 +3767,7 @@ describe('AgentPanelRoot workflow binding', () => {
 
     render(AgentPanelRoot, { global: { plugins: [i18n] } })
     useAgentPanelStore().isOpen = true
+    startPicking()
 
     expect(await screen.findByText('VAE Decode')).toBeInTheDocument()
     expect(screen.getByText('KSampler')).toBeInTheDocument()
@@ -3769,12 +3782,46 @@ describe('AgentPanelRoot workflow binding', () => {
     expect(hostStores.canvas.selectedItems).toEqual([state.nodes[1]])
   })
 
+  // Selecting nodes in the normal graph view is ordinary canvas work. Only
+  // picking mode fills the basket, so an open panel alone must stage nothing.
+  it('does not stage canvas selections outside picking mode', async () => {
+    makeTab()
+
+    render(AgentPanelRoot, { global: { plugins: [i18n] } })
+    useAgentPanelStore().isOpen = true
+
+    hostStores.canvas.selectedItems = [
+      { isNodeFake: true, id: 5, title: 'KSampler' }
+    ]
+    await nextTick()
+
+    expect(screen.queryByText('KSampler')).not.toBeInTheDocument()
+  })
+
+  // ...but a selection made beforehand is honoured the moment picking starts.
+  it('stages a pre-existing canvas selection once picking starts', async () => {
+    makeTab()
+
+    render(AgentPanelRoot, { global: { plugins: [i18n] } })
+    useAgentPanelStore().isOpen = true
+    hostStores.canvas.selectedItems = [
+      { isNodeFake: true, id: 5, title: 'KSampler' }
+    ]
+    await nextTick()
+    expect(screen.queryByText('KSampler')).not.toBeInTheDocument()
+
+    startPicking()
+
+    expect(await screen.findByText('KSampler')).toBeInTheDocument()
+  })
+
   it('stages selected nodes as chips and sends their ids once', async () => {
     makeTab()
     const bodies = mockMessagesEndpoint('wf-42')
 
     render(AgentPanelRoot, { global: { plugins: [i18n] } })
     useAgentPanelStore().isOpen = true
+    startPicking()
 
     hostStores.canvas.selectedItems = [
       { isNodeFake: true, id: 5, title: 'KSampler' }
@@ -3795,6 +3842,7 @@ describe('AgentPanelRoot workflow binding', () => {
 
     render(AgentPanelRoot, { global: { plugins: [i18n] } })
     useAgentPanelStore().isOpen = true
+    startPicking()
 
     hostStores.canvas.selectedItems = [
       { isNodeFake: true, id: 7, title: 'KSampler' }
@@ -3820,6 +3868,7 @@ describe('AgentPanelRoot workflow binding', () => {
     const panelStore = useAgentPanelStore()
     const first = render(AgentPanelRoot, { global: { plugins: [i18n] } })
     panelStore.isOpen = true
+    startPicking()
 
     hostStores.canvas.selectedItems = [
       { isNodeFake: true, id: 7, title: 'KSampler' }
@@ -3835,6 +3884,7 @@ describe('AgentPanelRoot workflow binding', () => {
 
     render(AgentPanelRoot, { global: { plugins: [i18n] } })
     panelStore.isOpen = true
+    startPicking()
     await nextTick()
     expect(screen.queryByText('KSampler')).not.toBeInTheDocument()
     await sendFromComposer('no nodes please')
@@ -3853,6 +3903,7 @@ describe('AgentPanelRoot workflow binding', () => {
 
     ws.emit('agent_message_done', { message_id: 'm-2', thread_id: 'th-1' })
     await screen.findByRole('button', { name: 'Send' })
+    startPicking()
     hostStores.canvas.selectedItems = [
       { isNodeFake: true, id: 8, title: 'VAEDecode' }
     ]
@@ -3870,6 +3921,7 @@ describe('AgentPanelRoot workflow binding', () => {
     const panelStore = useAgentPanelStore()
     const first = render(AgentPanelRoot, { global: { plugins: [i18n] } })
     panelStore.isOpen = true
+    startPicking()
 
     hostStores.canvas.selectedItems = [
       { isNodeFake: true, id: 7, title: 'First KSampler' }
@@ -3891,6 +3943,7 @@ describe('AgentPanelRoot workflow binding', () => {
     ]
     render(AgentPanelRoot, { global: { plugins: [i18n] } })
     panelStore.isOpen = true
+    startPicking()
 
     expect(await screen.findByText('Second KSampler')).toBeInTheDocument()
     await sendFromComposer('use this workflow')

--- a/src/workbench/extensions/agent/AgentPanelRoot.test.ts
+++ b/src/workbench/extensions/agent/AgentPanelRoot.test.ts
@@ -67,11 +67,17 @@ const appMock = vi.hoisted(() => {
           }
           selectedItems: Set<unknown>
           selectItems: ReturnType<typeof vi.fn>
+          select: ReturnType<typeof vi.fn>
           deselect: (node: unknown) => void
+          animateToBounds: ReturnType<typeof vi.fn>
           multi_select: boolean
           allow_dragnodes: boolean
           selectOnly: boolean
-          canvas: { focus: ReturnType<typeof vi.fn> }
+          canvas: {
+            focus: ReturnType<typeof vi.fn>
+            width: number
+            height: number
+          }
         }
       | undefined
   }
@@ -416,6 +422,10 @@ function setupNodeSelectionCanvas() {
     for (const item of items) selectedItems.add(item)
   })
   const deselect = vi.fn((node: unknown) => selectedItems.delete(node))
+  const select = vi.fn((node: unknown) => selectedItems.add(node))
+  // Entering selection mode frames the graph; the stub only has to record the
+  // call, but it must exist or onSelectNodes throws part-way through.
+  const animateToBounds = vi.fn()
   const graph = {
     nodes,
     getNodeById: (id: string) =>
@@ -425,15 +435,26 @@ function setupNodeSelectionCanvas() {
     graph,
     selectedItems,
     selectItems,
+    select,
     deselect,
+    animateToBounds,
     multi_select: false,
     allow_dragnodes: true,
     selectOnly: false,
-    canvas: { focus }
+    canvas: { focus, width: 1600, height: 900 }
   }
   appMock.canvas = canvas
   hostStores.canvas.currentGraph = graph
-  return { canvas, focus, nodes, selectedItems, selectItems, deselect }
+  return {
+    canvas,
+    focus,
+    nodes,
+    selectedItems,
+    selectItems,
+    select,
+    deselect,
+    animateToBounds
+  }
 }
 
 function renderCanvasNodeButtons(
@@ -4071,18 +4092,24 @@ describe('AgentPanelRoot workflow binding', () => {
   it('resolves picker nodes from the viewed subgraph, not the root graph', async () => {
     makeTab()
     const bodies = mockMessagesEndpoint('wf-42')
+    // `select` has to actually add to the selection: picking a mention now
+    // selects the node on the canvas, and staged chips are rebuilt from that
+    // selection, so a no-op stub would drop the chip it just staged.
+    const selectedItems = new Set<unknown>()
     appMock.canvas = {
       graph: {
         nodes: [{ id: 12, title: 'KSampler' }],
         getNodeById: () => null
       },
-      selectedItems: new Set(),
+      selectedItems,
       selectItems: vi.fn(),
+      select: vi.fn((node: unknown) => selectedItems.add(node)),
       deselect: vi.fn(),
+      animateToBounds: vi.fn(),
       multi_select: false,
       allow_dragnodes: true,
       selectOnly: false,
-      canvas: { focus: vi.fn() }
+      canvas: { focus: vi.fn(), width: 1600, height: 900 }
     }
 
     render(AgentPanelRoot, { global: { plugins: [i18n] } })

--- a/src/workbench/extensions/agent/AgentPanelRoot.vue
+++ b/src/workbench/extensions/agent/AgentPanelRoot.vue
@@ -116,7 +116,9 @@ const {
   add: addSelectionTag
 } = useCanvasSelection({
   selection: selectedNodes,
-  isLive: () => agentPanelStore.isOpen,
+  // Only picking mode fills the basket. Selecting nodes in the normal graph
+  // view is ordinary canvas work and must not stage a reference.
+  isLive: () => agentNodeSelectionStore.isActive,
   isPaused: () => agentNodeSelectionStore.isLoadingWorkflow,
   scope: () => workflowStore.activeWorkflow?.path ?? null,
   dismissedSignature: dismissedSelectionSignature
@@ -922,12 +924,17 @@ function onSelectNodes(): void {
   canvas.multi_select = true
   nodeSelectionCanvas = canvas
   selectingNodes = true
-  agentNodeSelectionStore.enter()
 
+  // Apply the selection before entering: `enter()` frames whatever is selected,
+  // so the merged set has to be in place first or it frames the stale one.
+  // Selecting here is safe because the basket only mirrors the canvas once the
+  // mode is active.
   if (merged.size) {
     canvas.selectItems([...merged.values()])
     canvasStore.updateSelectedItems()
   }
+
+  agentNodeSelectionStore.enter()
 
   void nextTick(() => {
     if (selectingNodes) canvas.canvas.focus()

--- a/src/workbench/extensions/agent/AgentPanelRoot.vue
+++ b/src/workbench/extensions/agent/AgentPanelRoot.vue
@@ -15,6 +15,7 @@ import {
 import { useI18n } from 'vue-i18n'
 
 import { useCurrentUser } from '@/composables/auth/useCurrentUser'
+import { useFocusNode } from '@/composables/canvas/useFocusNode'
 import { useTelemetry } from '@/platform/telemetry'
 import { useWorkflowService } from '@/platform/workflow/core/services/workflowService'
 import type { ComfyWorkflow } from '@/platform/workflow/management/stores/comfyWorkflow'
@@ -100,6 +101,7 @@ const tabActivity = useWorkflowTabActivityStore()
 const CREATING_TAB_MIN_DURATION_MS = 500
 
 const canvasStore = useCanvasStore()
+const { focusNodeInstance } = useFocusNode()
 const selectedNodes = computed<SelectedNode[]>(() =>
   canvasStore.selectedItems.filter(isLGraphNode).map((node) => ({
     id: String(node.id),
@@ -888,15 +890,31 @@ watch(
   }
 )
 
+/** Resolve a staged chip back to its node in the viewed graph. */
+function graphNodeById(id: string): LGraphNode | undefined {
+  return viewedGraphNodes().find((node) => String(node.id) === id)
+}
+
 function onSelectNodes(): void {
   if (selectingNodes) return
   const canvas = app.canvas
   if (!canvas) return
-  selectedGraphNodes = new Map(
+
+  // Chips staged before entering (via `@` mention) must read as selected on the
+  // canvas too, or the composer and the graph disagree about the same set.
+  // Merge them with whatever was already selected rather than one replacing the
+  // other.
+  const merged = new Map(
     [...canvas.selectedItems]
       .filter(isLGraphNode)
       .map((node) => [String(node.id), node] as const)
   )
+  for (const tag of selectionTags.value) {
+    const node = graphNodeById(tag.id)
+    if (node) merged.set(tag.id, node)
+  }
+  selectedGraphNodes = merged
+
   restoreAllowDragNodes = canvas.allow_dragnodes
   restoreSelectOnly = canvas.selectOnly
   canvas.allow_dragnodes = false
@@ -905,6 +923,12 @@ function onSelectNodes(): void {
   nodeSelectionCanvas = canvas
   selectingNodes = true
   agentNodeSelectionStore.enter()
+
+  if (merged.size) {
+    canvas.selectItems([...merged.values()])
+    canvasStore.updateSelectedItems()
+  }
+
   void nextTick(() => {
     if (selectingNodes) canvas.canvas.focus()
   })
@@ -945,9 +969,29 @@ function onOpenAssets(): void {
 
 function onMentionPick(node: SelectedNode): void {
   const stagedBefore = selectionTags.value.length
-  addSelectionTag(node)
+
+  // Select on the canvas first, so the chip and the graph agree about the same
+  // set. Staged chips are rebuilt wholesale from the canvas selection, so
+  // selecting is what makes the chip durable - staging it directly is the
+  // fallback for a node the canvas doesn't have.
+  const canvas = app.canvas
+  const graphNode = graphNodeById(node.id)
+  if (canvas && graphNode && !canvas.selectedItems.has(graphNode)) {
+    canvas.select(graphNode)
+    canvasStore.updateSelectedItems()
+  }
+  if (!selectionTags.value.some((tag) => tag.id === node.id)) {
+    addSelectionTag(node)
+  }
+
   if (selectionTags.value.length > stagedBefore)
     useTelemetry()?.trackAgentNodeTagged({ source: 'mention_picker' })
+}
+
+/** Fly the canvas to a chip's node so the user can see what they referenced. */
+function onFocusSelectionTag(id: string): void {
+  const node = graphNodeById(id)
+  if (node) void focusNodeInstance(node)
 }
 
 function onRemoveSelectionTag(id: string): void {
@@ -1087,6 +1131,7 @@ function onPanelDrop(event: DragEvent): void {
       @open-assets="onOpenAssets"
       @select-nodes="onSelectNodes"
       @remove-tag="onRemoveSelectionTag"
+      @focus-tag="onFocusSelectionTag"
       @mention-pick="onMentionPick"
       @feedback="onFeedback"
       @new-chat="onNewChat"

--- a/src/workbench/extensions/agent/components/agent/AgentPanel.vue
+++ b/src/workbench/extensions/agent/components/agent/AgentPanel.vue
@@ -69,6 +69,7 @@ const emit = defineEmits<{
   openAssets: []
   selectNodes: []
   removeTag: [id: string]
+  focusTag: [id: string]
   mentionPick: [node: SelectedNode]
   feedback: [turnId: string, vote: 'up' | 'down' | null]
   selectTab: [path: string]
@@ -298,6 +299,7 @@ defineExpose({ addAttachment, updateAttachment, removeAttachment })
             @open-assets="emit('openAssets')"
             @select-nodes="emit('selectNodes')"
             @remove-tag="emit('removeTag', $event)"
+            @focus-tag="emit('focusTag', $event)"
             @mention-pick="emit('mentionPick', $event)"
           >
             <template #header>

--- a/src/workbench/extensions/agent/components/agent/Composer.test.ts
+++ b/src/workbench/extensions/agent/components/agent/Composer.test.ts
@@ -315,6 +315,37 @@ describe('Composer', () => {
       ).toEqual(['Alpha', 'KSampler', 'VAE Decode'])
     })
 
+    // Re-picking a staged node is a no-op, so it drops out of the list.
+    it('hides nodes already in the basket', async () => {
+      mount({
+        getMentionNodes: () => NODES,
+        selectionTags: [NODES[0]]
+      })
+
+      await userEvent.type(screen.getByRole('textbox'), '@')
+
+      const labels = screen
+        .getAllByRole('option')
+        .map((option) => option.textContent?.trim())
+      expect(labels).not.toContain(NODES[0].title)
+      expect(screen.getAllByRole('option')).toHaveLength(NODES.length - 1)
+    })
+
+    // The staged node is only hidden from the picker, not from the duplicate
+    // check - its chip must still show the id that tells it apart from the
+    // same-titled node still in the graph.
+    it('keeps disambiguating a staged node against its graph twin', async () => {
+      const twin = { id: '11', title: NODES[0].title }
+      mount({
+        getMentionNodes: () => [...NODES, twin],
+        selectionTags: [NODES[0]]
+      })
+
+      await userEvent.type(screen.getByRole('textbox'), '@')
+
+      expect(screen.getByText(`#${NODES[0].id}`)).toBeInTheDocument()
+    })
+
     it('opens on @, filters with spaces, and stages the pick on Enter', async () => {
       const { emitted } = mount({ getMentionNodes: () => NODES })
       const box = screen.getByRole('textbox')

--- a/src/workbench/extensions/agent/components/agent/Composer.test.ts
+++ b/src/workbench/extensions/agent/components/agent/Composer.test.ts
@@ -543,6 +543,31 @@ describe('Composer', () => {
     ).toHaveTextContent('Remove')
   })
 
+  it('emits focusTag when a selection chip is activated', async () => {
+    const { emitted } = mount({
+      selectionTags: [{ id: '5', title: 'KSampler' }]
+    })
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Show on canvas' })
+    )
+
+    expect(emitted().focusTag).toEqual([['5']])
+  })
+
+  // The remove button sits outside the focus trigger; removing a chip must not
+  // also fly the canvas to the node being removed.
+  it('removes a selection chip without focusing its node', async () => {
+    const { emitted } = mount({
+      selectionTags: [{ id: '5', title: 'KSampler' }]
+    })
+
+    await userEvent.click(screen.getByRole('button', { name: 'Remove' }))
+
+    expect(emitted().removeTag).toEqual([['5']])
+    expect(emitted().focusTag).toBeUndefined()
+  })
+
   it('shows the id on a lone selection chip with a graph title twin', () => {
     const selected = { id: '5', title: 'KSampler' }
     mount({

--- a/src/workbench/extensions/agent/components/agent/Composer.vue
+++ b/src/workbench/extensions/agent/components/agent/Composer.vue
@@ -52,6 +52,7 @@ const emit = defineEmits<{
   openAssets: []
   selectNodes: []
   removeTag: [id: string]
+  focusTag: [id: string]
   mentionPick: [node: SelectedNode]
 }>()
 
@@ -376,24 +377,38 @@ defineExpose({
         <span>{{ t('agent.dragAndDropAssets') }}</span>
       </div>
       <div v-if="selectionTags.length" class="flex flex-wrap gap-2 p-3">
+        <!-- The label is the control that reveals the node on the canvas. The
+             remove button sits outside that trigger deliberately: nesting it
+             inside would surface both tooltips at once on hover. -->
         <span
           v-for="tag in selectionTags"
           :key="tag.id"
           class="bg-agent-surface-hover text-agent-fg inline-flex h-7 items-center gap-1 rounded-lg border border-neutral-200 px-2.5 text-xs/4 font-medium"
         >
-          <span class="icon-[comfy--node] size-3.5" />
-          <span class="max-w-40 truncate">{{ tag.title }}</span>
           <span
-            v-if="graphDupes.has(tag.title) || tagDupes.has(tag.title)"
-            :class="duplicateIdClass"
-            >#{{ tag.id }}</span
+            v-tooltip.top="buildAgentTooltipConfig(t('agent.focusNode'))"
+            role="button"
+            tabindex="0"
+            :aria-label="t('agent.focusNode')"
+            class="hover:text-agent-fg-hover flex cursor-pointer items-center gap-1 transition-colors"
+            @click="emit('focusTag', tag.id)"
+            @keydown.enter="emit('focusTag', tag.id)"
+            @keydown.space.prevent="emit('focusTag', tag.id)"
           >
+            <span class="icon-[comfy--node] size-3.5" />
+            <span class="max-w-40 truncate">{{ tag.title }}</span>
+            <span
+              v-if="graphDupes.has(tag.title) || tagDupes.has(tag.title)"
+              :class="duplicateIdClass"
+              >#{{ tag.id }}</span
+            >
+          </span>
           <button
             v-tooltip.top="buildAgentTooltipConfig(t('agent.remove'))"
             type="button"
             :aria-label="t('agent.remove')"
             class="text-agent-fg-muted hover:text-agent-fg flex size-3.5 cursor-pointer items-center justify-center transition-colors"
-            @click="emit('removeTag', tag.id)"
+            @click.stop="emit('removeTag', tag.id)"
           >
             <span class="icon-[lucide--x] size-3.5 shrink-0" />
           </button>

--- a/src/workbench/extensions/agent/components/agent/Composer.vue
+++ b/src/workbench/extensions/agent/components/agent/Composer.vue
@@ -61,8 +61,11 @@ const assetDragActive = inject<Readonly<Ref<boolean>>>(
   ref(false)
 )
 
+// Shared by the reference chips and the `@`-mention rows. Uses the same surface
+// token as the chip itself so the badge tracks the chip across themes, and the
+// same muted foreground as the chip's icon and remove button.
 const duplicateIdClass =
-  'shrink-0 rounded-[26px] bg-charcoal-400 px-1 py-0.5 font-mono text-xs/4 font-medium text-smoke-800'
+  'shrink-0 rounded-[26px] bg-agent-surface-hover px-1 py-0.5 font-mono text-xs/4 font-medium text-agent-fg-muted'
 
 const mentionNodes = ref<SelectedNode[]>([])
 const mentionAssets = ref<AssetItem[]>([])
@@ -91,6 +94,16 @@ type MentionMatch =
   | { kind: 'node'; id: string; label: string; node: SelectedNode }
   | { kind: 'asset'; id: string; label: string; asset: AssetItem }
 
+/**
+ * Nodes already in the basket, hidden from the picker - re-picking one is a
+ * no-op and only makes the list harder to scan.
+ *
+ * Filtered here rather than out of `mentionNodes`, because that list also feeds
+ * `graphDupes`: dropping a staged node from it would stop its chip showing the
+ * `#id` that disambiguates it from a same-titled node still in the graph.
+ */
+const stagedIds = computed(() => new Set(selectionTags.map((tag) => tag.id)))
+
 const mentionMatches = computed<MentionMatch[]>(() => {
   if (!mentionOpen.value) return []
   const query = mentionQuery.value.toLowerCase()
@@ -98,7 +111,8 @@ const mentionMatches = computed<MentionMatch[]>(() => {
     ...mentionNodes.value
       .filter(
         (node) =>
-          node.title.toLowerCase().includes(query) || node.id.includes(query)
+          !stagedIds.value.has(node.id) &&
+          (node.title.toLowerCase().includes(query) || node.id.includes(query))
       )
       .map(
         (node): MentionMatch => ({
@@ -379,23 +393,25 @@ defineExpose({
       <div v-if="selectionTags.length" class="flex flex-wrap gap-2 p-3">
         <!-- The label is the control that reveals the node on the canvas. The
              remove button sits outside that trigger deliberately: nesting it
-             inside would surface both tooltips at once on hover. -->
+             inside would surface both tooltips at once on hover. The hover fill
+             sits on the whole chip so the pill lights as one shape rather than
+             painting only the label's inline box. -->
         <span
           v-for="tag in selectionTags"
           :key="tag.id"
-          class="bg-agent-surface-hover text-agent-fg inline-flex h-7 items-center gap-1 rounded-lg border border-neutral-200 px-2.5 text-xs/4 font-medium"
+          class="bg-agent-surface-hover text-agent-fg inline-flex h-7 items-center gap-1 rounded-lg border border-border-default px-2.5 text-xs/4 font-medium transition-colors hover:bg-tertiary-background-hover"
         >
           <span
             v-tooltip.top="buildAgentTooltipConfig(t('agent.focusNode'))"
             role="button"
             tabindex="0"
             :aria-label="t('agent.focusNode')"
-            class="hover:text-agent-fg-hover flex cursor-pointer items-center gap-1 transition-colors"
+            class="flex cursor-pointer items-center gap-1 transition-colors"
             @click="emit('focusTag', tag.id)"
             @keydown.enter="emit('focusTag', tag.id)"
             @keydown.space.prevent="emit('focusTag', tag.id)"
           >
-            <span class="icon-[comfy--node] size-3.5" />
+            <span class="text-agent-fg-muted icon-[comfy--node] size-3.5" />
             <span class="max-w-40 truncate">{{ tag.title }}</span>
             <span
               v-if="graphDupes.has(tag.title) || tagDupes.has(tag.title)"

--- a/src/workbench/extensions/agent/composables/agent/useCanvasSelection.ts
+++ b/src/workbench/extensions/agent/composables/agent/useCanvasSelection.ts
@@ -37,7 +37,11 @@ export function useCanvasSelection(options: UseCanvasSelectionOptions) {
     ([isLive, isPaused, scope, nodes]) => {
       if (isPaused) return
       if (!isLive) {
-        staged.value = []
+        // Staged chips outlive the picking session. The basket is an explicit
+        // reference list the user built, not a mirror of the live canvas
+        // selection - so leaving the mode (which also clears the selection)
+        // must not empty it. Only the bookkeeping resets, so the next session
+        // starts clean.
         consumedSig.value = null
         stagedSig.value = null
         lastLiveSig = null


### PR DESCRIPTION
Ticket: [FE-1325 — Update composer placeholder](https://linear.app/comfyorg/issue/FE-1325/fe-update-composer-placeholder)

## Summary

Follow-up work on the agent's node-selection mode, branched off
`nathaniel/agent-panel-v1` @ `6f25dd769a`. Three defect fixes against behavior
the V1 branch already specifies, one new framing behavior, chrome polish, and a
set of rules that change what the reference basket *is*.

5 commits · 25 files · +952 / −40. Merges cleanly against the current base
(`eb3bfe7245`).

## What changes for the user

### 1. Chips and the canvas stay in sync (defect fixes)

| Before | After |
| --- | --- |
| `@`-mentioning a node made a chip, but the node was never selected on the canvas | The mention selects the node on the canvas; staging is the fallback |
| Re-entering the mode showed already-staged chips as unselected | Entry merges staged chips with the prior canvas selection and applies the union |
| Clicking a chip did nothing — it was a plain `<span>` | The chip label is the control (click / Enter / Space, "Show on canvas" tooltip) and focuses the node |

Order matters in the mention fix: staged chips are rebuilt wholesale from the
canvas selection, so selecting first is what makes a mention chip durable —
staging alone was wiped on the next selection change. The remove button sits
*outside* the focus trigger; nesting it surfaced two tooltips at once.

### 2. The basket is an owned list, not a canvas mirror

This is the behavioral change most worth reviewing, because it revises what the
feature means. Previously the basket mirrored the canvas selection: it staged
references from ordinary clicking and emptied itself the moment picking ended.

Now the basket fills **only while picking**, and on exit the canvas clears while
the chips stay.

- Clicking nodes outside the mode stages nothing (`isLive` keys on the mode, not on the panel being open)
- A selection made *before* entering is honored on entry
- Node deletion is blocked while picking (guarded inside `deleteSelected`, since the command, keybinding and selection toolbox all funnel through it)
- Exiting keeps the chips and clears the canvas
- Already-staged nodes drop out of the `@` picker

Two ordering decisions are load-bearing and would be wrong reversed: the merged
selection is applied *before* `enter()` so framing sees the right set, and
`exit()` drops the mode *before* deselecting — that is precisely what stops the
deselect from emptying the basket.

Pre-existing behavior worth knowing: `onSend` calls `exitNodeSelectionMode()`,
so sending now leaves the chips staged and the canvas deselected.

### 3. Entering the mode frames the graph

Nothing previously touched the camera, so off-screen nodes stayed off-screen
with no minimap to compensate. Entry now frames the current selection if there
is one, and the whole graph if there isn't — fitted within the region the docked
panel doesn't cover.

### 4. Nothing floats over the canvas

Toasts, the two bottom-left popups, and the canvas info readout are hidden for
the duration of the mode. Errors are *maintained* rather than dropped: sticky
messages survive being hidden and reappear on exit, and toasts raised during the
mode are queued and replayed afterwards.

The minimap now fades on the same 300ms beat as the action bars instead of
popping, and the sidebar panel is restored with the bars instead of snapping
back.

## Review notes

**This touches vendored litegraph** — the part most likely to need your eyes:
- `DragAndScale.ts` — `animateToBounds` gains an optional `viewport` so framing can fit within a sub-region. Default path unchanged, covered by a test.
- `LGraphCanvas.ts` — the delete guard.

Three non-obvious implementation constraints, each of which cost a debugging round:

1. **PrimeVue teleports every `<Toast>` container to `<body>`**, so no wrapper element inside `GlobalToast.vue` can reach them. Hiding is done by toggling a class on `<body>` with one CSS rule. A first attempt using a wrapper shipped no behavior change at all.
2. **The canvas info readout is painted onto the canvas**, not composed in the DOM, so CSS cannot reach it. It folds into the existing `show_info` effect in `useLitegraphSettings.ts`, read *inside* the `watchEffect` so a settings change mid-mode can't bring it back. The user's `Comfy.Graph.CanvasInfo` setting is never written to.
3. **`boundingRect` is a `Rectangle` extending `Float64Array` and stays `[0,0,0,0]` under Vue nodes.** `Array.isArray()` on it is always false. Bounds derive from `pos`/`size` instead.

## Known gaps

- Roughly 30 call sites use PrimeVue's `useToast()` directly rather than the toast store. They are hidden during the mode but *not* queued, so one carrying a `life` could expire unseen. All are billing, sharing and workspace dialogs, which cannot open while the canvas is in selection mode. Routing them through the store is a separate, wider change.
- The bottom-right zoom controls (`GraphCanvasMenu.vue`) remain visible during the mode. This is deliberate — the AC's "canvas menu" refers to the left sidebar menu, which `SideToolbar.vue` already hides.

## Verification

Manually tested in a running build, plus unit coverage on the behavior rules,
the framing maths, the delete guard and the picker filter.

One caveat on the manual pass: the agent panel is gated behind a PostHog feature
flag that does not enable on a plain local instance, and `isOpen` is
`localStorage` keyed per origin. The mode was therefore driven through
`agentNodeSelectionStore.isActive` directly — the same flag the real control
sets, but **the `add nodes from graph` click path itself is unexercised**.
