### PR TITLE
feat(maskeditor): add output mask opacity

### DIFF
--- a/src/components/maskeditor/ImageLayerSettingsPanel.test.ts
+++ b/src/components/maskeditor/ImageLayerSettingsPanel.test.ts
@@ -21,7 +21,9 @@ const initialMock = () =>
     maskCanvas: null as HTMLCanvasElement | null,
     rgbCanvas: null as HTMLCanvasElement | null,
     imgCanvas: null as HTMLCanvasElement | null,
-    setMaskOpacity: vi.fn()
+    setMaskOpacity: vi.fn(),
+    maskOutputOpacity: 1,
+    setMaskOutputOpacity: vi.fn()
   })
 
 let mockStore: ReturnType<typeof initialMock>
@@ -41,7 +43,7 @@ vi.mock('@/components/maskeditor/controls/SliderControl.vue', () => ({
     name: 'SliderControlStub',
     props: ['label', 'min', 'max', 'step', 'modelValue'],
     emits: ['update:modelValue'],
-    template: `<button data-slider="true" @click="$emit('update:modelValue', 0.3)">{{ modelValue }}</button>`
+    template: `<button :data-slider="label" @click="$emit('update:modelValue', 0.3)">{{ label }}: {{ modelValue }}</button>`
   }
 }))
 
