### PR TITLE
FE-1550 fix: lift Select and SearchAutocomplete dropdowns above modal dialogs

### DIFF
--- a/src/components/ui/search-input/SearchAutocomplete.vue
+++ b/src/components/ui/search-input/SearchAutocomplete.vue
@@ -70,7 +70,7 @@
         v-if="suggestions.length > 0"
         position="popper"
         :side-offset="4"
-        :style="contentStyle"
+        :style="[contentStyle, liftedContentStyle]"
         :class="
           cn(
             'z-3000 max-h-60 w-(--reka-combobox-trigger-width) overflow-y-auto',
@@ -115,6 +115,7 @@ import { computed, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import Button from '@/components/ui/button/Button.vue'
+import { useModalLiftedZIndex } from '@/composables/useModalLiftedZIndex'
 import type { SearchInputVariants } from './searchInput.variants'
 import {
   searchInputSizeConfig,
@@ -160,6 +161,7 @@ const modelValue = defineModel<string>({ required: true })
 const inputRef = ref<InstanceType<typeof ComboboxInput> | null>(null)
 const isOpen = ref(false)
 const isComposing = ref(false)
+const liftedContentStyle = useModalLiftedZIndex(isOpen)
 
 function focus() {
   inputRef.value?.$el?.focus()

--- a/src/components/ui/search-input/SearchAutocomplete.zindex.test.ts
+++ b/src/components/ui/search-input/SearchAutocomplete.zindex.test.ts
@@ -1,0 +1,64 @@
+import { ZIndex } from '@primeuix/utils/zindex'
+import { render } from '@testing-library/vue'
+import { afterEach, describe, expect, it } from 'vitest'
+import { createI18n } from 'vue-i18n'
+
+import SearchAutocomplete from './SearchAutocomplete.vue'
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: { en: { g: { searchPlaceholder: 'Search...', clear: 'Clear' } } }
+})
+
+function findContentElement(): HTMLElement | null {
+  return document.querySelector('[data-dismissable-layer]')
+}
+
+let openModal: HTMLElement | undefined
+
+afterEach(() => {
+  if (openModal) {
+    ZIndex.clear(openModal)
+    openModal = undefined
+  }
+})
+
+describe('SearchAutocomplete z-index', () => {
+  it('opens suggestions above a dialog registered with the modal z-index counter', async () => {
+    openModal = document.createElement('div')
+    ZIndex.set('modal', openModal, 3702)
+    const dialogZIndex = Number(openModal.style.zIndex)
+
+    const { rerender, unmount } = render(SearchAutocomplete, {
+      container: document.body.appendChild(document.createElement('div')),
+      props: { modelValue: 'fo', suggestions: [] },
+      global: { plugins: [i18n] }
+    })
+
+    await rerender({ suggestions: ['foo', 'foobar'] })
+
+    const content = findContentElement()
+    expect(content).not.toBeNull()
+    expect(Number(content!.style.zIndex)).toBeGreaterThan(dialogZIndex)
+
+    unmount()
+  })
+
+  it('keeps the static z-index class when no dialog is open', async () => {
+    const { rerender, unmount } = render(SearchAutocomplete, {
+      container: document.body.appendChild(document.createElement('div')),
+      props: { modelValue: 'fo', suggestions: [] },
+      global: { plugins: [i18n] }
+    })
+
+    await rerender({ suggestions: ['foo', 'foobar'] })
+
+    const content = findContentElement()
+    expect(content).not.toBeNull()
+    expect(content!.style.zIndex).toBe('')
+    expect(content!.className).toContain('z-3000')
+
+    unmount()
+  })
+})

--- a/src/components/ui/select/SelectContent.vue
+++ b/src/components/ui/select/SelectContent.vue
@@ -4,11 +4,13 @@ import {
   SelectContent,
   SelectPortal,
   SelectViewport,
+  injectSelectRootContext,
   useForwardPropsEmits
 } from 'reka-ui'
-import type { HTMLAttributes } from 'vue'
-import { computed } from 'vue'
+import type { HTMLAttributes, StyleValue } from 'vue'
+import { computed, useAttrs } from 'vue'
 
+import { useModalLiftedZIndex } from '@/composables/useModalLiftedZIndex'
 import { cn } from '@comfyorg/tailwind-utils'
 
 import SelectScrollDownButton from './SelectScrollDownButton.vue'
@@ -40,12 +42,21 @@ const delegatedProps = computed(() => ({
 }))
 
 const forwarded = useForwardPropsEmits(delegatedProps, emits)
+
+const attrs = useAttrs()
+const rootContext = injectSelectRootContext()
+const liftedStyle = useModalLiftedZIndex(rootContext.open)
+const mergedStyle = computed<StyleValue>(() => [
+  attrs.style as StyleValue,
+  liftedStyle.value
+])
 </script>
 
 <template>
   <SelectPortal :disabled="disablePortal">
     <SelectContent
       v-bind="{ ...forwarded, ...$attrs }"
+      :style="mergedStyle"
       :class="
         cn(
           'relative z-3000 max-h-96 min-w-32 overflow-hidden',

--- a/src/components/ui/select/SelectContent.zindex.test.ts
+++ b/src/components/ui/select/SelectContent.zindex.test.ts
@@ -1,0 +1,106 @@
+import { ZIndex } from '@primeuix/utils/zindex'
+import { render, screen } from '@testing-library/vue'
+import { afterEach, describe, expect, it } from 'vitest'
+import type { StyleValue } from 'vue'
+import { nextTick, ref } from 'vue'
+
+import Select from './Select.vue'
+import SelectContent from './SelectContent.vue'
+import SelectItem from './SelectItem.vue'
+import SelectTrigger from './SelectTrigger.vue'
+
+function findContentElement(): HTMLElement | null {
+  return document.querySelector('[data-dismissable-layer]')
+}
+
+function renderSelect(contentStyle?: StyleValue) {
+  const Parent = {
+    template: `
+      <Select v-model="sel">
+        <SelectTrigger size="md">Pick</SelectTrigger>
+        <SelectContent :style="contentStyle">
+          <SelectItem value="a">Option A</SelectItem>
+          <SelectItem value="b">Option B</SelectItem>
+        </SelectContent>
+      </Select>
+    `,
+    components: { Select, SelectContent, SelectItem, SelectTrigger },
+    setup() {
+      return { sel: ref<string>(), contentStyle }
+    }
+  }
+
+  return render(Parent, {
+    container: document.body.appendChild(document.createElement('div'))
+  })
+}
+
+async function openSelect(triggerEl: HTMLElement) {
+  if (!triggerEl.hasPointerCapture) {
+    triggerEl.hasPointerCapture = () => false
+    triggerEl.releasePointerCapture = () => {}
+  }
+  triggerEl.dispatchEvent(
+    new PointerEvent('pointerdown', {
+      button: 0,
+      pointerType: 'mouse',
+      bubbles: true
+    })
+  )
+  await nextTick()
+}
+
+let openModal: HTMLElement | undefined
+
+afterEach(() => {
+  if (openModal) {
+    ZIndex.clear(openModal)
+    openModal = undefined
+  }
+})
+
+describe('SelectContent z-index', () => {
+  it('opens above a dialog registered with the modal z-index counter', async () => {
+    openModal = document.createElement('div')
+    ZIndex.set('modal', openModal, 3702)
+    const dialogZIndex = Number(openModal.style.zIndex)
+    const { unmount } = renderSelect()
+
+    await openSelect(screen.getByRole('combobox'))
+
+    const content = findContentElement()
+    expect(content).not.toBeNull()
+    expect(Number(content!.style.zIndex)).toBeGreaterThan(dialogZIndex)
+
+    unmount()
+  })
+
+  it('keeps the static z-index class when no dialog is open', async () => {
+    const { unmount } = renderSelect()
+
+    await openSelect(screen.getByRole('combobox'))
+
+    const content = findContentElement()
+    expect(content).not.toBeNull()
+    expect(content!.style.zIndex).toBe('')
+    expect(content!.className).toContain('z-3000')
+
+    unmount()
+  })
+
+  it('preserves caller styles while lifting above a dialog', async () => {
+    openModal = document.createElement('div')
+    ZIndex.set('modal', openModal, 3702)
+    const dialogZIndex = Number(openModal.style.zIndex)
+    const { unmount } = renderSelect({ maxWidth: '100px' })
+
+    await openSelect(screen.getByRole('combobox'))
+
+    const content = findContentElement()
+    expect(content).not.toBeNull()
+    expect(content!.style.maxWidth).toBe('100px')
+    expect(Number(content!.style.zIndex)).toBeGreaterThan(dialogZIndex)
+
+    unmount()
+  })
+})


### PR DESCRIPTION
SelectContent and SearchAutocomplete panels used a static z-3000 class, losing to dialogs registered with the shared auto-incrementing modal z-index counter once it climbs past 3000 (e.g. long cloud sessions where the fullscreen Load3D viewer scrim reached 3702+ and covered the Up Direction dropdown). Apply useModalLiftedZIndex on open, matching SingleSelect/MultiSelect/Popover, while preserving caller-passed styles.

## Screenshots (if applicable)
before 

https://github.com/user-attachments/assets/6cc828da-2a80-4900-b73a-c26a1e208ce7


after


https://github.com/user-attachments/assets/9ff2ad1d-807e-4d0c-ac7d-5511bae759ce

