### PR TITLE
ci: pass branch refs through env instead of interpolating into run

### DIFF
--- a/.github/workflows/pr-update-playwright-expectations.yaml
+++ b/.github/workflows/pr-update-playwright-expectations.yaml
@@ -459,6 +459,8 @@ jobs:
 
       - name: Commit updated expectations
         id: commit
+        env:
+          TARGET_BRANCH: ${{ needs.setup.outputs.branch }}
         run: |
           git config --global user.name 'github-actions'
           git config --global user.email 'github-actions@github.com'
@@ -492,8 +494,8 @@ jobs:
 
           git commit -F /tmp/commit-msg.txt
 
-          echo "Pushing to ${{ needs.setup.outputs.branch }}..."
-          git push origin ${{ needs.setup.outputs.branch }}
+          echo "Pushing to $TARGET_BRANCH..."
+          git push origin "HEAD:refs/heads/$TARGET_BRANCH"
 
           echo "✓ Commit and push successful"
 

--- a/.github/workflows/pr-update-website-screenshots.yaml
+++ b/.github/workflows/pr-update-website-screenshots.yaml
@@ -99,6 +99,8 @@ jobs:
       - name: Commit updated screenshots
         id: commit
         if: steps.update-screenshots.outcome == 'success'
+        env:
+          TARGET_BRANCH: ${{ steps.pr-info.outputs.branch }}
         run: |
           git config --global --add safe.directory "$(pwd)"
           git config --global user.name 'github-actions'
@@ -116,7 +118,7 @@ jobs:
           echo "has-changes=true" >> $GITHUB_OUTPUT
           git add apps/website/e2e/
           git commit -m "[automated] Update website screenshot expectations"
-          git push origin ${{ steps.pr-info.outputs.branch }}
+          git push origin "HEAD:refs/heads/$TARGET_BRANCH"
 
       - name: Upload test report
         uses: actions/upload-artifact@v6


### PR DESCRIPTION
Two screenshot-update workflows interpolate a PR branch ref directly into a shell command:

| File | Value |
| --- | --- |
| `pr-update-playwright-expectations.yaml` | `needs.setup.outputs.branch` |
| `pr-update-website-screenshots.yaml` | `steps.pr-info.outputs.branch` |

GitHub resolves `${{ }}` expressions before handing a `run` block to the shell. Git ref names may contain shell metacharacters, so an interpolated branch can be parsed as script text instead of passed as one argument.

## Existing convention

Other workflows already pass refs through `env` and quote them. The locale workflow was originally the third affected site in this PR, but main fixed it independently in #15979 before this rebase.

## Reachability

These jobs require a collaborator-triggered action and effectively operate on same-repository branches. This is defense in depth around `PR_GH_TOKEN`, not a remote hole.

## Change

Pass each branch through `TARGET_BRANCH`, quote the expansion, and push the checked-out commit to an explicit destination:

```sh
git push origin "HEAD:refs/heads/$TARGET_BRANCH"
```

This keeps branch data out of shell script text and avoids relying on the local checkout's branch name.

Verified after rebasing onto current `origin/main`: both workflow files parse as YAML, `git diff --check` passes, and no direct branch-expression interpolation remains in these push commands.
