### PR TITLE
refactor: collapse duplicated group mode menu items into a table

### DIFF
--- a/src/extensions/core/groupOptions.test.ts
+++ b/src/extensions/core/groupOptions.test.ts
@@ -1,0 +1,175 @@
+import { fromPartial } from '@total-typescript/shoehorn'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type {
+  ContextMenuDivElement,
+  IContextMenuValue
+} from '@/lib/litegraph/src/interfaces'
+import type {
+  LGraph,
+  LGraphCanvas,
+  LGraphGroup,
+  LGraphNode
+} from '@/lib/litegraph/src/litegraph'
+import { LGraphEventMode } from '@/lib/litegraph/src/litegraph'
+import type { ComfyExtension } from '@/types/comfy'
+import { createMockLGraphNode } from '@/utils/__tests__/litegraphTestUtils'
+
+const { registerExtension } = vi.hoisted(() => ({
+  registerExtension: vi.fn()
+}))
+
+vi.mock('@/scripts/app', () => ({
+  app: { registerExtension }
+}))
+
+vi.mock('@/platform/settings/settingStore', () => ({
+  useSettingStore: () => ({ get: () => 10 })
+}))
+
+import '@/extensions/core/groupOptions'
+
+const ext = registerExtension.mock.calls[0]?.[0] as ComfyExtension
+
+const graphChange = vi.fn()
+
+function makeNode(mode: LGraphEventMode): LGraphNode {
+  return createMockLGraphNode({
+    mode,
+    graph: fromPartial<LGraph>({ change: graphChange })
+  })
+}
+
+function makeGroup(nodes: LGraphNode[]): LGraphGroup {
+  return fromPartial<LGraphGroup>({
+    nodes,
+    children: new Set(),
+    recomputeInsideNodes: vi.fn(),
+    resizeTo: vi.fn()
+  })
+}
+
+function makeCanvas(
+  group: LGraphGroup | null,
+  selectedItems: Set<unknown> = new Set()
+): LGraphCanvas {
+  return fromPartial<LGraphCanvas>({
+    graph: fromPartial({
+      getGroupOnPos: () => group,
+      add: vi.fn(),
+      change: vi.fn()
+    }),
+    graph_mouse: [0, 0],
+    selectedItems,
+    selectNodes: vi.fn(),
+    canvas: fromPartial({ focus: vi.fn() })
+  })
+}
+
+function menuFor(canvas: LGraphCanvas): (IContextMenuValue | null)[] {
+  return ext.getCanvasMenuItems!.call(ext, canvas)
+}
+
+function labels(items: (IContextMenuValue | null)[]): (string | null)[] {
+  return items.map((item) => (item ? String(item.content) : null))
+}
+
+const BASE_GROUP_ITEMS: (string | null)[] = [
+  'Add Selected Nodes To Group',
+  null,
+  'Fit Group To Nodes',
+  'Select Nodes'
+]
+
+beforeEach(() => {
+  graphChange.mockClear()
+})
+
+describe('Comfy.GroupOptions canvas menu', () => {
+  it('offers nothing when there is no group and no selection', () => {
+    expect(labels(menuFor(makeCanvas(null)))).toEqual([])
+  })
+
+  it('offers group creation when there is a selection but no group', () => {
+    const canvas = makeCanvas(null, new Set([{}]))
+    expect(labels(menuFor(canvas))).toEqual(['Add Group For Selected Nodes'])
+  })
+
+  it('offers only the add-to-group item for an empty group', () => {
+    const canvas = makeCanvas(makeGroup([]))
+    expect(labels(menuFor(canvas))).toEqual(['Add Selected Nodes To Group'])
+  })
+
+  it('disables the add-to-group item when nothing is selected', () => {
+    const items = menuFor(makeCanvas(makeGroup([])))
+    expect(items[0]?.disabled).toBe(true)
+  })
+
+  it.for<[name: string, mode: LGraphEventMode, expected: string[]]>([
+    [
+      'always',
+      LGraphEventMode.ALWAYS,
+      ['Set Group Nodes to Never', 'Bypass Group Nodes']
+    ],
+    [
+      'never',
+      LGraphEventMode.NEVER,
+      ['Set Group Nodes to Always', 'Bypass Group Nodes']
+    ],
+    [
+      'bypass',
+      LGraphEventMode.BYPASS,
+      ['Set Group Nodes to Always', 'Set Group Nodes to Never']
+    ],
+    [
+      'on trigger',
+      LGraphEventMode.ON_TRIGGER,
+      [
+        'Set Group Nodes to Always',
+        'Set Group Nodes to Never',
+        'Bypass Group Nodes'
+      ]
+    ]
+  ])(
+    'omits the current mode when every node is %s',
+    ([, mode, expectedModeItems]) => {
+      const group = makeGroup([makeNode(mode), makeNode(mode)])
+      expect(labels(menuFor(makeCanvas(group)))).toEqual([
+        ...BASE_GROUP_ITEMS,
+        ...expectedModeItems
+      ])
+    }
+  )
+
+  it('offers every mode when the nodes differ', () => {
+    const group = makeGroup([
+      makeNode(LGraphEventMode.ALWAYS),
+      makeNode(LGraphEventMode.NEVER)
+    ])
+    expect(labels(menuFor(makeCanvas(group)))).toEqual([
+      ...BASE_GROUP_ITEMS,
+      'Set Group Nodes to Always',
+      'Set Group Nodes to Never',
+      'Bypass Group Nodes'
+    ])
+  })
+
+  it.for<[label: string, expected: LGraphEventMode]>([
+    ['Set Group Nodes to Always', LGraphEventMode.ALWAYS],
+    ['Set Group Nodes to Never', LGraphEventMode.NEVER],
+    ['Bypass Group Nodes', LGraphEventMode.BYPASS]
+  ])('applies %s to every node in the group', ([label, expected]) => {
+    const nodes = [
+      makeNode(LGraphEventMode.ON_TRIGGER),
+      makeNode(LGraphEventMode.ON_TRIGGER)
+    ]
+    const items = menuFor(makeCanvas(makeGroup(nodes)))
+    const item = items.find((entry) => entry?.content === label)
+    const menuElement: ContextMenuDivElement = document.createElement('div')
+
+    item?.callback?.call(menuElement)
+
+    expect(nodes.map((node) => node.mode)).toEqual([expected, expected])
+    expect(graphChange).toHaveBeenCalledTimes(nodes.length)
+  })
+})

