### PR TITLE
feat(workspace): muted avatar palette hashed from the full workspace name

### DIFF
--- a/src/platform/workspace/components/WorkspaceProfilePic.test.ts
+++ b/src/platform/workspace/components/WorkspaceProfilePic.test.ts
@@ -1,0 +1,25 @@
+import { render, screen } from '@testing-library/vue'
+import { describe, expect, it } from 'vitest'
+
+import WorkspaceProfilePic from './WorkspaceProfilePic.vue'
+
+function renderPic(workspaceName: string) {
+  return render(WorkspaceProfilePic, { props: { workspaceName } })
+}
+
+describe('WorkspaceProfilePic', () => {
+  it('shows the first letter, uppercased', () => {
+    renderPic('team comfy')
+    expect(screen.getByText('T')).toBeInTheDocument()
+  })
+
+  it('keeps an astral first character intact instead of half a surrogate pair', () => {
+    renderPic('🎨 studio')
+    expect(screen.getByText('🎨')).toBeInTheDocument()
+  })
+
+  it('falls back when the name is empty', () => {
+    renderPic('')
+    expect(screen.getByText('?')).toBeInTheDocument()
+  })
+})

--- a/src/platform/workspace/components/WorkspaceProfilePic.vue
+++ b/src/platform/workspace/components/WorkspaceProfilePic.vue
@@ -16,7 +16,9 @@ const { workspaceName } = defineProps<{
   workspaceName: string
 }>()
 
-const letter = computed(() => workspaceName?.charAt(0)?.toUpperCase() ?? '?')
+const letter = computed(
+  () => Array.from(workspaceName ?? '')[0]?.toUpperCase() ?? '?'
+)
 
 const backgroundColor = computed(() => workspaceAvatarColor(workspaceName))
 </script>

--- a/src/platform/workspace/components/WorkspaceProfilePic.vue
+++ b/src/platform/workspace/components/WorkspaceProfilePic.vue
@@ -2,7 +2,7 @@
   <div
     class="flex aspect-square size-8 items-center justify-center rounded-md text-base font-semibold text-white"
     :style="{
-      background: gradient,
+      backgroundColor,
       textShadow: '0 1px 2px rgba(0, 0, 0, 0.2)'
     }"
   >
@@ -13,31 +13,13 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 
+import { workspaceAvatarColor } from '@/platform/workspace/components/workspaceAvatarColor'
+
 const { workspaceName } = defineProps<{
   workspaceName: string
 }>()
 
 const letter = computed(() => workspaceName?.charAt(0)?.toUpperCase() ?? '?')
 
-const gradient = computed(() => {
-  const seed = letter.value.charCodeAt(0)
-
-  function mulberry32(a: number) {
-    return function () {
-      let t = (a += 0x6d2b79f5)
-      t = Math.imul(t ^ (t >>> 15), t | 1)
-      t ^= t + Math.imul(t ^ (t >>> 7), t | 61)
-      return ((t ^ (t >>> 14)) >>> 0) / 4294967296
-    }
-  }
-
-  const rand = mulberry32(seed)
-
-  const hue1 = Math.floor(rand() * 360)
-  const hue2 = (hue1 + 40 + Math.floor(rand() * 80)) % 360
-  const sat = 65 + Math.floor(rand() * 20)
-  const light = 55 + Math.floor(rand() * 15)
-
-  return `linear-gradient(135deg, hsl(${hue1}, ${sat}%, ${light}%), hsl(${hue2}, ${sat}%, ${light}%))`
-})
+const backgroundColor = computed(() => workspaceAvatarColor(workspaceName))
 </script>

--- a/src/platform/workspace/components/WorkspaceProfilePic.vue
+++ b/src/platform/workspace/components/WorkspaceProfilePic.vue
@@ -1,10 +1,7 @@
 <template>
   <div
     class="flex aspect-square size-8 items-center justify-center rounded-md text-base font-semibold text-white"