@@ -53,6 +55,7 @@ const i18n = createI18n({
       maskEditor: {
         layers: 'Layers',
         maskOpacity: 'Mask Opacity',
+        maskOutputOpacity: 'Output Mask Opacity',
         maskBlendingOptions: 'Mask Blending Options',
         black: 'Black',
         white: 'White',
@@ -88,7 +91,7 @@ describe('ImageLayerSettingsPanel', () => {
       const { container } = renderPanel()
 
       await user.click(
-        container.querySelector('[data-slider="true"]') as HTMLElement
+        container.querySelector('[data-slider="Mask Opacity"]') as HTMLElement
       )
 
       expect(mockStore.setMaskOpacity).toHaveBeenCalledWith(0.3)
@@ -101,11 +104,30 @@ describe('ImageLayerSettingsPanel', () => {
 
       await expect(
         user.click(
-          container.querySelector('[data-slider="true"]') as HTMLElement
+          container.querySelector('[data-slider="Mask Opacity"]') as HTMLElement
         )
       ).resolves.not.toThrow()
 
       expect(mockStore.setMaskOpacity).toHaveBeenCalledWith(0.3)
+    })
+  })
+
+  describe('output mask opacity slider', () => {
+    it('should update output opacity without changing preview opacity', async () => {
+      const user = userEvent.setup()
+      const canvas = makeCanvas()
+      mockStore.maskCanvas = canvas
+      const { container } = renderPanel()
+
+      await user.click(
+        container.querySelector(
+          '[data-slider="Output Mask Opacity"]'
+        ) as HTMLElement
+      )
+
+      expect(mockStore.setMaskOutputOpacity).toHaveBeenCalledWith(0.3)
+      expect(mockStore.setMaskOpacity).not.toHaveBeenCalled()
+      expect(canvas.style.opacity).toBe('')
     })
   })
 

--- a/src/components/maskeditor/ImageLayerSettingsPanel.vue
+++ b/src/components/maskeditor/ImageLayerSettingsPanel.vue
@@ -13,6 +13,15 @@
       @update:model-value="onMaskOpacityChange"
     />
 
+    <SliderControl
+      :label="t('maskEditor.maskOutputOpacity')"
+      :min="0"
+      :max="1"
+      :step="0.01"
+      :model-value="store.maskOutputOpacity"
+      @update:model-value="store.setMaskOutputOpacity"
+    />
+
     <span class="text-left font-sans text-xs text-(--descrip-text)">{{
       t('maskEditor.maskBlendingOptions')
     }}</span>

--- a/src/composables/maskeditor/useMaskEditorSaver.test.ts
+++ b/src/composables/maskeditor/useMaskEditorSaver.test.ts
@@ -73,10 +73,11 @@ function createMockCanvas(seed?: Uint8ClampedArray): HTMLCanvasElement {
   return canvas
 }
 
-const mockEditorStore: Record<string, HTMLCanvasElement | null> = {
+const mockEditorStore: Record<string, HTMLCanvasElement | number | null> = {
   maskCanvas: null,
   rgbCanvas: null,
-  imgCanvas: null
+  imgCanvas: null,
+  maskOutputOpacity: 1
 }
 
 vi.mock('@/stores/maskEditorStore', () => ({
@@ -146,6 +147,7 @@ describe('useMaskEditorSaver', () => {
     mockEditorStore.maskCanvas = createMockCanvas()
     mockEditorStore.rgbCanvas = createMockCanvas()
     mockEditorStore.imgCanvas = createMockCanvas()
+    mockEditorStore.maskOutputOpacity = 1
 
     vi.mocked(api.fetchApi).mockResolvedValue({
       ok: true,
@@ -222,7 +224,7 @@ describe('useMaskEditorSaver', () => {
     expect(body.get('subfolder')).toBeNull()
   })
 
-  it('uploads masked layers with inverted mask alpha and preserved RGB', async () => {
+  it('uploads masked layers with inverted, output-scaled alpha and preserved RGB', async () => {
     // Seed a distinct opaque color per pixel, mask the first half of the
     // canvas, then decode the uploaded blobs and verify both the applied
     // alpha and that the RGB survives where the alpha is 0 (the pixels a
@@ -241,6 +243,7 @@ describe('useMaskEditorSaver', () => {
     mockEditorStore.imgCanvas = createMockCanvas(imgPixels)
     mockEditorStore.maskCanvas = createMockCanvas(maskPixels)
     mockEditorStore.rgbCanvas = createMockCanvas()
+    mockEditorStore.maskOutputOpacity = 0.5
 
     const fetchApiMock = vi.mocked(api.fetchApi)
     const { save } = useMaskEditorSaver()
@@ -263,7 +266,7 @@ describe('useMaskEditorSaver', () => {
       expect(width).toBe(CANVAS_SIZE)
       expect(height).toBe(CANVAS_SIZE)
       for (let i = 0; i < pixels.length; i += 4) {
-        expect(pixels[i + 3]).toBe(255 - maskPixels[i + 3])
+        expect(pixels[i + 3]).toBe(255 - Math.round(maskPixels[i + 3] * 0.5))
         expect(pixels[i]).toBe(imgPixels[i])
         expect(pixels[i + 1]).toBe(imgPixels[i + 1])
         expect(pixels[i + 2]).toBe(imgPixels[i + 2])

--- a/src/composables/maskeditor/useMaskEditorSaver.ts
+++ b/src/composables/maskeditor/useMaskEditorSaver.ts
@@ -76,14 +76,20 @@ export function useMaskEditorSaver() {
 
     const [maskedImage, paintLayer, paintedImage, paintedMaskedImage] =
       await Promise.all([
-        createMaskedImage(imgCanvas, maskCanvas, filenames.maskedImage),
+        createMaskedImage(
+          imgCanvas,
+          maskCanvas,
+          filenames.maskedImage,
+          editorStore.maskOutputOpacity
+        ),
         createPaintLayer(paintCanvas, filenames.paint),
         createPaintedImage(imgCanvas, paintCanvas, filenames.paintedImage),
         createPaintedMaskedImage(
           imgCanvas,
           paintCanvas,
           maskCanvas,
-          filenames.paintedMaskedImage
+          filenames.paintedMaskedImage,
+          editorStore.maskOutputOpacity
         )
       ])
 
@@ -104,7 +110,8 @@ export function useMaskEditorSaver() {
    */
   function applyMaskAsAlpha(
     ctx: CanvasRenderingContext2D,
-    maskCanvas: HTMLCanvasElement
+    maskCanvas: HTMLCanvasElement,
+    outputOpacity: number
   ): ImageData {
     const maskCtx = maskCanvas.getContext('2d')!
     const maskData = maskCtx.getImageData(
@@ -121,7 +128,8 @@ export function useMaskEditorSaver() {
       ctx.canvas.height
     )
     for (let i = 0; i < imageData.data.length; i += 4) {
-      imageData.data[i + 3] = 255 - maskData.data[i + 3]
+      const scaledMaskAlpha = maskData.data[i + 3] * outputOpacity
+      imageData.data[i + 3] = 255 - Math.round(scaledMaskAlpha)
     }
     ctx.putImageData(imageData, 0, 0)
 
@@ -131,7 +139,8 @@ export function useMaskEditorSaver() {
   async function createMaskedImage(
     imgCanvas: HTMLCanvasElement,
     maskCanvas: HTMLCanvasElement,
-    filename: string
+    filename: string,
+    outputOpacity: number
   ): Promise<EditorOutputLayer> {
     const canvas = document.createElement('canvas')
     canvas.width = imgCanvas.width
@@ -140,7 +149,7 @@ export function useMaskEditorSaver() {
 
     ctx.drawImage(imgCanvas, 0, 0)
 
-    const imageData = applyMaskAsAlpha(ctx, maskCanvas)
+    const imageData = applyMaskAsAlpha(ctx, maskCanvas, outputOpacity)
 
     const blob = await encodeRgbaAsPng(imageData)
     const ref = createFileRef(filename)
@@ -184,7 +193,8 @@ export function useMaskEditorSaver() {
     imgCanvas: HTMLCanvasElement,
     paintCanvas: HTMLCanvasElement,
     maskCanvas: HTMLCanvasElement,
-    filename: string
+    filename: string,
+    outputOpacity: number
   ): Promise<EditorOutputLayer> {
     const canvas = document.createElement('canvas')
     canvas.width = imgCanvas.width
@@ -196,7 +206,7 @@ export function useMaskEditorSaver() {
     ctx.globalCompositeOperation = 'source-over'
     ctx.drawImage(paintCanvas, 0, 0)
 
-    const imageData = applyMaskAsAlpha(ctx, maskCanvas)
+    const imageData = applyMaskAsAlpha(ctx, maskCanvas, outputOpacity)
 
     const blob = await encodeRgbaAsPng(imageData)
     const ref = createFileRef(filename)

--- a/src/locales/.source-manifest.json
+++ b/src/locales/.source-manifest.json
@@ -1,7 +1,7 @@
 {
   "files": {
     "commands.json": "6474557ea9947c6983e84c03b40b75573307717d",
-    "main.json": "b417a114d87667ee8111e6d3c575337bf7adef8f",
+    "main.json": "079ef4e41d55b6ba2641a369aa1d63f7cb5e32f1",
     "nodeDefs.json": "93c778a69bfe43a07e3bf07d1ecfadc26bf44661",
     "settings.json": "1028b58bfb4f3e4f5025cd8d933bd19085c291e3"
   },

--- a/src/locales/ar/main.json
+++ b/src/locales/ar/main.json
@@ -2601,6 +2601,7 @@
     "maskBlendingOptions": "خيارات دمج القناع",
     "maskLayer": "طبقة القناع",
     "maskOpacity": "شفافية القناع",
+    "maskOutputOpacity": "عتامة قناع الإخراج",
     "maskTolerance": "تسامح القناع",
     "method": "طريقة",
     "mirrorHorizontal": "انعكاس أفقي",

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -1393,6 +1393,7 @@
     "layers": "Layers",
     "maskLayer": "Mask Layer",
     "maskOpacity": "Mask Opacity",
+    "maskOutputOpacity": "Output Mask Opacity",
     "imageLayer": "Image Layer",
     "maskBlendingOptions": "Mask Blending Options",
     "paintLayer": "Paint Layer",

--- a/src/locales/es/main.json
+++ b/src/locales/es/main.json
@@ -2601,6 +2601,7 @@
     "maskBlendingOptions": "Opciones de fusión de máscara",
     "maskLayer": "Capa de máscara",
     "maskOpacity": "Opacidad de máscara",
+    "maskOutputOpacity": "Opacidad de la máscara de salida",
     "maskTolerance": "Tolerancia de máscara",
     "method": "Método",
     "mirrorHorizontal": "Espejar horizontalmente",

--- a/src/locales/fa/main.json
+++ b/src/locales/fa/main.json
@@ -2601,6 +2601,7 @@
     "maskBlendingOptions": "گزینه‌های ترکیب ماسک",
     "maskLayer": "لایه ماسک",
     "maskOpacity": "شفافیت ماسک",
+    "maskOutputOpacity": "شفافیت ماسک خروجی",
     "maskTolerance": "تلورانس ماسک",
     "method": "روش",
     "mirrorHorizontal": "آینه افقی",

--- a/src/locales/fr/main.json
+++ b/src/locales/fr/main.json
@@ -2601,6 +2601,7 @@
     "maskBlendingOptions": "Options de fusion du masque",
     "maskLayer": "Calque de masque",
     "maskOpacity": "Opacité du masque",
+    "maskOutputOpacity": "Opacité du masque de sortie",
     "maskTolerance": "Tolérance du masque",
     "method": "Méthode",
     "mirrorHorizontal": "Miroir horizontal",

--- a/src/locales/he/main.json
+++ b/src/locales/he/main.json
@@ -2601,6 +2601,7 @@
     "maskBlendingOptions": "אפשרויות מיזוג המסכה",
     "maskLayer": "שכבת המסכה",
     "maskOpacity": "אטימות המסכה",
+    "maskOutputOpacity": "אטימות מסכת הפלט",
     "maskTolerance": "סובלנות המסכה",
     "method": "שיטה",
     "mirrorHorizontal": "שיקוף אופקי",

--- a/src/locales/it/main.json
+++ b/src/locales/it/main.json
@@ -2601,6 +2601,7 @@
     "maskBlendingOptions": "Opzioni Fusione Maschera",
     "maskLayer": "Livello Maschera",
     "maskOpacity": "Opacità Maschera",
+    "maskOutputOpacity": "Opacità della maschera di output",
     "maskTolerance": "Tolleranza Maschera",
     "method": "Metodo",
     "mirrorHorizontal": "Specchia orizzontalmente",

--- a/src/locales/ja/main.json
+++ b/src/locales/ja/main.json
@@ -2601,6 +2601,7 @@
     "maskBlendingOptions": "マスク合成オプション",
     "maskLayer": "マスクレイヤー",
     "maskOpacity": "マスク不透明度",
+    "maskOutputOpacity": "出力マスクの不透明度",
     "maskTolerance": "マスク許容値",
     "method": "方法",
     "mirrorHorizontal": "左右反転",

--- a/src/locales/ko/main.json
+++ b/src/locales/ko/main.json
@@ -2601,6 +2601,7 @@
     "maskBlendingOptions": "마스크 혼합 옵션",
     "maskLayer": "마스크 레이어",
     "maskOpacity": "마스크 불투명도",
+    "maskOutputOpacity": "출력 마스크 불투명도",
     "maskTolerance": "마스크 허용치",
     "method": "방법",
     "mirrorHorizontal": "수평 반전",

--- a/src/locales/pt-BR/main.json
+++ b/src/locales/pt-BR/main.json
@@ -2601,6 +2601,7 @@
     "maskBlendingOptions": "Opções de mesclagem da máscara",
     "maskLayer": "Camada de máscara",
     "maskOpacity": "Opacidade da máscara",
+    "maskOutputOpacity": "Opacidade da máscara de saída",
     "maskTolerance": "Tolerância da máscara",
     "method": "Método",
     "mirrorHorizontal": "Espelhar horizontalmente",

--- a/src/locales/ru/main.json
+++ b/src/locales/ru/main.json
@@ -2601,6 +2601,7 @@
     "maskBlendingOptions": "Параметры смешивания маски",
     "maskLayer": "Слой маски",
     "maskOpacity": "Непрозрачность маски",
+    "maskOutputOpacity": "Непрозрачность выходной маски",
     "maskTolerance": "Допуск маски",
     "method": "Метод",
     "mirrorHorizontal": "Отразить по горизонтали",

--- a/src/locales/tr/main.json
+++ b/src/locales/tr/main.json
@@ -2601,6 +2601,7 @@
     "maskBlendingOptions": "Maske Karıştırma Seçenekleri",
     "maskLayer": "Maske Katmanı",
     "maskOpacity": "Maske Opaklığı",
+    "maskOutputOpacity": "Çıkış maskesi opaklığı",
     "maskTolerance": "Maske Toleransı",
     "method": "Yöntem",
     "mirrorHorizontal": "Yatay ayna",

--- a/src/locales/zh-TW/main.json
+++ b/src/locales/zh-TW/main.json
@@ -2601,6 +2601,7 @@
     "maskBlendingOptions": "遮罩混合選項",
     "maskLayer": "遮罩圖層",
     "maskOpacity": "遮罩不透明度",
+    "maskOutputOpacity": "輸出遮罩不透明度",
     "maskTolerance": "遮罩容差",
     "method": "方法",
     "mirrorHorizontal": "水平鏡像",

--- a/src/locales/zh/main.json
+++ b/src/locales/zh/main.json
@@ -2601,6 +2601,7 @@
     "maskBlendingOptions": "遮罩混合设置",
     "maskLayer": "遮罩层",
     "maskOpacity": "遮罩不透明度",
+    "maskOutputOpacity": "输出遮罩不透明度",
     "maskTolerance": "遮罩阈值",
     "method": "方法",
     "mirrorHorizontal": "水平翻转",

--- a/src/stores/maskEditorStore.test.ts
+++ b/src/stores/maskEditorStore.test.ts
@@ -148,6 +148,14 @@ describe('maskEditorStore', () => {
       expect(store.maskOpacity).toBe(1)
     })
 
+    it('should clamp maskOutputOpacity between 0 and 1', () => {
+      const store = useMaskEditorStore()
+      store.setMaskOutputOpacity(-0.5)
+      expect(store.maskOutputOpacity).toBe(0)
+      store.setMaskOutputOpacity(2)
+      expect(store.maskOutputOpacity).toBe(1)
+    })
+
     it('should clamp zoomRatio between 0.1 and 10', () => {
       const store = useMaskEditorStore()
       store.setZoomRatio(0.001)
@@ -316,6 +324,7 @@ describe('maskEditorStore', () => {
       store.setPanOffset({ x: 10, y: 20 })
       store.setCursorPoint({ x: 5, y: 5 })
       store.setMaskOpacity(0.2)
+      store.setMaskOutputOpacity(0.2)
       store.gpuTexturesNeedRecreation = true
       store.gpuTextureWidth = 100
       store.gpuTextureHeight = 200
@@ -347,6 +356,7 @@ describe('maskEditorStore', () => {
       expect(store.panOffset).toEqual({ x: 0, y: 0 })
       expect(store.cursorPoint).toEqual({ x: 0, y: 0 })
       expect(store.maskOpacity).toBe(0.8)
+      expect(store.maskOutputOpacity).toBe(1)
       expect(store.gpuTexturesNeedRecreation).toBe(false)
       expect(store.gpuTextureWidth).toBe(0)
       expect(store.gpuTextureHeight).toBe(0)

--- a/src/stores/maskEditorStore.ts
+++ b/src/stores/maskEditorStore.ts
@@ -65,6 +65,7 @@ export const useMaskEditorStore = defineStore('maskEditor', () => {
   const image = ref<HTMLImageElement | null>(null)
 
   const maskOpacity = ref<number>(0.8)
+  const maskOutputOpacity = ref<number>(1)
 
   const brushVisible = ref<boolean>(true)
   const isPanning = ref<boolean>(false)
@@ -198,6 +199,10 @@ export const useMaskEditorStore = defineStore('maskEditor', () => {
     maskOpacity.value = clamp(opacity, 0, 1)
   }
 
+  function setMaskOutputOpacity(opacity: number): void {
+    maskOutputOpacity.value = clamp(opacity, 0, 1)
+  }
+
   function resetState(): void {
     brushSettings.value = {
       type: BrushShape.Arc,
@@ -224,6 +229,7 @@ export const useMaskEditorStore = defineStore('maskEditor', () => {
     panOffset.value = { x: 0, y: 0 }
     cursorPoint.value = { x: 0, y: 0 }
     maskOpacity.value = 0.8
+    maskOutputOpacity.value = 1
 
     // Reset GPU recreation flags
     gpuTexturesNeedRecreation.value = false
@@ -265,6 +271,7 @@ export const useMaskEditorStore = defineStore('maskEditor', () => {
     pointerZone,
     image,
     maskOpacity,
+    maskOutputOpacity,
     canUndo,
     canRedo,
     maskColor,
@@ -303,6 +310,7 @@ export const useMaskEditorStore = defineStore('maskEditor', () => {
     triggerClear,
     clearTrigger,
     setMaskOpacity,
+    setMaskOutputOpacity,
     resetState
   }
 })


### PR DESCRIPTION
## Summary
- Add an **Output Mask Opacity** control independently of the existing preview-only mask opacity.
- Store, clamp, and reset the new output strength in the mask-editor state.
- Scale mask alpha before inverting it into image alpha for both saved masked layers:
  - the original image plus mask;
  - the painted image plus mask.
- Preserve original RGB data and keep the editor's visual preview opacity unchanged.
- Add the new label across all supported locales and advance the locale source manifest.

At `1.0` output is unchanged; lower values proportionally reduce mask alpha so more of the original image is preserved.

Fixes #15399.

## Tests
- Added state coverage for clamping and reset behavior.
- Added UI coverage proving the output slider does not modify the preview-only mask opacity or canvas style.
- Extended the save/compositing regression to decode uploaded PNGs and verify 50%-scaled inverted alpha while RGB remains preserved.

Validation:
- `pnpm exec vitest run src/stores/maskEditorStore.test.ts src/components/maskeditor/ImageLayerSettingsPanel.test.ts src/composables/maskeditor/useMaskEditorSaver.test.ts` — 52 passed
- `pnpm exec vue-tsc --noEmit` — passed
- Targeted ESLint — passed
- Targeted type-aware Oxlint — passed
- `pnpm locale:check` — passes; only the pre-existing pending translation set remains, with no new key pending
- `pnpm exec oxfmt --check <changed TS/Vue files>` — passed
- `git diff --check` — passed