### PR TITLE
test(oxlint): isolate ingest-type probe runs per process

### DIFF
--- a/tools/oxlint-plugins/comfyIngestTypes.test.ts
+++ b/tools/oxlint-plugins/comfyIngestTypes.test.ts
@@ -1,5 +1,15 @@
 import { execFileSync } from 'node:child_process'
-import { mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { randomUUID } from 'node:crypto'
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  utimesSync,
+  writeFileSync
+} from 'node:fs'
+import { tmpdir } from 'node:os'
 import path from 'node:path'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 
@@ -11,10 +21,75 @@ const repoConfig = path.resolve('.oxlintrc.json')
 // Probes are written into the trees `pnpm lint` actually lints and are checked
 // through the repo's own .oxlintrc.json, so a scoping or severity regression
 // fails here rather than passing against a bespoke config nothing else uses.
+// Each run owns a unique subdirectory, lints only that directory instead of
+// the whole src/browser_tests trees, and removes it on afterAll, process exit,
+// and SIGINT/SIGTERM; leftovers from a hard-killed run are swept by the next
+// run. (The roots must NOT be gitignored: oxlint honors .gitignore even for
+// explicitly passed targets and with --no-ignore, so ignoring them would make
+// every probe invisible to the very lint call under test.)
 const PROBE_DIR = '__ingest_type_probes__'
