### PR TITLE
fix(litegraph): getNodeById returns null instead of leaking undefined

### DIFF
--- a/src/extensions/core/imageCompare.ts
+++ b/src/extensions/core/imageCompare.ts
@@ -40,7 +40,6 @@ useExtensionService().registerExtension({
 
       if (widget) {
         widget.value = { beforeImages, afterImages }
-        widget.callback?.(widget.value)
       }
     }
   }

--- a/src/lib/litegraph/src/LGraph.test.ts
+++ b/src/lib/litegraph/src/LGraph.test.ts
@@ -120,6 +120,14 @@ describe('LGraph', () => {
     expect(graph.last_node_id).toBe(7)
   })
 
+  it('getNodeById returns null, never undefined, for unknown ids', () => {
+    const graph = new LGraph()
+
+    expect(graph.getNodeById(toNodeId(999))).toBeNull()
+    expect(graph.getNodeById(null)).toBeNull()
+    expect(graph.getNodeById(undefined)).toBeNull()
+  })
+
   test('can be instantiated', ({ expect }) => {
     // @ts-expect-error Intentional - extra holds any / all consumer data that should be serialised
     const graph = new LGraph({ extra: 'TestGraph' })

--- a/src/lib/litegraph/src/LGraph.ts
+++ b/src/lib/litegraph/src/LGraph.ts
@@ -1334,7 +1334,7 @@ export class LGraph
    */
   getNodeById(id: NodeId | null | undefined): LGraphNode | null {
     return id != null && id !== UNASSIGNED_NODE_ID
-      ? this._nodes_by_id[id]
+      ? (this._nodes_by_id[id] ?? null)
       : null
   }
 

--- a/src/lib/litegraph/src/LGraphCanvas.subgraphPasteDelete.test.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.subgraphPasteDelete.test.ts
@@ -275,8 +275,7 @@ describe('subgraph copy/paste then delete in both orders', () => {
     expect(f.original.isDetached).toBe(true)
     expect(f.rootGraph.nodes).toContain(f.copy)
     expect(f.rootGraph.nodes).not.toContain(f.original)
-    // `delete`d from the index, so the lookup is undefined rather than null.
-    expect(f.rootGraph.getNodeById(f.original.id)).toBeUndefined()
+    expect(f.rootGraph.getNodeById(f.original.id)).toBeNull()
 
     // The copy's promoted widget value is untouched by its sibling's removal.
     expect(promotedSeed(f.copy)).toBe(COPY_SEED)
@@ -318,7 +317,7 @@ describe('subgraph copy/paste then delete in both orders', () => {
     expect(f.copy.isDetached).toBe(true)
     expect(f.rootGraph.nodes).toContain(f.original)
     expect(f.rootGraph.nodes).not.toContain(f.copy)
-    expect(f.rootGraph.getNodeById(f.copy.id)).toBeUndefined()
+    expect(f.rootGraph.getNodeById(f.copy.id)).toBeNull()
 
     expect(promotedSeed(f.original)).toBe(ORIGINAL_SEED)
 

--- a/src/stores/appModeStore.test.ts
+++ b/src/stores/appModeStore.test.ts
@@ -1081,7 +1081,7 @@ describe('appModeStore', () => {
         rootGraph.getNodeById(id)
       )
 
-      expect(rootGraph.getNodeById(interior.id)).toBeUndefined()
+      expect(rootGraph.getNodeById(interior.id)).toBeNull()
 
       const result = store.pruneLinearData({
         inputs: [[interior.id, sourceWidgetName, { height: 120 }]],


### PR DESCRIPTION
## Summary
The signature promises LGraphNode | null but the lookup returned the raw index result, leaking undefined for unknown ids. Guards written against the signature (node !== null) let undefined through; WidgetCompositor crashed on it during the async-mount race after adding Create Layered Image from the node search, and the render error wedged the Vue renderer (search dialog and canvas stopped responding).

Also drops the dead widget.callback invocation in imageCompare: the imagecompare widget is created with a no-op callback and nothing else assigns one, and the store-backed value write already propagates to the Vue component.