### PR TITLE
ci(types): publish missing bridge dependencies

### DIFF
--- a/.github/workflows/release-npm-types.yaml
+++ b/.github/workflows/release-npm-types.yaml
@@ -89,6 +89,31 @@ jobs:
         env:
           PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1'
 
+      - name: Ensure desktop bridge types dependency is published
+        shell: bash
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          DIST_TAG: ${{ inputs.dist_tag }}
+        run: |
+          set -euo pipefail
+          BRIDGE_PACKAGE=packages/comfyui-desktop-bridge-types/package.json
+          NAME=$(node -p "require('./${BRIDGE_PACKAGE}').name")
+          VERSION=$(node -p "require('./${BRIDGE_PACKAGE}').version")
+
+          STATUS=0
+          OUTPUT=$(npm view "${NAME}@${VERSION}" --json 2>&1) || STATUS=$?
+          if [ "$STATUS" -eq 0 ]; then
+            echo "${NAME}@${VERSION} is already published."
+            exit 0
+          fi
+          if ! echo "$OUTPUT" | grep -q "E404"; then
+            echo "::error title=Registry lookup failed::${OUTPUT}" >&2
+            exit "$STATUS"
+          fi
+
+          echo "${NAME}@${VERSION} is missing; publishing it before frontend types."
+          pnpm --dir packages/comfyui-desktop-bridge-types publish --access public --tag "$DIST_TAG" --no-git-checks --ignore-scripts
+
       - name: Build types
         run: pnpm build:types
 

--- a/scripts/releaseNpmTypesWorkflow.test.ts
+++ b/scripts/releaseNpmTypesWorkflow.test.ts
@@ -1,0 +1,47 @@
+import { readFileSync } from 'node:fs'
+
+import { describe, expect, it } from 'vitest'
+
+const workflowPath = '.github/workflows/release-npm-types.yaml'
+
+function stepBlock(name: string): string {
+  const lines = readFileSync(workflowPath, 'utf8').split(/\r?\n/)
+  const heading = `- name: ${name}`
+  const start = lines.findIndex((line) => line.trimEnd().endsWith(heading))
+  expect(start, `missing workflow step ${name}`).toBeGreaterThanOrEqual(0)
+
+  const indent = lines[start].length - lines[start].trimStart().length
+  const nextStep = new RegExp(`^\\s{${indent}}- `)
+  const relativeEnd = lines
+    .slice(start + 1)
+    .findIndex((line) => nextStep.test(line))
+  return lines
+    .slice(start, relativeEnd === -1 ? undefined : start + 1 + relativeEnd)
+    .join('\n')
+}
+
+describe('frontend types release dependencies', () => {
+  it('publishes a missing desktop bridge dependency before building types', () => {
+    const workflow = readFileSync(workflowPath, 'utf8')
+    const step = stepBlock(
+      'Ensure desktop bridge types dependency is published'
+    )
+    const stepStart = workflow.indexOf(step)
+    const buildStart = workflow.indexOf('Build types')
+
+    expect(stepStart).toBeGreaterThan(-1)
+    expect(buildStart).toBeGreaterThan(stepStart)
+    expect(step).toContain(
+      'BRIDGE_PACKAGE=packages/comfyui-desktop-bridge-types/package.json'
+    )
+    expect(step).toContain("require('./${BRIDGE_PACKAGE}').name")
+    expect(step).toContain('npm view "${NAME}@${VERSION}" --json')
+    expect(step).toContain('grep -q "E404"')
+    expect(step).toContain('::error title=Registry lookup failed::')
+    expect(step).toContain(
+      'pnpm --dir packages/comfyui-desktop-bridge-types publish'
+    )
+    expect(step).toContain('--tag "$DIST_TAG"')
+    expect(step).toContain('NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}')
+  })
+})


### PR DESCRIPTION
## Summary
- Before publishing `@comfyorg/comfyui-frontend-types`, read the exact `@comfyorg/comfyui-desktop-bridge-types` version from the checked-out workspace.
- Query npm for that exact version.
- If it is already published, continue normally.
- If npm returns `E404`, publish the checked-out bridge-types package first using the same dist tag and npm credentials.
- Fail visibly on registry connectivity errors instead of proceeding to publish an uninstallable frontend-types package.
- Perform the dependency guarantee after install and before building frontend types.

This keeps the exact dependency intentional rather than broadening it to an incompatible older 0.1.x release. When a bridge version such as `0.1.4` is bumped but not manually published, the next types release now supplies the missing prerequisite itself.

Fixes #15499.

## Tests
- Added a workflow regression asserting that the release:
  - reads the bridge package name/version;
  - checks the exact registry version;
  - distinguishes `E404` from registry failures;
  - publishes with the release dist tag and npm credential;
  - does so before the frontend-types build.

Validation:
- `pnpm exec vitest run scripts/releaseNpmTypesWorkflow.test.ts` — 1 passed
- `python -c "import yaml; yaml.safe_load(...)"` — workflow YAML parsed
- Extracted the embedded bash step and ran `bash -n` — passed
- `pnpm build:types` — passed, and generated `dist/package.json` still contains the exact `0.1.4` prerequisite
- `pnpm exec vue-tsc --noEmit` — passed
- Targeted ESLint — passed
- `pnpm exec oxfmt --check scripts/releaseNpmTypesWorkflow.test.ts` — passed
- `git diff --check` — passed