### PR TITLE
docs(registry-census): separate corpus size from executed count

### DIFF
--- a/scripts/registry-census/README.md
+++ b/scripts/registry-census/README.md
@@ -1,7 +1,14 @@
 # Registry corpus & ecosystem matrix
 
-A PR advisory that executes the frontend JS of every registry pack (~5,100
-packs) against the commit under review and reports a population verdict.
+A PR advisory that mirrors every registry pack (~5,100) and executes the
+frontend JS of the ~1,900 that ship any, against the commit under review, and
+reports a population verdict.
+
+**The corpus size and the executed count are different numbers, and the verdict
+is against the executed count.** Roughly 3,100 packs ship no extension-shaped JS
+and are skipped by `build_matrix.py`, so quoting the corpus size as the number of
+packs tested overstates the evidence by about 2.6x. `matrix-verdict` prints both:
+`packs with extension JS executed: 1945 (no-JS packs ignored: 3098)`.
 
 Vendored from `Comfy-Org/ComfyUI_ECS_Compat_Check` (`compat/paths.py`,
 `fetch_corpus.py`, `refresh_registry.py`), a private migration-phase
@@ -202,7 +209,10 @@ array-concatenation would otherwise smuggle in.
 The rules are load-bearing, not incidental:
 
 - **No secret may ever be added to a pack-executing job.** `ecosystem-matrix`
-  and `matrix-detection-proof` run unreviewed code from ~5,100 repositories.
+  and `matrix-detection-proof` run unreviewed code from ~1,900 repositories,
+  selected from a corpus of ~5,100 by a rule any pack author can satisfy at
+  will — shipping one JS file moves a pack into the executing set, so treat the
+  blast radius as the whole registry.
   Adding a Slack webhook, a token, or `id-token: write` to either job hands
   that credential to every pack author in the registry. If you need to
   notify on failure, do it from a separate `workflow_run` job.


### PR DESCRIPTION
## Problem / Goal

`scripts/registry-census/README.md` opens with:

> A PR advisory that executes the frontend JS of **every registry pack (~5,100 packs)** against the commit under review and reports a population verdict.

It does not execute every pack. ~3,100 of them ship no extension-shaped JS and are skipped by `build_matrix.py:233` (`{'skipped': 'no extension-shaped JS'}`). The population the verdict is actually computed over is **1,945**.

The workflow already states this correctly — `ci-ecosystem-matrix.yaml:257` says *"executed ~1,900 packs' code"*. Only the README, the doc people read first, carries the overstatement, and that figure is currently being quoted into an ecosystem sign-off at ~2.6x its true value.

## Proposed Solution

Say both numbers and say which one the verdict is against. Two edits, no behaviour change.

1. Opening paragraph — corpus (~5,100 mirrored) vs executed (~1,900), plus the `matrix-verdict` line that prints both.
2. The pack-execution security note — the count changes from ~5,100 repos to ~1,900, but the *rule* must not weaken, so it is reworded rather than renumbered: any pack author can join the executing set by shipping one JS file, so the blast radius is still the whole registry.

## Acceptance Criteria

- [x] The README distinguishes the mirrored corpus from the executed population.
- [x] The security rule's strength is unchanged despite the smaller literal count.
- [x] Every number is taken from a job log, not from a doc.
- [x] `pnpm format:check` clean.

## Testing

Documentation only, no code path touched.

Numbers re-derived from primary sources at `feature/ecs-migration` head `f1bfb313d6`, not carried from another doc:

- `matrix-verdict`, run 32624738039 job 97159529786 — `packs with extension JS executed: 1945 (no-JS packs ignored: 3098) (hung or crashed: 1) (indeterminate, excluded: 6) (needed a pack-specific rewrite: 6)` / `VERDICT: PASS`
- `corpus`, same run job 97158189207 — `corpus cache valid: 5050/5239 targets available`
- Arithmetic closes: 1945 + 3098 + 1 + 6 = 5050
- Independently reproduced on run 32630931431 (same 1945 / 3098)
- `scripts/registry-census/README.md` is byte-identical on `main` and `feature/ecs-migration`, so this lands once and is correct on both

## Review Focus

The security bullet. I kept the rule at full strength while correcting the count, on the grounds that pack authors control which set they are in. If you would rather leave that bullet at ~5,100 and correct only the opening paragraph, say so and I will drop the second hunk.
