### PR TITLE
feat(billing): load, error, and empty states for local plans

### DIFF
--- a/browser_tests/tests/settingsPlansSubscribe.spec.ts
+++ b/browser_tests/tests/settingsPlansSubscribe.spec.ts
@@ -12,15 +12,8 @@ import { CloudAuthHelper } from '@e2e/fixtures/helpers/CloudAuthHelper'
 import { CommandHelper } from '@e2e/fixtures/helpers/CommandHelper'
 
 /**
- * Local plans section checkout and hardening — FE-1600.
- *
- * Off-cloud, the plan-card CTAs must subscribe through the workspace rail on
- * cloud ingest (never the legacy `/customers/cloud-subscription-checkout`),
- * open the Stripe page the backend returns, and flip the subscribed card to a
- * disabled "Current Plan" once op-polling reconciles. A failed plans fetch
- * must surface an error with a working retry, and the cards must fit a mobile
- * viewport. Billing mocks are cross-origin (app on localhost, ingest on its
- * own origin), so every fulfill carries CORS headers and answers OPTIONS
+ * Billing mocks are cross-origin (app on localhost, ingest on its own
+ * origin), so every fulfill carries CORS headers and answers OPTIONS
  * preflights.
  */
 const APP_URL = process.env.PLAYWRIGHT_TEST_URL || 'http://localhost:8188'
@@ -106,12 +99,12 @@ async function mockLegacyReads(page: Page) {
   )
 }
 
