### PR TITLE
fix: don't toggle boolean switch widget on Ctrl/Cmd+Enter

### DIFF
--- a/src/components/ui/switch/Switch.test.ts
+++ b/src/components/ui/switch/Switch.test.ts
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
-import { describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, onTestFinished, vi } from 'vitest'
 
 import Switch from './Switch.vue'
 
@@ -71,5 +71,60 @@ describe('Switch', () => {
 
     expect(onUpdate).not.toHaveBeenCalled()
     expect(control).not.toBeChecked()
+  })
+
+  it.for([
+    ['Ctrl', '{Control>}{Enter}{/Control}'],
+    ['Meta', '{Meta>}{Enter}{/Meta}']
+  ])('ignores Enter while %s is held', async ([, keystrokes]) => {
+    const user = userEvent.setup()
+    const onUpdate = vi.fn()
+
+    render(Switch, {
+      props: {
+        modelValue: false,
+        'onUpdate:modelValue': onUpdate
+      },
+      attrs: { 'aria-label': 'Notifications' }
+    })
+
+    const keysSeenByWindow: string[] = []
+    const recordKeydown = (event: KeyboardEvent) =>
+      keysSeenByWindow.push(event.key)
+    window.addEventListener('keydown', recordKeydown)
+    onTestFinished(() => {
+      window.removeEventListener('keydown', recordKeydown)
+    })
+
+    const control = screen.getByRole('switch', { name: 'Notifications' })
+    await user.tab()
+    expect(control).toHaveFocus()
+
+    await user.keyboard(keystrokes)
+    expect(onUpdate).not.toHaveBeenCalled()
+    expect(keysSeenByWindow).toContain('Enter')
+
+    await user.keyboard('[Enter]')
+    expect(onUpdate).toHaveBeenCalledWith(true)
+  })
+
+  it('stays interactive after a modified Enter is ignored', async () => {
+    const user = userEvent.setup()
+    const onUpdate = vi.fn()
+
+    render(Switch, {
+      props: {
+        modelValue: false,
+        'onUpdate:modelValue': onUpdate
+      },
+      attrs: { 'aria-label': 'Notifications' }
+    })
+
+    const control = screen.getByRole('switch', { name: 'Notifications' })
+    await user.tab()
+    await user.keyboard('{Control>}{Enter}{/Control}')
+    await user.click(control)
+
+    expect(onUpdate).toHaveBeenCalledExactlyOnceWith(true)
   })
 })

