### PR TITLE
fix(ci): make release label ensure idempotent

### DIFF
--- a/.github/workflows/release-branch-create.yaml
+++ b/.github/workflows/release-branch-create.yaml
@@ -177,17 +177,13 @@ jobs:
             COLOR="${COLORS[$PREFIX]}"
             DESCRIPTION="Backport PRs for ${PREFIX} ${BRANCH_BASE}"
 
-            if gh label view "$LABEL" >/dev/null 2>&1; then
-              gh label edit "$LABEL" \
-                --color "$COLOR" \
-                --description "$DESCRIPTION"
-              echo "🔄 Updated label $LABEL"
-            else
-              gh label create "$LABEL" \
-                --color "$COLOR" \
-                --description "$DESCRIPTION"
-              echo "✨ Created label $LABEL"
-            fi
+            # --force creates the label when missing and updates its color and
+            # description when it already exists, so re-runs never hard-fail.
+            gh label create "$LABEL" \
+              --color "$COLOR" \
+              --description "$DESCRIPTION" \
+              --force
+            echo "✅ Ensured label $LABEL"
           done
 
           MIN_LABELS_TO_KEEP=3

--- a/.github/workflows/release-branch-create.yaml
+++ b/.github/workflows/release-branch-create.yaml
@@ -15,6 +15,7 @@ jobs:
       contains(github.event.pull_request.labels.*.name, 'Release')
     permissions:
       contents: write
+      issues: write # labels are applied through the issues API
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## ELI-5

Every week a release runs a step that makes sure two labels exist (`core/1.53`, `cloud/1.53`) so backport PRs have something to be tagged with. That step first asked GitHub "does this label already exist?" using a command that doesn't exist — so the answer was always "no", and it always tried to *create* the label. Creating a label that's already there is an error, so the whole release run went red. This replaces the ask-then-create dance with one command that means "make sure it looks like this", which works whether or not the label is already there.

## Summary

The "Ensure release labels" step of `release-branch-create.yaml` fails whenever the `core/x.y` / `cloud/x.y` labels already exist, marking the release-branch run failed even though branch creation succeeded — and skipping the old-label pruning that runs after the create loop.

## Changes

- **What**: replaced the existence-check `if`/`else` at `.github/workflows/release-branch-create.yaml:180-190` with a single `gh label create "$LABEL" --color "$COLOR" --description "$DESCRIPTION" --force`. Branch creation and the `MIN_LABELS_TO_KEEP` pruning block are untouched.
- **Permissions**: added `issues: write` to the `create-release-branch` job. The job declares an explicit `permissions:` block, so every unlisted scope resolves to `none` — and all three label calls in it (`gh label create --force`, `gh label list`, `gh label delete`) go through the issues API. On the documented fallback to `secrets.GITHUB_TOKEN` they would have returned 403 and aborted the step under `set -euo pipefail`, defeating the idempotency this PR adds. Matches the scope and comment style already used by `pr-label-backport.yaml:53-55`. Raised in review by 2 of 8 reviewers.

## Root cause

`gh label view` is not a gh subcommand — gh has `label list/create/edit/delete/clone`. Verified directly against gh 2.92.0: `gh label view core/1.52 -R Comfy-Org/ComfyUI_frontend` returns `unknown command "view" for "gh label"` and exits 1. Because the check was written `if gh label view "$LABEL" >/dev/null 2>&1`, that error was swallowed and the condition was *always* false, so control always fell to `gh label create` — which hard-fails on a pre-existing label. Normal weeks never hit it because the workflow is the first thing to create the labels; it surfaced on 2026-08-24 when the 1.52 labels had been pre-created during the retroactive branch cut.

`gh label create --force` is the documented idempotent form (`gh label create --help`: *"Create a new label on GitHub, or update an existing one with `--force`"*; `-f, --force  Update the label color and description if label already exists`) — and it is exactly what gh's own failure message in the red run recommends.

## Review Focus

**The riskiest line is `--force`**, because it unconditionally rewrites an existing label's color and description. Three things make that safe here:

- It is precisely what the `gh label edit` branch this replaces was written to do — the edit path was simply unreachable, so `--force` restores the intended behavior rather than introducing new behavior.
- `--force` updates only color and description. It cannot rename a label (the name is the lookup key) and it does not touch label *assignments*, so no already-tagged backport PR loses its label.
- The only consumer of these labels, `pr-backport.yaml:125-132`, matches on the label **name** only (`^core/([0-9]+)\.([0-9]+)$` / `^cloud/…`) and never reads color or description — so the normalization is functionally inert for the automation.

Concretely, on the live repo today `core/1.52` and `cloud/1.52` carry the hand-created descriptions `Backport PRs for core/1.52` (slash); the next run will normalize them to the workflow's canonical `Backport PRs for core 1.52` (space). That is the intended edit-path behavior.

**Second thing worth a look:** this fix makes the pruning block reachable again in the pre-existing-label case. On the next successful minor cut, pruning will therefore remove exactly one label per prefix — `core/1.49` and `cloud/1.49` — because 4 versions currently exist per prefix and `MIN_LABELS_TO_KEEP=3`. That is existing, unmodified behavior, but it will visibly happen for the first time in a while, so it should not be a surprise.

## Verification

