### PR TITLE
fix(i18n): honor type-named output slot labels

### DIFF
--- a/src/services/litegraphService.test.ts
+++ b/src/services/litegraphService.test.ts
@@ -172,3 +172,58 @@ describe('useLitegraphService().registerNodeDef slot text (non-en)', () => {
     expect(node?.outputs[0]?.localized_name).toBe('Live Latent Name')
   })
 })
+
+describe('useLitegraphService().registerNodeDef type-named outputs', () => {
+  const nodeName = 'TestTypeNamedOutput'
+
+  const nodeDef: ComfyNodeDefV1 = {
+    name: nodeName,
+    display_name: 'Test Type Named Output',
+    category: 'testing',
+    python_module: 'nodes',
+    description: '',
+    input: { required: {} },
+    output: ['LATENT'],
+    output_name: ['LATENT'],
+    output_node: false
+  }
+
+  beforeEach(() => {
+    setActivePinia(createTestingPinia({ stubActions: false }))
+  })
+
+  afterEach(() => {
+    LiteGraph.unregisterNodeType(nodeName)
+    mergeCustomNodesI18n({})
+    i18n.global.setLocaleMessage('en', cloneDeep(enMessages))
+  })
+
+  it('prefers a slot-level translation over the data-type translation', async () => {
+    mergeCustomNodesI18n({
+      en: {
+        nodeDefs: {
+          [nodeName]: { outputs: { 0: { name: 'Custom Latent Output' } } }
+        }
+      }
+    })
+    i18n.global.mergeLocaleMessage('en', {
+      dataTypes: { LATENT: 'Canonical Latent' }
+    })
+
+    await useLitegraphService().registerNodeDef(nodeName, nodeDef)
+
+    const node = LiteGraph.createNode(nodeName)
+    expect(node?.outputs[0]?.localized_name).toBe('Custom Latent Output')
+  })
+
+  it('falls back to the data-type translation without a slot translation', async () => {
+    i18n.global.mergeLocaleMessage('en', {
+      dataTypes: { LATENT: 'Canonical Latent' }
+    })
+
+    await useLitegraphService().registerNodeDef(nodeName, nodeDef)
+
+    const node = LiteGraph.createNode(nodeName)
+    expect(node?.outputs[0]?.localized_name).toBe('Canonical Latent')
+  })
+})

--- a/src/services/litegraphService.ts
+++ b/src/services/litegraphService.ts
@@ -355,21 +355,30 @@ export const useLitegraphService = () => {
       const type = output.type === 'COMFY_MATCHTYPE_V3' ? '*' : output.type
       const shapeOptions = is_list ? { shape: LiteGraph.GRID_SHAPE } : {}
       const typeKey = `dataTypes.${normalizeI18nKey(type)}`
+      const localizedSlotName =
+        type !== name
+          ? resolveNodeDefSlotText(
+              'name',
+              nodeDefName(node),
+              output.index,
+              name
+            )
+          : resolveNodeDefSlotText(
+              'name',
+              nodeDefName(node),
+              output.index,
+              undefined,
+              ''
+            ) || st(typeKey, name)
       const outputOptions = {
         ...shapeOptions,
         // If the output name is different from the output type, use the output name.
         // e.g.
         // - type ("INT"); name ("Positive") => translate name
-        // - type ("FLOAT"); name ("FLOAT") => translate type
-        localized_name:
-          type !== name
-            ? resolveNodeDefSlotText(
-                'name',
-                nodeDefName(node),
-                output.index,
-                name
-              )
-            : st(typeKey, name)
+        // - type ("FLOAT"); name ("FLOAT") => prefer a slot translation, then
+        //   translate the type. Custom-node translations are still slot-specific
+        //   even when the slot's source name equals its data type.
+        localized_name: localizedSlotName
       }
       node.addOutput(name, type, outputOptions)
     }


### PR DESCRIPTION
## Summary
- Type-named outputs now try the slot-specific resolver first (`outputs.<index>.name`) instead of always selecting the generic `dataTypes.<TYPE>` translation.
- If no slot translation exists, they fall back to the data-type translation exactly as before.
- Outputs whose name differs from their type retain the existing slot/backend behavior.
- This keeps custom-node and backend-provided slot translations authoritative even when the source slot name equals its data type.

I also surveyed all bundled `nodeDefs.json` output entries against each locale's `dataTypes` table. The generated English bundle intentionally omits names for type-named outputs, so this change does not alter bundled English labels; it preserves the generic fallback while allowing slot-specific data supplied by custom nodes or the backend translation path.

Fixes #15347.

## Tests
- Added two regressions for a `LATENT` output named `LATENT`:
  - a slot-level translation wins over the canonical data-type translation;
  - the canonical data-type translation remains the fallback when no slot translation exists.

Validation:
- `pnpm exec vitest run src/services/litegraphService.test.ts` — 8 passed
- `pnpm exec vue-tsc --noEmit` — passed
- Targeted ESLint — passed
- Targeted type-aware Oxlint — passed
- `pnpm exec oxfmt --check src/services/litegraphService.ts src/services/litegraphService.test.ts` — passed
- `git diff --check` — passed