### PR TITLE
Fix ECS migration expected test failures

### DIFF
--- a/src/lib/litegraph/src/LGraph.inputSlotRealign.test.ts
+++ b/src/lib/litegraph/src/LGraph.inputSlotRealign.test.ts
@@ -324,7 +324,7 @@ describe('normalizeConfiguredTopology', () => {
     expect(normalized.links?.map((link) => link.id)).toEqual([2, 3])
     expect(normalized.nodes?.[1].inputs?.[0].link).toBe(2)
     expect(console.warn).toHaveBeenCalledWith(
-      'Dropping competing link to an occupied input',
+      'Dropping competing link to occupied input 2:0',
       expect.objectContaining({ droppedLinkId: 2, survivorLinkId: 1 })
     )
   })
@@ -541,7 +541,7 @@ describe('LGraph.configure realignment with an unmatched input name (#15581)', (
     )
   })
 
-  it.fails('realigns siblings when configure drops an input', () => {
+  it('realigns siblings when configure drops an input', () => {
     const graph = new LGraph()
     graph.configure(unmatchedInputNameWorkflow('test/DroppedInputTarget'))
 
@@ -554,7 +554,7 @@ describe('LGraph.configure realignment with an unmatched input name (#15581)', (
     })
   })
 
-  it.fails('realigns siblings when configure renames an input', () => {
+  it('realigns siblings when configure renames an input', () => {
     const graph = new LGraph()
     graph.configure(unmatchedInputNameWorkflow('test/RenamedInputTarget'))
 
@@ -567,7 +567,7 @@ describe('LGraph.configure realignment with an unmatched input name (#15581)', (
     })
   })
 
-  it.fails('reports no error while realigning around an unmatched name', () => {
+  it('reports no error while realigning around an unmatched name', () => {
     const error = vi.spyOn(console, 'error').mockImplementation(() => {})
 
     const graph = new LGraph()
@@ -582,7 +582,7 @@ describe('realignInputLinkSlots with a rejected batch (#15581)', () => {
     setActivePinia(createTestingPinia({ stubActions: false }))
   })
 
-  it.fails('lands the non-conflicting moves when one move is blocked', () => {
+  it('lands the non-conflicting moves when one move is blocked', () => {
     const graph = new LGraph()
     const source = new LGraphNode('Source')
     source.addOutput('out', 'number')

--- a/src/lib/litegraph/src/LGraph.ts
+++ b/src/lib/litegraph/src/LGraph.ts
@@ -2925,6 +2925,7 @@ export class LGraph
 
       let error = false
       const nodeDataMap = new Map<SerializedNodeId, ISerialisedNode>()
+      const realignmentDataMap = new Map<SerializedNodeId, ISerialisedNode>()
 
       // create nodes
       this._nodes = []
@@ -2949,6 +2950,10 @@ export class LGraph
           // add before configure, otherwise configure cannot create links
           this.add(node, true)
           nodeDataMap.set(node.id, n_info)
+          realignmentDataMap.set(node.id, {
+            ...n_info,
+            inputs: n_info.inputs?.map((input) => ({ ...input }))
+          })
         }
 
         // configure nodes afterwards so they can reach each other
@@ -2988,11 +2993,7 @@ export class LGraph
         }
       }
 
-      // Node configure() overrides may have reordered serialized inputs in
-      // place to match current node definitions; re-key links to the slots
-      // that reference them. Uses nodeDataMap: the effective normalized data
-      // nodes were actually configured from.
-      realignInputLinkSlots(this, nodeDataMap.values())
+      realignInputLinkSlots(this, realignmentDataMap.values())
 
       // groups
       this._groups.length = 0

--- a/src/lib/litegraph/src/LLink.spreadCopy.test.ts
+++ b/src/lib/litegraph/src/LLink.spreadCopy.test.ts
@@ -50,7 +50,7 @@ describe('plain-object copies of LLink (uncovered)', () => {
     setActivePinia(createTestingPinia({ stubActions: false }))
   })
 
-  it.fails('carries topology onto a spread copy of a link', () => {
+  it('carries topology onto a spread copy of a link', () => {
     const { graph, link } = connectedPair(toRerouteId(7))
     const copy: Partial<LLink> = { ...graph.links[link.id] }
 
@@ -63,7 +63,7 @@ describe('plain-object copies of LLink (uncovered)', () => {
     expect(copy.parentId).toBe(link.parentId)
   })
 
-  it.fails('rewires Custom-Scripts consumers from copied links (#15594)', () => {
+  it('rewires Custom-Scripts consumers from copied links (#15594)', () => {
     const { graph, source, consumers, inserted } = insertionScenario(2)
     const saved: Partial<LLink>[] = source.outputs[1].links!.map((id) => ({
       ...graph.links[id]

--- a/src/lib/litegraph/src/LLink.ts
+++ b/src/lib/litegraph/src/LLink.ts
@@ -52,6 +52,19 @@ export function resolveLinkTopology(topology: LinkTopology): LLink | undefined {
   return linkByTopology.get(toRaw(topology))
 }
 
+function defineEnumerableTopologyFacade(link: LLink): void {
+  const descriptors = Object.getOwnPropertyDescriptors(LLink.prototype)
+  Object.defineProperties(link, {
+    id: { ...descriptors.id, enumerable: true },
+    type: { ...descriptors.type, enumerable: true },
+    origin_id: { ...descriptors.origin_id, enumerable: true },
+    origin_slot: { ...descriptors.origin_slot, enumerable: true },
+    target_id: { ...descriptors.target_id, enumerable: true },
+    target_slot: { ...descriptors.target_slot, enumerable: true },
+    parentId: { ...descriptors.parentId, enumerable: true }
+  })
+}
+
 // Resolved connection union; eliminates subgraph in/out as a possibility
 export type ResolvedConnection = BaseResolvedConnection &
   (
@@ -318,6 +331,7 @@ export class LLink implements LinkSegment, Serialisable<SerialisableLLink> {
       targetSlot: target_slot,
       parentId
     }
+    defineEnumerableTopologyFacade(this)
   }
 
   /** @deprecated Use {@link LLink.create} */

--- a/src/lib/litegraph/src/linkDeduplication.conflictingOrigins.test.ts
+++ b/src/lib/litegraph/src/linkDeduplication.conflictingOrigins.test.ts
@@ -79,7 +79,7 @@ describe('normalizeConfiguredTopology with conflicting origins (#15577)', () => 
     )
   })
 
-  it.fails('warns when a link is dropped in favour of a different origin', () => {
+  it('warns when a link is dropped in favour of a different origin', () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
     configureConflictingOrigins()

--- a/src/lib/litegraph/src/linkDeduplication.ts
+++ b/src/lib/litegraph/src/linkDeduplication.ts
@@ -162,11 +162,6 @@ export function realignInputLinkSlots(
       referencedNames.set(link, names)
     }
 
-    const removals = [...referencedNames].flatMap(([link, names]) =>
-      node.inputs.some((input) => names.includes(input.name)) ? [] : [link]
-    )
-    for (const link of removals) referencedNames.delete(link)
-
     for (let pass = 0; pass < Math.max(1, referencedNames.size); pass++) {
       const moved: { link: LLink; slot: number }[] = []
       for (const [link, names] of referencedNames) {
@@ -179,7 +174,16 @@ export function realignInputLinkSlots(
           : slots[0]
         if (link.target_slot !== slot) moved.push({ link, slot })
       }
-      if (!moved.length && !removals.length) break
+      if (!moved.length) break
+
+      const unmatched = [...referencedNames].flatMap(([link, names]) =>
+        node.inputs.some((input) => names.includes(input.name)) ? [] : [link]
+      )
+      const destinationSlots = new Set(moved.map(({ slot }) => slot))
+      const removals = unmatched.filter(
+        (link) =>
+          graph.links.has(link.id) && destinationSlots.has(link.target_slot)
+      )
 
       const updates: EndpointUpdate[] = moved.map(({ link, slot }) => ({
         topology: link._state,
@@ -218,7 +222,6 @@ export function realignInputLinkSlots(
         }
         break
       }
-      removals.length = 0
       for (const { link, slot } of moved) {
         node.onConnectionsChange?.(
           NodeSlotType.INPUT,

--- a/src/lib/litegraph/src/linkDeduplication.ts
+++ b/src/lib/litegraph/src/linkDeduplication.ts
@@ -83,12 +83,15 @@ export function normalizeConfiguredTopology<T extends ConfiguredGraph>(
       toNodeId(survivor.origin_id) === toNodeId(fields.origin_id) &&
       survivor.origin_slot === fields.origin_slot
     if (!isExactDuplicate) {
-      console.warn('Dropping competing link to an occupied input', {
-        droppedLinkId: fields.id,
-        survivorLinkId: survivor.id,
-        targetNodeId: fields.target_id,
-        targetSlot: fields.target_slot
-      })
+      console.warn(
+        `Dropping competing link to occupied input ${fields.target_id}:${fields.target_slot}`,
+        {
+          droppedLinkId: fields.id,
+          survivorLinkId: survivor.id,
+          targetNodeId: fields.target_id,
+          targetSlot: fields.target_slot
+        }
+      )
     }
 
     if (
@@ -159,7 +162,12 @@ export function realignInputLinkSlots(
       referencedNames.set(link, names)
     }
 
-    for (let pass = 0; pass < referencedNames.size; pass++) {
+    const removals = [...referencedNames].flatMap(([link, names]) =>
+      node.inputs.some((input) => names.includes(input.name)) ? [] : [link]
+    )
+    for (const link of removals) referencedNames.delete(link)
+
+    for (let pass = 0; pass < Math.max(1, referencedNames.size); pass++) {
       const moved: { link: LLink; slot: number }[] = []
       for (const [link, names] of referencedNames) {
         const slots = node.inputs.flatMap((input, slot) =>
@@ -171,7 +179,7 @@ export function realignInputLinkSlots(
           : slots[0]
         if (link.target_slot !== slot) moved.push({ link, slot })
       }
-      if (!moved.length) break
+      if (!moved.length && !removals.length) break
 
       const updates: EndpointUpdate[] = moved.map(({ link, slot }) => ({
         topology: link._state,
@@ -179,9 +187,17 @@ export function realignInputLinkSlots(
       }))
       const result = useLinkStore().updateEndpoints(
         graphScopeOf(graph),
-        updates
+        updates,
+        removals.map((link) => link._state)
       )
       if (!result.ok) {
+        if (removals.length) {
+          useLinkStore().updateEndpoints(
+            graphScopeOf(graph),
+            [],
+            removals.map((link) => link._state)
+          )
+        }
         for (const { link, slot } of moved) {
           const fallback = useLinkStore().updateEndpoint(
             graphScopeOf(graph),
@@ -202,6 +218,7 @@ export function realignInputLinkSlots(
         }
         break
       }
+      removals.length = 0
       for (const { link, slot } of moved) {
         node.onConnectionsChange?.(
           NodeSlotType.INPUT,

--- a/src/lib/litegraph/src/subgraph/SubgraphDuplicateDeleteOrder.test.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphDuplicateDeleteOrder.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, onTestFinished, vi } from 'vitest'
 
 import type {
   ExportedSubgraphInstance,
@@ -12,7 +12,10 @@ import {
   LGraphNode as LGraphNodeClass,
   LiteGraph
 } from '@/lib/litegraph/src/litegraph'
+import { createTestNode } from '@/lib/litegraph/src/__fixtures__/nodeHelpers'
 import { useWidgetValueStore } from '@/stores/widgetValueStore'
+import { UNASSIGNED_NODE_ID } from '@/types/nodeId'
+import { widgetId } from '@/types/widgetId'
 
 import {
   createTestRootGraph,
@@ -30,6 +33,7 @@ vi.mock('@/services/litegraphService', () => ({
 
 const PROMOTED_INPUT = 'value'
 const EXTERNAL_INPUT = 'signal'
+const CONVERTIBLE_NODE_TYPE = 'test/convertible-promoted-widget'
 
 function addInteriorNodes(definition: Subgraph) {
   const withWidget = new LGraphNodeClass('Interior')
@@ -91,14 +95,30 @@ function promotedId(node: SubgraphNode) {
 }
 
 function convertPromotedWidgetNode(rootGraph: LGraph): SubgraphNode {
-  const producer = new LGraphNodeClass('Producer')
-  producer.addOutput('out', 'number')
-  rootGraph.add(producer)
+  const producer = createTestNode(rootGraph, [], ['number'])
 
-  const node = new LGraphNodeClass('Convertible')
-  const input = node.addInput(PROMOTED_INPUT, 'number')
-  input.widget = { name: PROMOTED_INPUT }
-  node.addWidget('number', PROMOTED_INPUT, 0, () => {})
+  if (!LiteGraph.registered_node_types[CONVERTIBLE_NODE_TYPE]) {
+    class ConvertibleNode extends LGraphNodeClass {
+      constructor() {
+        super('Convertible')
+        const input = this.addInput(PROMOTED_INPUT, 'number')
+        input.widget = { name: PROMOTED_INPUT }
+        this.addWidget('number', PROMOTED_INPUT, 0, () => {})
+      }
+    }
+    LiteGraph.registered_node_types[CONVERTIBLE_NODE_TYPE] = ConvertibleNode
+    onTestFinished(() => {
+      if (
+        LiteGraph.registered_node_types[CONVERTIBLE_NODE_TYPE] ===
+        ConvertibleNode
+      ) {
+        delete LiteGraph.registered_node_types[CONVERTIBLE_NODE_TYPE]
+      }
+    })
+  }
+
+  const node = LiteGraph.createNode(CONVERTIBLE_NODE_TYPE)
+  if (!node) throw new Error('expected a convertible node')
   rootGraph.add(node)
 
   if (!producer.connect(0, node, 0)) throw new Error('expected an input link')
@@ -211,7 +231,7 @@ describe('duplicated subgraph deleted in both orders (I4)', () => {
     ).toBeUndefined()
   })
 
-  it.fails('gives converted subgraphs independent promoted widgets (#15565)', () => {
+  it('gives converted subgraphs independent promoted widgets (#15565)', () => {
     const rootGraph = createTestRootGraph()
     registerTestSubgraphNodeTypes(rootGraph)
     const first = convertPromotedWidgetNode(rootGraph)
@@ -219,6 +239,11 @@ describe('duplicated subgraph deleted in both orders (I4)', () => {
 
     expect(first.id).not.toBe(second.id)
     expect(promotedId(first)).not.toBe(promotedId(second))
+    expect(
+      useWidgetValueStore().getWidget(
+        widgetId(rootGraph.id, UNASSIGNED_NODE_ID, PROMOTED_INPUT)
+      )
+    ).toBeUndefined()
 
     const id = promotedId(first)
     if (!id) throw new Error('expected a promoted widget id')

--- a/src/lib/litegraph/src/subgraph/SubgraphNode.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphNode.ts
@@ -451,6 +451,7 @@ export class SubgraphNode extends LGraphNode implements BaseLGraph {
 
   override configure(info: ExportedSubgraphInstance): void {
     for (const input of this.inputs) {
+      this._clearPromotedWidget(input)
       if (
         input._listenerController &&
         typeof input._listenerController.abort === 'function'

--- a/src/lib/litegraph/src/subgraph/SubgraphNode.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphNode.ts
@@ -583,6 +583,17 @@ export class SubgraphNode extends LGraphNode implements BaseLGraph {
   rebuildInputWidgetBindings(): void {
     this.invalidatePromotedViews()
 
+    const store = useWidgetValueStore()
+    const previousBindings = new Map(
+      this.inputs.flatMap((input) => {
+        if (!input.widgetId) return []
+        const state = store.getWidget(input.widgetId)
+        return state
+          ? [[input, { id: input.widgetId, value: state.value }]]
+          : []
+      })
+    )
+
     for (const input of this.inputs) {
       delete input.widget
       delete input.pos
@@ -591,6 +602,15 @@ export class SubgraphNode extends LGraphNode implements BaseLGraph {
       const subgraphInput = input._subgraphSlot
       if (!subgraphInput) continue
       this._resolveInputWidget(subgraphInput, input)
+      const previous = previousBindings.get(input)
+      if (previous && input.widgetId) {
+        store.setValue(input.widgetId, previous.value)
+      }
+    }
+
+    const activeIds = new Set(this.inputs.map((input) => input.widgetId))
+    for (const { id } of previousBindings.values()) {
+      if (!activeIds.has(id)) store.deleteWidget(id)
     }
 
     this.invalidatePromotedViews()
@@ -718,7 +738,7 @@ export class SubgraphNode extends LGraphNode implements BaseLGraph {
   }
 
   override onAdded(_graph: LGraph): void {
-    this.invalidatePromotedViews()
+    this.rebuildInputWidgetBindings()
   }
 
   /**


### PR DESCRIPTION
## Summary

Re-inventories the remaining expected test failures from the ECS migration and fixes the cases owned by ECS compatibility and lifecycle behavior.

## Changes

- **What**: Restores enumerable `LLink` topology facades, handles dropped inputs during link-slot realignment, and re-keys promoted subgraph widgets after node insertion.
- **What**: Converts 12 resolved expected failures to normal tests; retains five out-of-scope cases covering unsupported topology resurrection and pre-existing badge ordering parity.

## Review Focus

Please focus on the atomic removal/move behavior during input-slot realignment and promoted-widget value preservation while replacing provisional node IDs.

Fixes #15565