### PR TITLE
chore(risk-map): classify 12 unclassified high-consequence files

### DIFF
--- a/.github/risk.json
+++ b/.github/risk.json
@@ -13,7 +13,6 @@
   ],
   "tiers": ["R0", "R1", "R2", "R3"],
   "default_tier": "R0",
-
   "path_rules": [
     {
       "class": "risk-map",
@@ -81,9 +80,19 @@
       ]
     },
     {
+      "class": "service-endpoints",
+      "tier": "R3",
+      "paths": [
+        "src/config/comfyApi.ts",
+        "src/config/firebase.ts",
+        "src/config/turnstile.ts"
+      ],
+      "why": "Baked in at build time: the api.comfy.org / platform.comfy.org base URLs, the Firebase project credentials and the Turnstile signup sitekey. Pointing a release at the wrong backend or shipping a bad key is not recoverable by a revert alone. Listed as exact files rather than src/config/** so clientFeatureFlags.json stays in the R2 flag lane."
+    },
+    {
       "class": "billing",
       "tier": "R3",
-      "why": "billing / credits — money moves. Scoped to the application source tree: an unscoped **/ token glob matched the marketing site, e2e specs, PNG snapshots, stories, locale files and docs on filename characters alone",
+      "why": "billing / credits \u2014 money moves. Scoped to the application source tree: an unscoped **/ token glob matched the marketing site, e2e specs, PNG snapshots, stories, locale files and docs on filename characters alone Churnkey is the cancellation/retention vendor flow and workspaceApi carries credit limits, credit stops and billing_rail; neither has a money token in its path, so even the scoped globs above cannot see them. workspaceApi.ts is listed exactly rather than as workspaceApi* \u2014 its sibling workspaceApiUrl.ts is a 7-line URL builder, and sweeping it in would reintroduce the over-grading #15415 just removed.",
       "paths": [
         "src/**/billing/**",
         "src/**/pricing/**",
@@ -118,13 +127,15 @@
         "src/config/*pricing*",
         "src/config/*Pricing*",
         "src/config/*subscription*",
-        "src/config/*Subscription*"
+        "src/config/*Subscription*",
+        "src/platform/cloud/churnkey/**",
+        "src/platform/workspace/api/workspaceApi.ts"
       ]
     },
     {
       "class": "workflow-serialization",
       "tier": "R3",
-      "why": "saved user workflows are persistent state — a bad schema or serialize change corrupts files on save and does not cleanly revert",
+      "why": "saved user workflows are persistent state \u2014 a bad schema or serialize change corrupts files on save and does not cleanly revert comfyWorkflow.ts JSON.stringify()s the active graph state and writes it via save({force:true}), so it is a writer of the on-disk format despite sitting outside the persistence tree.",
       "paths": [
         "src/lib/litegraph/src/serialization*",
         "src/lib/litegraph/src/LGraph.ts",
@@ -137,13 +148,14 @@
         "src/platform/workflow/core/services/workflowService.ts",
         "src/platform/workflow/persistence/**",
         "src/platform/workflow/validation/schemas/**",
-        "src/utils/migration/**"
+        "src/utils/migration/**",
+        "src/platform/workflow/management/stores/comfyWorkflow.ts"
       ]
     },
     {
       "class": "extension-contract",
       "tier": "R3",
-      "why": "entity callbacks, node.widgets, serialize and the app/api surface are consumed by 40+ custom-node repos — consumers break out of band (ADR 0003/0008)",
+      "why": "entity callbacks, node.widgets, serialize and the app/api surface are consumed by 40+ custom-node repos \u2014 consumers break out of band (ADR 0003/0008) src/lib/litegraph/src/types/widgets.ts imports Bounds, CompositorWidgetValue and CurveData from these three modules, so they enter the @comfyorg/comfyui-frontend-types rollup (rollupTypes: true) and are part of the published surface even though they do not live under a schemas/ path.",
       "paths": [
         "packages/comfyui-desktop-bridge-types/**",
         "packages/*/src/schemas/**",
@@ -166,7 +178,10 @@
         "src/lib/litegraph/src/LGraph.ts",
         "src/lib/litegraph/src/LGraphNode.ts",
         "src/lib/litegraph/src/LGraphCanvas.ts",
-        "src/lib/litegraph/src/subgraph/**"
+        "src/lib/litegraph/src/subgraph/**",
+        "src/renderer/core/layout/types.ts",
+        "src/renderer/extensions/compositor/components/types.ts",
+        "src/components/curve/types.ts"
       ]
     },
     {
@@ -179,11 +194,10 @@
         "src/schemas/nodeDefSchema.ts"
       ]
     },
