### PR TITLE
test: add more migration-safe behavior coverage

### DIFF
--- a/browser_tests/tests/vueNodes/widgets/widgetValuePersistence.spec.ts
+++ b/browser_tests/tests/vueNodes/widgets/widgetValuePersistence.spec.ts
@@ -1,0 +1,40 @@
+import {
+  comfyExpect as expect,
+  comfyPageFixture as test
+} from '@e2e/fixtures/ComfyPage'
+
+test.describe(
+  'Widget value persistence',
+  { tag: ['@widget', '@vue-nodes'] },
+  () => {
+    test.afterEach(async ({ comfyPage }) => {
+      await comfyPage.workflow.setupWorkflowsDirectory({})
+    })
+
+    test('an emptied text widget remains empty after save and reload', async ({
+      comfyPage
+    }) => {
+      test.slow()
+      await comfyPage.workflow.loadWorkflow('inputs/string_input')
+
+      const widget = comfyPage.vueNodes.getWidgetByName(
+        'Node With String Input',
+        'string_input'
+      )
+      await widget.fill('temporary value')
+      await expect(widget).toHaveValue('temporary value')
+      await widget.fill('')
+      await expect(widget).toHaveValue('')
+
+      await comfyPage.menu.topbar.saveWorkflow('empty-widget-value')
+      await comfyPage.workflow.reloadAndWaitForApp()
+
+      await expect(
+        comfyPage.vueNodes.getWidgetByName(
+          'Node With String Input',
+          'string_input'
+        )
+      ).toHaveValue('')
+    })
+  }
+)

--- a/browser_tests/tests/vueNodes/widgets/widgetValuePersistence.spec.ts
+++ b/browser_tests/tests/vueNodes/widgets/widgetValuePersistence.spec.ts
@@ -11,7 +11,7 @@ test.describe(
       await comfyPage.workflow.setupWorkflowsDirectory({})
     })
 
