### PR TITLE
fix(telemetry): report graph link corruption found on workflow load

### DIFF
--- a/src/platform/telemetry/reportOnce.test.ts
+++ b/src/platform/telemetry/reportOnce.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { createOnceReporter } from './reportOnce'
+
+describe('createOnceReporter', () => {
+  it('reports a key once, however often it recurs', () => {
+    const report = vi.fn()
+    const reportOnce = createOnceReporter(10)
+
+    reportOnce('a', report)
+    reportOnce('a', report)
+    reportOnce('b', report)
+
+    expect(report).toHaveBeenCalledTimes(2)
+  })
+
+  it('stops reporting once the budget of distinct keys is spent', () => {
+    const report = vi.fn()
+    const reportOnce = createOnceReporter(2)
+
+    for (const key of ['a', 'b', 'c', 'd']) reportOnce(key, report)
+
+    expect(report).toHaveBeenCalledTimes(2)
+  })
+
+  it('gives each reporter its own budget', () => {
+    const report = vi.fn()
+    const spent = createOnceReporter(1)
+    const fresh = createOnceReporter(1)
+
+    spent('a', report)
+    spent('b', report)
+    fresh('c', report)
+
+    expect(report).toHaveBeenCalledTimes(2)
+  })
+})

--- a/src/platform/telemetry/reportOnce.ts
+++ b/src/platform/telemetry/reportOnce.ts
@@ -1,0 +1,20 @@
+/**
+ * Guards a report against repetition: each distinct key reports once, and a
+ * session reports at most `limit` distinct keys.
+ *
+ * Both bounds matter on paths a user can re-enter indefinitely — reloads, undo
+ * and redo — where an unguarded reporter would send the same finding on every
+ * pass and grow its key set for as long as the tab stays open. Give each kind
+ * of finding its own reporter so a common one cannot spend a rare one's budget.
+ */
+export function createOnceReporter(
+  limit: number
+): (key: string, report: () => void) => void {
+  const reported = new Set<string>()
+
+  return (key, report) => {
+    if (reported.has(key) || reported.size >= limit) return
+    reported.add(key)
+    report()
+  }
+}

