### PR TITLE
fix(groups): dispatch node mode command batches

### DIFF
--- a/src/extensions/core/groupNodeModeCommands.test.ts
+++ b/src/extensions/core/groupNodeModeCommands.test.ts
@@ -1,0 +1,116 @@
+import { fromPartial } from '@total-typescript/shoehorn'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { LGraph, LGraphNode } from '@/lib/litegraph/src/litegraph'
+import { LGraphEventMode } from '@/lib/litegraph/src/litegraph'
+import { toNodeId, type NodeId } from '@/types/nodeId'
+import { createMockLGraphNode } from '@/utils/__tests__/litegraphTestUtils'
+
+import {
+  applyGroupNodeModeCommandBatch,
+  createGroupNodeModeCommandBatch
+} from './groupNodeModeCommands'
+
+const beforeChange = vi.fn()
+const change = vi.fn()
+const afterChange = vi.fn()
+
+function makeNode(id: number, mode: LGraphEventMode): LGraphNode {
+  return createMockLGraphNode({ id: toNodeId(id), mode })
+}
+
+function makeGraph(nodes: LGraphNode[]): LGraph {
+  const nodesById = new Map(nodes.map((node) => [String(node.id), node]))
+  return fromPartial<LGraph>({
+    id: 'graph-id',
+    beforeChange,
+    change,
+    afterChange,
+    getNodeById: (id: NodeId | null | undefined) =>
+      nodesById.get(String(id)) ?? null
+  })
+}
+
+beforeEach(() => {
+  beforeChange.mockClear()
+  change.mockClear()
+  afterChange.mockClear()
+})
+
+describe('group node mode command batches', () => {
+  it('creates deterministic, serializable entries', () => {
+    const nodes = [
+      makeNode(10, LGraphEventMode.ALWAYS),
+      makeNode(2, LGraphEventMode.ON_TRIGGER)
+    ]
+
+    const batch = createGroupNodeModeCommandBatch(
+      'graph-id',
+      nodes,
+      LGraphEventMode.BYPASS
+    )
+
+    expect(batch).not.toBeNull()
+    expect(JSON.parse(JSON.stringify(batch))).toEqual({
+      type: 'comfy.groupNodeMode.set',
+      version: 1,
+      graphId: 'graph-id',
+      entries: [
+        { nodeId: 2, mode: LGraphEventMode.BYPASS },
+        { nodeId: 10, mode: LGraphEventMode.BYPASS }
+      ]
+    })
+  })
+
+  it('applies once and returns a mixed-mode inverse batch', () => {
+    const nodes = [
+      makeNode(10, LGraphEventMode.ON_TRIGGER),
+      makeNode(2, LGraphEventMode.ALWAYS)
+    ]
+    const graph = makeGraph(nodes)
+    const batch = createGroupNodeModeCommandBatch(
+      graph.id,
+      nodes,
+      LGraphEventMode.NEVER
+    )
+    expect(batch).not.toBeNull()
+
+    const inverse = applyGroupNodeModeCommandBatch(graph, batch!)
+
+    expect(inverse).not.toBeNull()
+    expect(nodes.map((node) => node.mode)).toEqual([
+      LGraphEventMode.NEVER,
+      LGraphEventMode.NEVER
+    ])
+    expect(beforeChange).toHaveBeenCalledTimes(1)
+    expect(change).toHaveBeenCalledTimes(1)
+    expect(afterChange).toHaveBeenCalledTimes(1)
+
+    const restoredInverse = applyGroupNodeModeCommandBatch(graph, inverse!)
+    expect(restoredInverse).toEqual(batch)
+    expect(nodes.map((node) => node.mode)).toEqual([
+      LGraphEventMode.ON_TRIGGER,
+      LGraphEventMode.ALWAYS
+    ])
+    expect(beforeChange).toHaveBeenCalledTimes(2)
+    expect(change).toHaveBeenCalledTimes(2)
+    expect(afterChange).toHaveBeenCalledTimes(2)
+  })
+
+  it('rejects an invalid replay without mutating or opening a transaction', () => {
+    const node = makeNode(1, LGraphEventMode.ALWAYS)
+    const graph = makeGraph([node])
+    const batch = {
+      type: 'comfy.groupNodeMode.set' as const,
+      version: 1 as const,
+      graphId: graph.id,
+      entries: [{ nodeId: 999, mode: LGraphEventMode.BYPASS }]
+    }
+
+    expect(applyGroupNodeModeCommandBatch(graph, batch)).toBeNull()
+    expect(node.mode).toBe(LGraphEventMode.ALWAYS)
+    expect(beforeChange).not.toHaveBeenCalled()
+    expect(change).not.toHaveBeenCalled()
+    expect(afterChange).not.toHaveBeenCalled()
+  })
+})

