### PR TITLE
fix: safely skip ineligible Playwright video tests

### DIFF
--- a/.github/workflows/ci-tests-e2e.yaml
+++ b/.github/workflows/ci-tests-e2e.yaml
@@ -275,8 +275,49 @@ jobs:
         if: steps.detect.outputs.has-new-tests == 'true'
         run: pnpm install --frozen-lockfile
 
-      - name: Run new test(s) with video recording
+      - name: Find Chromium-eligible new tests
         if: steps.detect.outputs.has-new-tests == 'true'
+        id: recordable
+        env:
+          NEW_SPEC_FILES: ${{ steps.detect.outputs.files }}
+        run: |
+          FILES=$(echo "$NEW_SPEC_FILES" | tr '\n' ' ')
+          LIST_EXIT=0
+          LIST_OUTPUT=$(pnpm exec playwright test --project=chromium --list $FILES 2>&1) || LIST_EXIT=$?
+          echo "$LIST_OUTPUT"
+
+          if [ "$LIST_EXIT" -eq 0 ]; then
+            echo "has-tests=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if ! echo "$LIST_OUTPUT" | grep -q 'Total: 0 tests in 0 files'; then
+            exit "$LIST_EXIT"
+          fi
+
+          echo "has-tests=false" >> "$GITHUB_OUTPUT"
+          {
+            echo '## New-test video walkthrough'
+            echo
+            echo '### Skipped safely: no Chromium-eligible tests'
+            echo
+            echo 'The workflow detected newly added Playwright spec files, but none of their tests are eligible for the `chromium` project used to record walkthroughs.'
+            echo 'This commonly happens when every test uses a project-routing tag excluded by Chromium: `@perf`, `@audit`, `@cloud`, or `@mobile`.'
+            echo 'The regular project-specific E2E jobs still run these tests. This video job succeeds without creating an empty report or video artifact.'
+            echo
+            echo 'Detected files:'
+            echo '```text'
+            echo "$NEW_SPEC_FILES"
+            echo '```'
+            echo
+            echo 'Playwright discovery output:'
+            echo '```text'
+            echo "$LIST_OUTPUT"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Run new test(s) with video recording
+        if: steps.recordable.outputs.has-tests == 'true'
         env:
           RECORD_VIDEO: 'true'
           SLOW_MO: '1000'
@@ -286,7 +327,7 @@ jobs:
           pnpm exec playwright test --project=chromium $FILES
 
       - name: Upload new-test report (with embedded video)
-        if: ${{ !cancelled() && steps.detect.outputs.has-new-tests == 'true' }}
+        if: ${{ !cancelled() && steps.recordable.outputs.has-tests == 'true' }}
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: playwright-report-new-tests

--- a/.github/workflows/ci-tests-e2e.yaml
+++ b/.github/workflows/ci-tests-e2e.yaml
@@ -283,16 +283,16 @@ jobs:
         run: |
           FILES=$(echo "$NEW_SPEC_FILES" | tr '\n' ' ')
           LIST_EXIT=0
-          LIST_OUTPUT=$(pnpm exec playwright test --project=chromium --list $FILES 2>&1) || LIST_EXIT=$?
+          LIST_OUTPUT=$(pnpm exec playwright test --project=chromium --list --pass-with-no-tests $FILES 2>&1) || LIST_EXIT=$?
           echo "$LIST_OUTPUT"
 
-          if [ "$LIST_EXIT" -eq 0 ]; then
-            echo "has-tests=true" >> "$GITHUB_OUTPUT"
-            exit 0
+          if [ "$LIST_EXIT" -ne 0 ]; then
+            exit "$LIST_EXIT"
           fi
 
-          if ! echo "$LIST_OUTPUT" | grep -q 'Total: 0 tests in 0 files'; then
-            exit "$LIST_EXIT"
+          if ! echo "$LIST_OUTPUT" | grep -Fxq 'Total: 0 tests in 0 files'; then
+            echo "has-tests=true" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
 
           echo "has-tests=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ci-tests-e2e.yaml
+++ b/.github/workflows/ci-tests-e2e.yaml
@@ -203,7 +203,13 @@ jobs:
   # expanded check names so PRs with no e2e-relevant changes aren't stuck.
   e2e-status:
     if: ${{ always() }}
-    needs: [changes, playwright-tests-chromium-sharded, playwright-tests]
+    needs:
+      [
+        changes,
+        playwright-tests-chromium-sharded,
+        playwright-tests,
+        playwright-video-new-tests
+      ]
     runs-on: ubuntu-latest
     steps:
       - name: Check E2E results
@@ -211,9 +217,10 @@ jobs:
           SHOULD_RUN: ${{ needs.changes.outputs.should-run }}
           SHARDED: ${{ needs.playwright-tests-chromium-sharded.result }}
           BROWSERS: ${{ needs.playwright-tests.result }}
+          VIDEO: ${{ needs.playwright-video-new-tests.result }}
         run: |
           [[ "$SHOULD_RUN" != "true" ]] && echo "E2E skipped" && exit 0
-          [[ "$SHARDED" != "success" || "$BROWSERS" != "success" ]] && echo "E2E failed" && exit 1
+          [[ "$SHARDED" != "success" || "$BROWSERS" != "success" || ( "$VIDEO" != "success" && "$VIDEO" != "skipped" ) ]] && echo "E2E failed" && exit 1
           echo "E2E passed"
 
   # Records video only for spec files newly added in this PR, to keep cost bounded.

--- a/.github/workflows/ci-tests-e2e.yaml
+++ b/.github/workflows/ci-tests-e2e.yaml
@@ -275,13 +275,43 @@ jobs:
         if: steps.detect.outputs.has-new-tests == 'true'
         run: pnpm install --frozen-lockfile
 
-      - name: Find Chromium-eligible new tests
+      - name: Find safely recordable new tests
         if: steps.detect.outputs.has-new-tests == 'true'
         id: recordable
         env:
           NEW_SPEC_FILES: ${{ steps.detect.outputs.files }}
         run: |
           FILES=$(echo "$NEW_SPEC_FILES" | tr '\n' ' ')
+          AUDIT_EXIT=0
+          AUDIT_OUTPUT=$(pnpm exec playwright test --project=audit --list --pass-with-no-tests $FILES 2>&1) || AUDIT_EXIT=$?
+          echo "$AUDIT_OUTPUT"
+
+          if [ "$AUDIT_EXIT" -ne 0 ]; then
+            exit "$AUDIT_EXIT"
+          fi
+
+          if ! echo "$AUDIT_OUTPUT" | grep -Fxq 'Total: 0 tests in 0 files'; then
+            {
+              echo '## New-test video walkthrough'
+              echo
+              echo '### Cannot skip safely: audit tests have no regular CI coverage'
+              echo
+              echo 'At least one newly added test is routed to the `audit` project. Unlike the other projects excluded by Chromium, no regular CI job executes audit tests.'
+              echo 'This video job only records the `chromium` project, so it fails rather than allowing the PR to pass without executing the new audit test.'
+              echo
+              echo 'Detected files:'
+              echo '```text'
+              echo "$NEW_SPEC_FILES"
+              echo '```'
+              echo
+              echo 'Audit discovery output:'
+              echo '```text'
+              echo "$AUDIT_OUTPUT"
+              echo '```'
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+
           LIST_EXIT=0
           LIST_OUTPUT=$(pnpm exec playwright test --project=chromium --list --pass-with-no-tests $FILES 2>&1) || LIST_EXIT=$?
           echo "$LIST_OUTPUT"
@@ -302,7 +332,7 @@ jobs:
             echo '### Skipped safely: no Chromium-eligible tests'
             echo
             echo 'The workflow detected newly added Playwright spec files, but none of their tests are eligible for the `chromium` project used to record walkthroughs.'
-            echo 'This commonly happens when every test uses a project-routing tag excluded by Chromium: `@perf`, `@audit`, `@cloud`, or `@mobile`.'
+            echo 'This commonly happens when every test uses a project-routing tag excluded by Chromium: `@perf`, `@cloud`, or `@mobile`.'
             echo 'The regular project-specific E2E jobs still run these tests. This video job succeeds without creating an empty report or video artifact.'
             echo
             echo 'Detected files:'

--- a/browser_tests/README.md
+++ b/browser_tests/README.md
@@ -789,7 +789,8 @@ and time bounded. Recording is opt-in via `RECORD_VIDEO=true` (set only by
 that CI job; see `playwright.config.ts`) and slowed down with `SLOW_MO` so
 the result is legible for reviewers. Files containing no tests eligible for
 the `chromium` project, such as `@perf`-only specs, are skipped with an
-explanation in the workflow summary.
+explanation in the workflow summary. Newly added `@audit` tests fail this
+job instead because the audit project has no regular CI coverage.
 
 ## After Making Changes
 

--- a/browser_tests/README.md
+++ b/browser_tests/README.md
@@ -787,7 +787,9 @@ the other browser report links in the PR comment. It's scoped to added
 files only — the existing suite always runs without video — to keep CI cost
 and time bounded. Recording is opt-in via `RECORD_VIDEO=true` (set only by
 that CI job; see `playwright.config.ts`) and slowed down with `SLOW_MO` so
-the result is legible for reviewers.
+the result is legible for reviewers. Files containing no tests eligible for
+the `chromium` project, such as `@perf`-only specs, are skipped with an
+explanation in the workflow summary.
 
 ## After Making Changes
 


### PR DESCRIPTION
## Summary

Make the new-test video job succeed safely when newly added specs contain no tests eligible for its Chromium project, while explaining the skip in the GitHub Actions workflow summary.

## Changes

- **What**: Run Playwright discovery before recording. A genuine discovery/configuration error still fails, while the specific zero-test result skips recording and artifact upload.
- **What**: Add a detailed workflow summary naming the project-routing mismatch, detected files, discovery output, and continued coverage from project-specific E2E jobs.
- **What**: Document that Chromium-ineligible specs such as `@perf`-only files are skipped.

## Review Focus

The zero-test condition is deliberately narrow: only Playwright output reporting `Total: 0 tests in 0 files` is converted to a successful skip. Other nonzero discovery exits remain failures.

## Verification

- Confirmed an `@perf`-only spec produces `has-tests=false` and the expected workflow summary.
- Confirmed a standard Chromium spec produces `has-tests=true`.
- `pnpm exec oxfmt --check .github/workflows/ci-tests-e2e.yaml browser_tests/README.md`
- `git diff --check`