### PR TITLE
feat: add Comfy H3 Sync Sound Challenge livestream to /events

### DIFF
--- a/apps/website/e2e/events.spec.ts
+++ b/apps/website/e2e/events.spec.ts
@@ -143,17 +143,20 @@ test.describe('Events page — desktop @smoke', () => {
 
     // Advance to whichever video slide comes next, waiting out island hydration
     // first and then each transition, so no click overshoots a slow render.
-    const activeLabel = () =>
-      activeSlide.locator('a').getAttribute('aria-label')
     await expect(activeSlide.locator('a')).toHaveCount(1)
+    const activeLabel = async () => {
+      const label = await activeSlide.locator('a').getAttribute('aria-label')
+      if (label === null) throw new Error('active slide link has no aria-label')
+      return label
+    }
 
     for (let step = 0; step < featuredEvents.length; step++) {
       const label = await activeLabel()
-      if (label && videoSlideTitles.includes(label)) break
+      if (videoSlideTitles.includes(label)) break
       await nextSlide.click()
       await expect(activeSlide.locator('a')).not.toHaveAttribute(
         'aria-label',
-        label!
+        label
       )
     }
     expect(videoSlideTitles).toContain(await activeLabel())
@@ -171,14 +174,13 @@ test.describe('Events page — desktop @smoke', () => {
           .catch(() => false)
       )
       .toBe(true)
-    const heldLabel = await activeSlide.locator('a').getAttribute('aria-label')
-    expect(heldLabel).toBeTruthy()
+    const heldLabel = await activeLabel()
 
     // Leaving the carousel releases the held advance.
     await page.mouse.move(0, 0)
     await expect(activeSlide.locator('a')).not.toHaveAttribute(
       'aria-label',
-      heldLabel!
+      heldLabel
     )
   })
 

--- a/apps/website/e2e/events.spec.ts
+++ b/apps/website/e2e/events.spec.ts
@@ -141,8 +141,8 @@ test.describe('Events page — desktop @smoke', () => {
 
     const activeSlide = hero.locator('[aria-hidden="false"]')
 
-    // Advance to whichever video slide comes next, waiting out island hydration
-    // first and then each transition, so no click overshoots a slow render.
+    // Advance to whichever video slide comes next. A click before the island
+    // hydrates is a no-op, so each advance retries until the slide changes.
     await expect(activeSlide.locator('a')).toHaveCount(1)
     const activeLabel = async () => {
       const label = await activeSlide.locator('a').getAttribute('aria-label')
@@ -153,11 +153,13 @@ test.describe('Events page — desktop @smoke', () => {
     for (let step = 0; step < featuredEvents.length; step++) {
       const label = await activeLabel()
       if (videoSlideTitles.includes(label)) break
-      await nextSlide.click()
-      await expect(activeSlide.locator('a')).not.toHaveAttribute(
-        'aria-label',
-        label
-      )
+      await expect(async () => {
+        await nextSlide.click()
+        await expect(activeSlide.locator('a')).not.toHaveAttribute(
+          'aria-label',
+          label
+        )
+      }).toPass()
     }
     expect(videoSlideTitles).toContain(await activeLabel())
     // Clicking left the button focused; drop that focus so only the hover holds

--- a/apps/website/e2e/events.spec.ts
+++ b/apps/website/e2e/events.spec.ts
@@ -124,10 +124,10 @@ test.describe('Events page — desktop @smoke', () => {
   test('a video slide that ends while hovered advances once the pointer leaves', async ({
     page
   }) => {
-    const firstVideoIndex = featuredEvents.findIndex(
-      (event) => event.media.type === 'video'
-    )
-    test.skip(firstVideoIndex < 0, 'needs a featured video slide')
+    const videoSlideTitles = featuredEvents
+      .filter((event) => event.media.type === 'video')
+      .map((event) => event.title.en)
+    test.skip(videoSlideTitles.length === 0, 'needs a featured video slide')
 
     await page.goto(PATH_EN)
     const hero = heroSection(page, 'en')
@@ -141,19 +141,22 @@ test.describe('Events page — desktop @smoke', () => {
 
     const activeSlide = hero.locator('[aria-hidden="false"]')
 
-    // The first featured slide is an image; advance to the first video slide.
-    // Retry to wait out island hydration, but click only while the active slide
-    // is not yet the video slide so a slow render never overshoots past it.
-    const videoSlideTitle = featuredEvents[firstVideoIndex].title.en
-    await expect(async () => {
-      const activeLabel = await activeSlide
-        .locator('a')
-        .getAttribute('aria-label')
-      if (activeLabel !== videoSlideTitle) await nextSlide.click()
-      await expect(activeSlide.locator('a')).toHaveAccessibleName(
-        videoSlideTitle
+    // Advance to whichever video slide comes next, waiting out island hydration
+    // first and then each transition, so no click overshoots a slow render.
+    const activeLabel = () =>
+      activeSlide.locator('a').getAttribute('aria-label')
+    await expect(activeSlide.locator('a')).toHaveCount(1)
+
+    for (let step = 0; step < featuredEvents.length; step++) {
+      const label = await activeLabel()
+      if (label && videoSlideTitles.includes(label)) break
+      await nextSlide.click()
+      await expect(activeSlide.locator('a')).not.toHaveAttribute(
+        'aria-label',
+        label!
       )
-    }).toPass({ timeout: 15_000 })
+    }
+    expect(videoSlideTitles).toContain(await activeLabel())
     // Clicking left the button focused; drop that focus so only the hover holds
     // the slide, letting the pointer leaving be what releases the advance.
     await nextSlide.blur()

--- a/apps/website/src/data/events.ts
+++ b/apps/website/src/data/events.ts
@@ -283,6 +283,38 @@ const events: readonly ComfyEvent[] = [
     }
   },
   {
+    id: 'h3-sync-sound-challenge',
+    category: 'livestream',
+    title: {
+      en: 'Comfy H3 Sync Sound Challenge: Guest Judge Livestream',
+      'zh-CN': 'Comfy H3 同步声音挑战赛：特邀评委直播'
+    },
+    description: {
+      en: 'Guest judges join us live to review the best MiniMax H3 sync sound entries from the community and break down what makes generated audio and picture land together.',
+      'zh-CN':
+        '特邀评委做客直播间，点评社区在 MiniMax H3 同步声音挑战赛中的优秀作品，并拆解让生成音频与画面同频的关键所在。'
+    },
+    location: { en: 'Online', 'zh-CN': '线上' },
+    dateLabel: {
+      en: 'September 2, 2026 · 10AM PT',
+      'zh-CN': '2026年9月2日 · 上午10点（PT）'
+    },
+    startDateTime: '2026-09-02T10:00:00-07:00',
+    liveVideoId: '2_vEJJU_MUU',
+    media: eventImage('09.02-comfy-h3-sync.jpg', {
+      en: 'Comfy H3 Sync Sound Challenge guest judge livestream',
+      'zh-CN': 'Comfy H3 同步声音挑战赛特邀评委直播'
+    }),
+    featured: {
+      order: 1,
+      media: eventImage('09.02-comfy-h3-sync.jpg', {
+        en: 'Comfy H3 Sync Sound Challenge guest judge livestream',
+        'zh-CN': 'Comfy H3 同步声音挑战赛特邀评委直播'
+      }),
+      showTitle: false
+    }
+  },
+  {
     id: 'ucan-agentic-commerce',
     category: 'community',
     title: {
@@ -365,7 +397,7 @@ const events: readonly ComfyEvent[] = [
       'livestream-aug-19.jpg'
     ),
     featured: {
-      order: 1,
+      order: 2,
       media: eventVideo(
         '08.19-Tool_landscape.mp4',
         {
@@ -398,7 +430,7 @@ const events: readonly ComfyEvent[] = [
     link: { href: launchesHref, newTab: false },
     liveVideoId: '4xS4LOn3CTE',
     featured: {
-      order: 3,
+      order: 4,
       media: eventVideo(
         'future-of-ai-post-production.mp4',
         {
@@ -563,7 +595,7 @@ const events: readonly ComfyEvent[] = [
     startDateTime: '2026-06-23',
     recordingVideoId: '31jiUhCEjJ4',
     featured: {
-      order: 2,
+      order: 3,
       media: eventVideo(
         'founders-live.mp4',
         {


### PR DESCRIPTION
## Summary

Adds the September 2 *Comfy H3 Sync Sound Challenge: Guest Judge Livestream* to `/events` as an upcoming event and as the second featured carousel slide, behind MUTEK.

## Changes

- **What**: New `h3-sync-sound-challenge` entry in `apps/website/src/data/events.ts`. Stored as `liveVideoId: 2_vEJJU_MUU`, so the event gets its own `/events/h3-sync-sound-challenge` page and both the slide and the upcoming-row CTA link there rather than out to YouTube. `media` is set alongside `featured.media` so the event keeps its card art once it moves to the past gallery. Existing featured slides shift down one position (MUTEK 0 → H3 1 → Beyond the Models 2 → Krea 3 → Post Production 4).
- **Supporting test change**: `a video slide that ends while hovered advances once the pointer leaves` walked forward to the *first* video slide on a fixed 15s budget with a 5s wait per click, so it only tolerated a four-slide carousel and broke on the fifth. It now advances to whichever video slide comes next and waits on each transition, making it independent of how many slides are configured. Verified it passes against both the previous and the new data.

Art was already uploaded to `media.comfy.org/website/events/09.02-comfy-h3-sync.jpg`, so no asset work is needed.

## Review Focus

Two judgment calls worth a look:

- **The timestamp is `-07:00`, not `-08:00`.** The event was given to me as "10AM PST", but September 2 falls in daylight time — PST would have rendered the stream an hour early. The label follows the existing convention of writing Pacific as "PT".
- **The artwork and the title do not match.** The image reads "Comfy H3 Sync Challenge: Live Judging"; the entry uses the title as supplied. Happy to align them either direction. Related: "TBD Special Guest Judges" is baked into the image, so confirming judges means re-uploading to the same CDN path — no code change.

The slide keeps `showTitle: false` because the art is self-titling; an overlay would duplicate the headline.

The description copy is mine (none was supplied) and is easy to swap — it appears on the card, the event page, calendar export, and JSON-LD. zh-CN is a first pass, consistent with the file's existing note that Chinese copy is pending native review.

## Verification

- `pnpm typecheck` 0 errors · `pnpm test:unit` 471 passed · `pnpm lint` 0 errors · `pnpm knip` clean
- `events.spec.ts` e2e: 9 passed
- Browser-checked both locales: carousel slide 2 with the `UPCOMING LIVESTREAM` eyebrow, the upcoming row between MUTEK and UCAN with the Livestream / 直播 CTA, and the event page embedding `2_vEJJU_MUU`. Built output confirms JSON-LD emits `VirtualLocation` + `OnlineEventAttendanceMode`.
