### PR TITLE
ci: defer ecosystem matrix until after E2E

### DIFF
--- a/.github/actions/changes-filter/action.yaml
+++ b/.github/actions/changes-filter/action.yaml
@@ -77,7 +77,9 @@ runs:
           ecosystem_matrix:
             - 'src/**'
             - 'scripts/registry-census/**'
+            - 'browser_tests/assets/default.json'
             - 'vitest.matrix.config.mts'
+            - 'vitest.setup.ts'
             - '.github/actions/changes-filter/action.yaml'
             - '.github/workflows/ci-ecosystem-matrix.yaml'
             - '.github/workflows/ci-tests-e2e.yaml'

--- a/.github/actions/changes-filter/action.yaml
+++ b/.github/actions/changes-filter/action.yaml
@@ -44,6 +44,9 @@ outputs:
   dependency-changes:
     description: 'Root `package.json`, `pnpm-lock.yaml`, or `pnpm-workspace.yaml` changed.'
     value: ${{ github.event_name != 'pull_request' || steps.filter.outputs.deps == 'true' }}
+  ecosystem-matrix-changes:
+    description: 'Frontend runtime or registry census infrastructure changed.'
+    value: ${{ github.event_name != 'pull_request' || steps.filter.outputs.ecosystem_matrix == 'true' }}
 
 runs:
   using: composite
@@ -71,6 +74,13 @@ runs:
             - 'package.json'
             - 'pnpm-lock.yaml'
             - 'pnpm-workspace.yaml'
+          ecosystem_matrix:
+            - 'src/**'
+            - 'scripts/registry-census/**'
+            - 'vitest.matrix.config.mts'
+            - '.github/actions/changes-filter/action.yaml'
+            - '.github/workflows/ci-ecosystem-matrix.yaml'
+            - '.github/workflows/ci-tests-e2e.yaml'
 
     - name: Filter relevant changes
       if: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/ci-ecosystem-matrix.yaml
+++ b/.github/workflows/ci-ecosystem-matrix.yaml
@@ -25,25 +25,7 @@
 name: 'CI: Ecosystem Matrix'
 
 on:
-  # A frontend change is the thing this advisory exists to catch, so src/** runs
-  # it. The corpus is restored, not refetched, so a PR run is bounded by
-  # execution rather than by the network.
-  pull_request:
-    paths:
-      - 'src/**'
-      - 'scripts/registry-census/**'
-      - 'vitest.matrix.config.mts'
-      - '.github/workflows/ci-ecosystem-matrix.yaml'
-  # Refreshes the corpus and writes the baseline every PR is measured against.
-  # Actions cache scoping means only a default-branch run can produce an entry
-  # that other branches restore.
-  push:
-    branches: [main]
-    paths:
-      - 'src/**'
-      - 'scripts/registry-census/**'
-      - 'vitest.matrix.config.mts'
-      - '.github/workflows/ci-ecosystem-matrix.yaml'
+  workflow_call:
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/ci-tests-e2e.yaml
+++ b/.github/workflows/ci-tests-e2e.yaml
@@ -20,6 +20,7 @@ jobs:
       contents: read
     outputs:
       should-run: ${{ steps.changes.outputs.should-run }}
+      ecosystem-matrix-changes: ${{ steps.changes.outputs.ecosystem-matrix-changes }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - id: changes
@@ -222,6 +223,21 @@ jobs:
           [[ "$SHOULD_RUN" != "true" ]] && echo "E2E skipped" && exit 0
           [[ "$SHARDED" != "success" || "$BROWSERS" != "success" || ( "$VIDEO" != "success" && "$VIDEO" != "skipped" ) ]] && echo "E2E failed" && exit 1
           echo "E2E passed"
+
+  ecosystem-matrix:
+    name: Ecosystem matrix (after E2E)
+    needs: [changes, e2e-status]
+    if: >-
+      ${{
+        needs.changes.outputs.ecosystem-matrix-changes == 'true'
+        && needs.e2e-status.result == 'success'
+        && (github.event_name == 'pull_request'
+          || (github.event_name == 'push'
+            && github.ref_name == github.event.repository.default_branch))
+      }}
+    permissions:
+      contents: read
+    uses: ./.github/workflows/ci-ecosystem-matrix.yaml
 
   upload-e2e-coverage:
     needs: [changes, playwright-tests-chromium-sharded]

--- a/.github/workflows/ci-tests-e2e.yaml
+++ b/.github/workflows/ci-tests-e2e.yaml
@@ -236,6 +236,7 @@ jobs:
             && github.ref_name == github.event.repository.default_branch))
       }}
     permissions:
+      actions: write
       contents: read
     uses: ./.github/workflows/ci-ecosystem-matrix.yaml
 

--- a/scripts/registry-census/README.md
+++ b/scripts/registry-census/README.md
@@ -82,15 +82,18 @@ Pure stdlib; needs `curl` and `tar` on PATH, plus `git` for `--write-pins`.
 
 ## In CI
 
-`.github/workflows/ci-ecosystem-matrix.yaml`. An exact cache hit restores the
-snapshot and corpus as-is, with no registry crawl or pack refetch. On a miss,
-the workflow rebuilds the corpus and refuses to cache or measure it unless at
-least 95% of pin-resolved, structurally eligible registry targets are
-available. Targets the pin bump could not resolve, unsupported hosts, invalid
-URLs or subdirectories, and packs outside the archive/staging budget are
-recorded but do not consume that outage floor. The minimum count of five
-failed targets keeps a small local `--limit` smoke run from acting like a
-census.
+`CI: Tests E2E` calls `.github/workflows/ci-ecosystem-matrix.yaml` after the
+required E2E gate passes for affected PRs and pushes to the default branch.
+This keeps the advisory census from occupying hosted runners ahead of required
+browser tests. The matrix workflow can also be dispatched directly. An exact
+cache hit restores the snapshot and corpus as-is, with no registry crawl or
+pack refetch. On a miss, the workflow rebuilds the corpus and refuses to cache
+or measure it unless at least 95% of pin-resolved, structurally eligible
+registry targets are available. Targets the pin bump could not resolve,
+unsupported hosts, invalid URLs or subdirectories, and packs outside the
+archive/staging budget are recorded but do not consume that outage floor. The
+minimum count of five failed targets keeps a small local `--limit` smoke run
+from acting like a census.
 
 The cache key covers the pin set plus the fetch and validation code, and
 Actions caches are immutable. Main normally provides the shared entry that
@@ -256,9 +259,9 @@ The advisory is red. In order:
 **Blast radius:** the matrix is an advisory PR check, not a required check.
 `ProtectMain` requires `test`, `lint-and-format`, `e2e-status` and
 `website-e2e`, so a red matrix informs but does not block. Promotion requires
-both adding `matrix-verdict` to required checks and adding a `merge_group`
-trigger; doing only the first leaves merge groups waiting for a check this
-workflow never reports.
+both making the called matrix verdict a required check and admitting
+`merge_group` events in the caller condition; doing only the first leaves merge
+groups waiting for a check the caller never reports.
 
 ## Detection proof (counter-evidence)
 


### PR DESCRIPTION
## Summary

Run the advisory ecosystem census only after required E2E passes so its four shards do not consume hosted-runner capacity ahead of browser tests.

## Changes

- **What**: Convert the census to a reusable workflow, call it from the E2E workflow after `e2e-status`, preserve path gating, default-branch refreshes, and manual dispatch.

## Review Focus

Confirm the reusable call preserves PR/default-branch behavior while excluding merge queues, and that the census begins only after `e2e-status` succeeds.

Validated with actionlint, format check, lint, typecheck, and knip.