### PR TITLE
test: make subgraph widget repromotion assertion discriminating

### DIFF
--- a/src/lib/litegraph/src/subgraph/SubgraphWidgetPromotion.test.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphWidgetPromotion.test.ts
@@ -7,6 +7,7 @@ import type {
   Subgraph,
   TWidgetType
 } from '@/lib/litegraph/src/litegraph'
+import type { IBaseWidget } from '@/lib/litegraph/src/types/widgets'
 import {
   BaseWidget,
   LGraphNode,
@@ -408,8 +409,12 @@ describe('SubgraphWidgetPromotion', () => {
         inputs: [{ name: 'value', type: 'number' }]
       })
 
-      const { node: first } = createNodeWithWidget('First', 'number', 42)
-      const { node: second } = createNodeWithWidget('Second', 'number', 42)
+      const { node: first } = createNodeWithWidget('First', 'number', 13)
+      const { node: second, widget: secondWidget } = createNodeWithWidget(
+        'Second',
+        'number',
+        27
+      )
       subgraph.add(first)
       subgraph.add(second)
       subgraph.inputNode.slots[0].connect(first.inputs[0], first)
@@ -418,12 +423,29 @@ describe('SubgraphWidgetPromotion', () => {
       const subgraphNode = createTestSubgraphNode(subgraph)
       expect(promotedInputs(subgraphNode)).toHaveLength(1)
       expect(subgraph.inputNode.slots[0].linkIds).toHaveLength(2)
+      // linkIds resolve in connection order, so `first` seeds the store.
+      expect(promotedWidgetStateByName(subgraphNode, 'value').value).toBe(13)
 
+      const repromotions: IBaseWidget[] = []
+      subgraph.events.addEventListener('widget-promoted', (e) => {
+        repromotions.push(e.detail.widget)
+      })
+
+      // Disconnect the interior widget that currently backs the promotion.
+      // The input must re-resolve to the remaining interior widget — observable
+      // as a repromotion event carrying that widget — not merely survive as a
+      // stale binding to the removed source.
       first.disconnectInput(0, true)
 
       expect(subgraph.inputNode.slots[0].linkIds).toHaveLength(1)
       expect(promotedInputs(subgraphNode)).toHaveLength(1)
       expect(subgraphNode.widgets).toHaveLength(1)
+      expect(repromotions).toHaveLength(1)
+      expect(repromotions[0]).toBe(secondWidget)
+      // Re-resolution deliberately keeps the store-backed value (see
+      // widgetValueStore.registerWidget): rebinding must not clobber the
+      // promoted value the user may have edited.
+      expect(promotedWidgetStateByName(subgraphNode, 'value').value).toBe(13)
 
       second.disconnectInput(0, true)
 


### PR DESCRIPTION
- Makes the post-#15615 repromotion regression test discriminating.
- Verifies the second widget re-fires `widget-promoted`.
- Keeps the promoted store value sticky by design.

<details><summary>Full context for agent readers</summary>

Follow-up to [review comment r3846703707](https://github.com/Comfy-Org/ComfyUI_frontend/pull/15615#discussion_r3846703707) on merged #15615.

This deliberately deviates from the comment's requested value rebind. `widgetValueStore.registerWidget` preserves existing same-type state, so rebinding must not clobber a promoted value the user may have edited. The discriminating assertion is instead that `widget-promoted` fires again with the second widget after the first active source disconnects. A bare early return from the input-disconnected re-resolution path therefore fails this test.

Verification on Node v24.15.0:

- `vitest run src/lib/litegraph/src/subgraph/SubgraphWidgetPromotion.test.ts`: 1 file, 45 tests passed
- `oxfmt --check` on the touched file: green
- `oxlint --type-aware` on the touched file: green
- `eslint` on the touched file: green
- `NODE_OPTIONS=--max-old-space-size=8192 vue-tsc --noEmit`: green
- `git diff --check`: green

</details>