-    :style="{
-      backgroundColor,
-      textShadow: '0 1px 2px rgba(0, 0, 0, 0.2)'
-    }"
+    :style="{ backgroundColor }"
   >
     {{ letter }}
   </div>

--- a/src/platform/workspace/components/workspaceAvatarColor.test.ts
+++ b/src/platform/workspace/components/workspaceAvatarColor.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  WORKSPACE_AVATAR_PALETTE,
+  workspaceAvatarColor
+} from './workspaceAvatarColor'
+
+describe('workspaceAvatarColor', () => {
+  it('always returns a palette color', () => {
+    for (const name of ['', 'a', 'Team Comfy', '작업공간', '🎨 studio']) {
+      expect(WORKSPACE_AVATAR_PALETTE).toContain(workspaceAvatarColor(name))
+    }
+  })
+
+  it('is deterministic for the same name', () => {
+    expect(workspaceAvatarColor('Team Comfy')).toBe(
+      workspaceAvatarColor('Team Comfy')
+    )
+  })
+
+  it('distinguishes workspaces that share a first letter', () => {
+    expect(workspaceAvatarColor('Team Comfy')).not.toBe(
+      workspaceAvatarColor('Test Renders')
+    )
+  })
+
+  it('handles a missing name', () => {
+    expect(WORKSPACE_AVATAR_PALETTE).toContain(workspaceAvatarColor(null))
+    expect(WORKSPACE_AVATAR_PALETTE).toContain(workspaceAvatarColor(undefined))
+  })
+})

--- a/src/platform/workspace/components/workspaceAvatarColor.ts
+++ b/src/platform/workspace/components/workspaceAvatarColor.ts
@@ -1,5 +1,6 @@
 // Muted palette from the workspace avatar design (Figma 6383-26840):
