### PR TITLE
test: subgraph promoted-widget host isolation across an input rebind

### DIFF
--- a/browser_tests/assets/subgraphs/shared-definition-two-hosts-promoted-text.json
+++ b/browser_tests/assets/subgraphs/shared-definition-two-hosts-promoted-text.json
@@ -1,0 +1,327 @@
+{
+  "id": "9f2c1c8e-7a41-4c1a-9d0e-2b6f5a3c7e10",
+  "revision": 0,
+  "last_node_id": 12,
+  "last_link_id": 9,
+  "nodes": [
+    {
+      "id": 11,
+      "type": "422723e8-4bf6-438c-823f-881ca81acead",
+      "pos": [80, 120],
+      "size": [400, 200],
+      "flags": {},
+      "order": 0,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        },
+        {
+          "name": "model",
+          "type": "MODEL",
+          "link": null
+        },
+        {
+          "name": "positive",
+          "type": "CONDITIONING",
+          "link": null
+        },
+        {
+          "name": "negative",
+          "type": "CONDITIONING",
+          "link": null
+        },
+        {
+          "name": "latent_image",
+          "type": "LATENT",
+          "link": null
+        }
+      ],
+      "outputs": [],
+      "properties": {},
+      "widgets_values": [""],
+      "title": "Host A"
+    },
+    {
+      "id": 12,
+      "type": "422723e8-4bf6-438c-823f-881ca81acead",
+      "pos": [560, 120],
+      "size": [400, 200],
+      "flags": {},
+      "order": 1,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        },
+        {
+          "name": "model",
+          "type": "MODEL",
+          "link": null
+        },
+        {
+          "name": "positive",
+          "type": "CONDITIONING",
+          "link": null
+        },
+        {
+          "name": "negative",
+          "type": "CONDITIONING",
+          "link": null
+        },
+        {
+          "name": "latent_image",
+          "type": "LATENT",
+          "link": null
+        }
+      ],
+      "outputs": [],
+      "properties": {},
+      "widgets_values": [""],
+      "title": "Host B"
+    }
+  ],
+  "links": [],
+  "groups": [],
+  "definitions": {
+    "subgraphs": [
+      {
+        "id": "422723e8-4bf6-438c-823f-881ca81acead",
+        "version": 1,
+        "state": {
+          "lastGroupId": 0,
+          "lastNodeId": 11,
+          "lastLinkId": 15,
+          "lastRerouteId": 0
+        },
+        "revision": 0,
+        "config": {},
+        "name": "New Subgraph",
+        "inputNode": {
+          "id": -10,
+          "bounding": [481.59912109375, 379.13336181640625, 120, 160]
+        },
+        "outputNode": {
+          "id": -20,
+          "bounding": [1121.59912109375, 379.13336181640625, 120, 40]
+        },
+        "inputs": [
+          {
+            "id": "0f07c10e-5705-4764-9b24-b69606c6dbcc",
+            "name": "text",
+            "type": "STRING",
+            "linkIds": [10],
+            "pos": {
+              "0": 581.59912109375,
+              "1": 399.13336181640625
+            }
+          },
+          {
+            "id": "214a5060-24dd-4299-ab78-8027dc5b9c59",
+            "name": "clip",
+            "type": "CLIP",
+            "linkIds": [11],
+            "pos": {
+              "0": 581.59912109375,
+              "1": 419.13336181640625
+            }
+          },
+          {
+            "id": "8ab94c5d-e7df-433c-9177-482a32340552",
+            "name": "model",
+            "type": "MODEL",
+            "linkIds": [12],
+            "pos": {
+              "0": 581.59912109375,
+              "1": 439.13336181640625
+            }
+          },
+          {
+            "id": "8a4cd719-8c67-473b-9b44-ac0582d02641",
+            "name": "positive",
+            "type": "CONDITIONING",
+            "linkIds": [13],
+            "pos": {
+              "0": 581.59912109375,
+              "1": 459.13336181640625
+            }
+          },
+          {
+            "id": "a78d6b3a-ad40-4300-b0a5-2cdbdb8dc135",
+            "name": "negative",
+            "type": "CONDITIONING",
+            "linkIds": [14],
+            "pos": {
+              "0": 581.59912109375,
+              "1": 479.13336181640625
+            }
+          },
+          {
+            "id": "4c7abe0c-902d-49ef-a5b0-cbf02b50b693",
+            "name": "latent_image",
+            "type": "LATENT",
+            "linkIds": [15],
+            "pos": {
+              "0": 581.59912109375,
+              "1": 499.13336181640625
+            }
+          }
+        ],
+        "outputs": [],
+        "widgets": [],
+        "nodes": [
+          {
+            "id": 10,
+            "type": "CLIPTextEncode",
+            "pos": [661.59912109375, 314.13336181640625],
+            "size": [400, 200],
+            "flags": {},
+            "order": 1,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "clip",
+                "name": "clip",
+                "type": "CLIP",
+                "link": 11
+              },
+              {
+                "localized_name": "text",
+                "name": "text",
+                "type": "STRING",
+                "widget": {
+                  "name": "text"
+                },
+                "link": 10
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "CONDITIONING",
+                "name": "CONDITIONING",
+                "type": "CONDITIONING",
+                "links": null
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "CLIPTextEncode"
+            },
+            "widgets_values": [""]
+          },
+          {
+            "id": 11,
+            "type": "KSampler",
+            "pos": [674.1234741210938, 570.5839233398438],
+            "size": [270, 262],
+            "flags": {},
+            "order": 0,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 12
+              },
+              {
+                "localized_name": "positive",
+                "name": "positive",
+                "type": "CONDITIONING",
+                "link": 13
+              },
+              {
+                "localized_name": "negative",
+                "name": "negative",
+                "type": "CONDITIONING",
+                "link": 14
+              },
+              {
+                "localized_name": "latent_image",
+                "name": "latent_image",
+                "type": "LATENT",
+                "link": 15
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "LATENT",
+                "name": "LATENT",
+                "type": "LATENT",
+                "links": null
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "KSampler"
+            },
+            "widgets_values": [0, "randomize", 20, 8, "euler", "simple", 1]
+          }
+        ],
+        "groups": [],
+        "links": [
+          {
+            "id": 10,
+            "origin_id": -10,
+            "origin_slot": 0,
+            "target_id": 10,
+            "target_slot": 1,
+            "type": "STRING"
+          },
+          {
+            "id": 11,
+            "origin_id": -10,
+            "origin_slot": 1,
+            "target_id": 10,
+            "target_slot": 0,
+            "type": "CLIP"
+          },
+          {
+            "id": 12,
+            "origin_id": -10,
+            "origin_slot": 2,
+            "target_id": 11,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 13,
+            "origin_id": -10,
+            "origin_slot": 3,
+            "target_id": 11,
+            "target_slot": 1,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 14,
+            "origin_id": -10,
+            "origin_slot": 4,
+            "target_id": 11,
+            "target_slot": 2,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 15,
+            "origin_id": -10,
+            "origin_slot": 5,
+            "target_id": 11,
+            "target_slot": 3,
+            "type": "LATENT"
+          }
+        ],
+        "extra": {}
+      }
+    ]
+  },
+  "config": {},
+  "extra": {
+    "ds": {
+      "scale": 0.7,
+      "offset": [0, 0]
+    },
+    "frontendVersion": "1.24.1"
+  },
+  "version": 0.4
+}

