### PR TITLE
chore: enforce redundant Vitest cleanup rule

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -135,7 +135,7 @@
       "files": ["**/*.test.{ts,tsx}"],
       "rules": {
         "comfy/no-module-scope-vitest-mocks": "warn",
-        "comfy/no-redundant-vitest-cleanup": "warn"
+        "comfy/no-redundant-vitest-cleanup": "error"
       }
     },
     {

--- a/apps/website/src/components/blocks/FeaturedCarousel02.test.ts
+++ b/apps/website/src/components/blocks/FeaturedCarousel02.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment happy-dom
 import userEvent from '@testing-library/user-event'
 import { render, screen } from '@testing-library/vue'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
 
 import { prefersReducedMotion } from '../../composables/useReducedMotion'
@@ -81,10 +81,6 @@ describe('FeaturedCarousel02', () => {
     // The suite asserts exact timer boundaries (4999ms vs 5000ms), so the
     // config's shouldAdvanceTime real-time drift must stay off.
     vi.useFakeTimers({ shouldAdvanceTime: false })
-  })
-
-  afterEach(() => {
-    vi.useRealTimers()
   })
 
   it('advances after DEFAULT_AUTOPLAY_MS, honors per-slide delays, and wraps to the first slide', async () => {

--- a/packages/shared-frontend-utils/src/networkUtil.test.ts
+++ b/packages/shared-frontend-utils/src/networkUtil.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { getClientCountry, isInChina } from './networkUtil'
 
@@ -21,10 +21,6 @@ beforeEach(() => {
   vi.stubGlobal('fetch', fetchMock)
   vi.stubGlobal('navigator', { language: 'en-US' })
   fetchMock.mockReset()
-})
-
-afterEach(() => {
-  vi.useRealTimers()
 })
 
 describe('getClientCountry', () => {

--- a/packages/shared-frontend-utils/src/networkUtil.test.ts
+++ b/packages/shared-frontend-utils/src/networkUtil.test.ts
@@ -24,7 +24,6 @@ beforeEach(() => {
 })
 
 afterEach(() => {
-  vi.unstubAllGlobals()
   vi.useRealTimers()
 })
 

--- a/src/components/rightSidePanel/RightSidePanel.test.ts
+++ b/src/components/rightSidePanel/RightSidePanel.test.ts
@@ -116,7 +116,6 @@ function renderPanel(
 
 describe('RightSidePanel active tab fallback', () => {
   beforeEach(() => {
-    vi.restoreAllMocks()
     mockApp.rootGraph = null
   })
 

--- a/src/composables/auth/useRegionGate.test.ts
+++ b/src/composables/auth/useRegionGate.test.ts
@@ -1,5 +1,5 @@
 import { render, screen, waitFor } from '@testing-library/vue'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { defineComponent, h } from 'vue'
 
 import { useRegionGate } from '@/composables/auth/useRegionGate'
@@ -22,10 +22,6 @@ const currentStatus = () => screen.getByRole('status').textContent
 
 beforeEach(() => {
   detection.outcome = Promise.resolve(false)
-})
-
-afterEach(() => {
-  vi.useRealTimers()
 })
 
 describe('useRegionGate', () => {

--- a/src/composables/useCopySystemInfo.test.ts
+++ b/src/composables/useCopySystemInfo.test.ts
@@ -66,7 +66,6 @@ const cloudStats: SystemStats = {
 
 describe('useCopySystemInfo', () => {
   beforeEach(() => {
-    vi.resetAllMocks()
     distributionFlags.isCloud = false
   })
 

--- a/src/lib/litegraph/src/CanvasPointer.deviceDetection.test.ts
+++ b/src/lib/litegraph/src/CanvasPointer.deviceDetection.test.ts
@@ -25,7 +25,7 @@
  *
  * @vitest-environment jsdom
  */
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { CanvasPointer } from '@/lib/litegraph/src/CanvasPointer'
 
@@ -40,10 +40,6 @@ describe('CanvasPointer Device Detection - Efficient Timestamp-Based TDD Tests',
     vi.spyOn(performance, 'now').mockReturnValue(0)
     vi.spyOn(global, 'setTimeout')
     vi.spyOn(global, 'clearTimeout')
-  })
-
-  afterEach(() => {
-    vi.clearAllTimers()
   })
 
   describe('Initial State', () => {

--- a/src/platform/assets/utils/assetUrlUtil.test.ts
+++ b/src/platform/assets/utils/assetUrlUtil.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import type { AssetItem } from '@/platform/assets/schemas/assetSchema'
 import {
@@ -24,8 +24,6 @@ function createAsset(overrides: Partial<AssetItem> = {}): AssetItem {
 }
 
 describe('getAssetSubfolder', () => {
-  beforeEach(() => vi.clearAllMocks())
-
   it('reads the subfolder from preview_url', () => {
     const asset = createAsset({
       preview_url: '/api/view?filename=clip.webm&type=output&subfolder=vid/2026'
@@ -54,8 +52,6 @@ describe('getAssetSubfolder', () => {
 })
 
 describe('getAssetUrl', () => {
-  beforeEach(() => vi.clearAllMocks())
-
   it('includes the subfolder carried by preview_url', () => {
     const asset = createAsset({
       preview_url: '/api/view?filename=clip.webm&type=output&subfolder=vid/2026'

--- a/src/platform/cloud/onboarding/CloudLoginView.test.ts
+++ b/src/platform/cloud/onboarding/CloudLoginView.test.ts
@@ -67,7 +67,6 @@ async function renderLoginView(
 
 afterEach(() => {
   isEmbeddedWebView.value = false
-  vi.unstubAllGlobals()
 })
 
 describe('CloudLoginView', () => {

--- a/src/platform/telemetry/reportError.test.ts
+++ b/src/platform/telemetry/reportError.test.ts
@@ -28,7 +28,6 @@ const datadogLive = (live: boolean) =>
 
 describe('reportError', () => {
   beforeEach(() => {
-    vi.clearAllMocks()
     sentryLive(true)
     datadogLive(true)
   })

--- a/src/renderer/extensions/layerEditor/composables/useLayerEditorSession.test.ts
+++ b/src/renderer/extensions/layerEditor/composables/useLayerEditorSession.test.ts
@@ -1,6 +1,5 @@
 import {
   afterAll,
-  afterEach,
   beforeAll,
   beforeEach,
   describe,
@@ -147,9 +146,6 @@ beforeEach(() => {
   vi.stubGlobal('cancelAnimationFrame', (id: number) => {
     pending.delete(id)
   })
-})
-afterEach(() => {
-  vi.unstubAllGlobals()
 })
 
 function flushFrames(): Promise<void> {

--- a/src/renderer/extensions/minimap/composables/useMinimap.intervalLifecycle.test.ts
+++ b/src/renderer/extensions/minimap/composables/useMinimap.intervalLifecycle.test.ts
@@ -131,7 +131,6 @@ describe('useMinimap change-detection interval', () => {
     // onto its callbacks, so tear down before the next test builds its own.
     active?.destroy()
     active = null
-    vi.useRealTimers()
   })
 
   it('polls on the interval and redraws when the graph changed', async () => {

--- a/src/schemas/nodeDef/inputSpecUtil.test.ts
+++ b/src/schemas/nodeDef/inputSpecUtil.test.ts
@@ -1,14 +1,10 @@
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import { flattenInputSpecs } from '@/schemas/nodeDef/inputSpecUtil'
 import type { ComfyNodeDef as ComfyNodeDefV1 } from '@/schemas/nodeDefSchema'
 import { ComfyNodeDefImpl } from '@/stores/nodeDefStore'
 
 describe('flattenInputSpecs', () => {
-  afterEach(() => {
-    vi.unstubAllEnvs()
-  })
-
   it('includes a dynamic combo input alongside its nested per-option inputs', () => {
     const nodeDef: ComfyNodeDefV1 = {
       name: 'SyncLipSyncNode',

--- a/src/scripts/api.sessionOverride.test.ts
+++ b/src/scripts/api.sessionOverride.test.ts
@@ -34,7 +34,6 @@ describe('api.getServerFeature session override outside component setup', () => 
 
   afterEach(() => {
     api.serverFeatureFlags.value = {}
-    vi.restoreAllMocks()
   })
 
   it('applies a numeric override to a flag that never routes through resolveFlag', () => {

--- a/src/scripts/changeTracker.test.ts
+++ b/src/scripts/changeTracker.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
   createNestedSubgraphs,
@@ -226,10 +226,6 @@ describe('ChangeTracker', () => {
     useQueueSettingsStore().mode = 'change'
     app.ui.autoQueueEnabled = false
     app.ui.autoQueueMode = 'instant'
-  })
-
-  afterEach(() => {
-    vi.clearAllTimers()
   })
 
   describe('captureCanvasState', () => {

--- a/src/scripts/changeTracker.test.ts
+++ b/src/scripts/changeTracker.test.ts
@@ -229,7 +229,6 @@ describe('ChangeTracker', () => {
   })
 
   afterEach(() => {
-    vi.restoreAllMocks()
     vi.clearAllTimers()
   })
 

--- a/src/scripts/metadata/readFile.test.ts
+++ b/src/scripts/metadata/readFile.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it } from 'vitest'
 
 import {
   mockFileReaderAbort,
@@ -7,8 +7,6 @@ import {
 import { readFileAsArrayBuffer } from './readFile'
 
 describe('readFileAsArrayBuffer', () => {
-  afterEach(() => vi.restoreAllMocks())
-
   it('reads the whole file into an ArrayBuffer when no cap is given', async () => {
     const bytes = new Uint8Array([1, 2, 3, 4, 5])
     const file = new File([bytes], 'test.bin')

--- a/src/utils/sessionFeatureFlagOverride.test.ts
+++ b/src/utils/sessionFeatureFlagOverride.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { getSessionOverride } from '@/utils/sessionFeatureFlagOverride'
 
@@ -28,10 +28,6 @@ describe('getSessionOverride', () => {
   beforeEach(() => {
     mockDistribution.isCloud = true
     mockCurrentUser.value = COMFY_EMPLOYEE
-  })
-
-  afterEach(() => {
-    vi.restoreAllMocks()
   })
 
   it('reads a bare flag as boolean true', () => {

--- a/src/utils/videoMetadataUtil.test.ts
+++ b/src/utils/videoMetadataUtil.test.ts
@@ -1,7 +1,7 @@
 ﻿import { BufferSource } from 'mediabunny'
 import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
   clearVideoMetadataCache,
@@ -101,10 +101,6 @@ describe('snapToStandardFrameRate', () => {
 describe('fetchVideoMetadata url gating', () => {
   beforeEach(() => {
     clearVideoMetadataCache()
-  })
-
-  afterEach(() => {
-    vi.unstubAllGlobals()
   })
 
   it('extracts metadata from a trusted view url', async () => {

--- a/src/vitestSetup.test.ts
+++ b/src/vitestSetup.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 /**
  * Guards the network block installed by `vitest.setup.ts`.
@@ -9,10 +9,6 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
  * explains. Keep this covered so the guard cannot be dropped silently.
  */
 describe('unit test network guard', () => {
-  afterEach(() => {
-    vi.unstubAllGlobals()
-  })
-
   it('rejects absolute http requests instead of dialling out', async () => {
     await expect(fetch('https://example.com/thing')).rejects.toThrow(
       /Blocked a real network request/

--- a/tools/oxlint-plugins/vitestCleanup.config.json
+++ b/tools/oxlint-plugins/vitestCleanup.config.json
@@ -16,7 +16,7 @@
       ],
       "rules": {
         "comfy/no-module-scope-vitest-mocks": "warn",
-        "comfy/no-redundant-vitest-cleanup": "warn"
+        "comfy/no-redundant-vitest-cleanup": "error"
       }
     }
   ]

--- a/tools/oxlint-plugins/vitestCleanup.test.ts
+++ b/tools/oxlint-plugins/vitestCleanup.test.ts
@@ -160,6 +160,13 @@ afterEach(() => {
   vi.useRealTimers()
   vi.clearAllTimers()
 })
+
+afterAll(() => {
+  vi.useFakeTimers()
+  setTimeout(() => undefined, 1)
+  vi.clearAllTimers()
+  vi.useRealTimers()
+})
 `
 
 const unrelatedFixture = `const vi = {
@@ -247,11 +254,13 @@ describe('Vitest cleanup rules', () => {
     }
   })
 
-  it('reports timer cleanup in after hooks but allows timer setup in before hooks', () => {
+  it('reports timer cleanup in afterEach but allows setup and afterAll cleanup', () => {
     expectReportsAt(output, [145, 146])
     const plainOutput = stripVTControlCharacters(output)
     expect(plainOutput).not.toContain('invalid.test.ts:141:')
     expect(plainOutput).not.toContain('invalid.test.ts:142:')
+    expect(plainOutput).not.toContain('invalid.test.ts:152:')
+    expect(plainOutput).not.toContain('invalid.test.ts:153:')
   })
 
   it('handles aliases, namespaces, concise callbacks, and nested control flow', () => {

--- a/tools/oxlint-plugins/vitestCleanup.test.ts
+++ b/tools/oxlint-plugins/vitestCleanup.test.ts
@@ -151,6 +151,15 @@ afterAll(() => vi.unstubAllGlobals())
 suiteSetup(() => vitest.stubGlobal('suite', true))
 beforeAll(() => vi.spyOn(console, 'log'))
 Vitest.beforeAll(() => Vitest.vi.stubGlobal('suite', true))
+
+beforeEach(() => {
+  vi.useRealTimers()
+  vi.clearAllTimers()
+})
+afterEach(() => {
+  vi.useRealTimers()
+  vi.clearAllTimers()
+})
 `
 
 const unrelatedFixture = `const vi = {
@@ -236,6 +245,13 @@ describe('Vitest cleanup rules', () => {
       )
       expect(reports?.length).toBeGreaterThanOrEqual(2)
     }
+  })
+
+  it('reports timer cleanup in after hooks but allows timer setup in before hooks', () => {
+    expectReportsAt(output, [145, 146])
+    const plainOutput = stripVTControlCharacters(output)
+    expect(plainOutput).not.toContain('invalid.test.ts:141:')
+    expect(plainOutput).not.toContain('invalid.test.ts:142:')
   })
 
   it('handles aliases, namespaces, concise callbacks, and nested control flow', () => {

--- a/tools/oxlint-plugins/vitestCleanup.ts
+++ b/tools/oxlint-plugins/vitestCleanup.ts
@@ -11,7 +11,7 @@ const REDUNDANT_TIMER_CLEANUP_METHODS = new Set([
 ])
 
 const MODULE_SCOPE_MOCK_METHODS = new Set(['spyOn', 'stubGlobal'])
-const AFTER_HOOK_IMPORTS = new Set(['afterAll', 'afterEach'])
+const AFTER_EACH_IMPORTS = new Set(['afterEach'])
 const BEFORE_ALL_IMPORTS = new Set(['beforeAll'])
 const HOOK_IMPORTS = new Set([
   'afterAll',
@@ -274,7 +274,7 @@ export const noRedundantVitestCleanup = {
             (REDUNDANT_CLEANUP_METHODS.has(methodName) &&
               runsDirectlyInHook(context, node)) ||
             (REDUNDANT_TIMER_CLEANUP_METHODS.has(methodName) &&
-              runsDirectlyInHook(context, node, AFTER_HOOK_IMPORTS))
+              runsDirectlyInHook(context, node, AFTER_EACH_IMPORTS))
           )
         ) {
           return

--- a/tools/oxlint-plugins/vitestCleanup.ts
+++ b/tools/oxlint-plugins/vitestCleanup.ts
@@ -5,8 +5,13 @@ const REDUNDANT_CLEANUP_METHODS = new Set([
   'unstubAllEnvs',
   'unstubAllGlobals'
 ])
+const REDUNDANT_TIMER_CLEANUP_METHODS = new Set([
+  'clearAllTimers',
+  'useRealTimers'
+])
 
 const MODULE_SCOPE_MOCK_METHODS = new Set(['spyOn', 'stubGlobal'])
+const AFTER_HOOK_IMPORTS = new Set(['afterAll', 'afterEach'])
 const BEFORE_ALL_IMPORTS = new Set(['beforeAll'])
 const HOOK_IMPORTS = new Set([
   'afterAll',
@@ -265,14 +270,18 @@ export const noRedundantVitestCleanup = {
         const methodName = vitestMethodName(context, node)
         if (
           !methodName ||
-          !REDUNDANT_CLEANUP_METHODS.has(methodName) ||
-          !runsDirectlyInHook(context, node)
+          !(
+            (REDUNDANT_CLEANUP_METHODS.has(methodName) &&
+              runsDirectlyInHook(context, node)) ||
+            (REDUNDANT_TIMER_CLEANUP_METHODS.has(methodName) &&
+              runsDirectlyInHook(context, node, AFTER_HOOK_IMPORTS))
+          )
         ) {
           return
         }
         context.report({
           node,
-          message: `vi.${methodName}() is redundant in a Vitest hook because Vitest performs this cleanup automatically.`
+          message: `vi.${methodName}() is redundant in a Vitest hook because the project test setup performs this cleanup automatically.`
         })
       }
     }


### PR DESCRIPTION
## Summary

Enforce redundant Vitest cleanup as a lint error now that the remaining violations are removed.

## Changes

- **What**: Set `comfy/no-redundant-vitest-cleanup` to `error` in both Oxlint configs and remove redundant test hooks.
- Include `vi.useRealTimers()` and `vi.clearAllTimers()` in `afterEach`. The shared `vitest.timer.setup.ts` restores real timers after every test, which discards scheduled fake timers.
- Keep timer APIs allowed in before hooks, `afterAll`, and test bodies, where they can intentionally select, control, or clean up timer behavior.

## Review Focus

Confirm the removed hooks are covered by the repository-wide Vitest mock and timer cleanup settings.