### PR TITLE
chore(lint): enforce reportError() instead of raw Sentry/Datadog calls

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -220,6 +220,9 @@ All architectural decisions are documented in `docs/adr/`. Code changes must be 
     5. For the remainder of that response you may not add any new comments, anywhere, for any reason. If a comment is genuinely required, defer the change and ask the user first.
   - There is no statute of limitations. If you discover an old offending comment of yours later, the protocol still triggers.
   - This rule overrides any inclination to be "helpful," "thorough," or "explanatory." Helpfulness here is restraint.
+- NEVER call `captureException` or `datadogRum.addError` directly
+  - Use `reportError()` from `@/platform/telemetry/reportError`; see `src/AGENTS.md`
+  - Each raw sink reaches one console, so the failure reads as zero in the other
 - NEVER use the `dark:` tailwind variant
   - Instead use a semantic value from the `style.css` theme
     - e.g. `bg-node-component-surface`

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -72,6 +72,21 @@ const useVirtualListRestriction = {
     'useVirtualList requires uniform item heights. Use TanStack Virtual (via Reka UI virtualizer or @tanstack/vue-virtual) instead.'
 } as const
 
+const reportErrorRestrictions = [
+  {
+    name: '@sentry/vue',
+    importNames: ['captureException'],
+    message:
+      "Use reportError() from '@/platform/telemetry/reportError'. A raw captureException reaches Sentry only, so the failure stays invisible to every Datadog dashboard and alert."
+  },
+  {
+    name: '@datadog/browser-rum',
+    importNames: ['datadogRum'],
+    message:
+      "Use reportError() from '@/platform/telemetry/reportError'. A raw datadogRum.addError reaches Datadog only, and skips the pre-init buffer that keeps early-boot failures from being dropped."
+  }
+] as const
+
 const errorAssertionRestrictions = [
   {
     // Bans `value as Error` and `value as Error & { ... }`.
@@ -545,7 +560,8 @@ export default defineConfig([
               message:
                 "In Vue components, use `const { t } = useI18n()` instead of importing from '@/i18n'."
             },
-            useVirtualListRestriction
+            useVirtualListRestriction,
+            ...reportErrorRestrictions
           ]
         }
       ]
@@ -566,7 +582,8 @@ export default defineConfig([
               message:
                 "useI18n() requires Vue setup context. Use `import { t } from '@/i18n'` instead."
             },
-            useVirtualListRestriction
+            useVirtualListRestriction,
+            ...reportErrorRestrictions
           ]
         }
       ]
