### PR TITLE
fix: migrate sparse widget values

### DIFF
--- a/src/utils/litegraphUtil.test.ts
+++ b/src/utils/litegraphUtil.test.ts
@@ -233,6 +233,7 @@ describe('getWidgetIdForNode', () => {
 describe('migrateWidgetsValues', () => {
   const inputDefs = {
     forced: fromPartial<InputSpec>({ name: 'forced', forceInput: true }),
+    preview: fromPartial<InputSpec>({ name: 'preview' }),
     steps: fromPartial<InputSpec>({ name: 'steps' })
   }
 

--- a/src/utils/litegraphUtil.test.ts
+++ b/src/utils/litegraphUtil.test.ts
@@ -267,11 +267,7 @@ describe('migrateWidgetsValues', () => {
   })
 
   it('migrates a sparse value array with a non-trailing skipped widget', () => {
-    const widgets = [
-      makeWidget('forced'),
-      makeWidget('preview', false),
-      makeWidget('steps')
-    ]
+    const widgets = [makeWidget('preview', false), makeWidget('steps')]
 
     expect(migrateWidgetsValues(inputDefs, widgets, [1, null, 20])).toEqual([
       20
@@ -279,7 +275,7 @@ describe('migrateWidgetsValues', () => {
   })
 
   it('continues to migrate a value array without skipped widgets', () => {
-    const widgets = [makeWidget('forced'), makeWidget('steps')]
+    const widgets = [makeWidget('steps')]
 
     expect(migrateWidgetsValues(inputDefs, widgets, [1, 20])).toEqual([20])
   })

--- a/src/utils/litegraphUtil.test.ts
+++ b/src/utils/litegraphUtil.test.ts
@@ -247,6 +247,25 @@ describe('migrateWidgetsValues', () => {
     expect(migrateWidgetsValues(inputDefs, widgets, [1, 20])).toEqual([20])
   })
 
+  it('compacts a mid-list hole with a trailing skipped widget', () => {
+    const holeInputDefs = {
+      a: fromPartial<InputSpec>({ name: 'a' }),
+      ui1: fromPartial<InputSpec>({ name: 'ui1' }),
+      b: fromPartial<InputSpec>({ name: 'b' }),
+      ui2: fromPartial<InputSpec>({ name: 'ui2' })
+    }
+    const widgets = [
+      makeWidget('a'),
+      makeWidget('ui1', false),
+      makeWidget('b'),
+      makeWidget('ui2', false)
+    ]
+
+    expect(
+      migrateWidgetsValues(holeInputDefs, widgets, ['av', null, 'bv'])
+    ).toEqual(['av', 'bv'])
+  })
+
   it('migrates a sparse value array with a non-trailing skipped widget', () => {
     const widgets = [
       makeWidget('forced'),

--- a/src/utils/litegraphUtil.test.ts
+++ b/src/utils/litegraphUtil.test.ts
@@ -6,6 +6,8 @@ import { fromAny, fromPartial } from '@total-typescript/shoehorn'
 import type { LGraphCanvas } from '@/lib/litegraph/src/litegraph'
 import { LGraph, LGraphNode, LiteGraph } from '@/lib/litegraph/src/litegraph'
 import { createTestSubgraph } from '@/lib/litegraph/src/subgraph/__fixtures__/subgraphHelpers'
+import type { IBaseWidget } from '@/lib/litegraph/src/types/widgets'
+import type { InputSpec } from '@/schemas/nodeDef/nodeDefSchemaV2'
 import { toNodeId } from '@/types/nodeId'
 import { widgetId } from '@/types/widgetId'
 import { createMockLGraphNode } from '@/utils/__tests__/litegraphTestUtils'
@@ -14,6 +16,7 @@ import {
   createNode,
   getWidgetIdForNode,
   mapLiveWidgetsById,
+  migrateWidgetsValues,
   resolveNode
 } from './litegraphUtil'
 
@@ -224,5 +227,34 @@ describe('getWidgetIdForNode', () => {
   it('returns undefined for placeholder node id (-1)', () => {
     const node = fakeNode(-1)
     expect(getWidgetIdForNode(node, { name: 'x' })).toBeUndefined()
+  })
+})
+
+describe('migrateWidgetsValues', () => {
+  const inputDefs = {
+    forced: fromPartial<InputSpec>({ name: 'forced', forceInput: true }),
+    steps: fromPartial<InputSpec>({ name: 'steps' })
+  }
+
+  function makeWidget(name: string, serialize = true): IBaseWidget {
+    return fromPartial<IBaseWidget>({ name, serialize })
+  }
+
+  it('migrates a sparse value array with a non-trailing skipped widget', () => {
+    const widgets = [
+      makeWidget('forced'),
+      makeWidget('preview', false),
+      makeWidget('steps')
+    ]
+
+    expect(migrateWidgetsValues(inputDefs, widgets, [1, null, 20])).toEqual([
+      20
+    ])
+  })
+
+  it('continues to migrate a value array without skipped widgets', () => {
+    const widgets = [makeWidget('forced'), makeWidget('steps')]
+
+    expect(migrateWidgetsValues(inputDefs, widgets, [1, 20])).toEqual([20])
   })
 })

--- a/src/utils/litegraphUtil.test.ts
+++ b/src/utils/litegraphUtil.test.ts
@@ -241,6 +241,12 @@ describe('migrateWidgetsValues', () => {
     return fromPartial<IBaseWidget>({ name, serialize })
   }
 
+  it('migrates a legacy force-input array with a trailing skipped widget', () => {
+    const widgets = [makeWidget('steps'), makeWidget('preview', false)]
+
+    expect(migrateWidgetsValues(inputDefs, widgets, [1, 20])).toEqual([20])
+  })
+
   it('migrates a sparse value array with a non-trailing skipped widget', () => {
     const widgets = [
       makeWidget('forced'),

--- a/src/utils/litegraphUtil.ts
+++ b/src/utils/litegraphUtil.ts
@@ -193,22 +193,30 @@ export function migrateWidgetsValues<TWidgetValue>(
   const originalWidgetsInputs = Object.values(inputDefs).filter(
     (input) => widgetNames.has(input.name) || input.forceInput
   )
+  const skippedWidgetNames = new Set(
+    map(
+      filter(widgets, (widget) => widget.serialize === false),
+      (widget) => widget.name
+    )
+  )
 
-  const widgetIndexHasForceInput = originalWidgetsInputs.flatMap((input) =>
-    input.control_after_generate
+  const widgetIndexHasForceInput = originalWidgetsInputs.flatMap((input) => {
+    if (skippedWidgetNames.has(input.name)) return []
+    return input.control_after_generate
       ? [!!input.forceInput, false]
       : [!!input.forceInput]
-  )
+  })
 
   const normalizedWidgetValues =
     widgetsValues.length === widgets.length
-      ? widgetsValues.filter((_, index) => widgets[index]?.serialize !== false)
+      ? filter(widgetsValues, (_, index) => widgets[index]?.serialize !== false)
       : widgetsValues
 
   if (widgetIndexHasForceInput.length !== normalizedWidgetValues.length)
     return widgetsValues
 
-  return normalizedWidgetValues.filter(
+  return filter(
+    normalizedWidgetValues,
     (_, index) => !widgetIndexHasForceInput[index]
   )
 }

--- a/src/utils/litegraphUtil.ts
+++ b/src/utils/litegraphUtil.ts
@@ -207,16 +207,21 @@ export function migrateWidgetsValues<TWidgetValue>(
       : [!!input.forceInput]
   })
 
-  const normalizedWidgetValues =
-    widgetsValues.length === widgets.length
-      ? filter(widgetsValues, (_, index) => widgets[index]?.serialize !== false)
-      : widgetsValues
+  const compactedWidgetValues = filter(
+    widgetsValues,
+    (_, index) => widgets[index]?.serialize !== false
+  )
+  const alignedWidgetValues =
+    compactedWidgetValues.length === widgetIndexHasForceInput.length
+      ? compactedWidgetValues
+      : widgetsValues.length === widgetIndexHasForceInput.length
+        ? widgetsValues
+        : undefined
 
-  if (widgetIndexHasForceInput.length !== normalizedWidgetValues.length)
-    return widgetsValues
+  if (!alignedWidgetValues) return widgetsValues
 
   return filter(
-    normalizedWidgetValues,
+    alignedWidgetValues,
     (_, index) => !widgetIndexHasForceInput[index]
   )
 }

--- a/src/utils/litegraphUtil.ts
+++ b/src/utils/litegraphUtil.ts
@@ -200,10 +200,17 @@ export function migrateWidgetsValues<TWidgetValue>(
       : [!!input.forceInput]
   )
 
-  if (widgetIndexHasForceInput.length !== widgetsValues?.length)
+  const normalizedWidgetValues =
+    widgetsValues.length === widgets.length
+      ? widgetsValues.filter((_, index) => widgets[index]?.serialize !== false)
+      : widgetsValues
+
+  if (widgetIndexHasForceInput.length !== normalizedWidgetValues.length)
     return widgetsValues
 
-  return widgetsValues.filter((_, index) => !widgetIndexHasForceInput[index])
+  return normalizedWidgetValues.filter(
+    (_, index) => !widgetIndexHasForceInput[index]
+  )
 }
 
 /**


### PR DESCRIPTION
## Summary

Ensure the pre-v1.16 `forceInput` migration handles full-index widget arrays containing a non-trailing `serialize: false` hole.

## Changes

- Normalize sparse full-index widget values against the live widget serialization flags before validating the migration shape.
- Preserve the existing path for dense/compacted arrays, including the no-skipped-widget case.
- Add regression coverage for the mid-list skipped-widget case and the ordinary migration path.

## Testing

- `pnpm lint`
- `pnpm typecheck`
- `pnpm knip`
- `pnpm format:check`
- `pnpm test:unit` (1,205 files; 16,575 passed, 7 expected failures, 13 skipped before the final rebase; post-rebase 1,204 files passed and the concurrently collided ingest test passed separately, 17/17)
- `pnpm test:unit src/utils/litegraphUtil.test.ts` (19/19)

E2E verification:

1. Load a pre-v1.16 workflow containing a node whose legacy widgets are ordered as `forceInput`, `serialize: false`, then a persisted widget (for example the affected `LoadAudio` shape).
2. Confirm the dummy `forceInput` entry is removed during load and the later persisted widget retains its saved value.
3. Save and reload the workflow; expect the later widget value to remain unchanged.

## Review Focus

The sparse normalization runs only when `widgets_values.length` matches the full live widget list. Already-compacted arrays remain unchanged, keeping this compatible with either the full-index reader in #15688 or the compacting-writer proposal in #14262.

Fixes #15736
