### PR TITLE
test: exercise ecosystem matrix in both node modes

### DIFF
--- a/.github/workflows/ci-ecosystem-matrix.yaml
+++ b/.github/workflows/ci-ecosystem-matrix.yaml
@@ -1,5 +1,6 @@
 # PR advisory: execute every registry pack's frontend JS against this commit's
-# frontend runtime and report the population result.
+# frontend runtime in both legacy and Nodes 2.0 modes, reporting each result
+# independently.
 #
 # The corpus is a mirror of the frontend JS of EVERY registry pack (~5,100
 # packs). Only the executable surface is kept - .js/.mjs plus the text assets
@@ -212,13 +213,13 @@ jobs:
   # gates (browser + backend): every JS-shipping pack's real extension code
   # is imported and driven against the real frontend runtime under vitest -
   # registration lifecycle, a user-operation battery, serialize/reload.
-  # Sharded 4 ways; vitest additionally parallelizes per core within a
-  # shard (~4.7s of test time per pack, measured).
+  # Each renderer is sharded 4 ways; vitest additionally parallelizes per core
+  # within a shard (~4.7s of test time per pack, measured).
   #
   # A shard checks harness integrity only: every built spec must write its
   # per-pack row. vitest's own exit code is ignored here because pack code
-  # leaks unhandled rejections. The ecosystem PASS/FAIL verdict is applied
-  # once, over all shards combined, by matrix-verdict below.
+  # leaks unhandled rejections. Each mode's ecosystem PASS/FAIL verdict is
+  # applied over its four shards by matrix-verdict below.
   ecosystem-matrix:
     needs: corpus
     if: github.repository == 'Comfy-Org/ComfyUI_frontend'
@@ -227,7 +228,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        renderer: [legacy, vue]
         shard: [1, 2, 3, 4]
+    env:
+      MATRIX_RENDERER: ${{ matrix.renderer }}
+      MATRIX_VUE: ${{ matrix.renderer == 'vue' && '1' || '0' }}
     steps:
       # This job EXECUTES unreviewed third-party pack code under vitest;
       # the checkout must not leave a usable git credential behind for it.
@@ -332,14 +337,13 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v6
         with:
-          name: ecosystem-matrix-shard-${{ matrix.shard }}
+          name: ecosystem-matrix-${{ matrix.renderer }}-shard-${{ matrix.shard }}
           path: matrix-rows/
           retention-days: 30
           if-no-files-found: warn
 
-  # The single combined result: all four shards' rows merge into one table
-  # and one combined verdict - this job's exit code IS the ecosystem verdict
-  # (0 PASS, 1 FAIL, 2 harness failure / no rows / short population).
+  # Each renderer gets its own combined result: four shards merge into one
+  # table and verdict. A Vue-only regression cannot hide behind a legacy PASS.
   #
   # MATRIX_EXPECT_SHARDS makes a dead shard withhold rather than PASS. Every
   # criterion is a ratio, so three shards produce a perfectly plausible
