### PR TITLE
fix: only treat blocking overlays as open modals

### DIFF
--- a/src/platform/keybindings/keybindingService.dialog.test.ts
+++ b/src/platform/keybindings/keybindingService.dialog.test.ts
@@ -185,4 +185,43 @@ describe('keybindingService - dialog gate', () => {
       document.body.removeChild(popper)
     }
   })
+
+  it('saves the workflow on Ctrl+S while a tab popover is open', async () => {
+    const popover = document.createElement('div')
+    popover.className = 'p-popover'
+    popover.setAttribute('role', 'dialog')
+    popover.setAttribute('aria-modal', 'true')
+    document.body.appendChild(popover)
+
+    try {
+      const event = createKeyboardEvent('s', document.body, { ctrlKey: true })
+      await keybindingService.keybindHandler(event)
+
+      expect(mockCommandExecute).toHaveBeenCalledWith('Comfy.SaveWorkflow')
+      expect(event.defaultPrevented).toBe(true)
+    } finally {
+      document.body.removeChild(popover)
+    }
+  })
+
+  it('saves the workflow on Ctrl+S once a masked dialog is closed', async () => {
+    const mask = document.createElement('div')
+    mask.style.display = 'none'
+    const dialog = document.createElement('div')
+    dialog.setAttribute('role', 'dialog')
+    dialog.setAttribute('aria-modal', 'true')
+    dialog.style.display = 'flex'
+    mask.appendChild(dialog)
+    document.body.appendChild(mask)
+
+    try {
+      const event = createKeyboardEvent('s', document.body, { ctrlKey: true })
+      await keybindingService.keybindHandler(event)
+
+      expect(mockCommandExecute).toHaveBeenCalledWith('Comfy.SaveWorkflow')
+      expect(event.defaultPrevented).toBe(true)
+    } finally {
+      document.body.removeChild(mask)
+    }
+  })
 })

--- a/src/utils/modalUtil.test.ts
+++ b/src/utils/modalUtil.test.ts
@@ -1,0 +1,128 @@
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { isModalOpen } from '@/utils/modalUtil'
+
+const NO_MANAGED_DIALOGS = 0
+
+function render(html: string): void {
+  document.body.insertAdjacentHTML('beforeend', html)
+}
+
+afterEach(() => {
+  document.body.innerHTML = ''
+})
+
+describe('isModalOpen', () => {
+  it('is false on a bare page', () => {
+    expect(isModalOpen(NO_MANAGED_DIALOGS)).toBe(false)
+  })
+
+  it('is true while the app has a managed dialog on the stack', () => {
+    expect(isModalOpen(1)).toBe(true)
+  })
+
+  describe('overlays that block the page', () => {
+    it('counts an ARIA modal', () => {
+      render('<div role="dialog" aria-modal="true"></div>')
+
+      expect(isModalOpen(NO_MANAGED_DIALOGS)).toBe(true)
+    })
+
+    it('counts an open Reka dialog', () => {
+      render('<div role="dialog" data-state="open"></div>')
+
+      expect(isModalOpen(NO_MANAGED_DIALOGS)).toBe(true)
+    })
+
+    it('counts an open native dialog', () => {
+      render('<dialog open></dialog>')
+
+      expect(isModalOpen(NO_MANAGED_DIALOGS)).toBe(true)
+    })
+
+    it('counts a visible legacy ComfyDialog', () => {
+      render('<div class="comfy-modal" style="display: flex"></div>')
+
+      expect(isModalOpen(NO_MANAGED_DIALOGS)).toBe(true)
+    })
+  })
+
+  describe('overlays that do not block the page', () => {
+    it('ignores a hidden legacy ComfyDialog', () => {
+      render('<div class="comfy-modal" style="display: none"></div>')
+
+      expect(isModalOpen(NO_MANAGED_DIALOGS)).toBe(false)
+    })
+
+    it('ignores a Reka popover', () => {
+      render(`
+        <div data-reka-popper-content-wrapper>
+          <div role="dialog" data-state="open"></div>
+        </div>
+      `)
+
+      expect(isModalOpen(NO_MANAGED_DIALOGS)).toBe(false)
+    })
+
+    // Regression: hovering a workflow tab renders a PrimeVue Popover, which
+    // declares aria-modal="true" despite being a non-blocking hover preview.
+    it('ignores a PrimeVue popover that declares itself modal', () => {
+      render('<div class="p-popover" role="dialog" aria-modal="true"></div>')
+
+      expect(isModalOpen(NO_MANAGED_DIALOGS)).toBe(false)
+    })
+
+    it('ignores content nested inside a popover', () => {
+      render(`
+        <div class="p-popover">
+          <div role="dialog" aria-modal="true"></div>
+        </div>
+      `)
+
+      expect(isModalOpen(NO_MANAGED_DIALOGS)).toBe(false)
+    })
+  })
+
+  describe('overlays left in the DOM after closing', () => {
+    it('ignores a dialog hidden by its own display', () => {
+      render(
+        '<div role="dialog" aria-modal="true" style="display: none"></div>'
+      )
+
+      expect(isModalOpen(NO_MANAGED_DIALOGS)).toBe(false)
+    })
+
+    // Regression: ComfyUI-Manager hides only the mask on close, leaving its
+    // aria-modal dialog node in the DOM for the rest of the session.
+    it('ignores a dialog hidden by an ancestor mask', () => {
+      render(`
+        <div class="p-dialog-mask" style="display: none">
+          <div role="dialog" aria-modal="true" style="display: flex"></div>
+        </div>
+      `)
+
+      expect(isModalOpen(NO_MANAGED_DIALOGS)).toBe(false)
+    })
+
+    it('still counts a dialog inside a visible mask', () => {
+      render(`
+        <div class="p-dialog-mask" style="display: flex">
+          <div role="dialog" aria-modal="true" style="display: flex"></div>
+        </div>
+      `)
+
+      expect(isModalOpen(NO_MANAGED_DIALOGS)).toBe(true)
+    })
+
+    it('still counts a sibling dialog that is genuinely open', () => {
+      render(`
+        <div class="p-dialog-mask" style="display: none">
+          <div role="dialog" aria-modal="true" style="display: flex"></div>
+        </div>
+        <div role="dialog" aria-modal="true"></div>
+      `)
+
+      expect(isModalOpen(NO_MANAGED_DIALOGS)).toBe(true)
+    })
+  })
+})

