### PR TITLE
fix: use generated workspace API response types

### DIFF
--- a/src/composables/billing/useBillingContext.test.ts
+++ b/src/composables/billing/useBillingContext.test.ts
@@ -15,6 +15,7 @@ const DEFAULT_BILLING_STATUS: BillingStatusResponse = {
   max_seats: 73,
   occupied_seats: 72,
   has_funds: true,
+  team_credit_stop: null,
   subscription_tier: 'PRO',
   subscription_duration: 'MONTHLY'
 }
@@ -181,8 +182,7 @@ describe('useBillingContext', () => {
     )
     mockPlans.value = []
     mockLegacyStatus.value = {
-      is_active: true,
-      has_funds: true,
+      ...DEFAULT_BILLING_STATUS,
       renewal_date: '2025-01-01T00:00:00Z'
     }
     mockBillingStatus.value = { ...DEFAULT_BILLING_STATUS }
@@ -525,13 +525,11 @@ describe('useBillingContext', () => {
 
     it('is false for a new credit-slider team subscriber', async () => {
       mockIsPersonal.value = false
-      // Real BE shape: underscore slug + populated credit stop. (subscription_tier
-      // is 'TEAM' on the wire, not yet in the FE SubscriptionTier union, so it is
-      // omitted here — the predicate does not depend on it.)
       mockBillingStatus.value = {
         is_active: true,
         has_funds: true,
         subscription_status: 'active',
+        subscription_tier: 'TEAM',
         subscription_duration: 'ANNUAL',
         plan_slug: 'team_per_credit_annual',
         team_credit_stop: {
@@ -637,16 +635,12 @@ describe('useBillingContext', () => {
       expect(isTeamPlan.value).toBe(false)
     })
 
-    // subscription_tier is omitted throughout: the backend sends 'TEAM' here, but
-    // the FE's SubscriptionTier resolves to the registry spec, which has no TEAM
-    // (tierPricing.ts imports comfyRegistryTypes for what is an ingest field).
-    // isTeamPlan reads the credit stop and the slug, never the tier — which is
-    // what keeps it working despite that divergence.
     it('is true for a credit-slider team sub, which carries a credit stop', async () => {
       mockIsPersonal.value = false
       mockBillingStatus.value = {
         is_active: true,
         has_funds: true,
+        subscription_tier: 'TEAM',
         plan_slug: 'team_per_credit_monthly',
         team_credit_stop: {
           id: 'team_700',

--- a/src/platform/cloud/subscription/composables/useBillingPolicyState.test.ts
+++ b/src/platform/cloud/subscription/composables/useBillingPolicyState.test.ts
@@ -24,7 +24,8 @@ describe('deriveBillingPolicyState', () => {
     ['STANDARD', 'LocalAndStandard', 'CloudAndStandard'],
     ['CREATOR', 'LocalAndCreator', 'CloudAndCreator'],
     ['PRO', 'LocalAndPro', 'CloudAndPro'],
-    ['FOUNDERS_EDITION', 'LocalAndFounders', 'CloudAndFounders']
+    ['FOUNDERS_EDITION', 'LocalAndFounders', 'CloudAndFounders'],
+    ['TEAM', 'LocalAndTeam', 'CloudAndTeam']
   ])(
     'maps an active subscription tier %s to %s off Cloud and %s on Cloud',
     ([tier, localKind, cloudKind]) => {

--- a/src/platform/cloud/subscription/composables/useBillingPolicyState.ts
+++ b/src/platform/cloud/subscription/composables/useBillingPolicyState.ts
@@ -41,6 +41,12 @@ export function deriveBillingPolicyState(input: {
       return { kind: `${distribution}AndPro` }
     case 'FOUNDERS_EDITION':
       return { kind: `${distribution}AndFounders` }
+    case 'TEAM':
+      return {
+        kind: input.canAccessSubscriptionFeatures
+          ? `${distribution}AndTeam`
+          : `${distribution}TeamWithoutActiveSubscription`
+      }
     case null:
       return { kind: `${distribution}AndUnknown` }
     default:

--- a/src/platform/cloud/subscription/composables/useSubscriptionCancellationWatcher.test.ts
+++ b/src/platform/cloud/subscription/composables/useSubscriptionCancellationWatcher.test.ts
@@ -18,7 +18,10 @@ describe('useSubscriptionCancellationWatcher', () => {
   const baseStatus: BillingStatusResponse = {
     is_active: true,
     has_funds: true,
-    renewal_date: '2025-11-16'
+    renewal_date: '2025-11-16',
+    max_seats: 1,
+    occupied_seats: 1,
+    team_credit_stop: null
   }
 
   const subscriptionStatus = ref<BillingStatusResponse | null>(baseStatus)
@@ -65,7 +68,10 @@ describe('useSubscriptionCancellationWatcher', () => {
           is_active: false,
           has_funds: true,
           renewal_date: '2025-11-16',
-          cancel_at: '2025-12-01'
+          cancel_at: '2025-12-01',
+          max_seats: 1,
+          occupied_seats: 1,
+          team_credit_stop: null
         }
       }
     })

--- a/src/platform/cloud/subscription/constants/tierPricing.ts
+++ b/src/platform/cloud/subscription/constants/tierPricing.ts
@@ -1,7 +1,7 @@
 import { remoteConfig } from '@/platform/remoteConfig/remoteConfig'
-import type { components } from '@/types/comfyRegistryTypes'
+import type { SubscriptionTier as IngestSubscriptionTier } from '@comfyorg/ingest-types'
 
-export type SubscriptionTier = components['schemas']['SubscriptionTier']
+export type SubscriptionTier = IngestSubscriptionTier
 
 export type TierKey = 'free' | 'standard' | 'creator' | 'pro' | 'founder'
 
@@ -10,7 +10,8 @@ export const TIER_TO_KEY: Record<SubscriptionTier, TierKey> = {
   STANDARD: 'standard',
   CREATOR: 'creator',
   PRO: 'pro',
-  FOUNDERS_EDITION: 'founder'
+  FOUNDERS_EDITION: 'founder',
+  TEAM: 'standard'
 }
 
 export const KEY_TO_TIER: Record<TierKey, SubscriptionTier> = {

--- a/src/platform/workspace/api/workspaceApi.test.ts
+++ b/src/platform/workspace/api/workspaceApi.test.ts
@@ -355,11 +355,7 @@ describe('workspaceApi', () => {
           headers: AUTH_HEADER
         }
       )
-      expect(result).toEqual({
-        ...data,
-        max_seats: null,
-        occupied_seats: null
-      })
+      expect(result).toEqual(data)
     })
 
     it('getBillingBalance() sends GET /billing/balance', async () => {

--- a/src/platform/workspace/api/workspaceApi.ts
+++ b/src/platform/workspace/api/workspaceApi.ts
@@ -3,9 +3,9 @@ import type {
   BillingBalanceResponse,
   BillingEventsResponse,
   BillingOpStatusResponse,
-  BillingPlansResponse as GeneratedBillingPlansResponse,
+  BillingPlansResponse,
   BillingStatus,
-  BillingStatusResponse as GeneratedBillingStatusResponse,
+  BillingStatusResponse,
   CancelSubscriptionRequest,
   CancelSubscriptionResponse,
   ChurnkeyAuthResponse,
@@ -15,29 +15,29 @@ import type {
   CreateWorkspaceRequest,
   ListInvitesResponse,
   ListMembersResponse,
-  ListWorkspacesResponse as GeneratedListWorkspacesResponse,
+  ListWorkspacesResponse,
   Member as GeneratedMember,
   PaymentPortalRequest,
   PaymentPortalResponse,
   PendingInvite,
-  Plan as GeneratedPlan,
-  PreviewSubscribeRequest as GeneratedPreviewSubscribeRequest,
+  Plan,
+  PreviewSubscribeRequest,
   PreviewSubscribeResponse,
   ResubscribeRequest,
   ResubscribeResponse,
   SubscribeRequest,
   SubscribeResponse,
   SubscriptionDuration,
+  SubscriptionTier,
   TeamCreditStops,
   TeamCreditStopSummary,
   UpdateWorkspaceRequest,
-  WorkspaceWithRole as GeneratedWorkspaceWithRole
+  WorkspaceWithRole
 } from '@comfyorg/ingest-types'
 import axios from 'axios'
 
 import { attachUnifiedRemintInterceptor } from '@/platform/auth/unified/remintRetry'
 import { churnkeyAuthResponseSchema } from '@/platform/cloud/churnkey/churnkeyAuthSchema'
-import type { SubscriptionTier } from '@/platform/cloud/subscription/constants/tierPricing'
 import {
   UNKNOWN_ERROR_CODE,
   errorResponseFromBody
@@ -52,24 +52,7 @@ import type { UserId } from '@/types/authTypes'
 
 export type WorkspaceType = 'personal' | 'team'
 export type WorkspaceRole = 'owner' | 'member'
-export type BillingRail = NonNullable<
-  GeneratedBillingStatusResponse['billing_rail']
->
-
-export type WorkspaceWithRole = Omit<
-  GeneratedWorkspaceWithRole,
-  'subscription_tier'
-> & {
-  // Uses the registry's SubscriptionTier (no TEAM) to match how the rest of
-  // the app threads subscription_tier through personal-plan pricing;
-  // workspace.type distinguishes team workspaces instead.
-  subscription_tier?: SubscriptionTier
-}
-
-export type ListWorkspacesResponse = Omit<
-  GeneratedListWorkspacesResponse,
-  'workspaces'
-> & { workspaces: WorkspaceWithRole[] }
+export type BillingRail = NonNullable<BillingStatusResponse['billing_rail']>
 
 export type Member = GeneratedMember & {
   // Per-member monthly credit limit UI (FE-1277). The cloud OpenAPI carries
@@ -87,22 +70,12 @@ export type { PendingInvite }
 
 export type { SubscriptionTier }
 export type { SubscriptionDuration }
-
-// Uses the registry's SubscriptionTier (no TEAM); the personal plan catalog
-// never lists team plans.
-export type Plan = Omit<GeneratedPlan, 'tier'> & { tier: SubscriptionTier }
-export type BillingPlansResponse = Omit<
-  GeneratedBillingPlansResponse,
-  'plans'
-> & { plans: Plan[] }
+export type { WorkspaceWithRole }
+export type { Plan }
 export type { TeamCreditStops }
 export type { TeamCreditStopSummary }
 
 type SubscribeBillingCycle = 'monthly' | 'yearly'
-
-interface PreviewSubscribeRequest extends GeneratedPreviewSubscribeRequest {
-  billing_cycle?: SubscribeBillingCycle
-}
 
 export interface SubscribeOptions {
   returnUrl?: string
@@ -115,7 +88,6 @@ export interface SubscribeOptions {
 
 export interface PreviewSubscribeOptions {
   teamCreditStopId?: string
-  billingCycle?: SubscribeBillingCycle
 }
 
 export type { SubscribeResponse }
@@ -123,29 +95,11 @@ export type { SubscribeResponse }
 export type { PreviewSubscribeResponse }
 
 export type BillingSubscriptionStatus = NonNullable<
-  GeneratedBillingStatusResponse['subscription_status']
+  BillingStatusResponse['subscription_status']
 >
 
 export type { BillingStatus }
-
-export type BillingStatusResponse = Omit<
-  GeneratedBillingStatusResponse,
-  'max_seats' | 'occupied_seats' | 'subscription_tier' | 'team_credit_stop'
-> & {
-  // The spec marks these required, but older/billing-disabled deployments
-  // can omit them; getBillingStatus() normalizes a missing value to null.
-  max_seats?: number | null
-  occupied_seats?: number | null
-  // Uses the registry's SubscriptionTier (no TEAM), matching WorkspaceWithRole.
-  subscription_tier?: SubscriptionTier
-  // The spec marks this required (always present, nullable); kept optional
-  // here to match how existing callers already read it defensively.
-  team_credit_stop?: TeamCreditStopSummary | null
-  // Not yet part of the ingest OpenAPI spec; scheduled-plan-change display
-  // ships ahead of the backend documenting these fields.
-  scheduled_plan_slug?: string
-  change_at?: string
-}
+export type { BillingStatusResponse }
 
 export type { BillingBalanceResponse }
 export type { CreateTopupResponse }
@@ -434,11 +388,7 @@ export const workspaceApi = {
         api.apiURL('/billing/status'),
         { headers }
       )
-      return {
-        ...response.data,
-        max_seats: response.data.max_seats ?? null,
-        occupied_seats: response.data.occupied_seats ?? null
-      }
+      return response.data
     } catch (err) {
       handleAxiosError(err)
     }
@@ -492,8 +442,7 @@ export const workspaceApi = {
         api.apiURL('/billing/preview-subscribe'),
         {
           plan_slug: planSlug,
-          team_credit_stop_id: options.teamCreditStopId,
-          billing_cycle: options.billingCycle
+          team_credit_stop_id: options.teamCreditStopId
         } satisfies PreviewSubscribeRequest,
         { headers }
       )

--- a/src/platform/workspace/components/subscriptionPanelWorkspace.logic.ts
+++ b/src/platform/workspace/components/subscriptionPanelWorkspace.logic.ts
@@ -1,14 +1,12 @@
-import type {
-  SubscriptionTier,
-  TierKey
-} from '@/platform/cloud/subscription/constants/tierPricing'
+import type { TierKey } from '@/platform/cloud/subscription/constants/tierPricing'
 import { TIER_TO_KEY } from '@/platform/cloud/subscription/constants/tierPricing'
+import type { SubscriptionTier } from '@/platform/workspace/api/workspaceApi'
 
 export function resolveSubscriptionTierKey(
   tier: SubscriptionTier | null | undefined
 ): TierKey {
   if (!tier) return 'free'
-  return TIER_TO_KEY[tier] ?? 'standard'
+  return TIER_TO_KEY[tier]
 }
 
 export function formatSubscriptionDate(

--- a/src/platform/workspace/composables/useSubscriptionCheckout.test.ts
+++ b/src/platform/workspace/composables/useSubscriptionCheckout.test.ts
@@ -830,7 +830,7 @@ describe('useSubscriptionCheckout', () => {
 
       expect(mockPreviewSubscribe).toHaveBeenCalledWith(
         'team_per_credit_monthly',
-        { teamCreditStopId: 'team_1400', billingCycle: 'monthly' }
+        { teamCreditStopId: 'team_1400' }
       )
       expect(checkout.previewData.value).toStrictEqual(transition)
     })
@@ -1058,8 +1058,7 @@ describe('useSubscriptionCheckout', () => {
       expect(mockPreviewSubscribe).toHaveBeenCalledWith(
         'team_per_credit_monthly',
         {
-          teamCreditStopId: 'team_700',
-          billingCycle: 'monthly'
+          teamCreditStopId: 'team_700'
         }
       )
       expect(checkout.previewData.value).not.toBeNull()

--- a/src/platform/workspace/composables/useSubscriptionCheckout.ts
+++ b/src/platform/workspace/composables/useSubscriptionCheckout.ts
@@ -586,8 +586,7 @@ export function useSubscriptionCheckout(
     try {
       const planSlug = getTeamPlanSlug(payload.billingCycle)
       response = await previewSubscribe(planSlug, {
-        teamCreditStopId: payload.stop.id,
-        billingCycle: payload.billingCycle
+        teamCreditStopId: payload.stop.id
       })
     } catch (error) {
       previewError = error
@@ -965,8 +964,7 @@ export function useSubscriptionCheckout(
         (isCancelled.value || reactivationRequired.value)
       ) {
         await refreshPreviewOnReactivationBlock(planSlug, {
-          teamCreditStopId: stop.id,
-          billingCycle
+          teamCreditStopId: stop.id
         })
         return
       }
@@ -980,8 +978,7 @@ export function useSubscriptionCheckout(
         (isCancelled.value || reactivationRequired.value)
       ) {
         await assertReactivationAmountUnchanged(planSlug, {
-          teamCreditStopId: stop.id,
-          billingCycle
+          teamCreditStopId: stop.id
         })
       }
       const response = await subscribe(planSlug, {
@@ -1014,8 +1011,7 @@ export function useSubscriptionCheckout(
     } catch (error) {
       if (hasErrorCode(error, 'REACTIVATION_CONFIRMATION_REQUIRED')) {
         await refreshPreviewOnReactivationBlock(planSlug, {
-          teamCreditStopId: stop.id,
-          billingCycle
+          teamCreditStopId: stop.id
         })
         return
       }
@@ -1032,8 +1028,7 @@ export function useSubscriptionCheckout(
       if (await recoverOutstandingPayment(error)) return
       if (
         await refreshExpiredProrationQuote(error, planSlug, {
-          teamCreditStopId: stop.id,
-          billingCycle
+          teamCreditStopId: stop.id
         })
       )
         return

--- a/src/platform/workspace/composables/useWorkspaceBilling.test.ts
+++ b/src/platform/workspace/composables/useWorkspaceBilling.test.ts
@@ -123,6 +123,7 @@ const activeStatus = {
   max_seats: 73,
   occupied_seats: 72,
   has_funds: true,
+  team_credit_stop: null,
   subscription_status: 'active' as const,
   subscription_tier: 'CREATOR' as const,
   subscription_duration: 'MONTHLY' as const,
@@ -135,6 +136,7 @@ const freeStatus = {
   max_seats: 0,
   occupied_seats: 100,
   has_funds: true,
+  team_credit_stop: null,
   subscription_tier: 'FREE' as const,
   plan_slug: 'free'
 }
@@ -253,9 +255,7 @@ describe('useWorkspaceBilling', () => {
         ...activeStatus,
         billing_rail: 'stripe',
         subscription_status: 'canceled',
-        cancel_at: '2026-06-01T00:00:00Z',
-        scheduled_plan_slug: 'pro-annual',
-        change_at: '2026-07-01T00:00:00Z'
+        cancel_at: '2026-06-01T00:00:00Z'
       })
 
       const billing = setupBilling()
@@ -266,8 +266,6 @@ describe('useWorkspaceBilling', () => {
         tier: 'CREATOR',
         duration: 'MONTHLY',
         planSlug: 'creator-monthly',
-        scheduledPlanSlug: 'pro-annual',
-        changeAt: '2026-07-01T00:00:00Z',
         renewalDate: '2026-05-01T00:00:00Z',
         endDate: '2026-06-01T00:00:00Z',
         isCancelled: true,

--- a/src/platform/workspace/composables/useWorkspaceBilling.ts
+++ b/src/platform/workspace/composables/useWorkspaceBilling.ts
@@ -140,8 +140,6 @@ export function useWorkspaceBilling(): BillingState & BillingActions {
       tier: status.subscription_tier ?? null,
       duration: status.subscription_duration ?? null,
       planSlug: status.plan_slug ?? null,
-      scheduledPlanSlug: status.scheduled_plan_slug ?? null,
-      changeAt: status.change_at ?? null,
       renewalDate: status.renewal_date ?? null,
       endDate: status.cancel_at ?? null,
       isCancelled: status.subscription_status === 'canceled',


### PR DESCRIPTION
## Summary

Use `@comfyorg/ingest-types` as the source of truth for workspace and billing API responses so frontend types cannot silently drift from the ingest OpenAPI contract.

## Changes

- **What**: Replaces hand-declared workspace, plan, and billing response types with generated exports; sources `SubscriptionTier` from ingest; handles the generated `TEAM` tier; updates consumers and fixtures for required `team_credit_stop`, `max_seats`, and `occupied_seats` fields.
- **Root cause**: `workspaceApi.ts` duplicated ingest response contracts locally and sourced `SubscriptionTier` from registry types. The copies diverged: registry omitted `TEAM`, the local billing response omitted required `team_credit_stop`, and seat fields were treated as nullable despite being required numbers in ingest.

## Review Focus

- `TEAM` intentionally maps to the existing `standard` pricing key.
- Genuine frontend-only request/member extensions remain local; server response shapes come from generated ingest types.
- No visual change; screenshots are not applicable.

## Verification

- `pnpm typecheck`
- 276 unit tests across 6 affected suites
- targeted ESLint and oxfmt checks
- pre-push `pnpm knip --cache`