### PR TITLE
[cloud/1.52] Backport #15793: Fix local billing routes to open Plan & Credits

### DIFF
--- a/browser_tests/tests/localCreditsNoSubscribeUi.spec.ts
+++ b/browser_tests/tests/localCreditsNoSubscribeUi.spec.ts
@@ -20,7 +20,7 @@ import { TestIds } from '@e2e/fixtures/selectors'
  * the default (local) `chromium` project instead.
  */
 test.describe('Local credits surfaces hide subscribe UI (non-cloud)', () => {
-  test('keeps "Add credits" working across the profile popover and Settings > Credits', async ({
+  test('opens Plan & Credits and keeps "Add credits" working', async ({
     comfyPage
   }) => {
     const page = comfyPage.page
@@ -41,36 +41,30 @@ test.describe('Local credits surfaces hide subscribe UI (non-cloud)', () => {
     await expect(topUpDialog.heading).toBeVisible()
     await topUpDialog.close()
 
-    // 2. Settings > Credits, reached the same way the reported bug did: the
-    //    popover's plan & credits entry, not a generic keyboard shortcut. This
-    //    must also hide the subscribe CTA and keep its own "Add credits"
-    //    button working, not just render a dead replacement for it.
     await page.getByTestId(TestIds.user.currentUserButton).click()
     popover = page.getByTestId(TestIds.user.currentUserPopover)
     await popover.getByTestId('plans-credits-menu-item').click()
 
     const settingsDialog = comfyPage.settingDialog
     await settingsDialog.waitForVisible()
-    const creditsContent = settingsDialog.contentArea
+    const planCreditsContent = settingsDialog.contentArea
     await expect(
-      creditsContent.getByText('Upgrade to add credits')
-    ).toHaveCount(0)
-    await expect(
-      creditsContent.getByRole('button', { name: 'Manage subscription' })
-    ).toHaveCount(0)
-    await expect(
-      creditsContent.getByRole('button', { name: 'Billing & invoices' })
-    ).toHaveCount(0)
-    await expect(
-      creditsContent.getByRole('button', { name: 'Invoice history' })
+      planCreditsContent.getByRole('button', { name: 'Credits', exact: true })
     ).toBeVisible()
-    const invoiceRequest = page.waitForRequest('**/customers/billing')
-    await creditsContent
-      .getByRole('button', { name: 'Invoice history' })
-      .click()
-    expect((await invoiceRequest).method()).toBe('POST')
+    await expect(
+      planCreditsContent.getByRole('button', { name: 'Activity', exact: true })
+    ).toBeVisible()
+    await expect(
+      planCreditsContent.getByText('Upgrade to add credits')
+    ).toHaveCount(0)
+    await expect(
+      planCreditsContent.getByRole('button', { name: 'Manage subscription' })
+    ).toHaveCount(0)
+    await expect(
+      planCreditsContent.getByRole('button', { name: 'Billing & invoices' })
+    ).toHaveCount(0)
 
-    const settingsAddCredits = creditsContent.getByRole('button', {
+    const settingsAddCredits = planCreditsContent.getByRole('button', {
       name: 'Add credits'
     })
     await expect(settingsAddCredits).toBeVisible()
@@ -80,9 +74,6 @@ test.describe('Local credits surfaces hide subscribe UI (non-cloud)', () => {
 
     await settingsDialog.close()
 
-    // 3. Reopening the popover afterward must still work — regression check
-    //    for the stuck-trigger bug, where visiting Settings > Credits left
-    //    the popover's top-up button permanently dead.
     await page.getByTestId(TestIds.user.currentUserButton).click()
     popover = page.getByTestId(TestIds.user.currentUserPopover)
     await expect(

--- a/src/platform/workspace/components/CurrentUserPopoverWorkspace.test.ts
+++ b/src/platform/workspace/components/CurrentUserPopoverWorkspace.test.ts
@@ -473,7 +473,7 @@ describe('CurrentUserPopoverWorkspace', () => {
       })
     )
 
-    expect(state.showSettingsDialog).toHaveBeenCalledWith('credits')
+    expect(state.showSettingsDialog).toHaveBeenCalledWith('workspace')
     expect(state.showPricingTable).not.toHaveBeenCalled()
     expect(emitted('close')).toHaveLength(1)
   })

--- a/src/platform/workspace/components/CurrentUserPopoverWorkspace.vue
+++ b/src/platform/workspace/components/CurrentUserPopoverWorkspace.vue
@@ -168,7 +168,7 @@
       type="button"
       class="flex w-full cursor-pointer appearance-none items-center gap-2 border-0 bg-transparent px-4 py-2 text-left hover:bg-secondary-background-hover focus-visible:bg-secondary-background-hover focus-visible:outline-none"
       data-testid="plans-credits-menu-item"
-      @click="handleOpenCreditsSettings"
+      @click="handleOpenPlanCreditsSettings"
     >
       <i class="icon-[lucide--coins] size-4 text-muted-foreground" />
       <span class="flex-1 text-sm text-base-foreground">{{
@@ -369,8 +369,8 @@ const handleOpenManagePlanSettings = () => {
   emit('close')
 }
 
-const handleOpenCreditsSettings = () => {
-  settingsDialog.show('credits')
+const handleOpenPlanCreditsSettings = () => {
+  settingsDialog.show('workspace')
   emit('close')
 }
 

--- a/src/platform/workspace/components/TopUpCreditsDialogContentWorkspace.test.ts
+++ b/src/platform/workspace/components/TopUpCreditsDialogContentWorkspace.test.ts
@@ -23,9 +23,6 @@ const mockPermissions = vi.hoisted(() => ({
   ref: undefined as { value: { canTopUp: boolean } } | undefined
 }))
 const mockShouldUseWorkspaceBilling = vi.hoisted(() => ({ value: true }))
-const mockDistributionTypes = vi.hoisted(() => ({ isCloud: true }))
-
-vi.mock('@/platform/distribution/types', () => mockDistributionTypes)
 const mockBillingOperationState = vi.hoisted(() => ({
   isAddingCredits: undefined as { value: boolean } | undefined,
   topupActionOperation: undefined as
@@ -209,7 +206,6 @@ async function clickAddCredits() {
 
 describe('TopUpCreditsDialogContentWorkspace', () => {
   beforeEach(() => {
-    mockDistributionTypes.isCloud = true
     setCanTopUp(true)
     mockShouldUseWorkspaceBilling.value = true
     setIsAddingCredits(false)
@@ -422,17 +418,6 @@ describe('TopUpCreditsDialogContentWorkspace', () => {
       billing_op_id: 'op-1',
       duration_ms: expect.any(Number)
     })
-  })
-
-  it('opens Credits settings after a completed local top-up', async () => {
-    mockDistributionTypes.isCloud = false
-    mockTopup.mockResolvedValue(topupResponse('completed'))
-
-    renderDialog()
-    await clickAddCredits()
-    await userEvent.click(screen.getByRole('button', { name: 'Pay $50.00' }))
-
-    expect(mockShowSettings).toHaveBeenCalledWith('credits')
   })
 
   it('keeps completed top-up telemetry successful when refresh fails', async () => {

--- a/src/platform/workspace/components/TopUpCreditsDialogContentWorkspace.vue
+++ b/src/platform/workspace/components/TopUpCreditsDialogContentWorkspace.vue
@@ -259,7 +259,6 @@ import { useBillingContext } from '@/composables/billing/useBillingContext'
 import { useBillingRouting } from '@/composables/billing/useBillingRouting'
 import { useExternalLink } from '@/composables/useExternalLink'
 import { useTelemetry } from '@/platform/telemetry'
-import { isCloud } from '@/platform/distribution/types'
 import { clearTopupTracking } from '@/platform/telemetry/topupTracker'
 import { categorizeBillingApiError } from '@/platform/telemetry/utils/billingFailureCategory'
 import { useSettingsDialog } from '@/platform/settings/composables/useSettingsDialog'
@@ -469,7 +468,7 @@ async function handleBuy() {
       })
       await Promise.allSettled([fetchBalance(), fetchStatus()])
       handleClose(false)
-      settingsDialog.show(isCloud ? 'workspace' : 'credits')
+      settingsDialog.show('workspace')
     } else if (response.status === 'pending') {
       void billingOperationStore
         .startOperation(response.billing_op_id, 'topup', { attemptStartedAt })

--- a/src/platform/workspace/stores/billingOperationStore.test.ts
+++ b/src/platform/workspace/stores/billingOperationStore.test.ts
@@ -6,9 +6,6 @@ import type { BillingOpStatusResponse } from '@/platform/workspace/api/workspace
 const mockFetchStatus = vi.fn()
 const mockFetchBalance = vi.fn()
 const mockReconcileSubscriptionSuccess = vi.fn()
-const mockDistributionTypes = vi.hoisted(() => ({ isCloud: true }))
-
-vi.mock('@/platform/distribution/types', () => mockDistributionTypes)
 
 vi.mock('@/composables/billing/useBillingContext', () => ({
   useBillingContext: () => ({
@@ -84,7 +81,6 @@ import { useBillingOperationStore } from './billingOperationStore'
 
 describe('billingOperationStore', () => {
   beforeEach(() => {
-    mockDistributionTypes.isCloud = true
     mockActiveWorkspaceId.value = 'workspace-1'
   })
 
@@ -366,22 +362,6 @@ describe('billingOperationStore', () => {
 
       expect(mockCloseDialog).toHaveBeenCalledWith({ key: 'top-up-credits' })
       expect(mockSettingsDialogShow).toHaveBeenCalledWith('workspace')
-    })
-
-    it('opens Credits settings after a polled local topup succeeds', async () => {
-      mockDistributionTypes.isCloud = false
-      vi.mocked(workspaceApi.getBillingOpStatus).mockResolvedValue({
-        id: 'op-1',
-        status: 'succeeded',
-        started_at: new Date().toISOString()
-      })
-
-      const store = useBillingOperationStore()
-      void store.startOperation('op-1', 'topup')
-
-      await vi.advanceTimersByTimeAsync(0)
-
-      expect(mockSettingsDialogShow).toHaveBeenCalledWith('credits')
     })
 
     it('fires purchase telemetry on subscription success', async () => {

--- a/src/platform/workspace/stores/billingOperationStore.ts
+++ b/src/platform/workspace/stores/billingOperationStore.ts
@@ -7,7 +7,6 @@ import { t } from '@/i18n'
 import type { TierKey } from '@/platform/cloud/subscription/constants/tierPricing'
 import type { BillingCycle } from '@/platform/cloud/subscription/utils/subscriptionTierRank'
 import { useSettingsDialog } from '@/platform/settings/composables/useSettingsDialog'
-import { isCloud } from '@/platform/distribution/types'
 import { useTelemetry } from '@/platform/telemetry'
 import type {
   BillingFailure,
@@ -424,7 +423,7 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
     // so leave it open. Top-ups have no such step: close and surface settings.
     if (operation.type === 'topup') {
       useDialogStore().closeDialog({ key: 'top-up-credits' })
-      useSettingsDialog().show(isCloud ? 'workspace' : 'credits')
+      useSettingsDialog().show('workspace')
     }
 
     const toastStore = useToastStore()


### PR DESCRIPTION
## Problem / Goal

This fix merged to main post-ECS-cut, so the 1.52 release line lacks it.

## Proposed Solution

Clean cherry-pick of 91a3866c8b8277ca0b73d8845eaa630e403ce565 onto `cloud/1.52` using `git cherry-pick -x`. No conflict resolutions or test adaptations were required.

## Acceptance Criteria

- [ ] Cherry-picked change is present on the release branch.
- [ ] CI is green on the release branch.