### PR TITLE
fix(billing): use user-scoped auth header for customer endpoints

### DIFF
--- a/src/services/customerEventsService.test.ts
+++ b/src/services/customerEventsService.test.ts
@@ -13,7 +13,7 @@ const mockAxiosInstance = vi.hoisted(() => ({
 }))
 
 const mockAuthStore = vi.hoisted(() => ({
-  getFirebaseAuthHeader: vi.fn()
+  getUserAuthHeader: vi.fn()
 }))
 
 const mockI18n = vi.hoisted(() => ({
@@ -80,7 +80,7 @@ describe('useCustomerEventsService', () => {
   }
 
   beforeEach(() => {
-    mockAuthStore.getFirebaseAuthHeader.mockResolvedValue(mockAuthHeaders)
+    mockAuthStore.getUserAuthHeader.mockResolvedValue(mockAuthHeaders)
     mockI18n.d.mockImplementation((date, options) => {
       // Mock i18n date formatting
       if (options?.month === 'short') {
@@ -117,7 +117,7 @@ describe('useCustomerEventsService', () => {
         limit: 10
       })
 
-      expect(mockAuthStore.getFirebaseAuthHeader).toHaveBeenCalled()
+      expect(mockAuthStore.getUserAuthHeader).toHaveBeenCalled()
       expect(mockAxiosInstance.get).toHaveBeenCalledWith('/customers/events', {
         params: { page: 1, limit: 10 },
         headers: mockAuthHeaders
@@ -140,7 +140,7 @@ describe('useCustomerEventsService', () => {
     })
 
     it('should return null when auth headers are missing', async () => {
-      mockAuthStore.getFirebaseAuthHeader.mockResolvedValue(null)
+      mockAuthStore.getUserAuthHeader.mockResolvedValue(null)
 
       const result = await service.getMyEvents()
 

--- a/src/services/customerEventsService.test.ts
+++ b/src/services/customerEventsService.test.ts
@@ -13,7 +13,8 @@ const mockAxiosInstance = vi.hoisted(() => ({
 }))
 
 const mockAuthStore = vi.hoisted(() => ({
-  getUserAuthHeader: vi.fn()
+  getUserAuthHeader: vi.fn(),
+  currentUserIdentity: vi.fn()
 }))
 
 const mockI18n = vi.hoisted(() => ({
@@ -81,6 +82,7 @@ describe('useCustomerEventsService', () => {
 
   beforeEach(() => {
     mockAuthStore.getUserAuthHeader.mockResolvedValue(mockAuthHeaders)
+    mockAuthStore.currentUserIdentity.mockReturnValue('api-key-a')
     mockI18n.d.mockImplementation((date, options) => {
       // Mock i18n date formatting
       if (options?.month === 'short') {
@@ -147,6 +149,25 @@ describe('useCustomerEventsService', () => {
       expect(result).toBeNull()
       expect(service.error.value).toBe('Authentication header is missing')
       expect(mockAxiosInstance.get).not.toHaveBeenCalled()
+    })
+
+    it('discards events that resolve after an A->B API key switch', async () => {
+      let resolveEvents!: (value: unknown) => void
+      const eventsRequestStarted = new Promise<void>((requestStarted) => {
+        mockAxiosInstance.get.mockImplementation(() => {
+          requestStarted()
+          return new Promise((resolve) => {
+            resolveEvents = resolve
+          })
+        })
+      })
+
+      const request = service.getMyEvents()
+      await eventsRequestStarted
+      mockAuthStore.currentUserIdentity.mockReturnValue('api-key-b')
+      resolveEvents({ data: mockEventsResponse })
+
+      await expect(request).resolves.toBeNull()
     })
 
     it('should handle 400 errors', async () => {

--- a/src/services/customerEventsService.test.ts
+++ b/src/services/customerEventsService.test.ts
@@ -170,6 +170,30 @@ describe('useCustomerEventsService', () => {
       await expect(request).resolves.toBeNull()
     })
 
+    it('never exposes a stale error after an A->B API key switch', async () => {
+      let rejectEvents!: (reason: unknown) => void
+      const eventsRequestStarted = new Promise<void>((requestStarted) => {
+        mockAxiosInstance.get.mockImplementation(() => {
+          requestStarted()
+          return new Promise((_resolve, reject) => {
+            rejectEvents = reject
+          })
+        })
+      })
+      vi.mocked(axios.isAxiosError).mockReturnValue(true)
+
+      const request = service.getMyEvents()
+      await eventsRequestStarted
+      mockAuthStore.currentUserIdentity.mockReturnValue('api-key-b')
+      rejectEvents({
+        response: { status: 400, data: { message: 'account A backend error' } }
+      })
+
+      await expect(request).resolves.toBeNull()
+      expect(service.error.value).toBeNull()
+      expect(service.isLoading.value).toBe(false)
+    })
+
     it('should handle 400 errors', async () => {
       const errorResponse = {
         response: {

--- a/src/services/customerEventsService.test.ts
+++ b/src/services/customerEventsService.test.ts
@@ -194,6 +194,34 @@ describe('useCustomerEventsService', () => {
       expect(service.isLoading.value).toBe(false)
     })
 
+    it('ignores a stale auth preflight once a newer request begins', async () => {
+      let resolveStaleHeader!: (value: unknown) => void
+      mockAuthStore.getUserAuthHeader.mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveStaleHeader = resolve
+          })
+      )
+      const staleRequest = service.getMyEvents()
+
+      mockAuthStore.currentUserIdentity.mockReturnValue('api-key-b')
+      const activeRequestStarted = new Promise<void>((requestStarted) => {
+        mockAxiosInstance.get.mockImplementation(() => {
+          requestStarted()
+          return new Promise(() => {})
+        })
+      })
+      const activeRequest = service.getMyEvents()
+      await activeRequestStarted
+
+      resolveStaleHeader(null)
+      await expect(staleRequest).resolves.toBeNull()
+
+      expect(service.error.value).toBeNull()
+      expect(service.isLoading.value).toBe(true)
+      void activeRequest
+    })
+
     it('should handle 400 errors', async () => {
       const errorResponse = {
         response: {

--- a/src/services/customerEventsService.ts
+++ b/src/services/customerEventsService.ts
@@ -190,7 +190,9 @@ export const useCustomerEventsService = () => {
       404: 'Not found'
     }
 
-    const authHeaders = await useAuthStore().getUserAuthHeader()
+    const authStore = useAuthStore()
+    const requestOwner = authStore.currentUserIdentity()
+    const authHeaders = await authStore.getUserAuthHeader()
     if (!authHeaders) {
       error.value = 'Authentication header is missing'
       return null
@@ -205,6 +207,9 @@ export const useCustomerEventsService = () => {
       { errorContext, routeSpecificErrors }
     )
 
+    if (authStore.currentUserIdentity() !== requestOwner) {
+      return null
+    }
     return result
   }
 

--- a/src/services/customerEventsService.ts
+++ b/src/services/customerEventsService.ts
@@ -190,7 +190,7 @@ export const useCustomerEventsService = () => {
       404: 'Not found'
     }
 
-    const authHeaders = await useAuthStore().getFirebaseAuthHeader()
+    const authHeaders = await useAuthStore().getUserAuthHeader()
     if (!authHeaders) {
       error.value = 'Authentication header is missing'
       return null

--- a/src/services/customerEventsService.ts
+++ b/src/services/customerEventsService.ts
@@ -190,15 +190,23 @@ export const useCustomerEventsService = () => {
 
     const authStore = useAuthStore()
     const requestOwner = authStore.currentUserIdentity()
-    const authHeaders = await authStore.getUserAuthHeader()
-    if (!authHeaders) {
-      error.value = 'Authentication header is missing'
-      return null
-    }
-
     const requestId = ++latestRequestId
     isLoading.value = true
     error.value = null
+
+    const authHeaders = await authStore.getUserAuthHeader()
+    if (requestId !== latestRequestId) {
+      return null
+    }
+    if (authStore.currentUserIdentity() !== requestOwner) {
+      isLoading.value = false
+      return null
+    }
+    if (!authHeaders) {
+      isLoading.value = false
+      error.value = 'Authentication header is missing'
+      return null
+    }
 
     const { data, errorMessage } = await executeRequest<CustomerEventsResponse>(
       () =>

--- a/src/services/customerEventsService.ts
+++ b/src/services/customerEventsService.ts
@@ -36,6 +36,7 @@ attachUnifiedRemintInterceptor(customerApiClient)
 export const useCustomerEventsService = () => {
   const isLoading = ref(false)
   const error = ref<string | null>(null)
+  let latestRequestId = 0
 
   watch(
     () => getComfyApiBaseUrl(),
@@ -44,30 +45,26 @@ export const useCustomerEventsService = () => {
     }
   )
 
-  const handleRequestError = (
+  const describeRequestError = (
     err: unknown,
     context: string,
     routeSpecificErrors?: Record<number, string>
-  ) => {
+  ): string | null => {
     // Don't treat cancellation as an error
-    if (isAbortError(err)) return
+    if (isAbortError(err)) return null
 
-    let message: string
     if (!axios.isAxiosError(err)) {
-      message = `${context} failed: ${err instanceof Error ? err.message : String(err)}`
-    } else {
-      const axiosError = err as AxiosError<{ message: string }>
-      const status = axiosError.response?.status
-      if (status && routeSpecificErrors?.[status]) {
-        message = routeSpecificErrors[status]
-      } else {
-        message =
-          axiosError.response?.data?.message ??
-          `${context} failed with status ${status}`
-      }
+      return `${context} failed: ${err instanceof Error ? err.message : String(err)}`
     }
-
-    error.value = message
+    const axiosError = err as AxiosError<{ message: string }>
+    const status = axiosError.response?.status
+    if (status && routeSpecificErrors?.[status]) {
+      return routeSpecificErrors[status]
+    }
+    return (
+      axiosError.response?.data?.message ??
+      `${context} failed with status ${status}`
+    )
   }
 
   const executeRequest = async <T>(
@@ -76,20 +73,21 @@ export const useCustomerEventsService = () => {
       errorContext: string
       routeSpecificErrors?: Record<number, string>
     }
-  ): Promise<T | null> => {
+  ): Promise<{ data: T | null; errorMessage: string | null }> => {
     const { errorContext, routeSpecificErrors } = options
-
-    isLoading.value = true
-    error.value = null
 
     try {
       const response = await requestCall()
-      return response.data
+      return { data: response.data, errorMessage: null }
     } catch (err) {
-      handleRequestError(err, errorContext, routeSpecificErrors)
-      return null
-    } finally {
-      isLoading.value = false
+      return {
+        data: null,
+        errorMessage: describeRequestError(
+          err,
+          errorContext,
+          routeSpecificErrors
+        )
+      }
     }
   }
 
@@ -198,7 +196,11 @@ export const useCustomerEventsService = () => {
       return null
     }
 
-    const result = await executeRequest<CustomerEventsResponse>(
+    const requestId = ++latestRequestId
+    isLoading.value = true
+    error.value = null
+
+    const { data, errorMessage } = await executeRequest<CustomerEventsResponse>(
       () =>
         customerApiClient.get('/customers/events', {
           params: { page, limit },
@@ -207,10 +209,15 @@ export const useCustomerEventsService = () => {
       { errorContext, routeSpecificErrors }
     )
 
+    if (requestId !== latestRequestId) {
+      return null
+    }
+    isLoading.value = false
     if (authStore.currentUserIdentity() !== requestOwner) {
       return null
     }
-    return result
+    error.value = errorMessage
+    return data
   }
 
   return {

--- a/src/stores/authStore.test.ts
+++ b/src/stores/authStore.test.ts
@@ -162,10 +162,11 @@ vi.mock('@/composables/useFeatureFlags', () => ({
 
 // Mock apiKeyAuthStore
 const mockApiKeyGetAuthHeader = vi.fn().mockReturnValue(null)
+const mockApiKeyGetApiKey = vi.fn()
 vi.mock('@/stores/apiKeyAuthStore', () => ({
   useApiKeyAuthStore: () => ({
     getAuthHeader: mockApiKeyGetAuthHeader,
-    getApiKey: vi.fn(),
+    getApiKey: mockApiKeyGetApiKey,
     currentUser: null,
     isAuthenticated: false,
     storeApiKey: vi.fn(),
@@ -240,6 +241,7 @@ describe('useAuthStore', () => {
 
     // Default: no API key auth
     mockApiKeyGetAuthHeader.mockReturnValue(null)
+    mockApiKeyGetApiKey.mockReturnValue(null)
     mockTeamWorkspaceStore.activeWorkspaceId = null
     mockTeamWorkspaceStore.resetForIdentityChange.mockReset()
   })
@@ -376,6 +378,7 @@ describe('useAuthStore', () => {
     beforeEach(() => {
       authStateCallback(null)
       mockApiKeyGetAuthHeader.mockReturnValue({ 'X-API-KEY': 'test-api-key' })
+      mockApiKeyGetApiKey.mockReturnValue('test-api-key')
     })
 
     it('fetchBalance sends the stored API key when no Firebase user exists', async () => {
@@ -398,6 +401,22 @@ describe('useAuthStore', () => {
         message: 'toastMessages.userNotAuthenticated'
       })
       expect(mockFetch).not.toHaveBeenCalled()
+    })
+
+    it('drops a late balance response after the API key changes mid-flight', async () => {
+      let resolveBalance!: (value: unknown) => void
+      mockFetch.mockReturnValueOnce(
+        new Promise((resolve) => {
+          resolveBalance = resolve
+        })
+      )
+
+      const request = store.fetchBalance()
+      mockApiKeyGetApiKey.mockReturnValue('another-api-key')
+      resolveBalance({ ok: true, json: () => Promise.resolve({ balance: 7 }) })
+
+      await expect(request).resolves.toBeNull()
+      expect(store.balance).toBeNull()
     })
 
     it('fetchBalance prefers the Firebase token over the API key when signed in', async () => {

--- a/src/stores/authStore.test.ts
+++ b/src/stores/authStore.test.ts
@@ -491,6 +491,65 @@ describe('useAuthStore', () => {
       })
       expect(mockFetch).not.toHaveBeenCalled()
     })
+    it('re-provisions the customer after the API key changes', async () => {
+      let customerPostCount = 0
+      mockFetch.mockImplementation((url: string, init?: RequestInit) => {
+        if (url.endsWith('/customers') && init?.method === 'POST') {
+          customerPostCount++
+          return Promise.resolve(mockCreateCustomerResponse)
+        }
+        if (url.endsWith('/customers/credit')) {
+          return Promise.resolve({
+            ok: true,
+            json: () =>
+              Promise.resolve({ checkout_url: 'https://stripe.test/checkout' })
+          })
+        }
+        return Promise.reject(new Error('Unexpected API call'))
+      })
+      const payload = { amount_micros: 5_000_000, currency: 'usd' }
+
+      await store.initiateCreditPurchase(payload)
+      mockApiKeyGetApiKey.mockReturnValue('another-api-key')
+      mockApiKeyGetAuthHeader.mockReturnValue({
+        'X-API-KEY': 'another-api-key'
+      })
+      await store.initiateCreditPurchase(payload)
+
+      expect(customerPostCount).toBe(2)
+    })
+
+    it('aborts a credit purchase when the API key changes during recovery', async () => {
+      let resolveCreate!: (value: unknown) => void
+      mockFetch.mockImplementation((url: string, init?: RequestInit) => {
+        if (url.endsWith('/customers') && init?.method === 'POST') {
+          return new Promise((resolve) => {
+            resolveCreate = resolve
+          })
+        }
+        return Promise.reject(new Error('Unexpected API call'))
+      })
+
+      const request = store.initiateCreditPurchase({
+        amount_micros: 5_000_000,
+        currency: 'usd'
+      })
+      await new Promise<void>((resolve) => setTimeout(resolve, 0))
+      mockApiKeyGetApiKey.mockReturnValue('another-api-key')
+      mockApiKeyGetAuthHeader.mockReturnValue({
+        'X-API-KEY': 'another-api-key'
+      })
+      resolveCreate(mockCreateCustomerResponse)
+
+      await expect(request).rejects.toMatchObject({
+        message: 'toastMessages.userNotAuthenticated'
+      })
+      expect(
+        mockFetch.mock.calls.some(([url]) =>
+          String(url).endsWith('/customers/credit')
+        )
+      ).toBe(false)
+    })
   })
 
   describe('login', () => {

--- a/src/stores/authStore.test.ts
+++ b/src/stores/authStore.test.ts
@@ -556,7 +556,7 @@ describe('useAuthStore', () => {
       resolveCreate(mockCreateCustomerResponse)
 
       await expect(request).rejects.toMatchObject({
-        message: 'toastMessages.failedToAccessBillingPortal'
+        message: 'toastMessages.userNotAuthenticated'
       })
       expect(billingCallCount).toBe(1)
     })
@@ -757,6 +757,126 @@ describe('useAuthStore', () => {
         'X-API-KEY': 'another-api-key'
       })
       resolveCreditBody({ checkout_url: 'https://stripe.test/checkout' })
+
+      await expect(request).rejects.toMatchObject({
+        message: 'toastMessages.userNotAuthenticated'
+      })
+    })
+
+    const accountAFailureResponse = {
+      ok: false,
+      status: 500,
+      statusText: 'Internal Server Error',
+      clone: () => ({
+        json: () => Promise.resolve({ message: 'account A backend error' })
+      }),
+      json: () => Promise.resolve({ message: 'account A backend error' }),
+      text: () =>
+        Promise.resolve(JSON.stringify({ message: 'account A backend error' }))
+    }
+
+    const switchToAnotherApiKey = () => {
+      mockApiKeyGetApiKey.mockReturnValue('another-api-key')
+      mockApiKeyGetAuthHeader.mockReturnValue({
+        'X-API-KEY': 'another-api-key'
+      })
+    }
+
+    it('suppresses a balance error that rejects after an A->B API key switch', async () => {
+      let resolveBalance!: (value: unknown) => void
+      const balanceRequestStarted = new Promise<void>((requestStarted) => {
+        mockFetch.mockImplementation((url: string) => {
+          if (url.endsWith('/customers/balance')) {
+            requestStarted()
+            return new Promise((resolve) => {
+              resolveBalance = resolve
+            })
+          }
+          return Promise.reject(new Error('Unexpected API call'))
+        })
+      })
+
+      const request = store.fetchBalance()
+      await balanceRequestStarted
+      switchToAnotherApiKey()
+      resolveBalance(accountAFailureResponse)
+
+      await expect(request).resolves.toBeNull()
+      expect(store.balance).toBeNull()
+    })
+
+    it('withholds a checkout error that rejects after an A->B API key switch', async () => {
+      let resolveCredit!: (value: unknown) => void
+      const creditRequestStarted = new Promise<void>((requestStarted) => {
+        mockFetch.mockImplementation((url: string, init?: RequestInit) => {
+          if (url.endsWith('/customers') && init?.method === 'POST') {
+            return Promise.resolve(mockCreateCustomerResponse)
+          }
+          if (url.endsWith('/customers/credit')) {
+            requestStarted()
+            return new Promise((resolve) => {
+              resolveCredit = resolve
+            })
+          }
+          return Promise.reject(new Error('Unexpected API call'))
+        })
+      })
+
+      const request = store.initiateCreditPurchase({
+        amount_micros: 5_000_000,
+        currency: 'usd'
+      })
+      await creditRequestStarted
+      switchToAnotherApiKey()
+      resolveCredit(accountAFailureResponse)
+
+      await expect(request).rejects.toMatchObject({
+        message: 'toastMessages.userNotAuthenticated'
+      })
+    })
+
+    it('withholds a portal error that rejects after an A->B API key switch', async () => {
+      let resolveBilling!: (value: unknown) => void
+      const billingRequestStarted = new Promise<void>((requestStarted) => {
+        mockFetch.mockImplementation((url: string) => {
+          if (url.endsWith('/customers/billing')) {
+            requestStarted()
+            return new Promise((resolve) => {
+              resolveBilling = resolve
+            })
+          }
+          return Promise.reject(new Error('Unexpected API call'))
+        })
+      })
+
+      const request = store.accessBillingPortal()
+      await billingRequestStarted
+      switchToAnotherApiKey()
+      resolveBilling(accountAFailureResponse)
+
+      await expect(request).rejects.toMatchObject({
+        message: 'toastMessages.userNotAuthenticated'
+      })
+    })
+
+    it('withholds a customer-creation error that rejects after an A->B API key switch', async () => {
+      let resolveCreate!: (value: unknown) => void
+      const createRequestStarted = new Promise<void>((requestStarted) => {
+        mockFetch.mockImplementation((url: string, init?: RequestInit) => {
+          if (url.endsWith('/customers') && init?.method === 'POST') {
+            requestStarted()
+            return new Promise((resolve) => {
+              resolveCreate = resolve
+            })
+          }
+          return Promise.reject(new Error('Unexpected API call'))
+        })
+      })
+
+      const request = store.createCustomer()
+      await createRequestStarted
+      switchToAnotherApiKey()
+      resolveCreate(accountAFailureResponse)
 
       await expect(request).rejects.toMatchObject({
         message: 'toastMessages.userNotAuthenticated'

--- a/src/stores/authStore.test.ts
+++ b/src/stores/authStore.test.ts
@@ -463,6 +463,34 @@ describe('useAuthStore', () => {
         })
       )
     })
+
+    it('accessBillingPortal sends the stored API key when no Firebase user exists', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({ billing_portal_url: 'https://stripe.test/portal' })
+      })
+
+      await store.accessBillingPortal()
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining('/customers/billing'),
+        expect.objectContaining({
+          method: 'POST',
+          headers: expect.objectContaining({ 'X-API-KEY': 'test-api-key' })
+        })
+      )
+    })
+
+    it('accessBillingPortal throws userNotAuthenticated when neither credential exists', async () => {
+      mockApiKeyGetAuthHeader.mockReturnValue(null)
+
+      await expect(store.accessBillingPortal()).rejects.toMatchObject({
+        name: 'AuthStoreError',
+        message: 'toastMessages.userNotAuthenticated'
+      })
+      expect(mockFetch).not.toHaveBeenCalled()
+    })
   })
 
   describe('login', () => {

--- a/src/stores/authStore.test.ts
+++ b/src/stores/authStore.test.ts
@@ -592,6 +592,70 @@ describe('useAuthStore', () => {
         )
       ).toBe(false)
     })
+
+    it('withholds a portal URL that succeeds after an A->B API key switch', async () => {
+      let resolveBilling!: (value: unknown) => void
+      mockFetch.mockImplementation((url: string) => {
+        if (url.endsWith('/customers/billing')) {
+          return new Promise((resolve) => {
+            resolveBilling = resolve
+          })
+        }
+        return Promise.reject(new Error('Unexpected API call'))
+      })
+
+      const request = store.accessBillingPortal()
+      await new Promise<void>((resolve) => setTimeout(resolve, 0))
+      mockApiKeyGetApiKey.mockReturnValue('another-api-key')
+      mockApiKeyGetAuthHeader.mockReturnValue({
+        'X-API-KEY': 'another-api-key'
+      })
+      resolveBilling({
+        ok: true,
+        status: 200,
+        json: () =>
+          Promise.resolve({ billing_portal_url: 'https://stripe.test/portal' })
+      })
+
+      await expect(request).rejects.toMatchObject({
+        message: 'toastMessages.userNotAuthenticated'
+      })
+    })
+
+    it('withholds a checkout URL that succeeds after an A->B API key switch', async () => {
+      let resolveCredit!: (value: unknown) => void
+      mockFetch.mockImplementation((url: string, init?: RequestInit) => {
+        if (url.endsWith('/customers') && init?.method === 'POST') {
+          return Promise.resolve(mockCreateCustomerResponse)
+        }
+        if (url.endsWith('/customers/credit')) {
+          return new Promise((resolve) => {
+            resolveCredit = resolve
+          })
+        }
+        return Promise.reject(new Error('Unexpected API call'))
+      })
+
+      const request = store.initiateCreditPurchase({
+        amount_micros: 5_000_000,
+        currency: 'usd'
+      })
+      await new Promise<void>((resolve) => setTimeout(resolve, 0))
+      mockApiKeyGetApiKey.mockReturnValue('another-api-key')
+      mockApiKeyGetAuthHeader.mockReturnValue({
+        'X-API-KEY': 'another-api-key'
+      })
+      resolveCredit({
+        ok: true,
+        status: 200,
+        json: () =>
+          Promise.resolve({ checkout_url: 'https://stripe.test/checkout' })
+      })
+
+      await expect(request).rejects.toMatchObject({
+        message: 'toastMessages.userNotAuthenticated'
+      })
+    })
   })
 
   describe('login', () => {

--- a/src/stores/authStore.test.ts
+++ b/src/stores/authStore.test.ts
@@ -690,6 +690,78 @@ describe('useAuthStore', () => {
         message: 'toastMessages.userNotAuthenticated'
       })
     })
+
+    it('withholds a portal URL when the API key changes while the body parses', async () => {
+      let resolvePortalBody!: (value: unknown) => void
+      const bodyParsingStarted = new Promise<void>((parsingStarted) => {
+        mockFetch.mockImplementation((url: string) => {
+          if (url.endsWith('/customers/billing')) {
+            return Promise.resolve({
+              ok: true,
+              status: 200,
+              json: () => {
+                parsingStarted()
+                return new Promise((resolve) => {
+                  resolvePortalBody = resolve
+                })
+              }
+            })
+          }
+          return Promise.reject(new Error('Unexpected API call'))
+        })
+      })
+
+      const request = store.accessBillingPortal()
+      await bodyParsingStarted
+      mockApiKeyGetApiKey.mockReturnValue('another-api-key')
+      mockApiKeyGetAuthHeader.mockReturnValue({
+        'X-API-KEY': 'another-api-key'
+      })
+      resolvePortalBody({ billing_portal_url: 'https://stripe.test/portal' })
+
+      await expect(request).rejects.toMatchObject({
+        message: 'toastMessages.userNotAuthenticated'
+      })
+    })
+
+    it('withholds a checkout URL when the API key changes while the body parses', async () => {
+      let resolveCreditBody!: (value: unknown) => void
+      const bodyParsingStarted = new Promise<void>((parsingStarted) => {
+        mockFetch.mockImplementation((url: string, init?: RequestInit) => {
+          if (url.endsWith('/customers') && init?.method === 'POST') {
+            return Promise.resolve(mockCreateCustomerResponse)
+          }
+          if (url.endsWith('/customers/credit')) {
+            return Promise.resolve({
+              ok: true,
+              status: 200,
+              json: () => {
+                parsingStarted()
+                return new Promise((resolve) => {
+                  resolveCreditBody = resolve
+                })
+              }
+            })
+          }
+          return Promise.reject(new Error('Unexpected API call'))
+        })
+      })
+
+      const request = store.initiateCreditPurchase({
+        amount_micros: 5_000_000,
+        currency: 'usd'
+      })
+      await bodyParsingStarted
+      mockApiKeyGetApiKey.mockReturnValue('another-api-key')
+      mockApiKeyGetAuthHeader.mockReturnValue({
+        'X-API-KEY': 'another-api-key'
+      })
+      resolveCreditBody({ checkout_url: 'https://stripe.test/checkout' })
+
+      await expect(request).rejects.toMatchObject({
+        message: 'toastMessages.userNotAuthenticated'
+      })
+    })
   })
 
   describe('login', () => {

--- a/src/stores/authStore.test.ts
+++ b/src/stores/authStore.test.ts
@@ -519,6 +519,48 @@ describe('useAuthStore', () => {
       expect(customerPostCount).toBe(2)
     })
 
+    it('does not retry with the old API key after a mid-recovery switch', async () => {
+      const missingCustomerResponse = {
+        ok: false,
+        status: 409,
+        clone: () => ({
+          json: () => Promise.resolve({ message: 'Failed to find customer' })
+        }),
+        json: () => Promise.resolve({ message: 'Failed to find customer' }),
+        text: () =>
+          Promise.resolve(
+            JSON.stringify({ message: 'Failed to find customer' })
+          )
+      }
+      let resolveCreate!: (value: unknown) => void
+      let billingCallCount = 0
+      mockFetch.mockImplementation((url: string, init?: RequestInit) => {
+        if (url.endsWith('/customers') && init?.method === 'POST') {
+          return new Promise((resolve) => {
+            resolveCreate = resolve
+          })
+        }
+        if (url.endsWith('/customers/billing')) {
+          billingCallCount++
+          return Promise.resolve(missingCustomerResponse)
+        }
+        return Promise.reject(new Error('Unexpected API call'))
+      })
+
+      const request = store.accessBillingPortal()
+      await new Promise<void>((resolve) => setTimeout(resolve, 0))
+      mockApiKeyGetApiKey.mockReturnValue('another-api-key')
+      mockApiKeyGetAuthHeader.mockReturnValue({
+        'X-API-KEY': 'another-api-key'
+      })
+      resolveCreate(mockCreateCustomerResponse)
+
+      await expect(request).rejects.toMatchObject({
+        message: 'toastMessages.failedToAccessBillingPortal'
+      })
+      expect(billingCallCount).toBe(1)
+    })
+
     it('aborts a credit purchase when the API key changes during recovery', async () => {
       let resolveCreate!: (value: unknown) => void
       mockFetch.mockImplementation((url: string, init?: RequestInit) => {

--- a/src/stores/authStore.test.ts
+++ b/src/stores/authStore.test.ts
@@ -372,6 +372,80 @@ describe('useAuthStore', () => {
     })
   })
 
+  describe('user-scoped billing endpoints with API-key sessions', () => {
+    beforeEach(() => {
+      authStateCallback(null)
+      mockApiKeyGetAuthHeader.mockReturnValue({ 'X-API-KEY': 'test-api-key' })
+    })
+
+    it('fetchBalance sends the stored API key when no Firebase user exists', async () => {
+      const result = await store.fetchBalance()
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining('/customers/balance'),
+        expect.objectContaining({
+          headers: expect.objectContaining({ 'X-API-KEY': 'test-api-key' })
+        })
+      )
+      expect(result).toEqual({ balance: 0 })
+    })
+
+    it('fetchBalance throws userNotAuthenticated when neither credential exists', async () => {
+      mockApiKeyGetAuthHeader.mockReturnValue(null)
+
+      await expect(store.fetchBalance()).rejects.toMatchObject({
+        name: 'AuthStoreError',
+        message: 'toastMessages.userNotAuthenticated'
+      })
+      expect(mockFetch).not.toHaveBeenCalled()
+    })
+
+    it('fetchBalance prefers the Firebase token over the API key when signed in', async () => {
+      authStateCallback(mockUser as User)
+
+      await store.fetchBalance()
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining('/customers/balance'),
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            Authorization: 'Bearer mock-id-token'
+          })
+        })
+      )
+      expect(mockApiKeyGetAuthHeader).not.toHaveBeenCalled()
+    })
+
+    it('initiateCreditPurchase sends the stored API key when no Firebase user exists', async () => {
+      mockFetch.mockImplementation((url: string) => {
+        if (url.endsWith('/customers')) {
+          return Promise.resolve(mockCreateCustomerResponse)
+        }
+        if (url.endsWith('/customers/credit')) {
+          return Promise.resolve({
+            ok: true,
+            json: () =>
+              Promise.resolve({ checkout_url: 'https://stripe.test/checkout' })
+          })
+        }
+        return Promise.reject(new Error('Unexpected API call'))
+      })
+
+      await store.initiateCreditPurchase({
+        amount_micros: 5_000_000,
+        currency: 'usd'
+      })
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining('/customers/credit'),
+        expect.objectContaining({
+          method: 'POST',
+          headers: expect.objectContaining({ 'X-API-KEY': 'test-api-key' })
+        })
+      )
+    })
+  })
+
   describe('login', () => {
     it('should login with valid credentials', async () => {
       const mockUserCredential = { user: mockUser }

--- a/src/stores/authStore.test.ts
+++ b/src/stores/authStore.test.ts
@@ -595,17 +595,20 @@ describe('useAuthStore', () => {
 
     it('withholds a portal URL that succeeds after an A->B API key switch', async () => {
       let resolveBilling!: (value: unknown) => void
-      mockFetch.mockImplementation((url: string) => {
-        if (url.endsWith('/customers/billing')) {
-          return new Promise((resolve) => {
-            resolveBilling = resolve
-          })
-        }
-        return Promise.reject(new Error('Unexpected API call'))
+      const billingRequestStarted = new Promise<void>((requestStarted) => {
+        mockFetch.mockImplementation((url: string) => {
+          if (url.endsWith('/customers/billing')) {
+            requestStarted()
+            return new Promise((resolve) => {
+              resolveBilling = resolve
+            })
+          }
+          return Promise.reject(new Error('Unexpected API call'))
+        })
       })
 
       const request = store.accessBillingPortal()
-      await new Promise<void>((resolve) => setTimeout(resolve, 0))
+      await billingRequestStarted
       mockApiKeyGetApiKey.mockReturnValue('another-api-key')
       mockApiKeyGetAuthHeader.mockReturnValue({
         'X-API-KEY': 'another-api-key'
@@ -624,23 +627,26 @@ describe('useAuthStore', () => {
 
     it('withholds a checkout URL that succeeds after an A->B API key switch', async () => {
       let resolveCredit!: (value: unknown) => void
-      mockFetch.mockImplementation((url: string, init?: RequestInit) => {
-        if (url.endsWith('/customers') && init?.method === 'POST') {
-          return Promise.resolve(mockCreateCustomerResponse)
-        }
-        if (url.endsWith('/customers/credit')) {
-          return new Promise((resolve) => {
-            resolveCredit = resolve
-          })
-        }
-        return Promise.reject(new Error('Unexpected API call'))
+      const creditRequestStarted = new Promise<void>((requestStarted) => {
+        mockFetch.mockImplementation((url: string, init?: RequestInit) => {
+          if (url.endsWith('/customers') && init?.method === 'POST') {
+            return Promise.resolve(mockCreateCustomerResponse)
+          }
+          if (url.endsWith('/customers/credit')) {
+            requestStarted()
+            return new Promise((resolve) => {
+              resolveCredit = resolve
+            })
+          }
+          return Promise.reject(new Error('Unexpected API call'))
+        })
       })
 
       const request = store.initiateCreditPurchase({
         amount_micros: 5_000_000,
         currency: 'usd'
       })
-      await new Promise<void>((resolve) => setTimeout(resolve, 0))
+      await creditRequestStarted
       mockApiKeyGetApiKey.mockReturnValue('another-api-key')
       mockApiKeyGetAuthHeader.mockReturnValue({
         'X-API-KEY': 'another-api-key'
@@ -653,6 +659,34 @@ describe('useAuthStore', () => {
       })
 
       await expect(request).rejects.toMatchObject({
+        message: 'toastMessages.userNotAuthenticated'
+      })
+    })
+
+    it('rejects a customer record created before an A->B API key switch', async () => {
+      let resolveCreate!: (value: unknown) => void
+      const createRequestStarted = new Promise<void>((requestStarted) => {
+        mockFetch.mockImplementation((url: string, init?: RequestInit) => {
+          if (url.endsWith('/customers') && init?.method === 'POST') {
+            requestStarted()
+            return new Promise((resolve) => {
+              resolveCreate = resolve
+            })
+          }
+          return Promise.reject(new Error('Unexpected API call'))
+        })
+      })
+
+      const request = store.createCustomer()
+      await createRequestStarted
+      mockApiKeyGetApiKey.mockReturnValue('another-api-key')
+      mockApiKeyGetAuthHeader.mockReturnValue({
+        'X-API-KEY': 'another-api-key'
+      })
+      resolveCreate(mockCreateCustomerResponse)
+
+      await expect(request).rejects.toMatchObject({
+        name: 'AuthStoreError',
         message: 'toastMessages.userNotAuthenticated'
       })
     })

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -432,6 +432,9 @@ export const useAuthStore = defineStore('auth', () => {
           return null
         }
         const { message } = await parseErrorResponse(response)
+        if (currentUserIdentity() !== requestOwner) {
+          return null
+        }
         throw new AuthStoreError(
           t('toastMessages.failedToFetchBalance', {
             error: message
@@ -482,6 +485,7 @@ export const useAuthStore = defineStore('auth', () => {
       isCloud && flags.unifiedCloudAuthEnabled
     )
     if (!createCustomerRes.ok) {
+      assertIdentityUnchanged(sessionIdentity)
       throw new AuthStoreError(
         t('toastMessages.failedToCreateCustomer', {
           error: createCustomerRes.statusText
@@ -816,6 +820,7 @@ export const useAuthStore = defineStore('auth', () => {
 
     if (!response.ok) {
       const { message } = await parseErrorResponse(response)
+      assertIdentityUnchanged(requestOwner)
       throw new AuthStoreError(
         t('toastMessages.failedToInitiateCreditPurchase', {
           error: message
@@ -859,6 +864,7 @@ export const useAuthStore = defineStore('auth', () => {
 
     if (!response.ok) {
       const { message } = await parseErrorResponse(response)
+      assertIdentityUnchanged(requestOwner)
       throw new AuthStoreError(
         t('toastMessages.failedToAccessBillingPortal', {
           error: message

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -299,6 +299,20 @@ export const useAuthStore = defineStore('auth', () => {
   const currentUserIdentity = (): string | null =>
     currentUser.value?.uid ?? useApiKeyAuthStore().getApiKey()
 
+  /**
+   * Response data from a user-scoped endpoint belongs to the identity that
+   * asked for it. A 200 bypasses the recovery guards in
+   * fetchWithCustomerRecovery, which only fence the missing-customer retry, so
+   * a credential swap while the request was in flight would hand the previous
+   * account's data to the current session — a Stripe portal or checkout URL
+   * minted for A opening inside B.
+   */
+  const assertIdentityUnchanged = (requestOwner: string | null): void => {
+    if (currentUserIdentity() !== requestOwner) {
+      throw new AuthStoreError(t('toastMessages.userNotAuthenticated'))
+    }
+  }
+
   const getWorkspaceAuthHeader = async (): Promise<AuthHeader | null> => {
     if (flags.unifiedCloudAuthEnabled) {
       const token = useWorkspaceAuthStore().getUnifiedToken()
@@ -809,6 +823,7 @@ export const useAuthStore = defineStore('auth', () => {
       )
     }
 
+    assertIdentityUnchanged(requestOwner)
     return response.json()
   }
 
@@ -820,6 +835,7 @@ export const useAuthStore = defineStore('auth', () => {
   const accessBillingPortal = async (
     targetTier?: BillingPortalTargetTier
   ): Promise<AccessBillingPortalResponse> => {
+    const requestOwner = currentUserIdentity()
     const authHeader = await getUserAuthHeader()
     if (!authHeader) {
       throw new AuthStoreError(t('toastMessages.userNotAuthenticated'))
@@ -848,6 +864,7 @@ export const useAuthStore = defineStore('auth', () => {
       )
     }
 
+    assertIdentityUnchanged(requestOwner)
     return response.json()
   }
 

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -500,7 +500,8 @@ export const useAuthStore = defineStore('auth', () => {
       )
     }
 
-    if (sessionIdentity !== null && currentUserIdentity() === sessionIdentity) {
+    assertIdentityUnchanged(sessionIdentity)
+    if (sessionIdentity !== null) {
       customerProvisionedIdentity.value = sessionIdentity
     }
     return createCustomerResJson

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -573,6 +573,7 @@ export const useAuthStore = defineStore('auth', () => {
     input: string,
     init?: RequestInit
   ): Promise<Response> => {
+    const requestOwner = currentUserIdentity()
     const remintFetch = (): Promise<Response> =>
       fetchWithUnifiedRemint(
         input,
@@ -583,7 +584,8 @@ export const useAuthStore = defineStore('auth', () => {
     const response = await remintFetch()
     if (
       !isCustomerEndpoint(input) ||
-      !(await isMissingCustomerResponse(response))
+      !(await isMissingCustomerResponse(response)) ||
+      currentUserIdentity() !== requestOwner
     ) {
       return response
     }
@@ -595,6 +597,10 @@ export const useAuthStore = defineStore('auth', () => {
         'Customer provisioning during 409 recovery failed; returning original response',
         error
       )
+      return response
+    }
+
+    if (currentUserIdentity() !== requestOwner) {
       return response
     }
 

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -824,8 +824,9 @@ export const useAuthStore = defineStore('auth', () => {
       )
     }
 
+    const creditPurchase: CreditPurchaseResponse = await response.json()
     assertIdentityUnchanged(requestOwner)
-    return response.json()
+    return creditPurchase
   }
 
   const initiateCreditPurchase = async (
@@ -865,8 +866,9 @@ export const useAuthStore = defineStore('auth', () => {
       )
     }
 
+    const billingPortal: AccessBillingPortalResponse = await response.json()
     assertIdentityUnchanged(requestOwner)
-    return response.json()
+    return billingPortal
   }
 
   return {
@@ -903,6 +905,7 @@ export const useAuthStore = defineStore('auth', () => {
     getFirebaseAuthHeader,
     getFirebaseAuthHeaderOrThrow,
     getUserAuthHeader,
+    currentUserIdentity,
     getWorkspaceAuthHeader,
     getWorkspaceAuthHeaderOrThrow,
     getAuthToken,

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -79,7 +79,7 @@ export const useAuthStore = defineStore('auth', () => {
   const loading = ref(false)
   const currentUser = ref<User | null>(null)
   const isInitialized = ref(false)
-  const customerCreated = ref(false)
+  const customerProvisionedIdentity = ref<string | null>(null)
   /**
    * Memoizes the in-flight or successful customer provisioning attempt for
    * the current account (see recoverMissingCustomer). Declared here so the
@@ -87,7 +87,7 @@ export const useAuthStore = defineStore('auth', () => {
    * otherwise run.
    */
   let customerRecovery: Promise<void> | null = null
-  let customerRecoveryUid: string | undefined
+  let customerRecoveryIdentity: string | null = null
   const isFetchingBalance = ref(false)
 
   // Balance state
@@ -176,9 +176,9 @@ export const useAuthStore = defineStore('auth', () => {
     // Customer provisioning state is per-account: without this reset, a
     // second account in the same browser session would be short-circuited by
     // the previous account's memoized recovery and stay stuck on 409s.
-    customerCreated.value = false
+    customerProvisionedIdentity.value = null
     customerRecovery = null
-    customerRecoveryUid = undefined
+    customerRecoveryIdentity = null
   })
 
   // Listen for token refresh events
@@ -444,7 +444,7 @@ export const useAuthStore = defineStore('auth', () => {
   const createCustomer = async (
     payload?: Omit<CreateCustomerPayload, 'signup_source'>
   ): Promise<CreateCustomerResponse> => {
-    const sessionUserId = currentUser.value?.uid
+    const sessionIdentity = currentUserIdentity()
     const authHeader = await getUserAuthHeader()
     if (!authHeader) {
       throw new AuthStoreError(t('toastMessages.userNotAuthenticated'))
@@ -486,8 +486,8 @@ export const useAuthStore = defineStore('auth', () => {
       )
     }
 
-    if (currentUser.value?.uid === sessionUserId) {
-      customerCreated.value = true
+    if (sessionIdentity !== null && currentUserIdentity() === sessionIdentity) {
+      customerProvisionedIdentity.value = sessionIdentity
     }
     return createCustomerResJson
   }
@@ -499,19 +499,22 @@ export const useAuthStore = defineStore('auth', () => {
    * request can retry, e.g. after a transient network failure.
    */
   const recoverMissingCustomer = (): Promise<void> => {
-    const sessionUserId = currentUser.value?.uid
-    if (customerRecovery === null || customerRecoveryUid !== sessionUserId) {
+    const sessionIdentity = currentUserIdentity()
+    if (
+      customerRecovery === null ||
+      customerRecoveryIdentity !== sessionIdentity
+    ) {
       const thisRecovery: Promise<void> = createCustomer()
         .then(() => undefined)
         .catch((error: unknown) => {
           if (customerRecovery === thisRecovery) {
             customerRecovery = null
-            customerRecoveryUid = undefined
+            customerRecoveryIdentity = null
           }
           throw error
         })
       customerRecovery = thisRecovery
-      customerRecoveryUid = sessionUserId
+      customerRecoveryIdentity = sessionIdentity
     }
     return customerRecovery
   }
@@ -762,6 +765,7 @@ export const useAuthStore = defineStore('auth', () => {
   const addCredits = async (
     requestBodyContent: CreditPurchasePayload
   ): Promise<CreditPurchaseResponse> => {
+    const requestOwner = currentUserIdentity()
     const authHeader = await getUserAuthHeader()
     if (!authHeader) {
       throw new AuthStoreError(t('toastMessages.userNotAuthenticated'))
@@ -770,8 +774,11 @@ export const useAuthStore = defineStore('auth', () => {
     // Ensure customer was created during login/registration. Routed through
     // recoverMissingCustomer so a concurrent 409-triggered recovery and this
     // pre-flight share one POST /customers instead of racing.
-    if (!customerCreated.value) {
+    if (customerProvisionedIdentity.value !== requestOwner) {
       await recoverMissingCustomer()
+      if (currentUserIdentity() !== requestOwner) {
+        throw new AuthStoreError(t('toastMessages.userNotAuthenticated'))
+      }
     }
 
     const response = await fetchWithCustomerRecovery(

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -286,6 +286,16 @@ export const useAuthStore = defineStore('auth', () => {
     return token ? { Authorization: `Bearer ${token}` } : null
   }
 
+  /**
+   * Returns the user-identity auth header for user-scoped endpoints
+   * (e.g., /customers/*): the Firebase token for signed-in sessions, the
+   * stored API key for API-key sessions. Never a workspace-scoped token.
+   */
+  const getUserAuthHeader = async (): Promise<AuthHeader | null> =>
+    currentUser.value === null
+      ? useApiKeyAuthStore().getAuthHeader()
+      : await getFirebaseAuthHeader()
+
   const getWorkspaceAuthHeader = async (): Promise<AuthHeader | null> => {
     if (flags.unifiedCloudAuthEnabled) {
       const token = useWorkspaceAuthStore().getUnifiedToken()
@@ -384,7 +394,7 @@ export const useAuthStore = defineStore('auth', () => {
     isFetchingBalance.value = true
     const requestOwnerUid = currentUser.value?.uid ?? null
     try {
-      const authHeader = await getFirebaseAuthHeader()
+      const authHeader = await getUserAuthHeader()
       if (!authHeader) {
         throw new AuthStoreError(t('toastMessages.userNotAuthenticated'))
       }
@@ -431,10 +441,7 @@ export const useAuthStore = defineStore('auth', () => {
     payload?: Omit<CreateCustomerPayload, 'signup_source'>
   ): Promise<CreateCustomerResponse> => {
     const sessionUserId = currentUser.value?.uid
-    const authHeader =
-      currentUser.value === null
-        ? useApiKeyAuthStore().getAuthHeader()
-        : await getFirebaseAuthHeader()
+    const authHeader = await getUserAuthHeader()
     if (!authHeader) {
       throw new AuthStoreError(t('toastMessages.userNotAuthenticated'))
     }
@@ -751,7 +758,7 @@ export const useAuthStore = defineStore('auth', () => {
   const addCredits = async (
     requestBodyContent: CreditPurchasePayload
   ): Promise<CreditPurchaseResponse> => {
-    const authHeader = await getFirebaseAuthHeader()
+    const authHeader = await getUserAuthHeader()
     if (!authHeader) {
       throw new AuthStoreError(t('toastMessages.userNotAuthenticated'))
     }
@@ -860,6 +867,7 @@ export const useAuthStore = defineStore('auth', () => {
     getAuthHeaderOrThrow,
     getFirebaseAuthHeader,
     getFirebaseAuthHeaderOrThrow,
+    getUserAuthHeader,
     getWorkspaceAuthHeader,
     getWorkspaceAuthHeaderOrThrow,
     getAuthToken,

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -296,6 +296,9 @@ export const useAuthStore = defineStore('auth', () => {
       ? useApiKeyAuthStore().getAuthHeader()
       : await getFirebaseAuthHeader()
 
+  const currentUserIdentity = (): string | null =>
+    currentUser.value?.uid ?? useApiKeyAuthStore().getApiKey()
+
   const getWorkspaceAuthHeader = async (): Promise<AuthHeader | null> => {
     if (flags.unifiedCloudAuthEnabled) {
       const token = useWorkspaceAuthStore().getUnifiedToken()
@@ -392,7 +395,7 @@ export const useAuthStore = defineStore('auth', () => {
 
   const fetchBalance = async (): Promise<GetCustomerBalanceResponse | null> => {
     isFetchingBalance.value = true
-    const requestOwnerUid = currentUser.value?.uid ?? null
+    const requestOwner = currentUserIdentity()
     try {
       const authHeader = await getUserAuthHeader()
       if (!authHeader) {
@@ -423,9 +426,10 @@ export const useAuthStore = defineStore('auth', () => {
       }
 
       const balanceData = await response.json()
-      // A direct A->B account switch nulls balance in onAuthStateChanged; a
-      // late-resolving request from the previous identity must not repaint it.
-      if ((currentUser.value?.uid ?? null) !== requestOwnerUid) {
+      // A direct A->B switch (Firebase account or stored API key) leaves this
+      // request owned by the previous identity; its late-resolving response
+      // must not repaint the new session's balance.
+      if (currentUserIdentity() !== requestOwner) {
         return null
       }
       // Update the last balance update time

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -807,7 +807,7 @@ export const useAuthStore = defineStore('auth', () => {
   const accessBillingPortal = async (
     targetTier?: BillingPortalTargetTier
   ): Promise<AccessBillingPortalResponse> => {
-    const authHeader = await getFirebaseAuthHeader()
+    const authHeader = await getUserAuthHeader()
     if (!authHeader) {
       throw new AuthStoreError(t('toastMessages.userNotAuthenticated'))
     }


### PR DESCRIPTION
## Why this is needed

Users who sign in with a **Comfy API key** (no Firebase session) cannot use any user-scoped billing surface: credit balance never loads, credit purchase fails, and the usage/events feed errors out. The same flows work fine for Firebase-authenticated users.

## Root cause

The user-scoped `/customers/*` endpoints accept either a Firebase ID token (`Authorization: Bearer …`) or a Comfy API key (`X-API-KEY`) — the backend resolves the user identity from whichever credential is presented. But on the frontend, most call sites requested **only** the Firebase header:

- `authStore.fetchBalance()` → `getFirebaseAuthHeader()` → returns `null` for API-key sessions → throws `userNotAuthenticated`
- `authStore.addCredits()` → same
- `customerEventsService.fetchEvents()` → same → "Authentication header is missing"

Only `createCustomer()` had an inline API-key fallback, so the customer record could be created, but every subsequent user-scoped call failed. The credential choice was duplicated ad hoc per call site instead of being defined once.

## How we change it

Add one auth-header accessor on `authStore` that encodes the credential rule for user-scoped endpoints, and use it at every user-scoped call site:

```ts
const getUserAuthHeader = async (): Promise<AuthHeader | null> =>
  currentUser.value === null
    ? useApiKeyAuthStore().getAuthHeader()   // API-key session → X-API-KEY
    : await getFirebaseAuthHeader()          // signed-in session → Firebase token
```

- `fetchBalance`, `addCredits`, `createCustomer`, `accessBillingPortal`, and `customerEventsService` now all go through `getUserAuthHeader()`.
- No frontend-derived identity or state: the frontend only forwards the stored credential; the server keeps deciding whose balance/events/purchase it is.
- Workspace-scoped calls are untouched — this helper is never a workspace token.

## AS IS

API-key session: the balance/customer calls fail with a missing auth header, so the app treats the session as unauthenticated and bounces the user back to the login dialog.

![AS IS — API-key session bounced to login](https://raw.githubusercontent.com/dante01yoon/ComfyUI_frontend/assets/pr-15891-screenshots/docs-assets/pr-15891/as-is-api-key-auth.png)

## TO BE

Same API-key session: user popover renders as authenticated and the credit balance loads (served by the backend from the `X-API-KEY` credential).

![TO BE — API-key session authenticated with balance loaded](https://raw.githubusercontent.com/dante01yoon/ComfyUI_frontend/assets/pr-15891-screenshots/docs-assets/pr-15891/to-be-api-key-auth.png)

## Tests

- New unit tests: API-key session sends `X-API-KEY` for `fetchBalance` / `initiateCreditPurchase`, Firebase token still preferred when signed in, and `userNotAuthenticated` is thrown when neither credential exists (`src/stores/authStore.test.ts`).
- `customerEventsService.test.ts` updated to cover the shared accessor.
- `accessBillingPortal` covered both ways: an API-key session sends `X-API-KEY` to `POST /customers/billing`, and `userNotAuthenticated` is still thrown when neither credential exists. Without it, Invoice History and Manage billing in the Credits panel stayed unreachable for API-key sessions even though the backend accepts the key there.
- 127/127 tests pass across both touched suites.

