### PR TITLE
test(minimap): guard destroy interval pause

### DIFF
--- a/src/renderer/extensions/minimap/composables/useMinimap.test.ts
+++ b/src/renderer/extensions/minimap/composables/useMinimap.test.ts
@@ -425,12 +425,15 @@ describe('useMinimap', () => {
       const minimap = await createAndInitializeMinimap()
 
       await minimap.init()
+      // The shouldPoll watcher already pauses once while inactive during
+      // setup. Clear that call so this assertion catches the destroy path.
+      mockIntervalPause.mockClear()
       minimap.destroy()
 
       // Both loops: rAF drives viewport sync, the interval drives change
       // detection. One spy each, or deleting either pause here goes unnoticed.
       expect(mockPause).toHaveBeenCalled()
-      expect(mockIntervalPause).toHaveBeenCalled()
+      expect(mockIntervalPause).toHaveBeenCalledTimes(1)
       expect(api.removeEventListener).toHaveBeenCalledWith(
         'graphChanged',
         expect.any(Function)


### PR DESCRIPTION
## Summary
- clear the interval-pause spy after minimap setup
- assert that `destroy()` performs exactly one additional pause
- cover the interval leak path independently of the initial `shouldPoll` pause

Closes #15278

## Test plan
- [x] Mutated check: removing `pauseChangeDetection()` from `destroy()` makes the guarded test fail with 0 calls instead of 1
- [x] `pnpm exec vitest run src/renderer/extensions/minimap/composables/useMinimap.test.ts`
- [x] `pnpm exec oxfmt --check src/renderer/extensions/minimap/composables/useMinimap.test.ts`
- [x] `pnpm exec oxlint src/renderer/extensions/minimap/composables/useMinimap.test.ts --type-aware`
- [x] `pnpm exec eslint src/renderer/extensions/minimap/composables/useMinimap.test.ts --cache`
- [x] `pnpm typecheck`