### PR TITLE
fix(telemetry): route every error report through one reporter that reaches both sinks

### DIFF
--- a/global.d.ts
+++ b/global.d.ts
@@ -1,6 +1,5 @@
 declare const __COMFYUI_FRONTEND_VERSION__: string
 declare const __COMFYUI_FRONTEND_COMMIT__: string
-declare const __SENTRY_ENABLED__: boolean
 declare const __SENTRY_DSN__: string
 declare const __ALGOLIA_APP_ID__: string
 declare const __ALGOLIA_API_KEY__: string

--- a/scripts/vite-define-shim.ts
+++ b/scripts/vite-define-shim.ts
@@ -5,7 +5,6 @@
 
 type GlobalWithDefines = typeof globalThis & {
   __COMFYUI_FRONTEND_VERSION__: string
-  __SENTRY_ENABLED__: boolean
   __SENTRY_DSN__: string
   __ALGOLIA_APP_ID__: string
   __ALGOLIA_API_KEY__: string
@@ -20,7 +19,6 @@ const globalWithDefines = globalThis as GlobalWithDefines
 // Set default values for Playwright test environment
 globalWithDefines.__COMFYUI_FRONTEND_VERSION__ =
   process.env.npm_package_version || '1.0.0'
-globalWithDefines.__SENTRY_ENABLED__ = false
 globalWithDefines.__SENTRY_DSN__ = ''
 globalWithDefines.__ALGOLIA_APP_ID__ = ''
 globalWithDefines.__ALGOLIA_API_KEY__ = ''

--- a/src/App.vue
+++ b/src/App.vue
@@ -5,13 +5,13 @@
 </template>
 
 <script setup lang="ts">
-import { captureException } from '@sentry/vue'
 import BlockUI from 'primevue/blockui'
 import { computed, onMounted, watch } from 'vue'
 
 import GlobalDialog from '@/components/dialog/GlobalDialog.vue'
 import config from '@/config'
 import { isDesktop } from '@/platform/distribution/types'
+import { reportError } from '@/platform/telemetry/reportError'
 import { app } from '@/scripts/app'
 import { useWorkspaceStore } from '@/stores/workspaceStore'
 import { electronAPI } from '@/utils/envUtil'
@@ -49,11 +49,9 @@ function handleResourceError(url: string, tagName: string) {
   console.error('[resource:loadError]', { url, tagName })
 
   if (__DISTRIBUTION__ === 'cloud') {
-    captureException(new Error(`Resource load failed: ${url}`), {
-      tags: {
-        error_type: 'resource_load_error',
-        tag_name: tagName
-      }
+    reportError(new Error(`Resource load failed: ${url}`), {
+      errorType: 'resource_load_error',
+      tags: { tag_name: tagName }
     })
   }
 }
@@ -77,18 +75,16 @@ onMounted(() => {
       message: info.message
     })
     if (__DISTRIBUTION__ === 'cloud') {
-      captureException(event.payload, {
+      reportError(event.payload, {
+        errorType: 'vite_preload_error',
         tags: {
-          error_type: 'vite_preload_error',
           file_type: info.fileType,
           chunk_name: info.chunkName ?? undefined
         },
-        contexts: {
-          preload: {
-            url: info.url,
-            fileType: info.fileType,
-            chunkName: info.chunkName
-          }
+        context: {
+          url: info.url,
+          fileType: info.fileType,
+          chunkName: info.chunkName
         }
       })
     }

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -1,6 +1,9 @@
 if (__DISTRIBUTION__ === 'cloud') {
   const { initDatadogRum } = await import('@/platform/telemetry/initDatadogRum')
-  void initDatadogRum().catch(() => {})
+  const { flushErrorReports } = await import('@/platform/telemetry/reportError')
+  void initDatadogRum()
+    .then(flushErrorReports)
+    .catch(() => {})
 }
 
 await import('./main')

--- a/src/main.ts
+++ b/src/main.ts
@@ -20,6 +20,7 @@ import {
   remoteConfig
 } from '@/platform/remoteConfig/remoteConfig'
 import { syncHostUserIdWithFirebaseAuth } from '@/platform/telemetry/hostUserIdSync'
+import { flushErrorReports } from '@/platform/telemetry/reportError'
 import '@/lib/litegraph/public/css/litegraph.css'
 import router from '@/router'
 import { isDesktop, isNightly } from '@/platform/distribution/types'
@@ -67,10 +68,16 @@ const sentryDsn = isCloud
   ? configValueOrDefault(remoteConfig.value, 'sentry_dsn', __SENTRY_DSN__)
   : __SENTRY_DSN__
 
+// __SENTRY_ENABLED__ is baked from the *build machine's* SENTRY_DSN, but cloud
+// resolves its DSN at runtime from remote config. Trusting the build-time flag
+// alone leaves every capture in the app silently inert whenever a cloud build
+// runs without the env var, however valid the runtime DSN turns out to be.
+const sentryEnabled = !import.meta.env.DEV && !!sentryDsn
+
 Sentry.init({
   app,
   dsn: sentryDsn,
-  enabled: __SENTRY_ENABLED__,
+  enabled: sentryEnabled,
   release: __COMFYUI_FRONTEND_VERSION__,
   normalizeDepth: 8,
   tracesSampleRate: isCloud ? 1.0 : 0,
@@ -92,6 +99,9 @@ Sentry.init({
         defaultIntegrations: false
       })
 })
+
+flushErrorReports()
+
 // Assertion reporter receives pre-formatted messages (with "[Assertion failed]: " prefix).
 // Strings here are intentionally not i18n'd: they're developer/nightly diagnostics,
 // not user-facing in stable releases.

--- a/src/platform/cloud/onboarding/auth.ts
+++ b/src/platform/cloud/onboarding/auth.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/vue'
 import { isEmpty } from 'es-toolkit/compat'
 
+import { reportError } from '@/platform/telemetry/reportError'
 import { api } from '@/scripts/api'
 import { toError } from '@/utils/errorUtil'
 
@@ -10,9 +11,6 @@ interface UserCloudStatus {
 
 const ONBOARDING_SURVEY_KEY = 'onboarding_survey'
 
-/**
- * Helper function to capture API errors with Sentry
- */
 function captureApiError(
   error: Error,
   endpoint: string,
@@ -21,25 +19,15 @@ function captureApiError(
   operation?: string,
   extraContext?: Record<string, unknown>
 ) {
-  const tags: Record<string, string | number> = {
-    api_endpoint: endpoint,
-    error_type: errorType
-  }
-
-  if (httpStatus !== undefined) {
-    tags.http_status = httpStatus
-  }
-
-  if (operation) {
-    tags.operation = operation
-  }
-
-  const sentryOptions: Sentry.ExclusiveEventHintOrCaptureContext = {
-    tags,
-    extra: extraContext ? { ...extraContext } : undefined
-  }
-
-  Sentry.captureException(error, sentryOptions)
+  reportError(error, {
+    errorType,
+    tags: {
+      api_endpoint: endpoint,
+      http_status: httpStatus,
+      operation
+    },
+    context: extraContext
+  })
 }
 
 /**
@@ -119,12 +107,10 @@ export async function getSurveyCompletedStatus(): Promise<boolean> {
     return !isEmpty(data.value)
   } catch (error) {
     // Network/parse failure: same fail-safe policy as a non-ok response.
-    Sentry.captureException(error, {
-      tags: {
-        api_endpoint: '/settings/{key}',
-        error_type: 'network_error'
-      },
-      extra: {
+    reportError(error, {
+      errorType: 'network_error',
+      tags: { api_endpoint: '/settings/{key}' },
+      context: {
         route_template: '/settings/{key}',
         route_actual: `/settings/${ONBOARDING_SURVEY_KEY}`
       },

--- a/src/platform/telemetry/reportError.test.ts
+++ b/src/platform/telemetry/reportError.test.ts
@@ -1,0 +1,152 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const captureException = vi.fn()
+const isEnabled = vi.fn()
+const addError = vi.fn()
+const getInitConfiguration = vi.fn()
+
+vi.mock('@sentry/vue', () => ({
+  captureException: (...args: unknown[]) => captureException(...args),
+  isEnabled: () => isEnabled()
+}))
+
+vi.mock('@datadog/browser-rum', () => ({
+  datadogRum: {
+    addError: (...args: unknown[]) => addError(...args),
+    getInitConfiguration: () => getInitConfiguration()
+  }
+}))
+
+async function loadReportError() {
+  vi.resetModules()
+  return import('./reportError')
+}
+
+const sentryLive = (live: boolean) => isEnabled.mockReturnValue(live)
+const datadogLive = (live: boolean) =>
+  getInitConfiguration.mockReturnValue(live ? {} : undefined)
+
+describe('reportError', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    sentryLive(true)
+    datadogLive(true)
+  })
+
+  it('reaches both Sentry and Datadog from a single call', async () => {
+    const { reportError } = await loadReportError()
+    const error = new Error('boom')
+
+    reportError(error, {
+      errorType: 'workspace_auth_gate_initialization_failure'
+    })
+
+    expect(captureException).toHaveBeenCalledWith(
+      error,
+      expect.objectContaining({
+        tags: expect.objectContaining({
+          error_type: 'workspace_auth_gate_initialization_failure'
+        })
+      })
+    )
+    expect(addError).toHaveBeenCalledWith(
+      error,
+      expect.objectContaining({
+        error_type: 'workspace_auth_gate_initialization_failure'
+      })
+    )
+  })
+
+  it('still reports to Datadog when Sentry is inert', async () => {
+    sentryLive(false)
+    const { reportError } = await loadReportError()
+
+    reportError(new Error('boom'), { errorType: 'bootstrap_auth_wait_timeout' })
+
+    expect(captureException).not.toHaveBeenCalled()
+    expect(addError).toHaveBeenCalledOnce()
+  })
+
+  it('buffers reports raised before any sink is live, then flushes them', async () => {
+    sentryLive(false)
+    datadogLive(false)
+    const { reportError, flushErrorReports } = await loadReportError()
+
+    reportError(new Error('early'), { errorType: 'resource_load_error' })
+    expect(addError).not.toHaveBeenCalled()
+
+    datadogLive(true)
+    flushErrorReports()
+
+    expect(addError).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'early' }),
+      expect.objectContaining({ error_type: 'resource_load_error' })
+    )
+  })
+
+  it('does not replay a buffered report twice', async () => {
+    sentryLive(false)
+    datadogLive(false)
+    const { reportError, flushErrorReports } = await loadReportError()
+
+    reportError(new Error('early'), { errorType: 'resource_load_error' })
+
+    datadogLive(true)
+    flushErrorReports()
+    flushErrorReports()
+
+    expect(addError).toHaveBeenCalledOnce()
+  })
+
+  it('bounds the buffer so a boot-time error storm cannot grow without limit', async () => {
+    sentryLive(false)
+    datadogLive(false)
+    const { reportError, flushErrorReports } = await loadReportError()
+
+    for (let i = 0; i < 200; i++) {
+      reportError(new Error(`e${i}`), { errorType: 'resource_load_error' })
+    }
+
+    datadogLive(true)
+    flushErrorReports()
+
+    expect(addError.mock.calls.length).toBeLessThanOrEqual(25)
+  })
+
+  it('normalizes a non-Error cause', async () => {
+    const { reportError } = await loadReportError()
+
+    reportError('just a string', { errorType: 'bootstrap_auth_wait_timeout' })
+
+    expect(addError).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'just a string' }),
+      expect.anything()
+    )
+  })
+
+  it('drops undefined tag values rather than forwarding them', async () => {
+    const { reportError } = await loadReportError()
+
+    reportError(new Error('boom'), {
+      errorType: 'http_error',
+      tags: { api_endpoint: '/settings/{key}', http_status: undefined }
+    })
+
+    const [, context] = addError.mock.calls[0]
+    expect(context).not.toHaveProperty('http_status')
+    expect(context).toMatchObject({ api_endpoint: '/settings/{key}' })
+  })
+
+  it('does not throw when a sink throws', async () => {
+    captureException.mockImplementation(() => {
+      throw new Error('sentry exploded')
+    })
+    const { reportError } = await loadReportError()
+
+    expect(() =>
+      reportError(new Error('boom'), {
+        errorType: 'bootstrap_auth_wait_timeout'
+      })
+    ).not.toThrow()
+  })
+})

--- a/src/platform/telemetry/reportError.test.ts
+++ b/src/platform/telemetry/reportError.test.ts
@@ -137,6 +137,21 @@ describe('reportError', () => {
     expect(context).toMatchObject({ api_endpoint: '/settings/{key}' })
   })
 
+  it('does not throw out of flushErrorReports when a sink throws', async () => {
+    sentryLive(false)
+    datadogLive(false)
+    const { reportError, flushErrorReports } = await loadReportError()
+
+    reportError(new Error('early'), { errorType: 'resource_load_error' })
+
+    datadogLive(true)
+    addError.mockImplementation(() => {
+      throw new Error('datadog exploded')
+    })
+
+    expect(() => flushErrorReports()).not.toThrow()
+  })
+
   it('does not throw when a sink throws', async () => {
     captureException.mockImplementation(() => {
       throw new Error('sentry exploded')

--- a/src/platform/telemetry/reportError.ts
+++ b/src/platform/telemetry/reportError.ts
@@ -1,0 +1,104 @@
+import { datadogRum } from '@datadog/browser-rum'
+import { captureException, isEnabled as isSentryEnabled } from '@sentry/vue'
+
+import { toError } from '@/utils/errorUtil'
+
+export interface ReportErrorOptions {
+  /**
+   * Stable machine-readable slug for this failure mode. Lands as the
+   * `error_type` Sentry tag and the `error_type` RUM context field, so the
+   * same query works against either console.
+   */
+  errorType: string
+  tags?: Record<string, string | number | boolean | undefined>
+  context?: Record<string, unknown>
+  level?: 'warning' | 'error'
+}
+
+interface PendingReport {
+  error: Error
+  options: ReportErrorOptions
+}
+
+/**
+ * Reports raised before any sink is live are held here rather than dropped.
+ * Sentry initializes synchronously in main.ts but Datadog RUM arrives behind
+ * `initTelemetry()`'s dynamic imports, so early-boot failures — the ones that
+ * leave a user on the splash screen — would otherwise vanish exactly when
+ * they matter most.
+ */
+const pendingReports: PendingReport[] = []
+const MAX_PENDING_REPORTS = 25
+
+const isDatadogRumLive = () => datadogRum.getInitConfiguration() !== undefined
+
+const definedEntriesOf = (
+  tags: ReportErrorOptions['tags']
+): Record<string, string | number | boolean> =>
+  Object.fromEntries(
+    Object.entries(tags ?? {}).filter(([, value]) => value !== undefined)
+  ) as Record<string, string | number | boolean>
+
+function dispatch(error: Error, options: ReportErrorOptions): boolean {
+  const { errorType, context, level } = options
+  const tags = definedEntriesOf(options.tags)
+  const sentryLive = isSentryEnabled()
+  const datadogLive = isDatadogRumLive()
+
+  if (sentryLive) {
+    captureException(error, {
+      tags: { ...tags, error_type: errorType },
+      extra: context,
+      level
+    })
+  }
+  if (datadogLive) {
+    datadogRum.addError(error, {
+      ...context,
+      ...tags,
+      error_type: errorType,
+      level
+    })
+  }
+
+  return sentryLive || datadogLive
+}
+
+/**
+ * Drains reports buffered before a sink came up. Safe to call repeatedly;
+ * a no-op while every sink is still inert.
+ */
+export function flushErrorReports(): void {
+  if (!pendingReports.length) return
+  if (!isSentryEnabled() && !isDatadogRumLive()) return
+
+  const drained = pendingReports.splice(0, pendingReports.length)
+  for (const { error, options } of drained) {
+    dispatch(error, options)
+  }
+}
+
+/**
+ * Report an error to every observability sink at once.
+ *
+ * Prefer this to calling `captureException` or `datadogRum.addError`
+ * directly: a raw `captureException` reaches Sentry only, which is how
+ * `workspace_auth_gate_initialization_failure` stayed invisible on every
+ * Datadog dashboard while it was firing in production.
+ *
+ * Never throws — a failing error reporter must not become a second failure.
+ */
+export function reportError(cause: unknown, options: ReportErrorOptions): void {
+  try {
+    flushErrorReports()
+
+    const error = toError(cause)
+    if (dispatch(error, options)) return
+
+    if (pendingReports.length < MAX_PENDING_REPORTS) {
+      pendingReports.push({ error, options })
+    }
+  } catch (reporterFailure) {
+    console.error('[reportError] failed to report', reporterFailure, cause)
+  }
+}

--- a/src/platform/telemetry/reportError.ts
+++ b/src/platform/telemetry/reportError.ts
@@ -57,7 +57,7 @@ function dispatch(error: Error, options: ReportErrorOptions): boolean {
       ...context,
       ...tags,
       error_type: errorType,
-      level
+      ...(level ? { level } : {})
     })
   }
 
@@ -67,6 +67,10 @@ function dispatch(error: Error, options: ReportErrorOptions): boolean {
 /**
  * Drains reports buffered before a sink came up. Safe to call repeatedly;
  * a no-op while every sink is still inert.
+ *
+ * Callers are `main.ts` and `bootstrap.ts` on the boot path, so this must
+ * never throw: a sink that explodes here would take the whole app down
+ * instead of the one report it failed to deliver.
  */
 export function flushErrorReports(): void {
   if (!pendingReports.length) return
@@ -74,7 +78,11 @@ export function flushErrorReports(): void {
 
   const drained = pendingReports.splice(0, pendingReports.length)
   for (const { error, options } of drained) {
-    dispatch(error, options)
+    try {
+      dispatch(error, options)
+    } catch (reporterFailure) {
+      console.error('[reportError] failed to flush', reporterFailure, error)
+    }
   }
 }
 

--- a/src/platform/workspace/auth/WorkspaceAuthGate.test.ts
+++ b/src/platform/workspace/auth/WorkspaceAuthGate.test.ts
@@ -12,9 +12,9 @@ async function flushPromises() {
   await new Promise((r) => setTimeout(r, 0))
 }
 
-const mockCaptureException = vi.hoisted(() => vi.fn())
-vi.mock('@sentry/vue', () => ({
-  captureException: mockCaptureException
+const mockReportError = vi.hoisted(() => vi.fn())
+vi.mock('@/platform/telemetry/reportError', () => ({
+  reportError: mockReportError
 }))
 
 const mockIsInitialized = ref(false)
@@ -187,7 +187,7 @@ describe('WorkspaceAuthGate', () => {
       expect(
         screen.getByText("Couldn't load your workspace")
       ).toBeInTheDocument()
-      expect(mockCaptureException).toHaveBeenCalledOnce()
+      expect(mockReportError).toHaveBeenCalledOnce()
     })
   })
 
@@ -248,7 +248,7 @@ describe('WorkspaceAuthGate', () => {
       expect(signal.aborted).toBe(true)
       expect(mockWorkspaceStoreInitialize).not.toHaveBeenCalled()
       expect(mockResumePendingPricingFlow).not.toHaveBeenCalled()
-      expect(mockCaptureException).not.toHaveBeenCalled()
+      expect(mockReportError).not.toHaveBeenCalled()
     })
 
     it('calls resumePendingPricingFlow after successful workspace init', async () => {
@@ -295,10 +295,8 @@ describe('WorkspaceAuthGate', () => {
       ).toBeInTheDocument()
       expect(screen.getByRole('alert')).toHaveFocus()
       expect(splashLoader).not.toBeInTheDocument()
-      expect(mockCaptureException).toHaveBeenCalledWith(error, {
-        tags: {
-          error_type: 'workspace_auth_gate_initialization_failure'
-        }
+      expect(mockReportError).toHaveBeenCalledWith(error, {
+        errorType: 'workspace_auth_gate_initialization_failure'
       })
     })
 

--- a/src/platform/workspace/auth/WorkspaceAuthGate.vue
+++ b/src/platform/workspace/auth/WorkspaceAuthGate.vue
@@ -56,7 +56,6 @@
  * The splash loader in index.html (z-9999) covers the screen during this
  * phase, so no separate loading indicator is needed here.
  */
-import { captureException } from '@sentry/vue'
 import { until } from '@vueuse/core'
 import { storeToRefs } from 'pinia'
 import { nextTick, onMounted, onUnmounted, ref, useTemplateRef } from 'vue'
@@ -71,6 +70,7 @@ import {
   remoteConfigState
 } from '@/platform/remoteConfig/remoteConfig'
 import { refreshRemoteConfig } from '@/platform/remoteConfig/refreshRemoteConfig'
+import { reportError } from '@/platform/telemetry/reportError'
 import { useWorkspaceAuthStore } from '@/platform/workspace/stores/workspaceAuthStore'
 import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
 import { useAuthStore } from '@/stores/authStore'
@@ -173,10 +173,8 @@ async function initialize(): Promise<void> {
   } catch (error) {
     if (generation !== initializationGeneration) return
     console.error('[WorkspaceAuthGate] Initialization failed:', error)
-    captureException(error, {
-      tags: {
-        error_type: 'workspace_auth_gate_initialization_failure'
-      }
+    reportError(error, {
+      errorType: 'workspace_auth_gate_initialization_failure'
     })
     initializationRetryable.value = isRetryableInitializationError(error)
     initializationState.value = 'error'

--- a/src/platform/workspace/composables/useWorkspaceBilling.test.ts
+++ b/src/platform/workspace/composables/useWorkspaceBilling.test.ts
@@ -30,7 +30,7 @@ const mockShow = vi.hoisted(() => vi.fn())
 const mockStartOperation = vi.hoisted(() => vi.fn())
 const mockGetOperation = vi.hoisted(() => vi.fn())
 const mockSetWorkspaceBillingRail = vi.hoisted(() => vi.fn())
-const mockCaptureException = vi.hoisted(() => vi.fn())
+const mockReportError = vi.hoisted(() => vi.fn())
 const mockActiveWorkspaceId = vi.hoisted(() => ({ value: 'workspace-1' }))
 
 // Hoisted so the vi.mock factory below can reference it: a plain top-level
@@ -75,8 +75,8 @@ vi.mock('@/platform/workspace/stores/billingOperationStore', () => ({
   })
 }))
 
-vi.mock('@sentry/vue', () => ({
-  captureException: mockCaptureException
+vi.mock('@/platform/telemetry/reportError', () => ({
+  reportError: mockReportError
 }))
 
 vi.mock('@/platform/workspace/stores/teamWorkspaceStore', () => ({
@@ -322,7 +322,7 @@ describe('useWorkspaceBilling', () => {
         undefined,
         actionUrl
       )
-      expect(mockCaptureException).not.toHaveBeenCalled()
+      expect(mockReportError).not.toHaveBeenCalled()
     })
 
     it('recovers a pending top-up as a top-up, not a subscription', async () => {
@@ -359,11 +359,11 @@ describe('useWorkspaceBilling', () => {
       const billing = setupBilling()
       await billing.fetchStatus()
 
-      expect(mockCaptureException).toHaveBeenCalledWith(
+      expect(mockReportError).toHaveBeenCalledWith(
         expect.objectContaining({
           message: expect.stringContaining('seat_change')
         }),
-        { tags: { error_type: 'billing_unknown_resume_mode' } }
+        { errorType: 'billing_unknown_resume_mode' }
       )
       // Recovery is preserved deliberately: without it the customer has no way
       // back to the payment page, while a wrong panel clears on reload.

--- a/src/platform/workspace/composables/useWorkspaceBilling.ts
+++ b/src/platform/workspace/composables/useWorkspaceBilling.ts
@@ -1,10 +1,10 @@
-import { captureException } from '@sentry/vue'
 import { computed, ref, shallowRef, watch } from 'vue'
 
 import { useBillingPlans } from '@/platform/cloud/subscription/composables/useBillingPlans'
 import { useSubscriptionDialog } from '@/platform/cloud/subscription/composables/useSubscriptionDialog'
 import type { SubscriptionDialogOptions } from '@/platform/cloud/subscription/composables/useSubscriptionDialog'
 import { useTelemetry } from '@/platform/telemetry'
+import { reportError } from '@/platform/telemetry/reportError'
 import { categorizeBillingApiError } from '@/platform/telemetry/utils/billingFailureCategory'
 import type {
   BillingBalanceResponse,
@@ -52,11 +52,11 @@ function resumeModeFor(
       // callable toString/valueOf, and throwing out of the branch that exists
       // to absorb a bad value would abort recovery entirely. The value came
       // from a parsed response, so it cannot be circular.
-      captureException(
+      reportError(
         new Error(
           `Unknown pending billing op type: ${JSON.stringify(unexpected)}`
         ),
-        { tags: { error_type: 'billing_unknown_resume_mode' } }
+        { errorType: 'billing_unknown_resume_mode' }
       )
       // Reachable only against a newer server. Dropping recovery strands a
       // customer who cannot reach the payment page; a wrong panel clears on

--- a/src/stores/bootstrapStore.test.ts
+++ b/src/stores/bootstrapStore.test.ts
@@ -66,14 +66,9 @@ const mockDistributionTypes = vi.hoisted(() => ({
 }))
 vi.mock('@/platform/distribution/types', () => mockDistributionTypes)
 
-const mockCaptureException = vi.hoisted(() => vi.fn())
-vi.mock('@sentry/vue', () => ({
-  captureException: mockCaptureException
-}))
-
-const mockAddError = vi.hoisted(() => vi.fn())
-vi.mock('@datadog/browser-rum', () => ({
-  datadogRum: { addError: mockAddError }
+const mockReportError = vi.hoisted(() => vi.fn())
+vi.mock('@/platform/telemetry/reportError', () => ({
+  reportError: mockReportError
 }))
 
 function requestFailure(status: number) {
@@ -141,8 +136,7 @@ describe('bootstrapStore', () => {
   describe('cloud mode', () => {
     beforeEach(() => {
       mockDistributionTypes.isCloud = true
-      mockCaptureException.mockReset()
-      mockAddError.mockReset()
+      mockReportError.mockReset()
     })
 
     it('waits for Firebase init before loading stores, then proceeds regardless of auth state', async () => {
@@ -182,7 +176,7 @@ describe('bootstrapStore', () => {
         await bootstrapPromise
 
         expect(settingStore.isReady).toBe(true)
-        expect(mockCaptureException).not.toHaveBeenCalled()
+        expect(mockReportError).not.toHaveBeenCalled()
       } finally {
         vi.useRealTimers()
       }
@@ -199,13 +193,9 @@ describe('bootstrapStore', () => {
         await vi.advanceTimersByTimeAsync(16_000 + 3_000 + 16_001)
         await bootstrapPromise
 
-        expect(mockCaptureException).toHaveBeenCalledOnce()
-        expect(mockCaptureException).toHaveBeenCalledWith(expect.any(Error), {
-          tags: { error_type: 'bootstrap_auth_wait_timeout' }
-        })
-        expect(mockAddError).toHaveBeenCalledOnce()
-        expect(mockAddError).toHaveBeenCalledWith(expect.any(Error), {
-          error_type: 'bootstrap_auth_wait_timeout'
+        expect(mockReportError).toHaveBeenCalledOnce()
+        expect(mockReportError).toHaveBeenCalledWith(expect.anything(), {
+          errorType: 'bootstrap_auth_wait_timeout'
         })
         // Bootstrap must not stay stuck: stores load even when Firebase never fires.
         expect(settingStore.isReady).toBe(true)

--- a/src/stores/bootstrapStore.ts
+++ b/src/stores/bootstrapStore.ts
@@ -1,11 +1,10 @@
-import { datadogRum } from '@datadog/browser-rum'
-import { captureException } from '@sentry/vue'
 import { until, useAsyncState } from '@vueuse/core'
 import axios from 'axios'
 import { defineStore, storeToRefs } from 'pinia'
 
 import { isCloud } from '@/platform/distribution/types'
 import { useSettingStore } from '@/platform/settings/settingStore'
+import { reportError } from '@/platform/telemetry/reportError'
 import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
 import type { CustomNodesI18n } from '@/schemas/apiSchema'
 import { api } from '@/scripts/api'
@@ -42,7 +41,8 @@ const AUTH_WAIT_RETRY_DELAY_MS = 3_000
  * login redirect for unauthenticated users separately.
  *
  * Retries once after a short delay; if auth is still unresolved, reports it
- * to Sentry and lets bootstrap continue rather than leaving the caller stuck.
+ * to every observability sink and lets bootstrap continue rather than leaving
+ * the caller stuck.
  */
 async function waitForCloudAuth(): Promise<void> {
   const { isInitialized } = storeToRefs(useAuthStore())
@@ -69,14 +69,7 @@ async function waitForCloudAuth(): Promise<void> {
         '[bootstrapStore] Auth still unresolved after retry; continuing bootstrap without confirmed auth',
         retryError
       )
-      const err =
-        retryError instanceof Error ? retryError : new Error(String(retryError))
-      // Report to both Datadog RUM and Sentry so the error surfaces in
-      // whichever observability platform is being monitored.
-      datadogRum.addError(err, { error_type: 'bootstrap_auth_wait_timeout' })
-      captureException(err, {
-        tags: { error_type: 'bootstrap_auth_wait_timeout' }
-      })
+      reportError(retryError, { errorType: 'bootstrap_auth_wait_timeout' })
     }
   }
 }

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -715,9 +715,6 @@ export default defineConfig({
       process.env.npm_package_version
     ),
     __COMFYUI_FRONTEND_COMMIT__: JSON.stringify(GIT_COMMIT),
-    __SENTRY_ENABLED__: JSON.stringify(
-      !(process.env.NODE_ENV === 'development' || !process.env.SENTRY_DSN)
-    ),
     __SENTRY_DSN__: JSON.stringify(process.env.SENTRY_DSN || ''),
     __ALGOLIA_APP_ID__: JSON.stringify(process.env.ALGOLIA_APP_ID || ''),
     __ALGOLIA_API_KEY__: JSON.stringify(process.env.ALGOLIA_API_KEY || ''),

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -110,7 +110,6 @@ declare global {
 
 // Define global variables for tests
 globalThis.__COMFYUI_FRONTEND_VERSION__ = '1.24.0'
-globalThis.__SENTRY_ENABLED__ = false
 globalThis.__SENTRY_DSN__ = ''
 globalThis.__ALGOLIA_APP_ID__ = ''
 globalThis.__ALGOLIA_API_KEY__ = ''


### PR DESCRIPTION
## Summary

`captureException` reaches Sentry only. That is how `workspace_auth_gate_initialization_failure` — one of the two `error_type` values IR-105 is tracked by — fired in production while reading as **zero** on every Datadog dashboard. Only `bootstrap_auth_wait_timeout` dual-wrote, and it did so by hand at the call site.

Adds `reportError(cause, { errorType, tags, context, level })` and migrates all seven call sites onto it. `error_type` lands as a Sentry tag and a RUM context field under the same name, so one query works against either console.

## Two further ways a report could go nowhere

**Build-time flag defeated the runtime DSN.** `Sentry.init({ enabled: __SENTRY_ENABLED__ })` baked the flag from the *build machine's* `SENTRY_DSN`, but cloud resolves its DSN at runtime from remote config (`sentry_dsn`). A cloud build without the env var left every capture in the app inert no matter how valid the runtime DSN turned out to be. `enabled` now derives from the resolved DSN; the dead define is removed rather than left to rot.

**Early-boot reports were dropped.** Datadog RUM initializes behind `initDatadogRum()`'s fire-and-forget dynamic import in `bootstrap.ts` while Sentry initializes in `main.ts`, so a failure raised before either sink existed went nowhere — precisely the failures that leave a user on the splash screen. Reports raised before a sink is live are now buffered (bounded at 25) and flushed once one comes up.

`reportError` never throws: a failing error reporter must not become a second failure.

## Verification

- `src/platform/telemetry/reportError.test.ts` — 8 cases: both-sink fan-out, degraded single-sink, buffer-then-flush, no double-replay, bounded buffer, non-`Error` normalization, `undefined` tag stripping, sink-throws containment.
- Existing suites migrated off the `@sentry/vue` mock onto the `reportError` mock: `bootstrapStore`, `WorkspaceAuthGate`, `useWorkspaceBilling`.
- `pnpm vitest run src/platform/telemetry/ src/platform/cloud/onboarding/auth.test.ts` — 391 passed.
- `pnpm lint`, `pnpm typecheck`, `pnpm knip` clean.

## Regression risk

Low-to-moderate. No behavior change at any call site beyond reaching a second sink. The `enabled` change means Sentry now activates in any non-dev build with a resolvable DSN — which is the intent, but it is the one line worth a close look.

## Follow-ups (not in this PR)

- Boot chunks that 404 never execute JS at all, so no in-app reporter can see them. Needs an inline sentinel in `index.html`.
- The `/` -> `/cloud/login` -> `/cloud/user-check` redirect loop emits neither `error_type` because auth succeeds on every lap. Needs its own instrumentation.