### PR TITLE
fix: restore own node collection fields

### DIFF
--- a/src/lib/litegraph/src/LGraphNode.nodeState.test.ts
+++ b/src/lib/litegraph/src/LGraphNode.nodeState.test.ts
@@ -59,6 +59,64 @@ describe('LGraphNode node-data adoption', () => {
     expect(statesIn(subgraph)[0]?.flags.collapsed).toBe(true)
   })
 
+  it('exposes enumerable own collection fields without replacing their views', () => {
+    const { node } = addNodeToSubgraph()
+    node.addWidget('text', 'prompt', '', () => undefined)
+    const inputs = node.inputs
+    const outputs = node.outputs
+    const widgets = node.widgets
+
+    node.inputs = []
+    node.outputs = []
+    node.widgets = [...widgets!]
+
+    expect(Object.hasOwn(node, 'inputs')).toBe(true)
+    expect(Object.hasOwn(node, 'outputs')).toBe(true)
+    expect(Object.hasOwn(node, 'widgets')).toBe(true)
+    expect(Object.keys(node)).toEqual(
+      expect.arrayContaining(['inputs', 'outputs', 'widgets'])
+    )
+    expect(node.inputs).toBe(inputs)
+    expect(node.outputs).toBe(outputs)
+    expect(node.widgets).toBe(widgets)
+  })
+
+  it('lets translation hooks persist slot labels', () => {
+    const node = new LGraphNode('Node')
+    const input = node.addInput('prompt', 'STRING')
+    input.widget = { name: 'prompt' }
+    node.addOutput('result', 'STRING')
+    node.addWidget('text', 'prompt', '', () => undefined)
+
+    const translations: Record<
+      'inputs' | 'outputs' | 'widgets',
+      Record<string, string>
+    > = {
+      inputs: { prompt: 'Translated prompt' },
+      outputs: { result: 'Translated result' },
+      widgets: { prompt: 'Translated prompt' }
+    }
+    for (const key of ['inputs', 'outputs', 'widgets'] as const) {
+      if (!Object.hasOwn(node, key)) continue
+      for (const item of node[key] ?? []) {
+        const label = translations[key][item.name]
+        if (label) item.label = label
+      }
+    }
+
+    const serialised = node.serialize()
+    expect(serialised.inputs?.[0].label).toBe('Translated prompt')
+    expect(serialised.outputs?.[0].label).toBe('Translated result')
+
+    const restored = new LGraphNode('Node')
+    const restoredInput = restored.addInput('prompt', 'STRING')
+    restoredInput.widget = { name: 'prompt' }
+    restored.addOutput('result', 'STRING')
+    restored.addWidget('text', 'prompt', '', () => undefined)
+    restored.configure(serialised)
+    expect(restored.widgets?.[0].label).toBe('Translated prompt')
+  })
+
   it('vacates its store entry on remove', () => {
     const { subgraph, node } = addNodeToSubgraph()
 

--- a/src/lib/litegraph/src/LGraphNode.ts
+++ b/src/lib/litegraph/src/LGraphNode.ts
@@ -1027,6 +1027,12 @@ export class LGraphNode
       type: type ?? '',
       titleMode: this.title_mode
     }
+    for (const property of ['inputs', 'outputs'] as const) {
+      Object.defineProperty(this, property, {
+        ...Object.getOwnPropertyDescriptor(LGraphNode.prototype, property),
+        enumerable: true
+      })
+    }
     this.size = [LiteGraph.NODE_WIDTH, 60]
     this.pos = [10, 10]
     this.strokeStyles = {


### PR DESCRIPTION
## Summary

Restore enumerable own collection fields expected by translation-pack node hooks while retaining ECS-backed collection identities.

## Changes

- **What**: Install own forwarding accessors for `inputs` and `outputs`; `widgets` remains the existing own forwarding view.
- Add regressions for own-property checks, `Object.keys(node)`, stable array identities, and translated label serialization.

## Review Focus

Confirm the own descriptors preserve store-backed arrays and restore compatibility with translation hooks that gate on `node.hasOwnProperty(key)`.