### PR TITLE
test: regression cover for the ECS node-shell and slot-link shims

### DIFF
--- a/src/lib/litegraph/src/LGraphNode.ownCollectionFields.test.ts
+++ b/src/lib/litegraph/src/LGraphNode.ownCollectionFields.test.ts
@@ -1,0 +1,87 @@
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { LGraphNode } from '@/lib/litegraph/src/litegraph'
+
+/**
+ * Regression cover for #15485.
+ *
+ * ECS made `inputs` / `outputs` / `widgets` prototype accessors. Prototype
+ * accessors are invisible to `hasOwnProperty`, and much of the ecosystem gates
+ * node-shell introspection on exactly that check, so those packs silently did
+ * nothing — the cause of both DIFFs measured by the compat battery.
+ *
+ * Two properties are load-bearing and have to hold together: the fields are own
+ * and enumerable, *and* they are still accessors over the ECS store. An own
+ * data property would pass the first half while detaching the collection from
+ * the store.
+ */
+
+const COLLECTIONS = ['inputs', 'outputs', 'widgets'] as const
+
+/** `node.hasOwnProperty(key)`, without tripping no-prototype-builtins. */
+function hasOwn(node: object, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(node, key)
+}
+
+function expectOwnAccessor(node: object, key: string): void {
+  expect(hasOwn(node, key), `hasOwnProperty(${key})`).toBe(true)
+  const descriptor = Object.getOwnPropertyDescriptor(node, key)
+  expect(descriptor?.enumerable, `${key} enumerable`).toBe(true)
+  expect(typeof descriptor?.get, `${key} getter`).toBe('function')
+  expect('value' in (descriptor ?? {}), `${key} is a data property`).toBe(false)
+}
+
+describe('LGraphNode own collection fields', () => {
+  beforeEach(() => {
+    setActivePinia(createTestingPinia({ stubActions: false }))
+  })
+
+  it('exposes the collections to shell introspection on a bare node', () => {
+    const node = new LGraphNode('Bare')
+
+    for (const key of COLLECTIONS) expectOwnAccessor(node, key)
+    expect(Object.keys(node)).toEqual(expect.arrayContaining([...COLLECTIONS]))
+
+    const enumerated: string[] = []
+    for (const key in node) enumerated.push(key)
+    expect(enumerated).toEqual(expect.arrayContaining([...COLLECTIONS]))
+  })
+
+  it('keeps the fields own on a subclass', () => {
+    class PackNode extends LGraphNode {
+      constructor() {
+        super('Pack node')
+        this.addInput('in', 'INT')
+      }
+    }
+
+    for (const key of COLLECTIONS) expectOwnAccessor(new PackNode(), key)
+  })
+
+  it('hands introspection the live collection, not a copy', () => {
+    const node = new LGraphNode('Forwarding')
+    node.addInput('prompt', 'STRING')
+
+    const [input] = node.inputs
+    input.label = 'Translated prompt'
+
+    expect(node.getInputInfo(0)?.label).toBe('Translated prompt')
+    expect(node.inputs).toBe(node.inputs)
+  })
+
+  it('keeps the fields own after configure restores serialized data', () => {
+    const source = new LGraphNode('Serialized')
+    source.addInput('prompt', 'STRING')
+    source.addOutput('result', 'STRING')
+    source.addWidget('text', 'prompt', '', () => undefined)
+
+    const restored = new LGraphNode('Serialized')
+    restored.configure(source.serialize())
+
+    for (const key of COLLECTIONS) expectOwnAccessor(restored, key)
+    expect(restored.inputs).toHaveLength(1)
+    expect(restored.outputs).toHaveLength(1)
+  })
+})

--- a/src/lib/litegraph/src/LGraphNode.ownCollectionFields.test.ts
+++ b/src/lib/litegraph/src/LGraphNode.ownCollectionFields.test.ts
@@ -4,19 +4,6 @@ import { beforeEach, describe, expect, it } from 'vitest'
 
 import { LGraphNode } from '@/lib/litegraph/src/litegraph'
 
-/**
- * Regression cover for #15485.
- *
- * ECS made `inputs` / `outputs` / `widgets` prototype accessors. Prototype
- * accessors are invisible to `hasOwnProperty`, and much of the ecosystem gates
- * node-shell introspection on exactly that check, so those packs silently did
- * nothing — the cause of both DIFFs measured by the compat battery.
- *
- * Two properties are load-bearing and have to hold together: the fields are own
- * and enumerable, *and* they are still accessors over the ECS store. An own
- * data property would pass the first half while detaching the collection from
- * the store.
- */
 
 const COLLECTIONS = ['inputs', 'outputs', 'widgets'] as const
 

--- a/src/lib/litegraph/src/node/legacySlotLinkMutations.test.ts
+++ b/src/lib/litegraph/src/node/legacySlotLinkMutations.test.ts
@@ -8,19 +8,6 @@ import type {
 } from '@/lib/litegraph/src/interfaces'
 import { LGraph, LGraphNode } from '@/lib/litegraph/src/litegraph'
 
