### PR TITLE
fix: decline unkeyable widget promotion

### DIFF
--- a/src/lib/litegraph/src/subgraph/SubgraphNode.test.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphNode.test.ts
@@ -14,6 +14,7 @@ import {
   LiteGraph,
   SubgraphNode
 } from '@/lib/litegraph/src/litegraph'
+import { isWidgetInputSlot } from '@/lib/litegraph/src/node/slotUtils'
 import type { ExportedSubgraphInstance } from '@/lib/litegraph/src/types/serialisation'
 import { NodeSlotType } from '@/lib/litegraph/src/types/globalEnums'
 import { useWidgetValueStore } from '@/stores/widgetValueStore'
@@ -251,22 +252,70 @@ describe('SubgraphNode Synchronization', () => {
   it('declines promotion when an empty widget name cannot be registered', () => {
     vi.spyOn(console, 'warn').mockImplementation(() => {})
     const subgraph = createTestSubgraph({
-      inputs: [{ name: '', type: 'STRING' }]
+      inputs: [
+        { name: '', type: 'STRING' },
+        { name: 'valid', type: 'STRING' }
+      ]
     })
 
     const interiorNode = new LGraphNode('Interior')
-    const input = interiorNode.addInput('', 'STRING')
-    input.widget = { name: '' }
+    const emptyInput = interiorNode.addInput('', 'STRING')
+    emptyInput.widget = { name: '' }
+    const validInput = interiorNode.addInput('valid', 'STRING')
+    validInput.widget = { name: 'valid' }
     interiorNode.addWidget('text', '', 'initial', () => {})
+    interiorNode.addWidget('text', 'valid', 'initial', () => {})
     subgraph.add(interiorNode)
-    subgraph.inputNode.slots[0].connect(interiorNode.inputs[0], interiorNode)
+    subgraph.inputNode.slots[0].connect(emptyInput, interiorNode)
+    subgraph.inputNode.slots[1].connect(validInput, interiorNode)
+
+    const subgraphNode = createTestSubgraphNode(subgraph)
+    subgraph.rootGraph.add(subgraphNode)
+    const declinedInput = subgraphNode.inputs[0]
+
+    expect(isWidgetInputSlot(declinedInput)).toBe(false)
+    expect(declinedInput.widgetId).toBeUndefined()
+    expect(subgraphNode.getWidgetFromSlot(declinedInput)).toBeUndefined()
+    expect(subgraphNode.widgets).toHaveLength(1)
+
+    subgraphNode.arrange()
+    expect(declinedInput.boundingRect[2]).toBe(LiteGraph.NODE_SLOT_HEIGHT)
+
+    const source = new LGraphNode('Source')
+    source.addOutput('out', 'STRING')
+    subgraph.rootGraph.add(source)
+
+    expect(source.connect(0, subgraphNode, 0)).not.toBeNull()
+    expect(declinedInput.link).not.toBeNull()
+  })
+
+  it('clears an existing promotion when registration is later declined', () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const subgraph = createTestSubgraph({
+      inputs: [{ name: 'value', type: 'STRING' }]
+    })
+
+    const interiorNode = new LGraphNode('Interior')
+    const input = interiorNode.addInput('value', 'STRING')
+    input.widget = { name: 'value' }
+    const widget = interiorNode.addWidget('text', 'value', 'initial', () => {})
+    subgraph.add(interiorNode)
+    subgraph.inputNode.slots[0].connect(input, interiorNode)
 
     const subgraphNode = createTestSubgraphNode(subgraph)
     const promotedInput = subgraphNode.inputs[0]
+    expect(promotedInput.widgetId).toBeDefined()
 
+    subgraph.inputs[0].name = ''
+    subgraph.inputs[0].events.dispatch('input-connected', {
+      input,
+      widget,
+      node: interiorNode
+    })
+
+    expect(isWidgetInputSlot(promotedInput)).toBe(false)
     expect(promotedInput.widgetId).toBeUndefined()
-    expect(subgraphNode.getWidgetFromSlot(promotedInput)).toBeUndefined()
-    expect(subgraphNode.widgets).toEqual([])
+    expect(promotedInput._widget).toBeUndefined()
   })
 
   it('binds promoted host widgets as stable LiteGraph widgets', () => {

--- a/src/lib/litegraph/src/subgraph/SubgraphNode.test.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphNode.test.ts
@@ -248,6 +248,27 @@ describe('SubgraphNode Synchronization', () => {
     )
   })
 
+  it('declines promotion when an empty widget name cannot be registered', () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const subgraph = createTestSubgraph({
+      inputs: [{ name: '', type: 'STRING' }]
+    })
+
+    const interiorNode = new LGraphNode('Interior')
+    const input = interiorNode.addInput('', 'STRING')
+    input.widget = { name: '' }
+    interiorNode.addWidget('text', '', 'initial', () => {})
+    subgraph.add(interiorNode)
+    subgraph.inputNode.slots[0].connect(interiorNode.inputs[0], interiorNode)
+
+    const subgraphNode = createTestSubgraphNode(subgraph)
+    const promotedInput = subgraphNode.inputs[0]
+
+    expect(promotedInput.widgetId).toBeUndefined()
+    expect(subgraphNode.getWidgetFromSlot(promotedInput)).toBeUndefined()
+    expect(subgraphNode.widgets).toEqual([])
+  })
+
   it('binds promoted host widgets as stable LiteGraph widgets', () => {
     const subgraph = createTestSubgraph({
       inputs: [{ name: 'text', type: 'STRING' }]

--- a/src/lib/litegraph/src/subgraph/SubgraphNode.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphNode.ts
@@ -668,8 +668,7 @@ export class SubgraphNode extends LGraphNode implements BaseLGraph {
 
     const id = widgetId(this.rootGraph.id, this.id, subgraphInput.name)
     const store = useWidgetValueStore()
-    input.widgetId = id
-    store.registerWidget(
+    const registered = store.registerWidget(
       id,
       {
         type: interiorWidget.type,
@@ -681,6 +680,9 @@ export class SubgraphNode extends LGraphNode implements BaseLGraph {
       },
       deriveWidgetRenderState(interiorWidget)
     )
+    if (!registered) return
+
+    input.widgetId = id
     input._widget =
       this.createPromotedHostWidget(input, id, interiorWidget) ??
       this._projectPromotedWidget(input)

--- a/src/lib/litegraph/src/subgraph/SubgraphNode.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphNode.ts
@@ -680,7 +680,13 @@ export class SubgraphNode extends LGraphNode implements BaseLGraph {
       },
       deriveWidgetRenderState(interiorWidget)
     )
-    if (!registered) return
+    if (!registered) {
+      delete input.pos
+      delete input.widget
+      delete input.widgetId
+      input._widget = undefined
+      return
+    }
 
     input.widgetId = id
     input._widget =


### PR DESCRIPTION
## Summary

Decline promoted host-widget creation when the widget value store rejects an un-keyable widget ID.

## Changes

- assign `input.widgetId` only after `registerWidget` succeeds
- leave empty-name promotions without a projected host widget or invalid ID
- add a regression test covering an empty-name widget connected through an empty-name subgraph input

## Testing

- `pnpm test:unit src/lib/litegraph/src/subgraph/SubgraphNode.test.ts` — 51 passed
- `pnpm typecheck`
- `pnpm lint` — 0 errors; 4 pre-existing unrelated warnings
- `pnpm format:check`
- `pnpm knip`
- `pnpm test:unit` — 1,231 files passed; 16,831 passed, 21 expected fail, 13 skipped

E2E verification:

1. Create a custom node with an empty-name string widget and matching empty-name input.
2. Convert/promote that input through a subgraph boundary.
3. Inspect the host subgraph node and save the workflow.
4. Confirm no projected host widget is created, the host input has no `widgetId`, and saving/rendering completes without an un-keyable store entry.

Expected result: the unsupported promotion is declined cleanly; named widget promotions continue to render and persist normally.

## Review focus

The failure path intentionally returns before dispatching `widget-promoted`, treating rejected registration as a cleanly declined promotion rather than creating a detached host projection.

Fixes #15763