--- a/src/extensions/core/groupNodeModeCommands.ts
+++ b/src/extensions/core/groupNodeModeCommands.ts
@@ -1,0 +1,159 @@
+import type { LGraph, LGraphNode } from '@/lib/litegraph/src/litegraph'
+import { LGraphEventMode } from '@/lib/litegraph/src/litegraph'
+import {
+  serializeNodeId,
+  toNodeId,
+  type SerializedNodeId
+} from '@/types/nodeId'
+
+const GROUP_NODE_MODE_COMMAND_TYPE = 'comfy.groupNodeMode.set'
+const GROUP_NODE_MODE_COMMAND_VERSION = 1
+
+const NODE_MODES: ReadonlySet<LGraphEventMode> = new Set([
+  LGraphEventMode.ALWAYS,
+  LGraphEventMode.ON_EVENT,
+  LGraphEventMode.NEVER,
+  LGraphEventMode.ON_TRIGGER,
+  LGraphEventMode.BYPASS
+])
+
+interface GroupNodeModeCommandEntry {
+  readonly nodeId: SerializedNodeId
+  readonly mode: LGraphEventMode
+}
+
+/**
+ * A serializable intent to set every node in a group to one execution mode.
+ *
+ * Node IDs and the graph ID make the batch deterministic and replayable; the
+ * entries are sorted so equivalent groups serialize identically.
+ */
+export interface GroupNodeModeCommandBatch {
+  readonly type: typeof GROUP_NODE_MODE_COMMAND_TYPE
+  readonly version: typeof GROUP_NODE_MODE_COMMAND_VERSION
+  readonly graphId: string
+  readonly entries: readonly GroupNodeModeCommandEntry[]
+}
+
+function createEntries(
+  nodes: readonly LGraphNode[],
+  getMode: (node: LGraphNode) => LGraphEventMode
+): GroupNodeModeCommandEntry[] {
+  return nodes
+    .map((node) => ({
+      nodeId: serializeNodeId(node.id),
+      mode: getMode(node)
+    }))
+    .sort(compareEntries)
+}
+
+function compareEntries(
+  left: GroupNodeModeCommandEntry,
+  right: GroupNodeModeCommandEntry
+): number {
+  return String(left.nodeId).localeCompare(String(right.nodeId), undefined, {
+    numeric: true
+  })
+}
+
+function createBatch(
+  graphId: string,
+  entries: readonly GroupNodeModeCommandEntry[]
+): GroupNodeModeCommandBatch | null {
+  if (
+    !graphId ||
+    entries.length === 0 ||
+    entries.some((entry) => !NODE_MODES.has(entry.mode))
+  ) {
+    return null
+  }
+
+  const sortedEntries = [...entries].sort(compareEntries)
+  const nodeIds = new Set(sortedEntries.map((entry) => String(entry.nodeId)))
+  if (nodeIds.size !== sortedEntries.length) return null
+
+  return {
+    type: GROUP_NODE_MODE_COMMAND_TYPE,
+    version: GROUP_NODE_MODE_COMMAND_VERSION,
+    graphId,
+    entries: sortedEntries
+  }
+}
+
+export function createGroupNodeModeCommandBatch(
+  graphId: string,
+  nodes: readonly LGraphNode[],
+  mode: LGraphEventMode
+): GroupNodeModeCommandBatch | null {
+  if (!NODE_MODES.has(mode) || nodes.length === 0) return null
+  return createBatch(
+    graphId,
+    createEntries(nodes, () => mode)
+  )
+}
+
+function resolveNodes(
+  graph: LGraph,
+  batch: GroupNodeModeCommandBatch
+): LGraphNode[] | null {
+  if (
+    batch.type !== GROUP_NODE_MODE_COMMAND_TYPE ||
+    batch.version !== GROUP_NODE_MODE_COMMAND_VERSION ||
+    batch.graphId !== graph.id ||
+    batch.entries.length === 0
+  ) {
+    return null
+  }
+
+  const nodes: LGraphNode[] = []
+  const seenNodeIds = new Set<string>()
+  for (const entry of batch.entries) {
+    if (!NODE_MODES.has(entry.mode)) return null
+    const nodeId = String(entry.nodeId)
+    if (seenNodeIds.has(nodeId)) return null
+    seenNodeIds.add(nodeId)
+
+    const node = graph.getNodeById(toNodeId(entry.nodeId))
+    if (!node) return null
+    nodes.push(node)
+  }
+  return nodes
+}
+
+/**
+ * Apply a command batch in one LiteGraph change transaction.
+ *
+ * Returns an inverse batch that can restore the previous modes. All node IDs
+ * are resolved and validated before the first mutation, so an invalid replay
+ * cannot partially modify a group.
+ */
+export function applyGroupNodeModeCommandBatch(
+  graph: LGraph,
+  batch: GroupNodeModeCommandBatch
+): GroupNodeModeCommandBatch | null {
+  const nodes = resolveNodes(graph, batch)
+  if (!nodes) return null
+
+  const inverse = createBatch(
+    graph.id,
+    createEntries(nodes, (node) => node.mode)
+  )
+  if (!inverse) return null
+
+  graph.beforeChange()
+  try {
+    for (let index = 0; index < nodes.length; index++) {
+      nodes[index].mode = batch.entries[index].mode
+    }
+    graph.change()
+  } catch (error) {
+    for (let index = 0; index < nodes.length; index++) {
+      nodes[index].mode = inverse.entries[index].mode
+    }
+    graph.change()
+    throw error
+  } finally {
+    graph.afterChange()
+  }
+  return inverse
+}

