### PR TITLE
test: reproduce #15577 and #15581 on the ECS branch

### DIFF
--- a/src/lib/litegraph/src/LGraph.inputSlotRealign.test.ts
+++ b/src/lib/litegraph/src/LGraph.inputSlotRealign.test.ts
@@ -492,6 +492,24 @@ function unmatchedInputNameWorkflow(nodeType: string): SerialisableGraph {
   }
 }
 
+function unmatchedInputLinkState(graph: LGraph) {
+  const target = graph.getNodeById(toNodeId(2))!
+  const serialized = graph.serialize()
+  const reloaded = new LGraph()
+  reloaded.configure(structuredClone(serialized))
+  const reloadedTarget = reloaded.getNodeById(toNodeId(2))!
+
+  return {
+    graphLinkIds: [...graph.links.keys()],
+    inputLinkIds: target.inputs.map((_, slot) => target.getInputLink(slot)?.id),
+    serializedLinkIds: (serialized.links ?? []).map(([id]) => toLinkId(id)),
+    reloadedGraphLinkIds: [...reloaded.links.keys()],
+    reloadedInputLinkIds: reloadedTarget.inputs.map(
+      (_, slot) => reloadedTarget.getInputLink(slot)?.id
+    )
+  }
+}
+
 describe('LGraph.configure realignment with an unmatched input name (#15581)', () => {
   beforeEach(() => {
     setActivePinia(createTestingPinia({ stubActions: false }))
@@ -510,18 +528,26 @@ describe('LGraph.configure realignment with an unmatched input name (#15581)', (
     const graph = new LGraph()
     graph.configure(unmatchedInputNameWorkflow('test/DroppedInputTarget'))
 
-    const target = graph.getNodeById(toNodeId(2))!
-    expect(target.getInputLink(0)?.id).toBe(toLinkId(1))
-    expect(target.getInputLink(1)?.id).toBe(toLinkId(2))
+    expect(unmatchedInputLinkState(graph)).toEqual({
+      graphLinkIds: [toLinkId(1), toLinkId(2)],
+      inputLinkIds: [toLinkId(1), toLinkId(2)],
+      serializedLinkIds: [toLinkId(1), toLinkId(2)],
+      reloadedGraphLinkIds: [toLinkId(1), toLinkId(2)],
+      reloadedInputLinkIds: [toLinkId(1), toLinkId(2)]
+    })
   })
 
   it.fails('realigns siblings when configure renames an input', () => {
     const graph = new LGraph()
     graph.configure(unmatchedInputNameWorkflow('test/RenamedInputTarget'))
 
-    const target = graph.getNodeById(toNodeId(2))!
-    expect(target.getInputLink(0)?.id).toBe(toLinkId(1))
-    expect(target.getInputLink(1)?.id).toBe(toLinkId(2))
+    expect(unmatchedInputLinkState(graph)).toEqual({
+      graphLinkIds: [toLinkId(1), toLinkId(2)],
+      inputLinkIds: [toLinkId(1), toLinkId(2), undefined],
+      serializedLinkIds: [toLinkId(1), toLinkId(2)],
+      reloadedGraphLinkIds: [toLinkId(1), toLinkId(2)],
+      reloadedInputLinkIds: [toLinkId(1), toLinkId(2), undefined]
+    })
   })
 
   it.fails('reports no error while realigning around an unmatched name', () => {
@@ -561,9 +587,17 @@ describe('realignInputLinkSlots with a rejected batch (#15581)', () => {
 
     realignInputLinkSlots(graph, [nodeData])
 
-    expect(
-      useLinkStore().getInputSlotLink(graphScopeOf(graph), target.id, 1)?.id
-    ).toBe(free.id)
+    expect({
+      graphLinkIds: [...graph.links.keys()],
+      inputLinkIds: target.inputs.map(
+        (_, slot) =>
+          useLinkStore().getInputSlotLink(graphScopeOf(graph), target.id, slot)
+            ?.id
+      )
+    }).toEqual({
+      graphLinkIds: [blocked.id, free.id],
+      inputLinkIds: [blocked.id, free.id, undefined]
+    })
   })
 })
 

--- a/src/lib/litegraph/src/LGraph.inputSlotRealign.test.ts
+++ b/src/lib/litegraph/src/LGraph.inputSlotRealign.test.ts
@@ -381,7 +381,6 @@ describe('LGraph.configure input slot realignment (#3348)', () => {
 
 const SHRUNK_DEFINITION_ORDER = ['in_a', 'in_b']
 
-/** Drops any serialized input its definition no longer declares. */
 class DroppedInputTargetNode extends LGraphNode {
   constructor(title?: string) {
     super(title ?? 'DroppedInputTarget')
@@ -402,7 +401,6 @@ class DroppedInputTargetNode extends LGraphNode {
 
 const RENAMED_DEFINITION_ORDER = ['in_a', 'in_b', 'in_c_v2']
 
-/** Renames a live input after configure, as a pack migrating a slot does. */
 class RenamedInputTargetNode extends LGraphNode {
   constructor(title?: string) {
     super(title ?? 'RenamedInputTarget')
@@ -422,11 +420,6 @@ class RenamedInputTargetNode extends LGraphNode {
   }
 }
 
-/**
- * Serialized target carrying one input name the live node will not have.
- * `in_c` holds link 3 at slot 0, so the moves `1: 1 -> 0` and `2: 2 -> 1`
- * form a batch whose first member collides with link 3's stale placement.
- */
 function unmatchedInputNameWorkflow(nodeType: string): SerialisableGraph {
   return {
     id: 'ab000000-0000-4000-8000-000000000004',

--- a/src/lib/litegraph/src/LGraph.inputSlotRealign.test.ts
+++ b/src/lib/litegraph/src/LGraph.inputSlotRealign.test.ts
@@ -1,6 +1,6 @@
 import { createTestingPinia } from '@pinia/testing'
 import { setActivePinia } from 'pinia'
-import { beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
   SUBGRAPH_INPUT_ID,
@@ -376,6 +376,194 @@ describe('LGraph.configure input slot realignment (#3348)', () => {
     expect(graph.getNodeById(toNodeId(2))?.getInputLink(2)?.id).toBe(
       toLinkId(1)
     )
+  })
+})
+
+const SHRUNK_DEFINITION_ORDER = ['in_a', 'in_b']
+
+/** Drops any serialized input its definition no longer declares. */
+class DroppedInputTargetNode extends LGraphNode {
+  constructor(title?: string) {
+    super(title ?? 'DroppedInputTarget')
+    for (const name of SHRUNK_DEFINITION_ORDER) this.addInput(name, 'number')
+  }
+
+  override configure(data: ISerialisedNode): void {
+    data.inputs = (data.inputs ?? [])
+      .filter((input) => SHRUNK_DEFINITION_ORDER.includes(input.name))
+      .sort(
+        (a, b) =>
+          SHRUNK_DEFINITION_ORDER.indexOf(a.name) -
+          SHRUNK_DEFINITION_ORDER.indexOf(b.name)
+      )
+    super.configure(data)
+  }
+}
+
+const RENAMED_DEFINITION_ORDER = ['in_a', 'in_b', 'in_c_v2']
+
+/** Renames a live input after configure, as a pack migrating a slot does. */
+class RenamedInputTargetNode extends LGraphNode {
+  constructor(title?: string) {
+    super(title ?? 'RenamedInputTarget')
+    for (const name of RENAMED_DEFINITION_ORDER) this.addInput(name, 'number')
+  }
+
+  override configure(data: ISerialisedNode): void {
+    super.configure(data)
+    for (const input of this.inputs) {
+      if (input.name === 'in_c') input.name = 'in_c_v2'
+    }
+    this.inputs.sort(
+      (a, b) =>
+        RENAMED_DEFINITION_ORDER.indexOf(a.name) -
+        RENAMED_DEFINITION_ORDER.indexOf(b.name)
+    )
+  }
+}
+
+/**
+ * Serialized target carrying one input name the live node will not have.
+ * `in_c` holds link 3 at slot 0, so the moves `1: 1 -> 0` and `2: 2 -> 1`
+ * form a batch whose first member collides with link 3's stale placement.
+ */
+function unmatchedInputNameWorkflow(nodeType: string): SerialisableGraph {
+  return {
+    id: 'ab000000-0000-4000-8000-000000000004',
+    version: 1,
+    revision: 0,
+    state: { lastNodeId: 2, lastLinkId: 3, lastGroupId: 0, lastRerouteId: 0 },
+    nodes: [
+      {
+        id: 1,
+        type: 'test/RealignSource',
+        pos: [0, 0],
+        size: [140, 60],
+        flags: {},
+        order: 0,
+        mode: 0,
+        inputs: [],
+        outputs: [{ name: 'out', type: 'number', links: [1, 2, 3] }],
+        properties: {}
+      },
+      {
+        id: 2,
+        type: nodeType,
+        pos: [300, 0],
+        size: [140, 80],
+        flags: {},
+        order: 1,
+        mode: 0,
+        inputs: [
+          { name: 'in_c', type: 'number', link: 3 },
+          { name: 'in_a', type: 'number', link: 1 },
+          { name: 'in_b', type: 'number', link: 2 }
+        ],
+        outputs: [],
+        properties: {}
+      }
+    ],
+    links: [
+      {
+        id: 3,
+        origin_id: 1,
+        origin_slot: 0,
+        target_id: 2,
+        target_slot: 0,
+        type: 'number'
+      },
+      {
+        id: 1,
+        origin_id: 1,
+        origin_slot: 0,
+        target_id: 2,
+        target_slot: 1,
+        type: 'number'
+      },
+      {
+        id: 2,
+        origin_id: 1,
+        origin_slot: 0,
+        target_id: 2,
+        target_slot: 2,
+        type: 'number'
+      }
+    ]
+  }
+}
+
+describe('LGraph.configure realignment with an unmatched input name (#15581)', () => {
+  beforeEach(() => {
+    setActivePinia(createTestingPinia({ stubActions: false }))
+    LiteGraph.registerNodeType('test/RealignSource', SourceNode)
+    LiteGraph.registerNodeType(
+      'test/DroppedInputTarget',
+      DroppedInputTargetNode
+    )
+    LiteGraph.registerNodeType(
+      'test/RenamedInputTarget',
+      RenamedInputTargetNode
+    )
+  })
+
+  it.fails('realigns siblings when configure drops an input', () => {
+    const graph = new LGraph()
+    graph.configure(unmatchedInputNameWorkflow('test/DroppedInputTarget'))
+
+    const target = graph.getNodeById(toNodeId(2))!
+    expect(target.getInputLink(0)?.id).toBe(toLinkId(1))
+    expect(target.getInputLink(1)?.id).toBe(toLinkId(2))
+  })
+
+  it.fails('realigns siblings when configure renames an input', () => {
+    const graph = new LGraph()
+    graph.configure(unmatchedInputNameWorkflow('test/RenamedInputTarget'))
+
+    const target = graph.getNodeById(toNodeId(2))!
+    expect(target.getInputLink(0)?.id).toBe(toLinkId(1))
+    expect(target.getInputLink(1)?.id).toBe(toLinkId(2))
+  })
+
+  it.fails('reports no error while realigning around an unmatched name', () => {
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    const graph = new LGraph()
+    graph.configure(unmatchedInputNameWorkflow('test/DroppedInputTarget'))
+
+    expect(error).not.toHaveBeenCalled()
+  })
+})
+
+describe('realignInputLinkSlots with a rejected batch (#15581)', () => {
+  beforeEach(() => {
+    setActivePinia(createTestingPinia({ stubActions: false }))
+  })
+
+  it.fails('lands the non-conflicting moves when one move is blocked', () => {
+    const graph = new LGraph()
+    const source = new LGraphNode('Source')
+    source.addOutput('out', 'number')
+    const target = new LGraphNode('Target')
+    for (const name of ['p', 'q', 'r']) target.addInput(name, 'number')
+    graph.add(source)
+    graph.add(target)
+
+    const squatter = source.connect(0, target, 0)!
+    const blocked = source.connect(0, target, 1)!
+    const free = source.connect(0, target, 2)!
+
+    const nodeData = target.serialize()
+    nodeData.inputs = [
+      { name: 'no_such_input', type: 'number', link: squatter.id },
+      { name: 'p', type: 'number', link: blocked.id },
+      { name: 'q', type: 'number', link: free.id }
+    ]
+
+    realignInputLinkSlots(graph, [nodeData])
+
+    expect(
+      useLinkStore().getInputSlotLink(graphScopeOf(graph), target.id, 1)?.id
+    ).toBe(free.id)
   })
 })
 

--- a/src/lib/litegraph/src/__fixtures__/duplicateLinks.ts
+++ b/src/lib/litegraph/src/__fixtures__/duplicateLinks.ts
@@ -74,6 +74,85 @@ export const duplicateLinksRoot: SerialisableGraph = {
 }
 
 /**
+ * Root graph where two links target the same input from *different* origins.
+ * SourceA (id 1) holds link 1, SourceB (id 2) holds link 2, and Target's
+ * serialized `inputs[0]` references link **2** — so the first link in array
+ * order and the link `input.link` names disagree.
+ *
+ * Not hypothetical: this is byte-for-byte what `main` serializes after a pack
+ * creates a link through the legacy slot mirrors alone (`output.links.push`,
+ * `input.link =`) instead of `node.connect()`, which is rgthree `link_fixer`'s
+ * repair idiom. Reproduced against `main` at 32d0b6e202.
+ */
+export const conflictingOriginLinksRoot: SerialisableGraph = {
+  id: 'dd000000-0000-4000-8000-000000000004',
+  version: 1,
+  revision: 0,
+  state: {
+    lastNodeId: 3,
+    lastLinkId: 2,
+    lastGroupId: 0,
+    lastRerouteId: 0
+  },
+  nodes: [
+    {
+      id: 1,
+      type: 'test/DupTestNode',
+      pos: [0, 0],
+      size: [200, 100],
+      flags: {},
+      order: 0,
+      mode: 0,
+      inputs: [{ name: 'input_0', type: 'number', link: null }],
+      outputs: [{ name: 'output_0', type: 'number', links: [1] }],
+      properties: {}
+    },
+    {
+      id: 2,
+      type: 'test/DupTestNode',
+      pos: [0, 200],
+      size: [200, 100],
+      flags: {},
+      order: 1,
+      mode: 0,
+      inputs: [{ name: 'input_0', type: 'number', link: null }],
+      outputs: [{ name: 'output_0', type: 'number', links: [2] }],
+      properties: {}
+    },
+    {
+      id: 3,
+      type: 'test/DupTestNode',
+      pos: [300, 0],
+      size: [200, 100],
+      flags: {},
+      order: 2,
+      mode: 0,
+      inputs: [{ name: 'input_0', type: 'number', link: 2 }],
+      outputs: [{ name: 'output_0', type: 'number', links: [] }],
+      properties: {}
+    }
+  ],
+  links: [
+    {
+      id: 1,
+      origin_id: 1,
+      origin_slot: 0,
+      target_id: 3,
+      target_slot: 0,
+      type: 'number'
+    },
+    {
+      id: 2,
+      origin_id: 2,
+      origin_slot: 0,
+      target_id: 3,
+      target_slot: 0,
+      type: 'number'
+    }
+  ]
+}
+
+/**
  * Root graph with slot-shifted duplicates. Target node has an extra input
  * (simulating widget-to-input conversion) that shifts the connected input
  * from slot 0 to slot 1. Link 1 is valid (referenced by input.link),

--- a/src/lib/litegraph/src/__fixtures__/duplicateLinks.ts
+++ b/src/lib/litegraph/src/__fixtures__/duplicateLinks.ts
@@ -73,17 +73,6 @@ export const duplicateLinksRoot: SerialisableGraph = {
   ]
 }
 
-/**
- * Root graph where two links target the same input from *different* origins.
- * SourceA (id 1) holds link 1, SourceB (id 2) holds link 2, and Target's
- * serialized `inputs[0]` references link **2** — so the first link in array
- * order and the link `input.link` names disagree.
- *
- * Not hypothetical: this is byte-for-byte what `main` serializes after a pack
- * creates a link through the legacy slot mirrors alone (`output.links.push`,
- * `input.link =`) instead of `node.connect()`, which is rgthree `link_fixer`'s
- * repair idiom. Reproduced against `main` at 32d0b6e202.
- */
 export const conflictingOriginLinksRoot: SerialisableGraph = {
   id: 'dd000000-0000-4000-8000-000000000004',
   version: 1,

--- a/src/lib/litegraph/src/linkDeduplication.conflictingOrigins.test.ts
+++ b/src/lib/litegraph/src/linkDeduplication.conflictingOrigins.test.ts
@@ -3,9 +3,15 @@ import { setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { LGraph, LGraphNode, LiteGraph } from '@/lib/litegraph/src/litegraph'
+import type {
+  SerialisableLLink,
+  SerialisedLLinkArray
+} from '@/lib/litegraph/src/LLink'
 import { useLinkStore } from '@/stores/linkStore'
 import { graphScopeOf } from '@/types/graphScopeId'
+import { toLinkId } from '@/types/linkId'
 import { toNodeId } from '@/types/nodeId'
+import type { NodeId } from '@/types/nodeId'
 
 import { conflictingOriginLinksRoot } from './__fixtures__/duplicateLinks'
 
@@ -23,23 +29,42 @@ function configureConflictingOrigins() {
   return graph
 }
 
+interface SerializedLinkFields {
+  origin_id: NodeId
+  target_id: NodeId
+  target_slot: number
+}
+
+function linkFieldsOf(
+  link: SerialisedLLinkArray | SerialisableLLink
+): SerializedLinkFields {
+  if (Array.isArray(link)) {
+    const [, origin_id, , target_id, target_slot] = link
+    return {
+      origin_id: toNodeId(origin_id),
+      target_id: toNodeId(target_id),
+      target_slot
+    }
+  }
+  return {
+    origin_id: toNodeId(link.origin_id),
+    target_id: toNodeId(link.target_id),
+    target_slot: link.target_slot
+  }
+}
+
 function linksIntoTargetSlot(
   links: ReturnType<LGraph['serialize']>['links'],
-  targetId: number,
+  targetId: NodeId,
   targetSlot: number
-) {
-  return (links ?? []).filter((link) => {
-    const [, , , target_id, target_slot] = Array.isArray(link)
-      ? link
-      : [
-          link.id,
-          link.origin_id,
-          link.origin_slot,
-          link.target_id,
-          link.target_slot
-        ]
-    return target_id === targetId && target_slot === targetSlot
-  })
+): SerializedLinkFields[] {
+  const fields = (links ?? []).map((link) =>
+    linkFieldsOf(link as SerialisedLLinkArray | SerialisableLLink)
+  )
+  return fields.filter(
+    ({ target_id, target_slot }) =>
+      target_id === targetId && target_slot === targetSlot
+  )
 }
 
 describe('normalizeConfiguredTopology with conflicting origins (#15577)', () => {
@@ -78,10 +103,13 @@ describe('normalizeConfiguredTopology with conflicting origins (#15577)', () => 
   it.fails('re-saves the workflow without changing the upstream node', () => {
     const graph = configureConflictingOrigins()
 
-    const [survivor] = linksIntoTargetSlot(graph.serialize().links, 3, 0)
-    const origin = Array.isArray(survivor) ? survivor[1] : survivor.origin_id
+    const [survivor] = linksIntoTargetSlot(
+      graph.serialize().links,
+      toNodeId(3),
+      0
+    )
 
-    expect(origin).toBe(toNodeId(2))
+    expect(survivor?.origin_id).toBe(toNodeId(2))
   })
 })
 
@@ -101,13 +129,13 @@ describe('legacy mirror link creation (#15577 reachability)', () => {
     graph.add(target)
     sourceA.connect(0, target, 0)
 
-    const mirroredId = ++graph.state.lastLinkId
+    const mirroredId = toLinkId(++graph.state.lastLinkId)
     const output = sourceB.outputs[0]
     output.links = [...(output.links ?? []), mirroredId]
     target.inputs[0].link = mirroredId
 
     expect(
-      linksIntoTargetSlot(graph.serialize().links, Number(target.id), 0)
+      linksIntoTargetSlot(graph.serialize().links, target.id, 0)
     ).toHaveLength(1)
     expect(target.getInputLink(0)?.origin_id).toBe(sourceA.id)
   })

--- a/src/lib/litegraph/src/linkDeduplication.conflictingOrigins.test.ts
+++ b/src/lib/litegraph/src/linkDeduplication.conflictingOrigins.test.ts
@@ -3,10 +3,8 @@ import { setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { LGraph, LGraphNode, LiteGraph } from '@/lib/litegraph/src/litegraph'
-import type {
-  SerialisableLLink,
-  SerialisedLLinkArray
-} from '@/lib/litegraph/src/LLink'
+import type { SerialisedLLinkArray } from '@/lib/litegraph/src/LLink'
+import type { SerialisableLLink } from '@/lib/litegraph/src/types/serialisation'
 import { useLinkStore } from '@/stores/linkStore'
 import { graphScopeOf } from '@/types/graphScopeId'
 import { toLinkId } from '@/types/linkId'

--- a/src/lib/litegraph/src/linkDeduplication.conflictingOrigins.test.ts
+++ b/src/lib/litegraph/src/linkDeduplication.conflictingOrigins.test.ts
@@ -1,0 +1,114 @@
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { LGraph, LGraphNode, LiteGraph } from '@/lib/litegraph/src/litegraph'
+import { useLinkStore } from '@/stores/linkStore'
+import { graphScopeOf } from '@/types/graphScopeId'
+import { toNodeId } from '@/types/nodeId'
+
+import { conflictingOriginLinksRoot } from './__fixtures__/duplicateLinks'
+
+class DupTestNode extends LGraphNode {
+  constructor(title?: string) {
+    super(title ?? 'DupTestNode')
+    this.addInput('input_0', 'number')
+    this.addOutput('output_0', 'number')
+  }
+}
+
+function configureConflictingOrigins() {
+  const graph = new LGraph()
+  graph.configure(structuredClone(conflictingOriginLinksRoot))
+  return graph
+}
+
+function linksIntoTargetSlot(
+  links: ReturnType<LGraph['serialize']>['links'],
+  targetId: number,
+  targetSlot: number
+) {
+  return (links ?? []).filter((link) => {
+    const [, , , target_id, target_slot] = Array.isArray(link)
+      ? link
+      : [
+          link.id,
+          link.origin_id,
+          link.origin_slot,
+          link.target_id,
+          link.target_slot
+        ]
+    return target_id === targetId && target_slot === targetSlot
+  })
+}
+
+describe('normalizeConfiguredTopology with conflicting origins (#15577)', () => {
+  beforeEach(() => {
+    setActivePinia(createTestingPinia({ stubActions: false }))
+    LiteGraph.registerNodeType('test/DupTestNode', DupTestNode)
+  })
+
+  it.fails('keeps the link that input.link references', () => {
+    const graph = configureConflictingOrigins()
+
+    expect(graph.getNodeById(toNodeId(3))?.getInputLink(0)?.origin_id).toBe(
+      toNodeId(2)
+    )
+  })
+
+  it.fails('warns when a link is dropped in favour of a different origin', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    configureConflictingOrigins()
+
+    expect(warn).toHaveBeenCalled()
+    expect(warn.mock.calls.flat().join(' ')).toContain('3:0')
+  })
+
+  it('registers exactly one link at the contested input', () => {
+    const graph = configureConflictingOrigins()
+
+    expect(graph.links.size).toBe(1)
+    expect(
+      useLinkStore().getInputSlotLink(graphScopeOf(graph), toNodeId(3), 0)
+    ).toBeDefined()
+    expect(graph.getNodeById(toNodeId(3))?.getInputLink(0)).toBeDefined()
+  })
+
+  it.fails('re-saves the workflow without changing the upstream node', () => {
+    const graph = configureConflictingOrigins()
+
+    const [survivor] = linksIntoTargetSlot(graph.serialize().links, 3, 0)
+    const origin = Array.isArray(survivor) ? survivor[1] : survivor.origin_id
+
+    expect(origin).toBe(toNodeId(2))
+  })
+})
+
+describe('legacy mirror link creation (#15577 reachability)', () => {
+  beforeEach(() => {
+    setActivePinia(createTestingPinia({ stubActions: false }))
+    LiteGraph.registerNodeType('test/DupTestNode', DupTestNode)
+  })
+
+  it('discards a link written only through the legacy slot mirrors', () => {
+    const graph = new LGraph()
+    const sourceA = LiteGraph.createNode('test/DupTestNode')!
+    const sourceB = LiteGraph.createNode('test/DupTestNode')!
+    const target = LiteGraph.createNode('test/DupTestNode')!
+    graph.add(sourceA)
+    graph.add(sourceB)
+    graph.add(target)
+    sourceA.connect(0, target, 0)
+
+    const mirroredId = ++graph.state.lastLinkId
+    const output = sourceB.outputs[0]
+    output.links = [...(output.links ?? []), mirroredId]
+    target.inputs[0].link = mirroredId
+
+    expect(
+      linksIntoTargetSlot(graph.serialize().links, Number(target.id), 0)
+    ).toHaveLength(1)
+    expect(target.getInputLink(0)?.origin_id).toBe(sourceA.id)
+  })
+})

--- a/src/lib/litegraph/src/linkDeduplication.conflictingOrigins.test.ts
+++ b/src/lib/litegraph/src/linkDeduplication.conflictingOrigins.test.ts
@@ -84,7 +84,6 @@ describe('normalizeConfiguredTopology with conflicting origins (#15577)', () => 
 
     configureConflictingOrigins()
 
-    expect(warn).toHaveBeenCalled()
     expect(warn.mock.calls.flat().join(' ')).toContain('3:0')
   })
 


### PR DESCRIPTION
Both #15577 and #15581 reproduce on this branch, and #15577 is reachable through files today's shipping frontend already saves. Seven `it.fails` assertions state the wanted behaviour; ten controls keep them from passing for the wrong reason.

## #15577 — reachable, and it re-wires the node

`normalizeConfiguredTopology` keys duplicates on `target_id:target_slot` and keeps `data.links[first]` rather than the link `input.link` names. With two links into one input from different origins, the node comes up fed by a different upstream node than the file names, and nothing is logged.

Reachability, measured rather than argued. Driving rgthree `link_fixer`'s mirror-only creation idiom (`output.links.push(id)` + `input.link = id`, no `connect()`) on `main` at `32d0b6e202` and serializing produces:

```
"links":[[1,1,0,3,0,"number"],[2,2,0,3,0,"number"]]
"inputs":[{"name":"input_0","type":"number","link":2}]
```

That is `conflictingOriginLinksRoot` byte for byte. The shape is not hypothetical and it persists across every save on `main`.

Same fixture, both branches:

| | `main` `32d0b6e202` | this branch `9f6ab9adda` |
| --- | --- | --- |
| `getInputLink(0).origin_id` | 2, the origin `input.link` names | 1 |
| links at `3:0` | 2 | 1 |

Dropping to one link is correct, the store enforces one link per input. Which one survives is the regression.

This branch closes the producer: the `input.link` setter ignores id assignment and the `output.links` view discards additions, so the same idiom now serializes one link. Pinned by `discards a link written only through the legacy slot mirrors`. Forward-safe, but files saved before the branch ships still load wrong.

Mutation: preferring the `input.link`-referenced survivor and warning on the drop flips both `it.fails` to pass, controls unchanged.

The negative control `test-cases.md` specified does not exist. Re-narrowing the key to the 4-tuple was predicted to leave two links registered and fail the degeneracy control. It does not: the store rejects the second link downstream and the terminal graph state is identical, link count and all. The 4-tuple key and the 2-tuple key are indistinguishable by any assertion on the resulting graph for this fixture. The control that remains proves the fixture is non-degenerate, which is what it is for.

## #15581 — reproduces, and the issue's suggested fallback does not fix it

A serialized input whose name has no live counterpart is skipped, keeps its stale `target_slot`, and the resulting `occupied-target` rejection `break`s the loop, abandoning every remaining move for that node.

Three cases in `LGraph.inputSlotRealign.test.ts`: `configure` drops an input, `configure` renames one, and `realignInputLinkSlots` called directly on a pre-seeded incumbent. Net effect in cases 1 and 2 is that `in_a` reports `in_c`'s link and `in_b` reports `in_a`'s. No `has_errors`, `console.error` only.

Two mutations, and they disagree:

| Mutation | `it.fails` flipped | Controls |
| --- | --- | --- |
| Per-link retry after a rejected batch, the issue's fallback | 1 of 4 | 8 green |
| Blocking incumbents passed to `updateEndpoints`'s `removals` | 4 of 4 | 8 green |

The per-link fallback fails because the collision cascades: link 3 squats slot 0, so link 1 cannot move off slot 1, so link 2 cannot move onto it. Retrying one at a time hits the same wall. Only evicting the stale incumbent clears it. Worth deciding before anyone implements the issue's first suggestion.

## Counts

17 tests across the two files: 10 pass, 7 expected fail. The eight pre-existing `#3348` tests stay green under both mutations, which is the negative control that the fix does not break what #3348 was filed for.

`oxfmt` and `oxlint --type-aware` clean. `vue-tsc --noEmit` clean for the three files in this diff; the repo-wide count is not meaningful from this worktree, see below.

On typecheck, because it will bite the next person working in a worktree with a borrowed `node_modules`. The first two pushes carried 10 real type errors that `vitest`, `oxfmt` and `oxlint --type-aware` all passed: nine branded-id mismatches (`TS2339`, `TS2322` on `LinkId`) and one wrong import path (`TS2459`). Fixed in `4651215809` and `20039d9e42`.

They got through because my local typecheck was lying, in two different ways:

1. `vue-tsc` **OOMs at the 2GB default heap** — `FATAL ERROR: Ineffective mark-compacts near heap limit`, exit 134, after 18 lines. Filtered for errors that reads as zero. Silence from a dead process is indistinguishable from a pass.
2. The phantom errors are **not only `TS2688`**. With `NODE_OPTIONS=--max-old-space-size=8192` the run completes at exit 2 with 1418 `TS2688` plus 68 `TS7006`/`TS7031`/`TS7053` implicit-any errors in `.vue` and `.stories.ts` — downstream fallout of the broken type roots, not real.

Working recipe: larger heap, confirm exit 2 rather than 134, then grep for your own changed files. Zero for all three files here.

## Wider class, filed separately

All three `updateEndpoints` call sites on this branch swallow rejection into `console.error` and degrade silently, none marks `has_errors`, none uses the repo's unified `reportError`. `slotLinks.ts:192` is the worst of them: on rejection it returns `[]` before `node.inputs.splice`, so the node keeps its old input layout and the empty return is indistinguishable from "nothing to replace". Follow-ups tracked in the workspace todo.

- Repros #15577
- Repros #15581
