### PR TITLE
fix(manager): normalize registry accelerators

### DIFF
--- a/src/workbench/extensions/manager/composables/useConflictDetection.test.ts
+++ b/src/workbench/extensions/manager/composables/useConflictDetection.test.ts
@@ -17,7 +17,8 @@ import type { ConflictDetectionResult } from '@/workbench/extensions/manager/typ
 import type * as ConflictUtils from '@/workbench/extensions/manager/utils/conflictUtils'
 import {
   checkAcceleratorCompatibility,
-  checkOSCompatibility
+  checkOSCompatibility,
+  normalizeAcceleratorList
 } from '@/workbench/extensions/manager/utils/systemCompatibility'
 import { checkVersionCompatibility } from '@/workbench/extensions/manager/utils/versionUtil'
 
@@ -53,7 +54,8 @@ vi.mock('@/workbench/extensions/manager/utils/versionUtil', () => ({
 vi.mock('@/workbench/extensions/manager/utils/systemCompatibility', () => ({
   checkOSCompatibility: vi.fn(() => null),
   checkAcceleratorCompatibility: vi.fn(() => null),
-  normalizeOSList: vi.fn((list) => list)
+  normalizeOSList: vi.fn((list) => list),
+  normalizeAcceleratorList: vi.fn(() => ['CUDA'])
 }))
 
 vi.mock('@/workbench/extensions/manager/utils/conflictUtils', async () => {
@@ -461,6 +463,22 @@ describe('useConflictDetection', () => {
       } as components['schemas']['NodeVersion'])
 
       expect(checkOSCompatibility).toHaveBeenCalledWith(['Linux'], undefined)
+      expect(checkAcceleratorCompatibility).toHaveBeenCalledWith(
+        ['CUDA'],
+        undefined
+      )
+    })
+
+    it('normalizes Registry accelerator classifiers before compatibility checks', () => {
+      const { checkNodeCompatibility } = useConflictDetection()
+      checkNodeCompatibility({
+        status: 'NodeVersionStatusActive',
+        supported_accelerators: ['GPU :: NVIDIA CUDA']
+      } as components['schemas']['NodeVersion'])
+
+      expect(normalizeAcceleratorList).toHaveBeenCalledWith([
+        'GPU :: NVIDIA CUDA'
+      ])
       expect(checkAcceleratorCompatibility).toHaveBeenCalledWith(
         ['CUDA'],
         undefined

--- a/src/workbench/extensions/manager/composables/useConflictDetection.ts
+++ b/src/workbench/extensions/manager/composables/useConflictDetection.ts
@@ -11,10 +11,7 @@ import { useManagerState } from '@/workbench/extensions/manager/composables/useM
 import { useComfyManagerService } from '@/workbench/extensions/manager/services/comfyManagerService'
 import { useComfyManagerStore } from '@/workbench/extensions/manager/stores/comfyManagerStore'
 import { useConflictDetectionStore } from '@/workbench/extensions/manager/stores/conflictDetectionStore'
-import type {
-  RegistryAccelerator,
-  RegistryOS
-} from '@/workbench/extensions/manager/types/compatibility.types'
+import type { RegistryOS } from '@/workbench/extensions/manager/types/compatibility.types'
 import type {
   ConflictDetectionResponse,
   ConflictDetectionResult,
@@ -28,7 +25,10 @@ import {
   deriveStatusFlags,
   evaluateCompatibility
 } from '@/workbench/extensions/manager/utils/conflictUtils'
-import { normalizeOSList } from '@/workbench/extensions/manager/utils/systemCompatibility'
+import {
+  normalizeAcceleratorList,
+  normalizeOSList
+} from '@/workbench/extensions/manager/utils/systemCompatibility'
 import { getFrontendVersion } from '@/workbench/extensions/manager/utils/versionUtil'
 
 /**
@@ -221,7 +221,9 @@ export function useConflictDetection() {
             supported_os: normalizeOSList(
               versionData.supported_os
             ) as Node['supported_os'],
-            supported_accelerators: versionData.supported_accelerators,
+            supported_accelerators: normalizeAcceleratorList(
+              versionData.supported_accelerators
+            ),
 
             // Status information
             version_status: versionData.status,
@@ -273,9 +275,9 @@ export function useConflictDetection() {
     const conflicts = evaluateCompatibility(
       {
         supported_os: packageReq.supported_os as RegistryOS[] | undefined,
-        supported_accelerators: packageReq.supported_accelerators as
-          | RegistryAccelerator[]
-          | undefined,
+        supported_accelerators: normalizeAcceleratorList(
+          packageReq.supported_accelerators
+        ),
         supported_comfyui_version: packageReq.supported_comfyui_version,
         supported_comfyui_frontend_version:
           packageReq.supported_comfyui_frontend_version,
@@ -583,8 +585,9 @@ export function useConflictDetection() {
     const conflicts = evaluateCompatibility(
       {
         supported_os: normalizeOSList(node.supported_os),
-        supported_accelerators:
-          node.supported_accelerators as RegistryAccelerator[],
+        supported_accelerators: normalizeAcceleratorList(
+          node.supported_accelerators
+        ),
         supported_comfyui_version: node.supported_comfyui_version,
         supported_comfyui_frontend_version:
           node.supported_comfyui_frontend_version,

--- a/src/workbench/extensions/manager/utils/systemCompatibility.test.ts
+++ b/src/workbench/extensions/manager/utils/systemCompatibility.test.ts
@@ -7,6 +7,7 @@ import type {
 import {
   checkAcceleratorCompatibility,
   checkOSCompatibility,
+  normalizeAcceleratorList,
   normalizeOSList
 } from '@/workbench/extensions/manager/utils/systemCompatibility'
 
@@ -189,6 +190,35 @@ describe('systemCompatibility', () => {
         current_value: 'Metal',
         required_value: 'CUDA, ROCm'
       })
+    })
+  })
+
+  describe('normalizeAcceleratorList', () => {
+    it('maps Registry GPU classifier names to canonical accelerators', () => {
+      const result = normalizeAcceleratorList([
+        'GPU :: NVIDIA CUDA',
+        'GPU :: AMD ROCm',
+        'GPU :: Apple Metal'
+      ])
+
+      expect(result).toEqual(['CUDA', 'ROCm', 'Metal'])
+      expect(checkAcceleratorCompatibility(result, 'cuda')).toBeNull()
+      expect(checkAcceleratorCompatibility(result, 'mps')).toBeNull()
+      expect(checkAcceleratorCompatibility(result, 'rocm')).toBeNull()
+    })
+
+    it('accepts canonical names case-insensitively and removes duplicates', () => {
+      expect(
+        normalizeAcceleratorList(['cuda', 'CUDA', 'rocm', 'ROCm', 'cpu'])
+      ).toEqual(['CUDA', 'ROCm', 'CPU'])
+    })
+
+    it('drops unknown values and treats a fully unknown list as unrestricted', () => {
+      expect(
+        normalizeAcceleratorList(['TPU', 'GPU :: Google TPU'])
+      ).toBeUndefined()
+      expect(normalizeAcceleratorList(null)).toBeUndefined()
+      expect(normalizeAcceleratorList([])).toBeUndefined()
     })
   })
 

--- a/src/workbench/extensions/manager/utils/systemCompatibility.ts
+++ b/src/workbench/extensions/manager/utils/systemCompatibility.ts
@@ -39,6 +39,16 @@ function getRegistryAccelerator(deviceType?: string): RegistryAccelerator {
   return 'CPU'
 }
 
+const ACCELERATOR_ALIASES: Record<string, RegistryAccelerator> = {
+  'gpu :: nvidia cuda': 'CUDA',
+  'gpu :: amd rocm': 'ROCm',
+  'gpu :: apple metal': 'Metal',
+  cuda: 'CUDA',
+  rocm: 'ROCm',
+  metal: 'Metal',
+  cpu: 'CPU'
+}
+
 /**
  * Checks OS compatibility
  * @param supported Supported OS list from Registry (null/undefined = all OS supported)
@@ -96,6 +106,32 @@ export function checkAcceleratorCompatibility(
   }
 
   return null
+}
+
+/**
+ * Normalizes accelerator values from the Registry API.
+ *
+ * Registry classifiers may contain the full `GPU :: vendor :: backend` form,
+ * while compatibility checks use the frontend's canonical short names.
+ * Unknown values are ignored; a list with no recognized accelerator means the
+ * Registry did not supply an enforceable accelerator constraint.
+ */
+export function normalizeAcceleratorList(
+  acceleratorValues?: string[] | null
+): RegistryAccelerator[] | undefined {
+  if (isNil(acceleratorValues) || isEmpty(acceleratorValues)) return undefined
+
+  const validAccelerators: RegistryAccelerator[] = []
+  for (const value of acceleratorValues) {
+    const normalizedValue = value.trim().toLowerCase()
+    const accelerator = ACCELERATOR_ALIASES[normalizedValue]
+
+    if (accelerator && !validAccelerators.includes(accelerator)) {
+      validAccelerators.push(accelerator)
+    }
+  }
+
+  return validAccelerators.length > 0 ? validAccelerators : undefined
 }
 
 /**


### PR DESCRIPTION
## Summary
- Add accelerator normalization alongside the existing OS normalization.
- Map Registry classifier values such as `GPU :: NVIDIA CUDA`, `GPU :: AMD ROCm`, and `GPU :: Apple Metal` to canonical `CUDA`, `ROCm`, and `Metal`.
- Accept canonical values case-insensitively, trim input, deduplicate results, and treat a list containing no recognized accelerator as unrestricted.
- Apply normalization at all three Registry-data entry points: bulk version requirements, package conflict analysis, and node-version compatibility checks.
- Remove unsafe casts that treated raw Registry strings as canonical accelerator values.

Fixes #15364.

## Tests
- Added regressions for classifier mapping, canonical/case-insensitive input, deduplication, null/empty handling, and unknown values.
- Added a conflict-detection regression proving `GPU :: NVIDIA CUDA` is normalized before the compatibility check.
- Verified compatibility for CUDA, Metal, and ROCm systems after normalization.

Validation:
- `pnpm exec vitest run src/workbench/extensions/manager/utils/systemCompatibility.test.ts src/workbench/extensions/manager/composables/useConflictDetection.test.ts src/workbench/extensions/manager/utils/conflictUtils.test.ts src/workbench/extensions/manager/components/manager/PackVersionSelectorPopover.test.ts` — 79 passed
- `pnpm exec vue-tsc --noEmit` — passed
- Targeted ESLint — passed
- `pnpm oxlint:main` — passed, with pre-existing warnings only
- `pnpm exec oxfmt --check <changed files>` — passed
- `git diff --check` — passed