### PR TITLE
[core/1.52] Backport #15794: fix(auth): restore API key user authentication

### DIFF
--- a/src/stores/apiKeyAuthStore.integration.test.ts
+++ b/src/stores/apiKeyAuthStore.integration.test.ts
@@ -1,0 +1,215 @@
+import type { User } from 'firebase/auth'
+import * as firebaseAuth from 'firebase/auth'
+import { createTestingPinia } from '@pinia/testing'
+import type { Pinia } from 'pinia'
+import { disposePinia, setActivePinia } from 'pinia'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import * as vuefire from 'vuefire'
+
+import { useApiKeyAuthStore } from '@/stores/apiKeyAuthStore'
+import { useAuthStore } from '@/stores/authStore'
+
+const mockFetch = vi.fn()
+
+vi.mock('vuefire', () => ({
+  useFirebaseAuth: vi.fn()
+}))
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({ t: (key: string) => key }),
+  createI18n: () => ({ global: { t: (key: string) => key } })
+}))
+
+vi.mock('firebase/auth', async (importOriginal) => {
+  const actual = await importOriginal<typeof firebaseAuth>()
+  return {
+    ...actual,
+    onAuthStateChanged: vi.fn(),
+    onIdTokenChanged: vi.fn(),
+    setPersistence: vi.fn().mockResolvedValue(undefined),
+    GoogleAuthProvider: class {
+      addScope = vi.fn()
+      setCustomParameters = vi.fn()
+    },
+    GithubAuthProvider: class {
+      addScope = vi.fn()
+      setCustomParameters = vi.fn()
+    }
+  }
+})
+
+vi.mock('@/platform/distribution/types', () => ({
+  DISTRIBUTION: 'cloud',
+  isCloud: true,
+  isDesktop: false
+}))
+
+vi.mock('@/composables/useFeatureFlags', () => ({
+  useFeatureFlags: () => ({
+    flags: { unifiedCloudAuthEnabled: false }
+  })
+}))
+
+vi.mock('@/platform/workspace/stores/workspaceAuthStore', () => ({
+  useWorkspaceAuthStore: () => ({
+    clearWorkspaceContext: vi.fn(),
+    getWorkspaceAuthHeader: vi.fn().mockReturnValue(null),
+    getUnifiedToken: vi.fn().mockReturnValue(undefined),
+    mintAtLogin: vi.fn()
+  })
+}))
+
+vi.mock('@/platform/workspace/stores/teamWorkspaceStore', () => ({
+  useTeamWorkspaceStore: () => ({
+    activeWorkspaceId: null,
+    resetForIdentityChange: vi.fn()
+  })
+}))
+
+vi.mock('@/platform/telemetry', () => ({
+  useTelemetry: () => ({ trackAuth: vi.fn() })
+}))
+
+vi.mock('@/services/dialogService', () => ({
+  useDialogService: () => ({ showErrorDialog: vi.fn() })
+}))
+
+describe('API key authentication initialization', () => {
+  let pinia: Pinia
+
+  beforeEach(() => {
+    localStorage.clear()
+    pinia = createTestingPinia({ stubActions: false })
+    setActivePinia(pinia)
+    vi.stubGlobal('fetch', mockFetch)
+    mockFetch.mockResolvedValue({
+      ok: true,
+      statusText: 'OK',
+      json: () => Promise.resolve({ id: 'test-customer-id' })
+    })
+
+    vi.mocked(vuefire.useFirebaseAuth).mockReturnValue(
+      {} as ReturnType<typeof vuefire.useFirebaseAuth>
+    )
+    vi.mocked(firebaseAuth.onAuthStateChanged).mockImplementation(
+      (_, callback) => {
+        ;(callback as (user: User | null) => void)(null)
+        return vi.fn()
+      }
+    )
+    vi.mocked(firebaseAuth.onIdTokenChanged).mockReturnValue(vi.fn())
+  })
+
+  afterEach(() => {
+    disposePinia(pinia)
+  })
+
+  const customerResponse = (id: string) => ({
+    ok: true,
+    statusText: 'OK',
+    json: () => Promise.resolve({ id })
+  })
+
+  const settleQueuedTasks = () => new Promise((resolve) => setTimeout(resolve))
+
+  const initializeStoreWithPendingLookup = async () => {
+    let settleLookup!: {
+      resolve: (response: unknown) => void
+      reject: (reason: Error) => void
+    }
+    mockFetch.mockImplementationOnce(
+      () =>
+        new Promise((resolve, reject) => {
+          settleLookup = { resolve, reject }
+        })
+    )
+    localStorage.setItem('comfy_api_key', 'key-a')
+    useAuthStore()
+    const apiKeyStore = useApiKeyAuthStore()
+    await vi.waitFor(() => expect(mockFetch).toHaveBeenCalledOnce())
+    return { apiKeyStore, ...settleLookup }
+  }
+
+  it('retains and validates a persisted key while the API key store initializes', async () => {
+    localStorage.setItem('comfy_api_key', 'persisted-api-key')
+    useAuthStore()
+
+    const apiKeyStore = useApiKeyAuthStore()
+
+    await vi.waitFor(() => expect(mockFetch).toHaveBeenCalledOnce())
+
+    expect(apiKeyStore.getApiKey()).toBe('persisted-api-key')
+    expect(apiKeyStore.currentUser).toEqual({ id: 'test-customer-id' })
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining('/customers'),
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          'X-API-KEY': 'persisted-api-key'
+        })
+      })
+    )
+  })
+
+  it('sends one customer lookup for the replacement key when the key changes before initialization runs', async () => {
+    localStorage.setItem('comfy_api_key', 'key-a')
+    useAuthStore()
+    const apiKeyStore = useApiKeyAuthStore()
+
+    void apiKeyStore.storeApiKey('key-b')
+
+    await vi.waitFor(() =>
+      expect(apiKeyStore.currentUser).toEqual({ id: 'test-customer-id' })
+    )
+    await settleQueuedTasks()
+
+    expect(mockFetch).toHaveBeenCalledOnce()
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining('/customers'),
+      expect.objectContaining({
+        headers: expect.objectContaining({ 'X-API-KEY': 'key-b' })
+      })
+    )
+  })
+
+  it('ignores a stale customer response after the key is replaced', async () => {
+    const { apiKeyStore, resolve } = await initializeStoreWithPendingLookup()
+
+    await apiKeyStore.storeApiKey('key-b')
+    await vi.waitFor(() =>
+      expect(apiKeyStore.currentUser).toEqual({ id: 'test-customer-id' })
+    )
+
+    resolve(customerResponse('stale-customer-id'))
+    await settleQueuedTasks()
+
+    expect(apiKeyStore.currentUser).toEqual({ id: 'test-customer-id' })
+    expect(apiKeyStore.getApiKey()).toBe('key-b')
+  })
+
+  it('retains the replacement key when the stale lookup fails', async () => {
+    const { apiKeyStore, reject } = await initializeStoreWithPendingLookup()
+
+    await apiKeyStore.storeApiKey('key-b')
+    await vi.waitFor(() =>
+      expect(apiKeyStore.currentUser).toEqual({ id: 'test-customer-id' })
+    )
+
+    reject(new Error('stale lookup failed'))
+    await settleQueuedTasks()
+
+    expect(apiKeyStore.getApiKey()).toBe('key-b')
+    expect(apiKeyStore.currentUser).toEqual({ id: 'test-customer-id' })
+  })
+
+  it('keeps the user signed out when a pending lookup resolves after the key is cleared', async () => {
+    const { apiKeyStore, resolve } = await initializeStoreWithPendingLookup()
+
+    await apiKeyStore.clearStoredApiKey()
+    resolve(customerResponse('stale-customer-id'))
+    await settleQueuedTasks()
+
+    expect(apiKeyStore.currentUser).toBeNull()
+    expect(apiKeyStore.getApiKey()).toBeNull()
+    expect(mockFetch).toHaveBeenCalledOnce()
+  })
+})

