### PR TITLE
test: restore extension coverage removed by the ECS migration

### DIFF
--- a/src/extensions/core/widgetInputs.test.ts
+++ b/src/extensions/core/widgetInputs.test.ts
@@ -1,5 +1,5 @@
 import { createTestingPinia } from '@pinia/testing'
-import { fromPartial } from '@total-typescript/shoehorn'
+import { fromAny, fromPartial } from '@total-typescript/shoehorn'
 import { setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -39,17 +39,25 @@ import {
   setWidgetConfig
 } from './widgetInputs'
 
+beforeEach(() => {
+  appState.configuringGraph = false
+  app.canvas.graph = null
+})
+
 /**
  * `registerExtension` is a mock, and `mockReset: true` clears its calls before
  * the first test runs — so the registered extension is captured at collection.
  */
-const widgetInputsExtension = vi.mocked(app.registerExtension).mock.calls[0][0]
+const widgetInputsExtension = vi.mocked(app.registerExtension).mock
+  .calls[0]?.[0]
+if (!widgetInputsExtension)
+  throw new Error('Comfy.WidgetInputs was not registered on import')
 
 /**
  * Applies the extension's `beforeRegisterNodeDef` to a throwaway node class.
  * `prepare` runs first, so hooks it installs are the ones the extension chains.
  */
-async function registerNodeType(
+async function applyNodeDefHooks(
   prepare?: (nodeType: typeof LGraphNode) => void
 ) {
   class TestNodeType extends LGraphNode {
@@ -122,9 +130,7 @@ describe('mergeIfValid', () => {
     // The call shape used by groupNode.ts: `config1` is supplied explicitly and
     // the "slot" is a bare object whose `widget` is the spec itself.
     const spec: InputSpec = ['INT', { min: 0, max: 100 }]
-    const output = { widget: spec } as unknown as Parameters<
-      typeof mergeIfValid
-    >[0]
+    const output: Parameters<typeof mergeIfValid>[0] = fromAny({ widget: spec })
 
     const { customConfig } = mergeIfValid(
       output,
@@ -208,7 +214,6 @@ describe('convertToInput', () => {
 describe('setWidgetConfig', () => {
   beforeEach(() => {
     setActivePinia(createTestingPinia({ stubActions: false }))
-    appState.configuringGraph = false
     widgetInputsExtension.registerCustomNodes?.(app)
   })
 
@@ -280,13 +285,12 @@ describe('setWidgetConfig', () => {
 describe('Comfy.WidgetInputs node-def hooks', () => {
   beforeEach(() => {
     setActivePinia(createTestingPinia({ stubActions: false }))
-    appState.configuringGraph = false
   })
 
   describe('onGraphConfigured', () => {
     it('resolves GET_CONFIG from the node definition, chaining the original hook', async () => {
       const original = vi.fn()
-      const TestNodeType = await registerNodeType((nodeType) => {
+      const TestNodeType = await applyNodeDefHooks((nodeType) => {
         nodeType.prototype.onGraphConfigured = original
       })
       TestNodeType.nodeData = fromPartial({
@@ -308,7 +312,7 @@ describe('Comfy.WidgetInputs node-def hooks', () => {
     })
 
     it('removes widget inputs that no longer have a backing widget', async () => {
-      const TestNodeType = await registerNodeType()
+      const TestNodeType = await applyNodeDefHooks()
       const node = new TestNodeType('Test')
       node.addInput('orphan', 'INT')
       node.inputs[0].widget = { name: 'orphan' }
@@ -321,7 +325,7 @@ describe('Comfy.WidgetInputs node-def hooks', () => {
 
   describe('onConfigure', () => {
     it('restores GET_CONFIG on pasted nodes', async () => {
-      const TestNodeType = await registerNodeType()
+      const TestNodeType = await applyNodeDefHooks()
       TestNodeType.nodeData = fromPartial({
         input: { required: { steps: ['INT', { max: 50 }] } }
       })
@@ -338,7 +342,7 @@ describe('Comfy.WidgetInputs node-def hooks', () => {
     })
 
     it('defers to onGraphConfigured while a whole graph is loading', async () => {
-      const TestNodeType = await registerNodeType()
+      const TestNodeType = await applyNodeDefHooks()
       appState.configuringGraph = true
       const node = new TestNodeType('Test')
       node.addInput('steps', 'INT')
@@ -356,7 +360,7 @@ describe('Comfy.WidgetInputs node-def hooks', () => {
     })
 
     async function targetIn(graph: LGraph) {
-      const TestNodeType = await registerNodeType()
+      const TestNodeType = await applyNodeDefHooks()
       const node = new TestNodeType('Test')
       graph.add(node)
       node.pos = [400, 400]

--- a/src/extensions/core/widgetInputs.test.ts
+++ b/src/extensions/core/widgetInputs.test.ts
@@ -1,15 +1,77 @@
 import { createTestingPinia } from '@pinia/testing'
+import { fromPartial } from '@total-typescript/shoehorn'
 import { setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { LGraph } from '@/lib/litegraph/src/litegraph'
+import { LGraph, LGraphNode, LiteGraph } from '@/lib/litegraph/src/litegraph'
+import type {
+  INodeInputSlot,
+  INodeOutputSlot
+} from '@/lib/litegraph/src/litegraph'
+import type { IBaseWidget } from '@/lib/litegraph/src/types/widgets'
+import type { ComfyNodeDef, InputSpec } from '@/schemas/nodeDefSchema'
+import { CONFIG, GET_CONFIG } from '@/services/litegraphService'
 import { useLinkStore } from '@/stores/linkStore'
 import { graphScopeOf } from '@/types/graphScopeId'
 import { toLinkId } from '@/types/linkId'
 import { toNodeId } from '@/types/nodeId'
 
-async function loadPrimitiveNode() {
-  return (await import('./widgetInputs')).PrimitiveNode
+/** `app.configuringGraph` is a getter on the real app, so route it via a ref. */
+const appState = vi.hoisted(() => ({ configuringGraph: false }))
+
+vi.mock('@/scripts/app', () => ({
+  app: {
+    canvas: { graph_mouse: [0, 0], graph: null },
+    get configuringGraph() {
+      return appState.configuringGraph
+    },
+    registerExtension: vi.fn()
+  }
+}))
+
+import { app } from '@/scripts/app'
+
+import {
+  PrimitiveNode,
+  convertToInput,
+  getWidgetConfig,
+  mergeIfValid,
+  setWidgetConfig
+} from './widgetInputs'
+
+/**
+ * `registerExtension` is a mock, and `mockReset: true` clears its calls before
+ * the first test runs — so the registered extension is captured at collection.
+ */
+const widgetInputsExtension = vi.mocked(app.registerExtension).mock.calls[0][0]
+
+/**
+ * Applies the extension's `beforeRegisterNodeDef` to a throwaway node class.
+ * `prepare` runs first, so hooks it installs are the ones the extension chains.
+ */
+async function registerNodeType(
+  prepare?: (nodeType: typeof LGraphNode) => void
+) {
+  class TestNodeType extends LGraphNode {
+    static override nodeData: LGraphNode['constructor']['nodeData']
+  }
+  prepare?.(TestNodeType)
+  await widgetInputsExtension.beforeRegisterNodeDef?.(
+    TestNodeType,
+    fromPartial<ComfyNodeDef>({}),
+    app
+  )
+  return TestNodeType
+}
+
+function widgetSlot(
+  config: InputSpec,
+  name = 'value'
+): INodeInputSlot | INodeOutputSlot {
+  return fromPartial({
+    name,
+    widget: { name, [GET_CONFIG]: () => config }
+  })
 }
 
 describe('PrimitiveNode', () => {
@@ -17,8 +79,7 @@ describe('PrimitiveNode', () => {
     setActivePinia(createTestingPinia({ stubActions: false }))
   })
 
-  it('resets itself when the store reports a link the graph cannot resolve', async () => {
-    const PrimitiveNode = await loadPrimitiveNode()
+  it('resets itself when the store reports a link the graph cannot resolve', () => {
     const graph = new LGraph()
     const node = new PrimitiveNode('Primitive')
     graph.add(node)
@@ -36,5 +97,314 @@ describe('PrimitiveNode', () => {
     node.onAfterGraphConfigured()
 
     expect(onLastDisconnect).toHaveBeenCalled()
-  }, 30_000)
+  })
+})
+
+describe('getWidgetConfig', () => {
+  it('prefers the merged CONFIG over the slot definition', () => {
+    const merged: InputSpec = ['INT', { min: 10, max: 20 }]
+    const slot = widgetSlot(['INT', { min: 0, max: 100 }])
+    slot.widget![CONFIG] = merged
+
+    expect(getWidgetConfig(slot)).toEqual(merged)
+  })
+
+  it('falls back to the slot definition, then to a wildcard', () => {
+    const declared: InputSpec = ['FLOAT', { step: 0.1 }]
+
+    expect(getWidgetConfig(widgetSlot(declared))).toEqual(declared)
+    expect(getWidgetConfig(fromPartial({ name: 'image' }))).toEqual(['*', {}])
+  })
+})
+
+describe('mergeIfValid', () => {
+  it('narrows a numeric range to the intersection and records it on the slot', () => {
+    // The call shape used by groupNode.ts: `config1` is supplied explicitly and
+    // the "slot" is a bare object whose `widget` is the spec itself.
+    const spec: InputSpec = ['INT', { min: 0, max: 100 }]
+    const output = { widget: spec } as unknown as Parameters<
+      typeof mergeIfValid
+    >[0]
+
+    const { customConfig } = mergeIfValid(
+      output,
+      ['INT', { min: 50, max: 200 }],
+      false,
+      undefined,
+      spec
+    )
+
+    expect(customConfig).toEqual({ min: 50, max: 100, step: 1 })
+    expect(output.widget![CONFIG]).toEqual(['INT', customConfig])
+  })
+
+  it('reads config1 from the slot when the caller omits it', () => {
+    const output = widgetSlot(['INT', { min: 0, max: 10 }])
+
+    const { customConfig } = mergeIfValid(output, ['INT', { min: 4, max: 10 }])
+
+    expect(customConfig).toEqual({ min: 4, max: 10, step: 1 })
+  })
+
+  it('rejects disjoint ranges without touching the slot or recreating', () => {
+    const output = widgetSlot(['INT', { min: 0, max: 10 }])
+    const recreateWidget = vi.fn()
+
+    const { customConfig } = mergeIfValid(
+      output,
+      ['INT', { min: 50, max: 60 }],
+      false,
+      recreateWidget
+    )
+
+    expect(customConfig).toEqual({})
+    expect(output.widget![CONFIG]).toBeUndefined()
+    expect(recreateWidget).not.toHaveBeenCalled()
+  })
+
+  it('recreates the widget on forceUpdate even when the merge fails', () => {
+    const output = widgetSlot(['INT', { min: 0, max: 10 }])
+    const recreateWidget = vi.fn()
+
+    mergeIfValid(output, ['INT', { min: 50, max: 60 }], true, recreateWidget)
+
+    expect(recreateWidget).toHaveBeenCalled()
+    expect(output.widget![CONFIG]).toBeUndefined()
+  })
+
+  it('clamps the recreated widget into the merged range and notifies it', () => {
+    const widget = fromPartial<IBaseWidget>({
+      value: 5,
+      options: { min: 10, max: 50 },
+      callback: vi.fn()
+    })
+    const output = widgetSlot(['INT', { min: 0, max: 50 }])
+
+    mergeIfValid(output, ['INT', { min: 10, max: 50 }], false, () => widget)
+
+    expect(widget.value).toBe(10)
+    expect(widget.callback).toHaveBeenCalledWith(10)
+  })
+})
+
+describe('convertToInput', () => {
+  it('warns and resolves the input slot hosting the widget', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const node = new LGraphNode('Target')
+    node.addInput('seed', 'INT')
+    node.addInput('steps', 'INT')
+    node.inputs[1].widget = { name: 'steps' }
+
+    expect(convertToInput(node, fromPartial({ name: 'steps' }))?.name).toBe(
+      'steps'
+    )
+    expect(convertToInput(node, fromPartial({ name: 'seed' }))).toBeUndefined()
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('remove call to convertToInput')
+    )
+  })
+})
+
+describe('setWidgetConfig', () => {
+  beforeEach(() => {
+    setActivePinia(createTestingPinia({ stubActions: false }))
+    appState.configuringGraph = false
+    widgetInputsExtension.registerCustomNodes?.(app)
+  })
+
+  /** A primitive feeding a widget-backed input, as reroute/paste leave it. */
+  function connectedPrimitive() {
+    const graph = new LGraph()
+    const target = new LGraphNode('Target')
+    graph.add(target)
+    target.addInput('value', 'INT')
+    target.inputs[0].widget = { name: 'value' }
+
+    const primitive = LiteGraph.createNode('PrimitiveNode')
+    if (!(primitive instanceof PrimitiveNode)) throw new Error('not registered')
+    graph.add(primitive)
+    primitive.connect(0, target, 0)
+
+    return { graph, primitive, slot: target.inputs[0] }
+  }
+
+  it('ignores slots that have no widget', () => {
+    const slot = fromPartial<INodeInputSlot>({ name: 'image', type: 'IMAGE' })
+
+    setWidgetConfig(slot, ['INT', {}])
+
+    expect(slot.widget).toBeUndefined()
+  })
+
+  it('publishes the config through GET_CONFIG, and drops the widget without one', () => {
+    const config: InputSpec = ['INT', { min: 0 }]
+    const slot = fromPartial<INodeInputSlot>({ widget: { name: 'value' } })
+
+    setWidgetConfig(slot, config)
+    expect(slot.widget![GET_CONFIG]!()).toEqual(config)
+
+    setWidgetConfig(slot)
+    expect(slot.widget).toBeUndefined()
+  })
+
+  it('rebuilds the upstream primitive when a config arrives', () => {
+    const { primitive, slot } = connectedPrimitive()
+    const recreateWidget = vi.spyOn(primitive, 'recreateWidget')
+
+    setWidgetConfig(slot, ['INT', { min: 0, max: 10 }])
+
+    expect(recreateWidget).toHaveBeenCalled()
+  })
+
+  it('disconnects and resets the upstream primitive when the config is dropped', () => {
+    const { graph, primitive, slot } = connectedPrimitive()
+    primitive.outputs[0].type = 'INT'
+
+    setWidgetConfig(slot, undefined)
+
+    expect(primitive.isOutputConnected(0)).toBe(false)
+    expect(primitive.outputs[0].type).toBe('*')
+    expect(graph.getNodeById(primitive.id)).toBe(primitive)
+  })
+
+  it('leaves the upstream primitive connected while the graph is configuring', () => {
+    const { primitive, slot } = connectedPrimitive()
+    appState.configuringGraph = true
+
+    setWidgetConfig(slot, undefined)
+
+    expect(primitive.isOutputConnected(0)).toBe(true)
+  })
+})
+
+describe('Comfy.WidgetInputs node-def hooks', () => {
+  beforeEach(() => {
+    setActivePinia(createTestingPinia({ stubActions: false }))
+    appState.configuringGraph = false
+  })
+
+  describe('onGraphConfigured', () => {
+    it('resolves GET_CONFIG from the node definition, chaining the original hook', async () => {
+      const original = vi.fn()
+      const TestNodeType = await registerNodeType((nodeType) => {
+        nodeType.prototype.onGraphConfigured = original
+      })
+      TestNodeType.nodeData = fromPartial({
+        input: { optional: { seed: ['INT', { min: 0, max: 8 }] } }
+      })
+
+      const node = new TestNodeType('Test')
+      node.addInput('seed', 'INT')
+      node.inputs[0].widget = { name: 'seed' }
+      node.addWidget('number', 'seed', 0, () => {})
+
+      node.onGraphConfigured?.()
+
+      expect(original).toHaveBeenCalled()
+      expect(node.inputs[0].widget![GET_CONFIG]!()).toEqual([
+        'INT',
+        { min: 0, max: 8 }
+      ])
+    })
+
+    it('removes widget inputs that no longer have a backing widget', async () => {
+      const TestNodeType = await registerNodeType()
+      const node = new TestNodeType('Test')
+      node.addInput('orphan', 'INT')
+      node.inputs[0].widget = { name: 'orphan' }
+
+      node.onGraphConfigured?.()
+
+      expect(node.inputs).toHaveLength(0)
+    })
+  })
+
+  describe('onConfigure', () => {
+    it('restores GET_CONFIG on pasted nodes', async () => {
+      const TestNodeType = await registerNodeType()
+      TestNodeType.nodeData = fromPartial({
+        input: { required: { steps: ['INT', { max: 50 }] } }
+      })
+      const node = new TestNodeType('Test')
+      node.addInput('steps', 'INT')
+      node.inputs[0].widget = { name: 'steps' }
+
+      node.onConfigure?.(fromPartial({}))
+
+      expect(node.inputs[0].widget![GET_CONFIG]!()).toEqual([
+        'INT',
+        { max: 50 }
+      ])
+    })
+
+    it('defers to onGraphConfigured while a whole graph is loading', async () => {
+      const TestNodeType = await registerNodeType()
+      appState.configuringGraph = true
+      const node = new TestNodeType('Test')
+      node.addInput('steps', 'INT')
+      node.inputs[0].widget = { name: 'steps' }
+
+      node.onConfigure?.(fromPartial({}))
+
+      expect(node.inputs[0].widget![GET_CONFIG]).toBeUndefined()
+    })
+  })
+
+  describe('onInputDblClick', () => {
+    beforeEach(() => {
+      widgetInputsExtension.registerCustomNodes?.(app)
+    })
+
+    async function targetIn(graph: LGraph) {
+      const TestNodeType = await registerNodeType()
+      const node = new TestNodeType('Test')
+      graph.add(node)
+      node.pos = [400, 400]
+      app.canvas.graph = graph
+      return node
+    }
+
+    it('ignores inputs that are neither widget-backed nor widget-typed', async () => {
+      const graph = new LGraph()
+      const node = await targetIn(graph)
+      node.addInput('image', 'IMAGE')
+
+      node.onInputDblClick?.(0, fromPartial({}))
+
+      expect(graph.nodes).toHaveLength(1)
+    })
+
+    it('attaches a titled primitive to a widget input', async () => {
+      const graph = new LGraph()
+      const node = await targetIn(graph)
+      node.addInput('seed', 'INT')
+      node.inputs[0].widget = { name: 'seed', [GET_CONFIG]: () => ['INT', {}] }
+
+      node.onInputDblClick?.(0, fromPartial({}))
+
+      const primitive = graph.nodes.find((n) => n instanceof PrimitiveNode)
+      expect(primitive).toBeDefined()
+      expect(primitive!.title).toBe('seed')
+      expect(primitive!.isOutputConnected(0)).toBe(true)
+      expect(primitive!.pos[0]).toBeLessThan(node.pos[0])
+    })
+
+    it('steps the primitive down past a node already occupying the slot', async () => {
+      const graph = new LGraph()
+      const node = await targetIn(graph)
+      node.addInput('seed', 'INT')
+      node.inputs[0].widget = { name: 'seed', [GET_CONFIG]: () => ['INT', {}] }
+
+      const blocker = new LGraphNode('Blocker')
+      graph.add(blocker)
+      blocker.pos = [0, 400]
+      blocker.size = [400, 20]
+      blocker.updateArea()
+
+      node.onInputDblClick?.(0, fromPartial({}))
+
+      const primitive = graph.nodes.find((n) => n instanceof PrimitiveNode)
+      expect(primitive!.pos[1]).toBeGreaterThan(node.pos[1])
+    })
+  })
 })

--- a/src/lib/litegraph/src/LGraphNode.propertyChanged.test.ts
+++ b/src/lib/litegraph/src/LGraphNode.propertyChanged.test.ts
@@ -4,7 +4,7 @@ import { beforeEach, describe, expect, it } from 'vitest'
 
 import type { LGraphEventMap } from './infrastructure/LGraphEventMap'
 import { LGraph, LGraphNode } from './litegraph'
-import { LGraphEventMode } from './types/globalEnums'
+import { LGraphEventMode, RenderShape } from './types/globalEnums'
 
 type PropertyChange = LGraphEventMap['node:property:changed']
 
@@ -41,6 +41,8 @@ describe('LGraphNode shell-state change events', () => {
     node.mode = LGraphEventMode.NEVER
     node.color = '#123456'
     node.bgcolor = '#654321'
+    node.shape = 'round'
+    node.showAdvanced = true
 
     expect(changes).toEqual([
       {
@@ -66,6 +68,18 @@ describe('LGraphNode shell-state change events', () => {
         property: 'bgcolor',
         oldValue: undefined,
         newValue: '#654321'
+      },
+      {
+        nodeId: node.id,
+        property: 'shape',
+        oldValue: undefined,
+        newValue: RenderShape.ROUND
+      },
+      {
+        nodeId: node.id,
+        property: 'showAdvanced',
+        oldValue: undefined,
+        newValue: true
       }
     ])
   })
@@ -90,6 +104,7 @@ describe('LGraphNode shell-state change events', () => {
   })
 
   it('does not announce flag changes, including collapse', () => {
+    // Characterizes a deliberate ECS migration divergence from main.
     const { graph, node } = attachedNode()
     const changes = observe(graph)
 
@@ -123,6 +138,7 @@ describe('LGraphNode flag serialization', () => {
   })
 
   it('keeps a cleared flag as an enumerable own key on the live node', () => {
+    // Characterizes a deliberate ECS migration divergence from main.
     const { node } = attachedNode()
 
     node.flags.collapsed = true

--- a/src/lib/litegraph/src/LGraphNode.propertyChanged.test.ts
+++ b/src/lib/litegraph/src/LGraphNode.propertyChanged.test.ts
@@ -1,0 +1,133 @@
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import type { LGraphEventMap } from './infrastructure/LGraphEventMap'
+import { LGraph, LGraphNode } from './litegraph'
+import { LGraphEventMode } from './types/globalEnums'
+
+type PropertyChange = LGraphEventMap['node:property:changed']
+
+/**
+ * Subscribes to the events the node itself produces. Nothing here fabricates a
+ * `node:property:changed` event — the assertions only see what `LGraphNode`
+ * dispatches through its graph.
+ */
+function observe(graph: LGraph) {
+  const changes: PropertyChange[] = []
+  graph.events.addEventListener('node:property:changed', (e) => {
+    changes.push(e.detail)
+  })
+  return changes
+}
+
+function attachedNode() {
+  const graph = new LGraph()
+  const node = new LGraphNode('Test Node')
+  graph.add(node)
+  return { graph, node }
+}
+
+describe('LGraphNode shell-state change events', () => {
+  beforeEach(() => {
+    setActivePinia(createTestingPinia({ stubActions: false }))
+  })
+
+  it('announces every tracked shell field with its before and after value', () => {
+    const { graph, node } = attachedNode()
+    const changes = observe(graph)
+
+    node.title = 'New Title'
+    node.mode = LGraphEventMode.NEVER
+    node.color = '#123456'
+    node.bgcolor = '#654321'
+
+    expect(changes).toEqual([
+      {
+        nodeId: node.id,
+        property: 'title',
+        oldValue: 'Test Node',
+        newValue: 'New Title'
+      },
+      {
+        nodeId: node.id,
+        property: 'mode',
+        oldValue: LGraphEventMode.ALWAYS,
+        newValue: LGraphEventMode.NEVER
+      },
+      {
+        nodeId: node.id,
+        property: 'color',
+        oldValue: undefined,
+        newValue: '#123456'
+      },
+      {
+        nodeId: node.id,
+        property: 'bgcolor',
+        oldValue: undefined,
+        newValue: '#654321'
+      }
+    ])
+  })
+
+  it('stays silent when a write does not change the value', () => {
+    const { graph, node } = attachedNode()
+    const changes = observe(graph)
+
+    node.title = 'Renamed'
+    node.title = 'Renamed'
+
+    expect(changes).toHaveLength(1)
+  })
+
+  it('still writes through when the node has no graph to announce on', () => {
+    const detached = new LGraphNode('Orphan')
+
+    expect(() => {
+      detached.title = 'Renamed'
+    }).not.toThrow()
+    expect(detached.title).toBe('Renamed')
+  })
+
+  it('does not announce flag changes, including collapse', () => {
+    const { graph, node } = attachedNode()
+    const changes = observe(graph)
+
+    node.flags.collapsed = true
+    node.collapse(true)
+    node.flags.pinned = true
+
+    expect(node.collapsed).toBe(false)
+    expect(changes).toEqual([])
+  })
+})
+
+describe('LGraphNode flag serialization', () => {
+  beforeEach(() => {
+    setActivePinia(createTestingPinia({ stubActions: false }))
+  })
+
+  it('serializes a set flag, including false, and omits an unset one', () => {
+    const { node } = attachedNode()
+
+    expect(node.serialize().flags).toEqual({})
+
+    node.flags.collapsed = true
+    expect(node.serialize().flags).toEqual({ collapsed: true })
+
+    node.flags.collapsed = false
+    expect(node.serialize().flags).toEqual({ collapsed: false })
+
+    node.flags.collapsed = undefined
+    expect(Object.keys(node.serialize().flags)).toEqual([])
+  })
+
+  it('keeps a cleared flag as an enumerable own key on the live node', () => {
+    const { node } = attachedNode()
+
+    node.flags.collapsed = true
+    node.flags.collapsed = undefined
+
+    expect(Object.keys(node.flags)).toEqual(['collapsed'])
+  })
+})


### PR DESCRIPTION
Restores unit coverage this branch removed from code that still exists. @DrJKL asked for these in #14246 ("Send them my way"), so this targets `feature/ecs-migration` rather than `main`.

Baseline for "what was covered before" is the merge base `ed091e43a6`. Nothing here is a blind port of a deleted test — the architecture changed underneath, so behaviour that differs from the merge base is pinned as the branch behaves today and called out below.

## `src/extensions/core/widgetInputs.test.ts` — 1 test to 21

The file went 46 tests to 1 while `widgetInputs.ts` went 658 to 659 lines. `getWidgetConfig`, `convertToInput`, `setWidgetConfig` and `mergeIfValid` are all still exported and still consumed by `groupNode.ts` and `rerouteNode.ts`, and `git grep -l` finds no tests for any of them anywhere on the branch.

What the replacements assert, against real collaborators rather than mocks (only `@/scripts/app` is mocked; `mergeInputSpec`, `LGraph`, `NodeInputSlot` and a really-registered `PrimitiveNode` are the production ones):

- `getWidgetConfig` — `CONFIG` wins over the slot's `GET_CONFIG`, which wins over the `['*', {}]` fallback.
- `mergeIfValid` — both real call shapes. `groupNode.ts` passes an explicit `config1` and a bare `{ widget: spec }`; `rerouteNode.ts` passes neither and lets the slot supply it. Covers range intersection, recording the merged spec back onto the slot, rejecting a disjoint merge without touching the slot, `forceUpdate` recreating anyway, and clamping the recreated widget into the merged range.
- `setWidgetConfig` — the plain-slot paths plus the `instanceof NodeSlot` path that reaches back through a real link to a real upstream `PrimitiveNode`: a config rebuilds it, dropping the config disconnects and resets it, and `app.configuringGraph` suppresses the disconnect.
- `convertToInput` — the deprecation warning and widget-name lookup.
- `beforeRegisterNodeDef` — `onGraphConfigured` (resolves `GET_CONFIG` from `nodeData`, chains onto a pre-existing prototype hook, removes widget inputs with no backing widget), `onConfigure` (restores `GET_CONFIG` on paste, defers while a whole graph is loading), and `onInputDblClick` (ignores non-widget non-`ComfyWidgets` inputs, otherwise creates a titled primitive, connects it, and steps it down past an occupied position).

### The `30_000` timeout on the surviving test

Removed — it is no longer needed, and it was never really about the assertion. It was the only per-test timeout on the branch. The test dynamically `import()`ed `./widgetInputs` inside the test body, so Vite transform time for the whole module graph was billed to the test: 3219 ms of a 5000 ms default budget. With the import hoisted to module scope (matching `widgetInputs.refreshCombo.test.ts`), all 21 tests in the file run in ~35 ms total.

## `src/lib/litegraph/src/LGraphNode.propertyChanged.test.ts` — replaces the deleted `LGraphNodeProperties.test.ts` (10 tests to 0)

`LGraphNodeProperties` is gone, but its behaviour moved into `LGraphNode.setTrackedState`, so the tests live next to their new owner. Every other `node:property:changed` test on the branch (`useErrorClearingHooks.test.ts`, `useMinimapGraph.test.ts`) dispatches a fabricated event, so nothing asserts that the producer fires at all. This subscribes to `graph.events` and asserts only on what the node itself dispatches:

- every tracked shell field (`title`, `mode`, `color`, `bgcolor`) announces with the correct `nodeId` / `property` / `oldValue` / `newValue`;
- a write that does not change the value is silent;
- a node with no graph still writes through and does not throw;
- flag mutations, including `collapse()`, announce nothing;
- `serialize().flags` keeps `true` and `false` and omits an unset flag;
- clearing a flag to `undefined` leaves it as an enumerable own key on the live `node.flags`.

### Characterised, not corrected

Three merge-base behaviours changed. All three are pinned as the branch behaves; none is asserted the old way.

1. **Same-value writes no longer emit.** `setTrackedState` returns early on `oldValue === value`. `LGraphNodeProperties` emitted unconditionally — its own test was literally named "should emit event when value is set to the same value".
2. **`flags.collapsed` no longer emits `node:property:changed`.** The merge base emitted `property: 'flags.collapsed'`; nothing does now, including `LGraphNode.collapse()`. No current listener needs it — `useMinimapGraph` filters to `mode`/`color`/`bgcolor` and `useErrorClearingHooks` to `mode` — so this is a behaviour note for extensions, not a live bug.
3. **The `flags` enumerability machinery is gone.** The merge base made a flag non-enumerable again when set back to `undefined`; now the key survives on `node.flags`. Serialization parity is intact regardless, because `serialize()` runs `flags` through `LiteGraph.cloneObject`, so `Object.keys(node.serialize().flags)` is still empty. That is the assertion that matters, and it is the one under test.

One further extension-facing note, not touched here: `BadgePosition` was dropped from the public `litegraph.ts` barrel (it was exported at `ed091e43a6`), and `node.badgePosition` is now a warning-only no-op. Worth a line on the extension breaking-change list.

## Mutation evidence

Every test was verified to be a detector: the production behaviour was perturbed so the property is violated, the file re-run, the exact failing set confirmed, then reverted and confirmed green. All 28 mutations below produced exactly the predicted failures and no others; the two files are green unmutated (21 and 6). Run twice in independent checkouts with identical results.

`src/extensions/core/widgetInputs.ts` — 21 mutations, 21 tests, every test covered:

| mutation | failures | test |
| --- | --- | --- |
| `_onFirstConnection` drops `onLastDisconnect()` on an unresolvable link | 1 | resets itself when the store reports a link the graph cannot resolve |
| `getWidgetConfig` always returns `['*', {}]` | 4 | both `getWidgetConfig` tests, plus `mergeIfValid` config1-from-slot and clamping |
| `getWidgetConfig` precedence swapped to `GET_CONFIG ?? CONFIG` | 1 | prefers the merged CONFIG over the slot definition |
| `mergeIfValid` recomputes `config1` and ignores the caller's | 1 | narrows a numeric range to the intersection |
| `mergeIfValid` never writes `CONFIG` back to the slot | 1 | narrows a numeric range to the intersection |
| `mergeIfValid` recreates unconditionally | 1 | rejects disjoint ranges without touching the slot or recreating |
| `mergeIfValid` ignores `forceUpdate` | 1 | recreates the widget on forceUpdate even when the merge fails |
| `mergeIfValid` drops the min clamp | 1 | clamps the recreated widget into the merged range |
| `setWidgetConfig` drops the `!slot.widget` guard | 1 | ignores slots that have no widget |
| `setWidgetConfig` config/no-config branches swapped | 1 | publishes the config through GET_CONFIG, and drops the widget without one |
| `setWidgetConfig` never calls `originNode.recreateWidget()` | 1 | rebuilds the upstream primitive when a config arrives |
| `setWidgetConfig` ignores `app.configuringGraph` | 1 | leaves the upstream primitive connected while the graph is configuring |
| `setWidgetConfig` never disconnects | 1 | disconnects and resets the upstream primitive when the config is dropped |
| `convertToInput` matches any widget slot | 1 | warns and resolves the input slot hosting the widget |
| `onGraphConfigured` not chained onto the original | 1 | resolves GET_CONFIG from the node definition, chaining the original hook |
| `onGraphConfigured` keeps orphan widget inputs | 1 | removes widget inputs that no longer have a backing widget |
| `onConfigure` ignores `app.configuringGraph` | 1 | defers to onGraphConfigured while a whole graph is loading |
| `onConfigure` never restores `GET_CONFIG` | 1 | restores GET_CONFIG on pasted nodes |
| `onInputDblClick` drops the non-widget guard | 1 | ignores inputs that are neither widget-backed nor widget-typed |
| `onInputDblClick` does not title the primitive | 1 | attaches a titled primitive to a widget input |
| `onInputDblClick` drops the overlap-avoidance loop | 1 | steps the primitive down past a node already occupying the slot |

`src/lib/litegraph/src/LGraphNode.ts` — 7 mutations, 6 tests, every test covered:

| mutation | failures | test |
| --- | --- | --- |
| `setTrackedState` drops the `oldValue === value` early return | 1 | stays silent when a write does not change the value |
| `setTrackedState` never triggers | 2 | announces every tracked shell field; stays silent on an unchanged write |
| `setTrackedState` payload has `oldValue`/`newValue` swapped | 1 | announces every tracked shell field with its before and after value |
| `collapse()` announces `flags.collapsed` (i.e. merge-base behaviour restored) | 1 | does not announce flag changes, including collapse |
| `serialize()` shares the live `flags` instead of cloning | 1 | serializes a set flag, including false, and omits an unset one |
| `flags` proxied to delete keys cleared to `undefined` (merge-base behaviour restored) | 1 | keeps a cleared flag as an enumerable own key on the live node |
| `setTrackedState` requires a graph (`this.graph!`) | 1 | still writes through when the node has no graph to announce on |

The two mutations marked "merge-base behaviour restored" are the interesting ones: reinstating what `main` does makes these tests fail, which is what makes them characterisation tests rather than change detectors — they are the record of what this branch deliberately changed.

Tests only. No production code is touched.
