### PR TITLE
perf(setup): prefetch /object_info so it overlaps extension loading

### DIFF
--- a/src/scripts/app.registerNodes.test.ts
+++ b/src/scripts/app.registerNodes.test.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+import type { ComfyNodeDef as ComfyNodeDefV1 } from '@/schemas/nodeDefSchema'
+import { app as comfyApp } from '@/scripts/app'
+
+vi.mock('@/services/extensionService', () => ({
+  useExtensionService: () => ({ invokeExtensionsAsync: vi.fn() })
+}))
+
+type AppInternals = {
+  nodeDefsPrefetch?: Promise<Record<string, ComfyNodeDefV1> | undefined>
+  vueAppReady: boolean
+  registerNodesFromDefs: (defs: Record<string, ComfyNodeDefV1>) => Promise<void>
+}
+
+const internals = comfyApp as unknown as AppInternals
+
+describe('ComfyApp.registerNodes prefetch reuse', () => {
+  beforeEach(() => {
+    internals.nodeDefsPrefetch = undefined
+    internals.vueAppReady = false
+    vi.spyOn(internals, 'registerNodesFromDefs').mockResolvedValue()
+  })
+
+  test('reuses a resolved prefetch without fetching again', async () => {
+    const defs = { A: {} } as unknown as Record<string, ComfyNodeDefV1>
+    const getNodeDefs = vi
+      .spyOn(comfyApp, 'getNodeDefs')
+      .mockResolvedValue({} as Record<string, ComfyNodeDefV1>)
+    internals.nodeDefsPrefetch = Promise.resolve(defs)
+
+    await comfyApp.registerNodes()
+
+    expect(getNodeDefs).not.toHaveBeenCalled()
+    expect(internals.registerNodesFromDefs).toHaveBeenCalledWith(defs)
+  })
+
+  test('refetches when the prefetch resolved undefined (failed)', async () => {
+    const fresh = { B: {} } as unknown as Record<string, ComfyNodeDefV1>
+    const getNodeDefs = vi
+      .spyOn(comfyApp, 'getNodeDefs')
+      .mockResolvedValue(fresh)
+    internals.nodeDefsPrefetch = Promise.resolve(undefined)
+
+    await comfyApp.registerNodes()
+
+    expect(getNodeDefs).toHaveBeenCalledTimes(1)
+    expect(internals.registerNodesFromDefs).toHaveBeenCalledWith(fresh)
+  })
+
+  test('fetches directly when no prefetch was set', async () => {
+    const fresh = { C: {} } as unknown as Record<string, ComfyNodeDefV1>
+    const getNodeDefs = vi
+      .spyOn(comfyApp, 'getNodeDefs')
+      .mockResolvedValue(fresh)
+
+    await comfyApp.registerNodes()
+
+    expect(getNodeDefs).toHaveBeenCalledTimes(1)
+    expect(internals.registerNodesFromDefs).toHaveBeenCalledWith(fresh)
+  })
+
+  test('clears the prefetch so a later call refetches', async () => {
+    const defs = { A: {} } as unknown as Record<string, ComfyNodeDefV1>
+    const getNodeDefs = vi
+      .spyOn(comfyApp, 'getNodeDefs')
+      .mockResolvedValue(defs)
+    internals.nodeDefsPrefetch = Promise.resolve(defs)
+
+    await comfyApp.registerNodes()
+    await comfyApp.registerNodes()
+
+    expect(getNodeDefs).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/scripts/app.registerNodes.test.ts
+++ b/src/scripts/app.registerNodes.test.ts
@@ -10,6 +10,7 @@ vi.mock('@/services/extensionService', () => ({
 type AppInternals = {
   nodeDefsPrefetch?: Promise<Record<string, ComfyNodeDefV1> | undefined>
   vueAppReady: boolean
+  startNodeDefsPrefetch: () => void
   registerNodesFromDefs: (defs: Record<string, ComfyNodeDefV1>) => Promise<void>
 }
 
@@ -57,6 +58,42 @@ describe('ComfyApp.registerNodes prefetch reuse', () => {
     await comfyApp.registerNodes()
 
     expect(getNodeDefs).toHaveBeenCalledTimes(1)
+    expect(internals.registerNodesFromDefs).toHaveBeenCalledWith(fresh)
+  })
+
+  test('startNodeDefsPrefetch stores the in-flight defs for reuse', async () => {
+    const defs = { A: {} } as unknown as Record<string, ComfyNodeDefV1>
+    const getNodeDefs = vi
+      .spyOn(comfyApp, 'getNodeDefs')
+      .mockResolvedValue(defs)
+
+    internals.startNodeDefsPrefetch()
+
+    expect(getNodeDefs).toHaveBeenCalledTimes(1)
+    await expect(internals.nodeDefsPrefetch).resolves.toBe(defs)
+  })
+
+  test('startNodeDefsPrefetch swallows a rejection into undefined', async () => {
+    vi.spyOn(comfyApp, 'getNodeDefs').mockRejectedValue(new Error('boom'))
+
+    internals.startNodeDefsPrefetch()
+
+    // Must resolve to undefined, never reject (no unhandled rejection), so
+    // registerNodes falls back cleanly.
+    await expect(internals.nodeDefsPrefetch).resolves.toBeUndefined()
+  })
+
+  test('a failed prefetch from startNodeDefsPrefetch falls back to a refetch', async () => {
+    const fresh = { B: {} } as unknown as Record<string, ComfyNodeDefV1>
+    const getNodeDefs = vi
+      .spyOn(comfyApp, 'getNodeDefs')
+      .mockRejectedValueOnce(new Error('boom'))
+      .mockResolvedValue(fresh)
+
+    internals.startNodeDefsPrefetch()
+    await comfyApp.registerNodes()
+
+    expect(getNodeDefs).toHaveBeenCalledTimes(2)
     expect(internals.registerNodesFromDefs).toHaveBeenCalledWith(fresh)
   })
 

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -935,8 +935,8 @@ export class ComfyApp {
     // Start the node-definition fetch now so its round trip overlaps the work
     // below; registerNodes() awaits the result. Auth is already resolved by the
     // time setup() runs, so this carries the same credentials the later call
-    // would. Errors are swallowed here and surfaced by the fallback refetch.
-    this.nodeDefsPrefetch = this.getNodeDefs().catch(() => undefined)
+    // would.
+    this.startNodeDefsPrefetch()
 
     await useWorkspaceStore().workflow.syncWorkflows()
     //Doesn't need to block. Blueprints will load async
@@ -1142,6 +1142,15 @@ export class ComfyApp {
   /**
    * Registers nodes with the graph
    */
+  /**
+   * Kicks off the `/object_info` fetch and stores it for registerNodes() to
+   * await. A failed fetch resolves to `undefined` so it never becomes an
+   * unhandled rejection; registerNodes() then refetches.
+   */
+  startNodeDefsPrefetch() {
+    this.nodeDefsPrefetch = this.getNodeDefs().catch(() => undefined)
+  }
+
   async registerNodes() {
     // Load node definitions from the backend, reusing the prefetch kicked off
     // in setup() when it succeeded and refetching if it failed or was skipped.

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -274,6 +274,12 @@ export class ComfyApp {
   static clipspace_return_node = null
 
   vueAppReady: boolean
+  /**
+   * In-flight `/object_info` fetch started at the top of setup() so its round
+   * trip overlaps loadExtensions and the init hooks instead of running after
+   * them. registerNodes() awaits it, falling back to a fresh fetch on failure.
+   */
+  private nodeDefsPrefetch?: Promise<Record<string, ComfyNodeDefV1> | undefined>
   api: ComfyApi
   ui: ComfyUI
   extensionManager!: ExtensionManager
@@ -926,6 +932,12 @@ export class ComfyApp {
 
     this.canvasElRef.value = canvasEl
 
+    // Start the node-definition fetch now so its round trip overlaps the work
+    // below; registerNodes() awaits the result. Auth is already resolved by the
+    // time setup() runs, so this carries the same credentials the later call
+    // would. Errors are swallowed here and surfaced by the fallback refetch.
+    this.nodeDefsPrefetch = this.getNodeDefs().catch(() => undefined)
+
     await useWorkspaceStore().workflow.syncWorkflows()
     //Doesn't need to block. Blueprints will load async
     void useSubgraphStore().fetchSubgraphs()
@@ -1131,8 +1143,11 @@ export class ComfyApp {
    * Registers nodes with the graph
    */
   async registerNodes() {
-    // Load node definitions from the backend
-    const defs = await this.getNodeDefs()
+    // Load node definitions from the backend, reusing the prefetch kicked off
+    // in setup() when it succeeded and refetching if it failed or was skipped.
+    const prefetch = this.nodeDefsPrefetch
+    this.nodeDefsPrefetch = undefined
+    const defs = (await prefetch) ?? (await this.getNodeDefs())
     await this.registerNodesFromDefs(defs)
     await useExtensionService().invokeExtensionsAsync('registerCustomNodes')
     if (this.vueAppReady) {


### PR DESCRIPTION
## Summary

`app.setup()` waited for `syncWorkflows`, `loadExtensions` and the extension `init` hooks to finish before it fetched node definitions, even though the `/object_info` fetch depends on none of them. This starts that fetch up front so it overlaps that work instead of running after it.

## Changes

- `app.setup()` now calls `startNodeDefsPrefetch()` at the top, which kicks off `getNodeDefs()` and stores the in-flight promise on the instance.
- `registerNodes()` awaits that stored promise instead of fetching fresh, and clears it. If the prefetch failed or was never started it falls back to a normal `getNodeDefs()`, so the original behavior is preserved.
- The prefetch swallows its own rejection to `undefined`, so a failed fetch can never become an unhandled rejection; `registerNodes()` then refetches.

## Review Focus

- The change touches `src/scripts/app.ts`, which is scraped into `window.comfyAPI`, so `comfy_api_surface` is flagged. No export changed: `nodeDefsPrefetch` is a private field and `getNodeDefs`/`registerNodes` keep their signatures. `startNodeDefsPrefetch` is a new public method on the app instance.
- This is a small scheduling win, not a large one. On a warm connection the fetch it overlaps is short; the payoff grows with backend latency but total boot is dominated by other serial work.

## QA

- [x] Unit: 7 passing in `app.registerNodes.test.ts` (reuse without refetch, refetch on failed/absent prefetch, direct fetch, clear-then-refetch, prefetch stores defs, prefetch swallows a rejection into undefined, failed-prefetch-then-refetch). The existing `app.getNodeDefs.test.ts` and `app.test.ts` still pass.
- [x] Real backend: `/object_info` is requested exactly once per boot across 4 runs (the prefetch is consumed, no double fetch). Evidence posted as a PR comment.
- [x] Mutation kill proven manually: dropping the prefetch `.catch` fails two of the tests. Evidence posted as a PR comment.
- [ ] The `/devshop` mutation gate could not run green on this diff for a reason unrelated to it: its test selection for `app.ts` (a heavily imported module) pulls in `browser_tests/tests/nodeBadge.spec.ts`, a Playwright spec that Vitest excludes, so the baseline run exits non-zero before any mutant is evaluated. The invariant it would check is proven by the manual mutation above. Flagged separately for the tooling.
- Not covered: no e2e for `setup()` boot ordering; the fetch-count and prefetch behavior are proven by unit tests plus the real-backend request-count probe.
