### PR TITLE
feat(build): add ASSET_CACHE_BUST to force every asset URL to rotate

### DIFF
--- a/.claude/skills/recovering-poisoned-asset-cache/SKILL.md
+++ b/.claude/skills/recovering-poisoned-asset-cache/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: recovering-poisoned-asset-cache
+description: 'Diagnose and recover users stuck on a blank page or endless splash screen because a CDN or browser has pinned a 404 for a boot chunk. Covers confirming the diagnosis, the origin-side fix, the edge purge, and forcing every asset URL to rotate when a redeploy cannot dislodge the cached 404. Use when users report "stuck on splash screen", "spinner forever", "blank page after deploy", a cached 404 on /assets/*, or when reloading does not fix a broken app.'
+---
+
+# Recovering a Poisoned Asset Cache
+
+A content-hashed chunk 404s. A cache stores that 404. Every client that reads
+from that cache is served a broken app, and **reloading cannot fix it** — the
+client is not asking origin, and with `immutable` it will not revalidate.
+
+This happened as IR-105: nginx stamped `Cache-Control: public, max-age=2592000,
+immutable` on 404 responses, Cloudflare honoured it, and `rolldown-runtime-*.js`
+— the module runtime, without which no other chunk can load — was served as a
+cached 404 to a subset of users for as long as 30 days.
+
+## Confirm the diagnosis before acting
+
+The same symptom ("stuck on splash / spinner forever") has at least three
+unrelated causes. Fixing the wrong one wastes an incident.
+
+```bash
+# 1. Is a boot asset 404ing, and is the 404 itself cached?
+curl -sI https://cloud.comfy.org/assets/<chunk>.js | grep -iE 'HTTP/|cache-control|cf-cache-status|age'
+```
+
+- `HTTP/2 404` + `cf-cache-status: HIT` → **poisoned cache.** This runbook applies.
+- `HTTP/2 404` + `cf-cache-status: MISS/BYPASS` → origin is genuinely missing
+  the file. Different problem: check the deploy and the bucket.
+- All boot assets `200` → **not this.** The app is booting and failing later.
+  Check for an unregistered route or an auth stall instead; those present
+  identically and this runbook will not help.
+
+```bash
+# 2. Prove the no-store fix is live, using a path that cannot exist
+curl -sI https://cloud.comfy.org/assets/does-not-exist-probe-QQQ.js | grep -iE 'HTTP/|cache-control|cf-cache-status'
+# want: 404 + cache-control: no-store + cf-cache-status: BYPASS
+```
+
+Run the probe **before** concluding anything. A single healthy edge node is a
+sample of one — it does not prove other colos are clean.
+
+## The three layers, and what each fix reaches
+
+Fixing one layer does not fix the others. Work down the list.
+
+| Layer                       | Fix                                                                    | Reaches                     |
+| --------------------------- | ---------------------------------------------------------------------- | --------------------------- |
+| Origin emits cacheable 404s | nginx `no-store` on 4xx/5xx for asset locations (Comfy-Org/cloud#6472) | **New** poisonings only     |
+| Edge holds poisoned entries | Cloudflare purge of the specific URLs                                  | New users hitting that colo |
+| Client has it pinned        | Nothing origin-side reaches them                                       | Only a URL change does      |
+
+That last row is the one people miss. A user whose browser holds
+`max-age=2592000, immutable` for a 404 is unreachable by any server-side action.
+
+## Forcing every asset URL to rotate
+
+### Why a redeploy is not enough
+
+The instinct is "ship a new build, the hashes change". **Measured, and it is
+false for exactly the chunks that matter.** Two cloud builds of this repo
+differing only in commit hash:
+
+- 153 of 495 JS chunks rotated
+- `rolldown-runtime`, `vendor-datadog`, `vendor-sentry`, `vendor-vue-core`
+  **kept byte-identical filenames**
+
+A content hash tracks content. Vendor chunks are leaves whose content comes from
+`node_modules`, which a commit does not change. App chunks rotate because the
+import specifiers inside them changed — that cascade never reaches the leaves.
+So a redeploy leaves the poisoned vendor URLs exactly where they were.
+
+### The mechanism
+
+```bash
+ASSET_CACHE_BUST=20260818 pnpm build:cloud
+```
+
+`ASSET_CACHE_BUST` inserts its value into every emitted asset filename:
+
+```
+assets/rolldown-runtime-xtsTai4I.js  ->  assets/rolldown-runtime-cb20260818-xtsTai4I.js
+```
+
+Verified: **495 of 495** hashed JS/CSS assets get a new URL, `index.html` is
+rewritten to match, and unset behaviour is byte-identical to today's build.
+Non-hashed static files (`favicon.ico`, `images/`, `CREDIT.txt`,
+`sorted-custom-node-map.json`) do not carry hashes and are unaffected — if one
+of those is the poisoned file, this will not help it.
+
+Use a date (`20260818`) rather than a counter. It is self-describing in a URL
+six months later and cannot collide.
+
+### The trap
+
+**Only ever increment `ASSET_CACHE_BUST`. Never clear it.**
+
+Clearing it reverts every filename to exactly the names that were poisoned, and
+any client still holding those entries breaks again — with no new deploy to
+blame. Treat it as a permanent, monotonic deploy variable: once set, it stays
+set, and the next incident bumps it.
+
+The salt changes the _filename_, not the content hash — `xtsTai4I` above is
+unchanged. That is deliberate and sufficient: caches key on URL.
+
+## Verify the recovery
+
+```bash
+# New URLs are live and cacheable as 200s
+curl -sI https://cloud.comfy.org/assets/rolldown-runtime-cb<salt>-<hash>.js | grep -iE 'HTTP/|cache-control'
+
+# The old poisoned URL is gone from index.html
+curl -s https://cloud.comfy.org/ | grep -oE 'assets/[^"]+\.js'
+```
+
+Then confirm in RUM that the failure actually stopped, rather than assuming:
+
+```
+@type:error @application.id:041a9897-5516-4b1f-a245-1a9aa6895488 @context.error_type:*
+```
+
+Dashboard: https://us5.datadoghq.com/dashboard/u9c-dtd-ui6
+
+Note the ceiling on what RUM can tell you here: if a boot chunk 404s, **no
+JavaScript executes**, so no in-app reporter ever fires. A flat error chart is
+not evidence the cached-404 failure stopped — it is what that failure looks
+like. Confirm from the server side (404 rate on `/assets/*`) instead.
+
+## Coverage gaps worth knowing
+
+- The nginx `no-store` fix covers `/assets/*` but **not** `/extensions/*`.
+  `/extensions/core/clipspace.js` still 404s as `public, max-age=14400` and
+  re-caches after every purge. Shorter TTL and not `immutable`, so it
+  self-heals in ~4h — but it is uncovered.
+- Nobody on the cloud team could purge the CDN or add an edge rule during
+  IR-105; both needed escalation. Budget for that delay, or fix the access.

--- a/.claude/skills/recovering-poisoned-asset-cache/SKILL.md
+++ b/.claude/skills/recovering-poisoned-asset-cache/SKILL.md
@@ -72,6 +72,22 @@ So a redeploy leaves the poisoned vendor URLs exactly where they were.
 
 ### The mechanism
 
+**In production, set the `ASSET_CACHE_BUST` repository variable** on
+`Comfy-Org/ComfyUI_frontend` (Settings → Secrets and variables → Actions →
+Variables) to today's date, e.g. `20260818`. Then deploy as normal.
+
+A repo variable rather than a one-off build input is the whole point: the salt
+has to apply to **every subsequent build**, not just the recovery one. A manual
+one-shot build would fix the incident and then the next routine deploy would
+revert every filename to the poisoned names.
+
+`cloud-dispatch-build.yaml` reads the variable into the `frontend-asset-build`
+dispatch payload as `asset_cache_bust`; `frontend-asset-predeploy.yml` in
+`Comfy-Org/cloud` passes it to both `pnpm build` invocations. Unset, the
+payload field is empty and the build is byte-identical to today's.
+
+Locally, or for a manual verification build:
+
 ```bash
 ASSET_CACHE_BUST=20260818 pnpm build:cloud
 ```
@@ -93,12 +109,16 @@ six months later and cannot collide.
 
 ### The trap
 
-**Only ever increment `ASSET_CACHE_BUST`. Never clear it.**
+**Only ever increment `ASSET_CACHE_BUST`. Never clear it, and never delete the
+repository variable.**
 
 Clearing it reverts every filename to exactly the names that were poisoned, and
 any client still holding those entries breaks again — with no new deploy to
 blame. Treat it as a permanent, monotonic deploy variable: once set, it stays
 set, and the next incident bumps it.
+
+This is the failure mode to watch for during a repo-settings cleanup: the
+variable looks like leftover incident debris precisely when it is doing its job.
 
 The salt changes the _filename_, not the content hash — `xtsTai4I` above is
 unchanged. That is deliberate and sufficient: caches key on URL.

--- a/.github/workflows/cloud-dispatch-build.yaml
+++ b/.github/workflows/cloud-dispatch-build.yaml
@@ -59,6 +59,10 @@ jobs:
           PR_EVENT_NUMBER: ${{ github.event.pull_request.number }}
           PR_LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
           GH_TOKEN: ${{ github.token }}
+          # Persistent asset cache-bust salt. Set as a repo variable so it
+          # applies to every subsequent build, not just one manual run —
+          # clearing it would revert filenames to the names that were poisoned.
+          ASSET_CACHE_BUST: ${{ vars.ASSET_CACHE_BUST }}
         run: |
           set -euo pipefail
 
@@ -123,7 +127,8 @@ jobs:
               --arg branch "${BRANCH}" \
               --arg pr_number "${PR_NUMBER}" \
               --arg variant "${VARIANT}" \
-              '{ref: $ref, branch: $branch, pr_number: $pr_number, variant: $variant}')"
+              --arg asset_cache_bust "${ASSET_CACHE_BUST}" \
+              '{ref: $ref, branch: $branch, pr_number: $pr_number, variant: $variant, asset_cache_bust: $asset_cache_bust}')"
             echo "json=${payload}" >> "${GITHUB_OUTPUT}"
           fi
 

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -159,6 +159,36 @@ if (!GIT_COMMIT) {
   }
 }
 
