### PR TITLE
fix: keep node preview images across workflow tab switches

### DIFF
--- a/src/platform/workflow/core/services/workflowService.test.ts
+++ b/src/platform/workflow/core/services/workflowService.test.ts
@@ -560,6 +560,20 @@ describe('useWorkflowService', () => {
       expect(closed).toBe(false)
       expect(workflowStore.closeWorkflow).not.toHaveBeenCalled()
     })
+
+    it('should release the closed workflow node previews', async () => {
+      const workflow = createModeTestWorkflow({
+        path: 'workflows/closing.json'
+      })
+      const discardPreviews = vi.spyOn(
+        useNodeOutputStore(),
+        'discardPreviewsForWorkflow'
+      )
+
+      await service.closeWorkflow(workflow, { warnIfUnsaved: false })
+
+      expect(discardPreviews).toHaveBeenCalledWith(workflow.path)
+    })
   })
 
   describe('afterLoadNewGraph', () => {

--- a/src/platform/workflow/core/services/workflowService.test.ts
+++ b/src/platform/workflow/core/services/workflowService.test.ts
@@ -14,6 +14,7 @@ import { useWorkflowStore } from '@/platform/workflow/management/stores/workflow
 import { useWorkflowService } from '@/platform/workflow/core/services/workflowService'
 import { useMissingNodesErrorStore } from '@/platform/nodeReplacement/missingNodesErrorStore'
 import { useExecutionErrorStore } from '@/stores/executionErrorStore'
+import { useNodeOutputStore } from '@/stores/nodeOutputStore'
 import { useMissingModelStore } from '@/platform/missingModel/missingModelStore'
 import { useMissingMediaStore } from '@/platform/missingMedia/missingMediaStore'
 import { app } from '@/scripts/app'
@@ -84,7 +85,9 @@ vi.mock('@/scripts/app', () => ({
   app: {
     canvas: { ds: { offset: [0, 0], scale: 1 } },
     rootGraph: { serialize: vi.fn(() => ({})), extra: {} },
-    loadGraphData: vi.fn()
+    loadGraphData: vi.fn(),
+    nodeOutputs: {},
+    nodePreviewImages: {}
   }
 }))
 
@@ -312,6 +315,21 @@ describe('useWorkflowService', () => {
           missingMediaCandidates: mediaCandidates
         })
       )
+    })
+
+    it('should stash node previews before app.clean() can revoke them', () => {
+      const activeWorkflow = createModeTestWorkflow({
+        path: 'workflows/test.json'
+      })
+      workflowStore.activeWorkflow = activeWorkflow
+      const stashPreviews = vi.spyOn(
+        useNodeOutputStore(),
+        'stashPreviewsForWorkflow'
+      )
+
+      useWorkflowService().beforeLoadNewGraph()
+
+      expect(stashPreviews).toHaveBeenCalledWith(activeWorkflow.path)
     })
 
     it('should save active workflow state through the V2 draft store', () => {
@@ -559,6 +577,16 @@ describe('useWorkflowService', () => {
       )
       vi.mocked(workflowStore.isActive).mockReturnValue(true)
       vi.mocked(workflowStore.openWorkflow).mockResolvedValue(existingWorkflow)
+    })
+
+    it('should restore the stashed previews of the newly active workflow', async () => {
+      workflowStore.activeWorkflow = existingWorkflow
+
+      await useWorkflowService().afterLoadNewGraph('repeat', makeWorkflowData())
+
+      expect(
+        useNodeOutputStore().restorePreviewsForWorkflow
+      ).toHaveBeenCalledWith(existingWorkflow.path)
     })
 
     it('should reuse the active workflow when loading the same path repeatedly', async () => {

--- a/src/platform/workflow/core/services/workflowService.ts
+++ b/src/platform/workflow/core/services/workflowService.ts
@@ -26,6 +26,7 @@ import { useAppMode } from '@/composables/useAppMode'
 import { useDomWidgetStore } from '@/stores/domWidgetStore'
 import { useAppModeStore } from '@/stores/appModeStore'
 import { useExecutionErrorStore } from '@/stores/executionErrorStore'
+import { useNodeOutputStore } from '@/stores/nodeOutputStore'
 import { useSubgraphNavigationStore } from '@/stores/subgraphNavigationStore'
 import { useMissingNodesErrorStore } from '@/platform/nodeReplacement/missingNodesErrorStore'
 import { useMissingModelStore } from '@/platform/missingModel/missingModelStore'
@@ -423,6 +424,9 @@ export const useWorkflowService = () => {
         missingMediaCandidates: mediaCandidates ?? undefined
       })
 
+      // Hand the previews to the store before `app.clean()` revokes them
+      useNodeOutputStore().stashPreviewsForWorkflow(activeWorkflow.path)
+
       // Capture thumbnail before loading new graph
       void workflowThumbnail.storeThumbnail(activeWorkflow)
       domWidgetStore.clear()
@@ -444,6 +448,17 @@ export const useWorkflowService = () => {
    * @param workflowData The initial workflow data loaded to the graph editor.
    */
   const afterLoadNewGraph = async (
+    value: string | ComfyWorkflow | null,
+    workflowData: ComfyWorkflowJSON,
+    shareId?: string
+  ) => {
+    await activateLoadedWorkflow(value, workflowData, shareId)
+    useNodeOutputStore().restorePreviewsForWorkflow(
+      useWorkspaceStore().workflow.activeWorkflow?.path
+    )
+  }
+
+  const activateLoadedWorkflow = async (
     value: string | ComfyWorkflow | null,
     workflowData: ComfyWorkflowJSON,
     shareId?: string

--- a/src/platform/workflow/core/services/workflowService.ts
+++ b/src/platform/workflow/core/services/workflowService.ts
@@ -349,6 +349,7 @@ export const useWorkflowService = () => {
     }
 
     await workflowStore.closeWorkflow(workflow)
+    useNodeOutputStore().discardPreviewsForWorkflow(workflow.path)
     return true
   }
 

--- a/src/scripts/app.test.ts
+++ b/src/scripts/app.test.ts
@@ -85,7 +85,9 @@ const {
   },
   mockNodeOutputStore: {
     refreshNodeOutputs: vi.fn(),
-    resetAllOutputsAndPreviews: vi.fn()
+    resetAllOutputsAndPreviews: vi.fn(),
+    stashPreviewsForWorkflow: vi.fn(),
+    restorePreviewsForWorkflow: vi.fn()
   },
   mockWorkspaceWorkflow: {
     activeWorkflow: null as ComfyWorkflow | null,

--- a/src/scripts/app.test.ts
+++ b/src/scripts/app.test.ts
@@ -87,7 +87,8 @@ const {
     refreshNodeOutputs: vi.fn(),
     resetAllOutputsAndPreviews: vi.fn(),
     stashPreviewsForWorkflow: vi.fn(),
-    restorePreviewsForWorkflow: vi.fn()
+    restorePreviewsForWorkflow: vi.fn(),
+    discardPreviewsForWorkflow: vi.fn()
   },
   mockWorkspaceWorkflow: {
     activeWorkflow: null as ComfyWorkflow | null,

--- a/src/stores/nodeOutputStore.ts
+++ b/src/stores/nodeOutputStore.ts
@@ -320,7 +320,8 @@ export const useNodeOutputStore = defineStore('nodeOutput', () => {
     nodePreviewImages.value = {}
   }
 
-  function discardStashedPreviews(workflowPath: string) {
+  /** Release the previews held for a workflow that is going away. */
+  function discardPreviewsForWorkflow(workflowPath: string) {
     const stashed = stashedPreviews.get(workflowPath)
     if (!stashed) return
 
@@ -331,7 +332,7 @@ export const useNodeOutputStore = defineStore('nodeOutput', () => {
   function discardClosedWorkflowPreviews() {
     const openPaths = new Set(workflowStore.openWorkflows.map((wf) => wf.path))
     for (const path of [...stashedPreviews.keys()]) {
-      if (!openPaths.has(path)) discardStashedPreviews(path)
+      if (!openPaths.has(path)) discardPreviewsForWorkflow(path)
     }
   }
 
@@ -343,7 +344,7 @@ export const useNodeOutputStore = defineStore('nodeOutput', () => {
    */
   function stashPreviewsForWorkflow(workflowPath: string) {
     discardClosedWorkflowPreviews()
-    discardStashedPreviews(workflowPath)
+    discardPreviewsForWorkflow(workflowPath)
 
     const previews = app.nodePreviewImages
     if (Object.keys(previews).length) {
@@ -507,6 +508,7 @@ export const useNodeOutputStore = defineStore('nodeOutput', () => {
     revokeSubgraphPreviews,
     stashPreviewsForWorkflow,
     restorePreviewsForWorkflow,
+    discardPreviewsForWorkflow,
     removeNodeOutputs,
     removeNodeOutputsForNode,
     snapshotOutputs,

--- a/src/stores/nodeOutputStore.ts
+++ b/src/stores/nodeOutputStore.ts
@@ -50,9 +50,15 @@ interface SetOutputOptions {
 }
 
 export const useNodeOutputStore = defineStore('nodeOutput', () => {
-  const { nodeIdToNodeLocatorId, nodeToNodeLocatorId } = useWorkflowStore()
+  const workflowStore = useWorkflowStore()
+  const { nodeIdToNodeLocatorId, nodeToNodeLocatorId } = workflowStore
   const scheduledRevoke: Record<NodeLocatorId, { stop: () => void }> = {}
   const latestPreview = ref<string[]>([])
+  /**
+   * Previews belonging to open-but-inactive workflows, keyed by workflow path.
+   * The stash owns the object URL retain taken when the previews were set.
+   */
+  const stashedPreviews = new Map<string, Record<string, string[]>>()
 
   function scheduleRevoke(locator: NodeLocatorId, cb: () => void) {
     scheduledRevoke[locator]?.stop()
@@ -298,17 +304,72 @@ export const useNodeOutputStore = defineStore('nodeOutput', () => {
     delete nodePreviewImages.value[nodeLocatorId]
   }
 
-  function revokeAllPreviews() {
-    for (const nodeLocatorId of Object.keys(app.nodePreviewImages)) {
-      const previews = app.nodePreviewImages[nodeLocatorId]
-      if (!previews?.[Symbol.iterator]) continue
+  function releasePreviewUrls(previews: Record<string, string[]>) {
+    for (const urls of Object.values(previews)) {
+      if (!urls?.[Symbol.iterator]) continue
 
-      for (const url of previews) {
+      for (const url of urls) {
         releaseSharedObjectUrl(url)
       }
     }
+  }
+
+  function revokeAllPreviews() {
+    releasePreviewUrls(app.nodePreviewImages)
     app.nodePreviewImages = {}
     nodePreviewImages.value = {}
+  }
+
+  function discardStashedPreviews(workflowPath: string) {
+    const stashed = stashedPreviews.get(workflowPath)
+    if (!stashed) return
+
+    stashedPreviews.delete(workflowPath)
+    releasePreviewUrls(stashed)
+  }
+
+  function discardClosedWorkflowPreviews() {
+    const openPaths = new Set(workflowStore.openWorkflows.map((wf) => wf.path))
+    for (const path of [...stashedPreviews.keys()]) {
+      if (!openPaths.has(path)) discardStashedPreviews(path)
+    }
+  }
+
+  /**
+   * Move the live previews into the stash so `app.clean()` cannot revoke them
+   * while `workflowPath` is loaded out of the editor. Preview frames arrive
+   * over the websocket and cannot be re-fetched, so releasing their object
+   * URLs on a tab switch loses them for good.
+   */
+  function stashPreviewsForWorkflow(workflowPath: string) {
+    discardClosedWorkflowPreviews()
+    discardStashedPreviews(workflowPath)
+
+    const previews = app.nodePreviewImages
+    if (Object.keys(previews).length) {
+      stashedPreviews.set(workflowPath, previews)
+    }
+    app.nodePreviewImages = {}
+    nodePreviewImages.value = {}
+  }
+
+  function restorePreviewsForWorkflow(workflowPath: string | undefined) {
+    if (!workflowPath) return
+
+    const stashed = stashedPreviews.get(workflowPath)
+    if (!stashed) return
+    stashedPreviews.delete(workflowPath)
+
+    const live = app.nodePreviewImages
+    const superseded: Record<string, string[]> = {}
+    for (const [nodeLocatorId, urls] of Object.entries(stashed)) {
+      // A preview that arrived while the graph was loading wins; the stashed
+      // copy for that node then has no owner left to release it.
+      if (nodeLocatorId in live) superseded[nodeLocatorId] = urls
+      else live[nodeLocatorId] = urls
+    }
+    releasePreviewUrls(superseded)
+    nodePreviewImages.value = { ...live }
   }
 
   function revokeSubgraphPreviews(subgraphNode: SubgraphNode) {
@@ -444,6 +505,8 @@ export const useNodeOutputStore = defineStore('nodeOutput', () => {
     revokePreviewsByLocatorId,
     revokeAllPreviews,
     revokeSubgraphPreviews,
+    stashPreviewsForWorkflow,
+    restorePreviewsForWorkflow,
     removeNodeOutputs,
     removeNodeOutputsForNode,
     snapshotOutputs,

--- a/src/stores/nodeOutputStore.workflowSwitch.test.ts
+++ b/src/stores/nodeOutputStore.workflowSwitch.test.ts
@@ -136,7 +136,18 @@ describe('nodeOutputStore preview lifecycle across workflow tab switches', () =>
     expect(store.nodePreviewImages).toEqual({})
   })
 
-  it('releases stashed previews once the workflow is closed', () => {
+  it('releases stashed previews when the workflow is closed', () => {
+    const store = useNodeOutputStore()
+    const previewUrl = createBlobUrl()
+
+    store.setNodePreviewsByNodeId(createMockNode(5).id, [previewUrl])
+    switchToWorkflow(WORKFLOW_B)
+    store.discardPreviewsForWorkflow(WORKFLOW_A)
+
+    expect(revokeObjectURL).toHaveBeenCalledWith(previewUrl)
+  })
+
+  it('releases stashed previews of a workflow closed without a discard', () => {
     const store = useNodeOutputStore()
     const previewUrl = createBlobUrl()
 
@@ -147,6 +158,41 @@ describe('nodeOutputStore preview lifecycle across workflow tab switches', () =>
     switchToWorkflow(WORKFLOW_B)
 
     expect(revokeObjectURL).toHaveBeenCalledWith(previewUrl)
+  })
+
+  it('keeps a preview that arrived while the graph was loading', () => {
+    const store = useNodeOutputStore()
+    const node = createMockNode(5)
+    const stashedUrl = createBlobUrl()
+    const arrivedUrl = createBlobUrl()
+
+    store.setNodePreviewsByNodeId(node.id, [stashedUrl])
+    switchToWorkflow(WORKFLOW_B)
+
+    // Back to A: a frame lands between app.clean() and afterLoadNewGraph().
+    store.stashPreviewsForWorkflow(WORKFLOW_B)
+    store.resetAllOutputsAndPreviews()
+    mocks.workflowStore.activeWorkflow = { path: WORKFLOW_A }
+    store.setNodePreviewsByNodeId(node.id, [arrivedUrl])
+    store.restorePreviewsForWorkflow(WORKFLOW_A)
+
+    expect(store.getNodePreviews(node)).toEqual([arrivedUrl])
+    expect(revokeObjectURL).toHaveBeenCalledWith(stashedUrl)
+    expect(revokeObjectURL).not.toHaveBeenCalledWith(arrivedUrl)
+  })
+
+  it('restores previews when the same workflow is reloaded in place', () => {
+    const store = useNodeOutputStore()
+    const node = createMockNode(5)
+    const previewUrl = createBlobUrl()
+
+    store.setNodePreviewsByNodeId(node.id, [previewUrl])
+    // Undo/redo reloads the active workflow via loadGraphData(clean = false).
+    store.stashPreviewsForWorkflow(WORKFLOW_A)
+    store.restorePreviewsForWorkflow(WORKFLOW_A)
+
+    expect(store.getNodePreviews(node)).toEqual([previewUrl])
+    expect(revokeObjectURL).not.toHaveBeenCalledWith(previewUrl)
   })
 
   it('still revokes previews when the workflow is cleared in place', () => {

--- a/src/stores/nodeOutputStore.workflowSwitch.test.ts
+++ b/src/stores/nodeOutputStore.workflowSwitch.test.ts
@@ -1,0 +1,127 @@
+import { fromAny } from '@total-typescript/shoehorn'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
+import { app } from '@/scripts/app'
+import { useNodeOutputStore } from '@/stores/nodeOutputStore'
+import { toNodeId } from '@/types/nodeId'
+
+const { WORKFLOW_A, WORKFLOW_B } = vi.hoisted(() => ({
+  WORKFLOW_A: 'workflows/a.json',
+  WORKFLOW_B: 'workflows/b.json'
+}))
+
+const mocks = vi.hoisted(() => ({
+  workflowStore: null as unknown as {
+    activeWorkflow: { path: string } | null
+    openWorkflowPaths: string[]
+    nodeIdToNodeLocatorId: (id: string | number) => string
+    nodeToNodeLocatorId: (node: { id: string | number }) => string
+  }
+}))
+
+vi.mock('@/utils/litegraphUtil', () => ({
+  isAnimatedOutput: vi.fn(() => false),
+  isVideoNode: vi.fn(() => false),
+  resolveNode: vi.fn()
+}))
+
+vi.mock('@/utils/graphTraversalUtil', () => ({
+  executionIdToNodeLocatorId: vi.fn((_rootGraph: unknown, id: string) => id)
+}))
+
+vi.mock('@/scripts/app', () => ({
+  app: {
+    getPreviewFormatParam: vi.fn(() => ''),
+    getRandParam: vi.fn(() => ''),
+    rootGraph: { getNodeById: vi.fn() },
+    nodeOutputs: {} as Record<string, unknown>,
+    nodePreviewImages: {} as Record<string, string[]>
+  }
+}))
+
+vi.mock('@/platform/workflow/management/stores/workflowStore', async () => {
+  const { reactive } = await import('vue')
+  mocks.workflowStore = reactive({
+    activeWorkflow: { path: WORKFLOW_A } as { path: string } | null,
+    openWorkflowPaths: [WORKFLOW_A, WORKFLOW_B],
+    nodeIdToNodeLocatorId: (id: string | number) => String(id),
+    nodeToNodeLocatorId: (node: { id: string | number }) => String(node.id)
+  })
+  return { useWorkflowStore: () => mocks.workflowStore }
+})
+
+const createMockNode = (id: number): LGraphNode =>
+  fromAny<LGraphNode, unknown>({ id: toNodeId(id), type: 'KSampler' })
+
+/**
+ * Mirrors `app.clean()`, which is what `loadGraphData` runs before it
+ * configures the incoming workflow's graph.
+ */
+function appClean() {
+  useNodeOutputStore().resetAllOutputsAndPreviews()
+}
+
+/** Mirrors `workflowService.afterLoadNewGraph` moving the active pointer. */
+function activateWorkflow(path: string | null) {
+  mocks.workflowStore.activeWorkflow = path ? { path } : null
+}
+
+/** Mirrors `loadGraphData` + `afterLoadNewGraph` for a tab switch. */
+function switchToWorkflow(path: string) {
+  appClean()
+  activateWorkflow(path)
+}
+
+describe('nodeOutputStore preview lifecycle across workflow tab switches', () => {
+  let revokeObjectURL: ReturnType<typeof vi.fn>
+  let urlCounter: number
+
+  const createBlobUrl = () => URL.createObjectURL(new Blob(['x']))
+
+  beforeEach(() => {
+    urlCounter = 0
+    revokeObjectURL = vi.fn()
+    vi.stubGlobal('URL', {
+      ...URL,
+      createObjectURL: vi.fn(() => `blob:mock/${++urlCounter}`),
+      revokeObjectURL
+    })
+    app.nodeOutputs = {}
+    app.nodePreviewImages = {}
+    mocks.workflowStore.activeWorkflow = { path: WORKFLOW_A }
+    mocks.workflowStore.openWorkflowPaths = [WORKFLOW_A, WORKFLOW_B]
+  })
+
+  it('keeps a finished run preview when the user switches tabs and comes back', () => {
+    const store = useNodeOutputStore()
+    const node = createMockNode(5)
+    const previewUrl = createBlobUrl()
+
+    // A run finished on workflow A and left its last preview frame on node 5.
+    // Nothing revokes it at execution end, so the node keeps displaying it.
+    store.setNodePreviewsByNodeId(node.id, [previewUrl])
+    expect(store.getNodePreviews(node)).toEqual([previewUrl])
+
+    // User switches to workflow B, then back to workflow A.
+    switchToWorkflow(WORKFLOW_B)
+    switchToWorkflow(WORKFLOW_A)
+
+    expect(store.getNodePreviews(node)).toEqual([previewUrl])
+    expect(store.nodePreviewImages['5']).toEqual([previewUrl])
+    // The blob must still be alive; a b_preview frame cannot be re-fetched.
+    expect(revokeObjectURL).not.toHaveBeenCalledWith(previewUrl)
+  })
+
+  it('does not revoke the preview blob when leaving the workflow', () => {
+    const store = useNodeOutputStore()
+    const previewUrl = createBlobUrl()
+
+    store.setNodePreviewsByNodeId(createMockNode(5).id, [previewUrl])
+    switchToWorkflow(WORKFLOW_B)
+
+    // Revoking makes the loss permanent: there is no source to re-derive a
+    // websocket preview frame from once the object URL is gone.
+    expect(revokeObjectURL).not.toHaveBeenCalledWith(previewUrl)
+  })
+})

--- a/src/stores/nodeOutputStore.workflowSwitch.test.ts
+++ b/src/stores/nodeOutputStore.workflowSwitch.test.ts
@@ -14,7 +14,7 @@ const { WORKFLOW_A, WORKFLOW_B } = vi.hoisted(() => ({
 const mocks = vi.hoisted(() => ({
   workflowStore: null as unknown as {
     activeWorkflow: { path: string } | null
-    openWorkflowPaths: string[]
+    openWorkflows: { path: string }[]
     nodeIdToNodeLocatorId: (id: string | number) => string
     nodeToNodeLocatorId: (node: { id: string | number }) => string
   }
@@ -44,7 +44,7 @@ vi.mock('@/platform/workflow/management/stores/workflowStore', async () => {
   const { reactive } = await import('vue')
   mocks.workflowStore = reactive({
     activeWorkflow: { path: WORKFLOW_A } as { path: string } | null,
-    openWorkflowPaths: [WORKFLOW_A, WORKFLOW_B],
+    openWorkflows: [{ path: WORKFLOW_A }, { path: WORKFLOW_B }],
     nodeIdToNodeLocatorId: (id: string | number) => String(id),
     nodeToNodeLocatorId: (node: { id: string | number }) => String(node.id)
   })
@@ -55,42 +55,42 @@ const createMockNode = (id: number): LGraphNode =>
   fromAny<LGraphNode, unknown>({ id: toNodeId(id), type: 'KSampler' })
 
 /**
- * Mirrors `app.clean()`, which is what `loadGraphData` runs before it
- * configures the incoming workflow's graph.
+ * Mirrors `workflowService.beforeLoadNewGraph()` -> `app.clean()` ->
+ * `workflowService.afterLoadNewGraph()`, the sequence every workflow load and
+ * tab switch runs.
  */
-function appClean() {
-  useNodeOutputStore().resetAllOutputsAndPreviews()
-}
-
-/** Mirrors `workflowService.afterLoadNewGraph` moving the active pointer. */
-function activateWorkflow(path: string | null) {
-  mocks.workflowStore.activeWorkflow = path ? { path } : null
-}
-
-/** Mirrors `loadGraphData` + `afterLoadNewGraph` for a tab switch. */
 function switchToWorkflow(path: string) {
-  appClean()
-  activateWorkflow(path)
+  const store = useNodeOutputStore()
+  const leaving = mocks.workflowStore.activeWorkflow
+  if (leaving) store.stashPreviewsForWorkflow(leaving.path)
+  store.resetAllOutputsAndPreviews()
+  mocks.workflowStore.activeWorkflow = { path }
+  store.restorePreviewsForWorkflow(path)
 }
+
+// Object URL retain counts live in a module-level map in objectUrlUtil, so
+// every test needs its own URLs or the counts leak between them.
+let urlCounter = 0
 
 describe('nodeOutputStore preview lifecycle across workflow tab switches', () => {
-  let revokeObjectURL: ReturnType<typeof vi.fn>
-  let urlCounter: number
+  let revokeObjectURL: ReturnType<typeof vi.spyOn>
 
   const createBlobUrl = () => URL.createObjectURL(new Blob(['x']))
 
   beforeEach(() => {
-    urlCounter = 0
-    revokeObjectURL = vi.fn()
-    vi.stubGlobal('URL', {
-      ...URL,
-      createObjectURL: vi.fn(() => `blob:mock/${++urlCounter}`),
-      revokeObjectURL
-    })
+    vi.spyOn(URL, 'createObjectURL').mockImplementation(
+      () => `blob:mock/${++urlCounter}`
+    )
+    revokeObjectURL = vi
+      .spyOn(URL, 'revokeObjectURL')
+      .mockImplementation(() => {})
     app.nodeOutputs = {}
     app.nodePreviewImages = {}
     mocks.workflowStore.activeWorkflow = { path: WORKFLOW_A }
-    mocks.workflowStore.openWorkflowPaths = [WORKFLOW_A, WORKFLOW_B]
+    mocks.workflowStore.openWorkflows = [
+      { path: WORKFLOW_A },
+      { path: WORKFLOW_B }
+    ]
   })
 
   it('keeps a finished run preview when the user switches tabs and comes back', () => {
@@ -123,5 +123,42 @@ describe('nodeOutputStore preview lifecycle across workflow tab switches', () =>
     // Revoking makes the loss permanent: there is no source to re-derive a
     // websocket preview frame from once the object URL is gone.
     expect(revokeObjectURL).not.toHaveBeenCalledWith(previewUrl)
+  })
+
+  it('does not show one workflow preview on another workflow same-id node', () => {
+    const store = useNodeOutputStore()
+    const node = createMockNode(5)
+
+    store.setNodePreviewsByNodeId(node.id, [createBlobUrl()])
+    switchToWorkflow(WORKFLOW_B)
+
+    expect(store.getNodePreviews(node)).toBeUndefined()
+    expect(store.nodePreviewImages).toEqual({})
+  })
+
+  it('releases stashed previews once the workflow is closed', () => {
+    const store = useNodeOutputStore()
+    const previewUrl = createBlobUrl()
+
+    store.setNodePreviewsByNodeId(createMockNode(5).id, [previewUrl])
+    switchToWorkflow(WORKFLOW_B)
+
+    mocks.workflowStore.openWorkflows = [{ path: WORKFLOW_B }]
+    switchToWorkflow(WORKFLOW_B)
+
+    expect(revokeObjectURL).toHaveBeenCalledWith(previewUrl)
+  })
+
+  it('still revokes previews when the workflow is cleared in place', () => {
+    const store = useNodeOutputStore()
+    const node = createMockNode(5)
+    const previewUrl = createBlobUrl()
+
+    store.setNodePreviewsByNodeId(node.id, [previewUrl])
+    // "Clear Workflow" calls app.clean() without loading another graph.
+    store.resetAllOutputsAndPreviews()
+
+    expect(store.getNodePreviews(node)).toBeUndefined()
+    expect(revokeObjectURL).toHaveBeenCalledWith(previewUrl)
   })
 })


### PR DESCRIPTION
## Summary

Node preview images are lost permanently on a workflow tab switch, because `app.clean()` revokes their object URLs and nothing restores them. This scopes preview state per workflow instead.

Fixes FE-1645

## Changes

- **What**: `workflowService.beforeLoadNewGraph()` hands the live previews to `nodeOutputStore` keyed by the outgoing workflow path, so `app.clean()` has nothing left to revoke. `afterLoadNewGraph()` puts back the previews belonging to the workflow that just became active.

### Before

1. Open workflow A with a KSampler, preview method anything but `none`.
2. Queue it and let it finish — the KSampler shows its final latent preview.
3. Switch to tab B, switch back to tab A.
4. The preview is gone and never comes back. Output images on other nodes survive the same switch.

`app.clean()` (`src/scripts/app.ts:2434`) runs on every workflow load and calls `resetAllOutputsAndPreviews()` → `revokeAllPreviews()` (`src/stores/nodeOutputStore.ts:301`), which releases every preview object URL and empties the maps. `nodeOutputs` survives only because `ChangeTracker` snapshots and restores it (`src/scripts/changeTracker.ts:306`/`350`); previews have no equivalent. Nothing revokes previews at execution end, so a finished run's last frame is real state a user is looking at — and a `b_preview` websocket frame cannot be re-fetched, so revoking makes the loss permanent.

### After

The preview is still there when you come back to the tab.

## Review Focus

- Keying by workflow path is load-bearing, not incidental. Node locator ids for root-graph nodes are bare node ids, so simply not clearing on load would show workflow A's node 5 preview on workflow B's node 5.
- Ownership of the object URL retain moves from the live map to the stash and back, so nothing is released on a tab switch. Released instead when: the workflow is cleared in place (`Clear Workflow` still calls `app.clean()` with no load following it), the workflow has been closed, or a preview arriving for the incoming graph supersedes the stashed one.
- Undo/redo goes through `loadGraphData(..., clean = false)` for the same workflow — it stashes and restores under the same path, so the net effect is unchanged.
- Deliberately not done: no `ChangeTracker` snapshot/restore field for previews, and no use of the `workflowTransientState` mechanism proposed in #14941, so this does not prejudge that review.

## Tests

`src/stores/nodeOutputStore.workflowSwitch.test.ts` covers the round trip, the same-node-id cross-workflow case, release on close, and clear-in-place. `workflowService.test.ts` covers the two lifecycle hooks.