@@ -356,6 +360,12 @@ jobs:
       && github.repository == 'Comfy-Org/ComfyUI_frontend'
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        renderer: [legacy, vue]
+    env:
+      MATRIX_RENDERER: ${{ matrix.renderer }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
@@ -373,7 +383,7 @@ jobs:
         continue-on-error: true
         uses: actions/download-artifact@v8
         with:
-          pattern: ecosystem-matrix-shard-*
+          pattern: ecosystem-matrix-${{ matrix.renderer }}-shard-*
           path: matrix-rows
           merge-multiple: true
 
@@ -397,8 +407,8 @@ jobs:
         uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: matrix-metrics
-          key: matrix-metrics-${{ github.run_id }}
-          restore-keys: matrix-metrics-
+          key: ${{ matrix.renderer == 'vue' && 'matrix-vue-metrics-' || 'matrix-metrics-' }}${{ github.run_id }}
+          restore-keys: ${{ matrix.renderer == 'vue' && 'matrix-vue-metrics-' || 'matrix-metrics-' }}
 
       - name: Verdict
         id: verdict
@@ -425,13 +435,13 @@ jobs:
         uses: actions/cache/save@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: matrix-metrics
-          key: matrix-metrics-${{ github.run_id }}-${{ github.run_attempt }}
+          key: ${{ matrix.renderer == 'vue' && 'matrix-vue-metrics-' || 'matrix-metrics-' }}${{ github.run_id }}-${{ github.run_attempt }}
 
       - name: Upload combined result
         if: always()
         uses: actions/upload-artifact@v6
         with:
-          name: ecosystem-matrix-combined
+          name: ecosystem-matrix-${{ matrix.renderer }}-combined
           path: matrix-rows/
           retention-days: 30
           if-no-files-found: warn
@@ -449,6 +459,13 @@ jobs:
     if: github.repository == 'Comfy-Org/ComfyUI_frontend'
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        renderer: [legacy, vue]
+    env:
+      MATRIX_RENDERER: ${{ matrix.renderer }}
+      MATRIX_VUE: ${{ matrix.renderer == 'vue' && '1' || '0' }}
     steps:
       # Runs the poison packs (and the same harness that runs real pack
       # code); same rule as the shard jobs - no persisted credential.
@@ -489,7 +506,8 @@ jobs:
       - name: Verdict must FAIL on poison
         run: |
           set +e
-          MATRIX_OUT="$PWD/matrix-proof" python3 scripts/registry-census/summarize_matrix.py > proof-verdict.txt 2>&1
+          MATRIX_OUT="$PWD/matrix-proof" MATRIX_RENDERER="$MATRIX_RENDERER" \
+            python3 scripts/registry-census/summarize_matrix.py > proof-verdict.txt 2>&1
           rc=$?
           set -e
           tail -8 proof-verdict.txt

--- a/scripts/registry-census/README.md
+++ b/scripts/registry-census/README.md
@@ -107,14 +107,23 @@ agree. A cache without its provenance cannot produce a verdict.
 `build_matrix.py` + `matrix_runner.ts` generate one vitest spec per
 JS-shipping pack and execute its real extension code against the real
 frontend runtime (registration lifecycle, a user-operation battery,
-serialize/reload), one JSON row per pack, sharded 4 ways. Packs with no
-extension JS are skipped and reported only as a count.
+serialize/reload), one JSON row per pack. The workflow runs four shards in
+legacy mode and four in Nodes 2.0 mode, with separate artifacts, baselines,
+and verdicts. Packs with no extension JS are skipped and reported only as a
+count.
 
 ### What the harness drives, and what it does not
 
 This is the scope of every number below. `ComfyApp.setup()` non-null-asserts
 five DOM elements and needs a 2D canvas context, so the real boot cannot run
 under happy-dom and the lifecycle is simulated.
+
+The Nodes 2.0 arm sets `LiteGraph.vueNodesMode` before pack code loads and
+therefore exercises mode-dependent graph, widget-store, and serialization
+behavior. It does not mount the Vue node component tree or make claims about
+pixels and DOM layout; browser-level custom-node coverage owns that surface.
+Every completed row records the active mode, and the verdict withholds if rows
+from different modes are mixed or the rows disagree with the workflow arm.
 
 | extension hook                                                                                                                                                                                                                                                 | driven                      |
 | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------- |
@@ -137,8 +146,8 @@ row. A green matrix did not catch a `setup`-dispatch regression, and cannot.
 
 ### PASS criteria
 
-Applied once by the `matrix-verdict` job over all four shards combined
-(`summarize_matrix.py`; exit 0 PASS, 1 FAIL, 2 harness/withheld):
+Applied independently by the two `matrix-verdict` jobs over each mode's four
+shards (`summarize_matrix.py`; exit 0 PASS, 1 FAIL, 2 harness/withheld):
 
 | criterion                                 | floor     | measured baseline |
 | ----------------------------------------- | --------- | ----------------- |
@@ -195,6 +204,8 @@ array-concatenation would otherwise smuggle in.
 | `MATRIX_RUN_ID`        | summarizer         | skips the delta when the baseline is this same run |
 | `MATRIX_EXPECT_SHARDS` | summarizer         | required manifest count; unset disables the check  |
 | `MATRIX_STALE_MARKER`  | summarizer         | path to `registry-stale.json`, if present          |
