### PR TITLE
billing: expire and invalidate cached capability snapshots

### DIFF
--- a/src/platform/workspace/api/capabilityRevision.test.ts
+++ b/src/platform/workspace/api/capabilityRevision.test.ts
@@ -1,0 +1,133 @@
+import type {
+  AxiosInstance,
+  AxiosResponse,
+  InternalAxiosRequestConfig
+} from 'axios'
+import axios, { AxiosError, AxiosHeaders } from 'axios'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  attachCapabilityRevisionInterceptor,
+  onCapabilityRevision
+} from './capabilityRevision'
+
+const unsubscribes: Array<() => void> = []
+
+function subscribe() {
+  const listener = vi.fn()
+  unsubscribes.push(onCapabilityRevision(listener))
+  return listener
+}
+
+function clientRespondingWith(
+  status: number,
+  headers: Record<string, string>
+): AxiosInstance {
+  const client = axios.create()
+  client.defaults.adapter = (config: InternalAxiosRequestConfig) => {
+    const response: AxiosResponse = {
+      data: {},
+      status,
+      statusText: '',
+      headers: new AxiosHeaders(headers),
+      config
+    }
+    return status >= 400
+      ? Promise.reject(
+          new AxiosError(
+            'Request failed',
+            'ERR_BAD_REQUEST',
+            config,
+            {},
+            response
+          )
+        )
+      : Promise.resolve(response)
+  }
+  attachCapabilityRevisionInterceptor(client)
+  return client
+}
+
+afterEach(() => {
+  while (unsubscribes.length) unsubscribes.pop()!()
+})
+
+describe('capabilityRevision', () => {
+  it('publishes the revision reported by a successful mutation', async () => {
+    const listener = subscribe()
+
+    await clientRespondingWith(200, { 'X-Capability-Revision': '42' }).post(
+      '/api/billing/subscribe'
+    )
+
+    expect(listener).toHaveBeenCalledExactlyOnceWith(42)
+  })
+
+  it('publishes the revision reported by a failed mutation', async () => {
+    const listener = subscribe()
+
+    await expect(
+      clientRespondingWith(402, { 'X-Capability-Revision': '43' }).post(
+        '/api/billing/subscribe'
+      )
+    ).rejects.toBeInstanceOf(AxiosError)
+
+    expect(listener).toHaveBeenCalledExactlyOnceWith(43)
+  })
+
+  it('reads the revision header case-insensitively', async () => {
+    const listener = subscribe()
+
+    await clientRespondingWith(200, { 'x-capability-revision': '7' }).post(
+      '/api/billing/topup'
+    )
+
+    expect(listener).toHaveBeenCalledExactlyOnceWith(7)
+  })
+
+  it('publishes nothing when the response omits the revision header', async () => {
+    const listener = subscribe()
+
+    await clientRespondingWith(200, {}).post('/api/billing/subscribe')
+
+    expect(listener).not.toHaveBeenCalled()
+  })
+
+  it('publishes nothing when a transport error carries no response', async () => {
+    const listener = subscribe()
+    const client = axios.create()
+    client.defaults.adapter = () =>
+      Promise.reject(new AxiosError('Network Error', 'ERR_NETWORK'))
+    attachCapabilityRevisionInterceptor(client)
+
+    await expect(client.post('/api/billing/subscribe')).rejects.toBeInstanceOf(
+      AxiosError
+    )
+
+    expect(listener).not.toHaveBeenCalled()
+  })
+
+  it.for(['', 'not-a-number', '0', '-1', '1.5', '9007199254740993'])(
+    'publishes nothing for an unusable revision header %j',
+    async (value) => {
+      const listener = subscribe()
+
+      await clientRespondingWith(200, {
+        'X-Capability-Revision': value
+      }).post('/api/billing/subscribe')
+
+      expect(listener).not.toHaveBeenCalled()
+    }
+  )
+
+  it('stops publishing to a listener once it unsubscribes', async () => {
+    const listener = vi.fn()
+    onCapabilityRevision(listener)()
+
+    await clientRespondingWith(200, { 'X-Capability-Revision': '9' }).post(
+      '/api/billing/subscribe'
+    )
+
+    expect(listener).not.toHaveBeenCalled()
+  })
+})