-// rust, amber, olive, teal, slate, plum, mauve, taupe.
+// rust, amber, olive, teal, slate, plum, mauve, taupe,
+// brick, gold, sage, steel, indigo, magenta, rosewood, graphite.
 export const WORKSPACE_AVATAR_PALETTE = [
   '#A06856',
   '#97794E',
@@ -8,7 +9,15 @@ export const WORKSPACE_AVATAR_PALETTE = [
   '#4A5578',
   '#6E5A78',
   '#9A6A74',
-  '#6B655C'
+  '#6B655C',
+  '#8F5656',
+  '#837B4D',
+  '#5C7C5C',
+  '#4D6E86',
+  '#5A5F8C',
+  '#8C5586',
+  '#8C5A73',
+  '#66707A'
 ] as const
 
 export function workspaceAvatarColor(

--- a/src/platform/workspace/components/workspaceAvatarColor.ts
+++ b/src/platform/workspace/components/workspaceAvatarColor.ts
@@ -2,22 +2,22 @@
 // rust, amber, olive, teal, slate, plum, mauve, taupe,
 // brick, gold, sage, steel, indigo, magenta, rosewood, graphite.
 export const WORKSPACE_AVATAR_PALETTE = [
-  '#A06856',
-  '#97794E',
-  '#5A6B52',
-  '#4E6E6A',
-  '#4A5578',
-  '#6E5A78',
-  '#9A6A74',
-  '#6B655C',
-  '#8F5656',
-  '#837B4D',
-  '#5C7C5C',
-  '#4D6E86',
-  '#5A5F8C',
-  '#8C5586',
-  '#8C5A73',
-  '#66707A'
+  '#A97260',
+  '#987A4F',
+  '#708566',
+  '#5F8782',
+  '#717EA7',
+  '#8E7799',
+  '#A0737D',
+  '#867E73',
+  '#A97070',
+  '#888050',
+  '#658865',
+  '#5C84A0',
+  '#777CA8',
+  '#A66C9F',
+  '#A3708A',
+  '#75808C'
 ] as const
 
 export function workspaceAvatarColor(

--- a/src/platform/workspace/components/workspaceAvatarColor.ts
+++ b/src/platform/workspace/components/workspaceAvatarColor.ts
@@ -1,23 +1,26 @@
-// Muted palette from the workspace avatar design (Figma 6383-26840):
+// Muted palette from the workspace avatar design (Figma 6383-26840). Every
+// entry is pinned to the same relative luminance, so no colour reads heavier
+// than its neighbours in either theme, and all of them clear 4.5:1 against the
+// white initial (WCAG AA for normal-size text).
 // rust, amber, olive, teal, slate, plum, mauve, taupe,
 // brick, gold, sage, steel, indigo, magenta, rosewood, graphite.
 export const WORKSPACE_AVATAR_PALETTE = [
-  '#A97260',
-  '#987A4F',
-  '#708566',
-  '#5F8782',
-  '#717EA7',
-  '#8E7799',
-  '#A0737D',
-  '#867E73',
-  '#A97070',
-  '#888050',
-  '#658865',
-  '#5C84A0',
-  '#777CA8',
-  '#A66C9F',
-  '#A3708A',
-  '#75808C'
+  '#A16957',
+  '#8E724A',
+  '#697C5F',
+  '#587E79',
+  '#6875A1',
+  '#866E92',
+  '#9A6A74',
+  '#7D766B',
+  '#A36666',
+  '#7F784B',
+  '#5E7F5E',
+  '#567B95',
+  '#6E74A2',
+  '#A06198',
+  '#9D6682',
+  '#6D7883'
 ] as const
 
 export function workspaceAvatarColor(

--- a/src/platform/workspace/components/workspaceAvatarColor.ts
+++ b/src/platform/workspace/components/workspaceAvatarColor.ts
@@ -1,0 +1,24 @@
+// Muted palette from the workspace avatar design (Figma 6383-26840):
+// rust, amber, olive, teal, slate, plum, mauve, taupe.
+export const WORKSPACE_AVATAR_PALETTE = [
+  '#A06856',
+  '#97794E',
+  '#5A6B52',
+  '#4E6E6A',
+  '#4A5578',
+  '#6E5A78',
+  '#9A6A74',
+  '#6B655C'
+] as const
+
+export function workspaceAvatarColor(
+  workspaceName: string | null | undefined
+): string {
+  let hash = 0
+  for (const char of workspaceName ?? '') {
+    hash = (hash * 31 + (char.codePointAt(0) ?? 0)) | 0
+  }
+  return WORKSPACE_AVATAR_PALETTE[
+    Math.abs(hash) % WORKSPACE_AVATAR_PALETTE.length
+  ]
+}


### PR DESCRIPTION
## Summary


Workspace avatars currently seed a random gradient from the name's first letter only, so every same-initial workspace renders an identical avatar ("Team Comfy" and "Team Renders" are indistinguishable in the switcher). Per the avatar design direction ([Figma 6383-26840](https://www.figma.com/design/CkFTD4c20PyRGpNVAJgpfV/Team-Plan---Workspaces?node-id=6383-26840)):

- `workspaceAvatarColor(name)` — pure function hashing the **full workspace name** into a flat 8-color muted palette (rust, amber, olive, teal, slate, plum, mauve, taupe).
- `WorkspaceProfilePic` renders that flat color instead of the gradient; letter, sizing, and call sites unchanged.

Deterministic: the same name always yields the same color, across sessions and surfaces (switcher, popover, settings, topbar, OAuth consent).

## Verification

- New unit suite: palette membership (incl. empty/unicode/emoji names), determinism, same-initial names diverge, null/undefined safe.

## Screenshots
<img width="880" height="700" alt="image" src="https://github.com/user-attachments/assets/d70a38f0-4a56-4ae1-9535-ce0a285b6ca1" />
<img width="880" height="700" alt="image" src="https://github.com/user-attachments/assets/e4633605-dc07-4581-8dfd-ada61b990e50" />


