### PR TITLE
fix(website): bump FDCT technologist avatar image versions

### DIFF
--- a/apps/website/src/data/fdct.ts
+++ b/apps/website/src/data/fdct.ts
@@ -24,20 +24,20 @@ export interface FdctTechnologist {
 const technologistIdentities = {
   'doug-hogan': {
     name: 'Doug Hogan',
-    avatarSrc: 'https://media.comfy.org/website/technologists/doug-hogan.png'
+    avatarSrc: 'https://media.comfy.org/website/technologists/doug-hogan_v2.png'
   },
   'chris-v': {
     name: 'Chris V.',
-    avatarSrc: 'https://media.comfy.org/website/technologists/chris-v.png'
+    avatarSrc: 'https://media.comfy.org/website/technologists/chris-v_v2.png'
   },
   'rob-losch': {
     name: 'Rob Losch',
-    avatarSrc: 'https://media.comfy.org/website/technologists/rob-losch_v2.png'
+    avatarSrc: 'https://media.comfy.org/website/technologists/rob-losch_v3.png'
   },
   'robert-paige': {
     name: 'Robert Paige',
     avatarSrc:
-      'https://media.comfy.org/website/technologists/robert-paige_v3.png'
+      'https://media.comfy.org/website/technologists/robert-paige_v4.png'
   }
 } as const
 


### PR DESCRIPTION
## Summary

Bump the avatar image versions for four technologists on the Forward Deployed Creatives (FDCT) page to their latest uploaded assets.

## Changes

- **What**: Updated `avatarSrc` for Doug Hogan (`_v2`), Chris V. (`_v2`), Rob Losch (`_v3`), and Robert Paige (`_v4`) in `apps/website/src/data/fdct.ts`.

## Review Focus

Verify each new asset URL resolves on media.comfy.org.

🤖 Generated with [Claude Code](https://claude.com/claude-code)