--- a/browser_tests/fixtures/helpers/SubgraphHelper.ts
+++ b/browser_tests/fixtures/helpers/SubgraphHelper.ts
@@ -356,6 +356,43 @@ export class SubgraphHelper {
     await this.comfyPage.nextFrame()
   }
 
+  /**
+   * Disconnects and reconnects the interior link feeding a promoted subgraph
+   * input, forcing every host node of this definition to re-resolve the
+   * promoted widget through `SubgraphNode._setWidget`.
+   *
+   * Must be called from inside the subgraph.
+   */
+  async rebindPromotedInput(
+    interiorNode: NodeReference,
+    inputName: string
+  ): Promise<void> {
+    const slotIndex = await this.page.evaluate(
+      ([nodeId, name]) => {
+        const node = window.app!.canvas.graph!.getNodeById(nodeId)
+        if (!node) throw new Error(`Node ${nodeId} not found`)
+        const index = node.inputs.findIndex((input) => input.name === name)
+        if (index === -1) {
+          throw new Error(`Input '${name}' not found on node ${nodeId}`)
+        }
+        return index
+      },
+      [interiorNode.id, inputName] as const
+    )
+
+    const slot = await interiorNode.getInput(slotIndex)
+    await slot.removeLinks()
+    await this.comfyPage.nextFrame()
+    await expect
+      .poll(() => slot.getLinkCount(), 'Interior link should be detached')
+      .toBe(0)
+
+    await this.connectFromInput(interiorNode, slotIndex, inputName)
+    await expect
+      .poll(() => slot.getLinkCount(), 'Interior link should be restored')
+      .toBe(1)
+  }
+
   async promoteWidget(nodeLocator: Locator, widgetName: string): Promise<void> {
     const widget = nodeLocator.getByLabel(widgetName, { exact: true })
     await this.comfyPage.contextMenu

--- a/browser_tests/tests/subgraph/subgraphPromotion.spec.ts
+++ b/browser_tests/tests/subgraph/subgraphPromotion.spec.ts
@@ -159,41 +159,41 @@ test.describe(
       )
 
       // Open bug #14495 — drop `test.fail` when the fix lands.
-      test.fail(
-        'Promoted STRING widget edit survives a rebind of the interior link',
-        async ({ comfyPage }) => {
-          await comfyPage.workflow.loadWorkflow(
-            'subgraphs/subgraph-with-promoted-text-widget'
-          )
-          await comfyPage.vueNodes.waitForNodes()
+      test('Promoted STRING widget edit survives a rebind of the interior link', async ({
+        comfyPage
+      }) => {
+        await comfyPage.workflow.loadWorkflow(
+          'subgraphs/subgraph-with-promoted-text-widget'
+        )
+        await comfyPage.vueNodes.waitForNodes()
 
-          const hostValue = 'promoted-value-rebind-test'
-          const promotedTextarea = comfyPage.vueNodes
-            .getNodeLocator('11')
-            .getByRole('textbox', { name: 'text' })
-          await promotedTextarea.fill(hostValue)
-          await expect(promotedTextarea).toHaveValue(hostValue)
+        const hostValue = 'promoted-value-rebind-test'
+        const promotedTextarea = comfyPage.vueNodes
+          .getNodeLocator('11')
+          .getByRole('textbox', { name: 'text' })
+        await promotedTextarea.fill(hostValue)
+        await expect(promotedTextarea).toHaveValue(hostValue)
 
-          await comfyPage.vueNodes.enterSubgraph('11')
-          await expect.poll(() => comfyPage.subgraph.isInSubgraph()).toBe(true)
+        await comfyPage.vueNodes.enterSubgraph('11')
+        await expect.poll(() => comfyPage.subgraph.isInSubgraph()).toBe(true)
 
-          const interiorNodes = await comfyPage.nodeOps.getNodeRefsByType(
-            'CLIPTextEncode',
-            true
-          )
-          expect(
-            interiorNodes,
-            'Expected exactly one interior CLIPTextEncode'
-          ).toHaveLength(1)
+        const interiorNodes = await comfyPage.nodeOps.getNodeRefsByType(
+          'CLIPTextEncode',
+          true
+        )
+        expect(
+          interiorNodes,
+          'Expected exactly one interior CLIPTextEncode'
+        ).toHaveLength(1)
 
-          await comfyPage.subgraph.rebindPromotedInput(interiorNodes[0], 'text')
+        await comfyPage.subgraph.rebindPromotedInput(interiorNodes[0], 'text')
 
-          await comfyPage.subgraph.exitViaBreadcrumb()
-          await comfyPage.vueNodes.waitForNodes()
+        await comfyPage.subgraph.exitViaBreadcrumb()
+        await comfyPage.vueNodes.waitForNodes()
 
-          await expect(promotedTextarea).toHaveValue(hostValue)
-        }
-      )
+        test.fail()
+        await expect(promotedTextarea).toHaveValue(hostValue)
+      })
     })
 
     test.describe('Manual Promote/Demote via Context Menu', () => {

--- a/browser_tests/tests/subgraph/subgraphPromotion.spec.ts
+++ b/browser_tests/tests/subgraph/subgraphPromotion.spec.ts
@@ -157,6 +157,43 @@ test.describe(
           ).toHaveValue(updatedInteriorContent)
         }
       )
