### PR TITLE
chore: remove V1 persistence fallbacks past deadline, drop feature_flags console.log

### DIFF
--- a/src/platform/workflow/persistence/composables/useWorkflowPersistenceV2.ts
+++ b/src/platform/workflow/persistence/composables/useWorkflowPersistenceV2.ts
@@ -188,7 +188,6 @@ export function useWorkflowPersistenceV2() {
     if (
       sessionPath &&
       (await draftStore.loadPersistedWorkflow({
-        workflowName: null,
         preferredPath: sessionPath
       }))
     )
@@ -205,7 +204,6 @@ export function useWorkflowPersistenceV2() {
 
     // 3. Fall back to most recent draft
     return await draftStore.loadPersistedWorkflow({
-      workflowName: null,
       fallbackToLatestDraft: true
     })
   }

--- a/src/platform/workflow/persistence/migration/migrateV1toV2.test.ts
+++ b/src/platform/workflow/persistence/migration/migrateV1toV2.test.ts
@@ -2,12 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { hashPath } from '../base/hashUtil'
 import { readOpenPaths } from '../base/storageIO'
-import {
-  cleanupV1Data,
-  getMigrationStatus,
-  isV2MigrationComplete,
-  migrateV1toV2
-} from './migrateV1toV2'
+import { isV2MigrationComplete, migrateV1toV2 } from './migrateV1toV2'
 
 describe('migrateV1toV2', () => {
   const workspaceId = 'test-workspace'
@@ -157,53 +152,6 @@ describe('migrateV1toV2', () => {
       ]
       expect(index.order).toEqual(expectedOrder)
     })
-
-    it('keeps V1 data intact after migration', () => {
-      const v1Drafts = {
-        'workflows/test.json': {
-          data: '{}',
-          updatedAt: 1000,
-          name: 'test',
-          isTemporary: true
-        }
-      }
-      setV1Data(v1Drafts, ['workflows/test.json'])
-
-      migrateV1toV2(workspaceId)
-
-      // V1 data should still exist
-      expect(
-        localStorage.getItem(`Comfy.Workflow.Drafts:${workspaceId}`)
-      ).not.toBeNull()
-      expect(
-        localStorage.getItem(`Comfy.Workflow.DraftOrder:${workspaceId}`)
-      ).not.toBeNull()
-    })
-  })
-
-  describe('cleanupV1Data', () => {
-    it('removes V1 keys', () => {
-      setV1Data(
-        {
-          'workflows/test.json': {
-            data: '{}',
-            updatedAt: 1,
-            name: 'test',
-            isTemporary: true
-          }
-        },
-        ['workflows/test.json']
-      )
-
-      cleanupV1Data(workspaceId)
-
-      expect(
-        localStorage.getItem(`Comfy.Workflow.Drafts:${workspaceId}`)
-      ).toBeNull()
-      expect(
-        localStorage.getItem(`Comfy.Workflow.DraftOrder:${workspaceId}`)
-      ).toBeNull()
-    })
   })
 
   describe('V1 tab state migration', () => {
@@ -282,34 +230,6 @@ describe('migrateV1toV2', () => {
 
       // No tab state to migrate — should remain null
       expect(openPaths).toBeNull()
-    })
-  })
-
-  describe('getMigrationStatus', () => {
-    it('reports correct status', () => {
-      setV1Data(
-        {
-          'workflows/a.json': {
-            data: '{}',
-            updatedAt: 1,
-            name: 'a',
-            isTemporary: true
-          },
-          'workflows/b.json': {
-            data: '{}',
-            updatedAt: 2,
-            name: 'b',
-            isTemporary: true
-          }
-        },
-        ['workflows/a.json', 'workflows/b.json']
-      )
-
-      const status = getMigrationStatus(workspaceId)
-      expect(status.v1Exists).toBe(true)
-      expect(status.v2Exists).toBe(false)
-      expect(status.v1DraftCount).toBe(2)
-      expect(status.v2DraftCount).toBe(0)
     })
   })
 })

--- a/src/platform/workflow/persistence/migration/migrateV1toV2.ts
+++ b/src/platform/workflow/persistence/migration/migrateV1toV2.ts
@@ -3,7 +3,6 @@
  *
  * Migrates draft data from V1 blob format to V2 per-draft keys.
  * Runs once on first load if V2 index doesn't exist.
- * Keeps V1 data intact for rollback until 2026-07-15.
  */
 
 import type { DraftIndexV2 } from '../base/draftTypes'
@@ -165,41 +164,5 @@ function migrateV1TabState(workspaceId: string, clientId?: string): void {
     writeOpenPaths(clientId, { workspaceId, paths, activeIndex })
   } catch {
     // Best effort - don't block draft migration on tab state errors
-  }
-}
-
-/**
- * Cleans up V1 data after successful migration.
- * Should NOT be called until 2026-07-15 to allow rollback.
- */
-export function cleanupV1Data(workspaceId: string = getWorkspaceId()): void {
-  try {
-    localStorage.removeItem(V1_KEYS.drafts(workspaceId))
-    localStorage.removeItem(V1_KEYS.order(workspaceId))
-    localStorage.removeItem(V1_KEYS.openPaths)
-    localStorage.removeItem(V1_KEYS.activeIndex)
-    console.warn('[V2 Migration] Cleaned up V1 data')
-  } catch {
-    // Ignore cleanup errors
-  }
-}
-
-/**
- * Gets migration status for debugging.
- */
-export function getMigrationStatus(workspaceId: string = getWorkspaceId()): {
-  v1Exists: boolean
-  v2Exists: boolean
-  v1DraftCount: number
-  v2DraftCount: number
-} {
-  const v1Data = readV1Drafts(workspaceId)
-  const v2Index = readIndex(workspaceId)
-
-  return {
-    v1Exists: v1Data !== null,
-    v2Exists: v2Index !== null,
-    v1DraftCount: v1Data ? v1Data.order.length : 0,
-    v2DraftCount: v2Index ? v2Index.order.length : 0
   }
 }

