### PR TITLE
fix: address valid ECS migration review findings

### DIFF
--- a/browser_tests/tests/vueNodes/layout/rendererToggleGeometry.spec.ts
+++ b/browser_tests/tests/vueNodes/layout/rendererToggleGeometry.spec.ts
@@ -199,9 +199,9 @@ test.describe('Renderer toggle geometry', { tag: ['@vue-nodes'] }, () => {
         y: clickPosition[1]
       })
 
-      expect(await comfyPage.nodeOps.getSelectedNodeIds()).toEqual([
-        ksampler.id
-      ])
+      await expect
+        .poll(() => comfyPage.nodeOps.getSelectedNodeIds())
+        .toEqual([ksampler.id])
     }
   )
 })

--- a/src/core/graph/subgraph/promotionUtils.ts
+++ b/src/core/graph/subgraph/promotionUtils.ts
@@ -303,11 +303,8 @@ export function promoteValueWidgetViaSubgraphInput(
   )
   if (hostInput) {
     hostInput.label = sourceSlot.label
-    const promotedState = hostInput.widgetId
-      ? useWidgetValueStore().getWidget(hostInput.widgetId)
-      : undefined
-    if (promotedState && sourceSlot.label)
-      promotedState.label = sourceSlot.label
+    if (hostInput.widgetId && sourceSlot.label)
+      useWidgetValueStore().setLabel(hostInput.widgetId, sourceSlot.label)
   }
 
   seedNestedPromotedInputState(subgraphNode, subgraphInput.name, sourceSlot)

--- a/src/core/graph/widgets/dynamicWidgets.test.ts
+++ b/src/core/graph/widgets/dynamicWidgets.test.ts
@@ -7,6 +7,7 @@ import {
 } from '@/core/graph/widgets/__fixtures__/dynamicInputHelpers'
 import { LGraph, LGraphNode, LiteGraph } from '@/lib/litegraph/src/litegraph'
 import { useLitegraphService } from '@/services/litegraphService'
+import { useLinkStore } from '@/stores/linkStore'
 
 setActivePinia(createTestingPinia({ stubActions: false }))
 beforeEach(() => setActivePinia(createTestingPinia({ stubActions: false })))
