### PR TITLE
chore: enforce module-scope Vitest mock rule

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -134,7 +134,7 @@
     {
       "files": ["**/*.test.{ts,tsx}"],
       "rules": {
-        "comfy/no-module-scope-vitest-mocks": "warn",
+        "comfy/no-module-scope-vitest-mocks": "error",
         "comfy/no-redundant-vitest-cleanup": "error"
       }
     },

--- a/src/base/common/downloadUtil.test.ts
+++ b/src/base/common/downloadUtil.test.ts
@@ -1,4 +1,5 @@
 import { fromAny, fromPartial } from '@total-typescript/shoehorn'
+import type { MockInstance } from 'vitest'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
@@ -25,13 +26,8 @@ vi.mock('@/platform/updates/common/toastStore', () => ({
   useToastStore: vi.fn(() => ({ addAlert: vi.fn() }))
 }))
 
-// Global stubs
-let createObjectURLSpy = vi
-  .spyOn(URL, 'createObjectURL')
-  .mockReturnValue('blob:mock-url')
-let revokeObjectURLSpy = vi
-  .spyOn(URL, 'revokeObjectURL')
-  .mockImplementation(() => {})
+let createObjectURLSpy: MockInstance<typeof URL.createObjectURL>
+let revokeObjectURLSpy: MockInstance<typeof URL.revokeObjectURL>
 
 describe('downloadUtil', () => {
   let mockLink: HTMLAnchorElement

--- a/src/scripts/ui.storageResilience.test.ts
+++ b/src/scripts/ui.storageResilience.test.ts
@@ -19,6 +19,7 @@ import { describe, expect, it, vi } from 'vitest'
 
 // Node >= 25's unconfigured Web Storage stub, installed before the import below
 // so the module-scope `new ComfyApp()` restores against it.
+// oxlint-disable-next-line comfy/no-module-scope-vitest-mocks -- must precede import-time ComfyApp construction
 vi.stubGlobal('localStorage', {} as Storage)
 
 // Imported once here rather than per test behind `vi.resetModules()`, which

--- a/tools/oxlint-plugins/vitestCleanup.config.json
+++ b/tools/oxlint-plugins/vitestCleanup.config.json
@@ -15,7 +15,7 @@
         "**/tools/**/*.test.{ts,tsx}"
       ],
       "rules": {
-        "comfy/no-module-scope-vitest-mocks": "warn",
+        "comfy/no-module-scope-vitest-mocks": "error",
         "comfy/no-redundant-vitest-cleanup": "error"
       }
     }


### PR DESCRIPTION
## Summary

Enforce `comfy/no-module-scope-vitest-mocks` now that its existing diagnostics are resolved.

Stacked on #15570.

## Changes

- **What**: Set the rule to `error` in both Oxlint configs.
- Move the duplicate `URL.createObjectURL` and `URL.revokeObjectURL` spies fully into `beforeEach`.
- Narrowly suppress the `localStorage` stub that must run before the import-time `ComfyApp` construction.

## Review Focus

Confirm the pre-import `localStorage` stub is the only justified module-scope exception.