### PR TITLE
ci: make Codecov project coverage informational

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -3,6 +3,9 @@ coverage:
     patch:
       default:
         informational: true
+    project:
+      default:
+        informational: true
 
 comment:
   layout: 'header, diff, flags, files'

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -12,7 +12,12 @@ const config: KnipConfig = {
         'src/types/index.ts',
         'src/storybook/mocks/**/*.ts'
       ],
-      project: ['**/*.{js,ts,vue}', '*.{js,ts,mts}', '!.claude/**']
+      project: [
+        '**/*.{js,ts,vue}',
+        '*.{js,ts,mts}',
+        '!.claude/**',
+        '!worktrees/**'
+      ]
     },
     'apps/desktop-ui': {
       entry: ['src/i18n.ts'],


### PR DESCRIPTION
## Summary

- Add `coverage.status.project.default.informational: true` to `codecov.yml` — the `codecov/project` status check was using Codecov's default blocking threshold, failing all PRs when overall repo coverage dropped
- The `codecov/patch` status was already informational (#13768); this extends the same treatment to the project-level check
- Also exclude `worktrees/**` from knip's project glob so local git worktrees don't produce false-positive "unused files" errors in the pre-push hook

## Root cause

Codecov creates two separate status checks: `codecov/patch` (diff coverage) and `codecov/project` (overall repo coverage). Only patch was set to informational; project was left at the blocking default, which fails PRs when overall coverage drops.