### PR TITLE
fix(billing): tolerate subscription tiers absent from the personal catalog

### DIFF
--- a/src/platform/cloud/subscription/composables/useBillingPolicyState.test.ts
+++ b/src/platform/cloud/subscription/composables/useBillingPolicyState.test.ts
@@ -114,12 +114,12 @@ describe('deriveBillingPolicyState', () => {
   )
 
   // The tier union is generated from the backend spec, so a value outside it is
-  // reachable at runtime even though the type forbids it. Treating it as unknown
-  // is what keeps a backend-side tier addition from breaking this build; this
-  // pins that behaviour rather than leaving the default branch untested.
+  // reachable at runtime even though the type forbids it. It must resolve to the
+  // restrictive state, not Unknown: Unknown grants topUpAccess 'allowed', which
+  // would hand paid-plan access to a tier purely for being unrecognised.
   it.for([
-    ['CloudAndUnknown', true],
-    ['LocalAndUnknown', false]
+    ['CloudWithoutActiveSubscription', true],
+    ['LocalWithoutActiveSubscription', false]
   ] as const)(
     'resolves an unrecognised tier as %s (isCloud=%s)',
     ([kind, isCloud]) => {

--- a/src/platform/cloud/subscription/composables/useBillingPolicyState.test.ts
+++ b/src/platform/cloud/subscription/composables/useBillingPolicyState.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
+import type { IngestSubscriptionTier } from '@/platform/cloud/subscription/constants/tierPricing'
 import { deriveBillingPolicyState } from './useBillingPolicyState'
 
 describe('deriveBillingPolicyState', () => {
@@ -107,6 +108,27 @@ describe('deriveBillingPolicyState', () => {
           canAccessSubscriptionFeatures: true,
           isTeamPlan: false,
           tier: 'TEAM'
+        })
+      ).toEqual({ kind })
+    }
+  )
+
+  // The tier union is generated from the backend spec, so a value outside it is
+  // reachable at runtime even though the type forbids it. Treating it as unknown
+  // is what keeps a backend-side tier addition from breaking this build; this
+  // pins that behaviour rather than leaving the default branch untested.
+  it.for([
+    ['CloudAndUnknown', true],
+    ['LocalAndUnknown', false]
+  ] as const)(
+    'resolves an unrecognised tier as %s (isCloud=%s)',
+    ([kind, isCloud]) => {
+      expect(
+        deriveBillingPolicyState({
+          isCloud,
+          canAccessSubscriptionFeatures: true,
+          isTeamPlan: false,
+          tier: 'ENTERPRISE' as IngestSubscriptionTier
         })
       ).toEqual({ kind })
     }

--- a/src/platform/cloud/subscription/composables/useBillingPolicyState.ts
+++ b/src/platform/cloud/subscription/composables/useBillingPolicyState.ts
@@ -46,7 +46,10 @@ export function deriveBillingPolicyState(input: {
     case null:
       return { kind: `${distribution}AndUnknown` }
     default:
-      return input.tier satisfies never
+      // The tier union comes from the backend spec and can gain values without
+      // a frontend change. Treating an unrecognised tier as unknown keeps that
+      // additive, at the cost of the compile-time exhaustiveness check.
+      return { kind: `${distribution}AndUnknown` }
   }
 }
 

--- a/src/platform/cloud/subscription/composables/useBillingPolicyState.ts
+++ b/src/platform/cloud/subscription/composables/useBillingPolicyState.ts
@@ -46,13 +46,23 @@ export function deriveBillingPolicyState(input: {
     case null:
       return { kind: `${distribution}AndUnknown` }
     default:
-      // The tier union comes from the backend spec and can gain values without
-      // a frontend change, so this must not be a compile error. It resolves to
-      // the restrictive state rather than Unknown: Unknown grants topUpAccess
-      // 'allowed', so an unrecognised tier would be handed paid-plan access on
-      // the strength of not being recognised. It also keeps "tier not loaded
-      // yet" (case null, above) distinguishable from "tier this build does not
-      // know", which would otherwise be the same state downstream.
+      // COMPATIBILITY FALLBACK, NOT A POLICY SIGNAL.
+      //
+      // The tier union is generated from the backend spec and can gain values
+      // without a frontend change, so this must not be a compile error. It
+      // resolves to the restrictive state rather than Unknown because Unknown
+      // grants topUpAccess 'allowed' — an unrecognised tier must not be handed
+      // paid-plan access for the sole reason that this build does not know it.
+      //
+      // It is deliberately NOT business-correct: a sales-managed tier that is
+      // genuinely active collapses to the same state as no subscription at all,
+      // so any UI keyed off this can offer subscribe/upgrade to someone who is
+      // already paying. Fail-closed on access, wrong on intent.
+      //
+      // Do not build cancellation, reactivation, pricing or upgrade decisions on
+      // this branch. Those need explicit server-sent capabilities (canOpenPricing,
+      // canChangePlan, canCancel, canReactivate) so a new tier cannot silently
+      // inherit a frontend-computed policy.
       return { kind: `${distribution}WithoutActiveSubscription` }
   }
 }

--- a/src/platform/cloud/subscription/composables/useBillingPolicyState.ts
+++ b/src/platform/cloud/subscription/composables/useBillingPolicyState.ts
@@ -47,9 +47,13 @@ export function deriveBillingPolicyState(input: {
       return { kind: `${distribution}AndUnknown` }
     default:
       // The tier union comes from the backend spec and can gain values without
-      // a frontend change. Treating an unrecognised tier as unknown keeps that
-      // additive, at the cost of the compile-time exhaustiveness check.
-      return { kind: `${distribution}AndUnknown` }
+      // a frontend change, so this must not be a compile error. It resolves to
+      // the restrictive state rather than Unknown: Unknown grants topUpAccess
+      // 'allowed', so an unrecognised tier would be handed paid-plan access on
+      // the strength of not being recognised. It also keeps "tier not loaded
+      // yet" (case null, above) distinguishable from "tier this build does not
+      // know", which would otherwise be the same state downstream.
+      return { kind: `${distribution}WithoutActiveSubscription` }
   }
 }
 

--- a/src/platform/cloud/subscription/constants/tierPricing.test.ts
+++ b/src/platform/cloud/subscription/constants/tierPricing.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+
+import type { IngestSubscriptionTier } from './tierPricing'
+import { toTierKey } from './tierPricing'
+
+describe('toTierKey', () => {
+  it('maps every personal-catalog tier to its key', () => {
+    expect(toTierKey('FREE')).toBe('free')
+    expect(toTierKey('STANDARD')).toBe('standard')
+    expect(toTierKey('CREATOR')).toBe('creator')
+    expect(toTierKey('PRO')).toBe('pro')
+    expect(toTierKey('FOUNDERS_EDITION')).toBe('founder')
+  })
+
+  it('returns null for workspace-level tiers', () => {
+    expect(toTierKey('TEAM')).toBeNull()
+  })
+
+  // The tier arrives as unvalidated JSON from the backend, so a value outside
+  // the union is reachable at runtime even though the type forbids it. It must
+  // return null rather than failing, which is what keeps a backend-side tier
+  // addition from breaking the frontend.
+  it('returns null for a tier the frontend does not know', () => {
+    expect(toTierKey('ENTERPRISE' as IngestSubscriptionTier)).toBeNull()
+  })
+
+  // hasOwnProperty rather than `in`: these are inherited from Object.prototype,
+  // so `in` would return a function or object where a TierKey is expected.
+  it.each(['constructor', 'toString', '__proto__', 'valueOf'])(
+    'returns null for the inherited property %s',
+    (key) => {
+      expect(toTierKey(key as IngestSubscriptionTier)).toBeNull()
+    }
+  )
+})

--- a/src/platform/cloud/subscription/constants/tierPricing.test.ts
+++ b/src/platform/cloud/subscription/constants/tierPricing.test.ts
@@ -26,7 +26,7 @@ describe('toTierKey', () => {
 
   // hasOwnProperty rather than `in`: these are inherited from Object.prototype,
   // so `in` would return a function or object where a TierKey is expected.
-  it.each(['constructor', 'toString', '__proto__', 'valueOf'])(
+  it.for(['constructor', 'toString', '__proto__', 'valueOf'])(
     'returns null for the inherited property %s',
     (key) => {
       expect(toTierKey(key as IngestSubscriptionTier)).toBeNull()

--- a/src/platform/cloud/subscription/constants/tierPricing.test.ts
+++ b/src/platform/cloud/subscription/constants/tierPricing.test.ts
@@ -32,4 +32,13 @@ describe('toTierKey', () => {
       expect(toTierKey(key as IngestSubscriptionTier)).toBeNull()
     }
   )
+
+  // tier is unvalidated backend JSON, so a non-string is reachable. These must
+  // return null rather than coercing to a property key or throwing.
+  it.for([[['FREE']], [{}], [null], [undefined], [42]])(
+    'returns null for the non-string value %s',
+    ([value]) => {
+      expect(toTierKey(value as unknown as IngestSubscriptionTier)).toBeNull()
+    }
+  )
 })

--- a/src/platform/cloud/subscription/constants/tierPricing.ts
+++ b/src/platform/cloud/subscription/constants/tierPricing.ts
@@ -57,11 +57,13 @@ const TIER_FEATURES: Record<TierKey, TierFeatures> = {
 export const DEFAULT_TIER_KEY: TierKey = 'standard'
 
 // Workspace-level tiers (TEAM, and any added later) map to no key in this
-// personal plan catalog. Membership is tested rather than listing the
-// exclusions, so a tier added to the ingest enum returns null instead of
-// failing the build.
+// personal plan catalog. Own-property membership is tested rather than listing
+// the exclusions, so a tier added to the ingest enum returns null instead of
+// failing the build. `in` would be wrong here: it walks the prototype chain, so
+// a runtime value of 'constructor' or 'toString' would return an inherited
+// function instead of null.
 export function toTierKey(tier: IngestSubscriptionTier): TierKey | null {
-  return tier in TIER_TO_KEY
+  return Object.prototype.hasOwnProperty.call(TIER_TO_KEY, tier)
     ? TIER_TO_KEY[tier as RegistrySubscriptionTier]
     : null
 }

--- a/src/platform/cloud/subscription/constants/tierPricing.ts
+++ b/src/platform/cloud/subscription/constants/tierPricing.ts
@@ -56,9 +56,14 @@ const TIER_FEATURES: Record<TierKey, TierFeatures> = {
 
 export const DEFAULT_TIER_KEY: TierKey = 'standard'
 
-// TEAM is workspace-level, so it maps to no key in this personal plan catalog.
+// Workspace-level tiers (TEAM, and any added later) map to no key in this
+// personal plan catalog. Membership is tested rather than listing the
+// exclusions, so a tier added to the ingest enum returns null instead of
+// failing the build.
 export function toTierKey(tier: IngestSubscriptionTier): TierKey | null {
-  return tier === 'TEAM' ? null : TIER_TO_KEY[tier]
+  return tier in TIER_TO_KEY
+    ? TIER_TO_KEY[tier as RegistrySubscriptionTier]
+    : null
 }
 
 // Includes the workspace-level TEAM, which toTierKey maps to null: a catalog

--- a/src/platform/cloud/subscription/constants/tierPricing.ts
+++ b/src/platform/cloud/subscription/constants/tierPricing.ts
@@ -63,7 +63,12 @@ export const DEFAULT_TIER_KEY: TierKey = 'standard'
 // a runtime value of 'constructor' or 'toString' would return an inherited
 // function instead of null.
 export function toTierKey(tier: IngestSubscriptionTier): TierKey | null {
-  return Object.prototype.hasOwnProperty.call(TIER_TO_KEY, tier)
+  // typeof guard first: tier is unvalidated backend JSON, so it is not
+  // necessarily a string. hasOwnProperty coerces its argument to a property
+  // key, which would accept ['FREE'] as FREE and throw on an object with a
+  // null toString.
+  return typeof tier === 'string' &&
+    Object.prototype.hasOwnProperty.call(TIER_TO_KEY, tier)
     ? TIER_TO_KEY[tier as RegistrySubscriptionTier]
     : null
 }

--- a/src/platform/cloud/subscription/constants/tierPricing.ts
+++ b/src/platform/cloud/subscription/constants/tierPricing.ts
@@ -56,21 +56,27 @@ const TIER_FEATURES: Record<TierKey, TierFeatures> = {
 
 export const DEFAULT_TIER_KEY: TierKey = 'standard'
 
-// Workspace-level tiers (TEAM, and any added later) map to no key in this
-// personal plan catalog. Own-property membership is tested rather than listing
-// the exclusions, so a tier added to the ingest enum returns null instead of
-// failing the build. `in` would be wrong here: it walks the prototype chain, so
-// a runtime value of 'constructor' or 'toString' would return an inherited
-// function instead of null.
-export function toTierKey(tier: IngestSubscriptionTier): TierKey | null {
-  // typeof guard first: tier is unvalidated backend JSON, so it is not
-  // necessarily a string. hasOwnProperty coerces its argument to a property
-  // key, which would accept ['FREE'] as FREE and throw on an object with a
-  // null toString.
-  return typeof tier === 'string' &&
+// Membership is tested rather than listing the exclusions, so a tier added to
+// the ingest enum narrows to false and returns null instead of failing the
+// build. Two details are load-bearing:
+//   - `typeof`, because tier is unvalidated backend JSON and need not be a
+//     string; hasOwnProperty coerces its argument to a property key, so
+//     ['FREE'] would be accepted as FREE and a null toString would throw.
+//   - own-property rather than `in`, which walks the prototype chain and would
+//     return an inherited function for 'constructor' or 'toString'.
+function isRegistrySubscriptionTier(
+  tier: unknown
+): tier is RegistrySubscriptionTier {
+  return (
+    typeof tier === 'string' &&
     Object.prototype.hasOwnProperty.call(TIER_TO_KEY, tier)
-    ? TIER_TO_KEY[tier as RegistrySubscriptionTier]
-    : null
+  )
+}
+
+// Workspace-level tiers (TEAM, and any added later) map to no key in this
+// personal plan catalog.
+export function toTierKey(tier: IngestSubscriptionTier): TierKey | null {
+  return isRegistrySubscriptionTier(tier) ? TIER_TO_KEY[tier] : null
 }
 
 // Includes the workspace-level TEAM, which toTierKey maps to null: a catalog


### PR DESCRIPTION
`SubscriptionTier` is generated from the backend spec, so the backend can add a tier without any frontend change. Two places assume it cannot, and both fail the build the next time one appears.

```
                      today   backend adds a tier
toTierKey             ok      ✗ TS7053  (indexes a Record of the 5 catalog tiers)
policy-state switch   ok      ✗ TS1360  (`satisfies never`)
                              ↓ with this PR
                      ok      ok  → null / AndUnknown
```

## The two spots

**`toTierKey`** listed its exclusions by hand (`tier === 'TEAM' ? null : ...`), so every future workspace-level tier had to be added there. It now tests own-property membership — the property actually wanted: *is this tier in the personal catalog?*

Own-property, not `in`: `in` walks the prototype chain, so a runtime tier of `constructor` or `toString` returned an inherited function where a `TierKey | null` is declared. Reachable because the tier arrives as unvalidated JSON.

**`useBillingPolicyState`** ended its tier switch with `satisfies never`. The `default` now returns the existing `AndUnknown` kind — the same one already used for a null tier.

## The trade-off in the second one

This gives up a compile-time exhaustiveness check. That check earns its keep when a union is owned locally; here the union is owned by a backend spec that can add values independently, so what it actually produces is a broken build in a repo that did not change.

`AndUnknown` is a real state with existing handling, not a silent fallthrough. A future tier needing distinct behaviour gets an explicit `case` then — the same work, minus the broken build.

Happy to revert this half to `satisfies never` and sequence tier additions frontend-first instead, if preferred.

## Verification

`vue-tsc --noEmit` clean on `main` today **and** with a tier appended to the generated union; without this PR that append gives 3 errors across these 2 files. 25 files / 315 tests pass.

New `tierPricing.test.ts` covers the catalog tiers, a workspace-level tier, an unknown tier and the inherited properties — the last four fail if the lookup reverts to `in`.

No behaviour change today: no tier outside the union exists yet.