### PR TITLE
fix: correct Vue node pointer hit areas

### DIFF
--- a/browser_tests/assets/vueNodes/collapsed-neighbors.json
+++ b/browser_tests/assets/vueNodes/collapsed-neighbors.json
@@ -1,0 +1,78 @@
+{
+  "id": "4050769c-f6e4-4ac0-9279-524c85509fa8",
+  "revision": 0,
+  "last_node_id": 39,
+  "last_link_id": 0,
+  "nodes": [
+    {
+      "id": 37,
+      "type": "KSampler",
+      "pos": [300, 300],
+      "size": [428, 437],
+      "flags": { "collapsed": true },
+      "order": 0,
+      "mode": 0,
+      "inputs": [
+        { "name": "model", "type": "MODEL", "link": null },
+        { "name": "positive", "type": "CONDITIONING", "link": null },
+        { "name": "negative", "type": "CONDITIONING", "link": null },
+        { "name": "latent_image", "type": "LATENT", "link": null }
+      ],
+      "outputs": [{ "name": "LATENT", "type": "LATENT", "links": null }],
+      "properties": { "Node name for S&R": "KSampler" },
+      "widgets_values": [0, "randomize", 20, 8, "euler", "simple", 1]
+    },
+    {
+      "id": 38,
+      "type": "VAEDecode",
+      "pos": [529, 300],
+      "size": [225, 107],
+      "flags": { "collapsed": true },
+      "order": 1,
+      "mode": 0,
+      "inputs": [
+        { "name": "samples", "type": "LATENT", "link": null },
+        { "name": "vae", "type": "VAE", "link": null }
+      ],
+      "outputs": [{ "name": "IMAGE", "type": "IMAGE", "links": null }],
+      "properties": { "Node name for S&R": "VAEDecode" }
+    },
+    {
+      "id": 39,
+      "type": "CLIPTextEncode",
+      "pos": [758, 300],
+      "size": [240, 155],
+      "flags": { "collapsed": true },
+      "order": 2,
+      "mode": 0,
+      "inputs": [
+        { "name": "clip", "type": "CLIP", "link": null },
+        {
+          "name": "text",
+          "type": "STRING",
+          "widget": { "name": "text" },
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": null
+        }
+      ],
+      "properties": { "Node name for S&R": "CLIPTextEncode" },
+      "widgets_values": [""]
+    }
+  ],
+  "links": [],
+  "groups": [],
+  "config": {},
+  "extra": {
+    "ds": {
+      "scale": 1,
+      "offset": [0, 0]
+    }
+  },
+  "version": 0.4
+}

--- a/browser_tests/tests/vueNodes/nodeStates/collapse.spec.ts
+++ b/browser_tests/tests/vueNodes/nodeStates/collapse.spec.ts
@@ -105,6 +105,37 @@ test.describe('Vue Node Collapse', { tag: '@vue-nodes' }, () => {
     })
   })
 
+  test('collapse button takes priority over the resize handle', async ({
+    comfyPage
+  }) => {
+    const vueNode = await comfyPage.vueNodes.getFixtureByTitle('KSampler')
+    const nodeRef = await comfyPage.nodeOps.getNodeRefById('3')
+    const positionBefore = await nodeRef.getProperty<[number, number]>('pos')
+    const buttonBox = await vueNode.collapseButton.boundingBox()
+    if (!buttonBox) throw new Error('Collapse button has no bounding box')
+
+    const clickPoint = {
+      x: buttonBox.x + 2,
+      y: buttonBox.y + buttonBox.height / 2
+    }
+    const hitsCollapseButton = await comfyPage.page.evaluate(({ x, y }) => {
+      return Boolean(
+        document
+          .elementFromPoint(x, y)
+          ?.closest('[data-testid="node-collapse-button"]')
+      )
+    }, clickPoint)
+    expect(hitsCollapseButton).toBe(true)
+
+    await comfyPage.page.mouse.click(clickPoint.x, clickPoint.y)
+    await comfyPage.nextFrame()
+
+    await expect(vueNode.body).toBeHidden()
+    await expect
+      .poll(() => nodeRef.getProperty<[number, number]>('pos'))
+      .toEqual(positionBefore)
+  })
+
   test('should preserve title when collapsing/expanding', async ({
     comfyPage
   }) => {
@@ -127,3 +158,92 @@ test.describe('Vue Node Collapse', { tag: '@vue-nodes' }, () => {
     await expect(vueNode.header).toContainText('Test Sampler')
   })
 })
