### PR TITLE
test: classify every overlay vocabulary against the modal gate

### DIFF
--- a/src/platform/keybindings/keybindingService.dialog.test.ts
+++ b/src/platform/keybindings/keybindingService.dialog.test.ts
@@ -229,4 +229,43 @@ describe('keybindingService - dialog gate', () => {
       document.body.removeChild(popper)
     }
   })
+
+  it('saves the workflow on Ctrl+S while a tab popover is open', async () => {
+    const popover = document.createElement('div')
+    popover.className = 'p-popover'
+    popover.setAttribute('role', 'dialog')
+    popover.setAttribute('aria-modal', 'true')
+    document.body.appendChild(popover)
+
+    try {
+      const event = createKeyboardEvent('s', document.body, { ctrlKey: true })
+      await keybindingService.keybindHandler(event)
+
+      expect(mockCommandExecute).toHaveBeenCalledWith('Comfy.SaveWorkflow')
+      expect(event.defaultPrevented).toBe(true)
+    } finally {
+      document.body.removeChild(popover)
+    }
+  })
+
+  it('saves the workflow on Ctrl+S once a masked dialog is closed', async () => {
+    const mask = document.createElement('div')
+    mask.style.display = 'none'
+    const dialog = document.createElement('div')
+    dialog.setAttribute('role', 'dialog')
+    dialog.setAttribute('aria-modal', 'true')
+    dialog.style.display = 'flex'
+    mask.appendChild(dialog)
+    document.body.appendChild(mask)
+
+    try {
+      const event = createKeyboardEvent('s', document.body, { ctrlKey: true })
+      await keybindingService.keybindHandler(event)
+
+      expect(mockCommandExecute).toHaveBeenCalledWith('Comfy.SaveWorkflow')
+      expect(event.defaultPrevented).toBe(true)
+    } finally {
+      document.body.removeChild(mask)
+    }
+  })
 })

