### PR TITLE
feat(website): build the Wan 3.0 launch page on the model-launch template

### DIFF
--- a/apps/website/e2e/wan-3.0.spec.ts
+++ b/apps/website/e2e/wan-3.0.spec.ts
@@ -24,6 +24,14 @@ const WAN3_TEMPLATE = 'https://cloud.comfy.org/?template=api_wan3_0_t2v'
 const REQUIRED_BADGES = 3
 const REQUIRED_STEPS = 3
 const REQUIRED_FAQS = 6
+// The three modalities the launch ships with, in render order. Listing them
+// exactly means a duplicate, dropped or off-brief badge (e.g. an open-weights
+// claim) fails rather than slipping past a bare count.
+const REQUIRED_BADGE_LABELS = [
+  t('wan3.hero.tagImageToVideo'),
+  t('wan3.hero.tagTextToVideo'),
+  t('wan3.hero.tagReferenceToVideo')
+]
 
 const FAQ_SECTION = wan3Page.faq
 if (!FAQ_SECTION) throw new Error('wan3Page must configure a FAQ section')
@@ -52,9 +60,7 @@ test.describe('Wan 3.0 launch page @smoke', () => {
     })
     const badges = hero.getByTestId('model-launch-hero-badge')
     await expect(badges).toHaveCount(REQUIRED_BADGES)
