### PR TITLE
fix: proxy legacy slot link mutations

### DIFF
--- a/browser_tests/tests/legacySlotMutation.spec.ts
+++ b/browser_tests/tests/legacySlotMutation.spec.ts
@@ -1,0 +1,50 @@
+import {
+  comfyExpect as expect,
+  comfyPageFixture as test
+} from '@e2e/fixtures/ComfyPage'
+
+test(
+  'Legacy custom nodes can remove links through slot mirrors',
+  { tag: ['@canvas', '@node'] },
+  async ({ comfyPage }) => {
+    await comfyPage.workflow.loadWorkflow('default')
+
+    const topology = await comfyPage.page.evaluate(() => {
+      const graph = window.app!.graph
+      const checkpoint = graph.nodes.find(
+        (node) => node.type === 'CheckpointLoaderSimple'
+      )
+      const sampler = graph.nodes.find((node) => node.type === 'KSampler')
+      if (!checkpoint || !sampler) throw new Error('Required nodes not found')
+
+      const modelLink = sampler.inputs[0].link
+      const clipLinks = checkpoint.outputs[1].links!
+      const removedClipLink = clipLinks[0]
+      const retainedClipLink = clipLinks[1]
+      const vaeLink = checkpoint.outputs[2].links![0]
+
+      sampler.inputs[0].link = null
+      clipLinks.splice(0, 1)
+      checkpoint.outputs[2].links = []
+
+      return {
+        modelDisconnected: modelLink != null && !graph.links.has(modelLink),
+        clipDisconnected:
+          removedClipLink != null && !graph.links.has(removedClipLink),
+        clipRetained:
+          retainedClipLink != null && graph.links.has(retainedClipLink),
+        retainedViewSynchronized:
+          clipLinks.length === 1 && clipLinks[0] === retainedClipLink,
+        vaeDisconnected: vaeLink != null && !graph.links.has(vaeLink)
+      }
+    })
+
+    expect(topology).toEqual({
+      modelDisconnected: true,
+      clipDisconnected: true,
+      clipRetained: true,
+      retainedViewSynchronized: true,
+      vaeDisconnected: true
+    })
+  }
+)

