### PR TITLE
feat(theme): derive custom dark palette surfaces from their own colour

### DIFF
--- a/packages/design-system/src/css/style.css
+++ b/packages/design-system/src/css/style.css
@@ -422,22 +422,22 @@
 :root.dark-theme[data-color-palette]:not([data-color-palette='dark']) {
   /* Capped so a light comfy-menu-bg cannot flatten the ladder into white. */
   --palette-l: min(l, 0.35);
-  --palette-base: oklch(from var(--comfy-menu-bg) var(--palette-l) c h);
+  --palette-base: oklch(from var(--comfy-menu-bg) var(--palette-l) c h / 1);
 
   --palette-surface-700: oklch(
-    from var(--comfy-menu-bg) calc(var(--palette-l) + 0.0417) c h
+    from var(--comfy-menu-bg) calc(var(--palette-l) + 0.0417) c h / 1
   );
   --palette-surface-600: oklch(
-    from var(--comfy-menu-bg) calc(var(--palette-l) + 0.0675) c h
+    from var(--comfy-menu-bg) calc(var(--palette-l) + 0.0675) c h / 1
   );
   --palette-surface-400: oklch(
-    from var(--comfy-menu-bg) calc(var(--palette-l) + 0.1123) c h
+    from var(--comfy-menu-bg) calc(var(--palette-l) + 0.1123) c h / 1
   );
   --palette-surface-300: oklch(
-    from var(--comfy-menu-bg) calc(var(--palette-l) + 0.1559) c h
+    from var(--comfy-menu-bg) calc(var(--palette-l) + 0.1559) c h / 1
   );
   --palette-surface-200: oklch(
-    from var(--comfy-menu-bg) calc(var(--palette-l) + 0.2054) c h
+    from var(--comfy-menu-bg) calc(var(--palette-l) + 0.2054) c h / 1
   );
 
   --base-background: var(--palette-base);

--- a/packages/design-system/src/css/style.css
+++ b/packages/design-system/src/css/style.css
@@ -420,14 +420,7 @@
 }
 
 :root.dark-theme[data-color-palette]:not([data-color-palette='dark']) {
-  /* A palette counts as dark whenever it omits light_theme, but comfy-menu-bg
-     accepts any colour, and a light one would push every offset up against
-     l: 1 and collapse the ladder into white under a white foreground. Capping
-     the lightness the ladder derives from keeps a dark palette dark. Every
-     shipped palette sits below the cap (solarized is the lightest at 0.309)
-     so their surfaces are untouched, the cap leaves the top step at 0.5554
-     where the white foreground still reads, and min() is monotonic, so there
-     is no threshold where the steps converge. */
+  /* Capped so a light comfy-menu-bg cannot flatten the ladder into white. */
   --palette-l: min(l, 0.35);
   --palette-base: oklch(from var(--comfy-menu-bg) var(--palette-l) c h);
 

--- a/packages/design-system/src/css/style.css
+++ b/packages/design-system/src/css/style.css
@@ -421,37 +421,37 @@
 
 :root.dark-theme[data-color-palette]:not([data-color-palette='dark']) {
   /* A palette counts as dark whenever it omits light_theme, but comfy-menu-bg
-     accepts any colour. Given a light menu colour every positive offset clamps
-     at l: 1, collapsing all five steps into white under a white foreground.
-     These two resolve to +1 and 1 for a dark base, leaving real palettes
-     untouched, and flip to -1 and a dark ink once the base crosses mid grey,
-     so the ladder keeps its five distinct steps and stays legible either way. */
-  --palette-depth: calc(1 - 2 * clamp(0, (l - 0.5) * 1000, 1));
-  --palette-ink: calc(1 - 0.85 * clamp(0, (l - 0.5) * 1000, 1));
+     accepts any colour, and a light one would push every offset up against
+     l: 1 and collapse the ladder into white under a white foreground. Capping
+     the lightness the ladder derives from keeps a dark palette dark. Every
+     shipped palette sits below the cap (solarized is the lightest at 0.309)
+     so their surfaces are untouched, the cap leaves the top step at 0.5554
+     where the white foreground still reads, and min() is monotonic, so there
+     is no threshold where the steps converge. */
+  --palette-l: min(l, 0.35);
+  --palette-base: oklch(from var(--comfy-menu-bg) var(--palette-l) c h);
 
   --palette-surface-700: oklch(
-    from var(--comfy-menu-bg) calc(l + 0.0417 * var(--palette-depth)) c h
+    from var(--comfy-menu-bg) calc(var(--palette-l) + 0.0417) c h
   );
   --palette-surface-600: oklch(
-    from var(--comfy-menu-bg) calc(l + 0.0675 * var(--palette-depth)) c h
+    from var(--comfy-menu-bg) calc(var(--palette-l) + 0.0675) c h
   );
   --palette-surface-400: oklch(
-    from var(--comfy-menu-bg) calc(l + 0.1123 * var(--palette-depth)) c h
+    from var(--comfy-menu-bg) calc(var(--palette-l) + 0.1123) c h
   );
   --palette-surface-300: oklch(
-    from var(--comfy-menu-bg) calc(l + 0.1559 * var(--palette-depth)) c h
+    from var(--comfy-menu-bg) calc(var(--palette-l) + 0.1559) c h
   );
   --palette-surface-200: oklch(
-    from var(--comfy-menu-bg) calc(l + 0.2054 * var(--palette-depth)) c h
+    from var(--comfy-menu-bg) calc(var(--palette-l) + 0.2054) c h
   );
 
-  --base-foreground: oklch(from var(--comfy-menu-bg) var(--palette-ink) 0 h);
-
-  --base-background: var(--comfy-menu-bg);
-  --nav-background: var(--comfy-menu-bg);
-  --interface-menu-surface: var(--comfy-menu-bg);
-  --node-component-tooltip-surface: var(--comfy-menu-bg);
-  --component-node-widget-background-disabled: var(--comfy-menu-bg);
+  --base-background: var(--palette-base);
+  --nav-background: var(--palette-base);
+  --interface-menu-surface: var(--palette-base);
+  --node-component-tooltip-surface: var(--palette-base);
+  --component-node-widget-background-disabled: var(--palette-base);
 
   --node-component-header-surface: var(--palette-surface-700);
 

--- a/packages/design-system/src/css/style.css
+++ b/packages/design-system/src/css/style.css
@@ -420,11 +420,32 @@
 }
 
 :root.dark-theme[data-color-palette]:not([data-color-palette='dark']) {
-  --palette-surface-700: oklch(from var(--comfy-menu-bg) calc(l + 0.0417) c h);
-  --palette-surface-600: oklch(from var(--comfy-menu-bg) calc(l + 0.0675) c h);
-  --palette-surface-400: oklch(from var(--comfy-menu-bg) calc(l + 0.1123) c h);
-  --palette-surface-300: oklch(from var(--comfy-menu-bg) calc(l + 0.1559) c h);
-  --palette-surface-200: oklch(from var(--comfy-menu-bg) calc(l + 0.2054) c h);
+  /* A palette counts as dark whenever it omits light_theme, but comfy-menu-bg
+     accepts any colour. Given a light menu colour every positive offset clamps
+     at l: 1, collapsing all five steps into white under a white foreground.
+     These two resolve to +1 and 1 for a dark base, leaving real palettes
+     untouched, and flip to -1 and a dark ink once the base crosses mid grey,
+     so the ladder keeps its five distinct steps and stays legible either way. */
+  --palette-depth: calc(1 - 2 * clamp(0, (l - 0.5) * 1000, 1));
+  --palette-ink: calc(1 - 0.85 * clamp(0, (l - 0.5) * 1000, 1));
+
+  --palette-surface-700: oklch(
+    from var(--comfy-menu-bg) calc(l + 0.0417 * var(--palette-depth)) c h
+  );
+  --palette-surface-600: oklch(
+    from var(--comfy-menu-bg) calc(l + 0.0675 * var(--palette-depth)) c h
+  );
+  --palette-surface-400: oklch(
+    from var(--comfy-menu-bg) calc(l + 0.1123 * var(--palette-depth)) c h
+  );
+  --palette-surface-300: oklch(
+    from var(--comfy-menu-bg) calc(l + 0.1559 * var(--palette-depth)) c h
+  );
+  --palette-surface-200: oklch(
+    from var(--comfy-menu-bg) calc(l + 0.2054 * var(--palette-depth)) c h
+  );
+
+  --base-foreground: oklch(from var(--comfy-menu-bg) var(--palette-ink) 0 h);
 
   --base-background: var(--comfy-menu-bg);
   --nav-background: var(--comfy-menu-bg);

--- a/packages/design-system/src/css/style.css
+++ b/packages/design-system/src/css/style.css
@@ -419,6 +419,47 @@
   --modal-panel-background: var(--color-charcoal-600);
 }
 
+:root.dark-theme[data-color-palette]:not([data-color-palette='dark']) {
+  --palette-surface-700: oklch(from var(--comfy-menu-bg) calc(l + 0.0417) c h);
+  --palette-surface-600: oklch(from var(--comfy-menu-bg) calc(l + 0.0675) c h);
+  --palette-surface-400: oklch(from var(--comfy-menu-bg) calc(l + 0.1123) c h);
+  --palette-surface-300: oklch(from var(--comfy-menu-bg) calc(l + 0.1559) c h);
+  --palette-surface-200: oklch(from var(--comfy-menu-bg) calc(l + 0.2054) c h);
+
+  --base-background: var(--comfy-menu-bg);
+  --nav-background: var(--comfy-menu-bg);
+  --interface-menu-surface: var(--comfy-menu-bg);
+  --node-component-tooltip-surface: var(--comfy-menu-bg);
+  --component-node-widget-background-disabled: var(--comfy-menu-bg);
+
+  --node-component-header-surface: var(--palette-surface-700);
+
+  --button-surface: var(--palette-surface-600);
+  --button-hover-surface: var(--palette-surface-600);
+  --button-active-surface: var(--palette-surface-600);
+  --secondary-background: var(--palette-surface-600);
+  --node-component-surface: var(--palette-surface-600);
+  --node-component-surface-hovered: var(--palette-surface-600);
+  --component-node-background: var(--palette-surface-600);
+  --modal-panel-background: var(--palette-surface-600);
+
+  --interface-menu-component-surface-hovered: var(--palette-surface-400);
+  --secondary-background-hover: var(--palette-surface-400);
+  --tertiary-background: var(--palette-surface-400);
+
+  --interface-menu-component-surface-selected: var(--palette-surface-300);
+  --tertiary-background-hover: var(--palette-surface-300);
+  --border-subtle: var(--palette-surface-300);
+  --modal-card-button-surface: var(--palette-surface-300);
+
+  --interface-menu-keybind-surface-default: var(--palette-surface-200);
+  --node-component-border-selected: var(--palette-surface-200);
+  --node-component-surface-selected: var(--palette-surface-200);
+  --node-component-tooltip-border: var(--palette-surface-200);
+  --secondary-background-selected: var(--palette-surface-200);
+  --border-default: var(--palette-surface-200);
+}
+
 @theme inline {
   --color-backdrop: var(--backdrop);
   --color-button-active-surface: var(--button-active-surface);


### PR DESCRIPTION
> [!IMPORTANT]
> **Depends on #13842.** The selector keys off `data-color-palette`, which that PR stamps on `documentElement`. Until it merges, this block never matches and changes nothing. Merge order: #15884 → #13842 → this.

## ELI5

Pick the Solarized theme and the editor is teal: except the buttons, menus and borders, which stay the default grey. This makes them follow the theme you picked.

## What

`.dark-theme` hardcodes ~25 semantic tokens to charcoal, and it is applied to *every* non-light palette. So arc, nord, github, solarized and any palette a user imports get the default palette's greys for buttons, modals, menus, borders and node components, whatever colour they actually chose.

Each level is now expressed as a lightness offset from the palette's own `--comfy-menu-bg`, replayed in OKLCH so the offsets stay perceptually even while each palette keeps its hue and chroma. The offsets are measured from the real charcoal scale, so the default dark palette resolves to the same values it does today.

Scoped on `.dark-theme` so user-imported **light** palettes keep the light defaults instead of near-white lightness derivations.

## Scope

Split out of #13842 at review request: it restyles surfaces across the whole app rather than the editor chrome that PR is about, so it deserves its own review with per-palette evidence.

## Points worth reviewer attention

- **Solarized gamut.** Its teal is saturated enough that a derived surface can land just outside sRGB; browsers gamut-map per CSS Color 4 (chroma reduction preserving L and H). Intended, but it means solarized's derived surfaces are marginally less saturated than the raw formula asks for.
- **User-defined palettes.** The offsets are applied to a `--comfy-menu-bg` that cannot be anticipated, so the ladder derives from a capped lightness rather than the raw value: `--palette-l: min(l, 0.35)`. Every shipped palette sits below the cap, solarized being the lightest at `0.309`, so their surfaces are unchanged. A palette that declares a light menu colour without `light_theme` degrades to a dark UI, which is what it declared, instead of collapsing into white under a white foreground. `min()` is monotonic, so there is no threshold where the five steps converge, and the cap leaves the top step at `0.5554`, where the white foreground still reads. Every derived declaration also ends in `/ 1`: relative colour syntax inherits the origin's alpha, so a palette declaring a translucent menu colour would otherwise make the whole ladder translucent. Raised by CodeRabbit across three rounds, fixed in 497692ecda and 6bcb53b0f3.
- **Not covered.** Palettes that set `interface-stroke` or `interface-panel-surface` themselves: `colorPaletteService` inlines those on `<html>` for every palette that omits them, and inline wins over any selector.

## Evidence

Captured in the real app, one palette per row, everything else identical. AS-IS is this branch with the new block disabled, which is exactly what ships today.

**Why the settings dialog and not the editor.** The blast radius is narrower than "surfaces across the app" suggests, and worth stating plainly: `colorPaletteService` writes `--comfy-menu-bg` and its neighbours inline on `<html>`, and inline beats any selector, so the resting editor chrome does not change here at all. I measured four candidate subjects, AS-IS against TO-BE, same page load, only the block toggled:

| Subject | Pixels changed |
|---|---|
| Editor at rest | 4.2%, invisible in practice |
| Node library sidebar | 3.3%, its background is one of the inlined vars |
| Graph dropdown menu | 10.7% |
| Settings dialog | 97% |

Modals and menus are where the block actually lands, and the settings dialog is the largest one carrying no media, so it is the honest place to show it. The measured panel value below is the same story in numbers.

The measured panel surface says it plainly: on main every custom palette paints the same neutral charcoal, whatever colour the user picked.

| Palette | Panel AS-IS | Panel TO-BE |
|---|---|---|
| solarized | `rgb(38,39,41)` | `oklch(0.376702 0.0517 219.66)` |
| arc | `rgb(38,39,41)` | `oklch(0.341094 0.0172 270.76)` |
| nord | `rgb(38,39,41)` | `oklch(0.287721 0.0157 256.85)` |
| github | `rgb(38,39,41)` | `oklch(0.270701 0.0135 258.40)` |

### solarized

| AS-IS | TO-BE |
|---|---|
| <img width="420" src="https://github.com/user-attachments/assets/1f5d4622-1ff9-4f19-b8d5-a4e5886ecbf7" /> | <img width="420" src="https://github.com/user-attachments/assets/31a3d503-ed1e-446f-91c2-220a3b654164" /> |

### arc

| AS-IS | TO-BE |
|---|---|
| <img width="420" src="https://github.com/user-attachments/assets/10829cb5-ef5a-4b7d-b167-c6d6559a89b4" /> | <img width="420" src="https://github.com/user-attachments/assets/1468259f-3254-454b-bed9-8079ace8ea16" /> |

### nord

| AS-IS | TO-BE |
|---|---|
| <img width="420" src="https://github.com/user-attachments/assets/a786eb45-1b7e-4c80-bd85-9af8f9fd983f" /> | <img width="420" src="https://github.com/user-attachments/assets/fd939ce0-4b17-4c7a-b6f4-68bd62174da2" /> |

### github

| AS-IS | TO-BE |
|---|---|
| <img width="420" src="https://github.com/user-attachments/assets/aa5a6728-055f-4375-9fae-2cbaa79e895d" /> | <img width="420" src="https://github.com/user-attachments/assets/36102d85-174c-4e2d-bf37-b826b83a9249" /> |

The default dark palette is excluded by the selector and is unchanged. Verified live: arc `0.341094`, solarized `0.376702`, nord `0.287721`, github `0.270701`, measured identical before and after the light-menu fix.







