### PR TITLE
feat(website): add /models-v2 model-page A/B preview (noindex, unlinked)

### DIFF
--- a/apps/website/astro.config.ts
+++ b/apps/website/astro.config.ts
@@ -18,9 +18,18 @@ const SITEMAP_EXCLUDED_PATHNAMES = new Set([
   ...LOCALE_PREFIXES.map((prefix) => `${prefix}/booking-confirmation`)
 ])
 
+// /models-v2 is an unlinked, noindex A/B-test preview — keep every slug out
+// of the sitemap until it graduates or is deleted.
+const SITEMAP_EXCLUDED_PREFIXES = LOCALE_PREFIXES.map(
+  (prefix) => `${prefix}/models-v2`
+)
+
 function isExcludedFromSitemap(page: string): boolean {
   const pathname = new URL(page).pathname.replace(/\/$/, '')
-  return SITEMAP_EXCLUDED_PATHNAMES.has(pathname)
+  return (
+    SITEMAP_EXCLUDED_PATHNAMES.has(pathname) ||
+    SITEMAP_EXCLUDED_PREFIXES.some((prefix) => pathname.startsWith(prefix))
+  )
 }
 
 export default defineConfig({

--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -16,6 +16,7 @@
     "test:visual": "playwright test --project visual",
     "test:visual:update": "playwright test --project visual --update-snapshots",
     "ashby:refresh-snapshot": "tsx ./scripts/refresh-ashby-snapshot.ts",
+    "models-v2:preview-check": "node ./scripts/models-v2-preview-check.mjs",
     "cloud-nodes:refresh-snapshot": "tsx ./scripts/refresh-cloud-nodes-snapshot.ts",
     "generate:models": "tsx ./scripts/generate-models.ts",
     "validate:jsonld": "tsx ./scripts/validate-jsonld.ts"

--- a/apps/website/scripts/models-v2-preview-check.mjs
+++ b/apps/website/scripts/models-v2-preview-check.mjs
@@ -1,0 +1,268 @@
+// E2E check for the /models-v2 A/B-test preview. Run against any base URL:
+//   node scripts/models-v2-preview-check.mjs http://localhost:4321
+//   node scripts/models-v2-preview-check.mjs https://<deployment>.vercel.app
+// Uses the repo's @playwright/test with the installed Chrome channel.
+import { chromium } from '@playwright/test'
+
+const BASE = process.argv[2] ?? 'http://localhost:4321'
+const results = []
+const check = (name, ok, note = '') => {
+  results.push([name, ok, note])
+  console.log(`${ok ? 'PASS' : 'FAIL'} ${name}${note ? ' — ' + note : ''}`)
+}
+
+const run = async () => {
+  const browser = await chromium.launch({ channel: 'chrome' })
+  const desktop = await (
+    await browser.newContext({ viewport: { width: 1440, height: 900 } })
+  ).newPage()
+
+  // ---------- DIRECTORY ----------
+  await desktop.goto(`${BASE}/models-v2`, { waitUntil: 'networkidle' })
+  const visible = () =>
+    desktop.$$eval(
+      '.m-card',
+      (els) => els.filter((e) => e.style.display !== 'none').length
+    )
+
+  const total = await visible()
+  await desktop.fill('#model-search', 'flux')
+  await desktop.waitForTimeout(300)
+  const flux = await visible()
+  check('search filters', flux > 3 && flux < total, `${flux}/${total}`)
+  check(
+    'match counter',
+    /match/.test((await desktop.textContent('#match-count')) ?? ''),
+    ''
+  )
+  await desktop.click('#search-clear')
+  await desktop.waitForTimeout(200)
+  check('search clear button', (await visible()) === total, '')
+  await desktop.fill('#model-search', 'wan')
+  await desktop.keyboard.press('Escape')
+  await desktop.waitForTimeout(200)
+  check('escape clears', (await visible()) === total, '')
+
+  for (const pill of ['partner', 'loras', 'launch']) {
+    await desktop.click(`[data-pill="${pill}"]`)
+    await desktop.waitForTimeout(250)
+    const n = await visible()
+    check(`pill ${pill}`, n > 0 && n < total, `${n}`)
+  }
+  await desktop.click('[data-pill="all"]')
+  await desktop.click('[data-try="q:flux"]')
+  await desktop.waitForTimeout(300)
+  check('try-chip q:flux', (await visible()) === flux, '')
+  await desktop.click('#search-clear')
+
+  // Scoped to <main>: the shared site footer links /p/supported-models by design.
+  check(
+    'no legacy links',
+    (await desktop.$$eval(
+      'main a[href*="/p/supported-models"]',
+      (a) => a.length
+    )) === 0,
+    ''
+  )
+  const llms = await desktop.request.get(`${BASE}/models-v2/llms.txt`)
+  check(
+    'llms.txt',
+    llms.status() === 200 && (await llms.text()).includes('FLUX 3'),
+    ''
+  )
+  const wanAlias = await desktop.request.get(`${BASE}/models-v2/wan`)
+  check('wan alias', wanAlias.status() === 200, '')
+
+  // ---------- MODEL PAGE (client-side nav — the astro:page-load path) ----------
+  await desktop.click('a[href="/models-v2/flux-3"]')
+  await desktop.waitForURL('**/models-v2/flux-3')
+  await desktop.waitForTimeout(400)
+
+  // APP | GRAPH | JSON
+  await desktop.click('[data-iview="graph"]')
+  check(
+    'graph view',
+    await desktop.$eval(
+      '#panel-graph',
+      (el) => !el.classList.contains('hidden')
+    ),
+    ''
+  )
+  check(
+    'graph svg',
+    (await desktop.$$eval('#panel-graph svg g', (g) => g.length)) >= 5,
+    ''
+  )
+  await desktop.click('[data-iview="json"]')
+  const j1 = (await desktop.textContent('#input-json')) ?? ''
+  check('json view payload', j1.includes('"workflow": "flux-3"'), '')
+  await desktop.click('[data-iview="app"]')
+  await desktop.fill('#pg-prompt', 'a red fox in the snow')
+  await desktop.click('[data-iview="json"]')
+  check(
+    'prompt live-binds json',
+    ((await desktop.textContent('#input-json')) ?? '').includes(
+      'a red fox in the snow'
+    ),
+    ''
+  )
+  await desktop.click('[data-iview="graph"]')
+  check(
+    'prompt live-binds graph',
+    ((await desktop.textContent('#g-prompt-1')) ?? '').includes('a red fox'),
+    ''
+  )
+  await desktop.click('[data-iview="app"]')
+
+  // repricing
+  const costBefore = (await desktop.textContent('#cost-line')) ?? ''
+  await desktop.selectOption('#sel-resolution', '1080p')
+  const costAfter = (await desktop.textContent('#cost-line')) ?? ''
+  check(
+    'resolution reprices',
+    costBefore !== costAfter && costAfter.includes('24'),
+    costAfter
+  )
+  await desktop.selectOption('#sel-resolution', '720p')
+
+  // reference image
+  await desktop.click('#add-image-btn')
+  await desktop.click('[data-iview="json"]')
+  check(
+    'reference image in payload',
+    ((await desktop.textContent('#input-json')) ?? '').includes(
+      'reference_image'
+    ),
+    ''
+  )
+  await desktop.click('[data-iview="app"]')
+
+  // result JSON tab (pre-run receipt)
+  await desktop.click('[data-rview="json"]')
+  check(
+    'result json example receipt',
+    ((await desktop.textContent('#result-json')) ?? '').includes(
+      '"status": "example"'
+    ),
+    ''
+  )
+  await desktop.click('[data-rview="preview"]')
+
+  // LLMs menu
+  await desktop.click('#llms-btn')
+  check(
+    'llms menu opens',
+    await desktop.$eval('#llms-menu', (el) => !el.classList.contains('hidden')),
+    ''
+  )
+  const mdHref = await desktop.$eval('#llms-menu a[href$=".md"]', (a) =>
+    a.getAttribute('href')
+  )
+  const md = await desktop.request.get(`${BASE}${mdHref}`)
+  check(
+    'page .md twin',
+    md.status() === 200 && (await md.text()).includes('FLUX 3'),
+    mdHref ?? ''
+  )
+  check(
+    'llm deep links',
+    (await desktop.$$eval(
+      '#llms-menu a[href*="claude.ai"], #llms-menu a[href*="chatgpt.com"]',
+      (a) => a.length
+    )) === 2,
+    ''
+  )
+  await desktop.click('body', { position: { x: 10, y: 400 } })
+
+  // gallery warm start
+  await desktop.evaluate(() =>
+    document.getElementById('gallery')?.scrollIntoView()
+  )
+  await desktop.waitForTimeout(300)
+  const firstPrompt = await desktop.$eval(
+    '[data-use-prompt]',
+    (b) => b.dataset.usePrompt
+  )
+  await desktop.click('[data-use-prompt]')
+  await desktop.waitForTimeout(600)
+  check(
+    'gallery use-prompt',
+    (await desktop.inputValue('#pg-prompt')) === firstPrompt,
+    ''
+  )
+
+  // journey: wall → auth → run → receipt → variations
+  await desktop.click('#pg-run')
+  await desktop.waitForSelector('#auth-modal:not(.hidden)', { timeout: 4000 })
+  check('auth wall', true, '')
+  await desktop.click('text=Continue with Google')
+  await desktop.waitForTimeout(2900)
+  check(
+    'meter decrements',
+    /4 left/i.test((await desktop.textContent('#free-meter')) ?? ''),
+    ''
+  )
+  await desktop.click('[data-rview="json"]')
+  const receipt = (await desktop.textContent('#result-json')) ?? ''
+  check(
+    'run receipt json',
+    receipt.includes('job_id') && receipt.includes('credits_charged'),
+    ''
+  )
+  await desktop.click('[data-rview="preview"]')
+  await desktop.click('#queue-vars')
+  await desktop.waitForTimeout(3400)
+  const varsLoaded = await desktop.$$eval(
+    '#var-strip img',
+    (imgs) => imgs.filter((i) => !i.classList.contains('hidden')).length
+  )
+  check('variations queue', varsLoaded === 4, `${varsLoaded}/4`)
+  await desktop.waitForSelector('#upgrade-overlay:not(.hidden)', {
+    timeout: 4000
+  })
+  check(
+    'upgrade moment at 0 runs',
+    /used/i.test((await desktop.textContent('#free-meter')) ?? ''),
+    ''
+  )
+  await desktop.click('#demo-reset')
+  await desktop.waitForTimeout(300)
+  check(
+    'demo reset',
+    /5 left/i.test((await desktop.textContent('#free-meter')) ?? ''),
+    ''
+  )
+
+  // ---------- MOBILE ----------
+  const mobile = await (
+    await browser.newContext({
+      viewport: { width: 390, height: 844 },
+      isMobile: true,
+      hasTouch: true
+    })
+  ).newPage()
+  await mobile.goto(`${BASE}/models-v2/minimax-h3`, {
+    waitUntil: 'networkidle'
+  })
+  await mobile.click('#pg-run-mobile')
+  await mobile.waitForSelector('#auth-modal:not(.hidden)', { timeout: 4000 })
+  check('mobile sticky bar wall', true, '')
+  await mobile.click('text=Continue with Google')
+  await mobile.waitForTimeout(2900)
+  check(
+    'mobile journey',
+    /4 left/i.test((await mobile.textContent('#free-meter')) ?? ''),
+    ''
+  )
+
+  await browser.close()
+
+  const pass = results.filter(([, ok]) => ok).length
+  console.log(`\n${pass}/${results.length} checks passed against ${BASE}`)
+  process.exit(pass === results.length ? 0 : 1)
+}
+
+run().catch((e) => {
+  console.error('SUITE ERROR:', e.message)
+  process.exit(1)
+})

--- a/apps/website/src/config/models-v2-demo.ts
+++ b/apps/website/src/config/models-v2-demo.ts
@@ -1,0 +1,425 @@
+// DEMO DATA for the /models-v2 A/B-test preview (not linked, noindex).
+// Featured roster = the actual 2026 launch lineup, ordered by measured landing
+// CVR where known (PostHog, Aug 2026) and partner spend rank (Jan–May 2026
+// Ramp data — used for ordering only; dollar figures deliberately not shown).
+// Run counts and per-run prices are placeholder estimates labeled "est."
+// Delete this file with the preview pages.
+import { models } from './models'
+
+const TPL =
+  'https://raw.githubusercontent.com/Comfy-Org/workflow_templates/main/templates'
+
+// Image CDN proxy: raw.githubusercontent rate-limits pages that request many
+// images at once. weserv caches + resizes at the edge — and doubles as the
+// demo of the rendition discipline from the gap audit (819KB raw → ~40KB card).
+export const proxyImg = (u: string, w = 800) =>
+  `https://wsrv.nl/?url=${encodeURIComponent(u)}&w=${w}&q=80&output=webp`
+
+export type Modality =
+  | 'video'
+  | 'i2v'
+  | 'image'
+  | 'edit'
+  | 'audio'
+  | 'upscale'
+  | '3d'
+
+export interface LaunchModel {
+  slug: string
+  name: string
+  publisher: string
+  blurb: string
+  modality: Modality
+  kind: 'open weights' | 'partner api'
+  dayZero?: boolean
+  img: string
+  gallery: string[]
+  runs: string
+  price: string
+  launchUrl?: string
+  workflowsUrl: string
+  promptExample: string
+}
+
+export const modalityMeta: Record<Modality, { label: string; color: string }> =
+  {
+    video: { label: 'Text to video', color: '#96b4ff' },
+    i2v: { label: 'Image to video', color: '#96b4ff' },
+    image: { label: 'Text to image', color: '#ff99f7' },
+    edit: { label: 'Image edit', color: '#dbd6f2' },
+    audio: { label: 'Audio + music', color: '#b7ded5' },
+    upscale: { label: 'Upscale', color: '#b7ded5' },
+    '3d': { label: '3D', color: '#fabc25' }
+  }
+
+const t = (n: string) => proxyImg(`${TPL}/${n}`, 800)
+
+// Ordered: measured CVR leaders first (flux-3 15.6%, minimax-h3 9.9%,
+// wan launches 8–9%), then day-zero freshness.
+export const launches: LaunchModel[] = [
+  {
+    slug: 'flux-3',
+    name: 'FLUX 3',
+    publisher: 'Black Forest Labs',
+    blurb:
+      'Frontier video generation. Animate a still frame into coherent, natural motion.',
+    modality: 'i2v',
+    kind: 'partner api',
+    dayZero: true,
+    img: t('api_bfl_flux3_i2v-1.webp'),
+    gallery: [
+      t('api_bfl_flux3_i2v-1.webp'),
+      t('api_bfl_flux3_t2v-1.webp'),
+      t('api_bfl_flux2_max_sofa_swap-1.webp'),
+      t('api_bfl_flux1_expand_image-1.webp')
+    ],
+    runs: '2.4M runs · est.',
+    price: 'from $0.09 / run · est.',
+    launchUrl: 'https://comfy.org/flux-3',
+    workflowsUrl: 'https://comfy.org/workflows/model/flux',
+    promptExample:
+      'A paper crane unfolds itself and lifts off a desk, morning light through blinds — subtle camera push.'
+  },
+  {
+    slug: 'minimax-h3',
+    name: 'MiniMax H3',
+    publisher: 'MiniMax',
+    blurb:
+      'Image-to-video with strong physics and character hold across shots.',
+    modality: 'i2v',
+    kind: 'partner api',
+    dayZero: true,
+    img: t('api_minimax_h3_t2v-1.webp'),
+    gallery: [
+      t('api_minimax_h3_t2v-1.webp'),
+      t('api_minimax_h3_r2v-1.webp'),
+      t('api_minimax_h3_flf2v-1.webp')
+    ],
+    runs: '980k runs · est.',
+    price: 'from $0.10 / run · est.',
+    launchUrl: 'https://comfy.org/minimax-h3',
+    workflowsUrl: 'https://comfy.org/workflows',
+    promptExample:
+      'A dancer mid-spin frozen in a warehouse — continue the motion, cloth and hair follow through.'
+  },
+  {
+    slug: 'wan-2-2',
+    name: 'Wan 2.2',
+    publisher: 'Alibaba',
+    blurb:
+      'Open-weights video generation. The production baseline for i2v on the graph.',
+    modality: 'video',
+    kind: 'open weights',
+    img: t('video_wan_vace_14B_ref2v-1.webp'),
+    gallery: [
+      t('video_wan_vace_14B_ref2v-1.webp'),
+      t('api_wan2_6_i2v-1.webp'),
+      t('api_wan2_6_t2v-1.webp')
+    ],
+    runs: '1.8M runs · est.',
+    price: 'from $0.04 / run · est.',
+    workflowsUrl: 'https://comfy.org/workflows/model/wan',
+    promptExample:
+      'Golden hour drone shot pushing over a ridge line, fog pooling in the valley — native ambient audio.'
+  },
+  {
+    slug: 'wan-3-0',
+    name: 'Wan 3.0',
+    publisher: 'Alibaba',
+    blurb:
+      'The next Wan generation — higher fidelity, longer shots, still open weights.',
+    modality: 'video',
+    kind: 'open weights',
+    dayZero: true,
+    img: t('api_wan2_7_t2v-1.webp'),
+    gallery: [
+      t('api_wan2_7_t2v-1.webp'),
+      t('api_wan2_7_i2v-1.webp'),
+      t('api_wan2_7_r2v-1.webp')
+    ],
+    runs: '640k runs · est.',
+    price: 'from $0.05 / run · est.',
+    launchUrl: 'https://comfy.org/wan-3-0',
+    workflowsUrl: 'https://comfy.org/workflows/model/wan',
+    promptExample:
+      'Slow orbital shot of a lighthouse in a storm, waves breaking white against the rocks.'
+  },
+  {
+    slug: 'ltx-2-5',
+    name: 'LTX 2.5',
+    publisher: 'Lightricks',
+    blurb:
+      'Fast iteration video. Draft loops in seconds, refine on the same seed.',
+    modality: 'video',
+    kind: 'open weights',
+    dayZero: true,
+    img: t('api_ltx2_5_t2v-1.webp'),
+    gallery: [
+      t('api_ltx2_5_t2v-1.webp'),
+      t('api_ltx2_5_i2v-1.webp'),
+      t('api_ltx2_5_flf2v-1.webp')
+    ],
+    runs: '510k runs · est.',
+    price: 'from $0.02 / run · est.',
+    launchUrl: 'https://comfy.org/ltx-2-5',
+    workflowsUrl: 'https://comfy.org/workflows',
+    promptExample:
+      'Looping macro of ink diffusing through water, teal into black, an unbroken loop.'
+  },
+  {
+    slug: 'seedance-2-5',
+    name: 'Seedance 2.5',
+    publisher: 'ByteDance',
+    blurb:
+      'Native 30-second single-shot video at 720p, from text or reference frames.',
+    modality: 'video',
+    kind: 'partner api',
+    img: t('api_seedance2_0_flf2v-1.webp'),
+    gallery: [
+      t('api_seedance2_0_flf2v-1.webp'),
+      t('api_seedance2_0_mini_r2v-1.webp'),
+      t('api_bytedance_seedance1_5_text_to_video-1.webp')
+    ],
+    runs: '880k runs · est.',
+    price: 'from $0.12 / run · est.',
+    launchUrl: 'https://comfy.org/seedance-2-5',
+    workflowsUrl: 'https://comfy.org/workflows',
+    promptExample:
+      'One continuous 30-second take: a chef plates a dish as the camera circles the pass.'
+  },
+  {
+    slug: 'grok-imagine-2',
+    name: 'Grok Imagine 2',
+    publisher: 'xAI',
+    blurb:
+      'Image generation and editing with xAI’s latest — on the same canvas as your open models.',
+    modality: 'edit',
+    kind: 'partner api',
+    dayZero: true,
+    img: t('api_grok_imagine_image_2_t2i-1.webp'),
+    gallery: [
+      t('api_grok_imagine_image_2_t2i-1.webp'),
+      t('api_grok_imagine_image_2_image_edit-1.webp'),
+      t('api_grok_image_edit-1.webp')
+    ],
+    runs: '420k runs · est.',
+    price: 'from $0.07 / run · est.',
+    workflowsUrl: 'https://comfy.org/workflows',
+    promptExample:
+      'Rebuild this product shot as a 1970s magazine ad — grain, type, and all.'
+  },
+  {
+    slug: 'gpt-image-2',
+    name: 'GPT Image 2',
+    publisher: 'OpenAI',
+    blurb:
+      'Fine-grained image generation and editing that follows instructions precisely.',
+    modality: 'edit',
+    kind: 'partner api',
+    img: t('api_openai_gpt_image_2_t2i-1.webp'),
+    gallery: [
+      t('api_openai_gpt_image_2_t2i-1.webp'),
+      t('api_openai_gpt_image_2_image_edit-1.webp'),
+      t('api_openai_fashion_billboard_generator-1.webp')
+    ],
+    runs: '760k runs · est.',
+    price: 'from $0.06 / run · est.',
+    workflowsUrl: 'https://comfy.org/workflows',
+    promptExample:
+      'Swap the label on this bottle to the attached design, keep the condensation.'
+  },
+  {
+    slug: 'minimax-music-3',
+    name: 'MiniMax Music 3',
+    publisher: 'MiniMax',
+    blurb:
+      'Complete songs with structure — verse, chorus, and a mix you can direct.',
+    modality: 'audio',
+    kind: 'partner api',
+    dayZero: true,
+    img: t('audio_minimax_music_3-1.webp'),
+    gallery: [
+      t('audio_minimax_music_3-1.webp'),
+      t('audio_ace_step1_5_xl_base-1.webp'),
+      t('api_bytedance_seed_audio1_0_t2a-1.webp')
+    ],
+    runs: '190k runs · est.',
+    price: 'from $0.06 / run · est.',
+    launchUrl: 'https://comfy.org/minimax-music-3',
+    workflowsUrl: 'https://comfy.org/workflows',
+    promptExample:
+      'A slow-burn synthwave track that opens on tape hiss and lands the chorus at 0:45.'
+  },
+  {
+    slug: 'wan-animate-2',
+    name: 'Wan Animate 2',
+    publisher: 'Alibaba',
+    blurb:
+      'Character animation from a single reference. Open weights, day zero.',
+    modality: 'i2v',
+    kind: 'open weights',
+    dayZero: true,
+    img: t('api_wan2_7_video_edit-1.webp'),
+    gallery: [
+      t('api_wan2_7_video_edit-1.webp'),
+      t('video_wan_vace_14B_ref2v-1.webp')
+    ],
+    runs: '420k runs · est.',
+    price: 'from $0.05 / run · est.',
+    launchUrl: 'https://comfy.org/wan-animate-2',
+    workflowsUrl: 'https://comfy.org/workflows/model/wan',
+    promptExample:
+      'Turn this character sheet into a walk cycle, three-quarter view, cape drag included.'
+  },
+  {
+    slug: 'qwen-image-edit',
+    name: 'Qwen Image Edit',
+    publisher: 'Qwen',
+    blurb: 'Instruction-based image editing that holds identity across edits.',
+    modality: 'edit',
+    kind: 'open weights',
+    img: t('image_qwen_Image_2512-1.webp'),
+    gallery: [
+      t('image_qwen_Image_2512-1.webp'),
+      t('api_qwen3_image_edit-1.webp'),
+      t('api_qwen3_t2i-1.webp')
+    ],
+    runs: '1.1M runs · est.',
+    price: 'from $0.01 / run · est.',
+    workflowsUrl: 'https://comfy.org/workflows',
+    promptExample:
+      'Same person, same light — swap the denim jacket for a wool coat.'
+  },
+  {
+    slug: 'kling-2-6',
+    name: 'Kling 2.6',
+    publisher: 'Kling AI',
+    blurb: 'Cinematic motion with pose and camera guidance, via partner nodes.',
+    modality: 'i2v',
+    kind: 'partner api',
+    img: t('api_kling2_6_i2v-1.webp'),
+    gallery: [
+      t('api_kling2_6_i2v-1.webp'),
+      t('api_kling_motion_control-1.webp'),
+      t('api_kling_avatar2-1.webp')
+    ],
+    runs: '380k runs · est.',
+    price: 'from $0.12 / run · est.',
+    workflowsUrl: 'https://comfy.org/workflows',
+    promptExample:
+      'Match this storyboard: she turns from the window as the train passes behind.'
+  }
+]
+
+// Ordered by Jan–May 2026 partner spend (Wan → Hunyuan → Topaz → xAI → MiniMax).
+// Figures intentionally not displayed.
+export const topPartnerApis: LaunchModel[] = [
+  launches.find((l) => l.slug === 'wan-3-0')!,
+  {
+    slug: 'hunyuan-3d',
+    name: 'Hunyuan 3D',
+    publisher: 'Tencent',
+    blurb: 'Image to textured 3D mesh, ready for your pipeline.',
+    modality: '3d',
+    kind: 'partner api',
+    img: t('3d_hunyuan3d_image_to_model-1.webp'),
+    gallery: [
+      t('3d_hunyuan3d_image_to_model-1.webp'),
+      t('3d_triposplat_image_to_gaussian_splat-1.webp')
+    ],
+    runs: '210k runs · est.',
+    price: 'from $0.15 / run · est.',
+    workflowsUrl: 'https://comfy.org/workflows',
+    promptExample:
+      'This sneaker photo → a clean, watertight mesh with PBR textures.'
+  },
+  launches.find((l) => l.slug === 'grok-imagine-2')!,
+  launches.find((l) => l.slug === 'gpt-image-2')!
+]
+
+export interface UseCaseCard {
+  title: string
+  desc: string
+  img: string
+  href: string
+  count: string
+}
+
+export const useCaseWorkflows: UseCaseCard[] = [
+  {
+    title: 'Product shots',
+    desc: 'Studio-grade shots from one phone photo. Relight, stage, upscale.',
+    img: t('api_openai_fashion_billboard_generator-1.webp'),
+    href: 'https://comfy.org/workflows',
+    count: '48 workflows'
+  },
+  {
+    title: 'AI face swap',
+    desc: 'Identity held across shots, edits, and angles.',
+    img: t('api_kling_avatar2-1.webp'),
+    href: 'https://comfy.org/workflows',
+    count: '22 workflows'
+  },
+  {
+    title: 'Expand image',
+    desc: 'Outpaint beyond the frame in the same style.',
+    img: t('api_bfl_flux1_expand_image-1.webp'),
+    href: 'https://comfy.org/workflows',
+    count: '18 workflows'
+  },
+  {
+    title: 'Relight',
+    desc: 'Golden hour on demand. Any photo, any light.',
+    img: t('api_beeble_switchx_image_edit-1.webp'),
+    href: 'https://comfy.org/workflows',
+    count: '16 workflows'
+  },
+  {
+    title: 'Character sheets',
+    desc: 'One reference in, consistent character out — every angle.',
+    img: t('Image_capybara_v0_1_text_to_image-1.webp'),
+    href: 'https://comfy.org/workflows',
+    count: '26 workflows'
+  },
+  {
+    title: 'Image to video',
+    desc: 'Animate any still with motion you control.',
+    img: t('api_bfl_flux3_i2v-1.webp'),
+    href: 'https://comfy.org/workflows/tag/image-to-video',
+    count: '31 workflows'
+  },
+  {
+    title: 'Upscale 4K',
+    desc: 'Detail without artifacts. Batch-ready.',
+    img: t('image_flux2-1.webp'),
+    href: 'https://comfy.org/workflows',
+    count: '14 workflows'
+  },
+  {
+    title: 'Music + audio',
+    desc: 'Full tracks and sound design with structure you direct.',
+    img: t('audio_minimax_music_3-1.webp'),
+    href: 'https://comfy.org/workflows',
+    count: '9 workflows'
+  }
+]
+
+export const dirLabel: Record<string, string> = {
+  diffusion_models: 'Diffusion',
+  checkpoints: 'Checkpoint',
+  loras: 'LoRA',
+  controlnet: 'ControlNet',
+  clip_vision: 'CLIP Vision',
+  model_patches: 'Patch',
+  vae: 'VAE',
+  text_encoders: 'Text encoder',
+  audio_encoders: 'Audio encoder',
+  latent_upscale_models: 'Latent upscale',
+  upscale_models: 'Upscale',
+  style_models: 'Style',
+  partner_nodes: 'Partner node'
+}
+
+export const registryModels = models
+
+export const fallbackImg = t('video_wan_vace_14B_ref2v-1.webp')

--- a/apps/website/src/pages/models-v2/[slug].astro
+++ b/apps/website/src/pages/models-v2/[slug].astro
@@ -1,0 +1,834 @@
+---
+// A/B TEST PREVIEW — playground-first model page, generated for every launch
+// model and every registry entry. Every visible control works: APP ⇄ GRAPH ⇄
+// JSON input views (App = the workflow's exposed inputs, Graph = the actual
+// node graph live-bound to them), Preview ⇄ JSON result receipt, live credit
+// repricing, LLMs menu with per-page markdown, gallery prompt warm-starts,
+// variations queue, and the full signup-journey demo. Not linked. noindex.
+import BaseLayout from '../../layouts/BaseLayout.astro'
+import {
+  launches,
+  topPartnerApis,
+  registryModels,
+  modalityMeta,
+  dirLabel,
+  fallbackImg,
+  proxyImg,
+  type LaunchModel
+} from '../../config/models-v2-demo'
+
+export function getStaticPaths() {
+  const launchLike = [...launches, ...topPartnerApis.filter((p) => !launches.includes(p))]
+  const launchSlugs = new Set(launchLike.map((l) => l.slug))
+  const launchPaths = launchLike.map((l) => ({
+    params: { slug: l.slug },
+    props: { launch: l, registry: null }
+  }))
+  const wanAlias = {
+    params: { slug: 'wan' },
+    props: { launch: launchLike.find((l) => l.slug === 'wan-2-2')!, registry: null }
+  }
+  const registryPaths = registryModels
+    .filter((m) => !launchSlugs.has(m.slug) && m.slug !== 'wan')
+    .map((m) => ({ params: { slug: m.slug }, props: { launch: null, registry: m } }))
+  return [...launchPaths, wanAlias, ...registryPaths]
+}
+
+interface Props {
+  launch: LaunchModel | null
+  registry: (typeof registryModels)[number] | null
+}
+const { launch, registry } = Astro.props
+
+const dirBlurb: Record<string, string> = {
+  diffusion_models: 'A diffusion model that generates images or video from text and image prompts.',
+  checkpoints: 'A full checkpoint — model, CLIP, and VAE in one file.',
+  loras: 'A lightweight add-on tuned for a style, character, or concept. Chain it onto a base model.',
+  controlnet: 'Steers generation with structural guides — depth, edges, or pose.',
+  clip_vision: 'Encodes images into embeddings for conditioning or style transfer.',
+  model_patches: 'A patch applied on top of a base model.',
+  vae: 'Translates between pixel space and latent space.',
+  text_encoders: 'Reads your prompt and translates it for the model.',
+  audio_encoders: 'Encodes audio for conditioning.',
+  latent_upscale_models: 'Upscales in latent space before decoding.',
+  upscale_models: 'Increases resolution while preserving detail.',
+  style_models: 'Transfers artistic style onto generated images.',
+  partner_nodes: 'A partner-hosted model that runs through Comfy API nodes — same canvas, one subscription.'
+}
+
+const name = launch ? launch.name : registry!.displayName
+const slugId = launch ? launch.slug : registry!.slug
+const pageSlug = Astro.params.slug
+const blurb = launch ? launch.blurb : (dirBlurb[registry!.directory] ?? 'A supported model in the Comfy registry.')
+const modality = launch ? launch.modality : 'image'
+const meta = modalityMeta[modality]
+const kind = launch ? launch.kind : (registry!.directory === 'partner_nodes' ? 'partner api' : 'open weights')
+const dayZero = launch?.dayZero ?? false
+const img = launch ? launch.img : registry!.thumbnailUrl ? proxyImg(registry!.thumbnailUrl, 1000) : fallbackImg
+const gallery = launch ? launch.gallery : [registry!.thumbnailUrl ? proxyImg(registry!.thumbnailUrl, 800) : fallbackImg]
+const runs = launch ? launch.runs : `${registry!.workflowCount} workflows use it`
+const price = launch ? launch.price : 'runs on Cloud credits · est.'
+const promptExample = launch
+  ? launch.promptExample
+  : 'Golden hour drone shot pushing over a ridge line, fog pooling in the valley — native ambient audio.'
+const baseCredits = kind === 'partner api' ? 12 : 6
+const workflowsUrl = launch
+  ? launch.workflowsUrl
+  : registry!.hubSlug
+    ? `https://comfy.org/workflows/model/${registry!.hubSlug}`
+    : 'https://comfy.org/workflows'
+const hfUrl = registry?.huggingFaceUrl
+const docsUrl = launch?.launchUrl ?? registry?.docsUrl
+
+const altPromptsByModality: Record<string, string[]> = {
+  video: ['Night market in the rain, neon reflections, slow dolly through the crowd.', 'A glass of water on a train window sill, landscape rushing past outside.'],
+  i2v: ['Continue the motion from this frame — wind picks up, hair and fabric follow.', 'Subtle parallax push-in on this still, dust motes drifting in the light.'],
+  image: ['Editorial product shot on wet slate, single hard key light, deep shadow.', 'Isometric cutaway of a tiny workshop, warm tungsten palette.'],
+  edit: ['Same scene, golden hour — keep every reflection consistent.', 'Swap the background to a studio sweep, keep the subject untouched.'],
+  audio: ['A four-bar lo-fi loop that swings, vinyl crackle underneath.', 'Rising cinematic pulse that resolves on a held brass chord.'],
+  upscale: ['Recover the fine text on the label without inventing detail.', 'Sharpen the weave of the fabric, keep the grain of the film.'],
+  '3d': ['A watertight mesh of this object with clean PBR textures.', 'Turntable-ready asset, quads only, sensible UV seams.']
+}
+const galleryPrompts = [promptExample, ...(altPromptsByModality[modality] ?? [])]
+
+const familyToken = slugId.split('-')[0]
+const familyVariants = registryModels
+  .filter((m) => m.slug.startsWith(familyToken) && m.slug !== (registry?.slug ?? ''))
+  .slice(0, 6)
+
+const costRows: Array<[string, string]> = [
+  [`${name} · 5s · 720p`, `${baseCredits} credits ≈ $${(baseCredits * 0.0084).toFixed(2)} · est.`],
+  [`${name} · 5s · 1080p`, `${baseCredits * 2} credits ≈ $${(baseCredits * 2 * 0.0084).toFixed(2)} · est.`],
+  [`${name} · 10s · 720p`, `${baseCredits * 2} credits ≈ $${(baseCredits * 2 * 0.0084).toFixed(2)} · est.`],
+  ['Creator plan / month', `≈ ${Math.round(2400 / baseCredits) * 10} runs · est.`]
+]
+
+const canonicalURL = new URL(Astro.url.pathname, Astro.site ?? 'https://comfy.org')
+const mdUrl = `/models-v2/${pageSlug}.md`
+const llmPrompt = encodeURIComponent(`Read ${canonicalURL.href}.md and help me run ${name} in ComfyUI. I want to understand the inputs and get my first output.`)
+const workflowCount = registry?.workflowCount ?? 0
+const softwareAppJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'SoftwareApplication',
+  name,
+  applicationCategory: 'MultimediaApplication',
+  operatingSystem: 'Any',
+  url: canonicalURL.href,
+  author: { '@type': 'Organization', name: 'Comfy Org', url: 'https://comfy.org' }
+}
+const breadcrumbJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'BreadcrumbList',
+  itemListElement: [
+    { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://comfy.org' },
+    { '@type': 'ListItem', position: 2, name: 'AI Models', item: new URL('/models-v2', Astro.site ?? 'https://comfy.org').href },
+    { '@type': 'ListItem', position: 3, name }
+  ]
+}
+const faqJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: [
+    {
+      '@type': 'Question',
+      name: `What is ${name}?`,
+      acceptedAnswer: { '@type': 'Answer', text: `${name} is ${blurb} You can run it in the browser playground, on Comfy Cloud, or locally in ComfyUI with full control over every parameter.` }
+    },
+    {
+      '@type': 'Question',
+      name: `How do I run ${name} in ComfyUI?`,
+      acceptedAnswer: { '@type': 'Answer', text: 'Press Run in the playground above — the first five runs are free and no card is required. You can also open the full graph on Comfy Cloud or download the workflow to run locally.' }
+    },
+    {
+      '@type': 'Question',
+      name: `Is ${name} free to use?`,
+      acceptedAnswer: { '@type': 'Answer', text: kind === 'open weights' ? `${name} is open weights: download it and run it locally in ComfyUI for free, forever. Comfy Cloud adds hosted GPUs with a free trial quota.` : `${name} runs through Comfy partner nodes on Cloud credits. New accounts include free runs to try it, with no card required.` }
+    },
+    ...(workflowCount > 0
+      ? [{
+          '@type': 'Question',
+          name: `How many ComfyUI workflows use ${name}?`,
+          acceptedAnswer: { '@type': 'Answer', text: `There are ${workflowCount} workflow templates using ${name}, ready to load and customize.` }
+        }]
+      : [])
+  ]
+}
+
+const WIRE = {
+  model: '#c8b4f5',
+  clip: '#f2ff59',
+  vae: '#f58ea8',
+  cond: '#ffa94d',
+  latent: '#ff99f7',
+  image: '#96b4ff'
+}
+---
+
+<BaseLayout
+  title={`${name} in ComfyUI — v2 Preview`}
+  description={`Run ${name} in your browser under full graph control. Playground-first page preview.`}
+  noindex={true}
+>
+  <Fragment slot="head">
+    <script is:inline type="application/ld+json" set:html={JSON.stringify(softwareAppJsonLd)} />
+    <script is:inline type="application/ld+json" set:html={JSON.stringify(breadcrumbJsonLd)} />
+    <script is:inline type="application/ld+json" set:html={JSON.stringify(faqJsonLd)} />
+  </Fragment>
+  <div class="fixed right-3 top-3 z-50 rounded-full border border-primary-comfy-yellow/40 bg-primary-comfy-ink/90 px-3 py-1 text-[10px] font-bold uppercase tracking-[0.2em] text-primary-comfy-yellow backdrop-blur">
+    A/B preview · noindex
+  </div>
+
+  <!-- COMPACT HEADER -->
+  <section class="mx-auto max-w-7xl px-5 pt-8 sm:px-6 lg:px-8 lg:pt-12">
+    <p class="text-[11px] font-semibold uppercase tracking-[0.25em] text-primary-warm-gray">
+      <a href="/models-v2" class="hover:text-primary-warm-white">Models</a> / {meta.label} / {name}
+    </p>
+    <div class="mt-3 flex flex-wrap items-center justify-between gap-3">
+      <div class="flex min-w-0 flex-wrap items-center gap-3">
+        <h1 class="max-w-full truncate text-2xl font-semibold text-primary-warm-white sm:text-3xl">{name}</h1>
+        <span class="rounded-lg border border-white/15 bg-white/5 px-3 py-1.5 text-xs font-semibold text-primary-comfy-canvas">{meta.label}</span>
+      </div>
+      <div class="hidden gap-2 sm:flex">
+        {docsUrl && <a href={docsUrl} class="rounded-lg border border-white/15 bg-white/5 px-3 py-1.5 text-[11px] font-extrabold uppercase tracking-widest text-primary-comfy-canvas hover:bg-white/10">{launch?.launchUrl ? 'Launch page ↗' : 'Docs ↗'}</a>}
+        <div class="relative" id="llms-wrap">
+          <button id="llms-btn" class="rounded-lg border border-white/15 bg-white/5 px-3 py-1.5 text-[11px] font-extrabold uppercase tracking-widest text-primary-comfy-canvas hover:bg-white/10">LLMs ▾</button>
+          <div id="llms-menu" class="absolute right-0 top-full z-40 mt-1.5 hidden w-60 overflow-hidden rounded-xl border border-white/15 bg-[#191320] py-1.5 shadow-2xl">
+            <button id="llms-copy" class="block w-full px-4 py-2.5 text-left text-xs text-primary-warm-white hover:bg-white/5">Copy page as Markdown<span id="llms-copied" class="hidden pl-2 text-[#b7ded5]">✓</span></button>
+            <a href={mdUrl} class="block px-4 py-2.5 text-xs text-primary-warm-white hover:bg-white/5">View as Markdown</a>
+            <a href="/models-v2/llms.txt" class="block px-4 py-2.5 text-xs text-primary-warm-white hover:bg-white/5">llms.txt — full catalog</a>
+            <div class="my-1 border-t border-white/10"></div>
+            <a href={`https://claude.ai/new?q=${llmPrompt}`} class="block px-4 py-2.5 text-xs text-primary-warm-white hover:bg-white/5">Open in Claude ↗</a>
+            <a href={`https://chatgpt.com/?q=${llmPrompt}`} class="block px-4 py-2.5 text-xs text-primary-warm-white hover:bg-white/5">Open in ChatGPT ↗</a>
+          </div>
+        </div>
+      </div>
+    </div>
+    <p class="mt-2 max-w-3xl text-sm font-light leading-relaxed text-primary-comfy-canvas sm:text-base">{blurb}</p>
+    <div class="mt-4 flex flex-wrap gap-1.5">
+      {dayZero && <span class="rounded bg-primary-comfy-yellow px-2 py-1 text-[10px] font-extrabold uppercase tracking-widest text-primary-comfy-ink">Day zero</span>}
+      <span class:list={['rounded px-2 py-1 text-[10px] font-extrabold uppercase tracking-widest', kind === 'open weights' ? 'bg-[#96b4ff]/15 text-[#96b4ff]' : 'bg-[#dbd6f2]/15 text-[#dbd6f2]']}>{kind}</span>
+      <span class="rounded border border-white/15 px-2 py-1 text-[10px] font-extrabold uppercase tracking-widest text-primary-comfy-canvas">Commercial use</span>
+      <span class="rounded border border-white/15 px-2 py-1 text-[10px] font-extrabold uppercase tracking-widest text-primary-comfy-canvas">{price}</span>
+      <span class="rounded border border-white/15 px-2 py-1 text-[10px] font-extrabold uppercase tracking-widest text-primary-comfy-canvas">{runs}</span>
+    </div>
+  </section>
+
+  <!-- TABS + TRIO -->
+  <section class="mx-auto max-w-7xl px-5 pt-6 sm:px-6 lg:px-8">
+    <div class="flex flex-wrap items-center justify-between gap-4 border-b border-white/10 pb-0">
+      <nav class="flex gap-6 overflow-x-auto text-xs font-extrabold uppercase tracking-[0.2em] sm:gap-8">
+        <span class="border-b-2 border-primary-comfy-yellow pb-3 text-primary-comfy-yellow">Playground</span>
+        <a href="#api" class="pb-3 text-primary-warm-gray hover:text-primary-warm-white">API</a>
+        <a href="#gallery" class="pb-3 text-primary-warm-gray hover:text-primary-warm-white">Examples</a>
+        <a href={workflowsUrl} class="pb-3 text-primary-warm-gray hover:text-primary-warm-white">Workflows ↗</a>
+      </nav>
+      <div class="hidden gap-2 pb-2 lg:flex">
+        <a href="https://comfy.org/download" class="rounded-lg border border-white/15 bg-white/5 px-4 py-2 text-[11px] font-extrabold uppercase tracking-widest text-primary-warm-white hover:bg-white/10">Run locally</a>
+        {hfUrl && <a href={hfUrl} class="rounded-lg border border-white/15 bg-white/5 px-4 py-2 text-[11px] font-extrabold uppercase tracking-widest text-primary-warm-white hover:bg-white/10">Download weights ↗</a>}
+        <a href="https://cloud.comfy.org?utm_source=models_v2_preview" class="rounded-lg border border-white/15 bg-white/5 px-4 py-2 text-[11px] font-extrabold uppercase tracking-widest text-primary-warm-white hover:bg-white/10">Open the full graph ↗</a>
+      </div>
+    </div>
+  </section>
+
+  <!-- PLAYGROUND -->
+  <section class="mx-auto max-w-7xl px-5 pt-6 sm:px-6 lg:px-8">
+    <div id="signed-in-strip" class="mb-4 hidden items-center justify-between gap-3 rounded-xl border border-[#b7ded5]/40 bg-[#b7ded5]/10 px-4 py-2.5 sm:flex-nowrap">
+      <p class="text-[11px] font-extrabold uppercase tracking-[0.15em] text-[#b7ded5]">Signed in · inputs restored — no survey, no plan picker</p>
+      <p id="free-meter" class="shrink-0 text-[11px] font-extrabold uppercase tracking-widest text-primary-comfy-yellow">Free runs: 5 left</p>
+    </div>
+
+    <div class="grid gap-5 lg:grid-cols-[460px_1fr]">
+      <!-- INPUT CARD -->
+      <div class="rounded-2xl border border-white/10 bg-white/[0.04] p-5 sm:p-6">
+        <div class="flex items-center justify-between">
+          <h2 class="text-xs font-extrabold uppercase tracking-[0.2em] text-primary-warm-white">Input</h2>
+          <div id="iview-toggle" class="flex overflow-hidden rounded-lg border border-white/15 text-[10px] font-extrabold uppercase tracking-wider">
+            <button data-iview="app" class="bg-primary-comfy-yellow px-3 py-1.5 text-primary-comfy-ink">App</button>
+            <button data-iview="graph" class="px-3 py-1.5 text-primary-comfy-canvas hover:text-primary-warm-white">Graph</button>
+            <button data-iview="json" class="px-3 py-1.5 text-primary-comfy-canvas hover:text-primary-warm-white">JSON</button>
+          </div>
+        </div>
+
+        <!-- APP VIEW — the workflow's exposed inputs, rendered as an app -->
+        <div id="panel-app">
+          <label class="mt-5 block text-[10px] font-extrabold uppercase tracking-[0.25em] text-primary-warm-gray">Prompt *</label>
+          <textarea
+            id="pg-prompt"
+            rows="4"
+            class="mt-2 w-full resize-none rounded-xl border border-white/15 bg-primary-comfy-ink p-4 text-sm font-light leading-relaxed text-primary-comfy-canvas focus:border-primary-comfy-yellow/60 focus:outline-none"
+          >{promptExample}</textarea>
+          <p class="mt-1.5 text-[11px] font-light text-primary-warm-gray">App view = this workflow’s exposed inputs. Flip to GRAPH to see where each one lands.</p>
+          <div class="mt-4 grid grid-cols-3 gap-2.5">
+            <div>
+              <span class="block text-[10px] font-extrabold uppercase tracking-[0.2em] text-primary-warm-gray">Aspect</span>
+              <select id="sel-aspect" class="mt-1.5 w-full rounded-lg border border-white/15 bg-primary-comfy-ink px-3 py-2.5 text-xs text-primary-comfy-canvas focus:border-primary-comfy-yellow/60 focus:outline-none">
+                <option>16:9</option><option>9:16</option><option>1:1</option>
+              </select>
+            </div>
+            <div>
+              <span class="block text-[10px] font-extrabold uppercase tracking-[0.2em] text-primary-warm-gray">Duration</span>
+              <select id="sel-duration" class="mt-1.5 w-full rounded-lg border border-white/15 bg-primary-comfy-ink px-3 py-2.5 text-xs text-primary-comfy-canvas focus:border-primary-comfy-yellow/60 focus:outline-none">
+                <option data-mult="1">5 s</option><option data-mult="2">10 s</option>
+              </select>
+            </div>
+            <div>
+              <span class="block text-[10px] font-extrabold uppercase tracking-[0.2em] text-primary-warm-gray">Resolution</span>
+              <select id="sel-resolution" class="mt-1.5 w-full rounded-lg border border-white/15 bg-primary-comfy-ink px-3 py-2.5 text-xs text-primary-comfy-canvas focus:border-primary-comfy-yellow/60 focus:outline-none">
+                <option data-mult="1">720p</option><option data-mult="2">1080p</option>
+              </select>
+            </div>
+          </div>
+          <label class="mt-4 block text-[10px] font-extrabold uppercase tracking-[0.25em] text-primary-warm-gray">Reference image</label>
+          <div id="dropzone" class="mt-2 flex items-center gap-3 rounded-xl border border-dashed border-white/25 bg-white/[0.02] px-4 py-4">
+            <button id="add-image-btn" class="rounded-lg bg-white/10 px-3 py-1.5 text-[10px] font-extrabold uppercase tracking-wider text-primary-comfy-canvas hover:bg-white/15">Add image ▾</button>
+            <span id="dropzone-label" class="text-xs font-light text-primary-warm-gray">or drop a frame to animate it</span>
+            <img id="ref-thumb" src={gallery[1] ?? gallery[0]} alt="" class="ml-auto hidden h-10 w-16 rounded-md object-cover" onerror="this.style.display='none'" />
+          </div>
+        </div>
+
+        <!-- GRAPH VIEW — the actual node graph, live-bound -->
+        <div id="panel-graph" class="hidden">
+          <div class="mt-4 overflow-hidden rounded-xl border border-white/12 bg-[#141018]">
+            <svg viewBox="0 0 440 330" class="w-full" font-family="ui-monospace, monospace">
+              <path d="M150 44 C 200 44, 150 138, 168 138" stroke={WIRE.model} fill="none" stroke-width="1.5"/>
+              <path d="M150 56 C 165 56, 155 34, 168 34" stroke={WIRE.clip} fill="none" stroke-width="1.5"/>
+              <path d="M150 68 C 210 68, 120 262, 168 262" stroke={WIRE.vae} fill="none" stroke-width="1.5"/>
+              <path d="M352 44 C 380 44, 140 156, 168 156" stroke={WIRE.cond} fill="none" stroke-width="1.5"/>
+              <path d="M152 148 C 162 148, 158 174, 168 174" stroke={WIRE.latent} fill="none" stroke-width="1.5"/>
+              <path d="M352 170 C 380 170, 140 276, 168 276" stroke={WIRE.latent} fill="none" stroke-width="1.5"/>
+              <path d="M292 266 C 306 266, 300 266, 312 266" stroke={WIRE.image} fill="none" stroke-width="1.5"/>
+
+              <g>
+                <rect x="10" y="18" width="140" height="62" rx="6" fill="#221b29" stroke="#3a3142"/>
+                <rect x="10" y="18" width="140" height="16" rx="6" fill="#2c2435"/>
+                <text x="16" y="30" fill="#f0efed" font-size="9" font-weight="bold">Load Checkpoint</text>
+                <text x="16" y="47" fill="#7e7c78" font-size="8">{slugId.slice(0, 22)}</text>
+                <circle cx="150" cy="44" r="3" fill={WIRE.model}/><text x="108" y="47" fill={WIRE.model} font-size="7">MODEL</text>
+                <circle cx="150" cy="56" r="3" fill={WIRE.clip}/><text x="120" y="59" fill={WIRE.clip} font-size="7">CLIP</text>
+                <circle cx="150" cy="68" r="3" fill={WIRE.vae}/><text x="124" y="71" fill={WIRE.vae} font-size="7">VAE</text>
+              </g>
+
+              <g>
+                <rect x="168" y="14" width="184" height="76" rx="6" fill="#221b29" stroke="#f2ff59" stroke-opacity="0.55"/>
+                <rect x="168" y="14" width="184" height="16" rx="6" fill="#2c2435"/>
+                <text x="174" y="26" fill="#f0efed" font-size="9" font-weight="bold">CLIP Text Encode</text>
+                <text x="174" y="43" fill="#c2bfb9" font-size="7.5" id="g-prompt-1">…</text>
+                <text x="174" y="54" fill="#c2bfb9" font-size="7.5" id="g-prompt-2"></text>
+                <text x="174" y="70" fill="#7e7c78" font-size="7">↑ your prompt field, live</text>
+                <circle cx="352" cy="44" r="3" fill={WIRE.cond}/>
+              </g>
+
+              <g>
+                <rect x="10" y="118" width="142" height="58" rx="6" fill="#221b29" stroke="#3a3142"/>
+                <rect x="10" y="118" width="142" height="16" rx="6" fill="#2c2435"/>
+                <text x="16" y="130" fill="#f0efed" font-size="9" font-weight="bold">Empty Latent</text>
+                <text x="16" y="148" fill="#c2bfb9" font-size="8" id="g-res">1280 × 720</text>
+                <text x="16" y="162" fill="#7e7c78" font-size="7">↑ resolution select</text>
+                <circle cx="152" cy="148" r="3" fill={WIRE.latent}/>
+              </g>
+
+              <g>
+                <rect x="168" y="112" width="184" height="106" rx="6" fill="#221b29" stroke="#3a3142"/>
+                <rect x="168" y="112" width="184" height="16" rx="6" fill="#2c2435"/>
+                <text x="174" y="124" fill="#f0efed" font-size="9" font-weight="bold">KSampler</text>
+                <circle cx="168" cy="138" r="3" fill={WIRE.model}/>
+                <circle cx="168" cy="156" r="3" fill={WIRE.cond}/>
+                <circle cx="168" cy="174" r="3" fill={WIRE.latent}/>
+                <text x="180" y="146" fill="#c2bfb9" font-size="8">seed <tspan id="g-seed" fill="#f2ff59">428790123</tspan></text>
+                <text x="180" y="162" fill="#c2bfb9" font-size="8">steps 24 · cfg 5.5</text>
+                <text x="180" y="178" fill="#c2bfb9" font-size="8">euler · duration <tspan id="g-dur" fill="#f2ff59">5s</tspan></text>
+                <text x="180" y="200" fill="#7e7c78" font-size="7">where the image is decided</text>
+                <circle cx="352" cy="170" r="3" fill={WIRE.latent}/>
+              </g>
+
+              <g>
+                <rect x="168" y="240" width="124" height="52" rx="6" fill="#221b29" stroke="#3a3142"/>
+                <rect x="168" y="240" width="124" height="16" rx="6" fill="#2c2435"/>
+                <text x="174" y="252" fill="#f0efed" font-size="9" font-weight="bold">VAE Decode</text>
+                <circle cx="292" cy="266" r="3" fill={WIRE.image}/>
+              </g>
+              <g>
+                <rect x="312" y="240" width="118" height="52" rx="6" fill="#221b29" stroke="#3a3142"/>
+                <rect x="312" y="240" width="118" height="16" rx="6" fill="#2c2435"/>
+                <text x="318" y="252" fill="#f0efed" font-size="9" font-weight="bold">Save Output</text>
+                <text x="318" y="270" fill="#7e7c78" font-size="7.5">yours, no watermark</text>
+              </g>
+            </svg>
+          </div>
+          <p class="mt-2 text-[11px] font-light text-primary-warm-gray">
+            The actual graph behind the app — typed wires and all. The app is a view; the graph is the truth.
+            <a href="https://cloud.comfy.org?utm_source=models_v2_preview" class="font-extrabold uppercase tracking-widest text-primary-comfy-yellow"> Open it in Cloud →</a>
+          </p>
+        </div>
+
+        <!-- JSON VIEW -->
+        <div id="panel-json" class="hidden">
+          <pre id="input-json" class="mt-4 max-h-[340px] overflow-auto rounded-xl border border-white/12 bg-[#141018] p-4 font-mono text-[11.5px] leading-relaxed text-[#b7ded5]"></pre>
+          <p class="mt-2 text-[11px] font-light text-primary-warm-gray">Live from your inputs — the exact payload the API takes. <button id="copy-json" class="font-extrabold uppercase tracking-widest text-primary-comfy-yellow">Copy</button><span id="copy-done" class="hidden pl-2 text-[#b7ded5]">copied ✓</span></p>
+        </div>
+
+        <div class="mt-5 flex items-center justify-between gap-3 border-t border-white/10 pt-4">
+          <button id="pg-reset" class="text-[11px] font-extrabold uppercase tracking-widest text-primary-warm-gray hover:text-primary-warm-white">Reset</button>
+          <div class="flex items-center gap-3">
+            <span class="hidden text-[11px] text-primary-warm-gray sm:block"><span id="cost-line">{baseCredits} credits ≈ ${(baseCredits * 0.0084).toFixed(2)}</span> · est.</span>
+            <button id="pg-run" data-base-credits={baseCredits} data-slug={slugId} class="rounded-xl bg-primary-comfy-yellow px-6 py-3 text-xs font-extrabold uppercase tracking-widest text-primary-comfy-ink transition hover:brightness-110">
+              Sign in to run — 5 free
+            </button>
+          </div>
+        </div>
+        <p class="mt-3 text-[11px] font-light text-primary-warm-gray">▶ Demo: everything above works — flip the views, change resolution (watch the price), add a reference image, then Run.</p>
+      </div>
+
+      <!-- RESULT CARD -->
+      <div class="flex flex-col overflow-hidden rounded-2xl border border-white/10 bg-black/25">
+        <div class="flex items-center justify-between px-5 py-3.5">
+          <h2 id="result-label" class="text-[11px] font-extrabold uppercase tracking-[0.2em] text-primary-warm-white">Result · example output</h2>
+          <div id="rview-toggle" class="flex gap-1.5 text-[10px] font-extrabold uppercase tracking-wider">
+            <button data-rview="preview" class="rounded-md bg-white/10 px-2.5 py-1 text-primary-warm-white">Preview</button>
+            <button data-rview="json" class="rounded-md px-2.5 py-1 text-primary-warm-gray hover:text-primary-warm-white">JSON</button>
+          </div>
+        </div>
+        <div class="relative aspect-video w-full bg-secondary-mauve/30">
+          <img id="result-img" src={img} alt={`${name} output`} class="h-full w-full object-cover transition-opacity duration-500" onerror="this.style.display='none'" />
+          <pre id="result-json" class="absolute inset-0 hidden overflow-auto bg-[#141018] p-5 font-mono text-[11.5px] leading-relaxed text-[#b7ded5]"></pre>
+          <div id="running-overlay" class="absolute inset-0 hidden flex-col items-center justify-center gap-4 bg-primary-comfy-ink/95 px-8 text-center">
+            <p class="text-[10px] font-extrabold uppercase tracking-[0.25em] text-[#b7ded5]">Restored your prompt and settings ✓</p>
+            <p class="text-lg font-semibold text-primary-warm-white">Running the graph</p>
+            <div class="h-1.5 w-56 overflow-hidden rounded-full bg-white/10 sm:w-72">
+              <div id="progress-fill" class="h-full w-0 rounded-full bg-primary-comfy-yellow transition-[width] duration-[2200ms] ease-out"></div>
+            </div>
+            <p class="font-mono text-[11px] text-primary-warm-gray">ksampler · queue position 1</p>
+          </div>
+          <div id="upgrade-overlay" class="absolute inset-0 hidden flex-col justify-center gap-3 overflow-y-auto bg-primary-comfy-ink/[0.97] px-6 py-6 sm:px-10">
+            <p class="text-[10px] font-extrabold uppercase tracking-[0.25em] text-primary-comfy-yellow">That was your fifth free run</p>
+            <p class="text-xl font-semibold text-primary-warm-white sm:text-2xl">Keep running it.</p>
+            <div class="divide-y divide-white/10 border-y border-white/10">
+              <div class="flex items-center justify-between gap-4 py-2.5">
+                <span class="text-xs font-extrabold uppercase tracking-wider text-primary-warm-white">Creator — $20/mo · est.</span>
+                <span class="text-[11px] font-light text-primary-comfy-canvas">≈ 220 runs of 720p · 1080p included</span>
+              </div>
+              <div class="flex items-center justify-between gap-4 py-2.5">
+                <span class="text-xs font-extrabold uppercase tracking-wider text-primary-warm-white">Pro — $60/mo · est.</span>
+                <span class="text-[11px] font-light text-primary-comfy-canvas">≈ 800 runs · API keys · batch queues</span>
+              </div>
+            </div>
+            <p class="text-xs font-light leading-relaxed text-primary-warm-gray">Your graphs, seeds, history, and all five outputs stay yours — free, forever. Or run it locally: it’s open source.</p>
+            <div class="flex flex-wrap items-center gap-4">
+              <button class="rounded-xl bg-primary-comfy-yellow px-5 py-2.5 text-[11px] font-extrabold uppercase tracking-widest text-primary-comfy-ink">Go Creator</button>
+              <span class="text-[11px] font-extrabold uppercase tracking-widest text-primary-comfy-canvas">See all plans →</span>
+              <button id="demo-reset" class="text-[11px] font-extrabold uppercase tracking-widest text-primary-warm-gray underline-offset-4 hover:underline">Replay demo</button>
+            </div>
+          </div>
+        </div>
+        <div class="flex items-center justify-between gap-3 px-5 py-3">
+          <p id="result-meta" class="truncate text-[10px] font-semibold uppercase tracking-[0.15em] text-primary-warm-gray">Seed 428790123 · 4.2s render · prompt saved through sign-in</p>
+          <span class="shrink-0 text-[11px] font-extrabold uppercase tracking-widest text-primary-comfy-yellow">Download ↓</span>
+        </div>
+        <!-- VARIATIONS QUEUE -->
+        <div id="var-block" class="hidden border-t border-white/10 px-5 py-4">
+          <div class="flex items-center justify-between gap-3">
+            <p class="text-[10px] font-extrabold uppercase tracking-[0.2em] text-primary-warm-white">The queue — pick the best, not the first</p>
+            <button id="queue-vars" class="rounded-lg bg-primary-comfy-yellow px-3 py-1.5 text-[10px] font-extrabold uppercase tracking-widest text-primary-comfy-ink">Queue 4 variations — <span id="var-cost">24</span> cr</button>
+          </div>
+          <div id="var-strip" class="mt-3 hidden grid-cols-4 gap-2">
+            {[0, 1, 2, 3].map((i) => (
+              <div class="var-slot relative aspect-video overflow-hidden rounded-lg border border-white/10 bg-white/[0.04]">
+                <div class="var-shimmer absolute inset-0 animate-pulse bg-white/[0.06]"></div>
+                <img data-var-img={gallery[i % gallery.length]} alt="" class="hidden h-full w-full object-cover" onerror="this.style.display='none'" />
+                <span class="absolute bottom-1 left-1.5 hidden rounded bg-black/60 px-1 py-0.5 font-mono text-[8px] text-primary-comfy-canvas">seed +{i + 1}</span>
+              </div>
+            ))}
+          </div>
+          <p id="var-note" class="mt-2 hidden text-[10px] font-light text-primary-warm-gray">Four seeds, one brief — charged on success only. This is the Queue mentality.</p>
+        </div>
+      </div>
+    </div>
+
+    <div class="mt-4 rounded-xl border border-primary-comfy-yellow/30 bg-primary-comfy-yellow/10 px-4 py-3 text-[11px] font-extrabold uppercase tracking-[0.15em] text-primary-comfy-yellow">
+      Five free runs after sign-in. No card. Your prompt and settings carry over.
+    </div>
+  </section>
+
+  <!-- EXAMPLES -->
+  <section id="gallery" class="mx-auto max-w-7xl scroll-mt-24 px-5 py-12 sm:px-6 lg:px-8 lg:py-16">
+    <div class="mb-6">
+      <h2 class="text-sm font-extrabold uppercase tracking-[0.3em] text-primary-comfy-yellow">Made with {name}</h2>
+      <p class="mt-1.5 text-sm font-light text-primary-warm-gray">Real outputs from the workflow templates — click one to load its prompt into the app.</p>
+    </div>
+    <ul class="grid grid-cols-2 gap-3 sm:gap-5 lg:grid-cols-3">
+      {gallery.map((src, i) => (
+        <li class="group relative overflow-hidden rounded-xl border border-white/10 bg-secondary-mauve/30">
+          <img src={src} alt={`${name} example`} loading="lazy" class="aspect-video w-full object-cover transition duration-500 group-hover:scale-[1.03]" onerror="this.style.display='none'" />
+          <button
+            data-use-prompt={galleryPrompts[i % galleryPrompts.length]}
+            class="absolute inset-x-0 bottom-0 bg-gradient-to-t from-primary-comfy-ink/95 to-transparent px-3 pb-2.5 pt-8 text-right text-[10px] font-extrabold uppercase tracking-widest text-primary-comfy-yellow opacity-100 transition lg:opacity-0 lg:group-hover:opacity-100"
+          >
+            Use this prompt →
+          </button>
+        </li>
+      ))}
+    </ul>
+  </section>
+
+  <!-- COST + FAMILY -->
+  <section class="bg-black/25 py-12 lg:py-16">
+    <div class="mx-auto max-w-7xl px-5 sm:px-6 lg:px-8">
+      <div class="grid gap-5 lg:grid-cols-2">
+        <div class="rounded-2xl border border-white/10 bg-white/[0.04] p-6 sm:p-7">
+          <h2 class="text-xs font-extrabold uppercase tracking-[0.25em] text-primary-comfy-yellow">What it costs</h2>
+          <p class="mt-2 text-sm font-light text-primary-warm-gray">Credits before you commit. No surprises after the wall.</p>
+          <div class="mt-4 divide-y divide-white/10 border-t border-white/10">
+            {costRows.map(([l, v]) => (
+              <div class="flex items-center justify-between gap-4 py-3">
+                <span class="text-sm text-primary-warm-white">{l}</span>
+                <span class="text-right text-xs font-semibold text-primary-comfy-canvas">{v}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+        {familyVariants.length > 0 && (
+          <div class="rounded-2xl border border-white/10 bg-white/[0.04] p-6 sm:p-7">
+            <h2 class="text-xs font-extrabold uppercase tracking-[0.25em] text-primary-comfy-yellow">Family files &amp; variants</h2>
+            <p class="mt-2 text-sm font-light text-primary-warm-gray">Related files from the registry — every one runnable on the graph.</p>
+            <div class="mt-4 divide-y divide-white/10 border-t border-white/10">
+              {familyVariants.map((v) => (
+                <a href={`/models-v2/${v.slug}`} class="flex items-center justify-between gap-4 py-3 transition hover:bg-white/[0.03]">
+                  <div class="min-w-0">
+                    <p class="truncate text-sm font-semibold text-primary-warm-white">{v.displayName}</p>
+                    <p class="text-[11px] font-light text-primary-warm-gray">{dirLabel[v.directory] ?? v.directory} · {v.workflowCount} workflows</p>
+                  </div>
+                  <span class="shrink-0 text-[11px] font-extrabold uppercase tracking-widest text-primary-comfy-yellow">Run →</span>
+                </a>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  </section>
+
+  <!-- API -->
+  <section id="api" class="mx-auto max-w-7xl scroll-mt-24 px-5 py-12 sm:px-6 lg:px-8 lg:pb-24">
+    <h2 class="text-sm font-extrabold uppercase tracking-[0.3em] text-primary-comfy-yellow">Run it your way</h2>
+    <div class="mt-4 overflow-x-auto rounded-2xl border border-white/10 bg-black/40 p-5 sm:p-7">
+      <pre class="font-mono text-xs leading-relaxed text-[#b7ded5] sm:text-[13px]">{`# Same graph the playground runs — as an endpoint
+curl -X POST https://api.comfy.org/v1/run \\
+  -H "Authorization: Bearer $COMFY_KEY" \\
+  -d '{ "workflow": "${slugId}", "prompt": "…" }'
+
+# → { "job_id": "j_8f2…", "credits": ${baseCredits}, "eta_s": 4 }`}</pre>
+    </div>
+    <p class="mt-3 text-xs font-light text-primary-warm-gray">The app above is this call — the JSON view shows the exact payload. Full reference · Comfy MCP · <a href={mdUrl} class="text-primary-comfy-yellow">this page as Markdown</a> · <a href="/models-v2/llms.txt" class="text-primary-comfy-yellow">llms.txt</a></p>
+  </section>
+
+  <!-- MOBILE STICKY RUN BAR -->
+  <div class="fixed inset-x-0 bottom-0 z-40 border-t border-white/10 bg-primary-comfy-ink/95 px-4 pb-[calc(env(safe-area-inset-bottom)+12px)] pt-3 backdrop-blur lg:hidden">
+    <button id="pg-run-mobile" class="w-full rounded-xl bg-primary-comfy-yellow py-3.5 text-sm font-extrabold uppercase tracking-widest text-primary-comfy-ink">
+      Run — ~{baseCredits} credits
+    </button>
+    <p class="mt-1.5 text-center text-[11px] font-light text-primary-warm-gray">Sign in at run · 5 free · no card</p>
+  </div>
+  <div class="h-24 lg:hidden"></div>
+
+  <!-- AUTH WALL MODAL -->
+  <div id="auth-modal" class="fixed inset-0 z-[60] hidden items-end justify-center bg-black/70 p-0 backdrop-blur-sm sm:items-center sm:p-6">
+    <div class="w-full max-w-md rounded-t-3xl border border-white/15 bg-[#191320] p-6 shadow-2xl sm:rounded-3xl sm:p-8">
+      <span class="rounded bg-primary-comfy-yellow/15 px-2.5 py-1 text-[10px] font-extrabold uppercase tracking-widest text-primary-comfy-yellow">This run: <span id="modal-credits">{baseCredits}</span> credits — free for you</span>
+      <h3 class="mt-4 text-2xl font-semibold text-primary-warm-white">5 free runs. No card.</h3>
+      <p class="mt-2 text-sm font-light leading-relaxed text-primary-comfy-canvas">Your prompt and settings are saved. The run starts the moment you’re in.</p>
+      <div class="mt-5 flex flex-col gap-2.5">
+        <button data-auth class="rounded-xl bg-primary-warm-white py-3 text-sm font-semibold text-primary-comfy-ink transition hover:brightness-95">Continue with Google</button>
+        <button data-auth class="rounded-xl border border-white/20 bg-white/5 py-3 text-sm font-semibold text-primary-warm-white transition hover:bg-white/10">Continue with GitHub</button>
+        <button data-auth class="rounded-xl border border-white/20 bg-white/5 py-3 text-sm font-semibold text-primary-warm-white transition hover:bg-white/10">Continue with email</button>
+      </div>
+      <p class="mt-4 text-[11px] font-light leading-relaxed text-primary-warm-gray">By continuing you agree to the Terms. Open source stays open — your graphs and outputs are yours.</p>
+      <button id="auth-close" class="mt-3 text-[11px] font-extrabold uppercase tracking-widest text-primary-warm-gray hover:text-primary-warm-white">Not now</button>
+    </div>
+  </div>
+
+  <script>
+    function initPlaygroundDemo() {
+      const runDesktop = document.getElementById('pg-run')
+      if (!runDesktop || runDesktop.dataset.bound === '1') return
+      runDesktop.dataset.bound = '1'
+
+      const $ = (id: string) => document.getElementById(id)
+      const modal = $('auth-modal')!
+      const strip = $('signed-in-strip')!
+      const meter = $('free-meter')!
+      const overlay = $('running-overlay')!
+      const upgrade = $('upgrade-overlay')!
+      const fill = $('progress-fill')!
+      const img = $('result-img') as HTMLImageElement
+      const label = $('result-label')!
+      const metaEl = $('result-meta')!
+      const runMobile = $('pg-run-mobile')!
+      const prompt = $('pg-prompt') as HTMLTextAreaElement
+      const selDur = $('sel-duration') as HTMLSelectElement
+      const selRes = $('sel-resolution') as HTMLSelectElement
+      const selAspect = $('sel-aspect') as HTMLSelectElement
+      const inputJson = $('input-json')!
+      const resultJson = $('result-json')!
+      const costLine = $('cost-line')!
+      const modalCredits = $('modal-credits')!
+      const varBlock = $('var-block')!
+      const varStrip = $('var-strip')!
+      const varCost = $('var-cost')!
+      const base = Number(runDesktop.dataset.baseCredits ?? '6')
+      const slug = runDesktop.dataset.slug ?? 'model'
+
+      let authed = false
+      let runsLeft = 5
+      let seed = 428790123
+      let refImage = false
+      let lastRun: Record<string, unknown> | null = null
+
+      const mult = (sel: HTMLSelectElement) => Number(sel.selectedOptions[0]?.dataset.mult ?? '1')
+      const creditsNow = () => base * mult(selDur) * mult(selRes)
+
+      const renderInputJson = () => {
+        const payload: Record<string, unknown> = {
+          workflow: slug,
+          inputs: {
+            prompt: prompt.value.trim(),
+            aspect_ratio: selAspect.value,
+            duration_s: mult(selDur) * 5,
+            resolution: selRes.value,
+            seed,
+            ...(refImage ? { reference_image: 'frame_0001.png' } : {})
+          },
+          estimate: { credits: creditsNow(), charged_on: 'success only' }
+        }
+        inputJson.textContent = JSON.stringify(payload, null, 2)
+      }
+
+      const renderResultJson = () => {
+        const receipt = lastRun ?? {
+          status: 'example',
+          note: 'This is a curated example. Run it to get your own receipt.',
+          seed,
+          model: slug
+        }
+        resultJson.textContent = JSON.stringify(receipt, null, 2)
+      }
+
+      const renderGraph = () => {
+        const p = prompt.value.trim()
+        const l1 = $('g-prompt-1'); const l2 = $('g-prompt-2')
+        if (l1) l1.textContent = '“' + p.slice(0, 34) + (p.length > 34 ? '…' : '”')
+        if (l2) l2.textContent = p.length > 34 ? p.slice(34, 66) + '…”' : ''
+        const res = $('g-res'); if (res) res.textContent = selRes.value === '1080p' ? '1920 × 1080' : '1280 × 720'
+        const gd = $('g-dur'); if (gd) gd.textContent = mult(selDur) * 5 + 's'
+        const gs = $('g-seed'); if (gs) gs.textContent = String(seed)
+      }
+
+      const setRunLabels = () => {
+        const c = creditsNow()
+        costLine.textContent = `${c} credits ≈ $${(c * 0.0084).toFixed(2)}`
+        modalCredits.textContent = String(c)
+        varCost.textContent = String(c * 4)
+        if (!authed) {
+          runDesktop.textContent = 'Sign in to run — 5 free'
+          runMobile.textContent = `Run — ~${c} credits`
+        } else if (runsLeft > 0) {
+          runDesktop.textContent = `Run again — ${runsLeft} free left`
+          runMobile.textContent = `Run — ${runsLeft} free left`
+        } else {
+          runDesktop.textContent = 'Go Creator — from $20/mo'
+          runMobile.textContent = 'Go Creator — from $20/mo'
+        }
+      }
+
+      const renderAll = () => { renderInputJson(); renderResultJson(); renderGraph(); setRunLabels() }
+
+      // input view toggle (APP | GRAPH | JSON)
+      const iPanels: Record<string, HTMLElement> = {
+        app: $('panel-app')!, graph: $('panel-graph')!, json: $('panel-json')!
+      }
+      $('iview-toggle')!.addEventListener('click', (e) => {
+        const btn = (e.target as HTMLElement).closest<HTMLElement>('[data-iview]')
+        if (!btn) return
+        const view = btn.dataset.iview!
+        for (const [k, panel] of Object.entries(iPanels)) panel.classList.toggle('hidden', k !== view)
+        for (const b of $('iview-toggle')!.querySelectorAll<HTMLElement>('[data-iview]')) {
+          const active = b === btn
+          b.classList.toggle('bg-primary-comfy-yellow', active)
+          b.classList.toggle('text-primary-comfy-ink', active)
+          b.classList.toggle('text-primary-comfy-canvas', !active)
+        }
+        renderAll()
+      })
+
+      // result view toggle (Preview | JSON)
+      $('rview-toggle')!.addEventListener('click', (e) => {
+        const btn = (e.target as HTMLElement).closest<HTMLElement>('[data-rview]')
+        if (!btn) return
+        const json = btn.dataset.rview === 'json'
+        resultJson.classList.toggle('hidden', !json)
+        img.classList.toggle('hidden', json)
+        for (const b of $('rview-toggle')!.querySelectorAll<HTMLElement>('[data-rview]')) {
+          const active = b === btn
+          b.classList.toggle('bg-white/10', active)
+          b.classList.toggle('text-primary-warm-white', active)
+          b.classList.toggle('text-primary-warm-gray', !active)
+        }
+        renderResultJson()
+      })
+
+      // live bindings
+      prompt.addEventListener('input', renderAll)
+      for (const sel of [selAspect, selDur, selRes]) sel.addEventListener('change', renderAll)
+
+      // reference image demo
+      $('add-image-btn')?.addEventListener('click', () => {
+        refImage = true
+        $('ref-thumb')?.classList.remove('hidden')
+        const dl = $('dropzone-label')
+        if (dl) dl.textContent = 'frame_0001.png ✓ — will run image-to-video'
+        $('dropzone')?.classList.add('border-[#b7ded5]/50')
+        renderAll()
+      })
+
+      // copy input json
+      $('copy-json')?.addEventListener('click', async () => {
+        try {
+          await navigator.clipboard.writeText(inputJson.textContent ?? '')
+          $('copy-done')?.classList.remove('hidden')
+          window.setTimeout(() => $('copy-done')?.classList.add('hidden'), 1600)
+        } catch { /* clipboard unavailable */ }
+      })
+
+      // LLMs menu
+      const llmsBtn = $('llms-btn')
+      const llmsMenu = $('llms-menu')
+      llmsBtn?.addEventListener('click', (e) => {
+        e.stopPropagation()
+        llmsMenu?.classList.toggle('hidden')
+      })
+      document.addEventListener('click', (e) => {
+        if (!llmsMenu || llmsMenu.classList.contains('hidden')) return
+        if (!(e.target as HTMLElement).closest('#llms-wrap')) llmsMenu.classList.add('hidden')
+      })
+      $('llms-copy')?.addEventListener('click', async () => {
+        try {
+          const md = await (await fetch(window.location.pathname + '.md')).text()
+          await navigator.clipboard.writeText(md)
+          $('llms-copied')?.classList.remove('hidden')
+          window.setTimeout(() => {
+            $('llms-copied')?.classList.add('hidden')
+            llmsMenu?.classList.add('hidden')
+          }, 1200)
+        } catch { /* fetch or clipboard unavailable */ }
+      })
+
+      // gallery → prompt warm start
+      document.querySelectorAll<HTMLElement>('[data-use-prompt]').forEach((b) =>
+        b.addEventListener('click', () => {
+          prompt.value = b.dataset.usePrompt ?? prompt.value
+          renderAll()
+          document.getElementById('pg-prompt')?.scrollIntoView({ behavior: 'smooth', block: 'center' })
+        })
+      )
+
+      const startRun = () => {
+        if (runsLeft <= 0) {
+          upgrade.classList.remove('hidden'); upgrade.classList.add('flex')
+          return
+        }
+        strip.classList.remove('hidden'); strip.classList.add('flex')
+        overlay.classList.remove('hidden'); overlay.classList.add('flex')
+        resultJson.classList.add('hidden'); img.classList.remove('hidden')
+        fill.style.width = '0%'
+        requestAnimationFrame(() => requestAnimationFrame(() => (fill.style.width = '92%')))
+        window.setTimeout(() => {
+          overlay.classList.add('hidden'); overlay.classList.remove('flex')
+          img.style.opacity = '0.4'
+          window.setTimeout(() => (img.style.opacity = '1'), 350)
+          runsLeft -= 1
+          seed += 1
+          lastRun = {
+            job_id: 'j_' + seed.toString(16),
+            status: 'succeeded',
+            model: slug,
+            seed,
+            credits_charged: creditsNow(),
+            charged_on: 'success only',
+            duration_s: 4.2,
+            nodes_executed: 24,
+            output: { type: 'video/webp', watermark: false, saved_to_history: true }
+          }
+          label.textContent = 'Result · your run'
+          metaEl.textContent = `Seed ${seed} · 4.2s render · saved to history · no watermark`
+          meter.textContent = runsLeft > 0 ? `Free runs: ${runsLeft} left` : 'Free runs used'
+          varBlock.classList.remove('hidden')
+          renderAll()
+          if (runsLeft <= 0) {
+            window.setTimeout(() => { upgrade.classList.remove('hidden'); upgrade.classList.add('flex') }, 900)
+          }
+        }, 2400)
+      }
+
+      // variations queue demo — each variation is a run and spends the meter
+      $('queue-vars')?.addEventListener('click', () => {
+        if (runsLeft <= 0) {
+          upgrade.classList.remove('hidden'); upgrade.classList.add('flex')
+          return
+        }
+        varStrip.classList.remove('hidden'); varStrip.classList.add('grid')
+        $('var-note')?.classList.remove('hidden')
+        const slots = [...varStrip.querySelectorAll<HTMLElement>('.var-slot')]
+        slots.forEach((slot, i) => {
+          window.setTimeout(() => {
+            const im = slot.querySelector('img') as HTMLImageElement
+            im.src = im.dataset.varImg ?? ''
+            im.classList.remove('hidden')
+            slot.querySelector('.var-shimmer')?.classList.add('hidden')
+            slot.querySelector('span')?.classList.remove('hidden')
+            if (runsLeft > 0) runsLeft -= 1
+            meter.textContent = runsLeft > 0 ? `Free runs: ${runsLeft} left` : 'Free runs used'
+            setRunLabels()
+            if (runsLeft <= 0 && i === slots.length - 1) {
+              window.setTimeout(() => { upgrade.classList.remove('hidden'); upgrade.classList.add('flex') }, 900)
+            }
+          }, 700 + i * 650)
+        })
+      })
+
+      const onRun = () => {
+        if (!authed) { modal.classList.remove('hidden'); modal.classList.add('flex') }
+        else startRun()
+      }
+      runDesktop.addEventListener('click', onRun)
+      runMobile.addEventListener('click', onRun)
+      modal.querySelectorAll('[data-auth]').forEach((b) =>
+        b.addEventListener('click', () => {
+          modal.classList.add('hidden'); modal.classList.remove('flex')
+          authed = true
+          setRunLabels()
+          startRun()
+        })
+      )
+      $('auth-close')!.addEventListener('click', () => {
+        modal.classList.add('hidden'); modal.classList.remove('flex')
+      })
+      $('demo-reset')!.addEventListener('click', () => {
+        authed = false; runsLeft = 5; seed = 428790123; lastRun = null; refImage = false
+        upgrade.classList.add('hidden'); upgrade.classList.remove('flex')
+        strip.classList.add('hidden'); strip.classList.remove('flex')
+        varBlock.classList.add('hidden')
+        varStrip.classList.add('hidden'); varStrip.classList.remove('grid')
+        $('ref-thumb')?.classList.add('hidden')
+        const dl = $('dropzone-label'); if (dl) dl.textContent = 'or drop a frame to animate it'
+        label.textContent = 'Result · example output'
+        metaEl.textContent = 'Seed 428790123 · 4.2s render · prompt saved through sign-in'
+        meter.textContent = 'Free runs: 5 left'
+        renderAll()
+      })
+
+      renderAll()
+    }
+
+    initPlaygroundDemo()
+    document.addEventListener('astro:page-load', initPlaygroundDemo)
+  </script>
+</BaseLayout>

--- a/apps/website/src/pages/models-v2/[slug].md.ts
+++ b/apps/website/src/pages/models-v2/[slug].md.ts
@@ -1,0 +1,100 @@
+// A/B TEST PREVIEW — per-model markdown twin (fal-style LLMs surface).
+// Every model page has a .md sibling: /models-v2/flux-3.md
+// Delete with the preview pages.
+import type { APIRoute } from 'astro'
+
+import {
+  launches,
+  registryModels,
+  topPartnerApis,
+  modalityMeta,
+  dirLabel,
+  type LaunchModel
+} from '../../config/models-v2-demo'
+
+const launchLike = [
+  ...launches,
+  ...topPartnerApis.filter((p) => !launches.includes(p))
+]
+const launchSlugs = new Set(launchLike.map((l) => l.slug))
+
+export function getStaticPaths() {
+  const launchPaths = launchLike.map((l) => ({
+    params: { slug: l.slug },
+    props: { launch: l, registry: null }
+  }))
+  const wanAlias = {
+    params: { slug: 'wan' },
+    props: {
+      launch: launchLike.find((l) => l.slug === 'wan-2-2')!,
+      registry: null
+    }
+  }
+  const registryPaths = registryModels
+    .filter((m) => !launchSlugs.has(m.slug) && m.slug !== 'wan')
+    .map((m) => ({
+      params: { slug: m.slug },
+      props: { launch: null, registry: m }
+    }))
+  return [...launchPaths, wanAlias, ...registryPaths]
+}
+
+interface MdProps {
+  launch: LaunchModel | null
+  registry: (typeof registryModels)[number] | null
+}
+
+export const GET: APIRoute = ({ props, params, site }) => {
+  const { launch, registry } = props as MdProps
+  const name = launch ? launch.name : registry!.displayName
+  const slugId = launch ? launch.slug : registry!.slug
+  const kind = launch
+    ? launch.kind
+    : registry!.directory === 'partner_nodes'
+      ? 'partner api'
+      : 'open weights'
+  const modality = launch ? launch.modality : 'image'
+  const baseCredits = kind === 'partner api' ? 12 : 6
+  const base = site ?? 'https://comfy.org'
+  const pageUrl = new URL(`/models-v2/${params.slug}`, base).href
+
+  const lines = [
+    `# ${name} in ComfyUI`,
+    '',
+    launch
+      ? launch.blurb
+      : `${name}: ${dirLabel[registry!.directory] ?? registry!.directory} in the Comfy model registry.`,
+    '',
+    '## Facts',
+    '',
+    `- Type: ${modalityMeta[modality].label}`,
+    `- License: ${kind}`,
+    `- Price: ~${baseCredits} credits per run (≈ $${(baseCredits * 0.0084).toFixed(2)}, estimate; 1080p or 10s doubles it)`,
+    ...(registry
+      ? [`- Workflow templates using it: ${registry.workflowCount}`]
+      : []),
+    ...(registry?.huggingFaceUrl
+      ? [`- Weights: ${registry.huggingFaceUrl}`]
+      : []),
+    ...(launch?.launchUrl ? [`- Launch page: ${launch.launchUrl}`] : []),
+    '',
+    '## How to run it',
+    '',
+    `1. Browser playground: ${pageUrl} — five free runs after sign-in, no card.`,
+    '2. Comfy Cloud (full graph, every parameter): https://cloud.comfy.org',
+    '3. Locally in ComfyUI (open source, free forever): https://comfy.org/download',
+    '',
+    '## API',
+    '',
+    '```bash',
+    'curl -X POST https://api.comfy.org/v1/run \\',
+    '  -H "Authorization: Bearer $COMFY_KEY" \\',
+    `  -d '{ "workflow": "${slugId}", "prompt": "…" }'`,
+    '```',
+    '',
+    `Full catalog: ${new URL('/models-v2/llms.txt', base).href}`
+  ]
+  return new Response(lines.join('\n'), {
+    headers: { 'Content-Type': 'text/markdown; charset=utf-8' }
+  })
+}

--- a/apps/website/src/pages/models-v2/index.astro
+++ b/apps/website/src/pages/models-v2/index.astro
@@ -1,0 +1,575 @@
+---
+// A/B TEST PREVIEW — v2 supported-models directory ("explore" variant).
+// Not linked from anywhere. noindex. Delete this folder to remove the preview.
+import BaseLayout from '../../layouts/BaseLayout.astro'
+import {
+  launches,
+  topPartnerApis,
+  useCaseWorkflows,
+  registryModels,
+  modalityMeta,
+  proxyImg,
+  dirLabel,
+  type LaunchModel
+} from '../../config/models-v2-demo'
+
+const hero = launches[0]
+const featured = launches.slice(0, 8)
+
+const hrefFor = (slug: string) => `/models-v2/${slug}`
+
+const kindTag = (l: LaunchModel) => (l.kind === 'open weights' ? 'open' : 'partner')
+const modTag = (l: LaunchModel) =>
+  l.modality === 'i2v' || l.modality === 'video' ? 'video'
+  : l.modality === 'audio' ? 'audio'
+  : 'image'
+
+const dirTag = (d: string) =>
+  d === 'partner_nodes' ? 'partner'
+  : d === 'loras' ? 'loras'
+  : d === 'audio_encoders' ? 'audio'
+  : d === 'vae' || d === 'text_encoders' || d === 'clip_vision' ? 'encoders'
+  : d === 'diffusion_models' || d === 'checkpoints' ? 'diffusion'
+  : 'other'
+
+const faqs: Array<[string, string]> = [
+  ['What does day-zero support mean?', 'When a new model releases, Comfy ships first-party support — nodes, templates, and a runnable workflow — the day the weights drop.'],
+  ['Is ComfyUI free?', 'ComfyUI is open source and free to run on your own GPU, forever. Comfy Cloud adds hosted GPUs with a free trial quota and paid tiers for scale.'],
+  ['Do partner models need separate accounts?', 'No. Kling, Grok, GPT Image, and other partner models run through your one Comfy account, on the same canvas as open models.'],
+  ['What VRAM do open models need?', 'Every family page lists per-variant VRAM in the checkpoints table — fp16, fp8, and GGUF builds cover cards from 12 GB up.']
+]
+
+const siteBase = Astro.site ?? 'https://comfy.org'
+const collectionJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'CollectionPage',
+  name: 'AI Models in ComfyUI',
+  url: new URL('/models-v2', siteBase).href,
+  mainEntity: {
+    '@type': 'ItemList',
+    itemListElement: launches.map((l, i) => ({
+      '@type': 'ListItem',
+      position: i + 1,
+      name: l.name,
+      url: new URL(`/models-v2/${l.slug}`, siteBase).href
+    }))
+  }
+}
+const breadcrumbJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'BreadcrumbList',
+  itemListElement: [
+    { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://comfy.org' },
+    { '@type': 'ListItem', position: 2, name: 'AI Models' }
+  ]
+}
+const faqJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: faqs.map(([q, a]) => ({
+    '@type': 'Question',
+    name: q,
+    acceptedAnswer: { '@type': 'Answer', text: a }
+  }))
+}
+
+const allCardTags: string[][] = [
+  ...launches.slice(0, 8).map((l) => ['launch', kindTag(l), modTag(l)]),
+  ...topPartnerApis.map((l) => ['partner', modTag(l)]),
+  ...registryModels.map((m) => [dirTag(m.directory), m.directory === 'partner_nodes' ? 'partner' : 'open'])
+]
+const tagCount = (tag: string) => allCardTags.filter((t2) => t2.includes(tag)).length
+const PILLS = [
+  ['all', 'All', allCardTags.length],
+  ['launch', 'Launches', tagCount('launch')],
+  ['open', 'Open weights', tagCount('open')],
+  ['partner', 'Partner APIs', tagCount('partner')],
+  ['video', 'Video', tagCount('video')],
+  ['image', 'Image + edit', tagCount('image')],
+  ['audio', 'Audio', tagCount('audio')],
+  ['diffusion', 'Diffusion', tagCount('diffusion')],
+  ['loras', 'LoRAs', tagCount('loras')],
+  ['encoders', 'VAE + encoders', tagCount('encoders')]
+] as const
+---
+
+<BaseLayout
+  title="AI Models in ComfyUI — v2 Preview"
+  description="Run 200+ open-weights and partner models with professional control. Preview of the next supported-models directory."
+  noindex={true}
+>
+  <Fragment slot="head">
+    <script is:inline type="application/ld+json" set:html={JSON.stringify(collectionJsonLd)} />
+    <script is:inline type="application/ld+json" set:html={JSON.stringify(breadcrumbJsonLd)} />
+    <script is:inline type="application/ld+json" set:html={JSON.stringify(faqJsonLd)} />
+  </Fragment>
+  <div class="fixed right-3 top-3 z-50 rounded-full border border-primary-comfy-yellow/40 bg-primary-comfy-ink/90 px-3 py-1 text-[10px] font-bold uppercase tracking-[0.2em] text-primary-comfy-yellow backdrop-blur">
+    A/B preview · noindex
+  </div>
+
+  <!-- HERO — the measured CVR leader gets the slot -->
+  <section class="mx-auto max-w-7xl px-5 pb-10 pt-12 sm:px-6 lg:px-8 lg:pt-20">
+    <div class="flex flex-col items-start gap-10 lg:flex-row lg:items-center lg:gap-16">
+      <div class="max-w-xl">
+        <p class="mb-3 text-[11px] font-semibold uppercase tracking-[0.25em] text-primary-warm-gray">
+          <a href="https://comfy.org" class="hover:text-primary-warm-white">Home</a> / AI models
+        </p>
+        <p class="mb-4 text-xs font-extrabold uppercase tracking-[0.35em] text-primary-comfy-yellow sm:text-sm">
+          Supported models
+        </p>
+        <h1 class="text-4xl font-light leading-[1.08] tracking-tight text-primary-warm-white sm:text-5xl lg:text-6xl">
+          Every model.<br />One graph.
+        </h1>
+        <p class="mt-5 text-base font-light leading-relaxed text-primary-comfy-canvas sm:text-lg">
+          Run 200+ open-weights and partner models with professional control —
+          FLUX, Wan, MiniMax, Kling, and every day-zero release. On your GPU or
+          on Comfy Cloud.
+        </p>
+        <div class="mt-7 flex flex-wrap gap-3">
+          <a
+            href={hrefFor(hero.slug)}
+            class="rounded-lg bg-primary-comfy-yellow px-6 py-3 text-sm font-extrabold uppercase tracking-wider text-primary-comfy-ink transition hover:brightness-110"
+          >
+            Run {hero.name} now
+          </a>
+          <a
+            href="https://comfy.org/workflows"
+            class="rounded-lg border border-white/20 bg-white/5 px-6 py-3 text-sm font-extrabold uppercase tracking-wider text-primary-warm-white transition hover:bg-white/10"
+          >
+            Browse workflows
+          </a>
+        </div>
+        <p class="mt-5 text-xs text-primary-warm-gray sm:text-sm">
+          {registryModels.length} models · day-zero releases weekly · 4M+ creators
+        </p>
+        <p class="mt-2 text-xs font-semibold uppercase tracking-widest text-primary-comfy-yellow/90">
+          5 free runs · no card · no watermark
+        </p>
+      </div>
+      <a
+        href={hrefFor(hero.slug)}
+        class="group relative w-full overflow-hidden rounded-2xl border border-white/10 lg:flex-1"
+      >
+        <img
+          src={hero.img}
+          alt={`${hero.name} example output`}
+          class="aspect-video w-full object-cover transition duration-500 group-hover:scale-[1.02]"
+          loading="eager"
+          fetchpriority="high"
+        />
+        <div class="flex items-center justify-between gap-3 bg-white/5 px-4 py-3 sm:px-5">
+          <span class="flex min-w-0 items-center gap-2">
+            {hero.dayZero && (
+              <span class="shrink-0 rounded bg-primary-comfy-yellow px-2 py-0.5 text-[10px] font-extrabold uppercase tracking-widest text-primary-comfy-ink">Day zero</span>
+            )}
+            <span class="truncate text-sm font-semibold text-primary-warm-white">{hero.name} — {hero.blurb.split('.')[0].toLowerCase()}</span>
+          </span>
+          <span class="shrink-0 text-xs font-extrabold uppercase tracking-widest text-primary-comfy-yellow">Try it →</span>
+        </div>
+      </a>
+    </div>
+  </section>
+
+  <!-- SEARCH + FILTERS (sticky) -->
+  <section class="sticky top-0 z-30 border-b border-white/5 bg-primary-comfy-ink/95 py-4 backdrop-blur" id="model-filter-root">
+    <div class="mx-auto max-w-7xl px-5 sm:px-6 lg:px-8">
+    <div class="flex flex-col gap-3 sm:flex-row">
+      <label class="flex flex-1 items-center gap-3 rounded-xl border border-white/15 bg-white/5 px-4 py-3.5 focus-within:border-primary-comfy-yellow/60 sm:px-5">
+        <svg class="h-4 w-4 shrink-0 text-primary-warm-gray" viewBox="0 0 16 16" fill="none"><circle cx="7" cy="7" r="5.5" stroke="currentColor" stroke-width="1.5"/><path d="M11 11l3.5 3.5" stroke="currentColor" stroke-width="1.5"/></svg>
+        <input
+          id="model-search"
+          type="search"
+          placeholder='Search 200+ models — try "flux", "wan", or "lora"'
+          class="w-full bg-transparent text-sm font-light text-primary-warm-white placeholder:text-primary-warm-gray focus:outline-none sm:text-base [&::-webkit-search-cancel-button]:hidden"
+        />
+        <button id="search-clear" class="hidden shrink-0 rounded-md px-1.5 text-lg font-light leading-none text-primary-warm-gray hover:text-primary-warm-white" aria-label="Clear search">×</button>
+      </label>
+      <span id="match-count" class="hidden rounded-xl border border-white/10 px-5 py-3.5 text-center text-xs font-semibold text-primary-warm-gray sm:block"></span>
+      <a
+        href="#browse-all"
+        class="rounded-xl border border-white/20 bg-white/5 px-5 py-3.5 text-center text-xs font-extrabold uppercase tracking-widest text-primary-warm-white transition hover:bg-white/10"
+      >
+        Browse all ↓
+      </a>
+    </div>
+    <div class="mt-3 flex items-center gap-2 overflow-x-auto pb-1 [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+      <span class="shrink-0 text-[11px] font-light text-primary-warm-gray">Try:</span>
+      {[
+        ['Newest launches', 'pill:launch'],
+        ['FLUX family', 'q:flux'],
+        ['Wan family', 'q:wan'],
+        ['Image to video', 'q:image to video'],
+        ['Music', 'q:music'],
+        ['LoRAs', 'pill:loras']
+      ].map(([label, action]) => (
+        <button
+          data-try={action}
+          class="shrink-0 rounded-full border border-white/12 bg-white/[0.04] px-3 py-1.5 text-[11px] text-primary-comfy-canvas transition hover:border-primary-comfy-yellow/50 hover:text-primary-warm-white"
+        >
+          {label}
+        </button>
+      ))}
+    </div>
+    <div class="mt-3 flex gap-2 overflow-x-auto pb-1 [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden" id="modality-pills">
+      {PILLS.map(([value, label, count], i) => (
+        <button
+          data-pill={value}
+          class:list={[
+            'shrink-0 rounded-full px-4 py-2 text-xs font-extrabold uppercase tracking-widest transition',
+            i === 0
+              ? 'is-active bg-primary-comfy-yellow text-primary-comfy-ink'
+              : 'border border-white/15 bg-white/5 text-primary-comfy-canvas hover:bg-white/10'
+          ]}
+        >
+          {label} <span class="opacity-60">{count}</span>
+        </button>
+      ))}
+    </div>
+    </div>
+  </section>
+
+  <!-- FEATURED LAUNCHES -->
+  <section class="py-10 lg:py-14" data-cardsection>
+    <div class="mx-auto max-w-7xl px-5 sm:px-6 lg:px-8">
+      <div class="mb-6 flex items-end justify-between gap-4">
+        <div>
+          <h2 class="text-sm font-extrabold uppercase tracking-[0.3em] text-primary-comfy-yellow">Featured launches</h2>
+          <p class="mt-1.5 text-sm font-light text-primary-warm-gray">The 2026 lineup, ordered by what actually converts.</p>
+        </div>
+      </div>
+      <ul class="grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-4">
+        {featured.map((card) => {
+          const meta = modalityMeta[card.modality]
+          return (
+            <li
+              class="m-card"
+              data-name={`${card.name} ${card.publisher} ${meta.label} ${card.kind}`.toLowerCase()}
+              data-tags={`launch ${kindTag(card)} ${modTag(card)}`}
+            >
+              <a
+                href={hrefFor(card.slug)}
+                class="group flex h-full flex-col overflow-hidden rounded-2xl border border-white/10 bg-white/[0.04] transition hover:border-white/25 hover:bg-white/[0.07]"
+              >
+                <div class="relative aspect-video overflow-hidden bg-secondary-mauve/40">
+                  <img
+                    src={card.img}
+                    alt={card.name}
+                    loading="lazy"
+                    class="h-full w-full object-cover transition duration-500 group-hover:scale-[1.04]"
+                    onerror="this.style.display='none'"
+                  />
+                  {card.dayZero && (
+                    <span class="absolute left-3 top-3 rounded bg-primary-comfy-yellow px-2 py-0.5 text-[10px] font-extrabold uppercase tracking-widest text-primary-comfy-ink">
+                      Day zero
+                    </span>
+                  )}
+                  <span class="absolute inset-x-0 bottom-0 bg-gradient-to-t from-primary-comfy-ink/95 to-transparent px-3 pb-2.5 pt-8 text-right text-[11px] font-extrabold uppercase tracking-widest text-primary-comfy-yellow opacity-100 transition lg:opacity-0 lg:group-hover:opacity-100">
+                    Open playground →
+                  </span>
+                </div>
+                <div class="flex flex-1 flex-col gap-2.5 p-4">
+                  <div class="flex items-baseline justify-between gap-2">
+                    <span class="text-base font-semibold text-primary-warm-white">{card.name}</span>
+                    <span class="shrink-0 text-xs text-primary-warm-gray">{card.publisher}</span>
+                  </div>
+                  <p class="text-sm font-light leading-snug text-primary-comfy-canvas">{card.blurb}</p>
+                  <div class="mt-auto flex flex-wrap items-center gap-1.5 pt-1">
+                    <span
+                      class="rounded px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider"
+                      style={`color:${meta.color};background:color-mix(in srgb, ${meta.color} 14%, transparent)`}
+                    >
+                      {meta.label}
+                    </span>
+                    <span class="rounded-full border border-white/15 px-2 py-0.5 text-[10px] text-primary-comfy-canvas">{card.kind}</span>
+                  </div>
+                  <div class="flex items-center justify-between text-[11px] text-primary-warm-gray">
+                    <span>{card.runs}</span>
+                    <span>{card.price}</span>
+                  </div>
+                </div>
+              </a>
+            </li>
+          )
+        })}
+      </ul>
+    </div>
+  </section>
+
+  <!-- TOP PARTNER APIS -->
+  <section class="bg-black/25 py-10 lg:py-14" data-cardsection>
+    <div class="mx-auto max-w-7xl px-5 sm:px-6 lg:px-8">
+      <div class="mb-6">
+        <h2 class="text-sm font-extrabold uppercase tracking-[0.3em] text-primary-comfy-yellow">Top partner APIs</h2>
+        <p class="mt-1.5 text-sm font-light text-primary-warm-gray">Ranked by real usage across the platform — one subscription, one queue.</p>
+      </div>
+      <ul class="grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-4">
+        {topPartnerApis.map((card) => {
+          const meta = modalityMeta[card.modality]
+          return (
+            <li
+              class="m-card"
+              data-name={`${card.name} ${card.publisher} ${meta.label}`.toLowerCase()}
+              data-tags={`partner ${modTag(card)}`}
+            >
+              <a
+                href={hrefFor(card.slug)}
+                class="group flex h-full flex-col overflow-hidden rounded-2xl border border-white/10 bg-white/[0.04] transition hover:border-white/25 hover:bg-white/[0.07]"
+              >
+                <div class="relative aspect-video overflow-hidden bg-secondary-mauve/40">
+                  <img src={card.img} alt={card.name} loading="lazy" class="h-full w-full object-cover transition duration-500 group-hover:scale-[1.04]" onerror="this.style.display='none'" />
+                  <span class="absolute inset-x-0 bottom-0 bg-gradient-to-t from-primary-comfy-ink/95 to-transparent px-3 pb-2.5 pt-8 text-right text-[11px] font-extrabold uppercase tracking-widest text-primary-comfy-yellow opacity-100 transition lg:opacity-0 lg:group-hover:opacity-100">
+                    Open playground →
+                  </span>
+                </div>
+                <div class="flex flex-1 flex-col gap-2 p-4">
+                  <div class="flex items-baseline justify-between gap-2">
+                    <span class="text-base font-semibold text-primary-warm-white">{card.name}</span>
+                    <span class="shrink-0 text-xs text-primary-warm-gray">{card.publisher}</span>
+                  </div>
+                  <p class="text-sm font-light leading-snug text-primary-comfy-canvas">{card.blurb}</p>
+                  <div class="mt-auto flex items-center justify-between pt-1 text-[11px] text-primary-warm-gray">
+                    <span>{card.runs}</span>
+                    <span class="font-extrabold uppercase tracking-widest text-primary-comfy-yellow">Run it →</span>
+                  </div>
+                </div>
+              </a>
+            </li>
+          )
+        })}
+      </ul>
+    </div>
+  </section>
+
+  <!-- USE-CASE WORKFLOWS -->
+  <section class="py-10 lg:py-14">
+    <div class="mx-auto max-w-7xl px-5 sm:px-6 lg:px-8">
+      <div class="mb-6 flex items-end justify-between gap-4">
+        <div>
+          <h2 class="text-sm font-extrabold uppercase tracking-[0.3em] text-primary-comfy-yellow">Start from the deliverable</h2>
+          <p class="mt-1.5 text-sm font-light text-primary-warm-gray">Top-converting use-case workflows, named after the thing you ship.</p>
+        </div>
+        <a href="https://comfy.org/workflows" class="hidden shrink-0 text-xs font-extrabold uppercase tracking-widest text-primary-comfy-canvas hover:text-primary-warm-white sm:block">All workflows →</a>
+      </div>
+      <ul class="grid grid-cols-2 gap-3 sm:gap-5 lg:grid-cols-4">
+        {useCaseWorkflows.map((tile) => (
+          <li>
+            <a href={tile.href} class="group flex h-full flex-col overflow-hidden rounded-2xl border border-white/10 bg-white/[0.04] transition hover:border-white/25 hover:bg-white/[0.07]">
+              <div class="relative aspect-[4/3] overflow-hidden bg-secondary-mauve/40">
+                <img src={tile.img} alt={tile.title} loading="lazy" class="h-full w-full object-cover transition duration-500 group-hover:scale-[1.05]" onerror="this.style.display='none'" />
+              </div>
+              <div class="flex flex-1 flex-col gap-1.5 p-3.5 sm:p-4">
+                <span class="text-xs font-extrabold uppercase tracking-[0.15em] text-primary-warm-white sm:text-sm">{tile.title}</span>
+                <span class="hidden text-xs font-light leading-snug text-primary-warm-gray sm:block">{tile.desc}</span>
+                <span class="mt-auto pt-1 text-[10px] font-extrabold uppercase tracking-widest text-primary-comfy-yellow">{tile.count} →</span>
+              </div>
+            </a>
+          </li>
+        ))}
+      </ul>
+    </div>
+  </section>
+
+  <!-- BROWSE ALL -->
+  <section class="bg-black/25 py-10 lg:py-14" data-cardsection id="browse-all">
+    <div class="mx-auto max-w-7xl px-5 sm:px-6 lg:px-8">
+      <div class="mb-6 flex items-end justify-between gap-4">
+        <div>
+          <h2 class="text-sm font-extrabold uppercase tracking-[0.3em] text-primary-comfy-yellow">Browse all {registryModels.length} models</h2>
+          <p class="mt-1.5 text-sm font-light text-primary-warm-gray">Every supported file, live from the registry. Search and filters apply here too.</p>
+        </div>
+
+      </div>
+      <ul class="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
+        {registryModels.map((m) => (
+          <li
+            class="m-card"
+            data-name={`${m.displayName} ${m.directory} ${dirLabel[m.directory] ?? ''}`.toLowerCase()}
+            data-tags={`${dirTag(m.directory)} ${m.directory === 'partner_nodes' ? 'partner' : 'open'}`}
+          >
+            <a
+              href={`/models-v2/${m.slug}`}
+              class="flex h-full items-center gap-3 rounded-xl border border-white/10 bg-white/[0.04] p-3 transition hover:border-white/25 hover:bg-white/[0.07]"
+            >
+              <div class="relative h-12 w-20 shrink-0 overflow-hidden rounded-lg bg-secondary-mauve/40">
+                {m.thumbnailUrl && (
+                  <img src={proxyImg(m.thumbnailUrl, 160)} alt="" loading="lazy" class="h-full w-full object-cover" onerror="this.style.display='none'" />
+                )}
+              </div>
+              <div class="min-w-0 flex-1">
+                <p class="truncate text-sm font-semibold text-primary-warm-white">{m.displayName}</p>
+                <p class="text-[11px] text-primary-warm-gray">{dirLabel[m.directory] ?? m.directory} · {m.workflowCount} workflows</p>
+              </div>
+              <span class="shrink-0 text-[10px] font-extrabold uppercase tracking-widest text-primary-comfy-yellow">Run →</span>
+            </a>
+          </li>
+        ))}
+      </ul>
+      <p id="no-results" class="hidden pt-8 text-center text-sm font-light text-primary-warm-gray">
+        Nothing matches — try a shorter query, or clear the filter pill.
+      </p>
+    </div>
+  </section>
+
+  <!-- OPEN VS API -->
+  <section class="mx-auto max-w-7xl px-5 py-10 sm:px-6 lg:px-8 lg:py-14">
+    <div class="grid gap-5 lg:grid-cols-2">
+      <div class="rounded-2xl border border-[#96b4ff]/35 bg-white/[0.04] p-7">
+        <h3 class="text-sm font-extrabold uppercase tracking-[0.3em] text-[#96b4ff]">Open weights</h3>
+        <p class="mt-3 text-[15px] font-light leading-relaxed text-primary-comfy-canvas">
+          Download the checkpoint, chain your LoRAs, keep the graph forever. Open source lasts forever.
+        </p>
+        <a href="#browse-all" class="mt-4 inline-block text-xs font-extrabold uppercase tracking-widest text-primary-comfy-yellow">Browse open models →</a>
+      </div>
+      <div class="rounded-2xl border border-[#dbd6f2]/35 bg-white/[0.04] p-7">
+        <h3 class="text-sm font-extrabold uppercase tracking-[0.3em] text-[#dbd6f2]">Partner APIs</h3>
+        <p class="mt-3 text-[15px] font-light leading-relaxed text-primary-comfy-canvas">
+          Kling, Veo, Grok, and GPT Image on the same canvas as your open models. One subscription, one queue.
+        </p>
+        <a href="#browse-all" class="mt-4 inline-block text-xs font-extrabold uppercase tracking-widest text-primary-comfy-yellow">Browse partner models →</a>
+      </div>
+    </div>
+  </section>
+
+  <!-- CONVERSION BAND -->
+  <section class="mx-auto max-w-7xl px-5 pb-12 sm:px-6 lg:px-8 lg:pb-16">
+    <div class="flex flex-col items-start justify-between gap-3 rounded-2xl bg-primary-comfy-yellow px-6 py-5 sm:flex-row sm:items-center sm:px-8">
+      <p class="text-sm font-extrabold uppercase tracking-[0.15em] text-primary-comfy-ink sm:text-base">
+        Five free runs. One sign-in. No countdowns.
+      </p>
+      <a href="https://cloud.comfy.org?utm_source=models_v2_preview" class="shrink-0 text-xs font-extrabold uppercase tracking-widest text-primary-comfy-ink underline-offset-4 hover:underline">
+        Try Cloud for free →
+      </a>
+    </div>
+  </section>
+
+  <!-- FAQ -->
+  <section class="mx-auto max-w-7xl px-5 pb-16 sm:px-6 lg:grid lg:grid-cols-[280px_1fr] lg:gap-14 lg:px-8 lg:pb-24">
+    <div class="mb-6 lg:mb-0">
+      <h2 class="text-sm font-extrabold uppercase tracking-[0.3em] text-primary-comfy-yellow">Questions</h2>
+      <p class="mt-2 text-2xl font-semibold text-primary-warm-white">AI models in ComfyUI</p>
+    </div>
+    <div class="divide-y divide-white/10 border-t border-white/10">
+      {faqs.map(([q, a]) => (
+        <details class="group py-4">
+          <summary class="flex cursor-pointer list-none items-center justify-between gap-4 text-[15px] text-primary-warm-white [&::-webkit-details-marker]:hidden">
+            {q}
+            <span class="text-xl font-light text-primary-warm-gray transition group-open:rotate-45">+</span>
+          </summary>
+          <p class="mt-3 max-w-2xl text-sm font-light leading-relaxed text-primary-comfy-canvas">{a}</p>
+        </details>
+      ))}
+    </div>
+  </section>
+
+  <script>
+    function initModelFilters() {
+      const search = document.getElementById('model-search') as HTMLInputElement | null
+      const pillWrap = document.getElementById('modality-pills')
+      if (!search || !pillWrap || search.dataset.bound === '1') return
+      search.dataset.bound = '1'
+
+      const cards = [...document.querySelectorAll<HTMLElement>('.m-card')]
+      const sections = [...document.querySelectorAll<HTMLElement>('[data-cardsection]')]
+      const countEl = document.getElementById('match-count')
+      const noResults = document.getElementById('no-results')
+      let activePill = 'all'
+
+      const apply = () => {
+        const q = search.value.trim().toLowerCase()
+        let visible = 0
+        for (const card of cards) {
+          const matchQ = !q || (card.dataset.name ?? '').includes(q)
+          const tags = (card.dataset.tags ?? '').split(' ')
+          const matchP = activePill === 'all' || tags.includes(activePill)
+          const show = matchQ && matchP
+          card.style.display = show ? '' : 'none'
+          if (show) visible += 1
+        }
+        for (const section of sections) {
+          const any = [...section.querySelectorAll<HTMLElement>('.m-card')].some(
+            (c) => c.style.display !== 'none'
+          )
+          section.style.display = any ? '' : 'none'
+        }
+        if (countEl) {
+          countEl.textContent = `${visible} match${visible === 1 ? '' : 'es'}`
+          countEl.classList.toggle('hidden', !q && activePill === 'all')
+        }
+        noResults?.classList.toggle('hidden', visible > 0)
+      }
+
+      const clearBtn = document.getElementById('search-clear')
+      const syncClear = () => clearBtn?.classList.toggle('hidden', !search.value)
+      search.addEventListener('input', () => { syncClear(); apply() })
+      search.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter') {
+          e.preventDefault()
+          document.getElementById('browse-all')?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+        }
+        if (e.key === 'Escape') {
+          search.value = ''
+          syncClear(); apply()
+        }
+      })
+      clearBtn?.addEventListener('click', () => {
+        search.value = ''
+        search.focus()
+        syncClear(); apply()
+      })
+      // shareable search state (?q=)
+      const params = new URLSearchParams(window.location.search)
+      const q0 = params.get('q')
+      if (q0) { search.value = q0; syncClear(); apply() }
+      search.addEventListener('change', () => {
+        const u = new URL(window.location.href)
+        if (search.value) u.searchParams.set('q', search.value)
+        else u.searchParams.delete('q')
+        window.history.replaceState({}, '', u)
+      })
+      document.querySelectorAll<HTMLElement>('[data-try]').forEach((chip) =>
+        chip.addEventListener('click', () => {
+          const [kind2, value] = (chip.dataset.try ?? '').split(/:(.*)/s)
+          if (kind2 === 'q') {
+            search.value = value
+            activePill = 'all'
+          } else {
+            search.value = ''
+            activePill = value
+          }
+          for (const b of pillWrap.querySelectorAll<HTMLElement>('[data-pill]')) {
+            const active = b.dataset.pill === activePill
+            b.classList.toggle('is-active', active)
+            b.classList.toggle('bg-primary-comfy-yellow', active)
+            b.classList.toggle('text-primary-comfy-ink', active)
+            b.classList.toggle('border', !active)
+            b.classList.toggle('border-white/15', !active)
+            b.classList.toggle('bg-white/5', !active)
+            b.classList.toggle('text-primary-comfy-canvas', !active)
+          }
+          syncClear()
+          apply()
+          document.getElementById('browse-all')?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+        })
+      )
+      pillWrap.addEventListener('click', (e) => {
+        const btn = (e.target as HTMLElement).closest<HTMLElement>('[data-pill]')
+        if (!btn) return
+        activePill = btn.dataset.pill ?? 'all'
+        for (const b of pillWrap.querySelectorAll<HTMLElement>('[data-pill]')) {
+          const active = b === btn
+          b.classList.toggle('is-active', active)
+          b.classList.toggle('bg-primary-comfy-yellow', active)
+          b.classList.toggle('text-primary-comfy-ink', active)
+          b.classList.toggle('border', !active)
+          b.classList.toggle('border-white/15', !active)
+          b.classList.toggle('bg-white/5', !active)
+          b.classList.toggle('text-primary-comfy-canvas', !active)
+        }
+        apply()
+      })
+    }
+
+    initModelFilters()
+    document.addEventListener('astro:page-load', initModelFilters)
+  </script>
+</BaseLayout>

--- a/apps/website/src/pages/models-v2/llms.txt.ts
+++ b/apps/website/src/pages/models-v2/llms.txt.ts
@@ -1,0 +1,43 @@
+// A/B TEST PREVIEW — agent-readable catalog for the /models-v2 preview
+// (fal-style llms.txt). Delete with the preview pages.
+import type { APIRoute } from 'astro'
+
+import { dirLabel, launches, registryModels } from '../../config/models-v2-demo'
+
+export const GET: APIRoute = ({ site }) => {
+  const base = new URL('/models-v2', site ?? 'https://comfy.org').href
+  const lines: string[] = [
+    '# AI Models in ComfyUI — preview catalog',
+    '',
+    '> Run 200+ open-weights and partner models with professional control,',
+    '> in the browser on Comfy Cloud or locally in ComfyUI. Five free runs',
+    '> after sign-in, no card. Prices below are estimates.',
+    '',
+    '## Featured launches',
+    ''
+  ]
+  for (const l of launches) {
+    lines.push(
+      `- [${l.name}](${base}/${l.slug === 'wan-2-2' ? 'wan' : l.slug}): ${l.blurb} ` +
+        `(${l.kind}, ${l.price.replace(' · est.', ' est.')}${l.dayZero ? ', day-zero supported' : ''})`
+    )
+  }
+  lines.push('', '## Registry', '')
+  for (const m of registryModels) {
+    lines.push(
+      `- [${m.displayName}](${base}/${m.slug}): ${dirLabel[m.directory] ?? m.directory}, ${m.workflowCount} workflows`
+    )
+  }
+  lines.push(
+    '',
+    '## Platform',
+    '',
+    '- [Comfy Cloud](https://cloud.comfy.org): hosted GPUs, every model, one subscription',
+    '- [Download ComfyUI](https://comfy.org/download): open source, runs locally, free forever',
+    '- [Workflows](https://comfy.org/workflows): ready-to-run community graphs',
+    '- [Docs](https://docs.comfy.org): tutorials and API reference'
+  )
+  return new Response(lines.join('\n'), {
+    headers: { 'Content-Type': 'text/plain; charset=utf-8' }
+  })
+}


### PR DESCRIPTION
## What

Moves the `/models-v2` model-page A/B preview into the repo so the preview and PR can be shared internally.

- `/models-v2` — index over the 2026 launch lineup (ordered by measured landing CVR + partner spend rank)
- `/models-v2/[slug]` — interactive per-model pages (APP | GRAPH | JSON views, prompt examples, workflows, API section), e.g. [`/models-v2/minimax-h3#api`](https://website-frontend-pb9zkjui6-comfyui.vercel.app/models-v2/minimax-h3#api)
- `/models-v2/llms.txt` + per-page `.md` endpoints for LLM consumption
- `scripts/models-v2-preview-check.mjs` — E2E smoke check, runnable against any base URL

## Guardrails

- All pages are `noindex` and linked from nowhere
- Added a `/models-v2` prefix exclusion to the sitemap so no slug leaks into `sitemap.xml`
- `models-v2-demo.ts` is demo data: run counts and per-run prices are placeholder estimates labeled "est."; delete that file together with the pages to remove the preview

## Preview

The website preview CI will comment a fresh Vercel URL on this PR (same project as the link above). Until then the CLI deploy above is current.

cc @nav-tej @robinjhuang

🤖 Generated with [Claude Code](https://claude.com/claude-code)
