### PR TITLE
Align Agent chat rename and history navigation

### DIFF
--- a/src/workbench/extensions/agent/AgentPanelRoot.test.ts
+++ b/src/workbench/extensions/agent/AgentPanelRoot.test.ts
@@ -1680,6 +1680,50 @@ describe('AgentPanelRoot history', () => {
     )
   })
 
+  it('starts renaming from a single click on the current title', async () => {
+    await renderWithActiveThread()
+
+    await userEvent.click(
+      screen.getByRole('button', {
+        name: i18n.global.t('agent.newChatTitle')
+      })
+    )
+
+    const input = await screen.findByRole<HTMLInputElement>('textbox', {
+      name: i18n.global.t('g.rename')
+    })
+    expect(input).toHaveFocus()
+    expect(input.selectionStart).toBe(0)
+    expect(input.selectionEnd).toBe(input.value.length)
+    expect(
+      screen.queryByRole('button', { name: i18n.global.t('agent.history') })
+    ).toBeNull()
+  })
+
+  it('opens Chat History from its dedicated control', async () => {
+    await renderWithActiveThread()
+
+    await userEvent.click(
+      screen.getByRole('button', {
+        name: i18n.global.t('agent.showChatHistory')
+      })
+    )
+
+    expect(
+      await screen.findByRole('heading', {
+        name: i18n.global.t('agent.history')
+      })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', {
+        name: i18n.global.t('agent.backToPreviousChat')
+      })
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByRole('textbox', { name: i18n.global.t('g.rename') })
+    ).toBeNull()
+  })
+
   it('abandons a rename on Escape', async () => {
     await renderWithActiveThread()
 
@@ -1706,7 +1750,9 @@ describe('AgentPanelRoot history', () => {
     await renderWithActiveThread()
 
     await userEvent.click(
-      screen.getByRole('button', { name: i18n.global.t('agent.newChatTitle') })
+      screen.getByRole('button', {
+        name: i18n.global.t('agent.showChatHistory')
+      })
     )
     await userEvent.click(
       screen.getByRole('button', {
@@ -1922,7 +1968,11 @@ describe('AgentPanelRoot transcript copy', () => {
     )
     await nextTick()
 
-    await userEvent.click(screen.getByRole('button', { name: 'make a cat' }))
+    await userEvent.click(
+      screen.getByRole('button', {
+        name: i18n.global.t('agent.showChatHistory')
+      })
+    )
     await userEvent.click(
       await screen.findByRole('button', {
         name: i18n.global.t('agent.copyMarkdown')
@@ -2158,7 +2208,9 @@ describe('AgentPanelRoot workflow binding', () => {
     expect(await screen.findAllByText('current')).not.toHaveLength(0)
 
     await userEvent.click(
-      screen.getByRole('button', { name: i18n.global.t('agent.newChatTitle') })
+      screen.getByRole('button', {
+        name: i18n.global.t('agent.showChatHistory')
+      })
     )
     expect(
       await screen.findByText(i18n.global.t('agent.historyEmpty'))
@@ -2166,7 +2218,9 @@ describe('AgentPanelRoot workflow binding', () => {
     expect(screen.queryByText('current')).not.toBeInTheDocument()
 
     await userEvent.click(
-      screen.getByRole('button', { name: i18n.global.t('agent.history') })
+      screen.getByRole('button', {
+        name: i18n.global.t('agent.backToPreviousChat')
+      })
     )
     expect(await screen.findAllByText('current')).not.toHaveLength(0)
   })

--- a/src/workbench/extensions/agent/components/agent/AgentPanel.test.ts
+++ b/src/workbench/extensions/agent/components/agent/AgentPanel.test.ts
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/vue'
+import { render, screen, within } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it } from 'vitest'
@@ -59,6 +59,41 @@ describe('AgentPanel', () => {
         'The AI agent can make mistakes. Double check your response.'
       )
     ).toBeInTheDocument()
+  })
+
+  it('groups chat options with the title and separates history navigation', () => {
+    const title = 'A comfortably short title'
+    render(AgentPanel, {
+      props: {
+        entries: [],
+        historyGroups,
+        sessionId: 'thread-1',
+        customTitle: title
+      },
+      global: {
+        plugins: [i18n],
+        stubs: {
+          Composer: true,
+          EmptyState: true,
+          PanelHeader: true
+        }
+      }
+    })
+
+    const titleGroup = screen.getByRole('group', {
+      name: i18n.global.t('agent.chatOptions')
+    })
+    const titleButton = within(titleGroup).getByRole('button', { name: title })
+    const optionsButton = within(titleGroup).getByRole('button', {
+      name: i18n.global.t('agent.chatOptions')
+    })
+    const historyButton = screen.getByRole('button', {
+      name: i18n.global.t('agent.showChatHistory')
+    })
+
+    expect(titleButton).toBeVisible()
+    expect(optionsButton).toBeVisible()
+    expect(titleGroup).not.toContainElement(historyButton)
   })
 
   it('focuses the composer input body after a suggestion and clears on blur', async () => {

--- a/src/workbench/extensions/agent/components/agent/AgentPanel.vue
+++ b/src/workbench/extensions/agent/components/agent/AgentPanel.vue
@@ -198,33 +198,49 @@ defineExpose({ addAttachment, updateAttachment, removeAttachment })
 
     <template v-else>
       <div class="flex h-10 shrink-0 items-center px-2">
-        <div
-          v-if="renaming"
-          class="text-agent-fg-muted flex items-center rounded-sm px-2 py-1"
+        <button
+          v-tooltip.bottom="buildAgentTooltipConfig(t('agent.showChatHistory'))"
+          type="button"
+          :aria-label="t('agent.showChatHistory')"
+          :class="[
+            'text-agent-fg-muted hover:bg-agent-surface-hover hover:text-agent-fg',
+            'focus-visible:ring-agent-accent focus-visible:ring-2 focus-visible:outline-none',
+            'flex size-6 shrink-0 cursor-pointer items-center justify-center rounded-sm transition-colors'
+          ]"
+          @click="onOpenHistory"
         >
-          <span class="icon-[lucide--align-justify] size-4 shrink-0" />
+          <span class="icon-[lucide--history] size-4 shrink-0" />
+        </button>
+        <template v-if="renaming">
           <input
             ref="renameInput"
             v-model="renameDraft"
             type="text"
             :aria-label="t('g.rename')"
-            class="text-agent-fg border-agent-accent h-6 max-w-64 rounded-lg border px-2 py-1 text-xs outline-none"
+            class="text-agent-fg border-agent-accent h-6 min-w-0 flex-1 rounded-lg border px-2 py-1 text-xs outline-none"
             @keydown="onRenameKeydown"
             @blur="commitRename"
           />
-        </div>
-        <template v-else>
+        </template>
+        <div
+          v-else
+          role="group"
+          :aria-label="t('agent.chatOptions')"
+          class="flex w-fit max-w-full min-w-0 items-center"
+        >
           <button
             ref="titleButton"
-            v-tooltip.bottom="
-              buildAgentTooltipConfig(t('agent.showChatHistory'))
-            "
             type="button"
-            class="text-agent-fg-muted hover:bg-agent-surface-hover flex h-6 cursor-pointer items-center gap-2 rounded-sm px-2 py-1 text-xs transition-colors"
-            @click="onOpenHistory"
+            :disabled="sessionId === null"
+            :class="[
+              'text-agent-fg-muted hover:bg-agent-surface-hover hover:text-agent-fg disabled:hover:text-agent-fg-muted',
+              'focus-visible:ring-agent-accent focus-visible:ring-2 focus-visible:outline-none',
+              'flex h-6 min-w-0 cursor-pointer items-center rounded-sm px-2 py-1 text-left text-xs transition-colors',
+              'disabled:cursor-default disabled:hover:bg-transparent'
+            ]"
+            @click="startRename"
           >
-            <span class="icon-[lucide--align-justify] size-4 shrink-0" />
-            <span class="max-w-56 truncate">{{
+            <span class="min-w-0 truncate">{{
               sessionTitle || t('agent.newChatTitle')
             }}</span>
           </button>
@@ -232,7 +248,7 @@ defineExpose({ addAttachment, updateAttachment, removeAttachment })
             <DropdownMenuTrigger
               v-tooltip.bottom="buildAgentTooltipConfig(t('agent.chatOptions'))"
               :aria-label="t('agent.chatOptions')"
-              class="text-agent-fg-muted hover:bg-agent-surface-hover hover:text-agent-fg flex size-6 cursor-pointer items-center justify-center rounded-sm transition-colors"
+              class="text-agent-fg-muted hover:bg-agent-surface-hover hover:text-agent-fg flex size-6 shrink-0 cursor-pointer items-center justify-center rounded-sm transition-colors"
             >
               <span class="icon-[lucide--chevron-down] size-3" />
             </DropdownMenuTrigger>
@@ -263,7 +279,7 @@ defineExpose({ addAttachment, updateAttachment, removeAttachment })
               </DropdownMenuContent>
             </DropdownMenuPortal>
           </DropdownMenuRoot>
-        </template>
+        </div>
       </div>
 
       <div class="min-h-0 flex-1">

--- a/src/workbench/extensions/agent/components/agent/ChatHistoryScreen.test.ts
+++ b/src/workbench/extensions/agent/components/agent/ChatHistoryScreen.test.ts
@@ -49,21 +49,27 @@ describe('ChatHistoryScreen', () => {
     i18n.global.locale.value = 'en'
   })
 
-  it('renders the 16px left chevron from the design', () => {
+  it('renders a separate back control and Chat History heading', () => {
     renderScreen()
 
-    const back = screen.getByRole('button', { name: 'Chat History' })
+    const back = screen.getByRole('button', {
+      name: 'Back to previous chat'
+    })
     // eslint-disable-next-line testing-library/no-node-access -- Iconify icons have no accessible role
     const icon = back.querySelector('.icon-\\[lucide--chevron-left\\]')
 
     expect(icon).toHaveClass('size-4')
+    expect(screen.getByRole('heading', { name: 'Chat History' })).toBeVisible()
+    expect(screen.queryByRole('button', { name: 'Chat History' })).toBeNull()
   })
 
   it('shows the exact back tooltip after hovering the control', async () => {
     const user = userEvent.setup()
     renderScreen()
 
-    const back = screen.getByRole('button', { name: 'Chat History' })
+    const back = screen.getByRole('button', {
+      name: 'Back to previous chat'
+    })
     expect(screen.queryByRole('tooltip', { hidden: true })).toBeNull()
     await user.hover(back)
 
@@ -76,7 +82,9 @@ describe('ChatHistoryScreen', () => {
     const user = userEvent.setup()
     const { emitted } = renderScreen()
 
-    await user.click(screen.getByRole('button', { name: 'Chat History' }))
+    await user.click(
+      screen.getByRole('button', { name: 'Back to previous chat' })
+    )
 
     expect(emitted().back).toEqual([[]])
   })

--- a/src/workbench/extensions/agent/components/agent/ChatHistoryScreen.vue
+++ b/src/workbench/extensions/agent/components/agent/ChatHistoryScreen.vue
@@ -91,17 +91,17 @@ function onRenameKeydown(session: ChatSession, event: KeyboardEvent): void {
 
 <template>
   <div class="flex h-full flex-col overflow-hidden">
-    <div class="flex h-10 shrink-0 items-center px-2">
+    <div class="flex h-10 shrink-0 items-center gap-1 px-2">
       <TooltipProvider v-bind="AGENT_REKA_TOOLTIP_PROVIDER_PROPS">
         <TooltipRoot disable-closing-trigger>
           <TooltipTrigger as-child>
             <button
               type="button"
-              class="text-agent-fg-muted hover:bg-agent-surface-hover hover:text-agent-fg flex h-6 cursor-pointer items-center gap-1 rounded-sm px-2 py-1 text-xs font-normal transition-colors"
+              :aria-label="t('agent.backToPreviousChat')"
+              class="text-agent-fg-muted hover:bg-agent-surface-hover hover:text-agent-fg flex size-6 shrink-0 cursor-pointer items-center justify-center rounded-sm transition-colors"
               @click="emit('back')"
             >
               <span class="icon-[lucide--chevron-left] size-4 shrink-0" />
-              <span>{{ t('agent.history') }}</span>
             </button>
           </TooltipTrigger>
           <TooltipPortal>
@@ -116,6 +116,9 @@ function onRenameKeydown(session: ChatSession, event: KeyboardEvent): void {
           </TooltipPortal>
         </TooltipRoot>
       </TooltipProvider>
+      <h2 class="text-agent-fg-muted m-0 text-xs font-normal">
+        {{ t('agent.history') }}
+      </h2>
     </div>
 
     <div class="min-h-0 flex-1 overflow-y-auto p-2">


### PR DESCRIPTION
## Summary

- add a dedicated Chat History control so the current title can single-click into inline rename
- keep the chat-options chevron beside the rendered title while allowing the title to use available width before truncating
- separate the History back icon from the non-interactive `Chat History` heading
- preserve the existing menu rename path and keyboard behavior

## Validation

- `AgentPanel.test.ts`: 4/4
- `ChatHistoryScreen.test.ts`: 10/10
- changed `AgentPanelRoot` behavior and stale back-control assertions verified
- pre-commit oxfmt, oxlint, ESLint, Stylelint, typecheck, and knip passed
- manually reviewed through the local Cloud dev proxy targeting `agent.comfy.org`

## Notes

- stacked on #13892 and intentionally targets `nathaniel/agent-panel-v1`
- rename persistence remains the existing frontend-local overlay pending BE-3130

Linear: [FE-1702](https://linear.app/comfyorg/issue/FE-1702/fe-align-chat-rename-interaction-with-design)