--- a/src/platform/workspace/api/capabilityRevision.ts
+++ b/src/platform/workspace/api/capabilityRevision.ts
@@ -1,0 +1,62 @@
+import type { AxiosInstance, AxiosResponse, RawAxiosHeaders } from 'axios'
+import axios, { AxiosHeaders } from 'axios'
+
+const CAPABILITY_REVISION_HEADER = 'X-Capability-Revision'
+
+type CapabilityRevisionListener = (revision: number) => void
+
+const listeners = new Set<CapabilityRevisionListener>()
+
+export function onCapabilityRevision(
+  listener: CapabilityRevisionListener
+): () => void {
+  listeners.add(listener)
+  return () => {
+    listeners.delete(listener)
+  }
+}
+
+function readCapabilityRevision(
+  response: AxiosResponse | undefined
+): number | null {
+  const headers = response?.headers
+  if (!headers) return null
+  const raw = AxiosHeaders.from(headers as RawAxiosHeaders).get(
+    CAPABILITY_REVISION_HEADER
+  )
+  const value = Array.isArray(raw) ? raw[0] : raw
+  if (typeof value !== 'string' && typeof value !== 'number') return null
+  const revision = Number(value)
+  return Number.isSafeInteger(revision) && revision > 0 ? revision : null
+}
+
+/**
+ * Installs a response interceptor that republishes the server's capability
+ * revision to {@link onCapabilityRevision} subscribers.
+ *
+ * The header is stamped before the handler runs, so a rejected mutation
+ * carries it too and the error arm has to read it as well. It is absent
+ * whenever CORS is bypassed (local desktop origins), so every read degrades to
+ * "no revision reported" rather than assuming presence.
+ */
+export function attachCapabilityRevisionInterceptor(
+  client: AxiosInstance
+): void {
+  const publish = (response: AxiosResponse | undefined) => {
+    const revision = readCapabilityRevision(response)
+    if (revision !== null) {
+      for (const listener of [...listeners]) listener(revision)
+    }
+  }
+
+  client.interceptors.response.use(
+    (response) => {
+      publish(response)
+      return response
+    },
+    (error: unknown) => {
+      publish(axios.isAxiosError(error) ? error.response : undefined)
+      throw error
+    }
+  )
+}

--- a/src/platform/workspace/api/workspaceApi.ts
+++ b/src/platform/workspace/api/workspaceApi.ts
@@ -43,6 +43,7 @@ import {
   UNKNOWN_ERROR_CODE,
   errorResponseFromBody
 } from '@/platform/remote/comfyui/errors'
