### PR TITLE
fix(website): point the Seedance try-workflows CTA at its hub page

### DIFF
--- a/apps/website/e2e/seedance.spec.ts
+++ b/apps/website/e2e/seedance.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test'
 
-import { externalLinks, getRoutes } from '../src/config/routes'
+import { getRoutes } from '../src/config/routes'
 import { creatorReviews } from '../src/data/creatorReviews'
 import { seedancePage } from '../src/data/seedance'
 import { t } from '../src/i18n/translations'
@@ -20,7 +20,10 @@ const HERO_PRIMARY_CTA: ModelLaunchCta | undefined =
 if (!HERO_PRIMARY_CTA)
   throw new Error('seedancePage must configure a hero primary CTA')
 const SEEDANCE_RUN: string = HERO_PRIMARY_CTA.href
-const CLOUD_WORKFLOWS_HUB = externalLinks.workflows
+// The hub's Seedance family page, which lists the shipped 2.5 workflows. The
+// CTA used to open the hub root, leaving the reader to find the model they had
+// just read about.
+const SEEDANCE_HUB_PAGE: string = seedancePage.hero.secondaryCta?.href ?? ''
 const PROMPT_CTA = t('seedance.hero.promptCta', 'en')
 const COPY_PROMPT = t('modelLaunch.copyPrompt', 'en')
 // `faq` is optional on the template (Wan Animate 2 ships without one), but
@@ -106,7 +109,9 @@ test.describe('Seedance 2.5 page — link targets', () => {
     await expect(primary).toHaveAttribute('href', /video_wan2_2/)
   })
 
