### PR TITLE
fix(assets): let modifier-clicks through the compact audio player

### DIFF
--- a/src/components/common/WaveAudioPlayer.vue
+++ b/src/components/common/WaveAudioPlayer.vue
@@ -14,7 +14,7 @@
       class="size-7 shrink-0 rounded-full bg-muted-foreground/15 hover:bg-muted-foreground/25"
       :aria-label="isPlaying ? $t('g.pause') : $t('g.play')"
       :loading="loading"
-      @click.stop="togglePlayPause"
+      @click="togglePlayPauseUnlessSelectionModifier"
     >
       <i
         v-if="!isPlaying"
@@ -221,8 +221,11 @@ function stopUnlessSelectionModifier(event: MouseEvent) {
 }
 
 function seekUnlessSelectionModifier(event: MouseEvent) {
-  if (hasSelectionModifier(event)) return
-  handleWaveformClick(event)
+  if (!hasSelectionModifier(event)) handleWaveformClick(event)
+}
+
+function togglePlayPauseUnlessSelectionModifier(event: MouseEvent) {
+  if (!hasSelectionModifier(event)) togglePlayPause()
 }
 
 function handleProgressClick(event: MouseEvent) {

--- a/src/components/common/WaveAudioPlayer.vue
+++ b/src/components/common/WaveAudioPlayer.vue
@@ -5,8 +5,8 @@
     :class="
       cn('flex w-full gap-2', align === 'center' ? 'items-center' : 'items-end')
     "
-    @pointerdown.stop
-    @click.stop
+    @pointerdown="stopUnlessSelectionModifier"
+    @click="stopUnlessSelectionModifier"
   >
     <Button
       variant="textonly"
@@ -32,7 +32,7 @@
         )
       "
       :style="{ height: height + 'px' }"
-      @click="handleWaveformClick"
+      @click="seekUnlessSelectionModifier"
     >
       <div
         v-for="(bar, index) in bars"
@@ -211,6 +211,19 @@ const {
   src: toRef(() => src),
   barCount
 })
