### PR TITLE
fix(nodeDataStore): log console.error on id collision (FE-1810)

### DIFF
--- a/src/stores/nodeDataStore.test.ts
+++ b/src/stores/nodeDataStore.test.ts
@@ -1,6 +1,6 @@
 import { createTestingPinia } from '@pinia/testing'
 import { setActivePinia } from 'pinia'
-import { assert, beforeEach, describe, expect, it } from 'vitest'
+import { assert, beforeEach, describe, expect, it, vi } from 'vitest'
 import { computed } from 'vue'
 
 import { LGraph, LGraphNode } from '@/lib/litegraph/src/litegraph'
@@ -66,28 +66,36 @@ describe('useNodeDataStore', () => {
     const store = useNodeDataStore()
     const first = node(1)
     const duplicate = node(1, 'sub-1')
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
 
     const registered = store.registerNode(graphScope(rootA, rootA), first)
     const rejected = store.registerNode(graphScope(rootA, 'sub-1'), duplicate)
 
     expect(registered?.id).toBe(first.id)
     expect(rejected).toBeUndefined()
+    expect(errorSpy).toHaveBeenCalledOnce()
+    expect(errorSpy.mock.calls[0][0]).toMatch(/belongs to graph/)
     expect(duplicate.graphId).toBe('sub-1')
     expect(store.getGraphNodesFor(rootA, rootA)).toEqual([registered])
     expect(store.getGraphNodesFor(rootA, 'sub-1')).toEqual([])
+    errorSpy.mockRestore()
   })
 
   it('rejects the registered node identity from a sibling owner', () => {
     const store = useNodeDataStore()
     const registered = node(1)
     store.registerNode(graphScope(rootA, rootA), registered)
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
 
     expect(
       store.registerNode(graphScope(rootA, 'sub-1'), registered)
     ).toBeUndefined()
+    expect(errorSpy).toHaveBeenCalledOnce()
+    expect(errorSpy.mock.calls[0][0]).toMatch(/belongs to graph/)
     expect(registered.graphId).toBe(rootA)
     expect(store.getGraphNodesFor(rootA, rootA)).toEqual([registered])
     expect(store.getGraphNodesFor(rootA, 'sub-1')).toEqual([])
+    errorSpy.mockRestore()
   })
 
   it('only deletes the registered identity from its owning graph', () => {

--- a/src/stores/nodeDataStore.ts
+++ b/src/stores/nodeDataStore.ts
@@ -53,7 +53,12 @@ export const useNodeDataStore = defineStore('nodeData', () => {
       incumbent.graphId === graphScope.owningGraphId
     )
       return incumbent
-    if (incumbent) return undefined
+    if (incumbent) {
+      console.error(
+        `Node ${state.id} belongs to graph ${incumbent.graphId}; graph ${graphScope.owningGraphId} cannot overwrite it.`
+      )
+      return undefined
+    }
     const bucket = existingBucket ?? rootBucket(graphScope.rootGraphId)
     const registered: NodeState = reactive(
       Object.assign(state, { graphId: graphScope.owningGraphId })


### PR DESCRIPTION
## Summary

- Adds `console.error` on the `if (incumbent) return undefined` branch of `registerNode` in `src/stores/nodeDataStore.ts`, matching the wording and style used by `linkStore.ts:210` and `rerouteStore.ts:131`
- Updates the two existing collision tests to assert the error is emitted (spy + restore pattern)

Without this, a genuine identity violation — two distinct `NodeState` objects claiming the same id — was silent at the console, indistinguishable from the normal id-collision retry path in `LGraph.ts:1171`. Nodes could be silently re-minted with new ids that appear in serialized workflows.

Closes [FE-1810](https://linear.app/comfyorg/issue/FE-1810).

## Test plan

- [ ] `pnpm vitest run src/stores/nodeDataStore.test.ts` — two collision tests now assert `console.error` is called once with a message matching `/belongs to graph/`
- [ ] Confirm no new errors appear in the normal (non-collision) registration path

🤖 Generated with [Claude Code](https://claude.com/claude-code)