### PR TITLE
refactor: migrate widget access to widgetValueStore in rich-ui nodes

### DIFF
--- a/src/composables/boundingBoxes/useBoundingBoxes.test.ts
+++ b/src/composables/boundingBoxes/useBoundingBoxes.test.ts
@@ -4,8 +4,12 @@ import type { Ref, ShallowRef } from 'vue'
 import { defineComponent, h, nextTick, ref, shallowRef } from 'vue'
 
 import { useBoundingBoxes } from './useBoundingBoxes'
+import { useWidgetValueStore } from '@/stores/widgetValueStore'
 import type { BoundingBox } from '@/types/boundingBoxes'
 import { toNodeId } from '@/types/nodeId'
+import type { NodeId } from '@/types/nodeId'
+import type { WidgetValue } from '@/types/simplifiedWidget'
+import { widgetId } from '@/types/widgetId'
 
 const { appState, outputState } = vi.hoisted(() => ({
   appState: { node: null as unknown },
@@ -78,30 +82,45 @@ function makeCanvas(): HTMLCanvasElement {
   return el
 }
 
+const GRAPH_ID = 'bbox-test-graph'
+const NODE_ID = toNodeId('1')
+
 interface MockNode {
-  widgets: { name: string; value: unknown }[]
+  id: NodeId
+  graph: { rootGraph: { id: string } }
   findInputSlot: (name: string) => number
   getInputNode: () => null
   isInputConnected?: () => boolean
 }
 
 function makeNode(): MockNode {
+  const store = useWidgetValueStore()
+  const register = (name: string, type: string, value: WidgetValue) =>
+    store.registerWidget(widgetId(GRAPH_ID, NODE_ID, name), {
+      type,
+      value,
+      options: {}
+    })
+  register('width', 'number', 512)
+  register('height', 'number', 512)
+  register('last_incoming', 'custom', [])
   return {
-    widgets: [
-      { name: 'width', value: 512 },
-      { name: 'height', value: 512 },
-      { name: 'last_incoming', value: [] }
-    ],
+    id: NODE_ID,
+    graph: { rootGraph: { id: GRAPH_ID } },
     findInputSlot: () => -1,
     getInputNode: () => null
   }
 }
 
-const lastIncomingOf = (node: MockNode) =>
-  node.widgets.find((w) => w.name === 'last_incoming')!.value
+const lastIncomingOf = () =>
+  useWidgetValueStore().getWidget(widgetId(GRAPH_ID, NODE_ID, 'last_incoming'))
+    ?.value
 
-const setLastIncomingOf = (node: MockNode, value: BoundingBox[]) => {
-  node.widgets.find((w) => w.name === 'last_incoming')!.value = value
+const setLastIncomingOf = (value: BoundingBox[]) => {
+  useWidgetValueStore().setValue(
+    widgetId(GRAPH_ID, NODE_ID, 'last_incoming'),
+    value
+  )
 }
 
 const pe = (
@@ -252,13 +271,13 @@ describe('useBoundingBoxes region editing', () => {
 
   it('clears all regions and invalidates the applied upstream input', async () => {
     const node = makeNode()
-    setLastIncomingOf(node, [box()])
+    setLastIncomingOf([box()])
     appState.node = node
     const c = setup([box(), box({ x: 0 })])
     c.clearAll()
     await flush()
     expect(modelBoxes(c)).toHaveLength(0)
-    expect(lastIncomingOf(node)).toEqual([])
+    expect(lastIncomingOf()).toEqual([])
   })
 })
 
@@ -294,13 +313,13 @@ describe('useBoundingBoxes incoming bboxes input', () => {
     const c = setup([box({ x: 200, width: 300 })])
     expect(modelBoxes(c)).toHaveLength(1)
     expect(modelBoxes(c)[0].width).toBe(300)
-    expect(lastIncomingOf(node)).toEqual(incoming)
+    expect(lastIncomingOf()).toEqual(incoming)
   })
 
   it('does not re-apply an already applied output after a remount', async () => {
     const node = makeConnectedNode()
     const incoming = [box({ x: 0, width: 100 })]
-    setLastIncomingOf(node, incoming)
+    setLastIncomingOf(incoming)
     appState.node = node
     outputState.outputs = { input_bboxes: incoming }
     const c = setup([box({ x: 200, width: 300 })])
@@ -387,12 +406,12 @@ describe('useBoundingBoxes incoming bboxes input', () => {
 
     expect(modelBoxes(c)).toHaveLength(1)
     expect(modelBoxes(c)[0].width).toBe(100)
-    expect(lastIncomingOf(node)).toEqual(incoming)
+    expect(lastIncomingOf()).toEqual(incoming)
   })
 
   it('re-seeds the canvas over user edits when the upstream value changes', async () => {
     const node = makeConnectedNode()
-    setLastIncomingOf(node, [box({ x: 0, width: 100 })])
+    setLastIncomingOf([box({ x: 0, width: 100 })])
     appState.node = node
     const c = setup([box({ x: 200, width: 300 })])
 
@@ -402,7 +421,7 @@ describe('useBoundingBoxes incoming bboxes input', () => {
     await flush()
 
     expect(modelBoxes(c)[0].width).toBe(128)
-    expect(lastIncomingOf(node)).toEqual(changed)
+    expect(lastIncomingOf()).toEqual(changed)
   })
 })
 

--- a/src/composables/boundingBoxes/useBoundingBoxes.ts
+++ b/src/composables/boundingBoxes/useBoundingBoxes.ts
@@ -18,6 +18,10 @@ import type {
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import type { NodeOutputWith } from '@/schemas/apiSchema'
 import { app } from '@/scripts/app'
+import {
+  nodeWidgetValue,
+  setNodeWidgetValue
+} from '@/composables/node/widgetStoreSync'
 import { useNodeOutputStore } from '@/stores/nodeOutputStore'
 import type { BoundingBox } from '@/types/boundingBoxes'
 import type { NodeId } from '@/types/nodeId'
@@ -73,8 +77,13 @@ export function useBoundingBoxes(
   const { selectedNodeIds } = storeToRefs(useCanvasStore())
   const isNodeSelected = computed(() => selectedNodeIds.value.has(nodeId))
 
+  const widgetValue = (name: string) =>
+    nodeWidgetValue(litegraphNode.value, name)
+  const setWidgetValue = (name: string, value: number | BoundingBox[]) =>
+    setNodeWidgetValue(litegraphNode.value, name, value)
+
   function dimWidget(name: 'width' | 'height'): number | undefined {
-    const v = litegraphNode.value?.widgets?.find((w) => w.name === name)?.value
+    const v = widgetValue(name)
     return typeof v === 'number' && v > 0 ? v : undefined
   }
   const widthValue = computed(() => dimWidget('width') ?? 1024)
@@ -648,16 +657,8 @@ export function useBoundingBoxes(
       Math.max(DIMENSION_STEP, Math.round(v / DIMENSION_STEP) * DIMENSION_STEP)
     const targetW = snap(naturalWidth)
     const targetH = snap(naturalHeight)
-    const widthWidget = node.widgets?.find((w) => w.name === 'width')
-    const heightWidget = node.widgets?.find((w) => w.name === 'height')
-    if (widthWidget && widthWidget.value !== targetW) {
-      widthWidget.value = targetW
-      widthWidget.callback?.(targetW)
-    }
-    if (heightWidget && heightWidget.value !== targetH) {
-      heightWidget.value = targetH
-      heightWidget.callback?.(targetH)
-    }
+    setWidgetValue('width', targetW)
+    setWidgetValue('height', targetH)
   }
 
   let lastBgUrl = ''
@@ -690,21 +691,13 @@ export function useBoundingBoxes(
     }
     img.src = url
   }
-  function lastIncomingWidget() {
-    return litegraphNode.value?.widgets?.find((w) => w.name === 'last_incoming')
-  }
-
   function lastIncomingValue(): BoundingBox[] {
-    const value = lastIncomingWidget()?.value
+    const value = widgetValue('last_incoming')
     return Array.isArray(value) ? (value as BoundingBox[]) : []
   }
 
   function setLastIncoming(boxes: BoundingBox[]) {
-    const widget = lastIncomingWidget()
-    if (!widget) return
-    const next = cloneDeep(boxes)
-    widget.value = next
-    widget.callback?.(next)
+    setWidgetValue('last_incoming', cloneDeep(boxes))
   }
 
   function applyIncomingBoxes(apply = true) {

--- a/src/composables/maskeditor/useMaskEditorLoader.test.ts
+++ b/src/composables/maskeditor/useMaskEditorLoader.test.ts
@@ -2,6 +2,9 @@ import { fromAny } from '@total-typescript/shoehorn'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
+import { useWidgetValueStore } from '@/stores/widgetValueStore'
+import { toNodeId } from '@/types/nodeId'
+import { widgetId } from '@/types/widgetId'
 import { api } from '@/scripts/api'
 import { useMaskEditorLoader } from './useMaskEditorLoader'
 
@@ -69,13 +72,19 @@ class MockImage {
   }
 }
 
+const GRAPH_ID = 'maskeditor-loader-test'
+
 function createLoadImageNode(widgetValue: string): LGraphNode {
+  useWidgetValueStore().registerWidget(
+    widgetId(GRAPH_ID, toNodeId(7), 'image'),
+    { type: 'string', value: widgetValue, options: {} }
+  )
   return fromAny<LGraphNode, unknown>({
     id: 7,
     type: 'LoadImage',
     imgs: [{ src: 'http://localhost:8188/api/view?filename=whatever.png' }],
     images: undefined,
-    widgets: [{ name: 'image', value: widgetValue }]
+    graph: { rootGraph: { id: GRAPH_ID } }
   })
 }
 

--- a/src/composables/maskeditor/useMaskEditorLoader.ts
+++ b/src/composables/maskeditor/useMaskEditorLoader.ts
@@ -2,6 +2,7 @@ import { useMaskEditorDataStore } from '@/stores/maskEditorDataStore'
 import type { ImageRef, ImageLayer } from '@/stores/maskEditorDataStore'
 import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
 import { useNodeOutputStore } from '@/stores/nodeOutputStore'
+import { nodeWidgetValue } from '@/composables/node/widgetStoreSync'
 import { isCloud } from '@/platform/distribution/types'
 import { api } from '@/scripts/api'
 import { app } from '@/scripts/app'
@@ -97,10 +98,10 @@ export function useMaskEditorLoader() {
 
       let nodeImageRef = parseImageRef(nodeImageUrl)
 
-      const imageWidget = node.widgets?.find((w) => w.name === 'image')
-      const widgetFilename = imageWidget
-        ? extractWidgetStringValue(imageWidget.value)
-        : undefined
+      const widgetFilename = extractWidgetStringValue(
+        nodeWidgetValue(node, 'image') ??
+          node.widgets?.find((w) => w.name === 'image')?.value
+      )
 
       // If we have a widget filename, we should prioritize it over the node image
       // because the node image might be stale (e.g. from a previous save)

--- a/src/composables/maskeditor/useMaskEditorSaver.test.ts
+++ b/src/composables/maskeditor/useMaskEditorSaver.test.ts
@@ -2,6 +2,9 @@ import { fromAny, fromPartial } from '@total-typescript/shoehorn'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
+import { useWidgetValueStore } from '@/stores/widgetValueStore'
+import { toNodeId } from '@/types/nodeId'
+import { widgetId } from '@/types/widgetId'
 import { api } from '@/scripts/api'
 import { app } from '@/scripts/app'
 import { useNodeOutputStore } from '@/stores/nodeOutputStore'
@@ -131,8 +134,15 @@ describe('useMaskEditorSaver', () => {
       ],
       widgets_values: ['original.png [input]'],
       properties: { image: 'original.png [input]' },
-      graph: { setDirtyCanvas: vi.fn() }
+      graph: {
+        setDirtyCanvas: vi.fn(),
+        rootGraph: { id: 'maskeditor-saver-test' }
+      }
     })
+    useWidgetValueStore().registerWidget(
+      widgetId('maskeditor-saver-test', toNodeId(42), 'image'),
+      { type: 'string', value: 'original.png [input]', options: {} }
+    )
 
     mockDataStore.sourceNode = mockNode
     mockDataStore.inputData = {

--- a/src/composables/maskeditor/useMaskEditorSaver.ts
+++ b/src/composables/maskeditor/useMaskEditorSaver.ts
@@ -3,6 +3,7 @@ import type { UploadImageResponse } from '@comfyorg/ingest-types'
 import { useMaskEditorDataStore } from '@/stores/maskEditorDataStore'
 import { useMaskEditorStore } from '@/stores/maskEditorStore'
 import { useNodeOutputStore } from '@/stores/nodeOutputStore'
+import { setNodeWidgetValue } from '@/composables/node/widgetStoreSync'
 import type {
   EditorOutputData,
   EditorOutputLayer,
@@ -273,6 +274,14 @@ export function useMaskEditorSaver() {
     app.canvas.setDirty(true)
   }
 
+  function writeImageWidgetValue(node: LGraphNode, value: string): boolean {
+    if (setNodeWidgetValue(node, 'image', value)) return true
+    const imageWidget = node.widgets?.find((w) => w.name === 'image')
+    if (!imageWidget) return false
+    imageWidget.value = value
+    return true
+  }
+
   function updateNodeWithServerReferences(
     node: LGraphNode,
     outputData: EditorOutputData
@@ -281,23 +290,10 @@ export function useMaskEditorSaver() {
 
     node.images = [mainRef]
 
-    const imageWidget = node.widgets?.find((w) => w.name === 'image')
-    if (imageWidget) {
-      const widgetValue =
-        mainRef.filename + (mainRef.type ? ` [${mainRef.type}]` : '')
-
-      imageWidget.value = widgetValue
-
-      if (node.properties) {
-        node.properties['image'] = widgetValue
-      }
-
-      if (node.widgets_values && node.widgets) {
-        const widgetIndex = node.widgets.indexOf(imageWidget)
-        if (widgetIndex >= 0) {
-          node.widgets_values[widgetIndex] = widgetValue
-        }
-      }
+    const widgetValue =
+      mainRef.filename + (mainRef.type ? ` [${mainRef.type}]` : '')
+    if (writeImageWidgetValue(node, widgetValue) && node.properties) {
+      node.properties['image'] = widgetValue
     }
 
     node.imgs = undefined

--- a/src/composables/node/widgetStoreSync.test.ts
+++ b/src/composables/node/widgetStoreSync.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it, vi } from 'vitest'
+import { nextTick } from 'vue'
+
+import {
+  nodeWidgetValue,
+  setNodeWidgetValue,
+  watchNodeWidgetValues
+} from '@/composables/node/widgetStoreSync'
+import { fromPartial } from '@total-typescript/shoehorn'
+
+import { CustomEventTarget } from '@/lib/litegraph/src/infrastructure/CustomEventTarget'
+import type { LGraphEventMap } from '@/lib/litegraph/src/infrastructure/LGraphEventMap'
+import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
+import { useWidgetValueStore } from '@/stores/widgetValueStore'
+import type { NodeId } from '@/types/nodeId'
+import { toNodeId } from '@/types/nodeId'
+import { widgetId } from '@/types/widgetId'
+import { createMockLGraphNode } from '@/utils/__tests__/litegraphTestUtils'
+
+const GRAPH_ID = 'widget-store-sync-graph'
+
+function makeNode(id: NodeId): LGraphNode {
+  return createMockLGraphNode({
+    id,
+    graph: {
+      rootGraph: { id: GRAPH_ID },
+      events: new CustomEventTarget<LGraphEventMap>()
+    }
+  })
+}
+
+function registerNumberWidget(nodeId: NodeId, name: string, value: number) {
+  useWidgetValueStore().registerWidget(widgetId(GRAPH_ID, nodeId, name), {
+    type: 'number',
+    value,
+    options: {}
+  })
+}
+
+describe('watchNodeWidgetValues', () => {
+  it('fires with the current values when a watched store value changes', async () => {
+    const nodeId = toNodeId(1)
+    const node = makeNode(nodeId)
+    registerNumberWidget(nodeId, 'width', 1024)
+    registerNumberWidget(nodeId, 'height', 768)
+    const onChange = vi.fn()
+
+    watchNodeWidgetValues(node, 'target-size', ['width', 'height'], onChange)
+    useWidgetValueStore().setValue(widgetId(GRAPH_ID, nodeId, 'width'), 2048)
+    await nextTick()
+
+    expect(onChange).toHaveBeenCalledTimes(1)
+    expect(onChange).toHaveBeenCalledWith([2048, 768])
+  })
+
+  it('does not fire when the same value is written again', async () => {
+    const nodeId = toNodeId(2)
+    const node = makeNode(nodeId)
+    registerNumberWidget(nodeId, 'width', 1024)
+    const onChange = vi.fn()
+
+    watchNodeWidgetValues(node, 'target-size', ['width'], onChange)
+    useWidgetValueStore().setValue(widgetId(GRAPH_ID, nodeId, 'width'), 1024)
+    await nextTick()
+
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  it('replaces the previous watcher when the same (node, key) is re-registered', async () => {
+    const nodeId = toNodeId(3)
+    const node = makeNode(nodeId)
+    registerNumberWidget(nodeId, 'width', 100)
+    const first = vi.fn()
+    const second = vi.fn()
+
+    watchNodeWidgetValues(node, 'target-size', ['width'], first)
+    watchNodeWidgetValues(node, 'target-size', ['width'], second)
+    useWidgetValueStore().setValue(widgetId(GRAPH_ID, nodeId, 'width'), 200)
+    await nextTick()
+
+    expect(first).not.toHaveBeenCalled()
+    expect(second).toHaveBeenCalledWith([200])
+  })
+
+  it('stops all watchers when the graph removes the node', async () => {
+    const nodeId = toNodeId(4)
+    const events = new CustomEventTarget<LGraphEventMap>()
+    const node = createMockLGraphNode({
+      id: nodeId,
+      graph: { rootGraph: { id: GRAPH_ID }, events }
+    })
+    registerNumberWidget(nodeId, 'width', 100)
+    registerNumberWidget(nodeId, 'height', 100)
+    const onWidthChange = vi.fn()
+    const onHeightChange = vi.fn()
+
+    watchNodeWidgetValues(node, 'width-sync', ['width'], onWidthChange)
+    watchNodeWidgetValues(node, 'height-sync', ['height'], onHeightChange)
+    events.dispatch('node:before-removed', { node })
+    useWidgetValueStore().setValue(widgetId(GRAPH_ID, nodeId, 'width'), 200)
+    useWidgetValueStore().setValue(widgetId(GRAPH_ID, nodeId, 'height'), 200)
+    await nextTick()
+
+    expect(onWidthChange).not.toHaveBeenCalled()
+    expect(onHeightChange).not.toHaveBeenCalled()
+  })
+
+  it('yields undefined for unregistered widget names without throwing', async () => {
+    const nodeId = toNodeId(5)
+    const node = makeNode(nodeId)
+    registerNumberWidget(nodeId, 'width', 100)
+    const onChange = vi.fn()
+
+    watchNodeWidgetValues(node, 'target-size', ['width', 'missing'], onChange)
+    useWidgetValueStore().setValue(widgetId(GRAPH_ID, nodeId, 'width'), 200)
+    await nextTick()
+
+    expect(onChange).toHaveBeenCalledWith([200, undefined])
+  })
+})
+
+describe('deferred wiring', () => {
+  it('defers via onAdded when the node has no graph yet, then fires normally', async () => {
+    const nodeId = toNodeId(8)
+    const node = createMockLGraphNode({ id: nodeId })
+    const onChange = vi.fn()
+
+    watchNodeWidgetValues(node, 'target-size', ['width'], onChange)
+    registerNumberWidget(nodeId, 'width', 100)
+    useWidgetValueStore().setValue(widgetId(GRAPH_ID, nodeId, 'width'), 200)
+    await nextTick()
+    expect(onChange).not.toHaveBeenCalled()
+
+    node.graph = fromPartial({ rootGraph: { id: GRAPH_ID } })
+    node.onAdded?.(fromPartial({}))
+    useWidgetValueStore().setValue(widgetId(GRAPH_ID, nodeId, 'width'), 300)
+    await nextTick()
+
+    expect(onChange).toHaveBeenCalledWith([300])
+  })
+})
+
+describe('setNodeWidgetValue', () => {
+  it('reports whether the widget exists and skips same-value writes', () => {
+    const nodeId = toNodeId(9)
+    const node = makeNode(nodeId)
+    registerNumberWidget(nodeId, 'width', 100)
+
+    expect(setNodeWidgetValue(node, 'width', 100)).toBe(true)
+    expect(setNodeWidgetValue(node, 'width', 200)).toBe(true)
+    expect(
+      useWidgetValueStore().getWidget(widgetId(GRAPH_ID, nodeId, 'width'))
+        ?.value
+    ).toBe(200)
+    expect(setNodeWidgetValue(node, 'missing', 1)).toBe(false)
+  })
+})
+
+describe('nodeWidgetValue', () => {
+  it('reads the current store value for a registered widget', () => {
+    const nodeId = toNodeId(6)
+    const node = makeNode(nodeId)
+    registerNumberWidget(nodeId, 'width', 512)
+
+    expect(nodeWidgetValue(node, 'width')).toBe(512)
+  })
+
+  it('returns undefined for a node without a graph', () => {
+    const node = createMockLGraphNode({ id: toNodeId(7) })
+
+    expect(nodeWidgetValue(node, 'width')).toBeUndefined()
+  })
+})

--- a/src/composables/node/widgetStoreSync.ts
+++ b/src/composables/node/widgetStoreSync.ts
@@ -1,0 +1,95 @@
+import { watch } from 'vue'
+import type { WatchStopHandle } from 'vue'
+
+import { useChainCallback } from '@/composables/functional/useChainCallback'
+import type { LGraphEventMap } from '@/lib/litegraph/src/infrastructure/LGraphEventMap'
+import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
+import { useWidgetValueStore } from '@/stores/widgetValueStore'
+import type { WidgetValue } from '@/types/simplifiedWidget'
+import type { WidgetId } from '@/types/widgetId'
+import { widgetId } from '@/types/widgetId'
+
+export type WidgetNode = LGraphNode | null
+
+const nodeSyncs = new Map<LGraphNode, Map<string, WatchStopHandle>>()
+const graphsWithRemovalListener = new WeakSet<
+  NonNullable<LGraphNode['graph']>
+>()
+
+function nodeWidgetId(node: WidgetNode, name: string): WidgetId | null {
+  const graphId = node?.graph?.rootGraph?.id
+  return graphId ? widgetId(graphId, node.id, name) : null
+}
+
+export function nodeWidgetValue(node: WidgetNode, name: string): unknown {
+  const id = nodeWidgetId(node, name)
+  return id ? useWidgetValueStore().getWidget(id)?.value : undefined
+}
+
+export function setNodeWidgetValue(
+  node: WidgetNode,
+  name: string,
+  value: WidgetValue
+): boolean {
+  const id = nodeWidgetId(node, name)
+  if (!id) return false
+  const store = useWidgetValueStore()
+  const state = store.getWidget(id)
+  if (!state) return false
+  if (state.value !== value) store.setValue(id, value)
+  return true
+}
+
+function disposeNodeSyncs(node: LGraphNode): void {
+  const active = nodeSyncs.get(node)
+  if (!active) return
+  for (const stop of active.values()) stop()
+  nodeSyncs.delete(node)
+}
+
+interface NodeRemovalEventTarget {
+  addEventListener(
+    type: 'node:before-removed',
+    listener: (
+      event: CustomEvent<LGraphEventMap['node:before-removed']>
+    ) => void
+  ): void
+}
+
+function ensureRemovalListener(node: LGraphNode): void {
+  const graph = node.graph
+  const events: NodeRemovalEventTarget | undefined = graph?.events
+  if (!graph || !events || graphsWithRemovalListener.has(graph)) return
+  graphsWithRemovalListener.add(graph)
+  events.addEventListener('node:before-removed', (event) => {
+    disposeNodeSyncs(event.detail.node)
+  })
+}
+
+export function watchNodeWidgetValues(
+  node: LGraphNode,
+  key: string,
+  names: readonly string[],
+  onChange: (values: unknown[]) => void
+): void {
+  if (!node.graph) {
+    node.onAdded = useChainCallback(node.onAdded, () => {
+      watchNodeWidgetValues(node, key, names, onChange)
+    })
+    return
+  }
+  ensureRemovalListener(node)
+  let syncs = nodeSyncs.get(node)
+  if (!syncs) {
+    syncs = new Map()
+    nodeSyncs.set(node, syncs)
+  }
+  syncs.get(key)?.()
+  syncs.set(
+    key,
+    watch(
+      () => names.map((name) => nodeWidgetValue(node, name)),
+      (values) => onChange(values)
+    )
+  )
+}

--- a/src/composables/painter/usePainter.test.ts
+++ b/src/composables/painter/usePainter.test.ts
@@ -1,21 +1,30 @@
 import { render } from '@testing-library/vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { defineComponent, nextTick, ref } from 'vue'
+import type * as VueI18n from 'vue-i18n'
 
 import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
 import type { IBaseWidget } from '@/lib/litegraph/src/types/widgets'
 import { api } from '@/scripts/api'
+import { useWidgetValueStore } from '@/stores/widgetValueStore'
 import { toNodeId } from '@/types/nodeId'
 import type { NodeId } from '@/types/nodeId'
+import type { WidgetValue } from '@/types/simplifiedWidget'
+import { widgetId } from '@/types/widgetId'
+import { createMockLGraphNode } from '@/utils/__tests__/litegraphTestUtils'
 
 import { usePainter } from './usePainter'
 
-vi.mock('vue-i18n', () => ({
-  useI18n: vi.fn(() => ({
-    t: (key: string, params?: Record<string, unknown>) =>
-      params ? `${key}:${JSON.stringify(params)}` : key
-  }))
-}))
+vi.mock('vue-i18n', async (importOriginal) => {
+  const actual = await importOriginal<typeof VueI18n>()
+  return {
+    ...actual,
+    useI18n: vi.fn(() => ({
+      t: (key: string, params?: Record<string, unknown>) =>
+        params ? `${key}:${JSON.stringify(params)}` : key
+    }))
+  }
+})
 
 vi.mock('@vueuse/core', () => ({
   useElementSize: vi.fn(() => ({
@@ -56,6 +65,8 @@ vi.mock('@/scripts/api', () => ({
   }
 }))
 
+const GRAPH_ID = 'painter-test'
+
 const mockWidgets: IBaseWidget[] = []
 const mockProperties: Record<string, unknown> = {}
 const mockIsInputConnected = vi.fn(() => false)
@@ -65,16 +76,16 @@ vi.mock('@/scripts/app', () => ({
   app: {
     canvas: {
       graph: {
-        getNodeById: vi.fn(() => ({
-          get widgets() {
-            return mockWidgets
-          },
-          get properties() {
-            return mockProperties
-          },
-          isInputConnected: mockIsInputConnected,
-          getInputNode: mockGetInputNode
-        }))
+        getNodeById: vi.fn((id: NodeId) =>
+          createMockLGraphNode({
+            id,
+            graph: { rootGraph: { id: GRAPH_ID } },
+            widgets: mockWidgets,
+            properties: mockProperties,
+            isInputConnected: mockIsInputConnected,
+            getInputNode: mockGetInputNode
+          })
+        )
       }
     }
   }
@@ -86,9 +97,20 @@ function makeWidget(name: string, value: unknown = null): IBaseWidget {
   return {
     name,
     value,
-    callback: vi.fn(),
     serializeValue: undefined
   } as unknown as IBaseWidget
+}
+
+function painterWidgetId(name: string, nodeId: NodeId = toNodeId('test-node')) {
+  return widgetId(GRAPH_ID, nodeId, name)
+}
+
+function registerWidgetState(name: string, type: string, value: WidgetValue) {
+  useWidgetValueStore().registerWidget(painterWidgetId(name), {
+    type,
+    value,
+    options: {}
+  })
 }
 
 /**
@@ -133,7 +155,8 @@ describe('usePainter', () => {
 
   describe('syncCanvasSizeFromWidgets', () => {
     it('reads width/height from widget values on initialization', () => {
-      mockWidgets.push(makeWidget('width', 1024), makeWidget('height', 768))
+      registerWidgetState('width', 'number', 1024)
+      registerWidgetState('height', 'number', 768)
 
       const { painter } = mountPainter()
 
@@ -167,7 +190,7 @@ describe('usePainter', () => {
     })
 
     it('restores backgroundColor from bg_color widget', () => {
-      mockWidgets.push(makeWidget('bg_color', '#123456'))
+      registerWidgetState('bg_color', 'color', '#123456')
 
       const { painter } = mountPainter()
 
@@ -206,10 +229,10 @@ describe('usePainter', () => {
   })
 
   describe('syncCanvasSizeToWidgets', () => {
-    it('syncs canvas dimensions to widgets when size changes', async () => {
-      const widthWidget = makeWidget('width', 512)
-      const heightWidget = makeWidget('height', 512)
-      mockWidgets.push(widthWidget, heightWidget)
+    it('syncs canvas dimensions to widget store when size changes', async () => {
+      const store = useWidgetValueStore()
+      registerWidgetState('width', 'number', 512)
+      registerWidgetState('height', 'number', 512)
 
       const { painter } = mountPainter()
 
@@ -217,25 +240,24 @@ describe('usePainter', () => {
       painter.canvasHeight.value = 600
       await nextTick()
 
-      expect(widthWidget.value).toBe(800)
-      expect(heightWidget.value).toBe(600)
-      expect(widthWidget.callback).toHaveBeenCalledWith(800)
-      expect(heightWidget.callback).toHaveBeenCalledWith(600)
+      expect(store.getWidget(painterWidgetId('width'))?.value).toBe(800)
+      expect(store.getWidget(painterWidgetId('height'))?.value).toBe(600)
     })
   })
 
   describe('syncBackgroundColorToWidget', () => {
-    it('syncs background color to widget when color changes', async () => {
-      const bgWidget = makeWidget('bg_color', '#000000')
-      mockWidgets.push(bgWidget)
+    it('syncs background color to widget store when color changes', async () => {
+      const store = useWidgetValueStore()
+      registerWidgetState('bg_color', 'color', '#000000')
 
       const { painter } = mountPainter()
 
       painter.backgroundColor.value = '#ff00ff'
       await nextTick()
 
-      expect(bgWidget.value).toBe('#ff00ff')
-      expect(bgWidget.callback).toHaveBeenCalledWith('#ff00ff')
+      expect(store.getWidget(painterWidgetId('bg_color'))?.value).toBe(
+        '#ff00ff'
+      )
     })
   })
 
@@ -258,9 +280,9 @@ describe('usePainter', () => {
 
   describe('handleInputImageLoad', () => {
     it('updates canvas size and widgets from loaded image dimensions', () => {
-      const widthWidget = makeWidget('width', 512)
-      const heightWidget = makeWidget('height', 512)
-      mockWidgets.push(widthWidget, heightWidget)
+      const store = useWidgetValueStore()
+      registerWidgetState('width', 'number', 512)
+      registerWidgetState('height', 'number', 512)
 
       const { painter } = mountPainter()
 
@@ -275,8 +297,8 @@ describe('usePainter', () => {
 
       expect(painter.canvasWidth.value).toBe(1920)
       expect(painter.canvasHeight.value).toBe(1080)
-      expect(widthWidget.value).toBe(1920)
-      expect(heightWidget.value).toBe(1080)
+      expect(store.getWidget(painterWidgetId('width'))?.value).toBe(1920)
+      expect(store.getWidget(painterWidgetId('height'))?.value).toBe(1080)
     })
   })
 

--- a/src/composables/painter/usePainter.ts
+++ b/src/composables/painter/usePainter.ts
@@ -16,6 +16,10 @@ import type { IBaseWidget } from '@/lib/litegraph/src/types/widgets'
 import { useToastStore } from '@/platform/updates/common/toastStore'
 import { api } from '@/scripts/api'
 import { app } from '@/scripts/app'
+import {
+  nodeWidgetValue,
+  setNodeWidgetValue
+} from '@/composables/node/widgetStoreSync'
 import { useNodeOutputStore } from '@/stores/nodeOutputStore'
 import type { NodeId } from '@/types/nodeId'
 
@@ -84,11 +88,10 @@ export function usePainter(nodeId: NodeId, options: UsePainterOptions) {
     return app.canvas.graph.getNodeById(nodeId) as LGraphNode | null
   })
 
-  function getWidgetByName(name: string): IBaseWidget | undefined {
-    return litegraphNode.value?.widgets?.find(
-      (w: IBaseWidget) => w.name === name
-    )
-  }
+  const widgetValue = (name: string) =>
+    nodeWidgetValue(litegraphNode.value, name)
+  const setWidgetValue = (name: string, value: number | string) =>
+    setNodeWidgetValue(litegraphNode.value, name, value)
 
   const tool = ref<PainterTool>(PAINTER_TOOLS.BRUSH)
   const brushSize = ref(20)
@@ -112,8 +115,8 @@ export function usePainter(nodeId: NodeId, options: UsePainterOptions) {
     if (props.painterBrushHardness != null)
       brushHardness.value = props.painterBrushHardness as number
 
-    const bgColorWidget = getWidgetByName('bg_color')
-    if (bgColorWidget) backgroundColor.value = bgColorWidget.value as string
+    const bgColor = widgetValue('bg_color')
+    if (typeof bgColor === 'string') backgroundColor.value = bgColor
   }
 
   function saveSettingsToProperties() {
@@ -128,25 +131,12 @@ export function usePainter(nodeId: NodeId, options: UsePainterOptions) {
   }
 
   function syncCanvasSizeToWidgets() {
-    const widthWidget = getWidgetByName('width')
-    const heightWidget = getWidgetByName('height')
-
-    if (widthWidget && widthWidget.value !== canvasWidth.value) {
-      widthWidget.value = canvasWidth.value
-      widthWidget.callback?.(canvasWidth.value)
-    }
-    if (heightWidget && heightWidget.value !== canvasHeight.value) {
-      heightWidget.value = canvasHeight.value
-      heightWidget.callback?.(canvasHeight.value)
-    }
+    setWidgetValue('width', canvasWidth.value)
+    setWidgetValue('height', canvasHeight.value)
   }
 
   function syncBackgroundColorToWidget() {
-    const bgColorWidget = getWidgetByName('bg_color')
-    if (bgColorWidget && bgColorWidget.value !== backgroundColor.value) {
-      bgColorWidget.value = backgroundColor.value
-      bgColorWidget.callback?.(backgroundColor.value)
-    }
+    setWidgetValue('bg_color', backgroundColor.value)
   }
 
   function updateInputImageUrl() {
@@ -170,10 +160,10 @@ export function usePainter(nodeId: NodeId, options: UsePainterOptions) {
   }
 
   function syncCanvasSizeFromWidgets() {
-    const w = getWidgetByName('width')
-    const h = getWidgetByName('height')
-    canvasWidth.value = (w?.value as number) ?? 512
-    canvasHeight.value = (h?.value as number) ?? 512
+    const w = widgetValue('width')
+    const h = widgetValue('height')
+    canvasWidth.value = typeof w === 'number' ? w : 512
+    canvasHeight.value = typeof h === 'number' ? h : 512
   }
 
   function activeHardness(): number {
@@ -584,16 +574,8 @@ export function usePainter(nodeId: NodeId, options: UsePainterOptions) {
 
   function handleInputImageLoad(e: Event) {
     const img = e.target as HTMLImageElement
-    const widthWidget = getWidgetByName('width')
-    const heightWidget = getWidgetByName('height')
-    if (widthWidget) {
-      widthWidget.value = img.naturalWidth
-      widthWidget.callback?.(img.naturalWidth)
-    }
-    if (heightWidget) {
-      heightWidget.value = img.naturalHeight
-      heightWidget.callback?.(img.naturalHeight)
-    }
+    setWidgetValue('width', img.naturalWidth)
+    setWidgetValue('height', img.naturalHeight)
     canvasWidth.value = img.naturalWidth
     canvasHeight.value = img.naturalHeight
   }

--- a/src/composables/useCameraInfo.test.ts
+++ b/src/composables/useCameraInfo.test.ts
@@ -1,8 +1,13 @@
-import { ref } from 'vue'
-import type { Ref } from 'vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { nextTick, shallowRef } from 'vue'
 
 import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
+import { useWidgetValueStore } from '@/stores/widgetValueStore'
+import { toNodeId } from '@/types/nodeId'
+import type { NodeId } from '@/types/nodeId'
+import { widgetId } from '@/types/widgetId'
+import { createMockLGraphNode } from '@/utils/__tests__/litegraphTestUtils'
+import { fromPartial } from '@total-typescript/shoehorn'
 
 interface ViewportInstance {
   ctorArgs: unknown[]
@@ -11,6 +16,7 @@ interface ViewportInstance {
   setTransformGizmoMode: ReturnType<typeof vi.fn>
   setLookThrough: ReturnType<typeof vi.fn>
   remove: ReturnType<typeof vi.fn>
+  overlay: { getState: ReturnType<typeof vi.fn> }
   viewport: {
     updateStatusMouseOnScene: ReturnType<typeof vi.fn>
     updateStatusMouseOnNode: ReturnType<typeof vi.fn>
@@ -28,6 +34,7 @@ const { ViewportMock, instances, addAlert } = vi.hoisted(() => {
       setTransformGizmoMode: vi.fn(),
       setLookThrough: vi.fn(),
       remove: vi.fn(),
+      overlay: { getState: vi.fn(() => null) },
       viewport: {
         updateStatusMouseOnScene: vi.fn(),
         updateStatusMouseOnNode: vi.fn(),
@@ -49,32 +56,36 @@ vi.mock('@/platform/updates/common/toastStore', () => ({
 
 import { useCameraInfo } from './useCameraInfo'
 
-interface FakeWidget {
-  name: string
-  value: unknown
-  callback?: (value: unknown, ...rest: unknown[]) => void
+const GRAPH_ID = 'use-camera-info-test-graph'
+
+let nodeCounter = 0
+
+function makeNode(values: Record<string, unknown> = {}): LGraphNode {
+  nodeCounter += 1
+  const nodeId = toNodeId(nodeCounter)
+  registerValues(nodeId, values)
+  return createMockLGraphNode({
+    id: nodeId,
+    graph: { rootGraph: { id: GRAPH_ID } }
+  })
 }
 
-interface FakeNode {
-  widgets: FakeWidget[]
-  onMouseEnter?: () => void
-  onMouseLeave?: () => void
-}
-
-function makeNode(values: Record<string, unknown>): FakeNode {
-  return {
-    widgets: Object.entries(values).map(([name, value]) => ({ name, value }))
+function registerValues(nodeId: NodeId, values: Record<string, unknown>): void {
+  const store = useWidgetValueStore()
+  for (const [name, value] of Object.entries(values)) {
+    store.registerWidget(widgetId(GRAPH_ID, nodeId, name), {
+      type: typeof value === 'number' ? 'number' : 'combo',
+      value: value as never,
+      options: {}
+    })
   }
 }
 
-function widget(node: FakeNode, name: string): FakeWidget {
-  const found = node.widgets.find((w) => w.name === name)
-  if (!found) throw new Error(`missing widget ${name}`)
-  return found
-}
-
-function nodeRef(node: FakeNode) {
-  return ref(node) as unknown as Ref<LGraphNode | null>
+function setValue(node: LGraphNode, name: string, value: unknown): void {
+  useWidgetValueStore().setValue(
+    widgetId(GRAPH_ID, node.id, name),
+    value as never
+  )
 }
 
 beforeEach(() => {
@@ -87,7 +98,7 @@ describe('useCameraInfo', () => {
   it('constructs the viewport from widget state and exposes the mode', () => {
     const node = makeNode({ mode: 'look_at', 'mode.distance': 7 })
     const container = document.createElement('div')
-    const camera = useCameraInfo(nodeRef(node))
+    const camera = useCameraInfo(shallowRef<LGraphNode | null>(node))
 
     camera.initialize(container)
 
@@ -103,7 +114,7 @@ describe('useCameraInfo', () => {
   })
 
   it('does nothing when the node is null', () => {
-    const camera = useCameraInfo(ref(null))
+    const camera = useCameraInfo(shallowRef<LGraphNode | null>(null))
     camera.initialize(document.createElement('div'))
 
     expect(ViewportMock).not.toHaveBeenCalled()
@@ -114,7 +125,9 @@ describe('useCameraInfo', () => {
       throw new Error('webgl unavailable')
     })
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
-    const camera = useCameraInfo(nodeRef(makeNode({ mode: 'orbit' })))
+    const camera = useCameraInfo(
+      shallowRef<LGraphNode | null>(makeNode({ mode: 'orbit' }))
+    )
 
     expect(() => camera.initialize(document.createElement('div'))).not.toThrow()
     expect(addAlert).toHaveBeenCalledOnce()
@@ -123,7 +136,9 @@ describe('useCameraInfo', () => {
   })
 
   it('forwards toolbar actions to the viewport', () => {
-    const camera = useCameraInfo(nodeRef(makeNode({ mode: 'orbit' })))
+    const camera = useCameraInfo(
+      shallowRef<LGraphNode | null>(makeNode({ mode: 'orbit' }))
+    )
     camera.initialize(document.createElement('div'))
 
     camera.setGizmosVisible(false)
@@ -137,44 +152,69 @@ describe('useCameraInfo', () => {
     expect(instances[0].setLookThrough).toHaveBeenCalledWith(true)
   })
 
-  it('re-applies state to the viewport when a widget changes, keeping the original callback', () => {
+  it('re-applies state to the viewport when a store value changes', async () => {
     const node = makeNode({ mode: 'orbit', target_x: 0 })
-    const original = vi.fn()
-    widget(node, 'target_x').callback = original
-    const camera = useCameraInfo(nodeRef(node))
+    const camera = useCameraInfo(shallowRef<LGraphNode | null>(node))
     camera.initialize(document.createElement('div'))
 
-    const targetX = widget(node, 'target_x')
-    targetX.value = 3
-    targetX.callback!(3)
+    setValue(node, 'target_x', 3)
+    await nextTick()
 
-    expect(original).toHaveBeenCalledWith(3)
     const applied = instances[0].applyState.mock.lastCall?.[0] as {
       target: { x: number }
     }
     expect(applied.target.x).toBe(3)
   })
 
-  it('updates the mode ref when the mode widget changes', () => {
+  it('skips re-applying state the viewport already holds', async () => {
+    const node = makeNode({ mode: 'orbit', target_x: 0 })
+    const camera = useCameraInfo(shallowRef<LGraphNode | null>(node))
+    camera.initialize(document.createElement('div'))
+    instances[0].overlay.getState.mockImplementation(() => ({
+      ...(instances[0].ctorArgs[1] as object),
+      target: { x: 3, y: 0, z: 0 }
+    }))
+
+    setValue(node, 'target_x', 3)
+    await nextTick()
+
+    expect(instances[0].applyState).not.toHaveBeenCalled()
+  })
+
+  it('updates the exposed mode when the mode widget changes', async () => {
     const node = makeNode({ mode: 'orbit' })
-    const camera = useCameraInfo(nodeRef(node))
+    const camera = useCameraInfo(shallowRef<LGraphNode | null>(node))
     camera.initialize(document.createElement('div'))
 
-    const modeWidget = widget(node, 'mode')
-    modeWidget.value = 'quaternion'
-    modeWidget.callback!('quaternion')
+    setValue(node, 'mode', 'quaternion')
+    await nextTick()
 
     expect(camera.mode.value).toBe('quaternion')
   })
 
+  it('picks up widgets registered after initialization (mode switch)', async () => {
+    const node = makeNode({ mode: 'orbit' })
+    const camera = useCameraInfo(shallowRef<LGraphNode | null>(node))
+    camera.initialize(document.createElement('div'))
+
+    setValue(node, 'mode', 'quaternion')
+    registerValues(node.id, { 'mode.quat_w': 0.5 })
+    await nextTick()
+
+    const applied = instances[0].applyState.mock.lastCall?.[0] as {
+      quaternion: { quat: { w: number } }
+    }
+    expect(applied.quaternion.quat.w).toBe(0.5)
+  })
+
   it('routes node hover into the viewport status flags', () => {
     const node = makeNode({ mode: 'orbit' })
-    const camera = useCameraInfo(nodeRef(node))
+    const camera = useCameraInfo(shallowRef<LGraphNode | null>(node))
     camera.initialize(document.createElement('div'))
 
     camera.handleMouseEnter()
     camera.handleMouseLeave()
-    node.onMouseEnter?.()
+    node.onMouseEnter?.(fromPartial({}))
 
     expect(instances[0].viewport.updateStatusMouseOnScene).toHaveBeenCalledWith(
       true
@@ -187,17 +227,17 @@ describe('useCameraInfo', () => {
     )
   })
 
-  it('removes the viewport and restores widget callbacks on cleanup', () => {
+  it('removes the viewport and stops applying store changes on cleanup', async () => {
     const node = makeNode({ mode: 'orbit', target_x: 0 })
-    const original = vi.fn()
-    widget(node, 'target_x').callback = original
-    const camera = useCameraInfo(nodeRef(node))
+    const camera = useCameraInfo(shallowRef<LGraphNode | null>(node))
     camera.initialize(document.createElement('div'))
 
     camera.cleanup()
+    setValue(node, 'target_x', 5)
+    await nextTick()
 
     expect(instances[0].remove).toHaveBeenCalledOnce()
-    expect(widget(node, 'target_x').callback).toBe(original)
+    expect(instances[0].applyState).not.toHaveBeenCalled()
   })
 
   it('restores the node mouse handlers on cleanup', () => {
@@ -206,7 +246,7 @@ describe('useCameraInfo', () => {
     const originalLeave = vi.fn()
     node.onMouseEnter = originalEnter
     node.onMouseLeave = originalLeave
-    const camera = useCameraInfo(nodeRef(node))
+    const camera = useCameraInfo(shallowRef<LGraphNode | null>(node))
     camera.initialize(document.createElement('div'))
 
     expect(node.onMouseEnter).not.toBe(originalEnter)
@@ -217,16 +257,15 @@ describe('useCameraInfo', () => {
     expect(node.onMouseLeave).toBe(originalLeave)
   })
 
-  it('re-wires widgets on a second initialize after cleanup', () => {
+  it('applies store changes to the new viewport after re-initialization', async () => {
     const node = makeNode({ mode: 'orbit', target_x: 0 })
-    const camera = useCameraInfo(nodeRef(node))
+    const camera = useCameraInfo(shallowRef<LGraphNode | null>(node))
     camera.initialize(document.createElement('div'))
     camera.cleanup()
     camera.initialize(document.createElement('div'))
 
-    const targetX = widget(node, 'target_x')
-    targetX.value = 5
-    targetX.callback!(5)
+    setValue(node, 'target_x', 5)
+    await nextTick()
 
     expect(instances).toHaveLength(2)
     expect(instances[1].applyState).toHaveBeenCalled()

--- a/src/composables/useCameraInfo.ts
+++ b/src/composables/useCameraInfo.ts
@@ -1,61 +1,32 @@
-import { computed, ref, toRaw, toRef } from 'vue'
+import { isEqual } from 'es-toolkit'
+import { computed, toRaw, toValue, watch } from 'vue'
 import type { MaybeRef } from 'vue'
 
 import { useChainCallback } from '@/composables/functional/useChainCallback'
 import { CameraInfoViewport } from '@/extensions/core/cameraInfo/CameraInfoViewport'
 import type { TransformGizmoMode } from '@/extensions/core/cameraInfo/CameraInfoViewport'
-import { DEFAULT_CAMERA_INFO_STATE } from '@/extensions/core/cameraInfo/types'
-import type { CameraInfoState } from '@/extensions/core/cameraInfo/types'
 import {
-  readStateFromWidgets,
-  writeWidgetValue
+  readCameraInfoState,
+  writeCameraInfoValue
 } from '@/extensions/core/cameraInfo/widgetBridge'
-import type { NodeWithWidgets } from '@/extensions/core/cameraInfo/widgetBridge'
 import { t } from '@/i18n'
 import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
 import { useToastStore } from '@/platform/updates/common/toastStore'
 
-type WidgetCallback = (value: unknown, ...rest: unknown[]) => void
-interface MutableWidget {
-  name: string
-  value: unknown
-  callback?: WidgetCallback
-}
-
-const WIDGET_NAMES = [
-  'mode',
-  'camera_type',
-  'target_x',
-  'target_y',
-  'target_z',
-  'roll',
-  'fov',
-  'zoom',
-  'mode.yaw',
-  'mode.pitch',
-  'mode.distance',
-  'mode.position_x',
-  'mode.position_y',
-  'mode.position_z',
-  'mode.quat_x',
-  'mode.quat_y',
-  'mode.quat_z',
-  'mode.quat_w'
-] as const
-
 export function useCameraInfo(nodeRef: MaybeRef<LGraphNode | null>) {
-  const node = toRef(nodeRef)
+  const node = computed(() => toValue(nodeRef))
   let viewport: CameraInfoViewport | null = null
   let wiredNode: LGraphNode | null = null
   let originalOnMouseEnter: LGraphNode['onMouseEnter']
   let originalOnMouseLeave: LGraphNode['onMouseLeave']
 
-  const cameraState = ref<CameraInfoState>(DEFAULT_CAMERA_INFO_STATE)
+  const cameraState = computed(() => readCameraInfoState(toRaw(node.value)))
   const mode = computed(() => cameraState.value.mode)
 
-  const wrappedWidgets: { widget: MutableWidget; original?: WidgetCallback }[] =
-    []
-  const wrappedSet = new WeakSet<MutableWidget>()
+  watch(cameraState, (state) => {
+    if (!viewport || isEqual(state, viewport.overlay.getState())) return
+    viewport.applyState(state)
+  })
 
   const initialize = (container: HTMLElement): void => {
     const raw = toRaw(node.value)
@@ -63,15 +34,12 @@ export function useCameraInfo(nodeRef: MaybeRef<LGraphNode | null>) {
     if (viewport) cleanup()
 
     try {
-      const initialState = readStateFromWidgets(raw as NodeWithWidgets)
-      cameraState.value = initialState
-      viewport = new CameraInfoViewport(container, initialState, {
+      viewport = new CameraInfoViewport(container, cameraState.value, {
         onHandleDrag: (fieldName, value) => {
-          writeWidgetValue(raw as NodeWithWidgets, fieldName, value)
+          writeCameraInfoValue(toRaw(node.value), fieldName, value)
         }
       })
-      wireWidgetsToOverlay(raw as NodeWithWidgets)
-      wireNodeMouseStatus(raw as LGraphNode)
+      wireNodeMouseStatus(raw)
     } catch (error) {
       console.error('Failed to initialize CameraInfoViewport:', error)
       cleanup()
@@ -82,7 +50,6 @@ export function useCameraInfo(nodeRef: MaybeRef<LGraphNode | null>) {
   }
 
   const cleanup = (): void => {
-    unwireWidgets()
     unwireNodeMouseStatus()
     viewport?.remove()
     viewport = null
@@ -127,36 +94,6 @@ export function useCameraInfo(nodeRef: MaybeRef<LGraphNode | null>) {
     wiredNode.onMouseEnter = originalOnMouseEnter
     wiredNode.onMouseLeave = originalOnMouseLeave
     wiredNode = null
-  }
-
-  function wireWidgetsToOverlay(target: NodeWithWidgets): void {
-    if (!target.widgets) return
-    for (const name of WIDGET_NAMES) {
-      const widget = target.widgets.find(
-        (w): w is MutableWidget => w.name === name
-      )
-      if (!widget || wrappedSet.has(widget)) continue
-      wrappedSet.add(widget)
-      const original = widget.callback
-      const isModeWidget = widget.name === 'mode'
-      wrappedWidgets.push({ widget, original })
-      widget.callback = (value, ...rest) => {
-        original?.call(widget, value, ...rest)
-        if (isModeWidget) wireWidgetsToOverlay(target)
-        if (!viewport) return
-        const state = readStateFromWidgets(target)
-        cameraState.value = state
-        viewport.applyState(state)
-      }
-    }
-  }
-
-  function unwireWidgets(): void {
-    for (const { widget, original } of wrappedWidgets) {
-      widget.callback = original
-      wrappedSet.delete(widget)
-    }
-    wrappedWidgets.length = 0
   }
 
   return {

--- a/src/extensions/core/cameraInfo/widgetBridge.test.ts
+++ b/src/extensions/core/cameraInfo/widgetBridge.test.ts
@@ -1,24 +1,58 @@
-import { describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { useWidgetValueStore } from '@/stores/widgetValueStore'
+import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
+import { toNodeId } from '@/types/nodeId'
+import { widgetId } from '@/types/widgetId'
+import { createMockLGraphNode } from '@/utils/__tests__/litegraphTestUtils'
 
 import { DEFAULT_CAMERA_INFO_STATE } from './types'
-import { readStateFromWidgets, writeWidgetValue } from './widgetBridge'
-import type { NodeWithWidgets } from './widgetBridge'
+import { readCameraInfoState, writeCameraInfoValue } from './widgetBridge'
 
-function nodeWithWidgets(
+const GRAPH_ID = 'camera-info-test-graph'
+
+let nodeCounter = 0
+
+function makeScope(): LGraphNode {
+  nodeCounter += 1
+  return createMockLGraphNode({
+    id: toNodeId(nodeCounter),
+    graph: { rootGraph: { id: GRAPH_ID } }
+  })
+}
+
+function registerValues(
+  scope: LGraphNode,
   values: Record<string, unknown>
-): NodeWithWidgets & { widgets: { name: string; value: unknown }[] } {
-  return {
-    widgets: Object.entries(values).map(([name, value]) => ({ name, value }))
+): void {
+  const store = useWidgetValueStore()
+  for (const [name, value] of Object.entries(values)) {
+    store.registerWidget(widgetId(GRAPH_ID, scope.id, name), {
+      type: typeof value === 'number' ? 'number' : 'combo',
+      value: value as never,
+      options: {}
+    })
   }
 }
 
-describe('readStateFromWidgets', () => {
-  it('returns defaults when the node has no widgets at all', () => {
-    expect(readStateFromWidgets({})).toEqual(DEFAULT_CAMERA_INFO_STATE)
+function storedValue(scope: LGraphNode, name: string): unknown {
+  return useWidgetValueStore().getWidget(widgetId(GRAPH_ID, scope.id, name))
+    ?.value
+}
+
+let scope: LGraphNode
+
+beforeEach(() => {
+  scope = makeScope()
+})
+
+describe('readCameraInfoState', () => {
+  it('returns defaults when no widgets are registered for the node', () => {
+    expect(readCameraInfoState(scope)).toEqual(DEFAULT_CAMERA_INFO_STATE)
   })
 
   it('reads each widget by name (orbit-mode example)', () => {
-    const node = nodeWithWidgets({
+    registerValues(scope, {
       mode: 'orbit',
       target_x: 1,
       target_y: 2,
@@ -32,7 +66,7 @@ describe('readStateFromWidgets', () => {
       'mode.distance': 7
     })
 
-    const state = readStateFromWidgets(node)
+    const state = readCameraInfoState(scope)
 
     expect(state.mode).toBe('orbit')
     expect(state.target).toEqual({ x: 1, y: 2, z: 3 })
@@ -43,7 +77,7 @@ describe('readStateFromWidgets', () => {
   })
 
   it('reads the orthographic camera type and quaternion-mode fields', () => {
-    const node = nodeWithWidgets({
+    registerValues(scope, {
       mode: 'quaternion',
       camera_type: 'orthographic',
       'mode.position_x': 1,
@@ -55,7 +89,7 @@ describe('readStateFromWidgets', () => {
       'mode.quat_w': 1
     })
 
-    const state = readStateFromWidgets(node)
+    const state = readCameraInfoState(scope)
 
     expect(state.cameraType).toBe('orthographic')
     expect(state.mode).toBe('quaternion')
@@ -64,13 +98,13 @@ describe('readStateFromWidgets', () => {
   })
 
   it('falls back when a widget value has the wrong type', () => {
-    const node = nodeWithWidgets({
+    registerValues(scope, {
       fov: 'not-a-number',
       mode: 'invalid-mode',
       camera_type: 42
     })
 
-    const state = readStateFromWidgets(node)
+    const state = readCameraInfoState(scope)
 
     expect(state.fov).toBe(DEFAULT_CAMERA_INFO_STATE.fov)
     expect(state.mode).toBe(DEFAULT_CAMERA_INFO_STATE.mode)
@@ -78,54 +112,44 @@ describe('readStateFromWidgets', () => {
   })
 
   it('rejects non-finite numbers (NaN / Infinity)', () => {
-    const node = nodeWithWidgets({
+    registerValues(scope, {
       'mode.yaw': Number.NaN,
       'mode.distance': Number.POSITIVE_INFINITY
     })
 
-    const state = readStateFromWidgets(node)
+    const state = readCameraInfoState(scope)
 
     expect(state.orbit.yaw).toBe(DEFAULT_CAMERA_INFO_STATE.orbit.yaw)
     expect(state.orbit.distance).toBe(DEFAULT_CAMERA_INFO_STATE.orbit.distance)
   })
 
-  it('reads quaternion mode widgets', () => {
-    const node = nodeWithWidgets({
-      mode: 'quaternion',
-      'mode.position_x': 1,
-      'mode.position_y': 2,
-      'mode.position_z': 3,
-      'mode.quat_x': 0,
-      'mode.quat_y': 0,
-      'mode.quat_z': 0,
-      'mode.quat_w': 1
-    })
+  it('does not read a same-named widget from another node', () => {
+    const other = makeScope()
+    registerValues(other, { fov: 99 })
 
-    const state = readStateFromWidgets(node)
-
-    expect(state.mode).toBe('quaternion')
-    expect(state.quaternion.position).toEqual({ x: 1, y: 2, z: 3 })
-    expect(state.quaternion.quat).toEqual({ x: 0, y: 0, z: 0, w: 1 })
+    expect(readCameraInfoState(scope).fov).toBe(DEFAULT_CAMERA_INFO_STATE.fov)
   })
 })
 
-describe('writeWidgetValue', () => {
+describe('writeCameraInfoValue', () => {
   it('updates the named widget when the value differs', () => {
-    const node = nodeWithWidgets({ 'mode.yaw': 0 })
-    writeWidgetValue(node, 'mode.yaw', 45)
-    expect(node.widgets.find((w) => w.name === 'mode.yaw')!.value).toBe(45)
+    registerValues(scope, { 'mode.yaw': 0 })
+
+    writeCameraInfoValue(scope, 'mode.yaw', 45)
+
+    expect(storedValue(scope, 'mode.yaw')).toBe(45)
   })
 
   it('is a no-op when the value already matches', () => {
-    const node = nodeWithWidgets({ fov: 35 })
-    const before = node.widgets[0].value
-    writeWidgetValue(node, 'fov', 35)
-    expect(node.widgets[0].value).toBe(before)
+    registerValues(scope, { fov: 35 })
+
+    writeCameraInfoValue(scope, 'fov', 35)
+
+    expect(storedValue(scope, 'fov')).toBe(35)
   })
 
-  it('is a no-op when the widget does not exist', () => {
-    const node = nodeWithWidgets({ fov: 35 })
-    expect(() => writeWidgetValue(node, 'does_not_exist', 1)).not.toThrow()
-    expect(node.widgets).toHaveLength(1)
+  it('does not create state for an unregistered widget', () => {
+    expect(() => writeCameraInfoValue(scope, 'does_not_exist', 1)).not.toThrow()
+    expect(storedValue(scope, 'does_not_exist')).toBeUndefined()
   })
 })

--- a/src/extensions/core/cameraInfo/widgetBridge.ts
+++ b/src/extensions/core/cameraInfo/widgetBridge.ts
@@ -1,18 +1,15 @@
+import {
+  nodeWidgetValue,
+  setNodeWidgetValue
+} from '@/composables/node/widgetStoreSync'
+import type { WidgetNode } from '@/composables/node/widgetStoreSync'
+
 import { DEFAULT_CAMERA_INFO_STATE } from './types'
 import type {
   CameraInfoCameraType,
   CameraInfoMode,
   CameraInfoState
 } from './types'
-
-interface WidgetLike {
-  name: string
-  value: unknown
-}
-
-export interface NodeWithWidgets {
-  widgets?: WidgetLike[]
-}
 
 const VALID_MODES: readonly CameraInfoMode[] = [
   'orbit',
@@ -24,34 +21,27 @@ const VALID_CAMERA_TYPES: readonly CameraInfoCameraType[] = [
   'orthographic'
 ]
 
-function widgetByName(
-  node: NodeWithWidgets,
-  name: string
-): WidgetLike | undefined {
-  return node.widgets?.find((w) => w.name === name)
-}
-
-function num(node: NodeWithWidgets, name: string, fallback: number): number {
-  const v = widgetByName(node, name)?.value
+function num(node: WidgetNode, name: string, fallback: number): number {
+  const v = nodeWidgetValue(node, name)
   return typeof v === 'number' && Number.isFinite(v) ? v : fallback
 }
 
-function pickMode(node: NodeWithWidgets): CameraInfoMode {
-  const v = widgetByName(node, 'mode')?.value
+function pickMode(node: WidgetNode): CameraInfoMode {
+  const v = nodeWidgetValue(node, 'mode')
   return typeof v === 'string' && (VALID_MODES as readonly string[]).includes(v)
     ? (v as CameraInfoMode)
     : DEFAULT_CAMERA_INFO_STATE.mode
 }
 
-function pickCameraType(node: NodeWithWidgets): CameraInfoCameraType {
-  const v = widgetByName(node, 'camera_type')?.value
+function pickCameraType(node: WidgetNode): CameraInfoCameraType {
+  const v = nodeWidgetValue(node, 'camera_type')
   return typeof v === 'string' &&
     (VALID_CAMERA_TYPES as readonly string[]).includes(v)
     ? (v as CameraInfoCameraType)
     : DEFAULT_CAMERA_INFO_STATE.cameraType
 }
 
-export function readStateFromWidgets(node: NodeWithWidgets): CameraInfoState {
+export function readCameraInfoState(node: WidgetNode): CameraInfoState {
   const d = DEFAULT_CAMERA_INFO_STATE
   return {
     mode: pickMode(node),
@@ -92,12 +82,10 @@ export function readStateFromWidgets(node: NodeWithWidgets): CameraInfoState {
   }
 }
 
-export function writeWidgetValue(
-  node: NodeWithWidgets,
+export function writeCameraInfoValue(
+  node: WidgetNode,
   name: string,
   value: number | string
 ): void {
-  const widget = widgetByName(node, name)
-  if (!widget || widget.value === value) return
-  widget.value = value
+  setNodeWidgetValue(node, name, value)
 }

--- a/src/extensions/core/imageCompare.ts
+++ b/src/extensions/core/imageCompare.ts
@@ -40,7 +40,6 @@ useExtensionService().registerExtension({
 
       if (widget) {
         widget.value = { beforeImages, afterImages }
-        widget.callback?.(widget.value)
       }
     }
   }

--- a/src/extensions/core/load3d.test.ts
+++ b/src/extensions/core/load3d.test.ts
@@ -348,6 +348,7 @@ describe('Comfy.Preview3D.nodeCreated', () => {
     await preview3DExt.nodeCreated(node)
 
     expect(configureMock).toHaveBeenCalledWith({
+      node,
       loadFolder: 'output',
       modelWidget: expect.objectContaining({ value: 'prev/model.glb' }),
       cameraState,

--- a/src/extensions/core/load3d.ts
+++ b/src/extensions/core/load3d.ts
@@ -19,7 +19,9 @@ import type {
   Model3DInfo
 } from '@/extensions/core/load3d/interfaces'
 import type Load3d from '@/extensions/core/load3d/Load3d'
-import Load3DConfiguration from '@/extensions/core/load3d/Load3DConfiguration'
+import Load3DConfiguration, {
+  wireTargetSizeSync
+} from '@/extensions/core/load3d/Load3DConfiguration'
 import {
   LOAD3D_NONE_MODEL,
   SUPPORTED_EXTENSIONS_ACCEPT
@@ -395,6 +397,7 @@ useExtensionService().registerExtension({
 
       const config = new Load3DConfiguration(load3d, node.properties)
       config.configure({
+        node,
         loadFolder: 'input',
         modelWidget,
         cameraState,
@@ -498,6 +501,7 @@ function applyPreview3DOutput(
   useLoad3d(node).waitForLoad3d((load3d) => {
     const config = new Load3DConfiguration(load3d, node.properties)
     config.configure({
+      node,
       loadFolder: 'output',
       modelWidget,
       cameraState,
@@ -611,6 +615,7 @@ useExtensionService().registerExtension({
 
       const config = new Load3DConfiguration(load3d, node.properties)
       config.configure({
+        node,
         loadFolder: 'output',
         modelWidget,
         cameraState,
@@ -647,6 +652,7 @@ useExtensionService().registerExtension({
           node.properties['Last Time Model File'] = modelFilePath
 
           const settings = {
+            node,
             loadFolder: 'output',
             modelWidget: modelWidget,
             cameraState: cameraState,
@@ -823,12 +829,7 @@ function createPreview3DAdvancedExtension(
             widthWidget.value as number,
             heightWidget.value as number
           )
-          widthWidget.callback = (value: number) => {
-            resolveLoad3d().setTargetSize(value, heightWidget.value as number)
-          }
-          heightWidget.callback = (value: number) => {
-            resolveLoad3d().setTargetSize(widthWidget.value as number, value)
-          }
+          wireTargetSizeSync(node, resolveLoad3d)
         }
 
         sceneWidget.serializeValue = async () => {

--- a/src/extensions/core/load3d/Load3DConfiguration.test.ts
+++ b/src/extensions/core/load3d/Load3DConfiguration.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { nextTick } from 'vue'
 
 import type Load3d from '@/extensions/core/load3d/Load3d'
 import Load3DConfiguration, {
@@ -14,7 +15,11 @@ import type {
 } from '@/extensions/core/load3d/interfaces'
 import type { IBaseWidget } from '@/lib/litegraph/src/types/widgets'
 import type { Dictionary } from '@/lib/litegraph/src/interfaces'
-import type { NodeProperty } from '@/lib/litegraph/src/LGraphNode'
+import type { LGraphNode, NodeProperty } from '@/lib/litegraph/src/LGraphNode'
+import { useWidgetValueStore } from '@/stores/widgetValueStore'
+import { toNodeId } from '@/types/nodeId'
+import { widgetId } from '@/types/widgetId'
+import { createMockLGraphNode } from '@/utils/__tests__/litegraphTestUtils'
 
 const { settingsGetMock } = vi.hoisted(() => ({
   settingsGetMock: vi.fn()
@@ -58,6 +63,36 @@ type WithPrivate = {
 function createConfig(properties?: Dictionary<NodeProperty | undefined>) {
   const load3d = {} as Load3d
   return new Load3DConfiguration(load3d, properties) as unknown as WithPrivate
+}
+
+const GRAPH_ID = 'load3d-config-test'
+let nodeSeq = 0
+
+function makeNode(): LGraphNode {
+  return createMockLGraphNode({
+    id: toNodeId(++nodeSeq),
+    graph: { rootGraph: { id: GRAPH_ID } }
+  })
+}
+
+function registerNodeWidget(
+  node: LGraphNode,
+  name: string,
+  value: string | number
+) {
+  useWidgetValueStore().registerWidget(widgetId(GRAPH_ID, node.id, name), {
+    type: typeof value === 'number' ? 'number' : 'string',
+    value,
+    options: {}
+  })
+}
+
+function setNodeWidgetValue(
+  node: LGraphNode,
+  name: string,
+  value: string | number
+) {
+  useWidgetValueStore().setValue(widgetId(GRAPH_ID, node.id, name), value)
 }
 
 function stubSettings(values: Record<string, unknown>) {
@@ -243,7 +278,11 @@ describe('Load3DConfiguration.silentOnNotFound propagation', () => {
   it('configure forwards silentOnNotFound: true from settings to loadModel', async () => {
     const config = new Load3DConfiguration(makeLoad3dMock())
     config.configure({
-      modelWidget: { value: 'model.glb' } as unknown as IBaseWidget,
+      node: makeNode(),
+      modelWidget: {
+        name: 'model_file',
+        value: 'model.glb'
+      } as unknown as IBaseWidget,
       loadFolder: 'output',
       silentOnNotFound: true
     })
@@ -256,7 +295,11 @@ describe('Load3DConfiguration.silentOnNotFound propagation', () => {
   it('configure uses silentOnNotFound: false when setting is omitted', async () => {
     const config = new Load3DConfiguration(makeLoad3dMock())
     config.configure({
-      modelWidget: { value: 'model.glb' } as unknown as IBaseWidget,
+      node: makeNode(),
+      modelWidget: {
+        name: 'model_file',
+        value: 'model.glb'
+      } as unknown as IBaseWidget,
       loadFolder: 'output'
     })
     await flush()
@@ -275,7 +318,11 @@ describe('Load3DConfiguration.silentOnNotFound propagation', () => {
       cameraType: 'perspective' as const
     }
     config.configure({
-      modelWidget: { value: 'model.glb' } as unknown as IBaseWidget,
+      node: makeNode(),
+      modelWidget: {
+        name: 'model_file',
+        value: 'model.glb'
+      } as unknown as IBaseWidget,
       loadFolder: 'output',
       cameraState: cameraState as unknown as Parameters<
         Load3DConfiguration['configure']
@@ -296,7 +343,11 @@ describe('Load3DConfiguration.silentOnNotFound propagation', () => {
     const load3d = makeLoad3dMock()
     const config = new Load3DConfiguration(load3d)
     config.configure({
-      modelWidget: { value: 'model.glb' } as unknown as IBaseWidget,
+      node: makeNode(),
+      modelWidget: {
+        name: 'model_file',
+        value: 'model.glb'
+      } as unknown as IBaseWidget,
       loadFolder: 'output'
     })
     await flush()
@@ -514,7 +565,11 @@ describe('Load3DConfiguration.configure forwards persisted + settings to load3d'
 
     const config = new Load3DConfiguration(load3d)
     config.configure({
-      modelWidget: { value: 'model.glb' } as unknown as IBaseWidget,
+      node: makeNode(),
+      modelWidget: {
+        name: 'model_file',
+        value: 'model.glb'
+      } as unknown as IBaseWidget,
       loadFolder: 'output'
     })
     await flush()
@@ -545,7 +600,11 @@ describe('Load3DConfiguration.configure forwards persisted + settings to load3d'
 
     const config = new Load3DConfiguration(load3d, properties)
     config.configure({
-      modelWidget: { value: 'model.glb' } as unknown as IBaseWidget,
+      node: makeNode(),
+      modelWidget: {
+        name: 'model_file',
+        value: 'model.glb'
+      } as unknown as IBaseWidget,
       loadFolder: 'output'
     })
     await flush()
@@ -600,7 +659,11 @@ describe('Load3DConfiguration "none" model handling', () => {
   it('does not load or clear a model when the initial widget value is "none"', async () => {
     const config = new Load3DConfiguration(load3d)
     config.configure({
-      modelWidget: { value: 'none' } as unknown as IBaseWidget,
+      node: makeNode(),
+      modelWidget: {
+        name: 'model_file',
+        value: 'none'
+      } as unknown as IBaseWidget,
       loadFolder: 'input'
     })
     await flush()
@@ -611,14 +674,20 @@ describe('Load3DConfiguration "none" model handling', () => {
 
   it('clears the model (and skips loadModel) when the widget value changes to "none"', async () => {
     const config = new Load3DConfiguration(load3d)
-    const widget = { value: 'model.glb' } as unknown as IBaseWidget
-    config.configure({ modelWidget: widget, loadFolder: 'input' })
+    const node = makeNode()
+    registerNodeWidget(node, 'model_file', 'model.glb')
+    const widget = {
+      name: 'model_file',
+      value: 'model.glb'
+    } as unknown as IBaseWidget
+    config.configure({ node, modelWidget: widget, loadFolder: 'input' })
     await flush()
 
     loadModelSpy.mockClear()
     clearModelSpy.mockClear()
 
-    widget.value = 'none'
+    setNodeWidgetValue(node, 'model_file', 'none')
+    await nextTick()
     await flush()
 
     expect(clearModelSpy).toHaveBeenCalledTimes(1)
@@ -627,13 +696,19 @@ describe('Load3DConfiguration "none" model handling', () => {
 
   it('loads a model when the widget value transitions from "none" to a real path', async () => {
     const config = new Load3DConfiguration(load3d)
-    const widget = { value: 'none' } as unknown as IBaseWidget
-    config.configure({ modelWidget: widget, loadFolder: 'input' })
+    const node = makeNode()
+    registerNodeWidget(node, 'model_file', 'none')
+    const widget = {
+      name: 'model_file',
+      value: 'none'
+    } as unknown as IBaseWidget
+    config.configure({ node, modelWidget: widget, loadFolder: 'input' })
     await flush()
 
     expect(loadModelSpy).not.toHaveBeenCalled()
 
-    widget.value = 'model.glb'
+    setNodeWidgetValue(node, 'model_file', 'model.glb')
+    await nextTick()
     await flush()
 
     expect(loadModelSpy).toHaveBeenCalledWith(expect.any(String), 'model.glb', {
@@ -674,14 +749,21 @@ describe('Load3DConfiguration.onSceneInvalidated', () => {
     vi.mocked(Load3dUtils.getResourceURL).mockReturnValue('/view')
   })
 
-  it('width.callback invokes onSceneInvalidated', async () => {
+  it('a width change via the store invokes onSceneInvalidated', async () => {
     const onSceneInvalidated = vi.fn()
-    const width = { value: 1024 } as unknown as IBaseWidget
-    const height = { value: 1024 } as unknown as IBaseWidget
+    const node = makeNode()
+    registerNodeWidget(node, 'width', 1024)
+    registerNodeWidget(node, 'height', 1024)
+    const width = { name: 'width', value: 1024 } as unknown as IBaseWidget
+    const height = { name: 'height', value: 1024 } as unknown as IBaseWidget
     const config = new Load3DConfiguration(makeLoad3dMock())
 
     config.configure({
-      modelWidget: { value: 'none' } as unknown as IBaseWidget,
+      node,
+      modelWidget: {
+        name: 'model_file',
+        value: 'none'
+      } as unknown as IBaseWidget,
       loadFolder: 'input',
       width,
       height,
@@ -689,19 +771,27 @@ describe('Load3DConfiguration.onSceneInvalidated', () => {
     })
     await flush()
 
-    width.callback!(2048)
+    setNodeWidgetValue(node, 'width', 2048)
+    await nextTick()
 
     expect(onSceneInvalidated).toHaveBeenCalledTimes(1)
   })
 
-  it('height.callback invokes onSceneInvalidated', async () => {
+  it('a height change via the store invokes onSceneInvalidated', async () => {
     const onSceneInvalidated = vi.fn()
-    const width = { value: 1024 } as unknown as IBaseWidget
-    const height = { value: 1024 } as unknown as IBaseWidget
+    const node = makeNode()
+    registerNodeWidget(node, 'width', 1024)
+    registerNodeWidget(node, 'height', 1024)
+    const width = { name: 'width', value: 1024 } as unknown as IBaseWidget
+    const height = { name: 'height', value: 1024 } as unknown as IBaseWidget
     const config = new Load3DConfiguration(makeLoad3dMock())
 
     config.configure({
-      modelWidget: { value: 'none' } as unknown as IBaseWidget,
+      node,
+      modelWidget: {
+        name: 'model_file',
+        value: 'none'
+      } as unknown as IBaseWidget,
       loadFolder: 'input',
       width,
       height,
@@ -709,59 +799,109 @@ describe('Load3DConfiguration.onSceneInvalidated', () => {
     })
     await flush()
 
-    height.callback!(2048)
+    setNodeWidgetValue(node, 'height', 2048)
+    await nextTick()
 
     expect(onSceneInvalidated).toHaveBeenCalledTimes(1)
   })
 
-  it('model_file widget callback invokes onSceneInvalidated after the model loads', async () => {
+  it('a same-value width write via the store does not invoke onSceneInvalidated', async () => {
     const onSceneInvalidated = vi.fn()
-    const modelWidget = { value: 'none' } as unknown as IBaseWidget
+    const node = makeNode()
+    registerNodeWidget(node, 'width', 1024)
+    registerNodeWidget(node, 'height', 1024)
+    const width = { name: 'width', value: 1024 } as unknown as IBaseWidget
+    const height = { name: 'height', value: 1024 } as unknown as IBaseWidget
     const config = new Load3DConfiguration(makeLoad3dMock())
 
     config.configure({
+      node,
+      modelWidget: {
+        name: 'model_file',
+        value: 'none'
+      } as unknown as IBaseWidget,
+      loadFolder: 'input',
+      width,
+      height,
+      onSceneInvalidated
+    })
+    await flush()
+
+    setNodeWidgetValue(node, 'width', 1024)
+    await nextTick()
+
+    expect(onSceneInvalidated).not.toHaveBeenCalled()
+  })
+
+  it('a model_file change via the store invokes onSceneInvalidated after the model loads', async () => {
+    const onSceneInvalidated = vi.fn()
+    const node = makeNode()
+    registerNodeWidget(node, 'model_file', 'none')
+    const modelWidget = {
+      name: 'model_file',
+      value: 'none'
+    } as unknown as IBaseWidget
+    const config = new Load3DConfiguration(makeLoad3dMock())
+
+    config.configure({
+      node,
       modelWidget,
       loadFolder: 'input',
       onSceneInvalidated
     })
     await flush()
 
-    modelWidget.value = 'model.glb'
+    setNodeWidgetValue(node, 'model_file', 'model.glb')
+    await nextTick()
     await flush()
 
     expect(onSceneInvalidated).toHaveBeenCalled()
   })
 
-  it('preserves any pre-existing model widget callback alongside the invalidation hook', async () => {
+  it('leaves any pre-existing model widget callback untouched', async () => {
     const onSceneInvalidated = vi.fn()
     const original = vi.fn()
+    const node = makeNode()
+    registerNodeWidget(node, 'model_file', 'none')
     const modelWidget = {
+      name: 'model_file',
       value: 'none',
       callback: original
     } as unknown as IBaseWidget
     const config = new Load3DConfiguration(makeLoad3dMock())
 
     config.configure({
+      node,
       modelWidget,
       loadFolder: 'input',
       onSceneInvalidated
     })
     await flush()
 
-    modelWidget.value = 'model.glb'
+    setNodeWidgetValue(node, 'model_file', 'model.glb')
+    await nextTick()
     await flush()
 
-    expect(original).toHaveBeenCalledWith('model.glb')
+    expect(modelWidget.callback).toBe(original)
     expect(onSceneInvalidated).toHaveBeenCalled()
   })
 
-  it('callbacks remain safe when onSceneInvalidated is omitted', async () => {
-    const width = { value: 1024 } as unknown as IBaseWidget
-    const height = { value: 1024 } as unknown as IBaseWidget
-    const modelWidget = { value: 'none' } as unknown as IBaseWidget
-    const config = new Load3DConfiguration(makeLoad3dMock())
+  it('store changes remain safe when onSceneInvalidated is omitted', async () => {
+    const node = makeNode()
+    registerNodeWidget(node, 'width', 1024)
+    registerNodeWidget(node, 'height', 1024)
+    registerNodeWidget(node, 'model_file', 'none')
+    const width = { name: 'width', value: 1024 } as unknown as IBaseWidget
+    const height = { name: 'height', value: 1024 } as unknown as IBaseWidget
+    const modelWidget = {
+      name: 'model_file',
+      value: 'none'
+    } as unknown as IBaseWidget
+    const load3d = makeLoad3dMock()
+    const config = new Load3DConfiguration(load3d)
 
     config.configure({
+      node,
       modelWidget,
       loadFolder: 'input',
       width,
@@ -769,10 +909,16 @@ describe('Load3DConfiguration.onSceneInvalidated', () => {
     })
     await flush()
 
-    expect(() => width.callback!(2048)).not.toThrow()
-    expect(() => height.callback!(2048)).not.toThrow()
-    expect(() => {
-      modelWidget.value = 'model.glb'
-    }).not.toThrow()
+    setNodeWidgetValue(node, 'width', 2048)
+    setNodeWidgetValue(node, 'model_file', 'model.glb')
+    await nextTick()
+    await flush()
+
+    expect(load3d.setTargetSize).toHaveBeenLastCalledWith(2048, 1024)
+    expect(load3d.loadModel).toHaveBeenCalledWith(
+      expect.any(String),
+      'model.glb',
+      { silentOnNotFound: false }
+    )
   })
 })

--- a/src/extensions/core/load3d/Load3DConfiguration.ts
+++ b/src/extensions/core/load3d/Load3DConfiguration.ts
@@ -9,13 +9,15 @@ import type {
   ModelConfig,
   SceneConfig
 } from '@/extensions/core/load3d/interfaces'
+import { watchNodeWidgetValues } from '@/composables/node/widgetStoreSync'
 import type { Dictionary } from '@/lib/litegraph/src/interfaces'
-import type { NodeProperty } from '@/lib/litegraph/src/LGraphNode'
+import type { LGraphNode, NodeProperty } from '@/lib/litegraph/src/LGraphNode'
 import type { IBaseWidget } from '@/lib/litegraph/src/types/widgets'
 import { useSettingStore } from '@/platform/settings/settingStore'
 import { api } from '@/scripts/api'
 
 type Load3DConfigurationSettings = {
+  node: LGraphNode
   loadFolder: string
   modelWidget: IBaseWidget
   cameraState?: CameraState
@@ -34,6 +36,23 @@ type Load3DConfigurationSettings = {
 }
 
 const ANNOTATED_FILENAME_PATTERN = / \[(input|output|temp)\]$/
+
+export function wireTargetSizeSync(
+  node: LGraphNode,
+  resolveLoad3d: () => Load3d,
+  onSceneInvalidated?: () => void
+): void {
+  watchNodeWidgetValues(
+    node,
+    'load3d:target-size',
+    ['width', 'height'],
+    ([w, h]) => {
+      if (typeof w !== 'number' || typeof h !== 'number') return
+      resolveLoad3d().setTargetSize(w, h)
+      onSceneInvalidated?.()
+    }
+  )
+}
 
 export function parseAnnotatedFilename(
   rawValue: string,
@@ -68,6 +87,7 @@ class Load3DConfiguration {
 
   configure(setting: Load3DConfigurationSettings) {
     this.setupModelHandling(
+      setting.node,
       setting.modelWidget,
       setting.loadFolder,
       setting.cameraState,
@@ -75,6 +95,7 @@ class Load3DConfiguration {
       setting.onSceneInvalidated
     )
     this.setupTargetSize(
+      setting.node,
       setting.width,
       setting.height,
       setting.onSceneInvalidated
@@ -83,22 +104,14 @@ class Load3DConfiguration {
   }
 
   private setupTargetSize(
+    node: LGraphNode,
     width?: IBaseWidget,
     height?: IBaseWidget,
     onSceneInvalidated?: () => void
   ) {
     if (width && height) {
       this.load3d.setTargetSize(width.value as number, height.value as number)
-
-      width.callback = (value: number) => {
-        this.load3d.setTargetSize(value, height.value as number)
-        onSceneInvalidated?.()
-      }
-
-      height.callback = (value: number) => {
-        this.load3d.setTargetSize(width.value as number, value)
-        onSceneInvalidated?.()
-      }
+      wireTargetSizeSync(node, () => this.load3d, onSceneInvalidated)
     }
   }
 
@@ -119,6 +132,7 @@ class Load3DConfiguration {
   }
 
   private setupModelHandling(
+    node: LGraphNode,
     modelWidget: IBaseWidget,
     loadFolder: string,
     cameraState?: CameraState,
@@ -134,32 +148,16 @@ class Load3DConfiguration {
       void onModelWidgetUpdate(modelWidget.value)
     }
 
-    const originalCallback = modelWidget.callback
-
-    let currentValue = modelWidget.value
-    Object.defineProperty(modelWidget, 'value', {
-      get() {
-        return currentValue
-      },
-      set(newValue) {
-        currentValue = newValue
-        if (modelWidget.callback && newValue !== undefined && newValue !== '') {
-          modelWidget.callback(newValue)
-        }
-      },
-      enumerable: true,
-      configurable: true
-    })
-
-    modelWidget.callback = (value: string | number | boolean | object) => {
-      void onModelWidgetUpdate(value)
-
-      if (originalCallback) {
-        originalCallback(value)
+    watchNodeWidgetValues(
+      node,
+      'load3d:model-file',
+      [modelWidget.name],
+      ([value]) => {
+        if (value === undefined) return
+        void onModelWidgetUpdate(value)
+        onSceneInvalidated?.()
       }
-
-      onSceneInvalidated?.()
-    }
+    )
   }
 
   private setupDefaultProperties(bgImagePath?: string) {
@@ -302,7 +300,7 @@ class Load3DConfiguration {
     silentOnNotFound: boolean = false
   ) {
     let isFirstLoad = true
-    return async (value: string | number | boolean | object) => {
+    return async (value: unknown) => {
       if (!value || value === LOAD3D_NONE_MODEL) {
         this.load3d.clearModel()
         return

--- a/src/extensions/core/load3dAdvanced.ts
+++ b/src/extensions/core/load3dAdvanced.ts
@@ -78,6 +78,7 @@ useExtensionService().registerExtension({
 
       const config = new Load3DConfiguration(load3d, node.properties)
       config.configure({
+        node,
         loadFolder: 'input',
         modelWidget,
         cameraState,

--- a/src/extensions/core/load3dPreviewExtensions.test.ts
+++ b/src/extensions/core/load3dPreviewExtensions.test.ts
@@ -1,7 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { nextTick } from 'vue'
 
 import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
+import { useWidgetValueStore } from '@/stores/widgetValueStore'
 import type { ComfyExtension } from '@/types/comfy'
+import { toNodeId } from '@/types/nodeId'
+import { widgetId } from '@/types/widgetId'
 
 const {
   registerExtensionMock,
@@ -39,11 +43,21 @@ vi.mock('@/composables/useLoad3d', () => ({
   nodeToLoad3dMap: nodeToLoad3dMapMock
 }))
 
-vi.mock('@/extensions/core/load3d/Load3DConfiguration', () => ({
-  default: class {
-    configureForSaveMesh = configureForSaveMeshMock
+vi.mock(
+  '@/extensions/core/load3d/Load3DConfiguration',
+  async (importOriginal) => {
+    const actual =
+      await importOriginal<
+        typeof import('@/extensions/core/load3d/Load3DConfiguration')
+      >()
+    return {
+      wireTargetSizeSync: actual.wireTargetSizeSync,
+      default: class {
+        configureForSaveMesh = configureForSaveMeshMock
+      }
+    }
   }
-}))
+)
 
 vi.mock('@/extensions/core/load3d/exportMenuHelper', () => ({
   createExportMenuItems: vi.fn(() => [{ content: 'Export' }])
@@ -311,36 +325,43 @@ describe('Comfy.PreviewGaussianSplat.nodeCreated', () => {
     expect(load3d.applyModelTransform).toHaveBeenCalledWith(transform)
   })
 
-  it('syncs width/height widgets to load3d.setTargetSize and registers callbacks', async () => {
+  it('syncs width/height widgets to load3d.setTargetSize via the widget store', async () => {
     const { splatExt } = await loadExtensionsFresh()
     const load3d = makeLoad3dMock()
     waitForLoad3dMock.mockImplementation((cb: (l: FakeLoad3d) => void) =>
       cb(load3d)
     )
-    const widthWidget: FakeWidget & { callback?: (v: number) => void } = {
-      name: 'width',
-      value: 800
-    }
-    const heightWidget: FakeWidget & { callback?: (v: number) => void } = {
-      name: 'height',
-      value: 600
-    }
+    const graphId = 'preview-ext-test'
+    const nodeId = toNodeId(1)
     const node = makePreviewNode({
       widgets: [
         { name: 'model_file', value: '' },
         { name: 'viewport_state', value: '' },
-        widthWidget,
-        heightWidget
+        { name: 'width', value: 800 },
+        { name: 'height', value: 600 }
       ]
+    })
+    Object.assign(node, { id: nodeId, graph: { rootGraph: { id: graphId } } })
+
+    const store = useWidgetValueStore()
+    store.registerWidget(widgetId(graphId, nodeId, 'width'), {
+      type: 'number',
+      value: 800,
+      options: {}
+    })
+    store.registerWidget(widgetId(graphId, nodeId, 'height'), {
+      type: 'number',
+      value: 600,
+      options: {}
     })
 
     await splatExt.nodeCreated(node)
 
     expect(load3d.setTargetSize).toHaveBeenCalledWith(800, 600)
-    expect(typeof widthWidget.callback).toBe('function')
-    expect(typeof heightWidget.callback).toBe('function')
 
-    widthWidget.callback!(1024)
+    store.setValue(widgetId(graphId, nodeId, 'width'), 1024)
+    await nextTick()
+
     expect(load3d.setTargetSize).toHaveBeenLastCalledWith(1024, 600)
   })
 

--- a/src/extensions/core/load3dPreviewExtensions.ts
+++ b/src/extensions/core/load3dPreviewExtensions.ts
@@ -9,7 +9,9 @@ import type {
   Model3DInfo
 } from '@/extensions/core/load3d/interfaces'
 import type Load3d from '@/extensions/core/load3d/Load3d'
-import Load3DConfiguration from '@/extensions/core/load3d/Load3DConfiguration'
+import Load3DConfiguration, {
+  wireTargetSizeSync
+} from '@/extensions/core/load3d/Load3DConfiguration'
 import { t } from '@/i18n'
 import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
 import type { IContextMenuValue } from '@/lib/litegraph/src/interfaces'
@@ -162,12 +164,7 @@ function createPreview3DExtension(
             widthWidget.value as number,
             heightWidget.value as number
           )
-          widthWidget.callback = (value: number) => {
-            resolveLoad3d().setTargetSize(value, heightWidget.value as number)
-          }
-          heightWidget.callback = (value: number) => {
-            resolveLoad3d().setTargetSize(widthWidget.value as number, value)
-          }
+          wireTargetSizeSync(node, resolveLoad3d)
         }
 
         if (sceneWidget) {

--- a/src/lib/litegraph/src/LGraph.test.ts
+++ b/src/lib/litegraph/src/LGraph.test.ts
@@ -120,6 +120,14 @@ describe('LGraph', () => {
     expect(graph.last_node_id).toBe(7)
   })
 
+  it('getNodeById returns null, never undefined, for unknown ids', () => {
+    const graph = new LGraph()
+
+    expect(graph.getNodeById(toNodeId(999))).toBeNull()
+    expect(graph.getNodeById(null)).toBeNull()
+    expect(graph.getNodeById(undefined)).toBeNull()
+  })
+
   test('can be instantiated', ({ expect }) => {
     // @ts-expect-error Intentional - extra holds any / all consumer data that should be serialised
     const graph = new LGraph({ extra: 'TestGraph' })

--- a/src/lib/litegraph/src/LGraph.ts
+++ b/src/lib/litegraph/src/LGraph.ts
@@ -1334,7 +1334,7 @@ export class LGraph
    */
   getNodeById(id: NodeId | null | undefined): LGraphNode | null {
     return id != null && id !== UNASSIGNED_NODE_ID
-      ? this._nodes_by_id[id]
+      ? (this._nodes_by_id[id] ?? null)
       : null
   }
 

--- a/src/renderer/extensions/compositor/composables/compositorSave.test.ts
+++ b/src/renderer/extensions/compositor/composables/compositorSave.test.ts
@@ -3,8 +3,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { defaultMode } from '@/renderer/extensions/layerEditor/engine/mode'
 import type { RasterData } from '@/renderer/extensions/layerEditor/engine/node'
 import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
-import type { IBaseWidget } from '@/lib/litegraph/src/types/widgets'
+import { useWidgetValueStore } from '@/stores/widgetValueStore'
 import { toNodeId } from '@/types/nodeId'
+import { widgetId } from '@/types/widgetId'
+import { createMockLGraphNode } from '@/utils/__tests__/litegraphTestUtils'
 
 import type { CompositorLayerState } from './compositorLayerState'
 import {
@@ -48,23 +50,28 @@ function makeSession() {
   }
 }
 
-function makeNode() {
-  const compositorWidget = {
-    name: 'compositor',
-    value: {},
-    callback: vi.fn()
-  } as unknown as IBaseWidget
-  const node = {
-    id: toNodeId(7),
-    widgets: [compositorWidget],
-    widgets_values: [{}]
-  } as unknown as LGraphNode
-  return { node, compositorWidget }
+const GRAPH_ID = 'compositor-save-test'
+const NODE_ID = toNodeId(7)
+
+function makeNode(): { node: LGraphNode } {
+  useWidgetValueStore().registerWidget(
+    widgetId(GRAPH_ID, NODE_ID, 'compositor'),
+    { type: 'compositor', value: {}, options: {} }
+  )
+  const node = createMockLGraphNode({
+    id: NODE_ID,
+    graph: { rootGraph: { id: GRAPH_ID } }
+  })
+  return { node }
 }
 
-function widgetValue(widget: IBaseWidget): CompositorLayerState {
-  return widget.value as CompositorLayerState
+function storedValue(): CompositorLayerState {
+  return useWidgetValueStore().getWidget(
+    widgetId(GRAPH_ID, NODE_ID, 'compositor')
+  )?.value as CompositorLayerState
 }
+
+const setValueSpy = () => vi.mocked(useWidgetValueStore().setValue)
 
 const cacheNode = { id: toNodeId(7) } as unknown as LGraphNode
 
@@ -84,14 +91,11 @@ describe('saveCompositorLayerState', () => {
   it('writes the layer state recipe to the compositor widget', () => {
     cacheFingerprint()
     const session = makeSession()
-    const { node, compositorWidget } = makeNode()
+    const { node } = makeNode()
 
     expect(saveCompositorLayerState(session, node)).toBe(true)
 
-    const savedState = widgetValue(compositorWidget)
-    expect(compositorWidget.callback).toHaveBeenCalledWith(savedState)
-    expect(node.widgets_values?.[0]).toBe(compositorWidget.value)
-
+    const savedState = storedValue()
     expect(savedState.canvas).toEqual({ w: 64, h: 48 })
     expect(savedState.layers).toHaveLength(1)
     expect(savedState.layers[0]).toMatchObject({
@@ -109,20 +113,20 @@ describe('saveCompositorLayerState', () => {
       [{ filename: 'a.png', subfolder: '', type: 'temp' }],
       ['hash-a', 'hash-b']
     )
-    const { node, compositorWidget } = makeNode()
+    const { node } = makeNode()
 
     saveCompositorLayerState(makeSession(), node)
 
-    expect(widgetValue(compositorWidget).inputs).toEqual(['hash-a', 'hash-b'])
+    expect(storedValue().inputs).toEqual(['hash-a', 'hash-b'])
   })
 
   it('refuses to save when no fingerprint is cached', () => {
-    const { node, compositorWidget } = makeNode()
+    const { node } = makeNode()
 
     expect(saveCompositorLayerState(makeSession(), node)).toBe(false)
 
-    expect(compositorWidget.callback).not.toHaveBeenCalled()
-    expect(node.widgets_values).toEqual([{}])
+    expect(setValueSpy()).not.toHaveBeenCalled()
+    expect(storedValue()).toEqual({})
   })
 
   it('keeps widgets untouched when extraction fails', () => {
@@ -131,13 +135,12 @@ describe('saveCompositorLayerState', () => {
     session.layerFlips = () => {
       throw new Error('boom')
     }
-    const { node, compositorWidget } = makeNode()
+    const { node } = makeNode()
 
     expect(saveCompositorLayerState(session, node)).toBe(false)
 
-    expect(compositorWidget.callback).not.toHaveBeenCalled()
-    expect(compositorWidget.value).toEqual({})
-    expect(node.widgets_values).toEqual([{}])
+    expect(setValueSpy()).not.toHaveBeenCalled()
+    expect(storedValue()).toEqual({})
   })
 })
 

--- a/src/renderer/extensions/compositor/composables/compositorWidgets.test.ts
+++ b/src/renderer/extensions/compositor/composables/compositorWidgets.test.ts
@@ -1,7 +1,10 @@
-import { describe, expect, it, vi } from 'vitest'
+import { describe, expect, it } from 'vitest'
 
 import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
-import type { IBaseWidget } from '@/lib/litegraph/src/types/widgets'
+import { useWidgetValueStore } from '@/stores/widgetValueStore'
+import { toNodeId } from '@/types/nodeId'
+import { widgetId } from '@/types/widgetId'
+import { createMockLGraphNode } from '@/utils/__tests__/litegraphTestUtils'
 
 import {
   getCompositorWidgetValue,
@@ -9,73 +12,88 @@ import {
   setCompositorWidgetValue
 } from './compositorWidgets'
 
-function makeNode() {
-  const compositorWidget = {
-    name: 'compositor',
-    value: { layers: [] },
-    callback: vi.fn()
-  } as unknown as IBaseWidget
-  const otherWidget = {
-    name: 'other',
-    value: 42,
-    callback: vi.fn()
-  } as unknown as IBaseWidget
-  const node = {
-    widgets: [otherWidget, compositorWidget],
-    widgets_values: [42, { layers: [] }]
-  } as unknown as LGraphNode
-  return { node, compositorWidget, otherWidget }
+const GRAPH_ID = 'compositor-test-graph'
+
+let nodeCounter = 0
+
+function makeNode({ registered = true } = {}): LGraphNode {
+  nodeCounter += 1
+  const nodeId = toNodeId(nodeCounter)
+  if (registered) {
+    useWidgetValueStore().registerWidget(
+      widgetId(GRAPH_ID, nodeId, 'compositor'),
+      { type: 'compositor', value: { layers: [] }, options: {} }
+    )
+  }
+  return createMockLGraphNode({
+    id: nodeId,
+    graph: { rootGraph: { id: GRAPH_ID } }
+  })
+}
+
+function storedValue(node: LGraphNode): unknown {
+  return useWidgetValueStore().getWidget(
+    widgetId(GRAPH_ID, node.id, 'compositor')
+  )?.value
 }
 
 describe('setCompositorWidgetValue', () => {
-  it('writes the widget value, fires its callback, and syncs widgets_values', () => {
-    const { node, compositorWidget } = makeNode()
+  it('writes the widget value to the store', () => {
+    const node = makeNode()
     const next = { canvas: { w: 8, h: 8 }, layers: [] }
 
     setCompositorWidgetValue(node, next)
 
-    expect(compositorWidget.value).toEqual(next)
-    expect(compositorWidget.callback).toHaveBeenCalledWith(next)
-    expect(node.widgets_values?.[1]).toEqual(next)
+    expect(storedValue(node)).toEqual(next)
   })
 
-  it('is a no-op when the compositor widget is missing', () => {
-    const { node, otherWidget } = makeNode()
-    node.widgets = [otherWidget]
-    node.widgets_values = [42]
+  it('falls back to the widget object when the store has no entry (detached node)', () => {
+    const node = makeNode({ registered: false })
+    const widget = { name: 'compositor', value: { layers: [] } }
+    node.widgets = [widget as never]
+    const next = { canvas: { w: 4, h: 4 }, layers: [] }
+
+    setCompositorWidgetValue(node, next)
+
+    expect(widget.value).toEqual(next)
+    expect(getCompositorWidgetValue(node)).toEqual(next)
+  })
+
+  it('is a no-op when the widget exists nowhere', () => {
+    const node = makeNode({ registered: false })
 
     setCompositorWidgetValue(node, { layers: [] })
 
-    expect(otherWidget.value).toBe(42)
-    expect(node.widgets_values).toEqual([42])
+    expect(storedValue(node)).toBeUndefined()
   })
 })
 
 describe('getCompositorWidgetValue', () => {
   it('returns the widget value when it has the expected shape', () => {
-    const { node } = makeNode()
+    const node = makeNode()
 
     expect(getCompositorWidgetValue(node)).toEqual({ layers: [] })
   })
 
   it('returns null for missing widgets or malformed values', () => {
-    const { node, compositorWidget } = makeNode()
-    compositorWidget.value = 'legacy-string'
+    const node = makeNode()
+    useWidgetValueStore().setValue(
+      widgetId(GRAPH_ID, node.id, 'compositor'),
+      'legacy-string'
+    )
     expect(getCompositorWidgetValue(node)).toBeNull()
 
-    node.widgets = []
-    expect(getCompositorWidgetValue(node)).toBeNull()
+    expect(getCompositorWidgetValue(makeNode({ registered: false }))).toBeNull()
   })
 })
 
 describe('resetCompositorStateWidgets', () => {
   it('resets the compositor widget to the empty value durably', () => {
-    const { node, compositorWidget } = makeNode()
+    const node = makeNode()
+    setCompositorWidgetValue(node, { canvas: { w: 8, h: 8 }, layers: [] })
 
     resetCompositorStateWidgets(node)
 
-    expect(compositorWidget.value).toEqual({})
-    expect(compositorWidget.callback).toHaveBeenCalledWith({})
-    expect(node.widgets_values).toEqual([42, {}])
+    expect(storedValue(node)).toEqual({})
   })
 })

--- a/src/renderer/extensions/compositor/composables/compositorWidgets.ts
+++ b/src/renderer/extensions/compositor/composables/compositorWidgets.ts
@@ -1,29 +1,30 @@
 import {
+  nodeWidgetValue,
+  setNodeWidgetValue
+} from '@/composables/node/widgetStoreSync'
+import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
+import {
   emptyCompositorWidgetValue,
   isCompositorWidgetValue
 } from '@/renderer/extensions/compositor/components/types'
 import type { CompositorWidgetValue } from '@/renderer/extensions/compositor/components/types'
-import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
 
 export function setCompositorWidgetValue(
   node: LGraphNode,
   value: CompositorWidgetValue
 ): void {
+  if (setNodeWidgetValue(node, 'compositor', value)) return
   const widget = node.widgets?.find((w) => w.name === 'compositor')
-  if (!widget) return
-  widget.value = value
-  widget.callback?.(value)
-  if (node.widgets_values && node.widgets) {
-    const index = node.widgets.indexOf(widget)
-    if (index >= 0) node.widgets_values[index] = value
-  }
+  if (widget) widget.value = value
 }
 
 export function getCompositorWidgetValue(
   node: LGraphNode
 ): CompositorWidgetValue | null {
-  const widget = node.widgets?.find((w) => w.name === 'compositor')
-  return isCompositorWidgetValue(widget?.value) ? widget.value : null
+  const value =
+    nodeWidgetValue(node, 'compositor') ??
+    node.widgets?.find((w) => w.name === 'compositor')?.value
+  return isCompositorWidgetValue(value) ? value : null
 }
 
 export function resetCompositorStateWidgets(node: LGraphNode): void {

--- a/src/renderer/extensions/compositor/composables/useCompositorAutoSave.test.ts
+++ b/src/renderer/extensions/compositor/composables/useCompositorAutoSave.test.ts
@@ -1,15 +1,20 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { Dirty } from '@/renderer/extensions/layerEditor/engine/history'
 import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
-import type { IBaseWidget } from '@/lib/litegraph/src/types/widgets'
+import { Dirty } from '@/renderer/extensions/layerEditor/engine/history'
+import { useWidgetValueStore } from '@/stores/widgetValueStore'
 import { toNodeId } from '@/types/nodeId'
+import { widgetId } from '@/types/widgetId'
+import { createMockLGraphNode } from '@/utils/__tests__/litegraphTestUtils'
 
+import { useCompositorAutoSave } from './useCompositorAutoSave'
 import {
   clearCompositorLayers,
   setCompositorLayers
 } from './useCompositorLayers'
-import { useCompositorAutoSave } from './useCompositorAutoSave'
+
+const GRAPH_ID = 'compositor-autosave-test'
+const NODE_ID = toNodeId(7)
 
 function makeSession() {
   const listeners = new Set<(mask: number) => void>()
@@ -32,21 +37,24 @@ function makeSession() {
   }
 }
 
-function makeNode() {
-  const compositorWidget = {
-    name: 'compositor',
-    value: {},
-    callback: vi.fn()
-  } as unknown as IBaseWidget
-  const node = {
-    id: toNodeId(7),
-    widgets: [compositorWidget],
-    widgets_values: [{}]
-  } as unknown as LGraphNode
-  return { node, compositorWidget }
+function makeNode(): LGraphNode {
+  useWidgetValueStore().registerWidget(
+    widgetId(GRAPH_ID, NODE_ID, 'compositor'),
+    { type: 'compositor', value: {}, options: {} }
+  )
+  return createMockLGraphNode({
+    id: NODE_ID,
+    graph: { rootGraph: { id: GRAPH_ID } }
+  })
 }
 
-const cacheNode = { id: toNodeId(7) } as unknown as LGraphNode
+const storedValue = () =>
+  useWidgetValueStore().getWidget(widgetId(GRAPH_ID, NODE_ID, 'compositor'))
+    ?.value
+
+const setValueSpy = () => vi.mocked(useWidgetValueStore().setValue)
+
+const cacheNode = { id: NODE_ID } as unknown as LGraphNode
 
 beforeEach(() => {
   setCompositorLayers(
@@ -64,34 +72,34 @@ describe('useCompositorAutoSave', () => {
   it('leaves the widget untouched when no fingerprint is cached', () => {
     clearCompositorLayers(cacheNode)
     const session = makeSession()
-    const { node, compositorWidget } = makeNode()
+    const node = makeNode()
     useCompositorAutoSave(session, node)
 
     session.emitHistoryChange()
     vi.advanceTimersByTime(2000)
 
-    expect(compositorWidget.callback).not.toHaveBeenCalled()
-    expect(node.widgets_values).toEqual([{}])
+    expect(setValueSpy()).not.toHaveBeenCalled()
+    expect(storedValue()).toEqual({})
   })
 
   it('debounces history changes into a single widget write', () => {
     const session = makeSession()
-    const { node, compositorWidget } = makeNode()
+    const node = makeNode()
     useCompositorAutoSave(session, node)
 
     session.emitHistoryChange()
     session.emitHistoryChange()
     session.emitHistoryChange()
-    expect(compositorWidget.callback).not.toHaveBeenCalled()
+    expect(setValueSpy()).not.toHaveBeenCalled()
 
     vi.advanceTimersByTime(300)
-    expect(compositorWidget.callback).toHaveBeenCalledTimes(1)
-    expect(compositorWidget.value).toMatchObject({ canvas: { w: 8, h: 8 } })
+    expect(setValueSpy()).toHaveBeenCalledTimes(1)
+    expect(storedValue()).toMatchObject({ canvas: { w: 8, h: 8 } })
   })
 
   it('saves again for edits after the debounce window', () => {
     const session = makeSession()
-    const { node, compositorWidget } = makeNode()
+    const node = makeNode()
     useCompositorAutoSave(session, node)
 
     session.emitHistoryChange()
@@ -99,23 +107,23 @@ describe('useCompositorAutoSave', () => {
     session.emitHistoryChange()
     vi.advanceTimersByTime(300)
 
-    expect(compositorWidget.callback).toHaveBeenCalledTimes(2)
+    expect(setValueSpy()).toHaveBeenCalledTimes(2)
   })
 
   it('ignores selection-only history changes', () => {
     const session = makeSession()
-    const { node, compositorWidget } = makeNode()
+    const node = makeNode()
     useCompositorAutoSave(session, node)
 
     session.emitHistoryChange(Dirty.SELECTION)
     vi.advanceTimersByTime(300)
 
-    expect(compositorWidget.callback).not.toHaveBeenCalled()
+    expect(setValueSpy()).not.toHaveBeenCalled()
   })
 
   it('stop() cancels pending saves and unsubscribes', () => {
     const session = makeSession()
-    const { node, compositorWidget } = makeNode()
+    const node = makeNode()
     const autoSave = useCompositorAutoSave(session, node)
 
     session.emitHistoryChange()
@@ -125,6 +133,6 @@ describe('useCompositorAutoSave', () => {
     session.emitHistoryChange()
     vi.advanceTimersByTime(300)
 
-    expect(compositorWidget.callback).not.toHaveBeenCalled()
+    expect(setValueSpy()).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/extensions/vueNodes/widgets/composables/useBoundingBoxWidget.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useBoundingBoxWidget.test.ts
@@ -1,0 +1,172 @@
+import { fromPartial } from '@total-typescript/shoehorn'
+import { describe, expect, it } from 'vitest'
+import { nextTick } from 'vue'
+
+import { LGraphNode } from '@/lib/litegraph/src/litegraph'
+import { useWidgetValueStore } from '@/stores/widgetValueStore'
+import { toNodeId } from '@/types/nodeId'
+import { widgetId } from '@/types/widgetId'
+
+import { useBoundingBoxWidget } from './useBoundingBoxWidget'
+
+const GRAPH_ID = 'bbox-widget-test'
+
+let nodeCounter = 0
+
+function makeNode(): LGraphNode {
+  nodeCounter += 1
+  const node = new LGraphNode('TestNode')
+  node.id = toNodeId(nodeCounter)
+  node.graph = fromPartial({ rootGraph: { id: GRAPH_ID } })
+  return node
+}
+
+function construct(node: LGraphNode, component?: string) {
+  return useBoundingBoxWidget()(
+    node,
+    fromPartial({ name: 'bounds', type: 'BOUNDINGBOX', component })
+  )
+}
+
+function value(node: LGraphNode, name: string): unknown {
+  return useWidgetValueStore().getWidget(widgetId(GRAPH_ID, node.id, name))
+    ?.value
+}
+
+function setValue(node: LGraphNode, name: string, v: unknown): void {
+  useWidgetValueStore().setValue(widgetId(GRAPH_ID, node.id, name), v as never)
+}
+
+describe('useBoundingBoxWidget', () => {
+  it('creates the composite widget with four linked numeric sub-widgets', () => {
+    const node = makeNode()
+    const widget = construct(node)
+
+    expect(widget.type).toBe('boundingbox')
+    expect(widget.linkedWidgets?.map((w) => w.name)).toEqual([
+      'bounds.x',
+      'bounds.y',
+      'bounds.width',
+      'bounds.height'
+    ])
+    expect(widget.linkedWidgets?.map((w) => w.label)).toEqual([
+      'x',
+      'y',
+      'width',
+      'height'
+    ])
+    expect(value(node, 'bounds')).toEqual({
+      x: 0,
+      y: 0,
+      width: 512,
+      height: 512
+    })
+  })
+
+  it('creates an imagecrop widget for the ImageCrop component', () => {
+    const widget = construct(makeNode(), 'ImageCrop')
+    expect(widget.type).toBe('imagecrop')
+  })
+
+  it('mirrors main bounds updates into the sub-widgets', async () => {
+    const node = makeNode()
+    construct(node)
+
+    setValue(node, 'bounds', { x: 10, y: 20, width: 30, height: 40 })
+    await nextTick()
+
+    expect(value(node, 'bounds.x')).toBe(10)
+    expect(value(node, 'bounds.y')).toBe(20)
+    expect(value(node, 'bounds.width')).toBe(30)
+    expect(value(node, 'bounds.height')).toBe(40)
+  })
+
+  it('keeps fractional main bounds intact while sub-widgets mirror them', async () => {
+    const node = makeNode()
+    construct(node)
+
+    setValue(node, 'bounds', { x: 3.2, y: 0, width: 512, height: 512 })
+    await nextTick()
+    await nextTick()
+
+    expect(value(node, 'bounds.x')).toBe(3.2)
+    expect(value(node, 'bounds')).toEqual({
+      x: 3.2,
+      y: 0,
+      width: 512,
+      height: 512
+    })
+  })
+
+  it('writes a rounded whole-object bounds update when a sub-widget is edited', async () => {
+    const node = makeNode()
+    construct(node)
+
+    setValue(node, 'bounds.x', 3.7)
+    await nextTick()
+
+    expect(value(node, 'bounds')).toEqual({
+      x: 4,
+      y: 0,
+      width: 512,
+      height: 512
+    })
+
+    await nextTick()
+    expect(value(node, 'bounds.x')).toBe(4)
+  })
+
+  it('replaces the bounds object identity on sub-widget edits', async () => {
+    const node = makeNode()
+    construct(node)
+    const before = value(node, 'bounds')
+
+    setValue(node, 'bounds.width', 256)
+    await nextTick()
+
+    expect(value(node, 'bounds')).not.toBe(before)
+    expect(value(node, 'bounds')).toMatchObject({ width: 256 })
+  })
+
+  it('snaps a fractional sub-widget entry back when it rounds to the current bounds', async () => {
+    const node = makeNode()
+    construct(node)
+
+    setValue(node, 'bounds.x', 0.4)
+    await nextTick()
+    await nextTick()
+
+    expect(value(node, 'bounds.x')).toBe(0)
+    expect(value(node, 'bounds')).toMatchObject({ x: 0 })
+  })
+
+  it('wires the sync lazily when constructed before the node joins a graph', async () => {
+    nodeCounter += 1
+    const node = new LGraphNode('TestNode')
+    node.id = toNodeId(nodeCounter)
+    construct(node)
+
+    node.graph = fromPartial({ rootGraph: { id: GRAPH_ID } })
+    const store = useWidgetValueStore()
+    for (const [name, v] of [
+      ['bounds', { x: 0, y: 0, width: 512, height: 512 }],
+      ['bounds.x', 0],
+      ['bounds.y', 0],
+      ['bounds.width', 512],
+      ['bounds.height', 512]
+    ] as const) {
+      store.registerWidget(widgetId(GRAPH_ID, node.id, name), {
+        type: 'number',
+        value: v as never,
+        options: {}
+      })
+    }
+    node.onAdded?.(fromPartial({}))
+
+    setValue(node, 'bounds', { x: 7, y: 8, width: 9, height: 10 })
+    await nextTick()
+
+    expect(value(node, 'bounds.x')).toBe(7)
+    expect(value(node, 'bounds.height')).toBe(10)
+  })
+})

--- a/src/renderer/extensions/vueNodes/widgets/composables/useBoundingBoxWidget.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useBoundingBoxWidget.ts
@@ -1,3 +1,8 @@
+import {
+  nodeWidgetValue,
+  setNodeWidgetValue,
+  watchNodeWidgetValues
+} from '@/composables/node/widgetStoreSync'
 import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
 import type {
   IBaseWidget,
@@ -22,6 +27,18 @@ function isNumericWidget(widget: IBaseWidget): widget is INumericWidget {
   return widget.type === 'number'
 }
 
+const FIELDS: (keyof Bounds)[] = ['x', 'y', 'width', 'height']
+
+function isBounds(value: unknown): value is Bounds {
+  return (
+    !!value &&
+    typeof value === 'object' &&
+    FIELDS.every(
+      (field) => typeof (value as Record<string, unknown>)[field] === 'number'
+    )
+  )
+}
+
 export const useBoundingBoxWidget = (): ComfyWidgetConstructorV2 => {
   return (
     node: LGraphNode,
@@ -38,22 +55,11 @@ export const useBoundingBoxWidget = (): ComfyWidgetConstructorV2 => {
 
     const widgetType = component === 'ImageCrop' ? 'imagecrop' : 'boundingbox'
 
-    const fields: (keyof Bounds)[] = ['x', 'y', 'width', 'height']
-    const subWidgets: INumericWidget[] = []
-
     const rawWidget = node.addWidget(
       widgetType,
       name,
       { ...defaultValue },
-      () => {
-        for (let i = 0; i < fields.length; i++) {
-          const field = fields[i]
-          const subWidget = subWidgets[i]
-          if (subWidget) {
-            subWidget.value = widget.value[field]
-          }
-        }
-      },
+      () => {},
       {
         serialize: true,
         canvasOnly: false
@@ -66,16 +72,16 @@ export const useBoundingBoxWidget = (): ComfyWidgetConstructorV2 => {
 
     const widget = rawWidget
 
-    for (const field of fields) {
+    const subWidgetName = (field: keyof Bounds) => `${name}.${field}`
+    const subWidgetNames = FIELDS.map(subWidgetName)
+
+    const subWidgets: INumericWidget[] = []
+    for (const field of FIELDS) {
       const subWidget = node.addWidget(
         'number',
-        field,
+        subWidgetName(field),
         defaultValue[field],
-        function (this: INumericWidget, v: number) {
-          this.value = Math.round(v)
-          widget.value[field] = this.value
-          widget.callback?.(widget.value)
-        },
+        () => {},
         {
           min: field === 'width' || field === 'height' ? 1 : 0,
           max: 8192,
@@ -91,10 +97,48 @@ export const useBoundingBoxWidget = (): ComfyWidgetConstructorV2 => {
         throw new Error(`Unexpected widget type: ${subWidget.type}`)
       }
 
+      subWidget.label = field
       subWidgets.push(subWidget)
     }
 
     widget.linkedWidgets = subWidgets
+
+    const syncSubWidgets = (bounds: Bounds) => {
+      for (const field of FIELDS) {
+        setNodeWidgetValue(node, subWidgetName(field), bounds[field])
+      }
+    }
+
+    watchNodeWidgetValues(node, `bounds:${name}:main`, [name], ([bounds]) => {
+      if (isBounds(bounds)) syncSubWidgets(bounds)
+    })
+
+    watchNodeWidgetValues(
+      node,
+      `bounds:${name}:fields`,
+      subWidgetNames,
+      (values) => {
+        const bounds = nodeWidgetValue(node, name)
+        if (!isBounds(bounds)) return
+        if (values.some((value) => typeof value !== 'number')) return
+        const fieldValues = values as number[]
+        const mirrorsBounds = FIELDS.every(
+          (field, i) => fieldValues[i] === bounds[field]
+        )
+        if (mirrorsBounds) return
+        const next: Bounds = {
+          x: Math.round(fieldValues[0]),
+          y: Math.round(fieldValues[1]),
+          width: Math.round(fieldValues[2]),
+          height: Math.round(fieldValues[3])
+        }
+        if (FIELDS.every((field) => next[field] === bounds[field])) {
+          syncSubWidgets(next)
+          return
+        }
+        setNodeWidgetValue(node, name, next)
+      }
+    )
 
     return widget
   }


### PR DESCRIPTION
## Summary

Post-ECS follow-up: BaseWidget values now live in widgetValueStore, so the legacy patterns (node.widgets traversal, direct .value mutation, callback monkey-patching and overwrites, manual widgets_values sync) are replaced with WidgetId-keyed store reads/writes and reactive watches.

Covers load3d/preview3d, camera-info, painter, bounding boxes, the boundingbox/imagecrop composite widget, compositor, mask editor, and image compare.

- New composables/node/widgetStoreSync helper as the single store access point: nodeWidgetValue / setNodeWidgetValue (WidgetNode = nullable node; absent node reads undefined and reports write failure; same-value writes are skipped) and watchNodeWidgetValues for per-(node, key) Vue watches. Re-registering a key replaces the previous watcher; watchers are wired lazily via onAdded when the node has no graph yet (a watcher created before the widgets register would collect no reactive dependencies and never fire), and all of a node's watchers dispose on the graph's typed node:before-removed event (fires on removal, clear, and subgraph release)
- Load3DConfiguration: drop the Object.defineProperty hijack of modelWidget.value (it shadowed the store delegation and detached the widget from the store) and the width/height/model callback overwrites; configure() takes the node and wires store watches instead. An empty model value still clears the scene; re-selecting the identical model value no longer forces a reload (explicit configure() paths cover execution-driven reloads). The width/height sync shared by the input and preview wiring paths is a single wireTargetSizeSync helper
- cameraInfo widgetBridge: reads/writes through widgetValueStore; the callback interception layer in useCameraInfo becomes a computed + watch, covering widgets registered after a mode switch
- usePainter: width/height/bg_color reads and writes go through the store; manual widget.callback invocations removed (verified no-ops); mask serializeValue override unchanged
- useBoundingBoxes: width/height and last_incoming reads/writes go through the store; manual widget.callback invocations removed (verified no-ops)
- useBoundingBoxWidget: the main-bounds <-> numeric sub-widget linkage moves from callback wiring and in-place field mutation (which bypassed setValue) to two store watches. Sub-widgets register under namespaced names (bounds.x) with bare labels so they cannot collide with same-named node widgets in the store; sub-widget edits write a rounded whole-object bounds update, fractional main bounds are mirrored without snapping, and fractional entries that round to the current bounds snap back
- compositorWidgets and maskeditor loader/saver: store-keyed reads/writes with a widget-object fallback for widgets that never registered in the store (custom-node widgets injected outside addWidget) and for nodes detached from a graph (debounced compositor auto-save landing after removal); manual widgets_values sync removed
- imageCompare: drop dead widget.callback invocation (created as no-op)
- litegraph: getNodeById returns null instead of leaking undefined for unknown ids; the leak let undefined through signature-based null guards and crashed WidgetCompositor during the async-mount race after adding the node from search, wedging the Vue renderer
