### PR TITLE
fix(agent): node selection mode — interaction and visual reference (FE-1325)

### DIFF
--- a/src/assets/css/style.css
+++ b/src/assets/css/style.css
@@ -5,7 +5,7 @@
    banner. PrimeVue teleports every `<Toast>` container to <body>, out of reach
    of any wrapper element, and several components mount their own groups, so the
    whole toast layer is hidden from the root. The mode's banner is not a toast
-   and is unaffected. Toggled by GlobalToast.vue. */
+   and is unaffected. Toggled by agentNodeSelectionStore. */
 .node-selection-active .p-toast {
   display: none;
 }

--- a/src/assets/css/style.css
+++ b/src/assets/css/style.css
@@ -1,6 +1,15 @@
 @import '@comfyorg/design-system/css/style.css';
 @import '../../workbench/extensions/agent/agentTheme.css';
 
+/* Node selection mode clears the canvas of everything but the graph and its own
+   banner. PrimeVue teleports every `<Toast>` container to <body>, out of reach
+   of any wrapper element, and several components mount their own groups, so the
+   whole toast layer is hidden from the root. The mode's banner is not a toast
+   and is unaffected. Toggled by GlobalToast.vue. */
+.node-selection-active .p-toast {
+  display: none;
+}
+
 /* Use 0.001ms instead of 0s so transitionend/animationend events still fire
    and JS listeners aren't broken. */
 .disable-animations *,

--- a/src/components/builder/VueNodeSwitchPopup.vue
+++ b/src/components/builder/VueNodeSwitchPopup.vue
@@ -1,6 +1,8 @@
 <template>
   <NotificationPopup
-    v-if="appModeStore.showVueNodeSwitchPopup"
+    v-if="
+      appModeStore.showVueNodeSwitchPopup && !agentNodeSelectionStore.isActive
+    "
     data-testid="linear-vue-node-switch-popup"
     :title="$t('appBuilder.vueNodeSwitch.title')"
     show-close
@@ -43,9 +45,13 @@ import { ref } from 'vue'
 import NotificationPopup from '@/components/common/NotificationPopup.vue'
 import Button from '@/components/ui/button/Button.vue'
 import { useSettingStore } from '@/platform/settings/settingStore'
+import { useAgentNodeSelectionStore } from '@/stores/agentNodeSelectionStore'
 import { useAppModeStore } from '@/stores/appModeStore'
 
 const appModeStore = useAppModeStore()
+// Node selection mode keeps the canvas clear of everything but the graph and
+// its own banner, so this popup steps aside for the duration and returns after.
+const agentNodeSelectionStore = useAgentNodeSelectionStore()
 const settingStore = useSettingStore()
 const dontShowAgain = ref(false)
 

--- a/src/components/graph/GraphCanvas.vue
+++ b/src/components/graph/GraphCanvas.vue
@@ -52,18 +52,15 @@
         v-if="canvasMenuEnabled && !isBuilderMode"
         class="pointer-events-auto"
       />
-      <!-- Fades with the rest of the chrome during node selection rather than
-           popping. Gated on `isActionBarsHidden` so it leaves and returns on the
-           same beat as the top bars and side toolbar. -->
+      <!-- No node-selection condition here on purpose: entering the mode turns
+           the minimap setting off, so this reacts the same way it does to the
+           user's own toggle - and leaves them free to switch it back on while
+           they pick. -->
       <MiniMap
         v-if="
           comfyAppReady && minimapEnabled && betaMenuEnabled && !isBuilderMode
         "
-        :class="[
-          'pointer-events-auto transition-opacity duration-300 ease-in-out',
-          agentNodeSelectionStore.isActionBarsHidden &&
-            'pointer-events-none opacity-0'
-        ]"
+        class="pointer-events-auto"
       />
       <NodeSelectionModeBanner />
     </template>

--- a/src/components/graph/GraphCanvas.vue
+++ b/src/components/graph/GraphCanvas.vue
@@ -52,15 +52,18 @@
         v-if="canvasMenuEnabled && !isBuilderMode"
         class="pointer-events-auto"
       />
+      <!-- Fades with the rest of the chrome during node selection rather than
+           popping. Gated on `isActionBarsHidden` so it leaves and returns on the
+           same beat as the top bars and side toolbar. -->
       <MiniMap
         v-if="
-          comfyAppReady &&
-          minimapEnabled &&
-          betaMenuEnabled &&
-          !isBuilderMode &&
-          !agentNodeSelectionStore.isActive
+          comfyAppReady && minimapEnabled && betaMenuEnabled && !isBuilderMode
         "
-        class="pointer-events-auto"
+        :class="[
+          'pointer-events-auto transition-opacity duration-300 ease-in-out',
+          agentNodeSelectionStore.isActionBarsHidden &&
+            'pointer-events-none opacity-0'
+        ]"
       />
       <NodeSelectionModeBanner />
     </template>

--- a/src/components/toast/GlobalToast.test.ts
+++ b/src/components/toast/GlobalToast.test.ts
@@ -67,40 +67,6 @@ describe('GlobalToast', () => {
     expect(toastStore.removeAllRequested).toBe(false)
   })
 
