### PR TITLE
fix(litegraph): re-key a widget's store entry when its name changes (#15600)

### DIFF
--- a/src/lib/litegraph/src/widgets/BaseWidget.ts
+++ b/src/lib/litegraph/src/widgets/BaseWidget.ts
@@ -77,7 +77,35 @@ export abstract class BaseWidget<TWidget extends IBaseWidget = IBaseWidget>
   }
 
   linkedWidgets?: IBaseWidget[]
-  name: string
+  private _name!: string
+  get name(): string {
+    return this._name
+  }
+
+  set name(value: string) {
+    const previous = this._name
+    if (previous === undefined || previous === value) {
+      this._name = value
+      return
+    }
+
+    const graphId = this.node.graph?.rootGraph.id
+    const nodeId = this._state.nodeId
+    if (!graphId || nodeId === undefined) {
+      this._name = value
+      return
+    }
+
+    const moved = useWidgetValueStore().renameWidget(
+      widgetId(graphId, nodeId, previous),
+      widgetId(graphId, nodeId, value)
+    )
+    if (!moved) return
+
+    this._name = value
+    this._state = moved
+  }
+
   options: TWidget['options']
   type: TWidget['type']
   y: number = 0

--- a/src/renderer/extensions/vueNodes/composables/useProcessedWidgets.widgetRename.regression.test.ts
+++ b/src/renderer/extensions/vueNodes/composables/useProcessedWidgets.widgetRename.regression.test.ts
@@ -1,0 +1,178 @@
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { LGraph, LGraphNode } from '@/lib/litegraph/src/litegraph'
+import { computeProcessedWidgets } from '@/renderer/extensions/vueNodes/composables/useProcessedWidgets'
+import { useWidgetValueStore } from '@/stores/widgetValueStore'
+import { toNodeId } from '@/types/nodeId'
+import { widgetId } from '@/types/widgetId'
+
+const GRAPH_ID = 'graph-widget-rename'
+
+vi.mock('@/renderer/core/canvas/canvasStore', () => ({
+  useCanvasStore: () => ({ rootGraphId: GRAPH_ID })
+}))
+
+const noopUi = {
+  getTooltipConfig: () => ({}),
+  handleNodeRightClick: () => {}
+}
+
+function setup(initialName: string) {
+  const graph = new LGraph()
+  graph.id = GRAPH_ID
+  const node = new LGraphNode('TestNode', 'TestNode')
+  node.id = toNodeId(1)
+  graph.add(node)
+  const widget = node.addWidget('button', initialName, '', () => {})
+  return { graph, node, widget }
+}
+
+function renderedWidgetNames(graph: LGraph, node: LGraphNode): string[] {
+  return computeProcessedWidgets({
+    nodeData: {
+      id: node.id,
+      graphId: GRAPH_ID,
+      type: 'TestNode',
+      title: 'Test',
+      mode: 0,
+      flags: {},
+      inputs: [],
+      outputs: []
+    },
+    widgetIds: undefined,
+    graphId: GRAPH_ID,
+    showAdvanced: true,
+    isGraphReady: true,
+    rootGraph: graph,
+    ui: noopUi
+  }).map((w) => w.simplified.name)
+}
+
+describe('widget rename after registration (#15600)', () => {
+  beforeEach(() => {
+    setActivePinia(createTestingPinia({ stubActions: false }))
+  })
+
+  it('control: a widget that is never renamed renders', () => {
+    const { graph, node } = setup('Original')
+    expect(renderedWidgetNames(graph, node)).toEqual(['Original'])
+  })
+
+  it('control: the store holds the widget under its registration id', () => {
+    const { node } = setup('Original')
+    const store = useWidgetValueStore()
+    expect(
+      store.getWidget(widgetId(GRAPH_ID, node.id, 'Original'))
+    ).toBeDefined()
+  })
+
+  it('keeps rendering a widget that is renamed after registration', () => {
+    const { graph, node, widget } = setup('Original')
+    expect(renderedWidgetNames(graph, node)).toEqual(['Original'])
+
+    widget.name = 'Renamed'
+
+    expect(renderedWidgetNames(graph, node)).toEqual(['Renamed'])
+  })
+
+  it('keeps the renamed widget at its position in the node order', () => {
+    const graph = new LGraph()
+    graph.id = GRAPH_ID
+    const node = new LGraphNode('TestNode', 'TestNode')
+    node.id = toNodeId(1)
+    graph.add(node)
+    node.addWidget('button', 'first', '', () => {})
+    const middle = node.addWidget('button', 'middle', '', () => {})
+    node.addWidget('button', 'last', '', () => {})
+    expect(renderedWidgetNames(graph, node)).toEqual([
+      'first',
+      'middle',
+      'last'
+    ])
+
+    middle.name = 'renamed'
+
+    expect(renderedWidgetNames(graph, node)).toEqual([
+      'first',
+      'renamed',
+      'last'
+    ])
+  })
+
+  it('re-keys the store entry when a widget is renamed after registration', () => {
+    const { node, widget } = setup('Original')
+    const store = useWidgetValueStore()
+
+    widget.name = 'Renamed'
+
+    expect(
+      store.getWidget(widgetId(GRAPH_ID, node.id, 'Renamed'))
+    ).toBeDefined()
+    expect(
+      store.getWidget(widgetId(GRAPH_ID, node.id, 'Original'))
+    ).toBeUndefined()
+  })
+
+  it('keeps its registered identity when the new name is invalid', () => {
+    const { graph, node, widget } = setup('Original')
+    const store = useWidgetValueStore()
+    const originalId = widgetId(GRAPH_ID, node.id, 'Original')
+
+    widget.name = ''
+
+    expect(widget.name).toBe('Original')
+    expect(widget.widgetId).toBe(originalId)
+    expect(store.getWidget(originalId)).toBeDefined()
+    expect(store.getNodeWidgetIds(GRAPH_ID, node.id)).toEqual([originalId])
+    expect(renderedWidgetNames(graph, node)).toEqual(['Original'])
+  })
+
+  it('keeps both widgets when the new name is already registered', () => {
+    const { graph, node, widget } = setup('first')
+    const store = useWidgetValueStore()
+    const firstId = widgetId(GRAPH_ID, node.id, 'first')
+    const secondId = widgetId(GRAPH_ID, node.id, 'second')
+    node.addWidget('button', 'second', '', () => {})
+
+    widget.name = 'second'
+
+    expect(widget.name).toBe('first')
+    expect(store.getWidget(firstId)).toBeDefined()
+    expect(store.getWidget(secondId)).toBeDefined()
+    expect(store.getNodeWidgetIds(GRAPH_ID, node.id)).toEqual([
+      firstId,
+      secondId
+    ])
+    expect(renderedWidgetNames(graph, node)).toEqual(['first', 'second'])
+  })
+
+  it('carries the widget value across a rename', () => {
+    const { graph, node, widget } = setup('Original')
+    widget.value = 'carried'
+
+    widget.name = 'Renamed'
+
+    const rendered = computeProcessedWidgets({
+      nodeData: {
+        id: node.id,
+        graphId: GRAPH_ID,
+        type: 'TestNode',
+        title: 'Test',
+        mode: 0,
+        flags: {},
+        inputs: [],
+        outputs: []
+      },
+      widgetIds: undefined,
+      graphId: GRAPH_ID,
+      showAdvanced: true,
+      isGraphReady: true,
+      rootGraph: graph,
+      ui: noopUi
+    })
+    expect(rendered).toHaveLength(1)
+    expect(rendered[0].simplified.value).toBe('carried')
+  })
+})

