### PR TITLE
fix(billing): open Plan & Credits and refresh the balance for rail-less sessions

### DIFF
--- a/src/components/dialog/content/TopUpCreditsDialogContentLegacy.test.ts
+++ b/src/components/dialog/content/TopUpCreditsDialogContentLegacy.test.ts
@@ -140,14 +140,14 @@ describe('TopUpCreditsDialogContentLegacy', () => {
     expect(mockShowSettings).toHaveBeenCalledWith('workspace')
   })
 
-  it('shows the credits settings panel when subscriptions are disabled', async () => {
+  it('shows Plan & Credits when no billing rail is active', async () => {
     mockIsSubscriptionEnabled.mockReturnValue(false)
     mockPurchaseCreditsDirect.mockResolvedValue(undefined)
 
     renderDialog()
     await clickBuyCredits()
 
-    expect(mockShowSettings).toHaveBeenCalledWith('credits')
+    expect(mockShowSettings).toHaveBeenCalledWith('workspace')
   })
 
   it('shows the workspace settings panel when workspace billing is active', async () => {

--- a/src/components/dialog/content/TopUpCreditsDialogContentLegacy.vue
+++ b/src/components/dialog/content/TopUpCreditsDialogContentLegacy.vue
@@ -158,9 +158,7 @@ import { creditsToUsd, usdToCredits } from '@/base/credits/comfyCredits'
 import Button from '@/components/ui/button/Button.vue'
 import FormattedNumberStepper from '@/components/ui/stepper/FormattedNumberStepper.vue'
 import { useAuthActions } from '@/composables/auth/useAuthActions'
-import { useBillingRouting } from '@/composables/billing/useBillingRouting'
 import { useExternalLink } from '@/composables/useExternalLink'
-import { useSubscription } from '@/platform/cloud/subscription/composables/useSubscription'
 import { useTelemetry } from '@/platform/telemetry'
 import { clearTopupTracking } from '@/platform/telemetry/topupTracker'
 import { categorizeBillingApiError } from '@/platform/telemetry/utils/billingFailureCategory'
@@ -179,9 +177,7 @@ const settingsDialog = useSettingsDialog()
 const telemetry = useTelemetry()
 const toast = useToast()
 const { buildDocsUrl, docsPaths } = useExternalLink()
-const { shouldUseWorkspaceBilling } = useBillingRouting()
 
-const { isSubscriptionEnabled } = useSubscription()
 // Constants
 const PRESET_AMOUNTS = [10, 25, 50, 100]
 const MIN_AMOUNT = 5
@@ -258,14 +254,14 @@ async function handleBuy() {
     telemetry?.trackApiCreditTopupButtonPurchaseClicked(payAmount.value)
     await authActions.purchaseCreditsDirect(payAmount.value)
 
-    // Close top-up dialog (keep tracking) and open credits panel to show updated balance
+    // Close top-up dialog (keep tracking) and open Plan & Credits to show the
+    // updated balance. The destination is the V1 panel for every session: the
+    // legacy `credits` panel is hidden from the settings menu, and keying this
+    // off the billing rail sent rail-less sessions (API key, pre-workspace
+    // bootstrap) to that hidden screen.
     handleClose(false)
 
-    const settingsPanel =
-      shouldUseWorkspaceBilling.value || isSubscriptionEnabled()
-        ? 'workspace'
-        : 'credits'
-    settingsDialog.show(settingsPanel)
+    settingsDialog.show('workspace')
   } catch (error) {
     console.error('Purchase failed:', error)
 

--- a/src/components/topbar/CurrentUserPopoverLegacy.test.ts
+++ b/src/components/topbar/CurrentUserPopoverLegacy.test.ts
@@ -285,7 +285,7 @@ describe('CurrentUserPopoverLegacy', () => {
     expect(onClose).toHaveBeenCalledTimes(1)
   })
 
-  it('opens credits settings from the legacy account menu', async () => {
+  it('opens Plan & Credits from the legacy account menu', async () => {
     const { user, onClose } = renderComponent()
 
     const menuItem = screen.getByTestId('manage-plan-menu-item')
@@ -293,7 +293,7 @@ describe('CurrentUserPopoverLegacy', () => {
 
     await user.click(menuItem)
 
-    expect(mockShowSettingsDialog).toHaveBeenCalledWith('credits')
+    expect(mockShowSettingsDialog).toHaveBeenCalledWith('workspace')
     expect(onClose).toHaveBeenCalledTimes(1)
   })
 

--- a/src/components/topbar/CurrentUserPopoverLegacy.vue
+++ b/src/components/topbar/CurrentUserPopoverLegacy.vue
@@ -244,7 +244,9 @@ const handleOpenUserSettings = () => {
 }
 
 const handleOpenPlanAndCreditsSettings = () => {
-  settingsDialog.show('credits')
+  // 'workspace' is the V1 Plan & Credits panel; the legacy 'credits' panel is
+  // hidden from the settings menu and only reachable by key.
+  settingsDialog.show('workspace')
   emit('close')
 }
 

--- a/src/composables/auth/useAuthActions.ts
+++ b/src/composables/auth/useAuthActions.ts
@@ -3,6 +3,7 @@ import { AuthErrorCodes } from 'firebase/auth'
 import { ref } from 'vue'
 
 import { useBillingContext } from '@/composables/billing/useBillingContext'
+import { watchForTopupBalanceUpdate } from '@/composables/billing/topupBalanceRefresh'
 import { useErrorHandling } from '@/composables/useErrorHandling'
 import type { ErrorRecoveryStrategy } from '@/composables/useErrorHandling'
 import { st, t } from '@/i18n'
@@ -192,6 +193,7 @@ export const useAuthActions = () => {
 
     useTelemetry()?.startTopupTracking()
     window.open(response.checkout_url, '_blank')
+    watchForTopupBalanceUpdate()
   }
 
   const purchaseCredits = wrapWithErrorHandlingAsync(

--- a/src/composables/billing/topupBalanceRefresh.test.ts
+++ b/src/composables/billing/topupBalanceRefresh.test.ts
@@ -67,6 +67,36 @@ describe('watchForTopupBalanceUpdate', () => {
     expect(mockFetchBalance).toHaveBeenCalledTimes(1)
   })
 
+  it('stays armed when a bounce back to the app spends the schedule', async () => {
+    watchForTopupBalanceUpdate()
+
+    // The user glances at the app before paying: the whole schedule runs
+    // against the unchanged balance.
+    returnToApp()
+    await vi.advanceTimersByTimeAsync(60_000)
+    const spentOnBounce = mockFetchBalance.mock.calls.length
+    expect(spentOnBounce).toBeGreaterThan(1)
+
+    // The real return, after paying, must still refresh.
+    mockFetchBalance.mockResolvedValue({ amount_micros: 6_000 })
+    returnToApp()
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(mockFetchBalance.mock.calls.length).toBe(spentOnBounce + 1)
+  })
+
+  it('treats the first post-return read as the baseline when none was loaded', async () => {
+    mockBalance.value = null
+
+    watchForTopupBalanceUpdate()
+    returnToApp()
+    await vi.advanceTimersByTimeAsync(60_000)
+
+    // The pre-purchase balance is not the increase we are waiting for, so the
+    // schedule must not stop on the first read.
+    expect(mockFetchBalance.mock.calls.length).toBeGreaterThan(1)
+  })
+
   it('keeps polling when a refresh rejects', async () => {
     vi.spyOn(console, 'warn').mockImplementation(() => {})
     mockFetchBalance.mockRejectedValue(new Error('network'))

--- a/src/composables/billing/topupBalanceRefresh.test.ts
+++ b/src/composables/billing/topupBalanceRefresh.test.ts
@@ -1,0 +1,80 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { watchForTopupBalanceUpdate } from './topupBalanceRefresh'
+
+const mockFetchBalance = vi.fn()
+const mockBalance = {
+  value: { amount_micros: 1_000 } as { amount_micros: number } | null
+}
+
+vi.mock('@/stores/authStore', () => ({
+  useAuthStore: () => ({
+    get balance() {
+      return mockBalance.value
+    },
+    fetchBalance: mockFetchBalance
+  })
+}))
+
+function returnToApp() {
+  vi.spyOn(document, 'visibilityState', 'get').mockReturnValue('visible')
+  document.dispatchEvent(new Event('visibilitychange'))
+}
+
+describe('watchForTopupBalanceUpdate', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.useFakeTimers()
+    mockFetchBalance.mockReset()
+    mockFetchBalance.mockResolvedValue({ amount_micros: 1_000 })
+    mockBalance.value = { amount_micros: 1_000 }
+  })
+
+  it('does not refresh until the app tab is visible again', async () => {
+    watchForTopupBalanceUpdate()
+
+    await vi.advanceTimersByTimeAsync(30_000)
+
+    expect(mockFetchBalance).not.toHaveBeenCalled()
+  })
+
+  it('refreshes the balance when the user returns from checkout', async () => {
+    watchForTopupBalanceUpdate()
+
+    returnToApp()
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(mockFetchBalance).toHaveBeenCalledTimes(1)
+  })
+
+  it('retries while the balance is unchanged, since the webhook lands late', async () => {
+    watchForTopupBalanceUpdate()
+
+    returnToApp()
+    await vi.advanceTimersByTimeAsync(30_000)
+
+    expect(mockFetchBalance.mock.calls.length).toBeGreaterThan(1)
+  })
+
+  it('stops retrying once the balance increases', async () => {
+    mockFetchBalance.mockResolvedValue({ amount_micros: 6_000 })
+
+    watchForTopupBalanceUpdate()
+    returnToApp()
+    await vi.advanceTimersByTimeAsync(30_000)
+
+    expect(mockFetchBalance).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps polling when a refresh rejects', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    mockFetchBalance.mockRejectedValue(new Error('network'))
+
+    watchForTopupBalanceUpdate()
+    returnToApp()
+    await vi.advanceTimersByTimeAsync(30_000)
+
+    expect(mockFetchBalance.mock.calls.length).toBeGreaterThan(1)
+  })
+})

--- a/src/composables/billing/topupBalanceRefresh.test.ts
+++ b/src/composables/billing/topupBalanceRefresh.test.ts
@@ -97,6 +97,33 @@ describe('watchForTopupBalanceUpdate', () => {
     expect(mockFetchBalance.mock.calls.length).toBeGreaterThan(1)
   })
 
+  it('refreshes when the window regains focus', async () => {
+    watchForTopupBalanceUpdate()
+
+    vi.spyOn(document, 'visibilityState', 'get').mockReturnValue('visible')
+    window.dispatchEvent(new Event('focus'))
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(mockFetchBalance).toHaveBeenCalledTimes(1)
+  })
+
+  it('still refreshes after payment when earlier returns spent the run cap', async () => {
+    watchForTopupBalanceUpdate()
+
+    // Five pre-payment glances consume every scheduled run.
+    for (let i = 0; i < 5; i++) {
+      returnToApp()
+      await vi.advanceTimersByTimeAsync(60_000)
+    }
+    mockFetchBalance.mockClear()
+    mockFetchBalance.mockResolvedValue({ amount_micros: 6_000 })
+
+    returnToApp()
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(mockFetchBalance).toHaveBeenCalledTimes(1)
+  })
+
   it('keeps polling when a refresh rejects', async () => {
     vi.spyOn(console, 'warn').mockImplementation(() => {})
     mockFetchBalance.mockRejectedValue(new Error('network'))

--- a/src/composables/billing/topupBalanceRefresh.ts
+++ b/src/composables/billing/topupBalanceRefresh.ts
@@ -7,13 +7,16 @@ import { useAuthStore } from '@/stores/authStore'
  * until a manual reload.
  *
  * Re-fetch when the app tab becomes visible again, retrying on a short schedule
- * because the webhook usually lands a beat after the redirect. Retries stop as
- * soon as the balance moves.
+ * because the webhook usually lands a beat after the redirect. Gaps between
+ * attempts, so the run spans ~37s.
  */
-const RETRY_DELAYS_MS = [0, 2_000, 5_000, 10_000, 20_000]
+const RETRY_GAPS_MS = [0, 2_000, 5_000, 10_000, 20_000]
 
 /** Drop the watch if the user never returns, rather than leaking listeners. */
 const WATCH_LIFETIME_MS = 15 * 60_000
+
+/** Bounds the polling a tab-switching user can trigger by re-arming. */
+const MAX_RUNS = 5
 
 let stopActiveWatch: (() => void) | null = null
 
@@ -27,44 +30,85 @@ export function watchForTopupBalanceUpdate(): void {
   stopActiveWatch?.()
 
   const authStore = useAuthStore()
-  const baselineMicros = authStore.balance?.amount_micros ?? 0
 
-  const timeouts: ReturnType<typeof setTimeout>[] = []
-  let started = false
+  // Null until a balance is known: treating "not loaded yet" as 0 would let the
+  // first read of the *pre-purchase* balance count as the increase we are
+  // waiting for, stopping the watch on the stale amount.
+  let baselineMicros: number | null = authStore.balance?.amount_micros ?? null
+
+  const timeouts = new Set<ReturnType<typeof setTimeout>>()
+  let stopped = false
+  let running = false
+  let runs = 0
 
   const stop = () => {
-    document.removeEventListener('visibilitychange', onReturn)
-    window.removeEventListener('focus', onReturn)
+    stopped = true
+    document.removeEventListener('visibilitychange', handleReturn)
+    window.removeEventListener('focus', handleReturn)
     for (const timeout of timeouts) clearTimeout(timeout)
-    timeouts.length = 0
+    timeouts.clear()
     if (stopActiveWatch === stop) stopActiveWatch = null
   }
 
-  const refresh = async () => {
+  const wait = (ms: number) =>
+    new Promise<void>((resolve) => {
+      const timeout = setTimeout(() => {
+        timeouts.delete(timeout)
+        resolve()
+      }, ms)
+      timeouts.add(timeout)
+    })
+
+  /** Fetch the balance; true once it has risen above the arming baseline. */
+  const refresh = async (): Promise<boolean> => {
     try {
       const balance = await authStore.fetchBalance()
-      if ((balance?.amount_micros ?? 0) > baselineMicros) stop()
+      const amountMicros = balance?.amount_micros ?? 0
+      if (baselineMicros === null) {
+        baselineMicros = amountMicros
+        return false
+      }
+      return amountMicros > baselineMicros
     } catch (error) {
       // A failed poll is not actionable: the next attempt (or the panel's own
       // fetch) covers it, and the purchase itself already succeeded.
       console.warn('[Billing] Top-up balance refresh failed', error)
+      return false
     }
   }
 
-  function onReturn() {
-    if (started || document.visibilityState !== 'visible') return
-    started = true
-    document.removeEventListener('visibilitychange', onReturn)
-    window.removeEventListener('focus', onReturn)
-
-    for (const delay of RETRY_DELAYS_MS) {
-      timeouts.push(setTimeout(() => void refresh(), delay))
+  async function onReturn() {
+    if (running || stopped || document.visibilityState !== 'visible') return
+    if (runs >= MAX_RUNS) {
+      stop()
+      return
     }
+    running = true
+    runs += 1
+
+    for (const gap of RETRY_GAPS_MS) {
+      await wait(gap)
+      if (stopped) return
+      if (await refresh()) {
+        stop()
+        return
+      }
+      if (stopped) return
+    }
+
+    // The schedule can be spent on a bounce back to the app *before* paying.
+    // Stay armed for the return that follows the actual payment; the watch
+    // lifetime is what bounds this, not the number of returns.
+    running = false
   }
 
-  document.addEventListener('visibilitychange', onReturn)
-  window.addEventListener('focus', onReturn)
-  timeouts.push(setTimeout(stop, WATCH_LIFETIME_MS))
+  function handleReturn() {
+    void onReturn()
+  }
+
+  document.addEventListener('visibilitychange', handleReturn)
+  window.addEventListener('focus', handleReturn)
+  timeouts.add(setTimeout(stop, WATCH_LIFETIME_MS))
 
   stopActiveWatch = stop
 }

--- a/src/composables/billing/topupBalanceRefresh.ts
+++ b/src/composables/billing/topupBalanceRefresh.ts
@@ -15,8 +15,8 @@ const RETRY_GAPS_MS = [0, 2_000, 5_000, 10_000, 20_000]
 /** Drop the watch if the user never returns, rather than leaking listeners. */
 const WATCH_LIFETIME_MS = 15 * 60_000
 
-/** Bounds the polling a tab-switching user can trigger by re-arming. */
-const MAX_RUNS = 5
+/** Full retry schedules a returning user can trigger; later returns get a single fetch. */
+const MAX_SCHEDULED_RUNS = 5
 
 let stopActiveWatch: (() => void) | null = null
 
@@ -79,14 +79,16 @@ export function watchForTopupBalanceUpdate(): void {
 
   async function onReturn() {
     if (running || stopped || document.visibilityState !== 'visible') return
-    if (runs >= MAX_RUNS) {
-      stop()
-      return
-    }
     running = true
     runs += 1
 
-    for (const gap of RETRY_GAPS_MS) {
+    // Past the run cap a return still refreshes once — the return after the
+    // actual payment must fetch no matter how often the user glanced back
+    // beforehand. Only the retry schedule is withheld; the lifetime timer is
+    // the sole terminal condition.
+    const gaps = runs > MAX_SCHEDULED_RUNS ? [0] : RETRY_GAPS_MS
+
+    for (const gap of gaps) {
       await wait(gap)
       if (stopped) return
       if (await refresh()) {
@@ -96,9 +98,6 @@ export function watchForTopupBalanceUpdate(): void {
       if (stopped) return
     }
 
-    // The schedule can be spent on a bounce back to the app *before* paying.
-    // Stay armed for the return that follows the actual payment; the watch
-    // lifetime is what bounds this, not the number of returns.
     running = false
   }
 

--- a/src/composables/billing/topupBalanceRefresh.ts
+++ b/src/composables/billing/topupBalanceRefresh.ts
@@ -1,0 +1,70 @@
+import { useAuthStore } from '@/stores/authStore'
+
+/**
+ * A Stripe credit top-up completes in a separate tab, and the balance only
+ * changes once Stripe's webhook reaches comfy-api. Nothing re-reads the balance
+ * when the user comes back, so the app keeps showing the pre-purchase amount
+ * until a manual reload.
+ *
+ * Re-fetch when the app tab becomes visible again, retrying on a short schedule
+ * because the webhook usually lands a beat after the redirect. Retries stop as
+ * soon as the balance moves.
+ */
+const RETRY_DELAYS_MS = [0, 2_000, 5_000, 10_000, 20_000]
+
+/** Drop the watch if the user never returns, rather than leaking listeners. */
+const WATCH_LIFETIME_MS = 15 * 60_000
+
+let stopActiveWatch: (() => void) | null = null
+
+/**
+ * Watch for the user returning from a Stripe top-up and refresh the balance.
+ * Safe to call repeatedly: a new call replaces any watch still pending.
+ */
+export function watchForTopupBalanceUpdate(): void {
+  if (typeof window === 'undefined' || typeof document === 'undefined') return
+
+  stopActiveWatch?.()
+
+  const authStore = useAuthStore()
+  const baselineMicros = authStore.balance?.amount_micros ?? 0
+
+  const timeouts: ReturnType<typeof setTimeout>[] = []
+  let started = false
+
+  const stop = () => {
+    document.removeEventListener('visibilitychange', onReturn)
+    window.removeEventListener('focus', onReturn)
+    for (const timeout of timeouts) clearTimeout(timeout)
+    timeouts.length = 0
+    if (stopActiveWatch === stop) stopActiveWatch = null
+  }
+
+  const refresh = async () => {
+    try {
+      const balance = await authStore.fetchBalance()
+      if ((balance?.amount_micros ?? 0) > baselineMicros) stop()
+    } catch (error) {
+      // A failed poll is not actionable: the next attempt (or the panel's own
+      // fetch) covers it, and the purchase itself already succeeded.
+      console.warn('[Billing] Top-up balance refresh failed', error)
+    }
+  }
+
+  function onReturn() {
+    if (started || document.visibilityState !== 'visible') return
+    started = true
+    document.removeEventListener('visibilitychange', onReturn)
+    window.removeEventListener('focus', onReturn)
+
+    for (const delay of RETRY_DELAYS_MS) {
+      timeouts.push(setTimeout(() => void refresh(), delay))
+    }
+  }
+
+  document.addEventListener('visibilitychange', onReturn)
+  window.addEventListener('focus', onReturn)
+  timeouts.push(setTimeout(stop, WATCH_LIFETIME_MS))
+
+  stopActiveWatch = stop
+}


### PR DESCRIPTION
## Why this is needed

A session with no workspace context — an API-key sign-in, or a pre-workspace bootstrap — still reaches billing through the legacy rail, and two of its entry points were never migrated to the V1 layout:

- The profile menu **Credits** action opens the legacy combined Credits + Activity screen instead of the tabbed **Plan & Credits** panel. That legacy panel is hidden from the settings menu and is only reachable by key, so the user lands somewhere they cannot navigate back to.
- After a Stripe credit top-up, returning to the app shows the **pre-purchase balance until a manual reload**, and drops the user on that same hidden screen.

Reported in [Slack](https://comfy-organization.slack.com/archives/C0932CGKT5K/p1787651927438829?thread_ts=1787034725.224329&cid=C0932CGKT5K).

## Root cause

**Destination.** #15793 routed the workspace-aware call sites to `workspace`, and deliberately left `CurrentUserPopoverLegacy` alone. But `CurrentUserButton` falls back to that legacy popover whenever `teamWorkspaceStore.initState !== 'ready'`, which is exactly the state an API-key session stays in — workspace discovery never runs for it. Two call sites still decide from the billing rail:

```ts
// CurrentUserPopoverLegacy.vue — always the hidden panel
settingsDialog.show('credits')

// TopUpCreditsDialogContentLegacy.vue — hidden panel whenever no rail is active
const settingsPanel =
  shouldUseWorkspaceBilling.value || isSubscriptionEnabled() ? 'workspace' : 'credits'
```

The rail is the wrong question. What decides whether `workspace` is reachable is panel availability, and `useSettingUI` registers Plan & Credits for every signed-in user (`shouldShowWorkspacePanel = isLoggedIn`). The panel also renders correctly on the legacy rail — its credits tile reads the same `/customers/balance` the legacy screen did.

**Stale balance.** The workspace rail has a completion path for top-ups (`billingOperationStore` polls, refreshes the balance, and opens Plan & Credits). The legacy rail has no equivalent: `purchaseCreditsDirect()` ends at `window.open(checkout_url, '_blank')`. Stripe completes out of band in another tab, so nothing ever re-reads the balance and the pre-purchase amount stays on screen.

## How we change it

- Both legacy call sites open `workspace`. The rail-derived branch in the top-up dialog goes away, along with its now-unused `useBillingRouting` / `useSubscription` reads.
- New `watchForTopupBalanceUpdate()` (`src/composables/billing/topupBalanceRefresh.ts`), called right after the checkout tab opens. It waits for the app tab to become visible again, then re-fetches the balance on a `0 / 2s / 5s / 10s / 20s` schedule — the webhook usually lands a beat after the redirect. Retries stop as soon as the balance moves; the watch drops itself after 15 minutes if the user never returns, and a failed poll is logged rather than surfaced, since the purchase itself already succeeded.

Cloud and workspace-billing sessions are unaffected: they already selected `workspace`, and their top-ups already refresh through `billingOperationStore`.

## AS IS / TO BE

| | AS IS | TO BE |
| --- | --- | --- |
| Profile menu → Credits | hidden combined Credits + Activity screen | tabbed Plan & Credits |
| After Stripe top-up | same hidden screen, stale balance until reload | tabbed Plan & Credits, balance refreshes on return |
| Cloud / workspace billing | Plan & Credits | unchanged |

### Screenshots

Both taken in the same API-key session against staging, differing only by this PR's commit.

**AS IS** — profile menu → Credits lands on the hidden legacy screen: one `Credits` heading with `Activity` stacked underneath, no tabs, and `Plan & Credits` sitting unselected in the sidebar.

![AS IS - legacy combined Credits and Activity screen](https://raw.githubusercontent.com/dante01yoon/ComfyUI_frontend/assets/pr-15892-screenshots/docs-assets/pr-15892/as-is.png)

**TO BE** — the same action opens `Plan & Credits` with the `Credits` and `Activity` tabs.

![TO BE - tabbed Plan and Credits panel](https://raw.githubusercontent.com/dante01yoon/ComfyUI_frontend/assets/pr-15892-screenshots/docs-assets/pr-15892/to-be.png)

## Verification

Local ComfyUI against staging (`--comfy-api-base https://stagingapi.comfy.org`) with a pure API-key session (no Firebase login), which is the state that reproduces this. The build under test also carried #15891, because an API-key session cannot read `/customers/*` without it — so the requests below are only reachable with that PR applied, and the screenshots above differ from each other by this PR's commit alone:

- Profile menu → **Credits** opens Plan & Credits with the **Credits** and **Activity** tabs.
- **Add credits → Continue to payment** issues `POST /customers/credit` (`201`), opens the Stripe tab, and returns to the tabbed panel.
- Simulating the return to the app tab issues `GET /customers/balance` immediately and again on the retry schedule.
- The watch survives an early return: a bounce back to the app before paying no longer consumes it, and the return after payment still refreshes.

Unit tests: `topupBalanceRefresh.test.ts` (new — no refresh before the tab is visible, refresh on return, retry while unchanged, stop once the balance rises, keep polling when a fetch rejects), plus updated destination assertions in `CurrentUserPopoverLegacy.test.ts` and `TopUpCreditsDialogContentLegacy.test.ts`. 117 tests pass across the touched suites; `pnpm typecheck` clean.

## Note

Independent of #15891 — no shared files — but the same API-key session is what surfaces both. **Manage billing** inside this panel needs that PR's `accessBillingPortal` fix to work.

https://claude.ai/code/session_01QQZvvG7jZKrEkkT93ezPPw


