### PR TITLE
fix(config): resolve the Cloud base URL from remote config

### DIFF
--- a/src/config/comfyApi.test.ts
+++ b/src/config/comfyApi.test.ts
@@ -43,7 +43,29 @@ describe('getComfyApiBaseUrl', () => {
 })
 
 describe('getComfyCloudBaseUrl', () => {
-  it('matches the non-production Firebase environment', () => {
+  const originalConfig = remoteConfig.value
+
+  beforeEach(() => {
+    remoteConfig.value = {}
+  })
+
+  afterEach(() => {
+    remoteConfig.value = originalConfig
+  })
+
+  it('honors the server-provided override', () => {
+    remoteConfig.value = {
+      comfy_cloud_base_url: 'https://my-ephem-cloud.example.com'
+    }
+    expect(getComfyCloudBaseUrl()).toBe('https://my-ephem-cloud.example.com')
+  })
+
+  it('falls back to the build-time default when the key is absent', () => {
+    expect(getComfyCloudBaseUrl()).toBe('https://testcloud.comfy.org')
+  })
+
+  it('falls back to the build-time default when the value is empty', () => {
+    remoteConfig.value = { comfy_cloud_base_url: '' }
     expect(getComfyCloudBaseUrl()).toBe('https://testcloud.comfy.org')
   })
 })
@@ -92,7 +114,7 @@ describe('compatibility with comfyui servers that predate the override keys', ()
 
   it('falls back to build-time defaults when /features omits the URL keys', async () => {
     // An older comfyui server has /features but doesn't know about
-    // comfy_api_base_url / comfy_platform_base_url yet.
+    // comfy_api_base_url / comfy_cloud_base_url / comfy_platform_base_url yet.
     vi.mocked(global.fetch).mockResolvedValue({
       ok: true,
       json: async () => ({
@@ -104,6 +126,7 @@ describe('compatibility with comfyui servers that predate the override keys', ()
     await refreshRemoteConfig({ useAuth: false })
 
     expect(getComfyApiBaseUrl()).toBe('https://stagingapi.comfy.org')
+    expect(getComfyCloudBaseUrl()).toBe('https://testcloud.comfy.org')
     expect(getComfyPlatformBaseUrl()).toBe('https://stagingplatform.comfy.org')
   })
 })

--- a/src/config/comfyApi.ts
+++ b/src/config/comfyApi.ts
@@ -34,7 +34,11 @@ export function getComfyApiBaseUrl(): string {
 }
 
 export function getComfyCloudBaseUrl(): string {
-  return BUILD_TIME_CLOUD_BASE_URL
+  return configValueOrDefault(
+    remoteConfig.value,
+    'comfy_cloud_base_url',
+    BUILD_TIME_CLOUD_BASE_URL
+  )
 }
 
 export function getComfyPlatformBaseUrl(): string {

--- a/src/platform/remoteConfig/types.ts
+++ b/src/platform/remoteConfig/types.ts
@@ -93,6 +93,7 @@ export type RemoteConfig = {
   server_health_alert?: ServerHealthAlert
   max_upload_size?: number
   comfy_api_base_url?: string
+  comfy_cloud_base_url?: string
   comfy_platform_base_url?: string
   firebase_config?: FirebaseRuntimeConfig
   firebase_env?: 'dev'


### PR DESCRIPTION
## Why

`getComfyCloudBaseUrl()` returned the build-time constant directly, while the two other functions in the same module resolve through `configValueOrDefault`:

```ts
export function getComfyApiBaseUrl(): string {
  return configValueOrDefault(remoteConfig.value, 'comfy_api_base_url', BUILD_TIME_API_BASE_URL)
}

export function getComfyCloudBaseUrl(): string {
  return BUILD_TIME_CLOUD_BASE_URL      // <- this one
}

export function getComfyPlatformBaseUrl(): string {
  return configValueOrDefault(remoteConfig.value, 'comfy_platform_base_url', BUILD_TIME_PLATFORM_BASE_URL)
}
```

Since #15164, Local and Desktop reach workspace and billing endpoints through this host (`workspaceApiUrl.ts` uses it for every non-Cloud request). A Desktop build is installed once and may never be updated, so a host pinned at build time cannot be changed for those clients afterward. The other two hosts already have that escape hatch; this one did not.

## Change

- Resolve `getComfyCloudBaseUrl()` from `comfy_cloud_base_url`, falling back to `BUILD_TIME_CLOUD_BASE_URL`.
- Add `comfy_cloud_base_url?: string` to `RemoteConfig`.
- Extend `comfyApi.test.ts` to cover override / absent / empty for the Cloud URL, matching the existing blocks for the API and platform URLs, and assert the Cloud fallback in the existing older-server compatibility test.

## Note

This is inert until the backend actually sends `comfy_cloud_base_url` — the fallback keeps current behaviour byte-for-byte until then. It is the client half of the escape hatch, and it means we do not need a frontend release to move the host later.

## Test plan

- `pnpm vitest run src/config/comfyApi.test.ts` — 10 passed
- `pnpm typecheck` — clean
