### PR TITLE
test: cover workflow state round trips in Playwright

### DIFF
--- a/browser_tests/tests/workflowStateRoundTrips.spec.ts
+++ b/browser_tests/tests/workflowStateRoundTrips.spec.ts
@@ -14,78 +14,115 @@ test.describe(
     })
 
     test('undo and redo a connected node deletion', async ({ comfyPage }) => {
-      await comfyPage.workflow.loadWorkflow('default')
+      const { sampler, samplerId, cfgWidget, originalBounds, originalCfg } =
+        await test.step('Load the connected sampler and record its state', async () => {
+          await comfyPage.workflow.loadWorkflow('default')
 
-      const sampler = await comfyPage.vueNodes.getFixtureByTitle('KSampler')
-      const cfgInput = comfyPage.vueNodes.getInputNumberControls(
-        comfyPage.vueNodes.getWidgetByName('KSampler', 'cfg')
-      ).input
-      const originalBounds = await sampler.boundingBox()
-      if (!originalBounds) throw new Error('KSampler is not rendered')
-      const originalCfg = Number(await cfgInput.inputValue())
+          const [samplerRef] =
+            await comfyPage.nodeOps.getNodeRefsByTitle('KSampler')
+          if (!samplerRef) throw new Error('KSampler was not found')
+          const sampler = await comfyPage.vueNodes.getFixtureByTitle('KSampler')
+          const cfgWidget = await samplerRef.getWidgetByName('cfg')
+          const originalBounds = await sampler.boundingBox()
+          if (!originalBounds) throw new Error('KSampler is not rendered')
 
-      await sampler.delete()
-      await expect(sampler.root).toBeHidden()
+          return {
+            sampler,
+            samplerId: String(samplerRef.id),
+            cfgWidget,
+            originalBounds,
+            originalCfg: await cfgWidget.getValue()
+          }
+        })
 
-      await comfyPage.keyboard.undo()
-      await expect(sampler.root).toBeVisible()
-      await expect(sampler.root).toHaveBounds(originalBounds)
-      await expect
-        .poll(async () => Number(await cfgInput.inputValue()))
-        .toBe(originalCfg)
-
-      await comfyPage.keyboard.redo()
-      await expect(sampler.root).toBeHidden()
-      await comfyPage.keyboard.undo()
-      await expect(sampler.root).toBeVisible()
-
-      let requestBody: unknown
-      await new ExecutionHelper(comfyPage).run({
-        onPromptRequest: (body) => {
-          requestBody = body
-        }
+      await test.step('Delete the sampler through the Vue node', async () => {
+        await sampler.delete()
+        await expect(sampler.root).toBeHidden()
       })
-      expect(requestBody).toMatchObject({
-        prompt: {
-          '3': {
-            class_type: 'KSampler',
-            inputs: {
-              cfg: originalCfg,
-              model: ['4', 0],
-              positive: ['6', 0],
-              negative: ['7', 0],
-              latent_image: ['5', 0]
+
+      await test.step('Undo restores its geometry and widget value', async () => {
+        await comfyPage.keyboard.undo()
+        await expect(sampler.root).toBeVisible()
+        await expect(sampler.root).toHaveBounds(originalBounds)
+        await expect.poll(() => cfgWidget.getValue()).toBe(originalCfg)
+      })
+
+      await test.step('Redo removes it and a second undo restores it', async () => {
+        await comfyPage.keyboard.redo()
+        await expect(sampler.root).toBeHidden()
+        await comfyPage.keyboard.undo()
+        await expect(sampler.root).toBeVisible()
+      })
+
+      await test.step('Queueing uses the restored sampler connections', async () => {
+        let requestBody: unknown
+        await new ExecutionHelper(comfyPage).run({
+          onPromptRequest: (body) => {
+            requestBody = body
+          }
+        })
+        expect(requestBody).toMatchObject({
+          prompt: {
+            [samplerId]: {
+              class_type: 'KSampler',
+              inputs: {
+                cfg: originalCfg,
+                model: ['4', 0],
+                positive: ['6', 0],
+                negative: ['7', 0],
+                latent_image: ['5', 0]
+              }
             }
           }
-        }
+        })
       })
     })
 
     test('the original subgraph remains usable after deleting its copy', async ({
       comfyPage
     }) => {
-      await comfyPage.workflow.loadWorkflow('subgraphs/basic-subgraph')
+      const { original, originalId, copy } =
+        await test.step('Copy and paste the subgraph through its Vue node', async () => {
+          await comfyPage.workflow.loadWorkflow('subgraphs/basic-subgraph')
 
-      const original = comfyPage.vueNodes.getNodeLocator('2')
-      await comfyPage.vueNodes.selectNode('2')
-      await comfyPage.page.mouse.move(10, 10)
-      await comfyPage.nextFrame()
-      await comfyPage.clipboard.copy()
-      await comfyPage.clipboard.paste()
+          const [originalRef] =
+            await comfyPage.nodeOps.getNodeRefsByTitle('New Subgraph')
+          if (!originalRef) throw new Error('Subgraph was not found')
+          const original =
+            await comfyPage.vueNodes.getFixtureByTitle('New Subgraph')
+          await original.select()
+          await comfyPage.page.mouse.move(10, 10)
+          await comfyPage.nextFrame()
+          await comfyPage.clipboard.copy()
+          await comfyPage.clipboard.paste()
 
-      await expect(
-        comfyPage.vueNodes.getNodeByTitle('New Subgraph')
-      ).toHaveCount(2)
-      await expect(comfyPage.vueNodes.selectedNodes).toHaveCount(1)
-      const copy = comfyPage.vueNodes.selectedNodes
-      await expect(copy).not.toHaveAttribute('data-node-id', '2')
+          await expect(
+            comfyPage.vueNodes.getNodeByTitle('New Subgraph')
+          ).toHaveCount(2)
+          await expect(comfyPage.vueNodes.selectedNodes).toHaveCount(1)
+          const copy = comfyPage.vueNodes.selectedNodes
+          await expect(copy).not.toHaveAttribute(
+            'data-node-id',
+            String(originalRef.id)
+          )
 
-      await comfyPage.vueNodes.deleteSelected()
-      await expect(copy).toBeHidden()
-      await expect(original).toBeVisible()
+          return {
+            original: original.root,
+            originalId: String(originalRef.id),
+            copy
+          }
+        })
 
-      await comfyPage.vueNodes.enterSubgraph('2')
-      await expect(comfyPage.vueNodes.nodes).toHaveCount(2)
+      await test.step('Delete the copy without removing the original', async () => {
+        await comfyPage.vueNodes.deleteSelected()
+        await expect(copy).toBeHidden()
+        await expect(original).toBeVisible()
+      })
+
+      await test.step('Enter the surviving original subgraph', async () => {
+        await comfyPage.vueNodes.enterSubgraph(originalId)
+        await expect(comfyPage.vueNodes.nodes).toHaveCount(2)
+      })
     })
   }
 )

--- a/browser_tests/tests/workflowStateRoundTrips.spec.ts
+++ b/browser_tests/tests/workflowStateRoundTrips.spec.ts
@@ -9,7 +9,6 @@ test.describe(
   { tag: ['@vue-nodes', '@canvas'] },
   () => {
     test.beforeEach(async ({ comfyPage }) => {
-      await comfyPage.settings.setSetting('Comfy.VueNodes.Enabled', true)
       await comfyPage.settings.setSetting('Comfy.UseNewMenu', 'Disabled')
     })
 

--- a/browser_tests/tests/workflowStateRoundTrips.spec.ts
+++ b/browser_tests/tests/workflowStateRoundTrips.spec.ts
@@ -4,86 +4,88 @@ import {
 } from '@e2e/fixtures/ComfyPage'
 import { ExecutionHelper } from '@e2e/fixtures/helpers/ExecutionHelper'
 
-test.describe('Workflow state round trips', { tag: ['@canvas'] }, () => {
-  test.beforeEach(async ({ comfyPage }) => {
-    await comfyPage.settings.setSetting('Comfy.UseNewMenu', 'Disabled')
-  })
-
-  test('undo and redo a connected node deletion', async ({ comfyPage }) => {
-    await comfyPage.workflow.loadWorkflow('default')
-
-    const sampler = await comfyPage.nodeOps.getNodeRefById('3')
-    const originalPosition = await sampler.getProperty<[number, number]>('pos')
-    const originalCfg = await (await sampler.getWidgetByName('cfg')).getValue()
-
-    await sampler.click('title')
-    await comfyPage.keyboard.delete()
-    await expect.poll(() => sampler.exists()).toBe(false)
-
-    await comfyPage.keyboard.undo()
-    await expect.poll(() => sampler.exists()).toBe(true)
-    expect(await sampler.getProperty<[number, number]>('pos')).toEqual(
-      originalPosition
-    )
-    expect(await (await sampler.getWidgetByName('cfg')).getValue()).toBe(
-      originalCfg
-    )
-
-    await comfyPage.keyboard.redo()
-    await expect.poll(() => sampler.exists()).toBe(false)
-    await comfyPage.keyboard.undo()
-    await expect.poll(() => sampler.exists()).toBe(true)
-
-    let requestBody: unknown
-    await new ExecutionHelper(comfyPage).run({
-      onPromptRequest: (body) => {
-        requestBody = body
-      }
+test.describe(
+  'Workflow state round trips',
+  { tag: ['@vue-nodes', '@canvas'] },
+  () => {
+    test.beforeEach(async ({ comfyPage }) => {
+      await comfyPage.settings.setSetting('Comfy.VueNodes.Enabled', true)
+      await comfyPage.settings.setSetting('Comfy.UseNewMenu', 'Disabled')
     })
-    expect(requestBody).toMatchObject({
-      prompt: {
-        '3': {
-          class_type: 'KSampler',
-          inputs: {
-            cfg: originalCfg,
-            model: ['4', 0],
-            positive: ['6', 0],
-            negative: ['7', 0],
-            latent_image: ['5', 0]
+
+    test('undo and redo a connected node deletion', async ({ comfyPage }) => {
+      await comfyPage.workflow.loadWorkflow('default')
+
+      const sampler = await comfyPage.vueNodes.getFixtureByTitle('KSampler')
+      const cfgInput = comfyPage.vueNodes.getInputNumberControls(
+        comfyPage.vueNodes.getWidgetByName('KSampler', 'cfg')
+      ).input
+      const originalBounds = await sampler.boundingBox()
+      if (!originalBounds) throw new Error('KSampler is not rendered')
+      const originalCfg = Number(await cfgInput.inputValue())
+
+      await sampler.delete()
+      await expect(sampler.root).toBeHidden()
+
+      await comfyPage.keyboard.undo()
+      await expect(sampler.root).toBeVisible()
+      await expect(sampler.root).toHaveBounds(originalBounds)
+      await expect
+        .poll(async () => Number(await cfgInput.inputValue()))
+        .toBe(originalCfg)
+
+      await comfyPage.keyboard.redo()
+      await expect(sampler.root).toBeHidden()
+      await comfyPage.keyboard.undo()
+      await expect(sampler.root).toBeVisible()
+
+      let requestBody: unknown
+      await new ExecutionHelper(comfyPage).run({
+        onPromptRequest: (body) => {
+          requestBody = body
+        }
+      })
+      expect(requestBody).toMatchObject({
+        prompt: {
+          '3': {
+            class_type: 'KSampler',
+            inputs: {
+              cfg: originalCfg,
+              model: ['4', 0],
+              positive: ['6', 0],
+              negative: ['7', 0],
+              latent_image: ['5', 0]
+            }
           }
         }
-      }
+      })
     })
-  })
 
-  test('the original subgraph remains usable after deleting its copy', async ({
-    comfyPage
-  }) => {
-    await comfyPage.workflow.loadWorkflow('subgraphs/basic-subgraph')
+    test('the original subgraph remains usable after deleting its copy', async ({
+      comfyPage
+    }) => {
+      await comfyPage.workflow.loadWorkflow('subgraphs/basic-subgraph')
 
-    const original = await comfyPage.nodeOps.getNodeRefById('2')
-    await original.click('title')
-    await comfyPage.page.mouse.move(10, 10)
-    await comfyPage.nextFrame()
-    await comfyPage.clipboard.copy()
-    await comfyPage.clipboard.paste()
+      const original = comfyPage.vueNodes.getNodeLocator('2')
+      await comfyPage.vueNodes.selectNode('2')
+      await comfyPage.page.mouse.move(10, 10)
+      await comfyPage.nextFrame()
+      await comfyPage.clipboard.copy()
+      await comfyPage.clipboard.paste()
 
-    await expect
-      .poll(
-        async () =>
-          (await comfyPage.nodeOps.getNodeRefsByTitle('New Subgraph')).length
-      )
-      .toBe(2)
-    const instances = await comfyPage.nodeOps.getNodeRefsByTitle('New Subgraph')
-    const copy = instances.find((node) => node.id !== original.id)
-    if (!copy) throw new Error('Pasted subgraph was not found')
-    expect(await copy.getType()).not.toBe(await original.getType())
+      await expect(
+        comfyPage.vueNodes.getNodeByTitle('New Subgraph')
+      ).toHaveCount(2)
+      await expect(comfyPage.vueNodes.selectedNodes).toHaveCount(1)
+      const copy = comfyPage.vueNodes.selectedNodes
+      await expect(copy).not.toHaveAttribute('data-node-id', '2')
 
-    await comfyPage.keyboard.delete()
-    await expect.poll(() => copy.exists()).toBe(false)
-    await expect.poll(() => original.exists()).toBe(true)
+      await comfyPage.vueNodes.deleteSelected()
+      await expect(copy).toBeHidden()
+      await expect(original).toBeVisible()
 
-    await original.navigateIntoSubgraph()
-    await expect.poll(() => comfyPage.subgraph.getNodeCount()).toBe(2)
-  })
-})
+      await comfyPage.vueNodes.enterSubgraph('2')
+      await expect(comfyPage.vueNodes.nodes).toHaveCount(2)
+    })
+  }
+)

--- a/browser_tests/tests/workflowStateRoundTrips.spec.ts
+++ b/browser_tests/tests/workflowStateRoundTrips.spec.ts
@@ -1,0 +1,89 @@
+import {
+  comfyPageFixture as test,
+  comfyExpect as expect
+} from '@e2e/fixtures/ComfyPage'
+import { ExecutionHelper } from '@e2e/fixtures/helpers/ExecutionHelper'
+
+test.describe('Workflow state round trips', { tag: ['@canvas'] }, () => {
+  test.beforeEach(async ({ comfyPage }) => {
+    await comfyPage.settings.setSetting('Comfy.UseNewMenu', 'Disabled')
+  })
+
+  test('undo and redo a connected node deletion', async ({ comfyPage }) => {
+    await comfyPage.workflow.loadWorkflow('default')
+
+    const sampler = await comfyPage.nodeOps.getNodeRefById('3')
+    const originalPosition = await sampler.getProperty<[number, number]>('pos')
+    const originalCfg = await (await sampler.getWidgetByName('cfg')).getValue()
+
+    await sampler.click('title')
+    await comfyPage.keyboard.delete()
+    await expect.poll(() => sampler.exists()).toBe(false)
+
+    await comfyPage.keyboard.undo()
+    await expect.poll(() => sampler.exists()).toBe(true)
+    expect(await sampler.getProperty<[number, number]>('pos')).toEqual(
+      originalPosition
+    )
+    expect(await (await sampler.getWidgetByName('cfg')).getValue()).toBe(
+      originalCfg
+    )
+
+    await comfyPage.keyboard.redo()
+    await expect.poll(() => sampler.exists()).toBe(false)
+    await comfyPage.keyboard.undo()
+    await expect.poll(() => sampler.exists()).toBe(true)
+
+    let requestBody: unknown
+    await new ExecutionHelper(comfyPage).run({
+      onPromptRequest: (body) => {
+        requestBody = body
+      }
+    })
+    expect(requestBody).toMatchObject({
+      prompt: {
+        '3': {
+          class_type: 'KSampler',
+          inputs: {
+            cfg: originalCfg,
+            model: ['4', 0],
+            positive: ['6', 0],
+            negative: ['7', 0],
+            latent_image: ['5', 0]
+          }
+        }
+      }
+    })
+  })
+
+  test('the original subgraph remains usable after deleting its copy', async ({
+    comfyPage
+  }) => {
+    await comfyPage.workflow.loadWorkflow('subgraphs/basic-subgraph')
+
+    const original = await comfyPage.nodeOps.getNodeRefById('2')
+    await original.click('title')
+    await comfyPage.page.mouse.move(10, 10)
+    await comfyPage.nextFrame()
+    await comfyPage.clipboard.copy()
+    await comfyPage.clipboard.paste()
+
+    await expect
+      .poll(
+        async () =>
+          (await comfyPage.nodeOps.getNodeRefsByTitle('New Subgraph')).length
+      )
+      .toBe(2)
+    const instances = await comfyPage.nodeOps.getNodeRefsByTitle('New Subgraph')
+    const copy = instances.find((node) => node.id !== original.id)
+    if (!copy) throw new Error('Pasted subgraph was not found')
+    expect(await copy.getType()).not.toBe(await original.getType())
+
+    await comfyPage.keyboard.delete()
+    await expect.poll(() => copy.exists()).toBe(false)
+    await expect.poll(() => original.exists()).toBe(true)
+
+    await original.navigateIntoSubgraph()
+    await expect.poll(() => comfyPage.subgraph.getNodeCount()).toBe(2)
+  })
+})


### PR DESCRIPTION
## Summary

Adds focused browser coverage for the user-visible workflow behaviors characterized by #15550.

## Changes

- **What**: Exercises connected-node delete/undo/redo through the real application command path and verifies the resulting `/prompt` request; exercises subgraph copy/paste/delete and verifies the surviving instance remains usable.

## Review Focus

Confirm these two flows are the smallest useful browser complement to #15550. Internal configure, late-registration, and promoted-null cases remain unit-level because reproducing them in Playwright would require test-only graph construction.