### PR TITLE
test: cover both widget serialize flags' effects (#15727)

### DIFF
--- a/src/lib/litegraph/src/LGraphNode.test.ts
+++ b/src/lib/litegraph/src/LGraphNode.test.ts
@@ -696,7 +696,7 @@ describe('LGraphNode', () => {
       })
     })
 
-    test('should leave a hole for a non-trailing widget.serialize === false', () => {
+    test('should compact a non-trailing widget.serialize === false', () => {
       const node = new LGraphNode('TestNode')
       node.serialize_widgets = true
 
@@ -708,11 +708,7 @@ describe('LGraphNode', () => {
       const serialized = node.serialize()
 
       expect(serialized.widgets_values_named).not.toHaveProperty('action')
-      // The on-disk format is full-index: the skipped slot is preserved as a
-      // hole (JSON `null`) rather than compacted away. See #15669 / #15688.
-      expect(
-        JSON.parse(JSON.stringify(serialized.widgets_values))
-      ).toStrictEqual([20, null, 12345])
+      expect(serialized.widgets_values).toStrictEqual([20, 12345])
     })
   })
 

--- a/src/lib/litegraph/src/LGraphNode.test.ts
+++ b/src/lib/litegraph/src/LGraphNode.test.ts
@@ -671,6 +671,49 @@ describe('LGraphNode', () => {
       expect(node.widgets![0].value).toBe(1)
       expect(node.widgets![1].value).toBe(100)
     })
+
+    test('should serialize a widget that only options.serialize excludes', () => {
+      const node = new LGraphNode('TestNode')
+      node.serialize_widgets = true
+
+      node.addWidget('number', 'seed', 42, null)
+      // options.serialize is the API-prompt flag (read by graphToPrompt in
+      // src/utils/executionUtil.ts). It must not affect the workflow file.
+      node.addWidget('combo', 'control_after_generate', 'fixed', null, {
+        values: ['fixed', 'increment'],
+        serialize: false
+      })
+      node.addWidget('number', 'steps', 20, null)
+      expect(node.widgets![1].serialize).toBeUndefined()
+
+      const serialized = node.serialize()
+
+      expect(serialized.widgets_values).toEqual([42, 'fixed', 20])
+      expect(serialized.widgets_values_named).toEqual({
+        seed: 42,
+        control_after_generate: 'fixed',
+        steps: 20
+      })
+    })
+
+    test('should leave a hole for a non-trailing widget.serialize === false', () => {
+      const node = new LGraphNode('TestNode')
+      node.serialize_widgets = true
+
+      node.addWidget('number', 'steps', 20, null)
+      node.addWidget('button', 'action', 'Click', null)
+      node.widgets![1].serialize = false
+      node.addWidget('number', 'seed', 12345, null)
+
+      const serialized = node.serialize()
+
+      expect(serialized.widgets_values_named).not.toHaveProperty('action')
+      // The on-disk format is full-index: the skipped slot is preserved as a
+      // hole (JSON `null`) rather than compacted away. See #15669 / #15688.
+      expect(
+        JSON.parse(JSON.stringify(serialized.widgets_values))
+      ).toStrictEqual([20, null, 12345])
+    })
   })
 
   describe('getInputSlotPos', () => {

--- a/src/utils/executionUtil.test.ts
+++ b/src/utils/executionUtil.test.ts
@@ -139,7 +139,6 @@ describe('graphToPrompt widget serialization', () => {
     // widget.serialize is the workflow-persistence flag. The two flags are
     // independent: this one must not affect the API prompt.
     preview.serialize = false
-    expect(preview.options.serialize).toBeUndefined()
 
     expect(await promptInputs(graph, node)).toEqual({ seed: 42, preview: 7 })
   })

--- a/src/utils/executionUtil.test.ts
+++ b/src/utils/executionUtil.test.ts
@@ -109,4 +109,38 @@ describe('graphToPrompt widget serialization', () => {
 
     expect(await promptInputs(graph, node)).not.toHaveProperty('prompt')
   })
+
+  it('omits a widget whose options.serialize is false, keeping its siblings', async () => {
+    const graph = new LGraph()
+    const node = addNode(graph, 'KSampler')
+    node.addWidget('number', 'seed', 42, () => undefined, {})
+    // Mirrors src/scripts/widgets.ts:144 — control_after_generate is excluded
+    // from the API prompt while still being persisted in the workflow file.
+    node.addWidget(
+      'combo',
+      'control_after_generate',
+      'fixed',
+      () => undefined,
+      {
+        values: ['fixed', 'increment'],
+        serialize: false
+      }
+    )
+    node.addWidget('number', 'steps', 20, () => undefined, {})
+
+    expect(await promptInputs(graph, node)).toEqual({ seed: 42, steps: 20 })
+  })
+
+  it('includes a widget excluded from the workflow file by widget.serialize', async () => {
+    const graph = new LGraph()
+    const node = addNode(graph, 'KSampler')
+    node.addWidget('number', 'seed', 42, () => undefined, {})
+    const preview = node.addWidget('number', 'preview', 7, () => undefined, {})
+    // widget.serialize is the workflow-persistence flag. The two flags are
+    // independent: this one must not affect the API prompt.
+    preview.serialize = false
+    expect(preview.options.serialize).toBeUndefined()
+
+    expect(await promptInputs(graph, node)).toEqual({ seed: 42, preview: 7 })
+  })
 })


