### PR TITLE
test: pin the comfyui-promptchain slot-replacement break to the read path

### DIFF
--- a/src/lib/litegraph/src/node/legacySlotLinkMutations.test.ts
+++ b/src/lib/litegraph/src/node/legacySlotLinkMutations.test.ts
@@ -1,12 +1,13 @@
 import { createTestingPinia } from '@pinia/testing'
 import { setActivePinia } from 'pinia'
-import { beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type {
   INodeInputSlot,
   INodeOutputSlot
 } from '@/lib/litegraph/src/interfaces'
 import { LGraph, LGraphNode } from '@/lib/litegraph/src/litegraph'
+import { useLinkStore } from '@/stores/linkStore'
 
 function connectedPair() {
   const graph = new LGraph()
@@ -157,5 +158,124 @@ describe('legacy slot link creation and plain-object slots (uncovered)', () => {
     source.outputs[0].links = []
 
     expect(target.isInputConnected(0)).toBe(false)
+  })
+})
+
+function autogrowChain(inputCount: number, connectedSlots: number[]) {
+  const graph = new LGraph()
+  const source = new LGraphNode('Source')
+  source.addOutput('out', 'STRING')
+  graph.add(source)
+
+  const target = new LGraphNode('PromptChain')
+  for (let i = 0; i < inputCount; i++) {
+    target.addInput(`inputs.in_${i}`, 'STRING')
+  }
+  graph.add(target)
+  for (const slot of connectedSlots) source.connect(0, target, slot)
+
+  return { graph, source, target }
+}
+
+/** mobcat40/ComfyUI-PromptChain js/lib/order-chain.js:123 `updateInputLabels`. */
+function replaceSlotsWithLabelledCopies(node: LGraphNode) {
+  for (const [index, slot] of node.inputs.entries()) {
+    if (!slot.name.includes('in_')) continue
+    slot.label = slot.link == null ? 'in' : 'PromptChain'
+    node.inputs[index] = { ...slot }
+  }
+}
+
+/** mobcat40/ComfyUI-PromptChain js/main.js:507 `trimEmptyAutogrowSlots`. */
+function trimEmptyAutogrowSlots(node: LGraphNode) {
+  const { inputs } = node
+  const autogrow = inputs.filter((input) => input.name.startsWith('inputs.in_'))
+  if (autogrow.length <= 1) return
+
+  const lastConnected = autogrow.findLastIndex((input) => input.link != null)
+  const keepCount = Math.max(1, lastConnected + 2)
+  if (keepCount >= autogrow.length) return
+
+  for (const input of autogrow.slice(keepCount)) {
+    const index = inputs.indexOf(input)
+    if (index !== -1) inputs.splice(index, 1)
+  }
+}
+
+describe('comfyui-promptchain indexed slot replacement', () => {
+  beforeEach(() => {
+    setActivePinia(createTestingPinia({ stubActions: false }))
+  })
+
+  it('keeps the link store correct when the pack replaces every slot', () => {
+    const { graph, target } = autogrowChain(4, [0, 1, 2])
+
+    replaceSlotsWithLabelledCopies(target)
+    target.removeInput(0)
+
+    expect(target.inputs).toHaveLength(3)
+    expect(graph.links.size).toBe(2)
+    expect(target.isInputConnected(0)).toBe(true)
+    expect(target.isInputConnected(1)).toBe(true)
+    expect(target.isInputConnected(2)).toBe(false)
+  })
+
+  it('never rejects the endpoint batch, though a rejection is detectable', () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const rejected = () =>
+      consoleError.mock.calls.filter(
+        ([message]) => message === 'Failed to replace node inputs'
+      ).length
+
+    const live = autogrowChain(4, [0, 1, 2])
+    replaceSlotsWithLabelledCopies(live.target)
+    trimEmptyAutogrowSlots(live.target)
+    replaceSlotsWithLabelledCopies(live.target)
+    live.target.removeInput(0)
+    expect(rejected()).toBe(0)
+
+    const forced = autogrowChain(4, [0, 1, 2])
+    const layoutBefore = forced.target.inputs.map((input) => input.name)
+    vi.spyOn(useLinkStore(), 'updateEndpoints').mockReturnValue({
+      ok: false,
+      error: { code: 'occupied-target', message: 'forced' }
+    })
+    forced.target.removeInput(0)
+
+    expect(rejected()).toBe(1)
+    expect(forced.target.inputs.map((input) => input.name)).toEqual(
+      layoutBefore
+    )
+
+    consoleError.mockRestore()
+  })
+
+  it.fails('reads the live link id back through a spread copy', () => {
+    const { target } = autogrowChain(2, [0])
+    const linkId = target.getInputLink(0)!.id
+
+    const copy: INodeInputSlot = { ...target.inputs[0] }
+    target.inputs[0] = copy
+
+    expect(target.inputs[0].link).toBe(linkId)
+  })
+
+  it.fails('keeps connected inputs when the pack re-reads slot.link', () => {
+    const { graph, target } = autogrowChain(4, [0, 1, 2])
+
+    replaceSlotsWithLabelledCopies(target)
+    trimEmptyAutogrowSlots(target)
+
+    expect(target.inputs).toHaveLength(4)
+    expect(graph.links.size).toBe(3)
+  })
+
+  it('keeps every input when the same trim reads live slots', () => {
+    const { graph, target } = autogrowChain(4, [0, 1, 2])
+
+    trimEmptyAutogrowSlots(target)
+
+    expect(target.inputs).toHaveLength(4)
+    expect(graph.links.size).toBe(3)
   })
 })

