### PR TITLE
feat(test-recorder): prefill flags, env versions, cloud ?ff= flags, --pr checkout

### DIFF
--- a/tools/test-recorder/AGENTS.md
+++ b/tools/test-recorder/AGENTS.md
@@ -8,6 +8,10 @@ environment variables for automation. When adding or changing a feature,
 implement and document both paths. A prompt-only or flag-only feature is
 incomplete.
 
+Every setup prompt in `record` MUST have a corresponding prefill flag. QA test
+plans must be able to embed one copy-pastable `pnpm comfy-test record ...`
+command that skips all setup questions when every answer is valid.
+
 ## Third audience: an agent supervising a human
 
 There is a third user of this tool beyond "human at a terminal" and
@@ -27,12 +31,14 @@ true.
 
 | Capability             | Interactive `record` path                    | Non-interactive path                                                                         |
 | ---------------------- | -------------------------------------------- | -------------------------------------------------------------------------------------------- |
-| Target distribution    | Distribution selector                        | `check --distribution <id>` or `COMFY_TEST_DISTRIBUTION`                                     |
-| Custom backend         | “Custom backend…” selection and URL prompt   | `check --backend <url>` or `COMFY_TEST_BACKEND`                                              |
+| Target distribution    | Distribution selector with live versions     | `record --distribution <id>`; `check --distribution <id>` or `COMFY_TEST_DISTRIBUTION`       |
+| Custom backend         | “Custom backend…” selection and URL prompt   | `record --backend <url>`; `check --backend <url>` or `COMFY_TEST_BACKEND`                    |
 | Workflow search        | Searchable workflow autocomplete             | `list --filter <keyword>`                                                                    |
 | Add workflow from file | “(add from file…)” workflow option           | `add-workflow <file> [--name <n>]`                                                           |
 | Test tags              | Tag multiselect with hints                   | `tags` lists the registry with descriptions; `plan --tags` and `transform --tags` apply tags |
-| Feature flags          | Feature-flag selector and custom flag prompt | `plan --feature-flags <specs>` or `transform --feature-flags <specs>`                        |
+| Record setup answers   | Guided prompts                               | `record --workflow --tags --feature-flags --use-case --description --name`                   |
+| Feature flags          | Feature-flag selector and custom flag prompt | `record`, `plan`, or `transform --feature-flags <specs>`                                     |
+| PR checkout            | Safe switch confirmation                     | `record --pr <number>`                                                                       |
 | Secret scrubbing       | Automatic during `record`, with a loud alert | Automatic in `transform <file>`; findings print as 🔒 lines in the summary                   |
 | Supervisor guidance    | Woven into `record` prompts and warnings     | `guide` prints the full operating manual for an agent helping a human                        |
 
