### PR TITLE
Cap Agent composer height for long prompts

### DIFF
--- a/browser_tests/tests/agent/agentPanel.spec.ts
+++ b/browser_tests/tests/agent/agentPanel.spec.ts
@@ -170,6 +170,57 @@ test.describe('In-App Agent panel', { tag: '@cloud' }, () => {
     await expect(firstSummary).toHaveAttribute('aria-expanded', 'false')
   })
 
+  test.describe('composer sizing', () => {
+    test.use({ viewport: { width: 1920, height: 1080 } })
+
+    test('caps long text at 400px and scrolls internally', async ({
+      comfyPage
+    }) => {
+      const page = comfyPage.page
+      await page.getByRole('button', { name: OPEN_AGENT_LABEL }).click()
+
+      const panel = page.locator('#agent-panel-root')
+      const composer = panel.getByRole('textbox', { name: /^Describe ideas/ })
+
+      await composer.fill('A growing prompt line\n'.repeat(14))
+      await expect
+        .poll(() =>
+          composer.evaluate((element) =>
+            Math.round(element.getBoundingClientRect().height)
+          )
+        )
+        .toBeGreaterThan(200)
+
+      await composer.fill('An overflowing prompt line\n'.repeat(60))
+      await expect
+        .poll(() =>
+          composer.evaluate((element) => ({
+            height: Math.round(element.getBoundingClientRect().height),
+            scrolls: element.scrollHeight > element.clientHeight
+          }))
+        )
+        .toEqual({ height: 400, scrolls: true })
+      await expect(
+        panel.getByText('What do you want to make?')
+      ).toBeInViewport()
+
+      await panel
+        .getByRole('button', { name: enMessages.agent.maximize })
+        .click()
+      await expect
+        .poll(() =>
+          composer.evaluate((element) => ({
+            height: Math.round(element.getBoundingClientRect().height),
+            scrolls: element.scrollHeight > element.clientHeight
+          }))
+        )
+        .toEqual({ height: 400, scrolls: true })
+      await expect(
+        panel.getByText('What do you want to make?')
+      ).toBeInViewport()
+    })
+  })
+
   test('keeps the Agent scrollbar track transparent', async ({ comfyPage }) => {
     const page = comfyPage.page
     await page.getByRole('button', { name: OPEN_AGENT_LABEL }).click()

--- a/src/workbench/extensions/agent/components/agent/Composer.vue
+++ b/src/workbench/extensions/agent/components/agent/Composer.vue
@@ -440,7 +440,7 @@ defineExpose({
           v-model="composer.draft.value"
           :aria-label="t('agent.placeholder')"
           rows="1"
-          class="text-agent-fg field-sizing-content max-h-50 min-h-16 w-full min-w-0 resize-none overflow-x-hidden overflow-y-auto rounded-none bg-transparent px-3 py-2 font-inter text-[14px]/5 font-normal wrap-break-word whitespace-pre-wrap focus-visible:ring-0"
+          class="text-agent-fg field-sizing-content max-h-100 min-h-16 w-full min-w-0 resize-none overflow-x-hidden overflow-y-auto rounded-none bg-transparent px-3 py-2 font-inter text-[14px]/5 font-normal wrap-break-word whitespace-pre-wrap focus-visible:ring-0"
           :aria-expanded="mentionVisible"
           aria-controls="agent-mention-listbox"
           :aria-activedescendant="


### PR DESCRIPTION
## Summary

- increase the Agent composer textarea cap from 200px to the designed 400px
- keep overflow scrolling inside the textarea so conversation content and composer controls remain accessible
- cover the behavior in both minimized and maximized panel layouts

## Changes

- **What**: Update the shared Composer textarea max-height and add a browser geometry contract for natural growth, the 400px cap, and internal scrolling.

## Validation

- targeted PM-180 Cloud Playwright contract: 3/3
- Composer component suite: 41/41
- format, lint, knip, production/browser typecheck, Stylelint, and diff checks passed
- manually reviewed through the local Cloud dev proxy targeting `agent.comfy.org`

## Review Focus

- Confirm the 400px limit matches both expanded and minimized designs.
- The broader Agent spec has two existing failures outside this diff: Cloud flag-off visibility and the initial tool-summary expanded state.

## Notes

- stacked on #13892 and intentionally targets `nathaniel/agent-panel-v1`
- no backend/API changes

Linear: [FE-1329](https://linear.app/comfyorg/issue/FE-1329/fe-add-composer-max-height)