### PR TITLE
feat(website): replace careers hero image with showcase video

### DIFF
--- a/apps/website/src/components/careers/HeroSection.test.ts
+++ b/apps/website/src/components/careers/HeroSection.test.ts
@@ -1,0 +1,28 @@
+// @vitest-environment happy-dom
+import { render, screen } from '@testing-library/vue'
+import { describe, expect, it } from 'vitest'
+
+import HeroSection from './HeroSection.vue'
+
+describe('careers HeroSection', () => {
+  it('renders the showcase video with a localized accessible label', () => {
+    render(HeroSection)
+
+    const video = screen.getByLabelText(
+      'Showcase reel of AI imagery and video generated with ComfyUI'
+    )
+    expect(video.tagName).toBe('VIDEO')
+    expect(video.getAttribute('src')).toBe(
+      'https://media.comfy.org/website/careers/hero-1280.mp4'
+    )
+    expect(video.hasAttribute('loop')).toBe(true)
+  })
+
+  it('localizes the video label for zh-CN', () => {
+    render(HeroSection, { props: { locale: 'zh-CN' } })
+
+    expect(
+      screen.getByLabelText('ComfyUI 生成的 AI 图像与视频精选合集')
+    ).toBeTruthy()
+  })
+})

--- a/apps/website/src/components/careers/HeroSection.vue
+++ b/apps/website/src/components/careers/HeroSection.vue
@@ -4,6 +4,7 @@ import type { Locale } from '../../i18n/translations'
 import { t } from '../../i18n/translations'
 import GlassCard from '../common/GlassCard.vue'
 import SectionLabel from '../common/SectionLabel.vue'
+import VideoPlayer from '../common/VideoPlayer.vue'
 
 const { locale = 'en' } = defineProps<{ locale?: Locale }>()
 </script>
@@ -15,19 +16,24 @@ const { locale = 'en' } = defineProps<{ locale?: Locale }>()
         {{ t('careers.hero.label', locale) }}
       </SectionLabel>
       <h1
-        class="text-primary-comfy-canvas mt-4 text-4xl font-light whitespace-pre-line md:text-6xl"
+        class="mt-4 text-4xl font-light whitespace-pre-line text-primary-comfy-canvas md:text-6xl"
       >
         {{ t('careers.hero.heading', locale) }}
       </h1>
     </div>
 
     <GlassCard class="mx-auto mt-12 max-w-3xl md:mt-16">
-      <img
-        src="https://media.comfy.org/website/careers/hero.webp"
-        alt="Comfy team"
-        class="w-full rounded-4xl object-cover"
+      <VideoPlayer
+        :aria-label="t('careers.hero.videoAlt', locale)"
+        src="https://media.comfy.org/website/careers/hero-1280.mp4"
+        poster="https://media.comfy.org/website/careers/hero-poster.jpg"
+        autoplay
+        lazy-autoplay
+        loop
+        mute-only
+        :locale
       />
-      <div class="text-primary-comfy-canvas space-y-6 p-8 text-base/relaxed">
+      <div class="space-y-6 p-8 text-base/relaxed text-primary-comfy-canvas">
         <p>{{ t('careers.hero.body1', locale) }}</p>
         <p>{{ t('careers.hero.body2', locale) }}</p>
         <p>{{ t('careers.hero.body3', locale) }}</p>

--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -1900,6 +1900,10 @@ const translations = {
     en: 'Building an operating\nsystem for Gen AI',
     'zh-CN': '构建生成式 AI 的\n\u201C操作系统\u201D'
   },
+  'careers.hero.videoAlt': {
+    en: 'Showcase reel of AI imagery and video generated with ComfyUI',
+    'zh-CN': 'ComfyUI 生成的 AI 图像与视频精选合集'
+  },
   'careers.hero.body1': {
     en: "We're building the world's leading visual AI platform \u2014 open, modular, and designed for those who want control, quality and scale in their creative process.",
     'zh-CN':

--- a/apps/website/src/pages/careers.astro
+++ b/apps/website/src/pages/careers.astro
@@ -52,7 +52,7 @@ const roles = itemListNode(
   ]}
   extraJsonLd={[roles]}
 >
-  <HeroSection />
+  <HeroSection client:load />
   <RolesSection departments={departments} client:visible />
   <WhyJoinSection client:visible />
   <TeamPhotosSection client:visible />

--- a/apps/website/src/pages/zh-CN/careers.astro
+++ b/apps/website/src/pages/zh-CN/careers.astro
@@ -55,7 +55,7 @@ const roles = itemListNode(
   ]}
   extraJsonLd={[roles]}
 >
-  <HeroSection locale="zh-CN" />
+  <HeroSection locale="zh-CN" client:load />
   <RolesSection locale="zh-CN" departments={departments} client:visible />
   <WhyJoinSection locale="zh-CN" client:visible />
   <TeamPhotosSection client:visible />


### PR DESCRIPTION
## Summary

Replaces the static hero image on `/careers` (and `/zh-CN/careers`) with a muted, looping showcase video in the hero card.

## Changes

- **What**: `careers/HeroSection.vue` now renders `VideoPlayer` (`autoplay` + `lazy-autoplay` + `loop` + `mute-only`, same pattern as the MCP launch film) instead of the `hero.webp` `<img>`; both careers pages hydrate the hero with `client:load`; new `careers.hero.videoAlt` i18n key (en / zh-CN).

## Review Focus

- The referenced assets do **not** exist on the CDN yet — `https://media.comfy.org/website/careers/hero-1280.mp4` and `hero-poster.jpg` must be uploaded before merge (encoded files were produced with `apps/website/scripts/process-videos.sh` and handed off in the session). Until then the hero shows an empty player.
- Careers hero was previously static HTML; it now ships the VideoPlayer island above the fold.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FzaWRG8xpN1pGtr7W72b3R)_