### PR TITLE
fix(workspace): hide subscription CTA on Local

### DIFF
--- a/browser_tests/tests/workspace/localWorkspaceSwitcher.spec.ts
+++ b/browser_tests/tests/workspace/localWorkspaceSwitcher.spec.ts
@@ -47,7 +47,9 @@ test.describe('Local workspace switcher', { tag: '@auth' }, () => {
       document.body.dataset.workspaceSwitchDocument = 'original'
     })
 
+    await comfyPage.toast.closeToasts()
     await page.getByRole('button', { name: 'Current user' }).click()
+    await expect(page.getByRole('button', { name: 'Subscribe' })).toHaveCount(0)
     await expect(page.getByTestId('workspace-switcher-trigger')).toContainText(
       PERSONAL_WORKSPACE_NAME
     )
@@ -72,6 +74,7 @@ test.describe('Local workspace switcher', { tag: '@auth' }, () => {
     await expect(page.getByTestId('workspace-switcher-trigger')).toContainText(
       TEAM_WORKSPACE_NAME
     )
+    await expect(page.getByRole('button', { name: 'Subscribe' })).toHaveCount(0)
     await expect.poll(() => billingRequestUrls.length).toBeGreaterThan(0)
     expect(tokenRequestBody).toEqual({ workspace_id: 'ws-team' })
     expect(billingRequestUrls).toEqual(

--- a/src/platform/workspace/components/CurrentUserPopoverWorkspace.test.ts
+++ b/src/platform/workspace/components/CurrentUserPopoverWorkspace.test.ts
@@ -315,15 +315,18 @@ describe('CurrentUserPopoverWorkspace', () => {
 
   it('keeps Subscribe hidden on Local after switching to an unsubscribed workspace', async () => {
     state.isCloud = false
-    const { rerender } = renderComponent('personal')
-
     state.canAccessSubscriptionFeatures = false
     state.canManageSubscription = true
+    const { rerender } = renderComponent('personal')
+
     if (!workspaceStoreMock.store) throw new Error('Workspace store not ready')
     workspaceStoreMock.store.workspaceName = 'Team Workspace'
     workspaceStoreMock.store.isInPersonalWorkspace = false
     await rerender({})
 
+    expect(screen.getByTestId('workspace-switcher-trigger')).toHaveTextContent(
+      'Team Workspace'
+    )
     expect(
       screen.queryByRole('button', { name: 'Subscribe' })
     ).not.toBeInTheDocument()

--- a/src/platform/workspace/components/CurrentUserPopoverWorkspace.test.ts
+++ b/src/platform/workspace/components/CurrentUserPopoverWorkspace.test.ts
@@ -12,6 +12,7 @@ import enMessages from '@/locales/en/main.json'
 import CurrentUserPopoverWorkspace from './CurrentUserPopoverWorkspace.vue'
 
 const state = vi.hoisted(() => ({
+  isCloud: true,
   billingStatus: 'paid',
   canAccessSubscriptionFeatures: true,
   isFreeTier: false,
@@ -91,7 +92,11 @@ vi.mock('@/platform/settings/composables/useSettingsDialog', () => ({
   useSettingsDialog: () => ({ show: state.showSettingsDialog })
 }))
 
-vi.mock('@/platform/distribution/types', () => ({ isCloud: true }))
+vi.mock('@/platform/distribution/types', () => ({
+  get isCloud() {
+    return state.isCloud
+  }
+}))
 
 vi.mock('@/services/dialogService', () => ({
   useDialogService: () => ({
@@ -161,6 +166,7 @@ function renderComponent(
 
 describe('CurrentUserPopoverWorkspace', () => {
   beforeEach(() => {
+    state.isCloud = true
     state.billingStatus = 'paid'
     state.canAccessSubscriptionFeatures = true
     state.isFreeTier = false
@@ -305,6 +311,22 @@ describe('CurrentUserPopoverWorkspace', () => {
     expect(
       screen.getByRole('button', { name: 'Subscribe' })
     ).toBeInTheDocument()
+  })
+
+  it('keeps Subscribe hidden on Local after switching to an unsubscribed workspace', async () => {
+    state.isCloud = false
+    const { rerender } = renderComponent('personal')
+
+    state.canAccessSubscriptionFeatures = false
+    state.canManageSubscription = true
+    if (!workspaceStoreMock.store) throw new Error('Workspace store not ready')
+    workspaceStoreMock.store.workspaceName = 'Team Workspace'
+    workspaceStoreMock.store.isInPersonalWorkspace = false
+    await rerender({})
+
+    expect(
+      screen.queryByRole('button', { name: 'Subscribe' })
+    ).not.toBeInTheDocument()
   })
 
   it.for([

--- a/src/platform/workspace/components/CurrentUserPopoverWorkspace.test.ts
+++ b/src/platform/workspace/components/CurrentUserPopoverWorkspace.test.ts
@@ -319,6 +319,10 @@ describe('CurrentUserPopoverWorkspace', () => {
     state.canManageSubscription = true
     const { rerender } = renderComponent('personal')
 
+    expect(
+      screen.queryByRole('button', { name: 'Subscribe' })
+    ).not.toBeInTheDocument()
+
     if (!workspaceStoreMock.store) throw new Error('Workspace store not ready')
     workspaceStoreMock.store.workspaceName = 'Team Workspace'
     workspaceStoreMock.store.isInPersonalWorkspace = false
@@ -329,6 +333,18 @@ describe('CurrentUserPopoverWorkspace', () => {
     )
     expect(
       screen.queryByRole('button', { name: 'Subscribe' })
+    ).not.toBeInTheDocument()
+  })
+
+  it('keeps Resubscribe hidden on Local for a cancelled plan', () => {
+    state.isCloud = false
+    state.isCancelled = true
+    state.canManageSubscriptionLifecycle = true
+
+    renderComponent('team')
+
+    expect(
+      screen.queryByRole('button', { name: 'Resubscribe' })
     ).not.toBeInTheDocument()
   })
 

--- a/src/platform/workspace/components/CurrentUserPopoverWorkspace.test.ts
+++ b/src/platform/workspace/components/CurrentUserPopoverWorkspace.test.ts
@@ -126,6 +126,13 @@ const WorkspaceSwitcherPopoverStub = defineComponent({
   `
 })
 
+const SubscribeButtonStub = defineComponent({
+  props: {
+    label: { type: String, required: true }
+  },
+  template: '<button type="button">{{ label }}</button>'
+})
+
 const i18n = createI18n({
   legacy: false,
   locale: 'en',
@@ -154,7 +161,7 @@ function renderComponent(
       },
       stubs: {
         WorkspaceSwitcherPopover: WorkspaceSwitcherPopoverStub,
-        SubscribeButton: true,
+        SubscribeButton: SubscribeButtonStub,
         UserAvatar: true,
         WorkspaceProfilePic: true,
         Skeleton: true,

--- a/src/platform/workspace/components/CurrentUserPopoverWorkspace.vue
+++ b/src/platform/workspace/components/CurrentUserPopoverWorkspace.vue
@@ -326,10 +326,11 @@ const showManagePlan = computed(
 )
 const showSubscribeAction = computed(
   () =>
-    (isCancelled.value && permissions.value.canManageSubscriptionLifecycle) ||
-    (!canAccessSubscriptionFeatures.value &&
-      !hasDelinquentSubscription.value &&
-      permissions.value.canManageSubscription)
+    isCloud &&
+    ((isCancelled.value && permissions.value.canManageSubscriptionLifecycle) ||
+      (!canAccessSubscriptionFeatures.value &&
+        !hasDelinquentSubscription.value &&
+        permissions.value.canManageSubscription))
 )
 
 const handleOpenUserSettings = () => {


### PR DESCRIPTION
## Why

QA findings 3 and 6 expose the same invalid Local-only state:

- **Finding 3:** a Local personal workspace without a subscription shows `Subscribe`.
- **Finding 6:** switching to another Local workspace recomputes billing state and shows the same `Subscribe` action.

Local workspace switching from [FE-1584](https://linear.app/comfyorg/issue/FE-1584/add-workspace-switcher-to-localdesktop-credits-only-no-settings) is limited to authentication and credits. Local does not support Cloud subscription management, so neither workspace state should offer a subscription CTA.

### Root cause

`CurrentUserPopoverWorkspace` derived `showSubscribeAction` only from subscription access, delinquency, lifecycle, and permission state. It did not include the app distribution. In Local, an unsubscribed workspace can validly have no subscription access while retaining workspace-management permissions; that combination incorrectly satisfied the Cloud `Subscribe` condition. A workspace switch recalculated the same condition, which is why findings 3 and 6 had the same visible outcome.

## How

- Gate `showSubscribeAction` on the existing deterministic `isCloud` distribution value.
- Preserve the existing Subscribe/Resubscribe behavior for Cloud distributions.
- Add unit coverage for a Local workspace changing from personal to an unsubscribed team workspace.
- Extend the Local workspace-switch browser test to assert the CTA is absent both before and after the switch.

## AS IS

![AS IS — Local Team Workspace showing Subscribe](https://ampcode.com/user-content/artifacts/7f7fc9ae0f228d09f6f76ed80a58c83230fbcffaf898c1e6818e712532cb0930-file.png)

Local after switching to Team Workspace incorrectly shows `Subscribe`.

## TO BE

![TO BE — Local Team Workspace without subscription CTA](https://ampcode.com/user-content/artifacts/5fcba122839eeaa2fd387c289b55198257a232778f0d6f89c68fdc0451e6d386-file.png)

Local after switching to Team Workspace keeps subscription actions hidden.

## Testing

- `pnpm test:unit src/platform/workspace/components/CurrentUserPopoverWorkspace.test.ts`
- `pnpm test:browser:local browser_tests/tests/workspace/localWorkspaceSwitcher.spec.ts --project=chromium`
- `pnpm typecheck`
- `pnpm typecheck:browser`
- `pnpm knip`
- lint-staged: oxfmt, stylelint, oxlint, ESLint

## References

- [QA findings](https://app.notion.com/p/3c36d73d365080b4a1b7ea008d323c69)
- [FE-1584](https://linear.app/comfyorg/issue/FE-1584/add-workspace-switcher-to-localdesktop-credits-only-no-settings)