### PR TITLE
fix(billing): tolerate subscription tiers absent from the personal catalog

### DIFF
--- a/src/platform/cloud/subscription/composables/useBillingPolicyState.test.ts
+++ b/src/platform/cloud/subscription/composables/useBillingPolicyState.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
+import type { IngestSubscriptionTier } from '@/platform/cloud/subscription/constants/tierPricing'
 import { deriveBillingPolicyState } from './useBillingPolicyState'
 
 describe('deriveBillingPolicyState', () => {
@@ -124,6 +125,27 @@ describe('deriveBillingPolicyState', () => {
           canAccessSubscriptionFeatures: false,
           isTeamPlan: false,
           tier: 'TEAM'
+        })
+      ).toEqual({ kind })
+    }
+  )
+
+  // The tier union is generated from the backend spec, so a value outside it is
+  // reachable at runtime even though the type forbids it. It must resolve to the
+  // restrictive state, not Unknown: Unknown grants topUpAccess 'allowed', which
+  // would hand paid-plan access to a tier purely for being unrecognised.
+  it.for([
+    ['CloudWithoutActiveSubscription', true],
+    ['LocalWithoutActiveSubscription', false]
+  ] as const)(
+    'resolves an unrecognised tier as %s (isCloud=%s)',
+    ([kind, isCloud]) => {
+      expect(
+        deriveBillingPolicyState({
+          isCloud,
+          canAccessSubscriptionFeatures: true,
+          isTeamPlan: false,
+          tier: 'ENTERPRISE' as IngestSubscriptionTier
         })
       ).toEqual({ kind })
     }

--- a/src/platform/cloud/subscription/composables/useBillingPolicyState.ts
+++ b/src/platform/cloud/subscription/composables/useBillingPolicyState.ts
@@ -44,7 +44,24 @@ export function deriveBillingPolicyState(input: {
     case null:
       return { kind: `${distribution}AndUnknown` }
     default:
-      return input.tier satisfies never
+      // COMPATIBILITY FALLBACK, NOT A POLICY SIGNAL.
+      //
+      // The tier union is generated from the backend spec and can gain values
+      // without a frontend change, so this must not be a compile error. It
+      // resolves to the restrictive state rather than Unknown because Unknown
+      // grants topUpAccess 'allowed' — an unrecognised tier must not be handed
+      // paid-plan access for the sole reason that this build does not know it.
+      //
+      // It is deliberately NOT business-correct: a sales-managed tier that is
+      // genuinely active collapses to the same state as no subscription at all,
+      // so any UI keyed off this can offer subscribe/upgrade to someone who is
+      // already paying. Fail-closed on access, wrong on intent.
+      //
+      // Do not build cancellation, reactivation, pricing or upgrade decisions on
+      // this branch. Those need explicit server-sent capabilities (canOpenPricing,
+      // canChangePlan, canCancel, canReactivate) so a new tier cannot silently
+      // inherit a frontend-computed policy.
+      return { kind: `${distribution}WithoutActiveSubscription` }
   }
 }
 

--- a/src/platform/cloud/subscription/constants/tierPricing.test.ts
+++ b/src/platform/cloud/subscription/constants/tierPricing.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+
+import type { IngestSubscriptionTier } from './tierPricing'
+import { toTierKey } from './tierPricing'
+
+describe('toTierKey', () => {
+  it('maps every personal-catalog tier to its key', () => {
+    expect(toTierKey('FREE')).toBe('free')
+    expect(toTierKey('STANDARD')).toBe('standard')
+    expect(toTierKey('CREATOR')).toBe('creator')
+    expect(toTierKey('PRO')).toBe('pro')
+    expect(toTierKey('FOUNDERS_EDITION')).toBe('founder')
+  })
+
+  it('returns null for workspace-level tiers', () => {
+    expect(toTierKey('TEAM')).toBeNull()
+  })
+
+  // The tier arrives as unvalidated JSON from the backend, so a value outside
+  // the union is reachable at runtime even though the type forbids it. It must
+  // return null rather than failing, which is what keeps a backend-side tier
+  // addition from breaking the frontend.
+  it('returns null for a tier the frontend does not know', () => {
+    expect(toTierKey('ENTERPRISE' as IngestSubscriptionTier)).toBeNull()
+  })
+
+  // hasOwnProperty rather than `in`: these are inherited from Object.prototype,
+  // so `in` would return a function or object where a TierKey is expected.
+  it.for(['constructor', 'toString', '__proto__', 'valueOf'])(
+    'returns null for the inherited property %s',
+    (key) => {
+      expect(toTierKey(key as IngestSubscriptionTier)).toBeNull()
+    }
+  )
+
+  // tier is unvalidated backend JSON, so a non-string is reachable. These must
+  // return null rather than coercing to a property key or throwing.
+  it.for([[['FREE']], [{}], [null], [undefined], [42]])(
+    'returns null for the non-string value %s',
+    ([value]) => {
+      expect(toTierKey(value as unknown as IngestSubscriptionTier)).toBeNull()
+    }
+  )
+})

--- a/src/platform/cloud/subscription/constants/tierPricing.test.ts
+++ b/src/platform/cloud/subscription/constants/tierPricing.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import type { IngestSubscriptionTier } from './tierPricing'
-import { toTierKey } from './tierPricing'
+import { hasActivePaidPlan, toTierKey } from './tierPricing'
 
 describe('toTierKey', () => {
   it('maps every personal-catalog tier to its key', () => {
@@ -41,4 +41,20 @@ describe('toTierKey', () => {
       expect(toTierKey(value as unknown as IngestSubscriptionTier)).toBeNull()
     }
   )
+})
+
+describe('hasActivePaidPlan', () => {
+  // Deliberately not keyed off toTierKey: workspace-level tiers map to no
+  // catalog key yet are paid plans, so a null key must not read as unpaid.
+  it('treats catalog, workspace-level, and unrecognised tiers as paid', () => {
+    expect(hasActivePaidPlan('PRO')).toBe(true)
+    expect(hasActivePaidPlan('TEAM')).toBe(true)
+    expect(hasActivePaidPlan('ENTERPRISE' as IngestSubscriptionTier)).toBe(true)
+  })
+
+  it('treats FREE and an absent tier as unpaid', () => {
+    expect(hasActivePaidPlan('FREE')).toBe(false)
+    expect(hasActivePaidPlan(null)).toBe(false)
+    expect(hasActivePaidPlan(undefined)).toBe(false)
+  })
 })

--- a/src/platform/cloud/subscription/constants/tierPricing.ts
+++ b/src/platform/cloud/subscription/constants/tierPricing.ts
@@ -56,9 +56,27 @@ const TIER_FEATURES: Record<TierKey, TierFeatures> = {
 
 export const DEFAULT_TIER_KEY: TierKey = 'standard'
 
-// TEAM is workspace-level, so it maps to no key in this personal plan catalog.
+// Membership is tested rather than listing the exclusions, so a tier added to
+// the ingest enum narrows to false and returns null instead of failing the
+// build. Two details are load-bearing:
+//   - `typeof`, because tier is unvalidated backend JSON and need not be a
+//     string; hasOwnProperty coerces its argument to a property key, so
+//     ['FREE'] would be accepted as FREE and a null toString would throw.
+//   - own-property rather than `in`, which walks the prototype chain and would
+//     return an inherited function for 'constructor' or 'toString'.
+function isRegistrySubscriptionTier(
+  tier: unknown
+): tier is RegistrySubscriptionTier {
+  return (
+    typeof tier === 'string' &&
+    Object.prototype.hasOwnProperty.call(TIER_TO_KEY, tier)
+  )
+}
+
+// Workspace-level tiers (TEAM, and any added later) map to no key in this
+// personal plan catalog.
 export function toTierKey(tier: IngestSubscriptionTier): TierKey | null {
-  return tier === 'TEAM' ? null : TIER_TO_KEY[tier]
+  return isRegistrySubscriptionTier(tier) ? TIER_TO_KEY[tier] : null
 }
 
 // Includes the workspace-level TEAM, which toTierKey maps to null: a catalog


### PR DESCRIPTION
## Why this is needed

cloud#6874 added `ENTERPRISE` to the ingest `SubscriptionTier` enum, and the regenerated types have already arrived on the frontend as #15813. That PR is red right now, and stays red until this lands. Until it merges, **every** backend change to the ingest OpenAPI spec is blocked from reaching the frontend, because the projection workflow reuses the single fixed-branch PR.

This PR resurrects the closed #15396 (unchanged in intent, rebased onto current main — one test-location conflict resolved) rather than re-deriving the fix. Credit to @wei-hai for the original.

## Root cause

Two consumers of the generated tier union assume the union is closed:

- `tierPricing.ts:61` — `toTierKey` indexes `TIER_TO_KEY[tier]`, a `Record` of the five personal-catalog tiers. A sixth member fails with TS7053.
- `useBillingPolicyState.ts:47` — `deriveBillingPolicyState`'s switch ends in `input.tier satisfies never`. A new member fails with TS1360/TS2322.

Exact errors, reproduced on #15813's `lint-and-format` run: `Found 3 errors in 2 files.`

The union is generated from the backend spec, so it can gain members without any frontend change. Consumers must tolerate that, not fail the build.

## How it changes

- `toTierKey` narrows with an `Object.hasOwn` type guard and returns `null` for any tier outside the personal catalog (TEAM, ENTERPRISE, future tiers, and non-string junk from unvalidated JSON).
- The policy switch's `satisfies never` becomes a fail-closed fallback to the restrictive no-subscription state, explicitly commented as **compatibility-only, not a policy signal** — an unrecognised tier must not inherit `topUpAccess: 'allowed'` just because this build doesn't know it.
- No explicit `case 'ENTERPRISE'` on purpose: the literal isn't in the union until #15813 merges, so referencing it here would not compile. The proper Enterprise rendering (label, hidden self-serve surfaces) follows in its own PR on top of the regenerated types.

## Verification

- `vitest`: 31 tests pass across both touched suites, including the new unrecognised-tier, inherited-property (`__proto__`/`constructor`), and non-string-input guards.
- `pnpm typecheck` passes against **current** types (no ENTERPRISE) — safe to merge now.
- `pnpm typecheck` also passes with #15813's regenerated `packages/ingest-types` overlaid — proves #15813 goes green once this lands.

## AS-IS / TO-BE

Type-level guard only — no rendered UI change in the app today (the fallback state is only reachable once a tier outside the current union arrives at runtime). Regression coverage is the test suite above rather than screenshots.

Known, deliberate limitation (inherited from #15396, called out in the code comment): until the Enterprise rendering PR lands, an active ENTERPRISE workspace resolves to the restrictive no-subscription state — fail-closed on access, wrong on intent. That window is why the Enterprise feature PR follows immediately after #15813.
