### PR TITLE
fix: add AbortController timeout to fetchApi to prevent connection pool exhaustion

### DIFF
--- a/src/composables/node/useNodeImageUpload.test.ts
+++ b/src/composables/node/useNodeImageUpload.test.ts
@@ -132,6 +132,10 @@ describe('useNodeImageUpload', () => {
 
     await capturedDragOnDrop([createFile()])
     expect(onUploadComplete).toHaveBeenCalledWith(['test.png'])
+    expect(mockFetchApi).toHaveBeenCalledWith(
+      '/upload/image',
+      expect.objectContaining({ timeoutMs: 120_000 })
+    )
   })
 
   it('includes subfolder in returned path', async () => {

--- a/src/composables/node/useNodeImageUpload.ts
+++ b/src/composables/node/useNodeImageUpload.ts
@@ -32,7 +32,7 @@ const uploadFile = async (
   const resp = await api.fetchApi('/upload/image', {
     method: 'POST',
     body,
-    signal: AbortSignal.timeout(UPLOAD_TIMEOUT_MS)
+    timeoutMs: UPLOAD_TIMEOUT_MS
   })
 
   if (resp.status !== 200) {

--- a/src/platform/telemetry/TelemetryRegistry.ts
+++ b/src/platform/telemetry/TelemetryRegistry.ts
@@ -48,6 +48,7 @@ import type {
   TabCountMetadata,
   TelemetryDispatcher,
   TelemetryProvider,
+  FetchTimeoutMetadata,
   TemplateFilterMetadata,
   TemplateLibraryClosedMetadata,
   TemplateLibraryMetadata,
@@ -395,5 +396,9 @@ export class TelemetryRegistry implements TelemetryDispatcher {
 
   trackPageView(pageName: string, properties?: PageViewMetadata): void {
     this.dispatch((provider) => provider.trackPageView?.(pageName, properties))
+  }
+
+  trackFetchTimeout(metadata: FetchTimeoutMetadata): void {
+    this.dispatch((provider) => provider.trackFetchTimeout?.(metadata))
   }
 }

--- a/src/platform/telemetry/providers/cloud/DatadogRumTelemetryProvider.test.ts
+++ b/src/platform/telemetry/providers/cloud/DatadogRumTelemetryProvider.test.ts
@@ -19,6 +19,23 @@ const workflowExecutionIntent = {
 } as const
 
 describe('DatadogRumTelemetryProvider', () => {
+  it('records fetch timeouts as RUM actions', () => {
+    new DatadogRumTelemetryProvider().trackFetchTimeout({
+      route: '/userdata/:resource',
+      method: 'GET',
+      timeout_ms: 60_000
+    })
+
+    expect(addAction).toHaveBeenCalledExactlyOnceWith(
+      TelemetryEvents.FETCH_TIMEOUT,
+      {
+        route: '/userdata/:resource',
+        method: 'GET',
+        timeout_ms: 60_000
+      }
+    )
+  })
+
   it('records terminal unified auth retry outcomes without request data', () => {
     new DatadogRumTelemetryProvider().trackUnifiedAuthRetry({
       transport: 'axios',

--- a/src/platform/telemetry/providers/cloud/DatadogRumTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/DatadogRumTelemetryProvider.ts
@@ -4,6 +4,7 @@ import { datadogRum } from '@datadog/browser-rum'
 import type {
   BillingTelemetryEvent,
   ExecutionOutcomeMetadata,
+  FetchTimeoutMetadata,
   ImageLoadFailureMetadata,
   TelemetryProvider,
   UnifiedAuthRefreshMetadata,
@@ -16,6 +17,10 @@ import {
 } from '../../types'
 
 export class DatadogRumTelemetryProvider implements TelemetryProvider {
+  trackFetchTimeout(metadata: FetchTimeoutMetadata): void {
+    datadogRum.addAction(TelemetryEvents.FETCH_TIMEOUT, metadata)
+  }
+
   trackUnifiedAuthRetry(metadata: UnifiedAuthRetryMetadata): void {
     datadogRum.addAction(
       metadata.outcome === 'succeeded'

--- a/src/platform/telemetry/providers/cloud/MixpanelTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/MixpanelTelemetryProvider.ts
@@ -9,6 +9,7 @@ import type {
   CreditTopupMetadata,
   DefaultViewSetMetadata,
   EnterLinearMetadata,
+  FetchTimeoutMetadata,
   HelpCenterClosedMetadata,
   HelpCenterOpenedMetadata,
   HelpResourceClickedMetadata,
@@ -402,5 +403,9 @@ export class MixpanelTelemetryProvider implements TelemetryProvider {
 
   trackUiButtonClicked(metadata: UiButtonClickMetadata): void {
     this.trackEvent(TelemetryEvents.UI_BUTTON_CLICKED, metadata)
+  }
+
+  trackFetchTimeout(metadata: FetchTimeoutMetadata): void {
+    this.trackEvent(TelemetryEvents.FETCH_TIMEOUT, metadata)
   }
 }

--- a/src/platform/telemetry/types.ts
+++ b/src/platform/telemetry/types.ts
@@ -954,6 +954,13 @@ export function getBillingTelemetryEventPayload(event: BillingTelemetryEvent) {
   }
 }
 
+export interface FetchTimeoutMetadata {
+  route: string
+  method: string
+  duration_ms: number
+  timeout_ms: number
+}
+
 /**
  * Telemetry provider interface for individual providers.
  * All methods are optional - providers only implement what they need.
@@ -1089,6 +1096,9 @@ export interface TelemetryProvider {
 
   // Page view tracking
   trackPageView?(pageName: string, properties?: PageViewMetadata): void
+
+  // Network error events
+  trackFetchTimeout?(metadata: FetchTimeoutMetadata): void
 }
 
 /**
@@ -1247,7 +1257,10 @@ export const TelemetryEvents = {
   NAMED_VALUES_SHADOW_DIFF_SUMMARY: 'app:named_values_shadow_diff_summary',
 
   // Page View
-  PAGE_VIEW: 'app:page_view'
+  PAGE_VIEW: 'app:page_view',
+
+  // Network
+  FETCH_TIMEOUT: 'app:fetch_timeout'
 } as const
 
 export type TelemetryEventName =
@@ -1340,3 +1353,4 @@ export type TelemetryEventProperties =
   | SubscriptionSuccessMetadata
   | WorkspaceInviteFailedMetadata
   | BillingTelemetryEvent
+  | FetchTimeoutMetadata

--- a/src/platform/telemetry/types.ts
+++ b/src/platform/telemetry/types.ts
@@ -957,7 +957,6 @@ export function getBillingTelemetryEventPayload(event: BillingTelemetryEvent) {
 export interface FetchTimeoutMetadata {
   route: string
   method: string
-  duration_ms: number
   timeout_ms: number
 }
 

--- a/src/scripts/api.fetchApi.test.ts
+++ b/src/scripts/api.fetchApi.test.ts
@@ -243,6 +243,23 @@ describe('api.fetchApi', () => {
       })
     })
 
+    it('normalizes the video metadata endpoint', async () => {
+      mockPendingFetch()
+
+      const request = api.fetchApi('/video_metadata?filename=private.mp4')
+      const rejection = expect(request).rejects.toMatchObject({
+        name: 'TimeoutError'
+      })
+      await vi.advanceTimersByTimeAsync(60_000)
+
+      await rejection
+      expect(trackFetchTimeout).toHaveBeenCalledExactlyOnceWith({
+        route: '/video_metadata',
+        method: 'GET',
+        timeout_ms: 60_000
+      })
+    })
+
     it('uses a caller-owned 120 second timeout', async () => {
       mockPendingFetch()
 

--- a/src/scripts/api.fetchApi.test.ts
+++ b/src/scripts/api.fetchApi.test.ts
@@ -243,30 +243,45 @@ describe('api.fetchApi', () => {
       })
     })
 
-    it('preserves a caller-owned 120 second timeout', async () => {
+    it('uses a caller-owned 120 second timeout', async () => {
       mockPendingFetch()
-      const controller = new AbortController()
-      setTimeout(
-        () =>
-          controller.abort(new DOMException('Upload timeout', 'TimeoutError')),
-        120_000
-      )
 
       const request = api.fetchApi('/upload/image', {
-        signal: controller.signal
+        timeoutMs: 120_000
       })
       const rejection = expect(request).rejects.toMatchObject({
         name: 'TimeoutError',
-        message: 'Upload timeout'
+        message: 'Fetch timeout'
       })
       await vi.advanceTimersByTimeAsync(60_000)
 
-      expect(controller.signal.aborted).toBe(false)
       expect(trackFetchTimeout).not.toHaveBeenCalled()
 
       await vi.advanceTimersByTimeAsync(60_000)
       await rejection
-      expect(trackFetchTimeout).not.toHaveBeenCalled()
+      expect(trackFetchTimeout).toHaveBeenCalledExactlyOnceWith({
+        route: '/upload/:resource',
+        method: 'GET',
+        timeout_ms: 120_000
+      })
+    })
+
+    it('applies the default timeout alongside caller cancellation', async () => {
+      mockPendingFetch()
+      const controller = new AbortController()
+
+      const request = api.fetchApi('/assets', { signal: controller.signal })
+      const rejection = expect(request).rejects.toMatchObject({
+        name: 'TimeoutError'
+      })
+      await vi.advanceTimersByTimeAsync(60_000)
+
+      await rejection
+      expect(trackFetchTimeout).toHaveBeenCalledExactlyOnceWith({
+        route: '/assets',
+        method: 'GET',
+        timeout_ms: 60_000
+      })
     })
 
     it('preserves caller cancellation without timeout telemetry', async () => {

--- a/src/scripts/api.fetchApi.test.ts
+++ b/src/scripts/api.fetchApi.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const { addBreadcrumb, trackFetchTimeout } = vi.hoisted(() => ({
   addBreadcrumb: vi.fn(),
@@ -197,10 +197,6 @@ describe('api.fetchApi', () => {
   describe('response header timeout', () => {
     beforeEach(() => {
       vi.useFakeTimers()
-    })
-
-    afterEach(() => {
-      vi.useRealTimers()
     })
 
     it('aborts with a TimeoutError and forwards normalized diagnostics', async () => {

--- a/src/scripts/api.fetchApi.test.ts
+++ b/src/scripts/api.fetchApi.test.ts
@@ -1,6 +1,35 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { addBreadcrumb, trackFetchTimeout } = vi.hoisted(() => ({
+  addBreadcrumb: vi.fn(),
+  trackFetchTimeout: vi.fn()
+}))
+
+vi.mock('@sentry/vue', () => ({ addBreadcrumb }))
+
+vi.mock('@/platform/telemetry', () => ({
+  useTelemetry: () => ({ trackFetchTimeout })
+}))
 
 import { api } from '@/scripts/api'
+
+function mockPendingFetch() {
+  return vi.mocked(global.fetch).mockImplementation((_input, init) => {
+    return new Promise<Response>((_resolve, reject) => {
+      const signal = init?.signal
+      if (!signal) return
+
+      if (signal.aborted) {
+        reject(signal.reason)
+        return
+      }
+
+      signal.addEventListener('abort', () => reject(signal.reason), {
+        once: true
+      })
+    })
+  })
+}
 
 describe('api.fetchApi', () => {
   beforeEach(() => {
@@ -162,6 +191,114 @@ describe('api.fetchApi', () => {
         expect.stringContaining('/api/test/route'),
         expect.any(Object)
       )
+    })
+  })
+
+  describe('response header timeout', () => {
+    beforeEach(() => {
+      vi.useFakeTimers()
+    })
+
+    afterEach(() => {
+      vi.useRealTimers()
+    })
+
+    it('aborts with a TimeoutError and forwards normalized diagnostics', async () => {
+      mockPendingFetch()
+
+      const request = api.fetchApi(
+        '/userdata/private%20workflow.json?directory=secret',
+        { method: 'post' }
+      )
+      const rejection = expect(request).rejects.toMatchObject({
+        name: 'TimeoutError',
+        message: 'Fetch timeout'
+      })
+      await vi.advanceTimersByTimeAsync(60_000)
+
+      await rejection
+      expect(trackFetchTimeout).toHaveBeenCalledExactlyOnceWith({
+        route: '/userdata/:resource',
+        method: 'POST',
+        timeout_ms: 60_000
+      })
+      expect(addBreadcrumb).toHaveBeenCalledExactlyOnceWith({
+        category: 'fetch',
+        message: 'Timeout on POST /userdata/:resource',
+        level: 'warning',
+        data: { timeout_ms: 60_000 }
+      })
+    })
+
+    it('uses a bounded fallback for unknown routes', async () => {
+      mockPendingFetch()
+
+      const request = api.fetchApi('/private-name/secret-id')
+      const rejection = expect(request).rejects.toMatchObject({
+        name: 'TimeoutError'
+      })
+      await vi.advanceTimersByTimeAsync(60_000)
+
+      await rejection
+      expect(trackFetchTimeout).toHaveBeenCalledExactlyOnceWith({
+        route: '/other',
+        method: 'GET',
+        timeout_ms: 60_000
+      })
+    })
+
+    it('preserves a caller-owned 120 second timeout', async () => {
+      mockPendingFetch()
+      const controller = new AbortController()
+      setTimeout(
+        () =>
+          controller.abort(new DOMException('Upload timeout', 'TimeoutError')),
+        120_000
+      )
+
+      const request = api.fetchApi('/upload/image', {
+        signal: controller.signal
+      })
+      const rejection = expect(request).rejects.toMatchObject({
+        name: 'TimeoutError',
+        message: 'Upload timeout'
+      })
+      await vi.advanceTimersByTimeAsync(60_000)
+
+      expect(controller.signal.aborted).toBe(false)
+      expect(trackFetchTimeout).not.toHaveBeenCalled()
+
+      await vi.advanceTimersByTimeAsync(60_000)
+      await rejection
+      expect(trackFetchTimeout).not.toHaveBeenCalled()
+    })
+
+    it('preserves caller cancellation without timeout telemetry', async () => {
+      mockPendingFetch()
+      const controller = new AbortController()
+
+      const request = api.fetchApi('/assets', { signal: controller.signal })
+      controller.abort()
+
+      await expect(request).rejects.toMatchObject({ name: 'AbortError' })
+      expect(trackFetchTimeout).not.toHaveBeenCalled()
+      expect(addBreadcrumb).not.toHaveBeenCalled()
+    })
+
+    it('clears the timeout when fetch resolves', async () => {
+      vi.mocked(global.fetch).mockResolvedValue(new Response())
+
+      await api.fetchApi('/test')
+
+      expect(vi.getTimerCount()).toBe(0)
+    })
+
+    it('clears the timeout when fetch rejects', async () => {
+      vi.mocked(global.fetch).mockRejectedValue(new Error('Network error'))
+
+      await expect(api.fetchApi('/test')).rejects.toThrow('Network error')
+
+      expect(vi.getTimerCount()).toBe(0)
     })
   })
 })

--- a/src/scripts/api.ts
+++ b/src/scripts/api.ts
@@ -168,6 +168,7 @@ const FETCH_ROUTE_GROUPS = new Set([
   'user',
   'userdata',
   'users',
+  'video_metadata',
   'view',
   'view_metadata',
   'workflow_templates',

--- a/src/scripts/api.ts
+++ b/src/scripts/api.ts
@@ -538,7 +538,7 @@ export class ComfyApi extends EventTarget {
         data: { duration_ms, timeout_ms: FETCH_TIMEOUT_MS }
       })
 
-      useTelemetry()?.trackFetchTimeout?.({
+      useTelemetry()?.trackFetchTimeout({
         route,
         method,
         duration_ms,

--- a/src/scripts/api.ts
+++ b/src/scripts/api.ts
@@ -569,10 +569,8 @@ export class ComfyApi extends EventTarget {
     addHeaderEntry(headers, 'Comfy-User', this.user)
 
     const controller = options?.signal ? null : new AbortController()
-    const startTime = Date.now()
     const timeoutId = controller
       ? setTimeout(() => {
-          const duration_ms = Date.now() - startTime
           const method = (options?.method ?? 'GET').toUpperCase()
           const routeTemplate = getFetchRouteTemplate(route)
 
@@ -580,16 +578,12 @@ export class ComfyApi extends EventTarget {
             category: 'fetch',
             message: `Timeout on ${method} ${routeTemplate}`,
             level: 'warning',
-            data: {
-              duration_ms,
-              timeout_ms: FETCH_RESPONSE_HEADERS_TIMEOUT_MS
-            }
+            data: { timeout_ms: FETCH_RESPONSE_HEADERS_TIMEOUT_MS }
           })
 
           useTelemetry()?.trackFetchTimeout({
             route: routeTemplate,
             method,
-            duration_ms,
             timeout_ms: FETCH_RESPONSE_HEADERS_TIMEOUT_MS
           })
 

--- a/src/scripts/api.ts
+++ b/src/scripts/api.ts
@@ -134,6 +134,50 @@ interface QueuePromptRequestBody {
 }
 
 const FETCH_RESPONSE_HEADERS_TIMEOUT_MS = 60_000
+const FETCH_ROUTE_GROUPS = new Set([
+  'assets',
+  'embeddings',
+  'experiment',
+  'extensions',
+  'features',
+  'files',
+  'folder_paths',
+  'free',
+  'global_subgraphs',
+  'history',
+  'hub',
+  'internal',
+  'interrupt',
+  'jobs',
+  'logs',
+  'models',
+  'node_replacements',
+  'object_info',
+  'prompt',
+  'providers',
+  'queue',
+  'secrets',
+  'settings',
+  'system_stats',
+  'upload',
+  'user',
+  'userdata',
+  'users',
+  'view',
+  'view_metadata',
+  'workflow_templates',
+  'workflows',
+  'workspace'
+])
+
+function getFetchRouteTemplate(route: string): string {
+  const segments = (route.split(/[?#]/)[0] ?? '').split('/').filter(Boolean)
+  const routeSegments = segments[0] === 'api' ? segments.slice(1) : segments
+  const [routeGroup, ...resources] = routeSegments
+
+  if (!routeGroup || !FETCH_ROUTE_GROUPS.has(routeGroup)) return '/other'
+  return `/${routeGroup}${resources.length ? '/:resource' : ''}`
+}
 
 /**
  * Options for queuePrompt method
@@ -530,10 +574,11 @@ export class ComfyApi extends EventTarget {
       ? setTimeout(() => {
           const duration_ms = Date.now() - startTime
           const method = (options?.method ?? 'GET').toUpperCase()
+          const routeTemplate = getFetchRouteTemplate(route)
 
           Sentry.addBreadcrumb({
             category: 'fetch',
-            message: `Timeout on ${method} ${route}`,
+            message: `Timeout on ${method} ${routeTemplate}`,
             level: 'warning',
             data: {
               duration_ms,
@@ -542,7 +587,7 @@ export class ComfyApi extends EventTarget {
           })
 
           useTelemetry()?.trackFetchTimeout({
-            route,
+            route: routeTemplate,
             method,
             duration_ms,
             timeout_ms: FETCH_RESPONSE_HEADERS_TIMEOUT_MS

--- a/src/scripts/api.ts
+++ b/src/scripts/api.ts
@@ -134,6 +134,11 @@ interface QueuePromptRequestBody {
 }
 
 const FETCH_RESPONSE_HEADERS_TIMEOUT_MS = 60_000
+
+interface FetchApiOptions extends RequestInit {
+  timeoutMs?: number | null
+}
+
 const FETCH_ROUTE_GROUPS = new Set([
   'assets',
   'embeddings',
@@ -538,8 +543,10 @@ export class ComfyApi extends EventTarget {
     }
   }
 
-  async fetchApi(route: string, options?: RequestInit) {
-    const headers: HeadersInit = options?.headers ?? {}
+  async fetchApi(route: string, options?: FetchApiOptions) {
+    const { timeoutMs = FETCH_RESPONSE_HEADERS_TIMEOUT_MS, ...requestOptions } =
+      options ?? {}
+    const headers: HeadersInit = requestOptions.headers ?? {}
     let unifiedRetryOn401 = false
 
     if (isCloud) {
@@ -568,36 +575,45 @@ export class ComfyApi extends EventTarget {
 
     addHeaderEntry(headers, 'Comfy-User', this.user)
 
-    const controller = options?.signal ? null : new AbortController()
-    const timeoutId = controller
+    const timeout =
+      timeoutMs === null
+        ? null
+        : { controller: new AbortController(), duration: timeoutMs }
+    const timeoutId = timeout
       ? setTimeout(() => {
-          const method = (options?.method ?? 'GET').toUpperCase()
+          const method = (requestOptions.method ?? 'GET').toUpperCase()
           const routeTemplate = getFetchRouteTemplate(route)
 
           Sentry.addBreadcrumb({
             category: 'fetch',
             message: `Timeout on ${method} ${routeTemplate}`,
             level: 'warning',
-            data: { timeout_ms: FETCH_RESPONSE_HEADERS_TIMEOUT_MS }
+            data: { timeout_ms: timeout.duration }
           })
 
           useTelemetry()?.trackFetchTimeout({
             route: routeTemplate,
             method,
-            timeout_ms: FETCH_RESPONSE_HEADERS_TIMEOUT_MS
+            timeout_ms: timeout.duration
           })
 
-          controller.abort(new DOMException('Fetch timeout', 'TimeoutError'))
-        }, FETCH_RESPONSE_HEADERS_TIMEOUT_MS)
+          timeout.controller.abort(
+            new DOMException('Fetch timeout', 'TimeoutError')
+          )
+        }, timeout.duration)
       : undefined
+    const signal =
+      requestOptions.signal && timeout
+        ? AbortSignal.any([requestOptions.signal, timeout.controller.signal])
+        : (requestOptions.signal ?? timeout?.controller.signal)
 
     return fetchWithUnifiedRemint(
       this.apiURL(route),
       {
         cache: 'no-cache',
-        ...options,
+        ...requestOptions,
         headers,
-        signal: options?.signal ?? controller?.signal
+        signal
       },
       unifiedRetryOn401
     ).finally(() => {

--- a/src/scripts/api.ts
+++ b/src/scripts/api.ts
@@ -17,6 +17,8 @@ import type {
   ModelFolderInfo
 } from '@/platform/assets/schemas/assetSchema'
 import { isCloud } from '@/platform/distribution/types'
+import * as Sentry from '@sentry/vue'
+import { useTelemetry } from '@/platform/telemetry'
 import { useToastStore } from '@/platform/updates/common/toastStore'
 import type { ShareableAssetsResponse } from '@/schemas/apiSchema'
 import {
@@ -519,11 +521,42 @@ export class ComfyApi extends EventTarget {
     }
 
     addHeaderEntry(headers, 'Comfy-User', this.user)
+
+    // AbortController timeout prevents connection pool exhaustion after long sessions.
+    // See: https://github.com/Comfy-Org/ComfyUI_frontend/issues/14389
+    const FETCH_TIMEOUT_MS = 60_000
+    const controller = new AbortController()
+    const startTime = Date.now()
+    const timeoutId = setTimeout(() => {
+      const duration_ms = Date.now() - startTime
+      const method = (options?.method ?? 'GET').toUpperCase()
+
+      Sentry.addBreadcrumb({
+        category: 'fetch',
+        message: `Timeout on ${method} ${route}`,
+        level: 'warning',
+        data: { duration_ms, timeout_ms: FETCH_TIMEOUT_MS }
+      })
+
+      useTelemetry()?.trackFetchTimeout?.({
+        route,
+        method,
+        duration_ms,
+        timeout_ms: FETCH_TIMEOUT_MS
+      })
+
+      controller.abort()
+    }, FETCH_TIMEOUT_MS)
+
+    const signal = options?.signal
+      ? AbortSignal.any([options.signal, controller.signal])
+      : controller.signal
+
     return fetchWithUnifiedRemint(
       this.apiURL(route),
-      { cache: 'no-cache', ...options, headers },
+      { cache: 'no-cache', ...options, headers, signal },
       unifiedRetryOn401
-    )
+    ).finally(() => clearTimeout(timeoutId))
   }
 
   /**

--- a/src/scripts/api.ts
+++ b/src/scripts/api.ts
@@ -133,7 +133,7 @@ interface QueuePromptRequestBody {
   number?: number
 }
 
-const FETCH_TIMEOUT_MS = 60_000
+const FETCH_RESPONSE_HEADERS_TIMEOUT_MS = 60_000
 
 /**
  * Options for queuePrompt method
@@ -535,18 +535,21 @@ export class ComfyApi extends EventTarget {
             category: 'fetch',
             message: `Timeout on ${method} ${route}`,
             level: 'warning',
-            data: { duration_ms, timeout_ms: FETCH_TIMEOUT_MS }
+            data: {
+              duration_ms,
+              timeout_ms: FETCH_RESPONSE_HEADERS_TIMEOUT_MS
+            }
           })
 
           useTelemetry()?.trackFetchTimeout({
             route,
             method,
             duration_ms,
-            timeout_ms: FETCH_TIMEOUT_MS
+            timeout_ms: FETCH_RESPONSE_HEADERS_TIMEOUT_MS
           })
 
           controller.abort(new DOMException('Fetch timeout', 'TimeoutError'))
-        }, FETCH_TIMEOUT_MS)
+        }, FETCH_RESPONSE_HEADERS_TIMEOUT_MS)
       : undefined
 
     return fetchWithUnifiedRemint(

--- a/src/scripts/api.ts
+++ b/src/scripts/api.ts
@@ -133,6 +133,8 @@ interface QueuePromptRequestBody {
   number?: number
 }
 
+const FETCH_TIMEOUT_MS = 60_000
+
 /**
  * Options for queuePrompt method
  */
@@ -522,41 +524,43 @@ export class ComfyApi extends EventTarget {
 
     addHeaderEntry(headers, 'Comfy-User', this.user)
 
-    // AbortController timeout prevents connection pool exhaustion after long sessions.
-    // See: https://github.com/Comfy-Org/ComfyUI_frontend/issues/14389
-    const FETCH_TIMEOUT_MS = 60_000
-    const controller = new AbortController()
+    const controller = options?.signal ? null : new AbortController()
     const startTime = Date.now()
-    const timeoutId = setTimeout(() => {
-      const duration_ms = Date.now() - startTime
-      const method = (options?.method ?? 'GET').toUpperCase()
+    const timeoutId = controller
+      ? setTimeout(() => {
+          const duration_ms = Date.now() - startTime
+          const method = (options?.method ?? 'GET').toUpperCase()
 
-      Sentry.addBreadcrumb({
-        category: 'fetch',
-        message: `Timeout on ${method} ${route}`,
-        level: 'warning',
-        data: { duration_ms, timeout_ms: FETCH_TIMEOUT_MS }
-      })
+          Sentry.addBreadcrumb({
+            category: 'fetch',
+            message: `Timeout on ${method} ${route}`,
+            level: 'warning',
+            data: { duration_ms, timeout_ms: FETCH_TIMEOUT_MS }
+          })
 
-      useTelemetry()?.trackFetchTimeout({
-        route,
-        method,
-        duration_ms,
-        timeout_ms: FETCH_TIMEOUT_MS
-      })
+          useTelemetry()?.trackFetchTimeout({
+            route,
+            method,
+            duration_ms,
+            timeout_ms: FETCH_TIMEOUT_MS
+          })
 
-      controller.abort()
-    }, FETCH_TIMEOUT_MS)
-
-    const signal = options?.signal
-      ? AbortSignal.any([options.signal, controller.signal])
-      : controller.signal
+          controller.abort()
+        }, FETCH_TIMEOUT_MS)
+      : undefined
 
     return fetchWithUnifiedRemint(
       this.apiURL(route),
-      { cache: 'no-cache', ...options, headers, signal },
+      {
+        cache: 'no-cache',
+        ...options,
+        headers,
+        signal: options?.signal ?? controller?.signal
+      },
       unifiedRetryOn401
-    ).finally(() => clearTimeout(timeoutId))
+    ).finally(() => {
+      if (timeoutId !== undefined) clearTimeout(timeoutId)
+    })
   }
 
   /**

--- a/src/scripts/api.ts
+++ b/src/scripts/api.ts
@@ -545,7 +545,7 @@ export class ComfyApi extends EventTarget {
             timeout_ms: FETCH_TIMEOUT_MS
           })
 
-          controller.abort()
+          controller.abort(new DOMException('Fetch timeout', 'TimeoutError'))
         }, FETCH_TIMEOUT_MS)
       : undefined
 


### PR DESCRIPTION
## Summary

Without a timeout, a hung fetch occupies one of the browser's ~6 HTTP/1.1 connection slots indefinitely after long sessions, silently blocking all subsequent requests to the same host (including `POST /prompt`). Refreshing fixes it because the tab's connection pool resets.

## Changes

- **What**: `fetchApi()` in `src/scripts/api.ts` now wraps every request in a 60 s `AbortController` timeout. Before aborting, it emits a Sentry breadcrumb and a Mixpanel `app:fetch_timeout` event so we can confirm the bug's breadth in production and verify the fix. Caller-supplied `signal`s are preserved via `AbortSignal.any()`.
- **Dependencies**: No new deps — uses `@sentry/vue` (already installed) and the existing `useTelemetry()` composable.

## Instrumentation

**Tools selected:** Sentry breadcrumb + Mixpanel event (`app:fetch_timeout`)

**Why not other tools:** No Datadog RUM or PostHog SDK in this codebase — telemetry flows through `MixpanelTelemetryProvider` only. GTM/Customer.io/Impact are product/marketing tools, not appropriate for error states.

## What to observe

- **Mixpanel `app:fetch_timeout`**: expect a spike at first deploy (confirming the hypothesis), then rate should drop to < 1/hr within 48 h as the timeout clears stuck slots.
- **Sentry breadcrumbs**: `category: fetch`, `level: warning` — visible in crash sessions showing which routes hung.

## Review Focus

- `AbortSignal.any` is supported in Chrome 116+, Firefox 124+, Safari 17.4+. If older browser support is required, replace with a manual `addEventListener('abort', ...)` chain.
- The 60 s ceiling is conservative. Legitimate long-running requests (if any) should pass their own `signal` — it's merged via `AbortSignal.any`, so neither cancels the other silently.

Fixes #14389