+
+function hasSelectionModifier(event: MouseEvent) {
+  return event.shiftKey || event.metaKey || event.ctrlKey
+}
+
+function stopUnlessSelectionModifier(event: MouseEvent) {
+  if (!hasSelectionModifier(event)) event.stopPropagation()
+}
+
+function seekUnlessSelectionModifier(event: MouseEvent) {
+  if (hasSelectionModifier(event)) return
+  handleWaveformClick(event)
+}
 
 function handleProgressClick(event: MouseEvent) {
   if (!progressRef.value) return

--- a/src/platform/assets/components/MediaAssetCard.test.ts
+++ b/src/platform/assets/components/MediaAssetCard.test.ts
@@ -82,7 +82,10 @@ function dispatchDragStart(
 }
 
 // The media preview is an async component, and transforming its chunk on a cold
-// cache regularly outlasts vi.waitFor's 1s default.
+// cache regularly outlasts vi.waitFor's 1s default — which in turn needs room
+// under the per-test timeout, whose 5s default it would otherwise consume.
+vi.setConfig({ testTimeout: 15000 })
+
 function findMediaElement(container: Element, tag: 'audio' | 'video') {
   return vi.waitFor(
     () => {
@@ -236,9 +239,12 @@ describe('MediaAssetCard', () => {
       const playButton = screen.getByRole('button', { name: 'g.play' })
       // eslint-disable-next-line testing-library/no-node-access -- the waveform strip has no interactive role
       const waveform = playButton.nextElementSibling!
-      // happy-dom lays nothing out, so the seek ratio needs a width to divide by.
+      // happy-dom lays nothing out, so the seek ratio needs a width to divide
+      // by, and userEvent always clicks at clientX 0 — straddling the origin
+      // puts that click mid-strip, a real seek to 0:05 rather than the 0:00
+      // already showing.
       vi.spyOn(waveform, 'getBoundingClientRect').mockReturnValue(
-        new DOMRect(0, 0, 100, 32)
+        new DOMRect(-50, 0, 100, 32)
       )
       return {
         ...rendered,
@@ -264,6 +270,7 @@ describe('MediaAssetCard', () => {
 
         expect(emitted().select).toHaveLength(1)
         expect(playSpy).not.toHaveBeenCalled()
+        expect(screen.getByText('0:00 / 0:10')).toBeInTheDocument()
       }
     )
 
@@ -273,6 +280,7 @@ describe('MediaAssetCard', () => {
 
       await user.click(waveform)
 
+      expect(screen.getByText('0:05 / 0:10')).toBeInTheDocument()
       expect(playSpy).toHaveBeenCalled()
       expect(emitted().select).toBeUndefined()
       expect(emitted()['toggle-selection']).toBeUndefined()
@@ -303,6 +311,18 @@ describe('MediaAssetCard', () => {
 
       expect(playSpy).toHaveBeenCalledTimes(1)
       expect(emitted().select).toBeUndefined()
+    })
+
+    it('selects without toggling playback from a modifier click on play', async () => {
+      const user = userEvent.setup()
+      const { emitted, playButton, playSpy } = await renderAudioCard()
+
+      await user.keyboard('{Shift>}')
+      await user.click(playButton)
+      await user.keyboard('{/Shift}')
+
+      expect(emitted().select).toHaveLength(1)
+      expect(playSpy).not.toHaveBeenCalled()
     })
   })
 

--- a/src/platform/assets/components/MediaAssetCard.test.ts
+++ b/src/platform/assets/components/MediaAssetCard.test.ts
@@ -81,6 +81,20 @@ function dispatchDragStart(
   return { event, add }
 }
 
+// The media preview is an async component, and transforming its chunk on a cold
+// cache regularly outlasts vi.waitFor's 1s default.
+function findMediaElement(container: Element, tag: 'audio' | 'video') {
+  return vi.waitFor(
+    () => {
+      // eslint-disable-next-line testing-library/no-node-access -- media elements have no ARIA role in happy-dom
+      const element = container.querySelector(tag)
+      expect(element).toBeInTheDocument()
+      return element!
+    },
+    { timeout: 4000 }
+  )
+}
+
 describe('MediaAssetCard', () => {
   describe('dragStart', () => {
     it('cancels the native drag when Ctrl is held so a marquee can start over the card', () => {
@@ -188,12 +202,7 @@ describe('MediaAssetCard', () => {
         loading: false,
         asset: { ...asset, name: 'clip.mp4' }
       })
-      const video = await vi.waitFor(() => {
-        // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access -- <video> has no ARIA role in happy-dom
-        const element = container.querySelector('video')
-        expect(element).toBeInTheDocument()
-        return element!
-      })
+      const video = await findMediaElement(container, 'video')
       const playSpy = vi
         .spyOn(video, 'play')
         .mockImplementation(() => Promise.resolve())
@@ -212,6 +221,91 @@ describe('MediaAssetCard', () => {
     }
   )
 
+  describe('audio player strip', () => {
+    const audioAsset: AssetItem = { ...asset, name: 'track.mp3' }
+
+    async function renderAudioCard() {
+      const rendered = renderCard({ loading: false, asset: audioAsset })
+      const audio = await findMediaElement(rendered.container, 'audio')
+      // A waveform click only seeks once the media reports a duration.
+      Object.defineProperty(audio, 'duration', {
+        value: 10,
+        configurable: true
+      })
+      await fireEvent(audio, new Event('durationchange'))
+      const playButton = screen.getByRole('button', { name: 'g.play' })
+      // eslint-disable-next-line testing-library/no-node-access -- the waveform strip has no interactive role
+      const waveform = playButton.nextElementSibling!
+      // happy-dom lays nothing out, so the seek ratio needs a width to divide by.
+      vi.spyOn(waveform, 'getBoundingClientRect').mockReturnValue(
+        new DOMRect(0, 0, 100, 32)
+      )
+      return {
+        ...rendered,
+        playButton,
+        waveform,
+        playSpy: vi.spyOn(audio, 'play').mockResolvedValue()
+      }
+    }
+
+    it.for([
+      { modifier: 'Shift', keyDown: '{Shift>}', keyUp: '{/Shift}' },
+      { modifier: 'Ctrl', keyDown: '{Control>}', keyUp: '{/Control}' },
+      { modifier: 'Meta', keyDown: '{Meta>}', keyUp: '{/Meta}' }
+    ])(
+      '$modifier-clicks the waveform to select without seeking',
+      async ({ keyDown, keyUp }) => {
+        const user = userEvent.setup()
+        const { emitted, waveform, playSpy } = await renderAudioCard()
+
+        await user.keyboard(keyDown)
+        await user.click(waveform)
+        await user.keyboard(keyUp)
+
+        expect(emitted().select).toHaveLength(1)
+        expect(playSpy).not.toHaveBeenCalled()
+      }
+    )
+
+    it('seeks without selecting from a plain click on the waveform', async () => {
+      const user = userEvent.setup()
+      const { emitted, waveform, playSpy } = await renderAudioCard()
+
+      await user.click(waveform)
+
+      expect(playSpy).toHaveBeenCalled()
+      expect(emitted().select).toBeUndefined()
+      expect(emitted()['toggle-selection']).toBeUndefined()
+    })
+
+    it('lets a modifier pointerdown out of the player but stops a plain one', async () => {
+      const user = userEvent.setup()
+      const { container, waveform } = await renderAudioCard()
+      // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access -- the grid listens for pointerdown outside the card
+      const card = container.querySelector('[data-asset-id="a"]')!
+      const onPointerDown = vi.fn()
+      card.addEventListener('pointerdown', onPointerDown)
+
+      await user.click(waveform)
+      expect(onPointerDown).not.toHaveBeenCalled()
+
+      await user.keyboard('{Control>}')
+      await user.click(waveform)
+      await user.keyboard('{/Control}')
+      expect(onPointerDown).toHaveBeenCalledTimes(1)
+    })
+
+    it('toggles playback without selecting from a plain click on play', async () => {
+      const user = userEvent.setup()
+      const { emitted, playButton, playSpy } = await renderAudioCard()
+
+      await user.click(playButton)
+
+      expect(playSpy).toHaveBeenCalledTimes(1)
+      expect(emitted().select).toBeUndefined()
+    })
+  })
+
   it('disables native controls for compact video cards', async () => {
     const user = userEvent.setup()
     const { container } = renderCard({
@@ -219,12 +313,7 @@ describe('MediaAssetCard', () => {
       asset: { ...asset, name: 'clip.mp4' },
       showNativeVideoControls: false
     })
-    const video = await vi.waitFor(() => {
-      // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access -- <video> has no ARIA role in happy-dom
-      const element = container.querySelector('video')
-      expect(element).toBeInTheDocument()
-      return element!
-    })
+    const video = await findMediaElement(container, 'video')
     const pauseSpy = vi.spyOn(video, 'pause').mockImplementation(() => {})
 
     Object.defineProperty(video, 'paused', {
@@ -254,12 +343,7 @@ describe('MediaAssetCard', () => {
       asset: { ...asset, name: 'clip.mp4' },
       showNativeVideoControls: false
     })
-    const video = await vi.waitFor(() => {
-      // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access -- <video> has no ARIA role in happy-dom
-      const element = container.querySelector('video')
-      expect(element).toBeInTheDocument()
-      return element!
-    })
+    const video = await findMediaElement(container, 'video')
 
     // eslint-disable-next-line testing-library/no-node-access -- the video hover target has no role
     const hoverTarget = video.parentElement!


### PR DESCRIPTION
## ELI-5

Clicking an audio card's little player used to be a dead zone for multi-select: shift/cmd/ctrl-clicking it did nothing, while the same gesture anywhere else on the card added it to the selection. The player was swallowing the click before the card could see it. Now it only swallows plain clicks — the ones that are genuinely meant for the player.

## Summary

The compact `WaveAudioPlayer` root carried `@pointerdown.stop @click.stop` unconditionally, so a modifier-carrying click never reached `MediaAssetCard`'s `handlePreviewClick`. Since `variant` defaults to `'compact'` and `MediaAudioTop.vue` mounts the player with no `variant`, that is the path every audio asset card takes — audio was the one media type whose preview could not be modifier-selected.

## Changes

- **What**: every interactive surface of the compact player now defers to the host's selection when a modifier (shift/meta/ctrl) is held — the root stops propagation only for unmodified clicks, the waveform skips seeking, and the play/pause control skips toggling. Behaviour with no modifier held is unchanged: the plain click is still stopped at the player root and does not select the card.
- The play control's `@click.stop` is gone rather than guarded. The root already stops every unmodified click, so `.stop` on the button was redundant for the case it was protecting, and keeping it would have swallowed the modified click it now needs to pass through.

## Review Focus

- **The riskiest line is `@pointerdown`.** `git log` shows both `.stop`s have been on this root since the component was introduced in #10158, with no intent comment and no later change (#12425 did not touch them). Letting a modified pointerdown through is not cosmetic: `useAssetGridSelection.onPointerDown` is bound on the grid container and starts a marquee when ctrl/cmd is held over a card, which is why `MediaAssetCard.dragStart` already cancels the native drag under Ctrl. That path was unreachable from the audio strip. The transport button is still excluded from the marquee by that composable's `INTERACTIVE_SELECTOR` (`button`), and the marquee ignores `e.button !== 0`, so nothing new starts a marquee from the play control or a right-click.
- **One thing deliberately untouched**: the `variant === 'expanded'` root, which is not on an asset-card path and keeps the unconditional `.stop`.
- **Blast radius swept.** `WaveAudioPlayer` has exactly **one** compact mount in `src/` — `MediaAudioTop.vue`, the audio asset card, i.e. the mount this fixes. The other two mounts (`ResultAudio.vue` in the queue result viewer, and the Storybook story) both pass `variant="expanded"`, so the play-control change reaches only the asset card; that is **1 mount intentionally not changed**. Sweeping the sibling corpus for the same bug class: of the six `Media*Top.vue` preview components, **0** others carry a `.stop`/`stopPropagation` on their preview root, so this was the last one swallowing the gesture.
- **`hasSelectionModifier` is a fourth copy** of the same three-term boolean (`MediaAssetCard.handlePreviewClick`, `MediaVideoTop.onVideoClick`, `useAssetGridSelection`). Not extracted here to keep the diff scoped — consolidating it is already tracked as #15028, which is also where the macOS Ctrl-is-secondary-click question belongs, since all four copies have to stay exact complements.

## Verification

- `vitest run src/platform/assets/components/MediaAssetCard.test.ts src/composables/useWaveAudioPlayer.test.ts`: 32 passed, 0 failed. Wider `vitest run src/platform/assets`: 768 passed, 0 failed.
- Red/green checked per behaviour, not just in aggregate: reverting the root/waveform change fails the three modifier variants and the pointerdown case; restoring `@click.stop="togglePlayPause"` fails the play-control case; stubbing out the `handleWaveformClick` call fails the plain-click seek case. The two plain-click regression guards pass either way, which is what pins the unchanged no-modifier behaviour.
- The seek assertions read the strip's rendered time (`0:05 / 0:10` after a plain click, `0:00 / 0:10` after a modifier click) rather than the `play` spy, so they fail on a seek regression and not only on a playback one. happy-dom lays nothing out and userEvent always clicks at `clientX` 0, so the mocked strip rect straddles the origin to put that click mid-waveform.
- `pnpm typecheck`: clean. `eslint` on both changed files: clean. `pnpm knip`: clean. `oxfmt`/`stylelint`/`oxlint` ran via the pre-commit hook.

## Notes and judgment calls

- **The negative-claim check does not apply here** — this diff adds no "unsupported"/throw/deny path; it restores a capability rather than denying one.
- **The reported artifact was exercised.** #15220 finding 2 was read directly and describes exactly this path; that issue also carries findings 1, 3 and others that this PR does not touch, so this is `Refs #15220`, not a closing reference — the issue stays open for the rest. One factual correction to the report I worked from: #14765, described there as still open, is merged.
- **No manual browser pass.** The tests drive the real `MediaAssetCard` → `MediaAudioTop` → `WaveAudioPlayer` stack (no stubs on that path) under happy-dom, but the gesture itself was not exercised in a real browser, and happy-dom lays nothing out so the waveform's rect is spied.
- **One acceptance detail could not be met.** The report asks that the original authors of this event contract be consulted before it changes; I have no channel to do that, so review here is standing in for it — flagging it explicitly rather than letting it pass silently.
- **Credit:** reported by @christian-byrne. The report asked for a `Co-Authored-By` commit trailer; that was deliberately not added, because the trailer records commit authorship and they did not write this code. Crediting in prose here instead.

## Provenance

- **Authored by:** agent-work loop
- **Verified:** vitest (MediaAssetCard + useWaveAudioPlayer): 32 passed, 0 failed; vitest (src/platform/assets): 768 passed, 0 failed; per-behaviour red/green re-runs: each of the three reverts fails only its own case; pnpm typecheck: clean; eslint on both changed files: clean; pnpm knip: clean
- **Deviations:** no manual browser verification of the gesture; the report's request to consult the original authors of the event contract before changing it could not be actioned from here