+
+      // Open bug #14495 — drop `test.fail` when the fix lands.
+      test.fail(
+        'Promoted STRING widget edit survives a rebind of the interior link',
+        async ({ comfyPage }) => {
+          await comfyPage.workflow.loadWorkflow(
+            'subgraphs/subgraph-with-promoted-text-widget'
+          )
+          await comfyPage.vueNodes.waitForNodes()
+
+          const hostValue = 'promoted-value-rebind-test'
+          const promotedTextarea = comfyPage.vueNodes
+            .getNodeLocator('11')
+            .getByRole('textbox', { name: 'text' })
+          await promotedTextarea.fill(hostValue)
+          await expect(promotedTextarea).toHaveValue(hostValue)
+
+          await comfyPage.vueNodes.enterSubgraph('11')
+          await expect.poll(() => comfyPage.subgraph.isInSubgraph()).toBe(true)
+
+          const interiorNodes = await comfyPage.nodeOps.getNodeRefsByType(
+            'CLIPTextEncode',
+            true
+          )
+          expect(
+            interiorNodes,
+            'Expected exactly one interior CLIPTextEncode'
+          ).toHaveLength(1)
+
+          await comfyPage.subgraph.rebindPromotedInput(interiorNodes[0], 'text')
+
+          await comfyPage.subgraph.exitViaBreadcrumb()
+          await comfyPage.vueNodes.waitForNodes()
+
+          await expect(promotedTextarea).toHaveValue(hostValue)
+        }
+      )
     })
 
     test.describe('Manual Promote/Demote via Context Menu', () => {

--- a/browser_tests/tests/subgraph/subgraphSharedDefinitionHostIsolation.spec.ts
+++ b/browser_tests/tests/subgraph/subgraphSharedDefinitionHostIsolation.spec.ts
@@ -1,0 +1,71 @@
+import {
+  comfyExpect as expect,
+  comfyPageFixture as test
+} from '@e2e/fixtures/ComfyPage'
+
+test.describe(
+  'Subgraph shared-definition host isolation',
+  { tag: ['@subgraph', '@widget', '@vue-nodes'] },
+  () => {
+    test('Rebinding a promoted input does not leak a host edit into a sibling host', async ({
+      comfyPage
+    }) => {
+      const hostAId = '11'
+      const hostBId = '12'
+      const hostAValue = 'host-a-edit'
+      const hostBValue = 'host-b-edit'
+
+      const promotedTextarea = (nodeId: string) =>
+        comfyPage.vueNodes
+          .getNodeLocator(nodeId)
+          .getByRole('textbox', { name: 'text' })
+
+      await comfyPage.workflow.loadWorkflow(
+        'subgraphs/shared-definition-two-hosts-promoted-text'
+      )
+      await comfyPage.vueNodes.waitForNodes()
+
+      const hostA = await comfyPage.nodeOps.getNodeRefById(hostAId)
+      const hostB = await comfyPage.nodeOps.getNodeRefById(hostBId)
+      const hostAType = await hostA.getType()
+      expect(
+        await hostB.getType(),
+        'Both hosts must instantiate the same subgraph definition'
+      ).toBe(hostAType)
+
+      await promotedTextarea(hostAId).fill(hostAValue)
+      await promotedTextarea(hostBId).fill(hostBValue)
+      await expect(promotedTextarea(hostAId)).toHaveValue(hostAValue)
+      await expect(promotedTextarea(hostBId)).toHaveValue(hostBValue)
+
+      await comfyPage.vueNodes.enterSubgraph(hostAId)
+      await expect.poll(() => comfyPage.subgraph.isInSubgraph()).toBe(true)
+
+      const interiorNodes = await comfyPage.nodeOps.getNodeRefsByType(
+        'CLIPTextEncode',
+        true
+      )
+      expect(
+        interiorNodes,
+        'Expected exactly one interior CLIPTextEncode'
+      ).toHaveLength(1)
+
+      await comfyPage.subgraph.rebindPromotedInput(interiorNodes[0], 'text')
+
+      await comfyPage.subgraph.exitViaBreadcrumb()
+      await comfyPage.vueNodes.waitForNodes()
+
+      await expect(promotedTextarea(hostAId)).toBeVisible()
+      await expect(promotedTextarea(hostBId)).toBeVisible()
+
+      await expect(
+        promotedTextarea(hostAId),
+        'Host A must not adopt the sibling host edit'
+      ).not.toHaveValue(hostBValue)
+      await expect(
+        promotedTextarea(hostBId),
+        'Host B must not adopt the sibling host edit'
+      ).not.toHaveValue(hostAValue)
+    })
+  }
+)

--- a/src/lib/litegraph/src/subgraph/SubgraphWidgetPromotion.test.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphWidgetPromotion.test.ts
@@ -420,6 +420,35 @@ describe('SubgraphWidgetPromotion', () => {
 
       expect(promotedWidgetStateByName(subgraphNode, 'value').value).toBe(99)
     })
+
+    it('keeps sibling hosts of one definition isolated across a rebind', async () => {
+      const subgraph = createTestSubgraph({
+        inputs: [{ name: 'value', type: 'STRING' }]
+      })
+      const { node: interiorNode, input: interiorInput } = createNodeWithWidget(
+        'Interior',
+        'text',
+        'seeded',
+        'STRING'
+      )
+      subgraph.add(interiorNode)
+      subgraph.inputNode.slots[0].connect(interiorNode.inputs[0], interiorNode)
+
+      const hostA = createTestSubgraphNode(subgraph, { id: 101 })
+      const hostB = createTestSubgraphNode(subgraph, { id: 102 })
+
+      hostA.widgets[0].value = 'a-edit'
+      hostB.widgets[0].value = 'b-edit'
+      expect(promotedWidgetStateByName(hostA, 'value').value).toBe('a-edit')
+      expect(promotedWidgetStateByName(hostB, 'value').value).toBe('b-edit')
+
+      interiorNode.disconnectInput(0)
+      await Promise.resolve()
+      subgraph.inputNode.slots[0].connect(interiorInput, interiorNode)
+
+      expect(promotedWidgetStateByName(hostA, 'value').value).not.toBe('b-edit')
+      expect(promotedWidgetStateByName(hostB, 'value').value).not.toBe('a-edit')
+    })
   })
 
   describe('Nested Subgraph Widget Promotion', () => {

--- a/src/lib/litegraph/src/subgraph/SubgraphWidgetPromotion.test.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphWidgetPromotion.test.ts
@@ -425,12 +425,11 @@ describe('SubgraphWidgetPromotion', () => {
       const subgraph = createTestSubgraph({
         inputs: [{ name: 'value', type: 'STRING' }]
       })
-      const { node: interiorNode, input: interiorInput } = createNodeWithWidget(
-        'Interior',
-        'text',
-        'seeded',
-        'STRING'
-      )
+      const {
+        node: interiorNode,
+        widget: interiorWidget,
+        input: interiorInput
+      } = createNodeWithWidget('Interior', 'text', 'seeded', 'STRING')
       subgraph.add(interiorNode)
       subgraph.inputNode.slots[0].connect(interiorNode.inputs[0], interiorNode)
 
@@ -441,6 +440,7 @@ describe('SubgraphWidgetPromotion', () => {
       hostB.widgets[0].value = 'b-edit'
       expect(promotedWidgetStateByName(hostA, 'value').value).toBe('a-edit')
       expect(promotedWidgetStateByName(hostB, 'value').value).toBe('b-edit')
+      expect(interiorWidget.value).toBe('seeded')
 
       interiorNode.disconnectInput(0)
       await Promise.resolve()


### PR DESCRIPTION
## Summary

Adds the missing regression coverage for promoted-widget ownership on subgraph host nodes: one spec for the architecture invariant (green today), one `test.fail` repro for the open #14495 bug.

## Changes

- **What**:
  - `browser_tests/tests/subgraph/subgraphSharedDefinitionHostIsolation.spec.ts` (new, **expected green**) — two host `SubgraphNode`s backed by one subgraph definition, each editing its own promoted STRING widget, then a rebind of the promoted input. Asserts neither host adopts the sibling's edit.
  - `browser_tests/tests/subgraph/subgraphPromotion.spec.ts` (**open-bug repro, marked `test.fail`**) — single host: edit the promoted STRING widget on the parent canvas, enter the subgraph, disconnect and reconnect the interior link, assert the edit survived. This is #14495 and is red on `main` today; `test.fail` keeps CI honest without landing a red test.
  - `SubgraphHelper.rebindPromotedInput()` — detaches and re-drags the interior link feeding a promoted subgraph input, forcing `SubgraphNode._setWidget` to re-run.
  - `SubgraphWidgetPromotion.test.ts` — fast unit-level guard for the same isolation invariant. Accompanies the e2e, does not replace it.
  - New asset `browser_tests/assets/subgraphs/shared-definition-two-hosts-promoted-text.json` — two hosts of one text-widget subgraph definition.

## Review Focus

`registerSubgraphNodeDef` builds one node class per subgraph id, closing over a single `Subgraph`. Every host instance of that definition therefore shares the same interior widget objects. ADR 0009 makes the host the owner of a promoted value and the interior widget a schema/default provider only; the new spec is the executable form of that rule.

Measured behaviour of the new unit guard (vitest, local, same checkout):

| | `main` | #14961 |
| --- | --- | --- |
| after host A edits `X`, host B edits `Y` | A=`X` B=`Y`, interior untouched | A=`X` B=`Y`, **interior=`Y`** |
| after rebinding the promoted input | A=`default` B=`default` | **A=`Y`** B=`Y` |

So on `main` a rebind loses both edits (#14495, covered by the `test.fail` spec), while under #14961's write-back it loses host A's edit *and* silently substitutes host B's — a cross-host data leak that #14495's symptom hides. The isolation spec passes on `main` and fails on `fix/fe-14495-promoted-string-widget-sync-v2`.

Note for anyone reading the original framing: the isolation assertion has to be "host A must not show host B's value", not "host A still shows its own value". The latter is red on `main` too, because `main` reverts both hosts to the interior default.

Related to #14495
