### PR TITLE
fix: keep toast notifications within mobile viewport

### DIFF
--- a/browser_tests/tests/toastNotifications.spec.ts
+++ b/browser_tests/tests/toastNotifications.spec.ts
@@ -64,4 +64,16 @@ test.describe('Toast Notifications', { tag: '@ui' }, () => {
 
     await expect(comfyPage.toast.toastErrors).not.toHaveCount(0)
   })
+
+  test(
+    'Toast fits within the mobile viewport',
+    { tag: '@mobile' },
+    async ({ comfyPage }) => {
+      await triggerErrorToast(comfyPage)
+
+      await expect(comfyPage.toast.visibleToasts.first()).toBeInViewport({
+        ratio: 1
+      })
+    }
+  )
 })

--- a/browser_tests/tests/toastNotifications.spec.ts
+++ b/browser_tests/tests/toastNotifications.spec.ts
@@ -69,11 +69,63 @@ test.describe('Toast Notifications', { tag: '@ui' }, () => {
     'Toast fits within the mobile viewport',
     { tag: '@mobile' },
     async ({ comfyPage }) => {
-      await triggerErrorToast(comfyPage)
+      const summary =
+        'Mobile viewport regression toast with an intentionally long summary'
+      const detail =
+        'This notification contains enough detail to wrap across several lines and verify that every part remains visible inside the narrow mobile viewport.'
+      await comfyPage.page.evaluate(
+        ({ summary, detail }) => {
+          window.app!.extensionManager.toast.add({
+            severity: 'error',
+            summary,
+            detail,
+            life: 30000
+          })
+        },
+        { summary, detail }
+      )
+      await comfyPage.nextFrame()
 
-      await expect(comfyPage.toast.visibleToasts.first()).toBeInViewport({
+      const toast = comfyPage.page
+        .locator('.p-toast-message')
+        .filter({ hasText: summary })
+      const toastDetail = toast.getByText(detail, { exact: true })
+      const viewport = comfyPage.page.viewportSize()
+      if (!viewport) {
+        throw new Error('The mobile test requires a configured viewport')
+      }
+
+      await expect(toast).toBeInViewport({
         ratio: 1
       })
+      await expect(toastDetail).toBeInViewport({ ratio: 1 })
+      await expect
+        .poll(async () => (await toast.boundingBox())?.x ?? 0)
+        .toBeGreaterThanOrEqual(16)
+      await expect
+        .poll(async () => {
+          const box = await toast.boundingBox()
+          return box ? viewport.width - box.x - box.width : 0
+        })
+        .toBeGreaterThanOrEqual(16)
+
+      await comfyPage.page.setViewportSize({ width: 800, height: 851 })
+      await expect
+        .poll(() =>
+          toast.evaluate((message) => {
+            const root = message.closest('.p-toast')
+            const graph = document.querySelector('.graph-canvas-container')
+            if (!root || !graph) return Number.POSITIVE_INFINITY
+
+            const graphRect = graph.getBoundingClientRect()
+            const expectedRight =
+              window.innerWidth - (graphRect.left + graphRect.width) + 20
+            return Math.abs(
+              Number.parseFloat(getComputedStyle(root).right) - expectedRight
+            )
+          })
+        )
+        .toBeLessThanOrEqual(0.5)
     }
   )
 })

--- a/src/components/toast/GlobalToast.vue
+++ b/src/components/toast/GlobalToast.vue
@@ -1,6 +1,11 @@
 <template>
-  <Toast />
-  <Toast group="billing-operation" position="top-right">
+  <Toast :auto-z-index="false" :pt="toastPt" />
+  <Toast
+    group="billing-operation"
+    position="top-right"
+    :auto-z-index="false"
+    :pt="toastPt"
+  >
     <template #message="slotProps">
       <div class="flex items-center gap-2">
         <!-- A spinner claims work is underway; an operation waiting on the
@@ -22,16 +27,29 @@
 </template>
 
 <script setup lang="ts">
+import { useEventListener } from '@vueuse/core'
 import Toast from 'primevue/toast'
+import type { ToastPassThroughOptions } from 'primevue/toast'
 import { useToast } from 'primevue/usetoast'
-import { nextTick, watch } from 'vue'
+import { nextTick, onUnmounted, watch } from 'vue'
 
 import { useSettingStore } from '@/platform/settings/settingStore'
 import { useToastStore } from '@/platform/updates/common/toastStore'
+import { createRafBatch } from '@/utils/rafBatch'
 
 const toast = useToast()
 const toastStore = useToastStore()
 const settingStore = useSettingStore()
+const toastPt = {
+  root: {
+    class:
+      'z-10000 max-sm:max-w-[calc(100vw-2rem)] max-sm:[--toast-mobile-right:1rem]',
+    style: {
+      top: 'var(--toast-top)',
+      right: 'var(--toast-mobile-right, var(--toast-right))'
+    }
+  }
+} satisfies ToastPassThroughOptions
 
 watch(
   () => toastStore.messagesToAdd,
@@ -83,17 +101,8 @@ function updateToastPosition() {
 
   styleElement.textContent = `
     .p-toast.p-component.p-toast-top-right {
-      top: ${rect.top + 100}px !important;
+      --toast-top: ${rect.top + 100}px;
       --toast-right: ${window.innerWidth - (rect.left + rect.width) + 20}px;
-      right: var(--toast-right) !important;
-       z-index: 10000 !important;
-    }
-
-    @media (max-width: 640px) {
-      .p-toast.p-component.p-toast-top-right {
-        --toast-right: 1rem;
-        max-width: calc(100vw - 2rem);
-      }
     }
   `
 }
@@ -105,14 +114,20 @@ function createStyleElement() {
   return style
 }
 
-watch(
-  () => settingStore.get('Comfy.UseNewMenu'),
-  () => nextTick(updateToastPosition),
-  { immediate: true }
-)
+const toastPositionBatch = createRafBatch(updateToastPosition)
+function scheduleToastPositionUpdate() {
+  void nextTick(toastPositionBatch.schedule)
+}
+
+useEventListener(window, 'resize', scheduleToastPositionUpdate)
+onUnmounted(toastPositionBatch.cancel)
+
+watch(() => settingStore.get('Comfy.UseNewMenu'), scheduleToastPositionUpdate, {
+  immediate: true
+})
 watch(
   () => settingStore.get('Comfy.Sidebar.Location'),
-  () => nextTick(updateToastPosition),
+  scheduleToastPositionUpdate,
   { immediate: true }
 )
 </script>

--- a/src/components/toast/GlobalToast.vue
+++ b/src/components/toast/GlobalToast.vue
@@ -84,8 +84,16 @@ function updateToastPosition() {
   styleElement.textContent = `
     .p-toast.p-component.p-toast-top-right {
       top: ${rect.top + 100}px !important;
-      right: ${window.innerWidth - (rect.left + rect.width) + 20}px !important;
+      --toast-right: ${window.innerWidth - (rect.left + rect.width) + 20}px;
+      right: var(--toast-right) !important;
        z-index: 10000 !important;
+    }
+
+    @media (max-width: 640px) {
+      .p-toast.p-component.p-toast-top-right {
+        --toast-right: 1rem;
+        max-width: calc(100vw - 2rem);
+      }
     }
   `
 }


### PR DESCRIPTION
## Summary

Keeps top-right toast notifications fully visible on narrow viewports while preserving their graph-aligned desktop position.

## Changes

- **What**: Applies a mobile-safe right offset and viewport-based maximum width, with mobile E2E coverage.

## Review Focus

The responsive behavior at the 640px breakpoint and alongside sidebar layouts.

Fixes #15294