### PR TITLE
fix: guard startResize against concurrent invocations to prevent listener leak

### DIFF
--- a/src/renderer/extensions/vueNodes/interactions/resize/useNodeResize.test.ts
+++ b/src/renderer/extensions/vueNodes/interactions/resize/useNodeResize.test.ts
@@ -11,11 +11,12 @@ type ResizeCallback = (
   element: HTMLElement
 ) => void
 
-// Capture pointermove/pointerup handlers registered via useEventListener.
+// Capture pointer handlers registered via useEventListener.
 // All registered handlers are kept so tests can observe stale (un-stopped) ones.
 const eventHandlers = vi.hoisted(() => ({
   pointermove: [] as ((e: PointerEvent) => void)[],
-  pointerup: [] as ((e: PointerEvent) => void)[]
+  pointerup: [] as ((e: PointerEvent) => void)[],
+  pointercancel: [] as ((e: PointerEvent) => void)[]
 }))
 
 const stopHandles = vi.hoisted(() => ({
@@ -25,7 +26,11 @@ const stopHandles = vi.hoisted(() => ({
 vi.mock('@vueuse/core', () => ({
   useEventListener: vi.fn(
     (eventName: string, handler: (...args: unknown[]) => void) => {
-      if (eventName === 'pointermove' || eventName === 'pointerup') {
+      if (
+        eventName === 'pointermove' ||
+        eventName === 'pointerup' ||
+        eventName === 'pointercancel'
+      ) {
         const handlers = eventHandlers[eventName]
         handlers.push(handler)
         const stop = vi.fn(() => {
@@ -162,7 +167,7 @@ function simulateMove(
     clientX: startX + deltaX,
     clientY: startY + deltaY
   })
-  for (const handler of eventHandlers.pointermove) handler(moveEvent)
+  for (const handler of [...eventHandlers.pointermove]) handler(moveEvent)
 }
 
 describe('useNodeResize', () => {
@@ -173,6 +178,7 @@ describe('useNodeResize', () => {
   beforeEach(async () => {
     eventHandlers.pointermove = []
     eventHandlers.pointerup = []
+    eventHandlers.pointercancel = []
     stopHandles.all.length = 0
     snapState.shouldSnap = false
     snapState.applySnapToPosition = (pos) => pos
@@ -333,6 +339,7 @@ describe('useNodeResize', () => {
       vi.clearAllMocks()
       eventHandlers.pointermove = []
       eventHandlers.pointerup = []
+      eventHandlers.pointercancel = []
       stopHandles.all.length = 0
       const cb = vi.fn<ResizeCallback>()
       const el = makeReflowingElement(300, 400, getMinContentHeight)
@@ -403,7 +410,7 @@ describe('useNodeResize', () => {
       const callsBeforeUp = cb.mock.calls.length
 
       const upEvent = createPointerEvent('pointerup', { pointerId: 1 })
-      for (const h of eventHandlers.pointerup) h(upEvent)
+      for (const h of [...eventHandlers.pointerup]) h(upEvent)
 
       // Subsequent moves should be ignored after cleanup
       simulateMove(40, 40)
@@ -421,7 +428,7 @@ describe('useNodeResize', () => {
 
       const upEvent = createPointerEvent('pointerup', { pointerId: 1 })
       expect(() => {
-        for (const h of eventHandlers.pointerup) h(upEvent)
+        for (const h of [...eventHandlers.pointerup]) h(upEvent)
       }).not.toThrow()
 
       // Further moves are ignored — cleanup still ran.
@@ -533,15 +540,16 @@ describe('useNodeResize', () => {
 
   describe('concurrent resize guard', () => {
     it('releases every listener set when two corners are grabbed at once', () => {
+      const handlesBeforeGesture = stopHandles.all.length
       startResizeAt(getStartResize(), handle, 'SE')
       startResizeAt(getStartResize(), handle, 'SW')
 
-      for (const h of eventHandlers.pointerup)
+      for (const h of [...eventHandlers.pointerup])
         h(createPointerEvent('pointerup'))
 
-      const unreleased = stopHandles.all.filter(
-        (s) => s.mock.calls.length === 0
-      )
+      const unreleased = stopHandles.all
+        .slice(handlesBeforeGesture)
+        .filter((s) => s.mock.calls.length === 0)
       expect(unreleased).toHaveLength(0)
     })
 
@@ -551,7 +559,7 @@ describe('useNodeResize', () => {
       startResizeAt(getStartResize(), handle, 'SW')
 
       // Release first gesture
-      for (const h of eventHandlers.pointerup)
+      for (const h of [...eventHandlers.pointerup])
         h(createPointerEvent('pointerup'))
 
       // Start a fresh resize — this is the "next resize" from the issue
@@ -562,6 +570,29 @@ describe('useNodeResize', () => {
       simulateMove(10, 10)
       // With the fix, only one handler runs; without it, the stranded L2 handler
       // also fires against the shared refs producing a second callback call.
+      expect(callback).toHaveBeenCalledTimes(1)
+    })
+
+    it('ignores events from pointers outside the active resize', () => {
+      startResizeAt(getStartResize(), handle, 'SE')
+
+      simulateMove(10, 10)
+      callback.mockClear()
+
+      const otherMove = createPointerEvent('pointermove', {
+        clientX: 550,
+        clientY: 550,
+        pointerId: 2
+      })
+      for (const h of [...eventHandlers.pointermove]) h(otherMove)
+      for (const h of [...eventHandlers.pointerup])
+        h(createPointerEvent('pointerup', { pointerId: 2 }))
+      for (const h of [...eventHandlers.pointercancel])
+        h(createPointerEvent('pointercancel', { pointerId: 2 }))
+
+      expect(callback).not.toHaveBeenCalled()
+
+      simulateMove(20, 20)
       expect(callback).toHaveBeenCalledTimes(1)
     })
   })

--- a/src/renderer/extensions/vueNodes/interactions/resize/useNodeResize.test.ts
+++ b/src/renderer/extensions/vueNodes/interactions/resize/useNodeResize.test.ts
@@ -11,19 +11,33 @@ type ResizeCallback = (
   element: HTMLElement
 ) => void
 
-// Capture pointermove/pointerup handlers registered via useEventListener
+// Capture pointermove/pointerup handlers registered via useEventListener.
+// All registered handlers are kept so tests can observe stale (un-stopped) ones.
 const eventHandlers = vi.hoisted(() => ({
-  pointermove: null as ((e: PointerEvent) => void) | null,
-  pointerup: null as ((e: PointerEvent) => void) | null
+  pointermove: [] as ((e: PointerEvent) => void)[],
+  pointerup: [] as ((e: PointerEvent) => void)[]
+}))
+
+const stopHandles = vi.hoisted(() => ({
+  all: [] as ReturnType<typeof vi.fn>[]
 }))
 
 vi.mock('@vueuse/core', () => ({
   useEventListener: vi.fn(
     (eventName: string, handler: (...args: unknown[]) => void) => {
       if (eventName === 'pointermove' || eventName === 'pointerup') {
-        eventHandlers[eventName] = handler
+        const handlers = eventHandlers[eventName]
+        handlers.push(handler)
+        const stop = vi.fn(() => {
+          const idx = handlers.indexOf(handler)
+          if (idx !== -1) handlers.splice(idx, 1)
+        })
+        stopHandles.all.push(stop)
+        return stop
       }
-      return vi.fn()
+      const stop = vi.fn()
+      stopHandles.all.push(stop)
+      return stop
     }
   )
 }))
@@ -148,7 +162,7 @@ function simulateMove(
     clientX: startX + deltaX,
     clientY: startY + deltaY
   })
-  eventHandlers.pointermove?.(moveEvent)
+  for (const handler of eventHandlers.pointermove) handler(moveEvent)
 }
 
 describe('useNodeResize', () => {
@@ -157,8 +171,9 @@ describe('useNodeResize', () => {
   let handle: HTMLElement
 
   beforeEach(async () => {
-    eventHandlers.pointermove = null
-    eventHandlers.pointerup = null
+    eventHandlers.pointermove = []
+    eventHandlers.pointerup = []
+    stopHandles.all.length = 0
     snapState.shouldSnap = false
     snapState.applySnapToPosition = (pos) => pos
     snapState.applySnapToSize = (size) => size
@@ -316,8 +331,9 @@ describe('useNodeResize', () => {
 
     async function setupDynamic(getMinContentHeight: () => number) {
       vi.clearAllMocks()
-      eventHandlers.pointermove = null
-      eventHandlers.pointerup = null
+      eventHandlers.pointermove = []
+      eventHandlers.pointerup = []
+      stopHandles.all.length = 0
       const cb = vi.fn<ResizeCallback>()
       const el = makeReflowingElement(300, 400, getMinContentHeight)
       const h = createMockHandle(el)
@@ -387,7 +403,7 @@ describe('useNodeResize', () => {
       const callsBeforeUp = cb.mock.calls.length
 
       const upEvent = createPointerEvent('pointerup', { pointerId: 1 })
-      eventHandlers.pointerup?.(upEvent)
+      for (const h of eventHandlers.pointerup) h(upEvent)
 
       // Subsequent moves should be ignored after cleanup
       simulateMove(40, 40)
@@ -404,7 +420,9 @@ describe('useNodeResize', () => {
       simulateMove(10, 10)
 
       const upEvent = createPointerEvent('pointerup', { pointerId: 1 })
-      expect(() => eventHandlers.pointerup?.(upEvent)).not.toThrow()
+      expect(() => {
+        for (const h of eventHandlers.pointerup) h(upEvent)
+      }).not.toThrow()
 
       // Further moves are ignored — cleanup still ran.
       const callsAfterUp = cb.mock.calls.length
@@ -510,6 +528,41 @@ describe('useNodeResize', () => {
       simulateMove(10, 10)
 
       expect(el.style.getPropertyValue('--node-width')).toBe('350px')
+    })
+  })
+
+  describe('concurrent resize guard', () => {
+    it('releases every listener set when two corners are grabbed at once', () => {
+      startResizeAt(getStartResize(), handle, 'SE')
+      startResizeAt(getStartResize(), handle, 'SW')
+
+      for (const h of eventHandlers.pointerup)
+        h(createPointerEvent('pointerup'))
+
+      const unreleased = stopHandles.all.filter(
+        (s) => s.mock.calls.length === 0
+      )
+      expect(unreleased).toHaveLength(0)
+    })
+
+    it('fires resizeCallback once per pointermove on next resize after a double grab', () => {
+      // Simulate double grab: first corner, then second before first releases
+      startResizeAt(getStartResize(), handle, 'SE')
+      startResizeAt(getStartResize(), handle, 'SW')
+
+      // Release first gesture
+      for (const h of eventHandlers.pointerup)
+        h(createPointerEvent('pointerup'))
+
+      // Start a fresh resize — this is the "next resize" from the issue
+      stopHandles.all.length = 0
+      startResizeAt(getStartResize(), handle, 'SE')
+
+      callback.mockClear()
+      simulateMove(10, 10)
+      // With the fix, only one handler runs; without it, the stranded L2 handler
+      // also fires against the shared refs producing a second callback call.
+      expect(callback).toHaveBeenCalledTimes(1)
     })
   })
 })

--- a/src/renderer/extensions/vueNodes/interactions/resize/useNodeResize.test.ts
+++ b/src/renderer/extensions/vueNodes/interactions/resize/useNodeResize.test.ts
@@ -1,5 +1,6 @@
 import type { MockInstance } from 'vitest'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Ref } from 'vue'
 
 import type { CompassCorners } from '@/lib/litegraph/src/interfaces'
 import { MIN_NODE_WIDTH } from '@/renderer/core/layout/transform/graphRenderTransform'
@@ -174,6 +175,7 @@ describe('useNodeResize', () => {
   let callback: ResizeCallback & MockInstance<ResizeCallback>
   let nodeElement: HTMLElement
   let handle: HTMLElement
+  let isResizing: Ref<boolean>
 
   beforeEach(async () => {
     eventHandlers.pointermove = []
@@ -190,10 +192,12 @@ describe('useNodeResize', () => {
 
     // Need fresh import after mocks are set up
     const { useNodeResize } = await import('./useNodeResize')
-    const { startResize } = useNodeResize(callback)
+    const resize = useNodeResize(callback)
+    isResizing = resize.isResizing
 
     // Store startResize for access in tests
-    ;(globalThis as Record<string, unknown>).__testStartResize = startResize
+    ;(globalThis as Record<string, unknown>).__testStartResize =
+      resize.startResize
   })
 
   function getStartResize() {
@@ -594,6 +598,24 @@ describe('useNodeResize', () => {
 
       simulateMove(20, 20)
       expect(callback).toHaveBeenCalledTimes(1)
+    })
+
+    it('tears down the resize when the active pointer cancels', () => {
+      startResizeAt(getStartResize(), handle, 'SE')
+      simulateMove(10, 10)
+      expect(isResizing.value).toBe(true)
+
+      for (const h of [...eventHandlers.pointercancel])
+        h(createPointerEvent('pointercancel', { pointerId: 1 }))
+
+      expect(isResizing.value).toBe(false)
+      expect(eventHandlers.pointermove).toHaveLength(0)
+      expect(eventHandlers.pointerup).toHaveLength(0)
+      expect(eventHandlers.pointercancel).toHaveLength(0)
+
+      callback.mockClear()
+      simulateMove(20, 20)
+      expect(callback).not.toHaveBeenCalled()
     })
   })
 })

--- a/src/renderer/extensions/vueNodes/interactions/resize/useNodeResize.test.ts
+++ b/src/renderer/extensions/vueNodes/interactions/resize/useNodeResize.test.ts
@@ -146,13 +146,13 @@ function startResizeAt(
   startResize: (event: PointerEvent, corner: CompassCorners) => void,
   handle: HTMLElement,
   corner: CompassCorners,
-  clientX = 500,
-  clientY = 500
+  { clientX = 500, clientY = 500, pointerId = 1 } = {}
 ) {
   const downEvent = createPointerEvent('pointerdown', {
     currentTarget: handle,
     clientX,
-    clientY
+    clientY,
+    pointerId
   })
   startResize(downEvent, corner)
 }
@@ -542,7 +542,7 @@ describe('useNodeResize', () => {
     it('releases every listener set when two corners are grabbed at once', () => {
       const handlesBeforeGesture = stopHandles.all.length
       startResizeAt(getStartResize(), handle, 'SE')
-      startResizeAt(getStartResize(), handle, 'SW')
+      startResizeAt(getStartResize(), handle, 'SW', { pointerId: 2 })
 
       for (const h of [...eventHandlers.pointerup])
         h(createPointerEvent('pointerup'))
@@ -556,7 +556,7 @@ describe('useNodeResize', () => {
     it('fires resizeCallback once per pointermove on next resize after a double grab', () => {
       // Simulate double grab: first corner, then second before first releases
       startResizeAt(getStartResize(), handle, 'SE')
-      startResizeAt(getStartResize(), handle, 'SW')
+      startResizeAt(getStartResize(), handle, 'SW', { pointerId: 2 })
 
       // Release first gesture
       for (const h of [...eventHandlers.pointerup])

--- a/src/renderer/extensions/vueNodes/interactions/resize/useNodeResize.test.ts
+++ b/src/renderer/extensions/vueNodes/interactions/resize/useNodeResize.test.ts
@@ -616,6 +616,10 @@ describe('useNodeResize', () => {
       callback.mockClear()
       simulateMove(20, 20)
       expect(callback).not.toHaveBeenCalled()
+
+      startResizeAt(getStartResize(), handle, 'SE')
+      simulateMove(30, 30)
+      expect(callback).toHaveBeenCalledTimes(1)
     })
   })
 })

--- a/src/renderer/extensions/vueNodes/interactions/resize/useNodeResize.ts
+++ b/src/renderer/extensions/vueNodes/interactions/resize/useNodeResize.ts
@@ -46,6 +46,7 @@ export function useNodeResize(
 
   const startResize = (event: PointerEvent, corner: CompassCorners = 'SE') => {
     event.stopPropagation()
+    if (isResizing.value) return
 
     const target = event.currentTarget
     if (!(target instanceof HTMLElement)) return

--- a/src/renderer/extensions/vueNodes/interactions/resize/useNodeResize.ts
+++ b/src/renderer/extensions/vueNodes/interactions/resize/useNodeResize.ts
@@ -37,6 +37,7 @@ export function useNodeResize(
   const resizeStartSize = ref<Size | null>(null)
   const resizeStartPosition = ref<Point | null>(null)
   const resizeCorner = ref<CompassCorners>('SE')
+  const activePointerId = ref<number | null>(null)
 
   // Snap-to-grid functionality
   const { shouldSnap, applySnapToPosition, applySnapToSize } = useNodeSnap()
@@ -95,6 +96,7 @@ export function useNodeResize(
     // Mark as resizing to prevent drag from activating
     layoutStore.isResizingVueNodes.value = true
     isResizing.value = true
+    activePointerId.value = event.pointerId
     resizeStartPointer.value = { x: event.clientX, y: event.clientY }
     resizeStartSize.value = startSize
     resizeStartPosition.value = startPosition
@@ -102,6 +104,7 @@ export function useNodeResize(
 
     const handlePointerMove = (moveEvent: PointerEvent) => {
       if (
+        moveEvent.pointerId !== activePointerId.value ||
         !isResizing.value ||
         !resizeStartPointer.value ||
         !resizeStartSize.value ||
@@ -217,23 +220,22 @@ export function useNodeResize(
     }
 
     const cleanup = () => {
-      if (!isResizing.value) return
-      isResizing.value = false
-      layoutStore.isResizingVueNodes.value = false
-      resizeStartPointer.value = null
-      resizeStartSize.value = null
-      resizeStartPosition.value = null
-
-      // Stop tracking shift key state
       stopShiftSync()
-
       stopMoveListen()
       stopUpListen()
       stopCancelListen()
+
+      if (!isResizing.value) return
+      isResizing.value = false
+      layoutStore.isResizingVueNodes.value = false
+      activePointerId.value = null
+      resizeStartPointer.value = null
+      resizeStartSize.value = null
+      resizeStartPosition.value = null
     }
 
     const handlePointerUp = (upEvent: PointerEvent) => {
-      if (isResizing.value) {
+      if (isResizing.value && upEvent.pointerId === activePointerId.value) {
         try {
           target.releasePointerCapture(upEvent.pointerId)
         } catch {
@@ -243,9 +245,16 @@ export function useNodeResize(
       }
     }
 
+    const handlePointerCancel = (cancelEvent: PointerEvent) => {
+      if (cancelEvent.pointerId === activePointerId.value) cleanup()
+    }
+
     const stopMoveListen = useEventListener('pointermove', handlePointerMove)
     const stopUpListen = useEventListener('pointerup', handlePointerUp)
-    const stopCancelListen = useEventListener('pointercancel', cleanup)
+    const stopCancelListen = useEventListener(
+      'pointercancel',
+      handlePointerCancel
+    )
   }
 
   return {


### PR DESCRIPTION
When two resize corners were grabbed simultaneously (multi-touch or fast double-grab), `startResize` registered a second listener set (`pointermove`, `pointerup`, `pointercancel`) while `isResizing` was already `true`. The first `pointerup` cleanup released set 1; the second cleanup's `if (!isResizing.value) return` guard then early-returned, stranding set 2 permanently for the page lifetime. On the next resize, the orphaned `pointermove` handler ran alongside the fresh one, calling `resizeCallback` twice per pointer move.

## Changes

- `useNodeResize.ts`: add `if (isResizing.value) return` at the top of `startResize`, immediately after `event.stopPropagation()`
- `useNodeResize.test.ts`: upgrade the `useEventListener` mock to collect all stop handles with removal-on-call semantics; add two regression tests in a new `concurrent resize guard` describe block

## Regression tests

- Asserts every stop handle is called after a double grab + `pointerup` (listener count)
- Asserts `resizeCallback` fires exactly once per `pointermove` on the subsequent resize (user-visible behaviour)

## Mutation verification

Removing the guard causes 2 failures:
- `releases every listener set when two corners are grabbed at once`: 3 unreleased handles (was `expected [] to have length 0, got 3`)
- `fires resizeCallback once per pointermove on next resize after a double grab`: callback fires 2× instead of 1×

Restoring the guard: 21/21 tests pass.

Full suite: `vitest run src/renderer/extensions/vueNodes` → 89 files, 1051 tests pass, 7 skipped.
`NODE_OPTIONS=--max-old-space-size=8192 vue-tsc --noEmit` → exit 0.

- Fixes #15616