The workflow only triggers on `pull_request: closed` (paths `package.json`, label `Release`) — it has **no `workflow_dispatch` trigger**, so the ticket's suggested "manual `workflow_dispatch` against a version where the labels already exist" verification path does not exist on this workflow. I did not add one: that is scope beyond the ticket, would need version inputs, and would let a manual run mutate real labels and branches. Live verification against the production repo's labels was also off the table — proving `--force` by running it would have mutated `Comfy-Org/ComfyUI_frontend`'s label set.

So I proved it by extracting the step's real `run:` script from the YAML (before and after) and executing it against a stub `gh` that mirrors the real CLI's semantics, which I verified against gh 2.92.0 first: `label view` is an unknown command; `label create` on an existing label errors unless `--force`; `label edit` updates; `label list --json name` lists names.

| Scenario | On `main` | With this change |
|---|---|---|
| 1.52 labels pre-exist (the reported repro) | exit 1 on `label with name "core/1.52" already exists`; `cloud/1.52` never attempted; pruning never runs | exit 0; both labels ensured, descriptions normalized; pruning runs and removes `core/1.49` + `cloud/1.49` |
| 1.53 labels absent (a normal week) | exit 0, labels created | exit 0, **identical** final label state (only the log line differs: `✨ Created` → `✅ Ensured`) |
| no labels at all | — | exit 0, both created, "nothing to prune" |
| same version run 3× in a row | — | converges after pass 1 and is stable — exit 0 every pass, no further pruning |

The pre-fix simulation reproduces the CI failure exactly: same message, same exit code, same "pruning never reached" outcome as run 32775241572, whose logs I read directly (`create-release-branch` conclusion `failure`; the only failing step is "Ensure release labels", completing 20:41:19Z on `label with name "core/1.52" already exists; use --force to update its color and description`).

One disclosure on method: my first simulation pass accidentally resolved `gh` to the real CLI rather than the stub, which issued one live `gh label create "core/1.52" …` (no `--force`) against this repo. It failed on the pre-existing label exactly as CI did, so nothing was mutated — I diffed the repo's full `core/*` + `cloud/*` label set before and after and it is byte-identical. It did serve as an unintended live confirmation of the bug. The harness now hard-asserts that `gh` resolves to the stub before running.

## Sweep — the part I am not fixing

- **`gh label view` call sites in the repo: 1 total, 1 fixed, 0 remaining.**
- Widening to the whole "is this `gh` subcommand real?" family — every `gh <noun> view/show/get/exists` under `.github/`, `scripts/` and `*.sh`: **13 call sites, of which 12 are `gh pr view`** (a real subcommand, all correct). This was the only invalid one.
- The prune block fetches with `--limit 200`; the repo currently has **182 labels**, so it is not truncating today but is within 18 of the cap. Pre-existing, and the ticket explicitly scopes pruning out — flagging it, not fixing it.

## Deviations from the ticket's stated acceptance

- The ticket's verification says "actionlint passes". **It does not, on this file, before or after** — actionlint reports 25 shellcheck findings (SC2086 word-splitting, one SC2129) on `release-branch-create.yaml` on `main` today, all inside the *other* two steps ("Check version bump type" at line 33 and "Post summary" at line 224). After this change it reports the same 25 findings, byte-identical apart from the line-number shift from removing 4 lines: **zero new, zero fixed, zero in the step I touched.** actionlint is not part of this repo's CI either — the YAML gate here is yamllint. Cleaning up those 25 pre-existing findings is a separate change on the same file and is deliberately not in this PR.
- The ticket's other verification route (manual `workflow_dispatch`) does not exist on this workflow — see Verification above.
- Final green acceptance can only come from a real run: the next weekly minor cut completing green through "Ensure release labels" and executing the pruning loop. The ticket should stay open until that run is observed. Nothing in this PR asserts that has happened.
- I included the `Co-Authored-By: Christian Byrne <cbyrne@comfy.org>` trailer the ticket asked for. Flagging it as a judgment call: the credit is for reporting and diagnosing, not for writing the diff — drop it if that is not the convention you want.

## Provenance

- **Authored by:** agent-work loop
- **Verified:** `issues: write` addition — YAML re-parsed (job permissions resolve to `{contents: write, issues: write}`), `./scripts/cicd/check-yaml.sh` exit 0, and `actionlint` reports the same 25 pre-existing findings as `main` (zero new). Original commit: `actionlint .github/workflows/release-branch-create.yaml` — 25 findings, identical to `main` (0 in the changed step); `yamllint --config-file .yamllint` on the changed file — clean, and repo-wide `scripts/cicd/check-yaml.sh` — exit 0 (1 pre-existing warning in an unrelated fixture); `pnpm exec oxfmt --check` on the changed file — clean; pre-commit hooks (lint-staged + unused-i18n check) ran and passed on commit; step-script simulation — 6 scenarios, all as tabled above. Not run, because the diff touches no JS/TS/CSS/Vue and no `*.sh`: `pnpm test:unit`, `pnpm lint`, `pnpm typecheck`, `scripts/cicd/check-shell.sh`.
- **Deviations:** see "Deviations from the ticket's stated acceptance" above — the ticket's two named verification routes (actionlint clean; manual `workflow_dispatch`) do not hold on this artifact, and final acceptance awaits a real minor-cut run.

