### PR TITLE
test(subgraph): pin promoted-widget survival across instance removal

### DIFF
--- a/src/lib/litegraph/src/subgraph/SubgraphNode.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphNode.ts
@@ -869,6 +869,7 @@ export class SubgraphNode extends LGraphNode implements BaseLGraph {
   override onRemoved(): void {
     this._eventAbortController.abort()
 
+    const store = useWidgetValueStore()
     for (const input of this.inputs) {
       if (
         input._listenerController &&
@@ -876,6 +877,7 @@ export class SubgraphNode extends LGraphNode implements BaseLGraph {
       ) {
         input._listenerController.abort()
       }
+      if (input.widgetId) store.deleteWidget(input.widgetId)
       this._clearPromotedWidget(input)
     }
     for (const widget of this._extraWidgets) widget.onRemove?.()

--- a/src/lib/litegraph/src/subgraph/SubgraphWidgetPromotion.test.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphWidgetPromotion.test.ts
@@ -342,29 +342,36 @@ describe('SubgraphWidgetPromotion', () => {
       )
     })
 
-    it('should fire widget-demoted events when node is removed', () => {
+    it('cleans up promoted widget state without demotion on removal', () => {
       const subgraph = createTestSubgraph({
         inputs: [{ name: 'input', type: 'number' }]
       })
 
       const { node } = createNodeWithWidget('Test Node')
       const subgraphNode = setupPromotedWidget(subgraph, node)
+      const promotedInput = promotedInputs(subgraphNode)[0]
+      if (!promotedInput) throw new Error('Missing promoted input')
 
       expect(subgraphNode.widgets).toHaveLength(
         promotedInputs(subgraphNode).length
       )
       expect(promotedInputs(subgraphNode)).toHaveLength(1)
+      expect(
+        useWidgetValueStore().getWidget(promotedInput.widgetId)
+      ).toBeDefined()
 
       const eventCapture = createEventCapture(subgraph.events, [
         'widget-demoted'
       ])
 
-      // Remove the subgraph node
       subgraphNode.onRemoved()
 
       const demotedEvents = eventCapture.getEventsByType('widget-demoted')
       expect(demotedEvents).toHaveLength(0)
       expect(promotedInputs(subgraphNode)).toHaveLength(1)
+      expect(
+        useWidgetValueStore().getWidget(promotedInput.widgetId)
+      ).toBeUndefined()
 
       eventCapture.cleanup()
     })


### PR DESCRIPTION
- Kept: explicit `SubgraphNode.onRemoved()` cleanup.
- Dropped: same-ID retention test and ADR note; `main` now owns replacement semantics.
- Verified: 453 subgraph tests, typecheck, lint, format.

<details><summary>Full context for agent readers</summary>

Rebased onto `main` at `e7d0d3e691` after the ECS stack landed in #15924.

Current `main` already clears node-owned widget state after `onRemoved()` and pins the end-to-end instance-removal and replacement behavior. This PR retains only the ownership gap that remains: `SubgraphNode.onRemoved()` now explicitly deletes each promoted widget projection itself. A direct regression test proves the projection exists before the callback, is absent afterward, and no demotion event is emitted.

Dropped as redundant or contradicted by current `main`:

- the duplicate-delete test's same-ID value-retention re-characterization;
- the ADR-0009 note claiming projection retention across instance removal.

Verification at [`5612db187`](https://github.com/Comfy-Org/ComfyUI_frontend/commit/5612db187d690cf6263e6dc9a4953c4a500c16a8):

- `src/lib/litegraph/src/subgraph/` + `src/core/graph/subgraph/`: 28 files, 453 tests passed;
- `vue-tsc --noEmit`;
- targeted oxfmt, type-aware oxlint, and ESLint.

</details>
