### PR TITLE
Fix: Resolve P0 marketing SEO issues (Sitemap Noindex & FAQ Schema)

### DIFF
--- a/apps/website/astro.config.ts
+++ b/apps/website/astro.config.ts
@@ -3,44 +3,10 @@ import mdx from '@astrojs/mdx'
 import sitemap from '@astrojs/sitemap'
 import vue from '@astrojs/vue'
 import tailwindcss from '@tailwindcss/vite'
+import { isExcludedFromSitemap } from './src/config/indexing'
 
 const LOCALES = ['en', 'zh-CN'] as const
 const DEFAULT_LOCALE = 'en'
-const PAYMENT_STATUSES = ['success', 'failed'] as const
-const LOCALE_PREFIXES = LOCALES.map((locale) =>
-  locale === DEFAULT_LOCALE ? '' : `/${locale}`
-)
-const EXCLUDED_MODELS = [
-  'qwen-3-8b',
-  'mistral-3-small-flux2-fp8',
-  'gemma-2-2b-it-elm-fp8-scaled',
-  'gemma-3-12b-it-fp8-scaled',
-  'gemma-3-12b-it',
-  'grok-image',
-  'qwen-2-5-vl-7b',
-  'umt5-xxl-fp16',
-  'qwen-image-2512-bf16',
-  't5xxl-fp8-e4m3fn-scaled'
-]
-
-const SITEMAP_EXCLUDED_PATHNAMES = new Set([
-  ...LOCALE_PREFIXES.flatMap((prefix) =>
-    PAYMENT_STATUSES.map((status) => `${prefix}/payment/${status}`)
-  ),
-  ...LOCALE_PREFIXES.map((prefix) => `${prefix}/individual-submission`),
-  ...LOCALE_PREFIXES.map((prefix) => `${prefix}/booking-confirmation`),
-  ...LOCALE_PREFIXES.map((prefix) => `${prefix}/privacy-policy`),
-  ...LOCALE_PREFIXES.map((prefix) => `${prefix}/terms-of-service`),
-  ...EXCLUDED_MODELS.flatMap((model) =>
-    LOCALE_PREFIXES.map((prefix) => `${prefix}/p/supported-models/${model}`)
-  )
-])
-
-function isExcludedFromSitemap(page: string): boolean {
-  const pathname = new URL(page).pathname.replace(/\/$/, '')
-  return SITEMAP_EXCLUDED_PATHNAMES.has(pathname)
-}
-
 export default defineConfig({
   site: 'https://comfy.org',
   output: 'static',

--- a/apps/website/astro.config.ts
+++ b/apps/website/astro.config.ts
@@ -10,12 +10,30 @@ const PAYMENT_STATUSES = ['success', 'failed'] as const
 const LOCALE_PREFIXES = LOCALES.map((locale) =>
   locale === DEFAULT_LOCALE ? '' : `/${locale}`
 )
+const EXCLUDED_MODELS = [
+  'qwen-3-8b',
+  'mistral-3-small-flux2-fp8',
+  'gemma-2-2b-it-elm-fp8-scaled',
+  'gemma-3-12b-it-fp8-scaled',
+  'gemma-3-12b-it',
+  'grok-image',
+  'qwen-2-5-vl-7b',
+  'umt5-xxl-fp16',
+  'qwen-image-2512-bf16',
+  't5xxl-fp8-e4m3fn-scaled'
+]
+
 const SITEMAP_EXCLUDED_PATHNAMES = new Set([
   ...LOCALE_PREFIXES.flatMap((prefix) =>
     PAYMENT_STATUSES.map((status) => `${prefix}/payment/${status}`)
   ),
   ...LOCALE_PREFIXES.map((prefix) => `${prefix}/individual-submission`),
-  ...LOCALE_PREFIXES.map((prefix) => `${prefix}/booking-confirmation`)
+  ...LOCALE_PREFIXES.map((prefix) => `${prefix}/booking-confirmation`),
+  ...LOCALE_PREFIXES.map((prefix) => `${prefix}/privacy-policy`),
+  ...LOCALE_PREFIXES.map((prefix) => `${prefix}/terms-of-service`),
+  ...EXCLUDED_MODELS.flatMap((model) =>
+    LOCALE_PREFIXES.map((prefix) => `${prefix}/p/supported-models/${model}`)
+  )
 ])
 
 function isExcludedFromSitemap(page: string): boolean {

--- a/apps/website/src/config/indexing.test.ts
+++ b/apps/website/src/config/indexing.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+import { isExcludedFromSitemap, isNoindexPathname } from './indexing'
+
+describe('indexing policy', () => {
+  it.for([
+    '/privacy-policy',
+    '/privacy-policy/',
+    '/zh-CN/privacy-policy',
+    '/terms-of-service',
+    '/zh-CN/terms-of-service/',
+    '/payment/success',
+    '/zh-CN/payment/failed/',
+    '/individual-submission',
+    '/zh-CN/booking-confirmation/'
+  ])('marks %s as noindex', (pathname) => {
+    expect(isNoindexPathname(pathname)).toBe(true)
+    expect(isExcludedFromSitemap(`https://comfy.org${pathname}`)).toBe(true)
+  })
+
+  it.for(['/privacy', '/cloud/pricing', '/p/supported-models/grok-imagine'])(
+    'keeps %s indexable',
+    (pathname) => {
+      expect(isNoindexPathname(pathname)).toBe(false)
+      expect(isExcludedFromSitemap(`https://comfy.org${pathname}`)).toBe(false)
+    }
+  )
+
+  it('derives model redirect exclusions from canonical model metadata', () => {
+    expect(
+      isExcludedFromSitemap('https://comfy.org/p/supported-models/qwen-3-8b/')
+    ).toBe(true)
+    expect(
+      isExcludedFromSitemap(
+        'https://comfy.org/zh-CN/p/supported-models/grok-image/'
+      )
+    ).toBe(true)
+  })
+})

--- a/apps/website/src/config/indexing.ts
+++ b/apps/website/src/config/indexing.ts
@@ -1,0 +1,44 @@
+import { models } from './models'
+
+const LOCALES = ['en', 'zh-CN'] as const
+const DEFAULT_LOCALE = 'en'
+const PAYMENT_STATUSES = ['success', 'failed'] as const
+
+const LOCALE_PREFIXES = LOCALES.map((locale) =>
+  locale === DEFAULT_LOCALE ? '' : `/${locale}`
+)
+
+const NOINDEX_PATHNAMES = new Set([
+  ...LOCALE_PREFIXES.flatMap((prefix) =>
+    PAYMENT_STATUSES.map((status) => `${prefix}/payment/${status}`)
+  ),
+  ...LOCALE_PREFIXES.map((prefix) => `${prefix}/individual-submission`),
+  ...LOCALE_PREFIXES.map((prefix) => `${prefix}/booking-confirmation`),
+  ...LOCALE_PREFIXES.map((prefix) => `${prefix}/privacy-policy`),
+  ...LOCALE_PREFIXES.map((prefix) => `${prefix}/terms-of-service`)
+])
+
+const MODEL_REDIRECT_PATHNAMES = new Set(
+  models
+    .filter((model) => model.canonicalSlug !== undefined)
+    .flatMap((model) =>
+      LOCALE_PREFIXES.map(
+        (prefix) => `${prefix}/p/supported-models/${model.slug}`
+      )
+    )
+)
+
+function normalizePathname(pathname: string): string {
+  return pathname.replace(/\/$/, '')
+}
+
+export function isNoindexPathname(pathname: string): boolean {
+  return NOINDEX_PATHNAMES.has(normalizePathname(pathname))
+}
+
+export function isExcludedFromSitemap(page: string): boolean {
+  const pathname = normalizePathname(new URL(page).pathname)
+  return (
+    NOINDEX_PATHNAMES.has(pathname) || MODEL_REDIRECT_PATHNAMES.has(pathname)
+  )
+}

--- a/apps/website/src/config/models.ts
+++ b/apps/website/src/config/models.ts
@@ -16,7 +16,7 @@ type ModelDirectory =
   | 'style_models'
   | 'partner_nodes'
 
-interface Model {
+export interface Model {
   readonly slug: string
   readonly canonicalSlug?: string
   readonly name: string

--- a/apps/website/src/layouts/BaseLayout.astro
+++ b/apps/website/src/layouts/BaseLayout.astro
@@ -6,6 +6,7 @@ import SiteFooter from '../components/common/SiteFooter.vue'
 import HeaderMain from '../components/common/HeaderMain/HeaderMain.vue'
 import AnnouncementBanner from '../templates/drops/AnnouncementBanner.vue'
 import { bannerConfig, getBannerData } from '../config/banner'
+import { isNoindexPathname } from '../config/indexing'
 import { isHrefActive } from '../composables/useCurrentPath'
 import {
   BANNER_DISMISS_ATTR,
@@ -50,6 +51,7 @@ const { siteUrl, locale, url } = pageContext(
   Astro.currentLocale,
 )
 const canonicalURL = new URL(url)
+const shouldNoindex = noindex || isNoindexPathname(Astro.url.pathname)
 const ogImageURL = new URL(ogImage, Astro.site ?? 'https://comfy.org')
 const rawStars = await fetchGitHubStars('Comfy-Org', 'ComfyUI')
 const githubStars = rawStars ? formatStarCount(rawStars) : ''
@@ -69,7 +71,7 @@ const bannerVersion = createBannerVersion(bannerData, locale)
 const gtmId = 'GTM-NP9JM6K7'
 const gtmEnabled = import.meta.env.PROD
 
-const structuredData = noindex
+const structuredData = shouldNoindex
   ? undefined
   : buildPageGraph(
       { siteUrl, locale },
@@ -98,7 +100,7 @@ const structuredData = noindex
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="description" content={description} />
     {keywordsContent && <meta name="keywords" content={keywordsContent} />}
-    {noindex && <meta name="robots" content="noindex, nofollow" />}
+    {shouldNoindex && <meta name="robots" content="noindex, nofollow" />}
     <title>{title}</title>
 
     <link rel="icon" type="image/png" href="/favicon-96x96.png" sizes="96x96" />

--- a/apps/website/src/pages/p/supported-models/[slug].astro
+++ b/apps/website/src/pages/p/supported-models/[slug].astro
@@ -11,6 +11,11 @@ import {
   pageContext,
   softwareApplicationNode,
 } from '../../../utils/jsonLd'
+import {
+  getWhatIsDescription,
+  getPageDescription,
+  getFaqPricingAnswer,
+} from '../../../utils/modelSeoCopy'
 
 export const getStaticPaths: GetStaticPaths = () => {
   return models.map((model) => ({
@@ -44,10 +49,10 @@ const dirDescriptions: Record<string, string> = {
 }
 
 const dirDesc = dirDescriptions[model.directory] ?? 'an AI model'
-const whatIsDescription = `${displayName} is ${dirDesc}. You can run it locally in ComfyUI with full control over every parameter, or access it through Comfy Cloud. ComfyUI's node-based workflow editor lets you connect ${displayName} with ControlNets, LoRAs, upscalers, and custom nodes to build any pipeline you need. There are ${model.workflowCount} community workflow templates using ${displayName} on Comfy Workflows, ready to load and customize.`
+const whatIsDescription = getWhatIsDescription(model, dirDesc)
 
 const pageTitle = `${displayName} in ComfyUI`
-const pageDescription = `Run ${displayName} in ComfyUI with full parameter control. ${model.workflowCount} community workflow templates, step-by-step tutorials, and free local inference.`
+const pageDescription = getPageDescription(model)
 
 const { siteUrl, locale, url } = pageContext(
   Astro.site,
@@ -95,10 +100,7 @@ const faqPage: JsonLdNode = {
       name: `Is ${displayName} free to use in ComfyUI?`,
       acceptedAnswer: {
         '@type': 'Answer',
-        text:
-          model.directory === 'partner_nodes' && !model.huggingFaceUrl
-            ? `This model runs exclusively on Comfy Cloud. Pay-per-compute pricing applies - see comfy.org/cloud/pricing`
-            : `ComfyUI is free and open source. ${model.huggingFaceUrl ? `${displayName} weights are available to download from Hugging Face.` : `${displayName} is available as a cloud API through Comfy Cloud.`} You only pay for compute when running on Comfy Cloud; local inference on your own hardware is always free.`,
+        text: getFaqPricingAnswer(model),
       },
     },
   ],

--- a/apps/website/src/pages/p/supported-models/[slug].astro
+++ b/apps/website/src/pages/p/supported-models/[slug].astro
@@ -95,7 +95,10 @@ const faqPage: JsonLdNode = {
       name: `Is ${displayName} free to use in ComfyUI?`,
       acceptedAnswer: {
         '@type': 'Answer',
-        text: `ComfyUI is free and open source. ${model.huggingFaceUrl ? `${displayName} weights are available to download from Hugging Face.` : `${displayName} is available as a cloud API through Comfy Cloud.`} You only pay for compute when running on Comfy Cloud; local inference on your own hardware is always free.`,
+        text:
+          model.directory === 'partner_nodes' && !model.huggingFaceUrl
+            ? `This model runs exclusively on Comfy Cloud. Pay-per-compute pricing applies - see comfy.org/cloud/pricing`
+            : `ComfyUI is free and open source. ${model.huggingFaceUrl ? `${displayName} weights are available to download from Hugging Face.` : `${displayName} is available as a cloud API through Comfy Cloud.`} You only pay for compute when running on Comfy Cloud; local inference on your own hardware is always free.`,
       },
     },
   ],

--- a/apps/website/src/utils/modelSeoCopy.test.ts
+++ b/apps/website/src/utils/modelSeoCopy.test.ts
@@ -103,13 +103,10 @@ describe('modelSeoCopy', () => {
       expect(ans).not.toContain('local inference')
     })
 
-    it('returns cloud API and local inference copy for standard models without HF URLs', () => {
+    it('returns cloud-only copy for standard models without HF URLs', () => {
       const ans = getFaqPricingAnswer(standardCloudApi)
-      expect(ans).toContain('ComfyUI is free and open source')
-      expect(ans).toContain('is available as a cloud API through Comfy Cloud')
-      expect(ans).toContain(
-        'local inference on your own hardware is always free'
-      )
+      expect(ans).toContain('exclusively on Comfy Cloud')
+      expect(ans).not.toContain('local inference')
     })
   })
 })

--- a/apps/website/src/utils/modelSeoCopy.test.ts
+++ b/apps/website/src/utils/modelSeoCopy.test.ts
@@ -1,0 +1,96 @@
+// @vitest-environment happy-dom
+import { describe, it, expect } from 'vitest'
+import {
+  getWhatIsDescription,
+  getPageDescription,
+  getFaqPricingAnswer
+} from './modelSeoCopy'
+import type { Model } from '../config/models'
+
+describe('modelSeoCopy', () => {
+  const localModel: Model = {
+    slug: 'local-model',
+    name: 'local_model',
+    displayName: 'Local Model',
+    directory: 'diffusion_models',
+    huggingFaceUrl: 'https://huggingface.co/local',
+    featured: false,
+    workflowCount: 10
+  }
+
+  const partnerWithHF: Model = {
+    slug: 'partner-hf',
+    name: 'partner_hf',
+    displayName: 'Partner HF',
+    directory: 'partner_nodes',
+    huggingFaceUrl: 'https://huggingface.co/partner',
+    featured: false,
+    workflowCount: 5
+  }
+
+  const partnerCloudOnly: Model = {
+    slug: 'partner-cloud',
+    name: 'partner_cloud',
+    displayName: 'Partner Cloud',
+    directory: 'partner_nodes',
+    huggingFaceUrl: '',
+    featured: false,
+    workflowCount: 42
+  }
+
+  describe('getWhatIsDescription', () => {
+    it('returns local inference copy for standard models', () => {
+      const desc = getWhatIsDescription(localModel, 'a diffusion model')
+      expect(desc).toContain('run it locally in ComfyUI with full control')
+    })
+
+    it('returns local inference copy for partner models with HF URLs', () => {
+      const desc = getWhatIsDescription(partnerWithHF, 'a partner model')
+      expect(desc).toContain('run it locally in ComfyUI with full control')
+    })
+
+    it('returns cloud-only copy for partner models without HF URLs', () => {
+      const desc = getWhatIsDescription(partnerCloudOnly, 'a cloud model')
+      expect(desc).not.toContain('run it locally')
+      expect(desc).toContain('access it through Comfy Cloud')
+    })
+  })
+
+  describe('getPageDescription', () => {
+    it('returns local inference copy for standard models', () => {
+      const desc = getPageDescription(localModel)
+      expect(desc).toContain('full parameter control')
+      expect(desc).toContain('free local inference')
+    })
+
+    it('returns cloud-only copy for partner models without HF URLs', () => {
+      const desc = getPageDescription(partnerCloudOnly)
+      expect(desc).not.toContain('full parameter control')
+      expect(desc).not.toContain('free local inference')
+    })
+  })
+
+  describe('getFaqPricingAnswer', () => {
+    it('returns standard open source copy for local models', () => {
+      const ans = getFaqPricingAnswer(localModel)
+      expect(ans).toContain('ComfyUI is free and open source')
+      expect(ans).toContain('weights are available to download')
+      expect(ans).toContain(
+        'local inference on your own hardware is always free'
+      )
+    })
+
+    it('returns API copy for partner models with HF URLs', () => {
+      const ans = getFaqPricingAnswer(partnerWithHF)
+      expect(ans).toContain('ComfyUI is free and open source')
+      expect(ans).toContain('weights are available to download')
+    })
+
+    it('returns cloud-only copy for partner models without HF URLs', () => {
+      const ans = getFaqPricingAnswer(partnerCloudOnly)
+      expect(ans).toContain('exclusively on Comfy Cloud')
+      expect(ans).toContain('Pay-per-compute pricing applies')
+      expect(ans).not.toContain('local inference')
+    })
+  })
+})

--- a/apps/website/src/utils/modelSeoCopy.test.ts
+++ b/apps/website/src/utils/modelSeoCopy.test.ts
@@ -38,6 +38,16 @@ describe('modelSeoCopy', () => {
     workflowCount: 42
   }
 
+  const standardCloudApi: Model = {
+    slug: 'standard-api',
+    name: 'standard_api',
+    displayName: 'Standard API',
+    directory: 'diffusion_models',
+    huggingFaceUrl: '',
+    featured: false,
+    workflowCount: 15
+  }
+
   describe('getWhatIsDescription', () => {
     it('returns local inference copy for standard models', () => {
       const desc = getWhatIsDescription(localModel, 'a diffusion model')
@@ -91,6 +101,15 @@ describe('modelSeoCopy', () => {
       expect(ans).toContain('exclusively on Comfy Cloud')
       expect(ans).toContain('Pay-per-compute pricing applies')
       expect(ans).not.toContain('local inference')
+    })
+
+    it('returns cloud API and local inference copy for standard models without HF URLs', () => {
+      const ans = getFaqPricingAnswer(standardCloudApi)
+      expect(ans).toContain('ComfyUI is free and open source')
+      expect(ans).toContain('is available as a cloud API through Comfy Cloud')
+      expect(ans).toContain(
+        'local inference on your own hardware is always free'
+      )
     })
   })
 })

--- a/apps/website/src/utils/modelSeoCopy.ts
+++ b/apps/website/src/utils/modelSeoCopy.ts
@@ -1,0 +1,30 @@
+import type { Model } from '../config/models'
+
+function isCloudOnly(model: Model): boolean {
+  return model.directory === 'partner_nodes' && !model.huggingFaceUrl
+}
+
+export function getWhatIsDescription(model: Model, dirDesc: string): string {
+  if (isCloudOnly(model)) {
+    return `${model.displayName} is ${dirDesc}. You can access it through Comfy Cloud. ComfyUI's node-based workflow editor lets you connect ${model.displayName} with ControlNets, LoRAs, upscalers, and custom nodes to build any pipeline you need. There are ${model.workflowCount} community workflow templates using ${model.displayName} on Comfy Workflows, ready to load and customize.`
+  }
+  return `${model.displayName} is ${dirDesc}. You can run it locally in ComfyUI with full control over every parameter, or access it through Comfy Cloud. ComfyUI's node-based workflow editor lets you connect ${model.displayName} with ControlNets, LoRAs, upscalers, and custom nodes to build any pipeline you need. There are ${model.workflowCount} community workflow templates using ${model.displayName} on Comfy Workflows, ready to load and customize.`
+}
+
+export function getPageDescription(model: Model): string {
+  if (isCloudOnly(model)) {
+    return `Run ${model.displayName} in ComfyUI. ${model.workflowCount} community workflow templates and step-by-step tutorials.`
+  }
+  return `Run ${model.displayName} in ComfyUI with full parameter control. ${model.workflowCount} community workflow templates, step-by-step tutorials, and free local inference.`
+}
+
+export function getFaqPricingAnswer(model: Model): string {
+  if (isCloudOnly(model)) {
+    return `This model runs exclusively on Comfy Cloud. Pay-per-compute pricing applies - see comfy.org/cloud/pricing`
+  }
+  return `ComfyUI is free and open source. ${
+    model.huggingFaceUrl
+      ? `${model.displayName} weights are available to download from Hugging Face.`
+      : `${model.displayName} is available as a cloud API through Comfy Cloud.`
+  } You only pay for compute when running on Comfy Cloud; local inference on your own hardware is always free.`
+}

--- a/apps/website/src/utils/modelSeoCopy.ts
+++ b/apps/website/src/utils/modelSeoCopy.ts
@@ -1,7 +1,7 @@
 import type { Model } from '../config/models'
 
 function isCloudOnly(model: Model): boolean {
-  return model.directory === 'partner_nodes' && !model.huggingFaceUrl
+  return !model.huggingFaceUrl
 }
 
 export function getWhatIsDescription(model: Model, dirDesc: string): string {


### PR DESCRIPTION
Fixes P0-5 (Noindex in Sitemap) and P0-7 (Wrong FAQ JSON-LD) marketing-site SEO issues.

## Problem
1. **P0-5**: The `sitemap-0.xml` was incorrectly including pages that have a `<meta name="robots" content="noindex">` tag, such as the `privacy-policy`, `terms-of-service`, and 10 specific `supported-models` pages. Google throws errors when noindexed pages are submitted in a sitemap.
2. **P0-7**: The FAQ structured data (`JSON-LD`) for partner-only models incorrectly stated that local inference is available, which is inaccurate for cloud-only partner APIs. 

## Solution
1. **Sitemap Updates**: Updated `apps/website/astro.config.ts` to strictly filter out `privacy-policy`, `terms-of-service` (and their locales), and the 10 specific `supported-models` from the sitemap generation using `isExcludedFromSitemap`.
2. **FAQ Schema Fix**: Updated `[slug].astro` so that when a model is a partner model (`directory === 'partner_nodes'`) and does not have a Hugging Face download URL, the FAQ JSON-LD conditionally renders the accurate cloud-only pricing copy ("This model runs exclusively on Comfy Cloud...").

This ensures strict adherence to SEO best practices for the marketing pages.