+| `MATRIX_RENDERER`      | summarizer         | expected row identity: `legacy` or `vue`           |
+| `MATRIX_VUE`           | runner             | exact mode selector: `0` for legacy, `1` for Vue   |
 
 ## Security posture
 
@@ -264,11 +275,12 @@ workflow never reports.
 
 `detection-proof/corpus/` is a synthetic corpus of seven poison packs, each
 broken in exactly one measured way, plus three clean controls. The
-`matrix-detection-proof` job runs the real matrix over it and passes only if
-`verify_detection.py` sees every channel fire with its exact poison message
-**and** breach the criterion it targets, AND `summarize_matrix.py` exits
-FAIL. Asserting only that the combined verdict went red would certify a
-channel as "fired" while it contributed nothing to the gate.
+`matrix-detection-proof` runs the real matrix over it once in each mode and
+passes only if `verify_detection.py` sees every channel fire with its exact
+poison message **and** breach the criterion it targets, AND
+`summarize_matrix.py` exits FAIL. Asserting only that the combined verdict went
+red would certify a channel as "fired" while it contributed nothing to the
+gate.
 
 The verifier also checks the reverse mapping: every verdict criterion must
 have poison counter-evidence or an explicit exemption explaining why it

--- a/scripts/registry-census/matrixMode.test.ts
+++ b/scripts/registry-census/matrixMode.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest'
+
+import { matrixRendererFromEnv } from './matrixMode'
+
+describe('matrixRendererFromEnv', () => {
+  it.for([
+    [undefined, 'legacy'],
+    ['', 'legacy'],
+    ['0', 'legacy'],
+    ['1', 'vue']
+  ] as const)('maps %s to %s', ([value, expected]) => {
+    expect(matrixRendererFromEnv(value)).toBe(expected)
+  })
+
+  it('rejects ambiguous values instead of silently selecting a renderer', () => {
+    expect(() => matrixRendererFromEnv('true')).toThrow(
+      'MATRIX_VUE must be 0 or 1'
+    )
+  })
+})

--- a/scripts/registry-census/matrixMode.ts
+++ b/scripts/registry-census/matrixMode.ts
@@ -1,0 +1,11 @@
+export type MatrixRenderer = 'legacy' | 'vue'
+
+export function matrixRendererFromEnv(
+  value: string | undefined = process.env.MATRIX_VUE
+): MatrixRenderer {
+  if (value === undefined || value === '' || value === '0') return 'legacy'
+  if (value === '1') return 'vue'
+  throw new Error(
+    `MATRIX_VUE must be 0 or 1, received ${JSON.stringify(value)}`
+  )
+}

