### PR TITLE
ci: attribute e2e Codecov uploads to the triggering run's head commit

### DIFF
--- a/.github/workflows/ci-tests-e2e-coverage.yaml
+++ b/.github/workflows/ci-tests-e2e-coverage.yaml
@@ -123,6 +123,9 @@ jobs:
           flags: e2e
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
+          override_commit: ${{ github.event.workflow_run.head_sha }}
+          override_branch: ${{ github.event.workflow_run.head_branch }}
+          override_pr: ${{ github.event.workflow_run.pull_requests[0].number }}
 
       - name: Generate HTML coverage report
         if: steps.coverage-shards.outputs.has-coverage == 'true'


### PR DESCRIPTION
## ELI-5

E2E coverage is uploaded by a follow-on workflow that runs *after* the E2E tests finish. In that context GitHub tells the job it is on `main`, so every PR's E2E coverage has been getting filed under main's latest commit instead of the PR's. Codecov then sees a PR head with unit coverage only, compares it against a main baseline inflated by other branches' E2E data, and reports a coverage drop that never happened. This tells the upload step which commit, branch and PR it is actually reporting for.

## Summary

Pass the triggering workflow run's head commit, branch and PR number to the `Upload E2E coverage to Codecov` step in `ci-tests-e2e-coverage.yaml`, so E2E coverage is attributed to the PR head instead of the default-branch tip.

## Changes

- **What**: three new inputs on the existing Codecov upload step — `override_commit: ${{ github.event.workflow_run.head_sha }}`, `override_branch: ${{ github.event.workflow_run.head_branch }}`, `override_pr: ${{ github.event.workflow_run.pull_requests[0].number }}`. Nothing else in the step changes (pinned action SHA, `files`, `flags`, `token`, `fail_ci_if_error` are all untouched), and `codecov.yml` is not touched.

## Review Focus

**The bug, measured today.** `ci-tests-e2e-coverage.yaml` runs on `workflow_run`, where `GITHUB_SHA`/`GITHUB_REF` point at the default-branch tip rather than the code that was tested — so the upload, which passed no overrides, always landed on main. Every run of this workflow reports `headBranch: main` (`gh run list --workflow ci-tests-e2e-coverage.yaml`), with four runs stacked on the same main commit in one morning. On Codecov, main `9ecd0a5f` carries 12 sessions / 125,112 lines while the two open PR heads I checked (`aa265ec1`, `12c38ff4`) carry 2 sessions / ~115k lines each — the ~10k-line gap is the E2E flag's files, present on main and absent on every PR head. Because the `project/default` status is scoped to the `unit` + `e2e` flags with `target: auto`, that asymmetry is exactly the phantom `codecov/project` failure seen on PRs whose `codecov/patch` passes.

**Why the three inputs are the right source.** For a `workflow_run` event, `github.event.workflow_run` describes the run that *did* the testing. I confirmed against live runs of `CI: Tests E2E` that its `head_sha` is the PR head commit for `pull_request` runs (e.g. `aa265ec133…` = PR #14543's `headRefOid`) and the pushed commit for `push` runs on main. That is the same SHA the unit-coverage upload already reports under, which is what makes the two flags land on one commit.

**The riskiest line is `override_pr`, and it is safe.** `workflow_run.pull_requests[]` is empty for fork PRs (a documented GitHub limitation) and for pushes/merge-queue runs, so `pull_requests[0].number` evaluates to an empty string. I checked the action at the pinned SHA `fb8b3582`: `override_pr` flows to `CC_PR`, and the uploader's `k_arg`/`v_arg` helpers emit no argument at all for an empty variable — so Codecov simply associates the upload by the (now correct) head SHA via the GitHub app. `override_commit`/`override_branch` are correct on every path. All three inputs exist at the pinned SHA (`action.yml` lines 97–111).

**Behaviour on main is unchanged** — a push to main already had `head_sha` equal to that main commit, so the upload lands where it landed before (slightly more precisely, since it can no longer drift to a newer tip picked up mid-run).

**Deliberately not changed.** No `ref:` was added to the `Checkout sources for genhtml` step: the lcov is self-contained and that checkout only feeds the HTML report's rendering, so checking out PR code in this privileged, secrets-bearing `workflow_run` context would be a security-surface change this fix does not need. `git_service: github` was not added preemptively — add it only if the upload step starts logging a git-service detection error.

**Known edge case, not addressed here:** if one branch has multiple open PRs, `pull_requests[0]` picks whichever GitHub lists first. The head SHA is authoritative for Codecov regardless, so the worst case is a coverage comment attached to the sibling PR.

## Verification

- `actionlint` on the edited file reports exactly the same two pre-existing shellcheck notices (SC2086, SC2129, both in unrelated `run:` blocks) as it does on the unmodified file on `main` — zero new findings.
- The file parses as YAML and the resulting step object carries the three inputs with the intended expressions.
- `oxfmt --check` (the formatter lint-staged applies to `.yaml`) passes.
- No source files are touched, so the unit and E2E suites are unaffected by this diff; there is no test that asserts on workflow contents.

**What cannot be verified before merge, and is therefore still open:** the workflow only runs from `main`, so confirming that a PR head actually receives the `e2e` flag requires this to be merged first. After merge, pick any open PR with a completed `CI: Tests E2E` run and check that (1) the triggered `CI: E2E Coverage` run's Codecov upload logs show the PR head SHA, (2) `https://api.codecov.io/api/v2/github/Comfy-Org/repos/ComfyUI_frontend/commits/<pr-head-sha>/` reports `totals.sessions >= 3`, and (3) `codecov/project` on that head reports a delta consistent with `codecov/patch`. Also confirm a subsequent push to main still uploads E2E coverage to that main commit.