-  // PrimeVue teleports each `<Toast>` container to `<body>`, so the layer is
-  // hidden by a root class rather than by a wrapper element - asserting on a
-  // wrapper would pass against the stub while proving nothing about the real
-  // toasts.
-  it('marks the root while node selection mode is active', async () => {
-    renderToast()
-    const nodeSelectionStore = useAgentNodeSelectionStore()
-
-    expect(document.body).not.toHaveClass('node-selection-active')
-
-    nodeSelectionStore.isActive = true
-    await nextTick()
-
-    expect(document.body).toHaveClass('node-selection-active')
-
-    nodeSelectionStore.isActive = false
-    await nextTick()
-
-    expect(document.body).not.toHaveClass('node-selection-active')
-  })
-
-  it('clears the root marker when unmounted mid-mode', async () => {
-    const { unmount } = renderToast()
-    const nodeSelectionStore = useAgentNodeSelectionStore()
-
-    nodeSelectionStore.isActive = true
-    await nextTick()
-    expect(document.body).toHaveClass('node-selection-active')
-
-    unmount()
-
-    expect(document.body).not.toHaveClass('node-selection-active')
-  })
-
   it('holds messages raised during node selection mode until it exits', async () => {
     renderToast()
     const toastStore = useToastStore()
@@ -151,6 +117,28 @@ describe('GlobalToast', () => {
 
     nodeSelectionStore.isActive = true
     await nextTick()
+    nodeSelectionStore.isActive = false
+    await nextTick()
+
+    expect(toastService.add).not.toHaveBeenCalled()
+  })
+
+  it('drops held messages when everything is dismissed mid-mode', async () => {
+    renderToast()
+    const toastStore = useToastStore()
+    const nodeSelectionStore = useAgentNodeSelectionStore()
+
+    nodeSelectionStore.isActive = true
+    await nextTick()
+
+    toastStore.messagesToAdd = [{ severity: 'error' as const, summary: 'Old' }]
+    await nextTick()
+
+    // A dismiss-everything clears the hidden queue too, or exiting would
+    // resurrect exactly what the caller just cleared.
+    toastStore.removeAllRequested = true
+    await nextTick()
+
     nodeSelectionStore.isActive = false
     await nextTick()
 

--- a/src/components/toast/GlobalToast.test.ts
+++ b/src/components/toast/GlobalToast.test.ts
@@ -5,6 +5,7 @@ import { nextTick } from 'vue'
 
 import GlobalToast from '@/components/toast/GlobalToast.vue'
 import { useToastStore } from '@/platform/updates/common/toastStore'
+import { useAgentNodeSelectionStore } from '@/stores/agentNodeSelectionStore'
 
 const toastService = vi.hoisted(() => ({
   add: vi.fn(),
@@ -64,5 +65,95 @@ describe('GlobalToast', () => {
 
     expect(toastService.removeAllGroups).toHaveBeenCalledOnce()
     expect(toastStore.removeAllRequested).toBe(false)
+  })
+
+  // PrimeVue teleports each `<Toast>` container to `<body>`, so the layer is
+  // hidden by a root class rather than by a wrapper element - asserting on a
+  // wrapper would pass against the stub while proving nothing about the real
+  // toasts.
+  it('marks the root while node selection mode is active', async () => {
+    renderToast()
+    const nodeSelectionStore = useAgentNodeSelectionStore()
+
+    expect(document.body).not.toHaveClass('node-selection-active')
+
+    nodeSelectionStore.isActive = true
+    await nextTick()
+
+    expect(document.body).toHaveClass('node-selection-active')
+
+    nodeSelectionStore.isActive = false
+    await nextTick()
+
+    expect(document.body).not.toHaveClass('node-selection-active')
+  })
+
+  it('clears the root marker when unmounted mid-mode', async () => {
+    const { unmount } = renderToast()
+    const nodeSelectionStore = useAgentNodeSelectionStore()
+
+    nodeSelectionStore.isActive = true
+    await nextTick()
+    expect(document.body).toHaveClass('node-selection-active')
+
+    unmount()
+
+    expect(document.body).not.toHaveClass('node-selection-active')
+  })
+
+  it('holds messages raised during node selection mode until it exits', async () => {
+    renderToast()
+    const toastStore = useToastStore()
+    const nodeSelectionStore = useAgentNodeSelectionStore()
+    const message = { severity: 'error' as const, summary: 'Failed' }
+
+    nodeSelectionStore.isActive = true
+    await nextTick()
+
+    toastStore.messagesToAdd = [message]
+    await nextTick()
+
+    // Held back rather than added to a hidden layer, where a message carrying
+    // a `life` would expire unseen.
+    expect(toastService.add).not.toHaveBeenCalled()
+    expect(toastStore.messagesToAdd).toEqual([])
+
+    nodeSelectionStore.isActive = false
+    await nextTick()
+
+    expect(toastService.add).toHaveBeenCalledWith(message)
+  })
+
+  it('replays held messages in the order they were raised', async () => {
+    renderToast()
+    const toastStore = useToastStore()
+    const nodeSelectionStore = useAgentNodeSelectionStore()
+    const first = { severity: 'error' as const, summary: 'First' }
+    const second = { severity: 'error' as const, summary: 'Second' }
+
+    nodeSelectionStore.isActive = true
+    await nextTick()
+
+    toastStore.messagesToAdd = [first]
+    await nextTick()
+    toastStore.messagesToAdd = [second]
+    await nextTick()
+
+    nodeSelectionStore.isActive = false
+    await nextTick()
+
+    expect(toastService.add.mock.calls).toEqual([[first], [second]])
+  })
+
+  it('does not replay anything when nothing was raised during the mode', async () => {
+    renderToast()
+    const nodeSelectionStore = useAgentNodeSelectionStore()
+
+    nodeSelectionStore.isActive = true
+    await nextTick()
+    nodeSelectionStore.isActive = false
+    await nextTick()
+
+    expect(toastService.add).not.toHaveBeenCalled()
   })
 })

--- a/src/components/toast/GlobalToast.vue
+++ b/src/components/toast/GlobalToast.vue
@@ -26,13 +26,27 @@
 
 <script setup lang="ts">
 import Toast from 'primevue/toast'
+import type { ToastMessageOptions } from 'primevue/toast'
 import { useToast } from 'primevue/usetoast'
-import { watch } from 'vue'
+import { computed, onScopeDispose, ref, watch } from 'vue'
 
 import { useToastStore } from '@/platform/updates/common/toastStore'
+import { useAgentNodeSelectionStore } from '@/stores/agentNodeSelectionStore'
+
+/** Paired with the `.p-toast` rule in `src/assets/css/style.css`. */
+const NODE_SELECTION_CLASS = 'node-selection-active'
 
 const toast = useToast()
 const toastStore = useToastStore()
+const agentNodeSelectionStore = useAgentNodeSelectionStore()
+const isNodeSelectionActive = computed(() => agentNodeSelectionStore.isActive)
+
+/**
+ * Messages raised while node selection mode is active. Adding them straight to
+ * a hidden toast layer would let anything carrying a `life` expire unseen, so
+ * they are held here and replayed once the mode exits.
+ */
+const deferredMessages = ref<ToastMessageOptions[]>([])
 
 watch(
   () => toastStore.messagesToAdd,
@@ -42,12 +56,47 @@ watch(
     }
 
     newMessages.forEach((message) => {
-      toast.add(message)
+      if (isNodeSelectionActive.value) {
+        deferredMessages.value.push(message)
+      } else {
+        toast.add(message)
+      }
     })
     toastStore.messagesToAdd = []
   },
   { deep: true }
 )
+
+/**
+ * PrimeVue teleports every `<Toast>` container to `<body>`, so no wrapper here
+ * can hide them - and other components mount their own `<Toast>` groups too.
+ * The whole layer is hidden from the root instead (see `style.css`). Messages
+ * without a `life` are sticky in PrimeVue, so errors already on screen survive
+ * the hide and are still there on exit.
+ */
+watch(
+  isNodeSelectionActive,
+  (active) => {
+    document.body.classList.toggle(NODE_SELECTION_CLASS, active)
+  },
+  { immediate: true }
+)
+
+onScopeDispose(() => {
+  document.body.classList.remove(NODE_SELECTION_CLASS)
+})
+
+watch(isNodeSelectionActive, (active) => {
+  if (active || deferredMessages.value.length === 0) {
+    return
+  }
+
+  const pending = deferredMessages.value
+  deferredMessages.value = []
+  pending.forEach((message) => {
+    toast.add(message)
+  })
+})
 
 watch(
   () => toastStore.messagesToRemove,

--- a/src/components/toast/GlobalToast.vue
+++ b/src/components/toast/GlobalToast.vue
@@ -28,25 +28,23 @@
 import Toast from 'primevue/toast'
 import type { ToastMessageOptions } from 'primevue/toast'
 import { useToast } from 'primevue/usetoast'
-import { computed, onScopeDispose, ref, watch } from 'vue'
+import { watch } from 'vue'
 
 import { useToastStore } from '@/platform/updates/common/toastStore'
 import { useAgentNodeSelectionStore } from '@/stores/agentNodeSelectionStore'
 
-/** Paired with the `.p-toast` rule in `src/assets/css/style.css`. */
-const NODE_SELECTION_CLASS = 'node-selection-active'
-
 const toast = useToast()
 const toastStore = useToastStore()
 const agentNodeSelectionStore = useAgentNodeSelectionStore()
-const isNodeSelectionActive = computed(() => agentNodeSelectionStore.isActive)
 
 /**
- * Messages raised while node selection mode is active. Adding them straight to
- * a hidden toast layer would let anything carrying a `life` expire unseen, so
- * they are held here and replayed once the mode exits.
+ * Messages raised while node selection mode is active. The mode hides the whole
+ * toast layer, and adding to a hidden layer would let anything carrying a `life`
+ * expire unseen - so they are held here and replayed on exit. Messages without a
+ * `life` are sticky in PrimeVue, so errors already on screen survive the hide
+ * untouched. Deliberately a plain array: nothing renders it.
  */
-const deferredMessages = ref<ToastMessageOptions[]>([])
+let deferredMessages: ToastMessageOptions[] = []
 
 watch(
   () => toastStore.messagesToAdd,
@@ -56,8 +54,8 @@ watch(
     }
 
     newMessages.forEach((message) => {
-      if (isNodeSelectionActive.value) {
-        deferredMessages.value.push(message)
+      if (agentNodeSelectionStore.isActive) {
+        deferredMessages.push(message)
       } else {
         toast.add(message)
       }
@@ -67,36 +65,15 @@ watch(
   { deep: true }
 )
 
-/**
- * PrimeVue teleports every `<Toast>` container to `<body>`, so no wrapper here
- * can hide them - and other components mount their own `<Toast>` groups too.
- * The whole layer is hidden from the root instead (see `style.css`). Messages
- * without a `life` are sticky in PrimeVue, so errors already on screen survive
- * the hide and are still there on exit.
- */
 watch(
-  isNodeSelectionActive,
+  () => agentNodeSelectionStore.isActive,
   (active) => {
-    document.body.classList.toggle(NODE_SELECTION_CLASS, active)
-  },
-  { immediate: true }
-)
-
-onScopeDispose(() => {
-  document.body.classList.remove(NODE_SELECTION_CLASS)
-})
-
-watch(isNodeSelectionActive, (active) => {
-  if (active || deferredMessages.value.length === 0) {
-    return
+    if (active) return
+    deferredMessages.splice(0).forEach((message) => {
+      toast.add(message)
+    })
   }
-
-  const pending = deferredMessages.value
-  deferredMessages.value = []
-  pending.forEach((message) => {
-    toast.add(message)
-  })
-})
+)
 
 watch(
   () => toastStore.messagesToRemove,
@@ -118,6 +95,9 @@ watch(
   (requested) => {
     if (requested) {
       toast.removeAllGroups()
+      // Held messages were cleared too - replaying them on exit would resurrect
+      // exactly what the caller just dismissed.
+      deferredMessages = []
       toastStore.removeAllRequested = false
     }
   }

--- a/src/composables/canvas/useFocusNode.ts
+++ b/src/composables/canvas/useFocusNode.ts
@@ -51,7 +51,7 @@ export function useFocusNode() {
     const graphNode = executionIdMap
       ? executionIdMap.get(nodeId)
       : getNodeByExecutionId(app.rootGraph, nodeId)
-    if (!graphNode?.graph) return
+    if (!graphNode) return
 
     await focusNodeInstance(graphNode)
   }

--- a/src/composables/canvas/useFocusNode.ts
+++ b/src/composables/canvas/useFocusNode.ts
@@ -32,6 +32,15 @@ async function navigateToGraph(targetGraph: LGraph) {
 export function useFocusNode() {
   const canvasStore = useCanvasStore()
 
+  /* Focus a known node instance, navigating to its owning graph first. */
+  async function focusNodeInstance(node: LGraphNode) {
+    const canvas = canvasStore.canvas
+    if (!canvas || !node.graph) return
+
+    await navigateToGraph(node.graph as LGraph)
+    canvas.animateToBounds(node.boundingRect)
+  }
+
   /* Locate and focus a node on the canvas by its execution ID. */
   async function focusNode(
     nodeId: string,
@@ -44,11 +53,11 @@ export function useFocusNode() {
       : getNodeByExecutionId(app.rootGraph, nodeId)
     if (!graphNode?.graph) return
 
-    await navigateToGraph(graphNode.graph as LGraph)
-    canvasStore.canvas?.animateToBounds(graphNode.boundingRect)
+    await focusNodeInstance(graphNode)
   }
 
   return {
-    focusNode
+    focusNode,
+    focusNodeInstance
   }
 }

--- a/src/composables/graph/useSelectionOperations.deleteGuard.test.ts
+++ b/src/composables/graph/useSelectionOperations.deleteGuard.test.ts
@@ -1,0 +1,53 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useSelectionOperations } from '@/composables/graph/useSelectionOperations'
+import { app } from '@/scripts/app'
+
+/**
+ * `selectOnly` marks the canvas as a picking surface rather than an editable
+ * one - the agent's node selection mode sets it. The guard lives at this call
+ * site rather than inside litegraph, so that vendored library stays untouched;
+ * the trade-off is that a new editing path has to opt in.
+ */
+vi.mock('@/scripts/app', () => ({
+  app: { canvas: undefined as unknown }
+}))
+
+vi.mock('@/services/dialogService', () => ({
+  useDialogService: () => ({ prompt: vi.fn() })
+}))
+
+function stubCanvas(selectOnly: boolean) {
+  const deleteSelected = vi.fn()
+  const canvas = {
+    selectOnly,
+    selectedItems: new Set([{ id: 1 }]),
+    deleteSelected,
+    setDirty: vi.fn()
+  }
+  ;(app as unknown as { canvas: unknown }).canvas = canvas
+  return { deleteSelected }
+}
+
+describe('useSelectionOperations delete guard', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('does not delete while the canvas is picking-only', () => {
+    const { deleteSelected } = stubCanvas(true)
+
+    useSelectionOperations().deleteSelection()
+
+    expect(deleteSelected).not.toHaveBeenCalled()
+  })
+
+  it('deletes normally when the canvas is editable', () => {
+    const { deleteSelected } = stubCanvas(false)
+
+    useSelectionOperations().deleteSelection()
+
+    expect(deleteSelected).toHaveBeenCalledOnce()
+  })
+})

--- a/src/composables/graph/useSelectionOperations.ts
+++ b/src/composables/graph/useSelectionOperations.ts
@@ -9,6 +9,7 @@ import {
 } from '@/renderer/core/canvas/canvasStore'
 import { app } from '@/scripts/app'
 import { useDialogService } from '@/services/dialogService'
+import { isSelectOnly } from '@/utils/litegraphUtil'
 
 /**
  * Composable for handling basic selection operations like copy, paste, duplicate, delete, rename
@@ -78,6 +79,9 @@ export function useSelectionOperations() {
 
   const deleteSelection = () => {
     const canvas = app.canvas
+    // Picking nodes for the agent is not editing: deleting stays off until the
+    // mode ends.
+    if (isSelectOnly(canvas)) return
     if (!canvas.selectedItems || canvas.selectedItems.size === 0) {
       toastStore.add({
         severity: 'warn',

--- a/src/composables/useCoreCommands.ts
+++ b/src/composables/useCoreCommands.ts
@@ -59,6 +59,7 @@ import {
   getAllNonIoNodesInSubgraph,
   getExecutionIdsForSelectedNodes
 } from '@/utils/graphTraversalUtil'
+import { isSelectOnly } from '@/utils/litegraphUtil'
 import { filterOutputNodes } from '@/utils/nodeFilterUtil'
 import {
   ManagerUIState,
@@ -934,6 +935,9 @@ export function useCoreCommands(): ComfyCommand[] {
       label: 'Delete Selected Items',
       versionAdded: '1.10.5',
       function: () => {
+        // Picking nodes for the agent is not editing: deleting stays off until
+        // the mode ends.
+        if (isSelectOnly(app.canvas)) return
         if (app.canvas.selectedItems.size === 0) {
           app.canvas.canvas.dispatchEvent(
             new CustomEvent('litegraph:no-items-selected', { bubbles: true })

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -4964,6 +4964,7 @@
     "copy": "Copy",
     "copied": "Copied!",
     "remove": "Remove",
+    "focusNode": "Show on canvas",
     "uploading": "Uploading",
     "noNodesToMention": "No nodes in this workflow",
     "friend": "there",

--- a/src/platform/settings/composables/useLitegraphSettings.test.ts
+++ b/src/platform/settings/composables/useLitegraphSettings.test.ts
@@ -1,0 +1,97 @@
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { effectScope, nextTick, ref } from 'vue'
+
+import { useLitegraphSettings } from '@/platform/settings/composables/useLitegraphSettings'
+import { useSettingStore } from '@/platform/settings/settingStore'
+// Mirrors the exemption in the composable under test.
+// eslint-disable-next-line import-x/no-restricted-paths
+import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
+import { useAgentNodeSelectionStore } from '@/stores/agentNodeSelectionStore'
+
+// The composable drives many settings off one canvas; only `show_info` matters
+// here, the rest are present so the other effects don't throw.
+const canvas = {
+  show_info: false,
+  zoom_speed: 1,
+  auto_pan_speed: 1,
+  links_render_mode: 0,
+  min_font_size_for_lod: 0,
+  draw: vi.fn(),
+  setDirty: vi.fn()
+}
+
+const settings = ref<Record<string, unknown>>({})
+
+vi.mock('@/platform/settings/settingStore', () => ({
+  useSettingStore: vi.fn(() => ({
+    get: (key: string) => settings.value[key]
+  }))
+}))
+
+function run() {
+  const scope = effectScope()
+  scope.run(() => useLitegraphSettings())
+  return scope
+}
+
+describe('useLitegraphSettings', () => {
+  beforeEach(() => {
+    setActivePinia(createTestingPinia({ stubActions: false }))
+    settings.value = {
+      'Comfy.Graph.CanvasInfo': true,
+      'Comfy.Graph.ZoomSpeed': 1,
+      'Comfy.Graph.AutoPanSpeed': 1
+    }
+    canvas.show_info = false
+    vi.mocked(useSettingStore).mockClear()
+    useCanvasStore().canvas = canvas as never
+  })
+
+  it('applies the canvas info setting', () => {
+    run()
+
+    expect(canvas.show_info).toBe(true)
+  })
+
+  // The overlay is drawn onto the canvas rather than composed in the DOM, so it
+  // cannot be hidden with CSS alongside the rest of the chrome.
+  it('suppresses the canvas info overlay during node selection mode', async () => {
+    const nodeSelectionStore = useAgentNodeSelectionStore()
+    run()
+    expect(canvas.show_info).toBe(true)
+
+    nodeSelectionStore.isActive = true
+    await nextTick()
+
+    expect(canvas.show_info).toBe(false)
+  })
+
+  it('restores the overlay on exit without touching the user setting', async () => {
+    const nodeSelectionStore = useAgentNodeSelectionStore()
+    run()
+
+    nodeSelectionStore.isActive = true
+    await nextTick()
+    nodeSelectionStore.isActive = false
+    await nextTick()
+
+    expect(canvas.show_info).toBe(true)
+    expect(settings.value['Comfy.Graph.CanvasInfo']).toBe(true)
+  })
+
+  it('leaves the overlay off during the mode when the setting is disabled', async () => {
+    const nodeSelectionStore = useAgentNodeSelectionStore()
+    settings.value['Comfy.Graph.CanvasInfo'] = false
+    run()
+
+    nodeSelectionStore.isActive = true
+    await nextTick()
+    expect(canvas.show_info).toBe(false)
+
+    nodeSelectionStore.isActive = false
+    await nextTick()
+    expect(canvas.show_info).toBe(false)
+  })
+})

--- a/src/platform/settings/composables/useLitegraphSettings.ts
+++ b/src/platform/settings/composables/useLitegraphSettings.ts
@@ -8,6 +8,7 @@ import {
 import { useSettingStore } from '@/platform/settings/settingStore'
 // eslint-disable-next-line import-x/no-restricted-paths
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
+import { useAgentNodeSelectionStore } from '@/stores/agentNodeSelectionStore'
 
 /**
  * Watch for changes in the setting store and update the LiteGraph settings accordingly.
@@ -15,11 +16,18 @@ import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 export const useLitegraphSettings = () => {
   const settingStore = useSettingStore()
   const canvasStore = useCanvasStore()
+  const agentNodeSelectionStore = useAgentNodeSelectionStore()
 
   watchEffect(() => {
     const canvasInfoEnabled = settingStore.get('Comfy.Graph.CanvasInfo')
+    // Node selection mode clears the canvas of everything but the graph and its
+    // own banner. This overlay is drawn onto the canvas rather than composed in
+    // the DOM, so it can't be hidden with CSS like the rest of the chrome. The
+    // user's setting is left untouched and takes effect again on exit.
+    const suppressedForNodeSelection = agentNodeSelectionStore.isActive
     if (canvasStore.canvas) {
-      canvasStore.canvas.show_info = canvasInfoEnabled
+      canvasStore.canvas.show_info =
+        canvasInfoEnabled && !suppressedForNodeSelection
       canvasStore.canvas.draw(false, true)
     }
   })

--- a/src/platform/updates/components/ReleaseNotificationToast.test.ts
+++ b/src/platform/updates/components/ReleaseNotificationToast.test.ts
@@ -3,6 +3,8 @@ import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
 
+import { useAgentNodeSelectionStore } from '@/stores/agentNodeSelectionStore'
+
 import type { ReleaseNote } from '../common/releaseService'
 import ReleaseNotificationToast from './ReleaseNotificationToast.vue'
 
@@ -129,6 +131,17 @@ describe('ReleaseNotificationToast', () => {
 
     renderComponent()
     expect(screen.getByText('New update is out!')).toBeInTheDocument()
+  })
+
+  it('stays hidden while node selection mode is active', () => {
+    mockReleaseStore.recentRelease = {
+      version: '1.2.3',
+      content: '# Test Release\n\nSome content'
+    } as ReleaseNote
+    useAgentNodeSelectionStore().isActive = true
+
+    renderComponent()
+    expect(screen.queryByText('New update is out!')).not.toBeInTheDocument()
   })
 
   it('displays rocket icon', () => {

--- a/src/platform/updates/components/ReleaseNotificationToast.vue
+++ b/src/platform/updates/components/ReleaseNotificationToast.vue
@@ -55,6 +55,7 @@ import NotificationPopup from '@/components/common/NotificationPopup.vue'
 import Button from '@/components/ui/button/Button.vue'
 import { useErrorHandling } from '@/composables/useErrorHandling'
 import { useExternalLink } from '@/composables/useExternalLink'
+import { useAgentNodeSelectionStore } from '@/stores/agentNodeSelectionStore'
 import { useCommandStore } from '@/stores/commandStore'
 import { isDesktop } from '@/platform/distribution/types'
 import { formatVersionAnchor } from '@/utils/formatUtil'
@@ -70,6 +71,7 @@ const { position = 'bottom-left' } = defineProps<{
 const { buildDocsUrl } = useExternalLink()
 const { toastErrorHandler } = useErrorHandling()
 const releaseStore = useReleaseStore()
+const agentNodeSelectionStore = useAgentNodeSelectionStore()
 const { t } = useI18n()
 
 // Local state for dismissed status
@@ -81,8 +83,13 @@ const latestRelease = computed<ReleaseNote | null>(() => {
 })
 
 // Show toast when new version available and not dismissed
+// Node selection mode keeps the canvas clear of everything but the graph and
+// its own banner, so this popup steps aside for the duration and returns after.
 const shouldShow = computed(
-  () => releaseStore.shouldShowToast && !isDismissed.value
+  () =>
+    releaseStore.shouldShowToast &&
+    !isDismissed.value &&
+    !agentNodeSelectionStore.isActive
 )
 
 // Generate changelog URL with version anchor (language-aware)

--- a/src/stores/agentNodeSelectionStore.test.ts
+++ b/src/stores/agentNodeSelectionStore.test.ts
@@ -12,6 +12,22 @@ vi.mock('@/stores/dialogStore', () => ({
   useDialogStore: () => ({ dialogStack })
 }))
 
+const settings = vi.hoisted(() => {
+  const values = new Map<string, unknown>()
+  return {
+    values,
+    get: (key: string) => values.get(key),
+    set: vi.fn((key: string, value: unknown) => {
+      values.set(key, value)
+      return Promise.resolve()
+    })
+  }
+})
+
+vi.mock('@/platform/settings/settingStore', () => ({
+  useSettingStore: () => settings
+}))
+
 /**
  * Real nodes carry `pos`/`size`; `boundingRect` is litegraph-renderer cache that
  * stays zeroed under Vue nodes, so the fit deliberately ignores it.
@@ -43,11 +59,58 @@ describe('agentNodeSelectionStore', () => {
   beforeEach(() => {
     vi.useFakeTimers()
     dialogStack.length = 0
+    settings.values.clear()
+    settings.set.mockClear()
     setActivePinia(createPinia())
   })
 
   afterEach(() => {
     vi.useRealTimers()
+    document.body.classList.remove('node-selection-active')
+  })
+
+  // PrimeVue teleports every `<Toast>` container to `<body>` and several
+  // components mount their own groups, so the layer can only be hidden from the
+  // root. The mode owns the marker because no one toast component renders them
+  // all - and because it must outlive any component that might unmount mid-mode.
+  it('hides the toast layer for the duration of the mode', async () => {
+    const store = useAgentNodeSelectionStore()
+
+    store.enter()
+    await nextTick()
+    expect(document.body).toHaveClass('node-selection-active')
+
+    store.exit()
+    await nextTick()
+    expect(document.body).not.toHaveClass('node-selection-active')
+  })
+
+  // Flipping the setting rather than overriding the minimap is what keeps the
+  // user's own toggle working while they pick.
+  it('turns a visible minimap off on entry and back on when leaving', async () => {
+    settings.values.set('Comfy.Minimap.Visible', true)
+    const store = useAgentNodeSelectionStore()
+
+    store.enter()
+    await nextTick()
+    expect(settings.values.get('Comfy.Minimap.Visible')).toBe(false)
+
+    store.exit()
+    await nextTick()
+    expect(settings.values.get('Comfy.Minimap.Visible')).toBe(true)
+  })
+
+  it('leaves the minimap setting alone when it was already off', async () => {
+    settings.values.set('Comfy.Minimap.Visible', false)
+    const store = useAgentNodeSelectionStore()
+
+    store.enter()
+    await nextTick()
+    store.exit()
+    await nextTick()
+
+    expect(settings.set).not.toHaveBeenCalled()
+    expect(settings.values.get('Comfy.Minimap.Visible')).toBe(false)
   })
 
   it('clears the canvas selection on exit', () => {

--- a/src/stores/agentNodeSelectionStore.test.ts
+++ b/src/stores/agentNodeSelectionStore.test.ts
@@ -99,10 +99,12 @@ describe('agentNodeSelectionStore', () => {
     expect(store.isActive).toBe(false)
     expect(store.isBannerVisible).toBe(false)
     expect(store.isActionBarsHidden).toBe(true)
-    expect(sidebar.activeSidebarTabId).toBe('assets')
+    // Staged like the entry side: still closed while the banner retracts.
+    expect(sidebar.activeSidebarTabId).toBeNull()
 
     vi.advanceTimersByTime(150)
     expect(store.isActionBarsHidden).toBe(false)
+    expect(sidebar.activeSidebarTabId).toBe('assets')
   })
 
   it('does not reopen a sidebar the user never had open', () => {

--- a/src/stores/agentNodeSelectionStore.test.ts
+++ b/src/stores/agentNodeSelectionStore.test.ts
@@ -2,6 +2,7 @@ import { createPinia, setActivePinia } from 'pinia'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
 
+import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import { useAgentNodeSelectionStore } from '@/stores/agentNodeSelectionStore'
 import { useSidebarTabStore } from '@/stores/workspace/sidebarTabStore'
 
@@ -10,6 +11,33 @@ const dialogStack = vi.hoisted(() => [] as unknown[])
 vi.mock('@/stores/dialogStore', () => ({
   useDialogStore: () => ({ dialogStack })
 }))
+
+/**
+ * Real nodes carry `pos`/`size`; `boundingRect` is litegraph-renderer cache that
+ * stays zeroed under Vue nodes, so the fit deliberately ignores it.
+ */
+function graphNode(
+  id: number,
+  pos?: [number, number],
+  size?: [number, number]
+) {
+  return { id, pos, size, boundingRect: new Float64Array(4) }
+}
+
+/** The minimum canvas surface entering and leaving the mode touches. */
+function stubCanvas(nodes: unknown[], selected: unknown[] = []) {
+  const animateToBounds = vi.fn()
+  const selectedItems = new Set(selected)
+  const deselectAll = vi.fn(() => selectedItems.clear())
+  useCanvasStore().canvas = {
+    graph: { nodes },
+    selectedItems,
+    deselectAll,
+    animateToBounds,
+    canvas: { width: 1600, height: 900 }
+  } as never
+  return { animateToBounds, deselectAll, selectedItems }
+}
 
 describe('agentNodeSelectionStore', () => {
   beforeEach(() => {
@@ -22,6 +50,30 @@ describe('agentNodeSelectionStore', () => {
     vi.useRealTimers()
   })
 
+  it('clears the canvas selection on exit', () => {
+    const node = graphNode(1, [0, 0], [100, 100])
+    const { deselectAll, selectedItems } = stubCanvas([node], [node])
+    const store = useAgentNodeSelectionStore()
+
+    store.enter()
+    store.exit()
+
+    expect(deselectAll).toHaveBeenCalledOnce()
+    expect(selectedItems.size).toBe(0)
+  })
+
+  it('leaves the canvas alone on exit when nothing was selected', () => {
+    const { deselectAll } = stubCanvas([graphNode(1, [0, 0], [100, 100])])
+    const store = useAgentNodeSelectionStore()
+
+    store.enter()
+    store.exit()
+
+    expect(deselectAll).not.toHaveBeenCalled()
+  })
+
+  // Entering with a selection means the user already knows which nodes they
+  // care about; framing the whole graph would zoom away from them.
   it('sequences selection chrome and restores the open sidebar', async () => {
     const sidebar = useSidebarTabStore()
     sidebar.activeSidebarTabId = 'assets'
@@ -51,6 +103,19 @@ describe('agentNodeSelectionStore', () => {
 
     vi.advanceTimersByTime(150)
     expect(store.isActionBarsHidden).toBe(false)
+  })
+
+  it('does not reopen a sidebar the user never had open', () => {
+    const sidebar = useSidebarTabStore()
+    sidebar.activeSidebarTabId = null
+    const store = useAgentNodeSelectionStore()
+
+    store.enter()
+    vi.advanceTimersByTime(200)
+    store.exit()
+    vi.advanceTimersByTime(150)
+
+    expect(sidebar.activeSidebarTabId).toBeNull()
   })
 
   it('exits on Escape unless a dialog is open', async () => {

--- a/src/stores/agentNodeSelectionStore.ts
+++ b/src/stores/agentNodeSelectionStore.ts
@@ -49,9 +49,15 @@ export const useAgentNodeSelectionStore = defineStore(
         isActionBarsHidden.value = false
       }, BANNER_TRANSITION_MS)
 
+      // Staged like the entry side rather than snapping back: the panel
+      // reappears with the action bars, once the banner has retracted, so the
+      // two never animate over each other.
       if (restoreSidebarTabId) {
-        sidebarTabStore.activeSidebarTabId = restoreSidebarTabId
+        const tabId = restoreSidebarTabId
         restoreSidebarTabId = null
+        sidebarTimeoutId = setTimeout(() => {
+          sidebarTabStore.activeSidebarTabId = tabId
+        }, BANNER_TRANSITION_MS)
       }
     })
 

--- a/src/stores/agentNodeSelectionStore.ts
+++ b/src/stores/agentNodeSelectionStore.ts
@@ -2,6 +2,7 @@ import { useEventListener } from '@vueuse/core'
 import { defineStore } from 'pinia'
 import { ref, watch } from 'vue'
 
+import { useSettingStore } from '@/platform/settings/settingStore'
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import { useDialogStore } from '@/stores/dialogStore'
 import { useSidebarTabStore } from '@/stores/workspace/sidebarTabStore'
@@ -9,12 +10,24 @@ import { useSidebarTabStore } from '@/stores/workspace/sidebarTabStore'
 const ACTION_BARS_TRANSITION_MS = 300
 const BANNER_TRANSITION_MS = 150
 const SIDEBAR_PANEL_TRANSITION_MS = 200
+
+/**
+ * Hides the whole toast layer for the duration of the mode. PrimeVue teleports
+ * every `<Toast>` container to `<body>`, and several components mount their own
+ * groups, so the layer can only be reached from the root - see the `.p-toast`
+ * rule in `src/assets/css/style.css`. The mode owns the class rather than any
+ * one toast component, since no single component renders all of those groups.
+ */
+const NODE_SELECTION_CLASS = 'node-selection-active'
+
+const MINIMAP_SETTING = 'Comfy.Minimap.Visible'
 export const useAgentNodeSelectionStore = defineStore(
   'agentNodeSelection',
   () => {
     const dialogStore = useDialogStore()
     const sidebarTabStore = useSidebarTabStore()
     const canvasStore = useCanvasStore()
+    const settingStore = useSettingStore()
     const isActive = ref(false)
     const isActionBarsHidden = ref(false)
     const isBannerVisible = ref(false)
@@ -24,10 +37,16 @@ export const useAgentNodeSelectionStore = defineStore(
     let transitionTimeoutId: ReturnType<typeof setTimeout> | undefined
     let sidebarTimeoutId: ReturnType<typeof setTimeout> | undefined
     let restoreSidebarTabId: string | null = null
+    let restoreMinimap = false
 
     watch(isActive, (active) => {
       clearTimeout(transitionTimeoutId)
       clearTimeout(sidebarTimeoutId)
+
+      // This watcher is created with the store, so it runs before any watcher a
+      // component registers on `isActive`. That is what lets GlobalToast replay
+      // its deferred messages onto an already-visible layer.
+      document.body.classList.toggle(NODE_SELECTION_CLASS, active)
 
       if (active) {
         isActionBarsHidden.value = true
@@ -41,6 +60,13 @@ export const useAgentNodeSelectionStore = defineStore(
             sidebarTabStore.activeSidebarTabId = null
           }, SIDEBAR_PANEL_TRANSITION_MS)
         }
+
+        // Flipping the user's own setting rather than overriding the minimap
+        // leaves the normal toggle working: anyone who wants the map back while
+        // picking can just switch it on, and only what we turned off is
+        // restored on exit.
+        restoreMinimap = settingStore.get(MINIMAP_SETTING)
+        if (restoreMinimap) void settingStore.set(MINIMAP_SETTING, false)
         return
       }
 
@@ -58,6 +84,11 @@ export const useAgentNodeSelectionStore = defineStore(
         sidebarTimeoutId = setTimeout(() => {
           sidebarTabStore.activeSidebarTabId = tabId
         }, BANNER_TRANSITION_MS)
+      }
+
+      if (restoreMinimap) {
+        restoreMinimap = false
+        void settingStore.set(MINIMAP_SETTING, true)
       }
     })
 

--- a/src/stores/agentNodeSelectionStore.ts
+++ b/src/stores/agentNodeSelectionStore.ts
@@ -2,18 +2,19 @@ import { useEventListener } from '@vueuse/core'
 import { defineStore } from 'pinia'
 import { ref, watch } from 'vue'
 
+import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import { useDialogStore } from '@/stores/dialogStore'
 import { useSidebarTabStore } from '@/stores/workspace/sidebarTabStore'
 
 const ACTION_BARS_TRANSITION_MS = 300
 const BANNER_TRANSITION_MS = 150
 const SIDEBAR_PANEL_TRANSITION_MS = 200
-
 export const useAgentNodeSelectionStore = defineStore(
   'agentNodeSelection',
   () => {
     const dialogStore = useDialogStore()
     const sidebarTabStore = useSidebarTabStore()
+    const canvasStore = useCanvasStore()
     const isActive = ref(false)
     const isActionBarsHidden = ref(false)
     const isBannerVisible = ref(false)
@@ -59,7 +60,16 @@ export const useAgentNodeSelectionStore = defineStore(
     }
 
     function exit(): void {
+      // Order matters: dropping out of the mode first stops the basket
+      // mirroring the canvas, so clearing the selection below leaves the
+      // staged chips intact. Picking is finished - the references stay in the
+      // composer, but the graph goes back to looking untouched.
       isActive.value = false
+
+      const canvas = canvasStore.canvas
+      if (!canvas?.selectedItems.size) return
+      canvas.deselectAll()
+      canvasStore.updateSelectedItems()
     }
 
     function saveNodeIds(

--- a/src/utils/litegraphUtil.ts
+++ b/src/utils/litegraphUtil.ts
@@ -133,6 +133,18 @@ export function addToComboValues(widget: IComboWidget, value: string) {
   }
 }
 
+/**
+ * True while the canvas is a picking surface rather than an editable one - the
+ * agent's node selection mode sets `selectOnly`.
+ *
+ * Guard every editing operation with this. It is checked at each call site
+ * rather than inside litegraph itself, to keep that vendored library untouched.
+ * A new way to edit the canvas therefore has to opt in: add the guard, or the
+ * operation will run during picking.
+ */
+export const isSelectOnly = (canvas: LGraphCanvas | undefined): boolean =>
+  canvas?.selectOnly === true
+
 export const isLGraphNode = (item: unknown): item is LGraphNode => {
   return item instanceof LGraphNode
 }

--- a/src/workbench/extensions/agent/AgentPanelRoot.test.ts
+++ b/src/workbench/extensions/agent/AgentPanelRoot.test.ts
@@ -67,11 +67,17 @@ const appMock = vi.hoisted(() => {
           }
           selectedItems: Set<unknown>
           selectItems: ReturnType<typeof vi.fn>
+          select: ReturnType<typeof vi.fn>
           deselect: (node: unknown) => void
+          animateToBounds: ReturnType<typeof vi.fn>
           multi_select: boolean
           allow_dragnodes: boolean
           selectOnly: boolean
-          canvas: { focus: ReturnType<typeof vi.fn> }
+          canvas: {
+            focus: ReturnType<typeof vi.fn>
+            width: number
+            height: number
+          }
         }
       | undefined
   }
@@ -416,6 +422,10 @@ function setupNodeSelectionCanvas() {
     for (const item of items) selectedItems.add(item)
   })
   const deselect = vi.fn((node: unknown) => selectedItems.delete(node))
+  const select = vi.fn((node: unknown) => selectedItems.add(node))
+  // Entering selection mode frames the graph; the stub only has to record the
+  // call, but it must exist or onSelectNodes throws part-way through.
+  const animateToBounds = vi.fn()
   const graph = {
     nodes,
     getNodeById: (id: string) =>
@@ -425,15 +435,26 @@ function setupNodeSelectionCanvas() {
     graph,
     selectedItems,
     selectItems,
+    select,
     deselect,
+    animateToBounds,
     multi_select: false,
     allow_dragnodes: true,
     selectOnly: false,
-    canvas: { focus }
+    canvas: { focus, width: 1600, height: 900 }
   }
   appMock.canvas = canvas
   hostStores.canvas.currentGraph = graph
-  return { canvas, focus, nodes, selectedItems, selectItems, deselect }
+  return {
+    canvas,
+    focus,
+    nodes,
+    selectedItems,
+    selectItems,
+    select,
+    deselect,
+    animateToBounds
+  }
 }
 
 function renderCanvasNodeButtons(
@@ -469,6 +490,16 @@ async function enterNodeSelectionMode(): Promise<void> {
       name: i18n.global.t('agent.addNodesFromGraph')
     })
   )
+}
+
+/**
+ * The basket only mirrors the canvas while picking, so anything asserting on
+ * staged chips has to be in the mode first. Set directly rather than driving the
+ * composer control: these tests are about what gets staged, not about how the
+ * mode is entered.
+ */
+function startPicking(): void {
+  useAgentNodeSelectionStore().isActive = true
 }
 
 async function startVueNodeSelection() {
@@ -847,116 +878,6 @@ describe('AgentPanelRoot attach flow', () => {
       })
     }
   )
-
-  it.for([
-    { mime: 'image/png', filename: 'gen.png' },
-    { mime: 'video/mp4', filename: 'movie.mp4' }
-  ])(
-    'stages an existing Media-card $mime reference without uploading',
-    async ({ mime, filename }) => {
-      const messageBodies: unknown[] = []
-      const fetchSpy = vi.fn(
-        async (input: RequestInfo | URL, init?: RequestInit) => {
-          const url = String(input)
-          if (init?.method === 'POST' && url.includes('/messages')) {
-            messageBodies.push(JSON.parse(String(init.body)))
-            return json(202, { thread_id: 'th-1', message_id: 'm-1' })
-          }
-          return new Response('{"threads":[]}', {
-            status: 200,
-            headers: { 'Content-Type': 'application/json' }
-          })
-        }
-      )
-      vi.stubGlobal('fetch', fetchSpy)
-      render(AgentPanelRoot, { global: { plugins: [i18n] } })
-      await nextTick()
-      const target = screen.getByRole('textbox')
-      const ref = `stored_${filename}`
-      const dragData = {
-        types: ['application/x-comfy-asset-info'],
-        getData: () =>
-          JSON.stringify({
-            filename,
-            type: 'input',
-            attachment_ref: ref,
-            media_kind: mime === 'image/png' ? 'image' : 'video',
-            preview_url:
-              mime === 'image/png'
-                ? `http://localhost/api/assets/${filename}/content`
-                : undefined
-          })
-      }
-
-      expect(dispatchDrag(target, 'drop', dragData)).toBe(true)
-      expect(dispatchDrag(target, 'drop', dragData)).toBe(true)
-      expect(await screen.findByText(filename)).toBeInTheDocument()
-      expect(screen.getAllByText(filename)).toHaveLength(1)
-      expect(
-        screen.queryByLabelText(i18n.global.t('agent.uploading'))
-      ).not.toBeInTheDocument()
-
-      await userEvent.click(screen.getByRole('button', { name: 'Send' }))
-
-      expect(messageBodies).toHaveLength(1)
-      expect(messageBodies[0]).toMatchObject({ attachments: [ref] })
-      expect(
-        fetchSpy.mock.calls.some(([url]) =>
-          /\/api\/(view|upload\/image)/.test(String(url))
-        )
-      ).toBe(false)
-    }
-  )
-
-  it('shows an uploading chip while a Media-card URI is still loading', async () => {
-    let resolveAsset: (response: Response) => void = () => {}
-    vi.stubGlobal(
-      'fetch',
-      vi.fn((input: RequestInfo | URL) => {
-        const url = String(input)
-        if (url.includes('/api/view'))
-          return new Promise<Response>((resolve) => {
-            resolveAsset = resolve
-          })
-        if (url.endsWith('/api/upload/image'))
-          return Promise.resolve(
-            new Response(JSON.stringify({ name: 'uploaded_gen.png' }), {
-              status: 200,
-              headers: { 'Content-Type': 'application/json' }
-            })
-          )
-        return Promise.resolve(
-          new Response('{"threads":[]}', {
-            status: 200,
-            headers: { 'Content-Type': 'application/json' }
-          })
-        )
-      })
-    )
-    render(AgentPanelRoot, { global: { plugins: [i18n] } })
-    await nextTick()
-    const target = screen.getByRole('textbox')
-    const dragData = {
-      types: ['application/x-comfy-asset-info', 'text/uri-list'],
-      getData: (type: string) =>
-        type === 'application/x-comfy-asset-info'
-          ? JSON.stringify({ filename: 'gen.png', type: 'input' })
-          : 'http://localhost/api/view?filename=gen.png'
-    }
-
-    expect(dispatchDrag(target, 'drop', dragData)).toBe(true)
-    expect(await screen.findByText('gen.png')).toBeInTheDocument()
-    expect(
-      screen.getByLabelText(i18n.global.t('agent.uploading'))
-    ).toBeInTheDocument()
-
-    resolveAsset(new Response(new Blob(['asset'], { type: 'image/png' })))
-    await vi.waitFor(() =>
-      expect(
-        screen.queryByLabelText(i18n.global.t('agent.uploading'))
-      ).not.toBeInTheDocument()
-    )
-  })
 
   it('attaches dropped assets and leaves other files to the graph loader', async () => {
     // The graph loader only opens a dropped workflow while the drop is
@@ -3679,6 +3600,7 @@ describe('AgentPanelRoot workflow binding', () => {
     render(AgentPanelRoot, { global: { plugins: [i18n] } })
 
     useAgentPanelStore().isOpen = true
+    startPicking()
     hostStores.canvas.selectedItems = [
       { isNodeFake: true, id: 7, title: 'KSampler' }
     ]
@@ -3811,6 +3733,7 @@ describe('AgentPanelRoot workflow binding', () => {
 
     render(AgentPanelRoot, { global: { plugins: [i18n] } })
     useAgentPanelStore().isOpen = true
+    startPicking()
 
     hostStores.canvas.selectedItems = [
       { isNodeFake: true, id: 5, title: 'KSampler' },
@@ -3844,6 +3767,7 @@ describe('AgentPanelRoot workflow binding', () => {
 
     render(AgentPanelRoot, { global: { plugins: [i18n] } })
     useAgentPanelStore().isOpen = true
+    startPicking()
 
     expect(await screen.findByText('VAE Decode')).toBeInTheDocument()
     expect(screen.getByText('KSampler')).toBeInTheDocument()
@@ -3858,12 +3782,46 @@ describe('AgentPanelRoot workflow binding', () => {
     expect(hostStores.canvas.selectedItems).toEqual([state.nodes[1]])
   })
 
+  // Selecting nodes in the normal graph view is ordinary canvas work. Only
+  // picking mode fills the basket, so an open panel alone must stage nothing.
+  it('does not stage canvas selections outside picking mode', async () => {
+    makeTab()
+
+    render(AgentPanelRoot, { global: { plugins: [i18n] } })
+    useAgentPanelStore().isOpen = true
+
+    hostStores.canvas.selectedItems = [
+      { isNodeFake: true, id: 5, title: 'KSampler' }
+    ]
+    await nextTick()
+
+    expect(screen.queryByText('KSampler')).not.toBeInTheDocument()
+  })
+
+  // ...but a selection made beforehand is honoured the moment picking starts.
+  it('stages a pre-existing canvas selection once picking starts', async () => {
+    makeTab()
+
+    render(AgentPanelRoot, { global: { plugins: [i18n] } })
+    useAgentPanelStore().isOpen = true
+    hostStores.canvas.selectedItems = [
+      { isNodeFake: true, id: 5, title: 'KSampler' }
+    ]
+    await nextTick()
+    expect(screen.queryByText('KSampler')).not.toBeInTheDocument()
+
+    startPicking()
+
+    expect(await screen.findByText('KSampler')).toBeInTheDocument()
+  })
+
   it('stages selected nodes as chips and sends their ids once', async () => {
     makeTab()
     const bodies = mockMessagesEndpoint('wf-42')
 
     render(AgentPanelRoot, { global: { plugins: [i18n] } })
     useAgentPanelStore().isOpen = true
+    startPicking()
 
     hostStores.canvas.selectedItems = [
       { isNodeFake: true, id: 5, title: 'KSampler' }
@@ -3884,6 +3842,7 @@ describe('AgentPanelRoot workflow binding', () => {
 
     render(AgentPanelRoot, { global: { plugins: [i18n] } })
     useAgentPanelStore().isOpen = true
+    startPicking()
 
     hostStores.canvas.selectedItems = [
       { isNodeFake: true, id: 7, title: 'KSampler' }
@@ -3909,6 +3868,7 @@ describe('AgentPanelRoot workflow binding', () => {
     const panelStore = useAgentPanelStore()
     const first = render(AgentPanelRoot, { global: { plugins: [i18n] } })
     panelStore.isOpen = true
+    startPicking()
 
     hostStores.canvas.selectedItems = [
       { isNodeFake: true, id: 7, title: 'KSampler' }
@@ -3924,6 +3884,7 @@ describe('AgentPanelRoot workflow binding', () => {
 
     render(AgentPanelRoot, { global: { plugins: [i18n] } })
     panelStore.isOpen = true
+    startPicking()
     await nextTick()
     expect(screen.queryByText('KSampler')).not.toBeInTheDocument()
     await sendFromComposer('no nodes please')
@@ -3942,6 +3903,7 @@ describe('AgentPanelRoot workflow binding', () => {
 
     ws.emit('agent_message_done', { message_id: 'm-2', thread_id: 'th-1' })
     await screen.findByRole('button', { name: 'Send' })
+    startPicking()
     hostStores.canvas.selectedItems = [
       { isNodeFake: true, id: 8, title: 'VAEDecode' }
     ]
@@ -3959,6 +3921,7 @@ describe('AgentPanelRoot workflow binding', () => {
     const panelStore = useAgentPanelStore()
     const first = render(AgentPanelRoot, { global: { plugins: [i18n] } })
     panelStore.isOpen = true
+    startPicking()
 
     hostStores.canvas.selectedItems = [
       { isNodeFake: true, id: 7, title: 'First KSampler' }
@@ -3980,6 +3943,7 @@ describe('AgentPanelRoot workflow binding', () => {
     ]
     render(AgentPanelRoot, { global: { plugins: [i18n] } })
     panelStore.isOpen = true
+    startPicking()
 
     expect(await screen.findByText('Second KSampler')).toBeInTheDocument()
     await sendFromComposer('use this workflow')
@@ -4181,18 +4145,24 @@ describe('AgentPanelRoot workflow binding', () => {
   it('resolves picker nodes from the viewed subgraph, not the root graph', async () => {
     makeTab()
     const bodies = mockMessagesEndpoint('wf-42')
+    // `select` has to actually add to the selection: picking a mention now
+    // selects the node on the canvas, and staged chips are rebuilt from that
+    // selection, so a no-op stub would drop the chip it just staged.
+    const selectedItems = new Set<unknown>()
     appMock.canvas = {
       graph: {
         nodes: [{ id: 12, title: 'KSampler' }],
         getNodeById: () => null
       },
-      selectedItems: new Set(),
+      selectedItems,
       selectItems: vi.fn(),
+      select: vi.fn((node: unknown) => selectedItems.add(node)),
       deselect: vi.fn(),
+      animateToBounds: vi.fn(),
       multi_select: false,
       allow_dragnodes: true,
       selectOnly: false,
-      canvas: { focus: vi.fn() }
+      canvas: { focus: vi.fn(), width: 1600, height: 900 }
     }
 
     render(AgentPanelRoot, { global: { plugins: [i18n] } })

--- a/src/workbench/extensions/agent/AgentPanelRoot.test.ts
+++ b/src/workbench/extensions/agent/AgentPanelRoot.test.ts
@@ -879,6 +879,116 @@ describe('AgentPanelRoot attach flow', () => {
     }
   )
 
+  it.for([
+    { mime: 'image/png', filename: 'gen.png' },
+    { mime: 'video/mp4', filename: 'movie.mp4' }
+  ])(
+    'stages an existing Media-card $mime reference without uploading',
+    async ({ mime, filename }) => {
+      const messageBodies: unknown[] = []
+      const fetchSpy = vi.fn(
+        async (input: RequestInfo | URL, init?: RequestInit) => {
+          const url = String(input)
+          if (init?.method === 'POST' && url.includes('/messages')) {
+            messageBodies.push(JSON.parse(String(init.body)))
+            return json(202, { thread_id: 'th-1', message_id: 'm-1' })
+          }
+          return new Response('{"threads":[]}', {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' }
+          })
+        }
+      )
+      vi.stubGlobal('fetch', fetchSpy)
+      render(AgentPanelRoot, { global: { plugins: [i18n] } })
+      await nextTick()
+      const target = screen.getByRole('textbox')
+      const ref = `stored_${filename}`
+      const dragData = {
+        types: ['application/x-comfy-asset-info'],
+        getData: () =>
+          JSON.stringify({
+            filename,
+            type: 'input',
+            attachment_ref: ref,
+            media_kind: mime === 'image/png' ? 'image' : 'video',
+            preview_url:
+              mime === 'image/png'
+                ? `http://localhost/api/assets/${filename}/content`
+                : undefined
+          })
+      }
+
+      expect(dispatchDrag(target, 'drop', dragData)).toBe(true)
+      expect(dispatchDrag(target, 'drop', dragData)).toBe(true)
+      expect(await screen.findByText(filename)).toBeInTheDocument()
+      expect(screen.getAllByText(filename)).toHaveLength(1)
+      expect(
+        screen.queryByLabelText(i18n.global.t('agent.uploading'))
+      ).not.toBeInTheDocument()
+
+      await userEvent.click(screen.getByRole('button', { name: 'Send' }))
+
+      expect(messageBodies).toHaveLength(1)
+      expect(messageBodies[0]).toMatchObject({ attachments: [ref] })
+      expect(
+        fetchSpy.mock.calls.some(([url]) =>
+          /\/api\/(view|upload\/image)/.test(String(url))
+        )
+      ).toBe(false)
+    }
+  )
+
+  it('shows an uploading chip while a Media-card URI is still loading', async () => {
+    let resolveAsset: (response: Response) => void = () => {}
+    vi.stubGlobal(
+      'fetch',
+      vi.fn((input: RequestInfo | URL) => {
+        const url = String(input)
+        if (url.includes('/api/view'))
+          return new Promise<Response>((resolve) => {
+            resolveAsset = resolve
+          })
+        if (url.endsWith('/api/upload/image'))
+          return Promise.resolve(
+            new Response(JSON.stringify({ name: 'uploaded_gen.png' }), {
+              status: 200,
+              headers: { 'Content-Type': 'application/json' }
+            })
+          )
+        return Promise.resolve(
+          new Response('{"threads":[]}', {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' }
+          })
+        )
+      })
+    )
+    render(AgentPanelRoot, { global: { plugins: [i18n] } })
+    await nextTick()
+    const target = screen.getByRole('textbox')
+    const dragData = {
+      types: ['application/x-comfy-asset-info', 'text/uri-list'],
+      getData: (type: string) =>
+        type === 'application/x-comfy-asset-info'
+          ? JSON.stringify({ filename: 'gen.png', type: 'input' })
+          : 'http://localhost/api/view?filename=gen.png'
+    }
+
+    expect(dispatchDrag(target, 'drop', dragData)).toBe(true)
+    expect(await screen.findByText('gen.png')).toBeInTheDocument()
+    expect(
+      screen.getByLabelText(i18n.global.t('agent.uploading'))
+    ).toBeInTheDocument()
+
+    resolveAsset(new Response(new Blob(['asset'], { type: 'image/png' })))
+    await vi.waitFor(() =>
+      expect(
+        screen.queryByLabelText(i18n.global.t('agent.uploading'))
+      ).not.toBeInTheDocument()
+    )
+  })
+
   it('attaches dropped assets and leaves other files to the graph loader', async () => {
     // The graph loader only opens a dropped workflow while the drop is
     // unclaimed, so the panel must not claim files it cannot attach.

--- a/src/workbench/extensions/agent/AgentPanelRoot.vue
+++ b/src/workbench/extensions/agent/AgentPanelRoot.vue
@@ -15,6 +15,7 @@ import {
 import { useI18n } from 'vue-i18n'
 
 import { useCurrentUser } from '@/composables/auth/useCurrentUser'
+import { useFocusNode } from '@/composables/canvas/useFocusNode'
 import { useTelemetry } from '@/platform/telemetry'
 import { useWorkflowService } from '@/platform/workflow/core/services/workflowService'
 import type { ComfyWorkflow } from '@/platform/workflow/management/stores/comfyWorkflow'
@@ -25,8 +26,7 @@ import { useAppMode } from '@/composables/useAppMode'
 import { MIME_ASSET_INFO } from '@/platform/assets/schemas/mediaAssetSchema'
 import { assetService } from '@/platform/assets/services/assetService'
 import {
-  fetchDroppedAsset,
-  getDroppedAsset,
+  extractFilesFromDragEvent,
   hasImageType,
   hasVideoType
 } from '@/utils/eventUtils'
@@ -101,6 +101,7 @@ const tabActivity = useWorkflowTabActivityStore()
 const CREATING_TAB_MIN_DURATION_MS = 500
 
 const canvasStore = useCanvasStore()
+const { focusNodeInstance } = useFocusNode()
 const selectedNodes = computed<SelectedNode[]>(() =>
   canvasStore.selectedItems.filter(isLGraphNode).map((node) => ({
     id: String(node.id),
@@ -115,7 +116,9 @@ const {
   add: addSelectionTag
 } = useCanvasSelection({
   selection: selectedNodes,
-  isLive: () => agentPanelStore.isOpen,
+  // Only picking mode fills the basket. Selecting nodes in the normal graph
+  // view is ordinary canvas work and must not stage a reference.
+  isLive: () => agentNodeSelectionStore.isActive,
   isPaused: () => agentNodeSelectionStore.isLoadingWorkflow,
   scope: () => workflowStore.activeWorkflow?.path ?? null,
   dismissedSignature: dismissedSelectionSignature
@@ -889,15 +892,31 @@ watch(
   }
 )
 
+/** Resolve a staged chip back to its node in the viewed graph. */
+function graphNodeById(id: string): LGraphNode | undefined {
+  return viewedGraphNodes().find((node) => String(node.id) === id)
+}
+
 function onSelectNodes(): void {
   if (selectingNodes) return
   const canvas = app.canvas
   if (!canvas) return
-  selectedGraphNodes = new Map(
+
+  // Chips staged before entering (via `@` mention) must read as selected on the
+  // canvas too, or the composer and the graph disagree about the same set.
+  // Merge them with whatever was already selected rather than one replacing the
+  // other.
+  const merged = new Map(
     [...canvas.selectedItems]
       .filter(isLGraphNode)
       .map((node) => [String(node.id), node] as const)
   )
+  for (const tag of selectionTags.value) {
+    const node = graphNodeById(tag.id)
+    if (node) merged.set(tag.id, node)
+  }
+  selectedGraphNodes = merged
+
   restoreAllowDragNodes = canvas.allow_dragnodes
   restoreSelectOnly = canvas.selectOnly
   canvas.allow_dragnodes = false
@@ -905,7 +924,18 @@ function onSelectNodes(): void {
   canvas.multi_select = true
   nodeSelectionCanvas = canvas
   selectingNodes = true
+
+  // Apply the selection before entering: `enter()` frames whatever is selected,
+  // so the merged set has to be in place first or it frames the stale one.
+  // Selecting here is safe because the basket only mirrors the canvas once the
+  // mode is active.
+  if (merged.size) {
+    canvas.selectItems([...merged.values()])
+    canvasStore.updateSelectedItems()
+  }
+
   agentNodeSelectionStore.enter()
+
   void nextTick(() => {
     if (selectingNodes) canvas.canvas.focus()
   })
@@ -946,9 +976,29 @@ function onOpenAssets(): void {
 
 function onMentionPick(node: SelectedNode): void {
   const stagedBefore = selectionTags.value.length
-  addSelectionTag(node)
+
+  // Select on the canvas first, so the chip and the graph agree about the same
+  // set. Staged chips are rebuilt wholesale from the canvas selection, so
+  // selecting is what makes the chip durable - staging it directly is the
+  // fallback for a node the canvas doesn't have.
+  const canvas = app.canvas
+  const graphNode = graphNodeById(node.id)
+  if (canvas && graphNode && !canvas.selectedItems.has(graphNode)) {
+    canvas.select(graphNode)
+    canvasStore.updateSelectedItems()
+  }
+  if (!selectionTags.value.some((tag) => tag.id === node.id)) {
+    addSelectionTag(node)
+  }
+
   if (selectionTags.value.length > stagedBefore)
     useTelemetry()?.trackAgentNodeTagged({ source: 'mention_picker' })
+}
+
+/** Fly the canvas to a chip's node so the user can see what they referenced. */
+function onFocusSelectionTag(id: string): void {
+  const node = graphNodeById(id)
+  if (node) void focusNodeInstance(node)
 }
 
 function onRemoveSelectionTag(id: string): void {
@@ -1006,8 +1056,10 @@ function onPanelDragLeave(): void {
 }
 
 async function attachDroppedAsset(event: DragEvent): Promise<void> {
-  const asset = event.dataTransfer && getDroppedAsset(event.dataTransfer)
-  if (!asset) {
+  const files = (await extractFilesFromDragEvent(event)).filter(
+    (file) => hasImageType(file) || hasVideoType(file)
+  )
+  if (files.length === 0) {
     toast.add({
       severity: 'warn',
       detail: t('agent.assetNotAttachable'),
@@ -1015,27 +1067,7 @@ async function attachDroppedAsset(event: DragEvent): Promise<void> {
     })
     return
   }
-
-  if (asset.ref && (asset.kind === 'image' || asset.kind === 'video')) {
-    panelRef.value?.addAttachment({
-      id: `asset:${asset.ref}`,
-      name: asset.name,
-      ref: asset.ref,
-      previewUrl: asset.previewUrl
-    })
-    return
-  }
-
-  const file = await attachment.addDeferredFile(asset.name, async () => {
-    const file = await fetchDroppedAsset(asset)
-    return file && (hasImageType(file) || hasVideoType(file)) ? file : undefined
-  })
-  if (!file)
-    toast.add({
-      severity: 'warn',
-      detail: t('agent.assetNotAttachable'),
-      life: 5000
-    })
+  await attachment.addFiles(files)
 }
 
 function onPanelDragOver(event: DragEvent): void {
@@ -1106,6 +1138,7 @@ function onPanelDrop(event: DragEvent): void {
       @open-assets="onOpenAssets"
       @select-nodes="onSelectNodes"
       @remove-tag="onRemoveSelectionTag"
+      @focus-tag="onFocusSelectionTag"
       @mention-pick="onMentionPick"
       @feedback="onFeedback"
       @new-chat="onNewChat"

--- a/src/workbench/extensions/agent/AgentPanelRoot.vue
+++ b/src/workbench/extensions/agent/AgentPanelRoot.vue
@@ -26,7 +26,8 @@ import { useAppMode } from '@/composables/useAppMode'
 import { MIME_ASSET_INFO } from '@/platform/assets/schemas/mediaAssetSchema'
 import { assetService } from '@/platform/assets/services/assetService'
 import {
-  extractFilesFromDragEvent,
+  fetchDroppedAsset,
+  getDroppedAsset,
   hasImageType,
   hasVideoType
 } from '@/utils/eventUtils'
@@ -1056,10 +1057,8 @@ function onPanelDragLeave(): void {
 }
 
 async function attachDroppedAsset(event: DragEvent): Promise<void> {
-  const files = (await extractFilesFromDragEvent(event)).filter(
-    (file) => hasImageType(file) || hasVideoType(file)
-  )
-  if (files.length === 0) {
+  const asset = event.dataTransfer && getDroppedAsset(event.dataTransfer)
+  if (!asset) {
     toast.add({
       severity: 'warn',
       detail: t('agent.assetNotAttachable'),
@@ -1067,7 +1066,27 @@ async function attachDroppedAsset(event: DragEvent): Promise<void> {
     })
     return
   }
-  await attachment.addFiles(files)
+
+  if (asset.ref && (asset.kind === 'image' || asset.kind === 'video')) {
+    panelRef.value?.addAttachment({
+      id: `asset:${asset.ref}`,
+      name: asset.name,
+      ref: asset.ref,
+      previewUrl: asset.previewUrl
+    })
+    return
+  }
+
+  const file = await attachment.addDeferredFile(asset.name, async () => {
+    const file = await fetchDroppedAsset(asset)
+    return file && (hasImageType(file) || hasVideoType(file)) ? file : undefined
+  })
+  if (!file)
+    toast.add({
+      severity: 'warn',
+      detail: t('agent.assetNotAttachable'),
+      life: 5000
+    })
 }
 
 function onPanelDragOver(event: DragEvent): void {

--- a/src/workbench/extensions/agent/AgentPanelRoot.vue
+++ b/src/workbench/extensions/agent/AgentPanelRoot.vue
@@ -912,8 +912,13 @@ function onSelectNodes(): void {
       .filter(isLGraphNode)
       .map((node) => [String(node.id), node] as const)
   )
+  // Index the graph once: resolving each chip with its own scan is
+  // O(chips x nodes), and this runs immediately before the entry animation.
+  const graphNodes = new Map(
+    viewedGraphNodes().map((node) => [String(node.id), node] as const)
+  )
   for (const tag of selectionTags.value) {
-    const node = graphNodeById(tag.id)
+    const node = graphNodes.get(tag.id)
     if (node) merged.set(tag.id, node)
   }
   selectedGraphNodes = merged
@@ -988,9 +993,7 @@ function onMentionPick(node: SelectedNode): void {
     canvas.select(graphNode)
     canvasStore.updateSelectedItems()
   }
-  if (!selectionTags.value.some((tag) => tag.id === node.id)) {
-    addSelectionTag(node)
-  }
+  addSelectionTag(node)
 
   if (selectionTags.value.length > stagedBefore)
     useTelemetry()?.trackAgentNodeTagged({ source: 'mention_picker' })

--- a/src/workbench/extensions/agent/components/agent/AgentPanel.vue
+++ b/src/workbench/extensions/agent/components/agent/AgentPanel.vue
@@ -69,6 +69,7 @@ const emit = defineEmits<{
   openAssets: []
   selectNodes: []
   removeTag: [id: string]
+  focusTag: [id: string]
   mentionPick: [node: SelectedNode]
   feedback: [turnId: string, vote: 'up' | 'down' | null]
   selectTab: [path: string]
@@ -298,6 +299,7 @@ defineExpose({ addAttachment, updateAttachment, removeAttachment })
             @open-assets="emit('openAssets')"
             @select-nodes="emit('selectNodes')"
             @remove-tag="emit('removeTag', $event)"
+            @focus-tag="emit('focusTag', $event)"
             @mention-pick="emit('mentionPick', $event)"
           >
             <template #header>

--- a/src/workbench/extensions/agent/components/agent/Composer.test.ts
+++ b/src/workbench/extensions/agent/components/agent/Composer.test.ts
@@ -315,6 +315,37 @@ describe('Composer', () => {
       ).toEqual(['Alpha', 'KSampler', 'VAE Decode'])
     })
 
+    // Re-picking a staged node is a no-op, so it drops out of the list.
+    it('hides nodes already in the basket', async () => {
+      mount({
+        getMentionNodes: () => NODES,
+        selectionTags: [NODES[0]]
+      })
+
+      await userEvent.type(screen.getByRole('textbox'), '@')
+
+      const labels = screen
+        .getAllByRole('option')
+        .map((option) => option.textContent?.trim())
+      expect(labels).not.toContain(NODES[0].title)
+      expect(screen.getAllByRole('option')).toHaveLength(NODES.length - 1)
+    })
+
+    // The staged node is only hidden from the picker, not from the duplicate
+    // check - its chip must still show the id that tells it apart from the
+    // same-titled node still in the graph.
+    it('keeps disambiguating a staged node against its graph twin', async () => {
+      const twin = { id: '11', title: NODES[0].title }
+      mount({
+        getMentionNodes: () => [...NODES, twin],
+        selectionTags: [NODES[0]]
+      })
+
+      await userEvent.type(screen.getByRole('textbox'), '@')
+
+      expect(screen.getByText(`#${NODES[0].id}`)).toBeInTheDocument()
+    })
+
     it('opens on @, filters with spaces, and stages the pick on Enter', async () => {
       const { emitted } = mount({ getMentionNodes: () => NODES })
       const box = screen.getByRole('textbox')
@@ -541,6 +572,31 @@ describe('Composer', () => {
     expect(
       await screen.findByRole('tooltip', { hidden: true })
     ).toHaveTextContent('Remove')
+  })
+
+  it('emits focusTag when a selection chip is activated', async () => {
+    const { emitted } = mount({
+      selectionTags: [{ id: '5', title: 'KSampler' }]
+    })
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Show on canvas' })
+    )
+
+    expect(emitted().focusTag).toEqual([['5']])
+  })
+
+  // The remove button sits outside the focus trigger; removing a chip must not
+  // also fly the canvas to the node being removed.
+  it('removes a selection chip without focusing its node', async () => {
+    const { emitted } = mount({
+      selectionTags: [{ id: '5', title: 'KSampler' }]
+    })
+
+    await userEvent.click(screen.getByRole('button', { name: 'Remove' }))
+
+    expect(emitted().removeTag).toEqual([['5']])
+    expect(emitted().focusTag).toBeUndefined()
   })
 
   it('shows the id on a lone selection chip with a graph title twin', () => {

--- a/src/workbench/extensions/agent/components/agent/Composer.vue
+++ b/src/workbench/extensions/agent/components/agent/Composer.vue
@@ -52,6 +52,7 @@ const emit = defineEmits<{
   openAssets: []
   selectNodes: []
   removeTag: [id: string]
+  focusTag: [id: string]
   mentionPick: [node: SelectedNode]
 }>()
 
@@ -60,8 +61,11 @@ const assetDragActive = inject<Readonly<Ref<boolean>>>(
   ref(false)
 )
 
+// Shared by the reference chips and the `@`-mention rows. Uses the same surface
+// token as the chip itself so the badge tracks the chip across themes, and the
+// same muted foreground as the chip's icon and remove button.
 const duplicateIdClass =
-  'shrink-0 rounded-[26px] bg-charcoal-400 px-1 py-0.5 font-mono text-xs/4 font-medium text-smoke-800'
+  'shrink-0 rounded-[26px] bg-agent-surface-hover px-1 py-0.5 font-mono text-xs/4 font-medium text-agent-fg-muted'
 
 const mentionNodes = ref<SelectedNode[]>([])
 const mentionAssets = ref<AssetItem[]>([])
@@ -90,6 +94,16 @@ type MentionMatch =
   | { kind: 'node'; id: string; label: string; node: SelectedNode }
   | { kind: 'asset'; id: string; label: string; asset: AssetItem }
 
+/**
+ * Nodes already in the basket, hidden from the picker - re-picking one is a
+ * no-op and only makes the list harder to scan.
+ *
+ * Filtered here rather than out of `mentionNodes`, because that list also feeds
+ * `graphDupes`: dropping a staged node from it would stop its chip showing the
+ * `#id` that disambiguates it from a same-titled node still in the graph.
+ */
+const stagedIds = computed(() => new Set(selectionTags.map((tag) => tag.id)))
+
 const mentionMatches = computed<MentionMatch[]>(() => {
   if (!mentionOpen.value) return []
   const query = mentionQuery.value.toLowerCase()
@@ -97,7 +111,8 @@ const mentionMatches = computed<MentionMatch[]>(() => {
     ...mentionNodes.value
       .filter(
         (node) =>
-          node.title.toLowerCase().includes(query) || node.id.includes(query)
+          !stagedIds.value.has(node.id) &&
+          (node.title.toLowerCase().includes(query) || node.id.includes(query))
       )
       .map(
         (node): MentionMatch => ({
@@ -376,24 +391,40 @@ defineExpose({
         <span>{{ t('agent.dragAndDropAssets') }}</span>
       </div>
       <div v-if="selectionTags.length" class="flex flex-wrap gap-2 p-3">
+        <!-- The label is the control that reveals the node on the canvas. The
+             remove button sits outside that trigger deliberately: nesting it
+             inside would surface both tooltips at once on hover. The hover fill
+             sits on the whole chip so the pill lights as one shape rather than
+             painting only the label's inline box. -->
         <span
           v-for="tag in selectionTags"
           :key="tag.id"
-          class="bg-agent-surface-hover text-agent-fg inline-flex h-7 items-center gap-1 rounded-lg border border-neutral-200 px-2.5 text-xs/4 font-medium"
+          class="bg-agent-surface-hover text-agent-fg inline-flex h-7 items-center gap-1 rounded-lg border border-border-default px-2.5 text-xs/4 font-medium transition-colors hover:bg-tertiary-background-hover"
         >
-          <span class="icon-[comfy--node] size-3.5" />
-          <span class="max-w-40 truncate">{{ tag.title }}</span>
           <span
-            v-if="graphDupes.has(tag.title) || tagDupes.has(tag.title)"
-            :class="duplicateIdClass"
-            >#{{ tag.id }}</span
+            v-tooltip.top="buildAgentTooltipConfig(t('agent.focusNode'))"
+            role="button"
+            tabindex="0"
+            :aria-label="t('agent.focusNode')"
+            class="flex cursor-pointer items-center gap-1 transition-colors"
+            @click="emit('focusTag', tag.id)"
+            @keydown.enter="emit('focusTag', tag.id)"
+            @keydown.space.prevent="emit('focusTag', tag.id)"
           >
+            <span class="text-agent-fg-muted icon-[comfy--node] size-3.5" />
+            <span class="max-w-40 truncate">{{ tag.title }}</span>
+            <span
+              v-if="graphDupes.has(tag.title) || tagDupes.has(tag.title)"
+              :class="duplicateIdClass"
+              >#{{ tag.id }}</span
+            >
+          </span>
           <button
             v-tooltip.top="buildAgentTooltipConfig(t('agent.remove'))"
             type="button"
             :aria-label="t('agent.remove')"
             class="text-agent-fg-muted hover:text-agent-fg flex size-3.5 cursor-pointer items-center justify-center transition-colors"
-            @click="emit('removeTag', tag.id)"
+            @click.stop="emit('removeTag', tag.id)"
           >
             <span class="icon-[lucide--x] size-3.5 shrink-0" />
           </button>

--- a/src/workbench/extensions/agent/components/agent/Composer.vue
+++ b/src/workbench/extensions/agent/components/agent/Composer.vue
@@ -395,21 +395,22 @@ defineExpose({
              remove button sits outside that trigger deliberately: nesting it
              inside would surface both tooltips at once on hover. The hover fill
              sits on the whole chip so the pill lights as one shape rather than
-             painting only the label's inline box. -->
+             painting only the label's inline box.
+
+             `p-0` is load-bearing: this app loads Tailwind's theme and utilities
+             but not its preflight, so a bare <button> keeps the browser's own
+             1px 6px padding. -->
         <span
           v-for="tag in selectionTags"
           :key="tag.id"
           class="bg-agent-surface-hover text-agent-fg inline-flex h-7 items-center gap-1 rounded-lg border border-border-default px-2.5 text-xs/4 font-medium transition-colors hover:bg-tertiary-background-hover"
         >
-          <span
+          <button
             v-tooltip.top="buildAgentTooltipConfig(t('agent.focusNode'))"
-            role="button"
-            tabindex="0"
+            type="button"
             :aria-label="t('agent.focusNode')"
-            class="flex cursor-pointer items-center gap-1 transition-colors"
+            class="flex cursor-pointer items-center gap-1 p-0 transition-colors"
             @click="emit('focusTag', tag.id)"
-            @keydown.enter="emit('focusTag', tag.id)"
-            @keydown.space.prevent="emit('focusTag', tag.id)"
           >
             <span class="text-agent-fg-muted icon-[comfy--node] size-3.5" />
             <span class="max-w-40 truncate">{{ tag.title }}</span>
@@ -418,7 +419,7 @@ defineExpose({
               :class="duplicateIdClass"
               >#{{ tag.id }}</span
             >
-          </span>
+          </button>
           <button
             v-tooltip.top="buildAgentTooltipConfig(t('agent.remove'))"
             type="button"

--- a/src/workbench/extensions/agent/composables/agent/useCanvasSelection.ts
+++ b/src/workbench/extensions/agent/composables/agent/useCanvasSelection.ts
@@ -37,7 +37,11 @@ export function useCanvasSelection(options: UseCanvasSelectionOptions) {
     ([isLive, isPaused, scope, nodes]) => {
       if (isPaused) return
       if (!isLive) {
-        staged.value = []
+        // Staged chips outlive the picking session. The basket is an explicit
+        // reference list the user built, not a mirror of the live canvas
+        // selection - so leaving the mode (which also clears the selection)
+        // must not empty it. Only the bookkeeping resets, so the next session
+        // starts clean.
         consumedSig.value = null
         stagedSig.value = null
         lastLiveSig = null


### PR DESCRIPTION

Linear: https://linear.app/comfyorg/issue/FE-1325/fe-update-composer-placeholder

## Read this first

**This is a reference PR. It is not production code.** Use it to see the
intended visual fidelity, the interaction patterns, and the flow. The goal is to
show what the design asks for.

## Summary

Node selection mode now keeps the composer and the canvas in agreement. A node
you pick on the canvas, a node you add with `@`, and a chip you click all point
at the same node. The chips stay in the composer after you leave the mode, and
the screen stays clear while you pick.

FE-1325 absorbed FE-1300 (Select nodes on graph), which was marked a duplicate.
The ticket description still describes only the placeholder. The placeholder
shipped on the V1 branch and this PR does not touch it.

In this list, "the mode" means node selection mode.

## What was covered, from a UX perspective

### 1. Hiding the floating UI in node selection mode

- The mode hides toasts, the bottom-left popups, and the canvas info readout.
- An error on screen is not lost. The mode shows it again after the exit.
- If a toast arrives during the mode, the mode shows it after the exit.
- The sidebar panel returns with the action bars, and not before them.

### 2. Node selection between the canvas and the composer

- The `@` mention picker selects the node on the canvas. Before, it added the
  node only to the composer.
- When the mode starts, it selects the nodes that are already in the composer.
- If the mode is not active, a click on a node adds no chip to the composer.
- The mode keeps a selection that you made before the mode started.
- When you leave the mode, the chips stay in the composer. The mode clears the
  canvas selection.
- The `@` list no longer shows the nodes that are already in the composer.

### 3. Safeguards for deletion and the minimap

- While the mode is active, the delete command does nothing. You cannot delete
  the nodes you are about to reference.
- When the mode starts, the minimap turns off. It returns on exit.
- You can turn the minimap on again while you pick nodes.

### 4. Highlighting and framing a node from its chip

- If you click a node chip, the canvas moves to that node. Before, the chip was
  a plain `<span>` and only the `X` did anything.
- The chip label is the control. It answers a click, Enter, and Space, and it
  shows a "Show on canvas" tooltip.

### 5. Visual updates to the node chips

- The chip border uses the semantic border token, not a fixed neutral color.
- The whole chip lights on hover, so the pill reads as one shape.
- The node icon and the `#id` badge use the muted foreground token.
- The `#id` badge uses the chip surface token for its background.

## One decision to review

The mode turns the minimap off through `Comfy.Minimap.Visible`, the user's own
setting. This keeps the minimap toggle live during the mode. The cost is that
the setting persists: a user who quits during the mode finds the minimap off in
the next session.

A condition in the template avoids the write, but then the toggle does nothing
while the mode is active.

## Scope

- 23 files. 256 lines of source code, 514 lines of tests.
- **No litegraph changes.** The delete guard sits at the two call sites, behind
  `isSelectOnly` in `src/utils/litegraphUtil.ts`.

## Testing

- The full unit suite passes. Typecheck, lint, and knip are clean.
- Manually tested in a running cloud build.

---

Replaces #15279, which carried the earlier combined branch. That version was
~950 lines and changed vendored litegraph. The framing work that needed those
litegraph changes is now split out into FE-1632 and FE-1633.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
