### PR TITLE
fix: clear stale modified flag when resetting change tracker

### DIFF
--- a/src/scripts/changeTracker.reset.test.ts
+++ b/src/scripts/changeTracker.reset.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import type { ComfyWorkflowJSON } from '@/platform/workflow/validation/schemas/workflowSchema'
+
+const mockWorkflowStore = vi.hoisted(() => ({
+  getWorkflowByPath: vi.fn()
+}))
+
+vi.mock('@/scripts/api', () => ({
+  api: {
+    dispatchCustomEvent: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn()
+  }
+}))
+
+vi.mock('@/platform/workflow/management/stores/workflowStore', () => ({
+  useWorkflowStore: vi.fn(() => mockWorkflowStore)
+}))
+
+import { api } from '@/scripts/api'
+import { ChangeTracker } from '@/scripts/changeTracker'
+
+function createState(nodeCount: number): ComfyWorkflowJSON {
+  return {
+    nodes: Array.from({ length: nodeCount }, (_, index) => ({
+      id: index + 1,
+      type: 'TestNode',
+      pos: [0, 0],
+      size: [100, 50],
+      flags: {},
+      order: index,
+      mode: 0,
+      inputs: [],
+      outputs: [],
+      properties: {}
+    })),
+    links: [],
+    groups: [],
+    extra: {},
+    config: {},
+    version: 0.4,
+    last_node_id: nodeCount,
+    last_link_id: 0
+  } as ComfyWorkflowJSON
+}
+
+describe('ChangeTracker.reset', () => {
+  it('clears a stale modified flag without dispatching a graph change', () => {
+    const initial = createState(1)
+    const changed = structuredClone(initial)
+    changed.nodes[0].widgets_values = [2]
+    const workflow = { path: '/test/workflow.json' } as never
+    const tracker = new ChangeTracker(workflow, initial)
+    tracker.activeState = changed
+    const workflowRecord = { isModified: true }
+    mockWorkflowStore.getWorkflowByPath.mockReturnValue(workflowRecord)
+
+    tracker.reset()
+
+    expect(workflowRecord.isModified).toBe(false)
+    expect(api.dispatchCustomEvent).not.toHaveBeenCalled()
+  })
+})

--- a/src/scripts/changeTracker.ts
+++ b/src/scripts/changeTracker.ts
@@ -29,6 +29,18 @@ function isActiveTracker(tracker: ChangeTracker): boolean {
   return useWorkflowStore().activeWorkflow?.changeTracker === tracker
 }
 
+function syncWorkflowModifiedFlag(tracker: ChangeTracker): void {
+  // Get the workflow from the store as ChangeTracker is raw object, i.e.
+  // `tracker.workflow` is not reactive.
+  const workflow = useWorkflowStore().getWorkflowByPath(tracker.workflow.path)
+  if (workflow) {
+    workflow.isModified = !ChangeTracker.graphEqual(
+      tracker.initialState,
+      tracker.activeState
+    )
+  }
+}
+
 function isAutoQueueOnChange(): boolean {
   return (
     useQueueSettingsStore().mode === 'change' ||
@@ -296,6 +308,7 @@ export class ChangeTracker {
 
     if (state) this.activeState = clone(state)
     this.initialState = clone(this.activeState)
+    syncWorkflowModifiedFlag(this)
   }
 
   store() {
@@ -372,15 +385,7 @@ export class ChangeTracker {
   }
 
   updateModified(previousState?: ComfyWorkflowJSON) {
-    // Get the workflow from the store as ChangeTracker is raw object, i.e.
-    // `this.workflow` is not reactive.
-    const workflow = useWorkflowStore().getWorkflowByPath(this.workflow.path)
-    if (workflow) {
-      workflow.isModified = !ChangeTracker.graphEqual(
-        this.initialState,
-        this.activeState
-      )
-    }
+    syncWorkflowModifiedFlag(this)
 
     const autoQueueGraphChanged =
       !!previousState &&


### PR DESCRIPTION
Fixes #15122.

## Summary
- Extract workflow dirty-flag synchronization into a shared helper.
- Recompute `workflow.isModified` when `ChangeTracker.reset()` re-baselines its state.
- Preserve the existing no-event behavior of `reset()`; only `updateModified()` continues dispatching graph-change events.

## Validation
- New regression test fails on pristine `main` (`expected true to be false`) and passes after the fix.
- `vitest run src/scripts/changeTracker.test.ts src/scripts/changeTracker.reset.test.ts` — 62 passed.
- `vue-tsc --noEmit` — passed.
- `oxfmt --check src/scripts/changeTracker.ts src/scripts/changeTracker.reset.test.ts` — passed.
- `oxlint --config tools/oxlint-plugins/vitestCleanup.config.json src/scripts/changeTracker.reset.test.ts` — passed.
- `git diff --check` — passed.