### PR TITLE
feat(workspace): add the Enterprise tier label

### DIFF
--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2878,6 +2878,9 @@
       "pro": {
         "name": "Pro",
         "feature1": "Longer workflow runtime (up to 1 hr)"
+      },
+      "enterprise": {
+        "name": "Enterprise"
       }
     },
     "required": {

--- a/src/platform/workspace/composables/useWorkspaceTierLabel.test.ts
+++ b/src/platform/workspace/composables/useWorkspaceTierLabel.test.ts
@@ -12,7 +12,8 @@ vi.mock('vue-i18n', () => ({
         'subscription.tiers.standard.name': 'Standard',
         'subscription.tiers.creator.name': 'Creator',
         'subscription.tiers.pro.name': 'Pro',
-        'subscription.tiers.founder.name': "Founder's Edition"
+        'subscription.tiers.founder.name': "Founder's Edition",
+        'subscription.tiers.enterprise.name': 'Enterprise'
       }
       return tierNames[key] ?? key
     })
@@ -50,6 +51,10 @@ describe('useWorkspaceTierLabel', () => {
       expect(formatTierName('FOUNDERS_EDITION', false)).toBe(
         "Founder's Edition"
       )
+    })
+
+    it('maps ENTERPRISE to enterprise label', () => {
+      expect(formatTierName('ENTERPRISE', false)).toBe('Enterprise')
     })
 
     it('falls back to standard for unknown tier', () => {
@@ -106,10 +111,19 @@ describe('useWorkspaceTierLabel', () => {
     it('returns null when plan slug does not match any known tier', () => {
       const result = getTierLabel({
         isSubscribed: true,
-        subscriptionPlan: 'ENTERPRISE_CUSTOM',
+        subscriptionPlan: 'UNKNOWN_CUSTOM',
         subscriptionTier: null
       })
       expect(result).toBeNull()
+    })
+
+    it('parses ENTERPRISE from plan slug fallback', () => {
+      const result = getTierLabel({
+        isSubscribed: true,
+        subscriptionPlan: 'ENTERPRISE_MONTHLY',
+        subscriptionTier: null
+      })
+      expect(result).toBe('Enterprise')
     })
 
     it('handles FOUNDERS_EDITION tier', () => {

--- a/src/platform/workspace/composables/useWorkspaceTierLabel.ts
+++ b/src/platform/workspace/composables/useWorkspaceTierLabel.ts
@@ -8,7 +8,8 @@ const tierKeyMap: Record<string, string> = {
   CREATOR: 'creator',
   PRO: 'pro',
   FOUNDER: 'founder',
-  FOUNDERS_EDITION: 'founder'
+  FOUNDERS_EDITION: 'founder',
+  ENTERPRISE: 'enterprise'
 }
 
 interface WorkspaceSubscriptionInfo {


### PR DESCRIPTION
Adds the display label for the Enterprise subscription tier.

`tierKeyMap` is a `Record<string, string>`, so an unmapped tier resolves to `''` and the workspace shows a **blank** tier name rather than failing visibly. This adds the mapping and its i18n string.

## Changes

- `useWorkspaceTierLabel.ts` — `ENTERPRISE: 'enterprise'`.
- `en/main.json` — `subscription.tiers.enterprise.name`.
- Tests — two new cases (direct tier and plan-slug fallback). One existing test used `ENTERPRISE_CUSTOM` as an example of an *unmapped* slug; now that `ENTERPRISE` is mapped it no longer is, so it was swapped for `UNKNOWN_CUSTOM` to preserve the original intent.

`tierPricing.ts` is unaffected — it is keyed off the registry schema, not the generation API's.

## Verification

`pnpm typecheck`, `pnpm lint`, and the composable's unit suite (17/17) all pass.