-    test('an emptied text widget remains empty after save and reload', async ({
+    test('an emptied text widget remains empty after save and reopen', async ({
       comfyPage
     }) => {
       test.slow()
@@ -27,7 +27,15 @@ test.describe(
       await expect(widget).toHaveValue('')
 
       await comfyPage.menu.topbar.saveWorkflow('empty-widget-value')
-      await comfyPage.workflow.reloadAndWaitForApp()
+      await comfyPage.menu.topbar.closeWorkflowTab('empty-widget-value')
+      await comfyPage.page.keyboard.press('w')
+      await comfyPage.menu.workflowsTab
+        .getPersistedItem('empty-widget-value')
+        .dblclick()
+      await expect
+        .poll(() => comfyPage.workflow.getActiveWorkflowPath())
+        .toContain('empty-widget-value')
+      await comfyPage.vueNodes.waitForNodes()
 
       await expect(
         comfyPage.vueNodes.getWidgetByName(

--- a/src/core/graph/widgets/dynamicWidgets.test.ts
+++ b/src/core/graph/widgets/dynamicWidgets.test.ts
@@ -70,22 +70,38 @@ describe('Dynamic Combos', () => {
     expect(node.inputs[1].name).toBe('0.0.0.0')
     expect(node.inputs[3].name).toBe('2.2.0.0')
   })
-  test('Shrinking rebuild preserves retained connections', () => {
+  test('Shrinking dynamic inputs preserves remaining connections and disconnects removed links', () => {
     const graph = new LGraph()
     const node = testNode()
-    addDynamicCombo(node, [[], ['IMAGE', 'IMAGE'], ['IMAGE']])
+    addDynamicCombo(node, [[], ['IMAGE', 'IMAGE', 'IMAGE'], ['IMAGE']])
     graph.add(node)
     addNodeInput(node, { name: 'other', isOptional: false, type: 'IMAGE' })
     node.widgets[0].value = '1'
     const retained = connectInput(node, 1, graph)
-    const removed = connectInput(node, 2, graph)
-    const unrelated = connectInput(node, 3, graph)
+    const removed = [connectInput(node, 2, graph), connectInput(node, 3, graph)]
+    const removedSources = removed.map((link) =>
+      graph.getNodeById(link.origin_id)
+    )
+    const unrelated = connectInput(node, 4, graph)
+    const onConnectionsChange =
+      vi.fn<NonNullable<LGraphNode['onConnectionsChange']>>()
+    node.onConnectionsChange = onConnectionsChange
 
     node.widgets[0].value = '2'
 
     expect(node.getInputLink(1)).toBe(retained)
     expect(node.getInputLink(2)).toBe(unrelated)
-    expect(graph.getLink(removed.id)).toBeUndefined()
+    for (const link of removed) {
+      expect(graph.getLink(link.id)).toBeUndefined()
+    }
+    for (const source of removedSources) {
+      expect(source?.outputs[0].links).toEqual([])
+    }
+    const disconnectedLinks = onConnectionsChange.mock.calls
+      .filter(([, , connected]) => !connected)
+      .map(([, , , link]) => link)
+    expect(disconnectedLinks).toHaveLength(2)
+    expect(new Set(disconnectedLinks)).toEqual(new Set(removed))
   })
   test('Growing rebuild preserves retained connections', () => {
     const graph = new LGraph()
@@ -101,22 +117,6 @@ describe('Dynamic Combos', () => {
 
     expect(node.getInputLink(1)).toBe(retained)
     expect(node.getInputLink(3)).toBe(unrelated)
-  })
-  test('Shrinking a larger group disconnects every removed link', () => {
-    const graph = new LGraph()
-    const node = testNode()
-    addDynamicCombo(node, [[], ['IMAGE', 'IMAGE', 'IMAGE'], ['IMAGE']])
-    graph.add(node)
-    node.widgets[0].value = '1'
-    const retained = connectInput(node, 1, graph)
-    const removed = [connectInput(node, 2, graph), connectInput(node, 3, graph)]
-
-    node.widgets[0].value = '2'
-
-    expect(node.getInputLink(1)).toBe(retained)
-    expect(removed.every((link) => graph.getLink(link.id) === undefined)).toBe(
-      true
-    )
   })
   test('Replacing a linked input emits one connected callback', () => {
     const graph = new LGraph()

--- a/src/core/graph/widgets/dynamicWidgets.test.ts
+++ b/src/core/graph/widgets/dynamicWidgets.test.ts
@@ -5,7 +5,7 @@ import {
   addAutogrow,
   addDynamicCombo
 } from '@/core/graph/widgets/__fixtures__/dynamicInputHelpers'
-import { LGraph, LGraphNode } from '@/lib/litegraph/src/litegraph'
+import { LGraph, LGraphNode, LiteGraph } from '@/lib/litegraph/src/litegraph'
 import { useLitegraphService } from '@/services/litegraphService'
 
 setActivePinia(createTestingPinia())
@@ -23,7 +23,9 @@ function connectInput(node: LGraphNode, inputIndex: number, graph: LGraph) {
   const node2 = testNode()
   node2.addOutput('out', '*')
   graph.add(node2)
-  node2.connect(0, node, inputIndex)
+  const link = node2.connect(0, node, inputIndex)
+  if (!link) throw new Error(`failed to connect input ${inputIndex}`)
+  return link
 }
 function testNode() {
   const node = new LGraphNode('test')
@@ -67,6 +69,75 @@ describe('Dynamic Combos', () => {
     expect(node.inputs.length).toBe(4)
     expect(node.inputs[1].name).toBe('0.0.0.0')
     expect(node.inputs[3].name).toBe('2.2.0.0')
+  })
+  test('Shrinking rebuild preserves retained connections', () => {
+    const graph = new LGraph()
+    const node = testNode()
+    addDynamicCombo(node, [[], ['IMAGE', 'IMAGE'], ['IMAGE']])
+    graph.add(node)
+    addNodeInput(node, { name: 'other', isOptional: false, type: 'IMAGE' })
+    node.widgets[0].value = '1'
+    const retained = connectInput(node, 1, graph)
+    const removed = connectInput(node, 2, graph)
+    const unrelated = connectInput(node, 3, graph)
+
+    node.widgets[0].value = '2'
+
+    expect(node.getInputLink(1)).toBe(retained)
+    expect(node.getInputLink(2)).toBe(unrelated)
+    expect(graph.getLink(removed.id)).toBeUndefined()
+  })
+  test('Growing rebuild preserves retained connections', () => {
+    const graph = new LGraph()
+    const node = testNode()
+    addDynamicCombo(node, [[], ['IMAGE'], ['IMAGE', 'IMAGE']])
+    graph.add(node)
+    addNodeInput(node, { name: 'other', isOptional: false, type: 'IMAGE' })
+    node.widgets[0].value = '1'
+    const retained = connectInput(node, 1, graph)
+    const unrelated = connectInput(node, 2, graph)
+
+    node.widgets[0].value = '2'
+
+    expect(node.getInputLink(1)).toBe(retained)
+    expect(node.getInputLink(3)).toBe(unrelated)
+  })
+  test('Shrinking a larger group disconnects every removed link', () => {
+    const graph = new LGraph()
+    const node = testNode()
+    addDynamicCombo(node, [[], ['IMAGE', 'IMAGE', 'IMAGE'], ['IMAGE']])
+    graph.add(node)
+    node.widgets[0].value = '1'
+    const retained = connectInput(node, 1, graph)
+    const removed = [connectInput(node, 2, graph), connectInput(node, 3, graph)]
+
+    node.widgets[0].value = '2'
+
+    expect(node.getInputLink(1)).toBe(retained)
+    expect(removed.every((link) => graph.getLink(link.id) === undefined)).toBe(
+      true
+    )
+  })
+  test('Replacing a linked input emits one connected callback', () => {
+    const graph = new LGraph()
+    const node = testNode()
+    addDynamicCombo(node, [[], ['IMAGE'], ['IMAGE']])
+    graph.add(node)
+    node.widgets[0].value = '1'
+    const link = connectInput(node, 1, graph)
+    const onConnectionsChange = vi.fn()
+    node.onConnectionsChange = onConnectionsChange
+
+    node.widgets[0].value = '2'
+
+    expect(onConnectionsChange).toHaveBeenCalledOnce()
+    expect(onConnectionsChange).toHaveBeenCalledWith(
+      LiteGraph.INPUT,
+      1,
+      true,
+      link,
+      node.inputs[1]
+    )
   })
   test('Dynamically added widgets have tooltips', () => {
     const node = testNode()

--- a/src/lib/litegraph/src/LGraph.test.ts
+++ b/src/lib/litegraph/src/LGraph.test.ts
@@ -442,6 +442,34 @@ describe('node:before-removed event', () => {
       'onNodeRemoved(graph=null)'
     ])
   })
+
+  it('fires node:before-removed for every node cleared', () => {
+    const graph = new LGraph()
+    graph.add(new LGraphNode('a'))
+    graph.add(new LGraphNode('b'))
+    const removed = vi.fn()
+    graph.events.addEventListener('node:before-removed', removed)
+
+    graph.clear()
+
+    expect(removed).toHaveBeenCalledTimes(2)
+  })
+
+  it('keeps floating links available during clear removal callbacks', () => {
+    const graph = new LGraph()
+    const node = new LGraphNode('node')
+    graph.add(node)
+    const link = new LLink(toLinkId(1), '*', node.id, 0, UNASSIGNED_NODE_ID, -1)
+    graph.addFloatingLink(link)
+    node.onRemoved = vi.fn(() => {
+      expect(graph.floatingLinks.get(link.id)).toBe(link)
+    })
+
+    graph.clear()
+
+    expect(node.onRemoved).toHaveBeenCalledOnce()
+    expect(graph.floatingLinks.size).toBe(0)
+  })
 })
 
 describe('Subgraph Definition Garbage Collection', () => {


### PR DESCRIPTION
## Summary

Add a third batch of behavior-focused regression coverage extracted from #14246.

## Changes

- **What**: Cover dynamic-input connection preservation, floating-link lifecycle during graph clearing, and empty widget value persistence across save and reopen.

## Review Focus

This PR is stacked on #15323 and exercises public behavior without depending on ECS stores or private migration state. It can be retargeted after the parent PRs merge.