+
+test.describe(
+  'Collapsed node hit testing',
+  { tag: ['@vue-nodes', '@canvas', '@node'] },
+  () => {
+    test.beforeEach(async ({ comfyPage }) => {
+      await comfyPage.workflow.loadWorkflow('vueNodes/collapsed-neighbors')
+      await comfyPage.vueNodes.waitForNodes(3)
+    })
+
+    test.afterEach(async ({ comfyPage }) => {
+      await comfyPage.canvasOps.resetView()
+    })
+
+    test('ignores separator overflow outside the visible header', async ({
+      comfyPage
+    }) => {
+      const node = comfyPage.vueNodes.getNodeLocator('39')
+      const nodeRef = await comfyPage.nodeOps.getNodeRefById('39')
+      const box = await node.boundingBox()
+      if (!box) throw new Error('Collapsed node has no bounding box')
+
+      const overflowPoint = {
+        x: box.x + box.width + 6,
+        y: box.y + box.height / 2
+      }
+      const hitNodeId = await comfyPage.page.evaluate(({ x, y }) => {
+        return (
+          document
+            .elementFromPoint(x, y)
+            ?.closest<HTMLElement>('[data-node-id]')?.dataset.nodeId ?? null
+        )
+      }, overflowPoint)
+      expect(hitNodeId).toBeNull()
+
+      const positionBefore = await nodeRef.getProperty<[number, number]>('pos')
+      await comfyPage.page.mouse.move(overflowPoint.x, overflowPoint.y)
+      await comfyPage.page.mouse.down()
+      await comfyPage.page.mouse.move(
+        overflowPoint.x + 50,
+        overflowPoint.y + 50,
+        { steps: 10 }
+      )
+      await comfyPage.page.mouse.up()
+      await comfyPage.nextFrame()
+
+      await expect
+        .poll(() => nodeRef.getProperty<[number, number]>('pos'))
+        .toEqual(positionBefore)
+    })
+
+    test('keeps neighboring visible headers independently draggable', async ({
+      comfyPage
+    }) => {
+      for (const { nodeId, fromRight } of [
+        { nodeId: '37', fromRight: true },
+        { nodeId: '38', fromRight: true },
+        { nodeId: '39', fromRight: false }
+      ]) {
+        const node = comfyPage.vueNodes.getNodeLocator(nodeId)
+        const nodeRef = await comfyPage.nodeOps.getNodeRefById(nodeId)
+        const box = await node.boundingBox()
+        if (!box)
+          throw new Error(`Collapsed node ${nodeId} has no bounding box`)
+
+        const dragPoint = {
+          x: box.x + (fromRight ? box.width - 2 : 2),
+          y: box.y + box.height / 2
+        }
+        const positionBefore =
+          await nodeRef.getProperty<[number, number]>('pos')
+
+        await comfyPage.page.mouse.move(dragPoint.x, dragPoint.y)
+        await comfyPage.page.mouse.down()
+        await comfyPage.page.mouse.move(dragPoint.x, dragPoint.y + 50, {
+          steps: 10
+        })
+        await comfyPage.page.mouse.up()
+        await comfyPage.nextFrame()
+
+        await expect
+          .poll(() => nodeRef.getProperty<[number, number]>('pos'))
+          .not.toEqual(positionBefore)
+        await expect(node).toHaveClass(/outline-node-component-outline/)
+        await expect(comfyPage.vueNodes.selectedNodes).toHaveCount(1)
+      }
+    })
+  }
+)

--- a/src/renderer/extensions/vueNodes/components/LGraphNode.vue
+++ b/src/renderer/extensions/vueNodes/components/LGraphNode.vue
@@ -94,12 +94,12 @@
           <SlotConnectionDot
             v-if="hasInputs"
             multi
-            class="absolute left-0 -translate-x-1/2"
+            class="pointer-events-none absolute left-0 -translate-x-1/2"
           />
           <SlotConnectionDot
             v-if="nodeData.outputs.length"
             multi
-            class="absolute right-0 translate-x-1/2"
+            class="pointer-events-none absolute right-0 translate-x-1/2"
           />
           <NodeSlots :node-data unified />
         </template>

--- a/src/renderer/extensions/vueNodes/components/NodeHeader.test.ts
+++ b/src/renderer/extensions/vueNodes/components/NodeHeader.test.ts
@@ -140,6 +140,21 @@ describe('NodeHeader.vue', () => {
     expect(onCollapse).toHaveBeenCalled()
   })
 
+  it('does not bubble pointer down from the collapse button', async () => {
+    const { user } = renderHeader()
+    const onPointerDown = vi.fn()
+    screen
+      .getByTestId('node-header-1')
+      .addEventListener('pointerdown', onPointerDown)
+
+    await user.pointer({
+      keys: '[MouseLeft]',
+      target: screen.getByTestId('node-collapse-button')
+    })
+
+    expect(onPointerDown).not.toHaveBeenCalled()
+  })
+
   it('shows the current node title and updates when prop changes', async () => {
     const { rerender } = renderHeader({
       nodeData: makeNodeData({ title: 'Original' })

--- a/src/renderer/extensions/vueNodes/components/NodeHeader.vue
+++ b/src/renderer/extensions/vueNodes/components/NodeHeader.vue
@@ -21,8 +21,9 @@
           <Button
             size="icon-sm"
             variant="textonly"
-            class="hover:bg-transparent"
+            class="z-10 hover:bg-transparent"
             data-testid="node-collapse-button"
+            @pointerdown.stop
             @click.stop="handleCollapse"
             @dblclick.stop
           >


### PR DESCRIPTION
## Summary

Restrict Vue node pointer hit testing so collapsed-node decorations no longer intercept dragging and the collapse control takes priority over the resize handle.

## Changes

- **What**: Disable pointer events on collapsed aggregate slot markers, keep the collapse control above the resize handle, and stop its pointer-down event from bubbling.
- **Tests**: Add unit and browser regressions for the collapse control, collapsed-header dragging, neighboring collapsed nodes, and separator overflow.

## Review Focus

Verify that normal socket hit targets and expanded-node behavior remain unchanged while collapsed nodes only drag from their visible headers.

## Testing

- `pnpm typecheck`
- `pnpm typecheck:browser`
- `pnpm lint`
- `pnpm format:check`
- `pnpm test:unit --run src/renderer/extensions/vueNodes/components/NodeHeader.test.ts`
- `pnpm test:unit --run src/renderer/extensions/vueNodes/components/LGraphNode.test.ts`
- Playwright collapse spec discovery passed; execution was unavailable without a local frontend/backend server.
