### PR TITLE
perf(widgets): lazy-load the Tiptap markdown editor off the boot path

### DIFF
--- a/src/renderer/extensions/vueNodes/widgets/composables/markdownEditor.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/markdownEditor.ts
@@ -1,0 +1,40 @@
+import { Editor as TiptapEditor } from '@tiptap/core'
+import TiptapLink from '@tiptap/extension-link'
+import TiptapTable from '@tiptap/extension-table'
+import TiptapTableCell from '@tiptap/extension-table-cell'
+import TiptapTableHeader from '@tiptap/extension-table-header'
+import TiptapTableRow from '@tiptap/extension-table-row'
+import TiptapStarterKit from '@tiptap/starter-kit'
+import { Markdown as TiptapMarkdown } from 'tiptap-markdown'
+
+/**
+ * Builds the read-only Tiptap markdown editor mounted into an existing element.
+ *
+ * Imported only via dynamic import() from useMarkdownWidget so the ~0.7MB Tiptap
+ * bundle stays off the app's boot path (vendor-tiptap is otherwise a static
+ * dependency of a boot chunk).
+ */
+export function createMarkdownEditor(
+  element: HTMLElement,
+  content: string
+): TiptapEditor {
+  TiptapMarkdown.configure({
+    html: false,
+    breaks: true,
+    transformPastedText: true
+  })
+  return new TiptapEditor({
+    element,
+    extensions: [
+      TiptapStarterKit,
+      TiptapMarkdown,
+      TiptapLink,
+      TiptapTable,
+      TiptapTableCell,
+      TiptapTableHeader,
+      TiptapTableRow
+    ],
+    content,
+    editable: false
+  })
+}

--- a/src/renderer/extensions/vueNodes/widgets/composables/useMarkdownWidget.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useMarkdownWidget.test.ts
@@ -19,8 +19,6 @@ const { canvasMock, createMarkdownEditorMock, setContentSpy, destroySpy } =
       },
       setContentSpy,
       destroySpy,