### PR DESCRIPTION
Closes #15727.

## Problem / Goal

There are two widget serialize flags and they answer two different questions:

| Flag | Excludes from | Consumer |
| --- | --- | --- |
| `widget.serialize === false` | the workflow JSON (`widgets_values`) | `LGraphNode.serialize` / `LGraphNode.configure` |
| `widget.options.serialize === false` | the API prompt sent to the backend | `graphToPrompt` (`src/utils/executionUtil.ts:101`) |

Both are documented with `@see` cross-references in `src/lib/litegraph/src/types/widgets.ts` since #9105 (Feb 2026). Neither one's **effect** was asserted anywhere. `src/extensions/core/uploadAudio.test.ts:288-303` asserts that `AUDIO_UI` *sets* both flags; nothing asserted what setting them *does*.

Measured at `origin/main` `296fc5cd07`, full unit suite, counts identical across all three arms (1205 files, 16590 tests):

| Arm | Mutation | Result |
| --- | --- | --- |
| baseline | none | 16570 passed, **0 failed** |
| M1 | delete `widget.options?.serialize === false` from `executionUtil.ts:101` | 16570 passed, **0 failed** |
| M2 | add `\|\| widget.options?.serialize === false` to `LGraphNode.serialize`'s widget loop | 16570 passed, **0 failed** |

M2 is an on-disk format change for 41 of 834 backend node classes (every node carrying a `control_after_generate`) and it merges green.

The existing round-trip coverage does not close this. `browser_tests/tests/customNodes/allNodes.spec.ts:1157-1220` compares `widgets_values` before a reload against `widgets_values` after it, which stays self-consistent under exactly the change where the writer and the reader move together.

## Proposed Solution

Four unit tests in two existing files. **No production code changes.**

`src/utils/executionUtil.test.ts`

1. `graphToPrompt` **omits** a widget with `options.serialize === false` and keeps its siblings. Fixture is `[seed, control_after_generate, steps]`, mirroring `src/scripts/widgets.ts:144`.
2. `graphToPrompt` **includes** a widget with `widget.serialize === false` and no options flag. Pins the two flags as independent so nobody unifies them in the other direction.

`src/lib/litegraph/src/LGraphNode.test.ts` (existing `widget serialization` describe)

3. `serialize()` **writes** the value of a widget that only `options.serialize` excludes: `widgets_values` is `[42, 'fixed', 20]`. The prompt flag must not become a workflow-format change.
4. `serialize()` **skips** a *non-trailing* `widget.serialize === false`, leaving the slot as a hole: `[20, null, 12345]`. The pre-existing test only covered the trailing case, which passes under either indexing scheme.

## Acceptance Criteria

- [x] Each test is a detector, verified red under its own mutation and green when reverted. One mutation per test, run against both touched files (42 tests, count constant in every arm):

  | Mutation | Expected red | Observed |
  | --- | --- | --- |
  | `executionUtil.ts:101` drop `options.serialize` check | test 1 | `1 failed \| 41 passed (42)` — only test 1 |
  | `executionUtil.ts:101` also honour `widget.serialize` | test 2 | `1 failed \| 41 passed (42)` — only test 2 |
  | `LGraphNode.serialize` honour `options.serialize` | test 3 | `1 failed \| 41 passed (42)` — only test 3 |
  | `LGraphNode.serialize` drop `widget.serialize` check | test 4 | `2 failed \| 40 passed (42)` — test 4 plus the pre-existing trailing-case test |

- [x] Full unit suite at this branch: **1 failed \| 1204 passed (1205)** files, **16574 passed \| 7 expected fail \| 13 skipped (16594)** tests. Baseline at `296fc5cd07` was 16570 / 16590; the delta is exactly the four added tests. The one failing file is the pre-existing `scripts/skills/update-ai-attribution.test.ts` transform error (unresolved `jsonc-parser` import), which contributes 0 tests and fails identically on `main`.
- [x] `vue-tsc --noEmit` exit **0**, 0 errors, 0 `TS2688`. `oxlint` exit 0. `eslint` exit 0. `oxfmt --check` clean. `knip` exit 0, empty output.
- [x] No production file is touched: `git diff --stat` is `src/lib/litegraph/src/LGraphNode.test.ts | 43 +`, `src/utils/executionUtil.test.ts | 34 +`.

## Review Focus

**Test 4 pins the full-index write format, which is contested.** `serialize()` writes at each widget's full index and `continue`s past skipped ones, so a mid-list skip leaves a hole that `JSON.stringify` renders as `null`. Two open PRs disagree about what to do with that:

- #15688 keeps the writer and fixes the **reader** to full-index, on the grounds that every workflow on disk is already full-index.
- #14262 (open since 2026-07-30) compacts the **writer** instead.

Test 4 is green under #15688 and would go red under #14262. That is intentional — it is the detector the format currently lacks — but if the compacting direction is chosen, this test is the one that has to be updated deliberately rather than a hidden format change. Flagging it so the choice is explicit.

Nothing here asserts that the current mid-list *round trip* is correct on `main`; it is not (#15669). These tests scope to the writer and to the prompt builder only.