--- a/src/platform/workflow/persistence/base/hashUtil.test.ts
+++ b/src/platform/workflow/persistence/base/hashUtil.test.ts
@@ -1,53 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
-import { fnv1a, hashPath } from './hashUtil'
-
-describe('fnv1a', () => {
-  it('returns consistent hash for same input', () => {
-    const hash1 = fnv1a('workflows/test.json')
-    const hash2 = fnv1a('workflows/test.json')
-    expect(hash1).toBe(hash2)
-  })
-
-  it('returns different hashes for different inputs', () => {
-    const hash1 = fnv1a('workflows/a.json')
-    const hash2 = fnv1a('workflows/b.json')
-    expect(hash1).not.toBe(hash2)
-  })
-
-  it('returns unsigned 32-bit integer', () => {
-    const hash = fnv1a('test')
-    expect(hash).toBeGreaterThanOrEqual(0)
-    expect(hash).toBeLessThanOrEqual(0xffffffff)
-  })
-
-  it('handles empty string', () => {
-    const hash = fnv1a('')
-    expect(hash).toBe(2166136261)
-  })
-
-  it('handles unicode characters', () => {
-    const hash = fnv1a('workflows/工作流程.json')
-    expect(hash).toBeGreaterThanOrEqual(0)
-    expect(hash).toBeLessThanOrEqual(0xffffffff)
-  })
-
-  it('handles special characters', () => {
-    const hash = fnv1a('workflows/My Workflow (Copy 2).json')
-    expect(hash).toBeGreaterThanOrEqual(0)
-  })
-})
+import { hashPath } from './hashUtil'
 
 describe('hashPath', () => {
   it('returns 8-character hex string', () => {
     const result = hashPath('workflows/test.json')
     expect(result).toMatch(/^[0-9a-f]{8}$/)
-  })
-
-  it('pads short hashes with leading zeros', () => {
-    const result = hashPath('')
-    expect(result).toHaveLength(8)
-    expect(result).toBe('811c9dc5')
   })
 
   it('returns consistent results', () => {

--- a/src/platform/workflow/persistence/base/hashUtil.test.ts
+++ b/src/platform/workflow/persistence/base/hashUtil.test.ts
@@ -8,6 +8,11 @@ describe('hashPath', () => {
     expect(result).toMatch(/^[0-9a-f]{8}$/)
   })
 
+  it('keys the same path the same way it did in earlier releases', () => {
+    expect(hashPath('')).toBe('811c9dc5')
+    expect(hashPath('workflows/Untitled.json')).toBe('325d5d45')
+  })
+
   it('returns consistent results', () => {
     const path = 'workflows/My Complex Workflow Name.json'
     const hash1 = hashPath(path)

--- a/src/platform/workflow/persistence/base/hashUtil.ts
+++ b/src/platform/workflow/persistence/base/hashUtil.ts
@@ -1,20 +1,4 @@
-/**
- * FNV-1a hash function for creating short, deterministic keys from strings.
- *
- * Used to create 8-character hex keys from workflow paths for localStorage keys.
- * FNV-1a is chosen for its simplicity, speed, and good distribution properties.
- *
- * @param str - The string to hash (typically a workflow path)
- * @returns A 32-bit unsigned integer hash
- */
-export function fnv1a(str: string): number {
-  let hash = 2166136261
-  for (let i = 0; i < str.length; i++) {
-    hash ^= str.charCodeAt(i)
-    hash = Math.imul(hash, 16777619)
-  }
-  return hash >>> 0
-}
+import { fnv1aHex } from '@/utils/hashUtil'
 
 /**
  * Creates an 8-character hex key from a workflow path using FNV-1a hash.
@@ -26,5 +10,5 @@ export function fnv1a(str: string): number {
  * hashPath("workflows/Untitled.json") // "1a2b3c4d"
  */
 export function hashPath(path: string): string {
-  return fnv1a(path).toString(16).padStart(8, '0')
+  return fnv1aHex(path)
 }

--- a/src/platform/workflow/persistence/base/hashUtil.ts
+++ b/src/platform/workflow/persistence/base/hashUtil.ts
@@ -3,6 +3,9 @@ import { fnv1aHex } from '@/utils/hashUtil'
 /**
  * Creates an 8-character hex key from a workflow path using FNV-1a hash.
  *
+ * Stored drafts are keyed by this value, so changing the digest orphans every
+ * draft a user has not saved yet.
+ *
  * @param path - The workflow path (e.g., "workflows/My Workflow.json")
  * @returns An 8-character hex string (e.g., "a1b2c3d4")
  *

--- a/src/platform/workflow/persistence/base/hashUtil.ts
+++ b/src/platform/workflow/persistence/base/hashUtil.ts
@@ -7,10 +7,10 @@ import { fnv1aHex } from '@/utils/hashUtil'
  * draft a user has not saved yet.
  *
  * @param path - The workflow path (e.g., "workflows/My Workflow.json")
- * @returns An 8-character hex string (e.g., "a1b2c3d4")
+ * @returns An 8-character hex string
  *
  * @example
- * hashPath("workflows/Untitled.json") // "1a2b3c4d"
+ * hashPath("workflows/Untitled.json") // "325d5d45"
  */
 export function hashPath(path: string): string {
   return fnv1aHex(path)

--- a/src/platform/workflow/validation/composables/__fixtures__/corruptWorkflows.ts
+++ b/src/platform/workflow/validation/composables/__fixtures__/corruptWorkflows.ts
@@ -1,0 +1,100 @@
+import type { SerialisedLLinkArray } from '@/lib/litegraph/src/LLink'
+import type { ISerialisedNode } from '@/lib/litegraph/src/types/serialisation'
+import type { ComfyWorkflowJSON } from '@/platform/workflow/validation/schemas/workflowSchema'
+
+type SerialisedInput = NonNullable<ISerialisedNode['inputs']>[number]
+type SerialisedOutput = NonNullable<ISerialisedNode['outputs']>[number]
+
+const createInput = (link: number | null): SerialisedInput =>
+  ({
+    name: 'in',
+    type: '*',
+    link
+  }) satisfies Partial<SerialisedInput> as SerialisedInput
+
+const createOutput = (links: number[]): SerialisedOutput =>
+  ({
+    name: 'out',
+    type: '*',
+    links
+  }) satisfies Partial<SerialisedOutput> as SerialisedOutput
+
+function createNode({
+  id,
+  inputs = [],
+  outputs = []
+}: {
+  id: number
+  inputs?: SerialisedInput[]
+  outputs?: SerialisedOutput[]
+}) {
+  return {
+    id,
+    type: 'TestNode',
+    pos: [0, 0],
+    size: [100, 100],
+    flags: {},
+    order: 0,
+    mode: 0,
+    properties: {},
+    inputs,
+    outputs
+  }
+}
+
+function createWorkflow(
+  id: string | undefined,
+  nodes: ReturnType<typeof createNode>[],
+  links: SerialisedLLinkArray[]
+): ComfyWorkflowJSON {
+  return {
+    ...(id ? { id } : {}),
+    last_node_id: 2,
+    last_link_id: 1,
+    nodes,
+    links,
+    groups: [],
+    config: {},
+    extra: {},
+    version: 0.4
+  } as unknown as ComfyWorkflowJSON
+}
+
+export const intactWorkflow = (id: string) =>
+  createWorkflow(
+    id,
+    [
+      createNode({ id: 1, outputs: [createOutput([1])] }),
+      createNode({ id: 2, inputs: [createInput(1)] })
+    ],
+    [[1, 1, 0, 2, 0, '*']]
+  )
+
+/** Link 1 targets node 2, which is not in the graph. */
+export const corruptWorkflow = (id: string) =>
+  createWorkflow(
+    id,
+    [createNode({ id: 1, outputs: [createOutput([1])] })],
+    [[1, 1, 0, 2, 0, '*']]
+  )
+
+/**
+ * Id-less workflows whose corruption differs only in which nodes it names.
+ * `patched`/`deleted` counts are identical across them, so a key built from
+ * counts alone would report the first and discard the rest. Node ids come from
+ * a counter because the reporters outlive a test: fixed ids would make a CI
+ * retry of a transient failure fail permanently.
+ */
+let nodeIdSeed = 1000
+export const unidentifiedCorruptWorkflow = () => {
+  const originId = (nodeIdSeed += 2)
+  return createWorkflow(
+    undefined,
+    [createNode({ id: originId, outputs: [createOutput([1])] })],
+    [[1, originId, 0, originId + 1, 0, '*']]
+  )
+}
+
+let workflowCount = 0
+export const uniqueId = () =>
+  `b4e984f1-b421-4d24-b8b4-ff895793a${String(workflowCount++).padStart(3, '0')}`

--- a/src/platform/workflow/validation/composables/__fixtures__/corruptWorkflows.ts
+++ b/src/platform/workflow/validation/composables/__fixtures__/corruptWorkflows.ts
@@ -71,12 +71,12 @@ export const intactWorkflow = (id: string) =>
     [[1, 1, 0, 2, 0, '*']]
   )
 
-/** Link 1 targets node 2, which is not in the graph. */
-export const corruptWorkflow = (id: string) =>
+/** Link 1 targets the node after `originId`, which is not in the graph. */
+export const corruptWorkflow = (id: string, originId = 1) =>
   createWorkflow(
     id,
-    [createNode({ id: 1, outputs: [createOutput([1])] })],
-    [[1, 1, 0, 2, 0, '*']]
+    [createNode({ id: originId, outputs: [createOutput([1])] })],
+    [[1, originId, 0, originId + 1, 0, '*']]
   )
 
 /**

--- a/src/platform/workflow/validation/composables/__fixtures__/corruptWorkflows.ts
+++ b/src/platform/workflow/validation/composables/__fixtures__/corruptWorkflows.ts
@@ -1,23 +1,24 @@
-import type { SerialisedLLinkArray } from '@/lib/litegraph/src/LLink'
-import type { ISerialisedNode } from '@/lib/litegraph/src/types/serialisation'
-import type { ComfyWorkflowJSON } from '@/platform/workflow/validation/schemas/workflowSchema'
+import type {
+  ComfyWorkflowJSON,
+  WorkflowJSON04
+} from '@/platform/workflow/validation/schemas/workflowSchema'
 
-type SerialisedInput = NonNullable<ISerialisedNode['inputs']>[number]
-type SerialisedOutput = NonNullable<ISerialisedNode['outputs']>[number]
+type SerialisedNode = WorkflowJSON04['nodes'][number]
+type SerialisedLink = WorkflowJSON04['links'][number]
+type SerialisedInput = NonNullable<SerialisedNode['inputs']>[number]
+type SerialisedOutput = NonNullable<SerialisedNode['outputs']>[number]
 
-const createInput = (link: number | null): SerialisedInput =>
-  ({
-    name: 'in',
-    type: '*',
-    link
-  }) satisfies Partial<SerialisedInput> as SerialisedInput
+const createInput = (link: number | null): SerialisedInput => ({
+  name: 'in',
+  type: '*',
+  link
+})
 
-const createOutput = (links: number[]): SerialisedOutput =>
-  ({
-    name: 'out',
-    type: '*',
-    links
-  }) satisfies Partial<SerialisedOutput> as SerialisedOutput
+const createOutput = (links: number[]): SerialisedOutput => ({
+  name: 'out',
+  type: '*',
+  links
+})
 
 function createNode({
   id,
@@ -27,7 +28,7 @@ function createNode({
   id: number
   inputs?: SerialisedInput[]
   outputs?: SerialisedOutput[]
-}) {
+}): SerialisedNode {
   return {
     id,
     type: 'TestNode',
@@ -44,8 +45,8 @@ function createNode({
 
 function createWorkflow(
   id: string | undefined,
-  nodes: ReturnType<typeof createNode>[],
-  links: SerialisedLLinkArray[]
+  nodes: SerialisedNode[],
+  links: SerialisedLink[]
 ): ComfyWorkflowJSON {
   return {
     ...(id ? { id } : {}),
@@ -57,7 +58,7 @@ function createWorkflow(
     config: {},
     extra: {},
     version: 0.4
-  } as unknown as ComfyWorkflowJSON
+  }
 }
 
 export const intactWorkflow = (id: string) =>

--- a/src/platform/workflow/validation/composables/useWorkflowValidation.budget.test.ts
+++ b/src/platform/workflow/validation/composables/useWorkflowValidation.budget.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 
+import type { ComfyWorkflowJSON } from '@/platform/workflow/validation/schemas/workflowSchema'
 import type * as LinkFixer from '@/utils/linkFixer'
 import { fixBadLinks } from '@/utils/linkFixer'
 
@@ -24,6 +25,9 @@ vi.mock('@/utils/linkFixer', async (importOriginal) => {
   return { ...actual, fixBadLinks: vi.fn(actual.fixBadLinks) }
 })
 
+const reload = (workflow: ComfyWorkflowJSON) =>
+  useWorkflowValidation().validateWorkflow(workflow)
+
 /**
  * The reporters are module state, so spending one of them here would leave the
  * rest of a shared file asserting against an exhausted budget. Vitest gives
@@ -35,21 +39,20 @@ describe('useWorkflowValidation reporting budget', () => {
 
   it('keeps reporting fixer failures after corruption reports run out', async () => {
     vi.spyOn(console, 'error').mockImplementation(() => {})
-    const validation = useWorkflowValidation()
 
     for (let i = 0; i <= MAX_REPORTS_PER_KIND; i++) {
-      await validation.validateWorkflow(unidentifiedCorruptWorkflow())
+      await reload(unidentifiedCorruptWorkflow())
     }
 
     reportError.mockClear()
-    await validation.validateWorkflow(unidentifiedCorruptWorkflow())
+    await reload(unidentifiedCorruptWorkflow())
     expect(reportError).not.toHaveBeenCalled()
 
     const cause = `link fixer exploded ${(explosions += 1)}`
     vi.mocked(fixBadLinks).mockImplementation(() => {
       throw new Error(cause)
     })
-    await validation.validateWorkflow(intactWorkflow(uniqueId()))
+    await reload(intactWorkflow(uniqueId()))
 
     expect(reportError).toHaveBeenCalledWith(
       expect.objectContaining({ message: cause }),

--- a/src/platform/workflow/validation/composables/useWorkflowValidation.budget.test.ts
+++ b/src/platform/workflow/validation/composables/useWorkflowValidation.budget.test.ts
@@ -33,22 +33,24 @@ const reload = (workflow: ComfyWorkflowJSON) =>
  * rest of a shared file asserting against an exhausted budget. Vitest gives
  * each file its own module registry; this one is that budget's own file, so no
  * ordering rule or `vi.resetModules()` is needed to keep the two apart.
+ *
+ * A budget can only be spent once per registry, so `retry` is off: a second
+ * attempt would assert against the budget the first attempt spent.
  */
-describe('useWorkflowValidation reporting budget', () => {
-  let explosions = 0
-
+describe('useWorkflowValidation reporting budget', { retry: 0 }, () => {
   it('keeps reporting fixer failures after corruption reports run out', async () => {
     vi.spyOn(console, 'error').mockImplementation(() => {})
 
-    for (let i = 0; i <= MAX_REPORTS_PER_KIND; i++) {
+    for (let i = 0; i < MAX_REPORTS_PER_KIND; i++) {
       await reload(unidentifiedCorruptWorkflow())
     }
+    expect(reportError).toHaveBeenCalledTimes(MAX_REPORTS_PER_KIND)
 
     reportError.mockClear()
     await reload(unidentifiedCorruptWorkflow())
     expect(reportError).not.toHaveBeenCalled()
 
-    const cause = `link fixer exploded ${(explosions += 1)}`
+    const cause = 'link fixer exploded'
     vi.mocked(fixBadLinks).mockImplementation(() => {
       throw new Error(cause)
     })

--- a/src/platform/workflow/validation/composables/useWorkflowValidation.budget.test.ts
+++ b/src/platform/workflow/validation/composables/useWorkflowValidation.budget.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import type * as LinkFixer from '@/utils/linkFixer'
+import { fixBadLinks } from '@/utils/linkFixer'
+
+import {
+  intactWorkflow,
+  unidentifiedCorruptWorkflow,
+  uniqueId
+} from './__fixtures__/corruptWorkflows'
+import {
+  MAX_REPORTS_PER_KIND,
+  useWorkflowValidation
+} from './useWorkflowValidation'
+
+const reportError = vi.fn()
+
+vi.mock('@/platform/telemetry/reportError', () => ({
+  reportError: (...args: unknown[]) => reportError(...args)
+}))
+
+vi.mock('@/utils/linkFixer', async (importOriginal) => {
+  const actual = await importOriginal<typeof LinkFixer>()
+  return { ...actual, fixBadLinks: vi.fn(actual.fixBadLinks) }
+})
+
+/**
+ * The reporters are module state, so spending one of them here would leave the
+ * rest of a shared file asserting against an exhausted budget. Vitest gives
+ * each file its own module registry; this one is that budget's own file, so no
+ * ordering rule or `vi.resetModules()` is needed to keep the two apart.
+ */
+describe('useWorkflowValidation reporting budget', () => {
+  let explosions = 0
+
+  it('keeps reporting fixer failures after corruption reports run out', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    const validation = useWorkflowValidation()
+
+    for (let i = 0; i <= MAX_REPORTS_PER_KIND; i++) {
+      await validation.validateWorkflow(unidentifiedCorruptWorkflow())
+    }
+
+    reportError.mockClear()
+    await validation.validateWorkflow(unidentifiedCorruptWorkflow())
+    expect(reportError).not.toHaveBeenCalled()
+
+    const cause = `link fixer exploded ${(explosions += 1)}`
+    vi.mocked(fixBadLinks).mockImplementation(() => {
+      throw new Error(cause)
+    })
+    await validation.validateWorkflow(intactWorkflow(uniqueId()))
+
+    expect(reportError).toHaveBeenCalledWith(
+      expect.objectContaining({ message: cause }),
+      expect.objectContaining({ errorType: 'workflow_link_fixer_failure' })
+    )
+  })
+})

--- a/src/platform/workflow/validation/composables/useWorkflowValidation.test.ts
+++ b/src/platform/workflow/validation/composables/useWorkflowValidation.test.ts
@@ -1,0 +1,100 @@
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { ComfyWorkflowJSON } from '@/platform/workflow/validation/schemas/workflowSchema'
+
+import { useWorkflowValidation } from './useWorkflowValidation'
+
+const reportError = vi.fn()
+
+vi.mock('@/platform/telemetry/reportError', () => ({
+  reportError: (...args: unknown[]) => reportError(...args)
+}))
+
+function createNode(id: number, extra: Record<string, unknown> = {}) {
+  return {
+    id,
+    type: 'TestNode',
+    pos: [0, 0],
+    size: [100, 100],
+    flags: {},
+    order: 0,
+    mode: 0,
+    properties: {},
+    ...extra
+  }
+}
+
+function createWorkflow(
+  nodes: ReturnType<typeof createNode>[],
+  links: unknown[]
+): ComfyWorkflowJSON {
+  return {
+    last_node_id: 2,
+    last_link_id: 1,
+    nodes,
+    links,
+    groups: [],
+    config: {},
+    extra: {},
+    version: 0.4
+  } as unknown as ComfyWorkflowJSON
+}
+
+const intactWorkflow = () =>
+  createWorkflow(
+    [
+      createNode(1, { outputs: [{ name: 'out', type: '*', links: [1] }] }),
+      createNode(2, { inputs: [{ name: 'in', type: '*', link: 1 }] })
+    ],
+    [[1, 1, 0, 2, 0, '*']]
+  )
+
+/** Link 1 points at node 2, which does not exist. */
+const corruptWorkflow = () =>
+  createWorkflow(
+    [createNode(1, { outputs: [{ name: 'out', type: '*', links: [1] }] })],
+    [[1, 1, 0, 2, 0, '*']]
+  )
+
+describe('useWorkflowValidation', () => {
+  beforeEach(() => {
+    setActivePinia(createTestingPinia({ stubActions: false }))
+  })
+
+  it('reports graph corruption found while loading a workflow', async () => {
+    await useWorkflowValidation().validateWorkflow(corruptWorkflow())
+
+    expect(reportError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: 'Workflow loaded with corrupt links'
+      }),
+      expect.objectContaining({
+        errorType: 'workflow_link_corruption',
+        level: 'warning',
+        tags: { patched: 1, deleted: 1, unrepaired: false, silent: false }
+      })
+    )
+  })
+
+  it('still reports corruption when validation is silenced', async () => {
+    await useWorkflowValidation().validateWorkflow(corruptWorkflow(), {
+      silent: true
+    })
+
+    expect(reportError).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        errorType: 'workflow_link_corruption',
+        tags: expect.objectContaining({ silent: true })
+      })
+    )
+  })
+
+  it('stays quiet for an intact workflow', async () => {
+    await useWorkflowValidation().validateWorkflow(intactWorkflow())
+
+    expect(reportError).not.toHaveBeenCalled()
+  })
+})

--- a/src/platform/workflow/validation/composables/useWorkflowValidation.test.ts
+++ b/src/platform/workflow/validation/composables/useWorkflowValidation.test.ts
@@ -119,6 +119,18 @@ describe('useWorkflowValidation', () => {
     expect(reportError).toHaveBeenCalledTimes(2)
   })
 
+  it('counts each identified workflow carrying the same corruption', async () => {
+    await reload(corruptWorkflow(uniqueId()))
+    await reload(corruptWorkflow(uniqueId()))
+
+    expect(reportError).toHaveBeenCalledTimes(2)
+    const [first, second] = [reportedOptions(0), reportedOptions(1)]
+    expect(first.context?.corruptionDigest).toBe(
+      second.context?.corruptionDigest
+    )
+    expect(first.context?.workflowId).not.toBe(second.context?.workflowId)
+  })
+
   it('stays quiet for an intact workflow', async () => {
     await useWorkflowValidation().validateWorkflow(intactWorkflow(uniqueId()))
 

--- a/src/platform/workflow/validation/composables/useWorkflowValidation.test.ts
+++ b/src/platform/workflow/validation/composables/useWorkflowValidation.test.ts
@@ -1,10 +1,15 @@
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
+import type { SerialisedLLinkArray } from '@/lib/litegraph/src/LLink'
+import type { ISerialisedNode } from '@/lib/litegraph/src/types/serialisation'
 import type { ComfyWorkflowJSON } from '@/platform/workflow/validation/schemas/workflowSchema'
+import type * as LinkFixer from '@/utils/linkFixer'
+import { fixBadLinks } from '@/utils/linkFixer'
 
 import { useWorkflowValidation } from './useWorkflowValidation'
+
+type SerialisedInput = NonNullable<ISerialisedNode['inputs']>[number]
+type SerialisedOutput = NonNullable<ISerialisedNode['outputs']>[number]
 
 const reportError = vi.fn()
 
@@ -12,7 +17,34 @@ vi.mock('@/platform/telemetry/reportError', () => ({
   reportError: (...args: unknown[]) => reportError(...args)
 }))
 
-function createNode(id: number, extra: Record<string, unknown> = {}) {
+vi.mock('@/utils/linkFixer', async (importOriginal) => {
+  const actual = await importOriginal<typeof LinkFixer>()
+  return { ...actual, fixBadLinks: vi.fn(actual.fixBadLinks) }
+})
+
+const createInput = (link: number | null): SerialisedInput =>
+  ({
+    name: 'in',
+    type: '*',
+    link
+  }) satisfies Partial<SerialisedInput> as SerialisedInput
+
+const createOutput = (links: number[]): SerialisedOutput =>
+  ({
+    name: 'out',
+    type: '*',
+    links
+  }) satisfies Partial<SerialisedOutput> as SerialisedOutput
+
+function createNode({
+  id,
+  inputs = [],
+  outputs = []
+}: {
+  id: number
+  inputs?: SerialisedInput[]
+  outputs?: SerialisedOutput[]
+}) {
   return {
     id,
     type: 'TestNode',
@@ -22,15 +54,18 @@ function createNode(id: number, extra: Record<string, unknown> = {}) {
     order: 0,
     mode: 0,
     properties: {},
-    ...extra
+    inputs,
+    outputs
   }
 }
 
 function createWorkflow(
+  id: string,
   nodes: ReturnType<typeof createNode>[],
-  links: unknown[]
+  links: SerialisedLLinkArray[]
 ): ComfyWorkflowJSON {
   return {
+    id,
     last_node_id: 2,
     last_link_id: 1,
     nodes,
@@ -42,29 +77,31 @@ function createWorkflow(
   } as unknown as ComfyWorkflowJSON
 }
 
-const intactWorkflow = () =>
+const intactWorkflow = (id: string) =>
   createWorkflow(
+    id,
     [
-      createNode(1, { outputs: [{ name: 'out', type: '*', links: [1] }] }),
-      createNode(2, { inputs: [{ name: 'in', type: '*', link: 1 }] })
+      createNode({ id: 1, outputs: [createOutput([1])] }),
+      createNode({ id: 2, inputs: [createInput(1)] })
     ],
     [[1, 1, 0, 2, 0, '*']]
   )
 
-/** Link 1 points at node 2, which does not exist. */
-const corruptWorkflow = () =>
+/** Link 1 targets node 2, which is not in the graph. */
+const corruptWorkflow = (id: string) =>
   createWorkflow(
-    [createNode(1, { outputs: [{ name: 'out', type: '*', links: [1] }] })],
+    id,
+    [createNode({ id: 1, outputs: [createOutput([1])] })],
     [[1, 1, 0, 2, 0, '*']]
   )
 
-describe('useWorkflowValidation', () => {
-  beforeEach(() => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
-  })
+let workflowCount = 0
+const uniqueId = () =>
+  `b4e984f1-b421-4d24-b8b4-ff895793a${String(workflowCount++).padStart(3, '0')}`
 
-  it('reports graph corruption found while loading a workflow', async () => {
-    await useWorkflowValidation().validateWorkflow(corruptWorkflow())
+describe('useWorkflowValidation', () => {
+  it('reports the corruption the link fixer found while loading a workflow', async () => {
+    await useWorkflowValidation().validateWorkflow(corruptWorkflow(uniqueId()))
 
     expect(reportError).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -73,28 +110,55 @@ describe('useWorkflowValidation', () => {
       expect.objectContaining({
         errorType: 'workflow_link_corruption',
         level: 'warning',
-        tags: { patched: 1, deleted: 1, unrepaired: false, silent: false }
+        context: expect.objectContaining({
+          patched: 1,
+          deleted: 1,
+          unrepaired: false
+        })
       })
     )
   })
 
-  it('still reports corruption when validation is silenced', async () => {
-    await useWorkflowValidation().validateWorkflow(corruptWorkflow(), {
-      silent: true
-    })
-
-    expect(reportError).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.objectContaining({
-        errorType: 'workflow_link_corruption',
-        tags: expect.objectContaining({ silent: true })
-      })
+  it('keeps the diagnostics when validation is silenced', async () => {
+    await useWorkflowValidation().validateWorkflow(
+      corruptWorkflow(uniqueId()),
+      { silent: true }
     )
+
+    const [, options] = reportError.mock.calls[0] as [
+      Error,
+      { context: { logSample: string[] } }
+    ]
+    expect(options.context.logSample.length).toBeGreaterThan(0)
+  })
+
+  it('reports a corrupt workflow once, not once per reload', async () => {
+    const workflowId = uniqueId()
+    const validation = useWorkflowValidation()
+
+    await validation.validateWorkflow(corruptWorkflow(workflowId))
+    await validation.validateWorkflow(corruptWorkflow(workflowId))
+
+    expect(reportError).toHaveBeenCalledOnce()
   })
 
   it('stays quiet for an intact workflow', async () => {
-    await useWorkflowValidation().validateWorkflow(intactWorkflow())
+    await useWorkflowValidation().validateWorkflow(intactWorkflow(uniqueId()))
 
     expect(reportError).not.toHaveBeenCalled()
+  })
+
+  it('reports the link fixer throwing rather than only logging it', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    vi.mocked(fixBadLinks).mockImplementation(() => {
+      throw new Error('link fixer exploded')
+    })
+
+    await useWorkflowValidation().validateWorkflow(intactWorkflow(uniqueId()))
+
+    expect(reportError).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'link fixer exploded' }),
+      { errorType: 'workflow_link_fixer_failure' }
+    )
   })
 })

--- a/src/platform/workflow/validation/composables/useWorkflowValidation.test.ts
+++ b/src/platform/workflow/validation/composables/useWorkflowValidation.test.ts
@@ -55,9 +55,15 @@ const reportedOptions = (call = 0) =>
 const reload = (workflow: ComfyWorkflowJSON) =>
   useWorkflowValidation().validateWorkflow(workflow)
 
+let corruptionShape = 10
+const distinctCorruptWorkflow = (id: string) =>
+  corruptWorkflow(id, corruptionShape++)
+
 describe('useWorkflowValidation', () => {
   it('reports the corruption the link fixer found while loading a workflow', async () => {
-    await useWorkflowValidation().validateWorkflow(corruptWorkflow(uniqueId()))
+    await useWorkflowValidation().validateWorkflow(
+      distinctCorruptWorkflow(uniqueId())
+    )
 
     expect(reportError).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -75,7 +81,9 @@ describe('useWorkflowValidation', () => {
   it('attributes the report to the workflow it came from', async () => {
     const workflowId = uniqueId()
 
-    await useWorkflowValidation().validateWorkflow(corruptWorkflow(workflowId))
+    await useWorkflowValidation().validateWorkflow(
+      distinctCorruptWorkflow(workflowId)
+    )
 
     expect(reportedOptions().context?.workflowId).toBe(workflowId)
   })
@@ -83,7 +91,9 @@ describe('useWorkflowValidation', () => {
   it('digests the fixer log instead of forwarding it', async () => {
     const fixerLogs = captureFixerLogs()
 
-    await useWorkflowValidation().validateWorkflow(corruptWorkflow(uniqueId()))
+    await useWorkflowValidation().validateWorkflow(
+      distinctCorruptWorkflow(uniqueId())
+    )
 
     const options = reportedOptions()
     expect(options.context?.corruptionDigest).toMatch(/^[0-9a-f]{8}$/)
@@ -94,7 +104,7 @@ describe('useWorkflowValidation', () => {
 
   it('reports, without a toast, when validation is silenced', async () => {
     const { graphData } = await useWorkflowValidation().validateWorkflow(
-      corruptWorkflow(uniqueId()),
+      distinctCorruptWorkflow(uniqueId()),
       { silent: true }
     )
 
@@ -105,30 +115,30 @@ describe('useWorkflowValidation', () => {
 
   it('reports a corrupt workflow once, not once per reload', async () => {
     const workflowId = uniqueId()
+    const shape = corruptionShape++
 
-    await reload(corruptWorkflow(workflowId))
-    await reload(corruptWorkflow(workflowId))
+    await reload(corruptWorkflow(workflowId, shape))
+    await reload(corruptWorkflow(workflowId, shape))
 
     expect(reportError).toHaveBeenCalledOnce()
   })
 
-  it('does not collapse distinct workflows that carry no id', async () => {
+  it('reports distinct corruption shapes separately without workflow ids', async () => {
     await reload(unidentifiedCorruptWorkflow())
     await reload(unidentifiedCorruptWorkflow())
 
     expect(reportError).toHaveBeenCalledTimes(2)
+    expect(reportedOptions(0).context?.corruptionDigest).not.toBe(
+      reportedOptions(1).context?.corruptionDigest
+    )
   })
 
-  it('counts each identified workflow carrying the same corruption', async () => {
-    await reload(corruptWorkflow(uniqueId()))
-    await reload(corruptWorkflow(uniqueId()))
+  it('reports the same corruption shape once across identified workflows', async () => {
+    const shape = corruptionShape++
+    await reload(corruptWorkflow(uniqueId(), shape))
+    await reload(corruptWorkflow(uniqueId(), shape))
 
-    expect(reportError).toHaveBeenCalledTimes(2)
-    const [first, second] = [reportedOptions(0), reportedOptions(1)]
-    expect(first.context?.corruptionDigest).toBe(
-      second.context?.corruptionDigest
-    )
-    expect(first.context?.workflowId).not.toBe(second.context?.workflowId)
+    expect(reportError).toHaveBeenCalledOnce()
   })
 
   it('stays quiet for an intact workflow', async () => {

--- a/src/platform/workflow/validation/composables/useWorkflowValidation.test.ts
+++ b/src/platform/workflow/validation/composables/useWorkflowValidation.test.ts
@@ -60,12 +60,12 @@ function createNode({
 }
 
 function createWorkflow(
-  id: string,
+  id: string | undefined,
   nodes: ReturnType<typeof createNode>[],
   links: SerialisedLLinkArray[]
 ): ComfyWorkflowJSON {
   return {
-    id,
+    ...(id ? { id } : {}),
     last_node_id: 2,
     last_link_id: 1,
     nodes,
@@ -95,6 +95,18 @@ const corruptWorkflow = (id: string) =>
     [[1, 1, 0, 2, 0, '*']]
   )
 
+/**
+ * Two id-less workflows whose corruption differs only in which nodes it names.
+ * `patched`/`deleted` counts are identical, so a key built from counts alone
+ * would report the first and discard the second.
+ */
+const unidentifiedCorruptWorkflow = (originId: number, missingId: number) =>
+  createWorkflow(
+    undefined,
+    [createNode({ id: originId, outputs: [createOutput([1])] })],
+    [[1, originId, 0, missingId, 0, '*']]
+  )
+
 let workflowCount = 0
 const uniqueId = () =>
   `b4e984f1-b421-4d24-b8b4-ff895793a${String(workflowCount++).padStart(3, '0')}`
@@ -110,13 +122,22 @@ describe('useWorkflowValidation', () => {
       expect.objectContaining({
         errorType: 'workflow_link_corruption',
         level: 'warning',
-        context: expect.objectContaining({
-          patched: 1,
-          deleted: 1,
-          unrepaired: false
-        })
+        tags: { unrepaired: false },
+        context: expect.objectContaining({ patched: 1, deleted: 1 })
       })
     )
+  })
+
+  it('attributes the report to the workflow it came from', async () => {
+    const workflowId = uniqueId()
+
+    await useWorkflowValidation().validateWorkflow(corruptWorkflow(workflowId))
+
+    const [, options] = reportError.mock.calls[0] as [
+      Error,
+      { context: { workflowId: string } }
+    ]
+    expect(options.context.workflowId).toBe(workflowId)
   })
 
   it('keeps the diagnostics when validation is silenced', async () => {
@@ -142,6 +163,15 @@ describe('useWorkflowValidation', () => {
     expect(reportError).toHaveBeenCalledOnce()
   })
 
+  it('does not collapse distinct workflows that carry no id', async () => {
+    const validation = useWorkflowValidation()
+
+    await validation.validateWorkflow(unidentifiedCorruptWorkflow(3, 4))
+    await validation.validateWorkflow(unidentifiedCorruptWorkflow(5, 6))
+
+    expect(reportError).toHaveBeenCalledTimes(2)
+  })
+
   it('stays quiet for an intact workflow', async () => {
     await useWorkflowValidation().validateWorkflow(intactWorkflow(uniqueId()))
 
@@ -158,7 +188,7 @@ describe('useWorkflowValidation', () => {
 
     expect(reportError).toHaveBeenCalledWith(
       expect.objectContaining({ message: 'link fixer exploded' }),
-      { errorType: 'workflow_link_fixer_failure' }
+      expect.objectContaining({ errorType: 'workflow_link_fixer_failure' })
     )
   })
 })

--- a/src/platform/workflow/validation/composables/useWorkflowValidation.test.ts
+++ b/src/platform/workflow/validation/composables/useWorkflowValidation.test.ts
@@ -1,16 +1,17 @@
 import { describe, expect, it, vi } from 'vitest'
 
-import type { SerialisedLLinkArray } from '@/lib/litegraph/src/LLink'
-import type { ISerialisedNode } from '@/lib/litegraph/src/types/serialisation'
-import type { ComfyWorkflowJSON } from '@/platform/workflow/validation/schemas/workflowSchema'
+import type { ReportErrorOptions } from '@/platform/telemetry/reportError'
 import { useToastStore } from '@/platform/updates/common/toastStore'
 import type * as LinkFixer from '@/utils/linkFixer'
 import { fixBadLinks } from '@/utils/linkFixer'
 
+import {
+  corruptWorkflow,
+  intactWorkflow,
+  unidentifiedCorruptWorkflow,
+  uniqueId
+} from './__fixtures__/corruptWorkflows'
 import { useWorkflowValidation } from './useWorkflowValidation'
-
-type SerialisedInput = NonNullable<ISerialisedNode['inputs']>[number]
-type SerialisedOutput = NonNullable<ISerialisedNode['outputs']>[number]
 
 const reportError = vi.fn()
 
@@ -23,99 +24,28 @@ vi.mock('@/utils/linkFixer', async (importOriginal) => {
   return { ...actual, fixBadLinks: vi.fn(actual.fixBadLinks) }
 })
 
-const createInput = (link: number | null): SerialisedInput =>
-  ({
-    name: 'in',
-    type: '*',
-    link
-  }) satisfies Partial<SerialisedInput> as SerialisedInput
+const actualLinkFixer =
+  await vi.importActual<typeof LinkFixer>('@/utils/linkFixer')
 
-const createOutput = (links: number[]): SerialisedOutput =>
-  ({
-    name: 'out',
-    type: '*',
-    links
-  }) satisfies Partial<SerialisedOutput> as SerialisedOutput
-
-function createNode({
-  id,
-  inputs = [],
-  outputs = []
-}: {
-  id: number
-  inputs?: SerialisedInput[]
-  outputs?: SerialisedOutput[]
-}) {
-  return {
-    id,
-    type: 'TestNode',
-    pos: [0, 0],
-    size: [100, 100],
-    flags: {},
-    order: 0,
-    mode: 0,
-    properties: {},
-    inputs,
-    outputs
-  }
+/** Tees every line the real fixer emits, without changing what it does. */
+function captureFixerLogs(): string[] {
+  const lines: string[] = []
+  vi.mocked(fixBadLinks).mockImplementation((graph, options = {}) =>
+    actualLinkFixer.fixBadLinks(graph, {
+      ...options,
+      logger: {
+        log: (...args: unknown[]) => {
+          lines.push(args.join(' '))
+          options.logger?.log(...args)
+        }
+      }
+    })
+  )
+  return lines
 }
 
-function createWorkflow(
-  id: string | undefined,
-  nodes: ReturnType<typeof createNode>[],
-  links: SerialisedLLinkArray[]
-): ComfyWorkflowJSON {
-  return {
-    ...(id ? { id } : {}),
-    last_node_id: 2,
-    last_link_id: 1,
-    nodes,
-    links,
-    groups: [],
-    config: {},
-    extra: {},
-    version: 0.4
-  } as unknown as ComfyWorkflowJSON
-}
-
-const intactWorkflow = (id: string) =>
-  createWorkflow(
-    id,
-    [
-      createNode({ id: 1, outputs: [createOutput([1])] }),
-      createNode({ id: 2, inputs: [createInput(1)] })
-    ],
-    [[1, 1, 0, 2, 0, '*']]
-  )
-
-/** Link 1 targets node 2, which is not in the graph. */
-const corruptWorkflow = (id: string) =>
-  createWorkflow(
-    id,
-    [createNode({ id: 1, outputs: [createOutput([1])] })],
-    [[1, 1, 0, 2, 0, '*']]
-  )
-
-/**
- * Id-less workflows whose corruption differs only in which nodes it names.
- * `patched`/`deleted` counts are identical across them, so a key built from
- * counts alone would report the first and discard the rest. Node ids come from
- * a counter because `reportedCorruption` outlives a test: fixed ids would make
- * a CI retry of a transient failure fail permanently.
- */
-let nodeIdSeed = 1000
-const unidentifiedCorruptWorkflow = () => {
-  const originId = (nodeIdSeed += 2)
-  return createWorkflow(
-    undefined,
-    [createNode({ id: originId, outputs: [createOutput([1])] })],
-    [[1, originId, 0, originId + 1, 0, '*']]
-  )
-}
-
-let workflowCount = 0
-const uniqueId = () =>
-  `b4e984f1-b421-4d24-b8b4-ff895793a${String(workflowCount++).padStart(3, '0')}`
+const reportedOptions = (call = 0) =>
+  (reportError.mock.calls[call] as [Error, ReportErrorOptions])[1]
 
 describe('useWorkflowValidation', () => {
   it('reports the corruption the link fixer found while loading a workflow', async () => {
@@ -139,11 +69,19 @@ describe('useWorkflowValidation', () => {
 
     await useWorkflowValidation().validateWorkflow(corruptWorkflow(workflowId))
 
-    const [, options] = reportError.mock.calls[0] as [
-      Error,
-      { context: { workflowId: string } }
-    ]
-    expect(options.context.workflowId).toBe(workflowId)
+    expect(reportedOptions().context?.workflowId).toBe(workflowId)
+  })
+
+  it('digests the fixer log instead of forwarding it', async () => {
+    const fixerLogs = captureFixerLogs()
+
+    await useWorkflowValidation().validateWorkflow(corruptWorkflow(uniqueId()))
+
+    const options = reportedOptions()
+    expect(options.context?.corruptionDigest).toMatch(/^[0-9a-f]{8}$/)
+    expect(fixerLogs).not.toHaveLength(0)
+    const payload = JSON.stringify(options)
+    for (const line of fixerLogs) expect(payload).not.toContain(line)
   })
 
   it('reports, without a toast, when validation is silenced', async () => {
@@ -176,19 +114,6 @@ describe('useWorkflowValidation', () => {
     expect(reportError).toHaveBeenCalledTimes(2)
   })
 
-  it('stops reporting once the per-session cap is reached', async () => {
-    vi.resetModules()
-    const { useWorkflowValidation: withEmptyBudget } =
-      await import('./useWorkflowValidation')
-    const validation = withEmptyBudget()
-
-    for (let i = 0; i < 40; i++) {
-      await validation.validateWorkflow(unidentifiedCorruptWorkflow())
-    }
-
-    expect(reportError).toHaveBeenCalledTimes(25)
-  })
-
   it('stays quiet for an intact workflow', async () => {
     await useWorkflowValidation().validateWorkflow(intactWorkflow(uniqueId()))
 
@@ -207,5 +132,19 @@ describe('useWorkflowValidation', () => {
       expect.objectContaining({ message: 'link fixer exploded' }),
       expect.objectContaining({ errorType: 'workflow_link_fixer_failure' })
     )
+  })
+
+  it('reports a fixer that keeps failing the same way once', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    vi.mocked(fixBadLinks).mockImplementation(() => {
+      throw new Error('link fixer exploded')
+    })
+    const workflowId = uniqueId()
+    const validation = useWorkflowValidation()
+
+    await validation.validateWorkflow(intactWorkflow(workflowId))
+    await validation.validateWorkflow(intactWorkflow(workflowId))
+
+    expect(reportError).toHaveBeenCalledOnce()
   })
 })

--- a/src/platform/workflow/validation/composables/useWorkflowValidation.test.ts
+++ b/src/platform/workflow/validation/composables/useWorkflowValidation.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest'
 
 import type { ReportErrorOptions } from '@/platform/telemetry/reportError'
 import { useToastStore } from '@/platform/updates/common/toastStore'
+import type { ComfyWorkflowJSON } from '@/platform/workflow/validation/schemas/workflowSchema'
 import type * as LinkFixer from '@/utils/linkFixer'
 import { fixBadLinks } from '@/utils/linkFixer'
 
@@ -46,6 +47,13 @@ function captureFixerLogs(): string[] {
 
 const reportedOptions = (call = 0) =>
   (reportError.mock.calls[call] as [Error, ReportErrorOptions])[1]
+
+/**
+ * `loadGraphData` builds the composable anew for every load, so a test that
+ * reuses one instance cannot tell a per-session guard from a per-load one.
+ */
+const reload = (workflow: ComfyWorkflowJSON) =>
+  useWorkflowValidation().validateWorkflow(workflow)
 
 describe('useWorkflowValidation', () => {
   it('reports the corruption the link fixer found while loading a workflow', async () => {
@@ -97,19 +105,16 @@ describe('useWorkflowValidation', () => {
 
   it('reports a corrupt workflow once, not once per reload', async () => {
     const workflowId = uniqueId()
-    const validation = useWorkflowValidation()
 
-    await validation.validateWorkflow(corruptWorkflow(workflowId))
-    await validation.validateWorkflow(corruptWorkflow(workflowId))
+    await reload(corruptWorkflow(workflowId))
+    await reload(corruptWorkflow(workflowId))
 
     expect(reportError).toHaveBeenCalledOnce()
   })
 
   it('does not collapse distinct workflows that carry no id', async () => {
-    const validation = useWorkflowValidation()
-
-    await validation.validateWorkflow(unidentifiedCorruptWorkflow())
-    await validation.validateWorkflow(unidentifiedCorruptWorkflow())
+    await reload(unidentifiedCorruptWorkflow())
+    await reload(unidentifiedCorruptWorkflow())
 
     expect(reportError).toHaveBeenCalledTimes(2)
   })
@@ -140,10 +145,9 @@ describe('useWorkflowValidation', () => {
       throw new Error('link fixer exploded')
     })
     const workflowId = uniqueId()
-    const validation = useWorkflowValidation()
 
-    await validation.validateWorkflow(intactWorkflow(workflowId))
-    await validation.validateWorkflow(intactWorkflow(workflowId))
+    await reload(intactWorkflow(workflowId))
+    await reload(intactWorkflow(workflowId))
 
     expect(reportError).toHaveBeenCalledOnce()
   })

--- a/src/platform/workflow/validation/composables/useWorkflowValidation.test.ts
+++ b/src/platform/workflow/validation/composables/useWorkflowValidation.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from 'vitest'
 import type { SerialisedLLinkArray } from '@/lib/litegraph/src/LLink'
 import type { ISerialisedNode } from '@/lib/litegraph/src/types/serialisation'
 import type { ComfyWorkflowJSON } from '@/platform/workflow/validation/schemas/workflowSchema'
+import { useToastStore } from '@/platform/updates/common/toastStore'
 import type * as LinkFixer from '@/utils/linkFixer'
 import { fixBadLinks } from '@/utils/linkFixer'
 
@@ -145,17 +146,15 @@ describe('useWorkflowValidation', () => {
     expect(options.context.workflowId).toBe(workflowId)
   })
 
-  it('keeps the diagnostics when validation is silenced', async () => {
-    await useWorkflowValidation().validateWorkflow(
+  it('reports, without a toast, when validation is silenced', async () => {
+    const { graphData } = await useWorkflowValidation().validateWorkflow(
       corruptWorkflow(uniqueId()),
       { silent: true }
     )
 
-    const [, options] = reportError.mock.calls[0] as [
-      Error,
-      { context: { logSample: string[] } }
-    ]
-    expect(options.context.logSample.length).toBeGreaterThan(0)
+    expect(reportError).toHaveBeenCalledOnce()
+    expect(useToastStore().add).not.toHaveBeenCalled()
+    expect(graphData?.links).toHaveLength(0)
   })
 
   it('reports a corrupt workflow once, not once per reload', async () => {
@@ -178,13 +177,16 @@ describe('useWorkflowValidation', () => {
   })
 
   it('stops reporting once the per-session cap is reached', async () => {
-    const validation = useWorkflowValidation()
+    vi.resetModules()
+    const { useWorkflowValidation: withEmptyBudget } =
+      await import('./useWorkflowValidation')
+    const validation = withEmptyBudget()
 
     for (let i = 0; i < 40; i++) {
       await validation.validateWorkflow(unidentifiedCorruptWorkflow())
     }
 
-    expect(reportError.mock.calls.length).toBeLessThanOrEqual(25)
+    expect(reportError).toHaveBeenCalledTimes(25)
   })
 
   it('stays quiet for an intact workflow', async () => {

--- a/src/platform/workflow/validation/composables/useWorkflowValidation.test.ts
+++ b/src/platform/workflow/validation/composables/useWorkflowValidation.test.ts
@@ -96,16 +96,21 @@ const corruptWorkflow = (id: string) =>
   )
 
 /**
- * Two id-less workflows whose corruption differs only in which nodes it names.
- * `patched`/`deleted` counts are identical, so a key built from counts alone
- * would report the first and discard the second.
+ * Id-less workflows whose corruption differs only in which nodes it names.
+ * `patched`/`deleted` counts are identical across them, so a key built from
+ * counts alone would report the first and discard the rest. Node ids come from
+ * a counter because `reportedCorruption` outlives a test: fixed ids would make
+ * a CI retry of a transient failure fail permanently.
  */
-const unidentifiedCorruptWorkflow = (originId: number, missingId: number) =>
-  createWorkflow(
+let nodeIdSeed = 1000
+const unidentifiedCorruptWorkflow = () => {
+  const originId = (nodeIdSeed += 2)
+  return createWorkflow(
     undefined,
     [createNode({ id: originId, outputs: [createOutput([1])] })],
-    [[1, originId, 0, missingId, 0, '*']]
+    [[1, originId, 0, originId + 1, 0, '*']]
   )
+}
 
 let workflowCount = 0
 const uniqueId = () =>
@@ -166,10 +171,20 @@ describe('useWorkflowValidation', () => {
   it('does not collapse distinct workflows that carry no id', async () => {
     const validation = useWorkflowValidation()
 
-    await validation.validateWorkflow(unidentifiedCorruptWorkflow(3, 4))
-    await validation.validateWorkflow(unidentifiedCorruptWorkflow(5, 6))
+    await validation.validateWorkflow(unidentifiedCorruptWorkflow())
+    await validation.validateWorkflow(unidentifiedCorruptWorkflow())
 
     expect(reportError).toHaveBeenCalledTimes(2)
+  })
+
+  it('stops reporting once the per-session cap is reached', async () => {
+    const validation = useWorkflowValidation()
+
+    for (let i = 0; i < 40; i++) {
+      await validation.validateWorkflow(unidentifiedCorruptWorkflow())
+    }
+
+    expect(reportError.mock.calls.length).toBeLessThanOrEqual(25)
   })
 
   it('stays quiet for an intact workflow', async () => {

--- a/src/platform/workflow/validation/composables/useWorkflowValidation.ts
+++ b/src/platform/workflow/validation/composables/useWorkflowValidation.ts
@@ -3,16 +3,30 @@ import { reportError } from '@/platform/telemetry/reportError'
 import { useToastStore } from '@/platform/updates/common/toastStore'
 import type { ComfyWorkflowJSON } from '@/platform/workflow/validation/schemas/workflowSchema'
 import { validateComfyWorkflow } from '@/platform/workflow/validation/schemas/workflowSchema'
-import { getErrorMessage } from '@/utils/errorUtil'
+import { toError } from '@/utils/errorUtil'
 import { fixBadLinks } from '@/utils/linkFixer'
 
 interface ValidationResult {
   graphData: ComfyWorkflowJSON | null
 }
 
-const LOG_SAMPLE_LIMIT = 20
-const LOG_LINE_LIMIT = 200
 const MAX_REPORTS_PER_KIND = 25
+
+/**
+ * FNV-1a. The fixer's log lines interpolate node ids, which the schema leaves
+ * unconstrained (`zNodeId` accepts any string), so they cannot be forwarded to
+ * the sinks or pinned in memory verbatim. Digesting them keeps distinct
+ * corruption distinguishable — for dedup, and for grouping in a dashboard —
+ * without shipping workflow content anywhere.
+ */
+function digest(value: string): string {
+  let hash = 0x811c9dc5
+  for (let i = 0; i < value.length; i++) {
+    hash ^= value.charCodeAt(i)
+    hash = Math.imul(hash, 0x01000193)
+  }
+  return (hash >>> 0).toString(16)
+}
 
 /**
  * Workflow loads re-enter validation on undo/redo, so without these a single
@@ -26,7 +40,7 @@ const MAX_REPORTS_PER_KIND = 25
 const reportedCorruption = new Set<string>()
 const reportedFixerFailures = new Set<string>()
 
-function reportOnce(seen: Set<string>, key: string, report: () => void): void {
+function reportOnce(key: string, seen: Set<string>, report: () => void): void {
   if (seen.has(key)) return
   if (seen.size >= MAX_REPORTS_PER_KIND) return
   seen.add(key)
@@ -56,14 +70,12 @@ export function useWorkflowValidation() {
 
     const { patched, deleted, hasBadLinks } = linkValidation
     const workflowId = graphData.id ?? 'unidentified'
-    const logSample = logs
-      .slice(0, LOG_SAMPLE_LIMIT)
-      .map((line) => line.slice(0, LOG_LINE_LIMIT))
+    const corruptionDigest = digest(logs.join('\n'))
 
     if (patched || deleted) {
       reportOnce(
+        [workflowId, patched, deleted, corruptionDigest].join('|'),
         reportedCorruption,
-        [workflowId, patched, deleted, ...logSample].join('|'),
         () => {
           reportError(new Error('Workflow loaded with corrupt links'), {
             errorType: 'workflow_link_corruption',
@@ -73,7 +85,7 @@ export function useWorkflowValidation() {
               workflowId,
               patched,
               deleted,
-              logSample,
+              corruptionDigest,
               logCount: logs.length
             }
           })
@@ -135,8 +147,8 @@ export function useWorkflowValidation() {
         // Link fixer itself is throwing an error
         console.error(err)
         const workflowId = graphData.id ?? 'unidentified'
-        const cause = getErrorMessage(err) ?? String(err)
-        reportOnce(reportedFixerFailures, `${workflowId}|${cause}`, () => {
+        const cause = toError(err).message
+        reportOnce(`${workflowId}|${cause}`, reportedFixerFailures, () => {
           reportError(err, {
             errorType: 'workflow_link_fixer_failure',
             context: { workflowId }

--- a/src/platform/workflow/validation/composables/useWorkflowValidation.ts
+++ b/src/platform/workflow/validation/composables/useWorkflowValidation.ts
@@ -15,9 +15,8 @@ interface ValidationResult {
 export const MAX_REPORTS_PER_KIND = 25
 
 /**
- * Keys must describe the corruption itself, not just the workflow: `id` is
- * optional in the schema, and the workflows most likely to be corrupt are the
- * legacy ones that lack it.
+ * DQ-18: per-corruption-shape dedup (2026-08-25). Keys describe the corruption
+ * itself so identical shapes report once per session, regardless of workflow.
  *
  * The two kinds hold separate budgets so that a session full of repairable
  * corruption cannot crowd out the rarer report that the fixer itself broke.
@@ -58,7 +57,7 @@ export function useWorkflowValidation() {
 
     if (patched || deleted) {
       reportCorruptionOnce(
-        [workflowId, patched, deleted, corruptionDigest].join('|'),
+        [patched, deleted, corruptionDigest].join('|'),
         () => {
           reportError(new Error('Workflow loaded with corrupt links'), {
             errorType: 'workflow_link_corruption',

--- a/src/platform/workflow/validation/composables/useWorkflowValidation.ts
+++ b/src/platform/workflow/validation/composables/useWorkflowValidation.ts
@@ -11,18 +11,25 @@ interface ValidationResult {
 }
 
 const LOG_SAMPLE_LIMIT = 20
+const LOG_LINE_LIMIT = 200
+const MAX_REPORTS_PER_KIND = 25
 
 /**
- * Workflow loads re-enter validation on undo/redo, so without this a single
+ * Workflow loads re-enter validation on undo/redo, so without these a single
  * corrupt workflow would report once per history step. Keys must describe the
  * corruption itself, not just the workflow: `id` is optional in the schema, and
  * the workflows most likely to be corrupt are the legacy ones that lack it.
+ *
+ * The two kinds hold separate budgets so that a session full of repairable
+ * corruption cannot crowd out the rarer report that the fixer itself broke.
  */
 const reportedCorruption = new Set<string>()
+const reportedFixerFailures = new Set<string>()
 
-function reportOnce(key: string, report: () => void): void {
-  if (reportedCorruption.has(key)) return
-  reportedCorruption.add(key)
+function reportOnce(seen: Set<string>, key: string, report: () => void): void {
+  if (seen.has(key)) return
+  if (seen.size >= MAX_REPORTS_PER_KIND) return
+  seen.add(key)
   report()
 }
 
@@ -49,23 +56,29 @@ export function useWorkflowValidation() {
 
     const { patched, deleted, hasBadLinks } = linkValidation
     const workflowId = graphData.id ?? 'unidentified'
-    const logSample = logs.slice(0, LOG_SAMPLE_LIMIT)
+    const logSample = logs
+      .slice(0, LOG_SAMPLE_LIMIT)
+      .map((line) => line.slice(0, LOG_LINE_LIMIT))
 
     if (patched || deleted) {
-      reportOnce([workflowId, patched, deleted, ...logSample].join('|'), () => {
-        reportError(new Error('Workflow loaded with corrupt links'), {
-          errorType: 'workflow_link_corruption',
-          level: 'warning',
-          tags: { unrepaired: hasBadLinks },
-          context: {
-            workflowId,
-            patched,
-            deleted,
-            logSample,
-            logCount: logs.length
-          }
-        })
-      })
+      reportOnce(
+        reportedCorruption,
+        [workflowId, patched, deleted, ...logSample].join('|'),
+        () => {
+          reportError(new Error('Workflow loaded with corrupt links'), {
+            errorType: 'workflow_link_corruption',
+            level: 'warning',
+            tags: { unrepaired: hasBadLinks },
+            context: {
+              workflowId,
+              patched,
+              deleted,
+              logSample,
+              logCount: logs.length
+            }
+          })
+        }
+      )
     }
 
     if (!silent && logs.length > 0) {
@@ -122,15 +135,13 @@ export function useWorkflowValidation() {
         // Link fixer itself is throwing an error
         console.error(err)
         const workflowId = graphData.id ?? 'unidentified'
-        reportOnce(
-          `fixer-failure|${workflowId}|${getErrorMessage(err)}`,
-          () => {
-            reportError(err, {
-              errorType: 'workflow_link_fixer_failure',
-              context: { workflowId }
-            })
-          }
-        )
+        const cause = getErrorMessage(err) ?? String(err)
+        reportOnce(reportedFixerFailures, `${workflowId}|${cause}`, () => {
+          reportError(err, {
+            errorType: 'workflow_link_fixer_failure',
+            context: { workflowId }
+          })
+        })
       }
     }
 

--- a/src/platform/workflow/validation/composables/useWorkflowValidation.ts
+++ b/src/platform/workflow/validation/composables/useWorkflowValidation.ts
@@ -11,6 +11,12 @@ interface ValidationResult {
 
 const LOG_SAMPLE_LIMIT = 20
 
+/**
+ * Workflow loads re-enter validation on undo/redo, so without this a single
+ * corrupt workflow would report once per history step.
+ */
+const reportedCorruptWorkflows = new Set<string>()
+
 export function useWorkflowValidation() {
   const toastStore = useToastStore()
 
@@ -25,7 +31,6 @@ export function useWorkflowValidation() {
     // Then validate and fix links if schema validation passed
     const linkValidation = fixBadLinks(graphData as ISerialisedGraph, {
       fix: true,
-      silent,
       logger: {
         log: (...args: unknown[]) => {
           logs.push(args.join(' '))
@@ -34,12 +39,16 @@ export function useWorkflowValidation() {
     })
 
     const { patched, deleted, hasBadLinks } = linkValidation
-    if (patched || deleted || hasBadLinks) {
+    const corruptionKey = `${graphData.id ?? 'unidentified'}:${patched}:${deleted}`
+    if ((patched || deleted) && !reportedCorruptWorkflows.has(corruptionKey)) {
+      reportedCorruptWorkflows.add(corruptionKey)
       reportError(new Error('Workflow loaded with corrupt links'), {
         errorType: 'workflow_link_corruption',
         level: 'warning',
-        tags: { patched, deleted, unrepaired: hasBadLinks, silent },
         context: {
+          patched,
+          deleted,
+          unrepaired: hasBadLinks,
           logSample: logs.slice(0, LOG_SAMPLE_LIMIT),
           logCount: logs.length
         }

--- a/src/platform/workflow/validation/composables/useWorkflowValidation.ts
+++ b/src/platform/workflow/validation/composables/useWorkflowValidation.ts
@@ -1,51 +1,29 @@
 import type { ISerialisedGraph } from '@/lib/litegraph/src/types/serialisation'
 import { reportError } from '@/platform/telemetry/reportError'
+import { createOnceReporter } from '@/platform/telemetry/reportOnce'
 import { useToastStore } from '@/platform/updates/common/toastStore'
 import type { ComfyWorkflowJSON } from '@/platform/workflow/validation/schemas/workflowSchema'
 import { validateComfyWorkflow } from '@/platform/workflow/validation/schemas/workflowSchema'
 import { toError } from '@/utils/errorUtil'
+import { fnv1aHex } from '@/utils/hashUtil'
 import { fixBadLinks } from '@/utils/linkFixer'
 
 interface ValidationResult {
   graphData: ComfyWorkflowJSON | null
 }
 
-const MAX_REPORTS_PER_KIND = 25
+export const MAX_REPORTS_PER_KIND = 25
 
 /**
- * FNV-1a. The fixer's log lines interpolate node ids, which the schema leaves
- * unconstrained (`zNodeId` accepts any string), so they cannot be forwarded to
- * the sinks or pinned in memory verbatim. Digesting them keeps distinct
- * corruption distinguishable — for dedup, and for grouping in a dashboard —
- * without shipping workflow content anywhere.
- */
-function digest(value: string): string {
-  let hash = 0x811c9dc5
-  for (let i = 0; i < value.length; i++) {
-    hash ^= value.charCodeAt(i)
-    hash = Math.imul(hash, 0x01000193)
-  }
-  return (hash >>> 0).toString(16)
-}
-
-/**
- * Workflow loads re-enter validation on undo/redo, so without these a single
- * corrupt workflow would report once per history step. Keys must describe the
- * corruption itself, not just the workflow: `id` is optional in the schema, and
- * the workflows most likely to be corrupt are the legacy ones that lack it.
+ * Keys must describe the corruption itself, not just the workflow: `id` is
+ * optional in the schema, and the workflows most likely to be corrupt are the
+ * legacy ones that lack it.
  *
  * The two kinds hold separate budgets so that a session full of repairable
  * corruption cannot crowd out the rarer report that the fixer itself broke.
  */
-const reportedCorruption = new Set<string>()
-const reportedFixerFailures = new Set<string>()
-
-function reportOnce(key: string, seen: Set<string>, report: () => void): void {
-  if (seen.has(key)) return
-  if (seen.size >= MAX_REPORTS_PER_KIND) return
-  seen.add(key)
-  report()
-}
+const reportCorruptionOnce = createOnceReporter(MAX_REPORTS_PER_KIND)
+const reportFixerFailureOnce = createOnceReporter(MAX_REPORTS_PER_KIND)
 
 export function useWorkflowValidation() {
   const toastStore = useToastStore()
@@ -70,12 +48,15 @@ export function useWorkflowValidation() {
 
     const { patched, deleted, hasBadLinks } = linkValidation
     const workflowId = graphData.id ?? 'unidentified'
-    const corruptionDigest = digest(logs.join('\n'))
+    // The fixer's log lines interpolate node ids, which the schema leaves
+    // unconstrained (`zNodeId` accepts any string), so they must not reach the
+    // sinks or be pinned in memory verbatim. The digest keeps distinct
+    // corruption distinguishable without shipping workflow content anywhere.
+    const corruptionDigest = fnv1aHex(logs.join('\n'))
 
     if (patched || deleted) {
-      reportOnce(
+      reportCorruptionOnce(
         [workflowId, patched, deleted, corruptionDigest].join('|'),
-        reportedCorruption,
         () => {
           reportError(new Error('Workflow loaded with corrupt links'), {
             errorType: 'workflow_link_corruption',
@@ -148,7 +129,7 @@ export function useWorkflowValidation() {
         console.error(err)
         const workflowId = graphData.id ?? 'unidentified'
         const cause = toError(err).message
-        reportOnce(`${workflowId}|${cause}`, reportedFixerFailures, () => {
+        reportFixerFailureOnce(`${workflowId}|${cause}`, () => {
           reportError(err, {
             errorType: 'workflow_link_fixer_failure',
             context: { workflowId }

--- a/src/platform/workflow/validation/composables/useWorkflowValidation.ts
+++ b/src/platform/workflow/validation/composables/useWorkflowValidation.ts
@@ -3,6 +3,7 @@ import { reportError } from '@/platform/telemetry/reportError'
 import { useToastStore } from '@/platform/updates/common/toastStore'
 import type { ComfyWorkflowJSON } from '@/platform/workflow/validation/schemas/workflowSchema'
 import { validateComfyWorkflow } from '@/platform/workflow/validation/schemas/workflowSchema'
+import { getErrorMessage } from '@/utils/errorUtil'
 import { fixBadLinks } from '@/utils/linkFixer'
 
 interface ValidationResult {
@@ -13,9 +14,17 @@ const LOG_SAMPLE_LIMIT = 20
 
 /**
  * Workflow loads re-enter validation on undo/redo, so without this a single
- * corrupt workflow would report once per history step.
+ * corrupt workflow would report once per history step. Keys must describe the
+ * corruption itself, not just the workflow: `id` is optional in the schema, and
+ * the workflows most likely to be corrupt are the legacy ones that lack it.
  */
-const reportedCorruptWorkflows = new Set<string>()
+const reportedCorruption = new Set<string>()
+
+function reportOnce(key: string, report: () => void): void {
+  if (reportedCorruption.has(key)) return
+  reportedCorruption.add(key)
+  report()
+}
 
 export function useWorkflowValidation() {
   const toastStore = useToastStore()
@@ -39,19 +48,23 @@ export function useWorkflowValidation() {
     })
 
     const { patched, deleted, hasBadLinks } = linkValidation
-    const corruptionKey = `${graphData.id ?? 'unidentified'}:${patched}:${deleted}`
-    if ((patched || deleted) && !reportedCorruptWorkflows.has(corruptionKey)) {
-      reportedCorruptWorkflows.add(corruptionKey)
-      reportError(new Error('Workflow loaded with corrupt links'), {
-        errorType: 'workflow_link_corruption',
-        level: 'warning',
-        context: {
-          patched,
-          deleted,
-          unrepaired: hasBadLinks,
-          logSample: logs.slice(0, LOG_SAMPLE_LIMIT),
-          logCount: logs.length
-        }
+    const workflowId = graphData.id ?? 'unidentified'
+    const logSample = logs.slice(0, LOG_SAMPLE_LIMIT)
+
+    if (patched || deleted) {
+      reportOnce([workflowId, patched, deleted, ...logSample].join('|'), () => {
+        reportError(new Error('Workflow loaded with corrupt links'), {
+          errorType: 'workflow_link_corruption',
+          level: 'warning',
+          tags: { unrepaired: hasBadLinks },
+          context: {
+            workflowId,
+            patched,
+            deleted,
+            logSample,
+            logCount: logs.length
+          }
+        })
       })
     }
 
@@ -108,7 +121,16 @@ export function useWorkflowValidation() {
       } catch (err) {
         // Link fixer itself is throwing an error
         console.error(err)
-        reportError(err, { errorType: 'workflow_link_fixer_failure' })
+        const workflowId = graphData.id ?? 'unidentified'
+        reportOnce(
+          `fixer-failure|${workflowId}|${getErrorMessage(err)}`,
+          () => {
+            reportError(err, {
+              errorType: 'workflow_link_fixer_failure',
+              context: { workflowId }
+            })
+          }
+        )
       }
     }
 

--- a/src/platform/workflow/validation/composables/useWorkflowValidation.ts
+++ b/src/platform/workflow/validation/composables/useWorkflowValidation.ts
@@ -36,7 +36,9 @@ export function useWorkflowValidation() {
 
     // Collect all logs in an array
     const logs: string[] = []
-    // Then validate and fix links if schema validation passed
+    // Then validate and fix links if schema validation passed. The fixer keeps
+    // logging even when validation is silenced, because the report below is
+    // derived from these lines; the toasts are what `silent` suppresses.
     const linkValidation = fixBadLinks(graphData as ISerialisedGraph, {
       fix: true,
       logger: {

--- a/src/platform/workflow/validation/composables/useWorkflowValidation.ts
+++ b/src/platform/workflow/validation/composables/useWorkflowValidation.ts
@@ -51,9 +51,9 @@ export function useWorkflowValidation() {
     const { patched, deleted, hasBadLinks } = linkValidation
     const workflowId = graphData.id ?? 'unidentified'
     // The fixer's log lines interpolate node ids, which the schema leaves
-    // unconstrained (`zNodeId` accepts any string), so they must not reach the
-    // sinks or be pinned in memory verbatim. The digest keeps distinct
-    // corruption distinguishable without shipping workflow content anywhere.
+    // unconstrained (`zNodeId` accepts any string), so the text itself must not
+    // reach the sinks or be pinned in memory. The digest distinguishes one
+    // corruption from another — it is a key, not an anonymiser.
     const corruptionDigest = fnv1aHex(logs.join('\n'))
 
     if (patched || deleted) {

--- a/src/platform/workflow/validation/composables/useWorkflowValidation.ts
+++ b/src/platform/workflow/validation/composables/useWorkflowValidation.ts
@@ -1,4 +1,5 @@
 import type { ISerialisedGraph } from '@/lib/litegraph/src/types/serialisation'
+import { reportError } from '@/platform/telemetry/reportError'
 import { useToastStore } from '@/platform/updates/common/toastStore'
 import type { ComfyWorkflowJSON } from '@/platform/workflow/validation/schemas/workflowSchema'
 import { validateComfyWorkflow } from '@/platform/workflow/validation/schemas/workflowSchema'
@@ -7,6 +8,8 @@ import { fixBadLinks } from '@/utils/linkFixer'
 interface ValidationResult {
   graphData: ComfyWorkflowJSON | null
 }
+
+const LOG_SAMPLE_LIMIT = 20
 
 export function useWorkflowValidation() {
   const toastStore = useToastStore()
@@ -29,6 +32,19 @@ export function useWorkflowValidation() {
         }
       }
     })
+
+    const { patched, deleted, hasBadLinks } = linkValidation
+    if (patched || deleted || hasBadLinks) {
+      reportError(new Error('Workflow loaded with corrupt links'), {
+        errorType: 'workflow_link_corruption',
+        level: 'warning',
+        tags: { patched, deleted, unrepaired: hasBadLinks, silent },
+        context: {
+          logSample: logs.slice(0, LOG_SAMPLE_LIMIT),
+          logCount: logs.length
+        }
+      })
+    }
 
     if (!silent && logs.length > 0) {
       toastStore.add({
@@ -83,6 +99,7 @@ export function useWorkflowValidation() {
       } catch (err) {
         // Link fixer itself is throwing an error
         console.error(err)
+        reportError(err, { errorType: 'workflow_link_fixer_failure' })
       }
     }
 

--- a/src/platform/workflow/validation/composables/useWorkflowValidation.ts
+++ b/src/platform/workflow/validation/composables/useWorkflowValidation.ts
@@ -130,6 +130,8 @@ export function useWorkflowValidation() {
         // Link fixer itself is throwing an error
         console.error(err)
         const workflowId = graphData.id ?? 'unidentified'
+        // Unlike the log above, this message reaches the sinks verbatim, so
+        // throw sites in the fixer must keep interpolating nothing.
         const cause = toError(err).message
         reportFixerFailureOnce(`${workflowId}|${cause}`, () => {
           reportError(err, {

--- a/src/utils/hashUtil.test.ts
+++ b/src/utils/hashUtil.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+
+import { fnv1a, fnv1aHex } from './hashUtil'
+
+describe('fnv1a', () => {
+  it('returns consistent hash for same input', () => {
+    const hash1 = fnv1a('workflows/test.json')
+    const hash2 = fnv1a('workflows/test.json')
+    expect(hash1).toBe(hash2)
+  })
+
+  it('returns different hashes for different inputs', () => {
+    const hash1 = fnv1a('workflows/a.json')
+    const hash2 = fnv1a('workflows/b.json')
+    expect(hash1).not.toBe(hash2)
+  })
+
+  it('returns unsigned 32-bit integer', () => {
+    const hash = fnv1a('test')
+    expect(hash).toBeGreaterThanOrEqual(0)
+    expect(hash).toBeLessThanOrEqual(0xffffffff)
+  })
+
+  it('handles empty string', () => {
+    const hash = fnv1a('')
+    expect(hash).toBe(2166136261)
+  })
+
+  it('handles unicode characters', () => {
+    const hash = fnv1a('workflows/工作流程.json')
+    expect(hash).toBeGreaterThanOrEqual(0)
+    expect(hash).toBeLessThanOrEqual(0xffffffff)
+  })
+
+  it('handles special characters', () => {
+    const hash = fnv1a('workflows/My Workflow (Copy 2).json')
+    expect(hash).toBeGreaterThanOrEqual(0)
+  })
+})
+
+describe('fnv1aHex', () => {
+  it('returns 8-character hex string', () => {
+    expect(fnv1aHex('workflows/test.json')).toMatch(/^[0-9a-f]{8}$/)
+  })
+
+  it('pads hashes below 0x10000000 with leading zeros', () => {
+    expect(fnv1a('pad-300')).toBeLessThan(0x10000000)
+    expect(fnv1aHex('pad-300')).toBe('022c1972')
+  })
+
+  it('produces different digests for similar inputs', () => {
+    expect(fnv1aHex('workflows/Untitled.json')).not.toBe(
+      fnv1aHex('workflows/Untitled (2).json')
+    )
+  })
+})

--- a/src/utils/hashUtil.ts
+++ b/src/utils/hashUtil.ts
@@ -1,0 +1,30 @@
+/**
+ * FNV-1a hash function for creating short, deterministic keys from strings.
+ *
+ * FNV-1a is chosen for its simplicity, speed, and good distribution properties.
+ * It is not cryptographic: use it for keying and grouping, never for secrets.
+ *
+ * @param str - The string to hash
+ * @returns A 32-bit unsigned integer hash
+ */
+export function fnv1a(str: string): number {
+  let hash = 2166136261
+  for (let i = 0; i < str.length; i++) {
+    hash ^= str.charCodeAt(i)
+    hash = Math.imul(hash, 16777619)
+  }
+  return hash >>> 0
+}
+
+/**
+ * Creates an 8-character hex digest of a string using FNV-1a.
+ *
+ * @param str - The string to hash
+ * @returns An 8-character hex string (e.g., "a1b2c3d4")
+ *
+ * @example
+ * fnv1aHex("workflows/Untitled.json") // "1a2b3c4d"
+ */
+export function fnv1aHex(str: string): string {
+  return fnv1a(str).toString(16).padStart(8, '0')
+}

--- a/src/utils/hashUtil.ts
+++ b/src/utils/hashUtil.ts
@@ -19,6 +19,9 @@ export function fnv1a(str: string): number {
 /**
  * Creates an 8-character hex digest of a string using FNV-1a.
  *
+ * Callers persist this output — see `hashPath`, which keys unsaved workflow
+ * drafts by it — so the digest of a given string must not change.
+ *
  * @param str - The string to hash
  * @returns An 8-character hex string (e.g., "a1b2c3d4")
  *

--- a/src/utils/hashUtil.ts
+++ b/src/utils/hashUtil.ts
@@ -23,10 +23,10 @@ export function fnv1a(str: string): number {
  * drafts by it — so the digest of a given string must not change.
  *
  * @param str - The string to hash
- * @returns An 8-character hex string (e.g., "a1b2c3d4")
+ * @returns An 8-character hex string
  *
  * @example
- * fnv1aHex("workflows/Untitled.json") // "1a2b3c4d"
+ * fnv1aHex("workflows/Untitled.json") // "325d5d45"
  */
 export function fnv1aHex(str: string): string {
   return fnv1a(str).toString(16).padStart(8, '0')


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

## Summary

`fixBadLinks` already computes a precise verdict on every validated workflow load — how many node connections it patched, how many links it deleted, whether corruption survived the repair. The only consumer turned that into a toast, or into nothing at all under `silent: true`, so none of it ever left the browser.

## Changes

- **What**: send the verdict through `reportError` as `workflow_link_corruption` (`level: warning`), and report the link fixer's own throw as `workflow_link_fixer_failure` instead of only `console.error`-ing it.
- **Deduplicated**, because `changeTracker.updateState` re-enters `loadGraphData` on every undo/redo, so an undeduped report would fire once per history step. The key is the corruption, not the workflow: `id` is optional in the schema, and the workflows most likely to be corrupt — legacy, template-derived, PNG-embedded — are exactly the ones without one. 77 of the 681 shipped templates carry no `id`.
- **Digested, not shipped.** The fixer's log lines interpolate node ids, and `zNodeId` is `z.union([z.number().int(), z.string()])` with no length or pattern bound. Forwarding them verbatim would put unconstrained workflow content into Sentry `extra` and Datadog context — `SentryTelemetryProvider.trackExecutionError` already draws this line, sending `nodeType` and deliberately not `nodeId`. An FNV-1a digest keeps distinct corruption distinguishable for dedup and grouping without shipping any of it.
- **Bounded**: 25 reports per session per kind, with corruption and fixer-failures on separate budgets so repairable noise cannot crowd out the rarer report that the fixer itself broke.
- `silent` is no longer forwarded to `fixBadLinks`. It only ever gated the injected array-pusher, so the report was empty exactly when no toast was shown either; the toast stays independently gated on `!silent`, which a test now pins.

## Review Focus

**The denominator is opt-in users only.** `Comfy.Validation.Workflows` is `defaultValue: false` (`coreSettings.ts:36`) and gates the sole caller at `app.ts:1279`. Nothing is detected when it is off, so nothing is discarded — this change is a strict improvement wherever detection runs, but a dashboard built on `workflow_link_corruption` measures opted-in users, not the corruption rate in the wild. Worth recording next to any chart. If that default ever flips, revisit the 25-report cap.

**`unrepaired` will almost always be false.** I probed nine distinct corruption shapes (missing origin, missing target, both missing, absent input slot, absent output slot, two and three links contending for one slot, duplicate link ids, input pointing at an unknown link id) and `fixBadLinks` converged on every one, so `hasBadLinks` was false in all nine. That is why there is no test for the `true` case — I could not construct it. The upside: if that tag ever goes true in production it is high-signal, not noise.

Three refinements were identified in review and deliberately deferred rather than churn further:

1. Move `corruptionDigest` from `context` to `tags` so Sentry indexes it. It is already queryable in Datadog, which flattens both.
2. Reserve budget for `unrepaired: true` so 25 distinct repairable digests in one tab cannot starve the severe case.
3. Hoist `logs.join('\n')` and compute the digest under the `patched || deleted` guard — currently joined twice on the corrupt path.

## Verification

- `pnpm typecheck`, `pnpm lint`, `pnpm knip`, `pnpm format` clean; 743 tests pass across `src/platform/workflow`, `src/utils/linkFixer.test.ts`, `src/scripts/app.test.ts`.
- Each new test was mutation-checked against the code it guards: reverting the dedup key to counts-only fails the id-less regression test, removing the report gate fails three, and dropping the digest fails two.
- Captured the actual payload a corrupt workflow produces end to end: `patched: 1, deleted: 1, unrepaired: false`, with the fixer's own trace (`Link 1 is funky... target 2 does not exist, but origin 1 does.` → `Deleting link #1.`) — the signal that previously reached a toast and then nothing.
