### PR TITLE
Allow editing the last stopped Agent prompt

### DIFF
--- a/browser_tests/tests/agent/agentPanel.spec.ts
+++ b/browser_tests/tests/agent/agentPanel.spec.ts
@@ -192,6 +192,42 @@ test.describe('In-App Agent panel', { tag: '@cloud' }, () => {
     expect(track.scrollbarColor).toMatch(/rgba\(0, 0, 0, 0\)$/)
   })
 
+  test('edits and resubmits the last prompt after stopping its turn', async ({
+    comfyPage,
+    postedMessages,
+    getWebSocket
+  }) => {
+    const page = comfyPage.page
+    await page.getByRole('button', { name: OPEN_AGENT_LABEL }).click()
+
+    const panel = page.locator('#agent-panel-root')
+    const composer = panel.getByRole('textbox', { name: /^Describe ideas/ })
+    const originalPrompt = 'Build a rainy city at night'
+    const revisedPrompt = 'Build a rainy city at sunrise'
+
+    await composer.fill(originalPrompt)
+    await panel.getByRole('button', { name: enMessages.agent.send }).click()
+    await expect.poll(() => postedMessages.length).toBe(1)
+
+    await panel.getByRole('button', { name: enMessages.agent.stop }).click()
+    await expect(
+      panel.getByRole('button', { name: enMessages.g.edit })
+    ).toHaveCount(0)
+
+    pushEvent(await getWebSocket(), MESSAGE_DONE_EVENT)
+    const editButton = panel.getByRole('button', { name: enMessages.g.edit })
+    await expect(editButton).toHaveCount(1)
+    await editButton.click()
+
+    await expect(composer).toHaveValue(originalPrompt)
+    await expect(composer).toBeFocused()
+
+    await composer.fill(revisedPrompt)
+    await panel.getByRole('button', { name: enMessages.agent.send }).click()
+    await expect.poll(() => postedMessages.length).toBe(2)
+    expect(postedMessages[1]).toContain(revisedPrompt)
+  })
+
   test('applies a draft_patch graph to the canvas', async ({
     comfyPage,
     postedMessages,

--- a/browser_tests/tests/agent/agentPanel.spec.ts
+++ b/browser_tests/tests/agent/agentPanel.spec.ts
@@ -209,6 +209,9 @@ test.describe('In-App Agent panel', { tag: '@cloud' }, () => {
     await panel.getByRole('button', { name: enMessages.agent.send }).click()
     await expect.poll(() => postedMessages.length).toBe(1)
 
+    await expect(
+      panel.getByRole('button', { name: enMessages.g.edit })
+    ).toHaveCount(0)
     await panel.getByRole('button', { name: enMessages.agent.stop }).click()
     await expect(
       panel.getByRole('button', { name: enMessages.g.edit })

--- a/browser_tests/tests/agent/agentPanelMocks.ts
+++ b/browser_tests/tests/agent/agentPanelMocks.ts
@@ -4,6 +4,7 @@ import { comfyPageFixture } from '@e2e/fixtures/ComfyPage'
 
 import type { RemoteConfig } from '@/platform/remoteConfig/types'
 import type {
+  AgentCancelAccepted,
   AgentDraftSnapshot,
   AgentTurnAccepted,
   AgentWsEvent,
@@ -24,6 +25,8 @@ const TURN_ACCEPTED: AgentTurnAccepted = {
   thread_id: THREAD_ID,
   workflow_id: WORKFLOW_ID
 }
+
+const CANCEL_ACCEPTED: AgentCancelAccepted = { status: 'cancelling' }
 
 const DRAFT_GRAPH: ComfyWorkflowJSON = {
   version: 0.4,
@@ -261,14 +264,25 @@ async function mockAgentBoot(
     const request = route.request()
     if (request.method() === 'POST') {
       postedMessages.push(request.postData() ?? '')
+      const accepted: AgentTurnAccepted = {
+        ...TURN_ACCEPTED,
+        message_id:
+          postedMessages.length === 1
+            ? TURN_ID
+            : `${TURN_ID}-${postedMessages.length}`
+      }
       return route.fulfill({
         status: 202,
         contentType: 'application/json',
-        body: JSON.stringify(TURN_ACCEPTED)
+        body: JSON.stringify(accepted)
       })
     }
     return route.fulfill(jsonRoute([]))
   })
+
+  await page.route('**/api/agent/threads/*/messages/*/cancel', (route: Route) =>
+    route.fulfill(jsonRoute(CANCEL_ACCEPTED))
+  )
 
   await page.route('**/api/agent/draft**', (r) =>
     r.fulfill(jsonRoute(DRAFT_SNAPSHOT))

--- a/src/workbench/extensions/agent/AgentPanelRoot.vue
+++ b/src/workbench/extensions/agent/AgentPanelRoot.vue
@@ -340,6 +340,7 @@ const {
   start,
   stop,
   entries,
+  editableTurnId,
   isStreaming,
   status,
   notices,
@@ -1161,6 +1162,7 @@ function onPanelDrop(event: DragEvent): void {
     <AgentPanel
       ref="panelRef"
       :entries
+      :editable-turn-id="editableTurnId"
       :user-name="userName"
       :streaming="isStreaming"
       :submitting="isSending || status === 'thinking'"

--- a/src/workbench/extensions/agent/components/agent/AgentPanel.test.ts
+++ b/src/workbench/extensions/agent/components/agent/AgentPanel.test.ts
@@ -2,8 +2,10 @@ import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it } from 'vitest'
+import { defineComponent } from 'vue'
 
 import { i18n } from '@/i18n'
+import type { TurnId } from '../../schemas/agentApiSchema'
 
 import AgentPanel from './AgentPanel.vue'
 
@@ -87,5 +89,41 @@ describe('AgentPanel', () => {
     await user.click(screen.getByRole('button', { name: 'New chat' }))
 
     expect(textarea).not.toHaveFocus()
+  })
+
+  it('replaces and focuses the composer draft when editing the eligible prompt', async () => {
+    const user = userEvent.setup()
+    const pinia = createPinia()
+    setActivePinia(pinia)
+    const prompt = 'Generate a yellow duck with a hockey mask'
+    const Harness = defineComponent({
+      components: { AgentPanel },
+      setup() {
+        return {
+          editableTurnId: 'msg-1' as TurnId,
+          entries: [{ id: 'msg-1' as TurnId, role: 'user', text: prompt }],
+          historyGroups
+        }
+      },
+      template: `<AgentPanel
+        :entries="entries"
+        :editable-turn-id="editableTurnId"
+        :history-groups="historyGroups"
+      />`
+    })
+    render(Harness, {
+      global: {
+        plugins: [pinia, i18n],
+        directives: { tooltip: {} },
+        stubs: { WorkflowSelectorChip: true }
+      }
+    })
+    const textarea = screen.getByRole('textbox')
+    await user.type(textarea, 'unfinished draft')
+
+    await user.click(screen.getByRole('button', { name: 'Edit' }))
+
+    expect(textarea).toHaveValue(prompt)
+    expect(textarea).toHaveFocus()
   })
 })

--- a/src/workbench/extensions/agent/components/agent/AgentPanel.test.ts
+++ b/src/workbench/extensions/agent/components/agent/AgentPanel.test.ts
@@ -2,7 +2,6 @@ import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it } from 'vitest'
-import { defineComponent } from 'vue'
 
 import { i18n } from '@/i18n'
 import type { TurnId } from '../../schemas/agentApiSchema'
@@ -96,22 +95,12 @@ describe('AgentPanel', () => {
     const pinia = createPinia()
     setActivePinia(pinia)
     const prompt = 'Generate a yellow duck with a hockey mask'
-    const Harness = defineComponent({
-      components: { AgentPanel },
-      setup() {
-        return {
-          editableTurnId: 'msg-1' as TurnId,
-          entries: [{ id: 'msg-1' as TurnId, role: 'user', text: prompt }],
-          historyGroups
-        }
+    render(AgentPanel, {
+      props: {
+        editableTurnId: 'msg-1' as TurnId,
+        entries: [{ id: 'msg-1' as TurnId, role: 'user', text: prompt }],
+        historyGroups
       },
-      template: `<AgentPanel
-        :entries="entries"
-        :editable-turn-id="editableTurnId"
-        :history-groups="historyGroups"
-      />`
-    })
-    render(Harness, {
       global: {
         plugins: [pinia, i18n],
         directives: { tooltip: {} },

--- a/src/workbench/extensions/agent/components/agent/AgentPanel.test.ts
+++ b/src/workbench/extensions/agent/components/agent/AgentPanel.test.ts
@@ -95,7 +95,7 @@ describe('AgentPanel', () => {
     const pinia = createPinia()
     setActivePinia(pinia)
     const prompt = 'Generate a yellow duck with a hockey mask'
-    render(AgentPanel, {
+    const { emitted } = render(AgentPanel, {
       props: {
         editableTurnId: 'msg-1' as TurnId,
         entries: [{ id: 'msg-1' as TurnId, role: 'user', text: prompt }],
@@ -114,5 +114,11 @@ describe('AgentPanel', () => {
 
     expect(textarea).toHaveValue(prompt)
     expect(textarea).toHaveFocus()
+
+    await user.clear(textarea)
+    await user.type(textarea, 'Generate a yellow duck at sunrise')
+    await user.click(screen.getByRole('button', { name: 'Send' }))
+
+    expect(emitted().send[0]).toEqual(['Generate a yellow duck at sunrise', []])
   })
 })

--- a/src/workbench/extensions/agent/components/agent/AgentPanel.vue
+++ b/src/workbench/extensions/agent/components/agent/AgentPanel.vue
@@ -14,6 +14,7 @@ import { buildAgentTooltipConfig } from '@/composables/useTooltipConfig'
 import type { AssetItem } from '@/platform/assets/schemas/assetSchema'
 
 import type { ActiveTab } from '../../types/activeTab'
+import type { TurnId } from '../../schemas/agentApiSchema'
 import type { ComposerAttachment } from '../../composables/agent/useComposer'
 import type { SelectedNode } from '../../composables/agent/useCanvasSelection'
 import type { ConversationEntry } from '../../stores/agent/agentConversationStore'
@@ -43,7 +44,8 @@ const {
   getMentionAssets = async () => [],
   sessionId = null,
   customTitle,
-  historyGroups
+  historyGroups,
+  editableTurnId = null
 } = defineProps<{
   entries: ConversationEntry[]
   userName?: string
@@ -61,6 +63,7 @@ const {
   sessionId?: string | null
   customTitle?: string
   historyGroups: HistoryGroups
+  editableTurnId?: TurnId | null
 }>()
 const emit = defineEmits<{
   send: [text: string, attachments: ComposerAttachment[]]
@@ -275,6 +278,8 @@ defineExpose({ addAttachment, updateAttachment, removeAttachment })
         <ConversationView
           v-else
           :entries="entries"
+          :editable-turn-id="editableTurnId"
+          @edit-prompt="composerRef?.replaceDraft($event)"
           @feedback="(id, vote) => emit('feedback', id, vote)"
         />
       </div>

--- a/src/workbench/extensions/agent/components/agent/Composer.vue
+++ b/src/workbench/extensions/agent/components/agent/Composer.vue
@@ -296,8 +296,14 @@ function insert(text: string): void {
   textareaRef.value?.focus()
 }
 
+function replaceDraft(text: string): void {
+  composer.draft.value = text
+  textareaRef.value?.focus()
+}
+
 defineExpose({
   insert,
+  replaceDraft,
   addAttachment: composer.addAttachment,
   updateAttachment: composer.updateAttachment,
   removeAttachment: composer.removeAttachment

--- a/src/workbench/extensions/agent/components/agent/ConversationView.vue
+++ b/src/workbench/extensions/agent/components/agent/ConversationView.vue
@@ -8,15 +8,18 @@ import { buildAgentTooltipConfig } from '@/composables/useTooltipConfig'
 import { cn } from '@comfyorg/tailwind-utils'
 
 import type { ConversationEntry } from '../../stores/agent/agentConversationStore'
+import type { TurnId } from '../../schemas/agentApiSchema'
 
 import AgentMessage from './message/AgentMessage.vue'
 import UserMessage from './message/UserMessage.vue'
 
-const { entries } = defineProps<{
+const { entries, editableTurnId = null } = defineProps<{
   entries: ConversationEntry[]
+  editableTurnId?: TurnId | null
 }>()
 const emit = defineEmits<{
   feedback: [turnId: string, vote: 'up' | 'down' | null]
+  editPrompt: [text: string]
 }>()
 
 const { t } = useI18n()
@@ -77,6 +80,8 @@ watch(
               :text="entry.text"
               :attachments="entry.attachments"
               :tags="entry.tags"
+              :editable="entry.id === editableTurnId"
+              @edit="emit('editPrompt', $event)"
             />
             <AgentMessage
               v-else

--- a/src/workbench/extensions/agent/components/agent/message/UserMessage.test.ts
+++ b/src/workbench/extensions/agent/components/agent/message/UserMessage.test.ts
@@ -28,6 +28,7 @@ function renderMessage(props: {
   text: string
   attachments?: { name: string; previewUrl?: string }[]
   tags?: string[]
+  editable?: boolean
 }) {
   return render(UserMessage, { props, global: { plugins: [i18n] } })
 }
@@ -78,6 +79,29 @@ describe('UserMessage', () => {
 
     await user.keyboard('{Enter}')
     expect(clipboard.copy).toHaveBeenCalledWith('make it cinematic')
+  })
+
+  it('offers an accessible edit action only when the prompt is editable', async () => {
+    const user = userEvent.setup()
+    const prompt = 'make it cinematic'
+    const { emitted } = renderMessage({ text: prompt, editable: true })
+
+    const editButton = screen.getByRole('button', { name: t('g.edit') })
+    await user.hover(editButton)
+    expect(
+      await screen.findByRole('tooltip', { hidden: true })
+    ).toHaveTextContent(t('g.edit'))
+    await user.click(editButton)
+
+    expect(emitted().edit).toEqual([[prompt]])
+  })
+
+  it('does not offer edit for a settled prompt without edit eligibility', () => {
+    renderMessage({ text: 'make it cinematic' })
+
+    expect(
+      screen.queryByRole('button', { name: t('g.edit') })
+    ).not.toBeInTheDocument()
   })
 
   it('offers no copy action on an attachment-only message', () => {

--- a/src/workbench/extensions/agent/components/agent/message/UserMessage.vue
+++ b/src/workbench/extensions/agent/components/agent/message/UserMessage.vue
@@ -9,11 +9,16 @@ import AgentTooltip from '../AgentTooltip.vue'
 const {
   text,
   attachments = [],
-  tags = []
+  tags = [],
+  editable = false
 } = defineProps<{
   text: string
   attachments?: UserAttachment[]
   tags?: string[]
+  editable?: boolean
+}>()
+const emit = defineEmits<{
+  edit: [text: string]
 }>()
 
 const { t } = useI18n()
@@ -68,6 +73,16 @@ const { copy, copied } = useClipboard({ copiedDuring: 2000, legacy: true })
       v-if="text"
       class="text-agent-fg-subtle flex opacity-0 transition-opacity group-hover:opacity-100 focus-within:opacity-100"
     >
+      <AgentTooltip v-if="editable" :label="t('g.edit')">
+        <button
+          type="button"
+          :aria-label="t('g.edit')"
+          class="hover:bg-agent-surface-hover hover:text-agent-fg flex size-6 cursor-pointer items-center justify-center rounded-lg p-1 transition-colors"
+          @click="emit('edit', text)"
+        >
+          <span class="icon-[lucide--pencil] size-3" />
+        </button>
+      </AgentTooltip>
       <AgentTooltip :label="copied ? t('agent.copied') : t('agent.copy')">
         <button
           type="button"

--- a/src/workbench/extensions/agent/components/agent/message/UserMessage.vue
+++ b/src/workbench/extensions/agent/components/agent/message/UserMessage.vue
@@ -71,7 +71,7 @@ const { copy, copied } = useClipboard({ copiedDuring: 2000, legacy: true })
     </div>
     <div
       v-if="text"
-      class="text-agent-fg-subtle flex opacity-0 transition-opacity group-hover:opacity-100 focus-within:opacity-100"
+      class="text-agent-fg-subtle pointer-events-none flex opacity-0 transition-opacity group-hover:pointer-events-auto group-hover:opacity-100 focus-within:pointer-events-auto focus-within:opacity-100 touch:pointer-events-auto touch:opacity-100"
     >
       <AgentTooltip v-if="editable" :label="t('g.edit')">
         <button

--- a/src/workbench/extensions/agent/composables/agent/useAgentSession.test.ts
+++ b/src/workbench/extensions/agent/composables/agent/useAgentSession.test.ts
@@ -133,6 +133,17 @@ const historyRow = (
   content: { text }
 })
 
+function editableTurnId(session: object): unknown {
+  const candidate: unknown = Reflect.get(session, 'editableTurnId')
+  if (
+    typeof candidate !== 'object' ||
+    candidate === null ||
+    !('value' in candidate)
+  )
+    return undefined
+  return candidate.value
+}
+
 describe('useAgentSession (v1 composition root)', () => {
   beforeEach(() => {
     setActivePinia(createPinia())
@@ -388,15 +399,33 @@ describe('useAgentSession (v1 composition root)', () => {
     await session.sendMessage('go')
     emit(delta('msg-1', 'working'))
     expect(session.isStreaming.value).toBe(true)
+    expect(editableTurnId(session)).toBeNull()
 
     await session.stopTurn()
     expect(cancelMessage).toHaveBeenCalledWith('th-1', 'msg-1')
     expect(session.notices.value).toHaveLength(0)
     expect(session.isStreaming.value).toBe(true)
+    expect(editableTurnId(session)).toBeNull()
 
     emit(delta('msg-1', ' Stopped at your request.'))
     emit(done('msg-1'))
     expect(session.isStreaming.value).toBe(false)
+    expect(editableTurnId(session)).toBe('msg-1')
+
+    session.newChat()
+    expect(editableTurnId(session)).toBeNull()
+  })
+
+  it('(d1) a normally completed turn is not editable', async () => {
+    const { source, emit } = fakeEvents()
+    const session = useAgentSession({ rest: fakeRest(), events: source })
+    session.start()
+
+    await session.sendMessage('go')
+    emit(done('msg-1'))
+
+    expect(session.isStreaming.value).toBe(false)
+    expect(editableTurnId(session)).toBeNull()
   })
 
   it('(d2) stopTurn rejecting with a network TypeError surfaces a notice, not an unhandled rejection', async () => {
@@ -419,6 +448,7 @@ describe('useAgentSession (v1 composition root)', () => {
     expect(session.notices.value).toEqual([
       { level: 'error', text: 'fetch failed' }
     ])
+    expect(editableTurnId(session)).toBeNull()
   })
 
   it('(d3) stopTurn before the POST acknowledgement cancels the acknowledged turn once', async () => {

--- a/src/workbench/extensions/agent/composables/agent/useAgentSession.test.ts
+++ b/src/workbench/extensions/agent/composables/agent/useAgentSession.test.ts
@@ -133,17 +133,6 @@ const historyRow = (
   content: { text }
 })
 
-function editableTurnId(session: object): unknown {
-  const candidate: unknown = Reflect.get(session, 'editableTurnId')
-  if (
-    typeof candidate !== 'object' ||
-    candidate === null ||
-    !('value' in candidate)
-  )
-    return undefined
-  return candidate.value
-}
-
 describe('useAgentSession (v1 composition root)', () => {
   beforeEach(() => {
     setActivePinia(createPinia())
@@ -399,21 +388,21 @@ describe('useAgentSession (v1 composition root)', () => {
     await session.sendMessage('go')
     emit(delta('msg-1', 'working'))
     expect(session.isStreaming.value).toBe(true)
-    expect(editableTurnId(session)).toBeNull()
+    expect(session.editableTurnId.value).toBeNull()
 
     await session.stopTurn()
     expect(cancelMessage).toHaveBeenCalledWith('th-1', 'msg-1')
     expect(session.notices.value).toHaveLength(0)
     expect(session.isStreaming.value).toBe(true)
-    expect(editableTurnId(session)).toBeNull()
+    expect(session.editableTurnId.value).toBeNull()
 
     emit(delta('msg-1', ' Stopped at your request.'))
     emit(done('msg-1'))
     expect(session.isStreaming.value).toBe(false)
-    expect(editableTurnId(session)).toBe('msg-1')
+    expect(session.editableTurnId.value).toBe('msg-1')
 
     session.newChat()
-    expect(editableTurnId(session)).toBeNull()
+    expect(session.editableTurnId.value).toBeNull()
   })
 
   it('(d1) a normally completed turn is not editable', async () => {
@@ -425,7 +414,7 @@ describe('useAgentSession (v1 composition root)', () => {
     emit(done('msg-1'))
 
     expect(session.isStreaming.value).toBe(false)
-    expect(editableTurnId(session)).toBeNull()
+    expect(session.editableTurnId.value).toBeNull()
   })
 
   it('(d2) stopTurn rejecting with a network TypeError surfaces a notice, not an unhandled rejection', async () => {
@@ -448,7 +437,7 @@ describe('useAgentSession (v1 composition root)', () => {
     expect(session.notices.value).toEqual([
       { level: 'error', text: 'fetch failed' }
     ])
-    expect(editableTurnId(session)).toBeNull()
+    expect(session.editableTurnId.value).toBeNull()
   })
 
   it('(d3) stopTurn before the POST acknowledgement cancels the acknowledged turn once', async () => {

--- a/src/workbench/extensions/agent/composables/agent/useAgentSession.test.ts
+++ b/src/workbench/extensions/agent/composables/agent/useAgentSession.test.ts
@@ -375,12 +375,18 @@ describe('useAgentSession (v1 composition root)', () => {
   })
 
   it('(d) stopTurn cancels the active turn; a 409 is swallowed and the socket settles it', async () => {
+    const postMessage = vi
+      .fn<
+        (threadId: string, req: PostMessageInput) => Promise<AgentTurnAccepted>
+      >()
+      .mockResolvedValueOnce({ thread_id: 'th-1', message_id: 'msg-1' })
+      .mockResolvedValueOnce({ thread_id: 'th-1', message_id: 'msg-2' })
     const cancelMessage = vi
       .fn<
         (threadId: string, messageId: string) => Promise<AgentCancelAccepted>
       >()
       .mockRejectedValue(new AgentApiError('already done', 409, undefined))
-    const rest = fakeRest({ cancelMessage })
+    const rest = fakeRest({ cancelMessage, postMessage })
     const { source, emit } = fakeEvents()
     const session = useAgentSession({ rest, events: source })
     session.start()
@@ -400,6 +406,14 @@ describe('useAgentSession (v1 composition root)', () => {
     emit(done('msg-1'))
     expect(session.isStreaming.value).toBe(false)
     expect(session.editableTurnId.value).toBe('msg-1')
+
+    await session.sendMessage('go revised')
+    expect(session.editableTurnId.value).toBeNull()
+    expect(
+      session.entries.value
+        .filter((entry) => entry.role === 'user')
+        .map((entry) => entry.text)
+    ).toEqual(['go', 'go revised'])
 
     session.newChat()
     expect(session.editableTurnId.value).toBeNull()

--- a/src/workbench/extensions/agent/composables/agent/useAgentSession.ts
+++ b/src/workbench/extensions/agent/composables/agent/useAgentSession.ts
@@ -38,6 +38,11 @@ export interface WorkflowTurnContext {
   tabPath: string
 }
 
+type PromptEditState =
+  | { phase: 'idle' }
+  | { phase: 'stopping'; turnId: TurnId }
+  | { phase: 'ready'; turnId: TurnId }
+
 export interface AgentSessionDeps {
   rest: AgentRestClient
   events: AgentEventSource
@@ -68,6 +73,7 @@ export function useAgentSession(deps: AgentSessionDeps) {
   const draftStore = useAgentDraftStore()
 
   const notices = ref<SessionNotice[]>([])
+  const promptEditState = ref<PromptEditState>({ phase: 'idle' })
   let resyncing = false
   const sending = ref(false)
 
@@ -182,6 +188,7 @@ export function useAgentSession(deps: AgentSessionDeps) {
       )
       return false
     }
+    promptEditState.value = { phase: 'idle' }
     sending.value = true
     stopRequestedWhileSending = false
     if (workflow?.prepare)
@@ -288,14 +295,17 @@ export function useAgentSession(deps: AgentSessionDeps) {
       if (sending.value) stopRequestedWhileSending = true
       return
     }
+    promptEditState.value = { phase: 'stopping', turnId }
     try {
       await rest.cancelMessage(threadId, turnId)
     } catch (error) {
       if (error instanceof AgentApiError) {
         if (error.status === 409) return
+        promptEditState.value = { phase: 'idle' }
         pushError(error.message)
         return
       }
+      promptEditState.value = { phase: 'idle' }
       pushError(error instanceof Error ? error.message : String(error))
     }
   }
@@ -304,6 +314,7 @@ export function useAgentSession(deps: AgentSessionDeps) {
 
   function newChat(): void {
     loadGeneration++
+    promptEditState.value = { phase: 'idle' }
     conversationStore.stashActiveTurn()
     conversationStore.reset()
     draftStore.reset()
@@ -316,6 +327,7 @@ export function useAgentSession(deps: AgentSessionDeps) {
 
   async function loadThread(threadId: string): Promise<void> {
     const generation = ++loadGeneration
+    promptEditState.value = { phase: 'idle' }
     const isCurrent = () =>
       generation === loadGeneration && ownedGeneration === sessionGeneration
     conversationStore.stashActiveTurn()
@@ -373,6 +385,17 @@ export function useAgentSession(deps: AgentSessionDeps) {
         return
       default:
         conversationStore.ingest(event)
+        if (
+          event.type === 'agent_message_done' &&
+          promptEditState.value.phase === 'stopping' &&
+          event.data.message_id === promptEditState.value.turnId &&
+          (event.data.thread_id === undefined ||
+            event.data.thread_id === conversationStore.threadId)
+        )
+          promptEditState.value = {
+            phase: 'ready',
+            turnId: promptEditState.value.turnId
+          }
     }
   }
 
@@ -386,9 +409,15 @@ export function useAgentSession(deps: AgentSessionDeps) {
   }
 
   const isSending = computed(() => sending.value)
+  const editableTurnId = computed(() =>
+    promptEditState.value.phase === 'ready'
+      ? promptEditState.value.turnId
+      : null
+  )
 
   return {
     isSending,
+    editableTurnId,
     start,
     stop,
     sendMessage,


### PR DESCRIPTION
## Summary

- allow the last explicitly stopped Agent prompt to be edited and resent
- restore its text into the focused composer while preserving the original transcript entry
- keep earlier prompts and normally completed turns non-editable

## Validation

- 67 targeted unit and component tests passed
- `pnpm typecheck`, `pnpm typecheck:browser`, `pnpm format:check`, `pnpm lint`, and `pnpm knip` passed
- browser coverage was added and statically validated; local execution remains blocked by the browser-test backend configuration
- manually reviewed through the local dev proxy targeting `agent.comfy.org`

## Notes

- stacked on #13892 and intentionally targets `nathaniel/agent-panel-v1`
- resubmission uses the existing append-only send flow; it does not mutate history or replay attachments and node selection

Linear: [FE-1705](https://linear.app/comfyorg/issue/FE-1705/fe-allow-editing-a-previously-sent-agent-prompt) · [PM-214](https://linear.app/comfyorg/issue/PM-214/allow-editing-a-previously-sent-prompt-to-the-agent)