--- a/src/utils/modalUtil.overlays.test.ts
+++ b/src/utils/modalUtil.overlays.test.ts
@@ -1,0 +1,299 @@
+import { composeStories, setProjectAnnotations } from '@storybook/vue3'
+import userEvent from '@testing-library/user-event'
+import { render, screen } from '@testing-library/vue'
+import { readFileSync, readdirSync } from 'node:fs'
+import { join } from 'node:path'
+import PrimeDialog from 'primevue/dialog'
+import { beforeAll, describe, expect, it, vi } from 'vitest'
+import type { App, Component } from 'vue'
+import { defineComponent, ref } from 'vue'
+
+import * as moreButtonStories from '@/components/button/MoreButton.stories'
+import * as jobDetailsPopoverStories from '@/components/queue/job/JobDetailsPopover.stories'
+import * as colorPickerStories from '@/components/ui/color-picker/ColorPicker.stories'
+import * as dialogStories from '@/components/ui/dialog/Dialog.stories'
+import * as baseModalLayoutStories from '@/components/widget/layout/BaseModalLayout.stories'
+import * as assetBrowserModalStories from '@/platform/assets/components/AssetBrowserModal.stories'
+import * as mediaLightboxStories from '@/platform/assets/components/MediaLightbox.stories'
+import * as assetBrowserDialogStories from '@/platform/assets/composables/useAssetBrowserDialog.stories'
+import { ComfyDialog } from '@/scripts/ui/dialog'
+import { isModalOpen } from '@/utils/modalUtil'
+
+import * as storybookPreview from '../../.storybook/preview'
+
+/**
+ * `isModalOpen` recognises overlays by their rendered markup, so hand-written
+ * DOM fixtures only ever test it against what their author believed the
+ * components emit. #15639 is what that gap costs: a PrimeVue `Popover`
+ * announces `aria-modal="true"`, nobody knew, and Ctrl+S stopped saving
+ * whenever one was on screen.
+ *
+ * These cases mount the real components and pin whether each must suppress the
+ * app's global keybindings. `modalUtil.test.ts` covers the predicate's logic;
+ * this file covers its premises.
+ */
+
+const NO_MANAGED_DIALOGS = 0
+
+/**
+ * The overlay vocabularies in use, keyed by how a component reaches for one.
+ * Every overlay in the app is one of these composed into something bigger, and
+ * the gate reads attributes each library emits unconditionally, so classifying
+ * the vocabulary classifies every component built on it - which `MoreButton`, a
+ * PrimeVue `Popover` one layer down, is here to demonstrate. That transitivity
+ * is why the gate must never key on anything a call site can switch off, as
+ * `.p-popover` was until `unstyled` call sites proved otherwise.
+ *
+ * Sibling entries from the same libraries are listed even when nothing uses
+ * them yet, so adopting one trips the coverage guard below. A whole new overlay
+ * library would not: that is the limit of a source scan, and it is a far more
+ * visible event than reusing a vocabulary the app already ships.
+ */
+const OVERLAY_VOCABULARIES = {
+  'PrimeVue Popover': /from 'primevue\/popover'/,
+  'PrimeVue Dialog': /from 'primevue\/dialog'/,
+  'PrimeVue Drawer': /from 'primevue\/drawer'/,
+  'PrimeVue ConfirmDialog': /from 'primevue\/confirmdialog'/,
+  'Reka Dialog': /\bDialogRoot\b|\bDialogContent\b|components\/ui\/dialog/,
+  'Reka Popover': /\bPopoverRoot\b|\bPopoverContent\b|components\/ui\/popover/,
+  'Reka AlertDialog': /\bAlertDialogRoot\b|\bAlertDialogContent\b/,
+  'hand-written ARIA modal': /aria-modal/,
+  'native dialog': /<dialog[\s>]|createElement\('dialog'\)|showModal\(/,
+  'legacy ComfyDialog': /comfy-modal/
+} as const
+
+type OverlayVocabulary = keyof typeof OVERLAY_VOCABULARIES
+
+type User = ReturnType<typeof userEvent.setup>
+
+interface OverlayCase {
+  label: string
+  /** Vocabularies this case puts through the gate, if any. */
+  covers?: OverlayVocabulary[]
+  /** Puts the overlay on screen the way a user would. */
+  open: (user: User) => Promise<void>
+  /**
+   * Something `open` must have put on screen. Without it a surface that
+   * silently stopped rendering would still satisfy every `blocksShortcuts:
+   * false` case, which is most of them.
+   */
+  onScreen: () => HTMLElement
+  /** Whether the surface must suppress the app's global keybindings. */
+  blocksShortcuts: boolean
+}
+
+/**
+ * `.storybook/preview.ts` registers pinia, i18n and PrimeVue through
+ * Storybook's `setup()`, which stores them on this global and replays them
+ * only from Storybook's own renderer. Pinned to `@storybook/vue3` 10.x; a major
+ * upgrade should re-check the name, because a miss here degrades to components
+ * failing to resolve rather than to an error.
+ */
+const storybookAppSetup = {
+  install(app: App) {
+    const setupFunctions = (
+      globalThis as typeof globalThis & {
+        PLUGINS_SETUP_FUNCTIONS?: Set<(app: App) => void>
+      }
+    ).PLUGINS_SETUP_FUNCTIONS
+    for (const setupFunction of setupFunctions ?? []) setupFunction(app)
+  }
+}
+
+const projectAnnotations = setProjectAnnotations([storybookPreview])
+
+beforeAll(projectAnnotations.beforeAll)
+
+function mount(component: Component): void {
+  render(component, { global: { plugins: [storybookAppSetup] } })
+}
+
+const PrimeVueDialogHost = defineComponent({
+  components: { PrimeDialog },
+  setup: () => ({ visible: ref(false) }),
+  template: `
+    <button @click="visible = true">Open settings</button>
+    <PrimeDialog v-model:visible="visible" modal header="Settings">
+      <p>Settings body</p>
+    </PrimeDialog>
+  `
+})
+
+/** Overlays reached through a story, so the story doubles as the fixture. */
+const storyCases: OverlayCase[] = [
+  {
+    // A PrimeVue Popover declares aria-modal="true" while being a
+    // non-blocking hover preview, which is the regression reported as #15639.
+    label: 'the MoreButton menu',
+    covers: ['PrimeVue Popover'],
+    open: async (user) => {
+      mount(composeStories(moreButtonStories).Basic)
+      await user.click(screen.getByRole('button'))
+    },
+    onScreen: () => screen.getByRole('button', { name: 'Profile' }),
+    blocksShortcuts: false
+  },
+  {
+    label: 'a Reka Dialog',
+    covers: ['Reka Dialog'],
+    open: async (user) => {
+      mount(composeStories(dialogStories).Default)
+      await user.click(screen.getByRole('button', { name: 'Open dialog' }))
+    },
+    onScreen: () => screen.getByText('Are you sure?'),
+    blocksShortcuts: true
+  },
+  {
+    label: 'the colour picker',
+    covers: ['Reka Popover'],
+    open: async (user) => {
+      mount(composeStories(colorPickerStories).Default)
+      await user.click(screen.getByRole('button', { expanded: false }))
+    },
+    onScreen: () => screen.getByText('Hex'),
+    blocksShortcuts: false
+  },
+  {
+    label: 'the media lightbox',
+    covers: ['hand-written ARIA modal'],
+    open: async (user) => {
+      mount(composeStories(mediaLightboxStories).SingleImage)
+      await user.click(screen.getByRole('button', { name: 'Open lightbox' }))
+    },
+    onScreen: () => screen.getByRole('dialog', { name: 'Gallery' }),
+    blocksShortcuts: true
+  },
+  {
+    label: 'the job details panel',
+    open: async () => {
+      mount(composeStories(jobDetailsPopoverStories).Queued)
+    },
+    onScreen: () => screen.getByText('Job Details'),
+    blocksShortcuts: false
+  },
+  {
+    label: 'a bare BaseModalLayout',
+    open: async () => {
+      mount(composeStories(baseModalLayoutStories).Default)
+    },
+    onScreen: () => screen.getByText('Installed'),
+    blocksShortcuts: false
+  },
+  {
+    label: 'a bare AssetBrowserModal',
+    open: async () => {
+      mount(composeStories(assetBrowserModalStories).Default)
+    },
+    onScreen: () => screen.getByLabelText('Search models'),
+    blocksShortcuts: false
+  },
+  {
+    // The story hand-rolls the scrim; in the app this modal is opened through
+    // the managed dialog stack, which gates on its own count.
+    label: 'the asset browser behind its own scrim',
+    open: async (user) => {
+      mount(composeStories(assetBrowserDialogStories).Demo)
+      await user.click(
+        screen.getByRole('button', { name: 'Browse Checkpoints' })
+      )
+    },
+    onScreen: () => screen.getByLabelText('Search models'),
+    blocksShortcuts: false
+  }
+]
+
+/** Overlays no story reaches, mounted directly. */
+const unstoriedCases: OverlayCase[] = [
+  {
+    label: 'a PrimeVue Dialog',
+    covers: ['PrimeVue Dialog'],
+    open: async (user) => {
+      mount(PrimeVueDialogHost)
+      await user.click(screen.getByRole('button', { name: 'Open settings' }))
+    },
+    onScreen: () => screen.getByText('Settings body'),
+    blocksShortcuts: true
+  },
+  {
+    label: 'a native dialog',
+    covers: ['native dialog'],
+    open: async () => {
+      const dialog = document.createElement('dialog')
+      dialog.textContent = 'Native dialog'
+      document.body.appendChild(dialog).showModal()
+    },
+    onScreen: () => screen.getByText('Native dialog'),
+    blocksShortcuts: true
+  },
+  {
+    label: 'an open ComfyDialog',
+    covers: ['legacy ComfyDialog'],
+    open: async () => {
+      new ComfyDialog().show('Something went wrong')
+    },
+    onScreen: () => screen.getByText('Something went wrong'),
+    blocksShortcuts: true
+  },
+  {
+    label: 'a closed ComfyDialog',
+    covers: ['legacy ComfyDialog'],
+    open: async () => {
+      const dialog = new ComfyDialog()
+      dialog.show('Something went wrong')
+      dialog.close()
+    },
+    onScreen: () => screen.getByText('Something went wrong'),
+    blocksShortcuts: false
+  }
+]
+
+const overlayCases = [...storyCases, ...unstoriedCases]
+
+describe('overlay surfaces', () => {
+  overlayCases.forEach(({ label, open, onScreen, blocksShortcuts }) => {
+    const outcome = blocksShortcuts ? 'suppresses' : 'passes through'
+
+    it(`${label} ${outcome} global shortcuts`, async () => {
+      expect(isModalOpen(NO_MANAGED_DIALOGS)).toBe(false)
+
+      await open(userEvent.setup({ advanceTimers: vi.advanceTimersByTime }))
+
+      expect(onScreen()).toBeInTheDocument()
+      expect(isModalOpen(NO_MANAGED_DIALOGS)).toBe(blocksShortcuts)
+    })
+  })
+})
+
+describe('overlay coverage', () => {
+  const SRC_ROOT = join(import.meta.dirname, '..')
+
+  /** The gate's own selector strings are not markup the app renders. */
+  const GATE_SOURCE = join('utils', 'modalUtil.ts')
+
+  function vocabulariesUsedInSource(): OverlayVocabulary[] {
+    const sources = readdirSync(SRC_ROOT, { recursive: true, encoding: 'utf8' })
+      .filter(
+        (file) =>
+          /\.(vue|tsx?)$/.test(file) &&
+          !/\.(test|spec)\.tsx?$/.test(file) &&
+          file !== GATE_SOURCE
+      )
+      .map((file) => readFileSync(join(SRC_ROOT, file), 'utf8'))
+
+    return Object.entries(OVERLAY_VOCABULARIES)
+      .filter(([, marker]) => sources.some((source) => marker.test(source)))
+      .map(([vocabulary]) => vocabulary as OverlayVocabulary)
+  }
+
+  it('classifies every overlay vocabulary the app renders', () => {
+    const classified = new Set(
+      overlayCases.flatMap(({ covers }) => covers ?? [])
+    )
+
+    const unclassified = vocabulariesUsedInSource()
+      .filter((vocabulary) => !classified.has(vocabulary))
+      .map((vocabulary) => `${vocabulary} - add a case to overlayCases`)
+
+    expect(unclassified).toEqual([])
+  })
+})

--- a/src/utils/modalUtil.overlays.test.ts
+++ b/src/utils/modalUtil.overlays.test.ts
@@ -38,11 +38,17 @@ const NO_MANAGED_DIALOGS = 0
 /**
  * The overlay vocabularies in use, keyed by how a component reaches for one.
  * Every overlay in the app is one of these composed into something bigger, and
- * the gate reads attributes each library emits unconditionally, so classifying
- * the vocabulary classifies every component built on it - which `MoreButton`, a
- * PrimeVue `Popover` one layer down, is here to demonstrate. That transitivity
- * is why the gate must never key on anything a call site can switch off, as
- * `.p-popover` was until `unstyled` call sites proved otherwise.
+ * the gate reads attributes each library emits unconditionally, so one case
+ * pins how the gate treats every component built on that vocabulary - which
+ * `MoreButton`, a PrimeVue `Popover` one layer down, is here to demonstrate.
+ * That is also why the gate must never key on anything a call site can switch
+ * off, as `.p-popover` was until `unstyled` call sites proved otherwise.
+ *
+ * What it does not pin is whether that treatment is still *right* for a call
+ * site that changes the surface's blocking semantics. Reka's `modal` prop is
+ * the live example: `<Popover modal>` inerts the page, and the gate reports no
+ * modal, because popper content is excluded wholesale. Nothing passes it today.
+ * A call site that does needs its own case, and a decision about the gate.
  *
  * Sibling entries from the same libraries are listed even when nothing uses
  * them yet, so adopting one trips the coverage guard below. A whole new overlay

--- a/src/utils/modalUtil.test.ts
+++ b/src/utils/modalUtil.test.ts
@@ -72,6 +72,16 @@ describe('isModalOpen', () => {
       expect(isModalOpen(NO_MANAGED_DIALOGS)).toBe(false)
     })
 
+    // Most Popover call sites pass `unstyled`, which drops the theme class
+    // and leaves data-pc-name as the only marker.
+    it('ignores an unstyled PrimeVue popover', () => {
+      render(
+        '<div data-pc-name="popover" role="dialog" aria-modal="true"></div>'
+      )
+
+      expect(isModalOpen(NO_MANAGED_DIALOGS)).toBe(false)
+    })
+
     it('ignores content nested inside a popover', () => {
       render(`
         <div class="p-popover">

--- a/src/utils/modalUtil.test.ts
+++ b/src/utils/modalUtil.test.ts
@@ -1,0 +1,128 @@
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { isModalOpen } from '@/utils/modalUtil'
+
+const NO_MANAGED_DIALOGS = 0
+
+function render(html: string): void {
+  document.body.insertAdjacentHTML('beforeend', html)
+}
+
+afterEach(() => {
+  document.body.innerHTML = ''
+})
+
+describe('isModalOpen', () => {
+  it('is false on a bare page', () => {
+    expect(isModalOpen(NO_MANAGED_DIALOGS)).toBe(false)
+  })
+
+  it('is true while the app has a managed dialog on the stack', () => {
+    expect(isModalOpen(1)).toBe(true)
+  })
+
+  describe('overlays that block the page', () => {
+    it('counts an ARIA modal', () => {
+      render('<div role="dialog" aria-modal="true"></div>')
+
+      expect(isModalOpen(NO_MANAGED_DIALOGS)).toBe(true)
+    })
+
+    it('counts an open Reka dialog', () => {
+      render('<div role="dialog" data-state="open"></div>')
+
+      expect(isModalOpen(NO_MANAGED_DIALOGS)).toBe(true)
+    })
+
+    it('counts an open native dialog', () => {
+      render('<dialog open></dialog>')
+
+      expect(isModalOpen(NO_MANAGED_DIALOGS)).toBe(true)
+    })
+
+    it('counts a visible legacy ComfyDialog', () => {
+      render('<div class="comfy-modal" style="display: flex"></div>')
+
+      expect(isModalOpen(NO_MANAGED_DIALOGS)).toBe(true)
+    })
+  })
+
+  describe('overlays that do not block the page', () => {
+    it('ignores a hidden legacy ComfyDialog', () => {
+      render('<div class="comfy-modal" style="display: none"></div>')
+
+      expect(isModalOpen(NO_MANAGED_DIALOGS)).toBe(false)
+    })
+
+    it('ignores a Reka popover', () => {
+      render(`
+        <div data-reka-popper-content-wrapper>
+          <div role="dialog" data-state="open"></div>
+        </div>
+      `)
+
+      expect(isModalOpen(NO_MANAGED_DIALOGS)).toBe(false)
+    })
+
+    // Regression: hovering a workflow tab renders a PrimeVue Popover, which
+    // declares aria-modal="true" despite being a non-blocking hover preview.
+    it('ignores a PrimeVue popover that declares itself modal', () => {
+      render('<div class="p-popover" role="dialog" aria-modal="true"></div>')
+
+      expect(isModalOpen(NO_MANAGED_DIALOGS)).toBe(false)
+    })
+
+    it('ignores content nested inside a popover', () => {
+      render(`
+        <div class="p-popover">
+          <div role="dialog" aria-modal="true"></div>
+        </div>
+      `)
+
+      expect(isModalOpen(NO_MANAGED_DIALOGS)).toBe(false)
+    })
+  })
+
+  describe('overlays left in the DOM after closing', () => {
+    it('ignores a dialog hidden by its own display', () => {
+      render(
+        '<div role="dialog" aria-modal="true" style="display: none"></div>'
+      )
+
+      expect(isModalOpen(NO_MANAGED_DIALOGS)).toBe(false)
+    })
+
+    // Regression: ComfyUI-Manager hides only the mask on close, leaving its
+    // aria-modal dialog node in the DOM for the rest of the session.
+    it('ignores a dialog hidden by an ancestor mask', () => {
+      render(`
+        <div class="p-dialog-mask" style="display: none">
+          <div role="dialog" aria-modal="true" style="display: flex"></div>
+        </div>
+      `)
+
+      expect(isModalOpen(NO_MANAGED_DIALOGS)).toBe(false)
+    })
+
+    it('still counts a dialog inside a visible mask', () => {
+      render(`
+        <div class="p-dialog-mask" style="display: flex">
+          <div role="dialog" aria-modal="true" style="display: flex"></div>
+        </div>
+      `)
+
+      expect(isModalOpen(NO_MANAGED_DIALOGS)).toBe(true)
+    })
+
+    it('still counts a sibling dialog that is genuinely open', () => {
+      render(`
+        <div class="p-dialog-mask" style="display: none">
+          <div role="dialog" aria-modal="true" style="display: flex"></div>
+        </div>
+        <div role="dialog" aria-modal="true"></div>
+      `)
+
+      expect(isModalOpen(NO_MANAGED_DIALOGS)).toBe(true)
+    })
+  })
+})

--- a/src/utils/modalUtil.ts
+++ b/src/utils/modalUtil.ts
@@ -4,9 +4,13 @@ const REKA_OPEN_DIALOG_SELECTOR = '[role="dialog"][data-state="open"]'
 /**
  * Popovers and dropdowns also render as role="dialog", but they neither trap
  * focus nor block the page, so they must not suppress global shortcuts.
+ *
+ * PrimeVue is matched on `data-pc-name` rather than only its theme class,
+ * because most Popover call sites pass `unstyled`, which drops `.p-popover`
+ * while keeping the attribute.
  */
 const NON_MODAL_OVERLAY_SELECTOR =
-  '.p-popover, [data-reka-popper-content-wrapper]'
+  '.p-popover, [data-pc-name="popover"], [data-reka-popper-content-wrapper]'
 
 /**
  * Overlays are commonly hidden by toggling `display` on an ancestor (a mask or

--- a/src/utils/modalUtil.ts
+++ b/src/utils/modalUtil.ts
@@ -1,4 +1,4 @@
-const ARIA_MODAL_SELECTOR = '[role="dialog"][aria-modal="true"]'
+const ARIA_MODAL_SELECTOR = '[role="dialog"][aria-modal="true"]:not([hidden])'
 const REKA_OPEN_DIALOG_SELECTOR = '[role="dialog"][data-state="open"]'
 
 /**

--- a/src/utils/modalUtil.ts
+++ b/src/utils/modalUtil.ts
@@ -33,6 +33,7 @@ function isDisplayNone(element: Element): boolean {
 function isBlockingModal(element: Element): boolean {
   return (
     element.closest(NON_MODAL_OVERLAY_SELECTOR) === null &&
+    element.closest('[hidden], [aria-hidden="true"]') === null &&
     !isDisplayNone(element)
   )
 }

--- a/src/utils/modalUtil.ts
+++ b/src/utils/modalUtil.ts
@@ -1,19 +1,52 @@
+const ARIA_MODAL_SELECTOR = '[role="dialog"][aria-modal="true"]'
+const REKA_OPEN_DIALOG_SELECTOR = '[role="dialog"][data-state="open"]'
+
+/**
+ * Popovers and dropdowns also render as role="dialog", but they neither trap
+ * focus nor block the page, so they must not suppress global shortcuts.
+ */
+const NON_MODAL_OVERLAY_SELECTOR =
+  '.p-popover, [data-reka-popper-content-wrapper]'
+
+/**
+ * Overlays are commonly hidden by toggling `display` on an ancestor (a mask or
+ * wrapper) while the dialog node itself keeps its own display value, and some
+ * extensions leave that node in the DOM permanently once created.
+ */
+function isDisplayNone(element: Element): boolean {
+  for (
+    let node: Element | null = element;
+    node !== null;
+    node = node.parentElement
+  ) {
+    if (getComputedStyle(node).display === 'none') {
+      return true
+    }
+  }
+  return false
+}
+
+function isBlockingModal(element: Element): boolean {
+  return (
+    element.closest(NON_MODAL_OVERLAY_SELECTOR) === null &&
+    !isDisplayNone(element)
+  )
+}
+
+function hasOpenAriaModal(): boolean {
+  return Array.from(document.querySelectorAll(ARIA_MODAL_SELECTOR)).some(
+    isBlockingModal
+  )
+}
+
 function hasOpenRekaDialog(): boolean {
-  return Array.from(
-    document.querySelectorAll('[role="dialog"][data-state="open"]')
-  ).some(
-    (dialog) => dialog.closest('[data-reka-popper-content-wrapper]') === null
+  return Array.from(document.querySelectorAll(REKA_OPEN_DIALOG_SELECTOR)).some(
+    isBlockingModal
   )
 }
 
 function hasOpenNativeDialog(): boolean {
   return document.querySelector('dialog[open]') !== null
-}
-
-function hasVisibleAriaModal(): boolean {
-  return Array.from(
-    document.querySelectorAll('[role="dialog"][aria-modal="true"]')
-  ).some((dialog) => dialog.closest('[hidden], [aria-hidden="true"]') === null)
 }
 
 /** ComfyDialog toggles visibility via inline display ('flex' / 'none'). */
@@ -28,7 +61,7 @@ function hasVisibleLegacyModal(): boolean {
 export function isModalOpen(managedDialogCount: number): boolean {
   return (
     managedDialogCount > 0 ||
-    hasVisibleAriaModal() ||
+    hasOpenAriaModal() ||
     hasOpenRekaDialog() ||
     hasOpenNativeDialog() ||
     hasVisibleLegacyModal()

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -816,6 +816,10 @@ export default defineConfig({
   },
 
   test: {
+    // `.storybook/main.ts` aliases this so `.storybook/preview.ts` can pull in
+    // the website's global stylesheet. Tests that mount portable stories have
+    // to load that same preview, so they need the alias too.
+    alias: { '@comfyorg/website': '/apps/website' },
     mockReset: true,
     restoreMocks: true,
     unstubEnvs: true,


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

*PR Created by the Glary-Bot Agent*

Follow-up to the point raised in #bug-dump: when #12184 added the "is a modal open?" gate, it should have come with coverage across the app's dialog surfaces — and that omission is why #15639 went unnoticed.

**Stacked on #15455** (base branch `glary/ctrl-s-modal-gate`), because the PrimeVue Popover case asserts the behaviour that PR establishes. GitHub will retarget to `main` when #15455 merges.

## Summary

`isModalOpen` recognises overlays by their rendered markup, so hand-written DOM fixtures only ever test it against what their author *believed* the components emit. That is exactly how #15639 happened: nobody knew a PrimeVue `Popover` announces `aria-modal="true"`.

This mounts the real components instead — the dialog stories, plus the overlay flavours no story reaches — and pins whether each must suppress global shortcuts.

Doing that immediately found a live instance of the same bug, fixed in the first commit.

## Changes

**`fix:` unstyled PrimeVue popovers still gated shortcuts.** #15455's deny-list matches `.p-popover`, but **10 of the 15 `primevue/popover` call sites pass `unstyled`**, which renders `role="dialog" aria-modal="true"` with no theme class on the node. Ctrl+S was still a silent no-op behind a MoreButton menu, the canvas-mode selector, a job context menu or a node-widget dropdown. Matching `data-pc-name="popover"` as well fixes it — PrimeVue's base component emits that attribute in both modes (`@primevue/core/basecomponent`: `_getPTDatasets` has no `isUnstyled` check, `_getPTClassValue` returns `undefined` when unstyled).

**`test:` `modalUtil.overlays.test.ts`.** 12 surfaces, each mounted for real and asserted against the gate:

| Surface | Suppresses shortcuts |
| --- | --- |
| MoreButton menu (PrimeVue Popover, one layer down) | no |
| Reka Dialog | yes |
| Colour picker (Reka Popover) | no |
| Media lightbox (hand-written ARIA modal) | yes |
| PrimeVue Dialog | yes |
| Native `<dialog>` | yes |
| ComfyDialog, open / closed | yes / no |
| Job details panel, bare BaseModalLayout, bare AssetBrowserModal, asset browser behind its own scrim | no |

Every case also has to name something the surface put on screen. Most expect the gate to stay *open*, so without that a surface which quietly stopped rendering would keep passing — which is how the Reka popover case was written before it had to prove itself.

## How future surfaces are covered

Not by listing stories. Story names do not reveal overlays: `MoreButton`, `ColorPicker` and `MediaLightbox` all mount one without saying so, and `MoreButton` — a PrimeVue Popover reached through one component — is the exact shape that produced #15639.

Instead the guard scans component sources, reduces every overlay in `src/` to the *vocabulary* it composes, and fails on any vocabulary no case classifies. The gate reads attributes each library emits unconditionally, so classifying the vocabulary classifies every component built on it. Sibling vocabularies (`primevue/drawer`, `primevue/confirmdialog`, Reka `AlertDialog`) are pre-registered so adopting one trips the guard:

```
AssertionError: expected [ Array(1) ] to deeply equal []
+   "PrimeVue Drawer - add a case to overlayCases",
```

A wholly new overlay *library* would not trip it. That is the limit of a source scan, it is stated in the file, and it arrives as a `package.json` change rather than silently.

## Validation

Browser A/B against a real backend, opening the canvas-mode selector (an `unstyled` popover) and pressing Ctrl+S:

| | popover markup | Ctrl+S prevented | workflow save dialog |
| --- | --- | --- | --- |
| without the selector fix | `data-pc-name="popover"`, no `.p-popover` | `true` | **no** |
| with the fix | same | `true` | **yes** |

The MoreButton case fails against the base commit and passes here, so the suite provably exercises the fix. Removing the `native dialog`, `hand-written ARIA modal` or `legacy ComfyDialog` classifications makes the guard name each one.

`pnpm test:unit` 1193 files / 16430 tests green; `typecheck`, `eslint`, `oxlint --type-aware`, `oxfmt`, `knip` clean.

## Screenshots

Canvas-mode popover open (bottom right) in both runs; the only difference is whether Ctrl+S produced the save dialog.


## Screenshots

![Without the fix: the canvas-mode popover (Select/Hand) is open at bottom right and Ctrl+S produced nothing](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/3c455cdd7f83e16ca7027833e290135f31edd6328562816dbb646d6dccd4e2ca/pr-images/1787205220226-2262ca66-fcb4-4712-9fd1-c9ec6c4a4955.png)

![With the fix: the same popover is open at bottom right and Ctrl+S opened ComfyUI's Save workflow dialog](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/3c455cdd7f83e16ca7027833e290135f31edd6328562816dbb646d6dccd4e2ca/pr-images/1787205220552-9e4fc455-302b-42c3-9cf0-70ab86558949.png)