### PR TITLE
fix(litegraph): clear widget and preview stores for the incoming graph id on configure

### DIFF
--- a/src/lib/litegraph/src/LGraph.configureStoreScope.test.ts
+++ b/src/lib/litegraph/src/LGraph.configureStoreScope.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from 'vitest'
+
+import { LGraph, LGraphNode, LiteGraph } from '@/lib/litegraph/src/litegraph'
+import { usePreviewExposureStore } from '@/stores/previewExposureStore'
+import { renameWidget } from '@/utils/widgetUtil'
+
+class LabelledWidgetNode extends LGraphNode {
+  static override title = 'LabelledWidget'
+  constructor() {
+    super('LabelledWidget')
+    this.serialize_widgets = true
+    this.addWidget('text', 'text', 'a cat', null)
+    const input = this.addInput('text', 'STRING')
+    input.widget = { name: 'text' }
+  }
+}
+
+LiteGraph.registerNodeType('test/LabelledWidget', LabelledWidgetNode)
+
+/**
+ * `configure` adopts the payload's graph id (`_configureBase`), while `clear`
+ * only drops store entries keyed by the id the graph held *before* configure.
+ * Anything the graph-id-keyed stores still hold for the incoming id therefore
+ * outlives the reload and is re-adopted instead of being read from the payload.
+ */
+describe('LGraph.configure clears graph-scoped stores for the incoming id', () => {
+  function addLabelledNode(graph: LGraph, label: string) {
+    const node = LiteGraph.createNode('test/LabelledWidget')!
+    graph.add(node)
+    renameWidget(node.widgets![0], node, label)
+    return node
+  }
+
+  function createSourceGraph() {
+    const graph = new LGraph()
+    const node = addLabelledNode(graph, 'Live Label')
+    return { graph, node }
+  }
+
+  test('a reloaded widget label is read from the payload, never inherited from the live store', () => {
+    const graph = new LGraph()
+    const dropped = addLabelledNode(graph, 'Dropped Label')
+    const kept = addLabelledNode(graph, 'Kept Label')
+
+    const payload = JSON.parse(JSON.stringify(graph.serialize()))
+    const droppedData = payload.nodes.find(
+      (n: { id: unknown }) => String(n.id) === String(dropped.id)
+    )
+    delete droppedData.inputs[0].label
+
+    const restored = new LGraph()
+    restored.configure(payload)
+
+    expect(restored.id).toBe(graph.id)
+    expect(restored.getNodeById(dropped.id)!.widgets![0].label).toBeUndefined()
+    expect(restored.getNodeById(kept.id)!.widgets![0].label).toBe('Kept Label')
+  })
+
+  test('preview exposures held for the incoming id do not survive the reload', () => {
+    const { graph } = createSourceGraph()
+    const store = usePreviewExposureStore()
+    store.setExposures(graph.id, '99', [
+      { sourceNodeId: '1', sourcePreviewName: 'preview', name: 'preview' }
+    ])
+
+    const payload = JSON.parse(JSON.stringify(graph.serialize()))
+
+    const restored = new LGraph()
+    restored.configure(payload)
+
+    expect(restored.id).toBe(graph.id)
+    expect(store.getExposures(restored.id, '99')).toEqual([])
+  })
+})

--- a/src/lib/litegraph/src/LGraph.configureStoreScope.test.ts
+++ b/src/lib/litegraph/src/LGraph.configureStoreScope.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'vitest'
 
+import type { ISerialisedGraph } from '@/lib/litegraph/src/litegraph'
 import { LGraph, LGraphNode, LiteGraph } from '@/lib/litegraph/src/litegraph'
 import { usePreviewExposureStore } from '@/stores/previewExposureStore'
 import { renameWidget } from '@/utils/widgetUtil'
@@ -37,16 +38,20 @@ describe('LGraph.configure clears graph-scoped stores for the incoming id', () =
     return { graph, node }
   }
 
