### PR TITLE
test: document registry id reuse contracts

### DIFF
--- a/src/stores/linkStore.test.ts
+++ b/src/stores/linkStore.test.ts
@@ -111,7 +111,7 @@ describe('useLinkStore', () => {
     expect(store.getInputSlotLink(graphA, toNodeId(9), 2)).toBe(registered)
   })
 
-  it('re-registers a link after deleting its owner bucket', () => {
+  it('reuses a deleted link id for a replacement link', () => {
     const store = useLinkStore()
     const topology = link(1, 5, 0, 9, 2)
     const current = computed(() => [...store.graphTopologies(graphA)][0])

--- a/src/stores/nodeDataStore.test.ts
+++ b/src/stores/nodeDataStore.test.ts
@@ -114,6 +114,24 @@ describe('useNodeDataStore', () => {
     expect(registered?.id).toBe(toNodeId(42))
     expect(store.getGraphNodesFor(rootA, rootA)).toEqual([registered])
   })
+
+  it('reuses a deleted node id for a replacement node', () => {
+    const store = useNodeDataStore()
+    const first = node(1)
+    const registered = store.registerNode(graphScope(rootA, rootA), first)
+    assert(registered)
+
+    expect(store.deleteNode(graphScope(rootA, rootA), registered)).toBe(true)
+
+    const replacement = node(1, 'sub-1')
+    const reRegistered = store.registerNode(
+      graphScope(rootA, 'sub-1'),
+      replacement
+    )
+    expect(reRegistered).toBeDefined()
+    expect(store.getGraphNodesFor(rootA, rootA)).toEqual([])
+    expect(store.getGraphNodesFor(rootA, 'sub-1')).toEqual([reRegistered])
+  })
 })
 
 describe('nodeDataStore registration via LGraph', () => {

--- a/src/stores/rerouteStore.test.ts
+++ b/src/stores/rerouteStore.test.ts
@@ -96,7 +96,7 @@ describe('useRerouteStore', () => {
     expect(store.deleteReroute(graphA, registered)).toBe(false)
   })
 
-  it('re-registers a chain after deleting its owner bucket', () => {
+  it('reuses a deleted reroute id for a replacement chain', () => {
     const store = useRerouteStore()
     const registered = store.registerReroute(graphA, chain(1))
     assert(registered)


### PR DESCRIPTION
## Summary

Documents the widget registry's type-discriminated collision rule and makes recycled-ID behavior explicit across the ECS entity stores.

## Changes

- Explain why `registerWidget` preserves same-type state but replaces a stale entry when a replacement node changes widget type.
- Add mutation-verified coverage that `nodeDataStore` accepts a replacement node after the prior owner is deleted.
- Rename the existing link and reroute replacement tests to state their recycled-ID contracts directly.

## Testing

- `pnpm exec vitest run src/stores/nodeDataStore.test.ts src/stores/linkStore.test.ts src/stores/rerouteStore.test.ts src/stores/widgetValueStore.test.ts` (82 passed)
- `pnpm format:check`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm knip`
- `pnpm test:unit` (1,231 files; 16,831 passed, 21 expected failures, 13 skipped)
- Mutation check: removing `bucket.byId.delete(state.id)` makes only the new node ID-reuse test fail; restoring it returns the focused suite to green.

E2E verification:

1. Run `pnpm dev` and open the local ComfyUI frontend.
2. Load a workflow, delete a node, then undo the deletion so the replacement reuses the serialized node ID.
3. Save and reload the workflow.
4. Confirm the restored node and its widgets remain present with their expected values; no visible runtime behavior changes are expected from this test/documentation-only PR.

## Review focus

- The production comment deliberately records only the load-bearing structural-key rationale; registry behavior is otherwise unchanged.
- The node test mirrors the already-covered link and reroute replacement contracts without prescribing a universal collision policy.

Fixes #15705
