### PR TITLE
test: pin literal rendering of HTML in node-search results

### DIFF
--- a/browser_tests/fixtures/utils/objectInfo.ts
+++ b/browser_tests/fixtures/utils/objectInfo.ts
@@ -104,6 +104,35 @@ export function appendComboInputOptions(
   ])
 }
 
+/**
+ * Clones an existing node definition under a new type whose display name is
+ * `displayName`, so a test can put arbitrary text on the node-search result
+ * label without depending on a real node happening to contain it.
+ *
+ * Deep-cloned: a spread would leave the copy sharing `input`/`output` with the
+ * donor, so a later mutator aimed at the clone would silently rewrite the real
+ * node in the same payload.
+ */
+export function addNodeWithDisplayName(
+  objectInfo: ObjectInfoResponse,
+  nodeType: string,
+  displayName: string,
+  donorNodeType = 'KSampler'
+): void {
+  const donor = objectInfo[donorNodeType]
+  if (!donor) {
+    throw new Error(`Missing object_info entry for ${donorNodeType}`)
+  }
+
+  objectInfo[nodeType] = {
+    ...structuredClone(donor),
+    name: nodeType,
+    display_name: displayName,
+    category: 'testing',
+    description: ''
+  }
+}
+
 export async function routeObjectInfoFromSetupApi(
   page: Page,
   customize?: (objectInfo: ObjectInfoResponse) => void | Promise<void>

--- a/browser_tests/tests/xss.spec.ts
+++ b/browser_tests/tests/xss.spec.ts
@@ -2,6 +2,15 @@ import {
   comfyPageFixture as test,
   comfyExpect as expect
 } from '@e2e/fixtures/ComfyPage'
+import {
+  addNodeWithDisplayName,
+  routeObjectInfoFromSetupApi
+} from '@e2e/fixtures/utils/objectInfo'
+
+const INJECTED_NODE_TYPE = 'HtmlEscapingProbeNode'
+const SEARCH_TERM = 'HtmlEscapingProbe'
+const XSS_FLAG = '__nodeSearchXss'
+const HTML_PAYLOAD = `${SEARCH_TERM} <img src=x onerror="window.${XSS_FLAG} = true">`
 
 test('Is not vulnerable to xss', async ({ comfyPage }) => {
   await test.step('in subgraph type', async () => {
@@ -25,3 +34,57 @@ test('Is not vulnerable to xss', async ({ comfyPage }) => {
     await expect(comfyPage.page.getByText('XSS E2')).toBeHidden()
   })
 })
+
+/**
+ * QA test plan "cloud 1.50 → 1.51", Node Search Highlights (#14789): search
+ * results must render HTML characters literally rather than as markup.
+ *
+ * The plan phrases this as "type a query containing HTML characters", but the
+ * query never reaches the DOM — `highlightQuery()` only ever emits slices of
+ * the node's display name, so the display name is the real injection point.
+ *
+ * `NodeSearchListItem.test.ts` already pins the escaping at the component
+ * level with the same payload shape, so this does not add coverage of the
+ * component itself. The slice it adds is narrow and specific: that nothing
+ * between the `object_info` response and that component — node-def store,
+ * search service, dialog — writes the display name as `innerHTML` on the way
+ * through.
+ */
+test(
+  'Does not render HTML in node search results',
+  { tag: ['@node'] },
+  async ({ comfyPage }) => {
+    const unrouteObjectInfo = await routeObjectInfoFromSetupApi(
+      comfyPage.page,
+      (objectInfo) =>
+        addNodeWithDisplayName(objectInfo, INJECTED_NODE_TYPE, HTML_PAYLOAD)
+    )
+
+    try {
+      await comfyPage.searchBoxV2.ensureV2Search()
+      // Reload so the node definition store boots from the patched object_info.
+      await comfyPage.workflow.reloadAndWaitForApp()
+
+      await comfyPage.searchBoxV2.open()
+      await comfyPage.searchBoxV2.input.fill(SEARCH_TERM)
+
+      const result = comfyPage.searchBoxV2.results
+        .filter({ hasText: SEARCH_TERM })
+        .first()
+      await expect(result).toBeVisible()
+
+      // `toContainText` compares rendered text, so anything parsed as markup
+      // would have been stripped out of it.
+      await expect(result).toContainText(HTML_PAYLOAD)
+      await expect(result.locator('img')).toHaveCount(0)
+
+      // Catches the payload executing anywhere on the page, not just inside
+      // the result row.
+      expect(
+        await comfyPage.page.evaluate((flag) => flag in window, XSS_FLAG)
+      ).toBe(false)
+    } finally {
+      await unrouteObjectInfo()
+    }
+  }
+)


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

Automates one item from the QA test plan for cloud 1.50 → 1.51 (Node Search Highlights, #14789):

> Open the node search, type a query containing HTML characters (e.g. `<img>`) — verify the search results render the text literally, not as HTML

## A note on what the plan item actually means

The plan phrases this as a property of the *query*, but the query never reaches the DOM: `highlightQuery()` only ever emits slices of the node's **display name**, split around the match. So the display name is the real injection point, and asserting on the query would be vacuous. This test targets the display name and says so in the file header.

## What it asserts

Patches `object_info` (via the existing `routeObjectInfoFromSetupApi`) to add a node whose display name carries an `<img src=x onerror=...>` payload, then searches for it and asserts:

- the payload survives as literal **text** in the result label
- no `img` element was created

`onerror` is used deliberately — a payload that gets parsed cannot pass silently.

## Why an e2e when a unit test exists

`NodeSearchListItem.test.ts` already covers escaping at the component level, and this does not replace it. The layer it adds is the one the unit test cannot reach: a node definition travelling from `object_info` through the node-def store into the v2 search dialog. `eslint` bans `v-html` under `src/components/searchbox/`, but a raw `innerHTML` assignment anywhere along that path would slip past both the linter and the component test.

## Verification

- Passes locally against a real backend + dev server, repeated runs, no flake.
- **Mutation-checked**: switching `HighlightedText.vue` to `v-html` turns the test red — the payload is parsed as markup and disappears from the rendered text (`"HtmlEscapingProbe Comfytesting"`). It is not a vacuous pass.
- `pnpm lint`, `pnpm format:check`, `pnpm typecheck` clean.
- Reviewed by a two-model reviewer pair; verdict PASS.

The node-cloning helper is added to `browser_tests/fixtures/utils/objectInfo.ts` alongside the existing `object_info` mutators rather than living in the spec.


## Screenshots

![Node search results showing the injected node's display name with the img/onerror payload rendered as literal text, with the matched prefix highlighted](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/16cc5eeadb5c02b8829af859b008e3d039d8081a430f394d40acfb1012fdc117/pr-images/1787444443148-c55bb6b4-4e44-4b19-aae0-141ee19d4a3c.png)