### PR TITLE
[core/1.52] Backport #15538: fix: keep node display_name and description across the locale collector boundary

### DIFF
--- a/scripts/collect-i18n-node-defs.ts
+++ b/scripts/collect-i18n-node-defs.ts
@@ -1,9 +1,9 @@
 import * as fs from 'fs'
 
+import type { ComfyNodeDef as ComfyNodeDefV2 } from '@/schemas/nodeDef/nodeDefSchemaV2'
 import type { ComfyNodeDef } from '@/schemas/nodeDefSchema'
 
 import { comfyPageFixture as test } from '../browser_tests/fixtures/ComfyPage'
-import type { ComfyNodeDefImpl } from '../src/stores/nodeDefStore'
 import type { WidgetLabels } from './nodeDefLocaleSerializer'
 import { serializeNodeDefLocales } from './nodeDefLocaleSerializer'
 
@@ -20,22 +20,21 @@ test('collect-i18n-node-defs', async ({ comfyPage }) => {
 
   // Note: Don't mock the object_info API endpoint - let it hit the actual backend
 
-  const nodeDefs: ComfyNodeDefImpl[] = await comfyPage.page.evaluate(
-    async () => {
-      const app = window.app
-      if (!app) throw new Error('ComfyUI app is not initialized')
+  const nodeDefs: ComfyNodeDefV2[] = await comfyPage.page.evaluate(async () => {
+    const app = window.app
+    if (!app) throw new Error('ComfyUI app is not initialized')
 
-      const rawNodeDefs = await app.api.getNodeDefs()
-      const { ComfyNodeDefImpl } = await import('../src/stores/nodeDefStore')
+    const rawNodeDefs = await app.api.getNodeDefs()
+    const { transformNodeDefV1ToV2 } =
+      await import('../src/schemas/nodeDef/migration')
 
-      return (
-        Object.values(rawNodeDefs)
-          // Ignore DevTools nodes (used for internal testing)
-          .filter((def: ComfyNodeDef) => !def.name.startsWith('DevTools'))
-          .map((def: ComfyNodeDef) => new ComfyNodeDefImpl(def))
-      )
-    }
-  )
+    return (
+      Object.values(rawNodeDefs)
+        // Ignore DevTools nodes (used for internal testing)
+        .filter((def: ComfyNodeDef) => !def.name.startsWith('DevTools'))
+        .map((def: ComfyNodeDef) => transformNodeDefV1ToV2(def))
+    )
+  })
 
   async function extractWidgetLabels() {
     const nodeLabels: WidgetLabels = {}

--- a/scripts/nodeDefLocaleSerializer.test.ts
+++ b/scripts/nodeDefLocaleSerializer.test.ts
@@ -1,6 +1,8 @@
 import { createI18n } from 'vue-i18n'
 import { describe, expect, it } from 'vitest'
 
+import { transformNodeDefV1ToV2 } from '@/schemas/nodeDef/migration'
+import type { ComfyNodeDef as ComfyNodeDefV1 } from '@/schemas/nodeDefSchema'
 import { escapeI18nMessage } from '@/utils/formatUtil'
 
 import { serializeNodeDefLocales } from './nodeDefLocaleSerializer'
@@ -15,6 +17,41 @@ function render(message: string): string {
 }
 
 describe('serializeNodeDefLocales', () => {
+  it('preserves raw backend text across the collector boundary', () => {
+    const backendNodeDef: ComfyNodeDefV1 = {
+      name: 'SerializationProbe',
+      display_name: 'Live Display Name',
+      description: 'Live description',
+      category: 'testing',
+      python_module: 'nodes',
+      input: {
+        required: {
+          seed: ['INT', { tooltip: 'Live input tooltip' }]
+        }
+      },
+      output: ['IMAGE'],
+      output_name: ['image'],
+      output_tooltips: ['Live output tooltip'],
+      output_node: false
+    }
+
+    const crossedBoundary = structuredClone(
+      transformNodeDefV1ToV2(backendNodeDef)
+    )
+    const { nodeDefinitions } = serializeNodeDefLocales([crossedBoundary])
+
+    expect(nodeDefinitions.SerializationProbe).toEqual({
+      display_name: 'Live Display Name',
+      description: 'Live description',
+      inputs: {
+        seed: { name: 'seed', tooltip: 'Live input tooltip' }
+      },
+      outputs: {
+        0: { name: 'image', tooltip: 'Live output tooltip' }
+      }
+    })
+  })
+
   it('escapes compiled fields and preserves raw tooltips', () => {
     const syntax = '@ $ {value} | 50%{done}'
     const inputName = `Input ${syntax}`


### PR DESCRIPTION
## Problem / Goal

This fix merged to main post-ECS-cut, so the 1.52 release line lacks it.

## Proposed Solution

Clean cherry-pick of e58a1649b8ff387b371bf449748f21b3962a5bb6 onto `core/1.52` using `git cherry-pick -x`. No conflict resolutions or test adaptations were required.

## Acceptance Criteria

- [ ] Cherry-picked change is present on the release branch.
- [ ] CI is green on the release branch.