--- a/src/extensions/core/groupOptions.ts
+++ b/src/extensions/core/groupOptions.ts
@@ -4,6 +4,7 @@ import type {
 } from '@/lib/litegraph/src/interfaces'
 import {
   LGraphCanvas,
+  LGraphEventMode,
   LGraphGroup,
   type LGraphNode
 } from '@/lib/litegraph/src/litegraph'
@@ -12,10 +13,16 @@ import type { ComfyExtension } from '@/types/comfy'
 
 import { app } from '../../scripts/app'
 
-function setNodeMode(node: LGraphNode, mode: number) {
+function setNodeMode(node: LGraphNode, mode: LGraphEventMode) {
   node.mode = mode
   node.graph?.change()
 }
+
+const MODE_MENU_ITEMS = [
+  { content: 'Set Group Nodes to Always', mode: LGraphEventMode.ALWAYS },
+  { content: 'Set Group Nodes to Never', mode: LGraphEventMode.NEVER },
+  { content: 'Bypass Group Nodes', mode: LGraphEventMode.BYPASS }
+] as const
 
 function addNodesToGroup(group: LGraphGroup, items: Iterable<Positionable>) {
   const padding = useSettingStore().get('Comfy.GroupSelectedNodes.Padding')
@@ -77,14 +84,10 @@ const ext: ComfyExtension = {
       items.push(null)
     }
 
-    // Check if all nodes are the same mode
-    let allNodesAreSameMode = true
-    for (let i = 1; i < nodesInGroup.length; i++) {
-      if (nodesInGroup[i].mode !== nodesInGroup[0].mode) {
-        allNodesAreSameMode = false
-        break
-      }
-    }
+    const firstMode = nodesInGroup[0].mode
+    const sharedMode = nodesInGroup.every((node) => node.mode === firstMode)
+      ? firstMode
+      : undefined
 
     items.push({
       content: 'Fit Group To Nodes',
@@ -109,124 +112,14 @@ const ext: ComfyExtension = {
       }
     })
 
-    // Modes
-    // 0: Always
-    // 1: On Event
-    // 2: Never
-    // 3: On Trigger
-    // 4: Bypass
-    // If all nodes are the same mode, add a menu option to change the mode
-    if (allNodesAreSameMode) {
-      const mode = nodesInGroup[0].mode
-      switch (mode) {
-        case 0:
-          // All nodes are always, option to disable, and bypass
-          items.push({
-            content: 'Set Group Nodes to Never',
-            callback: () => {
-              for (const node of nodesInGroup) {
-                setNodeMode(node, 2)
-              }
-            }
-          })
-          items.push({
-            content: 'Bypass Group Nodes',
-            callback: () => {
-              for (const node of nodesInGroup) {
-                setNodeMode(node, 4)
-              }
-            }
-          })
-          break
-        case 2:
-          // All nodes are never, option to enable, and bypass
-          items.push({
-            content: 'Set Group Nodes to Always',
-            callback: () => {
-              for (const node of nodesInGroup) {
-                setNodeMode(node, 0)
-              }
-            }
-          })
-          items.push({
-            content: 'Bypass Group Nodes',
-            callback: () => {
-              for (const node of nodesInGroup) {
-                setNodeMode(node, 4)
-              }
-            }
-          })
-          break
-        case 4:
-          // All nodes are bypass, option to enable, and disable
-          items.push({
-            content: 'Set Group Nodes to Always',
-            callback: () => {
-              for (const node of nodesInGroup) {
-                setNodeMode(node, 0)
-              }
-            }
-          })
-          items.push({
-            content: 'Set Group Nodes to Never',
-            callback: () => {
-              for (const node of nodesInGroup) {
-                setNodeMode(node, 2)
-              }
-            }
-          })
-          break
-        default:
-          // All nodes are On Trigger or On Event(Or other?), option to disable, set to always, or bypass
-          items.push({
-            content: 'Set Group Nodes to Always',
-            callback: () => {
-              for (const node of nodesInGroup) {
-                setNodeMode(node, 0)
-              }
-            }
-          })
-          items.push({
-            content: 'Set Group Nodes to Never',
-            callback: () => {
-              for (const node of nodesInGroup) {
-                setNodeMode(node, 2)
-              }
-            }
-          })
-          items.push({
-            content: 'Bypass Group Nodes',
-            callback: () => {
-              for (const node of nodesInGroup) {
-                setNodeMode(node, 4)
-              }
-            }
-          })
-          break
-      }
-    } else {
-      // Nodes are not all the same mode, add a menu option to change the mode to always, never, or bypass
+    for (const { content, mode } of MODE_MENU_ITEMS) {
+      if (mode === sharedMode) continue
+
       items.push({
-        content: 'Set Group Nodes to Always',
+        content,
         callback: () => {
           for (const node of nodesInGroup) {
-            setNodeMode(node, 0)
-          }
-        }
-      })
-      items.push({
-        content: 'Set Group Nodes to Never',
-        callback: () => {
-          for (const node of nodesInGroup) {
-            setNodeMode(node, 2)
-          }
-        }
-      })
-      items.push({
-        content: 'Bypass Group Nodes',
-        callback: () => {
-          for (const node of nodesInGroup) {
-            setNodeMode(node, 4)
+            setNodeMode(node, mode)
           }
         }
       })


### PR DESCRIPTION
## Summary

Collapse the four duplicated branches that build the group context-menu mode items into a single table, and add the characterization tests the file never had.

## Changes

- **What**: `getCanvasMenuItems` built the same three menu items (`Set Group Nodes to Always` / `Set Group Nodes to Never` / `Bypass Group Nodes`) in four separate branches, each omitting whichever mode the nodes were already in. That reduces to iterating the three modes and skipping the shared one. Bare `0` / `2` / `4` are now `LGraphEventMode`, which retires the hand-maintained mode comment. Net -124/+17 in the source file.
- **Breaking**: none — menu labels, ordering, `disabled` state and callback effects are unchanged.

Fallow: `dup:e18223f9` — 3 duplicated instances, 16 lines each
`src/extensions/core/groupOptions.ts`
Risk: R0 (no path rule matched — carried by surcharges, not a verified-safe tier) · value 15.0 / risk 5.0 / mechanical 0.72 · risk map `v0-frontend`

## Review Focus

The mode table is ordered Always, Never, Bypass, and each old branch is reproduced by skipping the group's shared mode:

- all Always → Never, Bypass
- all Never → Always, Bypass
- all Bypass → Always, Never
- all On Event / On Trigger, or mixed modes → all three

That last row is the one worth checking: the old `default:` case and the old `else` branch both emitted all three items, and both now fall out of "shared mode is not in the table" / "there is no shared mode".

Tests were written against the pre-refactor code and are unmodified by the refactor commit — they pass against both revisions.
