### PR TITLE
Test unsubscribed local credit purchase flow

### DIFF
--- a/browser_tests/fixtures/localAuthFixture.ts
+++ b/browser_tests/fixtures/localAuthFixture.ts
@@ -1,23 +1,26 @@
 import { test as base } from '@playwright/test'
 
+import type { operations } from '@/types/comfyRegistryTypes'
 import { ComfyPage } from '@e2e/fixtures/ComfyPage'
 import {
   createSubscriptionHelper,
-  withFreeTier
+  withUnsubscribed
 } from '@e2e/fixtures/helpers/SubscriptionHelper'
 import { mockWorkspace, workspace } from '@e2e/fixtures/utils/workspaceMocks'
 
 const LOCAL_AUTH_BOOT_TIMEOUT = 45_000
+type CreateCustomerResponse =
+  operations['createCustomer']['responses']['201']['content']['application/json']
 
 /**
- * Boots the local (non-Cloud) build as a logged-in Free-tier workspace owner.
+ * Boots the local (non-Cloud) build as a logged-in unsubscribed workspace owner.
  *
  * Firebase auth must be seeded via `ComfyPage.cloudAuth` *before* the app's
  * first navigation: seeding it against an already-booted page races the
  * app's own Firebase listener and can hang indefinitely. `comfyPageFixture`
  * seeds pre-boot for `@cloud`- and `@auth`-tagged tests. Prefer tagging a
  * spec `@auth` over using this fixture; it exists for specs that also need
- * the Free-tier subscription mocks and the bespoke boot below.
+ * the unsubscribed billing mocks and the bespoke boot below.
  */
 export const localAuthFixture = base.extend<{ comfyPage: ComfyPage }>({
   comfyPage: async ({ page, request }, use, testInfo) => {
@@ -34,7 +37,16 @@ export const localAuthFixture = base.extend<{ comfyPage: ComfyPage }>({
 
     await comfyPage.cloudAuth.mockAuth()
     await mockWorkspace(page, workspace('personal', 'owner'), [])
-    const subscriptionHelper = createSubscriptionHelper(page, withFreeTier())
+    await page.route('**/customers', (route) =>
+      route.fulfill({
+        status: 201,
+        json: { id: 'test-user-e2e' } satisfies CreateCustomerResponse
+      })
+    )
+    const subscriptionHelper = createSubscriptionHelper(
+      page,
+      withUnsubscribed()
+    )
     await subscriptionHelper.mock()
 
     await page.evaluate((id) => {

--- a/browser_tests/tests/localCreditsNoSubscribeUi.spec.ts
+++ b/browser_tests/tests/localCreditsNoSubscribeUi.spec.ts
@@ -1,32 +1,36 @@
 import { expect } from '@playwright/test'
 
+import type { operations } from '@/types/comfyRegistryTypes'
 import { TopUpCreditsDialog } from '@e2e/fixtures/components/TopUpCreditsDialog'
 import { localAuthFixture as test } from '@e2e/fixtures/localAuthFixture'
 import { TestIds } from '@e2e/fixtures/selectors'
 
+type CreditPurchaseResponse =
+  operations['InitiateCreditPurchase']['responses']['201']['content']['application/json']
+
 /**
- * Regression coverage for a local/non-cloud dead-click: a logged-in Free-tier
- * user on a local (non-Cloud) distribution must never see subscribe/upgrade
- * UI in the credits surfaces, and the "Add credits" purchase flow must keep
- * working no matter which of those surfaces was visited beforehand.
+ * Regression coverage for a local/non-cloud dead-click: an unsubscribed user
+ * on a local (non-Cloud) distribution must never see subscribe/upgrade UI in
+ * the credits surfaces, and the "Add credits" purchase flow must keep working
+ * no matter which of those surfaces was visited beforehand.
  *
  * Every other credits/billing e2e spec (creditsTile.spec.ts,
  * currentUserPopoverCredits.spec.ts, billingFacadeConsumers.spec.ts,
  * subscription.spec.ts) is tagged `@cloud` and only runs against the
  * Cloud-distribution build with an always-active paid subscription fixture,
  * so none of them ever exercise the OSS/local build (`isCloud === false`)
- * with a logged-in Free-tier account — the exact combination that trips
+ * with a logged-in unsubscribed account — the exact combination that trips
  * this bug. This spec intentionally carries no `@cloud` tag so it runs in
  * the default (local) `chromium` project instead.
  */
 test.describe('Local credits surfaces hide subscribe UI (non-cloud)', () => {
-  test('opens Plan & Credits and keeps "Add credits" working', async ({
+  test('lets an unsubscribed user add credits from local billing surfaces', async ({
     comfyPage
   }) => {
     const page = comfyPage.page
     const topUpDialog = new TopUpCreditsDialog(page)
 
-    // 1. Profile popover: a Free-tier local user gets "Add credits", never
+    // 1. Profile popover: an unsubscribed local user gets "Add credits", never
     //    "Upgrade to add credits" — subscribing is a Cloud-only concept.
     await page.getByTestId(TestIds.user.currentUserButton).click()
     let popover = page.getByTestId(TestIds.user.currentUserPopover)
@@ -70,7 +74,26 @@ test.describe('Local credits surfaces hide subscribe UI (non-cloud)', () => {
     await expect(settingsAddCredits).toBeVisible()
     await settingsAddCredits.click()
     await expect(topUpDialog.heading).toBeVisible()
-    await topUpDialog.close()
+
+    await page.route('**/customers/credit', (route) =>
+      route.fulfill({
+        status: 201,
+        json: {
+          checkout_url: 'https://checkout.stripe.com/mock'
+        } satisfies CreditPurchaseResponse
+      })
+    )
+    const [purchaseRequest] = await Promise.all([
+      page.waitForRequest('**/customers/credit'),
+      topUpDialog.root
+        .getByRole('button', { name: 'Continue to payment' })
+        .click()
+    ])
+    expect(purchaseRequest.postDataJSON()).toEqual({
+      amount_micros: 50_000_000,
+      currency: 'usd'
+    })
+    await expect(topUpDialog.root).toBeHidden()
 
     await settingsDialog.close()
 

--- a/browser_tests/tests/localCreditsNoSubscribeUi.spec.ts
+++ b/browser_tests/tests/localCreditsNoSubscribeUi.spec.ts
@@ -8,6 +8,8 @@ import { TestIds } from '@e2e/fixtures/selectors'
 type CreditPurchaseResponse =
   operations['InitiateCreditPurchase']['responses']['201']['content']['application/json']
 
+const MOCK_CHECKOUT_URL = 'https://checkout.stripe.com/mock'
+
 /**
  * Regression coverage for a local/non-cloud dead-click: an unsubscribed user
  * on a local (non-Cloud) distribution must never see subscribe/upgrade UI in
@@ -24,6 +26,15 @@ type CreditPurchaseResponse =
  * the default (local) `chromium` project instead.
  */
 test.describe('Local credits surfaces hide subscribe UI (non-cloud)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => {
+      window.open = (url) => {
+        document.documentElement.dataset.openedUrl = String(url)
+        return window
+      }
+    })
+  })
+
   test('lets an unsubscribed user add credits from local billing surfaces', async ({
     comfyPage
   }) => {
@@ -79,7 +90,7 @@ test.describe('Local credits surfaces hide subscribe UI (non-cloud)', () => {
       route.fulfill({
         status: 201,
         json: {
-          checkout_url: 'https://checkout.stripe.com/mock'
+          checkout_url: MOCK_CHECKOUT_URL
         } satisfies CreditPurchaseResponse
       })
     )
@@ -93,6 +104,9 @@ test.describe('Local credits surfaces hide subscribe UI (non-cloud)', () => {
       amount_micros: 50_000_000,
       currency: 'usd'
     })
+    await expect
+      .poll(() => page.locator('html').getAttribute('data-opened-url'))
+      .toBe(MOCK_CHECKOUT_URL)
     await expect(topUpDialog.root).toBeHidden()
 
     await settingsDialog.close()


### PR DESCRIPTION
## Summary

Correct the Local/Desktop billing E2E precondition so finding #11 is exercised as an unsubscribed user, then verify that the user can open **Plan & Credits** and complete the **Add credits** request flow.

The product routing fix and real-app UI change were merged in #15793; this PR is its test-only follow-up.

## Root Cause

`localAuthFixture` used `withFreeTier()`, which returns an active Free-tier subscription (`is_active: true`, `subscription_tier: 'FREE'`). Finding #11 concerns a logged-in Local/Desktop user with no active subscription (`is_active: false`).

Those are distinct backend states. Billing UI eligibility is derived from the mocked subscription response, including `canTopUp`, so the previous fixture could pass while exercising an active subscriber rather than the reported unsubscribed user story. It therefore did not provide deterministic regression coverage for the failure condition fixed in #15793.

## Fix

- Replace `withFreeTier()` with `withUnsubscribed()` so the fixture returns the correct backend state: `is_active: false`, `subscription_tier: 'FREE'`.
- Mock customer provisioning for that unsubscribed state using the generated Registry API response type.
- Update the E2E name and documentation to describe the actual precondition.
- Extend the user story beyond opening the dialog: assert the exact `POST /customers/credit` payload and verify the top-up dialog closes after the accepted purchase request.

The E2E now covers the Local profile popover, the routed Plan & Credits surface, absence of Cloud-only subscription actions, and Add credits from both surfaces. Immediate and polled top-up completion routing remain covered by the focused tests merged in #15793.

## AS IS — wrong fixture precondition and legacy destination

The fixture modeled an active Free-tier subscriber, not an unsubscribed Local/Desktop user. Under the original product behavior, **Plans and credits** opened the legacy combined Credits + Activity page:

![AS IS — legacy Local Credits page](https://ampcode.com/user-content/artifacts/ac9a166d32bfb27893e030609676f1d766bac946ebe230fab433a345e644a2a3-file.png)

## TO BE — unsubscribed precondition and Plan & Credits destination

The fixture now models the no-active-subscription state from finding #11, and the user story verifies the tabbed Plan & Credits page plus a working Add credits request:

![TO BE — tabbed Local Plan and Credits page](https://ampcode.com/user-content/artifacts/2cd756894e7c93336f9827949b3d0f580ebaaa280f14b8cfb83eb5971bee6fa4-file.png)

## Validation

- `pnpm exec oxfmt --check browser_tests/fixtures/localAuthFixture.ts browser_tests/tests/localCreditsNoSubscribeUi.spec.ts`
- `pnpm exec eslint browser_tests/fixtures/localAuthFixture.ts browser_tests/tests/localCreditsNoSubscribeUi.spec.ts`
- `pnpm typecheck:browser`
- `git diff --check`
- CI browser test matrix passed, including local Chromium shards

## Dependencies

None. Based on `main` after #15793.
