### PR TITLE
docs: record why WidgetId keys on name

### DIFF
--- a/docs/adr/0008-entity-component-system.md
+++ b/docs/adr/0008-entity-component-system.md
@@ -115,11 +115,63 @@ type GraphId = string & { readonly __brand: 'GraphId' }
 ```
 
 > **Amended (PR 12617):** Widgets are keyed by a branded composite **string**,
-> `WidgetId = graphId:nodeId:name` (`src/types/widgetId.ts`), rather than a
-> synthetic numeric `WidgetEntityId`. The composite stays self-documenting and
-> survives renames at the store layer. The numeric per-kind brands above for
-> Node/Link/Reroute/Group remain aspirational and unshipped; treat them as
-> design intent. Slots have no independent ID yet.
+> `WidgetId = graphId:nodeId:name` (`src/types/widgetId.ts`). See
+> [Widget identity keys on `name`](#widget-identity-keys-on-name) for why the
+> tail segment is the widget's name rather than a minted id. The numeric
+> per-kind brands above for Node/Link/Reroute/Group remain aspirational and
+> unshipped; treat them as design intent. Slots have no independent ID yet.
+
+#### Widget identity keys on `name`
+
+`WidgetId` is **derived**, not minted: any holder of a graph id, a node id and a
+widget name can compute it without consulting a registry. Every other entity
+kind here is the opposite — a minted id whose value carries no information.
+"Just give widgets a synthetic id" is re-proposed often enough that the reason
+belongs here rather than in a thread.
+
+**The prior art was built, shipped, and deleted.** Two rounds:
+
+- PR 8856 (`proto-widget-v2`) introduced `PromotedWidgetView` — synthetic widget
+  *objects* with identities held stable across re-derivation by a
+  `PromotedWidgetViewManager` cache.
+- PR 12617 deleted that manager, the view class, the `world/widgetValueIO`
+  indirection layer, and `IBaseWidget.entityId`, and declared `WidgetId` the
+  single canonical widget identity.
+
+Note that the deleted `WidgetEntityId` (`src/world/entityIds.ts`) was **not** a
+synthetic id. It was `Brand<string, 'WidgetEntityId'>` over the same
+`graphId:nodeId:name` composite — the same key under a different brand, removed
+as a duplicate. What PR 12617 actually retired was the synthetic *widget-object
+identity* layer, not a competing id scheme. An earlier revision of this
+amendment described `WidgetEntityId` as "synthetic numeric", which made the
+alternative look untried; it was not.
+
+**Why the name segment:**
+
+- **A widget has no independent lifetime to hang an id on.** Widgets are
+  re-derived from the node definition on every load and every definition
+  refresh. A minted id would have to be persisted and then re-attached to the
+  right widget on each re-derivation, and the only stable thing to match on is
+  the name. That does not remove the dependency on `name`; it adds a lookup
+  table keyed by `name` on top of it.
+- **`name` is already the durable identity in the serialization format.**
+  Workflow JSON addresses widget values by position and name. A minted id needs
+  a migration and still has to fall back to `name` for every workflow authored
+  before it.
+- **`name` is not user-mutable.** `label` is display-only and is the only field
+  a rename changes — see the `// Do NOT change input.widget.name` guard in
+  `SubgraphNode`'s rename handler and both user-facing rename paths
+  (`src/services/litegraphService.ts`, `SubgraphNode.ts`).
+- **Addressability without a registry.** `widgetId(graphId, nodeId, name)` is
+  computable from data already in hand at every call site. A minted id requires
+  a lookup before anything can be addressed, which is the indirection layer
+  PR 12617 deleted.
+
+**Costs accepted:** renaming a widget in a node definition orphans its stored
+state; two widgets on one node cannot share a name; and because the key is
+derived, re-registering an existing `WidgetId` with a different `type` is a
+legitimate re-mint rather than an identity collision — which is why
+`widgetValueStore.registerWidget` overwrites where the minted-id stores reject.
 
 ### Component Decomposition
 
@@ -327,7 +379,9 @@ only the Yjs-backed `layoutStore` uses serializable operations.
 - Additional indirection: reading a node's position requires a store lookup instead of `node.pos`
 - Learning curve for contributors unfamiliar with ECS patterns
 - Migration period where both OOP and ECS patterns coexist, increasing cognitive load
