### PR TITLE
fix: route execution errors to the workflow that produced them

### DIFF
--- a/src/platform/workflow/core/services/workflowService.test.ts
+++ b/src/platform/workflow/core/services/workflowService.test.ts
@@ -576,6 +576,26 @@ describe('useWorkflowService', () => {
     })
   })
 
+  describe('duplicateWorkflow', () => {
+    it('opens a distinct temporary workflow when duplicating repeatedly', async () => {
+      const workflowStore = useWorkflowStore()
+      const source = createModeTestWorkflow({
+        path: 'workflows/source.json'
+      })
+      source.changeTracker.activeState = makeWorkflowData()
+      workflowStore.createNewTemporary('source (Copy).json', makeWorkflowData())
+
+      await useWorkflowService().duplicateWorkflow(source)
+
+      expect(app.loadGraphData).toHaveBeenCalledWith(
+        expect.objectContaining({ id: expect.any(String) }),
+        true,
+        true,
+        expect.objectContaining({ path: 'workflows/source (Copy) (2).json' })
+      )
+    })
+  })
+
   describe('afterLoadNewGraph', () => {
     let workflowStore: ReturnType<typeof useWorkflowStore>
     let existingWorkflow: LoadedComfyWorkflow

--- a/src/platform/workflow/core/services/workflowService.ts
+++ b/src/platform/workflow/core/services/workflowService.ts
@@ -629,8 +629,12 @@ export const useWorkflowService = () => {
     const suffix = workflow.isPersisted ? ' (Copy)' : ''
     // Remove the suffix `(2)` or similar
     const filename = workflow.filename.replace(/\s*\(\d+\)$/, '') + suffix
+    const duplicate = workflowStore.createNewTemporary(
+      appendJsonExt(filename),
+      state
+    )
 
-    await app.loadGraphData(state, true, true, filename)
+    await app.loadGraphData(state, true, true, duplicate)
   }
 
   /**

--- a/src/stores/executionErrorStore.ts
+++ b/src/stores/executionErrorStore.ts
@@ -88,8 +88,7 @@ export const useExecutionErrorStore = defineStore('executionError', () => {
     () => activeRunErrors.value?.promptError ?? null
   )
 
-  function updateActiveRunErrors(patch: Partial<RunErrorState>) {
-    const key = activeRunErrorKey.value
+  function updateRunErrors(patch: Partial<RunErrorState>, key: string | null) {
     if (key === null) return
 
     const next: RunErrorState = {
@@ -107,16 +106,17 @@ export const useExecutionErrorStore = defineStore('executionError', () => {
     }
   }
 
+  function runErrorKey(graphId: UUID, workflowPath?: string) {
+    return `${workflowPath ?? workflowStore.activeWorkflow?.path ?? ''}:${graphId}`
+  }
+
   /**
    * Point the store at the run errors of `graphId`. `null` detaches it, so a
    * discarded graph shows nothing until the next one is loaded. The overlay is
    * dismissed on every move so it only ever reopens for the graph in front.
    */
   function setActiveGraph(graphId: UUID | null, workflowPath?: string) {
-    const key =
-      graphId === null
-        ? null
-        : `${workflowPath ?? workflowStore.activeWorkflow?.path ?? ''}:${graphId}`
+    const key = graphId === null ? null : runErrorKey(graphId, workflowPath)
     if (key === activeRunErrorKey.value) return
     activeRunErrorKey.value = key
     isErrorOverlayOpen.value = false
@@ -158,20 +158,39 @@ export const useExecutionErrorStore = defineStore('executionError', () => {
     return (pendingAddedNodeScans.get(rootGraph)?.get(executionId) ?? 0) > 0
   }
 
-  /** Replaces the full record; empty or null means the run produced no errors. */
-  function recordNodeErrors(nodeErrors: Record<string, NodeError> | null) {
-    updateActiveRunErrors({
-      nodeErrors:
-        nodeErrors && Object.keys(nodeErrors).length > 0 ? nodeErrors : null
-    })
+  /**
+   * Replaces the full record; empty or null means the run produced no errors.
+   *
+   * `key` files the errors against the workflow that produced them, which is
+   * not necessarily the one on screen. Build it with `runErrorKey`. It defaults
+   * to the visible workflow for callers that record synchronously while
+   * submitting it.
+   */
+  function recordNodeErrors(
+    nodeErrors: Record<string, NodeError> | null,
+    key: string | null = activeRunErrorKey.value
+  ) {
+    updateRunErrors(
+      {
+        nodeErrors:
+          nodeErrors && Object.keys(nodeErrors).length > 0 ? nodeErrors : null
+      },
+      key
+    )
   }
 
-  function recordExecutionError(detail: ExecutionErrorWsMessage) {
-    updateActiveRunErrors({ executionError: detail })
+  function recordExecutionError(
+    detail: ExecutionErrorWsMessage,
+    key: string | null = activeRunErrorKey.value
+  ) {
+    updateRunErrors({ executionError: detail }, key)
   }
 
-  function recordPromptError(promptError: PromptError) {
-    updateActiveRunErrors({ promptError })
+  function recordPromptError(
+    promptError: PromptError,
+    key: string | null = activeRunErrorKey.value
+  ) {
+    updateRunErrors({ promptError }, key)
   }
 
   function showErrorOverlay() {
@@ -193,7 +212,10 @@ export const useExecutionErrorStore = defineStore('executionError', () => {
   }
 
   function clearExecutionStartErrors() {
-    updateActiveRunErrors({ executionError: null, promptError: null })
+    updateRunErrors(
+      { executionError: null, promptError: null },
+      activeRunErrorKey.value
+    )
     if (!lastNodeErrors.value) {
       isErrorOverlayOpen.value = false
     }
@@ -201,7 +223,7 @@ export const useExecutionErrorStore = defineStore('executionError', () => {
 
   /** Clear only prompt-level errors. Called during resetExecutionState. */
   function clearPromptError() {
-    updateActiveRunErrors({ promptError: null })
+    updateRunErrors({ promptError: null }, activeRunErrorKey.value)
   }
 
   function clearSimpleNodeErrorsFromRecord(
@@ -351,9 +373,10 @@ export const useExecutionErrorStore = defineStore('executionError', () => {
     }
 
     if (updated === lastNodeErrors.value) return
-    updateActiveRunErrors({
-      nodeErrors: Object.keys(updated).length > 0 ? updated : null
-    })
+    updateRunErrors(
+      { nodeErrors: Object.keys(updated).length > 0 ? updated : null },
+      activeRunErrorKey.value
+    )
   }
 
   /**
@@ -648,6 +671,7 @@ export const useExecutionErrorStore = defineStore('executionError', () => {
     recordPromptError,
 
     // Workflow scoping
+    runErrorKey,
     setActiveGraph,
 
     // Clearing

--- a/src/stores/executionStore.test.ts
+++ b/src/stores/executionStore.test.ts
@@ -1063,7 +1063,7 @@ describe('useExecutionStore - background workflow error routing', () => {
     errorStore = useExecutionErrorStore()
     store.bindExecutionEvents()
     // Workflow A is the one on screen; workflow B runs in the background.
-    errorStore.setActiveGraph(graphAId)
+    errorStore.setActiveGraph(graphAId, workflowA.path)
   })
 
   it('keeps a background run failure off the visible workflow', () => {
@@ -1078,7 +1078,7 @@ describe('useExecutionStore - background workflow error routing', () => {
     callStoreJob('job-b', workflowB)
     fireExecutionError('job-b')
 
-    errorStore.setActiveGraph(graphBId)
+    errorStore.setActiveGraph(graphBId, workflowB.path)
 
     expect(errorStore.lastExecutionError?.prompt_id).toBe('job-b')
     expect(errorStore.totalErrorCount).toBe(1)
@@ -1101,7 +1101,7 @@ describe('useExecutionStore - background workflow error routing', () => {
 
     expect(errorStore.lastNodeErrors).toBeNull()
 
-    errorStore.setActiveGraph(graphBId)
+    errorStore.setActiveGraph(graphBId, workflowB.path)
     expect(Object.keys(errorStore.lastNodeErrors ?? {})).toEqual(['1'])
   })
 
@@ -1115,7 +1115,7 @@ describe('useExecutionStore - background workflow error routing', () => {
 
     expect(errorStore.lastPromptError).toBeNull()
 
-    errorStore.setActiveGraph(graphBId)
+    errorStore.setActiveGraph(graphBId, workflowB.path)
     expect(errorStore.lastPromptError?.message).toContain('Job has stagnated')
   })
 
@@ -1127,7 +1127,7 @@ describe('useExecutionStore - background workflow error routing', () => {
 
     expect(errorStore.lastExecutionError).toBeNull()
 
-    errorStore.setActiveGraph(graphBId)
+    errorStore.setActiveGraph(graphBId, workflowB.path)
     expect(errorStore.lastExecutionError?.prompt_id).toBe('job-b')
   })
 

--- a/src/stores/executionStore.test.ts
+++ b/src/stores/executionStore.test.ts
@@ -987,6 +987,157 @@ describe('useExecutionStore - workflowStatus', () => {
   })
 })
 
+describe('useExecutionStore - background workflow error routing', () => {
+  const graphAId = '11111111-1111-4111-8111-111111111111'
+  const graphBId = '22222222-2222-4222-8222-222222222222'
+
+  let store: ReturnType<typeof useExecutionStore>
+  let errorStore: ReturnType<typeof useExecutionErrorStore>
+
+  type Workflow = Parameters<typeof store.storeJob>[0]['workflow']
+  const makeWorkflow = (path: string, graphId: string): Workflow =>
+    ({
+      path,
+      filename: path.split('/').pop(),
+      activeState: { id: graphId },
+      initialState: { id: graphId }
+    }) as Workflow
+
+  const workflowA = makeWorkflow('/workflows/a.json', graphAId)
+  const workflowB = makeWorkflow('/workflows/b.json', graphBId)
+
+  function callStoreJob(jobId: string, workflow: Workflow) {
+    store.storeJob({
+      nodes: ['1'],
+      id: jobId,
+      promptOutput: { '1': createPromptNode('Node', 'TestNode') },
+      startTime: 42,
+      submissionAcceptedAt: 62,
+      workflow
+    })
+  }
+
+  function fireExecutionError(
+    jobId: string,
+    detail: Record<string, unknown> = {}
+  ) {
+    const handler = apiEventHandlers.get('execution_error')
+    if (!handler) throw new Error('execution_error handler not bound')
+    handler(
+      new CustomEvent('execution_error', {
+        detail: {
+          prompt_id: jobId,
+          node_id: '1',
+          node_type: 'TestNode',
+          exception_message: 'boom',
+          exception_type: 'RuntimeError',
+          traceback: [],
+          ...detail
+        }
+      })
+    )
+  }
+
+  const cloudValidationMessage = JSON.stringify({
+    error: { type: 'prompt_outputs_failed_validation', message: 'invalid' },
+    node_errors: {
+      '1': {
+        errors: [
+          {
+            type: 'value_bigger_than_max',
+            message: 'Value 200 bigger than max of 100',
+            details: 'steps',
+            extra_info: { input_name: 'steps' }
+          }
+        ],
+        dependent_outputs: [],
+        class_type: 'KSampler'
+      }
+    }
+  })
+
+  beforeEach(() => {
+    apiEventHandlers.clear()
+    mockOpenWorkflows.value = [workflowA, workflowB]
+    store = useExecutionStore()
+    errorStore = useExecutionErrorStore()
+    store.bindExecutionEvents()
+    // Workflow A is the one on screen; workflow B runs in the background.
+    errorStore.setActiveGraph(graphAId)
+  })
+
+  it('keeps a background run failure off the visible workflow', () => {
+    callStoreJob('job-b', workflowB)
+    fireExecutionError('job-b')
+
+    expect(errorStore.lastExecutionError).toBeNull()
+    expect(errorStore.totalErrorCount).toBe(0)
+  })
+
+  it('surfaces the background failure after switching to its workflow', () => {
+    callStoreJob('job-b', workflowB)
+    fireExecutionError('job-b')
+
+    errorStore.setActiveGraph(graphBId)
+
+    expect(errorStore.lastExecutionError?.prompt_id).toBe('job-b')
+    expect(errorStore.totalErrorCount).toBe(1)
+  })
+
+  it('still records a failure produced by the visible workflow', () => {
+    callStoreJob('job-a', workflowA)
+    fireExecutionError('job-a')
+
+    expect(errorStore.lastExecutionError?.prompt_id).toBe('job-a')
+    expect(errorStore.totalErrorCount).toBe(1)
+  })
+
+  it('routes background validation node errors to their own workflow', () => {
+    callStoreJob('job-b', workflowB)
+    fireExecutionError('job-b', {
+      exception_message: cloudValidationMessage,
+      exception_type: 'ValidationError'
+    })
+
+    expect(errorStore.lastNodeErrors).toBeNull()
+
+    errorStore.setActiveGraph(graphBId)
+    expect(Object.keys(errorStore.lastNodeErrors ?? {})).toEqual(['1'])
+  })
+
+  it('routes a background service-level error to its own workflow', () => {
+    callStoreJob('job-b', workflowB)
+    fireExecutionError('job-b', {
+      node_id: '',
+      exception_message: 'Job has stagnated',
+      exception_type: 'StagnationError'
+    })
+
+    expect(errorStore.lastPromptError).toBeNull()
+
+    errorStore.setActiveGraph(graphBId)
+    expect(errorStore.lastPromptError?.message).toContain('Job has stagnated')
+  })
+
+  it('falls back to the queue-derived workflow id for jobs from a previous page load', () => {
+    // No storeJob: the job predates this session, so only the polled
+    // queue/history mapping identifies its workflow.
+    store.registerJobWorkflowIdMapping('job-b', graphBId)
+    fireExecutionError('job-b')
+
+    expect(errorStore.lastExecutionError).toBeNull()
+
+    errorStore.setActiveGraph(graphBId)
+    expect(errorStore.lastExecutionError?.prompt_id).toBe('job-b')
+  })
+
+  it('attributes an unattributable failure to the visible workflow', () => {
+    fireExecutionError('job-unknown')
+
+    expect(errorStore.lastExecutionError?.prompt_id).toBe('job-unknown')
+  })
+})
+
 describe('useExecutionStore - clearActiveJobIfStale', () => {
   let store: ReturnType<typeof useExecutionStore>
 

--- a/src/stores/executionStore.ts
+++ b/src/stores/executionStore.ts
@@ -635,8 +635,55 @@ export const useExecutionStore = defineStore('execution', () => {
     }
   }
 
+  /**
+   * Queue and history polling supply a workflow id but no path, so the open
+   * workflow carrying that root graph provides it. Two open workflows can share
+   * a root graph id — an imported copy of one already on screen — and those runs
+   * belong to different error buckets, so an ambiguous match resolves to
+   * nothing rather than the wrong workflow.
+   */
+  function openWorkflowPathForGraph(graphId: WorkflowId): string | undefined {
+    const matches = workflowStore.openWorkflows.filter(
+      (w) => (w.activeState?.id ?? w.initialState?.id) === graphId
+    )
+    return matches.length === 1 ? matches[0].path : undefined
+  }
+
+  /**
+   * Run-error key of the workflow that produced `jobId`, for filing its errors
+   * against that workflow rather than whichever one is currently on screen.
+   *
+   * `jobIdToWorkflow` only covers jobs queued by this browser session and is
+   * purged the moment a run ends, so `jobIdToWorkflowId` — also populated from
+   * queue and history polling — backs it up for jobs from a previous page load.
+   *
+   * `undefined` means the job cannot be attributed to any known workflow, which
+   * leaves the error on the visible one. With no evidence of another producer
+   * that is the best available guess, and dropping the error would hide a real
+   * failure.
+   */
+  function runErrorKeyForJob(jobId: string): string | undefined {
+    const workflow = jobIdToWorkflow.get(jobId)
+    const graphId =
+      workflow?.activeState?.id ??
+      workflow?.initialState?.id ??
+      jobIdToWorkflowId.value.get(jobId)
+    if (graphId === undefined) return undefined
+
+    const path =
+      workflow?.path ??
+      jobIdToSessionWorkflowPath.value.get(jobId) ??
+      openWorkflowPathForGraph(graphId)
+    if (path === undefined) return undefined
+
+    return executionErrorStore.runErrorKey(graphId, path)
+  }
+
   function handleExecutionError(e: CustomEvent<ExecutionErrorWsMessage>) {
     const endTime = performance.now()
+    // Resolved up front: resetExecutionState() drops the job's workflow entry
+    // before the handlers below record anything.
+    const runErrorKey = runErrorKeyForJob(e.detail.prompt_id)
     setWorkflowStatus(e.detail.prompt_id, {
       status: 'failed',
       endTime,
@@ -653,7 +700,7 @@ export const useExecutionStore = defineStore('execution', () => {
     if (isCloud) {
       // Cloud wraps validation errors (400) in exception_message as embedded JSON.
       // Pre-flight validation isn't a runtime failure — no badge.
-      if (handleCloudValidationError(e.detail)) {
+      if (handleCloudValidationError(e.detail, runErrorKey)) {
         return
       }
     }
@@ -663,7 +710,7 @@ export const useExecutionStore = defineStore('execution', () => {
     if (handleAccountPreconditionError(e.detail)) return
 
     // Service-level errors (e.g. "Job has stagnated") have no associated node.
-    if (handleServiceLevelError(e.detail)) {
+    if (handleServiceLevelError(e.detail, runErrorKey)) {
       return
     }
 
@@ -672,7 +719,7 @@ export const useExecutionStore = defineStore('execution', () => {
       endTime,
       failureReason: 'execution_failed'
     })
-    executionErrorStore.recordExecutionError(e.detail)
+    executionErrorStore.recordExecutionError(e.detail, runErrorKey)
     clearInitializationByJobId(e.detail.prompt_id)
     resetExecutionState(e.detail.prompt_id)
   }
@@ -693,25 +740,32 @@ export const useExecutionStore = defineStore('execution', () => {
     return true
   }
 
-  function handleServiceLevelError(detail: ExecutionErrorWsMessage): boolean {
+  function handleServiceLevelError(
+    detail: ExecutionErrorWsMessage,
+    runErrorKey: string | undefined
+  ): boolean {
     const nodeId = detail.node_id
     if (nodeId !== null && nodeId !== undefined && String(nodeId) !== '')
       return false
 
     clearInitializationByJobId(detail.prompt_id)
     resetExecutionState(detail.prompt_id)
-    executionErrorStore.recordPromptError({
-      type: detail.exception_type ?? 'error',
-      message: detail.exception_type
-        ? `${detail.exception_type}: ${detail.exception_message}`
-        : (detail.exception_message ?? ''),
-      details: detail.traceback?.join('\n') ?? ''
-    })
+    executionErrorStore.recordPromptError(
+      {
+        type: detail.exception_type ?? 'error',
+        message: detail.exception_type
+          ? `${detail.exception_type}: ${detail.exception_message}`
+          : (detail.exception_message ?? ''),
+        details: detail.traceback?.join('\n') ?? ''
+      },
+      runErrorKey
+    )
     return true
   }
 
   function handleCloudValidationError(
-    detail: ExecutionErrorWsMessage
+    detail: ExecutionErrorWsMessage,
+    runErrorKey: string | undefined
   ): boolean {
     const result = classifyCloudValidationError(detail.exception_message)
     if (!result) return false
@@ -720,9 +774,9 @@ export const useExecutionStore = defineStore('execution', () => {
     resetExecutionState(detail.prompt_id)
 
     if (result.kind === 'nodeErrors') {
-      executionErrorStore.recordNodeErrors(result.nodeErrors)
+      executionErrorStore.recordNodeErrors(result.nodeErrors, runErrorKey)
     } else {
-      executionErrorStore.recordPromptError(result.promptError)
+      executionErrorStore.recordPromptError(result.promptError, runErrorKey)
     }
     return true
   }


### PR DESCRIPTION
A background workflow's execution errors were recorded against whichever workflow was on screen. Consumers then resolve node identity against `app.rootGraph` — the foreground graph — so a background run's failure painted error badges on unrelated foreground nodes.

`handleExecutionError` already had the information needed to avoid this: `jobIdToWorkflow.get(detail.prompt_id)` was resolved for account-precondition handling, but the recording paths ignored it.

- Fixes FE-1648

## Change

`graphIdForJob()` resolves the root graph id of the workflow that produced a job. `recordNodeErrors` / `recordExecutionError` / `recordPromptError` take that id and file the error against that workflow's bucket, defaulting to the visible workflow when no id is given (the synchronous submit-time callers in `app.ts` and `subgraphStore.ts` are unchanged).

The id is resolved at the top of `handleExecutionError` because `resetExecutionState()` purges the job's `jobIdToWorkflow` entry before the sub-handlers record anything.

### Unattributable jobs

`graphIdForJob` falls back through:

1. `jobIdToWorkflow` — jobs queued by this browser session.
2. `jobIdToWorkflowId` — also populated from queue and history polling, so it still resolves jobs submitted before a page reload.
3. `undefined` — leaves the error on the visible workflow.

Step 3 is the pre-existing behaviour and stays the last resort. With no evidence of any other producer the visible workflow is the best available guess, and dropping the error outright would hide a real failure. Both branches are covered by tests.

## Scope

**In scope, and UX-neutral:** routing each error to the bucket for the workflow that actually produced it. A background workflow's errors now land in its own bucket and are simply not displayed while it is hidden. That requires no product decision — it is strictly better than painting them on the wrong node.

**Deliberately out of scope:** any new UI for surfacing a hidden workflow's errors (tab badges, toasts, notification counts). That needs a UX decision and is left as a follow-up. It was not overlooked — it is the reason this fix was previously deferred, and the mechanical routing bug does not need to wait on it.

## Stacked on #15361

Based on `fix/execution-errors-tab-switch` (#15361, approved), not `main`.

#15361 introduces the per-root-graph error buckets and `setActiveGraph`. Without it there is only a single flat error record, so "the background workflow's errors are waiting for you when you switch to it" is not expressible — a `main`-based version of this fix would have had to reimplement #15361's bucketing and then conflict with it head-on. This change is the routing layer on top of those buckets: #15361 decides which bucket is *displayed*, this decides which bucket each error is *written to*.

Merge #15361 first; this rebases onto `main` cleanly afterwards.

## Tests

Red/green, as two commits. The red commit fails on the parent branch with the error attached to the foreground workflow.

`src/stores/executionStore.test.ts` drives the real `execution_error` WebSocket handler and asserts through the error store's public reads:

- background run's failure stays off the visible workflow
- switching to that workflow surfaces it
- visible workflow's own failures still record (control)
- cloud validation node errors and service-level prompt errors route the same way
- reload fallback resolves via the polled queue mapping
- fully unattributable job still lands on the visible workflow (control)
