### PR TITLE
feat(website): agent readiness - markdown negotiation, OpenAPI at /openapi.json, recoverable 404

### DIFF
--- a/apps/website/e2e/agent-readiness.spec.ts
+++ b/apps/website/e2e/agent-readiness.spec.ts
@@ -1,0 +1,71 @@
+import { expect } from '@playwright/test'
+
+import { test } from './fixtures/blockExternalMedia'
+
+test.describe('Agent readiness — markdown twins @smoke', () => {
+  for (const path of ['/index.md', '/api.md', '/404.md']) {
+    test(`${path} is served with markdown content`, async ({ page }) => {
+      const response = await page.request.get(path)
+      expect(response.status()).toBe(200)
+      const body = await response.text()
+      expect(body.startsWith('# ')).toBe(true)
+      expect(body).toContain('https://comfy.org/')
+    })
+  }
+
+  test('the 404 twin maps agents back to the machine surfaces', async ({
+    page
+  }) => {
+    const body = await (await page.request.get('/404.md')).text()
+    expect(body).toContain('https://comfy.org/llms.txt')
+    expect(body).toContain('https://comfy.org/sitemap-index.xml')
+    expect(body).toContain('https://comfy.org/index.md')
+  })
+})
+
+test.describe('Agent readiness — 404 recovery @smoke', () => {
+  test('unknown paths return 404 with recovery links', async ({ page }) => {
+    const response = await page.goto('/this-path-does-not-exist')
+    expect(response?.status()).toBe(404)
+
+    const nav = page.getByRole('navigation', {
+      name: 'Places to go from here'
+    })
+    await expect(nav).toBeVisible()
+    await expect(nav.getByRole('link', { name: 'llms.txt' })).toHaveAttribute(
+      'href',
+      '/llms.txt'
+    )
+    await expect(nav.getByRole('link', { name: 'Site map' })).toHaveAttribute(
+      'href',
+      '/sitemap-index.xml'
+    )
+    await expect(
+      nav.getByRole('link', { name: 'OpenAPI spec' })
+    ).toHaveAttribute('href', '/openapi.json')
+  })
+})
+
+test.describe('Agent readiness — homepage outline @smoke', () => {
+  test('renders one h1 and a full h2 section outline without JS state', async ({
+    page
+  }) => {
+    await page.goto('/')
+
+    await expect(page.locator('h1')).toHaveCount(1)
+
+    for (const name of [
+      'Latest model releases',
+      'How ComfyUI works',
+      'Industries that create with ComfyUI',
+      'Get started in minutes'
+    ]) {
+      await expect(page.getByRole('heading', { name, level: 2 })).toBeAttached()
+    }
+
+    // Model slide titles nest under the section heading as h3s.
+    await expect(
+      page.getByRole('heading', { name: 'Seedance 2.5', level: 3 })
+    ).toBeAttached()
+  })
+})

--- a/apps/website/middleware.ts
+++ b/apps/website/middleware.ts
@@ -1,0 +1,22 @@
+/**
+ * Vercel Edge Middleware: Accept-header content negotiation for agents
+ * (acceptmarkdown.com contract). Paths ending in a known file extension
+ * (assets, `.md` twins, `llms.txt`, sitemaps, `/openapi.json`) are served
+ * untouched by the static layer; matching by extension rather than "any dot"
+ * keeps dotted page routes like /seedance-2.5 in the negotiation surface.
+ * Must stay in sync with the Vary: Accept header rule in vercel.json.
+ */
+
+import { negotiateAgentContent } from './src/lib/content-negotiation'
+
+export const config = {
+  matcher: [
+    '/((?!.*\\.(?:md|txt|xml|json|ico|png|jpg|jpeg|webp|avif|gif|svg|css|js|mjs|map|woff|woff2|ttf|otf|eot|mp4|webm|vtt|pdf|zip|webmanifest)$).*)'
+  ]
+}
+
+export default function middleware(
+  request: Request
+): Promise<Response | undefined> {
+  return negotiateAgentContent(request)
+}

--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -18,7 +18,8 @@
     "ashby:refresh-snapshot": "tsx ./scripts/refresh-ashby-snapshot.ts",
     "cloud-nodes:refresh-snapshot": "tsx ./scripts/refresh-cloud-nodes-snapshot.ts",
     "generate:models": "tsx ./scripts/generate-models.ts",