-// Boots the local app with a mocked Firebase session and opens the settings
-// dialog on Plan & Credits. window.open is stubbed so no test spawns a real
-// checkout popup; the opened URL lands in dataset.openedUrl.
+/**
+ * Boots the app with a mocked Firebase session and opens Plan & Credits.
+ * window.open is stubbed; the opened URL lands in dataset.openedUrl.
+ */
 async function bootToPlansSection(page: Page, request: APIRequestContext) {
-  // A multi-user local server shows a user-selection screen unless a real
-  // user id is seeded (same approach as the ComfyPage fixture).
+  // Multi-user servers show a user-select screen unless a user id is seeded.
   const usersResponse = await request.get(`${APP_URL}/api/users`)
   const usersBody = (await usersResponse.json()) as {
     users?: Record<string, string>
@@ -141,7 +134,7 @@ async function bootToPlansSection(page: Page, request: APIRequestContext) {
   return dialog
 }
 
-test.describe('Local plans section subscribe (FE-1600)', () => {
+test.describe('Local plans section subscribe', () => {
   test('subscribes via the workspace rail and flips the card to Current', async ({
     page,
     request
@@ -295,7 +288,7 @@ test.describe('Local plans section subscribe (FE-1600)', () => {
 
     await page.setViewportSize({ width: 390, height: 844 })
 
-    // 1px tolerance for subpixel rounding, mirroring keybindingPanel.spec.ts.
+    // 1px tolerance for subpixel rounding.
     await expect
       .poll(() => section.evaluate((el) => el.scrollWidth - el.clientWidth))
       .toBeLessThanOrEqual(1)

--- a/browser_tests/tests/settingsPlansSubscribe.spec.ts
+++ b/browser_tests/tests/settingsPlansSubscribe.spec.ts
@@ -1,5 +1,5 @@
 import { expect } from '@playwright/test'
-import type { Route } from '@playwright/test'
+import type { APIRequestContext, Page, Route } from '@playwright/test'
 
 import type {
   BillingPlansResponse,
@@ -12,14 +12,16 @@ import { CloudAuthHelper } from '@e2e/fixtures/helpers/CloudAuthHelper'
 import { CommandHelper } from '@e2e/fixtures/helpers/CommandHelper'
 
 /**
- * Local plans section checkout — FE-1600 (S2).
+ * Local plans section checkout and hardening — FE-1600.
  *
  * Off-cloud, the plan-card CTAs must subscribe through the workspace rail on
  * cloud ingest (never the legacy `/customers/cloud-subscription-checkout`),
  * open the Stripe page the backend returns, and flip the subscribed card to a
- * disabled "Current Plan" once op-polling reconciles. Billing mocks are
- * cross-origin (app on localhost, ingest on its own origin), so every fulfill
- * carries CORS headers and answers OPTIONS preflights.
+ * disabled "Current Plan" once op-polling reconciles. A failed plans fetch
+ * must surface an error with a working retry, and the cards must fit a mobile
+ * viewport. Billing mocks are cross-origin (app on localhost, ingest on its
+ * own origin), so every fulfill carries CORS headers and answers OPTIONS
+ * preflights.
  */
 const APP_URL = process.env.PLAYWRIGHT_TEST_URL || 'http://localhost:8188'
 
@@ -87,7 +89,59 @@ function billingStatus(planSlug?: string): BillingStatusResponse {
   }
 }
 
-test.describe('Local plans section subscribe (FE-1600 S2)', () => {
+async function mockLegacyReads(page: Page) {
+  await page.route('**/customers/**', (r) =>
+    fulfillJson(
+      r,
+      r.request().url().includes('balance')
+        ? { amount_micros: 0, currency: 'usd' }
+        : { is_active: false }
+    )
+  )
+  await page.route('**/api/billing/status', (r) =>
+    fulfillJson(r, billingStatus())
+  )
+  await page.route('**/api/billing/balance', (r) =>
+    fulfillJson(r, { amount_micros: 0, currency: 'usd' })
+  )
+}
+
+// Boots the local app with a mocked Firebase session and opens the settings
+// dialog on Plan & Credits. window.open is stubbed so no test spawns a real
+// checkout popup; the opened URL lands in dataset.openedUrl.
+async function bootToPlansSection(page: Page, request: APIRequestContext) {
+  // A multi-user local server shows a user-selection screen unless a real
+  // user id is seeded (same approach as the ComfyPage fixture).
+  const usersResponse = await request.get(`${APP_URL}/api/users`)
+  const usersBody = (await usersResponse.json()) as {
+    users?: Record<string, string>
+  }
+  const userId = Object.keys(usersBody.users ?? {})[0]
+
+  await page.addInitScript((id) => {
+    if (id) localStorage.setItem('Comfy.userId', id)
+    window.open = (url) => {
+      document.documentElement.dataset.openedUrl = String(url)
+      return window
+    }
+  }, userId)
+
+  const auth = new CloudAuthHelper(page)
+  await auth.mockAuth()
+
+  await page.goto(APP_URL)
+  await page.waitForFunction(() => !!window.app?.extensionManager, null, {
+    timeout: 45_000
+  })
+
+  await new CommandHelper(page).executeCommand('Comfy.ShowSettingsDialog')
+  const dialog = page.getByTestId('settings-dialog')
+  await expect(dialog).toBeVisible()
+  await dialog.getByRole('button', { name: 'Plan & Credits' }).click()
+  return dialog
+}
+
+test.describe('Local plans section subscribe (FE-1600)', () => {
   test('subscribes via the workspace rail and flips the card to Current', async ({
     page,
     request
@@ -139,34 +193,7 @@ test.describe('Local plans section subscribe (FE-1600 S2)', () => {
       fulfillJson(r, { status: 'succeeded' })
     )
 
-    // A multi-user local server shows a user-selection screen unless a real
-    // user id is seeded (same approach as the ComfyPage fixture).
-    const usersResponse = await request.get(`${APP_URL}/api/users`)
-    const usersBody = (await usersResponse.json()) as {
-      users?: Record<string, string>
-    }
-    const userId = Object.keys(usersBody.users ?? {})[0]
-
-    await page.addInitScript((id) => {
-      if (id) localStorage.setItem('Comfy.userId', id)
-      window.open = (url) => {
-        document.documentElement.dataset.openedUrl = String(url)
-        return window
-      }
-    }, userId)
-
-    const auth = new CloudAuthHelper(page)
-    await auth.mockAuth()
-
-    await page.goto(APP_URL)
-    await page.waitForFunction(() => !!window.app?.extensionManager, null, {
-      timeout: 45_000
-    })
-
-    await new CommandHelper(page).executeCommand('Comfy.ShowSettingsDialog')
-    const dialog = page.getByTestId('settings-dialog')
-    await expect(dialog).toBeVisible()
-    await dialog.getByRole('button', { name: 'Plan & Credits' }).click()
+    const dialog = await bootToPlansSection(page, request)
 
     const chooseStandard = dialog.getByRole('button', {
       name: 'Choose Standard'
@@ -201,5 +228,76 @@ test.describe('Local plans section subscribe (FE-1600 S2)', () => {
     ).toBeEnabled()
 
     expect(legacyCheckoutRequests).toEqual([])
+  })
+
+  test('recovers from a failed plans fetch via retry', async ({
+    page,
+    request
+  }) => {
+    test.setTimeout(90_000)
+
+    let plansAvailable = false
+    await mockLegacyReads(page)
+    await page.route('**/api/billing/plans', async (r) => {
+      if (r.request().method() === 'OPTIONS') {
+        await r.fulfill({ status: 204, headers: CORS_HEADERS })
+        return
+      }
+      if (!plansAvailable) {
+        await r.fulfill({
+          status: 500,
+          contentType: 'application/json',
+          headers: CORS_HEADERS,
+          body: '{}'
+        })
+        return
+      }
+      await fulfillJson(r, plansResponse)
+    })
+
+    const dialog = await bootToPlansSection(page, request)
+
+    await expect(
+      dialog.getByText("We couldn't load your plan details.")
+    ).toBeVisible()
+    await expect(
+      dialog.getByRole('button', { name: 'Choose Standard' })
+    ).toHaveCount(0)
+
+    plansAvailable = true
+    await dialog.getByRole('button', { name: 'Try again' }).click()
+
+    await expect(
+      dialog.getByRole('button', { name: 'Choose Standard' })
+    ).toBeEnabled()
+    await expect(
+      dialog.getByText("We couldn't load your plan details.")
+    ).toHaveCount(0)
+  })
+
+  test('keeps the plans section within the viewport at mobile width', async ({
+    page,
+    request
+  }) => {
+    test.setTimeout(90_000)
+
+    await mockLegacyReads(page)
+    await page.route('**/api/billing/plans', (r) =>
+      fulfillJson(r, plansResponse)
+    )
+
+    const dialog = await bootToPlansSection(page, request)
+
+    const section = dialog.getByTestId('settings-plans-section')
+    await expect(
+      section.getByRole('button', { name: 'Choose Standard' })
+    ).toBeVisible()
+
+    await page.setViewportSize({ width: 390, height: 844 })
+
+    // 1px tolerance for subpixel rounding, mirroring keybindingPanel.spec.ts.
+    await expect
+      .poll(() => section.evaluate((el) => el.scrollWidth - el.clientWidth))
+      .toBeLessThanOrEqual(1)
   })
 })

--- a/browser_tests/tests/settingsPlansSubscribe.spec.ts
+++ b/browser_tests/tests/settingsPlansSubscribe.spec.ts
@@ -317,5 +317,14 @@ test.describe('Local plans section subscribe', () => {
     await expect
       .poll(() => section.evaluate((el) => el.scrollWidth - el.clientWidth))
       .toBeLessThanOrEqual(1)
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () =>
+            document.documentElement.scrollWidth -
+            document.documentElement.clientWidth
+        )
+      )
+      .toBeLessThanOrEqual(1)
   })
 })

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2638,6 +2638,7 @@
     "comingProjects": "Projects",
     "enterpriseCopy": "Need more members? Looking for more flexibility or custom features?",
     "contactUs": "Contact us",
+    "noPlansAvailable": "No plans are available right now. Check back soon.",
     "checkoutCaption": "Checkout happens right here: payment details handled securely by Stripe. Prefer no plan? Keep topping up, anytime."
   },
   "credits": {

--- a/src/platform/workspace/components/dialogs/settings/SettingsPlansSection.test.ts
+++ b/src/platform/workspace/components/dialogs/settings/SettingsPlansSection.test.ts
@@ -29,8 +29,6 @@ vi.mock('@/composables/billing/useBillingContext', () => ({
     fetchPlans: mockFetchPlans,
     plans: mockCatalogPlans,
     currentPlanSlug: mockCurrentPlanSlug,
-    // Inert on purpose: the fetch states must read the useBillingPlans
-    // singleton, not these.
     isLoading: { value: false },
     error: { value: null }
   })

--- a/src/platform/workspace/components/dialogs/settings/SettingsPlansSection.test.ts
+++ b/src/platform/workspace/components/dialogs/settings/SettingsPlansSection.test.ts
@@ -28,7 +28,12 @@ vi.mock('@/composables/billing/useBillingContext', () => ({
   useBillingContext: () => ({
     fetchPlans: mockFetchPlans,
     plans: mockCatalogPlans,
-    currentPlanSlug: mockCurrentPlanSlug
+    currentPlanSlug: mockCurrentPlanSlug,
+    // Deliberately inert: these track the legacy activeContext refresh, so the
+    // fetch-state tests fail if the section reads them instead of the
+    // useBillingPlans singleton.
+    isLoading: { value: false },
+    error: { value: null }
   })
 }))
 
@@ -98,8 +103,11 @@ function renderSection() {
 
 describe('SettingsPlansSection', () => {
   beforeEach(() => {
-    useBillingPlans().teamCreditStops.value = null
-    mockCatalogPlans.value = []
+    const billingPlans = useBillingPlans()
+    billingPlans.teamCreditStops.value = null
+    billingPlans.isLoading.value = false
+    billingPlans.error.value = null
+    mockCatalogPlans.value = yearlyCatalog()
     mockCurrentPlanSlug.value = null
     mockFetchPlans.mockReset()
     mockSubscribeToPersonal.mockReset()
@@ -309,5 +317,53 @@ describe('SettingsPlansSection', () => {
     expect(
       screen.getByRole('button', { name: 'Subscribe to Team Monthly' })
     ).toBeEnabled()
+  })
+
+  it('renders skeletons and no cards while the catalog is loading', () => {
+    mockCatalogPlans.value = []
+    useBillingPlans().isLoading.value = true
+    renderSection()
+
+    expect(screen.getByTestId('plans-skeleton')).toBeTruthy()
+    expect(screen.queryByRole('button', { name: 'Choose Standard' })).toBeNull()
+  })
+
+  it('shows the load error with a retry that re-dispatches the fetch', async () => {
+    mockCatalogPlans.value = []
+    useBillingPlans().error.value = 'network down'
+    renderSection()
+
+    expect(screen.getByText("We couldn't load your plan details.")).toBeTruthy()
+    expect(screen.queryByRole('button', { name: 'Choose Standard' })).toBeNull()
+
+    await userEvent.click(screen.getByRole('button', { name: 'Try again' }))
+    expect(mockFetchPlans).toHaveBeenCalledTimes(2)
+  })
+
+  it('shows the dedicated empty state when the catalog loads empty', () => {
+    mockCatalogPlans.value = []
+    renderSection()
+
+    expect(
+      screen.getByText('No plans are available right now. Check back soon.')
+    ).toBeTruthy()
+    expect(screen.queryByText("We couldn't load your plan details.")).toBeNull()
+    expect(screen.queryByRole('button', { name: 'Choose Standard' })).toBeNull()
+  })
+
+  it('keeps cached cards rendered through a refetch and a refetch failure', () => {
+    useBillingPlans().isLoading.value = true
+    const { unmount } = renderSection()
+
+    expect(screen.getByRole('button', { name: 'Choose Standard' })).toBeTruthy()
+    expect(screen.queryByTestId('plans-skeleton')).toBeNull()
+    unmount()
+
+    useBillingPlans().isLoading.value = false
+    useBillingPlans().error.value = 'refetch failed'
+    renderSection()
+
+    expect(screen.getByRole('button', { name: 'Choose Standard' })).toBeTruthy()
+    expect(screen.queryByText("We couldn't load your plan details.")).toBeNull()
   })
 })

--- a/src/platform/workspace/components/dialogs/settings/SettingsPlansSection.test.ts
+++ b/src/platform/workspace/components/dialogs/settings/SettingsPlansSection.test.ts
@@ -29,9 +29,8 @@ vi.mock('@/composables/billing/useBillingContext', () => ({
     fetchPlans: mockFetchPlans,
     plans: mockCatalogPlans,
     currentPlanSlug: mockCurrentPlanSlug,
-    // Deliberately inert: these track the legacy activeContext refresh, so the
-    // fetch-state tests fail if the section reads them instead of the
-    // useBillingPlans singleton.
+    // Inert on purpose: the fetch states must read the useBillingPlans
+    // singleton, not these.
     isLoading: { value: false },
     error: { value: null }
   })

--- a/src/platform/workspace/components/dialogs/settings/SettingsPlansSection.vue
+++ b/src/platform/workspace/components/dialogs/settings/SettingsPlansSection.vue
@@ -1,5 +1,8 @@
 <template>
-  <section class="flex shrink-0 flex-col gap-4">
+  <section
+    data-testid="settings-plans-section"
+    class="flex shrink-0 flex-col gap-4"
+  >
     <div class="flex flex-col gap-1">
       <h3 class="m-0 text-base font-semibold text-base-foreground">
         {{ t('settingsPlans.title') }}
@@ -9,155 +12,66 @@
       </p>
     </div>
 
-    <div class="flex flex-wrap items-center justify-between gap-3">
-      <ToggleGroup v-model="audience" type="single" variant="outline">
-        <ToggleGroupItem value="personal">
-          {{ t('settingsPlans.personal') }}
-        </ToggleGroupItem>
-        <ToggleGroupItem value="teams">
-          {{ t('settingsPlans.teams') }}
-        </ToggleGroupItem>
-      </ToggleGroup>
+    <template v-if="hasCatalog">
+      <div class="flex flex-wrap items-center justify-between gap-3">
+        <ToggleGroup v-model="audience" type="single" variant="outline">
+          <ToggleGroupItem value="personal">
+            {{ t('settingsPlans.personal') }}
+          </ToggleGroupItem>
+          <ToggleGroupItem value="teams">
+            {{ t('settingsPlans.teams') }}
+          </ToggleGroupItem>
+        </ToggleGroup>
 
-      <div class="flex items-center gap-2">
-        <Switch v-model="billedYearly" />
-        <span class="text-sm font-semibold text-base-foreground">
-          {{ t('settingsPlans.billedYearlyToggle') }}
-        </span>
-        <span
-          class="rounded-full bg-base-foreground px-2 py-0.5 text-2xs font-bold text-base-background"
-        >
-          {{ t('subscription.saveYearly') }}
-        </span>
-      </div>
-    </div>
-
-    <div
-      v-if="audience === 'personal'"
-      class="flex flex-col items-stretch gap-4 xl:flex-row"
-    >
-      <div
-        v-for="plan in plans"
-        :key="plan.key"
-        class="flex flex-1 flex-col gap-4 rounded-2xl border border-interface-stroke p-6"
-      >
-        <span class="text-base font-bold text-base-foreground">
-          {{ plan.name }}
-        </span>
-
-        <div class="flex flex-col gap-1">
-          <div class="flex items-baseline gap-2">
-            <span
-              class="text-[28px] leading-normal font-semibold text-base-foreground tabular-nums"
-            >
-              ${{ billedYearly ? plan.pricing.yearly : plan.pricing.monthly }}
-            </span>
-            <span class="text-base text-muted-foreground">
-              {{ t('subscription.usdPerMonth') }}
-            </span>
-          </div>
-          <span class="text-sm text-muted-foreground tabular-nums">
-            {{
-              billedYearly
-                ? t('subscription.billedYearly', {
-                    total: `$${plan.pricing.yearly * 12}`
-                  })
-                : t('subscription.billedMonthly')
-            }}
+        <div class="flex items-center gap-2">
+          <Switch v-model="billedYearly" />
+          <span class="text-sm font-semibold text-base-foreground">
+            {{ t('settingsPlans.billedYearlyToggle') }}
           </span>
-        </div>
-
-        <div class="border-t border-interface-stroke" />
-
-        <div class="flex flex-col gap-1">
-          <div class="flex items-center gap-1.5">
-            <i
-              class="icon-[lucide--coins] size-4 shrink-0 bg-credit"
-              aria-hidden="true"
-            />
-            <I18nT
-              :keypath="
-                billedYearly
-                  ? 'settingsPlans.creditsAYear'
-                  : 'settingsPlans.creditsAMonth'
-              "
-              tag="span"
-              class="text-sm text-base-foreground"
-            >
-              <template #credits>
-                <span class="font-bold tabular-nums">
-                  {{
-                    n(
-                      billedYearly
-                        ? plan.pricing.credits * 12
-                        : plan.pricing.credits
-                    )
-                  }}
-                </span>
-              </template>
-            </I18nT>
-          </div>
-          <span class="text-sm text-muted-foreground tabular-nums">
-            {{ t('settingsPlans.perDollar', { credits: perDollar(plan) }) }}
-          </span>
-        </div>
-
-        <div class="flex flex-col gap-2">
-          <span class="text-sm text-muted-foreground">
-            {{
-              plan.everythingIn
-                ? t('subscription.everythingInPlus', {
-                    plan: plan.everythingIn
-                  })
-                : t('subscription.whatsIncluded')
-            }}
-          </span>
-          <div
-            v-for="benefit in plan.benefits"
-            :key="benefit"
-            class="flex items-center gap-2"
+          <span
+            class="rounded-full bg-base-foreground px-2 py-0.5 text-2xs font-bold text-base-background"
           >
-            <i class="pi pi-check text-success-foreground text-xs" />
-            <span class="text-sm text-base-foreground">{{ benefit }}</span>
-          </div>
+            {{ t('subscription.saveYearly') }}
+          </span>
         </div>
-
-        <Button
-          variant="secondary"
-          size="lg"
-          class="mt-auto w-full"
-          :disabled="isCurrentPlan(plan.key) || isSubscribing"
-          @click="subscribeToPersonal(plan.key, selectedCycle)"
-        >
-          {{
-            isCurrentPlan(plan.key)
-              ? t('subscription.currentPlan')
-              : t('settingsPlans.choosePlan', { tier: plan.name })
-          }}
-        </Button>
       </div>
-    </div>
 
-    <template v-else>
       <div
-        class="flex flex-col rounded-2xl border border-interface-stroke xl:flex-row"
+        v-if="audience === 'personal'"
+        class="flex flex-col items-stretch gap-4 xl:flex-row"
       >
-        <div class="flex flex-1 flex-col gap-4 p-6">
+        <div
+          v-for="plan in plans"
+          :key="plan.key"
+          class="flex flex-1 flex-col gap-4 rounded-2xl border border-interface-stroke p-6"
+        >
+          <span class="text-base font-bold text-base-foreground">
+            {{ plan.name }}
+          </span>
+
           <div class="flex flex-col gap-1">
-            <span class="text-base font-bold text-base-foreground">
-              {{ t('subscription.teamPlan.name') }}
+            <div class="flex items-baseline gap-2">
+              <span
+                class="text-[28px] leading-normal font-semibold text-base-foreground tabular-nums"
+              >
+                ${{ billedYearly ? plan.pricing.yearly : plan.pricing.monthly }}
+              </span>
+              <span class="text-base text-muted-foreground">
+                {{ t('subscription.usdPerMonth') }}
+              </span>
+            </div>
+            <span class="text-sm text-muted-foreground tabular-nums">
+              {{
+                billedYearly
+                  ? t('subscription.billedYearly', {
+                      total: `$${plan.pricing.yearly * 12}`
+                    })
+                  : t('subscription.billedMonthly')
+              }}
             </span>
-            <p class="m-0 max-w-md text-sm text-muted-foreground">
-              {{ t('subscription.teamPlan.tagline') }}
-            </p>
           </div>
 
-          <CreditSlider
-            v-model="teamUsd"
-            :stops="teamStops"
-            :default-stop-index="teamDefaultStopIndex"
-            :cycle="billedYearly ? 'yearly' : 'monthly'"
-          />
+          <div class="border-t border-interface-stroke" />
 
           <div class="flex flex-col gap-1">
             <div class="flex items-center gap-1.5">
@@ -166,112 +80,232 @@
                 aria-hidden="true"
               />
               <I18nT
-                keypath="settingsPlans.creditsPerMonth"
+                :keypath="
+                  billedYearly
+                    ? 'settingsPlans.creditsAYear'
+                    : 'settingsPlans.creditsAMonth'
+                "
                 tag="span"
                 class="text-sm text-base-foreground"
               >
                 <template #credits>
                   <span class="font-bold tabular-nums">
-                    {{ n(selectedTeamStop.credits) }}
+                    {{
+                      n(
+                        billedYearly
+                          ? plan.pricing.credits * 12
+                          : plan.pricing.credits
+                      )
+                    }}
                   </span>
                 </template>
               </I18nT>
             </div>
+            <span class="text-sm text-muted-foreground tabular-nums">
+              {{ t('settingsPlans.perDollar', { credits: perDollar(plan) }) }}
+            </span>
+          </div>
+
+          <div class="flex flex-col gap-2">
             <span class="text-sm text-muted-foreground">
               {{
-                t('subscription.videoEstimate', {
-                  count: n(teamVideoEstimate)
-                })
+                plan.everythingIn
+                  ? t('subscription.everythingInPlus', {
+                      plan: plan.everythingIn
+                    })
+                  : t('subscription.whatsIncluded')
               }}
             </span>
+            <div
+              v-for="benefit in plan.benefits"
+              :key="benefit"
+              class="flex items-center gap-2"
+            >
+              <i class="pi pi-check text-success-foreground text-xs" />
+              <span class="text-sm text-base-foreground">{{ benefit }}</span>
+            </div>
           </div>
 
           <Button
             variant="secondary"
             size="lg"
             class="mt-auto w-full"
-            :disabled="isTeamCurrentPlan || isSubscribing"
-            @click="subscribeToTeam(selectedTeamStop, selectedCycle)"
+            :disabled="isCurrentPlan(plan.key) || isSubscribing"
+            @click="subscribeToPersonal(plan.key, selectedCycle)"
           >
             {{
-              isTeamCurrentPlan
-                ? t('subscription.teamPlan.currentPlan')
-                : billedYearly
-                  ? t('subscription.teamPlan.cta')
-                  : t('subscription.teamPlan.ctaMonthly')
+              isCurrentPlan(plan.key)
+                ? t('subscription.currentPlan')
+                : t('settingsPlans.choosePlan', { tier: plan.name })
             }}
           </Button>
         </div>
+      </div>
+
+      <template v-else>
+        <div
+          class="flex flex-col rounded-2xl border border-interface-stroke xl:flex-row"
+        >
+          <div class="flex flex-1 flex-col gap-4 p-6">
+            <div class="flex flex-col gap-1">
+              <span class="text-base font-bold text-base-foreground">
+                {{ t('subscription.teamPlan.name') }}
+              </span>
+              <p class="m-0 max-w-md text-sm text-muted-foreground">
+                {{ t('subscription.teamPlan.tagline') }}
+              </p>
+            </div>
+
+            <CreditSlider
+              v-model="teamUsd"
+              :stops="teamStops"
+              :default-stop-index="teamDefaultStopIndex"
+              :cycle="billedYearly ? 'yearly' : 'monthly'"
+            />
+
+            <div class="flex flex-col gap-1">
+              <div class="flex items-center gap-1.5">
+                <i
+                  class="icon-[lucide--coins] size-4 shrink-0 bg-credit"
+                  aria-hidden="true"
+                />
+                <I18nT
+                  keypath="settingsPlans.creditsPerMonth"
+                  tag="span"
+                  class="text-sm text-base-foreground"
+                >
+                  <template #credits>
+                    <span class="font-bold tabular-nums">
+                      {{ n(selectedTeamStop.credits) }}
+                    </span>
+                  </template>
+                </I18nT>
+              </div>
+              <span class="text-sm text-muted-foreground">
+                {{
+                  t('subscription.videoEstimate', {
+                    count: n(teamVideoEstimate)
+                  })
+                }}
+              </span>
+            </div>
+
+            <Button
+              variant="secondary"
+              size="lg"
+              class="mt-auto w-full"
+              :disabled="isTeamCurrentPlan || isSubscribing"
+              @click="subscribeToTeam(selectedTeamStop, selectedCycle)"
+            >
+              {{
+                isTeamCurrentPlan
+                  ? t('subscription.teamPlan.currentPlan')
+                  : billedYearly
+                    ? t('subscription.teamPlan.cta')
+                    : t('subscription.teamPlan.ctaMonthly')
+              }}
+            </Button>
+          </div>
+
+          <div
+            class="h-px w-full shrink-0 self-stretch bg-interface-stroke xl:h-auto xl:w-px"
+          />
+
+          <div class="flex flex-col gap-3 p-6 xl:w-80">
+            <span class="text-base font-semibold text-base-foreground">
+              {{ t('subscription.teamPlan.detailsTitle') }}
+            </span>
+            <span class="text-sm text-muted-foreground">
+              {{
+                t('subscription.everythingInPlus', {
+                  plan: t('subscription.tiers.pro.name')
+                })
+              }}
+            </span>
+            <div
+              v-for="perk in teamPerks"
+              :key="perk"
+              class="flex items-start gap-2"
+            >
+              <i class="pi pi-check text-success-foreground mt-0.5 text-xs" />
+              <span class="text-sm text-base-foreground">{{ perk }}</span>
+            </div>
+            <span class="text-sm text-muted-foreground">
+              {{ t('subscription.teamPlan.comingSoonLabel') }}
+            </span>
+            <div
+              v-for="item in teamComingSoon"
+              :key="item"
+              class="flex items-start gap-2"
+            >
+              <i class="pi pi-clock mt-0.5 text-xs text-muted-foreground" />
+              <span class="text-sm text-muted-foreground">{{ item }}</span>
+            </div>
+          </div>
+        </div>
 
         <div
-          class="h-px w-full shrink-0 self-stretch bg-interface-stroke xl:h-auto xl:w-px"
-        />
-
-        <div class="flex flex-col gap-3 p-6 xl:w-80">
-          <span class="text-base font-semibold text-base-foreground">
-            {{ t('subscription.teamPlan.detailsTitle') }}
-          </span>
-          <span class="text-sm text-muted-foreground">
-            {{
-              t('subscription.everythingInPlus', {
-                plan: t('subscription.tiers.pro.name')
-              })
-            }}
-          </span>
-          <div
-            v-for="perk in teamPerks"
-            :key="perk"
-            class="flex items-start gap-2"
-          >
-            <i class="pi pi-check text-success-foreground mt-0.5 text-xs" />
-            <span class="text-sm text-base-foreground">{{ perk }}</span>
+          class="flex flex-wrap items-center justify-between gap-3 rounded-2xl border border-interface-stroke px-6 py-4"
+        >
+          <div class="flex items-center gap-4">
+            <span
+              class="text-2xs font-bold tracking-widest text-credit uppercase"
+            >
+              {{ t('subscription.enterprise.name') }}
+            </span>
+            <span class="text-sm text-muted-foreground">
+              {{ t('settingsPlans.enterpriseCopy') }}
+            </span>
           </div>
-          <span class="text-sm text-muted-foreground">
-            {{ t('subscription.teamPlan.comingSoonLabel') }}
-          </span>
-          <div
-            v-for="item in teamComingSoon"
-            :key="item"
-            class="flex items-start gap-2"
-          >
-            <i class="pi pi-clock mt-0.5 text-xs text-muted-foreground" />
-            <span class="text-sm text-muted-foreground">{{ item }}</span>
-          </div>
+          <Button variant="secondary" size="lg">
+            {{ t('settingsPlans.contactUs') }}
+          </Button>
         </div>
-      </div>
+      </template>
 
-      <div
-        class="flex flex-wrap items-center justify-between gap-3 rounded-2xl border border-interface-stroke px-6 py-4"
-      >
-        <div class="flex items-center gap-4">
-          <span
-            class="text-2xs font-bold tracking-widest text-credit uppercase"
-          >
-            {{ t('subscription.enterprise.name') }}
-          </span>
-          <span class="text-sm text-muted-foreground">
-            {{ t('settingsPlans.enterpriseCopy') }}
-          </span>
-        </div>
-        <Button variant="secondary" size="lg">
-          {{ t('settingsPlans.contactUs') }}
-        </Button>
-      </div>
+      <p class="m-0 text-sm text-muted-foreground">
+        {{ t('settingsPlans.checkoutCaption') }}
+      </p>
     </template>
 
-    <p class="m-0 text-sm text-muted-foreground">
-      {{ t('settingsPlans.checkoutCaption') }}
+    <div
+      v-else-if="isLoadingPlans"
+      data-testid="plans-skeleton"
+      class="flex flex-col items-stretch gap-4 xl:flex-row"
+    >
+      <Skeleton v-for="i in 3" :key="i" class="h-72 flex-1 rounded-2xl" />
+    </div>
+
+    <div
+      v-else-if="planLoadError"
+      class="flex flex-col items-start gap-3 rounded-2xl border border-interface-stroke p-6"
+    >
+      <div class="flex items-center gap-2 text-text-secondary">
+        <i class="pi pi-exclamation-circle text-danger" aria-hidden="true" />
+        <span class="text-sm">{{ t('subscription.planLoadError') }}</span>
+      </div>
+      <Button variant="secondary" size="lg" @click="retryFetchPlans">
+        {{ t('subscription.planLoadErrorRetry') }}
+      </Button>
+    </div>
+
+    <p
+      v-else
+      class="m-0 rounded-2xl border border-interface-stroke p-6 text-sm text-muted-foreground"
+    >
+      {{ t('settingsPlans.noPlansAvailable') }}
     </p>
   </section>
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, ref, watch } from 'vue'
+import { computed, ref, watch } from 'vue'
 import { I18nT, useI18n } from 'vue-i18n'
 
 import { useBillingContext } from '@/composables/billing/useBillingContext'
 import Button from '@/components/ui/button/Button.vue'
 import CreditSlider from '@/components/ui/credit-slider/CreditSlider.vue'
+import Skeleton from '@/components/ui/skeleton/Skeleton.vue'
 import Switch from '@/components/ui/switch/Switch.vue'
 import ToggleGroup from '@/components/ui/toggle-group/ToggleGroup.vue'
 import ToggleGroupItem from '@/components/ui/toggle-group/ToggleGroupItem.vue'
@@ -337,15 +371,27 @@ const VIDEO_PER_CREDIT =
   TIER_PRICING.pro.videoEstimate / TIER_PRICING.pro.credits
 
 // Team stops mirror UnifiedPricingTable: backend-sourced when the shared plans
-// state has them, DES-197 fallback otherwise.
-const { teamCreditStops } = useBillingPlans()
+// state has them, DES-197 fallback otherwise. The fetch lifecycle also lives on
+// this singleton — useBillingContext's isLoading/error track the legacy
+// activeContext refresh off-cloud, not the plans fetch.
+const {
+  teamCreditStops,
+  isLoading: isLoadingPlans,
+  error: planLoadError
+} = useBillingPlans()
 const { fetchPlans, plans: catalogPlans, currentPlanSlug } = useBillingContext()
 const { isSubscribing, subscribeToPersonal, subscribeToTeam } =
   useSettingsPlansCheckout()
 
-onMounted(() => {
-  void fetchPlans()
-})
+// Fetched in setup rather than onMounted: isLoading flips synchronously, so the
+// first paint is the skeleton, never a flash of the empty state.
+void fetchPlans()
+
+const hasCatalog = computed(() => catalogPlans.value.length > 0)
+
+async function retryFetchPlans() {
+  await fetchPlans()
+}
 
 const selectedCycle = computed<BillingCycle>(() =>
   billedYearly.value ? 'yearly' : 'monthly'

--- a/src/platform/workspace/components/dialogs/settings/SettingsPlansSection.vue
+++ b/src/platform/workspace/components/dialogs/settings/SettingsPlansSection.vue
@@ -370,10 +370,8 @@ function perDollar(plan: PlanCard): number {
 const VIDEO_PER_CREDIT =
   TIER_PRICING.pro.videoEstimate / TIER_PRICING.pro.credits
 
-// Team stops mirror UnifiedPricingTable: backend-sourced when the shared plans
-// state has them, DES-197 fallback otherwise. The fetch lifecycle also lives on
-// this singleton — useBillingContext's isLoading/error track the legacy
-// activeContext refresh off-cloud, not the plans fetch.
+// The plans-fetch lifecycle lives on this singleton; useBillingContext's
+// isLoading/error track the legacy refresh instead.
 const {
   teamCreditStops,
   isLoading: isLoadingPlans,
@@ -383,8 +381,8 @@ const { fetchPlans, plans: catalogPlans, currentPlanSlug } = useBillingContext()
 const { isSubscribing, subscribeToPersonal, subscribeToTeam } =
   useSettingsPlansCheckout()
 
-// Fetched in setup rather than onMounted: isLoading flips synchronously, so the
-// first paint is the skeleton, never a flash of the empty state.
+// Setup-time so isLoading is set before the first paint (onMounted would
+// flash the empty state).
 void fetchPlans()
 
 const hasCatalog = computed(() => catalogPlans.value.length > 0)
@@ -397,9 +395,8 @@ const selectedCycle = computed<BillingCycle>(() =>
   billedYearly.value ? 'yearly' : 'monthly'
 )
 
-// Decision #8: the subscribed plan's card is a disabled "Current plan". A slug
-// outside the rendered catalog (founder, legacy plans) matches no card, so
-// every card stays actionable — cloud's existing behavior, inherited.
+// A slug outside the rendered catalog (founder, legacy plans) matches no
+// card, so every card stays actionable.
 function isCurrentPlan(tierKey: CheckoutTierKey): boolean {
   return (
     currentPlanSlug.value !== null &&


### PR DESCRIPTION
## Summary

Adds the load, error, and empty states to the local plans section, plus mobile width handling. While the catalog is loading the cards show a skeleton, a failed fetch shows an error with a retry button, and the section stays usable on a narrow viewport. This replaces the earlier behavior where a failed fetch silently fell back to static stops.

PR 4 of 4. Base: PR 3 (subscribe and checkout).

## Changes

- `SettingsPlansSection.vue` now branches on fetch state: a three-card skeleton while loading, an error message with a "Try again" button on failure, and the cards once the catalog resolves. The loading flag is read at setup so the first paint does not flash the empty state.
- `retryFetchPlans` re-runs the catalog fetch from the error state.
- The skeleton uses the shared `@/components/ui/skeleton/Skeleton.vue`.
- One new English string for the load-error copy. The other locales come from CI.

## Review Focus

- When a plans fetch fails, the section now shows an explicit error with a retry button instead of silently falling back to the static stops. That was an approved change, calling it out because it changes what a user sees when the backend is down. See `SettingsPlansSection.vue` around `planLoadError`.

## QA

- [x] Unit: 16 passing across the state-transition and section suites
- [x] Mutation: 5/5 killed on changed lines, 0 survivors
- [x] E2E (live): a 500 on the plans fetch shows the error, clicking "Try again" reloads the cards; the section stays within the viewport at 390px, asserted at the document level
- [x] Layer audit: no import-boundary violations
- [ ] Screenshot snapshot regeneration runs on CI
- [ ] Cloud `@cloud` suite half runs on CI