-const tsProbeDir = path.resolve('src', PROBE_DIR)
-const vueProbeDir = path.resolve('src/platform', PROBE_DIR)
-const browserTestProbeDir = path.resolve('browser_tests/fixtures', PROBE_DIR)
+const probeRoots = [
+  path.resolve('src', PROBE_DIR),
+  path.resolve('src/platform', PROBE_DIR),
+  path.resolve('browser_tests/fixtures', PROBE_DIR)
+]
+const runId = `run-${process.pid}-${randomUUID().slice(0, 8)}`
+const runDirs = probeRoots.map((root) => path.join(root, runId))
+
+// A run writes its probes once and finishes linting them within seconds, so a
+// probe directory older than five minutes can only be a leftover from an
+// interrupted process. Fresh siblings are left alone so a run that started
+// concurrently is never reaped mid-flight.
+const STALE_PROBE_MS = 5 * 60 * 1000
+
+function sweepStaleProbeRuns(
+  roots: readonly string[],
+  maxAgeMs = STALE_PROBE_MS
+): void {
+  const cutoff = Date.now() - maxAgeMs
+  for (const root of roots) {
+    let entries
+    try {
+      entries = readdirSync(root, { withFileTypes: true })
+    } catch {
+      continue
+    }
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue
+      const child = path.join(root, entry.name)
+      try {
+        if (statSync(child).mtimeMs < cutoff) {
+          rmSync(child, { recursive: true, force: true })
+        }
+      } catch {
+        continue
+      }
+    }
+  }
+}
+
+function removeProbeRun(): void {
+  for (const dir of runDirs) rmSync(dir, { recursive: true, force: true })
+}
+
+// Registered as soon as this run might write probes: afterAll never runs after
+// a crash or a worker timeout. Removing only this run's directories keeps the
+// handler safe while another worker is still running, and rmSync(force) makes
+// the afterAll + exit sequence idempotent.
+let cleanupRegistered = false
+function registerProbeCleanup(): void {
+  if (cleanupRegistered) return
+  cleanupRegistered = true
+  process.on('exit', removeProbeRun)
+  for (const signal of ['SIGINT', 'SIGTERM'] as const) {
+    process.on(signal, () => {
+      removeProbeRun()
+      // Restore default termination semantics: the main vitest process still
+      // handles the signal; this worker must not outlive it.
+      process.exit(signal === 'SIGINT' ? 130 : 143)
+    })
+  }
+}
 
 interface Finding {
   readonly file: string
@@ -207,22 +282,30 @@ describe('comfy/no-duplicate-ingest-type', () => {
   let findings: Finding[]
 
   beforeAll(() => {
-    for (const dir of [tsProbeDir, vueProbeDir, browserTestProbeDir]) {
-      mkdirSync(dir, { recursive: true })
-    }
-    writeFileSync(path.join(tsProbeDir, 'accepted.ts'), accepted)
-    writeFileSync(path.join(tsProbeDir, 'reported.ts'), reportedSource)
-    writeFileSync(path.join(tsProbeDir, 'uninvolved.ts'), uninvolved)
-    writeFileSync(path.join(tsProbeDir, 'unimported.ts'), unimported)
-    writeFileSync(path.join(vueProbeDir, 'Probe.vue'), vueProbe)
-    writeFileSync(path.join(browserTestProbeDir, 'probe.ts'), browserTestProbe)
+    registerProbeCleanup()
+    sweepStaleProbeRuns(probeRoots)
+    for (const dir of runDirs) mkdirSync(dir, { recursive: true })
+    writeFileSync(path.join(runDirs[0], 'accepted.ts'), accepted)
+    writeFileSync(path.join(runDirs[0], 'reported.ts'), reportedSource)
+    writeFileSync(path.join(runDirs[0], 'uninvolved.ts'), uninvolved)
+    writeFileSync(path.join(runDirs[0], 'unimported.ts'), unimported)
+    writeFileSync(path.join(runDirs[1], 'Probe.vue'), vueProbe)
+    writeFileSync(path.join(runDirs[2], 'probe.ts'), browserTestProbe)
 
-    findings = lint(['src', 'browser_tests'])
+    findings = lint(runDirs)
   })
 
   afterAll(() => {
-    for (const dir of [tsProbeDir, vueProbeDir, browserTestProbeDir]) {
-      rmSync(dir, { recursive: true, force: true })
+    removeProbeRun()
+    // Drop the probe roots too when this was the last live run. A concurrent
+    // sibling still owns its own subdirectory, in which case this fails and
+    // the empty-enough root simply stays until the next sweep.
+    for (const root of probeRoots) {
+      try {
+        rmSync(root, { force: true })
+      } catch {
+        continue
+      }
     }
   })
 
@@ -275,6 +358,46 @@ describe('comfy/no-duplicate-ingest-type', () => {
   // Root jsPlugins merge into it rather than being replaced, and fixtures are a
   // likely home for hand-built payloads, so pin that the rule reaches them.
   it('covers browser_tests fixtures, which have their own overrides block', () => {
-    expect(reported(path.join(PROBE_DIR, 'probe.ts'))).toContain('Plan')
+    // Oxlint reports POSIX-style, run-relative filenames; path.join would emit
+    // '\' on Windows and the suffix would never match.
+    expect(reported(`${PROBE_DIR}/${runId}/probe.ts`)).toContain('Plan')
+  })
+})
+
+describe('sweepStaleProbeRuns', () => {
+  const root = path.join(tmpdir(), `ingest-probe-sweep-${randomUUID()}`)
+
+  beforeAll(() => {
+    mkdirSync(root, { recursive: true })
+  })
+
+  afterAll(() => {
+    rmSync(root, { recursive: true, force: true })
+  })
+
+  it('removes probe directories older than the staleness floor', () => {
+    const stale = path.join(root, 'run-crashed')
+    mkdirSync(stale)
+    const old = new Date(Date.now() - STALE_PROBE_MS - 1000)
+    utimesSync(stale, old, old)
+
+    sweepStaleProbeRuns([root])
+
+    expect(existsSync(stale)).toBe(false)
+  })
+
+  it('keeps probe directories a concurrently running worker may still own', () => {
+    const fresh = path.join(root, 'run-live')
+    mkdirSync(fresh)
+
+    sweepStaleProbeRuns([root])
+
+    expect(existsSync(fresh)).toBe(true)
+  })
+
+  it('tolerates a probe root that does not exist', () => {
+    expect(() =>
+      sweepStaleProbeRuns([path.join(root, 'missing')])
+    ).not.toThrow()
   })
 })


### PR DESCRIPTION
Fixes #15523

## What changed

`tools/oxlint-plugins/comfyIngestTypes.test.ts` now gives every test process its own probe run instead of writing to fixed paths under `src/`, `src/platform/`, and `browser_tests/fixtures/`:

- **Unique per-run directories.** Probes live in `__ingest_type_probes__/<run-pid-uuid>/`, so two vitest processes (or a vitest run overlapping `pnpm lint`) never share probe paths.
- **Narrowed lint targets.** The rule check lints only the three per-run probe directories instead of the whole `src` + `browser_tests` trees (~3,000 files). The repo's own `.oxlintrc.json` is still the config under test, so the scoping/severity property is unchanged.
- **Crash-safe cleanup.** The run directory is removed on `afterAll`, on process `exit`, and on `SIGINT`/`SIGTERM` (registered before any probe is written, so the whole write window is covered).
- **Stale-run sweep.** `beforeAll` removes probe directories older than five minutes, so leftovers from a hard-killed run (where no signal handler can run) are cleaned by the next run; fresh siblings are preserved so a concurrently starting run is never reaped. Covered by three new unit tests (stale removed, fresh kept, missing root tolerated).
- **Windows path fix.** The `browser_tests` fixture assertion compared oxlint's POSIX-style `filename` against `path.join(...)`, which emits `\` on Windows and never matches — the test was failing on Windows on `main` (`1 failed | 16 passed`). It now matches the run-relative POSIX suffix.

## Why the `.gitignore` line from the issue is intentionally not added

I verified with oxlint 1.77 that a `.gitignore` entry hides the probe directories from oxlint **even when they are passed as explicit targets and with `--no-ignore`** — `oxlint src/__ingest_type_probes__` then reports `No files found to lint`. Gitignoring the roots would therefore make every probe invisible to the exact lint call under test and turn the suite red on every run. Signal/exit cleanup plus the stale sweep bound the exposure instead: the only remaining window is a `SIGKILL`ed run between the kill and the next unit-test run, and the leftovers are still plainly visible in `git status` rather than silently ignored.

## Verification

- Before (Windows, `main`): `1 failed | 16 passed` — `covers browser_tests fixtures` fails on the path-separator mismatch; test phase ~4.4 s dominated by linting both trees.
- After: `20 passed` (17 rule assertions + 3 sweep regressions); test phase ~0.36 s.
- Interrupted-run simulation: a probe directory backdated 6 minutes is removed by the next run; no probe roots remain in `git status` afterwards.
- `oxfmt --check`, `oxlint --config .oxlintrc.json --type-aware`, `oxlint --config tools/oxlint-plugins/vitestCleanup.config.json`, and `typecheck:tools` all pass.