### PR TITLE
fix(ci): repoint manager API types workflow to moved file path

### DIFF
--- a/.github/workflows/api-update-manager-api-types.yaml
+++ b/.github/workflows/api-update-manager-api-types.yaml
@@ -50,17 +50,17 @@ jobs:
       - name: Generate Manager API types
         run: |
           echo "Generating TypeScript types from ComfyUI-Manager@${{ steps.manager-info.outputs.commit }}..."
-          pnpm dlx openapi-typescript ./ComfyUI-Manager/openapi.yaml --output ./src/types/generatedManagerTypes.ts
+          pnpm dlx openapi-typescript ./ComfyUI-Manager/openapi.yaml --output ./src/workbench/extensions/manager/types/generatedManagerTypes.ts
 
       - name: Validate generated types
         run: |
-          if [ ! -f ./src/types/generatedManagerTypes.ts ]; then
+          if [ ! -f ./src/workbench/extensions/manager/types/generatedManagerTypes.ts ]; then
             echo "Error: Types file was not generated."
             exit 1
           fi
 
           # Check if file is not empty
-          if [ ! -s ./src/types/generatedManagerTypes.ts ]; then
+          if [ ! -s ./src/workbench/extensions/manager/types/generatedManagerTypes.ts ]; then
             echo "Error: Generated types file is empty."
             exit 1
           fi
@@ -68,12 +68,12 @@ jobs:
       - name: Lint generated types
         run: |
           echo "Linting generated ComfyUI-Manager API types..."
-          pnpm lint:fix:no-cache -- ./src/types/generatedManagerTypes.ts
+          pnpm lint:fix:no-cache -- ./src/workbench/extensions/manager/types/generatedManagerTypes.ts
 
       - name: Check for changes
         id: check-changes
         run: |
-          if [[ -z $(git status --porcelain ./src/types/generatedManagerTypes.ts) ]]; then
+          if [[ -z $(git status --porcelain ./src/workbench/extensions/manager/types/generatedManagerTypes.ts) ]]; then
             echo "No changes to ComfyUI-Manager API types detected."
             echo "changed=false" >> $GITHUB_OUTPUT
             exit 0
@@ -103,4 +103,4 @@ jobs:
           labels: Manager
           delete-branch: true
           add-paths: |
-            src/types/generatedManagerTypes.ts
+            src/workbench/extensions/manager/types/generatedManagerTypes.ts


### PR DESCRIPTION
## Problem

Every operational reference in `.github/workflows/api-update-manager-api-types.yaml` still targets `src/types/generatedManagerTypes.ts`. That file was moved to `src/workbench/extensions/manager/types/generatedManagerTypes.ts` in #5662 (2025-09-19), and the old path no longer exists. A manual dispatch today would generate a second file at the dead path, the change-check would gate on the dead path, and `add-paths` would offer a PR that never updates the file the codebase actually imports.

## Change

Repoints all six references (generate output, both validation checks, lint target, change check, `add-paths`) to the live path. No behavior change beyond the path.

## Verification

- Local emulation of the generate step (`pnpm dlx openapi-typescript` against current ComfyUI-Manager `openapi.yaml`, Node 25): writes only the live file, exit 0.
- Emulated lint step `pnpm lint:fix:no-cache -- <new path>`: exit 0.
- `actionlint`: only the 3 pre-existing SC2086 info notes, identical count on `main`'s copy.
- `yamllint`: exit 0.
- Note: the emulated regeneration produced a ~2,260-insertion diff vs the committed types — the file is stale because the workflow has had no successful run since the move. After this merges, a manual dispatch should produce the real update PR. Regeneration is deliberately out of scope here.

Pre-commit (lint-staged) and pre-push (knip) hooks both ran and passed under Node 25.