### PR TITLE
fix(litegraph): make the link-dedup survivor positionally authoritative (#15577)

### DIFF
--- a/src/lib/litegraph/src/LGraph.inputSlotRealign.test.ts
+++ b/src/lib/litegraph/src/LGraph.inputSlotRealign.test.ts
@@ -288,12 +288,16 @@ const LINK_BY_INPUT_NAME: Record<string, number> = {
   in_c: 2
 }
 
-function assertLinksRealigned(graph: LGraph, targetNodeId: NodeId) {
+function assertLinksRealigned(
+  graph: LGraph,
+  targetNodeId: NodeId,
+  linkByInputName: Record<string, number> = LINK_BY_INPUT_NAME
+) {
   const target = graph.getNodeById(targetNodeId)!
   const linkStore = useLinkStore()
 
   for (const [slot, input] of target.inputs.entries()) {
-    const expectedLinkId = toLinkId(LINK_BY_INPUT_NAME[input.name])
+    const expectedLinkId = toLinkId(linkByInputName[input.name])
     const link = graph.links.get(expectedLinkId)!
 
     expect(link.target_slot, `link.target_slot for input ${input.name}`).toBe(
@@ -339,8 +343,16 @@ describe('LGraph.configure input slot realignment (#3348)', () => {
     const graph = new LGraph()
     graph.configure(savedWorkflow({ duplicate: true }))
 
-    expect(graph.links.has(toLinkId(4))).toBe(false)
-    assertLinksRealigned(graph, toNodeId(2))
+    // #15577: links 3 and 4 both target `2:2` from the same origin `1:0`, so
+    // they are interchangeable and only the surviving *id* changed here - the
+    // serialized input names link 4, so 4 now wins and 3 is the rejected alias.
+    // Topology is unchanged: `in_a` resolves to origin `1:0` in both arms, as
+    // assertLinksRealigned still checks below.
+    expect(graph.links.has(toLinkId(3))).toBe(false)
+    assertLinksRealigned(graph, toNodeId(2), {
+      ...LINK_BY_INPUT_NAME,
+      in_a: 4
+    })
   })
 
   it('maps a rejected subgraph input fanout branch to its exact survivor', () => {
@@ -355,7 +367,11 @@ describe('LGraph.configure input slot realignment (#3348)', () => {
     graph.configure(workflow)
 
     const subgraph = graph.subgraphs.get(SUBGRAPH_ID)!
-    expect(subgraph.inputs[0].linkIds).toEqual([toLinkId(2)])
+    // #15577: links 2 and 3 both target `2:0` from the same origin, so only the
+    // surviving *id* changed - node 2's input scalar and the boundary slot both
+    // name link 3, so 3 now wins instead of document-order 2. Topology is
+    // unchanged: the slot still fans out to nodes 1 and 2 from the same origin.
+    expect(subgraph.inputs[0].linkIds).toEqual([toLinkId(3)])
   })
 
   it('uses the first slot when one link is referenced by multiple inputs', () => {

--- a/src/lib/litegraph/src/linkDeduplication.conflictingOrigins.test.ts
+++ b/src/lib/litegraph/src/linkDeduplication.conflictingOrigins.test.ts
@@ -71,7 +71,7 @@ describe('normalizeConfiguredTopology with conflicting origins (#15577)', () => 
     LiteGraph.registerNodeType('test/DupTestNode', DupTestNode)
   })
 
-  it.fails('keeps the link that input.link references', () => {
+  it('keeps the link that input.link references', () => {
     const graph = configureConflictingOrigins()
 
     expect(graph.getNodeById(toNodeId(3))?.getInputLink(0)?.origin_id).toBe(
@@ -79,7 +79,7 @@ describe('normalizeConfiguredTopology with conflicting origins (#15577)', () => 
     )
   })
 
-  it.fails('warns when a link is dropped in favour of a different origin', () => {
+  it('warns when a link is dropped in favour of a different origin', () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
     configureConflictingOrigins()
@@ -97,7 +97,7 @@ describe('normalizeConfiguredTopology with conflicting origins (#15577)', () => 
     expect(graph.getNodeById(toNodeId(3))?.getInputLink(0)).toBeDefined()
   })
 
-  it.fails('re-saves the workflow without changing the upstream node', () => {
+  it('re-saves the workflow without changing the upstream node', () => {
     const graph = configureConflictingOrigins()
 
     const [survivor] = linksIntoTargetSlot(

--- a/src/lib/litegraph/src/linkDeduplication.ts
+++ b/src/lib/litegraph/src/linkDeduplication.ts
@@ -54,36 +54,125 @@ export function remapLinkReferences(
   }
 }
 
+/**
+ * Removes serialized link ids from every list and scalar that names them.
+ * Used for links dropped because a *different* connection already owns the
+ * target slot: remapping would hand the loser's origin a link it does not own,
+ * so the reference must be deleted rather than repointed.
+ */
+function pruneLinkReferences(
+  data: ConfiguredGraph,
+  dropped: ReadonlySet<number>
+): void {
+  if (!dropped.size) return
+  const nodes = data.nodes ?? []
+
+  for (const input of nodes.flatMap((node) => node.inputs ?? [])) {
+    if (input.link != null && dropped.has(input.link)) input.link = null
+  }
+
+  const linkIdLists = [
+    ...nodes.flatMap((node) =>
+      (node.outputs ?? []).map((output) => output.links)
+    ),
+    ...(data.inputs ?? []).map((slot) => slot.linkIds),
+    ...(data.outputs ?? []).map((slot) => slot.linkIds),
+    ...(data.reroutes ?? []).map((reroute) => reroute.linkIds)
+  ]
+  for (const ids of linkIdLists) {
+    if (!ids) continue
+    const kept = ids.filter((id) => !dropped.has(id))
+    if (kept.length !== ids.length) ids.splice(0, ids.length, ...kept)
+  }
+
+  if (data.extra?.linkExtensions) {
+    data.extra.linkExtensions = data.extra.linkExtensions.filter(
+      (extension) => !dropped.has(extension.id)
+    )
+  }
+}
+
+/**
+ * Maps each `target_id:target_slot` to the link id the *target side* of the
+ * serialized data names, when that side can name exactly one.
+ *
+ * Positional, not membership. A node input holds a single scalar at a known
+ * index, so it is authoritative. A subgraph boundary slot holds an *array*
+ * (`SubgraphIO.linkIds`), and a file with two links into one boundary slot
+ * lists both ids, so containment cannot discriminate between them - such
+ * slots deliberately produce no entry here and fall back to document order.
+ */
+function authoritativeSurvivorByTarget(
+  data: ConfiguredGraph
+): Map<string, number> {
+  const authoritative = new Map<string, number>()
+  for (const node of data.nodes ?? []) {
+    const inputs = node.inputs ?? []
+    for (const [slot, input] of inputs.entries()) {
+      if (input?.link == null) continue
+      authoritative.set(`${toNodeId(node.id)}:${slot}`, input.link)
+    }
+  }
+  return authoritative
+}
+
 export function normalizeConfiguredTopology<T extends ConfiguredGraph>(
   data: T
 ): T {
   if (!data.links?.length) return data
 
-  const survivorByTarget = new Map<string, ReturnType<typeof linkFields>>()
-  const survivorByDuplicateId = new Map<number, number>()
-  const links = data.links.filter((link) => {
+  const authoritative = authoritativeSurvivorByTarget(data)
+
+  // Pass 1: group every link by the slot it targets, in document order.
+  const byTarget = new Map<string, ReturnType<typeof linkFields>[]>()
+  for (const link of data.links) {
     const fields = linkFields(link)
     const key = `${toNodeId(fields.target_id)}:${fields.target_slot}`
-    const survivor = survivorByTarget.get(key)
-    if (!survivor) {
-      survivorByTarget.set(key, fields)
-      return true
+    const group = byTarget.get(key)
+    if (group) group.push(fields)
+    else byTarget.set(key, [fields])
+  }
+
+  // Pass 2: pick the survivor per slot. The target side wins when it names a
+  // link that is actually in the group; otherwise keep document order.
+  const survivorIdByKey = new Map<string, number>()
+  const remapped = new Map<number, number>()
+  const dropped = new Set<number>()
+  for (const [key, group] of byTarget) {
+    if (group.length === 1) continue
+    const named = authoritative.get(key)
+    const survivor =
+      (named == null
+        ? undefined
+        : group.find((fields) => fields.id === named)) ?? group[0]
+    survivorIdByKey.set(key, survivor.id)
+    for (const fields of group) {
+      if (fields.id === survivor.id) continue
+      if (
+        toNodeId(survivor.origin_id) === toNodeId(fields.origin_id) &&
+        survivor.origin_slot === fields.origin_slot
+      ) {
+        remapped.set(fields.id, survivor.id)
+      } else {
+        dropped.add(fields.id)
+        console.warn(
+          `LiteGraph: link ${fields.id} (origin ${String(fields.origin_id)}:${fields.origin_slot}) dropped; ` +
+            `${key} is already connected by link ${survivor.id} (origin ${String(survivor.origin_id)}:${survivor.origin_slot})`
+        )
+      }
     }
-    if (
-      toNodeId(survivor.origin_id) === toNodeId(fields.origin_id) &&
-      survivor.origin_slot === fields.origin_slot
-    ) {
-      survivorByDuplicateId.set(fields.id, survivor.id)
-    }
-    return false
+  }
+
+  if (!remapped.size && !dropped.size) return data
+
+  const links = data.links.filter((link) => {
+    const { id } = linkFields(link)
+    return !remapped.has(id) && !dropped.has(id)
   })
-  if (links.length === data.links.length) return data
 
-  const normalized = Object.assign({}, data, { links })
-  if (!survivorByDuplicateId.size) return normalized
-
-  const cloned = cloneDeep(normalized)
-  remapLinkReferences(cloned, survivorByDuplicateId)
+  const cloned = cloneDeep(Object.assign({}, data, { links }))
+  if (remapped.size) remapLinkReferences(cloned, remapped)
+  pruneLinkReferences(cloned, dropped)
   return cloned
 }
 


### PR DESCRIPTION
Fixes #15577. Targets `feature/ecs-migration`, not `main` — the defect only exists on this branch.

## What breaks today

Configure-time dedup narrowed its key to `target_id:target_slot` and keeps `data.links[first]`:

```ts
const key = `${toNodeId(fields.target_id)}:${fields.target_slot}`
const survivor = survivorByTarget.get(key)
if (!survivor) { survivorByTarget.set(key, fields); return true }
```

When two links target one input from **different origins**, that drops an edge and picks the winner by document order. Measured round trip of a conflicting-origin file:

```
branch, as-is:   links [[1,1,0,3,0]]              node3.input.link = 1   <- origin 2 destroyed
main:            links [[1,1,0,3,0],[2,2,0,3,0]]  node3.input.link = 2
branch, patched: links [[2,2,0,3,0]]              node3.input.link = 2   <- matches main
```

So the input resolves to a different upstream node than it did on `main`, and the next save writes that wrong answer to disk. There is no signal: `realignInputLinkSlots` does `graph.links.get(input.link)`, misses, and skips.

Second defect, same rule: for a subgraph boundary slot the branch drops link 2 from `links` but leaves `2` in `outputs[0].linkIds`, because `survivorByDuplicateId` is only populated for same-origin duplicates so `remapLinkReferences` never runs. **The saved file names a link that does not exist.** `normalizeConfiguredTopology` runs on subgraph definitions too (`subgraph/subgraphDeduplication.ts:60`), so this is in scope.

## Why the target side is authoritative here, and was not on `main`

The tempting fix is to port `main`'s `selectSurvivorLink`, which searched `ids.find(id => input.link === id)`. That does not work, and the reason is the interesting part.

**Boundary slots list BOTH ids.** `SubgraphIO.linkIds?: number[]` (`types/serialisation.ts:179`) — its own docstring says *"An output slot should only ever have one link"*, an invariant asserted in a comment and carried in an array. A file with two links into one boundary slot lists both, so *membership is non-discriminating*: both candidates are contained and `.find` degenerates to document order. Any survivor rule shaped like "return the candidate some target-side reference contains" is ambiguous by construction.

**The authority is positional.** `main`'s `selectSurvivorLink` received a live `LGraphNode` *after* `configure()`, and its docstring is correct for that input: slot indices shift during widget-to-input conversion, so position was unusable and membership was all it had. This branch's `normalizeConfiguredTopology(data)` receives serialized data *before* `configure()` (`linkDeduplication.ts:57`). At that point `data.nodes[n].inputs[i]` **is** `target_slot i`, by construction — nothing has shifted yet. Positional authority is available precisely because the branch moved the work earlier. Carrying `main`'s membership scan across would import a workaround for a constraint that no longer applies.

## The fix

One file, `src/lib/litegraph/src/linkDeduplication.ts`, +109/−20.

```
Pass 1  group every link by `${target_id}:${target_slot}`, in document order
Pass 2  survivor = the id the target side NAMES, if it is in the group; else group[0]
          - node input   -> data.nodes[n].inputs[slot].link  (a scalar -> authoritative)
          - boundary slot -> data.outputs[slot].linkIds       (an ARRAY -> deliberately no entry)
Pass 3  same-origin losers      -> remap references  (existing behaviour, unchanged)
        different-origin losers -> PRUNE references + console.warn  (new)
```

Pass 3's split is the non-obvious part. Remapping a *different-origin* loser would rewrite the loser's origin node `output.links` from the dead id to the survivor's id, handing node 2 a link that belongs to node 1. For conflicting origins the correct repair is deletion, not repointing. That is why this needs `pruneLinkReferences` alongside the existing `remapLinkReferences`, and why "just change which id wins" is not the whole fix.

**What it does not fix.** When the target side names nothing (`input.link` null or dangling) or cannot name one thing (a boundary slot), it falls back to document order — which is exactly what `main` does. No divergence is introduced. The residual loss for the boundary case is unavoidable while one-link-per-input is a deliberate invariant of the link store.

Side effect, measured: this also repairs the dangling `outputs[0].linkIds` `[1,2]` → `[1]` above.

## Test deltas

Full `src/lib/litegraph` suite, re-measured at `907ca2b147` in a detached worktree with all 8 workspace `node_modules` hardlinked:

| Arm | Files | Result |
| --- | --- | --- |
| baseline (branch, unmodified) | 89 passed | 1296 passed, 18 expected-fail, 5 skipped (1319), exit 0 |
| fix only, tests untouched | 2 failed / 87 passed | 5 failed, 1294 passed, 15 expected-fail, 5 skipped |
| fix + this PR's test updates | 89 passed | **1299 passed, 15 expected-fail, 5 skipped, exit 0** |

The 5 failures in the middle arm are exactly the 3 + 2 below. Nothing else in the suite moves.

### 3 of 5: the `it.fails` markers flipping green — the intended signal

`linkDeduplication.conflictingOrigins.test.ts` (landed by #15592 before the fix existed) carries three markers asserting the wanted behaviour. All three report `Expect test to fail` under this patch — a **3/3 kill, with the unpatched branch as the negative control**.

Per our `it.fails` convention, a marker flipping green means the defect is fixed and **the marker is deleted**, not rewritten. Rewriting the assertion instead would re-fossilise the bug. So this PR deletes `it.fails` → `it` on:

- `keeps the link that input.link references`
- `warns when a link is dropped in favour of a different origin`
- `re-saves the workflow without changing the upstream node`

### 2 of 5: link-*id* identity expectations in `LGraph.inputSlotRealign.test.ts`

Both are **same-origin duplicate** fixtures, so both go down the remap path, not the prune path. Only *which of two interchangeable ids* survives changes. I verified topology rather than assuming it:

```
duplicate-drifted, baseline: in_a <- link 3 from 1:0 | in_b <- link 1 from 1:0 | in_c <- link 2 from 1:0
duplicate-drifted, patched:  in_a <- link 4 from 1:0 | in_b <- link 1 from 1:0 | in_c <- link 2 from 1:0

subgraph fanout, baseline:   node1.in_a <- link 1 from -10:0 | node2.in_a <- link 2 from -10:0
subgraph fanout, patched:    node1.in_a <- link 1 from -10:0 | node2.in_a <- link 3 from -10:0
```

Every input resolves to the **same origin at the same slot** in both arms. Under the patch the survivor is the id **the file itself names**, which is strictly more faithful to the serialized data. Both tests pinned the old document-order choice, i.e. exactly the behaviour #15577 asks to change.

Each updated line carries a one-line comment saying why the id moved and that topology did not, so this is not a silent behaviour change. The `target_slot` topology assertions in `assertLinksRealigned` are untouched and still run on both tests.

### Negative control on the updated expectations

With the two test files kept as updated and **the fix reverted**, all 5 tests fail with `AssertionError` on the intended lines — no `TypeError`, no vacuous pass:

```
AssertionError: expected true to be false          (links.has(3))
AssertionError: expected [ 2 ] to deeply equal [ 3 ] (boundary linkIds)
AssertionError: expected '1' to be '2'              (survivor origin)
AssertionError: expected '' to contain '3:0'        (the warn)
AssertionError: expected '1' to be '2'              (round trip)
```

## Reachability — real mechanism, unmeasured population

Being straight about this, because we already retracted one over-claim on this issue.

**The producer is proven in code with a live control.** An origin-side mirror write that leaves `input.link` dangling, followed by one ordinary `connect()` into the same input, emits two links into one target slot from different origins. `connect()` calls `disconnectInput`, which resolves the incumbent through `input.link`; that names a link not in `graph.links`, the lookup misses, the incumbent is never removed, and the new link joins it. The control — the same two connects without the preceding mirror write — yields one link, so the mirror write is load-bearing. `rgthree-comfy`'s `link_fixer.js` writes the origin mirror at `:70` and its input-repair branch is empty, which is exactly that state; `fixBadLinks(graph, true)` is live in shipped rgthree.

**Nobody has counted an affected user.** I scanned every local saved workflow I have: **206 files parsed, 2822 link records, 0 slots with two links from different origins, 0 with same-origin duplicates either.** So the shape is absent from my corpus and the producer has to actually run to create it. The population is real but **unmeasured** — not a known-affected set. Please do not quote a user count from this PR, because there isn't one.

The argument for fixing anyway is that the failure is *destructive and silent*: the branch rewrites the file with the wrong wiring and never marks it modified, so every day it is live on such a file the original wiring is closer to unrecoverable. That is a different risk profile from a wrong-pixel bug, and it is why I would rather land this before merge than after.

## Verification run by hand

Hooks are silently skipped in worktrees (`core.hooksPath=.husky/_`, directory absent), so I ran every gate myself and confirmed each instrument was live before trusting it:

| Gate | Result | Control |
| --- | --- | --- |
| `vitest run src/lib/litegraph` | exit 0, 89/89 files | `LLink.test.ts` 4/4 green first |
| `vitest run src/stores` | exit 0, 1056 passed, 47 files | — |
| `vue-tsc --noEmit` (8GB heap) | **exit 0**, 0 `TS2688`, 0 `error TS` | exit code captured, not grep-filtered |
| `eslint` (3 files) | exit 0 | `no-var` probe → exit 1 on a litegraph file |
| `oxlint` (3 files) | exit 0, no findings | `-D no-var` probe → exit 1 |
| `oxfmt --check` | exit 0, 3 files correct | — |
| `knip` | output **byte-identical to baseline** | exit code is pinned at 1 by pre-existing `apps/website` load errors, so diffed the output |

knip caught a real defect in my first pass: the two new helpers were exported and unused, adding 2 findings over baseline. They are module-local now.

## Notes for review

- **Merge-order collision.** This edits `LGraph.inputSlotRealign.test.ts`, the same file #15581's fix must edit. Both are green alone. Land them in a stated order or fold them together.
- **Saved-file id churn.** For same-origin duplicates the surviving link id changes. Topology is identical, but any external tool keyed on link id, or any diff of a saved workflow, will show movement. Nothing in-repo depends on it; nothing outside was checked.
- **Not benchmarked.** Pass 1 allocates one array per target slot instead of one entry. Same O(n), more allocation, on every `configure()`. Almost certainly noise, but unmeasured.
- **Boundary case coverage.** The #15592 fixture is plain-node only. That gap hid a both-links-dropped bug in my own first prototype (`(x != null && group.find(...)) ?? group[0]` evaluates to `false`, and `??` does not catch `false`). The boundary case is worth adding to the fixture set; the `inputSlotRealign` subgraph-fanout test exercises it only incidentally.
- **`subgraphDeduplication.ts:329`** runs its own `remapLinkReferences` with no prune counterpart. Not touched here — flagging it as possibly the same gap one layer down.

I am not the owner of this branch, so this is yours to take, rework or reject — I did not push to `feature/ecs-migration`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011p5NxEUYrsMnxdSB7WGuf1
