### PR TITLE
fix: route invited users to signup instead of login (BE-8032)

### DIFF
--- a/browser_tests/tests/cloud.spec.ts
+++ b/browser_tests/tests/cloud.spec.ts
@@ -3,6 +3,7 @@ import { comfyPageFixture as test } from '@e2e/fixtures/ComfyPage'
 
 const APP_URL = process.env.PLAYWRIGHT_TEST_URL || 'http://localhost:8188'
 const SHARE_AUTH_STORAGE_KEY = 'Comfy.PreservedQuery.share_auth'
+const INVITE_STORAGE_KEY = 'Comfy.PreservedQuery.invite'
 
 /**
  * Cloud distribution E2E tests.
@@ -38,6 +39,20 @@ test.describe('Cloud distribution UI', { tag: '@cloud' }, () => {
         )
       )
       .toBe(JSON.stringify({ share: 'abc' }))
+  })
+
+  /** A new invitee has no account, so login dead-ends on user-not-found. */
+  test('routes an invited logged-out visitor to signup instead of login', async ({
+    page
+  }) => {
+    await page.goto(new URL('/?invite=test-invite-token', APP_URL).toString())
+
+    await expect(page).toHaveURL(/\/cloud\/signup/, { timeout: 10_000 })
+    await expect
+      .poll(() =>
+        page.evaluate((key) => sessionStorage.getItem(key), INVITE_STORAGE_KEY)
+      )
+      .toBe(JSON.stringify({ invite: 'test-invite-token' }))
   })
 
   test('cloud login page renders sign-in options', async ({ page }) => {

--- a/browser_tests/tests/cloud.spec.ts
+++ b/browser_tests/tests/cloud.spec.ts
@@ -47,7 +47,9 @@ test.describe('Cloud distribution UI', { tag: '@cloud' }, () => {
   }) => {
     await page.goto(new URL('/?invite=test-invite-token', APP_URL).toString())
 
-    await expect(page).toHaveURL(/\/cloud\/signup/, { timeout: 10_000 })
+    await expect
+      .poll(() => new URL(page.url()).pathname, { timeout: 10_000 })
+      .toBe('/cloud/signup')
     await expect
       .poll(() =>
         page.evaluate((key) => sessionStorage.getItem(key), INVITE_STORAGE_KEY)

--- a/src/platform/cloud/onboarding/utils/inviteRedirect.test.ts
+++ b/src/platform/cloud/onboarding/utils/inviteRedirect.test.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, test } from 'vitest'
+import type { LocationQuery } from 'vue-router'
+
+import {
+  clearPreservedQuery,
+  getPreservedQueryParam
+} from '@/platform/navigation/preservedQueryManager'
+import { PRESERVED_QUERY_NAMESPACES } from '@/platform/navigation/preservedQueryNamespaces'
+
+import { resolveUnauthenticatedRedirectName } from './inviteRedirect'
+
+const stashInvite = (token: string) => {
+  sessionStorage.setItem(
+    `Comfy.PreservedQuery.${PRESERVED_QUERY_NAMESPACES.INVITE}`,
+    JSON.stringify({ invite: token })
+  )
+}
+
+describe('resolveUnauthenticatedRedirectName', () => {
+  beforeEach(() => {
+    clearPreservedQuery(PRESERVED_QUERY_NAMESPACES.INVITE)
+  })
+
+  test('routes to signup when the invite is in the live query', () => {
+    const query: LocationQuery = { invite: 'tok-123' }
+    expect(resolveUnauthenticatedRedirectName(query)).toBe('cloud-signup')
+  })
+
+  test('routes to login when no invite is present anywhere', () => {
+    expect(resolveUnauthenticatedRedirectName({})).toBe('cloud-login')
+  })
+
+  test('routes to signup from the preserved-query stash when the url has dropped the param', () => {
+    stashInvite('tok-stashed')
+
+    expect(
+      resolveUnauthenticatedRedirectName({}),
+      'a later navigation hop no longer carries ?invite= in the url, so the stash is the source of truth that keeps the invitee on the signup path'
+    ).toBe('cloud-signup')
+    // Sanity: the stash really is the thing being read here.
+    expect(
+      getPreservedQueryParam(PRESERVED_QUERY_NAMESPACES.INVITE, 'invite')
+    ).toBe('tok-stashed')
+  })
+
+  test('routes to signup when the invite param is repeated (array-valued)', () => {
+    const query: LocationQuery = { invite: ['tok-a', 'tok-b'] }
+    expect(resolveUnauthenticatedRedirectName(query)).toBe('cloud-signup')
+  })
+
+  test('routes to login when the invite param is empty and the stash is empty', () => {
+    const query: LocationQuery = { invite: '' }
+    expect(
+      resolveUnauthenticatedRedirectName(query),
+      'an empty ?invite= is not an invite in flight and must not divert a normal login'
+    ).toBe('cloud-login')
+  })
+})

--- a/src/platform/cloud/onboarding/utils/inviteRedirect.test.ts
+++ b/src/platform/cloud/onboarding/utils/inviteRedirect.test.ts
@@ -1,10 +1,7 @@
 import { beforeEach, describe, expect, test } from 'vitest'
 import type { LocationQuery } from 'vue-router'
 
-import {
-  clearPreservedQuery,
-  getPreservedQueryParam
-} from '@/platform/navigation/preservedQueryManager'
+import { clearPreservedQuery } from '@/platform/navigation/preservedQueryManager'
 import { PRESERVED_QUERY_NAMESPACES } from '@/platform/navigation/preservedQueryNamespaces'
 
 import { resolveUnauthenticatedRedirectName } from './inviteRedirect'
@@ -18,6 +15,11 @@ const stashInvite = (token: string) => {
 
 describe('resolveUnauthenticatedRedirectName', () => {
   beforeEach(() => {
+    // clearPreservedQuery skips storage when its in-memory namespace is cold, so
+    // wipe the raw key too or a stale stash leaks into the no-invite case.
+    sessionStorage.removeItem(
+      `Comfy.PreservedQuery.${PRESERVED_QUERY_NAMESPACES.INVITE}`
+    )
     clearPreservedQuery(PRESERVED_QUERY_NAMESPACES.INVITE)
   })
 
@@ -37,15 +39,19 @@ describe('resolveUnauthenticatedRedirectName', () => {
       resolveUnauthenticatedRedirectName({}),
       'a later navigation hop no longer carries ?invite= in the url, so the stash is the source of truth that keeps the invitee on the signup path'
     ).toBe('cloud-signup')
-    // Sanity: the stash really is the thing being read here.
-    expect(
-      getPreservedQueryParam(PRESERVED_QUERY_NAMESPACES.INVITE, 'invite')
-    ).toBe('tok-stashed')
   })
 
   test('routes to signup when the invite param is repeated (array-valued)', () => {
     const query: LocationQuery = { invite: ['tok-a', 'tok-b'] }
     expect(resolveUnauthenticatedRedirectName(query)).toBe('cloud-signup')
+  })
+
+  test('routes to signup when the first repeated invite value is empty', () => {
+    const query: LocationQuery = { invite: ['', 'tok-123'] }
+    expect(
+      resolveUnauthenticatedRedirectName(query),
+      'a real token in a later array slot is still an invite in flight'
+    ).toBe('cloud-signup')
   })
 
   test('routes to login when the invite param is empty and the stash is empty', () => {

--- a/src/platform/cloud/onboarding/utils/inviteRedirect.ts
+++ b/src/platform/cloud/onboarding/utils/inviteRedirect.ts
@@ -1,0 +1,10 @@
+import type { LocationQuery } from 'vue-router'
+
+// Red-step stub: returns the current (buggy) target unconditionally so the
+// regression test resolves its import and fails on behaviour, not on a missing
+// module. Replaced by the real implementation in the following commit.
+export const resolveUnauthenticatedRedirectName = (
+  _query: LocationQuery
+): 'cloud-login' | 'cloud-signup' => {
+  return 'cloud-login'
+}

--- a/src/platform/cloud/onboarding/utils/inviteRedirect.ts
+++ b/src/platform/cloud/onboarding/utils/inviteRedirect.ts
@@ -1,10 +1,27 @@
 import type { LocationQuery } from 'vue-router'
 
-// Red-step stub: returns the current (buggy) target unconditionally so the
-// regression test resolves its import and fails on behaviour, not on a missing
-// module. Replaced by the real implementation in the following commit.
+import { getPreservedQueryParam } from '@/platform/navigation/preservedQueryManager'
+import { PRESERVED_QUERY_NAMESPACES } from '@/platform/navigation/preservedQueryNamespaces'
+
+const firstNonEmpty = (value: LocationQuery[string]): string | undefined => {
+  const raw = Array.isArray(value) ? value[0] : value
+  return raw ? raw : undefined
+}
+
+const hasInviteInFlight = (query: LocationQuery): boolean => {
+  const fromQuery = firstNonEmpty(query.invite)
+  if (fromQuery) return true
+  return !!getPreservedQueryParam(PRESERVED_QUERY_NAMESPACES.INVITE, 'invite')
+}
+
+/**
+ * A brand-new invitee has no account, so sending them to login strands them on
+ * a Firebase `user-not-found`. While an invite is in flight — carried on the
+ * live query or already stashed by the preserved-query tracker for a later hop
+ * — route the unauthenticated visitor to signup instead.
+ */
 export const resolveUnauthenticatedRedirectName = (
-  _query: LocationQuery
+  query: LocationQuery
 ): 'cloud-login' | 'cloud-signup' => {
-  return 'cloud-login'
+  return hasInviteInFlight(query) ? 'cloud-signup' : 'cloud-login'
 }

--- a/src/platform/cloud/onboarding/utils/inviteRedirect.ts
+++ b/src/platform/cloud/onboarding/utils/inviteRedirect.ts
@@ -4,8 +4,10 @@ import { getPreservedQueryParam } from '@/platform/navigation/preservedQueryMana
 import { PRESERVED_QUERY_NAMESPACES } from '@/platform/navigation/preservedQueryNamespaces'
 
 const firstNonEmpty = (value: LocationQuery[string]): string | undefined => {
-  const raw = Array.isArray(value) ? value[0] : value
-  return raw ? raw : undefined
+  if (Array.isArray(value)) {
+    return value.find((item): item is string => !!item)
+  }
+  return value ? value : undefined
 }
 
 const hasInviteInFlight = (query: LocationQuery): boolean => {

--- a/src/router.ts
+++ b/src/router.ts
@@ -17,6 +17,7 @@ import LayoutDefault from '@/views/layouts/LayoutDefault.vue'
 
 import { captureOAuthRequestId } from '@/platform/cloud/oauth/oauthState'
 import { installDesktopLoginRedemption } from '@/platform/cloud/onboarding/desktopLoginRedemption'
+import { resolveUnauthenticatedRedirectName } from '@/platform/cloud/onboarding/utils/inviteRedirect'
 import { installPreservedQueryTracker } from '@/platform/navigation/preservedQueryTracker'
 import { PRESERVED_QUERY_NAMESPACES } from '@/platform/navigation/preservedQueryNamespaces'
 import { preserveLoggedOutShareAuthAttribution } from '@/platform/workflow/sharing/utils/shareAuthAttribution'
@@ -216,7 +217,7 @@ if (isCloud) {
     // Check if route requires authentication
     if (to.meta.requiresAuth && !isLoggedIn) {
       return next({
-        name: 'cloud-login',
+        name: resolveUnauthenticatedRedirectName(to.query),
         query
       })
     }
@@ -230,9 +231,9 @@ if (isCloud) {
         return loginSuccess ? next() : next(false)
       }
 
-      // For web, redirect to login
+      // For web, redirect to login (or signup when an invite is in flight)
       return next({
-        name: 'cloud-login',
+        name: resolveUnauthenticatedRedirectName(to.query),
         query
       })
     }


### PR DESCRIPTION
## Summary

A brand-new person opening a team-workspace invite link now lands on the sign-up page instead of login, so they can create the account the invite needs and actually join the workspace.

Fixes BE-8032

## Changes

- The global auth guard in `src/router.ts` now sends unauthenticated web visitors to `cloud-signup` instead of `cloud-login` when an invite is in flight. Before, every unauthenticated visitor was pushed to login, and a new invitee who typed their email there got a Firebase `user-not-found` and never reached the invite-accept step.
- Both unauthenticated branches of the guard (the `requiresAuth` branch and the web fallback) go through the same new helper, so the two paths can't drift.
- New helper `resolveUnauthenticatedRedirectName` in `src/platform/cloud/onboarding/utils/inviteRedirect.ts` decides login vs signup. It treats an invite as "in flight" when the token is on the incoming query or already in the preserved-query stash, so it still routes to signup on a later navigation hop that has dropped the url param. It is a pure function so it can be unit-tested without importing the router and its module side effects.
- The desktop sign-in dialog branch and the `previousFullPath` bounce-back are untouched.

No new UI. The existing post-sign-in toast ("You have been added to: <workspace>" with a View workspace button) already fires once invitees can get through signup, so the redirect is the whole fix. This stays frontend-only on purpose: the invite-accept endpoint is Firebase-auth-only and there is no unauthenticated token to workspace lookup, so routing new invitees to signup is the only fix available on the frontend side.

## Review Focus

- `inviteRedirect.ts` invite detection: it reads both `to.query.invite` (normalized for a repeated or empty param) and the preserved-query stash. The stash read is what makes the redirect survive a hop where the url no longer carries the token.
- `src/router.ts:220` and `src/router.ts:236`: confirm both unauthenticated branches pass `to.query` to the helper. These two call sites have no direct router-level test (importing the global guard pulls heavy module side effects), so the helper carries the covered logic and these are wiring.

## QA

- [x] Unit: 5/5 passing in the new `inviteRedirect.test.ts` suite (live query, no invite, stash-only durability, repeated array param, empty param)
- [x] Red-green: the regression test fails on the pre-fix behavior (3 of 5 cases red against an always-login stub) and passes after the fix
- [x] Mutation: 6/9 killed on changed lines, 0 unexplained survivors. `inviteRedirect.ts:8` swap_union_literal is an equivalent mutant caught by typecheck (TS2322). `router.ts:220` and `router.ts:236` swap_union_literal are documented baseline survivors (no test imports the global guard; the helper they call is fully covered).
- [x] E2E: new `@cloud` test in `cloud.spec.ts` asserts unauthenticated `/?invite=<token>` redirects to `cloud-signup` and stashes the token; the full cloud suite (5 tests) passes, so the normal unauthenticated login redirect is proven unbroken
- [x] Manual: on a staging build, opened `/?invite=<token>` while signed out and confirmed it now lands on Sign up instead of Log in
- [ ] Not covered: the full signed-out to accept to workspace journey was not run end to end because the invite email never arrived for the test alias on test or staging. That is an email delivery issue unrelated to this frontend change. Worth a manual pass once a real invite link is in hand.