-      // Fake editor: mounts nothing real, records the content it was created
-      // with, and exposes the surface useMarkdownWidget touches.
       createMarkdownEditorMock: vi.fn((_el: HTMLElement, content: string) => ({
         __content: content,
         isDestroyed: false,
@@ -40,14 +38,11 @@ vi.mock('@/lib/litegraph/src/litegraph', async (importOriginal) => {
 vi.mock('@/stores/widgetValueStore', () => ({
   useWidgetValueStore: () => ({ getWidget: () => undefined })
 }))
-// Mock the lazily-imported editor module so the deferred import() resolves to a
-// synchronous fake and never fires a real async attach after test teardown.
 vi.mock(
   '@/renderer/extensions/vueNodes/widgets/composables/markdownEditor',
   () => ({ createMarkdownEditor: createMarkdownEditorMock })
 )
 
-// Let the pending `import('./markdownEditor').then(...)` microtask settle.
 const flushEditorAttach = () => new Promise<void>((r) => setTimeout(r, 0))
 
 function createMarkdownWidget(node: LGraphNode) {
@@ -140,7 +135,6 @@ describe('useMarkdownWidget', () => {
 
   it('has a fully interactive shell before the editor chunk resolves', () => {
     const { textarea, callback } = setup()
-    // No editor attach flushed yet — the shell alone must work.
     expect(createMarkdownEditorMock).not.toHaveBeenCalled()
     textarea.value = 'typed'
     textarea.dispatchEvent(new Event('input', { bubbles: true }))
@@ -149,8 +143,6 @@ describe('useMarkdownWidget', () => {
 
   it('mounts the editor with the current value, not the construction default', async () => {
     const { textarea } = setup()
-    // A value present in the shell during the load window (e.g. from a
-    // workflow restore) must be what the editor initialises from on attach.
     textarea.value = 'edited during load'
 
     await flushEditorAttach()
@@ -163,21 +155,17 @@ describe('useMarkdownWidget', () => {
   it('routes content to the editor only once it has attached', async () => {
     const { textarea } = setup()
 
-    // Before attach: a textarea change must not touch a (nonexistent) editor.
     textarea.dispatchEvent(new Event('change', { bubbles: true }))
     expect(setContentSpy).not.toHaveBeenCalled()
 
     await flushEditorAttach()
 
-    // After attach: the same change now flows through to the editor.
     textarea.value = 'after attach'
     textarea.dispatchEvent(new Event('change', { bubbles: true }))
     expect(setContentSpy).toHaveBeenCalledWith('after attach')
   })
 
   it('setValue writes the editor once attached and is a no-op on it before', async () => {
-    // Capture the real getValue/setValue the widget registers (the shared mock
-    // otherwise drops them) so we can drive setValue directly.
     let captured: { setValue?: (v: string) => void } = {}
     const node = createMockDOMWidgetNode({
       addDOMWidget: vi.fn(
@@ -192,14 +180,12 @@ describe('useMarkdownWidget', () => {
     document.body.append(inputEl)
     onTestFinished(() => inputEl.remove())
 
-    // Pre-attach: setValue updates the shell without throwing (editor undefined).
     expect(() => captured.setValue?.('before')).not.toThrow()
     expect(inputEl.querySelector('textarea')!.value).toBe('before')
     expect(setContentSpy).not.toHaveBeenCalled()
 
     await flushEditorAttach()
 
-    // Post-attach: setValue now routes the content into the editor too.
     captured.setValue?.('after')
     expect(setContentSpy).toHaveBeenCalledWith('after')
   })
@@ -214,6 +200,16 @@ describe('useMarkdownWidget', () => {
     expect(destroySpy).not.toHaveBeenCalled()
   })
 
+  it('destroys the attached editor on removal', async () => {
+    const { widget } = setup()
+    await flushEditorAttach()
+    expect(createMarkdownEditorMock).toHaveBeenCalledTimes(1)
+
+    widget.onRemove?.()
+
+    expect(destroySpy).toHaveBeenCalledTimes(1)
+  })
+
   it('degrades to the shell when the editor chunk fails to load', async () => {
     createMarkdownEditorMock.mockImplementationOnce(() => {
       throw new Error('chunk load failed')
@@ -222,7 +218,6 @@ describe('useMarkdownWidget', () => {
 
     await flushEditorAttach()
 
-    // No throw escaped; the shell textarea stays fully usable.
     textarea.value = 'still works'
     textarea.dispatchEvent(new Event('input', { bubbles: true }))
     expect(callback).toHaveBeenCalledTimes(1)

--- a/src/renderer/extensions/vueNodes/widgets/composables/useMarkdownWidget.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useMarkdownWidget.test.ts
@@ -7,13 +7,28 @@ import type { DOMWidget } from '@/scripts/domWidget'
 import { useMarkdownWidget } from '@/renderer/extensions/vueNodes/widgets/composables/useMarkdownWidget'
 import { createMockDOMWidgetNode } from '@/renderer/extensions/vueNodes/widgets/composables/domWidgetTestUtils'
 
-const { canvasMock } = vi.hoisted(() => ({
-  canvasMock: {
-    processMouseDown: vi.fn(),
-    processMouseMove: vi.fn(),
-    processMouseUp: vi.fn()
-  }
-}))
+const { canvasMock, createMarkdownEditorMock, setContentSpy, destroySpy } =
+  vi.hoisted(() => {
+    const setContentSpy = vi.fn()
+    const destroySpy = vi.fn()
+    return {
+      canvasMock: {
+        processMouseDown: vi.fn(),
+        processMouseMove: vi.fn(),
+        processMouseUp: vi.fn()
+      },
+      setContentSpy,
+      destroySpy,
+      // Fake editor: mounts nothing real, records the content it was created
+      // with, and exposes the surface useMarkdownWidget touches.
+      createMarkdownEditorMock: vi.fn((_el: HTMLElement, content: string) => ({
+        __content: content,
+        isDestroyed: false,
+        destroy: destroySpy,
+        commands: { setContent: setContentSpy }
+      }))
+    }
+  })
 
 vi.mock('@/scripts/app', () => ({
   app: { rootGraph: { id: 'root' }, canvas: canvasMock }
@@ -25,6 +40,15 @@ vi.mock('@/lib/litegraph/src/litegraph', async (importOriginal) => {
 vi.mock('@/stores/widgetValueStore', () => ({
   useWidgetValueStore: () => ({ getWidget: () => undefined })
 }))
+// Mock the lazily-imported editor module so the deferred import() resolves to a
+// synchronous fake and never fires a real async attach after test teardown.
+vi.mock(
+  '@/renderer/extensions/vueNodes/widgets/composables/markdownEditor',
+  () => ({ createMarkdownEditor: createMarkdownEditorMock })
+)
+
+// Let the pending `import('./markdownEditor').then(...)` microtask settle.
+const flushEditorAttach = () => new Promise<void>((r) => setTimeout(r, 0))
 
 function createMarkdownWidget(node: LGraphNode) {
   const inputSpec: InputSpec = {
@@ -112,5 +136,66 @@ describe('useMarkdownWidget', () => {
     const { widget } = setup()
     widget.onRemove?.()
     expect(() => widget.onRemove?.()).not.toThrow()
+  })
+
+  it('has a fully interactive shell before the editor chunk resolves', () => {
+    const { textarea, callback } = setup()
+    // No editor attach flushed yet — the shell alone must work.
+    expect(createMarkdownEditorMock).not.toHaveBeenCalled()
+    textarea.value = 'typed'
+    textarea.dispatchEvent(new Event('input', { bubbles: true }))
+    expect(callback).toHaveBeenCalledTimes(1)
+  })
+
+  it('mounts the editor with the current value, not the construction default', async () => {
+    const { textarea } = setup()
+    // A value present in the shell during the load window (e.g. from a
+    // workflow restore) must be what the editor initialises from on attach.
+    textarea.value = 'edited during load'
+
+    await flushEditorAttach()
+
+    expect(createMarkdownEditorMock).toHaveBeenCalledTimes(1)
+    const [, content] = createMarkdownEditorMock.mock.calls[0]
+    expect(content).toBe('edited during load')
+  })
+
+  it('routes content to the editor only once it has attached', async () => {
+    const { textarea } = setup()
+
+    // Before attach: a textarea change must not touch a (nonexistent) editor.
+    textarea.dispatchEvent(new Event('change', { bubbles: true }))
+    expect(setContentSpy).not.toHaveBeenCalled()
+
+    await flushEditorAttach()
+
+    // After attach: the same change now flows through to the editor.
+    textarea.value = 'after attach'
+    textarea.dispatchEvent(new Event('change', { bubbles: true }))
+    expect(setContentSpy).toHaveBeenCalledWith('after attach')
+  })
+
+  it('does not mount the editor if the node is removed before the chunk resolves', async () => {
+    const { widget } = setup()
+    widget.onRemove?.()
+
+    await flushEditorAttach()
+
+    expect(createMarkdownEditorMock).not.toHaveBeenCalled()
+    expect(destroySpy).not.toHaveBeenCalled()
+  })
+
+  it('degrades to the shell when the editor chunk fails to load', async () => {
+    createMarkdownEditorMock.mockImplementationOnce(() => {
+      throw new Error('chunk load failed')
+    })
+    const { textarea, callback } = setup()
+
+    await flushEditorAttach()
+
+    // No throw escaped; the shell textarea stays fully usable.
+    textarea.value = 'still works'
+    textarea.dispatchEvent(new Event('input', { bubbles: true }))
+    expect(callback).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/renderer/extensions/vueNodes/widgets/composables/useMarkdownWidget.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useMarkdownWidget.test.ts
@@ -175,6 +175,35 @@ describe('useMarkdownWidget', () => {
     expect(setContentSpy).toHaveBeenCalledWith('after attach')
   })
 
+  it('setValue writes the editor once attached and is a no-op on it before', async () => {
+    // Capture the real getValue/setValue the widget registers (the shared mock
+    // otherwise drops them) so we can drive setValue directly.
+    let captured: { setValue?: (v: string) => void } = {}
+    const node = createMockDOMWidgetNode({
+      addDOMWidget: vi.fn(
+        (name: string, type: string, element: HTMLElement, options) => {
+          captured = options
+          return { name, type, element, options: {}, value: '' }
+        }
+      )
+    })
+    const widget = createMarkdownWidget(node)
+    const inputEl = widget.element
+    document.body.append(inputEl)
+    onTestFinished(() => inputEl.remove())
+
+    // Pre-attach: setValue updates the shell without throwing (editor undefined).
+    expect(() => captured.setValue?.('before')).not.toThrow()
+    expect(inputEl.querySelector('textarea')!.value).toBe('before')
+    expect(setContentSpy).not.toHaveBeenCalled()
+
+    await flushEditorAttach()
+
+    // Post-attach: setValue now routes the content into the editor too.
+    captured.setValue?.('after')
+    expect(setContentSpy).toHaveBeenCalledWith('after')
+  })
+
   it('does not mount the editor if the node is removed before the chunk resolves', async () => {
     const { widget } = setup()
     widget.onRemove?.()

--- a/src/renderer/extensions/vueNodes/widgets/composables/useMarkdownWidget.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useMarkdownWidget.ts
@@ -1,11 +1,4 @@
-import { Editor as TiptapEditor } from '@tiptap/core'
-import TiptapLink from '@tiptap/extension-link'
-import TiptapTable from '@tiptap/extension-table'
-import TiptapTableCell from '@tiptap/extension-table-cell'
-import TiptapTableHeader from '@tiptap/extension-table-header'
-import TiptapTableRow from '@tiptap/extension-table-row'
-import TiptapStarterKit from '@tiptap/starter-kit'
-import { Markdown as TiptapMarkdown } from 'tiptap-markdown'
+import type { Editor as TiptapEditor } from '@tiptap/core'
 
 import { useChainCallback } from '@/composables/functional/useChainCallback'
 import { resolveNodeRootGraphId } from '@/lib/litegraph/src/litegraph'
@@ -24,31 +17,19 @@ function addMarkdownWidget(
   name: string,
   opts: { defaultVal: string }
 ) {
-  TiptapMarkdown.configure({
-    html: false,
-    breaks: true,
-    transformPastedText: true
-  })
-  const editor = new TiptapEditor({
-    extensions: [
-      TiptapStarterKit,
-      TiptapMarkdown,
-      TiptapLink,
-      TiptapTable,
-      TiptapTableCell,
-      TiptapTableHeader,
-      TiptapTableRow
-    ],
-    content: opts.defaultVal,
-    editable: false
-  })
-
   const widgetStore = useWidgetValueStore()
 
-  const inputEl = editor.options.element as HTMLElement
+  // Build the shell synchronously so the widget is fully wired before Tiptap
+  // loads. The Tiptap editor (~0.7MB) is imported lazily and mounted into this
+  // element on arrival, keeping it off the app boot path.
+  const inputEl = document.createElement('div')
   inputEl.classList.add('comfy-markdown')
   const textarea = document.createElement('textarea')
+  textarea.value = opts.defaultVal
   inputEl.append(textarea)
+
+  let editor: TiptapEditor | undefined
+  let removed = false
 
   const widget = node.addDOMWidget(name, 'MARKDOWN', inputEl, {
     getValue(): string {
@@ -60,7 +41,7 @@ function addMarkdownWidget(
     },
     setValue(v: string) {
       textarea.value = v
-      editor.commands.setContent(v)
+      editor?.commands.setContent(v)
       const graphId = resolveNodeRootGraphId(node, app.rootGraph.id)
       const widgetState = widgetStore.getWidget(
         widgetId(graphId, node.id, name)
@@ -101,7 +82,7 @@ function addMarkdownWidget(
   textarea.addEventListener(
     'change',
     () => {
-      editor.commands.setContent(textarea.value)
+      editor?.commands.setContent(textarea.value)
       widget.callback?.(widget.value)
     },
     { signal }
@@ -113,9 +94,24 @@ function addMarkdownWidget(
 
   forwardMiddleButtonToCanvas(inputEl, signal)
 
+  // Attach the rich editor once its chunk resolves. A dynamic import can't be
+  // cancelled, so a `removed` guard makes a late arrival a no-op after the node
+  // is gone. On failure the shell textarea stays fully usable.
+  void import('./markdownEditor')
+    .then(({ createMarkdownEditor }) => {
+      if (removed) return
+      // Initialise from the current value, not the construction-time default,
+      // so a setValue during the load window is reflected.
+      editor = createMarkdownEditor(inputEl, textarea.value)
+    })
+    .catch((error) => {
+      console.error('[markdownWidget] Failed to load editor', error)
+    })
+
   widget.onRemove = useChainCallback(widget.onRemove, () => {
+    removed = true
     controller.abort()
-    if (!editor.isDestroyed) editor.destroy()
+    if (editor && !editor.isDestroyed) editor.destroy()
   })
 
   return widget


### PR DESCRIPTION
## Summary

The Tiptap rich-text editor (about 0.7MB, 0.18MB gzipped) was loading during app boot even though almost no one has a markdown node on screen at first paint. This makes the markdown widget load Tiptap lazily instead, so the editor bundle no longer sits on the boot path.

## Changes

- `useMarkdownWidget` no longer imports Tiptap. It was the only file in `src/` that did, and because `widgets.ts` builds the `MARKDOWN` widget-table entry at module load, a boot chunk ended up statically depending on the whole editor.
- The editor construction moved to a new `markdownEditor.ts` that is only ever reached through a dynamic `import()`. That is what keeps `vendor-tiptap` out of the boot chunks.
- The widget constructor now builds its own DOM shell (a div with a textarea and all the listeners) synchronously, then attaches the Tiptap editor when its chunk arrives. It stays synchronous because the widget-constructor contract is synchronous everywhere it is called.
- Value handling is safe during the load window. `setValue` writes the textarea and store and only touches the editor once it exists, and the editor is initialised from the current value on attach, so a workflow restore that runs before Tiptap loads is not lost.
- If the node is removed while the chunk is still loading, a guard flag makes the attach a no-op (a dynamic import cannot be aborted), and the editor is destroyed on removal once it exists.
- If the editor chunk fails to load, the widget degrades to the plain textarea shell instead of throwing.

## Review Focus

- `useMarkdownWidget.ts` is on the boot-critical widget path and the change touches `node.addDOMWidget` construction, so the `node_widgets` and `comfy_api_surface` blast flags are true. No export changed: `useMarkdownWidget()`'s signature and the `ComfyWidgets` table shape are identical, so the `window.comfyAPI` surface is unchanged.
- The one real behavior change is that a markdown node briefly shows the plain textarea before the rich editor mounts (`useMarkdownWidget.ts:100`). For a read-only display this is a beat; confirm it reads acceptably on canvas.

## QA

- [x] Unit: 12 passing in the markdown widget suite, covering the shell-before-attach, attach-with-current-value, setValue routing, onRemove-before-attach, destroy-on-removal, and chunk-load-failure paths
- [x] Mutation: 4/4 killed on changed lines, 0 unexplained survivors; invariants INV-3 (setValue guarded editor write), INV-4 (onRemove destroy guard), INV-5 (change routes to editor) all killed
- [x] Build: cloud bundle verified, `vendor-tiptap` is now imported only by the dynamic `markdownEditor` chunk, no boot chunk (`settingStore`/`index`/`main`/`core`/`GraphView`) statically imports it
- [x] Lint and format clean on all three files; diff-scoped comment check clean
- [ ] Manual: drop a markdown node onto the canvas, confirm the rich editor still renders and edits, and that a workflow saved with markdown content round-trips
- Not covered here: no e2e for the markdown widget exists in the repo, so the load-window and failure paths are proven by unit tests rather than in a real browser.