--- a/src/stores/apiKeyAuthStore.ts
+++ b/src/stores/apiKeyAuthStore.ts
@@ -1,6 +1,6 @@
 import { useLocalStorage } from '@vueuse/core'
 import { defineStore } from 'pinia'
-import { computed, ref, watch } from 'vue'
+import { computed, nextTick, ref, watch } from 'vue'
 
 import { useErrorHandling } from '@/composables/useErrorHandling'
 import { t } from '@/i18n'
@@ -23,13 +23,14 @@ export const useApiKeyAuthStore = defineStore('apiKeyAuth', () => {
   const currentUser = ref<ComfyApiUser | null>(null)
   const isAuthenticated = computed(() => !!currentUser.value)
 
-  const initializeUserFromApiKey = async () => {
+  const initializeUserFromApiKey = async (watchedApiKey: string) => {
     const createCustomerResponse = await authStore
       .createCustomer()
       .catch((err) => {
         console.error(err)
         return
       })
+    if (apiKey.value !== watchedApiKey) return
     if (!createCustomerResponse) {
       apiKey.value = null
       throw new Error(t('auth.login.noAssociatedUser'))
@@ -39,12 +40,12 @@ export const useApiKeyAuthStore = defineStore('apiKeyAuth', () => {
 
   watch(
     apiKey,
-    () => {
-      if (apiKey.value) {
-        // IF API key is set, initialize user
-        void initializeUserFromApiKey()
+    async (watchedApiKey) => {
+      if (watchedApiKey) {
+        await nextTick()
+        if (apiKey.value !== watchedApiKey) return
+        void initializeUserFromApiKey(watchedApiKey)
       } else {
-        // IF API key is cleared, clear user
         currentUser.value = null
       }
     },

--- a/src/stores/authStore.test.ts
+++ b/src/stores/authStore.test.ts
@@ -1192,15 +1192,22 @@ describe('useAuthStore', () => {
       })
     })
 
-    it('should reject API key auth when no Firebase user is present', async () => {
+    it('should use API key auth when no Firebase user is present', async () => {
       authStateCallback(null)
       mockApiKeyGetAuthHeader.mockReturnValue({ 'X-API-KEY': 'test-api-key' })
 
-      await expect(store.createCustomer()).rejects.toMatchObject({
-        name: 'AuthStoreError',
-        message: 'toastMessages.userNotAuthenticated'
-      })
-      expect(mockFetch).not.toHaveBeenCalled()
+      const result = await store.createCustomer()
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining('/customers'),
+        expect.objectContaining({
+          method: 'POST',
+          headers: expect.objectContaining({
+            'X-API-KEY': 'test-api-key'
+          })
+        })
+      )
+      expect(result).toEqual({ id: 'test-customer-id' })
     })
 
     it('should use Firebase token when Firebase user is present', async () => {
@@ -1218,11 +1225,21 @@ describe('useAuthStore', () => {
       expect(result).toEqual({ id: 'test-customer-id' })
     })
 
+    it('should not fall back to API key when Firebase token retrieval fails', async () => {
+      mockUser.getIdToken.mockResolvedValue(undefined)
+      mockApiKeyGetAuthHeader.mockReturnValue({ 'X-API-KEY': 'test-api-key' })
+
+      await expect(store.createCustomer()).rejects.toThrow()
+      expect(mockApiKeyGetAuthHeader).not.toHaveBeenCalled()
+      expect(mockFetch).not.toHaveBeenCalled()
+    })
+
     it('should throw when no auth method is available', async () => {
       authStateCallback(null)
       mockApiKeyGetAuthHeader.mockReturnValue(null)
 
       await expect(store.createCustomer()).rejects.toThrow()
+      expect(mockFetch).not.toHaveBeenCalled()
     })
 
     it('carries the HTTP status on a non-ok response', async () => {

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -431,7 +431,10 @@ export const useAuthStore = defineStore('auth', () => {
     payload?: Omit<CreateCustomerPayload, 'signup_source'>
   ): Promise<CreateCustomerResponse> => {
     const sessionUserId = currentUser.value?.uid
-    const authHeader = await getFirebaseAuthHeader()
+    const authHeader =
+      currentUser.value === null
+        ? useApiKeyAuthStore().getAuthHeader()
+        : await getFirebaseAuthHeader()
     if (!authHeader) {
       throw new AuthStoreError(t('toastMessages.userNotAuthenticated'))
     }


### PR DESCRIPTION
## Problem / Goal

This fix merged to main post-ECS-cut, so the 1.52 release line lacks it.

## Proposed Solution

Clean cherry-pick of a46f935faad3e75e2fb4ffae62db9491feb1d3e5 onto `core/1.52` using `git cherry-pick -x`. No conflict resolutions or test adaptations were required.

## Acceptance Criteria

- [ ] Cherry-picked change is present on the release branch.
- [ ] CI is green on the release branch.