### PR TITLE
feat: expose slot topology migration API

### DIFF
--- a/docs/extensions/README.md
+++ b/docs/extensions/README.md
@@ -18,6 +18,7 @@ Extensions are the primary way to add functionality to ComfyUI. They can be cust
   - Best practices for extension development
 - **[Node ID Migration Notes](./node-id-migration.md)** - Compatibility guidance for branded node IDs and subgraph boundary sentinel values
 - **[Link Registration Migration Notes](./link-registration-migration.md)** - Guidance for handling defensive floating-link registration failures
+- **[Slot Topology Migration](./slot-topology-migration.md)** - Replace direct `input.link` / `output.links` access with topology APIs
 
 ## Quick Links
 

--- a/docs/extensions/link-registration-migration.md
+++ b/docs/extensions/link-registration-migration.md
@@ -1,5 +1,8 @@
 # Link Registration Migration Notes
 
+For migration from direct `input.link` / `output.links` access, see
+[Slot topology migration](./slot-topology-migration.md).
+
 `LinkNetwork.addFloatingLink(link)` now returns `LLink | undefined`.
 
 For a new runtime link, pass the unassigned link id and use the returned link:

--- a/docs/extensions/slot-topology-migration.md
+++ b/docs/extensions/slot-topology-migration.md
@@ -1,0 +1,56 @@
+# Slot Topology Migration
+
+`linkStore` owns live graph connectivity. The legacy `input.link` and
+`output.links` properties are read-only projections: writes warn and have no
+effect, and `output.links` returns a frozen snapshot.
+
+## API mapping
+
+| Legacy operation                        | Replacement                                                    |
+| --------------------------------------- | -------------------------------------------------------------- |
+| `node.inputs[slot].link = null`         | `node.disconnectInput(slot)`                                   |
+| `node.outputs[slot].links = []`         | `node.disconnectOutput(slot)`                                  |
+| `node.outputs[slot].links.length = 0`   | `node.disconnectOutput(slot)`                                  |
+| `node.outputs[slot].links.push(linkId)` | `node.connect(slot, targetNode, targetSlot)`                   |
+| Remove every output link                | `node.disconnectOutput(slot)`                                  |
+| Remove links to one target              | `node.disconnectOutput(slot, targetNode)`                      |
+| Read the input link                     | `node.getInputLink(slot)`                                      |
+| Check connectivity                      | `node.isInputConnected(slot)` / `node.isOutputConnected(slot)` |
+| Enumerate output links                  | `outputLinks(node.graph, node.id, slot)`                       |
+
+Import `outputLinks` from the public app module:
+
+```ts
+import { outputLinks } from '../../scripts/app.js'
+
+if (!node.graph) return
+for (const link of outputLinks(node.graph, node.id, outputSlot)) {
+  const target = node.graph.getNodeById(link.target_id)
+  // Use link.target_slot and target as needed.
+}
+```
+
+`outputLinks()` returns link objects, not the link IDs exposed by the legacy
+mirror. Use `link.id` when an ID is required.
+
+Do not translate a link ID push into a direct store insertion. `connect()`
+coordinates input replacement, reroutes, graph versioning, veto hooks, and
+`onConnectionsChange` callbacks. Likewise, use `disconnectInput()` or
+`disconnectOutput()` instead of deleting IDs from a mirror array.
+
+## Tests and fixtures
+
+Tests should build a real graph and use the same topology APIs as production:
+
+```ts
+graph.add(source)
+graph.add(target)
+source.connect(sourceSlot, target, targetSlot)
+
+target.disconnectInput(targetSlot)
+source.disconnectOutput(sourceSlot)
+```
+
+Avoid mocks that simulate `connect()` by assigning `input.link`. Such mocks no
+longer model application behavior and can pass while production connectivity
+is unchanged.

--- a/src/lib/litegraph/src/litegraph.ts
+++ b/src/lib/litegraph/src/litegraph.ts
@@ -123,6 +123,7 @@ export {
   registerNodeState,
   unregisterNodeState
 } from './LGraphNode'
+export { outputLinks } from './node/slotLinks'
 export { LLink } from './LLink'
 export { createBounds } from './measure'
 export { Reroute, type RerouteId } from './Reroute'

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -21,7 +21,9 @@ import {
   LGraphNode,
   LiteGraph
 } from '@/lib/litegraph/src/litegraph'
+import type { LLink } from '@/lib/litegraph/src/LLink'
 import { snapPoint } from '@/lib/litegraph/src/measure'
+import { outputLinks as readOutputLinks } from '@/lib/litegraph/src/node/slotLinks'
 import type { Vector2 } from '@/lib/litegraph/src/litegraph'
 import type {
   IBaseWidget,
@@ -196,6 +198,14 @@ export function sanitizeNodeName(string: string) {
   return String(string).replace(/[&<>"'`=]/g, function fromEntityMap(s) {
     return entityMap[s as keyof typeof entityMap]
   })
+}
+
+export function outputLinks(
+  graph: LGraph,
+  nodeId: LGraphNode['id'],
+  slot: number
+): LLink[] {
+  return readOutputLinks(graph, nodeId, slot)
 }
 
 function syncPromotedComboHostOptions(rootGraph: LGraph): void {


### PR DESCRIPTION
## Summary

Expose store-backed output-link enumeration to extensions and document command-based migration from writable slot mirrors.

## Changes

- **What**: Export `outputLinks` through the public `scripts/app.js` shim and document connect/disconnect/read mappings.
- **Breaking**: Direct `input.link` and `output.links` writes remain warning-only no-ops by design.

## Review Focus

Confirm the public helper boundary and migration mappings cover extension topology use cases without restoring writable mirrors.