### PR TITLE
fix: fail CLA allowlist step on API errors (FE-1721)

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -41,6 +41,7 @@ jobs:
         # For each commit emit the GitHub login when the author/committer email resolves to a GitHub account
         # otherwise fall back to the raw git name.
         run: |
+          set -o pipefail
           others=$(gh api "repos/${{ github.repository }}/pulls/${PR_NUMBER}/commits" --paginate \
             --jq '.[] | (.author.login // .commit.author.name // empty), (.committer.login // .commit.committer.name // empty)' \
             | sort -u | grep -vix "${PR_AUTHOR}" | paste -sd, -)

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -41,10 +41,12 @@ jobs:
         # For each commit emit the GitHub login when the author/committer email resolves to a GitHub account
         # otherwise fall back to the raw git name.
         run: |
-          set -o pipefail
-          others=$(gh api "repos/${{ github.repository }}/pulls/${PR_NUMBER}/commits" --paginate \
-            --jq '.[] | (.author.login // .commit.author.name // empty), (.committer.login // .commit.committer.name // empty)' \
-            | sort -u | grep -vix "${PR_AUTHOR}" | paste -sd, -)
+          if ! commit_authors=$(gh api "repos/${{ github.repository }}/pulls/${PR_NUMBER}/commits" --paginate \
+            --jq '.[] | (.author.login // .commit.author.name // empty), (.committer.login // .commit.committer.name // empty)'); then
+            echo "Failed to fetch pull request commits" >&2
+            exit 1
+          fi
+          others=$(printf '%s\n' "$commit_authors" | sort -u | grep -vix "${PR_AUTHOR}" | paste -sd, -)
           if [ -n "$others" ]; then
             echo "allowlist=${BASE_ALLOWLIST},${others}" >> "$GITHUB_OUTPUT"
           else


### PR DESCRIPTION
## Summary

Make the CLA author allowlist step fail when its GitHub API request fails while preserving pull requests with no additional co-authors.

## Changes

- **What**: Capture the commit API response before filtering, fail explicitly on API errors, and keep an empty filtered allowlist valid.

## Review Focus

Confirm API or pagination failures stop the workflow while author-only pull requests still emit the base allowlist.

Mirrors the master workflow change in [Comfy-Org/comfy-cla#1](https://github.com/Comfy-Org/comfy-cla/pull/1).

Fixes #15555