--- a/src/components/ui/switch/Switch.vue
+++ b/src/components/ui/switch/Switch.vue
@@ -16,8 +16,19 @@ const {
 
 const modelValue = defineModel<boolean>({ default: false })
 
+// SwitchRoot toggles on Enter from its own keydown handler, so `.prevent` on a
+// fallthrough listener cannot stop it and `.stop` would swallow the global
+// Ctrl/Cmd+Enter shortcut. Veto the resulting update instead.
+let toggleRequestedByModifiedEnter = false
+
+function trackModifiedEnter(event: KeyboardEvent) {
+  if (event.key !== 'Enter' || !(event.ctrlKey || event.metaKey)) return
+  toggleRequestedByModifiedEnter = true
+  queueMicrotask(() => (toggleRequestedByModifiedEnter = false))
+}
+
 function updateModelValue(value: boolean) {
-  if (readonly) return
+  if (readonly || toggleRequestedByModifiedEnter) return
   modelValue.value = value
 }
 </script>
@@ -33,6 +44,7 @@ function updateModelValue(value: boolean) {
         customClass
       )
     "
+    @keydown="trackModifiedEnter"
     @update:model-value="updateModelValue"
   >
     <span

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetToggleSwitch.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetToggleSwitch.test.ts
@@ -95,6 +95,21 @@ describe('WidgetToggleSwitch Value Binding', () => {
       expect(onModelUpdate).toHaveBeenCalledWith(false)
     })
 
+    it('keeps its value when Ctrl+Enter is pressed while focused', async () => {
+      const widget = createToggleWidget(false)
+      const onModelUpdate = vi.fn()
+      const { user } = mountComponent(widget, false, onModelUpdate)
+
+      const control = screen.getByRole('switch')
+      await user.tab()
+      expect(control).toHaveFocus()
+
+      await user.keyboard('{Control>}{Enter}{/Control}')
+
+      expect(onModelUpdate).not.toHaveBeenCalled()
+      expect(control).not.toBeChecked()
+    })
+
     it('handles value changes gracefully', async () => {
       const widget = createToggleWidget(false)
       const onModelUpdate = vi.fn()


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

## Problem

A BOOLEAN widget's switch keeps keyboard focus after being clicked. `reka-ui`'s `SwitchRoot` binds `@keydown.enter.prevent="toggleCheck"` and matches on `event.key` alone, so it activates on **Ctrl+Enter** too — the global queue-prompt shortcut. Running a workflow therefore flipped whichever boolean switch was focused, and the value silently reverted on every run unless the user clicked elsewhere first.

Reported on Discord: ["every time I run the workflow, the switches revert to their original state… pressing the Enter key changes its state. Since the keyboard shortcut to launch the cue is Ctrl+Enter, it simultaneously triggers the switch change"](https://discordapp.com/channels/1218270712402415686/1247306607709393017/1539955188981432380)

- Fixes FE-1703

## Fix

`Switch.vue` records when an Enter keydown carries Ctrl/Cmd and vetoes the resulting model update, reusing the same gate that already handles `readonly`.

The obvious one-liners don't work here: `.prevent` does nothing to reka's own handler (it already calls `preventDefault()` itself), and `.stop`/`.stopImmediatePropagation()` would suppress the toggle but also stop the event reaching the `window` keydown listener that runs the queue command — trading one bug for a worse one. The fallthrough `@keydown` is merged ahead of reka's internal handler, so the latch is set before `toggleCheck` emits; `queueMicrotask` clears it so it can only ever affect that one synchronous dispatch.

`event.ctrlKey || event.metaKey` matches how `KeyComboImpl.fromEvent` derives `ctrl`, so it covers exactly the bound Enter combos (`Comfy.QueuePrompt`, `Comfy.QueuePromptFront`, `Comfy.Interrupt`) and nothing else.

**Scope note:** this is the shared `ui/switch` primitive, so Ctrl/Cmd+Enter now leaves *any* focused switch alone — `FormItem`, `FieldSwitch`, `ComfyMenuButton`, `ExtensionPanel`, `PackEnableToggle` and the Vue-nodes boolean widget. That's deliberate; no switch should be activated by a global shortcut. The labelled variant of the widget (`ToggleGroup`, rendered when `label_on`/`label_off` are set) was never affected — it's a plain `<button>` whose Enter→click is the keydown's default action, which the keybinding handler already cancels. Verified in the browser.

## Verification

Real Chromium against a live backend, `ImageStitch.match_image_size` in nodes 2.0:

| step | before | after |
| --- | --- | --- |
| click switch off | `false` | `false` |
| **Ctrl+Enter** | **`true`** (reverted) | **`false`** (held) — queue still fired |
| Cmd+Enter | — | `false` — queue still fired |
| bare Enter | toggles | toggles |
| click | toggles | toggles |

Unit tests cover both halves of the contract — that the switch doesn't toggle, *and* that the Enter keydown still reaches `window` so the shortcut keeps working. I mutation-checked that second assertion: swapping the fix for `stopImmediatePropagation()` fails it (`expected [ 'Tab', 'Control' ] to include 'Enter'`), which is the refactor that would otherwise silently break queueing.

`pnpm typecheck`, `pnpm lint`, `pnpm knip`, `pnpm format`, `pnpm build` all clean; 139 tests pass across `src/components/ui` and the widget.


## Screenshots

![Before: switch set to off by the user reverts to on after pressing Ctrl+Enter](https://pub-0c501c1cf38f477fa8efc67068523b33.r2.dev/sessions/9c47f6d0b9bb805f268e57879d5f35b3f6c1bd6e1fd2b53153e922f7c7ac508a/pr-images/1787350681389-abb66e30-bb0b-4185-827d-8ed3cf39b31a.png)

![After: switch stays off after pressing Ctrl+Enter](https://pub-0c501c1cf38f477fa8efc67068523b33.r2.dev/sessions/9c47f6d0b9bb805f268e57879d5f35b3f6c1bd6e1fd2b53153e922f7c7ac508a/pr-images/1787350681744-97973621-eb20-45b2-8c99-2f5e8e92f373.png)