### PR TITLE
docs(checks): add mechanical symbol sweep to doc-freshness check

### DIFF
--- a/.agents/checks/doc-freshness.md
+++ b/.agents/checks/doc-freshness.md
@@ -23,6 +23,34 @@ Rules:
 - Do NOT flag missing changelog entries for purely internal refactors
 - "Major" for stale docs that will mislead users, "minor" for missing JSDoc on public APIs, "nitpick" for minor doc improvements
 
+## Symbol sweep (mechanical — run it, don't estimate)
+
+For every symbol whose behavior, type, or contract the diff changes — exported functions,
+interface properties, class accessors, events, store APIs — and especially when the diff:
+
+- removes `readonly` from an interface property or loosens a type
+- inverts a documented invariant (e.g. "writes are ignored" becomes writes take effect)
+- changes what a public accessor returns or mutates
+
+do this:
+
+1. Grep `docs/` (including `docs/adr/`) for the exact symbol name (e.g. `output.links`,
+   `INodeInputSlot.link`) and for short phrases documenting its old contract (e.g. "read-only
+   compatibility accessors").
+2. Every hit that asserts the old behavior is a finding. List each file and line. The diff must
+   update them, or the review must flag them. The diff having updated ONE of the docs is not
+   evidence the others were updated — check each hit.
+3. A stale ADR is always "major": ADRs govern future changes and outlive the audit docs that
+   cite them.
+4. Sweep all docs regardless of freshness stamps. Stamped docs go stale at the same rate as
+   unstamped ones.
+
+Why this sweep is mandatory: PR #15501 inverted the slot-mirror compatibility contract (deleted
+`readonly` from `INodeInputSlot.link` / `INodeOutputSlot.links` and made legacy mirror writes
+take effect). Seven documents asserted the old contract; the diff updated exactly one. A
+documentation audit one day later then inserted the stale wording into an eighth place, including
+ADR 0008. A grep of the changed symbols over `docs/` would have caught every miss.
+
 ## ComfyUI_frontend Documentation
 
 This repository's public APIs are used by custom node and extension authors. Documentation lives at [docs.comfy.org](https://docs.comfy.org) (repo: Comfy-Org/docs).


### PR DESCRIPTION
PR #15501 inverted the slot-mirror compatibility contract and its diff updated 1 of the 7 docs asserting it; a doc-audit pass the next day then inserted the stale wording into an eighth place, including ADR 0008 (see #15728 for the doc fixes). The miss was mechanical, so the mitigation is too: this adds a mandatory symbol sweep to `.agents/checks/doc-freshness.md` — grep `docs/` (including `docs/adr/`) for every symbol whose contract the diff changes, treat each hit asserting the old behavior as a finding, rank stale ADRs major, and ignore freshness stamps (3 of the 6 missed docs were stamped).

Markdown-only change. `oxfmt --check` clean on the file. Git hooks did not run in this worktree (no `.husky/_`); no code paths touched.

Related: #15501 (the motivating miss), #15728 (fixes the resulting doc drift).