+  function serializeToJson(graph: LGraph): ISerialisedGraph {
+    return JSON.parse(JSON.stringify(graph.serialize())) as ISerialisedGraph
+  }
+
   test('a reloaded widget label is read from the payload, never inherited from the live store', () => {
     const graph = new LGraph()
     const dropped = addLabelledNode(graph, 'Dropped Label')
     const kept = addLabelledNode(graph, 'Kept Label')
 
-    const payload = JSON.parse(JSON.stringify(graph.serialize()))
+    const payload = serializeToJson(graph)
     const droppedData = payload.nodes.find(
-      (n: { id: unknown }) => String(n.id) === String(dropped.id)
-    )
-    delete droppedData.inputs[0].label
+      (n) => String(n.id) === String(dropped.id)
+    )!
+    delete droppedData.inputs![0].label
 
     const restored = new LGraph()
     restored.configure(payload)
@@ -63,7 +68,7 @@ describe('LGraph.configure clears graph-scoped stores for the incoming id', () =
       { sourceNodeId: '1', sourcePreviewName: 'preview', name: 'preview' }
     ])
 
-    const payload = JSON.parse(JSON.stringify(graph.serialize()))
+    const payload = serializeToJson(graph)
 
     const restored = new LGraph()
     restored.configure(payload)

--- a/src/lib/litegraph/src/LGraph.ts
+++ b/src/lib/litegraph/src/LGraph.ts
@@ -2592,6 +2592,8 @@ export class LGraph
           useLinkStore().clearGraph(topologyScope.rootGraphId)
           useRerouteStore().clearGraph(topologyScope.rootGraphId)
           useNodeDataStore().clearGraph(this.id)
