### PR TITLE
ci: stop e2e blaming PRs for the base branch's specs and for cancellations

### DIFF
--- a/.github/workflows/ci-tests-e2e.yaml
+++ b/.github/workflows/ci-tests-e2e.yaml
@@ -214,11 +214,13 @@ jobs:
     steps:
       - name: Check E2E results
         env:
+          CHANGES: ${{ needs.changes.result }}
           SHOULD_RUN: ${{ needs.changes.outputs.should-run }}
           SHARDED: ${{ needs.playwright-tests-chromium-sharded.result }}
           BROWSERS: ${{ needs.playwright-tests.result }}
           VIDEO: ${{ needs.playwright-video-new-tests.result }}
         run: |
+          [[ "$CHANGES" != "success" ]] && echo "changes gate did not complete ($CHANGES)" && exit 1
           [[ "$SHOULD_RUN" != "true" ]] && echo "E2E skipped" && exit 0
           echo "sharded=$SHARDED browsers=$BROWSERS video=$VIDEO"
           [[ "$SHARDED" == "cancelled" || "$BROWSERS" == "cancelled" || "$VIDEO" == "cancelled" ]] && echo "E2E cancelled, not failed - rerun to get a result" && exit 1

--- a/.github/workflows/ci-tests-e2e.yaml
+++ b/.github/workflows/ci-tests-e2e.yaml
@@ -223,7 +223,8 @@ jobs:
           [[ "$CHANGES" != "success" ]] && echo "changes gate did not complete ($CHANGES)" && exit 1
           [[ "$SHOULD_RUN" != "true" ]] && echo "E2E skipped" && exit 0
           echo "sharded=$SHARDED browsers=$BROWSERS video=$VIDEO"
-          [[ "$SHARDED" == "cancelled" || "$BROWSERS" == "cancelled" || "$VIDEO" == "cancelled" ]] && echo "E2E cancelled, not failed - rerun to get a result" && exit 1
+          [[ "$SHARDED" == "failure" || "$BROWSERS" == "failure" || "$VIDEO" == "failure" ]] && echo "E2E failed" && exit 1
+          [[ "$SHARDED" == "cancelled" || "$BROWSERS" == "cancelled" || "$VIDEO" == "cancelled" ]] && echo "E2E cancelled, not failed" && exit 1
           [[ "$SHARDED" != "success" || "$BROWSERS" != "success" || ( "$VIDEO" != "success" && "$VIDEO" != "skipped" ) ]] && echo "E2E failed" && exit 1
           echo "E2E passed"
 

--- a/.github/workflows/ci-tests-e2e.yaml
+++ b/.github/workflows/ci-tests-e2e.yaml
@@ -277,12 +277,12 @@ jobs:
           # onto. pull_request.base.sha is recorded when the PR opens and does not follow the
           # base branch, so diffing against it attributes every spec the base gained since
           # then to this PR.
-          if git rev-parse --verify --quiet HEAD^2 >/dev/null; then
-            BASE_SHA=$(git rev-parse HEAD^1)
+          if [[ "$(git rev-parse --verify --quiet HEAD^2)" == "${{ github.event.pull_request.head.sha }}" ]]; then
+            DIFF_RANGE="$(git rev-parse HEAD^1)..HEAD"
           else
-            BASE_SHA="${{ github.event.pull_request.base.sha }}"
+            DIFF_RANGE="${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}"
           fi
-          NEW_FILES=$(git diff --name-only --diff-filter=A "$BASE_SHA" HEAD -- browser_tests/tests | grep '\.spec\.ts$' || true)
+          NEW_FILES=$(git diff --name-only --diff-filter=A "$DIFF_RANGE" -- browser_tests/tests | grep '\.spec\.ts$' || true)
 
           if [ -z "$NEW_FILES" ]; then
             echo "has-new-tests=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ci-tests-e2e.yaml
+++ b/.github/workflows/ci-tests-e2e.yaml
@@ -220,9 +220,9 @@ jobs:
           BROWSERS: ${{ needs.playwright-tests.result }}
           VIDEO: ${{ needs.playwright-video-new-tests.result }}
         run: |
+          echo "changes=$CHANGES should_run=$SHOULD_RUN sharded=$SHARDED browsers=$BROWSERS video=$VIDEO"
           [[ "$CHANGES" != "success" ]] && echo "changes gate did not complete ($CHANGES)" && exit 1
           [[ "$SHOULD_RUN" != "true" ]] && echo "E2E skipped" && exit 0
