### PR TITLE
fix: remove locale prune size gate

### DIFF
--- a/.github/workflows/i18n-update-core.yaml
+++ b/.github/workflows/i18n-update-core.yaml
@@ -4,11 +4,6 @@ name: 'i18n: Update Core'
 on:
   # Manual dispatch for urgent translation updates
   workflow_dispatch:
-    inputs:
-      allow_prune:
-        description: 'Confirm deletions larger than the prune threshold'
-        type: boolean
-        default: false
   # Trigger on PRs to main and to release branches (core/x.y, cloud/x.y).
   # Release branches need this so translations for backported locale keys are
   # regenerated and baked into the version-bump PR, mirroring main. Additional
@@ -60,7 +55,7 @@ jobs:
         # the manifest even when another file fails) still get committed; the
         # final step re-surfaces the failure
         continue-on-error: true
-        run: pnpm locale ${{ inputs.allow_prune == true && '--allow-prune' || '' }} && pnpm format
+        run: pnpm locale && pnpm format
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       - name: Commit updated locales

--- a/scripts/i18n/config.ts
+++ b/scripts/i18n/config.ts
@@ -22,8 +22,6 @@ export interface TranslationPipelineConfig {
   localeConcurrency: number
   requestConcurrency: number
   maxTranslationRounds: number
-  pruneCountFloor: number
-  pruneRatioLimit: number
   glossary: string
   outputLocales: OutputLocale[]
 }
@@ -55,8 +53,6 @@ export const translationPipelineConfig: TranslationPipelineConfig = {
   localeConcurrency: 3,
   requestConcurrency: 2,
   maxTranslationRounds: 3,
-  pruneCountFloor: 25,
-  pruneRatioLimit: 0.02,
   glossary,
   outputLocales: [
     {

--- a/scripts/i18n/update-locales.test.ts
+++ b/scripts/i18n/update-locales.test.ts
@@ -25,7 +25,7 @@ import {
 import {
   assembleLeafTranslations,
   buildTranslationItems,
-  exceedsPruneThreshold
+  formatPruneSummary
 } from './update-locales'
 
 const locale: OutputLocale = { code: 'xx', name: 'Test Language' }
@@ -486,13 +486,15 @@ describe('validateLocale', () => {
   })
 })
 
-describe('exceedsPruneThreshold', () => {
-  it('permits small cleanups and refuses large shrinks', () => {
-    expect(exceedsPruneThreshold(0, 0)).toBe(false)
-    expect(exceedsPruneThreshold(79, 13557)).toBe(false)
-    expect(exceedsPruneThreshold(25, 100)).toBe(false)
-    expect(exceedsPruneThreshold(62, 124)).toBe(true)
-    expect(exceedsPruneThreshold(500, 9082)).toBe(true)
+describe('formatPruneSummary', () => {
+  it('reports all source deletions without blocking on their size', () => {
+    expect(formatPruneSummary('main.json', 0, 100)).toBeUndefined()
+    expect(formatPruneSummary('main.json', 1, 100)).toBe(
+      'WARNING: main.json: 1 of 100 English keys deleted; matching locale keys will be pruned.'
+    )
+    expect(formatPruneSummary('nodeDefs.json', 387, 9082)).toBe(
+      'WARNING: nodeDefs.json: 387 of 9082 English keys deleted; matching locale keys will be pruned.'
+    )
   })
 })
 

--- a/scripts/i18n/update-locales.ts
+++ b/scripts/i18n/update-locales.ts
@@ -225,15 +225,13 @@ function readManifestSource(
   }
 }
 
-export function exceedsPruneThreshold(
+export function formatPruneSummary(
+  filename: string,
   deletedCount: number,
-  previousLeafCount: number,
-  { pruneCountFloor, pruneRatioLimit } = translationPipelineConfig
-): boolean {
-  return (
-    deletedCount >
-    Math.max(pruneCountFloor, Math.ceil(previousLeafCount * pruneRatioLimit))
-  )
+  previousLeafCount: number
+): string | undefined {
+  if (deletedCount === 0) return
+  return `WARNING: ${filename}: ${deletedCount} of ${previousLeafCount} English keys deleted; matching locale keys will be pruned.`
 }
 
 function writeManifest(
@@ -425,24 +423,13 @@ async function run(argv: readonly string[]): Promise<void> {
     }
   })
 
-  const oversizedPrunes = plans
-    .filter((plan) =>
-      exceedsPruneThreshold(plan.changes.deleted.length, plan.previousLeafCount)
+  for (const plan of plans) {
+    const summary = formatPruneSummary(
+      plan.filename,
+      plan.changes.deleted.length,
+      plan.previousLeafCount
     )
-    .map(
-      (plan) =>
-        `${plan.filename}: ${plan.changes.deleted.length} of ${plan.previousLeafCount} keys would be deleted`
-    )
-  if (oversizedPrunes.length > 0) {
-    if (check) {
-      for (const line of oversizedPrunes) {
-        print(`WARNING: large prune pending — ${line}`)
-      }
-    } else if (!argv.includes('--allow-prune')) {
-      throw new Error(
-        `Refusing to prune:\n${oversizedPrunes.join('\n')}\nA shrink this large usually means collect-i18n observed a partial app (failed custom-node imports or an incomplete server node list). Verify the English sources are complete, or rerun with --allow-prune to confirm the deletions.`
-      )
-    }
+    if (summary) print(summary)
   }
 
   const states = loadLocaleFileStates(config, outputDir, plans)

--- a/src/locales/CONTRIBUTING.md
+++ b/src/locales/CONTRIBUTING.md
@@ -119,10 +119,10 @@ re-queued for translation, so corrupted strings heal on the next run. Results
 persist per entry file: a failure translating one file does not discard the
 completed, validated work of the others — those are written and their manifest
 entries advance, and only the failed files retry on the next run. Runs that
-would delete an implausibly large share of a file's keys abort that file
-without writing — that usually means `collect-i18n` observed a partial app;
-rerun with `--allow-prune` (or the `allow_prune` input on the manual workflow
-dispatch) only after confirming the English sources are complete.
+prune keys report each affected file's exact deleted-key count. The release PR
+diff and review approve those deletions; there is no separate size-based bypass.
+Source-manifest, translation, and protected-token integrity failures remain hard
+failures.
 `pnpm locale:check` runs offline in CI: it reports pending work and fails on
 protected-token violations that are not already queued for retranslation
 because the English source changed. The manifest's `knownViolations` field


### PR DESCRIPTION
## Summary

Removes the hard size-based refusal from locale generation so large valid prunes are approved through normal PR review.

## Changes

- **What**: Removes the prune thresholds, `--allow-prune`, and the manual-workflow input while logging each affected file's exact deletion count as a non-blocking warning.
- **Safety**: Source-manifest, translation, and protected-token integrity failures remain ordinary hard failures.
- **Scope**: No generated locales or release PR changes.

## Review Focus

PR review is now the approval gate for large legitimate locale deletions.
