### PR TITLE
fix(website): make the locale prop required so a missed locale cannot fail silently

### DIFF
--- a/.github/workflows/ci-website-build.yaml
+++ b/.github/workflows/ci-website-build.yaml
@@ -36,7 +36,10 @@ jobs:
         uses: ./.github/actions/setup-frontend
 
       - name: Typecheck website
-        run: pnpm --filter @comfyorg/website typecheck
+        run: pnpm typecheck:website
+
+      - name: Validate locale props
+        run: pnpm --filter @comfyorg/website validate:locale
 
       - name: Build website
         env:

--- a/apps/website/e2e/fdct.spec.ts
+++ b/apps/website/e2e/fdct.spec.ts
@@ -14,7 +14,7 @@ import { test } from './fixtures/blockExternalMedia'
 // one snapshot; localized fields (titles, descriptions, tags) are asserted per
 // locale. The Featured projects grid is its own curated list, independent of
 // the technologist dialogs.
-const projects = featuredProjectsOf()
+const projects = featuredProjectsOf('en')
 const technologists = technologistsOf('en')
 
 const builderReasonKeys = [

--- a/apps/website/e2e/locale.spec.ts
+++ b/apps/website/e2e/locale.spec.ts
@@ -78,12 +78,9 @@ test.describe('locale propagation', () => {
         page.getByText(line, { exact: false }).first()
       ).toBeAttached()
     }
-    await expect(
-      page.getByText(t('hero.subtitle', 'zh-CN'), { exact: false }).first()
-    ).toBeAttached()
-    await expect(
-      page.getByText(t('hero.subtitle', 'en'), { exact: false })
-    ).toHaveCount(0)
+    for (const line of t('hero.title', 'en').split('\n')) {
+      await expect(page.getByText(line, { exact: false })).toHaveCount(0)
+    }
   })
 
   test('a component nested inside another component forwards the locale', async ({

--- a/apps/website/e2e/locale.spec.ts
+++ b/apps/website/e2e/locale.spec.ts
@@ -1,0 +1,106 @@
+import { expect } from '@playwright/test'
+import type { Page } from '@playwright/test'
+
+import type { Locale } from '../src/i18n/translations'
+import { t } from '../src/i18n/translations'
+import { test } from './fixtures/blockExternalMedia'
+
+/**
+ * Every Vue island is its own app root, so each one receives the active locale
+ * as a prop. A missed prop used to render English instead of failing; these
+ * specs assert the rendered symptom so a regression cannot reach production
+ * silently.
+ */
+const ZH_ROUTES = [
+  '/zh-CN/',
+  '/zh-CN/about',
+  '/zh-CN/api',
+  '/zh-CN/cloud/',
+  '/zh-CN/cloud/pricing',
+  '/zh-CN/customers',
+  '/zh-CN/download',
+  '/zh-CN/gallery',
+  '/zh-CN/mcp',
+  '/zh-CN/wan-3.0'
+] as const
+
+const EN_ROUTES = ['/', '/cloud/', '/download'] as const
+
+/** Site-wide chrome: present on every page, and translated in both locales. */
+const CHROME_KEYS = [
+  'nav.products',
+  'nav.pricing',
+  'nav.community',
+  'nav.company',
+  'footer.company',
+  'footer.about'
+] as const
+
+async function expectChromeLocale(page: Page, locale: Locale) {
+  const other: Locale = locale === 'en' ? 'zh-CN' : 'en'
+
+  for (const key of CHROME_KEYS) {
+    await expect(
+      page.getByText(t(key, locale), { exact: true }).first()
+    ).toBeAttached()
+    await expect(page.getByText(t(key, other), { exact: true })).toHaveCount(0)
+  }
+}
+
+test.describe('locale propagation', () => {
+  for (const route of ZH_ROUTES) {
+    test(`${route} renders zh-CN chrome, not the English fallback`, async ({
+      page
+    }) => {
+      await page.goto(route)
+
+      await expect(page.locator('html')).toHaveAttribute('lang', 'zh-CN')
+      await expectChromeLocale(page, 'zh-CN')
+    })
+  }
+
+  for (const route of EN_ROUTES) {
+    test(`${route} renders en chrome`, async ({ page }) => {
+      await page.goto(route)
+
+      await expect(page.locator('html')).toHaveAttribute('lang', 'en')
+      await expectChromeLocale(page, 'en')
+    })
+  }
+
+  test('a deeply nested island receives the locale, not just the layout', async ({
+    page
+  }) => {
+    await page.goto('/zh-CN/')
+
+    for (const line of t('hero.title', 'zh-CN').split('\n')) {
+      await expect(
+        page.getByText(line, { exact: false }).first()
+      ).toBeAttached()
+    }
+    await expect(
+      page.getByText(t('hero.subtitle', 'zh-CN'), { exact: false }).first()
+    ).toBeAttached()
+    await expect(
+      page.getByText(t('hero.subtitle', 'en'), { exact: false })
+    ).toHaveCount(0)
+  })
+
+  test('a component nested inside another component forwards the locale', async ({
+    page
+  }) => {
+    await page.goto('/zh-CN/about')
+
+    // VideoPlayer is nested several components deep; its controls are only
+    // localized when every ancestor forwards `locale` down.
+    const localizedControl = page.locator(
+      `[aria-label="${t('player.fullscreen', 'zh-CN')}"]`
+    )
+    const englishControl = page.locator(
+      `[aria-label="${t('player.fullscreen', 'en')}"]`
+    )
+
+    await expect(localizedControl.first()).toBeAttached()
+    await expect(englishControl).toHaveCount(0)
+  })
+})

--- a/apps/website/e2e/minimax-license-professional-request.spec.ts
+++ b/apps/website/e2e/minimax-license-professional-request.spec.ts
@@ -5,7 +5,7 @@ import { t } from '../src/i18n/translations'
 import { test } from './fixtures/blockExternalMedia'
 
 const PATH = getRoutes('en').minimaxLicenseProfessionalRequest
-const TITLE = t('minimaxLicense.professionalRequest.title')
+const TITLE = t('minimaxLicense.professionalRequest.title', 'en')
 const HUBSPOT_FORM_ID = '40ef858c-374a-4958-8180-bfa54f0a67fb'
 const HUBSPOT_SCRIPT_SRC =
   'https://js-na2.hsforms.net/forms/embed/developer/244637579.js'
@@ -42,7 +42,7 @@ test.describe('MiniMax professional license request page @smoke', () => {
   test('links back to the license page for the terms', async ({ page }) => {
     await expect(
       page.getByRole('link', {
-        name: t('minimaxLicense.professionalRequest.introCta')
+        name: t('minimaxLicense.professionalRequest.introCta', 'en')
       })
     ).toHaveAttribute('href', getRoutes('en').minimaxLicense)
   })

--- a/apps/website/e2e/minimax-license.spec.ts
+++ b/apps/website/e2e/minimax-license.spec.ts
@@ -7,13 +7,13 @@ import { test } from './fixtures/blockExternalMedia'
 const PATH = '/minimax/license'
 const ZH_PATH = '/zh-CN/minimax/license'
 const CONTACT_HREF = 'https://comfy.org/contact'
-const META_TITLE = t('minimaxLicense.meta.title')
-const HERO_TITLE = t('minimaxLicense.hero.title')
-const HERO_CTA = t('minimaxLicense.hero.primaryCta')
+const META_TITLE = t('minimaxLicense.meta.title', 'en')
+const HERO_TITLE = t('minimaxLicense.hero.title', 'en')
+const HERO_CTA = t('minimaxLicense.hero.primaryCta', 'en')
 const HERO_VIDEO_PATTERN = /minimax-license\/hero\.mp4/
-const STEPS_HEADING = t('minimaxLicense.steps.heading')
-const FAQ_HEADING = t('minimaxLicense.faq.heading')
-const CLOSING_HEADING = t('minimaxLicense.cta.heading')
+const STEPS_HEADING = t('minimaxLicense.steps.heading', 'en')
+const FAQ_HEADING = t('minimaxLicense.faq.heading', 'en')
+const CLOSING_HEADING = t('minimaxLicense.cta.heading', 'en')
 
 test.describe('MiniMax license page @smoke', () => {
   test.beforeEach(async ({ page }) => {
@@ -61,14 +61,14 @@ test.describe('MiniMax license page @smoke', () => {
       .filter({
         has: page.getByRole('heading', { level: 2, name: CLOSING_HEADING })
       })
-      .getByRole('link', { name: t('minimaxLicense.cta.primaryCta') })
+      .getByRole('link', { name: t('minimaxLicense.cta.primaryCta', 'en') })
     await expect(closing).toHaveAttribute('href', CONTACT_HREF)
   })
 
   test('footer links back to this page', async ({ page }) => {
     const footerLink = page
       .locator('footer')
-      .getByRole('link', { name: t('footer.minimaxLicense') })
+      .getByRole('link', { name: t('footer.minimaxLicense', 'en') })
     await expect(footerLink).toHaveAttribute(
       'href',
       getRoutes('en').minimaxLicense

--- a/apps/website/e2e/wan-3.0.spec.ts
+++ b/apps/website/e2e/wan-3.0.spec.ts
@@ -8,12 +8,12 @@ import { waitForIsland } from './fixtures/islands'
 
 const PATH = '/wan-3.0'
 const ZH_PATH = '/zh-CN/wan-3.0'
-const HERO_TITLE = t('wan3.hero.title')
-const HERO_CTA = t('wan3.hero.primaryCta')
-const HERO_SECONDARY_CTA = t('wan3.hero.secondaryCta')
-const FAQ_HEADING = t('wan3.faq.heading')
-const RUN_OPTIONS_HEADING = t('wan3.runOptions.heading')
-const REVIEWS_HEADING = t('wan3.reviews.heading')
+const HERO_TITLE = t('wan3.hero.title', 'en')
+const HERO_CTA = t('wan3.hero.primaryCta', 'en')
+const HERO_SECONDARY_CTA = t('wan3.hero.secondaryCta', 'en')
+const FAQ_HEADING = t('wan3.faq.heading', 'en')
+const RUN_OPTIONS_HEADING = t('wan3.runOptions.heading', 'en')
+const REVIEWS_HEADING = t('wan3.reviews.heading', 'en')
 const MODELS_ROUTE = getRoutes('en').models
 const WAN3_TEMPLATE = 'https://cloud.comfy.org/?template=api_wan3_0_t2v'
 
@@ -26,9 +26,9 @@ const REQUIRED_FAQS = 6
 // exactly means a duplicate, dropped or off-brief badge (e.g. an open-weights
 // claim) fails rather than slipping past a bare count.
 const REQUIRED_BADGE_LABELS = [
-  t('wan3.hero.tagImageToVideo'),
-  t('wan3.hero.tagTextToVideo'),
-  t('wan3.hero.tagReferenceToVideo')
+  t('wan3.hero.tagImageToVideo', 'en'),
+  t('wan3.hero.tagTextToVideo', 'en'),
+  t('wan3.hero.tagReferenceToVideo', 'en')
 ]
 
 const FAQ_SECTION = wan3Page.faq
@@ -44,7 +44,7 @@ test.describe('Wan 3.0 launch page @smoke', () => {
     await expect(
       page.getByRole('heading', { level: 1, name: HERO_TITLE })
     ).toBeVisible()
-    await expect(page.getByText(t('wan3.hero.description'))).toBeVisible()
+    await expect(page.getByText(t('wan3.hero.description', 'en'))).toBeVisible()
     await expect(page.locator('meta[name="robots"]')).toHaveCount(0)
   })
 
@@ -81,15 +81,15 @@ test.describe('Wan 3.0 launch page @smoke', () => {
 
   test('breadcrumb trail links to the models catalog', async ({ page }) => {
     const modelsCrumb = page
-      .getByRole('navigation', { name: t('ui.breadcrumb') })
-      .getByRole('link', { name: t('models.breadcrumb.models') })
+      .getByRole('navigation', { name: t('ui.breadcrumb', 'en') })
+      .getByRole('link', { name: t('models.breadcrumb.models', 'en') })
     await expect(modelsCrumb).toHaveAttribute('href', MODELS_ROUTE)
   })
 
   test('footer links back to this page', async ({ page }) => {
     const footerLink = page
       .locator('footer')
-      .getByRole('link', { name: t('footer.wan3') })
+      .getByRole('link', { name: t('footer.wan3', 'en') })
     await expect(footerLink).toHaveAttribute('href', getRoutes('en').wan3)
   })
 

--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -19,7 +19,8 @@
     "cloud-nodes:refresh-snapshot": "tsx ./scripts/refresh-cloud-nodes-snapshot.ts",
     "generate:models": "tsx ./scripts/generate-models.ts",
     "validate:jsonld": "tsx ./scripts/validate-jsonld.ts",
-    "validate:llms-txt-links": "tsx ./scripts/validate-llms-txt-links.ts"
+    "validate:llms-txt-links": "tsx ./scripts/validate-llms-txt-links.ts",
+    "validate:locale": "tsx ./scripts/validate-locale-props.ts"
   },
   "dependencies": {
     "@astrojs/sitemap": "catalog:",

--- a/apps/website/scripts/validate-locale-props.ts
+++ b/apps/website/scripts/validate-locale-props.ts
@@ -2,7 +2,7 @@ import { readFileSync, readdirSync } from 'node:fs'
 import { dirname, join, relative, resolve, sep } from 'node:path'
 
 const SRC_DIR = join(process.cwd(), 'src')
-const LOCALES = ['en', 'zh-CN'] as const
+const LOCALES = ['en', 'zh-CN', 'ja'] as const
 const DEFAULT_LOCALE = 'en'
 
 type Locale = (typeof LOCALES)[number]
@@ -138,8 +138,9 @@ function lineOf(source: string, index: number): number {
 }
 
 /**
- * The locale a page renders in, derived from its path: `pages/zh-CN/**` is
- * `zh-CN`, everything else under `pages/` is the unprefixed default locale.
+ * The locale a page renders in, derived from its path: localized directories
+ * use their matching locale, while everything else under `pages/` uses the
+ * unprefixed default locale.
  * Shared components live outside `pages/` and inherit their caller's locale,
  * so they have no fixed locale and return `undefined`.
  */

--- a/apps/website/scripts/validate-locale-props.ts
+++ b/apps/website/scripts/validate-locale-props.ts
@@ -1,0 +1,230 @@
+import { readFileSync, readdirSync } from 'node:fs'
+import { dirname, join, relative, resolve, sep } from 'node:path'
+
+const SRC_DIR = join(process.cwd(), 'src')
+const LOCALES = ['en', 'zh-CN'] as const
+const DEFAULT_LOCALE = 'en'
+
+type Locale = (typeof LOCALES)[number]
+
+interface Violation {
+  file: string
+  line: number
+  message: string
+}
+
+interface ComponentUsage {
+  name: string
+  target: string
+  line: number
+  attributes: string
+}
+
+const LOCALE_PROP_DECLARATION = /\blocale\??\s*:\s*Locale\b/
+const IMPORT_STATEMENT =
+  /import\s+(\w+)\s+from\s+['"]([^'"]+\.(?:vue|astro))['"]/g
+/**
+ * `locale="en"`, `:locale="locale"`, Vue's same-name shorthand `:locale`, and
+ * Astro's shorthand `{locale}` all count as passing the prop.
+ */
+const LOCALE_ATTRIBUTE =
+  /(?:^|\s)(?:(?::|v-bind:)locale(?![\w-])|locale\s*=)|\{\s*locale\s*\}/
+const SPREAD_ATTRIBUTE = /\{\s*\.\.\.|v-bind\s*=/
+const LOCALE_LITERAL = /(?:^|\s)locale\s*=\s*(?:'([^']*)'|"([^"]*)")/
+
+function sourceFiles(): string[] {
+  return readdirSync(SRC_DIR, { recursive: true })
+    .map(String)
+    .filter((entry) => entry.endsWith('.vue') || entry.endsWith('.astro'))
+    .map((entry) => join(SRC_DIR, entry))
+}
+
+/**
+ * The region of a file that renders markup. Imports live outside it, and
+ * scanning only this region keeps TypeScript generics (`Foo<Bar>`) from
+ * registering as component usages.
+ */
+function templateOf(
+  source: string,
+  file: string
+): { text: string; offset: number } {
+  if (file.endsWith('.astro')) {
+    const fence = /^---\r?\n[\s\S]*?\r?\n---/.exec(source)
+    const offset = fence ? fence[0].length : 0
+    return { text: source.slice(offset), offset }
+  }
+
+  const open = source.indexOf('<template')
+  const close = source.lastIndexOf('</template>')
+  if (open === -1 || close === -1) return { text: '', offset: 0 }
+  return { text: source.slice(open, close), offset: open }
+}
+
+function declaresLocaleProp(source: string, file: string): boolean {
+  if (file.endsWith('.astro')) {
+    const fence = /^---\r?\n([\s\S]*?)\r?\n---/.exec(source)
+    return fence ? LOCALE_PROP_DECLARATION.test(fence[1]) : false
+  }
+  const { offset } = templateOf(source, file)
+  const scripts = offset > 0 ? source.slice(0, offset) : source
+  return LOCALE_PROP_DECLARATION.test(scripts)
+}
+
+function importedComponents(source: string, file: string): Map<string, string> {
+  const imports = new Map<string, string>()
+  for (const [, name, specifier] of source.matchAll(IMPORT_STATEMENT)) {
+    imports.set(name, resolve(dirname(file), specifier))
+  }
+  return imports
+}
+
+/**
+ * Attributes of the opening tag starting at `start`. Quote and brace tracking
+ * keeps `>` inside an expression (`count={a > b}`) from ending the tag early.
+ */
+function openingTagAttributes(text: string, start: number): string {
+  let quote: string | null = null
+  let depth = 0
+
+  for (let index = start; index < text.length; index++) {
+    const char = text[index]
+
+    if (quote) {
+      if (char === quote) quote = null
+      continue
+    }
+    if (char === '"' || char === "'" || char === '`') {
+      quote = char
+      continue
+    }
+    if (char === '{') depth++
+    else if (char === '}') depth--
+    else if (char === '>' && depth === 0) {
+      return text.slice(start, text[index - 1] === '/' ? index - 1 : index)
+    }
+  }
+  return text.slice(start)
+}
+
+function componentUsages(
+  source: string,
+  file: string,
+  imports: Map<string, string>
+): ComponentUsage[] {
+  const { text, offset } = templateOf(source, file)
+  const usages: ComponentUsage[] = []
+
+  for (const match of text.matchAll(/<([A-Z]\w*)/g)) {
+    const target = imports.get(match[1])
+    if (!target || match.index === undefined) continue
+
+    const attributesStart = match.index + match[0].length
+    usages.push({
+      name: match[1],
+      target,
+      line: lineOf(source, offset + match.index),
+      attributes: openingTagAttributes(text, attributesStart)
+    })
+  }
+  return usages
+}
+
+function lineOf(source: string, index: number): number {
+  let line = 1
+  for (let cursor = 0; cursor < index; cursor++) {
+    if (source[cursor] === '\n') line++
+  }
+  return line
+}
+
+/**
+ * The locale a page renders in, derived from its path: `pages/zh-CN/**` is
+ * `zh-CN`, everything else under `pages/` is the unprefixed default locale.
+ * Shared components live outside `pages/` and inherit their caller's locale,
+ * so they have no fixed locale and return `undefined`.
+ */
+function pageLocale(file: string): Locale | undefined {
+  const segments = relative(SRC_DIR, file).split(sep)
+  if (segments[0] !== 'pages') return undefined
+
+  const prefixed = LOCALES.find(
+    (locale) => locale !== DEFAULT_LOCALE && segments[1] === locale
+  )
+  return prefixed ?? DEFAULT_LOCALE
+}
+
+function main(): void {
+  const files = sourceFiles()
+  const sources = new Map(
+    files.map((file) => [file, readFileSync(file, 'utf8')])
+  )
+
+  const localeAware = new Set(
+    files.filter((file) => declaresLocaleProp(sources.get(file)!, file))
+  )
+
+  const violations: Violation[] = []
+
+  for (const file of files) {
+    const source = sources.get(file)!
+    const expected = pageLocale(file)
+    const usages = componentUsages(
+      source,
+      file,
+      importedComponents(source, file)
+    )
+
+    for (const usage of usages) {
+      if (!localeAware.has(usage.target)) continue
+
+      const { attributes } = usage
+      if (!LOCALE_ATTRIBUTE.test(attributes)) {
+        if (SPREAD_ATTRIBUTE.test(attributes)) continue
+        violations.push({
+          file,
+          line: usage.line,
+          message: `<${usage.name}> renders localized text but receives no \`locale\` prop`
+        })
+        continue
+      }
+
+      const literal = LOCALE_LITERAL.exec(attributes)
+      const passed = literal?.[1] ?? literal?.[2]
+      if (passed && expected && passed !== expected) {
+        violations.push({
+          file,
+          line: usage.line,
+          message: `<${usage.name}> is passed locale="${passed}" on a ${expected} page`
+        })
+      }
+    }
+  }
+
+  if (localeAware.size === 0) {
+    console.error(
+      'Locale prop validation found no locale-aware components, which means\ndetection is broken rather than the tree being clean. Failing loudly.'
+    )
+    process.exit(1)
+  }
+
+  if (violations.length > 0) {
+    console.error(
+      `Locale prop validation failed (${violations.length} violation${violations.length === 1 ? '' : 's'}):\n`
+    )
+    for (const violation of violations) {
+      console.error(
+        `  ${relative(process.cwd(), violation.file)}:${violation.line}\n    ${violation.message}`
+      )
+    }
+    console.error(
+      '\nEvery component that renders translated text needs the active locale.\nPass it explicitly: <Section locale="zh-CN" /> or :locale="locale".'
+    )
+    process.exit(1)
+  }
+
+  console.log(
+    `Locale props valid: ${localeAware.size} locale-aware components, ${files.length} files scanned.`
+  )
+}
+
+main()

--- a/apps/website/scripts/validate-locale-props.ts
+++ b/apps/website/scripts/validate-locale-props.ts
@@ -154,19 +154,20 @@ function pageLocale(file: string): Locale | undefined {
 }
 
 function main(): void {
-  const files = sourceFiles()
-  const sources = new Map(
-    files.map((file) => [file, readFileSync(file, 'utf8')])
-  )
+  const sources = sourceFiles().map((file) => ({
+    file,
+    source: readFileSync(file, 'utf8')
+  }))
 
   const localeAware = new Set(
-    files.filter((file) => declaresLocaleProp(sources.get(file)!, file))
+    sources
+      .filter(({ file, source }) => declaresLocaleProp(source, file))
+      .map(({ file }) => file)
   )
 
   const violations: Violation[] = []
 
-  for (const file of files) {
-    const source = sources.get(file)!
+  for (const { file, source } of sources) {
     const expected = pageLocale(file)
     const usages = componentUsages(
       source,
@@ -179,11 +180,15 @@ function main(): void {
 
       const { attributes } = usage
       if (!LOCALE_ATTRIBUTE.test(attributes)) {
-        if (SPREAD_ATTRIBUTE.test(attributes)) continue
+        // A spread may carry `locale`, but then it is invisible to this check
+        // and to a reader. Require it to be named.
+        const via = SPREAD_ATTRIBUTE.test(attributes)
+          ? 'receives `locale` only via a spread, which hides it from review'
+          : 'receives no `locale` prop'
         violations.push({
           file,
           line: usage.line,
-          message: `<${usage.name}> renders localized text but receives no \`locale\` prop`
+          message: `<${usage.name}> renders localized text but ${via}`
         })
         continue
       }
@@ -222,8 +227,8 @@ function main(): void {
     process.exit(1)
   }
 
-  console.log(
-    `Locale props valid: ${localeAware.size} locale-aware components, ${files.length} files scanned.`
+  process.stdout.write(
+    `Locale props valid: ${localeAware.size} locale-aware components, ${sources.length} files scanned.\n`
   )
 }
 

--- a/apps/website/src/components/about/CareersSection.vue
+++ b/apps/website/src/components/about/CareersSection.vue
@@ -6,7 +6,7 @@ import BrandButton from '../common/BrandButton.vue'
 import GlassCard from '../common/GlassCard.vue'
 import SectionLabel from '../common/SectionLabel.vue'
 
-const { locale = 'en' } = defineProps<{ locale?: Locale }>()
+const { locale } = defineProps<{ locale: Locale }>()
 </script>
 
 <template>
@@ -18,7 +18,7 @@ const { locale = 'en' } = defineProps<{ locale?: Locale }>()
       <div class="aspect-video w-full overflow-hidden rounded-4xl lg:w-1/2">
         <img
           src="https://media.comfy.org/website/about/team.webp"
-          alt="Comfy team"
+          :alt="t('ui.alt.comfyTeam', locale)"
           class="size-full object-cover"
           loading="lazy"
           decoding="async"

--- a/apps/website/src/components/about/HeroSection.vue
+++ b/apps/website/src/components/about/HeroSection.vue
@@ -8,7 +8,7 @@ import BrandButton from '../common/BrandButton.vue'
 import SectionLabel from '../common/SectionLabel.vue'
 import VideoPlayer from '../common/VideoPlayer.vue'
 
-const { locale = 'en' } = defineProps<{ locale?: Locale }>()
+const { locale } = defineProps<{ locale: Locale }>()
 
 const sectionRef = ref<HTMLElement>()
 const logoRef = ref<HTMLElement>()
@@ -38,7 +38,7 @@ useHeroAnimation({
       >
         <img
           src="https://media.comfy.org/website/about/c.webp"
-          alt="Comfy 3D logo"
+          :alt="t('ui.alt.comfy3dLogo', locale)"
           class="mx-auto w-full max-w-md lg:max-w-none"
         />
       </div>

--- a/apps/website/src/components/about/OurValuesSection.vue
+++ b/apps/website/src/components/about/OurValuesSection.vue
@@ -5,7 +5,7 @@ import { t } from '../../i18n/translations'
 import NodeBadge from '../common/NodeBadge.vue'
 import SectionLabel from '../common/SectionLabel.vue'
 
-const { locale = 'en' } = defineProps<{ locale?: Locale }>()
+const { locale } = defineProps<{ locale: Locale }>()
 
 type TranslationKey = Parameters<typeof t>[0]
 

--- a/apps/website/src/components/about/StorySection.vue
+++ b/apps/website/src/components/about/StorySection.vue
@@ -3,7 +3,7 @@ import type { Locale } from '../../i18n/translations'
 
 import { t } from '../../i18n/translations'
 
-const { locale = 'en' } = defineProps<{ locale?: Locale }>()
+const { locale } = defineProps<{ locale: Locale }>()
 
 const investors = [
   { name: 'CRAFT', icon: '/icons/investors/craft.svg' },
@@ -48,7 +48,7 @@ const investors = [
           <span
             class="bg-primary-comfy-yellow text-primary-comfy-ink flex h-full items-center px-2 text-sm font-bold tracking-wider"
           >
-            OUR
+            {{ t('about.story.investorsLabelPrefix', locale) }}
           </span>
         </div>
         <!-- Union connector (overlaps both badges to eliminate seams) -->
@@ -62,7 +62,7 @@ const investors = [
           <span
             class="bg-primary-comfy-yellow text-primary-comfy-ink flex h-full items-center px-3 text-lg font-bold tracking-wider"
           >
-            INVESTORS
+            {{ t('about.story.investorsLabelNoun', locale) }}
           </span>
           <img src="/icons/node-right.svg" alt="" class="h-full w-auto" />
         </div>

--- a/apps/website/src/components/about/ValuesSection.vue
+++ b/apps/website/src/components/about/ValuesSection.vue
@@ -19,7 +19,7 @@ const reasons: TranslationKey[] = [
       <template #right-card>
         <img
           src="https://media.comfy.org/website/about/c-logo.webp"
-          alt="Comfy logo"
+          :alt="t('ui.alt.comfyLogo', locale)"
           loading="lazy"
           decoding="async"
           class="mt-6 aspect-square w-full object-contain"
@@ -28,7 +28,7 @@ const reasons: TranslationKey[] = [
       <template #right-card-mobile>
         <img
           src="https://media.comfy.org/website/about/c-logo.webp"
-          alt="Comfy logo"
+          :alt="t('ui.alt.comfyLogo', locale)"
           loading="lazy"
           decoding="async"
           class="mt-6 aspect-square w-full max-w-xs object-contain"

--- a/apps/website/src/components/about/ValuesSection.vue
+++ b/apps/website/src/components/about/ValuesSection.vue
@@ -1,9 +1,10 @@
 <script setup lang="ts">
 import type { Locale, TranslationKey } from '../../i18n/translations'
+import { t } from '../../i18n/translations'
 
 import WireNodeLayout from '../common/WireNodeLayout.vue'
 
-const { locale = 'en' } = defineProps<{ locale?: Locale }>()
+const { locale } = defineProps<{ locale: Locale }>()
 
 const reasons: TranslationKey[] = [
   'about.careers.reason1',

--- a/apps/website/src/components/blocks/AddToCalendarButton.vue
+++ b/apps/website/src/components/blocks/AddToCalendarButton.vue
@@ -23,12 +23,12 @@ import Button from '../ui/button/Button.vue'
 
 const {
   event,
-  locale = 'en',
+  locale,
   size = 'lg',
   portalDisabled = false
 } = defineProps<{
   event: CalendarEvent
-  locale?: Locale
+  locale: Locale
   size?: ButtonVariants['size']
   /** Render the menu in place, e.g. inside a top-layer `<dialog>` that would
    * cover a body teleport. */

--- a/apps/website/src/components/blocks/CardSplitContent01.vue
+++ b/apps/website/src/components/blocks/CardSplitContent01.vue
@@ -15,7 +15,7 @@ type Cta = {
 }
 
 const {
-  locale = 'en',
+  locale,
   eyebrow,
   title,
   body,
@@ -27,7 +27,7 @@ const {
   videoAriaLabel,
   class: className
 } = defineProps<{
-  locale?: Locale
+  locale: Locale
   eyebrow: string
   title: string
   body: string

--- a/apps/website/src/components/blocks/FeatureRows01.vue
+++ b/apps/website/src/components/blocks/FeatureRows01.vue
@@ -30,15 +30,10 @@ export interface FeatureRow {
   media: RowMedia
 }
 
-const {
-  heading,
-  eyebrow,
-  locale = 'en',
-  rows
-} = defineProps<{
+const { heading, eyebrow, locale, rows } = defineProps<{
   heading: string
   eyebrow?: string
-  locale?: Locale
+  locale: Locale
   rows: readonly FeatureRow[]
 }>()
 </script>

--- a/apps/website/src/components/blocks/HeroSplit01.test.ts
+++ b/apps/website/src/components/blocks/HeroSplit01.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from 'vitest'
 import HeroSplit01 from './HeroSplit01.vue'
 
 const hero = {
+  locale: 'en' as const,
   badgeText: 'Platform',
   title: 'Build on Comfy',
   primaryCta: { label: 'Get Started', href: '/start' }

--- a/apps/website/src/components/blocks/HeroSplit01.vue
+++ b/apps/website/src/components/blocks/HeroSplit01.vue
@@ -25,7 +25,7 @@ type VideoTrack = {
 }
 
 const {
-  locale = 'en',
+  locale,
   badgeText,
   badgeLogoSrc,
   badgeLogoAlt,
@@ -58,7 +58,7 @@ const {
   beta = false,
   class: className
 } = defineProps<{
-  locale?: Locale
+  locale: Locale
   class?: HTMLAttributes['class']
   badgeText: string
   badgeLogoSrc?: string

--- a/apps/website/src/components/careers/HeroSection.vue
+++ b/apps/website/src/components/careers/HeroSection.vue
@@ -5,7 +5,7 @@ import { t } from '../../i18n/translations'
 import GlassCard from '../common/GlassCard.vue'
 import SectionLabel from '../common/SectionLabel.vue'
 
-const { locale = 'en' } = defineProps<{ locale?: Locale }>()
+const { locale } = defineProps<{ locale: Locale }>()
 </script>
 
 <template>
@@ -24,7 +24,7 @@ const { locale = 'en' } = defineProps<{ locale?: Locale }>()
     <GlassCard class="mx-auto mt-12 max-w-3xl md:mt-16">
       <img
         src="https://media.comfy.org/website/careers/hero.webp"
-        alt="Comfy team"
+        :alt="t('ui.alt.comfyTeam', locale)"
         class="w-full rounded-4xl object-cover"
       />
       <div class="text-primary-comfy-canvas space-y-6 p-8 text-base/relaxed">

--- a/apps/website/src/components/careers/RolesSection.vue
+++ b/apps/website/src/components/careers/RolesSection.vue
@@ -11,8 +11,8 @@ import { scrollTo } from '../../scripts/smoothScroll'
 import CategoryNav from '../common/CategoryNav.vue'
 import SectionLabel from '../common/SectionLabel.vue'
 
-const { locale = 'en', departments = [] } = defineProps<{
-  locale?: Locale
+const { locale, departments = [] } = defineProps<{
+  locale: Locale
   departments?: readonly Department[]
 }>()
 
@@ -99,6 +99,7 @@ function scrollToDepartment(deptKey: string) {
             </h2>
             <CategoryNav
               v-if="hasRoles"
+              :locale
               :categories="categories"
               :model-value="activeCategory"
               class="mt-4"

--- a/apps/website/src/components/careers/WhyJoinSection.vue
+++ b/apps/website/src/components/careers/WhyJoinSection.vue
@@ -1,9 +1,10 @@
 <script setup lang="ts">
 import type { Locale, TranslationKey } from '../../i18n/translations'
+import { t } from '../../i18n/translations'
 
 import WireNodeLayout from '../common/WireNodeLayout.vue'
 
-const { locale = 'en' } = defineProps<{ locale?: Locale }>()
+const { locale } = defineProps<{ locale: Locale }>()
 
 const reasons: TranslationKey[] = [
   'careers.whyJoin.reason1',
@@ -20,7 +21,7 @@ const reasons: TranslationKey[] = [
       <template #right-card>
         <img
           src="https://media.comfy.org/website/about/team.webp"
-          alt="Comfy team"
+          :alt="t('ui.alt.comfyTeam', locale)"
           class="mt-2 w-full rounded-2xl object-cover"
           loading="lazy"
           decoding="async"
@@ -29,7 +30,7 @@ const reasons: TranslationKey[] = [
       <template #right-card-mobile>
         <img
           src="https://media.comfy.org/website/about/team.webp"
-          alt="Comfy team"
+          :alt="t('ui.alt.comfyTeam', locale)"
           class="mt-2 w-full rounded-2xl object-cover"
           loading="lazy"
           decoding="async"

--- a/apps/website/src/components/cloud-nodes/HeroSection.vue
+++ b/apps/website/src/components/cloud-nodes/HeroSection.vue
@@ -4,8 +4,8 @@ import type { Locale } from '../../i18n/translations'
 import { t } from '../../i18n/translations'
 import SectionLabel from '../common/SectionLabel.vue'
 
-const { locale = 'en' } = defineProps<{
-  locale?: Locale
+const { locale } = defineProps<{
+  locale: Locale
 }>()
 </script>
 

--- a/apps/website/src/components/cloud-nodes/NodeList.vue
+++ b/apps/website/src/components/cloud-nodes/NodeList.vue
@@ -5,8 +5,8 @@ import type { Locale } from '../../i18n/translations'
 import { useNodesByCategory } from '../../composables/useNodesByCategory'
 import { t } from '../../i18n/translations'
 
-const { locale = 'en', nodes } = defineProps<{
-  locale?: Locale
+const { locale, nodes } = defineProps<{
+  locale: Locale
   nodes: readonly PackNode[]
 }>()
 

--- a/apps/website/src/components/cloud-nodes/PackCard.vue
+++ b/apps/website/src/components/cloud-nodes/PackCard.vue
@@ -6,8 +6,8 @@ import { t } from '../../i18n/translations'
 import NodeList from './NodeList.vue'
 import PackBanner from './PackBanner.vue'
 
-const { locale = 'en', pack } = defineProps<{
-  locale?: Locale
+const { locale, pack } = defineProps<{
+  locale: Locale
   pack: GridPack
 }>()
 

--- a/apps/website/src/components/cloud-nodes/PackDetail.vue
+++ b/apps/website/src/components/cloud-nodes/PackDetail.vue
@@ -13,9 +13,9 @@ import { useNodesByCategory } from '../../composables/useNodesByCategory'
 import { t } from '../../i18n/translations'
 import PackBanner from './PackBanner.vue'
 
-const { pack, locale = 'en' } = defineProps<{
+const { pack, locale } = defineProps<{
   pack: Pack
-  locale?: Locale
+  locale: Locale
 }>()
 
 const backHref =

--- a/apps/website/src/components/cloud-nodes/PackGridSection.vue
+++ b/apps/website/src/components/cloud-nodes/PackGridSection.vue
@@ -12,8 +12,8 @@ import { t } from '../../i18n/translations'
 import SectionLabel from '../common/SectionLabel.vue'
 import PackCard from './PackCard.vue'
 
-const { locale = 'en', packs } = defineProps<{
-  locale?: Locale
+const { locale, packs } = defineProps<{
+  locale: Locale
   packs: readonly GridPack[]
 }>()
 

--- a/apps/website/src/components/common/AudioPlayer.vue
+++ b/apps/website/src/components/common/AudioPlayer.vue
@@ -18,13 +18,13 @@ type AudioSource = {
 }
 
 const {
-  locale = 'en',
+  locale,
   sources,
   poster,
   ariaLabel,
   class: className
 } = defineProps<{
-  locale?: Locale
+  locale: Locale
   sources: readonly AudioSource[]
   poster: string
   ariaLabel?: string

--- a/apps/website/src/components/common/CallToActionSection.vue
+++ b/apps/website/src/components/common/CallToActionSection.vue
@@ -6,7 +6,7 @@ import { resolveRel } from '../../utils/cta'
 import Button from '../ui/button/Button.vue'
 
 const {
-  locale = 'en',
+  locale,
   headingKey,
   primaryLabelKey,
   primaryHref,
@@ -15,7 +15,7 @@ const {
   secondaryHref,
   secondaryTarget
 } = defineProps<{
-  locale?: Locale
+  locale: Locale
   headingKey: TranslationKey
   primaryLabelKey: TranslationKey
   primaryHref?: string

--- a/apps/website/src/components/common/CategoryNav.vue
+++ b/apps/website/src/components/common/CategoryNav.vue
@@ -1,14 +1,18 @@
 <script setup lang="ts">
 import { cn } from '@comfyorg/tailwind-utils'
 
+import type { Locale } from '../../i18n/translations'
+import { t } from '../../i18n/translations'
+
 interface CategoryItem {
   label: string
   value: string
 }
 
-const { categories, modelValue } = defineProps<{
+const { categories, modelValue, locale } = defineProps<{
   categories: CategoryItem[]
   modelValue: string
+  locale: Locale
 }>()
 
 const emit = defineEmits<{
@@ -19,7 +23,7 @@ const emit = defineEmits<{
 <template>
   <nav
     class="flex w-full scrollbar-none items-center gap-3 overflow-x-auto lg:flex-col lg:overflow-x-hidden"
-    aria-label="Category filter"
+    :aria-label="t('ui.nav.categoryFilter', locale)"
   >
     <button
       v-for="category in categories"

--- a/apps/website/src/components/common/ContentSection.vue
+++ b/apps/website/src/components/common/ContentSection.vue
@@ -17,13 +17,9 @@ import CategoryNav from './CategoryNav.vue'
 import SectionLabel from './SectionLabel.vue'
 import { deriveSections } from '../../config/contentSections'
 
-const {
-  prefix,
-  locale = 'en',
-  readMoreHref
-} = defineProps<{
+const { prefix, locale, readMoreHref } = defineProps<{
   prefix: string
-  locale?: Locale
+  locale: Locale
   readMoreHref?: string
 }>()
 
@@ -117,6 +113,7 @@ function scrollToSection(id: string) {
       <aside class="hidden scrollbar-none lg:block lg:w-48 lg:shrink-0">
         <div class="sticky top-32">
           <CategoryNav
+            :locale
             :categories="categories"
             :model-value="activeSection"
             @update:model-value="scrollToSection"

--- a/apps/website/src/components/common/FAQSection.vue
+++ b/apps/website/src/components/common/FAQSection.vue
@@ -6,14 +6,8 @@ import type { Locale, TranslationKey } from '../../i18n/translations'
 
 import { t } from '../../i18n/translations'
 
-const {
-  locale = 'en',
-  headingKey,
-  faqPrefix,
-  faqCount,
-  footerKey
-} = defineProps<{
-  locale?: Locale
+const { locale, headingKey, faqPrefix, faqCount, footerKey } = defineProps<{
+  locale: Locale
   headingKey: TranslationKey
   faqPrefix: string
   faqCount: number

--- a/apps/website/src/components/common/HeaderMain/HeaderMain.vue
+++ b/apps/website/src/components/common/HeaderMain/HeaderMain.vue
@@ -7,8 +7,8 @@ import HeaderMainDesktop from './HeaderMainDesktop.vue'
 import HeaderMainMobile from './HeaderMainMobile.vue'
 import Button from '@/components/ui/button/Button.vue'
 
-const { locale = 'en', githubStars = '' } = defineProps<{
-  locale?: Locale
+const { locale, githubStars = '' } = defineProps<{
+  locale: Locale
   githubStars?: string
 }>()
 const routes = getRoutes(locale)
@@ -34,12 +34,12 @@ const ctaButtons = [
 <template>
   <nav
     class="sticky top-0 z-50 flex items-center justify-between gap-4 bg-primary-comfy-ink px-6 py-5 lg:gap-4 lg:px-[clamp(0.25rem,4vw,5rem)] lg:py-8"
-    aria-label="Main navigation"
+    :aria-label="t('ui.nav.main', locale)"
   >
     <a
       :href="routes.home"
       class="inline-grid h-10 shrink-0 grid-cols-1 grid-rows-1 transition-[width]"
-      aria-label="Comfy home"
+      :aria-label="t('ui.nav.home', locale)"
     >
       <img
         src="/icons/logomark.svg"

--- a/apps/website/src/components/common/HeaderMain/HeaderMainDesktop.vue
+++ b/apps/website/src/components/common/HeaderMain/HeaderMainDesktop.vue
@@ -18,7 +18,7 @@ import NavColumn from './NavColumn.vue'
 import NavFeaturedCard from './NavFeaturedCard.vue'
 import NewBadge from './NewBadge.vue'
 
-const { locale = 'en' } = defineProps<{ locale?: Locale }>()
+const { locale } = defineProps<{ locale: Locale }>()
 const mainNavigation = getMainNavigation(locale)
 const currentPath = useCurrentPath()
 

--- a/apps/website/src/components/common/HeaderMain/HeaderMainMobile.vue
+++ b/apps/website/src/components/common/HeaderMain/HeaderMainMobile.vue
@@ -18,7 +18,7 @@ import SheetTrigger from '@/components/ui/sheet/SheetTrigger.vue'
 import Button from '@/components/ui/button/Button.vue'
 import { cn } from '@comfyorg/tailwind-utils'
 
-const { locale = 'en' } = defineProps<{ locale?: Locale }>()
+const { locale } = defineProps<{ locale: Locale }>()
 const routes = getRoutes(locale)
 const mainNavigation = getMainNavigation(locale)
 

--- a/apps/website/src/components/common/HubspotFormEmbed.test.ts
+++ b/apps/website/src/components/common/HubspotFormEmbed.test.ts
@@ -50,7 +50,7 @@ afterEach(() => loaderScript()?.remove())
 
 describe('HubspotFormEmbed', () => {
   it('addresses the requested form on the embed container', () => {
-    render(HubspotFormEmbed, { props: { formId: FORM_ID } })
+    render(HubspotFormEmbed, { props: { formId: FORM_ID, locale: 'en' } })
 
     const embed = screen.getByTestId('hubspot-form-embed')
     expect(embed.getAttribute('data-form-id')).toBe(FORM_ID)
@@ -59,15 +59,17 @@ describe('HubspotFormEmbed', () => {
   })
 
   it('loads the HubSpot script once however many embeds mount', () => {
-    render(HubspotFormEmbed, { props: { formId: FORM_ID } })
-    render(HubspotFormEmbed, { props: { formId: 'a-second-form' } })
+    render(HubspotFormEmbed, { props: { formId: FORM_ID, locale: 'en' } })
+    render(HubspotFormEmbed, {
+      props: { formId: 'a-second-form', locale: 'en' }
+    })
 
     expect(scriptsCreated(createElementSpy)).toBe(1)
     expect(loaderScript()?.src).toBe(SCRIPT_SRC)
   })
 
   it('offers an email fallback when the script fails to load', async () => {
-    render(HubspotFormEmbed, { props: { formId: FORM_ID } })
+    render(HubspotFormEmbed, { props: { formId: FORM_ID, locale: 'en' } })
 
     loaderScript()?.dispatchEvent(new Event('error'))
     await nextTick()

--- a/apps/website/src/components/common/HubspotFormEmbed.vue
+++ b/apps/website/src/components/common/HubspotFormEmbed.vue
@@ -5,9 +5,9 @@ import type { Locale } from '../../i18n/translations'
 
 import { t } from '../../i18n/translations'
 
-const { formId, locale = 'en' } = defineProps<{
+const { formId, locale } = defineProps<{
   formId: string
-  locale?: Locale
+  locale: Locale
 }>()
 
 const HUBSPOT_PORTAL_ID = '244637579'

--- a/apps/website/src/components/common/ProductCardsSection.vue
+++ b/apps/website/src/components/common/ProductCardsSection.vue
@@ -12,13 +12,13 @@ import SectionLabel from './SectionLabel.vue'
 type Product = 'local' | 'cloud' | 'platform' | 'enterprise'
 
 const {
-  locale = 'en',
+  locale,
   excludeProduct,
   labelKey = '',
   ctaKey,
   ctaVariant
 } = defineProps<{
-  locale?: Locale
+  locale: Locale
   excludeProduct?: Product
   labelKey?: TranslationKey
   ctaKey?: TranslationKey

--- a/apps/website/src/components/common/SiteFooter.vue
+++ b/apps/website/src/components/common/SiteFooter.vue
@@ -8,7 +8,7 @@ import { t } from '../../i18n/translations'
 import FooterLinkColumn from './FooterLinkColumn.vue'
 import type { FooterLink } from './FooterLinkColumn.vue'
 
-const { locale = 'en' } = defineProps<{ locale?: Locale }>()
+const { locale } = defineProps<{ locale: Locale }>()
 const routes = getRoutes(locale)
 
 const footerRef = ref<HTMLElement>()

--- a/apps/website/src/components/common/VideoPlayer.test.ts
+++ b/apps/website/src/components/common/VideoPlayer.test.ts
@@ -13,7 +13,11 @@ describe('VideoPlayer', () => {
     vi.spyOn(HTMLMediaElement.prototype, 'muted', 'get').mockReturnValue(true)
 
     render(VideoPlayer, {
-      props: { src: 'https://example.com/clip.mp4', muteOnly: true }
+      props: {
+        locale: 'en',
+        src: 'https://example.com/clip.mp4',
+        muteOnly: true
+      }
     })
 
     expect(await screen.findByRole('button', { name: 'Pause' })).toBeTruthy()
@@ -22,7 +26,11 @@ describe('VideoPlayer', () => {
 
   it('shows play and mute for a paused, unmuted video', async () => {
     render(VideoPlayer, {
-      props: { src: 'https://example.com/clip.mp4', muteOnly: true }
+      props: {
+        locale: 'en',
+        src: 'https://example.com/clip.mp4',
+        muteOnly: true
+      }
     })
 
     expect(await screen.findByRole('button', { name: 'Play' })).toBeTruthy()

--- a/apps/website/src/components/common/VideoPlayer.vue
+++ b/apps/website/src/components/common/VideoPlayer.vue
@@ -26,7 +26,7 @@ export type VideoTrack = {
 }
 
 const {
-  locale = 'en',
+  locale,
   src,
   poster,
   tracks = [],
@@ -43,7 +43,7 @@ const {
   ariaLabel,
   class: className
 } = defineProps<{
-  locale?: Locale
+  locale: Locale
   src?: string
   poster?: string
   tracks?: readonly VideoTrack[]

--- a/apps/website/src/components/common/WireNodeLayout.vue
+++ b/apps/website/src/components/common/WireNodeLayout.vue
@@ -19,7 +19,7 @@ const {
   titleAfterKey = 'about.careers.whyTitleAfter',
   labelKey = 'about.careers.whyLabel',
   variant = 'split',
-  locale = 'en'
+  locale
 } = defineProps<{
   reasons: TranslationKey[]
   rightCardPadding?: string
@@ -32,7 +32,7 @@ const {
    * wired to the reasons only (/forward-deployed-creatives).
    */
   variant?: 'split' | 'node'
-  locale?: Locale
+  locale: Locale
 }>()
 
 const slots = useSlots()

--- a/apps/website/src/components/contact/FormSection.vue
+++ b/apps/website/src/components/contact/FormSection.vue
@@ -8,8 +8,8 @@ import { t } from '../../i18n/translations'
 import HubspotFormEmbed from '../common/HubspotFormEmbed.vue'
 import SectionLabel from '../common/SectionLabel.vue'
 
-const { locale = 'en' } = defineProps<{
-  locale?: Locale
+const { locale } = defineProps<{
+  locale: Locale
 }>()
 
 const englishFormId = '94e05eab-1373-47f7-ab5e-d84f9e6aa262'

--- a/apps/website/src/components/customers/ArticleNav.vue
+++ b/apps/website/src/components/customers/ArticleNav.vue
@@ -5,12 +5,14 @@ import type { ComponentProps } from 'vue-component-type-helpers'
 
 import { prefersReducedMotion } from '../../composables/useReducedMotion'
 import { scrollTo } from '../../scripts/smoothScroll'
+import type { Locale } from '../../i18n/translations'
 import CategoryNav from '../common/CategoryNav.vue'
 
 type Category = ComponentProps<typeof CategoryNav>['categories'][number]
 
-const { categories } = defineProps<{
+const { categories, locale } = defineProps<{
   categories: Category[]
+  locale: Locale
 }>()
 
 const activeSection = ref(categories[0]?.value ?? '')
@@ -91,6 +93,7 @@ useEventListener('scroll', activateLastIfAtBottom, { passive: true })
 
 <template>
   <CategoryNav
+    :locale
     :categories
     :model-value="activeSection"
     @update:model-value="scrollToSection"

--- a/apps/website/src/components/customers/ContactSection.vue
+++ b/apps/website/src/components/customers/ContactSection.vue
@@ -2,7 +2,7 @@
 import type { Locale } from '../../i18n/translations'
 import { t } from '../../i18n/translations'
 
-const { locale = 'en' } = defineProps<{ locale?: Locale }>()
+const { locale } = defineProps<{ locale: Locale }>()
 </script>
 
 <template>

--- a/apps/website/src/components/customers/CustomerArticle.astro
+++ b/apps/website/src/components/customers/CustomerArticle.astro
@@ -24,10 +24,10 @@ import Video from './content/Video.astro'
 
 interface Props {
   entry: CustomerStoryEntry
-  locale?: Locale
+  locale: Locale
 }
 
-const { entry, locale = 'en' } = Astro.props
+const { entry, locale } = Astro.props
 const { Content } = await render(entry)
 
 const categories = entry.data.sections.map((section) => ({
@@ -60,6 +60,7 @@ const contentComponents = {
     <aside class="hidden scrollbar-none lg:block lg:w-48 lg:shrink-0">
       <div class="sticky top-32">
         <ArticleNav
+          locale={locale}
           categories={categories}
           client:media="(min-width: 1024px)"
         />

--- a/apps/website/src/components/customers/FeedbackSection.vue
+++ b/apps/website/src/components/customers/FeedbackSection.vue
@@ -3,7 +3,7 @@ import type { Locale } from '../../i18n/translations'
 import { t } from '../../i18n/translations'
 import ScrollCarousel from '../ui/scroll-carousel/ScrollCarousel.vue'
 
-const { locale = 'en' } = defineProps<{ locale?: Locale }>()
+const { locale } = defineProps<{ locale: Locale }>()
 
 const feedbacks = [
   {

--- a/apps/website/src/components/customers/HeroSection.vue
+++ b/apps/website/src/components/customers/HeroSection.vue
@@ -8,7 +8,7 @@ import { t } from '../../i18n/translations'
 import { ScrollTrigger } from '../../scripts/gsapSetup'
 import VideoPlayer from '../common/VideoPlayer.vue'
 
-const { locale = 'en' } = defineProps<{ locale?: Locale }>()
+const { locale } = defineProps<{ locale: Locale }>()
 
 const sectionRef = ref<HTMLElement>()
 const logoRef = ref<HTMLElement>()
@@ -40,7 +40,7 @@ function handleLogoLoad() {
       >
         <img
           src="https://media.comfy.org/website/customers/c-projection.webp"
-          alt="Comfy 3D logo"
+          :alt="t('ui.alt.comfy3dLogo', locale)"
           width="1568"
           height="1763"
           class="mx-auto h-auto w-full max-w-md lg:max-w-none"

--- a/apps/website/src/components/customers/StoryCard.vue
+++ b/apps/website/src/components/customers/StoryCard.vue
@@ -3,9 +3,9 @@ import type { Locale } from '../../i18n/translations'
 import { t } from '../../i18n/translations'
 import type { StoryCard } from '../../utils/customers'
 
-const { story, locale = 'en' } = defineProps<{
+const { story, locale } = defineProps<{
   story: StoryCard
-  locale?: Locale
+  locale: Locale
 }>()
 
 const prefix = locale === 'zh-CN' ? '/zh-CN' : ''

--- a/apps/website/src/components/customers/StorySection.vue
+++ b/apps/website/src/components/customers/StorySection.vue
@@ -3,9 +3,9 @@ import type { Locale } from '../../i18n/translations'
 import type { StoryCard as StoryCardType } from '../../utils/customers'
 import StoryCard from './StoryCard.vue'
 
-const { stories, locale = 'en' } = defineProps<{
+const { stories, locale } = defineProps<{
   stories: StoryCardType[]
-  locale?: Locale
+  locale: Locale
 }>()
 </script>
 

--- a/apps/website/src/components/customers/VideoSection.vue
+++ b/apps/website/src/components/customers/VideoSection.vue
@@ -3,7 +3,7 @@ import type { Locale } from '../../i18n/translations'
 
 import VideoPlayer from '../common/VideoPlayer.vue'
 
-const { locale = 'en' } = defineProps<{ locale?: Locale }>()
+const { locale } = defineProps<{ locale: Locale }>()
 </script>
 
 <template>

--- a/apps/website/src/components/customers/WhatsNextSection.vue
+++ b/apps/website/src/components/customers/WhatsNextSection.vue
@@ -4,16 +4,11 @@ import type { Locale, TranslationKey } from '../../i18n/translations'
 import { t } from '../../i18n/translations'
 import GlassCard from '../common/GlassCard.vue'
 
-const {
-  title,
-  image,
-  href,
-  locale = 'en'
-} = defineProps<{
+const { title, image, href, locale } = defineProps<{
   title: string
   image: string
   href: string
-  locale?: Locale
+  locale: Locale
 }>()
 </script>
 

--- a/apps/website/src/components/customers/content/ReadMore.vue
+++ b/apps/website/src/components/customers/content/ReadMore.vue
@@ -3,9 +3,9 @@ import type { Locale } from '../../../i18n/translations'
 import { t } from '../../../i18n/translations'
 import Button from '../../ui/button/Button.vue'
 
-const { href, locale = 'en' } = defineProps<{
+const { href, locale } = defineProps<{
   href: string
-  locale?: Locale
+  locale: Locale
 }>()
 </script>
 

--- a/apps/website/src/components/customers/content/Video.astro
+++ b/apps/website/src/components/customers/content/Video.astro
@@ -1,5 +1,6 @@
 ---
 import VideoPlayer from '../../common/VideoPlayer.vue'
+import { resolveLocale } from '../../../i18n/translations'
 
 interface Props {
   src: string
@@ -8,10 +9,11 @@ interface Props {
 }
 
 const { src, poster, caption } = Astro.props
+const locale = resolveLocale(Astro.currentLocale)
 ---
 
 <figure class="my-8">
-  <VideoPlayer src={src} poster={poster} client:visible />
+  <VideoPlayer locale={locale} src={src} poster={poster} client:visible />
   {
     caption && (
       <figcaption class="mt-3 text-xs text-primary-comfy-canvas">

--- a/apps/website/src/components/demos/ArcadeEmbed.vue
+++ b/apps/website/src/components/demos/ArcadeEmbed.vue
@@ -9,12 +9,12 @@ const {
   arcadeId,
   title,
   aspectRatio = 16 / 9,
-  locale = 'en'
+  locale
 } = defineProps<{
   arcadeId: string
   title: string
   aspectRatio?: number
-  locale?: Locale
+  locale: Locale
 }>()
 
 const loaded = ref(false)
@@ -53,6 +53,9 @@ const loaded = ref(false)
       />
     </div>
 
+    <!-- vue-eslint-parser reports noscript children as one raw text node, so
+      the t() interpolations below are flagged as literals. -->
+    <!-- eslint-disable @intlify/vue-i18n/no-raw-text -->
     <noscript>
       <p class="text-primary-warm-gray mt-4 text-sm">
         {{ t('demos.noscript', locale) }}
@@ -66,5 +69,6 @@ const loaded = ref(false)
         </a>
       </p>
     </noscript>
+    <!-- eslint-enable @intlify/vue-i18n/no-raw-text -->
   </section>
 </template>

--- a/apps/website/src/components/demos/DemoHeroSection.vue
+++ b/apps/website/src/components/demos/DemoHeroSection.vue
@@ -3,21 +3,15 @@ import type { Locale, TranslationKey } from '../../i18n/translations'
 
 import { t } from '../../i18n/translations'
 
-const {
-  label,
-  title,
-  description,
-  difficulty,
-  estimatedTime,
-  locale = 'en'
-} = defineProps<{
-  label: string
-  title: string
-  description: string
-  difficulty: 'beginner' | 'intermediate' | 'advanced'
-  estimatedTime: string
-  locale?: Locale
-}>()
+const { label, title, description, difficulty, estimatedTime, locale } =
+  defineProps<{
+    label: string
+    title: string
+    description: string
+    difficulty: 'beginner' | 'intermediate' | 'advanced'
+    estimatedTime: string
+    locale: Locale
+  }>()
 
 const difficultyKey = `demos.difficulty.${difficulty}` as TranslationKey
 </script>

--- a/apps/website/src/components/demos/DemoNavSection.vue
+++ b/apps/website/src/components/demos/DemoNavSection.vue
@@ -4,16 +4,11 @@ import type { Locale, TranslationKey } from '../../i18n/translations'
 import { localizeHref } from '../../config/routes'
 import { t } from '../../i18n/translations'
 
-const {
-  nextTitle,
-  nextSlug,
-  nextThumbnail,
-  locale = 'en'
-} = defineProps<{
+const { nextTitle, nextSlug, nextThumbnail, locale } = defineProps<{
   nextTitle: string
   nextSlug: string
   nextThumbnail: string
-  locale?: Locale
+  locale: Locale
 }>()
 
 const nextHref = localizeHref(`/demos/${nextSlug}`, locale)

--- a/apps/website/src/components/demos/DemoTranscript.vue
+++ b/apps/website/src/components/demos/DemoTranscript.vue
@@ -6,9 +6,9 @@ import { ref } from 'vue'
 
 import { t } from '../../i18n/translations'
 
-const { transcript, locale = 'en' } = defineProps<{
+const { transcript, locale } = defineProps<{
   transcript: string
-  locale?: Locale
+  locale: Locale
 }>()
 
 const expanded = ref(false)

--- a/apps/website/src/components/gallery/ContactSection.vue
+++ b/apps/website/src/components/gallery/ContactSection.vue
@@ -2,7 +2,7 @@
 import type { Locale } from '../../i18n/translations'
 import { t } from '../../i18n/translations'
 
-const { locale = 'en' } = defineProps<{ locale?: Locale }>()
+const { locale } = defineProps<{ locale: Locale }>()
 </script>
 
 <template>

--- a/apps/website/src/components/gallery/GalleryCard.vue
+++ b/apps/website/src/components/gallery/GalleryCard.vue
@@ -7,14 +7,14 @@ import GalleryItemAttribution from './GalleryItemAttribution.vue'
 
 const {
   item,
-  locale = 'en',
+  locale,
   aspect = 'var(--aspect-ratio-gallery-card)',
   mobile = false,
   objectPosition = 'center',
   objectFit = 'cover'
 } = defineProps<{
   item: GalleryItem
-  locale?: Locale
+  locale: Locale
   aspect?: string
   mobile?: boolean
   objectPosition?: CSSProperties['objectPosition']

--- a/apps/website/src/components/gallery/GalleryDetailModal.vue
+++ b/apps/website/src/components/gallery/GalleryDetailModal.vue
@@ -21,11 +21,11 @@ import GalleryItemAttribution from './GalleryItemAttribution.vue'
 const {
   items,
   initialIndex = 0,
-  locale = 'en'
+  locale
 } = defineProps<{
   items: GalleryItem[]
   initialIndex?: number
-  locale?: Locale
+  locale: Locale
 }>()
 
 const emit = defineEmits<{ close: [] }>()

--- a/apps/website/src/components/gallery/GalleryItemAttribution.vue
+++ b/apps/website/src/components/gallery/GalleryItemAttribution.vue
@@ -6,11 +6,11 @@ import { t } from '../../i18n/translations'
 const {
   item,
   highlightClass = 'text-primary-comfy-yellow',
-  locale = 'en'
+  locale
 } = defineProps<{
   item: GalleryItem
   highlightClass?: string
-  locale?: Locale
+  locale: Locale
 }>()
 </script>
 

--- a/apps/website/src/components/gallery/GallerySection.vue
+++ b/apps/website/src/components/gallery/GallerySection.vue
@@ -8,7 +8,7 @@ import type { Locale } from '../../i18n/translations'
 import GalleryCard from './GalleryCard.vue'
 import GalleryDetailModal from './GalleryDetailModal.vue'
 
-const { locale = 'en' } = defineProps<{ locale?: Locale }>()
+const { locale } = defineProps<{ locale: Locale }>()
 
 const modalOpen = ref(false)
 const modalIndex = ref(0)

--- a/apps/website/src/components/gallery/HeroSection.vue
+++ b/apps/website/src/components/gallery/HeroSection.vue
@@ -4,7 +4,7 @@ import type { Locale } from '../../i18n/translations'
 import { t } from '../../i18n/translations'
 import SectionLabel from '../common/SectionLabel.vue'
 
-const { locale = 'en' } = defineProps<{ locale?: Locale }>()
+const { locale } = defineProps<{ locale: Locale }>()
 </script>
 
 <template>

--- a/apps/website/src/components/home/CaseStudySpotlightSection.vue
+++ b/apps/website/src/components/home/CaseStudySpotlightSection.vue
@@ -7,7 +7,7 @@ import BrandButton from '../common/BrandButton.vue'
 import GlassCard from '../common/GlassCard.vue'
 import VideoPlayer from '../common/VideoPlayer.vue'
 
-const { locale = 'en' } = defineProps<{ locale?: Locale }>()
+const { locale } = defineProps<{ locale: Locale }>()
 const routes = getRoutes(locale)
 </script>
 

--- a/apps/website/src/components/home/GetStartedSection.vue
+++ b/apps/website/src/components/home/GetStartedSection.vue
@@ -4,7 +4,7 @@ import type { Locale } from '../../i18n/translations'
 import { externalLinks, getRoutes } from '../../config/routes'
 import { t } from '../../i18n/translations'
 
-const { locale = 'en' } = defineProps<{ locale?: Locale }>()
+const { locale } = defineProps<{ locale: Locale }>()
 const routes = getRoutes(locale)
 
 const steps = [

--- a/apps/website/src/components/home/ModelReleaseSection.test.ts
+++ b/apps/website/src/components/home/ModelReleaseSection.test.ts
@@ -8,7 +8,7 @@ import ModelReleaseSection from './ModelReleaseSection.vue'
 // slide and the pagination dots; the other slides are asserted by text.
 describe('ModelReleaseSection', () => {
   it('renders the four model slides with locale-aware CTAs', () => {
-    render(ModelReleaseSection)
+    render(ModelReleaseSection, { props: { locale: 'en' } })
 
     expect(screen.getByText('Seedance 2.5', { selector: 'h2' })).toBeTruthy()
     expect(screen.getByText('LTX 2.5', { selector: 'h2' })).toBeTruthy()

--- a/apps/website/src/components/home/ModelReleaseSection.vue
+++ b/apps/website/src/components/home/ModelReleaseSection.vue
@@ -6,7 +6,7 @@ import { t } from '../../i18n/translations'
 import FeaturedCarousel02 from '../blocks/FeaturedCarousel02.vue'
 import type { FeaturedSplitSlide } from '../blocks/FeaturedCarousel02.vue'
 
-const { locale = 'en' } = defineProps<{ locale?: Locale }>()
+const { locale } = defineProps<{ locale: Locale }>()
 const routes = getRoutes(locale)
 
 const slides: FeaturedSplitSlide[] = modelReleaseSlides.map((slide) => ({

--- a/apps/website/src/components/home/ProductCardsSection.vue
+++ b/apps/website/src/components/home/ProductCardsSection.vue
@@ -3,7 +3,7 @@ import type { Locale } from '../../i18n/translations'
 
 import ProductCardsSection from '../common/ProductCardsSection.vue'
 
-const { locale = 'en' } = defineProps<{ locale?: Locale }>()
+const { locale } = defineProps<{ locale: Locale }>()
 </script>
 
 <template>

--- a/apps/website/src/components/home/ProductShowcaseSection.vue
+++ b/apps/website/src/components/home/ProductShowcaseSection.vue
@@ -9,7 +9,7 @@ import NodeBadge from '../common/NodeBadge.vue'
 import LottieScene from './LottieScene.vue'
 import VideoMaskScene from './VideoMaskScene.vue'
 
-const { locale = 'en' } = defineProps<{ locale?: Locale }>()
+const { locale } = defineProps<{ locale: Locale }>()
 
 interface Feature {
   title: string

--- a/apps/website/src/components/learning/FeaturedTutorialCard.vue
+++ b/apps/website/src/components/learning/FeaturedTutorialCard.vue
@@ -11,9 +11,9 @@ import Badge from '../ui/badge/Badge.vue'
 import ButtonPill from '../ui/button-pill/ButtonPill.vue'
 import PlayOverlay from '../blocks/PlayOverlay.vue'
 
-const { tutorial, locale = 'en' } = defineProps<{
+const { tutorial, locale } = defineProps<{
   tutorial: LearningTutorial
-  locale?: Locale
+  locale: Locale
 }>()
 </script>
 

--- a/apps/website/src/components/learning/LearningCategoryNav.vue
+++ b/apps/website/src/components/learning/LearningCategoryNav.vue
@@ -17,8 +17,8 @@ import {
 import { localizeHref } from '../../config/routes'
 import { t } from '../../i18n/translations'
 
-const { locale = 'en', category } = defineProps<{
-  locale?: Locale
+const { locale, category } = defineProps<{
+  locale: Locale
   category?: LearningCategory
 }>()
 

--- a/apps/website/src/components/learning/LearningDirectorySection.vue
+++ b/apps/website/src/components/learning/LearningDirectorySection.vue
@@ -22,11 +22,11 @@ import LearningCategoryNav from './LearningCategoryNav.vue'
 import TutorialRow from './TutorialRow.vue'
 
 const {
-  locale = 'en',
+  locale,
   category,
   headingTag = 'h1'
 } = defineProps<{
-  locale?: Locale
+  locale: Locale
   category?: LearningCategory
   /** Demote the sidebar heading on pages whose h1 lives elsewhere
    * (the tutorial dialog). */

--- a/apps/website/src/components/learning/LearningWatchPage.vue
+++ b/apps/website/src/components/learning/LearningWatchPage.vue
@@ -21,9 +21,9 @@ import VideoPlayer from '../common/VideoPlayer.vue'
 import LearningVideoEmbed from './LearningVideoEmbed.vue'
 import Badge from '../ui/badge/Badge.vue'
 
-const { tutorial, locale = 'en' } = defineProps<{
+const { tutorial, locale } = defineProps<{
   tutorial: LearningTutorial
-  locale?: Locale
+  locale: Locale
 }>()
 
 const breadcrumbs = [

--- a/apps/website/src/components/learning/TutorialRow.vue
+++ b/apps/website/src/components/learning/TutorialRow.vue
@@ -11,9 +11,9 @@ import Badge from '../ui/badge/Badge.vue'
 import ButtonPill from '../ui/button-pill/ButtonPill.vue'
 import PlayOverlay from '../blocks/PlayOverlay.vue'
 
-const { tutorial, locale = 'en' } = defineProps<{
+const { tutorial, locale } = defineProps<{
   tutorial: LearningTutorial
-  locale?: Locale
+  locale: Locale
 }>()
 </script>
 

--- a/apps/website/src/components/legal/LegalContentSection.vue
+++ b/apps/website/src/components/legal/LegalContentSection.vue
@@ -9,13 +9,9 @@ import { hasKey, t, translationKeys } from '../../i18n/translations'
 import { prefersReducedMotion } from '../../composables/useReducedMotion'
 import { scrollTo } from '../../scripts/smoothScroll'
 
-const {
-  prefix,
-  locale = 'en',
-  tocLabelKey
-} = defineProps<{
+const { prefix, locale, tocLabelKey } = defineProps<{
   prefix: string
-  locale?: Locale
+  locale: Locale
   tocLabelKey: TranslationKey
 }>()
 

--- a/apps/website/src/components/legal/legalSections.test.ts
+++ b/apps/website/src/components/legal/legalSections.test.ts
@@ -44,7 +44,7 @@ describe('affiliate terms i18n', () => {
 
   it('section titles follow the "N. Section Name" pattern', () => {
     for (const id of EXPECTED_SECTION_IDS) {
-      const title = t(`${PREFIX}.${id}.title` as never)
+      const title = t(`${PREFIX}.${id}.title` as never, 'en')
       const numberPrefix = id.split('-')[0]
       expect(title).toMatch(new RegExp(`^${numberPrefix}\\. `))
     }

--- a/apps/website/src/components/models/ModelCreationsSection.vue
+++ b/apps/website/src/components/models/ModelCreationsSection.vue
@@ -9,7 +9,7 @@ import BrandButton from '../common/BrandButton.vue'
 import GalleryCard from '../gallery/GalleryCard.vue'
 import GalleryDetailModal from '../gallery/GalleryDetailModal.vue'
 
-const { locale = 'en' } = defineProps<{ locale?: Locale }>()
+const { locale } = defineProps<{ locale: Locale }>()
 
 const modelName = 'Grok'
 const ctaHref = 'https://comfy.org/workflows/model/grok'

--- a/apps/website/src/components/models/ModelHeroSection.vue
+++ b/apps/website/src/components/models/ModelHeroSection.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { cn } from '@comfyorg/tailwind-utils'
 import BrandButton from '../common/BrandButton.vue'
+import type { Locale } from '../../i18n/translations'
 import { t } from '../../i18n/translations'
 
 const {
@@ -10,7 +11,8 @@ const {
   blogUrl,
   hubSlug,
   workflowCount,
-  directory
+  directory,
+  locale
 } = defineProps<{
   displayName: string
   huggingFaceUrl: string
@@ -19,6 +21,7 @@ const {
   hubSlug?: string
   workflowCount: number
   directory: string
+  locale: Locale
 }>()
 
 const workflowsUrl = hubSlug
@@ -62,12 +65,12 @@ const isPartnerNode = directory === 'partner_nodes'
       </p>
 
       <h1 class="text-4xl font-bold text-primary-comfy-canvas lg:text-6xl">
-        {{ displayName }} in ComfyUI
+        {{ displayName }} {{ t('models.hero.inComfyUI', locale) }}
       </h1>
 
       <p class="text-sm text-primary-comfy-canvas/60">
         {{
-          t('models.hero.workflowCount').replace(
+          t('models.hero.workflowCount', locale).replace(
             '{count}',
             String(workflowCount)
           )
@@ -82,7 +85,7 @@ const isPartnerNode = directory === 'partner_nodes'
           size="lg"
           class="w-full uppercase sm:w-auto sm:min-w-48"
         >
-          {{ t('models.hero.primaryCta') }}
+          {{ t('models.hero.primaryCta', locale) }}
         </BrandButton>
 
         <BrandButton
@@ -94,7 +97,7 @@ const isPartnerNode = directory === 'partner_nodes'
           size="lg"
           class="w-full uppercase sm:w-auto sm:min-w-48"
         >
-          {{ t('models.hero.secondaryCta') }}
+          {{ t('models.hero.secondaryCta', locale) }}
         </BrandButton>
 
         <BrandButton
@@ -106,7 +109,7 @@ const isPartnerNode = directory === 'partner_nodes'
           size="lg"
           class="w-full uppercase sm:w-auto sm:min-w-48"
         >
-          {{ t('models.hero.cloudCta') }}
+          {{ t('models.hero.cloudCta', locale) }}
         </BrandButton>
 
         <BrandButton
@@ -118,7 +121,7 @@ const isPartnerNode = directory === 'partner_nodes'
           size="lg"
           class="w-full uppercase sm:w-auto sm:min-w-48"
         >
-          {{ t('models.hero.tutorialCta') }}
+          {{ t('models.hero.tutorialCta', locale) }}
         </BrandButton>
       </div>
 
@@ -129,7 +132,7 @@ const isPartnerNode = directory === 'partner_nodes'
           rel="noopener noreferrer"
           class="hover:text-primary-comfy-canvas underline"
         >
-          {{ t('models.hero.blogLink') }}
+          {{ t('models.hero.blogLink', locale) }}
         </a>
       </div>
     </div>

--- a/apps/website/src/components/models/ModelsHeroSection.vue
+++ b/apps/website/src/components/models/ModelsHeroSection.vue
@@ -4,14 +4,8 @@ import type { Locale } from '../../i18n/translations'
 import { t } from '../../i18n/translations'
 import BrandButton from '../common/BrandButton.vue'
 
-const {
-  locale = 'en',
-  modelName,
-  ctaHref,
-  videoSrc,
-  videoAriaLabel
-} = defineProps<{
-  locale?: Locale
+const { locale, modelName, ctaHref, videoSrc, videoAriaLabel } = defineProps<{
+  locale: Locale
   modelName: string
   ctaHref: string
   videoSrc: string

--- a/apps/website/src/components/payment/PaymentStatusSection.vue
+++ b/apps/website/src/components/payment/PaymentStatusSection.vue
@@ -13,9 +13,9 @@ import SectionLabel from '../common/SectionLabel.vue'
 
 type Status = 'success' | 'failed'
 
-const { status, locale = 'en' } = defineProps<{
+const { status, locale } = defineProps<{
   status: Status
-  locale?: Locale
+  locale: Locale
 }>()
 
 const primaryHref =

--- a/apps/website/src/components/pricing/CloudPricingSection.vue
+++ b/apps/website/src/components/pricing/CloudPricingSection.vue
@@ -5,8 +5,8 @@ import { externalLinks } from '../../config/routes'
 import PricingFreeBanner from './PricingFreeBanner.vue'
 import PricingSection from './PricingSection.vue'
 
-const { locale = 'en' } = defineProps<{
-  locale?: Locale
+const { locale } = defineProps<{
+  locale: Locale
 }>()
 </script>
 

--- a/apps/website/src/components/pricing/PricingContactBand.vue
+++ b/apps/website/src/components/pricing/PricingContactBand.vue
@@ -8,10 +8,10 @@ import Button from '../ui/button/Button.vue'
 import PricingCard from './PricingCard.vue'
 import PricingPlanLabel from './PricingPlanLabel.vue'
 
-const { locale = 'en', href } = defineProps<{
+const { locale, href } = defineProps<{
   labelKey: TranslationKey
   descriptionKey: TranslationKey
-  locale?: Locale
+  locale: Locale
   href?: string
 }>()
 

--- a/apps/website/src/components/pricing/PricingCredits.vue
+++ b/apps/website/src/components/pricing/PricingCredits.vue
@@ -6,16 +6,12 @@ import { Coins as CreditsIcon } from '@lucide/vue'
 
 import { t } from '../../i18n/translations'
 
-const {
-  locale = 'en',
-  estimateKey,
-  estimateCount
-} = defineProps<{
+const { locale, estimateKey, estimateCount } = defineProps<{
   credits: string
   label: string
   estimateKey?: TranslationKey
   estimateCount?: string
-  locale?: Locale
+  locale: Locale
 }>()
 
 const estimate = computed(() => {

--- a/apps/website/src/components/pricing/PricingFaq.astro
+++ b/apps/website/src/components/pricing/PricingFaq.astro
@@ -6,11 +6,11 @@ import { t } from '../../i18n/translations'
 import FaqLink from './FaqLink.astro'
 
 interface Props {
-  locale?: Locale
+  locale: Locale
   category?: 'pricing' | 'enterprise'
 }
 
-const { locale = 'en', category = 'pricing' } = Astro.props
+const { locale, category = 'pricing' } = Astro.props
 
 const entries = await getCollection('faq', (entry) =>
   entry.id.startsWith(`${category}/${locale}/`)

--- a/apps/website/src/components/pricing/PricingFreeBanner.test.ts
+++ b/apps/website/src/components/pricing/PricingFreeBanner.test.ts
@@ -14,7 +14,8 @@ const defaultProps = {
     labelKey: 'pricing.banner.cta',
     href: 'https://cloud.comfy.org',
     target: '_blank'
-  }
+  },
+  locale: 'en'
 } satisfies BannerProps
 
 function renderBanner(props: Partial<BannerProps> = {}) {

--- a/apps/website/src/components/pricing/PricingFreeBanner.vue
+++ b/apps/website/src/components/pricing/PricingFreeBanner.vue
@@ -5,7 +5,7 @@ import type { Locale, TranslationKey } from '../../i18n/translations'
 import { t } from '../../i18n/translations'
 import BrandButton from '../common/BrandButton.vue'
 
-const { locale = 'en' } = defineProps<{
+const { locale } = defineProps<{
   titleKey: TranslationKey
   subtitleKey: TranslationKey
   cta: {
@@ -13,7 +13,7 @@ const { locale = 'en' } = defineProps<{
     href: string
     target?: AnchorHTMLAttributes['target']
   }
-  locale?: Locale
+  locale: Locale
 }>()
 </script>
 

--- a/apps/website/src/components/pricing/PricingPlanFeatureList.vue
+++ b/apps/website/src/components/pricing/PricingPlanFeatureList.vue
@@ -29,9 +29,9 @@ const statusTextClass: Record<PlanFeatureStatus, string> = {
   coming: 'text-primary-warm-gray'
 }
 
-const { locale = 'en' } = defineProps<{
+const { locale } = defineProps<{
   features: PlanFeatureGroup[]
-  locale?: Locale
+  locale: Locale
 }>()
 </script>
 

--- a/apps/website/src/components/pricing/PricingPrice.vue
+++ b/apps/website/src/components/pricing/PricingPrice.vue
@@ -4,18 +4,14 @@ import { computed } from 'vue'
 
 import { t } from '../../i18n/translations'
 
-const {
-  locale = 'en',
-  billingPeriod,
-  yearlyTotal
-} = defineProps<{
+const { locale, billingPeriod, yearlyTotal } = defineProps<{
   price: string
   period: string
   originalPrice?: string
   discount?: string
   billingPeriod?: 'monthly' | 'yearly'
   yearlyTotal?: string
-  locale?: Locale
+  locale: Locale
 }>()
 
 const billingNote = computed(() => {

--- a/apps/website/src/components/pricing/PricingSection.vue
+++ b/apps/website/src/components/pricing/PricingSection.vue
@@ -20,11 +20,11 @@ import PricingPrice from './PricingPrice.vue'
 import PricingTeamCard from './PricingTeamCard.vue'
 
 const {
-  locale = 'en',
+  locale,
   headingLevel = 'h1',
   defaultBillingCycle = 'yearly'
 } = defineProps<{
-  locale?: Locale
+  locale: Locale
   headingLevel?: 'h1' | 'h2'
   defaultBillingCycle?: BillingCycle
 }>()

--- a/apps/website/src/components/pricing/PricingTeamCard.vue
+++ b/apps/website/src/components/pricing/PricingTeamCard.vue
@@ -19,9 +19,9 @@ import PricingPlanFeatureList from './PricingPlanFeatureList.vue'
 import PricingPlanLabel from './PricingPlanLabel.vue'
 import PricingPrice from './PricingPrice.vue'
 
-const { locale = 'en', billingPeriod } = defineProps<{
+const { locale, billingPeriod } = defineProps<{
   billingPeriod: 'monthly' | 'yearly'
-  locale?: Locale
+  locale: Locale
 }>()
 
 const teamCreditTierIndex = ref<number[]>([2])

--- a/apps/website/src/components/pricing/WhatsIncludedSection.vue
+++ b/apps/website/src/components/pricing/WhatsIncludedSection.vue
@@ -5,7 +5,7 @@ import { Clock } from '@lucide/vue'
 import { t } from '../../i18n/translations'
 import CheckIcon from '../icons/CheckIcon.vue'
 
-const { locale = 'en' } = defineProps<{ locale?: Locale }>()
+const { locale } = defineProps<{ locale: Locale }>()
 
 interface IncludedFeature {
   titleKey: TranslationKey

--- a/apps/website/src/components/product/cloud/AudienceSection.vue
+++ b/apps/website/src/components/product/cloud/AudienceSection.vue
@@ -6,7 +6,7 @@ import { t } from '../../../i18n/translations'
 import CardArrow from '../../common/CardArrow.vue'
 import GlassCard from '../../common/GlassCard.vue'
 
-const { locale = 'en' } = defineProps<{ locale?: Locale }>()
+const { locale } = defineProps<{ locale: Locale }>()
 
 const headingParts = t('cloud.audience.heading', locale).split('{creators}')
 

--- a/apps/website/src/components/product/cloud/FAQSection.vue
+++ b/apps/website/src/components/product/cloud/FAQSection.vue
@@ -3,7 +3,7 @@ import type { Locale } from '../../../i18n/translations'
 
 import FAQSection from '../../common/FAQSection.vue'
 
-const { locale = 'en' } = defineProps<{ locale?: Locale }>()
+const { locale } = defineProps<{ locale: Locale }>()
 </script>
 
 <template>

--- a/apps/website/src/components/product/cloud/HeroSection.vue
+++ b/apps/website/src/components/product/cloud/HeroSection.vue
@@ -6,7 +6,7 @@ import { t } from '../../../i18n/translations'
 import BrandButton from '../../common/BrandButton.vue'
 import ProductHeroBadge from '../../common/ProductHeroBadge.vue'
 
-const { locale = 'en' } = defineProps<{ locale?: Locale }>()
+const { locale } = defineProps<{ locale: Locale }>()
 </script>
 
 <template>

--- a/apps/website/src/components/product/cloud/PricingSection.vue
+++ b/apps/website/src/components/product/cloud/PricingSection.vue
@@ -5,7 +5,7 @@ import { SHOW_FREE_TIER } from '../../../config/features'
 import { getRoutes } from '../../../config/routes'
 import { t } from '../../../i18n/translations'
 
-const { locale = 'en' } = defineProps<{ locale?: Locale }>()
+const { locale } = defineProps<{ locale: Locale }>()
 </script>
 
 <template>

--- a/apps/website/src/components/product/cloud/ProductCardsSection.vue
+++ b/apps/website/src/components/product/cloud/ProductCardsSection.vue
@@ -3,7 +3,7 @@ import type { Locale } from '../../../i18n/translations'
 
 import ProductCardsSection from '../../common/ProductCardsSection.vue'
 
-const { locale = 'en' } = defineProps<{ locale?: Locale }>()
+const { locale } = defineProps<{ locale: Locale }>()
 </script>
 
 <template>

--- a/apps/website/src/components/product/cloud/ReasonSection.vue
+++ b/apps/website/src/components/product/cloud/ReasonSection.vue
@@ -6,7 +6,7 @@ import type { Reason } from '../shared/ReasonSection.vue'
 
 import ReasonSection from '../shared/ReasonSection.vue'
 
-const { locale = 'en' } = defineProps<{ locale?: Locale }>()
+const { locale } = defineProps<{ locale: Locale }>()
 
 interface CloudReason extends Reason {
   badge?: boolean

--- a/apps/website/src/components/product/local/DownloadLocalButton.vue
+++ b/apps/website/src/components/product/local/DownloadLocalButton.vue
@@ -12,8 +12,8 @@ import { t } from '../../../i18n/translations'
 import { captureDownloadClick } from '../../../scripts/posthog'
 import BrandButton from '../../common/BrandButton.vue'
 
-const { locale = 'en', class: customClass = '' } = defineProps<{
-  locale?: Locale
+const { locale, class: customClass = '' } = defineProps<{
+  locale: Locale
   class?: HTMLAttributes['class']
 }>()
 

--- a/apps/website/src/components/product/local/EcoSystemSection.vue
+++ b/apps/website/src/components/product/local/EcoSystemSection.vue
@@ -6,7 +6,7 @@ import { t } from '../../../i18n/translations'
 import BrandButton from '../../common/BrandButton.vue'
 import DownloadLocalButton from './DownloadLocalButton.vue'
 
-const { locale = 'en' } = defineProps<{ locale?: Locale }>()
+const { locale } = defineProps<{ locale: Locale }>()
 </script>
 
 <template>

--- a/apps/website/src/components/product/local/FAQSection.vue
+++ b/apps/website/src/components/product/local/FAQSection.vue
@@ -3,7 +3,7 @@ import type { Locale } from '../../../i18n/translations'
 
 import FAQSection from '../../common/FAQSection.vue'
 
-const { locale = 'en' } = defineProps<{ locale?: Locale }>()
+const { locale } = defineProps<{ locale: Locale }>()
 </script>
 
 <template>

--- a/apps/website/src/components/product/local/HeroSection.vue
+++ b/apps/website/src/components/product/local/HeroSection.vue
@@ -11,7 +11,7 @@ import ProductHeroBadge from '../../common/ProductHeroBadge.vue'
 import DownloadLocalButton from './DownloadLocalButton.vue'
 import MobileDownloadEmailForm from './MobileDownloadEmailForm.vue'
 
-const { locale = 'en' } = defineProps<{ locale?: Locale }>()
+const { locale } = defineProps<{ locale: Locale }>()
 
 const svgRef = ref<SVGSVGElement>()
 let animationId: number | null = null

--- a/apps/website/src/components/product/local/MobileDownloadEmailForm.test.ts
+++ b/apps/website/src/components/product/local/MobileDownloadEmailForm.test.ts
@@ -37,30 +37,30 @@ describe('MobileDownloadEmailForm', () => {
 
   it('renders nothing when the write key is not configured', () => {
     hoisted.isEnabled = false
-    render(MobileDownloadEmailForm)
+    render(MobileDownloadEmailForm, { props: { locale: 'en' } })
     expect(screen.queryByRole('textbox')).toBeNull()
   })
 
   it('renders nothing for non-mobile user agents', () => {
     hoisted.isMobileUa = false
-    render(MobileDownloadEmailForm)
+    render(MobileDownloadEmailForm, { props: { locale: 'en' } })
     expect(screen.queryByRole('textbox')).toBeNull()
   })
 
   it('preloads the SDK when the visible form mounts', () => {
-    render(MobileDownloadEmailForm)
+    render(MobileDownloadEmailForm, { props: { locale: 'en' } })
     expect(hoisted.mockPreload).toHaveBeenCalledOnce()
   })
 
   it('does not preload the SDK for non-mobile user agents', () => {
     hoisted.isMobileUa = false
-    render(MobileDownloadEmailForm)
+    render(MobileDownloadEmailForm, { props: { locale: 'en' } })
     expect(hoisted.mockPreload).not.toHaveBeenCalled()
   })
 
   it('shows an inline validation message for an invalid email and sends nothing', async () => {
     const user = userEvent.setup()
-    render(MobileDownloadEmailForm)
+    render(MobileDownloadEmailForm, { props: { locale: 'en' } })
 
     await user.type(screen.getByRole('textbox'), 'not-an-email')
     await user.click(
@@ -77,7 +77,7 @@ describe('MobileDownloadEmailForm', () => {
 
   it('fakes success without sending anything when the honeypot is filled', async () => {
     const user = userEvent.setup()
-    render(MobileDownloadEmailForm)
+    render(MobileDownloadEmailForm, { props: { locale: 'en' } })
 
     const visibleInput = screen.getByRole('textbox')
     await user.type(visibleInput, 'someone@example.com')
@@ -98,7 +98,7 @@ describe('MobileDownloadEmailForm', () => {
   it('shows an inline error on failure and lets a retry succeed', async () => {
     const user = userEvent.setup()
     hoisted.mockSubmit.mockRejectedValueOnce(new Error('network down'))
-    render(MobileDownloadEmailForm)
+    render(MobileDownloadEmailForm, { props: { locale: 'en' } })
 
     await user.type(screen.getByRole('textbox'), 'someone@example.com')
     const submitButton = screen.getByRole('button', {
@@ -126,7 +126,7 @@ describe('MobileDownloadEmailForm', () => {
           resolveSubmit = resolve
         })
     )
-    render(MobileDownloadEmailForm)
+    render(MobileDownloadEmailForm, { props: { locale: 'en' } })
 
     await user.type(screen.getByRole('textbox'), 'someone@example.com')
     const submitButton = screen.getByRole('button', {
@@ -148,7 +148,7 @@ describe('MobileDownloadEmailForm', () => {
 
   it('submits the entered email and swaps to the success line', async () => {
     const user = userEvent.setup()
-    render(MobileDownloadEmailForm)
+    render(MobileDownloadEmailForm, { props: { locale: 'en' } })
 
     await user.type(screen.getByRole('textbox'), 'someone@example.com')
     await user.click(
@@ -164,7 +164,7 @@ describe('MobileDownloadEmailForm', () => {
 
   it('moves focus to the success message when the form is removed', async () => {
     const user = userEvent.setup()
-    render(MobileDownloadEmailForm)
+    render(MobileDownloadEmailForm, { props: { locale: 'en' } })
 
     await user.type(screen.getByRole('textbox'), 'someone@example.com')
     await user.click(

--- a/apps/website/src/components/product/local/MobileDownloadEmailForm.vue
+++ b/apps/website/src/components/product/local/MobileDownloadEmailForm.vue
@@ -13,7 +13,7 @@ import {
   requestDownloadLink
 } from '../../../scripts/customerio'
 
-const { locale = 'en' } = defineProps<{ locale?: Locale }>()
+const { locale } = defineProps<{ locale: Locale }>()
 
 const { isMobileUa } = useDownloadUrl()
 

--- a/apps/website/src/components/product/local/ProductCardsSection.vue
+++ b/apps/website/src/components/product/local/ProductCardsSection.vue
@@ -3,7 +3,7 @@ import type { Locale } from '../../../i18n/translations'
 
 import ProductCardsSection from '../../common/ProductCardsSection.vue'
 
-const { locale = 'en' } = defineProps<{ locale?: Locale }>()
+const { locale } = defineProps<{ locale: Locale }>()
 </script>
 
 <template>

--- a/apps/website/src/components/product/local/ReasonSection.vue
+++ b/apps/website/src/components/product/local/ReasonSection.vue
@@ -5,7 +5,7 @@ import type { Reason } from '../shared/ReasonSection.vue'
 
 import ReasonSection from '../shared/ReasonSection.vue'
 
-const { locale = 'en' } = defineProps<{ locale?: Locale }>()
+const { locale } = defineProps<{ locale: Locale }>()
 
 const reasons: Reason[] = [
   {

--- a/apps/website/src/components/product/shared/AIModelsSection.vue
+++ b/apps/website/src/components/product/shared/AIModelsSection.vue
@@ -10,8 +10,8 @@ import CardArrow from '../../common/CardArrow.vue'
 import type { AiModelCard } from './aiModelCards'
 import { defaultAiModelCards } from './aiModelCards'
 
-const { locale = 'en', cards = defaultAiModelCards } = defineProps<{
-  locale?: Locale
+const { locale, cards = defaultAiModelCards } = defineProps<{
+  locale: Locale
   cards?: AiModelCard[]
 }>()
 

--- a/apps/website/src/components/product/shared/CloudBannerSection.vue
+++ b/apps/website/src/components/product/shared/CloudBannerSection.vue
@@ -4,7 +4,7 @@ import type { Locale } from '../../../i18n/translations'
 import { externalLinks } from '../../../config/routes'
 import { t } from '../../../i18n/translations'
 
-const { locale = 'en' } = defineProps<{ locale?: Locale }>()
+const { locale } = defineProps<{ locale: Locale }>()
 </script>
 
 <template>

--- a/apps/website/src/components/product/shared/ReasonSection.vue
+++ b/apps/website/src/components/product/shared/ReasonSection.vue
@@ -9,7 +9,7 @@ export interface Reason {
 }
 
 const {
-  locale = 'en',
+  locale,
   headingKey,
   headingHighlightKey,
   headingSuffixKey,
@@ -17,7 +17,7 @@ const {
   highlightClass = 'text-white',
   reasons
 } = defineProps<{
-  locale?: Locale
+  locale: Locale
   headingKey: TranslationKey
   headingHighlightKey?: TranslationKey
   headingSuffixKey?: TranslationKey

--- a/apps/website/src/components/ui/scroll-carousel/ScrollCarousel.vue
+++ b/apps/website/src/components/ui/scroll-carousel/ScrollCarousel.vue
@@ -8,11 +8,11 @@ import { t } from '../../../i18n/translations'
 import type { Locale } from '../../../i18n/translations'
 
 const {
-  locale = 'en',
+  locale,
   gapClass = 'gap-12 lg:gap-20',
   class: className
 } = defineProps<{
-  locale?: Locale
+  locale: Locale
   gapClass?: string
   class?: HTMLAttributes['class']
 }>()

--- a/apps/website/src/config/contentSections.ts
+++ b/apps/website/src/config/contentSections.ts
@@ -36,7 +36,7 @@ function inferBlockType(
   if (hasKey(`${bp}.heading`)) return 'heading'
   if (hasKey(`${bp}.ol`)) return 'ordered-list'
 
-  const value = hasKey(bp) ? t(bp as never) : ''
+  const value = hasKey(bp) ? t(bp as never, 'en') : ''
   if (value.includes('\n')) return 'list'
   return 'paragraph'
 }

--- a/apps/website/src/config/routes.ts
+++ b/apps/website/src/config/routes.ts
@@ -92,14 +92,14 @@ export function isLocaleInvariantPath(pathname: string): boolean {
   )
 }
 
-export function localizeHref(href: string, locale: Locale = 'en'): string {
+export function localizeHref(href: string, locale: Locale): string {
   if (locale === 'en' || !href.startsWith('/')) return href
   if (LOCALE_INVARIANT_PATHS.has(href)) return href
   if (locale === 'ja') return href === '/' ? '/ja/' : href
   return `/${locale}${href}`
 }
 
-export function getRoutes(locale: Locale = 'en'): Routes {
+export function getRoutes(locale: Locale): Routes {
   if (locale === 'en') return baseRoutes
   return Object.fromEntries(
     Object.entries(baseRoutes).map(([key, path]) => [

--- a/apps/website/src/data/fdct.ts
+++ b/apps/website/src/data/fdct.ts
@@ -42,9 +42,7 @@ const technologistIdentities = {
   }
 } as const
 
-export function technologists(
-  locale: Locale = 'en'
-): readonly FdctTechnologist[] {
+export function technologists(locale: Locale): readonly FdctTechnologist[] {
   return [
     {
       id: 'doug-hogan',
@@ -102,7 +100,7 @@ export interface FdctProject {
 // Top workflows from each technologist's hub page (most-popular order);
 // cover videos are the hub's own preview assets. Chris's picks land once
 // his hub page link is provided.
-export function projects(locale: Locale = 'en'): readonly FdctProject[] {
+export function projects(locale: Locale): readonly FdctProject[] {
   return [
     {
       id: 'product-advertisement-video',
@@ -324,7 +322,7 @@ export interface FdctFeaturedProject {
 // assets come from each workflow's own hub page; order and tag labels match
 // the design (10331:36004). The cards deliberately carry no workflow links.
 export function featuredProjects(
-  locale: Locale = 'en'
+  locale: Locale
 ): readonly FdctFeaturedProject[] {
   return [
     {

--- a/apps/website/src/data/wan3.test.ts
+++ b/apps/website/src/data/wan3.test.ts
@@ -29,7 +29,9 @@ function flushMount() {
 }
 
 function renderHero() {
-  render(ModelLaunchHeroSection, { props: { hero: wan3Page.hero } })
+  render(ModelLaunchHeroSection, {
+    props: { hero: wan3Page.hero, locale: 'en' }
+  })
   return flushMount()
 }
 

--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -8213,7 +8213,7 @@ export type LocalizedText = { en: string; 'zh-CN': string } & Partial<
   Record<Locale, string>
 >
 
-export function t(key: TranslationKey, locale: Locale = 'en'): string {
+export function t(key: TranslationKey, locale: Locale): string {
   const entry = translations[key] as LocalizedText
   return entry[locale] ?? entry.en
 }

--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -117,6 +117,12 @@ const translations = {
     'zh-CN': '复制'
   },
   'ui.breadcrumb': { en: 'Breadcrumb', 'zh-CN': '面包屑导航' },
+  'ui.alt.comfyLogo': { en: 'Comfy logo', 'zh-CN': 'Comfy 标志' },
+  'ui.alt.comfy3dLogo': { en: 'Comfy 3D logo', 'zh-CN': 'Comfy 3D 标志' },
+  'ui.alt.comfyTeam': { en: 'Comfy team', 'zh-CN': 'Comfy 团队' },
+  'ui.nav.main': { en: 'Main navigation', 'zh-CN': '主导航' },
+  'ui.nav.home': { en: 'Comfy home', 'zh-CN': 'Comfy 主页' },
+  'ui.nav.categoryFilter': { en: 'Category filter', 'zh-CN': '分类筛选' },
   'ui.readMore': { en: 'Read more', 'zh-CN': '展开' },
   'ui.readLess': { en: 'Read less', 'zh-CN': '收起' },
   'ui.copied': {
@@ -2018,10 +2024,8 @@ Enterprise`
     'zh-CN':
       '2023 年 1 月，市场上没有任何工具能将两个 AI 模型串联成可重复的工作流。一位魁北克市的开发者用两周时间自己构建了一个，并将其开源。'
   },
-  'about.story.investorsLabel': {
-    en: 'OUR INVESTORS',
-    'zh-CN': '我们的投资者'
-  },
+  'about.story.investorsLabelPrefix': { en: 'OUR', 'zh-CN': '我们的' },
+  'about.story.investorsLabelNoun': { en: 'INVESTORS', 'zh-CN': '投资者' },
   'about.story.investorsBody': {
     en: 'If it can be open, it should be open. That\u2019s how we build an ecosystem that moves faster than any company could think for, and it\u2019s how we think about code, content, and skins. We make money by building things worth paying for, not by controlling what we believe should be free.',
     'zh-CN':
@@ -5451,6 +5455,7 @@ Enterprise`
   },
 
   // Models – UI keys
+  'models.hero.inComfyUI': { en: 'in ComfyUI', 'zh-CN': '在 ComfyUI 中' },
   'models.hero.eyebrow': {
     en: 'AI Model',
     'zh-CN': 'AI 模型'
@@ -8216,6 +8221,17 @@ export type LocalizedText = { en: string; 'zh-CN': string } & Partial<
 export function t(key: TranslationKey, locale: Locale): string {
   const entry = translations[key] as LocalizedText
   return entry[locale] ?? entry.en
+}
+
+/**
+ * Narrows `Astro.currentLocale` to a supported locale. Only `.astro`
+ * components can call this — Vue islands render as isolated app roots with no
+ * access to the page's render context, so they must receive `locale` as a prop.
+ */
+export function resolveLocale(currentLocale: string | undefined): Locale {
+  return currentLocale === 'zh-CN' || currentLocale === 'ja'
+    ? currentLocale
+    : 'en'
 }
 
 export const translationKeys = Object.keys(translations) as TranslationKey[]

--- a/apps/website/src/pages/about.astro
+++ b/apps/website/src/pages/about.astro
@@ -25,9 +25,9 @@ const { siteUrl, locale } = pageContext(
     { name: t('breadcrumb.about', locale) },
   ]}
 >
-  <HeroSection client:load />
-  <StorySection />
-  <OurValuesSection />
-  <ValuesSection client:visible />
-  <CareersSection />
+  <HeroSection locale={locale} client:load />
+  <StorySection locale={locale} />
+  <OurValuesSection locale={locale} />
+  <ValuesSection locale={locale} client:visible />
+  <CareersSection locale={locale} />
 </BaseLayout>

--- a/apps/website/src/pages/affiliates/index.astro
+++ b/apps/website/src/pages/affiliates/index.astro
@@ -40,11 +40,11 @@ const faqPage: JsonLdNode = {
   extraJsonLd={[faqPage]}
 >
 
-  <HeroSection />
-  <HowItWorksSection />
-  <AudienceSection />
-  <BenefitsSection />
-  <BrandAssetsSection />
-  <FAQSection client:visible />
-  <CtaSection />
+  <HeroSection locale={locale} />
+  <HowItWorksSection locale={locale} />
+  <AudienceSection locale={locale} />
+  <BenefitsSection locale={locale} />
+  <BrandAssetsSection locale={locale} />
+  <FAQSection locale={locale} client:visible />
+  <CtaSection locale={locale} />
 </BaseLayout>

--- a/apps/website/src/pages/affiliates/terms.astro
+++ b/apps/website/src/pages/affiliates/terms.astro
@@ -12,13 +12,13 @@ import { t } from '../../i18n/translations'
 ---
 
 <BaseLayout
-  title={t('affiliate-terms.page.title')}
-  description={t('affiliate-terms.page.description')}
+  title={t('affiliate-terms.page.title', 'en')}
+  description={t('affiliate-terms.page.description', 'en')}
 >
-  <HeroSection title={t('affiliate-terms.page.heading')} />
+  <HeroSection title={t('affiliate-terms.page.heading', 'en')} />
   <p class="text-primary-warm-gray mt-2 text-center text-sm">
-    {t('affiliate-terms.page.effectiveDateLabel')}: {
-      t('affiliate-terms.effective-date')
+    {t('affiliate-terms.page.effectiveDateLabel', 'en')}: {
+      t('affiliate-terms.effective-date', 'en')
     }
   </p>
   <LegalContentSection

--- a/apps/website/src/pages/brand.astro
+++ b/apps/website/src/pages/brand.astro
@@ -18,11 +18,11 @@ const locale = 'en' as const
 >
   <div class="relative">
     <BrandBackground client:idle />
-    <BrandHeroSection />
-    <BrandLogosSection />
-    <BrandColorSection client:visible />
-    <BrandVoiceSection />
-    <BrandTrademarkSection />
-    <BrandQuestionsSection />
+    <BrandHeroSection locale={locale} />
+    <BrandLogosSection locale={locale} />
+    <BrandColorSection locale={locale} client:visible />
+    <BrandVoiceSection locale={locale} />
+    <BrandTrademarkSection locale={locale} />
+    <BrandQuestionsSection locale={locale} />
   </div>
 </BaseLayout>

--- a/apps/website/src/pages/careers.astro
+++ b/apps/website/src/pages/careers.astro
@@ -52,11 +52,11 @@ const roles = itemListNode(
   ]}
   extraJsonLd={[roles]}
 >
-  <HeroSection />
-  <RolesSection departments={departments} client:visible />
-  <WhyJoinSection client:visible />
+  <HeroSection locale={locale} />
+  <RolesSection locale={locale} departments={departments} client:visible />
+  <WhyJoinSection locale={locale} client:visible />
   <TeamPhotosSection client:visible />
-  <FAQSection
+  <FAQSection locale={locale}
     headingKey="careers.faq.heading"
     faqPrefix="careers.faq"
     faqCount={8}

--- a/apps/website/src/pages/cloud/index.astro
+++ b/apps/website/src/pages/cloud/index.astro
@@ -15,11 +15,11 @@ import { t } from '../../i18n/translations'
   description={t('cloud.hero.subtitle', 'en')}
   keywords={['comfyui web app', 'comfyui app', 'comfyui online', 'comfyui cloud', 'comfy cloud', 'comfy ui application', 'comfyui browser', 'cloud comfyui', 'managed comfyui']}
 >
-  <HeroSection />
-  <ReasonSection />
-  <AIModelsSection />
-  <AudienceSection />
-  <PricingSection />
-  <ProductCardsSection />
-  <FAQSection client:visible />
+  <HeroSection locale="en" />
+  <ReasonSection locale="en" />
+  <AIModelsSection locale="en" />
+  <AudienceSection locale="en" />
+  <PricingSection locale="en" />
+  <ProductCardsSection locale="en" />
+  <FAQSection locale="en" client:visible />
 </BaseLayout>

--- a/apps/website/src/pages/cloud/supported-nodes.astro
+++ b/apps/website/src/pages/cloud/supported-nodes.astro
@@ -44,6 +44,6 @@ const packList = itemListNode(
   ]}
   extraJsonLd={[packList]}
 >
-  <HeroSection client:visible />
-  <PackGridSection packs={gridPacks} client:visible />
+  <HeroSection locale={locale} client:visible />
+  <PackGridSection locale={locale} packs={gridPacks} client:visible />
 </BaseLayout>

--- a/apps/website/src/pages/cloud/supported-nodes/[pack].astro
+++ b/apps/website/src/pages/cloud/supported-nodes/[pack].astro
@@ -74,5 +74,5 @@ const software = softwareApplicationNode({
   ]}
   extraJsonLd={[software]}
 >
-  <PackDetail pack={pack} />
+  <PackDetail locale={locale} pack={pack} />
 </BaseLayout>

--- a/apps/website/src/pages/contact.astro
+++ b/apps/website/src/pages/contact.astro
@@ -40,7 +40,7 @@ const faqPage = faqPageNode(
   ]}
   extraJsonLd={[faqPage]}
 >
-  <FormSection client:load />
+  <FormSection locale={locale} client:load />
   <FAQSplit01
     client:visible
     heading={t('contact.faq.heading', locale)}

--- a/apps/website/src/pages/customers.astro
+++ b/apps/website/src/pages/customers.astro
@@ -39,9 +39,9 @@ const storyList = itemListNode(
   ]}
   extraJsonLd={[storyList]}
 >
-  <HeroSection client:load />
-  <StorySection stories={stories} />
-  <FeedbackSection client:load />
-  <VideoSection client:load />
-  <ContactSection />
+  <HeroSection locale={locale} client:load />
+  <StorySection locale={locale} stories={stories} />
+  <FeedbackSection locale={locale} client:load />
+  <VideoSection locale={locale} client:load />
+  <ContactSection locale={locale} />
 </BaseLayout>

--- a/apps/website/src/pages/customers/[slug].astro
+++ b/apps/website/src/pages/customers/[slug].astro
@@ -59,8 +59,8 @@ const article = articleNode({
     description={entry.data.description}
     image={entry.data.cover}
   />
-  <CustomerArticle entry={entry} />
-  <WhatsNextSection
+  <CustomerArticle locale={locale} entry={entry} />
+  <WhatsNextSection locale={locale}
     title={next.data.title}
     image={next.data.cover}
     href={`/customers/${storySlug(next.id)}`}

--- a/apps/website/src/pages/demos/[slug].astro
+++ b/apps/website/src/pages/demos/[slug].astro
@@ -24,14 +24,14 @@ export const getStaticPaths: GetStaticPaths = () => {
 const { slug } = Astro.params
 const demo = getDemoBySlug(slug as string)!
 const nextDemo = getNextDemo(slug as string)
-const title = t(demo.title)
-const description = t(demo.description)
 
 const { siteUrl, locale, url } = pageContext(
   Astro.site,
   Astro.url.pathname,
   Astro.currentLocale,
 )
+const title = t(demo.title, locale)
+const description = t(demo.description, locale)
 const educationalLevel =
   demo.difficulty === 'beginner'
     ? 'Beginner'
@@ -78,15 +78,15 @@ const learningResource: JsonLdNode = {
     <link rel="preconnect" href="https://demo.arcade.software" />
   </Fragment>
 
-  <DemoHeroSection
-    label={t(demo.category)}
+  <DemoHeroSection locale={locale}
+    label={t(demo.category, locale)}
     title={title}
     description={description}
     difficulty={demo.difficulty}
     estimatedTime={demo.estimatedTime}
   />
 
-  <ArcadeEmbed
+  <ArcadeEmbed locale={locale}
     arcadeId={demo.arcadeId}
     title={title}
     aspectRatio={demo.aspectRatio}
@@ -94,14 +94,14 @@ const learningResource: JsonLdNode = {
   />
 
   {demo.transcript && (
-    <DemoTranscript
-      transcript={t(demo.transcript)}
+    <DemoTranscript locale={locale}
+      transcript={t(demo.transcript, locale)}
       client:visible
     />
   )}
 
-  <DemoNavSection
-    nextTitle={t(nextDemo.title)}
+  <DemoNavSection locale={locale}
+    nextTitle={t(nextDemo.title, locale)}
     nextSlug={nextDemo.slug}
     nextThumbnail={nextDemo.thumbnail}
   />

--- a/apps/website/src/pages/download.astro
+++ b/apps/website/src/pages/download.astro
@@ -34,11 +34,11 @@ const { siteUrl, locale } = pageContext(
   extraJsonLd={[comfyUiApplicationNode(siteUrl), comfyUiSourceCodeNode(siteUrl)]}
   keywords={['comfyui app', 'comfyui desktop app', 'comfyui desktop', 'comfy ui application', 'comfyui download', 'download comfyui', 'comfyui windows', 'comfyui mac', 'comfyui linux']}
 >
-  <CloudBannerSection />
-  <HeroSection client:load />
-  <ReasonSection />
-  <EcoSystemSection client:visible />
-  <AIModelsSection />
-  <ProductCardsSection />
-  <FAQSection client:visible />
+  <CloudBannerSection locale={locale} />
+  <HeroSection locale={locale} client:load />
+  <ReasonSection locale={locale} />
+  <EcoSystemSection locale={locale} client:visible />
+  <AIModelsSection locale={locale} />
+  <ProductCardsSection locale={locale} />
+  <FAQSection locale={locale} client:visible />
 </BaseLayout>

--- a/apps/website/src/pages/enterprise-msa.astro
+++ b/apps/website/src/pages/enterprise-msa.astro
@@ -13,19 +13,19 @@ import { t } from '../i18n/translations'
 ---
 
 <BaseLayout
-  title={t('enterprise-msa.page.title')}
-  description={t('enterprise-msa.page.description')}
+  title={t('enterprise-msa.page.title', 'en')}
+  description={t('enterprise-msa.page.description', 'en')}
 >
-  <HeroSection title={t('enterprise-msa.page.heading')} />
+  <HeroSection title={t('enterprise-msa.page.heading', 'en')} />
   <p class="text-primary-warm-gray mt-2 text-center text-sm">
-    {t('enterprise-msa.page.effectiveDateLabel')}: {
-      t('enterprise-msa.effective-date')
+    {t('enterprise-msa.page.effectiveDateLabel', 'en')}: {
+      t('enterprise-msa.effective-date', 'en')
     }
   </p>
   <p
     class="text-primary-comfy-canvas mx-auto mt-8 max-w-3xl px-4 text-center text-sm/relaxed lg:px-0"
   >
-    {t('enterprise-msa.page.parties')}
+    {t('enterprise-msa.page.parties', 'en')}
   </p>
   <LegalContentSection
     prefix="enterprise-msa"

--- a/apps/website/src/pages/enterprise/index.astro
+++ b/apps/website/src/pages/enterprise/index.astro
@@ -190,6 +190,7 @@ const faqPage = buildFaqPageNode(url, faqs)
   extraJsonLd={[faqPage]}
 >
   <HeroSplit01
+    locale="en"
     badgeText="ENTERPRISE"
     title={'Govern ComfyUI across\nevery team and runtime.'}
     subtitle="Standardize how teams build, run, and deploy visual AI with ComfyUI Managed Builds, production capacity, commercial licensing, and hands-on implementation support."

--- a/apps/website/src/pages/gallery.astro
+++ b/apps/website/src/pages/gallery.astro
@@ -6,7 +6,7 @@ import ContactSection from '../components/gallery/ContactSection.vue'
 ---
 
 <BaseLayout title="Gallery - Comfy" description="Work built in ComfyUI by the community: images, video, and 3D. Submit your own to be featured on the site and Comfy's social channels.">
-  <HeroSection />
-  <GallerySection client:load />
-  <ContactSection />
+  <HeroSection locale="en" />
+  <GallerySection locale="en" client:load />
+  <ContactSection locale="en" />
 </BaseLayout>

--- a/apps/website/src/pages/index.astro
+++ b/apps/website/src/pages/index.astro
@@ -46,14 +46,14 @@ const { siteUrl } = pageContext(
     "generative ai workflows",
   ]}
 >
-  <HeroGraphSection client:load />
+  <HeroGraphSection locale="en" client:load />
   <SocialProofBarSection />
-  <MinimaxLicenseHeroSection client:visible />
-  <DeveloperPlatformSection client:visible />
+  <MinimaxLicenseHeroSection locale="en" client:visible />
+  <DeveloperPlatformSection locale="en" client:visible />
   <ModelReleaseSection locale="en" client:visible />
-  <FeaturedWorkflowsSection client:load />
+  <FeaturedWorkflowsSection locale="en" client:load />
   <ProductShowcaseSection locale="en" client:load />
-  <IndustriesSection client:load />
+  <IndustriesSection locale="en" client:load />
   <GetStartedSection locale="en" />
   <ProductCardsSection locale="en" />
   <CaseStudySpotlightSection locale="en" client:load />

--- a/apps/website/src/pages/index.astro
+++ b/apps/website/src/pages/index.astro
@@ -50,11 +50,11 @@ const { siteUrl } = pageContext(
   <SocialProofBarSection />
   <MinimaxLicenseHeroSection client:visible />
   <DeveloperPlatformSection client:visible />
-  <ModelReleaseSection client:visible />
+  <ModelReleaseSection locale="en" client:visible />
   <FeaturedWorkflowsSection client:load />
-  <ProductShowcaseSection client:load />
+  <ProductShowcaseSection locale="en" client:load />
   <IndustriesSection client:load />
-  <GetStartedSection />
-  <ProductCardsSection />
-  <CaseStudySpotlightSection client:load />
+  <GetStartedSection locale="en" />
+  <ProductCardsSection locale="en" />
+  <CaseStudySpotlightSection locale="en" client:load />
 </BaseLayout>

--- a/apps/website/src/pages/minimax/license/professional-request.astro
+++ b/apps/website/src/pages/minimax/license/professional-request.astro
@@ -13,7 +13,7 @@ import { absoluteUrl, organizationId, pageContext } from '../../../utils/jsonLd'
 // "MiniMax Commercial License - Professional" on HubSpot portal 244637579.
 const HUBSPOT_FORM_ID = '40ef858c-374a-4958-8180-bfa54f0a67fb'
 
-const TITLE = t('minimaxLicense.professionalRequest.title')
+const TITLE = t('minimaxLicense.professionalRequest.title', 'en')
 
 const { siteUrl } = pageContext(
   Astro.site,
@@ -25,13 +25,13 @@ const routes = getRoutes('en')
 
 <BaseLayout
   title={`${TITLE} - Comfy`}
-  description={t('minimaxLicense.professionalRequest.meta.description')}
+  description={t('minimaxLicense.professionalRequest.meta.description', 'en')}
   pageType="ContactPage"
   mainEntityId={organizationId(siteUrl)}
   breadcrumbs={[
-    { name: t('breadcrumb.home'), url: absoluteUrl(Astro.site, '/') },
+    { name: t('breadcrumb.home', 'en'), url: absoluteUrl(Astro.site, '/') },
     {
-      name: t('minimaxLicense.breadcrumb.model'),
+      name: t('minimaxLicense.breadcrumb.model', 'en'),
       url: absoluteUrl(Astro.site, routes.minimaxLicense),
     },
     { name: TITLE },
@@ -44,15 +44,15 @@ const routes = getRoutes('en')
       </h1>
 
       <p class="mt-6 text-sm text-primary-comfy-canvas">
-        {t('minimaxLicense.professionalRequest.intro')} <a
+        {t('minimaxLicense.professionalRequest.intro', 'en')} <a
           href={routes.minimaxLicense}
           class="text-primary-comfy-yellow underline underline-offset-4 hover:no-underline"
-          >{t('minimaxLicense.professionalRequest.introCta')}</a
+          >{t('minimaxLicense.professionalRequest.introCta', 'en')}</a
         >.
       </p>
 
       <div class="mt-12">
-        <HubspotFormEmbed formId={HUBSPOT_FORM_ID} client:load />
+        <HubspotFormEmbed locale="en" formId={HUBSPOT_FORM_ID} client:load />
       </div>
     </div>
   </section>

--- a/apps/website/src/pages/models.astro
+++ b/apps/website/src/pages/models.astro
@@ -10,13 +10,13 @@ import ProductShowcaseSection from '../components/home/ProductShowcaseSection.vu
   title="Models - Comfy"
   description="Run the world's leading AI models in ComfyUI. Browse every supported model with community workflow templates ready to run."
 >
-  <ModelsHeroSection
+  <ModelsHeroSection locale="en"
     modelName="Grok Imagine"
     ctaHref="/p/supported-models/grok-imagine"
     videoSrc="https://media.comfy.org/website/models/video_ComfdyUI_00001_.mp4"
     videoAriaLabel="Grok Imagine output created with ComfyUI"
   />
-  <ModelCreationsSection client:load />
-  <AIModelsSection client:load />
-  <ProductShowcaseSection client:load />
+  <ModelCreationsSection locale="en" client:load />
+  <AIModelsSection locale="en" client:load />
+  <ProductShowcaseSection locale="en" client:load />
 </BaseLayout>

--- a/apps/website/src/pages/p/supported-models/[slug].astro
+++ b/apps/website/src/pages/p/supported-models/[slug].astro
@@ -79,7 +79,7 @@ const faqPage = modelFaqJsonLd(faqs, jsonLdId(url, 'faq'))
         aria-expanded="false"
         class="cursor-pointer rounded-lg border border-white/15 bg-white/5 px-3 py-1.5 text-[11px] font-extrabold tracking-widest text-primary-comfy-canvas hover:bg-white/10"
       >
-        {t('models.llms.button')} ▾
+        {t('models.llms.button', 'en')} ▾
       </button>
       <div
         id="llms-menu"
@@ -89,16 +89,16 @@ const faqPage = modelFaqJsonLd(faqs, jsonLdId(url, 'faq'))
           id="llms-copy"
           class="block w-full cursor-pointer px-4 py-2.5 text-left text-xs text-primary-comfy-canvas hover:bg-white/5"
         >
-          {t('models.llms.copy')}<span id="llms-copied" class="hidden pl-2 text-primary-comfy-yellow">✓</span>
+          {t('models.llms.copy', 'en')}<span id="llms-copied" class="hidden pl-2 text-primary-comfy-yellow">✓</span>
         </button>
         <a href={llms.mdPath} class="block px-4 py-2.5 text-xs text-primary-comfy-canvas hover:bg-white/5">
-          {t('models.llms.view')}
+          {t('models.llms.view', 'en')}
         </a>
         <a
           href="/p/supported-models/llms.txt"
           class="block px-4 py-2.5 text-xs text-primary-comfy-canvas hover:bg-white/5"
         >
-          {t('models.llms.catalog')}
+          {t('models.llms.catalog', 'en')}
         </a>
         <div class="my-1 border-t border-white/10"></div>
         <a
@@ -107,7 +107,7 @@ const faqPage = modelFaqJsonLd(faqs, jsonLdId(url, 'faq'))
           rel="noopener noreferrer"
           class="block px-4 py-2.5 text-xs text-primary-comfy-canvas hover:bg-white/5"
         >
-          {t('models.llms.openClaude')} ↗
+          {t('models.llms.openClaude', 'en')} ↗
         </a>
         <a
           href={llms.chatgptUrl}
@@ -115,13 +115,14 @@ const faqPage = modelFaqJsonLd(faqs, jsonLdId(url, 'faq'))
           rel="noopener noreferrer"
           class="block px-4 py-2.5 text-xs text-primary-comfy-canvas hover:bg-white/5"
         >
-          {t('models.llms.openChatgpt')} ↗
+          {t('models.llms.openChatgpt', 'en')} ↗
         </a>
       </div>
     </div>
   </div>
 
   <ModelHeroSection
+    locale="en"
     displayName={displayName}
     huggingFaceUrl={model.huggingFaceUrl}
     docsUrl={model.docsUrl}
@@ -133,7 +134,7 @@ const faqPage = modelFaqJsonLd(faqs, jsonLdId(url, 'faq'))
 
   <section class="mx-auto max-w-7xl px-6 py-16 lg:px-8">
     <h2 class="text-2xl font-bold text-primary-comfy-canvas lg:text-3xl">
-      {t('models.whatIs.heading').replace('{name}', displayName)}
+      {t('models.whatIs.heading', 'en').replace('{name}', displayName)}
     </h2>
     <p class="mt-4 max-w-3xl text-base/relaxed text-primary-comfy-canvas/70 lg:text-lg/relaxed">
       {whatIsDescription}
@@ -145,7 +146,7 @@ const faqPage = modelFaqJsonLd(faqs, jsonLdId(url, 'faq'))
         rel="noopener noreferrer"
         class="mt-6 inline-block text-primary-comfy-yellow hover:underline"
       >
-        {t('models.whatIs.tutorialLink')}
+        {t('models.whatIs.tutorialLink', 'en')}
       </a>
     )}
   </section>

--- a/apps/website/src/pages/p/supported-models/index.astro
+++ b/apps/website/src/pages/p/supported-models/index.astro
@@ -9,8 +9,8 @@ import {
   pageContext,
 } from '../../../utils/jsonLd'
 
-const title = t('models.index.title')
-const subtitle = t('models.index.subtitle')
+const title = t('models.index.title', 'en')
+const subtitle = t('models.index.subtitle', 'en')
 
 const { url, locale } = pageContext(
   Astro.site,
@@ -58,7 +58,7 @@ const dirLabel: Record<string, string> = {
       <p
         class="mb-2 text-sm font-medium uppercase tracking-widest text-primary-comfy-yellow"
       >
-        {t('models.hero.eyebrow')}
+        {t('models.hero.eyebrow', 'en')}
       </p>
       <h1 class="text-4xl font-bold text-primary-comfy-canvas lg:text-6xl">
         {title}

--- a/apps/website/src/pages/payment/failed.astro
+++ b/apps/website/src/pages/payment/failed.astro
@@ -8,5 +8,5 @@ import PaymentStatusSection from '../../components/payment/PaymentStatusSection.
   description="Your payment was not completed."
   noindex
 >
-  <PaymentStatusSection status="failed" />
+  <PaymentStatusSection locale="en" status="failed" />
 </BaseLayout>

--- a/apps/website/src/pages/payment/success.astro
+++ b/apps/website/src/pages/payment/success.astro
@@ -8,5 +8,5 @@ import PaymentStatusSection from '../../components/payment/PaymentStatusSection.
   description="Your payment was processed successfully."
   noindex
 >
-  <PaymentStatusSection status="success" />
+  <PaymentStatusSection locale="en" status="success" />
 </BaseLayout>

--- a/apps/website/src/pages/pricing.astro
+++ b/apps/website/src/pages/pricing.astro
@@ -42,9 +42,9 @@ const productId = jsonLdId(url, 'product')
     }),
   ]}
 >
-  <MinimaxLicenseHeroSection client:visible />
-  <CloudPricingSection client:load />
-  <WhatsIncludedSection />
+  <MinimaxLicenseHeroSection locale={locale} client:visible />
+  <CloudPricingSection locale={locale} client:load />
+  <WhatsIncludedSection locale={locale} />
   <ResourceCostsSection
     locale={locale}
     heading={t('pricing.resourceCosts.heading', locale)}

--- a/apps/website/src/pages/privacy-policy.astro
+++ b/apps/website/src/pages/privacy-policy.astro
@@ -10,5 +10,5 @@ import HeroSection from '../components/legal/HeroSection.vue'
   noindex
 >
   <HeroSection title="Privacy Policy" />
-  <ContentSection prefix="privacy" client:load />
+  <ContentSection locale="en" prefix="privacy" client:load />
 </BaseLayout>

--- a/apps/website/src/pages/privacy/desktop.astro
+++ b/apps/website/src/pages/privacy/desktop.astro
@@ -9,5 +9,5 @@ import HeroSection from '../../components/legal/HeroSection.vue'
   description="Privacy policy for Comfy Desktop. Named processors, lawful basis under GDPR/UK GDPR, retention periods, and your rights."
 >
   <HeroSection title="Desktop Privacy Policy" />
-  <ContentSection prefix="desktop_privacy" client:load />
+  <ContentSection locale="en" prefix="desktop_privacy" client:load />
 </BaseLayout>

--- a/apps/website/src/pages/terms-of-service.astro
+++ b/apps/website/src/pages/terms-of-service.astro
@@ -12,7 +12,7 @@ import { t } from '../i18n/translations'
 >
   <HeroSection title="Terms of Service" />
   <p class="text-primary-warm-gray mt-2 text-center text-sm">
-    {t('tos.effectiveDateLabel')}: {t('tos.effectiveDate')}
+    {t('tos.effectiveDateLabel', 'en')}: {t('tos.effectiveDate', 'en')}
   </p>
-  <ContentSection prefix="tos" client:load />
+  <ContentSection locale="en" prefix="tos" client:load />
 </BaseLayout>

--- a/apps/website/src/templates/affiliate/AudienceSection.vue
+++ b/apps/website/src/templates/affiliate/AudienceSection.vue
@@ -5,7 +5,7 @@ import ChecklistSplit01 from '../../components/blocks/ChecklistSplit01.vue'
 import { affiliateAudienceCriteria } from '../../data/affiliateAudience'
 import { t } from '../../i18n/translations'
 
-const { locale = 'en' } = defineProps<{ locale?: Locale }>()
+const { locale } = defineProps<{ locale: Locale }>()
 
 const criteria = affiliateAudienceCriteria.map((criterion) => ({
   id: criterion.id,

--- a/apps/website/src/templates/affiliate/BenefitsSection.vue
+++ b/apps/website/src/templates/affiliate/BenefitsSection.vue
@@ -6,7 +6,7 @@ import { externalLinks } from '../../config/routes'
 import { affiliateBenefits } from '../../data/affiliateBenefits'
 import { t } from '../../i18n/translations'
 
-const { locale = 'en' } = defineProps<{ locale?: Locale }>()
+const { locale } = defineProps<{ locale: Locale }>()
 
 const benefits = affiliateBenefits.map((benefit) => ({
   id: benefit.id,

--- a/apps/website/src/templates/affiliate/BrandAssetsSection.vue
+++ b/apps/website/src/templates/affiliate/BrandAssetsSection.vue
@@ -6,7 +6,7 @@ import { getRoutes } from '../../config/routes'
 import { affiliateBrandAssets } from '../../data/affiliateBrandAssets'
 import { t } from '../../i18n/translations'
 
-const { locale = 'en' } = defineProps<{ locale?: Locale }>()
+const { locale } = defineProps<{ locale: Locale }>()
 
 const routes = getRoutes(locale)
 

--- a/apps/website/src/templates/affiliate/CtaSection.vue
+++ b/apps/website/src/templates/affiliate/CtaSection.vue
@@ -5,7 +5,7 @@ import CtaCenter01 from '../../components/blocks/CtaCenter01.vue'
 import { externalLinks, getRoutes } from '../../config/routes'
 import { t } from '../../i18n/translations'
 
-const { locale = 'en' } = defineProps<{ locale?: Locale }>()
+const { locale } = defineProps<{ locale: Locale }>()
 
 const routes = getRoutes(locale)
 </script>

--- a/apps/website/src/templates/affiliate/FAQSection.vue
+++ b/apps/website/src/templates/affiliate/FAQSection.vue
@@ -5,7 +5,7 @@ import FAQSplit01 from '../../components/blocks/FAQSplit01.vue'
 import { affiliateFaqs } from '../../data/affiliateFaq'
 import { t } from '../../i18n/translations'
 
-const { locale = 'en' } = defineProps<{ locale?: Locale }>()
+const { locale } = defineProps<{ locale: Locale }>()
 
 const faqs = affiliateFaqs.map((faq) => ({
   id: faq.id,

--- a/apps/website/src/templates/affiliate/HeroSection.vue
+++ b/apps/website/src/templates/affiliate/HeroSection.vue
@@ -5,11 +5,12 @@ import { t } from '../../i18n/translations'
 import HeroSplit01 from '../../components/blocks/HeroSplit01.vue'
 import { externalLinks } from '@/config/routes.ts'
 
-const { locale = 'en' } = defineProps<{ locale?: Locale }>()
+const { locale } = defineProps<{ locale: Locale }>()
 </script>
 
 <template>
   <HeroSplit01
+    :locale
     :badge-text="t('affiliate.hero.label', locale)"
     :title-highlight="t('affiliate.hero.headingHighlight', locale)"
     :title="t('affiliate.hero.headingMuted', locale)"

--- a/apps/website/src/templates/affiliate/HowItWorksSection.vue
+++ b/apps/website/src/templates/affiliate/HowItWorksSection.vue
@@ -5,7 +5,7 @@ import StepsGrid01 from '../../components/blocks/StepsGrid01.vue'
 import { affiliateHowItWorksSteps } from '../../data/affiliateHowItWorks'
 import { t } from '../../i18n/translations'
 
-const { locale = 'en' } = defineProps<{ locale?: Locale }>()
+const { locale } = defineProps<{ locale: Locale }>()
 
 const steps = affiliateHowItWorksSteps.map((step) => ({
   id: step.id,

--- a/apps/website/src/templates/brand/BrandColorSection.vue
+++ b/apps/website/src/templates/brand/BrandColorSection.vue
@@ -9,7 +9,7 @@ import SectionHeader from '../../components/common/SectionHeader.vue'
 import { brandColors } from '../../data/brandColors'
 import { t } from '../../i18n/translations'
 
-const { locale = 'en' } = defineProps<{ locale?: Locale }>()
+const { locale } = defineProps<{ locale: Locale }>()
 
 const specRows = ['hex', 'rgb', 'hsl', 'cmyk'] as const
 

--- a/apps/website/src/templates/brand/BrandHeroSection.vue
+++ b/apps/website/src/templates/brand/BrandHeroSection.vue
@@ -5,7 +5,7 @@ import Button from '../../components/ui/button/Button.vue'
 import { BRAND_ASSETS_ZIP, BRAND_GUIDELINES_PDF } from '../../data/brandAssets'
 import { t } from '../../i18n/translations'
 
-const { locale = 'en' } = defineProps<{ locale?: Locale }>()
+const { locale } = defineProps<{ locale: Locale }>()
 </script>
 
 <template>

--- a/apps/website/src/templates/brand/BrandLogosSection.vue
+++ b/apps/website/src/templates/brand/BrandLogosSection.vue
@@ -7,7 +7,7 @@ import SectionHeader from '../../components/common/SectionHeader.vue'
 import { affiliateBrandAssets } from '../../data/affiliateBrandAssets'
 import { t } from '../../i18n/translations'
 
-const { locale = 'en' } = defineProps<{ locale?: Locale }>()
+const { locale } = defineProps<{ locale: Locale }>()
 
 const assets = affiliateBrandAssets.map((asset) =>
   asset.id === 'icon' ? { ...asset, preview: '/icons/comfyicon.svg' } : asset

--- a/apps/website/src/templates/brand/BrandQuestionsSection.vue
+++ b/apps/website/src/templates/brand/BrandQuestionsSection.vue
@@ -6,7 +6,7 @@ import Button from '../../components/ui/button/Button.vue'
 import { externalLinks } from '../../config/routes.ts'
 import { t } from '../../i18n/translations'
 
-const { locale = 'en' } = defineProps<{ locale?: Locale }>()
+const { locale } = defineProps<{ locale: Locale }>()
 </script>
 
 <template>

--- a/apps/website/src/templates/brand/BrandTrademarkSection.vue
+++ b/apps/website/src/templates/brand/BrandTrademarkSection.vue
@@ -6,7 +6,7 @@ import Button from '../../components/ui/button/Button.vue'
 import { externalLinks } from '../../config/routes.ts'
 import { t } from '../../i18n/translations'
 
-const { locale = 'en' } = defineProps<{ locale?: Locale }>()
+const { locale } = defineProps<{ locale: Locale }>()
 </script>
 
 <template>

--- a/apps/website/src/templates/brand/BrandVoiceSection.vue
+++ b/apps/website/src/templates/brand/BrandVoiceSection.vue
@@ -4,7 +4,7 @@ import type { Locale } from '../../i18n/translations'
 import SectionHeader from '../../components/common/SectionHeader.vue'
 import { t } from '../../i18n/translations'
 
-const { locale = 'en' } = defineProps<{ locale?: Locale }>()
+const { locale } = defineProps<{ locale: Locale }>()
 
 const principles = [
   {

--- a/apps/website/src/templates/drops/AnnouncementBanner.vue
+++ b/apps/website/src/templates/drops/AnnouncementBanner.vue
@@ -9,14 +9,10 @@ import Button from '@/components/ui/button/Button.vue'
 import IconButton from '@/components/ui/icon-button/IconButton.vue'
 import { useBannerDismissal } from '../../composables/useBannerDismissal'
 
-const {
-  data,
-  version,
-  locale = 'en'
-} = defineProps<{
+const { data, version, locale } = defineProps<{
   data: BannerData
   version: string
-  locale?: Locale
+  locale: Locale
 }>()
 
 const { isVisible, close, persistHidden } = useBannerDismissal(version)

--- a/apps/website/src/templates/drops/CtaSection.vue
+++ b/apps/website/src/templates/drops/CtaSection.vue
@@ -5,7 +5,7 @@ import CtaCenter01 from '../../components/blocks/CtaCenter01.vue'
 import { externalLinks } from '../../config/routes'
 import { t } from '../../i18n/translations'
 
-const { locale = 'en' } = defineProps<{ locale?: Locale }>()
+const { locale } = defineProps<{ locale: Locale }>()
 </script>
 
 <template>

--- a/apps/website/src/templates/drops/DropsSection.vue
+++ b/apps/website/src/templates/drops/DropsSection.vue
@@ -8,7 +8,7 @@ import type { CardArticleGalleryItem } from '../../components/blocks/CardArticle
 import { drops } from '../../data/drops'
 import { t } from '../../i18n/translations'
 
-const { locale = 'en' } = defineProps<{ locale?: Locale }>()
+const { locale } = defineProps<{ locale: Locale }>()
 
 const items = computed<CardArticleGalleryItem[]>(() =>
   drops.map((drop) => ({

--- a/apps/website/src/templates/drops/HeroSection.vue
+++ b/apps/website/src/templates/drops/HeroSection.vue
@@ -7,7 +7,7 @@ import { externalLinks, getRoutes } from '../../config/routes'
 import { t } from '../../i18n/translations'
 import { livestream } from './livestream'
 
-const { locale = 'en' } = defineProps<{ locale?: Locale }>()
+const { locale } = defineProps<{ locale: Locale }>()
 
 const routes = getRoutes(locale)
 </script>

--- a/apps/website/src/templates/events/EventVideoDialog.vue
+++ b/apps/website/src/templates/events/EventVideoDialog.vue
@@ -16,20 +16,15 @@ import type { CalendarEvent } from '../../utils/calendar'
 import { t } from '../../i18n/translations'
 import { isUrlUnderPath, previousEntryUrl } from '../../utils/previousEntry'
 
-const {
-  title,
-  description,
-  youtubeVideoId,
-  calendarEvent,
-  locale
-} = defineProps<{
-  title: string
-  description: string
-  youtubeVideoId: string
-  /** Future events: offer adding the stream to the visitor's calendar. */
-  calendarEvent?: CalendarEvent
-  locale: Locale
-}>()
+const { title, description, youtubeVideoId, calendarEvent, locale } =
+  defineProps<{
+    title: string
+    description: string
+    youtubeVideoId: string
+    /** Future events: offer adding the stream to the visitor's calendar. */
+    calendarEvent?: CalendarEvent
+    locale: Locale
+  }>()
 
 const dialogEl = useTemplateRef<HTMLDialogElement>('dialogEl')
 

--- a/apps/website/src/templates/events/EventVideoDialog.vue
+++ b/apps/website/src/templates/events/EventVideoDialog.vue
@@ -21,14 +21,14 @@ const {
   description,
   youtubeVideoId,
   calendarEvent,
-  locale = 'en'
+  locale
 } = defineProps<{
   title: string
   description: string
   youtubeVideoId: string
   /** Future events: offer adding the stream to the visitor's calendar. */
   calendarEvent?: CalendarEvent
-  locale?: Locale
+  locale: Locale
 }>()
 
 const dialogEl = useTemplateRef<HTMLDialogElement>('dialogEl')

--- a/apps/website/src/templates/events/EventsHeroSection.vue
+++ b/apps/website/src/templates/events/EventsHeroSection.vue
@@ -9,7 +9,7 @@ import HeroCentered01 from '../../components/blocks/HeroCentered01.vue'
 import { featuredEvents } from '../../data/events'
 import { t } from '../../i18n/translations'
 
-const { locale = 'en' } = defineProps<{ locale?: Locale }>()
+const { locale } = defineProps<{ locale: Locale }>()
 
 const slides = computed<FeaturedSlide[]>(() =>
   featuredEvents.map((event) => ({

--- a/apps/website/src/templates/events/PastEventsSection.vue
+++ b/apps/website/src/templates/events/PastEventsSection.vue
@@ -9,7 +9,7 @@ import { localizeHref } from '../../config/routes'
 import { eventPath, eventVideoId, pastEvents } from '../../data/events'
 import { t } from '../../i18n/translations'
 
-const { locale = 'en' } = defineProps<{ locale?: Locale }>()
+const { locale } = defineProps<{ locale: Locale }>()
 
 const items = computed<CardArticleGalleryItem[]>(() =>
   pastEvents.flatMap((event) => {

--- a/apps/website/src/templates/events/UpcomingEventsSection.test.ts
+++ b/apps/website/src/templates/events/UpcomingEventsSection.test.ts
@@ -60,7 +60,7 @@ beforeEach(() => {
 
 describe('UpcomingEventsSection', () => {
   it('renders a row per upcoming event with its title, blurb, location and date', () => {
-    render(UpcomingEventsSection)
+    render(UpcomingEventsSection, { props: { locale: 'en' } })
 
     const rows = screen.getAllByRole('listitem')
     expect(rows).toHaveLength(2)
@@ -75,7 +75,7 @@ describe('UpcomingEventsSection', () => {
   })
 
   it('links streamed events to their own page and the rest straight out', () => {
-    render(UpcomingEventsSection)
+    render(UpcomingEventsSection, { props: { locale: 'en' } })
 
     const streamedLink = screen.getByRole('link', {
       name: `${streamedEvent.title.en} — Livestream`
@@ -96,7 +96,7 @@ describe('UpcomingEventsSection', () => {
   it('keeps the list in place when nothing is upcoming', () => {
     stub.upcomingEvents = []
 
-    render(UpcomingEventsSection)
+    render(UpcomingEventsSection, { props: { locale: 'en' } })
 
     expect(screen.getByRole('list')).toBeTruthy()
     expect(screen.queryAllByRole('listitem')).toHaveLength(0)

--- a/apps/website/src/templates/events/UpcomingEventsSection.vue
+++ b/apps/website/src/templates/events/UpcomingEventsSection.vue
@@ -16,7 +16,7 @@ import {
 import { t } from '../../i18n/translations'
 import { resolveRel } from '../../utils/cta'
 
-const { locale = 'en' } = defineProps<{ locale?: Locale }>()
+const { locale } = defineProps<{ locale: Locale }>()
 
 // Events with a stream open their own /events/[slug] page (dialog over the
 // directory); the rest link out to the event's page.

--- a/apps/website/src/templates/fdct/BuildersSection.vue
+++ b/apps/website/src/templates/fdct/BuildersSection.vue
@@ -5,7 +5,7 @@ import SectionHeader from '../../components/common/SectionHeader.vue'
 import WireNodeLayout from '../../components/common/WireNodeLayout.vue'
 import { t } from '../../i18n/translations'
 
-const { locale = 'en' } = defineProps<{ locale?: Locale }>()
+const { locale } = defineProps<{ locale: Locale }>()
 
 const reasons: TranslationKey[] = [
   'fdct.builders.reason1',

--- a/apps/website/src/templates/fdct/ClosingCtaSection.vue
+++ b/apps/website/src/templates/fdct/ClosingCtaSection.vue
@@ -6,7 +6,7 @@ import { localizeHref } from '../../config/routes'
 import { fdctPage } from '../../data/fdct'
 import { t } from '../../i18n/translations'
 
-const { locale = 'en' } = defineProps<{ locale?: Locale }>()
+const { locale } = defineProps<{ locale: Locale }>()
 </script>
 
 <template>

--- a/apps/website/src/templates/fdct/CtaBandsSection.vue
+++ b/apps/website/src/templates/fdct/CtaBandsSection.vue
@@ -6,7 +6,7 @@ import { localizeHref } from '../../config/routes'
 import { fdctPage } from '../../data/fdct'
 import { t } from '../../i18n/translations'
 
-const { locale = 'en' } = defineProps<{ locale?: Locale }>()
+const { locale } = defineProps<{ locale: Locale }>()
 
 const bands = [
   {

--- a/apps/website/src/templates/fdct/FAQSection.vue
+++ b/apps/website/src/templates/fdct/FAQSection.vue
@@ -5,7 +5,7 @@ import FAQSplit01 from '../../components/blocks/FAQSplit01.vue'
 import { fdctFaqs } from '../../data/fdct'
 import { t } from '../../i18n/translations'
 
-const { locale = 'en' } = defineProps<{ locale?: Locale }>()
+const { locale } = defineProps<{ locale: Locale }>()
 
 const faqs = fdctFaqs(locale)
 </script>

--- a/apps/website/src/templates/fdct/HeroSection.vue
+++ b/apps/website/src/templates/fdct/HeroSection.vue
@@ -6,7 +6,7 @@ import { localizeHref } from '../../config/routes'
 import { fdctPage } from '../../data/fdct'
 import { t } from '../../i18n/translations'
 
-const { locale = 'en' } = defineProps<{ locale?: Locale }>()
+const { locale } = defineProps<{ locale: Locale }>()
 </script>
 
 <template>

--- a/apps/website/src/templates/fdct/HowItWorksSection.vue
+++ b/apps/website/src/templates/fdct/HowItWorksSection.vue
@@ -4,7 +4,7 @@ import type { Locale } from '../../i18n/translations'
 import BenefitsGrid01 from '../../components/blocks/BenefitsGrid01.vue'
 import { t } from '../../i18n/translations'
 
-const { locale = 'en' } = defineProps<{ locale?: Locale }>()
+const { locale } = defineProps<{ locale: Locale }>()
 
 const steps = (['step1', 'step2', 'step3', 'step4'] as const).map((step) => ({
   id: step,

--- a/apps/website/src/templates/fdct/PastProjectsSection.vue
+++ b/apps/website/src/templates/fdct/PastProjectsSection.vue
@@ -8,7 +8,7 @@ import type { CardWorkflowItem } from '../../components/blocks/CardWorkflow01.vu
 import { featuredProjects } from '../../data/fdct'
 import { t } from '../../i18n/translations'
 
-const { locale = 'en' } = defineProps<{ locale?: Locale }>()
+const { locale } = defineProps<{ locale: Locale }>()
 
 const items = computed<CardWorkflowItem[]>(() =>
   featuredProjects(locale).map((project) => ({

--- a/apps/website/src/templates/fdct/TechnologistsSection.vue
+++ b/apps/website/src/templates/fdct/TechnologistsSection.vue
@@ -7,7 +7,7 @@ import type { FdctTechnologist } from '../../data/fdct'
 import { projects, technologists } from '../../data/fdct'
 import { t } from '../../i18n/translations'
 
-const { locale = 'en' } = defineProps<{ locale?: Locale }>()
+const { locale } = defineProps<{ locale: Locale }>()
 
 // Each dialog shows its technologist's workflows from the shared past-projects
 // list (already in most-popular order); profiles without any get no grid.

--- a/apps/website/src/templates/fdct/WhatYouGetSection.vue
+++ b/apps/website/src/templates/fdct/WhatYouGetSection.vue
@@ -4,7 +4,7 @@ import type { Locale } from '../../i18n/translations'
 import ChecklistSplit01 from '../../components/blocks/ChecklistSplit01.vue'
 import { t } from '../../i18n/translations'
 
-const { locale = 'en' } = defineProps<{ locale?: Locale }>()
+const { locale } = defineProps<{ locale: Locale }>()
 
 const criteria = (['item1', 'item2', 'item3', 'item4', 'item5'] as const).map(
   (item) => ({

--- a/apps/website/src/templates/mcp/ComfyMcpDemo.vue
+++ b/apps/website/src/templates/mcp/ComfyMcpDemo.vue
@@ -9,7 +9,7 @@ import type { Locale } from '../../i18n/translations'
 import { t } from '../../i18n/translations'
 import { mcpDemoPrompts, thumbUrls, visibleWindow } from './mcpDemoPrompts'
 
-const { locale = 'en' } = defineProps<{ locale?: Locale }>()
+const { locale } = defineProps<{ locale: Locale }>()
 
 const VISIBLE_CARDS = 5
 

--- a/apps/website/src/templates/mcp/FAQSection.vue
+++ b/apps/website/src/templates/mcp/FAQSection.vue
@@ -3,7 +3,7 @@ import FAQSplit01 from '../../components/blocks/FAQSplit01.vue'
 import type { Locale } from '../../i18n/translations'
 import { t } from '../../i18n/translations'
 
-const { locale = 'en' } = defineProps<{ locale?: Locale }>()
+const { locale } = defineProps<{ locale: Locale }>()
 
 const faqNumbers = [1, 2, 3, 4, 5, 6, 7, 8, 9] as const
 

--- a/apps/website/src/templates/mcp/HeroSection.vue
+++ b/apps/website/src/templates/mcp/HeroSection.vue
@@ -5,7 +5,7 @@ import { t } from '../../i18n/translations'
 import ComfyMcpDemo from './ComfyMcpDemo.vue'
 import { mcpCtas } from './ctas'
 
-const { locale = 'en' } = defineProps<{ locale?: Locale }>()
+const { locale } = defineProps<{ locale: Locale }>()
 
 const ctas = mcpCtas(locale)
 </script>

--- a/apps/website/src/templates/mcp/HowItWorksSection.vue
+++ b/apps/website/src/templates/mcp/HowItWorksSection.vue
@@ -5,7 +5,7 @@ import type { Locale } from '../../i18n/translations'
 import { t } from '../../i18n/translations'
 import { mcpCtas } from './ctas'
 
-const { locale = 'en' } = defineProps<{ locale?: Locale }>()
+const { locale } = defineProps<{ locale: Locale }>()
 
 const ctas = mcpCtas(locale)
 

--- a/apps/website/src/templates/mcp/SetupSection.vue
+++ b/apps/website/src/templates/mcp/SetupSection.vue
@@ -15,7 +15,7 @@ import {
   captureMcpConnectionTabClick
 } from '../../scripts/posthog'
 
-const { locale = 'en' } = defineProps<{ locale?: Locale }>()
+const { locale } = defineProps<{ locale: Locale }>()
 
 type ConnectionId = 'cloud' | 'local'
 

--- a/apps/website/src/templates/mcp/ToolsSection.vue
+++ b/apps/website/src/templates/mcp/ToolsSection.vue
@@ -5,7 +5,7 @@ import VideoPlayer from '../../components/common/VideoPlayer.vue'
 import type { Locale, TranslationKey } from '../../i18n/translations'
 import { t } from '../../i18n/translations'
 
-const { locale = 'en' } = defineProps<{ locale?: Locale }>()
+const { locale } = defineProps<{ locale: Locale }>()
 
 type ToolMedia =
   | { type: 'image'; src: string; fit?: 'cover' | 'contain' }

--- a/apps/website/src/templates/mcp/UseCasesSection.vue
+++ b/apps/website/src/templates/mcp/UseCasesSection.vue
@@ -4,7 +4,7 @@ import VideoPlayer from '../../components/common/VideoPlayer.vue'
 import type { Locale } from '../../i18n/translations'
 import { t } from '../../i18n/translations'
 
-const { locale = 'en' } = defineProps<{ locale?: Locale }>()
+const { locale } = defineProps<{ locale: Locale }>()
 </script>
 
 <template>

--- a/apps/website/src/templates/mcp/WhySection.vue
+++ b/apps/website/src/templates/mcp/WhySection.vue
@@ -4,7 +4,7 @@ import type { Reason } from '../../components/blocks/ReasonsSplit01.vue'
 import type { Locale } from '../../i18n/translations'
 import { t } from '../../i18n/translations'
 
-const { locale = 'en' } = defineProps<{ locale?: Locale }>()
+const { locale } = defineProps<{ locale: Locale }>()
 
 const reasonNumbers = [1, 2, 3, 4] as const
 

--- a/apps/website/src/templates/model-launch/ModelLaunchAudioGallerySection.vue
+++ b/apps/website/src/templates/model-launch/ModelLaunchAudioGallerySection.vue
@@ -4,9 +4,9 @@ import type { ModelLaunchAudioGallery } from './types'
 
 import ModelLaunchAudioSampleCard from './ModelLaunchAudioSampleCard.vue'
 
-const { locale = 'en', audioGallery } = defineProps<{
+const { locale, audioGallery } = defineProps<{
   audioGallery: ModelLaunchAudioGallery
-  locale?: Locale
+  locale: Locale
 }>()
 </script>
 

--- a/apps/website/src/templates/model-launch/ModelLaunchAudioSampleCard.vue
+++ b/apps/website/src/templates/model-launch/ModelLaunchAudioSampleCard.vue
@@ -6,9 +6,9 @@ import AudioPlayer from '../../components/common/AudioPlayer.vue'
 import CopyTextButton from '../../components/ui/copy-text-button/CopyTextButton.vue'
 import { t } from '../../i18n/translations'
 
-const { locale = 'en', card } = defineProps<{
+const { locale, card } = defineProps<{
   card: ModelLaunchAudioCard
-  locale?: Locale
+  locale: Locale
 }>()
 </script>
 

--- a/apps/website/src/templates/model-launch/ModelLaunchCtaSection.vue
+++ b/apps/website/src/templates/model-launch/ModelLaunchCtaSection.vue
@@ -5,9 +5,9 @@ import type { ModelLaunchClosingCta } from './types'
 import CtaCenter01 from '../../components/blocks/CtaCenter01.vue'
 import { t } from '../../i18n/translations'
 
-const { locale = 'en', cta } = defineProps<{
+const { locale, cta } = defineProps<{
   cta: ModelLaunchClosingCta
-  locale?: Locale
+  locale: Locale
 }>()
 </script>
 

--- a/apps/website/src/templates/model-launch/ModelLaunchFaqSection.vue
+++ b/apps/website/src/templates/model-launch/ModelLaunchFaqSection.vue
@@ -5,9 +5,9 @@ import type { ModelLaunchFaqSection } from './types'
 import FAQSplit01 from '../../components/blocks/FAQSplit01.vue'
 import { t } from '../../i18n/translations'
 
-const { locale = 'en', faq } = defineProps<{
+const { locale, faq } = defineProps<{
   faq: ModelLaunchFaqSection
-  locale?: Locale
+  locale: Locale
 }>()
 
 const faqs = faq.items.map((item) => ({

--- a/apps/website/src/templates/model-launch/ModelLaunchGallerySection.vue
+++ b/apps/website/src/templates/model-launch/ModelLaunchGallerySection.vue
@@ -12,9 +12,9 @@ import CopyTextButton from '../../components/ui/copy-text-button/CopyTextButton.
 import IconButton from '../../components/ui/icon-button/IconButton.vue'
 import { t } from '../../i18n/translations'
 
-const { locale = 'en', gallery } = defineProps<{
+const { locale, gallery } = defineProps<{
   gallery: ModelLaunchGallery
-  locale?: Locale
+  locale: Locale
 }>()
 
 // The cards sit well below the fold; defer their videos until the section

--- a/apps/website/src/templates/model-launch/ModelLaunchHeroCtaButtons.test.ts
+++ b/apps/website/src/templates/model-launch/ModelLaunchHeroCtaButtons.test.ts
@@ -7,7 +7,7 @@ import ModelLaunchHeroCtaButtons from './ModelLaunchHeroCtaButtons.vue'
 describe('ModelLaunchHeroCtaButtons', () => {
   it('renders no links when neither CTA is given', () => {
     render(ModelLaunchHeroCtaButtons, {
-      props: { primaryVariant: 'solid' }
+      props: { primaryVariant: 'solid', locale: 'en' }
     })
 
     expect(screen.queryAllByRole('link')).toHaveLength(0)
@@ -17,7 +17,8 @@ describe('ModelLaunchHeroCtaButtons', () => {
     render(ModelLaunchHeroCtaButtons, {
       props: {
         primaryCta: { labelKey: 'cta.getStarted', href: '/get-started' },
-        primaryVariant: 'solid'
+        primaryVariant: 'solid',
+        locale: 'en'
       }
     })
 
@@ -35,6 +36,7 @@ describe('ModelLaunchHeroCtaButtons', () => {
           target: '_blank'
         },
         primaryVariant: 'outline-light',
+        locale: 'en',
         secondaryCta: { labelKey: 'nav.docs', href: '/docs' }
       }
     })

--- a/apps/website/src/templates/model-launch/ModelLaunchHeroCtaButtons.vue
+++ b/apps/website/src/templates/model-launch/ModelLaunchHeroCtaButtons.vue
@@ -6,16 +6,11 @@ import type { ModelLaunchHero } from './types'
 import BrandButton from '../../components/common/BrandButton.vue'
 import { t } from '../../i18n/translations'
 
-const {
-  primaryCta,
-  primaryVariant,
-  secondaryCta,
-  locale = 'en'
-} = defineProps<{
+const { primaryCta, primaryVariant, secondaryCta, locale } = defineProps<{
   primaryCta?: ModelLaunchHero['primaryCta']
   primaryVariant: BrandButtonVariants['variant']
   secondaryCta?: ModelLaunchHero['secondaryCta']
-  locale?: Locale
+  locale: Locale
 }>()
 </script>
 

--- a/apps/website/src/templates/model-launch/ModelLaunchHeroSection.vue
+++ b/apps/website/src/templates/model-launch/ModelLaunchHeroSection.vue
@@ -14,12 +14,12 @@ import ModelLaunchHeroCtaButtons from './ModelLaunchHeroCtaButtons.vue'
 
 const {
   headingTag = 'h1',
-  locale = 'en',
+  locale,
   hero
 } = defineProps<{
   headingTag?: 'h1' | 'h2'
   hero: ModelLaunchHero
-  locale?: Locale
+  locale: Locale
 }>()
 
 // SSR (and the first client tick, before onMounted) has no reliable viewport

--- a/apps/website/src/templates/model-launch/ModelLaunchPricingSection.test.ts
+++ b/apps/website/src/templates/model-launch/ModelLaunchPricingSection.test.ts
@@ -13,7 +13,7 @@ if (!pricing) throw new Error('minimaxPage.pricing is no longer defined')
 
 describe('ModelLaunchPricingSection', () => {
   it('still renders the /minimax banner from its page config', () => {
-    render(ModelLaunchPricingSection, { props: { pricing } })
+    render(ModelLaunchPricingSection, { props: { pricing, locale: 'en' } })
 
     expect(
       screen.getByText("Start free. Upgrade when you're ready.")
@@ -39,7 +39,7 @@ describe('ModelLaunchPricingSection', () => {
 
   it('omits the banner when a page config does not define one', () => {
     render(ModelLaunchPricingSection, {
-      props: { pricing: { defaultBillingCycle: 'monthly' } }
+      props: { pricing: { defaultBillingCycle: 'monthly' }, locale: 'en' }
     })
 
     expect(screen.queryByRole('link', { name: 'TRY FREE' })).toBeNull()

--- a/apps/website/src/templates/model-launch/ModelLaunchPricingSection.vue
+++ b/apps/website/src/templates/model-launch/ModelLaunchPricingSection.vue
@@ -5,9 +5,9 @@ import type { ModelLaunchPricing } from './types'
 import PricingFreeBanner from '../../components/pricing/PricingFreeBanner.vue'
 import PricingSection from '../../components/pricing/PricingSection.vue'
 
-const { locale = 'en', pricing } = defineProps<{
+const { locale, pricing } = defineProps<{
   pricing: ModelLaunchPricing
-  locale?: Locale
+  locale: Locale
 }>()
 </script>
 

--- a/apps/website/src/templates/model-launch/ModelLaunchReviewsSection.vue
+++ b/apps/website/src/templates/model-launch/ModelLaunchReviewsSection.vue
@@ -8,9 +8,9 @@ import { getRoutes } from '../../config/routes'
 import { creatorReviews } from '../../data/creatorReviews'
 import { t } from '../../i18n/translations'
 
-const { locale = 'en', reviews } = defineProps<{
+const { locale, reviews } = defineProps<{
   reviews: ModelLaunchReviews
-  locale?: Locale
+  locale: Locale
 }>()
 
 const routes = getRoutes(locale)

--- a/apps/website/src/templates/model-launch/ModelLaunchRunOptionsSection.vue
+++ b/apps/website/src/templates/model-launch/ModelLaunchRunOptionsSection.vue
@@ -6,9 +6,9 @@ import ProductCard from '../../components/common/ProductCard.vue'
 import { getRoutes } from '../../config/routes'
 import { t } from '../../i18n/translations'
 
-const { locale = 'en', runOptions } = defineProps<{
+const { locale, runOptions } = defineProps<{
   runOptions: ModelLaunchRunOptions
-  locale?: Locale
+  locale: Locale
 }>()
 
 const routes = getRoutes(locale)

--- a/apps/website/src/templates/model-launch/ModelLaunchStepsSection.test.ts
+++ b/apps/website/src/templates/model-launch/ModelLaunchStepsSection.test.ts
@@ -20,13 +20,17 @@ const steps = (count: number): ModelLaunchSteps => ({
 
 describe('ModelLaunchStepsSection', () => {
   it('lays two items out on a two-column grid', () => {
-    render(ModelLaunchStepsSection, { props: { steps: steps(2) } })
+    render(ModelLaunchStepsSection, {
+      props: { steps: steps(2), locale: 'en' }
+    })
 
     expect(screen.getByRole('list').className).toContain('md:grid-cols-2')
   })
 
   it('keeps the three-column grid for longer step lists', () => {
-    render(ModelLaunchStepsSection, { props: { steps: steps(3) } })
+    render(ModelLaunchStepsSection, {
+      props: { steps: steps(3), locale: 'en' }
+    })
 
     expect(screen.getByRole('list').className).toContain('md:grid-cols-3')
   })

--- a/apps/website/src/templates/model-launch/ModelLaunchStepsSection.vue
+++ b/apps/website/src/templates/model-launch/ModelLaunchStepsSection.vue
@@ -7,9 +7,9 @@ import type { ModelLaunchSteps } from './types'
 import BrandButton from '../../components/common/BrandButton.vue'
 import { t } from '../../i18n/translations'
 
-const { locale = 'en', steps } = defineProps<{
+const { locale, steps } = defineProps<{
   steps: ModelLaunchSteps
-  locale?: Locale
+  locale: Locale
 }>()
 
 const stepNumber = (index: number) => String(index + 1).padStart(2, '0')

--- a/apps/website/src/utils/jsonLd.ts
+++ b/apps/website/src/utils/jsonLd.ts
@@ -1,5 +1,6 @@
 import { externalLinks } from '../config/routes'
 import type { Locale } from '../i18n/translations'
+import { resolveLocale } from '../i18n/translations'
 
 export type JsonLdNode = Record<string, unknown> & { '@type': string }
 
@@ -57,10 +58,7 @@ export function pageContext(
 ): PageContext & { url: string } {
   return {
     siteUrl: siteUrlFrom(site),
-    locale:
-      currentLocale === 'zh-CN' || currentLocale === 'ja'
-        ? currentLocale
-        : 'en',
+    locale: resolveLocale(currentLocale),
     url: absoluteUrl(site, pathname)
   }
 }

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -578,11 +578,29 @@ export default defineConfig([
     }
   },
 
-  // The website app is a marketing site with no vue-i18n setup
+  // The website app has no vue-i18n runtime — it translates through its own
+  // `t(key, locale)` helper in apps/website/src/i18n/translations.ts. no-raw-text
+  // is still the right gate: it only asks whether a user-visible literal reached
+  // the template, which is exactly what bypassing `t()` looks like.
   {
     files: ['apps/website/**/*.vue'],
     rules: {
-      '@intlify/vue-i18n/no-raw-text': 'off'
+      '@intlify/vue-i18n/no-raw-text': [
+        'error',
+        {
+          attributes: {
+            '/.+/': ['aria-label', 'label', 'placeholder', 'title'],
+            img: ['alt']
+          },
+          // Ignore strings that are:
+          // 1. Only symbols/numbers/whitespace (no letters)
+          // 2. Less than 2 characters
+          // 3. Email addresses
+          // 4. Product names and standard abbreviations, which are never translated
+          ignorePattern:
+            '^[^a-zA-Z]*$|^.{0,1}$|^[\\w._%+-]+@[\\w.-]+\\.[A-Za-z]{2,}$|^(Comfy|Comfy Org|ComfyUI|CC)$'
+        }
+      ]
     }
   },
   // Astro exposes virtual modules (astro:content, astro:assets, ...) that the

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -593,12 +593,13 @@ export default defineConfig([
             img: ['alt']
           },
           // Ignore strings that are:
-          // 1. Only symbols/numbers/whitespace (no letters)
+          // 1. Only symbols/numbers/whitespace — \P{L} covers every script, so
+          //    hardcoded Chinese still fails (the rule compiles this with /u)
           // 2. Less than 2 characters
           // 3. Email addresses
           // 4. Product names and standard abbreviations, which are never translated
           ignorePattern:
-            '^[^a-zA-Z]*$|^.{0,1}$|^[\\w._%+-]+@[\\w.-]+\\.[A-Za-z]{2,}$|^(Comfy|Comfy Org|ComfyUI|CC)$'
+            '^\\P{L}*$|^.{0,1}$|^[\\w._%+-]+@[\\w.-]+\\.[A-Za-z]{2,}$|^(Comfy|Comfy Org|ComfyUI|CC)$'
         }
       ]
     }

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "typecheck:browser": "vue-tsc --project browser_tests/tsconfig.json",
     "typecheck:scripts": "vue-tsc --project scripts/tsconfig.json",
     "typecheck:tools": "vue-tsc --project tools/tsconfig.json",
-    "typecheck:website": "pnpm --filter @comfyorg/website run typecheck",
+    "typecheck:website": "pnpm --filter @comfyorg/website run typecheck && vue-tsc --noEmit --project apps/website/tsconfig.json",
     "zipdist": "node scripts/zipdist.js",
     "test:custom-nodes:local": "start-server-and-test backend:custom-nodes http-get://127.0.0.1:8288/system_stats dev:custom-nodes http-get://localhost:5173 test:custom-nodes",
     "backend:custom-nodes": "sh -c 'cd \"${TEST_COMFYUI_DIR:?point at your ComfyUI checkout (README Prerequisites)}\"; cp \"$OLDPWD/browser_tests/assets/plain_video.mp4\" input/ || { echo \"could not stage plain_video.mp4 into $PWD/input - the curated VHS workflow cannot run without it\" >&2; exit 1; }; PY=python3; [ -x venv/bin/python ] && PY=venv/bin/python; [ -x .venv/bin/python ] && PY=.venv/bin/python; \"$PY\" main.py --port 8288 --multi-user --cache-none'",


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

## Why

`apps/website` is Astro SSG, so every Vue island is its own `createSSRApp` root and cannot read a shared reactive locale — each one takes `locale` as a prop. That part is forced by the architecture and does not change here.

What was wrong is that the prop and `t()` both **defaulted to `'en'`**:

```ts
const { locale = 'en' } = defineProps<{ locale?: Locale }>()
export function t(key: TranslationKey, locale: Locale = 'en'): string
```

So forgetting `locale` on a zh-CN page rendered English instead of failing. Nothing — not types, not lint, not CI — would tell you.

## What changed

**The default is now impossible.** `t()`, `localizeHref()`, `getRoutes()` and the fdct helpers require a locale, and `locale` is a required prop on all 156 components that render translated text. Omitting it is a type error:

```
src/pages/index.astro:52:4 - error ts(2322):
  Property 'locale' is missing in type '{}' but required in type '{ locale: Locale; }'.
```

Call sites now pass it explicitly — `locale={locale}` where the page already resolves one, `locale="en"` otherwise, mirroring how zh-CN pages already pass `locale="zh-CN"`. Added `resolveLocale()` for `.astro` components, which (unlike Vue islands) *can* read `Astro.currentLocale`.

**Gaps this exposed** — all latent, since every affected route is English-only today:
- `customers/content/Video.astro` never passed `locale` to `VideoPlayer`, whose controls are translated. It is injected into MDX via a component map so it cannot receive a prop; it now resolves its own locale.
- `CategoryNav`, `ModelHeroSection` and `affiliate/HeroSection` rendered translated text with no locale at all (`ModelHeroSection` had 6 single-arg `t()` calls).

**`apps/website` was never typechecked in CI.** `astro build` does not run `astro check`, and `astro check` does not read `.vue` internals — which is exactly why those 6 `t()` calls survived. Added `vue-tsc` to `typecheck:website` and wired both into `ci-website-build.yaml`. (It immediately caught a `t` used without an import while I was writing this PR.)

## Guardrails

Three layers, because no single one covers everything:

| | missing prop (`.astro`) | missing prop (`.vue`) | wrong locale literal | literal bypassing `t()` |
|---|---|---|---|---|
| `astro check` | ✅ | ❌ | ❌ | ❌ |
| `vue-tsc` | ✅ | ✅ | ❌ | ❌ |
| `validate:locale` | ✅ | ✅ | ✅ | ❌ |
| `no-raw-text` | ❌ | ❌ | ❌ | ✅ |

- **`scripts/validate-locale-props.ts`** (`pnpm --filter @comfyorg/website validate:locale`) catches what types cannot: `locale="en"` on a zh-CN page typechecks fine, because both are valid `Locale` values. It understands Vue's `:locale` same-name shorthand and Astro's `{locale}`, and fails loudly if it discovers zero locale-aware components rather than passing vacuously.
- **`@intlify/vue-i18n/no-raw-text`** is enabled for `apps/website` (it was explicitly `'off'`). The app has no vue-i18n runtime, but the rule only asks whether a user-visible literal reached the template — which is what bypassing `t()` looks like. It found 23, including untranslated `aria-label`s and an `OUR INVESTORS` badge that had a zh-CN translation sitting unused since the two-badge redesign. All are fixed; brand names and emails are ignored.
- **`e2e/locale.spec.ts`** asserts 10 zh-CN routes render Chinese chrome and *no* English fallback, that en routes stay English, and that a deeply nested `VideoPlayer` gets the locale.

## Verification

- `typecheck:website` (astro check + vue-tsc): **0 errors** · `validate:locale`: clean (158 components, 373 files) · `no-raw-text`: **0**
- Unit **440/440** · E2E **313/313** (desktop + mobile) · build: 599 pages
- Visual: 2 failures, **identical on `main`** (pre-existing, environment-related font rendering)
- **Negative-tested each layer.** Injected `locale="en"` on the zh-CN homepage: `astro check` passed it (0 errors — the gap that motivates the validator), while `validate:locale` and the e2e both failed. Injected a spread-provided locale and raw Chinese text: both now rejected.
- Built HTML inspected directly: no zh-CN page renders an English player control anywhere.

## Review follow-ups (second commit)

- `no-raw-text`'s `ignorePattern` used `^[^a-zA-Z]*$`, which treats every non-Latin script as symbols — hardcoded Chinese passed silently. The plugin compiles the pattern with `/u`, so it is now `^\P{L}*$`. Verified: raw Chinese went from 0 hits to flagged.
- `validate-locale-props` skipped any usage carrying a spread, so `<Section {...{ locale: 'en' }} />` on a zh-CN page passed both the validator and typecheck. Spreads are now reported — no existing usage relied on the exemption.

## Notes for the reviewer

- The bulk of the diff is one mechanical sweep (+829/−478 across 202 files); most of it is a 1:1 line swap. The interesting files are `i18n/translations.ts`, `scripts/validate-locale-props.ts`, `eslint.config.ts`, `e2e/locale.spec.ts` and `ci-website-build.yaml`.
- I added zh-CN strings for six a11y labels, the investors badge and one models-page phrase — **these are the only invented translations and are worth a native-speaker glance.**
- `pnpm lint` still only covers root `src/`, so `no-raw-text` is enforced via the pre-commit hook rather than CI. Extending the lint scope pulls in ~71 files of unrelated pre-existing Tailwind class-order autofixes, so I left it out; happy to do it as a focused follow-up.
- The root app's `ignorePattern` has the same non-Latin hole, untouched here as pre-existing.


## Screenshots

![zh-CN /about: the investors badge, previously hardcoded English, now renders the Chinese translation with the two-badge design intact](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/83d13c912d333a60a2d68fc1d72b062b5fcfbd4c553e43e93fafaf57e0d14938/pr-images/1786934691450-f10718cc-d860-45fb-99b3-6723449520f5.png)

![en /about: the same badge unchanged after routing its text through t()](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/83d13c912d333a60a2d68fc1d72b062b5fcfbd4c553e43e93fafaf57e0d14938/pr-images/1786934691975-8ee1efc1-eed6-48a9-bf06-c6a0265cbf52.png)

![zh-CN homepage rendering Chinese nav and hero with no English fallback](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/83d13c912d333a60a2d68fc1d72b062b5fcfbd4c553e43e93fafaf57e0d14938/pr-images/1786934692707-078c1119-0ed0-45ff-b14f-3d8053cd91f0.png)