### PR TITLE
refactor: simplify minimap change detection

### DIFF
--- a/src/renderer/core/layout/store/layoutStore.ts
+++ b/src/renderer/core/layout/store/layoutStore.ts
@@ -179,31 +179,12 @@ class LayoutStoreImpl implements LayoutStore {
   }
 
   /**
-   * Counter bumped when the Yjs-backed node, link and reroute maps change, for
-   * use as a cache key.
-   *
-   * Scope is exactly those maps. Slot, link and reroute *geometry* live in
-   * plain Maps that are mutated without bumping this, so a cache over
-   * `updateSlotLayout`/`clearAllSlotLayouts` output cannot be keyed on it.
-   * Anything deriving node geometry from this should also read that geometry
-   * from this store, so key and data stay consistent.
-   *
-   * Local per-peer counter, not a CRDT document version: two peers holding
-   * identical layouts will hold different values, so it is not meaningful to
-   * compare across peers.
-   */
-  get layoutVersion(): number {
-    return this.version
-  }
-
-  /**
    * Counter bumped only when node geometry changes: a node is added or
    * removed, or an existing node's position, size or bounds is written.
    *
-   * `layoutVersion` counts operations, so it also moves for changes nothing
-   * renders from geometry - `setNodeZIndex` alone fires on every widget
-   * pointerdown. Consumers that rebuild geometry-derived state should key on
-   * this instead, or they repaint for edits that cannot move a pixel.
+   * The general store version also moves for changes nothing renders from
+   * geometry. Consumers that rebuild geometry-derived state should key on this
+   * instead, or they repaint for edits that cannot move a pixel.
    *
    * Backed by `observeDeep`, so it covers writes that never touch a top-level
    * key - a move mutates fields inside a node's own map - and therefore also
@@ -231,18 +212,16 @@ class LayoutStoreImpl implements LayoutStore {
     this.slotSpatialIndex = new SpatialIndexManager<SlotId>()
     this.rerouteSpatialIndex = new SpatialIndexManager<string>()
 
-    // Geometry-only counter. observeDeep because a move writes fields inside a
-    // node's own map rather than a top-level key, so `observe` never sees it,
-    // and because remote updates run no local operation handler.
+    // observeDeep covers nested node fields and remote Yjs updates.
     this.ynodes.observeDeep((events) => {
       for (const event of events) {
-        const changedKeys =
-          event.target === this.ynodes
-            ? // Whole nodes added or removed.
-              ['position']
-            : [...event.changes.keys.keys()]
+        if (event.target === this.ynodes) {
+          this._nodeGeometryVersion++
+          return
+        }
 
-        if (changedKeys.some((key) => NODE_GEOMETRY_KEYS.has(key))) {
+        for (const key of event.changes.keys.keys()) {
+          if (!NODE_GEOMETRY_KEYS.has(key)) continue
           this._nodeGeometryVersion++
           return
         }
@@ -439,6 +418,13 @@ class LayoutStoreImpl implements LayoutStore {
       }
       return result
     })
+  }
+
+  /**
+   * Get current version for reactive change detection.
+   */
+  getVersion(): ComputedRef<number> {
+    return computed(() => this.version)
   }
 
   /**

--- a/src/renderer/core/layout/types.ts
+++ b/src/renderer/core/layout/types.ts
@@ -271,13 +271,6 @@ export interface LayoutChange {
 export interface LayoutStore {
   /** Node count, without materialising layouts as `getAllNodes()` does. */
   readonly nodeCount: number
-  /**
-   * Cache key for derived structures; see the implementation for its scope.
-   *
-   * Plain numbers on a non-reactive class instance: reading either inside a
-   * `computed` or `watch` tracks nothing and never re-evaluates. Poll them.
-   */
-  readonly layoutVersion: number
   /** Cache key for geometry-derived state; moves only when nodes move. */
   readonly nodeGeometryVersion: number
 
