### PR TITLE
feat: assert registration-identity invariants in registerNodeState/nodeDataStore

### DIFF
--- a/src/lib/litegraph/src/LGraphNode.nodeState.test.ts
+++ b/src/lib/litegraph/src/LGraphNode.nodeState.test.ts
@@ -11,7 +11,11 @@ import type { NodeState } from '@/types/nodeState'
 
 import { LGraphNode } from './litegraph'
 import type { Subgraph } from './litegraph'
-import { createTestSubgraph } from './subgraph/__fixtures__/subgraphHelpers'
+import { registerNodeState, unregisterNodeState } from './LGraphNode'
+import {
+  createTestRootGraph,
+  createTestSubgraph
+} from './subgraph/__fixtures__/subgraphHelpers'
 
 describe('LGraphNode node-data adoption', () => {
   beforeEach(() => {
@@ -160,5 +164,48 @@ describe('LGraphNode node-data adoption', () => {
       'LiteGraph: changing a node type after construction is deprecated'
     )
     expect(warn).toHaveBeenCalledTimes(2)
+  })
+})
+
+describe('LGraphNode registerNodeState / unregisterNodeState invariants', () => {
+  beforeEach(() => {
+    setActivePinia(createTestingPinia({ stubActions: false }))
+  })
+
+  it('asserts when registering a node that already belongs to a different root graph', () => {
+    // Register node in rootA's subgraph, then attempt to register into rootB.
+    const subgraphA = createTestSubgraph()
+    const node = new LGraphNode('Node')
+    subgraphA.add(node)
+
+    const rootB = createTestRootGraph()
+    expect(() => registerNodeState(rootB, node)).toThrow()
+  })
+
+  it('asserts when unregistering after _state has drifted from the bucket', () => {
+    const { subgraph, node } = (() => {
+      const sg = createTestSubgraph()
+      const n = new LGraphNode('Node')
+      sg.add(n)
+      return { subgraph: sg, node: n }
+    })()
+
+    // Manually replace _state so unregister can't find the original identity.
+    const originalState = node._state
+    // @ts-expect-error — deliberately corrupting internal state for test
+    node._state = { ...originalState }
+
+    expect(() => unregisterNodeState(node)).toThrow()
+
+    // Restore so cleanup doesn't double-assert.
+    // @ts-expect-error — restore after corruption
+    node._state = originalState
+  })
+
+  it('does not assert on normal register → remove cycle', () => {
+    const sg = createTestSubgraph()
+    const node = new LGraphNode('Node')
+    sg.add(node)
+    expect(() => sg.remove(node)).not.toThrow()
   })
 })

--- a/src/lib/litegraph/src/LGraphNode.nodeState.test.ts
+++ b/src/lib/litegraph/src/LGraphNode.nodeState.test.ts
@@ -183,22 +183,17 @@ describe('LGraphNode registerNodeState / unregisterNodeState invariants', () => 
   })
 
   it('asserts when unregistering after _state has drifted from the bucket', () => {
-    const { subgraph, node } = (() => {
-      const sg = createTestSubgraph()
-      const n = new LGraphNode('Node')
-      sg.add(n)
-      return { subgraph: sg, node: n }
-    })()
+    const sg = createTestSubgraph()
+    const node = new LGraphNode('Node')
+    sg.add(node)
 
     // Manually replace _state so unregister can't find the original identity.
     const originalState = node._state
-    // @ts-expect-error — deliberately corrupting internal state for test
     node._state = { ...originalState }
 
     expect(() => unregisterNodeState(node)).toThrow()
 
     // Restore so cleanup doesn't double-assert.
-    // @ts-expect-error — restore after corruption
     node._state = originalState
   })
 

--- a/src/lib/litegraph/src/LGraphNode.ts
+++ b/src/lib/litegraph/src/LGraphNode.ts
@@ -1,5 +1,7 @@
 import { shallowReactive, toValue } from 'vue'
 
