### PR TITLE
style(website): restyle the /models-v2 preview with shared components

### DIFF
--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -37,6 +37,7 @@
     "lenis": "catalog:",
     "posthog-js": "catalog:",
     "reka-ui": "catalog:",
+    "shiki": "catalog:",
     "three": "catalog:",
     "vue": "catalog:",
     "zod": "catalog:"

--- a/apps/website/scripts/models-v2-preview-check.mjs
+++ b/apps/website/scripts/models-v2-preview-check.mjs
@@ -105,17 +105,41 @@ const run = async () => {
   )
   await desktop.selectOption('#sel-resolution', '720p')
 
-  // reference image
-  await desktop.click('#add-image-btn')
+  // reference image — Add image opens the OS picker, which the browser cannot
+  // drive, so set the file on the input the button forwards to.
+  await desktop.setInputFiles('#ref-file', {
+    name: 'frame_0001.png',
+    mimeType: 'image/png',
+    buffer: Buffer.from(
+      '89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c4890000000a49444154789c63000100000500010d0a2db40000000049454e44ae426082',
+      'hex'
+    )
+  })
+  await desktop.waitForTimeout(300)
+  check(
+    'reference image attachment',
+    await desktop.isVisible('#ref-attachment'),
+    (await desktop.textContent('#ref-name')) ?? ''
+  )
   await desktop.click('[data-iview="json"]')
   check(
     'reference image in payload',
     ((await desktop.textContent('#input-json')) ?? '').includes(
-      'reference_image'
+      '"reference_image": "frame_0001.png"'
     ),
     ''
   )
   await desktop.click('[data-iview="app"]')
+  await desktop.click('#ref-remove')
+  await desktop.waitForTimeout(200)
+  check(
+    'remove clears the reference image',
+    !(await desktop.isVisible('#ref-attachment')) &&
+      !(
+        (await desktop.textContent('#input-json')) ?? ''
+      ).includes('reference_image'),
+    ''
+  )
 
   // result JSON tab (pre-run receipt)
   await desktop.click('[data-rview="json"]')