@@ -285,6 +278,7 @@ export interface LayoutStore {
   getNodeLayoutRef(nodeId: NodeId): Ref<NodeLayout | null>
   getNodesInBounds(bounds: Bounds): ComputedRef<NodeId[]>
   getAllNodes(): ComputedRef<ReadonlyMap<NodeId, NodeLayout>>
+  getVersion(): ComputedRef<number>
 
   // Spatial queries (non-reactive)
   queryNodeAtPoint(point: Point): NodeId | null

--- a/src/renderer/extensions/minimap/MiniMap.vue
+++ b/src/renderer/extensions/minimap/MiniMap.vue
@@ -1,7 +1,6 @@
 <template>
   <div
     v-if="visible && initialized"
-    ref="minimapRef"
     :class="
       cn(
         'minimap-main-container absolute right-0 bottom-[54px] z-1000 flex',
@@ -84,7 +83,7 @@
 
 <script setup lang="ts">
 import { breakpointsTailwind, useBreakpoints } from '@vueuse/core'
-import { onMounted, onUnmounted, ref, useTemplateRef } from 'vue'
+import { onUnmounted, ref, useTemplateRef } from 'vue'
 
 import Button from '@/components/ui/button/Button.vue'
 import { useMinimap } from '@/renderer/extensions/minimap/composables/useMinimap'
@@ -96,7 +95,6 @@ import MiniMapPanel from './MiniMapPanel.vue'
 const isMobile = useBreakpoints(breakpointsTailwind).smaller('md')
 
 const commandStore = useCommandStore()
-const minimapRef = ref<HTMLDivElement>()
 const containerRef = useTemplateRef<HTMLDivElement>('containerRef')
 const canvasRef = useTemplateRef<HTMLCanvasElement>('canvasRef')
 
@@ -119,8 +117,7 @@ const {
   handlePointerMove,
   handlePointerUp,
   handlePointerCancel,
-  handleWheel,
-  setMinimapRef
+  handleWheel
 } = useMinimap({
   containerRefMaybe: containerRef,
   canvasRefMaybe: canvasRef
@@ -131,12 +128,6 @@ const showOptionsPanel = ref(false)
 const toggleOptionsPanel = () => {
   showOptionsPanel.value = !showOptionsPanel.value
 }
-
-onMounted(() => {
-  if (minimapRef.value) {
-    setMinimapRef(minimapRef.value)
-  }
-})
 
 onUnmounted(() => {
   destroy()

--- a/src/renderer/extensions/minimap/composables/useMinimap.intervalLifecycle.test.ts
+++ b/src/renderer/extensions/minimap/composables/useMinimap.intervalLifecycle.test.ts
@@ -22,14 +22,7 @@ const mockGraph = {
   _nodes: mockNodes,
   links: createMockLinks([]),
   getNodeById: vi.fn((id: string) => mockNodes.find((n) => n.id === id)),
-  setDirtyCanvas: vi.fn(),
-  onNodeAdded: null,
-  onNodeRemoved: null,
-  onConnectionChange: null,
-  events: {
-    addEventListener: vi.fn(),
-    removeEventListener: vi.fn()
-  }
+  setDirtyCanvas: vi.fn()
 }
 
 const mockCanvas = {
@@ -54,14 +47,6 @@ vi.mock('@/stores/workspace/colorPaletteStore', () => ({
   useColorPaletteStore: vi.fn(() => ({
     completedActivePalette: { light_theme: false }
   }))
-}))
-
-vi.mock('@/scripts/api', () => ({
-  api: {
-    addEventListener: vi.fn(),
-    removeEventListener: vi.fn(),
-    apiURL: vi.fn().mockReturnValue('http://localhost:8188')
-  }
 }))
 
 vi.mock('@/scripts/app', () => ({
@@ -127,8 +112,6 @@ describe('useMinimap change-detection interval', () => {
   })
 
   afterEach(() => {
-    // The graph is module scope and each init() layers another set of wrappers
-    // onto its callbacks, so tear down before the next test builds its own.
     active?.destroy()
     active = null
     vi.useRealTimers()
@@ -202,31 +185,6 @@ describe('useMinimap change-detection interval', () => {
     } finally {
       visibility.mockRestore()
     }
-  })
-
-  it('a graphChanged event with nothing drawn changed does not repaint', async () => {
-    // graphChanged fires for zIndex (every widget pointerdown), widget values
-    // and title edits. The event is a hint to compare digests, not a command
-    // to repaint.
-    const { api } = await import('@/scripts/api')
-    await initMinimap()
-    await vi.advanceTimersByTimeAsync(POLL_MS + 10)
-    const settled = drawCalls()
-
-    const graphChangedHandler = vi
-      .mocked(api.addEventListener)
-      .mock.calls.find(([name]) => name === 'graphChanged')?.[1] as () => void
-    expect(graphChangedHandler).toBeTypeOf('function')
-
-    graphChangedHandler()
-    await vi.advanceTimersByTimeAsync(POLL_MS * 6)
-    expect(drawCalls()).toBe(settled)
-
-    // The same path must still repaint when the picture did change.
-    moveNode()
-    graphChangedHandler()
-    await vi.advanceTimersByTimeAsync(POLL_MS + 10)
-    expect(drawCalls()).toBeGreaterThan(settled)
   })
 
   it('starts polling when the canvas mounts after init', async () => {

--- a/src/renderer/extensions/minimap/composables/useMinimap.test.ts
+++ b/src/renderer/extensions/minimap/composables/useMinimap.test.ts
@@ -18,16 +18,18 @@ interface MockNode {
 
 interface MockGraph {
   _nodes: MockNode[]
-  links: Map<string, { id: string; target_id: string }>
+  links: Map<
+    string,
+    {
+      id: string
+      origin_id: string
+      target_id: string
+      origin_slot: number
+      target_slot: number
+    }
+  >
   getNodeById: Mock
   setDirtyCanvas: Mock
-  onNodeAdded: ((node: MockNode) => void) | null
-  onNodeRemoved: ((node: MockNode) => void) | null
-  onConnectionChange: ((node: MockNode) => void) | null
-  events: {
-    addEventListener: Mock
-    removeEventListener: Mock
-  }
 }
 
 interface MockCanvas {
@@ -115,11 +117,6 @@ vi.mock('@vueuse/core', () => {
           callback()
         })
       }
-    }),
-    useThrottleFn: vi.fn((callback) => {
-      return (...args: unknown[]) => {
-        return callback(...args)
-      }
     })
   }
 })
@@ -152,16 +149,20 @@ const setupMocks = () => {
 
   moduleMockGraph = {
     _nodes: mockNodes,
-    links: new Map([['link1', { id: 'link1', target_id: 'node2' }]]),
+    links: new Map([
+      [
+        'link1',
+        {
+          id: 'link1',
+          origin_id: 'node1',
+          target_id: 'node2',
+          origin_slot: 0,
+          target_slot: 0
+        }
+      ]
+    ]),
     getNodeById: vi.fn((id) => mockNodes.find((n) => n.id === id)),
-    setDirtyCanvas: vi.fn(),
-    onNodeAdded: null,
-    onNodeRemoved: null,
-    onConnectionChange: null,
-    events: {
-      addEventListener: vi.fn(),
-      removeEventListener: vi.fn()
-    }
+    setDirtyCanvas: vi.fn()
   }
 
   moduleMockCanvas = {
@@ -211,14 +212,6 @@ vi.mock('@/stores/workspace/colorPaletteStore', () => ({
   }))
 }))
 
-vi.mock('@/scripts/api', () => ({
-  api: {
-    addEventListener: vi.fn(),
-    removeEventListener: vi.fn(),
-    apiURL: vi.fn().mockReturnValue('http://localhost:8188')
-  }
-}))
-
 vi.mock('@/scripts/app', () => ({
   app: {
     canvas: {
@@ -240,7 +233,6 @@ vi.mock('@/stores/executionStore', () => ({
 }))
 
 import { useMinimap } from '@/renderer/extensions/minimap/composables/useMinimap'
-import { api } from '@/scripts/api'
 
 describe('useMinimap', () => {
   let moduleMockCanvasElement: HTMLCanvasElement
@@ -310,16 +302,20 @@ describe('useMinimap', () => {
 
     moduleMockGraph = {
       _nodes: mockNodes,
-      links: new Map([['link1', { id: 'link1', target_id: 'node2' }]]),
+      links: new Map([
+        [
+          'link1',
+          {
+            id: 'link1',
+            origin_id: 'node1',
+            target_id: 'node2',
+            origin_slot: 0,
+            target_slot: 0
+          }
+        ]
+      ]),
       getNodeById: vi.fn((id) => mockNodes.find((n) => n.id === id)),
-      setDirtyCanvas: vi.fn(),
-      onNodeAdded: null,
-      onNodeRemoved: null,
-      onConnectionChange: null,
-      events: {
-        addEventListener: vi.fn(),
-        removeEventListener: vi.fn()
-      }
+      setDirtyCanvas: vi.fn()
     }
 
     moduleMockCanvas = {
@@ -376,10 +372,6 @@ describe('useMinimap', () => {
       expect(defaultSettingStore.get).toHaveBeenCalledWith(
         'Comfy.Minimap.Visible'
       )
-      expect(api.addEventListener).toHaveBeenCalledWith(
-        'graphChanged',
-        expect.any(Function)
-      )
 
       if (minimap.visible.value) {
         expect(mockResume).toHaveBeenCalled()
@@ -394,19 +386,8 @@ describe('useMinimap', () => {
       await minimap.init()
 
       expect(minimap.initialized.value).toBe(false)
-      expect(api.addEventListener).not.toHaveBeenCalled()
 
       defaultCanvasStore.canvas = originalCanvas
-    })
-
-    it('should setup event listeners on graph', async () => {
-      const minimap = await createAndInitializeMinimap()
-
-      await minimap.init()
-
-      expect(moduleMockGraph.onNodeAdded).toBeDefined()
-      expect(moduleMockGraph.onNodeRemoved).toBeDefined()
-      expect(moduleMockGraph.onConnectionChange).toBeDefined()
     })
 
     it('should handle visibility from settings', async () => {
@@ -431,37 +412,8 @@ describe('useMinimap', () => {
       // detection. One spy each, or deleting either pause here goes unnoticed.
       expect(mockPause).toHaveBeenCalled()
       expect(mockIntervalPause).toHaveBeenCalled()
-      expect(api.removeEventListener).toHaveBeenCalledWith(
-        'graphChanged',
-        expect.any(Function)
-      )
       expect(window.removeEventListener).toHaveBeenCalled()
       expect(minimap.initialized.value).toBe(false)
-    })
-
-    it('should restore original graph callbacks', async () => {
-      const originalCallbacks = {
-        onNodeAdded: vi.fn(),
-        onNodeRemoved: vi.fn(),
-        onConnectionChange: vi.fn()
-      }
-
-      moduleMockGraph.onNodeAdded = originalCallbacks.onNodeAdded
-      moduleMockGraph.onNodeRemoved = originalCallbacks.onNodeRemoved
-      moduleMockGraph.onConnectionChange = originalCallbacks.onConnectionChange
-
-      const minimap = await createAndInitializeMinimap()
-
-      await minimap.init()
-      minimap.destroy()
-
-      expect(moduleMockGraph.onNodeAdded).toBe(originalCallbacks.onNodeAdded)
-      expect(moduleMockGraph.onNodeRemoved).toBe(
-        originalCallbacks.onNodeRemoved
-      )
-      expect(moduleMockGraph.onConnectionChange).toBe(
-        originalCallbacks.onConnectionChange
-      )
     })
   })
 
@@ -895,56 +847,6 @@ describe('useMinimap', () => {
     })
   })
 
-  describe('graph change handling', () => {
-    it('should handle node addition', async () => {
-      const minimap = await createAndInitializeMinimap()
-
-      await minimap.init()
-
-      const newNode = {
-        id: 'node3',
-        pos: [300, 200],
-        size: [100, 100],
-        constructor: { color: '#666' },
-        outputs: []
-      }
-
-      moduleMockGraph._nodes.push(newNode)
-      if (moduleMockGraph.onNodeAdded) {
-        moduleMockGraph.onNodeAdded(newNode)
-      }
-
-      await new Promise((resolve) => setTimeout(resolve, 600))
-    })
-
-    it('should handle node removal', async () => {
-      const minimap = await createAndInitializeMinimap()
-
-      await minimap.init()
-
-      const removedNode = moduleMockGraph._nodes[0]
-      moduleMockGraph._nodes.splice(0, 1)
-
-      if (moduleMockGraph.onNodeRemoved) {
-        moduleMockGraph.onNodeRemoved(removedNode)
-      }
-
-      await new Promise((resolve) => setTimeout(resolve, 600))
-    })
-
-    it('should handle connection changes', async () => {
-      const minimap = await createAndInitializeMinimap()
-
-      await minimap.init()
-
-      if (moduleMockGraph.onConnectionChange) {
-        moduleMockGraph.onConnectionChange(moduleMockGraph._nodes[0])
-      }
-
-      await new Promise((resolve) => setTimeout(resolve, 600))
-    })
-  })
-
   describe('container styles', () => {
     it('should provide correct container styles for dark theme', () => {
       const minimap = useMinimap()
@@ -997,17 +899,6 @@ describe('useMinimap', () => {
 
       expect(mockContext2D.fillRect).toHaveBeenCalled()
       expect(mockContext2D.fillStyle).toBeDefined()
-    })
-  })
-
-  describe('setMinimapRef', () => {
-    it('should set minimap reference', () => {
-      const minimap = useMinimap()
-      const ref = document.createElement('div')
-
-      minimap.setMinimapRef(ref)
-
-      expect(() => minimap.setMinimapRef(ref)).not.toThrow()
     })
   })
 })

--- a/src/renderer/extensions/minimap/composables/useMinimap.ts
+++ b/src/renderer/extensions/minimap/composables/useMinimap.ts
@@ -28,7 +28,6 @@ export function useMinimap({
   const workflowStore = useWorkflowStore()
   const settingStore = useSettingStore()
 
-  const minimapRef = ref<HTMLElement | null>(null)
   const canvasRef = canvasRefMaybe ?? shallowRef(null)
   const containerRef = containerRefMaybe ?? shallowRef(null)
 
@@ -57,12 +56,6 @@ export function useMinimap({
     panelStyles
   } = settings
 
-  const updateOption = async (key: MinimapSettingsKey, value: boolean) => {
-    await settingStore.set(key, value)
-    renderer.forceFullRedraw()
-    renderer.updateMinimap(viewport.updateBounds, viewport.updateViewport)
-  }
-
   // Viewport management
   const viewport = useMinimapViewport(canvas, graph, width, height)
 
@@ -82,18 +75,7 @@ export function useMinimap({
   // a full layout-map rebuild, so every path that redraws checks this first.
   const canDraw = computed(() => visible.value && !!canvasRef.value)
 
-  // Graph events are hints to compare the digests, not commands to repaint:
-  // graphChanged fires for plenty the minimap does not draw (zIndex from every
-  // widget pointerdown, widget values, title edits), and the digest is the one
-  // place that knows whether the picture moved.
-  const checkAndRepaint = () => {
-    if (!canDraw.value) return
-    if (graphManager.checkForChanges()) {
-      renderer.updateMinimap(viewport.updateBounds, viewport.updateViewport)
-    }
-  }
-
-  const graphManager = useMinimapGraph(graph, () => checkAndRepaint())
+  const changeDetector = useMinimapGraph(graph)
 
   // Rendering
   const renderer = useMinimapRenderer(
@@ -101,34 +83,35 @@ export function useMinimap({
     graph,
     viewport.bounds,
     viewport.scale,
-    graphManager.updateFlags,
+    changeDetector.updateFlags,
     settings,
     width,
     height
   )
 
-  // Most edits reach the digest comparison through useMinimapGraph's event
-  // hooks. This loop is the backstop for state that emits no event at all:
-  // snapPoint mutating `_pos` elements in place, extensions assigning
-  // `node.pos[0]` directly (only `size` is Proxy-wrapped against that),
-  // `has_errors`, group drags, and execution-state transitions, which arrive
-  // in executionStore rather than as graph events. Repaints happen only when
-  // the digests move, so idle ticks cost one O(n) comparison and nothing else.
+  const checkAndRepaint = () => {
+    if (!canDraw.value) return
+    if (changeDetector.checkForChanges()) {
+      renderer.updateMinimap(viewport.updateBounds, viewport.updateViewport)
+    }
+  }
+
+  const updateOption = async (key: MinimapSettingsKey, value: boolean) => {
+    await settingStore.set(key, value)
+    if (!canDraw.value) return
+    renderer.forceFullRedraw()
+    renderer.updateMinimap(viewport.updateBounds, viewport.updateViewport)
+  }
+
+  // Some rendered state is mutated directly and emits no reliable event. A
+  // single digest poll covers every source while avoiding work on idle ticks.
   const { pause: pauseChangeDetection, resume: resumeChangeDetection } =
     useIntervalFn(checkAndRepaint, CHANGE_DETECTION_INTERVAL_MS, {
       immediate: false
     })
 
-  // Polling is derived state, not something init() decides once. init() runs
-  // synchronously from the immediate canvas watcher - before the template ref
-  // has mounted - so any start decision taken there sees canvasRef as null and
-  // the poll never starts. Deriving from the refs means the loop starts the
-  // moment the canvas mounts and stops the moment any condition lapses.
-  //
-  // Document visibility is part of the condition because rAF was suspended
-  // entirely on a hidden tab while setInterval is only clamped, and a tab that
-  // is hidden at mount (middle-click, session restore) never fires a
-  // visibilitychange to a transition-only watcher.
+  // Derive polling from current lifecycle state because init can run before the
+  // template canvas mounts. Hidden documents pause the O(n) digest scan.
   const documentVisibility = useDocumentVisibility()
   const shouldPoll = computed(
     () =>
@@ -152,8 +135,6 @@ export function useMinimap({
     visible.value = settingStore.get('Comfy.Minimap.Visible')
 
     if (canvas.value && graph.value) {
-      graphManager.init()
-
       if (containerRef.value) {
         interaction.updateContainerRect()
       }
@@ -163,6 +144,7 @@ export function useMinimap({
       window.addEventListener('scroll', interaction.updateContainerRect)
       window.addEventListener('resize', viewport.updateCanvasDimensions)
 
+      if (canDraw.value) changeDetector.checkForChanges()
       renderer.forceFullRedraw()
       renderer.updateMinimap(viewport.updateBounds, viewport.updateViewport)
       viewport.updateViewport()
@@ -175,7 +157,7 @@ export function useMinimap({
   const destroy = () => {
     pauseChangeDetection()
     viewport.stopViewportSync()
-    graphManager.destroy()
+    changeDetector.reset()
 
     window.removeEventListener('resize', interaction.updateContainerRect)
     window.removeEventListener('scroll', interaction.updateContainerRect)
@@ -188,13 +170,7 @@ export function useMinimap({
     canvas,
     async (newCanvas, oldCanvas) => {
       if (oldCanvas) {
-        graphManager.cleanupEventListeners()
-        pauseChangeDetection()
-        viewport.stopViewportSync()
-        graphManager.destroy()
-        window.removeEventListener('resize', interaction.updateContainerRect)
-        window.removeEventListener('scroll', interaction.updateContainerRect)
-        window.removeEventListener('resize', viewport.updateCanvasDimensions)
+        destroy()
       }
       if (newCanvas && !initialized.value) {
         await init()
@@ -205,13 +181,12 @@ export function useMinimap({
 
   // Watch for graph changes (e.g., when navigating to/from subgraphs)
   watch(graph, (newGraph, oldGraph) => {
-    if (newGraph && newGraph !== oldGraph) {
-      graphManager.cleanupEventListeners(oldGraph || undefined)
-      graphManager.setupEventListeners()
-      if (!canDraw.value) return
-      renderer.forceFullRedraw()
-      renderer.updateMinimap(viewport.updateBounds, viewport.updateViewport)
-    }
+    if (!newGraph || newGraph === oldGraph) return
+    changeDetector.reset()
+    if (!canDraw.value) return
+    changeDetector.checkForChanges()
+    renderer.forceFullRedraw()
+    renderer.updateMinimap(viewport.updateBounds, viewport.updateViewport)
   })
 
   watch(visible, async (isVisible) => {
@@ -221,6 +196,7 @@ export function useMinimap({
       }
       viewport.updateCanvasDimensions()
 
+      changeDetector.checkForChanges()
       renderer.forceFullRedraw()
 
       await nextTick()
@@ -237,10 +213,6 @@ export function useMinimap({
   const toggle = async () => {
     visible.value = !visible.value
     await settingStore.set('Comfy.Minimap.Visible', visible.value)
-  }
-
-  const setMinimapRef = (ref: HTMLElement | null) => {
-    minimapRef.value = ref
   }
 
   // Dynamic viewport styles based on actual viewport transform
@@ -284,7 +256,6 @@ export function useMinimap({
     handlePointerUp: interaction.handlePointerUp,
     handlePointerCancel: interaction.handlePointerCancel,
     handleWheel: interaction.handleWheel,
-    setMinimapRef,
     updateOption
   }
 }

--- a/src/renderer/extensions/minimap/composables/useMinimapGraph.test.ts
+++ b/src/renderer/extensions/minimap/composables/useMinimapGraph.test.ts
@@ -1,26 +1,17 @@
-import { useThrottleFn } from '@vueuse/core'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { ref } from 'vue'
-import type { Ref } from 'vue'
+import { shallowRef } from 'vue'
 
-import { CustomEventTarget } from '@/lib/litegraph/src/infrastructure/CustomEventTarget'
-import type { LGraphEventMap } from '@/lib/litegraph/src/infrastructure/LGraphEventMap'
 import type { LGraph, LGraphNode } from '@/lib/litegraph/src/litegraph'
 import { toLinkId } from '@/types/linkId'
 import { toNodeId } from '@/types/nodeId'
 import { useLayoutMutations } from '@/renderer/core/layout/operations/layoutMutations'
 import { useMinimapGraph } from '@/renderer/extensions/minimap/composables/useMinimapGraph'
-import { api } from '@/scripts/api'
 import {
   createMockLGraph,
   createMockLGraphNode,
   createMockLLink,
   createMockLinks
 } from '@/utils/__tests__/litegraphTestUtils'
-
-vi.mock('@vueuse/core', () => ({
-  useThrottleFn: vi.fn((fn) => fn)
-}))
 
 const { mockProgressStates } = vi.hoisted(() => ({
   mockProgressStates: {} as Record<string, { state: string }>
@@ -32,16 +23,8 @@ vi.mock('@/stores/executionStore', () => ({
   }))
 }))
 
-vi.mock('@/scripts/api', () => ({
-  api: {
-    addEventListener: vi.fn(),
-    removeEventListener: vi.fn()
-  }
-}))
-
 describe('useMinimapGraph', () => {
   let mockGraph: LGraph
-  let onGraphChangedMock: () => void
 
   beforeEach(() => {
     mockGraph = createMockLGraph({
@@ -50,212 +33,20 @@ describe('useMinimapGraph', () => {
         createMockLGraphNode({ id: '1', pos: [100, 100], size: [150, 80] }),
         createMockLGraphNode({ id: '2', pos: [300, 200], size: [120, 60] })
       ],
-      links: createMockLinks([createMockLLink({ id: toLinkId(1) })]),
-      events: new CustomEventTarget<LGraphEventMap>(),
-      onNodeAdded: vi.fn(),
-      onNodeRemoved: vi.fn(),
-      onConnectionChange: vi.fn()
+      links: createMockLinks([createMockLLink({ id: toLinkId(1) })])
     })
 
-    onGraphChangedMock = vi.fn()
     for (const key of Object.keys(mockProgressStates)) {
       delete mockProgressStates[key]
     }
   })
 
-  it('should initialize with empty state', () => {
-    const graphRef = ref(mockGraph) as Ref<LGraph | null>
-    const graphManager = useMinimapGraph(graphRef, onGraphChangedMock)
-
-    expect(graphManager.updateFlags.value).toEqual({
-      bounds: false,
-      nodes: false,
-      connections: false,
-      viewport: false
-    })
-  })
-
-  it('should setup event listeners on init', () => {
-    const graphRef = ref(mockGraph) as Ref<LGraph | null>
-    const graphManager = useMinimapGraph(graphRef, onGraphChangedMock)
-
-    graphManager.init()
-
-    expect(api.addEventListener).toHaveBeenCalledWith(
-      'graphChanged',
-      expect.any(Function)
-    )
-  })
-
-  it('should wrap graph callbacks on setup', () => {
-    const originalOnNodeAdded = vi.fn()
-    const originalOnNodeRemoved = vi.fn()
-    const originalOnConnectionChange = vi.fn()
-
-    mockGraph.onNodeAdded = originalOnNodeAdded
-    mockGraph.onNodeRemoved = originalOnNodeRemoved
-    mockGraph.onConnectionChange = originalOnConnectionChange
-
-    const graphRef = ref(mockGraph) as Ref<LGraph | null>
-    const graphManager = useMinimapGraph(graphRef, onGraphChangedMock)
-
-    graphManager.setupEventListeners()
-
-    // Should wrap the callbacks
-    expect(mockGraph.onNodeAdded).not.toBe(originalOnNodeAdded)
-    expect(mockGraph.onNodeRemoved).not.toBe(originalOnNodeRemoved)
-    expect(mockGraph.onConnectionChange).not.toBe(originalOnConnectionChange)
-
-    // Test wrapped callbacks
-    const testNode = { id: '3' } as LGraphNode
-    mockGraph.onNodeAdded!(testNode)
-
-    expect(originalOnNodeAdded).toHaveBeenCalledWith(testNode)
-    expect(onGraphChangedMock).toHaveBeenCalled()
-  })
-
-  it('should prevent duplicate event listener setup', () => {
-    const graphRef = ref(mockGraph) as Ref<LGraph | null>
-    const graphManager = useMinimapGraph(graphRef, onGraphChangedMock)
-
-    graphManager.setupEventListeners()
-    const wrappedCallbacks = {
-      onNodeAdded: mockGraph.onNodeAdded,
-      onNodeRemoved: mockGraph.onNodeRemoved,
-      onConnectionChange: mockGraph.onConnectionChange
-    }
-
-    // Setup again - should not re-wrap
-    graphManager.setupEventListeners()
-
-    expect(mockGraph.onNodeAdded).toBe(wrappedCallbacks.onNodeAdded)
-    expect(mockGraph.onNodeRemoved).toBe(wrappedCallbacks.onNodeRemoved)
-    expect(mockGraph.onConnectionChange).toBe(
-      wrappedCallbacks.onConnectionChange
-    )
-  })
-
-  it('should cleanup event listeners properly', () => {
-    const originalOnNodeAdded = vi.fn()
-    const originalOnNodeRemoved = vi.fn()
-    const originalOnConnectionChange = vi.fn()
-
-    mockGraph.onNodeAdded = originalOnNodeAdded
-    mockGraph.onNodeRemoved = originalOnNodeRemoved
-    mockGraph.onConnectionChange = originalOnConnectionChange
-
-    const graphRef = ref(mockGraph) as Ref<LGraph | null>
-    const graphManager = useMinimapGraph(graphRef, onGraphChangedMock)
-
-    graphManager.setupEventListeners()
-    graphManager.cleanupEventListeners()
-
-    // Should restore original callbacks
-    expect(mockGraph.onNodeAdded).toBe(originalOnNodeAdded)
-    expect(mockGraph.onNodeRemoved).toBe(originalOnNodeRemoved)
-    expect(mockGraph.onConnectionChange).toBe(originalOnConnectionChange)
-  })
-
-  it('should handle cleanup for never-setup graph', () => {
-    const graphRef = ref(mockGraph) as Ref<LGraph | null>
-    const graphManager = useMinimapGraph(graphRef, onGraphChangedMock)
-
-    expect(() => graphManager.cleanupEventListeners()).not.toThrow()
-  })
-
-  it('cleanup leaves a later wrapper alone when one is layered on top', () => {
-    const graphRef = ref(mockGraph) as Ref<LGraph | null>
-    const graphManager = useMinimapGraph(graphRef, onGraphChangedMock)
-
-    graphManager.setupEventListeners()
-    const minimapWrapper = mockGraph.onNodeAdded
-
-    // Simulate another system adding its own wrapper on top
-    const downstream = vi.fn()
-    const layeredWrapper = vi.fn(function (this: unknown, node: LGraphNode) {
-      minimapWrapper?.call(this, node)
-      downstream(node)
-    })
-    mockGraph.onNodeAdded = layeredWrapper
-
-    graphManager.cleanupEventListeners()
-
-    // The newer wrapper must survive cleanup
-    expect(mockGraph.onNodeAdded).toBe(layeredWrapper)
-  })
-
-  it('a buried wrapper becomes inert after cleanup', () => {
-    const originalOnNodeAdded = vi.fn()
-    mockGraph.onNodeAdded = originalOnNodeAdded
-
-    const graphRef = ref(mockGraph) as Ref<LGraph | null>
-    const graphManager = useMinimapGraph(graphRef, onGraphChangedMock)
-
-    graphManager.setupEventListeners()
-    const buriedWrapper = mockGraph.onNodeAdded
-
-    // Layer something on top so cleanup can't restore.
-    mockGraph.onNodeAdded = vi.fn()
-    graphManager.cleanupEventListeners()
-    vi.mocked(onGraphChangedMock).mockClear()
-
-    // Call the method directly and ensure it is a no-op
-    const testNode = { id: '9' } as LGraphNode
-    buriedWrapper!(testNode)
-
-    expect(originalOnNodeAdded).toHaveBeenCalledWith(testNode)
-    expect(onGraphChangedMock).not.toHaveBeenCalled()
-  })
-
-  it('invalidates cache and fires update on visual property changes', () => {
-    const graphRef = ref(mockGraph) as Ref<LGraph | null>
-    const graphManager = useMinimapGraph(graphRef, onGraphChangedMock)
-    graphManager.setupEventListeners()
-
-    mockGraph.events.dispatch('node:property:changed', {
-      nodeId: '1',
-      property: 'color',
-      oldValue: '',
-      newValue: '#fff'
-    })
-
-    expect(onGraphChangedMock).toHaveBeenCalled()
-  })
-
-  it('ignores unrelated property changes', () => {
-    const graphRef = ref(mockGraph) as Ref<LGraph | null>
-    const graphManager = useMinimapGraph(graphRef, onGraphChangedMock)
-    graphManager.setupEventListeners()
-
-    mockGraph.events.dispatch('node:property:changed', {
-      nodeId: '1',
-      property: 'title',
-      oldValue: 'a',
-      newValue: 'b'
-    })
-
-    expect(onGraphChangedMock).not.toHaveBeenCalled()
-  })
-
-  it('detaches the property listener on cleanup', () => {
-    const graphRef = ref(mockGraph) as Ref<LGraph | null>
-    const graphManager = useMinimapGraph(graphRef, onGraphChangedMock)
-    graphManager.setupEventListeners()
-    graphManager.cleanupEventListeners()
-
-    mockGraph.events.dispatch('node:property:changed', {
-      nodeId: '1',
-      property: 'mode',
-      oldValue: 0,
-      newValue: 1
-    })
-
-    expect(onGraphChangedMock).not.toHaveBeenCalled()
-  })
+  function createChangeDetector(graph: LGraph | null = mockGraph) {
+    return useMinimapGraph(shallowRef<LGraph | null>(graph))
+  }
 
   it('should detect node position changes', () => {
-    const graphRef = ref(mockGraph) as Ref<LGraph | null>
-    const graphManager = useMinimapGraph(graphRef, onGraphChangedMock)
+    const graphManager = createChangeDetector()
 
     // First check - cache initial state
     let hasChanges = graphManager.checkForChanges()
@@ -274,8 +65,7 @@ describe('useMinimapGraph', () => {
   })
 
   it('should detect node count changes', () => {
-    const graphRef = ref(mockGraph) as Ref<LGraph | null>
-    const graphManager = useMinimapGraph(graphRef, onGraphChangedMock)
+    const graphManager = createChangeDetector()
 
     // Cache initial state
     graphManager.checkForChanges()
@@ -294,8 +84,7 @@ describe('useMinimapGraph', () => {
   })
 
   it('should detect connection changes', () => {
-    const graphRef = ref(mockGraph) as Ref<LGraph | null>
-    const graphManager = useMinimapGraph(graphRef, onGraphChangedMock)
+    const graphManager = createChangeDetector()
 
     // Cache initial state
     graphManager.checkForChanges()
@@ -320,8 +109,7 @@ describe('useMinimapGraph', () => {
       })
     ])
 
-    const graphRef = ref(mockGraph) as Ref<LGraph | null>
-    const graphManager = useMinimapGraph(graphRef, onGraphChangedMock)
+    const graphManager = createChangeDetector()
 
     graphManager.checkForChanges()
     expect(graphManager.checkForChanges()).toBe(false)
@@ -339,9 +127,33 @@ describe('useMinimapGraph', () => {
     expect(graphManager.updateFlags.value.connections).toBe(true)
   })
 
+  it('detects a rewire between nonnumeric node IDs', () => {
+    mockGraph.links = createMockLinks([
+      createMockLLink({
+        id: toLinkId(1),
+        origin_id: toNodeId('source'),
+        target_id: toNodeId('target-a')
+      })
+    ])
+
+    const graphManager = createChangeDetector()
+
+    graphManager.checkForChanges()
+    expect(graphManager.checkForChanges()).toBe(false)
+
+    mockGraph.links = createMockLinks([
+      createMockLLink({
+        id: toLinkId(1),
+        origin_id: toNodeId('source'),
+        target_id: toNodeId('target-b')
+      })
+    ])
+
+    expect(graphManager.checkForChanges()).toBe(true)
+  })
+
   it('keeps reporting no change while the graph is untouched', () => {
-    const graphRef = ref(mockGraph) as Ref<LGraph | null>
-    const graphManager = useMinimapGraph(graphRef, onGraphChangedMock)
+    const graphManager = createChangeDetector()
 
     graphManager.checkForChanges()
 
@@ -357,8 +169,7 @@ describe('useMinimapGraph', () => {
       createMockLGraphNode({ id: '3', pos: [Number.NaN, 0], size: [10, 10] })
     )
 
-    const graphRef = ref(mockGraph) as Ref<LGraph | null>
-    const graphManager = useMinimapGraph(graphRef, onGraphChangedMock)
+    const graphManager = createChangeDetector()
 
     graphManager.checkForChanges()
     expect(graphManager.checkForChanges()).toBe(false)
@@ -374,8 +185,7 @@ describe('useMinimapGraph', () => {
       size: { width: 150, height: 80 }
     })
 
-    const graphRef = ref(mockGraph) as Ref<LGraph | null>
-    const graphManager = useMinimapGraph(graphRef, onGraphChangedMock)
+    const graphManager = createChangeDetector()
 
     graphManager.checkForChanges()
     expect(graphManager.checkForChanges()).toBe(false)
@@ -393,8 +203,7 @@ describe('useMinimapGraph', () => {
       size: { width: 120, height: 60 }
     })
 
-    const graphRef = ref(mockGraph) as Ref<LGraph | null>
-    const graphManager = useMinimapGraph(graphRef, onGraphChangedMock)
+    const graphManager = createChangeDetector()
 
     graphManager.checkForChanges()
     expect(graphManager.checkForChanges()).toBe(false)
@@ -407,8 +216,7 @@ describe('useMinimapGraph', () => {
   })
 
   it('should detect a background colour change', () => {
-    const graphRef = ref(mockGraph) as Ref<LGraph | null>
-    const graphManager = useMinimapGraph(graphRef, onGraphChangedMock)
+    const graphManager = createChangeDetector()
 
     graphManager.checkForChanges()
     expect(graphManager.checkForChanges()).toBe(false)
@@ -423,8 +231,7 @@ describe('useMinimapGraph', () => {
       { pos: [0, 0], size: [400, 300], color: '#111111' }
     ] as LGraph['_groups']
 
-    const graphRef = ref(mockGraph) as Ref<LGraph | null>
-    const graphManager = useMinimapGraph(graphRef, onGraphChangedMock)
+    const graphManager = createChangeDetector()
 
     graphManager.checkForChanges()
     expect(graphManager.checkForChanges()).toBe(false)
@@ -435,8 +242,7 @@ describe('useMinimapGraph', () => {
   })
 
   it('should detect an execution-state transition', () => {
-    const graphRef = ref(mockGraph) as Ref<LGraph | null>
-    const graphManager = useMinimapGraph(graphRef, onGraphChangedMock)
+    const graphManager = createChangeDetector()
 
     graphManager.checkForChanges()
     expect(graphManager.checkForChanges()).toBe(false)
@@ -450,8 +256,7 @@ describe('useMinimapGraph', () => {
   })
 
   it('a visual-only change repaints without recomputing bounds', () => {
-    const graphRef = ref(mockGraph) as Ref<LGraph | null>
-    const graphManager = useMinimapGraph(graphRef, onGraphChangedMock)
+    const graphManager = createChangeDetector()
 
     graphManager.checkForChanges()
     graphManager.updateFlags.value.bounds = false
@@ -465,8 +270,7 @@ describe('useMinimapGraph', () => {
   })
 
   it('should detect an error-state change', () => {
-    const graphRef = ref(mockGraph) as Ref<LGraph | null>
-    const graphManager = useMinimapGraph(graphRef, onGraphChangedMock)
+    const graphManager = createChangeDetector()
 
     graphManager.checkForChanges()
     expect(graphManager.checkForChanges()).toBe(false)
@@ -477,8 +281,7 @@ describe('useMinimapGraph', () => {
   })
 
   it('should detect a mode change', () => {
-    const graphRef = ref(mockGraph) as Ref<LGraph | null>
-    const graphManager = useMinimapGraph(graphRef, onGraphChangedMock)
+    const graphManager = createChangeDetector()
 
     graphManager.checkForChanges()
     expect(graphManager.checkForChanges()).toBe(false)
@@ -489,8 +292,7 @@ describe('useMinimapGraph', () => {
   })
 
   it('should detect a fractional-only position change', () => {
-    const graphRef = ref(mockGraph) as Ref<LGraph | null>
-    const graphManager = useMinimapGraph(graphRef, onGraphChangedMock)
+    const graphManager = createChangeDetector()
 
     graphManager.checkForChanges()
     expect(graphManager.checkForChanges()).toBe(false)
@@ -505,8 +307,7 @@ describe('useMinimapGraph', () => {
       createMockLLink({ id: toLinkId(1), origin_slot: 0, target_slot: 0 })
     ])
 
-    const graphRef = ref(mockGraph) as Ref<LGraph | null>
-    const graphManager = useMinimapGraph(graphRef, onGraphChangedMock)
+    const graphManager = createChangeDetector()
 
     graphManager.checkForChanges()
     expect(graphManager.checkForChanges()).toBe(false)
@@ -520,90 +321,29 @@ describe('useMinimapGraph', () => {
     expect(graphManager.updateFlags.value.connections).toBe(true)
   })
 
-  it('should handle node removal in callbacks', () => {
-    const originalOnNodeRemoved = vi.fn()
-    mockGraph.onNodeRemoved = originalOnNodeRemoved
+  it('detects the current graph again after reset', () => {
+    const graphManager = createChangeDetector()
 
-    const graphRef = ref(mockGraph) as Ref<LGraph | null>
-    const graphManager = useMinimapGraph(graphRef, onGraphChangedMock)
-
-    graphManager.setupEventListeners()
-
-    const removedNode = { id: '2' } as LGraphNode
-    mockGraph.onNodeRemoved!(removedNode)
-
-    expect(originalOnNodeRemoved).toHaveBeenCalledWith(removedNode)
-    expect(onGraphChangedMock).toHaveBeenCalled()
-  })
-
-  it('should destroy properly', () => {
-    const graphRef = ref(mockGraph) as Ref<LGraph | null>
-    const graphManager = useMinimapGraph(graphRef, onGraphChangedMock)
-
-    graphManager.init()
-    graphManager.setupEventListeners()
-    graphManager.destroy()
-
-    expect(api.removeEventListener).toHaveBeenCalledWith(
-      'graphChanged',
-      expect.any(Function)
-    )
-  })
-
-  it('should clear cache', () => {
-    const graphRef = ref(mockGraph) as Ref<LGraph | null>
-    const graphManager = useMinimapGraph(graphRef, onGraphChangedMock)
-
-    // Populate cache
     graphManager.checkForChanges()
+    graphManager.reset()
 
-    // Clear cache
-    graphManager.clearCache()
-
-    // Should detect changes again after clear
-    const hasChanges = graphManager.checkForChanges()
-    expect(hasChanges).toBe(true)
+    expect(graphManager.checkForChanges()).toBe(true)
   })
 
-  it('should handle null graph gracefully', () => {
-    const graphRef = ref(null) as Ref<LGraph | null>
-    const graphManager = useMinimapGraph(graphRef, onGraphChangedMock)
+  it('reports no changes without a graph', () => {
+    const graphManager = createChangeDetector(null)
 
-    expect(() => graphManager.setupEventListeners()).not.toThrow()
-    expect(() => graphManager.cleanupEventListeners()).not.toThrow()
     expect(graphManager.checkForChanges()).toBe(false)
   })
 
-  it('should clean up removed nodes from cache', () => {
-    const graphRef = ref(mockGraph) as Ref<LGraph | null>
-    const graphManager = useMinimapGraph(graphRef, onGraphChangedMock)
+  it('detects node removal', () => {
+    const graphManager = createChangeDetector()
 
-    // Cache initial state
     graphManager.checkForChanges()
-
-    // Remove a node
     mockGraph._nodes = mockGraph._nodes.filter((n) => n.id !== '2')
 
     const hasChanges = graphManager.checkForChanges()
     expect(hasChanges).toBe(true)
     expect(graphManager.updateFlags.value.bounds).toBe(true)
-  })
-
-  it('should throttle graph changed callback', () => {
-    const throttledFn = vi.fn()
-    vi.mocked(useThrottleFn).mockReturnValue(throttledFn)
-
-    const graphRef = ref(mockGraph) as Ref<LGraph | null>
-    const graphManager = useMinimapGraph(graphRef, onGraphChangedMock)
-
-    graphManager.setupEventListeners()
-
-    // Trigger multiple changes rapidly
-    mockGraph.onNodeAdded!({ id: '3' } as LGraphNode)
-    mockGraph.onNodeAdded!({ id: '4' } as LGraphNode)
-    mockGraph.onNodeAdded!({ id: '5' } as LGraphNode)
-
-    // Should be throttled
-    expect(throttledFn).toHaveBeenCalledTimes(3)
   })
 })

--- a/src/renderer/extensions/minimap/composables/useMinimapGraph.ts
+++ b/src/renderer/extensions/minimap/composables/useMinimapGraph.ts
@@ -1,45 +1,21 @@
-import { useThrottleFn } from '@vueuse/core'
 import { ref } from 'vue'
 import type { Ref } from 'vue'
 
-import { useChainCallback } from '@/composables/functional/useChainCallback'
-import type { LGraphEventMap } from '@/lib/litegraph/src/infrastructure/LGraphEventMap'
-import type { LGraph, LGraphNode } from '@/lib/litegraph/src/litegraph'
+import type { LGraph } from '@/lib/litegraph/src/litegraph'
 import { layoutStore } from '@/renderer/core/layout/store/layoutStore'
-import { api } from '@/scripts/api'
+import type { NodeProgressState } from '@/schemas/apiSchema'
 import { useExecutionStore } from '@/stores/executionStore'
 
 import type { UpdateFlags } from '../types'
 
-interface GraphCallbacks {
-  onNodeAdded?: (node: LGraphNode) => void
-  onNodeRemoved?: (node: LGraphNode) => void
-  onConnectionChange?: (node: LGraphNode) => void
-}
-
-/**
- * Fixed-point quantisation for digest input, at eighth-pixel precision.
- * Mixing raw values would truncate at each `| 0`, so a drag or resize that
- * only changes the fractional part would leave the digest unchanged.
- */
 function quantise(value: number): number {
   return Math.round(value * 8)
 }
 
-/**
- * Mixes one term into a rolling digest.
- *
- * The coercion is on the term, not the sum: `(digest + NaN) | 0` is 0, which
- * would discard every node mixed in so far and make an unrelated change
- * invisible for as long as the non-finite value stays in the graph.
- */
 function mixIn(digest: number, value: number): number {
   return (Math.imul(digest, 31) + (Number.isFinite(value) ? value : 0)) | 0
 }
 
-/**
- * Cheap string hash for digest input (colors, execution states).
- */
 function hashString(value: string): number {
   let hash = value.length
   for (let i = 0; i < value.length; i++) {
@@ -48,28 +24,25 @@ function hashString(value: string): number {
   return hash
 }
 
-interface GraphDigests {
-  /** Node placement: drives bounds recomputation as well as repaint. */
+interface MinimapDigests {
   geometry: number
-  /** Everything else the renderer draws: repaint only, bounds untouched. */
   visual: number
+  connections: number
 }
 
 /**
- * Rolling digests over everything the minimap renders, in one allocation-free
- * pass. The digests are the single authority on "did the picture change":
- * event hooks and the poll are only signals to compare them, so any input the
- * renderer reads has to be mixed in here or changes to it stop repainting.
- *
- * Digests can in principle collide, which would drop a single refresh -
- * acceptable for an approximate overview, and the next change re-syncs it.
+ * Digests every value rendered by the minimap without allocating per-node
+ * cache entries. Geometry is separate because only it invalidates bounds.
  */
-function computeGraphDigests(graph: LGraph): GraphDigests {
-  // Store-side geometry: the renderer reads layoutStore whenever it holds
-  // nodes, so a write whose write-back to the litegraph node has not landed
-  // must still count. Geometry version, not layoutVersion - that counts
-  // operations, and zIndex alone fires one per widget pointerdown.
-  let geometry = mixIn(layoutStore.nodeGeometryVersion, graph._nodes.length)
+function computeMinimapDigests(
+  graph: LGraph,
+  nodeGeometryVersion: number,
+  progressStates: Readonly<Record<string, NodeProgressState>>
+): MinimapDigests {
+  // The renderer prefers LayoutStore geometry, which can update before the
+  // corresponding LiteGraph node. The geometry-only version closes that gap
+  // without repainting for unrelated store operations such as z-index changes.
+  let geometry = mixIn(nodeGeometryVersion, graph._nodes.length)
   let visual = 0
 
   for (const node of graph._nodes) {
@@ -92,11 +65,6 @@ function computeGraphDigests(graph: LGraph): GraphDigests {
     visual = mixIn(visual, group.color ? hashString(group.color) : 0)
   }
 
-  // Execution state is drawn as discrete outline colors, so mixing the state
-  // strings repaints exactly on transitions. Progress percentages are not
-  // rendered, which is what lets the per-progress-message watcher go: the
-  // poll picks up each transition within one tick at no per-message cost.
-  const progressStates = useExecutionStore().nodeProgressStates
   for (const nodeId in progressStates) {
     const state = progressStates[nodeId]?.state
     if (!state) continue
@@ -104,42 +72,28 @@ function computeGraphDigests(graph: LGraph): GraphDigests {
     visual = mixIn(visual, hashString(state))
   }
 
-  return { geometry, visual }
+  const links = graph.links
+  let connections = 0
+  if (links) {
+    for (const link of links.values()) {
+      if (!link) continue
+      connections = mixIn(connections, hashString(link.origin_id))
+      connections = mixIn(connections, hashString(link.target_id))
+      connections = mixIn(connections, link.origin_slot)
+      connections = mixIn(connections, link.target_slot)
+    }
+  }
+
+  return { geometry, visual, connections }
 }
 
 /**
- * Rolling digest of link endpoints and slots. Counting links alone would miss
- * a rewire that keeps the total unchanged, and endpoints alone would miss a
- * link moved to a different slot on the same pair of nodes.
+ * Tracks the graph state relevant to minimap rendering. Call `checkForChanges`
+ * from the owner's scheduler and `reset` when switching graphs.
  */
-function computeLinkDigest(graph: LGraph): number {
-  const links = graph.links
-  if (!links) return 0
-
-  let digest = 0
-  for (const link of links.values()) {
-    if (!link) continue
-    // Node ids are branded strings and need not be numeric; non-numeric ones
-    // contribute 0 here and are caught instead by the onConnectionChange hook.
-    digest = mixIn(digest, Number(link.origin_id))
-    digest = mixIn(digest, Number(link.target_id))
-    digest = mixIn(digest, link.origin_slot)
-    digest = mixIn(digest, link.target_slot)
-  }
-
-  return digest
-}
-
-export function useMinimapGraph(
-  graph: Ref<LGraph | null>,
-  onGraphChanged: () => void
-) {
-  // Null rather than a numeric sentinel: 0 is a digest these functions produce
-  // for an empty graph, so a numeric "no baseline" would be indistinguishable
-  // from a real first reading.
-  let geometryDigest: number | null = null
-  let visualDigest: number | null = null
-  let linkDigest: number | null = null
+export function useMinimapGraph(graph: Ref<LGraph | null>) {
+  const executionStore = useExecutionStore()
+  let previousDigests: MinimapDigests | null = null
   const updateFlags = ref<UpdateFlags>({
     bounds: false,
     nodes: false,
@@ -147,120 +101,22 @@ export function useMinimapGraph(
     viewport: false
   })
 
-  // Cleanup restores originals only when our wrapper is still on top, and
-  // marks any buried wrapper inert via `entry.live` so it can't fire dead work.
-  interface InstalledHooks {
-    originals: GraphCallbacks
-    wrappers: GraphCallbacks
-    live: boolean
-    onPropertyChanged: (
-      e: CustomEvent<LGraphEventMap['node:property:changed']>
-    ) => void
-  }
-  const hooksMap = new Map<string, InstalledHooks>()
-
-  const handleGraphChangedThrottled = useThrottleFn(() => {
-    onGraphChanged()
-  }, 500)
-
-  const setupEventListeners = () => {
-    const g = graph.value
-    if (!g || hooksMap.has(g.id)) return
-
-    const originals: GraphCallbacks = {
-      onNodeAdded: g.onNodeAdded,
-      onNodeRemoved: g.onNodeRemoved,
-      onConnectionChange: g.onConnectionChange
-    }
-    const wrappers: GraphCallbacks = {}
-
-    const onPropertyChanged = (
-      e: CustomEvent<LGraphEventMap['node:property:changed']>
-    ) => {
-      const { property } = e.detail
-      if (
-        property === 'mode' ||
-        property === 'bgcolor' ||
-        property === 'color'
-      ) {
-        void handleGraphChangedThrottled()
-      }
-    }
-
-    const entry: InstalledHooks = {
-      originals,
-      wrappers,
-      live: true,
-      onPropertyChanged
-    }
-    hooksMap.set(g.id, entry)
-
-    wrappers.onNodeAdded = useChainCallback(originals.onNodeAdded, function () {
-      if (!entry.live) return
-      void handleGraphChangedThrottled()
-    })
-    g.onNodeAdded = wrappers.onNodeAdded
-
-    wrappers.onNodeRemoved = useChainCallback(
-      originals.onNodeRemoved,
-      function () {
-        if (!entry.live) return
-        void handleGraphChangedThrottled()
-      }
-    )
-    g.onNodeRemoved = wrappers.onNodeRemoved
-
-    wrappers.onConnectionChange = useChainCallback(
-      originals.onConnectionChange,
-      function () {
-        if (!entry.live) return
-        void handleGraphChangedThrottled()
-      }
-    )
-    g.onConnectionChange = wrappers.onConnectionChange
-
-    g.events.addEventListener('node:property:changed', onPropertyChanged)
-  }
-
-  const cleanupEventListeners = (oldGraph?: LGraph) => {
-    const g = oldGraph || graph.value
-    if (!g) return
-    const entry = hooksMap.get(g.id)
-    if (!entry) return
-    const { originals, wrappers } = entry
-
-    if (g.onNodeAdded === wrappers.onNodeAdded)
-      g.onNodeAdded = originals.onNodeAdded
-    if (g.onNodeRemoved === wrappers.onNodeRemoved)
-      g.onNodeRemoved = originals.onNodeRemoved
-    if (g.onConnectionChange === wrappers.onConnectionChange)
-      g.onConnectionChange = originals.onConnectionChange
-    g.events.removeEventListener(
-      'node:property:changed',
-      entry.onPropertyChanged
-    )
-
-    entry.live = false
-    hooksMap.delete(g.id)
-  }
-
-  const checkForChangesInternal = () => {
+  const checkForChanges = () => {
     const g = graph.value
     if (!g) return false
 
-    const { geometry, visual } = computeGraphDigests(g)
-    const links = computeLinkDigest(g)
+    const currentDigests = computeMinimapDigests(
+      g,
+      layoutStore.nodeGeometryVersion,
+      executionStore.nodeProgressStates
+    )
+    const geometryChanged =
+      currentDigests.geometry !== previousDigests?.geometry
+    const visualChanged = currentDigests.visual !== previousDigests?.visual
+    const connectionChanged =
+      currentDigests.connections !== previousDigests?.connections
+    previousDigests = currentDigests
 
-    const geometryChanged = geometry !== geometryDigest
-    const visualChanged = visual !== visualDigest
-    const connectionChanged = links !== linkDigest
-
-    geometryDigest = geometry
-    visualDigest = visual
-    linkDigest = links
-
-    // Only geometry moves the graph's extent; a recolour, group drag or
-    // execution transition repaints without recomputing bounds.
     if (geometryChanged) {
       updateFlags.value.bounds = true
     }
@@ -274,30 +130,13 @@ export function useMinimapGraph(
     return geometryChanged || visualChanged || connectionChanged
   }
 
-  const init = () => {
-    setupEventListeners()
-    api.addEventListener('graphChanged', handleGraphChangedThrottled)
-  }
-
-  const destroy = () => {
-    cleanupEventListeners()
-    api.removeEventListener('graphChanged', handleGraphChangedThrottled)
-    clearCache()
-  }
-
-  const clearCache = () => {
-    geometryDigest = null
-    visualDigest = null
-    linkDigest = null
+  const reset = () => {
+    previousDigests = null
   }
 
   return {
     updateFlags,
-    setupEventListeners,
-    cleanupEventListeners,
-    checkForChanges: checkForChangesInternal,
-    init,
-    destroy,
-    clearCache
+    checkForChanges,
+    reset
   }
 }

--- a/src/renderer/extensions/minimap/data/AbstractMinimapDataSource.ts
+++ b/src/renderer/extensions/minimap/data/AbstractMinimapDataSource.ts
@@ -22,7 +22,6 @@ export abstract class AbstractMinimapDataSource implements IMinimapDataSource {
   /** Builds the node list. Called at most once per data source instance. */
   protected abstract buildNodes(): MinimapNodeData[]
 
-  abstract getNodeCount(): number
   abstract hasData(): boolean
 
   /**

--- a/src/renderer/extensions/minimap/data/LayoutStoreDataSource.ts
+++ b/src/renderer/extensions/minimap/data/LayoutStoreDataSource.ts
@@ -44,11 +44,7 @@ export class LayoutStoreDataSource extends AbstractMinimapDataSource {
     return nodes
   }
 
-  getNodeCount(): number {
-    return layoutStore.nodeCount
-  }
-
   hasData(): boolean {
-    return this.getNodeCount() > 0
+    return layoutStore.nodeCount > 0
   }
 }

--- a/src/renderer/extensions/minimap/data/LiteGraphDataSource.ts
+++ b/src/renderer/extensions/minimap/data/LiteGraphDataSource.ts
@@ -31,11 +31,7 @@ export class LiteGraphDataSource extends AbstractMinimapDataSource {
     })
   }
 
-  getNodeCount(): number {
-    return this.graph?._nodes?.length ?? 0
-  }
-
   hasData(): boolean {
-    return this.getNodeCount() > 0
+    return !!this.graph?._nodes.length
   }
 }

--- a/src/renderer/extensions/minimap/data/MinimapDataSource.test.ts
+++ b/src/renderer/extensions/minimap/data/MinimapDataSource.test.ts
@@ -71,7 +71,6 @@ describe('MinimapDataSource', () => {
       // Assert
       expect(dataSource).toBeDefined()
       expect(dataSource.hasData()).toBe(true)
-      expect(dataSource.getNodeCount()).toBe(1)
     })
 
     it('should create LiteGraphDataSource when LayoutStore is empty', () => {
@@ -106,7 +105,6 @@ describe('MinimapDataSource', () => {
       // Assert
       expect(dataSource).toBeDefined()
       expect(dataSource.hasData()).toBe(true)
-      expect(dataSource.getNodeCount()).toBe(1)
 
       const nodes = dataSource.getNodes()
       expect(nodes).toHaveLength(1)
@@ -137,7 +135,6 @@ describe('MinimapDataSource', () => {
 
       // Assert
       expect(dataSource.hasData()).toBe(false)
-      expect(dataSource.getNodeCount()).toBe(0)
       expect(dataSource.getNodes()).toEqual([])
       expect(dataSource.getLinks()).toEqual([])
       expect(dataSource.getGroups()).toEqual([])

--- a/src/renderer/extensions/minimap/types.ts
+++ b/src/renderer/extensions/minimap/types.ts
@@ -112,6 +112,5 @@ export interface IMinimapDataSource {
   getLinks(): MinimapLinkData[]
   getGroups(): MinimapGroupData[]
   getBounds(): MinimapBounds
-  getNodeCount(): number
   hasData(): boolean
 }


### PR DESCRIPTION
## Summary

Simplifies the minimap optimization from #15029 into one digest-driven change detector while preserving its performance and fixing nonnumeric node ID handling.

## Changes

- **What**: Removes the redundant graph callback, event, and throttle machinery around the authoritative 100 ms digest poll; removes dead minimap API/ref plumbing and redundant tests; keeps the detector focused behind the existing composable boundary.
- Hashes link endpoint IDs as strings so same-count rewires between UUID-style node IDs trigger a redraw.
- Restores the existing LayoutStore getVersion API for compatibility while retaining the cheap node count and geometry version paths used by the minimap.
- Reduces the follow-up by 643 net lines across implementation and tests.

## Performance

The existing 245-node minimap-idle benchmark was run five times against the merged implementation and this branch:

| | Merged #15029 | This branch |
| --- | ---: | ---: |
| Median style recalculations | 22 | 22 |
| Mean style recalculations | 23.2 | 22.4 |
| Total blocking time | 0 ms | 0 ms |

The string endpoint hash adds approximately 0.068 ms per 20,000-link digest scan.

## Review Focus

- The visibility-aware, canvas-gated 100 ms poll is now the sole redraw authority.
- Digest inputs remain split between visual changes and bounds-affecting changes.
- LayoutStore geometry tracking still covers local and remote Yjs updates without rebuilding layout data on each poll.
- Tests cover interval lifecycle, geometry and visual invalidation, slot-only rewires, and UUID-style endpoint rewires.