--- a/src/extensions/core/groupOptions.test.ts
+++ b/src/extensions/core/groupOptions.test.ts
@@ -19,6 +19,19 @@ const { registerExtension } = vi.hoisted(() => ({
   registerExtension: vi.fn()
 }))
 
+const {
+  createGroupNodeModeCommandBatch,
+  applyGroupNodeModeCommandBatch,
+  commandBatch
+} = vi.hoisted(() => {
+  const commandBatch = Symbol('group-node-mode-command-batch')
+  return {
+    commandBatch,
+    createGroupNodeModeCommandBatch: vi.fn(() => commandBatch),
+    applyGroupNodeModeCommandBatch: vi.fn()
+  }
+})
+
 vi.mock('@/scripts/app', () => ({
   app: { registerExtension }
 }))
@@ -27,16 +40,24 @@ vi.mock('@/platform/settings/settingStore', () => ({
   useSettingStore: () => ({ get: () => 10 })
 }))
 
+vi.mock('./groupNodeModeCommands', () => ({
+  createGroupNodeModeCommandBatch,
+  applyGroupNodeModeCommandBatch
+}))
+
 import '@/extensions/core/groupOptions'
 
 const ext = registerExtension.mock.calls[0]?.[0] as ComfyExtension
 
-const graphChange = vi.fn()
+const graphId = 'graph-id'
+const graph = fromPartial<LGraph>({
+  id: graphId
+})
 
 function makeNode(mode: LGraphEventMode): LGraphNode {
   return createMockLGraphNode({
     mode,
-    graph: fromPartial<LGraph>({ change: graphChange })
+    graph
   })
 }
 
@@ -82,7 +103,9 @@ const BASE_GROUP_ITEMS: (string | null)[] = [
 ]
 
 beforeEach(() => {
-  graphChange.mockClear()
+  createGroupNodeModeCommandBatch.mockClear()
+  createGroupNodeModeCommandBatch.mockReturnValue(commandBatch)
+  applyGroupNodeModeCommandBatch.mockClear()
 })
 
 describe('Comfy.GroupOptions canvas menu', () => {
@@ -154,11 +177,26 @@ describe('Comfy.GroupOptions canvas menu', () => {
     ])
   })
 