+/**
+ * Escape hatch for a poisoned CDN/browser cache.
+ *
+ * A content hash only changes when the chunk's own bytes change, so a routine
+ * redeploy leaves stable vendor chunks — `rolldown-runtime`, `vendor-*` — at
+ * byte-identical URLs. When one of those has been pinned as a 404 by an
+ * intermediary or a browser (IR-105), redeploying cannot dislodge it: the
+ * client never re-requests a URL it believes it already has.
+ *
+ * Setting ASSET_CACHE_BUST inserts its value into every emitted asset name, so
+ * every URL is new and nothing can be served from a poisoned entry.
+ *
+ * Only ever increment this. Clearing it reverts filenames to exactly the names
+ * that were poisoned in the first place.
+ */
+function assetCacheBustNames() {
+  const salt = process.env.ASSET_CACHE_BUST
+  if (!salt) return {}
+  if (!/^[a-zA-Z0-9]+$/.test(salt)) {
+    throw new Error(
+      `ASSET_CACHE_BUST must be alphanumeric (got "${salt}") — it becomes part of every asset filename.`
+    )
+  }
+  return {
+    entryFileNames: `assets/[name]-cb${salt}-[hash].js`,
+    chunkFileNames: `assets/[name]-cb${salt}-[hash].js`,
+    assetFileNames: `assets/[name]-cb${salt}-[hash][extname]`
+  }
+}
+
 // Disable Vue DevTools for production cloud distribution
 const DISABLE_VUE_PLUGINS =
   process.env.DISABLE_VUE_PLUGINS === 'true' ||
