### PR TITLE
test: tolerate sub-pixel drift in the mobile touch-pan screenshot

### DIFF
--- a/browser_tests/tests/vueNodes/interactions/canvas/pan.spec.ts
+++ b/browser_tests/tests/vueNodes/interactions/canvas/pan.spec.ts
@@ -209,8 +209,15 @@ test.describe('Vue Nodes Canvas Pan', { tag: '@vue-nodes' }, () => {
         { x: 64, y: 64 },
         { x: 256, y: 256 }
       )
+      // The touch pan lands the camera on a sub-pixel offset, so the canvas
+      // antialiases the node edges slightly differently between runs. Observed
+      // drift is 40 of 400k pixels, and it ejected two unrelated PRs from the
+      // merge queue on 2026-08-17 while the same base passed for a third.
+      // Same tolerance, and same reason, as the sibling canvas assertion in
+      // `interaction.spec.ts`.
       await expect(comfyPage.canvas).toHaveScreenshot(
-        'vue-nodes-paned-with-touch.png'
+        'vue-nodes-paned-with-touch.png',
+        { maxDiffPixels: 50 }
       )
     }
   )


### PR DESCRIPTION
## Summary

`@mobile Can pan with touch` (`pan.spec.ts:212`) asserts an exact canvas screenshot with no tolerance. It flakes, and because it only flakes once the merge queue rebuilds a PR against `main`, it ejects PRs silently.

## Evidence

Three merge-queue branches on 2026-08-17, all built on the same base commit `926d78c8bf`:

| queue branch | PR content | `CI: Tests E2E` |
| --- | --- | --- |
| `pr-14068-926d78c8bf` | per-language CODEOWNERS entries | ❌ `40 pixels (ratio 0.01)` |
| `pr-15067-fb633f46b3` | run acknowledgement ordering | ❌ `40 pixels (ratio 0.01)` |
| `pr-15108-926d78c8bf` | test: pin that script src loads never reach the network | ✅ pass |

Neither failing PR can move a canvas. The third passing on the same base is what rules out a regression on `main` and leaves flake. Both failures reported the identical `40 pixels`, and both PRs were removed from the queue by `github-merge-queue[bot]` with no reason recorded.

## The change

```ts
await expect(comfyPage.canvas).toHaveScreenshot(
  'vue-nodes-paned-with-touch.png',
  { maxDiffPixels: 50 }
)
```

`maxDiffPixels: 50` is the same tolerance, for the same reason, as the sibling canvas assertion at `interaction.spec.ts:234` ("Litegraph renders edge with a slight offset"). Other canvas-heavy specs already carry tolerances — `canvasSettings.spec.ts` uses `maxDiffPixels: 100`, `load3d.spec.ts` uses `maxDiffPixelRatio` up to `0.1`.

50 is deliberately just above the observed 40 and far below anything that would hide a real visual change: the canvas is 1081×1999, so this is 0.0019% of the image.

## Why this is worth fixing rather than retrying

The assertion passes on the PR branch and fails only on the queue branch. So the author sees a green PR, the queue ejects it without a reason, and `mergeStateStatus` goes back to `CLEAN` — indistinguishable from a PR that is simply waiting. Whoever is in the queue at the time absorbs the blame.

## Review focus

- If anyone believes the 40px delta is a **real** rendering change rather than sub-pixel antialiasing, say so and I will chase the cause instead — I could not reproduce it deterministically, and the passing run on the identical base is the main argument against a regression.
- I have deliberately **not** re-recorded the baseline. Accepting a new snapshot would bury the question of whether anything actually changed.
