### PR TITLE
fix(website): link the Models showcase page from the footer

### DIFF
--- a/apps/website/src/components/common/SiteFooter.test.ts
+++ b/apps/website/src/components/common/SiteFooter.test.ts
@@ -1,0 +1,27 @@
+// @vitest-environment happy-dom
+import { render, screen } from '@testing-library/vue'
+import { describe, expect, it } from 'vitest'
+
+import SiteFooter from './SiteFooter.vue'
+
+describe('SiteFooter', () => {
+  it('links the Models showcase page at its canonical English path', () => {
+    render(SiteFooter, { props: { locale: 'en' } })
+
+    const links = screen.getAllByRole('link', { name: 'Models' })
+    expect(links.length).toBeGreaterThan(0)
+    for (const link of links) {
+      expect(link.getAttribute('href')).toBe('/models')
+    }
+  })
+
+  it('links the localized Models showcase page for zh-CN', () => {
+    render(SiteFooter, { props: { locale: 'zh-CN' } })
+
+    const links = screen.getAllByRole('link', { name: '模型' })
+    expect(links.length).toBeGreaterThan(0)
+    for (const link of links) {
+      expect(link.getAttribute('href')).toBe('/zh-CN/models')
+    }
+  })
+})

--- a/apps/website/src/components/common/SiteFooter.vue
+++ b/apps/website/src/components/common/SiteFooter.vue
@@ -41,6 +41,10 @@ const topColumns: { title: string; links: FooterLink[] }[] = [
       { label: t('nav.pricing', locale), href: routes.cloudPricing },
       { label: t('nav.mcpServer', locale), href: routes.mcp },
       { label: t('nav.supportedModels', locale), href: routes.models },
+      {
+        label: t('footer.modelsShowcase', locale),
+        href: routes.modelsShowcase
+      },
       { label: t('footer.minimaxH3', locale), href: routes.minimax },
       {
         label: t('footer.minimaxMusic3', locale),

--- a/apps/website/src/config/routes.test.ts
+++ b/apps/website/src/config/routes.test.ts
@@ -28,6 +28,16 @@ describe('getRoutes models', () => {
   })
 })
 
+describe('getRoutes modelsShowcase', () => {
+  it('serves the models showcase page at its canonical path for en', () => {
+    expect(getRoutes('en').modelsShowcase).toBe('/models')
+  })
+
+  it('serves a localized models showcase path for zh-CN', () => {
+    expect(getRoutes('zh-CN').modelsShowcase).toBe('/zh-CN/models')
+  })
+})
+
 describe('getRoutes seedance', () => {
   it('serves the seedance page at its canonical path for en', () => {
     expect(getRoutes('en').seedance).toBe('/seedance-2.5')

--- a/apps/website/src/config/routes.ts
+++ b/apps/website/src/config/routes.ts
@@ -22,6 +22,7 @@ const baseRoutes = {
   affiliateTerms: '/affiliates/terms',
   contact: '/contact',
   models: '/p/supported-models',
+  modelsShowcase: '/models',
   mcp: '/mcp',
   minimax: '/minimax-h3',
   minimaxMusic3: '/minimax-music-3',

--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -5515,6 +5515,7 @@ const translations = {
   },
   'flux3.reviews.highlightCta': { en: 'GET STARTED', 'zh-CN': '开始使用' },
   'footer.flux3': { en: 'Flux 3', 'zh-CN': 'Flux 3' },
+  'footer.modelsShowcase': { en: 'Models', 'zh-CN': '模型' },
   // Wan Animate 2 model page (/wan-animate-2)
   'wanAnimate2.meta.title': {
     en: 'Wan Animate 2 on Comfy — Open-Source Character Animation',


### PR DESCRIPTION
## Summary
Of the 7 pages flagged as orphaned by the SEO audit, 3 were already fixed by recent commits the audit predates (events/, zh-CN/events/, zh-CN/gallery/ since 2026-07-28; flux-3/ since 2026-08-16), and 2 are <ComingSoon /> placeholders with no real content (demos/, case-studies/) — deliberately left unlinkedrather than promoting empty pages. Only models/ was a genuine orphan: a real, shipped page with zero internal links anywhere in the codebase, because the existing `models` route/nav label refers to the separate /p/supported-models catalog, not this page.

## Pages Affected
- comfy.org/models/ — added to footer Products column
- comfy.org/zh-CN/models/ — covered automatically via locale-aware routing


