### PR TITLE
test: assert locate emit on the child listener, not the wrapper root

### DIFF
--- a/src/components/rightSidePanel/errors/LocateNodeButton.test.ts
+++ b/src/components/rightSidePanel/errors/LocateNodeButton.test.ts
@@ -29,11 +29,12 @@ describe('LocateNodeButton', () => {
   it('stops click propagation so an ancestor handler does not also fire', async () => {
     const user = userEvent.setup()
     const onAncestorClick = vi.fn()
-    const { emitted } = render({
+    const onLocate = vi.fn()
+    render({
       components: { LocateNodeButton },
-      setup: () => ({ onAncestorClick }),
+      setup: () => ({ onAncestorClick, onLocate }),
       template:
-        '<div @click="onAncestorClick"><LocateNodeButton label="Locate node on canvas" /></div>'
+        '<div @click="onAncestorClick"><LocateNodeButton label="Locate node on canvas" @locate="onLocate" /></div>'
     })
 
     await user.click(
@@ -41,7 +42,7 @@ describe('LocateNodeButton', () => {
     )
 
     expect(onAncestorClick).not.toHaveBeenCalled()
-    expect(emitted().locate).toHaveLength(1)
+    expect(onLocate).toHaveBeenCalledTimes(1)
   })
 
   it('emits locate on keyboard activation without relying on implicit tab order', async () => {


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

Fixes the failing `test` job on #15413. Targets that PR's branch, so merging this here makes #15413 green.

## Problem

`emitted()` returned by `@testing-library/vue`'s `render()` reports events for the component handed to `render()` — internally it is just `emitted: name => wrapper.emitted(name)` on the mounted root.

The propagation test renders an ad-hoc wrapper, so the root is the `<div>`, not `LocateNodeButton`. The wrapper never emits `locate`; only the child does. So `emitted().locate` was `undefined` and `expect(undefined).toHaveLength(1)` threw:

```
AssertionError: Target cannot be null or undefined.
 ❯ LocateNodeButton.test.ts:44:30
```

Dumping what the wrapper actually reports confirms it — only native events that bubbled to the root element, and notably no `click`, which independently shows `@click.stop` is working:

```
pointerover, pointerenter, mouseover, mouseenter, pointermove,
mousemove, pointerdown, mousedown, focusin, pointerup, mouseup
```

The assertion could never pass, regardless of component behavior. The component itself is fine — no regression.

## Fix

Spy on the child's `@locate` handler instead of reading the wrapper's `emitted()`. `@vue/test-utils` `findComponent()` is not an option here — `docs/guidance/vitest.md` bans it in new tests — and `render()` exposes no way to reach a child's emitted events.

## Verification

- `pnpm vitest run src/components/rightSidePanel/errors/LocateNodeButton.test.ts` — 4/4 pass
- `pnpm vitest run src/components/rightSidePanel` — 208/208 pass
- `pnpm typecheck` (exit 0), `pnpm format:check`, ESLint on the changed file — all clean

The assertion keeps its teeth. Replacing `@click.stop="emit('locate')"` with `@click.stop="() => {}"` — precisely the swallowed-emit case the original PR set out to catch — still fails:

```
AssertionError: expected "vi.fn()" to be called 1 times, but got 0 times
 ❯ LocateNodeButton.test.ts:45:22
```
