### PR TITLE
fix(minimap): redraw after palette changes

### DIFF
--- a/src/renderer/extensions/minimap/composables/useMinimap.intervalLifecycle.test.ts
+++ b/src/renderer/extensions/minimap/composables/useMinimap.intervalLifecycle.test.ts
@@ -39,6 +39,8 @@ const mockCanvas = {
   setDirty: vi.fn()
 }
 
+const mockCompletedActivePalette = { light_theme: false }
+
 vi.mock('@/renderer/core/canvas/canvasStore', () => ({
   useCanvasStore: vi.fn(() => ({ canvas: mockCanvas }))
 }))
@@ -52,7 +54,7 @@ vi.mock('@/platform/settings/settingStore', () => ({
 
 vi.mock('@/stores/workspace/colorPaletteStore', () => ({
   useColorPaletteStore: vi.fn(() => ({
-    completedActivePalette: { light_theme: false }
+    completedActivePalette: mockCompletedActivePalette
   }))
 }))
 
@@ -124,6 +126,7 @@ describe('useMinimap change-detection interval', () => {
     vi.useFakeTimers()
     context = createMockCanvas2DContext()
     mockNodes[0].pos = [0, 0]
+    mockCompletedActivePalette.light_theme = false
   })
 
   afterEach(() => {
@@ -152,6 +155,17 @@ describe('useMinimap change-detection interval', () => {
     await vi.advanceTimersByTimeAsync(POLL_MS * 5)
 
     expect(drawCalls()).toBe(settled)
+  })
+
+  it('redraws after the palette theme changes without a graph edit', async () => {
+    await initMinimap()
+    await vi.advanceTimersByTimeAsync(POLL_MS + 10)
+    const settled = drawCalls()
+
+    mockCompletedActivePalette.light_theme = true
+    await vi.advanceTimersByTimeAsync(POLL_MS + 10)
+
+    expect(drawCalls()).toBeGreaterThan(settled)
   })
 
   it('stops polling when hidden and resumes only after the next interval', async () => {

--- a/src/renderer/extensions/minimap/composables/useMinimapGraph.ts
+++ b/src/renderer/extensions/minimap/composables/useMinimapGraph.ts
@@ -6,6 +6,7 @@ import { useChainCallback } from '@/composables/functional/useChainCallback'
 import type { LGraphEventMap } from '@/lib/litegraph/src/infrastructure/LGraphEventMap'
 import type { LGraph, LGraphNode } from '@/lib/litegraph/src/litegraph'
 import { layoutStore } from '@/renderer/core/layout/store/layoutStore'
+import { useColorPaletteStore } from '@/stores/workspace/colorPaletteStore'
 import { api } from '@/scripts/api'
 import { useExecutionStore } from '@/stores/executionStore'
 
@@ -71,6 +72,13 @@ function computeGraphDigests(graph: LGraph): GraphDigests {
   // operations, and zIndex alone fires one per widget pointerdown.
   let geometry = mixIn(layoutStore.nodeGeometryVersion, graph._nodes.length)
   let visual = 0
+
+  // The renderer derives its theme-aware colors from this flag. Include it in
+  // the digest so a palette switch repaints even when the graph is untouched.
+  visual = mixIn(
+    visual,
+    useColorPaletteStore().completedActivePalette.light_theme ? 1 : 0
+  )
 
   for (const node of graph._nodes) {
     const [x, y] = node.pos


### PR DESCRIPTION
## Summary
- include the active palette's light/dark mode in the minimap visual digest
- redraw the minimap after a palette switch even when no graph data changes
- add a polling regression test that fails without the digest term

Closes #15277

## Test plan
- [x] `pnpm exec vitest run src/renderer/extensions/minimap/composables/useMinimap.intervalLifecycle.test.ts`
- [x] `pnpm exec vitest run src/renderer/extensions/minimap`
- [x] `pnpm exec oxfmt --check <changed files>`
- [x] `pnpm exec oxlint <changed files> --type-aware`
- [x] `pnpm exec eslint <changed files> --cache`
- [x] `pnpm typecheck`