### PR TITLE
test: silence vitest/valid-expect by inlining expect() failure messages

### DIFF
--- a/src/composables/templateSearchConfig.test.ts
+++ b/src/composables/templateSearchConfig.test.ts
@@ -303,11 +303,19 @@ describe('rankByRelevanceThenUsage', () => {
     const order = (hits: SearchResult[]) =>
       rankByRelevanceThenUsage(hits).map((h) => h.id)
 
-    const stable = 'an intransitive score cluster must resolve to one order'
     const expected = order([a, b, c])
-    expect(order([c, b, a]), stable).toEqual(expected)
-    expect(order([b, a, c]), stable).toEqual(expected)
-    expect(order([c, a, b]), stable).toEqual(expected)
+    for (const permutation of [
+      [c, b, a],
+      [b, a, c],
+      [c, a, b]
+    ]) {
+      expect(
+        order(permutation),
+        `an intransitive score cluster must resolve to one order, but input order ${permutation
+          .map((h) => h.id)
+          .join('')} did not`
+      ).toEqual(expected)
+    }
   })
 
   it('breaks ties within a band by usage but not across bands', () => {

--- a/src/platform/workflow/templates/utils/templateRanking.test.ts
+++ b/src/platform/workflow/templates/utils/templateRanking.test.ts
@@ -18,10 +18,11 @@ describe('searchRankBoost', () => {
   })
 
   it('stays neutral inside the dead zone and engages just outside it', () => {
-    const inert =
-      "retired 1-10 ranks like the starter templates' 3 must stay inert"
     for (const insideDeadZone of [1, 2, 3, 4, 5, -1, -5]) {
-      expect(searchRankBoost(insideDeadZone), inert).toBe(0)
+      expect(
+        searchRankBoost(insideDeadZone),
+        `rank ${insideDeadZone} is a retired 1-10 rank like the starter templates' 3 and must stay inert`
+      ).toBe(0)
     }
     expect(searchRankBoost(6)).toBeGreaterThan(0)
     expect(searchRankBoost(-6)).toBeLessThan(0)


### PR DESCRIPTION
`pnpm lint` reported four `vitest(valid-expect)` warnings — "Expect takes at most 1 argument".

## What the rule actually flags

Vitest does **not** ignore `expect(value, message)`; it renders the second argument as the assertion message. Verified against the repo's Vitest 4.1.10:

```
AssertionError: THE_MESSAGE_SHOWS_UP: expected 2 to be 3 // Object.is equality
```

oxlint's `vitest/valid-expect` accepts a string or template **literal** there and only flags any other expression, because it cannot distinguish a message from a value the author believed was being compared. That is why only 4 of the ~300 two-argument `expect()` calls in the repo warn: those four passed the message through a local `const`.

## Findings

All four are messages, not dropped assertions — no test was silently weaker than it read. So the fix inlines the literal rather than deleting it, which would have thrown away the diagnostic:

- `src/platform/workflow/templates/utils/templateRanking.test.ts:24` — `inert` const
- `src/composables/templateSearchConfig.test.ts:308,309,310` — `stable` const

Both sites assert inside (or across) repeated inputs where the shared const could not name the failing case. Each now interpolates the offending iteration:

```
AssertionError: rank 9 is a retired 1-10 rank ... must stay inert: expected 0.333... to be +0
AssertionError: an intransitive score cluster must resolve to one order, but input order cba did not: ...
```

(both produced by deliberately breaking the assertions, then reverting)

## Verification

- `pnpm lint` — zero `valid-expect` warnings remain, repo-wide
- `pnpm vitest run` on both files — 42 passed
- `pnpm typecheck`, `pnpm format:check` clean
- Repo-wide AST-ish sweep of every `*.test.ts` for a non-literal second `expect()` argument found no other instances