### PR TITLE
feat: open Settings on Plans & Credits from a ?settings= deep link

### DIFF
--- a/browser_tests/tests/cloud.spec.ts
+++ b/browser_tests/tests/cloud.spec.ts
@@ -3,6 +3,7 @@ import { comfyPageFixture as test } from '@e2e/fixtures/ComfyPage'
 
 const APP_URL = process.env.PLAYWRIGHT_TEST_URL || 'http://localhost:8188'
 const SHARE_AUTH_STORAGE_KEY = 'Comfy.PreservedQuery.share_auth'
+const SETTINGS_STORAGE_KEY = 'Comfy.PreservedQuery.settings'
 
 /**
  * Cloud distribution E2E tests.
@@ -38,6 +39,22 @@ test.describe('Cloud distribution UI', { tag: '@cloud' }, () => {
         )
       )
       .toBe(JSON.stringify({ share: 'abc' }))
+  })
+
+  test('preserves the settings deep link before redirecting logged-out users', async ({
+    page
+  }) => {
+    await page.goto(new URL('/?settings=plan-credits', APP_URL).toString())
+
+    await expect(page).toHaveURL(/\/cloud\/login/, { timeout: 10_000 })
+    await expect
+      .poll(() =>
+        page.evaluate(
+          (key) => sessionStorage.getItem(key),
+          SETTINGS_STORAGE_KEY
+        )
+      )
+      .toBe(JSON.stringify({ settings: 'plan-credits' }))
   })
 
   test('cloud login page renders sign-in options', async ({ page }) => {

--- a/src/composables/useUrlActionLoaders.test.ts
+++ b/src/composables/useUrlActionLoaders.test.ts
@@ -14,10 +14,12 @@ const mocks = vi.hoisted(() => ({
   loadCreateWorkspace: vi.fn(async () => undefined),
   loadPricingTable: vi.fn(async () => undefined),
   loadTopUp: vi.fn(async () => undefined),
+  loadSettings: vi.fn(),
   useInvite: vi.fn(),
   useCreateWorkspace: vi.fn(),
   usePricingTable: vi.fn(),
-  useTopUp: vi.fn()
+  useTopUp: vi.fn(),
+  useSettings: vi.fn()
 }))
 mocks.useInvite.mockImplementation(() => ({
   loadInviteFromUrl: mocks.loadInvite
@@ -30,6 +32,9 @@ mocks.usePricingTable.mockImplementation(() => ({
 }))
 mocks.useTopUp.mockImplementation(() => ({
   loadTopUpFromUrl: mocks.loadTopUp
+}))
+mocks.useSettings.mockImplementation(() => ({
+  loadSettingsFromUrl: mocks.loadSettings
 }))
 
 vi.mock('@/platform/workspace/composables/useInviteUrlLoader', () => ({
@@ -44,6 +49,9 @@ vi.mock(
 )
 vi.mock('@/platform/cloud/subscription/composables/useTopUpUrlLoader', () => ({
   useTopUpUrlLoader: mocks.useTopUp
+}))
+vi.mock('@/platform/settings/composables/useSettingsUrlLoader', () => ({
+  useSettingsUrlLoader: mocks.useSettings
 }))
 
 describe('useUrlActionLoaders', () => {
@@ -61,6 +69,9 @@ describe('useUrlActionLoaders', () => {
     mocks.useTopUp.mockImplementation(() => ({
       loadTopUpFromUrl: mocks.loadTopUp
     }))
+    mocks.useSettings.mockImplementation(() => ({
+      loadSettingsFromUrl: mocks.loadSettings
+    }))
   })
 
   it('does not instantiate or run any loader off cloud', async () => {
@@ -73,10 +84,12 @@ describe('useUrlActionLoaders', () => {
     expect(mocks.useCreateWorkspace).not.toHaveBeenCalled()
     expect(mocks.usePricingTable).not.toHaveBeenCalled()
     expect(mocks.useTopUp).not.toHaveBeenCalled()
+    expect(mocks.useSettings).not.toHaveBeenCalled()
     expect(mocks.loadInvite).not.toHaveBeenCalled()
     expect(mocks.loadCreateWorkspace).not.toHaveBeenCalled()
     expect(mocks.loadPricingTable).not.toHaveBeenCalled()
     expect(mocks.loadTopUp).not.toHaveBeenCalled()
+    expect(mocks.loadSettings).not.toHaveBeenCalled()
   })
 
   it('runs all loaders on Cloud', async () => {
@@ -87,6 +100,7 @@ describe('useUrlActionLoaders', () => {
     expect(mocks.loadCreateWorkspace).toHaveBeenCalledOnce()
     expect(mocks.loadPricingTable).toHaveBeenCalledOnce()
     expect(mocks.loadTopUp).toHaveBeenCalledOnce()
+    expect(mocks.loadSettings).toHaveBeenCalledOnce()
   })
 
   it('isolates a pricing-loader failure so it does not abort the boot chain', async () => {
@@ -107,5 +121,17 @@ describe('useUrlActionLoaders', () => {
     await expect(runUrlActionLoaders()).resolves.toBeUndefined()
 
     expect(mocks.loadPricingTable).toHaveBeenCalledOnce()
+    expect(mocks.loadSettings).toHaveBeenCalledOnce()
+  })
+
+  it('isolates a settings-loader failure so it does not abort the boot chain', async () => {
+    mocks.loadSettings.mockImplementationOnce(() => {
+      throw new Error('boom')
+    })
+
+    const { runUrlActionLoaders } = useUrlActionLoaders()
+    await expect(runUrlActionLoaders()).resolves.toBeUndefined()
+
+    expect(mocks.loadTopUp).toHaveBeenCalledOnce()
   })
 })

--- a/src/composables/useUrlActionLoaders.ts
+++ b/src/composables/useUrlActionLoaders.ts
@@ -1,14 +1,15 @@
 import { usePricingTableUrlLoader } from '@/platform/cloud/subscription/composables/usePricingTableUrlLoader'
 import { useTopUpUrlLoader } from '@/platform/cloud/subscription/composables/useTopUpUrlLoader'
 import { isCloud } from '@/platform/distribution/types'
+import { useSettingsUrlLoader } from '@/platform/settings/composables/useSettingsUrlLoader'
 import { useCreateWorkspaceUrlLoader } from '@/platform/workspace/composables/useCreateWorkspaceUrlLoader'
 import { useInviteUrlLoader } from '@/platform/workspace/composables/useInviteUrlLoader'
 
 /**
  * Aggregates the query-param "deep link" loaders the cloud app checks on mount
- * (`?invite`, `?create_workspace`, `?pricing`, `?topup`). The loaders are
- * instantiated in setup so their `useRoute`/`useRouter` resolve; call
- * `runUrlActionLoaders()` from `onMounted` once the app is ready.
+ * (`?invite`, `?create_workspace`, `?pricing`, `?topup`, `?settings`). The
+ * loaders are instantiated in setup so their `useRoute`/`useRouter` resolve;
+ * call `runUrlActionLoaders()` from `onMounted` once the app is ready.
  */
 export function useUrlActionLoaders() {
   const inviteUrlLoader = isCloud ? useInviteUrlLoader() : null
@@ -17,6 +18,7 @@ export function useUrlActionLoaders() {
     : null
   const pricingTableUrlLoader = isCloud ? usePricingTableUrlLoader() : null
   const topUpUrlLoader = isCloud ? useTopUpUrlLoader() : null
+  const settingsUrlLoader = isCloud ? useSettingsUrlLoader() : null
 
   async function runUrlActionLoaders() {
     // Accept workspace invite from URL if present (e.g., ?invite=TOKEN).
@@ -56,6 +58,18 @@ export function useUrlActionLoaders() {
       } catch (error) {
         console.error(
           '[UrlActionLoaders] Failed to load top-up dialog from URL:',
+          error
+        )
+      }
+    }
+
+    // Open a Settings panel from URL if present (e.g. ?settings=plan-credits).
+    if (settingsUrlLoader) {
+      try {
+        settingsUrlLoader.loadSettingsFromUrl()
+      } catch (error) {
+        console.error(
+          '[UrlActionLoaders] Failed to load settings panel from URL:',
           error
         )
       }

--- a/src/platform/navigation/preservedQueryNamespaces.ts
+++ b/src/platform/navigation/preservedQueryNamespaces.ts
@@ -7,5 +7,6 @@ export const PRESERVED_QUERY_NAMESPACES = {
   OAUTH: 'oauth',
   PRICING: 'pricing',
   TOPUP: 'topup',
+  SETTINGS: 'settings',
   DESKTOP_LOGIN: 'desktop_login'
 } as const

--- a/src/platform/settings/composables/useSettingsUrlLoader.integration.test.ts
+++ b/src/platform/settings/composables/useSettingsUrlLoader.integration.test.ts
@@ -1,0 +1,109 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as VueRouter from 'vue-router'
+import type { Router } from 'vue-router'
+import { createMemoryHistory, createRouter } from 'vue-router'
+
+import { clearPreservedQuery } from '@/platform/navigation/preservedQueryManager'
+import { PRESERVED_QUERY_NAMESPACES } from '@/platform/navigation/preservedQueryNamespaces'
+import { installPreservedQueryTracker } from '@/platform/navigation/preservedQueryTracker'
+import { useSettingsUrlLoader } from '@/platform/settings/composables/useSettingsUrlLoader'
+
+const STORAGE_KEY = 'Comfy.PreservedQuery.settings'
+
+let testRouter: Router
+
+vi.mock('vue-router', async (importOriginal) => {
+  const actual = await importOriginal<typeof VueRouter>()
+  return {
+    ...actual,
+    useRoute: () => testRouter.currentRoute.value,
+    useRouter: () => testRouter
+  }
+})
+
+const mockShowSettings = vi.hoisted(() => vi.fn())
+
+vi.mock('@/platform/settings/composables/useSettingsDialog', () => ({
+  useSettingsDialog: () => ({
+    show: mockShowSettings
+  })
+}))
+
+function createAppLikeRouter(): Router {
+  const router = createRouter({
+    history: createMemoryHistory(),
+    routes: [{ path: '/:pathMatch(.*)*', component: { template: '<div />' } }]
+  })
+  installPreservedQueryTracker(router, [
+    {
+      namespace: PRESERVED_QUERY_NAMESPACES.SETTINGS,
+      keys: ['settings']
+    }
+  ])
+  return router
+}
+
+describe('useSettingsUrlLoader with real preserved-query boundaries', () => {
+  beforeEach(() => {
+    clearPreservedQuery(PRESERVED_QUERY_NAMESPACES.SETTINGS)
+    sessionStorage.clear()
+    testRouter = createAppLikeRouter()
+  })
+
+  it('opens Plans & Credits and cleans the URL when the param survives to mount', async () => {
+    await testRouter.push('/?settings=plan-credits&keep=1')
+
+    const { loadSettingsFromUrl } = useSettingsUrlLoader()
+    loadSettingsFromUrl()
+
+    expect(mockShowSettings).toHaveBeenCalledExactlyOnceWith('workspace')
+    await vi.waitFor(() =>
+      expect(testRouter.currentRoute.value.fullPath).toBe('/?keep=1')
+    )
+    expect(sessionStorage.getItem(STORAGE_KEY)).toBeNull()
+  })
+
+  it('restores the deep link through a login redirect that drops the query', async () => {
+    await testRouter.push('/?settings=plan-credits')
+    expect(sessionStorage.getItem(STORAGE_KEY)).toBe(
+      JSON.stringify({ settings: 'plan-credits' })
+    )
+
+    await testRouter.push('/cloud/login')
+    await testRouter.push('/')
+
+    const { loadSettingsFromUrl } = useSettingsUrlLoader()
+    loadSettingsFromUrl()
+
+    expect(mockShowSettings).toHaveBeenCalledExactlyOnceWith('workspace')
+    await vi.waitFor(() =>
+      expect(testRouter.currentRoute.value.fullPath).toBe('/')
+    )
+    expect(sessionStorage.getItem(STORAGE_KEY)).toBeNull()
+  })
+
+  it('consumes the stash so a later mount does not reopen the dialog', async () => {
+    await testRouter.push('/?settings=plan-credits')
+    await testRouter.push('/')
+    useSettingsUrlLoader().loadSettingsFromUrl()
+    mockShowSettings.mockClear()
+
+    await testRouter.push('/')
+    useSettingsUrlLoader().loadSettingsFromUrl()
+
+    expect(mockShowSettings).not.toHaveBeenCalled()
+  })
+
+  it('strips an unrecognized value without opening or leaving a stash behind', async () => {
+    await testRouter.push('/?settings=garbage')
+
+    const { loadSettingsFromUrl } = useSettingsUrlLoader()
+    loadSettingsFromUrl()
+
+    expect(mockShowSettings).not.toHaveBeenCalled()
+    await vi.waitFor(() =>
+      expect(testRouter.currentRoute.value.fullPath).toBe('/')
+    )
+    expect(sessionStorage.getItem(STORAGE_KEY)).toBeNull()
+  })
+})

--- a/src/platform/settings/composables/useSettingsUrlLoader.test.ts
+++ b/src/platform/settings/composables/useSettingsUrlLoader.test.ts
@@ -1,0 +1,126 @@
+import { fromAny } from '@total-typescript/shoehorn'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useSettingsUrlLoader } from './useSettingsUrlLoader'
+
+const preservedQueryMocks = vi.hoisted(() => ({
+  clearPreservedQuery: vi.fn(),
+  hydratePreservedQuery: vi.fn(),
+  mergePreservedQueryIntoQuery: vi.fn()
+}))
+
+vi.mock(
+  '@/platform/navigation/preservedQueryManager',
+  () => preservedQueryMocks
+)
+
+const mockRouteQuery = vi.hoisted(() => ({
+  value: {} as Record<string, string>
+}))
+const mockRouterReplace = vi.hoisted(() => vi.fn(async () => undefined))
+
+vi.mock('vue-router', () => ({
+  useRoute: () => ({
+    query: mockRouteQuery.value
+  }),
+  useRouter: () => ({
+    replace: mockRouterReplace
+  })
+}))
+
+const mockShowSettings = vi.hoisted(() => vi.fn())
+
+vi.mock('@/platform/settings/composables/useSettingsDialog', () => ({
+  useSettingsDialog: () => ({
+    show: mockShowSettings
+  })
+}))
+
+describe('useSettingsUrlLoader', () => {
+  beforeEach(() => {
+    mockRouteQuery.value = {}
+    preservedQueryMocks.mergePreservedQueryIntoQuery.mockReturnValue(null)
+  })
+
+  it('does nothing when no settings param present', () => {
+    mockRouteQuery.value = {}
+
+    const { loadSettingsFromUrl } = useSettingsUrlLoader()
+    loadSettingsFromUrl()
+
+    expect(mockShowSettings).not.toHaveBeenCalled()
+    expect(mockRouterReplace).not.toHaveBeenCalled()
+  })
+
+  it('opens the Plans & Credits panel and strips the param', () => {
+    mockRouteQuery.value = { settings: 'plan-credits' }
+
+    const { loadSettingsFromUrl } = useSettingsUrlLoader()
+    loadSettingsFromUrl()
+
+    expect(mockShowSettings).toHaveBeenCalledExactlyOnceWith('workspace')
+    expect(mockRouterReplace).toHaveBeenCalledWith({ query: {} })
+    expect(preservedQueryMocks.clearPreservedQuery).toHaveBeenCalledWith(
+      'settings'
+    )
+  })
+
+  it('preserves unrelated params when stripping', () => {
+    mockRouteQuery.value = { settings: 'plan-credits', other: 'param' }
+
+    const { loadSettingsFromUrl } = useSettingsUrlLoader()
+    loadSettingsFromUrl()
+
+    expect(mockRouterReplace).toHaveBeenCalledWith({
+      query: { other: 'param' }
+    })
+  })
+
+  it('strips but does not open for an unrecognized panel value', () => {
+    mockRouteQuery.value = { settings: 'garbage' }
+
+    const { loadSettingsFromUrl } = useSettingsUrlLoader()
+    loadSettingsFromUrl()
+
+    expect(mockShowSettings).not.toHaveBeenCalled()
+    expect(mockRouterReplace).toHaveBeenCalledWith({ query: {} })
+    expect(preservedQueryMocks.clearPreservedQuery).toHaveBeenCalledWith(
+      'settings'
+    )
+  })
+
+  it('strips but does not open for an empty param', () => {
+    mockRouteQuery.value = { settings: '' }
+
+    const { loadSettingsFromUrl } = useSettingsUrlLoader()
+    loadSettingsFromUrl()
+
+    expect(mockShowSettings).not.toHaveBeenCalled()
+    expect(mockRouterReplace).toHaveBeenCalledWith({ query: {} })
+  })
+
+  it('strips but does not open for a non-string param', () => {
+    mockRouteQuery.value = { settings: fromAny<string, unknown>(['array']) }
+
+    const { loadSettingsFromUrl } = useSettingsUrlLoader()
+    loadSettingsFromUrl()
+
+    expect(mockShowSettings).not.toHaveBeenCalled()
+    expect(mockRouterReplace).toHaveBeenCalledWith({ query: {} })
+  })
+
+  it('restores preserved query and opens the panel', () => {
+    mockRouteQuery.value = {}
+    preservedQueryMocks.mergePreservedQueryIntoQuery.mockReturnValue({
+      settings: 'plan-credits'
+    })
+
+    const { loadSettingsFromUrl } = useSettingsUrlLoader()
+    loadSettingsFromUrl()
+
+    expect(preservedQueryMocks.hydratePreservedQuery).toHaveBeenCalledWith(
+      'settings'
+    )
+    expect(mockShowSettings).toHaveBeenCalledExactlyOnceWith('workspace')
+  })
+})

--- a/src/platform/settings/composables/useSettingsUrlLoader.ts
+++ b/src/platform/settings/composables/useSettingsUrlLoader.ts
@@ -1,0 +1,61 @@
+import { useRoute, useRouter } from 'vue-router'
+
+import {
+  clearPreservedQuery,
+  hydratePreservedQuery,
+  mergePreservedQueryIntoQuery
+} from '@/platform/navigation/preservedQueryManager'
+import { PRESERVED_QUERY_NAMESPACES } from '@/platform/navigation/preservedQueryNamespaces'
+import { useSettingsDialog } from '@/platform/settings/composables/useSettingsDialog'
+import type { SettingPanelType } from '@/platform/settings/types'
+
+const NAMESPACE = PRESERVED_QUERY_NAMESPACES.SETTINGS
+
+const DEEP_LINKABLE_PANELS: Record<string, SettingPanelType> = {
+  'plan-credits': 'workspace'
+}
+
+/**
+ * Opens the Settings dialog on a named panel from a `?settings=` deep link
+ * (e.g. `?settings=plan-credits`), so external surfaces like platform.comfy.org
+ * can land users directly on the tab where they complete billing actions.
+ *
+ * Only values in `DEEP_LINKABLE_PANELS` open a panel; any other value is a
+ * silent no-op with the param stripped. Survives the login redirect via the
+ * preserved-query system, like the top-up URL loader.
+ */
+export function useSettingsUrlLoader() {
+  const route = useRoute()
+  const router = useRouter()
+  const settingsDialog = useSettingsDialog()
+
+  /** Reads `?settings=`, strips it, and opens the mapped Settings panel. */
+  function loadSettingsFromUrl() {
+    hydratePreservedQuery(NAMESPACE)
+    const query =
+      mergePreservedQueryIntoQuery(NAMESPACE, route.query) ?? route.query
+    const param = query.settings
+    if (param === undefined) return
+
+    // Strip any present settings param (even unrecognized or malformed values)
+    // and write the clean URL in a single replace, so a clean URL is
+    // guaranteed even if the replace rejects or no panel matches.
+    const cleanQuery = { ...query }
+    delete cleanQuery.settings
+    router.replace({ query: cleanQuery }).catch((error) => {
+      console.warn('[useSettingsUrlLoader] Failed to clean URL params:', error)
+    })
+    clearPreservedQuery(NAMESPACE)
+
+    if (typeof param !== 'string' || !param) return
+
+    const panel = DEEP_LINKABLE_PANELS[param]
+    if (!panel) return
+
+    settingsDialog.show(panel)
+  }
+
+  return {
+    loadSettingsFromUrl
+  }
+}

--- a/src/router.ts
+++ b/src/router.ts
@@ -130,6 +130,10 @@ installPreservedQueryTracker(router, [
     keys: ['topup']
   },
   {
+    namespace: PRESERVED_QUERY_NAMESPACES.SETTINGS,
+    keys: ['settings']
+  },
+  {
     namespace: PRESERVED_QUERY_NAMESPACES.DESKTOP_LOGIN,
     keys: ['desktop_login_code'],
     stripAfterCapture: true


### PR DESCRIPTION
## Summary

Adds a `?settings=plan-credits` deep link that opens the Settings dialog on the Plans & Credits panel, so platform.comfy.org can route users straight to the place where they complete billing actions instead of the default Cloud landing.

## Why / context

The new subscription and top-up flows won't be packaged into platform.comfy.org in time for launch, so platform redirects users to Cloud for any transaction. Today settings tabs are not URL-addressable — a redirected user lands on the default canvas and has to find Plans & Credits themselves. Closest existing deep links are `?pricing=1` and `?topup=1`; this follows the same URL-action-loader pattern. Slack context: https://comfy-organization.slack.com/archives/C0BNGQG2LCW/p1787597535486829

## Changes

- **What**: New `useSettingsUrlLoader` reads `?settings=`, strips the param, and opens the Settings dialog via `useSettingsDialog().show()` for values in an explicit allowlist (`plan-credits` → `workspace` panel, the same call the user popover makes). Wired into `useUrlActionLoaders` (cloud-only, runs on app mount) and registered in the preserved-query tracker so the param survives the login redirect, like `?topup=`.
- Unrecognized, empty, or non-string values are a silent no-op with the param stripped.

## Review Focus

- The allowlist maps URL values to `SettingPanelType` instead of passing the raw param through, so only intentionally exposed panels are URL-addressable.
- No permission gate: the Plans & Credits panel renders for every logged-in cloud user (members included), unlike `?topup=`/`?pricing=` which gate on billing permissions.

## Verification

AS IS (prod, cloud.comfy.org): visiting `/?settings=plan-credits` logged out redirects to `/cloud/login` and the param is not captured (`sessionStorage['Comfy.PreservedQuery.settings']` is `null`) — the intent is lost after login.

TO BE (this branch, real app via `pnpm dev:cloud`): the same visit stashes `{"settings":"plan-credits"}` in `sessionStorage['Comfy.PreservedQuery.settings']` before the login redirect, so the loader opens Plans & Credits once the app mounts after login.

Unit tests cover the loader (open/strip/no-op/preserved-query restore) and the aggregator wiring. A logged-in E2E/screenshot isn't reproducible from this environment (cloud E2E in CI runs unauthenticated by design, see `browser_tests/tests/cloud.spec.ts`); will attach a logged-in AS IS / TO BE capture from a testcloud account before merge.

## Screenshots (if applicable)

To be added: logged-in capture of the redirect landing on Plans & Credits (requires testcloud account).
