### PR TITLE
test: add behavior-level ECS regression coverage

### DIFF
--- a/browser_tests/tests/appModeBuilder.spec.ts
+++ b/browser_tests/tests/appModeBuilder.spec.ts
@@ -2,6 +2,11 @@ import {
   comfyPageFixture as test,
   comfyExpect as expect
 } from '@e2e/fixtures/ComfyPage'
+import {
+  dismissErrorOverlay,
+  enableErrorsOverlay
+} from '@e2e/fixtures/helpers/ErrorsTabHelper'
+import { ExecutionHelper } from '@e2e/fixtures/helpers/ExecutionHelper'
 
 test.describe('App mode builder selection', () => {
   test.beforeEach(async ({ comfyPage }) => {
@@ -94,33 +99,60 @@ test.describe('App mode builder selection', () => {
     }
   )
 
-  test('Can not select nodes with errors or notes', async ({ comfyPage }) => {
-    //Manually set error state on checkpoint loader
-    //Shouldn't be needed on ci, but has spotty reliability
-    await comfyPage.page.evaluate(() => (graph!.nodes[6].has_errors = true))
-    await comfyPage.settings.setSetting('Comfy.VueNodes.Enabled', true)
+  test(
+    'Can not select a node with an error',
+    { tag: '@vue-nodes' },
+    async ({ comfyPage }) => {
+      test.slow()
+      await comfyPage.workflow.loadWorkflow('default')
+      await enableErrorsOverlay(comfyPage)
 
-    const items = comfyPage.appMode.select.inputItems
-    await comfyPage.appMode.enterBuilder()
-    await comfyPage.appMode.steps.goToInputs()
-    await expect(items).toHaveCount(0)
+      const [checkpointLoader] =
+        await comfyPage.nodeOps.getNodeRefsByTitle('Load Checkpoint')
+      await new ExecutionHelper(comfyPage).mockValidationFailure({
+        [String(checkpointLoader.id)]: {
+          class_type: 'CheckpointLoaderSimple',
+          dependent_outputs: [],
+          errors: [
+            {
+              type: 'value_not_in_list',
+              message: 'Value not in list',
+              details: '',
+              extra_info: { input_name: 'ckpt_name' }
+            }
+          ]
+        }
+      })
+      await comfyPage.runButton.click()
+      await dismissErrorOverlay(comfyPage)
 
-    await comfyPage.appMode.select.selectInputWidget(
-      'Load Checkpoint',
-      'ckpt_name'
-    )
-    await expect(items).toHaveCount(0)
+      const items = comfyPage.appMode.select.inputItems
+      await comfyPage.appMode.enterBuilder()
+      await comfyPage.appMode.steps.goToInputs()
+      await comfyPage.appMode.select.selectInputWidget(
+        'Load Checkpoint',
+        'ckpt_name'
+      )
 
-    await comfyPage.workflow.loadWorkflow('nodes/note_nodes')
-    await comfyPage.appMode.enterBuilder()
-    await comfyPage.appMode.steps.goToInputs()
-    await expect(items).toHaveCount(0)
+      await expect(items).toHaveCount(0)
+    }
+  )
 
-    await comfyPage.appMode.select.selectInputWidget('Note', 'text')
-    await comfyPage.appMode.select.selectInputWidget('Markdown Note', 'text')
+  test(
+    'Can not select note nodes',
+    { tag: '@vue-nodes' },
+    async ({ comfyPage }) => {
+      await comfyPage.workflow.loadWorkflow('nodes/note_nodes')
 
-    await expect(items).toHaveCount(0)
-  })
+      const items = comfyPage.appMode.select.inputItems
+      await comfyPage.appMode.enterBuilder()
+      await comfyPage.appMode.steps.goToInputs()
+      await comfyPage.appMode.select.selectInputWidget('Note', 'text')
+      await comfyPage.appMode.select.selectInputWidget('Markdown Note', 'text')
+
+      await expect(items).toHaveCount(0)
+    }
+  )
 
   test('Marks canvas readOnly', async ({ comfyPage }) => {
     await comfyPage.searchBoxV2.openByDoubleClickCanvas()

--- a/browser_tests/tests/copyPaste.spec.ts
+++ b/browser_tests/tests/copyPaste.spec.ts
@@ -30,6 +30,35 @@ test.describe('Copy Paste', { tag: ['@screenshot', '@workflow'] }, () => {
     await expect(comfyPage.canvas).toHaveScreenshot('copied-node-with-link.png')
   })
 
+  test('Pasted copy of a pinned node lands at the cursor', async ({
+    comfyPage
+  }) => {
+    const node = await comfyPage.nodeOps.getFirstNodeRef()
+    if (!node) throw new Error('Workflow has no nodes')
+    await node.centerOnNode()
+    await node.clickContextMenuOption('Pin')
+    await comfyPage.contextMenu.waitForHidden()
+    await expect.poll(() => node.isPinned()).toBe(true)
+
+    const nodeType = await node.getType()
+    const originalNodes = await comfyPage.nodeOps.getNodeRefsByType(nodeType)
+    const originalIds = new Set(originalNodes.map(({ id }) => id))
+    await comfyPage.page.mouse.move(10, 10)
+    await comfyPage.nextFrame()
+    await comfyPage.clipboard.copy(comfyPage.canvas)
+    await comfyPage.clipboard.paste(comfyPage.canvas)
+
+    await expect
+      .poll(
+        async () => (await comfyPage.nodeOps.getNodeRefsByType(nodeType)).length
+      )
+      .toBe(originalNodes.length + 1)
+    const nodes = await comfyPage.nodeOps.getNodeRefsByType(nodeType)
+    const pasted = nodes.find(({ id }) => !originalIds.has(id))
+    if (!pasted) throw new Error('Pasted node not found')
+    expect(await pasted.getPosition()).not.toEqual(await node.getPosition())
+  })
+
   test('Can copy and paste text', async ({ comfyPage }) => {
     const textBox = comfyPage.widgetTextBox
     await textBox.click()

--- a/browser_tests/tests/copyPaste.spec.ts
+++ b/browser_tests/tests/copyPaste.spec.ts
@@ -7,6 +7,42 @@ test.beforeEach(async ({ comfyPage }) => {
   await comfyPage.settings.setSetting('Comfy.UseNewMenu', 'Disabled')
 })
 
+test(
+  'Pasted copy of a pinned node lands at the cursor',
+  { tag: ['@node', '@workflow'] },
+  async ({ comfyPage }) => {
+    const node = await comfyPage.nodeOps.getFirstNodeRef()
+    if (!node) throw new Error('Workflow has no nodes')
+    await node.centerOnNode()
+    await node.clickContextMenuOption('Pin')
+    await comfyPage.contextMenu.waitForHidden()
+    await expect.poll(() => node.isPinned()).toBe(true)
+
+    const nodeType = await node.getType()
+    const originalNodes = await comfyPage.nodeOps.getNodeRefsByType(nodeType)
+    const originalIds = new Set(originalNodes.map(({ id }) => id))
+    await comfyPage.page.mouse.move(400, 300)
+    await comfyPage.nextFrame()
+    await comfyPage.clipboard.copy(comfyPage.canvas)
+    await comfyPage.clipboard.paste(comfyPage.canvas)
+
+    await expect
+      .poll(
+        async () => (await comfyPage.nodeOps.getNodeRefsByType(nodeType)).length
+      )
+      .toBe(originalNodes.length + 1)
+    const nodes = await comfyPage.nodeOps.getNodeRefsByType(nodeType)
+    const pasted = nodes.find(({ id }) => !originalIds.has(id))
+    if (!pasted) throw new Error('Pasted node not found')
+    await expect
+      .poll(async () => {
+        const { x, y } = await pasted.getPosition()
+        return Math.hypot(x - 400, y - 300)
+      })
+      .toBeLessThanOrEqual(2)
+  }
+)
+
 test.describe('Copy Paste', { tag: ['@screenshot', '@workflow'] }, () => {
   test('Can copy and paste node', async ({ comfyPage }) => {
     await comfyPage.canvas.click({
@@ -28,35 +64,6 @@ test.describe('Copy Paste', { tag: ['@screenshot', '@workflow'] }, () => {
     await comfyPage.clipboard.copy()
     await comfyPage.page.keyboard.press('Control+Shift+V')
     await expect(comfyPage.canvas).toHaveScreenshot('copied-node-with-link.png')
-  })
-
-  test('Pasted copy of a pinned node lands at the cursor', async ({
-    comfyPage
-  }) => {
-    const node = await comfyPage.nodeOps.getFirstNodeRef()
-    if (!node) throw new Error('Workflow has no nodes')
-    await node.centerOnNode()
-    await node.clickContextMenuOption('Pin')
-    await comfyPage.contextMenu.waitForHidden()
-    await expect.poll(() => node.isPinned()).toBe(true)
-
-    const nodeType = await node.getType()
-    const originalNodes = await comfyPage.nodeOps.getNodeRefsByType(nodeType)
-    const originalIds = new Set(originalNodes.map(({ id }) => id))
-    await comfyPage.page.mouse.move(10, 10)
-    await comfyPage.nextFrame()
-    await comfyPage.clipboard.copy(comfyPage.canvas)
-    await comfyPage.clipboard.paste(comfyPage.canvas)
-
-    await expect
-      .poll(
-        async () => (await comfyPage.nodeOps.getNodeRefsByType(nodeType)).length
-      )
-      .toBe(originalNodes.length + 1)
-    const nodes = await comfyPage.nodeOps.getNodeRefsByType(nodeType)
-    const pasted = nodes.find(({ id }) => !originalIds.has(id))
-    if (!pasted) throw new Error('Pasted node not found')
-    expect(await pasted.getPosition()).not.toEqual(await node.getPosition())
   })
 
   test('Can copy and paste text', async ({ comfyPage }) => {

--- a/src/lib/litegraph/src/LGraph.test.ts
+++ b/src/lib/litegraph/src/LGraph.test.ts
@@ -434,6 +434,18 @@ describe('node:before-removed event', () => {
       'onNodeRemoved(graph=null)'
     ])
   })
+
+  it('fires node:before-removed for every node cleared', () => {
+    const graph = new LGraph()
+    graph.add(new LGraphNode('a'))
+    graph.add(new LGraphNode('b'))
+    const removed = vi.fn()
+    graph.events.addEventListener('node:before-removed', removed)
+
+    graph.clear()
+
+    expect(removed).toHaveBeenCalledTimes(2)
+  })
 })
 
 describe('Subgraph Definition Garbage Collection', () => {

--- a/src/lib/litegraph/src/LGraph.test.ts
+++ b/src/lib/litegraph/src/LGraph.test.ts
@@ -276,6 +276,12 @@ describe('Graph Clearing and Callbacks', () => {
     // Track callback invocations
     const nodeRemovedCallbacks = new Set<string>()
     const graphRemovedCallbacks = new Set<string>()
+    const beforeRemovedNodes: LGraphNode[] = []
+
+    graph.events.addEventListener('node:before-removed', (event) => {
+      expect(event.detail.node.graph).toBe(graph)
+      beforeRemovedNodes.push(event.detail.node)
+    })
 
     // Set up node.onRemoved() callbacks
     node1.onRemoved = () => {
@@ -301,6 +307,8 @@ describe('Graph Clearing and Callbacks', () => {
     expect(nodeRemovedCallbacks).toContain(String(node2.id))
     expect(graphRemovedCallbacks).toContain(String(node1.id))
     expect(graphRemovedCallbacks).toContain(String(node2.id))
+    expect(beforeRemovedNodes).toHaveLength(2)
+    expect(new Set(beforeRemovedNodes)).toEqual(new Set([node1, node2]))
 
     // Verify nodes were actually removed
     expect(graph.nodes.length).toBe(0)
@@ -433,18 +441,6 @@ describe('node:before-removed event', () => {
       'onRemoved(graph=set)',
       'onNodeRemoved(graph=null)'
     ])
-  })
-
-  it('fires node:before-removed for every node cleared', () => {
-    const graph = new LGraph()
-    graph.add(new LGraphNode('a'))
-    graph.add(new LGraphNode('b'))
-    const removed = vi.fn()
-    graph.events.addEventListener('node:before-removed', removed)
-
-    graph.clear()
-
-    expect(removed).toHaveBeenCalledTimes(2)
   })
 })
 

--- a/src/lib/litegraph/src/LGraphNode.test.ts
+++ b/src/lib/litegraph/src/LGraphNode.test.ts
@@ -147,6 +147,48 @@ describe('LGraphNode', () => {
   })
 
   describe('Disconnect I/O Slots', () => {
+    function createConnectedPair() {
+      const graph = new LGraph()
+      const sourceNode = new LGraphNode('source')
+      const targetNode = new LGraphNode('target')
+      sourceNode.addOutput('output', '*')
+      targetNode.addInput('input', '*')
+      graph.add(sourceNode)
+      graph.add(targetNode)
+      expect(sourceNode.connect(0, targetNode, 0)).not.toBeNull()
+      return { graph, sourceNode, targetNode }
+    }
+
+    function observeDisconnectedInput(targetNode: LGraphNode) {
+      const onConnectionsChange = vi.fn<
+        NonNullable<LGraphNode['onConnectionsChange']>
+      >(function (_type, slot, isConnected) {
+        expect(isConnected).toBe(false)
+        expect(this.isInputConnected(slot)).toBe(false)
+        expect(this.getInputLink(slot)).toBeNull()
+      })
+      targetNode.onConnectionsChange = onConnectionsChange
+      return onConnectionsChange
+    }
+
+    test('exposes disconnected state in callbacks when an output is disconnected', () => {
+      const { sourceNode, targetNode } = createConnectedPair()
+      const onConnectionsChange = observeDisconnectedInput(targetNode)
+
+      expect(sourceNode.disconnectOutput(0)).toBe(true)
+
+      expect(onConnectionsChange).toHaveBeenCalledOnce()
+    })
+
+    test('exposes disconnected state in callbacks when the source is removed', () => {
+      const { graph, sourceNode, targetNode } = createConnectedPair()
+      const onConnectionsChange = observeDisconnectedInput(targetNode)
+
+      graph.remove(sourceNode)
+
+      expect(onConnectionsChange).toHaveBeenCalledOnce()
+    })
+
     test('should disconnect input correctly', () => {
       const node1 = new LGraphNode('SourceNode')
       const node2 = new LGraphNode('TargetNode')

--- a/src/lib/litegraph/src/LGraphNode.test.ts
+++ b/src/lib/litegraph/src/LGraphNode.test.ts
@@ -180,6 +180,15 @@ describe('LGraphNode', () => {
       expect(onConnectionsChange).toHaveBeenCalledOnce()
     })
 
+    test('exposes disconnected state in callbacks when an input is disconnected', () => {
+      const { targetNode } = createConnectedPair()
+      const onConnectionsChange = observeDisconnectedInput(targetNode)
+
+      expect(targetNode.disconnectInput(0)).toBe(true)
+
+      expect(onConnectionsChange).toHaveBeenCalledOnce()
+    })
+
     test('exposes disconnected state in callbacks when the source is removed', () => {
       const { graph, sourceNode, targetNode } = createConnectedPair()
       const onConnectionsChange = observeDisconnectedInput(targetNode)

--- a/src/platform/workflow/core/utils/workflowFlattening.test.ts
+++ b/src/platform/workflow/core/utils/workflowFlattening.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest'
 import type { FlattenableWorkflowNode } from '@/platform/workflow/core/utils/workflowFlattening'
 import {
   buildSubgraphExecutionPaths,
+  collectSubgraphDefinitions,
   flattenWorkflowNodes
 } from '@/platform/workflow/core/utils/workflowFlattening'
 
@@ -24,6 +25,20 @@ function subgraphDef(
     outputNode: {}
   }
 }
+
+describe('collectSubgraphDefinitions', () => {
+  it('collects mutually cyclic definitions once', () => {
+    const defA = subgraphDef('def-A', [])
+    const defB = subgraphDef('def-B', [])
+    defA.definitions.subgraphs = [defB]
+    defB.definitions.subgraphs = [defA]
+
+    expect(collectSubgraphDefinitions([defA]).map(({ id }) => id)).toEqual([
+      'def-A',
+      'def-B'
+    ])
+  })
+})
 
 describe('buildSubgraphExecutionPaths', () => {
   it('returns empty map when there are no subgraph definitions', () => {

--- a/src/renderer/extensions/vueNodes/components/NodeWidgets.test.ts
+++ b/src/renderer/extensions/vueNodes/components/NodeWidgets.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable testing-library/no-container */
 /* eslint-disable testing-library/no-node-access */
 import { createTestingPinia } from '@pinia/testing'
-import { render } from '@testing-library/vue'
+import { render, screen } from '@testing-library/vue'
 import { setActivePinia } from 'pinia'
 import { nextTick } from 'vue'
 import { describe, expect, it, vi } from 'vitest'
@@ -14,6 +14,7 @@ import type {
   VueNodeData
 } from '@/composables/graph/useGraphNodeManager'
 import NodeWidgets from '@/renderer/extensions/vueNodes/components/NodeWidgets.vue'
+import { useExecutionErrorStore } from '@/stores/executionErrorStore'
 import { useWidgetValueStore } from '@/stores/widgetValueStore'
 import { createNodeExecutionId } from '@/types/nodeIdentification'
 import { widgetId } from '@/types/widgetId'
@@ -351,5 +352,33 @@ describe('NodeWidgets', () => {
     )
 
     expect(ids).toStrictEqual([seedAEntityId, seedBEntityId])
+  })
+
+  it('marks widgets with host execution errors', () => {
+    const nodeId = toNodeId(1)
+    const widget = createMockWidget({ name: 'seed', nodeId })
+    const nodeData = createMockNodeData('TestNode', [widget], nodeId)
+
+    renderComponent(nodeData, () => {
+      useExecutionErrorStore().recordNodeErrors({
+        [createNodeExecutionId([nodeId])]: {
+          errors: [
+            {
+              type: 'value_not_in_list',
+              message: 'seed is invalid',
+              details: '',
+              extra_info: { input_name: 'seed' }
+            }
+          ],
+          class_type: 'TestNode',
+          dependent_outputs: []
+        }
+      })
+    })
+
+    expect(screen.getByTestId('node-widget')).toHaveAttribute(
+      'data-has-error',
+      'true'
+    )
   })
 })

--- a/src/renderer/extensions/vueNodes/components/NodeWidgets.vue
+++ b/src/renderer/extensions/vueNodes/components/NodeWidgets.vue
@@ -26,6 +26,7 @@
       <div
         v-if="widget.visible"
         data-testid="node-widget"
+        :data-has-error="widget.hasError || undefined"
         class="lg-node-widget group col-span-full grid grid-cols-subgrid items-stretch pr-3"
       >
         <!-- Widget Input Slot Dot -->


### PR DESCRIPTION
## Summary

Add a second batch of implementation-independent regression coverage extracted from #14246.

## Changes

- **What**: Cover app-mode filtering through validation behavior, pinned-node copy/paste positioning, graph clear lifecycle events, and callback-visible disconnection state.

## Review Focus

This PR is stacked on #15327 and contains only tests that pass without the ECS migration implementation. It can target `main` after #15327 merges.