### PR TITLE
fix: realign links around unmatched inputs

### DIFF
--- a/src/lib/litegraph/src/LGraph.inputSlotRealign.test.ts
+++ b/src/lib/litegraph/src/LGraph.inputSlotRealign.test.ts
@@ -517,7 +517,7 @@ describe('LGraph.configure realignment with an unmatched input name (#15581)', (
     )
   })
 
-  it.fails('realigns siblings when configure drops an input', () => {
+  it('realigns siblings when configure drops an input', () => {
     const graph = new LGraph()
     graph.configure(unmatchedInputNameWorkflow('test/DroppedInputTarget'))
 
@@ -530,7 +530,7 @@ describe('LGraph.configure realignment with an unmatched input name (#15581)', (
     })
   })
 
-  it.fails('realigns siblings when configure renames an input', () => {
+  it('realigns siblings when configure renames an input', () => {
     const graph = new LGraph()
     graph.configure(unmatchedInputNameWorkflow('test/RenamedInputTarget'))
 
@@ -543,7 +543,7 @@ describe('LGraph.configure realignment with an unmatched input name (#15581)', (
     })
   })
 
-  it.fails('reports no error while realigning around an unmatched name', () => {
+  it('reports no error while realigning around an unmatched name', () => {
     const error = vi.spyOn(console, 'error').mockImplementation(() => {})
 
     const graph = new LGraph()
@@ -558,7 +558,7 @@ describe('realignInputLinkSlots with a rejected batch (#15581)', () => {
     setActivePinia(createTestingPinia({ stubActions: false }))
   })
 
-  it.fails('lands the non-conflicting moves when one move is blocked', () => {
+  it('lands the non-conflicting moves when one move is blocked', () => {
     const graph = new LGraph()
     const source = new LGraphNode('Source')
     source.addOutput('out', 'number')

--- a/src/lib/litegraph/src/linkDeduplication.ts
+++ b/src/lib/litegraph/src/linkDeduplication.ts
@@ -151,9 +151,15 @@ export function realignInputLinkSlots(
         topology: link._state,
         patch: { targetSlot: slot }
       }))
+      const movedLinks = new Set(moved.map(({ link }) => link))
+      const removals = moved.flatMap(({ slot }) => {
+        const incumbent = node.getInputLink(slot)
+        return incumbent && !movedLinks.has(incumbent) ? [incumbent._state] : []
+      })
       const result = useLinkStore().updateEndpoints(
         graphScopeOf(graph),
-        updates
+        updates,
+        removals
       )
       if (!result.ok) {
         console.error('Failed to realign input link slots', result.error)


### PR DESCRIPTION
## Summary

Keep valid sibling links aligned when a configured node renames or drops an input.

## Changes

- Include stale target-slot incumbents as removals in the atomic endpoint-update batch.
- Promote the existing dropped-input, renamed-input, error-reporting, and rejected-batch characterisations to passing regression tests.

## Testing

- `pnpm exec vitest run src/lib/litegraph/src/LGraph.inputSlotRealign.test.ts`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`
- `pnpm knip`
- `pnpm test:unit`

E2E verification:

1. Run `pnpm dev` and open a workflow saved with three linked custom-node inputs in the order `in_c`, `in_a`, `in_b`.
2. Load a version of that custom node whose `configure` drops or renames `in_c` and exposes `in_a`, `in_b` in definition order.
3. Confirm the stale `in_c` link is removed, while the other two links remain connected to `in_a` and `in_b`; re-save and reload and confirm the wiring remains unchanged.

## Review focus

The endpoint moves and stale-incumbent removals are deliberately submitted in one `updateEndpoints` call so collision validation remains atomic.

Fixes #15581
