### PR TITLE
docs: explain workflow asset portability

### DIFF
--- a/tools/test-recorder/src/commands/addWorkflow.test.ts
+++ b/tools/test-recorder/src/commands/addWorkflow.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { WORKFLOW_ASSET_EXPLANATION } from '../workflows/add'
+import { runAddWorkflow } from './addWorkflow'
+
+const { addWorkflow, findProjectRoot } = vi.hoisted(() => ({
+  addWorkflow: vi.fn(() => ({
+    destRelPath: 'browser_tests/assets/example.json'
+  })),
+  findProjectRoot: vi.fn(() => '/project')
+}))
+
+vi.mock('../recorder/runner', () => ({ findProjectRoot }))
+vi.mock('../workflows/add', () => ({
+  addWorkflow,
+  WORKFLOW_ASSET_EXPLANATION:
+    'This workflow is copied into shared test assets so automated runs on other machines can use it. Personal files that are not added this way will not work there.'
+}))
+
+describe('runAddWorkflow', () => {
+  it('explains why the workflow is copied into shared test assets', () => {
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined)
+
+    runAddWorkflow('/tmp/example.json')
+
+    expect(log).toHaveBeenNthCalledWith(1, 'browser_tests/assets/example.json')
+    expect(log).toHaveBeenNthCalledWith(2, WORKFLOW_ASSET_EXPLANATION)
+  })
+})

--- a/tools/test-recorder/src/commands/addWorkflow.test.ts
+++ b/tools/test-recorder/src/commands/addWorkflow.test.ts
@@ -30,14 +30,12 @@ describe('runAddWorkflow', () => {
     writeFileSync(sourcePath, '{"nodes":[]}')
     findProjectRoot.mockReturnValue(projectRoot)
     const log = vi.spyOn(console, 'log').mockImplementation(() => undefined)
+    const error = vi.spyOn(console, 'error').mockImplementation(() => undefined)
 
     runAddWorkflow(sourcePath)
 
-    expect(log).toHaveBeenNthCalledWith(1, 'example')
-    expect(log).toHaveBeenNthCalledWith(
-      2,
-      'This workflow is copied into shared test assets so automated runs on other machines can use it. Personal files that are not added this way will not work there.'
-    )
-    expect(log).toHaveBeenNthCalledWith(2, WORKFLOW_ASSET_EXPLANATION)
+    expect(log).toHaveBeenCalledOnce()
+    expect(log).toHaveBeenCalledWith('example')
+    expect(error).toHaveBeenCalledWith(WORKFLOW_ASSET_EXPLANATION)
   })
 })

--- a/tools/test-recorder/src/commands/addWorkflow.test.ts
+++ b/tools/test-recorder/src/commands/addWorkflow.test.ts
@@ -1,29 +1,43 @@
-import { describe, expect, it, vi } from 'vitest'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { WORKFLOW_ASSET_EXPLANATION } from '../workflows/add'
 import { runAddWorkflow } from './addWorkflow'
 
