### PR TITLE
feat: note 1080p and video extension in Seedance 2.5 hero copy

### DIFF
--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -5027,9 +5027,9 @@ const translations = {
     'zh-CN': 'Seedance 2.5 已上线'
   },
   'seedance.hero.description': {
-    en: "ByteDance's cinematic video model — multi-shot sequences with native audio, text or image in. You direct on the canvas; Seedance renders the cut.",
+    en: "ByteDance's cinematic video model — multi-shot sequences with native audio, text or image in. You direct on the canvas; Seedance renders the cut. Now available in 1080p with video extension.",
     'zh-CN':
-      '字节跳动的电影级视频模型：多镜头序列，原生音频，支持文本或图像输入。你在画布上执导，Seedance 负责渲染成片。'
+      '字节跳动的电影级视频模型：多镜头序列，原生音频，支持文本或图像输入。你在画布上执导，Seedance 负责渲染成片。现已支持 1080p 及视频扩展。'
   },
   'seedance.hero.primaryCta': {
     en: 'RUN SEEDANCE 2.5',


### PR DESCRIPTION
## Summary

Updates the /seedance-2.5 hero description to mention 1080p output and video extension.

## Changes

- **What**: Appended "Now available in 1080p with video extension." (and the zh-CN equivalent) to `seedance.hero.description` in `apps/website/src/i18n/translations.ts`.

## Review Focus

Copy-only change; both `en` and `zh-CN` strings updated to stay in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)