### PR TITLE
Restore legacy slot link mutations

### DIFF
--- a/src/lib/litegraph/src/node/NodeInputSlot.ts
+++ b/src/lib/litegraph/src/node/NodeInputSlot.ts
@@ -1,5 +1,5 @@
 import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
-import type { LinkId } from '@/lib/litegraph/src/LLink'
+import type { LLink,LinkId } from '@/lib/litegraph/src/LLink'
 import { LabelPosition } from '@/lib/litegraph/src/draw'
 import type {
   INodeInputSlot,
@@ -9,7 +9,8 @@ import type {
 } from '@/lib/litegraph/src/interfaces'
 import { LiteGraph } from '@/lib/litegraph/src/litegraph'
 import { NodeSlot } from '@/lib/litegraph/src/node/NodeSlot'
-import { inputHasLink, inputLinkId } from '@/lib/litegraph/src/node/slotLinks'
+import { inputHasLink, inputLink } from '@/lib/litegraph/src/node/slotLinks'
+import { restoreLegacyLink } from '@/lib/litegraph/src/node/restoreLegacyLink'
 import { warnDeprecated } from '@/lib/litegraph/src/utils/feedback'
 import type { IDrawOptions } from '@/lib/litegraph/src/node/NodeSlot'
 import type { SubgraphInput } from '@/lib/litegraph/src/subgraph/SubgraphInput'
@@ -19,17 +20,20 @@ import type { IBaseWidget } from '@/lib/litegraph/src/types/widgets'
 
 export class NodeInputSlot extends NodeSlot implements INodeInputSlot {
   alwaysVisible?: boolean
+  private legacyLink?: LLink
 
   /**
    * @deprecated Reads return the store-derived link id. Assigning null
-   * disconnects through the store; assigning an id is ignored. First-party
-   * code uses the slotLinks helpers and node topology methods.
+   * disconnects through the store; assigning that id again restores the
+   * observed topology when it is still valid.
    */
   get link(): LinkId | null {
     warnDeprecated(
       'input.link is deprecated. Read connectivity via node.isInputConnected(slot) / node.getInputLink(slot); mutate via node.connect() / node.disconnectInput().'
     )
-    return linkIdOf(this)
+    const link = linkOf(this)
+    if (link) this.legacyLink = link
+    return link?.id ?? null
   }
 
   set link(value: LinkId | null) {
@@ -37,7 +41,14 @@ export class NodeInputSlot extends NodeSlot implements INodeInputSlot {
       'Assignment to input.link is deprecated; null disconnects through the link store. Mutate via node.connect() / node.disconnectInput().'
     )
     const slot = indexOf(this)
-    if (value === null && slot !== -1) this._node.disconnectInput(slot)
+    if (slot === -1) return
+    if (value === null) {
+      const link = linkOf(this)
+      if (link) this.legacyLink = link
+      this._node.disconnectInput(slot)
+    } else if (this.legacyLink?.id === value) {
+      restoreLegacyLink(this.legacyLink, this._node, slot, 'input')
+    }
   }
 
   get isWidgetInputSlot(): boolean {
@@ -124,7 +135,10 @@ function indexOf(slot: NodeInputSlot): number {
 }
 
 function linkIdOf(slot: NodeInputSlot): LinkId | null {
+  return linkOf(slot)?.id ?? null
+}
+
+function linkOf(slot: NodeInputSlot): LLink | undefined {
   const { graph } = slot.node
-  if (!graph) return null
-  return inputLinkId(graph, slot.node.id, indexOf(slot)) ?? null
+  return graph ? inputLink(graph, slot.node.id, indexOf(slot)) : undefined
 }

--- a/src/lib/litegraph/src/node/NodeInputSlot.ts
+++ b/src/lib/litegraph/src/node/NodeInputSlot.ts
@@ -1,5 +1,5 @@
 import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
-import type { LLink,LinkId } from '@/lib/litegraph/src/LLink'
+import type { LLink, LinkId } from '@/lib/litegraph/src/LLink'
 import { LabelPosition } from '@/lib/litegraph/src/draw'
 import type {
   INodeInputSlot,

--- a/src/lib/litegraph/src/node/NodeOutputSlot.ts
+++ b/src/lib/litegraph/src/node/NodeOutputSlot.ts
@@ -1,5 +1,5 @@
 import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
-import type { LLink,LinkId } from '@/lib/litegraph/src/LLink'
+import type { LLink, LinkId } from '@/lib/litegraph/src/LLink'
 import { LabelPosition } from '@/lib/litegraph/src/draw'
 import type {
   INodeInputSlot,

--- a/src/lib/litegraph/src/node/NodeOutputSlot.ts
+++ b/src/lib/litegraph/src/node/NodeOutputSlot.ts
@@ -1,5 +1,5 @@
 import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
-import type { LinkId } from '@/lib/litegraph/src/LLink'
+import type { LLink,LinkId } from '@/lib/litegraph/src/LLink'
 import { LabelPosition } from '@/lib/litegraph/src/draw'
 import type {
   INodeInputSlot,
@@ -11,11 +11,8 @@ import { LiteGraph } from '@/lib/litegraph/src/litegraph'
 import { createArrayMutationView } from '@/lib/litegraph/src/infrastructure/createMutationView'
 import { NodeSlot } from '@/lib/litegraph/src/node/NodeSlot'
 import type { IDrawOptions } from '@/lib/litegraph/src/node/NodeSlot'
-import {
-  outputHasLinks,
-  outputLinkIds,
-  outputLinks
-} from '@/lib/litegraph/src/node/slotLinks'
+import { restoreLegacyLink } from '@/lib/litegraph/src/node/restoreLegacyLink'
+import { outputHasLinks, outputLinks } from '@/lib/litegraph/src/node/slotLinks'
 import type { SubgraphInput } from '@/lib/litegraph/src/subgraph/SubgraphInput'
 import type { SubgraphOutput } from '@/lib/litegraph/src/subgraph/SubgraphOutput'
 import { isSubgraphOutput } from '@/lib/litegraph/src/subgraph/subgraphUtils'
@@ -25,13 +22,14 @@ export class NodeOutputSlot extends NodeSlot implements INodeOutputSlot {
   _data?: unknown
   slot_index?: number
   private readonly legacyLinkIds!: LinkId[]
+  private readonly legacyLinks!: Map<LinkId, LLink>
   private readonly legacyLinksView!: LinkId[]
   private legacyLinksPresent!: boolean
 
   /**
    * @deprecated Reads return a stable store-derived view. Removing ids from the
-   * view disconnects them; additions are discarded. First-party code uses the
-   * slotLinks helpers and node topology methods.
+   * view disconnects them; adding a previously observed id restores its
+   * topology when it is still valid.
    */
   get links(): LinkId[] | null {
     warnDeprecated(
@@ -51,7 +49,9 @@ export class NodeOutputSlot extends NodeSlot implements INodeOutputSlot {
   }
 
   private synchronizeLegacyLinks(): void {
-    const ids = linkIdsOf(this)
+    const links = linksOf(this)
+    for (const link of links) this.legacyLinks.set(link.id, link)
+    const ids = links.map((link) => link.id)
     this.legacyLinkIds.splice(0, this.legacyLinkIds.length, ...ids)
     if (ids.length) this.legacyLinksPresent = true
   }
@@ -73,9 +73,16 @@ export class NodeOutputSlot extends NodeSlot implements INodeOutputSlot {
     }
 
     const desired = new Set(this.legacyLinkIds)
-    for (const link of outputLinks(graph, this._node.id, slot)) {
+    const current = outputLinks(graph, this._node.id, slot)
+    for (const link of current) this.legacyLinks.set(link.id, link)
+    for (const link of current) {
       if (desired.has(link.id)) continue
       graph.getNodeById(link.target_id)?.disconnectInput(link.target_slot)
+    }
+    for (const id of desired) {
+      if (graph.getLink(id)) continue
+      const link = this.legacyLinks.get(id)
+      if (link) restoreLegacyLink(link, this._node, slot, 'output')
     }
     this.synchronizeLegacyLinks()
   }
@@ -103,6 +110,7 @@ export class NodeOutputSlot extends NodeSlot implements INodeOutputSlot {
     const legacyLinkIds: LinkId[] = []
     Object.defineProperties(this, {
       legacyLinkIds: { value: legacyLinkIds },
+      legacyLinks: { value: new Map<LinkId, LLink>() },
       legacyLinksView: {
         value: createArrayMutationView(
           legacyLinkIds,
@@ -175,6 +183,10 @@ function indexOf(slot: NodeOutputSlot): number {
 }
 
 function linkIdsOf(slot: NodeOutputSlot): LinkId[] {
+  return linksOf(slot).map((link) => link.id)
+}
+
+function linksOf(slot: NodeOutputSlot): LLink[] {
   const { graph } = slot.node
-  return graph ? outputLinkIds(graph, slot.node.id, indexOf(slot)) : []
+  return graph ? outputLinks(graph, slot.node.id, indexOf(slot)) : []
 }

--- a/src/lib/litegraph/src/node/legacySlotLinkMutations.test.ts
+++ b/src/lib/litegraph/src/node/legacySlotLinkMutations.test.ts
@@ -112,8 +112,8 @@ describe('legacy slot link creation and plain-object slots (uncovered)', () => {
     setActivePinia(createTestingPinia({ stubActions: false }))
   })
 
-  it.fails('restores a link from a saved id', () => {
-    const { source, target } = connectedPair()
+  it('restores a link from a saved id', () => {
+    const { graph, source, target } = connectedPair()
     const saved = target.inputs[0].link
 
     target.inputs[0].link = null
@@ -122,9 +122,52 @@ describe('legacy slot link creation and plain-object slots (uncovered)', () => {
     target.inputs[0].link = saved
     expect(target.inputs[0].link).toBe(saved)
     expect(source.isOutputConnected(0)).toBe(true)
+    expect(saved && graph.getLink(saved)).toBeDefined()
   })
 
-  it.fails('reconnects a link pushed back onto the output view', () => {
+  it('does not restore a saved input link over a newer connection', () => {
+    const { graph, source, target } = connectedPair()
+    const saved = target.inputs[0].link
+    target.inputs[0].link = null
+
+    const replacementSource = new LGraphNode('Replacement source')
+    replacementSource.addOutput('out', 'INT')
+    graph.add(replacementSource)
+    const replacement = replacementSource.connect(0, target, 0)!
+
+    target.inputs[0].link = saved
+
+    expect(target.inputs[0].link).toBe(replacement.id)
+    expect(source.isOutputConnected(0)).toBe(false)
+    expect(replacementSource.isOutputConnected(0)).toBe(true)
+  })
+
+  it('does not restore a saved input link after its source is removed', () => {
+    const { graph, source, target } = connectedPair()
+    const saved = target.inputs[0].link
+    target.inputs[0].link = null
+    graph.remove(source)
+
+    expect(() => {
+      target.inputs[0].link = saved
+    }).not.toThrow()
+    expect(target.inputs[0].link).toBeNull()
+  })
+
+  it('does not restore an id copied from another input slot', () => {
+    const { graph, target } = connectedPair()
+    const saved = target.inputs[0].link
+    target.inputs[0].link = null
+
+    const otherTarget = new LGraphNode('Other target')
+    otherTarget.addInput('in', 'INT')
+    graph.add(otherTarget)
+    otherTarget.inputs[0].link = saved
+
+    expect(otherTarget.inputs[0].link).toBeNull()
+  })
+
+  it('reconnects a link pushed back onto the output view', () => {
     const { source, target } = connectedPair()
     const output = source.outputs[0]
     const [id] = output.links!
@@ -135,6 +178,32 @@ describe('legacy slot link creation and plain-object slots (uncovered)', () => {
     output.links!.push(id)
     expect(source.isOutputConnected(0)).toBe(true)
     expect(target.isInputConnected(0)).toBe(true)
+    expect(target.inputs[0].link).toBe(id)
+  })
+
+  it('restores one removed fan-out link without disturbing its sibling', () => {
+    const { source, targets } = fanOut(2)
+    const view = source.outputs[0].links!
+    const removed = view.pop()!
+
+    expect(targets[0].isInputConnected(0)).toBe(true)
+    expect(targets[1].isInputConnected(0)).toBe(false)
+
+    view.push(removed)
+
+    expect(targets.every((target) => target.isInputConnected(0))).toBe(true)
+    expect(source.outputs[0].links).toHaveLength(2)
+  })
+
+  it('does not restore an output link after its target is removed', () => {
+    const { graph, source, target } = connectedPair()
+    const view = source.outputs[0].links!
+    const [id] = view
+    view.length = 0
+    graph.remove(target)
+
+    expect(() => view.push(id)).not.toThrow()
+    expect(source.outputs[0].links).toEqual([])
   })
 
   it('disconnects through a plain-object input slot', () => {

--- a/src/lib/litegraph/src/node/legacySlotLinkMutations.test.ts
+++ b/src/lib/litegraph/src/node/legacySlotLinkMutations.test.ts
@@ -6,7 +6,8 @@ import type {
   INodeInputSlot,
   INodeOutputSlot
 } from '@/lib/litegraph/src/interfaces'
-import { LGraph, LGraphNode } from '@/lib/litegraph/src/litegraph'
+import { LGraph, LGraphNode, LiteGraph } from '@/lib/litegraph/src/litegraph'
+import { createTestSubgraph } from '@/lib/litegraph/src/subgraph/__fixtures__/subgraphHelpers'
 import { useLinkStore } from '@/stores/linkStore'
 
 function connectedPair() {
@@ -204,6 +205,87 @@ describe('legacy slot link creation and plain-object slots (uncovered)', () => {
 
     expect(() => view.push(id)).not.toThrow()
     expect(source.outputs[0].links).toEqual([])
+  })
+
+  it('does not restore a second event output when fan-out is disabled', () => {
+    const { source, targets } = fanOut(2)
+    source.outputs[0].type = LiteGraph.EVENT
+    const saved = targets[0].inputs[0].link
+    targets[0].inputs[0].link = null
+
+    const previous = LiteGraph.allow_multi_output_for_events
+    LiteGraph.allow_multi_output_for_events = false
+    try {
+      targets[0].inputs[0].link = saved
+    } finally {
+      LiteGraph.allow_multi_output_for_events = previous
+    }
+
+    expect(targets[0].isInputConnected(0)).toBe(false)
+    expect(targets[1].isInputConnected(0)).toBe(true)
+    expect(source.outputs[0].links).toHaveLength(1)
+  })
+
+  it('fails safely when restoring from a subgraph input', () => {
+    const subgraph = createTestSubgraph({
+      inputs: [{ name: 'value', type: 'INT' }]
+    })
+    const target = new LGraphNode('Target')
+    target.addInput('in', 'INT')
+    subgraph.add(target)
+    const saved = subgraph.inputs[0].connect(target.inputs[0], target)!.id
+    target.inputs[0].link = null
+
+    expect(() => {
+      target.inputs[0].link = saved
+    }).not.toThrow()
+    expect(target.inputs[0].link).toBeNull()
+  })
+
+  it('fails safely when restoring to a subgraph output', () => {
+    const subgraph = createTestSubgraph({
+      outputs: [{ name: 'value', type: 'INT' }]
+    })
+    const source = new LGraphNode('Source')
+    source.addOutput('out', 'INT')
+    subgraph.add(source)
+    const saved = subgraph.outputs[0].connect(source.outputs[0], source)!.id
+    const view = source.outputs[0].links!
+    source.disconnectOutput(0)
+
+    expect(source.outputs[0].links).toBeNull()
+    expect(() => view.push(saved)).not.toThrow()
+    expect(source.outputs[0].links).toBeNull()
+  })
+
+  it('honors connection callback vetoes when restoring', () => {
+    for (const side of ['input', 'output'] as const) {
+      const { source, target } = connectedPair()
+      const saved = target.inputs[0].link
+      target.inputs[0].link = null
+      if (side === 'input') target.onConnectInput = () => false
+      else source.onConnectOutput = () => false
+
+      target.inputs[0].link = saved
+
+      expect(target.isInputConnected(0), side).toBe(false)
+      expect(source.isOutputConnected(0), side).toBe(false)
+    }
+  })
+
+  it('fails safely when a connection callback removes the restored link', () => {
+    const { source, target } = connectedPair()
+    const saved = target.inputs[0].link
+    target.inputs[0].link = null
+    source.onConnectionsChange = (_side, _slot, connected) => {
+      if (connected) target.disconnectInput(0)
+    }
+
+    expect(() => {
+      target.inputs[0].link = saved
+    }).not.toThrow()
+    expect(target.isInputConnected(0)).toBe(false)
+    expect(source.isOutputConnected(0)).toBe(false)
   })
 
   it('disconnects through a plain-object input slot', () => {

--- a/src/lib/litegraph/src/node/restoreLegacyLink.ts
+++ b/src/lib/litegraph/src/node/restoreLegacyLink.ts
@@ -1,0 +1,82 @@
+import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
+import type { LLink } from '@/lib/litegraph/src/LLink'
+import { registerLinkTopology } from '@/lib/litegraph/src/LLink'
+import { inputHasLink } from '@/lib/litegraph/src/node/slotLinks'
+import { anchorRerouteChain } from '@/lib/litegraph/src/Reroute'
+import { LiteGraph } from '@/lib/litegraph/src/litegraph'
+import { NodeSlotType } from '@/lib/litegraph/src/types/globalEnums'
+
+export function restoreLegacyLink(
+  link: LLink,
+  node: LGraphNode,
+  slot: number,
+  side: 'input' | 'output'
+): boolean {
+  const { graph } = node
+  if (!graph || graph.getLink(link.id)) return false
+  if (
+    side === 'input'
+      ? !link.hasTarget(node.id, slot)
+      : !link.hasOrigin(node.id, slot)
+  )
+    return false
+
+  const outputNode = graph.getNodeById(link.origin_id)
+  const inputNode = graph.getNodeById(link.target_id)
+  const output = outputNode?.outputs[link.origin_slot]
+  const input = inputNode?.inputs[link.target_slot]
+  if (!outputNode || !inputNode || !output || !input) return false
+  if (inputHasLink(graph, inputNode.id, link.target_slot)) return false
+  if (!LiteGraph.isValidConnection(output.type, input.type)) return false
+  if (
+    inputNode.onConnectInput?.(
+      link.target_slot,
+      output.type,
+      output,
+      outputNode,
+      link.origin_slot
+    ) === false ||
+    outputNode.onConnectOutput?.(
+      link.origin_slot,
+      input.type,
+      input,
+      inputNode,
+      link.target_slot
+    ) === false
+  )
+    return false
+
+  if (link.parentId !== undefined && !graph.reroutes.has(link.parentId)) {
+    link.parentId = undefined
+  }
+  if (!registerLinkTopology(graph, link)) return false
+
+  anchorRerouteChain(graph, link)
+  graph.incrementVersion()
+  outputNode.onConnectionsChange?.(
+    NodeSlotType.OUTPUT,
+    link.origin_slot,
+    true,
+    link,
+    output
+  )
+  if (graph.getLink(link.id) !== link) {
+    graph.afterChange()
+    return false
+  }
+  inputNode.onConnectionsChange?.(
+    NodeSlotType.INPUT,
+    link.target_slot,
+    true,
+    link,
+    input
+  )
+  if (graph.getLink(link.id) !== link) {
+    graph.afterChange()
+    return false
+  }
+
+  outputNode.setDirtyCanvas(false, true)
+  graph.afterChange()
+  return true
+}

--- a/src/lib/litegraph/src/node/restoreLegacyLink.ts
+++ b/src/lib/litegraph/src/node/restoreLegacyLink.ts
@@ -1,7 +1,10 @@
 import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
 import type { LLink } from '@/lib/litegraph/src/LLink'
 import { registerLinkTopology } from '@/lib/litegraph/src/LLink'
-import { inputHasLink } from '@/lib/litegraph/src/node/slotLinks'
+import {
+  inputHasLink,
+  outputHasLinks
+} from '@/lib/litegraph/src/node/slotLinks'
 import { anchorRerouteChain } from '@/lib/litegraph/src/Reroute'
 import { LiteGraph } from '@/lib/litegraph/src/litegraph'
 import { NodeSlotType } from '@/lib/litegraph/src/types/globalEnums'
@@ -14,6 +17,7 @@ export function restoreLegacyLink(
 ): boolean {
   const { graph } = node
   if (!graph || graph.getLink(link.id)) return false
+  if (link.originIsIoNode || link.targetIsIoNode) return false
   if (
     side === 'input'
       ? !link.hasTarget(node.id, slot)
@@ -27,6 +31,12 @@ export function restoreLegacyLink(
   const input = inputNode?.inputs[link.target_slot]
   if (!outputNode || !inputNode || !output || !input) return false
   if (inputHasLink(graph, inputNode.id, link.target_slot)) return false
+  if (
+    output.type === LiteGraph.EVENT &&
+    !LiteGraph.allow_multi_output_for_events &&
+    outputHasLinks(graph, outputNode.id, link.origin_slot)
+  )
+    return false
   if (!LiteGraph.isValidConnection(output.type, input.type)) return false
   if (
     inputNode.onConnectInput?.(


### PR DESCRIPTION
## Summary

Restores previously observed links when deprecated slot mirrors re-add their IDs while keeping the link store authoritative.

## Changes

- **What**: Retains detached topology as compatibility-command input for `input.link` and the existing `output.links` mutation view.
- **Safety**: Rejects restoration when an endpoint is missing, the target is occupied, the ID is live, or the ID came from another slot.
- **Tests**: Covers input and output restoration, fan-out, conflicts, copied IDs, and removed endpoints.

## Review Focus

Please focus on the restoration validation boundary and whether retaining detached `LLink` instances on legacy slots is sufficiently narrow for compatibility.

## Red-Green Verification

- `9586adbadf` adds the failing restoration cases.
- `b52a4503fc` implements store-authoritative restoration.