### PR TITLE
fix(cicd): create releases with the release PAT on core/1.50

### DIFF
--- a/.github/workflows/release-draft-create.yaml
+++ b/.github/workflows/release-draft-create.yaml
@@ -81,9 +81,9 @@ jobs:
       - name: Create release
         id: create_release
         uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
+          # GITHUB_TOKEN is refused on core/* lines with a 403, even with contents: write.
+          token: ${{ secrets.PR_GH_TOKEN }}
           files: |
             dist.zip
             dist-desktop.zip


### PR DESCRIPTION
## Problem

`release-draft-create.yaml` is triggered by `pull_request: closed`, so it runs from **the base branch's own copy** of the workflow. #15003 switched Create Release to `secrets.PR_GH_TOKEN` on `main` on 2026-08-10, but that fix was never backported, so `core/1.47` through `core/1.50` still pass `GITHUB_TOKEN`.

`GITHUB_TOKEN` is refused with `403 Resource not accessible by integration` when creating a release on a `core/*` line, so every patch cut from these branches fails at the tag step.

This is not theoretical. Run [31929089801](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/31929089801) cut `1.49.7`, the bump PR merged, and `v1.49.7` was never created. `core/1.49` has sat at `package.json` 1.49.7 with `v1.49.6` as its newest tag since 2026-08-16, and ComfyUI pins 1.49.6 — so 1.49.7 and the #15211 popular-templates backport have not reached users.

## Fix

Same one-line change as #15003, applied to this line.

Companion PRs cover the other affected branches: core/1.47, core/1.48, core/1.49, core/1.50.

After this merges, `core/1.49` still needs its missing release recovered with `release-recover-tag.yaml` (#15006).

## Test

`actionlint` and `scripts/cicd/check-yaml.sh` are clean on the changed file. The two warnings they emit here (`SC2086` on line 34, and a `comments-indentation` hit in `ci-tests-e2e.yaml`) are pre-existing and reproduce without this change.