@@ -630,6 +660,7 @@ export default defineConfig({
       },
       output: {
         keepNames: true,
+        ...assetCacheBustNames(),
         codeSplitting: {
           groups: [
             // Framework core - highest priority, very stable


### PR DESCRIPTION
## Problem

A redeploy does not dislodge a cached 404.

Measured on two cloud builds of this repo differing only in commit hash:

- 153 of 495 JS chunks rotated
- `rolldown-runtime`, `vendor-datadog`, `vendor-sentry`, `vendor-vue-core` kept **byte-identical filenames**

A content hash tracks content, and vendor chunk content comes from `node_modules`, which a commit does not change. App chunks rotate because the import specifiers inside them changed; that cascade never reaches the leaves.

Those leaves are exactly the chunks IR-105 had pinned as 404s (`rolldown-runtime-AHe5SSxj.js`, `vendor-datadog-C4tz-hk_.js`). So the instinct voiced during that incident — "deploy with a new asset hash" — would not have worked, and a client holding `max-age=2592000, immutable` on a 404 is unreachable by any server-side fix.

## Change

```bash
ASSET_CACHE_BUST=20260818 pnpm build:cloud
```

Inserts the salt into every emitted asset filename:

```
assets/rolldown-runtime-xtsTai4I.js  ->  assets/rolldown-runtime-cb20260818-xtsTai4I.js
```

Non-alphanumeric salts throw at config load, since the value becomes part of a filename.

## Verification

Empirical, on real cloud builds in this worktree:

| Check | Result |
|---|---|
| Build determinism control (same inputs twice) | 0 differing filenames |
| Commit-hash change only | 153/495 rotated; all four vendor leaves unchanged |
| `ASSET_CACHE_BUST` set | **495/495** hashed JS/CSS rotated |
| `index.html` rewritten | yes — all four boot assets |
| Salt unset | byte-identical to today's build |
| Invalid salt | rejected with a clear error |

Unhashed static files (`favicon.ico`, `images/`, `CREDIT.txt`, `sorted-custom-node-map.json`) carry no hash and are unaffected.

## The trap, documented in the skill

**Only ever increment the salt. Never clear it.** Clearing reverts every filename to exactly the names that were poisoned, breaking any client still holding those entries — with no new deploy to blame.

## Also adds

`.claude/skills/recovering-poisoned-asset-cache/` — the full recovery runbook: how to confirm the diagnosis (the same "stuck on splash" symptom has three unrelated causes, and this fixes one of them), which of the three cache layers each available fix actually reaches, and why a flat RUM error chart is *not* evidence this failure stopped.

## Regression risk

Very low. No behavior change unless `ASSET_CACHE_BUST` is set; the unset path is byte-identical.