### PR TITLE
Apply sort-modules ordering across TypeScript sources

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -28,3 +28,6 @@ e3bb29ceb8174b8bbca9e48ec7d42cd540f40efa
 
 # Migrate Tailwind styles to design-system package
 9f19d8fb4bd22518879343b49c05634dca777df0
+
+# Apply sort-modules ordering across TypeScript sources
+fe2939cbd47f5047f556a2ff83707d8a7c88dada

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -130,7 +130,7 @@
       "files": ["src/**/*.ts"],
       "rules": {
         "perfectionist/sort-modules": [
-          "warn",
+          "error",
           {
             "type": "unsorted",
             "partitionByComment": false,

--- a/src/base/common/downloadUtil.ts
+++ b/src/base/common/downloadUtil.ts
@@ -80,6 +80,33 @@ const extractFilenameFromUrl = (url: string): string | null => {
 }
 
 /**
+ * Fetch a URL and return its body as a Blob.
+ * Shared by download and open-in-new-tab cloud paths.
+ */
+async function fetchAsBlob(url: string): Promise<Response> {
+  const response = await fetch(url)
+  if (!response.ok) {
+    throw new Error(`Failed to fetch ${url}: ${response.status}`)
+  }
+  return response
+}
+
+async function downloadViaBlobFetch(
+  href: string,
+  fallbackFilename: string
+): Promise<void> {
+  const response = await fetchAsBlob(href)
+
+  // Try to get filename from Content-Disposition header (set by backend)
+  const contentDisposition = response.headers.get('Content-Disposition')
+  const headerFilename =
+    extractFilenameFromContentDisposition(contentDisposition)
+
+  const blob = await response.blob()
+  downloadBlob(headerFilename ?? fallbackFilename, blob)
+}
+
+/**
  * Extract filename from Content-Disposition header
  * Handles both simple format: attachment; filename="name.png"
  * And RFC 5987 format: attachment; filename="fallback.png"; filename*=UTF-8''encoded%20name.png
@@ -114,33 +141,6 @@ export function extractFilenameFromContentDisposition(
   }
 
   return null
-}
-
-/**
- * Fetch a URL and return its body as a Blob.
- * Shared by download and open-in-new-tab cloud paths.
- */
-async function fetchAsBlob(url: string): Promise<Response> {
-  const response = await fetch(url)
-  if (!response.ok) {
-    throw new Error(`Failed to fetch ${url}: ${response.status}`)
-  }
-  return response
-}
-
-async function downloadViaBlobFetch(
-  href: string,
-  fallbackFilename: string
-): Promise<void> {
-  const response = await fetchAsBlob(href)
-
-  // Try to get filename from Content-Disposition header (set by backend)
-  const contentDisposition = response.headers.get('Content-Disposition')
-  const headerFilename =
-    extractFilenameFromContentDisposition(contentDisposition)
-
-  const blob = await response.blob()
-  downloadBlob(headerFilename ?? fallbackFilename, blob)
 }
 
 /**

--- a/src/components/error/useErrorOverlayState.ts
+++ b/src/components/error/useErrorOverlayState.ts
@@ -14,6 +14,13 @@ import type { MissingModelGroup } from '@/platform/missingModel/types'
 
 type OverlayCopy = { title?: string; message: string }
 
+interface OverlayGroupContext {
+  missingPackGroups: MissingPackGroup[]
+  missingModelGroups: MissingModelGroup[]
+  missingMediaGroups: MissingMediaGroup[]
+  swapNodeGroups: SwapNodeGroup[]
+}
+
 function resolveSingleOverlayCopy(group: ErrorGroup): OverlayCopy | undefined {
   if (group.type === 'execution') {
     const [card] = group.cards
@@ -77,13 +84,6 @@ function hasSingleRowWithAtMostOneReference(
   return (
     rows.length === 1 && row !== undefined && row.referencingNodes.length <= 1
   )
-}
-
-interface OverlayGroupContext {
-  missingPackGroups: MissingPackGroup[]
-  missingModelGroups: MissingModelGroup[]
-  missingMediaGroups: MissingMediaGroup[]
-  swapNodeGroups: SwapNodeGroup[]
 }
 
 function isSingleLeafGroup(

--- a/src/components/load3d/Load3DMenuBar.test.ts
+++ b/src/components/load3d/Load3DMenuBar.test.ts
@@ -35,6 +35,8 @@ const i18n = createI18n({
   messages: { en: enMessages }
 })
 
+type RenderProps = Partial<ComponentProps<typeof Load3DMenuBar>>
+
 function makeSceneConfig(): SceneConfig {
   return {
     showGrid: true,
@@ -74,8 +76,6 @@ function makeLightConfig(): LightConfig {
     }
   }
 }
-
-type RenderProps = Partial<ComponentProps<typeof Load3DMenuBar>>
 
 function renderMenuBar(overrides: RenderProps = {}) {
   const result = render(Load3DMenuBar, {

--- a/src/components/load3d/menubar/GizmoMenuGroup.test.ts
+++ b/src/components/load3d/menubar/GizmoMenuGroup.test.ts
@@ -16,6 +16,14 @@ const i18n = createI18n({
   messages: { en: enMessages }
 })
 
+type Props = {
+  config: ModelConfig
+  compact?: boolean
+  onToggleGizmo?: (enabled: boolean) => void
+  onSetGizmoMode?: (mode: GizmoMode) => void
+  onResetGizmoTransform?: () => void
+}
+
 function makeConfig(enabled: boolean): ModelConfig {
   return {
     upDirection: 'original',
@@ -29,14 +37,6 @@ function makeConfig(enabled: boolean): ModelConfig {
       scale: { x: 1, y: 1, z: 1 }
     }
   }
-}
-
-type Props = {
-  config: ModelConfig
-  compact?: boolean
-  onToggleGizmo?: (enabled: boolean) => void
-  onSetGizmoMode?: (mode: GizmoMode) => void
-  onResetGizmoTransform?: () => void
 }
 
 function renderGroup(props: Props) {

--- a/src/components/load3d/menubar/HdriMenuGroup.test.ts
+++ b/src/components/load3d/menubar/HdriMenuGroup.test.ts
@@ -16,6 +16,12 @@ const i18n = createI18n({
   messages: { en: enMessages }
 })
 
+type Props = {
+  config?: LightConfig
+  sceneHasImage?: boolean
+  onUpdateHdriFile?: (file: File | null) => void
+}
+
 function makeConfig(hdri?: Partial<HDRIConfig>): LightConfig {
   return {
     intensity: 5,
@@ -29,12 +35,6 @@ function makeConfig(hdri?: Partial<HDRIConfig>): LightConfig {
         }
       : undefined
   }
-}
-
-type Props = {
-  config?: LightConfig
-  sceneHasImage?: boolean
-  onUpdateHdriFile?: (file: File | null) => void
 }
 
 function renderGroup(props: Props = {}) {

--- a/src/components/load3d/menubar/SceneMenuGroup.test.ts
+++ b/src/components/load3d/menubar/SceneMenuGroup.test.ts
@@ -13,6 +13,14 @@ const i18n = createI18n({
   messages: { en: enMessages }
 })
 
+type Props = {
+  config?: SceneConfig
+  fov?: number
+  hdriActive?: boolean
+  canUseBackgroundImage?: boolean
+  onUpdateBackgroundImage?: (file: File | null) => void
+}
+
 function makeConfig(overrides: Partial<SceneConfig> = {}): SceneConfig {
   return {
     showGrid: true,
@@ -21,14 +29,6 @@ function makeConfig(overrides: Partial<SceneConfig> = {}): SceneConfig {
     backgroundRenderMode: 'tiled',
     ...overrides
   }
-}
-
-type Props = {
-  config?: SceneConfig
-  fov?: number
-  hdriActive?: boolean
-  canUseBackgroundImage?: boolean
-  onUpdateBackgroundImage?: (file: File | null) => void
 }
 
 function renderGroup(props: Props = {}) {

--- a/src/components/queue/job/useJobErrorReporting.ts
+++ b/src/components/queue/job/useJobErrorReporting.ts
@@ -6,6 +6,12 @@ import type { TaskItemImpl } from '@/stores/queueStore'
 
 type CopyHandler = (value: string) => void | Promise<void>
 
+type UseJobErrorReportingOptions = {
+  taskForJob: ComputedRef<TaskItemImpl | null>
+  copyToClipboard: CopyHandler
+  dialog: JobErrorDialogService
+}
+
 export type JobErrorDialogService = {
   showExecutionErrorDialog: (executionError: ExecutionErrorDialogInput) => void
   showErrorDialog: (
@@ -15,12 +21,6 @@ export type JobErrorDialogService = {
       [key: string]: unknown
     }
   ) => void
-}
-
-type UseJobErrorReportingOptions = {
-  taskForJob: ComputedRef<TaskItemImpl | null>
-  copyToClipboard: CopyHandler
-  dialog: JobErrorDialogService
 }
 
 export const useJobErrorReporting = ({

--- a/src/components/queue/job/useQueueEstimates.ts
+++ b/src/components/queue/job/useQueueEstimates.ts
@@ -8,6 +8,8 @@ import type { JobState } from '@/types/queue'
 type QueueStore = ReturnType<typeof useQueueStore>
 type ExecutionStore = ReturnType<typeof useExecutionStore>
 
+type EstimateRange = [number, number]
+
 export type UseQueueEstimatesOptions = {
   queueStore: QueueStore
   executionStore: ExecutionStore
@@ -17,8 +19,6 @@ export type UseQueueEstimatesOptions = {
   jobsAhead: ComputedRef<number | null>
   nowTs: Ref<number>
 }
-
-type EstimateRange = [number, number]
 
 export const formatElapsedTime = (ms: number): string => {
   const totalSec = Math.max(0, Math.floor(ms / 1000))

--- a/src/components/rightSidePanel/errors/types.ts
+++ b/src/components/rightSidePanel/errors/types.ts
@@ -1,6 +1,15 @@
 import type { ResolvedErrorMessage } from '@/platform/errorCatalog/types'
 import type { NodeExecutionId } from '@/types/nodeIdentification'
 
+interface ErrorGroupBase extends Omit<ResolvedErrorMessage, 'displayTitle'> {
+  /** Stable structural key used for rendering, collapse state, and cache identity. */
+  groupKey: string
+  /** Human-friendly title resolved for UI display. */
+  displayTitle: string
+  count: number
+  priority: number
+}
+
 export interface ErrorItem extends ResolvedErrorMessage {
   /** Raw source/API-compatible message. */
   message: string
@@ -17,15 +26,6 @@ export interface ErrorCardData {
   nodeTitle?: string
   graphNodeId?: string
   errors: ErrorItem[]
-}
-
-interface ErrorGroupBase extends Omit<ResolvedErrorMessage, 'displayTitle'> {
-  /** Stable structural key used for rendering, collapse state, and cache identity. */
-  groupKey: string
-  /** Human-friendly title resolved for UI display. */
-  displayTitle: string
-  count: number
-  priority: number
 }
 
 export type ErrorGroup =

--- a/src/components/rightSidePanel/errors/useErrorGroups.ts
+++ b/src/components/rightSidePanel/errors/useErrorGroups.ts
@@ -48,18 +48,6 @@ const PROMPT_CARD_ID = '__prompt__'
 /** Sentinel: distinguishes "fetch in-flight" from "fetch done, pack not found (null)". */
 const RESOLVING = '__RESOLVING__'
 
-export interface MissingPackGroup {
-  packId: string | null
-  nodeTypes: MissingNodeType[]
-  isResolving: boolean
-}
-
-export interface SwapNodeGroup {
-  type: string
-  newNodeId: string | undefined
-  nodeTypes: MissingNodeType[]
-}
-
 interface GroupEntry {
   type: 'execution'
   displayTitle: string
@@ -227,6 +215,18 @@ function searchErrorGroups(groups: ErrorGroup[], query: string) {
       }
     })
     .filter((group) => group.type !== 'execution' || group.cards.length > 0)
+}
+
+export interface MissingPackGroup {
+  packId: string | null
+  nodeTypes: MissingNodeType[]
+  isResolving: boolean
+}
+
+export interface SwapNodeGroup {
+  type: string
+  newNodeId: string | undefined
+  nodeTypes: MissingNodeType[]
 }
 
 export function useErrorGroups(searchQuery: MaybeRefOrGetter<string>) {

--- a/src/components/rightSidePanel/shared.ts
+++ b/src/components/rightSidePanel/shared.ts
@@ -15,12 +15,6 @@ export const GetNodeParentGroupKey: InjectionKey<
   (node: LGraphNode) => LGraphGroup | null
 > = Symbol('getNodeParentGroup')
 
-export type NodeWidgetsList = Array<{ node: LGraphNode; widget: IBaseWidget }>
-export type NodeWidgetsListList = Array<{
-  node: LGraphNode
-  widgets: NodeWidgetsList
-}>
-
 interface WidgetSearchItem {
   index: number
   searchableLabel: string
@@ -28,97 +22,13 @@ interface WidgetSearchItem {
   searchableType: string
   searchableValue: string
 }
-
-/**
- * Searches widgets in a list using fuzzy search and returns search results.
- * Uses Fuse.js for better matching with typo tolerance and relevance ranking.
- * Filters by name, localized label, type, and user-input value.
- */
-export function searchWidgets<T extends { widget: IBaseWidget }[]>(
-  list: T,
-  query: string
-): T {
-  if (query.trim() === '') {
-    return list
-  }
-
-  const searchableList: WidgetSearchItem[] = list.map((item, index) => {
-    const searchableItem = {
-      index,
-      searchableLabel: item.widget.label?.toLowerCase() || '',
-      searchableName: item.widget.name.toLowerCase(),
-      searchableType: item.widget.type.toLowerCase(),
-      searchableValue: item.widget.value?.toString().toLowerCase() || ''
-    }
-    return searchableItem
-  })
-
-  const fuseOptions: IFuseOptions<WidgetSearchItem> = {
-    keys: [
-      { name: 'searchableName', weight: 0.4 },
-      { name: 'searchableLabel', weight: 0.3 },
-      { name: 'searchableValue', weight: 0.3 },
-      { name: 'searchableType', weight: 0.2 }
-    ],
-    threshold: 0.3
-  }
-
-  const fuse = new Fuse(searchableList, fuseOptions)
-  const results = fuse.search(query.trim())
-
-  const matchedItems = new Set(
-    results.map((result) => list[result.item.index]!)
-  )
-
-  return list.filter((item) => matchedItems.has(item)) as T
-}
-
 type NodeSearchItem = {
   nodeId: NodeId
   searchableTitle: string
 }
 
-/**
- * Searches widgets and nodes in a list using fuzzy search and returns search results.
- * Uses Fuse.js for node title matching with typo tolerance and relevance ranking.
- * First checks if the node title matches the query (if so, keeps entire node).
- * Otherwise, filters widgets using searchWidgets.
- */
-export function searchWidgetsAndNodes(
-  list: NodeWidgetsListList,
-  query: string
-): NodeWidgetsListList {
-  if (query.trim() === '') {
-    return list
-  }
-
-  const searchableList: NodeSearchItem[] = list.map((item) => ({
-    nodeId: item.node.id,
-    searchableTitle: (item.node.getTitle() ?? '').toLowerCase()
-  }))
-
-  const fuseOptions: IFuseOptions<NodeSearchItem> = {
-    keys: [{ name: 'searchableTitle', weight: 1.0 }],
-    threshold: 0.3
-  }
-
-  const fuse = new Fuse(searchableList, fuseOptions)
-  const nodeMatches = fuse.search(query.trim())
-  const matchedNodeIds = new Set(
-    nodeMatches.map((result) => result.item.nodeId)
-  )
-
-  return list.flatMap((item) => {
-    if (matchedNodeIds.has(item.node.id)) {
-      return [item]
-    }
-
-    const widgets = searchWidgets(item.widgets, query)
-    return widgets.length > 0 ? [{ ...item, widgets }] : []
-  })
-}
-
 type MixedSelectionItem = LGraphGroup | LGraphNode
+
 type FlatAndCategorizeSelectedItemsResult = {
   all: MixedSelectionItem[]
   nodes: LGraphNode[]
@@ -131,48 +41,6 @@ type FlatItemsContext = {
   nodeToParentGroup: Map<LGraphNode, LGraphGroup>
   depth: number
   parentGroup?: LGraphGroup
-}
-
-/**
- * The selected items may contain "Group" nodes, which can include child nodes.
- * This function flattens such structures and categorizes items into:
- * - all: all categorizable nodes (does not include nodes in "others")
- * - nodes: node items
- * - groups: group items
- * - others: items not currently supported
- * - nodeToParentGroup: a map from each node to its direct parent group (if any)
- * @param items The selected items to flatten and categorize
- * @returns An object containing arrays: all, nodes, groups, others, and nodeToParentGroup map
- */
-export function flatAndCategorizeSelectedItems(
-  items: Positionable[]
-): FlatAndCategorizeSelectedItemsResult {
-  const ctx: FlatItemsContext = {
-    nodeToParentGroup: new Map<LGraphNode, LGraphGroup>(),
-    depth: 0
-  }
-  const { all, nodes, groups, others } = flatItems(items, ctx)
-  return {
-    all: repeatItems(all),
-    nodes: repeatItems(nodes),
-    groups: repeatItems(groups),
-    others: repeatItems(others),
-    nodeToParentGroup: ctx.nodeToParentGroup
-  }
-}
-
-export function useFlatAndCategorizeSelectedItems(
-  items: MaybeRefOrGetter<Positionable[]>
-) {
-  const result = computed(() => flatAndCategorizeSelectedItems(toValue(items)))
-
-  return {
-    flattedItems: computed(() => result.value.all),
-    selectedNodes: computed(() => result.value.nodes),
-    selectedGroups: computed(() => result.value.groups),
-    selectedOthers: computed(() => result.value.others),
-    nodeToParentGroup: computed(() => result.value.nodeToParentGroup)
-  }
 }
 
 function flatItems(
@@ -245,6 +113,138 @@ function repeatItems<T>(items: T[]): T[] {
     result.push(item)
   }
   return result
+}
+export type NodeWidgetsList = Array<{ node: LGraphNode; widget: IBaseWidget }>
+
+export type NodeWidgetsListList = Array<{
+  node: LGraphNode
+  widgets: NodeWidgetsList
+}>
+
+/**
+ * Searches widgets in a list using fuzzy search and returns search results.
+ * Uses Fuse.js for better matching with typo tolerance and relevance ranking.
+ * Filters by name, localized label, type, and user-input value.
+ */
+export function searchWidgets<T extends { widget: IBaseWidget }[]>(
+  list: T,
+  query: string
+): T {
+  if (query.trim() === '') {
+    return list
+  }
+
+  const searchableList: WidgetSearchItem[] = list.map((item, index) => {
+    const searchableItem = {
+      index,
+      searchableLabel: item.widget.label?.toLowerCase() || '',
+      searchableName: item.widget.name.toLowerCase(),
+      searchableType: item.widget.type.toLowerCase(),
+      searchableValue: item.widget.value?.toString().toLowerCase() || ''
+    }
+    return searchableItem
+  })
+
+  const fuseOptions: IFuseOptions<WidgetSearchItem> = {
+    keys: [
+      { name: 'searchableName', weight: 0.4 },
+      { name: 'searchableLabel', weight: 0.3 },
+      { name: 'searchableValue', weight: 0.3 },
+      { name: 'searchableType', weight: 0.2 }
+    ],
+    threshold: 0.3
+  }
+
+  const fuse = new Fuse(searchableList, fuseOptions)
+  const results = fuse.search(query.trim())
+
+  const matchedItems = new Set(
+    results.map((result) => list[result.item.index]!)
+  )
+
+  return list.filter((item) => matchedItems.has(item)) as T
+}
+
+/**
+ * Searches widgets and nodes in a list using fuzzy search and returns search results.
+ * Uses Fuse.js for node title matching with typo tolerance and relevance ranking.
+ * First checks if the node title matches the query (if so, keeps entire node).
+ * Otherwise, filters widgets using searchWidgets.
+ */
+export function searchWidgetsAndNodes(
+  list: NodeWidgetsListList,
+  query: string
+): NodeWidgetsListList {
+  if (query.trim() === '') {
+    return list
+  }
+
+  const searchableList: NodeSearchItem[] = list.map((item) => ({
+    nodeId: item.node.id,
+    searchableTitle: (item.node.getTitle() ?? '').toLowerCase()
+  }))
+
+  const fuseOptions: IFuseOptions<NodeSearchItem> = {
+    keys: [{ name: 'searchableTitle', weight: 1.0 }],
+    threshold: 0.3
+  }
+
+  const fuse = new Fuse(searchableList, fuseOptions)
+  const nodeMatches = fuse.search(query.trim())
+  const matchedNodeIds = new Set(
+    nodeMatches.map((result) => result.item.nodeId)
+  )
+
+  return list.flatMap((item) => {
+    if (matchedNodeIds.has(item.node.id)) {
+      return [item]
+    }
+
+    const widgets = searchWidgets(item.widgets, query)
+    return widgets.length > 0 ? [{ ...item, widgets }] : []
+  })
+}
+
+/**
+ * The selected items may contain "Group" nodes, which can include child nodes.
+ * This function flattens such structures and categorizes items into:
+ * - all: all categorizable nodes (does not include nodes in "others")
+ * - nodes: node items
+ * - groups: group items
+ * - others: items not currently supported
+ * - nodeToParentGroup: a map from each node to its direct parent group (if any)
+ * @param items The selected items to flatten and categorize
+ * @returns An object containing arrays: all, nodes, groups, others, and nodeToParentGroup map
+ */
+export function flatAndCategorizeSelectedItems(
+  items: Positionable[]
+): FlatAndCategorizeSelectedItemsResult {
+  const ctx: FlatItemsContext = {
+    nodeToParentGroup: new Map<LGraphNode, LGraphGroup>(),
+    depth: 0
+  }
+  const { all, nodes, groups, others } = flatItems(items, ctx)
+  return {
+    all: repeatItems(all),
+    nodes: repeatItems(nodes),
+    groups: repeatItems(groups),
+    others: repeatItems(others),
+    nodeToParentGroup: ctx.nodeToParentGroup
+  }
+}
+
+export function useFlatAndCategorizeSelectedItems(
+  items: MaybeRefOrGetter<Positionable[]>
+) {
+  const result = computed(() => flatAndCategorizeSelectedItems(toValue(items)))
+
+  return {
+    flattedItems: computed(() => result.value.all),
+    selectedNodes: computed(() => result.value.nodes),
+    selectedGroups: computed(() => result.value.groups),
+    selectedOthers: computed(() => result.value.others),
+    nodeToParentGroup: computed(() => result.value.nodeToParentGroup)
+  }
 }
 
 export function computedSectionDataList(nodes: MaybeRefOrGetter<LGraphNode[]>) {

--- a/src/components/ui/chart/useChart.ts
+++ b/src/components/ui/chart/useChart.ts
@@ -123,6 +123,33 @@ function getDefaultOptions(type: ChartType): ChartOptions {
   }
 }
 
+function deepMerge<T extends Record<string, unknown>>(
+  target: T,
+  source: Record<string, unknown>
+): T {
+  const result = { ...target } as Record<string, unknown>
+  for (const key of Object.keys(source)) {
+    const srcVal = source[key]
+    const tgtVal = result[key]
+    if (
+      srcVal &&
+      typeof srcVal === 'object' &&
+      !Array.isArray(srcVal) &&
+      tgtVal &&
+      typeof tgtVal === 'object' &&
+      !Array.isArray(tgtVal)
+    ) {
+      result[key] = deepMerge(
+        tgtVal as Record<string, unknown>,
+        srcVal as Record<string, unknown>
+      )
+    } else {
+      result[key] = srcVal
+    }
+  }
+  return result as T
+}
+
 export function useChart(
   canvasRef: Ref<HTMLCanvasElement | null>,
   type: Ref<ChartType>,
@@ -166,31 +193,4 @@ export function useChart(
   })
 
   return { chartInstance }
-}
-
-function deepMerge<T extends Record<string, unknown>>(
-  target: T,
-  source: Record<string, unknown>
-): T {
-  const result = { ...target } as Record<string, unknown>
-  for (const key of Object.keys(source)) {
-    const srcVal = source[key]
-    const tgtVal = result[key]
-    if (
-      srcVal &&
-      typeof srcVal === 'object' &&
-      !Array.isArray(srcVal) &&
-      tgtVal &&
-      typeof tgtVal === 'object' &&
-      !Array.isArray(tgtVal)
-    ) {
-      result[key] = deepMerge(
-        tgtVal as Record<string, unknown>,
-        srcVal as Record<string, unknown>
-      )
-    } else {
-      result[key] = srcVal
-    }
-  }
-  return result as T
 }

--- a/src/composables/boundingBoxes/boundingBoxesUtil.ts
+++ b/src/composables/boundingBoxes/boundingBoxesUtil.ts
@@ -1,5 +1,18 @@
 import type { BoundingBox, BoundingBoxMetadata } from '@/types/boundingBoxes'
 
+interface BoxCandidate {
+  index: number
+  mode: HitMode
+}
+
+interface TagRect {
+  x: number
+  y: number
+  w: number
+  h: number
+  tag: string
+}
+
 export type HitMode =
   | 'move'
   | 'draw'
@@ -17,19 +30,6 @@ export interface Region extends BoundingBoxMetadata {
   y: number
   w: number
   h: number
-}
-
-interface BoxCandidate {
-  index: number
-  mode: HitMode
-}
-
-interface TagRect {
-  x: number
-  y: number
-  w: number
-  h: number
-  tag: string
 }
 
 const clamp01 = (v: number) => Math.max(0, Math.min(1, v))
@@ -73,6 +73,33 @@ function rectHitTest(
   if (my >= y1 && my <= y2 && Math.abs(mx - x2) < rx) return 'resize-r'
   if (mx >= x1 && mx <= x2 && my >= y1 && my <= y2) return 'move'
   return null
+}
+
+function isBoundingBox(b: unknown): b is BoundingBox {
+  if (!b || typeof b !== 'object') return false
+  const box = b as Record<string, unknown>
+  return (
+    typeof box.x === 'number' &&
+    typeof box.y === 'number' &&
+    typeof box.width === 'number' &&
+    typeof box.height === 'number'
+  )
+}
+
+function normalizeHexColor(color: unknown): string | null {
+  if (typeof color !== 'string') return null
+  const hex = color.trim().toLowerCase()
+  const short = /^#([0-9a-f])([0-9a-f])([0-9a-f])$/.exec(hex)
+  if (short) {
+    return `#${short[1]}${short[1]}${short[2]}${short[2]}${short[3]}${short[3]}`
+  }
+  return /^#([0-9a-f]{6}|[0-9a-f]{8})$/.test(hex) ? hex : null
+}
+
+function normalizePalette(palette: unknown): string[] {
+  return Array.isArray(palette)
+    ? palette.map(normalizeHexColor).filter((c): c is string => c !== null)
+    : []
 }
 
 export function applyDrag(
@@ -189,33 +216,6 @@ export function tagRects(
     rects[i] = r
   }
   return rects
-}
-
-function isBoundingBox(b: unknown): b is BoundingBox {
-  if (!b || typeof b !== 'object') return false
-  const box = b as Record<string, unknown>
-  return (
-    typeof box.x === 'number' &&
-    typeof box.y === 'number' &&
-    typeof box.width === 'number' &&
-    typeof box.height === 'number'
-  )
-}
-
-function normalizeHexColor(color: unknown): string | null {
-  if (typeof color !== 'string') return null
-  const hex = color.trim().toLowerCase()
-  const short = /^#([0-9a-f])([0-9a-f])([0-9a-f])$/.exec(hex)
-  if (short) {
-    return `#${short[1]}${short[1]}${short[2]}${short[2]}${short[3]}${short[3]}`
-  }
-  return /^#([0-9a-f]{6}|[0-9a-f]{8})$/.test(hex) ? hex : null
-}
-
-function normalizePalette(palette: unknown): string[] {
-  return Array.isArray(palette)
-    ? palette.map(normalizeHexColor).filter((c): c is string => c !== null)
-    : []
 }
 
 export function fromBoundingBoxes(

--- a/src/composables/boundingBoxes/useBoundingBoxes.test.ts
+++ b/src/composables/boundingBoxes/useBoundingBoxes.test.ts
@@ -55,6 +55,13 @@ const ctx = {
   lineWidth: 0
 } as unknown as CanvasRenderingContext2D
 
+interface MockNode {
+  widgets: { name: string; value: unknown }[]
+  findInputSlot: (name: string) => number
+  getInputNode: () => null
+  isInputConnected?: () => boolean
+}
+
 function makeCanvas(): HTMLCanvasElement {
   const el = document.createElement('canvas')
   Object.defineProperty(el, 'clientWidth', { value: 100, configurable: true })
@@ -76,13 +83,6 @@ function makeCanvas(): HTMLCanvasElement {
   el.setPointerCapture = () => {}
   el.releasePointerCapture = () => {}
   return el
-}
-
-interface MockNode {
-  widgets: { name: string; value: unknown }[]
-  findInputSlot: (name: string) => number
-  getInputNode: () => null
-  isInputConnected?: () => boolean
 }
 
 function makeNode(): MockNode {

--- a/src/composables/canvas/useSelectionToolboxPosition.ts
+++ b/src/composables/canvas/useSelectionToolboxPosition.ts
@@ -84,6 +84,14 @@ function getSelectionBounds(
   return getFullNodeBounds(item)
 }
 
+// External cleanup utility to be called when SelectionToolbox component unmounts
+function resetMoreOptionsState() {
+  moreOptionsOpen.value = false
+  moreOptionsRestorePending.value = false
+  moreOptionsWasOpenBeforeDrag = false
+  moreOptionsSelectionSignature = null
+}
+
 export function useSelectionToolboxPosition(
   toolboxRef: Ref<HTMLElement | undefined>
 ) {
@@ -284,12 +292,4 @@ export function useSelectionToolboxPosition(
   return {
     visible
   }
-}
-
-// External cleanup utility to be called when SelectionToolbox component unmounts
-function resetMoreOptionsState() {
-  moreOptionsOpen.value = false
-  moreOptionsRestorePending.value = false
-  moreOptionsWasOpenBeforeDrag = false
-  moreOptionsSelectionSignature = null
 }

--- a/src/composables/element/useAbsolutePosition.ts
+++ b/src/composables/element/useAbsolutePosition.ts
@@ -6,6 +6,11 @@ import type { Size, Vector2 } from '@/lib/litegraph/src/litegraph'
 import { useSettingStore } from '@/platform/settings/settingStore'
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 
+interface UseAbsolutePositionReturn {
+  style: Ref<CSSProperties>
+  updatePosition: (config: PositionConfig) => void
+}
+
 export interface PositionConfig {
   /* The position of the element on litegraph canvas */
   pos: Vector2
@@ -13,11 +18,6 @@ export interface PositionConfig {
   size: Size
   /* The scale factor of the canvas */
   scale?: number
-}
-
-interface UseAbsolutePositionReturn {
-  style: Ref<CSSProperties>
-  updatePosition: (config: PositionConfig) => void
 }
 
 export function useAbsolutePosition(

--- a/src/composables/element/useDomClipping.ts
+++ b/src/composables/element/useDomClipping.ts
@@ -8,22 +8,6 @@ interface Rect {
   height: number
 }
 
-/**
- * Finds the intersection between two rectangles
- */
-function intersect(a: Rect, b: Rect): [number, number, number, number] | null {
-  const x1 = Math.max(a.x, b.x)
-  const y1 = Math.max(a.y, b.y)
-  const x2 = Math.min(a.x + a.width, b.x + b.width)
-  const y2 = Math.min(a.y + a.height, b.y + b.height)
-
-  if (x1 >= x2 || y1 >= y2) {
-    return null
-  }
-
-  return [x1, y1, x2 - x1, y2 - y1]
-}
-
 interface ClippingOptions {
   margin?: number
 }
@@ -43,6 +27,22 @@ interface UseDomClippingReturn {
       offset: [number, number]
     }
   ) => void
+}
+
+/**
+ * Finds the intersection between two rectangles
+ */
+function intersect(a: Rect, b: Rect): [number, number, number, number] | null {
+  const x1 = Math.max(a.x, b.x)
+  const y1 = Math.max(a.y, b.y)
+  const x2 = Math.min(a.x + a.width, b.x + b.width)
+  const y2 = Math.min(a.y + a.height, b.y + b.height)
+
+  if (x1 >= x2 || y1 >= y2) {
+    return null
+  }
+
+  return [x1, y1, x2 - x1, y2 - y1]
 }
 
 export function useDomClipping(

--- a/src/composables/graph/contextMenuConverter.ts
+++ b/src/composables/graph/contextMenuConverter.ts
@@ -268,6 +268,172 @@ function getMenuItemOrder(label: string): number {
 }
 
 /**
+ * Capture submenu items from a dynamic submenu callback
+ * Intercepts ContextMenu constructor to extract items without creating HTML menu
+ */
+function captureDynamicSubmenu(
+  item: IContextMenuValue,
+  node?: LGraphNode
+): SubMenuOption[] | undefined {
+  let capturedItems: readonly (IContextMenuValue | string | null)[] | undefined
+  let capturedOptions: IContextMenuOptions | undefined
+
+  // Store original ContextMenu constructor
+  const OriginalContextMenu = LiteGraph.ContextMenu
+
+  try {
+    // Mock ContextMenu constructor to capture submenu items and options
+    LiteGraph.ContextMenu = function (
+      items: readonly (IContextMenuValue | string | null)[],
+      options?: IContextMenuOptions
+    ) {
+      // Capture both items and options
+      capturedItems = items
+      capturedOptions = options
+      // Return a minimal mock object to prevent errors
+      return {
+        close: () => {},
+        root: document.createElement('div')
+      } as unknown as ContextMenu
+    } as unknown as typeof ContextMenu
+
+    // Execute the callback to trigger submenu creation
+    try {
+      // Create a mock MouseEvent for the callback
+      const mockEvent = new MouseEvent('click', {
+        bubbles: true,
+        cancelable: true,
+        clientX: 0,
+        clientY: 0
+      })
+
+      // Create a mock parent menu
+      const mockMenu = {
+        close: () => {},
+        root: document.createElement('div')
+      } as unknown as ContextMenu
+
+      // Call the callback which should trigger ContextMenu constructor
+      // Callback signature varies, but typically: (value, options, event, menu, node)
+      void item.callback?.call(
+        item as unknown as ContextMenuDivElement,
+        item.value,
+        {},
+        mockEvent,
+        mockMenu,
+        node // Pass the node context for callbacks that need it
+      )
+    } catch (error) {
+      console.warn(
+        '[ContextMenuConverter] Error executing callback for:',
+        item.content,
+        error
+      )
+    }
+  } finally {
+    // Always restore original constructor
+    LiteGraph.ContextMenu = OriginalContextMenu
+  }
+
+  // Convert captured items to Vue submenu format
+  if (capturedItems) {
+    const converted = convertSubmenuToOptions(capturedItems, capturedOptions)
+    return converted
+  }
+
+  console.warn('[ContextMenuConverter] No items captured for:', item.content)
+  return undefined
+}
+
+/**
+ * Convert LiteGraph submenu items to Vue SubMenuOption format
+ */
+function convertSubmenuToOptions(
+  items: readonly (IContextMenuValue | string | null)[],
+  options?: IContextMenuOptions
+): SubMenuOption[] {
+  const result: SubMenuOption[] = []
+
+  for (const item of items) {
+    // Skip null separators
+    if (item === null) {
+      continue
+    }
+
+    // Handle string items (simple labels like in Mode/Shapes menus)
+    if (typeof item === 'string') {
+      const subOption: SubMenuOption = {
+        label: item,
+        action: () => {
+          try {
+            // Call the options callback with the string value
+            if (options?.callback) {
+              void options.callback.call(
+                null,
+                item,
+                options,
+                undefined,
+                undefined,
+                options.extra
+              )
+            }
+          } catch (error) {
+            console.error('Error executing string item callback:', error)
+          }
+        }
+      }
+      result.push(subOption)
+      continue
+    }
+
+    // Handle object items
+    if (!item.content) {
+      continue
+    }
+
+    // Extract text content from HTML if present
+    const content = stripHtmlTags(item.content)
+
+    const subOption: SubMenuOption = {
+      label: content,
+      action: () => {
+        try {
+          void item.callback?.call(
+            item as unknown as ContextMenuDivElement,
+            item.value,
+            {},
+            undefined,
+            undefined,
+            item
+          )
+        } catch (error) {
+          console.error('Error executing submenu callback:', error)
+        }
+      }
+    }
+
+    // Pass through disabled state
+    if (item.disabled) {
+      subOption.disabled = true
+    }
+
+    result.push(subOption)
+  }
+  return result
+}
+
+/**
+ * Strip HTML tags from content string safely
+ * LiteGraph menu items often include HTML for styling
+ */
+function stripHtmlTags(html: string): string {
+  // Use DOMPurify to sanitize and strip all HTML tags
+  const sanitized = DOMPurify.sanitize(html, { ALLOWED_TAGS: [] })
+  const result = sanitized.trim()
+  return result || html.replace(/<[^>]*>/g, '').trim() || html
+}
+
+/**
  * Build structured menu with core items first, then extensions under a labeled section
  * Ensures Delete always appears at the bottom
  */
@@ -474,170 +640,4 @@ export function convertContextMenuToOptions(
   }
 
   return result
-}
-
-/**
- * Capture submenu items from a dynamic submenu callback
- * Intercepts ContextMenu constructor to extract items without creating HTML menu
- */
-function captureDynamicSubmenu(
-  item: IContextMenuValue,
-  node?: LGraphNode
-): SubMenuOption[] | undefined {
-  let capturedItems: readonly (IContextMenuValue | string | null)[] | undefined
-  let capturedOptions: IContextMenuOptions | undefined
-
-  // Store original ContextMenu constructor
-  const OriginalContextMenu = LiteGraph.ContextMenu
-
-  try {
-    // Mock ContextMenu constructor to capture submenu items and options
-    LiteGraph.ContextMenu = function (
-      items: readonly (IContextMenuValue | string | null)[],
-      options?: IContextMenuOptions
-    ) {
-      // Capture both items and options
-      capturedItems = items
-      capturedOptions = options
-      // Return a minimal mock object to prevent errors
-      return {
-        close: () => {},
-        root: document.createElement('div')
-      } as unknown as ContextMenu
-    } as unknown as typeof ContextMenu
-
-    // Execute the callback to trigger submenu creation
-    try {
-      // Create a mock MouseEvent for the callback
-      const mockEvent = new MouseEvent('click', {
-        bubbles: true,
-        cancelable: true,
-        clientX: 0,
-        clientY: 0
-      })
-
-      // Create a mock parent menu
-      const mockMenu = {
-        close: () => {},
-        root: document.createElement('div')
-      } as unknown as ContextMenu
-
-      // Call the callback which should trigger ContextMenu constructor
-      // Callback signature varies, but typically: (value, options, event, menu, node)
-      void item.callback?.call(
-        item as unknown as ContextMenuDivElement,
-        item.value,
-        {},
-        mockEvent,
-        mockMenu,
-        node // Pass the node context for callbacks that need it
-      )
-    } catch (error) {
-      console.warn(
-        '[ContextMenuConverter] Error executing callback for:',
-        item.content,
-        error
-      )
-    }
-  } finally {
-    // Always restore original constructor
-    LiteGraph.ContextMenu = OriginalContextMenu
-  }
-
-  // Convert captured items to Vue submenu format
-  if (capturedItems) {
-    const converted = convertSubmenuToOptions(capturedItems, capturedOptions)
-    return converted
-  }
-
-  console.warn('[ContextMenuConverter] No items captured for:', item.content)
-  return undefined
-}
-
-/**
- * Convert LiteGraph submenu items to Vue SubMenuOption format
- */
-function convertSubmenuToOptions(
-  items: readonly (IContextMenuValue | string | null)[],
-  options?: IContextMenuOptions
-): SubMenuOption[] {
-  const result: SubMenuOption[] = []
-
-  for (const item of items) {
-    // Skip null separators
-    if (item === null) {
-      continue
-    }
-
-    // Handle string items (simple labels like in Mode/Shapes menus)
-    if (typeof item === 'string') {
-      const subOption: SubMenuOption = {
-        label: item,
-        action: () => {
-          try {
-            // Call the options callback with the string value
-            if (options?.callback) {
-              void options.callback.call(
-                null,
-                item,
-                options,
-                undefined,
-                undefined,
-                options.extra
-              )
-            }
-          } catch (error) {
-            console.error('Error executing string item callback:', error)
-          }
-        }
-      }
-      result.push(subOption)
-      continue
-    }
-
-    // Handle object items
-    if (!item.content) {
-      continue
-    }
-
-    // Extract text content from HTML if present
-    const content = stripHtmlTags(item.content)
-
-    const subOption: SubMenuOption = {
-      label: content,
-      action: () => {
-        try {
-          void item.callback?.call(
-            item as unknown as ContextMenuDivElement,
-            item.value,
-            {},
-            undefined,
-            undefined,
-            item
-          )
-        } catch (error) {
-          console.error('Error executing submenu callback:', error)
-        }
-      }
-    }
-
-    // Pass through disabled state
-    if (item.disabled) {
-      subOption.disabled = true
-    }
-
-    result.push(subOption)
-  }
-  return result
-}
-
-/**
- * Strip HTML tags from content string safely
- * LiteGraph menu items often include HTML for styling
- */
-function stripHtmlTags(html: string): string {
-  // Use DOMPurify to sanitize and strip all HTML tags
-  const sanitized = DOMPurify.sanitize(html, { ALLOWED_TAGS: [] })
-  const result = sanitized.trim()
-  return result || html.replace(/<[^>]*>/g, '').trim() || html
 }

--- a/src/composables/graph/useArrangeNodes.ts
+++ b/src/composables/graph/useArrangeNodes.ts
@@ -144,6 +144,11 @@ const arrangeGrid = (
   })
 }
 
+interface ArrangeOptions {
+  gap?: number
+  captureUndo?: boolean
+}
+
 export function computeArrangement(
   nodes: LGraphNode[],
   layout: ArrangeLayout,
@@ -155,11 +160,6 @@ export function computeArrangement(
   if (layout === 'vertical') return arrangeVertical(boxes, anchor, gap)
   if (layout === 'horizontal') return arrangeHorizontal(boxes, anchor, gap)
   return arrangeGrid(boxes, anchor, gap)
-}
-
-interface ArrangeOptions {
-  gap?: number
-  captureUndo?: boolean
 }
 
 export function useArrangeNodes() {

--- a/src/composables/graph/useErrorClearingHooks.ts
+++ b/src/composables/graph/useErrorClearingHooks.ts
@@ -59,6 +59,11 @@ type OriginalCallbacks = {
 
 const originalCallbacks = new WeakMap<LGraphNode, OriginalCallbacks>()
 
+interface PendingScanControl {
+  cancel: () => void
+  finish: () => void
+}
+
 function getRemovedNodeExecutionId(graph: LGraph, nodeId: NodeId): string {
   if (!app.rootGraph) return String(nodeId)
 
@@ -410,11 +415,6 @@ async function runAddedNodeScan(
   } finally {
     await Promise.allSettled(pendingVerifications)
   }
-}
-
-interface PendingScanControl {
-  cancel: () => void
-  finish: () => void
 }
 
 function scheduleAddedNodeScan(

--- a/src/composables/graph/useGraphNodeManager.ts
+++ b/src/composables/graph/useGraphNodeManager.ts
@@ -42,115 +42,18 @@ import type { TitleMode } from '@/lib/litegraph/src/types/globalEnums'
 import { NodeSlotType } from '@/lib/litegraph/src/types/globalEnums'
 import { app } from '@/scripts/app'
 
-export interface WidgetSlotMetadata {
-  index: number
-  linked: boolean
-  originNodeId?: NodeId
-  originOutputName?: string
-  type: string
-}
-
 type Badges = (LGraphBadge | (() => LGraphBadge))[]
-
-/**
- * Minimal render-specific widget data extracted from LiteGraph widgets.
- * Value and metadata (label, hidden, disabled, etc.) are accessed via widgetValueStore.
- */
-export interface SafeWidgetData {
-  widgetId?: WidgetId
-  nodeId?: NodeId
-  name: string
-  type: string
-  /** Callback to invoke when widget value changes (wraps LiteGraph callback + triggerDraw) */
-  callback?: ((value: unknown) => void) | undefined
-  /** Control widget for seed randomization/increment/decrement */
-  controlWidget?: SafeControlWidget
-  /** Whether widget has custom layout size computation */
-  hasLayoutSize?: boolean
-  /** Whether widget is a DOM widget */
-  isDOMWidget?: boolean
-  /**
-   * Widget options needed for render decisions.
-   * Note: Most metadata should be accessed via widgetValueStore.getWidget().
-   */
-  options?: {
-    canvasOnly?: boolean
-    advanced?: boolean
-    hidden?: boolean
-    read_only?: boolean
-    values?: unknown
-  }
-  /** Input specification from node definition */
-  spec?: InputSpec
-  /** Input slot metadata (index and link status) */
-  slotMetadata?: WidgetSlotMetadata
-  /**
-   * Execution ID of the interior node that owns the source widget.
-   * Only set for promoted widgets where the source node differs from the host
-   * subgraph node. Retained for source-scoped validation errors.
-   */
-  sourceExecutionId?: NodeExecutionId
-  /**
-   * Interior source widget name. Only set for promoted widgets, where `name` is
-   * the host input slot name and the source widget name can differ.
-   */
-  sourceWidgetName?: string
-  /** Tooltip text from the resolved widget. */
-  tooltip?: string
-}
-
-export interface VueNodeData {
-  executing: boolean
-  id: NodeId
-  mode: number
-  selected: boolean
-  title: string
-  type: string
-  apiNode?: boolean
-  badges?: Badges
-  bgcolor?: string
-  color?: string
-  flags?: {
-    collapsed?: boolean
-    ghost?: boolean
-    pinned?: boolean
-  }
-  hasErrors?: boolean
-  inputs?: INodeInputSlot[]
-  outputs?: INodeOutputSlot[]
-  resizable?: boolean
-  shape?: number
-  showAdvanced?: boolean
-  subgraphId?: string | null
-  titleMode?: TitleMode
-  widgets?: SafeWidgetData[]
-}
-
-export interface GraphNodeManager {
-  // Reactive state - safe data extracted from LiteGraph nodes
-  vueNodeData: ReadonlyMap<NodeId, VueNodeData>
-
-  // Access to original LiteGraph nodes (non-reactive)
-  getNode(id: NodeId): LGraphNode | undefined
-
-  // Lifecycle methods
-  cleanup(): void
-}
-
-export function getControlWidget(
-  widget: IBaseWidget
-): SafeControlWidget | undefined {
-  const cagWidget = widget.linkedWidgets?.find((w) => w[IS_CONTROL_WIDGET])
-  if (!cagWidget) return
-  return {
-    value: normalizeControlOption(cagWidget.value),
-    update: (value) => (cagWidget.value = normalizeControlOption(value))
-  }
-}
 
 interface SharedWidgetEnhancements {
   controlWidget?: SafeControlWidget
   spec?: InputSpec
+}
+
+interface PromotedWidgetMetadata {
+  controlWidget?: SafeControlWidget
+  isDOMWidget: boolean
+  sourceExecutionId?: NodeExecutionId
+  sourceWidgetName?: string
 }
 
 function getSharedWidgetEnhancements(
@@ -214,13 +117,6 @@ function isDOMBackedWidget(widget: IBaseWidget): boolean {
     ('element' in widget && !!widget.element) ||
     ('component' in widget && !!widget.component)
   )
-}
-
-interface PromotedWidgetMetadata {
-  controlWidget?: SafeControlWidget
-  isDOMWidget: boolean
-  sourceExecutionId?: NodeExecutionId
-  sourceWidgetName?: string
 }
 
 /**
@@ -357,6 +253,110 @@ function buildSlotMetadata(
     if (input.widget?.name) metadata.set(input.widget.name, slotInfo)
   })
   return metadata
+}
+
+export interface WidgetSlotMetadata {
+  index: number
+  linked: boolean
+  originNodeId?: NodeId
+  originOutputName?: string
+  type: string
+}
+
+/**
+ * Minimal render-specific widget data extracted from LiteGraph widgets.
+ * Value and metadata (label, hidden, disabled, etc.) are accessed via widgetValueStore.
+ */
+export interface SafeWidgetData {
+  widgetId?: WidgetId
+  nodeId?: NodeId
+  name: string
+  type: string
+  /** Callback to invoke when widget value changes (wraps LiteGraph callback + triggerDraw) */
+  callback?: ((value: unknown) => void) | undefined
+  /** Control widget for seed randomization/increment/decrement */
+  controlWidget?: SafeControlWidget
+  /** Whether widget has custom layout size computation */
+  hasLayoutSize?: boolean
+  /** Whether widget is a DOM widget */
+  isDOMWidget?: boolean
+  /**
+   * Widget options needed for render decisions.
+   * Note: Most metadata should be accessed via widgetValueStore.getWidget().
+   */
+  options?: {
+    canvasOnly?: boolean
+    advanced?: boolean
+    hidden?: boolean
+    read_only?: boolean
+    values?: unknown
+  }
+  /** Input specification from node definition */
+  spec?: InputSpec
+  /** Input slot metadata (index and link status) */
+  slotMetadata?: WidgetSlotMetadata
+  /**
+   * Execution ID of the interior node that owns the source widget.
+   * Only set for promoted widgets where the source node differs from the host
+   * subgraph node. Retained for source-scoped validation errors.
+   */
+  sourceExecutionId?: NodeExecutionId
+  /**
+   * Interior source widget name. Only set for promoted widgets, where `name` is
+   * the host input slot name and the source widget name can differ.
+   */
+  sourceWidgetName?: string
+  /** Tooltip text from the resolved widget. */
+  tooltip?: string
+}
+
+export interface VueNodeData {
+  executing: boolean
+  id: NodeId
+  mode: number
+  selected: boolean
+  title: string
+  type: string
+  apiNode?: boolean
+  badges?: Badges
+  bgcolor?: string
+  color?: string
+  flags?: {
+    collapsed?: boolean
+    ghost?: boolean
+    pinned?: boolean
+  }
+  hasErrors?: boolean
+  inputs?: INodeInputSlot[]
+  outputs?: INodeOutputSlot[]
+  resizable?: boolean
+  shape?: number
+  showAdvanced?: boolean
+  subgraphId?: string | null
+  titleMode?: TitleMode
+  widgets?: SafeWidgetData[]
+}
+
+export interface GraphNodeManager {
+  // Reactive state - safe data extracted from LiteGraph nodes
+  vueNodeData: ReadonlyMap<NodeId, VueNodeData>
+
+  // Access to original LiteGraph nodes (non-reactive)
+  getNode(id: NodeId): LGraphNode | undefined
+
+  // Lifecycle methods
+  cleanup(): void
+}
+
+export function getControlWidget(
+  widget: IBaseWidget
+): SafeControlWidget | undefined {
+  const cagWidget = widget.linkedWidgets?.find((w) => w[IS_CONTROL_WIDGET])
+  if (!cagWidget) return
+  return {
+    value: normalizeControlOption(cagWidget.value),
+    update: (value) => (cagWidget.value = normalizeControlOption(value))
+  }
 }
 
 // Extract safe data from LiteGraph node for Vue consumption

--- a/src/composables/graph/useMoreOptionsMenu.ts
+++ b/src/composables/graph/useMoreOptionsMenu.ts
@@ -49,6 +49,26 @@ let nodeOptionsInstance: null | NodeOptionsInstance = null
 
 const hoveredWidget = ref<[string, SerializedNodeId | undefined]>()
 
+interface NodeOptionsInstance {
+  toggle: (event: Event) => void
+  show: (event: MouseEvent) => void
+  hide: () => void
+  isOpen: Ref<boolean>
+}
+
+/**
+ * Mark menu options as coming from Vue hardcoded menu
+ */
+function markAsVueOptions(options: MenuOption[]): MenuOption[] {
+  return options.map((opt) => {
+    // Don't mark dividers or category labels
+    if (opt.type === 'divider' || opt.type === 'category') {
+      return opt
+    }
+    return { ...opt, source: 'vue' }
+  })
+}
+
 /**
  * Toggle the node options popover
  * @param event - The trigger event
@@ -82,13 +102,6 @@ export function isNodeOptionsOpen(): boolean {
   return nodeOptionsInstance?.isOpen.value ?? false
 }
 
-interface NodeOptionsInstance {
-  toggle: (event: Event) => void
-  show: (event: MouseEvent) => void
-  hide: () => void
-  isOpen: Ref<boolean>
-}
-
 /**
  * Register the NodeOptions component instance
  * @param instance - The NodeOptions component instance
@@ -97,19 +110,6 @@ export function registerNodeOptionsInstance(
   instance: null | NodeOptionsInstance
 ) {
   nodeOptionsInstance = instance
-}
-
-/**
- * Mark menu options as coming from Vue hardcoded menu
- */
-function markAsVueOptions(options: MenuOption[]): MenuOption[] {
-  return options.map((opt) => {
-    // Don't mark dividers or category labels
-    if (opt.type === 'divider' || opt.type === 'category') {
-      return opt
-    }
-    return { ...opt, source: 'vue' }
-  })
 }
 
 /**

--- a/src/composables/maskeditor/brushDrawingUtils.ts
+++ b/src/composables/maskeditor/brushDrawingUtils.ts
@@ -4,6 +4,8 @@ import { hexToRgb, parseToRgb } from '@/utils/colorUtil'
 import { BrushShape } from '@/extensions/core/maskeditor/types'
 import type { Point } from '@/extensions/core/maskeditor/types'
 
+type MaskColor = { r: number; g: number; b: number }
+
 export type DirtyRect = {
   minX: number
   minY: number
@@ -11,43 +13,13 @@ export type DirtyRect = {
   maxY: number
 }
 
-type MaskColor = { r: number; g: number; b: number }
-
 const brushTextureCache = new QuickLRU<string, HTMLCanvasElement>({
   maxSize: 20
 })
 
-export function resetDirtyRect(): DirtyRect {
-  return { minX: Infinity, minY: Infinity, maxX: -Infinity, maxY: -Infinity }
-}
-
-export function updateDirtyRect(
-  rect: DirtyRect,
-  x: number,
-  y: number,
-  radius: number
-): DirtyRect {
-  const padding = 2
-  return {
-    minX: Math.min(rect.minX, x - radius - padding),
-    minY: Math.min(rect.minY, y - radius - padding),
-    maxX: Math.max(rect.maxX, x + radius + padding),
-    maxY: Math.max(rect.maxY, y + radius + padding)
-  }
-}
-
 function formatRgba(hex: string, alpha: number): string {
   const { r, g, b } = hexToRgb(hex)
   return `rgba(${r}, ${g}, ${b}, ${alpha})`
-}
-
-export function premultiplyData(data: Uint8ClampedArray): void {
-  for (let i = 0; i < data.length; i += 4) {
-    const a = data[i + 3] / 255
-    data[i] = Math.round(data[i] * a)
-    data[i + 1] = Math.round(data[i + 1] * a)
-    data[i + 2] = Math.round(data[i + 2] * a)
-  }
 }
 
 function drawShapeOnContext(
@@ -152,6 +124,34 @@ function getCachedBrushTexture(
   tempCtx.putImageData(imageData, 0, 0)
   brushTextureCache.set(cacheKey, tempCanvas)
   return tempCanvas
+}
+
+export function resetDirtyRect(): DirtyRect {
+  return { minX: Infinity, minY: Infinity, maxX: -Infinity, maxY: -Infinity }
+}
+
+export function updateDirtyRect(
+  rect: DirtyRect,
+  x: number,
+  y: number,
+  radius: number
+): DirtyRect {
+  const padding = 2
+  return {
+    minX: Math.min(rect.minX, x - radius - padding),
+    minY: Math.min(rect.minY, y - radius - padding),
+    maxX: Math.max(rect.maxX, x + radius + padding),
+    maxY: Math.max(rect.maxY, y + radius + padding)
+  }
+}
+
+export function premultiplyData(data: Uint8ClampedArray): void {
+  for (let i = 0; i < data.length; i += 4) {
+    const a = data[i + 3] / 255
+    data[i] = Math.round(data[i] * a)
+    data[i + 1] = Math.round(data[i + 1] * a)
+    data[i + 2] = Math.round(data[i + 2] * a)
+  }
 }
 
 export function drawRgbShape(

--- a/src/composables/maskeditor/splineUtils.ts
+++ b/src/composables/maskeditor/splineUtils.ts
@@ -1,5 +1,13 @@
 import type { Point } from '@/extensions/core/maskeditor/types'
 
+function add(p1: Point, p2: Point): Point {
+  return { x: p1.x + p2.x, y: p1.y + p2.y }
+}
+
+function mul(p: Point, s: number): Point {
+  return { x: p.x * s, y: p.y * s }
+}
+
 /**
  * Evaluates a Catmull-Rom spline at parameter t between p1 and p2
  * @param p0 Previous control point
@@ -56,14 +64,6 @@ export function catmullRomSpline(
   const C = interp(B1, B2, t1, t2, tInterp)
 
   return C
-}
-
-function add(p1: Point, p2: Point): Point {
-  return { x: p1.x + p2.x, y: p1.y + p2.y }
-}
-
-function mul(p: Point, s: number): Point {
-  return { x: p.x * s, y: p.y * s }
 }
 
 /**

--- a/src/composables/maskeditor/useMaskEditorLoader.test.ts
+++ b/src/composables/maskeditor/useMaskEditorLoader.test.ts
@@ -51,24 +51,6 @@ vi.mock('@/scripts/app', () => ({
 const requestedUrls: string[] = []
 let failUrlPattern: RegExp | null = null
 
-class MockImage {
-  crossOrigin = ''
-  onload: ((ev: Event) => void) | null = null
-  onerror: ((ev: unknown) => void) | null = null
-  private _src = ''
-  get src() {
-    return this._src
-  }
-  set src(value: string) {
-    this._src = value
-    requestedUrls.push(value)
-    queueMicrotask(() => {
-      if (failUrlPattern?.test(value)) this.onerror?.(new Event('error'))
-      else this.onload?.(new Event('load'))
-    })
-  }
-}
-
 function createLoadImageNode(widgetValue: string): LGraphNode {
   return fromAny<LGraphNode, unknown>({
     id: 7,
@@ -85,6 +67,24 @@ function subfolderOf(url: string): string | null {
 
 function requestedLayerUrls(layerFilename: string): string[] {
   return requestedUrls.filter((url) => url.includes(layerFilename))
+}
+
+class MockImage {
+  crossOrigin = ''
+  onload: ((ev: Event) => void) | null = null
+  onerror: ((ev: unknown) => void) | null = null
+  private _src = ''
+  get src() {
+    return this._src
+  }
+  set src(value: string) {
+    this._src = value
+    requestedUrls.push(value)
+    queueMicrotask(() => {
+      if (failUrlPattern?.test(value)) this.onerror?.(new Event('error'))
+      else this.onload?.(new Event('load'))
+    })
+  }
 }
 
 describe('useMaskEditorLoader', () => {

--- a/src/composables/maskeditor/useMaskEditorLoader.ts
+++ b/src/composables/maskeditor/useMaskEditorLoader.ts
@@ -7,18 +7,6 @@ import { api } from '@/scripts/api'
 import { app } from '@/scripts/app'
 import { parseImageWidgetValue } from '@/utils/imageUtil'
 
-export function extractWidgetStringValue(value: unknown): string | undefined {
-  if (typeof value === 'string') return value
-  if (
-    value &&
-    typeof value === 'object' &&
-    'filename' in value &&
-    typeof value.filename === 'string'
-  )
-    return value.filename
-  return undefined
-}
-
 // Private image utility functions
 interface ImageLayerFilenames {
   maskedImage: string
@@ -32,6 +20,18 @@ interface MaskLayersResponse {
   painted?: string
   paint?: string
   mask?: string
+}
+
+export function extractWidgetStringValue(value: unknown): string | undefined {
+  if (typeof value === 'string') return value
+  if (
+    value &&
+    typeof value === 'object' &&
+    'filename' in value &&
+    typeof value.filename === 'string'
+  )
+    return value.filename
+  return undefined
 }
 
 const paintedMaskedImagePrefix = 'clipspace-painted-masked-'

--- a/src/composables/node/usePromotedPreviews.test.ts
+++ b/src/composables/node/usePromotedPreviews.test.ts
@@ -36,6 +36,12 @@ vi.mock('@/stores/nodeOutputStore', () => {
   return { useNodeOutputStore: () => store }
 })
 
+interface ArrangeOptions {
+  id?: number
+  previewMediaType?: 'image' | 'video' | 'audio' | 'model'
+  urls?: string[]
+}
+
 function clearMockNodeOutputStore() {
   const { nodeOutputs, nodePreviewImages } = useNodeOutputStore()
   for (const key of Object.keys(nodeOutputs)) delete nodeOutputs[key]
@@ -96,12 +102,6 @@ function exposePreview(
     String(setup.subgraphNode.id),
     { sourceNodeId, sourcePreviewName }
   )
-}
-
-interface ArrangeOptions {
-  id?: number
-  previewMediaType?: 'image' | 'video' | 'audio' | 'model'
-  urls?: string[]
 }
 
 function arrangePromotedPreview(options: ArrangeOptions = {}) {

--- a/src/composables/templateSearchConfig.ts
+++ b/src/composables/templateSearchConfig.ts
@@ -40,6 +40,18 @@ function cjkGrams(word: string): string[] {
   return grams
 }
 
+function searchOptions(combineWith: 'AND' | 'OR' = 'AND') {
+  // Description demoted below default so an incidental prose mention never
+  // outranks a real title/model match.
+  return {
+    boost: { title: 3, models: 2, tags: 2, description: 0.5 },
+    prefix: true,
+    fuzzy: termFuzziness,
+    combineWith,
+    tokenize
+  }
+}
+
 /**
  * Emits sub-parts so a term matches however it's typed: `-`/`_` splits, a
  * trailing version (`wan2.7` → `wan`, `2.7`), and CJK character grams.
@@ -69,18 +81,6 @@ export function termFuzziness(term: string): number | false {
   return term.length <= 3 || /\d/.test(term) ? false : 0.2
 }
 
-function searchOptions(combineWith: 'AND' | 'OR' = 'AND') {
-  // Description demoted below default so an incidental prose mention never
-  // outranks a real title/model match.
-  return {
-    boost: { title: 3, models: 2, tags: 2, description: 0.5 },
-    prefix: true,
-    fuzzy: termFuzziness,
-    combineWith,
-    tokenize
-  }
-}
-
 // `{X}2{Y}` shorthand expanded by structure (t2i, txt2img, …) rather than one
 // entry per spelling.
 const MODALITY_STEMS: Record<string, string> = {
@@ -106,6 +106,10 @@ const SAME_MODALITY_EDIT: Record<string, string> = {
 
 const ACRONYMS: Record<string, string> = {
   cn: 'controlnet'
+}
+
+function searchRankMultiplier(searchRank: number | undefined): number {
+  return 1 + searchRankBoost(searchRank) * SEARCH_RANK_RELEVANCE_WEIGHT
 }
 
 export function expandAbbreviation(token: string): string | null {
@@ -160,10 +164,6 @@ export function createTemplateSearchIndex(
   })
   index.addAll(templates)
   return index
-}
-
-function searchRankMultiplier(searchRank: number | undefined): number {
-  return 1 + searchRankBoost(searchRank) * SEARCH_RANK_RELEVANCE_WEIGHT
 }
 
 // Rank by curated relevance, with usage breaking ties inside a score band.

--- a/src/composables/useFeatureFlags.ts
+++ b/src/composables/useFeatureFlags.ts
@@ -14,37 +14,6 @@ import { getDevOverride } from '@/utils/devFeatureFlagOverride'
 import { getSessionOverride } from '@/utils/sessionFeatureFlagOverride'
 
 /**
- * Known server feature flags (top-level, not extensions)
- */
-export enum ServerFeatureFlag {
-  SUPPORTS_PREVIEW_METADATA = 'supports_preview_metadata',
-  MAX_UPLOAD_SIZE = 'max_upload_size',
-  MANAGER_SUPPORTS_V4 = 'extension.manager.supports_v4',
-  MODEL_UPLOAD_BUTTON_ENABLED = 'model_upload_button_enabled',
-  ASSET_RENAME_ENABLED = 'asset_rename_enabled',
-  PRIVATE_MODELS_ENABLED = 'private_models_enabled',
-  ONBOARDING_SURVEY_ENABLED = 'onboarding_survey_enabled',
-  LINEAR_TOGGLE_ENABLED = 'linear_toggle_enabled',
-  PARTNER_NODE_GOVERNANCE_ENABLED = 'partner_node_governance_enabled',
-  USER_SECRETS_ENABLED = 'user_secrets_enabled',
-  NODE_REPLACEMENTS = 'node_replacements',
-  NODE_LIBRARY_ESSENTIALS_ENABLED = 'node_library_essentials_enabled',
-  WORKFLOW_SHARING_ENABLED = 'workflow_sharing_enabled',
-  COMFYHUB_UPLOAD_ENABLED = 'comfyhub_upload_enabled',
-  COMFYHUB_PROFILE_GATE_ENABLED = 'comfyhub_profile_gate_enabled',
-  SHOW_SIGNIN_BUTTON = 'show_signin_button',
-  UNIFIED_CLOUD_AUTH = 'unified_cloud_auth',
-  BILLING_CONTROL_ENABLED = 'billing_control_enabled',
-  LEGACY_BILLING_MIGRATION_ENABLED = 'legacy_billing_migration_enabled',
-  V1_PAYMENT_RECOVERY = 'v1_payment_recovery',
-  FREE_TIER_JOB_ALLOWANCE_ENABLED = 'free_tier_job_allowance_enabled',
-  CHURNKEY_APP_ID = 'churnkey_app_id',
-  SIGNUP_TURNSTILE = 'signup_turnstile',
-  SUPPORTS_MODEL_TYPE_TAGS = 'supports_model_type_tags',
-  ONBOARDING_TOUR_ENABLED = 'onboarding_tour_enabled'
-}
-
-/**
  * Resolves a feature flag value with session override > dev override >
  * remoteConfig > serverFeature priority.
  */
@@ -82,6 +51,37 @@ function resolveAuthGatedFlag(
   if (!isAuthenticatedConfigLoaded.value) return cachedValue.value ?? false
 
   return remoteConfigValue ?? api.getServerFeature(flagKey, false)
+}
+
+/**
+ * Known server feature flags (top-level, not extensions)
+ */
+export enum ServerFeatureFlag {
+  SUPPORTS_PREVIEW_METADATA = 'supports_preview_metadata',
+  MAX_UPLOAD_SIZE = 'max_upload_size',
+  MANAGER_SUPPORTS_V4 = 'extension.manager.supports_v4',
+  MODEL_UPLOAD_BUTTON_ENABLED = 'model_upload_button_enabled',
+  ASSET_RENAME_ENABLED = 'asset_rename_enabled',
+  PRIVATE_MODELS_ENABLED = 'private_models_enabled',
+  ONBOARDING_SURVEY_ENABLED = 'onboarding_survey_enabled',
+  LINEAR_TOGGLE_ENABLED = 'linear_toggle_enabled',
+  PARTNER_NODE_GOVERNANCE_ENABLED = 'partner_node_governance_enabled',
+  USER_SECRETS_ENABLED = 'user_secrets_enabled',
+  NODE_REPLACEMENTS = 'node_replacements',
+  NODE_LIBRARY_ESSENTIALS_ENABLED = 'node_library_essentials_enabled',
+  WORKFLOW_SHARING_ENABLED = 'workflow_sharing_enabled',
+  COMFYHUB_UPLOAD_ENABLED = 'comfyhub_upload_enabled',
+  COMFYHUB_PROFILE_GATE_ENABLED = 'comfyhub_profile_gate_enabled',
+  SHOW_SIGNIN_BUTTON = 'show_signin_button',
+  UNIFIED_CLOUD_AUTH = 'unified_cloud_auth',
+  BILLING_CONTROL_ENABLED = 'billing_control_enabled',
+  LEGACY_BILLING_MIGRATION_ENABLED = 'legacy_billing_migration_enabled',
+  V1_PAYMENT_RECOVERY = 'v1_payment_recovery',
+  FREE_TIER_JOB_ALLOWANCE_ENABLED = 'free_tier_job_allowance_enabled',
+  CHURNKEY_APP_ID = 'churnkey_app_id',
+  SIGNUP_TURNSTILE = 'signup_turnstile',
+  SUPPORTS_MODEL_TYPE_TAGS = 'supports_model_type_tags',
+  ONBOARDING_TOUR_ENABLED = 'onboarding_tour_enabled'
 }
 
 /**

--- a/src/composables/useImageCrop.test.ts
+++ b/src/composables/useImageCrop.test.ts
@@ -101,6 +101,11 @@ const ImageCropHarness = defineComponent({
   `
 })
 
+type CropVm = Record<string, unknown> & {
+  $el: HTMLDivElement
+  modelValue: { x: number; y: number; width: number; height: number }
+}
+
 function flushResizeObservers() {
   for (const cb of [...resizeObserverCallbacks]) {
     cb()
@@ -154,11 +159,6 @@ function makePointerEvent(
     value: target
   })
   return ev
-}
-
-type CropVm = Record<string, unknown> & {
-  $el: HTMLDivElement
-  modelValue: { x: number; y: number; width: number; height: number }
 }
 
 function setupImageLayout(vm: CropVm, nw: number, nh: number) {

--- a/src/composables/usePaste.ts
+++ b/src/composables/usePaste.ts
@@ -13,33 +13,6 @@ import {
 } from '@/utils/litegraphUtil'
 import { shouldIgnoreCopyPaste } from '@/workbench/eventHelpers'
 
-export function cloneDataTransfer(original: DataTransfer): DataTransfer {
-  const persistent = new DataTransfer()
-
-  // Copy string data
-  for (const type of original.types) {
-    const data = original.getData(type)
-    if (data) {
-      persistent.setData(type, data)
-    }
-  }
-
-  for (const item of original.items) {
-    if (item.kind === 'file') {
-      const file = item.getAsFile()
-      if (file) {
-        persistent.items.add(file)
-      }
-    }
-  }
-
-  // Preserve dropEffect and effectAllowed
-  persistent.dropEffect = original.dropEffect
-  persistent.effectAllowed = original.effectAllowed
-
-  return persistent
-}
-
 function pasteClipboardItems(data: DataTransfer): boolean {
   const rawData = data.getData('text/html')
   const match = rawData.match(/data-metadata="([A-Za-z0-9+/=]+)"/)?.[1]
@@ -77,6 +50,33 @@ function pasteItemsOnNode(
       .map((i) => i.getAsFile())
       .filter((f) => f !== null)
   )
+}
+
+export function cloneDataTransfer(original: DataTransfer): DataTransfer {
+  const persistent = new DataTransfer()
+
+  // Copy string data
+  for (const type of original.types) {
+    const data = original.getData(type)
+    if (data) {
+      persistent.setData(type, data)
+    }
+  }
+
+  for (const item of original.items) {
+    if (item.kind === 'file') {
+      const file = item.getAsFile()
+      if (file) {
+        persistent.items.add(file)
+      }
+    }
+  }
+
+  // Preserve dropEffect and effectAllowed
+  persistent.dropEffect = original.dropEffect
+  persistent.effectAllowed = original.effectAllowed
+
+  return persistent
 }
 
 export async function pasteImageNode(

--- a/src/composables/useUpstreamValue.ts
+++ b/src/composables/useUpstreamValue.ts
@@ -11,6 +11,17 @@ type ValueExtractor<T = unknown> = (
   outputName: string | undefined
 ) => T | undefined
 
+function isBoundsObject(value: unknown): value is Bounds {
+  if (typeof value !== 'object' || value === null) return false
+  const v = value as Record<string, unknown>
+  return (
+    typeof v.x === 'number' &&
+    typeof v.y === 'number' &&
+    typeof v.width === 'number' &&
+    typeof v.height === 'number'
+  )
+}
+
 export function useUpstreamValue<T>(
   getLinkedUpstream: () => LinkedUpstreamInfo | undefined,
   extractValue: ValueExtractor<T>
@@ -39,17 +50,6 @@ export function singleValueExtractor<T>(
     const validValues = widgets.map((w) => w.value).filter(isValid)
     return validValues.length === 1 ? validValues[0] : undefined
   }
-}
-
-function isBoundsObject(value: unknown): value is Bounds {
-  if (typeof value !== 'object' || value === null) return false
-  const v = value as Record<string, unknown>
-  return (
-    typeof v.x === 'number' &&
-    typeof v.y === 'number' &&
-    typeof v.width === 'number' &&
-    typeof v.height === 'number'
-  )
 }
 
 export function boundsExtractor(): ValueExtractor<Bounds> {

--- a/src/composables/video/useCropBoxEditor.ts
+++ b/src/composables/video/useCropBoxEditor.ts
@@ -7,9 +7,6 @@ import type { Bounds } from '@/renderer/core/layout/types'
 
 export const MIN_CROP_SIZE = 16
 
-export type CropResizeDir = 'n' | 's' | 'e' | 'w' | 'ne' | 'nw' | 'se' | 'sw'
-export type CropDragMode = 'move' | CropResizeDir
-
 interface UseCropBoxEditorOptions {
   rootEl: Ref<HTMLElement | null>
   sourceWidth: Ref<number>
@@ -17,6 +14,9 @@ interface UseCropBoxEditorOptions {
   isDisabled: () => boolean
   lockedRatio?: Ref<number | null>
 }
+export type CropResizeDir = 'n' | 's' | 'e' | 'w' | 'ne' | 'nw' | 'se' | 'sw'
+
+export type CropDragMode = 'move' | CropResizeDir
 
 export function useCropBoxEditor(
   bounds: Ref<Bounds>,

--- a/src/composables/video/useCropRatioLock.ts
+++ b/src/composables/video/useCropRatioLock.ts
@@ -12,6 +12,10 @@ interface UseCropRatioLockOptions {
   sourceHeight: Ref<number>
 }
 
+function isPositiveFinite(value: number) {
+  return Number.isFinite(value) && value > 0
+}
+
 export function useCropRatioLock(
   bounds: Ref<Bounds>,
   options: UseCropRatioLockOptions
@@ -92,8 +96,4 @@ export function useCropRatioLock(
   })
 
   return { lockedRatio, ratioKeys, selectedRatio, isLockEnabled, canLockRatio }
-}
-
-function isPositiveFinite(value: number) {
-  return Number.isFinite(value) && value > 0
 }

--- a/src/composables/video/useTrimPlayback.test.ts
+++ b/src/composables/video/useTrimPlayback.test.ts
@@ -6,6 +6,10 @@ import { useTrimPlayback } from './useTrimPlayback'
 
 type Listener = (event: Event) => void
 
+async function flushSeek() {
+  await new Promise((resolve) => setTimeout(resolve))
+}
+
 class MockVideoElement {
   duration = 10
   paused = true
@@ -44,10 +48,6 @@ class MockVideoElement {
       listener(new Event(type))
     }
   }
-}
-
-async function flushSeek() {
-  await new Promise((resolve) => setTimeout(resolve))
 }
 
 describe('useTrimPlayback', () => {

--- a/src/composables/video/useVideoFilmstrip.test.ts
+++ b/src/composables/video/useVideoFilmstrip.test.ts
@@ -17,6 +17,45 @@ vi.mock('@/utils/videoMetadataUtil', () => ({
 
 type VideoListener = (event: Event) => void
 
+function createMockCanvas(context: unknown = { drawImage: vi.fn() }) {
+  return {
+    width: 0,
+    height: 0,
+    getContext: () => context,
+    toBlob: (callback: BlobCallback) =>
+      callback(new Blob(['thumb'], { type: 'image/jpeg' }))
+  } as unknown as HTMLCanvasElement
+}
+
+function installVideoMocks({
+  onVideoCreated,
+  onCanvasCreated,
+  canvasContext = { drawImage: vi.fn() } as unknown
+}: {
+  onVideoCreated?: (video: MockVideoElement) => void
+  onCanvasCreated?: (canvas: HTMLCanvasElement) => void
+  canvasContext?: unknown
+} = {}) {
+  const originalCreateElement = document.createElement.bind(document)
+
+  vi.spyOn(document, 'createElement').mockImplementation((tagName) => {
+    if (tagName === 'video') {
+      const video = new MockVideoElement()
+      onVideoCreated?.(video)
+      if (video.autoEmitMetadata) {
+        queueMicrotask(() => video.emit('loadedmetadata'))
+      }
+      return video as unknown as HTMLVideoElement
+    }
+    if (tagName === 'canvas') {
+      const canvas = createMockCanvas(canvasContext)
+      onCanvasCreated?.(canvas)
+      return canvas
+    }
+    return originalCreateElement(tagName)
+  })
+}
+
 class MockVideoElement {
   preload = ''
   muted = false
@@ -97,45 +136,6 @@ class MockOffscreenCanvas {
   async convertToBlob() {
     return new Blob(['thumb'], { type: 'image/jpeg' })
   }
-}
-
-function createMockCanvas(context: unknown = { drawImage: vi.fn() }) {
-  return {
-    width: 0,
-    height: 0,
-    getContext: () => context,
-    toBlob: (callback: BlobCallback) =>
-      callback(new Blob(['thumb'], { type: 'image/jpeg' }))
-  } as unknown as HTMLCanvasElement
-}
-
-function installVideoMocks({
-  onVideoCreated,
-  onCanvasCreated,
-  canvasContext = { drawImage: vi.fn() } as unknown
-}: {
-  onVideoCreated?: (video: MockVideoElement) => void
-  onCanvasCreated?: (canvas: HTMLCanvasElement) => void
-  canvasContext?: unknown
-} = {}) {
-  const originalCreateElement = document.createElement.bind(document)
-
-  vi.spyOn(document, 'createElement').mockImplementation((tagName) => {
-    if (tagName === 'video') {
-      const video = new MockVideoElement()
-      onVideoCreated?.(video)
-      if (video.autoEmitMetadata) {
-        queueMicrotask(() => video.emit('loadedmetadata'))
-      }
-      return video as unknown as HTMLVideoElement
-    }
-    if (tagName === 'canvas') {
-      const canvas = createMockCanvas(canvasContext)
-      onCanvasCreated?.(canvas)
-      return canvas
-    }
-    return originalCreateElement(tagName)
-  })
 }
 
 describe('useVideoFilmstrip', () => {

--- a/src/composables/video/useVideoFilmstrip.ts
+++ b/src/composables/video/useVideoFilmstrip.ts
@@ -10,14 +10,9 @@ export const FILMSTRIP_THUMBNAIL_MAX_WIDTH = 384
 const METADATA_EVENT_TIMEOUT_MS = 15000
 const SEEK_EVENT_TIMEOUT_MS = 5000
 
-export type FilmstripError = 'canvas-unavailable' | 'load-failed'
-
 interface UseVideoFilmstripOptions {
   fps?: number
 }
-
-class EventTimeoutError extends Error {}
-class LoadAbortedError extends Error {}
 
 function waitForEvent(
   target: EventTarget,
@@ -67,7 +62,6 @@ function blobToDataUrl(blob: Blob): Promise<string> {
     reader.readAsDataURL(blob)
   })
 }
-
 function canvasToJpegDataUrl(canvas: HTMLCanvasElement): Promise<string> {
   return new Promise((resolve) => {
     canvas.toBlob(
@@ -170,6 +164,12 @@ async function captureRepresentativeFrame(
   }
   return captureFrame(video, canvas, context)
 }
+
+class EventTimeoutError extends Error {}
+
+class LoadAbortedError extends Error {}
+
+export type FilmstripError = 'canvas-unavailable' | 'load-failed'
 
 export function useVideoFilmstrip(
   videoUrl: Ref<string | undefined>,

--- a/src/constants/essentialsNodes.ts
+++ b/src/constants/essentialsNodes.ts
@@ -2,12 +2,22 @@ import { mapValues } from 'es-toolkit'
 
 import { BLUEPRINT_TYPE_PREFIX } from '@/utils/blueprintUtils'
 
-export type EssentialsMediaType = 'image' | 'video' | 'text' | 'audio' | '3d'
-
 interface EssentialsPath {
   section: string
   subgroup?: string
 }
+
+interface EssentialSubgroup {
+  key: string
+  media: EssentialsMediaType
+  tiles: EssentialTile[]
+}
+
+function blueprint(name: string) {
+  return BLUEPRINT_TYPE_PREFIX + name
+}
+
+export type EssentialsMediaType = 'image' | 'video' | 'text' | 'audio' | '3d'
 
 export interface EssentialTile {
   icon?: string
@@ -24,20 +34,10 @@ export interface EssentialTile {
   nodeName: string
 }
 
-interface EssentialSubgroup {
-  key: string
-  media: EssentialsMediaType
-  tiles: EssentialTile[]
-}
-
 export interface EssentialSection {
   key: string
   subgroups?: EssentialSubgroup[]
   tiles?: EssentialTile[]
-}
-
-function blueprint(name: string) {
-  return BLUEPRINT_TYPE_PREFIX + name
 }
 
 export const ESSENTIAL_SECTIONS: EssentialSection[] = [

--- a/src/core/graph/subgraph/createPromotionErrorReconciler.ts
+++ b/src/core/graph/subgraph/createPromotionErrorReconciler.ts
@@ -21,6 +21,11 @@ interface PromotionErrorReconcilerHandlers {
   ) => void
 }
 
+interface Subscription {
+  unsubscribe: () => void
+  hostCount: number
+}
+
 export interface PromotionErrorReconciler {
   /** Subscribes a subgraph host and every definition nested inside it. */
   attachNode: (node: LGraphNode) => void
@@ -30,11 +35,6 @@ export interface PromotionErrorReconciler {
   attach: (subgraph: Subgraph) => void
   /** Releases everything still subscribed. */
   dispose: () => void
-}
-
-interface Subscription {
-  unsubscribe: () => void
-  hostCount: number
 }
 
 export function createPromotionErrorReconciler({

--- a/src/core/graph/subgraph/liftNodeErrorsToBoundary.ts
+++ b/src/core/graph/subgraph/liftNodeErrorsToBoundary.ts
@@ -9,83 +9,16 @@ import type { NodeValidationError } from '@/utils/executionErrorUtil'
 import { getNodeByExecutionId } from '@/utils/graphTraversalUtil'
 import { isSubgraph } from '@/utils/typeGuardUtil'
 
-export interface LiftedErrorExtraInfo {
-  input_name: string
-  source_execution_id: string
-  source_input_name: string
-}
-
-export interface LiftedSurface {
-  hostExecId: NodeExecutionId
-  hostInputName: string
-}
-
 interface ErrorPlacement {
   kind: 'own' | 'lifted'
   targetExecId: string
   error: NodeValidationError
 }
 
-export function getLiftedErrorSource(
-  error: NodeValidationError
-): LiftedErrorExtraInfo | null {
-  const extraInfo = error.extra_info
-  if (!extraInfo) return null
-
-  const { input_name, source_execution_id, source_input_name } = extraInfo
-  if (
-    typeof input_name !== 'string' ||
-    typeof source_execution_id !== 'string' ||
-    typeof source_input_name !== 'string'
-  ) {
-    return null
-  }
-
-  return { input_name, source_execution_id, source_input_name }
-}
-
 function getHostExecutionId(executionId: string): NodeExecutionId | null {
   const separatorIndex = executionId.lastIndexOf(':')
   if (separatorIndex <= 0) return null
   return tryNormalizeNodeExecutionId(executionId.slice(0, separatorIndex))
-}
-
-/**
- * Boundary surfaces that expose `(executionId, inputName)`, innermost first.
- * Walks one host per level and stops at the last resolvable surface, so an
- * unresolvable deeper host falls back to the shallower one (fail-open).
- */
-export function resolveLiftChain(
-  rootGraph: LGraph,
-  executionId: string,
-  inputName: string
-): LiftedSurface[] {
-  const chain: LiftedSurface[] = []
-  let currentExecId = executionId
-  let currentInputName = inputName
-
-  for (;;) {
-    const node = getNodeByExecutionId(rootGraph, currentExecId)
-    const graph = node?.graph
-    if (!node || !graph || !isSubgraph(graph)) break
-
-    const slot = node.inputs?.find((input) => input.name === currentInputName)
-    if (slot?.link == null) break
-
-    const subgraphInput = graph
-      .getLink(slot.link)
-      ?.resolve(graph)?.subgraphInput
-    if (!subgraphInput) break
-
-    const hostExecId = getHostExecutionId(currentExecId)
-    if (!hostExecId || !getNodeByExecutionId(rootGraph, hostExecId)) break
-
-    chain.push({ hostExecId, hostInputName: subgraphInput.name })
-    currentExecId = hostExecId
-    currentInputName = subgraphInput.name
-  }
-
-  return chain
 }
 
 function createEmptyNodeError(nodeError: NodeError): NodeError {
@@ -144,6 +77,73 @@ function toErrorPlacement(
       }
     }
   }
+}
+
+export interface LiftedErrorExtraInfo {
+  input_name: string
+  source_execution_id: string
+  source_input_name: string
+}
+
+export interface LiftedSurface {
+  hostExecId: NodeExecutionId
+  hostInputName: string
+}
+
+export function getLiftedErrorSource(
+  error: NodeValidationError
+): LiftedErrorExtraInfo | null {
+  const extraInfo = error.extra_info
+  if (!extraInfo) return null
+
+  const { input_name, source_execution_id, source_input_name } = extraInfo
+  if (
+    typeof input_name !== 'string' ||
+    typeof source_execution_id !== 'string' ||
+    typeof source_input_name !== 'string'
+  ) {
+    return null
+  }
+
+  return { input_name, source_execution_id, source_input_name }
+}
+
+/**
+ * Boundary surfaces that expose `(executionId, inputName)`, innermost first.
+ * Walks one host per level and stops at the last resolvable surface, so an
+ * unresolvable deeper host falls back to the shallower one (fail-open).
+ */
+export function resolveLiftChain(
+  rootGraph: LGraph,
+  executionId: string,
+  inputName: string
+): LiftedSurface[] {
+  const chain: LiftedSurface[] = []
+  let currentExecId = executionId
+  let currentInputName = inputName
+
+  for (;;) {
+    const node = getNodeByExecutionId(rootGraph, currentExecId)
+    const graph = node?.graph
+    if (!node || !graph || !isSubgraph(graph)) break
+
+    const slot = node.inputs?.find((input) => input.name === currentInputName)
+    if (slot?.link == null) break
+
+    const subgraphInput = graph
+      .getLink(slot.link)
+      ?.resolve(graph)?.subgraphInput
+    if (!subgraphInput) break
+
+    const hostExecId = getHostExecutionId(currentExecId)
+    if (!hostExecId || !getNodeByExecutionId(rootGraph, hostExecId)) break
+
+    chain.push({ hostExecId, hostInputName: subgraphInput.name })
+    currentExecId = hostExecId
+    currentInputName = subgraphInput.name
+  }
+
+  return chain
 }
 
 export function liftNodeErrorsToBoundary(

--- a/src/core/graph/subgraph/migration/proxyWidgetMigration.ts
+++ b/src/core/graph/subgraph/migration/proxyWidgetMigration.ts
@@ -43,6 +43,36 @@ interface StrippedPrefix {
   deepestPrefixId?: NodeId
 }
 
+interface FlushArgs {
+  hostNode: SubgraphNode
+  hostWidgetValues?: readonly unknown[]
+}
+
+interface PrimitiveBypassTargetRef {
+  targetNodeId: NodeId
+  targetSlot: number
+}
+
+type Plan =
+  | { kind: 'alreadyLinked'; subgraphInputName: string }
+  | { kind: 'createSubgraphInput'; sourceWidgetName: string }
+  | {
+      kind: 'primitiveBypass'
+      primitiveNodeId: NodeId
+      sourceWidgetName: string
+      targets: readonly PrimitiveBypassTargetRef[]
+    }
+  | { kind: 'previewExposure'; sourcePreviewName: string }
+  | { kind: 'quarantine'; reason: ProxyWidgetQuarantineReason }
+
+interface PendingEntry {
+  originalEntry: SerializedProxyWidgetTuple
+  normalized: LegacyProxyEntrySource
+  hostValue: TWidgetValue | undefined
+  isHole: boolean
+  plan: Plan
+}
+
 function stripLegacyPrefixes(sourceWidgetName: string): StrippedPrefix {
   let remaining = sourceWidgetName
   let deepestPrefixId: NodeId | undefined
@@ -62,6 +92,35 @@ function canResolveLegacyProxy(
   return (
     resolveConcretePromotedWidget(hostNode, sourceNodeId, widgetName).status ===
     'resolved'
+  )
+}
+
+function resolveSourceWidget(
+  sourceNode: LGraphNode,
+  sourceWidgetName: string,
+  disambiguatingSourceNodeId?: string
+): IBaseWidget | undefined {
+  if (sourceNode.isSubgraphNode()) {
+    const input = sourceNode.inputs.find((input) => {
+      const target = resolveSubgraphInputTarget(sourceNode, input.name)
+      if (disambiguatingSourceNodeId) {
+        return (
+          target?.widgetName === sourceWidgetName &&
+          target.nodeId === disambiguatingSourceNodeId
+        )
+      }
+      if (input.name === sourceWidgetName) return true
+      return target?.widgetName === sourceWidgetName
+    })
+    // Store-backed projection for a promoted input on a nested subgraph node:
+    // getSlotFromWidget locates the backing slot by widgetId.
+    if (input?.widgetId) return promotedInputWidget(input) ?? undefined
+  }
+
+  const widgets = sourceNode.widgets
+  return (
+    widgets?.find((w) => w.name === sourceWidgetName) ??
+    getPromotableWidgets(sourceNode).find((w) => w.name === sourceWidgetName)
   )
 }
 
@@ -100,153 +159,21 @@ export function normalizeLegacyProxyWidgetEntry(
   }
 }
 
-function resolveSourceWidget(
-  sourceNode: LGraphNode,
-  sourceWidgetName: string,
-  disambiguatingSourceNodeId?: string
-): IBaseWidget | undefined {
-  if (sourceNode.isSubgraphNode()) {
-    const input = sourceNode.inputs.find((input) => {
-      const target = resolveSubgraphInputTarget(sourceNode, input.name)
-      if (disambiguatingSourceNodeId) {
-        return (
-          target?.widgetName === sourceWidgetName &&
-          target.nodeId === disambiguatingSourceNodeId
-        )
-      }
-      if (input.name === sourceWidgetName) return true
-      return target?.widgetName === sourceWidgetName
-    })
-    // Store-backed projection for a promoted input on a nested subgraph node:
-    // getSlotFromWidget locates the backing slot by widgetId.
-    if (input?.widgetId) return promotedInputWidget(input) ?? undefined
-  }
-
-  const widgets = sourceNode.widgets
-  return (
-    widgets?.find((w) => w.name === sourceWidgetName) ??
-    getPromotableWidgets(sourceNode).find((w) => w.name === sourceWidgetName)
-  )
-}
-
-interface FlushArgs {
-  hostNode: SubgraphNode
-  hostWidgetValues?: readonly unknown[]
-}
-
-interface PrimitiveBypassTargetRef {
-  targetNodeId: NodeId
-  targetSlot: number
-}
-
-type Plan =
-  | { kind: 'alreadyLinked'; subgraphInputName: string }
-  | { kind: 'createSubgraphInput'; sourceWidgetName: string }
-  | {
-      kind: 'primitiveBypass'
-      primitiveNodeId: NodeId
-      sourceWidgetName: string
-      targets: readonly PrimitiveBypassTargetRef[]
-    }
-  | { kind: 'previewExposure'; sourcePreviewName: string }
-  | { kind: 'quarantine'; reason: ProxyWidgetQuarantineReason }
-
-interface PendingEntry {
-  originalEntry: SerializedProxyWidgetTuple
-  normalized: LegacyProxyEntrySource
-  hostValue: TWidgetValue | undefined
-  isHole: boolean
-  plan: Plan
-}
-
 const PRIMITIVE_NODE_TYPE = 'PrimitiveNode'
 const QUARANTINE_PROPERTY = 'proxyWidgetErrorQuarantine'
 const QUARANTINE_VERSION = 1
 const PROXY_BYPASS_MARKER_PROPERTY = 'proxyBypassedToSubgraphInput'
 
-export function flushProxyWidgetMigration(args: FlushArgs): void {
-  const { hostNode, hostWidgetValues } = args
+type Outcome<TOk, TReason = ProxyWidgetQuarantineReason> =
+  | ({ ok: true } & TOk)
+  | { ok: false; reason: TReason }
 
-  const tuples = parseProxyWidgets(hostNode.properties.proxyWidgets)
-  if (tuples.length === 0) return
+type RepairValueResult = Outcome<{ subgraphInputName: string }>
 
-  const normalizedEntries = tuples.map((originalEntry) => {
-    const [sourceNodeId, sourceWidgetName, disambiguator] = originalEntry
-    return {
-      originalEntry,
-      normalized: normalizeLegacyProxyWidgetEntry(
-        hostNode,
-        sourceNodeId,
-        sourceWidgetName,
-        disambiguator
-      )
-    }
-  })
-  const cohort = normalizedEntries.map((entry) => entry.normalized)
-
-  const pending: PendingEntry[] = normalizedEntries.map((entry, index) => {
-    const { value, isHole } = pickHostValue(hostWidgetValues, index)
-    return {
-      ...entry,
-      hostValue: value,
-      isHole,
-      plan: classify(hostNode, entry.normalized, cohort)
-    }
-  })
-
-  const previewStore = usePreviewExposureStore()
-  const quarantineToAppend: ProxyWidgetErrorQuarantineEntry[] = []
-  const primitiveCohorts = new Map<NodeId, PendingEntry[]>()
-
-  for (const entry of pending) {
-    switch (entry.plan.kind) {
-      case 'primitiveBypass': {
-        const c = primitiveCohorts.get(entry.plan.primitiveNodeId) ?? []
-        c.push(entry)
-        primitiveCohorts.set(entry.plan.primitiveNodeId, c)
-        break
-      }
-      case 'alreadyLinked': {
-        const r = repairAlreadyLinked(
-          hostNode,
-          entry,
-          entry.plan.subgraphInputName
-        )
-        if (!r.ok) quarantineToAppend.push(quarantineFor(entry, r.reason))
-        break
-      }
-      case 'createSubgraphInput': {
-        const r = repairCreateSubgraphInput(
-          hostNode,
-          entry,
-          entry.plan.sourceWidgetName
-        )
-        if (!r.ok) quarantineToAppend.push(quarantineFor(entry, r.reason))
-        break
-      }
-      case 'previewExposure': {
-        const r = migratePreview(hostNode, entry, previewStore, entry.plan)
-        if (!r.ok) quarantineToAppend.push(quarantineFor(entry, r.reason))
-        break
-      }
-      case 'quarantine':
-        quarantineToAppend.push(quarantineFor(entry, entry.plan.reason))
-        break
-    }
-  }
-
-  for (const c of primitiveCohorts.values()) {
-    const r = repairPrimitive(hostNode, c)
-    if (!r.ok)
-      for (const e of c) quarantineToAppend.push(quarantineFor(e, r.reason))
-  }
-
-  if (quarantineToAppend.length > 0) {
-    appendQuarantine(hostNode, quarantineToAppend)
-  }
-
-  delete hostNode.properties.proxyWidgets
-}
+type RepairPrimitiveResult = Outcome<
+  { subgraphInputName: string; reconnectCount: number },
+  'primitiveBypassFailed'
+>
 
 function pickHostValue(
   hostWidgetValues: readonly unknown[] | undefined,
@@ -413,12 +340,6 @@ function addUniqueSubgraphInput(
   return subgraph.addInput(uniqueName, type)
 }
 
-type Outcome<TOk, TReason = ProxyWidgetQuarantineReason> =
-  | ({ ok: true } & TOk)
-  | { ok: false; reason: TReason }
-
-type RepairValueResult = Outcome<{ subgraphInputName: string }>
-
 function repairAlreadyLinked(
   hostNode: SubgraphNode,
   entry: PendingEntry,
@@ -501,10 +422,89 @@ function repairCreateSubgraphInput(
   return { ok: true, subgraphInputName: newSubgraphInput.name }
 }
 
-type RepairPrimitiveResult = Outcome<
-  { subgraphInputName: string; reconnectCount: number },
-  'primitiveBypassFailed'
->
+export function flushProxyWidgetMigration(args: FlushArgs): void {
+  const { hostNode, hostWidgetValues } = args
+
+  const tuples = parseProxyWidgets(hostNode.properties.proxyWidgets)
+  if (tuples.length === 0) return
+
+  const normalizedEntries = tuples.map((originalEntry) => {
+    const [sourceNodeId, sourceWidgetName, disambiguator] = originalEntry
+    return {
+      originalEntry,
+      normalized: normalizeLegacyProxyWidgetEntry(
+        hostNode,
+        sourceNodeId,
+        sourceWidgetName,
+        disambiguator
+      )
+    }
+  })
+  const cohort = normalizedEntries.map((entry) => entry.normalized)
+
+  const pending: PendingEntry[] = normalizedEntries.map((entry, index) => {
+    const { value, isHole } = pickHostValue(hostWidgetValues, index)
+    return {
+      ...entry,
+      hostValue: value,
+      isHole,
+      plan: classify(hostNode, entry.normalized, cohort)
+    }
+  })
+
+  const previewStore = usePreviewExposureStore()
+  const quarantineToAppend: ProxyWidgetErrorQuarantineEntry[] = []
+  const primitiveCohorts = new Map<NodeId, PendingEntry[]>()
+
+  for (const entry of pending) {
+    switch (entry.plan.kind) {
+      case 'primitiveBypass': {
+        const c = primitiveCohorts.get(entry.plan.primitiveNodeId) ?? []
+        c.push(entry)
+        primitiveCohorts.set(entry.plan.primitiveNodeId, c)
+        break
+      }
+      case 'alreadyLinked': {
+        const r = repairAlreadyLinked(
+          hostNode,
+          entry,
+          entry.plan.subgraphInputName
+        )
+        if (!r.ok) quarantineToAppend.push(quarantineFor(entry, r.reason))
+        break
+      }
+      case 'createSubgraphInput': {
+        const r = repairCreateSubgraphInput(
+          hostNode,
+          entry,
+          entry.plan.sourceWidgetName
+        )
+        if (!r.ok) quarantineToAppend.push(quarantineFor(entry, r.reason))
+        break
+      }
+      case 'previewExposure': {
+        const r = migratePreview(hostNode, entry, previewStore, entry.plan)
+        if (!r.ok) quarantineToAppend.push(quarantineFor(entry, r.reason))
+        break
+      }
+      case 'quarantine':
+        quarantineToAppend.push(quarantineFor(entry, entry.plan.reason))
+        break
+    }
+  }
+
+  for (const c of primitiveCohorts.values()) {
+    const r = repairPrimitive(hostNode, c)
+    if (!r.ok)
+      for (const e of c) quarantineToAppend.push(quarantineFor(e, r.reason))
+  }
+
+  if (quarantineToAppend.length > 0) {
+    appendQuarantine(hostNode, quarantineToAppend)
+  }
+
+  delete hostNode.properties.proxyWidgets
+}
 
 const PRIMITIVE_FAILED: RepairPrimitiveResult = {
   ok: false,
@@ -521,6 +521,11 @@ interface CohortValidationOk {
   sourceWidgetName: string
   uniqueEntries: readonly PendingEntry[]
 }
+
+type MigratePreviewResult = Outcome<
+  { previewName: string },
+  'missingSourceNode' | 'missingSourceWidget'
+>
 
 function failPrimitive(message: string, ctx?: unknown): RepairPrimitiveResult {
   console.warn(`[proxyWidgetMigration] ${message}`, ctx)
@@ -695,11 +700,6 @@ function repairPrimitive(
     reconnectCount: targets.length
   }
 }
-
-type MigratePreviewResult = Outcome<
-  { previewName: string },
-  'missingSourceNode' | 'missingSourceWidget'
->
 
 function migratePreview(
   hostNode: SubgraphNode,

--- a/src/core/graph/subgraph/promotionUtils.ts
+++ b/src/core/graph/subgraph/promotionUtils.ts
@@ -27,8 +27,168 @@ import { useWidgetValueStore } from '@/stores/widgetValueStore'
 
 type PartialNode = Pick<LGraphNode, 'title' | 'id' | 'type'>
 
-export type WidgetItem = [LGraphNode, IBaseWidget]
+type CanonicalPromotionResult =
+  | { ok: true }
+  | { ok: false; reason: 'missingSourceSlot' | 'connectFailed' }
 export { CANVAS_IMAGE_PREVIEW_WIDGET }
+
+function resolvePromotionSource(
+  subgraphNode: SubgraphNode,
+  subgraphInput: { linkIds: readonly LinkId[] }
+): PromotedWidgetSource | undefined {
+  for (const linkId of subgraphInput.linkIds) {
+    const link = subgraphNode.subgraph.getLink(linkId)
+    if (!link) continue
+
+    const { inputNode } = link.resolve(subgraphNode.subgraph)
+    if (!inputNode || !Array.isArray(inputNode.inputs)) continue
+
+    const targetInput = inputNode.inputs.find((entry) => entry.link === linkId)
+    if (!targetInput) continue
+
+    if (inputNode.isSubgraphNode()) {
+      return {
+        sourceNodeId: inputNode.id,
+        sourceWidgetName: targetInput.name
+      }
+    }
+
+    const targetWidget = inputNode.getWidgetFromSlot(targetInput)
+    if (!targetWidget) continue
+
+    return {
+      sourceNodeId: inputNode.id,
+      sourceWidgetName: targetWidget.name
+    }
+  }
+}
+
+function applySubgraphInputOrder(
+  subgraphNode: SubgraphNode,
+  orderedIndices: readonly number[]
+): void {
+  const widgetValues = subgraphNode.inputs.map((input) => {
+    const id = input?.widgetId
+    if (!id) return undefined
+    const value = useWidgetValueStore().getWidget(id)?.value
+    return isWidgetValue(value) ? value : undefined
+  })
+
+  reorderSubgraphInputs(subgraphNode, orderedIndices)
+
+  for (const [newIndex, oldIndex] of orderedIndices.entries()) {
+    const value = widgetValues[oldIndex]
+    const id = subgraphNode.inputs[newIndex]?.widgetId
+    if (value === undefined || !id) continue
+    useWidgetValueStore().setValue(id, value)
+  }
+}
+
+function isSamePromotedInput(
+  subgraphNode: SubgraphNode,
+  inputIndex: number,
+  orderedWidget: Pick<IBaseWidget, 'widgetId'>
+): boolean {
+  const input = subgraphNode.inputs[inputIndex]
+  const linkedInput = input?._subgraphSlot
+  if (!input || !linkedInput) return false
+
+  for (const linkId of linkedInput.linkIds) {
+    const link = subgraphNode.subgraph.getLink(linkId)
+    if (!link) continue
+
+    const { inputNode, input: targetInput } = link.resolve(
+      subgraphNode.subgraph
+    )
+    if (!inputNode || !targetInput) continue
+
+    const targetWidget = inputNode.getWidgetFromSlot(targetInput)
+    if (targetWidget === orderedWidget) return true
+
+    if (input.widgetId && input.widgetId === orderedWidget.widgetId) return true
+  }
+
+  return false
+}
+
+function isPreviewExposed(
+  subgraphNode: SubgraphNode,
+  source: PromotedWidgetSource
+): boolean {
+  const hostLocator = String(subgraphNode.id)
+  return usePreviewExposureStore()
+    .getExposures(subgraphNode.rootGraph.id, hostLocator)
+    .some(
+      (exposure) =>
+        exposure.sourceNodeId === source.sourceNodeId &&
+        exposure.sourcePreviewName === source.sourceWidgetName
+    )
+}
+
+function toPromotionSource(
+  node: PartialNode,
+  widget: IBaseWidget
+): PromotedWidgetSource {
+  return {
+    sourceNodeId: node.id,
+    sourceWidgetName: getWidgetName(widget)
+  }
+}
+
+function seedNestedPromotedInputState(
+  subgraphNode: SubgraphNode,
+  inputName: string,
+  sourceSlot: { widgetId?: WidgetId; label?: string }
+): void {
+  if (!sourceSlot.widgetId) return
+
+  const hostInput = subgraphNode.inputs.find(
+    (input) => input._subgraphSlot?.name === inputName
+  )
+  if (!hostInput || hostInput.widgetId) return
+
+  const sourceState = useWidgetValueStore().getWidget(sourceSlot.widgetId)
+  if (!sourceState) return
+
+  const id = widgetId(subgraphNode.rootGraph.id, subgraphNode.id, inputName)
+  hostInput.widget ??= { name: inputName }
+  hostInput.widget.name = inputName
+  hostInput.widgetId = id
+  useWidgetValueStore().registerWidget(id, {
+    type: sourceState.type,
+    value: sourceState.value,
+    options: cloneDeep(sourceState.options ?? {}),
+    label: hostInput.label ?? sourceSlot.label ?? inputName,
+    serialize: sourceState.serialize,
+    disabled: sourceState.disabled,
+    isDOMWidget: sourceState.isDOMWidget
+  })
+}
+
+function promotePreviewViaExposure(
+  subgraphNode: SubgraphNode,
+  sourceNode: LGraphNode,
+  sourcePreviewName: string
+): void {
+  const store = usePreviewExposureStore()
+  const rootGraphId = subgraphNode.rootGraph.id
+  const hostLocator = String(subgraphNode.id)
+  const existing = store
+    .getExposures(rootGraphId, hostLocator)
+    .some(
+      (exposure) =>
+        exposure.sourceNodeId === String(sourceNode.id) &&
+        exposure.sourcePreviewName === sourcePreviewName
+    )
+  if (existing) return
+
+  store.addExposure(rootGraphId, hostLocator, {
+    sourceNodeId: sourceNode.id,
+    sourcePreviewName
+  })
+}
+
+export type WidgetItem = [LGraphNode, IBaseWidget]
 
 export function getWidgetName(w: IBaseWidget): string {
   return w.name
@@ -98,37 +258,6 @@ export function createPromotedHostWidgetIdLookup(
     hostWidgetIdBySource.get(key(sourceNodeId, sourceWidgetName))
 }
 
-function resolvePromotionSource(
-  subgraphNode: SubgraphNode,
-  subgraphInput: { linkIds: readonly LinkId[] }
-): PromotedWidgetSource | undefined {
-  for (const linkId of subgraphInput.linkIds) {
-    const link = subgraphNode.subgraph.getLink(linkId)
-    if (!link) continue
-
-    const { inputNode } = link.resolve(subgraphNode.subgraph)
-    if (!inputNode || !Array.isArray(inputNode.inputs)) continue
-
-    const targetInput = inputNode.inputs.find((entry) => entry.link === linkId)
-    if (!targetInput) continue
-
-    if (inputNode.isSubgraphNode()) {
-      return {
-        sourceNodeId: inputNode.id,
-        sourceWidgetName: targetInput.name
-      }
-    }
-
-    const targetWidget = inputNode.getWidgetFromSlot(targetInput)
-    if (!targetWidget) continue
-
-    return {
-      sourceNodeId: inputNode.id,
-      sourceWidgetName: targetWidget.name
-    }
-  }
-}
-
 export function reorderSubgraphInputsByName(
   subgraphNode: SubgraphNode,
   orderedInputNames: readonly string[]
@@ -169,68 +298,6 @@ export function reorderSubgraphInputsByWidgetOrder(
   applySubgraphInputOrder(subgraphNode, orderedIndices)
 }
 
-function applySubgraphInputOrder(
-  subgraphNode: SubgraphNode,
-  orderedIndices: readonly number[]
-): void {
-  const widgetValues = subgraphNode.inputs.map((input) => {
-    const id = input?.widgetId
-    if (!id) return undefined
-    const value = useWidgetValueStore().getWidget(id)?.value
-    return isWidgetValue(value) ? value : undefined
-  })
-
-  reorderSubgraphInputs(subgraphNode, orderedIndices)
-
-  for (const [newIndex, oldIndex] of orderedIndices.entries()) {
-    const value = widgetValues[oldIndex]
-    const id = subgraphNode.inputs[newIndex]?.widgetId
-    if (value === undefined || !id) continue
-    useWidgetValueStore().setValue(id, value)
-  }
-}
-
-function isSamePromotedInput(
-  subgraphNode: SubgraphNode,
-  inputIndex: number,
-  orderedWidget: Pick<IBaseWidget, 'widgetId'>
-): boolean {
-  const input = subgraphNode.inputs[inputIndex]
-  const linkedInput = input?._subgraphSlot
-  if (!input || !linkedInput) return false
-
-  for (const linkId of linkedInput.linkIds) {
-    const link = subgraphNode.subgraph.getLink(linkId)
-    if (!link) continue
-
-    const { inputNode, input: targetInput } = link.resolve(
-      subgraphNode.subgraph
-    )
-    if (!inputNode || !targetInput) continue
-
-    const targetWidget = inputNode.getWidgetFromSlot(targetInput)
-    if (targetWidget === orderedWidget) return true
-
-    if (input.widgetId && input.widgetId === orderedWidget.widgetId) return true
-  }
-
-  return false
-}
-
-function isPreviewExposed(
-  subgraphNode: SubgraphNode,
-  source: PromotedWidgetSource
-): boolean {
-  const hostLocator = String(subgraphNode.id)
-  return usePreviewExposureStore()
-    .getExposures(subgraphNode.rootGraph.id, hostLocator)
-    .some(
-      (exposure) =>
-        exposure.sourceNodeId === source.sourceNodeId &&
-        exposure.sourcePreviewName === source.sourceWidgetName
-    )
-}
-
 export function isWidgetPromotedOnSubgraphNode(
   subgraphNode: SubgraphNode,
   source: PromotedWidgetSource,
@@ -247,16 +314,6 @@ export function isWidgetPromotedOnSubgraphNode(
   )
 }
 
-function toPromotionSource(
-  node: PartialNode,
-  widget: IBaseWidget
-): PromotedWidgetSource {
-  return {
-    sourceNodeId: node.id,
-    sourceWidgetName: getWidgetName(widget)
-  }
-}
-
 export function refreshPromotedWidgetRendering(parents: SubgraphNode[]): void {
   for (const parent of parents) {
     parent.expandToFitContent()
@@ -264,10 +321,6 @@ export function refreshPromotedWidgetRendering(parents: SubgraphNode[]): void {
   }
   useCanvasStore().canvas?.setDirty(true, true)
 }
-
-type CanonicalPromotionResult =
-  | { ok: true }
-  | { ok: false; reason: 'missingSourceSlot' | 'connectFailed' }
 
 export function promoteValueWidgetViaSubgraphInput(
   subgraphNode: SubgraphNode,
@@ -305,60 +358,25 @@ export function promoteValueWidgetViaSubgraphInput(
   return { ok: true }
 }
 
-function seedNestedPromotedInputState(
-  subgraphNode: SubgraphNode,
-  inputName: string,
-  sourceSlot: { widgetId?: WidgetId; label?: string }
-): void {
-  if (!sourceSlot.widgetId) return
-
-  const hostInput = subgraphNode.inputs.find(
-    (input) => input._subgraphSlot?.name === inputName
-  )
-  if (!hostInput || hostInput.widgetId) return
-
-  const sourceState = useWidgetValueStore().getWidget(sourceSlot.widgetId)
-  if (!sourceState) return
-
-  const id = widgetId(subgraphNode.rootGraph.id, subgraphNode.id, inputName)
-  hostInput.widget ??= { name: inputName }
-  hostInput.widget.name = inputName
-  hostInput.widgetId = id
-  useWidgetValueStore().registerWidget(id, {
-    type: sourceState.type,
-    value: sourceState.value,
-    options: cloneDeep(sourceState.options ?? {}),
-    label: hostInput.label ?? sourceSlot.label ?? inputName,
-    serialize: sourceState.serialize,
-    disabled: sourceState.disabled,
-    isDOMWidget: sourceState.isDOMWidget
-  })
-}
-
-function promotePreviewViaExposure(
-  subgraphNode: SubgraphNode,
-  sourceNode: LGraphNode,
-  sourcePreviewName: string
-): void {
-  const store = usePreviewExposureStore()
-  const rootGraphId = subgraphNode.rootGraph.id
-  const hostLocator = String(subgraphNode.id)
-  const existing = store
-    .getExposures(rootGraphId, hostLocator)
-    .some(
-      (exposure) =>
-        exposure.sourceNodeId === String(sourceNode.id) &&
-        exposure.sourcePreviewName === sourcePreviewName
-    )
-  if (existing) return
-
-  store.addExposure(rootGraphId, hostLocator, {
-    sourceNodeId: sourceNode.id,
-    sourcePreviewName
-  })
-}
-
 const PREVIEW_WIDGET_TYPES = new Set(['preview', 'video', 'audioUI'])
+
+function getParentNodes(): SubgraphNode[] {
+  const { navigationStack } = useSubgraphNavigationStore()
+  const subgraph = navigationStack.at(-1)
+  if (!subgraph) {
+    useToastStore().add({
+      severity: 'error',
+      summary: t('g.error'),
+      detail: t('subgraphStore.promoteOutsideSubgraph')
+    })
+    return []
+  }
+  const parentGraph = navigationStack.at(-2) ?? subgraph.rootGraph
+  return parentGraph.nodes.filter(
+    (node): node is SubgraphNode =>
+      node.type === subgraph.id && node.isSubgraphNode()
+  )
+}
 
 export function isPreviewPseudoWidget(widget: IBaseWidget): boolean {
   if (widget.name.startsWith('$$')) return true
@@ -465,24 +483,6 @@ export function demoteWidget(
   })
 }
 
-function getParentNodes(): SubgraphNode[] {
-  const { navigationStack } = useSubgraphNavigationStore()
-  const subgraph = navigationStack.at(-1)
-  if (!subgraph) {
-    useToastStore().add({
-      severity: 'error',
-      summary: t('g.error'),
-      detail: t('subgraphStore.promoteOutsideSubgraph')
-    })
-    return []
-  }
-  const parentGraph = navigationStack.at(-2) ?? subgraph.rootGraph
-  return parentGraph.nodes.filter(
-    (node): node is SubgraphNode =>
-      node.type === subgraph.id && node.isSubgraphNode()
-  )
-}
-
 export function addWidgetPromotionOptions(
   options: (IContextMenuValue<unknown> | null)[],
   widget: IBaseWidget,
@@ -540,14 +540,6 @@ const recommendedNodes = [
   'PreviewImage'
 ]
 const recommendedWidgetNames = ['seed']
-export function isRecommendedWidget([node, widget]: WidgetItem) {
-  return (
-    !widget.computedDisabled &&
-    (recommendedNodes.includes(node.type) ||
-      recommendedWidgetNames.includes(widget.name))
-  )
-}
-
 function supportsVirtualPreviewWidget(node: LGraphNode): boolean {
   return supportsVirtualCanvasImagePreview(node)
 }
@@ -563,6 +555,18 @@ function createVirtualCanvasImagePreviewWidget(): IBaseWidget {
   }
 }
 
+function nodeWidgets(n: LGraphNode): WidgetItem[] {
+  return getPromotableWidgets(n).map((w: IBaseWidget) => [n, w])
+}
+
+export function isRecommendedWidget([node, widget]: WidgetItem) {
+  return (
+    !widget.computedDisabled &&
+    (recommendedNodes.includes(node.type) ||
+      recommendedWidgetNames.includes(widget.name))
+  )
+}
+
 export function getPromotableWidgets(node: LGraphNode): IBaseWidget[] {
   const widgets = [...(node.widgets ?? [])]
 
@@ -575,10 +579,6 @@ export function getPromotableWidgets(node: LGraphNode): IBaseWidget[] {
   }
 
   return widgets
-}
-
-function nodeWidgets(n: LGraphNode): WidgetItem[] {
-  return getPromotableWidgets(n).map((w: IBaseWidget) => [n, w])
 }
 
 export function autoExposeKnownPreviewNodes(subgraphNode: SubgraphNode): void {

--- a/src/core/graph/subgraph/resolveConcretePromotedWidget.ts
+++ b/src/core/graph/subgraph/resolveConcretePromotedWidget.ts
@@ -70,16 +70,6 @@ function hasActiveConsumer(
   return false
 }
 
-export function hasActivePromotedWidgetConsumer(
-  hostNode: LGraphNode,
-  inputName: string
-): boolean {
-  return (
-    hostNode.isSubgraphNode() &&
-    hasActiveConsumer(hostNode, inputName, 0, new WeakMap())
-  )
-}
-
 function traversePromotedWidgetChain(
   hostNode: SubgraphNode,
   nodeId: NodeId,
@@ -131,6 +121,16 @@ function traversePromotedWidgetChain(
   }
 
   return { status: 'failure', failure: 'max-depth-exceeded' }
+}
+
+export function hasActivePromotedWidgetConsumer(
+  hostNode: LGraphNode,
+  inputName: string
+): boolean {
+  return (
+    hostNode.isSubgraphNode() &&
+    hasActiveConsumer(hostNode, inputName, 0, new WeakMap())
+  )
 }
 
 export function resolveConcretePromotedWidget(

--- a/src/core/graph/subgraph/resolvePromotedWidgetSource.ts
+++ b/src/core/graph/subgraph/resolvePromotedWidgetSource.ts
@@ -14,18 +14,18 @@ type PromotedWidgetInput = INodeInputSlot & {
   widgetId: NonNullable<INodeInputSlot['widgetId']>
 }
 
-function hasWidgetId(
-  input: INodeInputSlot | undefined
-): input is PromotedWidgetInput {
-  return input?.widgetId !== undefined
-}
-
 interface ResolvedPromotedWidgetSource {
   input: PromotedWidgetInput
   sourceExecutionId?: NodeExecutionId
   sourceNode: LGraphNode
   sourceWidget: IBaseWidget
   sourceWidgetName: string
+}
+
+function hasWidgetId(
+  input: INodeInputSlot | undefined
+): input is PromotedWidgetInput {
+  return input?.widgetId !== undefined
 }
 
 export function resolvePromotedWidgetSource(

--- a/src/core/graph/widgets/dynamicTypes.ts
+++ b/src/core/graph/widgets/dynamicTypes.ts
@@ -14,12 +14,6 @@ const dynamicTypeResolvers: Record<
       .data?.template?.allowed_types?.split(',') ?? []
 }
 
-export function resolveInputType(input: InputSpecV2): string[] {
-  return input.type in dynamicTypeResolvers
-    ? dynamicTypeResolvers[input.type](input)
-    : input.type.split(',')
-}
-
 function resolveAutogrowType(rawSpec: InputSpecV2): string[] {
   const { input } = zAutogrowOptions.safeParse(rawSpec).data?.template ?? {}
 
@@ -32,4 +26,10 @@ function resolveAutogrowType(rawSpec: InputSpecV2): string[] {
       resolveInputType(transformInputSpecV1ToV2(v, { name }))
     )
   )
+}
+
+export function resolveInputType(input: InputSpecV2): string[] {
+  return input.type in dynamicTypeResolvers
+    ? dynamicTypeResolvers[input.type](input)
+    : input.type.split(',')
 }

--- a/src/core/graph/widgets/dynamicWidgets.ts
+++ b/src/core/graph/widgets/dynamicWidgets.ts
@@ -223,16 +223,6 @@ const dynamicInputs: Record<
   COMFY_MATCHTYPE_V3: applyMatchType
 }
 
-export function applyDynamicInputs(
-  node: LGraphNode,
-  inputSpec: InputSpecV2
-): boolean {
-  if (!(inputSpec.type in dynamicInputs)) return false
-  //TODO: move parsing/validation of inputSpec here?
-  dynamicInputs[inputSpec.type](node, inputSpec)
-  return true
-}
-
 function spliceInputs(
   node: LGraphNode,
   startIndex: number,
@@ -445,6 +435,16 @@ function addAutogrowGroup(
   const insertionIndex = lastIndex === -1 ? node.inputs.length : lastIndex + 1
   spliceInputs(node, insertionIndex, 0, ...newInputs)
   app.canvas?.setDirty(true, true)
+}
+
+export function applyDynamicInputs(
+  node: LGraphNode,
+  inputSpec: InputSpecV2
+): boolean {
+  if (!(inputSpec.type in dynamicInputs)) return false
+  //TODO: move parsing/validation of inputSpec here?
+  dynamicInputs[inputSpec.type](node, inputSpec)
+  return true
 }
 
 const ORDINAL_REGEX = /\d+$/

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -39,6 +39,8 @@ const loadingLocales = new Map<string, Promise<void>>()
 // Store custom nodes i18n data for merging when locales are lazily loaded
 const customNodesI18nData: Record<string, unknown> = {}
 
+export type NodeDefTextField = 'display_name' | 'description'
+
 /**
  * Dynamically load a shipped locale's bundles (nodeDefs, commands, settings).
  * Callers must pre-resolve untrusted input via `resolveSupportedLocale` or
@@ -133,8 +135,6 @@ export function mergeCustomNodesI18n(i18nData: Record<string, unknown>): void {
   }
 }
 
-export type NodeDefTextField = 'display_name' | 'description'
-
 /**
  * Raw `/object_info` text, kept out of the vue-i18n message tree so English
  * never reaches the message compiler. Rebuilt on every fetch, so a def that
@@ -145,27 +145,10 @@ const backendNodeText = new Map<
   Partial<Record<NodeDefTextField, string>>
 >()
 
-export function setBackendNodeText(
-  defs: Iterable<{
-    name?: unknown
-    display_name?: unknown
-    description?: unknown
-  }>
-): void {
-  backendNodeText.clear()
-  for (const def of defs) {
-    if (typeof def?.name !== 'string') continue
-    const entry: Partial<Record<NodeDefTextField, string>> = {}
-    if (typeof def.display_name === 'string' && def.display_name) {
-      entry.display_name = def.display_name
-    }
-    if (typeof def.description === 'string' && def.description) {
-      entry.description = def.description
-    }
-    if (entry.display_name ?? entry.description)
-      backendNodeText.set(def.name, entry)
-  }
-}
+/**
+ * Reads a resolved locale message. `st` compiles it; `stRaw` does not.
+ */
+type MessageReader = (key: string, fallbackMessage: string) => string
 
 function customNodesProvide(nodeName: string, path: string): boolean {
   const data = customNodesI18nData[i18n.global.locale.value]
@@ -196,11 +179,6 @@ function nodeDefKeyCandidates(nodeName: string): string[] {
   const normalized = normalizeI18nKey(nodeName)
   return normalized === nodeName ? [normalized] : [normalized, nodeName]
 }
-
-/**
- * Reads a resolved locale message. `st` compiles it; `stRaw` does not.
- */
-type MessageReader = (key: string, fallbackMessage: string) => string
 
 function translateNodeDefText(
   nodeName: string,
@@ -240,6 +218,40 @@ function resolveNodeDefPath(
   return translateNodeDefText(nodeName, path, fallback, read)
 }
 
+/**
+ * `name` is escaped by `scripts/nodeDefLocaleSerializer.ts` and has to be
+ * compiled back; `tooltip` is stored verbatim and must never reach the message
+ * compiler, or a literal `{'@'}` would render to the user.
+ */
+function slotMessageReader(field: NodeDefSlotTextField): MessageReader {
+  return field === 'tooltip' ? stRaw : st
+}
+
+/** Slot fields the generated locales carry text for. */
+export type NodeDefSlotTextField = 'name' | 'tooltip'
+
+export function setBackendNodeText(
+  defs: Iterable<{
+    name?: unknown
+    display_name?: unknown
+    description?: unknown
+  }>
+): void {
+  backendNodeText.clear()
+  for (const def of defs) {
+    if (typeof def?.name !== 'string') continue
+    const entry: Partial<Record<NodeDefTextField, string>> = {}
+    if (typeof def.display_name === 'string' && def.display_name) {
+      entry.display_name = def.display_name
+    }
+    if (typeof def.description === 'string' && def.description) {
+      entry.description = def.description
+    }
+    if (entry.display_name ?? entry.description)
+      backendNodeText.set(def.name, entry)
+  }
+}
+
 export function resolveNodeDefText(
   field: NodeDefTextField,
   nodeName: string,
@@ -249,18 +261,6 @@ export function resolveNodeDefText(
   const fallback = backend ?? (field === 'display_name' ? nodeName : '')
 
   return resolveNodeDefPath(nodeName, field, backend, fallback, st)
-}
-
-/** Slot fields the generated locales carry text for. */
-export type NodeDefSlotTextField = 'name' | 'tooltip'
-
-/**
- * `name` is escaped by `scripts/nodeDefLocaleSerializer.ts` and has to be
- * compiled back; `tooltip` is stored verbatim and must never reach the message
- * compiler, or a literal `{'@'}` would render to the user.
- */
-function slotMessageReader(field: NodeDefSlotTextField): MessageReader {
-  return field === 'tooltip' ? stRaw : st
 }
 
 export function resolveNodeDefSlotText(

--- a/src/lib/litegraph/src/DragAndScale.ts
+++ b/src/lib/litegraph/src/DragAndScale.ts
@@ -1,6 +1,17 @@
 import type { Point, ReadOnlyRect, Rect } from './interfaces'
 import { EaseFunction, Rectangle } from './litegraph'
 
+/**
+ * Copies the values of one state into another, preserving references.
+ * @param from The state to copy values from.
+ * @param to The state to copy values into.
+ */
+function copyState(from: DragAndScaleState, to: DragAndScaleState): void {
+  to.scale = from.scale
+  to.offset[0] = from.offset[0]
+  to.offset[1] = from.offset[1]
+}
+
 export interface DragAndScaleState {
   /**
    * The offset from the top-left of the current canvas viewport to `[0, 0]` in graph space.
@@ -308,15 +319,4 @@ export class DragAndScale {
     this.offset[0] = 0
     this.offset[1] = 0
   }
-}
-
-/**
- * Copies the values of one state into another, preserving references.
- * @param from The state to copy values from.
- * @param to The state to copy values into.
- */
-function copyState(from: DragAndScaleState, to: DragAndScaleState): void {
-  to.scale = from.scale
-  to.offset[0] = from.offset[0]
-  to.offset[1] = from.offset[1]
 }

--- a/src/lib/litegraph/src/LGraph.ts
+++ b/src/lib/litegraph/src/LGraph.ts
@@ -106,6 +106,14 @@ export type {
 
 const validTriggerActions = new Set<LGraphTriggerAction>(LGraphTriggerActions)
 
+type ParamsArray<T, K extends MethodNames<T>> = Parameters<
+  Extract<T[K], (...args: never[]) => unknown>
+>[1] extends undefined
+  ?
+      | Parameters<Extract<T[K], (...args: never[]) => unknown>>
+      | Parameters<Extract<T[K], (...args: never[]) => unknown>>[0]
+  : Parameters<Extract<T[K], (...args: never[]) => unknown>>
+
 function isLGraphTriggerAction(action: string): action is LGraphTriggerAction {
   return validTriggerActions.has(action as LGraphTriggerAction)
 }
@@ -126,6 +134,32 @@ function syncLastNodeId(state: LGraphState, id: NodeId): void {
   }
 }
 
+function fireNodeRemovalLifecycle(node: LGraphNode): void {
+  const graph: LGraph | null = node.graph
+  graph?.events.dispatch('node:before-removed', { node })
+  node.onRemoved?.()
+  graph?.onNodeRemoved?.(node)
+}
+
+function patchLinkNodeIds(
+  links: Map<LinkId, LLink>,
+  remappedIds: Map<NodeId, NodeId>
+): void {
+  for (const link of links.values()) {
+    const newOrigin =
+      link.origin_id === UNASSIGNED_NODE_ID
+        ? undefined
+        : remappedIds.get(link.origin_id)
+    if (newOrigin !== undefined) link.origin_id = newOrigin
+
+    const newTarget =
+      link.target_id === UNASSIGNED_NODE_ID
+        ? undefined
+        : remappedIds.get(link.target_id)
+    if (newTarget !== undefined) link.target_id = newTarget
+  }
+}
+
 export type RendererType = 'LG' | 'Vue' | 'Vue-corrected'
 
 /**
@@ -140,14 +174,6 @@ export interface LGraphState {
   lastLinkId: LinkId
   lastRerouteId: RerouteId
 }
-
-type ParamsArray<T, K extends MethodNames<T>> = Parameters<
-  Extract<T[K], (...args: never[]) => unknown>
->[1] extends undefined
-  ?
-      | Parameters<Extract<T[K], (...args: never[]) => unknown>>
-      | Parameters<Extract<T[K], (...args: never[]) => unknown>>[0]
-  : Parameters<Extract<T[K], (...args: never[]) => unknown>>
 
 /** Configuration used by {@link LGraph} `config`. */
 export interface LGraphConfig {
@@ -178,12 +204,14 @@ export interface BaseLGraph {
   readonly rootGraph: LGraph
 }
 
-function fireNodeRemovalLifecycle(node: LGraphNode): void {
-  const graph: LGraph | null = node.graph
-  graph?.events.dispatch('node:before-removed', { node })
-  node.onRemoved?.()
-  graph?.onNodeRemoved?.(node)
-}
+/** Internal; simplifies type definitions. */
+export type GraphOrSubgraph = LGraph | Subgraph
+
+// ============================================================================
+// TEMPORARY: Subgraph class moved here to resolve circular dependency
+// This is a temporary solution until the architecture can be refactored
+// TODO: Move back to separate file once circular dependencies are resolved
+// ============================================================================
 
 /**
  * LGraph is the class that contain a full graph. We instantiate one and add nodes to it, and then we can run the execution loop.
@@ -2824,15 +2852,6 @@ export class LGraph
   }
 }
 
-/** Internal; simplifies type definitions. */
-export type GraphOrSubgraph = LGraph | Subgraph
-
-// ============================================================================
-// TEMPORARY: Subgraph class moved here to resolve circular dependency
-// This is a temporary solution until the architecture can be refactored
-// TODO: Move back to separate file once circular dependencies are resolved
-// ============================================================================
-
 /** A subgraph definition. */
 export class Subgraph
   extends LGraph
@@ -3173,24 +3192,5 @@ export class Subgraph
         : undefined,
       extra: this.extra
     }
-  }
-}
-
-function patchLinkNodeIds(
-  links: Map<LinkId, LLink>,
-  remappedIds: Map<NodeId, NodeId>
-): void {
-  for (const link of links.values()) {
-    const newOrigin =
-      link.origin_id === UNASSIGNED_NODE_ID
-        ? undefined
-        : remappedIds.get(link.origin_id)
-    if (newOrigin !== undefined) link.origin_id = newOrigin
-
-    const newTarget =
-      link.target_id === UNASSIGNED_NODE_ID
-        ? undefined
-        : remappedIds.get(link.target_id)
-    if (newTarget !== undefined) link.target_id = newTarget
   }
 }

--- a/src/lib/litegraph/src/LGraphBadge.ts
+++ b/src/lib/litegraph/src/LGraphBadge.ts
@@ -3,11 +3,6 @@ import { LGraphIcon } from './LGraphIcon'
 import type { LGraphIconOptions } from './LGraphIcon'
 import { cachedMeasureText } from './utils/textMeasureCache'
 
-export enum BadgePosition {
-  TopLeft = 'top-left',
-  TopRight = 'top-right'
-}
-
 export interface LGraphBadgeOptions {
   text: string
   fgColor?: string
@@ -20,6 +15,11 @@ export interface LGraphBadgeOptions {
   onClick?: (e: MouseEvent) => void
   xOffset?: number
   yOffset?: number
+}
+
+export enum BadgePosition {
+  TopLeft = 'top-left',
+  TopRight = 'top-right'
 }
 
 export class LGraphBadge {

--- a/src/lib/litegraph/src/LGraphCanvas.cloneZIndex.test.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.cloneZIndex.test.ts
@@ -15,15 +15,6 @@ import {
 
 const TEST_NODE_TYPE = 'test/CloneZIndex' as const
 
-class TestNode extends LGraphNode {
-  static override type = TEST_NODE_TYPE
-
-  constructor(title?: string) {
-    super(title ?? TEST_NODE_TYPE)
-    this.type = TEST_NODE_TYPE
-  }
-}
-
 function createCanvas(graph: LGraph): LGraphCanvas {
   const el = document.createElement('canvas')
   el.width = 800
@@ -112,6 +103,15 @@ function setZIndex(nodeId: NodeId, zIndex: number, previousZIndex: number) {
     source: LayoutSource.Canvas,
     actor: 'test'
   })
+}
+
+class TestNode extends LGraphNode {
+  static override type = TEST_NODE_TYPE
+
+  constructor(title?: string) {
+    super(title ?? TEST_NODE_TYPE)
+    this.type = TEST_NODE_TYPE
+  }
 }
 
 describe('cloned node z-index in Vue renderer', () => {

--- a/src/lib/litegraph/src/LGraphCanvas.onMenuAdd.test.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.onMenuAdd.test.ts
@@ -9,13 +9,7 @@ import {
   LiteGraph
 } from '@/lib/litegraph/src/litegraph'
 
-class TestNode extends LGraphNode {
-  static override type = 'TestNode'
-
-  constructor(title?: string) {
-    super(title ?? 'TestNode')
-  }
-}
+type MenuEntry = IContextMenuValue<string>
 
 function makeNodeClass(title: string) {
   class N extends TestNode {
@@ -50,7 +44,13 @@ function createCanvas(graph: LGraph): LGraphCanvas {
   return new LGraphCanvas(el, graph, { skip_render: true })
 }
 
-type MenuEntry = IContextMenuValue<string>
+class TestNode extends LGraphNode {
+  static override type = 'TestNode'
+
+  constructor(title?: string) {
+    super(title ?? 'TestNode')
+  }
+}
 
 describe('LGraphCanvas.onMenuAdd category sorting', () => {
   let graph: LGraph

--- a/src/lib/litegraph/src/LGraphCanvas.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.ts
@@ -277,6 +277,149 @@ const temp_vec2: Point = [0, 0]
 const tmp_area = new Rectangle()
 const margin_area = new Rectangle()
 const link_bounding = new Rectangle()
+function patchLinkNodeIds(
+  links:
+    | { origin_id: SerializedNodeId; target_id: SerializedNodeId }[]
+    | undefined,
+  remappedIds: Map<SerializedNodeId, SerializedNodeId>
+) {
+  if (!links?.length) return
+
+  for (const link of links) {
+    const newOriginId = remappedIds.get(link.origin_id)
+    if (newOriginId !== undefined) link.origin_id = newOriginId
+
+    const newTargetId = remappedIds.get(link.target_id)
+    if (newTargetId !== undefined) link.target_id = newTargetId
+  }
+}
+
+function remapNodeId(
+  nodeId: string,
+  remappedIds: Map<SerializedNodeId, SerializedNodeId>
+): SerializedNodeId | undefined {
+  const directMatch = remappedIds.get(nodeId)
+  if (directMatch !== undefined) return directMatch
+  if (!/^-?\d+$/.test(nodeId)) return undefined
+
+  const numericId = Number(nodeId)
+  if (!Number.isSafeInteger(numericId)) return undefined
+
+  return remappedIds.get(numericId)
+}
+
+function remapProxyWidgets(
+  info: ISerialisedNode,
+  remappedIds: Map<SerializedNodeId, SerializedNodeId> | undefined
+) {
+  if (!remappedIds || remappedIds.size === 0) return
+
+  const proxyWidgets = info.properties?.proxyWidgets
+  if (!Array.isArray(proxyWidgets)) return
+
+  for (const entry of proxyWidgets) {
+    if (!Array.isArray(entry)) continue
+
+    const [nodeId] = entry
+    if (typeof nodeId !== 'string' || nodeId === '-1') continue
+
+    const remappedNodeId = remapNodeId(nodeId, remappedIds)
+    if (remappedNodeId !== undefined) entry[0] = String(remappedNodeId)
+  }
+}
+
+function hasStringSourceNodeId(
+  value: unknown
+): value is { sourceNodeId: string } {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'sourceNodeId' in value &&
+    typeof value.sourceNodeId === 'string'
+  )
+}
+
+function remapPreviewExposures(
+  info: ISerialisedNode,
+  remappedIds: Map<SerializedNodeId, SerializedNodeId> | undefined
+) {
+  if (!remappedIds || remappedIds.size === 0) return
+
+  const previewExposures = info.properties?.previewExposures
+  if (!Array.isArray(previewExposures)) return
+
+  for (const entry of previewExposures) {
+    if (!hasStringSourceNodeId(entry) || entry.sourceNodeId === '-1') continue
+
+    const remappedNodeId = remapNodeId(entry.sourceNodeId, remappedIds)
+    if (remappedNodeId !== undefined)
+      entry.sourceNodeId = String(remappedNodeId)
+  }
+}
+
+export function remapClipboardSubgraphNodeIds(
+  parsed: ClipboardItems,
+  rootGraph: LGraph
+): void {
+  const usedNodeIds = new Set<number>()
+  forEachNode(rootGraph, (node) => {
+    const numericId = Number(node.id)
+    if (!Number.isInteger(numericId)) return
+    usedNodeIds.add(numericId)
+    if (rootGraph.state.lastNodeId < numericId)
+      rootGraph.state.lastNodeId = numericId
+  })
+
+  function nextUniqueNodeId() {
+    while (usedNodeIds.has(++rootGraph.state.lastNodeId));
+    const nextId = rootGraph.state.lastNodeId
+    usedNodeIds.add(nextId)
+    return nextId
+  }
+
+  const subgraphNodeIdMap = new Map<
+    SubgraphId,
+    Map<SerializedNodeId, SerializedNodeId>
+  >()
+  for (const subgraphInfo of parsed.subgraphs ?? []) {
+    const remappedIds = new Map<SerializedNodeId, SerializedNodeId>()
+    const interiorNodes = subgraphInfo.nodes ?? []
+
+    for (const nodeInfo of interiorNodes) {
+      if (typeof nodeInfo.id !== 'number') continue
+
+      if (usedNodeIds.has(nodeInfo.id)) {
+        const oldId = nodeInfo.id
+        const newId = nextUniqueNodeId()
+        remappedIds.set(oldId, newId)
+        nodeInfo.id = newId
+        continue
+      }
+
+      usedNodeIds.add(nodeInfo.id)
+      if (rootGraph.state.lastNodeId < nodeInfo.id)
+        rootGraph.state.lastNodeId = nodeInfo.id
+    }
+
+    if (remappedIds.size > 0) {
+      patchLinkNodeIds(subgraphInfo.links, remappedIds)
+      subgraphNodeIdMap.set(subgraphInfo.id, remappedIds)
+    }
+  }
+
+  const allNodeInfo: ISerialisedNode[] = [
+    parsed.nodes ? [parsed.nodes] : [],
+    parsed.subgraphs ? parsed.subgraphs.map((s) => s.nodes ?? []) : []
+  ].flat(2)
+
+  for (const nodeInfo of allNodeInfo) {
+    if (typeof nodeInfo.type !== 'string') continue
+    const remappedIds = subgraphNodeIdMap.get(nodeInfo.type)
+    remapProxyWidgets(nodeInfo, remappedIds)
+    remapPreviewExposures(nodeInfo, remappedIds)
+  }
+}
+
 /**
  * This class is in charge of rendering one graph inside a canvas. And provides all the interaction required.
  * Valid callbacks are: onNodeSelected, onNodeDeselected, onShowNodePanel, onNodeDblClicked
@@ -9009,148 +9152,5 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
         offset: [...this.ds.offset] as [number, number]
       }
     }
-  }
-}
-
-function patchLinkNodeIds(
-  links:
-    | { origin_id: SerializedNodeId; target_id: SerializedNodeId }[]
-    | undefined,
-  remappedIds: Map<SerializedNodeId, SerializedNodeId>
-) {
-  if (!links?.length) return
-
-  for (const link of links) {
-    const newOriginId = remappedIds.get(link.origin_id)
-    if (newOriginId !== undefined) link.origin_id = newOriginId
-
-    const newTargetId = remappedIds.get(link.target_id)
-    if (newTargetId !== undefined) link.target_id = newTargetId
-  }
-}
-
-function remapNodeId(
-  nodeId: string,
-  remappedIds: Map<SerializedNodeId, SerializedNodeId>
-): SerializedNodeId | undefined {
-  const directMatch = remappedIds.get(nodeId)
-  if (directMatch !== undefined) return directMatch
-  if (!/^-?\d+$/.test(nodeId)) return undefined
-
-  const numericId = Number(nodeId)
-  if (!Number.isSafeInteger(numericId)) return undefined
-
-  return remappedIds.get(numericId)
-}
-
-function remapProxyWidgets(
-  info: ISerialisedNode,
-  remappedIds: Map<SerializedNodeId, SerializedNodeId> | undefined
-) {
-  if (!remappedIds || remappedIds.size === 0) return
-
-  const proxyWidgets = info.properties?.proxyWidgets
-  if (!Array.isArray(proxyWidgets)) return
-
-  for (const entry of proxyWidgets) {
-    if (!Array.isArray(entry)) continue
-
-    const [nodeId] = entry
-    if (typeof nodeId !== 'string' || nodeId === '-1') continue
-
-    const remappedNodeId = remapNodeId(nodeId, remappedIds)
-    if (remappedNodeId !== undefined) entry[0] = String(remappedNodeId)
-  }
-}
-
-function hasStringSourceNodeId(
-  value: unknown
-): value is { sourceNodeId: string } {
-  return (
-    typeof value === 'object' &&
-    value !== null &&
-    'sourceNodeId' in value &&
-    typeof value.sourceNodeId === 'string'
-  )
-}
-
-function remapPreviewExposures(
-  info: ISerialisedNode,
-  remappedIds: Map<SerializedNodeId, SerializedNodeId> | undefined
-) {
-  if (!remappedIds || remappedIds.size === 0) return
-
-  const previewExposures = info.properties?.previewExposures
-  if (!Array.isArray(previewExposures)) return
-
-  for (const entry of previewExposures) {
-    if (!hasStringSourceNodeId(entry) || entry.sourceNodeId === '-1') continue
-
-    const remappedNodeId = remapNodeId(entry.sourceNodeId, remappedIds)
-    if (remappedNodeId !== undefined)
-      entry.sourceNodeId = String(remappedNodeId)
-  }
-}
-
-export function remapClipboardSubgraphNodeIds(
-  parsed: ClipboardItems,
-  rootGraph: LGraph
-): void {
-  const usedNodeIds = new Set<number>()
-  forEachNode(rootGraph, (node) => {
-    const numericId = Number(node.id)
-    if (!Number.isInteger(numericId)) return
-    usedNodeIds.add(numericId)
-    if (rootGraph.state.lastNodeId < numericId)
-      rootGraph.state.lastNodeId = numericId
-  })
-
-  function nextUniqueNodeId() {
-    while (usedNodeIds.has(++rootGraph.state.lastNodeId));
-    const nextId = rootGraph.state.lastNodeId
-    usedNodeIds.add(nextId)
-    return nextId
-  }
-
-  const subgraphNodeIdMap = new Map<
-    SubgraphId,
-    Map<SerializedNodeId, SerializedNodeId>
-  >()
-  for (const subgraphInfo of parsed.subgraphs ?? []) {
-    const remappedIds = new Map<SerializedNodeId, SerializedNodeId>()
-    const interiorNodes = subgraphInfo.nodes ?? []
-
-    for (const nodeInfo of interiorNodes) {
-      if (typeof nodeInfo.id !== 'number') continue
-
-      if (usedNodeIds.has(nodeInfo.id)) {
-        const oldId = nodeInfo.id
-        const newId = nextUniqueNodeId()
-        remappedIds.set(oldId, newId)
-        nodeInfo.id = newId
-        continue
-      }
-
-      usedNodeIds.add(nodeInfo.id)
-      if (rootGraph.state.lastNodeId < nodeInfo.id)
-        rootGraph.state.lastNodeId = nodeInfo.id
-    }
-
-    if (remappedIds.size > 0) {
-      patchLinkNodeIds(subgraphInfo.links, remappedIds)
-      subgraphNodeIdMap.set(subgraphInfo.id, remappedIds)
-    }
-  }
-
-  const allNodeInfo: ISerialisedNode[] = [
-    parsed.nodes ? [parsed.nodes] : [],
-    parsed.subgraphs ? parsed.subgraphs.map((s) => s.nodes ?? []) : []
-  ].flat(2)
-
-  for (const nodeInfo of allNodeInfo) {
-    if (typeof nodeInfo.type !== 'string') continue
-    const remappedIds = subgraphNodeIdMap.get(nodeInfo.type)
-    remapProxyWidgets(nodeInfo, remappedIds)
-    remapPreviewExposures(nodeInfo, remappedIds)
   }
 }

--- a/src/lib/litegraph/src/LLink.ts
+++ b/src/lib/litegraph/src/LLink.ts
@@ -30,23 +30,6 @@ import type { Serialisable, SerialisableLLink } from './types/serialisation'
 const layoutMutations = useLayoutMutations()
 
 export type { LinkId } from '@/types/linkId'
-export type SerialisedLLinkArray = [
-  id: number,
-  origin_id: SerializedNodeId,
-  origin_slot: number,
-  target_id: SerializedNodeId,
-  target_slot: number,
-  type: ISlotType
-]
-
-// Resolved connection union; eliminates subgraph in/out as a possibility
-export type ResolvedConnection = BaseResolvedConnection &
-  (
-    | (ResolvedSubgraphInput & ResolvedNormalOutput)
-    | (ResolvedNormalInput & ResolvedSubgraphOutput)
-    | (ResolvedNormalInput & ResolvedNormalOutput)
-  )
-
 interface BaseResolvedConnection {
   link: LLink
   /** The node on the input side of the link (owns {@link input}) */
@@ -92,6 +75,23 @@ type BasicReadonlyNetwork = Pick<
   ReadonlyLinkNetwork,
   'getNodeById' | 'links' | 'getLink' | 'inputNode' | 'outputNode'
 >
+
+export type SerialisedLLinkArray = [
+  id: number,
+  origin_id: SerializedNodeId,
+  origin_slot: number,
+  target_id: SerializedNodeId,
+  target_slot: number,
+  type: ISlotType
+]
+
+// Resolved connection union; eliminates subgraph in/out as a possibility
+export type ResolvedConnection = BaseResolvedConnection &
+  (
+    | (ResolvedSubgraphInput & ResolvedNormalOutput)
+    | (ResolvedNormalInput & ResolvedSubgraphOutput)
+    | (ResolvedNormalInput & ResolvedNormalOutput)
+  )
 
 // this is the class in charge of storing link information
 export class LLink implements LinkSegment, Serialisable<SerialisableLLink> {

--- a/src/lib/litegraph/src/Reroute.ts
+++ b/src/lib/litegraph/src/Reroute.ts
@@ -27,6 +27,135 @@ const layoutMutations = useLayoutMutations()
 
 export type { RerouteId } from '@/types/rerouteId'
 
+/**
+ * Retrieves the position of the next reroute in the chain, or the destination input slot on this link.
+ * @param network The network of links
+ * @param link The link representing the current reroute chain
+ * @param id The ID of "this" reroute
+ * @returns The position of the next reroute or the input slot target, otherwise `undefined`.
+ */
+function getNextPos(
+  network: ReadonlyLinkNetwork,
+  link: LLink | undefined,
+  id: RerouteId
+) {
+  if (!link) return
+
+  const linkPos = LLink.findNextReroute(network, link, id)?.pos
+  if (linkPos) return linkPos
+
+  // Floating link with no input to find
+  if (link.target_id === UNASSIGNED_NODE_ID || link.target_slot === -1) return
+
+  return network.getNodeById(link.target_id)?.getInputPos(link.target_slot)
+}
+
+/** Returns the direction from one point to another in radians. */
+function getDirection(fromPos: Point, toPos: Point) {
+  return Math.atan2(toPos[1] - fromPos[1], toPos[0] - fromPos[0])
+}
+
+/**
+ * Represents a slot on a reroute.
+ * @private Designed for internal use within this module.
+ */
+class RerouteSlot {
+  /** The reroute that the slot belongs to. */
+  private readonly reroute: Reroute
+
+  private readonly offsetMultiplier: 1 | -1
+  /** Centre point of this slot. */
+  get pos(): Point {
+    const [x, y] = this.reroute.pos
+    return [x + Reroute.slotOffset * this.offsetMultiplier, y]
+  }
+
+  /** Whether any changes require a redraw. */
+  dirty: boolean = false
+
+  private hoveringInternal = false
+  /** Whether the pointer is hovering over the slot itself. */
+  get hovering() {
+    return this.hoveringInternal
+  }
+
+  set hovering(value) {
+    if (!Object.is(this.hoveringInternal, value)) {
+      this.hoveringInternal = value
+      this.dirty = true
+    }
+  }
+
+  private showOutlineInternal = false
+  /** Whether the slot outline / faint background is visible. */
+  get showOutline() {
+    return this.showOutlineInternal
+  }
+
+  set showOutline(value) {
+    if (!Object.is(this.showOutlineInternal, value)) {
+      this.showOutlineInternal = value
+      this.dirty = true
+    }
+  }
+
+  constructor(reroute: Reroute, isInput: boolean) {
+    this.reroute = reroute
+    this.offsetMultiplier = isInput ? -1 : 1
+  }
+
+  /**
+   * Updates the slot's visibility based on the position of the pointer.
+   * @param pos The position of the pointer.
+   * @param outlineOnly If `true`, slot will display with the faded outline only ({@link showOutline}).
+   */
+  update(pos: Point, outlineOnly?: boolean) {
+    if (outlineOnly) {
+      this.hovering = false
+      this.showOutline = true
+    } else {
+      const dist = distance(this.pos, pos)
+      this.hovering = dist <= 2 * Reroute.slotRadius
+      this.showOutline = dist <= 5 * Reroute.slotRadius
+    }
+  }
+
+  /** Hides the slot. */
+  hide() {
+    this.hovering = false
+    this.showOutline = false
+  }
+
+  /**
+   * Draws the slot on the canvas.
+   * @param ctx The canvas context to draw on.
+   */
+  draw(ctx: CanvasRenderingContext2D): void {
+    const { fillStyle, strokeStyle, lineWidth } = ctx
+    const {
+      showOutline,
+      hovering,
+      pos: [x, y]
+    } = this
+    if (!showOutline) return
+
+    try {
+      ctx.fillStyle = hovering ? this.reroute.colour : 'rgba(127,127,127,0.3)'
+      ctx.strokeStyle = 'rgb(0,0,0,0.5)'
+      ctx.lineWidth = 1
+
+      ctx.beginPath()
+      ctx.arc(x, y, Reroute.slotRadius, 0, 2 * Math.PI)
+      ctx.fill()
+      ctx.stroke()
+    } finally {
+      ctx.fillStyle = fillStyle
+      ctx.strokeStyle = strokeStyle
+      ctx.lineWidth = lineWidth
+    }
+  }
+}
+
 /** The input or output slot that an incomplete reroute link is connected to. */
 export interface FloatingRerouteSlot {
   /** Floating connection to an input or output */
@@ -692,133 +821,4 @@ export class Reroute
       floating: this.floating ? { slotType: this.floating.slotType } : undefined
     }
   }
-}
-
-/**
- * Represents a slot on a reroute.
- * @private Designed for internal use within this module.
- */
-class RerouteSlot {
-  /** The reroute that the slot belongs to. */
-  private readonly reroute: Reroute
-
-  private readonly offsetMultiplier: 1 | -1
-  /** Centre point of this slot. */
-  get pos(): Point {
-    const [x, y] = this.reroute.pos
-    return [x + Reroute.slotOffset * this.offsetMultiplier, y]
-  }
-
-  /** Whether any changes require a redraw. */
-  dirty: boolean = false
-
-  private hoveringInternal = false
-  /** Whether the pointer is hovering over the slot itself. */
-  get hovering() {
-    return this.hoveringInternal
-  }
-
-  set hovering(value) {
-    if (!Object.is(this.hoveringInternal, value)) {
-      this.hoveringInternal = value
-      this.dirty = true
-    }
-  }
-
-  private showOutlineInternal = false
-  /** Whether the slot outline / faint background is visible. */
-  get showOutline() {
-    return this.showOutlineInternal
-  }
-
-  set showOutline(value) {
-    if (!Object.is(this.showOutlineInternal, value)) {
-      this.showOutlineInternal = value
-      this.dirty = true
-    }
-  }
-
-  constructor(reroute: Reroute, isInput: boolean) {
-    this.reroute = reroute
-    this.offsetMultiplier = isInput ? -1 : 1
-  }
-
-  /**
-   * Updates the slot's visibility based on the position of the pointer.
-   * @param pos The position of the pointer.
-   * @param outlineOnly If `true`, slot will display with the faded outline only ({@link showOutline}).
-   */
-  update(pos: Point, outlineOnly?: boolean) {
-    if (outlineOnly) {
-      this.hovering = false
-      this.showOutline = true
-    } else {
-      const dist = distance(this.pos, pos)
-      this.hovering = dist <= 2 * Reroute.slotRadius
-      this.showOutline = dist <= 5 * Reroute.slotRadius
-    }
-  }
-
-  /** Hides the slot. */
-  hide() {
-    this.hovering = false
-    this.showOutline = false
-  }
-
-  /**
-   * Draws the slot on the canvas.
-   * @param ctx The canvas context to draw on.
-   */
-  draw(ctx: CanvasRenderingContext2D): void {
-    const { fillStyle, strokeStyle, lineWidth } = ctx
-    const {
-      showOutline,
-      hovering,
-      pos: [x, y]
-    } = this
-    if (!showOutline) return
-
-    try {
-      ctx.fillStyle = hovering ? this.reroute.colour : 'rgba(127,127,127,0.3)'
-      ctx.strokeStyle = 'rgb(0,0,0,0.5)'
-      ctx.lineWidth = 1
-
-      ctx.beginPath()
-      ctx.arc(x, y, Reroute.slotRadius, 0, 2 * Math.PI)
-      ctx.fill()
-      ctx.stroke()
-    } finally {
-      ctx.fillStyle = fillStyle
-      ctx.strokeStyle = strokeStyle
-      ctx.lineWidth = lineWidth
-    }
-  }
-}
-
-/**
- * Retrieves the position of the next reroute in the chain, or the destination input slot on this link.
- * @param network The network of links
- * @param link The link representing the current reroute chain
- * @param id The ID of "this" reroute
- * @returns The position of the next reroute or the input slot target, otherwise `undefined`.
- */
-function getNextPos(
-  network: ReadonlyLinkNetwork,
-  link: LLink | undefined,
-  id: RerouteId
-) {
-  if (!link) return
-
-  const linkPos = LLink.findNextReroute(network, link, id)?.pos
-  if (linkPos) return linkPos
-
-  // Floating link with no input to find
-  if (link.target_id === UNASSIGNED_NODE_ID || link.target_slot === -1) return
-
-  return network.getNodeById(link.target_id)?.getInputPos(link.target_slot)
-}
-
-/** Returns the direction from one point to another in radians. */
-function getDirection(fromPos: Point, toPos: Point) {
-  return Math.atan2(toPos[1] - fromPos[1], toPos[0] - fromPos[0])
 }

--- a/src/lib/litegraph/src/canvas/LinkConnector.ts
+++ b/src/lib/litegraph/src/canvas/LinkConnector.ts
@@ -78,6 +78,42 @@ interface LinkConnectorExport {
   network: LinkNetwork
 }
 
+/** Validates that a single {@link RenderLink} can be dropped on the specified reroute. */
+function canConnectInputLinkToReroute(
+  link:
+    | ToInputRenderLink
+    | MovingInputLink
+    | FloatingRenderLink
+    | ToInputFromIoNodeLink,
+  inputNode: LGraphNode,
+  input: INodeInputSlot,
+  reroute: Reroute
+): boolean {
+  const { fromReroute } = link
+
+  if (
+    !link.canConnectToInput(inputNode, input) ||
+    // Would result in no change
+    fromReroute?.id === reroute.id ||
+    // Cannot connect from child to parent reroute
+    fromReroute?.getReroutes()?.includes(reroute)
+  ) {
+    return false
+  }
+
+  // Would result in no change
+  if (link instanceof ToInputRenderLink) {
+    if (reroute.parentId == null) {
+      // Link would make no change - output to reroute
+      if (reroute.firstLink?.hasOrigin(link.node.id, link.fromSlotIndex))
+        return false
+    } else if (link.fromReroute?.id === reroute.parentId) {
+      return false
+    }
+  }
+  return true
+}
+
 /**
  * Component of {@link LGraphCanvas} that handles connecting and moving links.
  * @see {@link LLink}
@@ -1124,40 +1160,4 @@ export class LinkConnector {
     state.draggingExistingLinks = false
     state.snapLinksPos = undefined
   }
-}
-
-/** Validates that a single {@link RenderLink} can be dropped on the specified reroute. */
-function canConnectInputLinkToReroute(
-  link:
-    | ToInputRenderLink
-    | MovingInputLink
-    | FloatingRenderLink
-    | ToInputFromIoNodeLink,
-  inputNode: LGraphNode,
-  input: INodeInputSlot,
-  reroute: Reroute
-): boolean {
-  const { fromReroute } = link
-
-  if (
-    !link.canConnectToInput(inputNode, input) ||
-    // Would result in no change
-    fromReroute?.id === reroute.id ||
-    // Cannot connect from child to parent reroute
-    fromReroute?.getReroutes()?.includes(reroute)
-  ) {
-    return false
-  }
-
-  // Would result in no change
-  if (link instanceof ToInputRenderLink) {
-    if (reroute.parentId == null) {
-      // Link would make no change - output to reroute
-      if (reroute.firstLink?.hasOrigin(link.node.id, link.fromSlotIndex))
-        return false
-    } else if (link.fromReroute?.id === reroute.parentId) {
-      return false
-    }
-  }
-  return true
 }

--- a/src/lib/litegraph/src/draw.ts
+++ b/src/lib/litegraph/src/draw.ts
@@ -8,26 +8,74 @@ const ELLIPSIS = '\u2026'
 const TWO_DOT_LEADER = '\u2025'
 const ONE_DOT_LEADER = '\u2024'
 
-export enum SlotType {
-  Array = 'array',
-  Event = -1
+interface IDrawTextInAreaOptions {
+  /** The canvas to draw the text on. */
+  ctx: CanvasRenderingContext2D
+  /** The text to draw. */
+  text: string
+  /** The area the text will be drawn in. */
+  area: Rectangle
+  /** The alignment of the text. */
+  align?: 'left' | 'right' | 'center'
 }
 
-/** @see RenderShape */
-export enum SlotShape {
-  Box = RenderShape.BOX,
-  Arrow = RenderShape.ARROW,
-  Grid = RenderShape.GRID,
-  Circle = RenderShape.CIRCLE,
-  HollowCircle = RenderShape.HollowCircle
-}
+/**
+ * Truncates text using binary search to fit within a given width, appending an ellipsis if needed.
+ * @param ctx The canvas rendering context.
+ * @param text The text to truncate.
+ * @param maxWidth The maximum width the text (plus ellipsis) can occupy.
+ * @returns The truncated text, or the original text if it fits.
+ */
+function truncateTextToWidth(
+  ctx: CanvasRenderingContext2D,
+  text: string,
+  maxWidth: number
+): string {
+  if (!(maxWidth > 0)) return ''
 
-/** @see LinkDirection */
-export enum SlotDirection {}
+  // Text fits
+  const fullWidth = cachedMeasureText(ctx, text)
+  if (fullWidth <= maxWidth) return text
 
-export enum LabelPosition {
-  Left = 'left',
-  Right = 'right'
+  const ellipsisWidth = cachedMeasureText(ctx, ELLIPSIS) * 0.75
+
+  // Can't even fit ellipsis
+  if (ellipsisWidth > maxWidth) {
+    const twoDotsWidth = cachedMeasureText(ctx, TWO_DOT_LEADER) * 0.75
+    if (twoDotsWidth < maxWidth) return TWO_DOT_LEADER
+
+    const oneDotWidth = cachedMeasureText(ctx, ONE_DOT_LEADER) * 0.75
+    return oneDotWidth < maxWidth ? ONE_DOT_LEADER : ''
+  }
+
+  let min = 0
+  let max = text.length
+  let bestLen = 0
+
+  // Binary search for the longest substring that fits with the ellipsis
+  while (min <= max) {
+    const mid = Math.floor((min + max) * 0.5)
+
+    // Avoid measuring empty string + ellipsis
+    if (mid === 0) {
+      min = mid + 1
+      continue
+    }
+
+    const sub = text.substring(0, mid)
+    const currentWidth = cachedMeasureText(ctx, sub) + ellipsisWidth
+
+    if (currentWidth <= maxWidth) {
+      // This length fits, try potentially longer
+      bestLen = mid
+      min = mid + 1
+    } else {
+      // Too long, try shorter
+      max = mid - 1
+    }
+  }
+
+  return bestLen === 0 ? ELLIPSIS : text.substring(0, bestLen) + ELLIPSIS
 }
 
 export interface IDrawBoundingOptions {
@@ -49,15 +97,26 @@ export interface IDrawBoundingOptions {
   lineWidth?: number
 }
 
-interface IDrawTextInAreaOptions {
-  /** The canvas to draw the text on. */
-  ctx: CanvasRenderingContext2D
-  /** The text to draw. */
-  text: string
-  /** The area the text will be drawn in. */
-  area: Rectangle
-  /** The alignment of the text. */
-  align?: 'left' | 'right' | 'center'
+export enum SlotType {
+  Array = 'array',
+  Event = -1
+}
+
+/** @see RenderShape */
+export enum SlotShape {
+  Box = RenderShape.BOX,
+  Arrow = RenderShape.ARROW,
+  Grid = RenderShape.GRID,
+  Circle = RenderShape.CIRCLE,
+  HollowCircle = RenderShape.HollowCircle
+}
+
+/** @see LinkDirection */
+export enum SlotDirection {}
+
+export enum LabelPosition {
+  Left = 'left',
+  Right = 'right'
 }
 
 /**
@@ -145,65 +204,6 @@ export function strokeShape(
 
   // TODO: Store and reset value properly.  Callers currently expect this behaviour (e.g. muted nodes).
   ctx.globalAlpha = 1
-}
-
-/**
- * Truncates text using binary search to fit within a given width, appending an ellipsis if needed.
- * @param ctx The canvas rendering context.
- * @param text The text to truncate.
- * @param maxWidth The maximum width the text (plus ellipsis) can occupy.
- * @returns The truncated text, or the original text if it fits.
- */
-function truncateTextToWidth(
-  ctx: CanvasRenderingContext2D,
-  text: string,
-  maxWidth: number
-): string {
-  if (!(maxWidth > 0)) return ''
-
-  // Text fits
-  const fullWidth = cachedMeasureText(ctx, text)
-  if (fullWidth <= maxWidth) return text
-
-  const ellipsisWidth = cachedMeasureText(ctx, ELLIPSIS) * 0.75
-
-  // Can't even fit ellipsis
-  if (ellipsisWidth > maxWidth) {
-    const twoDotsWidth = cachedMeasureText(ctx, TWO_DOT_LEADER) * 0.75
-    if (twoDotsWidth < maxWidth) return TWO_DOT_LEADER
-
-    const oneDotWidth = cachedMeasureText(ctx, ONE_DOT_LEADER) * 0.75
-    return oneDotWidth < maxWidth ? ONE_DOT_LEADER : ''
-  }
-
-  let min = 0
-  let max = text.length
-  let bestLen = 0
-
-  // Binary search for the longest substring that fits with the ellipsis
-  while (min <= max) {
-    const mid = Math.floor((min + max) * 0.5)
-
-    // Avoid measuring empty string + ellipsis
-    if (mid === 0) {
-      min = mid + 1
-      continue
-    }
-
-    const sub = text.substring(0, mid)
-    const currentWidth = cachedMeasureText(ctx, sub) + ellipsisWidth
-
-    if (currentWidth <= maxWidth) {
-      // This length fits, try potentially longer
-      bestLen = mid
-      min = mid + 1
-    } else {
-      // Too long, try shorter
-      max = mid - 1
-    }
-  }
-
-  return bestLen === 0 ? ELLIPSIS : text.substring(0, bestLen) + ELLIPSIS
 }
 
 /**

--- a/src/lib/litegraph/src/infrastructure/Rectangle.ts
+++ b/src/lib/litegraph/src/infrastructure/Rectangle.ts
@@ -7,6 +7,18 @@ import type {
 } from '@/lib/litegraph/src/interfaces'
 import { isInRectangle } from '@/lib/litegraph/src/measure'
 
+export type ReadOnlyRectangle = Omit<
+  ReadOnlyTypedArray<Rectangle>,
+  | 'setHeightBottomAnchored'
+  | 'setWidthRightAnchored'
+  | 'resizeTopLeft'
+  | 'resizeBottomLeft'
+  | 'resizeTopRight'
+  | 'resizeBottomRight'
+  | 'resizeBottomRight'
+  | 'updateTo'
+>
+
 /**
  * A rectangle, represented as a float64 array of 4 numbers: [x, y, width, height].
  *
@@ -467,15 +479,3 @@ export class Rectangle extends Float64Array {
     }
   }
 }
-
-export type ReadOnlyRectangle = Omit<
-  ReadOnlyTypedArray<Rectangle>,
-  | 'setHeightBottomAnchored'
-  | 'setWidthRightAnchored'
-  | 'resizeTopLeft'
-  | 'resizeBottomLeft'
-  | 'resizeTopRight'
-  | 'resizeBottomRight'
-  | 'resizeBottomRight'
-  | 'updateTo'
->

--- a/src/lib/litegraph/src/interfaces.ts
+++ b/src/lib/litegraph/src/interfaces.ts
@@ -20,6 +20,36 @@ import type {
 } from './types/globalEnums'
 import type { IBaseWidget } from './types/widgets'
 
+/** An object containing a set of child objects */
+interface Parent<TChild> {
+  /** All objects owned by the parent object. */
+  readonly children?: ReadonlySet<TChild>
+}
+
+interface IInputOrOutput {
+  // If an input, this will be defined
+  input?: INodeInputSlot | null
+  // If an output, this will be defined
+  output?: INodeOutputSlot | null
+}
+
+/** Union of property names that are of type Match */
+type KeysOfType<T, Match> = Exclude<
+  { [P in keyof T]: T[P] extends Match ? P : never }[keyof T],
+  undefined
+>
+
+interface IContextMenuBase {
+  title?: string
+  className?: string
+}
+
+interface IContextMenuSubmenu<
+  TValue = unknown
+> extends IContextMenuOptions<TValue> {
+  options: ConstructorParameters<typeof ContextMenu<TValue>>[0]
+}
+
 export type Dictionary<T> = { [key: string]: T }
 
 /** Allows all properties to be null.  The same as `Partial<T>`, but adds null instead of undefined. */
@@ -75,12 +105,6 @@ export interface HasBoundingRect {
    * @see {@link move}
    */
   readonly boundingRect: ReadOnlyRect
-}
-
-/** An object containing a set of child objects */
-interface Parent<TChild> {
-  /** All objects owned by the parent object. */
-  readonly children?: ReadonlySet<TChild>
 }
 
 /**
@@ -186,6 +210,8 @@ export interface LinkNetwork extends ReadonlyLinkNetwork {
   removeFloatingLink(link: LLink): void
 }
 
+export type { SlotIndex } from '@/types/slotId'
+
 /**
  * Locates graph items.
  */
@@ -225,21 +251,12 @@ export interface LinkSegment {
   readonly origin_slot: SlotIndex | undefined
 }
 
-interface IInputOrOutput {
-  // If an input, this will be defined
-  input?: INodeInputSlot | null
-  // If an output, this will be defined
-  output?: INodeOutputSlot | null
-}
-
 export interface IFoundSlot extends IInputOrOutput {
   // Slot index
   slot: SlotIndex
   // Centre point of the rendered slot connection
   link_pos: Point
 }
-
-export type { SlotIndex } from '@/types/slotId'
 
 /** A point represented as `[x, y]` co-ordinates */
 export type Point = [x: number, y: number]
@@ -256,23 +273,16 @@ export type Rect =
 export type ReadOnlyRect =
   | readonly [x: number, y: number, width: number, height: number]
   | ReadOnlyTypedArray<Float64Array>
-
 export type ReadOnlyTypedArray<T extends Float64Array> = Omit<
   Readonly<T>,
   'fill' | 'copyWithin' | 'reverse' | 'set' | 'sort' | 'subarray'
 >
-
-/** Union of property names that are of type Match */
-type KeysOfType<T, Match> = Exclude<
-  { [P in keyof T]: T[P] extends Match ? P : never }[keyof T],
-  undefined
->
-
 /** The names of all (optional) methods and functions in T */
 export type MethodNames<T> = KeysOfType<
   T,
   ((...args: unknown[]) => unknown) | undefined
 >
+
 export interface NewNodePosition {
   node: LGraphNode
   newPos: {
@@ -280,6 +290,7 @@ export interface NewNodePosition {
     y: number
   }
 }
+
 export interface IBoundaryNodes {
   top: LGraphNode
   right: LGraphNode
@@ -413,11 +424,6 @@ export interface ConnectingLink extends IInputOrOutput {
   link?: LLink
 }
 
-interface IContextMenuBase {
-  title?: string
-  className?: string
-}
-
 /** ContextMenu */
 export interface IContextMenuOptions<
   TValue = unknown,
@@ -465,12 +471,6 @@ export interface IContextMenuValue<
     previous_menu?: ContextMenu<TValue>,
     extra?: TExtra
   ): void | boolean | Promise<void | boolean>
-}
-
-interface IContextMenuSubmenu<
-  TValue = unknown
-> extends IContextMenuOptions<TValue> {
-  options: ConstructorParameters<typeof ContextMenu<TValue>>[0]
 }
 
 export interface ContextMenuDivElement<

--- a/src/lib/litegraph/src/litegraph.ts
+++ b/src/lib/litegraph/src/litegraph.ts
@@ -23,12 +23,6 @@ loadPolyfills()
 
 // Backwards compat
 
-// Type definitions for litegraph.js 0.7.0
-// Project: litegraph.js
-// Definitions by: NateScarlet <https://github.com/NateScarlet>
-/** @deprecated Use {@link Point} instead. */
-export type Vector2 = Point
-
 interface IContextMenuItem {
   content: string
   callback?: ContextMenuEventListener
@@ -49,6 +43,12 @@ type ContextMenuEventListener = (
   parentMenu: ContextMenu<unknown> | undefined,
   node: LGraphNode
 ) => boolean | void
+
+// Type definitions for litegraph.js 0.7.0
+// Project: litegraph.js
+// Definitions by: NateScarlet <https://github.com/NateScarlet>
+/** @deprecated Use {@link Point} instead. */
+export type Vector2 = Point
 
 export interface LinkReleaseContextExtended {
   links: ConnectingLink[]

--- a/src/lib/litegraph/src/subgraph/ExecutableNodeDTO.ts
+++ b/src/lib/litegraph/src/subgraph/ExecutableNodeDTO.ts
@@ -14,16 +14,6 @@ import { LGraphEventMode, LiteGraph } from '@/lib/litegraph/src/litegraph'
 import type { Subgraph } from './Subgraph'
 import type { SubgraphNode } from './SubgraphNode'
 
-export type ExecutionId = string
-
-/**
- * Interface describing the data transfer objects used when compiling a graph for execution.
- */
-export type ExecutableLGraphNode = Omit<
-  ExecutableNodeDTO,
-  'graph' | 'node' | 'subgraphNode'
->
-
 /**
  * The end result of resolving a DTO input.
  * When a widget value is returned, {@link widgetInfo} is present and {@link origin_slot} is `-1`.
@@ -38,6 +28,16 @@ type ResolvedInput = {
   /** Boxed widget value (e.g. for widgets). If this box is `undefined`, then an input link is connected, and widget values from the subgraph node are ignored. */
   widgetInfo?: { value: unknown }
 }
+
+export type ExecutionId = string
+
+/**
+ * Interface describing the data transfer objects used when compiling a graph for execution.
+ */
+export type ExecutableLGraphNode = Omit<
+  ExecutableNodeDTO,
+  'graph' | 'node' | 'subgraphNode'
+>
 
 /**
  * Concrete implementation of {@link ExecutableLGraphNode}.

--- a/src/lib/litegraph/src/subgraph/__fixtures__/subgraphHelpers.ts
+++ b/src/lib/litegraph/src/subgraph/__fixtures__/subgraphHelpers.ts
@@ -34,40 +34,6 @@ const FIXTURE_UUID_PREFIX = '00000000-0000-4000-8000-'
 
 let fixtureUuidSequence = 1
 
-class FixtureStringConcatenateNode extends LGraphNode {
-  constructor() {
-    super('StringConcatenate')
-    const input = this.addInput('string_a', 'STRING')
-    input.widget = { name: 'string_a' }
-    this.addOutput('STRING', 'STRING')
-    this.addWidget('text', 'string_a', '', () => {})
-    this.addWidget('text', 'string_b', '', () => {})
-    this.addWidget('text', 'delimiter', '', () => {})
-  }
-}
-
-export function cleanupComplexPromotionFixtureNodeType(): void {
-  if (!LiteGraph.registered_node_types[FIXTURE_STRING_CONCAT_TYPE]) return
-  LiteGraph.unregisterNodeType(FIXTURE_STRING_CONCAT_TYPE)
-}
-
-function nextFixtureUuid(): UUID {
-  const suffix = fixtureUuidSequence.toString(16).padStart(12, '0')
-  fixtureUuidSequence += 1
-  return `${FIXTURE_UUID_PREFIX}${suffix}`
-}
-
-export function resetSubgraphFixtureState(): void {
-  fixtureUuidSequence = 1
-  cleanupComplexPromotionFixtureNodeType()
-}
-
-export function createTestRootGraph(id: UUID = nextFixtureUuid()): LGraph {
-  const graph = new LGraph()
-  graph.id = id
-  return graph
-}
-
 interface TestSubgraphOptions {
   rootGraph?: LGraph
   rootGraphId?: UUID
@@ -97,13 +63,6 @@ interface BoundaryLinkedSubgraphOptions {
   interiorType?: string
 }
 
-export interface BoundaryLinkedSubgraphFixture {
-  rootGraph: LGraph
-  subgraph: Subgraph
-  host: SubgraphNode
-  interior: LGraphNode
-}
-
 interface NestedSubgraphOptions {
   depth?: number
   nodesPerLevel?: number
@@ -126,6 +85,31 @@ interface CapturedEvent<T = unknown> {
   timestamp: number
 }
 
+function nextFixtureUuid(): UUID {
+  const suffix = fixtureUuidSequence.toString(16).padStart(12, '0')
+  fixtureUuidSequence += 1
+  return `${FIXTURE_UUID_PREFIX}${suffix}`
+}
+
+class FixtureStringConcatenateNode extends LGraphNode {
+  constructor() {
+    super('StringConcatenate')
+    const input = this.addInput('string_a', 'STRING')
+    input.widget = { name: 'string_a' }
+    this.addOutput('STRING', 'STRING')
+    this.addWidget('text', 'string_a', '', () => {})
+    this.addWidget('text', 'string_b', '', () => {})
+    this.addWidget('text', 'delimiter', '', () => {})
+  }
+}
+
+export interface BoundaryLinkedSubgraphFixture {
+  rootGraph: LGraph
+  subgraph: Subgraph
+  host: SubgraphNode
+  interior: LGraphNode
+}
+
 /** Return type for createEventCapture with typed getEventsByType */
 export interface EventCapture<TEventMap extends object> {
   events: CapturedEvent<TEventMap[keyof TEventMap]>[]
@@ -134,6 +118,22 @@ export interface EventCapture<TEventMap extends object> {
   getEventsByType: <K extends keyof TEventMap & string>(
     type: K
   ) => CapturedEvent<TEventMap[K]>[]
+}
+
+export function cleanupComplexPromotionFixtureNodeType(): void {
+  if (!LiteGraph.registered_node_types[FIXTURE_STRING_CONCAT_TYPE]) return
+  LiteGraph.unregisterNodeType(FIXTURE_STRING_CONCAT_TYPE)
+}
+
+export function resetSubgraphFixtureState(): void {
+  fixtureUuidSequence = 1
+  cleanupComplexPromotionFixtureNodeType()
+}
+
+export function createTestRootGraph(id: UUID = nextFixtureUuid()): LGraph {
+  const graph = new LGraph()
+  graph.id = id
+  return graph
 }
 
 /**

--- a/src/lib/litegraph/src/subgraph/subgraphDeduplication.ts
+++ b/src/lib/litegraph/src/subgraph/subgraphDeduplication.ts
@@ -16,52 +16,6 @@ interface DeduplicationResult {
 }
 
 /**
- * Dedupes node IDs across serialized subgraph definitions to prevent widget
- * store key collisions, and patches any root-level legacy proxyWidgets that
- * reference the remapped inner IDs. Returns deep clones; inputs are not
- * mutated. `state.lastNodeId` is advanced.
- */
-export function deduplicateSubgraphNodeIds(
-  subgraphs: ExportedSubgraph[],
-  reservedNodeIds: Set<number>,
-  state: LGraphState,
-  rootNodes?: ISerialisedNode[]
-): DeduplicationResult {
-  const clonedSubgraphs = structuredClone(subgraphs)
-  const clonedRootNodes = rootNodes ? structuredClone(rootNodes) : undefined
-
-  const usedNodeIds = new Set(reservedNodeIds)
-  const usedNodeIdKeys = new Set<NodeId>([...reservedNodeIds].map(toNodeId))
-  const subgraphIdSet = new Set(clonedSubgraphs.map((sg) => sg.id))
-  const remapBySubgraph = new Map<string, Map<NodeId, SerializedNodeId>>()
-
-  for (const subgraph of clonedSubgraphs) {
-    const remappedIds = remapNodeIds(
-      subgraph.nodes ?? [],
-      usedNodeIdKeys,
-      usedNodeIds,
-      state
-    )
-
-    if (remappedIds.size === 0) continue
-    remapBySubgraph.set(subgraph.id, remappedIds)
-
-    patchSerialisedLinks(subgraph.links ?? [], remappedIds)
-    patchPromotedWidgets(subgraph.widgets ?? [], remappedIds)
-  }
-
-  for (const subgraph of clonedSubgraphs) {
-    patchProxyWidgets(subgraph.nodes ?? [], subgraphIdSet, remapBySubgraph)
-  }
-
-  if (clonedRootNodes) {
-    patchProxyWidgets(clonedRootNodes, subgraphIdSet, remapBySubgraph)
-  }
-
-  return { subgraphs: clonedSubgraphs, rootNodes: clonedRootNodes }
-}
-
-/**
  * Remaps duplicate node IDs to unique values, updating `usedNodeIds`
  * and `state.lastNodeId` as new IDs are allocated.
  *
@@ -152,6 +106,75 @@ function patchPromotedWidgets(
   }
 }
 
+/** Patches legacy proxyWidgets in root-level SubgraphNode instances. */
+function patchProxyWidgets(
+  rootNodes: ISerialisedNode[],
+  subgraphIdSet: Set<string>,
+  remapBySubgraph: Map<string, Map<NodeId, SerializedNodeId>>
+): void {
+  for (const node of rootNodes) {
+    if (!subgraphIdSet.has(node.type)) continue
+    const remappedIds = remapBySubgraph.get(node.type)
+    if (!remappedIds) continue
+
+    const proxyWidgets = node.properties?.proxyWidgets
+    if (!Array.isArray(proxyWidgets)) continue
+
+    for (const entry of proxyWidgets) {
+      if (!Array.isArray(entry)) continue
+      const oldId = toNodeId(entry[0])
+      const newId = remappedIds.get(oldId)
+      if (newId !== undefined) entry[0] = String(newId)
+    }
+  }
+}
+
+/**
+ * Dedupes node IDs across serialized subgraph definitions to prevent widget
+ * store key collisions, and patches any root-level legacy proxyWidgets that
+ * reference the remapped inner IDs. Returns deep clones; inputs are not
+ * mutated. `state.lastNodeId` is advanced.
+ */
+export function deduplicateSubgraphNodeIds(
+  subgraphs: ExportedSubgraph[],
+  reservedNodeIds: Set<number>,
+  state: LGraphState,
+  rootNodes?: ISerialisedNode[]
+): DeduplicationResult {
+  const clonedSubgraphs = structuredClone(subgraphs)
+  const clonedRootNodes = rootNodes ? structuredClone(rootNodes) : undefined
+
+  const usedNodeIds = new Set(reservedNodeIds)
+  const usedNodeIdKeys = new Set<NodeId>([...reservedNodeIds].map(toNodeId))
+  const subgraphIdSet = new Set(clonedSubgraphs.map((sg) => sg.id))
+  const remapBySubgraph = new Map<string, Map<NodeId, SerializedNodeId>>()
+
+  for (const subgraph of clonedSubgraphs) {
+    const remappedIds = remapNodeIds(
+      subgraph.nodes ?? [],
+      usedNodeIdKeys,
+      usedNodeIds,
+      state
+    )
+
+    if (remappedIds.size === 0) continue
+    remapBySubgraph.set(subgraph.id, remappedIds)
+
+    patchSerialisedLinks(subgraph.links ?? [], remappedIds)
+    patchPromotedWidgets(subgraph.widgets ?? [], remappedIds)
+  }
+
+  for (const subgraph of clonedSubgraphs) {
+    patchProxyWidgets(subgraph.nodes ?? [], subgraphIdSet, remapBySubgraph)
+  }
+
+  if (clonedRootNodes) {
+    patchProxyWidgets(clonedRootNodes, subgraphIdSet, remapBySubgraph)
+  }
+
+  return { subgraphs: clonedSubgraphs, rootNodes: clonedRootNodes }
+}
+
 /**
  * Topologically sorts subgraph definitions so that leaf subgraphs (those
  * that no other subgraph depends on) are configured first. This ensures
@@ -207,27 +230,4 @@ export function topologicalSortSubgraphs(
   if (sorted.length !== subgraphs.length) return subgraphs
 
   return sorted
-}
-
-/** Patches legacy proxyWidgets in root-level SubgraphNode instances. */
-function patchProxyWidgets(
-  rootNodes: ISerialisedNode[],
-  subgraphIdSet: Set<string>,
-  remapBySubgraph: Map<string, Map<NodeId, SerializedNodeId>>
-): void {
-  for (const node of rootNodes) {
-    if (!subgraphIdSet.has(node.type)) continue
-    const remappedIds = remapBySubgraph.get(node.type)
-    if (!remappedIds) continue
-
-    const proxyWidgets = node.properties?.proxyWidgets
-    if (!Array.isArray(proxyWidgets)) continue
-
-    for (const entry of proxyWidgets) {
-      if (!Array.isArray(entry)) continue
-      const oldId = toNodeId(entry[0])
-      const newId = remappedIds.get(oldId)
-      if (newId !== undefined) entry[0] = String(newId)
-    }
-  }
 }

--- a/src/lib/litegraph/src/subgraph/subgraphUtils.ts
+++ b/src/lib/litegraph/src/subgraph/subgraphUtils.ts
@@ -41,6 +41,52 @@ interface FilteredItems {
   unknown: Set<Positionable>
 }
 
+interface BoundaryLinks {
+  boundaryLinks: LLink[]
+  boundaryFloatingLinks: LLink[]
+  internalLinks: LLink[]
+  boundaryInputLinks: LLink[]
+  boundaryOutputLinks: LLink[]
+}
+
+function mapReroutes(
+  link: SerialisableLLink,
+  reroutes: Map<RerouteId, Reroute>
+) {
+  let child: SerialisableLLink | Reroute = link
+  let nextReroute =
+    child.parentId === undefined
+      ? undefined
+      : reroutes.get(toRerouteId(child.parentId))
+
+  while (child.parentId !== undefined && nextReroute) {
+    child = nextReroute
+    nextReroute =
+      child.parentId === undefined
+        ? undefined
+        : reroutes.get(toRerouteId(child.parentId))
+  }
+
+  const lastId = child.parentId
+  child.parentId = undefined
+  return lastId
+}
+
+function reorderInPlace<T>(arr: T[], indices: readonly number[]): void {
+  arr.splice(0, arr.length, ...indices.flatMap((i) => arr[i] ?? []))
+}
+
+function* indexedLinks<S>(
+  slots: readonly S[],
+  resolve: (slot: S) => Iterable<LLink | undefined>
+): Generator<readonly [number, LLink]> {
+  for (const [index, slot] of slots.entries()) {
+    for (const link of resolve(slot)) {
+      if (link) yield [index, link] as const
+    }
+  }
+}
+
 export function splitPositionables(
   items: Iterable<Positionable>
 ): FilteredItems {
@@ -84,15 +130,6 @@ export function splitPositionables(
     unknown
   }
 }
-
-interface BoundaryLinks {
-  boundaryLinks: LLink[]
-  boundaryFloatingLinks: LLink[]
-  internalLinks: LLink[]
-  boundaryInputLinks: LLink[]
-  boundaryOutputLinks: LLink[]
-}
-
 export function getBoundaryLinks(
   graph: LGraph,
   items: Set<Positionable>
@@ -262,28 +299,6 @@ export function groupResolvedByOutput(
   }
 
   return groupedByOutput
-}
-function mapReroutes(
-  link: SerialisableLLink,
-  reroutes: Map<RerouteId, Reroute>
-) {
-  let child: SerialisableLLink | Reroute = link
-  let nextReroute =
-    child.parentId === undefined
-      ? undefined
-      : reroutes.get(toRerouteId(child.parentId))
-
-  while (child.parentId !== undefined && nextReroute) {
-    child = nextReroute
-    nextReroute =
-      child.parentId === undefined
-        ? undefined
-        : reroutes.get(toRerouteId(child.parentId))
-  }
-
-  const lastId = child.parentId
-  child.parentId = undefined
-  return lastId
 }
 
 export function mapSubgraphInputsAndLinks(
@@ -487,21 +502,6 @@ export function findUsedSubgraphIds(
   }
 
   return usedSubgraphIds
-}
-
-function reorderInPlace<T>(arr: T[], indices: readonly number[]): void {
-  arr.splice(0, arr.length, ...indices.flatMap((i) => arr[i] ?? []))
-}
-
-function* indexedLinks<S>(
-  slots: readonly S[],
-  resolve: (slot: S) => Iterable<LLink | undefined>
-): Generator<readonly [number, LLink]> {
-  for (const [index, slot] of slots.entries()) {
-    for (const link of resolve(slot)) {
-      if (link) yield [index, link] as const
-    }
-  }
 }
 
 export function reorderSubgraphInputs(

--- a/src/lib/litegraph/src/types/events.ts
+++ b/src/lib/litegraph/src/types/events.ts
@@ -30,30 +30,15 @@ interface IOffsetWorkaround {
   safeOffsetY: number
 }
 
-/** All properties added when converting a pointer event to a CanvasPointerEvent (via {@link LGraphCanvas.adjustMouseEvent}). */
-export type CanvasPointerExtensions = ICanvasPosition &
-  IDeltaPosition &
-  IOffsetWorkaround
-
 interface LegacyMouseEvent {
   /** @deprecated Part of DragAndScale mouse API - incomplete / not maintained */
   dragging?: boolean
   click_time?: number
 }
 
-/** PointerEvent with canvasX/Y and deltaX/Y properties */
-export interface CanvasPointerEvent extends PointerEvent, CanvasMouseEvent {}
-
 /** MouseEvent with canvasX/Y and deltaX/Y properties */
 interface CanvasMouseEvent
   extends MouseEvent, Readonly<CanvasPointerExtensions>, LegacyMouseEvent {}
-
-export type CanvasEventDetail =
-  | GenericEventDetail
-  | GroupDoubleClickEventDetail
-  | NodeDoubleClickEventDetail
-  | EmptyDoubleClickEventDetail
-  | EmptyReleaseEventDetail
 
 interface GenericEventDetail {
   subType: 'before-change' | 'after-change'
@@ -81,3 +66,18 @@ interface NodeDoubleClickEventDetail extends OriginalEvent {
   subType: 'node-double-click'
   node: LGraphNode
 }
+
+/** All properties added when converting a pointer event to a CanvasPointerEvent (via {@link LGraphCanvas.adjustMouseEvent}). */
+export type CanvasPointerExtensions = ICanvasPosition &
+  IDeltaPosition &
+  IOffsetWorkaround
+
+/** PointerEvent with canvasX/Y and deltaX/Y properties */
+export interface CanvasPointerEvent extends PointerEvent, CanvasMouseEvent {}
+
+export type CanvasEventDetail =
+  | GenericEventDetail
+  | GroupDoubleClickEventDetail
+  | NodeDoubleClickEventDetail
+  | EmptyDoubleClickEventDetail
+  | EmptyReleaseEventDetail

--- a/src/lib/litegraph/src/types/serialisation.ts
+++ b/src/lib/litegraph/src/types/serialisation.ts
@@ -20,18 +20,6 @@ import type { LiteGraph } from '../litegraph'
 import type { RenderShape } from './globalEnums'
 import type { TWidgetValue } from './widgets'
 
-/**
- * An object that implements custom pre-serialization logic via {@link Serialisable.asSerialisable}.
- */
-export interface Serialisable<SerialisableObject> {
-  /**
-   * Prepares this object for serialization.
-   * Creates a partial shallow copy of itself, with only the properties that should be serialised.
-   * @returns An object that can immediately be serialized to JSON.
-   */
-  asSerialisable(): SerialisableObject
-}
-
 interface BaseExportedGraph {
   /** Unique graph ID.  Automatically generated if not provided. */
   id: UUID
@@ -54,6 +42,29 @@ interface SerialisableGraphState {
   lastRerouteId: number
 }
 
+/** Properties of nodes that are used by subgraph instances. */
+type NodeSubgraphSharedProps = Omit<
+  ISerialisedNode,
+  'properties' | 'showAdvanced'
+>
+
+/** Properties shared by subgraph and node I/O slots. */
+type SubgraphIOShared = Omit<
+  INodeSlot,
+  'boundingRect' | 'nameLocked' | 'locked' | 'removable' | '_floatingLinks'
+>
+
+/**
+ * An object that implements custom pre-serialization logic via {@link Serialisable.asSerialisable}.
+ */
+export interface Serialisable<SerialisableObject> {
+  /**
+   * Prepares this object for serialization.
+   * Creates a partial shallow copy of itself, with only the properties that should be serialised.
+   * @returns An object that can immediately be serialized to JSON.
+   */
+  asSerialisable(): SerialisableObject
+}
 export interface SerialisableGraph extends BaseExportedGraph {
   /** Schema version.  @remarks Version bump should add to const union, which is used to narrow type during deserialise. */
   version: 0 | 1
@@ -73,6 +84,7 @@ export type ISerialisableNodeInput = Omit<
   link?: number | null
   widget?: { name: string }
 }
+
 export type ISerialisableNodeOutput = Omit<
   INodeOutputSlot,
   'boundingRect' | '_data' | 'links' | '_floatingLinks'
@@ -108,12 +120,6 @@ export interface ISerialisedNode {
   widgets_values?: TWidgetValue[]
   widgets_values_named?: Record<string, TWidgetValue>
 }
-
-/** Properties of nodes that are used by subgraph instances. */
-type NodeSubgraphSharedProps = Omit<
-  ISerialisedNode,
-  'properties' | 'showAdvanced'
->
 
 /** A single instance of a subgraph; where it is used on a graph, any customisation to shape / colour etc. */
 export interface ExportedSubgraphInstance extends NodeSubgraphSharedProps {
@@ -161,12 +167,6 @@ export interface ExportedSubgraph extends SerialisableGraph {
   /** A list of node widgets displayed in the parent graph, on the subgraph object. */
   widgets?: ExposedWidget[]
 }
-
-/** Properties shared by subgraph and node I/O slots. */
-type SubgraphIOShared = Omit<
-  INodeSlot,
-  'boundingRect' | 'nameLocked' | 'locked' | 'removable' | '_floatingLinks'
->
 
 /** Subgraph I/O slots */
 export interface SubgraphIO extends SubgraphIOShared {

--- a/src/lib/litegraph/src/types/widgets.ts
+++ b/src/lib/litegraph/src/types/widgets.ts
@@ -15,6 +15,40 @@ import type {
 import type { CanvasPointer, LGraphCanvas, LGraphNode } from '../litegraph'
 import type { CanvasPointerEvent } from './events'
 
+interface IWidgetSliderOptions extends IWidgetOptions<number[]> {
+  min: number
+  max: number
+  step2: number
+  slider_color?: CanvasColour
+  marker_color?: CanvasColour
+}
+
+interface IWidgetKnobOptions extends IWidgetOptions<number[]> {
+  min: number
+  max: number
+  step2: number
+  slider_color?: CanvasColour // TODO: Replace with knob color
+  marker_color?: CanvasColour
+  gradient_stops?: string
+}
+
+type ComboWidgetValues =
+  | string[]
+  | Record<string, string>
+  | ((widget?: IComboWidget, node?: LGraphNode) => string[])
+
+/** A custom widget - accepts any value and has no built-in special handling */
+interface ICustomWidget extends IBaseWidget<string | object, 'custom'> {
+  type: 'custom'
+  value: string | object
+}
+
+/** Image display widget */
+interface IImageWidget extends IBaseWidget<string, 'image'> {
+  type: 'image'
+  value: string
+}
+
 export interface NodeBindable {
   setNodeId(nodeId: NodeId): void
 }
@@ -83,28 +117,11 @@ export interface IWidgetOptions<TValues = unknown> {
   hidden?: boolean
 }
 
-interface IWidgetSliderOptions extends IWidgetOptions<number[]> {
-  min: number
-  max: number
-  step2: number
-  slider_color?: CanvasColour
-  marker_color?: CanvasColour
-}
-
 export interface IWidgetGradientSliderOptions extends IWidgetOptions<number[]> {
   min: number
   max: number
   step2: number
   gradient_stops?: ColorStop[]
-}
-
-interface IWidgetKnobOptions extends IWidgetOptions<number[]> {
-  min: number
-  max: number
-  step2: number
-  slider_color?: CanvasColour // TODO: Replace with knob color
-  marker_color?: CanvasColour
-  gradient_stops?: string
 }
 
 export interface IWidgetAssetOptions extends IWidgetOptions {
@@ -202,11 +219,6 @@ export interface IStringComboWidget extends IBaseWidget<
   value: string
 }
 
-type ComboWidgetValues =
-  | string[]
-  | Record<string, string>
-  | ((widget?: IComboWidget, node?: LGraphNode) => string[])
-
 /** A combo-box widget (dropdown, select, etc) */
 export interface IComboWidget extends IBaseWidget<
   string | number,
@@ -236,12 +248,6 @@ export interface IButtonWidget extends IBaseWidget<
   clicked: boolean
 }
 
-/** A custom widget - accepts any value and has no built-in special handling */
-interface ICustomWidget extends IBaseWidget<string | object, 'custom'> {
-  type: 'custom'
-  value: string | object
-}
-
 /** File upload widget for selecting and uploading files */
 export interface IFileUploadWidget extends IBaseWidget<string, 'fileupload'> {
   type: 'fileupload'
@@ -258,12 +264,6 @@ export interface IColorWidget extends IBaseWidget<string, 'color'> {
 /** Markdown widget for displaying formatted text */
 export interface IMarkdownWidget extends IBaseWidget<string, 'markdown'> {
   type: 'markdown'
-  value: string
-}
-
-/** Image display widget */
-interface IImageWidget extends IBaseWidget<string, 'image'> {
-  type: 'image'
   value: string
 }
 
@@ -431,14 +431,6 @@ export interface IVideoEditWidget extends IBaseWidget<
 export type TWidgetType = IWidget['type']
 export type TWidgetValue = IWidget['value']
 
-export function isWidgetValue(value: unknown): value is TWidgetValue {
-  if (value === undefined) return true
-  if (typeof value === 'string') return true
-  if (typeof value === 'number') return true
-  if (typeof value === 'boolean') return true
-  return value !== null && typeof value === 'object'
-}
-
 /**
  * The base type for all widgets.  Should not be implemented directly.
  * @template TValue The type of value this widget holds.
@@ -605,4 +597,12 @@ export interface IBaseWidget<
     node: LGraphNode,
     canvas: LGraphCanvas
   ): boolean
+}
+
+export function isWidgetValue(value: unknown): value is TWidgetValue {
+  if (value === undefined) return true
+  if (typeof value === 'string') return true
+  if (typeof value === 'number') return true
+  if (typeof value === 'boolean') return true
+  return value !== null && typeof value === 'object'
 }

--- a/src/lib/litegraph/src/utils/collections.ts
+++ b/src/lib/litegraph/src/utils/collections.ts
@@ -3,6 +3,10 @@ import { parseSlotTypes } from '@/lib/litegraph/src/strings'
 
 import type { ISlotType, Positionable } from '../interfaces'
 
+type FreeSlotResult<T extends { type: ISlotType }> =
+  | { index: number; slot: T }
+  | undefined
+
 /**
  * Creates a flat set of all positionable items by recursively iterating through all child items.
  *
@@ -62,10 +66,6 @@ export function findFirstNode(
     if (item instanceof LGraphNode) return item
   }
 }
-
-type FreeSlotResult<T extends { type: ISlotType }> =
-  | { index: number; slot: T }
-  | undefined
 
 /**
  * Finds the first free in/out slot with any of the comma-delimited types in {@link type}.

--- a/src/lib/litegraph/src/utils/type.ts
+++ b/src/lib/litegraph/src/utils/type.ts
@@ -3,6 +3,20 @@ import { without } from 'es-toolkit'
 import type { IColorable, ISlotType } from '@/lib/litegraph/src/interfaces'
 import type { NodeBindable } from '@/lib/litegraph/src/types/widgets'
 
+function intersection(...sets: string[][]): string[] {
+  const itemCounts: Record<string, number> = {}
+  for (const set of sets)
+    for (const item of new Set(set))
+      itemCounts[item] = (itemCounts[item] ?? 0) + 1
+  return Object.entries(itemCounts)
+    .filter(([, count]) => count === sets.length)
+    .map(([key]) => key)
+}
+
+function isStrings(types: unknown[]): types is string[] {
+  return types.every((t) => typeof t === 'string')
+}
+
 /**
  * Converts a plain object to a class instance if it is not already an instance of the class.
  *
@@ -51,18 +65,4 @@ export function commonType(...types: ISlotType[]): ISlotType | undefined {
   if (combinedTypes.length === 0) return undefined
 
   return combinedTypes.join(',')
-}
-
-function intersection(...sets: string[][]): string[] {
-  const itemCounts: Record<string, number> = {}
-  for (const set of sets)
-    for (const item of new Set(set))
-      itemCounts[item] = (itemCounts[item] ?? 0) + 1
-  return Object.entries(itemCounts)
-    .filter(([, count]) => count === sets.length)
-    .map(([key]) => key)
-}
-
-function isStrings(types: unknown[]): types is string[] {
-  return types.every((t) => typeof t === 'string')
 }

--- a/src/lib/litegraph/src/widgets/BaseWidget.ts
+++ b/src/lib/litegraph/src/widgets/BaseWidget.ts
@@ -22,15 +22,6 @@ import type { WidgetId } from '@/types/widgetId'
 import { widgetId } from '@/types/widgetId'
 import type { WidgetState } from '@/types/widgetState'
 
-export interface DrawWidgetOptions {
-  /** The width of the node where this widget will be displayed. */
-  width: number
-  /** Synonym for "low quality". */
-  showText?: boolean
-  /** Transient image source for preview widgets rendered on behalf of another node (e.g. subgraph promotion). */
-  previewImages?: HTMLImageElement[]
-}
-
 interface DrawTruncatingTextOptions extends DrawWidgetOptions {
   /** The canvas context to draw the text on. */
   ctx: CanvasRenderingContext2D
@@ -38,6 +29,15 @@ interface DrawTruncatingTextOptions extends DrawWidgetOptions {
   leftPadding?: number
   /** The amount of padding to add to the right of the text. */
   rightPadding?: number
+}
+
+export interface DrawWidgetOptions {
+  /** The width of the node where this widget will be displayed. */
+  width: number
+  /** Synonym for "low quality". */
+  showText?: boolean
+  /** Transient image source for preview widgets rendered on behalf of another node (e.g. subgraph promotion). */
+  previewImages?: HTMLImageElement[]
 }
 
 export interface WidgetEventOptions {

--- a/src/platform/assets/composables/media/assetMappers.ts
+++ b/src/platform/assets/composables/media/assetMappers.ts
@@ -6,6 +6,17 @@ import { api } from '@/scripts/api'
 import type { ResultItemImpl, TaskItemImpl } from '@/stores/queueStore'
 
 /**
+ * Strips ComfyUI's trailing directory-type annotation (e.g. ` [input]`,
+ * ` [output]`, `[temp]`) from a filename returned by the OSS internal
+ * `/internal/files/{type}` endpoint. The annotation is part of the wire
+ * format LoadImage-style widgets expect, but for the assets sidebar we
+ * want the canonical on-disk filename so type detection / titles work.
+ */
+function stripDirectoryAnnotation(filename: string): string {
+  return filename.replace(/\s*\[(?:input|output|temp)\]\s*$/i, '')
+}
+
+/**
  * Extract asset type from tags array
  * @param tags The tags array from AssetItem
  * @returns The asset type ('input' or 'output')
@@ -52,17 +63,6 @@ export function mapTaskOutputToAssetItem(
     preview_url: output.url,
     user_metadata: metadata
   }
-}
-
-/**
- * Strips ComfyUI's trailing directory-type annotation (e.g. ` [input]`,
- * ` [output]`, `[temp]`) from a filename returned by the OSS internal
- * `/internal/files/{type}` endpoint. The annotation is part of the wire
- * format LoadImage-style widgets expect, but for the assets sidebar we
- * want the canonical on-disk filename so type detection / titles work.
- */
-function stripDirectoryAnnotation(filename: string): string {
-  return filename.replace(/\s*\[(?:input|output|temp)\]\s*$/i, '')
 }
 
 /**

--- a/src/platform/assets/composables/useModelTypes.ts
+++ b/src/platform/assets/composables/useModelTypes.ts
@@ -2,6 +2,11 @@ import { createSharedComposable, useAsyncState } from '@vueuse/core'
 
 import { api } from '@/scripts/api'
 
+interface ModelTypeOption {
+  name: string // Display name
+  value: string // Actual tag value
+}
+
 /**
  * Format folder name to display name
  * Converts "upscale_models" -> "Upscale Model"
@@ -30,11 +35,6 @@ function formatDisplayName(folderName: string): string {
     .split('_')
     .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
     .join(' ')
-}
-
-interface ModelTypeOption {
-  name: string // Display name
-  value: string // Actual tag value
 }
 
 const DISALLOWED_MODEL_TYPES = ['nlf'] as const

--- a/src/platform/assets/composables/useOutputStacks.ts
+++ b/src/platform/assets/composables/useOutputStacks.ts
@@ -8,14 +8,14 @@ import {
   resolveOutputAssetItems
 } from '@/platform/assets/utils/outputAssetUtil'
 
+type UseOutputStacksOptions = {
+  assets: Ref<AssetItem[]>
+}
+
 export type OutputStackListItem = {
   key: string
   asset: AssetItem
   isChild?: boolean
-}
-
-type UseOutputStacksOptions = {
-  assets: Ref<AssetItem[]>
 }
 
 export function useOutputStacks({ assets }: UseOutputStacksOptions) {

--- a/src/platform/assets/composables/useUploadModelWizard.ts
+++ b/src/platform/assets/composables/useUploadModelWizard.ts
@@ -37,6 +37,21 @@ interface ModelTypeOption {
 
 const MODEL_ROOT_TAG = 'models'
 
+interface MissingModelUploadContext {
+  kind: 'missing-model-resolution'
+  missingModelName: string
+  requiredModelType: string
+  replacementTargets: Array<{
+    nodeId: string
+    nodeLabel: string
+    widgetName: string
+  }>
+}
+
+interface UploadModelWizardOptions {
+  requiredModelType?: string
+}
+
 export interface UploadModelSuccess {
   filename: string
   modelType?: string
@@ -51,22 +66,7 @@ export interface UploadModelTypeMismatch {
   requiredModelTypeLabel: string
 }
 
-interface MissingModelUploadContext {
-  kind: 'missing-model-resolution'
-  missingModelName: string
-  requiredModelType: string
-  replacementTargets: Array<{
-    nodeId: string
-    nodeLabel: string
-    widgetName: string
-  }>
-}
-
 export type UploadModelDialogContext = MissingModelUploadContext
-
-interface UploadModelWizardOptions {
-  requiredModelType?: string
-}
 
 export function useUploadModelWizard(
   modelTypes: Ref<ModelTypeOption[]>,

--- a/src/platform/assets/mediaAssetFilterOptions.ts
+++ b/src/platform/assets/mediaAssetFilterOptions.ts
@@ -1,9 +1,9 @@
-export type MediaAssetDateFilter = '' | 'today' | 'week' | 'month' | 'year'
-
 interface FilterOption<T extends string> {
   value: T
   label: string
 }
+
+export type MediaAssetDateFilter = '' | 'today' | 'week' | 'month' | 'year'
 
 export const mediaTypeFilterOptions: FilterOption<string>[] = [
   { value: 'image', label: 'sideToolbar.mediaAssets.filterImage' },

--- a/src/platform/assets/schemas/assetMetadataSchema.ts
+++ b/src/platform/assets/schemas/assetMetadataSchema.ts
@@ -2,6 +2,19 @@ import type { ComfyWorkflowJSON } from '@/platform/workflow/validation/schemas/w
 import type { ResultItemImpl } from '@/stores/queueStore'
 
 /**
+ * Type guard to check if metadata is OutputAssetMetadata
+ */
+function isOutputAssetMetadata(
+  metadata: Record<string, unknown> | undefined
+): metadata is OutputAssetMetadata {
+  if (!metadata) return false
+  return (
+    typeof metadata.jobId === 'string' &&
+    (typeof metadata.nodeId === 'string' || typeof metadata.nodeId === 'number')
+  )
+}
+
+/**
  * Metadata for output assets from queue store
  * Extends Record<string, unknown> for compatibility with AssetItem schema
  */
@@ -14,19 +27,6 @@ export interface OutputAssetMetadata extends Record<string, unknown> {
   workflow?: ComfyWorkflowJSON
   outputCount?: number
   allOutputs?: ResultItemImpl[]
-}
-
-/**
- * Type guard to check if metadata is OutputAssetMetadata
- */
-function isOutputAssetMetadata(
-  metadata: Record<string, unknown> | undefined
-): metadata is OutputAssetMetadata {
-  if (!metadata) return false
-  return (
-    typeof metadata.jobId === 'string' &&
-    (typeof metadata.nodeId === 'string' || typeof metadata.nodeId === 'number')
-  )
 }
 
 /**

--- a/src/platform/assets/schemas/mediaAssetSchema.ts
+++ b/src/platform/assets/schemas/mediaAssetSchema.ts
@@ -37,10 +37,6 @@ const zAssetContextSchema = z.object({
   outputCount: z.number().positive().optional() // Only for output context
 })
 
-// Export the inferred types
-export type AssetMeta = z.infer<typeof zMediaAssetDisplayItemSchema>
-export type AssetContext = z.infer<typeof zAssetContextSchema>
-
 // Injection key for MediaAsset provide/inject pattern
 interface MediaAssetProviderValue {
   asset: Ref<AssetMeta | undefined>
@@ -48,6 +44,10 @@ interface MediaAssetProviderValue {
   isVideoPlaying: Ref<boolean>
   showVideoControls: Ref<boolean>
 }
+// Export the inferred types
+export type AssetMeta = z.infer<typeof zMediaAssetDisplayItemSchema>
+
+export type AssetContext = z.infer<typeof zAssetContextSchema>
 
 export const MediaAssetKey: InjectionKey<MediaAssetProviderValue> =
   Symbol('mediaAsset')

--- a/src/platform/assets/services/assetService.ts
+++ b/src/platform/assets/services/assetService.ts
@@ -32,20 +32,6 @@ import { api } from '@/scripts/api'
 import { useModelToNodeStore } from '@/stores/modelToNodeStore'
 import { parseErrorResponse } from '@/platform/remote/comfyui/errors'
 
-export interface PaginationOptions {
-  limit?: number
-  offset?: number
-}
-
-export interface AssetPaginationOptions extends PaginationOptions {
-  /**
-   * Opaque keyset cursor from a prior response's `next_cursor`. When set, the
-   * server resumes after that cursor and `offset` is ignored.
-   */
-  after?: string
-  signal?: AbortSignal
-}
-
 interface AssetRequestOptions extends PaginationOptions {
   includeTags: string[]
   excludeTags?: string[]
@@ -184,6 +170,20 @@ function getLocalizedErrorMessage(errorCode: string): string {
     st('assetBrowser.errorUnknown', 'Unknown error') ||
     'Unknown error'
   )
+}
+
+export interface PaginationOptions {
+  limit?: number
+  offset?: number
+}
+
+export interface AssetPaginationOptions extends PaginationOptions {
+  /**
+   * Opaque keyset cursor from a prior response's `next_cursor`. When set, the
+   * server resumes after that cursor and `offset` is ignored.
+   */
+  after?: string
+  signal?: AbortSignal
 }
 
 const ASSETS_ENDPOINT = '/assets'

--- a/src/platform/assets/utils/assetMetadataUtils.ts
+++ b/src/platform/assets/utils/assetMetadataUtils.ts
@@ -148,6 +148,51 @@ export function getSourceName(url: string): string {
 /** Prefix for the namespaced tag that carries a model's folder category, e.g. `model_type:checkpoints`. */
 export const MODEL_TYPE_TAG_PREFIX = 'model_type:'
 
+/** Strips the `model_type:` prefix off each namespaced tag, dropping non-`model_type:` tags. */
+function getModelTypeTagValues(asset: AssetItem): string[] {
+  return asset.tags
+    .filter((tag) => tag.startsWith(MODEL_TYPE_TAG_PREFIX))
+    .map((tag) => tag.slice(MODEL_TYPE_TAG_PREFIX.length))
+    .filter((tag) => tag.length > 0)
+}
+
+/**
+ * The asset's primary `model_type:` membership: the lexicographically-first of
+ * its stripped `model_type:` values, or `undefined` for an uncovered asset.
+ * Sorting makes the choice deterministic because the backend does not guarantee
+ * the order of an asset's `model_type:` tags. This is the single membership a
+ * re-type replaces and the value the edit dropdown / browser title reflect.
+ */
+function getPrimaryModelType(asset: AssetItem): string | undefined {
+  return getModelTypeTagValues(asset).toSorted()[0]
+}
+
+/** Legacy grouping: each non-`models` tag's top-level path segment. */
+function getBareTagCategories(asset: AssetItem): string[] {
+  return asset.tags
+    .filter((tag) => tag !== MODELS_TAG && tag.length > 0)
+    .map((tag) => tag.split('/')[0])
+}
+
+/** Number of `parent/child` segments in a tag, used to pick the most specific. */
+function pathDepth(tag: string): number {
+  return tag.split('/').length
+}
+
+/**
+ * Type guard: a pixel dimension is a finite positive integer. `metadata` is
+ * typed as `Record<string, unknown>`, so `typeof === 'number'` alone admits
+ * NaN, Infinity, 0, negatives, and fractional values.
+ */
+function isValidDimension(value: unknown): value is number {
+  return typeof value === 'number' && Number.isInteger(value) && value > 0
+}
+
+export interface ImageDimensions {
+  width: number
+  height: number
+}
+
 /**
  * Extracts the model type from asset tags as a bare (non-namespaced) value.
  * Never returns a raw `model_type:*` literal: this value feeds edit widgets
@@ -173,25 +218,6 @@ export function getAssetModelType(asset: AssetItem): string | null {
 export function toModelTypeTag(folderName: string): string {
   if (folderName.startsWith(MODEL_TYPE_TAG_PREFIX)) return folderName
   return `${MODEL_TYPE_TAG_PREFIX}${folderName}`
-}
-
-/** Strips the `model_type:` prefix off each namespaced tag, dropping non-`model_type:` tags. */
-function getModelTypeTagValues(asset: AssetItem): string[] {
-  return asset.tags
-    .filter((tag) => tag.startsWith(MODEL_TYPE_TAG_PREFIX))
-    .map((tag) => tag.slice(MODEL_TYPE_TAG_PREFIX.length))
-    .filter((tag) => tag.length > 0)
-}
-
-/**
- * The asset's primary `model_type:` membership: the lexicographically-first of
- * its stripped `model_type:` values, or `undefined` for an uncovered asset.
- * Sorting makes the choice deterministic because the backend does not guarantee
- * the order of an asset's `model_type:` tags. This is the single membership a
- * re-type replaces and the value the edit dropdown / browser title reflect.
- */
-function getPrimaryModelType(asset: AssetItem): string | undefined {
-  return getModelTypeTagValues(asset).toSorted()[0]
 }
 
 /**
@@ -261,13 +287,6 @@ export function resolveModelTypeTagUpdate(
   return buildModelTypeTagUpdate(asset, newFolderName, modelTypeMode)
 }
 
-/** Legacy grouping: each non-`models` tag's top-level path segment. */
-function getBareTagCategories(asset: AssetItem): string[] {
-  return asset.tags
-    .filter((tag) => tag !== MODELS_TAG && tag.length > 0)
-    .map((tag) => tag.split('/')[0])
-}
-
 /**
  * Resolves the category keys a model asset is grouped under.
  *
@@ -313,11 +332,6 @@ export function getPrimaryCategoryTag(
     )
   }
   return asset.tags.find((tag) => tag !== MODELS_TAG)
-}
-
-/** Number of `parent/child` segments in a tag, used to pick the most specific. */
-function pathDepth(tag: string): number {
-  return tag.split('/').length
 }
 
 /** Removes the `model_type:` namespace prefix from a tag when present. */
@@ -469,20 +483,6 @@ export function getAssetCardTitle(asset: AssetItem): string {
   const curatedName = getStringProperty(asset, 'name')
   if (curatedName && curatedName !== asset.name) return curatedName
   return getAssetDisplayFilename(asset)
-}
-
-export interface ImageDimensions {
-  width: number
-  height: number
-}
-
-/**
- * Type guard: a pixel dimension is a finite positive integer. `metadata` is
- * typed as `Record<string, unknown>`, so `typeof === 'number'` alone admits
- * NaN, Infinity, 0, negatives, and fractional values.
- */
-function isValidDimension(value: unknown): value is number {
-  return typeof value === 'number' && Number.isInteger(value) && value > 0
 }
 
 /**

--- a/src/platform/assets/utils/assetPreviewUtil.ts
+++ b/src/platform/assets/utils/assetPreviewUtil.ts
@@ -10,12 +10,6 @@ interface AssetRecord {
   preview_id?: string | null
 }
 
-export function isAssetPreviewSupported(): boolean {
-  return (
-    assetService.isAssetAPIEnabled() || api.getServerFeature('assets', false)
-  )
-}
-
 async function fetchAssets(
   params: Record<string, string>
 ): Promise<AssetRecord[]> {
@@ -31,6 +25,21 @@ function resolvePreviewUrl(asset: AssetRecord): string {
 
   const contentId = asset.preview_id ?? asset.id
   return api.apiURL(`/assets/${contentId}/content`)
+}
+
+function blobToDataUrl(blob: Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onload = () => resolve(reader.result as string)
+    reader.onerror = reject
+    reader.readAsDataURL(blob)
+  })
+}
+
+export function isAssetPreviewSupported(): boolean {
+  return (
+    assetService.isAssetAPIEnabled() || api.getServerFeature('assets', false)
+  )
 }
 
 /**
@@ -87,13 +96,4 @@ export async function persistThumbnail(
   } catch {
     // Non-critical — client still shows the rendered thumbnail
   }
-}
-
-function blobToDataUrl(blob: Blob): Promise<string> {
-  return new Promise((resolve, reject) => {
-    const reader = new FileReader()
-    reader.onload = () => resolve(reader.result as string)
-    reader.onerror = reject
-    reader.readAsDataURL(blob)
-  })
 }

--- a/src/platform/assets/utils/assetSortUtils.ts
+++ b/src/platform/assets/utils/assetSortUtils.ts
@@ -5,6 +5,10 @@
 
 import type { AssetSortOption } from '../types/filterTypes'
 
+function getDisplayName(item: SortableItem): string {
+  return item.label ?? item.name
+}
+
 /**
  * Minimal interface for sortable items
  * Works with both AssetItem and FormDropdownItem
@@ -13,10 +17,6 @@ export interface SortableItem {
   name: string
   label?: string
   created_at?: string | null
-}
-
-function getDisplayName(item: SortableItem): string {
-  return item.label ?? item.name
 }
 
 /**

--- a/src/platform/assets/utils/marqueeSelectionUtil.ts
+++ b/src/platform/assets/utils/marqueeSelectionUtil.ts
@@ -1,5 +1,14 @@
 import type { RectEdges } from '@/utils/mathUtil'
 
+function rectsIntersect(a: RectEdges, b: RectEdges): boolean {
+  return !(
+    a.right < b.left ||
+    a.left > b.right ||
+    a.bottom < b.top ||
+    a.top > b.bottom
+  )
+}
+
 export interface MarqueeCard {
   id: string
   rect: RectEdges
@@ -15,15 +24,6 @@ export function normalizeMarqueeRect(
     right: Math.max(start.x, end.x),
     bottom: Math.max(start.y, end.y)
   }
-}
-
-function rectsIntersect(a: RectEdges, b: RectEdges): boolean {
-  return !(
-    a.right < b.left ||
-    a.left > b.right ||
-    a.bottom < b.top ||
-    a.top > b.bottom
-  )
 }
 
 /**

--- a/src/platform/assets/utils/outputAssetUtil.ts
+++ b/src/platform/assets/utils/outputAssetUtil.ts
@@ -41,31 +41,6 @@ function shouldLoadFullOutputs(
   )
 }
 
-export function getAssetOutputCount(
-  asset: Pick<AssetItem, 'user_metadata'>
-): number {
-  const count = asset.user_metadata?.outputCount
-  return typeof count === 'number' && count > 0 ? count : 1
-}
-
-export function getTotalAssetOutputCount(
-  assets: Pick<AssetItem, 'user_metadata'>[]
-): number {
-  return assets.reduce((sum, asset) => sum + getAssetOutputCount(asset), 0)
-}
-
-export function getOutputKey({
-  nodeId,
-  subfolder,
-  filename
-}: OutputKeyParts): string | null {
-  if (nodeId == null || subfolder == null || !filename) {
-    return null
-  }
-
-  return `${nodeId}-${subfolder}-${filename}`
-}
-
 /**
  * Maps a job's outputs to AssetItems with ids derived from the composite
  * `<nodeId>-<subfolder>-<filename>` key. Records sharing a composite key are
@@ -253,6 +228,31 @@ async function enrichWithJobAssets(
       )
     return match ? overlayJobAsset(item, match) : item
   })
+}
+
+export function getAssetOutputCount(
+  asset: Pick<AssetItem, 'user_metadata'>
+): number {
+  const count = asset.user_metadata?.outputCount
+  return typeof count === 'number' && count > 0 ? count : 1
+}
+
+export function getTotalAssetOutputCount(
+  assets: Pick<AssetItem, 'user_metadata'>[]
+): number {
+  return assets.reduce((sum, asset) => sum + getAssetOutputCount(asset), 0)
+}
+
+export function getOutputKey({
+  nodeId,
+  subfolder,
+  filename
+}: OutputKeyParts): string | null {
+  if (nodeId == null || subfolder == null || !filename) {
+    return null
+  }
+
+  return `${nodeId}-${subfolder}-${filename}`
 }
 
 export async function resolveOutputAssetItems(

--- a/src/platform/assets/utils/resolveModelNodeFromAsset.ts
+++ b/src/platform/assets/utils/resolveModelNodeFromAsset.ts
@@ -14,19 +14,19 @@ import type { ModelNodeProvider } from '@/stores/modelToNodeStore'
 
 type ResolveErrorCode = 'INVALID_ASSET' | 'NO_PROVIDER'
 
-export interface ResolveModelNodeError {
-  code: ResolveErrorCode
-  message: string
-  assetId: string
-  details?: Record<string, unknown>
-}
-
 interface ResolvedModelNode {
   provider: ModelNodeProvider
   filename: string
 }
 
 type Result<T, E> = { success: true; value: T } | { success: false; error: E }
+
+export interface ResolveModelNodeError {
+  code: ResolveErrorCode
+  message: string
+  assetId: string
+  details?: Record<string, unknown>
+}
 
 /**
  * Resolves an asset item to the node provider and filename needed to add a

--- a/src/platform/auth/unified/remintRetry.ts
+++ b/src/platform/auth/unified/remintRetry.ts
@@ -17,22 +17,6 @@ let cachedUnifiedFlags:
   | undefined
 
 /**
- * Single gate for the reactive guard: a cloud build with `unified_cloud_auth`
- * ON. Memoizes the feature-flag accessor so the hot `fetchApi` path does not
- * build a fresh reactive proxy per request (the cached getter still reflects
- * live flag changes), and is reused at every cloud request seam so the gate
- * cannot be forgotten on a new call site.
- */
-export async function shouldRemintCloudRequest(): Promise<boolean> {
-  if (!isCloud) return false
-  if (!cachedUnifiedFlags) {
-    const { useFeatureFlags } = await import('@/composables/useFeatureFlags')
-    cachedUnifiedFlags = useFeatureFlags().flags
-  }
-  return cachedUnifiedFlags.unifiedCloudAuthEnabled
-}
-
-/**
  * Re-mints the unified Cloud JWT once from the current Firebase identity and
  * returns the fresh token, or `null` when there is nothing to retry with: no
  * active unified session, or the re-mint failed. A permanent auth failure is
@@ -93,6 +77,33 @@ function fetchRequestHeaders(
   return input instanceof Request ? new Headers(input.headers) : new Headers()
 }
 
+function isRetriableUnauthorized(
+  error: unknown
+): error is AxiosError & { config: InternalAxiosRequestConfig } {
+  if (!axios.isAxiosError(error)) return false
+  const config = error.config
+  if (!config || config.__unifiedRetried || config.__skipUnifiedRemint) {
+    return false
+  }
+  return error.response?.status === 401
+}
+
+/**
+ * Single gate for the reactive guard: a cloud build with `unified_cloud_auth`
+ * ON. Memoizes the feature-flag accessor so the hot `fetchApi` path does not
+ * build a fresh reactive proxy per request (the cached getter still reflects
+ * live flag changes), and is reused at every cloud request seam so the gate
+ * cannot be forgotten on a new call site.
+ */
+export async function shouldRemintCloudRequest(): Promise<boolean> {
+  if (!isCloud) return false
+  if (!cachedUnifiedFlags) {
+    const { useFeatureFlags } = await import('@/composables/useFeatureFlags')
+    cachedUnifiedFlags = useFeatureFlags().flags
+  }
+  return cachedUnifiedFlags.unifiedCloudAuthEnabled
+}
+
 /**
  * Issues a `fetch` and, on a `401`, re-mints the unified Cloud JWT once and
  * retries the request exactly once with the fresh token. A persistent `401`
@@ -150,17 +161,6 @@ export async function fetchWithUnifiedRemint(
     trackRetry('fetch', 'failed', undefined, 'retry_request_failed')
     throw error
   }
-}
-
-function isRetriableUnauthorized(
-  error: unknown
-): error is AxiosError & { config: InternalAxiosRequestConfig } {
-  if (!axios.isAxiosError(error)) return false
-  const config = error.config
-  if (!config || config.__unifiedRetried || config.__skipUnifiedRemint) {
-    return false
-  }
-  return error.response?.status === 401
 }
 
 /**

--- a/src/platform/cloud/churnkey/churnkeyClient.ts
+++ b/src/platform/cloud/churnkey/churnkeyClient.ts
@@ -33,17 +33,6 @@ function churnkeyError(error: unknown, type?: string): Error {
   return type ? new Error(`${baseError.message} (${type})`) : baseError
 }
 
-export interface ChurnkeyShowOptions {
-  handleCancel: (
-    surveyResponse?: string | null,
-    freeformFeedback?: string | null
-  ) => Promise<ChurnkeyHandlerResult>
-}
-
-export interface ChurnkeySession {
-  show: (options: ChurnkeyShowOptions) => Promise<ChurnkeySessionResults>
-}
-
 function rejectUnsupportedOffer(): Promise<never> {
   return Promise.reject(
     new Error(t('subscription.cancelDialog.offerUnavailable'))
@@ -116,6 +105,17 @@ function createSession(
         }
       })
   }
+}
+
+export interface ChurnkeyShowOptions {
+  handleCancel: (
+    surveyResponse?: string | null,
+    freeformFeedback?: string | null
+  ) => Promise<ChurnkeyHandlerResult>
+}
+
+export interface ChurnkeySession {
+  show: (options: ChurnkeyShowOptions) => Promise<ChurnkeySessionResults>
 }
 
 export async function prepareChurnkey(): Promise<ChurnkeySession | null> {

--- a/src/platform/cloud/churnkey/types.ts
+++ b/src/platform/cloud/churnkey/types.ts
@@ -2,6 +2,17 @@ import type { ChurnkeyAuthResponse } from '@comfyorg/ingest-types'
 
 type ChurnkeyMode = ChurnkeyAuthResponse['mode']
 
+type ChurnkeyUnsupportedHandler = (
+  ...args: unknown[]
+) => Promise<ChurnkeyHandlerResult>
+
+interface ChurnkeyWindow {
+  created?: boolean
+  init?: ChurnkeyInit
+  hide?: () => void
+  clearState?: () => void
+}
+
 export interface ChurnkeyHandlerResult {
   message?: string
 }
@@ -9,10 +20,6 @@ export interface ChurnkeyHandlerResult {
 export interface ChurnkeySessionResults {
   aborted?: boolean
 }
-
-type ChurnkeyUnsupportedHandler = (
-  ...args: unknown[]
-) => Promise<ChurnkeyHandlerResult>
 
 export interface ChurnkeyInitConfig {
   appId: string
@@ -36,13 +43,6 @@ export interface ChurnkeyInitConfig {
 }
 
 export type ChurnkeyInit = (action: 'show', config: ChurnkeyInitConfig) => void
-
-interface ChurnkeyWindow {
-  created?: boolean
-  init?: ChurnkeyInit
-  hide?: () => void
-  clearState?: () => void
-}
 
 declare global {
   interface Window {

--- a/src/platform/cloud/oauth/oauthApi.ts
+++ b/src/platform/cloud/oauth/oauthApi.ts
@@ -12,14 +12,14 @@ import type {
 // initiated from /oauth/authorize). The Vite proxy / production ingress is
 // the single point of routing.
 
-export type OAuthWorkspace = OAuthConsentChallengeWorkspace
-
 /**
  * The spec marks these required, but backends predating them omit both, so the
  * consent screen degrades instead of rejecting the challenge. Presence is all
  * that deviates — the field types still come from the generated contract.
  */
 type SurfacedOnlyByNewerBackends = 'resource_display_name' | 'redirect_uri'
+
+export type OAuthWorkspace = OAuthConsentChallengeWorkspace
 
 export type OAuthConsentChallenge = Omit<
   GeneratedOAuthConsentChallenge,
@@ -62,16 +62,6 @@ const EXECUTABLE_SCHEMES: ReadonlySet<string> = new Set([
   'vbscript:',
   'about:'
 ])
-
-export class OAuthApiError extends Error {
-  constructor(
-    message: string,
-    readonly status: number
-  ) {
-    super(message)
-    this.name = 'OAuthApiError'
-  }
-}
 
 async function readErrorMessage(response: Response): Promise<string> {
   const body: unknown = await response.json().catch(() => null)
@@ -214,4 +204,14 @@ export async function submitOAuthConsentDecision({
   // Navigate the parsed URL, not the raw string, so the value validated
   // above is byte-for-byte the value the browser receives.
   globalThis.location.href = target.href
+}
+
+export class OAuthApiError extends Error {
+  constructor(
+    message: string,
+    readonly status: number
+  ) {
+    super(message)
+    this.name = 'OAuthApiError'
+  }
 }

--- a/src/platform/cloud/onboarding/composables/useProgressBarPainter.ts
+++ b/src/platform/cloud/onboarding/composables/useProgressBarPainter.ts
@@ -10,6 +10,12 @@ interface SlideProgressInput {
   fallbackMs: number
 }
 
+interface ProgressBarPainterOptions {
+  target: MaybeRefOrGetter<HTMLElement | null | undefined>
+  progress: () => number
+  active: MaybeRefOrGetter<boolean>
+}
+
 /**
  * Fraction of the way to the next slide. Falls back to elapsed wall-clock against
  * the watchdog's delay, so a buffering video still tracks when it will change.
@@ -25,12 +31,6 @@ export function slideProgress({
       ? currentTime / duration
       : elapsedMs / fallbackMs
   return clamp(ratio, 0, 1)
-}
-
-interface ProgressBarPainterOptions {
-  target: MaybeRefOrGetter<HTMLElement | null | undefined>
-  progress: () => number
-  active: MaybeRefOrGetter<boolean>
 }
 
 /**

--- a/src/platform/cloud/subscription/composables/useSubscriptionDialog.ts
+++ b/src/platform/cloud/subscription/composables/useSubscriptionDialog.ts
@@ -13,18 +13,6 @@ import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspace
 const DIALOG_KEY = 'subscription-required'
 const RESUME_PRICING_KEY = 'comfy:resume-team-pricing'
 
-export interface SubscriptionDialogOptions {
-  reason?: PaymentIntentSource
-  /**
-   * Forces the unified pricing dialog to open on a specific plan tab,
-   * overriding the workspace-derived default (e.g. an "Upgrade to Team" CTA
-   * always lands on the team tab even from a personal workspace).
-   */
-  planMode?: 'personal' | 'team'
-  /** Starts checkout in workspace billing dialogs; legacy billing stays table-only. */
-  initialCheckout?: SubscriptionCheckoutSelection
-}
-
 function getInitialPlanMode(
   explicitMode: SubscriptionDialogOptions['planMode'],
   isTeamPlan: boolean,
@@ -35,6 +23,18 @@ function getInitialPlanMode(
   if (isTeamPlan) return 'team'
   if (hasCurrentPlan) return 'personal'
   return isPersonalWorkspace ? 'personal' : 'team'
+}
+
+export interface SubscriptionDialogOptions {
+  reason?: PaymentIntentSource
+  /**
+   * Forces the unified pricing dialog to open on a specific plan tab,
+   * overriding the workspace-derived default (e.g. an "Upgrade to Team" CTA
+   * always lands on the team tab even from a personal workspace).
+   */
+  planMode?: 'personal' | 'team'
+  /** Starts checkout in workspace billing dialogs; legacy billing stays table-only. */
+  initialCheckout?: SubscriptionCheckoutSelection
 }
 
 export const useSubscriptionDialog = () => {

--- a/src/platform/cloud/subscription/utils/subscriptionCheckoutTracker.ts
+++ b/src/platform/cloud/subscription/utils/subscriptionCheckoutTracker.ts
@@ -36,6 +36,17 @@ interface SubscriptionStatusSnapshot {
   subscription_duration?: SubscriptionDuration | null
 }
 
+interface PendingSubscriptionCheckoutAttemptInput {
+  tier: TierKey
+  cycle: BillingCycle
+  checkout_type: SubscriptionCheckoutType
+  previous_tier?: TierKey
+  previous_cycle?: BillingCycle
+  payment_intent_source?: PaymentIntentSource
+  operation?: 'resubscribe'
+  resubscribe_source?: ResubscribeClickMetadata['source']
+}
+
 export interface PendingSubscriptionCheckoutAttempt {
   attempt_id: string
   started_at_ms: number
@@ -48,17 +59,6 @@ export interface PendingSubscriptionCheckoutAttempt {
   /** Set when this attempt was initiated from the resubscribe flow, not a plain subscribe. */
   operation?: 'resubscribe'
   /** Click-time source for a resubscribe attempt; carried through to the terminal event. */
-  resubscribe_source?: ResubscribeClickMetadata['source']
-}
-
-interface PendingSubscriptionCheckoutAttemptInput {
-  tier: TierKey
-  cycle: BillingCycle
-  checkout_type: SubscriptionCheckoutType
-  previous_tier?: TierKey
-  previous_cycle?: BillingCycle
-  payment_intent_source?: PaymentIntentSource
-  operation?: 'resubscribe'
   resubscribe_source?: ResubscribeClickMetadata['source']
 }
 

--- a/src/platform/cloud/subscription/utils/subscriptionCheckoutUtil.ts
+++ b/src/platform/cloud/subscription/utils/subscriptionCheckoutUtil.ts
@@ -44,44 +44,6 @@ interface PerformSubscriptionCheckoutOptions {
   paymentIntentSource?: PaymentIntentSource
 }
 
-/**
- * Core subscription checkout logic shared between PricingTable and
- * SubscriptionRedirectView. Handles:
- * - Ensuring the user is authenticated
- * - Calling the backend checkout endpoint
- * - Normalizing error responses
- * - Opening the checkout URL in a new tab when available
- * - Reporting checkout-initiation failures via `trackBillingEvent`
- *
- * Callers are responsible for:
- * - Guarding on cloud-only behavior (isCloud)
- * - Managing loading state
- * - Wrapping with error handling (e.g. useErrorHandling)
- */
-export async function performSubscriptionCheckout(
-  tierKey: TierKey,
-  currentBillingCycle: BillingCycle,
-  options: PerformSubscriptionCheckoutOptions = {}
-): Promise<void> {
-  if (!isCloud) return
-
-  try {
-    await initiateSubscriptionCheckout(tierKey, currentBillingCycle, options)
-  } catch (error) {
-    useTelemetry()?.trackBillingEvent({
-      operation: 'subscription_checkout',
-      stage: 'failed',
-      outcome: 'failure',
-      tier: tierKey,
-      cycle: currentBillingCycle,
-      checkout_type: 'new',
-      payment_intent_source: options.paymentIntentSource,
-      failure_category: categorizeBillingApiError(error)
-    })
-    throw error
-  }
-}
-
 async function initiateSubscriptionCheckout(
   tierKey: TierKey,
   currentBillingCycle: BillingCycle,
@@ -168,5 +130,43 @@ async function initiateSubscriptionCheckout(
       persistPendingSubscriptionCheckoutAttempt(pendingAttempt)
       globalThis.location.href = data.checkout_url
     }
+  }
+}
+
+/**
+ * Core subscription checkout logic shared between PricingTable and
+ * SubscriptionRedirectView. Handles:
+ * - Ensuring the user is authenticated
+ * - Calling the backend checkout endpoint
+ * - Normalizing error responses
+ * - Opening the checkout URL in a new tab when available
+ * - Reporting checkout-initiation failures via `trackBillingEvent`
+ *
+ * Callers are responsible for:
+ * - Guarding on cloud-only behavior (isCloud)
+ * - Managing loading state
+ * - Wrapping with error handling (e.g. useErrorHandling)
+ */
+export async function performSubscriptionCheckout(
+  tierKey: TierKey,
+  currentBillingCycle: BillingCycle,
+  options: PerformSubscriptionCheckoutOptions = {}
+): Promise<void> {
+  if (!isCloud) return
+
+  try {
+    await initiateSubscriptionCheckout(tierKey, currentBillingCycle, options)
+  } catch (error) {
+    useTelemetry()?.trackBillingEvent({
+      operation: 'subscription_checkout',
+      stage: 'failed',
+      outcome: 'failure',
+      tier: tierKey,
+      cycle: currentBillingCycle,
+      checkout_type: 'new',
+      payment_intent_source: options.paymentIntentSource,
+      failure_category: categorizeBillingApiError(error)
+    })
+    throw error
   }
 }

--- a/src/platform/cloud/subscription/utils/subscriptionTierRank.ts
+++ b/src/platform/cloud/subscription/utils/subscriptionTierRank.ts
@@ -1,14 +1,14 @@
 import type { TierKey } from '@/platform/cloud/subscription/constants/tierPricing'
 
-export type BillingCycle = 'monthly' | 'yearly'
-
 type RankedTierKey = Exclude<TierKey, 'founder' | 'free'>
-type RankedPlanKey = `${BillingCycle}-${RankedTierKey}`
 
+type RankedPlanKey = `${BillingCycle}-${RankedTierKey}`
 interface PlanDescriptor {
   tierKey: TierKey
   billingCycle: BillingCycle
 }
+
+export type BillingCycle = 'monthly' | 'yearly'
 
 const PLAN_ORDER: RankedPlanKey[] = [
   'yearly-pro',

--- a/src/platform/cloud/subscription/utils/teamSubscriptionCheckoutUtil.ts
+++ b/src/platform/cloud/subscription/utils/teamSubscriptionCheckoutUtil.ts
@@ -13,6 +13,42 @@ interface PerformTeamSubscriptionCheckoutOptions {
   paymentIntentSource?: PaymentIntentSource
 }
 
+async function initiateTeamSubscriptionCheckout(
+  teamCreditStopId: string,
+  billingCycle: BillingCycle,
+  options: PerformTeamSubscriptionCheckoutOptions
+): Promise<void> {
+  const planSlug = getTeamPlanSlug(billingCycle)
+  const response = await workspaceApi.subscribe(planSlug, {
+    returnUrl: `${getComfyPlatformBaseUrl()}/payment/success`,
+    cancelUrl: `${getComfyPlatformBaseUrl()}/payment/failed`,
+    teamCreditStopId
+  })
+
+  trackWorkspaceCheckoutStarted({
+    tier: 'team',
+    cycle: billingCycle,
+    checkoutType: 'new',
+    billingOpId: response.billing_op_id,
+    paymentIntentSource: options.paymentIntentSource
+  })
+
+  if (response.status === 'needs_payment_method') {
+    // A needs_payment_method response without a URL is unusable: surface it to
+    // the caller's error handling rather than silently dropping the user home
+    // with a subscription stuck mid-payment.
+    if (!response.payment_method_url) {
+      throw new Error(
+        'Team subscription needs a payment method but no payment URL was returned'
+      )
+    }
+    globalThis.location.href = response.payment_method_url
+    return
+  }
+
+  globalThis.location.href = '/'
+}
+
 /**
  * Direct team-plan checkout for the marketing `/cloud/subscribe?tier=team` deep
  * link: subscribes to the per-credit Team plan at the chosen slider stop and
@@ -54,40 +90,4 @@ export async function performTeamSubscriptionCheckout(
     })
     throw error
   }
-}
-
-async function initiateTeamSubscriptionCheckout(
-  teamCreditStopId: string,
-  billingCycle: BillingCycle,
-  options: PerformTeamSubscriptionCheckoutOptions
-): Promise<void> {
-  const planSlug = getTeamPlanSlug(billingCycle)
-  const response = await workspaceApi.subscribe(planSlug, {
-    returnUrl: `${getComfyPlatformBaseUrl()}/payment/success`,
-    cancelUrl: `${getComfyPlatformBaseUrl()}/payment/failed`,
-    teamCreditStopId
-  })
-
-  trackWorkspaceCheckoutStarted({
-    tier: 'team',
-    cycle: billingCycle,
-    checkoutType: 'new',
-    billingOpId: response.billing_op_id,
-    paymentIntentSource: options.paymentIntentSource
-  })
-
-  if (response.status === 'needs_payment_method') {
-    // A needs_payment_method response without a URL is unusable: surface it to
-    // the caller's error handling rather than silently dropping the user home
-    // with a subscription stuck mid-payment.
-    if (!response.payment_method_url) {
-      throw new Error(
-        'Team subscription needs a payment method but no payment URL was returned'
-      )
-    }
-    globalThis.location.href = response.payment_method_url
-    return
-  }
-
-  globalThis.location.href = '/'
 }

--- a/src/platform/errorCatalog/missingErrorResolver.ts
+++ b/src/platform/errorCatalog/missingErrorResolver.ts
@@ -7,6 +7,35 @@ import { countMissingMediaReferences } from '@/platform/missingMedia/missingMedi
 import { countMissingModels } from '@/platform/missingModel/missingModelGrouping'
 import { st } from '@/i18n'
 
+type NodeTypeErrorSource = Extract<
+  MissingErrorMessageSource,
+  { kind: 'missing_node' | 'swap_nodes' }
+>
+
+type NodeTypeErrorItem = NodeTypeErrorSource['nodeTypes'][number]
+type MissingNodeSource = Extract<
+  MissingErrorMessageSource,
+  { kind: 'missing_node' }
+>
+
+type SwapNodeSource = Extract<MissingErrorMessageSource, { kind: 'swap_nodes' }>
+
+type MissingModelSource = Extract<
+  MissingErrorMessageSource,
+  { kind: 'missing_model' }
+>
+
+type MissingMediaSource = Extract<
+  MissingErrorMessageSource,
+  { kind: 'missing_media' }
+>
+
+interface MissingMediaItemLabelSource {
+  nodeDisplayName?: string
+  nodeType?: string
+  widgetName?: string
+}
+
 function formatNodeTypeName(nodeType: string): string | null {
   const trimmed = nodeType.trim()
   if (!trimmed) return null
@@ -19,12 +48,6 @@ function formatNodeTypeName(nodeType: string): string | null {
     .trim()
 }
 
-type NodeTypeErrorSource = Extract<
-  MissingErrorMessageSource,
-  { kind: 'missing_node' | 'swap_nodes' }
->
-type NodeTypeErrorItem = NodeTypeErrorSource['nodeTypes'][number]
-
 function getNodeTypeLabel(nodeType: NodeTypeErrorItem): string {
   return typeof nodeType === 'string' ? nodeType : nodeType.type
 }
@@ -34,11 +57,6 @@ function getDistinctNodeTypeLabels(nodeTypes: NodeTypeErrorItem[]): string[] {
   for (const nodeType of nodeTypes) labels.add(getNodeTypeLabel(nodeType))
   return Array.from(labels)
 }
-
-type MissingNodeSource = Extract<
-  MissingErrorMessageSource,
-  { kind: 'missing_node' }
->
 
 function isMissingNodeType(nodeType: NodeTypeErrorItem): boolean {
   return typeof nodeType === 'string' || !nodeType.isReplaceable
@@ -103,8 +121,6 @@ function resolveMissingNodeToastMessage(source: MissingNodeSource): string {
   return translateCatalogMessage(key, fallback, { count })
 }
 
-type SwapNodeSource = Extract<MissingErrorMessageSource, { kind: 'swap_nodes' }>
-
 function isSwapNodeType(nodeType: NodeTypeErrorItem): nodeType is Exclude<
   NodeTypeErrorItem,
   string
@@ -161,11 +177,6 @@ function resolveSwapNodeDisplayMessage(): string {
     'Some nodes can be replaced with alternatives'
   )
 }
-
-type MissingModelSource = Extract<
-  MissingErrorMessageSource,
-  { kind: 'missing_model' }
->
 
 function getMissingModelCount(source: MissingModelSource): number {
   return countMissingModels(source.groups) || source.count
@@ -244,17 +255,6 @@ function resolveMissingModelToastMessage(source: MissingModelSource): string {
   )
 }
 
-type MissingMediaSource = Extract<
-  MissingErrorMessageSource,
-  { kind: 'missing_media' }
->
-
-interface MissingMediaItemLabelSource {
-  nodeDisplayName?: string
-  nodeType?: string
-  widgetName?: string
-}
-
 function getMissingMediaItems(source: MissingMediaSource) {
   return source.groups.flatMap((group) => group.items)
 }
@@ -270,27 +270,6 @@ function resolveMissingMediaDisplayMessage(): string {
     'errorCatalog.missingErrors.missing_media.displayMessage',
     'A required media input has no file selected.'
   )
-}
-
-export function resolveMissingMediaItemLabel(
-  source: MissingMediaItemLabelSource
-): { displayItemLabel: string } {
-  const nodeName = normalizeNodeName(
-    source.nodeDisplayName ||
-      formatNodeTypeName(source.nodeType ?? '') ||
-      undefined
-  )
-  const inputName =
-    source.widgetName?.trim() ||
-    translateCatalogMessage('errorCatalog.fallbacks.inputName', 'unknown input')
-
-  return {
-    displayItemLabel: translateCatalogMessage(
-      'errorCatalog.missingErrors.missing_media.itemLabel',
-      '{nodeName} - {inputName}',
-      { nodeName, inputName }
-    )
-  }
 }
 
 function resolveMissingMediaToastTitle(source: MissingMediaSource): string {
@@ -328,6 +307,27 @@ function resolveMissingMediaToastMessage(source: MissingMediaSource): string {
       nodeName: displayNodeName
     }
   )
+}
+
+export function resolveMissingMediaItemLabel(
+  source: MissingMediaItemLabelSource
+): { displayItemLabel: string } {
+  const nodeName = normalizeNodeName(
+    source.nodeDisplayName ||
+      formatNodeTypeName(source.nodeType ?? '') ||
+      undefined
+  )
+  const inputName =
+    source.widgetName?.trim() ||
+    translateCatalogMessage('errorCatalog.fallbacks.inputName', 'unknown input')
+
+  return {
+    displayItemLabel: translateCatalogMessage(
+      'errorCatalog.missingErrors.missing_media.itemLabel',
+      '{nodeName} - {inputName}',
+      { nodeName, inputName }
+    )
+  }
 }
 
 export function resolveMissingErrorMessage(

--- a/src/platform/errorCatalog/runtimeErrorMatcher.ts
+++ b/src/platform/errorCatalog/runtimeErrorMatcher.ts
@@ -127,11 +127,6 @@ const PREPROCESSING_FAILED_PREFIXES = [
   'Failed to complete preparation:'
 ]
 
-export interface RuntimeErrorInfo {
-  exceptionType: string
-  exceptionMessage: string
-}
-
 interface RuntimeCatalogMatch {
   catalogId: string
   params?: CatalogParams
@@ -211,6 +206,11 @@ function isSubscriptionUpgradeMessage(message: string): boolean {
     message.toLowerCase().startsWith(SUBSCRIPTION_UPGRADE_REQUIRED_PREFIX) &&
     getSubscriptionUpgradeDetails(message).length > 0
   )
+}
+
+export interface RuntimeErrorInfo {
+  exceptionType: string
+  exceptionMessage: string
 }
 
 // Order matters: the first matching rule wins. Keep narrow user-actionable

--- a/src/platform/keybindings/keyCombo.ts
+++ b/src/platform/keybindings/keyCombo.ts
@@ -10,6 +10,31 @@ const MODIFIER_KEY_LABELS: Record<string, string> = {
   Shift: 'Shift'
 }
 
+function toNormalizedString(combo: KeyComboImpl): string {
+  const sequences = getModifierSequences(combo)
+
+  if (!combo.isModifier || sequences.length === 0) {
+    sequences.push(getKeyLabel(combo.key, true))
+  }
+
+  return sequences.join(' + ')
+}
+
+function getModifierSequences(combo: KeyComboImpl): string[] {
+  const sequences: string[] = []
+  if (combo.ctrl) sequences.push('Ctrl')
+  if (combo.alt) sequences.push('Alt')
+  if (combo.shift) sequences.push('Shift')
+  return sequences
+}
+
+function getKeyLabel(key: string, normalizeSingleCharacter = false): string {
+  const label = MODIFIER_KEY_LABELS[key] ?? key
+  return normalizeSingleCharacter && label.length === 1
+    ? label.toLowerCase()
+    : label
+}
+
 export class KeyComboImpl implements KeyCombo {
   key: string
   ctrl: boolean
@@ -89,29 +114,4 @@ export class KeyComboImpl implements KeyCombo {
 
     return sequences
   }
-}
-
-function toNormalizedString(combo: KeyComboImpl): string {
-  const sequences = getModifierSequences(combo)
-
-  if (!combo.isModifier || sequences.length === 0) {
-    sequences.push(getKeyLabel(combo.key, true))
-  }
-
-  return sequences.join(' + ')
-}
-
-function getModifierSequences(combo: KeyComboImpl): string[] {
-  const sequences: string[] = []
-  if (combo.ctrl) sequences.push('Ctrl')
-  if (combo.alt) sequences.push('Alt')
-  if (combo.shift) sequences.push('Shift')
-  return sequences
-}
-
-function getKeyLabel(key: string, normalizeSingleCharacter = false): string {
-  const label = MODIFIER_KEY_LABELS[key] ?? key
-  return normalizeSingleCharacter && label.length === 1
-    ? label.toLowerCase()
-    : label
 }

--- a/src/platform/missingMedia/__fixtures__/promotedMedia.ts
+++ b/src/platform/missingMedia/__fixtures__/promotedMedia.ts
@@ -38,6 +38,30 @@ interface PromotedMediaBranch {
   intermediateHost?: SubgraphNode
 }
 
+function addPromotedMediaSource(
+  subgraph: Subgraph,
+  id: number,
+  value: string,
+  options: string[]
+): LGraphNode {
+  const sourceNode = new LGraphNode(promotedMediaNodeType)
+  sourceNode.id = toNodeId(id)
+  sourceNode.type = promotedMediaNodeType
+  const sourceInput = sourceNode.addInput('image', 'COMBO')
+  const sourceWidget = sourceNode.addWidget(
+    'combo',
+    'image',
+    value,
+    () => undefined,
+    { values: [...options] }
+  )
+  sourceInput.widget = { name: sourceWidget.name }
+  subgraph.add(sourceNode)
+  const link = subgraph.inputNode.slots[0].connect(sourceInput, sourceNode)
+  if (!link) throw new Error('Expected promoted image input link')
+  return sourceNode
+}
+
 export interface PromotedMediaRuntime {
   rootGraph: LGraph
   subgraph: Subgraph
@@ -124,30 +148,6 @@ export function createPromotedMissingMediaCandidate(
     name: hostWidget.value,
     isMissing: true
   }
-}
-
-function addPromotedMediaSource(
-  subgraph: Subgraph,
-  id: number,
-  value: string,
-  options: string[]
-): LGraphNode {
-  const sourceNode = new LGraphNode(promotedMediaNodeType)
-  sourceNode.id = toNodeId(id)
-  sourceNode.type = promotedMediaNodeType
-  const sourceInput = sourceNode.addInput('image', 'COMBO')
-  const sourceWidget = sourceNode.addWidget(
-    'combo',
-    'image',
-    value,
-    () => undefined,
-    { values: [...options] }
-  )
-  sourceInput.widget = { name: sourceWidget.name }
-  subgraph.add(sourceNode)
-  const link = subgraph.inputNode.slots[0].connect(sourceInput, sourceNode)
-  if (!link) throw new Error('Expected promoted image input link')
-  return sourceNode
 }
 
 export function createPromotedMediaRuntime({

--- a/src/platform/missingMedia/missingMediaAssetResolver.ts
+++ b/src/platform/missingMedia/missingMediaAssetResolver.ts
@@ -13,91 +13,11 @@ interface MediaPathDetectionOptions {
   allowCompactSuffix: boolean
 }
 
-export interface MissingMediaAssetSources {
-  inputAssets: AssetItem[]
-  generatedAssets: AssetItem[]
-}
-
-export interface ResolveMissingMediaAssetSourcesOptions {
-  signal?: AbortSignal
-  isCloud: boolean
-  includeGeneratedAssets: boolean
-  generatedMatchNames: ReadonlySet<string>
-  generatedHashRequiredNames?: ReadonlySet<string>
-  allowCompactSuffix: boolean
-}
-
-export type MissingMediaAssetResolver = (
-  options: ResolveMissingMediaAssetSourcesOptions
-) => Promise<MissingMediaAssetSources>
-
-export async function resolveMissingMediaAssetSources({
-  signal,
-  isCloud,
-  includeGeneratedAssets,
-  generatedMatchNames,
-  generatedHashRequiredNames = new Set<string>(),
-  allowCompactSuffix
-}: ResolveMissingMediaAssetSourcesOptions): Promise<MissingMediaAssetSources> {
-  const pathOptions = { allowCompactSuffix }
-
-  const controller = new AbortController()
-  const abortFromCaller = () => controller.abort(signal?.reason)
-  if (signal?.aborted) {
-    abortFromCaller()
-  } else {
-    signal?.addEventListener('abort', abortFromCaller, { once: true })
-  }
-
-  try {
-    const [inputAssets, generatedAssets] = await Promise.all([
-      abortSiblingsOnFailure(
-        isCloud
-          ? assetService.getInputAssetsIncludingPublic(controller.signal)
-          : Promise.resolve<AssetItem[]>([]),
-        controller
-      ),
-      abortSiblingsOnFailure(
-        includeGeneratedAssets
-          ? fetchGeneratedAssets(controller.signal, {
-              isCloud,
-              generatedMatchNames,
-              generatedHashRequiredNames,
-              pathOptions
-            })
-          : Promise.resolve<AssetItem[]>([]),
-        controller
-      )
-    ])
-
-    return { inputAssets, generatedAssets }
-  } finally {
-    signal?.removeEventListener('abort', abortFromCaller)
-  }
-}
-
 interface FetchGeneratedAssetsOptions {
   isCloud: boolean
   generatedMatchNames: ReadonlySet<string>
   generatedHashRequiredNames: ReadonlySet<string>
   pathOptions: MediaPathDetectionOptions
-}
-
-export function getAssetDetectionNames(
-  asset: AssetItem,
-  options: MediaPathDetectionOptions
-): string[] {
-  const names = new Set<string>()
-  // Treat names and hashes as opaque match keys because Cloud may use either in widget values.
-  addPathDetectionNames(names, asset.hash, options)
-  addPathDetectionNames(names, asset.name, options)
-
-  const subfolder = asset.user_metadata?.subfolder
-  if (typeof subfolder === 'string' && subfolder) {
-    addSubfolderPathDetectionNames(names, subfolder, asset.name, options)
-  }
-
-  return Array.from(names)
 }
 
 async function fetchGeneratedAssets(
@@ -320,4 +240,84 @@ function mapHistoryJobToAsset(job: JobListItem): AssetItem | null {
       subfolder: output.subfolder
     }
   }
+}
+
+export interface MissingMediaAssetSources {
+  inputAssets: AssetItem[]
+  generatedAssets: AssetItem[]
+}
+
+export interface ResolveMissingMediaAssetSourcesOptions {
+  signal?: AbortSignal
+  isCloud: boolean
+  includeGeneratedAssets: boolean
+  generatedMatchNames: ReadonlySet<string>
+  generatedHashRequiredNames?: ReadonlySet<string>
+  allowCompactSuffix: boolean
+}
+
+export type MissingMediaAssetResolver = (
+  options: ResolveMissingMediaAssetSourcesOptions
+) => Promise<MissingMediaAssetSources>
+
+export async function resolveMissingMediaAssetSources({
+  signal,
+  isCloud,
+  includeGeneratedAssets,
+  generatedMatchNames,
+  generatedHashRequiredNames = new Set<string>(),
+  allowCompactSuffix
+}: ResolveMissingMediaAssetSourcesOptions): Promise<MissingMediaAssetSources> {
+  const pathOptions = { allowCompactSuffix }
+
+  const controller = new AbortController()
+  const abortFromCaller = () => controller.abort(signal?.reason)
+  if (signal?.aborted) {
+    abortFromCaller()
+  } else {
+    signal?.addEventListener('abort', abortFromCaller, { once: true })
+  }
+
+  try {
+    const [inputAssets, generatedAssets] = await Promise.all([
+      abortSiblingsOnFailure(
+        isCloud
+          ? assetService.getInputAssetsIncludingPublic(controller.signal)
+          : Promise.resolve<AssetItem[]>([]),
+        controller
+      ),
+      abortSiblingsOnFailure(
+        includeGeneratedAssets
+          ? fetchGeneratedAssets(controller.signal, {
+              isCloud,
+              generatedMatchNames,
+              generatedHashRequiredNames,
+              pathOptions
+            })
+          : Promise.resolve<AssetItem[]>([]),
+        controller
+      )
+    ])
+
+    return { inputAssets, generatedAssets }
+  } finally {
+    signal?.removeEventListener('abort', abortFromCaller)
+  }
+}
+
+export function getAssetDetectionNames(
+  asset: AssetItem,
+  options: MediaPathDetectionOptions
+): string[] {
+  const names = new Set<string>()
+  // Treat names and hashes as opaque match keys because Cloud may use either in widget values.
+  addPathDetectionNames(names, asset.hash, options)
+  addPathDetectionNames(names, asset.name, options)
+
+  const subfolder = asset.user_metadata?.subfolder
+  if (typeof subfolder === 'string' && subfolder) {
+    addSubfolderPathDetectionNames(names, subfolder, asset.name, options)
+  }
+
+  return Array.from(names)
 }

--- a/src/platform/missingMedia/missingMediaScan.ts
+++ b/src/platform/missingMedia/missingMediaScan.ts
@@ -37,6 +37,17 @@ import {
 } from './missingMediaAssetResolver'
 import type { MissingMediaAssetResolver } from './missingMediaAssetResolver'
 
+interface MediaVerificationOptions {
+  isCloud: boolean
+  signal?: AbortSignal
+  resolveAssetSources?: MissingMediaAssetResolver
+}
+
+interface GeneratedCandidateMatchNames {
+  names: Set<string>
+  hashRequiredNames: Set<string>
+}
+
 function isComboWidget(widget: IBaseWidget): widget is IComboWidget {
   return widget.type === 'combo'
 }
@@ -57,6 +68,95 @@ function mediaTypeFromSpec(
   if (spec.image_upload || spec.animated_image_upload) return 'image'
   if (spec.audio_upload) return 'audio'
   return undefined
+}
+
+function getGeneratedCandidateMatchNames(
+  candidates: MissingMediaCandidate[],
+  isCloud: boolean,
+  pathOptions: { allowCompactSuffix: boolean }
+): GeneratedCandidateMatchNames {
+  const names = new Set<string>()
+  const hashRequiredNames = new Set<string>()
+
+  for (const candidate of candidates) {
+    if (!isGeneratedCandidate(candidate, pathOptions)) continue
+
+    const normalized = normalizeAnnotatedMediaPathForDetection(
+      candidate.name,
+      pathOptions
+    )
+    const lookupName = isCloud ? getMediaPathBasename(normalized) : normalized
+    names.add(lookupName)
+    if (isCloud && lookupName !== normalized) {
+      hashRequiredNames.add(lookupName)
+    }
+  }
+
+  return { names, hashRequiredNames }
+}
+
+function isGeneratedCandidate(
+  candidate: MissingMediaCandidate,
+  pathOptions: { allowCompactSuffix: boolean }
+): boolean {
+  const type = getAnnotatedMediaPathTypeForDetection(
+    candidate.name,
+    pathOptions
+  )
+  return type === 'output'
+}
+
+function isCandidateResolved(
+  candidate: MissingMediaCandidate,
+  identifiers: ReadonlySet<string>,
+  isOutputCandidate: boolean,
+  isCloud: boolean,
+  outputAssetHashIdentifiers: ReadonlySet<string>,
+  pathOptions: { allowCompactSuffix: boolean }
+): boolean {
+  const detectionNames = getMediaPathDetectionNames(candidate.name, pathOptions)
+  if (detectionNames.some((name) => identifiers.has(name))) return true
+  if (!isOutputCandidate || !isCloud) return false
+
+  const normalized = normalizeAnnotatedMediaPathForDetection(
+    candidate.name,
+    pathOptions
+  )
+  const basename = getMediaPathBasename(normalized)
+  return basename !== normalized && outputAssetHashIdentifiers.has(basename)
+}
+
+function getMediaPathBasename(value: string): string {
+  const separatorIndex = Math.max(
+    value.lastIndexOf('/'),
+    value.lastIndexOf('\\')
+  )
+  return separatorIndex === -1 ? value : value.slice(separatorIndex + 1)
+}
+
+function addAssetIdentifiers(
+  identifiers: Set<string>,
+  assets: AssetItem[],
+  pathOptions: { allowCompactSuffix: boolean }
+) {
+  for (const asset of assets) {
+    for (const name of getAssetDetectionNames(asset, pathOptions)) {
+      identifiers.add(name)
+    }
+  }
+}
+
+function addAssetHashIdentifiers(
+  identifiers: Set<string>,
+  assets: AssetItem[],
+  pathOptions: { allowCompactSuffix: boolean }
+) {
+  for (const asset of assets) {
+    if (!asset.hash) continue
+    for (const name of getMediaPathDetectionNames(asset.hash, pathOptions)) {
+      identifiers.add(name)
+    }
+  }
 }
 
 /**
@@ -180,17 +280,6 @@ export function isMissingMediaCandidateActive(
   )
 }
 
-interface MediaVerificationOptions {
-  isCloud: boolean
-  signal?: AbortSignal
-  resolveAssetSources?: MissingMediaAssetResolver
-}
-
-interface GeneratedCandidateMatchNames {
-  names: Set<string>
-  hashRequiredNames: Set<string>
-}
-
 /**
  * Verify media candidates against assets available to the current runtime.
  *
@@ -273,95 +362,6 @@ export async function verifyMediaCandidates(
       outputAssetHashIdentifiers,
       pathOptions
     )
-  }
-}
-
-function getGeneratedCandidateMatchNames(
-  candidates: MissingMediaCandidate[],
-  isCloud: boolean,
-  pathOptions: { allowCompactSuffix: boolean }
-): GeneratedCandidateMatchNames {
-  const names = new Set<string>()
-  const hashRequiredNames = new Set<string>()
-
-  for (const candidate of candidates) {
-    if (!isGeneratedCandidate(candidate, pathOptions)) continue
-
-    const normalized = normalizeAnnotatedMediaPathForDetection(
-      candidate.name,
-      pathOptions
-    )
-    const lookupName = isCloud ? getMediaPathBasename(normalized) : normalized
-    names.add(lookupName)
-    if (isCloud && lookupName !== normalized) {
-      hashRequiredNames.add(lookupName)
-    }
-  }
-
-  return { names, hashRequiredNames }
-}
-
-function isGeneratedCandidate(
-  candidate: MissingMediaCandidate,
-  pathOptions: { allowCompactSuffix: boolean }
-): boolean {
-  const type = getAnnotatedMediaPathTypeForDetection(
-    candidate.name,
-    pathOptions
-  )
-  return type === 'output'
-}
-
-function isCandidateResolved(
-  candidate: MissingMediaCandidate,
-  identifiers: ReadonlySet<string>,
-  isOutputCandidate: boolean,
-  isCloud: boolean,
-  outputAssetHashIdentifiers: ReadonlySet<string>,
-  pathOptions: { allowCompactSuffix: boolean }
-): boolean {
-  const detectionNames = getMediaPathDetectionNames(candidate.name, pathOptions)
-  if (detectionNames.some((name) => identifiers.has(name))) return true
-  if (!isOutputCandidate || !isCloud) return false
-
-  const normalized = normalizeAnnotatedMediaPathForDetection(
-    candidate.name,
-    pathOptions
-  )
-  const basename = getMediaPathBasename(normalized)
-  return basename !== normalized && outputAssetHashIdentifiers.has(basename)
-}
-
-function getMediaPathBasename(value: string): string {
-  const separatorIndex = Math.max(
-    value.lastIndexOf('/'),
-    value.lastIndexOf('\\')
-  )
-  return separatorIndex === -1 ? value : value.slice(separatorIndex + 1)
-}
-
-function addAssetIdentifiers(
-  identifiers: Set<string>,
-  assets: AssetItem[],
-  pathOptions: { allowCompactSuffix: boolean }
-) {
-  for (const asset of assets) {
-    for (const name of getAssetDetectionNames(asset, pathOptions)) {
-      identifiers.add(name)
-    }
-  }
-}
-
-function addAssetHashIdentifiers(
-  identifiers: Set<string>,
-  assets: AssetItem[],
-  pathOptions: { allowCompactSuffix: boolean }
-) {
-  for (const asset of assets) {
-    if (!asset.hash) continue
-    for (const name of getMediaPathDetectionNames(asset.hash, pathOptions)) {
-      identifiers.add(name)
-    }
   }
 }
 

--- a/src/platform/missingModel/missingModelDownload.ts
+++ b/src/platform/missingModel/missingModelDownload.ts
@@ -37,10 +37,23 @@ function isModelUrlAllowlisted(url: string): boolean {
 
 const MODEL_LIBRARY_TAB_ID = 'model-library'
 
-export interface ModelWithUrl {
-  name: string
-  url: string
-  directory: string
+interface ModelMetadata {
+  fileSize: number | null
+  gatedRepoUrl: string | null
+}
+
+interface MetadataFetchResult {
+  metadata: ModelMetadata
+  cacheable: boolean
+}
+
+interface CivitaiModelFile {
+  sizeKB: number
+  downloadUrl: string
+}
+
+interface CivitaiModelVersionResponse {
+  files: CivitaiModelFile[]
 }
 
 async function startDesktop2ModelDownload(
@@ -74,17 +87,23 @@ function openUrlInNewTab(url: string, downloadAs?: string): void {
   link.click()
 }
 
-export function openGatedRepoPage(url: string): void {
-  if (!isTrustedHuggingFaceUrl(url)) return
-  openUrlInNewTab(url)
-}
-
 function hasHuggingFaceHost(url: string): boolean {
   try {
     return new URL(url).hostname.toLowerCase() === 'huggingface.co'
   } catch {
     return false
   }
+}
+
+export interface ModelWithUrl {
+  name: string
+  url: string
+  directory: string
+}
+
+export function openGatedRepoPage(url: string): void {
+  if (!isTrustedHuggingFaceUrl(url)) return
+  openUrlInNewTab(url)
 }
 
 export function isTrustedHuggingFaceUrl(url: string): boolean {
@@ -146,32 +165,8 @@ export function downloadModel(
   }
 }
 
-interface ModelMetadata {
-  fileSize: number | null
-  gatedRepoUrl: string | null
-}
-
-interface MetadataFetchResult {
-  metadata: ModelMetadata
-  cacheable: boolean
-}
-
-interface CivitaiModelFile {
-  sizeKB: number
-  downloadUrl: string
-}
-
-interface CivitaiModelVersionResponse {
-  files: CivitaiModelFile[]
-}
-
 const metadataCache = new Map<string, ModelMetadata>()
 const inflight = new Map<string, Promise<ModelMetadata>>()
-
-export function clearMetadataCache(): void {
-  metadataCache.clear()
-  inflight.clear()
-}
 
 async function fetchCivitaiMetadata(url: string): Promise<MetadataFetchResult> {
   try {
@@ -217,6 +212,11 @@ async function fetchCivitaiMetadata(url: string): Promise<MetadataFetchResult> {
       cacheable: false
     }
   }
+}
+
+export function clearMetadataCache(): void {
+  metadataCache.clear()
+  inflight.clear()
 }
 
 const GATED_STATUS_CODES = new Set([401, 403, 451])

--- a/src/platform/missingModel/missingModelPipeline.ts
+++ b/src/platform/missingModel/missingModelPipeline.ts
@@ -23,11 +23,6 @@ import {
   isMissingCandidateActive
 } from '@/utils/graphTraversalUtil'
 
-export interface MissingModelPipelineResult {
-  missingModels: ModelFile[]
-  confirmedCandidates: MissingModelCandidate[]
-}
-
 interface MissingModelPipelineStore {
   missingModelCandidates: MissingModelCandidate[] | null
   createVerificationAbortController: () => AbortController
@@ -98,6 +93,11 @@ function getCurrentMissingModelMetadata(
       ?.filter(hasDownloadMetadata)
       .map(toModelFile) ?? []
   )
+}
+
+export interface MissingModelPipelineResult {
+  missingModels: ModelFile[]
+  confirmedCandidates: MissingModelCandidate[]
 }
 
 export async function runMissingModelPipeline({

--- a/src/platform/missingModel/missingModelScan.ts
+++ b/src/platform/missingModel/missingModelScan.ts
@@ -28,8 +28,21 @@ import { LGraphEventMode } from '@/lib/litegraph/src/types/globalEnums'
 import { resolveComboValues } from '@/utils/litegraphUtil'
 import { getParentExecutionIds } from '@/types/nodeIdentification'
 
-export type MissingModelWorkflowData = FlattenableWorkflowGraph & {
-  models?: ModelFile[]
+interface ModelWidgetScanTarget {
+  executionId: NodeExecutionId
+  nodeType: string
+  candidateWidgetName: string
+  definitionWidgetName: string
+  sourceExecutionId?: NodeExecutionId
+  valueWidget: IBaseWidget
+  definitionWidget: IBaseWidget
+  embeddedModels?: ModelFile[]
+}
+
+type NodeWithEmbeddedModels = {
+  properties?: {
+    models?: ModelFile[]
+  }
 }
 
 function isComboWidget(widget: IBaseWidget): widget is IComboWidget {
@@ -77,21 +90,8 @@ function isInactiveMode(mode: number | undefined): boolean {
   return mode === LGraphEventMode.NEVER || mode === LGraphEventMode.BYPASS
 }
 
-interface ModelWidgetScanTarget {
-  executionId: NodeExecutionId
-  nodeType: string
-  candidateWidgetName: string
-  definitionWidgetName: string
-  sourceExecutionId?: NodeExecutionId
-  valueWidget: IBaseWidget
-  definitionWidget: IBaseWidget
-  embeddedModels?: ModelFile[]
-}
-
-type NodeWithEmbeddedModels = {
-  properties?: {
-    models?: ModelFile[]
-  }
+export type MissingModelWorkflowData = FlattenableWorkflowGraph & {
+  models?: ModelFile[]
 }
 
 // Full set of model file extensions used for scanning candidate widgets.
@@ -108,86 +108,9 @@ export const MODEL_FILE_EXTENSIONS = new Set([
   '.gguf'
 ])
 
-export function isModelFileName(name: string): boolean {
-  const lower = name.toLowerCase()
-  return Array.from(MODEL_FILE_EXTENSIONS).some((ext) => lower.endsWith(ext))
-}
-
-/**
- * Scan COMBO and asset widgets on configured graph nodes for model-like values.
- * Must be called after `graph.configure()` so widget name/value mappings are accurate.
- *
- * Non-asset-supported nodes: `isMissing` resolved immediately via widget options.
- * Asset-supported nodes: `isMissing` left `undefined` for async verification.
- */
-export function scanAllModelCandidates(
-  rootGraph: LGraph,
-  isAssetSupported: (nodeType: string, widgetName: string) => boolean,
-  getDirectory?: (nodeType: string) => string | undefined
-): MissingModelCandidate[] {
-  if (!rootGraph) return []
-
-  const allNodes = collectAllNodes(rootGraph)
-  const candidates: MissingModelCandidate[] = []
-
-  for (const node of allNodes) {
-    if (isInactiveMode(node.mode)) continue
-
-    candidates.push(
-      ...scanNodeModelCandidates(
-        rootGraph,
-        node,
-        isAssetSupported,
-        getDirectory
-      )
-    )
-  }
-
-  return candidates
-}
-
-/** Scan a single node's widgets for missing model candidates (OSS immediate resolution). */
-export function scanNodeModelCandidates(
-  rootGraph: LGraph,
-  node: LGraphNode,
-  isAssetSupported: (nodeType: string, widgetName: string) => boolean,
-  getDirectory?: (nodeType: string) => string | undefined
-): MissingModelCandidate[] {
-  const widgets = node.isSubgraphNode?.()
-    ? promotedInputWidgets(node)
-    : (node.widgets ?? [])
-  if (!widgets.length) return []
-
-  const executionId = getExecutionIdByNode(rootGraph, node)
-  if (!executionId) return []
-
-  const candidates: MissingModelCandidate[] = []
-
-  for (const widget of widgets) {
-    const target = getModelWidgetScanTarget(
-      rootGraph,
-      node,
-      widget,
-      executionId
-    )
-    if (!target) continue
-
-    let candidate: MissingModelCandidate | null = null
-
-    if (isAssetScanTarget(target)) {
-      candidate = scanAssetWidget(target, getDirectory)
-    } else if (isComboScanTarget(target)) {
-      candidate = scanComboWidget(target, isAssetSupported, getDirectory)
-    }
-
-    if (candidate) {
-      candidates.push(
-        enrichCandidateFromNodeProperties(candidate, target.embeddedModels)
-      )
-    }
-  }
-
-  return candidates
+interface AssetVerifier {
+  updateModelsForNodeType: (nodeType: string) => Promise<void>
+  getAssets: (nodeType: string) => AssetItem[] | undefined
 }
 
 function getModelWidgetScanTarget(
@@ -303,6 +226,146 @@ function scanComboWidget(
   }
 }
 
+function collectEmbeddedModels(
+  allNodes: ReturnType<typeof flattenWorkflowNodes>,
+  graphData: MissingModelWorkflowData
+): ModelFile[] {
+  const result: ModelFile[] = []
+  const nodesById = new Map(allNodes.map((node) => [String(node.id), node]))
+
+  for (const node of allNodes) {
+    if (!isNodeAndAncestorsActive(node, nodesById)) continue
+
+    const selected = getSelectedModelsMetadata(node)
+    if (!selected?.length) continue
+
+    result.push(...selected)
+  }
+
+  if (graphData.models?.length) result.push(...graphData.models)
+
+  return result
+}
+
+function isNodeAndAncestorsActive(
+  node: ReturnType<typeof flattenWorkflowNodes>[number],
+  nodesById: ReadonlyMap<
+    string,
+    ReturnType<typeof flattenWorkflowNodes>[number]
+  >
+): boolean {
+  if (isInactiveMode(node.mode)) return false
+
+  for (const ancestorId of getParentExecutionIds(String(node.id))) {
+    const ancestor = nodesById.get(ancestorId)
+    if (isInactiveMode(ancestor?.mode)) return false
+  }
+
+  return true
+}
+
+function normalizePath(path: string): string {
+  return path.replace(/\\/g, '/')
+}
+
+function isAssetInstalled(
+  candidate: MissingModelCandidate,
+  assets: AssetItem[]
+): boolean {
+  if (candidate.hash && candidate.hashType) {
+    const candidateHash = `${candidate.hashType}:${candidate.hash}`
+    if (assets.some((a) => a.hash === candidateHash)) return true
+  }
+
+  const normalizedName = normalizePath(candidate.name)
+  return assets.some((a) => {
+    const f = normalizePath(getAssetFilename(a))
+    return f === normalizedName || f.endsWith('/' + normalizedName)
+  })
+}
+
+export function isModelFileName(name: string): boolean {
+  const lower = name.toLowerCase()
+  return Array.from(MODEL_FILE_EXTENSIONS).some((ext) => lower.endsWith(ext))
+}
+
+/**
+ * Scan COMBO and asset widgets on configured graph nodes for model-like values.
+ * Must be called after `graph.configure()` so widget name/value mappings are accurate.
+ *
+ * Non-asset-supported nodes: `isMissing` resolved immediately via widget options.
+ * Asset-supported nodes: `isMissing` left `undefined` for async verification.
+ */
+export function scanAllModelCandidates(
+  rootGraph: LGraph,
+  isAssetSupported: (nodeType: string, widgetName: string) => boolean,
+  getDirectory?: (nodeType: string) => string | undefined
+): MissingModelCandidate[] {
+  if (!rootGraph) return []
+
+  const allNodes = collectAllNodes(rootGraph)
+  const candidates: MissingModelCandidate[] = []
+
+  for (const node of allNodes) {
+    if (isInactiveMode(node.mode)) continue
+
+    candidates.push(
+      ...scanNodeModelCandidates(
+        rootGraph,
+        node,
+        isAssetSupported,
+        getDirectory
+      )
+    )
+  }
+
+  return candidates
+}
+
+/** Scan a single node's widgets for missing model candidates (OSS immediate resolution). */
+export function scanNodeModelCandidates(
+  rootGraph: LGraph,
+  node: LGraphNode,
+  isAssetSupported: (nodeType: string, widgetName: string) => boolean,
+  getDirectory?: (nodeType: string) => string | undefined
+): MissingModelCandidate[] {
+  const widgets = node.isSubgraphNode?.()
+    ? promotedInputWidgets(node)
+    : (node.widgets ?? [])
+  if (!widgets.length) return []
+
+  const executionId = getExecutionIdByNode(rootGraph, node)
+  if (!executionId) return []
+
+  const candidates: MissingModelCandidate[] = []
+
+  for (const widget of widgets) {
+    const target = getModelWidgetScanTarget(
+      rootGraph,
+      node,
+      widget,
+      executionId
+    )
+    if (!target) continue
+
+    let candidate: MissingModelCandidate | null = null
+
+    if (isAssetScanTarget(target)) {
+      candidate = scanAssetWidget(target, getDirectory)
+    } else if (isComboScanTarget(target)) {
+      candidate = scanComboWidget(target, isAssetSupported, getDirectory)
+    }
+
+    if (candidate) {
+      candidates.push(
+        enrichCandidateFromNodeProperties(candidate, target.embeddedModels)
+      )
+    }
+  }
+
+  return candidates
+}
+
 export function enrichWithEmbeddedMetadata(
   candidates: readonly MissingModelCandidate[],
   graphData: MissingModelWorkflowData
@@ -351,49 +414,6 @@ export function enrichWithEmbeddedMetadata(
   return enriched
 }
 
-function collectEmbeddedModels(
-  allNodes: ReturnType<typeof flattenWorkflowNodes>,
-  graphData: MissingModelWorkflowData
-): ModelFile[] {
-  const result: ModelFile[] = []
-  const nodesById = new Map(allNodes.map((node) => [String(node.id), node]))
-
-  for (const node of allNodes) {
-    if (!isNodeAndAncestorsActive(node, nodesById)) continue
-
-    const selected = getSelectedModelsMetadata(node)
-    if (!selected?.length) continue
-
-    result.push(...selected)
-  }
-
-  if (graphData.models?.length) result.push(...graphData.models)
-
-  return result
-}
-
-function isNodeAndAncestorsActive(
-  node: ReturnType<typeof flattenWorkflowNodes>[number],
-  nodesById: ReadonlyMap<
-    string,
-    ReturnType<typeof flattenWorkflowNodes>[number]
-  >
-): boolean {
-  if (isInactiveMode(node.mode)) return false
-
-  for (const ancestorId of getParentExecutionIds(String(node.id))) {
-    const ancestor = nodesById.get(ancestorId)
-    if (isInactiveMode(ancestor?.mode)) return false
-  }
-
-  return true
-}
-
-interface AssetVerifier {
-  updateModelsForNodeType: (nodeType: string) => Promise<void>
-  getAssets: (nodeType: string) => AssetItem[] | undefined
-}
-
 export async function verifyAssetSupportedCandidates(
   candidates: MissingModelCandidate[],
   signal?: AbortSignal,
@@ -438,26 +458,6 @@ export async function verifyAssetSupportedCandidates(
     const assets = store.getAssets(c.nodeType) ?? []
     c.isMissing = !isAssetInstalled(c, assets)
   }
-}
-
-function normalizePath(path: string): string {
-  return path.replace(/\\/g, '/')
-}
-
-function isAssetInstalled(
-  candidate: MissingModelCandidate,
-  assets: AssetItem[]
-): boolean {
-  if (candidate.hash && candidate.hashType) {
-    const candidateHash = `${candidate.hashType}:${candidate.hash}`
-    if (assets.some((a) => a.hash === candidateHash)) return true
-  }
-
-  const normalizedName = normalizePath(candidate.name)
-  return assets.some((a) => {
-    const f = normalizePath(getAssetFilename(a))
-    return f === normalizedName || f.endsWith('/' + normalizedName)
-  })
 }
 
 export function groupCandidatesByName(

--- a/src/platform/onboarding/fixtures/coachmarkTargets.ts
+++ b/src/platform/onboarding/fixtures/coachmarkTargets.ts
@@ -1,5 +1,10 @@
 import type { RectTarget } from '../coachmarkRegistry'
 
+export interface TestRectTarget extends RectTarget {
+  move: () => void
+  listenerCount: () => number
+}
+
 /** An element with a non-zero measured rect, so it counts as laid out. */
 export function laidOut(rect = new DOMRect(10, 10, 80, 30)): HTMLElement {
   const el = document.createElement('div')
@@ -17,11 +22,6 @@ export function mountNode(nodeId = '7'): HTMLElement {
   node.setAttribute('data-node-id', nodeId)
   document.body.append(node)
   return node
-}
-
-export interface TestRectTarget extends RectTarget {
-  move: () => void
-  listenerCount: () => number
 }
 
 /** Stands in for a canvas node: reports its own rect, moves with the camera. */

--- a/src/platform/onboarding/onboardingTourStore.ts
+++ b/src/platform/onboarding/onboardingTourStore.ts
@@ -28,20 +28,6 @@ import { useTourTriggers } from './useTourTriggers'
 
 const DEFER_TIMEOUT_MS = 8000
 
-/**
- * How the last run of a tour ended. Whatever follows a tour has to know which
- * ending it is following: "a tour ran" cannot tell a tour walked to the end
- * apart from one the user waved away on step 1, or one a missing target tore
- * down.
- */
-export type TourEnding =
-  | { tour: EntryPath; outcome: 'completed' }
-  | {
-      tour: EntryPath
-      outcome: 'skipped'
-      skipReason: OnboardingTourSkipReason
-    }
-
 /** Empty when a runtime resolver fails, so one bad graph costs only its own tour. */
 async function resolveDefinition(
   definition: TourDefinition
@@ -55,6 +41,20 @@ async function resolveDefinition(
     return { steps: [], reason: 'resolver_failed' }
   }
 }
+
+/**
+ * How the last run of a tour ended. Whatever follows a tour has to know which
+ * ending it is following: "a tour ran" cannot tell a tour walked to the end
+ * apart from one the user waved away on step 1, or one a missing target tore
+ * down.
+ */
+export type TourEnding =
+  | { tour: EntryPath; outcome: 'completed' }
+  | {
+      tour: EntryPath
+      outcome: 'skipped'
+      skipReason: OnboardingTourSkipReason
+    }
 
 /**
  * The tour state machine: which tour starts and when, which steps run, and the

--- a/src/platform/onboarding/onboardingTours.ts
+++ b/src/platform/onboarding/onboardingTours.ts
@@ -42,10 +42,6 @@ export const FIRST_RUN_COACH_IDS = {
   sink: 'first-run-sink'
 } as const
 
-export type CoachId =
-  | (typeof COACH_IDS)[keyof typeof COACH_IDS]
-  | (typeof FIRST_RUN_COACH_IDS)[keyof typeof FIRST_RUN_COACH_IDS]
-
 interface StepBase {
   /**
    * Derives the step's translation keys:
@@ -63,6 +59,10 @@ interface LandingStep extends StepBase {
   kind: 'landing'
   image?: string
 }
+
+export type CoachId =
+  | (typeof COACH_IDS)[keyof typeof COACH_IDS]
+  | (typeof FIRST_RUN_COACH_IDS)[keyof typeof FIRST_RUN_COACH_IDS]
 
 /** Spotlights a target, or centres itself when the step names none. */
 export interface SpotlightStep extends StepBase {

--- a/src/platform/onboarding/tourState.ts
+++ b/src/platform/onboarding/tourState.ts
@@ -2,6 +2,11 @@ import type { CoachStep, EntryPath } from './onboardingTours'
 
 export const IDLE = { phase: 'idle' } as const
 
+type RunningState = Extract<
+  TourState,
+  { phase: 'waiting' | 'entering' | 'showing' }
+>
+
 /**
  * One activation of a tour. The same tour can start, lose its trigger and start
  * again, so its name cannot tell a reply meant for this run apart from one that
@@ -36,10 +41,15 @@ export type TourState =
       idx: number
     }
 
-type RunningState = Extract<
-  TourState,
-  { phase: 'waiting' | 'entering' | 'showing' }
->
+/** Events answering an `await` name their run, so a late reply can be refused. */
+export type TourEvent =
+  | { type: 'requested'; tour: EntryPath; run: RunId }
+  | { type: 'resolved'; run: RunId; steps: CoachStep[] }
+  | { type: 'resolvedEmpty'; run: RunId }
+  | { type: 'targetAwaited'; run: RunId; fromIdx: number | null }
+  | { type: 'stepEntering'; run: RunId; toIdx: number }
+  | { type: 'stepShown'; run: RunId; idx: number }
+  | { type: 'ended'; run: RunId }
 
 export function isRunning(state: TourState): state is RunningState {
   return (
@@ -57,16 +67,6 @@ export function shownIdx(state: TourState): number | null {
   if (state.phase === 'waiting') return state.fromIdx
   return null
 }
-
-/** Events answering an `await` name their run, so a late reply can be refused. */
-export type TourEvent =
-  | { type: 'requested'; tour: EntryPath; run: RunId }
-  | { type: 'resolved'; run: RunId; steps: CoachStep[] }
-  | { type: 'resolvedEmpty'; run: RunId }
-  | { type: 'targetAwaited'; run: RunId; fromIdx: number | null }
-  | { type: 'stepEntering'; run: RunId; toIdx: number }
-  | { type: 'stepShown'; run: RunId; idx: number }
-  | { type: 'ended'; run: RunId }
 
 /**
  * The only transition table. An event meaningless in the current phase, or from

--- a/src/platform/remote/comfyui/errors.ts
+++ b/src/platform/remote/comfyui/errors.ts
@@ -22,6 +22,20 @@ const MAX_RAW_MESSAGE_LENGTH = 500
 const MARKUP_DOCUMENT = /^<[a-z!/]/i
 
 /**
+ * Parse JSON when possible, otherwise surface the raw text. A blank or
+ * whitespace-only body yields `undefined` so callers fall through to a
+ * status-derived fallback.
+ */
+function parseJsonOrText(text: string): unknown {
+  if (text.trim() === '') return undefined
+  try {
+    return JSON.parse(text)
+  } catch {
+    return text
+  }
+}
+
+/**
  * Coerce an already-parsed error body into the canonical
  * `ErrorResponse { code, message, details? }` shape.
  *
@@ -60,20 +74,6 @@ export function errorResponseFromBody(
       : fallbackMessage
   const details = isPlainObject(record.details) ? record.details : undefined
   return details !== undefined ? { code, message, details } : { code, message }
-}
-
-/**
- * Parse JSON when possible, otherwise surface the raw text. A blank or
- * whitespace-only body yields `undefined` so callers fall through to a
- * status-derived fallback.
- */
-function parseJsonOrText(text: string): unknown {
-  if (text.trim() === '') return undefined
-  try {
-    return JSON.parse(text)
-  } catch {
-    return text
-  }
 }
 
 /**

--- a/src/platform/remote/comfyui/jobs/fetchJobs.ts
+++ b/src/platform/remote/comfyui/jobs/fetchJobs.ts
@@ -33,14 +33,6 @@ interface FetchJobsRawResult {
   hasMore: boolean
 }
 
-export interface FetchHistoryPageResult {
-  jobs: JobListItem[]
-  total: number
-  offset: number
-  limit: number
-  hasMore: boolean
-}
-
 /**
  * Fetches raw jobs from /jobs endpoint
  * @internal
@@ -77,6 +69,14 @@ async function fetchJobsRaw(
     console.error('[Jobs API] Error fetching jobs:', error)
     return { jobs: [], total: 0, offset, limit: maxItems, hasMore: false }
   }
+}
+
+export interface FetchHistoryPageResult {
+  jobs: JobListItem[]
+  total: number
+  offset: number
+  limit: number
+  hasMore: boolean
 }
 
 // Large offset to ensure running/pending jobs sort above history

--- a/src/platform/remoteConfig/refreshRemoteConfig.ts
+++ b/src/platform/remoteConfig/refreshRemoteConfig.ts
@@ -24,17 +24,6 @@ interface RefreshRemoteConfigOptions {
 let refreshGeneration = 0
 const activeRefreshControllers = new Set<AbortController>()
 
-export function invalidateRemoteConfig(): void {
-  refreshGeneration++
-  for (const controller of activeRefreshControllers) controller.abort()
-  activeRefreshControllers.clear()
-  window.__CONFIG__ = {}
-  remoteConfig.value = {}
-  remoteConfigErrorStatus.value = null
-  remoteConfigState.value = 'unloaded'
-  cachedLegacyBillingMigrationEnabled.value = undefined
-}
-
 async function fetchRemoteConfig(
   useAuth: boolean,
   signal?: AbortSignal
@@ -44,6 +33,17 @@ async function fetchRemoteConfig(
     return fetch(api.apiURL('/features'), { cache: 'no-store', signal })
   }
   return api.fetchApi('/features', { cache: 'no-store', signal })
+}
+
+export function invalidateRemoteConfig(): void {
+  refreshGeneration++
+  for (const controller of activeRefreshControllers) controller.abort()
+  activeRefreshControllers.clear()
+  window.__CONFIG__ = {}
+  remoteConfig.value = {}
+  remoteConfigErrorStatus.value = null
+  remoteConfigState.value = 'unloaded'
+  cachedLegacyBillingMigrationEnabled.value = undefined
 }
 
 /**

--- a/src/platform/secrets/api/secretsApi.ts
+++ b/src/platform/secrets/api/secretsApi.ts
@@ -15,17 +15,6 @@ import type {
 } from '../types'
 import { SECRET_ERROR_CODES } from '../types'
 
-export class SecretsApiError extends Error {
-  constructor(
-    message: string,
-    public readonly status?: number,
-    public readonly code?: SecretErrorCode
-  ) {
-    super(message)
-    this.name = 'SecretsApiError'
-  }
-}
-
 async function handleResponse<T>(response: Response): Promise<T> {
   if (!response.ok) {
     const errorData = await parseErrorResponse(response)
@@ -80,5 +69,16 @@ export async function deleteSecret(id: string): Promise<void> {
   })
   if (!response.ok) {
     await handleResponse<void>(response)
+  }
+}
+
+export class SecretsApiError extends Error {
+  constructor(
+    message: string,
+    public readonly status?: number,
+    public readonly code?: SecretErrorCode
+  ) {
+    super(message)
+    this.name = 'SecretsApiError'
   }
 }

--- a/src/platform/settings/settingStore.ts
+++ b/src/platform/settings/settingStore.ts
@@ -22,10 +22,6 @@ export const getSettingInfo = (setting: SettingParams) => {
   }
 }
 
-export interface SettingTreeNode extends TreeNode {
-  data?: SettingParams
-}
-
 interface AppliedSetting<TValue> {
   previousValue: TValue
   newValue: TValue
@@ -116,6 +112,10 @@ function settingChangedEvent<K extends keyof Settings>(
         new_value: applied.newValue
       }
     : { setting_id: key }
+}
+
+export interface SettingTreeNode extends TreeNode {
+  data?: SettingParams
 }
 
 export const useSettingStore = defineStore('setting', () => {

--- a/src/platform/settings/types.ts
+++ b/src/platform/settings/types.ts
@@ -21,11 +21,6 @@ type SettingCustomRenderer = (
   attrs?: Record<string, unknown>
 ) => HTMLElement
 
-export interface SettingOption {
-  text: string
-  value?: string | number
-}
-
 type SettingTelemetryOptions =
   | {
       trackChanges: false
@@ -35,6 +30,11 @@ type SettingTelemetryOptions =
       trackChanges?: true
       includeValues?: boolean
     }
+
+export interface SettingOption {
+  text: string
+  value?: string | number
+}
 
 export interface SettingParams<TValue = unknown> extends FormItem {
   id: keyof Settings

--- a/src/platform/surveys/useSurveyEligibility.ts
+++ b/src/platform/surveys/useSurveyEligibility.ts
@@ -6,6 +6,11 @@ import { isCloud, isDesktop, isNightly } from '@/platform/distribution/types'
 
 import { useFeatureUsageTracker } from './useFeatureUsageTracker'
 
+interface SurveyState {
+  optedOut: boolean
+  seenSurveys: Record<string, number>
+}
+
 export interface FeatureSurveyConfig {
   /** Feature identifier. Must remain static after initialization. */
   featureId: string
@@ -20,11 +25,6 @@ export interface FeatureSurveyConfig {
    *   when to open the survey — the global controller ignores it.
    */
   presentation?: 'floating' | 'inline-cta'
-}
-
-interface SurveyState {
-  optedOut: boolean
-  seenSurveys: Record<string, number>
 }
 
 const STORAGE_KEY = 'Comfy.SurveyState'

--- a/src/platform/tasks/services/taskService.ts
+++ b/src/platform/tasks/services/taskService.ts
@@ -41,16 +41,6 @@ const zTaskResponse = z.object({
   completed_at: z.string().datetime().optional()
 })
 
-export type TaskResponse = z.infer<typeof zTaskResponse>
-
-/**
- * Identifier for a background task tracked by the `/tasks` API.
- *
- * Backed by `TaskResponse.id` which is `z.string().uuid()`. This alias names
- * that primitive at use sites without changing structural typing.
- */
-export type TaskId = string
-
 function createTaskService() {
   async function getTask(taskId: TaskId): Promise<TaskResponse> {
     const res = await api.fetchApi(`${TASKS_ENDPOINT}/${taskId}`)
@@ -74,5 +64,15 @@ function createTaskService() {
 
   return { getTask }
 }
+
+export type TaskResponse = z.infer<typeof zTaskResponse>
+
+/**
+ * Identifier for a background task tracked by the `/tasks` API.
+ *
+ * Backed by `TaskResponse.id` which is `z.string().uuid()`. This alias names
+ * that primitive at use sites without changing structural typing.
+ */
+export type TaskId = string
 
 export const taskService = createTaskService()

--- a/src/platform/telemetry/datadogRumBeforeSend.ts
+++ b/src/platform/telemetry/datadogRumBeforeSend.ts
@@ -16,23 +16,6 @@ type RumErrorOrigin =
   | { origin: 'extension'; extension: string }
   | { origin: 'third_party' }
 
-export function classifyRumErrorOrigin(stack?: string): RumErrorOrigin {
-  if (!stack) return { origin: 'third_party' }
-
-  for (const line of stack.split('\n')) {
-    const extensionFolder = /\/extensions\/([^/?#]+)\//.exec(line)?.[1]
-    if (extensionFolder) {
-      return FIRST_PARTY_EXTENSION_FOLDERS.has(extensionFolder)
-        ? { origin: 'first_party' }
-        : { origin: 'extension', extension: extensionFolder }
-    }
-
-    if (line.includes('/assets/')) return { origin: 'first_party' }
-  }
-
-  return { origin: 'third_party' }
-}
-
 function shouldKeepRumEvent(event: Parameters<RumBeforeSend>[0]): boolean {
   if (event.type !== 'error') return true
 
@@ -63,6 +46,23 @@ function tagRumErrorOrigin(event: RumErrorEvent): void {
   } catch {
     return
   }
+}
+
+export function classifyRumErrorOrigin(stack?: string): RumErrorOrigin {
+  if (!stack) return { origin: 'third_party' }
+
+  for (const line of stack.split('\n')) {
+    const extensionFolder = /\/extensions\/([^/?#]+)\//.exec(line)?.[1]
+    if (extensionFolder) {
+      return FIRST_PARTY_EXTENSION_FOLDERS.has(extensionFolder)
+        ? { origin: 'first_party' }
+        : { origin: 'extension', extension: extensionFolder }
+    }
+
+    if (line.includes('/assets/')) return { origin: 'first_party' }
+  }
+
+  return { origin: 'third_party' }
 }
 
 export const rumBeforeSend: RumBeforeSend = (event) => {

--- a/src/platform/telemetry/reportError.ts
+++ b/src/platform/telemetry/reportError.ts
@@ -3,6 +3,11 @@ import { captureException, isEnabled as isSentryEnabled } from '@sentry/vue'
 
 import { toError } from '@/utils/errorUtil'
 
+interface PendingReport {
+  error: Error
+  options: ReportErrorOptions
+}
+
 export interface ReportErrorOptions {
   /**
    * Stable machine-readable slug for this failure mode. Lands as the
@@ -13,11 +18,6 @@ export interface ReportErrorOptions {
   tags?: Record<string, string | number | boolean | undefined>
   context?: Record<string, unknown>
   level?: 'warning' | 'error'
-}
-
-interface PendingReport {
-  error: Error
-  options: ReportErrorOptions
 }
 
 /**

--- a/src/platform/telemetry/types.ts
+++ b/src/platform/telemetry/types.ts
@@ -17,6 +17,140 @@ import type { BillingCycle } from '@/platform/cloud/subscription/utils/subscript
 import type { AuditLog } from '@/services/customerEventsService'
 import type { AppMode } from '@/utils/appMode'
 
+interface ExecutionOutcomeBaseMetadata extends WorkflowExecutionIntent {
+  startTime: number
+  submissionAcceptedAt?: number
+  executionStartedAt?: number
+  endTime: number
+  workflowContext?: WorkflowExecutionContext
+}
+
+type ShareFlowStep =
+  | 'dialog_opened'
+  | 'save_prompted'
+  | 'link_created'
+  | 'link_copied'
+
+interface EcommerceItemMetadata {
+  item_name: string
+  item_category: string
+  item_variant?: string
+  price: number
+  quantity: number
+}
+interface EcommerceMetadata {
+  currency: string
+  value: number
+  items: EcommerceItemMetadata[]
+}
+
+type BillingFailureCategory =
+  | 'validation'
+  | 'network'
+  | 'api_rejected'
+  | 'provider_decline'
+  | 'redirect'
+  | 'poll_timeout'
+  | 'stale_operation'
+  | 'rendering'
+  | 'unknown'
+
+type BillingErrorCode =
+  | 'downgrade_not_allowed'
+  | 'member_removal_failed'
+  | 'missing_checkout_response'
+  | 'missing_payment_method_url'
+  | 'payment_popup_blocked'
+  | 'reactivation_not_confirmed'
+  | 'reactivation_amount_changed'
+
+type BillingStarted = {
+  stage: 'started'
+  outcome: 'pending'
+}
+
+type BillingSucceeded = {
+  stage: 'succeeded'
+  outcome: 'success'
+}
+
+type BillingFailed = BillingFailure & {
+  stage: 'failed'
+  outcome: 'failure'
+}
+
+type BillingTimedOut = {
+  stage: 'timeout'
+  outcome: 'failure'
+  failure_category: 'poll_timeout'
+}
+
+type SubscriptionCheckoutBillingEvent = {
+  operation: 'subscription_checkout'
+  billing_op_id?: string
+  tier?: SubscriptionCheckoutTier
+  cycle?: BillingCycle
+  checkout_type?: SubscriptionCheckoutType
+  payment_intent_source?: PaymentIntentSource
+  /**
+   * Client-observed end-to-end wall time from this attempt's canonical
+   * `started` event through to this terminal event.
+   */
+  duration_ms?: number
+} & (BillingStarted | BillingSucceeded | BillingFailed)
+
+type BillingOperationBillingEvent = {
+  operation: 'operation'
+  /** Absent when the initiating call itself failed, before the backend returned one to poll. */
+  billing_op_id?: string
+  operation_type: 'subscription' | 'topup' | 'cancel'
+  tier?: SubscriptionCheckoutTier
+  cycle?: BillingCycle
+  checkout_type?: SubscriptionCheckoutType
+  payment_intent_source?: PaymentIntentSource
+  /**
+   * Client-observed end-to-end wall time from this attempt's canonical
+   * `started` event through to this terminal event, including the
+   * initiating API call's latency (not just the poll-observation window).
+   * On `timeout` this is how long the client watched, not the operation's
+   * true duration.
+   */
+  duration_ms?: number
+} & (BillingStarted | BillingSucceeded | BillingFailed | BillingTimedOut)
+
+type ResubscribeBillingEvent = {
+  operation: 'resubscribe'
+  source: ResubscribeClickMetadata['source']
+  payment_intent_source?: PaymentIntentSource
+} & (BillingStarted | BillingSucceeded | BillingFailed)
+
+type TopupBillingEvent = {
+  operation: 'topup'
+  billing_op_id?: string
+  /**
+   * Client-observed end-to-end wall time from this attempt's canonical
+   * `started` event through to this terminal event.
+   */
+  duration_ms?: number
+} & (BillingStarted | BillingSucceeded | BillingFailed)
+
+type DowngradeToPersonalBillingEvent = {
+  operation: 'downgrade_to_personal'
+  member_removal_count: number
+  member_removal_failures: number
+  target_tier?: TierKey
+  /**
+   * Client-observed end-to-end wall time from this attempt's canonical
+   * `started` event through to this terminal event.
+   */
+  duration_ms?: number
+} & (BillingStarted | BillingSucceeded | BillingFailed)
+
+type BillingTelemetryEventNameFor<T extends BillingTelemetryEvent> =
+  T extends BillingTelemetryEvent
+    ? `billing.${T['operation']}.${T['stage']}`
+    : never
+
 export type AuthMethod = 'email' | 'google' | 'github'
 
 export type PaymentIntentSource =
@@ -36,6 +170,7 @@ export type PaymentIntentSource =
   | 'free_tier_quota'
 
 export type SubscriptionCheckoutType = 'new' | 'change'
+
 export type SubscriptionCheckoutTier = TierKey | 'team'
 
 /**
@@ -258,14 +393,6 @@ export type WorkflowExecutionFailureReason =
   | 'execution_failed'
   | 'execution_interrupted'
 
-interface ExecutionOutcomeBaseMetadata extends WorkflowExecutionIntent {
-  startTime: number
-  submissionAcceptedAt?: number
-  executionStartedAt?: number
-  endTime: number
-  workflowContext?: WorkflowExecutionContext
-}
-
 export type ExecutionOutcomeMetadata = ExecutionOutcomeBaseMetadata &
   (
     | {
@@ -358,12 +485,6 @@ export interface WorkflowSavedMetadata {
 export interface DefaultViewSetMetadata {
   default_view: 'app' | 'graph'
 }
-
-type ShareFlowStep =
-  | 'dialog_opened'
-  | 'save_prompted'
-  | 'link_created'
-  | 'link_copied'
 
 export interface ShareFlowMetadata {
   step: ShareFlowStep
@@ -678,20 +799,6 @@ export interface BeginCheckoutMetadata
   payment_intent_source?: PaymentIntentSource
 }
 
-interface EcommerceItemMetadata {
-  item_name: string
-  item_category: string
-  item_variant?: string
-  price: number
-  quantity: number
-}
-
-interface EcommerceMetadata {
-  currency: string
-  value: number
-  items: EcommerceItemMetadata[]
-}
-
 export interface SubscriptionSuccessMetadata extends Record<string, unknown> {
   user_id?: string
   checkout_attempt_id?: string
@@ -727,112 +834,10 @@ export interface WorkspaceInviteFailedMetadata extends Record<string, unknown> {
   failed_count: number
 }
 
-type BillingFailureCategory =
-  | 'validation'
-  | 'network'
-  | 'api_rejected'
-  | 'provider_decline'
-  | 'redirect'
-  | 'poll_timeout'
-  | 'stale_operation'
-  | 'rendering'
-  | 'unknown'
-
-type BillingErrorCode =
-  | 'downgrade_not_allowed'
-  | 'member_removal_failed'
-  | 'missing_checkout_response'
-  | 'missing_payment_method_url'
-  | 'payment_popup_blocked'
-  | 'reactivation_not_confirmed'
-  | 'reactivation_amount_changed'
-
 export interface BillingFailure {
   failure_category: BillingFailureCategory
   error_code?: BillingErrorCode
 }
-
-type BillingStarted = {
-  stage: 'started'
-  outcome: 'pending'
-}
-
-type BillingSucceeded = {
-  stage: 'succeeded'
-  outcome: 'success'
-}
-
-type BillingFailed = BillingFailure & {
-  stage: 'failed'
-  outcome: 'failure'
-}
-
-type BillingTimedOut = {
-  stage: 'timeout'
-  outcome: 'failure'
-  failure_category: 'poll_timeout'
-}
-
-type SubscriptionCheckoutBillingEvent = {
-  operation: 'subscription_checkout'
-  billing_op_id?: string
-  tier?: SubscriptionCheckoutTier
-  cycle?: BillingCycle
-  checkout_type?: SubscriptionCheckoutType
-  payment_intent_source?: PaymentIntentSource
-  /**
-   * Client-observed end-to-end wall time from this attempt's canonical
-   * `started` event through to this terminal event.
-   */
-  duration_ms?: number
-} & (BillingStarted | BillingSucceeded | BillingFailed)
-
-type BillingOperationBillingEvent = {
-  operation: 'operation'
-  /** Absent when the initiating call itself failed, before the backend returned one to poll. */
-  billing_op_id?: string
-  operation_type: 'subscription' | 'topup' | 'cancel'
-  tier?: SubscriptionCheckoutTier
-  cycle?: BillingCycle
-  checkout_type?: SubscriptionCheckoutType
-  payment_intent_source?: PaymentIntentSource
-  /**
-   * Client-observed end-to-end wall time from this attempt's canonical
-   * `started` event through to this terminal event, including the
-   * initiating API call's latency (not just the poll-observation window).
-   * On `timeout` this is how long the client watched, not the operation's
-   * true duration.
-   */
-  duration_ms?: number
-} & (BillingStarted | BillingSucceeded | BillingFailed | BillingTimedOut)
-
-type ResubscribeBillingEvent = {
-  operation: 'resubscribe'
-  source: ResubscribeClickMetadata['source']
-  payment_intent_source?: PaymentIntentSource
-} & (BillingStarted | BillingSucceeded | BillingFailed)
-
-type TopupBillingEvent = {
-  operation: 'topup'
-  billing_op_id?: string
-  /**
-   * Client-observed end-to-end wall time from this attempt's canonical
-   * `started` event through to this terminal event.
-   */
-  duration_ms?: number
-} & (BillingStarted | BillingSucceeded | BillingFailed)
-
-type DowngradeToPersonalBillingEvent = {
-  operation: 'downgrade_to_personal'
-  member_removal_count: number
-  member_removal_failures: number
-  target_tier?: TierKey
-  /**
-   * Client-observed end-to-end wall time from this attempt's canonical
-   * `started` event through to this terminal event.
-   */
-  duration_ms?: number
-} & (BillingStarted | BillingSucceeded | BillingFailed)
 
 export type BillingTelemetryEvent =
   | SubscriptionCheckoutBillingEvent
@@ -841,59 +846,8 @@ export type BillingTelemetryEvent =
   | TopupBillingEvent
   | DowngradeToPersonalBillingEvent
 
-type BillingTelemetryEventNameFor<T extends BillingTelemetryEvent> =
-  T extends BillingTelemetryEvent
-    ? `billing.${T['operation']}.${T['stage']}`
-    : never
-
 export type BillingTelemetryEventName =
   BillingTelemetryEventNameFor<BillingTelemetryEvent>
-
-export function getBillingTelemetryEventName(
-  event: BillingTelemetryEvent
-): BillingTelemetryEventName {
-  return `billing.${event.operation}.${event.stage}` as BillingTelemetryEventName
-}
-
-export function getBillingTelemetryEventPayload(event: BillingTelemetryEvent) {
-  return {
-    operation: event.operation,
-    stage: event.stage,
-    outcome: event.outcome,
-    ...('billing_op_id' in event &&
-      event.billing_op_id !== undefined && {
-        billing_op_id: event.billing_op_id
-      }),
-    ...('operation_type' in event && {
-      operation_type: event.operation_type
-    }),
-    ...('tier' in event && event.tier !== undefined && { tier: event.tier }),
-    ...('cycle' in event &&
-      event.cycle !== undefined && { cycle: event.cycle }),
-    ...('checkout_type' in event &&
-      event.checkout_type !== undefined && {
-        checkout_type: event.checkout_type
-      }),
-    ...('payment_intent_source' in event &&
-      event.payment_intent_source !== undefined && {
-        payment_intent_source: event.payment_intent_source
-      }),
-    ...('source' in event && { source: event.source }),
-    ...('failure_category' in event && {
-      failure_category: event.failure_category
-    }),
-    ...('error_code' in event &&
-      event.error_code !== undefined && { error_code: event.error_code }),
-    ...('member_removal_count' in event && {
-      member_removal_count: event.member_removal_count,
-      member_removal_failures: event.member_removal_failures
-    }),
-    ...('target_tier' in event &&
-      event.target_tier !== undefined && { target_tier: event.target_tier }),
-    ...('duration_ms' in event &&
-      event.duration_ms !== undefined && { duration_ms: event.duration_ms })
-  }
-}
 
 /**
  * Telemetry provider interface for individual providers.
@@ -1030,6 +984,52 @@ export interface TelemetryProvider {
  * to registered providers using optional chaining.
  */
 export type TelemetryDispatcher = Required<TelemetryProvider>
+
+export function getBillingTelemetryEventName(
+  event: BillingTelemetryEvent
+): BillingTelemetryEventName {
+  return `billing.${event.operation}.${event.stage}` as BillingTelemetryEventName
+}
+
+export function getBillingTelemetryEventPayload(event: BillingTelemetryEvent) {
+  return {
+    operation: event.operation,
+    stage: event.stage,
+    outcome: event.outcome,
+    ...('billing_op_id' in event &&
+      event.billing_op_id !== undefined && {
+        billing_op_id: event.billing_op_id
+      }),
+    ...('operation_type' in event && {
+      operation_type: event.operation_type
+    }),
+    ...('tier' in event && event.tier !== undefined && { tier: event.tier }),
+    ...('cycle' in event &&
+      event.cycle !== undefined && { cycle: event.cycle }),
+    ...('checkout_type' in event &&
+      event.checkout_type !== undefined && {
+        checkout_type: event.checkout_type
+      }),
+    ...('payment_intent_source' in event &&
+      event.payment_intent_source !== undefined && {
+        payment_intent_source: event.payment_intent_source
+      }),
+    ...('source' in event && { source: event.source }),
+    ...('failure_category' in event && {
+      failure_category: event.failure_category
+    }),
+    ...('error_code' in event &&
+      event.error_code !== undefined && { error_code: event.error_code }),
+    ...('member_removal_count' in event && {
+      member_removal_count: event.member_removal_count,
+      member_removal_failures: event.member_removal_failures
+    }),
+    ...('target_tier' in event &&
+      event.target_tier !== undefined && { target_tier: event.target_tier }),
+    ...('duration_ms' in event &&
+      event.duration_ms !== undefined && { duration_ms: event.duration_ms })
+  }
+}
 
 /**
  * Telemetry event constants
@@ -1204,15 +1204,6 @@ const executionTriggerSources = [
 
 export type ExecutionTriggerSource = (typeof executionTriggerSources)[number]
 
-export function normalizeExecutionTriggerSource(
-  value: unknown
-): ExecutionTriggerSource {
-  return (
-    executionTriggerSources.find((triggerSource) => triggerSource === value) ??
-    'unknown'
-  )
-}
-
 /**
  * Union type for all possible telemetry event properties
  */
@@ -1257,3 +1248,12 @@ export type TelemetryEventProperties =
   | SubscriptionSuccessMetadata
   | WorkspaceInviteFailedMetadata
   | BillingTelemetryEvent
+
+export function normalizeExecutionTriggerSource(
+  value: unknown
+): ExecutionTriggerSource {
+  return (
+    executionTriggerSources.find((triggerSource) => triggerSource === value) ??
+    'unknown'
+  )
+}

--- a/src/platform/updates/common/releaseService.ts
+++ b/src/platform/updates/common/releaseService.ts
@@ -6,12 +6,12 @@ import { getComfyApiBaseUrl } from '@/config/comfyApi'
 import type { components, operations } from '@/types/comfyRegistryTypes'
 import { isAbortError } from '@/utils/typeGuardUtil'
 
-// Use generated types from OpenAPI spec
-export type ReleaseNote = components['schemas']['ReleaseNote']
 type GetReleasesParams = operations['getReleaseNotes']['parameters']['query']
-
 // Use generated error response type
 type ErrorResponse = components['schemas']['ErrorResponse']
+
+// Use generated types from OpenAPI spec
+export type ReleaseNote = components['schemas']['ReleaseNote']
 
 const releaseApiClient = axios.create({
   baseURL: getComfyApiBaseUrl(),

--- a/src/platform/workflow/core/utils/workflowFlattening.ts
+++ b/src/platform/workflow/core/utils/workflowFlattening.ts
@@ -1,20 +1,5 @@
 import type { SerializedNodeId } from '@/types/nodeId'
 
-export interface FlattenableWorkflowNode {
-  id: SerializedNodeId
-  type: string
-  mode?: number
-  widgets_values?: readonly unknown[] | Record<string, unknown>
-  properties?: Record<string, unknown>
-}
-
-export interface FlattenableWorkflowGraph {
-  nodes?: readonly FlattenableWorkflowNode[]
-  definitions?: {
-    subgraphs?: readonly unknown[]
-  }
-}
-
 interface FlattenableSubgraphDefinition {
   id: string
   name: string
@@ -56,6 +41,21 @@ function isSubgraphDefinition(
     'inputNode' in candidate &&
     'outputNode' in candidate
   )
+}
+
+export interface FlattenableWorkflowNode {
+  id: SerializedNodeId
+  type: string
+  mode?: number
+  widgets_values?: readonly unknown[] | Record<string, unknown>
+  properties?: Record<string, unknown>
+}
+
+export interface FlattenableWorkflowGraph {
+  nodes?: readonly FlattenableWorkflowNode[]
+  definitions?: {
+    subgraphs?: readonly unknown[]
+  }
 }
 
 /**

--- a/src/platform/workflow/management/stores/comfyWorkflow.ts
+++ b/src/platform/workflow/management/stores/comfyWorkflow.ts
@@ -12,13 +12,13 @@ import type { SerializedNodeId } from '@/types/nodeId'
 import type { AppMode } from '@/utils/appMode'
 import type { WidgetId } from '@/types/widgetId'
 
+type LinearInputId = WidgetId | NodeLocatorId | SerializedNodeId
+
+type LinearOutputNodeId = SerializedNodeId
 export interface InputWidgetConfig {
   height?: number
   description?: string
 }
-
-type LinearInputId = WidgetId | NodeLocatorId | SerializedNodeId
-type LinearOutputNodeId = SerializedNodeId
 export type LinearInput = [LinearInputId, string, InputWidgetConfig?]
 
 export interface LinearData {
@@ -30,6 +30,15 @@ export interface PendingWarnings {
   missingNodeTypes?: MissingNodeType[]
   missingModelCandidates?: MissingModelCandidate[]
   missingMediaCandidates?: MissingMediaCandidate[]
+}
+
+export interface LoadedComfyWorkflow extends ComfyWorkflow {
+  isLoaded: true
+  originalContent: string
+  content: string
+  changeTracker: ChangeTracker
+  initialState: ComfyWorkflowJSON
+  activeState: ComfyWorkflowJSON
 }
 
 export class ComfyWorkflow extends UserFile {
@@ -203,13 +212,4 @@ export class ComfyWorkflow extends UserFile {
       defaultValue: this.filename
     })
   }
-}
-
-export interface LoadedComfyWorkflow extends ComfyWorkflow {
-  isLoaded: true
-  originalContent: string
-  content: string
-  changeTracker: ChangeTracker
-  initialState: ComfyWorkflowJSON
-  activeState: ComfyWorkflowJSON
 }

--- a/src/platform/workflow/persistence/base/storageIO.ts
+++ b/src/platform/workflow/persistence/base/storageIO.ts
@@ -17,13 +17,6 @@ let storageAvailable = true
 let workflowWritesBlocked = false
 const pendingPersistenceFlushes = new Set<() => void>()
 
-export function registerWorkflowPersistenceFlush(
-  flush: () => void
-): () => void {
-  pendingPersistenceFlushes.add(flush)
-  return () => pendingPersistenceFlushes.delete(flush)
-}
-
 function flushPendingWorkflowPersistence(): void {
   for (const flush of pendingPersistenceFlushes) {
     try {
@@ -32,14 +25,6 @@ function flushPendingWorkflowPersistence(): void {
       console.warn('Failed to flush pending workflow persistence', error)
     }
   }
-}
-
-export function isStorageAvailable(): boolean {
-  return storageAvailable && !workflowWritesBlocked
-}
-
-export function markStorageUnavailable(): void {
-  storageAvailable = false
 }
 
 function isQuotaExceeded(error: unknown): boolean {
@@ -62,6 +47,128 @@ function isValidIndex(value: unknown): value is DraftIndexV2 {
     typeof obj.entries === 'object' &&
     obj.entries !== null
   )
+}
+
+/**
+ * Searches sessionStorage for a pointer matching the target workspaceId
+ * when the exact clientId key has no entry (e.g. clientId changed after reload).
+ * Migrates the found pointer to the new clientId key.
+ */
+function findAndMigratePointer<T extends { workspaceId: string }>(
+  newKey: string,
+  prefix: string,
+  targetWorkspaceId: string
+): T | null {
+  for (let i = 0; i < sessionStorage.length; i++) {
+    const storageKey = sessionStorage.key(i)
+    if (!storageKey?.startsWith(prefix) || storageKey === newKey) continue
+
+    const json = sessionStorage.getItem(storageKey)
+    if (!json) continue
+
+    try {
+      const pointer = JSON.parse(json) as T
+      if (pointer.workspaceId === targetWorkspaceId) {
+        sessionStorage.setItem(newKey, json)
+        sessionStorage.removeItem(storageKey)
+        return pointer
+      }
+    } catch {
+      continue
+    }
+  }
+  return null
+}
+
+/**
+ * Reads a session pointer by clientId with workspace-based fallback.
+ * Validates workspace on exact match and removes stale cross-workspace pointers.
+ * If no valid entry exists, searches for any pointer matching the target
+ * workspaceId and migrates it to the new key.
+ */
+function readSessionPointer<T extends { workspaceId: string }>(
+  key: string,
+  prefix: string,
+  targetWorkspaceId?: string
+): T | null {
+  try {
+    const json = sessionStorage.getItem(key)
+    if (json) {
+      const pointer = JSON.parse(json) as T
+      if (targetWorkspaceId && pointer.workspaceId !== targetWorkspaceId) {
+        sessionStorage.removeItem(key)
+      } else {
+        return pointer
+      }
+    }
+
+    if (targetWorkspaceId) {
+      return findAndMigratePointer<T>(key, prefix, targetWorkspaceId)
+    }
+
+    return null
+  } catch {
+    return null
+  }
+}
+
+function hasWorkspaceId(obj: Record<string, unknown>): boolean {
+  return typeof obj.workspaceId === 'string'
+}
+
+function isValidActivePathPointer(value: unknown): value is ActivePathPointer {
+  if (typeof value !== 'object' || value === null) return false
+  const obj = value as Record<string, unknown>
+  return hasWorkspaceId(obj) && typeof obj.path === 'string'
+}
+
+function isValidOpenPathsPointer(value: unknown): value is OpenPathsPointer {
+  if (typeof value !== 'object' || value === null) return false
+  const obj = value as Record<string, unknown>
+  return (
+    hasWorkspaceId(obj) &&
+    Array.isArray(obj.paths) &&
+    typeof obj.activeIndex === 'number'
+  )
+}
+
+function readLocalPointer<T>(
+  key: string,
+  validate: (value: unknown) => value is T
+): T | null {
+  try {
+    const json = localStorage.getItem(key)
+    if (!json) return null
+    const parsed = JSON.parse(json)
+    return validate(parsed) ? parsed : null
+  } catch {
+    return null
+  }
+}
+
+function writeStorage(storage: Storage, key: string, value: string): void {
+  if (!storageAvailable || workflowWritesBlocked) return
+
+  try {
+    storage.setItem(key, value)
+  } catch {
+    // Best effort — silently degrade when storage is full or unavailable
+  }
+}
+
+export function registerWorkflowPersistenceFlush(
+  flush: () => void
+): () => void {
+  pendingPersistenceFlushes.add(flush)
+  return () => pendingPersistenceFlushes.delete(flush)
+}
+
+export function isStorageAvailable(): boolean {
+  return storageAvailable && !workflowWritesBlocked
+}
+
+export function markStorageUnavailable(): void {
+  storageAvailable = false
 }
 
 /**
@@ -205,69 +312,6 @@ export function deleteOrphanPayloads(
 }
 
 /**
- * Searches sessionStorage for a pointer matching the target workspaceId
- * when the exact clientId key has no entry (e.g. clientId changed after reload).
- * Migrates the found pointer to the new clientId key.
- */
-function findAndMigratePointer<T extends { workspaceId: string }>(
-  newKey: string,
-  prefix: string,
-  targetWorkspaceId: string
-): T | null {
-  for (let i = 0; i < sessionStorage.length; i++) {
-    const storageKey = sessionStorage.key(i)
-    if (!storageKey?.startsWith(prefix) || storageKey === newKey) continue
-
-    const json = sessionStorage.getItem(storageKey)
-    if (!json) continue
-
-    try {
-      const pointer = JSON.parse(json) as T
-      if (pointer.workspaceId === targetWorkspaceId) {
-        sessionStorage.setItem(newKey, json)
-        sessionStorage.removeItem(storageKey)
-        return pointer
-      }
-    } catch {
-      continue
-    }
-  }
-  return null
-}
-
-/**
- * Reads a session pointer by clientId with workspace-based fallback.
- * Validates workspace on exact match and removes stale cross-workspace pointers.
- * If no valid entry exists, searches for any pointer matching the target
- * workspaceId and migrates it to the new key.
- */
-function readSessionPointer<T extends { workspaceId: string }>(
-  key: string,
-  prefix: string,
-  targetWorkspaceId?: string
-): T | null {
-  try {
-    const json = sessionStorage.getItem(key)
-    if (json) {
-      const pointer = JSON.parse(json) as T
-      if (targetWorkspaceId && pointer.workspaceId !== targetWorkspaceId) {
-        sessionStorage.removeItem(key)
-      } else {
-        return pointer
-      }
-    }
-
-    if (targetWorkspaceId) {
-      return findAndMigratePointer<T>(key, prefix, targetWorkspaceId)
-    }
-
-    return null
-  } catch {
-    return null
-  }
-}
-
-/**
  * Reads the active path pointer from sessionStorage.
  * Falls back to workspace-based search when clientId changes after reload,
  * then to localStorage when sessionStorage is empty (browser restart).
@@ -357,50 +401,6 @@ export function writeOpenPaths(
     StorageKeys.lastOpenPaths(pointer.workspaceId),
     json
   )
-}
-
-function hasWorkspaceId(obj: Record<string, unknown>): boolean {
-  return typeof obj.workspaceId === 'string'
-}
-
-function isValidActivePathPointer(value: unknown): value is ActivePathPointer {
-  if (typeof value !== 'object' || value === null) return false
-  const obj = value as Record<string, unknown>
-  return hasWorkspaceId(obj) && typeof obj.path === 'string'
-}
-
-function isValidOpenPathsPointer(value: unknown): value is OpenPathsPointer {
-  if (typeof value !== 'object' || value === null) return false
-  const obj = value as Record<string, unknown>
-  return (
-    hasWorkspaceId(obj) &&
-    Array.isArray(obj.paths) &&
-    typeof obj.activeIndex === 'number'
-  )
-}
-
-function readLocalPointer<T>(
-  key: string,
-  validate: (value: unknown) => value is T
-): T | null {
-  try {
-    const json = localStorage.getItem(key)
-    if (!json) return null
-    const parsed = JSON.parse(json)
-    return validate(parsed) ? parsed : null
-  } catch {
-    return null
-  }
-}
-
-function writeStorage(storage: Storage, key: string, value: string): void {
-  if (!storageAvailable || workflowWritesBlocked) return
-
-  try {
-    storage.setItem(key, value)
-  } catch {
-    // Best effort — silently degrade when storage is full or unavailable
-  }
 }
 
 const legacyLocalRestoreKeys = [

--- a/src/platform/workflow/persistence/migration/migrateV1toV2.ts
+++ b/src/platform/workflow/persistence/migration/migrateV1toV2.ts
@@ -38,14 +38,6 @@ const V1_KEYS = {
 }
 
 /**
- * Checks if V2 migration has been completed for the current workspace.
- */
-export function isV2MigrationComplete(workspaceId: string): boolean {
-  const v2Index = readIndex(workspaceId)
-  return v2Index !== null
-}
-
-/**
  * Reads V1 drafts from localStorage.
  */
 function readV1Drafts(
@@ -64,6 +56,44 @@ function readV1Drafts(
   } catch {
     return null
   }
+}
+
+/**
+ * Migrates V1 tab state (open paths + active index) to V2 format.
+ * V1 stored these in localStorage via setStorageValue fallback.
+ * V2 uses sessionStorage keyed by clientId.
+ */
+function migrateV1TabState(workspaceId: string, clientId?: string): void {
+  if (!clientId) return
+
+  try {
+    const pathsJson = localStorage.getItem(V1_KEYS.openPaths)
+    if (!pathsJson) return
+
+    const paths = JSON.parse(pathsJson)
+    if (!Array.isArray(paths) || paths.length === 0) return
+
+    const indexJson = localStorage.getItem(V1_KEYS.activeIndex)
+    let activeIndex = 0
+    if (indexJson !== null) {
+      const parsed = JSON.parse(indexJson)
+      if (typeof parsed === 'number' && Number.isFinite(parsed)) {
+        activeIndex = Math.min(Math.max(0, parsed), paths.length - 1)
+      }
+    }
+
+    writeOpenPaths(clientId, { workspaceId, paths, activeIndex })
+  } catch {
+    // Best effort - don't block draft migration on tab state errors
+  }
+}
+
+/**
+ * Checks if V2 migration has been completed for the current workspace.
+ */
+export function isV2MigrationComplete(workspaceId: string): boolean {
+  const v2Index = readIndex(workspaceId)
+  return v2Index !== null
 }
 
 /**
@@ -136,36 +166,6 @@ export function migrateV1toV2(
     console.warn(`[V2 Migration] Migrated ${migrated} drafts from V1 to V2`)
   }
   return migrated
-}
-
-/**
- * Migrates V1 tab state (open paths + active index) to V2 format.
- * V1 stored these in localStorage via setStorageValue fallback.
- * V2 uses sessionStorage keyed by clientId.
- */
-function migrateV1TabState(workspaceId: string, clientId?: string): void {
-  if (!clientId) return
-
-  try {
-    const pathsJson = localStorage.getItem(V1_KEYS.openPaths)
-    if (!pathsJson) return
-
-    const paths = JSON.parse(pathsJson)
-    if (!Array.isArray(paths) || paths.length === 0) return
-
-    const indexJson = localStorage.getItem(V1_KEYS.activeIndex)
-    let activeIndex = 0
-    if (indexJson !== null) {
-      const parsed = JSON.parse(indexJson)
-      if (typeof parsed === 'number' && Number.isFinite(parsed)) {
-        activeIndex = Math.min(Math.max(0, parsed), paths.length - 1)
-      }
-    }
-
-    writeOpenPaths(clientId, { workspaceId, paths, activeIndex })
-  } catch {
-    // Best effort - don't block draft migration on tab state errors
-  }
 }
 
 /**

--- a/src/platform/workflow/sharing/composables/lazyShareDialog.ts
+++ b/src/platform/workflow/sharing/composables/lazyShareDialog.ts
@@ -1,3 +1,7 @@
+function importShareDialog() {
+  return import('@/platform/workflow/sharing/composables/useShareDialog')
+}
+
 export function prefetchShareDialog() {
   importShareDialog().catch((error) => {
     console.error(error)
@@ -7,8 +11,4 @@ export function prefetchShareDialog() {
 export async function openShareDialog() {
   const { useShareDialog } = await importShareDialog()
   useShareDialog().show()
-}
-
-function importShareDialog() {
-  return import('@/platform/workflow/sharing/composables/useShareDialog')
 }

--- a/src/platform/workflow/sharing/composables/useSharedWorkflowUrlLoader.ts
+++ b/src/platform/workflow/sharing/composables/useSharedWorkflowUrlLoader.ts
@@ -20,19 +20,19 @@ import { app } from '@/scripts/app'
 import { useDialogService } from '@/services/dialogService'
 import { useDialogStore } from '@/stores/dialogStore'
 
-export type SharedWorkflowUrlLoadStatus =
-  | 'not-present'
-  | 'loaded'
-  | 'loaded-without-assets'
-  | 'cancelled'
-  | 'failed'
-
 type DialogResult =
   | { action: 'copy-and-open'; payload: SharedWorkflowPayload }
   | { action: 'open-only'; payload: SharedWorkflowPayload }
   | { action: 'cancel' }
 
 type OpeningAction = Exclude<DialogResult['action'], 'cancel'>
+
+export type SharedWorkflowUrlLoadStatus =
+  | 'not-present'
+  | 'loaded'
+  | 'loaded-without-assets'
+  | 'cancelled'
+  | 'failed'
 
 const OPEN_SHARED_WORKFLOW_DIALOG_KEY = 'open-shared-workflow'
 

--- a/src/platform/workflow/sharing/services/workflowShareService.ts
+++ b/src/platform/workflow/sharing/services/workflowShareService.ts
@@ -21,21 +21,6 @@ import {
 import { api } from '@/scripts/api'
 import { app } from '@/scripts/app'
 
-class SharedWorkflowLoadError extends Error {
-  readonly status: number | null
-
-  constructor(status: number | null, message?: string) {
-    super(message ?? `Failed to load shared workflow: ${status ?? 'unknown'}`)
-    this.name = 'SharedWorkflowLoadError'
-    this.status = status
-  }
-
-  get isRetryable(): boolean {
-    if (this.status === null) return true
-    return this.status >= 500 || this.status === 408 || this.status === 429
-  }
-}
-
 function mapApiThumbnailType(
   value: 'image' | 'video' | 'image_comparison' | null | undefined
 ): ThumbnailType | undefined {
@@ -129,6 +114,21 @@ function decodeSharedWorkflowPayload(
     publishedAt: r.publish_time ? parsePublishedAt(r.publish_time) : null,
     workflowJson: r.workflow_json as ComfyWorkflowJSON,
     assets: r.assets
+  }
+}
+
+class SharedWorkflowLoadError extends Error {
+  readonly status: number | null
+
+  constructor(status: number | null, message?: string) {
+    super(message ?? `Failed to load shared workflow: ${status ?? 'unknown'}`)
+    this.name = 'SharedWorkflowLoadError'
+    this.status = status
+  }
+
+  get isRetryable(): boolean {
+    if (this.status === null) return true
+    return this.status >= 500 || this.status === 408 || this.status === 429
   }
 }
 

--- a/src/platform/workflow/templates/types/template.ts
+++ b/src/platform/workflow/templates/types/template.ts
@@ -69,14 +69,6 @@ export interface TemplateInfo {
   logos?: LogoInfo[]
 }
 
-export enum TemplateIncludeOnDistributionEnum {
-  Cloud = 'cloud',
-  Local = 'local',
-  Desktop = 'desktop',
-  Mac = 'mac',
-  Windows = 'windows'
-}
-
 export interface WorkflowTemplates {
   moduleName: string
   templates: TemplateInfo[]
@@ -95,3 +87,11 @@ export interface TemplateGroup {
 }
 
 export type TemplateTypeFilter = 'all' | 'nodeGraph' | 'apps'
+
+export enum TemplateIncludeOnDistributionEnum {
+  Cloud = 'cloud',
+  Local = 'local',
+  Desktop = 'desktop',
+  Mac = 'mac',
+  Windows = 'windows'
+}

--- a/src/platform/workflow/templates/utils/templateDisplay.ts
+++ b/src/platform/workflow/templates/utils/templateDisplay.ts
@@ -57,11 +57,6 @@ function toSlug(provider: string): string {
   )
 }
 
-export function getProviderIconClass(provider: string): string | null {
-  const slug = toSlug(provider)
-  return AVAILABLE_ICON_SLUGS.has(slug) ? `icon-mask-[comfy--${slug}]` : null
-}
-
 export interface ProviderBadge {
   provider: string
   iconClass: string | null
@@ -71,6 +66,11 @@ export interface ProviderBadge {
 export interface ProviderBadges {
   visible: ProviderBadge[]
   extraProviders: string[]
+}
+
+export function getProviderIconClass(provider: string): string | null {
+  const slug = toSlug(provider)
+  return AVAILABLE_ICON_SLUGS.has(slug) ? `icon-mask-[comfy--${slug}]` : null
 }
 
 /** Badges shown before the rest collapse into a "+N" chip. */

--- a/src/platform/workspace/api/partnerNodePolicyApi.ts
+++ b/src/platform/workspace/api/partnerNodePolicyApi.ts
@@ -22,32 +22,6 @@ const partnerNodePolicyResponseSchema = z.object({
   providers: z.array(partnerProviderPolicyEntrySchema)
 })
 
-export interface PartnerProvider {
-  id: string
-  displayName: string
-  nodeCategories: readonly string[]
-}
-
-export interface PartnerProviderPolicyEntry {
-  providerId: string
-  enabled: boolean
-}
-
-export interface PartnerNodePolicy {
-  enforcementEnabled: boolean
-  providers: readonly PartnerProviderPolicyEntry[]
-}
-
-export class PartnerNodePolicyApiError extends Error {
-  constructor(
-    public readonly status: number,
-    message: string
-  ) {
-    super(message)
-    this.name = 'PartnerNodePolicyApiError'
-  }
-}
-
 function normalizePolicy(
   data: z.infer<typeof partnerNodePolicyResponseSchema>
 ): PartnerNodePolicy {
@@ -62,6 +36,22 @@ function normalizePolicy(
 
 function throwResponseError(response: Response): never {
   throw new PartnerNodePolicyApiError(response.status, response.statusText)
+}
+
+export interface PartnerProvider {
+  id: string
+  displayName: string
+  nodeCategories: readonly string[]
+}
+
+export interface PartnerProviderPolicyEntry {
+  providerId: string
+  enabled: boolean
+}
+
+export interface PartnerNodePolicy {
+  enforcementEnabled: boolean
+  providers: readonly PartnerProviderPolicyEntry[]
 }
 
 export async function getPartnerProviders(): Promise<PartnerProvider[]> {
@@ -109,4 +99,14 @@ export async function updatePartnerNodePolicy(
   return normalizePolicy(
     partnerNodePolicyResponseSchema.parse(await response.json())
   )
+}
+
+export class PartnerNodePolicyApiError extends Error {
+  constructor(
+    public readonly status: number,
+    message: string
+  ) {
+    super(message)
+    this.name = 'PartnerNodePolicyApiError'
+  }
 }

--- a/src/platform/workspace/api/workspaceApi.ts
+++ b/src/platform/workspace/api/workspaceApi.ts
@@ -50,15 +50,41 @@ import { api } from '@/scripts/api'
 import { useAuthStore } from '@/stores/authStore'
 import type { UserId } from '@/types/authTypes'
 
-export type WorkspaceType = 'personal' | 'team'
-export type WorkspaceRole = 'owner' | 'member'
-export type BillingRail = NonNullable<
-  GeneratedBillingStatusResponse['billing_rail']
->
+type SubscribeBillingCycle = 'monthly' | 'yearly'
+interface PreviewSubscribeRequest extends GeneratedPreviewSubscribeRequest {
+  billing_cycle?: SubscribeBillingCycle
+}
+type SpecRequiredButOmittedByOlderDeployments =
+  | 'max_seats'
+  | 'occupied_seats'
+  | 'team_credit_stop'
 
 export type { WorkspaceWithRole }
 
 export type { ListWorkspacesResponse }
+
+interface GetBillingEventsParams {
+  page?: number
+  limit?: number
+}
+
+export type WorkspaceType = 'personal' | 'team'
+
+export type { PendingInvite }
+
+export type { SubscriptionTier }
+export type { SubscriptionDuration }
+
+export type { Plan }
+export type { BillingPlansResponse }
+export type { TeamCreditStops }
+export type { TeamCreditStopSummary }
+
+export type WorkspaceRole = 'owner' | 'member'
+
+export type BillingRail = NonNullable<
+  GeneratedBillingStatusResponse['billing_rail']
+>
 
 export type Member = GeneratedMember & {
   // Per-member monthly credit limit UI (FE-1277). The cloud OpenAPI carries
@@ -72,21 +98,9 @@ export interface ListMembersParams {
   limit?: number
 }
 
-export type { PendingInvite }
+export type { SubscribeResponse }
 
-export type { SubscriptionTier }
-export type { SubscriptionDuration }
-
-export type { Plan }
-export type { BillingPlansResponse }
-export type { TeamCreditStops }
-export type { TeamCreditStopSummary }
-
-type SubscribeBillingCycle = 'monthly' | 'yearly'
-
-interface PreviewSubscribeRequest extends GeneratedPreviewSubscribeRequest {
-  billing_cycle?: SubscribeBillingCycle
-}
+export type { PreviewSubscribeResponse }
 
 export interface SubscribeOptions {
   returnUrl?: string
@@ -97,25 +111,20 @@ export interface SubscribeOptions {
   prorationAt?: string
 }
 
+export type { BillingStatus }
+
 export interface PreviewSubscribeOptions {
   teamCreditStopId?: string
   billingCycle?: SubscribeBillingCycle
 }
 
-export type { SubscribeResponse }
-
-export type { PreviewSubscribeResponse }
-
 export type BillingSubscriptionStatus = NonNullable<
   GeneratedBillingStatusResponse['subscription_status']
 >
 
-export type { BillingStatus }
-
-type SpecRequiredButOmittedByOlderDeployments =
-  | 'max_seats'
-  | 'occupied_seats'
-  | 'team_credit_stop'
+export type { BillingBalanceResponse }
+export type { CreateTopupResponse }
+export type { BillingOpStatusResponse }
 
 export type BillingStatusResponse = Omit<
   GeneratedBillingStatusResponse,
@@ -132,15 +141,6 @@ export type BillingStatusResponse = Omit<
     scheduled_plan_slug?: string
     change_at?: string
   }
-
-export type { BillingBalanceResponse }
-export type { CreateTopupResponse }
-export type { BillingOpStatusResponse }
-
-interface GetBillingEventsParams {
-  page?: number
-  limit?: number
-}
 
 export class WorkspaceApiError extends Error {
   constructor(

--- a/src/platform/workspace/components/dialogs/settings/WorkspaceActivityContent.test.ts
+++ b/src/platform/workspace/components/dialogs/settings/WorkspaceActivityContent.test.ts
@@ -32,12 +32,6 @@ vi.mock('@/config/comfyApi', () => ({
   getComfyPlatformBaseUrl: () => 'https://platform.test'
 }))
 
-class NoopResizeObserver implements ResizeObserver {
-  observe = vi.fn()
-  unobserve = vi.fn()
-  disconnect = vi.fn()
-}
-
 function renderContent(events: ActivityEvent[] = []) {
   const i18n = createI18n({
     legacy: false,
@@ -48,6 +42,12 @@ function renderContent(events: ActivityEvent[] = []) {
     props: { search: '', events },
     global: { plugins: [i18n] }
   })
+}
+
+class NoopResizeObserver implements ResizeObserver {
+  observe = vi.fn()
+  unobserve = vi.fn()
+  disconnect = vi.fn()
 }
 
 const creditedRow: ActivityEvent = {

--- a/src/platform/workspace/composables/useBillingBanner.ts
+++ b/src/platform/workspace/composables/useBillingBanner.ts
@@ -7,56 +7,6 @@ import { isCloud } from '@/platform/distribution/types'
 import type { BillingStatus } from '@/platform/workspace/api/workspaceApi'
 import { useWorkspaceUI } from '@/platform/workspace/composables/useWorkspaceUI'
 
-export type BillingBannerKind =
-  | 'paused'
-  | 'paymentFailed'
-  | 'outOfCredits'
-  | 'ending'
-
-export interface BillingBannerInputs {
-  billingControlEnabled: boolean
-  v1PaymentRecovery: boolean
-  isTeamPlan: boolean
-  isLoaded: boolean
-  isActiveSubscription: boolean
-  billingStatus: BillingStatus | null
-  hasFunds: boolean | null
-  isCancelled: boolean
-  endDate: string | null
-  canManage: boolean
-  outOfCreditsDismissed: boolean
-}
-
-// The single billing banner slot, in priority order: paused > paymentFailed >
-// outOfCredits > ending. Payment recovery and the existing billing-control
-// notices have independent rollout gates.
-export function deriveBillingBanner(
-  inputs: BillingBannerInputs
-): BillingBannerKind | null {
-  if (!inputs.isTeamPlan || !inputs.isLoaded) {
-    return null
-  }
-
-  if (inputs.v1PaymentRecovery) {
-    if (inputs.billingStatus === 'paused') return 'paused'
-    if (inputs.billingStatus === 'payment_failed' && inputs.canManage) {
-      return 'paymentFailed'
-    }
-  }
-
-  if (!inputs.isActiveSubscription) return null
-  if (!inputs.billingControlEnabled) return null
-
-  if (inputs.hasFunds === false && !inputs.outOfCreditsDismissed) {
-    return 'outOfCredits'
-  }
-  if (inputs.isCancelled && inputs.endDate && inputs.canManage) {
-    return 'ending'
-  }
-
-  return null
-}
-
 function useBillingBannerInternal() {
   const {
     isActiveSubscription,
@@ -109,6 +59,56 @@ function useBillingBannerInternal() {
   }
 
   return { kind, dismiss }
+}
+
+export type BillingBannerKind =
+  | 'paused'
+  | 'paymentFailed'
+  | 'outOfCredits'
+  | 'ending'
+
+export interface BillingBannerInputs {
+  billingControlEnabled: boolean
+  v1PaymentRecovery: boolean
+  isTeamPlan: boolean
+  isLoaded: boolean
+  isActiveSubscription: boolean
+  billingStatus: BillingStatus | null
+  hasFunds: boolean | null
+  isCancelled: boolean
+  endDate: string | null
+  canManage: boolean
+  outOfCreditsDismissed: boolean
+}
+
+// The single billing banner slot, in priority order: paused > paymentFailed >
+// outOfCredits > ending. Payment recovery and the existing billing-control
+// notices have independent rollout gates.
+export function deriveBillingBanner(
+  inputs: BillingBannerInputs
+): BillingBannerKind | null {
+  if (!inputs.isTeamPlan || !inputs.isLoaded) {
+    return null
+  }
+
+  if (inputs.v1PaymentRecovery) {
+    if (inputs.billingStatus === 'paused') return 'paused'
+    if (inputs.billingStatus === 'payment_failed' && inputs.canManage) {
+      return 'paymentFailed'
+    }
+  }
+
+  if (!inputs.isActiveSubscription) return null
+  if (!inputs.billingControlEnabled) return null
+
+  if (inputs.hasFunds === false && !inputs.outOfCreditsDismissed) {
+    return 'outOfCredits'
+  }
+  if (inputs.isCancelled && inputs.endDate && inputs.canManage) {
+    return 'ending'
+  }
+
+  return null
 }
 
 export const useBillingBanner = createSharedComposable(useBillingBannerInternal)

--- a/src/platform/workspace/composables/useDowngradeToPersonal.ts
+++ b/src/platform/workspace/composables/useDowngradeToPersonal.ts
@@ -31,24 +31,6 @@ export interface DowngradePreview {
   requiresReactivationConfirmation: boolean
 }
 
-/** Thrown by `downgradeToPersonal` when the billing authority requires
- *  reactivation consent, so the still-open confirmation can collect it and
- *  retry with `confirmReactivation: true`. */
-export class ReactivationConfirmationRequiredError extends Error {
-  constructor(public readonly preview: PreviewSubscribeResponse) {
-    super(t('subscription.downgrade.reactivationConfirmationRequired'))
-  }
-}
-
-/** Thrown by `downgradeToPersonal` when the amount a caller confirmed no
- *  longer matches a fresh preview taken right before billing — refuses to
- *  charge an amount the user never actually saw and consented to. */
-export class ReactivationAmountChangedError extends Error {
-  constructor(public readonly preview: PreviewSubscribeResponse) {
-    super(t('subscription.downgrade.reactivationAmountChanged'))
-  }
-}
-
 /**
  * Team-plan downgrade to personal: validate via `previewSubscribe`, remove
  * every member except the original owner, then initiate the tier change.
@@ -415,5 +397,23 @@ export function useDowngradeToPersonal() {
     refreshMembers,
     previewDowngrade,
     downgradeToPersonal
+  }
+}
+
+/** Thrown by `downgradeToPersonal` when the billing authority requires
+ *  reactivation consent, so the still-open confirmation can collect it and
+ *  retry with `confirmReactivation: true`. */
+export class ReactivationConfirmationRequiredError extends Error {
+  constructor(public readonly preview: PreviewSubscribeResponse) {
+    super(t('subscription.downgrade.reactivationConfirmationRequired'))
+  }
+}
+
+/** Thrown by `downgradeToPersonal` when the amount a caller confirmed no
+ *  longer matches a fresh preview taken right before billing — refuses to
+ *  charge an amount the user never actually saw and consented to. */
+export class ReactivationAmountChangedError extends Error {
+  constructor(public readonly preview: PreviewSubscribeResponse) {
+    super(t('subscription.downgrade.reactivationAmountChanged'))
   }
 }

--- a/src/platform/workspace/composables/useMembersPanel.ts
+++ b/src/platform/workspace/composables/useMembersPanel.ts
@@ -22,6 +22,14 @@ type ActiveView = 'active' | 'pending'
 type SortField = 'inviteDate' | 'expiryDate' | 'role'
 type SortDirection = 'asc' | 'desc'
 
+type InviteSortField = 'inviteDate' | 'expiryDate'
+
+// Pending invites carry no role, so the members' 'role' sort has no equivalent
+// here and falls back to the invite date.
+function toInviteSortField(sortField: SortField): InviteSortField {
+  return sortField === 'expiryDate' ? 'expiryDate' : 'inviteDate'
+}
+
 export function sortMembers(
   members: WorkspaceMember[],
   currentUserEmail: string | null,
@@ -61,14 +69,6 @@ export function filterBySearch<T extends { email: string; name?: string }>(
       item.email.toLowerCase().includes(q) ||
       ('name' in item && item.name?.toLowerCase().includes(q))
   )
-}
-
-type InviteSortField = 'inviteDate' | 'expiryDate'
-
-// Pending invites carry no role, so the members' 'role' sort has no equivalent
-// here and falls back to the invite date.
-function toInviteSortField(sortField: SortField): InviteSortField {
-  return sortField === 'expiryDate' ? 'expiryDate' : 'inviteDate'
 }
 
 export function sortPendingInvites(

--- a/src/platform/workspace/composables/useSubscriptionCheckout.test.ts
+++ b/src/platform/workspace/composables/useSubscriptionCheckout.test.ts
@@ -10,6 +10,25 @@ import type {
 
 import { findPlanSlug } from './useSubscriptionCheckout'
 
+interface ReactivationPreviewPlanInput {
+  slug: string
+  tier: PreviewSubscribeResponse['new_plan']['tier']
+  duration: PreviewSubscribeResponse['new_plan']['duration']
+  priceCents: number
+  creditsCents: number
+  periodEnd: string
+}
+
+interface ReactivationPreviewInput {
+  effectiveAt: string
+  costTodayCents: number
+  costNextPeriodCents: number
+  creditsTodayCents: number
+  creditsNextPeriodCents: number
+  currentPlan: ReactivationPreviewPlanInput
+  newPlan: ReactivationPreviewPlanInput
+}
+
 function makeStandardYearly(): Plan {
   return {
     slug: 'standard-yearly',
@@ -50,25 +69,6 @@ function allPlans(): Plan[] {
 
 function errorWithCode(code: string, message = 'error') {
   return Object.assign(new Error(message), { code })
-}
-
-interface ReactivationPreviewPlanInput {
-  slug: string
-  tier: PreviewSubscribeResponse['new_plan']['tier']
-  duration: PreviewSubscribeResponse['new_plan']['duration']
-  priceCents: number
-  creditsCents: number
-  periodEnd: string
-}
-
-interface ReactivationPreviewInput {
-  effectiveAt: string
-  costTodayCents: number
-  costNextPeriodCents: number
-  creditsTodayCents: number
-  creditsNextPeriodCents: number
-  currentPlan: ReactivationPreviewPlanInput
-  newPlan: ReactivationPreviewPlanInput
 }
 
 function makeReactivationAuthorityPreview({

--- a/src/platform/workspace/composables/useSubscriptionCheckout.ts
+++ b/src/platform/workspace/composables/useSubscriptionCheckout.ts
@@ -29,20 +29,6 @@ import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspace
 import { trackWorkspaceCheckoutStarted } from '@/platform/workspace/utils/workspaceCheckoutTelemetry'
 
 type CheckoutStep = 'pricing' | 'preview' | 'success'
-export type CheckoutTierKey = Exclude<TierKey, 'free' | 'founder'>
-
-export type SubscriptionCheckoutSelection =
-  | {
-      planMode: 'personal'
-      tierKey: CheckoutTierKey
-      billingCycle: BillingCycle
-    }
-  | {
-      planMode: 'team'
-      stop: TeamPlanSelection
-      billingCycle: BillingCycle
-    }
-
 interface SelectedTeamCheckout {
   stop: TeamPlanSelection
   checkoutType: SubscriptionCheckoutType
@@ -79,6 +65,20 @@ function parseBillingPortalUrl(url: unknown): URL | null {
  *  user consented to. Caught by the surrounding try/catch and surfaced
  *  through the same toast as any other subscribe failure. */
 class ReactivationAmountChangedError extends Error {}
+
+export type CheckoutTierKey = Exclude<TierKey, 'free' | 'founder'>
+
+export type SubscriptionCheckoutSelection =
+  | {
+      planMode: 'personal'
+      tierKey: CheckoutTierKey
+      billingCycle: BillingCycle
+    }
+  | {
+      planMode: 'team'
+      stop: TeamPlanSelection
+      billingCycle: BillingCycle
+    }
 
 export function findPlanSlug(
   plans: Plan[],

--- a/src/platform/workspace/stores/billingOperationStore.ts
+++ b/src/platform/workspace/stores/billingOperationStore.ts
@@ -34,6 +34,26 @@ const CHECKOUT_SUPERSEDED_REASON = 'checkout_superseded'
 type OperationType = 'subscription' | 'topup' | 'cancel'
 type OperationStatus = 'pending' | 'succeeded' | 'failed' | 'timeout'
 
+interface BillingOperation {
+  opId: string
+  type: OperationType
+  status: OperationStatus
+  errorMessage: string | null
+  startedAt: number
+  operationStartedAt: number
+  businessAttemptStartedAt?: number
+  actionUrl: string | null
+  authenticationRequiredSeen: boolean
+  workspaceId: string | null
+  tier?: SubscriptionCheckoutTier
+  cycle?: BillingCycle
+  checkoutType?: SubscriptionCheckoutType
+  paymentIntentSource?: PaymentIntentSource
+  downgradeToPersonal?: StartOperationMetadata['downgradeToPersonal']
+}
+
+type TerminalResolver = (operation: BillingOperation) => void
+
 export interface StartOperationMetadata {
   tier?: SubscriptionCheckoutTier
   cycle?: BillingCycle
@@ -55,26 +75,6 @@ export interface StartOperationMetadata {
    */
   attemptStartedAt?: number
 }
-
-interface BillingOperation {
-  opId: string
-  type: OperationType
-  status: OperationStatus
-  errorMessage: string | null
-  startedAt: number
-  operationStartedAt: number
-  businessAttemptStartedAt?: number
-  actionUrl: string | null
-  authenticationRequiredSeen: boolean
-  workspaceId: string | null
-  tier?: SubscriptionCheckoutTier
-  cycle?: BillingCycle
-  checkoutType?: SubscriptionCheckoutType
-  paymentIntentSource?: PaymentIntentSource
-  downgradeToPersonal?: StartOperationMetadata['downgradeToPersonal']
-}
-
-type TerminalResolver = (operation: BillingOperation) => void
 
 export const useBillingOperationStore = defineStore('billingOperation', () => {
   const workspaceStore = useTeamWorkspaceStore()

--- a/src/platform/workspace/stores/teamWorkspaceStore.ts
+++ b/src/platform/workspace/stores/teamWorkspaceStore.ts
@@ -21,24 +21,6 @@ import type {
 } from '../api/workspaceApi'
 import { workspaceApi } from '../api/workspaceApi'
 
-export interface WorkspaceMember {
-  id: string
-  name: string
-  email: string
-  joinDate: Date
-  role: 'owner' | 'member'
-  isOriginalOwner: boolean
-  creditsUsedThisMonth?: number
-  monthlyCreditLimit?: number | null
-}
-
-export interface WorkspacePendingInvite {
-  id: string
-  email: string
-  inviteDate: Date
-  expiryDate: Date
-}
-
 type SubscriptionPlan = string | null
 
 interface WorkspaceState extends WorkspaceWithRole {
@@ -88,16 +70,6 @@ function createWorkspaceState(workspace: WorkspaceWithRole): WorkspaceState {
   }
 }
 
-export function sortWorkspaces<T extends WorkspaceWithRole>(list: T[]): T[] {
-  return [...list].sort((a, b) => {
-    if (a.type === 'personal') return -1
-    if (b.type === 'personal') return 1
-    const dateA = a.role === 'owner' ? a.created_at : a.joined_at
-    const dateB = b.role === 'owner' ? b.created_at : b.joined_at
-    return dateA.localeCompare(dateB)
-  })
-}
-
 function getLastWorkspaceId(): string | null {
   try {
     return localStorage.getItem(WORKSPACE_STORAGE_KEYS.LAST_WORKSPACE_ID)
@@ -120,6 +92,34 @@ function clearLastWorkspaceId(): void {
   } catch {
     console.warn('Failed to clear last workspace ID from localStorage')
   }
+}
+
+export interface WorkspaceMember {
+  id: string
+  name: string
+  email: string
+  joinDate: Date
+  role: 'owner' | 'member'
+  isOriginalOwner: boolean
+  creditsUsedThisMonth?: number
+  monthlyCreditLimit?: number | null
+}
+
+export interface WorkspacePendingInvite {
+  id: string
+  email: string
+  inviteDate: Date
+  expiryDate: Date
+}
+
+export function sortWorkspaces<T extends WorkspaceWithRole>(list: T[]): T[] {
+  return [...list].sort((a, b) => {
+    if (a.type === 'personal') return -1
+    if (b.type === 'personal') return 1
+    const dateA = a.role === 'owner' ? a.created_at : a.joined_at
+    const dateB = b.role === 'owner' ? b.created_at : b.joined_at
+    return dateA.localeCompare(dateB)
+  })
 }
 
 const MAX_OWNED_WORKSPACES = 10

--- a/src/platform/workspace/stores/workspaceAuthStore.ts
+++ b/src/platform/workspace/stores/workspaceAuthStore.ts
@@ -49,6 +49,13 @@ const RECOVERY_COOLDOWN_MS = 5000
 // long-lived session cannot grow the context Map unbounded.
 const ISSUED_TOKEN_CONTEXT_GRACE_MS = 5 * 60 * 1000
 
+interface MintedToken {
+  token: string
+  expiresAt: number
+  workspace: WorkspaceIdentity
+  ownerUid: string
+}
+
 export class WorkspaceAuthError extends Error {
   constructor(
     message: string,
@@ -57,13 +64,6 @@ export class WorkspaceAuthError extends Error {
     super(message)
     this.name = 'WorkspaceAuthError'
   }
-}
-
-interface MintedToken {
-  token: string
-  expiresAt: number
-  workspace: WorkspaceIdentity
-  ownerUid: string
 }
 
 const PERMANENT_AUTH_ERROR_CODES = new Set([

--- a/src/renderer/core/canvas/links/linkConnectorAdapter.ts
+++ b/src/renderer/core/canvas/links/linkConnectorAdapter.ts
@@ -12,6 +12,22 @@ import { isSubgraph } from '@/utils/typeGuardUtil'
 // Keep one adapter per graph so rendering and interaction share state.
 const adapterByGraph = new WeakMap<LGraph, LinkConnectorAdapter>()
 
+/** Convenience creator using the current app canvas graph. */
+export function createLinkConnectorAdapter(): LinkConnectorAdapter | null {
+  const graph = app.canvas?.graph
+  const connector = app.canvas?.linkConnector
+  if (!graph || !connector) return null
+
+  const adapter = adapterByGraph.get(graph)
+  if (adapter && adapter.linkConnector === connector) {
+    return adapter
+  }
+
+  const newAdapter = new LinkConnectorAdapter(graph, connector)
+  adapterByGraph.set(graph, newAdapter)
+  return newAdapter
+}
+
 /**
  * Renderer‑agnostic adapter around LiteGraph's LinkConnector.
  *
@@ -156,20 +172,4 @@ export class LinkConnectorAdapter {
   reset(): void {
     this.linkConnector.reset()
   }
-}
-
-/** Convenience creator using the current app canvas graph. */
-export function createLinkConnectorAdapter(): LinkConnectorAdapter | null {
-  const graph = app.canvas?.graph
-  const connector = app.canvas?.linkConnector
-  if (!graph || !connector) return null
-
-  const adapter = adapterByGraph.get(graph)
-  if (adapter && adapter.linkConnector === connector) {
-    return adapter
-  }
-
-  const newAdapter = new LinkConnectorAdapter(graph, connector)
-  adapterByGraph.set(graph, newAdapter)
-  return newAdapter
 }

--- a/src/renderer/core/canvas/links/slotLinkDragUIState.ts
+++ b/src/renderer/core/canvas/links/slotLinkDragUIState.ts
@@ -26,11 +26,6 @@ interface SlotDragSource {
   movingExistingOutput?: boolean
 }
 
-export interface SlotDropCandidate {
-  layout: SlotLayout
-  compatible: boolean
-}
-
 interface PointerPosition {
   client: Point
   canvas: Point
@@ -43,6 +38,11 @@ interface SlotDragState {
   pointer: PointerPosition
   candidate: SlotDropCandidate | null
   compatible: Map<string, boolean>
+}
+
+export interface SlotDropCandidate {
+  layout: SlotLayout
+  compatible: boolean
 }
 
 const state = reactive<SlotDragState>({

--- a/src/renderer/core/canvas/litegraph/slotCalculations.ts
+++ b/src/renderer/core/canvas/litegraph/slotCalculations.ts
@@ -16,29 +16,6 @@ import { isWidgetInputSlot } from '@/lib/litegraph/src/node/slotUtils'
 import { getSlotKey } from '@/renderer/core/layout/slots/slotIdentifier'
 import { layoutStore } from '@/renderer/core/layout/store/layoutStore'
 
-export interface SlotPositionContext {
-  /** Node's X position in graph coordinates */
-  nodeX: number
-  /** Node's Y position in graph coordinates */
-  nodeY: number
-  /** Node's width */
-  nodeWidth: number
-  /** Node's height */
-  nodeHeight: number
-  /** Whether the node is collapsed */
-  collapsed: boolean
-  /** Collapsed width (if applicable) */
-  collapsedWidth?: number
-  /** Node constructor's slot_start_y offset */
-  slotStartY?: number
-  /** Node's input slots */
-  inputs: INodeInputSlot[]
-  /** Node's output slots */
-  outputs: INodeOutputSlot[]
-  /** Node's widgets (for widget slot detection) */
-  widgets?: Array<{ name?: string }>
-}
-
 /**
  * Calculate the position of an input slot in graph coordinates
  * @param context Node context containing position and slot data
@@ -53,38 +30,6 @@ function calculateInputSlotPos(
   if (!input) return [context.nodeX, context.nodeY]
 
   return calculateInputSlotPosFromSlot(context, input)
-}
-
-/**
- * Calculate the position of an input slot in graph coordinates
- * @param context Node context containing position and slot data
- * @param input The input slot object
- * @returns Position of the input slot center in graph coordinates
- */
-export function calculateInputSlotPosFromSlot(
-  context: SlotPositionContext,
-  input: INodeInputSlot
-): Point {
-  const { nodeX, nodeY, collapsed } = context
-
-  // Handle collapsed nodes
-  if (collapsed) {
-    const halfTitle = LiteGraph.NODE_TITLE_HEIGHT * 0.5
-    return [nodeX, nodeY - halfTitle]
-  }
-
-  // Handle hard-coded positions
-  const { pos } = input
-  if (pos) return [nodeX + pos[0], nodeY + pos[1]]
-
-  // Default vertical slots
-  const offsetX = LiteGraph.NODE_SLOT_HEIGHT * 0.5
-  const nodeOffsetY = context.slotStartY || 0
-  const defaultVerticalInputs = getDefaultVerticalInputs(context)
-  const slotIndex = defaultVerticalInputs.indexOf(input)
-  const slotY = (slotIndex + 0.7) * LiteGraph.NODE_SLOT_HEIGHT
-
-  return [nodeX + offsetX, nodeY + slotY + nodeOffsetY]
 }
 
 /**
@@ -123,6 +68,81 @@ function calculateOutputSlotPos(
 
   // TODO: Why +1?
   return [nodeX + nodeWidth + 1 - offsetX, nodeY + slotY + nodeOffsetY]
+}
+
+/**
+ * Get the inputs that are not positioned with absolute coordinates
+ */
+function getDefaultVerticalInputs(
+  context: SlotPositionContext
+): INodeInputSlot[] {
+  return context.inputs.filter(
+    (slot) => !slot.pos && !(context.widgets?.length && isWidgetInputSlot(slot))
+  )
+}
+
+/**
+ * Get the outputs that are not positioned with absolute coordinates
+ */
+function getDefaultVerticalOutputs(
+  context: SlotPositionContext
+): INodeOutputSlot[] {
+  return context.outputs.filter((slot) => !slot.pos)
+}
+
+export interface SlotPositionContext {
+  /** Node's X position in graph coordinates */
+  nodeX: number
+  /** Node's Y position in graph coordinates */
+  nodeY: number
+  /** Node's width */
+  nodeWidth: number
+  /** Node's height */
+  nodeHeight: number
+  /** Whether the node is collapsed */
+  collapsed: boolean
+  /** Collapsed width (if applicable) */
+  collapsedWidth?: number
+  /** Node constructor's slot_start_y offset */
+  slotStartY?: number
+  /** Node's input slots */
+  inputs: INodeInputSlot[]
+  /** Node's output slots */
+  outputs: INodeOutputSlot[]
+  /** Node's widgets (for widget slot detection) */
+  widgets?: Array<{ name?: string }>
+}
+
+/**
+ * Calculate the position of an input slot in graph coordinates
+ * @param context Node context containing position and slot data
+ * @param input The input slot object
+ * @returns Position of the input slot center in graph coordinates
+ */
+export function calculateInputSlotPosFromSlot(
+  context: SlotPositionContext,
+  input: INodeInputSlot
+): Point {
+  const { nodeX, nodeY, collapsed } = context
+
+  // Handle collapsed nodes
+  if (collapsed) {
+    const halfTitle = LiteGraph.NODE_TITLE_HEIGHT * 0.5
+    return [nodeX, nodeY - halfTitle]
+  }
+
+  // Handle hard-coded positions
+  const { pos } = input
+  if (pos) return [nodeX + pos[0], nodeY + pos[1]]
+
+  // Default vertical slots
+  const offsetX = LiteGraph.NODE_SLOT_HEIGHT * 0.5
+  const nodeOffsetY = context.slotStartY || 0
+  const defaultVerticalInputs = getDefaultVerticalInputs(context)
+  const slotIndex = defaultVerticalInputs.indexOf(input)
+  const slotY = (slotIndex + 0.7) * LiteGraph.NODE_SLOT_HEIGHT
+
+  return [nodeX + offsetX, nodeY + slotY + nodeOffsetY]
 }
 
 /**
@@ -190,24 +210,4 @@ export function getSlotPosition(
   return isInput
     ? calculateInputSlotPos(context, slotIndex)
     : calculateOutputSlotPos(context, slotIndex)
-}
-
-/**
- * Get the inputs that are not positioned with absolute coordinates
- */
-function getDefaultVerticalInputs(
-  context: SlotPositionContext
-): INodeInputSlot[] {
-  return context.inputs.filter(
-    (slot) => !slot.pos && !(context.widgets?.length && isWidgetInputSlot(slot))
-  )
-}
-
-/**
- * Get the outputs that are not positioned with absolute coordinates
- */
-function getDefaultVerticalOutputs(
-  context: SlotPositionContext
-): INodeOutputSlot[] {
-  return context.outputs.filter((slot) => !slot.pos)
 }

--- a/src/renderer/core/canvas/pathRenderer.test.ts
+++ b/src/renderer/core/canvas/pathRenderer.test.ts
@@ -7,25 +7,6 @@ import type {
 } from '@/renderer/core/canvas/pathRenderer'
 import { CanvasPathRenderer } from '@/renderer/core/canvas/pathRenderer'
 
-class StubPath2D {
-  calls: Array<{ method: string; args: unknown[] }> = []
-  moveTo(...args: unknown[]) {
-    this.calls.push({ method: 'moveTo', args })
-  }
-  lineTo(...args: unknown[]) {
-    this.calls.push({ method: 'lineTo', args })
-  }
-  bezierCurveTo(...args: unknown[]) {
-    this.calls.push({ method: 'bezierCurveTo', args })
-  }
-  quadraticCurveTo(...args: unknown[]) {
-    this.calls.push({ method: 'quadraticCurveTo', args })
-  }
-  arc(...args: unknown[]) {
-    this.calls.push({ method: 'arc', args })
-  }
-}
-
 function createMockCtx(): CanvasRenderingContext2D {
   return {
     save: vi.fn(),
@@ -73,6 +54,25 @@ function makeContext(overrides: Partial<RenderContext> = {}): RenderContext {
       ...overrides.colors
     },
     ...overrides
+  }
+}
+
+class StubPath2D {
+  calls: Array<{ method: string; args: unknown[] }> = []
+  moveTo(...args: unknown[]) {
+    this.calls.push({ method: 'moveTo', args })
+  }
+  lineTo(...args: unknown[]) {
+    this.calls.push({ method: 'lineTo', args })
+  }
+  bezierCurveTo(...args: unknown[]) {
+    this.calls.push({ method: 'bezierCurveTo', args })
+  }
+  quadraticCurveTo(...args: unknown[]) {
+    this.calls.push({ method: 'quadraticCurveTo', args })
+  }
+  arc(...args: unknown[]) {
+    this.calls.push({ method: 'arc', args })
   }
 }
 

--- a/src/renderer/core/canvas/pathRenderer.ts
+++ b/src/renderer/core/canvas/pathRenderer.ts
@@ -7,13 +7,47 @@
  * Can be reused in any canvas-based project without modification.
  */
 
+interface RenderStyle {
+  mode: RenderMode
+  connectionWidth: number
+  borderWidth?: number
+  arrowShape?: ArrowShape
+  showArrows?: boolean
+  lowQuality?: boolean
+  // Center marker properties
+  showCenterMarker?: boolean
+  centerMarkerShape?: 'circle' | 'arrow'
+  highQuality?: boolean
+}
+
+interface RenderColors {
+  default: string
+  byType: Record<string, string>
+  highlighted: string
+}
+interface DragLinkData {
+  /** Fixed end - the slot being dragged from */
+  fixedPoint: Point
+  fixedDirection: Direction
+  /** Moving end - follows mouse */
+  dragPoint: Point
+  dragDirection?: Direction
+  /** Visual properties */
+  color?: string
+  type?: string
+  disabled?: boolean
+  /** Whether dragging from input (reverse direction) */
+  fromInput?: boolean
+}
 export interface Point {
   x: number
   y: number
 }
 
 export type Direction = 'left' | 'right' | 'up' | 'down' | 'none'
+
 export type RenderMode = 'spline' | 'straight' | 'linear'
+
 export type ArrowShape = 'triangle' | 'circle' | 'square'
 
 export interface LinkRenderData {
@@ -38,25 +72,6 @@ export interface LinkRenderData {
   centerAngle?: number
 }
 
-interface RenderStyle {
-  mode: RenderMode
-  connectionWidth: number
-  borderWidth?: number
-  arrowShape?: ArrowShape
-  showArrows?: boolean
-  lowQuality?: boolean
-  // Center marker properties
-  showCenterMarker?: boolean
-  centerMarkerShape?: 'circle' | 'arrow'
-  highQuality?: boolean
-}
-
-interface RenderColors {
-  default: string
-  byType: Record<string, string>
-  highlighted: string
-}
-
 export interface RenderContext {
   style: RenderStyle
   colors: RenderColors
@@ -68,21 +83,6 @@ export interface RenderContext {
   }
   scale?: number // Canvas scale for quality adjustments
   highlightedIds?: Set<string>
-}
-
-interface DragLinkData {
-  /** Fixed end - the slot being dragged from */
-  fixedPoint: Point
-  fixedDirection: Direction
-  /** Moving end - follows mouse */
-  dragPoint: Point
-  dragDirection?: Direction
-  /** Visual properties */
-  color?: string
-  type?: string
-  disabled?: boolean
-  /** Whether dragging from input (reverse direction) */
-  fromInput?: boolean
 }
 
 export class CanvasPathRenderer {

--- a/src/renderer/core/layout/store/layoutStore.ts
+++ b/src/renderer/core/layout/store/layoutStore.ts
@@ -72,15 +72,6 @@ const logger = log.getLogger('LayoutStore')
 /** Fields whose value changes move a node on screen. */
 const NODE_GEOMETRY_KEYS = new Set(['position', 'size', 'bounds'])
 
-// Utility functions
-function asRerouteId(id: string | number): RerouteId {
-  return toRerouteId(Number(id))
-}
-
-function asLinkId(id: string | number): LinkId {
-  return toLinkId(Number(id))
-}
-
 interface LinkData {
   id: LinkId
   sourceNodeId: NodeId
@@ -100,6 +91,15 @@ interface RerouteData {
 interface TypedYMap<T> {
   get<K extends keyof T>(key: K): T[K] | undefined
   get<K extends keyof T>(key: K, defaultValue: T[K]): T[K]
+}
+
+// Utility functions
+function asRerouteId(id: string | number): RerouteId {
+  return toRerouteId(Number(id))
+}
+
+function asLinkId(id: string | number): LinkId {
+  return toLinkId(Number(id))
 }
 
 class LayoutStoreImpl implements LayoutStore {

--- a/src/renderer/core/layout/transform/useTransformSettling.ts
+++ b/src/renderer/core/layout/transform/useTransformSettling.ts
@@ -18,6 +18,57 @@ interface TransformSettlingOptions {
 }
 
 /**
+ * Calls `onDrag` on each pointermove while a pointer is held down.
+ */
+function usePointerDrag(
+  target: MaybeRefOrGetter<HTMLElement | null | undefined>,
+  onDrag: () => void,
+  eventOptions: AddEventListenerOptions
+) {
+  /** Number of active pointers (supports multi-touch correctly). */
+  const pointerCount = ref(0)
+
+  useEventListener(
+    target,
+    'pointerdown',
+    (e: PointerEvent) => {
+      // Only primary (0) and middle (1) buttons trigger canvas pan.
+      if (e.button === 0 || isMiddleButtonEvent(e)) pointerCount.value++
+    },
+    eventOptions
+  )
+
+  useEventListener(
+    target,
+    'pointermove',
+    () => {
+      if (pointerCount.value > 0) onDrag()
+    },
+    eventOptions
+  )
+
+  // Listen on window so the release is caught even if the pointer
+  // leaves the canvas before the button is released.
+  useEventListener(
+    window,
+    'pointerup',
+    () => {
+      if (pointerCount.value > 0) pointerCount.value--
+    },
+    eventOptions
+  )
+
+  useEventListener(
+    window,
+    'pointercancel',
+    () => {
+      if (pointerCount.value > 0) pointerCount.value--
+    },
+    eventOptions
+  )
+}
+
+/**
  * Tracks when canvas transforms (zoom or pan) are actively changing vs settled.
  *
  * This composable helps optimize rendering quality during transform interactions.
@@ -69,55 +120,4 @@ export function useTransformSettling(
   return {
     isTransforming
   }
-}
-
-/**
- * Calls `onDrag` on each pointermove while a pointer is held down.
- */
-function usePointerDrag(
-  target: MaybeRefOrGetter<HTMLElement | null | undefined>,
-  onDrag: () => void,
-  eventOptions: AddEventListenerOptions
-) {
-  /** Number of active pointers (supports multi-touch correctly). */
-  const pointerCount = ref(0)
-
-  useEventListener(
-    target,
-    'pointerdown',
-    (e: PointerEvent) => {
-      // Only primary (0) and middle (1) buttons trigger canvas pan.
-      if (e.button === 0 || isMiddleButtonEvent(e)) pointerCount.value++
-    },
-    eventOptions
-  )
-
-  useEventListener(
-    target,
-    'pointermove',
-    () => {
-      if (pointerCount.value > 0) onDrag()
-    },
-    eventOptions
-  )
-
-  // Listen on window so the release is caught even if the pointer
-  // leaves the canvas before the button is released.
-  useEventListener(
-    window,
-    'pointerup',
-    () => {
-      if (pointerCount.value > 0) pointerCount.value--
-    },
-    eventOptions
-  )
-
-  useEventListener(
-    window,
-    'pointercancel',
-    () => {
-      if (pointerCount.value > 0) pointerCount.value--
-    },
-    eventOptions
-  )
 }

--- a/src/renderer/core/layout/types.ts
+++ b/src/renderer/core/layout/types.ts
@@ -11,12 +11,63 @@ import type { NodeId } from '@/types/nodeId'
 import type { RerouteId } from '@/types/rerouteId'
 import type { SlotDirection, SlotId, SlotIndex } from '@/types/slotId'
 
-// Enum for layout source types
-export enum LayoutSource {
-  Canvas = 'canvas',
-  Vue = 'vue',
-  DOM = 'dom',
-  External = 'external'
+/**
+ * Meta-only base for all operations - contains common fields
+ */
+interface OperationMeta {
+  /** Unique operation ID for deduplication */
+  id?: string
+  /** Timestamp for ordering operations */
+  timestamp: number
+  /** Actor who performed the operation (for CRDT) */
+  actor: string
+  /** Source system that initiated the operation */
+  source: LayoutSource
+  /** Operation type discriminator */
+  type: OperationType
+}
+
+/**
+ * Entity-specific base types for proper type discrimination
+ */
+type NodeOpBase = OperationMeta & { entity: 'node'; nodeId: NodeId }
+
+type LinkOpBase = OperationMeta & { entity: 'link'; linkId: LinkId }
+
+type RerouteOpBase = OperationMeta & {
+  entity: 'reroute'
+  rerouteId: RerouteId
+}
+
+/**
+ * Operation type discriminator for type narrowing
+ */
+type OperationType =
+  | 'moveNode'
+  | 'resizeNode'
+  | 'setNodeZIndex'
+  | 'createNode'
+  | 'deleteNode'
+  | 'setNodeVisibility'
+  | 'batchUpdateBounds'
+  | 'createLink'
+  | 'deleteLink'
+  | 'createReroute'
+  | 'deleteReroute'
+  | 'moveReroute'
+
+export type { LinkId }
+export type { NodeId }
+export type { RerouteId }
+export type { SlotId }
+
+/**
+ * Set node visibility operation
+ */
+interface SetNodeVisibilityOperation extends NodeOpBase {
+  type: 'setNodeVisibility'
+  visible: boolean
+  previousVisible: boolean
 }
 
 // Basic geometric types
@@ -42,11 +93,6 @@ export interface NodeBoundsUpdate {
   bounds: Bounds
 }
 
-export type { LinkId }
-export type { NodeId }
-export type { RerouteId }
-export type { SlotId }
-
 // Layout data structures
 export interface NodeLayout {
   id: NodeId
@@ -65,7 +111,6 @@ export interface SlotLayout {
   position: Point
   bounds: Bounds
 }
-
 export interface LinkLayout {
   id: LinkId
   path: Path2D
@@ -76,7 +121,6 @@ export interface LinkLayout {
   sourceSlot: number
   targetSlot: number
 }
-
 // Layout for individual link segments (for precise hit-testing)
 export interface LinkSegmentLayout {
   linkId: LinkId
@@ -92,49 +136,6 @@ export interface RerouteLayout {
   radius: number
   bounds: Bounds
 }
-
-/**
- * Meta-only base for all operations - contains common fields
- */
-interface OperationMeta {
-  /** Unique operation ID for deduplication */
-  id?: string
-  /** Timestamp for ordering operations */
-  timestamp: number
-  /** Actor who performed the operation (for CRDT) */
-  actor: string
-  /** Source system that initiated the operation */
-  source: LayoutSource
-  /** Operation type discriminator */
-  type: OperationType
-}
-
-/**
- * Entity-specific base types for proper type discrimination
- */
-type NodeOpBase = OperationMeta & { entity: 'node'; nodeId: NodeId }
-type LinkOpBase = OperationMeta & { entity: 'link'; linkId: LinkId }
-type RerouteOpBase = OperationMeta & {
-  entity: 'reroute'
-  rerouteId: RerouteId
-}
-
-/**
- * Operation type discriminator for type narrowing
- */
-type OperationType =
-  | 'moveNode'
-  | 'resizeNode'
-  | 'setNodeZIndex'
-  | 'createNode'
-  | 'deleteNode'
-  | 'setNodeVisibility'
-  | 'batchUpdateBounds'
-  | 'createLink'
-  | 'deleteLink'
-  | 'createReroute'
-  | 'deleteReroute'
-  | 'moveReroute'
 
 /**
  * Move node operation
@@ -177,15 +178,6 @@ export interface CreateNodeOperation extends NodeOpBase {
 export interface DeleteNodeOperation extends NodeOpBase {
   type: 'deleteNode'
   previousLayout: NodeLayout
-}
-
-/**
- * Set node visibility operation
- */
-interface SetNodeVisibilityOperation extends NodeOpBase {
-  type: 'setNodeVisibility'
-  visible: boolean
-  previousVisible: boolean
 }
 
 /**
@@ -376,4 +368,12 @@ export interface LayoutStore {
   batchUpdateSlotLayouts(
     updates: Array<{ key: SlotId; layout: SlotLayout }>
   ): void
+}
+
+// Enum for layout source types
+export enum LayoutSource {
+  Canvas = 'canvas',
+  Vue = 'vue',
+  DOM = 'dom',
+  External = 'external'
 }

--- a/src/renderer/core/layout/utils/mappers.ts
+++ b/src/renderer/core/layout/utils/mappers.ts
@@ -14,6 +14,15 @@ export const NODE_LAYOUT_DEFAULTS: NodeLayout = {
   bounds: { x: 0, y: 0, width: 100, height: 50 }
 }
 
+function getOr<K extends keyof NodeLayout>(
+  map: NodeLayoutMap,
+  key: K,
+  fallback: NodeLayout[K]
+): NodeLayout[K] {
+  const v = map.get(key)
+  return (v ?? fallback) as NodeLayout[K]
+}
+
 export function layoutToYNode(layout: NodeLayout): NodeLayoutMap {
   const ynode = new Y.Map<NodeLayout[keyof NodeLayout]>() as NodeLayoutMap
   ynode.set('id', layout.id)
@@ -23,15 +32,6 @@ export function layoutToYNode(layout: NodeLayout): NodeLayoutMap {
   ynode.set('visible', layout.visible)
   ynode.set('bounds', layout.bounds)
   return ynode
-}
-
-function getOr<K extends keyof NodeLayout>(
-  map: NodeLayoutMap,
-  key: K,
-  fallback: NodeLayout[K]
-): NodeLayout[K] {
-  const v = map.get(key)
-  return (v ?? fallback) as NodeLayout[K]
 }
 
 export function yNodeToLayout(ynode: NodeLayoutMap): NodeLayout {

--- a/src/renderer/core/spatial/QuadTree.ts
+++ b/src/renderer/core/spatial/QuadTree.ts
@@ -7,13 +7,6 @@ import type {
   SpatialIndexDebugInfo
 } from '@/types/spatialIndex'
 
-export interface Bounds {
-  x: number
-  y: number
-  width: number
-  height: number
-}
-
 interface QuadTreeItem<T> {
   id: string
   bounds: Bounds
@@ -216,6 +209,13 @@ class QuadNode<T> {
       children: this.children?.map((child) => child.getDebugInfo())
     }
   }
+}
+
+export interface Bounds {
+  x: number
+  y: number
+  width: number
+  height: number
 }
 
 export class QuadTree<T> {

--- a/src/renderer/extensions/compositor/composables/compositorLayerState.ts
+++ b/src/renderer/extensions/compositor/composables/compositorLayerState.ts
@@ -32,29 +32,6 @@ const DEFAULT_BACKGROUND_ENTRY: CompositorBackgroundEntry = {
 
 const LAYER_STATE_VERSION = 1
 
-export interface CompositorLayerState {
-  version?: typeof LAYER_STATE_VERSION
-  canvas?: { w: number; h: number }
-  inputs?: string[]
-  background?: CompositorBackgroundEntry
-  order?: number[]
-  layers: Array<CompositorLayerEntry | null>
-}
-
-export interface CompositorBBox {
-  x: number
-  y: number
-  width: number
-  height: number
-  name?: string | null
-  rotation?: number
-  visible?: boolean
-  opacity?: number
-  blend?: string
-  flipH?: boolean
-  flipV?: boolean
-}
-
 interface CompositorLayerStateInit {
   canvas?: { w: number; h: number }
   background?: CompositorBackgroundEntry
@@ -144,49 +121,6 @@ function backgroundEntry(node: FillData): CompositorBackgroundEntry {
   }
 }
 
-export function extractLayerState(
-  canvas: { w: number; h: number },
-  layers: readonly SceneNode[],
-  layerFlips: (id: string) => { h: boolean; v: boolean },
-  inputs?: string[],
-  inputOrder?: readonly string[]
-): CompositorLayerState {
-  const background = layers.find(
-    (node): node is FillData => node.kind === 'fill'
-  )
-  const imageNodes = layers.filter((node) => node.kind !== 'fill')
-  const orderIds = inputOrder ?? imageNodes.map((node) => node.id)
-  const inputIndex = new Map(orderIds.map((id, index) => [id, index]))
-  const entries: Array<CompositorLayerEntry | null> = orderIds.map(() => null)
-  const order: number[] = []
-  for (const node of imageNodes) {
-    const index = inputIndex.get(node.id)
-    if (index === undefined) continue
-    const flips = layerFlips(node.id)
-    entries[index] = {
-      name: node.name,
-      visible: node.visible,
-      opacity: node.opacity,
-      blend: node.mode.blend,
-      transform: { ...node.transform },
-      flipH: flips.h,
-      flipV: flips.v
-    }
-    order.push(index)
-  }
-  const identityOrder =
-    order.length === entries.length &&
-    order.every((value, index) => value === index)
-  return {
-    version: LAYER_STATE_VERSION,
-    canvas: { w: canvas.w, h: canvas.h },
-    ...(inputs ? { inputs } : {}),
-    ...(background ? { background: backgroundEntry(background) } : {}),
-    ...(identityOrder ? {} : { order }),
-    layers: entries
-  }
-}
-
 function parseCanvasSize(value: unknown): { w: number; h: number } | undefined {
   if (typeof value !== 'object' || value === null) return undefined
   const { w, h } = value as Record<string, unknown>
@@ -244,6 +178,103 @@ function parseJson(json: string): unknown {
   }
 }
 
+function bboxLayerState(
+  bboxes: ReadonlyArray<CompositorBBox | null> | undefined
+): CompositorLayerStateInit | null {
+  if (!bboxes?.some((bbox) => bbox !== null)) return null
+  return {
+    layers: bboxes.map((bbox) =>
+      bbox
+        ? {
+            ...(typeof bbox.name === 'string' && bbox.name
+              ? { name: bbox.name }
+              : {}),
+            ...(typeof bbox.visible === 'boolean'
+              ? { visible: bbox.visible }
+              : {}),
+            ...(isFiniteNumber(bbox.opacity) ? { opacity: bbox.opacity } : {}),
+            ...(isBlendFn(bbox.blend) ? { blend: bbox.blend } : {}),
+            ...(bbox.flipH === true ? { flipH: true } : {}),
+            ...(bbox.flipV === true ? { flipV: true } : {}),
+            transform: {
+              x: bbox.x,
+              y: bbox.y,
+              w: bbox.width,
+              h: bbox.height,
+              rotation: isFiniteNumber(bbox.rotation) ? bbox.rotation : 0
+            }
+          }
+        : null
+    )
+  }
+}
+
+export interface CompositorLayerState {
+  version?: typeof LAYER_STATE_VERSION
+  canvas?: { w: number; h: number }
+  inputs?: string[]
+  background?: CompositorBackgroundEntry
+  order?: number[]
+  layers: Array<CompositorLayerEntry | null>
+}
+
+export interface CompositorBBox {
+  x: number
+  y: number
+  width: number
+  height: number
+  name?: string | null
+  rotation?: number
+  visible?: boolean
+  opacity?: number
+  blend?: string
+  flipH?: boolean
+  flipV?: boolean
+}
+
+export function extractLayerState(
+  canvas: { w: number; h: number },
+  layers: readonly SceneNode[],
+  layerFlips: (id: string) => { h: boolean; v: boolean },
+  inputs?: string[],
+  inputOrder?: readonly string[]
+): CompositorLayerState {
+  const background = layers.find(
+    (node): node is FillData => node.kind === 'fill'
+  )
+  const imageNodes = layers.filter((node) => node.kind !== 'fill')
+  const orderIds = inputOrder ?? imageNodes.map((node) => node.id)
+  const inputIndex = new Map(orderIds.map((id, index) => [id, index]))
+  const entries: Array<CompositorLayerEntry | null> = orderIds.map(() => null)
+  const order: number[] = []
+  for (const node of imageNodes) {
+    const index = inputIndex.get(node.id)
+    if (index === undefined) continue
+    const flips = layerFlips(node.id)
+    entries[index] = {
+      name: node.name,
+      visible: node.visible,
+      opacity: node.opacity,
+      blend: node.mode.blend,
+      transform: { ...node.transform },
+      flipH: flips.h,
+      flipV: flips.v
+    }
+    order.push(index)
+  }
+  const identityOrder =
+    order.length === entries.length &&
+    order.every((value, index) => value === index)
+  return {
+    version: LAYER_STATE_VERSION,
+    canvas: { w: canvas.w, h: canvas.h },
+    ...(inputs ? { inputs } : {}),
+    ...(background ? { background: backgroundEntry(background) } : {}),
+    ...(identityOrder ? {} : { order }),
+    layers: entries
+  }
+}
+
 export function parseLayerState(value: unknown): CompositorLayerState | null {
   const raw = typeof value === 'string' ? parseJson(value) : value
   if (typeof raw !== 'object' || raw === null) return null
@@ -279,37 +310,6 @@ export function layerStateInputsMatch(
     saved.length === current.length &&
     saved.every((value, index) => value === current[index])
   )
-}
-
-function bboxLayerState(
-  bboxes: ReadonlyArray<CompositorBBox | null> | undefined
-): CompositorLayerStateInit | null {
-  if (!bboxes?.some((bbox) => bbox !== null)) return null
-  return {
-    layers: bboxes.map((bbox) =>
-      bbox
-        ? {
-            ...(typeof bbox.name === 'string' && bbox.name
-              ? { name: bbox.name }
-              : {}),
-            ...(typeof bbox.visible === 'boolean'
-              ? { visible: bbox.visible }
-              : {}),
-            ...(isFiniteNumber(bbox.opacity) ? { opacity: bbox.opacity } : {}),
-            ...(isBlendFn(bbox.blend) ? { blend: bbox.blend } : {}),
-            ...(bbox.flipH === true ? { flipH: true } : {}),
-            ...(bbox.flipV === true ? { flipV: true } : {}),
-            transform: {
-              x: bbox.x,
-              y: bbox.y,
-              w: bbox.width,
-              h: bbox.height,
-              rotation: isFiniteNumber(bbox.rotation) ? bbox.rotation : 0
-            }
-          }
-        : null
-    )
-  }
 }
 
 export function resolveInitialLayerState(

--- a/src/renderer/extensions/compositor/composables/useCompositorLayers.ts
+++ b/src/renderer/extensions/compositor/composables/useCompositorLayers.ts
@@ -25,6 +25,10 @@ function cacheKey(node: CompositorNodeRef): NodeLocatorId {
   )
 }
 
+function revokeIfObjectUrl(url: string | undefined): void {
+  if (url?.startsWith('blob:')) URL.revokeObjectURL(url)
+}
+
 export function setCompositorLayers(
   node: CompositorNodeRef,
   refs: ImageFileRef[],
@@ -59,10 +63,6 @@ export function getCompositorBBoxes(
 export function clearCompositorLayers(node: CompositorNodeRef): void {
   cacheByNode.delete(cacheKey(node))
   clearCompositorPreviewOverride(node)
-}
-
-function revokeIfObjectUrl(url: string | undefined): void {
-  if (url?.startsWith('blob:')) URL.revokeObjectURL(url)
 }
 
 export function setCompositorPreviewOverride(

--- a/src/renderer/extensions/firstRunTour/roles/heuristicRoles.test.ts
+++ b/src/renderer/extensions/firstRunTour/roles/heuristicRoles.test.ts
@@ -11,10 +11,6 @@ import { LGraphEventMode } from '@/lib/litegraph/src/types/globalEnums'
 
 import { heuristicRoles } from './heuristicRoles'
 
-class OutputNode extends LGraphNode {
-  static override nodeData = { output_node: true }
-}
-
 function addNode(
   graph: LGraph | Subgraph,
   type: string,
@@ -97,6 +93,10 @@ function addExposedPrompt(root: LGraph, portName: string) {
   const slot = text.addInput('text', 'STRING', { widget: { name: 'text' } })
   subgraph.inputNode.slots[0].connect(slot, text)
   return text
+}
+
+class OutputNode extends LGraphNode {
+  static override nodeData = { output_node: true }
 }
 
 describe('heuristicRoles', () => {

--- a/src/renderer/extensions/firstRunTour/roles/resolveTourRoles.test.ts
+++ b/src/renderer/extensions/firstRunTour/roles/resolveTourRoles.test.ts
@@ -22,10 +22,6 @@ if (!source || !prompt) {
   )
 }
 
-class OutputNode extends LGraphNode {
-  static override nodeData = { output_node: true }
-}
-
 function addPinnedNode(graph: LGraph | Subgraph, pin: RolePin) {
   const node = new LGraphNode(pin.type, pin.type)
   node.id = toNodeId(pin.id)
@@ -40,6 +36,10 @@ function addHostedSubgraph(root: LGraph, parent: LGraph | Subgraph = root) {
   const host = createTestSubgraphNode(subgraph, { parentGraph: parent })
   parent.add(host)
   return { subgraph, host }
+}
+
+class OutputNode extends LGraphNode {
+  static override nodeData = { output_node: true }
 }
 
 describe('resolveTourRoles', () => {

--- a/src/renderer/extensions/firstRunTour/roles/resolveTourRoles.ts
+++ b/src/renderer/extensions/firstRunTour/roles/resolveTourRoles.ts
@@ -15,13 +15,6 @@ import type {
   TourMediaKind
 } from './tourRolePins'
 
-export interface ResolvedRoles {
-  source: NodeId | null
-  promptHost: NodeId | null
-  sink: NodeId | null
-  mediaKind: TourMediaKind
-}
-
 /** The root-graph node a role is spotlit through: itself, or the subgraph node holding it. */
 function rootHost(
   node: LGraphNode | null | undefined,
@@ -51,6 +44,13 @@ function resolveFromGraph(graph: LGraph): ResolvedRoles | null {
     sink: rootHost(roles.sink, graph),
     mediaKind: roles.mediaKind
   }
+}
+
+export interface ResolvedRoles {
+  source: NodeId | null
+  promptHost: NodeId | null
+  sink: NodeId | null
+  mediaKind: TourMediaKind
 }
 
 /**

--- a/src/renderer/extensions/firstRunTour/tour/cameraFraming.ts
+++ b/src/renderer/extensions/firstRunTour/tour/cameraFraming.ts
@@ -19,6 +19,19 @@ interface Viewport {
   height: number
 }
 
+function prefersReducedMotion(): boolean {
+  return window.matchMedia('(prefers-reduced-motion: reduce)').matches
+}
+
+/** Re-solves the fill each time: it is a fraction of a viewport that can resize. */
+function fitInstantly(bounds: ReadOnlyRect) {
+  const canvas = useCanvasStore().canvas
+  const viewport = canvas?.canvas.getBoundingClientRect()
+  if (!canvas || !viewport?.width || !viewport.height) return
+  canvas.ds.fitToBounds(bounds, { zoom: focusFill(bounds, viewport) })
+  canvas.setDirty(true, true)
+}
+
 /**
  * Fill fraction that frames `bounds` beside the card. The fit centres the node
  * and so splits the free width evenly, hence room for a card column on each
@@ -39,19 +52,6 @@ export function focusFill(bounds: ReadOnlyRect, viewport: Viewport): number {
     (scale * Math.max(width, 300)) / viewport.width,
     (scale * Math.max(height, 300)) / viewport.height
   )
-}
-
-function prefersReducedMotion(): boolean {
-  return window.matchMedia('(prefers-reduced-motion: reduce)').matches
-}
-
-/** Re-solves the fill each time: it is a fraction of a viewport that can resize. */
-function fitInstantly(bounds: ReadOnlyRect) {
-  const canvas = useCanvasStore().canvas
-  const viewport = canvas?.canvas.getBoundingClientRect()
-  if (!canvas || !viewport?.width || !viewport.height) return
-  canvas.ds.fitToBounds(bounds, { zoom: focusFill(bounds, viewport) })
-  canvas.setDirty(true, true)
 }
 
 const SETTLED_PX = 8

--- a/src/renderer/extensions/firstRunTour/tour/firstRunTourDefinition.ts
+++ b/src/renderer/extensions/firstRunTour/tour/firstRunTourDefinition.ts
@@ -20,14 +20,14 @@ import type { TourStep } from '../roles/tourSequence'
 import { frameNode } from './cameraFraming'
 import { canvasNodeTarget } from './canvasCoachTarget'
 
-/** How far the run has got, which is all the Run step's copy has to report. */
-export type RunState = 'idle' | 'generating' | 'succeeded' | 'failed'
-
 /**
  * What the workflow does. The Upload and Prompt steps mean something different
  * in each, so it selects their copy.
  */
 type TourShape = 't2i' | 'i2v' | 'image-edit' | 'other'
+
+/** How far the run has got, which is all the Run step's copy has to report. */
+export type RunState = 'idle' | 'generating' | 'succeeded' | 'failed'
 
 const COACH_ID: Record<TourStep['kind'], CoachId> = {
   upload: FIRST_RUN_COACH_IDS.source,
@@ -39,10 +39,9 @@ const COACH_ID: Record<TourStep['kind'], CoachId> = {
 /** Undoes the last registration; the tour holds one target set at a time. */
 let releaseRegistered = () => {}
 
-/** Drops the canvas targets a finished tour registered. */
-export function releaseFirstRunTargets() {
-  releaseRegistered()
-  releaseRegistered = () => {}
+interface StepContext {
+  shape: TourShape
+  runState: Readonly<Ref<RunState>>
 }
 
 function registerCanvasTargets(sequence: TourStep[]) {
@@ -71,11 +70,6 @@ function tourShape({
   if (!promptHost || !sink) return 'other'
   if (!source) return 't2i'
   return mediaKind === 'video' ? 'i2v' : 'image-edit'
-}
-
-interface StepContext {
-  shape: TourShape
-  runState: Readonly<Ref<RunState>>
 }
 
 /**
@@ -117,6 +111,12 @@ function toCoachStep(
     }
 
   return { ...framed, name: `${step.kind}.${shape}` }
+}
+
+/** Drops the canvas targets a finished tour registered. */
+export function releaseFirstRunTargets() {
+  releaseRegistered()
+  releaseRegistered = () => {}
 }
 
 /**

--- a/src/renderer/extensions/layerEditor/composables/useLayerEditorExport.ts
+++ b/src/renderer/extensions/layerEditor/composables/useLayerEditorExport.ts
@@ -15,10 +15,6 @@ function exportTimestamp(d: Date): string {
   return `${date}-${time}`
 }
 
-export function psdExportFilename(d: Date): string {
-  return `comfyui-layers-${exportTimestamp(d)}.psd`
-}
-
 function readbackCanvas(session: LayerEditorSession): HTMLCanvasElement {
   const img = session.compositor.readback()
   const canvas = document.createElement('canvas')
@@ -28,6 +24,10 @@ function readbackCanvas(session: LayerEditorSession): HTMLCanvasElement {
   if (!ctx) throw new Error('2d context unavailable')
   ctx.putImageData(img, 0, 0)
   return canvas
+}
+
+export function psdExportFilename(d: Date): string {
+  return `comfyui-layers-${exportTimestamp(d)}.psd`
 }
 
 export async function buildSessionPsdBlob(

--- a/src/renderer/extensions/layerEditor/composables/useLayerEditorSession.ts
+++ b/src/renderer/extensions/layerEditor/composables/useLayerEditorSession.ts
@@ -63,18 +63,6 @@ export const DEFAULT_BACKGROUND_COLOR = '#ffffff'
 
 const HEX_COLOR_RE = /^#[0-9a-fA-F]{6}$/
 
-export interface LayerEditorSessionOptions {
-  createCompositor?: () => Compositor
-  loadImage?: (url: string) => Promise<HTMLCanvasElement>
-}
-
-export interface LayerEditorElements {
-  viewport: HTMLElement
-  container: HTMLElement
-  main: HTMLCanvasElement
-  overlay: HTMLCanvasElement
-}
-
 function loadImageElement(url: string): Promise<HTMLImageElement> {
   return new Promise((resolve, reject) => {
     const img = new Image()
@@ -92,12 +80,6 @@ async function defaultLoadImage(url: string): Promise<HTMLCanvasElement> {
   canvas.height = img.naturalHeight || img.height
   canvas.getContext('2d')?.drawImage(img, 0, 0)
   return canvas
-}
-
-export function isTextEditingTarget(target: EventTarget | null): boolean {
-  const el = target as HTMLElement | null
-  const tag = el?.tagName
-  return tag === 'INPUT' || tag === 'TEXTAREA' || Boolean(el?.isContentEditable)
 }
 
 function sameTransform(a: Transform, b: Transform): boolean {
@@ -134,7 +116,25 @@ function flipCanvasAxis(
   return canvas
 }
 
+export interface LayerEditorSessionOptions {
+  createCompositor?: () => Compositor
+  loadImage?: (url: string) => Promise<HTMLCanvasElement>
+}
+
+export interface LayerEditorElements {
+  viewport: HTMLElement
+  container: HTMLElement
+  main: HTMLCanvasElement
+  overlay: HTMLCanvasElement
+}
+
 export type LayerEditorSession = ReturnType<typeof useLayerEditorSession>
+
+export function isTextEditingTarget(target: EventTarget | null): boolean {
+  const el = target as HTMLElement | null
+  const tag = el?.tagName
+  return tag === 'INPUT' || tag === 'TEXTAREA' || Boolean(el?.isContentEditable)
+}
 
 export function useLayerEditorSession(opts: LayerEditorSessionOptions = {}) {
   registerBuiltinKinds()

--- a/src/renderer/extensions/layerEditor/engine/commands/selection.ts
+++ b/src/renderer/extensions/layerEditor/engine/commands/selection.ts
@@ -4,6 +4,12 @@ import { Dirty } from '../history'
 import type { Command, Direction } from '../history'
 import type { ChannelData } from '../node'
 
+function applySelectionSnapshot(doc: Document, s: SelectionSnapshot): void {
+  doc.channels = doc.channels.filter((ch) => ch.role !== 'selection')
+  if (s.channel) doc.channels.push({ ...s.channel })
+  doc.selectionId = s.channel ? s.selectionId : undefined
+}
+
 export interface SelectionSnapshot {
   channel: ChannelData | null
   selectionId: string | undefined
@@ -20,12 +26,6 @@ export function snapshotSelection(doc: Document): SelectionSnapshot {
       : null,
     selectionId: channel ? channel.id : undefined
   }
-}
-
-function applySelectionSnapshot(doc: Document, s: SelectionSnapshot): void {
-  doc.channels = doc.channels.filter((ch) => ch.role !== 'selection')
-  if (s.channel) doc.channels.push({ ...s.channel })
-  doc.selectionId = s.channel ? s.selectionId : undefined
 }
 
 export class SetSelectionCommand implements Command {

--- a/src/renderer/extensions/layerEditor/engine/compositor.ts
+++ b/src/renderer/extensions/layerEditor/engine/compositor.ts
@@ -1,15 +1,6 @@
 import type { EffectiveMode } from './mode'
 import type { Rect } from './node'
 
-export interface NodeTexture {
-  source: WebGLTexture | HTMLCanvasElement | ImageBitmap | OffscreenCanvas
-  rect: Rect
-  linear: boolean
-  key?: string
-  version?: number
-  dirtyRects?: Rect[]
-}
-
 interface LayerInput {
   texture: NodeTexture
   mode: EffectiveMode
@@ -21,6 +12,15 @@ interface AdjustmentInput {
   adjust: { op: number; params: number[]; lut?: Uint8Array }
   opacity: number
   mask?: NodeTexture
+}
+
+export interface NodeTexture {
+  source: WebGLTexture | HTMLCanvasElement | ImageBitmap | OffscreenCanvas
+  rect: Rect
+  linear: boolean
+  key?: string
+  version?: number
+  dirtyRects?: Rect[]
 }
 
 export type CompositeInput = LayerInput | AdjustmentInput

--- a/src/renderer/extensions/layerEditor/engine/compositor/webglCompositor.ts
+++ b/src/renderer/extensions/layerEditor/engine/compositor/webglCompositor.ts
@@ -223,6 +223,18 @@ function link(
   return p
 }
 
+function flipRows(px: Uint8ClampedArray, w: number, h: number): void {
+  const row = w * 4
+  const tmp = new Uint8ClampedArray(row)
+  for (let y = 0; y < h >> 1; y++) {
+    const top = y * row
+    const bot = (h - 1 - y) * row
+    tmp.set(px.subarray(top, top + row))
+    px.copyWithin(top, bot, bot + row)
+    px.set(tmp, bot)
+  }
+}
+
 export function createWebGLCompositor(): Compositor {
   let canvas: OffscreenCanvas | HTMLCanvasElement | null = null
   let gl: WebGL2RenderingContext | null = null
@@ -871,17 +883,5 @@ export function createWebGLCompositor(): Compositor {
     g.bindTexture(g.TEXTURE_2D, src.tex)
     g.uniform1i(loc(copyProg!, 'u_tex'), 0)
     drawFullscreen()
-  }
-}
-
-function flipRows(px: Uint8ClampedArray, w: number, h: number): void {
-  const row = w * 4
-  const tmp = new Uint8ClampedArray(row)
-  for (let y = 0; y < h >> 1; y++) {
-    const top = y * row
-    const bot = (h - 1 - y) * row
-    tmp.set(px.subarray(top, top + row))
-    px.copyWithin(top, bot, bot + row)
-    px.set(tmp, bot)
   }
 }

--- a/src/renderer/extensions/layerEditor/engine/editor/editor.selection.test.ts
+++ b/src/renderer/extensions/layerEditor/engine/editor/editor.selection.test.ts
@@ -14,6 +14,18 @@ beforeAll(() => {
   registerBuiltinTools()
 })
 
+interface PixelBuf {
+  w: number
+  h: number
+  data: Uint8ClampedArray
+}
+
+interface FakeImg {
+  width: number
+  height: number
+  data: Uint8ClampedArray
+}
+
 class FakeCompositor implements Compositor {
   init() {
     return true
@@ -44,18 +56,6 @@ class FakeCompositor implements Compositor {
     return null
   }
   dispose() {}
-}
-
-interface PixelBuf {
-  w: number
-  h: number
-  data: Uint8ClampedArray
-}
-
-interface FakeImg {
-  width: number
-  height: number
-  data: Uint8ClampedArray
 }
 
 const bufs = new WeakMap<HTMLCanvasElement, PixelBuf>()

--- a/src/renderer/extensions/layerEditor/engine/editor/editor.test.ts
+++ b/src/renderer/extensions/layerEditor/engine/editor/editor.test.ts
@@ -17,6 +17,28 @@ beforeAll(() => {
   registerBuiltinTools()
 })
 
+function probeToolContext(editor: Editor): ToolContext {
+  let captured: ToolContext | null = null
+  registerTool({
+    id: 'probe',
+    create: (ctx) => {
+      captured = ctx
+      return {
+        id: 'probe',
+        control: defaultControl(),
+        onButtonPress: () => {},
+        onMotion: () => {},
+        onButtonRelease: () => {},
+        onHover: () => {},
+        cursorFor: () => 'default',
+        drawOverlay: () => {}
+      }
+    }
+  })
+  editor.setTool('probe')
+  return captured!
+}
+
 class FakeCompositor implements Compositor {
   canvas: HTMLCanvasElement | null = null
   readbackSize = { w: 1, h: 1 }
@@ -50,28 +72,6 @@ class FakeCompositor implements Compositor {
     return this.canvas
   }
   dispose() {}
-}
-
-function probeToolContext(editor: Editor): ToolContext {
-  let captured: ToolContext | null = null
-  registerTool({
-    id: 'probe',
-    create: (ctx) => {
-      captured = ctx
-      return {
-        id: 'probe',
-        control: defaultControl(),
-        onButtonPress: () => {},
-        onMotion: () => {},
-        onButtonRelease: () => {},
-        onHover: () => {},
-        cursorFor: () => 'default',
-        drawOverlay: () => {}
-      }
-    }
-  })
-  editor.setTool('probe')
-  return captured!
 }
 
 const ev = { pressure: 0.5, shiftKey: false } as unknown as PointerEvent

--- a/src/renderer/extensions/layerEditor/engine/editor/editor.ts
+++ b/src/renderer/extensions/layerEditor/engine/editor/editor.ts
@@ -68,12 +68,6 @@ type FloatSession =
   | { mode: 'resize'; handle: HandleId; before: Transform }
   | { mode: 'rotate'; before: Transform; grab: number }
 
-export interface EditorOptions {
-  compositor: Compositor
-  content?: ContentStore
-  onChange?: () => void
-}
-
 function emptyDocument(width: number, height: number): Document {
   const root: GroupData = {
     kind: 'group',
@@ -88,6 +82,12 @@ function emptyDocument(width: number, height: number): Document {
     passThrough: false
   }
   return { version: 2, width, height, root, channels: [] }
+}
+
+export interface EditorOptions {
+  compositor: Compositor
+  content?: ContentStore
+  onChange?: () => void
 }
 
 export interface Editor {

--- a/src/renderer/extensions/layerEditor/engine/editor/selectionMath.ts
+++ b/src/renderer/extensions/layerEditor/engine/editor/selectionMath.ts
@@ -1,89 +1,5 @@
 import type { Rect, Vec2 } from '../node'
 
-export type SelectionOp = 'replace' | 'add' | 'subtract' | 'intersect'
-
-export interface GrayMask {
-  data: Float32Array
-  width: number
-  height: number
-}
-
-export function emptyMask(width: number, height: number): GrayMask {
-  return { data: new Float32Array(width * height), width, height }
-}
-
-export function maskFromCanvas(canvas: HTMLCanvasElement): GrayMask | null {
-  const g = canvas.getContext('2d')
-  if (!g) return null
-  const img = g.getImageData(0, 0, canvas.width, canvas.height)
-  const mask = emptyMask(canvas.width, canvas.height)
-  for (let p = 0; p < mask.data.length; p++)
-    mask.data[p] = img.data[p * 4] / 255
-  return mask
-}
-
-export function maskToCanvas(mask: GrayMask): HTMLCanvasElement | null {
-  const c = document.createElement('canvas')
-  c.width = mask.width
-  c.height = mask.height
-  const g = c.getContext('2d')
-  if (!g) return null
-  const img = g.createImageData(mask.width, mask.height)
-  for (let p = 0; p < mask.data.length; p++) {
-    const v = Math.round(Math.max(0, Math.min(1, mask.data[p])) * 255)
-    img.data[p * 4] = img.data[p * 4 + 1] = img.data[p * 4 + 2] = v
-    img.data[p * 4 + 3] = 255
-  }
-  g.putImageData(img, 0, 0)
-  return c
-}
-
-export function combineMasks(
-  base: GrayMask,
-  addOn: GrayMask,
-  op: SelectionOp
-): GrayMask {
-  const out = emptyMask(base.width, base.height)
-  const a = base.data
-  const b = addOn.data
-  const d = out.data
-  switch (op) {
-    case 'replace':
-      d.set(b)
-      break
-    case 'add':
-      for (let p = 0; p < d.length; p++) d[p] = Math.min(a[p] + b[p], 1)
-      break
-    case 'subtract':
-      for (let p = 0; p < d.length; p++) d[p] = Math.max(a[p] - b[p], 0)
-      break
-    case 'intersect':
-      for (let p = 0; p < d.length; p++) d[p] = Math.min(a[p], b[p])
-      break
-  }
-  return out
-}
-
-export function maskBounds(mask: GrayMask): Rect | null {
-  let minX = mask.width
-  let minY = mask.height
-  let maxX = -1
-  let maxY = -1
-  for (let y = 0; y < mask.height; y++) {
-    const row = y * mask.width
-    for (let x = 0; x < mask.width; x++) {
-      if (mask.data[row + x] > 0) {
-        if (x < minX) minX = x
-        if (x > maxX) maxX = x
-        if (y < minY) minY = y
-        if (y > maxY) maxY = y
-      }
-    }
-  }
-  if (maxX < 0) return null
-  return { x: minX, y: minY, w: maxX - minX + 1, h: maxY - minY + 1 }
-}
-
 function vanHerk(
   line: Float32Array,
   out: Float32Array,
@@ -215,42 +131,6 @@ function withBounds(
   return pasteMask(run(cropMask(mask, rect)), rect, mask.width, mask.height)
 }
 
-export function growMask(
-  mask: GrayMask,
-  radius: number,
-  bounds: Rect | null = null
-): GrayMask {
-  return withBounds(mask, bounds, Math.round(radius) + 1, (m) =>
-    ellipticalFilter(m, radius, Math.max, 0)
-  )
-}
-
-export function shrinkMask(
-  mask: GrayMask,
-  radius: number,
-  bounds: Rect | null = null
-): GrayMask {
-  return withBounds(mask, bounds, Math.round(radius) + 1, (m) =>
-    ellipticalFilter(m, radius, Math.min, 0)
-  )
-}
-
-export function borderMask(
-  mask: GrayMask,
-  radius: number,
-  bounds: Rect | null = null
-): GrayMask {
-  return withBounds(mask, bounds, Math.round(radius) + 1, (m) => {
-    const grown = ellipticalFilter(m, radius, Math.max, 0)
-    const shrunk = ellipticalFilter(m, radius, Math.min, 0)
-    const out = emptyMask(m.width, m.height)
-    for (let p = 0; p < out.data.length; p++) {
-      out.data[p] = Math.max(grown.data[p] - shrunk.data[p], 0)
-    }
-    return out
-  })
-}
-
 function boxBlurPass(
   src: Float32Array,
   dst: Float32Array,
@@ -298,16 +178,6 @@ function boxesForGauss(sigma: number, n: number): number[] {
   const sizes: number[] = []
   for (let i = 0; i < n; i++) sizes.push(i < m ? wl : wu)
   return sizes
-}
-
-export function featherMask(
-  mask: GrayMask,
-  radius: number,
-  bounds: Rect | null = null
-): GrayMask {
-  return withBounds(mask, bounds, Math.ceil(radius) + 2, (m) =>
-    featherMaskFull(m, radius)
-  )
 }
 
 function smallGaussian(mask: GrayMask, sigma: number): GrayMask {
@@ -365,12 +235,6 @@ function featherMaskFull(mask: GrayMask, radius: number): GrayMask {
   return cur
 }
 
-export interface FloodSource {
-  data: Uint8ClampedArray
-  width: number
-  height: number
-}
-
 function pixelDifference(
   c1r: number,
   c1g: number,
@@ -400,6 +264,142 @@ function pixelDifference(
     return 1
   }
   return max > threshold ? 0 : 1
+}
+
+export type SelectionOp = 'replace' | 'add' | 'subtract' | 'intersect'
+
+export interface GrayMask {
+  data: Float32Array
+  width: number
+  height: number
+}
+
+export interface FloodSource {
+  data: Uint8ClampedArray
+  width: number
+  height: number
+}
+
+export function emptyMask(width: number, height: number): GrayMask {
+  return { data: new Float32Array(width * height), width, height }
+}
+
+export function maskFromCanvas(canvas: HTMLCanvasElement): GrayMask | null {
+  const g = canvas.getContext('2d')
+  if (!g) return null
+  const img = g.getImageData(0, 0, canvas.width, canvas.height)
+  const mask = emptyMask(canvas.width, canvas.height)
+  for (let p = 0; p < mask.data.length; p++)
+    mask.data[p] = img.data[p * 4] / 255
+  return mask
+}
+
+export function maskToCanvas(mask: GrayMask): HTMLCanvasElement | null {
+  const c = document.createElement('canvas')
+  c.width = mask.width
+  c.height = mask.height
+  const g = c.getContext('2d')
+  if (!g) return null
+  const img = g.createImageData(mask.width, mask.height)
+  for (let p = 0; p < mask.data.length; p++) {
+    const v = Math.round(Math.max(0, Math.min(1, mask.data[p])) * 255)
+    img.data[p * 4] = img.data[p * 4 + 1] = img.data[p * 4 + 2] = v
+    img.data[p * 4 + 3] = 255
+  }
+  g.putImageData(img, 0, 0)
+  return c
+}
+
+export function combineMasks(
+  base: GrayMask,
+  addOn: GrayMask,
+  op: SelectionOp
+): GrayMask {
+  const out = emptyMask(base.width, base.height)
+  const a = base.data
+  const b = addOn.data
+  const d = out.data
+  switch (op) {
+    case 'replace':
+      d.set(b)
+      break
+    case 'add':
+      for (let p = 0; p < d.length; p++) d[p] = Math.min(a[p] + b[p], 1)
+      break
+    case 'subtract':
+      for (let p = 0; p < d.length; p++) d[p] = Math.max(a[p] - b[p], 0)
+      break
+    case 'intersect':
+      for (let p = 0; p < d.length; p++) d[p] = Math.min(a[p], b[p])
+      break
+  }
+  return out
+}
+
+export function maskBounds(mask: GrayMask): Rect | null {
+  let minX = mask.width
+  let minY = mask.height
+  let maxX = -1
+  let maxY = -1
+  for (let y = 0; y < mask.height; y++) {
+    const row = y * mask.width
+    for (let x = 0; x < mask.width; x++) {
+      if (mask.data[row + x] > 0) {
+        if (x < minX) minX = x
+        if (x > maxX) maxX = x
+        if (y < minY) minY = y
+        if (y > maxY) maxY = y
+      }
+    }
+  }
+  if (maxX < 0) return null
+  return { x: minX, y: minY, w: maxX - minX + 1, h: maxY - minY + 1 }
+}
+
+export function growMask(
+  mask: GrayMask,
+  radius: number,
+  bounds: Rect | null = null
+): GrayMask {
+  return withBounds(mask, bounds, Math.round(radius) + 1, (m) =>
+    ellipticalFilter(m, radius, Math.max, 0)
+  )
+}
+
+export function shrinkMask(
+  mask: GrayMask,
+  radius: number,
+  bounds: Rect | null = null
+): GrayMask {
+  return withBounds(mask, bounds, Math.round(radius) + 1, (m) =>
+    ellipticalFilter(m, radius, Math.min, 0)
+  )
+}
+
+export function borderMask(
+  mask: GrayMask,
+  radius: number,
+  bounds: Rect | null = null
+): GrayMask {
+  return withBounds(mask, bounds, Math.round(radius) + 1, (m) => {
+    const grown = ellipticalFilter(m, radius, Math.max, 0)
+    const shrunk = ellipticalFilter(m, radius, Math.min, 0)
+    const out = emptyMask(m.width, m.height)
+    for (let p = 0; p < out.data.length; p++) {
+      out.data[p] = Math.max(grown.data[p] - shrunk.data[p], 0)
+    }
+    return out
+  })
+}
+
+export function featherMask(
+  mask: GrayMask,
+  radius: number,
+  bounds: Rect | null = null
+): GrayMask {
+  return withBounds(mask, bounds, Math.ceil(radius) + 2, (m) =>
+    featherMaskFull(m, radius)
+  )
 }
 
 export function floodSelectMask(

--- a/src/renderer/extensions/layerEditor/engine/fill.ts
+++ b/src/renderer/extensions/layerEditor/engine/fill.ts
@@ -19,17 +19,6 @@ const clamp01 = (v: number): number => Math.max(0, Math.min(1, v))
 const num = (v: unknown, d: number): number =>
   typeof v === 'number' && isFinite(v) ? v : d
 
-export function defaultFillSpec(): FillSpec {
-  return { type: 'solid', color: '#808080' }
-}
-
-export function defaultGradientStops(): GradientStop[] {
-  return [
-    { offset: 0, color: '#000000' },
-    { offset: 1, color: '#ffffff' }
-  ]
-}
-
 function normalizeStops(raw: unknown): GradientStop[] {
   const arr = Array.isArray(raw) ? raw : []
   const stops: GradientStop[] = []
@@ -44,6 +33,33 @@ function normalizeStops(raw: unknown): GradientStop[] {
   }
   stops.sort((a, b) => a.offset - b.offset)
   return stops.length >= 2 ? stops : defaultGradientStops()
+}
+
+function stopColor(stop: GradientStop): string {
+  if (stop.alpha === undefined || stop.alpha >= 1) return stop.color
+  const hex = stop.color.replace('#', '')
+  const full =
+    hex.length === 3
+      ? hex
+          .split('')
+          .map((c) => c + c)
+          .join('')
+      : hex
+  const r = parseInt(full.slice(0, 2), 16)
+  const g = parseInt(full.slice(2, 4), 16)
+  const b = parseInt(full.slice(4, 6), 16)
+  return `rgba(${r},${g},${b},${stop.alpha})`
+}
+
+export function defaultFillSpec(): FillSpec {
+  return { type: 'solid', color: '#808080' }
+}
+
+export function defaultGradientStops(): GradientStop[] {
+  return [
+    { offset: 0, color: '#000000' },
+    { offset: 1, color: '#ffffff' }
+  ]
 }
 
 export function normalizeFillSpec(raw: unknown): FillSpec {
@@ -96,22 +112,6 @@ export function linearEndpoints(
     from: { x: cx - dx * half, y: cy - dy * half },
     to: { x: cx + dx * half, y: cy + dy * half }
   }
-}
-
-function stopColor(stop: GradientStop): string {
-  if (stop.alpha === undefined || stop.alpha >= 1) return stop.color
-  const hex = stop.color.replace('#', '')
-  const full =
-    hex.length === 3
-      ? hex
-          .split('')
-          .map((c) => c + c)
-          .join('')
-      : hex
-  const r = parseInt(full.slice(0, 2), 16)
-  const g = parseInt(full.slice(2, 4), 16)
-  const b = parseInt(full.slice(4, 6), 16)
-  return `rgba(${r},${g},${b},${stop.alpha})`
 }
 
 export function paintFillInto(

--- a/src/renderer/extensions/layerEditor/engine/history.ts
+++ b/src/renderer/extensions/layerEditor/engine/history.ts
@@ -21,6 +21,11 @@ export interface Command {
   contentRefs?(): string[]
 }
 
+export interface HistoryOptions {
+  byteBudget?: number
+  minSteps?: number
+}
+
 export class CommandGroup implements Command {
   readonly children: Command[] = []
   constructor(readonly label: string) {}
@@ -45,11 +50,6 @@ export class CommandGroup implements Command {
   get empty(): boolean {
     return this.children.length === 0
   }
-}
-
-export interface HistoryOptions {
-  byteBudget?: number
-  minSteps?: number
 }
 
 export class History {

--- a/src/renderer/extensions/layerEditor/engine/mode.ts
+++ b/src/renderer/extensions/layerEditor/engine/mode.ts
@@ -1,3 +1,18 @@
+type SpaceOrAuto = ColorSpace | 'auto'
+
+function def(
+  blend: BlendFn,
+  blendSpace: ColorSpace,
+  composite: CompositeMode
+): LayerModeDef {
+  return {
+    blend,
+    defaultBlendSpace: blendSpace,
+    defaultCompositeSpace: 'linear',
+    defaultComposite: composite
+  }
+}
+
 export type BlendFn =
   | 'normal'
   | 'multiply'
@@ -34,8 +49,6 @@ export type CompositeMode =
   | 'clip-to-layer'
   | 'intersection'
 
-type SpaceOrAuto = ColorSpace | 'auto'
-
 export interface LayerMode {
   blend: BlendFn
   blendSpace: SpaceOrAuto
@@ -57,19 +70,6 @@ export interface LayerModeDef {
   defaultBlendSpace: ColorSpace
   defaultCompositeSpace: ColorSpace
   defaultComposite: CompositeMode
-}
-
-function def(
-  blend: BlendFn,
-  blendSpace: ColorSpace,
-  composite: CompositeMode
-): LayerModeDef {
-  return {
-    blend,
-    defaultBlendSpace: blendSpace,
-    defaultCompositeSpace: 'linear',
-    defaultComposite: composite
-  }
 }
 
 export const LAYER_MODES: Record<BlendFn, LayerModeDef> = {

--- a/src/renderer/extensions/layerEditor/engine/node.ts
+++ b/src/renderer/extensions/layerEditor/engine/node.ts
@@ -1,6 +1,14 @@
 import type { FillSpec } from './fill'
 import type { LayerMode } from './mode'
 
+interface Locks {
+  content: boolean
+  position: boolean
+  visibility: boolean
+}
+
+type ChannelRole = 'mask' | 'selection' | 'saved'
+
 export interface Vec2 {
   x: number
   y: number
@@ -21,12 +29,6 @@ export interface Transform {
   rotation: number
 }
 
-interface Locks {
-  content: boolean
-  position: boolean
-  visibility: boolean
-}
-
 export interface NodeBase {
   id: string
   kind: string
@@ -38,8 +40,6 @@ export interface NodeBase {
   locks: Locks
   colorTag?: string
 }
-
-type ChannelRole = 'mask' | 'selection' | 'saved'
 
 export interface ChannelData {
   id: string

--- a/src/renderer/extensions/layerEditor/engine/render/outsideCanvasPreview.ts
+++ b/src/renderer/extensions/layerEditor/engine/render/outsideCanvasPreview.ts
@@ -6,12 +6,6 @@ import type { Bitmap } from './place'
 
 const CLIPPED_LAYER_PREVIEW_OPACITY = 0.4
 
-export interface OutsideCanvasPreviewLayer {
-  bitmap: Bitmap
-  opacity: number
-  transform: Transform
-}
-
 interface CanvasSize {
   w: number
   h: number
@@ -28,6 +22,12 @@ function extendsOutsideCanvas(
     bounds.x + bounds.w > canvas.w ||
     bounds.y + bounds.h > canvas.h
   )
+}
+
+export interface OutsideCanvasPreviewLayer {
+  bitmap: Bitmap
+  opacity: number
+  transform: Transform
 }
 
 export function drawOutsideCanvasPreview(

--- a/src/renderer/extensions/layerEditor/engine/render/renderStack.test.ts
+++ b/src/renderer/extensions/layerEditor/engine/render/renderStack.test.ts
@@ -71,6 +71,10 @@ function doc(children: SceneNode[]): Document {
   }
 }
 
+function deps(compositor: Compositor): RenderDeps {
+  return { content: new DefaultContentStore(), compositor }
+}
+
 class FakeCompositor implements Compositor {
   composites: Array<{
     inputs: CompositeInput[]
@@ -119,10 +123,6 @@ class FakeCompositor implements Compositor {
     return null
   }
   dispose() {}
-}
-
-function deps(compositor: Compositor): RenderDeps {
-  return { content: new DefaultContentStore(), compositor }
 }
 
 describe('renderDocument', () => {

--- a/src/renderer/extensions/layerEditor/engine/render/renderStack.ts
+++ b/src/renderer/extensions/layerEditor/engine/render/renderStack.ts
@@ -8,29 +8,7 @@ import { getNodeKind } from '../nodeKind'
 import type { Bitmap } from './place'
 import { placeBitmap } from './place'
 
-export interface PlacedEntry {
-  stamp: string
-  canvas: HTMLCanvasElement
-}
-
-export interface PreviewOverride {
-  canvas: HTMLCanvasElement
-  version: number
-  rects?: Rect[] | null
-}
-
-export interface RenderDeps {
-  content: ContentStore
-  compositor: Compositor
-  devicePixelRatio?: number
-  overrides?: Map<string, PreviewOverride>
-  placedCache?: Map<string, PlacedEntry>
-}
-
-export interface BuiltInputs {
-  inputs: CompositeInput[]
-  cleanup: () => void
-}
+type PlacedFn = ReturnType<typeof makePlaced>
 
 function transformStamp(t: Transform): string {
   return `${t.x},${t.y},${t.w},${t.h},${t.rotation}`
@@ -69,8 +47,6 @@ function makePlaced(deps: RenderDeps, region: Rect, used: Set<string>) {
     return { source: canvas, rect: region, linear, key: stamp }
   }
 }
-
-type PlacedFn = ReturnType<typeof makePlaced>
 
 function renderMaskTexture(
   node: SceneNode,
@@ -265,6 +241,30 @@ function buildInputs(
   }
 
   return { inputs, cleanup: () => cleanups.forEach((fn) => fn()) }
+}
+
+export interface PlacedEntry {
+  stamp: string
+  canvas: HTMLCanvasElement
+}
+
+export interface PreviewOverride {
+  canvas: HTMLCanvasElement
+  version: number
+  rects?: Rect[] | null
+}
+
+export interface RenderDeps {
+  content: ContentStore
+  compositor: Compositor
+  devicePixelRatio?: number
+  overrides?: Map<string, PreviewOverride>
+  placedCache?: Map<string, PlacedEntry>
+}
+
+export interface BuiltInputs {
+  inputs: CompositeInput[]
+  cleanup: () => void
 }
 
 export function buildDocumentInputs(

--- a/src/renderer/extensions/layerEditor/engine/snapping.ts
+++ b/src/renderer/extensions/layerEditor/engine/snapping.ts
@@ -1,72 +1,14 @@
 import type { Rect } from './node'
-export interface SnapTargets {
-  xs: number[]
-  ys: number[]
-}
-export interface Guide {
-  axis: 'x' | 'y'
-  pos: number
-  kind?: 'edge' | 'gap'
-  cross?: number
-  spans?: Array<[number, number]>
-}
-export interface SnapExtras {
-  gridX?: number
-  gridY?: number
-  guideXs?: number[]
-  guideYs?: number[]
-}
-export interface SnapOpts {
-  thrX: number
-  thrY: number
-  minWH: number
-  boundsW?: number
-  boundsH?: number
-  clamp?: boolean
-  eqRects?: Rect[]
-}
-export interface SnapResult {
-  rect: Rect
-  guides: Guide[]
-}
-
-function clampNum(v: number, lo: number, hi: number): number {
-  return Math.max(lo, Math.min(hi, v))
-}
-
-export function buildSnapTargets(
-  otherRects: Rect[],
-  bounds?: { w: number; h: number },
-  extras?: SnapExtras
-): SnapTargets {
-  const bw = bounds?.w ?? 1
-  const bh = bounds?.h ?? 1
-  const xs = [0, bw / 2, bw]
-  const ys = [0, bh / 2, bh]
-  for (const r of otherRects) {
-    xs.push(r.x, r.x + r.w / 2, r.x + r.w)
-    ys.push(r.y, r.y + r.h / 2, r.y + r.h)
-  }
-  if (extras?.gridX && extras.gridX > 0) {
-    for (let v = 0; v <= bw + 1e-9; v += extras.gridX) xs.push(v)
-  }
-  if (extras?.gridY && extras.gridY > 0) {
-    for (let v = 0; v <= bh + 1e-9; v += extras.gridY) ys.push(v)
-  }
-  for (const g of extras?.guideXs ?? []) xs.push(g)
-  for (const g of extras?.guideYs ?? []) ys.push(g)
-  return { xs, ys }
-}
-
 interface EqCandidate {
   pos: number
   guide: Guide
 }
-
+function clampNum(v: number, lo: number, hi: number): number {
+  return Math.max(lo, Math.min(hi, v))
+}
 function overlaps(a0: number, a1: number, b0: number, b1: number): boolean {
   return a0 < b1 && a1 > b0
 }
-
 function eqCandidatesAxis(
   rect: Rect,
   others: Rect[],
@@ -151,6 +93,64 @@ function eqCandidatesAxis(
     }
   }
   return out
+}
+export interface SnapTargets {
+  xs: number[]
+  ys: number[]
+}
+
+export interface Guide {
+  axis: 'x' | 'y'
+  pos: number
+  kind?: 'edge' | 'gap'
+  cross?: number
+  spans?: Array<[number, number]>
+}
+
+export interface SnapExtras {
+  gridX?: number
+  gridY?: number
+  guideXs?: number[]
+  guideYs?: number[]
+}
+
+export interface SnapOpts {
+  thrX: number
+  thrY: number
+  minWH: number
+  boundsW?: number
+  boundsH?: number
+  clamp?: boolean
+  eqRects?: Rect[]
+}
+
+export interface SnapResult {
+  rect: Rect
+  guides: Guide[]
+}
+
+export function buildSnapTargets(
+  otherRects: Rect[],
+  bounds?: { w: number; h: number },
+  extras?: SnapExtras
+): SnapTargets {
+  const bw = bounds?.w ?? 1
+  const bh = bounds?.h ?? 1
+  const xs = [0, bw / 2, bw]
+  const ys = [0, bh / 2, bh]
+  for (const r of otherRects) {
+    xs.push(r.x, r.x + r.w / 2, r.x + r.w)
+    ys.push(r.y, r.y + r.h / 2, r.y + r.h)
+  }
+  if (extras?.gridX && extras.gridX > 0) {
+    for (let v = 0; v <= bw + 1e-9; v += extras.gridX) xs.push(v)
+  }
+  if (extras?.gridY && extras.gridY > 0) {
+    for (let v = 0; v <= bh + 1e-9; v += extras.gridY) ys.push(v)
+  }
+  for (const g of extras?.guideXs ?? []) xs.push(g)
+  for (const g of extras?.guideYs ?? []) ys.push(g)
+  return { xs, ys }
 }
 
 export function nearestTarget(

--- a/src/renderer/extensions/layerEditor/engine/tool.ts
+++ b/src/renderer/extensions/layerEditor/engine/tool.ts
@@ -17,18 +17,6 @@ export interface ToolControl {
   motionMode: 'exact' | 'compressed'
 }
 
-export function defaultControl(): ToolControl {
-  return {
-    active: false,
-    pausedDepth: 0,
-    abortMask: 0,
-    cursor: 'default',
-    wantsClick: true,
-    wantsDoubleClick: false,
-    motionMode: 'compressed'
-  }
-}
-
 export type CanvasItem =
   | {
       type: 'handle'
@@ -90,6 +78,18 @@ export interface Tool {
 export interface ToolDef {
   id: string
   create(ctx: ToolContext): Tool
+}
+
+export function defaultControl(): ToolControl {
+  return {
+    active: false,
+    pausedDepth: 0,
+    abortMask: 0,
+    cursor: 'default',
+    wantsClick: true,
+    wantsDoubleClick: false,
+    motionMode: 'compressed'
+  }
 }
 
 const registry = new Map<string, ToolDef>()

--- a/src/renderer/extensions/layerEditor/engine/tools/transformMath.ts
+++ b/src/renderer/extensions/layerEditor/engine/tools/transformMath.ts
@@ -43,14 +43,14 @@ function rot(p: Vec2, a: number): Vec2 {
   return { x: p.x * c - p.y * s, y: p.x * s + p.y * c }
 }
 
-export function center(t: Transform): Vec2 {
-  return { x: t.x + t.w / 2, y: t.y + t.h / 2 }
-}
-
 function axes(t: Transform): { ex: Vec2; ey: Vec2 } {
   const c = Math.cos(t.rotation)
   const s = Math.sin(t.rotation)
   return { ex: { x: c, y: s }, ey: { x: -s, y: c } }
+}
+
+export function center(t: Transform): Vec2 {
+  return { x: t.x + t.w / 2, y: t.y + t.h / 2 }
 }
 
 export function handlePos(t: Transform, h: HandleId): Vec2 {

--- a/src/renderer/extensions/layerEditor/engine/tools/transformTool.ts
+++ b/src/renderer/extensions/layerEditor/engine/tools/transformTool.ts
@@ -56,12 +56,6 @@ type Drag =
       bases: Map<string, Transform>
     }
 
-export interface TransformToolApi {
-  apply(): boolean
-  cancel(): boolean
-  isDirty(): boolean
-}
-
 function sameTransform(a: Transform, b: Transform): boolean {
   return (
     a.x === b.x &&
@@ -74,10 +68,6 @@ function sameTransform(a: Transform, b: Transform): boolean {
 
 function sameIds(a: string[], b: string[]): boolean {
   return a.length === b.length && a.every((x, i) => x === b[i])
-}
-
-export function canTransformNode(node: SceneNode | null): node is SceneNode {
-  return !!node && TRANSFORMABLE_KINDS.has(node.kind) && !node.locks.position
 }
 
 function computeGizmo(targets: SceneNode[]): Transform {
@@ -483,6 +473,16 @@ class TransformTool implements Tool, TransformToolApi {
     if (changed) this.ctx.requestRender()
     return changed
   }
+}
+
+export interface TransformToolApi {
+  apply(): boolean
+  cancel(): boolean
+  isDirty(): boolean
+}
+
+export function canTransformNode(node: SceneNode | null): node is SceneNode {
+  return !!node && TRANSFORMABLE_KINDS.has(node.kind) && !node.locks.position
 }
 
 export function isTransformTool(

--- a/src/renderer/extensions/layerEditor/psdExport.ts
+++ b/src/renderer/extensions/layerEditor/psdExport.ts
@@ -38,31 +38,6 @@ export interface PsdExportDeps {
 
 const clamp01 = (v: number) => Math.max(0, Math.min(1, v))
 
-export function makeGuid(): string {
-  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function')
-    return crypto.randomUUID()
-  let out = ''
-  for (let i = 0; i < 36; i++) {
-    if (i === 8 || i === 13 || i === 18 || i === 23) out += '-'
-    else out += Math.floor(Math.random() * 16).toString(16)
-  }
-  return out
-}
-
-export function transformCorners(t: Transform): number[] {
-  const cx = t.x + t.w / 2
-  const cy = t.y + t.h / 2
-  const cos = Math.cos(t.rotation)
-  const sin = Math.sin(t.rotation)
-  const pt = (dx: number, dy: number) => [
-    cx + dx * cos - dy * sin,
-    cy + dx * sin + dy * cos
-  ]
-  const hw = t.w / 2
-  const hh = t.h / 2
-  return [...pt(-hw, -hh), ...pt(hw, -hh), ...pt(hw, hh), ...pt(-hw, hh)]
-}
-
 function maskData(
   node: SceneNode,
   deps: PsdExportDeps
@@ -152,6 +127,16 @@ async function buildLayer(
   return layer
 }
 
+async function canvasPngBytes(canvas: HTMLCanvasElement): Promise<Uint8Array> {
+  const blob = await new Promise<Blob>((res, rej) =>
+    canvas.toBlob(
+      (b) => (b ? res(b) : rej(new Error('toBlob null'))),
+      'image/png'
+    )
+  )
+  return new Uint8Array(await blob.arrayBuffer())
+}
+
 export interface PsdRenderHost {
   document(): Document
   render(): void
@@ -160,6 +145,31 @@ export interface PsdRenderHost {
 
 export interface PsdContentSource {
   get(id: string): ContentEntry | undefined
+}
+
+export function makeGuid(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function')
+    return crypto.randomUUID()
+  let out = ''
+  for (let i = 0; i < 36; i++) {
+    if (i === 8 || i === 13 || i === 18 || i === 23) out += '-'
+    else out += Math.floor(Math.random() * 16).toString(16)
+  }
+  return out
+}
+
+export function transformCorners(t: Transform): number[] {
+  const cx = t.x + t.w / 2
+  const cy = t.y + t.h / 2
+  const cos = Math.cos(t.rotation)
+  const sin = Math.sin(t.rotation)
+  const pt = (dx: number, dy: number) => [
+    cx + dx * cos - dy * sin,
+    cy + dx * sin + dy * cos
+  ]
+  const hw = t.w / 2
+  const hh = t.h / 2
+  return [...pt(-hw, -hh), ...pt(hw, -hh), ...pt(hw, hh), ...pt(-hw, hh)]
 }
 
 export function leafPlacedBounds(t: Transform, doc: Document): Rect {
@@ -235,16 +245,6 @@ export function maskToPlacedCanvas(
   ctx.rotate(tf.rotation)
   ctx.drawImage(entry.canvas, -tf.w / 2, -tf.h / 2, tf.w, tf.h)
   return { canvas: c, left: bounds.x, top: bounds.y }
-}
-
-async function canvasPngBytes(canvas: HTMLCanvasElement): Promise<Uint8Array> {
-  const blob = await new Promise<Blob>((res, rej) =>
-    canvas.toBlob(
-      (b) => (b ? res(b) : rej(new Error('toBlob null'))),
-      'image/png'
-    )
-  )
-  return new Uint8Array(await blob.arrayBuffer())
 }
 
 export async function buildPsdFromEditor(

--- a/src/renderer/extensions/minimap/composables/useMinimapGraph.ts
+++ b/src/renderer/extensions/minimap/composables/useMinimapGraph.ts
@@ -17,6 +17,13 @@ interface GraphCallbacks {
   onConnectionChange?: (node: LGraphNode) => void
 }
 
+interface GraphDigests {
+  /** Node placement: drives bounds recomputation as well as repaint. */
+  geometry: number
+  /** Everything else the renderer draws: repaint only, bounds untouched. */
+  visual: number
+}
+
 /**
  * Fixed-point quantisation for digest input, at eighth-pixel precision.
  * Mixing raw values would truncate at each `| 0`, so a drag or resize that
@@ -46,13 +53,6 @@ function hashString(value: string): number {
     hash = (Math.imul(hash, 31) + value.charCodeAt(i)) | 0
   }
   return hash
-}
-
-interface GraphDigests {
-  /** Node placement: drives bounds recomputation as well as repaint. */
-  geometry: number
-  /** Everything else the renderer draws: repaint only, bounds untouched. */
-  visual: number
 }
 
 /**

--- a/src/renderer/extensions/minimap/types.ts
+++ b/src/renderer/extensions/minimap/types.ts
@@ -4,6 +4,14 @@
 import type { LGraph } from '@/lib/litegraph/src/litegraph'
 import type { NodeId } from '@/types/nodeId'
 
+interface MinimapRenderSettings {
+  nodeColors: boolean
+  showLinks: boolean
+  showGroups: boolean
+  renderBypass: boolean
+  renderError: boolean
+}
+
 /**
  * Minimal interface for what the minimap needs from the canvas
  */
@@ -28,14 +36,6 @@ export interface MinimapRenderContext {
   settings: MinimapRenderSettings
   width: number
   height: number
-}
-
-interface MinimapRenderSettings {
-  nodeColors: boolean
-  showLinks: boolean
-  showGroups: boolean
-  renderBypass: boolean
-  renderError: boolean
 }
 
 export interface MinimapBounds {

--- a/src/renderer/extensions/vueNodes/composables/usePartitionedBadges.ts
+++ b/src/renderer/extensions/vueNodes/composables/usePartitionedBadges.ts
@@ -16,17 +16,49 @@ import type { SerializedNodeId } from '@/types/nodeId'
 import { NodeBadgeMode } from '@/types/nodeSource'
 import { widgetId } from '@/types/widgetId'
 
-function splitAroundFirstSpace(text: string): [string, string | undefined] {
-  const index = text.indexOf(' ')
-  if (index === -1) return [text, undefined]
-  return [text.slice(0, index), text.slice(index + 1)]
-}
-
 type TrackableNode = {
   id: SerializedNodeId
   type: string
   inputs?: INodeInputSlot[]
 }
+
+function splitAroundFirstSpace(text: string): [string, string | undefined] {
+  const index = text.indexOf(' ')
+  if (index === -1) return [text, undefined]
+  return [text.slice(0, index), text.slice(index + 1)]
+}
+/**
+ * Register reactive deps on every contained api node's pricing inputs so the
+ * SubgraphNode wrapper's badge computed re-runs when an inner (e.g. promoted)
+ * widget value changes. Also tracks the wrapper's own promoted widget host
+ * values so user edits on the wrapper trigger re-evaluation.
+ */
+function trackSubgraphInnerNodePrices(wrapper: LGraphNode) {
+  if (!wrapper.isSubgraphNode()) return
+  // Touch each promoted widget's host value to register reactive deps.
+  for (const w of wrapper.widgets ?? []) void w.value
+
+  const visited = new Set<string>()
+  function walk(nodes: LGraphNode[]) {
+    for (const inner of nodes) {
+      if (inner.isSubgraphNode()) {
+        const id = String(inner.subgraph.id)
+        if (visited.has(id)) continue
+        visited.add(id)
+        walk(inner.subgraph.nodes)
+        continue
+      }
+      if (!inner.constructor?.nodeData?.api_node) continue
+      trackNodePrice({
+        id: inner.id,
+        type: inner.type ?? '',
+        inputs: inner.inputs
+      })
+    }
+  }
+  walk(wrapper.subgraph.nodes)
+}
+
 //TODO deduplicate reactivity tracking once more thoroughly tested
 export function trackNodePrice(node: TrackableNode) {
   const {
@@ -71,38 +103,6 @@ export function trackNodePrice(node: TrackableNode) {
       }
     })
   }
-}
-
-/**
- * Register reactive deps on every contained api node's pricing inputs so the
- * SubgraphNode wrapper's badge computed re-runs when an inner (e.g. promoted)
- * widget value changes. Also tracks the wrapper's own promoted widget host
- * values so user edits on the wrapper trigger re-evaluation.
- */
-function trackSubgraphInnerNodePrices(wrapper: LGraphNode) {
-  if (!wrapper.isSubgraphNode()) return
-  // Touch each promoted widget's host value to register reactive deps.
-  for (const w of wrapper.widgets ?? []) void w.value
-
-  const visited = new Set<string>()
-  function walk(nodes: LGraphNode[]) {
-    for (const inner of nodes) {
-      if (inner.isSubgraphNode()) {
-        const id = String(inner.subgraph.id)
-        if (visited.has(id)) continue
-        visited.add(id)
-        walk(inner.subgraph.nodes)
-        continue
-      }
-      if (!inner.constructor?.nodeData?.api_node) continue
-      trackNodePrice({
-        id: inner.id,
-        type: inner.type ?? '',
-        inputs: inner.inputs
-      })
-    }
-  }
-  walk(wrapper.subgraph.nodes)
 }
 
 export function usePartitionedBadges(nodeData: VueNodeData) {

--- a/src/renderer/extensions/vueNodes/composables/useProcessedWidgets.ts
+++ b/src/renderer/extensions/vueNodes/composables/useProcessedWidgets.ts
@@ -55,10 +55,6 @@ import type {
 
 const TOOLTIP_VALUE_TYPES = ['asset', 'combo', 'number', 'text'] as const
 type TooltipValueType = (typeof TOOLTIP_VALUE_TYPES)[number]
-function isTooltipValueType(val: unknown): val is TooltipValueType {
-  return TOOLTIP_VALUE_TYPES.includes(val as TooltipValueType)
-}
-
 interface ProcessedWidget {
   advanced: boolean
   handleContextMenu: (e: PointerEvent) => void
@@ -93,6 +89,10 @@ interface ComputeProcessedWidgetsOptions {
   ui: WidgetUiCallbacks
 }
 
+function isTooltipValueType(val: unknown): val is TooltipValueType {
+  return TOOLTIP_VALUE_TYPES.includes(val as TooltipValueType)
+}
+
 function createWidgetUpdateHandler(
   widgetState: WidgetState | undefined,
   widget: SafeWidgetData,
@@ -122,6 +122,37 @@ function createWidgetUpdateHandler(
       options
     )
   }
+}
+
+function getProcessedNodeExecutionId(
+  isGraphReady: boolean,
+  rootGraph: LGraph | null,
+  nodeData: VueNodeData
+): NodeExecutionId | null {
+  if (!isGraphReady || !rootGraph) return createNodeExecutionId([nodeData.id])
+
+  return getExecutionIdFromNodeData(rootGraph, nodeData)
+}
+
+function getWidgetNodeLocatorId(
+  nodeData: VueNodeData,
+  bareWidgetId: NodeId | null,
+  sourceExecutionId: NodeExecutionId | undefined,
+  rootGraph: LGraph | null
+): NodeLocatorId | undefined {
+  if (sourceExecutionId && rootGraph) {
+    const sourceLocator = executionIdToNodeLocatorId(
+      rootGraph,
+      sourceExecutionId
+    )
+    if (sourceLocator) return sourceLocator
+  }
+
+  if (!bareWidgetId) return undefined
+
+  return (
+    createNodeLocatorId(nodeData.subgraphId ?? null, bareWidgetId) ?? undefined
+  )
 }
 
 export function hasWidgetError(
@@ -177,37 +208,6 @@ export function getWidgetIdentity(
     dedupeIdentity ??
     `transient:${String(nodeId ?? '')}:${widget.name}:${widget.type}:${index}`
   return { dedupeIdentity, renderKey }
-}
-
-function getProcessedNodeExecutionId(
-  isGraphReady: boolean,
-  rootGraph: LGraph | null,
-  nodeData: VueNodeData
-): NodeExecutionId | null {
-  if (!isGraphReady || !rootGraph) return createNodeExecutionId([nodeData.id])
-
-  return getExecutionIdFromNodeData(rootGraph, nodeData)
-}
-
-function getWidgetNodeLocatorId(
-  nodeData: VueNodeData,
-  bareWidgetId: NodeId | null,
-  sourceExecutionId: NodeExecutionId | undefined,
-  rootGraph: LGraph | null
-): NodeLocatorId | undefined {
-  if (sourceExecutionId && rootGraph) {
-    const sourceLocator = executionIdToNodeLocatorId(
-      rootGraph,
-      sourceExecutionId
-    )
-    if (sourceLocator) return sourceLocator
-  }
-
-  if (!bareWidgetId) return undefined
-
-  return (
-    createNodeLocatorId(nodeData.subgraphId ?? null, bareWidgetId) ?? undefined
-  )
 }
 
 export function isWidgetVisible(

--- a/src/renderer/extensions/vueNodes/composables/useSlotElementTracking.ts
+++ b/src/renderer/extensions/vueNodes/composables/useSlotElementTracking.ts
@@ -31,14 +31,6 @@ const raf = createRafBatch(() => {
   flushScheduledSlotLayoutSync()
 })
 
-export function scheduleSlotLayoutSync(nodeId: NodeId) {
-  // Drop signals for unregistered nodes (e.g. preview nodes with synthetic
-  // ids from LGraphNodePreview) - they'd otherwise pump setDirty per RAF.
-  if (!useNodeSlotRegistryStore().getNode(nodeId)) return
-  pendingNodes.add(nodeId)
-  raf.schedule()
-}
-
 function shouldWaitForSlotLayouts(): boolean {
   const graph = app.canvas?.graph
   const hasNodes = Boolean(graph && graph._nodes && graph._nodes.length > 0)
@@ -56,19 +48,6 @@ function getSlotElementRect(el: HTMLElement): DOMRect | null {
   const rect = el.getBoundingClientRect()
   if (rect.width <= 0 || rect.height <= 0) return null
   return rect
-}
-
-export function requestSlotLayoutSyncForAllNodes(): void {
-  const nodeSlotRegistryStore = useNodeSlotRegistryStore()
-  for (const nodeId of nodeSlotRegistryStore.getNodeIds()) {
-    scheduleSlotLayoutSync(nodeId)
-  }
-
-  // If no slots are currently registered, run the completion check immediately
-  // so pendingSlotSync can be cleared when the graph has no nodes.
-  if (pendingNodes.size === 0) {
-    flushScheduledSlotLayoutSync()
-  }
 }
 
 function createSlotLayout(options: {
@@ -92,6 +71,62 @@ function createSlotLayout(options: {
       width: size,
       height: size
     }
+  }
+}
+
+function updateNodeSlotsFromCache(nodeId: NodeId) {
+  const nodeSlotRegistryStore = useNodeSlotRegistryStore()
+  const node = nodeSlotRegistryStore.getNode(nodeId)
+  if (!node) return
+  const nodeLayout = layoutStore.getNodeLayoutRef(nodeId).value
+  if (!nodeLayout) return
+
+  const batch: Array<{ key: SlotId; layout: SlotLayout }> = []
+
+  for (const [slotKey, entry] of node.slots) {
+    if (!entry.cachedOffset) {
+      // schedule a sync to seed offset
+      scheduleSlotLayoutSync(nodeId)
+      continue
+    }
+
+    const centerCanvas = {
+      x: nodeLayout.position.x + entry.cachedOffset.x,
+      y: nodeLayout.position.y + entry.cachedOffset.y
+    }
+
+    batch.push({
+      key: slotKey,
+      layout: createSlotLayout({
+        nodeId,
+        index: entry.index,
+        type: entry.type,
+        centerCanvas
+      })
+    })
+  }
+
+  if (batch.length) layoutStore.batchUpdateSlotLayouts(batch)
+}
+
+export function scheduleSlotLayoutSync(nodeId: NodeId) {
+  // Drop signals for unregistered nodes (e.g. preview nodes with synthetic
+  // ids from LGraphNodePreview) - they'd otherwise pump setDirty per RAF.
+  if (!useNodeSlotRegistryStore().getNode(nodeId)) return
+  pendingNodes.add(nodeId)
+  raf.schedule()
+}
+
+export function requestSlotLayoutSyncForAllNodes(): void {
+  const nodeSlotRegistryStore = useNodeSlotRegistryStore()
+  for (const nodeId of nodeSlotRegistryStore.getNodeIds()) {
+    scheduleSlotLayoutSync(nodeId)
+  }
+
+  // If no slots are currently registered, run the completion check immediately
+  // so pendingSlotSync can be cleared when the graph has no nodes.
+  if (pendingNodes.size === 0) {
+    flushScheduledSlotLayoutSync()
   }
 }
 
@@ -223,41 +258,6 @@ export function syncNodeSlotLayoutsFromDOM(nodeId: NodeId) {
       layout: nextLayout
     })
   }
-  if (batch.length) layoutStore.batchUpdateSlotLayouts(batch)
-}
-
-function updateNodeSlotsFromCache(nodeId: NodeId) {
-  const nodeSlotRegistryStore = useNodeSlotRegistryStore()
-  const node = nodeSlotRegistryStore.getNode(nodeId)
-  if (!node) return
-  const nodeLayout = layoutStore.getNodeLayoutRef(nodeId).value
-  if (!nodeLayout) return
-
-  const batch: Array<{ key: SlotId; layout: SlotLayout }> = []
-
-  for (const [slotKey, entry] of node.slots) {
-    if (!entry.cachedOffset) {
-      // schedule a sync to seed offset
-      scheduleSlotLayoutSync(nodeId)
-      continue
-    }
-
-    const centerCanvas = {
-      x: nodeLayout.position.x + entry.cachedOffset.x,
-      y: nodeLayout.position.y + entry.cachedOffset.y
-    }
-
-    batch.push({
-      key: slotKey,
-      layout: createSlotLayout({
-        nodeId,
-        index: entry.index,
-        type: entry.type,
-        centerCanvas
-      })
-    })
-  }
-
   if (batch.length) layoutStore.batchUpdateSlotLayouts(batch)
 }
 

--- a/src/renderer/extensions/vueNodes/layout/ensureCorrectLayoutScale.test.ts
+++ b/src/renderer/extensions/vueNodes/layout/ensureCorrectLayoutScale.test.ts
@@ -11,6 +11,8 @@ vi.mock('@/scripts/app', () => ({
 
 import { ensureCorrectLayoutScale } from './ensureCorrectLayoutScale'
 
+type MockNode = ReturnType<typeof createNode>
+
 function createNode(id: string, x: number, y: number, w: number, h: number) {
   return {
     id,
@@ -27,8 +29,6 @@ function createNode(id: string, x: number, y: number, w: number, h: number) {
     }
   }
 }
-
-type MockNode = ReturnType<typeof createNode>
 
 function createMockGraph(
   nodes: MockNode[],

--- a/src/renderer/extensions/vueNodes/utils/nodeStyleUtils.ts
+++ b/src/renderer/extensions/vueNodes/utils/nodeStyleUtils.ts
@@ -2,6 +2,12 @@ import { RenderShape } from '@/lib/litegraph/src/types/globalEnums'
 import { useColorPaletteStore } from '@/stores/workspace/colorPaletteStore'
 import { adjustColor } from '@/utils/colorUtil'
 
+export interface ShapeClassVariants {
+  readonly box: string
+  readonly card: string
+  readonly default: string
+}
+
 /**
  * Applies light theme color adjustments to a color
  */
@@ -11,12 +17,6 @@ export function applyLightThemeColor(color?: string): string {
   if (!useColorPaletteStore().completedActivePalette.light_theme) return color
 
   return adjustColor(color, { lightness: 0.5 })
-}
-
-export interface ShapeClassVariants {
-  readonly box: string
-  readonly card: string
-  readonly default: string
 }
 
 /**

--- a/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdownMenuActions.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdownMenuActions.test.ts
@@ -75,6 +75,8 @@ type MenuProps = {
   onSearchEnter?: () => void
 }
 
+type TestUser = ReturnType<typeof userEvent.setup>
+
 function renderMenu(props: MenuProps = {}) {
   const layoutMode = ref<LayoutMode>(props.layoutMode ?? 'list')
   const searchQuery = ref<string>(props.searchQuery ?? '')
@@ -139,8 +141,6 @@ function renderMenu(props: MenuProps = {}) {
     baseModelSelected
   }
 }
-
-type TestUser = ReturnType<typeof userEvent.setup>
 
 async function openPopover(user: TestUser, triggerName: string) {
   await user.click(screen.getByRole('button', { name: triggerName }))

--- a/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/shared.ts
+++ b/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/shared.ts
@@ -12,19 +12,6 @@ import type { FormDropdownItem, SortOption } from './types'
  */
 export const DROPDOWN_PANEL_CLASS = 'comfy-form-dropdown-panel'
 
-export async function defaultSearcher(
-  query: string,
-  items: FormDropdownItem[]
-) {
-  if (query.trim() === '') return items
-  const words = query.trim().toLowerCase().split(' ')
-  return items.filter((item) => {
-    const name = item.name.toLowerCase()
-    const label = item.label?.toLowerCase() ?? ''
-    return words.every((word) => name.includes(word) || label.includes(word))
-  })
-}
-
 /**
  * Create a SortOption that delegates to the shared sortAssets utility
  */
@@ -37,6 +24,19 @@ function createSortOption(
     name,
     sorter: ({ items }) => sortAssets(items, id)
   }
+}
+
+export async function defaultSearcher(
+  query: string,
+  items: FormDropdownItem[]
+) {
+  if (query.trim() === '') return items
+  const words = query.trim().toLowerCase().split(' ')
+  return items.filter((item) => {
+    const name = item.name.toLowerCase()
+    const label = item.label?.toLowerCase() ?? ''
+    return words.every((word) => name.includes(word) || label.includes(word))
+  })
 }
 
 export function getDefaultSortOptions(): SortOption<AssetSortOption>[] {

--- a/src/renderer/extensions/vueNodes/widgets/composables/useWidgetSelectItems.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useWidgetSelectItems.ts
@@ -30,6 +30,18 @@ import type { IAssetsProvider } from '@/platform/assets/composables/media/IAsset
 import type { AssetKind } from '@/types/widgetTypes'
 import { getMediaTypeFromFilename } from '@/utils/formatUtil'
 
+interface UseWidgetSelectItemsOptions {
+  values: MaybeRefOrGetter<unknown[] | undefined>
+  getOptionLabel: MaybeRefOrGetter<
+    ((value?: string | null) => string) | undefined
+  >
+  modelValue: Ref<string | undefined>
+  assetKind: MaybeRefOrGetter<AssetKind | undefined>
+  outputMediaAssets: IAssetsProvider
+  assetData: ReturnType<typeof useAssetWidgetData> | null
+  isAssetMode: MaybeRefOrGetter<boolean | undefined>
+}
+
 function getDisplayLabel(
   value: string,
   getOptionLabel?: ((value?: string | null) => string) | undefined
@@ -57,18 +69,6 @@ function getMediaUrl(
   const params = new URLSearchParams({ filename, type })
   appendCloudResParam(params, filename)
   return `/api/view?${params}`
-}
-
-interface UseWidgetSelectItemsOptions {
-  values: MaybeRefOrGetter<unknown[] | undefined>
-  getOptionLabel: MaybeRefOrGetter<
-    ((value?: string | null) => string) | undefined
-  >
-  modelValue: Ref<string | undefined>
-  assetKind: MaybeRefOrGetter<AssetKind | undefined>
-  outputMediaAssets: IAssetsProvider
-  assetData: ReturnType<typeof useAssetWidgetData> | null
-  isAssetMode: MaybeRefOrGetter<boolean | undefined>
 }
 
 export function useWidgetSelectItems(options: UseWidgetSelectItemsOptions) {

--- a/src/renderer/extensions/vueNodes/widgets/utils/multilineTextarea.ts
+++ b/src/renderer/extensions/vueNodes/widgets/utils/multilineTextarea.ts
@@ -12,6 +12,13 @@ import type { WidgetId } from '@/types/widgetId'
 
 const TRACKPAD_DETECTION_THRESHOLD = 50
 
+interface PromotedMultilineWidgetContext {
+  subgraphNode: LGraphNode
+  input: INodeInputSlot
+  widgetId: WidgetId
+  sourceWidget: Readonly<IBaseWidget>
+}
+
 /** Creates the `<textarea>` element backing a `customtext` multiline widget. */
 export function createMultilineInputElement(
   value: string,
@@ -106,13 +113,6 @@ export function bindMultilineTextareaWidget(
   widget.onRemove = useChainCallback(widget.onRemove, () => {
     controller.abort()
   })
-}
-
-interface PromotedMultilineWidgetContext {
-  subgraphNode: LGraphNode
-  input: INodeInputSlot
-  widgetId: WidgetId
-  sourceWidget: Readonly<IBaseWidget>
 }
 
 /**

--- a/src/renderer/extensions/vueNodes/widgets/utils/resolvePromotedWidget.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/utils/resolvePromotedWidget.test.ts
@@ -4,19 +4,19 @@ import { LGraphNode } from '@/lib/litegraph/src/litegraph'
 import type { IBaseWidget } from '@/lib/litegraph/src/types/widgets'
 import { resolveWidgetFromHostNode } from '@/renderer/extensions/vueNodes/widgets/utils/resolvePromotedWidget'
 
-class TestNode extends LGraphNode {
-  constructor(widgets: IBaseWidget[]) {
-    super('TestNode')
-    this.widgets = widgets
-  }
-}
-
 function createWidget(name: string): IBaseWidget {
   return {
     name,
     type: 'text',
     y: 0,
     options: {}
+  }
+}
+
+class TestNode extends LGraphNode {
+  constructor(widgets: IBaseWidget[]) {
+    super('TestNode')
+    this.widgets = widgets
   }
 }
 

--- a/src/renderer/glsl/sharedGLContext.ts
+++ b/src/renderer/glsl/sharedGLContext.ts
@@ -1,13 +1,13 @@
-export interface SharedGLHandle {
-  canvas: OffscreenCanvas
-  gl: WebGL2RenderingContext
-  release: () => void
-}
-
 interface SharedGL {
   canvas: OffscreenCanvas
   gl: WebGL2RenderingContext
   refs: number
+}
+
+export interface SharedGLHandle {
+  canvas: OffscreenCanvas
+  gl: WebGL2RenderingContext
+  release: () => void
 }
 
 let current: SharedGL | null = null

--- a/src/renderer/glsl/useGLSLPreview.ts
+++ b/src/renderer/glsl/useGLSLPreview.ts
@@ -33,86 +33,6 @@ import {
 } from '@/renderer/glsl/glslPreviewUtils'
 
 /**
- * Two-tier composable for GLSL live preview.
- *
- * Outer tier (always created): only 2 cheap computed refs to detect
- * whether the node is GLSL-related. For non-GLSL nodes this is the
- * only cost — no watchers, store subscriptions, or renderer.
- *
- * Inner tier (lazy): created via effectScope when the node is detected
- * as a GLSLShader or a subgraph containing one. Contains all the
- * expensive logic: store reads, watchers, debounce, WebGL renderer.
- */
-export function useGLSLPreview(
-  nodeMaybe: MaybeRefOrGetter<LGraphNode | null | undefined>
-) {
-  const lastError = ref<string | null>(null)
-  const hideExecutedOutput = ref(false)
-
-  const nodeRef = computed(() => toValue(nodeMaybe) ?? null)
-
-  const isGLSLNode = computed(() => nodeRef.value?.type === GLSL_NODE_TYPE)
-
-  const isGLSLSubgraphNode = computed(() => {
-    const node = nodeRef.value
-    if (!node?.isSubgraphNode()) return false
-    const subgraph = node.subgraph as Subgraph | undefined
-    return subgraph?.nodes.some((n) => n.type === GLSL_NODE_TYPE) ?? false
-  })
-
-  const isGLSLRelated = computed(
-    () => isGLSLNode.value || isGLSLSubgraphNode.value
-  )
-
-  let innerScope: EffectScope | null = null
-  let innerDispose: (() => void) | null = null
-  const isActive = ref(false)
-
-  watch(
-    isGLSLRelated,
-    (related) => {
-      if (related && !innerScope) {
-        innerScope = effectScope()
-        innerDispose = innerScope.run(() =>
-          createInnerPreview(
-            nodeRef,
-            isGLSLNode,
-            isGLSLSubgraphNode,
-            lastError,
-            isActive,
-            hideExecutedOutput
-          )
-        )!
-      } else if (!related && innerScope) {
-        innerDispose?.()
-        innerScope.stop()
-        innerScope = null
-        innerDispose = null
-        isActive.value = false
-      }
-    },
-    { immediate: true }
-  )
-
-  onScopeDispose(() => {
-    innerDispose?.()
-    innerScope?.stop()
-  })
-
-  return {
-    isActive: computed(() => isActive.value),
-    hideExecutedOutput: computed(() => hideExecutedOutput.value),
-    lastError,
-    dispose() {
-      innerDispose?.()
-      innerScope?.stop()
-      innerScope = null
-      innerDispose = null
-    }
-  }
-}
-
-/**
  * Inner tier: all expensive GLSL preview logic.
  * Runs inside its own effectScope so it can be created/destroyed
  * independently of the component lifecycle.
@@ -507,5 +427,85 @@ function createInnerPreview(
     renderer = null
 
     revokePreview()
+  }
+}
+
+/**
+ * Two-tier composable for GLSL live preview.
+ *
+ * Outer tier (always created): only 2 cheap computed refs to detect
+ * whether the node is GLSL-related. For non-GLSL nodes this is the
+ * only cost — no watchers, store subscriptions, or renderer.
+ *
+ * Inner tier (lazy): created via effectScope when the node is detected
+ * as a GLSLShader or a subgraph containing one. Contains all the
+ * expensive logic: store reads, watchers, debounce, WebGL renderer.
+ */
+export function useGLSLPreview(
+  nodeMaybe: MaybeRefOrGetter<LGraphNode | null | undefined>
+) {
+  const lastError = ref<string | null>(null)
+  const hideExecutedOutput = ref(false)
+
+  const nodeRef = computed(() => toValue(nodeMaybe) ?? null)
+
+  const isGLSLNode = computed(() => nodeRef.value?.type === GLSL_NODE_TYPE)
+
+  const isGLSLSubgraphNode = computed(() => {
+    const node = nodeRef.value
+    if (!node?.isSubgraphNode()) return false
+    const subgraph = node.subgraph as Subgraph | undefined
+    return subgraph?.nodes.some((n) => n.type === GLSL_NODE_TYPE) ?? false
+  })
+
+  const isGLSLRelated = computed(
+    () => isGLSLNode.value || isGLSLSubgraphNode.value
+  )
+
+  let innerScope: EffectScope | null = null
+  let innerDispose: (() => void) | null = null
+  const isActive = ref(false)
+
+  watch(
+    isGLSLRelated,
+    (related) => {
+      if (related && !innerScope) {
+        innerScope = effectScope()
+        innerDispose = innerScope.run(() =>
+          createInnerPreview(
+            nodeRef,
+            isGLSLNode,
+            isGLSLSubgraphNode,
+            lastError,
+            isActive,
+            hideExecutedOutput
+          )
+        )!
+      } else if (!related && innerScope) {
+        innerDispose?.()
+        innerScope.stop()
+        innerScope = null
+        innerDispose = null
+        isActive.value = false
+      }
+    },
+    { immediate: true }
+  )
+
+  onScopeDispose(() => {
+    innerDispose?.()
+    innerScope?.stop()
+  })
+
+  return {
+    isActive: computed(() => isActive.value),
+    hideExecutedOutput: computed(() => hideExecutedOutput.value),
+    lastError,
+    dispose() {
+      innerDispose?.()
+      innerScope?.stop()
+      innerScope = null
+      innerDispose = null
+    }
   }
 }

--- a/src/renderer/hdr/colorGamut.ts
+++ b/src/renderer/hdr/colorGamut.ts
@@ -105,22 +105,6 @@ function invert(m: Mat3): Mat3 {
 const SRGB_TO_XYZ = rgbToXyz(CHROMATICITIES.sRGB)
 const XYZ_TO_SRGB = invert(SRGB_TO_XYZ)
 
-export function gamutToSrgbMatrix(gamut: GamutName): Mat3 {
-  if (gamut === 'sRGB') return IDENTITY
-  return multiply(XYZ_TO_SRGB, rgbToXyz(CHROMATICITIES[gamut]))
-}
-
-export interface ChromaticityCoords {
-  redX: number
-  redY: number
-  greenX: number
-  greenY: number
-  blueX: number
-  blueY: number
-  whiteX: number
-  whiteY: number
-}
-
 function matchesGamut(c: ChromaticityCoords, gamut: GamutName): boolean {
   const ref = CHROMATICITIES[gamut]
   const tol = 0.01
@@ -134,6 +118,22 @@ function matchesGamut(c: ChromaticityCoords, gamut: GamutName): boolean {
     Math.abs(c.whiteX - ref.white[0]) < tol &&
     Math.abs(c.whiteY - ref.white[1]) < tol
   )
+}
+
+export interface ChromaticityCoords {
+  redX: number
+  redY: number
+  greenX: number
+  greenY: number
+  blueX: number
+  blueY: number
+  whiteX: number
+  whiteY: number
+}
+
+export function gamutToSrgbMatrix(gamut: GamutName): Mat3 {
+  if (gamut === 'sRGB') return IDENTITY
+  return multiply(XYZ_TO_SRGB, rgbToXyz(CHROMATICITIES[gamut]))
 }
 
 export function detectGamutFromChromaticities(

--- a/src/renderer/hdr/hdrStats.ts
+++ b/src/renderer/hdr/hdrStats.ts
@@ -7,6 +7,14 @@ export interface ImageStats {
   infCount: number
 }
 
+export interface ChannelHistograms {
+  r: Uint32Array
+  g: Uint32Array
+  b: Uint32Array
+  a: Uint32Array | null
+  luminance: Uint32Array
+}
+
 export function computeImageStats(
   read: (index: number) => number,
   length: number,
@@ -45,14 +53,6 @@ export function computeImageStats(
   const mean = sum / count
   const variance = Math.max(0, sumSq / count - mean * mean)
   return { min, max, mean, stdDev: Math.sqrt(variance), nanCount, infCount }
-}
-
-export interface ChannelHistograms {
-  r: Uint32Array
-  g: Uint32Array
-  b: Uint32Array
-  a: Uint32Array | null
-  luminance: Uint32Array
 }
 
 export function computeChannelHistograms(

--- a/src/renderer/three/sharedWebGLRenderer.ts
+++ b/src/renderer/three/sharedWebGLRenderer.ts
@@ -8,6 +8,11 @@ export type RendererViewState = {
   clearAlpha: number
 }
 
+export type SharedRendererHandle = {
+  renderer: THREE.WebGLRenderer
+  release: () => void
+}
+
 export function createRendererViewState(): RendererViewState {
   return {
     toneMapping: THREE.NoToneMapping,
@@ -26,11 +31,6 @@ export function applyRendererViewState(
   renderer.toneMappingExposure = state.toneMappingExposure
   renderer.outputColorSpace = state.outputColorSpace
   renderer.setClearColor(state.clearColor, state.clearAlpha)
-}
-
-export type SharedRendererHandle = {
-  renderer: THREE.WebGLRenderer
-  release: () => void
 }
 
 let sharedRenderer: THREE.WebGLRenderer | null = null

--- a/src/services/customerEventsService.ts
+++ b/src/services/customerEventsService.ts
@@ -9,13 +9,6 @@ import { useAuthStore } from '@/stores/authStore'
 import type { components, operations } from '@/types/comfyRegistryTypes'
 import { isAbortError } from '@/utils/typeGuardUtil'
 
-export enum EventType {
-  CREDIT_ADDED = 'credit_added',
-  ACCOUNT_CREATED = 'account_created',
-  API_USAGE_STARTED = 'api_usage_started',
-  API_USAGE_COMPLETED = 'api_usage_completed'
-}
-
 type CustomerEventsResponse =
   operations['GetCustomerEvents']['responses']['200']['content']['application/json']
 
@@ -23,6 +16,13 @@ type CustomerEventsResponseQuery =
   operations['GetCustomerEvents']['parameters']['query']
 
 export type AuditLog = components['schemas']['AuditLog']
+
+export enum EventType {
+  CREDIT_ADDED = 'credit_added',
+  ACCOUNT_CREATED = 'account_created',
+  API_USAGE_STARTED = 'api_usage_started',
+  API_USAGE_COMPLETED = 'api_usage_completed'
+}
 
 const customerApiClient = axios.create({
   baseURL: getComfyApiBaseUrl(),

--- a/src/services/dialogService.ts
+++ b/src/services/dialogService.ts
@@ -54,15 +54,6 @@ const HUG_CONTENT_CLASS =
  */
 const SELF_STYLED_PANEL_CONTENT_CLASS = `${HUG_CONTENT_CLASS} border-none bg-transparent shadow-none`
 
-export type ConfirmationDialogType =
-  | 'default'
-  | 'overwrite'
-  | 'overwriteBlueprint'
-  | 'delete'
-  | 'dirtyClose'
-  | 'reinstall'
-  | 'info'
-
 interface BaseConfirmOptions {
   /** Dialog heading */
   title: string
@@ -87,6 +78,15 @@ type ConfirmOptions = BaseConfirmOptions &
         denyLabel?: never
       }
   )
+
+export type ConfirmationDialogType =
+  | 'default'
+  | 'overwrite'
+  | 'overwriteBlueprint'
+  | 'delete'
+  | 'dirtyClose'
+  | 'reinstall'
+  | 'info'
 
 /**
  * Minimal interface for execution error dialogs.

--- a/src/services/jobOutputCache.ts
+++ b/src/services/jobOutputCache.ts
@@ -40,6 +40,11 @@ let latestTaskRequestId: string | null = null
 
 // ===== Task Output Caching =====
 
+function getPreviewableOutputs(outputs?: TaskOutput): ResultItemImpl[] {
+  if (!outputs) return []
+  return ResultItemImpl.filterPreviewable(parseTaskOutput(outputs))
+}
+
 export function findActiveIndex(
   items: readonly ResultItemImpl[],
   url?: string
@@ -83,11 +88,6 @@ export async function getOutputsForTask(
     console.warn('Failed to load full outputs, using preview:', error)
     return [...task.previewableOutputs]
   }
-}
-
-function getPreviewableOutputs(outputs?: TaskOutput): ResultItemImpl[] {
-  if (!outputs) return []
-  return ResultItemImpl.filterPreviewable(parseTaskOutput(outputs))
 }
 
 export function getPreviewableOutputsFromJobDetail(

--- a/src/services/litegraphService.ts
+++ b/src/services/litegraphService.ts
@@ -124,6 +124,11 @@ async function reencodeAsPngBlob(
 export const CONFIG = Symbol()
 export const GET_CONFIG = Symbol()
 
+function getMinSize(node: LGraphNode) {
+  node._initialMinSize ??= { width: 1, height: 1 }
+  return node._initialMinSize
+}
+
 export function getExtraOptionsForWidget(
   node: LGraphNode,
   widget: IBaseWidget
@@ -165,11 +170,6 @@ export function getExtraOptionsForWidget(
     addWidgetPromotionOptions(options, widget, node)
   }
   return options
-}
-
-function getMinSize(node: LGraphNode) {
-  node._initialMinSize ??= { width: 1, height: 1 }
-  return node._initialMinSize
 }
 
 /**

--- a/src/services/load3dService.ts
+++ b/src/services/load3dService.ts
@@ -71,6 +71,15 @@ let cachedNodeToLoad3dMap: Map<LGraphNode, Load3d> | null = null
 let cachedUseLoad3dViewer: UseLoad3dViewerFn | null = null
 let cachedSkeletonUtils: SkeletonUtilsModule | null = null
 
+// Type definitions for Load3D node
+interface SceneConfig {
+  backgroundImage?: string
+}
+
+interface Load3DNode extends LGraphNode {
+  syncLoad3dConfig?: () => void
+}
+
 // Sync accessor - returns null if module not yet loaded
 function getNodeToLoad3dMapSync(): Map<LGraphNode, Load3d> | null {
   return cachedNodeToLoad3dMap
@@ -98,15 +107,6 @@ async function loadSkeletonUtils() {
     cachedSkeletonUtils = await import('three/examples/jsm/utils/SkeletonUtils')
   }
   return cachedSkeletonUtils
-}
-
-// Type definitions for Load3D node
-interface SceneConfig {
-  backgroundImage?: string
-}
-
-interface Load3DNode extends LGraphNode {
-  syncLoad3dConfig?: () => void
 }
 
 const viewerInstances = new Map<NodeId, ReturnType<UseLoad3dViewerFn>>()

--- a/src/services/subgraphPseudoWidgetCache.ts
+++ b/src/services/subgraphPseudoWidgetCache.ts
@@ -1,17 +1,6 @@
 import type { PromotedWidgetSource } from '@/core/graph/subgraph/promotedWidgetTypes'
 import type { NodeId } from '@/types/nodeId'
 
-export interface SubgraphPseudoWidget {
-  name: string
-}
-
-export interface SubgraphPseudoWidgetNode<
-  TWidget extends SubgraphPseudoWidget
-> {
-  id: string | number
-  widgets?: TWidget[]
-}
-
 interface SubgraphPseudoWidgetCacheEntry<
   TNode extends SubgraphPseudoWidgetNode<TWidget>,
   TWidget extends SubgraphPseudoWidget
@@ -19,15 +8,6 @@ interface SubgraphPseudoWidgetCacheEntry<
   sourceNodeId: NodeId
   sourceWidgetName: string
   node: TNode
-}
-
-export interface SubgraphPseudoWidgetCache<
-  TNode extends SubgraphPseudoWidgetNode<TWidget>,
-  TWidget extends SubgraphPseudoWidget
-> {
-  promotions: readonly PromotedWidgetSource[]
-  entries: SubgraphPseudoWidgetCacheEntry<TNode, TWidget>[]
-  nodes: TNode[]
 }
 
 interface ResolveSubgraphPseudoWidgetCacheArgs<
@@ -75,6 +55,26 @@ function isCacheStillValid<
       isPreviewPseudoWidget
     )
   })
+}
+
+export interface SubgraphPseudoWidget {
+  name: string
+}
+
+export interface SubgraphPseudoWidgetNode<
+  TWidget extends SubgraphPseudoWidget
+> {
+  id: string | number
+  widgets?: TWidget[]
+}
+
+export interface SubgraphPseudoWidgetCache<
+  TNode extends SubgraphPseudoWidgetNode<TWidget>,
+  TWidget extends SubgraphPseudoWidget
+> {
+  promotions: readonly PromotedWidgetSource[]
+  entries: SubgraphPseudoWidgetCacheEntry<TNode, TWidget>[]
+  nodes: TNode[]
 }
 
 export function resolveSubgraphPseudoWidgetCache<

--- a/src/stores/assetDownloadStore.ts
+++ b/src/stores/assetDownloadStore.ts
@@ -7,6 +7,12 @@ import { taskService } from '@/platform/tasks/services/taskService'
 import type { AssetDownloadWsMessage } from '@/schemas/apiSchema'
 import { api } from '@/scripts/api'
 
+interface CompletedDownload {
+  taskId: TaskId
+  modelType: string
+  timestamp: number
+}
+
 export interface AssetDownload {
   taskId: TaskId
   assetName: string
@@ -19,12 +25,6 @@ export interface AssetDownload {
   error?: string
   modelType?: string
   acknowledged?: boolean
-}
-
-interface CompletedDownload {
-  taskId: TaskId
-  modelType: string
-  timestamp: number
 }
 const STALE_THRESHOLD_MS = 10_000
 const POLL_INTERVAL_MS = 10_000

--- a/src/stores/dialogStore.ts
+++ b/src/stores/dialogStore.ts
@@ -83,6 +83,12 @@ interface CustomDialogComponentProps {
   footerClass?: HTMLAttributes['class']
 }
 
+interface UpdateDialogOptions {
+  key: string
+  contentProps?: Partial<DialogInstance['contentProps']>
+  dialogComponentProps?: Partial<DialogComponentProps>
+}
+
 export type DialogComponentProps = Record<string, unknown> &
   CustomDialogComponentProps
 
@@ -120,12 +126,6 @@ export interface ShowDialogOptions<
    * @default 1
    */
   priority?: number
-}
-
-interface UpdateDialogOptions {
-  key: string
-  contentProps?: Partial<DialogInstance['contentProps']>
-  dialogComponentProps?: Partial<DialogComponentProps>
 }
 
 export const useDialogStore = defineStore('dialog', () => {

--- a/src/stores/executionStore.ts
+++ b/src/stores/executionStore.ts
@@ -110,8 +110,6 @@ function buildExecutionNodeLookup(
  */
 export const MAX_PROGRESS_JOBS = 1000
 
-export type WorkflowExecutionStatus = 'running' | 'completed' | 'failed'
-
 interface WorkflowStatusUpdate {
   status: WorkflowExecutionStatus
   executionStartedAt?: number
@@ -119,6 +117,8 @@ interface WorkflowStatusUpdate {
   failureReason?: WorkflowExecutionFailureReason
   showStatus?: boolean
 }
+
+export type WorkflowExecutionStatus = 'running' | 'completed' | 'failed'
 
 export const WORKFLOW_STATUS_I18N_KEYS: Record<
   WorkflowExecutionStatus,

--- a/src/stores/maskEditorDataStore.ts
+++ b/src/stores/maskEditorDataStore.ts
@@ -3,6 +3,14 @@ import { ref, computed } from 'vue'
 import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
 import type { NodeId } from '@/types/nodeId'
 
+interface EditorInputData {
+  baseLayer: ImageLayer
+  maskLayer: ImageLayer
+  paintLayer?: ImageLayer
+  sourceRef: ImageRef
+  nodeId: NodeId
+}
+
 export interface ImageRef {
   filename: string
   subfolder?: string
@@ -12,14 +20,6 @@ export interface ImageRef {
 export interface ImageLayer {
   image: HTMLImageElement
   url: string
-}
-
-interface EditorInputData {
-  baseLayer: ImageLayer
-  maskLayer: ImageLayer
-  paintLayer?: ImageLayer
-  sourceRef: ImageRef
-  nodeId: NodeId
 }
 
 export interface EditorOutputLayer {

--- a/src/stores/modelStore.ts
+++ b/src/stores/modelStore.ts
@@ -29,6 +29,27 @@ function _findInMetadata(
   return null
 }
 
+export enum ResourceState {
+  Uninitialized,
+  Loading,
+  Loaded
+}
+
+/**
+ * Resolves the preview image for a model: embedded metadata thumbnail when
+ * loaded, otherwise the server-rendered `.webp` preview. The preview endpoint
+ * reads a rendered thumbnail off local disk, which is unavailable on Cloud
+ * (model bytes live in object storage), so Cloud resolves to no preview.
+ */
+export function getModelPreviewUrl(model: ComfyModelDef): string {
+  if (model.image) return model.image
+  if (isCloud) return ''
+  const extension = model.file_name.split('.').pop()
+  const filename = model.file_name.replace(`.${extension}`, '.webp')
+  const encodedFilename = encodeURIComponent(filename).replace(/%2F/g, '/')
+  return `/api/experiment/models/preview/${encodeURIComponent(model.directory)}/${model.path_index}/${encodedFilename}`
+}
+
 /** Defines and holds metadata for a model */
 export class ComfyModelDef {
   /** Path to the model */
@@ -156,27 +177,6 @@ export class ComfyModelDef {
       console.error('Error loading model metadata', this.file_name, this, error)
     }
   }
-}
-
-export enum ResourceState {
-  Uninitialized,
-  Loading,
-  Loaded
-}
-
-/**
- * Resolves the preview image for a model: embedded metadata thumbnail when
- * loaded, otherwise the server-rendered `.webp` preview. The preview endpoint
- * reads a rendered thumbnail off local disk, which is unavailable on Cloud
- * (model bytes live in object storage), so Cloud resolves to no preview.
- */
-export function getModelPreviewUrl(model: ComfyModelDef): string {
-  if (model.image) return model.image
-  if (isCloud) return ''
-  const extension = model.file_name.split('.').pop()
-  const filename = model.file_name.replace(`.${extension}`, '.webp')
-  const encodedFilename = encodeURIComponent(filename).replace(/%2F/g, '/')
-  return `/api/experiment/models/preview/${encodeURIComponent(model.directory)}/${model.path_index}/${encodedFilename}`
 }
 
 /**

--- a/src/stores/nodeDefStore.ts
+++ b/src/stores/nodeDefStore.ts
@@ -295,31 +295,6 @@ interface BuildNodeDefTreeOptions {
   pathExtractor?: (nodeDef: ComfyNodeDefImpl) => string[]
 }
 
-export function buildNodeDefTree(
-  nodeDefs: ComfyNodeDefImpl[],
-  options: BuildNodeDefTreeOptions = {}
-): TreeNode {
-  const { pathExtractor } = options
-  const defaultPathExtractor = (nodeDef: ComfyNodeDefImpl) =>
-    nodeDef.nodePath.split('/')
-  return buildTree(nodeDefs, pathExtractor || defaultPathExtractor)
-}
-
-export function createDummyFolderNodeDef(folderPath: string): ComfyNodeDefImpl {
-  return new ComfyNodeDefImpl({
-    name: '',
-    display_name: '',
-    category: folderPath.endsWith('/') ? folderPath.slice(0, -1) : folderPath,
-    python_module: 'nodes',
-    description: 'Dummy Folder Node (User should never see this string)',
-    input: {},
-    output: [],
-    output_name: [],
-    output_is_list: [],
-    output_node: false
-  } as ComfyNodeDefV1)
-}
-
 /**
  * Defines a filter for node definitions in the node library.
  * Filters are applied in a single pass to determine node visibility.
@@ -347,6 +322,31 @@ export interface NodeDefFilter {
    * @returns true if the node should be visible, false to hide it
    */
   predicate: (nodeDef: ComfyNodeDefImpl) => boolean
+}
+
+export function buildNodeDefTree(
+  nodeDefs: ComfyNodeDefImpl[],
+  options: BuildNodeDefTreeOptions = {}
+): TreeNode {
+  const { pathExtractor } = options
+  const defaultPathExtractor = (nodeDef: ComfyNodeDefImpl) =>
+    nodeDef.nodePath.split('/')
+  return buildTree(nodeDefs, pathExtractor || defaultPathExtractor)
+}
+
+export function createDummyFolderNodeDef(folderPath: string): ComfyNodeDefImpl {
+  return new ComfyNodeDefImpl({
+    name: '',
+    display_name: '',
+    category: folderPath.endsWith('/') ? folderPath.slice(0, -1) : folderPath,
+    python_module: 'nodes',
+    description: 'Dummy Folder Node (User should never see this string)',
+    input: {},
+    output: [],
+    output_name: [],
+    output_is_list: [],
+    output_node: false
+  } as ComfyNodeDefV1)
 }
 
 export const useNodeDefStore = defineStore('nodeDef', () => {

--- a/src/stores/userFileStore.ts
+++ b/src/stores/userFileStore.ts
@@ -8,6 +8,12 @@ import { getPathDetails } from '@/utils/formatUtil'
 import { syncEntities } from '@/utils/syncUtil'
 import { buildTree } from '@/utils/treeUtil'
 
+interface LoadedUserFile extends UserFile {
+  isLoaded: true
+  originalContent: string
+  content: string
+}
+
 /**
  * Normalizes a timestamp value that may be either a number (milliseconds)
  * or an ISO 8601 string (from Go's time.Time JSON serialization) into
@@ -193,12 +199,6 @@ export class UserFile {
     }
     return this
   }
-}
-
-interface LoadedUserFile extends UserFile {
-  isLoaded: true
-  originalContent: string
-  content: string
 }
 
 export const useUserFileStore = defineStore('userFile', () => {

--- a/src/stores/workspace/favoritedWidgetsStore.ts
+++ b/src/stores/workspace/favoritedWidgetsStore.ts
@@ -37,11 +37,6 @@ interface FavoritedWidget extends FavoritedWidgetId {
   label: string
 }
 
-export interface ValidFavoritedWidget extends FavoritedWidget {
-  node: LGraphNode
-  widget: IBaseWidget
-}
-
 /**
  * Storage format for persisted favorited widgets.
  * Stored in workflow.extra.favoritedWidgets.
@@ -49,6 +44,11 @@ export interface ValidFavoritedWidget extends FavoritedWidget {
 interface FavoritedWidgetStorage {
   /** Array of favorited widget identifiers */
   favorites: FavoritedWidgetId[]
+}
+
+export interface ValidFavoritedWidget extends FavoritedWidget {
+  node: LGraphNode
+  widget: IBaseWidget
 }
 
 /**

--- a/src/stores/workspace/rightSidePanelStore.ts
+++ b/src/stores/workspace/rightSidePanelStore.ts
@@ -3,6 +3,8 @@ import { computed, ref, watch } from 'vue'
 
 import { useSettingStore } from '@/platform/settings/settingStore'
 
+type RightSidePanelSection = 'advanced-inputs' | string
+
 export type RightSidePanelTab =
   | 'parameters'
   | 'nodes'
@@ -10,8 +12,6 @@ export type RightSidePanelTab =
   | 'info'
   | 'subgraph'
   | 'errors'
-
-type RightSidePanelSection = 'advanced-inputs' | string
 
 /**
  * Store for managing the right side panel state.

--- a/src/types/comfy.ts
+++ b/src/types/comfy.ts
@@ -18,13 +18,6 @@ import type { BottomPanelExtension } from '@/types/extensionTypes'
 
 type Widgets = Record<string, ComfyWidgetConstructor>
 
-export interface AboutPageBadge {
-  label: string
-  url: string
-  icon: string
-  severity?: 'danger' | 'warn'
-}
-
 type MenuCommandGroup = {
   /**
    * The path to the menu group.
@@ -35,6 +28,13 @@ type MenuCommandGroup = {
    * Note: Commands must be defined in `commands` array in the extension.
    */
   commands: string[]
+}
+
+export interface AboutPageBadge {
+  label: string
+  url: string
+  icon: string
+  severity?: 'danger' | 'warn'
 }
 
 export interface TopbarBadge {

--- a/src/types/extensionTypes.ts
+++ b/src/types/extensionTypes.ts
@@ -21,6 +21,12 @@ interface BaseBottomPanelExtension {
   targetPanel?: 'terminal' | 'shortcuts'
 }
 
+type VueSidebarTabExtension = BaseSidebarTabExtension & VueExtension
+
+type CustomSidebarTabExtension = BaseSidebarTabExtension & CustomExtension
+
+type VueBottomPanelExtension = BaseBottomPanelExtension & VueExtension
+type CustomBottomPanelExtension = BaseBottomPanelExtension & CustomExtension
 export interface VueExtension {
   id: string
   type: 'vue'
@@ -33,15 +39,9 @@ export interface CustomExtension {
   render: (container: HTMLElement) => void
   destroy?: () => void
 }
-
-type VueSidebarTabExtension = BaseSidebarTabExtension & VueExtension
-type CustomSidebarTabExtension = BaseSidebarTabExtension & CustomExtension
 export type SidebarTabExtension =
   | VueSidebarTabExtension
   | CustomSidebarTabExtension
-
-type VueBottomPanelExtension = BaseBottomPanelExtension & VueExtension
-type CustomBottomPanelExtension = BaseBottomPanelExtension & CustomExtension
 export type BottomPanelExtension =
   | VueBottomPanelExtension
   | CustomBottomPanelExtension

--- a/src/types/metadataTypes.ts
+++ b/src/types/metadataTypes.ts
@@ -3,12 +3,23 @@ import type {
   ComfyWorkflowJSON
 } from '@/platform/workflow/validation/schemas/workflowSchema'
 
-/**
- * Tag names used in ComfyUI metadata
- */
-export enum ComfyMetadataTags {
-  PROMPT = 'PROMPT',
-  WORKFLOW = 'WORKFLOW'
+type GltfExtras = {
+  workflow?: string | object
+  prompt?: string | object
+  [key: string]: unknown
+}
+
+type AvifIlocItemExtent = {
+  extent_offset: number
+  extent_length: number
+}
+
+type AvifIlocItem = {
+  item_ID: number
+  data_reference_index: number
+  base_offset: number
+  extent_count: number
+  extents: AvifIlocItemExtent[]
 }
 
 /**
@@ -44,17 +55,6 @@ export type TextRange = {
   end: number
 }
 
-export enum ASCII {
-  GLTF = 0x46546c67,
-  JSON = 0x4e4f534a,
-  OPEN_BRACE = 0x7b
-}
-
-export enum GltfSizeBytes {
-  HEADER = 12,
-  CHUNK_HEADER = 8
-}
-
 export type GltfHeader = {
   magicNumber: number
   gltfFormatVersion: number
@@ -64,12 +64,6 @@ export type GltfHeader = {
 export type GltfChunkHeader = {
   chunkLengthBytes: number
   chunkTypeIdentifier: number
-}
-
-type GltfExtras = {
-  workflow?: string | object
-  prompt?: string | object
-  [key: string]: unknown
 }
 
 export type GltfJsonData = {
@@ -112,19 +106,6 @@ export type AvifIinfBox = {
   entries: AvifInfeBox[]
 }
 
-type AvifIlocItemExtent = {
-  extent_offset: number
-  extent_length: number
-}
-
-type AvifIlocItem = {
-  item_ID: number
-  data_reference_index: number
-  base_offset: number
-  extent_count: number
-  extents: AvifIlocItemExtent[]
-}
-
 export type AvifIlocBox = {
   box_header: {
     size: number
@@ -138,4 +119,23 @@ export type AvifIlocBox = {
   index_size: number
   item_count: number
   items: AvifIlocItem[]
+}
+
+/**
+ * Tag names used in ComfyUI metadata
+ */
+export enum ComfyMetadataTags {
+  PROMPT = 'PROMPT',
+  WORKFLOW = 'WORKFLOW'
+}
+
+export enum ASCII {
+  GLTF = 0x46546c67,
+  JSON = 0x4e4f534a,
+  OPEN_BRACE = 0x7b
+}
+
+export enum GltfSizeBytes {
+  HEADER = 12,
+  CHUNK_HEADER = 8
 }

--- a/src/types/nodeId.ts
+++ b/src/types/nodeId.ts
@@ -1,8 +1,8 @@
+type ToNodeIdInput = number | (string & { readonly __brand?: never })
+
 export type SerializedNodeId = number | string
 
 export type NodeId = string & { readonly __brand: 'NodeId' }
-
-type ToNodeIdInput = number | (string & { readonly __brand?: never })
 
 export function toNodeId(value: ToNodeIdInput): NodeId {
   return String(value) as NodeId

--- a/src/types/nodeIdentification.ts
+++ b/src/types/nodeIdentification.ts
@@ -4,6 +4,25 @@ import type { NodeId, SerializedNodeId } from '@/types/nodeId'
 const UUID_PATTERN =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 
+function requireNodeIdSegment(value: unknown): NodeId | null {
+  const nodeId = parseNodeId(value)
+  if (!nodeId || nodeId.includes(':')) return null
+  return nodeId
+}
+
+function parseNodeIdSegments(values: readonly unknown[]): NodeId[] | null {
+  const nodeIds = values.map(requireNodeIdSegment)
+  return nodeIds.every((nodeId): nodeId is NodeId => nodeId !== null)
+    ? nodeIds
+    : null
+}
+
+function nodeExecutionIdFromString(value: string): NodeExecutionId | null {
+  return parseNodeIdSegments(value.split(':'))
+    ? (value as NodeExecutionId)
+    : null
+}
+
 /**
  * A globally unique identifier for nodes that maintains consistency across
  * multiple instances of the same subgraph.
@@ -29,25 +48,6 @@ export type NodeLocatorId = string & { readonly __brand: 'NodeLocatorId' }
  * Example: "123:456:789" (node 789 in subgraph 456 in subgraph 123)
  */
 export type NodeExecutionId = string & { readonly __brand: 'NodeExecutionId' }
-
-function requireNodeIdSegment(value: unknown): NodeId | null {
-  const nodeId = parseNodeId(value)
-  if (!nodeId || nodeId.includes(':')) return null
-  return nodeId
-}
-
-function parseNodeIdSegments(values: readonly unknown[]): NodeId[] | null {
-  const nodeIds = values.map(requireNodeIdSegment)
-  return nodeIds.every((nodeId): nodeId is NodeId => nodeId !== null)
-    ? nodeIds
-    : null
-}
-
-function nodeExecutionIdFromString(value: string): NodeExecutionId | null {
-  return parseNodeIdSegments(value.split(':'))
-    ? (value as NodeExecutionId)
-    : null
-}
 
 /**
  * Type guard to check if a value is a NodeLocatorId

--- a/src/types/simplifiedWidget.ts
+++ b/src/types/simplifiedWidget.ts
@@ -24,16 +24,11 @@ export const CONTROL_OPTIONS = [
   'decrement',
   'randomize'
 ] as const
-export type ControlOptions = (typeof CONTROL_OPTIONS)[number]
-
 function isControlOption(val: WidgetValue): val is ControlOptions {
   return CONTROL_OPTIONS.includes(val as ControlOptions)
 }
 
-export function normalizeControlOption(val: WidgetValue): ControlOptions {
-  if (isControlOption(val)) return val
-  return 'randomize'
-}
+export type ControlOptions = (typeof CONTROL_OPTIONS)[number]
 
 export type SafeControlWidget = {
   value: ControlOptions
@@ -96,4 +91,9 @@ export interface SimplifiedControlWidget<
   O extends IWidgetOptions = IWidgetOptions
 > extends SimplifiedWidget<T, O> {
   controlWidget: SafeControlWidget
+}
+
+export function normalizeControlOption(val: WidgetValue): ControlOptions {
+  if (isControlOption(val)) return val
+  return 'randomize'
 }

--- a/src/types/widgetId.ts
+++ b/src/types/widgetId.ts
@@ -7,6 +7,15 @@ export type WidgetId = string & { readonly __brand: 'WidgetId' }
 const SEPARATOR = ':'
 const WIDGET_ID_PATTERN = /^(?<graphId>[^:]+):(?<nodeId>[^:]+):(?<name>[^:]+)$/u
 
+function decodeWidgetIdSegment(segment: string): string {
+  try {
+    return decodeURIComponent(segment)
+  } catch (error) {
+    if (error instanceof URIError) return segment
+    throw error
+  }
+}
+
 export function widgetId(
   graphId: UUID,
   localNodeId: NodeId,
@@ -17,15 +26,6 @@ export function widgetId(
     encodeURIComponent(String(localNodeId)),
     encodeURIComponent(name)
   ].join(SEPARATOR) as WidgetId
-}
-
-function decodeWidgetIdSegment(segment: string): string {
-  try {
-    return decodeURIComponent(segment)
-  } catch (error) {
-    if (error instanceof URIError) return segment
-    throw error
-  }
 }
 
 export function parseWidgetId(id: WidgetId): {

--- a/src/types/workflowMenuItem.ts
+++ b/src/types/workflowMenuItem.ts
@@ -1,10 +1,10 @@
 import type { OverlayIconProps } from '@/components/common/OverlayIcon.vue'
 
-export type WorkflowMenuItem = WorkflowMenuSeparator | WorkflowMenuAction
-
 interface WorkflowMenuSeparator {
   separator: true
 }
+
+export type WorkflowMenuItem = WorkflowMenuSeparator | WorkflowMenuAction
 
 export interface WorkflowMenuAction {
   separator?: false

--- a/src/utils/appMode.ts
+++ b/src/utils/appMode.ts
@@ -1,3 +1,8 @@
+type WorkflowModeSource = {
+  activeMode: AppMode | null
+  initialMode: AppMode | null | undefined
+}
+
 export type AppMode =
   | 'graph'
   | 'app'
@@ -6,11 +11,6 @@ export type AppMode =
   | 'builder:arrange'
 
 export type ViewMode = 'graph' | 'app'
-
-type WorkflowModeSource = {
-  activeMode: AppMode | null
-  initialMode: AppMode | null | undefined
-}
 
 export function getWorkflowMode(
   workflow: WorkflowModeSource | null | undefined

--- a/src/utils/colorUtil.ts
+++ b/src/utils/colorUtil.ts
@@ -6,21 +6,21 @@ interface HSB {
   s: number
   b: number
 }
+type HSL = { h: number; s: number; l: number }
+type HSLA = { h: number; s: number; l: number; a: number }
+type ColorFormatInternal = 'hex' | 'rgb' | 'rgba' | 'hsl' | 'hsla'
+interface HSV {
+  h: number
+  s: number
+  v: number
+}
 export interface HSVA {
   h: number
   s: number
   v: number
   a: number
 }
-type HSL = { h: number; s: number; l: number }
-type HSLA = { h: number; s: number; l: number; a: number }
-type ColorFormatInternal = 'hex' | 'rgb' | 'rgba' | 'hsl' | 'hsla'
 export type ColorFormat = 'hex' | 'rgb' | 'hsb'
-interface HSV {
-  h: number
-  s: number
-  v: number
-}
 
 export interface ColorAdjustOptions {
   lightness?: number
@@ -244,10 +244,6 @@ const isHSLA = (color: unknown): color is HSLA => {
   )
 }
 
-export function isColorFormat(v: unknown): v is ColorFormat {
-  return v === 'hex' || v === 'rgb' || v === 'hsb'
-}
-
 function isHSBObject(v: unknown): v is HSB {
   if (!v || typeof v !== 'object') return false
   const rec = v as Record<string, unknown>
@@ -272,44 +268,6 @@ function isHSVObject(v: unknown): v is HSV {
     typeof (rec as Record<string, unknown>).v === 'number' &&
     Number.isFinite((rec as Record<string, number>).v!)
   )
-}
-
-export function toHexFromFormat(val: unknown, format: ColorFormat): string {
-  if (format === 'hex' && typeof val === 'string') {
-    const raw = val.trim().toLowerCase()
-    if (!raw) return '#000000'
-    if (/^[0-9a-f]{3,4}$/.test(raw)) return `#${raw}`
-    if (/^#[0-9a-f]{3,4}$/.test(raw)) return raw
-    if (/^[0-9a-f]{6}$/.test(raw)) return `#${raw}`
-    if (/^#[0-9a-f]{6}$/.test(raw)) return raw
-    if (/^[0-9a-f]{8}$/.test(raw)) return `#${raw}`
-    if (/^#[0-9a-f]{8}$/.test(raw)) return raw
-    return '#000000'
-  }
-
-  if (format === 'rgb' && typeof val === 'string') {
-    const rgb = parseToRgb(val)
-    return rgbToHex(rgb).toLowerCase()
-  }
-
-  if (format === 'hsb') {
-    if (isHSBObject(val)) {
-      return rgbToHex(hsbToRgb(val)).toLowerCase()
-    }
-    if (isHSVObject(val)) {
-      const { h, s, v } = val
-      return rgbToHex(hsbToRgb({ h, s, b: v })).toLowerCase()
-    }
-    if (typeof val === 'string') {
-      const nums = val.match(/\d+(?:\.\d+)?/g)?.map(Number) || []
-      if (nums.length >= 3) {
-        return rgbToHex(
-          hsbToRgb({ h: nums[0], s: nums[1], b: nums[2] })
-        ).toLowerCase()
-      }
-    }
-  }
-  return '#000000'
 }
 
 function parseToHSLA(color: string, format: ColorFormatInternal): HSLA | null {
@@ -364,6 +322,48 @@ function parseToHSLA(color: string, format: ColorFormatInternal): HSLA | null {
     default:
       return null
   }
+}
+
+export function isColorFormat(v: unknown): v is ColorFormat {
+  return v === 'hex' || v === 'rgb' || v === 'hsb'
+}
+
+export function toHexFromFormat(val: unknown, format: ColorFormat): string {
+  if (format === 'hex' && typeof val === 'string') {
+    const raw = val.trim().toLowerCase()
+    if (!raw) return '#000000'
+    if (/^[0-9a-f]{3,4}$/.test(raw)) return `#${raw}`
+    if (/^#[0-9a-f]{3,4}$/.test(raw)) return raw
+    if (/^[0-9a-f]{6}$/.test(raw)) return `#${raw}`
+    if (/^#[0-9a-f]{6}$/.test(raw)) return raw
+    if (/^[0-9a-f]{8}$/.test(raw)) return `#${raw}`
+    if (/^#[0-9a-f]{8}$/.test(raw)) return raw
+    return '#000000'
+  }
+
+  if (format === 'rgb' && typeof val === 'string') {
+    const rgb = parseToRgb(val)
+    return rgbToHex(rgb).toLowerCase()
+  }
+
+  if (format === 'hsb') {
+    if (isHSBObject(val)) {
+      return rgbToHex(hsbToRgb(val)).toLowerCase()
+    }
+    if (isHSVObject(val)) {
+      const { h, s, v } = val
+      return rgbToHex(hsbToRgb({ h, s, b: v })).toLowerCase()
+    }
+    if (typeof val === 'string') {
+      const nums = val.match(/\d+(?:\.\d+)?/g)?.map(Number) || []
+      if (nums.length >= 3) {
+        return rgbToHex(
+          hsbToRgb({ h: nums[0], s: nums[1], b: nums[2] })
+        ).toLowerCase()
+      }
+    }
+  }
+  return '#000000'
 }
 
 export function rgbToHsv({ r, g, b }: RGB): {

--- a/src/utils/executionErrorUtil.ts
+++ b/src/utils/executionErrorUtil.ts
@@ -16,6 +16,10 @@ interface CloudValidationError {
   node_errors?: Record<SerializedNodeId, NodeError>
 }
 
+type CloudValidationResult =
+  | { kind: 'nodeErrors'; nodeErrors: Record<SerializedNodeId, NodeError> }
+  | { kind: 'promptError'; promptError: PromptError }
+
 export function isCloudValidationError(
   value: unknown
 ): value is CloudValidationError {
@@ -50,10 +54,6 @@ export function tryExtractValidationError(
     return null
   }
 }
-
-type CloudValidationResult =
-  | { kind: 'nodeErrors'; nodeErrors: Record<SerializedNodeId, NodeError> }
-  | { kind: 'promptError'; promptError: PromptError }
 
 export function normalizePromptError(
   error: RawPromptError | undefined

--- a/src/utils/fuseUtil.ts
+++ b/src/utils/fuseUtil.ts
@@ -1,6 +1,14 @@
 import type { FuseOptionKey, FuseSearchOptions, IFuseOptions } from 'fuse.js'
 import Fuse from 'fuse.js'
 
+function isFuseSearchable(item: unknown): item is FuseSearchable {
+  return (
+    typeof item === 'object' &&
+    item !== null &&
+    'postProcessSearchScores' in item
+  )
+}
+
 export type SearchAuxScore = number[]
 
 export interface FuseFilterWithValue<T, O = string> {
@@ -8,79 +16,8 @@ export interface FuseFilterWithValue<T, O = string> {
   value: O
 }
 
-export class FuseFilter<T, O = string> {
-  public readonly fuseSearch: FuseSearch<O>
-  /** The unique identifier for the filter. */
-  public readonly id: string
-  /** The name of the filter for display purposes. */
-  public readonly name: string
-  /** The sequence of characters to invoke the filter. */
-  public readonly invokeSequence: string
-  /** A function that returns the options for the filter. */
-  public readonly getItemOptions: (item: T) => O[]
-
-  constructor(
-    data: T[],
-    options: {
-      id: string
-      name: string
-      invokeSequence: string
-      getItemOptions: (item: T) => O[]
-      fuseOptions?: IFuseOptions<O>
-    }
-  ) {
-    this.id = options.id
-    this.name = options.name
-    this.invokeSequence = options.invokeSequence
-    this.getItemOptions = options.getItemOptions
-
-    this.fuseSearch = new FuseSearch(this.getAllNodeOptions(data), {
-      fuseOptions: options.fuseOptions
-    })
-  }
-
-  public getAllNodeOptions(data: T[]): O[] {
-    const options = new Set<O>()
-    for (const item of data) {
-      for (const option of this.getItemOptions(item)) {
-        options.add(option)
-      }
-    }
-    return Array.from(options)
-  }
-
-  public matches(
-    item: T,
-    value: O,
-    extraOptions: {
-      wildcard?: O
-    } = {}
-  ): boolean {
-    const { wildcard } = extraOptions
-
-    if (wildcard && value === wildcard) {
-      return true
-    }
-    const options = this.getItemOptions(item)
-    if (wildcard) return options.some((option) => option === wildcard)
-    if (typeof value !== 'string' || !value.includes(','))
-      return options.includes(value)
-    const values = value.split(',')
-    //Alas, typescript doesn't understand string satisfies O
-    return values.some((v) => options.includes(v as O))
-  }
-}
-
 export interface FuseSearchable {
   postProcessSearchScores: (scores: SearchAuxScore) => SearchAuxScore
-}
-
-function isFuseSearchable(item: unknown): item is FuseSearchable {
-  return (
-    typeof item === 'object' &&
-    item !== null &&
-    'postProcessSearchScores' in item
-  )
 }
 
 /**
@@ -215,5 +152,68 @@ export class FuseSearch<T> {
       }
     }
     return a.length - b.length
+  }
+}
+
+export class FuseFilter<T, O = string> {
+  public readonly fuseSearch: FuseSearch<O>
+  /** The unique identifier for the filter. */
+  public readonly id: string
+  /** The name of the filter for display purposes. */
+  public readonly name: string
+  /** The sequence of characters to invoke the filter. */
+  public readonly invokeSequence: string
+  /** A function that returns the options for the filter. */
+  public readonly getItemOptions: (item: T) => O[]
+
+  constructor(
+    data: T[],
+    options: {
+      id: string
+      name: string
+      invokeSequence: string
+      getItemOptions: (item: T) => O[]
+      fuseOptions?: IFuseOptions<O>
+    }
+  ) {
+    this.id = options.id
+    this.name = options.name
+    this.invokeSequence = options.invokeSequence
+    this.getItemOptions = options.getItemOptions
+
+    this.fuseSearch = new FuseSearch(this.getAllNodeOptions(data), {
+      fuseOptions: options.fuseOptions
+    })
+  }
+
+  public getAllNodeOptions(data: T[]): O[] {
+    const options = new Set<O>()
+    for (const item of data) {
+      for (const option of this.getItemOptions(item)) {
+        options.add(option)
+      }
+    }
+    return Array.from(options)
+  }
+
+  public matches(
+    item: T,
+    value: O,
+    extraOptions: {
+      wildcard?: O
+    } = {}
+  ): boolean {
+    const { wildcard } = extraOptions
+
+    if (wildcard && value === wildcard) {
+      return true
+    }
+    const options = this.getItemOptions(item)
+    if (wildcard) return options.some((option) => option === wildcard)
+    if (typeof value !== 'string' || !value.includes(','))
+      return options.includes(value)
+    const values = value.split(',')
+    //Alas, typescript doesn't understand string satisfies O
+    return values.some((v) => options.includes(v as O))
   }
 }

--- a/src/utils/graphTraversalUtil.ts
+++ b/src/utils/graphTraversalUtil.ts
@@ -16,6 +16,32 @@ import type { NodeId } from '@/types/nodeId'
 
 import { isSubgraphIoNode } from './typeGuardUtil'
 
+/**
+ * Options for traverseNodesDepthFirst function
+ */
+interface TraverseNodesOptions<T> {
+  /** Function called for each node during traversal */
+  visitor?: (node: LGraphNode, context: T) => T
+  /** Initial context value */
+  initialContext?: T
+  /** Whether to traverse into subgraph nodes (default: true) */
+  expandSubgraphs?: boolean
+}
+
+/**
+ * Options for collectFromNodes function
+ */
+interface CollectFromNodesOptions<T, C> {
+  /** Function that returns data to collect for each node */
+  collector?: (node: LGraphNode, context: C) => T | null
+  /** Function that builds context for child nodes */
+  contextBuilder?: (node: LGraphNode, parentContext: C) => C
+  /** Initial context value */
+  initialContext?: C
+  /** Whether to traverse into subgraph nodes (default: true) */
+  expandSubgraphs?: boolean
+}
+
 function parseNodeIdPath(path: string[]): NodeId[] | null {
   const nodeIds = path.map(parseNodeId)
   return nodeIds.every((nodeId): nodeId is NodeId => nodeId !== null)
@@ -31,6 +57,29 @@ function createExecutionIdFromPath(
   if (!parentNodeIds) return null
 
   return createNodeExecutionId([...parentNodeIds, nodeId])
+}
+
+function getCandidateActivityExecutionId(candidate: {
+  nodeId?: string | number | null | undefined
+  sourceExecutionId?: string | number | null | undefined
+}): string | null {
+  const executionId = candidate.sourceExecutionId ?? candidate.nodeId
+  return executionId == null ? null : String(executionId)
+}
+
+function findPartialExecutionPathToGraph(
+  target: LGraph,
+  root: LGraph
+): string | undefined {
+  for (const node of root.nodes) {
+    if (!node.isSubgraphNode()) continue
+
+    if (node.subgraph === target) return `${node.id}`
+
+    const subpath = findPartialExecutionPathToGraph(target, node.subgraph)
+    if (subpath !== undefined) return node.id + ':' + subpath
+  }
+  return undefined
 }
 
 /**
@@ -445,14 +494,6 @@ export function isExecutionPathActive(
   return isAncestorPathActive(rootGraph, executionId)
 }
 
-function getCandidateActivityExecutionId(candidate: {
-  nodeId?: string | number | null | undefined
-  sourceExecutionId?: string | number | null | undefined
-}): string | null {
-  const executionId = candidate.sourceExecutionId ?? candidate.nodeId
-  return executionId == null ? null : String(executionId)
-}
-
 export function isCandidateScopeActive(
   rootGraph: LGraph | null | undefined,
   candidate: {
@@ -680,18 +721,6 @@ export function getAllNonIoNodesInSubgraph(subgraph: Subgraph): LGraphNode[] {
 }
 
 /**
- * Options for traverseNodesDepthFirst function
- */
-interface TraverseNodesOptions<T> {
-  /** Function called for each node during traversal */
-  visitor?: (node: LGraphNode, context: T) => T
-  /** Initial context value */
-  initialContext?: T
-  /** Whether to traverse into subgraph nodes (default: true) */
-  expandSubgraphs?: boolean
-}
-
-/**
  * Performs depth-first traversal of nodes and their subgraphs.
  * Generic visitor pattern that can be used for various node processing tasks.
  *
@@ -753,20 +782,6 @@ export function reduceAllNodes<T>(
     result = reducer(result, node)
   })
   return result
-}
-
-/**
- * Options for collectFromNodes function
- */
-interface CollectFromNodesOptions<T, C> {
-  /** Function that returns data to collect for each node */
-  collector?: (node: LGraphNode, context: C) => T | null
-  /** Function that builds context for child nodes */
-  contextBuilder?: (node: LGraphNode, parentContext: C) => C
-  /** Initial context value */
-  initialContext?: C
-  /** Whether to traverse into subgraph nodes (default: true) */
-  expandSubgraphs?: boolean
 }
 
 /**
@@ -860,19 +875,4 @@ export function getActiveGraphNodeIds(
     }
   }
   return ids
-}
-
-function findPartialExecutionPathToGraph(
-  target: LGraph,
-  root: LGraph
-): string | undefined {
-  for (const node of root.nodes) {
-    if (!node.isSubgraphNode()) continue
-
-    if (node.subgraph === target) return `${node.id}`
-
-    const subpath = findPartialExecutionPathToGraph(target, node.subgraph)
-    if (subpath !== undefined) return node.id + ':' + subpath
-  }
-  return undefined
 }

--- a/src/utils/hostWhitelist.ts
+++ b/src/utils/hostWhitelist.ts
@@ -12,6 +12,11 @@
 
 const HOST_WHITELIST: string[] = ['localhost']
 
+function isLocalhostLabel(h: string): boolean {
+  // 'localhost' and any subdomain (e.g., 'app.localhost')
+  return h === 'localhost' || h.endsWith('.localhost')
+}
+
 /** Normalize for comparison: lowercase, strip port/brackets, trim trailing dot. */
 export function normalizeHost(input: string): string {
   let h = (input || '').trim().toLowerCase()
@@ -36,6 +41,8 @@ export function normalizeHost(input: string): string {
   return h
 }
 
+/* -------------------- Helpers -------------------- */
+
 /** Public check used by the UI. */
 export function isHostWhitelisted(rawHost: string): boolean {
   const host = normalizeHost(rawHost)
@@ -45,13 +52,6 @@ export function isHostWhitelisted(rawHost: string): boolean {
   if (isComfyOrgHost(host)) return true
   const normalizedList = HOST_WHITELIST.map(normalizeHost)
   return normalizedList.includes(host)
-}
-
-/* -------------------- Helpers -------------------- */
-
-function isLocalhostLabel(h: string): boolean {
-  // 'localhost' and any subdomain (e.g., 'app.localhost')
-  return h === 'localhost' || h.endsWith('.localhost')
 }
 
 const IPV4_OCTET = '(?:25[0-5]|2[0-4]\\d|1\\d\\d|0?\\d?\\d)'

--- a/src/utils/linkFixer.ts
+++ b/src/utils/linkFixer.ts
@@ -35,17 +35,17 @@ import type {
   ISerialisedNode
 } from '@/lib/litegraph/src/types/serialisation'
 
+enum IoDirection {
+  INPUT,
+  OUTPUT
+}
+
 interface BadLinksData<T = ISerialisedGraph | LGraph> {
   hasBadLinks: boolean
   fixed: boolean
   graph: T
   patched: number
   deleted: number
-}
-
-enum IoDirection {
-  INPUT,
-  OUTPUT
 }
 
 function getNodeById(graph: ISerialisedGraph | LGraph, id: SerializedNodeId) {

--- a/src/utils/litegraphUtil.ts
+++ b/src/utils/litegraphUtil.ts
@@ -161,6 +161,44 @@ export const getItemsColorOption = (items: unknown[]): ColorOption | null => {
     : null
 }
 
+function matchesLegacyApi(input: ISerialisableNodeInput) {
+  return !(input.widget && input.link === null && !input.label)
+}
+
+/**
+ * Duplication to handle the legacy link arrays in the root workflow.
+ * @see compressWidgetInputSlots
+ * @param subgraph The subgraph to compress widget input slots for.
+ */
+function compressSubgraphWidgetInputSlots(
+  subgraphs: ExportedSubgraph[] | undefined,
+  visited = new WeakSet<ExportedSubgraph>()
+) {
+  if (!subgraphs) return
+
+  for (const subgraph of subgraphs) {
+    if (visited.has(subgraph)) throw new Error('Infinite loop detected')
+    visited.add(subgraph)
+
+    if (subgraph.nodes) {
+      for (const node of subgraph.nodes) {
+        node.inputs = node.inputs?.filter(matchesLegacyApi)
+
+        if (!subgraph.links) continue
+
+        for (const [inputIndex, input] of node.inputs?.entries() ?? []) {
+          if (input.link) {
+            const link = subgraph.links.find((link) => link.id === input.link)
+            if (link) link.target_slot = inputIndex
+          }
+        }
+      }
+    }
+
+    compressSubgraphWidgetInputSlots(subgraph.definitions?.subgraphs, visited)
+  }
+}
+
 export function executeWidgetsCallback(
   nodes: LGraphNode[],
   callbackName: 'onRemove' | 'beforeQueued' | 'afterQueued',
@@ -276,44 +314,6 @@ export function compressWidgetInputSlots(graph: ISerialisedGraph) {
   }
 
   compressSubgraphWidgetInputSlots(graph.definitions?.subgraphs)
-}
-
-function matchesLegacyApi(input: ISerialisableNodeInput) {
-  return !(input.widget && input.link === null && !input.label)
-}
-
-/**
- * Duplication to handle the legacy link arrays in the root workflow.
- * @see compressWidgetInputSlots
- * @param subgraph The subgraph to compress widget input slots for.
- */
-function compressSubgraphWidgetInputSlots(
-  subgraphs: ExportedSubgraph[] | undefined,
-  visited = new WeakSet<ExportedSubgraph>()
-) {
-  if (!subgraphs) return
-
-  for (const subgraph of subgraphs) {
-    if (visited.has(subgraph)) throw new Error('Infinite loop detected')
-    visited.add(subgraph)
-
-    if (subgraph.nodes) {
-      for (const node of subgraph.nodes) {
-        node.inputs = node.inputs?.filter(matchesLegacyApi)
-
-        if (!subgraph.links) continue
-
-        for (const [inputIndex, input] of node.inputs?.entries() ?? []) {
-          if (input.link) {
-            const link = subgraph.links.find((link) => link.id === input.link)
-            if (link) link.target_slot = inputIndex
-          }
-        }
-      }
-    }
-
-    compressSubgraphWidgetInputSlots(subgraph.definitions?.subgraphs, visited)
-  }
 }
 
 export function getLinkTypeColor(typeName: string): string {

--- a/src/utils/mathUtil.ts
+++ b/src/utils/mathUtil.ts
@@ -3,6 +3,9 @@ import { clamp } from 'es-toolkit/math'
 import type { ReadOnlyRect } from '@/lib/litegraph/src/interfaces'
 import type { Bounds } from '@/renderer/core/layout/types'
 
+/** Simple 2D point or size as [x, y] or [width, height] */
+type Vec2 = readonly [number, number]
+
 /** A rectangle's viewport edges: the DOMRect subset, so a DOMRect is directly assignable. */
 export type RectEdges = Pick<DOMRect, 'left' | 'top' | 'right' | 'bottom'>
 
@@ -43,9 +46,6 @@ export function denormalize(
 ): number {
   return min + normalized * (max - min)
 }
-
-/** Simple 2D point or size as [x, y] or [width, height] */
-type Vec2 = readonly [number, number]
 
 /** `value` wrapped into `[0, length)`. Unlike `%`, negatives wrap to the end. */
 export const wrapIndex = (value: number, length: number): number =>

--- a/src/utils/migration/migrateReroute.ts
+++ b/src/utils/migration/migrateReroute.ts
@@ -18,26 +18,6 @@ type LinkExtension = {
 }
 
 /**
- * Identifies all legacy Reroute nodes in a workflow
- */
-export function findLegacyRerouteNodes(
-  workflow: WorkflowJSON04
-): RerouteNode[] {
-  return workflow.nodes.filter(
-    (node) => node.type === 'Reroute'
-  ) as RerouteNode[]
-}
-
-/**
- * Checks if the workflow has no native reroutes
- */
-export function noNativeReroutes(workflow: WorkflowJSON04): boolean {
-  return (
-    !workflow.extra?.reroutes?.length && !workflow.extra?.linkExtensions?.length
-  )
-}
-
-/**
  * Gets the center position of a node
  */
 function getNodeCenter(node: ComfyNode): [number, number] {
@@ -308,6 +288,26 @@ class ConversionContext {
       }
     }
   }
+}
+
+/**
+ * Identifies all legacy Reroute nodes in a workflow
+ */
+export function findLegacyRerouteNodes(
+  workflow: WorkflowJSON04
+): RerouteNode[] {
+  return workflow.nodes.filter(
+    (node) => node.type === 'Reroute'
+  ) as RerouteNode[]
+}
+
+/**
+ * Checks if the workflow has no native reroutes
+ */
+export function noNativeReroutes(workflow: WorkflowJSON04): boolean {
+  return (
+    !workflow.extra?.reroutes?.length && !workflow.extra?.linkExtensions?.length
+  )
 }
 
 /**

--- a/src/utils/queueDisplay.ts
+++ b/src/utils/queueDisplay.ts
@@ -3,6 +3,14 @@ import type { JobState } from '@/types/queue'
 import { formatDuration } from '@/utils/formatUtil'
 import { clampPercentInt, formatPercent0 } from '@/utils/numberUtil'
 
+type JobDisplay = {
+  iconName: string
+  iconImageUrl?: string
+  primary: string
+  secondary: string
+  showClear: boolean
+}
+
 export type BuildJobDisplayCtx = {
   t: (k: string, v?: Record<string, unknown>) => string
   locale: string
@@ -14,14 +22,6 @@ export type BuildJobDisplayCtx = {
   showAddedHint?: boolean
   /** Whether the app is running in cloud distribution */
   isCloud?: boolean
-}
-
-type JobDisplay = {
-  iconName: string
-  iconImageUrl?: string
-  primary: string
-  secondary: string
-  showClear: boolean
 }
 
 export const iconForJobState = (state: JobState): string => {

--- a/src/utils/sessionFeatureFlagOverride.ts
+++ b/src/utils/sessionFeatureFlagOverride.ts
@@ -10,6 +10,13 @@ const EMPLOYEE_EMAIL_DOMAIN = '@comfy.org'
 type OverrideMap = Record<string, unknown>
 
 /**
+ * The captured overrides plus the query string they came from. Remembering the
+ * source makes capture idempotent: re-reading the same URL does not rewrite
+ * storage, so a flag can be read as often as a render needs.
+ */
+type StoredState = { search: string; overrides: OverrideMap }
+
+/**
  * Overrides apply only to a signed-in Comfy employee, so a link handed to a
  * customer stays inert on their machine. With every flag overridable, this is
  * the only thing standing between a `?ff=` link and the app's behaviour, so it
@@ -45,13 +52,6 @@ function parseOverrideValue(rawValue: string | undefined): unknown {
     return rawValue
   }
 }
-
-/**
- * The captured overrides plus the query string they came from. Remembering the
- * source makes capture idempotent: re-reading the same URL does not rewrite
- * storage, so a flag can be read as often as a render needs.
- */
-type StoredState = { search: string; overrides: OverrideMap }
 
 function emptyState(): StoredState {
   return { search: '', overrides: {} }

--- a/src/utils/videoMetadataUtil.ts
+++ b/src/utils/videoMetadataUtil.ts
@@ -30,13 +30,6 @@ const FRAME_RATE_SNAP_TOLERANCE = 0.01
 
 const PACKET_STATS_SAMPLE_SIZE = 100
 
-export function snapToStandardFrameRate(fps: number): number {
-  const standard = STANDARD_FRAME_RATES.find(
-    (candidate) => Math.abs(fps - candidate) <= FRAME_RATE_SNAP_TOLERANCE
-  )
-  return standard ?? fps
-}
-
 function isTrustedOrigin(url: URL): boolean {
   if (url.origin === window.location.origin) return true
   try {
@@ -59,6 +52,13 @@ function parseProbeableViewUrl(videoUrl: string): URL | undefined {
   if (!url.pathname.endsWith('/view')) return undefined
   if (url.searchParams.get('filename') === null) return undefined
   return url
+}
+
+export function snapToStandardFrameRate(fps: number): number {
+  const standard = STANDARD_FRAME_RATES.find(
+    (candidate) => Math.abs(fps - candidate) <= FRAME_RATE_SNAP_TOLERANCE
+  )
+  return standard ?? fps
 }
 
 let mediabunnyModulePromise: ReturnType<typeof importMediabunny> | undefined
@@ -107,11 +107,6 @@ function raceWithAbort<T>(
   })
 }
 
-export function clearVideoMetadataCache(): void {
-  metadataCache.clear()
-  inflightProbes.clear()
-}
-
 function rememberMetadata(key: string, metadata: VideoMetadata): void {
   metadataCache.delete(key)
   metadataCache.set(key, metadata)
@@ -119,6 +114,23 @@ function rememberMetadata(key: string, metadata: VideoMetadata): void {
     const oldest = metadataCache.keys().next().value
     if (oldest !== undefined) metadataCache.delete(oldest)
   }
+}
+
+async function probeVideoUrl(
+  videoUrl: string
+): Promise<VideoMetadata | undefined> {
+  try {
+    const { UrlSource } = await loadMediabunny()
+    const source = new UrlSource(videoUrl, { getRetryDelay: () => null })
+    return await extractVideoMetadata(source)
+  } catch {
+    return undefined
+  }
+}
+
+export function clearVideoMetadataCache(): void {
+  metadataCache.clear()
+  inflightProbes.clear()
 }
 
 export async function extractVideoMetadata(
@@ -162,18 +174,6 @@ export async function extractVideoMetadata(
       signal?.removeEventListener('abort', disposeOnAbort)
       if (!disposed) input.dispose()
     }
-  } catch {
-    return undefined
-  }
-}
-
-async function probeVideoUrl(
-  videoUrl: string
-): Promise<VideoMetadata | undefined> {
-  try {
-    const { UrlSource } = await loadMediabunny()
-    const source = new UrlSource(videoUrl, { getRetryDelay: () => null })
-    return await extractVideoMetadata(source)
   } catch {
     return undefined
   }

--- a/src/workbench/extensions/manager/types/comfyManagerTypes.ts
+++ b/src/workbench/extensions/manager/types/comfyManagerTypes.ts
@@ -22,17 +22,6 @@ export const isMergedNodePack = (
 export const IsInstallingKey: InjectionKey<Ref<boolean>> =
   Symbol('isInstalling')
 
-export enum ManagerTab {
-  All = 'all',
-  NotInstalled = 'notInstalled',
-  AllInstalled = 'allInstalled',
-  UpdateAvailable = 'updateAvailable',
-  Conflicting = 'conflicting',
-  Workflow = 'workflow',
-  Missing = 'missing',
-  Unresolved = 'unresolved'
-}
-
 export type TaskLog = {
   taskName: string
   taskId: string
@@ -44,17 +33,28 @@ export interface UseNodePacksOptions {
   maxConcurrent?: number
 }
 
+export interface ManagerState {
+  selectedTabId: ManagerTab
+  searchQuery: string
+  searchMode: 'nodes' | 'packs'
+  sortField: string
+}
+
+export enum ManagerTab {
+  All = 'all',
+  NotInstalled = 'notInstalled',
+  AllInstalled = 'allInstalled',
+  UpdateAvailable = 'updateAvailable',
+  Conflicting = 'conflicting',
+  Workflow = 'workflow',
+  Missing = 'missing',
+  Unresolved = 'unresolved'
+}
+
 export enum SortableAlgoliaField {
   Downloads = 'total_install',
   Created = 'create_time',
   Updated = 'update_time',
   Publisher = 'publisher_id',
   Name = 'name'
-}
-
-export interface ManagerState {
-  selectedTabId: ManagerTab
-  searchQuery: string
-  searchMode: 'nodes' | 'packs'
-  sortField: string
 }

--- a/src/workbench/extensions/manager/types/conflictDetectionTypes.ts
+++ b/src/workbench/extensions/manager/types/conflictDetectionTypes.ts
@@ -7,6 +7,14 @@
  */
 import type { components } from '@/types/comfyRegistryTypes'
 
+/**
+ * Detailed information about a Python import failure
+ */
+interface ImportFailureDetail {
+  error?: string
+  traceback?: string
+}
+
 // Re-export core types from Registry API
 export type Node = components['schemas']['Node']
 
@@ -77,14 +85,6 @@ export interface ConflictDetectionResponse {
   error_message?: string
   results: ConflictDetectionResult[]
   detected_system_environment?: Partial<SystemEnvironment>
-}
-
-/**
- * Detailed information about a Python import failure
- */
-interface ImportFailureDetail {
-  error?: string
-  traceback?: string
 }
 
 /**

--- a/src/workbench/extensions/manager/utils/conflictUtils.ts
+++ b/src/workbench/extensions/manager/utils/conflictUtils.ts
@@ -17,6 +17,21 @@ import {
 import { checkVersionCompatibility } from '@/workbench/extensions/manager/utils/versionUtil'
 
 /**
+ * Normalized compatibility inputs for a single package, produced by each call
+ * site from its own source shape. Banned/pending are pre-derived booleans
+ * (see {@link deriveStatusFlags}) since the two callers read status from
+ * different source shapes (Node vs NodeVersion).
+ */
+export interface CompatibilityInput {
+  supported_os?: RegistryOS[]
+  supported_accelerators?: RegistryAccelerator[]
+  supported_comfyui_version?: string
+  supported_comfyui_frontend_version?: string
+  isBanned: boolean
+  isPending: boolean
+}
+
+/**
  * Checks for banned package status conflicts.
  */
 export function createBannedConflict(
@@ -63,21 +78,6 @@ export function deriveStatusFlags(status?: string): {
       status === 'NodeStatusBanned' || status === 'NodeVersionStatusBanned',
     isPending: status === 'NodeVersionStatusPending'
   }
-}
-
-/**
- * Normalized compatibility inputs for a single package, produced by each call
- * site from its own source shape. Banned/pending are pre-derived booleans
- * (see {@link deriveStatusFlags}) since the two callers read status from
- * different source shapes (Node vs NodeVersion).
- */
-export interface CompatibilityInput {
-  supported_os?: RegistryOS[]
-  supported_accelerators?: RegistryAccelerator[]
-  supported_comfyui_version?: string
-  supported_comfyui_frontend_version?: string
-  isBanned: boolean
-  isPending: boolean
 }
 
 /**


### PR DESCRIPTION
## Summary

Apply the `perfectionist/sort-modules` autofix across existing TypeScript sources, then enforce the rule as an error.

## Changes

- **What**: Reorders declarations in 233 files, changes `perfectionist/sort-modules` from warning to error, and adds the pure autofix commit (`fe2939cbd47f5047f556a2ff83707d8a7c88dada`) to `.git-blame-ignore-revs`.

## Review Focus

The 17 files with moved class declarations were reviewed for module-evaluation TDZ hazards. Every moved class is referenced only from deferred function/method bodies or instantiated after module evaluation; no suppressions were required.

The rule reports zero remaining violations. It still does not cover `export const`, expression declarations, imports, or from-exports.

Verification:

- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `pnpm test:unit` — 1,191 files and 16,401 tests passed; 8 skipped
- Targeted Playwright: 45/57 passed initially; 7/12 timed-out tests passed serially. The remaining five failures reproduce unchanged on the parent branch (three canvas drag-coordinate assertions and two subgraph reload timeouts).
