### PR TITLE
ci: validate action pins on push to main

### DIFF
--- a/.github/workflows/ci-validate-action-pins.yaml
+++ b/.github/workflows/ci-validate-action-pins.yaml
@@ -1,6 +1,14 @@
 name: Validate Action SHA Pins
 
 on:
+  # A PR only re-checks the pins it edits, so a stale major merges green and reddens every later workflow PR.
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/**'
+      - '.github/actions/**'
+      - '.pinact.yaml'
   pull_request:
     paths:
       - '.github/workflows/**'


### PR DESCRIPTION
## Problem

`ci-validate-action-pins` runs on `pull_request` only, and pinact only re-checks the pins a PR's own diff touches. So a workflow PR that went green against an older `.pinact.yaml` can merge a stale major, and nothing re-validates it afterwards.

The next unrelated workflow PR then fails, annotated against a file its author never edited. That happened with `download-artifact@v7` from #14560, which reddened #14039 and cost a debugging cycle to attribute.

## Fix

Add a `push: main` trigger with the same paths. Main gets re-validated on merge, so the break is attributed to the PR that introduced it.

## Test

`scripts/cicd/check-yaml.sh` and `actionlint` clean. The push trigger is only observable once this is on main.