--- a/scripts/registry-census/matrix_runner.ts
+++ b/scripts/registry-census/matrix_runner.ts
@@ -19,6 +19,7 @@ import type {
 import type { CanvasPointerEvent } from '@/lib/litegraph/src/types/events'
 import type { IBaseWidget } from '@/lib/litegraph/src/types/widgets'
 import type { useWidgetValueStore } from '@/stores/widgetValueStore'
+import { matrixRendererFromEnv } from '@/../scripts/registry-census/matrixMode'
 
 const S = (v: unknown) => JSON.stringify(v)
 const errMsg = (e: unknown) =>
@@ -141,7 +142,8 @@ async function installGlobals() {
   const utilsMod = await import('@/scripts/utils')
   const domWidgetMod = await import('@/scripts/domWidget')
   lg.LiteGraph.alwaysRepeatWarnings = true
-  if (process.env.MATRIX_VUE) lg.LiteGraph.vueNodesMode = true
+  const renderer = matrixRendererFromEnv()
+  lg.LiteGraph.vueNodesMode = renderer === 'vue'
   lg.LiteGraph.onDeprecationWarning = [
     (m: string) => {
       const st = new Error().stack ?? ''
@@ -170,7 +172,7 @@ async function installGlobals() {
   }
   Object.assign(globalThis, globals)
   if (typeof window !== 'undefined') Object.assign(window, globals)
-  return { lg, app: appMod.app }
+  return { lg, app: appMod.app, renderer }
 }
 
 function signature(graph: LGraph, store: WidgetValueStore | undefined) {
@@ -254,7 +256,8 @@ export async function runPack(
   const row: Record<string, unknown> = { pack, safe }
   const ops: Record<string, OpRecord> = {}
   let storeReadErrors = 0
-  const { lg, app } = await installGlobals()
+  const { lg, app, renderer } = await installGlobals()
+  row.renderer = renderer
   const { LGraph, LiteGraph } = lg
 
   // ---- LOAD the pack's real entry files ---------------------------------

--- a/scripts/registry-census/summarize_matrix.py
+++ b/scripts/registry-census/summarize_matrix.py
@@ -70,6 +70,7 @@ CRITERION_LABELS = {
 DELTA_CRITERION_LABEL = 'entry-clean delta vs previous run'
 
 EXPECTED_ROW_KEYS = (
+    'renderer',
     'selfCheck',
     'load',
     'loadedOk',
@@ -117,6 +118,7 @@ def evaluate(
     run_id: str = '',
     expect_shards: int | None = None,
     stale: dict | None = None,
+    expected_renderer: str | None = None,
 ) -> Verdict:
     if not rows:
         return Verdict(2, ['no matrix rows to summarize'])
@@ -160,6 +162,25 @@ def evaluate(
             lines.append(f'  {key}: {len(packs)} row(s): {_named(packs)}')
         lines.append('')
         return Verdict(2, lines)
+
+    renderers = {row.get('renderer') for row in done}
+    if len(renderers) != 1 or not renderers <= {'legacy', 'vue'}:
+        lines.append(
+            'RENDERER IDENTITY DRIFT: completed rows must all report exactly'
+            f' one supported renderer, received {sorted(map(str, renderers))}.'
+        )
+        return Verdict(2, lines)
+    renderer = next(iter(renderers))
+    if expected_renderer is not None and renderer != expected_renderer:
+        lines.append(
+            'RENDERER IDENTITY DRIFT: workflow expected '
+            f'{expected_renderer}, rows reported {renderer}. Verdict withheld.'
+        )
+        return Verdict(2, lines)
+    lines.append(
+        f'renderer: {renderer} (vueNodesMode = '
+        f'{str(renderer == "vue").lower()})'
+    )
 
     # build_matrix.py marks a pack indeterminate when it cannot tell which
     # files ComfyUI would actually serve. Those packs still run - the row is
@@ -377,11 +398,20 @@ def evaluate(
         if not held:
             breaches.append(f'{label} {measured_pct:.1f}% < {floor:.0f}%')
 
+    prev_renderer = prev.get('renderer') if isinstance(prev, dict) else None
+    prev_matches_renderer = prev_renderer == renderer or (
+        prev_renderer is None and renderer == 'legacy'
+    )
     prev_entry = prev.get('entryPct') if isinstance(prev, dict) else None
     if prev is None:
         lines.append(
             f'  {DELTA_CRITERION_LABEL:42s}   n/a'
             '  (no previous metrics)'
+        )
+    elif isinstance(prev, dict) and not prev_matches_renderer:
+        lines.append(
+            f'  {DELTA_CRITERION_LABEL:42s}   n/a'
+            '  (previous metrics are for another or unknown renderer)'
         )
     elif isinstance(prev, dict) and run_id and prev.get('runId') == run_id:
         # A re-run restored this same run's earlier write; comparing a
@@ -415,7 +445,11 @@ def evaluate(
     # widget rows, say - moves the signature and nothing else. Reported, not
     # gated: a legitimate frontend change moves these too, so a floor here
     # would cry wolf on the diffs it is supposed to be measuring.
-    prev_sigs = prev.get('sigHashes') if isinstance(prev, dict) else None
+    prev_sigs = (
+        prev.get('sigHashes')
+        if isinstance(prev, dict) and prev_matches_renderer
+        else None
+    )
     if isinstance(prev_sigs, dict):
         shared = sig_hashes.keys() & prev_sigs.keys()
         moved = sorted(p for p in shared if sig_hashes[p] != prev_sigs[p])
@@ -440,6 +474,7 @@ def evaluate(
         lines,
         [],
         {
+            'renderer': renderer,
             'packs': len(done),
             'incomplete': len(stubs),
             'anyPct': round(any_pct, 3),
@@ -513,6 +548,14 @@ def main() -> int:
         )
         return 2
 
+    expected_renderer = os.environ.get('MATRIX_RENDERER', '')
+    if expected_renderer not in ('', 'legacy', 'vue'):
+        print(
+            f'MATRIX_RENDERER is not legacy or vue: {expected_renderer!r}',
+            file=sys.stderr,
+        )
+        return 2
+
     prev_path = os.environ.get('MATRIX_PREV', '')
     prev = (
         _read_json(prev_path, 'previous metrics')
@@ -536,6 +579,7 @@ def main() -> int:
         os.environ.get('MATRIX_RUN_ID', ''),
         int(expect_raw) if expect_raw else None,
         stale,
+        expected_renderer or None,
     )
 
     report = '\n'.join(verdict.lines)

--- a/scripts/registry-census/test_summarize_matrix.py
+++ b/scripts/registry-census/test_summarize_matrix.py
@@ -28,6 +28,7 @@ import summarize_matrix as sm
 def row(pack: str, **over: object) -> dict:
     base: dict = {
         'pack': pack,
+        'renderer': 'legacy',
         'selfCheck': 'OK',
         'load': {'./a.js': 'OK', './b.js': 'OK'},
         'loadedOk': 2,
@@ -209,6 +210,18 @@ class HarnessGates(unittest.TestCase):
         self.assertIn('selfCheck: 99 row(s)', report)
         self.assertIsNone(verdict.metrics)
 
+    def test_mixed_renderer_rows_are_withheld(self) -> None:
+        rows = population()
+        rows[0]['renderer'] = 'vue'
+        verdict = sm.evaluate(rows, {})
+        self.assertEqual(verdict.code, 2)
+        self.assertIn('RENDERER IDENTITY DRIFT', '\n'.join(verdict.lines))
+
+    def test_expected_renderer_must_match_rows(self) -> None:
+        verdict = sm.evaluate(population(), {}, expected_renderer='vue')
+        self.assertEqual(verdict.code, 2)
+        self.assertIn('workflow expected vue', '\n'.join(verdict.lines))
+
     def test_empty_operation_maps_fail_closed(self) -> None:
         rows = population()
         for r in rows:
@@ -313,26 +326,63 @@ class DeltaGate(unittest.TestCase):
         self.assertIn('no previous metrics', '\n'.join(v.lines))
 
     def test_erosion_beyond_tolerance_fails(self) -> None:
-        prev = {'entryPct': 100.0, 'runId': 'run-1'}
+        prev = {
+            'renderer': 'legacy',
+            'entryPct': 100.0,
+            'runId': 'run-1',
+        }
         v = sm.evaluate(self.eroded(), {}, prev, 'run-2')
         self.assertEqual(v.code, 1)
         self.assertIn('dropped 5.0pp', v.breaches[0])
         self.assertIsNone(v.metrics)
 
     def test_same_run_metrics_skip_the_delta(self) -> None:
-        prev = {'entryPct': 100.0, 'runId': 'run-2'}
+        prev = {
+            'renderer': 'legacy',
+            'entryPct': 100.0,
+            'runId': 'run-2',
+        }
         v = sm.evaluate(self.eroded(), {}, prev, 'run-2')
         self.assertEqual(v.code, 0)
         self.assertIn('metrics are from this run', '\n'.join(v.lines))
 
     def test_malformed_metrics_skip_the_delta(self) -> None:
-        for prev in ({'runId': 'run-1'}, {'entryPct': 'n/a'}, []):
+        for prev in (
+            {'renderer': 'legacy', 'runId': 'run-1'},
+            {'renderer': 'legacy', 'entryPct': 'n/a'},
+            [],
+        ):
             with self.subTest(prev=prev):
                 v = sm.evaluate(self.eroded(), {}, prev, 'run-2')
                 self.assertEqual(v.code, 0)
                 self.assertIn(
                     'previous metrics malformed', '\n'.join(v.lines)
                 )
+
+    def test_other_renderer_metrics_do_not_feed_the_delta(self) -> None:
+        prev = {'renderer': 'vue', 'entryPct': 100.0, 'runId': 'run-1'}
+        verdict = sm.evaluate(self.eroded(), {}, prev, 'run-2')
+        self.assertEqual(verdict.code, 0)
+        self.assertIn(
+            'previous metrics are for another or unknown renderer',
+            '\n'.join(verdict.lines),
+        )
+
+    def test_unlabelled_pre_renderer_baseline_is_legacy_only(self) -> None:
+        previous = {'entryPct': 100.0, 'runId': 'run-1'}
+        legacy = sm.evaluate(self.eroded(), {}, previous, 'run-2')
+        self.assertEqual(legacy.code, 1)
+        self.assertIn('dropped 5.0pp', legacy.breaches[0])
+
+        vue_rows = self.eroded()
+        for item in vue_rows:
+            item['renderer'] = 'vue'
+        vue = sm.evaluate(vue_rows, {}, previous, 'run-2')
+        self.assertEqual(vue.code, 0)
+        self.assertIn(
+            'previous metrics are for another or unknown renderer',
+            '\n'.join(vue.lines),
+        )
 
 
 class StaleRegistry(unittest.TestCase):
@@ -391,6 +441,18 @@ class MainIO(unittest.TestCase):
         self.assertEqual(json.loads(metrics)['verdict'], 'PASS')
         self.assertIn('## Ecosystem matrix', output)
         self.assertIn('VERDICT: PASS', output)
+        self.assertIn('renderer: legacy (vueNodesMode = false)', output)
+
+    def test_vue_renderer_identity_reaches_metrics_and_summary(self) -> None:
+        rows = population()
+        for item in rows:
+            item['renderer'] = 'vue'
+        code, metrics, output = self.run_main(
+            rows, MATRIX_RENDERER='vue'
+        )
+        self.assertEqual(code, 0)
+        self.assertEqual(json.loads(metrics)['renderer'], 'vue')
+        self.assertIn('renderer: vue (vueNodesMode = true)', output)
 
     def test_fail_does_not_ratchet_the_baseline(self) -> None:
         code, metrics, output = self.run_main(broken(50, break_op_err))
@@ -425,6 +487,13 @@ class MainIO(unittest.TestCase):
     def test_non_numeric_shard_expectation_is_withheld(self) -> None:
         code, _, _ = self.run_main(population(), MATRIX_EXPECT_SHARDS='four')
         self.assertEqual(code, 2)
+
+    def test_unknown_renderer_expectation_is_withheld(self) -> None:
+        code, metrics, _ = self.run_main(
+            population(), MATRIX_RENDERER='nodes-2'
+        )
+        self.assertEqual(code, 2)
+        self.assertEqual(metrics, '')
 
     def test_stale_marker_is_read_from_the_environment(self) -> None:
         with tempfile.NamedTemporaryFile('w', suffix='.json') as fh:


### PR DESCRIPTION
## Summary

Run the ecosystem compatibility matrix independently in legacy and Nodes 2.0 modes so a mode-specific regression cannot hide behind the other arm.

## Changes

- **What**: Add legacy/Vue axes to the four-shard matrix, verdict, and poison-corpus jobs; isolate artifacts and baselines by mode; record and validate the runtime renderer identity in every completed row.
- **What**: Fail closed on mixed or mislabeled renderer rows and reject cross-renderer baselines.
- **What**: Document that this happy-dom harness exercises mode-dependent graph/store behavior, while browser E2E owns actual Vue DOM rendering.

## Review Focus

Confirm the two modes remain independent end to end: runtime selection, row identity, shard artifacts, cached baselines, verdicts, and detection proof.

Fixes #15724