--- a/browser_tests/tests/legacySlotMutation.spec.ts
+++ b/browser_tests/tests/legacySlotMutation.spec.ts
@@ -9,42 +9,61 @@ test(
   async ({ comfyPage }) => {
     await comfyPage.workflow.loadWorkflow('default')
 
-    const topology = await comfyPage.page.evaluate(() => {
-      const graph = window.app!.graph
-      const checkpoint = graph.nodes.find(
-        (node) => node.type === 'CheckpointLoaderSimple'
-      )
-      const sampler = graph.nodes.find((node) => node.type === 'KSampler')
-      if (!checkpoint || !sampler) throw new Error('Required nodes not found')
+    await test.step('Disconnect an input by assigning null', async () => {
+      const disconnected = await comfyPage.page.evaluate(() => {
+        const graph = window.app!.graph
+        const sampler = graph.nodes.find((node) => node.type === 'KSampler')
+        if (!sampler) throw new Error('KSampler not found')
 
-      const modelLink = sampler.inputs[0].link
-      const clipLinks = checkpoint.outputs[1].links!
-      const removedClipLink = clipLinks[0]
-      const retainedClipLink = clipLinks[1]
-      const vaeLink = checkpoint.outputs[2].links![0]
+        const link = sampler.inputs[0].link
+        sampler.inputs[0].link = null
+        return link != null && !graph.links.has(link)
+      })
 
-      sampler.inputs[0].link = null
-      clipLinks.splice(0, 1)
-      checkpoint.outputs[2].links = []
-
-      return {
-        modelDisconnected: modelLink != null && !graph.links.has(modelLink),
-        clipDisconnected:
-          removedClipLink != null && !graph.links.has(removedClipLink),
-        clipRetained:
-          retainedClipLink != null && graph.links.has(retainedClipLink),
-        retainedViewSynchronized:
-          clipLinks.length === 1 && clipLinks[0] === retainedClipLink,
-        vaeDisconnected: vaeLink != null && !graph.links.has(vaeLink)
-      }
+      expect(disconnected).toBe(true)
     })
 
-    expect(topology).toEqual({
-      modelDisconnected: true,
-      clipDisconnected: true,
-      clipRetained: true,
-      retainedViewSynchronized: true,
-      vaeDisconnected: true
+    await test.step('Disconnect one output link with splice', async () => {
+      const topology = await comfyPage.page.evaluate(() => {
+        const graph = window.app!.graph
+        const checkpoint = graph.nodes.find(
+          (node) => node.type === 'CheckpointLoaderSimple'
+        )
+        if (!checkpoint) throw new Error('CheckpointLoaderSimple not found')
+
+        const links = checkpoint.outputs[1].links!
+        const removedLink = links[0]
+        const retainedLink = links[1]
+        links.splice(0, 1)
+
+        return {
+          removed: removedLink != null && !graph.links.has(removedLink),
+          retained: retainedLink != null && graph.links.has(retainedLink),
+          viewSynchronized: links.length === 1 && links[0] === retainedLink
+        }
+      })
+
+      expect(topology).toEqual({
+        removed: true,
+        retained: true,
+        viewSynchronized: true
+      })
+    })
+
+    await test.step('Disconnect all output links by assigning an empty array', async () => {
+      const disconnected = await comfyPage.page.evaluate(() => {
+        const graph = window.app!.graph
+        const checkpoint = graph.nodes.find(
+          (node) => node.type === 'CheckpointLoaderSimple'
+        )
+        if (!checkpoint) throw new Error('CheckpointLoaderSimple not found')
+
+        const link = checkpoint.outputs[2].links![0]
+        checkpoint.outputs[2].links = []
+        return link != null && !graph.links.has(link)
+      })
+
+      expect(disconnected).toBe(true)
     })
   }
 )

--- a/docs/architecture/ecs/ecs-extension-compatibility-audit.md
+++ b/docs/architecture/ecs/ecs-extension-compatibility-audit.md
@@ -44,14 +44,14 @@ replacement rather than a transient empty input.
 
 ## Deprecated compatibility behavior
 
-| Surface                                 | Read behavior                                                                   | Write / migration behavior                                                                                                     |
-| --------------------------------------- | ------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
-| `graph.links[id]`                       | Proxy-backed indexed access remains temporarily.                                | Use `graph.links.get(id)` and normal `Map` iteration.                                                                          |
-| `input.link`                            | Returns the current store-derived ID or `null` and emits deprecation telemetry. | Assignment is ignored. Use `isInputConnected()`, `getInputLink()`, `connect()`, or `disconnectInput()`.                        |
-| `output.links`                          | Returns a fresh frozen ID array or `null` and emits telemetry.                  | Assignment and array mutation cannot change topology. Use node queries, `outputLinks()`, `connect()`, or `disconnectOutput()`. |
-| `node.badgePosition`                    | Returns the fixed top-right position.                                           | Assignment is ignored; badges always render top-right.                                                                         |
-| `LGraphCanvas.repositionNodesVueMode()` | Alias remains callable.                                                         | Use `applyNodePositions()`.                                                                                                    |
-| Graph `onBeforeChange`                  | Hook remains declared.                                                          | Prefer `LGraphCanvas.onBeforeChange`; graph hook is scheduled for removal.                                                     |
+| Surface                                 | Read behavior                                                                   | Write / migration behavior                                                                         |
+| --------------------------------------- | ------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| `graph.links[id]`                       | Proxy-backed indexed access remains temporarily.                                | Use `graph.links.get(id)` and normal `Map` iteration.                                              |
+| `input.link`                            | Returns the current store-derived ID or `null` and emits deprecation telemetry. | Assigning `null` disconnects; ID assignment is ignored. Prefer `connect()` or `disconnectInput()`. |
+| `output.links`                          | Returns a stable store-derived ID view or `null` and emits telemetry.           | Removing IDs disconnects; additions are discarded. Prefer `connect()` or `disconnectOutput()`.     |
+| `node.badgePosition`                    | Returns the fixed top-right position.                                           | Assignment is ignored; badges always render top-right.                                             |
+| `LGraphCanvas.repositionNodesVueMode()` | Alias remains callable.                                                         | Use `applyNodePositions()`.                                                                        |
+| Graph `onBeforeChange`                  | Hook remains declared.                                                          | Prefer `LGraphCanvas.onBeforeChange`; graph hook is scheduled for removal.                         |
 
 Serialized slot `link`/`links` fields are still emitted for workflow
 compatibility, but constructors strip those mirrors before rebuilding topology.
@@ -91,8 +91,9 @@ import-boundary rules are in
 
 Topology is authoritative in `linkStore`; slot mirrors no longer drive links.
 Callback code reading the deprecated accessors sees current store state. Code
-that used `input.link = ...`, `output.links.push(...)`, or replacement of either
-property is now a no-op and must move to graph/node mutation APIs.
+that clears `input.link` or removes IDs from `output.links` is routed through
+topology operations for compatibility. Adding a link ID remains a no-op and
+must move to `connect()`, which has the endpoint context needed to create it.
 
 ### Node shell properties and enumeration
 
@@ -118,7 +119,7 @@ Derived first-party rows are recomputed on read; extension entries remain on
 
 - `widgets_up` is detected and warned about but is not supported by the Vue
   renderer. Use normal widget ordering/layout.
-- Direct mutation of `input.link` or `output.links` is unsupported.
+- ID-only additions through `input.link` or `output.links` are unsupported.
 - Treating `LinkMap` as a native Map with internal slots, retaining iterators
   across topology revisions, or assuming `set()` cannot reject is unsupported.
 - Constructing a root graph without active Pinia is unsupported.

--- a/src/lib/litegraph/src/infrastructure/createMutationView.ts
+++ b/src/lib/litegraph/src/infrastructure/createMutationView.ts
@@ -90,10 +90,12 @@ export function createMutationView<
 
 export function createArrayMutationView<TValue>(
   target: TValue[],
-  commit: () => void
+  commit: () => void,
+  synchronize?: () => void
 ): TValue[] {
   return createMutationView(target, {
     commit,
+    synchronize,
     shouldCommitMethod: (property) => arrayMutationMethods.has(property)
   })
 }

--- a/src/lib/litegraph/src/interfaces.ts
+++ b/src/lib/litegraph/src/interfaces.ts
@@ -370,7 +370,7 @@ export interface INodeInputSlot extends INodeSlot {
    * `node.getInputLink(slot)`; mutate via `node.connect()` /
    * `node.disconnectInput()`.
    */
-  readonly link?: LinkId | null
+  link?: LinkId | null
   widget?: IWidgetLocator
   widgetId?: WidgetId
   alwaysVisible?: boolean
@@ -392,7 +392,7 @@ export interface INodeOutputSlot extends INodeSlot {
    * `node.getOutputNodes(slot)`; mutate via `node.connect()` /
    * `node.disconnectOutput()`.
    */
-  readonly links?: readonly LinkId[] | null
+  links?: LinkId[] | null
   _data?: unknown
   slot_index?: SlotIndex
 }

--- a/src/lib/litegraph/src/node/NodeInputSlot.test.ts
+++ b/src/lib/litegraph/src/node/NodeInputSlot.test.ts
@@ -82,8 +82,8 @@ describe('NodeInputSlot', () => {
     expect(input?.isConnected).toBe(true)
   })
 
-  it('ignores writes, warns, and keeps the store-derived value', () => {
-    const { target, link } = createConnectedPair()
+  it('routes null assignment through disconnectInput', () => {
+    const { target } = createConnectedPair()
     const input: { link?: LinkId | null } = target.inputs[0]
 
     expect(() => {
@@ -93,7 +93,20 @@ describe('NodeInputSlot', () => {
       expect.stringContaining('Assignment to input.link is deprecated'),
       undefined
     )
+    expect(target.inputs[0].link).toBeNull()
+  })
+
+  it('does not move a link from an id-only assignment', () => {
+    const { graph, source, target, link } = createConnectedPair()
+    const otherTarget = new LGraphNode('Other target')
+    otherTarget.addInput('in', 'INT')
+    graph.add(otherTarget)
+
+    otherTarget.inputs[0].link = link.id
+
     expect(target.inputs[0].link).toBe(link.id)
+    expect(otherTarget.inputs[0].link).toBeNull()
+    expect(source.outputs[0].links).toEqual([link.id])
   })
 })
 

--- a/src/lib/litegraph/src/node/NodeInputSlot.ts
+++ b/src/lib/litegraph/src/node/NodeInputSlot.ts
@@ -21,9 +21,9 @@ export class NodeInputSlot extends NodeSlot implements INodeInputSlot {
   alwaysVisible?: boolean
 
   /**
-   * @deprecated Reads return the store-derived link id; writes fire telemetry
-   * and are ignored, since the store cannot be mutated through the mirror.
-   * First-party code uses the slotLinks helpers.
+   * @deprecated Reads return the store-derived link id. Assigning null
+   * disconnects through the store; assigning an id is ignored. First-party
+   * code uses the slotLinks helpers and node topology methods.
    */
   get link(): LinkId | null {
     warnDeprecated(
@@ -32,10 +32,12 @@ export class NodeInputSlot extends NodeSlot implements INodeInputSlot {
     return linkIdOf(this)
   }
 
-  set link(_value: LinkId | null) {
+  set link(value: LinkId | null) {
     warnDeprecated(
-      'Assignment to input.link is deprecated and has no effect; connectivity is derived from the link store. Mutate via node.connect() / node.disconnectInput().'
+      'Assignment to input.link is deprecated; null disconnects through the link store. Mutate via node.connect() / node.disconnectInput().'
     )
+    const slot = indexOf(this)
+    if (value === null && slot !== -1) this._node.disconnectInput(slot)
   }
 
   get isWidgetInputSlot(): boolean {

--- a/src/lib/litegraph/src/node/NodeOutputSlot.test.ts
+++ b/src/lib/litegraph/src/node/NodeOutputSlot.test.ts
@@ -3,7 +3,6 @@ import { fromAny } from '@total-typescript/shoehorn'
 import { setActivePinia } from 'pinia'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import type { LinkId } from '@/lib/litegraph/src/LLink'
 import { LGraph, LGraphNode, LiteGraph } from '@/lib/litegraph/src/litegraph'
 import { NodeOutputSlot } from '@/lib/litegraph/src/node/NodeOutputSlot'
 import { toLinkId } from '@/types/linkId'
@@ -88,20 +87,23 @@ describe('NodeOutputSlot deprecated links getter', () => {
     source.graph!.add(secondTarget)
     const second = source.connect(0, secondTarget, 0)!
 
-    const links = source.outputs[0].links as LinkId[]
+    const slot = source.outputs[0]
+    const links = slot.links
+    if (!links) throw new Error('Expected connected output links')
     expect(links).toEqual([first.id, second.id])
     expect(links.pop()).toBe(second.id)
     expect(secondTarget.inputs[0].link).toBeNull()
     expect(target.inputs[0].link).toBe(first.id)
-    expect(source.outputs[0].links).toBe(links)
+    expect(slot.links).toBe(links)
     expect(links).toEqual([first.id])
   })
 
   it('synchronizes a retained array view with topology commands', () => {
     const { source, target } = createConnectedGraph()
-    const slot = source.outputs[0] as { links: LinkId[] | null }
+    const slot = source.outputs[0]
     slot.links = []
-    const links = slot.links!
+    const links = slot.links
+    if (!links) throw new Error('Expected retained output links')
     const first = source.connect(0, target, 0)!
 
     expect(links).toEqual([first.id])
@@ -111,11 +113,13 @@ describe('NodeOutputSlot deprecated links getter', () => {
 
   it('accepts unresolved additions without changing topology', () => {
     const { source } = createConnectedGraph()
-    const slot = source.outputs[0] as { links: LinkId[] | null }
+    const slot = source.outputs[0]
 
     slot.links = []
     expect(slot.links).toEqual([])
-    expect(() => slot.links!.push(toLinkId(404))).not.toThrow()
+    const links = slot.links
+    if (!links) throw new Error('Expected assigned output links')
+    expect(() => links.push(toLinkId(404))).not.toThrow()
     expect(slot.links).toEqual([])
   })
 })

--- a/src/lib/litegraph/src/node/NodeOutputSlot.test.ts
+++ b/src/lib/litegraph/src/node/NodeOutputSlot.test.ts
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { LinkId } from '@/lib/litegraph/src/LLink'
 import { LGraph, LGraphNode, LiteGraph } from '@/lib/litegraph/src/litegraph'
 import { NodeOutputSlot } from '@/lib/litegraph/src/node/NodeOutputSlot'
+import { toLinkId } from '@/types/linkId'
 
 function createConnectedGraph() {
   const graph = new LGraph()
@@ -64,9 +65,9 @@ describe('NodeOutputSlot deprecated links getter', () => {
     expect(orphan.outputs[0].links).toBeNull()
   })
 
-  it('ignores writes, warns, and keeps the store-derived value', () => {
+  it('routes null assignment through disconnectOutput', () => {
     const { source, target } = createConnectedGraph()
-    const link = source.connect(0, target, 0)
+    source.connect(0, target, 0)
     const slot: { links?: unknown } = source.outputs[0]
 
     expect(() => {
@@ -76,15 +77,46 @@ describe('NodeOutputSlot deprecated links getter', () => {
       expect.stringContaining('Assignment to output.links is deprecated'),
       undefined
     )
-    expect(source.outputs[0].links).toEqual([link!.id])
+    expect(source.outputs[0].links).toBeNull()
   })
 
-  it('throws on mutation of the returned array', () => {
+  it('routes removals from the returned array through disconnectInput', () => {
     const { source, target } = createConnectedGraph()
-    source.connect(0, target, 0)
+    const first = source.connect(0, target, 0)!
+    const secondTarget = new LGraphNode('Second target')
+    secondTarget.addInput('in', 'INT')
+    source.graph!.add(secondTarget)
+    const second = source.connect(0, secondTarget, 0)!
 
     const links = source.outputs[0].links as LinkId[]
-    expect(() => links.push(links[0])).toThrow(TypeError)
+    expect(links).toEqual([first.id, second.id])
+    expect(links.pop()).toBe(second.id)
+    expect(secondTarget.inputs[0].link).toBeNull()
+    expect(target.inputs[0].link).toBe(first.id)
+    expect(source.outputs[0].links).toBe(links)
+    expect(links).toEqual([first.id])
+  })
+
+  it('synchronizes a retained array view with topology commands', () => {
+    const { source, target } = createConnectedGraph()
+    const slot = source.outputs[0] as { links: LinkId[] | null }
+    slot.links = []
+    const links = slot.links!
+    const first = source.connect(0, target, 0)!
+
+    expect(links).toEqual([first.id])
+    source.disconnectOutput(0)
+    expect(links).toEqual([])
+  })
+
+  it('accepts unresolved additions without changing topology', () => {
+    const { source } = createConnectedGraph()
+    const slot = source.outputs[0] as { links: LinkId[] | null }
+
+    slot.links = []
+    expect(slot.links).toEqual([])
+    expect(() => slot.links!.push(toLinkId(404))).not.toThrow()
+    expect(slot.links).toEqual([])
   })
 })
 

--- a/src/lib/litegraph/src/node/NodeOutputSlot.ts
+++ b/src/lib/litegraph/src/node/NodeOutputSlot.ts
@@ -8,11 +8,13 @@ import type {
   Point
 } from '@/lib/litegraph/src/interfaces'
 import { LiteGraph } from '@/lib/litegraph/src/litegraph'
+import { createArrayMutationView } from '@/lib/litegraph/src/infrastructure/createMutationView'
 import { NodeSlot } from '@/lib/litegraph/src/node/NodeSlot'
 import type { IDrawOptions } from '@/lib/litegraph/src/node/NodeSlot'
 import {
   outputHasLinks,
-  outputLinkIds
+  outputLinkIds,
+  outputLinks
 } from '@/lib/litegraph/src/node/slotLinks'
 import type { SubgraphInput } from '@/lib/litegraph/src/subgraph/SubgraphInput'
 import type { SubgraphOutput } from '@/lib/litegraph/src/subgraph/SubgraphOutput'
@@ -22,24 +24,54 @@ import { warnDeprecated } from '@/lib/litegraph/src/utils/feedback'
 export class NodeOutputSlot extends NodeSlot implements INodeOutputSlot {
   _data?: unknown
   slot_index?: number
+  private readonly legacyLinkIds!: LinkId[]
+  private readonly legacyLinksView!: LinkId[]
+  private legacyLinksPresent!: boolean
 
   /**
-   * @deprecated Reads return a fresh store-derived array; writes fire telemetry
-   * and are ignored, since the store cannot be mutated through the mirror.
-   * First-party code uses the slotLinks helpers.
+   * @deprecated Reads return a stable store-derived view. Removing ids from the
+   * view disconnects them; additions are discarded. First-party code uses the
+   * slotLinks helpers and node topology methods.
    */
-  get links(): readonly LinkId[] | null {
+  get links(): LinkId[] | null {
     warnDeprecated(
-      'output.links is deprecated. Read connectivity via node.isOutputConnected(slot) / node.getOutputNodes(slot); enumerate links via outputLinks(graph, node.id, slot); mutate via node.connect() / node.disconnectOutput().'
+      'output.links is deprecated. Read connectivity via node.isOutputConnected(slot) / node.getOutputNodes(slot); mutate via node.connect() / node.disconnectOutput().'
     )
-    const ids = linkIdsOf(this)
-    return ids.length ? Object.freeze(ids) : null
+    this.synchronizeLegacyLinks()
+    return this.legacyLinksPresent ? this.legacyLinksView : null
   }
 
-  set links(_value: readonly LinkId[] | null) {
+  set links(value: readonly LinkId[] | null) {
     warnDeprecated(
-      'Assignment to output.links is deprecated and has no effect; connectivity is derived from the link store. Mutate via node.connect() / node.disconnectOutput().'
+      'Assignment to output.links is deprecated; removals disconnect through the link store. Add links via node.connect().'
     )
+    this.legacyLinksPresent = value !== null
+    this.legacyLinkIds.splice(0, this.legacyLinkIds.length, ...(value ?? []))
+    this.commitLegacyLinks()
+  }
+
+  private synchronizeLegacyLinks(preservePresence = false): void {
+    const hadIds = this.legacyLinkIds.length > 0
+    const ids = linkIdsOf(this)
+    this.legacyLinkIds.splice(0, this.legacyLinkIds.length, ...ids)
+    if (ids.length) this.legacyLinksPresent = true
+    else if (hadIds && !preservePresence) this.legacyLinksPresent = false
+  }
+
+  private commitLegacyLinks(): void {
+    const { graph } = this._node
+    const slot = indexOf(this)
+    if (!graph || slot === -1) {
+      this.legacyLinkIds.splice(0)
+      return
+    }
+
+    const desired = new Set(this.legacyLinkIds)
+    for (const link of outputLinks(graph, this._node.id, slot)) {
+      if (desired.has(link.id)) continue
+      graph.getNodeById(link.target_id)?.disconnectInput(link.target_slot)
+    }
+    this.synchronizeLegacyLinks(true)
   }
 
   get isWidgetInputSlot(): false {
@@ -61,6 +93,20 @@ export class NodeOutputSlot extends NodeSlot implements INodeOutputSlot {
     // ctor's Object.assign does not trip the deprecated setter above.
     const { links: _legacyLinks, ...rest } = slot
     super(rest, node)
+
+    const legacyLinkIds: LinkId[] = []
+    Object.defineProperties(this, {
+      legacyLinkIds: { value: legacyLinkIds },
+      legacyLinksView: {
+        value: createArrayMutationView(
+          legacyLinkIds,
+          () => this.commitLegacyLinks(),
+          () => this.synchronizeLegacyLinks()
+        )
+      },
+      legacyLinksPresent: { value: false, writable: true }
+    })
+
     this._data = slot._data
     this.slot_index = slot.slot_index
   }


### PR DESCRIPTION
## Summary

Preserve legacy custom-node link-removal behavior while keeping topology owned by the link store.

## Changes

- **What**: Route `input.link = null` and removals from `output.links` through topology commands, keep retained output arrays synchronized, and document the supported compatibility boundary.
- **Tests**: Add focused slot tests and a Playwright custom-node compatibility test covering direct assignment and in-place mutation.

## Review Focus

ID-only link additions remain intentionally ignored because they do not provide the endpoint context required by `node.connect()`.