### PR TITLE
fix: back group-node missing reports with canvas instance ids

### DIFF
--- a/src/extensions/core/groupNode.test.ts
+++ b/src/extensions/core/groupNode.test.ts
@@ -1,16 +1,24 @@
 import { fromPartial } from '@total-typescript/shoehorn'
 import { describe, expect, it, vi } from 'vitest'
 
+import { t } from '@/i18n'
+
 import type { SerialisedLLinkArray } from '@/lib/litegraph/src/LLink'
 import type { ComfyNode } from '@/platform/workflow/validation/schemas/workflowSchema'
 
-import type { MissingNodeType } from '@/types/comfy'
+import type { ComfyExtension, MissingNodeType } from '@/types/comfy'
 
 import type { GroupNodeWorkflowData } from './groupNode'
 
+const extensionHolder = vi.hoisted(() => ({
+  ext: undefined as ComfyExtension | undefined
+}))
+
 vi.mock('@/scripts/app', () => ({
   app: {
-    registerExtension: vi.fn()
+    registerExtension: (ext: ComfyExtension) => {
+      extensionHolder.ext = ext
+    }
   }
 }))
 
@@ -158,12 +166,12 @@ describe('GroupNodeConfig.registerFromWorkflow', () => {
       expect.objectContaining({
         type: 'workflow>MyGroup',
         nodeId: '7',
-        hint: ' (missing: NotInstalledNode)'
+        hint: t('g.missingNodeTypesInGroup', { types: 'NotInstalledNode' })
       }),
       expect.objectContaining({
         type: 'workflow>MyGroup',
         nodeId: '9',
-        hint: ' (missing: NotInstalledNode)'
+        hint: t('g.missingNodeTypesInGroup', { types: 'NotInstalledNode' })
       })
     ])
   })
@@ -198,5 +206,44 @@ describe('GroupNodeConfig.registerFromWorkflow', () => {
     expect(
       missing.every((entry) => typeof entry === 'string' || !entry.nodeId)
     ).toBe(true)
+  })
+})
+
+describe('group node extension beforeConfigureGraph', () => {
+  it('wires canvas instance ids per group into registerFromWorkflow', async () => {
+    const ext = extensionHolder.ext
+    if (!ext?.beforeConfigureGraph) throw new Error('extension not registered')
+    const spy = vi
+      .spyOn(GroupNodeConfig, 'registerFromWorkflow')
+      .mockResolvedValue()
+    const groupNodes = {
+      MyGroup: fromPartial<GroupNodeWorkflowData>({
+        nodes: [{ index: 0, type: 'NotInstalledNode' }],
+        links: [],
+        external: []
+      })
+    }
+    const graphData = fromPartial<
+      Parameters<typeof ext.beforeConfigureGraph>[0]
+    >({
+      nodes: [
+        { id: 7, type: 'workflow>MyGroup' },
+        { id: 9, type: 'workflow>MyGroup' },
+        { id: 3, type: 'KSampler' }
+      ],
+      extra: { groupNodes }
+    })
+
+    try {
+      await ext.beforeConfigureGraph(graphData, [], fromPartial({}))
+
+      expect(spy).toHaveBeenCalledWith(
+        groupNodes,
+        [],
+        new Map([['MyGroup', [7, 9]]])
+      )
+    } finally {
+      spy.mockRestore()
+    }
   })
 })

--- a/src/extensions/core/groupNode.test.ts
+++ b/src/extensions/core/groupNode.test.ts
@@ -1,3 +1,4 @@
+import { fromPartial } from '@total-typescript/shoehorn'
 import { describe, expect, it, vi } from 'vitest'
 
 import type { SerialisedLLinkArray } from '@/lib/litegraph/src/LLink'
