### PR TITLE
ci(perf): preserve main-branch baselines

### DIFF
--- a/.github/workflows/ci-perf-report.yaml
+++ b/.github/workflows/ci-perf-report.yaml
@@ -73,9 +73,23 @@ jobs:
           if-no-files-found: warn
 
       - name: Save perf baseline to perf-data branch
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && steps.perf.outcome == 'success'
-        continue-on-error: true
+        # Save completed measurements even when another benchmark fails.  On
+        # main, a missing/empty report is an error: otherwise every later PR
+        # silently compares against an increasingly stale baseline.
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && !cancelled()
         run: |
+          trap 'git worktree remove /tmp/perf-data --force 2>/dev/null || true' EXIT
+          if ! test -s test-results/perf-metrics.json; then
+            echo "::error::perf-metrics.json is missing or empty; refusing to skip the main-branch baseline update"
+            exit 1
+          fi
+          MEASUREMENT_COUNT=$(node -e "const report=require('./test-results/perf-metrics.json'); process.stdout.write(String(report.measurements?.length ?? 0))")
+          if test "$MEASUREMENT_COUNT" -eq 0; then
+            echo "::error::perf-metrics.json contains no measurements; refusing to skip the main-branch baseline update"
+            exit 1
+          fi
+          echo "Saving $MEASUREMENT_COUNT completed perf measurement(s)"
+
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git config url."https://x-access-token:${GH_TOKEN}@github.com/".insteadOf "https://github.com/"

--- a/browser_tests/tests/performance.spec.ts
+++ b/browser_tests/tests/performance.spec.ts
@@ -403,7 +403,7 @@ test.describe('Performance', { tag: ['@perf'] }, () => {
 
   test(
     'subgraph transition (enter and exit)',
-    { tag: ['@vue-nodes'] },
+    { tag: ['@vue-nodes', '@perf-quarantine'] },
     async ({ comfyPage }, testInfo) => {
       // Heaviest perf test: loads an 80-node subgraph and pays ~30s/repeat.
       // The signal is dominated by N=80 mount cost, so a single sample per

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -52,6 +52,10 @@ export default defineConfig({
       },
       timeout: 60_000,
       grep: /@perf/,
+      // #15409: this transition benchmark is quarantined until its CI timeout
+      // is diagnosed. It must not prevent the other main-branch measurements
+      // from refreshing the perf-data baseline.
+      grepInvert: /@perf-quarantine/,
       fullyParallel: false
     },
 

--- a/scripts/perfReporting.test.ts
+++ b/scripts/perfReporting.test.ts
@@ -1,0 +1,52 @@
+import { readFileSync } from 'node:fs'
+
+import { describe, expect, it } from 'vitest'
+
+import config from '../playwright.config'
+
+const workflowPath = '.github/workflows/ci-perf-report.yaml'
+const performanceSpecPath = 'browser_tests/tests/performance.spec.ts'
+
+function workflowStep(name: string): string {
+  const lines = readFileSync(workflowPath, 'utf8').split(/\r?\n/)
+  const heading = `- name: ${name}`
+  const startIndex = lines.findIndex((line) => line.trimEnd().endsWith(heading))
+  expect(startIndex, `missing workflow step ${name}`).toBeGreaterThanOrEqual(0)
+
+  const indent = lines[startIndex].length - lines[startIndex].trimStart().length
+  const nextStep = new RegExp(`^\\s{${indent}}- `)
+  const endIndex = lines
+    .slice(startIndex + 1)
+    .findIndex((line) => nextStep.test(line))
+  return lines
+    .slice(startIndex, endIndex === -1 ? undefined : startIndex + 1 + endIndex)
+    .join('\n')
+}
+
+describe('performance baseline reporting', () => {
+  it('quarantines the flaky subgraph transition without excluding other perf tests', () => {
+    const project = config.projects?.find(
+      (entry) => entry.name === 'performance'
+    )
+    const spec = readFileSync(performanceSpecPath, 'utf8')
+
+    expect(project?.grep?.source).toContain('@perf')
+    expect(project?.grepInvert?.source).toContain('@perf-quarantine')
+    expect(spec).toContain("{ tag: ['@vue-nodes', '@perf-quarantine'] }")
+  })
+
+  it('persists completed main-branch measurements instead of requiring every test to pass', () => {
+    const runStep = workflowStep('Run performance tests')
+    const saveStep = workflowStep('Save perf baseline to perf-data branch')
+
+    expect(runStep).toContain('continue-on-error: true')
+    expect(saveStep).not.toContain('continue-on-error: true')
+    expect(saveStep).not.toContain("steps.perf.outcome == 'success'")
+    expect(saveStep).toContain('!cancelled()')
+    expect(saveStep).toContain('test -s test-results/perf-metrics.json')
+    expect(saveStep).toContain('report.measurements?.length ?? 0')
+    expect(saveStep).toContain(
+      'refusing to skip the main-branch baseline update'
+    )
+  })
+})


### PR DESCRIPTION
## Summary
- Stop gating the main-branch `perf-data` save on `steps.perf.outcome == 'success'`; `continue-on-error` changes a step conclusion without changing its outcome, so the old gate skipped baseline writes whenever the suite exited nonzero.
- Save completed measurements even when another benchmark fails, and fail visibly on main when `perf-metrics.json` is missing, malformed, or contains zero measurements.
- Validate and report the saved measurement count before touching the `perf-data` worktree.
- Clean up the worktree with an EXIT trap, including on validation or push failures.
- Quarantine the currently failing `subgraph-transition-enter` benchmark with `@perf-quarantine` and exclude only that tag from the performance project, so the remaining main-branch measurements keep refreshing baselines while the timeout is diagnosed.

Fixes #15409.

## Tests
- Added reporting regressions that fail against the old workflow/config by asserting:
  - the performance project still selects `@perf` but excludes only `@perf-quarantine`;
  - the flaky subgraph transition is explicitly tagged;
  - the perf run remains non-blocking while the baseline save is mandatory and no longer depends on `steps.perf.outcome`;
  - missing/empty measurement reports are rejected.

Validation:
- `pnpm exec vitest run scripts/perfReporting.test.ts` — 2 passed
- `pnpm exec vue-tsc --noEmit` — passed
- `pnpm oxlint:main` — passed, with pre-existing warnings only
- `pnpm exec oxfmt --check playwright.config.ts browser_tests/tests/performance.spec.ts scripts/perfReporting.test.ts` — passed
- `python -c "import yaml; yaml.safe_load(open('.github/workflows/ci-perf-report.yaml'))"` — passed
- `git diff --check` — passed