--- a/apps/website/scripts/models-v2-preview-check.mjs
+++ b/apps/website/scripts/models-v2-preview-check.mjs
@@ -175,9 +175,7 @@ const run = async () => {
   await desktop.click('body', { position: { x: 10, y: 400 } })
 
   // gallery warm start
-  await desktop.evaluate(() =>
-    document.getElementById('gallery')?.scrollIntoView()
-  )
+  await desktop.click('[data-tab="gallery"]')
   await desktop.waitForTimeout(300)
   const firstPrompt = await desktop.$eval(
     '[data-use-prompt]',

--- a/apps/website/scripts/models-v2-preview-check.mjs
+++ b/apps/website/scripts/models-v2-preview-check.mjs
@@ -144,10 +144,12 @@ const run = async () => {
     md.status() === 200 && (await md.text()).includes('FLUX 3'),
     mdHref ?? ''
   )
+  // Scoped to <main> rather than one menu: the deep links have moved between
+  // the LLMs and open-in menus, and the check is about them existing.
   check(
     'llm deep links',
     (await desktop.$$eval(
-      '#llms-menu a[href*="claude.ai"], #llms-menu a[href*="chatgpt.com"]',
+      'main a[href*="claude.ai"], main a[href*="chatgpt.com"]',
       (a) => a.length
     )) === 2,
     ''

--- a/apps/website/scripts/models-v2-preview-check.mjs
+++ b/apps/website/scripts/models-v2-preview-check.mjs
@@ -135,9 +135,9 @@ const run = async () => {
   check(
     'remove clears the reference image',
     !(await desktop.isVisible('#ref-attachment')) &&
-      !(
-        (await desktop.textContent('#input-json')) ?? ''
-      ).includes('reference_image'),
+      !((await desktop.textContent('#input-json')) ?? '').includes(
+        'reference_image'
+      ),
     ''
   )
 

--- a/apps/website/scripts/models-v2-preview-check.mjs
+++ b/apps/website/scripts/models-v2-preview-check.mjs
@@ -78,21 +78,7 @@ const run = async () => {
   await desktop.waitForURL('**/models-v2/flux-3')
   await desktop.waitForTimeout(400)
 
-  // APP | GRAPH | JSON
-  await desktop.click('[data-iview="graph"]')
-  check(
-    'graph view',
-    await desktop.$eval(
-      '#panel-graph',
-      (el) => !el.classList.contains('hidden')
-    ),
-    ''
-  )
-  check(
-    'graph svg',
-    (await desktop.$$eval('#panel-graph svg g', (g) => g.length)) >= 5,
-    ''
-  )
+  // APP | JSON
   await desktop.click('[data-iview="json"]')
   const j1 = (await desktop.textContent('#input-json')) ?? ''
   check('json view payload', j1.includes('"workflow": "flux-3"'), '')
@@ -104,12 +90,6 @@ const run = async () => {
     ((await desktop.textContent('#input-json')) ?? '').includes(
       'a red fox in the snow'
     ),
-    ''
-  )
-  await desktop.click('[data-iview="graph"]')
-  check(
-    'prompt live-binds graph',
-    ((await desktop.textContent('#g-prompt-1')) ?? '').includes('a red fox'),
     ''
   )
   await desktop.click('[data-iview="app"]')

--- a/apps/website/src/components/common/BrandButton.vue
+++ b/apps/website/src/components/common/BrandButton.vue
@@ -2,7 +2,7 @@
 import { cn } from '@comfyorg/tailwind-utils'
 
 import { computed } from 'vue'
-import type { HTMLAttributes } from 'vue'
+import type { AnchorHTMLAttributes, HTMLAttributes } from 'vue'
 
 import type { BrandButtonVariants } from './brandButton.variants'
 import { brandButtonVariants } from './brandButton.variants'
@@ -12,6 +12,7 @@ const props = defineProps<{
   href?: string
   target?: string
   rel?: string
+  download?: AnchorHTMLAttributes['download']
   variant?: BrandButtonVariants['variant']
   size?: BrandButtonVariants['size']
   class?: HTMLAttributes['class']
@@ -28,6 +29,7 @@ const resolvedRel = computed(() =>
     :href="props.href"
     :target="props.target"
     :rel="resolvedRel"
+    :download="props.download"
     :class="
       cn(
         brandButtonVariants({ variant: props.variant, size: props.size }),

--- a/apps/website/src/components/common/Breadcrumbs.astro
+++ b/apps/website/src/components/common/Breadcrumbs.astro
@@ -1,0 +1,56 @@
+---
+/**
+ * Breadcrumb trail, matching the treatment on the workflow detail pages.
+ *
+ * The rendered trail MUST mirror the BreadcrumbList JSON-LD of the page
+ * exactly — same labels, same order — so the visible navigation agrees with
+ * the structured data. A crumb without an `href` renders as the current page.
+ *
+ * This is the trail only. The caller owns the surrounding layout, because the
+ * directory nests it inside a hero column while the model page gives it its
+ * own row. `BreadcrumbBar.vue` is the full-width variant, with its own
+ * container and an "updated" slot.
+ */
+interface Crumb {
+  label: string
+  href?: string
+}
+
+interface Props {
+  crumbs: readonly Crumb[]
+  label?: string
+  class?: string
+}
+
+const { crumbs, label = 'Breadcrumb', class: className } = Astro.props
+---
+
+<nav aria-label={label} class:list={['text-sm', className]}>
+  <ol class="flex min-w-0 items-center gap-2 text-primary-comfy-canvas/75">
+    {
+      crumbs.map((crumb, i) => (
+        <li class:list={['flex items-center gap-2', i === crumbs.length - 1 ? 'min-w-0' : 'shrink-0']}>
+          {i > 0 && (
+            <svg
+              class="size-3.5 shrink-0 text-primary-comfy-canvas/40"
+              viewBox="0 0 24 24"
+              fill="none"
+              aria-hidden="true"
+            >
+              <path
+                d="M9 6l6 6-6 6"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+            </svg>
+          )}
+          {crumb.href
+            ? <a href={crumb.href} class="transition-colors hover:text-primary-comfy-canvas">{crumb.label}</a>
+            : <span aria-current="page" class="line-clamp-1 text-primary-comfy-canvas">{crumb.label}</span>}
+        </li>
+      ))
+    }
+  </ol>
+</nav>

--- a/apps/website/src/lib/highlight.ts
+++ b/apps/website/src/lib/highlight.ts
@@ -1,0 +1,67 @@
+/**
+ * Shiki highlighting for the code blocks on the model pages, matching the
+ * treatment the workflow pages use.
+ *
+ * `kanagawa-wave` is the closest bundled theme to the Comfy palette: its
+ * background sits nearest `--color-primary-comfy-ink` of any dark theme, its
+ * warm beige foreground tracks `--color-primary-comfy-canvas`, and its accent
+ * lands 15° off `--color-primary-comfy-yellow` at a muted chroma.
+ *
+ * Runs at build time for the static snippets and in the browser for the live
+ * payload, so it loads through dynamic imports and the JavaScript regex engine
+ * — no Oniguruma wasm, and nothing reaches the page chunk until a block is
+ * actually highlighted. Grammars load per language too.
+ */
+import type { HighlighterCore } from 'shiki/core'
+
+const CODE_THEME = 'kanagawa-wave'
+
+export type CodeLang = 'json' | 'shell'
+
+// Markup grows ~7x the source and the cost is linear. The payloads these blocks
+// render are a few hundred bytes; anything past this keeps its plain rendering.
+const MAX_HIGHLIGHT_BYTES = 128 * 1024
+
+const GRAMMARS = {
+  json: () => import('shiki/langs/json.mjs'),
+  shell: () => import('shiki/langs/shellscript.mjs')
+} satisfies Record<CodeLang, () => Promise<unknown>>
+
+let pending: Promise<HighlighterCore> | null = null
+
+function highlighter(): Promise<HighlighterCore> {
+  pending ??= Promise.all([
+    import('shiki/core'),
+    import('shiki/engine/javascript')
+  ]).then(([{ createHighlighterCore }, { createJavaScriptRegexEngine }]) =>
+    createHighlighterCore({
+      themes: [import('shiki/themes/kanagawa-wave.mjs')],
+      langs: [],
+      engine: createJavaScriptRegexEngine()
+    })
+  )
+  return pending
+}
+
+/**
+ * Tokenized spans for a `<pre>` the caller already owns — `structure: 'inline'`
+ * drops Shiki's own wrapper, so the element and its classes survive. Null when
+ * the code is too large or highlighting fails, leaving callers on raw text.
+ */
+export async function highlightInline(
+  code: string,
+  lang: CodeLang
+): Promise<string | null> {
+  if (code.length > MAX_HIGHLIGHT_BYTES) return null
+  try {
+    const hl = await highlighter()
+    if (!hl.getLoadedLanguages().includes(lang)) {
+      await hl.loadLanguage(
+        (await GRAMMARS[lang]()) as Parameters<typeof hl.loadLanguage>[0]
+      )
+    }
+    return hl.codeToHtml(code, { lang, theme: CODE_THEME, structure: 'inline' })
+  } catch {
+    return null
+  }
+}

--- a/apps/website/src/pages/models-v2/[slug].astro
+++ b/apps/website/src/pages/models-v2/[slug].astro
@@ -10,6 +10,7 @@ import { cn } from '@comfyorg/tailwind-utils'
 import BaseLayout from '../../layouts/BaseLayout.astro'
 import GlassCard from '../../components/common/GlassCard.vue'
 import { brandButtonVariants } from '../../components/common/brandButton.variants'
+import Badge from '../../components/ui/badge/Badge.vue'
 import { toggleVariants } from '../../components/ui/toggle'
 import {
   launches,
@@ -212,7 +213,7 @@ const faqJsonLd = {
     <div class="mt-3 flex flex-wrap items-center justify-between gap-3">
       <div class="flex min-w-0 flex-wrap items-center gap-3">
         <h1 class="max-w-full truncate text-2xl font-semibold text-primary-warm-white sm:text-3xl">{name}</h1>
-        <span class:list={[pill, pillMuted]}>{meta.label}</span>
+        <Badge variant="accent">{meta.label}</Badge>
       </div>
       <div class="hidden gap-2 sm:flex">
         {docsUrl && <a href={docsUrl} class:list={[outlineButton, 'text-2xs uppercase tracking-widest']}>{launch?.launchUrl ? 'Launch page ↗' : 'Docs ↗'}</a>}

--- a/apps/website/src/pages/models-v2/[slug].astro
+++ b/apps/website/src/pages/models-v2/[slug].astro
@@ -96,6 +96,8 @@ const iconButton = 'group shrink-0 cursor-pointer rounded-lg border border-trans
 const primaryButton = brandButtonVariants({ variant: 'solid', size: 'xs' })
 const outlineAccentButton = brandButtonVariants({ variant: 'outline', size: 'xs' })
 const outlineButton = brandButtonVariants({ variant: 'outline-light', size: 'sm' })
+const solidAccentButton = brandButtonVariants({ variant: 'solid', size: 'sm' })
+const outlineAccentButtonSm = brandButtonVariants({ variant: 'outline', size: 'sm' })
 const tab = cn(
   toggleVariants(),
   'rounded-none px-4 first:rounded-l-xl last:rounded-r-xl'
@@ -215,22 +217,10 @@ const faqJsonLd = {
         <h1 class="max-w-full truncate text-2xl font-semibold text-primary-warm-white sm:text-3xl">{name}</h1>
         <Badge variant="accent">{meta.label}</Badge>
       </div>
-      <div class="hidden gap-2 sm:flex">
-        {docsUrl && <a href={docsUrl} class:list={[outlineButton, 'text-2xs uppercase tracking-widest']}>{launch?.launchUrl ? 'Launch page ↗' : 'Docs ↗'}</a>}
-        <div class="relative" id="llms-wrap">
-          <button id="llms-btn" class="inline-flex items-center gap-3 rounded-lg border border-transparency-white-t20 bg-transparency-white-t4 px-3 py-2.5 text-xs font-normal text-primary-comfy-canvas transition-colors hover:bg-transparency-white-t8">
-            LLMs
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="size-4"><path d="m6 9 6 6 6-6"/></svg>
-          </button>
-          <div id="llms-menu" class="absolute right-0 top-full z-40 mt-1.5 hidden w-60 overflow-hidden rounded-xl border border-transparency-white-t20 bg-site-dropdown py-1.5 shadow-2xl">
-            <button id="llms-copy" class="block w-full cursor-pointer px-4 py-2.5 text-left text-xs text-primary-warm-white hover:bg-transparency-white-t4">Copy page as Markdown<span id="llms-copied" class="hidden pl-2 text-primary-comfy-yellow">✓</span></button>
-            <a href={mdUrl} class="block px-4 py-2.5 text-xs text-primary-warm-white hover:bg-transparency-white-t4">View as Markdown</a>
-            <a href="/models-v2/llms.txt" class="block px-4 py-2.5 text-xs text-primary-warm-white hover:bg-transparency-white-t4">llms.txt — full catalog</a>
-            <div class="my-1 border-t border-white/10"></div>
-            <a href={`https://claude.ai/new?q=${llmPrompt}`} class="block px-4 py-2.5 text-xs text-primary-warm-white hover:bg-transparency-white-t4">Open in Claude ↗</a>
-            <a href={`https://chatgpt.com/?q=${llmPrompt}`} class="block px-4 py-2.5 text-xs text-primary-warm-white hover:bg-transparency-white-t4">Open in ChatGPT ↗</a>
-          </div>
-        </div>
+      <div class="hidden gap-2 lg:flex">
+        {docsUrl && <a href={docsUrl} class:list={[outlineAccentButtonSm, 'text-2xs uppercase tracking-widest']}>Learn more</a>}
+        <a href={workflowsUrl} class:list={[solidAccentButton, 'text-2xs uppercase tracking-widest']}>Try workflows</a>
+        {hfUrl && <a href={hfUrl} class:list={[outlineAccentButtonSm, 'text-2xs uppercase tracking-widest']}>Download weights ↗</a>}
       </div>
     </div>
     <p class="mt-2 max-w-3xl text-sm font-light leading-relaxed text-primary-comfy-canvas sm:text-base">{blurb}</p>
@@ -251,11 +241,37 @@ const faqJsonLd = {
         <button type="button" role="tab" data-tab="api" data-state="off" aria-controls="panel-api" aria-selected="false" class={tab}>API</button>
         <button type="button" role="tab" data-tab="gallery" data-state="off" aria-controls="panel-gallery" aria-selected="false" class={tab}>Examples</button>
       </nav>
-      <div class="hidden gap-2 pb-2 lg:flex">
-        <a href="https://comfy.org/download" class:list={[outlineButton, 'text-2xs uppercase tracking-widest']}>Run locally</a>
-        <a href={workflowsUrl} class:list={[outlineButton, 'text-2xs uppercase tracking-widest']}>Workflows ↗</a>
-        {hfUrl && <a href={hfUrl} class:list={[outlineButton, 'text-2xs uppercase tracking-widest']}>Download weights ↗</a>}
-        <a href="https://cloud.comfy.org?utm_source=models_v2_preview" class:list={[outlineButton, 'text-2xs uppercase tracking-widest']}>Open the full graph ↗</a>
+      <div class="hidden gap-2 sm:flex">
+        <div class="relative" id="llms-wrap">
+          <div class="inline-flex items-stretch divide-x divide-transparency-white-t20 overflow-hidden rounded-lg border border-transparency-white-t20 bg-transparency-white-t4 text-xs font-normal text-primary-comfy-canvas">
+            <button id="llms-copy" class="cursor-pointer px-3 py-2.5 transition-colors hover:bg-transparency-white-t8">Copy markdown<span id="llms-copied" class="hidden pl-2 text-primary-comfy-yellow">✓</span></button>
+            <button id="llms-btn" aria-haspopup="menu" aria-expanded="false" aria-label="More formats for LLMs" class="cursor-pointer px-2 transition-colors hover:bg-transparency-white-t8">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="size-4"><path d="m6 9 6 6 6-6"/></svg>
+            </button>
+          </div>
+          <div id="llms-menu" role="menu" class="absolute right-0 top-full z-40 mt-1.5 hidden w-60 overflow-hidden rounded-xl border border-transparency-white-t20 bg-site-dropdown py-1.5 shadow-2xl">
+            <a href={mdUrl} class="block px-4 py-2.5 text-xs text-primary-warm-white hover:bg-transparency-white-t4">View as Markdown</a>
+            <a href="/models-v2/llms.txt" class="block px-4 py-2.5 text-xs text-primary-warm-white hover:bg-transparency-white-t4">llms.txt — full catalog</a>
+          </div>
+        </div>
+        <div class="relative" id="graph-wrap">
+          <div class="inline-flex items-stretch divide-x divide-transparency-white-t20 overflow-hidden rounded-lg border border-transparency-white-t20 bg-transparency-white-t4 text-xs font-normal text-primary-comfy-canvas">
+            <a href="https://cloud.comfy.org?utm_source=models_v2_preview" class="px-3 py-2.5 transition-colors hover:bg-transparency-white-t8">Open the full graph</a>
+            <button id="graph-btn" aria-haspopup="menu" aria-expanded="false" aria-label="More ways to open this model" class="cursor-pointer px-2 transition-colors hover:bg-transparency-white-t8">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="size-4"><path d="m6 9 6 6 6-6"/></svg>
+            </button>
+          </div>
+          <div id="graph-menu" role="menu" class="absolute right-0 top-full z-40 mt-1.5 hidden w-60 overflow-hidden rounded-xl border border-transparency-white-t20 bg-site-dropdown py-1.5 shadow-2xl">
+            <a href={`https://chatgpt.com/?q=${llmPrompt}`} class="flex items-center justify-between gap-3 px-4 py-2.5 text-xs text-primary-warm-white hover:bg-transparency-white-t4">
+              Open in ChatGPT
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="size-4 shrink-0"><path d="M7 7h10v10"/><path d="M7 17 17 7"/></svg>
+            </a>
+            <a href={`https://claude.ai/new?q=${llmPrompt}`} class="flex items-center justify-between gap-3 px-4 py-2.5 text-xs text-primary-warm-white hover:bg-transparency-white-t4">
+              Open in Claude
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="size-4 shrink-0"><path d="M7 7h10v10"/><path d="M7 17 17 7"/></svg>
+            </a>
+          </div>
+        </div>
       </div>
     </div>
   </section>
@@ -762,26 +778,35 @@ const faqJsonLd = {
         renderAll()
       })
 
-      // LLMs menu
-      const llmsBtn = $('llms-btn')
-      const llmsMenu = $('llms-menu')
-      llmsBtn?.addEventListener('click', (e) => {
-        e.stopPropagation()
-        llmsMenu?.classList.toggle('hidden')
-      })
+      // split button menus
+      const splitMenus = [
+        { wrap: '#llms-wrap', trigger: 'llms-btn', menu: 'llms-menu' },
+        { wrap: '#graph-wrap', trigger: 'graph-btn', menu: 'graph-menu' }
+      ]
+      const setMenuOpen = (trigger: string, menu: string, open: boolean) => {
+        $(menu)?.classList.toggle('hidden', !open)
+        $(trigger)?.setAttribute('aria-expanded', String(open))
+      }
+      for (const { trigger, menu } of splitMenus) {
+        $(trigger)?.addEventListener('click', (e) => {
+          e.stopPropagation()
+          const open = $(menu)?.classList.contains('hidden') ?? false
+          for (const other of splitMenus) setMenuOpen(other.trigger, other.menu, false)
+          setMenuOpen(trigger, menu, open)
+        })
+      }
       document.addEventListener('click', (e) => {
-        if (!llmsMenu || llmsMenu.classList.contains('hidden')) return
-        if (!(e.target as HTMLElement).closest('#llms-wrap')) llmsMenu.classList.add('hidden')
+        const target = e.target as HTMLElement
+        for (const { wrap, trigger, menu } of splitMenus) {
+          if (!target.closest(wrap)) setMenuOpen(trigger, menu, false)
+        }
       })
       $('llms-copy')?.addEventListener('click', async () => {
         try {
           const md = await (await fetch(window.location.pathname + '.md')).text()
           await navigator.clipboard.writeText(md)
           $('llms-copied')?.classList.remove('hidden')
-          window.setTimeout(() => {
-            $('llms-copied')?.classList.add('hidden')
-            llmsMenu?.classList.add('hidden')
-          }, 1200)
+          window.setTimeout(() => $('llms-copied')?.classList.add('hidden'), 1200)
         } catch { /* fetch or clipboard unavailable */ }
       })
 

--- a/apps/website/src/pages/models-v2/[slug].astro
+++ b/apps/website/src/pages/models-v2/[slug].astro
@@ -5,7 +5,12 @@
 // receipt, live credit
 // repricing, LLMs menu with per-page markdown, gallery prompt warm-starts,
 // variations queue, and the full signup-journey demo. Not linked. noindex.
+import { cn } from '@comfyorg/tailwind-utils'
+
 import BaseLayout from '../../layouts/BaseLayout.astro'
+import GlassCard from '../../components/common/GlassCard.vue'
+import { brandButtonVariants } from '../../components/common/brandButton.variants'
+import { toggleVariants } from '../../components/ui/toggle'
 import {
   launches,
   topPartnerApis,
@@ -75,7 +80,25 @@ const promptExample = launch
 const baseCredits = kind === 'partner api' ? 12 : 6
 const kindLabel = kind === 'open weights' ? 'Open weights' : 'Partner API'
 const sentence = (s: string) => s.charAt(0).toUpperCase() + s.slice(1)
-const tagPill = 'inline-flex h-6 items-center rounded-full px-4 text-xs font-normal'
+const pill = 'inline-flex h-6 shrink-0 items-center rounded-full px-4 text-xs font-normal transition-colors'
+const pillMuted = 'bg-transparency-white-t4 text-primary-comfy-canvas'
+const pillActive = 'bg-transparency-white-t8 text-primary-comfy-canvas'
+const pillIdle = 'text-primary-warm-gray hover:bg-transparency-white-t4 hover:text-primary-comfy-canvas'
+const sectionTitle = 'text-xs font-bold uppercase tracking-widest text-primary-comfy-yellow'
+const panelTitle = 'text-xs font-bold uppercase tracking-widest text-primary-warm-white'
+const cardTitle = 'text-sm font-bold uppercase tracking-widest text-primary-comfy-yellow'
+const bodyCopy = 'text-sm font-light text-primary-warm-gray'
+const helperCopy = 'text-2xs font-light text-primary-warm-gray'
+const fieldLabel = 'block text-2xs font-bold uppercase tracking-widest text-primary-warm-gray'
+const textAction = 'text-2xs font-bold uppercase tracking-widest text-primary-warm-gray hover:text-primary-warm-white'
+const iconButton = 'group shrink-0 cursor-pointer rounded-lg border border-transparency-white-t20 bg-transparency-white-t4 p-1.5 text-primary-warm-gray transition-colors hover:bg-transparency-white-t8 hover:text-primary-warm-white'
+const primaryButton = brandButtonVariants({ variant: 'solid', size: 'xs' })
+const outlineAccentButton = brandButtonVariants({ variant: 'outline', size: 'xs' })
+const outlineButton = brandButtonVariants({ variant: 'outline-light', size: 'sm' })
+const tab = cn(
+  toggleVariants(),
+  'rounded-none px-4 first:rounded-l-xl last:rounded-r-xl'
+)
 const workflowsUrl = launch
   ? launch.workflowsUrl
   : registry!.hubSlug
@@ -177,112 +200,124 @@ const faqJsonLd = {
     <script is:inline type="application/ld+json" set:html={JSON.stringify(breadcrumbJsonLd)} />
     <script is:inline type="application/ld+json" set:html={JSON.stringify(faqJsonLd)} />
   </Fragment>
-  <div class="fixed right-3 top-3 z-50 rounded-full border border-primary-comfy-yellow/40 bg-primary-comfy-ink/90 px-3 py-1 text-[10px] font-bold uppercase tracking-[0.2em] text-primary-comfy-yellow backdrop-blur">
+  <div class="fixed right-3 top-3 z-50 rounded-full border border-primary-comfy-yellow/40 bg-primary-comfy-ink/90 px-3 py-1 text-2xs font-bold uppercase tracking-widest text-primary-comfy-yellow backdrop-blur">
     A/B preview · noindex
   </div>
 
   <!-- COMPACT HEADER -->
-  <section class="mx-auto max-w-7xl px-5 pt-8 sm:px-6 lg:px-8 lg:pt-12">
-    <p class="text-[11px] font-semibold uppercase tracking-[0.25em] text-primary-warm-gray">
+  <section class="mx-auto max-w-9xl px-5 pt-8 sm:px-6 lg:px-20 lg:pt-12">
+    <p class="text-2xs font-bold uppercase tracking-widest text-primary-warm-gray">
       <a href="/models-v2" class="hover:text-primary-warm-white">Models</a> / {meta.label} / {name}
     </p>
     <div class="mt-3 flex flex-wrap items-center justify-between gap-3">
       <div class="flex min-w-0 flex-wrap items-center gap-3">
         <h1 class="max-w-full truncate text-2xl font-semibold text-primary-warm-white sm:text-3xl">{name}</h1>
-        <span class="rounded-lg border border-white/15 bg-white/5 px-3 py-1.5 text-xs font-semibold text-primary-comfy-canvas">{meta.label}</span>
+        <span class:list={[pill, pillMuted]}>{meta.label}</span>
       </div>
       <div class="hidden gap-2 sm:flex">
-        {docsUrl && <a href={docsUrl} class="rounded-lg border border-white/15 bg-white/5 px-3 py-1.5 text-[11px] font-extrabold uppercase tracking-widest text-primary-comfy-canvas hover:bg-white/10">{launch?.launchUrl ? 'Launch page ↗' : 'Docs ↗'}</a>}
+        {docsUrl && <a href={docsUrl} class:list={[outlineButton, 'text-2xs uppercase tracking-widest']}>{launch?.launchUrl ? 'Launch page ↗' : 'Docs ↗'}</a>}
         <div class="relative" id="llms-wrap">
-          <button id="llms-btn" class="rounded-lg border border-white/15 bg-white/5 px-3 py-1.5 text-[11px] font-extrabold uppercase tracking-widest text-primary-comfy-canvas hover:bg-white/10">LLMs ▾</button>
-          <div id="llms-menu" class="absolute right-0 top-full z-40 mt-1.5 hidden w-60 overflow-hidden rounded-xl border border-white/15 bg-[#191320] py-1.5 shadow-2xl">
-            <button id="llms-copy" class="block w-full px-4 py-2.5 text-left text-xs text-primary-warm-white hover:bg-white/5">Copy page as Markdown<span id="llms-copied" class="hidden pl-2 text-[#b7ded5]">✓</span></button>
-            <a href={mdUrl} class="block px-4 py-2.5 text-xs text-primary-warm-white hover:bg-white/5">View as Markdown</a>
-            <a href="/models-v2/llms.txt" class="block px-4 py-2.5 text-xs text-primary-warm-white hover:bg-white/5">llms.txt — full catalog</a>
+          <button id="llms-btn" class="inline-flex items-center gap-3 rounded-lg border border-transparency-white-t20 bg-transparency-white-t4 px-3 py-2.5 text-xs font-normal text-primary-comfy-canvas transition-colors hover:bg-transparency-white-t8">
+            LLMs
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="size-4"><path d="m6 9 6 6 6-6"/></svg>
+          </button>
+          <div id="llms-menu" class="absolute right-0 top-full z-40 mt-1.5 hidden w-60 overflow-hidden rounded-xl border border-transparency-white-t20 bg-site-dropdown py-1.5 shadow-2xl">
+            <button id="llms-copy" class="block w-full cursor-pointer px-4 py-2.5 text-left text-xs text-primary-warm-white hover:bg-transparency-white-t4">Copy page as Markdown<span id="llms-copied" class="hidden pl-2 text-primary-comfy-yellow">✓</span></button>
+            <a href={mdUrl} class="block px-4 py-2.5 text-xs text-primary-warm-white hover:bg-transparency-white-t4">View as Markdown</a>
+            <a href="/models-v2/llms.txt" class="block px-4 py-2.5 text-xs text-primary-warm-white hover:bg-transparency-white-t4">llms.txt — full catalog</a>
             <div class="my-1 border-t border-white/10"></div>
-            <a href={`https://claude.ai/new?q=${llmPrompt}`} class="block px-4 py-2.5 text-xs text-primary-warm-white hover:bg-white/5">Open in Claude ↗</a>
-            <a href={`https://chatgpt.com/?q=${llmPrompt}`} class="block px-4 py-2.5 text-xs text-primary-warm-white hover:bg-white/5">Open in ChatGPT ↗</a>
+            <a href={`https://claude.ai/new?q=${llmPrompt}`} class="block px-4 py-2.5 text-xs text-primary-warm-white hover:bg-transparency-white-t4">Open in Claude ↗</a>
+            <a href={`https://chatgpt.com/?q=${llmPrompt}`} class="block px-4 py-2.5 text-xs text-primary-warm-white hover:bg-transparency-white-t4">Open in ChatGPT ↗</a>
           </div>
         </div>
       </div>
     </div>
     <p class="mt-2 max-w-3xl text-sm font-light leading-relaxed text-primary-comfy-canvas sm:text-base">{blurb}</p>
     <div class="mt-4 flex flex-wrap gap-1.5">
-      {dayZero && <span class:list={[tagPill, 'bg-primary-comfy-yellow text-primary-comfy-ink']}>Day zero</span>}
-      <span class:list={[tagPill, kind === 'open weights' ? 'bg-[#96b4ff]/15 text-[#96b4ff]' : 'bg-[#dbd6f2]/15 text-[#dbd6f2]']}>{kindLabel}</span>
-      <span class:list={[tagPill, 'bg-transparency-white-t4 text-primary-comfy-canvas']}>Commercial use</span>
-      <span class:list={[tagPill, 'bg-transparency-white-t4 text-primary-comfy-canvas']}>{sentence(price)}</span>
-      <span class:list={[tagPill, 'bg-transparency-white-t4 text-primary-comfy-canvas']}>{sentence(runs)}</span>
+      {dayZero && <span class:list={[pill, 'bg-primary-comfy-yellow text-primary-comfy-ink']}>Day zero</span>}
+      <span class:list={[pill, kind === 'open weights' ? 'bg-primary-comfy-plum/30 text-primary-comfy-canvas' : 'bg-secondary-mauve/30 text-primary-comfy-canvas']}>{kindLabel}</span>
+      <span class:list={[pill, pillMuted]}>Commercial use</span>
+      <span class:list={[pill, pillMuted]}>{sentence(price)}</span>
+      <span class:list={[pill, pillMuted]}>{sentence(runs)}</span>
     </div>
   </section>
 
   <!-- TABS + TRIO -->
-  <section class="mx-auto max-w-7xl px-5 pt-6 sm:px-6 lg:px-8">
-    <div class="flex flex-wrap items-center justify-between gap-4 border-b border-white/10 pb-0">
-      <nav class="flex gap-6 overflow-x-auto text-xs font-extrabold uppercase tracking-[0.2em] sm:gap-8" role="tablist" aria-label="Model page sections">
-        <button type="button" role="tab" data-tab="playground" aria-controls="panel-playground" aria-selected="true" class="border-b-2 border-transparent pb-3 uppercase text-primary-warm-gray transition hover:text-primary-warm-white aria-selected:border-primary-comfy-yellow aria-selected:text-primary-comfy-yellow">Playground</button>
-        <button type="button" role="tab" data-tab="api" aria-controls="panel-api" aria-selected="false" class="border-b-2 border-transparent pb-3 uppercase text-primary-warm-gray transition hover:text-primary-warm-white aria-selected:border-primary-comfy-yellow aria-selected:text-primary-comfy-yellow">API</button>
-        <button type="button" role="tab" data-tab="gallery" aria-controls="panel-gallery" aria-selected="false" class="border-b-2 border-transparent pb-3 uppercase text-primary-warm-gray transition hover:text-primary-warm-white aria-selected:border-primary-comfy-yellow aria-selected:text-primary-comfy-yellow">Examples</button>
-        <a href={workflowsUrl} class="pb-3 text-primary-warm-gray hover:text-primary-warm-white">Workflows ↗</a>
+  <section class="mx-auto max-w-9xl px-5 pt-6 sm:px-6 lg:px-20">
+    <div class="flex flex-wrap items-center justify-between gap-4">
+      <nav class="ring-primary-warm-white/20 flex w-fit max-w-full items-center gap-0.5 overflow-x-auto rounded-2xl p-1.5 ring-2" role="tablist" aria-label="Model page sections">
+        <button type="button" role="tab" data-tab="playground" data-state="on" aria-controls="panel-playground" aria-selected="true" class={tab}>Playground</button>
+        <button type="button" role="tab" data-tab="api" data-state="off" aria-controls="panel-api" aria-selected="false" class={tab}>API</button>
+        <button type="button" role="tab" data-tab="gallery" data-state="off" aria-controls="panel-gallery" aria-selected="false" class={tab}>Examples</button>
+        <a href={workflowsUrl} data-state="off" class={tab}>Workflows ↗</a>
       </nav>
       <div class="hidden gap-2 pb-2 lg:flex">
-        <a href="https://comfy.org/download" class="rounded-lg border border-white/15 bg-white/5 px-4 py-2 text-[11px] font-extrabold uppercase tracking-widest text-primary-warm-white hover:bg-white/10">Run locally</a>
-        {hfUrl && <a href={hfUrl} class="rounded-lg border border-white/15 bg-white/5 px-4 py-2 text-[11px] font-extrabold uppercase tracking-widest text-primary-warm-white hover:bg-white/10">Download weights ↗</a>}
-        <a href="https://cloud.comfy.org?utm_source=models_v2_preview" class="rounded-lg border border-white/15 bg-white/5 px-4 py-2 text-[11px] font-extrabold uppercase tracking-widest text-primary-warm-white hover:bg-white/10">Open the full graph ↗</a>
+        <a href="https://comfy.org/download" class:list={[outlineButton, 'text-2xs uppercase tracking-widest']}>Run locally</a>
+        {hfUrl && <a href={hfUrl} class:list={[outlineButton, 'text-2xs uppercase tracking-widest']}>Download weights ↗</a>}
+        <a href="https://cloud.comfy.org?utm_source=models_v2_preview" class:list={[outlineButton, 'text-2xs uppercase tracking-widest']}>Open the full graph ↗</a>
       </div>
     </div>
   </section>
 
   <!-- PLAYGROUND -->
-  <section id="panel-playground" data-panel="playground" role="tabpanel" class="mx-auto max-w-7xl px-5 pt-6 sm:px-6 lg:px-8">
-    <div id="signed-in-strip" class="mb-4 hidden items-center justify-between gap-3 rounded-xl border border-[#b7ded5]/40 bg-[#b7ded5]/10 px-4 py-2.5 sm:flex-nowrap">
-      <p class="text-[11px] font-extrabold uppercase tracking-[0.15em] text-[#b7ded5]">Signed in · inputs restored — no survey, no plan picker</p>
-      <p id="free-meter" class="shrink-0 text-[11px] font-extrabold uppercase tracking-widest text-primary-comfy-yellow">Free runs: 5 left</p>
+  <section id="panel-playground" data-panel="playground" role="tabpanel" class="mx-auto max-w-9xl px-5 pt-6 sm:px-6 lg:px-20">
+    <div id="signed-in-strip" class="mb-4 hidden items-center justify-between gap-3 rounded-xl border border-primary-comfy-yellow/40 bg-primary-comfy-yellow/10 px-4 py-2.5 sm:flex-nowrap">
+      <p class="text-2xs font-bold uppercase tracking-widest text-primary-comfy-yellow">Signed in · inputs restored — no survey, no plan picker</p>
+      <p id="free-meter" class="shrink-0 text-2xs font-bold uppercase tracking-widest text-primary-comfy-yellow">Free runs: 5 left</p>
     </div>
 
-    <div class="grid gap-5 lg:grid-cols-2">
+    <GlassCard class="grid gap-2 lg:grid-cols-2">
       <!-- INPUT CARD -->
-      <div class="rounded-2xl border border-white/10 p-5 sm:p-6">
+      <div class="rounded-4xl bg-primary-comfy-ink p-5 sm:p-6">
         <div class="flex items-center justify-between">
-          <h2 class="text-xs font-extrabold uppercase tracking-[0.2em] text-primary-warm-white">Input</h2>
+          <h2 class={cardTitle}>Input</h2>
           <div id="iview-toggle" class="flex gap-1.5">
-            <button data-iview="app" class="inline-flex h-6 items-center rounded-full px-4 text-xs font-normal transition-colors bg-transparency-white-t8 text-primary-comfy-canvas">App</button>
-            <button data-iview="json" class="inline-flex h-6 items-center rounded-full px-4 text-xs font-normal transition-colors text-primary-warm-gray hover:bg-transparency-white-t4 hover:text-primary-comfy-canvas">JSON</button>
+            <button data-iview="app" class:list={[pill, pillActive]}>App</button>
+            <button data-iview="json" class:list={[pill, pillIdle]}>JSON</button>
           </div>
         </div>
 
         <!-- APP VIEW — the workflow's exposed inputs, rendered as an app -->
         <div id="panel-app">
-          <label class="mt-5 block text-[10px] font-extrabold uppercase tracking-[0.25em] text-primary-warm-gray">Prompt *</label>
+          <label class:list={[fieldLabel, 'mt-5']}>Prompt *</label>
           <textarea
             id="pg-prompt"
             rows="4"
-            class="mt-2 w-full resize-none rounded-xl border border-white/15 bg-primary-comfy-ink p-4 text-sm font-light leading-relaxed text-primary-comfy-canvas focus:border-primary-comfy-yellow/60 focus:outline-none"
+            class="mt-2 w-full resize-none rounded-xl border border-transparency-white-t20 bg-transparency-white-t4 p-4 text-sm font-light leading-relaxed text-primary-comfy-canvas focus:border-primary-comfy-yellow/60 focus:outline-none"
           >{promptExample}</textarea>
-          <p class="mt-1.5 text-[11px] font-light text-primary-warm-gray">App view = this workflow’s exposed inputs.</p>
+          <p class:list={[helperCopy, 'mt-1.5']}>App view = this workflow’s exposed inputs.</p>
           <div class="mt-4 grid grid-cols-3 gap-2.5">
             <div>
-              <span class="block text-[10px] font-extrabold uppercase tracking-[0.2em] text-primary-warm-gray">Aspect</span>
-              <select id="sel-aspect" class="mt-1.5 w-full rounded-lg border border-white/15 bg-primary-comfy-ink px-3 py-2.5 text-xs text-primary-comfy-canvas focus:border-primary-comfy-yellow/60 focus:outline-none">
-                <option>16:9</option><option>9:16</option><option>1:1</option>
-              </select>
+              <span class={fieldLabel}>Aspect</span>
+              <div class="relative mt-1.5">
+                <select id="sel-aspect" class="w-full appearance-none rounded-lg border border-transparency-white-t20 bg-transparency-white-t4 py-2.5 pl-3 pr-10 text-xs text-primary-comfy-canvas focus:border-primary-comfy-yellow/60 focus:outline-none">
+                  <option>16:9</option><option>9:16</option><option>1:1</option>
+                </select>
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="pointer-events-none absolute right-3 top-1/2 size-4 -translate-y-1/2 text-primary-comfy-canvas"><path d="m6 9 6 6 6-6"/></svg>
+              </div>
             </div>
             <div>
-              <span class="block text-[10px] font-extrabold uppercase tracking-[0.2em] text-primary-warm-gray">Duration</span>
-              <select id="sel-duration" class="mt-1.5 w-full rounded-lg border border-white/15 bg-primary-comfy-ink px-3 py-2.5 text-xs text-primary-comfy-canvas focus:border-primary-comfy-yellow/60 focus:outline-none">
-                <option data-mult="1">5 s</option><option data-mult="2">10 s</option>
-              </select>
+              <span class={fieldLabel}>Duration</span>
+              <div class="relative mt-1.5">
+                <select id="sel-duration" class="w-full appearance-none rounded-lg border border-transparency-white-t20 bg-transparency-white-t4 py-2.5 pl-3 pr-10 text-xs text-primary-comfy-canvas focus:border-primary-comfy-yellow/60 focus:outline-none">
+                  <option data-mult="1">5 s</option><option data-mult="2">10 s</option>
+                </select>
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="pointer-events-none absolute right-3 top-1/2 size-4 -translate-y-1/2 text-primary-comfy-canvas"><path d="m6 9 6 6 6-6"/></svg>
+              </div>
             </div>
             <div>
-              <span class="block text-[10px] font-extrabold uppercase tracking-[0.2em] text-primary-warm-gray">Resolution</span>
-              <select id="sel-resolution" class="mt-1.5 w-full rounded-lg border border-white/15 bg-primary-comfy-ink px-3 py-2.5 text-xs text-primary-comfy-canvas focus:border-primary-comfy-yellow/60 focus:outline-none">
-                <option data-mult="1">720p</option><option data-mult="2">1080p</option>
-              </select>
+              <span class={fieldLabel}>Resolution</span>
+              <div class="relative mt-1.5">
+                <select id="sel-resolution" class="w-full appearance-none rounded-lg border border-transparency-white-t20 bg-transparency-white-t4 py-2.5 pl-3 pr-10 text-xs text-primary-comfy-canvas focus:border-primary-comfy-yellow/60 focus:outline-none">
+                  <option data-mult="1">720p</option><option data-mult="2">1080p</option>
+                </select>
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="pointer-events-none absolute right-3 top-1/2 size-4 -translate-y-1/2 text-primary-comfy-canvas"><path d="m6 9 6 6 6-6"/></svg>
+              </div>
             </div>
           </div>
-          <label class="mt-4 block text-[10px] font-extrabold uppercase tracking-[0.25em] text-primary-warm-gray">Reference image</label>
-          <div id="dropzone" class="mt-2 flex items-center gap-3 rounded-xl border border-dashed border-white/25 bg-white/[0.02] px-4 py-4">
-            <button id="add-image-btn" class="rounded-lg bg-white/10 px-3 py-1.5 text-[10px] font-extrabold uppercase tracking-wider text-primary-comfy-canvas hover:bg-white/15">Add image ▾</button>
+          <label class:list={[fieldLabel, 'mt-4']}>Reference image</label>
+          <div id="dropzone" class="mt-2 flex items-center gap-3 rounded-xl border border-dashed border-transparency-white-t20 bg-transparency-white-t4 px-4 py-4">
+            <button id="add-image-btn" class:list={[outlineButton, 'px-3 py-1.5 text-2xs uppercase tracking-widest']}>Add image ▾</button>
             <span id="dropzone-label" class="text-xs font-light text-primary-warm-gray">or drop a frame to animate it</span>
             <img id="ref-thumb" src={gallery[1] ?? gallery[0]} alt="" class="ml-auto hidden h-10 w-16 rounded-md object-cover" onerror="this.style.display='none'" />
           </div>
@@ -290,103 +325,107 @@ const faqJsonLd = {
 
         <!-- JSON VIEW -->
         <div id="panel-json" class="hidden">
-          <div class="relative mt-4 overflow-hidden rounded-2xl border border-white/15">
+          <div class="relative mt-4 overflow-hidden rounded-2xl border border-transparency-white-t20">
             <pre id="input-json" class="max-h-96 scrollbar-code overflow-auto whitespace-pre-wrap break-words p-4 font-mono text-xs leading-relaxed text-primary-warm-gray"></pre>
-            <button type="button" data-copy="input-json" title="Copy" aria-label="Copy" class="absolute right-3 top-3 group shrink-0 cursor-pointer rounded-lg border border-white/15 bg-white/5 p-1.5 text-primary-warm-gray transition-colors hover:bg-white/10 hover:text-primary-warm-white"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="size-3.5 group-data-[copied]:hidden"><rect width="14" height="14" x="8" y="8" rx="2" ry="2"/><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/></svg><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="hidden size-3.5 group-data-[copied]:block"><path d="M20 6 9 17l-5-5"/></svg></button>
+            <button type="button" data-copy="input-json" title="Copy" aria-label="Copy" class:list={[iconButton, 'absolute right-3 top-3']}><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="size-3.5 group-data-[copied]:hidden"><rect width="14" height="14" x="8" y="8" rx="2" ry="2"/><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/></svg><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="hidden size-3.5 group-data-[copied]:block"><path d="M20 6 9 17l-5-5"/></svg></button>
           </div>
-          <p class="mt-2 text-[11px] font-light text-primary-warm-gray">Live from your inputs — the exact payload the API takes.</p>
+          <p class:list={[helperCopy, 'mt-2']}>Live from your inputs — the exact payload the API takes.</p>
         </div>
 
         <div class="mt-5 flex items-center justify-between gap-3 border-t border-white/10 pt-4">
-          <button id="pg-reset" class="text-[11px] font-extrabold uppercase tracking-widest text-primary-warm-gray hover:text-primary-warm-white">Reset</button>
+          <button id="pg-reset" class={textAction}>Reset</button>
           <div class="flex items-center gap-3">
-            <span class="hidden text-[11px] text-primary-warm-gray sm:block"><span id="cost-line">{baseCredits} credits ≈ ${(baseCredits * 0.0084).toFixed(2)}</span> · est.</span>
-            <button id="pg-run" data-base-credits={baseCredits} data-slug={slugId} class="rounded-xl bg-primary-comfy-yellow px-6 py-3 text-xs font-extrabold uppercase tracking-widest text-primary-comfy-ink transition hover:brightness-110">
+            <span class="hidden text-2xs text-primary-warm-gray sm:block"><span id="cost-line">{baseCredits} credits ≈ ${(baseCredits * 0.0084).toFixed(2)}</span> · est.</span>
+            <button id="pg-run" data-base-credits={baseCredits} data-slug={slugId} class:list={[primaryButton, 'uppercase tracking-widest']}>
               Sign in to run — 5 free
             </button>
           </div>
         </div>
-        <p class="mt-3 text-[11px] font-light text-primary-warm-gray">▶ Demo: everything above works — flip the views, change resolution (watch the price), add a reference image, then Run.</p>
+        <p class:list={[helperCopy, 'mt-3']}>▶ Demo: everything above works — flip the views, change resolution (watch the price), add a reference image, then Run.</p>
       </div>
 
       <!-- RESULT CARD -->
-      <div class="flex flex-col rounded-2xl border border-white/10 p-5 sm:p-6">
+      <div class="flex flex-col rounded-4xl bg-primary-comfy-ink p-5 sm:p-6">
         <div class="flex items-center justify-between">
-          <h2 class="text-[11px] font-extrabold uppercase tracking-[0.2em] text-primary-warm-white">Result</h2>
+          <h2 class={cardTitle}>Result</h2>
           <div id="rview-toggle" class="flex gap-1.5">
-            <button data-rview="preview" class="inline-flex h-6 items-center rounded-full px-4 text-xs font-normal transition-colors bg-transparency-white-t8 text-primary-comfy-canvas">Preview</button>
-            <button data-rview="json" class="inline-flex h-6 items-center rounded-full px-4 text-xs font-normal transition-colors text-primary-warm-gray hover:bg-transparency-white-t4 hover:text-primary-comfy-canvas">JSON</button>
+            <button data-rview="preview" class:list={[pill, pillActive]}>Preview</button>
+            <button data-rview="json" class:list={[pill, pillIdle]}>JSON</button>
           </div>
         </div>
         <div class="relative mt-5 aspect-video w-full overflow-hidden rounded-2xl">
           <img id="result-img" src={img} alt={`${name} output`} class="h-full w-full object-cover transition-opacity duration-500" onerror="this.style.display='none'" />
-          <div id="result-json-box" class="absolute inset-0 hidden overflow-hidden rounded-2xl border border-white/15">
+          <div id="result-json-box" class="absolute inset-0 hidden overflow-hidden rounded-2xl border border-transparency-white-t20">
             <pre id="result-json" class="scrollbar-code h-full overflow-auto whitespace-pre-wrap break-words p-4 font-mono text-xs leading-relaxed text-primary-warm-gray"></pre>
-            <button type="button" data-copy="result-json" title="Copy" aria-label="Copy" class="absolute right-3 top-3 group shrink-0 cursor-pointer rounded-lg border border-white/15 bg-white/5 p-1.5 text-primary-warm-gray transition-colors hover:bg-white/10 hover:text-primary-warm-white"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="size-3.5 group-data-[copied]:hidden"><rect width="14" height="14" x="8" y="8" rx="2" ry="2"/><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/></svg><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="hidden size-3.5 group-data-[copied]:block"><path d="M20 6 9 17l-5-5"/></svg></button>
+            <button type="button" data-copy="result-json" title="Copy" aria-label="Copy" class:list={[iconButton, 'absolute right-3 top-3']}><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="size-3.5 group-data-[copied]:hidden"><rect width="14" height="14" x="8" y="8" rx="2" ry="2"/><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/></svg><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="hidden size-3.5 group-data-[copied]:block"><path d="M20 6 9 17l-5-5"/></svg></button>
           </div>
           <div id="running-overlay" class="absolute inset-0 hidden flex-col items-center justify-center gap-4 bg-primary-comfy-ink/95 px-8 text-center">
-            <p class="text-[10px] font-extrabold uppercase tracking-[0.25em] text-[#b7ded5]">Restored your prompt and settings ✓</p>
+            <p class={sectionTitle}>Restored your prompt and settings ✓</p>
             <p class="text-lg font-semibold text-primary-warm-white">Running the graph</p>
             <div class="h-1.5 w-56 overflow-hidden rounded-full bg-white/10 sm:w-72">
               <div id="progress-fill" class="h-full w-0 rounded-full bg-primary-comfy-yellow transition-[width] duration-[2200ms] ease-out"></div>
             </div>
-            <p class="font-mono text-[11px] text-primary-warm-gray">ksampler · queue position 1</p>
+            <p class="font-mono text-2xs text-primary-warm-gray">ksampler · queue position 1</p>
           </div>
           <div id="upgrade-overlay" class="absolute inset-0 hidden flex-col justify-center gap-3 overflow-y-auto bg-primary-comfy-ink/[0.97] px-6 py-6 sm:px-10">
-            <p class="text-[10px] font-extrabold uppercase tracking-[0.25em] text-primary-comfy-yellow">That was your fifth free run</p>
+            <p class={sectionTitle}>That was your fifth free run</p>
             <p class="text-xl font-semibold text-primary-warm-white sm:text-2xl">Keep running it.</p>
             <div class="divide-y divide-white/10 border-y border-white/10">
               <div class="flex items-center justify-between gap-4 py-2.5">
-                <span class="text-xs font-extrabold uppercase tracking-wider text-primary-warm-white">Creator — $20/mo · est.</span>
-                <span class="text-[11px] font-light text-primary-comfy-canvas">≈ 220 runs of 720p · 1080p included</span>
+                <span class="text-xs font-bold uppercase tracking-widest text-primary-warm-white">Creator — $20/mo · est.</span>
+                <span class="text-2xs font-light text-primary-comfy-canvas">≈ 220 runs of 720p · 1080p included</span>
               </div>
               <div class="flex items-center justify-between gap-4 py-2.5">
-                <span class="text-xs font-extrabold uppercase tracking-wider text-primary-warm-white">Pro — $60/mo · est.</span>
-                <span class="text-[11px] font-light text-primary-comfy-canvas">≈ 800 runs · API keys · batch queues</span>
+                <span class="text-xs font-bold uppercase tracking-widest text-primary-warm-white">Pro — $60/mo · est.</span>
+                <span class="text-2xs font-light text-primary-comfy-canvas">≈ 800 runs · API keys · batch queues</span>
               </div>
             </div>
             <p class="text-xs font-light leading-relaxed text-primary-warm-gray">Your graphs, seeds, history, and all five outputs stay yours — free, forever. Or run it locally: it’s open source.</p>
             <div class="flex flex-wrap items-center gap-4">
-              <button class="rounded-xl bg-primary-comfy-yellow px-5 py-2.5 text-[11px] font-extrabold uppercase tracking-widest text-primary-comfy-ink">Go Creator</button>
-              <span class="text-[11px] font-extrabold uppercase tracking-widest text-primary-comfy-canvas">See all plans →</span>
-              <button id="demo-reset" class="text-[11px] font-extrabold uppercase tracking-widest text-primary-warm-gray underline-offset-4 hover:underline">Replay demo</button>
+              <button class:list={[primaryButton, 'uppercase tracking-widest']}>Go Creator</button>
+              <span class="text-2xs font-bold uppercase tracking-widest text-primary-comfy-canvas">See all plans →</span>
+              <button id="demo-reset" class={textAction}>Replay demo</button>
             </div>
           </div>
         </div>
         <div class="flex items-center justify-between gap-3 pt-3">
-          <p id="result-meta" class="truncate text-[10px] font-semibold uppercase tracking-[0.15em] text-primary-warm-gray">Seed 428790123 · 4.2s render · prompt saved through sign-in</p>
-          <span class="shrink-0 text-[11px] font-extrabold uppercase tracking-widest text-primary-comfy-yellow">Download ↓</span>
+          <p id="result-meta" class="truncate text-2xs font-bold uppercase tracking-widest text-primary-warm-gray">Seed 428790123 · 4.2s render · prompt saved through sign-in</p>
+          <span class="shrink-0 text-2xs font-bold uppercase tracking-widest text-primary-comfy-yellow">Download ↓</span>
         </div>
         <!-- VARIATIONS QUEUE -->
         <div id="var-block" class="hidden border-t border-white/10 px-5 py-4">
           <div class="flex items-center justify-between gap-3">
-            <p class="text-[10px] font-extrabold uppercase tracking-[0.2em] text-primary-warm-white">The queue — pick the best, not the first</p>
-            <button id="queue-vars" class="rounded-lg bg-primary-comfy-yellow px-3 py-1.5 text-[10px] font-extrabold uppercase tracking-widest text-primary-comfy-ink">Queue 4 variations — <span id="var-cost">24</span> cr</button>
+            <p class={panelTitle}>The queue — pick the best, not the first</p>
+            <button id="queue-vars" class:list={[primaryButton, 'uppercase tracking-widest']}>Queue 4 variations — <span id="var-cost">24</span> cr</button>
           </div>
           <div id="var-strip" class="mt-3 hidden grid-cols-4 gap-2">
             {[0, 1, 2, 3].map((i) => (
-              <div class="var-slot relative aspect-video overflow-hidden rounded-lg border border-white/10 bg-white/[0.04]">
+              <div class="var-slot relative aspect-video overflow-hidden rounded-lg border border-white/10 bg-transparency-white-t4">
                 <div class="var-shimmer absolute inset-0 animate-pulse bg-white/[0.06]"></div>
                 <img data-var-img={gallery[i % gallery.length]} alt="" class="hidden h-full w-full object-cover" onerror="this.style.display='none'" />
                 <span class="absolute bottom-1 left-1.5 hidden rounded bg-black/60 px-1 py-0.5 font-mono text-[8px] text-primary-comfy-canvas">seed +{i + 1}</span>
               </div>
             ))}
           </div>
-          <p id="var-note" class="mt-2 hidden text-[10px] font-light text-primary-warm-gray">Four seeds, one brief — charged on success only. This is the Queue mentality.</p>
+          <p id="var-note" class:list={[helperCopy, 'mt-2 hidden']}>Four seeds, one brief — charged on success only. This is the Queue mentality.</p>
         </div>
       </div>
-    </div>
+    </GlassCard>
 
-    <div class="mt-4 rounded-xl border border-primary-comfy-yellow/30 bg-primary-comfy-yellow/10 px-4 py-3 text-[11px] font-extrabold uppercase tracking-[0.15em] text-primary-comfy-yellow">
-      Five free runs after sign-in. No card. Your prompt and settings carry over.
+    <div class="mt-4 flex flex-col gap-4 rounded-3xl bg-primary-comfy-ink-light px-8 py-6 sm:flex-row sm:items-center sm:justify-between">
+      <div>
+        <p class="text-lg font-bold text-primary-comfy-canvas">Start free. Upgrade when you're ready.</p>
+        <p class="mt-1 text-sm text-primary-comfy-canvas">5 free runs on real GPUs — no credit card required.</p>
+      </div>
+      <button id="free-run-cta" class:list={[outlineAccentButton, 'shrink-0 self-start sm:self-auto']}>Try free</button>
     </div>
   </section>
 
   <!-- EXAMPLES -->
-  <section id="panel-gallery" data-panel="gallery" role="tabpanel" hidden class="mx-auto max-w-7xl scroll-mt-24 px-5 py-12 sm:px-6 lg:px-8 lg:py-16">
+  <section id="panel-gallery" data-panel="gallery" role="tabpanel" hidden class="mx-auto max-w-9xl scroll-mt-24 px-5 py-12 sm:px-6 lg:px-20 lg:py-16">
     <div class="mb-6">
-      <h2 class="text-sm font-extrabold uppercase tracking-[0.3em] text-primary-comfy-yellow">Made with {name}</h2>
-      <p class="mt-1.5 text-sm font-light text-primary-warm-gray">Real outputs from the workflow templates — click one to load its prompt into the app.</p>
+      <h2 class={sectionTitle}>Made with {name}</h2>
+      <p class:list={[bodyCopy, 'mt-2']}>Real outputs from the workflow templates — click one to load its prompt into the app.</p>
     </div>
     <ul class="grid grid-cols-2 gap-3 sm:gap-5 lg:grid-cols-3">
       {gallery.map((src, i) => (
@@ -394,7 +433,7 @@ const faqJsonLd = {
           <img src={src} alt={`${name} example`} loading="lazy" class="aspect-video w-full object-cover transition duration-500 group-hover:scale-[1.03]" onerror="this.style.display='none'" />
           <button
             data-use-prompt={galleryPrompts[i % galleryPrompts.length]}
-            class="absolute inset-x-0 bottom-0 bg-gradient-to-t from-primary-comfy-ink/95 to-transparent px-3 pb-2.5 pt-8 text-right text-[10px] font-extrabold uppercase tracking-widest text-primary-comfy-yellow opacity-100 transition lg:opacity-0 lg:group-hover:opacity-100"
+            class="absolute inset-x-0 bottom-0 bg-gradient-to-t from-primary-comfy-ink/95 to-transparent px-3 pb-2.5 pt-8 text-right text-2xs font-bold uppercase tracking-widest text-primary-comfy-yellow opacity-100 transition lg:opacity-0 lg:group-hover:opacity-100"
           >
             Use this prompt →
           </button>
@@ -404,79 +443,81 @@ const faqJsonLd = {
   </section>
 
   <!-- API -->
-  <section id="panel-api" data-panel="api" role="tabpanel" hidden class="mx-auto max-w-7xl scroll-mt-24 px-5 py-12 sm:px-6 lg:px-8 lg:pb-24">
-    <h2 class="text-sm font-extrabold uppercase tracking-[0.3em] text-primary-comfy-yellow">Run it your way</h2>
-    <div class="mt-4 overflow-hidden rounded-2xl border border-white/15">
-      <div class="flex items-center justify-between gap-3 border-b border-white/15 px-4 py-2.5">
-        <span class="truncate text-[11px] font-extrabold uppercase tracking-widest text-primary-warm-gray">curl</span>
-        <button type="button" data-copy="api-curl" title="Copy" aria-label="Copy" class="group shrink-0 cursor-pointer rounded-lg border border-white/15 bg-white/5 p-1.5 text-primary-warm-gray transition-colors hover:bg-white/10 hover:text-primary-warm-white"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="size-3.5 group-data-[copied]:hidden"><rect width="14" height="14" x="8" y="8" rx="2" ry="2"/><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/></svg><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="hidden size-3.5 group-data-[copied]:block"><path d="M20 6 9 17l-5-5"/></svg></button>
+  <section id="panel-api" data-panel="api" role="tabpanel" hidden class="mx-auto max-w-9xl scroll-mt-24 px-5 py-12 sm:px-6 lg:px-20 lg:pb-24">
+    <h2 class={sectionTitle}>Run it your way</h2>
+    <div class="mt-4 overflow-hidden rounded-2xl border border-transparency-white-t20">
+      <div class="flex items-center justify-between gap-3 border-b border-transparency-white-t20 px-4 py-2.5">
+        <span class="truncate text-2xs font-bold uppercase tracking-widest text-primary-warm-gray">curl</span>
+        <button type="button" data-copy="api-curl" title="Copy" aria-label="Copy" class={iconButton}><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="size-3.5 group-data-[copied]:hidden"><rect width="14" height="14" x="8" y="8" rx="2" ry="2"/><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/></svg><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="hidden size-3.5 group-data-[copied]:block"><path d="M20 6 9 17l-5-5"/></svg></button>
       </div>
       {curlHtml
         ? <pre id="api-curl" class="scrollbar-code overflow-auto whitespace-pre-wrap break-words p-4 font-mono text-xs leading-relaxed text-primary-warm-gray" set:html={curlHtml} />
         : <pre id="api-curl" class="scrollbar-code overflow-auto whitespace-pre-wrap break-words p-4 font-mono text-xs leading-relaxed text-primary-warm-gray">{curlSnippet}</pre>}
     </div>
-    <p class="mt-3 text-xs font-light text-primary-warm-gray">The app above is this call — the JSON view shows the exact payload. Full reference · Comfy MCP · <a href={mdUrl} class="text-primary-comfy-yellow">this page as Markdown</a> · <a href="/models-v2/llms.txt" class="text-primary-comfy-yellow">llms.txt</a></p>
+    <p class:list={[helperCopy, 'mt-3']}>The app above is this call — the JSON view shows the exact payload. Full reference · Comfy MCP · <a href={mdUrl} class="text-primary-comfy-yellow">this page as Markdown</a> · <a href="/models-v2/llms.txt" class="text-primary-comfy-yellow">llms.txt</a></p>
   </section>
 
   <!-- COST + FAMILY -->
   <section class="py-12 lg:py-16">
-    <div class="mx-auto max-w-7xl px-5 sm:px-6 lg:px-8">
-      <div class="grid gap-5 lg:grid-cols-2">
-        <div class="rounded-2xl border border-white/10 bg-white/[0.04] p-6 sm:p-7">
-          <h2 class="text-xs font-extrabold uppercase tracking-[0.25em] text-primary-comfy-yellow">What it costs</h2>
-          <p class="mt-2 text-sm font-light text-primary-warm-gray">Credits before you commit. No surprises after the wall.</p>
-          <div class="mt-4 divide-y divide-white/10 border-t border-white/10">
-            {costRows.map(([l, v]) => (
-              <div class="flex items-center justify-between gap-4 py-3">
-                <span class="text-sm text-primary-warm-white">{l}</span>
-                <span class="text-right text-xs font-semibold text-primary-comfy-canvas">{v}</span>
-              </div>
-            ))}
-          </div>
-        </div>
-        {familyVariants.length > 0 && (
-          <div class="rounded-2xl border border-white/10 bg-white/[0.04] p-6 sm:p-7">
-            <h2 class="text-xs font-extrabold uppercase tracking-[0.25em] text-primary-comfy-yellow">Family files &amp; variants</h2>
-            <p class="mt-2 text-sm font-light text-primary-warm-gray">Related files from the registry — every one runnable on the graph.</p>
+    <div class="mx-auto max-w-9xl px-5 sm:px-6 lg:px-20">
+      <GlassCard>
+        <div class="grid gap-2 lg:grid-cols-2">
+          <div class="rounded-4xl bg-primary-comfy-ink p-6 sm:p-7">
+            <h2 class={cardTitle}>What it costs</h2>
+            <p class:list={[bodyCopy, 'mt-2']}>Credits before you commit. No surprises after the wall.</p>
             <div class="mt-4 divide-y divide-white/10 border-t border-white/10">
-              {familyVariants.map((v) => (
-                <a href={`/models-v2/${v.slug}`} class="flex items-center justify-between gap-4 py-3 transition hover:bg-white/[0.03]">
-                  <div class="min-w-0">
-                    <p class="truncate text-sm font-semibold text-primary-warm-white">{v.displayName}</p>
-                    <p class="text-[11px] font-light text-primary-warm-gray">{dirLabel[v.directory] ?? v.directory} · {v.workflowCount} workflows</p>
-                  </div>
-                  <span class="shrink-0 text-[11px] font-extrabold uppercase tracking-widest text-primary-comfy-yellow">Run →</span>
-                </a>
+              {costRows.map(([l, v]) => (
+                <div class="flex items-center justify-between gap-4 py-3">
+                  <span class="text-sm text-primary-warm-white">{l}</span>
+                  <span class="text-right text-xs font-semibold text-primary-comfy-canvas">{v}</span>
+                </div>
               ))}
             </div>
           </div>
-        )}
-      </div>
+          {familyVariants.length > 0 && (
+            <div class="rounded-4xl bg-primary-comfy-ink p-6 sm:p-7">
+              <h2 class={cardTitle}>Family files &amp; variants</h2>
+              <p class:list={[bodyCopy, 'mt-2']}>Related files from the registry — every one runnable on the graph.</p>
+              <div class="mt-4 divide-y divide-white/10 border-t border-white/10">
+                {familyVariants.map((v) => (
+                  <a href={`/models-v2/${v.slug}`} class="flex items-center justify-between gap-4 py-3 transition hover:bg-white/[0.03]">
+                    <div class="min-w-0">
+                      <p class="truncate text-sm font-semibold text-primary-warm-white">{v.displayName}</p>
+                      <p class="text-2xs font-light text-primary-warm-gray">{dirLabel[v.directory] ?? v.directory} · {v.workflowCount} workflows</p>
+                    </div>
+                    <span class="shrink-0 text-2xs font-bold uppercase tracking-widest text-primary-comfy-yellow">Run →</span>
+                  </a>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+      </GlassCard>
     </div>
   </section>
 
   <!-- MOBILE STICKY RUN BAR -->
   <div class="fixed inset-x-0 bottom-0 z-40 border-t border-white/10 bg-primary-comfy-ink/95 px-4 pb-[calc(env(safe-area-inset-bottom)+12px)] pt-3 backdrop-blur lg:hidden">
-    <button id="pg-run-mobile" class="w-full rounded-xl bg-primary-comfy-yellow py-3.5 text-sm font-extrabold uppercase tracking-widest text-primary-comfy-ink">
+    <button id="pg-run-mobile" class:list={[primaryButton, 'w-full py-3.5 uppercase tracking-widest']}>
       Run — ~{baseCredits} credits
     </button>
-    <p class="mt-1.5 text-center text-[11px] font-light text-primary-warm-gray">Sign in at run · 5 free · no card</p>
+    <p class:list={[helperCopy, 'mt-1.5 text-center']}>Sign in at run · 5 free · no card</p>
   </div>
   <div class="h-24 lg:hidden"></div>
 
   <!-- AUTH WALL MODAL -->
   <div id="auth-modal" class="fixed inset-0 z-[60] hidden items-end justify-center bg-black/70 p-0 backdrop-blur-sm sm:items-center sm:p-6">
-    <div class="w-full max-w-md rounded-t-3xl border border-white/15 bg-[#191320] p-6 shadow-2xl sm:rounded-3xl sm:p-8">
-      <span class="rounded bg-primary-comfy-yellow/15 px-2.5 py-1 text-[10px] font-extrabold uppercase tracking-widest text-primary-comfy-yellow">This run: <span id="modal-credits">{baseCredits}</span> credits — free for you</span>
+    <div class="w-full max-w-md rounded-t-3xl border border-transparency-white-t20 bg-site-dropdown p-6 shadow-2xl sm:rounded-3xl sm:p-8">
+      <span class:list={[pill, 'bg-primary-comfy-yellow/15 text-primary-comfy-yellow']}>This run: <span id="modal-credits">{baseCredits}</span> credits — free for you</span>
       <h3 class="mt-4 text-2xl font-semibold text-primary-warm-white">5 free runs. No card.</h3>
       <p class="mt-2 text-sm font-light leading-relaxed text-primary-comfy-canvas">Your prompt and settings are saved. The run starts the moment you’re in.</p>
       <div class="mt-5 flex flex-col gap-2.5">
-        <button data-auth class="rounded-xl bg-primary-warm-white py-3 text-sm font-semibold text-primary-comfy-ink transition hover:brightness-95">Continue with Google</button>
-        <button data-auth class="rounded-xl border border-white/20 bg-white/5 py-3 text-sm font-semibold text-primary-warm-white transition hover:bg-white/10">Continue with GitHub</button>
-        <button data-auth class="rounded-xl border border-white/20 bg-white/5 py-3 text-sm font-semibold text-primary-warm-white transition hover:bg-white/10">Continue with email</button>
+        <button data-auth class:list={[primaryButton, 'w-full']}>Continue with Google</button>
+        <button data-auth class:list={[outlineButton, 'w-full']}>Continue with GitHub</button>
+        <button data-auth class:list={[outlineButton, 'w-full']}>Continue with email</button>
       </div>
-      <p class="mt-4 text-[11px] font-light leading-relaxed text-primary-warm-gray">By continuing you agree to the Terms. Open source stays open — your graphs and outputs are yours.</p>
-      <button id="auth-close" class="mt-3 text-[11px] font-extrabold uppercase tracking-widest text-primary-warm-gray hover:text-primary-warm-white">Not now</button>
+      <p class:list={[helperCopy, 'mt-4 leading-relaxed']}>By continuing you agree to the Terms. Open source stays open — your graphs and outputs are yours.</p>
+      <button id="auth-close" class:list={[textAction, 'mt-3']}>Not now</button>
     </div>
   </div>
 
@@ -490,7 +531,11 @@ const faqJsonLd = {
       const names = tabs.map((t) => t.dataset.tab)
       const show = (name: string | undefined) => {
         const active = name && names.includes(name) ? name : 'playground'
-        tabs.forEach((t) => t.setAttribute('aria-selected', String(t.dataset.tab === active)))
+        tabs.forEach((t) => {
+          const selected = t.dataset.tab === active
+          t.setAttribute('aria-selected', String(selected))
+          t.dataset.state = selected ? 'on' : 'off'
+        })
         panels.forEach((p) => (p.hidden = p.dataset.panel !== active))
       }
 
@@ -677,7 +722,7 @@ const faqJsonLd = {
         $('ref-thumb')?.classList.remove('hidden')
         const dl = $('dropzone-label')
         if (dl) dl.textContent = 'frame_0001.png ✓ — will run image-to-video'
-        $('dropzone')?.classList.add('border-[#b7ded5]/50')
+        $('dropzone')?.classList.add('border-primary-comfy-yellow/50')
         renderAll()
       })
 
@@ -783,6 +828,7 @@ const faqJsonLd = {
       }
       runDesktop.addEventListener('click', onRun)
       runMobile.addEventListener('click', onRun)
+      $('free-run-cta')?.addEventListener('click', onRun)
       modal.querySelectorAll('[data-auth]').forEach((b) =>
         b.addEventListener('click', () => {
           modal.classList.add('hidden'); modal.classList.remove('flex')

--- a/apps/website/src/pages/models-v2/[slug].astro
+++ b/apps/website/src/pages/models-v2/[slug].astro
@@ -312,15 +312,15 @@ const faqJsonLd = {
       <!-- RESULT CARD -->
       <div class="flex flex-col overflow-hidden rounded-2xl border border-white/10">
         <div class="flex items-center justify-between px-5 py-3.5">
-          <h2 id="result-label" class="text-[11px] font-extrabold uppercase tracking-[0.2em] text-primary-warm-white">Result · example output</h2>
+          <h2 class="text-[11px] font-extrabold uppercase tracking-[0.2em] text-primary-warm-white">Result</h2>
           <div id="rview-toggle" class="flex gap-1.5 text-[10px] font-extrabold uppercase tracking-wider">
             <button data-rview="preview" class="rounded-md bg-white/10 px-2.5 py-1 text-primary-warm-white">Preview</button>
             <button data-rview="json" class="rounded-md px-2.5 py-1 text-primary-warm-gray hover:text-primary-warm-white">JSON</button>
           </div>
         </div>
-        <div class="relative aspect-video w-full bg-secondary-mauve/30">
+        <div class="relative aspect-video w-full">
           <img id="result-img" src={img} alt={`${name} output`} class="h-full w-full object-cover transition-opacity duration-500" onerror="this.style.display='none'" />
-          <div id="result-json-box" class="absolute inset-4 hidden overflow-hidden rounded-2xl border border-white/15 bg-primary-comfy-ink">
+          <div id="result-json-box" class="absolute inset-4 hidden overflow-hidden rounded-2xl border border-white/15">
             <pre id="result-json" class="scrollbar-code h-full overflow-auto whitespace-pre-wrap break-words p-4 font-mono text-xs leading-relaxed text-primary-warm-gray"></pre>
             <button type="button" data-copy="result-json" title="Copy" aria-label="Copy" class="absolute right-3 top-3 group shrink-0 cursor-pointer rounded-lg border border-white/15 bg-white/5 p-1.5 text-primary-warm-gray transition-colors hover:bg-white/10 hover:text-primary-warm-white"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="size-3.5 group-data-[copied]:hidden"><rect width="14" height="14" x="8" y="8" rx="2" ry="2"/><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/></svg><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="hidden size-3.5 group-data-[copied]:block"><path d="M20 6 9 17l-5-5"/></svg></button>
           </div>
@@ -559,7 +559,6 @@ const faqJsonLd = {
       const upgrade = $('upgrade-overlay')!
       const fill = $('progress-fill')!
       const img = $('result-img') as HTMLImageElement
-      const label = $('result-label')!
       const metaEl = $('result-meta')!
       const runMobile = $('pg-run-mobile')!
       const prompt = $('pg-prompt') as HTMLTextAreaElement
@@ -738,7 +737,6 @@ const faqJsonLd = {
             nodes_executed: 24,
             output: { type: 'video/webp', watermark: false, saved_to_history: true }
           }
-          label.textContent = 'Result · your run'
           metaEl.textContent = `Seed ${seed} · 4.2s render · saved to history · no watermark`
           meter.textContent = runsLeft > 0 ? `Free runs: ${runsLeft} left` : 'Free runs used'
           varBlock.classList.remove('hidden')
@@ -800,7 +798,6 @@ const faqJsonLd = {
         varStrip.classList.add('hidden'); varStrip.classList.remove('grid')
         $('ref-thumb')?.classList.add('hidden')
         const dl = $('dropzone-label'); if (dl) dl.textContent = 'or drop a frame to animate it'
-        label.textContent = 'Result · example output'
         metaEl.textContent = 'Seed 428790123 · 4.2s render · prompt saved through sign-in'
         meter.textContent = 'Free runs: 5 left'
         renderAll()

--- a/apps/website/src/pages/models-v2/[slug].astro
+++ b/apps/website/src/pages/models-v2/[slug].astro
@@ -369,7 +369,10 @@ const faqJsonLd = {
                   <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="size-3.5"><path d="M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.5L14.5 2z"/><path d="M14 2v6h6"/><path d="m10 13-2 2 2 2"/><path d="m14 17 2-2-2-2"/></svg>
                   <span class="font-mono text-2xs">json</span>
                 </div>
-                <button type="button" data-copy="result-json" title="Copy" aria-label="Copy" class={iconButton}><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="size-3.5 group-data-[copied]:hidden"><rect width="14" height="14" x="8" y="8" rx="2" ry="2"/><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/></svg><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="hidden size-3.5 group-data-[copied]:block"><path d="M20 6 9 17l-5-5"/></svg></button>
+                <div class="flex items-center gap-2">
+                  <button type="button" data-copy="result-json" title="Copy" aria-label="Copy" class={iconButton}><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="size-3.5 group-data-[copied]:hidden"><rect width="14" height="14" x="8" y="8" rx="2" ry="2"/><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/></svg><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="hidden size-3.5 group-data-[copied]:block"><path d="M20 6 9 17l-5-5"/></svg></button>
+                  <button type="button" data-download="result-json" data-filename={`${slugId}-result.json`} title="Download JSON" aria-label="Download JSON" class={iconButton}><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="size-3.5"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><path d="m7 10 5 5 5-5"/><path d="M12 15V3"/></svg></button>
+                </div>
               </div>
               <pre id="result-json" class="scrollbar-code min-h-0 flex-1 overflow-auto whitespace-pre-wrap break-words p-4 font-mono text-xs leading-relaxed text-primary-warm-gray"></pre>
             </div>
@@ -589,6 +592,19 @@ const faqJsonLd = {
             b.dataset.copied = ''
             window.setTimeout(() => delete b.dataset.copied, 1200)
           } catch { /* clipboard unavailable */ }
+        })
+      )
+
+      document.querySelectorAll<HTMLElement>('[data-download]').forEach((button) =>
+        button.addEventListener('click', () => {
+          const text = document.getElementById(button.dataset.download!)?.textContent
+          if (!text) return
+          const url = URL.createObjectURL(new Blob([text], { type: 'application/json' }))
+          const link = document.createElement('a')
+          link.href = url
+          link.download = button.dataset.filename ?? 'result.json'
+          link.click()
+          URL.revokeObjectURL(url)
         })
       )
     }

--- a/apps/website/src/pages/models-v2/[slug].astro
+++ b/apps/website/src/pages/models-v2/[slug].astro
@@ -451,7 +451,7 @@ const faqJsonLd = {
         <p class="text-lg font-bold text-primary-comfy-canvas">Start free. Upgrade when you're ready.</p>
         <p class="mt-1 text-sm text-primary-comfy-canvas">5 free runs on real GPUs — no credit card required.</p>
       </div>
-      <BrandButton id="free-run-cta" variant="outline" size="xs" class="shrink-0 self-start sm:self-auto">Try free</BrandButton>
+      <BrandButton id="free-run-cta" variant="outline" size="xs" class="shrink-0 self-start uppercase tracking-widest sm:self-auto">Try free</BrandButton>
     </div>
   </section>
 

--- a/apps/website/src/pages/models-v2/[slug].astro
+++ b/apps/website/src/pages/models-v2/[slug].astro
@@ -8,7 +8,7 @@
 import { cn } from '@comfyorg/tailwind-utils'
 
 import BaseLayout from '../../layouts/BaseLayout.astro'
-import { Coins as CreditsIcon } from '@lucide/vue'
+import { ArrowUpRight, Coins as CreditsIcon } from '@lucide/vue'
 
 import BrandButton from '../../components/common/BrandButton.vue'
 import GlassCard from '../../components/common/GlassCard.vue'
@@ -527,7 +527,7 @@ const faqJsonLd = {
                       <p class="truncate text-sm font-semibold text-primary-warm-white">{v.displayName}</p>
                       <p class="text-2xs font-light text-primary-warm-gray">{dirLabel[v.directory] ?? v.directory} · {v.workflowCount} workflows</p>
                     </div>
-                    <span class="shrink-0 text-2xs font-bold uppercase tracking-widest text-primary-comfy-yellow">Run →</span>
+                    <span class="flex shrink-0 items-center gap-1.5 text-2xs font-bold uppercase tracking-widest text-primary-comfy-yellow">Run <ArrowUpRight class="size-4 shrink-0" aria-hidden="true" /></span>
                   </a>
                 ))}
               </div>

--- a/apps/website/src/pages/models-v2/[slug].astro
+++ b/apps/website/src/pages/models-v2/[slug].astro
@@ -326,9 +326,15 @@ const faqJsonLd = {
 
         <!-- JSON VIEW -->
         <div id="panel-json" class="hidden">
-          <div class="relative mt-4 overflow-hidden rounded-2xl border border-transparency-white-t20">
+          <div class="mt-4 overflow-hidden rounded-2xl border border-transparency-white-t20">
+            <div class="flex items-center justify-between border-b border-transparency-white-t20 px-4 py-2">
+              <div class="flex items-center gap-2 text-primary-warm-gray">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="size-3.5"><path d="M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.5L14.5 2z"/><path d="M14 2v6h6"/><path d="m10 13-2 2 2 2"/><path d="m14 17 2-2-2-2"/></svg>
+                <span class="font-mono text-2xs">json</span>
+              </div>
+              <button type="button" data-copy="input-json" title="Copy" aria-label="Copy" class={iconButton}><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="size-3.5 group-data-[copied]:hidden"><rect width="14" height="14" x="8" y="8" rx="2" ry="2"/><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/></svg><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="hidden size-3.5 group-data-[copied]:block"><path d="M20 6 9 17l-5-5"/></svg></button>
+            </div>
             <pre id="input-json" class="max-h-96 scrollbar-code overflow-auto whitespace-pre-wrap break-words p-4 font-mono text-xs leading-relaxed text-primary-warm-gray"></pre>
-            <button type="button" data-copy="input-json" title="Copy" aria-label="Copy" class:list={[iconButton, 'absolute right-3 top-3']}><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="size-3.5 group-data-[copied]:hidden"><rect width="14" height="14" x="8" y="8" rx="2" ry="2"/><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/></svg><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="hidden size-3.5 group-data-[copied]:block"><path d="M20 6 9 17l-5-5"/></svg></button>
           </div>
           <p class:list={[helperCopy, 'mt-2']}>Live from your inputs — the exact payload the API takes.</p>
         </div>
@@ -357,8 +363,16 @@ const faqJsonLd = {
         <div class="relative mt-5 aspect-video w-full overflow-hidden rounded-2xl">
           <img id="result-img" src={img} alt={`${name} output`} class="h-full w-full object-cover transition-opacity duration-500" onerror="this.style.display='none'" />
           <div id="result-json-box" class="absolute inset-0 hidden overflow-hidden rounded-2xl border border-transparency-white-t20">
-            <pre id="result-json" class="scrollbar-code h-full overflow-auto whitespace-pre-wrap break-words p-4 font-mono text-xs leading-relaxed text-primary-warm-gray"></pre>
-            <button type="button" data-copy="result-json" title="Copy" aria-label="Copy" class:list={[iconButton, 'absolute right-3 top-3']}><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="size-3.5 group-data-[copied]:hidden"><rect width="14" height="14" x="8" y="8" rx="2" ry="2"/><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/></svg><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="hidden size-3.5 group-data-[copied]:block"><path d="M20 6 9 17l-5-5"/></svg></button>
+            <div class="flex h-full flex-col">
+              <div class="flex items-center justify-between border-b border-transparency-white-t20 px-4 py-2">
+                <div class="flex items-center gap-2 text-primary-warm-gray">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="size-3.5"><path d="M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.5L14.5 2z"/><path d="M14 2v6h6"/><path d="m10 13-2 2 2 2"/><path d="m14 17 2-2-2-2"/></svg>
+                  <span class="font-mono text-2xs">json</span>
+                </div>
+                <button type="button" data-copy="result-json" title="Copy" aria-label="Copy" class={iconButton}><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="size-3.5 group-data-[copied]:hidden"><rect width="14" height="14" x="8" y="8" rx="2" ry="2"/><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/></svg><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="hidden size-3.5 group-data-[copied]:block"><path d="M20 6 9 17l-5-5"/></svg></button>
+              </div>
+              <pre id="result-json" class="scrollbar-code min-h-0 flex-1 overflow-auto whitespace-pre-wrap break-words p-4 font-mono text-xs leading-relaxed text-primary-warm-gray"></pre>
+            </div>
           </div>
           <div id="running-overlay" class="absolute inset-0 hidden flex-col items-center justify-center gap-4 bg-primary-comfy-ink/95 px-8 text-center">
             <p class={sectionTitle}>Restored your prompt and settings ✓</p>

--- a/apps/website/src/pages/models-v2/[slug].astro
+++ b/apps/website/src/pages/models-v2/[slug].astro
@@ -222,7 +222,7 @@ const faqJsonLd = {
         {hfUrl && <BrandButton href={hfUrl} variant="outline" size="sm" class="text-2xs uppercase tracking-widest">Download weights ↗</BrandButton>}
       </div>
     </div>
-    <p class="mt-2 max-w-3xl text-sm font-light leading-relaxed text-primary-comfy-canvas sm:text-base">{blurb}</p>
+    <p class="mt-2 max-w-3xl text-sm text-primary-comfy-canvas lg:text-base">{blurb}</p>
     <div class="mt-4 flex flex-wrap gap-1.5">
       {dayZero && <span class:list={[pill, pillMuted]}>Day zero</span>}
       <span class:list={[pill, pillMuted]}>{kindLabel}</span>

--- a/apps/website/src/pages/models-v2/[slug].astro
+++ b/apps/website/src/pages/models-v2/[slug].astro
@@ -73,6 +73,9 @@ const promptExample = launch
   ? launch.promptExample
   : 'Golden hour drone shot pushing over a ridge line, fog pooling in the valley — native ambient audio.'
 const baseCredits = kind === 'partner api' ? 12 : 6
+const kindLabel = kind === 'open weights' ? 'Open weights' : 'Partner API'
+const sentence = (s: string) => s.charAt(0).toUpperCase() + s.slice(1)
+const tagPill = 'inline-flex h-6 items-center rounded-full px-4 text-xs font-normal'
 const workflowsUrl = launch
   ? launch.workflowsUrl
   : registry!.hubSlug
@@ -205,11 +208,11 @@ const faqJsonLd = {
     </div>
     <p class="mt-2 max-w-3xl text-sm font-light leading-relaxed text-primary-comfy-canvas sm:text-base">{blurb}</p>
     <div class="mt-4 flex flex-wrap gap-1.5">
-      {dayZero && <span class="rounded bg-primary-comfy-yellow px-2 py-1 text-[10px] font-extrabold uppercase tracking-widest text-primary-comfy-ink">Day zero</span>}
-      <span class:list={['rounded px-2 py-1 text-[10px] font-extrabold uppercase tracking-widest', kind === 'open weights' ? 'bg-[#96b4ff]/15 text-[#96b4ff]' : 'bg-[#dbd6f2]/15 text-[#dbd6f2]']}>{kind}</span>
-      <span class="rounded border border-white/15 px-2 py-1 text-[10px] font-extrabold uppercase tracking-widest text-primary-comfy-canvas">Commercial use</span>
-      <span class="rounded border border-white/15 px-2 py-1 text-[10px] font-extrabold uppercase tracking-widest text-primary-comfy-canvas">{price}</span>
-      <span class="rounded border border-white/15 px-2 py-1 text-[10px] font-extrabold uppercase tracking-widest text-primary-comfy-canvas">{runs}</span>
+      {dayZero && <span class:list={[tagPill, 'bg-primary-comfy-yellow text-primary-comfy-ink']}>Day zero</span>}
+      <span class:list={[tagPill, kind === 'open weights' ? 'bg-[#96b4ff]/15 text-[#96b4ff]' : 'bg-[#dbd6f2]/15 text-[#dbd6f2]']}>{kindLabel}</span>
+      <span class:list={[tagPill, 'bg-transparency-white-t4 text-primary-comfy-canvas']}>Commercial use</span>
+      <span class:list={[tagPill, 'bg-transparency-white-t4 text-primary-comfy-canvas']}>{sentence(price)}</span>
+      <span class:list={[tagPill, 'bg-transparency-white-t4 text-primary-comfy-canvas']}>{sentence(runs)}</span>
     </div>
   </section>
 

--- a/apps/website/src/pages/models-v2/[slug].astro
+++ b/apps/website/src/pages/models-v2/[slug].astro
@@ -287,12 +287,9 @@ const faqJsonLd = {
 
         <!-- JSON VIEW -->
         <div id="panel-json" class="hidden">
-          <div class="mt-4 overflow-hidden rounded-2xl border border-white/15">
-            <div class="flex items-center justify-between gap-3 border-b border-white/15 px-4 py-2.5">
-              <span class="truncate text-[11px] font-extrabold uppercase tracking-widest text-primary-warm-gray">Request payload</span>
-              <button type="button" data-copy="input-json" title="Copy" aria-label="Copy" class="group shrink-0 cursor-pointer rounded-lg border border-white/15 bg-white/5 p-1.5 text-primary-warm-gray transition-colors hover:bg-white/10 hover:text-primary-warm-white"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="size-3.5 group-data-[copied]:hidden"><rect width="14" height="14" x="8" y="8" rx="2" ry="2"/><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/></svg><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="hidden size-3.5 group-data-[copied]:block"><path d="M20 6 9 17l-5-5"/></svg></button>
-            </div>
+          <div class="relative mt-4 overflow-hidden rounded-2xl border border-white/15">
             <pre id="input-json" class="max-h-96 scrollbar-code overflow-auto whitespace-pre-wrap break-words p-4 font-mono text-xs leading-relaxed text-primary-warm-gray"></pre>
+            <button type="button" data-copy="input-json" title="Copy" aria-label="Copy" class="absolute right-3 top-3 group shrink-0 cursor-pointer rounded-lg border border-white/15 bg-white/5 p-1.5 text-primary-warm-gray transition-colors hover:bg-white/10 hover:text-primary-warm-white"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="size-3.5 group-data-[copied]:hidden"><rect width="14" height="14" x="8" y="8" rx="2" ry="2"/><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/></svg><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="hidden size-3.5 group-data-[copied]:block"><path d="M20 6 9 17l-5-5"/></svg></button>
           </div>
           <p class="mt-2 text-[11px] font-light text-primary-warm-gray">Live from your inputs — the exact payload the API takes.</p>
         </div>

--- a/apps/website/src/pages/models-v2/[slug].astro
+++ b/apps/website/src/pages/models-v2/[slug].astro
@@ -286,7 +286,6 @@ const faqJsonLd = {
             rows="4"
             class="mt-2 w-full resize-none rounded-xl border border-transparency-white-t20 bg-transparency-white-t4 p-4 text-sm font-light leading-relaxed text-primary-comfy-canvas focus:border-primary-comfy-yellow/60 focus:outline-none"
           >{promptExample}</textarea>
-          <p class:list={[helperCopy, 'mt-1.5']}>App view = this workflow’s exposed inputs.</p>
           <div class="mt-4 grid grid-cols-3 gap-2.5">
             <div>
               <span class={fieldLabel}>Aspect</span>
@@ -348,7 +347,6 @@ const faqJsonLd = {
             </button>
           </div>
         </div>
-        <p class:list={[helperCopy, 'mt-3']}>▶ Demo: everything above works — flip the views, change resolution (watch the price), add a reference image, then Run.</p>
       </div>
 
       <!-- RESULT CARD -->

--- a/apps/website/src/pages/models-v2/[slug].astro
+++ b/apps/website/src/pages/models-v2/[slug].astro
@@ -22,6 +22,7 @@ import {
   proxyImg,
   type LaunchModel
 } from '../../config/models-v2-demo'
+import Breadcrumbs from '../../components/common/Breadcrumbs.astro'
 import { highlightInline } from '../../lib/highlight'
 
 export function getStaticPaths() {
@@ -158,6 +159,11 @@ const breadcrumbJsonLd = {
     { '@type': 'ListItem', position: 3, name }
   ]
 }
+const breadcrumbs = [
+  { label: 'Home', href: 'https://comfy.org' },
+  { label: 'AI Models', href: '/models-v2' },
+  { label: name }
+]
 const faqJsonLd = {
   '@context': 'https://schema.org',
   '@type': 'FAQPage',
@@ -204,9 +210,7 @@ const faqJsonLd = {
 
   <!-- COMPACT HEADER -->
   <section class="mx-auto max-w-9xl px-5 pt-8 sm:px-6 lg:px-20 lg:pt-12">
-    <p class="text-2xs font-bold uppercase tracking-widest text-primary-warm-gray">
-      <a href="/models-v2" class="hover:text-primary-warm-white">Models</a> / {meta.label} / {name}
-    </p>
+    <Breadcrumbs crumbs={breadcrumbs} />
     <div class="mt-3 flex flex-wrap items-center justify-between gap-3">
       <div class="flex min-w-0 flex-wrap items-center gap-3">
         <h1 class="max-w-full truncate text-2xl font-semibold text-primary-warm-white sm:text-3xl">{name}</h1>

--- a/apps/website/src/pages/models-v2/[slug].astro
+++ b/apps/website/src/pages/models-v2/[slug].astro
@@ -1,8 +1,8 @@
 ---
 // A/B TEST PREVIEW — playground-first model page, generated for every launch
-// model and every registry entry. Every visible control works: APP ⇄ GRAPH ⇄
-// JSON input views (App = the workflow's exposed inputs, Graph = the actual
-// node graph live-bound to them), Preview ⇄ JSON result receipt, live credit
+// model and every registry entry. Every visible control works: APP ⇄ JSON
+// input views (App = the workflow's exposed inputs), Preview ⇄ JSON result
+// receipt, live credit
 // repricing, LLMs menu with per-page markdown, gallery prompt warm-starts,
 // variations queue, and the full signup-journey demo. Not linked. noindex.
 import BaseLayout from '../../layouts/BaseLayout.astro'
@@ -153,15 +153,6 @@ const faqJsonLd = {
       : [])
   ]
 }
-
-const WIRE = {
-  model: '#c8b4f5',
-  clip: '#f2ff59',
-  vae: '#f58ea8',
-  cond: '#ffa94d',
-  latent: '#ff99f7',
-  image: '#96b4ff'
-}
 ---
 
 <BaseLayout
@@ -244,7 +235,6 @@ const WIRE = {
           <h2 class="text-xs font-extrabold uppercase tracking-[0.2em] text-primary-warm-white">Input</h2>
           <div id="iview-toggle" class="flex overflow-hidden rounded-lg border border-white/15 text-[10px] font-extrabold uppercase tracking-wider">
             <button data-iview="app" class="bg-primary-comfy-yellow px-3 py-1.5 text-primary-comfy-ink">App</button>
-            <button data-iview="graph" class="px-3 py-1.5 text-primary-comfy-canvas hover:text-primary-warm-white">Graph</button>
             <button data-iview="json" class="px-3 py-1.5 text-primary-comfy-canvas hover:text-primary-warm-white">JSON</button>
           </div>
         </div>
@@ -257,7 +247,7 @@ const WIRE = {
             rows="4"
             class="mt-2 w-full resize-none rounded-xl border border-white/15 bg-primary-comfy-ink p-4 text-sm font-light leading-relaxed text-primary-comfy-canvas focus:border-primary-comfy-yellow/60 focus:outline-none"
           >{promptExample}</textarea>
-          <p class="mt-1.5 text-[11px] font-light text-primary-warm-gray">App view = this workflow’s exposed inputs. Flip to GRAPH to see where each one lands.</p>
+          <p class="mt-1.5 text-[11px] font-light text-primary-warm-gray">App view = this workflow’s exposed inputs.</p>
           <div class="mt-4 grid grid-cols-3 gap-2.5">
             <div>
               <span class="block text-[10px] font-extrabold uppercase tracking-[0.2em] text-primary-warm-gray">Aspect</span>
@@ -284,81 +274,6 @@ const WIRE = {
             <span id="dropzone-label" class="text-xs font-light text-primary-warm-gray">or drop a frame to animate it</span>
             <img id="ref-thumb" src={gallery[1] ?? gallery[0]} alt="" class="ml-auto hidden h-10 w-16 rounded-md object-cover" onerror="this.style.display='none'" />
           </div>
-        </div>
-
-        <!-- GRAPH VIEW — the actual node graph, live-bound -->
-        <div id="panel-graph" class="hidden">
-          <div class="mt-4 overflow-hidden rounded-xl border border-white/12 bg-[#141018]">
-            <svg viewBox="0 0 440 330" class="w-full" font-family="ui-monospace, monospace">
-              <path d="M150 44 C 200 44, 150 138, 168 138" stroke={WIRE.model} fill="none" stroke-width="1.5"/>
-              <path d="M150 56 C 165 56, 155 34, 168 34" stroke={WIRE.clip} fill="none" stroke-width="1.5"/>
-              <path d="M150 68 C 210 68, 120 262, 168 262" stroke={WIRE.vae} fill="none" stroke-width="1.5"/>
-              <path d="M352 44 C 380 44, 140 156, 168 156" stroke={WIRE.cond} fill="none" stroke-width="1.5"/>
-              <path d="M152 148 C 162 148, 158 174, 168 174" stroke={WIRE.latent} fill="none" stroke-width="1.5"/>
-              <path d="M352 170 C 380 170, 140 276, 168 276" stroke={WIRE.latent} fill="none" stroke-width="1.5"/>
-              <path d="M292 266 C 306 266, 300 266, 312 266" stroke={WIRE.image} fill="none" stroke-width="1.5"/>
-
-              <g>
-                <rect x="10" y="18" width="140" height="62" rx="6" fill="#221b29" stroke="#3a3142"/>
-                <rect x="10" y="18" width="140" height="16" rx="6" fill="#2c2435"/>
-                <text x="16" y="30" fill="#f0efed" font-size="9" font-weight="bold">Load Checkpoint</text>
-                <text x="16" y="47" fill="#7e7c78" font-size="8">{slugId.slice(0, 22)}</text>
-                <circle cx="150" cy="44" r="3" fill={WIRE.model}/><text x="108" y="47" fill={WIRE.model} font-size="7">MODEL</text>
-                <circle cx="150" cy="56" r="3" fill={WIRE.clip}/><text x="120" y="59" fill={WIRE.clip} font-size="7">CLIP</text>
-                <circle cx="150" cy="68" r="3" fill={WIRE.vae}/><text x="124" y="71" fill={WIRE.vae} font-size="7">VAE</text>
-              </g>
-
-              <g>
-                <rect x="168" y="14" width="184" height="76" rx="6" fill="#221b29" stroke="#f2ff59" stroke-opacity="0.55"/>
-                <rect x="168" y="14" width="184" height="16" rx="6" fill="#2c2435"/>
-                <text x="174" y="26" fill="#f0efed" font-size="9" font-weight="bold">CLIP Text Encode</text>
-                <text x="174" y="43" fill="#c2bfb9" font-size="7.5" id="g-prompt-1">…</text>
-                <text x="174" y="54" fill="#c2bfb9" font-size="7.5" id="g-prompt-2"></text>
-                <text x="174" y="70" fill="#7e7c78" font-size="7">↑ your prompt field, live</text>
-                <circle cx="352" cy="44" r="3" fill={WIRE.cond}/>
-              </g>
-
-              <g>
-                <rect x="10" y="118" width="142" height="58" rx="6" fill="#221b29" stroke="#3a3142"/>
-                <rect x="10" y="118" width="142" height="16" rx="6" fill="#2c2435"/>
-                <text x="16" y="130" fill="#f0efed" font-size="9" font-weight="bold">Empty Latent</text>
-                <text x="16" y="148" fill="#c2bfb9" font-size="8" id="g-res">1280 × 720</text>
-                <text x="16" y="162" fill="#7e7c78" font-size="7">↑ resolution select</text>
-                <circle cx="152" cy="148" r="3" fill={WIRE.latent}/>
-              </g>
-
-              <g>
-                <rect x="168" y="112" width="184" height="106" rx="6" fill="#221b29" stroke="#3a3142"/>
-                <rect x="168" y="112" width="184" height="16" rx="6" fill="#2c2435"/>
-                <text x="174" y="124" fill="#f0efed" font-size="9" font-weight="bold">KSampler</text>
-                <circle cx="168" cy="138" r="3" fill={WIRE.model}/>
-                <circle cx="168" cy="156" r="3" fill={WIRE.cond}/>
-                <circle cx="168" cy="174" r="3" fill={WIRE.latent}/>
-                <text x="180" y="146" fill="#c2bfb9" font-size="8">seed <tspan id="g-seed" fill="#f2ff59">428790123</tspan></text>
-                <text x="180" y="162" fill="#c2bfb9" font-size="8">steps 24 · cfg 5.5</text>
-                <text x="180" y="178" fill="#c2bfb9" font-size="8">euler · duration <tspan id="g-dur" fill="#f2ff59">5s</tspan></text>
-                <text x="180" y="200" fill="#7e7c78" font-size="7">where the image is decided</text>
-                <circle cx="352" cy="170" r="3" fill={WIRE.latent}/>
-              </g>
-
-              <g>
-                <rect x="168" y="240" width="124" height="52" rx="6" fill="#221b29" stroke="#3a3142"/>
-                <rect x="168" y="240" width="124" height="16" rx="6" fill="#2c2435"/>
-                <text x="174" y="252" fill="#f0efed" font-size="9" font-weight="bold">VAE Decode</text>
-                <circle cx="292" cy="266" r="3" fill={WIRE.image}/>
-              </g>
-              <g>
-                <rect x="312" y="240" width="118" height="52" rx="6" fill="#221b29" stroke="#3a3142"/>
-                <rect x="312" y="240" width="118" height="16" rx="6" fill="#2c2435"/>
-                <text x="318" y="252" fill="#f0efed" font-size="9" font-weight="bold">Save Output</text>
-                <text x="318" y="270" fill="#7e7c78" font-size="7.5">yours, no watermark</text>
-              </g>
-            </svg>
-          </div>
-          <p class="mt-2 text-[11px] font-light text-primary-warm-gray">
-            The actual graph behind the app — typed wires and all. The app is a view; the graph is the truth.
-            <a href="https://cloud.comfy.org?utm_source=models_v2_preview" class="font-extrabold uppercase tracking-widest text-primary-comfy-yellow"> Open it in Cloud →</a>
-          </p>
         </div>
 
         <!-- JSON VIEW -->
@@ -646,16 +561,6 @@ curl -X POST https://api.comfy.org/v1/run \\
         resultJson.textContent = JSON.stringify(receipt, null, 2)
       }
 
-      const renderGraph = () => {
-        const p = prompt.value.trim()
-        const l1 = $('g-prompt-1'); const l2 = $('g-prompt-2')
-        if (l1) l1.textContent = '“' + p.slice(0, 34) + (p.length > 34 ? '…' : '”')
-        if (l2) l2.textContent = p.length > 34 ? p.slice(34, 66) + '…”' : ''
-        const res = $('g-res'); if (res) res.textContent = selRes.value === '1080p' ? '1920 × 1080' : '1280 × 720'
-        const gd = $('g-dur'); if (gd) gd.textContent = mult(selDur) * 5 + 's'
-        const gs = $('g-seed'); if (gs) gs.textContent = String(seed)
-      }
-
       const setRunLabels = () => {
         const c = creditsNow()
         costLine.textContent = `${c} credits ≈ $${(c * 0.0084).toFixed(2)}`
@@ -673,11 +578,11 @@ curl -X POST https://api.comfy.org/v1/run \\
         }
       }
 
-      const renderAll = () => { renderInputJson(); renderResultJson(); renderGraph(); setRunLabels() }
+      const renderAll = () => { renderInputJson(); renderResultJson(); setRunLabels() }
 
-      // input view toggle (APP | GRAPH | JSON)
+      // input view toggle (APP | JSON)
       const iPanels: Record<string, HTMLElement> = {
-        app: $('panel-app')!, graph: $('panel-graph')!, json: $('panel-json')!
+        app: $('panel-app')!, json: $('panel-json')!
       }
       $('iview-toggle')!.addEventListener('click', (e) => {
         const btn = (e.target as HTMLElement).closest<HTMLElement>('[data-iview]')

--- a/apps/website/src/pages/models-v2/[slug].astro
+++ b/apps/website/src/pages/models-v2/[slug].astro
@@ -278,7 +278,9 @@ const faqJsonLd = {
 
         <!-- JSON VIEW -->
         <div id="panel-json" class="hidden">
-          <pre id="input-json" class="mt-4 max-h-[340px] overflow-auto rounded-xl border border-white/12 bg-[#141018] p-4 font-mono text-[11.5px] leading-relaxed text-[#b7ded5]"></pre>
+          <div class="mt-4 overflow-hidden rounded-2xl border border-white/15">
+            <pre id="input-json" class="max-h-96 overflow-auto whitespace-pre-wrap break-words p-4 font-mono text-xs leading-relaxed text-primary-warm-gray"></pre>
+          </div>
           <p class="mt-2 text-[11px] font-light text-primary-warm-gray">Live from your inputs — the exact payload the API takes. <button id="copy-json" class="font-extrabold uppercase tracking-widest text-primary-comfy-yellow">Copy</button><span id="copy-done" class="hidden pl-2 text-[#b7ded5]">copied ✓</span></p>
         </div>
 
@@ -305,7 +307,7 @@ const faqJsonLd = {
         </div>
         <div class="relative aspect-video w-full bg-secondary-mauve/30">
           <img id="result-img" src={img} alt={`${name} output`} class="h-full w-full object-cover transition-opacity duration-500" onerror="this.style.display='none'" />
-          <pre id="result-json" class="absolute inset-0 hidden overflow-auto bg-[#141018] p-5 font-mono text-[11.5px] leading-relaxed text-[#b7ded5]"></pre>
+          <pre id="result-json" class="absolute inset-0 hidden bg-primary-comfy-ink overflow-auto whitespace-pre-wrap break-words p-4 font-mono text-xs leading-relaxed text-primary-warm-gray"></pre>
           <div id="running-overlay" class="absolute inset-0 hidden flex-col items-center justify-center gap-4 bg-primary-comfy-ink/95 px-8 text-center">
             <p class="text-[10px] font-extrabold uppercase tracking-[0.25em] text-[#b7ded5]">Restored your prompt and settings ✓</p>
             <p class="text-lg font-semibold text-primary-warm-white">Running the graph</p>
@@ -388,8 +390,8 @@ const faqJsonLd = {
   <!-- API -->
   <section id="panel-api" data-panel="api" role="tabpanel" hidden class="mx-auto max-w-7xl scroll-mt-24 px-5 py-12 sm:px-6 lg:px-8 lg:pb-24">
     <h2 class="text-sm font-extrabold uppercase tracking-[0.3em] text-primary-comfy-yellow">Run it your way</h2>
-    <div class="mt-4 overflow-x-auto rounded-2xl border border-white/10 bg-black/40 p-5 sm:p-7">
-      <pre class="font-mono text-xs leading-relaxed text-[#b7ded5] sm:text-[13px]">{`# Same graph the playground runs — as an endpoint
+    <div class="mt-4 overflow-hidden rounded-2xl border border-white/15">
+      <pre class="overflow-auto whitespace-pre-wrap break-words p-4 font-mono text-xs leading-relaxed text-primary-warm-gray">{`# Same graph the playground runs — as an endpoint
 curl -X POST https://api.comfy.org/v1/run \\
   -H "Authorization: Bearer $COMFY_KEY" \\
   -d '{ "workflow": "${slugId}", "prompt": "…" }'

--- a/apps/website/src/pages/models-v2/[slug].astro
+++ b/apps/website/src/pages/models-v2/[slug].astro
@@ -406,9 +406,14 @@ const faqJsonLd = {
             </div>
           </div>
         </div>
-        <div class="flex items-center justify-between gap-3 pt-3">
-          <p id="result-meta" class="truncate text-2xs font-bold uppercase tracking-widest text-primary-warm-gray">Seed 428790123 · 4.2s render · prompt saved through sign-in</p>
-          <span class="shrink-0 text-2xs font-bold uppercase tracking-widest text-primary-comfy-yellow">Download ↓</span>
+        <div id="result-meta" class="flex max-w-full flex-wrap items-center gap-2 pt-3">
+          <span id="result-seed" class:list={[pill, pillMuted]}>Seed 428790123</span>
+          <span class:list={[pill, pillMuted]}>4.2s render</span>
+        </div>
+        <div class="mt-auto flex justify-end pt-3">
+          <div id="result-download" class="shrink-0">
+            <a href={img} download={`${slugId}-result`} class:list={[outlineAccentButton, 'uppercase tracking-widest']}>Download</a>
+          </div>
         </div>
         <!-- VARIATIONS QUEUE -->
         <div id="var-block" class="hidden border-t border-white/10 px-5 py-4">
@@ -635,7 +640,7 @@ const faqJsonLd = {
       const upgrade = $('upgrade-overlay')!
       const fill = $('progress-fill')!
       const img = $('result-img') as HTMLImageElement
-      const metaEl = $('result-meta')!
+      const resultSeed = $('result-seed')!
       const runMobile = $('pg-run-mobile')!
       const prompt = $('pg-prompt') as HTMLTextAreaElement
       const selDur = $('sel-duration') as HTMLSelectElement
@@ -732,6 +737,8 @@ const faqJsonLd = {
         const json = btn.dataset.rview === 'json'
         $('result-json-box')!.classList.toggle('hidden', !json)
         img.classList.toggle('hidden', json)
+        $('result-meta')!.classList.toggle('hidden', json)
+        $('result-download')!.classList.toggle('hidden', json)
         for (const b of $('rview-toggle')!.querySelectorAll<HTMLElement>('[data-rview]')) {
           const active = b === btn
           b.classList.toggle('bg-transparency-white-t8', active)
@@ -798,6 +805,8 @@ const faqJsonLd = {
         strip.classList.remove('hidden'); strip.classList.add('flex')
         overlay.classList.remove('hidden'); overlay.classList.add('flex')
         $('result-json-box')!.classList.add('hidden'); img.classList.remove('hidden')
+        $('result-meta')!.classList.remove('hidden')
+        $('result-download')!.classList.remove('hidden')
         fill.style.width = '0%'
         requestAnimationFrame(() => requestAnimationFrame(() => (fill.style.width = '92%')))
         window.setTimeout(() => {
@@ -817,7 +826,7 @@ const faqJsonLd = {
             nodes_executed: 24,
             output: { type: 'video/webp', watermark: false, saved_to_history: true }
           }
-          metaEl.textContent = `Seed ${seed} · 4.2s render · saved to history · no watermark`
+          resultSeed.textContent = `Seed ${seed}`
           meter.textContent = runsLeft > 0 ? `Free runs: ${runsLeft} left` : 'Free runs used'
           varBlock.classList.remove('hidden')
           renderAll()
@@ -879,7 +888,7 @@ const faqJsonLd = {
         varStrip.classList.add('hidden'); varStrip.classList.remove('grid')
         $('ref-thumb')?.classList.add('hidden')
         const dl = $('dropzone-label'); if (dl) dl.textContent = 'or drop a frame to animate it'
-        metaEl.textContent = 'Seed 428790123 · 4.2s render · prompt saved through sign-in'
+        resultSeed.textContent = 'Seed 428790123'
         meter.textContent = 'Free runs: 5 left'
         renderAll()
       })

--- a/apps/website/src/pages/models-v2/[slug].astro
+++ b/apps/website/src/pages/models-v2/[slug].astro
@@ -234,7 +234,7 @@ const faqJsonLd = {
   </section>
 
   <!-- TABS + TRIO -->
-  <section class="mx-auto max-w-9xl px-5 pt-6 sm:px-6 lg:px-20">
+  <section class="mx-auto max-w-9xl px-5 pt-16 sm:px-6 lg:px-20">
     <div class="flex flex-wrap items-center justify-between gap-4">
       <nav class="ring-primary-warm-white/20 flex w-fit max-w-full items-center gap-0.5 overflow-x-auto rounded-2xl p-1.5 ring-2" role="tablist" aria-label="Model page sections">
         <button type="button" role="tab" data-tab="playground" data-state="on" aria-controls="panel-playground" aria-selected="true" class={tab}>Playground</button>
@@ -449,7 +449,7 @@ const faqJsonLd = {
       </div>
     </GlassCard>
 
-    <div class="my-6 flex flex-col gap-4 rounded-3xl bg-primary-comfy-ink-light px-8 py-6 sm:flex-row sm:items-center sm:justify-between">
+    <div class="my-8 flex flex-col gap-4 rounded-3xl bg-primary-comfy-ink-light px-8 py-6 sm:flex-row sm:items-center sm:justify-between">
       <div>
         <p class="text-lg font-bold text-primary-comfy-canvas">Start free. Upgrade when you're ready.</p>
         <p class="mt-1 text-sm text-primary-comfy-canvas">5 free runs on real GPUs — no credit card required.</p>

--- a/apps/website/src/pages/models-v2/[slug].astro
+++ b/apps/website/src/pages/models-v2/[slug].astro
@@ -8,7 +8,7 @@
 import { cn } from '@comfyorg/tailwind-utils'
 
 import BaseLayout from '../../layouts/BaseLayout.astro'
-import { ArrowRight, Coins as CreditsIcon, Download as DownloadIcon } from '@lucide/vue'
+import { ArrowRight, Coins as CreditsIcon, Download as DownloadIcon, X as RemoveIcon } from '@lucide/vue'
 
 import BrandButton from '../../components/common/BrandButton.vue'
 import GlassCard from '../../components/common/GlassCard.vue'
@@ -372,10 +372,23 @@ const faqJsonLd = {
           </div>
           <p class:list={[helperCopy, 'mt-1.5']}>Change value for a different output.</p>
           <label class:list={[fieldLabel, 'mt-4']}>Reference image</label>
-          <div id="dropzone" class="mt-2 flex flex-col items-center gap-3 rounded-xl border border-dashed border-transparency-white-t20 bg-transparency-white-t4 px-4 py-4 text-center">
-            <BrandButton id="add-image-btn" variant="outline-light" size="sm" class="px-3 py-1.5 text-2xs uppercase tracking-widest">Add image</BrandButton>
-            <span id="dropzone-label" class="text-xs font-light text-primary-warm-gray">or drop a frame to animate it</span>
-            <img id="ref-thumb" src={gallery[1] ?? gallery[0]} alt="" class="hidden h-10 w-16 rounded-md object-cover" onerror="this.style.display='none'" />
+          <div id="dropzone" class="mt-2 flex flex-col items-center gap-3 rounded-xl border border-dashed border-transparency-white-t20 bg-transparency-white-t4 px-4 py-4 text-center transition-colors hover:border-primary-comfy-yellow/40 hover:bg-transparency-white-t8">
+            <button id="add-image-btn" type="button" class="cursor-pointer rounded-lg border border-transparency-white-t20 bg-transparency-white-t4 px-3 py-2.5 text-xs font-normal text-primary-comfy-canvas transition-colors hover:bg-transparency-white-t8"><span class="ppformula-text-center">Add image</span></button>
+            <span class="text-xs font-light text-primary-warm-gray">or drag and drop the image here</span>
+          </div>
+
+          <!-- Attachment — media above content, as the shared attachment pattern lays it out -->
+          <div id="ref-attachment" class="mt-2 hidden overflow-hidden rounded-xl border border-transparency-white-t20 bg-transparency-white-t4">
+            <img src={gallery[1] ?? gallery[0]} alt="" class="aspect-video w-full object-cover" onerror="this.style.display='none'" />
+            <div class="flex items-center justify-between gap-3 px-3 py-2.5">
+              <div class="min-w-0">
+                <p class="truncate text-xs text-primary-comfy-canvas">frame_0001.png</p>
+                <p class="text-2xs font-light text-primary-warm-gray">PNG · 820 KB</p>
+              </div>
+              <button id="ref-remove" type="button" title="Remove" aria-label="Remove" class="shrink-0 cursor-pointer rounded-lg border border-transparency-white-t20 bg-transparency-white-t4 p-1.5 text-primary-warm-gray transition-colors hover:bg-transparency-white-t8 hover:text-primary-warm-white">
+                <RemoveIcon class="size-3.5 shrink-0" aria-hidden="true" />
+              </button>
+            </div>
           </div>
         </div>
 
@@ -828,10 +841,13 @@ const faqJsonLd = {
       // reference image demo
       $('add-image-btn')?.addEventListener('click', () => {
         refImage = true
-        $('ref-thumb')?.classList.remove('hidden')
-        const dl = $('dropzone-label')
-        if (dl) dl.textContent = 'frame_0001.png ✓ — will run image-to-video'
-        $('dropzone')?.classList.add('border-primary-comfy-yellow/50')
+        $('ref-attachment')?.classList.remove('hidden')
+        renderAll()
+      })
+
+      $('ref-remove')?.addEventListener('click', () => {
+        refImage = false
+        $('ref-attachment')?.classList.add('hidden')
         renderAll()
       })
 
@@ -967,8 +983,7 @@ const faqJsonLd = {
         strip.classList.add('hidden'); strip.classList.remove('flex')
         varBlock.classList.add('hidden')
         varStrip.classList.add('hidden'); varStrip.classList.remove('grid')
-        $('ref-thumb')?.classList.add('hidden')
-        const dl = $('dropzone-label'); if (dl) dl.textContent = 'or drop a frame to animate it'
+        $('ref-attachment')?.classList.add('hidden')
         resultSeed.textContent = `Seed ${DEFAULT_SEED}`
         meter.textContent = 'Free runs: 5 left'
         renderAll()

--- a/apps/website/src/pages/models-v2/[slug].astro
+++ b/apps/website/src/pages/models-v2/[slug].astro
@@ -16,6 +16,7 @@ import {
   proxyImg,
   type LaunchModel
 } from '../../config/models-v2-demo'
+import { highlightInline } from '../../lib/highlight'
 
 export function getStaticPaths() {
   const launchLike = [...launches, ...topPartnerApis.filter((p) => !launches.includes(p))]
@@ -105,6 +106,14 @@ const costRows: Array<[string, string]> = [
 
 const canonicalURL = new URL(Astro.url.pathname, Astro.site ?? 'https://comfy.org')
 const mdUrl = `/models-v2/${pageSlug}.md`
+
+const curlSnippet = `# Same graph the playground runs — as an endpoint
+curl -X POST https://api.comfy.org/v1/run \\
+  -H "Authorization: Bearer $COMFY_KEY" \\
+  -d '{ "workflow": "${slugId}", "prompt": "…" }'
+
+# → { "job_id": "j_8f2…", "credits": ${baseCredits}, "eta_s": 4 }`
+const curlHtml = await highlightInline(curlSnippet, 'shell')
 const llmPrompt = encodeURIComponent(`Read ${canonicalURL.href}.md and help me run ${name} in ComfyUI. I want to understand the inputs and get my first output.`)
 const workflowCount = registry?.workflowCount ?? 0
 const softwareAppJsonLd = {
@@ -279,9 +288,13 @@ const faqJsonLd = {
         <!-- JSON VIEW -->
         <div id="panel-json" class="hidden">
           <div class="mt-4 overflow-hidden rounded-2xl border border-white/15">
-            <pre id="input-json" class="max-h-96 overflow-auto whitespace-pre-wrap break-words p-4 font-mono text-xs leading-relaxed text-primary-warm-gray"></pre>
+            <div class="flex items-center justify-between gap-3 border-b border-white/15 px-4 py-2.5">
+              <span class="truncate text-[11px] font-extrabold uppercase tracking-widest text-primary-warm-gray">Request payload</span>
+              <button type="button" data-copy="input-json" title="Copy" aria-label="Copy" class="group shrink-0 cursor-pointer rounded-lg border border-white/15 bg-white/5 p-1.5 text-primary-warm-gray transition-colors hover:bg-white/10 hover:text-primary-warm-white"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="size-3.5 group-data-[copied]:hidden"><rect width="14" height="14" x="8" y="8" rx="2" ry="2"/><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/></svg><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="hidden size-3.5 group-data-[copied]:block"><path d="M20 6 9 17l-5-5"/></svg></button>
+            </div>
+            <pre id="input-json" class="max-h-96 scrollbar-code overflow-auto whitespace-pre-wrap break-words p-4 font-mono text-xs leading-relaxed text-primary-warm-gray"></pre>
           </div>
-          <p class="mt-2 text-[11px] font-light text-primary-warm-gray">Live from your inputs — the exact payload the API takes. <button id="copy-json" class="font-extrabold uppercase tracking-widest text-primary-comfy-yellow">Copy</button><span id="copy-done" class="hidden pl-2 text-[#b7ded5]">copied ✓</span></p>
+          <p class="mt-2 text-[11px] font-light text-primary-warm-gray">Live from your inputs — the exact payload the API takes.</p>
         </div>
 
         <div class="mt-5 flex items-center justify-between gap-3 border-t border-white/10 pt-4">
@@ -307,7 +320,8 @@ const faqJsonLd = {
         </div>
         <div class="relative aspect-video w-full bg-secondary-mauve/30">
           <img id="result-img" src={img} alt={`${name} output`} class="h-full w-full object-cover transition-opacity duration-500" onerror="this.style.display='none'" />
-          <pre id="result-json" class="absolute inset-0 hidden bg-primary-comfy-ink overflow-auto whitespace-pre-wrap break-words p-4 font-mono text-xs leading-relaxed text-primary-warm-gray"></pre>
+          <pre id="result-json" class="absolute inset-0 hidden bg-primary-comfy-ink scrollbar-code overflow-auto whitespace-pre-wrap break-words p-4 font-mono text-xs leading-relaxed text-primary-warm-gray"></pre>
+          <button type="button" id="copy-result" data-copy="result-json" title="Copy" aria-label="Copy" class="absolute right-3 top-3 hidden group shrink-0 cursor-pointer rounded-lg border border-white/15 bg-white/5 p-1.5 text-primary-warm-gray transition-colors hover:bg-white/10 hover:text-primary-warm-white"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="size-3.5 group-data-[copied]:hidden"><rect width="14" height="14" x="8" y="8" rx="2" ry="2"/><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/></svg><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="hidden size-3.5 group-data-[copied]:block"><path d="M20 6 9 17l-5-5"/></svg></button>
           <div id="running-overlay" class="absolute inset-0 hidden flex-col items-center justify-center gap-4 bg-primary-comfy-ink/95 px-8 text-center">
             <p class="text-[10px] font-extrabold uppercase tracking-[0.25em] text-[#b7ded5]">Restored your prompt and settings ✓</p>
             <p class="text-lg font-semibold text-primary-warm-white">Running the graph</p>
@@ -391,12 +405,13 @@ const faqJsonLd = {
   <section id="panel-api" data-panel="api" role="tabpanel" hidden class="mx-auto max-w-7xl scroll-mt-24 px-5 py-12 sm:px-6 lg:px-8 lg:pb-24">
     <h2 class="text-sm font-extrabold uppercase tracking-[0.3em] text-primary-comfy-yellow">Run it your way</h2>
     <div class="mt-4 overflow-hidden rounded-2xl border border-white/15">
-      <pre class="overflow-auto whitespace-pre-wrap break-words p-4 font-mono text-xs leading-relaxed text-primary-warm-gray">{`# Same graph the playground runs — as an endpoint
-curl -X POST https://api.comfy.org/v1/run \\
-  -H "Authorization: Bearer $COMFY_KEY" \\
-  -d '{ "workflow": "${slugId}", "prompt": "…" }'
-
-# → { "job_id": "j_8f2…", "credits": ${baseCredits}, "eta_s": 4 }`}</pre>
+      <div class="flex items-center justify-between gap-3 border-b border-white/15 px-4 py-2.5">
+        <span class="truncate text-[11px] font-extrabold uppercase tracking-widest text-primary-warm-gray">curl</span>
+        <button type="button" data-copy="api-curl" title="Copy" aria-label="Copy" class="group shrink-0 cursor-pointer rounded-lg border border-white/15 bg-white/5 p-1.5 text-primary-warm-gray transition-colors hover:bg-white/10 hover:text-primary-warm-white"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="size-3.5 group-data-[copied]:hidden"><rect width="14" height="14" x="8" y="8" rx="2" ry="2"/><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/></svg><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="hidden size-3.5 group-data-[copied]:block"><path d="M20 6 9 17l-5-5"/></svg></button>
+      </div>
+      {curlHtml
+        ? <pre id="api-curl" class="scrollbar-code overflow-auto whitespace-pre-wrap break-words p-4 font-mono text-xs leading-relaxed text-primary-warm-gray" set:html={curlHtml} />
+        : <pre id="api-curl" class="scrollbar-code overflow-auto whitespace-pre-wrap break-words p-4 font-mono text-xs leading-relaxed text-primary-warm-gray">{curlSnippet}</pre>}
     </div>
     <p class="mt-3 text-xs font-light text-primary-warm-gray">The app above is this call — the JSON view shows the exact payload. Full reference · Comfy MCP · <a href={mdUrl} class="text-primary-comfy-yellow">this page as Markdown</a> · <a href="/models-v2/llms.txt" class="text-primary-comfy-yellow">llms.txt</a></p>
   </section>
@@ -498,12 +513,43 @@ curl -X POST https://api.comfy.org/v1/run \\
       window.addEventListener('hashchange', showFromHash)
     }
 
+    function initCodeCopy() {
+      const buttons = Array.from(document.querySelectorAll<HTMLElement>('[data-copy]'))
+      if (!buttons.length || buttons[0].dataset.bound === '1') return
+      buttons.forEach((b) => (b.dataset.bound = '1'))
+
+      buttons.forEach((b) =>
+        b.addEventListener('click', async () => {
+          const text = document.getElementById(b.dataset.copy!)?.textContent
+          if (!text) return
+          try {
+            await navigator.clipboard.writeText(text)
+            b.dataset.copied = ''
+            window.setTimeout(() => delete b.dataset.copied, 1200)
+          } catch { /* clipboard unavailable */ }
+        })
+      )
+    }
+
     function initPlaygroundDemo() {
       const runDesktop = document.getElementById('pg-run')
       if (!runDesktop || runDesktop.dataset.bound === '1') return
       runDesktop.dataset.bound = '1'
 
       const $ = (id: string) => document.getElementById(id)
+
+      // Text lands first so the block is never blank; the tokenized markup
+      // replaces it once Shiki resolves. A newer paint wins on late arrivals.
+      const paintJson = (el: HTMLElement, code: string) => {
+        el.textContent = code
+        const stamp = String(Number(el.dataset.paint ?? '0') + 1)
+        el.dataset.paint = stamp
+        void import('../../lib/highlight').then(({ highlightInline }) =>
+          highlightInline(code, 'json').then((html) => {
+            if (html && el.dataset.paint === stamp) el.innerHTML = html
+          })
+        )
+      }
       const modal = $('auth-modal')!
       const strip = $('signed-in-strip')!
       const meter = $('free-meter')!
@@ -550,7 +596,7 @@ curl -X POST https://api.comfy.org/v1/run \\
           },
           estimate: { credits: creditsNow(), charged_on: 'success only' }
         }
-        inputJson.textContent = JSON.stringify(payload, null, 2)
+        paintJson(inputJson, JSON.stringify(payload, null, 2))
       }
 
       const renderResultJson = () => {
@@ -560,7 +606,7 @@ curl -X POST https://api.comfy.org/v1/run \\
           seed,
           model: slug
         }
-        resultJson.textContent = JSON.stringify(receipt, null, 2)
+        paintJson(resultJson, JSON.stringify(receipt, null, 2))
       }
 
       const setRunLabels = () => {
@@ -606,6 +652,7 @@ curl -X POST https://api.comfy.org/v1/run \\
         if (!btn) return
         const json = btn.dataset.rview === 'json'
         resultJson.classList.toggle('hidden', !json)
+        $('copy-result')?.classList.toggle('hidden', !json)
         img.classList.toggle('hidden', json)
         for (const b of $('rview-toggle')!.querySelectorAll<HTMLElement>('[data-rview]')) {
           const active = b === btn
@@ -628,15 +675,6 @@ curl -X POST https://api.comfy.org/v1/run \\
         if (dl) dl.textContent = 'frame_0001.png ✓ — will run image-to-video'
         $('dropzone')?.classList.add('border-[#b7ded5]/50')
         renderAll()
-      })
-
-      // copy input json
-      $('copy-json')?.addEventListener('click', async () => {
-        try {
-          await navigator.clipboard.writeText(inputJson.textContent ?? '')
-          $('copy-done')?.classList.remove('hidden')
-          window.setTimeout(() => $('copy-done')?.classList.add('hidden'), 1600)
-        } catch { /* clipboard unavailable */ }
       })
 
       // LLMs menu
@@ -679,7 +717,7 @@ curl -X POST https://api.comfy.org/v1/run \\
         }
         strip.classList.remove('hidden'); strip.classList.add('flex')
         overlay.classList.remove('hidden'); overlay.classList.add('flex')
-        resultJson.classList.add('hidden'); img.classList.remove('hidden')
+        resultJson.classList.add('hidden'); $('copy-result')?.classList.add('hidden'); img.classList.remove('hidden')
         fill.style.width = '0%'
         requestAnimationFrame(() => requestAnimationFrame(() => (fill.style.width = '92%')))
         window.setTimeout(() => {
@@ -770,11 +808,13 @@ curl -X POST https://api.comfy.org/v1/run \\
       renderAll()
     }
 
-    initModelTabs()
-    initPlaygroundDemo()
-    document.addEventListener('astro:page-load', () => {
+    const initAll = () => {
       initModelTabs()
+      initCodeCopy()
       initPlaygroundDemo()
-    })
+    }
+
+    initAll()
+    document.addEventListener('astro:page-load', initAll)
   </script>
 </BaseLayout>

--- a/apps/website/src/pages/models-v2/[slug].astro
+++ b/apps/website/src/pages/models-v2/[slug].astro
@@ -135,7 +135,17 @@ const costRows = [
 const canonicalURL = new URL(Astro.url.pathname, Astro.site ?? 'https://comfy.org')
 const mdUrl = `/models-v2/${pageSlug}.md`
 
-const defaultSeed = 428790123
+// A model's example seed is derived from its slug: distinct per model, and
+// stable across builds so the page output stays reproducible.
+const seedFromSlug = (slug: string) => {
+  let hash = 2166136261
+  for (let i = 0; i < slug.length; i++) {
+    hash ^= slug.charCodeAt(i)
+    hash = Math.imul(hash, 16777619)
+  }
+  return (Math.abs(hash) % 900_000_000) + 100_000_000
+}
+const defaultSeed = seedFromSlug(slugId)
 const curlSnippet = `# Same graph the playground runs — as an endpoint
 curl -X POST https://api.comfy.org/v1/run \\
   -H "Authorization: Bearer $COMFY_KEY" \\

--- a/apps/website/src/pages/models-v2/[slug].astro
+++ b/apps/website/src/pages/models-v2/[slug].astro
@@ -356,11 +356,11 @@ const faqJsonLd = {
               min="0"
               step="1"
               value={defaultSeed}
-              class="w-full rounded-lg border border-transparency-white-t20 bg-transparency-white-t4 px-3 py-2.5 font-mono text-xs text-primary-comfy-canvas focus:border-primary-comfy-yellow/60 focus:outline-none"
+              class="w-full rounded-lg border border-transparency-white-t20 bg-transparency-white-t4 px-3 py-2.5 text-xs text-primary-comfy-canvas focus:border-primary-comfy-yellow/60 focus:outline-none"
             />
-            <BrandButton id="seed-shuffle" variant="outline-light" size="sm" class="shrink-0 px-3 py-1.5 text-2xs uppercase tracking-widest">Shuffle</BrandButton>
+            <button id="seed-shuffle" type="button" class="shrink-0 cursor-pointer rounded-lg border border-transparency-white-t20 bg-transparency-white-t4 px-3 py-2.5 text-xs font-normal text-primary-comfy-canvas transition-colors hover:bg-transparency-white-t8"><span class="ppformula-text-center">Shuffle</span></button>
           </div>
-          <p class:list={[helperCopy, 'mt-1.5']}>Same seed and prompt give the same output. Change it for a different take.</p>
+          <p class:list={[helperCopy, 'mt-1.5']}>Change value for a different output.</p>
           <label class:list={[fieldLabel, 'mt-4']}>Reference image</label>
           <div id="dropzone" class="mt-2 flex flex-col items-center gap-3 rounded-xl border border-dashed border-transparency-white-t20 bg-transparency-white-t4 px-4 py-4 text-center">
             <BrandButton id="add-image-btn" variant="outline-light" size="sm" class="px-3 py-1.5 text-2xs uppercase tracking-widest">Add image</BrandButton>

--- a/apps/website/src/pages/models-v2/[slug].astro
+++ b/apps/website/src/pages/models-v2/[slug].astro
@@ -239,7 +239,7 @@ const faqJsonLd = {
 
     <div class="grid gap-5 lg:grid-cols-2">
       <!-- INPUT CARD -->
-      <div class="rounded-2xl border border-white/10 bg-white/[0.04] p-5 sm:p-6">
+      <div class="rounded-2xl border border-white/10 p-5 sm:p-6">
         <div class="flex items-center justify-between">
           <h2 class="text-xs font-extrabold uppercase tracking-[0.2em] text-primary-warm-white">Input</h2>
           <div id="iview-toggle" class="flex overflow-hidden rounded-lg border border-white/15 text-[10px] font-extrabold uppercase tracking-wider">
@@ -310,7 +310,7 @@ const faqJsonLd = {
       </div>
 
       <!-- RESULT CARD -->
-      <div class="flex flex-col overflow-hidden rounded-2xl border border-white/10 bg-black/25">
+      <div class="flex flex-col overflow-hidden rounded-2xl border border-white/10">
         <div class="flex items-center justify-between px-5 py-3.5">
           <h2 id="result-label" class="text-[11px] font-extrabold uppercase tracking-[0.2em] text-primary-warm-white">Result · example output</h2>
           <div id="rview-toggle" class="flex gap-1.5 text-[10px] font-extrabold uppercase tracking-wider">

--- a/apps/website/src/pages/models-v2/[slug].astro
+++ b/apps/website/src/pages/models-v2/[slug].astro
@@ -249,10 +249,10 @@ const faqJsonLd = {
         <button type="button" role="tab" data-tab="playground" data-state="on" aria-controls="panel-playground" aria-selected="true" class={tab}>Playground</button>
         <button type="button" role="tab" data-tab="api" data-state="off" aria-controls="panel-api" aria-selected="false" class={tab}>API</button>
         <button type="button" role="tab" data-tab="gallery" data-state="off" aria-controls="panel-gallery" aria-selected="false" class={tab}>Examples</button>
-        <a href={workflowsUrl} data-state="off" class={tab}>Workflows ↗</a>
       </nav>
       <div class="hidden gap-2 pb-2 lg:flex">
         <a href="https://comfy.org/download" class:list={[outlineButton, 'text-2xs uppercase tracking-widest']}>Run locally</a>
+        <a href={workflowsUrl} class:list={[outlineButton, 'text-2xs uppercase tracking-widest']}>Workflows ↗</a>
         {hfUrl && <a href={hfUrl} class:list={[outlineButton, 'text-2xs uppercase tracking-widest']}>Download weights ↗</a>}
         <a href="https://cloud.comfy.org?utm_source=models_v2_preview" class:list={[outlineButton, 'text-2xs uppercase tracking-widest']}>Open the full graph ↗</a>
       </div>

--- a/apps/website/src/pages/models-v2/[slug].astro
+++ b/apps/website/src/pages/models-v2/[slug].astro
@@ -237,7 +237,7 @@ const WIRE = {
       <p id="free-meter" class="shrink-0 text-[11px] font-extrabold uppercase tracking-widest text-primary-comfy-yellow">Free runs: 5 left</p>
     </div>
 
-    <div class="grid gap-5 lg:grid-cols-[460px_1fr]">
+    <div class="grid gap-5 lg:grid-cols-2">
       <!-- INPUT CARD -->
       <div class="rounded-2xl border border-white/10 bg-white/[0.04] p-5 sm:p-6">
         <div class="flex items-center justify-between">

--- a/apps/website/src/pages/models-v2/[slug].astro
+++ b/apps/website/src/pages/models-v2/[slug].astro
@@ -8,7 +8,7 @@
 import { cn } from '@comfyorg/tailwind-utils'
 
 import BaseLayout from '../../layouts/BaseLayout.astro'
-import { ArrowUpRight, Coins as CreditsIcon } from '@lucide/vue'
+import { ArrowRight, Coins as CreditsIcon } from '@lucide/vue'
 
 import BrandButton from '../../components/common/BrandButton.vue'
 import GlassCard from '../../components/common/GlassCard.vue'
@@ -25,6 +25,7 @@ import {
   type LaunchModel
 } from '../../config/models-v2-demo'
 import Breadcrumbs from '../../components/common/Breadcrumbs.astro'
+import { buttonVariants } from '../../components/ui/button'
 import { highlightInline } from '../../lib/highlight'
 
 export function getStaticPaths() {
@@ -161,6 +162,11 @@ const breadcrumbJsonLd = {
     { '@type': 'ListItem', position: 3, name }
   ]
 }
+// Same call and merge the events section makes, so the link reads identically.
+// cn resolves the variant's casing and type scale against the size defaults —
+// concatenating leaves both and the wrong one wins. The arrow carries no size
+// class on purpose: the variant sizes a bare svg to size-6.
+const runLink = cn(buttonVariants({ variant: 'link' }), 'normal-case')
 const breadcrumbs = [
   { label: 'Home', href: 'https://comfy.org' },
   { label: 'AI Models', href: '/models-v2' },
@@ -221,7 +227,6 @@ const faqJsonLd = {
       <div class="hidden gap-2 lg:flex">
         {docsUrl && <BrandButton href={docsUrl} variant="outline" size="sm" class="text-2xs uppercase tracking-widest">Learn more</BrandButton>}
         <BrandButton href={workflowsUrl} variant="solid" size="sm" class="text-2xs uppercase tracking-widest">Try workflows</BrandButton>
-        {hfUrl && <BrandButton href={hfUrl} variant="outline" size="sm" class="text-2xs uppercase tracking-widest">Download weights ↗</BrandButton>}
       </div>
     </div>
     <p class="mt-2 max-w-3xl text-sm text-primary-comfy-canvas lg:text-base">{blurb}</p>
@@ -253,6 +258,15 @@ const faqJsonLd = {
           <div id="llms-menu" role="menu" class="absolute right-0 top-full z-40 mt-1.5 hidden w-60 overflow-hidden rounded-xl border border-transparency-white-t20 bg-site-dropdown py-1.5 shadow-2xl">
             <a href={mdUrl} class="block px-4 py-2.5 text-xs text-primary-warm-white hover:bg-transparency-white-t4">View as Markdown</a>
             <a href="/models-v2/llms.txt" class="block px-4 py-2.5 text-xs text-primary-warm-white hover:bg-transparency-white-t4">llms.txt — full catalog</a>
+            {hfUrl && (
+              <Fragment>
+                <div class="my-1.5 border-t border-transparency-white-t20"></div>
+                <a href={hfUrl} class="flex items-center justify-between gap-3 px-4 py-2.5 text-xs text-primary-warm-white hover:bg-transparency-white-t4">
+                  Download weights
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="size-4 shrink-0"><path d="M7 7h10v10"/><path d="M7 17 17 7"/></svg>
+                </a>
+              </Fragment>
+            )}
           </div>
         </div>
         <div class="relative" id="graph-wrap">
@@ -527,7 +541,7 @@ const faqJsonLd = {
                       <p class="truncate text-sm font-semibold text-primary-warm-white">{v.displayName}</p>
                       <p class="text-2xs font-light text-primary-warm-gray">{dirLabel[v.directory] ?? v.directory} · {v.workflowCount} workflows</p>
                     </div>
-                    <span class="flex shrink-0 items-center gap-1.5 text-2xs font-bold uppercase tracking-widest text-primary-comfy-yellow">Run <ArrowUpRight class="size-4 shrink-0" aria-hidden="true" /></span>
+                    <span class={runLink}>Run <ArrowRight aria-hidden="true" /></span>
                   </a>
                 ))}
               </div>

--- a/apps/website/src/pages/models-v2/[slug].astro
+++ b/apps/website/src/pages/models-v2/[slug].astro
@@ -242,9 +242,9 @@ const faqJsonLd = {
       <div class="rounded-2xl border border-white/10 p-5 sm:p-6">
         <div class="flex items-center justify-between">
           <h2 class="text-xs font-extrabold uppercase tracking-[0.2em] text-primary-warm-white">Input</h2>
-          <div id="iview-toggle" class="flex overflow-hidden rounded-lg border border-white/15 text-[10px] font-extrabold uppercase tracking-wider">
-            <button data-iview="app" class="bg-primary-comfy-yellow px-3 py-1.5 text-primary-comfy-ink">App</button>
-            <button data-iview="json" class="px-3 py-1.5 text-primary-comfy-canvas hover:text-primary-warm-white">JSON</button>
+          <div id="iview-toggle" class="flex gap-1.5 text-[10px] font-extrabold uppercase tracking-wider">
+            <button data-iview="app" class="rounded-md bg-white/10 px-2.5 py-1 text-primary-warm-white">App</button>
+            <button data-iview="json" class="rounded-md px-2.5 py-1 text-primary-warm-gray hover:text-primary-warm-white">JSON</button>
           </div>
         </div>
 
@@ -637,9 +637,9 @@ const faqJsonLd = {
         for (const [k, panel] of Object.entries(iPanels)) panel.classList.toggle('hidden', k !== view)
         for (const b of $('iview-toggle')!.querySelectorAll<HTMLElement>('[data-iview]')) {
           const active = b === btn
-          b.classList.toggle('bg-primary-comfy-yellow', active)
-          b.classList.toggle('text-primary-comfy-ink', active)
-          b.classList.toggle('text-primary-comfy-canvas', !active)
+          b.classList.toggle('bg-white/10', active)
+          b.classList.toggle('text-primary-warm-white', active)
+          b.classList.toggle('text-primary-warm-gray', !active)
         }
         renderAll()
       })

--- a/apps/website/src/pages/models-v2/[slug].astro
+++ b/apps/website/src/pages/models-v2/[slug].astro
@@ -320,8 +320,10 @@ const faqJsonLd = {
         </div>
         <div class="relative aspect-video w-full bg-secondary-mauve/30">
           <img id="result-img" src={img} alt={`${name} output`} class="h-full w-full object-cover transition-opacity duration-500" onerror="this.style.display='none'" />
-          <pre id="result-json" class="absolute inset-0 hidden bg-primary-comfy-ink scrollbar-code overflow-auto whitespace-pre-wrap break-words p-4 font-mono text-xs leading-relaxed text-primary-warm-gray"></pre>
-          <button type="button" id="copy-result" data-copy="result-json" title="Copy" aria-label="Copy" class="absolute right-3 top-3 hidden group shrink-0 cursor-pointer rounded-lg border border-white/15 bg-white/5 p-1.5 text-primary-warm-gray transition-colors hover:bg-white/10 hover:text-primary-warm-white"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="size-3.5 group-data-[copied]:hidden"><rect width="14" height="14" x="8" y="8" rx="2" ry="2"/><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/></svg><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="hidden size-3.5 group-data-[copied]:block"><path d="M20 6 9 17l-5-5"/></svg></button>
+          <div id="result-json-box" class="absolute inset-4 hidden overflow-hidden rounded-2xl border border-white/15 bg-primary-comfy-ink">
+            <pre id="result-json" class="scrollbar-code h-full overflow-auto whitespace-pre-wrap break-words p-4 font-mono text-xs leading-relaxed text-primary-warm-gray"></pre>
+            <button type="button" data-copy="result-json" title="Copy" aria-label="Copy" class="absolute right-3 top-3 group shrink-0 cursor-pointer rounded-lg border border-white/15 bg-white/5 p-1.5 text-primary-warm-gray transition-colors hover:bg-white/10 hover:text-primary-warm-white"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="size-3.5 group-data-[copied]:hidden"><rect width="14" height="14" x="8" y="8" rx="2" ry="2"/><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/></svg><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="hidden size-3.5 group-data-[copied]:block"><path d="M20 6 9 17l-5-5"/></svg></button>
+          </div>
           <div id="running-overlay" class="absolute inset-0 hidden flex-col items-center justify-center gap-4 bg-primary-comfy-ink/95 px-8 text-center">
             <p class="text-[10px] font-extrabold uppercase tracking-[0.25em] text-[#b7ded5]">Restored your prompt and settings ✓</p>
             <p class="text-lg font-semibold text-primary-warm-white">Running the graph</p>
@@ -651,8 +653,7 @@ const faqJsonLd = {
         const btn = (e.target as HTMLElement).closest<HTMLElement>('[data-rview]')
         if (!btn) return
         const json = btn.dataset.rview === 'json'
-        resultJson.classList.toggle('hidden', !json)
-        $('copy-result')?.classList.toggle('hidden', !json)
+        $('result-json-box')!.classList.toggle('hidden', !json)
         img.classList.toggle('hidden', json)
         for (const b of $('rview-toggle')!.querySelectorAll<HTMLElement>('[data-rview]')) {
           const active = b === btn
@@ -717,7 +718,7 @@ const faqJsonLd = {
         }
         strip.classList.remove('hidden'); strip.classList.add('flex')
         overlay.classList.remove('hidden'); overlay.classList.add('flex')
-        resultJson.classList.add('hidden'); $('copy-result')?.classList.add('hidden'); img.classList.remove('hidden')
+        $('result-json-box')!.classList.add('hidden'); img.classList.remove('hidden')
         fill.style.width = '0%'
         requestAnimationFrame(() => requestAnimationFrame(() => (fill.style.width = '92%')))
         window.setTimeout(() => {

--- a/apps/website/src/pages/models-v2/[slug].astro
+++ b/apps/website/src/pages/models-v2/[slug].astro
@@ -372,18 +372,19 @@ const faqJsonLd = {
           </div>
           <p class:list={[helperCopy, 'mt-1.5']}>Change value for a different output.</p>
           <label class:list={[fieldLabel, 'mt-4']}>Reference image</label>
-          <div id="dropzone" class="mt-2 flex flex-col items-center gap-3 rounded-xl border border-dashed border-transparency-white-t20 bg-transparency-white-t4 px-4 py-4 text-center transition-colors hover:border-primary-comfy-yellow/40 hover:bg-transparency-white-t8">
+          <input id="ref-file" type="file" accept="image/*" class="hidden" />
+          <div id="dropzone" class="mt-2 flex flex-col items-center gap-3 rounded-xl border border-dashed border-transparency-white-t20 bg-transparency-white-t4 px-4 py-4 text-center transition-colors data-[dragging]:border-primary-comfy-yellow/40 data-[dragging]:bg-transparency-white-t8">
             <button id="add-image-btn" type="button" class="cursor-pointer rounded-lg border border-transparency-white-t20 bg-transparency-white-t4 px-3 py-2.5 text-xs font-normal text-primary-comfy-canvas transition-colors hover:bg-transparency-white-t8"><span class="ppformula-text-center">Add image</span></button>
             <span class="text-xs font-light text-primary-warm-gray">or drag and drop the image here</span>
           </div>
 
           <!-- Attachment — media above content, as the shared attachment pattern lays it out -->
           <div id="ref-attachment" class="mt-2 hidden overflow-hidden rounded-xl border border-transparency-white-t20 bg-transparency-white-t4">
-            <img src={gallery[1] ?? gallery[0]} alt="" class="aspect-video w-full object-cover" onerror="this.style.display='none'" />
+            <img id="ref-preview" alt="" class="aspect-video w-full object-cover" onerror="this.style.display='none'" />
             <div class="flex items-center justify-between gap-3 px-3 py-2.5">
               <div class="min-w-0">
-                <p class="truncate text-xs text-primary-comfy-canvas">frame_0001.png</p>
-                <p class="text-2xs font-light text-primary-warm-gray">PNG · 820 KB</p>
+                <p id="ref-name" class="truncate text-xs text-primary-comfy-canvas"></p>
+                <p id="ref-meta" class="text-2xs font-light text-primary-warm-gray"></p>
               </div>
               <button id="ref-remove" type="button" title="Remove" aria-label="Remove" class="shrink-0 cursor-pointer rounded-lg border border-transparency-white-t20 bg-transparency-white-t4 p-1.5 text-primary-warm-gray transition-colors hover:bg-transparency-white-t8 hover:text-primary-warm-white">
                 <RemoveIcon class="size-3.5 shrink-0" aria-hidden="true" />
@@ -737,7 +738,7 @@ const faqJsonLd = {
 
       let authed = false
       let runsLeft = 5
-      let refImage = false
+      let refImage: string | null = null
       let lastRun: Record<string, unknown> | null = null
 
       const mult = (sel: HTMLSelectElement) => Number(sel.selectedOptions[0]?.dataset.mult ?? '1')
@@ -752,7 +753,7 @@ const faqJsonLd = {
             duration_s: mult(selDur) * 5,
             resolution: selRes.value,
             seed: seedNow(),
-            ...(refImage ? { reference_image: 'frame_0001.png' } : {})
+            ...(refImage ? { reference_image: refImage } : {})
           },
           estimate: { credits: creditsNow(), charged_on: 'success only' }
         }
@@ -839,16 +840,59 @@ const faqJsonLd = {
       })
 
       // reference image demo
-      $('add-image-btn')?.addEventListener('click', () => {
-        refImage = true
-        $('ref-attachment')?.classList.remove('hidden')
-        renderAll()
-      })
+      const refFile = $('ref-file') as HTMLInputElement
+      const refPreview = $('ref-preview') as HTMLImageElement
+      const dropzone = $('dropzone')!
+      let previewUrl: string | null = null
 
-      $('ref-remove')?.addEventListener('click', () => {
-        refImage = false
-        $('ref-attachment')?.classList.add('hidden')
+      const fileSize = (bytes: number) =>
+        bytes >= 1024 * 1024
+          ? `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+          : `${Math.max(1, Math.round(bytes / 1024))} KB`
+
+      const fileKind = (file: File) =>
+        (file.type.split('/')[1] || file.name.split('.').pop() || 'image').toUpperCase()
+
+      const clearImage = () => {
+        if (previewUrl) URL.revokeObjectURL(previewUrl)
+        previewUrl = null
+        refImage = null
+        refFile.value = ''
+        $('ref-attachment')!.classList.add('hidden')
         renderAll()
+      }
+
+      const acceptImage = (file: File | undefined) => {
+        if (!file || !file.type.startsWith('image/')) return
+        if (previewUrl) URL.revokeObjectURL(previewUrl)
+        previewUrl = URL.createObjectURL(file)
+        refPreview.style.display = ''
+        refPreview.src = previewUrl
+        $('ref-name')!.textContent = file.name
+        $('ref-meta')!.textContent = `${fileKind(file)} · ${fileSize(file.size)}`
+        refImage = file.name
+        $('ref-attachment')!.classList.remove('hidden')
+        renderAll()
+      }
+
+      $('add-image-btn')?.addEventListener('click', () => refFile.click())
+      refFile.addEventListener('change', () => acceptImage(refFile.files?.[0]))
+      $('ref-remove')?.addEventListener('click', clearImage)
+
+      // The drop zone lights up while a file is over it, not on plain hover.
+      for (const type of ['dragenter', 'dragover']) {
+        dropzone.addEventListener(type, (e) => {
+          e.preventDefault()
+          dropzone.dataset.dragging = ''
+        })
+      }
+      dropzone.addEventListener('dragleave', (e) => {
+        if (!dropzone.contains(e.relatedTarget as Node)) delete dropzone.dataset.dragging
+      })
+      dropzone.addEventListener('drop', (e) => {
+        e.preventDefault()
+        delete dropzone.dataset.dragging
+        acceptImage(e.dataTransfer?.files?.[0])
       })
 
       // split button menus
@@ -977,13 +1021,13 @@ const faqJsonLd = {
         modal.classList.add('hidden'); modal.classList.remove('flex')
       })
       $('demo-reset')!.addEventListener('click', () => {
-        authed = false; runsLeft = 5; lastRun = null; refImage = false
+        authed = false; runsLeft = 5; lastRun = null
+        clearImage()
         seedInput.value = DEFAULT_SEED
         upgrade.classList.add('hidden'); upgrade.classList.remove('flex')
         strip.classList.add('hidden'); strip.classList.remove('flex')
         varBlock.classList.add('hidden')
         varStrip.classList.add('hidden'); varStrip.classList.remove('grid')
-        $('ref-attachment')?.classList.add('hidden')
         resultSeed.textContent = `Seed ${DEFAULT_SEED}`
         meter.textContent = 'Free runs: 5 left'
         renderAll()

--- a/apps/website/src/pages/models-v2/[slug].astro
+++ b/apps/website/src/pages/models-v2/[slug].astro
@@ -8,7 +8,7 @@
 import { cn } from '@comfyorg/tailwind-utils'
 
 import BaseLayout from '../../layouts/BaseLayout.astro'
-import { ArrowRight, Coins as CreditsIcon } from '@lucide/vue'
+import { ArrowRight, Coins as CreditsIcon, Download as DownloadIcon } from '@lucide/vue'
 
 import BrandButton from '../../components/common/BrandButton.vue'
 import GlassCard from '../../components/common/GlassCard.vue'
@@ -263,7 +263,7 @@ const faqJsonLd = {
                 <div class="my-1.5 border-t border-transparency-white-t20"></div>
                 <a href={hfUrl} class="flex items-center justify-between gap-3 px-4 py-2.5 text-xs text-primary-warm-white hover:bg-transparency-white-t4">
                   Download weights
-                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="size-4 shrink-0"><path d="M7 7h10v10"/><path d="M7 17 17 7"/></svg>
+                  <DownloadIcon class="size-4 shrink-0" aria-hidden="true" />
                 </a>
               </Fragment>
             )}

--- a/apps/website/src/pages/models-v2/[slug].astro
+++ b/apps/website/src/pages/models-v2/[slug].astro
@@ -8,8 +8,8 @@
 import { cn } from '@comfyorg/tailwind-utils'
 
 import BaseLayout from '../../layouts/BaseLayout.astro'
+import BrandButton from '../../components/common/BrandButton.vue'
 import GlassCard from '../../components/common/GlassCard.vue'
-import { brandButtonVariants } from '../../components/common/brandButton.variants'
 import Badge from '../../components/ui/badge/Badge.vue'
 import { toggleVariants } from '../../components/ui/toggle'
 import {
@@ -93,11 +93,6 @@ const helperCopy = 'text-2xs font-light text-primary-warm-gray'
 const fieldLabel = 'block text-2xs font-bold uppercase tracking-widest text-primary-warm-gray'
 const textAction = 'text-2xs font-bold uppercase tracking-widest text-primary-warm-gray hover:text-primary-warm-white'
 const iconButton = 'group shrink-0 cursor-pointer rounded-lg border border-transparency-white-t20 bg-transparency-white-t4 p-1.5 text-primary-warm-gray transition-colors hover:bg-transparency-white-t8 hover:text-primary-warm-white'
-const primaryButton = brandButtonVariants({ variant: 'solid', size: 'xs' })
-const outlineAccentButton = brandButtonVariants({ variant: 'outline', size: 'xs' })
-const outlineButton = brandButtonVariants({ variant: 'outline-light', size: 'sm' })
-const solidAccentButton = brandButtonVariants({ variant: 'solid', size: 'sm' })
-const outlineAccentButtonSm = brandButtonVariants({ variant: 'outline', size: 'sm' })
 const tab = cn(
   toggleVariants(),
   'rounded-none px-4 first:rounded-l-xl last:rounded-r-xl'
@@ -218,9 +213,9 @@ const faqJsonLd = {
         <Badge variant="accent">{meta.label}</Badge>
       </div>
       <div class="hidden gap-2 lg:flex">
-        {docsUrl && <a href={docsUrl} class:list={[outlineAccentButtonSm, 'text-2xs uppercase tracking-widest']}>Learn more</a>}
-        <a href={workflowsUrl} class:list={[solidAccentButton, 'text-2xs uppercase tracking-widest']}>Try workflows</a>
-        {hfUrl && <a href={hfUrl} class:list={[outlineAccentButtonSm, 'text-2xs uppercase tracking-widest']}>Download weights ↗</a>}
+        {docsUrl && <BrandButton href={docsUrl} variant="outline" size="sm" class="text-2xs uppercase tracking-widest">Learn more</BrandButton>}
+        <BrandButton href={workflowsUrl} variant="solid" size="sm" class="text-2xs uppercase tracking-widest">Try workflows</BrandButton>
+        {hfUrl && <BrandButton href={hfUrl} variant="outline" size="sm" class="text-2xs uppercase tracking-widest">Download weights ↗</BrandButton>}
       </div>
     </div>
     <p class="mt-2 max-w-3xl text-sm font-light leading-relaxed text-primary-comfy-canvas sm:text-base">{blurb}</p>
@@ -237,14 +232,14 @@ const faqJsonLd = {
   <section class="mx-auto max-w-9xl px-5 pt-16 sm:px-6 lg:px-20">
     <div class="flex flex-wrap items-center justify-between gap-4">
       <nav class="ring-primary-warm-white/20 flex w-fit max-w-full items-center gap-0.5 overflow-x-auto rounded-2xl p-1.5 ring-2" role="tablist" aria-label="Model page sections">
-        <button type="button" role="tab" data-tab="playground" data-state="on" aria-controls="panel-playground" aria-selected="true" class={tab}>Playground</button>
-        <button type="button" role="tab" data-tab="api" data-state="off" aria-controls="panel-api" aria-selected="false" class={tab}>API</button>
-        <button type="button" role="tab" data-tab="gallery" data-state="off" aria-controls="panel-gallery" aria-selected="false" class={tab}>Examples</button>
+        <button type="button" role="tab" data-tab="playground" data-state="on" aria-controls="panel-playground" aria-selected="true" class={tab}><span class="ppformula-text-center">Playground</span></button>
+        <button type="button" role="tab" data-tab="api" data-state="off" aria-controls="panel-api" aria-selected="false" class={tab}><span class="ppformula-text-center">API</span></button>
+        <button type="button" role="tab" data-tab="gallery" data-state="off" aria-controls="panel-gallery" aria-selected="false" class={tab}><span class="ppformula-text-center">Examples</span></button>
       </nav>
       <div class="hidden gap-2 sm:flex">
         <div class="relative" id="llms-wrap">
           <div class="inline-flex items-stretch divide-x divide-transparency-white-t20 overflow-hidden rounded-lg border border-transparency-white-t20 bg-transparency-white-t4 text-xs font-normal text-primary-comfy-canvas">
-            <button id="llms-copy" class="cursor-pointer px-3 py-2.5 transition-colors hover:bg-transparency-white-t8">Copy markdown<span id="llms-copied" class="hidden pl-2 text-primary-comfy-yellow">✓</span></button>
+            <button id="llms-copy" class="cursor-pointer px-3 py-2.5 transition-colors hover:bg-transparency-white-t8"><span class="ppformula-text-center">Copy markdown<span id="llms-copied" class="hidden pl-2 text-primary-comfy-yellow">✓</span></span></button>
             <button id="llms-btn" aria-haspopup="menu" aria-expanded="false" aria-label="More formats for LLMs" class="cursor-pointer px-2 transition-colors hover:bg-transparency-white-t8">
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="size-4"><path d="m6 9 6 6 6-6"/></svg>
             </button>
@@ -256,7 +251,7 @@ const faqJsonLd = {
         </div>
         <div class="relative" id="graph-wrap">
           <div class="inline-flex items-stretch divide-x divide-transparency-white-t20 overflow-hidden rounded-lg border border-transparency-white-t20 bg-transparency-white-t4 text-xs font-normal text-primary-comfy-canvas">
-            <a href="https://cloud.comfy.org?utm_source=models_v2_preview" class="px-3 py-2.5 transition-colors hover:bg-transparency-white-t8">Open the full graph</a>
+            <a href="https://cloud.comfy.org?utm_source=models_v2_preview" class="px-3 py-2.5 transition-colors hover:bg-transparency-white-t8"><span class="ppformula-text-center">Open the full graph</span></a>
             <button id="graph-btn" aria-haspopup="menu" aria-expanded="false" aria-label="More ways to open this model" class="cursor-pointer px-2 transition-colors hover:bg-transparency-white-t8">
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="size-4"><path d="m6 9 6 6 6-6"/></svg>
             </button>
@@ -333,7 +328,7 @@ const faqJsonLd = {
           </div>
           <label class:list={[fieldLabel, 'mt-4']}>Reference image</label>
           <div id="dropzone" class="mt-2 flex flex-col items-center gap-3 rounded-xl border border-dashed border-transparency-white-t20 bg-transparency-white-t4 px-4 py-4 text-center">
-            <button id="add-image-btn" class:list={[outlineButton, 'px-3 py-1.5 text-2xs uppercase tracking-widest']}>Add image</button>
+            <BrandButton id="add-image-btn" variant="outline-light" size="sm" class="px-3 py-1.5 text-2xs uppercase tracking-widest">Add image</BrandButton>
             <span id="dropzone-label" class="text-xs font-light text-primary-warm-gray">or drop a frame to animate it</span>
             <img id="ref-thumb" src={gallery[1] ?? gallery[0]} alt="" class="hidden h-10 w-16 rounded-md object-cover" onerror="this.style.display='none'" />
           </div>
@@ -357,10 +352,8 @@ const faqJsonLd = {
         <div class="mt-5 flex items-center justify-between gap-3 border-t border-white/10 pt-4">
           <span class="hidden text-2xs text-primary-warm-gray sm:block"><span id="cost-line">{baseCredits} credits ≈ ${(baseCredits * 0.0084).toFixed(2)}</span> · est.</span>
           <div class="flex items-center gap-3">
-            <button id="pg-reset" class:list={[outlineAccentButton, 'uppercase tracking-widest']}>Reset</button>
-            <button id="pg-run" data-base-credits={baseCredits} data-slug={slugId} class:list={[primaryButton, 'uppercase tracking-widest']}>
-              Sign in to run — 5 free
-            </button>
+            <BrandButton id="pg-reset" variant="outline" size="xs" class="uppercase tracking-widest">Reset</BrandButton>
+            <BrandButton id="pg-run" data-base-credits={baseCredits} data-slug={slugId} variant="solid" size="xs" class="uppercase tracking-widest">Sign in to run — 5 free</BrandButton>
           </div>
         </div>
       </div>
@@ -414,7 +407,7 @@ const faqJsonLd = {
             </div>
             <p class="text-xs font-light leading-relaxed text-primary-warm-gray">Your graphs, seeds, history, and all five outputs stay yours — free, forever. Or run it locally: it’s open source.</p>
             <div class="flex flex-wrap items-center gap-4">
-              <button class:list={[primaryButton, 'uppercase tracking-widest']}>Go Creator</button>
+              <BrandButton variant="solid" size="xs" class="uppercase tracking-widest">Go Creator</BrandButton>
               <span class="text-2xs font-bold uppercase tracking-widest text-primary-comfy-canvas">See all plans →</span>
               <button id="demo-reset" class={textAction}>Replay demo</button>
             </div>
@@ -426,14 +419,14 @@ const faqJsonLd = {
         </div>
         <div class="mt-auto flex justify-end pt-3">
           <div id="result-download" class="shrink-0">
-            <a href={img} download={`${slugId}-result`} class:list={[outlineAccentButton, 'uppercase tracking-widest']}>Download</a>
+            <BrandButton href={img} download={`${slugId}-result`} variant="outline" size="xs" class="uppercase tracking-widest">Download</BrandButton>
           </div>
         </div>
         <!-- VARIATIONS QUEUE -->
         <div id="var-block" class="hidden border-t border-white/10 px-5 py-4">
           <div class="flex items-center justify-between gap-3">
             <p class={panelTitle}>The queue — pick the best, not the first</p>
-            <button id="queue-vars" class:list={[primaryButton, 'uppercase tracking-widest']}>Queue 4 variations — <span id="var-cost">24</span> cr</button>
+            <BrandButton id="queue-vars" variant="solid" size="xs" class="uppercase tracking-widest">Queue 4 variations — <span id="var-cost">24</span> cr</BrandButton>
           </div>
           <div id="var-strip" class="mt-3 hidden grid-cols-4 gap-2">
             {[0, 1, 2, 3].map((i) => (
@@ -454,7 +447,7 @@ const faqJsonLd = {
         <p class="text-lg font-bold text-primary-comfy-canvas">Start free. Upgrade when you're ready.</p>
         <p class="mt-1 text-sm text-primary-comfy-canvas">5 free runs on real GPUs — no credit card required.</p>
       </div>
-      <button id="free-run-cta" class:list={[outlineAccentButton, 'shrink-0 self-start sm:self-auto']}>Try free</button>
+      <BrandButton id="free-run-cta" variant="outline" size="xs" class="shrink-0 self-start sm:self-auto">Try free</BrandButton>
     </div>
   </section>
 
@@ -535,9 +528,7 @@ const faqJsonLd = {
 
   <!-- MOBILE STICKY RUN BAR -->
   <div class="fixed inset-x-0 bottom-0 z-40 border-t border-white/10 bg-primary-comfy-ink/95 px-4 pb-[calc(env(safe-area-inset-bottom)+12px)] pt-3 backdrop-blur lg:hidden">
-    <button id="pg-run-mobile" class:list={[primaryButton, 'w-full py-3.5 uppercase tracking-widest']}>
-      Run — ~{baseCredits} credits
-    </button>
+    <BrandButton id="pg-run-mobile" variant="solid" size="xs" class="w-full py-3.5 uppercase tracking-widest">Run — ~{baseCredits} credits</BrandButton>
     <p class:list={[helperCopy, 'mt-1.5 text-center']}>Sign in at run · 5 free · no card</p>
   </div>
   <div class="h-24 lg:hidden"></div>
@@ -549,9 +540,9 @@ const faqJsonLd = {
       <h3 class="mt-4 text-2xl font-semibold text-primary-warm-white">5 free runs. No card.</h3>
       <p class="mt-2 text-sm font-light leading-relaxed text-primary-comfy-canvas">Your prompt and settings are saved. The run starts the moment you’re in.</p>
       <div class="mt-5 flex flex-col gap-2.5">
-        <button data-auth class:list={[primaryButton, 'w-full']}>Continue with Google</button>
-        <button data-auth class:list={[outlineButton, 'w-full']}>Continue with GitHub</button>
-        <button data-auth class:list={[outlineButton, 'w-full']}>Continue with email</button>
+        <BrandButton data-auth variant="solid" size="xs" class="w-full">Continue with Google</BrandButton>
+        <BrandButton data-auth variant="outline-light" size="sm" class="w-full">Continue with GitHub</BrandButton>
+        <BrandButton data-auth variant="outline-light" size="sm" class="w-full">Continue with email</BrandButton>
       </div>
       <p class:list={[helperCopy, 'mt-4 leading-relaxed']}>By continuing you agree to the Terms. Open source stays open — your graphs and outputs are yours.</p>
       <button id="auth-close" class:list={[textAction, 'mt-3']}>Not now</button>
@@ -670,6 +661,12 @@ const faqJsonLd = {
       const base = Number(runDesktop.dataset.baseCredits ?? '6')
       const slug = runDesktop.dataset.slug ?? 'model'
 
+      // BrandButton wraps labels in a centering span — writing to the button
+      // itself would strip it.
+      const label = (el: HTMLElement) => el.querySelector('span') ?? el
+      const runDesktopLabel = label(runDesktop)
+      const runMobileLabel = label(runMobile)
+
       let authed = false
       let runsLeft = 5
       let seed = 428790123
@@ -711,14 +708,14 @@ const faqJsonLd = {
         modalCredits.textContent = String(c)
         varCost.textContent = String(c * 4)
         if (!authed) {
-          runDesktop.textContent = 'Sign in to run — 5 free'
-          runMobile.textContent = `Run — ~${c} credits`
+          runDesktopLabel.textContent = 'Sign in to run — 5 free'
+          runMobileLabel.textContent = `Run — ~${c} credits`
         } else if (runsLeft > 0) {
-          runDesktop.textContent = `Run again — ${runsLeft} free left`
-          runMobile.textContent = `Run — ${runsLeft} free left`
+          runDesktopLabel.textContent = `Run again — ${runsLeft} free left`
+          runMobileLabel.textContent = `Run — ${runsLeft} free left`
         } else {
-          runDesktop.textContent = 'Go Creator — from $20/mo'
-          runMobile.textContent = 'Go Creator — from $20/mo'
+          runDesktopLabel.textContent = 'Go Creator — from $20/mo'
+          runMobileLabel.textContent = 'Go Creator — from $20/mo'
         }
       }
 

--- a/apps/website/src/pages/models-v2/[slug].astro
+++ b/apps/website/src/pages/models-v2/[slug].astro
@@ -346,6 +346,20 @@ const faqJsonLd = {
               </div>
             </div>
           </div>
+          <label class:list={[fieldLabel, 'mt-4']} for="pg-seed">Seed</label>
+          <div class="mt-1.5 flex gap-2">
+            <input
+              id="pg-seed"
+              type="number"
+              inputmode="numeric"
+              min="0"
+              step="1"
+              value={428790123}
+              class="w-full rounded-lg border border-transparency-white-t20 bg-transparency-white-t4 px-3 py-2.5 font-mono text-xs text-primary-comfy-canvas focus:border-primary-comfy-yellow/60 focus:outline-none"
+            />
+            <BrandButton id="seed-shuffle" variant="outline-light" size="sm" class="shrink-0 px-3 py-1.5 text-2xs uppercase tracking-widest">Shuffle</BrandButton>
+          </div>
+          <p class:list={[helperCopy, 'mt-1.5']}>Same seed and prompt give the same output. Change it for a different take.</p>
           <label class:list={[fieldLabel, 'mt-4']}>Reference image</label>
           <div id="dropzone" class="mt-2 flex flex-col items-center gap-3 rounded-xl border border-dashed border-transparency-white-t20 bg-transparency-white-t4 px-4 py-4 text-center">
             <BrandButton id="add-image-btn" variant="outline-light" size="sm" class="px-3 py-1.5 text-2xs uppercase tracking-widest">Add image</BrandButton>
@@ -693,9 +707,12 @@ const faqJsonLd = {
       const runDesktopLabel = label(runDesktop)
       const runMobileLabel = label(runMobile)
 
+      const seedInput = $('pg-seed') as HTMLInputElement
+      const DEFAULT_SEED = '428790123'
+      const seedNow = () => Number(seedInput.value) || 0
+
       let authed = false
       let runsLeft = 5
-      let seed = 428790123
       let refImage = false
       let lastRun: Record<string, unknown> | null = null
 
@@ -710,7 +727,7 @@ const faqJsonLd = {
             aspect_ratio: selAspect.value,
             duration_s: mult(selDur) * 5,
             resolution: selRes.value,
-            seed,
+            seed: seedNow(),
             ...(refImage ? { reference_image: 'frame_0001.png' } : {})
           },
           estimate: { credits: creditsNow(), charged_on: 'success only' }
@@ -722,7 +739,7 @@ const faqJsonLd = {
         const receipt = lastRun ?? {
           status: 'example',
           note: 'This is a curated example. Run it to get your own receipt.',
-          seed,
+          seed: seedNow(),
           model: slug
         }
         paintJson(resultJson, JSON.stringify(receipt, null, 2))
@@ -789,7 +806,13 @@ const faqJsonLd = {
 
       // live bindings
       prompt.addEventListener('input', renderAll)
+      seedInput.addEventListener('input', renderAll)
       for (const sel of [selAspect, selDur, selRes]) sel.addEventListener('change', renderAll)
+
+      $('seed-shuffle')!.addEventListener('click', () => {
+        seedInput.value = String(Math.floor(Math.random() * 1_000_000_000))
+        renderAll()
+      })
 
       // reference image demo
       $('add-image-btn')?.addEventListener('click', () => {
@@ -860,19 +883,19 @@ const faqJsonLd = {
           img.style.opacity = '0.4'
           window.setTimeout(() => (img.style.opacity = '1'), 350)
           runsLeft -= 1
-          seed += 1
+          const runSeed = seedNow()
           lastRun = {
-            job_id: 'j_' + seed.toString(16),
+            job_id: 'j_' + runSeed.toString(16),
             status: 'succeeded',
             model: slug,
-            seed,
+            seed: runSeed,
             credits_charged: creditsNow(),
             charged_on: 'success only',
             duration_s: 4.2,
             nodes_executed: 24,
             output: { type: 'video/webp', watermark: false, saved_to_history: true }
           }
-          resultSeed.textContent = `Seed ${seed}`
+          resultSeed.textContent = `Seed ${runSeed}`
           meter.textContent = runsLeft > 0 ? `Free runs: ${runsLeft} left` : 'Free runs used'
           varBlock.classList.remove('hidden')
           renderAll()
@@ -927,14 +950,15 @@ const faqJsonLd = {
         modal.classList.add('hidden'); modal.classList.remove('flex')
       })
       $('demo-reset')!.addEventListener('click', () => {
-        authed = false; runsLeft = 5; seed = 428790123; lastRun = null; refImage = false
+        authed = false; runsLeft = 5; lastRun = null; refImage = false
+        seedInput.value = DEFAULT_SEED
         upgrade.classList.add('hidden'); upgrade.classList.remove('flex')
         strip.classList.add('hidden'); strip.classList.remove('flex')
         varBlock.classList.add('hidden')
         varStrip.classList.add('hidden'); varStrip.classList.remove('grid')
         $('ref-thumb')?.classList.add('hidden')
         const dl = $('dropzone-label'); if (dl) dl.textContent = 'or drop a frame to animate it'
-        resultSeed.textContent = 'Seed 428790123'
+        resultSeed.textContent = `Seed ${DEFAULT_SEED}`
         meter.textContent = 'Free runs: 5 left'
         renderAll()
       })

--- a/apps/website/src/pages/models-v2/[slug].astro
+++ b/apps/website/src/pages/models-v2/[slug].astro
@@ -274,7 +274,7 @@ const faqJsonLd = {
           <h2 class={cardTitle}>Input</h2>
           <div id="iview-toggle" class="flex gap-1.5">
             <button data-iview="app" class:list={[pill, pillActive]}>App</button>
-            <button data-iview="json" class:list={[pill, pillIdle]}>JSON</button>
+            <button data-iview="json" class:list={[pill, pillIdle]}>Code</button>
           </div>
         </div>
 
@@ -351,7 +351,7 @@ const faqJsonLd = {
           <h2 class={cardTitle}>Result</h2>
           <div id="rview-toggle" class="flex gap-1.5">
             <button data-rview="preview" class:list={[pill, pillActive]}>Preview</button>
-            <button data-rview="json" class:list={[pill, pillIdle]}>JSON</button>
+            <button data-rview="json" class:list={[pill, pillIdle]}>Code</button>
           </div>
         </div>
         <div class="relative mt-5 aspect-video w-full overflow-hidden rounded-2xl">

--- a/apps/website/src/pages/models-v2/[slug].astro
+++ b/apps/website/src/pages/models-v2/[slug].astro
@@ -378,18 +378,19 @@ const faqJsonLd = {
             <span class="text-xs font-light text-primary-warm-gray">or drag and drop the image here</span>
           </div>
 
-          <!-- Attachment — media above content, as the shared attachment pattern lays it out -->
-          <div id="ref-attachment" class="mt-2 hidden overflow-hidden rounded-xl border border-transparency-white-t20 bg-transparency-white-t4">
-            <img id="ref-preview" alt="" class="aspect-video w-full object-cover" onerror="this.style.display='none'" />
-            <div class="flex items-center justify-between gap-3 px-3 py-2.5">
-              <div class="min-w-0">
-                <p id="ref-name" class="truncate text-xs text-primary-comfy-canvas"></p>
-                <p id="ref-meta" class="text-2xs font-light text-primary-warm-gray"></p>
-              </div>
-              <button id="ref-remove" type="button" title="Remove" aria-label="Remove" class="shrink-0 cursor-pointer rounded-lg border border-transparency-white-t20 bg-transparency-white-t4 p-1.5 text-primary-warm-gray transition-colors hover:bg-transparency-white-t8 hover:text-primary-warm-white">
-                <RemoveIcon class="size-3.5 shrink-0" aria-hidden="true" />
-              </button>
+          <!-- Attachment — the shared pattern's vertical form: a square media box,
+               the file below it, and the remove action over the media's corner. -->
+          <div id="ref-attachment" class="relative mt-2 hidden w-30 rounded-xl border border-transparency-white-t20 bg-transparency-white-t4 p-2">
+            <div class="aspect-square w-full overflow-hidden rounded-lg bg-transparency-white-t8">
+              <img id="ref-preview" alt="" class="aspect-square w-full object-cover" onerror="this.style.display='none'" />
             </div>
+            <div class="px-0.5 pt-2">
+              <p id="ref-name" class="truncate text-xs text-primary-comfy-canvas"></p>
+              <p id="ref-meta" class="truncate text-2xs font-light text-primary-warm-gray"></p>
+            </div>
+            <button id="ref-remove" type="button" title="Remove" aria-label="Remove" class="absolute right-3 top-3 z-20 cursor-pointer rounded-lg border border-transparency-white-t20 bg-primary-comfy-ink/80 p-1.5 text-primary-comfy-canvas backdrop-blur transition-colors hover:bg-primary-comfy-ink hover:text-primary-warm-white">
+              <RemoveIcon class="size-3.5 shrink-0" aria-hidden="true" />
+            </button>
           </div>
         </div>
 

--- a/apps/website/src/pages/models-v2/[slug].astro
+++ b/apps/website/src/pages/models-v2/[slug].astro
@@ -216,10 +216,10 @@ const WIRE = {
   <!-- TABS + TRIO -->
   <section class="mx-auto max-w-7xl px-5 pt-6 sm:px-6 lg:px-8">
     <div class="flex flex-wrap items-center justify-between gap-4 border-b border-white/10 pb-0">
-      <nav class="flex gap-6 overflow-x-auto text-xs font-extrabold uppercase tracking-[0.2em] sm:gap-8">
-        <span class="border-b-2 border-primary-comfy-yellow pb-3 text-primary-comfy-yellow">Playground</span>
-        <a href="#api" class="pb-3 text-primary-warm-gray hover:text-primary-warm-white">API</a>
-        <a href="#gallery" class="pb-3 text-primary-warm-gray hover:text-primary-warm-white">Examples</a>
+      <nav class="flex gap-6 overflow-x-auto text-xs font-extrabold uppercase tracking-[0.2em] sm:gap-8" role="tablist" aria-label="Model page sections">
+        <button type="button" role="tab" data-tab="playground" aria-controls="panel-playground" aria-selected="true" class="border-b-2 border-transparent pb-3 uppercase text-primary-warm-gray transition hover:text-primary-warm-white aria-selected:border-primary-comfy-yellow aria-selected:text-primary-comfy-yellow">Playground</button>
+        <button type="button" role="tab" data-tab="api" aria-controls="panel-api" aria-selected="false" class="border-b-2 border-transparent pb-3 uppercase text-primary-warm-gray transition hover:text-primary-warm-white aria-selected:border-primary-comfy-yellow aria-selected:text-primary-comfy-yellow">API</button>
+        <button type="button" role="tab" data-tab="gallery" aria-controls="panel-gallery" aria-selected="false" class="border-b-2 border-transparent pb-3 uppercase text-primary-warm-gray transition hover:text-primary-warm-white aria-selected:border-primary-comfy-yellow aria-selected:text-primary-comfy-yellow">Examples</button>
         <a href={workflowsUrl} class="pb-3 text-primary-warm-gray hover:text-primary-warm-white">Workflows ↗</a>
       </nav>
       <div class="hidden gap-2 pb-2 lg:flex">
@@ -231,7 +231,7 @@ const WIRE = {
   </section>
 
   <!-- PLAYGROUND -->
-  <section class="mx-auto max-w-7xl px-5 pt-6 sm:px-6 lg:px-8">
+  <section id="panel-playground" data-panel="playground" role="tabpanel" class="mx-auto max-w-7xl px-5 pt-6 sm:px-6 lg:px-8">
     <div id="signed-in-strip" class="mb-4 hidden items-center justify-between gap-3 rounded-xl border border-[#b7ded5]/40 bg-[#b7ded5]/10 px-4 py-2.5 sm:flex-nowrap">
       <p class="text-[11px] font-extrabold uppercase tracking-[0.15em] text-[#b7ded5]">Signed in · inputs restored — no survey, no plan picker</p>
       <p id="free-meter" class="shrink-0 text-[11px] font-extrabold uppercase tracking-widest text-primary-comfy-yellow">Free runs: 5 left</p>
@@ -450,7 +450,7 @@ const WIRE = {
   </section>
 
   <!-- EXAMPLES -->
-  <section id="gallery" class="mx-auto max-w-7xl scroll-mt-24 px-5 py-12 sm:px-6 lg:px-8 lg:py-16">
+  <section id="panel-gallery" data-panel="gallery" role="tabpanel" hidden class="mx-auto max-w-7xl scroll-mt-24 px-5 py-12 sm:px-6 lg:px-8 lg:py-16">
     <div class="mb-6">
       <h2 class="text-sm font-extrabold uppercase tracking-[0.3em] text-primary-comfy-yellow">Made with {name}</h2>
       <p class="mt-1.5 text-sm font-light text-primary-warm-gray">Real outputs from the workflow templates — click one to load its prompt into the app.</p>
@@ -468,6 +468,20 @@ const WIRE = {
         </li>
       ))}
     </ul>
+  </section>
+
+  <!-- API -->
+  <section id="panel-api" data-panel="api" role="tabpanel" hidden class="mx-auto max-w-7xl scroll-mt-24 px-5 py-12 sm:px-6 lg:px-8 lg:pb-24">
+    <h2 class="text-sm font-extrabold uppercase tracking-[0.3em] text-primary-comfy-yellow">Run it your way</h2>
+    <div class="mt-4 overflow-x-auto rounded-2xl border border-white/10 bg-black/40 p-5 sm:p-7">
+      <pre class="font-mono text-xs leading-relaxed text-[#b7ded5] sm:text-[13px]">{`# Same graph the playground runs — as an endpoint
+curl -X POST https://api.comfy.org/v1/run \\
+  -H "Authorization: Bearer $COMFY_KEY" \\
+  -d '{ "workflow": "${slugId}", "prompt": "…" }'
+
+# → { "job_id": "j_8f2…", "credits": ${baseCredits}, "eta_s": 4 }`}</pre>
+    </div>
+    <p class="mt-3 text-xs font-light text-primary-warm-gray">The app above is this call — the JSON view shows the exact payload. Full reference · Comfy MCP · <a href={mdUrl} class="text-primary-comfy-yellow">this page as Markdown</a> · <a href="/models-v2/llms.txt" class="text-primary-comfy-yellow">llms.txt</a></p>
   </section>
 
   <!-- COST + FAMILY -->
@@ -507,20 +521,6 @@ const WIRE = {
     </div>
   </section>
 
-  <!-- API -->
-  <section id="api" class="mx-auto max-w-7xl scroll-mt-24 px-5 py-12 sm:px-6 lg:px-8 lg:pb-24">
-    <h2 class="text-sm font-extrabold uppercase tracking-[0.3em] text-primary-comfy-yellow">Run it your way</h2>
-    <div class="mt-4 overflow-x-auto rounded-2xl border border-white/10 bg-black/40 p-5 sm:p-7">
-      <pre class="font-mono text-xs leading-relaxed text-[#b7ded5] sm:text-[13px]">{`# Same graph the playground runs — as an endpoint
-curl -X POST https://api.comfy.org/v1/run \\
-  -H "Authorization: Bearer $COMFY_KEY" \\
-  -d '{ "workflow": "${slugId}", "prompt": "…" }'
-
-# → { "job_id": "j_8f2…", "credits": ${baseCredits}, "eta_s": 4 }`}</pre>
-    </div>
-    <p class="mt-3 text-xs font-light text-primary-warm-gray">The app above is this call — the JSON view shows the exact payload. Full reference · Comfy MCP · <a href={mdUrl} class="text-primary-comfy-yellow">this page as Markdown</a> · <a href="/models-v2/llms.txt" class="text-primary-comfy-yellow">llms.txt</a></p>
-  </section>
-
   <!-- MOBILE STICKY RUN BAR -->
   <div class="fixed inset-x-0 bottom-0 z-40 border-t border-white/10 bg-primary-comfy-ink/95 px-4 pb-[calc(env(safe-area-inset-bottom)+12px)] pt-3 backdrop-blur lg:hidden">
     <button id="pg-run-mobile" class="w-full rounded-xl bg-primary-comfy-yellow py-3.5 text-sm font-extrabold uppercase tracking-widest text-primary-comfy-ink">
@@ -547,6 +547,40 @@ curl -X POST https://api.comfy.org/v1/run \\
   </div>
 
   <script>
+    function initModelTabs() {
+      const tabs = Array.from(document.querySelectorAll<HTMLElement>('[data-tab]'))
+      const panels = Array.from(document.querySelectorAll<HTMLElement>('[data-panel]'))
+      if (!tabs.length || tabs[0].dataset.bound === '1') return
+      tabs.forEach((t) => (t.dataset.bound = '1'))
+
+      const names = tabs.map((t) => t.dataset.tab)
+      const show = (name: string | undefined) => {
+        const active = name && names.includes(name) ? name : 'playground'
+        tabs.forEach((t) => t.setAttribute('aria-selected', String(t.dataset.tab === active)))
+        panels.forEach((p) => (p.hidden = p.dataset.panel !== active))
+      }
+
+      tabs.forEach((t) =>
+        t.addEventListener('click', () => {
+          show(t.dataset.tab)
+          history.replaceState(null, '', t.dataset.tab === 'playground' ? location.pathname : `#${t.dataset.tab}`)
+        })
+      )
+
+      const toTop = () => window.scrollTo(0, 0)
+
+      const showFromHash = () => {
+        show(location.hash.slice(1))
+        if (!location.hash) return
+        toTop()
+        requestAnimationFrame(toTop)
+        window.addEventListener('load', toTop, { once: true })
+      }
+
+      showFromHash()
+      window.addEventListener('hashchange', showFromHash)
+    }
+
     function initPlaygroundDemo() {
       const runDesktop = document.getElementById('pg-run')
       if (!runDesktop || runDesktop.dataset.bound === '1') return
@@ -726,6 +760,7 @@ curl -X POST https://api.comfy.org/v1/run \\
         b.addEventListener('click', () => {
           prompt.value = b.dataset.usePrompt ?? prompt.value
           renderAll()
+          document.querySelector<HTMLElement>('[data-tab="playground"]')?.click()
           document.getElementById('pg-prompt')?.scrollIntoView({ behavior: 'smooth', block: 'center' })
         })
       )
@@ -828,7 +863,11 @@ curl -X POST https://api.comfy.org/v1/run \\
       renderAll()
     }
 
+    initModelTabs()
     initPlaygroundDemo()
-    document.addEventListener('astro:page-load', initPlaygroundDemo)
+    document.addEventListener('astro:page-load', () => {
+      initModelTabs()
+      initPlaygroundDemo()
+    })
   </script>
 </BaseLayout>

--- a/apps/website/src/pages/models-v2/[slug].astro
+++ b/apps/website/src/pages/models-v2/[slug].astro
@@ -210,8 +210,8 @@ const faqJsonLd = {
 
   <!-- COMPACT HEADER -->
   <section class="mx-auto max-w-9xl px-5 pt-8 sm:px-6 lg:px-20 lg:pt-12">
-    <Breadcrumbs crumbs={breadcrumbs} />
-    <div class="mt-3 flex flex-wrap items-center justify-between gap-3">
+    <Breadcrumbs crumbs={breadcrumbs} class="mb-6 lg:mb-8" />
+    <div class="flex flex-wrap items-center justify-between gap-3">
       <div class="flex min-w-0 flex-wrap items-center gap-3">
         <h1 class="max-w-full truncate text-2xl font-semibold text-primary-warm-white sm:text-3xl">{name}</h1>
         <Badge variant="accent">{meta.label}</Badge>

--- a/apps/website/src/pages/models-v2/[slug].astro
+++ b/apps/website/src/pages/models-v2/[slug].astro
@@ -235,8 +235,8 @@ const faqJsonLd = {
     </div>
     <p class="mt-2 max-w-3xl text-sm font-light leading-relaxed text-primary-comfy-canvas sm:text-base">{blurb}</p>
     <div class="mt-4 flex flex-wrap gap-1.5">
-      {dayZero && <span class:list={[pill, 'bg-primary-comfy-yellow text-primary-comfy-ink']}>Day zero</span>}
-      <span class:list={[pill, kind === 'open weights' ? 'bg-primary-comfy-plum/30 text-primary-comfy-canvas' : 'bg-secondary-mauve/30 text-primary-comfy-canvas']}>{kindLabel}</span>
+      {dayZero && <span class:list={[pill, pillMuted]}>Day zero</span>}
+      <span class:list={[pill, pillMuted]}>{kindLabel}</span>
       <span class:list={[pill, pillMuted]}>Commercial use</span>
       <span class:list={[pill, pillMuted]}>{sentence(price)}</span>
       <span class:list={[pill, pillMuted]}>{sentence(runs)}</span>

--- a/apps/website/src/pages/models-v2/[slug].astro
+++ b/apps/website/src/pages/models-v2/[slug].astro
@@ -242,9 +242,9 @@ const faqJsonLd = {
       <div class="rounded-2xl border border-white/10 p-5 sm:p-6">
         <div class="flex items-center justify-between">
           <h2 class="text-xs font-extrabold uppercase tracking-[0.2em] text-primary-warm-white">Input</h2>
-          <div id="iview-toggle" class="flex gap-1.5 text-[10px] font-extrabold uppercase tracking-wider">
-            <button data-iview="app" class="rounded-md bg-white/10 px-2.5 py-1 text-primary-warm-white">App</button>
-            <button data-iview="json" class="rounded-md px-2.5 py-1 text-primary-warm-gray hover:text-primary-warm-white">JSON</button>
+          <div id="iview-toggle" class="flex gap-1.5">
+            <button data-iview="app" class="inline-flex h-6 items-center rounded-full px-4 text-xs font-normal transition-colors bg-transparency-white-t8 text-primary-comfy-canvas">App</button>
+            <button data-iview="json" class="inline-flex h-6 items-center rounded-full px-4 text-xs font-normal transition-colors text-primary-warm-gray hover:bg-transparency-white-t4 hover:text-primary-comfy-canvas">JSON</button>
           </div>
         </div>
 
@@ -310,9 +310,9 @@ const faqJsonLd = {
       <div class="flex flex-col overflow-hidden rounded-2xl border border-white/10">
         <div class="flex items-center justify-between px-5 py-3.5">
           <h2 class="text-[11px] font-extrabold uppercase tracking-[0.2em] text-primary-warm-white">Result</h2>
-          <div id="rview-toggle" class="flex gap-1.5 text-[10px] font-extrabold uppercase tracking-wider">
-            <button data-rview="preview" class="rounded-md bg-white/10 px-2.5 py-1 text-primary-warm-white">Preview</button>
-            <button data-rview="json" class="rounded-md px-2.5 py-1 text-primary-warm-gray hover:text-primary-warm-white">JSON</button>
+          <div id="rview-toggle" class="flex gap-1.5">
+            <button data-rview="preview" class="inline-flex h-6 items-center rounded-full px-4 text-xs font-normal transition-colors bg-transparency-white-t8 text-primary-comfy-canvas">Preview</button>
+            <button data-rview="json" class="inline-flex h-6 items-center rounded-full px-4 text-xs font-normal transition-colors text-primary-warm-gray hover:bg-transparency-white-t4 hover:text-primary-comfy-canvas">JSON</button>
           </div>
         </div>
         <div class="relative aspect-video w-full">
@@ -637,9 +637,11 @@ const faqJsonLd = {
         for (const [k, panel] of Object.entries(iPanels)) panel.classList.toggle('hidden', k !== view)
         for (const b of $('iview-toggle')!.querySelectorAll<HTMLElement>('[data-iview]')) {
           const active = b === btn
-          b.classList.toggle('bg-white/10', active)
-          b.classList.toggle('text-primary-warm-white', active)
+          b.classList.toggle('bg-transparency-white-t8', active)
+          b.classList.toggle('text-primary-comfy-canvas', active)
           b.classList.toggle('text-primary-warm-gray', !active)
+          b.classList.toggle('hover:bg-transparency-white-t4', !active)
+          b.classList.toggle('hover:text-primary-comfy-canvas', !active)
         }
         renderAll()
       })
@@ -653,9 +655,11 @@ const faqJsonLd = {
         img.classList.toggle('hidden', json)
         for (const b of $('rview-toggle')!.querySelectorAll<HTMLElement>('[data-rview]')) {
           const active = b === btn
-          b.classList.toggle('bg-white/10', active)
-          b.classList.toggle('text-primary-warm-white', active)
+          b.classList.toggle('bg-transparency-white-t8', active)
+          b.classList.toggle('text-primary-comfy-canvas', active)
           b.classList.toggle('text-primary-warm-gray', !active)
+          b.classList.toggle('hover:bg-transparency-white-t4', !active)
+          b.classList.toggle('hover:text-primary-comfy-canvas', !active)
         }
         renderResultJson()
       })

--- a/apps/website/src/pages/models-v2/[slug].astro
+++ b/apps/website/src/pages/models-v2/[slug].astro
@@ -135,6 +135,7 @@ const costRows = [
 const canonicalURL = new URL(Astro.url.pathname, Astro.site ?? 'https://comfy.org')
 const mdUrl = `/models-v2/${pageSlug}.md`
 
+const defaultSeed = 428790123
 const curlSnippet = `# Same graph the playground runs — as an endpoint
 curl -X POST https://api.comfy.org/v1/run \\
   -H "Authorization: Bearer $COMFY_KEY" \\
@@ -354,7 +355,7 @@ const faqJsonLd = {
               inputmode="numeric"
               min="0"
               step="1"
-              value={428790123}
+              value={defaultSeed}
               class="w-full rounded-lg border border-transparency-white-t20 bg-transparency-white-t4 px-3 py-2.5 font-mono text-xs text-primary-comfy-canvas focus:border-primary-comfy-yellow/60 focus:outline-none"
             />
             <BrandButton id="seed-shuffle" variant="outline-light" size="sm" class="shrink-0 px-3 py-1.5 text-2xs uppercase tracking-widest">Shuffle</BrandButton>
@@ -451,7 +452,7 @@ const faqJsonLd = {
           </div>
         </div>
         <div id="result-meta" class="flex max-w-full flex-wrap items-center gap-2 pt-3">
-          <span id="result-seed" class:list={[pill, pillMuted]}>Seed 428790123</span>
+          <span id="result-seed" class:list={[pill, pillMuted]}>Seed {defaultSeed}</span>
           <span class:list={[pill, pillMuted]}>4.2s render</span>
         </div>
         <div class="mt-auto flex justify-end pt-3">
@@ -708,7 +709,7 @@ const faqJsonLd = {
       const runMobileLabel = label(runMobile)
 
       const seedInput = $('pg-seed') as HTMLInputElement
-      const DEFAULT_SEED = '428790123'
+      const DEFAULT_SEED = seedInput.defaultValue
       const seedNow = () => Number(seedInput.value) || 0
 
       let authed = false

--- a/apps/website/src/pages/models-v2/[slug].astro
+++ b/apps/website/src/pages/models-v2/[slug].astro
@@ -310,17 +310,17 @@ const faqJsonLd = {
       </div>
 
       <!-- RESULT CARD -->
-      <div class="flex flex-col overflow-hidden rounded-2xl border border-white/10">
-        <div class="flex items-center justify-between px-5 py-3.5">
+      <div class="flex flex-col rounded-2xl border border-white/10 p-5 sm:p-6">
+        <div class="flex items-center justify-between">
           <h2 class="text-[11px] font-extrabold uppercase tracking-[0.2em] text-primary-warm-white">Result</h2>
           <div id="rview-toggle" class="flex gap-1.5">
             <button data-rview="preview" class="inline-flex h-6 items-center rounded-full px-4 text-xs font-normal transition-colors bg-transparency-white-t8 text-primary-comfy-canvas">Preview</button>
             <button data-rview="json" class="inline-flex h-6 items-center rounded-full px-4 text-xs font-normal transition-colors text-primary-warm-gray hover:bg-transparency-white-t4 hover:text-primary-comfy-canvas">JSON</button>
           </div>
         </div>
-        <div class="relative aspect-video w-full">
+        <div class="relative mt-5 aspect-video w-full overflow-hidden rounded-2xl">
           <img id="result-img" src={img} alt={`${name} output`} class="h-full w-full object-cover transition-opacity duration-500" onerror="this.style.display='none'" />
-          <div id="result-json-box" class="absolute inset-4 hidden overflow-hidden rounded-2xl border border-white/15">
+          <div id="result-json-box" class="absolute inset-0 hidden overflow-hidden rounded-2xl border border-white/15">
             <pre id="result-json" class="scrollbar-code h-full overflow-auto whitespace-pre-wrap break-words p-4 font-mono text-xs leading-relaxed text-primary-warm-gray"></pre>
             <button type="button" data-copy="result-json" title="Copy" aria-label="Copy" class="absolute right-3 top-3 group shrink-0 cursor-pointer rounded-lg border border-white/15 bg-white/5 p-1.5 text-primary-warm-gray transition-colors hover:bg-white/10 hover:text-primary-warm-white"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="size-3.5 group-data-[copied]:hidden"><rect width="14" height="14" x="8" y="8" rx="2" ry="2"/><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/></svg><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="hidden size-3.5 group-data-[copied]:block"><path d="M20 6 9 17l-5-5"/></svg></button>
           </div>
@@ -353,7 +353,7 @@ const faqJsonLd = {
             </div>
           </div>
         </div>
-        <div class="flex items-center justify-between gap-3 px-5 py-3">
+        <div class="flex items-center justify-between gap-3 pt-3">
           <p id="result-meta" class="truncate text-[10px] font-semibold uppercase tracking-[0.15em] text-primary-warm-gray">Seed 428790123 · 4.2s render · prompt saved through sign-in</p>
           <span class="shrink-0 text-[11px] font-extrabold uppercase tracking-widest text-primary-comfy-yellow">Download ↓</span>
         </div>
@@ -419,7 +419,7 @@ const faqJsonLd = {
   </section>
 
   <!-- COST + FAMILY -->
-  <section class="bg-black/25 py-12 lg:py-16">
+  <section class="py-12 lg:py-16">
     <div class="mx-auto max-w-7xl px-5 sm:px-6 lg:px-8">
       <div class="grid gap-5 lg:grid-cols-2">
         <div class="rounded-2xl border border-white/10 bg-white/[0.04] p-6 sm:p-7">

--- a/apps/website/src/pages/models-v2/[slug].astro
+++ b/apps/website/src/pages/models-v2/[slug].astro
@@ -433,7 +433,7 @@ const faqJsonLd = {
       </div>
     </GlassCard>
 
-    <div class="mt-4 flex flex-col gap-4 rounded-3xl bg-primary-comfy-ink-light px-8 py-6 sm:flex-row sm:items-center sm:justify-between">
+    <div class="my-6 flex flex-col gap-4 rounded-3xl bg-primary-comfy-ink-light px-8 py-6 sm:flex-row sm:items-center sm:justify-between">
       <div>
         <p class="text-lg font-bold text-primary-comfy-canvas">Start free. Upgrade when you're ready.</p>
         <p class="mt-1 text-sm text-primary-comfy-canvas">5 free runs on real GPUs — no credit card required.</p>
@@ -479,7 +479,7 @@ const faqJsonLd = {
   </section>
 
   <!-- COST + FAMILY -->
-  <section class="py-12 lg:py-16">
+  <section class="pb-12 lg:pb-16">
     <div class="mx-auto max-w-9xl px-5 sm:px-6 lg:px-20">
       <GlassCard>
         <div class="grid gap-2 lg:grid-cols-2">

--- a/apps/website/src/pages/models-v2/[slug].astro
+++ b/apps/website/src/pages/models-v2/[slug].astro
@@ -8,6 +8,8 @@
 import { cn } from '@comfyorg/tailwind-utils'
 
 import BaseLayout from '../../layouts/BaseLayout.astro'
+import { Coins as CreditsIcon } from '@lucide/vue'
+
 import BrandButton from '../../components/common/BrandButton.vue'
 import GlassCard from '../../components/common/GlassCard.vue'
 import Badge from '../../components/ui/badge/Badge.vue'
@@ -122,11 +124,11 @@ const familyVariants = registryModels
   .filter((m) => m.slug.startsWith(familyToken) && m.slug !== (registry?.slug ?? ''))
   .slice(0, 6)
 
-const costRows: Array<[string, string]> = [
-  [`${name} · 5s · 720p`, `${baseCredits} credits ≈ $${(baseCredits * 0.0084).toFixed(2)} · est.`],
-  [`${name} · 5s · 1080p`, `${baseCredits * 2} credits ≈ $${(baseCredits * 2 * 0.0084).toFixed(2)} · est.`],
-  [`${name} · 10s · 720p`, `${baseCredits * 2} credits ≈ $${(baseCredits * 2 * 0.0084).toFixed(2)} · est.`],
-  ['Creator plan / month', `≈ ${Math.round(2400 / baseCredits) * 10} runs · est.`]
+const costRows = [
+  { label: `${name} · 5s · 720p`, value: `${baseCredits} credits ≈ $${(baseCredits * 0.0084).toFixed(2)} · est.`, credits: true },
+  { label: `${name} · 5s · 1080p`, value: `${baseCredits * 2} credits ≈ $${(baseCredits * 2 * 0.0084).toFixed(2)} · est.`, credits: true },
+  { label: `${name} · 10s · 720p`, value: `${baseCredits * 2} credits ≈ $${(baseCredits * 2 * 0.0084).toFixed(2)} · est.`, credits: true },
+  { label: 'Creator plan / month', value: `≈ ${Math.round(2400 / baseCredits) * 10} runs · est.`, credits: false }
 ]
 
 const canonicalURL = new URL(Astro.url.pathname, Astro.site ?? 'https://comfy.org')
@@ -354,7 +356,10 @@ const faqJsonLd = {
         </div>
 
         <div class="mt-5 flex items-center justify-between gap-3 border-t border-white/10 pt-4">
-          <span class="hidden text-2xs text-primary-warm-gray sm:block"><span id="cost-line">{baseCredits} credits ≈ ${(baseCredits * 0.0084).toFixed(2)}</span> · est.</span>
+          <span class="hidden items-center gap-1.5 text-2xs text-primary-warm-gray sm:flex">
+            <CreditsIcon class="size-3.5 shrink-0 text-primary-comfy-orange" aria-hidden="true" />
+            <span><span id="cost-line">{baseCredits} credits ≈ ${(baseCredits * 0.0084).toFixed(2)}</span> · est.</span>
+          </span>
           <div class="flex items-center gap-3">
             <BrandButton id="pg-reset" variant="outline" size="xs" class="uppercase tracking-widest">Reset</BrandButton>
             <BrandButton id="pg-run" data-base-credits={baseCredits} data-slug={slugId} variant="solid" size="xs" class="uppercase tracking-widest">Sign in to run — 5 free</BrandButton>
@@ -500,10 +505,13 @@ const faqJsonLd = {
             <h2 class={cardTitle}>What it costs</h2>
             <p class:list={[bodyCopy, 'mt-2']}>Credits before you commit. No surprises after the wall.</p>
             <div class="mt-4 divide-y divide-white/10 border-t border-white/10">
-              {costRows.map(([l, v]) => (
+              {costRows.map((row) => (
                 <div class="flex items-center justify-between gap-4 py-3">
-                  <span class="text-sm text-primary-warm-white">{l}</span>
-                  <span class="text-right text-xs font-semibold text-primary-comfy-canvas">{v}</span>
+                  <span class="text-sm text-primary-warm-white">{row.label}</span>
+                  <span class="flex items-center gap-1.5 text-right text-xs font-semibold text-primary-comfy-canvas">
+                    {row.credits && <CreditsIcon class="size-3.5 shrink-0 text-primary-comfy-orange" aria-hidden="true" />}
+                    {row.value}
+                  </span>
                 </div>
               ))}
             </div>

--- a/apps/website/src/pages/models-v2/[slug].astro
+++ b/apps/website/src/pages/models-v2/[slug].astro
@@ -317,10 +317,10 @@ const faqJsonLd = {
             </div>
           </div>
           <label class:list={[fieldLabel, 'mt-4']}>Reference image</label>
-          <div id="dropzone" class="mt-2 flex items-center gap-3 rounded-xl border border-dashed border-transparency-white-t20 bg-transparency-white-t4 px-4 py-4">
-            <button id="add-image-btn" class:list={[outlineButton, 'px-3 py-1.5 text-2xs uppercase tracking-widest']}>Add image ▾</button>
+          <div id="dropzone" class="mt-2 flex flex-col items-center gap-3 rounded-xl border border-dashed border-transparency-white-t20 bg-transparency-white-t4 px-4 py-4 text-center">
+            <button id="add-image-btn" class:list={[outlineButton, 'px-3 py-1.5 text-2xs uppercase tracking-widest']}>Add image</button>
             <span id="dropzone-label" class="text-xs font-light text-primary-warm-gray">or drop a frame to animate it</span>
-            <img id="ref-thumb" src={gallery[1] ?? gallery[0]} alt="" class="ml-auto hidden h-10 w-16 rounded-md object-cover" onerror="this.style.display='none'" />
+            <img id="ref-thumb" src={gallery[1] ?? gallery[0]} alt="" class="hidden h-10 w-16 rounded-md object-cover" onerror="this.style.display='none'" />
           </div>
         </div>
 

--- a/apps/website/src/pages/models-v2/[slug].astro
+++ b/apps/website/src/pages/models-v2/[slug].astro
@@ -340,9 +340,9 @@ const faqJsonLd = {
         </div>
 
         <div class="mt-5 flex items-center justify-between gap-3 border-t border-white/10 pt-4">
-          <button id="pg-reset" class={textAction}>Reset</button>
+          <span class="hidden text-2xs text-primary-warm-gray sm:block"><span id="cost-line">{baseCredits} credits ≈ ${(baseCredits * 0.0084).toFixed(2)}</span> · est.</span>
           <div class="flex items-center gap-3">
-            <span class="hidden text-2xs text-primary-warm-gray sm:block"><span id="cost-line">{baseCredits} credits ≈ ${(baseCredits * 0.0084).toFixed(2)}</span> · est.</span>
+            <button id="pg-reset" class:list={[outlineAccentButton, 'uppercase tracking-widest']}>Reset</button>
             <button id="pg-run" data-base-credits={baseCredits} data-slug={slugId} class:list={[primaryButton, 'uppercase tracking-widest']}>
               Sign in to run — 5 free
             </button>

--- a/apps/website/src/pages/models-v2/index.astro
+++ b/apps/website/src/pages/models-v2/index.astro
@@ -111,7 +111,7 @@ const PILLS = [
   </div>
 
   <!-- HERO — the measured CVR leader gets the slot -->
-  <section class="mx-auto max-w-7xl px-5 pb-10 pt-12 sm:px-6 lg:px-8 lg:pt-20">
+  <section class="mx-auto max-w-9xl px-5 pb-10 pt-12 sm:px-6 lg:px-20 lg:pt-20">
     <div class="flex flex-col items-start gap-10 lg:flex-row lg:items-center lg:gap-16">
       <div class="max-w-xl">
         <p class="mb-3 text-[11px] font-semibold uppercase tracking-[0.25em] text-primary-warm-gray">
@@ -175,7 +175,7 @@ const PILLS = [
 
   <!-- SEARCH + FILTERS (sticky) -->
   <section class="sticky top-0 z-30 border-b border-white/5 bg-primary-comfy-ink/95 py-4 backdrop-blur" id="model-filter-root">
-    <div class="mx-auto max-w-7xl px-5 sm:px-6 lg:px-8">
+    <div class="mx-auto max-w-9xl px-5 sm:px-6 lg:px-20">
     <div class="flex flex-col gap-3 sm:flex-row">
       <label class="flex flex-1 items-center gap-3 rounded-xl border border-white/15 bg-white/5 px-4 py-3.5 focus-within:border-primary-comfy-yellow/60 sm:px-5">
         <svg class="h-4 w-4 shrink-0 text-primary-warm-gray" viewBox="0 0 16 16" fill="none"><circle cx="7" cy="7" r="5.5" stroke="currentColor" stroke-width="1.5"/><path d="M11 11l3.5 3.5" stroke="currentColor" stroke-width="1.5"/></svg>
@@ -233,7 +233,7 @@ const PILLS = [
 
   <!-- FEATURED LAUNCHES -->
   <section class="py-10 lg:py-14" data-cardsection>
-    <div class="mx-auto max-w-7xl px-5 sm:px-6 lg:px-8">
+    <div class="mx-auto max-w-9xl px-5 sm:px-6 lg:px-20">
       <div class="mb-6 flex items-end justify-between gap-4">
         <div>
           <h2 class="text-sm font-extrabold uppercase tracking-[0.3em] text-primary-comfy-yellow">Featured launches</h2>
@@ -300,7 +300,7 @@ const PILLS = [
 
   <!-- TOP PARTNER APIS -->
   <section class="bg-black/25 py-10 lg:py-14" data-cardsection>
-    <div class="mx-auto max-w-7xl px-5 sm:px-6 lg:px-8">
+    <div class="mx-auto max-w-9xl px-5 sm:px-6 lg:px-20">
       <div class="mb-6">
         <h2 class="text-sm font-extrabold uppercase tracking-[0.3em] text-primary-comfy-yellow">Top partner APIs</h2>
         <p class="mt-1.5 text-sm font-light text-primary-warm-gray">Ranked by real usage across the platform — one subscription, one queue.</p>
@@ -345,7 +345,7 @@ const PILLS = [
 
   <!-- USE-CASE WORKFLOWS -->
   <section class="py-10 lg:py-14">
-    <div class="mx-auto max-w-7xl px-5 sm:px-6 lg:px-8">
+    <div class="mx-auto max-w-9xl px-5 sm:px-6 lg:px-20">
       <div class="mb-6 flex items-end justify-between gap-4">
         <div>
           <h2 class="text-sm font-extrabold uppercase tracking-[0.3em] text-primary-comfy-yellow">Start from the deliverable</h2>
@@ -374,7 +374,7 @@ const PILLS = [
 
   <!-- BROWSE ALL -->
   <section class="bg-black/25 py-10 lg:py-14" data-cardsection id="browse-all">
-    <div class="mx-auto max-w-7xl px-5 sm:px-6 lg:px-8">
+    <div class="mx-auto max-w-9xl px-5 sm:px-6 lg:px-20">
       <div class="mb-6 flex items-end justify-between gap-4">
         <div>
           <h2 class="text-sm font-extrabold uppercase tracking-[0.3em] text-primary-comfy-yellow">Browse all {registryModels.length} models</h2>
@@ -414,7 +414,7 @@ const PILLS = [
   </section>
 
   <!-- OPEN VS API -->
-  <section class="mx-auto max-w-7xl px-5 py-10 sm:px-6 lg:px-8 lg:py-14">
+  <section class="mx-auto max-w-9xl px-5 py-10 sm:px-6 lg:px-20 lg:py-14">
     <div class="grid gap-5 lg:grid-cols-2">
       <div class="rounded-2xl border border-[#96b4ff]/35 bg-white/[0.04] p-7">
         <h3 class="text-sm font-extrabold uppercase tracking-[0.3em] text-[#96b4ff]">Open weights</h3>
@@ -434,7 +434,7 @@ const PILLS = [
   </section>
 
   <!-- CONVERSION BAND -->
-  <section class="mx-auto max-w-7xl px-5 pb-12 sm:px-6 lg:px-8 lg:pb-16">
+  <section class="mx-auto max-w-9xl px-5 pb-12 sm:px-6 lg:px-20 lg:pb-16">
     <div class="flex flex-col items-start justify-between gap-3 rounded-2xl bg-primary-comfy-yellow px-6 py-5 sm:flex-row sm:items-center sm:px-8">
       <p class="text-sm font-extrabold uppercase tracking-[0.15em] text-primary-comfy-ink sm:text-base">
         Five free runs. One sign-in. No countdowns.
@@ -446,7 +446,7 @@ const PILLS = [
   </section>
 
   <!-- FAQ -->
-  <section class="mx-auto max-w-7xl px-5 pb-16 sm:px-6 lg:grid lg:grid-cols-[280px_1fr] lg:gap-14 lg:px-8 lg:pb-24">
+  <section class="mx-auto max-w-9xl px-5 pb-16 sm:px-6 lg:grid lg:grid-cols-[280px_1fr] lg:gap-14 lg:px-20 lg:pb-24">
     <div class="mb-6 lg:mb-0">
       <h2 class="text-sm font-extrabold uppercase tracking-[0.3em] text-primary-comfy-yellow">Questions</h2>
       <p class="mt-2 text-2xl font-semibold text-primary-warm-white">AI models in ComfyUI</p>

--- a/apps/website/src/pages/models-v2/index.astro
+++ b/apps/website/src/pages/models-v2/index.astro
@@ -19,6 +19,9 @@ const featured = launches.slice(0, 8)
 const hrefFor = (slug: string) => `/models-v2/${slug}`
 
 const kindTag = (l: LaunchModel) => (l.kind === 'open weights' ? 'open' : 'partner')
+const kindLabel = (k: string) => (k === 'open weights' ? 'Open weights' : 'Partner API')
+const pill = 'shrink-0 inline-flex h-6 items-center gap-1 rounded-full px-4 text-xs font-normal transition-colors'
+const pillIdle = 'bg-transparency-white-t4 text-primary-comfy-canvas'
 const modTag = (l: LaunchModel) =>
   l.modality === 'i2v' || l.modality === 'video' ? 'video'
   : l.modality === 'audio' ? 'audio'
@@ -204,7 +207,7 @@ const PILLS = [
       ].map(([label, action]) => (
         <button
           data-try={action}
-          class="shrink-0 rounded-full border border-white/12 bg-white/[0.04] px-3 py-1.5 text-[11px] text-primary-comfy-canvas transition hover:border-primary-comfy-yellow/50 hover:text-primary-warm-white"
+          class:list={[pill, pillIdle, 'hover:bg-transparency-white-t8 hover:text-primary-warm-white']}
         >
           {label}
         </button>
@@ -215,10 +218,10 @@ const PILLS = [
         <button
           data-pill={value}
           class:list={[
-            'shrink-0 rounded-full px-4 py-2 text-xs font-extrabold uppercase tracking-widest transition',
+            pill,
             i === 0
               ? 'is-active bg-primary-comfy-yellow text-primary-comfy-ink'
-              : 'border border-white/15 bg-white/5 text-primary-comfy-canvas hover:bg-white/10'
+              : `${pillIdle} hover:bg-transparency-white-t8`
           ]}
         >
           {label} <span class="opacity-60">{count}</span>
@@ -280,7 +283,7 @@ const PILLS = [
                     >
                       {meta.label}
                     </span>
-                    <span class="rounded-full border border-white/15 px-2 py-0.5 text-[10px] text-primary-comfy-canvas">{card.kind}</span>
+                    <span class:list={[pill, pillIdle]}>{kindLabel(card.kind)}</span>
                   </div>
                   <div class="flex items-center justify-between text-[11px] text-primary-warm-gray">
                     <span>{card.runs}</span>
@@ -541,9 +544,8 @@ const PILLS = [
             b.classList.toggle('is-active', active)
             b.classList.toggle('bg-primary-comfy-yellow', active)
             b.classList.toggle('text-primary-comfy-ink', active)
-            b.classList.toggle('border', !active)
-            b.classList.toggle('border-white/15', !active)
-            b.classList.toggle('bg-white/5', !active)
+            b.classList.toggle('bg-transparency-white-t4', !active)
+            b.classList.toggle('hover:bg-transparency-white-t8', !active)
             b.classList.toggle('text-primary-comfy-canvas', !active)
           }
           syncClear()
@@ -560,9 +562,8 @@ const PILLS = [
           b.classList.toggle('is-active', active)
           b.classList.toggle('bg-primary-comfy-yellow', active)
           b.classList.toggle('text-primary-comfy-ink', active)
-          b.classList.toggle('border', !active)
-          b.classList.toggle('border-white/15', !active)
-          b.classList.toggle('bg-white/5', !active)
+          b.classList.toggle('bg-transparency-white-t4', !active)
+          b.classList.toggle('hover:bg-transparency-white-t8', !active)
           b.classList.toggle('text-primary-comfy-canvas', !active)
         }
         apply()

--- a/apps/website/src/pages/models-v2/index.astro
+++ b/apps/website/src/pages/models-v2/index.astro
@@ -1,6 +1,7 @@
 ---
 // A/B TEST PREVIEW — v2 supported-models directory ("explore" variant).
 // Not linked from anywhere. noindex. Delete this folder to remove the preview.
+import Breadcrumbs from '../../components/common/Breadcrumbs.astro'
 import BaseLayout from '../../layouts/BaseLayout.astro'
 import {
   launches,
@@ -66,6 +67,10 @@ const breadcrumbJsonLd = {
     { '@type': 'ListItem', position: 2, name: 'AI Models' }
   ]
 }
+const breadcrumbs = [
+  { label: 'Home', href: 'https://comfy.org' },
+  { label: 'AI Models' }
+]
 const faqJsonLd = {
   '@context': 'https://schema.org',
   '@type': 'FAQPage',
@@ -114,9 +119,7 @@ const PILLS = [
   <section class="mx-auto max-w-9xl px-5 pb-10 pt-12 sm:px-6 lg:px-20 lg:pt-20">
     <div class="flex flex-col items-start gap-10 lg:flex-row lg:items-center lg:gap-16">
       <div class="max-w-xl">
-        <p class="mb-3 text-[11px] font-semibold uppercase tracking-[0.25em] text-primary-warm-gray">
-          <a href="https://comfy.org" class="hover:text-primary-warm-white">Home</a> / AI models
-        </p>
+        <Breadcrumbs crumbs={breadcrumbs} class="mb-3" />
         <p class="mb-4 text-xs font-extrabold uppercase tracking-[0.35em] text-primary-comfy-yellow sm:text-sm">
           Supported models
         </p>

--- a/apps/website/src/styles/global.css
+++ b/apps/website/src/styles/global.css
@@ -242,6 +242,24 @@
   }
 }
 
+@utility scrollbar-code {
+  scrollbar-width: thin;
+  scrollbar-color: rgb(255 255 255 / 0.15) transparent;
+
+  &::-webkit-scrollbar {
+    width: 4px;
+  }
+
+  &::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background: rgb(255 255 255 / 0.15);
+    border-radius: 9999px;
+  }
+}
+
 @utility scrollbar-none {
   -ms-overflow-style: none;
   scrollbar-width: none;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -327,6 +327,9 @@ catalogs:
     rollup-plugin-visualizer:
       specifier: ^6.0.4
       version: 6.0.11
+    shiki:
+      specifier: ^4.3.1
+      version: 4.3.1
     storybook:
       specifier: ^10.5.6
       version: 10.5.6
@@ -997,6 +1000,9 @@ importers:
       reka-ui:
         specifier: 'catalog:'
         version: 2.6.2(typescript@6.0.3)(vue@3.5.41(typescript@6.0.3))
+      shiki:
+        specifier: 'catalog:'
+        version: 4.3.1
       three:
         specifier: 'catalog:'
         version: 0.184.0
@@ -9898,7 +9904,7 @@ snapshots:
     dependencies:
       '@emnapi/core': 1.11.1
       '@emnapi/runtime': 1.11.1
-      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+      '@napi-rs/wasm-runtime': 1.2.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
     optional: true
 
   '@bruits/satteri-win32-arm64-msvc@0.9.5':
@@ -11054,6 +11060,13 @@ snapshots:
     dependencies:
       '@emnapi/core': 1.9.2
       '@emnapi/runtime': 1.9.2
+      '@tybys/wasm-util': 0.10.3
+    optional: true
+
+  '@napi-rs/wasm-runtime@1.2.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
+    dependencies:
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
       '@tybys/wasm-util': 0.10.3
     optional: true
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -118,6 +118,7 @@ catalog:
   primevue: 4.2.5
   reka-ui: 2.6.2
   rollup-plugin-visualizer: ^6.0.4
+  shiki: ^4.3.1
   storybook: ^10.5.6
   stylelint: ^17.14.0
   tailwindcss: ^4.3.2


### PR DESCRIPTION
> [!IMPORTANT]
> **This is a design PR. The changes are mainly visual.** It restyles the
> `/models-v2` preview and does not build out the behavior behind it.
> Functionality is left out on purpose, for the reviewer to add and to test.
> Treat the interactions here as a demo, not as finished work.

## Summary

Restyle the `/models-v2` model page and directory on top of #15386, so the preview uses the site's shared components and the code block treatment from the workflow pages.

## Changes

- **What**:
  - Page sections open as tabs instead of scrolling to anchors. One panel opens at a time, and `#api` and `#gallery` still open the right tab.
  - The Graph input view is gone. The input toggle has two views.
  - Code blocks get Shiki highlighting with the `kanagawa-wave` theme, matching the workflow pages. The curl example is highlighted at build time. The live request and the run receipt are highlighted in the browser.
  - Every code block has a copy control. The run receipt also downloads as a file. Long values wrap instead of scrolling sideways.
  - Controls route through `BrandButton`, `GlassCard`, the shared badge, and the shared pill, instead of hand-written classes. This also corrects the label baseline that the hand-rolled controls missed.
  - Header pills, view toggles, and directory pills share one 24px sentence-case treatment. Active pills stay yellow, and idle pills use the transparency tokens.
  - Playground is 50/50 instead of a fixed 460px column. Cards lost their own fills. The result card matches the inset of the input card in both views.
  - Header actions regroup into three main actions and two split buttons.
  - Copy that described visible controls is gone. The result title is "Result", and the format toggle says Code.
- **Dependencies**: `shiki` added to the catalog and to `apps/website`. It was only present transitively through Astro, so the highlighting would have broken when Astro changed its internals.

## Review Focus

- **Casing moved out of CSS.** `kind` and `price` are lowercase in the demo data and only read correctly because `uppercase` hid it. They now carry display labels, so the acronym stays "Partner API" rather than "Partner Api".
- **`highlight.ts` is ported from the hub**, with `shellscript` swapped in for the python and typescript grammars. Text paints before the tokens arrive, so a block is never blank, and a paint counter stops a slow highlight from overwriting a newer payload.
- **Copy reads `textContent`**, so the highlight spans never reach the clipboard. The copied request still parses as JSON.
- **The preview check moved with the page.** The three graph checks are gone with the feature, the gallery check opens the Examples tab, and the LLM deep-link check is scoped to `main` rather than to one menu, because those links have already moved between menus once.
- **The mauve placeholder behind the preview media is gone.** If the image fails to load, that area is now empty rather than tinted.

## Verification

- `astro check`: 0 errors
- `astro build`: 926 pages, clean
- `pnpm knip`: clean
- `models-v2:preview-check`: 28/28 against the built output