-    "validate:jsonld": "tsx ./scripts/validate-jsonld.ts"
+    "validate:jsonld": "tsx ./scripts/validate-jsonld.ts",
+    "agent:check": "tsx ./scripts/agent-readiness-check.ts"
   },
   "dependencies": {
     "@astrojs/sitemap": "catalog:",

--- a/apps/website/public/llms.txt
+++ b/apps/website/public/llms.txt
@@ -11,6 +11,8 @@ The Comfy ecosystem spans four surfaces:
 
 Studios building with Comfy include Series Entertainment, Moment Factory, Open Story Movement, and Ubisoft (La Forge). Use cases concentrate in VFX & animation, advertising & creative studios, gaming, and eCommerce/fashion.
 
+Agent access: the homepage and /api honor `Accept: text/markdown` content negotiation, with markdown twins at https://comfy.org/index.md and https://comfy.org/api.md. Nonexistent paths return HTTP 404 — with a markdown body when markdown is requested. The Comfy API is described by the OpenAPI 3.0 spec at https://comfy.org/openapi.json, and every docs.comfy.org page serves markdown when you append `.md` to its URL.
+
 ## Product
 
 - [Homepage](https://comfy.org/): Overview of Comfy and the four product surfaces (Local, Cloud, API, Enterprise).
@@ -35,7 +37,11 @@ Studios building with Comfy include Series Entertainment, Moment Factory, Open S
 
 ## Developers and Documentation
 
-- [ComfyUI Docs](https://docs.comfy.org/): Official documentation for installing, configuring, and extending ComfyUI.
+- [ComfyUI Docs](https://docs.comfy.org/): Official documentation for installing, configuring, and extending ComfyUI. Markdown index at https://docs.comfy.org/llms.txt.
+- [Comfy API OpenAPI spec](https://comfy.org/openapi.json): OpenAPI 3.0 specification for api.comfy.org — every operation typed, with unique operationIds. Also served at https://api.comfy.org/openapi.
+- [Comfy Cloud API overview](https://docs.comfy.org/development/cloud/overview): Trigger ComfyUI workflows from your own code on Comfy Cloud.
+- [Comfy SDKs](https://docs.comfy.org/development/api-development/sdks): Python (`pip install comfy-sdk`) and TypeScript (`npm install @comfyorg/sdk`) clients for the Comfy API.
+- [Comfy MCP](https://comfy.org/mcp/): Drive ComfyUI from agents over MCP; server endpoint at https://cloud.comfy.org/mcp.
 - [ComfyUI on GitHub](https://github.com/comfyanonymous/ComfyUI): Source repository for the open-source ComfyUI runtime.
 - [Comfy-Org on GitHub](https://github.com/Comfy-Org): Organization-wide repositories — frontend, registry, manager, docs, and tooling.
 - [Comfy Registry](https://registry.comfy.org/): Public registry of ComfyUI custom nodes and extensions, with versioning and search.

--- a/apps/website/scripts/agent-readiness-check.ts
+++ b/apps/website/scripts/agent-readiness-check.ts
@@ -1,0 +1,135 @@
+/**
+ * Agent-readiness probe for a deployed comfy.org website origin. The
+ * negotiation checks exercise Vercel Edge Middleware, so point this at a
+ * deployment (preview or production), not `astro preview`.
+ *
+ *   pnpm agent:check https://<deployment>.vercel.app
+ */
+
+const base = process.argv[2]?.replace(/\/$/, '')
+if (!base) {
+  console.error('Usage: pnpm agent:check <baseUrl>')
+  process.exit(2)
+}
+
+let failures = 0
+
+function report(name: string, ok: boolean, detail?: string) {
+  process.stdout.write(
+    `${ok ? 'PASS' : 'FAIL'}  ${name}${ok ? '' : ` — ${detail}`}\n`
+  )
+  if (!ok) failures++
+}
+
+async function probe(path: string, init?: RequestInit) {
+  const res = await fetch(`${base}${path}`, { redirect: 'manual', ...init })
+  const body = init?.method === 'HEAD' ? '' : await res.text()
+  return { res, body }
+}
+
+const md = { headers: { accept: 'text/markdown' } }
+
+{
+  const { res } = await probe('/some-path-that-does-not-exist')
+  report(
+    '404 status for unknown paths',
+    res.status === 404,
+    `got ${res.status}`
+  )
+}
+{
+  const { res, body } = await probe('/nonexistent-agent-check', md)
+  report(
+    '404 markdown body for agents',
+    res.status === 404 &&
+      (res.headers.get('content-type') ?? '').includes('text/markdown') &&
+      body.includes('llms.txt'),
+    `status ${res.status}, type ${res.headers.get('content-type')}`
+  )
+}
+for (const path of ['/', '/api']) {
+  const { res, body } = await probe(path, md)
+  report(
+    `markdown negotiation on ${path}`,
+    res.status === 200 &&
+      (res.headers.get('content-type') ?? '').includes('text/markdown') &&
+      (res.headers.get('vary') ?? '').includes('Accept') &&
+      body.startsWith('# '),
+    `status ${res.status}, type ${res.headers.get('content-type')}, vary ${res.headers.get('vary')}`
+  )
+}
+{
+  const { res } = await probe('/', { headers: { accept: 'text/html' } })
+  report(
+    'html negotiation keeps Vary: Accept',
+    (res.headers.get('content-type') ?? '').includes('text/html') &&
+      (res.headers.get('vary') ?? '').includes('Accept'),
+    `type ${res.headers.get('content-type')}, vary ${res.headers.get('vary')}`
+  )
+}
+{
+  const { res } = await probe('/', {
+    headers: { accept: 'text/html, text/markdown;q=0.5' }
+  })
+  report(
+    'q-values honored (html preferred)',
+    (res.headers.get('content-type') ?? '').includes('text/html'),
+    `type ${res.headers.get('content-type')}`
+  )
+}
+{
+  const { res } = await probe('/', { headers: { accept: 'application/pdf' } })
+  report('406 for unsupported Accept', res.status === 406, `got ${res.status}`)
+}
+for (const path of ['/index.md', '/api.md', '/404.md']) {
+  const { res } = await probe(path)
+  report(
+    `twin ${path} served as markdown`,
+    res.status === 200 &&
+      (res.headers.get('content-type') ?? '').includes('text/markdown'),
+    `status ${res.status}, type ${res.headers.get('content-type')}`
+  )
+}
+{
+  const { res, body } = await probe('/openapi.json')
+  let ok = res.status === 200
+  if (ok) {
+    try {
+      const spec = JSON.parse(body)
+      ok = Boolean(spec.openapi) && Object.keys(spec.paths ?? {}).length > 100
+    } catch {
+      ok = false
+    }
+  }
+  report('OpenAPI spec at /openapi.json', ok, `status ${res.status}`)
+}
+for (const [path, target] of [
+  ['/developers', '/api'],
+  ['/docs', 'https://docs.comfy.org/']
+]) {
+  const { res } = await probe(path)
+  report(
+    `${path} redirects to ${target}`,
+    res.status >= 300 &&
+      res.status < 400 &&
+      (res.headers.get('location') ?? '').includes(target),
+    `status ${res.status}, location ${res.headers.get('location')}`
+  )
+}
+{
+  const { res, body } = await probe('/llms.txt')
+  report(
+    'llms.txt lists developer surfaces',
+    res.status === 200 &&
+      body.includes('/openapi.json') &&
+      body.includes('text/markdown'),
+    `status ${res.status}`
+  )
+}
+
+process.stdout.write(
+  failures === 0 ? '\nAll checks passed.\n' : `\n${failures} failed.\n`
+)
+process.exit(failures === 0 ? 0 : 1)
+
+export {}

--- a/apps/website/src/components/blocks/FeaturedCarousel02.vue
+++ b/apps/website/src/components/blocks/FeaturedCarousel02.vue
@@ -50,11 +50,14 @@ const DEFAULT_AUTOPLAY_MS = 5000
 const {
   locale = 'en',
   slides,
-  class: className
+  class: className,
+  headingLevel = 'h2'
 } = defineProps<{
   locale?: Locale
   slides: FeaturedSplitSlide[]
   class?: HTMLAttributes['class']
+  /** Slide-title heading tag, so callers can nest slides under a section h2. */
+  headingLevel?: 'h2' | 'h3'
 }>()
 
 const activeIndex = ref(0)
@@ -231,11 +234,12 @@ useCarouselAutoplay({
             >
               {{ slide.eyebrow }}
             </p>
-            <h2
+            <component
+              :is="headingLevel"
               class="mt-7 max-w-200 text-3xl leading-[135%] font-medium text-primary-comfy-canvas"
             >
               {{ slide.title }}
-            </h2>
+            </component>
             <p
               v-if="slide.body"
               class="mt-5 max-w-160 text-[17px] leading-[160%] font-light text-primary-comfy-canvas"

--- a/apps/website/src/components/home/ModelReleaseSection.test.ts
+++ b/apps/website/src/components/home/ModelReleaseSection.test.ts
@@ -10,10 +10,13 @@ describe('ModelReleaseSection', () => {
   it('renders the four model slides with locale-aware CTAs', () => {
     render(ModelReleaseSection)
 
-    expect(screen.getByText('Seedance 2.5', { selector: 'h2' })).toBeTruthy()
-    expect(screen.getByText('LTX 2.5', { selector: 'h2' })).toBeTruthy()
-    expect(screen.getByText('Wan Animate 2', { selector: 'h2' })).toBeTruthy()
-    expect(screen.getByText('MiniMax H3', { selector: 'h2' })).toBeTruthy()
+    expect(
+      screen.getByText('Latest model releases', { selector: 'h2' })
+    ).toBeTruthy()
+    expect(screen.getByText('Seedance 2.5', { selector: 'h3' })).toBeTruthy()
+    expect(screen.getByText('LTX 2.5', { selector: 'h3' })).toBeTruthy()
+    expect(screen.getByText('Wan Animate 2', { selector: 'h3' })).toBeTruthy()
+    expect(screen.getByText('MiniMax H3', { selector: 'h3' })).toBeTruthy()
 
     const explore = screen.getByRole('link', { name: 'Explore Seedance 2.5' })
     expect(explore.getAttribute('href')).toBe('/seedance-2.5')

--- a/apps/website/src/components/home/ModelReleaseSection.vue
+++ b/apps/website/src/components/home/ModelReleaseSection.vue
@@ -35,5 +35,13 @@ const slides: FeaturedSplitSlide[] = modelReleaseSlides.map((slide) => ({
 </script>
 
 <template>
-  <FeaturedCarousel02 :locale :slides class="py-14 md:py-20" />
+  <section>
+    <h2 class="sr-only">{{ t('modelRelease.heading', locale) }}</h2>
+    <FeaturedCarousel02
+      :locale
+      :slides
+      heading-level="h3"
+      class="py-14 md:py-20"
+    />
+  </section>
 </template>

--- a/apps/website/src/components/home/ProductShowcaseSection.vue
+++ b/apps/website/src/components/home/ProductShowcaseSection.vue
@@ -61,11 +61,12 @@ watch(activeIndex, (current, previous) => {
   >
     <!-- Section header -->
     <div class="flex flex-col items-center text-center">
+      <h2 class="sr-only">{{ t('showcase.heading', locale) }}</h2>
       <NodeBadge :segments="badgeSegments" segment-class="" />
-      <p class="text-primary-comfy-canvas mt-12 max-w-xl text-sm/relaxed">
+      <p class="mt-12 max-w-xl text-sm/relaxed text-primary-comfy-canvas">
         {{ t('showcase.subtitle1', locale) }}
       </p>
-      <p class="text-primary-comfy-canvas mt-4 max-w-xl text-sm/relaxed">
+      <p class="mt-4 max-w-xl text-sm/relaxed text-primary-comfy-canvas">
         {{ t('showcase.subtitle2', locale) }}
       </p>
     </div>
@@ -83,7 +84,7 @@ watch(activeIndex, (current, previous) => {
           "
         >
           <div
-            class="bg-primary-comfy-ink relative size-full overflow-hidden rounded-[calc(2.5rem-2px)]"
+            class="relative size-full overflow-hidden rounded-[calc(2.5rem-2px)] bg-primary-comfy-ink"
           >
             <video
               v-for="(feature, i) in features"
@@ -118,7 +119,7 @@ watch(activeIndex, (current, previous) => {
               class="animate-border-spin size-full overflow-hidden rounded-4xl p-0.5"
             >
               <div
-                class="bg-primary-comfy-ink size-full overflow-hidden rounded-[calc(2rem-2px)]"
+                class="size-full overflow-hidden rounded-[calc(2rem-2px)] bg-primary-comfy-ink"
               >
                 <video
                   :src="feature.video"

--- a/apps/website/src/components/home/UseCaseSection.vue
+++ b/apps/website/src/components/home/UseCaseSection.vue
@@ -143,7 +143,7 @@ useParallax([leftImgRef], {
 <template>
   <section
     ref="sectionRef"
-    class="bg-primary-comfy-ink relative isolate overflow-x-clip pt-20 lg:h-[calc(100vh+60px)] lg:py-24"
+    class="relative isolate overflow-x-clip bg-primary-comfy-ink pt-20 lg:h-[calc(100vh+60px)] lg:py-24"
   >
     <svg class="absolute size-0" width="0" height="0" aria-hidden="true">
       <defs>
@@ -165,11 +165,11 @@ useParallax([leftImgRef], {
     >
       <!-- Label row -->
       <div class="relative z-20 col-span-full flex justify-center py-4">
-        <p
-          class="text-primary-comfy-yellow from-primary-comfy-ink to-primary-comfy-ink/10 shrink grow-0 bg-linear-to-b text-center text-sm font-bold tracking-widest uppercase lg:text-base"
+        <h2
+          class="text-primary-comfy-yellow shrink grow-0 bg-linear-to-b from-primary-comfy-ink to-primary-comfy-ink/10 text-center text-sm font-bold tracking-widest uppercase lg:text-base"
         >
           {{ t('useCase.label', locale) }}
-        </p>
+        </h2>
       </div>
 
       <!-- Left blob rail -->
@@ -227,7 +227,7 @@ useParallax([leftImgRef], {
       <div
         class="col-span-full mt-8 flex flex-col items-center gap-8 px-4 lg:mt-[clamp(0.25rem,1vh,2rem)] lg:gap-[clamp(0.25rem,1vh,2rem)]"
       >
-        <p class="text-primary-warm-gray max-w-md text-center text-base">
+        <p class="max-w-md text-center text-base text-primary-warm-gray">
           {{ t('useCase.body', locale) }}
         </p>
 

--- a/apps/website/src/config/routes.ts
+++ b/apps/website/src/config/routes.ts
@@ -95,7 +95,7 @@ export const externalLinks = {
   cloudStatus: 'https://status.comfy.org',
   discord: 'https://discord.com/invite/comfyorg',
   docs: 'https://docs.comfy.org/',
-  docsApi: 'https://docs.comfy.org/development/cloud/overview#quick-start',
+  docsApi: 'https://docs.comfy.org/development/cloud/overview',
   comfyMcpRepo: 'https://github.com/Comfy-Org/comfy-mcp',
   docsMcp: 'https://docs.comfy.org/agent-tools/mcp',
   docsMcpLocal:

--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -144,6 +144,10 @@ const translations = {
   },
 
   // Model release carousel (home page)
+  'modelRelease.heading': {
+    en: 'Latest model releases',
+    'zh-CN': '最新模型发布'
+  },
   'modelRelease.eyebrow': {
     en: 'New Model Release',
     'zh-CN': '新模型发布'
@@ -256,6 +260,10 @@ const translations = {
   },
   'showcase.badgeHow': { en: 'HOW', 'zh-CN': '了解' },
   'showcase.badgeWorks': { en: 'WORKS', 'zh-CN': '运行方式' },
+  'showcase.heading': {
+    en: 'How ComfyUI works',
+    'zh-CN': 'ComfyUI 如何运作'
+  },
 
   // UseCaseSection
   'useCase.label': {
@@ -429,6 +437,36 @@ const translations = {
   'buildWhat.subtitle': {
     en: "Comfy gives you the building blocks to create workflows nobody's imagined yet — and share them with everyone.",
     'zh-CN': 'Comfy 为您提供构建模块，创造出前所未有的工作流——并与所有人分享。'
+  },
+
+  // 404 page recovery links
+  'notFound.hint': {
+    en: 'This path does not exist. These do:',
+    'zh-CN': '此路径不存在。下面这些存在：'
+  },
+  'notFound.home': {
+    en: 'Home',
+    'zh-CN': '首页'
+  },
+  'notFound.download': {
+    en: 'Download',
+    'zh-CN': '下载'
+  },
+  'notFound.sitemap': {
+    en: 'Site map',
+    'zh-CN': '站点地图'
+  },
+  'notFound.openapi': {
+    en: 'OpenAPI spec',
+    'zh-CN': 'OpenAPI 规范'
+  },
+  'notFound.llms': {
+    en: 'llms.txt',
+    'zh-CN': 'llms.txt'
+  },
+  'notFound.linksLabel': {
+    en: 'Places to go from here',
+    'zh-CN': '可以前往的页面'
   },
 
   // API – HeroSection

--- a/apps/website/src/lib/accept.test.ts
+++ b/apps/website/src/lib/accept.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest'
+
+import { negotiate, parseAccept } from './accept'
+
+const SUPPORTED = ['text/html', 'text/markdown'] as const
+
+describe('parseAccept', () => {
+  it('parses types, parameters, and q-values', () => {
+    expect(parseAccept('text/markdown, text/html;q=0.8, */*;q=0.1')).toEqual([
+      { type: 'text', subtype: 'markdown', q: 1 },
+      { type: 'text', subtype: 'html', q: 0.8 },
+      { type: '*', subtype: '*', q: 0.1 }
+    ])
+  })
+
+  it('lowercases type names and tolerates whitespace', () => {
+    expect(parseAccept(' TEXT/Markdown ;  q=0.5 ')).toEqual([
+      { type: 'text', subtype: 'markdown', q: 0.5 }
+    ])
+  })
+
+  it('skips entries without a slash', () => {
+    expect(parseAccept('gibberish, text/html')).toEqual([
+      { type: 'text', subtype: 'html', q: 1 }
+    ])
+  })
+
+  it('clamps out-of-range q and ignores malformed q', () => {
+    expect(parseAccept('text/html;q=2')[0]?.q).toBe(1)
+    expect(parseAccept('text/html;q=-1')[0]?.q).toBe(0)
+    expect(parseAccept('text/html;q=abc')[0]?.q).toBe(1)
+    expect(parseAccept('text/html;q=')[0]?.q).toBe(1)
+  })
+
+  it('does not split on delimiters inside quoted parameter values', () => {
+    expect(parseAccept('text/html;q=0.5;x="a, text/markdown, b"')).toEqual([
+      { type: 'text', subtype: 'html', q: 0.5 }
+    ])
+    expect(parseAccept('text/html;x="a;q=0"')[0]?.q).toBe(1)
+  })
+})
+
+// Test vectors from acceptmarkdown.com/guides/accept-parsing.
+describe('negotiate', () => {
+  it('serves markdown for a bare text/markdown', () => {
+    expect(negotiate('text/markdown', SUPPORTED).choice).toBe('text/markdown')
+  })
+
+  it('serves markdown when it outranks html by q', () => {
+    expect(negotiate('text/markdown, text/html;q=0.8', SUPPORTED).choice).toBe(
+      'text/markdown'
+    )
+  })
+
+  it('serves html for a bare text/html', () => {
+    expect(negotiate('text/html', SUPPORTED).choice).toBe('text/html')
+  })
+
+  it('respects q=0 as explicit rejection', () => {
+    expect(negotiate('text/markdown;q=0, text/html', SUPPORTED).choice).toBe(
+      'text/html'
+    )
+  })
+
+  it('returns null when the only match is rejected', () => {
+    expect(negotiate('text/markdown;q=0', ['text/markdown']).choice).toBeNull()
+  })
+
+  it('a specific q=0 overrides a wildcard for that type', () => {
+    const result = negotiate('text/markdown;q=0, */*', SUPPORTED)
+    expect(result.scores['text/markdown']).toBe(0)
+    expect(result.choice).toBe('text/html')
+  })
+
+  it('missing header means no constraint: serve the default', () => {
+    expect(negotiate(null, SUPPORTED).choice).toBe('text/html')
+  })
+
+  it('*/* serves the default', () => {
+    expect(negotiate('*/*', SUPPORTED).choice).toBe('text/html')
+  })
+
+  it('text/* ties resolve to the server-preferred type', () => {
+    expect(negotiate('text/*', SUPPORTED).choice).toBe('text/html')
+  })
+
+  it('a real Chrome header serves html, not markdown', () => {
+    const chrome =
+      'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8'
+    expect(negotiate(chrome, SUPPORTED).choice).toBe('text/html')
+  })
+
+  it('an empty header (present but blank) is unsatisfiable', () => {
+    expect(negotiate('', SUPPORTED).choice).toBeNull()
+  })
+
+  it('unsupported-only headers are unsatisfiable', () => {
+    expect(negotiate('application/pdf', SUPPORTED).choice).toBeNull()
+  })
+
+  it('reports per-type scores', () => {
+    const { scores } = negotiate('text/markdown, text/html;q=0.8', SUPPORTED)
+    expect(scores).toEqual({ 'text/html': 0.8, 'text/markdown': 1 })
+  })
+})

--- a/apps/website/src/lib/accept.ts
+++ b/apps/website/src/lib/accept.ts
@@ -1,0 +1,113 @@
+/**
+ * Accept-header negotiation (RFC 9110 §12.5.1) for the HTML/markdown twin
+ * surface. Ranking: q-value first, ties broken by specificity (exact type >
+ * type wildcard > catch-all), and q=0 is an explicit rejection — a more
+ * specific q=0 entry overrides a wildcard's positive q for that type.
+ */
+
+export interface AcceptEntry {
+  type: string
+  subtype: string
+  q: number
+}
+
+/** Split on a delimiter, but not inside RFC 9110 quoted-string values. */
+function splitOutsideQuotes(input: string, delimiter: string): string[] {
+  const pieces: string[] = []
+  let current = ''
+  let inQuotes = false
+  for (let i = 0; i < input.length; i++) {
+    const char = input[i]
+    if (inQuotes && char === '\\' && i + 1 < input.length) {
+      current += char + input[i + 1]
+      i++
+      continue
+    }
+    if (char === '"') inQuotes = !inQuotes
+    if (char === delimiter && !inQuotes) {
+      pieces.push(current)
+      current = ''
+    } else {
+      current += char
+    }
+  }
+  pieces.push(current)
+  return pieces
+}
+
+export function parseAccept(header: string): AcceptEntry[] {
+  const entries: AcceptEntry[] = []
+  for (const raw of splitOutsideQuotes(header, ',')) {
+    const parts = splitOutsideQuotes(raw.trim(), ';')
+    const range = parts[0]?.trim().toLowerCase()
+    if (!range || !range.includes('/')) continue
+    const [type, subtype] = range.split('/', 2)
+    if (!type || !subtype) continue
+    let q = 1
+    for (const param of parts.slice(1)) {
+      const [name, value] = param.split('=', 2).map((piece) => piece.trim())
+      if (name?.toLowerCase() !== 'q' || !value) continue
+      const parsed = Number(value)
+      // A malformed q-value is ignored rather than treated as 0: serving a
+      // spec-correct default beats returning 406 to a sloppy client.
+      if (Number.isFinite(parsed)) q = Math.min(Math.max(parsed, 0), 1)
+    }
+    entries.push({ type, subtype, q })
+  }
+  return entries
+}
+
+function matchScore(entries: AcceptEntry[], mediaType: string): number {
+  const [type, subtype] = mediaType.split('/', 2)
+  let bestSpecificity = 0
+  let bestQ = 0
+  for (const entry of entries) {
+    let specificity: number
+    if (entry.type === type && entry.subtype === subtype) specificity = 3
+    else if (entry.type === type && entry.subtype === '*') specificity = 2
+    else if (entry.type === '*' && entry.subtype === '*') specificity = 1
+    else continue
+    if (specificity > bestSpecificity) {
+      bestSpecificity = specificity
+      bestQ = entry.q
+    }
+  }
+  return bestQ
+}
+
+export interface Negotiation {
+  /** The supported type to serve, or null when nothing is acceptable (406). */
+  choice: string | null
+  /** Effective q-value per supported type; 0 means not acceptable. */
+  scores: Record<string, number>
+}
+
+/**
+ * Pick which of `supported` to serve for an Accept header. A missing header
+ * (null) means "no constraint" and selects the server default — the first
+ * entry of `supported`. An empty or unsatisfiable header yields choice null.
+ * Ties on q-value resolve to the earliest entry in `supported`.
+ */
+export function negotiate(
+  header: string | null,
+  supported: readonly string[]
+): Negotiation {
+  if (header === null) {
+    const scores: Record<string, number> = {}
+    for (const type of supported) scores[type] = 1
+    return { choice: supported[0] ?? null, scores }
+  }
+  const entries = parseAccept(header)
+  const scores: Record<string, number> = {}
+  let choice: string | null = null
+  let bestQ = 0
+  for (const type of supported) {
+    const q = matchScore(entries, type)
+    scores[type] = q
+    if (q > bestQ) {
+      bestQ = q
+      choice = type
+    }
+  }
+  return { choice, scores }
+}

--- a/apps/website/src/lib/agent-markdown.test.ts
+++ b/apps/website/src/lib/agent-markdown.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  apiMarkdown,
+  homepageMarkdown,
+  notFoundMarkdown
+} from './agent-markdown'
+
+describe('homepageMarkdown', () => {
+  const markdown = homepageMarkdown()
+
+  it('opens with a single H1 and substantial content', () => {
+    expect(markdown.startsWith('# Comfy — ')).toBe(true)
+    expect(markdown.match(/^# /gm)).toHaveLength(1)
+    expect(markdown.length).toBeGreaterThan(500)
+  })
+
+  it('has a section hierarchy', () => {
+    const sections = markdown.match(/^## /gm) ?? []
+    expect(sections.length).toBeGreaterThanOrEqual(5)
+  })
+
+  it('links the product surfaces and agent resources', () => {
+    for (const needle of [
+      'https://comfy.org/download',
+      'https://comfy.org/cloud',
+      'https://comfy.org/api',
+      'https://comfy.org/openapi.json',
+      'https://comfy.org/llms.txt',
+      'https://comfy.org/sitemap-index.xml',
+      'https://docs.comfy.org/',
+      'Accept: text/markdown'
+    ]) {
+      expect(markdown).toContain(needle)
+    }
+  })
+
+  it('contains no unresolved newline escapes from i18n strings', () => {
+    expect(markdown).not.toMatch(/\S\n\S*\\n/)
+    expect(markdown).not.toContain('undefined')
+  })
+})
+
+describe('apiMarkdown', () => {
+  const markdown = apiMarkdown()
+
+  it('opens with a Comfy API H1', () => {
+    expect(markdown.startsWith('# Comfy API — ')).toBe(true)
+    expect(markdown.match(/^# /gm)).toHaveLength(1)
+  })
+
+  it('links keys, docs, SDKs, and the OpenAPI spec', () => {
+    for (const needle of [
+      'https://platform.comfy.org/profile/api-keys',
+      'https://docs.comfy.org/development/api-development/sdks',
+      'pip install comfy-sdk',
+      '@comfyorg/sdk',
+      'https://comfy.org/openapi.json',
+      'https://cloud.comfy.org/mcp'
+    ]) {
+      expect(markdown).toContain(needle)
+    }
+  })
+})
+
+describe('notFoundMarkdown', () => {
+  const markdown = notFoundMarkdown()
+
+  it('is a short recovery map for agents', () => {
+    expect(markdown.startsWith('# 404')).toBe(true)
+    for (const needle of [
+      'https://comfy.org/llms.txt',
+      'https://comfy.org/sitemap-index.xml',
+      'https://comfy.org/index.md',
+      'https://comfy.org/openapi.json',
+      'https://docs.comfy.org/'
+    ]) {
+      expect(markdown).toContain(needle)
+    }
+  })
+})

--- a/apps/website/src/lib/agent-markdown.ts
+++ b/apps/website/src/lib/agent-markdown.ts
@@ -1,0 +1,151 @@
+/**
+ * Markdown twins served to agents: `/index.md`, `/api.md`, and `/404.md`,
+ * plus the same bodies via `Accept: text/markdown` negotiation (middleware.ts).
+ * Composed from the live i18n strings and route tables so the twins can't
+ * drift from the rendered pages.
+ */
+
+import { externalLinks, getRoutes } from '../config/routes'
+import { modelReleaseSlides } from '../data/modelRelease'
+import { t } from '../i18n/translations'
+
+const SITE = 'https://comfy.org'
+const OPENAPI_PATH = '/openapi.json'
+
+const routes = getRoutes('en')
+
+function en(...keys: Parameters<typeof t>[0][]): string {
+  return keys
+    .map((key) => t(key, 'en'))
+    .join('')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+function abs(path: string): string {
+  return new URL(path, SITE).toString()
+}
+
+function agentFooter(pagePath: string, twinPath: string): string {
+  return [
+    '---',
+    '',
+    `This is the markdown twin of ${abs(pagePath)}, also served there via \`Accept: text/markdown\` content negotiation (direct URL: ${abs(twinPath)}).`,
+    `Machine-readable index of the site: ${abs('/llms.txt')} · Site map: ${abs('/sitemap-index.xml')} · OpenAPI spec: ${abs(OPENAPI_PATH)}`,
+    ''
+  ].join('\n')
+}
+
+export function homepageMarkdown(): string {
+  const modelLines = modelReleaseSlides.map((slide) => {
+    const title = en(slide.titleKey)
+    const body = en(slide.bodyKey)
+    return `- **${title}** — ${body} ([explore](${abs(routes[slide.exploreRoute])}))`
+  })
+
+  return [
+    `# Comfy — ${en('hero.title')}`,
+    '',
+    `> ${en('hero.subtitle')}`,
+    '',
+    'Comfy is built around ComfyUI — the open-source node-graph runtime with 60,000+ community nodes and thousands of shared workflows. It ships as a free local app, a managed cloud, an API, and an enterprise platform.',
+    '',
+    '## Latest model releases',
+    '',
+    ...modelLines,
+    '',
+    '## How ComfyUI works',
+    '',
+    `${en('showcase.subtitle1')} ${en('showcase.subtitle2')}`,
+    '',
+    `- **${en('showcase.feature1.title')}** — ${en('showcase.feature1.description')}`,
+    `- **${en('showcase.feature2.title')}** — ${en('showcase.feature2.description')}`,
+    `- **${en('showcase.feature3.title')}** — ${en('showcase.feature3.description')}`,
+    '',
+    `## ${en('useCase.label')}`,
+    '',
+    `${en('useCase.vfx')} · ${en('useCase.advertising')} · ${en('useCase.gaming')} · ${en('useCase.ecommerce')}. ${en('useCase.body')}`,
+    '',
+    `## ${en('getStarted.heading')}`,
+    '',
+    `1. **${en('getStarted.step1.title')}** — [Download Comfy Desktop](${abs(routes.download)}) or [try Comfy Cloud](${externalLinks.cloud}).`,
+    `2. **${en('getStarted.step2.title')}** — start from [a community workflow](${externalLinks.workflows}) or build your own.`,
+    `3. **${en('getStarted.step3.title')}** — ${en('getStarted.step3.description')}`,
+    '',
+    `## ${en('products.heading')}`,
+    '',
+    `${en('products.subheading')}`,
+    '',
+    `- [${en('products.local.title')}](${abs(routes.download)}) — ${en('products.local.description')}`,
+    `- [${en('products.cloud.title')}](${abs(routes.cloud)}) — ${en('products.cloud.description')}`,
+    `- [${en('products.api.title')}](${abs(routes.api)}) — ${en('products.api.description')}`,
+    `- [${en('products.enterprise.title')}](${abs(routes.cloudEnterprise)}) — ${en('products.enterprise.description')}`,
+    '',
+    '## For developers and agents',
+    '',
+    `- [Comfy API](${abs(routes.api)}) — markdown twin at ${abs('/api.md')}`,
+    `- [OpenAPI 3 spec](${abs(OPENAPI_PATH)}) — every operation typed, with unique operationIds (source: https://api.comfy.org/openapi)`,
+    `- [Documentation](${externalLinks.docs}) — every docs page also serves markdown (append \`.md\`); index at https://docs.comfy.org/llms.txt`,
+    `- [Comfy MCP](${abs(routes.mcp)}) — MCP server endpoint at ${externalLinks.mcpEndpoint}`,
+    `- [Community workflows](${externalLinks.workflows})`,
+    '',
+    agentFooter('/', '/index.md')
+  ].join('\n')
+}
+
+export function apiMarkdown(): string {
+  return [
+    `# Comfy API — ${en('api.hero.heading')}`,
+    '',
+    `> ${en('api.hero.subtitle')}`,
+    '',
+    `- [Get API keys](${externalLinks.apiKeys})`,
+    `- [API quick start](${externalLinks.docsApi})`,
+    `- [SDKs](${externalLinks.docsSdk}) — Python (\`pip install comfy-sdk\`) and TypeScript (\`npm install @comfyorg/sdk\`)`,
+    `- [OpenAPI 3 spec](${abs(OPENAPI_PATH)}) — every operation typed, with unique operationIds (source: https://api.comfy.org/openapi)`,
+    `- [Comfy MCP](${abs(routes.mcp)}) — MCP server endpoint at ${externalLinks.mcpEndpoint}`,
+    '',
+    `## ${en('api.steps.heading')}`,
+    '',
+    `1. **${en('api.steps.step1.title')}** — ${en('api.steps.step1.description')}`,
+    `2. **${en('api.steps.step2.title')}** — ${en('api.steps.step2.description')}`,
+    `3. **${en('api.steps.step3.title')}** — ${en('api.steps.step3.description')}`,
+    '',
+    `## ${en('api.automation.heading')}`,
+    '',
+    `${en('api.automation.subtitle')}`,
+    '',
+    `- **${en('api.automation.feature1.title')}** — ${en('api.automation.feature1.description')}`,
+    `- **${en('api.automation.feature2.title')}** — ${en('api.automation.feature2.description')}`,
+    `- **${en('api.automation.feature3.title')}** — ${en('api.automation.feature3.description')}`,
+    '',
+    `## ${en('api.reason.heading', 'api.reason.headingHighlight', 'api.reason.headingSuffix')}`,
+    '',
+    `${en('api.reason.subtitle')}`,
+    '',
+    `- **${en('api.reason.1.title')}** — ${en('api.reason.1.description')}`,
+    `- **${en('api.reason.2.title')}** — ${en('api.reason.2.description')}`,
+    `- **${en('api.reason.3.title')}** — ${en('api.reason.3.description')}`,
+    '',
+    agentFooter(routes.api, '/api.md')
+  ].join('\n')
+}
+
+export function notFoundMarkdown(): string {
+  return [
+    '# 404 — page not found',
+    '',
+    'Nothing lives at this path on comfy.org. These paths do:',
+    '',
+    `- [Homepage](${abs('/')}) — markdown twin at ${abs('/index.md')}`,
+    `- [llms.txt](${abs('/llms.txt')}) — index of every important page on this site`,
+    `- [Site map](${abs('/sitemap-index.xml')})`,
+    `- [Comfy API](${abs(routes.api)}) — markdown twin at ${abs('/api.md')}`,
+    `- [OpenAPI 3 spec](${abs(OPENAPI_PATH)})`,
+    `- [Documentation](${externalLinks.docs}) — markdown index at https://docs.comfy.org/llms.txt`,
+    `- [Download Comfy Desktop](${abs(routes.download)})`,
+    `- [Comfy Cloud](${abs(routes.cloud)})`,
+    `- [Community workflows](${externalLinks.workflows})`,
+    ''
+  ].join('\n')
+}

--- a/apps/website/src/lib/content-negotiation.test.ts
+++ b/apps/website/src/lib/content-negotiation.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  markdownTwinPath,
+  NEGOTIATION_BYPASS_HEADER,
+  negotiateAgentContent
+} from './content-negotiation'
+
+const ORIGIN = 'https://website-frontend-comfyui.vercel.app'
+
+function fetchRouting(routes: Record<string, number>) {
+  return vi.fn<typeof fetch>(async (input) => {
+    const url = new URL(String(input))
+    const status = routes[url.pathname] ?? 404
+    return new Response(status === 404 ? 'not here' : `body:${url.pathname}`, {
+      status
+    })
+  })
+}
+
+function request(
+  path: string,
+  init: { accept?: string; method?: string; bypass?: boolean } = {}
+): Request {
+  const headers = new Headers()
+  if (init.accept !== undefined) headers.set('accept', init.accept)
+  if (init.bypass) headers.set(NEGOTIATION_BYPASS_HEADER, '1')
+  return new Request(new URL(path, ORIGIN), {
+    method: init.method ?? 'GET',
+    headers
+  })
+}
+
+describe('markdownTwinPath', () => {
+  it('maps the root to /index.md', () => {
+    expect(markdownTwinPath('/')).toBe('/index.md')
+  })
+
+  it('maps pages with and without trailing slashes', () => {
+    expect(markdownTwinPath('/api')).toBe('/api.md')
+    expect(markdownTwinPath('/api/')).toBe('/api.md')
+    expect(markdownTwinPath('/cloud/pricing')).toBe('/cloud/pricing.md')
+  })
+
+  it('leaves .md paths alone', () => {
+    expect(markdownTwinPath('/api.md')).toBe('/api.md')
+  })
+})
+
+describe('negotiateAgentContent', () => {
+  it('passes browsers through without any subrequests', async () => {
+    const fetchImpl = fetchRouting({})
+    const chrome =
+      'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8'
+    const result = await negotiateAgentContent(
+      request('/', { accept: chrome }),
+      fetchImpl
+    )
+    expect(result).toBeUndefined()
+    expect(fetchImpl).not.toHaveBeenCalled()
+  })
+
+  it('passes requests without an Accept header through', async () => {
+    const fetchImpl = fetchRouting({})
+    const result = await negotiateAgentContent(request('/'), fetchImpl)
+    expect(result).toBeUndefined()
+    expect(fetchImpl).not.toHaveBeenCalled()
+  })
+
+  it('rewrites to the markdown twin when markdown is preferred', async () => {
+    const fetchImpl = fetchRouting({ '/index.md': 200 })
+    const result = await negotiateAgentContent(
+      request('/', { accept: 'text/markdown' }),
+      fetchImpl
+    )
+    expect(result?.headers.get('x-middleware-rewrite')).toBe(
+      `${ORIGIN}/index.md`
+    )
+    expect(result?.headers.get('vary')).toBe('Accept')
+    expect(result?.headers.get('content-location')).toBe('/index.md')
+    const [, init] = fetchImpl.mock.calls[0] ?? []
+    expect(init?.method).toBe('HEAD')
+  })
+
+  it('lets the platform answer redirect-source paths', async () => {
+    const fetchImpl = fetchRouting({ '/developers': 307 })
+    const result = await negotiateAgentContent(
+      request('/developers', { accept: 'text/markdown' }),
+      fetchImpl
+    )
+    expect(result).toBeUndefined()
+  })
+
+  it('marks its subrequests with the bypass header', async () => {
+    const fetchImpl = fetchRouting({ '/index.md': 200 })
+    await negotiateAgentContent(
+      request('/', { accept: 'text/markdown' }),
+      fetchImpl
+    )
+    const [, init] = fetchImpl.mock.calls[0] ?? []
+    expect(new Headers(init?.headers).get(NEGOTIATION_BYPASS_HEADER)).toBe('1')
+  })
+
+  it('falls back to HTML when no twin exists but the page does', async () => {
+    const fetchImpl = fetchRouting({ '/cloud': 200 })
+    const result = await negotiateAgentContent(
+      request('/cloud', { accept: 'text/markdown, text/html;q=0.5' }),
+      fetchImpl
+    )
+    expect(result).toBeUndefined()
+  })
+
+  it('returns 406 when only markdown is acceptable and none exists', async () => {
+    const fetchImpl = fetchRouting({ '/cloud': 200 })
+    const result = await negotiateAgentContent(
+      request('/cloud', { accept: 'text/markdown' }),
+      fetchImpl
+    )
+    expect(result?.status).toBe(406)
+    expect(result?.headers.get('vary')).toBe('Accept')
+    expect(result?.headers.get('cache-control')).toBe('no-store')
+    const body = await result?.text()
+    expect(body).toContain('text/html')
+    expect(body).toContain('text/markdown')
+    expect(body).toContain('You requested: text/markdown')
+  })
+
+  it('returns 406 immediately for unsupported-only Accept values', async () => {
+    const fetchImpl = fetchRouting({})
+    const result = await negotiateAgentContent(
+      request('/', { accept: 'application/pdf' }),
+      fetchImpl
+    )
+    expect(result?.status).toBe(406)
+    expect(fetchImpl).not.toHaveBeenCalled()
+  })
+
+  it('serves the markdown 404 for nonexistent paths', async () => {
+    const fetchImpl = fetchRouting({ '/404.md': 200 })
+    const result = await negotiateAgentContent(
+      request('/no-such-page', { accept: 'text/markdown' }),
+      fetchImpl
+    )
+    expect(result?.status).toBe(404)
+    expect(result?.headers.get('content-type')).toBe(
+      'text/markdown; charset=utf-8'
+    )
+    expect(result?.headers.get('content-location')).toBe('/404.md')
+    expect(await result?.text()).toBe('body:/404.md')
+  })
+
+  it('rewrites HEAD requests the same way as GET', async () => {
+    const fetchImpl = fetchRouting({ '/index.md': 200 })
+    const result = await negotiateAgentContent(
+      request('/', { accept: 'text/markdown', method: 'HEAD' }),
+      fetchImpl
+    )
+    expect(result?.headers.get('x-middleware-rewrite')).toBe(
+      `${ORIGIN}/index.md`
+    )
+  })
+
+  it('ignores non-GET/HEAD methods', async () => {
+    const fetchImpl = fetchRouting({})
+    const result = await negotiateAgentContent(
+      request('/', { accept: 'text/markdown', method: 'POST' }),
+      fetchImpl
+    )
+    expect(result).toBeUndefined()
+    expect(fetchImpl).not.toHaveBeenCalled()
+  })
+
+  it('ignores its own subrequests', async () => {
+    const fetchImpl = fetchRouting({ '/index.md': 200 })
+    const result = await negotiateAgentContent(
+      request('/', { accept: 'text/markdown', bypass: true }),
+      fetchImpl
+    )
+    expect(result).toBeUndefined()
+    expect(fetchImpl).not.toHaveBeenCalled()
+  })
+})

--- a/apps/website/src/lib/content-negotiation.ts
+++ b/apps/website/src/lib/content-negotiation.ts
@@ -1,0 +1,132 @@
+/**
+ * Edge-middleware logic behind `middleware.ts`: serve the prebuilt `.md` twin
+ * of a page when the Accept header prefers text/markdown, a markdown 404 for
+ * nonexistent paths, and 406 when nothing we produce is acceptable
+ * (acceptmarkdown.com contract). Kept separate from the middleware entry so
+ * vitest can drive it with an injected fetch.
+ */
+
+import { negotiate } from './accept'
+
+/**
+ * Marks middleware-issued subrequests back into the same deployment so a
+ * matcher overlap can never recurse.
+ */
+export const NEGOTIATION_BYPASS_HEADER = 'x-comfy-content-negotiation'
+
+const SUPPORTED = ['text/html', 'text/markdown'] as const
+const MARKDOWN_CONTENT_TYPE = 'text/markdown; charset=utf-8'
+
+/** `/` → `/index.md`, `/api` and `/api/` → `/api.md`. */
+export function markdownTwinPath(pathname: string): string {
+  const trimmed =
+    pathname.length > 1 && pathname.endsWith('/')
+      ? pathname.slice(0, -1)
+      : pathname
+  if (trimmed === '/' || trimmed === '') return '/index.md'
+  if (trimmed.endsWith('.md')) return trimmed
+  return `${trimmed}.md`
+}
+
+/**
+ * Hand the request to the static layer at the twin's path. Serving the file
+ * through a rewrite (rather than proxying its body here) keeps correct
+ * Content-Type and ETag semantics on both GET and HEAD — Vercel drops entity
+ * headers from middleware-constructed HEAD responses. `Vary: Accept` on the
+ * negotiated URL comes from the vercel.json header rule; the copy here covers
+ * responses the router serves without consulting that rule.
+ */
+function rewriteToTwin(twinUrl: URL, twinPath: string): Response {
+  return new Response(null, {
+    headers: {
+      'x-middleware-rewrite': twinUrl.toString(),
+      'Content-Location': twinPath,
+      Vary: 'Accept'
+    }
+  })
+}
+
+function markdownResponse(
+  body: BodyInit | null,
+  status: number,
+  contentLocation: string
+): Response {
+  return new Response(body, {
+    status,
+    headers: {
+      'Content-Type': MARKDOWN_CONTENT_TYPE,
+      'Content-Location': contentLocation,
+      Vary: 'Accept',
+      'Cache-Control': 'public, max-age=0, must-revalidate'
+    }
+  })
+}
+
+function notAcceptable(accept: string | null): Response {
+  const body = [
+    'This resource is available in:',
+    ...SUPPORTED.map((type) => `- ${type}`),
+    '',
+    `You requested: ${accept ?? '(no Accept header)'}`,
+    ''
+  ].join('\n')
+  return new Response(body, {
+    status: 406,
+    headers: {
+      'Content-Type': 'text/plain; charset=utf-8',
+      Vary: 'Accept',
+      'Cache-Control': 'no-store'
+    }
+  })
+}
+
+/**
+ * Returns a Response to short-circuit with, or undefined to let the static
+ * layer serve the request unchanged.
+ */
+export async function negotiateAgentContent(
+  request: Request,
+  fetchImpl: typeof fetch = fetch
+): Promise<Response | undefined> {
+  if (request.method !== 'GET' && request.method !== 'HEAD') return undefined
+  if (request.headers.get(NEGOTIATION_BYPASS_HEADER) !== null) return undefined
+
+  const accept = request.headers.get('accept')
+  const { choice, scores } = negotiate(accept, SUPPORTED)
+  if (choice === 'text/html') return undefined
+  if (choice === null) return notAcceptable(accept)
+
+  const url = new URL(request.url)
+  const bypassHeaders = { [NEGOTIATION_BYPASS_HEADER]: '1' }
+  const twinPath = markdownTwinPath(url.pathname)
+  const twinUrl = new URL(twinPath, url.origin)
+  const twinProbe = await fetchImpl(twinUrl.toString(), {
+    method: 'HEAD',
+    headers: bypassHeaders
+  })
+  void twinProbe.body?.cancel()
+  if (twinProbe.ok) return rewriteToTwin(twinUrl, twinPath)
+
+  // No twin. Redirect sources are answered by the platform's redirect (the
+  // target renegotiates); nonexistent paths get the markdown 404 so agents
+  // can recover; existing HTML-only pages fall back when the client allows.
+  const page = await fetchImpl(
+    new URL(url.pathname + url.search, url.origin).toString(),
+    { method: 'HEAD', headers: bypassHeaders, redirect: 'manual' }
+  )
+  void page.body?.cancel()
+  if (page.status >= 300 && page.status < 400) return undefined
+  if (page.status === 404) {
+    const notFoundTwin = await fetchImpl(
+      new URL('/404.md', url.origin).toString(),
+      { headers: bypassHeaders }
+    )
+    if (notFoundTwin.ok) {
+      return markdownResponse(notFoundTwin.body, 404, '/404.md')
+    }
+    void notFoundTwin.body?.cancel()
+    return undefined
+  }
+  if ((scores['text/html'] ?? 0) > 0) return undefined
+  return notAcceptable(accept)
+}

--- a/apps/website/src/lib/vercel-config.test.ts
+++ b/apps/website/src/lib/vercel-config.test.ts
@@ -1,0 +1,84 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+interface VercelRoute {
+  source: string
+  destination?: string
+  permanent?: boolean
+  headers?: { key: string; value: string }[]
+  has?: unknown[]
+}
+
+interface VercelConfig {
+  rewrites?: VercelRoute[]
+  redirects?: VercelRoute[]
+  headers?: VercelRoute[]
+}
+
+const config = JSON.parse(
+  readFileSync(new URL('../../vercel.json', import.meta.url), 'utf8')
+) as VercelConfig
+
+describe('vercel.json agent-readiness surface', () => {
+  it('publishes the live OpenAPI spec at /openapi.json and /api/openapi.json', () => {
+    const sources = (config.rewrites ?? []).filter(
+      (rule) => rule.destination === 'https://api.comfy.org/openapi'
+    )
+    expect(sources.map((rule) => rule.source).sort()).toEqual([
+      '/api/openapi.json',
+      '/openapi.json'
+    ])
+  })
+
+  it('sets Vary: Accept on extension-less page paths', () => {
+    const rule = (config.headers ?? []).find((entry) =>
+      entry.headers?.some(
+        (header) => header.key === 'Vary' && header.value === 'Accept'
+      )
+    )
+    expect(rule).toBeDefined()
+    // Must exclude asset extensions (including .md twins and llms.txt) while
+    // keeping dotted page routes like /seedance-2.5 covered, must match the
+    // middleware.ts matcher, and must not be host-scoped.
+    expect(rule?.source).toBe(
+      '/((?!.*\\.(?:md|txt|xml|json|ico|png|jpg|jpeg|webp|avif|gif|svg|css|js|mjs|map|woff|woff2|ttf|otf|eot|mp4|webm|vtt|pdf|zip|webmanifest)$).*)'
+    )
+    expect(rule?.has).toBeUndefined()
+  })
+
+  it('canonicalizes the markdown twins to their HTML pages', () => {
+    const linkFor = (source: string) =>
+      (config.headers ?? [])
+        .find((entry) => entry.source === source)
+        ?.headers?.find((header) => header.key === 'Link')?.value
+    expect(linkFor('/index.md')).toBe('<https://comfy.org/>; rel="canonical"')
+    expect(linkFor('/api.md')).toBe('<https://comfy.org/api>; rel="canonical"')
+  })
+
+  it('keeps predictable developer entry points', () => {
+    const redirects = config.redirects ?? []
+    expect(
+      redirects.find((rule) => rule.source === '/developers')?.destination
+    ).toBe('/api')
+    expect(redirects.find((rule) => rule.source === '/docs')?.destination).toBe(
+      'https://docs.comfy.org/'
+    )
+  })
+
+  it('preserves the pre-existing redirects', () => {
+    const redirects = config.redirects ?? []
+    expect(
+      redirects.find((rule) => rule.source === '/pricing')?.destination
+    ).toBe('/cloud/pricing')
+    expect(
+      redirects.find((rule) => rule.source === '/login')?.destination
+    ).toBe('https://cloud.comfy.org/cloud/login')
+  })
+
+  it('preserves the anti-noindex header for the production origin host', () => {
+    const rule = (config.headers ?? []).find((entry) =>
+      entry.headers?.some((header) => header.key === 'X-Robots-Tag')
+    )
+    expect(rule?.headers?.[0]?.value).toBe('index, follow')
+  })
+})

--- a/apps/website/src/pages/404.astro
+++ b/apps/website/src/pages/404.astro
@@ -1,5 +1,20 @@
 ---
+import { externalLinks, getRoutes } from '../config/routes'
+import { t } from '../i18n/translations'
 import BaseLayout from '../layouts/BaseLayout.astro'
+
+const routes = getRoutes('en')
+
+const recoveryLinks = [
+  { label: t('notFound.home', 'en'), href: routes.home },
+  { label: t('notFound.download', 'en'), href: routes.download },
+  { label: t('nav.comfyCloud', 'en'), href: routes.cloud },
+  { label: t('nav.comfyHub', 'en'), href: externalLinks.workflows },
+  { label: t('nav.docs', 'en'), href: externalLinks.docs },
+  { label: t('notFound.sitemap', 'en'), href: '/sitemap-index.xml' },
+  { label: t('notFound.llms', 'en'), href: '/llms.txt' },
+  { label: t('notFound.openapi', 'en'), href: '/openapi.json' }
+]
 ---
 
 <BaseLayout
@@ -33,6 +48,20 @@ import BaseLayout from '../layouts/BaseLayout.astro'
           class="mx-2.5 opacity-50">|</span
         >Best: <span id="scoreBest">0</span></p
       >
+      <nav
+        aria-label={t('notFound.linksLabel', 'en')}
+        class="flex max-w-xl flex-wrap items-center justify-center gap-x-4 gap-y-1 font-mono text-xs tracking-[0.05em] opacity-75 max-md:landscape:hidden">
+        <span>{t('notFound.hint', 'en')}</span>
+        {
+          recoveryLinks.map((link) => (
+            <a
+              class="underline underline-offset-2 hover:opacity-80"
+              href={link.href}>
+              {link.label}
+            </a>
+          ))
+        }
+      </nav>
     </div>
     <div class="relative flex min-h-0 flex-1 items-center justify-center overflow-hidden">
       <svg

--- a/apps/website/src/pages/404.md.ts
+++ b/apps/website/src/pages/404.md.ts
@@ -1,0 +1,8 @@
+import type { APIRoute } from 'astro'
+
+import { notFoundMarkdown } from '../lib/agent-markdown'
+
+export const GET: APIRoute = () =>
+  new Response(notFoundMarkdown(), {
+    headers: { 'Content-Type': 'text/markdown; charset=utf-8' }
+  })

--- a/apps/website/src/pages/api.astro
+++ b/apps/website/src/pages/api.astro
@@ -6,9 +6,22 @@ import AutomationSection from '../components/product/api/AutomationSection.vue'
 import StepsSection from '../components/product/api/StepsSection.vue'
 import ReasonSection from '../components/product/api/ReasonSection.vue'
 import ProductCardsSection from '../components/common/ProductCardsSection.vue'
+import { t } from '../i18n/translations'
 ---
 
-<BaseLayout title="Comfy API">
+<BaseLayout
+  title="Comfy API - Run ComfyUI Workflows Programmatically"
+  description={t('api.hero.subtitle', 'en')}
+  keywords={[
+    'comfy api',
+    'comfyui api',
+    'comfy cloud api',
+    'comfyui workflow api',
+    'comfy sdk',
+    'comfyui sdk',
+    'image generation api',
+    'video generation api'
+  ]}>
   <CloudBannerSection />
   <HeroSection client:load />
   <AutomationSection />

--- a/apps/website/src/pages/api.md.ts
+++ b/apps/website/src/pages/api.md.ts
@@ -1,0 +1,8 @@
+import type { APIRoute } from 'astro'
+
+import { apiMarkdown } from '../lib/agent-markdown'
+
+export const GET: APIRoute = () =>
+  new Response(apiMarkdown(), {
+    headers: { 'Content-Type': 'text/markdown; charset=utf-8' }
+  })

--- a/apps/website/src/pages/index.md.ts
+++ b/apps/website/src/pages/index.md.ts
@@ -1,0 +1,8 @@
+import type { APIRoute } from 'astro'
+
+import { homepageMarkdown } from '../lib/agent-markdown'
+
+export const GET: APIRoute = () =>
+  new Response(homepageMarkdown(), {
+    headers: { 'Content-Type': 'text/markdown; charset=utf-8' }
+  })

--- a/apps/website/tsconfig.json
+++ b/apps/website/tsconfig.json
@@ -17,6 +17,7 @@
     "e2e/**/*",
     "scripts/**/*",
     "astro.config.ts",
+    "middleware.ts",
     "playwright.config.ts",
     "vitest.config.ts"
   ],

--- a/apps/website/vercel.json
+++ b/apps/website/vercel.json
@@ -7,6 +7,16 @@
   "github": {
     "enabled": false
   },
+  "rewrites": [
+    {
+      "source": "/openapi.json",
+      "destination": "https://api.comfy.org/openapi"
+    },
+    {
+      "source": "/api/openapi.json",
+      "destination": "https://api.comfy.org/openapi"
+    }
+  ],
   "headers": [
     {
       "source": "/(.*)",
@@ -14,6 +24,22 @@
         { "type": "host", "value": "website-frontend-comfyui.vercel.app" }
       ],
       "headers": [{ "key": "X-Robots-Tag", "value": "index, follow" }]
+    },
+    {
+      "source": "/((?!.*\\.(?:md|txt|xml|json|ico|png|jpg|jpeg|webp|avif|gif|svg|css|js|mjs|map|woff|woff2|ttf|otf|eot|mp4|webm|vtt|pdf|zip|webmanifest)$).*)",
+      "headers": [{ "key": "Vary", "value": "Accept" }]
+    },
+    {
+      "source": "/index.md",
+      "headers": [
+        { "key": "Link", "value": "<https://comfy.org/>; rel=\"canonical\"" }
+      ]
+    },
+    {
+      "source": "/api.md",
+      "headers": [
+        { "key": "Link", "value": "<https://comfy.org/api>; rel=\"canonical\"" }
+      ]
     },
     {
       "source": "/payment/(.*)",
@@ -93,6 +119,16 @@
     {
       "source": "/login",
       "destination": "https://cloud.comfy.org/cloud/login",
+      "permanent": false
+    },
+    {
+      "source": "/developers",
+      "destination": "/api",
+      "permanent": false
+    },
+    {
+      "source": "/docs",
+      "destination": "https://docs.comfy.org/",
       "permanent": false
     }
   ]

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -44,7 +44,8 @@ const config: KnipConfig = {
       project: ['src/**/*.{js,ts}']
     },
     'apps/website': {
-      entry: ['src/scripts/**/*.ts']
+      // middleware.ts is the Vercel Edge Middleware entry point
+      entry: ['src/scripts/**/*.ts', 'middleware.ts']
     }
   },
   ignoreDependencies: [


### PR DESCRIPTION
## Summary

Makes comfy.org agent-readable: `Accept: text/markdown` content negotiation with prebuilt markdown twins, the live OpenAPI spec published at `/openapi.json`, a recoverable 404 (markdown body for agents, visible links for humans), a semantically complete homepage heading outline, and an expanded developer section in `llms.txt`.

## Changes

- **What**:
  - `middleware.ts` (Vercel Edge Middleware) + `src/lib/accept.ts` + `src/lib/content-negotiation.ts`: RFC 9110 Accept negotiation (q-values, specificity, q=0 rejection, quote-aware parsing). Markdown-preferring requests rewrite to the page's `.md` twin via `x-middleware-rewrite`, so the static layer keeps correct `Content-Type`/`ETag` on GET and HEAD. Unsatisfiable Accept gets 406 with a body listing the supported types; nonexistent paths get a markdown 404; redirect sources pass through to the platform redirect. Runs on page routes — paths not ending in a known asset extension — so dotted slugs like `/seedance-2.5` participate (see `config.matcher`).
  - Markdown twins `/index.md`, `/api.md`, `/404.md` (`src/pages/*.md.ts`) composed from the same `translations.ts` strings and route tables as the pages, so copy can't drift.
  - `vercel.json`: `/openapi.json` + `/api/openapi.json` rewrite to `https://api.comfy.org/openapi` (376 operations, all with unique operationIds and typed schemas, served live so it never drifts); `Vary: Accept` on page routes (same pattern as the matcher); `Link: rel="canonical"` on the twins (header `noindex` would be stripped by comfy-router, canonical is router-safe); `/developers` → `/api` and `/docs` → docs.comfy.org redirects.
  - `404.astro`: recovery-links row (home, download, cloud, workflows, docs, site map, llms.txt, OpenAPI spec), i18n'd, hidden on short landscape viewports so the snake game keeps its height.
  - Homepage outline: section h2s for model releases (slides demoted to h3 via a `headingLevel` prop on `FeaturedCarousel02`), the showcase (sr-only "How ComfyUI works"), and use cases (existing visible label promoted `p` → `h2`, identical classes). `/api` page gains a descriptive title, meta description, and keywords.
  - `public/llms.txt`: agent-access note (negotiation, twins, OpenAPI) and Developers entries for the OpenAPI spec, Cloud API overview, SDKs, and MCP. Dropped the dead `#quick-start` anchor from `externalLinks.docsApi` (target page has no such heading; button behavior unchanged).
  - `scripts/agent-readiness-check.ts` (`pnpm agent:check <baseUrl>`): 14-probe verification suite for any deployment.
- **Breaking**: none. Browsers and crawlers send HTML-preferring Accept headers and are untouched; requests without Accept or with `*/*` get HTML. New 406 applies only to clients whose Accept excludes both HTML and markdown.
- **Dependencies**: none.

## Review Focus

- The middleware runs on every extension-less GET/HEAD; browser requests exit before any subrequest (Accept prefers HTML). Markdown-preferring requests cost 1–3 HEAD probes against the same deployment, guarded against recursion by the `x-comfy-content-negotiation` header.
- comfy-router interaction was verified from its source: request/response headers pass through verbatim for page routes, no caching applies to them, and everything unmatched routes to this origin, so `/openapi.json`, twins, and negotiation work through comfy.org unchanged. The router's noindex-stripping is why the twins use `Link: rel="canonical"` instead of `X-Robots-Tag`.
- 404 recovery links are a small visible addition to the 404 page — see the first deep link below; hidden on short landscape viewports so the game keeps its height.

Verified on preview `website-frontend-arobo3j2a-comfyui.vercel.app`: all 14 `agent:check` probes pass (negotiation + Vary on GET/HEAD, q-values, 406, markdown 404, twins, OpenAPI, redirects); 516 unit tests, `astro check` 0 errors, knip clean, e2e desktop suite green (272).

Deep links for review:
- 404 + links: https://website-frontend-arobo3j2a-comfyui.vercel.app/definitely-not-a-page
- Markdown twin: https://website-frontend-arobo3j2a-comfyui.vercel.app/index.md
- Spec: https://website-frontend-arobo3j2a-comfyui.vercel.app/openapi.json
- Negotiation: `curl -sI -H "Accept: text/markdown" https://website-frontend-arobo3j2a-comfyui.vercel.app/`