@@ -48,8 +54,10 @@ initialFeatureFlags })`.
 - **cloud / cloud-staging / cloud-prod / custom** — bare-page template:
   `page.goto(PLAYWRIGHT_TEST_URL)` and the recorder enabled immediately —
   no boot gate, so a sign-in screen can't stall the recorder (sign in
-  manually, then record). Feature flags are seeded via `ff:<key>`
-  localStorage entries (the same mechanism as `FeatureFlagHelper.seedFlags`).
+  manually, then record). Feature flags use repeatable
+  `?ff=<key>:<JSON value>` URL parameters. The app captures these in
+  `Comfy.FeatureFlagOverride` session storage, so they apply only to the
+  recording tab and disappear when it closes.
   Workflow pre-load is unsupported; `record` warns and the human loads it
   in the app.
 

--- a/tools/test-recorder/README.md
+++ b/tools/test-recorder/README.md
@@ -19,6 +19,10 @@ pnpm comfy-test list        # List available workflows
 
 See the [Browser Tests README](../../browser_tests/README.md) for full setup instructions.
 
+Cloud recordings pass feature flags as repeatable `?ff=name:value` URL
+parameters. These overrides are scoped to the opened browser tab and disappear
+when it closes. Local recordings continue to seed `ff:<name>` in local storage.
+
 ## For Agents
 
 `record` requires an interactive terminal and a human clicking a real

--- a/tools/test-recorder/README.md
+++ b/tools/test-recorder/README.md
@@ -19,9 +19,31 @@ pnpm comfy-test list        # List available workflows
 
 See the [Browser Tests README](../../browser_tests/README.md) for full setup instructions.
 
+A test plan can prefill every setup answer in one copy-pastable command:
+
+```bash
+pnpm comfy-test record --distribution cloud --workflow default --tags @canvas,@widget --feature-flags linear_toggle_enabled:true --use-case test-plan-step --description "seed stays fixed across runs" --name fixed-seed
+```
+
+Supplied answers are confirmed and their prompts are skipped. Invalid values
+show a warning and return to the corresponding prompt.
+
+Record flags:
+
+- `--distribution <cloud|cloud-staging|cloud-prod|local>` selects the backend environment.
+- `--backend <url>` connects to a custom backend and implies a custom distribution.
+- `--workflow <name>`, `--tags <a,b>`, and `--feature-flags <key:value,...>` configure the recording.
+- `--use-case <reproduce-bug|verify-change|test-plan-step|contribute>`, `--description <text>`, and `--name <slug>` describe and name it.
+- `--pr <number>` checks whether the checkout matches a PR and offers to switch safely. It never switches a checkout with uncommitted changes.
+
+The distribution selector fetches and displays the currently deployed backend
+version for each cloud environment. `comfy-test check --distribution <id>`
+prints the same backend, ComfyUI, and deployment-environment information.
+
 Cloud recordings pass feature flags as repeatable `?ff=name:value` URL
 parameters. These overrides are scoped to the opened browser tab and disappear
-when it closes. Local recordings continue to seed `ff:<name>` in local storage.
+when it closes. Local recordings continue to seed the existing `ff:<name>`
+local-storage overrides through the test fixture.
 
 ## For Agents
 

--- a/tools/test-recorder/src/commands/check.ts
+++ b/tools/test-recorder/src/commands/check.ts
@@ -11,8 +11,9 @@ import { checkDevServer } from '../checks/devServer'
 import { checkBackend } from '../checks/backend'
 import { checkModels } from '../checks/models'
 import type { Distribution } from '../devserver/distributions'
-import { alert, header, pass } from '../ui/logger'
+import { alert, header, pass, info } from '../ui/logger'
 import type { CheckResult } from '../checks/types'
+import { fetchEnvInfo } from '../devserver/envInfo'
 
 export async function runChecks(
   distribution: Distribution,
@@ -23,6 +24,17 @@ export async function runChecks(
   allPassed: boolean
 }> {
   if (options.showHeader !== false) header('Environment Check')
+
+  if (distribution.backendUrl && distribution.id !== 'local') {
+    const env = await fetchEnvInfo(distribution.backendUrl)
+    if (env.ok) {
+      info([
+        `${env.deployEnvironment}: backend ${env.cloudVersion}, ComfyUI ${env.comfyuiVersion}`
+      ])
+    } else {
+      info(['Environment version information is currently unavailable.'])
+    }
+  }
 
   let root = projectRoot
   if (!root) {

--- a/tools/test-recorder/src/commands/guide.ts
+++ b/tools/test-recorder/src/commands/guide.ts
@@ -17,15 +17,19 @@ export function runGuide(): void {
 
   header('The handoff — do this first')
   info([
-    'Immediately give them these three commands to paste into a NEW terminal:',
+    'Immediately give them these commands to paste into a NEW terminal:',
     '',
     pc.cyan('  cd <path to ComfyUI_frontend>'),
     pc.cyan('  nvm use'),
-    pc.cyan('  pnpm comfy-test record'),
+    pc.cyan(
+      '  pnpm comfy-test record --distribution <environment> --workflow <workflow> --tags <tags> --feature-flags <flags> --use-case test-plan-step --description "<test-plan step>" --name <short-name> [--pr <number>]'
+    ),
     '',
     'If they use fnm, the second command is `fnm use` instead.',
     'A new terminal window means opening the Terminal app and starting a',
     'fresh window. On macOS: open Terminal, then press Cmd+N.',
+    'Build the final line from the test plan so valid answers skip every setup',
+    'question. Omit only answers the test plan genuinely does not provide.',
     'Do not explain setup or servers first. The tool guides everything else.'
   ])
 
@@ -36,7 +40,7 @@ export function runGuide(): void {
     'Never say “fix node” or explain version-manager jargon. Give the command.',
     'Never mention branch names or say “switch back to <branch>.”',
     'Say: “You’re all done — the tool put things back.”',
-    'Show no shell commands beyond the three above unless the tool printed them.',
+    'Show no shell commands beyond those above unless the tool printed them.',
     'Use plain words and short sentences.'
   ])
 
@@ -53,7 +57,8 @@ export function runGuide(): void {
 
   header('What they will see')
   info([
-    'The tool asks guided questions. There are no wrong answers.',
+    'The tool confirms answers copied from the test plan, then asks only for',
+    'anything missing or invalid. There are no wrong answers.',
     'Then a browser opens with a small floating toolbar at the top middle.',
     'Nothing records until they press Record.',
     'Signing in and looking around before that is safe.',

--- a/tools/test-recorder/src/commands/guide.ts
+++ b/tools/test-recorder/src/commands/guide.ts
@@ -58,7 +58,9 @@ export function runGuide(): void {
     'Nothing records until they press Record.',
     'Signing in and looking around before that is safe.',
     'They press Record, do the thing they are testing, add a proof step with',
-    'the toolbar, and close the window. The code saves automatically.'
+    'the toolbar, and close the window. The code saves automatically.',
+    'On cloud environments, feature-flag links apply only to that browser',
+    'tab and disappear when it closes.'
   ])
 
   header('Stay out of the way')

--- a/tools/test-recorder/src/commands/prCheckout.test.ts
+++ b/tools/test-recorder/src/commands/prCheckout.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+
+import { decidePrCheckout } from './prCheckout'
+
+describe('decidePrCheckout', () => {
+  it.for([
+    ['feature', 'feature', false, 'already-on-branch'],
+    ['feature', 'feature', true, 'already-on-branch'],
+    ['main', 'feature', true, 'refuse-dirty'],
+    ['main', 'feature', false, 'offer-switch']
+  ] as const)(
+    'returns %s / %s / dirty=%s as %s',
+    ([current, target, dirty, expected]) => {
+      expect(decidePrCheckout(current, target, dirty)).toBe(expected)
+    }
+  )
+})

--- a/tools/test-recorder/src/commands/prCheckout.ts
+++ b/tools/test-recorder/src/commands/prCheckout.ts
@@ -1,0 +1,14 @@
+export type PrCheckoutAction =
+  | 'already-on-branch'
+  | 'refuse-dirty'
+  | 'offer-switch'
+
+export function decidePrCheckout(
+  currentBranch: string,
+  prBranch: string,
+  dirty: boolean
+): PrCheckoutAction {
+  if (currentBranch === prBranch) return 'already-on-branch'
+  if (dirty) return 'refuse-dirty'
+  return 'offer-switch'
+}

--- a/tools/test-recorder/src/commands/record.ts
+++ b/tools/test-recorder/src/commands/record.ts
@@ -40,6 +40,7 @@ import {
 } from '../devserver/distributions'
 import { ensureDevServer } from '../devserver/manager'
 import { discoverFlagKeys, parseFeatureFlagSpecs } from '../featureFlags'
+import type { RecordPrefill } from './recordPrefill'
 
 const PASTE_SENTINEL = '.'
 const ADD_WORKFLOW_SENTINEL = '__add-workflow__'
@@ -128,7 +129,13 @@ async function offerAgentRefactor(
   pass('Test refactored', specPath)
 }
 
-export async function runRecord(): Promise<void> {
+function printPrefill(label: string, value: string, source: string): void {
+  console.log(`  ${label}: ${value} (from ${source})`)
+}
+
+export async function runRecord(
+  prefill: RecordPrefill = { warnings: [] }
+): Promise<void> {
   if (!process.stdin.isTTY) {
     fail(
       'comfy-test record needs an interactive terminal',
@@ -167,28 +174,41 @@ export async function runRecord(): Promise<void> {
   ])
   blank()
 
+  for (const warning of prefill.warnings) {
+    warn(`${warning} Asking you instead.`)
+  }
+
   stepHeader(1, 7, 'Target Distribution')
-  const selectedDistribution = await select({
-    message: 'Which distribution do you want to record against?',
-    options: [
-      ...DISTRIBUTIONS.map(({ id, label, hint }) => ({
-        value: id,
-        label,
-        hint
-      })),
-      {
-        value: CUSTOM_DISTRIBUTION_SENTINEL,
-        label: 'Custom backend…',
-        hint: 'connect Vite to another backend URL'
-      }
-    ],
-    initialValue: 'cloud'
-  })
-  if (isCancel(selectedDistribution)) {
+  const selectedDistribution = prefill.distribution
+    ? prefill.distribution.id
+    : await select({
+        message: 'Which distribution do you want to record against?',
+        options: [
+          ...DISTRIBUTIONS.map(({ id, label, hint }) => ({
+            value: id,
+            label,
+            hint
+          })),
+          {
+            value: CUSTOM_DISTRIBUTION_SENTINEL,
+            label: 'Custom backend…',
+            hint: 'connect Vite to another backend URL'
+          }
+        ],
+        initialValue: 'cloud'
+      })
+  if (prefill.distribution) {
+    printPrefill(
+      'Distribution',
+      prefill.distribution.id,
+      prefill.distributionSource ?? '--distribution'
+    )
+  } else if (isCancel(selectedDistribution)) {
     cancel('Operation cancelled')
     process.exit(0)
   }
-  let distribution = resolveDistribution(selectedDistribution)
+  let distribution =
+    prefill.distribution ?? resolveDistribution(selectedDistribution)
   if (selectedDistribution === CUSTOM_DISTRIBUTION_SENTINEL) {
     const backendInput = await text({
       message: 'Backend URL:',
@@ -248,16 +268,20 @@ export async function runRecord(): Promise<void> {
 
   stepHeader(4, 7, 'Configure Your Test')
 
-  const useCaseChoice = await select({
-    message:
-      "What brings you here today? There's no wrong answer — this just helps us ask the right question next.",
-    options: USE_CASES.map(({ id, label, hint }) => ({
-      value: id,
-      label,
-      hint
-    }))
-  })
-  if (isCancel(useCaseChoice)) {
+  const useCaseChoice = prefill.useCase
+    ? prefill.useCase.id
+    : await select({
+        message:
+          "What brings you here today? There's no wrong answer — this just helps us ask the right question next.",
+        options: USE_CASES.map(({ id, label, hint }) => ({
+          value: id,
+          label,
+          hint
+        }))
+      })
+  if (prefill.useCase) {
+    printPrefill('Use case', prefill.useCase.id, '--use-case')
+  } else if (isCancel(useCaseChoice)) {
     cancel('Operation cancelled')
     process.exit(0)
   }
@@ -274,13 +298,17 @@ export async function runRecord(): Promise<void> {
   ])
   blank()
 
-  const description = await text({
-    message: useCase.question,
-    placeholder: useCase.placeholder,
-    validate: (value) =>
-      toSlug(value ?? '') ? undefined : 'Use some letters or numbers.'
-  })
-  if (isCancel(description)) {
+  const description =
+    prefill.description ??
+    (await text({
+      message: useCase.question,
+      placeholder: useCase.placeholder,
+      validate: (value) =>
+        toSlug(value ?? '') ? undefined : 'Use some letters or numbers.'
+    }))
+  if (prefill.description) {
+    printPrefill('Description', prefill.description, '--description')
+  } else if (isCancel(description)) {
     cancel('Operation cancelled')
     process.exit(0)
   }
@@ -288,10 +316,15 @@ export async function runRecord(): Promise<void> {
   let testDescription: string = description
   let slug = toSlug(description)
 
-  const filenameOk = await confirm({
-    message: `Generated filename: ${slug}.spec.ts — looks good?`
-  })
-  if (isCancel(filenameOk)) {
+  const filenameOk = prefill.name
+    ? true
+    : await confirm({
+        message: `Generated filename: ${slug}.spec.ts — looks good?`
+      })
+  if (prefill.name) {
+    slug = prefill.name
+    printPrefill('Name', prefill.name, '--name')
+  } else if (isCancel(filenameOk)) {
     cancel('Operation cancelled')
     process.exit(0)
   }
@@ -315,18 +348,22 @@ export async function runRecord(): Promise<void> {
   ])
   blank()
 
-  const selectedTags = await multiselect({
-    message:
-      'Pick tags: press SPACE to select each one, ENTER when done (ENTER alone = no tags):',
-    options: TAG_REGISTRY.map(({ tag, hint }) => ({
-      value: tag,
-      label: tag,
-      hint
-    })),
-    initialValues: [],
-    required: false
-  })
-  if (isCancel(selectedTags)) {
+  const selectedTags =
+    prefill.tags ??
+    (await multiselect({
+      message:
+        'Pick tags: press SPACE to select each one, ENTER when done (ENTER alone = no tags):',
+      options: TAG_REGISTRY.map(({ tag, hint }) => ({
+        value: tag,
+        label: tag,
+        hint
+      })),
+      initialValues: [],
+      required: false
+    }))
+  if (prefill.tags) {
+    printPrefill('Tags', prefill.tags.join(', '), '--tags')
+  } else if (isCancel(selectedTags)) {
     cancel('Operation cancelled')
     process.exit(0)
   }
@@ -350,13 +387,29 @@ export async function runRecord(): Promise<void> {
     ...rest.map((wf) => ({ value: wf, label: wf }))
   ]
 
-  const selectedWorkflow = await autocomplete({
-    message: `Start with a pre-loaded workflow? (${workflows.length} available)`,
-    options: workflowOptions,
-    initialValue: '',
-    maxItems: 12
-  })
-  if (isCancel(selectedWorkflow)) {
+  const validPrefillWorkflow =
+    prefill.workflow !== undefined &&
+    (prefill.workflow === '' || workflows.includes(prefill.workflow))
+      ? prefill.workflow
+      : undefined
+  if (prefill.workflow !== undefined && validPrefillWorkflow === undefined) {
+    warn(`Unknown --workflow "${prefill.workflow}". Asking you instead.`)
+  }
+  const selectedWorkflow =
+    validPrefillWorkflow ??
+    (await autocomplete({
+      message: `Start with a pre-loaded workflow? (${workflows.length} available)`,
+      options: workflowOptions,
+      initialValue: '',
+      maxItems: 12
+    }))
+  if (validPrefillWorkflow !== undefined) {
+    printPrefill(
+      'Workflow',
+      validPrefillWorkflow || '(empty canvas)',
+      '--workflow'
+    )
+  } else if (isCancel(selectedWorkflow)) {
     cancel('Operation cancelled')
     process.exit(0)
   }
@@ -389,17 +442,27 @@ export async function runRecord(): Promise<void> {
     }
   }
 
-  const overrideFeatureFlags = await confirm({
-    message: 'Override feature flags for this test?',
-    initialValue: false
-  })
-  if (isCancel(overrideFeatureFlags)) {
+  const overrideFeatureFlags = prefill.featureFlags
+    ? true
+    : await confirm({
+        message: 'Override feature flags for this test?',
+        initialValue: false
+      })
+  if (prefill.featureFlags) {
+    printPrefill(
+      'Feature flags',
+      Object.entries(prefill.featureFlags)
+        .map(([key, value]) => `${key}:${JSON.stringify(value)}`)
+        .join(', '),
+      '--feature-flags'
+    )
+  } else if (isCancel(overrideFeatureFlags)) {
     cancel('Operation cancelled')
     process.exit(0)
   }
 
   let selectedFeatureFlags: string[] = []
-  if (overrideFeatureFlags) {
+  if (overrideFeatureFlags && !prefill.featureFlags) {
     const availableFlags = discoverFlagKeys(projectRoot)
     if (availableFlags.length > 0) {
       const selected = await autocompleteMultiselect({
@@ -427,7 +490,8 @@ export async function runRecord(): Promise<void> {
       ...customFlags.split(',').map((flag) => flag.trim())
     ]
   }
-  const featureFlags = parseFeatureFlagSpecs(selectedFeatureFlags)
+  const featureFlags =
+    prefill.featureFlags ?? parseFeatureFlagSpecs(selectedFeatureFlags)
 
   stepHeader(5, 7, 'Record')
 

--- a/tools/test-recorder/src/commands/record.ts
+++ b/tools/test-recorder/src/commands/record.ts
@@ -39,6 +39,7 @@ import {
   resolveDistribution
 } from '../devserver/distributions'
 import { ensureDevServer } from '../devserver/manager'
+import { fetchEnvInfo } from '../devserver/envInfo'
 import { discoverFlagKeys, parseFeatureFlagSpecs } from '../featureFlags'
 import type { RecordPrefill } from './recordPrefill'
 
@@ -179,15 +180,32 @@ export async function runRecord(
   }
 
   stepHeader(1, 7, 'Target Distribution')
+  const distributionInfo = await Promise.all(
+    DISTRIBUTIONS.map(async (candidate) => ({
+      id: candidate.id,
+      info:
+        candidate.backendUrl && candidate.id !== 'local'
+          ? await fetchEnvInfo(candidate.backendUrl)
+          : { ok: false as const }
+    }))
+  )
   const selectedDistribution = prefill.distribution
     ? prefill.distribution.id
     : await select({
         message: 'Which distribution do you want to record against?',
         options: [
-          ...DISTRIBUTIONS.map(({ id, label, hint }) => ({
+          ...DISTRIBUTIONS.map(({ id, label, hint, backendUrl }) => ({
             value: id,
             label,
-            hint
+            hint: (() => {
+              const env = distributionInfo.find(
+                (entry) => entry.id === id
+              )?.info
+              if (!env?.ok || !backendUrl) return hint
+              const host = new URL(backendUrl).host
+              const suffix = id === 'cloud' ? ' (default)' : ''
+              return `${host} — backend ${env.cloudVersion}${suffix}`
+            })()
           })),
           {
             value: CUSTOM_DISTRIBUTION_SENTINEL,
@@ -227,6 +245,17 @@ export async function runRecord(
     distribution = customDistribution(normalized.url)
   }
   if (!distribution) throw new Error('Selected distribution is unavailable')
+
+  const branch = runCommand('git', ['branch', '--show-current'], {
+    cwd: process.cwd(),
+    stdio: 'pipe'
+  })
+    .stdout?.toString()
+    .trim()
+  info([
+    `The app you're testing is your local checkout (branch ${branch || 'unknown'}). ` +
+      'The environment choice only picks which backend it talks to.'
+  ])
 
   stepHeader(2, 7, 'Environment Check')
   const { allPassed } = await runChecks(distribution, undefined, {

--- a/tools/test-recorder/src/commands/record.ts
+++ b/tools/test-recorder/src/commands/record.ts
@@ -135,6 +135,14 @@ function printPrefill(label: string, value: string, source: string): void {
   console.log(`  ${label}: ${value} (from ${source})`)
 }
 
+function answered<T>(value: T | symbol): T {
+  if (isCancel(value)) {
+    cancel('Operation cancelled')
+    process.exit(0)
+  }
+  return value
+}
+
 async function preparePrCheckout(
   pr: string,
   projectRoot: string
@@ -282,39 +290,38 @@ export async function runRecord(
   )
   const selectedDistribution = prefill.distribution
     ? prefill.distribution.id
-    : await select({
-        message: 'Which distribution do you want to record against?',
-        options: [
-          ...DISTRIBUTIONS.map(({ id, label, hint, backendUrl }) => ({
-            value: id,
-            label,
-            hint: (() => {
-              const env = distributionInfo.find(
-                (entry) => entry.id === id
-              )?.info
-              if (!env?.ok || !backendUrl) return hint
-              const host = new URL(backendUrl).host
-              const suffix = id === 'cloud' ? ' (default)' : ''
-              return `${host} — backend ${env.cloudVersion}${suffix}`
-            })()
-          })),
-          {
-            value: CUSTOM_DISTRIBUTION_SENTINEL,
-            label: 'Custom backend…',
-            hint: 'connect Vite to another backend URL'
-          }
-        ],
-        initialValue: 'cloud'
-      })
+    : answered(
+        await select({
+          message: 'Which distribution do you want to record against?',
+          options: [
+            ...DISTRIBUTIONS.map(({ id, label, hint, backendUrl }) => ({
+              value: id,
+              label,
+              hint: (() => {
+                const env = distributionInfo.find(
+                  (entry) => entry.id === id
+                )?.info
+                if (!env?.ok || !backendUrl) return hint
+                const host = new URL(backendUrl).host
+                const suffix = id === 'cloud' ? ' (default)' : ''
+                return `${host} — backend ${env.cloudVersion}${suffix}`
+              })()
+            })),
+            {
+              value: CUSTOM_DISTRIBUTION_SENTINEL,
+              label: 'Custom backend…',
+              hint: 'connect Vite to another backend URL'
+            }
+          ],
+          initialValue: 'cloud'
+        })
+      )
   if (prefill.distribution) {
     printPrefill(
       'Distribution',
       prefill.distribution.id,
       prefill.distributionSource ?? '--distribution'
     )
-  } else if (isCancel(selectedDistribution)) {
-    cancel('Operation cancelled')
-    process.exit(0)
   }
   let distribution =
     prefill.distribution ?? resolveDistribution(selectedDistribution)
@@ -390,20 +397,19 @@ export async function runRecord(
 
   const useCaseChoice = prefill.useCase
     ? prefill.useCase.id
-    : await select({
-        message:
-          "What brings you here today? There's no wrong answer — this just helps us ask the right question next.",
-        options: USE_CASES.map(({ id, label, hint }) => ({
-          value: id,
-          label,
-          hint
-        }))
-      })
+    : answered(
+        await select({
+          message:
+            "What brings you here today? There's no wrong answer — this just helps us ask the right question next.",
+          options: USE_CASES.map(({ id, label, hint }) => ({
+            value: id,
+            label,
+            hint
+          }))
+        })
+      )
   if (prefill.useCase) {
     printPrefill('Use case', prefill.useCase.id, '--use-case')
-  } else if (isCancel(useCaseChoice)) {
-    cancel('Operation cancelled')
-    process.exit(0)
   }
   const useCase = useCaseById(useCaseChoice) ?? USE_CASES[0]
 
@@ -420,17 +426,16 @@ export async function runRecord(
 
   const description =
     prefill.description ??
-    (await text({
-      message: useCase.question,
-      placeholder: useCase.placeholder,
-      validate: (value) =>
-        toSlug(value ?? '') ? undefined : 'Use some letters or numbers.'
-    }))
+    answered(
+      await text({
+        message: useCase.question,
+        placeholder: useCase.placeholder,
+        validate: (value) =>
+          toSlug(value ?? '') ? undefined : 'Use some letters or numbers.'
+      })
+    )
   if (prefill.description) {
     printPrefill('Description', prefill.description, '--description')
-  } else if (isCancel(description)) {
-    cancel('Operation cancelled')
-    process.exit(0)
   }
 
   let testDescription: string = description
@@ -438,15 +443,14 @@ export async function runRecord(
 
   const filenameOk = prefill.name
     ? true
-    : await confirm({
-        message: `Generated filename: ${slug}.spec.ts — looks good?`
-      })
+    : answered(
+        await confirm({
+          message: `Generated filename: ${slug}.spec.ts — looks good?`
+        })
+      )
   if (prefill.name) {
     slug = prefill.name
     printPrefill('Name', prefill.name, '--name')
-  } else if (isCancel(filenameOk)) {
-    cancel('Operation cancelled')
-    process.exit(0)
   }
   if (!filenameOk) {
     const customName = await text({
@@ -470,22 +474,21 @@ export async function runRecord(
 
   const selectedTags =
     prefill.tags ??
-    (await multiselect({
-      message:
-        'Pick tags: press SPACE to select each one, ENTER when done (ENTER alone = no tags):',
-      options: TAG_REGISTRY.map(({ tag, hint }) => ({
-        value: tag,
-        label: tag,
-        hint
-      })),
-      initialValues: [],
-      required: false
-    }))
+    answered(
+      await multiselect({
+        message:
+          'Pick tags: press SPACE to select each one, ENTER when done (ENTER alone = no tags):',
+        options: TAG_REGISTRY.map(({ tag, hint }) => ({
+          value: tag,
+          label: tag,
+          hint
+        })),
+        initialValues: [],
+        required: false
+      })
+    )
   if (prefill.tags) {
     printPrefill('Tags', prefill.tags.join(', '), '--tags')
-  } else if (isCancel(selectedTags)) {
-    cancel('Operation cancelled')
-    process.exit(0)
   }
 
   const workflows = listWorkflows(projectRoot)
@@ -517,21 +520,20 @@ export async function runRecord(
   }
   const selectedWorkflow =
     validPrefillWorkflow ??
-    (await autocomplete({
-      message: `Start with a pre-loaded workflow? (${workflows.length} available)`,
-      options: workflowOptions,
-      initialValue: '',
-      maxItems: 12
-    }))
+    answered(
+      await autocomplete({
+        message: `Start with a pre-loaded workflow? (${workflows.length} available)`,
+        options: workflowOptions,
+        initialValue: '',
+        maxItems: 12
+      })
+    )
   if (validPrefillWorkflow !== undefined) {
     printPrefill(
       'Workflow',
       validPrefillWorkflow || '(empty canvas)',
       '--workflow'
     )
-  } else if (isCancel(selectedWorkflow)) {
-    cancel('Operation cancelled')
-    process.exit(0)
   }
 
   let seedWorkflow = selectedWorkflow
@@ -564,10 +566,12 @@ export async function runRecord(
 
   const overrideFeatureFlags = prefill.featureFlags
     ? true
-    : await confirm({
-        message: 'Override feature flags for this test?',
-        initialValue: false
-      })
+    : answered(
+        await confirm({
+          message: 'Override feature flags for this test?',
+          initialValue: false
+        })
+      )
   if (prefill.featureFlags) {
     printPrefill(
       'Feature flags',
@@ -576,9 +580,6 @@ export async function runRecord(
         .join(', '),
       '--feature-flags'
     )
-  } else if (isCancel(overrideFeatureFlags)) {
-    cancel('Operation cancelled')
-    process.exit(0)
   }
 
   let selectedFeatureFlags: string[] = []
@@ -712,7 +713,7 @@ export async function runRecord(
 
   const transformResult = transform(recordedCode, {
     testName: slug,
-    tags: selectedTags as string[],
+    tags: selectedTags,
     workflow: seedWorkflow || undefined,
     featureFlags
   })

--- a/tools/test-recorder/src/commands/record.ts
+++ b/tools/test-recorder/src/commands/record.ts
@@ -42,6 +42,7 @@ import { ensureDevServer } from '../devserver/manager'
 import { fetchEnvInfo } from '../devserver/envInfo'
 import { discoverFlagKeys, parseFeatureFlagSpecs } from '../featureFlags'
 import type { RecordPrefill } from './recordPrefill'
+import { decidePrCheckout } from './prCheckout'
 
 const PASTE_SENTINEL = '.'
 const ADD_WORKFLOW_SENTINEL = '__add-workflow__'
@@ -134,6 +135,85 @@ function printPrefill(label: string, value: string, source: string): void {
   console.log(`  ${label}: ${value} (from ${source})`)
 }
 
+async function preparePrCheckout(
+  pr: string,
+  projectRoot: string
+): Promise<void> {
+  const details = runCommand(
+    'gh',
+    [
+      'pr',
+      'view',
+      pr,
+      '--json',
+      'headRefName,title,state',
+      '-q',
+      '[.headRefName,.title,.state] | @tsv'
+    ],
+    { cwd: projectRoot, stdio: 'pipe' }
+  )
+  if (details.error || details.status !== 0) {
+    warn(`Could not look up PR #${pr}. Continuing on the current checkout.`)
+    info([`Install or sign in to gh, then run: gh pr checkout ${pr}`])
+    return
+  }
+
+  const [prBranch, title] = details.stdout.toString().trim().split('\t')
+  if (!prBranch || !title) {
+    warn(`Could not read PR #${pr}. Continuing on the current checkout.`)
+    return
+  }
+  const currentBranch = runCommand('git', ['branch', '--show-current'], {
+    cwd: projectRoot,
+    stdio: 'pipe'
+  })
+    .stdout.toString()
+    .trim()
+  const dirty =
+    runCommand('git', ['status', '--porcelain'], {
+      cwd: projectRoot,
+      stdio: 'pipe'
+    })
+      .stdout.toString()
+      .trim().length > 0
+  const action = decidePrCheckout(currentBranch, prBranch, dirty)
+  if (action === 'already-on-branch') {
+    pass(`Your checkout already has the code for PR #${pr}`, prBranch)
+    return
+  }
+  if (action === 'refuse-dirty') {
+    warn(
+      `PR #${pr} targets "${prBranch}", but this checkout has unsaved changes. ` +
+        `I won't switch and risk losing them. Continuing on "${currentBranch}".`
+    )
+    info([`Save or commit your changes, then run: gh pr checkout ${pr}`])
+    return
+  }
+
+  info([
+    `This test plan targets PR #${pr} — '${title}'.`,
+    `Your checkout is on '${currentBranch}'. I can switch to the PR's code for you.`
+  ])
+  const shouldSwitch = await confirm({
+    message: `Switch to the code for PR #${pr}?`
+  })
+  if (isCancel(shouldSwitch) || !shouldSwitch) {
+    warn(`Continuing on "${currentBranch}" instead of PR #${pr}.`)
+    info([`To switch later, run: gh pr checkout ${pr}`])
+    return
+  }
+  const checkout = runCommand('gh', ['pr', 'checkout', pr], {
+    cwd: projectRoot,
+    stdio: 'pipe'
+  })
+  if (checkout.error || checkout.status !== 0) {
+    warn(`Could not switch to PR #${pr}. Continuing on "${currentBranch}".`)
+    info([`Try manually: gh pr checkout ${pr}`])
+    return
+  }
+  pass(`Switched to the code for PR #${pr}`, prBranch)
+}
+
 export async function runRecord(
   prefill: RecordPrefill = { warnings: [] }
 ): Promise<void> {
@@ -177,6 +257,17 @@ export async function runRecord(
 
   for (const warning of prefill.warnings) {
     warn(`${warning} Asking you instead.`)
+  }
+
+  if (prefill.pr) {
+    let root: string
+    try {
+      root = findProjectRoot()
+    } catch {
+      warn(`Could not find the checkout for PR #${prefill.pr}. Continuing.`)
+      root = process.cwd()
+    }
+    await preparePrCheckout(prefill.pr, root)
   }
 
   stepHeader(1, 7, 'Target Distribution')

--- a/tools/test-recorder/src/commands/recordPrefill.test.ts
+++ b/tools/test-recorder/src/commands/recordPrefill.test.ts
@@ -53,4 +53,13 @@ describe('resolveRecordPrefill', () => {
       distributionSource: '--backend'
     })
   })
+
+  it('keeps a numeric pull request and rejects other values', () => {
+    expect(resolveRecordPrefill({ pr: '123' }).pr).toBe('123')
+    const invalid = resolveRecordPrefill({ pr: 'abc' })
+    expect(invalid.pr).toBeUndefined()
+    expect(invalid.warnings).toContain(
+      'Invalid --pr "abc": use a pull request number.'
+    )
+  })
 })

--- a/tools/test-recorder/src/commands/recordPrefill.test.ts
+++ b/tools/test-recorder/src/commands/recordPrefill.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+
+import { resolveRecordPrefill } from './recordPrefill'
+
+describe('resolveRecordPrefill', () => {
+  it('maps valid record flags to prompt-skipping options', () => {
+    const result = resolveRecordPrefill({
+      distribution: 'cloud-staging',
+      workflow: 'default',
+      tags: '@canvas,@widget',
+      'feature-flags': 'linear_toggle_enabled:true,count:2',
+      'use-case': 'test-plan-step',
+      description: 'seed stays fixed across runs',
+      name: 'fixed-seed'
+    })
+
+    expect(result).toMatchObject({
+      distribution: { id: 'cloud-staging' },
+      distributionSource: '--distribution',
+      workflow: 'default',
+      tags: ['@canvas', '@widget'],
+      featureFlags: { linear_toggle_enabled: true, count: 2 },
+      useCase: { id: 'test-plan-step' },
+      description: 'seed stays fixed across runs',
+      name: 'fixed-seed',
+      warnings: []
+    })
+  })
+
+  it('drops invalid values and returns warnings for interactive fallback', () => {
+    const result = resolveRecordPrefill({
+      distribution: 'moon',
+      tags: 'not-a-tag',
+      'use-case': 'other',
+      description: '---',
+      name: '---'
+    })
+
+    expect(result.distribution).toBeUndefined()
+    expect(result.tags).toBeUndefined()
+    expect(result.useCase).toBeUndefined()
+    expect(result.description).toBeUndefined()
+    expect(result.name).toBeUndefined()
+    expect(result.warnings).toHaveLength(5)
+  })
+
+  it('normalizes a custom backend and makes it the distribution', () => {
+    expect(resolveRecordPrefill({ backend: 'agent.comfy.org' })).toMatchObject({
+      distribution: {
+        id: 'custom',
+        backendUrl: 'https://agent.comfy.org/'
+      },
+      distributionSource: '--backend'
+    })
+  })
+})

--- a/tools/test-recorder/src/commands/recordPrefill.ts
+++ b/tools/test-recorder/src/commands/recordPrefill.ts
@@ -66,6 +66,11 @@ export function resolveRecordPrefill(
     warnings.push(`Unknown --tags: ${invalidTags.join(', ')}.`)
   }
 
+  const pr = flags.pr?.trim()
+  if (pr !== undefined && !/^\d+$/.test(pr)) {
+    warnings.push(`Invalid --pr "${pr}": use a pull request number.`)
+  }
+
   return {
     distribution,
     distributionSource,
@@ -78,6 +83,6 @@ export function resolveRecordPrefill(
     description: toSlug(description ?? '') ? description : undefined,
     name: toSlug(name ?? '') ? toSlug(name ?? '') : undefined,
     warnings,
-    pr: flags.pr
+    pr: pr && /^\d+$/.test(pr) ? pr : undefined
   }
 }

--- a/tools/test-recorder/src/commands/recordPrefill.ts
+++ b/tools/test-recorder/src/commands/recordPrefill.ts
@@ -1,0 +1,83 @@
+import { parseTags } from '../cli/flags'
+import {
+  customDistribution,
+  normalizeBackendUrl,
+  resolveDistribution
+} from '../devserver/distributions'
+import type { Distribution } from '../devserver/distributions'
+import { parseFeatureFlagSpecs } from '../featureFlags'
+import { TAG_REGISTRY } from '../tags'
+import { useCaseById } from '../useCases'
+import type { UseCase } from '../useCases'
+import { toSlug } from '../cli/slug'
+
+export interface RecordPrefill {
+  distribution?: Distribution
+  distributionSource?: string
+  workflow?: string
+  tags?: string[]
+  featureFlags?: Record<string, unknown>
+  useCase?: UseCase
+  description?: string
+  name?: string
+  warnings: string[]
+  pr?: string
+}
+
+export function resolveRecordPrefill(
+  flags: Record<string, string | undefined>
+): RecordPrefill {
+  const warnings: string[] = []
+  let distribution: Distribution | undefined
+  let distributionSource: string | undefined
+
+  if (flags.backend) {
+    const normalized = normalizeBackendUrl(flags.backend)
+    if (normalized.ok) {
+      distribution = customDistribution(normalized.url)
+      distributionSource = '--backend'
+    } else {
+      warnings.push(`Invalid --backend: ${normalized.reason}`)
+    }
+  } else if (flags.distribution !== undefined) {
+    distribution = resolveDistribution(flags.distribution)
+    if (distribution) distributionSource = '--distribution'
+    else warnings.push(`Unknown --distribution "${flags.distribution}".`)
+  }
+
+  const useCase = flags['use-case'] ? useCaseById(flags['use-case']) : undefined
+  if (flags['use-case'] && !useCase) {
+    warnings.push(`Unknown --use-case "${flags['use-case']}".`)
+  }
+
+  const description = flags.description?.trim()
+  if (flags.description !== undefined && !toSlug(description ?? '')) {
+    warnings.push('Invalid --description: use some letters or numbers.')
+  }
+  const name = flags.name?.trim()
+  if (flags.name !== undefined && !toSlug(name ?? '')) {
+    warnings.push('Invalid --name: use some letters or numbers.')
+  }
+
+  const tags = parseTags(flags.tags)
+  const knownTags = new Set(TAG_REGISTRY.map(({ tag }) => tag))
+  const invalidTags = tags?.filter((tag) => !knownTags.has(tag)) ?? []
+  if (invalidTags.length > 0) {
+    warnings.push(`Unknown --tags: ${invalidTags.join(', ')}.`)
+  }
+
+  return {
+    distribution,
+    distributionSource,
+    workflow: flags.workflow,
+    tags: invalidTags.length === 0 ? tags : undefined,
+    featureFlags: flags['feature-flags']
+      ? parseFeatureFlagSpecs(flags['feature-flags'].split(','))
+      : undefined,
+    useCase,
+    description: toSlug(description ?? '') ? description : undefined,
+    name: toSlug(name ?? '') ? toSlug(name ?? '') : undefined,
+    warnings,
+    pr: flags.pr
+  }
+}

--- a/tools/test-recorder/src/devserver/distributions.ts
+++ b/tools/test-recorder/src/devserver/distributions.ts
@@ -13,21 +13,24 @@ export const DISTRIBUTIONS: readonly Distribution[] = [
     label: 'Cloud',
     hint: 'testcloud.comfy.org (default)',
     script: 'dev:cloud',
-    needsLocalBackend: false
+    needsLocalBackend: false,
+    backendUrl: 'https://testcloud.comfy.org/'
   },
   {
     id: 'cloud-staging',
     label: 'Cloud staging',
     hint: 'staging cloud backend',
     script: 'dev:cloud:staging',
-    needsLocalBackend: false
+    needsLocalBackend: false,
+    backendUrl: 'https://stagingcloud.comfy.org/'
   },
   {
     id: 'cloud-prod',
     label: 'Cloud production',
     hint: 'production cloud backend',
     script: 'dev:cloud:prod',
-    needsLocalBackend: false
+    needsLocalBackend: false,
+    backendUrl: 'https://cloud.comfy.org/'
   },
   {
     id: 'local',

--- a/tools/test-recorder/src/devserver/envInfo.test.ts
+++ b/tools/test-recorder/src/devserver/envInfo.test.ts
@@ -31,9 +31,9 @@ describe('fetchEnvInfo', () => {
   })
 
   it.for([
-    ['HTTP failure', new Response('', { status: 503 })],
-    ['invalid payload', new Response('{}')]
-  ])('returns failure for %s', async ([_label, response]) => {
+    { label: 'HTTP failure', response: new Response('', { status: 503 }) },
+    { label: 'invalid payload', response: new Response('{}') }
+  ])('returns failure for $label', async ({ response }) => {
     vi.mocked(fetch).mockResolvedValue(response)
     await expect(fetchEnvInfo('https://example.com/')).resolves.toEqual({
       ok: false

--- a/tools/test-recorder/src/devserver/envInfo.test.ts
+++ b/tools/test-recorder/src/devserver/envInfo.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { fetchEnvInfo } from './envInfo'
+
+describe('fetchEnvInfo', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn())
+  })
+
+  it('returns cloud environment versions from system stats', async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          system: {
+            cloud_version: 'e299178',
+            comfyui_version: 'abc1234',
+            deploy_environment: 'test'
+          }
+        })
+      )
+    )
+
+    await expect(fetchEnvInfo('https://testcloud.comfy.org/')).resolves.toEqual(
+      {
+        ok: true,
+        cloudVersion: 'e299178',
+        comfyuiVersion: 'abc1234',
+        deployEnvironment: 'test'
+      }
+    )
+  })
+
+  it.for([
+    ['HTTP failure', new Response('', { status: 503 })],
+    ['invalid payload', new Response('{}')]
+  ])('returns failure for %s', async ([_label, response]) => {
+    vi.mocked(fetch).mockResolvedValue(response)
+    await expect(fetchEnvInfo('https://example.com/')).resolves.toEqual({
+      ok: false
+    })
+  })
+
+  it('aborts a request that exceeds the timeout', async () => {
+    vi.mocked(fetch).mockImplementation(
+      (_input, init) =>
+        new Promise((_resolve, reject) => {
+          init?.signal?.addEventListener('abort', () =>
+            reject(new DOMException('Aborted', 'AbortError'))
+          )
+        })
+    )
+
+    await expect(fetchEnvInfo('https://example.com/', 1)).resolves.toEqual({
+      ok: false
+    })
+  })
+})

--- a/tools/test-recorder/src/devserver/envInfo.ts
+++ b/tools/test-recorder/src/devserver/envInfo.ts
@@ -1,0 +1,50 @@
+export type EnvInfoResult =
+  | {
+      ok: true
+      cloudVersion: string
+      comfyuiVersion: string
+      deployEnvironment: string
+    }
+  | { ok: false }
+
+interface SystemStatsResponse {
+  system?: {
+    cloud_version?: unknown
+    comfyui_version?: unknown
+    deploy_environment?: unknown
+  }
+}
+
+export async function fetchEnvInfo(
+  backendUrl: string,
+  timeoutMs = 2500
+): Promise<EnvInfoResult> {
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), timeoutMs)
+  try {
+    const response = await fetch(new URL('api/system_stats', backendUrl), {
+      signal: controller.signal
+    })
+    if (!response.ok) return { ok: false }
+    const data: unknown = await response.json()
+    if (typeof data !== 'object' || data === null) return { ok: false }
+    const system = (data as SystemStatsResponse).system
+    if (
+      typeof system?.cloud_version !== 'string' ||
+      typeof system.comfyui_version !== 'string' ||
+      typeof system.deploy_environment !== 'string'
+    ) {
+      return { ok: false }
+    }
+    return {
+      ok: true,
+      cloudVersion: system.cloud_version,
+      comfyuiVersion: system.comfyui_version,
+      deployEnvironment: system.deploy_environment
+    }
+  } catch {
+    return { ok: false }
+  } finally {
+    clearTimeout(timeout)
+  }
+}

--- a/tools/test-recorder/src/featureFlags.test.ts
+++ b/tools/test-recorder/src/featureFlags.test.ts
@@ -1,10 +1,36 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+  buildFfQuery,
   extractEnumValues,
   formatInitialFeatureFlags,
   parseFeatureFlagSpecs
 } from './featureFlags'
+
+describe('buildFfQuery', () => {
+  it('encodes repeatable ff parameters with JSON-typed values', () => {
+    const query = buildFfQuery({
+      enabled: true,
+      disabled: false,
+      count: 12,
+      label: '12',
+      mode: 'enforce'
+    })
+    const params = new URLSearchParams(query)
+
+    expect(params.getAll('ff')).toEqual([
+      'enabled',
+      'disabled:false',
+      'count:12',
+      'label:"12"',
+      'mode:"enforce"'
+    ])
+  })
+
+  it('returns no query for no flags', () => {
+    expect(buildFfQuery({})).toBe('')
+  })
+})
 
 describe('parseFeatureFlagSpecs', () => {
   it('parses bare and JSON values while preserving colons', () => {

--- a/tools/test-recorder/src/featureFlags.ts
+++ b/tools/test-recorder/src/featureFlags.ts
@@ -26,6 +26,17 @@ export function parseFeatureFlagSpecs(
   )
 }
 
+export function buildFfQuery(flags: Record<string, unknown>): string {
+  const params = new URLSearchParams()
+  for (const [key, value] of Object.entries(flags)) {
+    const encodedValue =
+      value === true ? key : `${key}:${JSON.stringify(value) ?? String(value)}`
+    params.append('ff', encodedValue)
+  }
+  const query = params.toString()
+  return query ? `?${query}` : ''
+}
+
 export function extractEnumValues(source: string): string[] {
   const enumBody = source.match(
     /export\s+enum\s+ServerFeatureFlag\s*\{([\s\S]*?)\}/

--- a/tools/test-recorder/src/index.ts
+++ b/tools/test-recorder/src/index.ts
@@ -11,8 +11,21 @@ intro(pc.bgCyan(pc.black(' 🎭 ComfyUI Test Recorder ')))
 try {
   switch (command) {
     case 'record': {
+      const { parseFlags } = await import('./cli/flags')
+      const { flags } = parseFlags(args.slice(1), [
+        'distribution',
+        'backend',
+        'workflow',
+        'tags',
+        'feature-flags',
+        'use-case',
+        'description',
+        'name',
+        'pr'
+      ])
+      const { resolveRecordPrefill } = await import('./commands/recordPrefill')
       const { runRecord } = await import('./commands/record')
-      await runRecord()
+      await runRecord(resolveRecordPrefill(flags))
       break
     }
     case 'add-workflow': {
@@ -190,7 +203,10 @@ try {
 Usage: comfy-test <command>
 
 Commands:
-  record      Record a new browser test interactively (needs a terminal)
+  record [--distribution <id>] [--backend <url>] [--workflow <name>]
+         [--tags <a,b>] [--feature-flags <specs>] [--use-case <id>]
+         [--description <text>] [--name <slug>] [--pr <number>]
+              Record a browser test; supplied answers skip setup prompts
   add-workflow <file> [--name <n>]
               Add and validate a workflow asset from disk
   plan        Print a test plan for an agent to hand to playwright-test-generator

--- a/tools/test-recorder/src/recorder/runner.ts
+++ b/tools/test-recorder/src/recorder/runner.ts
@@ -15,6 +15,7 @@ import { runCommand } from '../cli/run'
 import { devServerUrl } from '../checks/devServerUrl'
 import { box, info } from '../ui/logger'
 import type { Distribution } from '../devserver/distributions'
+import { buildFfQuery } from '../featureFlags'
 
 interface RunnerOptions {
   testName: string
@@ -154,7 +155,9 @@ export async function runRecording(
           // buttons, which is everything a recording needs.
           PW_CODEGEN_NO_INSPECTOR: '1',
           // Without this the fixture records against :8188's bundled frontend.
-          PLAYWRIGHT_TEST_URL: devServerUrl()
+          PLAYWRIGHT_TEST_URL:
+            devServerUrl() +
+            (target === 'cloud' ? buildFfQuery(options.featureFlags ?? {}) : '')
         }
       }
     )

--- a/tools/test-recorder/src/recorder/template.test.ts
+++ b/tools/test-recorder/src/recorder/template.test.ts
@@ -190,19 +190,14 @@ describe('recording template', () => {
       expect(code).not.toContain('loadWorkflow')
     })
 
-    it('seeds feature flags via ff: localStorage keys before navigation', () => {
+    it('does not seed localStorage feature flags for cloud recordings', () => {
       const { code } = generate({
         testName: 'demo',
         featureFlags: { onboarding_tour_enabled: true, custom_flag: 12 },
         target: 'cloud'
       })
-      const seedAt = code.indexOf('addInitScript')
-      expect(seedAt).toBeGreaterThan(-1)
-      expect(seedAt).toBeLessThan(code.indexOf('page.goto('))
-      expect(code).toContain("'ff:' + key")
-      expect(code).toContain(
-        '{"onboarding_tour_enabled":true,"custom_flag":12}'
-      )
+      expect(code).not.toContain('addInitScript')
+      expect(code).not.toContain("'ff:' + key")
     })
 
     it('omits flag seeding when no flags are selected', () => {

--- a/tools/test-recorder/src/recorder/template.ts
+++ b/tools/test-recorder/src/recorder/template.ts
@@ -134,19 +134,6 @@ function cloudTemplate(
   safeName: string,
   safeOutputPath: string
 ): string {
-  const hasFlags =
-    options.featureFlags && Object.keys(options.featureFlags).length > 0
-  // The app reads feature-flag overrides from localStorage 'ff:<key>' keys —
-  // the same mechanism FeatureFlagHelper.seedFlags uses in cloud specs.
-  const flagSeedBlock = hasFlags
-    ? `  await page.addInitScript((flags) => {
-    for (const [key, value] of Object.entries(flags)) {
-      localStorage.setItem('ff:' + key, JSON.stringify(value))
-    }
-  }, ${JSON.stringify(options.featureFlags)})
-`
-    : ''
-
   const stateFile = options.storageStateFile
   const safeStateFile = stateFile ? JSON.stringify(stateFile) : undefined
   const reuseLoginBlock =
@@ -173,7 +160,7 @@ function cloudTemplate(
 import { test } from '@playwright/test'
 
 ${reuseLoginBlock}test(${safeName}, async ({ page }) => {
-${flagSeedBlock}  await page.goto(process.env.PLAYWRIGHT_TEST_URL ?? 'http://localhost:5173')
+  await page.goto(process.env.PLAYWRIGHT_TEST_URL ?? 'http://localhost:5173')
 ${persistLoginBlock}  // The cloud app may show a sign-in screen first — sign in manually, then
   // record. Nothing is captured until the Record button is clicked, so the
   // recorder opens immediately rather than gating on app boot.


### PR DESCRIPTION
Follow-up usability pass on `tools/test-recorder` so QA test plans can embed one copy-pastable `pnpm comfy-test record` command and non-devs get clearer environment context.

- Prefill every `record` setup prompt from flags: `--distribution`, `--backend`, `--workflow`, `--tags`, `--feature-flags`, `--use-case`, `--description`, `--name`. Invalid values warn and fall back to the interactive prompt instead of failing.
- Show live backend versions in the distribution selector (testcloud/stagingcloud/cloud) via `/api/system_stats`, so testers can see which release each environment maps to.
- Apply feature flags on cloud targets through repeatable `?ff=key:value` URL params (session-scoped overrides, matching the app's `Comfy.FeatureFlagOverride` handling) instead of dev overrides that don't work off local.
- `--pr <number>` checks out the PR branch safely before recording, with plain-language confirmation.
- Docs: AGENTS.md interface-parity table and README updated; `guide` output stays in sync with the new prompts.

## Test plan

- `pnpm typecheck`, `pnpm lint`, `pnpm knip` green
- 249 unit tests in `tools/test-recorder` pass (`vitest run tools/test-recorder`)
- Manual: interactive `record` run with no flags (prompts unchanged), fully-prefilled run skips all setup questions, invalid `--workflow` warns and falls back to prompt
