### PR TITLE
[cloud/1.52] Backport #15430: fix(workspace): guard prompt billing context

### DIFF
--- a/browser_tests/fixtures/workspaceSwitcherFixture.ts
+++ b/browser_tests/fixtures/workspaceSwitcherFixture.ts
@@ -6,6 +6,7 @@ import {
   EMPTY_BILLING_PLANS,
   ENDED_STANDARD_BILLING_STATUS
 } from '@e2e/fixtures/data/cloudWorkspace'
+import { makeWorkspaceTokenResponse } from '@e2e/fixtures/data/workspaceAuthFixtures'
 import {
   WORKSPACE_SWITCHER_REMOTE_CONFIG,
   WORKSPACE_SWITCHER_WORKSPACES
@@ -18,7 +19,14 @@ import { mockWorkspaceList } from '@e2e/fixtures/utils/workspaceMocks'
  * (team workspaces enabled), the workspace list, workspace-token minting for
  * whichever workspace is being switched to, and a no-op session refresh.
  */
-export const workspaceSwitcherTest = comfyPageFixture.extend({
+interface WorkspaceSwitchTokenGate {
+  requestReceived: Promise<void>
+  release: () => void
+}
+
+export const workspaceSwitcherTest = comfyPageFixture.extend<{
+  workspaceSwitchTokenGate: WorkspaceSwitchTokenGate
+}>({
   page: async ({ page }, use) => {
     await page.route('**/api/features', (route) =>
       route.fulfill(jsonRoute(WORKSPACE_SWITCHER_REMOTE_CONFIG))
@@ -67,5 +75,51 @@ export const workspaceSwitcherTest = comfyPageFixture.extend({
     )
 
     await use(page)
+  },
+  workspaceSwitchTokenGate: async ({ page }, use) => {
+    let markRequestReceived: () => void = () => {}
+    const requestReceived = new Promise<void>((resolve) => {
+      markRequestReceived = resolve
+    })
+    let releaseToken: () => void = () => {}
+    const tokenRelease = new Promise<void>((resolve) => {
+      releaseToken = resolve
+    })
+    await page.route('**/api/auth/token', async (route) => {
+      const requestBody = route.request().postDataJSON() as {
+        workspace_id?: string
+      }
+      if (requestBody.workspace_id !== 'ws-team') {
+        await route.fallback()
+        return
+      }
+
+      markRequestReceived()
+      await tokenRelease
+      const workspace = WORKSPACE_SWITCHER_WORKSPACES.find(
+        ({ id }) => id === requestBody.workspace_id
+      )
+      if (!workspace) {
+        await route.fulfill({ status: 404 })
+        return
+      }
+      await route.fulfill(
+        jsonRoute(
+          makeWorkspaceTokenResponse(
+            workspace,
+            `mock-workspace-token-${workspace.id}`
+          )
+        )
+      )
+    })
+
+    try {
+      await use({
+        requestReceived,
+        release: releaseToken
+      })
+    } finally {
+      releaseToken()
+    }
   }
 })

--- a/browser_tests/tests/workspace/localWorkspaceSwitcher.spec.ts
+++ b/browser_tests/tests/workspace/localWorkspaceSwitcher.spec.ts
@@ -95,4 +95,39 @@ test.describe('Local workspace switcher', { tag: '@auth' }, () => {
       await page.evaluate(() => document.body.dataset.workspaceSwitchDocument)
     ).toBe('original')
   })
+
+  test('queues with the target workspace after a delayed switch', async ({
+    comfyPage,
+    workspaceSwitchTokenGate
+  }) => {
+    const page = comfyPage.page
+    await comfyPage.settings.setSetting('Comfy.UseNewMenu', 'Top')
+    await comfyPage.workflow.loadWorkflow('default')
+    await comfyPage.toast.closeToasts()
+    await page.getByRole('button', { name: 'Current user' }).click()
+    await page.getByTestId('workspace-switcher-trigger').click()
+    const promptRequest = page.waitForRequest(
+      (request) =>
+        request.method() === 'POST' &&
+        new URL(request.url()).pathname.endsWith('/api/prompt')
+    )
+
+    await page
+      .getByTestId('workspace-switcher-panel')
+      .getByText(TEAM_WORKSPACE_NAME, { exact: true })
+      .click()
+    await workspaceSwitchTokenGate.requestReceived
+    await page.evaluate(() => {
+      void window.app!.queuePrompt(0)
+    })
+    workspaceSwitchTokenGate.release()
+
+    expect((await promptRequest).postDataJSON()).toEqual(
+      expect.objectContaining({
+        extra_data: expect.objectContaining({
+          auth_token_comfy_org: 'mock-workspace-token-ws-team'
+        })
+      })
+    )
+  })
 })

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2129,7 +2129,8 @@
     "extensionFileHint": "This may be due to the following script",
     "promptExecutionError": "Prompt execution failed",
     "accessRestrictedTitle": "Access Restricted",
-    "accessRestrictedMessage": "Your account is not authorized for this feature."
+    "accessRestrictedMessage": "Your account is not authorized for this feature.",
+    "workspaceChangedDuringExecution": "Your active workspace changed while preparing this execution. Run the workflow again to use the current workspace."
   },
   "apiNodesSignInDialog": {
     "title": "Sign In Required to Use API Nodes",

--- a/src/platform/workspace/stores/teamWorkspaceStore.test.ts
+++ b/src/platform/workspace/stores/teamWorkspaceStore.test.ts
@@ -455,6 +455,7 @@ describe('useTeamWorkspaceStore', () => {
       await store.switchWorkspace(currentId!)
 
       expect(mockReload).not.toHaveBeenCalled()
+      expect(store.workspaceTransitionGeneration).toBe(0)
     })
 
     it('clears workflow restore state before switching workspaces', async () => {
@@ -504,6 +505,7 @@ describe('useTeamWorkspaceStore', () => {
       expect(mockReload).not.toHaveBeenCalled()
       expect(store.isSwitching).toBe(false)
       expect(store.activeWorkspaceBillingRail).toBeNull()
+      expect(store.workspaceTransitionGeneration).toBe(1)
 
       store.setWorkspaceBillingRail(mockTeamWorkspace.id, 'metronome')
       expect(store.activeWorkspaceBillingRail).toBe('metronome')
@@ -533,6 +535,81 @@ describe('useTeamWorkspaceStore', () => {
       await firstSwitch
 
       expect(store.activeWorkspaceId).toBe(mockTeamWorkspace.id)
+    })
+
+    it('waits for an in-progress local workspace switch', async () => {
+      mockDistributionTypes.isCloud = false
+      const store = useTeamWorkspaceStore()
+      await store.initialize()
+
+      let finishSwitch: () => void = () => {}
+      mockWorkspaceAuthStore.switchWorkspace.mockImplementationOnce(
+        () =>
+          new Promise<void>((resolve) => {
+            finishSwitch = () => {
+              mockWorkspaceAuthStore.currentWorkspace = mockTeamWorkspace
+              resolve()
+            }
+          })
+      )
+
+      const workspaceSwitch = store.switchWorkspace(mockTeamWorkspace.id)
+      const switchBarrier = store.waitForWorkspaceSwitch()
+      let barrierResolved = false
+      void switchBarrier.then(() => {
+        barrierResolved = true
+      })
+
+      await Promise.resolve()
+      expect(barrierResolved).toBe(false)
+      expect(store.activeWorkspaceId).toBe(mockPersonalWorkspace.id)
+
+      finishSwitch()
+      await switchBarrier
+
+      expect(store.activeWorkspaceId).toBe(mockTeamWorkspace.id)
+      await workspaceSwitch
+    })
+
+    it('does not wait for a previous identity workspace switch', async () => {
+      mockDistributionTypes.isCloud = false
+      const store = useTeamWorkspaceStore()
+      await store.initialize()
+
+      let finishSwitch: () => void = () => {}
+      mockWorkspaceAuthStore.switchWorkspace.mockImplementationOnce(
+        () =>
+          new Promise<void>((resolve) => {
+            finishSwitch = resolve
+          })
+      )
+
+      const previousIdentitySwitch = store.switchWorkspace(mockTeamWorkspace.id)
+      store.resetForIdentityChange()
+
+      await expect(store.waitForWorkspaceSwitch()).resolves.toBeUndefined()
+
+      finishSwitch()
+      await previousIdentitySwitch
+    })
+
+    it('propagates a failed local workspace switch to waiters', async () => {
+      mockDistributionTypes.isCloud = false
+      const store = useTeamWorkspaceStore()
+      await store.initialize()
+      mockWorkspaceAuthStore.switchWorkspace.mockRejectedValueOnce(
+        new Error('Token exchange failed')
+      )
+
+      const workspaceSwitch = store.switchWorkspace(mockTeamWorkspace.id)
+
+      await Promise.all([
+        expect(workspaceSwitch).rejects.toThrow('Token exchange failed'),
+        expect(store.waitForWorkspaceSwitch()).rejects.toThrow(
+          'Token exchange failed'
+        )
+      ])
+      expect(store.activeWorkspaceId).toBe(mockPersonalWorkspace.id)
     })
 
     it('sets isSwitching flag during operation', async () => {

--- a/src/platform/workspace/stores/teamWorkspaceStore.ts
+++ b/src/platform/workspace/stores/teamWorkspaceStore.ts
@@ -139,8 +139,13 @@ export const useTeamWorkspaceStore = defineStore('teamWorkspace', () => {
   const isDeleting = ref(false)
   const isSwitching = ref(false)
   const isFetchingWorkspaces = ref(false)
+  const mutableWorkspaceTransitionGeneration = ref(0)
+  const workspaceTransitionGeneration = computed(
+    () => mutableWorkspaceTransitionGeneration.value
+  )
   let identityGeneration = 0
   let initializationPromise: Promise<void> | null = null
+  let pendingWorkspaceSwitch: Promise<void> | null = null
 
   function isStaleIdentity(generation: number): boolean {
     return generation !== identityGeneration
@@ -457,14 +462,11 @@ export const useTeamWorkspaceStore = defineStore('teamWorkspace', () => {
    * Switch to a different workspace.
    * Clears workspace context and reloads the page.
    */
-  async function switchWorkspace(workspaceId: string): Promise<void> {
-    if (workspaceId === activeWorkspaceId.value) return
-    if (!isCloud && isSwitching.value)
-      throw new Error('Workspace switch already in progress')
-
+  async function executeWorkspaceSwitch(workspaceId: string): Promise<void> {
     const generation = identityGeneration
     const workspaceAuthStore = useWorkspaceAuthStore()
 
+    mutableWorkspaceTransitionGeneration.value++
     isSwitching.value = true
 
     try {
@@ -509,6 +511,26 @@ export const useTeamWorkspaceStore = defineStore('teamWorkspace', () => {
       }
       throw e
     }
+  }
+
+  async function switchWorkspace(workspaceId: string): Promise<void> {
+    if (workspaceId === activeWorkspaceId.value) return
+    if (!isCloud && isSwitching.value)
+      throw new Error('Workspace switch already in progress')
+
+    const workspaceSwitch = executeWorkspaceSwitch(workspaceId)
+    pendingWorkspaceSwitch = workspaceSwitch
+    try {
+      await workspaceSwitch
+    } finally {
+      if (pendingWorkspaceSwitch === workspaceSwitch) {
+        pendingWorkspaceSwitch = null
+      }
+    }
+  }
+
+  function waitForWorkspaceSwitch(): Promise<void> {
+    return pendingWorkspaceSwitch ?? Promise.resolve()
   }
 
   /**
@@ -901,6 +923,8 @@ export const useTeamWorkspaceStore = defineStore('teamWorkspace', () => {
 
   function resetForIdentityChange(): void {
     identityGeneration++
+    mutableWorkspaceTransitionGeneration.value++
+    pendingWorkspaceSwitch = null
     initializationPromise = null
     initState.value = 'uninitialized'
     workspaces.value = []
@@ -921,6 +945,7 @@ export const useTeamWorkspaceStore = defineStore('teamWorkspace', () => {
     initState,
     workspaces,
     activeWorkspaceId,
+    workspaceTransitionGeneration,
     error,
     isCreating,
     isDeleting,
@@ -952,6 +977,7 @@ export const useTeamWorkspaceStore = defineStore('teamWorkspace', () => {
 
     // Workspace Actions
     switchWorkspace,
+    waitForWorkspaceSwitch,
     forgetRevokedActiveWorkspace,
     createWorkspace,
     deleteWorkspace,

--- a/src/scripts/app.test.ts
+++ b/src/scripts/app.test.ts
@@ -33,6 +33,7 @@ import { installErrorClearingHooks } from '@/composables/graph/useErrorClearingH
 import { setTelemetryRegistry } from '@/platform/telemetry'
 import { TelemetryRegistry } from '@/platform/telemetry/TelemetryRegistry'
 import * as executionContextUtils from '@/platform/telemetry/utils/getExecutionContext'
+import { isCloud } from '@/platform/distribution/types'
 
 import { PromptExecutionError, api } from '@/scripts/api'
 import { useExecutionErrorStore } from '@/stores/executionErrorStore'
@@ -60,6 +61,7 @@ const {
   mockToastStore,
   mockExtensionService,
   mockNodeOutputStore,
+  mockTeamWorkspaceStore,
   mockWorkspaceWorkflow,
   mockRefreshMissingModelPipeline,
   mockImportA1111,
@@ -89,6 +91,11 @@ const {
     stashPreviewsForWorkflow: vi.fn(),
     restorePreviewsForWorkflow: vi.fn(),
     discardPreviewsForWorkflow: vi.fn()
+  },
+  mockTeamWorkspaceStore: {
+    activeWorkspaceId: 'workspace-a' as string | null,
+    workspaceTransitionGeneration: 0,
+    waitForWorkspaceSwitch: vi.fn(() => Promise.resolve())
   },
   mockWorkspaceWorkflow: {
     activeWorkflow: null as ComfyWorkflow | null,
@@ -120,6 +127,10 @@ vi.mock('@/stores/apiKeyAuthStore', () => ({
 
 vi.mock('@/stores/authStore', () => ({
   useAuthStore: vi.fn(() => mockAuthStore)
+}))
+
+vi.mock('@/platform/workspace/stores/teamWorkspaceStore', () => ({
+  useTeamWorkspaceStore: vi.fn(() => mockTeamWorkspaceStore)
 }))
 
 vi.mock('@/platform/settings/settingStore', () => ({
@@ -283,7 +294,10 @@ describe('ComfyApp', () => {
       return workflow
     })
     mockApiKeyAuthStore.getApiKey.mockReturnValue(undefined)
-    mockAuthStore.getWorkspaceAuthToken.mockResolvedValue(undefined)
+    mockAuthStore.getWorkspaceAuthToken.mockResolvedValue('workspace-token')
+    mockTeamWorkspaceStore.activeWorkspaceId = 'workspace-a'
+    mockTeamWorkspaceStore.workspaceTransitionGeneration = 0
+    mockTeamWorkspaceStore.waitForWorkspaceSwitch.mockResolvedValue()
     mockExtensionService.invokeExtensions.mockReturnValue([])
     mockExtensionService.invokeExtensionsAsync.mockResolvedValue(undefined)
     vi.mocked(extractFilesFromDragEvent).mockResolvedValue([])
@@ -336,6 +350,188 @@ describe('ComfyApp', () => {
       resolveToken('workspace-token')
       await expect(submission).resolves.toBe(true)
       expect(queuePrompt).toHaveBeenCalledOnce()
+    })
+
+    it('waits for a workspace switch before selecting the billing context', async () => {
+      prepareEmptyPromptQueue()
+      let finishSwitch: () => void = () => {}
+      mockTeamWorkspaceStore.waitForWorkspaceSwitch.mockImplementationOnce(
+        () =>
+          new Promise<void>((resolve) => {
+            finishSwitch = () => {
+              mockTeamWorkspaceStore.activeWorkspaceId = 'workspace-b'
+              resolve()
+            }
+          })
+      )
+      mockAuthStore.getWorkspaceAuthToken.mockResolvedValueOnce(
+        'workspace-token-b'
+      )
+      const queuePrompt = vi
+        .spyOn(api, 'queuePrompt')
+        .mockImplementation(() => {
+          expect(api.authToken).toBe('workspace-token-b')
+          return Promise.resolve({ prompt_id: 'job-1', error: '' })
+        })
+
+      const submission = app.queuePrompt(0)
+      await vi.waitFor(() =>
+        expect(
+          mockTeamWorkspaceStore.waitForWorkspaceSwitch
+        ).toHaveBeenCalledOnce()
+      )
+
+      expect(mockAuthStore.getWorkspaceAuthToken).not.toHaveBeenCalled()
+      expect(app.graphToPrompt).not.toHaveBeenCalled()
+      expect(queuePrompt).not.toHaveBeenCalled()
+
+      finishSwitch()
+      await expect(submission).resolves.toBe(true)
+
+      expect(mockAuthStore.getWorkspaceAuthToken).toHaveBeenCalledOnce()
+      expect(queuePrompt).toHaveBeenCalledOnce()
+    })
+
+    it('does not submit when an in-progress workspace switch fails', async () => {
+      prepareEmptyPromptQueue()
+      mockTeamWorkspaceStore.waitForWorkspaceSwitch.mockRejectedValueOnce(
+        new Error('Token exchange failed')
+      )
+      const queuePrompt = vi.spyOn(api, 'queuePrompt')
+      const showDialog = vi.spyOn(useDialogStore(), 'showDialog')
+
+      await expect(app.queuePrompt(0)).resolves.toBe(false)
+
+      expect(mockAuthStore.getWorkspaceAuthToken).not.toHaveBeenCalled()
+      expect(app.graphToPrompt).not.toHaveBeenCalled()
+      expect(queuePrompt).not.toHaveBeenCalled()
+      expect(showDialog).toHaveBeenCalledOnce()
+    })
+
+    it.skipIf(isCloud)(
+      'uses a workspace initialized while local authentication is pending',
+      async () => {
+        prepareEmptyPromptQueue()
+        mockTeamWorkspaceStore.activeWorkspaceId = null
+        mockAuthStore.getWorkspaceAuthToken.mockImplementationOnce(async () => {
+          mockTeamWorkspaceStore.activeWorkspaceId = 'workspace-a'
+          return 'workspace-token'
+        })
+        const queuePrompt = vi
+          .spyOn(api, 'queuePrompt')
+          .mockImplementation(() => {
+            expect(api.authToken).toBe('workspace-token')
+            return Promise.resolve({ prompt_id: 'job-1', error: '' })
+          })
+
+        await expect(app.queuePrompt(0)).resolves.toBe(true)
+
+        expect(queuePrompt).toHaveBeenCalledOnce()
+      }
+    )
+
+    it.skipIf(!isCloud)(
+      'does not submit when a cloud workspace appears during authentication',
+      async () => {
+        prepareEmptyPromptQueue()
+        mockTeamWorkspaceStore.activeWorkspaceId = null
+        mockAuthStore.getWorkspaceAuthToken.mockImplementationOnce(async () => {
+          mockTeamWorkspaceStore.activeWorkspaceId = 'workspace-a'
+          return 'firebase-token'
+        })
+        const queuePrompt = vi.spyOn(api, 'queuePrompt')
+        const showDialog = vi.spyOn(useDialogStore(), 'showDialog')
+
+        await expect(app.queuePrompt(0)).resolves.toBe(false)
+
+        expect(queuePrompt).not.toHaveBeenCalled()
+        expect(showDialog).toHaveBeenCalledOnce()
+      }
+    )
+
+    it('does not submit when the workspace changes during authentication', async () => {
+      prepareEmptyPromptQueue()
+      mockAuthStore.getWorkspaceAuthToken.mockImplementationOnce(async () => {
+        mockTeamWorkspaceStore.activeWorkspaceId = 'workspace-b'
+        return 'workspace-token-a'
+      })
+      const queuePrompt = vi.spyOn(api, 'queuePrompt')
+      const showDialog = vi.spyOn(useDialogStore(), 'showDialog')
+
+      await expect(app.queuePrompt(0)).resolves.toBe(false)
+
+      expect(queuePrompt).not.toHaveBeenCalled()
+      expect(showDialog).toHaveBeenCalledOnce()
+    })
+
+    it('does not submit a prompt after the active workspace changes', async () => {
+      prepareEmptyPromptQueue()
+      let finishPromptBuild: () => void = () => {}
+      vi.spyOn(app, 'graphToPrompt').mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            finishPromptBuild = () =>
+              resolve({
+                output: {},
+                workflow: createWorkflowGraphData()
+              })
+          })
+      )
+      const queuePrompt = vi.spyOn(api, 'queuePrompt')
+      const showDialog = vi.spyOn(useDialogStore(), 'showDialog')
+
+      const submission = app.queuePrompt(0)
+      await vi.waitFor(() => expect(app.graphToPrompt).toHaveBeenCalledOnce())
+      mockTeamWorkspaceStore.activeWorkspaceId = 'workspace-b'
+      finishPromptBuild()
+
+      await expect(submission).resolves.toBe(false)
+      expect(queuePrompt).not.toHaveBeenCalled()
+      expect(showDialog).toHaveBeenCalledOnce()
+    })
+
+    it('does not fall back to an API key when workspace authentication fails', async () => {
+      prepareEmptyPromptQueue()
+      mockAuthStore.getWorkspaceAuthToken.mockResolvedValueOnce(undefined)
+      mockApiKeyAuthStore.getApiKey.mockReturnValueOnce('api-key')
+      const queuePrompt = vi.spyOn(api, 'queuePrompt')
+      const showDialog = vi.spyOn(useDialogStore(), 'showDialog')
+
+      await expect(app.queuePrompt(0)).resolves.toBe(false)
+      expect(queuePrompt).not.toHaveBeenCalled()
+      expect(showDialog).toHaveBeenCalledOnce()
+    })
+
+    it('does not submit after switching away and back to the same workspace', async () => {
+      prepareEmptyPromptQueue()
+      mockAuthStore.getWorkspaceAuthToken.mockResolvedValueOnce(
+        'workspace-token'
+      )
+      let finishPromptBuild: () => void = () => {}
+      vi.spyOn(app, 'graphToPrompt').mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            finishPromptBuild = () =>
+              resolve({
+                output: {},
+                workflow: createWorkflowGraphData()
+              })
+          })
+      )
+      const queuePrompt = vi.spyOn(api, 'queuePrompt')
+      const showDialog = vi.spyOn(useDialogStore(), 'showDialog')
+
+      const submission = app.queuePrompt(0)
+      await vi.waitFor(() => expect(app.graphToPrompt).toHaveBeenCalledOnce())
+      mockTeamWorkspaceStore.activeWorkspaceId = 'workspace-b'
+      mockTeamWorkspaceStore.workspaceTransitionGeneration++
+      mockTeamWorkspaceStore.activeWorkspaceId = 'workspace-a'
+      mockTeamWorkspaceStore.workspaceTransitionGeneration++
+      finishPromptBuild()
+
+      await expect(submission).resolves.toBe(false)
+      expect(queuePrompt).not.toHaveBeenCalled()
+      expect(showDialog).toHaveBeenCalledOnce()
     })
 
     it('preserves missing node packs when submitting a prompt', async () => {

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -79,6 +79,7 @@ import {
 } from '@/scripts/domWidget'
 import { useAccountPreconditionDialog } from '@/platform/cloud/subscription/composables/useAccountPreconditionDialog'
 import { resolveAccountPrecondition } from '@/platform/errorCatalog/accountPreconditionRouting'
+import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
 import { useDialogService } from '@/services/dialogService'
 import { useExtensionService } from '@/services/extensionService'
 import { useLitegraphService } from '@/services/litegraphService'
@@ -1640,7 +1641,42 @@ export class ComfyApp {
     let queueResultOverride: boolean | null = null
 
     // Get auth token for backend nodes - uses workspace token if enabled, otherwise Firebase token
+    const teamWorkspaceStore = useTeamWorkspaceStore()
+    try {
+      await teamWorkspaceStore.waitForWorkspaceSwitch()
+    } catch (error) {
+      useDialogService().showErrorDialog(error, {
+        title: t('errorDialog.promptExecutionError'),
+        reportType: 'promptExecutionError'
+      })
+      this.queueItems.length = 0
+      this.processingQueue = false
+      return false
+    }
+    const workspaceIdBeforeAuthentication = teamWorkspaceStore.activeWorkspaceId
+    const workspaceGenerationBeforeAuthentication =
+      teamWorkspaceStore.workspaceTransitionGeneration
     const comfyOrgAuthToken = await useAuthStore().getWorkspaceAuthToken()
+    const executionWorkspaceId = teamWorkspaceStore.activeWorkspaceId
+    const executionWorkspaceGeneration =
+      teamWorkspaceStore.workspaceTransitionGeneration
+    const workspaceChangedWhileAuthenticating =
+      (workspaceIdBeforeAuthentication !== executionWorkspaceId ||
+        workspaceGenerationBeforeAuthentication !==
+          executionWorkspaceGeneration) &&
+      (isCloud || workspaceIdBeforeAuthentication !== null)
+    if (executionWorkspaceId && !comfyOrgAuthToken) {
+      useDialogService().showErrorDialog(
+        new Error(t('toastMessages.userNotAuthenticated')),
+        {
+          title: t('errorDialog.promptExecutionError'),
+          reportType: 'promptExecutionError'
+        }
+      )
+      this.queueItems.length = 0
+      this.processingQueue = false
+      return false
+    }
     const comfyOrgApiKey = useApiKeyAuthStore().getApiKey()
 
     try {
@@ -1712,6 +1748,22 @@ export class ComfyApp {
               executionScope: isPartialExecution ? 'partial' : 'full',
               viewMode: getWorkflowMode(queuedWorkflow)
             })
+          }
+          if (
+            workspaceChangedWhileAuthenticating ||
+            executionWorkspaceId !== teamWorkspaceStore.activeWorkspaceId ||
+            executionWorkspaceGeneration !==
+              teamWorkspaceStore.workspaceTransitionGeneration
+          ) {
+            useDialogService().showErrorDialog(
+              new Error(t('errorDialog.workspaceChangedDuringExecution')),
+              {
+                title: t('errorDialog.promptExecutionError'),
+                reportType: 'promptExecutionError'
+              }
+            )
+            queueResultOverride = false
+            break
           }
           try {
             api.authToken = comfyOrgAuthToken


### PR DESCRIPTION
## Problem / Goal

This fix merged to main post-ECS-cut, so the 1.52 release line lacks it.

## Proposed Solution

Clean cherry-pick of 87684ed089315396e6500387da51c424f9bb7e6a onto `cloud/1.52` using `git cherry-pick -x`. No conflict resolutions or test adaptations were required.

## Acceptance Criteria

- [ ] Cherry-picked change is present on the release branch.
- [ ] CI is green on the release branch.