### PR TITLE
feat: add Basics learning category with YouTube tutorials

### DIFF
--- a/apps/website/e2e/learning.spec.ts
+++ b/apps/website/e2e/learning.spec.ts
@@ -26,6 +26,12 @@ const categoryNav = (page: Page, locale: 'en' | 'zh-CN' = 'en') =>
 // metadata helpers, so these assertions catch a regression in the helpers or
 // the underlying strings — not just the wiring.
 const EXPECTED_META = {
+  basics: {
+    heading: 'ComfyUI Basics',
+    description:
+      'Beginner ComfyUI tutorials — learn the node graph, LoRAs, style transfer, and ControlNets from the ground up.',
+    title: 'ComfyUI Basics - Comfy'
+  },
   vfx: {
     heading: 'VFX Tutorials',
     description:
@@ -239,6 +245,16 @@ test.describe('Learning category pages @smoke', () => {
 
 test.describe('Learning tutorial page @smoke', () => {
   const [firstTutorial] = learningTutorials
+  const selfHostedTutorial = learningTutorials.find(
+    (tutorial) => tutorial.videoSrc && !tutorial.youtubeId
+  )
+  const youtubeTutorial = learningTutorials.find(
+    (tutorial) => tutorial.youtubeId
+  )
+  const workflowTutorial = learningTutorials.find((tutorial) => tutorial.href)
+  if (!selfHostedTutorial || !youtubeTutorial || !workflowTutorial) {
+    throw new Error('expected self-hosted, youtube, and workflow tutorials')
+  }
 
   test('a thumbnail navigates to the dedicated tutorial page', async ({
     page
@@ -257,10 +273,10 @@ test.describe('Learning tutorial page @smoke', () => {
   test('the page exposes an indexable heading and autoplay video', async ({
     page
   }) => {
-    await page.goto(tutorialPath(firstTutorial))
+    await page.goto(tutorialPath(selfHostedTutorial))
 
     await expect(page.getByRole('heading', { level: 1 })).toHaveText(
-      firstTutorial.title.en
+      selfHostedTutorial.title.en
     )
     // Attribute-level autoplay check: blockExternalMedia aborts the video
     // request, so actual playback never starts in e2e.
@@ -268,6 +284,20 @@ test.describe('Learning tutorial page @smoke', () => {
     await expect(video).toBeVisible()
     await expect(video).toHaveAttribute('autoplay', '')
     await expect(video).toHaveAttribute('muted', '')
+  })
+
+  test('youtube tutorials embed a nocookie iframe instead of a video', async ({
+    page
+  }) => {
+    await page.goto(tutorialPath(youtubeTutorial))
+
+    await expect(page.locator('video')).toHaveCount(0)
+    const iframe = page.locator('iframe[src*="youtube-nocookie.com/embed/"]')
+    await expect(iframe).toBeVisible()
+    await expect(iframe).toHaveAttribute(
+      'src',
+      new RegExp(`/embed/${youtubeTutorial.youtubeId}\\b`)
+    )
   })
 
   test('the breadcrumb links back to the directory and category', async ({
@@ -302,10 +332,9 @@ test.describe('Learning tutorial page @smoke', () => {
   })
 
   test('links to the workflow from the title block', async ({ page }) => {
-    if (!firstTutorial.href) throw new Error('expected a workflow link')
-    await page.goto(tutorialPath(firstTutorial))
+    await page.goto(tutorialPath(workflowTutorial))
 
-    const workflowLink = page.locator(`a[href="${firstTutorial.href}"]`)
+    const workflowLink = page.locator(`a[href="${workflowTutorial.href}"]`)
     await expect(workflowLink).toHaveText(t('cta.tryWorkflow', 'en'))
   })
 

--- a/apps/website/e2e/learning.spec.ts
+++ b/apps/website/e2e/learning.spec.ts
@@ -114,41 +114,34 @@ test.describe('Learning page @smoke', () => {
     }
   })
 
-  test('tutorials with a workflow link expose an external Try Workflow link', async ({
+  test('tutorials with a CTA link expose their labelled external link', async ({
     page
   }) => {
     const linkedTutorials = learningTutorials.filter(
       (tutorial) => tutorial.href
     )
-    const workflowLinks = page.getByRole('link', {
-      name: t('cta.tryWorkflow', 'en')
-    })
-    const hrefs = await workflowLinks.evaluateAll((links) =>
-      links.map((link) => link.getAttribute('href'))
-    )
+    expect(linkedTutorials.length).toBeGreaterThan(0)
     for (const tutorial of linkedTutorials) {
-      expect(hrefs).toContain(tutorial.href)
+      const link = page.locator(`a[href="${tutorial.href}"]`)
+      await expect(link).toContainText(
+        t(tutorial.ctaLabelKey ?? 'cta.tryWorkflow', 'en')
+      )
     }
   })
 
-  test('newTab tutorials open their workflow link in a new tab', async ({
+  test('newTab tutorials open their CTA link in a new tab', async ({
     page
   }) => {
-    const links = page.getByRole('link', { name: t('cta.tryWorkflow', 'en') })
-    const attrs = await links.evaluateAll((elements) =>
-      elements.map((element) => ({
-        href: element.getAttribute('href') ?? '',
-        target: element.getAttribute('target')
-      }))
+    const linkedTutorials = learningTutorials.filter(
+      (tutorial) => tutorial.href
     )
-    // The page-level CTA shares the label; only judge tutorial links.
-    const tutorialAttrs = attrs.filter(({ href }) =>
-      learningTutorials.some((item) => item.href === href)
-    )
-    expect(tutorialAttrs.length).toBeGreaterThan(0)
-    for (const { href, target } of tutorialAttrs) {
-      const tutorial = learningTutorials.find((item) => item.href === href)
-      expect(target, href).toBe(tutorial?.newTab ? '_blank' : null)
+    for (const tutorial of linkedTutorials) {
+      const link = page.locator(`a[href="${tutorial.href}"]`)
+      if (tutorial.newTab) {
+        await expect(link).toHaveAttribute('target', '_blank')
+      } else {
+        await expect(link).not.toHaveAttribute('target', '_blank')
+      }
     }
   })
 
@@ -331,11 +324,13 @@ test.describe('Learning tutorial page @smoke', () => {
     }
   })
 
-  test('links to the workflow from the title block', async ({ page }) => {
+  test('links to the CTA target from the title block', async ({ page }) => {
     await page.goto(tutorialPath(workflowTutorial))
 
-    const workflowLink = page.locator(`a[href="${workflowTutorial.href}"]`)
-    await expect(workflowLink).toHaveText(t('cta.tryWorkflow', 'en'))
+    const ctaLink = page.locator(`a[href="${workflowTutorial.href}"]`)
+    await expect(ctaLink).toHaveText(
+      t(workflowTutorial.ctaLabelKey ?? 'cta.tryWorkflow', 'en')
+    )
   })
 
   test('the chapter strip links to same-category siblings', async ({

--- a/apps/website/src/components/learning/FeaturedTutorialCard.vue
+++ b/apps/website/src/components/learning/FeaturedTutorialCard.vue
@@ -56,7 +56,7 @@ const { tutorial, locale = 'en' } = defineProps<{
           size="default"
           class="ps-0"
         >
-          {{ t('cta.tryWorkflow', locale) }}
+          {{ t(tutorial.ctaLabelKey ?? 'cta.tryWorkflow', locale) }}
         </ButtonPill>
       </div>
     </div>

--- a/apps/website/src/components/learning/LearningTutorialPage.astro
+++ b/apps/website/src/components/learning/LearningTutorialPage.astro
@@ -9,7 +9,9 @@ import { externalLinks, localizeHref } from '../../config/routes'
 import type { LearningTutorial } from '../../data/learningTutorials'
 import {
   learningCrumbs,
-  tutorialDescription
+  tutorialDescription,
+  youtubeEmbedUrl,
+  youtubeWatchUrl
 } from '../../data/learningTutorials'
 import type { JsonLdNode } from '../../utils/jsonLd'
 import {
@@ -42,7 +44,12 @@ const video: JsonLdNode = videoObjectNode({
   name: title,
   description,
   thumbnailUrl: tutorial.poster,
-  contentUrl: tutorial.videoSrc,
+  contentUrl: tutorial.youtubeId
+    ? youtubeWatchUrl(tutorial.youtubeId)
+    : tutorial.videoSrc,
+  embedUrl: tutorial.youtubeId
+    ? youtubeEmbedUrl(tutorial.youtubeId)
+    : undefined,
   uploadDate: tutorial.publishedDate,
   locale
 })

--- a/apps/website/src/components/learning/LearningTutorialPage.astro
+++ b/apps/website/src/components/learning/LearningTutorialPage.astro
@@ -10,8 +10,7 @@ import type { LearningTutorial } from '../../data/learningTutorials'
 import {
   learningCrumbs,
   tutorialDescription,
-  youtubeEmbedUrl,
-  youtubeWatchUrl
+  youtubeEmbedUrl
 } from '../../data/learningTutorials'
 import type { JsonLdNode } from '../../utils/jsonLd'
 import {
@@ -44,9 +43,7 @@ const video: JsonLdNode = videoObjectNode({
   name: title,
   description,
   thumbnailUrl: tutorial.poster,
-  contentUrl: tutorial.youtubeId
-    ? youtubeWatchUrl(tutorial.youtubeId)
-    : tutorial.videoSrc,
+  contentUrl: tutorial.videoSrc,
   embedUrl: tutorial.youtubeId
     ? youtubeEmbedUrl(tutorial.youtubeId)
     : undefined,

--- a/apps/website/src/components/learning/LearningVideoEmbed.test.ts
+++ b/apps/website/src/components/learning/LearningVideoEmbed.test.ts
@@ -1,0 +1,27 @@
+// @vitest-environment happy-dom
+import { render, screen } from '@testing-library/vue'
+import { describe, expect, it } from 'vitest'
+
+import LearningVideoEmbed from './LearningVideoEmbed.vue'
+
+function renderEmbed(youtubeId = 'TQhIYT1ZYGQ', title = 'Node Graph Basics') {
+  render(LearningVideoEmbed, { props: { youtubeId, title } })
+  return screen.getByTitle(title)
+}
+
+describe('LearningVideoEmbed', () => {
+  it('embeds the privacy-friendly nocookie player for the given id', () => {
+    const iframe = renderEmbed('abc123', 'Full Node Graph Basics')
+
+    expect(iframe.getAttribute('src')).toBe(
+      'https://www.youtube-nocookie.com/embed/abc123?autoplay=1&mute=1&rel=0'
+    )
+  })
+
+  it('lazy-loads the titled frame and allows fullscreen', () => {
+    const iframe = renderEmbed('abc123', 'Full Node Graph Basics')
+
+    expect(iframe.getAttribute('loading')).toBe('lazy')
+    expect(iframe.hasAttribute('allowfullscreen')).toBe(true)
+  })
+})

--- a/apps/website/src/components/learning/LearningVideoEmbed.vue
+++ b/apps/website/src/components/learning/LearningVideoEmbed.vue
@@ -1,0 +1,37 @@
+<script setup lang="ts">
+import type { HTMLAttributes } from 'vue'
+
+import { cn } from '@comfyorg/tailwind-utils'
+
+import { youtubeEmbedUrl } from '../../data/learningTutorials'
+
+const {
+  youtubeId,
+  title,
+  class: className
+} = defineProps<{
+  youtubeId: string
+  title: string
+  class?: HTMLAttributes['class']
+}>()
+</script>
+
+<template>
+  <div
+    :class="
+      cn(
+        'relative aspect-video overflow-hidden rounded-4xl border border-white/10 bg-black',
+        className
+      )
+    "
+  >
+    <iframe
+      :src="youtubeEmbedUrl(youtubeId)"
+      :title
+      class="size-full"
+      loading="lazy"
+      allow="autoplay; encrypted-media; picture-in-picture; fullscreen"
+      allowfullscreen
+    />
+  </div>
+</template>

--- a/apps/website/src/components/learning/LearningWatchPage.test.ts
+++ b/apps/website/src/components/learning/LearningWatchPage.test.ts
@@ -1,0 +1,39 @@
+// @vitest-environment happy-dom
+import { render, screen } from '@testing-library/vue'
+import { describe, expect, it } from 'vitest'
+
+import { filterByCategory } from '../../data/learningTutorials'
+import LearningWatchPage from './LearningWatchPage.vue'
+
+const youtubeTutorial = filterByCategory('basics')[0]
+const hostedTutorial = filterByCategory('vfx')[0]
+
+const stubs = {
+  LearningVideoEmbed: { template: '<div data-testid="youtube-embed" />' },
+  VideoPlayer: { template: '<div data-testid="hosted-video" />' }
+}
+
+function renderWatchPage(tutorial: typeof youtubeTutorial) {
+  render(LearningWatchPage, {
+    props: { tutorial, locale: 'en' },
+    global: { stubs }
+  })
+}
+
+describe('LearningWatchPage', () => {
+  it('embeds the YouTube player for tutorials with a youtubeId', () => {
+    expect(youtubeTutorial.youtubeId).toBeTruthy()
+    renderWatchPage(youtubeTutorial)
+
+    expect(screen.getByTestId('youtube-embed')).toBeTruthy()
+    expect(screen.queryByTestId('hosted-video')).toBeNull()
+  })
+
+  it('falls back to the hosted VideoPlayer for self-hosted tutorials', () => {
+    expect(hostedTutorial.videoSrc).toBeTruthy()
+    renderWatchPage(hostedTutorial)
+
+    expect(screen.getByTestId('hosted-video')).toBeTruthy()
+    expect(screen.queryByTestId('youtube-embed')).toBeNull()
+  })
+})

--- a/apps/website/src/components/learning/LearningWatchPage.test.ts
+++ b/apps/website/src/components/learning/LearningWatchPage.test.ts
@@ -2,18 +2,28 @@
 import { render, screen } from '@testing-library/vue'
 import { describe, expect, it } from 'vitest'
 
+import type { LearningTutorial } from '../../data/learningTutorials'
+
 import { filterByCategory } from '../../data/learningTutorials'
 import LearningWatchPage from './LearningWatchPage.vue'
 
-const youtubeTutorial = filterByCategory('basics')[0]
-const hostedTutorial = filterByCategory('vfx')[0]
+const youtubeTutorial = filterByCategory('basics').find(
+  (tutorial) => tutorial.youtubeId !== undefined
+)
+if (!youtubeTutorial)
+  throw new Error('Expected a Basics tutorial with youtubeId')
+
+const hostedTutorial = filterByCategory('vfx').find(
+  (tutorial) => tutorial.videoSrc !== undefined
+)
+if (!hostedTutorial) throw new Error('Expected a VFX tutorial with videoSrc')
 
 const stubs = {
   LearningVideoEmbed: { template: '<div data-testid="youtube-embed" />' },
   VideoPlayer: { template: '<div data-testid="hosted-video" />' }
 }
 
-function renderWatchPage(tutorial: typeof youtubeTutorial) {
+function renderWatchPage(tutorial: LearningTutorial) {
   render(LearningWatchPage, {
     props: { tutorial, locale: 'en' },
     global: { stubs }
@@ -22,7 +32,6 @@ function renderWatchPage(tutorial: typeof youtubeTutorial) {
 
 describe('LearningWatchPage', () => {
   it('embeds the YouTube player for tutorials with a youtubeId', () => {
-    expect(youtubeTutorial.youtubeId).toBeTruthy()
     renderWatchPage(youtubeTutorial)
 
     expect(screen.getByTestId('youtube-embed')).toBeTruthy()
@@ -30,7 +39,6 @@ describe('LearningWatchPage', () => {
   })
 
   it('falls back to the hosted VideoPlayer for self-hosted tutorials', () => {
-    expect(hostedTutorial.videoSrc).toBeTruthy()
     renderWatchPage(hostedTutorial)
 
     expect(screen.getByTestId('hosted-video')).toBeTruthy()

--- a/apps/website/src/components/learning/LearningWatchPage.vue
+++ b/apps/website/src/components/learning/LearningWatchPage.vue
@@ -18,6 +18,7 @@ import WatchPageLayout from '../blocks/WatchPageLayout.vue'
 import WatchRecommendedCard from '../blocks/WatchRecommendedCard.vue'
 import Button from '../ui/button/Button.vue'
 import VideoPlayer from '../common/VideoPlayer.vue'
+import LearningVideoEmbed from './LearningVideoEmbed.vue'
 import Badge from '../ui/badge/Badge.vue'
 
 const { tutorial, locale = 'en' } = defineProps<{
@@ -59,7 +60,15 @@ const recommended = recommendedFor(tutorial).map((item) => ({
     :read-more-label="t('ui.readMore', locale)"
     :read-less-label="t('ui.readLess', locale)"
   >
+    <LearningVideoEmbed
+      v-if="tutorial.youtubeId"
+      :key="tutorial.id"
+      :youtube-id="tutorial.youtubeId"
+      :title="tutorial.title[locale]"
+      class="w-full"
+    />
     <VideoPlayer
+      v-else
       :key="tutorial.id"
       :locale
       :src="tutorial.videoSrc"

--- a/apps/website/src/components/learning/LearningWatchPage.vue
+++ b/apps/website/src/components/learning/LearningWatchPage.vue
@@ -102,6 +102,7 @@ const recommended = recommendedFor(tutorial).map((item) => ({
         size="sm"
         :href="tutorial.href"
         :target="tutorial.newTab ? '_blank' : undefined"
+        :rel="tutorial.newTab ? 'noopener noreferrer' : undefined"
       >
         {{ t(tutorial.ctaLabelKey ?? 'cta.tryWorkflow', locale) }}
       </Button>

--- a/apps/website/src/components/learning/LearningWatchPage.vue
+++ b/apps/website/src/components/learning/LearningWatchPage.vue
@@ -103,7 +103,7 @@ const recommended = recommendedFor(tutorial).map((item) => ({
         :href="tutorial.href"
         :target="tutorial.newTab ? '_blank' : undefined"
       >
-        {{ t('cta.tryWorkflow', locale) }}
+        {{ t(tutorial.ctaLabelKey ?? 'cta.tryWorkflow', locale) }}
       </Button>
     </template>
 

--- a/apps/website/src/components/learning/TutorialRow.vue
+++ b/apps/website/src/components/learning/TutorialRow.vue
@@ -67,7 +67,7 @@ const { tutorial, locale = 'en' } = defineProps<{
       size="default"
       class="ps-0"
     >
-      {{ t('cta.tryWorkflow', locale) }}
+      {{ t(tutorial.ctaLabelKey ?? 'cta.tryWorkflow', locale) }}
     </ButtonPill>
   </li>
 </template>

--- a/apps/website/src/data/learningTutorials.test.ts
+++ b/apps/website/src/data/learningTutorials.test.ts
@@ -6,8 +6,7 @@ import {
   learningCategories,
   learningTutorials,
   recommendedFor,
-  youtubeEmbedUrl,
-  youtubeWatchUrl
+  youtubeEmbedUrl
 } from './learningTutorials'
 
 const firstVfx = filterByCategory('vfx')[0]
@@ -53,12 +52,9 @@ describe('video source', () => {
     }
   })
 
-  it('builds nocookie embed and canonical watch URLs from an id', () => {
+  it('builds a privacy-friendly nocookie embed URL from an id', () => {
     expect(youtubeEmbedUrl('abc123')).toBe(
       'https://www.youtube-nocookie.com/embed/abc123?autoplay=1&mute=1&rel=0'
-    )
-    expect(youtubeWatchUrl('abc123')).toBe(
-      'https://www.youtube.com/watch?v=abc123'
     )
   })
 })
@@ -68,7 +64,9 @@ describe('basics CTA', () => {
     const basics = filterByCategory('basics')
     expect(basics.length).toBeGreaterThan(0)
     for (const tutorial of basics) {
-      expect(tutorial.href).toContain('cloud.comfy.org')
+      expect(tutorial.href).toMatch(
+        /^https:\/\/cloud\.comfy\.org\/\?.*utm_campaign=free_tier.*utm_content=learning_basics_/
+      )
       expect(tutorial.newTab).toBe(true)
       expect(tutorial.ctaLabelKey).toBe('cta.tryForFree')
     }

--- a/apps/website/src/data/learningTutorials.test.ts
+++ b/apps/website/src/data/learningTutorials.test.ts
@@ -63,6 +63,18 @@ describe('video source', () => {
   })
 })
 
+describe('basics CTA', () => {
+  it('sends basics tutorials to cloud signup with a Try for Free label', () => {
+    const basics = filterByCategory('basics')
+    expect(basics.length).toBeGreaterThan(0)
+    for (const tutorial of basics) {
+      expect(tutorial.href).toContain('cloud.comfy.org')
+      expect(tutorial.newTab).toBe(true)
+      expect(tutorial.ctaLabelKey).toBe('cta.tryForFree')
+    }
+  })
+})
+
 describe('recommendedFor', () => {
   it('only recommends tutorials from other categories', () => {
     const recommended = recommendedFor(firstVfx)

--- a/apps/website/src/data/learningTutorials.test.ts
+++ b/apps/website/src/data/learningTutorials.test.ts
@@ -5,7 +5,9 @@ import {
   filterByCategory,
   learningCategories,
   learningTutorials,
-  recommendedFor
+  recommendedFor,
+  youtubeEmbedUrl,
+  youtubeWatchUrl
 } from './learningTutorials'
 
 const firstVfx = filterByCategory('vfx')[0]
@@ -39,6 +41,25 @@ describe('categoryChapters', () => {
     const episodes = categoryChapters(firstVfx).map((item) => item.episode)
     expect(episodes).toEqual([...episodes].sort((a, b) => a - b))
     expect(categoryChapters(firstVfx)[0]).toEqual(secondVfx)
+  })
+})
+
+describe('video source', () => {
+  it('plays via exactly one of videoSrc or youtubeId', () => {
+    for (const tutorial of learningTutorials) {
+      expect(Boolean(tutorial.videoSrc) !== Boolean(tutorial.youtubeId)).toBe(
+        true
+      )
+    }
+  })
+
+  it('builds nocookie embed and canonical watch URLs from an id', () => {
+    expect(youtubeEmbedUrl('abc123')).toBe(
+      'https://www.youtube-nocookie.com/embed/abc123?autoplay=1&mute=1&rel=0'
+    )
+    expect(youtubeWatchUrl('abc123')).toBe(
+      'https://www.youtube.com/watch?v=abc123'
+    )
   })
 })
 

--- a/apps/website/src/data/learningTutorials.ts
+++ b/apps/website/src/data/learningTutorials.ts
@@ -138,6 +138,7 @@ export const learningTutorials: readonly LearningTutorial[] = [
     slug: 'full-node-graph-basics',
     category: 'basics',
     episode: 1,
+    author: dougHogan,
     youtubeId: 'TQhIYT1ZYGQ',
     title: {
       en: 'ComfyUI Tutorial for Beginners: Full Node Graph Basics (2026)',
@@ -157,6 +158,7 @@ export const learningTutorials: readonly LearningTutorial[] = [
     slug: 'loras-style-transfer-controlnets',
     category: 'basics',
     episode: 2,
+    author: dougHogan,
     youtubeId: '-igiHGaxKek',
     title: {
       en: 'ComfyUI Tutorial for Beginners: LoRAs, Style Transfer & ControlNets (2026)',

--- a/apps/website/src/data/learningTutorials.ts
+++ b/apps/website/src/data/learningTutorials.ts
@@ -17,7 +17,7 @@ interface TutorialAuthor {
   avatar?: string
 }
 
-export interface LearningTutorial {
+interface LearningTutorialBase {
   id: string
   /** Kebab-case, human-readable — the SEO slug in /learning/<category>/<slug>. */
   slug: string
@@ -28,10 +28,6 @@ export interface LearningTutorial {
   title: LocalizedText
   /** Optional authored copy; when absent the detail page uses a template. */
   description?: LocalizedText
-  /** Self-hosted MP4 source; omit for YouTube items (see youtubeId). */
-  videoSrc?: string
-  /** When set, the watch page embeds a YouTube iframe instead of <video>. */
-  youtubeId?: string
   href?: string
   /** CTA button label; defaults to "Try Workflow" when omitted. */
   ctaLabelKey?: TranslationKey
@@ -44,6 +40,18 @@ export interface LearningTutorial {
   /** Shown on the watch page's author card; the card hides when absent. */
   author?: TutorialAuthor
 }
+
+/** Exactly one video source: a self-hosted MP4 or a YouTube embed, never both. */
+type LearningVideoSource =
+  | { videoSrc: string; youtubeId?: never }
+  | { youtubeId: string; videoSrc?: never }
+
+/**
+ * A tutorial plays from exactly one source. Self-hosted items set `videoSrc`
+ * (an MP4 rendered via `<video>`); YouTube items set `youtubeId` (embedded in
+ * an iframe on the watch page).
+ */
+export type LearningTutorial = LearningTutorialBase & LearningVideoSource
 
 /** Category slugs, in nav order — also drives the /learning/[slug] routes. */
 export const learningCategories: readonly LearningCategory[] = [
@@ -725,10 +733,6 @@ export const getTutorialByCategoryAndSlug = (
 /** Privacy-friendly embed URL for the watch-page iframe (YouTube items). */
 export const youtubeEmbedUrl = (id: string): string =>
   `https://www.youtube-nocookie.com/embed/${id}?autoplay=1&mute=1&rel=0`
-
-/** Canonical watch URL, used as the VideoObject contentUrl for YouTube items. */
-export const youtubeWatchUrl = (id: string): string =>
-  `https://www.youtube.com/watch?v=${id}`
 
 /** Canonical path for a category's directory page (wrap with localizeHref for zh-CN). */
 export const categoryPath = (category: LearningCategory): string =>

--- a/apps/website/src/data/learningTutorials.ts
+++ b/apps/website/src/data/learningTutorials.ts
@@ -7,7 +7,7 @@ import type {
 
 import { t } from '../i18n/translations'
 
-export type LearningCategory = 'vfx' | 'animations' | 'ads'
+export type LearningCategory = 'basics' | 'vfx' | 'animations' | 'ads'
 
 interface TutorialAuthor {
   name: LocalizedText
@@ -27,7 +27,10 @@ export interface LearningTutorial {
   title: LocalizedText
   /** Optional authored copy; when absent the detail page uses a template. */
   description?: LocalizedText
-  videoSrc: string
+  /** Self-hosted MP4 source; omit for YouTube items (see youtubeId). */
+  videoSrc?: string
+  /** When set, the watch page embeds a YouTube iframe instead of <video>. */
+  youtubeId?: string
   href?: string
   /** Open the workflow link in a new tab (e.g. cloud.comfy.org). */
   newTab?: boolean
@@ -41,18 +44,21 @@ export interface LearningTutorial {
 
 /** Category slugs, in nav order — also drives the /learning/[slug] routes. */
 export const learningCategories: readonly LearningCategory[] = [
+  'basics',
   'vfx',
   'animations',
   'ads'
 ]
 
 export const categoryLabelKeys: Record<LearningCategory, TranslationKey> = {
+  basics: 'learning.categories.basics',
   vfx: 'learning.categories.vfx',
   animations: 'learning.categories.animations',
   ads: 'learning.categories.ads'
 }
 
 export const categoryBlurbKeys: Record<LearningCategory, TranslationKey> = {
+  basics: 'learning.categories.basics.blurb',
   vfx: 'learning.categories.vfx.blurb',
   animations: 'learning.categories.animations.blurb',
   ads: 'learning.categories.ads.blurb'
@@ -60,6 +66,7 @@ export const categoryBlurbKeys: Record<LearningCategory, TranslationKey> = {
 
 /** Per-vertical h1 (the "All" view falls back to the generic learning title). */
 const categoryHeadingKeys: Record<LearningCategory, TranslationKey> = {
+  basics: 'learning.categories.basics.heading',
   vfx: 'learning.categories.vfx.heading',
   animations: 'learning.categories.animations.heading',
   ads: 'learning.categories.ads.heading'
@@ -67,6 +74,7 @@ const categoryHeadingKeys: Record<LearningCategory, TranslationKey> = {
 
 /** Per-vertical lead-in, reused as the page description / meta description. */
 const categoryDescriptionKeys: Record<LearningCategory, TranslationKey> = {
+  basics: 'learning.categories.basics.description',
   vfx: 'learning.categories.vfx.description',
   animations: 'learning.categories.animations.description',
   ads: 'learning.categories.ads.description'
@@ -108,6 +116,10 @@ const backgroundsTag: TranslationKey = 'tags.backgrounds'
 const threeDTag: TranslationKey = 'tags.threeD'
 const inBetweeningTag: TranslationKey = 'tags.inBetweening'
 const compositingTag: TranslationKey = 'tags.compositing'
+const fundamentalsTag: TranslationKey = 'tags.fundamentals'
+const nodeGraphTag: TranslationKey = 'tags.nodeGraph'
+const loraTag: TranslationKey = 'tags.lora'
+const controlNetTag: TranslationKey = 'tags.controlNet'
 
 const dougHogan: TutorialAuthor = {
   name: { en: 'Doug Hogan', 'zh-CN': 'Doug Hogan' },
@@ -120,6 +132,44 @@ const shaneFu: TutorialAuthor = {
 }
 
 export const learningTutorials: readonly LearningTutorial[] = [
+  {
+    id: 'basics_node_graph',
+    publishedDate: '2026-07-31',
+    slug: 'full-node-graph-basics',
+    category: 'basics',
+    episode: 1,
+    youtubeId: 'TQhIYT1ZYGQ',
+    title: {
+      en: 'ComfyUI Tutorial for Beginners: Full Node Graph Basics (2026)',
+      'zh-CN': 'ComfyUI 新手教程：完整节点图基础 (2026)'
+    },
+    description: {
+      en: "A beginner's tour of the ComfyUI node graph — how nodes, links, and the run queue fit together to build your first working pipeline.",
+      'zh-CN':
+        '面向初学者的 ComfyUI 节点图入门——了解节点、连线与运行队列如何协同，搭建你的第一条可用流程。'
+    },
+    poster: 'https://img.youtube.com/vi/TQhIYT1ZYGQ/maxresdefault.jpg',
+    tags: [fundamentalsTag, nodeGraphTag]
+  },
+  {
+    id: 'basics_loras_style_controlnets',
+    publishedDate: '2026-08-17',
+    slug: 'loras-style-transfer-controlnets',
+    category: 'basics',
+    episode: 2,
+    youtubeId: '-igiHGaxKek',
+    title: {
+      en: 'ComfyUI Tutorial for Beginners: LoRAs, Style Transfer & ControlNets (2026)',
+      'zh-CN': 'ComfyUI 新手教程：LoRA、风格迁移与 ControlNet (2026)'
+    },
+    description: {
+      en: 'Go further with LoRAs, style transfer, and ControlNets — what each one does and how to wire them into a ComfyUI workflow.',
+      'zh-CN':
+        '进阶了解 LoRA、风格迁移与 ControlNet——各自的作用，以及如何将它们接入 ComfyUI 工作流。'
+    },
+    poster: 'https://img.youtube.com/vi/-igiHGaxKek/maxresdefault.jpg',
+    tags: [fundamentalsTag, loraTag, controlNetTag, styleTransferTag]
+  },
   {
     id: 'cleanplate_walkthrough_v03',
     publishedDate: '2026-05-26',
@@ -660,6 +710,14 @@ export const getTutorialByCategoryAndSlug = (
   learningTutorials.find(
     (tutorial) => tutorial.category === category && tutorial.slug === slug
   )
+
+/** Privacy-friendly embed URL for the watch-page iframe (YouTube items). */
+export const youtubeEmbedUrl = (id: string): string =>
+  `https://www.youtube-nocookie.com/embed/${id}?autoplay=1&mute=1&rel=0`
+
+/** Canonical watch URL, used as the VideoObject contentUrl for YouTube items. */
+export const youtubeWatchUrl = (id: string): string =>
+  `https://www.youtube.com/watch?v=${id}`
 
 /** Canonical path for a category's directory page (wrap with localizeHref for zh-CN). */
 export const categoryPath = (category: LearningCategory): string =>

--- a/apps/website/src/data/learningTutorials.ts
+++ b/apps/website/src/data/learningTutorials.ts
@@ -5,6 +5,7 @@ import type {
   TranslationKey
 } from '../i18n/translations'
 
+import { externalLinks } from '../config/routes'
 import { t } from '../i18n/translations'
 
 export type LearningCategory = 'basics' | 'vfx' | 'animations' | 'ads'
@@ -32,6 +33,8 @@ export interface LearningTutorial {
   /** When set, the watch page embeds a YouTube iframe instead of <video>. */
   youtubeId?: string
   href?: string
+  /** CTA button label; defaults to "Try Workflow" when omitted. */
+  ctaLabelKey?: TranslationKey
   /** Open the workflow link in a new tab (e.g. cloud.comfy.org). */
   newTab?: boolean
   poster: string
@@ -150,6 +153,9 @@ export const learningTutorials: readonly LearningTutorial[] = [
         '面向初学者的 ComfyUI 节点图入门——了解节点、连线与运行队列如何协同，搭建你的第一条可用流程。'
     },
     poster: 'https://img.youtube.com/vi/TQhIYT1ZYGQ/maxresdefault.jpg',
+    href: externalLinks.cloudCta('learning_basics_node_graph'),
+    newTab: true,
+    ctaLabelKey: 'cta.tryForFree',
     tags: [fundamentalsTag, nodeGraphTag]
   },
   {
@@ -170,6 +176,9 @@ export const learningTutorials: readonly LearningTutorial[] = [
         '进阶了解 LoRA、风格迁移与 ControlNet——各自的作用，以及如何将它们接入 ComfyUI 工作流。'
     },
     poster: 'https://img.youtube.com/vi/-igiHGaxKek/maxresdefault.jpg',
+    href: externalLinks.cloudCta('learning_basics_loras'),
+    newTab: true,
+    ctaLabelKey: 'cta.tryForFree',
     tags: [fundamentalsTag, loraTag, controlNetTag, styleTransferTag]
   },
   {

--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -70,6 +70,22 @@ const translations = {
     en: 'Compositing',
     'zh-CN': '合成'
   },
+  'tags.fundamentals': {
+    en: 'Fundamentals',
+    'zh-CN': '基础入门'
+  },
+  'tags.nodeGraph': {
+    en: 'Node Graph',
+    'zh-CN': '节点图'
+  },
+  'tags.lora': {
+    en: 'LoRA',
+    'zh-CN': 'LoRA'
+  },
+  'tags.controlNet': {
+    en: 'ControlNet',
+    'zh-CN': 'ControlNet'
+  },
 
   // UI (global, reusable across sections)
   'ui.copy': {
@@ -1664,6 +1680,11 @@ const translations = {
     en: 'Every tutorial and workflow',
     'zh-CN': '所有教程与工作流'
   },
+  'learning.categories.basics': { en: 'Basics', 'zh-CN': '基础' },
+  'learning.categories.basics.blurb': {
+    en: 'Fundamentals and getting started',
+    'zh-CN': '基础入门与上手指南'
+  },
   'learning.categories.vfx': { en: 'VFX', 'zh-CN': 'VFX' },
   'learning.categories.vfx.blurb': {
     en: 'Compositing, cleanup and shot work',
@@ -1681,6 +1702,15 @@ const translations = {
   },
   // Per-vertical h1 + description/meta copy, swapped when a category filter is
   // active (see learningHeading / learningDescription).
+  'learning.categories.basics.heading': {
+    en: 'ComfyUI Basics',
+    'zh-CN': 'ComfyUI 基础教程'
+  },
+  'learning.categories.basics.description': {
+    en: 'Beginner ComfyUI tutorials — learn the node graph, LoRAs, style transfer, and ControlNets from the ground up.',
+    'zh-CN':
+      '面向初学者的 ComfyUI 教程——从零开始掌握节点图、LoRA、风格迁移与 ControlNet。'
+  },
   'learning.categories.vfx.heading': {
     en: 'VFX Tutorials',
     'zh-CN': 'VFX 教程'

--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -105,6 +105,10 @@ const translations = {
     en: 'Try Workflow',
     'zh-CN': '试用工作流'
   },
+  'cta.tryForFree': {
+    en: 'Try for Free',
+    'zh-CN': '免费试用'
+  },
   'cta.getStarted': {
     en: 'GET STARTED',
     'zh-CN': '快速开始'

--- a/apps/website/src/utils/jsonLd.ts
+++ b/apps/website/src/utils/jsonLd.ts
@@ -413,7 +413,8 @@ export interface VideoObjectInput {
   name: string
   description: string
   thumbnailUrl: string
-  contentUrl: string
+  /** Self-hosted media URL; omit for embed-only videos (set embedUrl instead). */
+  contentUrl?: string
   uploadDate: string
   locale: Locale
   embedUrl?: string


### PR DESCRIPTION
## Summary

Adds a "Basics" category (first in nav) to /learning with two beginner YouTube tutorials, teaching /learning to play YouTube embeds alongside self-hosted MP4s.

## Changes

- **What**: New `basics` `LearningCategory` (nav-first) with two tutorials from the official ComfyUI channel. `LearningTutorial` now supports `youtubeId?` (YouTube embed) in addition to `videoSrc?` (self-hosted); exactly one is set. When `youtubeId` is present, `LearningWatchPage` renders a new `LearningVideoEmbed.vue` (youtube-nocookie iframe, `?autoplay=1&mute=1&rel=0`, mirroring `HeroLivestream01`) instead of `VideoPlayer`, which is left untouched. Posters use YouTube thumbnails. `VideoObject` JSON-LD gains `embedUrl` (and `contentUrl` becomes optional) for embedded items. New `tags.fundamentals/nodeGraph/lora/controlNet` and full en + zh-CN category copy.
- **Breaking**: `LearningTutorial.videoSrc` and `VideoObjectInput.contentUrl` are now optional. Extensions/consumers of learning data must branch on `youtubeId` rather than assume `videoSrc` exists.

## Review Focus

- `videoSrc`/`youtubeId` exactly-one invariant (unit-tested in `learningTutorials.test.ts`).
- JSON-LD mapping for embedded videos: `embedUrl` = nocookie embed, `contentUrl` = canonical watch URL.
- Posters use `img.youtube.com/vi/<id>/maxresdefault.jpg`; if any thumbnail 404s, `hqdefault.jpg` is the always-present fallback.
- Playwright was not run locally (multi-worktree dev-server/port contention); it will run in CI. Verified via `vitest` (8 passed) + `astro check` (0 errors) + lint/format.