### PR TITLE
fix: support audio uploads on custom node input names

### DIFF
--- a/src/extensions/core/uploadAudio.test.ts
+++ b/src/extensions/core/uploadAudio.test.ts
@@ -19,7 +19,11 @@ let capturedFileSelect:
   | undefined
 let capturedPaste: ((files: File[]) => Promise<File[] | never[]>) | undefined
 
-type AudioUploadWidget = (node: LGraphNode, inputName: string) => unknown
+type AudioUploadWidget = (
+  node: LGraphNode,
+  inputName: string,
+  inputData?: InputSpec
+) => unknown
 
 vi.mock('extendable-media-recorder', () => ({
   MediaRecorder: class MockMediaRecorder {}
@@ -113,9 +117,9 @@ function failResponse(status = 500) {
   }
 }
 
-function createAudioNode() {
+function createAudioNode(audioInputName = 'audio') {
   const audioWidget = {
-    name: 'audio',
+    name: audioInputName,
     value: 'previous.mp3',
     options: { values: ['previous.mp3'] },
     callback: vi.fn()
@@ -238,6 +242,21 @@ describe('Comfy.UploadAudio AUDIOUPLOAD widget', () => {
     expect(node.graph?.setDirtyCanvas).toHaveBeenCalledWith(true)
   })
 
+  it('uploads through a custom audio input named by the node definition', async () => {
+    const AUDIOUPLOAD = await loadAudioUploadWidget()
+    const { audioWidget, node } = createAudioNode('reference_audio')
+    AUDIOUPLOAD(node, 'upload', [
+      'AUDIOUPLOAD',
+      { audioInputName: 'reference_audio' }
+    ])
+    mockFetchApi.mockResolvedValueOnce(successResponse('uploaded.mp3'))
+
+    await capturedFileSelect!([createFile()])
+
+    expect(audioWidget.value).toBe('uploaded.mp3')
+    expect(audioWidget.options.values).toContain('uploaded.mp3')
+  })
+
   it('returns early when no files are provided', async () => {
     const AUDIOUPLOAD = await loadAudioUploadWidget()
     const { node } = createAudioNode()
@@ -302,5 +321,26 @@ describe('audio node definition setup', () => {
     )
 
     expect(nodeData.input?.required?.audioUI).toEqual(['AUDIO_UI', {}])
+  })
+
+  it('passes the audio_upload input name to the AUDIOUPLOAD widget', async () => {
+    const extension = await loadExtension('Comfy.UploadAudio')
+    const nodeData = createCustomAudioNodeDef()
+
+    await extension.beforeRegisterNodeDef!(fromAny({}), nodeData, fromAny({}))
+
+    expect(nodeData.input?.required?.upload).toEqual([
+      'AUDIOUPLOAD',
+      { audioInputName: 'reference_audio' }
+    ])
+  })
+
+  it('skips nodes without an audio_upload input', async () => {
+    const extension = await loadExtension('Comfy.UploadAudio')
+    const nodeData = createNodeDef({ audio: [['clip.mp3'], {}] })
+
+    await extension.beforeRegisterNodeDef!(fromAny({}), nodeData, fromAny({}))
+
+    expect(nodeData.input?.required?.upload).toBeUndefined()
   })
 })

--- a/src/extensions/core/uploadAudio.test.ts
+++ b/src/extensions/core/uploadAudio.test.ts
@@ -2,6 +2,7 @@ import { fromAny } from '@total-typescript/shoehorn'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
+import type { ComfyNodeDef, InputSpec } from '@/schemas/nodeDefSchema'
 import type { ComfyExtension } from '@/types/comfy'
 
 const { mockAddAlert, mockApiURL, mockFetchApi, mockRegisterExtension } =
@@ -137,15 +138,19 @@ function createAudioNode() {
   return { audioUIWidget, audioWidget, node, uploadWidget }
 }
 
-async function loadAudioUploadWidget() {
+async function loadExtension(name: string) {
   vi.resetModules()
   mockRegisterExtension.mockClear()
   await import('./uploadAudio')
   const extension = mockRegisterExtension.mock.calls
     .map(([extension]) => extension as ComfyExtension)
-    .find((extension) => extension.name === 'Comfy.UploadAudio')
-  if (!extension)
-    throw new Error('Comfy.UploadAudio extension was not registered')
+    .find((extension) => extension.name === name)
+  if (!extension) throw new Error(`${name} extension was not registered`)
+  return extension
+}
+
+async function loadAudioUploadWidget() {
+  const extension = await loadExtension('Comfy.UploadAudio')
   const widgets = await extension.getCustomWidgets!(fromAny({}))
   return (widgets as Record<string, AudioUploadWidget>).AUDIOUPLOAD
 }
@@ -249,14 +254,7 @@ describe('Comfy.UploadAudio AUDIOUPLOAD widget', () => {
 type AudioUIWidget = (node: LGraphNode, inputName: string) => unknown
 
 async function loadAudioUIWidget() {
-  vi.resetModules()
-  mockRegisterExtension.mockClear()
-  await import('./uploadAudio')
-  const extension = mockRegisterExtension.mock.calls
-    .map(([extension]) => extension as ComfyExtension)
-    .find((extension) => extension.name === 'Comfy.AudioWidget')
-  if (!extension)
-    throw new Error('Comfy.AudioWidget extension was not registered')
+  const extension = await loadExtension('Comfy.AudioWidget')
   const widgets = await extension.getCustomWidgets!(fromAny({}))
   return (widgets as Record<string, AudioUIWidget>).AUDIO_UI
 }
@@ -277,5 +275,32 @@ describe('Comfy.AudioWidget AUDIO_UI widget', () => {
 
     expect(domWidget.serialize).toBe(false)
     expect(domWidget.options.serialize).toBe(false)
+  })
+})
+
+function createNodeDef(
+  requiredInputs: Record<string, InputSpec>
+): ComfyNodeDef {
+  return fromAny<ComfyNodeDef, unknown>({ input: { required: requiredInputs } })
+}
+
+function createCustomAudioNodeDef(): ComfyNodeDef {
+  return createNodeDef({
+    reference_audio: [['clip.mp3'], { audio_upload: true }]
+  })
+}
+
+describe('audio node definition setup', () => {
+  it('injects audioUI for custom nodes declaring an audio_upload input', async () => {
+    const extension = await loadExtension('Comfy.AudioWidget')
+    const nodeData = createCustomAudioNodeDef()
+
+    await extension.beforeRegisterNodeDef!(
+      fromAny({ prototype: { comfyClass: 'CustomLoadAudio' } }),
+      nodeData,
+      fromAny({})
+    )
+
+    expect(nodeData.input?.required?.audioUI).toEqual(['AUDIO_UI', {}])
   })
 })

--- a/src/extensions/core/uploadAudio.test.ts
+++ b/src/extensions/core/uploadAudio.test.ts
@@ -117,6 +117,21 @@ function failResponse(status = 500) {
   }
 }
 
+// Top-level dynamic import: a static import would be hoisted above the consts
+// the vi.mock factories close over.
+await import('./uploadAudio')
+const registeredExtensions = mockRegisterExtension.mock.calls.map(
+  ([extension]) => extension as ComfyExtension
+)
+
+function loadExtension(name: string) {
+  const extension = registeredExtensions.find(
+    (extension) => extension.name === name
+  )
+  if (!extension) throw new Error(`${name} extension was not registered`)
+  return extension
+}
+
 function createAudioNode(audioInputName = 'audio') {
   const audioWidget = {
     name: audioInputName,
@@ -142,19 +157,8 @@ function createAudioNode(audioInputName = 'audio') {
   return { audioUIWidget, audioWidget, node, uploadWidget }
 }
 
-async function loadExtension(name: string) {
-  vi.resetModules()
-  mockRegisterExtension.mockClear()
-  await import('./uploadAudio')
-  const extension = mockRegisterExtension.mock.calls
-    .map(([extension]) => extension as ComfyExtension)
-    .find((extension) => extension.name === name)
-  if (!extension) throw new Error(`${name} extension was not registered`)
-  return extension
-}
-
 async function loadAudioUploadWidget() {
-  const extension = await loadExtension('Comfy.UploadAudio')
+  const extension = loadExtension('Comfy.UploadAudio')
   const widgets = await extension.getCustomWidgets!(fromAny({}))
   return (widgets as Record<string, AudioUploadWidget>).AUDIOUPLOAD
 }
@@ -273,7 +277,7 @@ describe('Comfy.UploadAudio AUDIOUPLOAD widget', () => {
 type AudioUIWidget = (node: LGraphNode, inputName: string) => unknown
 
 async function loadAudioUIWidget() {
-  const extension = await loadExtension('Comfy.AudioWidget')
+  const extension = loadExtension('Comfy.AudioWidget')
   const widgets = await extension.getCustomWidgets!(fromAny({}))
   return (widgets as Record<string, AudioUIWidget>).AUDIO_UI
 }
@@ -311,7 +315,7 @@ function createCustomAudioNodeDef(): ComfyNodeDef {
 
 describe('audio node definition setup', () => {
   it('injects audioUI for custom nodes declaring an audio_upload input', async () => {
-    const extension = await loadExtension('Comfy.AudioWidget')
+    const extension = loadExtension('Comfy.AudioWidget')
     const nodeData = createCustomAudioNodeDef()
 
     await extension.beforeRegisterNodeDef!(
@@ -324,7 +328,7 @@ describe('audio node definition setup', () => {
   })
 
   it('passes the audio_upload input name to the AUDIOUPLOAD widget', async () => {
-    const extension = await loadExtension('Comfy.UploadAudio')
+    const extension = loadExtension('Comfy.UploadAudio')
     const nodeData = createCustomAudioNodeDef()
 
     await extension.beforeRegisterNodeDef!(fromAny({}), nodeData, fromAny({}))
@@ -336,7 +340,7 @@ describe('audio node definition setup', () => {
   })
 
   it('skips nodes without an audio_upload input', async () => {
-    const extension = await loadExtension('Comfy.UploadAudio')
+    const extension = loadExtension('Comfy.UploadAudio')
     const nodeData = createNodeDef({ audio: [['clip.mp3'], {}] })
 
     await extension.beforeRegisterNodeDef!(fromAny({}), nodeData, fromAny({}))

--- a/src/extensions/core/uploadAudio.ts
+++ b/src/extensions/core/uploadAudio.ts
@@ -16,7 +16,7 @@ import {
   splitFilePath
 } from '@/renderer/extensions/vueNodes/widgets/utils/audioUtils'
 import type { NodeExecutionOutput } from '@/schemas/apiSchema'
-import type { ComfyNodeDef } from '@/schemas/nodeDefSchema'
+import type { ComfyNodeDef, InputSpec } from '@/schemas/nodeDefSchema'
 import type { DOMWidget } from '@/scripts/domWidget'
 import { useAudioService } from '@/services/audioService'
 import { type NodeLocatorId } from '@/types'
@@ -26,6 +26,15 @@ import { getNodeByLocatorId } from '@/utils/graphTraversalUtil'
 import { api } from '../../scripts/api'
 import { app } from '../../scripts/app'
 import { useWidgetValueStore } from '@/stores/widgetValueStore'
+
+function findAudioUploadInputName(
+  requiredInputs: Record<string, InputSpec> | undefined
+): string | undefined {
+  const audioUploadInput = Object.entries(requiredInputs ?? {}).find(
+    ([, [, options]]) => options?.audio_upload === true
+  )
+  return audioUploadInput?.[0]
+}
 
 function updateUIWidget(
   audioUIWidget: DOMWidget<HTMLAudioElement, string>,
@@ -100,18 +109,21 @@ app.registerExtension({
     nodeType: typeof LGraphNode,
     nodeData: ComfyNodeDef
   ) {
+    const isBuiltInAudioNode = [
+      'LoadAudio',
+      'SaveAudio',
+      'PreviewAudio',
+      'SaveAudioMP3',
+      'SaveAudioOpus',
+      'SaveAudioAdvanced'
+    ].includes(
+      // @ts-expect-error fixme ts strict error
+      nodeType.prototype.comfyClass
+    )
+
     if (
-      [
-        'LoadAudio',
-        'SaveAudio',
-        'PreviewAudio',
-        'SaveAudioMP3',
-        'SaveAudioOpus',
-        'SaveAudioAdvanced'
-      ].includes(
-        // @ts-expect-error fixme ts strict error
-        nodeType.prototype.comfyClass
-      )
+      isBuiltInAudioNode ||
+      findAudioUploadInputName(nodeData.input?.required)
     ) {
       // @ts-expect-error fixme ts strict error
       nodeData.input.required.audioUI = ['AUDIO_UI', {}]

--- a/src/extensions/core/uploadAudio.ts
+++ b/src/extensions/core/uploadAudio.ts
@@ -213,17 +213,22 @@ app.registerExtension({
     _nodeType: typeof LGraphNode,
     nodeData: ComfyNodeDef
   ) {
-    if (nodeData?.input?.required?.audio?.[1]?.audio_upload === true) {
-      nodeData.input.required.upload = ['AUDIOUPLOAD', {}]
+    const requiredInputs = nodeData.input?.required
+    const audioInputName = findAudioUploadInputName(requiredInputs)
+    if (requiredInputs && audioInputName) {
+      requiredInputs.upload = ['AUDIOUPLOAD', { audioInputName }]
     }
   },
   getCustomWidgets() {
     return {
-      AUDIOUPLOAD(node, inputName: string) {
+      AUDIOUPLOAD(node, inputName: string, inputData) {
+        const audioInputName = inputData?.[1]?.audioInputName
+        const audioWidgetName =
+          typeof audioInputName === 'string' ? audioInputName : 'audio'
         // The widget that allows user to select file.
         // @ts-expect-error fixme ts strict error
         const audioWidget = node.widgets.find(
-          (w) => w.name === 'audio'
+          (w) => w.name === audioWidgetName
         ) as IStringWidget
         // @ts-expect-error fixme ts strict error
         const audioUIWidget = node.widgets.find(


### PR DESCRIPTION
## Summary

Support audio uploads on custom nodes that declare `audio_upload` without requiring the input to be named `audio` or the node to use a built-in audio class.

## Changes

**What**: Previously, audio upload setup depended on two built-in assumptions:

- The uploadable input was named `audio`.
- The audio player UI was only injected for a fixed set of built-in node classes.

As a result, custom nodes could receive an upload control without its required audio player, or receive no working upload control when the audio input used a name such as `reference_audio`.

This brings the custom-node behavior closer to image and video uploads, which already associate the generated upload control with the input identified by the node definition.

## Review Focus

This PR does not attempt full upload-path parity with image/video which would be a broader refactor - that's maybe best left to you guys. 