-  test('the hero run CTA opens the same Cloud workflow', async ({ page }) => {
+  test('the hero CTAs open Cloud to run and the hub to browse', async ({
+    page
+  }) => {
     const hero = page.locator('section').filter({
       has: page.getByRole('heading', { level: 1, name: HERO_TITLE })
     })
@@ -116,7 +121,10 @@ test.describe('Seedance 2.5 page — link targets', () => {
 
     await expect(
       hero.getByRole('link', { name: t('seedance.hero.secondaryCta', 'en') })
-    ).toHaveAttribute('href', CLOUD_WORKFLOWS_HUB)
+    ).toHaveAttribute('href', SEEDANCE_HUB_PAGE)
+    await expect(
+      hero.getByRole('link', { name: t('seedance.hero.secondaryCta', 'en') })
+    ).toHaveAttribute('href', /\/workflows\/model\/seedance$/)
   })
 
   test('renders one step card per configured step', async ({ page }) => {

--- a/apps/website/src/data/seedance.test.ts
+++ b/apps/website/src/data/seedance.test.ts
@@ -30,6 +30,25 @@ function pageCopy(locale: Locale): { label: string; text: string }[] {
   ]
 }
 
+describe('seedance 2.5 workflow links', () => {
+  it('sends "try workflows" to the Seedance family page, not the hub root', () => {
+    // The hub root makes the reader search for the model they just read about.
+    // The family page lists the shipped 2.5 workflows, which is what the launch
+    // playbook asks the page to link, and matches what /ltx-2.5 already does.
+    expect(seedancePage.hero.secondaryCta?.href).toBe(
+      'https://comfy.org/workflows/model/seedance'
+    )
+  })
+
+  it('keeps the run CTAs on Cloud, which is a separate deliberate choice', () => {
+    // Reference-to-video on Cloud is the "run it" path chosen for this launch;
+    // linking the hub instead would undo that, so it is pinned here.
+    expect(seedancePage.hero.primaryCta.href).toContain(
+      'cloud.comfy.org/?template=api_seedance2_5_r2v'
+    )
+  })
+})
+
 describe('seedance 2.5 landing copy', () => {
   // Offenders are collected rather than asserted one by one so a failure names
   // every surface that has to change.

--- a/apps/website/src/data/seedance.test.ts
+++ b/apps/website/src/data/seedance.test.ts
@@ -47,6 +47,15 @@ describe('seedance 2.5 workflow links', () => {
       'cloud.comfy.org/?template=api_seedance2_5_r2v'
     )
   })
+
+  it('keeps the draft CTA on a template that costs nothing to run', () => {
+    // The step above this CTA promises "zero credits" in both locales, so it
+    // has to open a Cloud template that is not an `api_` one; those bill per
+    // render.
+    expect(seedancePage.steps?.primaryCta?.href).toMatch(
+      /cloud\.comfy\.org\/\?template=(?!api_)/
+    )
+  })
 })
 
 describe('seedance 2.5 landing copy', () => {

--- a/apps/website/src/data/seedance.test.ts
+++ b/apps/website/src/data/seedance.test.ts
@@ -43,7 +43,7 @@ describe('seedance 2.5 workflow links', () => {
   it('keeps the run CTAs on Cloud, which is a separate deliberate choice', () => {
     // Reference-to-video on Cloud is the "run it" path chosen for this launch;
     // linking the hub instead would undo that, so it is pinned here.
-    expect(seedancePage.hero.primaryCta.href).toContain(
+    expect(seedancePage.hero.primaryCta?.href).toContain(
       'cloud.comfy.org/?template=api_seedance2_5_r2v'
     )
   })

--- a/apps/website/src/data/seedance.ts
+++ b/apps/website/src/data/seedance.ts
@@ -10,7 +10,12 @@ import { externalLinks } from '../config/routes'
 // section points at Wan 2.2 instead, which is open source and costs nothing.
 const seedanceLinks = {
   cloudRun: 'https://cloud.comfy.org/?template=api_seedance2_5_r2v',
-  freeDraft: 'https://cloud.comfy.org/?template=video_wan2_2_14B_t2v'
+  freeDraft: 'https://cloud.comfy.org/?template=video_wan2_2_14B_t2v',
+  // The hub's Seedance family page, which lists the shipped 2.5 workflows
+  // (text to video, reference to video, first-last frame and the rest). The
+  // "try workflows" CTA pointed at the hub root, which makes the reader find
+  // them, the same fix /ltx-2.5 already carries.
+  hubModel: `${externalLinks.workflows}/model/seedance`
 } as const
 
 // Seedance 2.5 renders, encoded to the site's web video profile (VP9 webm,
@@ -196,7 +201,7 @@ export const seedancePage: ModelLaunchPage = {
     },
     secondaryCta: {
       labelKey: 'seedance.hero.secondaryCta',
-      href: externalLinks.workflows,
+      href: seedanceLinks.hubModel,
       target: '_blank'
     }
   },


### PR DESCRIPTION
Part of GTM-289. The Seedance launch page has a "try workflows" CTA that opens the **hub root**, so a reader who just spent a page reading about Seedance 2.5 has to go and find it among 600 workflows.

It now opens the hub's Seedance family page, which lists the shipped 2.5 workflows (text to video, reference to video, first-last frame and the rest). I verified live that the page surfaces them: `Seedance 2.5: Text to Video` and `Seedance 2.5: Reference to Video` both appear on it.

This is the same field, pointed the same way, that `/ltx-2.5` already uses (`ltxLinks.hubModel`).

## What is deliberately unchanged

The run CTAs still open reference-to-video on Cloud. That was chosen for this launch, and the data file says so in a comment, so I pinned it with a test rather than leave the next person wondering whether the two links should match.

## Verified

Rendered link present on both `/seedance-2.5/` and `/zh-CN/seedance-2.5/` in a real build. 442 unit tests passing, two new. Lint and format clean via the repo's own oxlint/oxfmt.

## Still open on GTM-289, not in this PR

The launch playbook also asks for a section listing ~3 individual workflows with their own cards. The model-launch template has no section type for that today, so it would mean a new template section plus new copy in two locales, which is design input rather than a link fix. Worth doing, worth scoping with @nav first.

Separately, none of the seven Seedance 2.5 workflows is flagged as an App yet (all return `is_app: false` from the cloud API), which is the other half of the ticket and belongs with Deep/Purz.