-const { addWorkflow, findProjectRoot } = vi.hoisted(() => ({
-  addWorkflow: vi.fn(() => ({
-    destRelPath: 'browser_tests/assets/example.json'
-  })),
-  findProjectRoot: vi.fn(() => '/project')
+const { findProjectRoot } = vi.hoisted(() => ({
+  findProjectRoot: vi.fn()
 }))
 
 vi.mock('../recorder/runner', () => ({ findProjectRoot }))
-vi.mock('../workflows/add', () => ({
-  addWorkflow,
-  WORKFLOW_ASSET_EXPLANATION:
-    'This workflow is copied into shared test assets so automated runs on other machines can use it. Personal files that are not added this way will not work there.'
-}))
+
+const tempDirs: string[] = []
+
+afterEach(() => {
+  for (const dir of tempDirs) rmSync(dir, { recursive: true, force: true })
+  tempDirs.length = 0
+})
 
 describe('runAddWorkflow', () => {
   it('explains why the workflow is copied into shared test assets', () => {
+    const projectRoot = mkdtempSync(join(tmpdir(), 'comfy-workflow-command-'))
+    tempDirs.push(projectRoot)
+    mkdirSync(join(projectRoot, 'browser_tests', 'assets'), {
+      recursive: true
+    })
+    const sourcePath = join(projectRoot, 'example.json')
+    writeFileSync(sourcePath, '{"nodes":[]}')
+    findProjectRoot.mockReturnValue(projectRoot)
     const log = vi.spyOn(console, 'log').mockImplementation(() => undefined)
 
-    runAddWorkflow('/tmp/example.json')
+    runAddWorkflow(sourcePath)
 
-    expect(log).toHaveBeenNthCalledWith(1, 'browser_tests/assets/example.json')
+    expect(log).toHaveBeenNthCalledWith(1, 'example')
+    expect(log).toHaveBeenNthCalledWith(
+      2,
+      'This workflow is copied into shared test assets so automated runs on other machines can use it. Personal files that are not added this way will not work there.'
+    )
     expect(log).toHaveBeenNthCalledWith(2, WORKFLOW_ASSET_EXPLANATION)
   })
 })

--- a/tools/test-recorder/src/commands/addWorkflow.ts
+++ b/tools/test-recorder/src/commands/addWorkflow.ts
@@ -1,7 +1,8 @@
 import { findProjectRoot } from '../recorder/runner'
-import { addWorkflow } from '../workflows/add'
+import { addWorkflow, WORKFLOW_ASSET_EXPLANATION } from '../workflows/add'
 
 export function runAddWorkflow(filePath: string, name?: string): void {
   const { destRelPath } = addWorkflow(filePath, findProjectRoot(), name)
   console.log(destRelPath)
+  console.log(WORKFLOW_ASSET_EXPLANATION)
 }

--- a/tools/test-recorder/src/commands/addWorkflow.ts
+++ b/tools/test-recorder/src/commands/addWorkflow.ts
@@ -4,5 +4,5 @@ import { addWorkflow, WORKFLOW_ASSET_EXPLANATION } from '../workflows/add'
 export function runAddWorkflow(filePath: string, name?: string): void {
   const { destRelPath } = addWorkflow(filePath, findProjectRoot(), name)
   console.log(destRelPath)
-  console.log(WORKFLOW_ASSET_EXPLANATION)
+  console.error(WORKFLOW_ASSET_EXPLANATION)
 }

--- a/tools/test-recorder/src/commands/record.test.ts
+++ b/tools/test-recorder/src/commands/record.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { resolveDistribution } from '../devserver/distributions'
 import { USE_CASES } from '../useCases'
+import { WORKFLOW_ASSET_EXPLANATION } from '../workflows/add'
 import { runRecord } from './record'
 
 const { autocomplete, info, path, runChecks, runCommand } = vi.hoisted(() => ({
@@ -46,8 +47,13 @@ vi.mock('../ui/logger', () => ({
 }))
 vi.mock('../ui/steps', () => ({ stepHeader: vi.fn() }))
 
+const originalIsTTY = process.stdin.isTTY
+
 afterEach(() => {
-  Reflect.deleteProperty(process.stdin, 'isTTY')
+  Object.defineProperty(process.stdin, 'isTTY', {
+    configurable: true,
+    value: originalIsTTY
+  })
 })
 
 describe('runRecord', () => {
@@ -55,6 +61,13 @@ describe('runRecord', () => {
     Object.defineProperty(process.stdin, 'isTTY', {
       configurable: true,
       value: true
+    })
+    const exit = vi
+      .spyOn(process, 'exit')
+      .mockImplementation(() => undefined as never)
+    path.mockImplementationOnce(async () => {
+      expect(info).toHaveBeenCalledWith([WORKFLOW_ASSET_EXPLANATION])
+      throw new Error('stop after file picker')
     })
 
     await expect(
@@ -68,11 +81,7 @@ describe('runRecord', () => {
       })
     ).rejects.toThrow('stop after file picker')
 
-    expect(info).toHaveBeenCalledWith([
-      'This workflow is copied into shared test assets so automated runs on other machines can use it. Personal files that are not added this way will not work there.'
-    ])
-    expect(info.mock.invocationCallOrder.at(-1)).toBeLessThan(
-      path.mock.invocationCallOrder[0]
-    )
+    expect(info).toHaveBeenCalledWith([WORKFLOW_ASSET_EXPLANATION])
+    expect(exit).not.toHaveBeenCalled()
   })
 })

--- a/tools/test-recorder/src/commands/record.test.ts
+++ b/tools/test-recorder/src/commands/record.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { resolveDistribution } from '../devserver/distributions'
+import { USE_CASES } from '../useCases'
+import { runRecord } from './record'
+
+const { autocomplete, info, path, runChecks, runCommand } = vi.hoisted(() => ({
+  autocomplete: vi.fn(async () => '__add-workflow__'),
+  info: vi.fn(),
+  path: vi.fn(async () => {
+    throw new Error('stop after file picker')
+  }),
+  runChecks: vi.fn(async () => ({ allPassed: true })),
+  runCommand: vi.fn(() => ({ status: 0, stdout: Buffer.from('main') }))
+}))
+
+vi.mock('@clack/prompts', () => ({
+  autocomplete,
+  cancel: vi.fn(),
+  confirm: vi.fn(),
+  isCancel: vi.fn(() => false),
+  multiselect: vi.fn(),
+  path,
+  select: vi.fn(),
+  spinner: vi.fn(() => ({ start: vi.fn(), stop: vi.fn() })),
+  text: vi.fn()
+}))
+vi.mock('./check', () => ({ runChecks }))
+vi.mock('../cli/run', () => ({ runCommand }))
+vi.mock('../devserver/envInfo', () => ({
+  fetchEnvInfo: vi.fn(async () => ({ ok: false }))
+}))
+vi.mock('../recorder/runner', () => ({
+  findProjectRoot: vi.fn(() => '/project'),
+  listWorkflows: vi.fn(() => ['default']),
+  runRecording: vi.fn()
+}))
+vi.mock('../ui/logger', () => ({
+  alert: vi.fn(),
+  blank: vi.fn(),
+  box: vi.fn(),
+  fail: vi.fn(),
+  info,
+  pass: vi.fn(),
+  warn: vi.fn()
+}))
+vi.mock('../ui/steps', () => ({ stepHeader: vi.fn() }))
+
+afterEach(() => {
+  Reflect.deleteProperty(process.stdin, 'isTTY')
+})
+
+describe('runRecord', () => {
+  it('explains workflow portability before opening the file picker', async () => {
+    Object.defineProperty(process.stdin, 'isTTY', {
+      configurable: true,
+      value: true
+    })
+
+    await expect(
+      runRecord({
+        distribution: resolveDistribution('local'),
+        useCase: USE_CASES[0],
+        description: 'workflow portability',
+        name: 'workflow-portability',
+        tags: [],
+        warnings: []
+      })
+    ).rejects.toThrow('stop after file picker')
+
+    expect(info).toHaveBeenCalledWith([
+      'This workflow is copied into shared test assets so automated runs on other machines can use it. Personal files that are not added this way will not work there.'
+    ])
+    expect(info.mock.invocationCallOrder.at(-1)).toBeLessThan(
+      path.mock.invocationCallOrder[0]
+    )
+  })
+})

--- a/tools/test-recorder/src/commands/record.ts
+++ b/tools/test-recorder/src/commands/record.ts
@@ -31,7 +31,7 @@ import { pass, fail, warn, alert, info, blank, box } from '../ui/logger'
 import { toSlug } from '../cli/slug'
 import { TAG_REGISTRY } from '../tags'
 import { USE_CASES, useCaseById } from '../useCases'
-import { addWorkflow } from '../workflows/add'
+import { addWorkflow, WORKFLOW_ASSET_EXPLANATION } from '../workflows/add'
 import {
   customDistribution,
   DISTRIBUTIONS,
@@ -538,6 +538,7 @@ export async function runRecord(
 
   let seedWorkflow = selectedWorkflow
   if (selectedWorkflow === ADD_WORKFLOW_SENTINEL) {
+    info([WORKFLOW_ASSET_EXPLANATION])
     const workflowPath = await path({
       message: 'Select a ComfyUI workflow JSON file:',
       root: process.cwd(),

--- a/tools/test-recorder/src/workflows/add.ts
+++ b/tools/test-recorder/src/workflows/add.ts
@@ -2,6 +2,9 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { basename, join } from 'node:path'
 import { toSlug } from '../cli/slug'
 
+export const WORKFLOW_ASSET_EXPLANATION =
+  'This workflow is copied into shared test assets so automated runs on other machines can use it. Personal files that are not added this way will not work there.'
+
 export type WorkflowValidationResult =
   | { ok: true }
   | { ok: false; reason: string }


### PR DESCRIPTION
## Summary

Explain why local workflow files are copied into shared test assets in both recorder entry points.

## Changes

- Show the portability explanation before the interactive workflow file picker.
- Print the same explanation after `comfy-test add-workflow` succeeds.
- Add regression coverage for the non-interactive command output.

## Testing

- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`
- `pnpm knip`
- `pnpm test:unit tools/test-recorder` (250 tests)
- Full `pnpm test:unit`: 17,431 passed; one unrelated `load3dLazy.test.ts` timeout reproduced in isolation in the fresh worktree.

E2E verification:

1. Run `pnpm comfy-test record`, choose `(add from file…)`, and confirm the shared-test-assets explanation appears before the JSON file picker.
2. Run `pnpm comfy-test add-workflow /path/to/workflow.json --name portability-check` and confirm the copied workflow name is followed by the same explanation.
3. Expected result: both paths state that automated runs on other machines need the shared asset and that personal files not added this way will not work there.

## Review focus

Please check the wording for non-technical contributors and the placement immediately before interactive selection.

Fixes #15852
