### PR TITLE
Let the Agent add menu fit its content

### DIFF
--- a/browser_tests/tests/agent/agentPanel.spec.ts
+++ b/browser_tests/tests/agent/agentPanel.spec.ts
@@ -192,6 +192,47 @@ test.describe('In-App Agent panel', { tag: '@cloud' }, () => {
     expect(track.scrollbarColor).toMatch(/rgba\(0, 0, 0, 0\)$/)
   })
 
+  test('sizes the add-to-prompt menu around its longest item', async ({
+    comfyPage
+  }) => {
+    const page = comfyPage.page
+    await page.getByRole('button', { name: OPEN_AGENT_LABEL }).click()
+
+    const panel = page.locator('#agent-panel-root')
+    await panel
+      .getByRole('button', { name: enMessages.agent.addToPrompt })
+      .click()
+
+    const menu = page.getByRole('menu')
+    const longestItem = menu.getByRole('menuitem', {
+      name: enMessages.agent.addFromAssets
+    })
+    const icon = longestItem.locator('span').first()
+    const label = longestItem.getByText(enMessages.agent.addFromAssets, {
+      exact: true
+    })
+
+    await expect(longestItem).toBeVisible()
+    await expect
+      .poll(() => menu.boundingBox().then((box) => box?.width))
+      .toBeGreaterThan(186)
+    await expect
+      .poll(async () => {
+        const [itemBox, iconBox, labelBox] = await Promise.all([
+          longestItem.boundingBox(),
+          icon.boundingBox(),
+          label.boundingBox()
+        ])
+        if (!itemBox || !iconBox || !labelBox) return Number.POSITIVE_INFINITY
+
+        const leftInset = iconBox.x - itemBox.x
+        const rightInset =
+          itemBox.x + itemBox.width - (labelBox.x + labelBox.width)
+        return Math.abs(leftInset - rightInset)
+      })
+      .toBeLessThanOrEqual(1)
+  })
+
   test('applies a draft_patch graph to the canvas', async ({
     comfyPage,
     postedMessages,

--- a/src/workbench/extensions/agent/components/agent/Composer.vue
+++ b/src/workbench/extensions/agent/components/agent/Composer.vue
@@ -488,7 +488,7 @@ defineExpose({
               side="top"
               align="start"
               :side-offset="4"
-              class="agent-scope bg-agent-surface-raised z-1100 box-border w-[186px] rounded-[10px] border border-white/10 p-1 font-inter shadow-lg"
+              class="agent-scope bg-agent-surface-raised z-1100 box-border w-max min-w-[186px] rounded-[10px] border border-white/10 p-1 font-inter shadow-lg"
             >
               <DropdownMenuItem
                 class="text-agent-fg data-highlighted:bg-agent-surface-hover mb-0.5 box-border flex h-7 w-full cursor-pointer items-center gap-1.5 rounded-lg px-1.5 py-1 text-[14px]/5 font-normal outline-none"


### PR DESCRIPTION
## Summary

- let the Agent composer's add-to-prompt menu grow with its content
- retain the existing 186px minimum while restoring balanced insets around the widest item
- keep menu actions, alignment, item spacing, and keyboard behavior unchanged

## Changes

- **What**: Replace the fixed menu width with intrinsic sizing plus the existing minimum, backed by a rendered-geometry browser contract.

## Validation

- targeted FE-1707 Cloud Playwright contract: 3/3
- Composer component suite: 41/41
- format, lint, knip, production/browser typecheck, Stylelint, and diff checks passed
- full Agent spec: 3/5; the two unchanged failures are Cloud flag-off visibility and the existing initial tool-summary expanded state

## Review Focus

- Confirm the menu remains compact at a 186px minimum and grows only when its content requires it.
- The geometry contract checks that the widest current item keeps balanced left/right content insets.

## Screenshots

- No static screenshot included; the browser geometry contract validates the affected open-menu state directly.

## Notes

- stacked on #13892 and intentionally targets `nathaniel/agent-panel-v1`
- separate from PM-180 / #15527

Linear: [FE-1707](https://linear.app/comfyorg/issue/FE-1707/fe-let-the-agent-add-to-prompt-menu-fit-its-content)