### PR TITLE
fix(website): link supported-models and supported-nodes cards to cano…

### DIFF
--- a/apps/website/e2e/cloud-nodes.spec.ts
+++ b/apps/website/e2e/cloud-nodes.spec.ts
@@ -43,7 +43,7 @@ test.describe('Cloud nodes page @smoke', () => {
 
     await firstCard.locator('a').first().click()
 
-    await expect(page).toHaveURL(/\/cloud\/supported-nodes\/[a-z0-9-]+$/)
+    await expect(page).toHaveURL(/\/cloud\/supported-nodes\/[a-z0-9-]+\/$/)
     await expect(page.getByTestId('cloud-node-pack-detail')).toBeVisible()
   })
 
@@ -163,7 +163,9 @@ test.describe('Cloud nodes page (zh-CN) @smoke', () => {
 
     await firstCard.locator('a').first().click()
 
-    await expect(page).toHaveURL(/\/zh-CN\/cloud\/supported-nodes\/[a-z0-9-]+$/)
+    await expect(page).toHaveURL(
+      /\/zh-CN\/cloud\/supported-nodes\/[a-z0-9-]+\/$/
+    )
     await expect(page.getByTestId('cloud-node-pack-detail')).toBeVisible()
   })
 })

--- a/apps/website/src/components/cloud-nodes/PackCard.vue
+++ b/apps/website/src/components/cloud-nodes/PackCard.vue
@@ -13,8 +13,8 @@ const { locale = 'en', pack } = defineProps<{
 
 const detailHref =
   locale === 'zh-CN'
-    ? `/zh-CN/cloud/supported-nodes/${pack.id}`
-    : `/cloud/supported-nodes/${pack.id}`
+    ? `/zh-CN/cloud/supported-nodes/${pack.id}/`
+    : `/cloud/supported-nodes/${pack.id}/`
 
 function nodeCountLabel(nodeCount: number): string {
   const key =
@@ -27,7 +27,7 @@ function nodeCountLabel(nodeCount: number): string {
 
 <template>
   <article
-    class="bg-transparency-white-t5 border-primary-warm-gray/20 flex h-full flex-col overflow-hidden rounded-3xl border"
+    class="bg-transparency-white-t5 flex h-full flex-col overflow-hidden rounded-3xl border border-primary-warm-gray/20"
     data-testid="cloud-node-pack-card"
   >
     <PackBanner
@@ -38,7 +38,7 @@ function nodeCountLabel(nodeCount: number): string {
 
     <div class="flex flex-1 flex-col gap-5 p-5 md:p-6">
       <div class="flex flex-col gap-2">
-        <h3 class="text-primary-comfy-canvas text-2xl/tight font-semibold">
+        <h3 class="text-2xl/tight font-semibold text-primary-comfy-canvas">
           <a
             :href="detailHref"
             class="hover:text-primary-comfy-yellow"
@@ -47,7 +47,7 @@ function nodeCountLabel(nodeCount: number): string {
             {{ pack.displayName }}
           </a>
         </h3>
-        <p class="text-primary-warm-gray text-sm/relaxed">
+        <p class="text-sm/relaxed text-primary-warm-gray">
           {{
             pack.description ||
             t('cloudNodes.card.unavailableDescription', locale)

--- a/apps/website/src/pages/p/supported-models/index.astro
+++ b/apps/website/src/pages/p/supported-models/index.astro
@@ -72,7 +72,7 @@ const dirLabel: Record<string, string> = {
       {models.map((model) => (
         <li>
           <a
-            href={`/p/supported-models/${model.slug}`}
+            href={`/p/supported-models/${model.slug}/`}
             class="flex h-full flex-col gap-3 rounded-xl border border-white/10 p-5 transition-colors hover:border-white/25 hover:bg-white/5"
           >
             <div class="flex items-start justify-between gap-2">


### PR DESCRIPTION
## Summary
Internal links from the /p/supported-models/ and /cloud/supported-nodes/ index pages
omitted the trailing slash, while every page's own canonical tag (built by
absoluteUrl() in utils/jsonLd.ts) always includes one. On-page links therefore
pointed at a URL string distinct from each page's declared canonical — consistent
with SEO tooling reporting these pages as having no internal links pointing at them.
Fix: append the trailing slash to both link sources so they match the canonical URL.

## Pages Affected
- comfy.org/p/supported-models/* (all model detail pages, e.g. /p/supported-models/clip-vision-h/) — linked from src/pages/p/supported-models/index.astro
- comfy.org/cloud/supported-nodes/* (all pack detail pages) — linked from src/components/cloud-nodes/PackCard.vue
- comfy.org/zh-CN/cloud/supported-nodes/* (localized pack detail pages) — same component, zh-CN branch