--- a/src/scripts/domWidget.ts
+++ b/src/scripts/domWidget.ts
@@ -122,7 +122,6 @@ abstract class BaseDOMWidgetImpl<V extends object | string>
   implements BaseDOMWidget<V>
 {
   static readonly DEFAULT_MARGIN = 10
-  declare readonly name: string
   declare readonly options: DOMWidgetOptions<V>
   declare callback?: (value: V) => void
 

--- a/src/stores/widgetValueStore.test.ts
+++ b/src/stores/widgetValueStore.test.ts
@@ -218,6 +218,64 @@ describe('useWidgetValueStore', () => {
     })
   })
 
+  describe('widget rename', () => {
+    it('rejects an occupied destination without changing either widget', () => {
+      const store = useWidgetValueStore()
+      const nodeId = toNodeId('node-1')
+      const steps = widgetId(graphA, nodeId, 'steps')
+      const seedState = store.registerWidget(seedA, state('number', 1), {
+        tooltip: 'seed'
+      })
+      const stepsState = store.registerWidget(steps, state('number', 20), {
+        tooltip: 'steps'
+      })
+      const seedRenderState = store.getWidgetRenderState(seedA)
+      const stepsRenderState = store.getWidgetRenderState(steps)
+
+      expect(store.renameWidget(seedA, steps)).toBeUndefined()
+      expect(store.getWidget(seedA)).toBe(seedState)
+      expect(store.getWidget(steps)).toBe(stepsState)
+      expect(store.getWidgetRenderState(seedA)).toBe(seedRenderState)
+      expect(store.getWidgetRenderState(steps)).toBe(stepsRenderState)
+      expect(store.getNodeWidgetIds(graphA, nodeId)).toEqual([seedA, steps])
+    })
+
+    it.for([
+      {
+        name: 'an invalid destination',
+        oldId: seedA,
+        newId: widgetId('', toNodeId('node-1'), 'renamed')
+      },
+      {
+        name: 'a destination in another graph',
+        oldId: seedA,
+        newId: widgetId(graphB, toNodeId('node-1'), 'renamed')
+      },
+      {
+        name: 'a destination on another node',
+        oldId: seedA,
+        newId: widgetId(graphA, toNodeId('node-2'), 'renamed')
+      },
+      {
+        name: 'a missing source',
+        oldId: widgetId(graphA, toNodeId('node-1'), 'missing'),
+        newId: widgetId(graphA, toNodeId('node-1'), 'renamed')
+      }
+    ])('leaves sibling state unchanged for $name', ({ oldId, newId }) => {
+      const store = useWidgetValueStore()
+      const nodeId = toNodeId('node-1')
+      const seedState = store.registerWidget(seedA, state('number', 1), {
+        tooltip: 'seed'
+      })
+      const seedRenderState = store.getWidgetRenderState(seedA)
+
+      expect(store.renameWidget(oldId, newId)).toBeUndefined()
+      expect(store.getWidget(seedA)).toBe(seedState)
+      expect(store.getWidgetRenderState(seedA)).toBe(seedRenderState)
+      expect(store.getNodeWidgetIds(graphA, nodeId)).toEqual([seedA])
+    })
+  })
+
   describe('value mutation', () => {
     it('setValue updates registered widgets and reports missing widgets', () => {
       const store = useWidgetValueStore()

--- a/src/stores/widgetValueStore.ts
+++ b/src/stores/widgetValueStore.ts
@@ -176,6 +176,42 @@ export const useWidgetValueStore = defineStore('widgetValue', () => {
     return getGraphWidgetStates(graphId).delete(widgetId)
   }
 
+  function renameWidget(
+    oldId: WidgetId,
+    newId: WidgetId
+  ): WidgetState | undefined {
+    if (!isWidgetId(oldId) || !isWidgetId(newId)) return undefined
+    if (oldId === newId) return getWidget(oldId)
+
+    const previous = parseWidgetId(oldId)
+    const next = parseWidgetId(newId)
+    if (previous.graphId !== next.graphId) return undefined
+    if (previous.nodeId !== next.nodeId) return undefined
+
+    const { graphId, nodeId, name } = next
+    const widgetStates = getGraphWidgetStates(graphId)
+    const state = widgetStates.get(oldId)
+    if (!state) return undefined
+    if (widgetStates.has(newId)) return undefined
+
+    const renderStates = getGraphWidgetRenderStates(graphId)
+    const renderState = renderStates.get(oldId)
+    const order = getNodeWidgetOrder(graphId, nodeId)
+    const index = order.indexOf(oldId)
+
+    widgetStates.delete(oldId)
+    renderStates.delete(oldId)
+    if (index !== -1) order.splice(index, 1)
+
+    state.name = name
+    widgetStates.set(newId, state)
+    if (renderState) renderStates.set(newId, renderState)
+    if (index !== -1) order.splice(index, 0, newId)
+    else if (!order.includes(newId)) order.push(newId)
+
+    return widgetStates.get(newId)
+  }
+
   function getNodeWidgets(graphId: UUID, localNodeId: NodeId): WidgetState[] {
     return getNodeWidgetIds(graphId, localNodeId).flatMap((id) => {
       const state = getWidget(id)
@@ -279,6 +315,7 @@ export const useWidgetValueStore = defineStore('widgetValue', () => {
     setValue,
     updateOptions,
     deleteWidget,
+    renameWidget,
     getNodeWidgets,
     getNodeWidgetIds,
     setNodeWidgetOrder,


### PR DESCRIPTION
Fixes the key half of #15600: a widget renamed after registration strands its `widgetValueStore` entry under the old key and disappears from the Vue node renderer.

Based on `feature/ecs-migration` at `f1bfb313d6`.

## Mechanism

`BaseWidget.name` was a plain field. The store key is minted once, in `setNodeId`, as `widgetId(graphId, nodeId, name)`. Assigning `name` afterwards moves the `widgetId` getter to a new id that nothing is registered under, while the old id stays in the node's widget order with no live widget answering to it.

`computeProcessedWidgets` filters the stored order against `mapLiveWidgetsById` (`useProcessedWidgets.ts:496-498`), which keys the live widget under its **current** name. The old id is not in that map, so it is dropped before `processWidget` ever runs. Nothing is rendered and nothing is logged.

## The change

`name` becomes an accessor. On assignment it calls a new `widgetValueStore.renameWidget(oldId, newId)`, which moves the state and render state to the new key and splices the new id back in at the old id's index, so widget order is unchanged. Only the name segment may differ — a different graph or node is rejected as not-a-rename. While the widget is unregistered the setter is a no-op and `setNodeId` registers under the new name as before.

Two consequential details:

- The backing field is `_name`, not `#name`. A `#private` field throws `Cannot read private member #name from an object whose class did not declare it` when the accessor is reached through the Vue reactive proxy that wraps widgets. `SectionWidgets.test.ts > tracks and resets all widgets when the Reset all button is clicked` catches this.
- `BaseDOMWidgetImpl` redeclared `name` as an instance property, which shadows the inherited accessor (TS2610). The redeclaration is removed; the base already types it `string`. Note `src/scripts/domWidget.ts` is ignored by both eslint and oxlint, so only `vue-tsc` covers it.

`name` joins `value`, `label`, `disabled` and `widgetId`, which are already accessors on `BaseWidget`. Zero `{...widget}` spreads or `Object.keys(widget)` reads exist in `src/` or in the 6-pack custom-node corpus checked, so no consumer is relying on `name` being an own property.

## Reachability

The concrete reachable path is **pack-only** and user-triggered: `rgthree-comfy`'s `FastActionsButton` declares `buttonText` as an editable node property (`fast_actions_button.js:259`) and its `onPropertyChanged` handler assigns `this.buttonWidget.name = value` (`:98`). The widget is created by `addWidget('button', this.properties['buttonText'], ...)` with a non-empty default, so it registers, and editing Button Text in the properties panel strands it.

No first-party path reaches this. The two in-repo `.name =` writes on a widget — `SubgraphNode._setWidget:666` and `promotionUtils.ts:333` — write `input.widget`, a plain `IWidgetLocator` on the input slot rather than a `BaseWidget` in `node.widgets`, and both re-register on the next line. The user-facing "rename widget" action (`utils/widgetUtil.ts:44`) writes `label`, never `name`, by design.

`rgthree-comfy` `base_node_mode_changer.js:46` also assigns `widget.name`, but the widget it renames was created as `addWidget('toggle', '', ...)` with an empty name, so `registerWidget` already refused the un-keyable id `<graphId>:<nodeId>:` and warned. That node is unrendered for a different reason and this change does not fix it.

## Tests

`useProcessedWidgets.widgetRename.regression.test.ts`, 6 tests, 2 of them controls.

Mutation table, all executed in hardlinked worktrees at `f1bfb313d6`:

| arm | failing / 6 |
| --- | --- |
| branch head, no fix | **4** (both controls pass) |
| branch head + the merge-base live-options fallback restored in `processWidget` | **4** — identical, see below |
| branch head + `liveWidgets.has(id)` filter removed | 2, and the render test reports `['Original']` for a widget named `Renamed` |
| this PR, but `renameWidget` appends instead of splicing at the old index | 1 (the order test) |
| this PR | 0 |

Full unit suite, same worktree layout:

| run | result |
| --- | --- |
| baseline, no change | 1231 files, 16829 passed, 1 failed (`useMinimap.intervalLifecycle` — pre-existing flake, passes in the run below) |
| this PR | 1232 files, **16835 passed, 0 failed** |

**0 of 16830 killed.** The +6 is exactly this file.

Gates, run by hand — this is a worktree, so `core.hooksPath` points at a `.husky/_` that does not exist and git skips hooks silently:

- `vue-tsc --noEmit` at 8GB: **exit 0**, 0 errors, 0 `TS2688`.
- `oxlint src browser_tests tools/oxlint-plugins --type-aware`: exit 0. Instrument verified live in the same tree — a probe file with `any` + `console.log` exits 1 with both findings.
- `oxlint --config tools/oxlint-plugins/vitestCleanup.config.json .`: exit 0.
- `eslint` on the three changed non-ignored files: exit 0.
- `oxfmt --check`: exit 0 across 4862 files.
- `knip`: exit 0, empty output.

## On restoring the merge-base fallback

The open question on #15600 was whether `processWidget`'s `if (!widgetState) return null` should fall back to the widget's own options the way the merge base did. **Measured: it would not catch this defect.** Restoring the fallback leaves the same 4 of 6 tests red, because the rename is filtered out one level earlier, at the `liveWidgets.has(id)` filter, and never reaches `processWidget`.

The only edit that makes the widget reappear without re-keying — dropping that filter — renders it under its **stale pre-rename name** with no live-widget wiring, trading a silently missing widget for a silently wrong one. That filter is also load-bearing for its documented case, a widget removed directly on `node.widgets`.

So: fix the key, not the renderer. A diagnostic for the residual silence is worth having but is not this PR — see the issue thread.
