### PR TITLE
fix(billing): hide monthly credit bar on Local

### DIFF
--- a/src/platform/cloud/subscription/components/CreditsTile.test.ts
+++ b/src/platform/cloud/subscription/components/CreditsTile.test.ts
@@ -231,6 +231,16 @@ describe('CreditsTile', () => {
     expect(container.textContent).toContain('Used after monthly runs out')
   })
 
+  it('hides the monthly usage bar on Local', () => {
+    mockIsCloud.value = false
+    activeProSubscription()
+    renderTile()
+
+    expect(screen.queryByRole('progressbar')).toBeNull()
+    expect(screen.queryByText('Monthly')).toBeNull()
+    expect(screen.getByText('Additional credits')).toBeTruthy()
+  })
+
   it('renders a compact monthly summary for narrow containers', () => {
     activeProSubscription()
     const { container } = renderTile()

--- a/src/platform/cloud/subscription/components/CreditsTile.vue
+++ b/src/platform/cloud/subscription/components/CreditsTile.vue
@@ -235,6 +235,7 @@ import {
   getTierCredits
 } from '@/platform/cloud/subscription/constants/tierPricing'
 import { computeMonthlyUsage } from '@/platform/cloud/subscription/utils/creditsProgress'
+import { isCloud } from '@/platform/distribution/types'
 import { useTelemetry } from '@/platform/telemetry'
 import { pendingTopupNeedsRefresh } from '@/platform/telemetry/topupTracker'
 import { useWorkspaceUI } from '@/platform/workspace/composables/useWorkspaceUI'
@@ -360,6 +361,7 @@ const showBreakdown = computed(
 )
 const showBar = computed(
   () =>
+    isCloud &&
     showBreakdown.value &&
     creditPoolTotalCredits.value !== null &&
     creditPoolTotalCredits.value > 0


### PR DESCRIPTION
## Summary

Restores the production Local credits presentation by keeping the monthly usage bar Cloud-only. This fixes QA finding #9 from the Local/Desktop billing workspace switcher review.

## Root cause

[#15164](https://github.com/Comfy-Org/ComfyUI_frontend/pull/15164) moved Local from legacy billing state to workspace billing after workspace initialization. `CreditsTile` derived the monthly bar only from subscription access and credit-pool data, so the richer workspace response exposed a Cloud subscription breakdown that production Local did not show.

## Changes

- **What**: Gate the monthly usage bar on the deterministic app distribution while preserving the total and additional-credit balance shown on Local.
- **Regression coverage**: Assert that Local hides the bar while the existing Cloud test keeps verifying the full monthly breakdown.

## Review Focus

Confirm the display boundary only: Local keeps workspace-scoped balances from FE-1584 without adopting Cloud's monthly subscription progress UI.

## Validation

- `pnpm test:unit src/platform/cloud/subscription/components/CreditsTile.test.ts` (29/29)
- `pnpm typecheck`
- targeted oxfmt, oxlint, ESLint, stylelint
- pre-push `pnpm knip`

## Screenshots

### AS US 
<img width="614" height="447" alt="Screenshot 2026-08-23 at 6 07 42 PM" src="https://github.com/user-attachments/assets/60499070-ea57-4e6b-9ed9-763c0f08dcbf" />
`core/1.51` exposes the Monthly bar on Local | Production Local presentation restored; Monthly bar hidden 

### TO BE 
<img width="649" height="320" alt="Screenshot 2026-08-23 at 6 07 40 PM" src="https://github.com/user-attachments/assets/39c3b31d-609d-4be7-803c-de39a3adca04" />

[QA finding #9](https://app.notion.com/p/3c36d73d365080b4a1b7ea008d323c69)