+          useWidgetValueStore().clearGraph(this.id)
+          usePreviewExposureStore().clearGraph(this.id)
         } else {
           useLinkStore().clearOwner(topologyScope)
           useRerouteStore().clearOwner(topologyScope)


### PR DESCRIPTION
`LGraph.configure` leaves graph-scoped store state alive for the graph id it is about to adopt, so a reloaded node can re-adopt the live entry instead of reading the payload.

`resetAfterClear()` clears under `this.id` — the id held *before* configure (`LGraph.ts:575`). `_configureBase()` then assigns `this.id = data.id` (`LGraph.ts:2566`). `configure` already re-clears `linkStore`, `rerouteStore` and `nodeDataStore` for the incoming id right after `_configureBase`; `widgetValueStore` and `previewExposureStore` were missing from that block. Widget state is keyed `graphId:nodeId:name` and `registerWidget` returns the existing entry for a key, so `widget.label` — whose only home after reload is the store — survives a reload that should have re-read it from JSON.

This is the open question left on #15604 and deliberately not taken in #15603.

## Why this is safe

Production has exactly one `new LGraph()` (`src/scripts/app.ts:938`), the singleton root graph. Every production `configure` runs on that instance, where `clear()` has already dropped the same id, so the added clears are a no-op unless the incoming payload carries a *different* id — in which case anything still held for it belongs to a previously-open workflow and is stale by construction. Two live root `LGraph`s sharing an id only happens in tests.

## Numbers

Denominator: **3842 passing tests across 237 files**, enumerated 2026-08-22 as `src/lib/litegraph` + `src/stores` + `src/core/graph` + `src/renderer/extensions/vueNodes/widgets` + the 36 further `src/**/*.test.ts` matching `.configure(|loadGraphData|widgetValueStore|previewExposureStore`. Not the full suite.

| run | result |
| --- | --- |
| baseline, no change | 3842 passed / 237 files |
| with this change | 3842 passed / 237 files |
| with this change + 2 new tests | 3845 passed / 238 files |

Behaviour-preserving: **0 of 3842 killed.**

## It closes the vacuity class

`LGraphNode.widgetLabelRename.regression.test.ts` was repaired test-side in #15603 by routing its reloads through `reloadSerializedGraph`, which clears the payload id's stores by hand. Rewriting those three reloads the naive way — plain `new LGraph().configure(graph.serialize())`, no helper — and re-running the audit's mutations:

| mutation | naive tests, before this change | naive tests, after |
| --- | --- | --- |
| M12 — `renameWidget` stops writing `input.label` (#13861's exact root cause) | 2 / 5 killed | **5 / 5** |
| M9 — `serialize()` drops `label` + `localized_name` from every input | 1 / 5 killed | **4 / 5** |

Control: naive tests, no mutation, no change — 5 / 5 pass. So the kills are the mutations, not the rewrite.

The point is not the two extra kills. It is that after this change a round-trip test written the obvious way is a real detector, instead of needing a helper nobody is obliged to call.

## Tests

`LGraph.configureStoreScope.test.ts`, two tests, each pinning one added line:

| removed line | failing test |
| --- | --- |
| `useWidgetValueStore().clearGraph(this.id)` | `a reloaded widget label is read from the payload, never inherited from the live store` |
| `usePreviewExposureStore().clearGraph(this.id)` | `preview exposures held for the incoming id do not survive the reload` |

Reverting both: 2 / 2 fail. The label test drops the label from one node's payload and keeps it on a second node, so a build where labels never restore at all cannot pass it by asserting `undefined`.

## Gates

Worktrees run no git hooks (`core.hooksPath` points at a `.husky/_` that a worktree never has), so
every gate below was run by hand at head `3ad1c7df79`, from a worktree with its own
`pnpm install --frozen-lockfile` rather than a borrowed `node_modules`. Command, then exit code:

| Gate | Command | Exit | Output |
| --- | --- | --- | --- |
| typecheck | `vue-tsc --noEmit` | **0** | 0 errors, 0 `TS2688` |
| eslint | `eslint src` | **0** | 4 pre-existing `no-restricted-syntax` warnings, none in this diff |
| oxlint | `oxlint src browser_tests tools/oxlint-plugins --type-aware` | **0** | 0 bytes |
| oxlint audit | `oxlint --config tools/oxlint-plugins/vitestCleanup.config.json .` | **0** | 0 bytes |
| stylelint | `stylelint '{apps,packages,src}/**/*.{css,vue}'` | **0** | 0 bytes |
| format | `oxfmt --check` | **0** | all files correctly formatted |
| knip | `knip --cache` | **0** | 0 bytes |
| tests | `vitest run src/lib/litegraph/src/LGraph.configureStoreScope.test.ts` | **0** | 2 passed |

`NODE_OPTIONS=--max-old-space-size=8192` on both `vue-tsc` and `eslint`: at Node's 2 GB default
`eslint src` aborts with exit 134 and a core dump, and `vue-tsc` does the same. Neither prints
anything a grep for `error` would catch.

### Two earlier claims in this description were wrong, and are retracted

- **"eslint reports nothing on `src/lib/litegraph/` paths."** False. That came from probing with
  `debugger`, and `no-debugger` is `[0]` — disabled repo-wide. Re-probed with `no-var`, confirmed at
  error level via `eslint --print-config`: injecting `var __probe = 1` into
  `src/lib/litegraph/src/LLink.ts` gives `error no-var`, exit 1. eslint lints that tree normally and
  the result above is real evidence, not a vacuous one.
- **"`knip` — exit 1, pre-existing."** That exit 1 was an artefact of running against a borrowed
  `node_modules`, which leaves `apps/website/node_modules` absent and pins the exit code. With a real
  install in the checkout, `knip --cache` exits 0 with no output.

`oxlint`'s 0 exit is reported alongside its output byte count on purpose: most of this repo's oxlint
rules run at warning severity, where a finding prints and still exits 0. 0 bytes of output is the
claim; the exit code alone would not be.

## Follow-ups, not taken here

- `layoutStore` is cleared by `resetAfterClear` but not for the incoming id. Same shape, not measured, deliberately out of scope.
- `SubgraphNode._hydratePreviewExposures`'s legacy branch reads exposures back out of the store. That read happens during node creation, after this clear, so it is unaffected — but it is a second place where store state crosses a configure boundary.

