### PR TITLE
fix(website): stop reading union-only fields off heterogeneous data

### DIFF
--- a/apps/website/src/templates/drops/DropsSection.vue
+++ b/apps/website/src/templates/drops/DropsSection.vue
@@ -21,7 +21,7 @@ const items = computed<CardArticleGalleryItem[]>(() =>
       type: drop.media.type,
       src: drop.media.src,
       alt: drop.media.alt[locale],
-      poster: drop.media.poster
+      poster: drop.media.type === 'video' ? drop.media.poster : undefined
     },
     cta: {
       label: drop.cta.label[locale],

--- a/apps/website/src/templates/mcp/mcpDemoPrompts.ts
+++ b/apps/website/src/templates/mcp/mcpDemoPrompts.ts
@@ -12,7 +12,7 @@ export type McpDemoPrompt = {
   stacked?: boolean
 }
 
-export const mcpDemoPrompts = [
+export const mcpDemoPrompts: readonly McpDemoPrompt[] = [
   {
     id: 'keyframe-board',
     promptKey: 'mcp.hero.demoPromptKeyframeBoard',
@@ -75,7 +75,7 @@ export const mcpDemoPrompts = [
     toolKey: 'mcp.hero.demoToolSetExtension',
     result: 'set_extension.png'
   }
-] as const satisfies readonly McpDemoPrompt[]
+]
 
 export function thumbUrls({ id, variants }: McpDemoPrompt): string[] {
   return variants


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

## Summary

Fixes 6 of the 9 pre-existing `vue-tsc` errors in `apps/website`, both caused by reading a field that does not exist on every member of a union. First of three stacked PRs that end with `vue-tsc` running in CI.

## Changes

- **What**:
  - `templates/mcp/mcpDemoPrompts.ts` — the array was declared `as const satisfies readonly McpDemoPrompt[]`. `satisfies` checks assignability but preserves the `as const` type, so the array became a union of nine distinct literal shapes rather than `McpDemoPrompt[]`. Since no single member declares all of `via` / `variants` / `stacked`, every read of those optional fields failed (5 errors in `ComfyMcpDemo.vue`). Annotating as `readonly McpDemoPrompt[]` restores the intended optional fields and matches how `data/drops.ts` declares its data. No consumer depended on the literal types.
  - `templates/drops/DropsSection.vue` — `drop.media.poster` was read without narrowing `DropMedia` on its `type` discriminant; `poster` only exists on the `video` member. Now narrowed with `drop.media.type === 'video' ? drop.media.poster : undefined`.
- **Breaking**: none. Both changes are type-level only — see Review Focus.

## Review Focus

Neither change alters runtime behaviour:

- `DropsSection`: for `type: 'video'` the value still comes from `drop.media.poster`; for images the property access already evaluated to `undefined` at runtime, which is exactly what the ternary now yields. Confirmed no drop in `data/drops.ts` passes a poster — all three `videoFor(...)` calls take only `(fileName, alt)` — so the rendered output is byte-identical.
- `mcpDemoPrompts`: dropping `as const` only widens literal types to their declared ones. The values are unchanged.

These were invisible until now because `.vue` files are type-checked by nothing in this repo — that gap is fixed in the third PR of this stack.

## Verification

`astro check` 0 errors · `vue-tsc` drops from 9 errors to 3 (the remaining 3 are fixed in the next PR) · 422 unit tests passing (1 pre-existing `minimaxMusic3` `.jpeg` failure, also fails on `main`) · lint/format/knip clean · production build 595 pages.

Manually verified the MCP hero demo in a production build (screenshot below) — all three optional fields still render exactly as before:
- `variants: 4` → Character Concepts shows 4 separate thumbnails
- `stacked: true` → Keyframe Board shows the offset layers behind the thumbnail
- `via` → NOTION / FIGMA / BLENDER badges render, and cards without `via` (Set Extension) correctly show none

Also loaded `/launches` (DropsSection): 3 videos, 0 with a `poster` attribute (matching the data), 31 images, none with a broken `src`, and no page errors.


## Screenshots

![MCP hero demo after the change: variants render 4 thumbnails, stacked renders offset layers, via badges render](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/2695e99a517e67b129af85ec68092712a7c0cba612e302caf6af9fd7e5752a65/pr-images/1786746110431-2af25860-51b3-42c0-8373-0ad3ed79aefe.png)