+  it('does not dispatch a batch spanning graphs', () => {
+    const nodes = [
+      makeNode(LGraphEventMode.ALWAYS),
+      makeNode(LGraphEventMode.ALWAYS)
+    ]
+    nodes[1].graph = fromPartial<LGraph>({ id: 'other-graph' })
+    const items = menuFor(makeCanvas(makeGroup(nodes)))
+    const item = items.find((entry) => entry?.content === 'Bypass Group Nodes')
+
+    item?.callback?.call(document.createElement('div'))
+
+    expect(createGroupNodeModeCommandBatch).not.toHaveBeenCalled()
+    expect(applyGroupNodeModeCommandBatch).not.toHaveBeenCalled()
+  })
+
   it.for<[label: string, expected: LGraphEventMode]>([
     ['Set Group Nodes to Always', LGraphEventMode.ALWAYS],
     ['Set Group Nodes to Never', LGraphEventMode.NEVER],
     ['Bypass Group Nodes', LGraphEventMode.BYPASS]
-  ])('applies %s to every node in the group', ([label, expected]) => {
+  ])('dispatches %s as one command batch', ([label, expected]) => {
     const nodes = [
       makeNode(LGraphEventMode.ON_TRIGGER),
       makeNode(LGraphEventMode.ON_TRIGGER)
@@ -169,7 +207,14 @@ describe('Comfy.GroupOptions canvas menu', () => {
 
     item?.callback?.call(menuElement)
 
-    expect(nodes.map((node) => node.mode)).toEqual([expected, expected])
-    expect(graphChange).toHaveBeenCalledTimes(nodes.length)
+    expect(createGroupNodeModeCommandBatch).toHaveBeenCalledWith(
+      graphId,
+      nodes,
+      expected
+    )
+    expect(applyGroupNodeModeCommandBatch).toHaveBeenCalledExactlyOnceWith(
+      graph,
+      commandBatch
+    )
   })
 })

--- a/src/extensions/core/groupOptions.ts
+++ b/src/extensions/core/groupOptions.ts
@@ -5,18 +5,16 @@ import type {
 import {
   LGraphCanvas,
   LGraphEventMode,
-  LGraphGroup,
-  type LGraphNode
+  LGraphGroup
 } from '@/lib/litegraph/src/litegraph'
 import { useSettingStore } from '@/platform/settings/settingStore'
 import type { ComfyExtension } from '@/types/comfy'
 
 import { app } from '../../scripts/app'
-
-function setNodeMode(node: LGraphNode, mode: LGraphEventMode) {
-  node.mode = mode
-  node.graph?.change()
-}
+import {
+  applyGroupNodeModeCommandBatch,
+  createGroupNodeModeCommandBatch
+} from './groupNodeModeCommands'
 
 const MODE_MENU_ITEMS = [
   { content: 'Set Group Nodes to Always', mode: LGraphEventMode.ALWAYS },
@@ -118,9 +116,16 @@ const ext: ComfyExtension = {
       items.push({
         content,
         callback: () => {
-          for (const node of nodesInGroup) {
-            setNodeMode(node, mode)
+          const graph = nodesInGroup[0]?.graph
+          if (!graph || nodesInGroup.some((node) => node.graph !== graph)) {
+            return
           }
+          const batch = createGroupNodeModeCommandBatch(
+            graph.id,
+            nodesInGroup,
+            mode
+          )
+          if (batch) applyGroupNodeModeCommandBatch(graph, batch)
         }
       })
     }


### PR DESCRIPTION
## Summary
- Replace the group menu’s per-node `node.mode` assignments with a serializable node-mode command batch.
- Command entries use graph/node IDs, natural ID ordering, a command type, and a version, making equivalent batches deterministic and replayable.
- Validate graph identity, node IDs, duplicate IDs, and every mode before touching a node; invalid replays return without opening a transaction.
- Apply the whole batch inside one `beforeChange` / `change` / `afterChange` transaction and return a mixed-mode inverse batch for restoration.
- Reject a group whose nodes accidentally span graphs.

Fixes #15369.

## Tests
- Added command-batch regressions for:
  - deterministic JSON serialization;
  - one-transaction application and inverse restoration of mixed modes;
  - invalid replay rejection without mutation or transaction events.
- Updated group-menu tests to assert one command creation and one batch application per action, including the cross-graph boundary.

Validation:
- `pnpm exec vitest run src/extensions/core/groupOptions.test.ts src/extensions/core/groupNodeModeCommands.test.ts` — 16 passed
- `pnpm exec vue-tsc --noEmit` — passed
- `pnpm oxlint:main` — passed, with pre-existing warnings only
- `pnpm exec oxfmt --check <changed files>` — passed
- Pre-push `knip --cache` — passed
- `git diff --check origin/main..HEAD` — passed