--- a/src/platform/workflow/persistence/stores/workflowDraftStoreV2.test.ts
+++ b/src/platform/workflow/persistence/stores/workflowDraftStoreV2.test.ts
@@ -245,7 +245,6 @@ describe('workflowDraftStoreV2', () => {
       })
 
       const result = await store.loadPersistedWorkflow({
-        workflowName: 'test',
         preferredPath: 'workflows/test.json'
       })
 
@@ -261,7 +260,6 @@ describe('workflowDraftStoreV2', () => {
       })
 
       const result = await store.loadPersistedWorkflow({
-        workflowName: null,
         preferredPath: 'workflows/missing.json',
         fallbackToLatestDraft: true
       })
@@ -273,7 +271,6 @@ describe('workflowDraftStoreV2', () => {
       const store = useWorkflowDraftStoreV2()
 
       const result = await store.loadPersistedWorkflow({
-        workflowName: null,
         fallbackToLatestDraft: true
       })
 

--- a/src/platform/workflow/persistence/stores/workflowDraftStoreV2.ts
+++ b/src/platform/workflow/persistence/stores/workflowDraftStoreV2.ts
@@ -34,7 +34,6 @@ import {
   writeIndex,
   writePayload
 } from '../base/storageIO'
-import { api } from '@/scripts/api'
 import { app as comfyApp } from '@/scripts/app'
 
 interface DraftMeta {
@@ -43,7 +42,6 @@ interface DraftMeta {
 }
 
 interface LoadPersistedWorkflowOptions {
-  workflowName: string | null
   preferredPath?: string | null
   fallbackToLatestDraft?: boolean
 }
@@ -344,11 +342,7 @@ export const useWorkflowDraftStoreV2 = defineStore('workflowDraftV2', () => {
   async function loadPersistedWorkflow(
     options: LoadPersistedWorkflowOptions
   ): Promise<boolean> {
-    const {
-      workflowName,
-      preferredPath,
-      fallbackToLatestDraft = false
-    } = options
+    const { preferredPath, fallbackToLatestDraft = false } = options
 
     // 1. Try preferred path
     if (preferredPath && (await loadDraft(preferredPath))) {
@@ -363,33 +357,7 @@ export const useWorkflowDraftStoreV2 = defineStore('workflowDraftV2', () => {
       }
     }
 
-    // Legacy fallbacks are NOT workspace-scoped and must only be used for
-    // personal workspace to prevent cross-workspace data leakage.
-    // These exist only for migration from V1 and should be removed after 2026-07-15.
-    if (currentWorkspaceId() !== 'personal') {
-      return false
-    }
-
-    // 3. Legacy fallback: sessionStorage payload (remove after 2026-07-15)
-    const clientId = api.initialClientId ?? api.clientId
-    if (clientId) {
-      try {
-        const sessionPayload = sessionStorage.getItem(`workflow:${clientId}`)
-        if (await tryLoadGraph(sessionPayload, workflowName)) {
-          return true
-        }
-      } catch {
-        // Ignore storage access errors and continue fallback chain
-      }
-    }
-
-    // 4. Legacy fallback: localStorage payload (remove after 2026-07-15)
-    try {
-      const localPayload = localStorage.getItem('workflow')
-      return await tryLoadGraph(localPayload, workflowName)
-    } catch {
-      return false
-    }
+    return false
   }
 
   /**

--- a/src/scripts/api.ts
+++ b/src/scripts/api.ts
@@ -892,12 +892,7 @@ export class ComfyApi extends EventTarget {
               this.dispatchCustomEvent('autoQueueGraphChanged')
               break
             case 'feature_flags':
-              // Store server feature flags
               this.serverFeatureFlags.value = msg.data
-              console.log(
-                'Server feature flags received:',
-                this.serverFeatureFlags.value
-              )
               this.dispatchCustomEvent('feature_flags', msg.data)
               break
             default:


### PR DESCRIPTION
Items from the 2026-07-15 rollback window, now expired, plus a production console.log.

**What changed:**

- `workflowDraftStoreV2`: removed legacy session/localStorage restore fallbacks (steps 3 & 4 in `loadPersistedWorkflow`, guarded by `remove after 2026-07-15` comments); removed `workflowName` from `LoadPersistedWorkflowOptions` (was only consumed by those fallbacks)
- `migrateV1toV2`: deleted `cleanupV1Data` and `getMigrationStatus` — both had zero production call sites (tests only)
- `api.ts`: dropped `console.log` of full server feature-flags payload logged on every WS connection
- Tests and callers updated accordingly; `migrateV1toV2` function itself and `V1_KEYS` retained (still called from `useWorkflowPersistenceV2` for users upgrading from V1)

**Verified by running:**
- `pnpm exec vitest run src/platform/workflow/persistence/migration/migrateV1toV2.test.ts src/platform/workflow/persistence/stores/workflowDraftStoreV2.test.ts src/platform/workflow/persistence/composables/useWorkflowPersistenceV2.test.ts` — 55 tests pass
- `pnpm typecheck` — clean (run by pre-commit hook)
- Positive control `src/lib/litegraph/src/LLink.test.ts` passes before and after

Fixes #15663