### PR TITLE
[backport core/1.51] feat(workspace): enable local credit workspace switching FE-1584

### DIFF
--- a/browser_tests/fixtures/workspaceSwitcherFixture.ts
+++ b/browser_tests/fixtures/workspaceSwitcherFixture.ts
@@ -2,6 +2,11 @@ import type { WorkspaceTokenResponse } from '@/platform/workspace/stores/workspa
 
 import { comfyPageFixture } from '@e2e/fixtures/ComfyPage'
 import {
+  EMPTY_BILLING_BALANCE,
+  EMPTY_BILLING_PLANS,
+  ENDED_STANDARD_BILLING_STATUS
+} from '@e2e/fixtures/data/cloudWorkspace'
+import {
   WORKSPACE_SWITCHER_REMOTE_CONFIG,
   WORKSPACE_SWITCHER_WORKSPACES
 } from '@e2e/fixtures/data/workspaceSwitcher'
@@ -50,6 +55,15 @@ export const workspaceSwitcherTest = comfyPageFixture.extend({
 
     await page.route('**/api/auth/session', (route) =>
       route.fulfill({ status: 204 })
+    )
+    await page.route('**/api/billing/status', (route) =>
+      route.fulfill(jsonRoute(ENDED_STANDARD_BILLING_STATUS))
+    )
+    await page.route('**/api/billing/balance', (route) =>
+      route.fulfill(jsonRoute(EMPTY_BILLING_BALANCE))
+    )
+    await page.route('**/api/billing/plans', (route) =>
+      route.fulfill(jsonRoute(EMPTY_BILLING_PLANS))
     )
 
     await use(page)

--- a/browser_tests/tests/workspace/localWorkspaceSwitcher.spec.ts
+++ b/browser_tests/tests/workspace/localWorkspaceSwitcher.spec.ts
@@ -1,0 +1,95 @@
+import { expect } from '@playwright/test'
+
+import {
+  PERSONAL_WORKSPACE_NAME,
+  TEAM_WORKSPACE_NAME
+} from '@e2e/fixtures/data/workspaceSwitcher'
+import { workspaceSwitcherTest as test } from '@e2e/fixtures/workspaceSwitcherFixture'
+
+test.describe('Local workspace switcher', { tag: '@auth' }, () => {
+  test.describe.configure({ timeout: 60_000 })
+
+  test('switches the active workspace without reloading or losing the workflow', async ({
+    comfyPage
+  }) => {
+    const page = comfyPage.page
+    const localOrigin = new URL(page.url()).origin
+    const billingRequestUrls: string[] = []
+    const localBillingRequestUrls: string[] = []
+    const billingAuthorizationHeaders: string[] = []
+    let tokenRequestBody: unknown
+
+    page.on('request', (request) => {
+      if (!request.url().includes('/api/billing/')) return
+      billingRequestUrls.push(request.url())
+      billingAuthorizationHeaders.push(request.headers().authorization ?? '')
+      if (new URL(request.url()).origin === localOrigin) {
+        localBillingRequestUrls.push(request.url())
+      }
+    })
+    page.on('request', (request) => {
+      if (
+        request.method() === 'POST' &&
+        request.url().endsWith('/api/auth/token')
+      ) {
+        tokenRequestBody = request.postDataJSON()
+      }
+    })
+
+    await comfyPage.settings.setSetting('Comfy.UseNewMenu', 'Top')
+    await comfyPage.settings.setSetting(
+      'Comfy.Workflow.WorkflowTabsPosition',
+      'Topbar'
+    )
+    const workflowName = `local-workspace-${Date.now().toString(36)}`
+    await comfyPage.menu.topbar.saveWorkflow(workflowName)
+    await page.evaluate(() => {
+      document.body.dataset.workspaceSwitchDocument = 'original'
+    })
+
+    await page.getByRole('button', { name: 'Current user' }).click()
+    await expect(page.getByTestId('workspace-switcher-trigger')).toContainText(
+      PERSONAL_WORKSPACE_NAME
+    )
+    await page.getByTestId('workspace-switcher-trigger').click()
+
+    const panel = page.getByTestId('workspace-switcher-panel')
+    await expect(panel.getByText(PERSONAL_WORKSPACE_NAME)).toBeVisible()
+    await expect(panel.getByText(TEAM_WORKSPACE_NAME)).toBeVisible()
+    await expect(panel.getByText('Owner')).toHaveCount(2)
+    await expect(panel.getByText('Member')).toHaveCount(1)
+    const scopeCaption = panel.getByText(
+      'Workspaces only affect which credits you use.'
+    )
+    await expect(scopeCaption).toBeVisible()
+    await scopeCaption.locator('..').locator('.pi-info-circle').hover()
+    await expect(page.getByRole('tooltip')).toHaveText(
+      'Runs that use partner nodes spend credits from this workspace. Unlike on Cloud, every workspace saves to your usual output folder.'
+    )
+
+    await panel.getByText(TEAM_WORKSPACE_NAME, { exact: true }).click()
+
+    await expect(page.getByTestId('workspace-switcher-trigger')).toContainText(
+      TEAM_WORKSPACE_NAME
+    )
+    await expect.poll(() => billingRequestUrls.length).toBeGreaterThan(0)
+    expect(tokenRequestBody).toEqual({ workspace_id: 'ws-team' })
+    expect(billingRequestUrls).toEqual(
+      expect.arrayContaining([
+        expect.stringMatching(
+          /^https:\/\/testcloud\.comfy\.org\/api\/billing\//
+        )
+      ])
+    )
+    expect(localBillingRequestUrls).toEqual([])
+    await expect
+      .poll(() => billingAuthorizationHeaders)
+      .toContain('Bearer mock-workspace-token-ws-team')
+    await expect
+      .poll(() => comfyPage.menu.topbar.getTabNames())
+      .toContain(workflowName)
+    expect(
+      await page.evaluate(() => document.body.dataset.workspaceSwitchDocument)
+    ).toBe('original')
+  })
+})

--- a/browser_tests/tests/workspaceSwitcher.spec.ts
+++ b/browser_tests/tests/workspaceSwitcher.spec.ts
@@ -42,6 +42,9 @@ test.describe('Workspace switcher', { tag: '@cloud' }, () => {
 
     const panel = page.getByTestId('workspace-switcher-panel')
     await expect(panel).toBeVisible()
+    await expect(
+      panel.getByText('Workspaces only affect which credits you use.')
+    ).toHaveCount(0)
 
     const profileMenu = page.locator('.current-user-popover')
     const panelBox = await panel.boundingBox()

--- a/src/components/topbar/CurrentUserButton.test.ts
+++ b/src/components/topbar/CurrentUserButton.test.ts
@@ -217,4 +217,25 @@ describe('CurrentUserButton', () => {
     expect(screen.getByText('WorkspaceProfilePic')).toBeInTheDocument()
     expect(screen.queryByText('Avatar')).not.toBeInTheDocument()
   })
+
+  it('shows WorkspaceProfilePic for an active local team workspace', () => {
+    mockTeamWorkspaceStore.initState.value = 'ready'
+    mockTeamWorkspaceStore.isInPersonalWorkspace.value = false
+    mockTeamWorkspaceStore.workspaceName.value = 'My Team'
+
+    renderComponent()
+
+    expect(screen.getByText('WorkspaceProfilePic')).toBeInTheDocument()
+    expect(screen.queryByText('Avatar')).not.toBeInTheDocument()
+  })
+
+  it('shows workspace actions after local workspace initialization', async () => {
+    mockTeamWorkspaceStore.initState.value = 'ready'
+    const { user } = renderComponent()
+
+    await user.click(screen.getByRole('button', { name: 'Current user' }))
+
+    expect(screen.getByText('Workspace Popover Content')).toBeInTheDocument()
+    expect(screen.queryByText('Popover Content')).not.toBeInTheDocument()
+  })
 })

--- a/src/components/topbar/CurrentUserButton.vue
+++ b/src/components/topbar/CurrentUserButton.vue
@@ -49,7 +49,7 @@
       @show="onPopoverShow"
     >
       <CurrentUserPopoverWorkspace
-        v-if="isCloud"
+        v-if="showWorkspacePopover"
         ref="workspacePopoverContent"
         :account-actions-only="initState !== 'ready'"
         @close="closePopover"
@@ -101,7 +101,10 @@ const showWorkspaceSkeleton = computed(
   () => isCloud && initState.value === 'loading'
 )
 const showWorkspaceIcon = computed(
-  () => isCloud && initState.value === 'ready' && !isInPersonalWorkspace.value
+  () => initState.value === 'ready' && !isInPersonalWorkspace.value
+)
+const showWorkspacePopover = computed(
+  () => isCloud || initState.value === 'ready'
 )
 
 const workspaceName = computed(() => {

--- a/src/components/topbar/CurrentUserPopoverLegacy.test.ts
+++ b/src/components/topbar/CurrentUserPopoverLegacy.test.ts
@@ -1,3 +1,4 @@
+import { createTestingPinia } from '@pinia/testing'
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -68,6 +69,7 @@ const mockTier = ref<SubscriptionInfo['tier']>('CREATOR')
 const mockSubscription = ref<SubscriptionInfo | null>(makeSubscription())
 const mockBalance = ref<BalanceInfo | null>(null)
 const mockIsLoading = ref(false)
+const mockIsTeamPlan = ref(false)
 
 vi.mock('@/composables/billing/useBillingContext', () => ({
   useBillingContext: vi.fn(() => ({
@@ -76,6 +78,7 @@ vi.mock('@/composables/billing/useBillingContext', () => ({
     subscription: mockSubscription,
     balance: mockBalance,
     isLoading: mockIsLoading,
+    isTeamPlan: mockIsTeamPlan,
     fetchBalance: mockFetchBalance
   }))
 }))
@@ -121,7 +124,7 @@ describe('CurrentUserPopoverLegacy', () => {
     mockIsLoading.value = false
   })
 
-  function renderComponent() {
+  function renderComponent(teamWorkspaceState?: Record<string, unknown>) {
     const i18n = createI18n({
       legacy: false,
       locale: 'en',
@@ -132,7 +135,15 @@ describe('CurrentUserPopoverLegacy', () => {
 
     render(CurrentUserPopoverLegacy, {
       global: {
-        plugins: [i18n],
+        plugins: [
+          i18n,
+          createTestingPinia({
+            createSpy: vi.fn,
+            initialState: teamWorkspaceState
+              ? { teamWorkspace: teamWorkspaceState }
+              : {}
+          })
+        ],
         stubs: {
           Divider: true
         }
@@ -380,6 +391,103 @@ describe('CurrentUserPopoverLegacy', () => {
         }
       })
       expect(screen.getByText('0')).toBeInTheDocument()
+    })
+  })
+  describe('workspace selector (non-cloud)', () => {
+    const workspace = (overrides: Record<string, unknown>) => ({
+      isSubscribed: false,
+      subscriptionPlan: null,
+      subscriptionTier: null,
+      members: [],
+      pendingInvites: [],
+      ...overrides
+    })
+
+    const readyWorkspaceState = {
+      initState: 'ready',
+      activeWorkspaceId: 'ws-personal',
+      isFetchingWorkspaces: false,
+      workspaces: [
+        workspace({
+          id: 'ws-personal',
+          name: 'Personal Workspace',
+          type: 'personal',
+          role: 'owner'
+        }),
+        workspace({
+          id: 'ws-team',
+          name: 'Team Comfy',
+          type: 'team',
+          role: 'member'
+        })
+      ]
+    }
+
+    it('stays hidden while the workspace store is not hydrated', () => {
+      renderComponent()
+
+      expect(screen.queryByTestId('workspace-switcher-trigger')).toBeNull()
+    })
+
+    it.for(['ready', 'error'])(
+      'stays hidden when workspace initialization is %s without workspaces',
+      (initState) => {
+        renderComponent({
+          initState,
+          activeWorkspaceId: null,
+          isFetchingWorkspaces: false,
+          workspaces: []
+        })
+
+        expect(screen.queryByTestId('workspace-switcher-trigger')).toBeNull()
+      }
+    )
+
+    it('shows the trigger and opens the switcher once the store is ready', async () => {
+      const { user } = renderComponent(readyWorkspaceState)
+
+      const trigger = screen.getByTestId('workspace-switcher-trigger')
+      expect(trigger).toHaveAttribute('aria-expanded', 'false')
+      expect(trigger).toHaveAttribute('aria-haspopup', 'menu')
+      expect(trigger).toHaveAttribute(
+        'aria-controls',
+        'workspace-switcher-panel'
+      )
+      expect(screen.queryByTestId('workspace-switcher-panel')).toBeNull()
+
+      await user.click(trigger)
+
+      const panel = screen.getByTestId('workspace-switcher-panel')
+      expect(panel).toBeInTheDocument()
+      expect(panel).toHaveAttribute('id', 'workspace-switcher-panel')
+      expect(panel).toHaveAttribute('role', 'menu')
+      expect(trigger).toHaveAttribute('aria-expanded', 'true')
+    })
+
+    it('closes the switcher on Escape or a click elsewhere', async () => {
+      const { user } = renderComponent(readyWorkspaceState)
+      const trigger = screen.getByTestId('workspace-switcher-trigger')
+
+      await user.click(trigger)
+      await user.keyboard('{Escape}')
+      expect(screen.queryByTestId('workspace-switcher-panel')).toBeNull()
+
+      await user.click(trigger)
+      await user.click(screen.getByText('Test User'))
+      expect(screen.queryByTestId('workspace-switcher-panel')).toBeNull()
+    })
+
+    it('keeps credits visible but hides top-up for workspace members', () => {
+      mockCanAccessSubscriptionFeatures.value = false
+      renderComponent({
+        ...readyWorkspaceState,
+        activeWorkspaceId: 'ws-team'
+      })
+
+      expect(screen.getByTestId('manage-plan-menu-item')).toHaveTextContent(
+        enMessages.credits.credits
+      )
+      expect(screen.queryByTestId('add-credits-button')).toBeNull()
     })
   })
 })

--- a/src/components/topbar/CurrentUserPopoverLegacy.vue
+++ b/src/components/topbar/CurrentUserPopoverLegacy.vue
@@ -30,9 +30,46 @@
       </span>
     </div>
 
+    <div v-if="showWorkspaceSwitcher" class="relative">
+      <Button
+        ref="workspaceSwitcherTrigger"
+        v-tooltip="{ value: workspaceName, showDelay: 300 }"
+        variant="muted-textonly"
+        class="flex h-auto w-full items-center justify-between rounded-lg px-4 py-2 hover:bg-secondary-background-hover"
+        :aria-expanded="isWorkspaceSwitcherOpen"
+        aria-haspopup="menu"
+        aria-controls="workspace-switcher-panel"
+        data-testid="workspace-switcher-trigger"
+        @click="isWorkspaceSwitcherOpen = !isWorkspaceSwitcherOpen"
+        @keydown.escape.stop="isWorkspaceSwitcherOpen = false"
+      >
+        <div class="flex w-0 flex-1 items-center gap-2">
+          <WorkspaceProfilePic
+            class="size-6 shrink-0 text-xs"
+            :workspace-name="workspaceName"
+          />
+          <span class="truncate text-sm text-base-foreground">
+            {{ workspaceName }}
+          </span>
+        </div>
+        <i class="pi pi-chevron-down shrink-0 text-sm text-muted-foreground" />
+      </Button>
+
+      <div
+        v-if="isWorkspaceSwitcherOpen"
+        id="workspace-switcher-panel"
+        ref="workspaceSwitcherPanel"
+        role="menu"
+        class="absolute top-0 right-full z-10 mr-4 rounded-lg border border-border-default bg-base-background shadow-[1px_1px_8px_0_rgba(0,0,0,0.4)]"
+        data-testid="workspace-switcher-panel"
+      >
+        <WorkspaceSwitcherPopover @select="isWorkspaceSwitcherOpen = false" />
+      </div>
+    </div>
+
     <!-- Credits Section -->
     <div
-      v-if="canAccessSubscriptionFeatures"
+      v-if="canAccessSubscriptionFeatures || showWorkspaceSwitcher"
       class="flex items-center gap-2 px-4 py-2"
     >
       <i class="icon-[lucide--coins] text-sm text-credit" />
@@ -51,6 +88,7 @@
         <i class="icon-[lucide--circle-help]" />
       </Button>
       <Button
+        v-if="showAddCredits"
         variant="secondary"
         size="sm"
         class="text-base-foreground"
@@ -76,7 +114,7 @@
     </div>
 
     <div
-      v-if="canAccessSubscriptionFeatures"
+      v-if="canAccessSubscriptionFeatures || showWorkspaceSwitcher"
       class="flex cursor-pointer items-center gap-2 px-4 py-2 hover:bg-secondary-background-hover"
       data-testid="manage-plan-menu-item"
       @click="handleOpenPlanAndCreditsSettings"
@@ -114,9 +152,11 @@
 </template>
 
 <script setup lang="ts">
+import { onClickOutside } from '@vueuse/core'
+import { storeToRefs } from 'pinia'
 import Divider from 'primevue/divider'
 import Skeleton from 'primevue/skeleton'
-import { computed, onMounted } from 'vue'
+import { computed, onMounted, ref, useTemplateRef } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import { formatCreditsFromCents } from '@/base/credits/comfyCredits'
@@ -127,7 +167,11 @@ import { useBillingContext } from '@/composables/billing/useBillingContext'
 import { useExternalLink } from '@/composables/useExternalLink'
 import { useTelemetry } from '@/platform/telemetry'
 import { useSettingsDialog } from '@/platform/settings/composables/useSettingsDialog'
+import WorkspaceProfilePic from '@/platform/workspace/components/WorkspaceProfilePic.vue'
+import WorkspaceSwitcherPopover from '@/platform/workspace/components/WorkspaceSwitcherPopover.vue'
 import { useWorkspaceTierLabel } from '@/platform/workspace/composables/useWorkspaceTierLabel'
+import { useWorkspaceUI } from '@/platform/workspace/composables/useWorkspaceUI'
+import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
 import { useDialogService } from '@/services/dialogService'
 
 const emit = defineEmits<{
@@ -150,6 +194,32 @@ const {
 } = useBillingContext()
 const { formatTierName } = useWorkspaceTierLabel()
 const { locale } = useI18n()
+
+const { initState, workspaces, workspaceName } = storeToRefs(
+  useTeamWorkspaceStore()
+)
+const isWorkspaceSwitcherOpen = ref(false)
+const workspaceSwitcherTrigger = useTemplateRef('workspaceSwitcherTrigger')
+const workspaceSwitcherPanel = useTemplateRef('workspaceSwitcherPanel')
+
+onClickOutside(
+  workspaceSwitcherPanel,
+  () => {
+    isWorkspaceSwitcherOpen.value = false
+  },
+  { ignore: [workspaceSwitcherTrigger] }
+)
+
+const showWorkspaceSwitcher = computed(
+  () => initState.value === 'ready' && workspaces.value.length > 0
+)
+
+const { permissions } = useWorkspaceUI()
+const showAddCredits = computed(() =>
+  showWorkspaceSwitcher.value
+    ? permissions.value.canTopUp
+    : canAccessSubscriptionFeatures.value
+)
 
 const subscriptionTierName = computed(() =>
   formatTierName(tier.value, subscription.value?.duration === 'ANNUAL')

--- a/src/composables/billing/useBillingRouting.test.ts
+++ b/src/composables/billing/useBillingRouting.test.ts
@@ -58,14 +58,24 @@ describe('useBillingRouting', () => {
     mockActiveWorkspaceBillingRail.value = null
   })
 
-  it('uses legacy billing off Cloud', () => {
+  it('uses legacy billing off Cloud until a workspace context loads', () => {
     mockIsCloud.value = false
-    mockActiveWorkspace.value = team
+    mockActiveWorkspace.value = null
 
     const { type, shouldUseWorkspaceBilling } = useBillingRouting()
 
     expect(type.value).toBe('legacy')
     expect(shouldUseWorkspaceBilling.value).toBe(false)
+  })
+
+  it('uses workspace billing off Cloud once a workspace context loads', () => {
+    mockIsCloud.value = false
+    mockActiveWorkspace.value = team
+
+    const { type, shouldUseWorkspaceBilling } = useBillingRouting()
+
+    expect(type.value).toBe('workspace')
+    expect(shouldUseWorkspaceBilling.value).toBe(true)
   })
 
   it('uses workspace billing for a Cloud personal workspace', () => {
@@ -76,7 +86,6 @@ describe('useBillingRouting', () => {
   })
 
   it('uses unified pricing while keeping legacy Stripe top-ups on Checkout', () => {
-    mockActiveWorkspace.value = personal
     mockActiveWorkspaceBillingRail.value = 'legacy_stripe'
 
     const { type, shouldUseWorkspaceBilling, shouldUseUnifiedPricing } =

--- a/src/composables/billing/useBillingRouting.ts
+++ b/src/composables/billing/useBillingRouting.ts
@@ -11,7 +11,8 @@ import type { BillingType } from './types'
  * (`/customers/*`) or workspace-scoped (`/api/billing/*`). Personal workspaces
  * use workspace billing unless an explicit legacy Stripe rail selects legacy
  * account operations and its migration flag is off. An unloaded workspace
- * remains legacy during bootstrap, and OSS always uses legacy billing.
+ * remains legacy during bootstrap; Local/Desktop uses workspace billing after
+ * its Cloud-backed workspace context loads.
  */
 export function useBillingRouting() {
   const { flags } = useFeatureFlags()
@@ -22,10 +23,6 @@ export function useBillingRouting() {
   })
 
   const type = computed<BillingType>(() => {
-    if (!isCloud) return 'legacy'
-
-    // An unloaded workspace has no type yet; stay legacy so bootstrap never
-    // eagerly routes to workspace billing.
     const workspaceType = workspaceStore.activeWorkspace?.type
     if (!workspaceType) return 'legacy'
 

--- a/src/composables/useFeatureFlags.test.ts
+++ b/src/composables/useFeatureFlags.test.ts
@@ -562,6 +562,7 @@ describe('useFeatureFlags', () => {
 
   describe('unifiedCloudAuthEnabled', () => {
     it('reads the unified_cloud_auth server feature when set', () => {
+      vi.mocked(distributionTypes).isCloud = true
       vi.mocked(api.getServerFeature).mockImplementation(
         (path, defaultValue) => {
           if (path === ServerFeatureFlag.UNIFIED_CLOUD_AUTH) return true
@@ -574,11 +575,19 @@ describe('useFeatureFlags', () => {
     })
 
     it('lets a dev override beat the server value', () => {
+      vi.mocked(distributionTypes).isCloud = true
       vi.mocked(api.getServerFeature).mockReturnValue(false)
       localStorage.setItem('ff:unified_cloud_auth', 'true')
 
       const { flags } = useFeatureFlags()
       expect(flags.unifiedCloudAuthEnabled).toBe(true)
+    })
+
+    it('is disabled outside the cloud distribution', () => {
+      vi.mocked(distributionTypes).isCloud = false
+      remoteConfig.value = { unified_cloud_auth: true }
+
+      expect(useFeatureFlags().flags.unifiedCloudAuthEnabled).toBe(false)
     })
   })
 

--- a/src/composables/useFeatureFlags.ts
+++ b/src/composables/useFeatureFlags.ts
@@ -189,6 +189,8 @@ export function useFeatureFlags() {
       )
     },
     get unifiedCloudAuthEnabled() {
+      if (!isCloud) return false
+
       return resolveFlag(
         ServerFeatureFlag.UNIFIED_CLOUD_AUTH,
         remoteConfig.value.unified_cloud_auth,

--- a/src/config/comfyApi.test.ts
+++ b/src/config/comfyApi.test.ts
@@ -3,7 +3,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { refreshRemoteConfig } from '@/platform/remoteConfig/refreshRemoteConfig'
 import { remoteConfig } from '@/platform/remoteConfig/remoteConfig'
 
-import { getComfyApiBaseUrl, getComfyPlatformBaseUrl } from './comfyApi'
+import {
+  getComfyApiBaseUrl,
+  getComfyCloudBaseUrl,
+  getComfyPlatformBaseUrl
+} from './comfyApi'
 
 vi.mock('@/scripts/api', () => ({
   api: {
@@ -35,6 +39,12 @@ describe('getComfyApiBaseUrl', () => {
   it('falls back to the build-time default when the value is empty', () => {
     remoteConfig.value = { comfy_api_base_url: '' }
     expect(getComfyApiBaseUrl()).toBe('https://stagingapi.comfy.org')
+  })
+})
+
+describe('getComfyCloudBaseUrl', () => {
+  it('matches the non-production Firebase environment', () => {
+    expect(getComfyCloudBaseUrl()).toBe('https://testcloud.comfy.org')
   })
 })
 

--- a/src/config/comfyApi.ts
+++ b/src/config/comfyApi.ts
@@ -6,12 +6,19 @@ import {
 const PROD_API_BASE_URL = 'https://api.comfy.org'
 const STAGING_API_BASE_URL = 'https://stagingapi.comfy.org'
 
+const PROD_CLOUD_BASE_URL = 'https://cloud.comfy.org'
+const STAGING_CLOUD_BASE_URL = 'https://testcloud.comfy.org'
+
 const PROD_PLATFORM_BASE_URL = 'https://platform.comfy.org'
 const STAGING_PLATFORM_BASE_URL = 'https://stagingplatform.comfy.org'
 
 const BUILD_TIME_API_BASE_URL = __USE_PROD_CONFIG__
   ? PROD_API_BASE_URL
   : (import.meta.env.VITE_STAGING_API_BASE_URL ?? STAGING_API_BASE_URL)
+
+const BUILD_TIME_CLOUD_BASE_URL = __USE_PROD_CONFIG__
+  ? PROD_CLOUD_BASE_URL
+  : (import.meta.env.VITE_STAGING_CLOUD_BASE_URL ?? STAGING_CLOUD_BASE_URL)
 
 const BUILD_TIME_PLATFORM_BASE_URL = __USE_PROD_CONFIG__
   ? PROD_PLATFORM_BASE_URL
@@ -24,6 +31,10 @@ export function getComfyApiBaseUrl(): string {
     'comfy_api_base_url',
     BUILD_TIME_API_BASE_URL
   )
+}
+
+export function getComfyCloudBaseUrl(): string {
+  return BUILD_TIME_CLOUD_BASE_URL
 }
 
 export function getComfyPlatformBaseUrl(): string {

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -3338,6 +3338,8 @@
     "nameValidationError": "Name must be 1–50 characters using letters, numbers, spaces, or common punctuation."
   },
   "workspaceSwitcher": {
+    "scopeCaption": "Workspaces only affect which credits you use.",
+    "scopeTooltip": "Runs that use partner nodes spend credits from this workspace. Unlike on Cloud, every workspace saves to your usual output folder.",
     "switchWorkspace": "Switch workspace",
     "subscribe": "Subscribe",
     "personal": "Personal",

--- a/src/platform/cloud/subscription/components/PricingTable.test.ts
+++ b/src/platform/cloud/subscription/components/PricingTable.test.ts
@@ -117,7 +117,7 @@ vi.mock('@/composables/useErrorHandling', () => ({
 vi.mock('@/stores/authStore', () => ({
   useAuthStore: () =>
     reactive({
-      getAuthHeader: mockGetAuthHeader,
+      getFirebaseAuthHeader: mockGetAuthHeader,
       fetchWithCustomerRecovery: (input: string, init?: RequestInit) =>
         fetch(input, init),
       userId: computed(() => mockUserId.value)

--- a/src/platform/cloud/subscription/composables/useSubscription.test.ts
+++ b/src/platform/cloud/subscription/composables/useSubscription.test.ts
@@ -164,7 +164,7 @@ vi.mock('@/services/dialogService', () => ({
 
 vi.mock('@/stores/authStore', () => ({
   useAuthStore: vi.fn(() => ({
-    getAuthHeader: mockGetAuthHeader,
+    getFirebaseAuthHeader: mockGetAuthHeader,
     fetchWithCustomerRecovery: (input: string, init?: RequestInit) =>
       fetch(input, init),
     get isInitialized() {

--- a/src/platform/cloud/subscription/composables/useSubscription.ts
+++ b/src/platform/cloud/subscription/composables/useSubscription.ts
@@ -57,7 +57,7 @@ function useSubscriptionInternal() {
 
   const authStore = useAuthStore()
   const workspaceStore = useTeamWorkspaceStore()
-  const { getAuthHeader, fetchWithCustomerRecovery } = authStore
+  const { getFirebaseAuthHeader, fetchWithCustomerRecovery } = authStore
   const { wrapWithErrorHandlingAsync } = useErrorHandling()
 
   const { isLoggedIn } = useCurrentUser()
@@ -211,7 +211,7 @@ function useSubscriptionInternal() {
   }
 
   const buildAuthHeaders = async (): Promise<Record<string, string>> => {
-    const authHeader = await getAuthHeader()
+    const authHeader = await getFirebaseAuthHeader()
     if (!authHeader) {
       throw new AuthStoreError(t('toastMessages.userNotAuthenticated'))
     }

--- a/src/platform/cloud/subscription/utils/subscriptionCheckoutUtil.test.ts
+++ b/src/platform/cloud/subscription/utils/subscriptionCheckoutUtil.test.ts
@@ -71,7 +71,7 @@ vi.mock('@/platform/telemetry', () => ({
 vi.mock('@/stores/authStore', () => ({
   useAuthStore: vi.fn(() =>
     reactive({
-      getAuthHeader: mockGetAuthHeader,
+      getFirebaseAuthHeader: mockGetAuthHeader,
       fetchWithCustomerRecovery: (input: string, init?: RequestInit) =>
         fetch(input, init),
       userId: computed(() => mockUserId.value)

--- a/src/platform/cloud/subscription/utils/subscriptionCheckoutUtil.ts
+++ b/src/platform/cloud/subscription/utils/subscriptionCheckoutUtil.ts
@@ -92,7 +92,7 @@ async function initiateSubscriptionCheckout(
   const authStore = useAuthStore()
   const { userId } = storeToRefs(authStore)
   const telemetry = useTelemetry()
-  const authHeader = await authStore.getAuthHeader()
+  const authHeader = await authStore.getFirebaseAuthHeader()
 
   if (!authHeader) {
     throw new AuthStoreError(t('toastMessages.userNotAuthenticated'))

--- a/src/platform/workflow/persistence/base/storageKeys.test.ts
+++ b/src/platform/workflow/persistence/base/storageKeys.test.ts
@@ -1,7 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+const mockDistributionTypes = vi.hoisted(() => ({ isCloud: true }))
+
+vi.mock('@/platform/distribution/types', () => mockDistributionTypes)
+
 describe('storageKeys', () => {
   beforeEach(() => {
+    mockDistributionTypes.isCloud = true
     vi.resetModules()
   })
 
@@ -27,6 +32,17 @@ describe('storageKeys', () => {
       )
       const { getWorkspaceId } = await import('./storageKeys')
       expect(getWorkspaceId()).toBe('ws-abc-123')
+    })
+
+    it('keeps local workflow storage in the personal namespace', async () => {
+      mockDistributionTypes.isCloud = false
+      sessionStorage.setItem(
+        'Comfy.Workspace.Current',
+        JSON.stringify({ type: 'team', id: 'ws-abc-123' })
+      )
+      const { getWorkspaceId } = await import('./storageKeys')
+
+      expect(getWorkspaceId()).toBe('personal')
     })
 
     it('returns personal when JSON parsing fails', async () => {

--- a/src/platform/workflow/persistence/base/storageKeys.ts
+++ b/src/platform/workflow/persistence/base/storageKeys.ts
@@ -1,4 +1,5 @@
 import { WORKSPACE_STORAGE_KEYS } from '@/platform/workspace/workspaceConstants'
+import { isCloud } from '@/platform/distribution/types'
 
 import { hashPath } from './hashUtil'
 
@@ -11,6 +12,8 @@ import { hashPath } from './hashUtil'
  * when this module is first imported.
  */
 export function getWorkspaceId(): string {
+  if (!isCloud) return 'personal'
+
   try {
     const json = sessionStorage.getItem(
       WORKSPACE_STORAGE_KEYS.CURRENT_WORKSPACE

--- a/src/platform/workflow/persistence/composables/useWorkflowPersistenceV2.test.ts
+++ b/src/platform/workflow/persistence/composables/useWorkflowPersistenceV2.test.ts
@@ -129,7 +129,7 @@ vi.mock('@/platform/navigation/preservedQueryNamespaces', () => ({
 }))
 
 vi.mock('@/platform/distribution/types', () => ({
-  isCloud: false
+  isCloud: true
 }))
 
 vi.mock('../migration/migrateV1toV2', () => ({

--- a/src/platform/workflow/persistence/composables/useWorkflowTabState.test.ts
+++ b/src/platform/workflow/persistence/composables/useWorkflowTabState.test.ts
@@ -7,6 +7,8 @@ vi.mock('@/scripts/api', () => ({
   }
 }))
 
+vi.mock('@/platform/distribution/types', () => ({ isCloud: true }))
+
 describe('useWorkflowTabState', () => {
   beforeEach(() => {
     vi.resetModules()

--- a/src/platform/workspace/api/workspaceApi.test.ts
+++ b/src/platform/workspace/api/workspaceApi.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const {
   mockAxiosInstance,
-  mockGetAuthHeaderOrThrow,
+  mockGetWorkspaceAuthHeaderOrThrow,
   mockGetFirebaseAuthHeaderOrThrow
 } = vi.hoisted(() => ({
   mockAxiosInstance: {
@@ -12,7 +12,7 @@ const {
     delete: vi.fn(),
     interceptors: { response: { use: vi.fn() } }
   },
-  mockGetAuthHeaderOrThrow: vi.fn(),
+  mockGetWorkspaceAuthHeaderOrThrow: vi.fn(),
   mockGetFirebaseAuthHeaderOrThrow: vi.fn()
 }))
 
@@ -40,9 +40,13 @@ vi.mock('@/scripts/api', () => ({
   }
 }))
 
+vi.mock('./workspaceApiUrl', () => ({
+  workspaceApiUrl: (path: string) => `/api${path}`
+}))
+
 vi.mock('@/stores/authStore', () => ({
   useAuthStore: () => ({
-    getAuthHeaderOrThrow: mockGetAuthHeaderOrThrow,
+    getWorkspaceAuthHeaderOrThrow: mockGetWorkspaceAuthHeaderOrThrow,
     getFirebaseAuthHeaderOrThrow: mockGetFirebaseAuthHeaderOrThrow
   })
 }))
@@ -53,14 +57,14 @@ const AUTH_HEADER = { Authorization: 'Bearer test-token' }
 
 describe('workspaceApi', () => {
   beforeEach(() => {
-    mockGetAuthHeaderOrThrow.mockResolvedValue(AUTH_HEADER)
+    mockGetWorkspaceAuthHeaderOrThrow.mockResolvedValue(AUTH_HEADER)
     mockGetFirebaseAuthHeaderOrThrow.mockResolvedValue(AUTH_HEADER)
   })
 
   describe('authentication', () => {
-    it('propagates error when getAuthHeaderOrThrow rejects', async () => {
+    it('propagates error when workspace authentication rejects', async () => {
       const authError = new Error('toastMessages.userNotAuthenticated')
-      mockGetAuthHeaderOrThrow.mockRejectedValue(authError)
+      mockGetWorkspaceAuthHeaderOrThrow.mockRejectedValue(authError)
 
       await expect(workspaceApi.list()).rejects.toBe(authError)
     })
@@ -332,7 +336,7 @@ describe('workspaceApi', () => {
       const result = await workspaceApi.acceptInvite('abc-token')
 
       expect(mockGetFirebaseAuthHeaderOrThrow).toHaveBeenCalled()
-      expect(mockGetAuthHeaderOrThrow).not.toHaveBeenCalled()
+      expect(mockGetWorkspaceAuthHeaderOrThrow).not.toHaveBeenCalled()
       expect(mockAxiosInstance.post).toHaveBeenCalledWith(
         '/api/invites/abc-token/accept',
         null,

--- a/src/platform/workspace/api/workspaceApi.ts
+++ b/src/platform/workspace/api/workspaceApi.ts
@@ -46,9 +46,10 @@ import type {
   WorkspaceId,
   WorkspaceInviteId
 } from '@/platform/workspace/workspaceTypes'
-import { api } from '@/scripts/api'
 import { useAuthStore } from '@/stores/authStore'
 import type { UserId } from '@/types/authTypes'
+
+import { workspaceApiUrl } from './workspaceApiUrl'
 
 export type WorkspaceType = 'personal' | 'team'
 export type WorkspaceRole = 'owner' | 'member'
@@ -163,7 +164,7 @@ const workspaceApiClient = axios.create({
 attachUnifiedRemintInterceptor(workspaceApiClient)
 
 async function getAuthHeaderOrThrow() {
-  return useAuthStore().getAuthHeaderOrThrow()
+  return useAuthStore().getWorkspaceAuthHeaderOrThrow()
 }
 
 function handleAxiosError(err: unknown): never {
@@ -193,7 +194,7 @@ export const workspaceApi = {
     const headers = await getAuthHeaderOrThrow()
     try {
       const response = await workspaceApiClient.get<ListWorkspacesResponse>(
-        api.apiURL('/workspaces'),
+        workspaceApiUrl('/workspaces'),
         { headers }
       )
       return response.data
@@ -210,7 +211,7 @@ export const workspaceApi = {
     const headers = await getAuthHeaderOrThrow()
     try {
       const response = await workspaceApiClient.post<WorkspaceWithRole>(
-        api.apiURL('/workspaces'),
+        workspaceApiUrl('/workspaces'),
         payload,
         { headers }
       )
@@ -231,7 +232,7 @@ export const workspaceApi = {
     const headers = await getAuthHeaderOrThrow()
     try {
       const response = await workspaceApiClient.patch<WorkspaceWithRole>(
-        api.apiURL(`/workspaces/${workspaceId}`),
+        workspaceApiUrl(`/workspaces/${workspaceId}`),
         payload,
         { headers }
       )
@@ -249,7 +250,7 @@ export const workspaceApi = {
     const headers = await getAuthHeaderOrThrow()
     try {
       await workspaceApiClient.delete(
-        api.apiURL(`/workspaces/${workspaceId}`),
+        workspaceApiUrl(`/workspaces/${workspaceId}`),
         {
           headers
         }
@@ -266,7 +267,7 @@ export const workspaceApi = {
   async leave(): Promise<void> {
     const headers = await getAuthHeaderOrThrow()
     try {
-      await workspaceApiClient.post(api.apiURL('/workspace/leave'), null, {
+      await workspaceApiClient.post(workspaceApiUrl('/workspace/leave'), null, {
         headers
       })
     } catch (err) {
@@ -282,7 +283,7 @@ export const workspaceApi = {
     const headers = await getAuthHeaderOrThrow()
     try {
       const response = await workspaceApiClient.get<ListMembersResponse>(
-        api.apiURL('/workspace/members'),
+        workspaceApiUrl('/workspace/members'),
         { headers, params }
       )
       return response.data
@@ -299,7 +300,7 @@ export const workspaceApi = {
     const headers = await getAuthHeaderOrThrow()
     try {
       await workspaceApiClient.delete(
-        api.apiURL(`/workspace/members/${userId}`),
+        workspaceApiUrl(`/workspace/members/${userId}`),
         { headers }
       )
     } catch (err) {
@@ -315,7 +316,7 @@ export const workspaceApi = {
     const headers = await getAuthHeaderOrThrow()
     try {
       const response = await workspaceApiClient.patch<Member>(
-        api.apiURL(`/workspace/members/${userId}`),
+        workspaceApiUrl(`/workspace/members/${userId}`),
         { role },
         { headers }
       )
@@ -333,7 +334,7 @@ export const workspaceApi = {
     const headers = await getAuthHeaderOrThrow()
     try {
       const response = await workspaceApiClient.get<ListInvitesResponse>(
-        api.apiURL('/workspace/invites'),
+        workspaceApiUrl('/workspace/invites'),
         { headers }
       )
       return response.data
@@ -350,7 +351,7 @@ export const workspaceApi = {
     const headers = await getAuthHeaderOrThrow()
     try {
       const response = await workspaceApiClient.post<PendingInvite>(
-        api.apiURL('/workspace/invites'),
+        workspaceApiUrl('/workspace/invites'),
         payload,
         { headers }
       )
@@ -368,7 +369,7 @@ export const workspaceApi = {
     const headers = await getAuthHeaderOrThrow()
     try {
       await workspaceApiClient.delete(
-        api.apiURL(`/workspace/invites/${inviteId}`),
+        workspaceApiUrl(`/workspace/invites/${inviteId}`),
         { headers }
       )
     } catch (err) {
@@ -380,7 +381,9 @@ export const workspaceApi = {
     const headers = await getAuthHeaderOrThrow()
     try {
       const response = await workspaceApiClient.post<PendingInvite>(
-        api.apiURL(`/workspace/invites/${encodeURIComponent(inviteId)}/resend`),
+        workspaceApiUrl(
+          `/workspace/invites/${encodeURIComponent(inviteId)}/resend`
+        ),
         null,
         { headers }
       )
@@ -399,7 +402,7 @@ export const workspaceApi = {
     const headers = await useAuthStore().getFirebaseAuthHeaderOrThrow()
     try {
       const response = await workspaceApiClient.post<AcceptInviteResponse>(
-        api.apiURL(`/invites/${token}/accept`),
+        workspaceApiUrl(`/invites/${token}/accept`),
         null,
         { headers, __skipUnifiedRemint: true }
       )
@@ -417,7 +420,7 @@ export const workspaceApi = {
     const headers = await getAuthHeaderOrThrow()
     try {
       const response = await workspaceApiClient.get<BillingStatusResponse>(
-        api.apiURL('/billing/status'),
+        workspaceApiUrl('/billing/status'),
         { headers }
       )
       return response.data
@@ -434,7 +437,7 @@ export const workspaceApi = {
     const headers = await getAuthHeaderOrThrow()
     try {
       const response = await workspaceApiClient.get<BillingBalanceResponse>(
-        api.apiURL('/billing/balance'),
+        workspaceApiUrl('/billing/balance'),
         { headers }
       )
       return response.data
@@ -451,7 +454,7 @@ export const workspaceApi = {
     const headers = await getAuthHeaderOrThrow()
     try {
       const response = await workspaceApiClient.get<BillingPlansResponse>(
-        api.apiURL('/billing/plans'),
+        workspaceApiUrl('/billing/plans'),
         { headers }
       )
       return response.data
@@ -471,7 +474,7 @@ export const workspaceApi = {
     const headers = await getAuthHeaderOrThrow()
     try {
       const response = await workspaceApiClient.post<PreviewSubscribeResponse>(
-        api.apiURL('/billing/preview-subscribe'),
+        workspaceApiUrl('/billing/preview-subscribe'),
         {
           plan_slug: planSlug,
           team_credit_stop_id: options.teamCreditStopId,
@@ -496,7 +499,7 @@ export const workspaceApi = {
     const headers = await getAuthHeaderOrThrow()
     try {
       const response = await workspaceApiClient.post<SubscribeResponse>(
-        api.apiURL('/billing/subscribe'),
+        workspaceApiUrl('/billing/subscribe'),
         {
           plan_slug: planSlug,
           return_url: options.returnUrl,
@@ -525,7 +528,7 @@ export const workspaceApi = {
     try {
       const response =
         await workspaceApiClient.post<CancelSubscriptionResponse>(
-          api.apiURL('/billing/subscription/cancel'),
+          workspaceApiUrl('/billing/subscription/cancel'),
           {
             idempotency_key: idempotencyKey
           } satisfies CancelSubscriptionRequest,
@@ -541,7 +544,7 @@ export const workspaceApi = {
     const headers = await getAuthHeaderOrThrow()
     try {
       const response = await workspaceApiClient.get<unknown>(
-        api.apiURL('/billing/churnkey/auth'),
+        workspaceApiUrl('/billing/churnkey/auth'),
         { headers }
       )
       return churnkeyAuthResponseSchema.parse(response.data)
@@ -558,7 +561,7 @@ export const workspaceApi = {
     const headers = await getAuthHeaderOrThrow()
     try {
       const response = await workspaceApiClient.post<ResubscribeResponse>(
-        api.apiURL('/billing/subscription/resubscribe'),
+        workspaceApiUrl('/billing/subscription/resubscribe'),
         { idempotency_key: idempotencyKey } satisfies ResubscribeRequest,
         { headers }
       )
@@ -578,7 +581,7 @@ export const workspaceApi = {
     const headers = await getAuthHeaderOrThrow()
     try {
       const response = await workspaceApiClient.post<PaymentPortalResponse>(
-        api.apiURL('/billing/payment-portal'),
+        workspaceApiUrl('/billing/payment-portal'),
         { return_url: returnUrl } satisfies PaymentPortalRequest,
         { headers }
       )
@@ -599,7 +602,7 @@ export const workspaceApi = {
     const headers = await getAuthHeaderOrThrow()
     try {
       const response = await workspaceApiClient.post<CreateTopupResponse>(
-        api.apiURL('/billing/topup'),
+        workspaceApiUrl('/billing/topup'),
         {
           amount_cents: amountCents,
           idempotency_key: idempotencyKey
@@ -622,7 +625,7 @@ export const workspaceApi = {
     const headers = await getAuthHeaderOrThrow()
     try {
       const response = await workspaceApiClient.get<BillingEventsResponse>(
-        api.apiURL('/billing/events'),
+        workspaceApiUrl('/billing/events'),
         { headers, params }
       )
       return response.data
@@ -639,7 +642,7 @@ export const workspaceApi = {
     const headers = await getAuthHeaderOrThrow()
     try {
       const response = await workspaceApiClient.get<BillingOpStatusResponse>(
-        api.apiURL(`/billing/ops/${opId}`),
+        workspaceApiUrl(`/billing/ops/${opId}`),
         { headers, timeout: 30_000 }
       )
       return response.data

--- a/src/platform/workspace/api/workspaceApiUrl.test.ts
+++ b/src/platform/workspace/api/workspaceApiUrl.test.ts
@@ -1,0 +1,31 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const distributionMocks = vi.hoisted(() => ({ isCloud: false }))
+
+vi.mock('@/platform/distribution/types', () => distributionMocks)
+vi.mock('@/config/comfyApi', () => ({
+  getComfyCloudBaseUrl: () => 'https://testcloud.comfy.org'
+}))
+vi.mock('@/scripts/api', () => ({
+  api: { apiURL: (route: string) => `/api${route}` }
+}))
+
+import { workspaceApiUrl } from './workspaceApiUrl'
+
+describe('workspaceApiUrl', () => {
+  beforeEach(() => {
+    distributionMocks.isCloud = false
+  })
+
+  it('uses the paired Cloud gateway outside Cloud', () => {
+    expect(workspaceApiUrl('/workspaces')).toBe(
+      'https://testcloud.comfy.org/api/workspaces'
+    )
+  })
+
+  it('keeps same-origin routing on Cloud', () => {
+    distributionMocks.isCloud = true
+
+    expect(workspaceApiUrl('/workspaces')).toBe('/api/workspaces')
+  })
+})

--- a/src/platform/workspace/api/workspaceApiUrl.ts
+++ b/src/platform/workspace/api/workspaceApiUrl.ts
@@ -1,0 +1,7 @@
+import { getComfyCloudBaseUrl } from '@/config/comfyApi'
+import { isCloud } from '@/platform/distribution/types'
+import { api } from '@/scripts/api'
+
+export function workspaceApiUrl(route: string): string {
+  return isCloud ? api.apiURL(route) : `${getComfyCloudBaseUrl()}/api${route}`
+}

--- a/src/platform/workspace/auth/WorkspaceAuthGate.test.ts
+++ b/src/platform/workspace/auth/WorkspaceAuthGate.test.ts
@@ -154,6 +154,68 @@ describe('WorkspaceAuthGate', () => {
       expect(screen.getByTestId('slot-content')).toBeInTheDocument()
       expect(mockRefreshRemoteConfig).not.toHaveBeenCalled()
     })
+
+    it('initializes workspace context in the background for a signed-in user', async () => {
+      mockIsCloud.value = false
+      mockIsInitialized.value = true
+      mockCurrentUser.value = { uid: 'user-123' }
+
+      mountComponent()
+      await flushPromises()
+
+      expect(screen.getByTestId('slot-content')).toBeInTheDocument()
+      expect(mockWorkspaceStoreInitialize).toHaveBeenCalledOnce()
+      expect(mockRefreshRemoteConfig).not.toHaveBeenCalled()
+    })
+
+    it('initializes workspace context after a mid-session sign-in', async () => {
+      mockIsCloud.value = false
+      mockIsInitialized.value = true
+
+      mountComponent()
+      await flushPromises()
+      expect(mockWorkspaceStoreInitialize).not.toHaveBeenCalled()
+
+      mockCurrentUser.value = { uid: 'user-123' }
+      await flushPromises()
+
+      expect(mockWorkspaceStoreInitialize).toHaveBeenCalledOnce()
+    })
+
+    it('deduplicates mount and auth-hydration initialization', async () => {
+      mockIsCloud.value = false
+
+      mountComponent()
+      mockCurrentUser.value = { uid: 'user-123' }
+      mockIsInitialized.value = true
+      await flushPromises()
+
+      expect(mockWorkspaceStoreInitialize).toHaveBeenCalledOnce()
+    })
+
+    it('cancels pending initialization when unmounted', async () => {
+      mockIsCloud.value = false
+
+      const { unmount } = mountComponent()
+      unmount()
+      mockCurrentUser.value = { uid: 'user-123' }
+      mockIsInitialized.value = true
+      await flushPromises()
+
+      expect(mockWorkspaceStoreInitialize).not.toHaveBeenCalled()
+    })
+
+    it('cancels pending initialization on logout', async () => {
+      mockIsCloud.value = false
+      mockCurrentUser.value = { uid: 'user-123' }
+
+      mountComponent()
+      mockCurrentUser.value = null
+      mockIsInitialized.value = true
+      await flushPromises()
+
+      expect(mockWorkspaceStoreInitialize).not.toHaveBeenCalled()
+    })
   })
 
   describe('cloud builds - unauthenticated user', () => {

--- a/src/platform/workspace/auth/WorkspaceAuthGate.vue
+++ b/src/platform/workspace/auth/WorkspaceAuthGate.vue
@@ -58,7 +58,14 @@
  */
 import { until } from '@vueuse/core'
 import { storeToRefs } from 'pinia'
-import { nextTick, onMounted, onUnmounted, ref, useTemplateRef } from 'vue'
+import {
+  nextTick,
+  onMounted,
+  onUnmounted,
+  ref,
+  useTemplateRef,
+  watch
+} from 'vue'
 
 import Button from '@/components/ui/button/Button.vue'
 import { useAuthActions } from '@/composables/auth/useAuthActions'
@@ -86,15 +93,22 @@ const errorPanel = useTemplateRef<HTMLElement>('errorPanel')
 const subscriptionDialog = useSubscriptionDialog()
 let initializationGeneration = 0
 let initializationController: AbortController | null = null
+let backgroundInitialization: Promise<void> | null = null
+let backgroundInitializationUserId: string | null | undefined
 
 function cancelInitialization(): void {
   initializationGeneration++
   initializationController?.abort()
   initializationController = null
+  backgroundInitialization = null
+  backgroundInitializationUserId = undefined
 }
 
 async function initialize(): Promise<void> {
-  if (!isCloud) return
+  if (!isCloud) {
+    void initializeWorkspacesInBackground()
+    return
+  }
 
   cancelInitialization()
   const generation = initializationGeneration
@@ -228,11 +242,66 @@ async function initializeWorkspaceMode(): Promise<void> {
   }
 }
 
+function initializeWorkspacesInBackground(): Promise<void> {
+  const { isInitialized, currentUser } = storeToRefs(useAuthStore())
+  const userId = currentUser.value?.uid ?? null
+  if (backgroundInitialization && backgroundInitializationUserId === userId) {
+    return backgroundInitialization
+  }
+
+  cancelInitialization()
+  const generation = initializationGeneration
+  backgroundInitializationUserId = userId
+
+  const operation = (async () => {
+    if (!isInitialized.value) {
+      await until(isInitialized).toBe(true, {
+        timeout: FIREBASE_INIT_TIMEOUT_MS,
+        throwOnTimeout: true
+      })
+    }
+    if (
+      generation !== initializationGeneration ||
+      currentUser.value?.uid !== userId
+    ) {
+      return
+    }
+    await initializeWorkspaceMode()
+  })().catch((error: unknown) => {
+    if (generation === initializationGeneration) {
+      console.warn(
+        '[WorkspaceAuthGate] Background workspace initialization failed:',
+        error
+      )
+    }
+  })
+
+  backgroundInitialization = operation
+  void operation.finally(() => {
+    if (backgroundInitialization === operation) {
+      backgroundInitialization = null
+      backgroundInitializationUserId = undefined
+    }
+  })
+  return operation
+}
+
 // Initialize on mount. This gate should be placed on the authenticated layout
 // (LayoutDefault) so it mounts fresh after login and unmounts on logout.
 // The router guard ensures only authenticated users reach this layout.
 onMounted(() => {
   void initialize()
 })
+
+if (!isCloud) {
+  const { currentUser } = storeToRefs(useAuthStore())
+  watch(currentUser, (user) => {
+    if (user) {
+      void initializeWorkspacesInBackground()
+    } else {
+      cancelInitialization()
+    }
+  })
+}
 onUnmounted(cancelInitialization)
 </script>

--- a/src/platform/workspace/components/CurrentUserPopoverWorkspace.test.ts
+++ b/src/platform/workspace/components/CurrentUserPopoverWorkspace.test.ts
@@ -174,15 +174,35 @@ describe('CurrentUserPopoverWorkspace', () => {
   it('toggles the workspace switcher panel from the selector row', async () => {
     const user = userEvent.setup()
     renderComponent()
+    const trigger = screen.getByTestId('workspace-switcher-trigger')
 
     expect(
       screen.queryByTestId('workspace-switcher-panel')
     ).not.toBeInTheDocument()
+    expect(trigger).toHaveAttribute('aria-expanded', 'false')
+    expect(trigger).toHaveAttribute('aria-haspopup', 'menu')
+    expect(trigger).toHaveAttribute('aria-controls', 'workspace-switcher-panel')
 
-    await user.click(screen.getByTestId('workspace-switcher-trigger'))
-    expect(screen.getByTestId('workspace-switcher-panel')).toBeInTheDocument()
+    await user.click(trigger)
+    const panel = screen.getByTestId('workspace-switcher-panel')
+    expect(panel).toHaveAttribute('id', 'workspace-switcher-panel')
+    expect(panel).toHaveAttribute('role', 'menu')
+    expect(trigger).toHaveAttribute('aria-expanded', 'true')
 
-    await user.click(screen.getByTestId('workspace-switcher-trigger'))
+    await user.click(trigger)
+    expect(
+      screen.queryByTestId('workspace-switcher-panel')
+    ).not.toBeInTheDocument()
+  })
+
+  it('closes the workspace switcher panel on Escape', async () => {
+    const user = userEvent.setup()
+    renderComponent()
+    const trigger = screen.getByTestId('workspace-switcher-trigger')
+
+    await user.click(trigger)
+    await user.keyboard('{Escape}')
+
     expect(
       screen.queryByTestId('workspace-switcher-panel')
     ).not.toBeInTheDocument()

--- a/src/platform/workspace/components/CurrentUserPopoverWorkspace.vue
+++ b/src/platform/workspace/components/CurrentUserPopoverWorkspace.vue
@@ -26,12 +26,17 @@
 
     <!-- Workspace Selector -->
     <div v-if="!accountActionsOnly" class="relative">
-      <div
+      <button
         ref="workspaceSwitcherTrigger"
         v-tooltip="{ value: workspaceName, showDelay: 300 }"
-        class="flex cursor-pointer items-center justify-between rounded-lg px-4 py-2 hover:bg-secondary-background-hover"
+        type="button"
+        class="flex w-full cursor-pointer items-center justify-between rounded-lg px-4 py-2 hover:bg-secondary-background-hover"
+        :aria-expanded="isWorkspaceSwitcherOpen"
+        aria-haspopup="menu"
+        aria-controls="workspace-switcher-panel"
         data-testid="workspace-switcher-trigger"
         @click="toggleWorkspaceSwitcher"
+        @keydown.escape.stop="isWorkspaceSwitcherOpen = false"
       >
         <div class="flex w-0 flex-1 items-center gap-2">
           <WorkspaceProfilePic
@@ -43,11 +48,13 @@
           </span>
         </div>
         <i class="pi pi-chevron-down shrink-0 text-sm text-muted-foreground" />
-      </div>
+      </button>
 
       <div
         v-if="isWorkspaceSwitcherOpen"
+        id="workspace-switcher-panel"
         ref="workspaceSwitcherPanel"
+        role="menu"
         class="absolute top-0 right-full z-10 mr-4 rounded-lg border border-border-default bg-base-background shadow-[1px_1px_8px_0_rgba(0,0,0,0.4)]"
         data-testid="workspace-switcher-panel"
       >

--- a/src/platform/workspace/components/TopUpCreditsDialogContentWorkspace.test.ts
+++ b/src/platform/workspace/components/TopUpCreditsDialogContentWorkspace.test.ts
@@ -23,6 +23,9 @@ const mockPermissions = vi.hoisted(() => ({
   ref: undefined as { value: { canTopUp: boolean } } | undefined
 }))
 const mockShouldUseWorkspaceBilling = vi.hoisted(() => ({ value: true }))
+const mockDistributionTypes = vi.hoisted(() => ({ isCloud: true }))
+
+vi.mock('@/platform/distribution/types', () => mockDistributionTypes)
 const mockBillingOperationState = vi.hoisted(() => ({
   isAddingCredits: undefined as { value: boolean } | undefined,
   topupActionOperation: undefined as
@@ -206,6 +209,7 @@ async function clickAddCredits() {
 
 describe('TopUpCreditsDialogContentWorkspace', () => {
   beforeEach(() => {
+    mockDistributionTypes.isCloud = true
     setCanTopUp(true)
     mockShouldUseWorkspaceBilling.value = true
     setIsAddingCredits(false)
@@ -418,6 +422,17 @@ describe('TopUpCreditsDialogContentWorkspace', () => {
       billing_op_id: 'op-1',
       duration_ms: expect.any(Number)
     })
+  })
+
+  it('opens Credits settings after a completed local top-up', async () => {
+    mockDistributionTypes.isCloud = false
+    mockTopup.mockResolvedValue(topupResponse('completed'))
+
+    renderDialog()
+    await clickAddCredits()
+    await userEvent.click(screen.getByRole('button', { name: 'Pay $50.00' }))
+
+    expect(mockShowSettings).toHaveBeenCalledWith('credits')
   })
 
   it('keeps completed top-up telemetry successful when refresh fails', async () => {

--- a/src/platform/workspace/components/TopUpCreditsDialogContentWorkspace.vue
+++ b/src/platform/workspace/components/TopUpCreditsDialogContentWorkspace.vue
@@ -259,6 +259,7 @@ import { useBillingContext } from '@/composables/billing/useBillingContext'
 import { useBillingRouting } from '@/composables/billing/useBillingRouting'
 import { useExternalLink } from '@/composables/useExternalLink'
 import { useTelemetry } from '@/platform/telemetry'
+import { isCloud } from '@/platform/distribution/types'
 import { clearTopupTracking } from '@/platform/telemetry/topupTracker'
 import { categorizeBillingApiError } from '@/platform/telemetry/utils/billingFailureCategory'
 import { useSettingsDialog } from '@/platform/settings/composables/useSettingsDialog'
@@ -468,7 +469,7 @@ async function handleBuy() {
       })
       await Promise.allSettled([fetchBalance(), fetchStatus()])
       handleClose(false)
-      settingsDialog.show('workspace')
+      settingsDialog.show(isCloud ? 'workspace' : 'credits')
     } else if (response.status === 'pending') {
       void billingOperationStore
         .startOperation(response.billing_op_id, 'topup', { attemptStartedAt })

--- a/src/platform/workspace/components/WorkspaceSwitcherPopover.test.ts
+++ b/src/platform/workspace/components/WorkspaceSwitcherPopover.test.ts
@@ -19,6 +19,10 @@ vi.mock('@/composables/billing/useBillingContext', () => ({
   useBillingContext: () => ({ subscription: billingMocks.subscription })
 }))
 
+const distributionMocks = vi.hoisted(() => ({ isCloud: true }))
+
+vi.mock('@/platform/distribution/types', () => distributionMocks)
+
 const LONG_WORKSPACE_NAME =
   'Quantum Renaissance Collective for Hyperdimensional Latent Diffusion Research and Experimental Workflow Engineering'
 
@@ -31,6 +35,9 @@ const i18n = createI18n({
         personal: 'Personal',
         roleOwner: 'Owner',
         roleMember: 'Member',
+        scopeCaption: 'Workspaces only affect which credits you use.',
+        scopeTooltip:
+          'Runs that use partner nodes spend credits from this workspace. Unlike on Cloud, every workspace saves to your usual output folder.',
         createWorkspace: 'Create a team workspace',
         maxWorkspacesReached:
           'You can only own 10 workspaces. Delete one to create a new one.'
@@ -99,8 +106,19 @@ function renderComponent(
 }
 
 describe('WorkspaceSwitcherPopover', () => {
+  it('shows the credits-scope caption off cloud', () => {
+    distributionMocks.isCloud = false
+    renderComponent()
+    expect(
+      screen.getByText('Workspaces only affect which credits you use.')
+    ).toBeInTheDocument()
+
+    distributionMocks.isCloud = true
+  })
+
   beforeEach(() => {
     billingMocks.subscription.value = null
+    distributionMocks.isCloud = true
   })
 
   it.for([
@@ -238,5 +256,14 @@ describe('WorkspaceSwitcherPopover', () => {
 
     const createWorkspaceButton = screen.getByText('Create a team workspace')
     expect(list).not.toContainElement(createWorkspaceButton)
+  })
+
+  it('hides the create-workspace footer on non-cloud distributions', () => {
+    distributionMocks.isCloud = false
+
+    renderComponent()
+
+    expect(screen.queryByText('Create a team workspace')).toBeNull()
+    expect(screen.queryByText(/You can only own 10 workspaces/)).toBeNull()
   })
 })

--- a/src/platform/workspace/components/WorkspaceSwitcherPopover.vue
+++ b/src/platform/workspace/components/WorkspaceSwitcherPopover.vue
@@ -34,6 +34,7 @@
             >
               <button
                 class="flex min-w-0 flex-1 cursor-pointer items-center gap-2 border-none bg-transparent p-0"
+                :disabled="!isCloud && isSwitching"
                 @click="handleSelectWorkspace(workspace)"
               >
                 <WorkspaceProfilePic
@@ -70,8 +71,22 @@
       </template>
     </div>
 
+    <div
+      v-if="!isCloud"
+      class="flex shrink-0 items-center gap-2 px-4 py-2 text-xs text-muted-foreground"
+    >
+      <i
+        v-tooltip.left="{
+          value: $t('workspaceSwitcher.scopeTooltip'),
+          showDelay: 300
+        }"
+        class="pi pi-info-circle text-xs"
+      />
+      <span>{{ $t('workspaceSwitcher.scopeCaption') }}</span>
+    </div>
+
     <!-- Create workspace button -->
-    <div class="shrink-0 border-t border-border-default p-2">
+    <div v-if="isCloud" class="shrink-0 border-t border-border-default p-2">
       <div
         :class="
           cn(
@@ -113,6 +128,7 @@ import { useI18n } from 'vue-i18n'
 
 import WorkspaceProfilePic from '@/platform/workspace/components/WorkspaceProfilePic.vue'
 import { useBillingContext } from '@/composables/billing/useBillingContext'
+import { isCloud } from '@/platform/distribution/types'
 import { useWorkspaceSwitch } from '@/platform/workspace/composables/useWorkspaceSwitch'
 import { useWorkspaceTierLabel } from '@/platform/workspace/composables/useWorkspaceTierLabel'
 import type {
@@ -151,8 +167,13 @@ const currentSubscriptionTierName = computed(() => {
 })
 
 const workspaceStore = useTeamWorkspaceStore()
-const { workspaceId, workspaces, canCreateWorkspace, isFetchingWorkspaces } =
-  storeToRefs(workspaceStore)
+const {
+  workspaceId,
+  workspaces,
+  canCreateWorkspace,
+  isFetchingWorkspaces,
+  isSwitching
+} = storeToRefs(workspaceStore)
 
 const availableWorkspaces = computed<AvailableWorkspace[]>(() =>
   workspaces.value.map((w) => ({

--- a/src/platform/workspace/stores/billingOperationStore.test.ts
+++ b/src/platform/workspace/stores/billingOperationStore.test.ts
@@ -6,6 +6,9 @@ import type { BillingOpStatusResponse } from '@/platform/workspace/api/workspace
 const mockFetchStatus = vi.fn()
 const mockFetchBalance = vi.fn()
 const mockReconcileSubscriptionSuccess = vi.fn()
+const mockDistributionTypes = vi.hoisted(() => ({ isCloud: true }))
+
+vi.mock('@/platform/distribution/types', () => mockDistributionTypes)
 
 vi.mock('@/composables/billing/useBillingContext', () => ({
   useBillingContext: () => ({
@@ -81,6 +84,7 @@ import { useBillingOperationStore } from './billingOperationStore'
 
 describe('billingOperationStore', () => {
   beforeEach(() => {
+    mockDistributionTypes.isCloud = true
     mockActiveWorkspaceId.value = 'workspace-1'
   })
 
@@ -362,6 +366,22 @@ describe('billingOperationStore', () => {
 
       expect(mockCloseDialog).toHaveBeenCalledWith({ key: 'top-up-credits' })
       expect(mockSettingsDialogShow).toHaveBeenCalledWith('workspace')
+    })
+
+    it('opens Credits settings after a polled local topup succeeds', async () => {
+      mockDistributionTypes.isCloud = false
+      vi.mocked(workspaceApi.getBillingOpStatus).mockResolvedValue({
+        id: 'op-1',
+        status: 'succeeded',
+        started_at: new Date().toISOString()
+      })
+
+      const store = useBillingOperationStore()
+      void store.startOperation('op-1', 'topup')
+
+      await vi.advanceTimersByTimeAsync(0)
+
+      expect(mockSettingsDialogShow).toHaveBeenCalledWith('credits')
     })
 
     it('fires purchase telemetry on subscription success', async () => {

--- a/src/platform/workspace/stores/billingOperationStore.ts
+++ b/src/platform/workspace/stores/billingOperationStore.ts
@@ -7,6 +7,7 @@ import { t } from '@/i18n'
 import type { TierKey } from '@/platform/cloud/subscription/constants/tierPricing'
 import type { BillingCycle } from '@/platform/cloud/subscription/utils/subscriptionTierRank'
 import { useSettingsDialog } from '@/platform/settings/composables/useSettingsDialog'
+import { isCloud } from '@/platform/distribution/types'
 import { useTelemetry } from '@/platform/telemetry'
 import type {
   BillingFailure,
@@ -423,7 +424,7 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
     // so leave it open. Top-ups have no such step: close and surface settings.
     if (operation.type === 'topup') {
       useDialogStore().closeDialog({ key: 'top-up-credits' })
-      useSettingsDialog().show('workspace')
+      useSettingsDialog().show(isCloud ? 'workspace' : 'credits')
     }
 
     const toastStore = useToastStore()

--- a/src/platform/workspace/stores/teamWorkspaceStore.test.ts
+++ b/src/platform/workspace/stores/teamWorkspaceStore.test.ts
@@ -4,6 +4,10 @@ import { WORKSPACE_STORAGE_KEYS } from '@/platform/workspace/workspaceConstants'
 
 import { sortWorkspaces, useTeamWorkspaceStore } from './teamWorkspaceStore'
 
+const mockDistributionTypes = vi.hoisted(() => ({ isCloud: true }))
+
+vi.mock('@/platform/distribution/types', () => mockDistributionTypes)
+
 // Mock workspaceAuthStore
 const mockWorkspaceAuthStore = vi.hoisted(() => ({
   currentWorkspace: null as {
@@ -157,7 +161,9 @@ function expectCleanupBeforeContextAndReload(): void {
 
 describe('useTeamWorkspaceStore', () => {
   beforeEach(() => {
+    mockDistributionTypes.isCloud = true
     vi.stubGlobal('localStorage', mockLocalStorage)
+    sessionStorage.clear()
     mockCurrentUser.userEmail.value = null
 
     // Reset workspaceAuthStore mock state
@@ -305,6 +311,27 @@ describe('useTeamWorkspaceStore', () => {
       expect(mockWorkspaceApi.list).toHaveBeenCalledTimes(1)
     })
 
+    it('shares an in-flight initialization with concurrent callers', async () => {
+      let resolveList: (value: unknown) => void = () => {}
+      mockWorkspaceApi.list.mockReturnValueOnce(
+        new Promise((resolve) => {
+          resolveList = resolve
+        })
+      )
+      const store = useTeamWorkspaceStore()
+
+      const firstInitialization = store.initialize()
+      const secondInitialization = store.initialize()
+      await vi.waitFor(() =>
+        expect(mockWorkspaceApi.list).toHaveBeenCalledOnce()
+      )
+      resolveList({ workspaces: [mockPersonalWorkspace] })
+
+      await Promise.all([firstInitialization, secondInitialization])
+      expect(mockWorkspaceApi.list).toHaveBeenCalledOnce()
+      expect(store.initState).toBe('ready')
+    })
+
     it('can retry after initialization fails', async () => {
       mockWorkspaceApi.list.mockResolvedValueOnce({ workspaces: [] })
       const store = useTeamWorkspaceStore()
@@ -341,6 +368,19 @@ describe('useTeamWorkspaceStore', () => {
         expect.objectContaining({ id: mockMemberWorkspace.id })
       ])
       expect(store.activeWorkspaceId).toBe(mockMemberWorkspace.id)
+    })
+
+    it('clears cached billing rails when identity state is reset', async () => {
+      const store = useTeamWorkspaceStore()
+      await store.initialize()
+      store.setWorkspaceBillingRail(mockPersonalWorkspace.id, 'legacy_stripe')
+      expect(store.activeWorkspaceBillingRail).toBe('legacy_stripe')
+
+      store.resetForIdentityChange()
+      await store.initialize()
+
+      expect(store.activeWorkspaceId).toBe(mockPersonalWorkspace.id)
+      expect(store.activeWorkspaceBillingRail).toBeNull()
     })
 
     it('does not let a previous user initialization overwrite the next user', async () => {
@@ -434,6 +474,65 @@ describe('useTeamWorkspaceStore', () => {
       expect(
         mockWorkspaceAuthStore.clearWorkspaceContext.mock.invocationCallOrder[0]
       ).toBeLessThan(mockReload.mock.invocationCallOrder[0])
+    })
+
+    it('switches local billing context without touching workflow state', async () => {
+      mockDistributionTypes.isCloud = false
+      mockWorkspaceAuthStore.switchWorkspace.mockImplementation(
+        async (workspaceId: string) => {
+          const workspace = [mockPersonalWorkspace, mockTeamWorkspace].find(
+            ({ id }) => id === workspaceId
+          )
+          mockWorkspaceAuthStore.currentWorkspace = workspace ?? null
+        }
+      )
+      const store = useTeamWorkspaceStore()
+      await store.initialize()
+      store.setWorkspaceBillingRail(mockPersonalWorkspace.id, 'legacy_stripe')
+      expect(store.activeWorkspaceBillingRail).toBe('legacy_stripe')
+
+      await store.switchWorkspace(mockTeamWorkspace.id)
+
+      expect(mockWorkspaceAuthStore.switchWorkspace).toHaveBeenLastCalledWith(
+        mockTeamWorkspace.id
+      )
+      expect(store.activeWorkspaceId).toBe(mockTeamWorkspace.id)
+      expect(mockPrepareWorkflowWorkspaceTransition).not.toHaveBeenCalled()
+      expect(
+        mockWorkspaceAuthStore.clearWorkspaceContext
+      ).not.toHaveBeenCalled()
+      expect(mockReload).not.toHaveBeenCalled()
+      expect(store.isSwitching).toBe(false)
+      expect(store.activeWorkspaceBillingRail).toBeNull()
+
+      store.setWorkspaceBillingRail(mockTeamWorkspace.id, 'metronome')
+      expect(store.activeWorkspaceBillingRail).toBe('metronome')
+    })
+
+    it('rejects an overlapping local switch', async () => {
+      mockDistributionTypes.isCloud = false
+      const store = useTeamWorkspaceStore()
+      await store.initialize()
+
+      let finishSwitch: () => void = () => {}
+      mockWorkspaceAuthStore.switchWorkspace.mockImplementationOnce(
+        () =>
+          new Promise<void>((resolve) => {
+            finishSwitch = () => {
+              mockWorkspaceAuthStore.currentWorkspace = mockTeamWorkspace
+              resolve()
+            }
+          })
+      )
+
+      const firstSwitch = store.switchWorkspace(mockTeamWorkspace.id)
+      await expect(
+        store.switchWorkspace(mockMemberWorkspace.id)
+      ).rejects.toThrow('Workspace switch already in progress')
+      finishSwitch()
+      await firstSwitch
+
+      expect(store.activeWorkspaceId).toBe(mockTeamWorkspace.id)
     })
 
     it('sets isSwitching flag during operation', async () => {
@@ -556,6 +655,24 @@ describe('useTeamWorkspaceStore', () => {
       const handled = store.forgetRevokedActiveWorkspace('some-other-workspace')
 
       expect(handled).toBe(false)
+      expect(mockReload).not.toHaveBeenCalled()
+    })
+
+    it('falls back locally without clearing workflow state or reloading', async () => {
+      mockDistributionTypes.isCloud = false
+      mockWorkspaceAuthStore.initializeFromSession.mockReturnValue(true)
+      mockWorkspaceAuthStore.currentWorkspace = mockTeamWorkspace
+      const store = useTeamWorkspaceStore()
+      await store.initialize()
+
+      expect(store.forgetRevokedActiveWorkspace(mockTeamWorkspace.id)).toBe(
+        true
+      )
+      expect(store.activeWorkspaceId).toBe(mockPersonalWorkspace.id)
+      expect(store.workspaces.map(({ id }) => id)).not.toContain(
+        mockTeamWorkspace.id
+      )
+      expect(mockPrepareWorkflowWorkspaceTransition).not.toHaveBeenCalled()
       expect(mockReload).not.toHaveBeenCalled()
     })
   })

--- a/src/platform/workspace/stores/teamWorkspaceStore.ts
+++ b/src/platform/workspace/stores/teamWorkspaceStore.ts
@@ -2,6 +2,7 @@ import { defineStore } from 'pinia'
 import { computed, ref, shallowRef } from 'vue'
 
 import { useCurrentUser } from '@/composables/auth/useCurrentUser'
+import { isCloud } from '@/platform/distribution/types'
 import { WORKSPACE_STORAGE_KEYS } from '@/platform/workspace/workspaceConstants'
 import { clearPreservedQuery } from '@/platform/navigation/preservedQueryManager'
 import { PRESERVED_QUERY_NAMESPACES } from '@/platform/navigation/preservedQueryNamespaces'
@@ -139,6 +140,7 @@ export const useTeamWorkspaceStore = defineStore('teamWorkspace', () => {
   const isSwitching = ref(false)
   const isFetchingWorkspaces = ref(false)
   let identityGeneration = 0
+  let initializationPromise: Promise<void> | null = null
 
   function isStaleIdentity(generation: number): boolean {
     return generation !== identityGeneration
@@ -263,10 +265,7 @@ export const useTeamWorkspaceStore = defineStore('teamWorkspace', () => {
    * Retries on transient failures with exponential backoff.
    * Call once on app boot.
    */
-  async function initialize(): Promise<void> {
-    if (initState.value !== 'uninitialized' && initState.value !== 'error')
-      return
-
+  async function performInitialization(): Promise<void> {
     const generation = identityGeneration
     initState.value = 'loading'
     isFetchingWorkspaces.value = true
@@ -310,7 +309,7 @@ export const useTeamWorkspaceStore = defineStore('teamWorkspace', () => {
           }
 
           // Session workspace not found (deleted/access revoked) - fallback to default
-          clearWorkflowRestoreState()
+          if (isCloud) clearWorkflowRestoreState()
           workspaceAuthStore.clearWorkspaceContext()
 
           const personal = workspaces.value.find((w) => w.type === 'personal')
@@ -391,6 +390,25 @@ export const useTeamWorkspaceStore = defineStore('teamWorkspace', () => {
     isFetchingWorkspaces.value = false
   }
 
+  function initialize(): Promise<void> {
+    if (initializationPromise) return initializationPromise
+    if (initState.value !== 'uninitialized' && initState.value !== 'error') {
+      return Promise.resolve()
+    }
+
+    const promise = performInitialization()
+    initializationPromise = promise
+    void promise.then(
+      () => {
+        if (initializationPromise === promise) initializationPromise = null
+      },
+      () => {
+        if (initializationPromise === promise) initializationPromise = null
+      }
+    )
+    return promise
+  }
+
   /**
    * Re-fetch workspaces from API without changing active workspace.
    */
@@ -417,6 +435,18 @@ export const useTeamWorkspaceStore = defineStore('teamWorkspace', () => {
     const revoked = workspaces.value.find((w) => w.id === workspaceId)
     if (revoked?.type === 'personal') return true
 
+    if (!isCloud) {
+      const personal = workspaces.value.find((w) => w.type === 'personal')
+      workspaces.value = workspaces.value.filter((w) => w.id !== workspaceId)
+      mutableActiveWorkspaceId.value = personal?.id ?? null
+      if (personal) {
+        setLastWorkspaceId(personal.id)
+      } else {
+        clearLastWorkspaceId()
+      }
+      return true
+    }
+
     prepareWorkflowWorkspaceTransition()
     clearLastWorkspaceId()
     window.location.reload()
@@ -429,6 +459,8 @@ export const useTeamWorkspaceStore = defineStore('teamWorkspace', () => {
    */
   async function switchWorkspace(workspaceId: string): Promise<void> {
     if (workspaceId === activeWorkspaceId.value) return
+    if (!isCloud && isSwitching.value)
+      throw new Error('Workspace switch already in progress')
 
     const generation = identityGeneration
     const workspaceAuthStore = useWorkspaceAuthStore()
@@ -452,7 +484,18 @@ export const useTeamWorkspaceStore = defineStore('teamWorkspace', () => {
 
       if (isStaleIdentity(generation)) return
 
-      // Clear current workspace context and persist new workspace ID
+      if (!isCloud) {
+        await workspaceAuthStore.switchWorkspace(workspaceId)
+        if (isStaleIdentity(generation)) return
+        if (workspaceAuthStore.currentWorkspace?.id !== workspaceId) {
+          throw new Error('Workspace authentication did not switch')
+        }
+        mutableActiveWorkspaceId.value = workspaceId
+        setLastWorkspaceId(workspaceId)
+        isSwitching.value = false
+        return
+      }
+
       prepareWorkflowWorkspaceTransition()
       workspaceAuthStore.clearWorkspaceContext()
       setLastWorkspaceId(workspaceId)
@@ -858,9 +901,11 @@ export const useTeamWorkspaceStore = defineStore('teamWorkspace', () => {
 
   function resetForIdentityChange(): void {
     identityGeneration++
+    initializationPromise = null
     initState.value = 'uninitialized'
     workspaces.value = []
     mutableActiveWorkspaceId.value = null
+    billingRailByWorkspaceId.value = {}
     error.value = null
     isCreating.value = false
     isDeleting.value = false

--- a/src/platform/workspace/stores/useWorkspaceAuth.test.ts
+++ b/src/platform/workspace/stores/useWorkspaceAuth.test.ts
@@ -22,6 +22,12 @@ const mockCurrentUser = vi.hoisted((): { value: { uid: string } | null } => ({
 const mockForgetRevokedActiveWorkspace = vi.fn()
 const mockPrepareWorkflowWorkspaceTransition = vi.hoisted(() => vi.fn())
 const mockReload = vi.fn()
+const mockDistributionTypes = vi.hoisted(() => ({ isCloud: true }))
+const mockTeamWorkspaceState = vi.hoisted(() => ({
+  activeWorkspaceId: null as string | null
+}))
+
+vi.mock('@/platform/distribution/types', () => mockDistributionTypes)
 
 vi.mock('@/stores/authStore', () => ({
   useAuthStore: () => ({
@@ -35,7 +41,10 @@ vi.mock('@/stores/authStore', () => ({
 
 vi.mock('@/platform/workspace/stores/teamWorkspaceStore', () => ({
   useTeamWorkspaceStore: () => ({
-    forgetRevokedActiveWorkspace: mockForgetRevokedActiveWorkspace
+    forgetRevokedActiveWorkspace: mockForgetRevokedActiveWorkspace,
+    get activeWorkspaceId() {
+      return mockTeamWorkspaceState.activeWorkspaceId
+    }
   })
 }))
 
@@ -59,6 +68,10 @@ vi.mock('@/scripts/api', () => ({
   api: {
     apiURL: (route: string) => `https://api.example.com/api${route}`
   }
+}))
+
+vi.mock('@/platform/workspace/api/workspaceApiUrl', () => ({
+  workspaceApiUrl: (route: string) => `https://api.example.com/api${route}`
 }))
 
 vi.mock('@/i18n', () => ({
@@ -102,6 +115,8 @@ function expectedExpiresAtMs(expiresAt: string): string {
 
 describe('useWorkspaceAuthStore', () => {
   beforeEach(() => {
+    mockDistributionTypes.isCloud = true
+    mockTeamWorkspaceState.activeWorkspaceId = null
     vi.stubGlobal('location', {
       reload: mockReload,
       origin: 'http://localhost'
@@ -1122,6 +1137,37 @@ describe('useWorkspaceAuthStore', () => {
 
       expect(token).toBe('token-workspace-123')
       expect(mockFetch).toHaveBeenCalledTimes(2)
+    })
+
+    it('does not restore a stale local selection after another switch completes', async () => {
+      mockDistributionTypes.isCloud = false
+      mockTeamWorkspaceState.activeWorkspaceId = 'workspace-123'
+      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      const mockFetch = vi.fn().mockImplementation((_url, options) => {
+        const { workspace_id: workspaceId } = JSON.parse(options.body)
+        if (workspaceId === 'workspace-other') {
+          mockTeamWorkspaceState.activeWorkspaceId = workspaceId
+        }
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              ...mockTokenResponse,
+              token: `token-${workspaceId}`,
+              workspace: { ...mockWorkspace, id: workspaceId }
+            })
+        })
+      })
+      vi.stubGlobal('fetch', mockFetch)
+
+      const store = useWorkspaceAuthStore()
+      const switchPromise = store.switchWorkspace('workspace-other')
+      const token = await store.ensureWorkspaceToken('workspace-123')
+      await switchPromise
+
+      expect(token).toBeNull()
+      expect(store.currentWorkspace?.id).toBe('workspace-other')
+      expect(mockFetch).toHaveBeenCalledOnce()
     })
   })
 

--- a/src/platform/workspace/stores/workspaceAuthStore.ts
+++ b/src/platform/workspace/stores/workspaceAuthStore.ts
@@ -12,12 +12,13 @@ import {
 } from '@/platform/workspace/workspaceConstants'
 import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
 import { useToastStore } from '@/platform/updates/common/toastStore'
-import { api } from '@/scripts/api'
 import { useAuthStore } from '@/stores/authStore'
 import type { AuthHeader } from '@/types/authTypes'
 import { parseErrorResponse } from '@/platform/remote/comfyui/errors'
 import type { WorkspaceIdentity } from '@/platform/workspace/workspaceTypes'
 import { useFeatureFlags } from '@/composables/useFeatureFlags'
+import { isCloud } from '@/platform/distribution/types'
+import { workspaceApiUrl } from '@/platform/workspace/api/workspaceApiUrl'
 
 // Picked off the generated schema: a hand-written enum that lags the spec would
 // reject a valid persisted identity and silently clear the session.
@@ -356,7 +357,7 @@ export const useWorkspaceAuthStore = defineStore('workspaceAuth', () => {
       )
     }
 
-    const response = await fetch(api.apiURL('/auth/token'), {
+    const response = await fetch(workspaceApiUrl('/auth/token'), {
       method: 'POST',
       headers: {
         Authorization: `Bearer ${firebaseToken}`,
@@ -533,9 +534,10 @@ export const useWorkspaceAuthStore = defineStore('workspaceAuth', () => {
     err: unknown,
     failedWorkspaceId?: string
   ): void {
+    let invalidSelectionHandled = false
     if (isPermanentRecoveryFailure(err)) {
       const hadContext = currentWorkspace.value !== null
-      endWorkspaceSession(
+      invalidSelectionHandled = endWorkspaceSession(
         failedWorkspaceId && isWorkspaceSelectionInvalid(err)
           ? failedWorkspaceId
           : undefined
@@ -544,7 +546,7 @@ export const useWorkspaceAuthStore = defineStore('workspaceAuth', () => {
         surfacePermanentAuthError(err)
       }
     }
-    startRecoveryCooldown()
+    if (!invalidSelectionHandled) startRecoveryCooldown()
     console.warn('Workspace auth recovery failed:', err)
   }
 
@@ -570,10 +572,19 @@ export const useWorkspaceAuthStore = defineStore('workspaceAuth', () => {
       if (inFlightSwitchPromise) {
         await inFlightSwitchPromise.catch(() => {})
         if (!isCurrentUser(ownerUid)) return null
+        if (!isCloud && currentWorkspace.value?.id !== targetWorkspaceId) {
+          return null
+        }
         continue
       }
 
       if (!targetWorkspaceId || Date.now() < recoveryCooldownUntil) {
+        return null
+      }
+      if (
+        !isCloud &&
+        useTeamWorkspaceStore().activeWorkspaceId !== targetWorkspaceId
+      ) {
         return null
       }
 
@@ -965,9 +976,9 @@ export const useWorkspaceAuthStore = defineStore('workspaceAuth', () => {
     clearUnifiedContext()
   }
 
-  function endWorkspaceSession(revokedWorkspaceId?: string): void {
+  function endWorkspaceSession(revokedWorkspaceId?: string): boolean {
     const hadContext = currentWorkspace.value !== null
-    if (hadContext) prepareWorkflowWorkspaceTransition()
+    if (isCloud && hadContext) prepareWorkflowWorkspaceTransition()
     const revokedWorkspaceHandled = revokedWorkspaceId
       ? useTeamWorkspaceStore().forgetRevokedActiveWorkspace(revokedWorkspaceId)
       : false
@@ -975,9 +986,10 @@ export const useWorkspaceAuthStore = defineStore('workspaceAuth', () => {
     const shouldReload = revokedWorkspaceId
       ? !revokedWorkspaceHandled
       : hadContext
-    if (shouldReload) {
+    if (isCloud && shouldReload) {
       window.location.reload()
     }
+    return !isCloud && revokedWorkspaceHandled
   }
 
   return {

--- a/src/scripts/app.test.ts
+++ b/src/scripts/app.test.ts
@@ -69,7 +69,7 @@ const {
     getApiKey: vi.fn()
   },
   mockAuthStore: {
-    getAuthToken: vi.fn()
+    getWorkspaceAuthToken: vi.fn()
   },
   mockSettingStore: {
     get: vi.fn()
@@ -225,11 +225,12 @@ function createTestFile(name: string, type: string): File {
  * Point the workflowService mock at the real implementation for tests that
  * exercise the load lifecycle itself rather than app.ts's calls into it.
  */
+const actualWorkflowService = await vi.importActual<
+  typeof import('@/platform/workflow/core/services/workflowService')
+>('@/platform/workflow/core/services/workflowService')
+
 async function useRealWorkflowService(): Promise<WorkflowService> {
-  const actual = await vi.importActual<
-    typeof import('@/platform/workflow/core/services/workflowService')
-  >('@/platform/workflow/core/services/workflowService')
-  const real = actual.useWorkflowService()
+  const real = actualWorkflowService.useWorkflowService()
   mockWorkflowService.beforeLoadNewGraph.mockImplementation(
     real.beforeLoadNewGraph
   )
@@ -282,7 +283,7 @@ describe('ComfyApp', () => {
       return workflow
     })
     mockApiKeyAuthStore.getApiKey.mockReturnValue(undefined)
-    mockAuthStore.getAuthToken.mockResolvedValue(undefined)
+    mockAuthStore.getWorkspaceAuthToken.mockResolvedValue(undefined)
     mockExtensionService.invokeExtensions.mockReturnValue([])
     mockExtensionService.invokeExtensionsAsync.mockResolvedValue(undefined)
     vi.mocked(extractFilesFromDragEvent).mockResolvedValue([])
@@ -310,6 +311,32 @@ describe('ComfyApp', () => {
       })
       vi.spyOn(api, 'dispatchCustomEvent').mockImplementation(() => true)
     }
+
+    it('waits for workspace authentication before submitting the prompt', async () => {
+      prepareEmptyPromptQueue()
+      let resolveToken: (token: string) => void = () => {}
+      mockAuthStore.getWorkspaceAuthToken.mockReturnValueOnce(
+        new Promise((resolve) => {
+          resolveToken = resolve
+        })
+      )
+      const queuePrompt = vi
+        .spyOn(api, 'queuePrompt')
+        .mockImplementation(() => {
+          expect(api.authToken).toBe('workspace-token')
+          return Promise.resolve({ prompt_id: 'job-1', error: '' })
+        })
+
+      const submission = app.queuePrompt(0)
+      await vi.waitFor(() =>
+        expect(mockAuthStore.getWorkspaceAuthToken).toHaveBeenCalledOnce()
+      )
+      expect(queuePrompt).not.toHaveBeenCalled()
+
+      resolveToken('workspace-token')
+      await expect(submission).resolves.toBe(true)
+      expect(queuePrompt).toHaveBeenCalledOnce()
+    })
 
     it('preserves missing node packs when submitting a prompt', async () => {
       prepareEmptyPromptQueue()

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -1640,7 +1640,7 @@ export class ComfyApp {
     let queueResultOverride: boolean | null = null
 
     // Get auth token for backend nodes - uses workspace token if enabled, otherwise Firebase token
-    const comfyOrgAuthToken = await useAuthStore().getAuthToken()
+    const comfyOrgAuthToken = await useAuthStore().getWorkspaceAuthToken()
     const comfyOrgApiKey = useApiKeyAuthStore().getApiKey()
 
     try {

--- a/src/services/customerEventsService.test.ts
+++ b/src/services/customerEventsService.test.ts
@@ -13,7 +13,7 @@ const mockAxiosInstance = vi.hoisted(() => ({
 }))
 
 const mockAuthStore = vi.hoisted(() => ({
-  getAuthHeader: vi.fn()
+  getFirebaseAuthHeader: vi.fn()
 }))
 
 const mockI18n = vi.hoisted(() => ({
@@ -80,8 +80,7 @@ describe('useCustomerEventsService', () => {
   }
 
   beforeEach(() => {
-    // Setup default mocks
-    mockAuthStore.getAuthHeader.mockResolvedValue(mockAuthHeaders)
+    mockAuthStore.getFirebaseAuthHeader.mockResolvedValue(mockAuthHeaders)
     mockI18n.d.mockImplementation((date, options) => {
       // Mock i18n date formatting
       if (options?.month === 'short') {
@@ -118,7 +117,7 @@ describe('useCustomerEventsService', () => {
         limit: 10
       })
 
-      expect(mockAuthStore.getAuthHeader).toHaveBeenCalled()
+      expect(mockAuthStore.getFirebaseAuthHeader).toHaveBeenCalled()
       expect(mockAxiosInstance.get).toHaveBeenCalledWith('/customers/events', {
         params: { page: 1, limit: 10 },
         headers: mockAuthHeaders
@@ -141,7 +140,7 @@ describe('useCustomerEventsService', () => {
     })
 
     it('should return null when auth headers are missing', async () => {
-      mockAuthStore.getAuthHeader.mockResolvedValue(null)
+      mockAuthStore.getFirebaseAuthHeader.mockResolvedValue(null)
 
       const result = await service.getMyEvents()
 

--- a/src/services/customerEventsService.ts
+++ b/src/services/customerEventsService.ts
@@ -190,8 +190,7 @@ export const useCustomerEventsService = () => {
       404: 'Not found'
     }
 
-    // Get auth headers
-    const authHeaders = await useAuthStore().getAuthHeader()
+    const authHeaders = await useAuthStore().getFirebaseAuthHeader()
     if (!authHeaders) {
       error.value = 'Authentication header is missing'
       return null

--- a/src/stores/__tests__/authTokenPriority.test.ts
+++ b/src/stores/__tests__/authTokenPriority.test.ts
@@ -20,16 +20,22 @@ const { mockDistributionTypes } = vi.hoisted(() => ({
 
 const mockWorkspaceAuthHeader = vi.fn().mockReturnValue(null)
 const mockGetWorkspaceToken = vi.fn().mockReturnValue(undefined)
+const mockEnsureWorkspaceAuthHeader = vi.fn()
+const mockEnsureWorkspaceToken = vi.fn()
 const mockClearWorkspaceContext = vi.fn()
 const mockMintAtLogin = vi.fn().mockResolvedValue(false)
 let mockUnifiedToken: string | null = null
 const mockResetForIdentityChange = vi.fn()
+const mockInitializeWorkspaces = vi.fn().mockResolvedValue(undefined)
 let mockActiveWorkspaceId: string | null = null
+let mockTeamWorkspaceInitState = 'ready'
 
 vi.mock('@/platform/workspace/stores/workspaceAuthStore', () => ({
   useWorkspaceAuthStore: () => ({
     getWorkspaceAuthHeader: mockWorkspaceAuthHeader,
     getWorkspaceToken: mockGetWorkspaceToken,
+    ensureWorkspaceAuthHeader: mockEnsureWorkspaceAuthHeader,
+    ensureWorkspaceToken: mockEnsureWorkspaceToken,
     getUnifiedToken: () => mockUnifiedToken ?? undefined,
     clearWorkspaceContext: mockClearWorkspaceContext,
     mintAtLogin: mockMintAtLogin,
@@ -44,6 +50,10 @@ vi.mock('@/platform/workspace/stores/teamWorkspaceStore', () => ({
     get activeWorkspaceId() {
       return mockActiveWorkspaceId
     },
+    get initState() {
+      return mockTeamWorkspaceInitState
+    },
+    initialize: mockInitializeWorkspaces,
     resetForIdentityChange: mockResetForIdentityChange
   })
 }))
@@ -128,9 +138,13 @@ describe('auth token priority chain', () => {
     mockFeatureFlags.unifiedCloudAuthEnabled = false
     mockUnifiedToken = null
     mockActiveWorkspaceId = null
+    mockTeamWorkspaceInitState = 'ready'
     mockWorkspaceAuthHeader.mockReturnValue(null)
     mockGetWorkspaceToken.mockReturnValue(undefined)
+    mockEnsureWorkspaceAuthHeader.mockResolvedValue(null)
+    mockEnsureWorkspaceToken.mockResolvedValue(null)
     mockMintAtLogin.mockResolvedValue(false)
+    mockInitializeWorkspaces.mockResolvedValue(undefined)
     mockApiKeyGetAuthHeader.mockReturnValue(null)
     mockUser.getIdToken.mockResolvedValue('firebase-token')
 
@@ -185,6 +199,19 @@ describe('auth token priority chain', () => {
       })
     })
 
+    it('keeps generic authentication user-scoped outside Cloud', async () => {
+      mockDistributionTypes.isCloud = false
+      mockActiveWorkspaceId = 'workspace-123'
+      mockEnsureWorkspaceAuthHeader.mockResolvedValue({
+        Authorization: 'Bearer workspace-token'
+      })
+
+      const header = await store.getAuthHeader()
+
+      expect(mockEnsureWorkspaceAuthHeader).not.toHaveBeenCalled()
+      expect(header).toEqual({ Authorization: 'Bearer firebase-token' })
+    })
+
     it('returns API key when neither workspace nor Firebase are available', async () => {
       authStateCallback(null)
       mockApiKeyGetAuthHeader.mockReturnValue({ 'X-API-KEY': 'test-key' })
@@ -218,6 +245,99 @@ describe('auth token priority chain', () => {
       const token = await store.getAuthToken()
 
       expect(token).toBe('firebase-token')
+    })
+
+    it('keeps generic tokens user-scoped outside Cloud', async () => {
+      mockDistributionTypes.isCloud = false
+      mockActiveWorkspaceId = 'workspace-123'
+      mockEnsureWorkspaceToken.mockResolvedValue('workspace-raw-token')
+
+      const token = await store.getAuthToken()
+
+      expect(mockEnsureWorkspaceToken).not.toHaveBeenCalled()
+      expect(token).toBe('firebase-token')
+    })
+  })
+
+  describe('explicit workspace authentication', () => {
+    it('uses selected workspace authentication outside Cloud', async () => {
+      mockDistributionTypes.isCloud = false
+      mockActiveWorkspaceId = 'workspace-123'
+      mockEnsureWorkspaceAuthHeader.mockResolvedValue({
+        Authorization: 'Bearer workspace-token'
+      })
+      mockEnsureWorkspaceToken.mockResolvedValue('workspace-raw-token')
+
+      await expect(store.getWorkspaceAuthHeader()).resolves.toEqual({
+        Authorization: 'Bearer workspace-token'
+      })
+      await expect(store.getWorkspaceAuthToken()).resolves.toBe(
+        'workspace-raw-token'
+      )
+      expect(mockEnsureWorkspaceAuthHeader).toHaveBeenCalledWith(
+        'workspace-123'
+      )
+      expect(mockEnsureWorkspaceToken).toHaveBeenCalledWith('workspace-123')
+    })
+
+    it('waits for workspace initialization before queue authentication', async () => {
+      mockDistributionTypes.isCloud = false
+      mockTeamWorkspaceInitState = 'uninitialized'
+      mockInitializeWorkspaces.mockImplementation(async () => {
+        mockActiveWorkspaceId = 'workspace-123'
+        mockTeamWorkspaceInitState = 'ready'
+      })
+      mockEnsureWorkspaceToken.mockResolvedValue('workspace-raw-token')
+
+      await expect(store.getWorkspaceAuthHeader()).resolves.toEqual({
+        Authorization: 'Bearer firebase-token'
+      })
+      await expect(store.getWorkspaceAuthToken()).resolves.toBe(
+        'workspace-raw-token'
+      )
+      expect(mockInitializeWorkspaces).toHaveBeenCalledOnce()
+      expect(mockEnsureWorkspaceToken).toHaveBeenCalledWith('workspace-123')
+    })
+
+    it('waits for an in-flight workspace selection before queue authentication', async () => {
+      mockDistributionTypes.isCloud = false
+      mockTeamWorkspaceInitState = 'loading'
+      mockInitializeWorkspaces.mockImplementation(async () => {
+        mockActiveWorkspaceId = 'workspace-123'
+        mockTeamWorkspaceInitState = 'ready'
+      })
+      mockEnsureWorkspaceToken.mockResolvedValue('workspace-raw-token')
+
+      await expect(store.getWorkspaceAuthToken()).resolves.toBe(
+        'workspace-raw-token'
+      )
+      expect(mockUser.getIdToken).not.toHaveBeenCalled()
+    })
+
+    it('fails queue authentication closed after workspace initialization errors', async () => {
+      mockDistributionTypes.isCloud = false
+      mockTeamWorkspaceInitState = 'uninitialized'
+      mockInitializeWorkspaces.mockRejectedValue(new Error('Network error'))
+
+      await expect(store.getWorkspaceAuthToken()).resolves.toBeUndefined()
+      expect(mockUser.getIdToken).not.toHaveBeenCalled()
+      expect(mockEnsureWorkspaceToken).not.toHaveBeenCalled()
+    })
+
+    it('retries queue authentication after a previous initialization error', async () => {
+      mockDistributionTypes.isCloud = false
+      mockTeamWorkspaceInitState = 'error'
+      mockInitializeWorkspaces.mockImplementation(async () => {
+        mockActiveWorkspaceId = 'workspace-123'
+        mockTeamWorkspaceInitState = 'ready'
+      })
+      mockEnsureWorkspaceToken.mockResolvedValue('workspace-raw-token')
+
+      await expect(store.getWorkspaceAuthToken()).resolves.toBe(
+        'workspace-raw-token'
+      )
+      expect(mockInitializeWorkspaces).toHaveBeenCalledOnce()
+      expect(mockEnsureWorkspaceToken).toHaveBeenCalledWith('workspace-123')
     })
   })
 

--- a/src/stores/authStore.test.ts
+++ b/src/stores/authStore.test.ts
@@ -1192,22 +1192,15 @@ describe('useAuthStore', () => {
       })
     })
 
-    it('should succeed with API key auth when no Firebase user is present', async () => {
+    it('should reject API key auth when no Firebase user is present', async () => {
       authStateCallback(null)
       mockApiKeyGetAuthHeader.mockReturnValue({ 'X-API-KEY': 'test-api-key' })
 
-      const result = await store.createCustomer()
-
-      expect(mockFetch).toHaveBeenCalledWith(
-        expect.stringContaining('/customers'),
-        expect.objectContaining({
-          method: 'POST',
-          headers: expect.objectContaining({
-            'X-API-KEY': 'test-api-key'
-          })
-        })
-      )
-      expect(result).toEqual({ id: 'test-customer-id' })
+      await expect(store.createCustomer()).rejects.toMatchObject({
+        name: 'AuthStoreError',
+        message: 'toastMessages.userNotAuthenticated'
+      })
+      expect(mockFetch).not.toHaveBeenCalled()
     })
 
     it('should use Firebase token when Firebase user is present', async () => {

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -255,16 +255,14 @@ export const useAuthStore = defineStore('auth', () => {
       return token ? { Authorization: `Bearer ${token}` } : null
     }
 
+    const workspaceAuth = useWorkspaceAuthStore()
+    const activeWorkspaceId = useTeamWorkspaceStore().activeWorkspaceId
+
+    if (isCloud && activeWorkspaceId) {
+      return workspaceAuth.ensureWorkspaceAuthHeader(activeWorkspaceId)
+    }
+
     if (isCloud) {
-      const workspaceAuth = useWorkspaceAuthStore()
-      const activeWorkspaceId = useTeamWorkspaceStore().activeWorkspaceId
-
-      // Recover the workspace token rather than downgrade to the personal
-      // identity, which is what makes cloud requests oscillate.
-      if (activeWorkspaceId) {
-        return workspaceAuth.ensureWorkspaceAuthHeader(activeWorkspaceId)
-      }
-
       const wsHeader = workspaceAuth.getWorkspaceAuthHeader()
       if (wsHeader) return wsHeader
     }
@@ -288,10 +286,21 @@ export const useAuthStore = defineStore('auth', () => {
     return token ? { Authorization: `Bearer ${token}` } : null
   }
 
+  const getWorkspaceAuthHeader = async (): Promise<AuthHeader | null> => {
+    if (flags.unifiedCloudAuthEnabled) {
+      const token = useWorkspaceAuthStore().getUnifiedToken()
+      return token ? { Authorization: `Bearer ${token}` } : null
+    }
+
+    const activeWorkspaceId = useTeamWorkspaceStore().activeWorkspaceId
+    if (!activeWorkspaceId) return getFirebaseAuthHeader()
+    return useWorkspaceAuthStore().ensureWorkspaceAuthHeader(activeWorkspaceId)
+  }
+
   /**
    * Returns the raw auth token (not wrapped in a header object).
    * When unified_cloud_auth is enabled, returns the single Cloud JWT; otherwise
-   * priority is workspace token > Firebase token.
+   * Cloud priority is workspace token > Firebase token.
    * Use this for WebSocket connections and backend node auth.
    */
   const getAuthToken = async (): Promise<string | undefined> => {
@@ -299,23 +308,52 @@ export const useAuthStore = defineStore('auth', () => {
       return useWorkspaceAuthStore().getUnifiedToken()
     }
 
+    const workspaceAuth = useWorkspaceAuthStore()
+    const activeWorkspaceId = useTeamWorkspaceStore().activeWorkspaceId
+
+    if (isCloud && activeWorkspaceId) {
+      return (
+        (await workspaceAuth.ensureWorkspaceToken(activeWorkspaceId)) ??
+        undefined
+      )
+    }
+
     if (isCloud) {
-      const workspaceAuth = useWorkspaceAuthStore()
-      const activeWorkspaceId = useTeamWorkspaceStore().activeWorkspaceId
-
-      // Mirror getAuthHeader for WebSocket/queue auth.
-      if (activeWorkspaceId) {
-        return (
-          (await workspaceAuth.ensureWorkspaceToken(activeWorkspaceId)) ??
-          undefined
-        )
-      }
-
       const wsToken = workspaceAuth.getWorkspaceToken()
       if (wsToken) return wsToken
     }
 
     return await getIdToken()
+  }
+
+  const getWorkspaceAuthToken = async (): Promise<string | undefined> => {
+    if (flags.unifiedCloudAuthEnabled) {
+      return useWorkspaceAuthStore().getUnifiedToken()
+    }
+
+    const teamWorkspaceStore = useTeamWorkspaceStore()
+    if (
+      !isCloud &&
+      currentUser.value &&
+      !teamWorkspaceStore.activeWorkspaceId &&
+      (teamWorkspaceStore.initState === 'uninitialized' ||
+        teamWorkspaceStore.initState === 'loading' ||
+        teamWorkspaceStore.initState === 'error')
+    ) {
+      try {
+        await teamWorkspaceStore.initialize()
+      } catch {
+        return undefined
+      }
+    }
+
+    const activeWorkspaceId = teamWorkspaceStore.activeWorkspaceId
+    if (!isCloud && currentUser.value && !activeWorkspaceId) return undefined
+    if (!activeWorkspaceId) return (await getIdToken()) ?? undefined
+    return (
+      (await useWorkspaceAuthStore().ensureWorkspaceToken(activeWorkspaceId)) ??
+      undefined
+    )
   }
 
   const getAuthHeaderOrThrow = async (): Promise<AuthHeader> => {
@@ -334,11 +372,19 @@ export const useAuthStore = defineStore('auth', () => {
     return authHeader
   }
 
+  const getWorkspaceAuthHeaderOrThrow = async (): Promise<AuthHeader> => {
+    const authHeader = await getWorkspaceAuthHeader()
+    if (!authHeader) {
+      throw new AuthStoreError(t('toastMessages.userNotAuthenticated'))
+    }
+    return authHeader
+  }
+
   const fetchBalance = async (): Promise<GetCustomerBalanceResponse | null> => {
     isFetchingBalance.value = true
     const requestOwnerUid = currentUser.value?.uid ?? null
     try {
-      const authHeader = await getAuthHeader()
+      const authHeader = await getFirebaseAuthHeader()
       if (!authHeader) {
         throw new AuthStoreError(t('toastMessages.userNotAuthenticated'))
       }
@@ -385,7 +431,7 @@ export const useAuthStore = defineStore('auth', () => {
     payload?: Omit<CreateCustomerPayload, 'signup_source'>
   ): Promise<CreateCustomerResponse> => {
     const sessionUserId = currentUser.value?.uid
-    const authHeader = await getAuthHeader()
+    const authHeader = await getFirebaseAuthHeader()
     if (!authHeader) {
       throw new AuthStoreError(t('toastMessages.userNotAuthenticated'))
     }
@@ -702,7 +748,7 @@ export const useAuthStore = defineStore('auth', () => {
   const addCredits = async (
     requestBodyContent: CreditPurchasePayload
   ): Promise<CreditPurchaseResponse> => {
-    const authHeader = await getAuthHeader()
+    const authHeader = await getFirebaseAuthHeader()
     if (!authHeader) {
       throw new AuthStoreError(t('toastMessages.userNotAuthenticated'))
     }
@@ -747,7 +793,7 @@ export const useAuthStore = defineStore('auth', () => {
   const accessBillingPortal = async (
     targetTier?: BillingPortalTargetTier
   ): Promise<AccessBillingPortalResponse> => {
-    const authHeader = await getAuthHeader()
+    const authHeader = await getFirebaseAuthHeader()
     if (!authHeader) {
       throw new AuthStoreError(t('toastMessages.userNotAuthenticated'))
     }
@@ -811,7 +857,10 @@ export const useAuthStore = defineStore('auth', () => {
     getAuthHeaderOrThrow,
     getFirebaseAuthHeader,
     getFirebaseAuthHeaderOrThrow,
+    getWorkspaceAuthHeader,
+    getWorkspaceAuthHeaderOrThrow,
     getAuthToken,
+    getWorkspaceAuthToken,
     notifyTokenRefreshed
   }
 })

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -20,6 +20,7 @@ declare global {
   interface ImportMetaEnv {
     VITE_APP_VERSION?: string
     VITE_STAGING_API_BASE_URL?: string
+    VITE_STAGING_CLOUD_BASE_URL?: string
     VITE_STAGING_PLATFORM_BASE_URL?: string
   }
 


### PR DESCRIPTION
## Summary

Manual backport of #15164 to `core/1.51`, preserving the original local/Desktop credit-workspace switching behavior and regression coverage.

## Changes

- **What**: Cherry-picks squash commit `848cd39ed06a2da6fea389305cf7210a0a18c5ee` onto the current `core/1.51` tip.
- **Conflict resolution**: The commit applied cleanly; no semantic conflict edits were required. The resulting stable patch ID exactly matches the original commit (`d4910c5a0c7422e75a8e878248822032be6ab222`).

## Verification

- `pnpm test:unit <24 changed workspace switcher/auth/billing/persistence test files>`
  - 24 test files passed
  - 756 tests passed
- Push hook: `knip --cache` passed.

## Review Focus

Confirm local credit-workspace switching, workspace-auth routing, billing attribution, and local workflow persistence remain equivalent to #15164 on the 1.51 release line.
