### PR TITLE
fix(paste): ignore clipboard node metadata left by an earlier copy

### DIFF
--- a/src/composables/useCopy.ts
+++ b/src/composables/useCopy.ts
@@ -3,13 +3,7 @@ import { useEventListener } from '@vueuse/core'
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import { shouldIgnoreCopyPaste } from '@/workbench/eventHelpers'
 
-/**
- * Identifies the copy that produced the clipboard's node metadata, so the
- * paste handler can tell an in-app copy from a payload left behind by an
- * earlier one. Only the id is stored, never the payload: a serialized
- * selection can run to megabytes against a ~5MB origin quota, and a failed
- * write would misclassify the user's own fresh copy as stale.
- */
+/** Identifies the last in-app copy. Only the id, never the payload. */
 export const LAST_COPY_ID_KEY = 'Comfy.Clipboard.LastCopyId'
 
 const clipboardHTMLWrapper = (id: string | null) => [
@@ -55,10 +49,7 @@ export const useCopy = () => {
     const canvas = canvasStore.canvas
     if (canvas?.selectedItems) {
       const serializedData = canvas.copyToClipboard()
-      // Persist the id before it reaches the clipboard, so the two can only
-      // diverge in the safe direction: metadata without an id reads as
-      // stale, whereas an id the paste handler never learned about would
-      // make the user's own copy look stale.
+      // Before the clipboard write, so the two can only diverge safely.
       let copyId: string | null = null
       try {
         const id = crypto.randomUUID()

--- a/src/composables/useCopy.ts
+++ b/src/composables/useCopy.ts
@@ -3,8 +3,17 @@ import { useEventListener } from '@vueuse/core'
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import { shouldIgnoreCopyPaste } from '@/workbench/eventHelpers'
 
-const clipboardHTMLWrapper = [
-  '<meta charset="utf-8"><div><span data-metadata="',
+/**
+ * Identifies the copy that produced the clipboard's node metadata, so the
+ * paste handler can tell an in-app copy from a payload left behind by an
+ * earlier one. Only the id is stored, never the payload: a serialized
+ * selection can run to megabytes against a ~5MB origin quota, and a failed
+ * write would misclassify the user's own fresh copy as stale.
+ */
+export const LAST_COPY_ID_KEY = 'Comfy.Clipboard.LastCopyId'
+
+const clipboardHTMLWrapper = (id: string) => [
+  `<meta charset="utf-8"><div><span data-copy-id="${id}" data-metadata="`,
   '"></span></div><span style="white-space:pre-wrap;">Text</span>'
 ]
 const clipboardByteChunkSize = 0x8000
@@ -47,12 +56,14 @@ export const useCopy = () => {
     if (canvas?.selectedItems) {
       const serializedData = canvas.copyToClipboard()
       try {
+        const copyId = crypto.randomUUID()
         const base64Data = encodeClipboardData(serializedData)
         // clearData doesn't remove images from clipboard
         e.clipboardData?.setData(
           'text/html',
-          clipboardHTMLWrapper.join(base64Data)
+          clipboardHTMLWrapper(copyId).join(base64Data)
         )
+        localStorage.setItem(LAST_COPY_ID_KEY, copyId)
       } catch (error) {
         console.error(error)
       }

--- a/src/composables/useCopy.ts
+++ b/src/composables/useCopy.ts
@@ -12,8 +12,8 @@ import { shouldIgnoreCopyPaste } from '@/workbench/eventHelpers'
  */
 export const LAST_COPY_ID_KEY = 'Comfy.Clipboard.LastCopyId'
 
-const clipboardHTMLWrapper = (id: string) => [
-  `<meta charset="utf-8"><div><span data-copy-id="${id}" data-metadata="`,
+const clipboardHTMLWrapper = (id: string | null) => [
+  `<meta charset="utf-8"><div>${id ? `<span data-copy-id="${id}" ` : '<span '}data-metadata="`,
   '"></span></div><span style="white-space:pre-wrap;">Text</span>'
 ]
 const clipboardByteChunkSize = 0x8000
@@ -55,15 +55,25 @@ export const useCopy = () => {
     const canvas = canvasStore.canvas
     if (canvas?.selectedItems) {
       const serializedData = canvas.copyToClipboard()
+      // Persist the id before it reaches the clipboard, so the two can only
+      // diverge in the safe direction: metadata without an id reads as
+      // stale, whereas an id the paste handler never learned about would
+      // make the user's own copy look stale.
+      let copyId: string | null = null
       try {
-        const copyId = crypto.randomUUID()
+        const id = crypto.randomUUID()
+        localStorage.setItem(LAST_COPY_ID_KEY, id)
+        copyId = id
+      } catch (error) {
+        console.error(error)
+      }
+      try {
         const base64Data = encodeClipboardData(serializedData)
         // clearData doesn't remove images from clipboard
         e.clipboardData?.setData(
           'text/html',
           clipboardHTMLWrapper(copyId).join(base64Data)
         )
-        localStorage.setItem(LAST_COPY_ID_KEY, copyId)
       } catch (error) {
         console.error(error)
       }

--- a/src/composables/usePaste.test.ts
+++ b/src/composables/usePaste.test.ts
@@ -1,10 +1,11 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type {
   LGraphCanvas,
   LGraph,
   LGraphGroup,
   LGraphNode
 } from '@/lib/litegraph/src/litegraph'
+import { LAST_COPY_ID_KEY } from '@/composables/useCopy'
 import { app } from '@/scripts/app'
 import { createMockLGraphNode } from '@/utils/__tests__/litegraphTestUtils'
 import {
@@ -574,31 +575,70 @@ describe('usePaste', () => {
     })
   })
 
-  it('should skip node metadata paste when a media node is selected', async () => {
-    const mockNode = createMockLGraphNode({
-      is_selected: true,
-      pasteFile: vi.fn(),
-      pasteFiles: vi.fn()
+  describe('media node selected', () => {
+    function setupMediaNodeSelected() {
+      const mockNode = createMockLGraphNode({
+        is_selected: true,
+        pasteFile: vi.fn(),
+        pasteFiles: vi.fn()
+      })
+      mockCanvas.current_node = mockNode
+      vi.mocked(isImageNode).mockReturnValue(true)
+      usePaste()
+    }
+
+    function dispatchMetadataPaste(decoded: string, copyId?: string) {
+      const idAttr = copyId ? ` data-copy-id="${copyId}"` : ''
+      const dataTransfer = new DataTransfer()
+      dataTransfer.setData(
+        'text/html',
+        `<div${idAttr} data-metadata="${btoa(decoded)}"></div>`
+      )
+      dataTransfer.setData('text/plain', 'some text')
+      document.dispatchEvent(
+        new ClipboardEvent('paste', { clipboardData: dataTransfer })
+      )
+    }
+
+    afterEach(() => {
+      localStorage.removeItem('litegrapheditor_clipboard')
+      localStorage.removeItem(LAST_COPY_ID_KEY)
     })
-    mockCanvas.current_node = mockNode
-    vi.mocked(isImageNode).mockReturnValue(true)
 
-    usePaste()
+    it('skips paste entirely for stale node metadata', async () => {
+      setupMediaNodeSelected()
+      dispatchMetadataPaste(JSON.stringify({ nodes: [{ type: 'KSampler' }] }))
 
-    const nodeData = { nodes: [{ type: 'KSampler' }] }
-    const encoded = btoa(JSON.stringify(nodeData))
-    const html = `<div data-metadata="${encoded}"></div>`
+      await vi.waitFor(() => {
+        expect(mockCanvas._deserializeItems).not.toHaveBeenCalled()
+        expect(mockCanvas.pasteFromClipboard).not.toHaveBeenCalled()
+      })
+    })
 
-    const dataTransfer = new DataTransfer()
-    dataTransfer.setData('text/html', html)
-    dataTransfer.setData('text/plain', 'some text')
+    it('pastes a freshly copied node', async () => {
+      setupMediaNodeSelected()
+      const serialized = JSON.stringify({ nodes: [{ type: 'LoadImage' }] })
+      localStorage.setItem(LAST_COPY_ID_KEY, 'copy-1')
+      dispatchMetadataPaste(serialized, 'copy-1')
 
-    const event = new ClipboardEvent('paste', { clipboardData: dataTransfer })
-    document.dispatchEvent(event)
+      await vi.waitFor(() => {
+        expect(mockCanvas._deserializeItems).not.toHaveBeenCalled()
+        expect(mockCanvas.pasteFromClipboard).toHaveBeenCalled()
+      })
+    })
 
-    await vi.waitFor(() => {
-      expect(mockCanvas._deserializeItems).not.toHaveBeenCalled()
-      expect(mockCanvas.pasteFromClipboard).toHaveBeenCalled()
+    it('pastes the internal clipboard after a menu copy left older OS metadata', async () => {
+      setupMediaNodeSelected()
+      const ctrlCCopy = JSON.stringify({ nodes: [{ type: 'KSampler' }] })
+      const menuCopy = JSON.stringify({ nodes: [{ type: 'CLIPTextEncode' }] })
+      localStorage.setItem(LAST_COPY_ID_KEY, 'copy-1')
+      localStorage.setItem('litegrapheditor_clipboard', menuCopy)
+      dispatchMetadataPaste(ctrlCCopy, 'copy-1')
+
+      await vi.waitFor(() => {
+        expect(mockCanvas._deserializeItems).not.toHaveBeenCalled()
+        expect(mockCanvas.pasteFromClipboard).toHaveBeenCalled()
+      })
     })
   })
 })

--- a/src/composables/usePaste.test.ts
+++ b/src/composables/usePaste.test.ts
@@ -615,6 +615,20 @@ describe('usePaste', () => {
       })
     })
 
+    it('skips paste when the metadata carries a different copy id', async () => {
+      setupMediaNodeSelected()
+      localStorage.setItem(LAST_COPY_ID_KEY, 'copy-2')
+      dispatchMetadataPaste(
+        JSON.stringify({ nodes: [{ type: 'KSampler' }] }),
+        'copy-1'
+      )
+
+      await vi.waitFor(() => {
+        expect(mockCanvas._deserializeItems).not.toHaveBeenCalled()
+        expect(mockCanvas.pasteFromClipboard).not.toHaveBeenCalled()
+      })
+    })
+
     it('pastes a freshly copied node', async () => {
       setupMediaNodeSelected()
       const serialized = JSON.stringify({ nodes: [{ type: 'LoadImage' }] })

--- a/src/composables/usePaste.ts
+++ b/src/composables/usePaste.ts
@@ -1,5 +1,7 @@
 import { useEventListener } from '@vueuse/core'
 
+import { LAST_COPY_ID_KEY } from '@/composables/useCopy'
+
 import type { LGraphCanvas, LGraphNode } from '@/lib/litegraph/src/litegraph'
 import type { ComfyWorkflowJSON } from '@/platform/workflow/validation/schemas/workflowSchema'
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
@@ -40,21 +42,43 @@ export function cloneDataTransfer(original: DataTransfer): DataTransfer {
   return persistent
 }
 
-function pasteClipboardItems(data: DataTransfer): boolean {
-  const rawData = data.getData('text/html')
-  const match = rawData.match(/data-metadata="([A-Za-z0-9+/=]+)"/)?.[1]
-  if (!match) return false
+function decodeNodeMetadata(rawHtml: string): string | null {
+  const match = rawHtml.match(/data-metadata="([A-Za-z0-9+/=]+)"/)?.[1]
+  if (!match) return null
   try {
     // Decode UTF-8 safe base64
     const binaryString = atob(match)
     const bytes = Uint8Array.from(binaryString, (c) => c.charCodeAt(0))
-    const decodedData = new TextDecoder().decode(bytes)
+    return new TextDecoder().decode(bytes)
+  } catch {
+    return null
+  }
+}
+
+function pasteClipboardItems(data: DataTransfer): boolean {
+  const decodedData = decodeNodeMetadata(data.getData('text/html'))
+  if (decodedData === null) return false
+  try {
     useCanvasStore().getCanvas()._deserializeItems(JSON.parse(decodedData), {})
     return true
   } catch (err) {
     console.error(err)
   }
   return false
+}
+
+/**
+ * Node metadata is stale when the copy that produced it is not the last one
+ * this profile made. useCopy stamps each copy with an id and remembers it;
+ * metadata carrying a different id (or none) was left behind by an earlier
+ * copy, a copy from another instance, or a page that happens to expose the
+ * attribute. Comparing ids rather than payloads keeps this independent of
+ * how either clipboard serializes.
+ */
+function hasStaleNodeMetadata(rawHtml: string): boolean {
+  if (decodeNodeMetadata(rawHtml) === null) return false
+  const copyId = rawHtml.match(/data-copy-id="([^"]+)"/)?.[1]
+  return !copyId || copyId !== localStorage.getItem(LAST_COPY_ID_KEY)
 }
 
 function pasteItemsOnNode(
@@ -233,6 +257,8 @@ export const usePaste = () => {
     const isMediaNodeSelected =
       isImageNodeSelected || isVideoNodeSelected || isAudioNodeSelected
     if (!isMediaNodeSelected && pasteClipboardItems(data)) return
+    const staleMetadataOnMediaNode =
+      isMediaNodeSelected && hasStaleNodeMetadata(data.getData('text/html'))
 
     // No image found. Look for node data
     data = data.getData('text/plain')
@@ -261,8 +287,11 @@ export const usePaste = () => {
         return
       }
 
-      // Litegraph default paste
-      canvas.pasteFromClipboard()
+      // Litegraph default paste. Skipped when a media node is selected and
+      // the clipboard carries stale node metadata: the user is targeting
+      // that node, and the leftover payload must not paste an old node
+      // (see the imagePastePriority e2e). A fresh in-app copy still pastes.
+      if (!staleMetadataOnMediaNode) canvas.pasteFromClipboard()
     }
   })
 }

--- a/src/composables/usePaste.ts
+++ b/src/composables/usePaste.ts
@@ -67,14 +67,7 @@ function pasteClipboardItems(data: DataTransfer): boolean {
   return false
 }
 
-/**
- * Node metadata is stale when the copy that produced it is not the last one
- * this profile made. useCopy stamps each copy with an id and remembers it;
- * metadata carrying a different id (or none) was left behind by an earlier
- * copy, a copy from another instance, or a page that happens to expose the
- * attribute. Comparing ids rather than payloads keeps this independent of
- * how either clipboard serializes.
- */
+/** Stale when the copy that produced it is not the last one made here. */
 function hasStaleNodeMetadata(rawHtml: string): boolean {
   if (decodeNodeMetadata(rawHtml) === null) return false
   const copyId = rawHtml.match(/data-copy-id="([^"]+)"/)?.[1]
@@ -287,10 +280,7 @@ export const usePaste = () => {
         return
       }
 
-      // Litegraph default paste. Skipped when a media node is selected and
-      // the clipboard carries stale node metadata: the user is targeting
-      // that node, and the leftover payload must not paste an old node
-      // (see the imagePastePriority e2e). A fresh in-app copy still pastes.
+      // Litegraph default paste.
       if (!staleMetadataOnMediaNode) canvas.pasteFromClipboard()
     }
   })


### PR DESCRIPTION
> [!IMPORTANT]
> **Merge this first.** #13842 depends on it: that PR's compact tab bar is what lets
> `imagePastePriority.spec.ts` run, so its CI stays red until this lands.
> Merge order: this, then #13842, then #15893.

## ELI5

Copy a node, then copy something else outside Comfy, then click an image node and paste. Today the old node lands on the graph. It should do nothing.

## What

Pasting onto a selected media node falls through to litegraph's default paste, which deserializes whatever node metadata the OS clipboard still carries: even when that metadata is left over from an earlier copy.

`useCopy` now stamps each copy with an id, keeps it in `localStorage`, and embeds it in the clipboard metadata. Metadata whose id does not match the last copy is treated as leftover, and the default paste is skipped while a media node is selected. A fresh in-app copy still duplicates as before.

Comparing ids rather than serialized payloads keeps this independent of how either clipboard serializes, and stores a handful of bytes instead of a full selection, so a `QuotaExceededError` cannot silently reclassify a fresh copy as stale.

## Why it surfaced now

`browser_tests/tests/imagePastePriority.spec.ts` passes on `main` without exercising anything: the 38px workflow tab bar swallows the fixture's title clicks at y=35, so nothing is selected or copied and the assertion holds vacuously. A compact tab bar in #13842 let those clicks through, the spec ran for the first time, and it failed. Split out of that PR after review, since it is a behaviour change unrelated to theming.

## Testing

- `vitest run src/composables/usePaste.test.ts src/composables/useCopy.test.ts`: 40 passing, covering the stale path, the fresh path, and a menu copy that moved litegraph's clipboard past the OS payload.
- `imagePastePriority.spec.ts` covers the end-to-end case once a tab bar change lets it run.
