### PR TITLE
docs: correct mistranslation of sigmas from 'variance' in Chinese

### DIFF
--- a/src/locales/zh/nodeDefs.json
+++ b/src/locales/zh/nodeDefs.json
@@ -19825,11 +19825,11 @@
     },
     "outputs": {
       "0": {
-        "name": "高方差",
+        "name": "高Sigmas",
         "tooltip": null
       },
       "1": {
-        "name": "低方差",
+        "name": "低Sigmas",
         "tooltip": null
       }
     }
@@ -19846,11 +19846,11 @@
     },
     "outputs": {
       "0": {
-        "name": "高方差",
+        "name": "高Sigmas",
         "tooltip": null
       },
       "1": {
-        "name": "低方差",
+        "name": "低Sigmas",
         "tooltip": null
       }
     }


### PR DESCRIPTION
## Summary

correct mistranslation of sigmas from 'variance' in Chinese.

## Changes

- **What**: docs `src/locales/zh/nodeDefs.json` fix