@@ -237,6 +238,36 @@ describe('Autogrow', () => {
     )
     expect(inputCalls.every(([, slot]) => slot >= 0)).toBe(true)
     expect(inputCalls.filter(([, , connected]) => !connected)).toHaveLength(1)
+  })
+  test('Rejected autogrow compaction preserves its input layout', async () => {
+    const graph = new LGraph()
+    const node = testNode()
+    const onConnectionsChange = vi.fn()
+    node.onConnectionsChange = onConnectionsChange
+    graph.add(node)
+    addAutogrow(node, { min: 1, input: inputsSpec, prefix: 'test' })
+    connectInput(node, 0, graph)
+    connectInput(node, 1, graph)
+    connectInput(node, 2, graph)
+    const updateEndpoints = vi
+      .spyOn(useLinkStore(), 'updateEndpoints')
+      .mockReturnValue({
+        ok: false,
+        error: { code: 'occupied-target', message: 'Target is occupied' }
+      })
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    node.disconnectInput(1)
+    const inputNames = node.inputs.map(({ name }) => name)
+    const widgetNames = node.widgets.map(({ name }) => name)
+    onConnectionsChange.mockClear()
+    await nextTick()
+
+    expect(updateEndpoints).toHaveBeenCalled()
+    expect(node.inputs.map(({ name }) => name)).toEqual(inputNames)
+    expect(node.widgets.map(({ name }) => name)).toEqual(widgetNames)
+    expect(onConnectionsChange).not.toHaveBeenCalled()
+    consoleError.mockRestore()
   })
   test('Removing a connection ignores stale autogrow callbacks after group removal', () => {
     const graph = new LGraph()

--- a/src/core/graph/widgets/dynamicWidgets.ts
+++ b/src/core/graph/widgets/dynamicWidgets.ts
@@ -134,7 +134,8 @@ function dynamicComboWidget(
     }
 
     if (!newSpec) {
-      commitMutatedInputs(node, previous, inputLinks)
+      const result = commitMutatedInputs(node, previous, inputLinks)
+      if (!result.ok) return
       syncNodeWidgetOrder(node)
       return
     }
@@ -180,7 +181,8 @@ function dynamicComboWidget(
       )
         //input is inputOnly, but lacks an insertion point
         throw new Error('Failed to find input socket for ' + widget.name)
-      commitMutatedInputs(node, previous, inputLinks)
+      const result = commitMutatedInputs(node, previous, inputLinks)
+      if (!result.ok) return
       return
     }
     const addedInputs = node.inputs
@@ -201,8 +203,9 @@ function dynamicComboWidget(
       const link = inputLinks.get(input)
       if (replacement && link) inputLinks.set(replacement, link)
     }
-    const replacements = commitMutatedInputs(node, previous, inputLinks)
-    for (const { input, link, slot } of replacements) {
+    const result = commitMutatedInputs(node, previous, inputLinks)
+    if (!result.ok) return
+    for (const { input, link, slot } of result.replacements) {
       node.onConnectionsChange?.(LiteGraph.INPUT, slot, true, link, input)
     }
 
@@ -273,7 +276,7 @@ function changeOutputType(
     slot
   )
   for (const topology of topologies) {
-    const link = node.graph.links[topology.id]
+    const link = node.graph.getLink(topology.id)
     if (!link) continue
     const { input, inputNode, subgraphOutput } = link.resolve(node.graph)
     const inputType = (input ?? subgraphOutput)?.type
@@ -459,7 +462,8 @@ function addAutogrowGroup(
   )
   const insertionIndex = lastIndex === -1 ? node.inputs.length : lastIndex + 1
   node.inputs.splice(insertionIndex, 0, ...newInputs)
-  commitMutatedInputs(node, previous, inputLinks)
+  const result = commitMutatedInputs(node, previous, inputLinks)
+  if (!result.ok) return
   app.canvas?.setDirty(true, true)
 }
 
@@ -553,7 +557,8 @@ function autogrowInputDisconnected(index: number, node: AutogrowNode) {
   }
   const toRemove = removalChecks.slice(i + stride * 2)
   const finalInputs = node.inputs.filter((input) => !toRemove.includes(input))
-  replaceNodeInputs(node, previous, finalInputs, inputLinks)
+  const result = replaceNodeInputs(node, previous, finalInputs, inputLinks)
+  if (!result.ok) return
 
   for (const { input, link } of transplants) {
     const slot = node.inputs.indexOf(input)

--- a/src/lib/litegraph/src/LGraphNode.test.ts
+++ b/src/lib/litegraph/src/LGraphNode.test.ts
@@ -12,6 +12,7 @@ import type { Rect } from '@/lib/litegraph/src/interfaces'
 import { resizeNodeLayout } from '@/renderer/core/layout/operations/graphLayoutAttachment'
 import { layoutStore } from '@/renderer/core/layout/store/layoutStore'
 import { LayoutSource } from '@/renderer/core/layout/types'
+import { useNodeDataStore } from '@/stores/nodeDataStore'
 import { useWidgetValueStore } from '@/stores/widgetValueStore'
 import type { LGraphCanvas } from '@/lib/litegraph/src/LGraphCanvas'
 import type { CanvasPointerEvent } from '@/lib/litegraph/src/types/events'
@@ -1342,16 +1343,12 @@ describe('titleMode in node state', () => {
     class TitlelessNode extends LGraphNode {
       static title_mode = TitleMode.NO_TITLE
     }
+    const graph = new LGraph()
     const node = new TitlelessNode('titleless')
+    graph.add(node)
 
-    // The renderer decides whether to draw a header from this; reroutes and
-    // other NO_TITLE classes draw a title bar without it.
-    expect(node._state.titleMode).toBe(TitleMode.NO_TITLE)
-  })
-
-  test('defaults to a normal title', () => {
-    expect(new LGraphNode('plain')._state.titleMode).toBe(
-      TitleMode.NORMAL_TITLE
-    )
+    expect(
+      useNodeDataStore().getGraphNodesFor(graph.id, graph.id)[0]?.titleMode
+    ).toBe(TitleMode.NO_TITLE)
   })
 })

--- a/src/lib/litegraph/src/LGraphNode.ts
+++ b/src/lib/litegraph/src/LGraphNode.ts
@@ -1965,14 +1965,14 @@ export class LGraphNode
 
     if (graph) {
       const previous = captureInputLayout(this)
-      replaceNodeInputs(
+      const result = replaceNodeInputs(
         this,
         previous,
         previous.inputs.toSpliced(slot, 1),
         previous.links,
         true
       )
-      if (this.inputs.includes(slotInfo)) return
+      if (!result.ok) return
       for (const floatingLink of graph.floatingLinks.values()) {
         if (
           floatingLink.target_id === this.id &&

--- a/src/lib/litegraph/src/node/slotLinks.test.ts
+++ b/src/lib/litegraph/src/node/slotLinks.test.ts
@@ -271,7 +271,13 @@ describe('slotLinks', () => {
 
     expect(
       replaceNodeInputs(target, previous, [target.inputs[0]], assignments)
-    ).toEqual([])
+    ).toEqual({
+      ok: false,
+      error: {
+        code: 'unowned-topology',
+        message: `Link ${stale.id} does not own its current placement`
+      }
+    })
     expect(consoleError).toHaveBeenCalledWith('Failed to replace node inputs', {
       code: 'unowned-topology',
       message: `Link ${stale.id} does not own its current placement`

--- a/src/lib/litegraph/src/node/slotLinks.ts
+++ b/src/lib/litegraph/src/node/slotLinks.ts
@@ -1,4 +1,5 @@
 import { useLinkStore } from '@/stores/linkStore'
+import type { EndpointUpdateError } from '@/stores/linkStore'
 import { graphScopeOf } from '@/types/graphScopeId'
 import type { LinkId } from '@/types/linkId'
 import type { NodeId } from '@/types/nodeId'
@@ -93,6 +94,10 @@ interface InputReplacement {
   slot: number
 }
 
+export type InputReplacementResult =
+  | { ok: true; replacements: InputReplacement[] }
+  | { ok: false; error: EndpointUpdateError }
+
 export function finalizeInputLinkRemoval(
   node: LGraphNode,
   input: INodeInputSlot,
@@ -150,7 +155,7 @@ export function replaceNodeInputs(
   finalInputs: readonly INodeInputSlot[],
   assignments: ReadonlyMap<INodeInputSlot, LLink> = previous.links,
   keepReroutes = false
-): InputReplacement[] {
+): InputReplacementResult {
   if (
     node.inputs.length !== previous.inputs.length ||
     node.inputs.some((input, slot) => input !== previous.inputs[slot])
@@ -191,7 +196,7 @@ export function replaceNodeInputs(
     )
     if (!result.ok) {
       console.error('Failed to replace node inputs', result.error)
-      return []
+      return result
     }
     node.inputs.splice(0, node.inputs.length, ...finalInputs)
     for (const { link, slot } of removals.toReversed()) {
@@ -210,5 +215,8 @@ export function replaceNodeInputs(
   }
 
   const oldInputs = new Set(previous.inputs)
-  return finalAssignments.filter(({ input }) => !oldInputs.has(input))
+  return {
+    ok: true,
+    replacements: finalAssignments.filter(({ input }) => !oldInputs.has(input))
+  }
 }

--- a/src/lib/litegraph/src/nodeBadgeDraw.test.ts
+++ b/src/lib/litegraph/src/nodeBadgeDraw.test.ts
@@ -1,13 +1,74 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import type { BadgeData, CoreBadgeData } from '@/types/badgeData'
 
 import { LGraphNode } from '@/lib/litegraph/src/litegraph'
-import { badgeDrawObjects } from './nodeBadgeDraw'
+import {
+  badgeDrawObjects,
+  badgeRows,
+  registerBadgeRowsProvider
+} from './nodeBadgeDraw'
 
 function coreRow(part: CoreBadgeData['part'], text: string): BadgeData {
   return { kind: 'core', part, text, fgColor: '#fff', bgColor: '#000' }
 }
+
+const registrations: (() => void)[] = []
+
+function register(
+  provider: Parameters<typeof registerBadgeRowsProvider>[0]
+): () => void {
+  const dispose = registerBadgeRowsProvider(provider)
+  registrations.push(dispose)
+  return dispose
+}
+
+afterEach(() => {
+  for (const dispose of registrations.splice(0).reverse()) dispose()
+})
+
+describe('registerBadgeRowsProvider', () => {
+  const node = new LGraphNode('n')
+  const firstRows = [coreRow('id', '#1')]
+  const secondRows = [coreRow('id', '#2')]
+  const firstProvider = () => firstRows
+  const secondProvider = () => secondRows
+
+  it('registers and disposes a provider', () => {
+    const dispose = register(firstProvider)
+    expect(badgeRows(node)).toBe(firstRows)
+
+    dispose()
+    expect(badgeRows(node)).toEqual([])
+  })
+
+  it('keeps the installed provider when a conflicting registration fails', () => {
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {})
+    register(firstProvider)
+    const disposeConflict = register(secondProvider)
+    disposeConflict()
+
+    expect(badgeRows(node)).toBe(firstRows)
+    expect(error).toHaveBeenCalledWith(
+      'A badge rows provider is already registered'
+    )
+  })
+
+  it('does not let a stale disposer clear a newer registration', () => {
+    const disposeFirst = register(firstProvider)
+    register(firstProvider)
+
+    disposeFirst()
+    expect(badgeRows(node)).toBe(firstRows)
+  })
+
+  it('allows re-registration after disposal', () => {
+    register(firstProvider)()
+    register(secondProvider)
+
+    expect(badgeRows(node)).toBe(secondRows)
+  })
+})
 
 describe('badgeDrawObjects', () => {
   it('joins core parts into one badge in id, lifecycle, source order', () => {

--- a/src/lib/litegraph/src/nodeBadgeDraw.ts
+++ b/src/lib/litegraph/src/nodeBadgeDraw.ts
@@ -72,17 +72,29 @@ export function badgeRows(node: LGraphNode): readonly BadgeData[] {
 type BadgeRowsProvider = typeof badgeRows
 
 let rowsProvider: BadgeRowsProvider | undefined
+let rowsProviderRegistration: symbol | undefined
 
 /**
  * Installs the app-layer badge derivation. A seam so litegraph never
  * imports the derivation's store/pricing dependency graph.
  */
-export function registerBadgeRowsProvider(provider: BadgeRowsProvider): void {
+export function registerBadgeRowsProvider(
+  provider: BadgeRowsProvider
+): () => void {
   if (rowsProvider && rowsProvider !== provider) {
     console.error('A badge rows provider is already registered')
-    return
+    return () => {}
   }
+
+  const registration = Symbol()
   rowsProvider = provider
+  rowsProviderRegistration = registration
+
+  return () => {
+    if (rowsProviderRegistration !== registration) return
+    rowsProvider = undefined
+    rowsProviderRegistration = undefined
+  }
 }
 
 const drawCache = new WeakMap<

--- a/src/lib/litegraph/src/subgraph/subgraphUtils.test.ts
+++ b/src/lib/litegraph/src/subgraph/subgraphUtils.test.ts
@@ -4,10 +4,12 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
   LGraph,
+  LGraphNode,
   findUsedSubgraphIds,
   getDirectSubgraphIds
 } from '@/lib/litegraph/src/litegraph'
 import type { UUID } from '@/lib/litegraph/src/litegraph'
+import { useLinkStore } from '@/stores/linkStore'
 
 import { reorderSubgraphInputs } from './subgraphUtils'
 import {
@@ -46,6 +48,41 @@ describe('subgraphUtils', () => {
         'reorderSubgraphInputs: host and subgraph inputs differ',
         { hostInputs: 1, subgraphInputs: 2 }
       )
+      consoleError.mockRestore()
+    })
+
+    it('preserves both input orders when endpoint updates are rejected', () => {
+      const graph = new LGraph()
+      const subgraph = createTestSubgraph({
+        inputs: [
+          { name: 'first', type: 'STRING' },
+          { name: 'second', type: 'STRING' }
+        ]
+      })
+      const host = createTestSubgraphNode(subgraph)
+      graph.add(host)
+      const source = new LGraphNode('Source')
+      source.addOutput('out', 'STRING')
+      graph.add(source)
+      const link = source.connect(0, host, 0)!
+      vi.spyOn(useLinkStore(), 'updateEndpoints').mockReturnValue({
+        ok: false,
+        error: { code: 'occupied-target', message: 'Target is occupied' }
+      })
+      const invalidatePromotedViews = vi.spyOn(host, 'invalidatePromotedViews')
+      const consoleError = vi
+        .spyOn(console, 'error')
+        .mockImplementation(() => {})
+
+      reorderSubgraphInputs(host, [1, 0])
+
+      expect(host.inputs.map(({ name }) => name)).toEqual(['first', 'second'])
+      expect(subgraph.inputs.map(({ name }) => name)).toEqual([
+        'first',
+        'second'
+      ])
+      expect(link.target_slot).toBe(0)
+      expect(invalidatePromotedViews).not.toHaveBeenCalled()
       consoleError.mockRestore()
     })
   })

--- a/src/lib/litegraph/src/subgraph/subgraphUtils.ts
+++ b/src/lib/litegraph/src/subgraph/subgraphUtils.ts
@@ -595,8 +595,13 @@ export function reorderSubgraphInputs(
     (index) => previousInputs.inputs[index]
   )
 
+  const result = replaceNodeInputs(
+    subgraphNode,
+    previousInputs,
+    orderedHostInputs
+  )
+  if (!result.ok) return
   reorderInPlace(subgraph.inputs, orderedIndices)
-  replaceNodeInputs(subgraphNode, previousInputs, orderedHostInputs)
   subgraphNode.invalidatePromotedViews()
 
   function* innerLinks(input: SubgraphInput): Generator<LLink | undefined> {

--- a/src/platform/nodeReplacement/useNodeReplacement.test.ts
+++ b/src/platform/nodeReplacement/useNodeReplacement.test.ts
@@ -106,8 +106,9 @@ function createMockGraph(
   links: ReturnType<typeof createMockLink>[] = []
 ): LGraph {
   const linksMap = new Map(links.map((l) => [l.id, l]))
+  const linkStore = useLinkStore()
   for (const l of links) {
-    useLinkStore().registerLink(GRAPH_SCOPE, {
+    linkStore.registerLink(GRAPH_SCOPE, {
       id: toLinkId(l.id),
       graphId: GRAPH_SCOPE.owningGraphId,
       originNodeId: toNodeId(l.origin_id),
@@ -122,6 +123,13 @@ function createMockGraph(
     _nodes_by_id: Object.fromEntries(nodes.map((n) => [n.id, n])),
     links: linksMap,
     getLink: (id: number) => linksMap.get(id),
+    removeLink: (id: number) => {
+      const topology = [...linkStore.graphTopologies(GRAPH_SCOPE)].find(
+        (link) => link.id === id
+      )
+      if (topology) linkStore.deleteLink(GRAPH_SCOPE, topology)
+      linksMap.delete(id)
+    },
     id: GRAPH_ID,
     rootGraph: { id: GRAPH_ID },
     events: new CustomEventTarget<LGraphEventMap>(),
@@ -359,6 +367,43 @@ describe('useNodeReplacement', () => {
       // Output link should be remapped
       expect(link.origin_id).toBe(1)
       expect(link.origin_slot).toBe(0)
+    })
+
+    it('removes unmapped links without removing mapped links', () => {
+      const mapped = createMockLink(20, 1, 0, 5, 0)
+      const unmapped = createMockLink(21, 1, 1, 6, 0)
+      const placeholder = createPlaceholderNode(
+        1,
+        'OldNode',
+        [],
+        [
+          { name: 'kept', links: [20] },
+          { name: 'removed', links: [21] }
+        ]
+      )
+      const graph = createMockGraph([placeholder], [mapped, unmapped])
+      placeholder.graph = graph
+      Object.assign(app, { rootGraph: graph })
+      vi.mocked(collectAllNodes).mockReturnValue([placeholder])
+      vi.mocked(LiteGraph.createNode).mockReturnValue(
+        createNewNode([], [{ name: 'kept', links: null }])
+      )
+
+      useNodeReplacement().replaceNodesInPlace([
+        makeMissingNodeType('OldNode', {
+          new_node_id: 'NewNode',
+          old_node_id: 'OldNode',
+          old_widget_ids: null,
+          input_mapping: null,
+          output_mapping: [{ new_idx: 0, old_idx: 0 }]
+        })
+      ])
+
+      expect(graph.links.has(toLinkId(20))).toBe(true)
+      expect(graph.links.has(toLinkId(21))).toBe(false)
+      expect(
+        [...useLinkStore().graphTopologies(GRAPH_SCOPE)].map((link) => link.id)
+      ).toEqual([toLinkId(20)])
     })
 
     it('should apply set_value to widget', () => {

--- a/src/platform/nodeReplacement/useNodeReplacement.ts
+++ b/src/platform/nodeReplacement/useNodeReplacement.ts
@@ -16,6 +16,7 @@ import { app, sanitizeNodeName } from '@/scripts/app'
 import { useMissingNodesErrorStore } from '@/platform/nodeReplacement/missingNodesErrorStore'
 import { clearNodeOwnedStoreState } from '@/stores/clearNodeOwnedStoreState'
 import type { MissingNodeType } from '@/types/comfy'
+import type { LinkId } from '@/types/linkId'
 import { collectAllNodes } from '@/utils/graphTraversalUtil'
 
 interface ReplacementGroup {
@@ -173,6 +174,38 @@ function replaceWithMapping(
     !canTransferReplacementOwnership(node, newNode)
   )
     throw new Error(`Cannot replace node ${node.id}: ownership is invalid`)
+
+  const transferredLinkIds = new Set<LinkId>()
+  for (const inputMap of replacement.input_mapping ?? []) {
+    if (!('old_id' in inputMap) || isDotNotation(inputMap.new_id)) continue
+    const oldSlotIdx = node.inputs?.findIndex((i) => i.name === inputMap.old_id)
+    const newSlotIdx = newNode.inputs?.findIndex(
+      (i) => i.name === inputMap.new_id
+    )
+    if (
+      oldSlotIdx == null ||
+      oldSlotIdx === -1 ||
+      newSlotIdx == null ||
+      newSlotIdx === -1
+    )
+      continue
+    const linkId = inputLinkId(nodeGraph, node.id, oldSlotIdx)
+    if (linkId != null) transferredLinkIds.add(linkId)
+  }
+  for (const outMap of replacement.output_mapping ?? []) {
+    if (!newNode.outputs?.[outMap.new_idx]) continue
+    for (const link of outputLinks(nodeGraph, node.id, outMap.old_idx)) {
+      transferredLinkIds.add(link.id)
+    }
+  }
+  for (const link of [...nodeGraph.links.values()]) {
+    if (
+      (link.origin_id === node.id || link.target_id === node.id) &&
+      !transferredLinkIds.has(link.id)
+    ) {
+      nodeGraph.removeLink(link.id)
+    }
+  }
 
   node.onRemoved?.()
   if (

--- a/src/platform/workflow/core/utils/workflowToClipboardItems.test.ts
+++ b/src/platform/workflow/core/utils/workflowToClipboardItems.test.ts
@@ -111,6 +111,20 @@ describe('workflowToClipboardItems', () => {
     expect(items.subgraphs?.map(({ id }) => id)).toEqual([parent.id, child.id])
     expect(items.subgraphs?.every(({ definitions }) => !definitions)).toBe(true)
   })
+
+  it('flattens cyclic subgraph definitions once', () => {
+    const child = subgraph()
+    const parent = subgraph([child])
+    child.definitions = { subgraphs: [parent] }
+    const workflow = {
+      ...workflowV1(),
+      definitions: { subgraphs: [parent] }
+    }
+
+    const items = workflowToClipboardItems(workflow)
+
+    expect(items.subgraphs?.map(({ id }) => id)).toEqual([parent.id, child.id])
+  })
 })
 
 function subgraph(definitions?: ExportedSubgraph[]): ExportedSubgraph {

--- a/src/renderer/core/canvas/litegraph/notifyLayoutChanges.test.ts
+++ b/src/renderer/core/canvas/litegraph/notifyLayoutChanges.test.ts
@@ -60,6 +60,7 @@ describe('notifyLayoutChanges', () => {
     await vi.waitFor(() => expect(setDirty).toHaveBeenCalled())
 
     expect(onResize).toHaveBeenCalledTimes(1)
+    expect([...onResize.mock.calls[0][0]]).toEqual([300, 200])
   })
 
   it.for([

--- a/src/renderer/core/layout/operations/graphLayoutAttachment.test.ts
+++ b/src/renderer/core/layout/operations/graphLayoutAttachment.test.ts
@@ -1,0 +1,57 @@
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { LGraph, LGraphNode } from '@/lib/litegraph/src/litegraph'
+import { layoutStore } from '@/renderer/core/layout/store/layoutStore'
+import { toNodeId } from '@/types/nodeId'
+
+import {
+  attachNodeLayout,
+  detachNodeLayout,
+  setNodePosition
+} from './graphLayoutAttachment'
+
+describe('node layout attachment ownership', () => {
+  beforeEach(() => {
+    setActivePinia(createTestingPinia({ stubActions: false }))
+    layoutStore.resetForTests()
+  })
+
+  function nodeFor(graph: LGraph, id: string): LGraphNode {
+    const node = new LGraphNode(id)
+    node.id = toNodeId(id)
+    node.graph = graph
+    return node
+  }
+
+  it('keeps an adopted layout when the stale instance detaches', () => {
+    const graph = new LGraph()
+    const oldNode = nodeFor(graph, 'shared')
+    const replacement = nodeFor(graph, 'shared')
+    attachNodeLayout(graph, oldNode)
+
+    attachNodeLayout(graph, replacement)
+    detachNodeLayout(oldNode)
+    setNodePosition(replacement, [40, 50])
+
+    expect(
+      layoutStore.getNodeLayout(graph.id, replacement.id)?.position
+    ).toEqual({ x: 40, y: 50 })
+  })
+
+  it('supports detach before attaching the replacement', () => {
+    const graph = new LGraph()
+    const oldNode = nodeFor(graph, 'shared')
+    const replacement = nodeFor(graph, 'shared')
+    attachNodeLayout(graph, oldNode)
+
+    detachNodeLayout(oldNode)
+    attachNodeLayout(graph, replacement)
+    setNodePosition(replacement, [60, 70])
+
+    expect(
+      layoutStore.getNodeLayout(graph.id, replacement.id)?.position
+    ).toEqual({ x: 60, y: 70 })
+  })
+})

--- a/src/renderer/core/layout/operations/graphLayoutAttachment.ts
+++ b/src/renderer/core/layout/operations/graphLayoutAttachment.ts
@@ -29,6 +29,34 @@ const nodeAttachments = new WeakMap<
   LGraphNode,
   LayoutAttachment<LGraphNode['id']>
 >()
+const nodeAttachmentOwners = new Map<
+  UUID,
+  Map<LGraphNode['id'], WeakRef<LGraphNode>>
+>()
+
+function nodeAttachmentOwner(
+  graphId: UUID,
+  nodeId: LGraphNode['id']
+): LGraphNode | undefined {
+  return nodeAttachmentOwners.get(graphId)?.get(nodeId)?.deref()
+}
+
+function setNodeAttachmentOwner(graphId: UUID, node: LGraphNode): void {
+  let owners = nodeAttachmentOwners.get(graphId)
+  if (!owners) {
+    owners = new Map()
+    nodeAttachmentOwners.set(graphId, owners)
+  }
+  owners.set(node.id, new WeakRef(node))
+}
+
+function deleteNodeAttachmentOwner(graphId: UUID, node: LGraphNode): boolean {
+  const owners = nodeAttachmentOwners.get(graphId)
+  if (owners?.get(node.id)?.deref() !== node) return false
+  owners.delete(node.id)
+  if (owners.size === 0) nodeAttachmentOwners.delete(graphId)
+  return true
+}
 interface NodeGeometryProjection {
   buffer: Rectangle
   geometryVersion: number
@@ -231,6 +259,7 @@ function adoptNodeAttachment(graphId: UUID, node: LGraphNode): void {
     projection.buffer
   )
   nodeAttachments.set(node, { graphId, id: node.id })
+  setNodeAttachmentOwner(graphId, node)
   if (geometrySynchronized) {
     projection.geometryVersion = layoutStore.geometryVersion
   }
@@ -245,6 +274,7 @@ function transferableNodeAttachment(
     !attachment ||
     nodeAttachments.has(replacement) ||
     attachment.id !== replacement.id ||
+    nodeAttachmentOwner(attachment.graphId, attachment.id) !== node ||
     !layoutStore.getNodeLayout(attachment.graphId, attachment.id)
   )
     return
@@ -273,6 +303,7 @@ export function transferLayoutAttachment(
 
   nodeAttachments.delete(node)
   nodeAttachments.set(replacement, attachment)
+  setNodeAttachmentOwner(attachment.graphId, replacement)
   if (geometrySynchronized) {
     nodeGeometryProjection(replacement).geometryVersion =
       layoutStore.geometryVersion
@@ -287,6 +318,7 @@ export function detachNodeLayout(node: LGraphNode): void {
 
   layoutStore.readNodeRect(graphId, nodeId, nodeGeometryProjection(node).buffer)
   nodeAttachments.delete(node)
+  if (!deleteNodeAttachmentOwner(graphId, node)) return
   layoutStore.applyOperation({
     ...canvasOperationMeta(),
     graphId,
@@ -466,7 +498,8 @@ export function detachGraphLayouts(
         nodeGeometryProjection(node).buffer
       )
       nodeAttachments.delete(node)
-      if (meta) {
+      const owned = deleteNodeAttachmentOwner(attachment.graphId, node)
+      if (meta && owned) {
         operations.push({
           ...meta,
           graphId: attachment.graphId,

--- a/src/renderer/core/layout/utils/mappers.ts
+++ b/src/renderer/core/layout/utils/mappers.ts
@@ -1,8 +1,9 @@
 import * as Y from 'yjs'
 
+import { toGroupId } from '@/types/groupId'
 import type { GroupId } from '@/types/groupId'
 import type { GroupLayout, NodeLayout } from '@/renderer/core/layout/types'
-import { toNodeId } from '@/types/nodeId'
+import { parseNodeId, toNodeId } from '@/types/nodeId'
 import type { NodeId } from '@/types/nodeId'
 
 /**
@@ -44,7 +45,7 @@ function yNodeRect(ynode: NodeLayoutMap): Readonly<StoredRect> {
 export function yNodeToLayout(ynode: NodeLayoutMap): NodeLayout {
   const [x, y, width, height] = yNodeRect(ynode)
   return {
-    id: (ynode.get('id') ?? toNodeId('unknown-node')) as NodeId,
+    id: parseNodeId(ynode.get('id')) ?? toNodeId('unknown-node'),
     position: { x, y },
     size: { width, height },
     bounds: { x, y, width, height },
@@ -88,8 +89,9 @@ export function yGroupToLayout(
 ): GroupLayout {
   const [x, y, width, height] =
     (ygroup.get('rect') as StoredRect | undefined) ?? DEFAULT_GROUP_RECT
+  const storedId = ygroup.get('id')
   return {
-    id: (ygroup.get('id') ?? groupId) as GroupId,
+    id: typeof storedId === 'number' ? toGroupId(storedId) : groupId,
     position: { x, y },
     size: { width, height }
   }

--- a/src/renderer/extensions/vueNodes/components/NodeWidgets.test.ts
+++ b/src/renderer/extensions/vueNodes/components/NodeWidgets.test.ts
@@ -263,8 +263,9 @@ describe('NodeWidgets', () => {
       }
     })
 
-    expect(container.querySelector('.widget-stub')?.className).toContain(
-      'text-node-stroke-error'
+    expect(container.querySelector('.widget-stub')).toHaveAttribute(
+      'aria-invalid',
+      'true'
     )
   })
 })

--- a/src/renderer/extensions/vueNodes/components/WidgetGrid.vue
+++ b/src/renderer/extensions/vueNodes/components/WidgetGrid.vue
@@ -48,6 +48,7 @@
             :widget="widget.simplified"
             :node-id
             :node-type
+            :aria-invalid="widget.hasError || undefined"
             :class="
               cn(
                 'col-span-2',

--- a/src/stores/linkStore.ts
+++ b/src/stores/linkStore.ts
@@ -22,7 +22,7 @@ export interface EndpointUpdate {
   topology: LinkTopology
   patch: EndpointPatch
 }
-interface EndpointUpdateError {
+export interface EndpointUpdateError {
   code:
     | 'duplicate-topology'
     | 'unowned-topology'

--- a/src/stores/widgetValueStore.ts
+++ b/src/stores/widgetValueStore.ts
@@ -222,6 +222,13 @@ export const useWidgetValueStore = defineStore('widgetValue', () => {
     return true
   }
 
+  function setLabel(widgetId: WidgetId, label: string): boolean {
+    const state = getWidget(widgetId)
+    if (!state) return false
+    state.label = label
+    return true
+  }
+
   function updateOptions(
     widgetId: WidgetId,
     options: Partial<WidgetState['options']>
@@ -369,6 +376,7 @@ export const useWidgetValueStore = defineStore('widgetValue', () => {
     getWidget,
     getWidgetRenderState,
     setValue,
+    setLabel,
     updateOptions,
     deleteWidget,
     getNodeWidgets,

--- a/src/systems/badgeSystem.ts
+++ b/src/systems/badgeSystem.ts
@@ -291,6 +291,6 @@ export function graphCreditsBadges(
 }
 
 /** Installs {@link nodeBadges} as the legacy canvas's badge row source. */
-export function installNodeBadges(): void {
-  registerBadgeRowsProvider(nodeBadges)
+export function installNodeBadges(): () => void {
+  return registerBadgeRowsProvider(nodeBadges)
 }


### PR DESCRIPTION
## Summary

Addresses the remaining valid review findings from #14246 as a child of #15670.

## Changes

- **What**: Makes input topology failures explicit, preserves layout ownership during same-ID replacement, removes unmapped replacement links, and adds badge-provider disposal.
- **What**: Routes widget metadata through its store, uses typed graph/link and layout ID access, and repairs focused unit and browser assertions.

## Review Focus

Please focus on rejected endpoint-update behavior, same-ID layout attachment ownership, and replacement-link cleanup.