### PR TITLE
fix(website): replace schedule-a-demo CTA copy on learning pages

### DIFF
--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -1715,12 +1715,8 @@ const translations = {
 
   // LearningCallToActionSection
   'learning.cta.heading': {
-    en: 'Schedule a demo and see how ComfyUI fits your team’s creative needs.',
-    'zh-CN': '预约演示，了解 ComfyUI 如何契合你的团队创作需求。'
-  },
-  'learning.cta.contactSales': {
-    en: 'Contact Sales',
-    'zh-CN': '联系销售'
+    en: 'Everything Comfy ships. All in one place.',
+    'zh-CN': 'Comfy 的全部内容，一处尽享。'
   },
   'learning.cta.runComfy': {
     en: 'Run Comfy for free',


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

The closing CTA on the learning pages read "Schedule a demo and see how ComfyUI fits your team's creative needs." while the buttons underneath were **Try Workflow** / **Run Comfy for free** — there was no demo to schedule. Flagged on `/learning/ads` in #website-and-docs; Ola confirmed the schedule CTA shouldn't be there and supplied the replacement copy.

## Changes

- `learning.cta.heading` → "Everything Comfy ships. All in one place." (zh-CN: "Comfy 的全部内容，一处尽享。", reusing the existing translation of that same string from `launches.cta.heading`)
- Removed `learning.cta.contactSales`, an unused leftover of the sales CTA (no references anywhere in the repo)

Buttons and links are unchanged. The key is shared by `LearningDirectoryPage.astro` and `LearningTutorialPage.astro`, so the fix covers `/learning`, `/learning/{vfx,animations,ads}`, every `/learning/*/[slug]` tutorial page, and their zh-CN equivalents — the wrong copy was on all of them, not just `/learning/ads`.

## Verification

- `pnpm typecheck:website` — 0 errors
- `pnpm test:unit` (website) — 440 passed
- `pnpm knip`, oxfmt, eslint — clean
- `astro build` — 599 pages; `grep -rl "Schedule a demo" dist` returns nothing
- `playwright test e2e/learning.spec.ts` — 25 passed (the CTA test reads the heading through `t()`, so it tracks the new copy)
- Rendered `/learning/ads` and `/zh-CN/learning/ads` against a local preview build (screenshots below)


## Screenshots

![/learning/ads closing CTA now reads "Everything Comfy ships. All in one place." with TRY WORKFLOW and RUN COMFY FOR FREE buttons](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/5c9db7e992ca4d5e43b4dba99ea3a83bdc8fa64eb3f03e550fee4f74423810a4/pr-images/1786937340200-b8689630-0d5e-45c7-9381-89f7fcb5336d.png)

![/zh-CN/learning/ads closing CTA rendering the localized copy](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/5c9db7e992ca4d5e43b4dba99ea3a83bdc8fa64eb3f03e550fee4f74423810a4/pr-images/1786937340834-59f93ceb-461a-4175-b228-f74754692f3e.png)