### PR TITLE
fix: emit cameraChanged once with the full camera state

### DIFF
--- a/src/extensions/core/load3d/ControlsManager.test.ts
+++ b/src/extensions/core/load3d/ControlsManager.test.ts
@@ -1,8 +1,7 @@
-import * as THREE from 'three'
+﻿import * as THREE from 'three'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { ControlsManager } from './ControlsManager'
-import type { EventManagerInterface } from './interfaces'
 
 const { mockOrbitControls } = vi.hoisted(() => ({
   mockOrbitControls: vi.fn()
@@ -35,25 +34,15 @@ vi.mock('three/examples/jsm/controls/OrbitControls', () => {
   return { OrbitControls }
 })
 
-function makeMockEventManager() {
-  return {
-    addEventListener: vi.fn(),
-    removeEventListener: vi.fn(),
-    emitEvent: vi.fn()
-  } satisfies EventManagerInterface
-}
-
 function makeElement() {
   return document.createElement('div')
 }
 
 describe('ControlsManager', () => {
-  let events: ReturnType<typeof makeMockEventManager>
   let camera: THREE.PerspectiveCamera
   let manager: ControlsManager
 
   beforeEach(() => {
-    events = makeMockEventManager()
     camera = new THREE.PerspectiveCamera()
   })
 
@@ -61,49 +50,16 @@ describe('ControlsManager', () => {
     it('attaches OrbitControls to the interaction element', () => {
       const element = makeElement()
 
-      manager = new ControlsManager(element, camera, events)
+      manager = new ControlsManager(element, camera)
 
       expect(mockOrbitControls).toHaveBeenCalledWith(camera, element)
       expect(manager.controls.enableDamping).toBe(true)
     })
   })
 
-  describe('init', () => {
-    it('emits cameraChanged with a perspective state when the controls fire end', () => {
-      manager = new ControlsManager(makeElement(), camera, events)
-      camera.position.set(1, 2, 3)
-      camera.zoom = 1.25
-      manager.controls.target.set(4, 5, 6)
-      manager.init()
-
-      ;(manager.controls as unknown as { fire(e: string): void }).fire('end')
-
-      expect(events.emitEvent).toHaveBeenCalledWith('cameraChanged', {
-        position: expect.objectContaining({ x: 1, y: 2, z: 3 }),
-        target: expect.objectContaining({ x: 4, y: 5, z: 6 }),
-        zoom: 1.25,
-        cameraType: 'perspective'
-      })
-    })
-
-    it('reports orthographic camera type when initialized with one', () => {
-      const ortho = new THREE.OrthographicCamera()
-      ortho.zoom = 0.5
-      manager = new ControlsManager(makeElement(), ortho, events)
-      manager.init()
-
-      ;(manager.controls as unknown as { fire(e: string): void }).fire('end')
-
-      expect(events.emitEvent).toHaveBeenCalledWith(
-        'cameraChanged',
-        expect.objectContaining({ cameraType: 'orthographic', zoom: 0.5 })
-      )
-    })
-  })
-
   describe('updateCamera', () => {
     it('rebinds controls to the new camera, copies position from the previous one, and preserves the target', () => {
-      manager = new ControlsManager(makeElement(), camera, events)
+      manager = new ControlsManager(makeElement(), camera)
       camera.position.set(7, 8, 9)
       manager.controls.target.set(1, 1, 1)
 
@@ -119,7 +75,7 @@ describe('ControlsManager', () => {
 
   describe('update / reset', () => {
     it('update delegates to controls.update', () => {
-      manager = new ControlsManager(makeElement(), camera, events)
+      manager = new ControlsManager(makeElement(), camera)
 
       manager.update()
 
@@ -127,7 +83,7 @@ describe('ControlsManager', () => {
     })
 
     it('reset clears the target back to the origin and refreshes', () => {
-      manager = new ControlsManager(makeElement(), camera, events)
+      manager = new ControlsManager(makeElement(), camera)
       manager.controls.target.set(5, 6, 7)
 
       manager.reset()
@@ -139,7 +95,7 @@ describe('ControlsManager', () => {
 
   describe('dispose', () => {
     it('disposes the underlying OrbitControls', () => {
-      manager = new ControlsManager(makeElement(), camera, events)
+      manager = new ControlsManager(makeElement(), camera)
 
       manager.dispose()
 
@@ -149,7 +105,7 @@ describe('ControlsManager', () => {
 
   describe('detach / attach', () => {
     it('detach disables OrbitControls interaction', () => {
-      manager = new ControlsManager(makeElement(), camera, events)
+      manager = new ControlsManager(makeElement(), camera)
       expect(manager.controls.enabled).toBe(true)
 
       manager.detach()
@@ -158,7 +114,7 @@ describe('ControlsManager', () => {
     })
 
     it('attach re-enables OrbitControls interaction', () => {
-      manager = new ControlsManager(makeElement(), camera, events)
+      manager = new ControlsManager(makeElement(), camera)
       manager.detach()
 
       manager.attach()

--- a/src/extensions/core/load3d/ControlsManager.ts
+++ b/src/extensions/core/load3d/ControlsManager.ts
@@ -1,46 +1,17 @@
 import * as THREE from 'three'
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls'
 
-import {
-  type ControlsManagerInterface,
-  type EventManagerInterface
-} from './interfaces'
+import { type ControlsManagerInterface } from './interfaces'
 
 export class ControlsManager implements ControlsManagerInterface {
   controls: OrbitControls
-  private eventManager: EventManagerInterface
-  private camera: THREE.Camera
 
-  constructor(
-    interactionElement: HTMLElement,
-    camera: THREE.Camera,
-    eventManager: EventManagerInterface
-  ) {
-    this.eventManager = eventManager
-    this.camera = camera
-
+  constructor(interactionElement: HTMLElement, camera: THREE.Camera) {
     this.controls = new OrbitControls(camera, interactionElement)
     this.controls.enableDamping = true
   }
 
-  init(): void {
-    this.controls.addEventListener('end', () => {
-      const cameraState = {
-        position: this.camera.position.clone(),
-        target: this.controls.target.clone(),
-        zoom:
-          this.camera instanceof THREE.OrthographicCamera
-            ? (this.camera as THREE.OrthographicCamera).zoom
-            : (this.camera as THREE.PerspectiveCamera).zoom,
-        cameraType:
-          this.camera instanceof THREE.PerspectiveCamera
-            ? 'perspective'
-            : 'orthographic'
-      }
-
-      this.eventManager.emitEvent('cameraChanged', cameraState)
-    })
-  }
+  init(): void {}
 
   dispose(): void {
     this.controls.dispose()
@@ -56,7 +27,6 @@ export class ControlsManager implements ControlsManagerInterface {
     const position = this.controls.object.position.clone()
     const target = this.controls.target.clone()
 
-    this.camera = camera
     this.controls.object = camera
     this.controls.target = target
     camera.position.copy(position)

--- a/src/extensions/core/load3d/ControlsManager.ts
+++ b/src/extensions/core/load3d/ControlsManager.ts
@@ -1,7 +1,7 @@
 import * as THREE from 'three'
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls'
 
-import { type ControlsManagerInterface } from './interfaces'
+import type { ControlsManagerInterface } from './interfaces'
 
 export class ControlsManager implements ControlsManagerInterface {
   controls: OrbitControls

--- a/src/extensions/core/load3d/ViewHelperManager.test.ts
+++ b/src/extensions/core/load3d/ViewHelperManager.test.ts
@@ -2,7 +2,7 @@ import * as THREE from 'three'
 import type { OrbitControls } from 'three/examples/jsm/controls/OrbitControls'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import type { EventManagerInterface } from './interfaces'
+import type { CameraState, EventManagerInterface } from './interfaces'
 import { ViewHelperManager } from './ViewHelperManager'
 
 interface MockViewHelperInstance {
@@ -56,6 +56,12 @@ describe('ViewHelperManager', () => {
   let camera: THREE.PerspectiveCamera
   let controls: OrbitControls
   let manager: ViewHelperManager
+  const cameraState = {
+    position: { x: 1, y: 2, z: 3 },
+    target: { x: 4, y: 5, z: 6 },
+    zoom: 1.5,
+    cameraType: 'perspective'
+  } as unknown as CameraState
 
   beforeEach(() => {
     viewHelperInstances.length = 0
@@ -66,6 +72,7 @@ describe('ViewHelperManager', () => {
       {} as THREE.WebGLRenderer,
       () => camera,
       () => controls,
+      () => cameraState,
       events
     )
   })
@@ -89,6 +96,7 @@ describe('ViewHelperManager', () => {
         {} as THREE.WebGLRenderer,
         () => camera,
         () => controls,
+        () => cameraState,
         events
       )
 
@@ -148,39 +156,7 @@ describe('ViewHelperManager', () => {
       expect(events.emitEvent).not.toHaveBeenCalled()
     })
 
-    it('emits cameraChanged with a perspective state when the animation just finished', () => {
-      manager.createViewHelper(document.createElement('div'))
-      camera.position.set(1, 2, 3)
-      camera.zoom = 1.5
-      controls.target.set(4, 5, 6)
-      manager.viewHelper.animating = true
-      ;(
-        manager.viewHelper.update as unknown as {
-          mockImplementation(fn: () => void): void
-        }
-      ).mockImplementation(() => {
-        manager.viewHelper.animating = false
-      })
-
-      manager.update(0)
-
-      expect(events.emitEvent).toHaveBeenCalledWith('cameraChanged', {
-        position: expect.objectContaining({ x: 1, y: 2, z: 3 }),
-        target: expect.objectContaining({ x: 4, y: 5, z: 6 }),
-        zoom: 1.5,
-        cameraType: 'perspective'
-      })
-    })
-
-    it('reports orthographic when the active camera is an OrthographicCamera', () => {
-      const ortho = new THREE.OrthographicCamera()
-      ortho.zoom = 0.5
-      manager = new ViewHelperManager(
-        {} as THREE.WebGLRenderer,
-        () => ortho,
-        () => controls,
-        events
-      )
+    it('emits cameraChanged with the full camera state when the animation just finished', () => {
       manager.createViewHelper(document.createElement('div'))
       manager.viewHelper.animating = true
       ;(
@@ -195,7 +171,7 @@ describe('ViewHelperManager', () => {
 
       expect(events.emitEvent).toHaveBeenCalledWith(
         'cameraChanged',
-        expect.objectContaining({ cameraType: 'orthographic', zoom: 0.5 })
+        cameraState
       )
     })
   })

--- a/src/extensions/core/load3d/ViewHelperManager.test.ts
+++ b/src/extensions/core/load3d/ViewHelperManager.test.ts
@@ -56,12 +56,18 @@ describe('ViewHelperManager', () => {
   let camera: THREE.PerspectiveCamera
   let controls: OrbitControls
   let manager: ViewHelperManager
-  const cameraState = {
-    position: { x: 1, y: 2, z: 3 },
-    target: { x: 4, y: 5, z: 6 },
+  const cameraState: CameraState = {
+    position: new THREE.Vector3(1, 2, 3),
+    target: new THREE.Vector3(4, 5, 6),
     zoom: 1.5,
-    cameraType: 'perspective'
-  } as unknown as CameraState
+    cameraType: 'perspective',
+    quaternion: { x: 0, y: 0, z: 0, w: 1 },
+    fov: 35,
+    aspect: 1.5,
+    near: 0.1,
+    far: 1000,
+    frustum: { left: -2, right: 2, top: 2, bottom: -2 }
+  }
 
   beforeEach(() => {
     viewHelperInstances.length = 0

--- a/src/extensions/core/load3d/ViewHelperManager.ts
+++ b/src/extensions/core/load3d/ViewHelperManager.ts
@@ -3,6 +3,7 @@ import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls'
 import { ViewHelper } from 'three/examples/jsm/helpers/ViewHelper'
 
 import {
+  type CameraState,
   type EventManagerInterface,
   type ViewHelperManagerInterface
 } from './interfaces'
@@ -13,6 +14,7 @@ export class ViewHelperManager implements ViewHelperManagerInterface {
 
   private getActiveCamera: () => THREE.Camera
   private getControls: () => OrbitControls
+  private getCameraState: () => CameraState
   private eventManager: EventManagerInterface
 
   private readonly helperCamera = new THREE.OrthographicCamera(
@@ -29,10 +31,12 @@ export class ViewHelperManager implements ViewHelperManagerInterface {
     _renderer: THREE.WebGLRenderer,
     getActiveCamera: () => THREE.Camera,
     getControls: () => OrbitControls,
+    getCameraState: () => CameraState,
     eventManager: EventManagerInterface
   ) {
     this.getActiveCamera = getActiveCamera
     this.getControls = getControls
+    this.getCameraState = getCameraState
     this.eventManager = eventManager
     this.helperCamera.position.set(0, 0, 2)
   }
@@ -96,20 +100,7 @@ export class ViewHelperManager implements ViewHelperManagerInterface {
       this.viewHelper.update(delta)
 
       if (!this.viewHelper.animating) {
-        const cameraState = {
-          position: this.getActiveCamera().position.clone(),
-          target: this.getControls().target.clone(),
-          zoom:
-            this.getActiveCamera() instanceof THREE.OrthographicCamera
-              ? (this.getActiveCamera() as THREE.OrthographicCamera).zoom
-              : (this.getActiveCamera() as THREE.PerspectiveCamera).zoom,
-          cameraType:
-            this.getActiveCamera() instanceof THREE.PerspectiveCamera
-              ? 'perspective'
-              : 'orthographic'
-        }
-
-        this.eventManager.emitEvent('cameraChanged', cameraState)
+        this.eventManager.emitEvent('cameraChanged', this.getCameraState())
       }
     }
   }

--- a/src/extensions/core/load3d/createLoad3d.ts
+++ b/src/extensions/core/load3d/createLoad3d.ts
@@ -43,11 +43,7 @@ function buildLoad3dDeps(container: HTMLElement): Load3dDeps {
   )
 
   cameraManager = new CameraManager(renderer, eventManager)
-  controlsManager = new ControlsManager(
-    container,
-    cameraManager.activeCamera,
-    eventManager
-  )
+  controlsManager = new ControlsManager(container, cameraManager.activeCamera)
   cameraManager.setControls(controlsManager.controls)
 
   const lightingManager = new LightingManager(sceneManager.scene, eventManager)
@@ -61,6 +57,7 @@ function buildLoad3dDeps(container: HTMLElement): Load3dDeps {
     renderer,
     getActiveCamera,
     getControls,
+    () => cameraManager.getCameraState(),
     eventManager
   )
 


### PR DESCRIPTION
## Summary
rework part1 for https://github.com/Comfy-Org/ComfyUI_frontend/pull/14975

OrbitControls end fired two cameraChanged emitters: ControlsManager sent a hand-built partial state (position/target/zoom/cameraType) while CameraManager sent the full getCameraState() shape. The alternating shapes were written into properties['Camera Config'] and each flip registered as a graph change. ViewHelperManager emitted the same partial shape after view helper animations.

CameraManager is now the single emitter for controls interactions, and ViewHelperManager emits via a getCameraState callback, so every cameraChanged payload carries the one canonical CameraState shape.

## Screenshots (if applicable)
changed camera,
before:
```
write #1: position,target,zoom,cameraType,quaternion,fov,aspect,near,far,frustum
VM3879:8 
write #2: position,target,zoom,cameraType
```

after:

`write #1: position,target,zoom,cameraType,quaternion,fov,aspect,near,far,frustum`