### PR TITLE
re-loosen asset schema

### DIFF
--- a/src/platform/assets/schemas/assetSchema.ts
+++ b/src/platform/assets/schemas/assetSchema.ts
@@ -7,10 +7,15 @@ import { z } from 'zod'
 // Zod schemas for asset API validation matching ComfyUI Assets REST API spec
 const zAsset = z.object({
   ...zIngestAsset.shape,
+  created_at: z.string().datetime({ local: true }),
+  hash: z.string().optional(),
   id: z.string(),
+  last_access_time: z.string().datetime({ local: true }).optional(),
+  preview_url: z.string().optional(),
   size: zIngestAsset.shape.size.unwrap().transform(Number).optional(),
   tags: zIngestAsset.shape.tags.default([]),
-  thumbnail_url: z.string().optional()
+  thumbnail_url: z.string().optional(),
+  updated_at: z.string().datetime({ local: true })
 })
 
 const zAssetResponse = zListAssetsResponse

--- a/src/platform/assets/services/assetService.test.ts
+++ b/src/platform/assets/services/assetService.test.ts
@@ -424,6 +424,25 @@ describe(assetService.deleteAsset, () => {
   })
 })
 
+describe('assetResponseSchema accepts real API shapes', () => {
+  it("parses an asset that doesn't satisfy cloud schema", async () => {
+    const asset = {
+      id: 'real-api-shape',
+      created_at: '2025-06-15T09:30:00',
+      updated_at: '2025-06-15T10:00:00',
+      hash: 'badhash'
+    }
+    fetchApiMock.mockResolvedValueOnce(
+      buildAssetListResponse([validAsset(asset)])
+    )
+
+    const assets = await assetService.getAssetsByTag('models')
+
+    expect(assets).toHaveLength(1)
+    expect(assets[0]).toMatchObject(asset)
+  })
+})
+
 describe(assetService.getAssetModels, () => {
   beforeEach(() => {
     assetService.invalidateModelBuckets()


### PR DESCRIPTION
#14858 more closely aligned the asset schema to match the spec defined by cloud generated types. Since cloud doesn't satisfy it's own schema, this would result in assets being skipped on cloud. The schema is loosened for these inaccuracies. A test was added to verify that these specific inaccuracies be accepted.