@@ -135,13 +136,13 @@ describe('GroupNodeConfig.processInputSlots', () => {
 
 describe('GroupNodeConfig.registerFromWorkflow', () => {
   function groupWithMissingInnerNode(): Record<string, GroupNodeWorkflowData> {
-    return {
+    return fromPartial({
       MyGroup: {
         nodes: [{ index: 0, type: 'NotInstalledNode' }],
         links: [],
         external: []
-      } as unknown as GroupNodeWorkflowData
-    }
+      }
+    })
   }
 
   it('backs each report with a canvas instance id when the map is provided', async () => {
@@ -165,6 +166,18 @@ describe('GroupNodeConfig.registerFromWorkflow', () => {
         hint: ' (missing: NotInstalledNode)'
       })
     ])
+  })
+
+  it('emits nothing for a missing group with no canvas instances when the map is provided', async () => {
+    const missing: MissingNodeType[] = []
+
+    await GroupNodeConfig.registerFromWorkflow(
+      groupWithMissingInnerNode(),
+      missing,
+      new Map()
+    )
+
+    expect(missing).toStrictEqual([])
   })
 
   it('keeps the legacy unbacked entries when no instance map is given', async () => {

--- a/src/extensions/core/groupNode.test.ts
+++ b/src/extensions/core/groupNode.test.ts
@@ -1,28 +1,46 @@
+import { createTestingPinia } from '@pinia/testing'
 import { fromPartial } from '@total-typescript/shoehorn'
+import { getActivePinia, setActivePinia } from 'pinia'
 import { describe, expect, it, vi } from 'vitest'
 
 import { t } from '@/i18n'
 
 import type { SerialisedLLinkArray } from '@/lib/litegraph/src/LLink'
+import type { LGraph } from '@/lib/litegraph/src/litegraph'
+import { LGraphNode } from '@/lib/litegraph/src/litegraph'
 import type { ComfyNode } from '@/platform/workflow/validation/schemas/workflowSchema'
+import { useMissingNodesErrorStore } from '@/platform/nodeReplacement/missingNodesErrorStore'
 
 import type { ComfyExtension, MissingNodeType } from '@/types/comfy'
 
 import type { GroupNodeWorkflowData } from './groupNode'
 
-const extensionHolder = vi.hoisted(() => ({
-  ext: undefined as ComfyExtension | undefined
+const extensionState = vi.hoisted(() => ({
+  ext: undefined as ComfyExtension | undefined,
+  configuringGraph: false,
+  rootGraph: {
+    extra: {} as Record<string, unknown>,
+    nodes: [] as { id: string | number }[]
+  }
 }))
 
 vi.mock('@/scripts/app', () => ({
   app: {
+    get configuringGraph() {
+      return extensionState.configuringGraph
+    },
+    rootGraph: extensionState.rootGraph,
     registerExtension: (ext: ComfyExtension) => {
-      extensionHolder.ext = ext
+      extensionState.ext = ext
     }
   }
 }))
 
-import { GroupNodeConfig, replaceLegacySeparators } from './groupNode'
+import {
+  GroupNodeConfig,
+  GroupNodeHandler,
+  replaceLegacySeparators
+} from './groupNode'
 
 function makeNode(type: string): ComfyNode {
   return {
@@ -143,10 +161,12 @@ describe('GroupNodeConfig.processInputSlots', () => {
 })
 
 describe('GroupNodeConfig.registerFromWorkflow', () => {
-  function groupWithMissingInnerNode(): Record<string, GroupNodeWorkflowData> {
+  function groupWithMissingInnerNodes(
+    types: string[] = ['NotInstalledNode']
+  ): Record<string, GroupNodeWorkflowData> {
     return fromPartial({
       MyGroup: {
-        nodes: [{ index: 0, type: 'NotInstalledNode' }],
+        nodes: types.map((type, index) => ({ index, type })),
         links: [],
         external: []
       }
@@ -157,7 +177,7 @@ describe('GroupNodeConfig.registerFromWorkflow', () => {
     const missing: MissingNodeType[] = []
 
     await GroupNodeConfig.registerFromWorkflow(
-      groupWithMissingInnerNode(),
+      groupWithMissingInnerNodes(),
       missing,
       new Map([['MyGroup', [7, 9]]])
     )
@@ -176,11 +196,35 @@ describe('GroupNodeConfig.registerFromWorkflow', () => {
     ])
   })
 
+  it('deduplicates repeated missing inner types in each report', async () => {
+    const missing: MissingNodeType[] = []
+
+    await GroupNodeConfig.registerFromWorkflow(
+      groupWithMissingInnerNodes([
+        'NotInstalledNode',
+        'AnotherMissingNode',
+        'NotInstalledNode'
+      ]),
+      missing,
+      new Map([['MyGroup', [7]]])
+    )
+
+    expect(missing).toStrictEqual([
+      expect.objectContaining({
+        type: 'workflow>MyGroup',
+        nodeId: '7',
+        hint: t('g.missingNodeTypesInGroup', {
+          types: 'NotInstalledNode, AnotherMissingNode'
+        })
+      })
+    ])
+  })
+
   it('emits nothing for a missing group with no canvas instances when the map is provided', async () => {
     const missing: MissingNodeType[] = []
 
     await GroupNodeConfig.registerFromWorkflow(
-      groupWithMissingInnerNode(),
+      groupWithMissingInnerNodes(),
       missing,
       new Map()
     )
@@ -192,7 +236,7 @@ describe('GroupNodeConfig.registerFromWorkflow', () => {
     const missing: MissingNodeType[] = []
 
     await GroupNodeConfig.registerFromWorkflow(
-      groupWithMissingInnerNode(),
+      groupWithMissingInnerNodes(),
       missing
     )
 
@@ -210,8 +254,8 @@ describe('GroupNodeConfig.registerFromWorkflow', () => {
 })
 
 describe('group node extension beforeConfigureGraph', () => {
-  it('wires canvas instance ids per group into registerFromWorkflow', async () => {
-    const ext = extensionHolder.ext
+  it('wires serialized instance positions per group into registerFromWorkflow', async () => {
+    const ext = extensionState.ext
     if (!ext?.beforeConfigureGraph) throw new Error('extension not registered')
     const spy = vi
       .spyOn(GroupNodeConfig, 'registerFromWorkflow')
@@ -240,10 +284,149 @@ describe('group node extension beforeConfigureGraph', () => {
       expect(spy).toHaveBeenCalledWith(
         groupNodes,
         [],
-        new Map([['MyGroup', [7, 9]]])
+        new Map([['MyGroup', [0, 1]]])
       )
     } finally {
       spy.mockRestore()
+    }
+  })
+
+  it('binds duplicate serialized ids to distinct configured graph ids', async () => {
+    const ext = extensionState.ext
+    if (!ext?.beforeConfigureGraph || !ext.afterConfigureGraph) {
+      throw new Error('extension not registered')
+    }
+    const groupNodes = {
+      MyGroup: fromPartial<GroupNodeWorkflowData>({
+        nodes: [{ index: 0, type: 'NotInstalledNode' }],
+        links: [],
+        external: []
+      })
+    }
+    const graphData = fromPartial<
+      Parameters<typeof ext.beforeConfigureGraph>[0]
+    >({
+      nodes: [
+        { id: 7, type: 'workflow>MyGroup' },
+        { id: 7, type: 'workflow>MyGroup' }
+      ],
+      extra: { groupNodes }
+    })
+    const missingNodeTypes: MissingNodeType[] = []
+    extensionState.rootGraph.nodes = [{ id: 7 }, { id: 8 }]
+
+    try {
+      await ext.beforeConfigureGraph(
+        graphData,
+        missingNodeTypes,
+        fromPartial({})
+      )
+      await ext.afterConfigureGraph(missingNodeTypes, fromPartial({}))
+
+      expect(missingNodeTypes).toStrictEqual([
+        expect.objectContaining({ nodeId: '7', type: 'workflow>MyGroup' }),
+        expect.objectContaining({ nodeId: '8', type: 'workflow>MyGroup' })
+      ])
+
+      const previousPinia = getActivePinia()
+      setActivePinia(createTestingPinia({ stubActions: false }))
+      try {
+        const store = useMissingNodesErrorStore()
+        store.setMissingNodeTypes(missingNodeTypes)
+        store.removeMissingNodesByNodeId('7')
+
+        expect(store.missingNodesError?.nodeTypes).toStrictEqual([
+          expect.objectContaining({ nodeId: '8', type: 'workflow>MyGroup' })
+        ])
+      } finally {
+        setActivePinia(previousPinia)
+      }
+    } finally {
+      extensionState.rootGraph.nodes = []
+    }
+  })
+
+  it('does not reinterpret reports appended by concurrent extensions', async () => {
+    const ext = extensionState.ext
+    if (!ext?.beforeConfigureGraph || !ext.afterConfigureGraph) {
+      throw new Error('extension not registered')
+    }
+    const missingNodeTypes: MissingNodeType[] = []
+    const unrelatedReport = { type: 'OtherMissingNode', nodeId: '99' }
+    const spy = vi
+      .spyOn(GroupNodeConfig, 'registerFromWorkflow')
+      .mockImplementation(async (_groupNodes, groupNodeReports) => {
+        groupNodeReports.push({
+          type: 'workflow>MyGroup',
+          nodeId: '0'
+        })
+        missingNodeTypes.push(unrelatedReport)
+      })
+    const graphData = fromPartial<
+      Parameters<typeof ext.beforeConfigureGraph>[0]
+    >({
+      nodes: [{ id: 7, type: 'workflow>MyGroup' }],
+      extra: {
+        groupNodes: {
+          MyGroup: fromPartial<GroupNodeWorkflowData>({
+            nodes: [{ index: 0, type: 'NotInstalledNode' }],
+            links: [],
+            external: []
+          })
+        }
+      }
+    })
+    extensionState.rootGraph.nodes = [{ id: 7 }]
+
+    try {
+      await ext.beforeConfigureGraph(
+        graphData,
+        missingNodeTypes,
+        fromPartial({})
+      )
+      await ext.afterConfigureGraph(missingNodeTypes, fromPartial({}))
+
+      expect(missingNodeTypes).toStrictEqual([
+        unrelatedReport,
+        expect.objectContaining({
+          type: 'workflow>MyGroup',
+          nodeId: '7'
+        })
+      ])
+    } finally {
+      extensionState.rootGraph.nodes = []
+      spy.mockRestore()
+    }
+  })
+
+  it('does not retain loading state after graph configuration fails', async () => {
+    const ext = extensionState.ext
+    if (!ext?.nodeCreated) throw new Error('extension not registered')
+    const convertToNodes = vi.fn(() => [])
+    const isGroupNode = vi
+      .spyOn(GroupNodeHandler, 'isGroupNode')
+      .mockReturnValue(true)
+    const getHandler = vi
+      .spyOn(GroupNodeHandler, 'getHandler')
+      .mockReturnValue(fromPartial({ convertToNodes }))
+    const graph = fromPartial<LGraph>({ convertToSubgraph: vi.fn() })
+    const failedLoadNode = new LGraphNode('Failed load')
+    const pastedNode = new LGraphNode('Pasted')
+    failedLoadNode.graph = graph
+    pastedNode.graph = graph
+
+    try {
+      extensionState.configuringGraph = true
+      ext.nodeCreated(failedLoadNode, fromPartial({}))
+      extensionState.configuringGraph = false
+      ext.nodeCreated(pastedNode, fromPartial({}))
+      await Promise.resolve()
+
+      expect(convertToNodes).toHaveBeenCalledOnce()
+    } finally {
+      extensionState.configuringGraph = false
+      isGroupNode.mockRestore()
+      getHandler.mockRestore()
     }
   })
 })

--- a/src/extensions/core/groupNode.test.ts
+++ b/src/extensions/core/groupNode.test.ts
@@ -3,6 +3,8 @@ import { describe, expect, it, vi } from 'vitest'
 import type { SerialisedLLinkArray } from '@/lib/litegraph/src/LLink'
 import type { ComfyNode } from '@/platform/workflow/validation/schemas/workflowSchema'
 
+import type { MissingNodeType } from '@/types/comfy'
+
 import type { GroupNodeWorkflowData } from './groupNode'
 
 vi.mock('@/scripts/app', () => ({
@@ -128,5 +130,60 @@ describe('GroupNodeConfig.processInputSlots', () => {
     )
 
     expect(inputMap).toEqual({ model: 0, latent_image: 1 })
+  })
+})
+
+describe('GroupNodeConfig.registerFromWorkflow', () => {
+  function groupWithMissingInnerNode(): Record<string, GroupNodeWorkflowData> {
+    return {
+      MyGroup: {
+        nodes: [{ index: 0, type: 'NotInstalledNode' }],
+        links: [],
+        external: []
+      } as unknown as GroupNodeWorkflowData
+    }
+  }
+
+  it('backs each report with a canvas instance id when the map is provided', async () => {
+    const missing: MissingNodeType[] = []
+
+    await GroupNodeConfig.registerFromWorkflow(
+      groupWithMissingInnerNode(),
+      missing,
+      new Map([['MyGroup', [7, 9]]])
+    )
+
+    expect(missing).toStrictEqual([
+      expect.objectContaining({
+        type: 'workflow>MyGroup',
+        nodeId: '7',
+        hint: ' (missing: NotInstalledNode)'
+      }),
+      expect.objectContaining({
+        type: 'workflow>MyGroup',
+        nodeId: '9',
+        hint: ' (missing: NotInstalledNode)'
+      })
+    ])
+  })
+
+  it('keeps the legacy unbacked entries when no instance map is given', async () => {
+    const missing: MissingNodeType[] = []
+
+    await GroupNodeConfig.registerFromWorkflow(
+      groupWithMissingInnerNode(),
+      missing
+    )
+
+    expect(missing).toStrictEqual([
+      expect.objectContaining({
+        type: 'NotInstalledNode',
+        hint: " (In group node 'workflow>MyGroup')"
+      }),
+      expect.objectContaining({ type: 'workflow>MyGroup' })
+    ])
+    expect(
+      missing.every((entry) => typeof entry === 'string' || !entry.nodeId)
+    ).toBe(true)
   })
 })

--- a/src/extensions/core/groupNode.test.ts
+++ b/src/extensions/core/groupNode.test.ts
@@ -7,9 +7,11 @@ import { t } from '@/i18n'
 
 import type { SerialisedLLinkArray } from '@/lib/litegraph/src/LLink'
 import type { LGraph } from '@/lib/litegraph/src/litegraph'
-import { LGraphNode } from '@/lib/litegraph/src/litegraph'
+import { LGraphNode, LiteGraph } from '@/lib/litegraph/src/litegraph'
 import type { ComfyNode } from '@/platform/workflow/validation/schemas/workflowSchema'
 import { useMissingNodesErrorStore } from '@/platform/nodeReplacement/missingNodesErrorStore'
+import type { ComfyNodeDef } from '@/schemas/nodeDefSchema'
+import { useNodeDefStore } from '@/stores/nodeDefStore'
 
 import type { ComfyExtension, MissingNodeType } from '@/types/comfy'
 
@@ -21,7 +23,9 @@ const extensionState = vi.hoisted(() => ({
   rootGraph: {
     extra: {} as Record<string, unknown>,
     nodes: [] as { id: string | number }[]
-  }
+  },
+  registerNodeDef:
+    vi.fn<(typeName: string, nodeDef: ComfyNodeDef) => Promise<void>>()
 }))
 
 vi.mock('@/scripts/app', () => ({
@@ -30,6 +34,7 @@ vi.mock('@/scripts/app', () => ({
       return extensionState.configuringGraph
     },
     rootGraph: extensionState.rootGraph,
+    registerNodeDef: extensionState.registerNodeDef,
     registerExtension: (ext: ComfyExtension) => {
       extensionState.ext = ext
     }
@@ -232,6 +237,56 @@ describe('GroupNodeConfig.registerFromWorkflow', () => {
     expect(missing).toStrictEqual([])
   })
 
+  it('removes a prior same-name group type before reporting missing nodes', async () => {
+    const groupType = 'workflow>MyGroup'
+    const missing: MissingNodeType[] = []
+    const previousPinia = getActivePinia()
+    setActivePinia(createTestingPinia({ stubActions: false }))
+    extensionState.registerNodeDef.mockImplementation(
+      async (typeName, nodeDef) => {
+        class PreviousGroupNode extends LGraphNode {
+          static override nodeData = nodeDef
+        }
+        LiteGraph.registerNodeType(typeName, PreviousGroupNode)
+      }
+    )
+
+    try {
+      await GroupNodeConfig.registerFromWorkflow(
+        {
+          MyGroup: {
+            nodes: [],
+            links: [],
+            external: []
+          }
+        },
+        []
+      )
+      const previousGroupNode = LiteGraph.createNode(groupType)
+      if (!previousGroupNode) throw new Error('group type not registered')
+      expect(GroupNodeHandler.isGroupNode(previousGroupNode)).toBe(true)
+      expect(useNodeDefStore().nodeDefsByName[groupType]).toBeDefined()
+
+      await GroupNodeConfig.registerFromWorkflow(
+        groupWithMissingInnerNodes(),
+        missing,
+        new Map([['MyGroup', [7]]])
+      )
+
+      expect(LiteGraph.registered_node_types[groupType]).toBeUndefined()
+      expect(useNodeDefStore().nodeDefsByName[groupType]).toBeUndefined()
+      expect(missing).toStrictEqual([
+        expect.objectContaining({ type: groupType, nodeId: '7' })
+      ])
+    } finally {
+      extensionState.registerNodeDef.mockReset()
+      setActivePinia(previousPinia)
+      if (groupType in LiteGraph.registered_node_types) {
+        LiteGraph.unregisterNodeType(groupType)
+      }
+    }
+  })
+
   it('keeps the legacy unbacked entries when no instance map is given', async () => {
     const missing: MissingNodeType[] = []
 
@@ -399,7 +454,7 @@ describe('group node extension beforeConfigureGraph', () => {
     }
   })
 
-  it('does not retain loading state after graph configuration fails', async () => {
+  it('skips stray conversion while configuring and converts afterwards', async () => {
     const ext = extensionState.ext
     if (!ext?.nodeCreated) throw new Error('extension not registered')
     const convertToNodes = vi.fn(() => [])

--- a/src/extensions/core/groupNode.test.ts
+++ b/src/extensions/core/groupNode.test.ts
@@ -265,6 +265,7 @@ describe('GroupNodeConfig.registerFromWorkflow', () => {
       const previousGroupNode = LiteGraph.createNode(groupType)
       if (!previousGroupNode) throw new Error('group type not registered')
       expect(GroupNodeHandler.isGroupNode(previousGroupNode)).toBe(true)
+      expect(LiteGraph.Nodes.PreviousGroupNode).toBeDefined()
       expect(useNodeDefStore().nodeDefsByName[groupType]).toBeDefined()
 
       await GroupNodeConfig.registerFromWorkflow(
@@ -274,6 +275,7 @@ describe('GroupNodeConfig.registerFromWorkflow', () => {
       )
 
       expect(LiteGraph.registered_node_types[groupType]).toBeUndefined()
+      expect(LiteGraph.Nodes.PreviousGroupNode).toBeUndefined()
       expect(useNodeDefStore().nodeDefsByName[groupType]).toBeUndefined()
       expect(missing).toStrictEqual([
         expect.objectContaining({ type: groupType, nodeId: '7' })

--- a/src/extensions/core/groupNode.ts
+++ b/src/extensions/core/groupNode.ts
@@ -10,7 +10,7 @@ import type {
 import type { ComfyNodeDef, InputSpec } from '@/schemas/nodeDefSchema'
 import { useNodeDefStore } from '@/stores/nodeDefStore'
 import { useWidgetStore } from '@/stores/widgetStore'
-import type { ComfyExtension } from '@/types/comfy'
+import type { ComfyExtension, MissingNodeType } from '@/types/comfy'
 import { deserialiseAndCreate } from '@/utils/vintageClipboard'
 
 import { app } from '../../scripts/app'
@@ -763,42 +763,58 @@ export class GroupNodeConfig {
 
   static async registerFromWorkflow(
     groupNodes: Record<string, GroupNodeWorkflowData>,
-    missingNodeTypes: (
-      | string
-      | { type: string; hint?: string; action?: unknown }
-    )[]
+    missingNodeTypes: MissingNodeType[],
+    instanceIdsByGroup?: Map<string, (string | number)[]>
   ) {
     for (const g in groupNodes) {
       const groupData = groupNodes[g]
 
-      let hasMissing = false
-      for (const n of groupData.nodes) {
-        // Find missing node types
-        if (!n.type || !(n.type in LiteGraph.registered_node_types)) {
-          missingNodeTypes.push({
-            type: n.type ?? 'unknown',
-            hint: ` (In group node '${PREFIX}${SEPARATOR}${g}')`
-          })
+      const missingInnerTypes = [
+        ...new Set(
+          groupData.nodes
+            .filter(
+              (n) => !n.type || !(n.type in LiteGraph.registered_node_types)
+            )
+            .map((n) => n.type ?? 'unknown')
+        )
+      ]
 
-          missingNodeTypes.push({
-            type: `${PREFIX}${SEPARATOR}` + g,
-            action: {
-              text: 'Remove from workflow',
-              callback: (e: MouseEvent) => {
-                delete groupNodes[g]
-                const target = e.target as HTMLElement
-                target.textContent = 'Removed'
-                target.style.pointerEvents = 'none'
-                target.style.opacity = '0.7'
-              }
-            }
-          })
-
-          hasMissing = true
+      if (missingInnerTypes.length) {
+        const groupType = `${PREFIX}${SEPARATOR}${g}`
+        const removeAction = {
+          text: 'Remove from workflow',
+          callback: (e?: MouseEvent) => {
+            delete groupNodes[g]
+            const target = e?.target as HTMLElement | undefined
+            if (!target) return
+            target.textContent = 'Removed'
+            target.style.pointerEvents = 'none'
+            target.style.opacity = '0.7'
+          }
         }
+        const instanceIds = instanceIdsByGroup?.get(g) ?? []
+        if (instanceIds.length) {
+          // One report per canvas instance so every entry is backed by a
+          // real node and can be retired when that node goes away.
+          for (const id of instanceIds) {
+            missingNodeTypes.push({
+              type: groupType,
+              nodeId: String(id),
+              hint: ` (missing: ${missingInnerTypes.join(', ')})`,
+              action: removeAction
+            })
+          }
+        } else {
+          for (const missingType of missingInnerTypes) {
+            missingNodeTypes.push({
+              type: missingType,
+              hint: ` (In group node '${groupType}')`
+            })
+          }
+          missingNodeTypes.push({ type: groupType, action: removeAction })
+        }
+        continue
       }
-
-      if (hasMissing) continue
 
       const config = new GroupNodeConfig(g, groupData)
       await config.registerType()
@@ -1056,7 +1072,21 @@ const ext: ComfyExtension = {
       | undefined
     if (nodes) {
       replaceLegacySeparators(graphData.nodes)
-      await GroupNodeConfig.registerFromWorkflow(nodes, missingNodeTypes)
+      const instanceIdsByGroup = new Map<string, (string | number)[]>()
+      const groupTypePrefix = `${PREFIX}${SEPARATOR}`
+      for (const n of graphData.nodes) {
+        const type = String(n.type ?? '')
+        if (!type.startsWith(groupTypePrefix) || n.id == null) continue
+        const groupName = type.slice(groupTypePrefix.length)
+        const ids = instanceIdsByGroup.get(groupName) ?? []
+        ids.push(n.id)
+        instanceIdsByGroup.set(groupName, ids)
+      }
+      await GroupNodeConfig.registerFromWorkflow(
+        nodes,
+        missingNodeTypes,
+        instanceIdsByGroup
+      )
     }
   },
   afterConfigureGraph() {

--- a/src/extensions/core/groupNode.ts
+++ b/src/extensions/core/groupNode.ts
@@ -10,7 +10,7 @@ import type {
 import type { ComfyNodeDef, InputSpec } from '@/schemas/nodeDefSchema'
 import { useNodeDefStore } from '@/stores/nodeDefStore'
 import { useWidgetStore } from '@/stores/widgetStore'
-import type { ComfyExtension, MissingNodeType } from '@/types/comfy'
+import type { ComfyExtension } from '@/types/comfy'
 import { deserialiseAndCreate } from '@/utils/vintageClipboard'
 
 import { app } from '../../scripts/app'
@@ -763,7 +763,15 @@ export class GroupNodeConfig {
 
   static async registerFromWorkflow(
     groupNodes: Record<string, GroupNodeWorkflowData>,
-    missingNodeTypes: MissingNodeType[],
+    missingNodeTypes: (
+      | string
+      | {
+          type: string
+          nodeId?: string | number
+          hint?: string
+          action?: unknown
+        }
+    )[],
     instanceIdsByGroup?: Map<string, (string | number)[]>
   ) {
     for (const g in groupNodes) {
@@ -792,11 +800,12 @@ export class GroupNodeConfig {
             target.style.opacity = '0.7'
           }
         }
-        const instanceIds = instanceIdsByGroup?.get(g) ?? []
-        if (instanceIds.length) {
+        if (instanceIdsByGroup) {
           // One report per canvas instance so every entry is backed by a
-          // real node and can be retired when that node goes away.
-          for (const id of instanceIds) {
+          // real node and can be retired when that node goes away. A group
+          // definition with no instances gets no report: there is no node
+          // to locate, and nothing that could ever retire the row.
+          for (const id of instanceIdsByGroup.get(g) ?? []) {
             missingNodeTypes.push({
               type: groupType,
               nodeId: String(id),

--- a/src/extensions/core/groupNode.ts
+++ b/src/extensions/core/groupNode.ts
@@ -1,4 +1,5 @@
 import { PREFIX, SEPARATOR } from '@/constants/groupNodeConstants'
+import { t } from '@/i18n'
 import type { SerialisedLLinkArray } from '@/lib/litegraph/src/LLink'
 import type { LGraphNodeConstructor } from '@/lib/litegraph/src/litegraph'
 import { LGraphNode, LiteGraph } from '@/lib/litegraph/src/litegraph'
@@ -809,7 +810,9 @@ export class GroupNodeConfig {
             missingNodeTypes.push({
               type: groupType,
               nodeId: String(id),
-              hint: ` (missing: ${missingInnerTypes.join(', ')})`,
+              hint: t('g.missingNodeTypesInGroup', {
+                types: missingInnerTypes.join(', ')
+              }),
               action: removeAction
             })
           }

--- a/src/extensions/core/groupNode.ts
+++ b/src/extensions/core/groupNode.ts
@@ -11,7 +11,7 @@ import type {
 import type { ComfyNodeDef, InputSpec } from '@/schemas/nodeDefSchema'
 import { useNodeDefStore } from '@/stores/nodeDefStore'
 import { useWidgetStore } from '@/stores/widgetStore'
-import type { ComfyExtension } from '@/types/comfy'
+import type { ComfyExtension, MissingNodeType } from '@/types/comfy'
 import { deserialiseAndCreate } from '@/utils/vintageClipboard'
 
 import { app } from '../../scripts/app'
@@ -844,7 +844,6 @@ export class GroupNodeConfig {
  * {@link convertToNodes} and {@link LGraph.convertToSubgraph} repackages the
  * result as a subgraph.
  *
- * @knipIgnoreUnusedButUsedByCustomNodes
  */
 export class GroupNodeHandler {
   node: LGraphNode
@@ -1058,8 +1057,10 @@ function convertLoadedGroupNodes(): number {
   }
 }
 
-/** True while a workflow load is in progress, to defer stray paste conversions. */
-let isLoadingWorkflow = false
+const groupNodeReportIndices = new WeakMap<
+  Exclude<MissingNodeType, string>,
+  number
+>()
 
 const id = 'Comfy.GroupNode'
 
@@ -1076,38 +1077,55 @@ const ext: ComfyExtension = {
   },
   async beforeConfigureGraph(
     graphData: ComfyWorkflowJSON,
-    missingNodeTypes: string[]
+    missingNodeTypes: MissingNodeType[]
   ) {
-    isLoadingWorkflow = true
     const nodes = graphData?.extra?.groupNodes as
       | Record<string, GroupNodeWorkflowData>
       | undefined
     if (nodes) {
       replaceLegacySeparators(graphData.nodes)
-      const instanceIdsByGroup = new Map<string, (string | number)[]>()
+      const instanceIndicesByGroup = new Map<string, number[]>()
       const groupTypePrefix = `${PREFIX}${SEPARATOR}`
-      for (const n of graphData.nodes) {
+      for (const [nodeIndex, n] of graphData.nodes.entries()) {
         const type = String(n.type ?? '')
-        if (!type.startsWith(groupTypePrefix) || n.id == null) continue
+        if (!type.startsWith(groupTypePrefix)) continue
         const groupName = type.slice(groupTypePrefix.length)
-        const ids = instanceIdsByGroup.get(groupName) ?? []
-        ids.push(n.id)
-        instanceIdsByGroup.set(groupName, ids)
+        const indices = instanceIndicesByGroup.get(groupName) ?? []
+        indices.push(nodeIndex)
+        instanceIndicesByGroup.set(groupName, indices)
       }
+      const groupNodeReports: MissingNodeType[] = []
       await GroupNodeConfig.registerFromWorkflow(
         nodes,
-        missingNodeTypes,
-        instanceIdsByGroup
+        groupNodeReports,
+        instanceIndicesByGroup
       )
+      for (const report of groupNodeReports) {
+        if (typeof report === 'string' || report.nodeId == null) continue
+        const nodeIndex = Number(report.nodeId)
+        if (Number.isInteger(nodeIndex)) {
+          groupNodeReportIndices.set(report, nodeIndex)
+        }
+      }
+      missingNodeTypes.push(...groupNodeReports)
     }
   },
-  afterConfigureGraph() {
-    try {
-      if (convertLoadedGroupNodes() > 0) {
-        delete app.rootGraph.extra?.groupNodes
+  afterConfigureGraph(missingNodeTypes) {
+    for (let index = missingNodeTypes.length - 1; index >= 0; index--) {
+      const report = missingNodeTypes[index]
+      if (typeof report === 'string') continue
+      const nodeIndex = groupNodeReportIndices.get(report)
+      if (nodeIndex === undefined) continue
+      groupNodeReportIndices.delete(report)
+      const node = app.rootGraph.nodes[nodeIndex]
+      if (node) {
+        report.nodeId = String(node.id)
+      } else {
+        missingNodeTypes.splice(index, 1)
       }
-    } finally {
-      isLoadingWorkflow = false
+    }
+    if (convertLoadedGroupNodes() > 0) {
+      delete app.rootGraph.extra?.groupNodes
     }
   },
   nodeCreated(node: LGraphNode) {
@@ -1115,7 +1133,7 @@ const ext: ComfyExtension = {
     const handler = GroupNodeHandler.getHandler(node)
     // A stray group node created after load (e.g. paste) has no migration pass;
     // convert it to a subgraph once it has joined a graph.
-    if (!isLoadingWorkflow) {
+    if (!app.configuringGraph) {
       queueMicrotask(() => {
         const graph = node.graph
         if (graph && handler && GroupNodeHandler.isGroupNode(node)) {

--- a/src/extensions/core/groupNode.ts
+++ b/src/extensions/core/groupNode.ts
@@ -790,6 +790,13 @@ export class GroupNodeConfig {
 
       if (missingInnerTypes.length) {
         const groupType = `${PREFIX}${SEPARATOR}${g}`
+        const registeredGroupType = LiteGraph.registered_node_types[
+          groupType
+        ] as LGraphNodeConstructor | undefined
+        if (registeredGroupType?.nodeData?.[GROUP]) {
+          LiteGraph.unregisterNodeType(groupType)
+          useNodeDefStore().removeNodeDef(groupType)
+        }
         const removeAction = {
           text: 'Remove from workflow',
           callback: (e?: MouseEvent) => {

--- a/src/lib/litegraph/src/LiteGraphGlobal.ts
+++ b/src/lib/litegraph/src/LiteGraphGlobal.ts
@@ -457,8 +457,8 @@ export class LiteGraphGlobal {
 
     delete this.registered_node_types[String(base_class.type)]
 
-    const name = base_class.constructor.name
-    if (name) delete this.Nodes[name]
+    const name = base_class.name
+    if (name && this.Nodes[name] === base_class) delete this.Nodes[name]
   }
 
   /**

--- a/src/lib/litegraph/src/litegraph.test.ts
+++ b/src/lib/litegraph/src/litegraph.test.ts
@@ -5,7 +5,8 @@ import {
   LiteGraphGlobal,
   LGraphCanvas,
   LiteGraph,
-  LGraph
+  LGraph,
+  LGraphNode
 } from '@/lib/litegraph/src/litegraph'
 
 import { LGraph as DirectLGraph } from '@/lib/litegraph/src/LGraph'
@@ -26,6 +27,22 @@ describe('Litegraph module', () => {
   test('clamps values', () => {
     expect(clamp(-1.124, 13, 24)).toStrictEqual(13)
     expect(clamp(Infinity, 18, 29)).toStrictEqual(29)
+  })
+
+  test('preserves a newer constructor map entry with the same name', () => {
+    const liteGraph = new LiteGraphGlobal()
+    const FirstNode = class SharedNode extends LGraphNode {}
+    const SecondNode = class SharedNode extends LGraphNode {}
+    liteGraph.registerNodeType('test/first', FirstNode)
+    liteGraph.registerNodeType('test/second', SecondNode)
+
+    liteGraph.unregisterNodeType('test/first')
+
+    expect(liteGraph.registered_node_types['test/first']).toBeUndefined()
+    expect(liteGraph.Nodes.SharedNode).toBe(SecondNode)
+
+    liteGraph.unregisterNodeType('test/second')
+    expect(liteGraph.Nodes.SharedNode).toBeUndefined()
   })
 })
 

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -106,6 +106,7 @@
     "enter": "Enter",
     "enterSubgraph": "Enter subgraph",
     "inSubgraph": "in subgraph '{name}'",
+    "missingNodeTypesInGroup": "missing: {types}",
     "resizeFromBottomRight": "Resize from bottom-right corner",
     "resizeFromTopRight": "Resize from top-right corner",
     "resizeFromBottomLeft": "Resize from bottom-left corner",

--- a/src/stores/nodeDefStore.ts
+++ b/src/stores/nodeDefStore.ts
@@ -434,6 +434,9 @@ export const useNodeDefStore = defineStore('nodeDef', () => {
     const nodeDefImpl = new ComfyNodeDefImpl(nodeDef)
     nodeDefsByName.value[nodeDef.name] = nodeDefImpl
   }
+  function removeNodeDef(nodeName: string) {
+    delete nodeDefsByName.value[nodeName]
+  }
   function fromLGraphNode(node: LGraphNode): ComfyNodeDefImpl | null {
     const nodeTypeName = node.constructor?.nodeData?.name ?? node.type
     if (!nodeTypeName) return null
@@ -549,6 +552,7 @@ export const useNodeDefStore = defineStore('nodeDef', () => {
 
     updateNodeDefs,
     addNodeDef,
+    removeNodeDef,
     fromLGraphNode,
     getInputSpecForWidget,
     registerNodeDefFilter,


### PR DESCRIPTION
## ELI5

Missing group-node warnings must point to the real node that can retire them. This PR gives every group instance its own report and rebinds duplicate serialized IDs to the canonical IDs assigned during graph configuration.

## Summary

- Emit one backed report per group-node instance while preserving the loose legacy `registerFromWorkflow` caller contract.
- Isolate group reports from concurrent extension hooks and bind them to post-configure canonical node IDs.
- Avoid custom load-state leakage by using `app.configuringGraph`.
- Deduplicate missing inner types and localize the group hint.
- Remove stale synthesized group constructors and node definitions before a same-name missing group loads.
- Fix `unregisterNodeType` cleanup of the class-name constructor map while preserving newer same-name registrations.

## Test plan

- [x] `groupNode.test.ts`: 18 passed.
- [x] Focused constructor-name collision regression passed.
- [x] Duplicate serialized IDs produce distinct reports with independent retirement.
- [x] Commit typecheck and pre-push knip passed.
- [x] AMP review: CLEAN.

## Provenance

- **Authored by:** interactive session
- **From:** importer-contract review follow-up; related #15141
- **Breaking:** none; the exported static retains its legacy loose parameter shape.