-          echo "sharded=$SHARDED browsers=$BROWSERS video=$VIDEO"
           [[ "$SHARDED" == "failure" || "$BROWSERS" == "failure" || "$VIDEO" == "failure" ]] && echo "E2E failed" && exit 1
           [[ "$SHARDED" == "cancelled" || "$BROWSERS" == "cancelled" || "$VIDEO" == "cancelled" ]] && echo "E2E cancelled, not failed" && exit 1
           [[ "$SHARDED" != "success" || "$BROWSERS" != "success" || ( "$VIDEO" != "success" && "$VIDEO" != "skipped" ) ]] && echo "E2E failed" && exit 1

--- a/.github/workflows/ci-tests-e2e.yaml
+++ b/.github/workflows/ci-tests-e2e.yaml
@@ -268,8 +268,16 @@ jobs:
         id: detect
         run: |
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
-          BASE_SHA="${{ github.event.pull_request.base.sha }}"
-          NEW_FILES=$(git diff --name-only --diff-filter=A "$BASE_SHA"...HEAD -- browser_tests/tests | grep '\.spec\.ts$' || true)
+          # HEAD is refs/pull/N/merge, so its first parent is the base tip the PR was merged
+          # onto. pull_request.base.sha is recorded when the PR opens and does not follow the
+          # base branch, so diffing against it attributes every spec the base gained since
+          # then to this PR.
+          if git rev-parse --verify --quiet HEAD^2 >/dev/null; then
+            BASE_SHA=$(git rev-parse HEAD^1)
+          else
+            BASE_SHA="${{ github.event.pull_request.base.sha }}"
+          fi
+          NEW_FILES=$(git diff --name-only --diff-filter=A "$BASE_SHA" HEAD -- browser_tests/tests | grep '\.spec\.ts$' || true)
 
           if [ -z "$NEW_FILES" ]; then
             echo "has-new-tests=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ci-tests-e2e.yaml
+++ b/.github/workflows/ci-tests-e2e.yaml
@@ -220,6 +220,8 @@ jobs:
           VIDEO: ${{ needs.playwright-video-new-tests.result }}
         run: |
           [[ "$SHOULD_RUN" != "true" ]] && echo "E2E skipped" && exit 0
+          echo "sharded=$SHARDED browsers=$BROWSERS video=$VIDEO"
+          [[ "$SHARDED" == "cancelled" || "$BROWSERS" == "cancelled" || "$VIDEO" == "cancelled" ]] && echo "E2E cancelled, not failed - rerun to get a result" && exit 1
           [[ "$SHARDED" != "success" || "$BROWSERS" != "success" || ( "$VIDEO" != "success" && "$VIDEO" != "skipped" ) ]] && echo "E2E failed" && exit 1
           echo "E2E passed"
 


### PR DESCRIPTION
Two defects in `ci-tests-e2e.yaml` that both made this workflow blame a PR for something it did not do. Same file, so they are one PR.

### 1. New-spec detection uses a base that never moves

`playwright-video-new-tests` runs the spec files a PR adds. On a branch whose base is stale it instead runs specs other people merged, and fails on them.

`github.event.pull_request.base.sha` is recorded when the PR opens and does not advance with the base branch. `actions/checkout` leaves `HEAD` at `refs/pull/N/merge`, which already contains everything the base gained since. Three-dot diffing the merge commit against that frozen SHA therefore reports the base's own additions as added by the PR.

Measured on https://github.com/Comfy-Org/ComfyUI_frontend/pull/14073, using the exact merge commit from its run (`a580416262`, logged as `Merge 957bfb36d2 into b2d6e414df`), branch point 2026-07-23:

| detection | new spec files |
| --- | --- |
| `git diff --diff-filter=A $BASE_SHA...HEAD` (before) | **22** |
| `git diff --diff-filter=A HEAD^1 HEAD` (after) | **0** |

22 matches that run's `NEW_SPEC_FILES` list exactly, and 0 is correct — 14073 modifies `previewAsText.spec.ts` and adds no spec. The job failed on `subgraphResizePreservation.spec.ts`, which came from #14461. Rebasing "fixed" it, which is why this reads as flakiness rather than a bug. It gets worse the longer a branch lives.

### 2. A cancelled run is reported as a failed one

`e2e-status` funnels `cancelled` into the same branch as `failure` and prints `E2E failed`. Since `e2e-status` is a required check, a cancelled run leaves a red required check with a message asserting the tests failed. On 14073 this cost real time chasing a failure that never happened — run `31986467016` was cancelled 50s in, and the PR looked broken.

Still exits non-zero: merging without e2e having run would be a false green. Only the diagnosis changes, plus the three job results are now echoed — the old message named none of them, so you could not tell which leg failed without opening the run.

`upload-e2e-coverage` already special-cases `cancelled`, so the distinction exists in this file; the status gate just did not make it.

Verified across all five outcomes (all-green, video-skipped, real failure, cancelled, should-run false) — exit codes unchanged except that cancelled now says so.