### PR TITLE
fix: show promoted advanced widgets on ECS

### DIFF
--- a/browser_tests/tests/subgraph/subgraphPromotion.spec.ts
+++ b/browser_tests/tests/subgraph/subgraphPromotion.spec.ts
@@ -98,47 +98,56 @@ test.describe(
           'Promoted advanced widget remains visible when global advanced widgets are disabled',
           { tag: ['@node'] },
           async ({ comfyPage }) => {
-            await comfyPage.settings.setSetting(
-              'Comfy.Node.AlwaysShowAdvancedWidgets',
-              false
-            )
-            const modelSamplingNode = await comfyPage.nodeOps.addNode(
-              'ModelSamplingFlux',
-              {},
-              { x: 500, y: 200 }
-            )
-            await comfyPage.nextFrame()
-            await expect(
-              comfyPage.vueNodes.getNodeLocator(String(modelSamplingNode.id))
-            ).toBeVisible()
+            const subgraphNodeId =
+              await test.step('Convert a node with hidden advanced widgets to a subgraph', async () => {
+                await comfyPage.settings.setSetting(
+                  'Comfy.Node.AlwaysShowAdvancedWidgets',
+                  false
+                )
+                const modelSamplingNode = await comfyPage.nodeOps.addNode(
+                  'ModelSamplingFlux',
+                  {},
+                  { x: 500, y: 200 }
+                )
+                await comfyPage.nextFrame()
+                await expect(
+                  comfyPage.vueNodes.getNodeLocator(
+                    String(modelSamplingNode.id)
+                  )
+                ).toBeVisible()
 
-            await modelSamplingNode.click('title')
-            const subgraphNode = await modelSamplingNode.convertToSubgraph()
-            const subgraphNodeId = String(subgraphNode.id)
+                await modelSamplingNode.click('title')
+                const subgraphNode = await modelSamplingNode.convertToSubgraph()
+                return String(subgraphNode.id)
+              })
 
-            await comfyPage.vueNodes.enterSubgraph(subgraphNodeId)
-            const interiorNode =
-              comfyPage.vueNodes.getNodeByTitle('ModelSamplingFlux')
-            await expect(interiorNode).toBeVisible()
-            await interiorNode
-              .getByText('Show advanced inputs', { exact: true })
-              .click()
-            await expect(
-              interiorNode.getByLabel('max_shift', { exact: true })
-            ).toBeVisible()
-            await comfyPage.subgraph.promoteWidget(interiorNode, 'max_shift')
-            await comfyPage.subgraph.exitViaBreadcrumb()
+            await test.step('Promote an advanced interior widget', async () => {
+              await comfyPage.vueNodes.enterSubgraph(subgraphNodeId)
+              const interiorNode =
+                comfyPage.vueNodes.getNodeByTitle('ModelSamplingFlux')
+              await expect(interiorNode).toBeVisible()
+              await interiorNode
+                .getByText('Show advanced inputs', { exact: true })
+                .click()
+              await expect(
+                interiorNode.getByLabel('max_shift', { exact: true })
+              ).toBeVisible()
+              await comfyPage.subgraph.promoteWidget(interiorNode, 'max_shift')
+              await comfyPage.subgraph.exitViaBreadcrumb()
+            })
 
-            await expectPromotedWidgetNamesToContain(
-              comfyPage,
-              subgraphNodeId,
-              'max_shift'
-            )
-            await expect(
-              comfyPage.vueNodes
-                .getNodeLocator(subgraphNodeId)
-                .getByLabel('max_shift', { exact: true })
-            ).toBeVisible()
+            await test.step('Keep the promoted widget visible on the host', async () => {
+              await expectPromotedWidgetNamesToContain(
+                comfyPage,
+                subgraphNodeId,
+                'max_shift'
+              )
+              await expect(
+                comfyPage.vueNodes
+                  .getNodeLocator(subgraphNodeId)
+                  .getByLabel('max_shift', { exact: true })
+              ).toBeVisible()
+            })
           }
         )
 

