### PR TITLE
test: mock camera info in load3d lazy tests

### DIFF
--- a/src/extensions/core/load3dLazy.test.ts
+++ b/src/extensions/core/load3dLazy.test.ts
@@ -29,6 +29,7 @@ vi.mock('@/extensions/core/load3d', () => ({}))
 vi.mock('@/extensions/core/load3dAdvanced', () => ({}))
 vi.mock('@/extensions/core/load3dPreviewExtensions', () => ({}))
 vi.mock('@/extensions/core/saveMesh', () => ({}))
+vi.mock('@/extensions/core/cameraInfo', () => ({}))
 
 type Hook = (
   nodeType: typeof LGraphNode,


### PR DESCRIPTION
## Summary

Prevent the `load3dLazy` unit suite from transforming the real camera-info dependency graph during lazy-load tests.

## Changes

- Mock `cameraInfo`, matching every other dynamically loaded 3D extension in the test boundary.
- Preserve the existing 16 behavioral assertions without increasing Vitest timeouts.

## Testing

- `pnpm test:unit src/extensions/core/load3dLazy.test.ts` — 16 tests pass in ~0.7s; transform time falls from 8.82s to ~0.08s.
- `pnpm typecheck && pnpm lint && pnpm format:check && pnpm knip && pnpm test:unit` — 1,293 test files pass, with 17,484 passing tests, 20 expected failures, and 14 skips.
- E2E verification: on Node 25.9.0, run `pnpm test:unit src/extensions/core/load3dLazy.test.ts` from a fresh checkout; expect all 16 tests to finish without either `Load3D` or `Preview3D` reaching the 5-second timeout. No browser clicks are applicable because this is test-isolation-only and does not change runtime UI behavior.

## Review Focus

Confirm the test boundary mocks all five modules dynamically imported by `load3dLazy` while retaining the lazy-load behavior assertions.

Fixes #15858
