### PR TITLE
fix(website): clear the real ESLint findings in apps/website

### DIFF
--- a/apps/website/src/components/product/api/HeroSection.vue
+++ b/apps/website/src/components/product/api/HeroSection.vue
@@ -109,8 +109,8 @@ onMounted(() => {
     const time = Date.now() / 1000
     const cycle = time % 1.0
 
-    let stampAmt = 0
-    let conveyorEject = 0
+    let stampAmt: number
+    let conveyorEject: number
 
     if (cycle < 0.35) {
       const p = cycle / 0.35
@@ -224,13 +224,13 @@ onUnmounted(() => {
       <ProductHeroBadge text="API" />
 
       <h1
-        class="text-primary-comfy-canvas mt-6 text-3xl/tight font-light md:text-4xl/tight lg:max-w-2xl lg:text-5xl/tight xl:whitespace-pre-line"
+        class="mt-6 text-3xl/tight font-light text-primary-comfy-canvas md:text-4xl/tight lg:max-w-2xl lg:text-5xl/tight xl:whitespace-pre-line"
       >
         {{ t('api.hero.heading', locale) }}
       </h1>
 
       <p
-        class="text-primary-comfy-canvas mt-6 max-w-md text-sm lg:mt-6 lg:text-base"
+        class="mt-6 max-w-md text-sm text-primary-comfy-canvas lg:mt-6 lg:text-base"
       >
         {{ t('api.hero.subtitle', locale) }}
       </p>

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -488,6 +488,24 @@ export default defineConfig([
       'import-x/no-unresolved': ['error', { ignore: ['^astro:'] }]
     }
   },
+  // These wrappers forward reka-ui props wholesale via
+  // useForwardPropsEmits/reactiveOmit + v-bind, which the rule cannot trace,
+  // so it reports every forwarded prop as unused. Deleting them would drop
+  // the component's public API. Scoped to the wrapper directories so the
+  // bespoke components under ui/ keep the rule.
+  {
+    files: [
+      'apps/website/src/components/ui/accordion/*.vue',
+      'apps/website/src/components/ui/dialog/*.vue',
+      'apps/website/src/components/ui/navigation-menu/*.vue',
+      'apps/website/src/components/ui/sheet/*.vue',
+      'apps/website/src/components/ui/slider/*.vue',
+      'apps/website/src/components/ui/toggle-group/*.vue'
+    ],
+    rules: {
+      'vue/no-unused-properties': 'off'
+    }
+  },
   // i18n import enforcement
   // Vue components must use the useI18n() composable, not the global t/d/st/te
   {


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

## Summary

Running the repo's full ESLint ruleset over `apps/website` reports 181 errors. 169 are auto-fixable Tailwind class ordering (handled in the next PR); this PR clears the 12 that are not.

> Stacked on #15300. Base is `glary/website-strict-tsconfig`, so review only the top commit.

## Changes

- **What**:
  - `components/product/api/HeroSection.vue` — `stampAmt` and `conveyorEject` were initialised to `0` and then unconditionally reassigned by **both** branches of the following `if`/`else`, so the initialiser never survived. Declared without an initialiser; TypeScript's definite-assignment analysis covers both paths.
  - `eslint.config.ts` — the other 10 findings are `vue/no-unused-properties` false positives on the reka-ui wrappers under `components/ui/`, which re-declare a component's props and forward them wholesale via `useForwardPropsEmits` / `reactiveOmit` + `v-bind`. The rule only tracks props referenced by name, so it cannot see the forwarding. The rule is now off for the six wrapper directories.
- **Breaking**: none.

## Review Focus

**Why a config exception rather than deleting the props.** Deleting them would remove each component's public API — `Sheet.vue` declares `DialogRootProps` purely to forward them. That the codebase already agrees is visible in the tree: **eight of these wrappers carry file-local `/* eslint-disable vue/no-unused-properties -- props forwarded via ... */` comments today**, in `accordion/` and `dialog/`. The `sheet/` ones had simply been missed, which is why they showed up as errors. This moves that existing, hand-maintained exception into config so new wrappers cannot drift the same way. (The now-redundant inline disables are removed by the autofix in the next PR.)

**Scope is deliberately narrow.** An earlier revision disabled the rule for all of `components/ui/**`, which would have silently dropped the check on the ten bespoke directories there. It is now limited to the six directories that actually use forwarding helpers. Verified with `eslint --print-config`:

| file | `vue/no-unused-properties` |
|---|---|
| `copyable-field/CopyableField.vue` | `[2]` — active |
| `scroll-carousel/ScrollCarousel.vue` | `[2]` — active |
| `badge/Badge.vue` | `[2]` — active |
| `toggle/Toggle.vue` | `[2]` — active |
| `sheet/Sheet.vue` | `[0]` — exempt |
| `dialog/Dialog.vue` | `[0]` — exempt |

## Verification

ESLint on `apps/website` drops from 181 errors to 169 — all remaining are the auto-fixable Tailwind rules. `astro check` 0 errors · 422 unit tests passing (1 pre-existing `minimaxMusic3` failure, also on `main`) · production build 595 pages.

`HeroSection` drives a `<canvas>` animation from those two variables, so I checked it in a production build rather than trusting the type-checker: sampling the full canvas across 6 frames gives 6 distinct checksums, i.e. still animating. (An initial sample of only the top-left 300×300 showed no change — that region is the uniform `fillRect` background, not a regression.)