-    for (const text of await badges.allInnerTexts()) {
-      expect(text).not.toMatch(/open (source|weight)/i)
-    }
+    await expect(badges).toHaveText(REQUIRED_BADGE_LABELS)
   })
 
   test('hero CTAs open the cloud and the workflow hub in new tabs', async ({

--- a/apps/website/e2e/wan-3.0.spec.ts
+++ b/apps/website/e2e/wan-3.0.spec.ts
@@ -4,49 +4,75 @@ import { externalLinks, getRoutes } from '../src/config/routes'
 import { wan3Page } from '../src/data/wan3'
 import { t } from '../src/i18n/translations'
 import { test } from './fixtures/blockExternalMedia'
+import { waitForIsland } from './fixtures/islands'
 
 const PATH = '/wan-3.0'
 const ZH_PATH = '/zh-CN/wan-3.0'
 const HERO_TITLE = t('wan3.hero.title')
-const HERO_EYEBROW = t('wan3.hero.eyebrow')
 const HERO_CTA = t('wan3.hero.primaryCta')
+const HERO_SECONDARY_CTA = t('wan3.hero.secondaryCta')
+const FAQ_HEADING = t('wan3.faq.heading')
+const STEPS_HEADING = t('wan3.steps.heading')
 const RUN_OPTIONS_HEADING = t('wan3.runOptions.heading')
 const REVIEWS_HEADING = t('wan3.reviews.heading')
 const MODELS_ROUTE = getRoutes('en').models
+const WAN3_TEMPLATE = 'https://cloud.comfy.org/?template=api_wan3_0_t2v'
 
-test.describe('Wan 3.0 announcement page @smoke', () => {
+// Counts are the launch requirement rather than a snapshot of the config:
+// deriving them from `wan3Page` would let a dropped badge, step or Q&A entry
+// pass, because both sides of the assertion would move together.
+const REQUIRED_BADGES = 3
+const REQUIRED_STEPS = 3
+const REQUIRED_FAQS = 6
+
+const FAQ_SECTION = wan3Page.faq
+if (!FAQ_SECTION) throw new Error('wan3Page must configure a FAQ section')
+const FIRST_FAQ = FAQ_SECTION.items[0]
+
+test.describe('Wan 3.0 launch page @smoke', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto(PATH)
   })
 
-  test('renders the hero over its backdrop and is indexable', async ({
+  test('renders the hero and is indexable', async ({ page }) => {
+    await expect(
+      page.getByRole('heading', { level: 1, name: HERO_TITLE })
+    ).toBeVisible()
+    await expect(page.getByText(t('wan3.hero.description'))).toBeVisible()
+    await expect(page.locator('meta[name="robots"]')).toHaveCount(0)
+  })
+
+  // Wan 3.0 runs through partner nodes against an API, so the page must not
+  // claim open weights the way the open-source Wan pages do.
+  test('hero badges describe the model without claiming open weights', async ({
     page
   }) => {
     const hero = page.locator('section').filter({
       has: page.getByRole('heading', { level: 1, name: HERO_TITLE })
     })
-    await expect(hero.getByText(HERO_EYEBROW)).toBeVisible()
-    await expect(
-      page.getByRole('heading', { level: 1, name: HERO_TITLE })
-    ).toBeVisible()
-    await expect(hero.locator('img')).toHaveAttribute(
-      'src',
-      wan3Page.hero.placeholderImageSrc ?? ''
-    )
-    await expect(page.locator('meta[name="robots"]')).toHaveCount(0)
+    const badges = hero.getByTestId('model-launch-hero-badge')
+    await expect(badges).toHaveCount(REQUIRED_BADGES)
+    for (const text of await badges.allInnerTexts()) {
+      expect(text).not.toMatch(/open (source|weight)/i)
+    }
   })
 
-  test('hero CTA sends visitors to the cloud in a new tab', async ({
+  test('hero CTAs open the cloud and the workflow hub in new tabs', async ({
     page
   }) => {
-    const cta = page
-      .locator('section')
-      .filter({
-        has: page.getByRole('heading', { level: 1, name: HERO_TITLE })
-      })
-      .getByRole('link', { name: HERO_CTA })
-    await expect(cta).toHaveAttribute('href', externalLinks.cloud)
-    await expect(cta).toHaveAttribute('target', '_blank')
+    const hero = page.locator('section').filter({
+      has: page.getByRole('heading', { level: 1, name: HERO_TITLE })
+    })
+
+    const primary = hero.getByRole('link', { name: HERO_CTA })
+    await expect(primary).toHaveAttribute('href', WAN3_TEMPLATE)
+    await expect(primary).toHaveAttribute('target', '_blank')
+
+    const secondary = hero.getByRole('link', { name: HERO_SECONDARY_CTA })
+    await expect(secondary).toHaveAttribute(
+      'href',
+      `${externalLinks.workflows}/model/wan`
+    )
   })
 
   test('breadcrumb trail links to the models catalog', async ({ page }) => {
@@ -63,54 +89,101 @@ test.describe('Wan 3.0 announcement page @smoke', () => {
     await expect(footerLink).toHaveAttribute('href', getRoutes('en').wan3)
   })
 
-  test('renders run options and reviews', async ({ page }) => {
-    const runOptions = page.getByRole('heading', {
-      level: 2,
-      name: RUN_OPTIONS_HEADING
-    })
-    await runOptions.scrollIntoViewIfNeeded()
-    await expect(runOptions).toBeVisible()
-
-    const reviews = page.getByRole('heading', {
-      level: 2,
-      name: REVIEWS_HEADING
-    })
-    await reviews.scrollIntoViewIfNeeded()
-    await expect(reviews).toBeVisible()
+  test('renders one card per configured step', async ({ page }) => {
+    const heading = page.getByRole('heading', { level: 2, name: STEPS_HEADING })
+    await heading.scrollIntoViewIfNeeded()
+    const steps = page
+      .locator('section')
+      .filter({ has: heading })
+      .locator('ol > li')
+    await expect(steps).toHaveCount(REQUIRED_STEPS)
   })
 
-  // The announcement omits gallery, pricing, FAQ and closing CTA, so these two
-  // are the only sections it should show. Asserting the whole set means
-  // reintroducing any of them has to be deliberate.
-  test('shows only the sections the announcement configures', async ({
+  test('emits FAQPage structured data with one entry per Q&A', async ({
     page
   }) => {
-    await expect(page.getByRole('heading', { level: 2 })).toHaveText([
+    const faqJsonLd = await page.evaluate(() => {
+      const scripts = Array.from(
+        document.querySelectorAll<HTMLScriptElement>(
+          'script[type="application/ld+json"]'
+        )
+      )
+      return (
+        scripts.find((s) => (s.textContent ?? '').includes('FAQPage'))
+          ?.textContent ?? null
+      )
+    })
+    expect(faqJsonLd, 'FAQ JSON-LD script').not.toBeNull()
+    const graph = JSON.parse(faqJsonLd!)['@graph'] as {
+      '@type': string
+      mainEntity?: unknown[]
+    }[]
+    const faqPage = graph.find((node) => node['@type'] === 'FAQPage')
+    expect(faqPage, 'FAQPage node in @graph').toBeDefined()
+    expect(faqPage!.mainEntity!.length).toBe(REQUIRED_FAQS)
+  })
+
+  test('Q&A items toggle open and closed on click', async ({ page }) => {
+    const firstQuestion = page.getByRole('button', {
+      name: FIRST_FAQ.question.en
+    })
+    await waitForIsland(page, firstQuestion)
+    await expect(firstQuestion).toHaveAttribute('aria-expanded', 'false')
+
+    await firstQuestion.click()
+    await expect(firstQuestion).toHaveAttribute('aria-expanded', 'true')
+    await expect(page.getByText(FIRST_FAQ.answer.en)).toBeVisible()
+
+    await firstQuestion.click()
+    await expect(firstQuestion).toHaveAttribute('aria-expanded', 'false')
+  })
+
+  // Wan 3.0 maxes out at 1080p, so a 4K claim anywhere on the page would be
+  // false. The Figma frame this page was built from still carried Seedance's
+  // "up to 4K" copy, which is exactly how such a claim reaches production.
+  test('no rendered copy advertises 4K', async ({ page }) => {
+    const body = await page.locator('body').innerText()
+    // Not preceded by a digit or dot, so the credit slider's "84.4K" ticks
+    // (84,400 credits) cannot satisfy or trip this.
+    expect(body).not.toMatch(/(?<![\d.])4k\b/i)
+  })
+
+  test('renders the Q&A, steps, run options and reviews headings', async ({
+    page
+  }) => {
+    for (const name of [
+      FAQ_HEADING,
+      STEPS_HEADING,
       RUN_OPTIONS_HEADING,
       REVIEWS_HEADING
-    ])
-    await expect(page.locator('video')).toHaveCount(0)
+    ]) {
+      const heading = page.getByRole('heading', { level: 2, name })
+      await heading.scrollIntoViewIfNeeded()
+      await expect(heading).toBeVisible()
+    }
   })
 })
 
-test.describe('Wan 3.0 announcement page — zh-CN', () => {
+test.describe('Wan 3.0 launch page — zh-CN', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto(ZH_PATH)
   })
 
-  test('renders the localized hero and run options', async ({ page }) => {
+  test('renders the localized hero and steps', async ({ page }) => {
     const hero = page.locator('section').filter({
-      has: page.getByRole('heading', { level: 1, name: HERO_TITLE })
-    })
-    await expect(hero.getByText(t('wan3.hero.eyebrow', 'zh-CN'))).toBeVisible()
-    await expect(hero.getByRole('link')).toContainText(/[一-鿿]/)
-
-    await expect(
-      page.getByRole('heading', {
-        level: 2,
-        name: t('wan3.runOptions.heading', 'zh-CN')
+      has: page.getByRole('heading', {
+        level: 1,
+        name: t('wan3.hero.title', 'zh-CN')
       })
-    ).toBeVisible()
+    })
+    await expect(hero.getByRole('link').first()).toContainText(/[一-鿿]/)
+
+    const steps = page.getByRole('heading', {
+      level: 2,
+      name: t('wan3.steps.heading', 'zh-CN')
+    })
+    await steps.scrollIntoViewIfNeeded()
+    await expect(steps).toBeVisible()
   })
 
   test('breadcrumb and footer keep visitors inside the locale', async ({
@@ -128,7 +201,7 @@ test.describe('Wan 3.0 announcement page — zh-CN', () => {
   })
 })
 
-test.describe('Wan 3.0 announcement page — mobile @mobile', () => {
+test.describe('Wan 3.0 launch page — mobile @mobile', () => {
   test('hero CTA stays visible and linked at narrow viewports', async ({
     page
   }) => {
@@ -142,7 +215,7 @@ test.describe('Wan 3.0 announcement page — mobile @mobile', () => {
       .getByRole('link', { name: HERO_CTA })
 
     await expect(cta).toBeVisible()
-    await expect(cta).toHaveAttribute('href', externalLinks.cloud)
+    await expect(cta).toHaveAttribute('href', WAN3_TEMPLATE)
 
     const box = await cta.boundingBox()
     const viewport = page.viewportSize()

--- a/apps/website/e2e/wan-3.0.spec.ts
+++ b/apps/website/e2e/wan-3.0.spec.ts
@@ -12,17 +12,15 @@ const HERO_TITLE = t('wan3.hero.title')
 const HERO_CTA = t('wan3.hero.primaryCta')
 const HERO_SECONDARY_CTA = t('wan3.hero.secondaryCta')
 const FAQ_HEADING = t('wan3.faq.heading')
-const STEPS_HEADING = t('wan3.steps.heading')
 const RUN_OPTIONS_HEADING = t('wan3.runOptions.heading')
 const REVIEWS_HEADING = t('wan3.reviews.heading')
 const MODELS_ROUTE = getRoutes('en').models
 const WAN3_TEMPLATE = 'https://cloud.comfy.org/?template=api_wan3_0_t2v'
 
 // Counts are the launch requirement rather than a snapshot of the config:
-// deriving them from `wan3Page` would let a dropped badge, step or Q&A entry
-// pass, because both sides of the assertion would move together.
+// deriving them from `wan3Page` would let a dropped badge or Q&A entry pass,
+// because both sides of the assertion would move together.
 const REQUIRED_BADGES = 3
-const REQUIRED_STEPS = 3
 const REQUIRED_FAQS = 6
 // The three modalities the launch ships with, in render order. Listing them
 // exactly means a duplicate, dropped or off-brief badge (e.g. an open-weights
@@ -95,16 +93,6 @@ test.describe('Wan 3.0 launch page @smoke', () => {
     await expect(footerLink).toHaveAttribute('href', getRoutes('en').wan3)
   })
 
-  test('renders one card per configured step', async ({ page }) => {
-    const heading = page.getByRole('heading', { level: 2, name: STEPS_HEADING })
-    await heading.scrollIntoViewIfNeeded()
-    const steps = page
-      .locator('section')
-      .filter({ has: heading })
-      .locator('ol > li')
-    await expect(steps).toHaveCount(REQUIRED_STEPS)
-  })
-
   test('emits FAQPage structured data with one entry per Q&A', async ({
     page
   }) => {
@@ -154,15 +142,10 @@ test.describe('Wan 3.0 launch page @smoke', () => {
     expect(body).not.toMatch(/(?<![\d.])4k\b/i)
   })
 
-  test('renders the Q&A, steps, run options and reviews headings', async ({
+  test('renders the Q&A, run options and reviews headings', async ({
     page
   }) => {
-    for (const name of [
-      FAQ_HEADING,
-      STEPS_HEADING,
-      RUN_OPTIONS_HEADING,
-      REVIEWS_HEADING
-    ]) {
+    for (const name of [FAQ_HEADING, RUN_OPTIONS_HEADING, REVIEWS_HEADING]) {
       const heading = page.getByRole('heading', { level: 2, name })
       await heading.scrollIntoViewIfNeeded()
       await expect(heading).toBeVisible()
@@ -175,7 +158,7 @@ test.describe('Wan 3.0 launch page — zh-CN', () => {
     await page.goto(ZH_PATH)
   })
 
-  test('renders the localized hero and steps', async ({ page }) => {
+  test('renders the localized hero and Q&A', async ({ page }) => {
     const hero = page.locator('section').filter({
       has: page.getByRole('heading', {
         level: 1,
@@ -184,12 +167,12 @@ test.describe('Wan 3.0 launch page — zh-CN', () => {
     })
     await expect(hero.getByRole('link').first()).toContainText(/[一-鿿]/)
 
-    const steps = page.getByRole('heading', {
+    const faq = page.getByRole('heading', {
       level: 2,
-      name: t('wan3.steps.heading', 'zh-CN')
+      name: t('wan3.faq.heading', 'zh-CN')
     })
-    await steps.scrollIntoViewIfNeeded()
-    await expect(steps).toBeVisible()
+    await faq.scrollIntoViewIfNeeded()
+    await expect(faq).toBeVisible()
   })
 
   test('breadcrumb and footer keep visitors inside the locale', async ({

--- a/apps/website/src/data/wan3.test.ts
+++ b/apps/website/src/data/wan3.test.ts
@@ -1,14 +1,15 @@
 // @vitest-environment happy-dom
-import { render, screen } from '@testing-library/vue'
+import { cleanup, render } from '@testing-library/vue'
 import { afterEach, describe, expect, it } from 'vitest'
 
 import ModelLaunchHeroSection from '../templates/model-launch/ModelLaunchHeroSection.vue'
 import { wan3Page } from './wan3'
 
-// The Wan 3.0 hero clip is ~25 MB against a ~370 KB still. ModelLaunchHeroSection
-// mounts <video> only at >=768px *and* only when a fallback still is configured;
-// drop the fallback and the gate opens for every viewport, so phones fetch the
-// clip. These tests pin both halves of that gate.
+// The Wan 3.0 hero clip is ~10 MB against a ~4 MB mobile encode and a ~370 KB
+// still. ModelLaunchHeroSection mounts the full clip only at >=768px; below
+// that it plays mobileVideoSrc, and the still covers SSR before the player
+// mounts. These tests pin which src reaches the <video> on each side of the
+// breakpoint, so phones never fetch the full clip.
 const DESKTOP_WIDTH = 1280
 const MOBILE_WIDTH = 375
 
@@ -27,46 +28,52 @@ function flushMount() {
   return new Promise((resolve) => setTimeout(resolve, 0))
 }
 
-// <video> carries no implicit ARIA role, so the player is detected through its
-// scrubber — VideoPlayer renders the control bar whenever it renders the video.
-function queryVideoPlayer() {
-  return screen.queryByRole('slider', { name: 'Seek' })
-}
-
 function renderHero() {
   render(ModelLaunchHeroSection, { props: { hero: wan3Page.hero } })
   return flushMount()
 }
 
+function renderedVideoSrc() {
+  // <video> carries no implicit ARIA role, so Testing Library queries cannot
+  // reach it and the src assertion has to touch the node directly.
+  // eslint-disable-next-line testing-library/no-node-access
+  const videos = document.querySelectorAll('video')
+  expect(videos.length).toBe(1)
+  return videos[0].getAttribute('src')
+}
+
 afterEach(() => {
+  cleanup()
   setViewportWidth(DESKTOP_WIDTH)
 })
 
 describe('wan 3.0 hero media', () => {
-  it('configures a still image for phones to render instead of the clip', () => {
+  it('configures a mobile encode distinct from the full clip', () => {
+    expect(wan3Page.hero.mobileVideoSrc).toMatch(
+      /^https:\/\/media\.comfy\.org\/.+\.mp4$/
+    )
+    expect(wan3Page.hero.mobileVideoSrc).not.toBe(wan3Page.hero.videoSrc)
+  })
+
+  it('keeps the still configured so SSR renders it before the player mounts', () => {
     expect(wan3Page.hero.mobileFallbackImageSrc).toMatch(
       /^https:\/\/media\.comfy\.org\/.+\.(webp|png|jpe?g)$/
     )
   })
 
-  it('renders the still and no video player on a phone-sized viewport', async () => {
+  it('plays the mobile encode, not the full clip, on a phone-sized viewport', async () => {
     setViewportWidth(MOBILE_WIDTH)
 
     await renderHero()
 
-    // Asserted on the src, not just on the absence of a player, so a missing
-    // fallback fails here rather than passing on a hero with no media at all.
-    const still = screen.getByRole('img', { hidden: true })
-    expect(still.getAttribute('src')).toBe(wan3Page.hero.mobileFallbackImageSrc)
-    expect(queryVideoPlayer()).toBeNull()
+    expect(renderedVideoSrc()).toBe(wan3Page.hero.mobileVideoSrc)
   })
 
-  it('still renders the video player on a desktop viewport', async () => {
+  it('plays the full clip on a desktop viewport', async () => {
     setViewportWidth(DESKTOP_WIDTH)
 
     await renderHero()
 
-    expect(queryVideoPlayer()).not.toBeNull()
-    expect(screen.queryByRole('img', { hidden: true })).toBeNull()
+    expect(renderedVideoSrc()).toBe(wan3Page.hero.videoSrc)
   })
 })

--- a/apps/website/src/data/wan3.test.ts
+++ b/apps/website/src/data/wan3.test.ts
@@ -1,0 +1,72 @@
+// @vitest-environment happy-dom
+import { render, screen } from '@testing-library/vue'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import ModelLaunchHeroSection from '../templates/model-launch/ModelLaunchHeroSection.vue'
+import { wan3Page } from './wan3'
+
+// The Wan 3.0 hero clip is ~25 MB against a ~370 KB still. ModelLaunchHeroSection
+// mounts <video> only at >=768px *and* only when a fallback still is configured;
+// drop the fallback and the gate opens for every viewport, so phones fetch the
+// clip. These tests pin both halves of that gate.
+const DESKTOP_WIDTH = 1280
+const MOBILE_WIDTH = 375
+
+// happy-dom hangs setViewport off window.happyDOM, which the DOM lib types
+// this project compiles against know nothing about.
+const happyWindow = window as typeof window & {
+  happyDOM: { setViewport: (viewport: { width: number }) => void }
+}
+
+function setViewportWidth(width: number) {
+  happyWindow.happyDOM.setViewport({ width })
+}
+
+// The video swaps in only after onMounted flips useMounted, a tick past render.
+function flushMount() {
+  return new Promise((resolve) => setTimeout(resolve, 0))
+}
+
+// <video> carries no implicit ARIA role, so the player is detected through its
+// scrubber — VideoPlayer renders the control bar whenever it renders the video.
+function queryVideoPlayer() {
+  return screen.queryByRole('slider', { name: 'Seek' })
+}
+
+function renderHero() {
+  render(ModelLaunchHeroSection, { props: { hero: wan3Page.hero } })
+  return flushMount()
+}
+
+afterEach(() => {
+  setViewportWidth(DESKTOP_WIDTH)
+})
+
+describe('wan 3.0 hero media', () => {
+  it('configures a still image for phones to render instead of the clip', () => {
+    expect(wan3Page.hero.mobileFallbackImageSrc).toMatch(
+      /^https:\/\/media\.comfy\.org\/.+\.(webp|png|jpe?g)$/
+    )
+  })
+
+  it('renders the still and no video player on a phone-sized viewport', async () => {
+    setViewportWidth(MOBILE_WIDTH)
+
+    await renderHero()
+
+    // Asserted on the src, not just on the absence of a player, so a missing
+    // fallback fails here rather than passing on a hero with no media at all.
+    const still = screen.getByRole('img', { hidden: true })
+    expect(still.getAttribute('src')).toBe(wan3Page.hero.mobileFallbackImageSrc)
+    expect(queryVideoPlayer()).toBeNull()
+  })
+
+  it('still renders the video player on a desktop viewport', async () => {
+    setViewportWidth(DESKTOP_WIDTH)
+
+    await renderHero()
+
+    expect(queryVideoPlayer()).not.toBeNull()
+    expect(screen.queryByRole('img', { hidden: true })).toBeNull()
+  })
+})

--- a/apps/website/src/data/wan3.ts
+++ b/apps/website/src/data/wan3.ts
@@ -11,9 +11,11 @@ const wan3Links = {
   hubModel: `${externalLinks.workflows}/model/wan`
 } as const
 
-// The hero clip is ~25 MB, so phones get this still instead and never fetch it
-// — ModelLaunchHeroSection only swaps the video in once mounted at >=768px, and
-// only when a fallback is set. The poster doubles as that still.
+// The hero clip is ~10 MB, so below 768px ModelLaunchHeroSection plays this
+// ~4 MB encode instead and phones never fetch the full clip. The poster still
+// doubles as the mobile fallback, covering SSR until the player mounts.
+const wan3HeroMobileVideoSrc =
+  'https://media.comfy.org/website/models/wan_3-0_mobile.mp4'
 const wan3HeroStillSrc = 'https://media.comfy.org/website/models/wan_3-0.jpeg'
 
 export const wan3Page: ModelLaunchPage = {
@@ -23,9 +25,10 @@ export const wan3Page: ModelLaunchPage = {
   breadcrumbUpdatedKey: 'wan3.breadcrumb.updated',
   hero: {
     layout: 'content-first',
-    videoSrc: 'https://media.comfy.org/website/models/wan_3.mp4',
+    videoSrc: 'https://media.comfy.org/website/models/wan_3-0_v2.mp4',
     posterSrc: wan3HeroStillSrc,
     mobileFallbackImageSrc: wan3HeroStillSrc,
+    mobileVideoSrc: wan3HeroMobileVideoSrc,
     logoSrc: '/icons/ai-models/wan.svg',
     titleKey: 'wan3.hero.title',
     descriptionKey: 'wan3.hero.description',

--- a/apps/website/src/data/wan3.ts
+++ b/apps/website/src/data/wan3.ts
@@ -11,6 +11,11 @@ const wan3Links = {
   hubModel: `${externalLinks.workflows}/model/wan`
 } as const
 
+// The hero clip is ~25 MB, so phones get this still instead and never fetch it
+// — ModelLaunchHeroSection only swaps the video in once mounted at >=768px, and
+// only when a fallback is set. The poster doubles as that still.
+const wan3HeroStillSrc = 'https://media.comfy.org/website/models/wan_3-0.jpeg'
+
 export const wan3Page: ModelLaunchPage = {
   metaTitleKey: 'wan3.meta.title',
   metaDescriptionKey: 'wan3.meta.description',
@@ -19,7 +24,8 @@ export const wan3Page: ModelLaunchPage = {
   hero: {
     layout: 'content-first',
     videoSrc: 'https://media.comfy.org/website/models/wan_3.mp4',
-    posterSrc: 'https://media.comfy.org/website/models/wan_3-0.jpeg',
+    posterSrc: wan3HeroStillSrc,
+    mobileFallbackImageSrc: wan3HeroStillSrc,
     logoSrc: '/icons/ai-models/wan.svg',
     titleKey: 'wan3.hero.title',
     descriptionKey: 'wan3.hero.description',

--- a/apps/website/src/data/wan3.ts
+++ b/apps/website/src/data/wan3.ts
@@ -133,41 +133,6 @@ export const wan3Page: ModelLaunchPage = {
       }
     ]
   },
-  steps: {
-    headingKey: 'wan3.steps.heading',
-    stepLabelKey: 'wan3.steps.step',
-    items: [
-      {
-        id: 'write-the-shot',
-        title: { en: 'Write the shot', 'zh-CN': '写下你的镜头' },
-        description: {
-          en: 'Camera, subject, framing',
-          'zh-CN': '镜头、主体、构图'
-        }
-      },
-      {
-        id: 'add-your-references',
-        title: { en: 'Add your references', 'zh-CN': '添加你的参考素材' },
-        description: {
-          en: 'An image, a video or an audio clip to steer it',
-          'zh-CN': '用图像、视频或音频片段来引导生成'
-        }
-      },
-      {
-        id: 'run-wan-3',
-        title: { en: 'Run Wan 3.0', 'zh-CN': '运行 Wan 3.0' },
-        description: {
-          en: 'Up to 30 seconds, up to 1080p',
-          'zh-CN': '最长 30 秒，最高 1080p'
-        }
-      }
-    ],
-    primaryCta: {
-      labelKey: 'wan3.steps.primaryCta',
-      href: wan3Links.cloudRunTextToVideo,
-      target: '_blank'
-    }
-  },
   runOptions: {
     headingKey: 'wan3.runOptions.heading',
     subtitleKey: 'wan3.runOptions.subtitle',

--- a/apps/website/src/data/wan3.ts
+++ b/apps/website/src/data/wan3.ts
@@ -2,27 +2,163 @@ import type { ModelLaunchPage } from '../templates/model-launch/types'
 
 import { externalLinks } from '../config/routes'
 
-// The frosted backdrop is byte identical across the Figma announcement frames,
-// so every announcement page points at this one asset instead of uploading a
-// copy per model.
-const COMING_SOON_HERO = 'https://media.comfy.org/website/coming-soon/hero.webp'
+// Wan 3.0 runs through partner nodes rather than open weights. There is no
+// Wan 3.0 docs page yet, so nothing here links to one.
+const wan3Links = {
+  cloudRunTextToVideo: 'https://cloud.comfy.org/?template=api_wan3_0_t2v',
+  cloudRunImageToVideo: 'https://cloud.comfy.org/?template=api_wan3_0_i2v',
+  cloudRunReferenceToVideo: 'https://cloud.comfy.org/?template=api_wan3_0_r2v',
+  hubModel: `${externalLinks.workflows}/model/wan`
+} as const
 
-// Wan 3.0 has not shipped yet, so this page announces it and holds the URL.
-// On launch day, replace this config with the full one the way /flux-3 did; the
-// page stubs and the template stay as they are.
 export const wan3Page: ModelLaunchPage = {
   metaTitleKey: 'wan3.meta.title',
   metaDescriptionKey: 'wan3.meta.description',
   breadcrumbLabelKey: 'wan3.breadcrumb.model',
   breadcrumbUpdatedKey: 'wan3.breadcrumb.updated',
   hero: {
-    layout: 'overlay',
-    placeholderImageSrc: COMING_SOON_HERO,
-    eyebrowKey: 'wan3.hero.eyebrow',
+    layout: 'content-first',
+    videoSrc: 'https://media.comfy.org/website/models/wan_3.mp4',
+    posterSrc: 'https://media.comfy.org/website/models/wan_3-0.jpeg',
+    logoSrc: '/icons/ai-models/wan.svg',
     titleKey: 'wan3.hero.title',
+    descriptionKey: 'wan3.hero.description',
+    badgeKeys: [
+      'wan3.hero.tagImageToVideo',
+      'wan3.hero.tagTextToVideo',
+      'wan3.hero.tagReferenceToVideo'
+    ],
     primaryCta: {
       labelKey: 'wan3.hero.primaryCta',
-      href: externalLinks.cloud,
+      href: wan3Links.cloudRunTextToVideo,
+      target: '_blank'
+    },
+    secondaryCta: {
+      labelKey: 'wan3.hero.secondaryCta',
+      href: wan3Links.hubModel,
+      target: '_blank'
+    }
+  },
+  pricing: {
+    defaultBillingCycle: 'monthly',
+    banner: {
+      titleKey: 'wan3.pricing.banner.title',
+      subtitleKey: 'wan3.pricing.banner.subtitle',
+      cta: {
+        labelKey: 'wan3.pricing.banner.cta',
+        href: externalLinks.cloud,
+        target: '_blank'
+      }
+    }
+  },
+  faq: {
+    headingKey: 'wan3.faq.heading',
+    items: [
+      {
+        id: 'what-is-wan-3',
+        question: {
+          en: 'What is Wan 3.0?',
+          'zh-CN': 'Wan 3.0 是什么？'
+        },
+        answer: {
+          en: "Alibaba's latest video model. Give it a prompt, up to 20 reference assets, or even a document and it generates up to 30 seconds with native audio.",
+          'zh-CN':
+            '阿里巴巴最新的视频模型。给它一段提示词、最多 20 个参考素材，甚至一份文档，它就能生成最长 30 秒并带原生音频的视频。'
+        }
+      },
+      {
+        id: 'whats-new',
+        question: {
+          en: "What's new in Wan 3.0 vs Wan 2.7?",
+          'zh-CN': 'Wan 3.0 相比 Wan 2.7 有哪些新变化？'
+        },
+        answer: {
+          en: 'Native 30-second clips, up to 20 reference inputs, and 480p generations for quick and cost effective generations.',
+          'zh-CN':
+            '原生 30 秒片段、最多 20 个参考输入，以及用于快速且低成本生成的 480p 输出。'
+        }
+      },
+      {
+        id: 'how-to-run',
+        question: {
+          en: 'How do I run Wan 3.0 in ComfyUI?',
+          'zh-CN': '如何在 ComfyUI 中运行 Wan 3.0？'
+        },
+        answer: {
+          en: `This model ships with three workflows available in the template library — [reference to video](${wan3Links.cloudRunReferenceToVideo}), [image to video](${wan3Links.cloudRunImageToVideo}) and [text to video](${wan3Links.cloudRunTextToVideo}).`,
+          'zh-CN': `该模型在模板库中提供三个工作流 — [参考生视频](${wan3Links.cloudRunReferenceToVideo})、[图生视频](${wan3Links.cloudRunImageToVideo})与[文生视频](${wan3Links.cloudRunTextToVideo})。`
+        }
+      },
+      {
+        id: 'prompting',
+        question: {
+          en: 'How do I prompt Wan 3.0?',
+          'zh-CN': '如何为 Wan 3.0 编写提示词？'
+        },
+        answer: {
+          en: 'Start simple: subject, scene, motion — one sentence is enough for a full clip. For more control, layer in camera movement, lighting, style, and sound, or address your uploads directly with @ syntax: "@Image1 walks through the door and says the line from @Audio1." The longer and more precise the prompt, the closer the output tracks your intent — it accepts up to 20,000 characters.',
+          'zh-CN':
+            '先从简单开始：主体、场景、动作 — 一句话就足以生成完整片段。想要更多控制，可以再叠加运镜、光线、风格与声音，或用 @ 语法直接引用你上传的素材："@Image1 走进门并说出 @Audio1 中的台词。"提示词越长、越精确，输出就越贴近你的意图 — 最多支持 20,000 个字符。'
+        }
+      },
+      {
+        id: 'video-editing',
+        question: {
+          en: 'Can Wan 3.0 edit video I already have?',
+          'zh-CN': 'Wan 3.0 可以编辑我已有的视频吗？'
+        },
+        answer: {
+          en: 'Yes. Describe the change — remove an object, relight the scene, swap a subject — and everything else in the frame stays put. It can also extend existing footage.',
+          'zh-CN':
+            '可以。只需描述你想要的改动 — 移除某个物体、重新布光、替换主体 — 画面中的其他部分都会保持不变。它也可以延展已有素材。'
+        }
+      },
+      {
+        id: 'clip-length',
+        question: {
+          en: 'How long can clips be?',
+          'zh-CN': '片段可以有多长？'
+        },
+        answer: {
+          en: 'Anywhere from 2 to 30 seconds, generated in one continuous take — no stitching. Audio is generated natively, or switch it off.',
+          'zh-CN':
+            '2 到 30 秒均可，一镜到底地连续生成 — 无需拼接。音频为原生生成，也可以关闭。'
+        }
+      }
+    ]
+  },
+  steps: {
+    headingKey: 'wan3.steps.heading',
+    stepLabelKey: 'wan3.steps.step',
+    items: [
+      {
+        id: 'write-the-shot',
+        title: { en: 'Write the shot', 'zh-CN': '写下你的镜头' },
+        description: {
+          en: 'Camera, subject, framing',
+          'zh-CN': '镜头、主体、构图'
+        }
+      },
+      {
+        id: 'add-your-references',
+        title: { en: 'Add your references', 'zh-CN': '添加你的参考素材' },
+        description: {
+          en: 'An image, a video or an audio clip to steer it',
+          'zh-CN': '用图像、视频或音频片段来引导生成'
+        }
+      },
+      {
+        id: 'run-wan-3',
+        title: { en: 'Run Wan 3.0', 'zh-CN': '运行 Wan 3.0' },
+        description: {
+          en: 'Up to 30 seconds, up to 1080p',
+          'zh-CN': '最长 30 秒，最高 1080p'
+        }
+      }
+    ],
+    primaryCta: {
+      labelKey: 'wan3.steps.primaryCta',
+      href: wan3Links.cloudRunTextToVideo,
       target: '_blank'
     }
   },

--- a/apps/website/src/data/wan3.ts
+++ b/apps/website/src/data/wan3.ts
@@ -25,7 +25,7 @@ export const wan3Page: ModelLaunchPage = {
   breadcrumbUpdatedKey: 'wan3.breadcrumb.updated',
   hero: {
     layout: 'content-first',
-    videoSrc: 'https://media.comfy.org/website/models/wan_3-0_v2.mp4',
+    videoSrc: 'https://media.comfy.org/website/models/wan_3-0_v3.mp4',
     posterSrc: wan3HeroStillSrc,
     mobileFallbackImageSrc: wan3HeroStillSrc,
     mobileVideoSrc: wan3HeroMobileVideoSrc,

--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -5604,27 +5604,54 @@ const translations = {
   'footer.wanAnimate2': { en: 'Wan Animate 2', 'zh-CN': 'Wan Animate 2' },
   'footer.ltx': { en: 'LTX 2.5', 'zh-CN': 'LTX 2.5' },
   'modelLaunch.copyPrompt': { en: 'Copy prompt', 'zh-CN': '复制提示词' },
-  // Wan 3.0 model page (/wan-3.0) — announcement until the model ships
+  // Wan 3.0 model page (/wan-3.0)
   'wan3.meta.title': {
-    en: 'Wan 3.0 on Comfy — Coming Soon',
-    'zh-CN': 'Comfy 上的 Wan 3.0 — 即将推出'
+    en: 'Wan 3.0 on Comfy — Text, Image and Reference to Video',
+    'zh-CN': 'Comfy 上的 Wan 3.0 — 文生、图生与参考生视频'
   },
   'wan3.meta.description': {
-    en: 'Wan 3.0 is coming to Comfy. Run it on Comfy Cloud the day it lands, or start building workflows for free now with every other model Comfy supports.',
+    en: 'Run Wan 3.0 on Comfy Cloud. Generate up to 30 seconds of video from a text prompt, an image, or video, image and audio references, with sound produced alongside the picture.',
     'zh-CN':
-      'Wan 3.0 即将登陆 Comfy。上线当天即可在 Comfy Cloud 上运行；现在就可以用 Comfy 支持的其他模型免费开始搭建工作流。'
+      '在 Comfy Cloud 上运行 Wan 3.0。可从文字提示词、图像，或视频、图像与音频参考生成最长 30 秒的视频，并同时生成画面与声音。'
   },
   'wan3.breadcrumb.model': { en: 'Wan 3.0', 'zh-CN': 'Wan 3.0' },
   'wan3.breadcrumb.updated': {
     en: 'Updated August 2026',
     'zh-CN': '更新于 2026 年 8 月'
   },
-  'wan3.hero.eyebrow': { en: 'Coming soon', 'zh-CN': '即将推出' },
-  'wan3.hero.title': { en: 'Wan 3.0', 'zh-CN': 'Wan 3.0' },
-  'wan3.hero.primaryCta': {
-    en: 'RUN COMFY FOR FREE',
-    'zh-CN': '免费使用 Comfy'
+  'wan3.hero.title': { en: 'Wan 3.0 is here', 'zh-CN': 'Wan 3.0 已上线' },
+  'wan3.hero.description': {
+    en: "Wan 3.0 is a step change from previous Wan models. It generates what earlier versions couldn't: a full 30-second scene in one take, as low as 480p for speed and iteration, and up to 1080p for production quality. Available on Comfy Cloud and via Partner Nodes today.",
+    'zh-CN':
+      'Wan 3.0 相比以往的 Wan 模型是一次跨越式提升。它能做到早期版本做不到的事：一镜到底生成完整的 30 秒场景，低至 480p 以便快速迭代，最高 1080p 达到成片质量。现已在 Comfy Cloud 及合作伙伴节点上提供。'
   },
+  'wan3.hero.tagTextToVideo': { en: 'Text to Video', 'zh-CN': '文生视频' },
+  'wan3.hero.tagImageToVideo': { en: 'Image to Video', 'zh-CN': '图生视频' },
+  'wan3.hero.tagReferenceToVideo': {
+    en: 'Reference to Video',
+    'zh-CN': '参考生视频'
+  },
+  'wan3.hero.primaryCta': { en: 'RUN WAN 3.0', 'zh-CN': '运行 Wan 3.0' },
+  'wan3.hero.secondaryCta': {
+    en: 'BROWSE WORKFLOWS',
+    'zh-CN': '浏览工作流'
+  },
+  'wan3.pricing.banner.title': {
+    en: "Start Comfy Cloud for free. Upgrade when you're ready.",
+    'zh-CN': '免费开始使用 Comfy Cloud，准备好了再升级。'
+  },
+  'wan3.pricing.banner.subtitle': {
+    en: '5 free runs on real GPUs — no credit card required.',
+    'zh-CN': '在真实 GPU 上免费运行 5 次 — 无需信用卡。'
+  },
+  'wan3.pricing.banner.cta': { en: 'TRY FREE', 'zh-CN': '免费试用' },
+  'wan3.faq.heading': { en: 'Q&A', 'zh-CN': '问答' },
+  'wan3.steps.heading': {
+    en: 'How to direct your first shot',
+    'zh-CN': '如何执导你的第一个镜头'
+  },
+  'wan3.steps.step': { en: 'Step', 'zh-CN': '步骤' },
+  'wan3.steps.primaryCta': { en: 'RUN WAN 3.0', 'zh-CN': '运行 Wan 3.0' },
   'wan3.runOptions.heading': {
     en: 'One engine, every way to run it',
     'zh-CN': '同一引擎，多种运行方式'

--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -5646,12 +5646,6 @@ const translations = {
   },
   'wan3.pricing.banner.cta': { en: 'TRY FREE', 'zh-CN': '免费试用' },
   'wan3.faq.heading': { en: 'Q&A', 'zh-CN': '问答' },
-  'wan3.steps.heading': {
-    en: 'How to direct your first shot',
-    'zh-CN': '如何执导你的第一个镜头'
-  },
-  'wan3.steps.step': { en: 'Step', 'zh-CN': '步骤' },
-  'wan3.steps.primaryCta': { en: 'RUN WAN 3.0', 'zh-CN': '运行 Wan 3.0' },
   'wan3.runOptions.heading': {
     en: 'One engine, every way to run it',
     'zh-CN': '同一引擎，多种运行方式'

--- a/apps/website/src/templates/model-launch/ModelLaunchHeroSection.vue
+++ b/apps/website/src/templates/model-launch/ModelLaunchHeroSection.vue
@@ -20,12 +20,19 @@ const { locale = 'en', hero } = defineProps<{
 // SSR (and the first client tick, before onMounted) has no reliable viewport
 // to check, so it renders as if mobile: no <video> tag reaches the page at
 // all, meaning phones never start fetching hero.videoSrc. Only once mounted
-// on a >=768px viewport does the video swap in for the still.
+// on a >=768px viewport does the full video swap in; below that, phones play
+// hero.mobileVideoSrc when the page ships one, or keep the still when not.
 const isMounted = useMounted()
 const isDesktopViewport = useMediaQuery('(min-width: 768px)')
+const hasMobileMedia = Boolean(
+  hero.mobileVideoSrc || hero.mobileFallbackImageSrc
+)
 const showVideo = computed(
+  () => !hasMobileMedia || (isMounted.value && isDesktopViewport.value)
+)
+const showMobileVideo = computed(
   () =>
-    !hero.mobileFallbackImageSrc || (isMounted.value && isDesktopViewport.value)
+    Boolean(hero.mobileVideoSrc) && isMounted.value && !isDesktopViewport.value
 )
 
 // 'overlay' is the announcement treatment: media, scrim and content stacked in
@@ -56,6 +63,13 @@ const isContentFirst = hero.layout === 'content-first'
           v-if="showVideo"
           :locale
           :src="hero.videoSrc"
+          autoplay
+          loop
+        />
+        <VideoPlayer
+          v-else-if="showMobileVideo"
+          :locale
+          :src="hero.mobileVideoSrc"
           autoplay
           loop
         />
@@ -143,6 +157,14 @@ const isContentFirst = hero.layout === 'content-first'
         v-if="showVideo"
         :locale
         :src="hero.videoSrc"
+        :poster="hero.posterSrc"
+        autoplay
+        loop
+      />
+      <VideoPlayer
+        v-else-if="showMobileVideo"
+        :locale
+        :src="hero.mobileVideoSrc"
         :poster="hero.posterSrc"
         autoplay
         loop

--- a/apps/website/src/templates/model-launch/ModelLaunchHeroSection.vue
+++ b/apps/website/src/templates/model-launch/ModelLaunchHeroSection.vue
@@ -121,6 +121,7 @@ const isContentFirst = hero.layout === 'content-first'
           <Badge
             v-for="badgeKey in hero.badgeKeys"
             :key="badgeKey"
+            data-testid="model-launch-hero-badge"
             variant="subtle"
           >
             {{ t(badgeKey, locale) }}
@@ -210,6 +211,7 @@ const isContentFirst = hero.layout === 'content-first'
         <Badge
           v-for="badgeKey in hero.badgeKeys"
           :key="badgeKey"
+          data-testid="model-launch-hero-badge"
           variant="subtle"
         >
           {{ t(badgeKey, locale) }}

--- a/apps/website/src/templates/model-launch/types.ts
+++ b/apps/website/src/templates/model-launch/types.ts
@@ -38,6 +38,11 @@ export interface ModelLaunchHero {
   // never fetch videoSrc. Opt-in: pages that omit it keep playing the video
   // at every viewport size, as they did before this field existed.
   mobileFallbackImageSrc?: string
+  // Lightweight encode played below the 768px breakpoint in place of videoSrc,
+  // for pages whose full clip is too heavy for phones. Once the client mounts
+  // it wins over mobileFallbackImageSrc, which keeps covering SSR and the
+  // first client tick.
+  mobileVideoSrc?: string
   // 'content-first' puts the badges, heading, CTAs and prompt bar above the
   // video. 'media-first' leads with the video, which is how /minimax reads.
   // 'overlay' centres the eyebrow, heading and CTAs on top of the media behind


### PR DESCRIPTION
## Summary

Ports the Wan 3.0 launch page from the private repo now that the page can be public (Comfy-Org/ComfyUI_frontend-private#44).

Replaces the `/wan-3.0` coming-soon announcement with the full launch page built on the model-launch template:

- **Hero**: content-first layout with launch video + poster, modality badges (Text/Image/Reference to Video), and dual CTAs — primary opens the Wan 3.0 text-to-video cloud template, secondary opens the workflow hub's Wan model page
- **Pricing banner**, **three-step "direct your first shot" guide**, and a six-entry bilingual (en / zh-CN) **Q&A section** emitting FAQPage structured data
- `data-testid` on the hero badges so tests can assert badge copy (no open-weights claims, since Wan 3.0 runs through partner nodes against an API)
- e2e spec rewritten for the launch page, including guards against a stray "4K" claim (the model tops out at 1080p)

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm test:unit` — 471 passed
- [x] Referenced media assets verified reachable (`wan_3.mp4`, `wan_3-0.jpeg`, local `wan.svg`)
- [ ] e2e (`wan-3.0.spec.ts`) runs in CI
