### PR TITLE
test: cover the dialog chrome contract in Playwright

### DIFF
--- a/browser_tests/fixtures/ComfyPage.ts
+++ b/browser_tests/fixtures/ComfyPage.ts
@@ -29,7 +29,6 @@ import { ComfyNodeSearchBox } from '@e2e/fixtures/components/ComfyNodeSearchBox'
 import { ComfyNodeSearchBoxV2 } from '@e2e/fixtures/components/ComfyNodeSearchBoxV2'
 import { ConfirmDialog } from '@e2e/fixtures/components/ConfirmDialog'
 import { ContextMenu } from '@e2e/fixtures/components/ContextMenu'
-import { DialogChrome } from '@e2e/fixtures/components/DialogChrome'
 import { MediaLightbox } from '@e2e/fixtures/components/MediaLightbox'
 import { QueuePanel } from '@e2e/fixtures/components/QueuePanel'
 import { SettingDialog } from '@e2e/fixtures/components/SettingDialog'
@@ -185,7 +184,6 @@ export class ComfyPage {
   public readonly templates: ComfyTemplates
   public readonly settingDialog: SettingDialog
   public readonly confirmDialog: ConfirmDialog
-  public readonly dialogChrome: DialogChrome
   public readonly templatesDialog: TemplatesDialog
   public readonly titleEditor: TitleEditor
   public readonly mediaLightbox: MediaLightbox
@@ -243,7 +241,6 @@ export class ComfyPage {
     this.templates = new ComfyTemplates(page)
     this.settingDialog = new SettingDialog(page, this)
     this.confirmDialog = new ConfirmDialog(page)
-    this.dialogChrome = new DialogChrome(page)
     this.templatesDialog = new TemplatesDialog(page)
     this.titleEditor = new TitleEditor(page)
     this.mediaLightbox = new MediaLightbox(page)

--- a/browser_tests/fixtures/ComfyPage.ts
+++ b/browser_tests/fixtures/ComfyPage.ts
@@ -29,6 +29,7 @@ import { ComfyNodeSearchBox } from '@e2e/fixtures/components/ComfyNodeSearchBox'
 import { ComfyNodeSearchBoxV2 } from '@e2e/fixtures/components/ComfyNodeSearchBoxV2'
 import { ConfirmDialog } from '@e2e/fixtures/components/ConfirmDialog'
 import { ContextMenu } from '@e2e/fixtures/components/ContextMenu'
+import { DialogChrome } from '@e2e/fixtures/components/DialogChrome'
 import { MediaLightbox } from '@e2e/fixtures/components/MediaLightbox'
 import { QueuePanel } from '@e2e/fixtures/components/QueuePanel'
 import { SettingDialog } from '@e2e/fixtures/components/SettingDialog'
@@ -184,6 +185,7 @@ export class ComfyPage {
   public readonly templates: ComfyTemplates
   public readonly settingDialog: SettingDialog
   public readonly confirmDialog: ConfirmDialog
+  public readonly dialogChrome: DialogChrome
   public readonly templatesDialog: TemplatesDialog
   public readonly titleEditor: TitleEditor
   public readonly mediaLightbox: MediaLightbox
@@ -241,6 +243,7 @@ export class ComfyPage {
     this.templates = new ComfyTemplates(page)
     this.settingDialog = new SettingDialog(page, this)
     this.confirmDialog = new ConfirmDialog(page)
+    this.dialogChrome = new DialogChrome(page)
     this.templatesDialog = new TemplatesDialog(page)
     this.titleEditor = new TitleEditor(page)
     this.mediaLightbox = new MediaLightbox(page)

--- a/browser_tests/fixtures/components/DialogChrome.ts
+++ b/browser_tests/fixtures/components/DialogChrome.ts
@@ -1,0 +1,85 @@
+import type { Locator, Page } from '@playwright/test'
+
+import { TestIds } from '@e2e/fixtures/selectors'
+
+/**
+ * The chrome shared by every dialog rendered through `GlobalDialog` — focus
+ * handling, escape dismissal, stacking and modality — as opposed to any single
+ * dialog's content. Dialogs are opened through the real `dialogService` API so
+ * the chrome under test is the one users get.
+ */
+export class DialogChrome {
+  readonly dialogs: Locator
+  readonly overlays: Locator
+
+  constructor(public readonly page: Page) {
+    this.dialogs = page.getByRole('dialog')
+    this.overlays = page.getByTestId(TestIds.dialogs.overlay)
+  }
+
+  /**
+   * Opens the core prompt dialog, whose text input carries `autofocus` — the
+   * attribute `GlobalDialog` honors in place of Reka's first-tabbable default.
+   */
+  async openPrompt(message = 'Dialog chrome prompt'): Promise<void> {
+    await this.openViaService((msg) => {
+      void window
+        .app!.extensionManager.dialog.prompt({
+          title: 'Dialog chrome',
+          message: msg,
+          defaultValue: ''
+        })
+        .catch(() => {})
+    }, message)
+  }
+
+  async openConfirm(message = 'Dialog chrome confirm'): Promise<void> {
+    await this.openViaService((msg) => {
+      void window
+        .app!.extensionManager.dialog.confirm({
+          title: 'Dialog chrome',
+          type: 'default',
+          message: msg
+        })
+        .catch(() => {})
+    }, message)
+  }
+
+  async isFocusInside(container: Locator): Promise<boolean> {
+    return container.evaluate((el) => el.contains(document.activeElement))
+  }
+
+  /**
+   * Whether the page behind the dialog is pointer-inert. Reka's modal mode
+   * disables body pointer events; the non-modal container dialogs (Settings,
+   * Manager) deliberately leave the page interactive so the nested PrimeVue
+   * dialogs they host keep working.
+   */
+  async isPageInert(): Promise<boolean> {
+    return this.page.evaluate(
+      () => document.body.style.pointerEvents === 'none'
+    )
+  }
+
+  async stackingOrder(): Promise<number[]> {
+    return this.dialogs.evaluateAll((els) =>
+      els.map((el) => Number(getComputedStyle(el).zIndex))
+    )
+  }
+
+  /** Dialog-store key of each open dialog, rendered by `GlobalDialog` as `aria-labelledby`. */
+  async openDialogKeys(): Promise<(string | null)[]> {
+    return this.dialogs.evaluateAll((els) =>
+      els.map((el) => el.getAttribute('aria-labelledby'))
+    )
+  }
+
+  private async openViaService(
+    show: (message: string) => void,
+    message: string
+  ): Promise<void> {
+    const before = await this.dialogs.count()
+    await this.page.evaluate(show, message)
+    await this.dialogs.nth(before).waitFor({ state: 'visible' })
+  }
+}

--- a/browser_tests/fixtures/dialogChromeFixture.ts
+++ b/browser_tests/fixtures/dialogChromeFixture.ts
@@ -1,0 +1,11 @@
+import { test as base } from '@playwright/test'
+
+import { DialogChrome } from '@e2e/fixtures/components/DialogChrome'
+
+export const dialogChromeFixture = base.extend<{
+  dialogChrome: DialogChrome
+}>({
+  dialogChrome: async ({ page }, use) => {
+    await use(new DialogChrome(page))
+  }
+})

--- a/browser_tests/fixtures/selectors.ts
+++ b/browser_tests/fixtures/selectors.ts
@@ -36,6 +36,7 @@ export const TestIds = {
     zoomPercentageInput: 'zoom-percentage-input'
   },
   dialogs: {
+    overlay: 'dialog-overlay',
     settings: 'settings-dialog',
     settingsContainer: 'settings-container',
     settingsTabAbout: 'settings-tab-about',

--- a/browser_tests/tests/dialogs/dialogChrome.spec.ts
+++ b/browser_tests/tests/dialogs/dialogChrome.spec.ts
@@ -1,7 +1,10 @@
-import { expect } from '@playwright/test'
+import { expect, mergeTests } from '@playwright/test'
 
-import { comfyPageFixture as test } from '@e2e/fixtures/ComfyPage'
+import { comfyPageFixture } from '@e2e/fixtures/ComfyPage'
+import { dialogChromeFixture } from '@e2e/fixtures/dialogChromeFixture'
 import { TestIds } from '@e2e/fixtures/selectors'
+
+const test = mergeTests(comfyPageFixture, dialogChromeFixture)
 
 /**
  * Contract shared by every dialog rendered through `GlobalDialog`, exercised
@@ -11,13 +14,13 @@ import { TestIds } from '@e2e/fixtures/selectors'
  */
 test.describe('Dialog chrome', { tag: '@ui' }, () => {
   test('moves focus onto the content autofocus target when opened', async ({
-    comfyPage
+    comfyPage,
+    dialogChrome
   }) => {
-    const chrome = comfyPage.dialogChrome
+    await expect(comfyPage.canvas).toBeVisible()
+    await dialogChrome.openPrompt()
 
-    await chrome.openPrompt()
-
-    const dialog = chrome.dialogs
+    const dialog = dialogChrome.dialogs
     await expect(dialog).toBeVisible()
     await expect(
       dialog.locator('input[autofocus]'),
@@ -25,54 +28,60 @@ test.describe('Dialog chrome', { tag: '@ui' }, () => {
     ).toBeFocused()
   })
 
-  test('keeps Tab focus inside a modal dialog', async ({ comfyPage }) => {
-    const chrome = comfyPage.dialogChrome
-    await chrome.openPrompt()
-    const dialog = chrome.dialogs
+  test('keeps Tab focus inside a modal dialog', async ({
+    comfyPage,
+    dialogChrome
+  }) => {
+    await dialogChrome.openPrompt()
+    const dialog = dialogChrome.dialogs
     await expect(dialog).toBeVisible()
 
+    // Containment must hold after every press, so this asserts immediately
+    // rather than polling — polling would let a transient escape recover
+    // unnoticed, which is the regression the test exists to catch. Reka's
+    // FocusScope handles Tab synchronously, so there is no race to lose.
     for (let press = 1; press <= 6; press++) {
       await comfyPage.page.keyboard.press('Tab')
       expect(
-        await chrome.isFocusInside(dialog),
+        await dialogChrome.isFocusInside(dialog),
         `focus escaped the modal dialog after ${press} Tab press(es)`
       ).toBe(true)
     }
   })
 
   test('makes the page pointer-inert while a modal dialog is open', async ({
-    comfyPage
+    comfyPage,
+    dialogChrome
   }) => {
-    const chrome = comfyPage.dialogChrome
-    expect(await chrome.isPageInert()).toBe(false)
+    expect(await dialogChrome.isPageInert()).toBe(false)
 
-    await chrome.openPrompt()
-    await expect(chrome.dialogs).toBeVisible()
-    await expect.poll(() => chrome.isPageInert()).toBe(true)
+    await dialogChrome.openPrompt()
+    await expect(dialogChrome.dialogs).toBeVisible()
+    await expect.poll(() => dialogChrome.isPageInert()).toBe(true)
 
     await comfyPage.page.keyboard.press('Escape')
-    await expect(chrome.dialogs).toBeHidden()
+    await expect(dialogChrome.dialogs).toBeHidden()
     await expect
-      .poll(() => chrome.isPageInert(), {
+      .poll(() => dialogChrome.isPageInert(), {
         message: 'page stayed inert after the modal dialog closed'
       })
       .toBe(false)
   })
 
-  test('restores focus to the invoking element when closed', async ({
-    comfyPage
+  test('restores focus to the previously focused element when closed', async ({
+    comfyPage,
+    dialogChrome
   }) => {
-    const chrome = comfyPage.dialogChrome
     const settingsButton = comfyPage.page
       .getByTestId(TestIds.sidebar.toolbar)
       .getByRole('button', { name: /^Settings/ })
     await settingsButton.focus()
     await expect(settingsButton).toBeFocused()
 
-    await chrome.openConfirm()
-    await expect(chrome.dialogs).toBeVisible()
+    await dialogChrome.openConfirm()
+    await expect(dialogChrome.dialogs).toBeVisible()
     await comfyPage.page.keyboard.press('Escape')
-    await expect(chrome.dialogs).toBeHidden()
+    await expect(dialogChrome.dialogs).toBeHidden()
 
     await expect(
       settingsButton,
@@ -80,32 +89,40 @@ test.describe('Dialog chrome', { tag: '@ui' }, () => {
     ).toBeFocused()
   })
 
-  test('closes only the top-most dialog on Escape', async ({ comfyPage }) => {
-    const chrome = comfyPage.dialogChrome
+  test('closes only the top-most dialog on Escape', async ({
+    comfyPage,
+    dialogChrome
+  }) => {
     await comfyPage.settingDialog.open()
-    await chrome.openConfirm()
+    await dialogChrome.openConfirm()
 
-    await expect(chrome.dialogs).toHaveCount(2)
+    await expect(dialogChrome.dialogs).toHaveCount(2)
 
     await comfyPage.page.keyboard.press('Escape')
 
-    await expect(chrome.dialogs).toHaveCount(1)
+    await expect(dialogChrome.dialogs).toHaveCount(1)
     expect(
-      await chrome.openDialogKeys(),
+      await dialogChrome.openDialogKeys(),
       'Escape dismissed the container dialog instead of only the top-most one'
     ).toEqual(['global-settings'])
 
     await comfyPage.page.keyboard.press('Escape')
-    await expect(chrome.dialogs).toHaveCount(0)
+    await expect(dialogChrome.dialogs).toHaveCount(0)
   })
 
-  test('stacks a later dialog above an earlier one', async ({ comfyPage }) => {
-    const chrome = comfyPage.dialogChrome
+  test('stacks a later dialog above an earlier one', async ({
+    comfyPage,
+    dialogChrome
+  }) => {
     await comfyPage.settingDialog.open()
-    await chrome.openConfirm()
-    await expect(chrome.dialogs).toHaveCount(2)
+    await dialogChrome.openConfirm()
+    await expect(dialogChrome.dialogs).toHaveCount(2)
+    await expect(
+      dialogChrome.overlays,
+      'each stacked dialog renders its own scrim'
+    ).toHaveCount(2)
 
-    const [lower, upper] = await chrome.stackingOrder()
+    const [lower, upper] = await dialogChrome.stackingOrder()
     expect(
       upper,
       'the dialog opened last must render above the one opened first'
@@ -113,15 +130,14 @@ test.describe('Dialog chrome', { tag: '@ui' }, () => {
   })
 
   test('leaves the page interactive for a non-modal container dialog', async ({
-    comfyPage
+    comfyPage,
+    dialogChrome
   }) => {
-    const chrome = comfyPage.dialogChrome
-
     await comfyPage.settingDialog.open()
     await expect(comfyPage.settingDialog.root).toBeVisible()
 
     expect(
-      await chrome.isPageInert(),
+      await dialogChrome.isPageInert(),
       'Settings is non-modal so that the nested PrimeVue dialogs it hosts keep pointer events'
     ).toBe(false)
   })
@@ -148,14 +164,18 @@ test.describe('Dialog chrome', { tag: '@ui' }, () => {
       if ((await select.getAttribute('aria-expanded')) !== 'true')
         await select.click()
       await expect(select).toHaveAttribute('aria-expanded', 'true')
-    }).toPass({ timeout: 20_000 })
+    }).toPass({ timeout: 10_000 })
 
     await expect(
       settings.root,
       'opening a body-portaled PrimeVue overlay must not read as an outside interaction'
     ).toBeVisible()
 
-    await comfyPage.page.getByRole('option').first().click()
+    // Re-selecting the current value keeps the assertion about the overlay
+    // interaction rather than about changing a persisted setting.
+    await comfyPage.page
+      .getByRole('option', { name: 'Top', exact: true })
+      .click()
 
     await expect(
       settings.root,

--- a/browser_tests/tests/dialogs/dialogChrome.spec.ts
+++ b/browser_tests/tests/dialogs/dialogChrome.spec.ts
@@ -1,0 +1,165 @@
+import { expect } from '@playwright/test'
+
+import { comfyPageFixture as test } from '@e2e/fixtures/ComfyPage'
+import { TestIds } from '@e2e/fixtures/selectors'
+
+/**
+ * Contract shared by every dialog rendered through `GlobalDialog`, exercised
+ * against the core prompt/confirm dialogs and Settings. The behaviours here —
+ * real focus movement, real stacking order, real pointer inertness — are the
+ * ones jsdom cannot observe, so they are only meaningful in a browser.
+ */
+test.describe('Dialog chrome', { tag: '@ui' }, () => {
+  test('moves focus onto the content autofocus target when opened', async ({
+    comfyPage
+  }) => {
+    const chrome = comfyPage.dialogChrome
+
+    await chrome.openPrompt()
+
+    const dialog = chrome.dialogs
+    await expect(dialog).toBeVisible()
+    await expect(
+      dialog.locator('input[autofocus]'),
+      'GlobalDialog focuses the [autofocus] target instead of the first tabbable element'
+    ).toBeFocused()
+  })
+
+  test('keeps Tab focus inside a modal dialog', async ({ comfyPage }) => {
+    const chrome = comfyPage.dialogChrome
+    await chrome.openPrompt()
+    const dialog = chrome.dialogs
+    await expect(dialog).toBeVisible()
+
+    for (let press = 1; press <= 6; press++) {
+      await comfyPage.page.keyboard.press('Tab')
+      expect(
+        await chrome.isFocusInside(dialog),
+        `focus escaped the modal dialog after ${press} Tab press(es)`
+      ).toBe(true)
+    }
+  })
+
+  test('makes the page pointer-inert while a modal dialog is open', async ({
+    comfyPage
+  }) => {
+    const chrome = comfyPage.dialogChrome
+    expect(await chrome.isPageInert()).toBe(false)
+
+    await chrome.openPrompt()
+    await expect(chrome.dialogs).toBeVisible()
+    await expect.poll(() => chrome.isPageInert()).toBe(true)
+
+    await comfyPage.page.keyboard.press('Escape')
+    await expect(chrome.dialogs).toBeHidden()
+    await expect
+      .poll(() => chrome.isPageInert(), {
+        message: 'page stayed inert after the modal dialog closed'
+      })
+      .toBe(false)
+  })
+
+  test('restores focus to the invoking element when closed', async ({
+    comfyPage
+  }) => {
+    const chrome = comfyPage.dialogChrome
+    const settingsButton = comfyPage.page
+      .getByTestId(TestIds.sidebar.toolbar)
+      .getByRole('button', { name: /^Settings/ })
+    await settingsButton.focus()
+    await expect(settingsButton).toBeFocused()
+
+    await chrome.openConfirm()
+    await expect(chrome.dialogs).toBeVisible()
+    await comfyPage.page.keyboard.press('Escape')
+    await expect(chrome.dialogs).toBeHidden()
+
+    await expect(
+      settingsButton,
+      'focus must return to the element that was focused before the dialog opened'
+    ).toBeFocused()
+  })
+
+  test('closes only the top-most dialog on Escape', async ({ comfyPage }) => {
+    const chrome = comfyPage.dialogChrome
+    await comfyPage.settingDialog.open()
+    await chrome.openConfirm()
+
+    await expect(chrome.dialogs).toHaveCount(2)
+
+    await comfyPage.page.keyboard.press('Escape')
+
+    await expect(chrome.dialogs).toHaveCount(1)
+    expect(
+      await chrome.openDialogKeys(),
+      'Escape dismissed the container dialog instead of only the top-most one'
+    ).toEqual(['global-settings'])
+
+    await comfyPage.page.keyboard.press('Escape')
+    await expect(chrome.dialogs).toHaveCount(0)
+  })
+
+  test('stacks a later dialog above an earlier one', async ({ comfyPage }) => {
+    const chrome = comfyPage.dialogChrome
+    await comfyPage.settingDialog.open()
+    await chrome.openConfirm()
+    await expect(chrome.dialogs).toHaveCount(2)
+
+    const [lower, upper] = await chrome.stackingOrder()
+    expect(
+      upper,
+      'the dialog opened last must render above the one opened first'
+    ).toBeGreaterThan(lower)
+  })
+
+  test('leaves the page interactive for a non-modal container dialog', async ({
+    comfyPage
+  }) => {
+    const chrome = comfyPage.dialogChrome
+
+    await comfyPage.settingDialog.open()
+    await expect(comfyPage.settingDialog.root).toBeVisible()
+
+    expect(
+      await chrome.isPageInert(),
+      'Settings is non-modal so that the nested PrimeVue dialogs it hosts keep pointer events'
+    ).toBe(false)
+  })
+
+  test('stays open while a PrimeVue overlay inside it is used', async ({
+    comfyPage
+  }) => {
+    const settings = comfyPage.settingDialog
+    await settings.open()
+    await settings.searchBox.fill('Use new menu')
+
+    const settingRow = settings.root.locator(
+      '[data-setting-id="Comfy.UseNewMenu"]'
+    )
+    await expect(settingRow).toBeVisible()
+
+    const select = settingRow.getByRole('combobox')
+    await expect(select).toBeVisible()
+    await expect(select).toBeEnabled()
+
+    // PrimeVue re-renders the filtered settings list, replacing the combobox
+    // element, so the first click can land on a stale node.
+    await expect(async () => {
+      if ((await select.getAttribute('aria-expanded')) !== 'true')
+        await select.click()
+      await expect(select).toHaveAttribute('aria-expanded', 'true')
+    }).toPass({ timeout: 20_000 })
+
+    await expect(
+      settings.root,
+      'opening a body-portaled PrimeVue overlay must not read as an outside interaction'
+    ).toBeVisible()
+
+    await comfyPage.page.getByRole('option').first().click()
+
+    await expect(
+      settings.root,
+      'clicking inside a body-portaled PrimeVue overlay must not dismiss the dialog'
+    ).toBeVisible()
+  })
+})


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

## Summary

Every dialog rendered through `GlobalDialog` shares a chrome contract — focus handling, escape dismissal, stacking and modality — that has **no browser-level coverage**. It is exercised only by Vitest, which cannot observe real focus movement, real stacking order, or real pointer inertness.

Adds `browser_tests/tests/dialogs/dialogChrome.spec.ts` (8 tests) plus a `DialogChrome` page object registered as a Playwright fixture per `browser_tests/README.md`.

## Coverage added

| Test | Contract it pins |
|---|---|
| moves focus onto the content autofocus target | `GlobalDialog.onRekaOpenAutoFocus` overriding Reka's first-tabbable default |
| keeps Tab focus inside a modal dialog | Reka `FocusScope` containment |
| makes the page pointer-inert while a modal dialog is open | modal contract, and that inertness is released on close |
| restores focus to the previously focused element when closed | focus recovery on dismiss |
| closes only the top-most dialog on Escape | escape routing across a stack |
| stacks a later dialog above an earlier one | `vRekaZIndex` ordering, plus one scrim per dialog |
| leaves the page interactive for a non-modal container dialog | Settings' `modal: false`, which the nested PrimeVue dialogs it hosts depend on |
| stays open while a PrimeVue overlay inside it is used | `rekaPrimeVueBridge` treating body-portaled overlays as inside |

Dialogs are driven through the real `dialogService` API, so the chrome under test is the one users get. **No application source is touched.**

## Verification

- 8/8 green; `--repeat-each=3` → 24/24, no flakes
- `pnpm lint`, `pnpm typecheck`, `pnpm format:check`, `pnpm knip` clean
- Regression sample (`settingsDialog`, `queueClearHistory`) 15/15 green
- **Mutation-tested for non-vacuity:** disabling `onRekaOpenAutoFocus` turns the autofocus test red; forcing `closeOnEscape: false` turns the escape-stacking test red

## Notes for reviewers

Two behaviours were deliberately **not** asserted, because observed behaviour contradicts the prop names and I did not want to cement possibly-unintended semantics:

1. **Backdrop click does not dismiss Reka dialogs**, regardless of `dismissableMask: true`. Verified this is not caused by `rekaPrimeVueBridge` — the scrim matches none of its selectors. `dismissableMask` looks inert on the Reka path and is worth a separate look.
2. **Modal dialogs render no `aria-modal`.** `role="dialog"` and `aria-labelledby` are present; `aria-modal` is absent — an a11y gap given `.agents/checks/accessibility.md` explicitly covers modal semantics.

Also noted: `dialogStore.updateCloseOnEscapeStates()`'s `dialog === topDialog` clause is redundant on the Reka path (Reka's layer stack already scopes Escape to the top layer). It still matters for the legacy PrimeVue branch, exactly as its docstring says, so it is left alone.

Part of a dialog E2E coverage audit; sibling PRs cover spec retagging and reorganisation.