### PR TITLE
chore(lint): enable no-throw-literal and convert the 14 bare-literal throws

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -29,6 +29,7 @@
   ],
   "jsPlugins": ["./tools/oxlint-plugins/comfy.ts"],
   "rules": {
+    "no-throw-literal": "error",
     "comfy/no-duplicate-ingest-type": "error",
     "no-async-promise-executor": "off",
     "no-console": [

--- a/src/lib/litegraph/src/ContextMenu.ts
+++ b/src/lib/litegraph/src/ContextMenu.ts
@@ -361,7 +361,8 @@ export class ContextMenu<TValue = unknown> {
           if (r === true) close_parent = false
         }
         if (value.submenu) {
-          if (!value.submenu.options) throw 'ContextMenu submenu needs options'
+          if (!value.submenu.options)
+            throw new Error('ContextMenu submenu needs options')
 
           new that.constructor(value.submenu.options, {
             callback: value.submenu.callback,

--- a/src/lib/litegraph/src/LGraph.ts
+++ b/src/lib/litegraph/src/LGraph.ts
@@ -1316,7 +1316,7 @@ export class LGraph
     node.id = parseNodeId(node.id) ?? UNASSIGNED_NODE_ID
 
     if (this._nodes.length >= LiteGraph.MAX_NUMBER_OF_NODES) {
-      throw 'LiteGraph: max number of nodes in a graph reached'
+      throw new Error('LiteGraph: max number of nodes in a graph reached')
     }
 
     // give him an id

--- a/src/lib/litegraph/src/LGraphCanvas.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.ts
@@ -1715,7 +1715,7 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
     menu: ContextMenu<string | null>,
     node: LGraphNode
   ): boolean {
-    if (!node) throw 'no node for color'
+    if (!node) throw new Error('no node for color')
 
     const values: IContextMenuValue<
       string | null,
@@ -1777,7 +1777,7 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
     menu?: ContextMenu<(typeof LiteGraph.VALID_SHAPES)[number]>,
     node?: LGraphNode
   ): boolean {
-    if (!node) throw 'no node passed'
+    if (!node) throw new Error('no node passed')
 
     new LiteGraph.ContextMenu<(typeof LiteGraph.VALID_SHAPES)[number]>(
       LiteGraph.VALID_SHAPES,
@@ -1957,7 +1957,9 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
     if (typeof canvas === 'string') {
       const el = document.getElementById(canvas)
       if (!(el instanceof HTMLCanvasElement))
-        throw 'Error validating LiteGraph canvas: Canvas element not found'
+        throw new Error(
+          'Error validating LiteGraph canvas: Canvas element not found'
+        )
       return el
     }
     return canvas
@@ -1999,9 +2001,11 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
     const ctx = element.getContext?.('2d')
     if (ctx == null) {
       if (element.localName != 'canvas') {
-        throw `Element supplied for LGraphCanvas must be a <canvas> element, you passed a ${element.localName}`
+        throw new Error(
+          `Element supplied for LGraphCanvas must be a <canvas> element, you passed a ${element.localName}`
+        )
       }
-      throw "This browser doesn't support Canvas"
+      throw new Error("This browser doesn't support Canvas")
     }
     this.ctx = ctx
 

--- a/src/lib/litegraph/src/LGraphNode.ts
+++ b/src/lib/litegraph/src/LGraphNode.ts
@@ -2236,7 +2236,9 @@ export class LGraphNode
       )
     }
     if (type == 'combo' && !w.options.values) {
-      throw "LiteGraph addWidget('combo',...) requires to pass values in options: { values:['red','blue'] }"
+      throw new Error(
+        "LiteGraph addWidget('combo',...) requires to pass values in options: { values:['red','blue'] }"
+      )
     }
 
     const widget = this.addCustomWidget(w)
@@ -3064,11 +3066,11 @@ export class LGraphNode
 
     if (target_node && typeof target_node === 'number') {
       const nodeById = graph.getNodeById(target_node)
-      if (!nodeById) throw 'target node is null'
+      if (!nodeById) throw new Error('target node is null')
 
       target_node = nodeById
     }
-    if (!target_node) throw 'target node is null'
+    if (!target_node) throw new Error('target node is null')
 
     // avoid loopback
     if (target_node == this) return null
@@ -3363,7 +3365,7 @@ export class LGraphNode
       typeof target_node === 'number'
         ? graph.getNodeById(target_node)
         : target_node
-    if (target_node && !onlyTarget) throw 'Target Node not found'
+    if (target_node && !onlyTarget) throw new Error('Target Node not found')
     if (output instanceof NodeOutputSlot) {
       output._setLegacyLinksPresent(Boolean(onlyTarget))
     }

--- a/src/lib/litegraph/src/LiteGraphGlobal.ts
+++ b/src/lib/litegraph/src/LiteGraphGlobal.ts
@@ -409,7 +409,9 @@ export class LiteGraphGlobal {
    */
   registerNodeType(type: string, base_class: typeof LGraphNode): void {
     if (!base_class.prototype)
-      throw 'Cannot register a simple object, it must be a class with a prototype'
+      throw new Error(
+        'Cannot register a simple object, it must be a class with a prototype'
+      )
     base_class.type = type
 
     const classname = base_class.name
@@ -453,7 +455,7 @@ export class LiteGraphGlobal {
   unregisterNodeType(type: string | typeof LGraphNode): void {
     const base_class =
       typeof type === 'string' ? this.registered_node_types[type] : type
-    if (!base_class) throw `node type not found: ${String(type)}`
+    if (!base_class) throw new Error(`node type not found: ${String(type)}`)
 
     delete this.registered_node_types[String(base_class.type)]
 

--- a/src/platform/cloud/subscription/components/CreditsTile.vue
+++ b/src/platform/cloud/subscription/components/CreditsTile.vue
@@ -446,7 +446,10 @@ async function refreshLatestCredits() {
         lastError = error
       }
     }
-    if (lastError) throw lastError
+    if (lastError)
+      throw lastError instanceof Error
+        ? lastError
+        : new Error(String(lastError))
   })()
 
   try {


### PR DESCRIPTION
Fixes #15635.

## Summary

- **Enable the rule**: `"no-throw-literal": "error"` in `.oxlintrc.json` (bundled in oxlint's eslint plugin — no new dependency; the eslint config never configured it or `only-throw-error`).
- **Convert all 14 sites** flagged at `5002fae1b1` (identical count at `a2603c5`, the current `main`): 13 in `src/lib/litegraph/` (string literals, one template literal) and the `CreditsTile.vue` active-refresh re-throw. Litegraph already uses `new Error(...)` in the majority of its throws — these are the inconsistent minority.
- The **CreditsTile** site re-throws a caught `lastError: unknown`; it now wraps a non-`Error` value in `new Error(String(lastError))` instead of re-throwing it bare. Its only catcher treats it generically, so no caller depended on the string shape.
- I checked the litegraph call sites for string-shape dependencies: no `catch` around the converted throws reads `.message`/`.stack` off the value conditionally on it being a string.

`npx oxlint -A all -D no-throw-literal src` → **0 warnings, 0 errors** (14 before). `.oxlintrc.json` stays valid JSON with a one-line diff. `LGraphNode.test.ts` (34 tests, covers one converted site's module) passes.
