### PR TITLE
fix(subgraph): avoid positional bypass links

### DIFF
--- a/src/lib/litegraph/src/subgraph/ExecutableNodeDTO.test.ts
+++ b/src/lib/litegraph/src/subgraph/ExecutableNodeDTO.test.ts
@@ -11,6 +11,7 @@ import { toNodeId } from '@/types/nodeId'
 
 import {
   createNestedSubgraphs,
+  createTestRootGraph,
   createTestSubgraph,
   createTestSubgraphNode,
   resetSubgraphFixtureState
@@ -360,6 +361,55 @@ describe('Bypass node output resolution', () => {
     const resolved = bypassedDto.resolveOutput(0, 'IMAGE', new Set())
     expect(resolved).toBeDefined()
     expect(resolved?.node).toBe(upstreamDto)
+  })
+
+  it('should not pair an unrelated subgraph input with a bypassed output', () => {
+    const rootGraph = createTestRootGraph()
+    const subgraph = createTestSubgraph({
+      rootGraph,
+      inputs: [{ name: 'input', type: 'IMAGE' }],
+      outputs: [{ name: 'output', type: 'IMAGE' }]
+    })
+    const subgraphNode = createTestSubgraphNode(subgraph, {
+      id: 1,
+      parentGraph: rootGraph
+    })
+    rootGraph.add(subgraphNode)
+
+    const unrelatedNode = new LGraphNode('Unrelated interior node')
+    unrelatedNode.addOutput('source', 'IMAGE')
+    subgraph.add(unrelatedNode)
+
+    const upstreamNode = new LGraphNode('Upstream')
+    upstreamNode.addOutput('image', 'IMAGE')
+    rootGraph.add(upstreamNode)
+    upstreamNode.connect(0, subgraphNode, 0)
+
+    const nodesByExecutionId = new Map()
+    const upstreamDto = new ExecutableNodeDTO(
+      upstreamNode,
+      [],
+      nodesByExecutionId,
+      undefined
+    )
+    const subgraphDto = new ExecutableNodeDTO(
+      subgraphNode,
+      [],
+      nodesByExecutionId,
+      undefined
+    )
+    nodesByExecutionId.set(upstreamDto.id, upstreamDto)
+    nodesByExecutionId.set(subgraphDto.id, subgraphDto)
+
+    subgraphNode.mode = LGraphEventMode.BYPASS
+    const warningSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    try {
+      const resolved = subgraphDto.resolveOutput(0, 'IMAGE', new Set())
+
+      expect(resolved).toBeUndefined()
+    } finally {
+      warningSpy.mockRestore()
+    }
   })
 })
 

--- a/src/lib/litegraph/src/subgraph/ExecutableNodeDTO.ts
+++ b/src/lib/litegraph/src/subgraph/ExecutableNodeDTO.ts
@@ -347,6 +347,10 @@ export class ExecutableNodeDTO implements ExecutableLGraphNode {
    * @returns The index of the input slot on this node, otherwise `-1`.
    */
   private _getBypassSlotIndex(slot: number, type: ISlotType) {
+    if (this.node.isSubgraphNode()) {
+      return this._getSubgraphBypassSlotIndex(slot, type)
+    }
+
     const { inputs } = this
     const oppositeInput = inputs[slot]
     const outputType = this.node.outputs[slot].type
@@ -375,6 +379,32 @@ export class ExecutableNodeDTO implements ExecutableLGraphNode {
         LiteGraph.isValidConnection(input.type, outputType) &&
         LiteGraph.isValidConnection(input.type, type)
     )
+  }
+
+  /**
+   * Subgraph inputs and outputs are independent boundary slots, so their
+   * positions cannot establish a bypass relationship.  Only an output wired
+   * directly to a subgraph input inside the subgraph can be bypassed to that
+   * input; outputs produced by interior nodes have no safe external shortcut.
+   */
+  private _getSubgraphBypassSlotIndex(slot: number, type: ISlotType) {
+    const { node } = this
+    if (!node.isSubgraphNode()) return -1
+
+    const output = node.outputs.at(slot)
+    if (!output) return -1
+
+    const innerLink = node.resolveSubgraphOutputLink(slot)
+    if (!innerLink?.subgraphInput) return -1
+
+    const inputSlot = innerLink.link.origin_slot
+    const input = this.inputs.at(inputSlot)
+    if (!input) return -1
+
+    return LiteGraph.isValidConnection(input.type, output.type) &&
+      LiteGraph.isValidConnection(input.type, type)
+      ? inputSlot
+      : -1
   }
 
   /**


### PR DESCRIPTION
Fixes #15508

## Why
The generic bypass matcher assumed an output and the input at the same slot index were related. Subgraph boundary inputs and outputs are independent, so a bypassed subgraph could pass an output through an unrelated input even when its interior nodes had no relationship.

## What changed
- Subgraph bypass selection no longer uses positional or generic type-based input matching.
- A subgraph output can shortcut only when it is wired directly to the corresponding subgraph input inside the subgraph.
- Outputs backed by unrelated interior nodes resolve to no bypass input instead of borrowing one.
- Added a regression test with an externally connected input and an unconnected output.

## Validation
- `vitest run src/lib/litegraph/src/subgraph/ExecutableNodeDTO.test.ts -t "unrelated subgraph input"` (new test fails before the change)
- `vitest run src/lib/litegraph/src/subgraph/ExecutableNodeDTO.test.ts` — 36 passed
- `vue-tsc --noEmit --pretty false`
- `eslint src/lib/litegraph/src/subgraph/ExecutableNodeDTO.ts src/lib/litegraph/src/subgraph/ExecutableNodeDTO.test.ts`
- `oxfmt --check src/lib/litegraph/src/subgraph/ExecutableNodeDTO.ts src/lib/litegraph/src/subgraph/ExecutableNodeDTO.test.ts`