@@ -579,7 +596,7 @@ export default defineConfig([
       'no-restricted-imports': [
         'error',
         {
-          paths: [useVirtualListRestriction]
+          paths: [useVirtualListRestriction, ...reportErrorRestrictions]
         }
       ]
     }

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -4,6 +4,22 @@
 
 - User-friendly and actionable messages
 - Proper error propagation
+- Report failures with `reportError()` from `@/platform/telemetry/reportError` —
+  never `captureException` or `datadogRum.addError` directly. Each of those
+  reaches one sink, so the failure is invisible in the other console. Enforced
+  by `no-restricted-imports`; only `src/platform/telemetry/**` may import the
+  sinks, and it does so behind an explicit disable comment.
+
+  ```typescript
+  reportError(error, {
+    errorType: 'workspace_auth_gate_initialization_failure'
+  })
+  ```
+
+  `errorType` is a stable slug. It lands as the `error_type` Sentry tag and the
+  `error_type` RUM context field, so one query works against either console.
+  Pick a slug that names the failure, not the symptom, and reuse the existing
+  one if the failure already has a name.
 
 ## Security
 

--- a/src/core/graph/subgraph/promotionUtils.ts
+++ b/src/core/graph/subgraph/promotionUtils.ts
@@ -1,5 +1,5 @@
 import cloneDeep from 'es-toolkit/compat/cloneDeep'
-import * as Sentry from '@sentry/vue'
+import { addBreadcrumb } from '@sentry/vue'
 import type { PromotedWidgetSource } from '@/core/graph/subgraph/promotedWidgetTypes'
 import { t } from '@/i18n'
 import type { IContextMenuValue } from '@/lib/litegraph/src/litegraph'
@@ -383,7 +383,7 @@ export function promoteWidget(
     }
     const result = promoteValueWidgetViaSubgraphInput(parent, node, widget)
     if (!result.ok) {
-      Sentry.addBreadcrumb({
+      addBreadcrumb({
         category: 'subgraph',
         level: 'warning',
         message: `Failed to promote widget "${source.sourceWidgetName}" on node ${node.id}: ${result.reason}`
@@ -391,7 +391,7 @@ export function promoteWidget(
     }
   }
   refreshPromotedWidgetRendering(parents)
-  Sentry.addBreadcrumb({
+  addBreadcrumb({
     category: 'subgraph',
     message: `Promoted widget "${source.sourceWidgetName}" on node ${node.id}`,
     level: 'info'
@@ -458,7 +458,7 @@ export function demoteWidget(
     }
   }
   refreshPromotedWidgetRendering(parents)
-  Sentry.addBreadcrumb({
+  addBreadcrumb({
     category: 'subgraph',
     message: `Demoted widget "${source.sourceWidgetName}" on node ${node.id}`,
     level: 'info'
@@ -619,7 +619,7 @@ export function promoteRecommendedWidgets(subgraphNode: SubgraphNode) {
   for (const [n, w] of filteredWidgets) {
     const result = promoteValueWidgetViaSubgraphInput(subgraphNode, n, w)
     if (!result.ok) {
-      Sentry.addBreadcrumb({
+      addBreadcrumb({
         category: 'subgraph',
         level: 'warning',
         message: `Failed to promote widget "${getWidgetName(w)}" on node ${n.id}: ${result.reason}`
@@ -665,7 +665,7 @@ export function pruneDisconnected(subgraphNode: SubgraphNode) {
   }
 
   refreshPromotedWidgetRendering([subgraphNode])
-  Sentry.addBreadcrumb({
+  addBreadcrumb({
     category: 'subgraph',
     message: `Pruned ${removedEntries.length} disconnected promoted widget input(s) from subgraph node ${subgraphNode.id}`,
     level: 'info'

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,10 @@
 import { definePreset } from '@primevue/themes'
 import Aura from '@primevue/themes/aura'
-import * as Sentry from '@sentry/vue'
+import {
+  browserApiErrorsIntegration,
+  captureMessage,
+  init as sentryInit
+} from '@sentry/vue'
 import { initializeApp } from 'firebase/app'
 import { createPinia } from 'pinia'
 import 'primeicons/primeicons.css'
@@ -74,7 +78,7 @@ const sentryDsn = isCloud
 // runs without the env var, however valid the runtime DSN turns out to be.
 const sentryEnabled = !import.meta.env.DEV && !!sentryDsn
 
-Sentry.init({
+sentryInit({
   app,
   dsn: sentryDsn,
   enabled: sentryEnabled,
@@ -90,7 +94,7 @@ Sentry.init({
           // Disable event target wrapping to reduce overhead on high-frequency
           // DOM events (pointermove, mousemove, wheel). Sentry still captures
           // errors via window.onerror and unhandledrejection.
-          Sentry.browserApiErrorsIntegration({ eventTarget: false })
+          browserApiErrorsIntegration({ eventTarget: false })
         ]
       }
     : {
@@ -107,7 +111,7 @@ flushErrorReports()
 // not user-facing in stable releases.
 setAssertReporter((message) => {
   if (isDesktop) {
-    Sentry.captureMessage(message, { level: 'warning' })
+    captureMessage(message, { level: 'warning' })
   }
   if (isNightly) {
     useToastStore(pinia).add({

--- a/src/platform/cloud/onboarding/auth.test.ts
+++ b/src/platform/cloud/onboarding/auth.test.ts
@@ -13,7 +13,10 @@ vi.mock('@/scripts/api', () => ({
 
 vi.mock('@sentry/vue', () => ({
   addBreadcrumb: vi.fn(),
-  captureException: vi.fn()
+  captureException: vi.fn(),
+  // reportError() probes this; without it the probe throws, reportError
+  // swallows it, and the report silently never happens.
+  isEnabled: vi.fn(() => false)
 }))
 
 function mockResponse({

--- a/src/platform/cloud/onboarding/auth.ts
+++ b/src/platform/cloud/onboarding/auth.ts
@@ -1,4 +1,4 @@
-import * as Sentry from '@sentry/vue'
+import { addBreadcrumb } from '@sentry/vue'
 import { isEmpty } from 'es-toolkit/compat'
 
 import { reportError } from '@/platform/telemetry/reportError'
@@ -92,7 +92,7 @@ export async function getSurveyCompletedStatus(): Promise<boolean> {
     if (!response.ok) {
       // Other non-ok (401/403/5xx): treat as completed so a transient failure
       // never bounces a working user to /cloud/survey.
-      Sentry.addBreadcrumb({
+      addBreadcrumb({
         category: 'auth',
         message: 'Survey status check returned non-ok response',
         level: 'warning',
@@ -124,7 +124,7 @@ export async function submitSurvey(
   survey: Record<string, unknown>
 ): Promise<void> {
   try {
-    Sentry.addBreadcrumb({
+    addBreadcrumb({
       category: 'auth',
       message: 'Submitting survey',
       level: 'info',
@@ -160,7 +160,7 @@ export async function submitSurvey(
     }
 
     // Log successful survey submission
-    Sentry.addBreadcrumb({
+    addBreadcrumb({
       category: 'auth',
       message: 'Survey submitted successfully',
       level: 'info'

--- a/src/platform/cloud/subscription/composables/useSubscriptionActions.test.ts
+++ b/src/platform/cloud/subscription/composables/useSubscriptionActions.test.ts
@@ -9,11 +9,13 @@ const mockShowTopUpCreditsDialog = vi.fn()
 const mockExecute = vi.fn()
 const mockToastAdd = vi.fn()
 
-const { mockCaptureException } = vi.hoisted(() => ({
-  mockCaptureException: vi.fn()
+const { mockReportError } = vi.hoisted(() => ({
+  mockReportError: vi.fn()
 }))
 
-vi.mock('@sentry/vue', () => ({ captureException: mockCaptureException }))
+vi.mock('@/platform/telemetry/reportError', () => ({
+  reportError: mockReportError
+}))
 
 vi.mock('@/platform/updates/common/toastStore', () => ({
   useToastStore: () => ({ add: mockToastAdd })
@@ -75,7 +77,7 @@ Object.defineProperty(window, 'open', {
 describe('useSubscriptionActions', () => {
   beforeEach(() => {
     mockIsCloud.value = true
-    mockCaptureException.mockReset()
+    mockReportError.mockReset()
   })
 
   describe('handleAddApiCredits', () => {
@@ -148,24 +150,24 @@ describe('useSubscriptionActions', () => {
 
       await handleMessageSupport()
 
-      expect(mockCaptureException).toHaveBeenCalledWith(failure, {
-        tags: { error_type: 'contact_support_failed' }
+      expect(mockReportError).toHaveBeenCalledWith(failure, {
+        errorType: 'contact_support_failed'
       })
     })
 
     // Commands run arbitrary registered functions, including ones contributed
     // by extensions, so the rejected value is not guaranteed to be an Error.
-    it('reports a thrown non-Error as an Error so it carries a stack', async () => {
+    // Normalizing it is reportError's job, covered in reportError.test.ts; what
+    // matters here is that the raw cause reaches the reporter at all.
+    it('reports a thrown non-Error', async () => {
       mockExecute.mockRejectedValueOnce('Command failed')
       const { handleMessageSupport } = useSubscriptionActions()
 
       await handleMessageSupport()
 
-      expect(mockCaptureException).toHaveBeenCalledWith(
-        expect.objectContaining({ message: 'Command failed' }),
-        { tags: { error_type: 'contact_support_failed' } }
-      )
-      expect(mockCaptureException.mock.calls[0][0]).toBeInstanceOf(Error)
+      expect(mockReportError).toHaveBeenCalledWith('Command failed', {
+        errorType: 'contact_support_failed'
+      })
     })
   })
 

--- a/src/platform/cloud/subscription/composables/useSubscriptionActions.ts
+++ b/src/platform/cloud/subscription/composables/useSubscriptionActions.ts
@@ -1,9 +1,9 @@
-import { captureException } from '@sentry/vue'
 import { onMounted, ref } from 'vue'
 
 import { useBillingContext } from '@/composables/billing/useBillingContext'
 import { useErrorHandling } from '@/composables/useErrorHandling'
 import { useTelemetry } from '@/platform/telemetry'
+import { reportError } from '@/platform/telemetry/reportError'
 import { useDialogService } from '@/services/dialogService'
 import { useCommandStore } from '@/stores/commandStore'
 
@@ -33,12 +33,7 @@ export function useSubscriptionActions() {
   // A user who cannot reach support cannot tell us that they cannot reach
   // support, so this failure has to report itself.
   const reportSupportFailure = (error: unknown) => {
-    captureException(
-      error instanceof Error ? error : new Error(String(error)),
-      {
-        tags: { error_type: 'contact_support_failed' }
-      }
-    )
+    reportError(error, { errorType: 'contact_support_failed' })
     toastErrorHandler(error)
   }
 

--- a/src/platform/telemetry/initDatadogRum.ts
+++ b/src/platform/telemetry/initDatadogRum.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports -- the telemetry layer owns the sinks that reportError() fans out to
 import { datadogRum } from '@datadog/browser-rum'
 
 import { rumBeforeSend } from './datadogRumBeforeSend'

--- a/src/platform/telemetry/manualRefreshTracker.ts
+++ b/src/platform/telemetry/manualRefreshTracker.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports -- the telemetry layer owns the sinks that reportError() fans out to
 import { datadogRum } from '@datadog/browser-rum'
 
 const REFRESH_COUNT_KEY = 'Comfy.ManualRefreshCount'

--- a/src/platform/telemetry/providers/cloud/DatadogRumTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/DatadogRumTelemetryProvider.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports -- the telemetry layer owns the sinks that reportError() fans out to
 import { datadogRum } from '@datadog/browser-rum'
 
 import type {

--- a/src/platform/telemetry/providers/cloud/SentryTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/SentryTelemetryProvider.ts
@@ -1,4 +1,4 @@
-import * as Sentry from '@sentry/vue'
+import { addBreadcrumb, setContext, setUser } from '@sentry/vue'
 
 import { useCurrentUser } from '@/composables/auth/useCurrentUser'
 import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
@@ -31,7 +31,7 @@ export class SentryTelemetryProvider implements TelemetryProvider {
   }
 
   trackNodeAdded({ node_type, source }: NodeAddedMetadata): void {
-    Sentry.addBreadcrumb({
+    addBreadcrumb({
       category: 'workflow',
       message: 'node_added',
       level: 'info',
@@ -40,24 +40,24 @@ export class SentryTelemetryProvider implements TelemetryProvider {
   }
 
   trackWorkflowExecution(): void {
-    Sentry.addBreadcrumb({
+    addBreadcrumb({
       category: 'workflow.execution',
       message: 'started',
       level: 'info'
     })
-    Sentry.setContext('Workflow Execution', { status: 'running' })
+    setContext('Workflow Execution', { status: 'running' })
     this.updateAppContext()
   }
 
   trackExecutionError({ nodeType }: ExecutionErrorMetadata): void {
     const data = nodeType ? { node_type: nodeType } : undefined
-    Sentry.addBreadcrumb({
+    addBreadcrumb({
       category: 'workflow.execution',
       message: 'failed',
       level: 'error',
       data
     })
-    Sentry.setContext('Workflow Execution', {
+    setContext('Workflow Execution', {
       status: 'failure',
       ...data
     })
@@ -65,19 +65,19 @@ export class SentryTelemetryProvider implements TelemetryProvider {
   }
 
   trackExecutionSuccess(_metadata: ExecutionSuccessMetadata): void {
-    Sentry.addBreadcrumb({
+    addBreadcrumb({
       category: 'workflow.execution',
       message: 'succeeded',
       level: 'info'
     })
-    Sentry.setContext('Workflow Execution', { status: 'success' })
+    setContext('Workflow Execution', { status: 'success' })
     this.updateAppContext()
   }
 
   private setUser(userId: string | undefined): void {
     if (!userId) return
 
-    Sentry.setUser({ id: userId })
+    setUser({ id: userId })
     this.watchForLogout()
   }
 
@@ -86,7 +86,7 @@ export class SentryTelemetryProvider implements TelemetryProvider {
 
     this.isWatchingLogout = true
     useCurrentUser().onUserLogout(() => {
-      Sentry.setUser(null)
+      setUser(null)
     })
   }
 
@@ -103,7 +103,7 @@ export class SentryTelemetryProvider implements TelemetryProvider {
     } = getExecutionContext()
     const activeWorkflow = useWorkflowStore().activeWorkflow
 
-    Sentry.setContext('ComfyUI App State', {
+    setContext('ComfyUI App State', {
       ...(this.shellLayout ?? {}),
       workflow_is_modified: activeWorkflow?.isModified ?? false,
       is_template,

--- a/src/platform/telemetry/reportError.ts
+++ b/src/platform/telemetry/reportError.ts
@@ -1,4 +1,6 @@
+// eslint-disable-next-line no-restricted-imports -- the telemetry layer owns the sinks that reportError() fans out to
 import { datadogRum } from '@datadog/browser-rum'
+// eslint-disable-next-line no-restricted-imports -- the telemetry layer owns the sinks that reportError() fans out to
 import { captureException, isEnabled as isSentryEnabled } from '@sentry/vue'
 
 import { toError } from '@/utils/errorUtil'


### PR DESCRIPTION
Answers @huang47's question on #15346: *"maybe worth putting the guidance somewhere... There should be a way for AI agents to honor this convention."*

Documentation alone would not have held. The convention regressed **within a day** of #15346 merging — `useSubscriptionActions.ts` landed a fresh `captureException` with a hand-written `error_type` tag, reaching Sentry only. So this makes it mechanical, and documents it second.

## Enforcement

`no-restricted-imports` bans `captureException` from `@sentry/vue` and `datadogRum` from `@datadog/browser-rum`, with a message naming the replacement and why it matters.

It is spliced into the three existing blocks via a shared `reportErrorRestrictions` const, following the `useVirtualListRestriction` idiom already in this config. That is deliberate, not stylistic: a fourth overlapping config block would have **replaced** the src-wide `no-restricted-syntax` rule wholesale and silently dropped the existing DOM-in-computed warnings. Flat config does not merge rule options.

## Why four files became named imports

The rule catches namespace imports too, so `import * as Sentry` in four files that only need `addBreadcrumb`/`setUser`/`setContext`/`init` was flagged. Those are narrowed to named imports rather than blanket-disabled — a disable comment on the namespace import would let a future `Sentry.captureException` slip in underneath it, which is exactly the regression being prevented.

That leaves four legitimate importers, all under `src/platform/telemetry/`, each with an explicit `eslint-disable-next-line ... -- the telemetry layer owns the sinks that reportError() fans out to`. One grep now finds every direct-sink user in the repo.

## Documentation, where agents read it

- `AGENTS.md` Common Pitfalls entry (the list agents are steered by)
- `src/AGENTS.md` Error Handling section — usage, and how to pick an `errorType` slug

## Verification

- Red-green: a probe importing each banned symbol errors in **both** `.ts` and `.vue`; removing the probes returns lint to 0 errors.
- The four pre-existing DOM-in-computed warnings are still reported — confirming the splice did not clobber the existing rules.
- `pnpm typecheck` clean; 522 tests pass across the affected suites.

## Regression risk

Low. Lint config plus one behavioural call site (`useSubscriptionActions.ts`, now dual-sink instead of Sentry-only) and four import-style changes with no call-site semantics changed.