### PR TITLE
test: cover direct widget array mutations

### DIFF
--- a/browser_tests/tests/vueNodes/widgets/legacy.spec.ts
+++ b/browser_tests/tests/vueNodes/widgets/legacy.spec.ts
@@ -25,12 +25,18 @@ test('@vue-nodes In App Mode, widget width updates with panel size', async ({
     ])
   })
 
-  const getWidth = async () =>
+  const getRenderedWidth = async () =>
     (await comfyPage.appMode.linearWidgets.locator('canvas').boundingBox())
       ?.width ?? 0
+  const getWidgetWidth = () =>
+    comfyPage.page.evaluate(
+      (nodeId) => window.app!.graph.getNodeById(nodeId)!.widgets![0].width ?? 0,
+      legacyNodeId
+    )
 
   await test.step('Mouse clicks resolve to button regions', async () => {
     const legacyWidget = comfyPage.appMode.linearWidgets.locator('canvas')
+    await expect(legacyWidget).toBeVisible()
     const { width, height } = (await legacyWidget.boundingBox())!
 
     const nodeRef = await comfyPage.nodeOps.getNodeRefById(legacyNodeId)
@@ -43,17 +49,22 @@ test('@vue-nodes In App Mode, widget width updates with panel size', async ({
   })
 
   await test.step('Resize to update width', async () => {
-    await expect.poll(getWidth).toBeGreaterThan(0)
-    const initialWidth = await getWidth()
+    await expect.poll(getRenderedWidth).toBeGreaterThan(0)
+    await expect.poll(getWidgetWidth).toBeGreaterThan(0)
+    const initialRenderedWidth = await getRenderedWidth()
+    const initialWidgetWidth = await getWidgetWidth()
 
     const gutter = comfyPage.page.getByRole('separator')
 
     await expect(gutter).toBeVisible()
     await comfyMouse.dragElementBy(gutter, { x: -200 })
-    await expect.poll(getWidth).toBeGreaterThan(initialWidth)
-    const intermediateWidth = await getWidth()
+    await expect.poll(getRenderedWidth).toBeGreaterThan(initialRenderedWidth)
+    await expect.poll(getWidgetWidth).toBeGreaterThan(initialWidgetWidth)
+    const intermediateRenderedWidth = await getRenderedWidth()
+    const intermediateWidgetWidth = await getWidgetWidth()
 
     await comfyMouse.dragElementBy(gutter, { x: 100 })
-    await expect.poll(getWidth).toBeLessThan(intermediateWidth)
+    await expect.poll(getRenderedWidth).toBeLessThan(intermediateRenderedWidth)
+    await expect.poll(getWidgetWidth).toBeLessThan(intermediateWidgetWidth)
   })
 })

--- a/browser_tests/tests/vueNodes/widgets/widgetReactivity.spec.ts
+++ b/browser_tests/tests/vueNodes/widgets/widgetReactivity.spec.ts
@@ -2,7 +2,6 @@ import {
   comfyExpect as expect,
   comfyPageFixture as test
 } from '@e2e/fixtures/ComfyPage'
-import type { TestGraphAccess } from '@e2e/types/globals'
 import { toNodeId } from '@/types/nodeId'
 
 test.describe('Vue Widget Reactivity', { tag: '@vue-nodes' }, () => {
@@ -42,28 +41,91 @@ test.describe('Vue Widget Reactivity', { tag: '@vue-nodes' }, () => {
     await expect(widgets).toHaveCount(4)
   })
 
-  test('Should hide removed widgets', async ({ comfyPage }) => {
-    const loadCheckpointNode = comfyPage.page.locator(
-      'css=[data-testid="node-body-3"] > .lg-node-widgets > div'
+  test('Should display widgets in the order of the live widget array', async ({
+    comfyPage
+  }) => {
+    const nodeId = toNodeId(
+      await comfyPage.page.evaluate(() => {
+        const node = window.app!.graph.nodes.find(
+          (node) => (node.widgets?.length ?? 0) === 1
+        )
+        if (!node) throw new Error('Node with one widget not found')
+
+        const workflow = node.addWidget('text', 'saola-workflow', '', () => {})
+        node.addWidget('text', 'okapi-resolution', '', () => {})
+
+        const element = document.createElement('div')
+        element.textContent = 'numbat-stage'
+        node.addDOMWidget('numbat-stage', 'numbat-stage', element, {
+          serialize: false
+        })
+
+        const upload = node.addWidget(
+          'button',
+          'quoll-upload',
+          undefined,
+          () => {}
+        )
+        const link = node.addWidget('button', 'olm-link', undefined, () => {})
+        const widgets = node.widgets!
+        widgets.splice(widgets.indexOf(upload), 1)
+        widgets.splice(widgets.indexOf(workflow) + 1, 0, upload)
+        widgets.splice(widgets.indexOf(link), 1)
+        widgets.splice(widgets.indexOf(upload) + 1, 0, link)
+
+        return String(node.id)
+      })
     )
-    await comfyPage.page.evaluate(() => {
-      const graph = window.graph as TestGraphAccess
-      const node = graph._nodes_by_id['3']
+
+    await comfyPage.nextFrame()
+    const orderedWidgets = comfyPage.vueNodes
+      .getNodeLocator(nodeId)
+      .locator('.lg-node-widget')
+      .filter({ hasText: /saola|quoll|olm|okapi|numbat/ })
+
+    await expect(orderedWidgets).toContainText([
+      'saola-workflow',
+      'quoll-upload',
+      'olm-link',
+      'okapi-resolution',
+      'numbat-stage'
+    ])
+  })
+
+  test('Should hide removed widgets', async ({ comfyPage }) => {
+    const nodeId = toNodeId(
+      await comfyPage.page.evaluate(() => {
+        const node = window.app!.graph.nodes.find(
+          (node) => node.type === 'KSampler'
+        )
+        if (!node) throw new Error('KSampler node not found')
+        return String(node.id)
+      })
+    )
+
+    const widgets = comfyPage.vueNodes
+      .getNodeLocator(nodeId)
+      .locator('.lg-node-widget')
+
+    await expect(widgets).toHaveCount(6)
+    await comfyPage.page.evaluate((nodeId) => {
+      const node = window.app!.graph.getNodeById(nodeId)
+      if (!node) throw new Error(`Node ${nodeId} not found`)
       node.widgets!.pop()
-    })
-    await expect(loadCheckpointNode).toHaveCount(5)
-    await comfyPage.page.evaluate(() => {
-      const graph = window.graph as TestGraphAccess
-      const node = graph._nodes_by_id['3']
+    }, nodeId)
+    await expect(widgets).toHaveCount(5)
+    await comfyPage.page.evaluate((nodeId) => {
+      const node = window.app!.graph.getNodeById(nodeId)
+      if (!node) throw new Error(`Node ${nodeId} not found`)
       node.widgets!.length--
-    })
-    await expect(loadCheckpointNode).toHaveCount(4)
-    await comfyPage.page.evaluate(() => {
-      const graph = window.graph as TestGraphAccess
-      const node = graph._nodes_by_id['3']
+    }, nodeId)
+    await expect(widgets).toHaveCount(4)
+    await comfyPage.page.evaluate((nodeId) => {
+      const node = window.app!.graph.getNodeById(nodeId)
+      if (!node) throw new Error(`Node ${nodeId} not found`)
       node.widgets!.splice(0, 1)
-    })
-    await expect(loadCheckpointNode).toHaveCount(3)
+    }, nodeId)
+    await expect(widgets).toHaveCount(3)
   })
 
   test('Can load dynamic combos', async ({ comfyPage }) => {


### PR DESCRIPTION
## Summary

Add failing browser coverage for extension-driven widget reordering and restore compatibility assertions affected by the ECS migration.

## Changes

- **What**: Reproduce a custom DOM widget plus button widgets reordered through direct `node.widgets.splice()` calls.
- **What**: Restore dynamic removal coverage for `pop()`, `length--`, and `splice()` without fixed node IDs.
- **What**: Keep rendered-width coverage while restoring the legacy widget's `width` compatibility assertion.

## Review Focus

This is a test-only child PR targeting `feature/ecs-migration`. The ordering test is intentionally red: Vue renders registration order instead of the live `node.widgets` order. The legacy App Mode scenario also currently fails before its width assertions because the selected legacy widget is absent from App Mode.