### PR TITLE
fix: preserve the live size when serializing missing-node placeholders

### DIFF
--- a/src/lib/litegraph/src/LGraphNode.test.ts
+++ b/src/lib/litegraph/src/LGraphNode.test.ts
@@ -67,6 +67,25 @@ describe('LGraphNode', () => {
     Object.assign(LiteGraph, origLiteGraph)
   })
 
+  // Regression (#15628): a missing-node placeholder carries
+  // last_serialization so original data is not lost; serialize() preserved
+  // the live pos but silently dropped the live size, so resizing a
+  // placeholder was lost on save.
+  test('placeholder serialize keeps the live size', () => {
+    const node = new LGraphNode('MissingNode')
+    node.pos = [11, 22]
+    node.size = [700, 800]
+    node.last_serialization = getMockISerialisedNode({
+      type: 'MissingNode',
+      pos: [1, 2],
+      size: [300, 400]
+    })
+
+    const json = node.serialize()
+    expect(json.pos).toEqual([11, 22])
+    expect(json.size).toEqual([700, 800])
+  })
+
   test('should serialize position/size correctly', () => {
     const node = new LGraphNode('TestNode')
     node.pos = [10, 20]

--- a/src/lib/litegraph/src/LGraphNode.ts
+++ b/src/lib/litegraph/src/LGraphNode.ts
@@ -1061,7 +1061,7 @@ export class LGraphNode
 
     // special case for when there were errors
     if (this.constructor === LGraphNode && this.last_serialization)
-      return { ...this.last_serialization, mode: o.mode, pos: o.pos }
+      return { ...this.last_serialization, mode: o.mode, pos: o.pos, size: o.size }
 
     if (this.inputs)
       o.inputs = this.inputs.map((input) => inputAsSerialisable(input))


### PR DESCRIPTION
Fixes #15628.

## Summary

`LGraphNode.serialize()` special-cases missing-node placeholders by returning `{ ...this.last_serialization, mode: o.mode, pos: o.pos }` — the live **position** is preserved, but the live **size** is not: it comes back out of `last_serialization`, i.e. whatever the workflow file said before the node type went missing. The issue verifies it by execution: a placeholder with `last_serialization.size = [300, 400]` resized live to `[700, 800]` serializes as `[300, 400]`, while position round-trips correctly.

The user-visible path: install a workflow using a node pack you don't have → ComfyUI creates a placeholder with `has_errors = true` → drag it (the new position saves) → resize it so its error text is readable (the new size does not save).

The fix adds `size: o.size` to the overridden fields, exactly like `pos`:

```ts
return { ...this.last_serialization, mode: o.mode, pos: o.pos, size: o.size }
```

## Test

Added `placeholder serialize keeps the live size` to `LGraphNode.test.ts`: a placeholder with `last_serialization` at `[1,2]/[300,400]`, live `pos = [11,22]`, live `size = [700,800]` — serializes as `[11,22]/[700,800]`.

- With the fix: `LGraphNode.test.ts` 35/35 pass.
- Differential (one-liner reverted, test kept): the new test fails — size serializes as `[300, 400]`.