-- Widgets and Slots need synthetic IDs, adding ID management complexity
+- Slots need synthetic IDs, adding ID management complexity. Widgets no longer
+  do — see [Widget identity keys on `name`](#widget-identity-keys-on-name) —
+  but the derived key trades that away for renames orphaning stored state
 
 ### Render-Loop Performance Implications and Mitigations
 

--- a/docs/adr/0008-entity-component-system.md
+++ b/docs/adr/0008-entity-component-system.md
@@ -132,7 +132,7 @@ belongs here rather than in a thread.
 **The prior art was built, shipped, and deleted.** Two rounds:
 
 - PR 8856 (`proto-widget-v2`) introduced `PromotedWidgetView` — synthetic widget
-  *objects* with identities held stable across re-derivation by a
+  _objects_ with identities held stable across re-derivation by a
   `PromotedWidgetViewManager` cache.
 - PR 12617 deleted that manager, the view class, the `world/widgetValueIO`
   indirection layer, and `IBaseWidget.entityId`, and declared `WidgetId` the
@@ -141,8 +141,8 @@ belongs here rather than in a thread.
 Note that the deleted `WidgetEntityId` (`src/world/entityIds.ts`) was **not** a
 synthetic id. It was `Brand<string, 'WidgetEntityId'>` over the same
 `graphId:nodeId:name` composite — the same key under a different brand, removed
-as a duplicate. What PR 12617 actually retired was the synthetic *widget-object
-identity* layer, not a competing id scheme. An earlier revision of this
+as a duplicate. What PR 12617 actually retired was the synthetic _widget-object
+identity_ layer, not a competing id scheme. An earlier revision of this
 amendment described `WidgetEntityId` as "synthetic numeric", which made the
 alternative look untried; it was not.
 

--- a/src/types/widgetId.ts
+++ b/src/types/widgetId.ts
@@ -4,16 +4,8 @@ type UUID = string
 
 /**
  * A widget's canonical identity: `graphId:nodeId:name`.
- *
- * Derived, not minted — computable at any call site that already holds the
- * three segments, so addressing a widget needs no registry lookup. The tail
- * segment is the widget's `name` (never `label`, which is display-only and is
- * what a user rename changes).
- *
- * A synthetic widget identity was built (PR 8856) and deleted (PR 12617); see
- * "Widget identity keys on `name`" in `docs/adr/0008-entity-component-system.md`
- * before proposing one again. Note the trade: because the key is derived, a
- * widget renamed in a node definition orphans its stored state, and two widgets
+ * Because the key is derived, a widget renamed in a node
+ * definition orphans its stored state, and two widgets
  * on one node cannot share a name.
  */
 export type WidgetId = string & { readonly __brand: 'WidgetId' }

--- a/src/types/widgetId.ts
+++ b/src/types/widgetId.ts
@@ -2,6 +2,20 @@ import { toNodeId } from '@/types/nodeId'
 import type { NodeId } from '@/types/nodeId'
 type UUID = string
 
+/**
+ * A widget's canonical identity: `graphId:nodeId:name`.
+ *
+ * Derived, not minted — computable at any call site that already holds the
+ * three segments, so addressing a widget needs no registry lookup. The tail
+ * segment is the widget's `name` (never `label`, which is display-only and is
+ * what a user rename changes).
+ *
+ * A synthetic widget identity was built (PR 8856) and deleted (PR 12617); see
+ * "Widget identity keys on `name`" in `docs/adr/0008-entity-component-system.md`
+ * before proposing one again. Note the trade: because the key is derived, a
+ * widget renamed in a node definition orphans its stored state, and two widgets
+ * on one node cannot share a name.
+ */
 export type WidgetId = string & { readonly __brand: 'WidgetId' }
 
 const SEPARATOR = ':'


### PR DESCRIPTION
## Problem / Goal

ADR 0008 describes the deleted `WidgetEntityId` as synthetic and numeric, but it was a branded string derived from `graphId:nodeId:name`. The ADR also does not preserve why the earlier synthetic widget-object identity layer was removed, so the same alternative is repeatedly re-proposed.

## Proposed Solution

Correct the history in ADR 0008 and document why `WidgetId` uses `name`: widgets are re-derived from node definitions, `name` is the durable non-display identity, and the key remains addressable without a registry. Record the accepted costs and link the rationale from `src/types/widgetId.ts`.

## Acceptance Criteria

- ADR 0008 no longer calls `WidgetEntityId` synthetic or numeric.
- ADR 0008 distinguishes the deleted branded key from the deleted synthetic widget-object identity layer.
- The rationale and tradeoffs for `graphId:nodeId:name` are recorded next to the decision and linked from `WidgetId`.

Linear: FE-1814. Prepared by dead Claude session 3bd9016a; taken over and shipped by Amp thread T-01a0307d.