--- a/src/utils/modalUtil.ts
+++ b/src/utils/modalUtil.ts
@@ -1,8 +1,47 @@
+const ARIA_MODAL_SELECTOR = '[role="dialog"][aria-modal="true"]'
+const REKA_OPEN_DIALOG_SELECTOR = '[role="dialog"][data-state="open"]'
+
+/**
+ * Popovers and dropdowns also render as role="dialog", but they neither trap
+ * focus nor block the page, so they must not suppress global shortcuts.
+ */
+const NON_MODAL_OVERLAY_SELECTOR =
+  '.p-popover, [data-reka-popper-content-wrapper]'
+
+/**
+ * Overlays are commonly hidden by toggling `display` on an ancestor (a mask or
+ * wrapper) while the dialog node itself keeps its own display value, and some
+ * extensions leave that node in the DOM permanently once created.
+ */
+function isDisplayNone(element: Element): boolean {
+  for (
+    let node: Element | null = element;
+    node !== null;
+    node = node.parentElement
+  ) {
+    if (getComputedStyle(node).display === 'none') {
+      return true
+    }
+  }
+  return false
+}
+
+function isBlockingModal(element: Element): boolean {
+  return (
+    element.closest(NON_MODAL_OVERLAY_SELECTOR) === null &&
+    !isDisplayNone(element)
+  )
+}
+
+function hasOpenAriaModal(): boolean {
+  return Array.from(document.querySelectorAll(ARIA_MODAL_SELECTOR)).some(
+    isBlockingModal
+  )
+}
+
 function hasOpenRekaDialog(): boolean {
-  return Array.from(
-    document.querySelectorAll('[role="dialog"][data-state="open"]')
-  ).some(
-    (dialog) => dialog.closest('[data-reka-popper-content-wrapper]') === null
+  return Array.from(document.querySelectorAll(REKA_OPEN_DIALOG_SELECTOR)).some(
+    isBlockingModal
   )
 }
 
@@ -22,7 +61,7 @@ function hasVisibleLegacyModal(): boolean {
 export function isModalOpen(managedDialogCount: number): boolean {
   return (
     managedDialogCount > 0 ||
-    document.querySelector('[role="dialog"][aria-modal="true"]') !== null ||
+    hasOpenAriaModal() ||
     hasOpenRekaDialog() ||
     hasOpenNativeDialog() ||
     hasVisibleLegacyModal()


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

Follow-up to #15066, which stopped Ctrl+S being handed to the browser but left it a silent no-op in the two scenarios users actually reported.

## Summary

`isModalOpen` matched `[role="dialog"][aria-modal="true"]` by **existence alone** — no visibility check, and no exclusion for overlays that declare modality without blocking the page. Two very common things tripped it:

- **PrimeVue `Popover`** renders `role="dialog"` with `aria-modal="true"` (`popover/index.mjs`), so hovering a workflow tab made the app consider itself modal for as long as the preview was up.
- **ComfyUI-Manager** builds its dialog with `role='dialog'` + `ariaModal: 'true'` and an inline `display: flex`, parented to a mask (`comfyui-gui-builder.js:104-110`). `close()` hides only the mask, so the node stays in the DOM at `display: flex` for the rest of the session — one click on "Manager" left Ctrl+S dead until reload.

With #15066 merged the browser no longer hijacks the combo, but the gate still declines to run the command, so Ctrl+S silently does nothing in both cases.

## Changes

A matched node now has to be neither popover content nor hidden (by itself or an ancestor) before it counts as an open modal. The same predicate is applied to the Reka query, so both `role="dialog"` checks agree — previously only the Reka one excluded popper content.

Hiding is detected by walking ancestors for `display: none`, because the mechanism in the wild is a hidden *wrapper* around a still-`display: flex` dialog. `checkVisibility()` would read better but is not implemented in happy-dom, so it is untestable here.

- **Breaking**: none.
- **Dependencies**: none.

## Review Focus

- `managedDialogCount > 0` still short-circuits first, so nothing about the app's own dialog stack changes.
- The gate's original purpose (#12184, #14024) is intact: a genuinely open modal still suppresses global commands, and the existing "does NOT execute … from inside an open dialog" test still passes unchanged. I deliberately did **not** restore the in-dialog escape hatch that #14024 removed — that removal was intentional (it fixed #13987's "pressing W opens the sidebar behind the modal").
- `.p-popover` is a deny-list entry, so it un-gates bare-key shortcuts for all 15 PrimeVue Popover call sites, not just the workflow tab. Focus in an `INPUT`/`TEXTAREA`/`contenteditable` already returns earlier, so text entry is unaffected, and this matches how Reka popovers already behaved on `main`.

## Tests

`modalUtil.test.ts` is new and enumerates every overlay flavour the predicate claims to support — managed stack, ARIA modal, Reka dialog, native `<dialog>`, legacy `.comfy-modal` — plus their non-blocking and left-in-the-DOM counterparts. That structure is a direct answer to the point that a change like #12184 should have come with coverage across all dialog stories.

The 6 behavioural tests fail on `main` and pass here; 189 tests pass across `modalUtil`, all `platform/keybindings`, and `changeTracker`.

## Validation

Verified in a browser against a real ComfyUI backend, reading `event.defaultPrevented` from a `keydown` listener:

| scenario | `defaultPrevented` | workflow saved |
| --- | --- | --- |
| canvas focused (baseline) | `true` | yes |
| workflow-tab popover open | `true` | yes |
| Manager node left in DOM | `true` | yes |
| genuine modal open | `true` | **no** (correctly suppressed) |

Bare `w` with a genuine modal open stays unprevented and does not toggle the sidebar.

`pnpm typecheck`, ESLint, oxlint and oxfmt clean.

## Known follow-up (not in this PR)

`src/platform/assets/composables/useAssetGridSelection.ts:215` still uses the raw `document.querySelector('[role="dialog"][aria-modal="true"]')` check, so Ctrl+A in the asset grid remains broken by both of the same repros. Routing it through this predicate is a small, separate change.

- Fixes Comfy-Org/ComfyUI#15639


## Screenshots

![ComfyUI's native Save workflow dialog opening on Ctrl+S after the fix, instead of the browser's Save Page As dialog](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/2aa06f8423a1619e7932b16c42acc407df789ba31633d49213a3800eb28fedd0/pr-images/1787196117322-06e88446-6b3f-4644-8bf5-e2283ce9ca34.png)