### PR TITLE
Align Vue badge display order

### DIFF
--- a/src/composables/node/badgeRendererParity.test.ts
+++ b/src/composables/node/badgeRendererParity.test.ts
@@ -117,7 +117,7 @@ describe('badge renderer parity (I2)', () => {
       expect(legacyBadgeText(node)).toBe('#1 BETA my_pack')
     })
 
-    it.fails('renders Vue badges in the same display order', () => {
+    it('renders Vue badges in the same display order', () => {
       const node = setup(
         NodeBadgeMode.ShowAll,
         'CustomNode',
@@ -139,7 +139,7 @@ describe('badge renderer parity (I2)', () => {
       expect(legacyBadgeText(node)).toBe('#1 BETA my_pack')
     })
 
-    it.fails('renders Vue badges in the same display order', () => {
+    it('renders Vue badges in the same display order', () => {
       const node = setup(
         NodeBadgeMode.HideBuiltIn,
         'CustomNode',
@@ -164,7 +164,7 @@ describe('badge renderer parity (I2)', () => {
       expect(legacyBadgeText(node)).toBe(`#1 BETA ${CORE_SOURCE_BADGE}`)
     })
 
-    it.fails('renders Vue badges in the same display order', () => {
+    it('renders Vue badges in the same display order', () => {
       const node = setup(NodeBadgeMode.ShowAll, 'CoreNode', 'nodes')
 
       expect(vueBadgeText(node)).toBe(`#1 BETA ${CORE_SOURCE_BADGE}`)

--- a/src/renderer/extensions/vueNodes/components/NodeBadges.test.ts
+++ b/src/renderer/extensions/vueNodes/components/NodeBadges.test.ts
@@ -1,0 +1,23 @@
+import { render, screen } from '@testing-library/vue'
+import { describe, expect, it } from 'vitest'
+
+import NodeBadges from '@/renderer/extensions/vueNodes/components/NodeBadges.vue'
+
+describe('NodeBadges', () => {
+  it('renders the Comfy badge after the core badges', () => {
+    render(NodeBadges, {
+      props: {
+        hasComfyBadge: true,
+        core: [{ text: '#1' }, { text: 'BETA' }],
+        extension: []
+      }
+    })
+
+    const coreBadge = screen.getByText('BETA')
+    const comfyBadge = screen.getByTestId('comfy-badge')
+    expect(
+      coreBadge.compareDocumentPosition(comfyBadge) &
+        Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy()
+  })
+})

--- a/src/renderer/extensions/vueNodes/components/NodeBadges.vue
+++ b/src/renderer/extensions/vueNodes/components/NodeBadges.vue
@@ -14,12 +14,6 @@ defineProps<{
     class="flex h-5 w-full gap-2 px-2 text-muted-foreground"
   >
     <div
-      v-if="hasComfyBadge"
-      class="flex size-6 items-center justify-center rounded-full bg-component-node-widget-background"
-    >
-      <i class="icon-[comfy--comfy-c] size-3" />
-    </div>
-    <div
       v-if="core.length"
       class="flex h-6 items-center justify-center overflow-clip rounded-full bg-component-node-widget-background"
     >
@@ -34,6 +28,13 @@ defineProps<{
           class="h-6 first:pl-2 last:pr-2"
         />
       </template>
+    </div>
+    <div
+      v-if="hasComfyBadge"
+      data-testid="comfy-badge"
+      class="flex size-6 items-center justify-center rounded-full bg-component-node-widget-background"
+    >
+      <i class="icon-[comfy--comfy-c] size-3" />
     </div>
     <div
       v-if="extension.length"

--- a/src/renderer/extensions/vueNodes/composables/usePartitionedBadges.test.ts
+++ b/src/renderer/extensions/vueNodes/composables/usePartitionedBadges.test.ts
@@ -96,7 +96,7 @@ describe('usePartitionedBadges', () => {
 
     expect(partitioned.value).toEqual({
       hasComfyBadge: false,
-      core: [{ text: 'BETA' }, { text: '#5' }, { text: 'testpack' }],
+      core: [{ text: '#5' }, { text: 'BETA' }, { text: 'testpack' }],
       extension: [],
       pricing: [{ required: '$0.05', rest: 'x 3 Runs' }]
     })
@@ -157,8 +157,8 @@ describe('usePartitionedBadges', () => {
     addNodeDef('CustomNode', 'custom_nodes.testpack')
 
     expect(partitioned.value.core).toEqual([
-      { text: 'BETA' },
       { text: '#5' },
+      { text: 'BETA' },
       { text: 'testpack' }
     ])
   })

--- a/src/renderer/extensions/vueNodes/composables/usePartitionedBadges.ts
+++ b/src/renderer/extensions/vueNodes/composables/usePartitionedBadges.ts
@@ -7,6 +7,8 @@ import type { NodeBadgeProps } from '@/renderer/extensions/vueNodes/components/N
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import { useNodeDefStore } from '@/stores/nodeDefStore'
 import { nodeBadges } from '@/systems/badgeSystem'
+import { CORE_JOIN_ORDER } from '@/types/badgeData'
+import type { CoreBadgePart } from '@/types/badgeData'
 import { NodeBadgeMode } from '@/types/nodeSource'
 import { resolveNode } from '@/utils/litegraphUtil'
 
@@ -33,7 +35,7 @@ export function usePartitionedBadges(nodeData: NodeState) {
       settingStore.get('Comfy.NodeBadge.NodeSourceBadgeMode') ===
         NodeBadgeMode.ShowAll
 
-    const core: NodeBadgeProps[] = []
+    const coreByPart = new Map<CoreBadgePart, NodeBadgeProps>()
     const extension: NodeBadgeProps[] = []
     const pricing: { required: string; rest?: string }[] = []
 
@@ -46,7 +48,7 @@ export function usePartitionedBadges(nodeData: NodeState) {
         continue
       }
       if (nodeDef?.isCoreNode && row.part === 'source') continue
-      core.push({
+      coreByPart.set(row.part, {
         text: row.part === 'lifecycle' ? trim(row.text, ['[', ']']) : row.text
       })
     }
@@ -58,7 +60,10 @@ export function usePartitionedBadges(nodeData: NodeState) {
 
     return {
       hasComfyBadge: showComfyLogo && pricing.length === 0,
-      core,
+      core: CORE_JOIN_ORDER.flatMap((part) => {
+        const badge = coreByPart.get(part)
+        return badge ? [badge] : []
+      }),
       extension,
       pricing
     }


### PR DESCRIPTION
## Summary

Aligns Vue node badge chip ordering with the legacy canvas renderer.

## Changes

- **What**: Projects Vue core badges in the shared ID, lifecycle, source display order without changing badge derivation or visibility semantics.
- **Tests**: Promotes the three renderer-parity expected failures and updates direct composable expectations.

## Review Focus

Please focus on keeping ordering renderer-local while preserving the existing separate Comfy logo treatment for core nodes.

## Red-Green Verification

- `333404f143` makes the ordering expectations fail.
- `eab101efa8` applies the Vue projection fix.