### PR TITLE
docs: apply accepted ADR and exceptions-log suggestions

### DIFF
--- a/docs/adr/0017-id-based-slot-records-are-the-slot-destination.md
+++ b/docs/adr/0017-id-based-slot-records-are-the-slot-destination.md
@@ -1,4 +1,4 @@
-# 17. ID-Based Slot Records Are the Slot Destination
+# 17. ID-Based Slot Records Own Slot State
 
 Date: 2026-08-24
 
@@ -6,134 +6,80 @@ Date: 2026-08-24
 
 Accepted
 
-Decided by Christian Byrne on 2026-08-24 (program decision D-dq-08, option A),
-conditional on three artifacts: this ADR, full documentation of the current
-transitional state, and an entry in the central repo exceptions log
-(`docs/exceptions-log.md`). The transitional-state documentation lives in the
-Context section below; the exceptions-log entry lands as a companion change.
-
 ## Context
 
-The ECS migration (#14246, ADR-0008) moved node shell state, widget values,
-link topology, and reroute chains into stores. Slots are the one remaining
-component family whose live state is still owned by class instances — the
-"class-owned component fields" retirement item.
+The ECS migration moved node shell state, widget values, link topology, and
+reroute chains into stores. Slot metadata is the remaining exception.
 
-### Current state (verified at main `a8abe573c0`)
+Today:
 
-- `NodeState.inputs` / `NodeState.outputs` are `shallowReactive` arrays of
-  `INodeInputSlot` / `INodeOutputSlot` **class instances**
-  (`src/types/nodeState.ts`, `createNodeShellState` in
-  `src/core/graph/nodeShell/nodeShellState.ts`).
-- `LGraphNode.inputs` is a getter over the store proxy's `_state.inputs`
-  (`src/lib/litegraph/src/LGraphNode.ts`). The array **container** is
-  store-held, but every slot **field** (name, type, geometry, flags) lives on
-  the class instance the array points at. There is no slot record, no slot
-  store, and no slot id.
-- Link **connectivity** is already store-owned: `linkStore` answers
-  "is this slot connected, and by what links"; the mutable `input.link` /
-  `output.links` mirrors were deleted, leaving deprecated read-only
-  compatibility accessors (see
-  `docs/architecture/output-slot-connectivity.md`). Slot entity extraction
-  (`SlotIdentity` / `SlotVisual` rows, retiring the class instances and their
-  `shallowReactive` graft) was explicitly deferred there as the
-  `SlotConnection` phase: "Introducing it now would be premature."
+- `NodeState.inputs` and `NodeState.outputs` contain `INodeInputSlot` and
+  `INodeOutputSlot` class instances.
+- The arrays are store-held, but fields such as name, type, geometry, and flags
+  live on those class instances. Slots have no records, store, or IDs.
+- Link connectivity already lives in `linkStore`. The deprecated `input.link`
+  and `output.links` accessors derive their values from that store.
 
-### The ambiguity this ADR resolves
-
-PR #15544 proposes flipping `NodeState` slot arrays from class instances to
-plain descriptors, with a Proxy virtual array projecting descriptors back to
-class instances at the extension boundary. Its own structural follow-up plan
-(slice 1) then proposes restoring **real slot-class arrays** at the extension
-boundary, deriving descriptors at the node-state boundary "until a complete
-ID-based slot record can replace both representations." Both representations
-are named as interim, but slice 1 does not say which side is _authoritative_
-during the interim — and "keep real slot-class arrays, derive descriptors
-from them" reads as class arrays owning live state again, which is exactly
-the state the retirement item exists to end.
+PR #15544 explores descriptors and Proxy-backed arrays as compatibility layers.
+Those layers may change how extensions access slots, but they do not answer
+which representation owns the data during the migration. This ADR establishes
+one source of truth.
 
 ## Decision
 
-**ID-based slot records in stores are the destination for slot state.
-Slot-class arrays — and any descriptor or Proxy projection of them — are
-derived views over store state, never owners.**
+Each slot will eventually have an ID-keyed record in a store. That record will
+own the slot's state.
 
-Three rules follow:
+`LGraphNode.inputs`, `LGraphNode.outputs`, descriptors, Proxies, and
+extension-facing slot objects may remain during the migration. Once a slot
+field moves into a store record, every compatibility view must read and write
+that record rather than keep separate state.
 
-1. **Authority direction is one-way.** Once a slot field's source of truth
-   moves into a store record, no later change may make a class instance or a
-   boundary projection authoritative over it again. During any interim step
-   (including a #15544-style compat boundary), views must read from and write
-   through store state; a change that reverses that direction is a regression,
-   not a judgment call.
-2. **The current class-instance ownership is a known, bounded exception, not
-   an accepted end state.** It is recorded in the central exceptions log
-   (`docs/exceptions-log.md`) with an owner and an exit condition: the
-   exception closes when slot records own slot state and both interim
-   representations (class-instance `NodeState` arrays, and any
-   descriptor/Proxy boundary layer) are retired.
-3. **Slot records are introduced for function, not form.** The repo's
-   retirement ledger explicitly rules out "slot IDs or component stores
-   created solely to match an abstract ECS model." A slot record lands when
-   it replaces both interim representations and retires the authority
-   ambiguity — carried by work that needs it, not as a purity refactor.
+The current class-owned state is a temporary exception recorded in
+`docs/exceptions-log.md`. The exception closes when store records own slot state
+and the class-owned arrays and any descriptor or Proxy layer have been removed.
 
-### Deliberately not decided here: the slot key scheme
+We will introduce slot records when implementation work can replace the current
+representations. We will not add them only to make the code resemble an
+abstract ECS model.
 
-Whether slot ids are **structural** (derived from position, e.g.
-`graphId:nodeId:direction:index` or `:name`, like `WidgetId`) or **minted**
-(app-issued counters, like `NodeId` / `LinkId`) is left to the PR that
-introduces the record. The choice is consequential: per ADR-0008's
-"Amendment (2026-08-23): registration and collision contract," the key kind
-determines the collision family — structural keys resolve-and-reuse, minted
-identity keys reject-or-remint. Widget re-mint semantics (values surviving
-node replacement) suggest slots share the structural family, but slot
-reordering and renaming complicate positional keys. That analysis belongs
-with the implementation; whichever kind is chosen, the collision contract
-must be added to ADR-0008's amendment and pinned in
+### Slot keys
+
+This ADR does not choose between structural keys, such as
+`graphId:nodeId:direction:index`, and minted IDs. Structural keys make reuse
+straightforward but must account for slot renames and reordering. Minted IDs
+need explicit collision and reminting behavior.
+
+The implementation that chooses the key format must document its collision
+behavior in ADR-0008 and test it in
 `src/stores/storeCollisionContracts.test.ts`.
 
 ## Migration path
 
-1. **Now (interim).** Class instances remain the live slot state; the
-   extension-visible surface is unchanged; the exceptions-log entry is open.
-2. **Boundary compat step (#15544 family, if it proceeds).** The
-   extension-visible arrays stay real slot-class arrays for ecosystem
-   compatibility, but as _views_: descriptors derived at the node-state
-   boundary, mutations flowing through store state. Rule 1 applies from the
-   moment any slot field moves store-side.
-3. **Slot record introduction.** The deferred `SlotConnection` phase:
-   `SlotIdentity` / `SlotVisual` (or equivalent) rows in a store, readers and
-   writers migrated, collision contract recorded and tested.
-4. **Retirement.** Remove the descriptor/Proxy boundary layer (if it landed)
-   and the class-instance `NodeState` arrays once ecosystem tests cover
-   indexed access, mutation methods, reflection, and stable slot identity.
-   Closing this step ticks the "class-owned component fields" retirement item
-   and closes the exceptions-log entry.
+1. Keep the current slot classes and extension API while the exception is open.
+2. Move each migrated slot field into store state. Compatibility objects must
+   read and write that state.
+3. Add ID-keyed slot records, migrate readers and writers, and test the chosen
+   collision behavior.
+4. Remove the class-owned arrays and any descriptor or Proxy layer after
+   ecosystem tests cover indexed access, array mutations, reflection, and
+   stable slot identity.
 
 ## Consequences
 
-- Slot authority becomes consistent with every other migrated component
-  family: stores own state, classes and projections are views. Reviews gain a
-  bright-line rule for slot-touching PRs — check the authority direction.
-- The interim state is legible: anyone finding class-owned slot fields can
-  follow the exceptions-log entry to the exit condition instead of guessing
-  whether it is intended.
-- Ecosystem compatibility work (indexed access, array mutation methods,
-  reflection, slot identity stability) is on the critical path to retirement
-  and must be tested before either interim representation is removed.
-- The slot key-kind decision is deferred with its constraints written down;
-  ADR-0008's collision-contract amendment gains a slot row when it is made.
+- Slot metadata will have one source of truth, consistent with other migrated
+  entity state.
+- Extensions can keep using slot arrays while the migration is in progress.
+- Compatibility behavior must be tested before either interim representation
+  is removed.
+- The slot key format remains undecided until the implementation has enough
+  information to choose it.
 
 ## References
 
-- Program decision D-dq-08 (2026-08-24), packet
-  `sc-01-slot-destination-decision` (program records; mirrored to the Notion
-  decision log per D-proc-01)
-- ADR-0008 "Entity Component System," including "Amendment (2026-08-23):
-  registration and collision contract"
-- `docs/architecture/output-slot-connectivity.md` (deferred `SlotConnection`
-  phase; link-connectivity store migration)
+- ADR-0008, "Entity Component System"
+- `docs/architecture/output-slot-connectivity.md`
 - `docs/architecture/node-data-store.md`
-- `docs/exceptions-log.md` (central exceptions log; companion entry)
-- #14246 (ECS migration merge), #15544 (descriptor/Proxy boundary proposal)
+- `docs/exceptions-log.md`
+- PR #14246, ECS migration
+- PR #15544, descriptor and Proxy boundary proposal

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -25,7 +25,7 @@ An Architecture Decision Record captures an important architectural decision mad
 | [0013](0013-telemetry-service-selection.md)                                 | Telemetry Service Selection                                 | Accepted | 2026-07-28 |
 | [0014](0014-billing-telemetry-attempt-correlation-and-workspace-scoping.md) | Billing Telemetry Attempt Correlation and Workspace Scoping | Proposed | 2026-07-28 |
 | [0015](0015-adopt-fallow.md)                                                | Adopt Fallow                                                | Proposed | 2026-06-29 |
-| [0017](0017-id-based-slot-records-are-the-slot-destination.md)              | ID-Based Slot Records Are the Slot Destination              | Accepted | 2026-08-24 |
+| [0017](0017-id-based-slot-records-are-the-slot-destination.md)              | ID-Based Slot Records Own Slot State                        | Accepted | 2026-08-24 |
 
 ## Creating a New ADR
 

--- a/docs/exceptions-log.md
+++ b/docs/exceptions-log.md
@@ -1,65 +1,94 @@
-# Repository Exceptions Log
+# Repository exceptions and compatibility contracts
 
-This file is the central log of **known, bounded, deliberate exceptions** to
-the repository's house invariants (single source of truth, store-owned state
-with derived views, documented-and-tested contracts, no compatibility
-guarantees beyond those explicitly granted).
+This file records two kinds of deliberate departures from the repository's
+normal architecture rules:
 
-An exception belongs here when a change knowingly deviates from an invariant
-**on purpose** — as a transitional state, a scoped compatibility contract, or
-a consciously accepted gap — rather than by accident. Logging it makes the
-deviation legible: anyone who finds the deviating code can look up whether it
-is intended, who owns it, and what closes it.
+- Temporary exceptions describe a known transitional state and how to end it.
+- Compatibility contracts preserve a specific behavior for external consumers.
 
 ## Rules
 
-1. **Every entry has an owner, an entry date, an exit condition, and a link
-   to the decision that granted it.** An exception without an exit condition
-   is not an exception; it is an unrecorded change to the invariant.
-2. **Entries are never silently deleted.** When an exception's exit condition
-   is met, move its row to the Closed section with the closing date and the
-   change that closed it.
-3. **Exceptions do not generalize.** Each entry covers exactly the scope it
-   states. Extending an exception (more properties, more stores, more time)
-   requires a new decision, not an edit to the existing row.
-4. **Reviewers may cite this log.** A PR that deviates from a house invariant
-   without a matching entry here (or a new entry added in the same PR) is a
-   defect, not a judgment call.
+A temporary exception must name its scope, owner, opening date, closing
+condition, and decision record. When it closes, move it to the closed section
+and add the closing date and change that closed it.
+
+An entry applies only to the scope it names. Expanding that scope requires a
+new decision. A pull request that introduces another exception must add or
+reference an entry here.
+
+Compatibility contracts do not need a closing date. Changing one requires a
+superseding decision.
 
 ## Open exceptions
 
-### EX-001 — Slot state is class-owned (dual representation) during the slot migration
+### EX-001: Slot metadata remains class-owned during migration
 
-| Field                  | Value                                                                                                                                                                                                                                                                                                                                                       |
-| ---------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Invariant excepted** | Stores own entity state; class instances and boundary projections are derived views.                                                                                                                                                                                                                                                                        |
-| **Exception**          | Node slot state (`NodeInputSlot` / `NodeOutputSlot` instances) remains live, class-owned state: `NodeState` holds slot-class instances, `nodeShellState` exposes them via `shallowReactive` arrays, and `LGraphNode.inputs`/`outputs` read them through the store proxy. The store holds the _container_; the slot _fields_ are class-owned.                |
-| **Owner**              | Christian Byrne                                                                                                                                                                                                                                                                                                                                             |
-| **Entered**            | 2026-08-24                                                                                                                                                                                                                                                                                                                                                  |
-| **Exit condition**     | ID-based slot records own slot state and **both** interim representations — the class-instance `NodeState` arrays and any descriptor/Proxy boundary layer (#15544 family) — are retired. Authority direction is one-way in the meantime: once a slot field moves store-side, no change may make a class instance or projection authoritative over it again. |
-| **Decision record**    | [ADR-0017](adr/0017-id-based-slot-records-are-the-slot-destination.md) (program decision D-dq-08, 2026-08-24; mirrored to the Notion decision log)                                                                                                                                                                                                          |
+**Normal rule:** Stores own entity state. Classes and boundary objects expose
+views of that state.
 
-### EX-002 — Store collision contract is live in code but not yet documented and pinned on `main`
+**Current exception:** `NodeState` holds `NodeInputSlot` and `NodeOutputSlot`
+instances in `shallowReactive` arrays. `LGraphNode.inputs` and
+`LGraphNode.outputs` expose those arrays through the store proxy. The array
+containers are store-held, but slot fields remain on the class instances.
 
-| Field                  | Value                                                                                                                                                                                                                                                                                                                                                       |
-| ---------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Invariant excepted** | Behavioral contracts are documented in ADRs and pinned by tests before they are relied on.                                                                                                                                                                                                                                                                  |
-| **Exception**          | The per-store registration collision contract (identity-keyed stores — `nodeDataStore`, `linkStore`, `rerouteStore` — reject on collision, caller remints; the structural-keyed `widgetValueStore` resolves) is live in code, but `main`'s ADR collision table predates it and misstates per-store behavior, and no invariant test suite pins the contract. |
-| **Owner**              | Christian Byrne                                                                                                                                                                                                                                                                                                                                             |
-| **Entered**            | 2026-08-24                                                                                                                                                                                                                                                                                                                                                  |
-| **Exit condition**     | The D-dq-04 bundle lands on `main`: the remint-loop collision log (#15720), the corrected contract documentation (#15761 rebase — ADR-0003 table corrections and the ADR-0008 registration/collision amendment), and the four-store invariant test suite (`src/stores/storeCollisionContracts.test.ts`).                                                    |
-| **Decision record**    | Program decision D-dq-04 (2026-08-24; mirrored to the Notion decision log); PRs #15720, #15761; issue #15743                                                                                                                                                                                                                                                |
+**Owner:** Christian Byrne
 
-### EX-003 — `LLink` guarantees exactly seven own-enumerable legacy topology properties
+**Opened:** 2026-08-24
 
-| Field                  | Value                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
-| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| **Invariant excepted** | Entity instances make no enumeration or spread-copy compatibility guarantee; state is exposed through accessors over store-backed state.                                                                                                                                                                                                                                                                                                                                                                                                                                 |
-| **Exception**          | Exactly seven historically own-enumerable `LLink` properties — `id`, `type`, `origin_id`, `origin_slot`, `target_id`, `target_slot`, `parentId` — are preserved as own enumerable **forwarding descriptors** (prototype accessors copied onto each instance) so ecosystem spread-copy consumers keep working. Reads and writes still delegate to the store-backed `LLink._state`; no synchronized plain fields exist. This is **not** a general entity-enumeration guarantee: no other `LLink` keys, and no other entity types (`Reroute`, widgets, nodes), are covered. |
-| **Owner**              | Christian Byrne (implementation vehicle: #15654)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
-| **Entered**            | 2026-08-24                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
-| **Exit condition**     | Bounded in scope, not time. Superseding decision required if: the project adopts and publishes a breaking policy that entity enumeration is unsupported; the forwarding descriptors are shown to violate a concrete invariant; or measured consumers require an exact whole-object/key-order contract rather than these seven values.                                                                                                                                                                                                                                    |
-| **Decision record**    | Program decision D-c6-01 (2026-08-24; mirrored to the Notion decision log); PR #15654 (implementation), PR #15778 (closed as duplicate; carries the original patch and discussion)                                                                                                                                                                                                                                                                                                                                                                                       |
+**Closes when:** ID-keyed store records own slot state and both interim
+representations have been removed: the class-instance arrays and any descriptor
+or Proxy compatibility layer. Once a field moves into a store record, no class
+or projection may become a separate source of truth for it.
+
+**Decision:** [ADR-0017](adr/0017-id-based-slot-records-are-the-slot-destination.md)
+
+### EX-002: Store collision behavior is not yet documented and tested
+
+**Normal rule:** Tests and ADRs document behavioral contracts before other code
+relies on them.
+
+**Current exception:** `nodeDataStore`, `linkStore`, and `rerouteStore` reject
+identity-key collisions so the caller can mint a new ID. `widgetValueStore`
+resolves structural-key collisions. The behavior exists in code, but the ADR
+collision table is outdated and no shared test suite covers all four stores.
+
+**Owner:** Christian Byrne
+
+**Opened:** 2026-08-24
+
+**Closes when:** PRs #15720 and #15761 land with the corrected ADR text and
+`src/stores/storeCollisionContracts.test.ts` covers all four stores. Issue
+#15743 tracks the work.
+
+**Decision:** PRs #15720 and #15761
+
+## Compatibility contracts
+
+### EX-003: `LLink` preserves seven enumerable topology properties
+
+`LLink` keeps these own enumerable properties for consumers that copy links
+with object spread:
+
+- `id`
+- `type`
+- `origin_id`
+- `origin_slot`
+- `target_id`
+- `target_slot`
+- `parentId`
+
+They are forwarding descriptors. Reads and writes still use the store-backed
+`LLink._state`; the instance does not keep synchronized copies.
+
+This contract covers no other `LLink` properties and no other entity types.
+Changing it requires a superseding decision based on the published extension
+policy, a concrete invariant violation, or measured consumer requirements.
+
+**Owner:** Christian Byrne
+
+**Recorded:** 2026-08-24
+
+**Decision:** PR #15654. PR #15778 contains the original patch and discussion.
 
 ## Closed exceptions
 


### PR DESCRIPTION
- Applies all 3 accepted docs suggestions from #15810.
- Preserves ADR-0017's decision and EX-003's 7-property scope.
- Retitles ADR-0017 and updates its index entry.

<details><summary>Full context for agent readers</summary>

Post-merge follow-up to #15810 and its accepted review threads:

- [r3848177895](https://github.com/Comfy-Org/ComfyUI_frontend/pull/15810#discussion_r3848177895)
- [r3848177912](https://github.com/Comfy-Org/ComfyUI_frontend/pull/15810#discussion_r3848177912)
- [r3848177919](https://github.com/Comfy-Org/ComfyUI_frontend/pull/15810#discussion_r3848177919)

The changes simplify ADR-0017, restructure the exceptions log into temporary exceptions and permanent compatibility contracts, preserve EX-003's exact seven enumerable `LLink` properties, and update the ADR index title.

Verification:

- `oxfmt --check docs/adr/0017-id-based-slot-records-are-the-slot-destination.md docs/adr/README.md docs/exceptions-log.md`: green
- `git diff --check`: green

</details>