### PR TITLE
test: pin node.widgets mutation view against store order

### DIFF
--- a/src/lib/litegraph/src/node/widgetsView.test.ts
+++ b/src/lib/litegraph/src/node/widgetsView.test.ts
@@ -1,0 +1,82 @@
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { LGraph, LGraphNode } from '@/lib/litegraph/src/litegraph'
+import type { IBaseWidget } from '@/lib/litegraph/src/types/widgets'
+import { useWidgetValueStore } from '@/stores/widgetValueStore'
+
+function createNodeWithWidgets(values: Record<string, number>) {
+  const graph = new LGraph()
+  const node = new LGraphNode('test')
+  graph.add(node)
+  for (const [name, value] of Object.entries(values)) {
+    node.addWidget('number', name, value, () => undefined, {})
+  }
+  return { node, widgets: [...node.widgets!] }
+}
+
+function storedOrder(node: LGraphNode): string[] {
+  return useWidgetValueStore()
+    .getNodeWidgets(node.graph!.rootGraph.id, node.id)
+    .map((widget) => widget.name)
+}
+
+function storedValue(widget: IBaseWidget) {
+  return useWidgetValueStore().getWidget(widget.widgetId!)?.value
+}
+
+/** Node packs rebuild `node.widgets` by writing to the array directly. */
+describe('widgets view', () => {
+  beforeEach(() => {
+    setActivePinia(createTestingPinia({ stubActions: false }))
+  })
+
+  it('restores order and value when a widget is spliced out and pushed back', () => {
+    const { node, widgets } = createNodeWithWidgets({ a: 10, b: 20, c: 30 })
+    const [removed] = widgets
+
+    node.widgets!.splice(0, 1)
+    node.widgets!.push(removed)
+
+    expect(storedOrder(node)).toEqual(['b', 'c', 'a'])
+    expect(storedValue(removed)).toBe(10)
+  })
+
+  it('commits order when a slot is assigned by index', () => {
+    const { node, widgets } = createNodeWithWidgets({ a: 10, b: 20, c: 30 })
+
+    node.widgets![0] = widgets[2]
+    node.widgets![2] = widgets[0]
+
+    expect(storedOrder(node)).toEqual(['c', 'b', 'a'])
+  })
+
+  it('commits order when the array is truncated by length', () => {
+    const { node, widgets } = createNodeWithWidgets({ a: 10, b: 20, c: 30 })
+
+    node.widgets!.length = 2
+
+    expect(storedOrder(node)).toEqual(['a', 'b'])
+    expect(storedValue(widgets[2])).toBe(30)
+  })
+
+  it('clears order but keeps values when widgets are unset', () => {
+    const { node, widgets } = createNodeWithWidgets({ a: 10, b: 20 })
+
+    node.widgets = undefined
+
+    expect(node.widgets).toBeUndefined()
+    expect(storedOrder(node)).toEqual([])
+    expect(storedValue(widgets[0])).toBe(10)
+  })
+
+  it('commits order when widgets are assigned back after being unset', () => {
+    const { node, widgets } = createNodeWithWidgets({ a: 10, b: 20 })
+
+    node.widgets = undefined
+    node.widgets = [widgets[1], widgets[0]]
+
+    expect(storedOrder(node)).toEqual(['b', 'a'])
+  })
+})


### PR DESCRIPTION
## Summary

Regression test for the `node.widgets` mutation view from #15453, so a later change cannot silently undo it. Ben's ECS Compatibility Pre-Release Report marks "shims have no regression tests in the frontend's own suite" as a before-ship gate; this closes it for #15453.

## Changes

- **What**: `src/lib/litegraph/src/node/widgetsView.test.ts`, 5 tests. Every raw write to `node.widgets` must reach `widgetValueStore` render order: splice-then-push, indexed assignment, `length` truncation, `node.widgets = undefined`, and assigning an array back after unsetting.
- **What**: Three of them also pin what the commit must not destroy — a widget dropped from the order keeps its stored value, so remove-then-re-add preserves what the user set.

## Review Focus

Mutation verification. Four perturbations of production source, each reverted after measuring; 5 tests in the new file, 89 in the existing widget/mutation-view suite (`LGraphNode.test.ts`, `widgetValueStore.test.ts`, `createMutationView.test.ts`).

| Perturbation | New file | Existing 89 |
| --- | --- | --- |
| `widgetsView.ts`: `view: target` — mutation view removed | **4 fail** | 2 fail |
| `createMutationView.ts`: `shouldCommitMethod: () => false` | **2 fail** | 3 fail |
| `createMutationView.ts`: `commitIfChanged` compares `length` only | **1 fail** | 7 fail |
| `widgetsView.ts`: `syncWidgetOrder` calls pre-shim `setNodeWidgetOrder` | **2 fail** | 1 fail |

Restored: 5/5 and 89/89 green.

Perturbation 3 is the one that rules out a vacuous test: it leaves every array length unchanged and drops only the element-identity comparison, so a test counting widgets rather than reading order stays green through it. Perturbation 4 is the likeliest real regression — `replaceNodeWidgetOrder` and `setNodeWidgetOrder` differ only in whether the order may shrink, and consolidating them is an obvious future cleanup.

The gap this fills is narrow and specific: no existing test asserts **store order** after an indexed assignment or a `length` write. `notifies readers when a widget is removed in place` uses `length = 0` but asserts the reactive view, which still updates without the shim because the target is `shallowReactive`.

Deliberately not covered, to stay non-redundant: `sort`/`reverse`/`pop`/`shift`/`unshift` (one `get`-trap mechanism, already caught by the existing suite in perturbation 2); `delete node.widgets[i]` (trips type-aware oxlint `no-array-delete`, and `deleteProperty` is covered in `createMutationView.test.ts`); view identity across reassignment (covered by `keeps one view and synchronizes direct replacements and mutations`).

One finding worth recording: the `set` trap in `createMutationView` cannot be tested in isolation. Removing it falls through to the proxy's default `set`, which re-dispatches through `[[DefineOwnProperty]]` on the receiver and hits the `defineProperty` trap, so the commit still happens. The two traps are not independent.