--- a/browser_tests/tests/subgraph/subgraphPromotion.spec.ts
+++ b/browser_tests/tests/subgraph/subgraphPromotion.spec.ts
@@ -94,6 +94,54 @@ test.describe(
       'Promoted Widget Visibility in Vue Mode',
       { tag: ['@vue-nodes'] },
       () => {
+        test(
+          'Promoted advanced widget remains visible when global advanced widgets are disabled',
+          { tag: ['@node'] },
+          async ({ comfyPage }) => {
+            await comfyPage.settings.setSetting(
+              'Comfy.Node.AlwaysShowAdvancedWidgets',
+              false
+            )
+            const modelSamplingNode = await comfyPage.nodeOps.addNode(
+              'ModelSamplingFlux',
+              {},
+              { x: 500, y: 200 }
+            )
+            await comfyPage.nextFrame()
+            await expect(
+              comfyPage.vueNodes.getNodeLocator(String(modelSamplingNode.id))
+            ).toBeVisible()
+
+            await modelSamplingNode.click('title')
+            const subgraphNode = await modelSamplingNode.convertToSubgraph()
+            const subgraphNodeId = String(subgraphNode.id)
+
+            await comfyPage.vueNodes.enterSubgraph(subgraphNodeId)
+            const interiorNode =
+              comfyPage.vueNodes.getNodeByTitle('ModelSamplingFlux')
+            await expect(interiorNode).toBeVisible()
+            await interiorNode
+              .getByText('Show advanced inputs', { exact: true })
+              .click()
+            await expect(
+              interiorNode.getByLabel('max_shift', { exact: true })
+            ).toBeVisible()
+            await comfyPage.subgraph.promoteWidget(interiorNode, 'max_shift')
+            await comfyPage.subgraph.exitViaBreadcrumb()
+
+            await expectPromotedWidgetNamesToContain(
+              comfyPage,
+              subgraphNodeId,
+              'max_shift'
+            )
+            await expect(
+              comfyPage.vueNodes
+                .getNodeLocator(subgraphNodeId)
+                .getByLabel('max_shift', { exact: true })
+            ).toBeVisible()
+          }
+        )
+
         test('Promoted text widget renders and enters the subgraph in Vue mode', async ({
           comfyPage
         }) => {

--- a/src/renderer/extensions/vueNodes/composables/useProcessedWidgets.test.ts
+++ b/src/renderer/extensions/vueNodes/composables/useProcessedWidgets.test.ts
@@ -339,25 +339,22 @@ describe('promoted subgraph widgets', () => {
     )
   })
 
-  it('shows an advanced promoted widget on the node canvas', () => {
+  it.for([
+    ['shows on the node canvas', { advanced: true }, false, true],
+    ['shows when selected in App Mode', { advanced: true }, true, true],
+    [
+      'stays hidden when explicitly hidden',
+      { advanced: true, hidden: true },
+      true,
+      false
+    ]
+  ] as const)('%s', ([, options, explicitWidgetIds, visible]) => {
     const { graph, hostNode } = setupComplexPromotionFixture()
-    setHostWidgetOptions(hostNode, { advanced: true })
+    setHostWidgetOptions(hostNode, options)
 
-    expect(processHostWidget(graph, hostNode, false).visible).toBe(true)
-  })
-
-  it('shows a selected advanced promoted widget in App Mode', () => {
-    const { graph, hostNode } = setupComplexPromotionFixture()
-    setHostWidgetOptions(hostNode, { advanced: true })
-
-    expect(processHostWidget(graph, hostNode).visible).toBe(true)
-  })
-
-  it('keeps explicitly hidden promoted widgets hidden', () => {
-    const { graph, hostNode } = setupComplexPromotionFixture()
-    setHostWidgetOptions(hostNode, { advanced: true, hidden: true })
-
-    expect(processHostWidget(graph, hostNode).visible).toBe(false)
+    expect(processHostWidget(graph, hostNode, explicitWidgetIds).visible).toBe(
+      visible
+    )
   })
 
   it('clears errors on both the interior source and the host', () => {

--- a/src/renderer/extensions/vueNodes/composables/useProcessedWidgets.test.ts
+++ b/src/renderer/extensions/vueNodes/composables/useProcessedWidgets.test.ts
@@ -302,9 +302,9 @@ describe('promoted subgraph widgets', () => {
   ) {
     const id = hostNode.widgets[0]?.widgetId
     if (!id) throw new Error('Expected the promoted host widget to be keyed')
-    const state = useWidgetValueStore().getWidget(id)
-    if (!state) throw new Error('Expected promoted host widget state')
-    state.options = options
+    if (!useWidgetValueStore().setOptions(id, options)) {
+      throw new Error('Expected promoted host widget state')
+    }
   }
 
   function recordInteriorError() {

--- a/src/renderer/extensions/vueNodes/composables/useProcessedWidgets.test.ts
+++ b/src/renderer/extensions/vueNodes/composables/useProcessedWidgets.test.ts
@@ -302,7 +302,7 @@ describe('promoted subgraph widgets', () => {
   ) {
     const id = hostNode.widgets[0]?.widgetId
     if (!id) throw new Error('Expected the promoted host widget to be keyed')
-    if (!useWidgetValueStore().setOptions(id, options)) {
+    if (!useWidgetValueStore().updateOptions(id, options)) {
       throw new Error('Expected promoted host widget state')
     }
   }

--- a/src/renderer/extensions/vueNodes/composables/useProcessedWidgets.test.ts
+++ b/src/renderer/extensions/vueNodes/composables/useProcessedWidgets.test.ts
@@ -278,18 +278,33 @@ describe('promoted subgraph widgets', () => {
     cleanupComplexPromotionFixtureNodeType()
   })
 
-  function processHostWidget(graph: LGraph, hostNode: SubgraphNode) {
+  function processHostWidget(
+    graph: LGraph,
+    hostNode: SubgraphNode,
+    explicitWidgetIds = true
+  ) {
     const id = hostNode.widgets[0]?.widgetId
     if (!id) throw new Error('Expected the promoted host widget to be keyed')
     return computeProcessedWidgets({
       nodeData: hostNode._state,
-      widgetIds: [id],
+      widgetIds: explicitWidgetIds ? [id] : undefined,
       graphId: graph.id,
       showAdvanced: false,
       isGraphReady: true,
       rootGraph: graph,
       ui: noopUi
     })[0]
+  }
+
+  function setHostWidgetOptions(
+    hostNode: SubgraphNode,
+    options: IBaseWidget['options']
+  ) {
+    const id = hostNode.widgets[0]?.widgetId
+    if (!id) throw new Error('Expected the promoted host widget to be keyed')
+    const state = useWidgetValueStore().getWidget(id)
+    if (!state) throw new Error('Expected promoted host widget state')
+    state.options = options
   }
 
   function recordInteriorError() {
@@ -322,6 +337,27 @@ describe('promoted subgraph widgets', () => {
     expect(processHostWidget(graph, hostNode).simplified.nodeLocatorId).toBe(
       createNodeLocatorId(subgraph.id, INTERIOR_ID)
     )
+  })
+
+  it('shows an advanced promoted widget on the node canvas', () => {
+    const { graph, hostNode } = setupComplexPromotionFixture()
+    setHostWidgetOptions(hostNode, { advanced: true })
+
+    expect(processHostWidget(graph, hostNode, false).visible).toBe(true)
+  })
+
+  it('shows a selected advanced promoted widget in App Mode', () => {
+    const { graph, hostNode } = setupComplexPromotionFixture()
+    setHostWidgetOptions(hostNode, { advanced: true })
+
+    expect(processHostWidget(graph, hostNode).visible).toBe(true)
+  })
+
+  it('keeps explicitly hidden promoted widgets hidden', () => {
+    const { graph, hostNode } = setupComplexPromotionFixture()
+    setHostWidgetOptions(hostNode, { advanced: true, hidden: true })
+
+    expect(processHostWidget(graph, hostNode).visible).toBe(false)
   })
 
   it('clears errors on both the interior source and the host', () => {

--- a/src/renderer/extensions/vueNodes/composables/useProcessedWidgets.ts
+++ b/src/renderer/extensions/vueNodes/composables/useProcessedWidgets.ts
@@ -146,6 +146,7 @@ function buildSlotMetadata(
       originOutputName: link
         ? originNode?.outputs?.[link.originSlot]?.name
         : undefined,
+      promoted: input.widgetId !== undefined,
       type: String(input.type)
     }
     if (input.name) metadata.set(input.name, slotInfo)
@@ -375,7 +376,11 @@ function processWidget(
     )
 
   const slotInfo = ctx.slotMetadata.get(widgetState.name)
-  const visible = isWidgetVisible(options, ctx.showAdvanced, slotInfo?.linked)
+  const visible = isWidgetVisible(
+    options,
+    ctx.showAdvanced,
+    slotInfo?.linked || slotInfo?.promoted
+  )
   const isDisabled = slotInfo?.linked || widgetState.disabled
   const widgetOptions = isDisabled ? { ...options, disabled: true } : options
   const value = widgetState.value as WidgetValue

--- a/src/renderer/extensions/vueNodes/composables/useProcessedWidgets.ts
+++ b/src/renderer/extensions/vueNodes/composables/useProcessedWidgets.ts
@@ -167,11 +167,11 @@ function getHostNode(
 function isWidgetVisible(
   options: IWidgetOptions,
   showAdvanced: boolean,
-  linked = false
+  ignoreAdvanced = false
 ): boolean {
   const hidden = options.hidden ?? false
   const advanced = options.advanced ?? false
-  return !hidden && (!advanced || showAdvanced || linked)
+  return !hidden && (!advanced || showAdvanced || ignoreAdvanced)
 }
 
 function hasWidgetError(

--- a/src/renderer/extensions/vueNodes/types/widgetGrid.ts
+++ b/src/renderer/extensions/vueNodes/types/widgetGrid.ts
@@ -10,6 +10,7 @@ export interface WidgetSlotMetadata {
   linked: boolean
   originNodeId?: NodeId
   originOutputName?: string
+  promoted: boolean
   type: string
 }
 

--- a/src/stores/widgetValueStore.test.ts
+++ b/src/stores/widgetValueStore.test.ts
@@ -216,6 +216,17 @@ describe('useWidgetValueStore', () => {
       ).toBe(false)
     })
 
+    it('setOptions replaces registered widget options and reports missing widgets', () => {
+      const store = useWidgetValueStore()
+      store.registerWidget(seedA, state('number', 100))
+
+      expect(store.setOptions(seedA, { advanced: true })).toBe(true)
+      expect(store.getWidget(seedA)?.options).toEqual({ advanced: true })
+      expect(
+        store.setOptions(widgetId(graphA, toNodeId('missing'), 'seed'), {})
+      ).toBe(false)
+    })
+
     it('deleteWidget removes registered widgets from node order', () => {
       const store = useWidgetValueStore()
       const steps = widgetId(graphA, toNodeId('node-1'), 'steps')

--- a/src/stores/widgetValueStore.test.ts
+++ b/src/stores/widgetValueStore.test.ts
@@ -216,14 +216,21 @@ describe('useWidgetValueStore', () => {
       ).toBe(false)
     })
 
-    it('setOptions replaces registered widget options and reports missing widgets', () => {
+    it('updateOptions preserves existing options and reports missing widgets', () => {
       const store = useWidgetValueStore()
-      store.registerWidget(seedA, state('number', 100))
+      store.registerWidget(
+        seedA,
+        state('number', 100, { options: { min: 0, max: 10 } })
+      )
 
-      expect(store.setOptions(seedA, { advanced: true })).toBe(true)
-      expect(store.getWidget(seedA)?.options).toEqual({ advanced: true })
+      expect(store.updateOptions(seedA, { advanced: true })).toBe(true)
+      expect(store.getWidget(seedA)?.options).toEqual({
+        min: 0,
+        max: 10,
+        advanced: true
+      })
       expect(
-        store.setOptions(widgetId(graphA, toNodeId('missing'), 'seed'), {})
+        store.updateOptions(widgetId(graphA, toNodeId('missing'), 'seed'), {})
       ).toBe(false)
     })
 

--- a/src/stores/widgetValueStore.ts
+++ b/src/stores/widgetValueStore.ts
@@ -157,6 +157,16 @@ export const useWidgetValueStore = defineStore('widgetValue', () => {
     return true
   }
 
+  function setOptions(
+    widgetId: WidgetId,
+    options: WidgetState['options']
+  ): boolean {
+    const state = getWidget(widgetId)
+    if (!state) return false
+    state.options = options
+    return true
+  }
+
   function deleteWidget(widgetId: WidgetId): boolean {
     if (!isWidgetId(widgetId)) return false
 
@@ -220,6 +230,7 @@ export const useWidgetValueStore = defineStore('widgetValue', () => {
     getWidget,
     getWidgetRenderState,
     setValue,
+    setOptions,
     deleteWidget,
     getNodeWidgets,
     getNodeWidgetIds,

--- a/src/stores/widgetValueStore.ts
+++ b/src/stores/widgetValueStore.ts
@@ -157,13 +157,13 @@ export const useWidgetValueStore = defineStore('widgetValue', () => {
     return true
   }
 
-  function setOptions(
+  function updateOptions(
     widgetId: WidgetId,
-    options: WidgetState['options']
+    options: Partial<WidgetState['options']>
   ): boolean {
     const state = getWidget(widgetId)
     if (!state) return false
-    state.options = options
+    state.options = { ...state.options, ...options }
     return true
   }
 
@@ -230,7 +230,7 @@ export const useWidgetValueStore = defineStore('widgetValue', () => {
     getWidget,
     getWidgetRenderState,
     setValue,
-    setOptions,
+    updateOptions,
     deleteWidget,
     getNodeWidgets,
     getNodeWidgetIds,


### PR DESCRIPTION
## Summary

Forward-ports the promoted advanced-widget visibility invariant from #14647 to the store-backed ECS rendering path.

Promoted host inputs are user-selected public controls and bypass only the advanced-widget filter. Explicitly hidden widgets remain hidden.

## Red-green verification

- `4e2084d8a0` adds canvas and App Mode regressions; both fail on the ECS base because visibility only recognizes external links.
- `796648dcae` derives promotion from the host input's canonical `widgetId`; all regressions pass.

## Test plan

- [x] Confirm canvas regression fails before the fix
- [x] Confirm App Mode regression fails before the fix
- [x] Confirm targeted unit suite passes after the fix (39 tests)
- [x] Run typecheck, lint, and format checks