-
     {
       "class": "flag-defaults",
       "tier": "R2",
-      "why": "the flag config and flag plumbing are the rollout lever — flipping a default changes behavior for every user at once",
+      "why": "the flag config and flag plumbing are the rollout lever \u2014 flipping a default changes behavior for every user at once",
       "paths": [
         "src/config/clientFeatureFlags.json",
         "**/useFeatureFlags*",
@@ -205,7 +219,7 @@
     {
       "class": "core-infra",
       "tier": "R2",
-      "why": "cross-cutting state, API layer, routing, bootstrap, canvas engine and published packages — blast radius is every feature, and packages/** breaks consumers out of band",
+      "why": "cross-cutting state, API layer, routing, bootstrap, canvas engine and published packages \u2014 blast radius is every feature, and packages/** breaks consumers out of band",
       "paths": [
         "src/stores/**",
         "src/services/**",
@@ -221,10 +235,9 @@
     {
       "class": "website",
       "tier": "R2",
-      "why": "the marketing site is production and had no rule at all — but it is copy and layout, so it cannot corrupt a saved workflow or move money",
+      "why": "the marketing site is production and had no rule at all \u2014 but it is copy and layout, so it cannot corrupt a saved workflow or move money",
       "paths": ["apps/website/**"]
     },
-
     {
       "class": "docs",
       "tier": "R0",
@@ -260,14 +273,12 @@
       ]
     }
   ],
-
   "provenance_tiers": {
     "runbook": "R0",
     "agent-supervised": "R1",
     "human": "R1",
     "external": "R3"
   },
-
   "reversibility": {
     "irreversible_classes": ["workflow-serialization", "secrets"],
     "delete_sensitive_classes": [
@@ -292,7 +303,6 @@
       "**/testdata/**"
     ]
   },
-
   "flippable_flag_paths": [
     "**/useFeatureFlags*",
     "**/useVueFeatureFlags*",


### PR DESCRIPTION
## What

Twelve files currently match **no path rule** in `.github/risk.json` and fall through to `default_tier: R0`. Each one is high-consequence. This classifies them and nothing else.

Found while running the map over the whole tree to see what `R0` was actually covering — the map is new (#14889) so this is coverage feedback, not a criticism of it.

## The twelve

| files | class | why they were invisible |
| --- | --- | --- |
| `src/config/{comfyApi,firebase,turnstile}.ts` | **`service-endpoints`** (new, R3) | Bake in the `api.comfy.org` / `platform.comfy.org` base URLs, the Firebase project credentials and the Turnstile signup sitekey at build time |
| `src/platform/cloud/churnkey/**`<br>`src/platform/workspace/api/workspaceApi*` | `billing` (R3) | The existing `billing` globs match on filename tokens (`**/billing/**`, `**/pricing/**`, `**/credits/**`). Neither of these has a money word in its path |
| `src/platform/workflow/management/stores/comfyWorkflow.ts` | `workflow-serialization` (R3) | Lives outside the covered `workflow/persistence/**` |
| `src/renderer/core/layout/types.ts`<br>`src/renderer/extensions/compositor/components/types.ts`<br>`src/components/curve/types.ts` | `extension-contract` (R3) | Do not sit under a `schemas/` path |

Evidence for the two least obvious:

**`comfyWorkflow.ts` is a writer of the on-disk format.**
```ts
// src/platform/workflow/management/stores/comfyWorkflow.ts:172
this.content = JSON.stringify(this.activeState)
// :175
const ret = await super.save({ force: true })
```

**The three `types.ts` modules ship to consumers.** `src/lib/litegraph/src/types/widgets.ts` opens with:
```ts
import type { Bounds } from '@/renderer/core/layout/types'
import type { CompositorWidgetValue } from '@/renderer/extensions/compositor/components/types'
import type { CurveData } from '@/components/curve/types'
```
litegraph reaches `src/types/index.ts`, which is the `rollupTypes: true` entry for the published `@comfyorg/comfyui-frontend-types`. So these are part of the published surface.

**`workspaceApi` is money code.** `subscribe()` sends `team_credit_stop_id` and `billing_cycle`; the module carries credit limits and `billing_rail`.

## Verification

Applied the map to all **5553 tracked files**, before and after:

```
5553 tracked files; 12 change tier

  R0 -> R3  extension-contract     src/components/curve/types.ts
  R0 -> R3  service-endpoints      src/config/comfyApi.ts
  R0 -> R3  service-endpoints      src/config/firebase.ts
  R0 -> R3  service-endpoints      src/config/turnstile.ts
  R0 -> R3  billing                src/platform/cloud/churnkey/churnkeyClient.test.ts
  R0 -> R3  billing                src/platform/cloud/churnkey/churnkeyClient.ts
  R0 -> R3  billing                src/platform/cloud/churnkey/types.ts
  R0 -> R3  workflow-serialization src/platform/workflow/management/stores/comfyWorkflow.ts
  R0 -> R3  billing                src/platform/workspace/api/workspaceApi.test.ts
  R0 -> R3  billing                src/platform/workspace/api/workspaceApi.ts
  R0 -> R3  extension-contract     src/renderer/core/layout/types.ts
  R0 -> R3  extension-contract     src/renderer/extensions/compositor/components/types.ts

✓ no downgrades
```

Nothing else in the repo changes tier. JSON parses; `prettier --check` clean.

## Two things worth your call

**1. Two colocated test files inherit R3** (`churnkeyClient.test.ts`, `workspaceApi.test.ts`), so a test-only change to them now grades R3. The map's globs have no negation, so "tests are R0 regardless of tree" is not expressible — this is pre-existing (285 files already match the R0 `tests` rule and still floor R2/R3 because a co-matching rule wins), not something this PR introduces. Happy to narrow to exact non-test filenames if you'd rather, though that's more brittle.

**2. I deliberately did not do the big coverage expansion.** 2316 of 5551 tracked files still match no rule. I drafted rules taking that to 98% and then measured the effect: over the risk-labeled PRs merged since the map landed, adding R2 rules for every unclassified app tree moves **one** PR's label — the provenance axis already floors a human PR at R1, and `core-infra` R2 dominates via `worst()`. So the static gap is large and the operational gap is not, and padding the map would dilute it rather than serve it. These twelve are different: they are all R3, and R3 is the tier that actually changes what a reviewer sees.

Separately, and not for this PR: an R0 *rule* can never bind, because the floor is a `worst()` starting from `default_tier: R0`. That makes `default_tier: R0` the only place R0 has force, and it spends it making unmapped paths the safest thing in the file — which is what let 42% of the tree read as "safe" when it meant "unknown". Worth a conversation about `default_tier: R1`, but that is a repo-wide decision, not a drive-by.