+import { assert } from '@/base/assert'
+
 import {
   calculateInputSlotPosFromSlot,
   getSlotPosition
@@ -4462,6 +4464,11 @@ export function registerNodeState(
   node: LGraphNode
 ): boolean {
   const graphScope = graphScopeOf(graph)
+  assert(
+    node._graphScope === undefined ||
+      node._graphScope.rootGraphId === graphScope.rootGraphId,
+    `registerNodeState: node ${node.id} already registered under a different root graph`
+  )
   node._state.graphId = graph.id
   const registered = useNodeDataStore().registerNode(graphScope, node._state)
   if (!registered) return false
@@ -4477,7 +4484,11 @@ export function registerNodeState(
  */
 export function unregisterNodeState(node: LGraphNode): void {
   if (!node._graphScope) return
-  useNodeDataStore().deleteNode(node._graphScope, node._state)
+  const deleted = useNodeDataStore().deleteNode(node._graphScope, node._state)
+  assert(
+    deleted,
+    `unregisterNodeState: state for node ${node.id} not found in bucket (identity drift)`
+  )
   node._graphScope = undefined
 }
 

--- a/src/stores/nodeDataStore.test.ts
+++ b/src/stores/nodeDataStore.test.ts
@@ -62,32 +62,29 @@ describe('useNodeDataStore', () => {
     expect(store.getGraphNodesFor(rootA, sub).map((n) => n.id)).toEqual(['2'])
   })
 
-  it('rejects a duplicate id without changing either registration', () => {
+  it('asserts on duplicate (id, graphId) distinct-state registration', () => {
     const store = useNodeDataStore()
     const first = node(1)
     const duplicate = node(1, 'sub-1')
 
-    const registered = store.registerNode(graphScope(rootA, rootA), first)
-    const rejected = store.registerNode(graphScope(rootA, 'sub-1'), duplicate)
-
-    expect(registered?.id).toBe(first.id)
-    expect(rejected).toBeUndefined()
-    expect(duplicate.graphId).toBe('sub-1')
-    expect(store.getGraphNodesFor(rootA, rootA)).toEqual([registered])
-    expect(store.getGraphNodesFor(rootA, 'sub-1')).toEqual([])
+    store.registerNode(graphScope(rootA, rootA), first)
+    expect(() => store.registerNode(graphScope(rootA, 'sub-1'), duplicate)).toThrow()
   })
 
-  it('rejects the registered node identity from a sibling owner', () => {
+  it('asserts when the same state object is re-registered under a different owner', () => {
     const store = useNodeDataStore()
     const registered = node(1)
     store.registerNode(graphScope(rootA, rootA), registered)
 
-    expect(
-      store.registerNode(graphScope(rootA, 'sub-1'), registered)
-    ).toBeUndefined()
-    expect(registered.graphId).toBe(rootA)
-    expect(store.getGraphNodesFor(rootA, rootA)).toEqual([registered])
-    expect(store.getGraphNodesFor(rootA, 'sub-1')).toEqual([])
+    expect(() => store.registerNode(graphScope(rootA, 'sub-1'), registered)).toThrow()
+  })
+
+  it('does NOT assert on idempotent same-state re-registration', () => {
+    const store = useNodeDataStore()
+    const state = node(1)
+    const scope = graphScope(rootA, rootA)
+    const registered = store.registerNode(scope, state)!
+    expect(() => store.registerNode(scope, registered)).not.toThrow()
   })
 
   it('only deletes the registered identity from its owning graph', () => {

--- a/src/stores/nodeDataStore.test.ts
+++ b/src/stores/nodeDataStore.test.ts
@@ -68,7 +68,9 @@ describe('useNodeDataStore', () => {
     const duplicate = node(1, 'sub-1')
 
     store.registerNode(graphScope(rootA, rootA), first)
-    expect(() => store.registerNode(graphScope(rootA, 'sub-1'), duplicate)).toThrow()
+    expect(() =>
+      store.registerNode(graphScope(rootA, 'sub-1'), duplicate)
+    ).toThrow()
   })
 
   it('asserts when the same state object is re-registered under a different owner', () => {
@@ -76,7 +78,9 @@ describe('useNodeDataStore', () => {
     const registered = node(1)
     store.registerNode(graphScope(rootA, rootA), registered)
 
-    expect(() => store.registerNode(graphScope(rootA, 'sub-1'), registered)).toThrow()
+    expect(() =>
+      store.registerNode(graphScope(rootA, 'sub-1'), registered)
+    ).toThrow()
   })
 
   it('does NOT assert on idempotent same-state re-registration', () => {

--- a/src/stores/nodeDataStore.ts
+++ b/src/stores/nodeDataStore.ts
@@ -1,6 +1,7 @@
 import { defineStore } from 'pinia'
 import { reactive, toRaw } from 'vue'
 
+import { assert } from '@/base/assert'
 import { toOwningGraphId, toRootGraphId } from '@/types/graphScopeId'
 import type {
   GraphScope,
@@ -53,7 +54,13 @@ export const useNodeDataStore = defineStore('nodeData', () => {
       incumbent.graphId === graphScope.owningGraphId
     )
       return incumbent
-    if (incumbent) return undefined
+    if (incumbent) {
+      assert(
+        false,
+        `nodeDataStore: duplicate NodeState for node ${state.id} in graph ${state.graphId}`
+      )
+      return undefined
+    }
     const bucket = existingBucket ?? rootBucket(graphScope.rootGraphId)
     const registered: NodeState = reactive(
       Object.assign(state, { graphId: graphScope.owningGraphId })


### PR DESCRIPTION
## Summary

Closes [BE-5048](https://linear.app/comfyorg/issue/BE-5048/assert-registration-identity-invariants-in) / #15706

Three silent failure modes in the node-data-store registration lifecycle now assert in DEV instead of failing silently:

- **Cross-root re-registration** (`registerNodeState`): asserts `node._graphScope.rootGraphId` matches the new graph's root before mutating state — previously would strand the old bucket entry as a ghost
- **Identity drift on unregister** (`unregisterNodeState`): captures the `boolean` return from `deleteNode` and asserts it's `true` — catches cases where `_state` was reassigned after registration, leaving a ghost `NodeState` the renderer keeps drawing
- **Duplicate NodeState for same `(id, graphId)`** (`nodeDataStore.registerNode`): replaces the silent `return undefined` with an `assert(false, ...)` for the case where a genuinely different state object collides on the same id — idempotent same-object re-registration still returns early without asserting

## Test plan

- [ ] `pnpm test:unit` fully green (22 tests pass across `nodeDataStore.test.ts` and `LGraphNode.nodeState.test.ts`)
- [ ] New tests cover: cross-root assert, identity-drift assert, duplicate-identity assert, idempotent same-state re-registration does NOT assert, normal register→remove does NOT assert

🤖 Generated with [Claude Code](https://claude.com/claude-code)