### PR TITLE
fix: preserve initial node execution state

### DIFF
--- a/src/stores/executionStore.test.ts
+++ b/src/stores/executionStore.test.ts
@@ -1817,6 +1817,35 @@ describe('useExecutionStore - RAF batching', () => {
         expect.objectContaining({ state: 'running' })
       )
     })
+
+    it('discards a pending node progress state when execution stops', () => {
+      expect.assertions(1)
+      const progressStateHandler = getRegisteredHandler('progress_state')
+      const executingHandler = apiEventHandlers.get('executing')!
+
+      progressStateHandler(
+        new CustomEvent('progress_state', {
+          detail: {
+            prompt_id: 'job-1',
+            nodes: {
+              '1': {
+                value: 0,
+                max: 10,
+                state: 'running',
+                node_id: '1',
+                prompt_id: 'job-1',
+                display_node_id: '1'
+              }
+            }
+          }
+        })
+      )
+
+      executingHandler(new CustomEvent('executing', { detail: null }))
+      vi.advanceTimersToNextFrame()
+
+      expect(Object.keys(store.nodeProgressStates)).toHaveLength(0)
+    })
   })
 
   describe('concurrent progress and progress_state in the same frame', () => {

--- a/src/stores/executionStore.test.ts
+++ b/src/stores/executionStore.test.ts
@@ -1780,19 +1780,25 @@ describe('useExecutionStore - RAF batching', () => {
     })
   })
 
-  describe('executing cancels both coalescers', () => {
-    it('discards pending progress_state RAF when a new node starts executing', () => {
+  describe('executing preserves node progress state', () => {
+    it('applies the initial running state when executing follows in the same frame', () => {
       expect.assertions(1)
+      const startHandler = getRegisteredHandler('execution_start')
       const progressStateHandler = getRegisteredHandler('progress_state')
       const executingHandler = getRegisteredHandler('executing')
 
+      startHandler(
+        new CustomEvent('execution_start', {
+          detail: { prompt_id: 'job-1', timestamp: 0 }
+        })
+      )
       progressStateHandler(
         new CustomEvent('progress_state', {
           detail: {
             prompt_id: 'job-1',
             nodes: {
               '1': {
-                value: 5,
+                value: 0,
                 max: 10,
                 state: 'running',
                 node_id: '1',
@@ -1804,10 +1810,12 @@ describe('useExecutionStore - RAF batching', () => {
         })
       )
 
-      executingHandler(new CustomEvent('executing', { detail: '2' }))
+      executingHandler(new CustomEvent('executing', { detail: '1' }))
       vi.advanceTimersToNextFrame()
 
-      expect(Object.keys(store.nodeProgressStates)).toHaveLength(0)
+      expect(store.nodeProgressStates['1']).toEqual(
+        expect.objectContaining({ state: 'running' })
+      )
     })
   })
 

--- a/src/stores/executionStore.ts
+++ b/src/stores/executionStore.ts
@@ -525,7 +525,8 @@ export const useExecutionStore = defineStore('execution', () => {
   }
 
   function handleExecuting(e: CustomEvent<string | number | null>): void {
-    cancelPendingProgressUpdates()
+    progressCoalescer.cancel()
+    if (e.detail == null) progressStateCoalescer.cancel()
 
     // Clear the current node progress when a new node starts executing
     _executingNodeProgress.value = null


### PR DESCRIPTION
## Summary

Preserve the initial running progress snapshot when an `executing` event arrives before the next animation frame.

## Changes

- Keep pending `progress_state` snapshots across non-null `executing` events.
- Continue cancelling scalar progress between nodes and all pending progress when execution stops.
- Cover both the backend event order and the terminal cancellation path.

## Testing

- Confirmed the regression test failed in CI before the fix (1 failed, 16,792 passed).
- `pnpm test:unit src/stores/executionStore.test.ts` (114 passed)
- `pnpm typecheck`
- Pre-commit formatting, oxlint, ESLint, and typecheck
- Pre-push knip