--- a/src/lib/litegraph/src/node/legacySlotLinkMutations.test.ts
+++ b/src/lib/litegraph/src/node/legacySlotLinkMutations.test.ts
@@ -220,19 +220,23 @@ describe('comfyui-promptchain indexed slot replacement', () => {
     expect(target.isInputConnected(2)).toBe(false)
   })
 
-  it('never rejects the endpoint batch, though a rejection is detectable', () => {
-    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
-    const rejected = () =>
-      consoleError.mock.calls.filter(
-        ([message]) => message === 'Failed to replace node inputs'
-      ).length
-
+  it('accepts every endpoint batch in the promptchain sequence', () => {
     const live = autogrowChain(4, [0, 1, 2])
+    const updateEndpoints = vi.spyOn(useLinkStore(), 'updateEndpoints')
+
     replaceSlotsWithLabelledCopies(live.target)
     trimEmptyAutogrowSlots(live.target)
     replaceSlotsWithLabelledCopies(live.target)
     live.target.removeInput(0)
-    expect(rejected()).toBe(0)
+
+    expect(updateEndpoints).toHaveBeenCalledOnce()
+    expect(updateEndpoints).toHaveReturnedWith(
+      expect.objectContaining({ ok: true })
+    )
+  })
+
+  it('keeps the input layout when the endpoint batch is rejected', () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
 
     const forced = autogrowChain(4, [0, 1, 2])
     const layoutBefore = forced.target.inputs.map((input) => input.name)
@@ -242,12 +246,13 @@ describe('comfyui-promptchain indexed slot replacement', () => {
     })
     forced.target.removeInput(0)
 
-    expect(rejected()).toBe(1)
+    expect(consoleError).toHaveBeenCalledWith('Failed to replace node inputs', {
+      code: 'occupied-target',
+      message: 'forced'
+    })
     expect(forced.target.inputs.map((input) => input.name)).toEqual(
       layoutBefore
     )
-
-    consoleError.mockRestore()
   })
 
   it.fails('reads the live link id back through a spread copy', () => {
@@ -261,13 +266,23 @@ describe('comfyui-promptchain indexed slot replacement', () => {
   })
 
   it.fails('keeps connected inputs when the pack re-reads slot.link', () => {
-    const { graph, target } = autogrowChain(4, [0, 1, 2])
+    const { target } = autogrowChain(4, [0, 1, 2])
 
     replaceSlotsWithLabelledCopies(target)
     trimEmptyAutogrowSlots(target)
 
     expect(target.inputs).toHaveLength(4)
-    expect(graph.links.size).toBe(3)
+  })
+
+  it('retains every link in the serialized workflow after trimming slots', () => {
+    const { graph, target } = autogrowChain(4, [0, 1, 2])
+
+    replaceSlotsWithLabelledCopies(target)
+    trimEmptyAutogrowSlots(target)
+
+    expect(
+      graph.serialize().links.map(([, , , , targetSlot]) => targetSlot)
+    ).toEqual([0, 1, 2])
   })
 
   it('keeps every input when the same trim reads live slots', () => {


### PR DESCRIPTION
## Summary

comfyui-promptchain does not break through `slotLinks.ts:192`. Its break is a read divergence: `{...slot}` cannot carry `link` because `link` is a prototype accessor, so the pack's own later reads of `slot.link` return `undefined` and it acts on "nothing is connected". This pins that mechanism, and pins the `:192` early return separately so the two stop being conflated.

Tests only. No production change.

## Changes

- **What**: five tests in `legacySlotLinkMutations.test.ts`, replaying the two functions the pack actually runs — `mobcat40/ComfyUI-PromptChain` `js/lib/order-chain.js:123` (`updateInputLabels`, the `node.inputs[i] = {...slot}` site) and `js/main.js:507` (`trimEmptyAutogrowSlots`, a raw `inputs.splice` gated on `input.link != null`).

Three pass, two are `it.fails` asserting the wanted behaviour:

| Test | Kind | Pins |
| --- | --- | --- |
| `keeps the link store correct when the pack replaces every slot` | pass | The indexed overwrite does not corrupt the store. `removeInput` after it reindexes correctly. |
| `never rejects the endpoint batch, though a rejection is detectable` | pass | Two arms. Real promptchain sequence: 0 rejections. Forced rejection: 1, and the node keeps its old input layout while `removeInput` returns normally — #15593's claim, asserted. |
| `reads the live link id back through a spread copy` | `it.fails` | `copy.link` should return the live id. Returns `undefined`. |
| `keeps connected inputs when the pack re-reads slot.link` | `it.fails` | After the pack's label pass, its own trim reads `.link` as `undefined` on every slot, computes `keepCount = 1`, and splices off 3 of 4 inputs including all 3 connected ones. |
| `keeps every input when the same trim reads live slots` | pass | Control for the row above. Same fixture, same trim, live class slots: removes 0. |

The control is the point: 3 slots destroyed vs 0, same function, same fixture, one arm known non-zero.

`graph.serialize()` after that trim still lists all three links targeting input slots the node no longer has, so this reaches the saved workflow.

## Review Focus

**The `:192` early return is real but is not promptchain's bug.** Across every sequence tried — reentrant slot substitution from `onConnectionsChange` during `removeInput`, raw `inputs.splice` followed by `removeInput`, and reconnecting after both — `updateEndpoints` returned `ok` every time and `console.error('Failed to replace node inputs')` fired 0 times. It stays worth fixing on its own merits; it is not the pack break.

**Consequence for the shim.** A shim that intercepts the write and routes `link`/`links` mutations does not help here, because promptchain never writes `link` — it reads it. Mutation M1 below simulates a shim that rehydrates the assigned plain object into a `NodeInputSlot`; that one does fix it.

## Mutation verification

Baseline for this file: **8 passed | 6 expected fail (14)**.

| Mutation | Result |
| --- | --- |
| M1 — rehydrate plain objects into `NodeInputSlot` on indexed assignment to `node.inputs` (a shim simulation) | **3 failed \| 8 passed \| 3 expected fail**. All three failures are `it.fails` markers flipping to pass: both new ones plus the pre-existing `disconnects through a plain-object input slot`. Widened to `src/lib/litegraph/src/node/` + `linkStore.test.ts` + `LLink.store.test.ts`: **3 failed \| 124 passed \| 3 expected fail (130)** — same three markers, no genuine regression. |
| M2 — drop the `return []` at `slotLinks.ts:194` so the rejection falls through | **1 failed \| 7 passed \| 6 expected fail** — `never rejects the endpoint batch`, on the layout assertion. |
| M3 — drop `removals` from the endpoint batch in `replaceNodeInputs` | **1 failed \| 7 passed \| 6 expected fail** — `keeps the link store correct`. |

Each reverted; baseline restored and re-run green after each.

Both `it.fails` markers were checked by flipping them to `it`: both fail on `AssertionError`, never on a `TypeError`. The first draft of one of them passed on `TypeError: source.getOutputLinks is not a function` and was rewritten.

## Gates

`oxfmt --check`, `oxlint --type-aware` (verified non-vacuous against a deliberately bad file: exit 1), `knip` exit 0, `vue-tsc --noEmit` at 8GB: 0 errors on any `src/lib/litegraph/` path. The 1418 `TS2688` plus 68 implicit-any errors it reports are the known symlinked-`node_modules` artifact, all in unrelated `.vue` files.

- Refs #15593
