### PR TITLE
fix(website): point the Hunyuan3D model page at the hub slug that exists

### DIFF
--- a/apps/website/src/config/model-metadata.ts
+++ b/apps/website/src/config/model-metadata.ts
@@ -71,7 +71,10 @@ export const modelMetadata: Record<string, ModelOverride> = {
   },
   'hunyuan-3d': {
     docsUrl: 'https://docs.comfy.org/tutorials/3d/hunyuan3D-2',
-    hubSlug: 'hunyuan-3d',
+    // The hub spells this family without the hyphen, and unlike the other
+    // mismatches here it is not a variant alias the hub redirects, so the
+    // hyphenated URL 404s rather than resolving.
+    hubSlug: 'hunyuan3d',
     featured: true
   },
   vidu: {


### PR DESCRIPTION
Fixes one of Sameer's P0-1 model 404s.

`/p/supported-models/hunyuan-3d` links to `www.comfy.org/workflows/model/hunyuan-3d`, which 301s to `comfy.org/workflows/model/hunyuan-3d/` and 404s. The hub spells that family `hunyuan3d`.

The interface comment in this file already states the contract, "only set when the page exists", so this is just the value being wrong.

## Why this one and not the others

I checked all 35 `hubSlug` values against the live hub. Seven return 404:

```
flux-1           404      ltx-2      404
flux-1-kontext   404      ltx-2-3    404
flux-2           404      sdxl       404
hunyuan-3d       404
```

Six of those are variant aliases the hub already knows how to redirect, which the locale route proves today:

```
/es/workflows/model/flux-2/   301 -> /es/workflows/model/flux/
/es/workflows/model/sdxl/     301 -> /es/workflows/model/stable-diffusion/
/es/workflows/model/hunyuan-3d/  404
```

They 404 in English only because the English model route does not resolve aliases yet, which is what Comfy-Org/workflow_templates#1164 fixes. So those six need no change here and will resolve once that ships and the hub is deployed.

`hunyuan-3d` is the exception: it is not a variant of `hunyuan3d` anywhere in the hub catalog, so no redirect will ever pick it up. It needs the correct slug.

## No test

The failure mode is "this slug does not exist on another property", which a unit test cannot see without a network call. The check that would catch it is a link crawl against the hub, which is worth having but belongs in CI rather than in this one-line fix.