+import { attachCapabilityRevisionInterceptor } from '@/platform/workspace/api/capabilityRevision'
 import type {
   WorkspaceId,
   WorkspaceInviteId
@@ -134,6 +135,7 @@ const workspaceApiClient = axios.create({
 
 // acceptInvite opts out via __skipUnifiedRemint (it is deliberately Firebase-authed).
 attachUnifiedRemintInterceptor(workspaceApiClient)
+attachCapabilityRevisionInterceptor(workspaceApiClient)
 
 async function getAuthHeaderOrThrow() {
   return useAuthStore().getWorkspaceAuthHeaderOrThrow()

--- a/src/platform/workspace/composables/useBillingCapabilities.test.ts
+++ b/src/platform/workspace/composables/useBillingCapabilities.test.ts
@@ -1,7 +1,11 @@
 import type { BillingCapabilitiesResponse } from '@comfyorg/ingest-types'
+import type { AxiosResponse, InternalAxiosRequestConfig } from 'axios'
+import axios, { AxiosError, AxiosHeaders } from 'axios'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { effectScope } from 'vue'
 import type { EffectScope } from 'vue'
+
+import { attachCapabilityRevisionInterceptor } from '@/platform/workspace/api/capabilityRevision'
 
 import { useBillingCapabilities } from './useBillingCapabilities'
 
@@ -61,7 +65,8 @@ vi.mock('@/stores/authStore', () => ({
 function capabilitiesResponse(
   canTopUp: boolean,
   workspaceId = 'workspace-1',
-  canSubscribeSelfServe = true
+  canSubscribeSelfServe = true,
+  freshness: { expiresAt?: string; revision?: number } = {}
 ): BillingCapabilitiesResponse {
   return {
     resolved_for: {
@@ -82,9 +87,46 @@ function capabilitiesResponse(
       can_subscribe_self_serve: false,
       can_top_up: false
     },
-    revision: 1,
-    expires_at: '2099-01-01T00:00:00Z'
+    revision: freshness.revision ?? 1,
+    expires_at: freshness.expiresAt ?? '2099-01-01T00:00:00Z'
   }
+}
+
+function expiresIn(ms: number): string {
+  return new Date(Date.now() + ms).toISOString()
+}
+
+/** Drives a mutation response through the shared capability-revision interceptor. */
+async function emitMutationRevision(
+  revision: string | undefined,
+  status = 200
+): Promise<void> {
+  const client = axios.create()
+  client.defaults.adapter = (config: InternalAxiosRequestConfig) => {
+    const response: AxiosResponse = {
+      data: {},
+      status,
+      statusText: '',
+      headers: new AxiosHeaders(
+        revision === undefined ? {} : { 'X-Capability-Revision': revision }
+      ),
+      config
+    }
+    return status >= 400
+      ? Promise.reject(
+          new AxiosError(
+            'Request failed',
+            'ERR_BAD_REQUEST',
+            config,
+            {},
+            response
+          )
+        )
+      : Promise.resolve(response)
+  }
+  attachCapabilityRevisionInterceptor(client)
+  await client.post('/api/billing/subscribe').catch(() => {})
+  await vi.advanceTimersByTimeAsync(0)
 }
 
 describe('useBillingCapabilities', () => {
@@ -279,5 +321,205 @@ describe('useBillingCapabilities', () => {
     await billingCapabilities.initialize()
 
     expect(billingCapabilities.canTopUp.value).toBe(false)
+  })
+
+  it('refetches the capability snapshot once the server snapshot expires', async () => {
+    mockGetBillingCapabilities
+      .mockResolvedValueOnce(
+        capabilitiesResponse(false, 'workspace-1', true, {
+          expiresAt: expiresIn(30_000)
+        })
+      )
+      .mockResolvedValueOnce(
+        capabilitiesResponse(true, 'workspace-1', true, {
+          expiresAt: expiresIn(90_000)
+        })
+      )
+
+    await billingCapabilities.initialize()
+    expect(billingCapabilities.canTopUp.value).toBe(false)
+
+    await vi.advanceTimersByTimeAsync(30_000)
+
+    expect(mockGetBillingCapabilities).toHaveBeenCalledTimes(2)
+    expect(billingCapabilities.canTopUp.value).toBe(true)
+  })
+
+  it('defers the refresh until a hidden tab becomes visible again', async () => {
+    const visibility = vi
+      .spyOn(document, 'visibilityState', 'get')
+      .mockReturnValue('hidden')
+    mockGetBillingCapabilities
+      .mockResolvedValueOnce(
+        capabilitiesResponse(false, 'workspace-1', true, {
+          expiresAt: expiresIn(30_000)
+        })
+      )
+      .mockResolvedValueOnce(capabilitiesResponse(true))
+
+    await billingCapabilities.initialize()
+    await vi.advanceTimersByTimeAsync(120_000)
+    expect(mockGetBillingCapabilities).toHaveBeenCalledOnce()
+
+    visibility.mockReturnValue('visible')
+    document.dispatchEvent(new Event('visibilitychange'))
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(mockGetBillingCapabilities).toHaveBeenCalledTimes(2)
+    expect(billingCapabilities.canTopUp.value).toBe(true)
+  })
+
+  it('reschedules for the remaining lifetime when the tab returns before expiry', async () => {
+    const visibility = vi
+      .spyOn(document, 'visibilityState', 'get')
+      .mockReturnValue('visible')
+    mockGetBillingCapabilities
+      .mockResolvedValueOnce(
+        capabilitiesResponse(false, 'workspace-1', true, {
+          expiresAt: expiresIn(30_000)
+        })
+      )
+      .mockResolvedValueOnce(capabilitiesResponse(true))
+
+    await billingCapabilities.initialize()
+
+    visibility.mockReturnValue('hidden')
+    document.dispatchEvent(new Event('visibilitychange'))
+    await vi.advanceTimersByTimeAsync(10_000)
+
+    visibility.mockReturnValue('visible')
+    document.dispatchEvent(new Event('visibilitychange'))
+
+    await vi.advanceTimersByTimeAsync(19_000)
+    expect(mockGetBillingCapabilities).toHaveBeenCalledOnce()
+
+    await vi.advanceTimersByTimeAsync(2_000)
+    expect(mockGetBillingCapabilities).toHaveBeenCalledTimes(2)
+  })
+
+  it('retimes the refresh for the new workspace after a workspace switch', async () => {
+    mockGetBillingCapabilities
+      .mockResolvedValueOnce(
+        capabilitiesResponse(false, 'workspace-1', true, {
+          expiresAt: expiresIn(30_000)
+        })
+      )
+      .mockResolvedValueOnce(
+        capabilitiesResponse(false, 'workspace-2', true, {
+          expiresAt: expiresIn(120_000)
+        })
+      )
+      .mockResolvedValueOnce(
+        capabilitiesResponse(true, 'workspace-2', true, {
+          expiresAt: expiresIn(600_000)
+        })
+      )
+
+    await billingCapabilities.initialize()
+    mockScope.workspaceId = 'workspace-2'
+    await billingCapabilities.initialize()
+    expect(mockGetBillingCapabilities).toHaveBeenCalledTimes(2)
+
+    await vi.advanceTimersByTimeAsync(60_000)
+    expect(mockGetBillingCapabilities).toHaveBeenCalledTimes(2)
+
+    await vi.advanceTimersByTimeAsync(65_000)
+    expect(mockGetBillingCapabilities).toHaveBeenCalledTimes(3)
+    expect(billingCapabilities.canTopUp.value).toBe(true)
+  })
+
+  it('stops refreshing once the shared composable scope is disposed', async () => {
+    mockGetBillingCapabilities
+      .mockResolvedValueOnce(
+        capabilitiesResponse(false, 'workspace-1', true, {
+          expiresAt: expiresIn(30_000)
+        })
+      )
+      .mockResolvedValueOnce(
+        capabilitiesResponse(true, 'workspace-1', true, {
+          expiresAt: expiresIn(90_000)
+        })
+      )
+
+    await billingCapabilities.initialize()
+    await vi.advanceTimersByTimeAsync(30_000)
+    expect(mockGetBillingCapabilities).toHaveBeenCalledTimes(2)
+
+    scope.stop()
+    await vi.advanceTimersByTimeAsync(300_000)
+
+    expect(mockGetBillingCapabilities).toHaveBeenCalledTimes(2)
+  })
+
+  it('refetches when a mutation reports a different capability revision', async () => {
+    mockGetBillingCapabilities
+      .mockResolvedValueOnce(
+        capabilitiesResponse(false, 'workspace-1', true, { revision: 4 })
+      )
+      .mockResolvedValueOnce(
+        capabilitiesResponse(true, 'workspace-1', true, { revision: 5 })
+      )
+
+    await billingCapabilities.initialize()
+    expect(billingCapabilities.canTopUp.value).toBe(false)
+
+    await emitMutationRevision('5')
+
+    expect(mockGetBillingCapabilities).toHaveBeenCalledTimes(2)
+    expect(billingCapabilities.canTopUp.value).toBe(true)
+  })
+
+  it('refetches when a failed mutation reports a different capability revision', async () => {
+    mockGetBillingCapabilities
+      .mockResolvedValueOnce(
+        capabilitiesResponse(false, 'workspace-1', true, { revision: 4 })
+      )
+      .mockResolvedValueOnce(
+        capabilitiesResponse(true, 'workspace-1', true, { revision: 5 })
+      )
+
+    await billingCapabilities.initialize()
+
+    await emitMutationRevision('5', 402)
+
+    expect(mockGetBillingCapabilities).toHaveBeenCalledTimes(2)
+    expect(billingCapabilities.canTopUp.value).toBe(true)
+  })
+
+  it('ignores a mutation that reports the cached capability revision', async () => {
+    mockGetBillingCapabilities
+      .mockResolvedValueOnce(
+        capabilitiesResponse(false, 'workspace-1', true, { revision: 4 })
+      )
+      .mockResolvedValueOnce(
+        capabilitiesResponse(true, 'workspace-1', true, { revision: 6 })
+      )
+
+    await billingCapabilities.initialize()
+
+    await emitMutationRevision('4')
+    expect(mockGetBillingCapabilities).toHaveBeenCalledOnce()
+
+    await emitMutationRevision('6')
+    expect(mockGetBillingCapabilities).toHaveBeenCalledTimes(2)
+  })
+
+  it('ignores a mutation whose response omits the revision header', async () => {
+    mockGetBillingCapabilities
+      .mockResolvedValueOnce(
+        capabilitiesResponse(false, 'workspace-1', true, { revision: 4 })
+      )
+      .mockResolvedValueOnce(
+        capabilitiesResponse(true, 'workspace-1', true, { revision: 6 })
+      )
+
+    await billingCapabilities.initialize()
+
+    await emitMutationRevision(undefined)
+    expect(mockGetBillingCapabilities).toHaveBeenCalledOnce()
+    expect(billingCapabilities.canTopUp.value).toBe(false)
+
+    await emitMutationRevision('6')
+    expect(mockGetBillingCapabilities).toHaveBeenCalledTimes(2)
   })
 })

--- a/src/platform/workspace/composables/useBillingCapabilities.ts
+++ b/src/platform/workspace/composables/useBillingCapabilities.ts
@@ -1,9 +1,14 @@
 import type { BillingCapabilitiesResponse } from '@comfyorg/ingest-types'
-import { createSharedComposable } from '@vueuse/core'
-import { computed, shallowRef, watch } from 'vue'
+import {
+  createSharedComposable,
+  defaultDocument,
+  useEventListener
+} from '@vueuse/core'
+import { computed, onScopeDispose, shallowRef, watch } from 'vue'
 
 import { isCloud } from '@/platform/distribution/types'
 import { reportError } from '@/platform/telemetry/reportError'
+import { onCapabilityRevision } from '@/platform/workspace/api/capabilityRevision'
 import {
   WorkspaceApiError,
   workspaceApi
@@ -25,6 +30,12 @@ type CapabilityReadState =
       response: BillingCapabilitiesResponse
     }
 
+// Clock skew can make a fresh snapshot look already expired, and setTimeout
+// overflows past ~24.8 days into firing immediately. Either would spin the
+// refetch into a loop, so the scheduled delay is clamped.
+const MIN_REFRESH_DELAY_MS = 5_000
+const MAX_REFRESH_DELAY_MS = 24 * 60 * 60 * 1000
+
 interface ActiveCapabilityRequest {
   requestId: number
   authUid: string
@@ -40,6 +51,7 @@ function useBillingCapabilitiesInternal() {
   let initialized = false
   let latestRequestId = 0
   let activeRequest: ActiveCapabilityRequest | null = null
+  let refreshTimer: ReturnType<typeof setTimeout> | null = null
 
   const capabilities = computed(() => {
     const userId = authStore.currentUser?.uid
@@ -90,7 +102,64 @@ function useBillingCapabilitiesInternal() {
     )
   })
 
+  function clearRefreshTimer(): void {
+    if (refreshTimer === null) return
+    clearTimeout(refreshTimer)
+    refreshTimer = null
+  }
+
+  function expiryOf(state: CapabilityReadState): number | null {
+    if (state.status !== 'resolved') return null
+    const expiresAt = Date.parse(state.response.expires_at)
+    return Number.isFinite(expiresAt) ? expiresAt : null
+  }
+
+  // `capabilities` is a computed, and wall-clock time is not a reactive
+  // dependency, so expiry has to be pushed rather than read lazily. The timer
+  // runs only while the document is visible: staleness is unobservable in a
+  // hidden tab, and returning to the tab is itself a visibility transition.
+  function scheduleRefresh(): void {
+    clearRefreshTimer()
+    const expiresAt = expiryOf(readState.value)
+    if (expiresAt === null) return
+    if (defaultDocument?.visibilityState === 'hidden') return
+
+    const delay = Math.min(
+      MAX_REFRESH_DELAY_MS,
+      Math.max(MIN_REFRESH_DELAY_MS, expiresAt - Date.now())
+    )
+    refreshTimer = setTimeout(() => {
+      refreshTimer = null
+      void fetchCapabilities()
+    }, delay)
+  }
+
+  useEventListener(defaultDocument, 'visibilitychange', () => {
+    if (defaultDocument?.visibilityState === 'hidden') {
+      clearRefreshTimer()
+      return
+    }
+    const expiresAt = expiryOf(readState.value)
+    if (expiresAt === null) return
+    if (expiresAt <= Date.now()) void fetchCapabilities()
+    else scheduleRefresh()
+  })
+
+  const stopRevisionListener = onCapabilityRevision((revision) => {
+    const state = readState.value
+    if (state.status !== 'resolved' || state.response.revision === revision) {
+      return
+    }
+    void fetchCapabilities()
+  })
+
+  onScopeDispose(() => {
+    clearRefreshTimer()
+    stopRevisionListener()
+  })
+
   function resetRead(): void {
+    clearRefreshTimer()
     latestRequestId++
     activeRequest?.controller.abort()
     activeRequest = null
@@ -147,6 +216,7 @@ function useBillingCapabilitiesInternal() {
                 response
               }
             : { status: 'unavailable', authUid: userId, workspaceId }
+        scheduleRefresh()
       } catch (error) {
         if (
           requestId !== latestRequestId ||


### PR DESCRIPTION
## Summary

Consumes the capability response's freshness contract, so a snapshot can't outlive a webhook-processed billing change or a mutation made in another tab. Raised independently by two reviewers on #15803.

Stacked on #15803, lands before #15804 — so no renderer ever ships without it.

## Two halves

**Expiry refresh.** A single `setTimeout` derived from the snapshot's `expires_at`, gated on document visibility: scheduled only while the tab is visible, cleared when it hides, and on return either refetched immediately (if already expired) or rescheduled for the remaining lifetime.

This is push, not pull, deliberately — `capabilities` is a `computed`, and wall-clock time is not a reactive dependency, so a lazy check inside it would stay memoized while the UI renders stale values. Visibility gating keeps an unconditional 2 requests/minute per session out of hidden tabs, where staleness is unobservable anyway.

The delay is clamped to `[5s, 24h]`: clock skew can make a fresh 30s snapshot look already expired (delay 0 → refetch → still expired → loop), and `setTimeout` silently overflows past ~24.8 days into firing immediately.

**Revision invalidation.** A response interceptor on `workspaceApiClient` reads `X-Capability-Revision` and invalidates when it differs from the cached snapshot's `revision`. It sits beside the existing `attachUnifiedRemintInterceptor` on the same client rather than introducing a new layer; the notifier is its own module because `workspaceApi` cannot import the composable that imports it.

Four contract details it handles:
- The header is absent on desktop, where CORS is bypassed for local origins — every read is defensive and degrades silently.
- The middleware stamps the header *before* the handler, so failed mutations carry it. Both interceptor arms are registered; a 402 still invalidates.
- The header is declared only on the capabilities GET, so generated types never surface it on mutations — the read is hand-written against `AxiosHeaders`.
- `POST /api/billing/payment-portal` has no revision middleware yet, so portal-driven changes invalidate via the 30s timer rather than instantly. Known backend gap, tracked separately, not worked around here.

## Verification

- 21 new tests. Each was confirmed to **fail against the unfixed source** rather than assumed — including the two absence assertions, which pair the negative with a positive tail so they cannot pass vacuously.
- `pnpm typecheck`, `typecheck:browser`, `lint`, `format:check`, `knip` — all clean.
- Full suite under `--coverage` (both new files land in the critical-coverage glob): **17,509 passed**, 0 coverage-threshold errors. The 12 `check-binary-size` failures are pre-existing and environmental.

## Reviewer note

Interceptor ordering is the non-obvious bit: the revision interceptor registers after the remint one, so a re-minted 401 retry publishes twice. Self-limiting — the first publish moves `readState` to `pending` and the listener ignores anything not `resolved`.
