### PR TITLE
fix(billing): recover interrupted subscription checkout on boot

### DIFF
--- a/src/components/graph/GraphCanvas.firstRunEntry.test.ts
+++ b/src/components/graph/GraphCanvas.firstRunEntry.test.ts
@@ -16,7 +16,9 @@ import GraphCanvas from './GraphCanvas.vue'
  * feeds the startup outcome to `handleStartupOutcome`, and the URL workflow
  * results to `handleUrlWorkflow`. Both composables are unit-tested on their
  * own; this file covers the seam, so deleting either call from the startup
- * sequence fails a test instead of silently disconnecting the feature.
+ * sequence fails a test instead of silently disconnecting the feature. It also
+ * pins the order the deep-link loaders depend on: dialogs they open must land
+ * on top of the overlays `handleStartupOutcome` establishes.
  */
 const mocks = vi.hoisted(() => ({
   handleStartupOutcome: vi.fn(),
@@ -24,6 +26,7 @@ const mocks = vi.hoisted(() => ({
   initializeWorkflow: vi.fn(),
   loadTemplateFromUrlIfPresent: vi.fn(),
   loadSharedWorkflowFromUrlIfPresent: vi.fn(),
+  runUrlActionLoaders: vi.fn(),
   workspaceStore: {
     spinner: false,
     focusMode: false,
@@ -88,7 +91,9 @@ vi.mock('@/services/useNewUserService', () => ({
 }))
 
 vi.mock('@/composables/useUrlActionLoaders', () => ({
-  useUrlActionLoaders: () => ({ runUrlActionLoaders: vi.fn() })
+  useUrlActionLoaders: () => ({
+    runUrlActionLoaders: mocks.runUrlActionLoaders
+  })
 }))
 
 vi.mock('@/platform/updates/common/releaseStore', () => ({
@@ -191,6 +196,14 @@ describe('GraphCanvas first-run tour wiring', () => {
     await mountGraphCanvas()
 
     expect(mocks.handleStartupOutcome).toHaveBeenCalledWith('url-intent')
+  })
+
+  it('settles the startup outcome before running the URL action loaders', async () => {
+    await mountGraphCanvas()
+
+    expect(
+      mocks.runUrlActionLoaders.mock.invocationCallOrder[0]
+    ).toBeGreaterThan(mocks.handleStartupOutcome.mock.invocationCallOrder[0])
   })
 
   it('offers the tour over a workflow that arrived from the URL', async () => {

--- a/src/composables/useUrlActionLoaders.test.ts
+++ b/src/composables/useUrlActionLoaders.test.ts
@@ -14,10 +14,12 @@ const mocks = vi.hoisted(() => ({
   loadCreateWorkspace: vi.fn(async () => undefined),
   loadPricingTable: vi.fn(async () => undefined),
   loadTopUp: vi.fn(async () => undefined),
+  resumePendingPricingFlow: vi.fn(async () => undefined),
   useInvite: vi.fn(),
   useCreateWorkspace: vi.fn(),
   usePricingTable: vi.fn(),
-  useTopUp: vi.fn()
+  useTopUp: vi.fn(),
+  useSubscriptionDialog: vi.fn()
 }))
 mocks.useInvite.mockImplementation(() => ({
   loadInviteFromUrl: mocks.loadInvite
@@ -30,6 +32,9 @@ mocks.usePricingTable.mockImplementation(() => ({
 }))
 mocks.useTopUp.mockImplementation(() => ({
   loadTopUpFromUrl: mocks.loadTopUp
+}))
+mocks.useSubscriptionDialog.mockImplementation(() => ({
+  resumePendingPricingFlow: mocks.resumePendingPricingFlow
 }))
 
 vi.mock('@/platform/workspace/composables/useInviteUrlLoader', () => ({
@@ -45,6 +50,10 @@ vi.mock(
 vi.mock('@/platform/cloud/subscription/composables/useTopUpUrlLoader', () => ({
   useTopUpUrlLoader: mocks.useTopUp
 }))
+vi.mock(
+  '@/platform/cloud/subscription/composables/useSubscriptionDialog',
+  () => ({ useSubscriptionDialog: mocks.useSubscriptionDialog })
+)
 
 describe('useUrlActionLoaders', () => {
   beforeEach(() => {
@@ -61,6 +70,9 @@ describe('useUrlActionLoaders', () => {
     mocks.useTopUp.mockImplementation(() => ({
       loadTopUpFromUrl: mocks.loadTopUp
     }))
+    mocks.useSubscriptionDialog.mockImplementation(() => ({
+      resumePendingPricingFlow: mocks.resumePendingPricingFlow
+    }))
   })
 
   it('does not instantiate or run any loader off cloud', async () => {
@@ -73,10 +85,12 @@ describe('useUrlActionLoaders', () => {
     expect(mocks.useCreateWorkspace).not.toHaveBeenCalled()
     expect(mocks.usePricingTable).not.toHaveBeenCalled()
     expect(mocks.useTopUp).not.toHaveBeenCalled()
+    expect(mocks.useSubscriptionDialog).not.toHaveBeenCalled()
     expect(mocks.loadInvite).not.toHaveBeenCalled()
     expect(mocks.loadCreateWorkspace).not.toHaveBeenCalled()
     expect(mocks.loadPricingTable).not.toHaveBeenCalled()
     expect(mocks.loadTopUp).not.toHaveBeenCalled()
+    expect(mocks.resumePendingPricingFlow).not.toHaveBeenCalled()
   })
 
   it('runs all loaders on Cloud', async () => {
@@ -86,6 +100,25 @@ describe('useUrlActionLoaders', () => {
     expect(mocks.loadInvite).toHaveBeenCalledOnce()
     expect(mocks.loadCreateWorkspace).toHaveBeenCalledOnce()
     expect(mocks.loadPricingTable).toHaveBeenCalledOnce()
+    expect(mocks.loadTopUp).toHaveBeenCalledOnce()
+  })
+
+  it('recovers an interrupted checkout after the deep-link loaders', async () => {
+    const { runUrlActionLoaders } = useUrlActionLoaders()
+    await runUrlActionLoaders()
+
+    expect(mocks.resumePendingPricingFlow).toHaveBeenCalledOnce()
+    expect(
+      mocks.resumePendingPricingFlow.mock.invocationCallOrder[0]
+    ).toBeGreaterThan(mocks.loadTopUp.mock.invocationCallOrder[0])
+  })
+
+  it('isolates a checkout-recovery failure so it does not abort the boot chain', async () => {
+    mocks.resumePendingPricingFlow.mockRejectedValueOnce(new Error('boom'))
+
+    const { runUrlActionLoaders } = useUrlActionLoaders()
+    await expect(runUrlActionLoaders()).resolves.toBeUndefined()
+
     expect(mocks.loadTopUp).toHaveBeenCalledOnce()
   })
 

--- a/src/composables/useUrlActionLoaders.ts
+++ b/src/composables/useUrlActionLoaders.ts
@@ -1,4 +1,5 @@
 import { usePricingTableUrlLoader } from '@/platform/cloud/subscription/composables/usePricingTableUrlLoader'
+import { useSubscriptionDialog } from '@/platform/cloud/subscription/composables/useSubscriptionDialog'
 import { useTopUpUrlLoader } from '@/platform/cloud/subscription/composables/useTopUpUrlLoader'
 import { isCloud } from '@/platform/distribution/types'
 import { useCreateWorkspaceUrlLoader } from '@/platform/workspace/composables/useCreateWorkspaceUrlLoader'
@@ -6,9 +7,10 @@ import { useInviteUrlLoader } from '@/platform/workspace/composables/useInviteUr
 
 /**
  * Aggregates the query-param "deep link" loaders the cloud app checks on mount
- * (`?invite`, `?create_workspace`, `?pricing`, `?topup`). The loaders are
- * instantiated in setup so their `useRoute`/`useRouter` resolve; call
- * `runUrlActionLoaders()` from `onMounted` once the app is ready.
+ * (`?invite`, `?create_workspace`, `?pricing`, `?topup`), then recovers an
+ * interrupted checkout. The loaders are instantiated in setup so their
+ * `useRoute`/`useRouter` resolve; call `runUrlActionLoaders()` from
+ * `onMounted` once the app is ready.
  */
 export function useUrlActionLoaders() {
   const inviteUrlLoader = isCloud ? useInviteUrlLoader() : null
@@ -17,6 +19,7 @@ export function useUrlActionLoaders() {
     : null
   const pricingTableUrlLoader = isCloud ? usePricingTableUrlLoader() : null
   const topUpUrlLoader = isCloud ? useTopUpUrlLoader() : null
+  const subscriptionDialog = isCloud ? useSubscriptionDialog() : null
 
   async function runUrlActionLoaders() {
     // Accept workspace invite from URL if present (e.g., ?invite=TOKEN).
@@ -56,6 +59,20 @@ export function useUrlActionLoaders() {
       } catch (error) {
         console.error(
           '[UrlActionLoaders] Failed to load top-up dialog from URL:',
+          error
+        )
+      }
+    }
+
+    // Reopen a checkout that was interrupted by a redirect payment. Runs here,
+    // not during workspace init, so the first-run and Templates overlays are
+    // already settled and the recovered dialog is reachable.
+    if (subscriptionDialog) {
+      try {
+        await subscriptionDialog.resumePendingPricingFlow()
+      } catch (error) {
+        console.error(
+          '[UrlActionLoaders] Failed to resume pending billing flow:',
           error
         )
       }

--- a/src/platform/cloud/subscription/composables/useSubscriptionDialog.test.ts
+++ b/src/platform/cloud/subscription/composables/useSubscriptionDialog.test.ts
@@ -1,5 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import type { SubscriptionInfo } from '@/composables/billing/types'
+import type {
+  BillingSubscriptionStatus,
+  TeamCreditStops,
+  TeamCreditStopSummary
+} from '@/platform/workspace/api/workspaceApi'
+import { savePendingSubscriptionCheckout } from '@/platform/workspace/utils/pendingSubscriptionCheckout'
+
 import { useSubscriptionDialog } from './useSubscriptionDialog'
 
 const mockCloseDialog = vi.fn()
@@ -18,6 +26,23 @@ const mockIsLegacyTeamPlan = vi.hoisted(() => ({ value: false }))
 const mockIsTeamPlan = vi.hoisted(() => ({ value: false }))
 const mockCurrentPlanSlug = vi.hoisted(() => ({ value: null as string | null }))
 const mockCanManageSubscription = vi.hoisted(() => ({ value: true }))
+const mockActiveWorkspaceId = vi.hoisted(() => ({ value: 'workspace-1' }))
+const mockUserId = vi.hoisted(() => ({ value: 'user-1' as string | undefined }))
+const mockStartOperation = vi.hoisted(() => vi.fn())
+const mockFetchPlans = vi.hoisted(() => vi.fn())
+const mockFetchStatus = vi.hoisted(() => vi.fn())
+const mockTeamCreditStops = vi.hoisted(() => ({
+  value: null as TeamCreditStops | null
+}))
+const mockCurrentTeamCreditStop = vi.hoisted(() => ({
+  value: null as TeamCreditStopSummary | null
+}))
+const mockSubscription = vi.hoisted(() => ({
+  value: null as Pick<SubscriptionInfo, 'duration'> | null
+}))
+const mockSubscriptionStatus = vi.hoisted(() => ({
+  value: null as BillingSubscriptionStatus | null
+}))
 
 vi.mock('vue', async (importOriginal) => {
   const actual = await importOriginal()
@@ -63,8 +88,23 @@ vi.mock('@/platform/distribution/types', () => ({
 
 vi.mock('@/platform/workspace/stores/teamWorkspaceStore', () => ({
   useTeamWorkspaceStore: () => ({
+    get activeWorkspaceId() {
+      return mockActiveWorkspaceId.value
+    },
     get isInPersonalWorkspace() {
       return mockIsInPersonalWorkspace.value
+    }
+  })
+}))
+
+vi.mock('@/platform/workspace/stores/billingOperationStore', () => ({
+  useBillingOperationStore: () => ({ startOperation: mockStartOperation })
+}))
+
+vi.mock('@/stores/authStore', () => ({
+  useAuthStore: () => ({
+    get userId() {
+      return mockUserId.value
     }
   })
 }))
@@ -75,7 +115,13 @@ vi.mock('@/composables/billing/useBillingContext', () => ({
     isLegacyTeamPlan: mockIsLegacyTeamPlan,
     isTeamPlan: mockIsTeamPlan,
     currentPlanSlug: mockCurrentPlanSlug,
-    tier: mockTier
+    tier: mockTier,
+    fetchPlans: mockFetchPlans,
+    fetchStatus: mockFetchStatus,
+    teamCreditStops: mockTeamCreditStops,
+    currentTeamCreditStop: mockCurrentTeamCreditStop,
+    subscription: mockSubscription,
+    subscriptionStatus: mockSubscriptionStatus
   })
 }))
 
@@ -117,6 +163,16 @@ describe('useSubscriptionDialog', () => {
     mockIsTeamPlan.value = false
     mockCurrentPlanSlug.value = null
     mockCanManageSubscription.value = true
+    mockActiveWorkspaceId.value = 'workspace-1'
+    mockUserId.value = 'user-1'
+    mockStartOperation.mockResolvedValue({ status: 'succeeded' })
+    mockFetchPlans.mockResolvedValue(undefined)
+    mockFetchStatus.mockResolvedValue(undefined)
+    mockTeamCreditStops.value = null
+    mockCurrentTeamCreditStop.value = null
+    mockSubscription.value = null
+    mockSubscriptionStatus.value = null
+    sessionStorage.clear()
   })
 
   describe('showPricingTable', () => {
@@ -543,7 +599,7 @@ describe('useSubscriptionDialog', () => {
     it('does nothing when no resume intent is stored', () => {
       const { resumePendingPricingFlow } = useSubscriptionDialog()
 
-      resumePendingPricingFlow()
+      void resumePendingPricingFlow()
 
       expect(mockShowLayoutDialog).not.toHaveBeenCalled()
     })
@@ -555,7 +611,7 @@ describe('useSubscriptionDialog', () => {
       mockCurrentPlanSlug.value = 'creator-monthly'
 
       const { resumePendingPricingFlow } = useSubscriptionDialog()
-      resumePendingPricingFlow()
+      void resumePendingPricingFlow()
 
       expect(sessionStorage.getItem('comfy:resume-team-pricing')).toBeNull()
       expect(mockShowLayoutDialog).toHaveBeenCalledWith(
@@ -571,7 +627,7 @@ describe('useSubscriptionDialog', () => {
       mockIsInPersonalWorkspace.value = true
 
       const { resumePendingPricingFlow } = useSubscriptionDialog()
-      resumePendingPricingFlow()
+      void resumePendingPricingFlow()
 
       expect(sessionStorage.getItem('comfy:resume-team-pricing')).toBeNull()
       expect(mockShowLayoutDialog).not.toHaveBeenCalled()
@@ -582,11 +638,241 @@ describe('useSubscriptionDialog', () => {
       mockIsInPersonalWorkspace.value = false
 
       const { resumePendingPricingFlow } = useSubscriptionDialog()
-      resumePendingPricingFlow()
+      void resumePendingPricingFlow()
       mockShowLayoutDialog.mockClear()
 
-      resumePendingPricingFlow()
+      void resumePendingPricingFlow()
       expect(mockShowLayoutDialog).not.toHaveBeenCalled()
+    })
+
+    it('reconciles a failed redirect and reopens the attempted checkout', async () => {
+      mockShouldUseWorkspaceBilling.value = true
+      mockStartOperation.mockResolvedValueOnce({ status: 'failed' })
+      savePendingSubscriptionCheckout({
+        operationId: 'op-alipay',
+        workspaceId: 'workspace-1',
+        ownerUid: 'user-1',
+        selection: {
+          planMode: 'personal',
+          tierKey: 'creator',
+          billingCycle: 'monthly'
+        },
+        attemptedAt: Date.now()
+      })
+
+      const { resumePendingPricingFlow } = useSubscriptionDialog()
+      await resumePendingPricingFlow()
+
+      expect(mockStartOperation).toHaveBeenCalledWith(
+        'op-alipay',
+        'subscription',
+        {
+          tier: 'creator',
+          cycle: 'monthly',
+          attemptStartedAt: expect.any(Number)
+        }
+      )
+      expect(mockShowLayoutDialog).toHaveBeenCalledWith(
+        expect.objectContaining({
+          props: expect.objectContaining({
+            initialPlanMode: 'personal',
+            initialCheckout: {
+              planMode: 'personal',
+              tierKey: 'creator',
+              billingCycle: 'monthly'
+            }
+          })
+        })
+      )
+      expect(
+        sessionStorage.getItem('comfy:pending-subscription-checkout')
+      ).toBeNull()
+    })
+
+    it('completes a succeeded redirect silently', async () => {
+      mockShouldUseWorkspaceBilling.value = true
+      savePendingSubscriptionCheckout({
+        operationId: 'op-succeeded',
+        workspaceId: 'workspace-1',
+        ownerUid: 'user-1',
+        selection: {
+          planMode: 'personal',
+          tierKey: 'creator',
+          billingCycle: 'monthly'
+        },
+        attemptedAt: Date.now()
+      })
+
+      const { resumePendingPricingFlow } = useSubscriptionDialog()
+      await resumePendingPricingFlow()
+
+      expect(mockStartOperation).toHaveBeenCalledOnce()
+      expect(mockShowLayoutDialog).not.toHaveBeenCalled()
+      expect(
+        sessionStorage.getItem('comfy:pending-subscription-checkout')
+      ).toBeNull()
+    })
+
+    it('does not reopen checkout when reconciliation times out', async () => {
+      mockShouldUseWorkspaceBilling.value = true
+      mockStartOperation.mockResolvedValueOnce({ status: 'timeout' })
+      savePendingSubscriptionCheckout({
+        operationId: 'op-timeout',
+        workspaceId: 'workspace-1',
+        ownerUid: 'user-1',
+        selection: {
+          planMode: 'personal',
+          tierKey: 'creator',
+          billingCycle: 'monthly'
+        },
+        attemptedAt: Date.now()
+      })
+
+      const { resumePendingPricingFlow } = useSubscriptionDialog()
+      await resumePendingPricingFlow()
+
+      expect(mockShowLayoutDialog).not.toHaveBeenCalled()
+      expect(
+        sessionStorage.getItem('comfy:pending-subscription-checkout')
+      ).toBeNull()
+    })
+
+    it('clears a checkout owned by another user without reconciling it', async () => {
+      savePendingSubscriptionCheckout({
+        operationId: 'op-other-user',
+        workspaceId: 'workspace-1',
+        ownerUid: 'user-2',
+        selection: {
+          planMode: 'personal',
+          tierKey: 'standard',
+          billingCycle: 'yearly'
+        },
+        attemptedAt: Date.now()
+      })
+
+      const { resumePendingPricingFlow } = useSubscriptionDialog()
+      await resumePendingPricingFlow()
+
+      expect(mockStartOperation).not.toHaveBeenCalled()
+      expect(mockShowLayoutDialog).not.toHaveBeenCalled()
+      expect(
+        sessionStorage.getItem('comfy:pending-subscription-checkout')
+      ).toBeNull()
+    })
+
+    it('clears a checkout for another workspace without reconciling it', async () => {
+      savePendingSubscriptionCheckout({
+        operationId: 'op-other-workspace',
+        workspaceId: 'workspace-2',
+        ownerUid: 'user-1',
+        selection: {
+          planMode: 'personal',
+          tierKey: 'standard',
+          billingCycle: 'yearly'
+        },
+        attemptedAt: Date.now()
+      })
+
+      const { resumePendingPricingFlow } = useSubscriptionDialog()
+      await resumePendingPricingFlow()
+
+      expect(mockStartOperation).not.toHaveBeenCalled()
+      expect(mockShowLayoutDialog).not.toHaveBeenCalled()
+      expect(
+        sessionStorage.getItem('comfy:pending-subscription-checkout')
+      ).toBeNull()
+    })
+
+    it('restores a Team plan change from fresh catalog and subscription state', async () => {
+      mockShouldUseWorkspaceBilling.value = true
+      mockStartOperation.mockResolvedValueOnce({ status: 'failed' })
+      mockFetchPlans.mockImplementationOnce(async () => {
+        mockTeamCreditStops.value = {
+          default_stop_index: 0,
+          stops: [
+            {
+              id: 'team_700',
+              credits: 147_700,
+              monthly: {
+                list_price_cents: 70_000,
+                price_cents: 66_500
+              },
+              yearly: {
+                list_price_cents: 70_000,
+                price_cents: 63_000
+              }
+            }
+          ]
+        }
+      })
+      mockFetchStatus.mockImplementationOnce(async () => {
+        mockCurrentTeamCreditStop.value = {
+          id: 'team_400',
+          stop_usd: 400,
+          credits_monthly: 84_400
+        }
+        mockSubscription.value = { duration: 'MONTHLY' }
+        mockSubscriptionStatus.value = 'active'
+      })
+      savePendingSubscriptionCheckout({
+        operationId: 'op-team-change',
+        workspaceId: 'workspace-1',
+        ownerUid: 'user-1',
+        selection: {
+          planMode: 'team',
+          teamCreditStopId: 'team_700',
+          billingCycle: 'yearly'
+        },
+        attemptedAt: Date.now()
+      })
+
+      const { resumePendingPricingFlow } = useSubscriptionDialog()
+      await resumePendingPricingFlow()
+
+      expect(mockShowLayoutDialog).toHaveBeenCalledWith(
+        expect.objectContaining({
+          props: expect.objectContaining({
+            initialCheckout: {
+              planMode: 'team',
+              stop: {
+                id: 'team_700',
+                credits: 147_700,
+                usd: 700,
+                discountedUsd: 630
+              },
+              billingCycle: 'yearly',
+              isChange: true
+            }
+          })
+        })
+      )
+    })
+
+    it('falls back to Team pricing when the stop catalog is unavailable', async () => {
+      mockShouldUseWorkspaceBilling.value = true
+      mockStartOperation.mockResolvedValueOnce({ status: 'failed' })
+      savePendingSubscriptionCheckout({
+        operationId: 'op-team-catalog-failure',
+        workspaceId: 'workspace-1',
+        ownerUid: 'user-1',
+        selection: {
+          planMode: 'team',
+          teamCreditStopId: 'team_700',
+          billingCycle: 'yearly'
+        },
+        attemptedAt: Date.now()
+      })
+
+      const { resumePendingPricingFlow } = useSubscriptionDialog()
+      await resumePendingPricingFlow()
+
+      expect(mockShowLayoutDialog).toHaveBeenCalledWith(
+        expect.objectContaining({
+          props: expect.objectContaining({ initialPlanMode: 'team' })
+        })
+      )
+      const props = mockShowLayoutDialog.mock.calls[0][0].props
+      expect(props.initialCheckout).toBeUndefined()
     })
   })
 })

--- a/src/platform/cloud/subscription/composables/useSubscriptionDialog.ts
+++ b/src/platform/cloud/subscription/composables/useSubscriptionDialog.ts
@@ -3,12 +3,23 @@ import { useDialogService } from '@/services/dialogService'
 import { useDialogStore } from '@/stores/dialogStore'
 import { useBillingContext } from '@/composables/billing/useBillingContext'
 import { useBillingRouting } from '@/composables/billing/useBillingRouting'
+import {
+  getStopDiscountedMonthlyUsd,
+  mapApiTeamCreditStops
+} from '@/platform/cloud/subscription/constants/teamPlanCreditStops'
 import { isCloud } from '@/platform/distribution/types'
 import { useTelemetry } from '@/platform/telemetry'
 import type { PaymentIntentSource } from '@/platform/telemetry/types'
 import type { SubscriptionCheckoutSelection } from '@/platform/workspace/composables/useSubscriptionCheckout'
 import { useWorkspaceUI } from '@/platform/workspace/composables/useWorkspaceUI'
+import { useBillingOperationStore } from '@/platform/workspace/stores/billingOperationStore'
 import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
+import { useAuthStore } from '@/stores/authStore'
+import {
+  clearPendingSubscriptionCheckout,
+  getPendingSubscriptionCheckout
+} from '@/platform/workspace/utils/pendingSubscriptionCheckout'
+import type { PendingSubscriptionCheckout } from '@/platform/workspace/utils/pendingSubscriptionCheckout'
 
 const DIALOG_KEY = 'subscription-required'
 const RESUME_PRICING_KEY = 'comfy:resume-team-pricing'
@@ -222,11 +233,86 @@ export const useSubscriptionDialog = () => {
       })
   }
 
-  /**
-   * Check for and consume a pending team pricing resume intent.
-   * Call once after workspace initialization on app boot.
-   */
-  function resumePendingPricingFlow() {
+  async function restoreCheckoutSelection(
+    pending: PendingSubscriptionCheckout
+  ): Promise<SubscriptionCheckoutSelection | null> {
+    const selection = pending.selection
+    if (selection.planMode === 'personal') return selection
+
+    const {
+      fetchPlans,
+      fetchStatus,
+      teamCreditStops,
+      currentTeamCreditStop,
+      subscription,
+      subscriptionStatus
+    } = useBillingContext()
+    await Promise.all([fetchPlans(), fetchStatus()])
+    const stop = mapApiTeamCreditStops(teamCreditStops.value?.stops ?? []).find(
+      ({ id }) => id === selection.teamCreditStopId
+    )
+    if (!stop?.id) return null
+
+    return {
+      planMode: 'team',
+      stop: {
+        id: stop.id,
+        usd: stop.usd,
+        credits: stop.credits,
+        discountedUsd: getStopDiscountedMonthlyUsd(stop, selection.billingCycle)
+      },
+      billingCycle: selection.billingCycle,
+      isChange:
+        currentTeamCreditStop.value !== null &&
+        subscriptionStatus.value !== 'ended' &&
+        (currentTeamCreditStop.value.id !== stop.id ||
+          (subscription.value?.duration === 'MONTHLY'
+            ? 'monthly'
+            : 'yearly') !== selection.billingCycle)
+    }
+  }
+
+  async function resumePendingCheckout(
+    pending: PendingSubscriptionCheckout
+  ): Promise<void> {
+    if (
+      pending.workspaceId !== workspaceStore.activeWorkspaceId ||
+      pending.ownerUid !== useAuthStore().userId
+    ) {
+      clearPendingSubscriptionCheckout(pending.operationId)
+      return
+    }
+
+    const billingOperationStore = useBillingOperationStore()
+    try {
+      const operation = await billingOperationStore.startOperation(
+        pending.operationId,
+        'subscription',
+        {
+          tier:
+            pending.selection.planMode === 'personal'
+              ? pending.selection.tierKey
+              : 'team',
+          cycle: pending.selection.billingCycle,
+          attemptStartedAt: pending.attemptedAt
+        }
+      )
+      if (operation.status !== 'failed') return
+
+      const initialCheckout = await restoreCheckoutSelection(pending)
+      showPricingTable({
+        planMode: pending.selection.planMode,
+        ...(initialCheckout && { initialCheckout })
+      })
+    } finally {
+      clearPendingSubscriptionCheckout(pending.operationId)
+    }
+  }
+
+  function resumePendingPricingFlow(): Promise<void> | void {
+    const pendingCheckout = getPendingSubscriptionCheckout()
+    if (pendingCheckout) return resumePendingCheckout(pendingCheckout)
+
     try {
       const pending = sessionStorage.getItem(RESUME_PRICING_KEY)
       if (!pending) return

--- a/src/platform/workspace/api/workspaceApi.ts
+++ b/src/platform/workspace/api/workspaceApi.ts
@@ -611,7 +611,7 @@ export const workspaceApi = {
     const headers = await getAuthHeaderOrThrow()
     try {
       const response = await workspaceApiClient.get<BillingOpStatusResponse>(
-        workspaceApiUrl(`/billing/ops/${opId}`),
+        workspaceApiUrl(`/billing/ops/${encodeURIComponent(opId)}`),
         { headers, timeout: 30_000 }
       )
       return response.data

--- a/src/platform/workspace/auth/WorkspaceAuthGate.test.ts
+++ b/src/platform/workspace/auth/WorkspaceAuthGate.test.ts
@@ -98,20 +98,6 @@ vi.mock('@/platform/distribution/types', () => ({
   }
 }))
 
-const mockResumePendingPricingFlow = vi.fn()
-vi.mock(
-  '@/platform/cloud/subscription/composables/useSubscriptionDialog',
-  () => ({
-    useSubscriptionDialog: () => ({
-      show: vi.fn(),
-      showPricingTable: vi.fn(),
-      hide: vi.fn(),
-      startTeamWorkspaceUpgradeFlow: vi.fn(),
-      resumePendingPricingFlow: mockResumePendingPricingFlow
-    })
-  })
-)
-
 describe('WorkspaceAuthGate', () => {
   beforeEach(() => {
     mockIsCloud.value = true
@@ -309,17 +295,7 @@ describe('WorkspaceAuthGate', () => {
 
       expect(signal.aborted).toBe(true)
       expect(mockWorkspaceStoreInitialize).not.toHaveBeenCalled()
-      expect(mockResumePendingPricingFlow).not.toHaveBeenCalled()
       expect(mockReportError).not.toHaveBeenCalled()
-    })
-
-    it('calls resumePendingPricingFlow after successful workspace init', async () => {
-      mockWorkspaceStoreInitState.value = 'ready'
-
-      mountComponent()
-      await flushPromises()
-
-      expect(mockResumePendingPricingFlow).toHaveBeenCalled()
     })
 
     it('skips workspace init when store is already initialized', async () => {
@@ -546,7 +522,6 @@ describe('WorkspaceAuthGate', () => {
       expect(retrySignal.aborted).toBe(true)
       expect(mockLogout).toHaveBeenCalledOnce()
       expect(mockWorkspaceStoreInitialize).not.toHaveBeenCalled()
-      expect(mockResumePendingPricingFlow).not.toHaveBeenCalled()
     })
   })
 })

--- a/src/platform/workspace/auth/WorkspaceAuthGate.vue
+++ b/src/platform/workspace/auth/WorkspaceAuthGate.vue
@@ -71,7 +71,6 @@ import Button from '@/components/ui/button/Button.vue'
 import { useAuthActions } from '@/composables/auth/useAuthActions'
 import { useFeatureFlags } from '@/composables/useFeatureFlags'
 import { isCloud } from '@/platform/distribution/types'
-import { useSubscriptionDialog } from '@/platform/cloud/subscription/composables/useSubscriptionDialog'
 import {
   remoteConfigErrorStatus,
   remoteConfigState
@@ -90,7 +89,6 @@ const initializationState = ref<
 >(isCloud ? 'initializing' : 'ready')
 const initializationRetryable = ref(true)
 const errorPanel = useTemplateRef<HTMLElement>('errorPanel')
-const subscriptionDialog = useSubscriptionDialog()
 let initializationGeneration = 0
 let initializationController: AbortController | null = null
 let backgroundInitialization: Promise<void> | null = null
@@ -171,14 +169,6 @@ async function initialize(): Promise<void> {
       !workspaceAuthStore.getUnifiedToken()
     ) {
       throw new Error('Unified cloud auth was cleared during workspace setup')
-    }
-
-    // Resume any pending pricing flow from team workspace creation
-    // Only safe after workspace store initialized successfully — the pricing
-    // dialog reads workspace state to decide which variant to show.
-    const workspaceStore = useTeamWorkspaceStore()
-    if (workspaceStore.initState === 'ready') {
-      subscriptionDialog.resumePendingPricingFlow()
     }
 
     if (generation === initializationGeneration) {

--- a/src/platform/workspace/composables/useSubscriptionCheckout.test.ts
+++ b/src/platform/workspace/composables/useSubscriptionCheckout.test.ts
@@ -394,6 +394,7 @@ describe('useSubscriptionCheckout', () => {
       canDowngradeToPersonal: true
     }
     mockSubscription.value = null
+    sessionStorage.clear()
     emit = vi.fn()
   })
 
@@ -2379,6 +2380,55 @@ describe('useSubscriptionCheckout', () => {
         }
       )
       expect(checkout.checkoutStep.value).toBe('preview')
+    })
+
+    it('persists pending checkout context on the legacy Stripe rail', async () => {
+      mockShouldUseWorkspaceBilling.value = false
+      const checkout = await setup()
+      checkout.selectedTierKey.value = 'creator'
+      checkout.selectedBillingCycle.value = 'monthly'
+      mockSubscribe.mockResolvedValueOnce({
+        status: 'pending_payment',
+        billing_op_id: 'op-legacy-alipay'
+      })
+      let resolveOperation!: (operation: {
+        status: 'failed'
+        workspaceId: string
+      }) => void
+      mockStartOperation.mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveOperation = resolve
+          })
+      )
+
+      const payment = checkout.handleAddCreditCard()
+      await vi.waitFor(() => expect(mockSubscribe).toHaveBeenCalledOnce())
+      await vi.waitFor(() => {
+        expect(
+          JSON.parse(
+            sessionStorage.getItem('comfy:pending-subscription-checkout') ??
+              'null'
+          )
+        ).toMatchObject({
+          operationId: 'op-legacy-alipay',
+          workspaceId: 'workspace-1',
+          ownerUid: 'user-1',
+          selection: {
+            planMode: 'personal',
+            tierKey: 'creator',
+            billingCycle: 'monthly'
+          },
+          attemptedAt: expect.any(Number)
+        })
+      })
+
+      resolveOperation({ status: 'failed', workspaceId: 'workspace-1' })
+      await payment
+
+      expect(
+        sessionStorage.getItem('comfy:pending-subscription-checkout')
+      ).toBeNull()
     })
 
     it('shows error toast on subscribe failure', async () => {

--- a/src/platform/workspace/composables/useSubscriptionCheckout.ts
+++ b/src/platform/workspace/composables/useSubscriptionCheckout.ts
@@ -16,6 +16,7 @@ import type {
   SubscriptionCheckoutType
 } from '@/platform/telemetry/types'
 import { categorizeBillingApiError } from '@/platform/telemetry/utils/billingFailureCategory'
+import { useAuthStore } from '@/stores/authStore'
 import type {
   Plan,
   PreviewSubscribeOptions,
@@ -26,6 +27,10 @@ import { workspaceApi } from '@/platform/workspace/api/workspaceApi'
 import { useWorkspaceUI } from '@/platform/workspace/composables/useWorkspaceUI'
 import { useBillingOperationStore } from '@/platform/workspace/stores/billingOperationStore'
 import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
+import {
+  clearPendingSubscriptionCheckout,
+  savePendingSubscriptionCheckout
+} from '@/platform/workspace/utils/pendingSubscriptionCheckout'
 import { trackWorkspaceCheckoutStarted } from '@/platform/workspace/utils/workspaceCheckoutTelemetry'
 
 type CheckoutStep = 'pricing' | 'preview' | 'success'
@@ -41,6 +46,7 @@ export type SubscriptionCheckoutSelection =
       planMode: 'team'
       stop: TeamPlanSelection
       billingCycle: BillingCycle
+      isChange?: boolean
     }
 
 interface SelectedTeamCheckout {
@@ -885,6 +891,8 @@ export function useSubscriptionCheckout(
       return
     }
 
+    savePendingCheckout(response.billing_op_id, context)
+
     // needs_payment_method / pending_payment both finish asynchronously, so poll
     // the billing op either way. needs_payment_method additionally points at a
     // Stripe page to collect a card when the backend supplies the URL; without
@@ -907,6 +915,45 @@ export function useSubscriptionCheckout(
     await advanceToSuccessOnOperation(response.billing_op_id, context)
   }
 
+  function savePendingCheckout(
+    operationId: string,
+    context: SubscriptionOutcomeContext
+  ): void {
+    const workspaceId = workspaceStore.activeWorkspaceId
+    const ownerUid = useAuthStore().userId
+    if (!workspaceId || !ownerUid) return
+    const attemptedAt = context.attemptStartedAt ?? Date.now()
+
+    if (context.tier === 'team') {
+      const teamCreditStopId = selectedTeamCheckout.value?.stop.id
+      if (!teamCreditStopId) return
+      savePendingSubscriptionCheckout({
+        operationId,
+        workspaceId,
+        ownerUid,
+        selection: {
+          planMode: 'team',
+          teamCreditStopId,
+          billingCycle: context.cycle
+        },
+        attemptedAt
+      })
+      return
+    }
+
+    savePendingSubscriptionCheckout({
+      operationId,
+      workspaceId,
+      ownerUid,
+      selection: {
+        planMode: 'personal',
+        tierKey: context.tier,
+        billingCycle: context.cycle
+      },
+      attemptedAt
+    })
+  }
+
   // A Stripe-backed subscribe finishes asynchronously: await the billing op and
   // advance to the success step ourselves. The store refreshes status/balance
   // before resolving and surfaces any failure via toast.
@@ -915,23 +962,27 @@ export function useSubscriptionCheckout(
     context: SubscriptionOutcomeContext
   ) {
     activeCheckoutOperationId.value = opId
-    const operation = await billingOperationStore.startOperation(
-      opId,
-      'subscription',
-      {
-        tier: context.tier,
-        cycle: context.cycle,
-        checkoutType: context.checkoutType,
-        paymentIntentSource,
-        attemptStartedAt: context.attemptStartedAt
+    try {
+      const operation = await billingOperationStore.startOperation(
+        opId,
+        'subscription',
+        {
+          tier: context.tier,
+          cycle: context.cycle,
+          checkoutType: context.checkoutType,
+          paymentIntentSource,
+          attemptStartedAt: context.attemptStartedAt
+        }
+      )
+      if (
+        operation.status === 'succeeded' &&
+        activeCheckoutOperationId.value === opId &&
+        operation.workspaceId === workspaceStore.activeWorkspaceId
+      ) {
+        checkoutStep.value = 'success'
       }
-    )
-    if (
-      operation.status === 'succeeded' &&
-      activeCheckoutOperationId.value === opId &&
-      operation.workspaceId === workspaceStore.activeWorkspaceId
-    ) {
-      checkoutStep.value = 'success'
+    } finally {
+      clearPendingSubscriptionCheckout(opId)
     }
   }
 

--- a/src/platform/workspace/utils/pendingSubscriptionCheckout.test.ts
+++ b/src/platform/workspace/utils/pendingSubscriptionCheckout.test.ts
@@ -1,0 +1,85 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import type { PendingSubscriptionCheckout } from './pendingSubscriptionCheckout'
+import {
+  clearPendingSubscriptionCheckout,
+  getPendingSubscriptionCheckout,
+  savePendingSubscriptionCheckout
+} from './pendingSubscriptionCheckout'
+
+const STORAGE_KEY = 'comfy:pending-subscription-checkout'
+
+function checkoutFixture(
+  overrides: Partial<PendingSubscriptionCheckout> = {}
+): PendingSubscriptionCheckout {
+  return {
+    operationId: 'op-1',
+    workspaceId: 'workspace-1',
+    ownerUid: 'user-1',
+    selection: {
+      planMode: 'personal',
+      tierKey: 'standard',
+      billingCycle: 'yearly'
+    },
+    attemptedAt: Date.now(),
+    ...overrides
+  }
+}
+
+describe('pendingSubscriptionCheckout', () => {
+  beforeEach(() => sessionStorage.clear())
+
+  it('round-trips a saved checkout', () => {
+    const checkout = checkoutFixture()
+    savePendingSubscriptionCheckout(checkout)
+
+    expect(getPendingSubscriptionCheckout()).toEqual(checkout)
+  })
+
+  it('rejects and clears stale checkout context', () => {
+    const now = Date.now()
+    savePendingSubscriptionCheckout(
+      checkoutFixture({
+        operationId: 'op-stale',
+        attemptedAt: now - 24 * 60 * 60_000 - 1
+      })
+    )
+
+    expect(getPendingSubscriptionCheckout(now)).toBeNull()
+    expect(sessionStorage.getItem(STORAGE_KEY)).toBeNull()
+  })
+
+  it('rejects and clears malformed checkout context', () => {
+    sessionStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        ...checkoutFixture({ operationId: 'op-malformed' }),
+        selection: {
+          planMode: 'personal',
+          tierKey: 'free',
+          billingCycle: 'yearly'
+        }
+      })
+    )
+
+    expect(getPendingSubscriptionCheckout()).toBeNull()
+    expect(sessionStorage.getItem(STORAGE_KEY)).toBeNull()
+  })
+
+  it('rejects and clears unparseable checkout context', () => {
+    sessionStorage.setItem(STORAGE_KEY, '{not json')
+
+    expect(getPendingSubscriptionCheckout()).toBeNull()
+    expect(sessionStorage.getItem(STORAGE_KEY)).toBeNull()
+  })
+
+  it('clears only the entry matching the given operation id', () => {
+    savePendingSubscriptionCheckout(checkoutFixture({ operationId: 'op-new' }))
+
+    clearPendingSubscriptionCheckout('op-old')
+    expect(getPendingSubscriptionCheckout()?.operationId).toBe('op-new')
+
+    clearPendingSubscriptionCheckout('op-new')
+    expect(getPendingSubscriptionCheckout()).toBeNull()
+  })
+})

--- a/src/platform/workspace/utils/pendingSubscriptionCheckout.ts
+++ b/src/platform/workspace/utils/pendingSubscriptionCheckout.ts
@@ -1,0 +1,125 @@
+import type { TierKey } from '@/platform/cloud/subscription/constants/tierPricing'
+import type { BillingCycle } from '@/platform/cloud/subscription/utils/subscriptionTierRank'
+
+const STORAGE_KEY = 'comfy:pending-subscription-checkout'
+const MAX_AGE_MS = 24 * 60 * 60_000
+
+type CheckoutTierKey = Exclude<TierKey, 'free' | 'founder'>
+
+type PendingSubscriptionSelection =
+  | {
+      planMode: 'personal'
+      tierKey: CheckoutTierKey
+      billingCycle: BillingCycle
+    }
+  | {
+      planMode: 'team'
+      teamCreditStopId: string
+      billingCycle: BillingCycle
+    }
+
+export interface PendingSubscriptionCheckout {
+  operationId: string
+  workspaceId: string
+  ownerUid: string
+  selection: PendingSubscriptionSelection
+  attemptedAt: number
+}
+
+const CHECKOUT_TIERS: readonly CheckoutTierKey[] = [
+  'standard',
+  'creator',
+  'pro'
+]
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0
+}
+
+function isBillingCycle(value: unknown): value is BillingCycle {
+  return value === 'monthly' || value === 'yearly'
+}
+
+function isSelection(value: unknown): value is PendingSubscriptionSelection {
+  if (!value || typeof value !== 'object') return false
+  if (!('planMode' in value) || !('billingCycle' in value)) return false
+  if (!isBillingCycle(value.billingCycle)) return false
+
+  if (value.planMode === 'personal') {
+    return (
+      'tierKey' in value &&
+      CHECKOUT_TIERS.some((tierKey) => tierKey === value.tierKey)
+    )
+  }
+
+  return (
+    value.planMode === 'team' &&
+    'teamCreditStopId' in value &&
+    isNonEmptyString(value.teamCreditStopId)
+  )
+}
+
+function isPendingCheckout(
+  value: unknown,
+  now: number
+): value is PendingSubscriptionCheckout {
+  if (!value || typeof value !== 'object') return false
+  if (
+    !('operationId' in value) ||
+    !isNonEmptyString(value.operationId) ||
+    !('workspaceId' in value) ||
+    !isNonEmptyString(value.workspaceId) ||
+    !('ownerUid' in value) ||
+    !isNonEmptyString(value.ownerUid) ||
+    !('attemptedAt' in value) ||
+    typeof value.attemptedAt !== 'number' ||
+    !Number.isFinite(value.attemptedAt) ||
+    value.attemptedAt > now ||
+    now - value.attemptedAt > MAX_AGE_MS ||
+    !('selection' in value)
+  ) {
+    return false
+  }
+  return isSelection(value.selection)
+}
+
+export function savePendingSubscriptionCheckout(
+  checkout: PendingSubscriptionCheckout
+): void {
+  try {
+    sessionStorage.setItem(STORAGE_KEY, JSON.stringify(checkout))
+  } catch {
+    return
+  }
+}
+
+export function getPendingSubscriptionCheckout(
+  now = Date.now()
+): PendingSubscriptionCheckout | null {
+  try {
+    const stored = sessionStorage.getItem(STORAGE_KEY)
+    if (!stored) return null
+    const checkout: unknown = JSON.parse(stored)
+    if (isPendingCheckout(checkout, now)) return checkout
+    sessionStorage.removeItem(STORAGE_KEY)
+  } catch {
+    try {
+      sessionStorage.removeItem(STORAGE_KEY)
+    } catch {
+      return null
+    }
+  }
+  return null
+}
+
+export function clearPendingSubscriptionCheckout(operationId?: string): void {
+  try {
+    if (operationId) {
+      const checkout = getPendingSubscriptionCheckout()
+      if (checkout?.operationId !== operationId) return
+    }
+    sessionStorage.removeItem(STORAGE_KEY)
+  } catch {
+    return
+  }
+}


### PR DESCRIPTION
## Summary

Recovers a subscription checkout that was interrupted mid-verification (e.g. an Alipay redirect opened while the original tab is later reloaded): the attempted selection is persisted before polling begins and reconciled on the next app boot — a confirmed payment completes silently, a failed one reopens the pricing dialog pre-seeded with the exact plan the user picked.

## Changes

- **What**: Persist `{operationId, workspaceId, ownerUid, selection}` to `sessionStorage` when a subscribe response resolves asynchronously (`pending_payment` / `needs_payment_method`), clear it once the in-session poll reaches a terminal state, and on boot reconcile any surviving entry through `billingOperationStore.startOperation`. The reconcile runs from `runUrlActionLoaders()` (moved out of `WorkspaceAuthGate` together with the existing team-pricing resume) so the first-run and Templates overlays are settled before the recovered dialog opens. Only a `failed` outcome reopens the pricing dialog (a `timeout` is indeterminate — the payment may still land — so it clears silently); team selections are re-derived from freshly fetched plans and billing status, falling back to the plain pricing table when the stop no longer exists. Entries are validated field-by-field on read, expire after 24h, and are dropped when the workspace or signed-in user differs from the one that persisted them.

## Review Focus

- Reconciliation on boot: only `failed` reopens the dialog; `succeeded` and `timeout` resolve silently.
- `clearPendingSubscriptionCheckout(operationId)` is id-guarded so a stale reconcile can never clear a newer checkout's entry.
- Team resume awaits both `fetchPlans()` and `fetchStatus()` before deriving `isChange`, so a resumed plan change is never misclassified as a fresh subscribe while status is still loading.

Extracted from #14483 (commits `5fd3e35607`, `6e5071942e`, `2346b9f30a`, `3c9a3a477b`, and the overlay-ordering fix `874b32e4ff`), re-derived against current `main` so it works on the existing checkout rails without the embedded-checkout stack. It intentionally hardens over the provenance commits — `ownerUid` scoping, failed-only reopen, the `fetchStatus()` await, and `encodeURIComponent` on the op-status path — so when #14483 reconciles on top of this, these guards should be kept.

Checks run locally: typecheck, lint, format, knip, and the full `src/platform/workspace` + `src/platform/cloud/subscription` Vitest suites (84 files / 1482 tests).
