### PR TITLE
fix: address ECS migration review findings

### DIFF
--- a/src/components/builder/AppModeWidgetList.vue
+++ b/src/components/builder/AppModeWidgetList.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, provide } from 'vue'
+import { computed, provide, watchEffect } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import WidgetDescription from '@/components/builder/WidgetDescription.vue'
@@ -87,15 +87,22 @@ function isWidgetInputLinked(node: LGraphNode, widgetName: string): boolean {
   return linkStore.isInputSlotConnected(graphScopeOf(graph), node.id, slot)
 }
 
+watchEffect(() => {
+  for (const entry of resolvedInputs.value) {
+    if (entry.status !== 'resolved') continue
+    if (entry.node.mode !== LGraphEventMode.ALWAYS) continue
+    ensureSelectedWidgetState(entry.widgetId, entry.widget)
+  }
+})
+
 const mappedSelections = computed((): WidgetEntry[] => {
   return resolvedInputs.value.flatMap((entry) => {
     if (entry.status !== 'resolved') return []
     const { widgetId, node, widget, config } = entry
     if (node.mode !== LGraphEventMode.ALWAYS) return []
 
-    ensureSelectedWidgetState(widgetId, widget)
-    const fullNodeData = nodeToNodeData(node, widgetId)
     if (isWidgetInputLinked(node, widget.name)) return []
+    const fullNodeData = nodeToNodeData(node, widgetId)
 
     return [
       {

--- a/src/lib/litegraph/src/LGraph.inputSlotRealign.test.ts
+++ b/src/lib/litegraph/src/LGraph.inputSlotRealign.test.ts
@@ -1,13 +1,16 @@
 import { createTestingPinia } from '@pinia/testing'
 import { setActivePinia } from 'pinia'
-import { beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
   SUBGRAPH_INPUT_ID,
   SUBGRAPH_OUTPUT_ID
 } from '@/lib/litegraph/src/constants'
 import { LGraph, LGraphNode, LiteGraph } from '@/lib/litegraph/src/litegraph'
-import { realignInputLinkSlots } from '@/lib/litegraph/src/linkDeduplication'
+import {
+  normalizeConfiguredTopology,
+  realignInputLinkSlots
+} from '@/lib/litegraph/src/linkDeduplication'
 import type {
   ExportedSubgraph,
   ISerialisedNode,
@@ -305,6 +308,27 @@ function assertLinksRealigned(graph: LGraph, targetNodeId: NodeId) {
     ).toBe(expectedLinkId)
   }
 }
+
+describe('normalizeConfiguredTopology', () => {
+  it('keeps the competing link referenced by the target input', () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const data = savedWorkflow()
+    const target = data.nodes?.find((node) => node.id === 2)
+    if (!target?.inputs || !data.links) throw new Error('Invalid fixture')
+    target.inputs[0].link = 2
+    data.links[1].origin_id = 99
+    data.links[1].target_slot = 0
+
+    const normalized = normalizeConfiguredTopology(data)
+
+    expect(normalized.links?.map((link) => link.id)).toEqual([2, 3])
+    expect(normalized.nodes?.[1].inputs?.[0].link).toBe(2)
+    expect(console.warn).toHaveBeenCalledWith(
+      'Dropping competing link to an occupied input',
+      expect.objectContaining({ droppedLinkId: 2, survivorLinkId: 1 })
+    )
+  })
+})
 
 describe('LGraph.configure input slot realignment (#3348)', () => {
   beforeEach(() => {

--- a/src/lib/litegraph/src/LGraph.inputSlotRealign.test.ts
+++ b/src/lib/litegraph/src/LGraph.inputSlotRealign.test.ts
@@ -435,4 +435,37 @@ describe('realignInputLinkSlots', () => {
       link.id
     )
   })
+
+  it('continues after one link cannot be realigned', () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    const graph = new LGraph()
+    const source = new LGraphNode('Source')
+    source.addOutput('out', 'number')
+    const target = new LGraphNode('Target')
+    target.addInput('first', 'number')
+    target.addInput('occupied', 'number')
+    target.addInput('third', 'number')
+    target.addInput('destination', 'number')
+    graph.add(source)
+    graph.add(target)
+    const blocked = source.connect(0, target, 0)!
+    source.connect(0, target, 1)
+    const movable = source.connect(0, target, 2)!
+    const nodeData = target.serialize()
+    nodeData.inputs = [
+      { ...nodeData.inputs![0], name: 'occupied', link: blocked.id },
+      { ...nodeData.inputs![1], name: 'removed', link: null },
+      { ...nodeData.inputs![2], link: null },
+      { ...nodeData.inputs![3], link: movable.id }
+    ]
+
+    realignInputLinkSlots(graph, [nodeData])
+
+    expect(blocked.target_slot).toBe(0)
+    expect(movable.target_slot).toBe(3)
+    expect(console.error).toHaveBeenCalledWith(
+      'Failed to realign input link slot',
+      expect.objectContaining({ code: 'occupied-target' })
+    )
+  })
 })

--- a/src/lib/litegraph/src/LGraph.test.ts
+++ b/src/lib/litegraph/src/LGraph.test.ts
@@ -886,6 +886,47 @@ describe('Graph Clearing and Callbacks', () => {
       []
     )
   })
+
+  test('configure clears state already stored under the incoming graph id', () => {
+    const incoming = new LGraph()
+    const incomingId = 'graph-configure-cleanup' as UUID
+    incoming.id = incomingId
+    const data = incoming.asSerialisable()
+    const staleNodeId = toNodeId(77)
+    const staleWidgetId = widgetId(incomingId, staleNodeId, 'seed')
+    useWidgetValueStore().registerWidget(staleWidgetId, {
+      type: 'number',
+      value: 1,
+      options: {}
+    })
+    usePreviewExposureStore().addExposure(incomingId, String(staleNodeId), {
+      sourceNodeId: '10',
+      sourcePreviewName: '$$canvas-image-preview'
+    })
+    layoutStore.applyOperation({
+      type: 'createNode',
+      graphId: incomingId,
+      nodeId: staleNodeId,
+      layout: {
+        id: staleNodeId,
+        position: { x: 0, y: 0 },
+        size: { width: 100, height: 100 },
+        zIndex: 1,
+        visible: true,
+        bounds: { x: 0, y: 0, width: 100, height: 100 }
+      },
+      timestamp: Date.now(),
+      source: LayoutSource.Canvas
+    })
+
+    new LGraph().configure(data)
+
+    expect(useWidgetValueStore().getWidget(staleWidgetId)).toBeUndefined()
+    expect(
+      usePreviewExposureStore().getExposures(incomingId, String(staleNodeId))
+    ).toEqual([])
+    expect(layoutStore.getNodeLayout(incomingId, staleNodeId)).toBeNull()
+  })
 })
 
 describe('node:before-removed event', () => {

--- a/src/lib/litegraph/src/LGraph.ts
+++ b/src/lib/litegraph/src/LGraph.ts
@@ -2817,9 +2817,12 @@ export class LGraph
       if (options.clearGraph) {
         const topologyScope = graphScopeOf(this)
         if (this.isRootGraph) {
+          usePreviewExposureStore().clearGraph(this.id)
+          useWidgetValueStore().clearGraph(this.id)
           useLinkStore().clearGraph(topologyScope.rootGraphId)
           useRerouteStore().clearGraph(topologyScope.rootGraphId)
           useNodeDataStore().clearGraph(this.id)
+          layoutStore.clearGraph(this.id)
         } else {
           useLinkStore().clearOwner(topologyScope)
           useRerouteStore().clearOwner(topologyScope)

--- a/src/lib/litegraph/src/LGraphCanvas.titleButtons.test.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.titleButtons.test.ts
@@ -8,6 +8,7 @@ import {
   LGraphNode,
   LiteGraph
 } from '@/lib/litegraph/src/litegraph'
+import { RenderShape } from '@/lib/litegraph/src/types/globalEnums'
 
 describe('LGraphCanvas Title Button Rendering', () => {
   let canvas: LGraphCanvas
@@ -86,6 +87,18 @@ describe('LGraphCanvas Title Button Rendering', () => {
   })
 
   describe('drawNode title button rendering', () => {
+    it('clips using the node rendering shape', () => {
+      Object.defineProperty(node, 'constructor', {
+        value: { shape: RenderShape.ROUND }
+      })
+      node.clip_area = true
+
+      canvas.drawNode(node, ctx)
+
+      expect(ctx.roundRect).toHaveBeenCalled()
+      expect(ctx.rect).not.toHaveBeenCalled()
+    })
+
     it('should render visible title buttons', () => {
       const button1 = node.addTitleButton({
         name: 'button1',

--- a/src/lib/litegraph/src/LGraphCanvas.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.ts
@@ -5684,7 +5684,7 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
       return
 
     // clip if required (mask)
-    const shape = node.shape || RenderShape.BOX
+    const shape = node.renderingShape
     const size = temp_vec2
     size[0] = node.renderingSize[0]
     size[1] = node.renderingSize[1]

--- a/src/lib/litegraph/src/LGraphNode.test.ts
+++ b/src/lib/litegraph/src/LGraphNode.test.ts
@@ -271,7 +271,7 @@ describe('LGraphNode', () => {
       const disconnected = node2.disconnectInput(0)
       expect(disconnected).toBe(true)
       expect(node2.inputs[0].link).toBeNull()
-      expect(node1.outputs[0].links).toBeNull()
+      expect(node1.outputs[0].links).toEqual([])
       expect(graph.links.has(link!.id)).toBe(false)
 
       // Test disconnecting by slot name
@@ -347,7 +347,7 @@ describe('LGraphNode', () => {
       )
       expect(disconnectedByName).toBe(true)
       expect(targetNode1.inputs[0].link).toBeNull()
-      expect(sourceNode.outputs[1].links).toBeNull()
+      expect(sourceNode.outputs[1].links).toEqual([])
 
       // Test disconnecting all connections from an output
       const link4 = sourceNode.connect(0, targetNode1, 0)

--- a/src/lib/litegraph/src/LGraphNode.ts
+++ b/src/lib/litegraph/src/LGraphNode.ts
@@ -3377,6 +3377,9 @@ export class LGraphNode
         ? graph.getNodeById(target_node)
         : target_node
     if (target_node && !onlyTarget) throw 'Target Node not found'
+    if (output instanceof NodeOutputSlot) {
+      output._setLegacyLinksPresent(Boolean(onlyTarget))
+    }
 
     for (const link_info of outputLinks(graph, this.id, slot)) {
       if (onlyTarget && link_info.target_id != onlyTarget.id) continue

--- a/src/lib/litegraph/src/LLink.store.test.ts
+++ b/src/lib/litegraph/src/LLink.store.test.ts
@@ -530,6 +530,27 @@ describe('LLink ↔ linkStore integration', () => {
     )
   })
 
+  it('reports a rejected legacy endpoint mutation', () => {
+    const graph = new LGraph()
+    const firstSource = new LGraphNode('First source')
+    const secondSource = new LGraphNode('Second source')
+    const target = new LGraphNode('Target')
+    firstSource.addOutput('out', 'INT')
+    secondSource.addOutput('out', 'INT')
+    target.addInput('first', 'INT')
+    target.addInput('second', 'INT')
+    graph.add(firstSource)
+    graph.add(secondSource)
+    graph.add(target)
+    const first = firstSource.connect(0, target, 0)!
+    secondSource.connect(0, target, 1)
+
+    expect(() => {
+      first.target_slot = 1
+    }).toThrow('Failed to update link endpoints (occupied-target)')
+    expect(first.target_slot).toBe(0)
+  })
+
   it('updates regular and floating views after endpoint changes', () => {
     const graph = new LGraph()
     const a = new LGraphNode('A')

--- a/src/lib/litegraph/src/LLink.ts
+++ b/src/lib/litegraph/src/LLink.ts
@@ -115,7 +115,9 @@ function applyEndpointPatch(link: LLink, patch: EndpointPatch): void {
       patch
     )
     if (!result.ok) {
-      console.error('Failed to update link endpoints', result.error)
+      throw new Error(
+        `Failed to update link endpoints (${result.error.code}): ${result.error.message}`
+      )
     }
   } else {
     Object.assign(link._state, patch)

--- a/src/lib/litegraph/src/canvas/LinkConnector.integration.test.ts
+++ b/src/lib/litegraph/src/canvas/LinkConnector.integration.test.ts
@@ -448,7 +448,7 @@ describe('LinkConnector Integration', () => {
       expect(connector.outputLinks.length).toBe(0)
 
       expect(disconnectedNode.outputs[0].links).toHaveLength(2)
-      expect(hasOutputNode.outputs[0].links).toBeNull()
+      expect(hasOutputNode.outputs[0].links).toEqual([])
 
       const reroutesAfter = disconnectedNode.outputs[0].links
         ?.map((linkId) => graph.links.get(linkId)!)

--- a/src/lib/litegraph/src/linkDeduplication.ts
+++ b/src/lib/litegraph/src/linkDeduplication.ts
@@ -59,29 +59,55 @@ export function normalizeConfiguredTopology<T extends ConfiguredGraph>(
 ): T {
   if (!data.links?.length) return data
 
-  const survivorByTarget = new Map<string, ReturnType<typeof linkFields>>()
+  const referencedInputLinks = new Set(
+    (data.nodes ?? []).flatMap((node) =>
+      (node.inputs ?? []).flatMap((input) =>
+        input.link == null ? [] : [input.link]
+      )
+    )
+  )
+  const survivorIndexByTarget = new Map<string, number>()
   const survivorByDuplicateId = new Map<number, number>()
-  const links = data.links.filter((link) => {
+  const links: ConfiguredLink[] = []
+  for (const link of data.links) {
     const fields = linkFields(link)
     const key = `${toNodeId(fields.target_id)}:${fields.target_slot}`
-    const survivor = survivorByTarget.get(key)
-    if (!survivor) {
-      survivorByTarget.set(key, fields)
-      return true
+    const survivorIndex = survivorIndexByTarget.get(key)
+    if (survivorIndex === undefined) {
+      survivorIndexByTarget.set(key, links.length)
+      links.push(link)
+      continue
     }
-    if (
+    const survivor = linkFields(links[survivorIndex])
+    const isExactDuplicate =
       toNodeId(survivor.origin_id) === toNodeId(fields.origin_id) &&
       survivor.origin_slot === fields.origin_slot
+    if (!isExactDuplicate) {
+      console.warn('Dropping competing link to an occupied input', {
+        droppedLinkId: fields.id,
+        survivorLinkId: survivor.id,
+        targetNodeId: fields.target_id,
+        targetSlot: fields.target_slot
+      })
+    }
+
+    if (
+      !isExactDuplicate &&
+      referencedInputLinks.has(fields.id) &&
+      !referencedInputLinks.has(survivor.id)
     ) {
+      links[survivorIndex] = link
+      for (const [id, survivorId] of survivorByDuplicateId) {
+        if (survivorId === survivor.id) survivorByDuplicateId.set(id, fields.id)
+      }
+      survivorByDuplicateId.set(survivor.id, fields.id)
+    } else {
       survivorByDuplicateId.set(fields.id, survivor.id)
     }
-    return false
-  })
+  }
   if (links.length === data.links.length) return data
 
   const normalized = Object.assign({}, data, { links })
-  if (!survivorByDuplicateId.size) return normalized
-
   const cloned = cloneDeep(normalized)
   remapLinkReferences(cloned, survivorByDuplicateId)
   return cloned

--- a/src/lib/litegraph/src/linkDeduplication.ts
+++ b/src/lib/litegraph/src/linkDeduplication.ts
@@ -182,7 +182,24 @@ export function realignInputLinkSlots(
         updates
       )
       if (!result.ok) {
-        console.error('Failed to realign input link slots', result.error)
+        for (const { link, slot } of moved) {
+          const fallback = useLinkStore().updateEndpoint(
+            graphScopeOf(graph),
+            link._state,
+            { targetSlot: slot }
+          )
+          if (!fallback.ok) {
+            console.error('Failed to realign input link slot', fallback.error)
+            continue
+          }
+          node.onConnectionsChange?.(
+            NodeSlotType.INPUT,
+            slot,
+            true,
+            link,
+            node.inputs[slot]
+          )
+        }
         break
       }
       for (const { link, slot } of moved) {

--- a/src/lib/litegraph/src/node/NodeOutputSlot.test.ts
+++ b/src/lib/litegraph/src/node/NodeOutputSlot.test.ts
@@ -55,6 +55,15 @@ describe('NodeOutputSlot deprecated links getter', () => {
     expect(source.outputs[0].links).toBeNull()
   })
 
+  it('retains an empty array after disconnecting a specific target', () => {
+    const { source, target } = createConnectedGraph()
+    source.connect(0, target, 0)
+
+    source.disconnectOutput(0, target)
+
+    expect(source.outputs[0].links).toEqual([])
+  })
+
   it('returns null for an unconnected slot and for a graphless node', () => {
     const { source } = createConnectedGraph()
     expect(source.outputs[0].links).toBeNull()

--- a/src/lib/litegraph/src/node/NodeOutputSlot.ts
+++ b/src/lib/litegraph/src/node/NodeOutputSlot.ts
@@ -50,12 +50,18 @@ export class NodeOutputSlot extends NodeSlot implements INodeOutputSlot {
     this.commitLegacyLinks()
   }
 
-  private synchronizeLegacyLinks(preservePresence = false): void {
-    const hadIds = this.legacyLinkIds.length > 0
+  private synchronizeLegacyLinks(): void {
     const ids = linkIdsOf(this)
     this.legacyLinkIds.splice(0, this.legacyLinkIds.length, ...ids)
     if (ids.length) this.legacyLinksPresent = true
-    else if (hadIds && !preservePresence) this.legacyLinksPresent = false
+  }
+
+  _setLegacyLinksPresent(present: boolean): void {
+    this.legacyLinksPresent = present
+  }
+
+  _serialiseLinkIds(ids: LinkId[]): LinkId[] | null {
+    return ids.length || this.legacyLinksPresent ? ids : null
   }
 
   private commitLegacyLinks(): void {
@@ -71,7 +77,7 @@ export class NodeOutputSlot extends NodeSlot implements INodeOutputSlot {
       if (desired.has(link.id)) continue
       graph.getNodeById(link.target_id)?.disconnectInput(link.target_slot)
     }
-    this.synchronizeLegacyLinks(true)
+    this.synchronizeLegacyLinks()
   }
 
   get isWidgetInputSlot(): false {
@@ -153,7 +159,7 @@ export class NodeOutputSlot extends NodeSlot implements INodeOutputSlot {
     const ids = linkIdsOf(this)
     return {
       ...super.toJSON(),
-      links: ids.length ? ids : null,
+      links: this._serialiseLinkIds(ids),
       slot_index: this.slot_index
     }
   }

--- a/src/lib/litegraph/src/node/legacySlotLinkMutations.test.ts
+++ b/src/lib/litegraph/src/node/legacySlotLinkMutations.test.ts
@@ -136,7 +136,7 @@ describe('legacy slot link creation and plain-object slots (uncovered)', () => {
     expect(target.isInputConnected(0)).toBe(true)
   })
 
-  it.fails('disconnects through a plain-object input slot', () => {
+  it('disconnects through a plain-object input slot', () => {
     // The shape the one confirmed-broken pack uses: replace the slot with a
     // spread copy, then mutate that. `link` is an accessor, so the copy carries
     // neither the shim nor the current id.
@@ -149,7 +149,7 @@ describe('legacy slot link creation and plain-object slots (uncovered)', () => {
     expect(source.isOutputConnected(0)).toBe(false)
   })
 
-  it.fails('disconnects through a plain-object output slot', () => {
+  it('disconnects through a plain-object output slot', () => {
     const { source, target } = connectedPair()
     const copy: INodeOutputSlot = { ...source.outputs[0] }
     source.outputs[0] = copy

--- a/src/lib/litegraph/src/node/slotUtils.test.ts
+++ b/src/lib/litegraph/src/node/slotUtils.test.ts
@@ -14,18 +14,20 @@ type OutputSlotParam = INodeOutputSlot & { widget?: IWidget }
 function createConnectedGraph(linkIds: number[]) {
   const graph = new LGraph()
   const source = new LGraphNode('Source')
+  const targets: LGraphNode[] = []
   source.addOutput('out', 'number')
   graph.add(source)
 
   for (const [i, linkId] of linkIds.entries()) {
     const target = new LGraphNode(`Target${i}`)
+    targets.push(target)
     target.addInput('in', 'number')
     graph.add(target)
     graph.state.lastLinkId = toLinkId(linkId - 1)
     source.connect(0, target, 0)
   }
 
-  return { graph, source }
+  return { graph, source, targets }
 }
 
 describe('outputAsSerialisable', () => {
@@ -69,6 +71,19 @@ describe('outputAsSerialisable', () => {
       0
     )
     expect(serialised.links).toBeNull()
+  })
+
+  it('serialises an empty array after a targeted disconnect', () => {
+    const { source, targets } = createConnectedGraph([1])
+    source.disconnectOutput(0, targets[0])
+
+    const serialised = outputAsSerialisable(
+      source.outputs[0] as OutputSlotParam,
+      source,
+      0
+    )
+
+    expect(serialised.links).toEqual([])
   })
 
   it('serialises null for a node with no graph', () => {

--- a/src/lib/litegraph/src/node/slotUtils.ts
+++ b/src/lib/litegraph/src/node/slotUtils.ts
@@ -1,4 +1,5 @@
 import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
+import type { LinkId } from '@/lib/litegraph/src/LLink'
 import type {
   IWidgetInputSlot,
   SharedIntersection
@@ -18,6 +19,16 @@ type CommonIoSlotProps = SharedIntersection<
   ISerialisableNodeInput,
   ISerialisableNodeOutput
 >
+
+function serialisesLegacyLinkPresence(
+  slot: INodeOutputSlot
+): slot is INodeOutputSlot & {
+  _serialiseLinkIds(ids: LinkId[]): LinkId[] | null
+} {
+  return (
+    '_serialiseLinkIds' in slot && typeof slot._serialiseLinkIds === 'function'
+  )
+}
 
 function shallowCloneCommonProps(slot: CommonIoSlotProps): CommonIoSlotProps {
   const {
@@ -76,13 +87,18 @@ export function outputAsSerialisable(
   // Output widgets do not exist in Litegraph; this is a temporary downstream workaround.
   const outputWidget = widget ? { widget: { name: widget.name } } : null
   const ids = node.graph ? outputLinkIds(node.graph, node.id, slotIndex) : []
+  const links = serialisesLegacyLinkPresence(slot)
+    ? slot._serialiseLinkIds(ids)
+    : ids.length
+      ? ids
+      : (slot.links ?? null)
 
   return {
     ...shallowCloneCommonProps(slot),
     ...outputWidget,
     pos,
     slot_index,
-    links: ids.length ? ids : null
+    links
   }
 }
 

--- a/src/lib/litegraph/src/widgets/BaseWidget.test.ts
+++ b/src/lib/litegraph/src/widgets/BaseWidget.test.ts
@@ -215,6 +215,24 @@ describe('BaseWidget store integration', () => {
       ).toBe('number-custom')
     })
 
+    it('registers duplicate widget names under distinct ids', () => {
+      const first = createTestWidget(node, { name: 'duplicate' })
+      const second = createTestWidget(node, { name: 'duplicate' })
+      node.widgets = [first, second]
+
+      first.setNodeId(toNodeId(1))
+      second.setNodeId(toNodeId(1))
+
+      expect(first.widgetId).toBe(widgetId(graph.id, toNodeId(1), 'duplicate'))
+      expect(second.widgetId).toBe(
+        widgetId(graph.id, toNodeId(1), 'duplicate#1')
+      )
+      expect(store.getNodeWidgetIds(graph.id, toNodeId(1))).toEqual([
+        first.widgetId,
+        second.widgetId
+      ])
+    })
+
     it('stores explicit isDOMWidget false over component presence', () => {
       const widget = createTestWidget(node, { name: 'flaggedDomWidget' })
       Object.assign(widget, { component: {}, isDOMWidget: false })

--- a/src/lib/litegraph/src/widgets/BaseWidget.ts
+++ b/src/lib/litegraph/src/widgets/BaseWidget.ts
@@ -133,11 +133,22 @@ export abstract class BaseWidget<TWidget extends IBaseWidget = IBaseWidget>
     this._state.value = value
   }
 
+  private get storeName(): string {
+    const index = this.node.widgets?.indexOf(this) ?? -1
+    const duplicateIndex =
+      index > 0
+        ? this.node.widgets
+            ?.slice(0, index)
+            .filter((widget) => widget.name === this.name).length
+        : 0
+    return duplicateIndex ? `${this.name}#${duplicateIndex}` : this.name
+  }
+
   get widgetId(): WidgetId | undefined {
     const graphId = this.node.graph?.rootGraph.id
     const nodeId = this._state.nodeId
     if (!graphId || nodeId === undefined) return undefined
-    return widgetId(graphId, nodeId, this.name)
+    return widgetId(graphId, nodeId, this.storeName)
   }
 
   /**
@@ -149,7 +160,7 @@ export abstract class BaseWidget<TWidget extends IBaseWidget = IBaseWidget>
     if (!graphId) return
 
     const registered = useWidgetValueStore().registerWidget(
-      widgetId(graphId, nodeId, this.name),
+      widgetId(graphId, nodeId, this.storeName),
       {
         ...this._state,
         type: this.type,

--- a/src/renderer/core/canvas/litegraph/arrangeForLegacyRender.test.ts
+++ b/src/renderer/core/canvas/litegraph/arrangeForLegacyRender.test.ts
@@ -1,10 +1,11 @@
 import { createTestingPinia } from '@pinia/testing'
 import { setActivePinia } from 'pinia'
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { LGraph, LGraphNode, LiteGraph } from '@/lib/litegraph/src/litegraph'
 import { arrangeForLegacyRender } from '@/renderer/core/canvas/litegraph/arrangeForLegacyRender'
 import { useLayoutMutations } from '@/renderer/core/layout/operations/layoutMutations'
+import { layoutStore } from '@/renderer/core/layout/store/layoutStore'
 import { LayoutSource } from '@/renderer/core/layout/types'
 
 function addedNode(graph: LGraph) {
@@ -59,5 +60,16 @@ describe('arrangeForLegacyRender', () => {
     arrangeForLegacyRender(graph)
 
     expect(graph._nodes).toEqual([second, first])
+  })
+
+  it('reads each node layout once while sorting', () => {
+    const graph = new LGraph()
+    const nodes = [addedNode(graph), addedNode(graph), addedNode(graph)]
+    for (const node of nodes) node.flags.collapsed = true
+    const getNodeLayout = vi.spyOn(layoutStore, 'getNodeLayout')
+
+    arrangeForLegacyRender(graph)
+
+    expect(getNodeLayout).toHaveBeenCalledTimes(nodes.length)
   })
 })

--- a/src/renderer/core/canvas/litegraph/arrangeForLegacyRender.ts
+++ b/src/renderer/core/canvas/litegraph/arrangeForLegacyRender.ts
@@ -14,10 +14,14 @@ const logger = log.getLogger('arrangeForLegacyRender')
  */
 export function arrangeForLegacyRender(graph: LGraph): void {
   const rootGraphId = graph.rootGraph.id
+  const zIndexByNode = new Map(
+    graph._nodes.map((node) => [
+      node,
+      layoutStore.getNodeLayout(rootGraphId, node.id)?.zIndex ?? 0
+    ])
+  )
   graph._nodes.sort(
-    (a, b) =>
-      (layoutStore.getNodeLayout(rootGraphId, a.id)?.zIndex ?? 0) -
-      (layoutStore.getNodeLayout(rootGraphId, b.id)?.zIndex ?? 0)
+    (a, b) => (zIndexByNode.get(a) ?? 0) - (zIndexByNode.get(b) ?? 0)
   )
 
   for (const node of graph._nodes) {

--- a/src/renderer/extensions/vueNodes/components/LGraphNode.vue
+++ b/src/renderer/extensions/vueNodes/components/LGraphNode.vue
@@ -627,7 +627,7 @@ const { hideExecutedOutput } = useGLSLPreview(lgraphNode)
 
 const widgetValueStore = useWidgetValueStore()
 const widgetIds = computed(() => {
-  const graphId = app.rootGraph?.id
+  const graphId = canvasStore.rootGraphId
   const bareNodeId = stripGraphPrefix(nodeData.id)
   if (!graphId || !bareNodeId) return []
 

--- a/src/renderer/extensions/vueNodes/composables/useProcessedWidgets.test.ts
+++ b/src/renderer/extensions/vueNodes/composables/useProcessedWidgets.test.ts
@@ -431,6 +431,17 @@ describe('computeProcessedWidgets', () => {
     expect(result[0].simplified.value).toBeNull()
   })
 
+  it('uses the live widget type after runtime changes', () => {
+    const id = widgetId(GRAPH_ID, toNodeId(1), 'text')
+    registerWidgetState(id, { type: 'combo' })
+    const widget = createMockWidget({ widgetId: id, name: 'text', type: '' })
+    const { graph } = createGraphWithNode([widget])
+
+    const result = processWidgets({ widgetIds: [id], rootGraph: graph })
+
+    expect(result).toEqual([])
+  })
+
   it('uses widget state nodeId for simplified widget locator', () => {
     const subgraphId = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890'
     const id = widgetId(GRAPH_ID, toNodeId('inner-node'), 'text')

--- a/src/renderer/extensions/vueNodes/composables/useProcessedWidgets.ts
+++ b/src/renderer/extensions/vueNodes/composables/useProcessedWidgets.ts
@@ -363,17 +363,15 @@ function processWidget(
   const widgetState = ctx.widgetValueStore.getWidget(id)
   if (!widgetState) return null
 
+  const liveWidget = ctx.liveWidgets.get(id)
+  const type = liveWidget?.type ?? widgetState.type
   const renderState = ctx.widgetValueStore.getWidgetRenderState(id)
   const options: IWidgetOptions = { ...(widgetState.options ?? {}) }
   if (options.advanced === undefined) options.advanced = renderState?.advanced
-  if (!shouldRenderAsVue({ type: widgetState.type, options })) return null
+  if (!shouldRenderAsVue({ type, options })) return null
 
   const { live, errorTarget, controlWidget, sourceExecutionId } =
-    resolveLiveWidgetContext(
-      ctx.rootGraph,
-      ctx.hostNode,
-      ctx.liveWidgets.get(id)
-    )
+    resolveLiveWidgetContext(ctx.rootGraph, ctx.hostNode, liveWidget)
 
   const slotInfo = ctx.slotMetadata.get(widgetState.name)
   const visible = isWidgetVisible(
@@ -403,7 +401,7 @@ function processWidget(
 
   const simplified: SimplifiedWidget = {
     name: widgetState.name,
-    type: widgetState.type,
+    type,
     value,
     borderStyle: widgetOptions.advanced
       ? 'ring ring-component-node-widget-advanced'
@@ -420,7 +418,7 @@ function processWidget(
   }
 
   const valueTooltip =
-    isTooltipValueType(widgetState.type) && String(value).length > 10
+    isTooltipValueType(type) && String(value).length > 10
       ? String(value)
       : undefined
   const tooltipConfig = ctx.ui.getTooltipConfig(
@@ -446,9 +444,9 @@ function processWidget(
       ctx.missingMediaStore
     ),
     widgetId: id,
-    renderKey: `${id}:${widgetState.type}`,
+    renderKey: `${id}:${type}`,
     vueComponent:
-      getComponent(widgetState.type) ||
+      getComponent(type) ||
       (renderState?.isDOMWidget ? WidgetDOM : WidgetLegacy),
     simplified,
     visible,

--- a/src/stores/widgetValueStore.test.ts
+++ b/src/stores/widgetValueStore.test.ts
@@ -96,14 +96,24 @@ describe('useWidgetValueStore', () => {
       expect(registered.y).toBe(42)
     })
 
-    it('registerWidget is idempotent and does not overwrite existing state', () => {
+    it('refreshes metadata without overwriting the current value', () => {
       const store = useWidgetValueStore()
       const first = store.registerWidget(seedA, state('number', 11))!
       first.value = 99
 
-      const second = store.registerWidget(seedA, state('number', 11))!
+      const second = store.registerWidget(
+        seedA,
+        state('number', 11, {
+          label: 'Updated seed',
+          options: { min: 4 },
+          disabled: true
+        })
+      )!
       expect(second).toBe(first)
       expect(second.value).toBe(99)
+      expect(second.label).toBe('Updated seed')
+      expect(second.options).toEqual({ min: 4 })
+      expect(second.disabled).toBe(true)
     })
 
     it('replaces a stale entry when the widget type changes', () => {

--- a/src/stores/widgetValueStore.test.ts
+++ b/src/stores/widgetValueStore.test.ts
@@ -367,10 +367,11 @@ describe('useWidgetValueStore', () => {
       }
     })
 
-    it('getWidget / setValue / deleteWidget tolerate un-keyable ids', () => {
+    it('read, update, and delete operations tolerate un-keyable ids', () => {
       const store = useWidgetValueStore()
       for (const id of malformedIds) {
         expect(store.getWidget(id)).toBeUndefined()
+        expect(store.getWidgetRenderState(id)).toBeUndefined()
         expect(store.setValue(id, 1)).toBe(false)
         expect(store.deleteWidget(id)).toBe(false)
       }

--- a/src/stores/widgetValueStore.test.ts
+++ b/src/stores/widgetValueStore.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import type { UUID } from '@/utils/uuid'
 import { toNodeId } from '@/types/nodeId'
@@ -26,6 +26,18 @@ describe('useWidgetValueStore', () => {
     it('getWidget returns undefined for unregistered widget', () => {
       const store = useWidgetValueStore()
       expect(store.getWidget(seedA)).toBeUndefined()
+    })
+
+    it('does not create state while reading missing widgets', () => {
+      const store = useWidgetValueStore()
+      const onMutation = vi.fn()
+      store.$subscribe(onMutation, { flush: 'sync' })
+
+      expect(store.getWidget(seedA)).toBeUndefined()
+      expect(store.getWidgetRenderState(seedA)).toBeUndefined()
+      expect(store.getNodeWidgetIds(graphA, toNodeId('node-1'))).toEqual([])
+
+      expect(onMutation).not.toHaveBeenCalled()
     })
 
     it('widgetState.value can be read and written directly', () => {

--- a/src/stores/widgetValueStore.ts
+++ b/src/stores/widgetValueStore.ts
@@ -202,6 +202,8 @@ export const useWidgetValueStore = defineStore('widgetValue', () => {
   function getWidgetRenderState(
     widgetId: WidgetId
   ): WidgetRenderState | undefined {
+    if (!isWidgetId(widgetId)) return undefined
+
     const { graphId } = parseWidgetId(widgetId)
     return getGraphWidgetRenderStates(graphId).get(widgetId)
   }

--- a/src/stores/widgetValueStore.ts
+++ b/src/stores/widgetValueStore.ts
@@ -153,6 +153,11 @@ export const useWidgetValueStore = defineStore('widgetValue', () => {
 
     const existing = getWidget(widgetId)
     if (existing && existing.type === init.type) {
+      const value = existing.value
+      Object.assign(existing, init, {
+        value,
+        y: init.y ?? existing.y
+      })
       appendNodeWidgetOrder(widgetId)
       return existing as WidgetState<TValue>
     }

--- a/src/stores/widgetValueStore.ts
+++ b/src/stores/widgetValueStore.ts
@@ -127,7 +127,8 @@ export const useWidgetValueStore = defineStore('widgetValue', () => {
 
   function removeNodeWidgetOrder(widgetId: WidgetId): void {
     const { graphId, nodeId } = parseWidgetId(widgetId)
-    const graphOrders = getGraphNodeWidgetOrders(graphId)
+    const graphOrders = graphNodeWidgetOrders.value.get(graphId)
+    if (!graphOrders) return
     const order = graphOrders.get(nodeId)
     if (!order) return
 
@@ -196,7 +197,7 @@ export const useWidgetValueStore = defineStore('widgetValue', () => {
     if (!isWidgetId(widgetId)) return undefined
 
     const { graphId } = parseWidgetId(widgetId)
-    return getGraphWidgetStates(graphId).get(widgetId)
+    return graphWidgetStates.value.get(graphId)?.get(widgetId)
   }
 
   function getWidgetRenderState(
@@ -205,7 +206,7 @@ export const useWidgetValueStore = defineStore('widgetValue', () => {
     if (!isWidgetId(widgetId)) return undefined
 
     const { graphId } = parseWidgetId(widgetId)
-    return getGraphWidgetRenderStates(graphId).get(widgetId)
+    return graphWidgetRenderStates.value.get(graphId)?.get(widgetId)
   }
 
   function setValue(widgetId: WidgetId, value: WidgetState['value']): boolean {
@@ -229,9 +230,9 @@ export const useWidgetValueStore = defineStore('widgetValue', () => {
     if (!isWidgetId(widgetId)) return false
 
     const { graphId } = parseWidgetId(widgetId)
-    getGraphWidgetRenderStates(graphId).delete(widgetId)
+    graphWidgetRenderStates.value.get(graphId)?.delete(widgetId)
     removeNodeWidgetOrder(widgetId)
-    return getGraphWidgetStates(graphId).delete(widgetId)
+    return graphWidgetStates.value.get(graphId)?.delete(widgetId) ?? false
   }
 
   function getNodeWidgets(graphId: UUID, localNodeId: NodeId): WidgetState[] {
@@ -260,7 +261,9 @@ export const useWidgetValueStore = defineStore('widgetValue', () => {
   }
 
   function getNodeWidgetIds(graphId: UUID, localNodeId: NodeId): WidgetId[] {
-    return [...getNodeWidgetOrder(graphId, localNodeId)]
+    return [
+      ...(graphNodeWidgetOrders.value.get(graphId)?.get(localNodeId) ?? [])
+    ]
   }
 
   function setNodeWidgetOrder(

--- a/src/systems/badgeSystem.subgraph.test.ts
+++ b/src/systems/badgeSystem.subgraph.test.ts
@@ -24,8 +24,8 @@ vi.mock('@/composables/node/useNodePricing', () => ({
   useNodePricing: () => ({
     getNodeDisplayPrice,
     getNodeRevisionRef: () => ({ value: 0 }),
-    hasDynamicPricing: () => false,
-    getRelevantWidgetNames: () => [],
+    hasDynamicPricing: () => true,
+    getRelevantWidgetNames: () => ['prompt'],
     getInputNames: () => [],
     getInputGroupPrefixes: () => []
   })
@@ -128,6 +128,29 @@ describe('badge derivation subgraph credits aggregation', () => {
     useWidgetValueStore().setValue(inputWidgetId, 'outer value')
 
     expect(wrapperCredits()).toEqual(['outer value'])
+  })
+
+  it('reacts to an unpromoted inner pricing widget', () => {
+    const { addInner, wrapperCredits } = setup()
+    const apiNode = new ApiNode('api')
+    const widget = apiNode.addWidget(
+      'string',
+      'prompt',
+      'first',
+      () => undefined,
+      {}
+    )
+    addInner(apiNode, 11)
+    const id = widget.widgetId
+    if (!id) throw new Error('Missing inner widget id')
+    getNodeDisplayPrice.mockImplementation(() =>
+      String(useWidgetValueStore().getWidget(id)?.value)
+    )
+    expect(wrapperCredits()).toEqual(['first'])
+
+    useWidgetValueStore().setValue(id, 'second')
+
+    expect(wrapperCredits()).toEqual(['second'])
   })
 
   describe('graphCreditsBadges', () => {

--- a/src/systems/badgeSystem.ts
+++ b/src/systems/badgeSystem.ts
@@ -177,7 +177,8 @@ function gatherSubgraphCredits(wrapper: SubgraphNode): PricingBadgeSources {
       : undefined
   )
   for (const leaf of apiLeaves) {
-    void pricing.getNodeRevisionRef(leaf.id).value
+    const graphId = leaf.graph?.rootGraph.id
+    if (graphId !== undefined) touchPricingSources(graphId, leaf)
   }
 
   if (apiLeaves.length !== 1) {

--- a/src/utils/litegraphUtil.test.ts
+++ b/src/utils/litegraphUtil.test.ts
@@ -10,7 +10,12 @@ import { toNodeId } from '@/types/nodeId'
 import { widgetId } from '@/types/widgetId'
 import { createMockLGraphNode } from '@/utils/__tests__/litegraphTestUtils'
 
-import { createNode, getWidgetIdForNode, resolveNode } from './litegraphUtil'
+import {
+  createNode,
+  getWidgetIdForNode,
+  mapLiveWidgetsById,
+  resolveNode
+} from './litegraphUtil'
 
 beforeEach(() => setActivePinia(createTestingPinia({ stubActions: false })))
 
@@ -179,6 +184,19 @@ describe('getWidgetIdForNode', () => {
     expect(getWidgetIdForNode(node, { name: 'UNKNOWN' }, 1)).toBe(
       widgetId(graphId, toNodeId(42), 'UNKNOWN#1')
     )
+  })
+
+  it('distinguishes duplicate names across widget types', () => {
+    const node = fakeNode(42)
+    node.widgets = [
+      { name: 'shared', type: 'number', value: 1, options: {}, y: 0 },
+      { name: 'shared', type: 'text', value: 'two', options: {}, y: 0 }
+    ]
+
+    expect([...mapLiveWidgetsById(node).keys()]).toEqual([
+      widgetId(graphId, toNodeId(42), 'shared'),
+      widgetId(graphId, toNodeId(42), 'shared#1')
+    ])
   })
 
   it('returns undefined when the node has no graph', () => {

--- a/src/utils/litegraphUtil.ts
+++ b/src/utils/litegraphUtil.ts
@@ -338,11 +338,10 @@ export function mapLiveWidgetsById(
   node: LGraphNode
 ): Map<WidgetId, IBaseWidget> {
   const byId = new Map<WidgetId, IBaseWidget>()
-  const duplicateIndexByKey = new Map<string, number>()
+  const duplicateIndexByName = new Map<string, number>()
   for (const widget of node.widgets ?? []) {
-    const duplicateKey = `${widget.name}:${widget.type}`
-    const duplicateIndex = duplicateIndexByKey.get(duplicateKey) ?? 0
-    duplicateIndexByKey.set(duplicateKey, duplicateIndex + 1)
+    const duplicateIndex = duplicateIndexByName.get(widget.name) ?? 0
+    duplicateIndexByName.set(widget.name, duplicateIndex + 1)
     const id = getWidgetIdForNode(node, widget, duplicateIndex)
     if (id) byId.set(id, widget)
   }


### PR DESCRIPTION
## Summary

- address the 15 substantive review findings from #14246 against the current #15544 stack
- preserve legacy topology and widget compatibility while keeping store reads and app-mode registration side-effect safe
- fix root-graph reactivity, nested pricing, stale store cleanup, node clipping, and legacy sort performance

## Testing

- `pnpm lint`
- `pnpm format:check`
- `pnpm typecheck`
- `pnpm knip`
- targeted Vitest suites for each change
- full unit run: 16,841 passed; one unrelated camera-framing timing test failed and then passed in isolation; five stale link-array assertions were updated and their 150-test focused suite passed

Child of #15544. Review findings originated in #14246 and were checked against #15536 and #15544.