-/**
- * Regression cover for #15485's sibling, #15501.
- *
- * ECS moved link ownership into the link store, so `input.link = null` and
- * removals from `output.links` became writes to a derived mirror and stopped
- * changing topology — legacy disconnects broke ecosystem-wide. The shim routes
- * those removals back through the store's topology commands.
- *
- * Only the removal direction is shimmed. The creation direction and
- * plain-object slots remain open; they are recorded below as `it.fails` on the
- * behaviour we want, so closing the gap turns them red rather than pinning
- * today's wrong answer.
- */
 
 function connectedPair() {
   const graph = new LGraph()

--- a/src/lib/litegraph/src/node/legacySlotLinkMutations.test.ts
+++ b/src/lib/litegraph/src/node/legacySlotLinkMutations.test.ts
@@ -1,0 +1,175 @@
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import type {
+  INodeInputSlot,
+  INodeOutputSlot
+} from '@/lib/litegraph/src/interfaces'
+import { LGraph, LGraphNode } from '@/lib/litegraph/src/litegraph'
+
+/**
+ * Regression cover for #15485's sibling, #15501.
+ *
+ * ECS moved link ownership into the link store, so `input.link = null` and
+ * removals from `output.links` became writes to a derived mirror and stopped
+ * changing topology — legacy disconnects broke ecosystem-wide. The shim routes
+ * those removals back through the store's topology commands.
+ *
+ * Only the removal direction is shimmed. The creation direction and
+ * plain-object slots remain open; they are recorded below as `it.fails` on the
+ * behaviour we want, so closing the gap turns them red rather than pinning
+ * today's wrong answer.
+ */
+
+function connectedPair() {
+  const graph = new LGraph()
+  const source = new LGraphNode('Source')
+  source.addOutput('out', 'INT')
+  graph.add(source)
+
+  const target = new LGraphNode('Target')
+  target.addInput('in', 'INT')
+  graph.add(target)
+
+  const link = source.connect(0, target, 0)!
+  return { graph, source, target, link }
+}
+
+function fanOut(count: number) {
+  const graph = new LGraph()
+  const source = new LGraphNode('Source')
+  source.addOutput('out', 'INT')
+  graph.add(source)
+
+  const targets = Array.from({ length: count }, (_, index) => {
+    const target = new LGraphNode(`Target ${index}`)
+    target.addInput('in', 'INT')
+    graph.add(target)
+    source.connect(0, target, 0)
+    return target
+  })
+
+  return { graph, source, targets }
+}
+
+describe('legacy slot link removal', () => {
+  beforeEach(() => {
+    setActivePinia(createTestingPinia({ stubActions: false }))
+  })
+
+  it('propagates input.link = null to the far end of the link', () => {
+    const { source, target } = connectedPair()
+
+    target.inputs[0].link = null
+
+    expect(target.isInputConnected(0)).toBe(false)
+    expect(source.isOutputConnected(0)).toBe(false)
+    expect(source.outputs[0].links).toBeNull()
+    expect(source.getOutputNodes(0) ?? []).toHaveLength(0)
+  })
+
+  it('disconnects the links a filter-and-reassign drops', () => {
+    const { source, targets } = fanOut(3)
+    const output = source.outputs[0]
+    const [dropped, , alsoDropped] = output.links!
+
+    output.links = output.links!.filter(
+      (id) => id !== dropped && id !== alsoDropped
+    )
+
+    expect(targets[0].isInputConnected(0)).toBe(false)
+    expect(targets[2].isInputConnected(0)).toBe(false)
+    expect(targets[1].isInputConnected(0)).toBe(true)
+    expect(source.getOutputNodes(0)).toEqual([targets[1]])
+  })
+
+  it('disconnects each link spliced out of the retained view in turn', () => {
+    const { source, targets } = fanOut(3)
+    const view = source.outputs[0].links!
+
+    for (const id of [...view]) view.splice(view.indexOf(id), 1)
+
+    for (const [index, target] of targets.entries()) {
+      expect(target.isInputConnected(0), `target ${index}`).toBe(false)
+    }
+    expect(source.isOutputConnected(0)).toBe(false)
+  })
+
+  it('disconnects everything when the view is truncated by length', () => {
+    // `length` is a property write rather than an array method, so it reaches
+    // the mutation view through a different trap than the cases above.
+    const { source, targets } = fanOut(2)
+    const view = source.outputs[0].links!
+
+    view.length = 0
+
+    expect(targets.every((target) => !target.isInputConnected(0))).toBe(true)
+    expect(source.isOutputConnected(0)).toBe(false)
+  })
+
+  it('ignores removals on slots detached from their node', () => {
+    const { source, target } = connectedPair()
+    const [detachedInput] = target.inputs.splice(0, 1)
+    const [detachedOutput] = source.outputs.splice(0, 1)
+
+    expect(() => {
+      detachedInput.link = null
+      detachedOutput.links = []
+    }).not.toThrow()
+  })
+})
+
+describe('legacy slot link creation and plain-object slots (uncovered)', () => {
+  beforeEach(() => {
+    setActivePinia(createTestingPinia({ stubActions: false }))
+  })
+
+  it.fails('restores a link from a saved id', () => {
+    const { source, target } = connectedPair()
+    const saved = target.inputs[0].link
+
+    target.inputs[0].link = null
+    expect(source.isOutputConnected(0)).toBe(false)
+
+    target.inputs[0].link = saved
+    expect(target.inputs[0].link).toBe(saved)
+    expect(source.isOutputConnected(0)).toBe(true)
+  })
+
+  it.fails('reconnects a link pushed back onto the output view', () => {
+    const { source, target } = connectedPair()
+    const output = source.outputs[0]
+    const [id] = output.links!
+
+    output.links = []
+    expect(source.isOutputConnected(0)).toBe(false)
+
+    output.links!.push(id)
+    expect(source.isOutputConnected(0)).toBe(true)
+    expect(target.isInputConnected(0)).toBe(true)
+  })
+
+  it.fails('disconnects through a plain-object input slot', () => {
+    // The shape the one confirmed-broken pack uses: replace the slot with a
+    // spread copy, then mutate that. `link` is an accessor, so the copy carries
+    // neither the shim nor the current id.
+    const { source, target } = connectedPair()
+    const copy: INodeInputSlot = { ...target.inputs[0] }
+    target.inputs[0] = copy
+
+    target.inputs[0].link = null
+
+    expect(source.isOutputConnected(0)).toBe(false)
+  })
+
+  it.fails('disconnects through a plain-object output slot', () => {
+    const { source, target } = connectedPair()
+    const copy: INodeOutputSlot = { ...source.outputs[0] }
+    source.outputs[0] = copy
+
+    source.outputs[0].links = []
+
+    expect(target.isInputConnected(0)).toBe(false)
+  })
+})


### PR DESCRIPTION
The #15485 and #15501 shims are what makes 200+ packs work untouched on this branch, and nothing in this repo's suite would notice if a later change undid one. These two files are that tripwire.

## What is pinned

**#15485 — own enumerable collection fields** (`src/lib/litegraph/src/LGraphNode.ownCollectionFields.test.ts`, 4 tests)

`inputs` / `outputs` / `widgets` are own, enumerable, **and** still accessors over the ECS store. Both halves matter: own-and-enumerable is what `hasOwnProperty`-gated pack introspection needs, and accessor-ness is what keeps the store authoritative. An own data property would satisfy the first and silently detach the collection. Covered on a bare node, a subclass, and after `configure()` restores serialized data.

**#15501 — legacy slot link removal** (`src/lib/litegraph/src/node/legacySlotLinkMutations.test.ts`, 5 tests + 4 markers)

Removal only, asserted at both ends of the link, not just the near end: `input.link = null`, filter-and-reassign on `output.links`, per-link `splice` on the retained view, `length` truncation (a property write, so a different trap than the array methods), and inertness on slots detached from their node.

The creation direction and plain-object slots stay open. They are `it.fails` asserting the behaviour we want, so closing the gap turns them red and they get promoted. Nothing here pins the current wrong answer.

## Mutation verification

| Mutation in production source | Result |
| --- | --- |
| #15485: drop the own-descriptor install loop | 3 of 4 fail, `hasOwnProperty(inputs): expected false to be true` |
| #15485: keep the loop, set `enumerable: false` | 3 of 4 fail, `inputs enumerable: expected false to be true` |
| #15485: swap the accessor for an own data property | 3 of 4 fail, `inputs getter: expected 'undefined' to be 'function'` |
| #15501: revert `input.link` setter to a no-op | 1 fails, `it.fails` count unchanged |
| #15501: stop `commitLegacyLinks` issuing topology commands | 3 fail, `it.fails` count unchanged |

Each reverted afterwards and re-confirmed green: 9 passed, 4 expected fail.

## Gates

`oxfmt --check`, `oxlint --type-aware`, `eslint`, `vue-tsc`, `knip`, both test files. `vue-tsc` reports 1,486 errors in this checkout, all of them the documented `TS2688` symlinked-`node_modules` phantoms and the implicit-anys they cascade into; 0 under `src/lib/litegraph`, 0 naming these files. `knip` reports 23 unresolved imports, all in `apps/website`, none naming these files.

Note for whoever works in a worktree next: `core.hooksPath` points at `.husky/_`, which only exists after `pnpm install` runs in that checkout. In a worktree with a borrowed `node_modules` the pre-commit and pre-push hooks silently do not run. The gates above were run explicitly.
