### PR TITLE
fix(cloud): suspend onboarding during desktop sign-in approval

### DIFF
--- a/src/platform/cloud/onboarding/desktopLoginRedemption.test.ts
+++ b/src/platform/cloud/onboarding/desktopLoginRedemption.test.ts
@@ -180,6 +180,8 @@ describe('installDesktopLoginRedemption', () => {
 
   it('does not fetch before the user approves the confirmation dialog', async () => {
     const { trigger, seedStash } = await setup()
+    const { isDesktopLoginApprovalPending } =
+      await import('./desktopLoginRedemptionState')
     seedStash(VALID_CODE)
     let approve!: (value: boolean) => void
     mockConfirm.mockReturnValue(
@@ -191,11 +193,13 @@ describe('installDesktopLoginRedemption', () => {
 
     await trigger()
     await vi.waitFor(() => expect(mockConfirm).toHaveBeenCalledTimes(1))
+    expect(isDesktopLoginApprovalPending.value).toBe(true)
     expect(mockFetch).not.toHaveBeenCalled()
 
     approve(true)
     await flushRedemption()
 
+    expect(isDesktopLoginApprovalPending.value).toBe(false)
     expect(mockFetch).toHaveBeenCalledTimes(1)
   })
 

--- a/src/platform/cloud/onboarding/desktopLoginRedemption.test.ts
+++ b/src/platform/cloud/onboarding/desktopLoginRedemption.test.ts
@@ -161,6 +161,7 @@ describe('installDesktopLoginRedemption', () => {
 
     expect(mockConfirm).toHaveBeenCalledTimes(1)
     expect(mockConfirm).toHaveBeenCalledWith({
+      key: 'desktop-login-redemption',
       title: 'desktopLogin.confirmSummary',
       message: 'desktopLogin.confirmMessage'
     })

--- a/src/platform/cloud/onboarding/desktopLoginRedemption.ts
+++ b/src/platform/cloud/onboarding/desktopLoginRedemption.ts
@@ -8,6 +8,7 @@ import {
 } from '@/platform/navigation/preservedQueryManager'
 import { PRESERVED_QUERY_NAMESPACES } from '@/platform/navigation/preservedQueryNamespaces'
 import { useToastStore } from '@/platform/updates/common/toastStore'
+import { withDesktopLoginApproval } from '@/platform/cloud/onboarding/desktopLoginRedemptionState'
 import { api } from '@/scripts/api'
 import { useDialogService } from '@/services/dialogService'
 import { useAuthStore } from '@/stores/authStore'
@@ -116,10 +117,12 @@ async function confirmRedemption(
   uid: string
 ): Promise<boolean> {
   if (state.approvedUserUid === uid) return true
-  const confirmed = await useDialogService().confirm({
-    title: t('desktopLogin.confirmSummary'),
-    message: t('desktopLogin.confirmMessage')
-  })
+  const confirmed = await withDesktopLoginApproval(() =>
+    useDialogService().confirm({
+      title: t('desktopLogin.confirmSummary'),
+      message: t('desktopLogin.confirmMessage')
+    })
+  )
   if (confirmed !== true) return false
   state.approvedUserUid = uid
   return true

--- a/src/platform/cloud/onboarding/desktopLoginRedemption.ts
+++ b/src/platform/cloud/onboarding/desktopLoginRedemption.ts
@@ -119,6 +119,7 @@ async function confirmRedemption(
   if (state.approvedUserUid === uid) return true
   const confirmed = await withDesktopLoginApproval(() =>
     useDialogService().confirm({
+      key: 'desktop-login-redemption',
       title: t('desktopLogin.confirmSummary'),
       message: t('desktopLogin.confirmMessage')
     })

--- a/src/platform/cloud/onboarding/desktopLoginRedemptionState.ts
+++ b/src/platform/cloud/onboarding/desktopLoginRedemptionState.ts
@@ -1,0 +1,24 @@
+import { computed, ref } from 'vue'
+
+const pendingApprovalCount = ref(0)
+
+/** True only while the browser is waiting for desktop sign-in approval. */
+export const isDesktopLoginApprovalPending = computed(
+  () => pendingApprovalCount.value > 0
+)
+
+/**
+ * Marks the approval dialog as the active takeover for exactly as long as the
+ * supplied operation is pending. A counter keeps this correct if the flow is
+ * ever made concurrent.
+ */
+export async function withDesktopLoginApproval<T>(
+  operation: () => Promise<T>
+): Promise<T> {
+  pendingApprovalCount.value++
+  try {
+    return await operation()
+  } finally {
+    pendingApprovalCount.value--
+  }
+}

--- a/src/renderer/extensions/firstRunTour/FirstRunTour.test.ts
+++ b/src/renderer/extensions/firstRunTour/FirstRunTour.test.ts
@@ -1,0 +1,65 @@
+import { render, screen } from '@testing-library/vue'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { nextTick } from 'vue'
+
+import { withDesktopLoginApproval } from '@/platform/cloud/onboarding/desktopLoginRedemptionState'
+
+const mocks = vi.hoisted(() => ({
+  gettingStartedVisible: false
+}))
+
+vi.mock('./gettingStarted/firstRunEntry', async () => {
+  const { computed } = await import('vue')
+  return {
+    useFirstRunEntry: () => ({
+      gettingStartedVisible: computed(() => mocks.gettingStartedVisible)
+    })
+  }
+})
+
+vi.mock('./gettingStarted/GettingStartedScreen.vue', () => ({
+  default: {
+    template: '<div data-testid="getting-started-screen" />'
+  }
+}))
+
+vi.mock('./nudge/FirstRunTourNudge.vue', () => ({
+  default: { template: '<div />' }
+}))
+
+vi.mock('./tour/useFirstRunTourController', () => ({
+  useFirstRunTourController: vi.fn()
+}))
+
+async function renderFirstRunTour() {
+  const { default: FirstRunTour } = await import('./FirstRunTour.vue')
+  return render(FirstRunTour)
+}
+
+describe('FirstRunTour desktop sign-in arbitration', () => {
+  beforeEach(() => {
+    mocks.gettingStartedVisible = true
+  })
+
+  it('suspends onboarding while desktop sign-in approval is pending', async () => {
+    await renderFirstRunTour()
+    expect(screen.getByTestId('getting-started-screen')).toBeInTheDocument()
+
+    let finishApproval!: () => void
+    const approval = withDesktopLoginApproval(
+      () =>
+        new Promise<void>((resolve) => {
+          finishApproval = resolve
+        })
+    )
+    await nextTick()
+
+    expect(screen.queryByTestId('getting-started-screen')).toBeNull()
+
+    finishApproval()
+    await approval
+    await nextTick()
+
+    expect(screen.getByTestId('getting-started-screen')).toBeInTheDocument()
+  })
+})

--- a/src/renderer/extensions/firstRunTour/FirstRunTour.test.ts
+++ b/src/renderer/extensions/firstRunTour/FirstRunTour.test.ts
@@ -4,6 +4,8 @@ import { nextTick } from 'vue'
 
 import { withDesktopLoginApproval } from '@/platform/cloud/onboarding/desktopLoginRedemptionState'
 
+import FirstRunTour from './FirstRunTour.vue'
+
 const mocks = vi.hoisted(() => ({
   gettingStartedVisible: false
 }))
@@ -31,35 +33,37 @@ vi.mock('./tour/useFirstRunTourController', () => ({
   useFirstRunTourController: vi.fn()
 }))
 
-async function renderFirstRunTour() {
-  const { default: FirstRunTour } = await import('./FirstRunTour.vue')
-  return render(FirstRunTour)
-}
-
 describe('FirstRunTour desktop sign-in arbitration', () => {
   beforeEach(() => {
     mocks.gettingStartedVisible = true
   })
 
-  it('suspends onboarding while desktop sign-in approval is pending', async () => {
-    await renderFirstRunTour()
-    expect(screen.getByTestId('getting-started-screen')).toBeInTheDocument()
+  it.for([
+    ['approved', true],
+    ['declined', false],
+    ['dismissed', null]
+  ] as const)(
+    'suspends onboarding until desktop sign-in is %s',
+    async ([_label, result]) => {
+      render(FirstRunTour)
+      expect(screen.getByTestId('getting-started-screen')).toBeInTheDocument()
 
-    let finishApproval!: () => void
-    const approval = withDesktopLoginApproval(
-      () =>
-        new Promise<void>((resolve) => {
-          finishApproval = resolve
-        })
-    )
-    await nextTick()
+      let finishApproval!: (result: boolean | null) => void
+      const approval = withDesktopLoginApproval(
+        () =>
+          new Promise<boolean | null>((resolve) => {
+            finishApproval = resolve
+          })
+      )
+      await nextTick()
 
-    expect(screen.queryByTestId('getting-started-screen')).toBeNull()
+      expect(screen.queryByTestId('getting-started-screen')).toBeNull()
 
-    finishApproval()
-    await approval
-    await nextTick()
+      finishApproval(result)
+      await approval
+      await nextTick()
 
-    expect(screen.getByTestId('getting-started-screen')).toBeInTheDocument()
-  })
+      expect(screen.getByTestId('getting-started-screen')).toBeInTheDocument()
+    }
+  )
 })

--- a/src/renderer/extensions/firstRunTour/FirstRunTour.vue
+++ b/src/renderer/extensions/firstRunTour/FirstRunTour.vue
@@ -1,10 +1,13 @@
 <template>
-  <GettingStartedScreen v-if="gettingStartedVisible" />
+  <GettingStartedScreen
+    v-if="gettingStartedVisible && !isDesktopLoginApprovalPending"
+  />
   <FirstRunTourNudge />
 </template>
 
 <script setup lang="ts">
 import GettingStartedScreen from './gettingStarted/GettingStartedScreen.vue'
+import { isDesktopLoginApprovalPending } from '@/platform/cloud/onboarding/desktopLoginRedemptionState'
 import { useFirstRunEntry } from './gettingStarted/firstRunEntry'
 import FirstRunTourNudge from './nudge/FirstRunTourNudge.vue'
 import { useFirstRunTourController } from './tour/useFirstRunTourController'

--- a/src/renderer/extensions/firstRunTour/FirstRunTour.vue
+++ b/src/renderer/extensions/firstRunTour/FirstRunTour.vue
@@ -1,11 +1,11 @@
 <template>
-  <GettingStartedScreen
-    v-if="gettingStartedVisible && !isDesktopLoginApprovalPending"
-  />
+  <GettingStartedScreen v-if="shouldShowGettingStarted" />
   <FirstRunTourNudge />
 </template>
 
 <script setup lang="ts">
+import { computed } from 'vue'
+
 import GettingStartedScreen from './gettingStarted/GettingStartedScreen.vue'
 import { isDesktopLoginApprovalPending } from '@/platform/cloud/onboarding/desktopLoginRedemptionState'
 import { useFirstRunEntry } from './gettingStarted/firstRunEntry'
@@ -13,6 +13,9 @@ import FirstRunTourNudge from './nudge/FirstRunTourNudge.vue'
 import { useFirstRunTourController } from './tour/useFirstRunTourController'
 
 const { gettingStartedVisible } = useFirstRunEntry()
+const shouldShowGettingStarted = computed(
+  () => gettingStartedVisible.value && !isDesktopLoginApprovalPending.value
+)
 
 useFirstRunTourController()
 </script>

--- a/src/services/dialogService.renderer.test.ts
+++ b/src/services/dialogService.renderer.test.ts
@@ -49,6 +49,16 @@ describe('dialogService Reka renderer opt-in', () => {
     expect(args.dialogComponentProps.size).toBe('md')
   })
 
+  it('confirm() allows an isolated dialog key', () => {
+    void useDialogService().confirm({
+      key: 'desktop-login-redemption',
+      title: 'T',
+      message: 'M'
+    })
+    const [args] = showDialog.mock.calls[0]
+    expect(args.key).toBe('desktop-login-redemption')
+  })
+
   it("showBillingComingSoonDialog() sets renderer 'reka', size 'sm', and 360px contentClass", () => {
     useDialogService().showBillingComingSoonDialog()
     const [args] = showDialog.mock.calls[0]

--- a/src/services/dialogService.ts
+++ b/src/services/dialogService.ts
@@ -64,6 +64,8 @@ export type ConfirmationDialogType =
   | 'info'
 
 interface BaseConfirmOptions {
+  /** Override the shared prompt key when this confirmation has its own lifecycle. */
+  key?: string
   /** Dialog heading */
   title: string
   /** The main message body */
@@ -300,6 +302,7 @@ export const useDialogService = () => {
    * `null` if the dialog is cancelled or closed
    */
   async function confirm({
+    key = 'global-prompt',
     title,
     message,
     type = 'default',
@@ -309,7 +312,7 @@ export const useDialogService = () => {
   }: ConfirmOptions): Promise<boolean | null> {
     return new Promise((resolve) => {
       const options: ShowDialogOptions = {
-        key: 'global-prompt',
+        key,
         title,
         component: ConfirmationDialogContent,
         props: {


### PR DESCRIPTION
## Summary

- suspend the Getting Started takeover while the desktop sign-in approval is pending
- give desktop approval an isolated dialog key so an existing generic prompt cannot strand the flow
- restore onboarding after the approval is approved, declined, or dismissed
- keep the incident fix scoped to the conflicting desktop-auth and onboarding flows

## Root cause

The Getting Started screen is a full-screen teleported `FocusScope` at `z-2000`. The desktop sign-in confirmation is opened through the global dialog stack. When both appeared during a new-user sign-in, the onboarding focus trap remained above the approval dialog, so the user could not complete the desktop sign-in redemption.

## Rollout

1. Keep the production onboarding flag disabled via https://github.com/Comfy-Org/cloud/pull/7416.
2. Merge and backport this fix to the active Cloud release line.
3. Ship the frontend-only Cloud patch and smoke-test new-user desktop sign-in.
4. Re-enable onboarding in production in a separate dynamic-config PR.

A generalized application-wide blocking-surface arbiter is intentionally left out of this incident hotfix.

## Validation

- `mise exec -- pnpm vitest run src/services/dialogService.renderer.test.ts src/platform/cloud/onboarding/desktopLoginRedemption.test.ts src/renderer/extensions/firstRunTour/FirstRunTour.test.ts` (45 passed)
- repository pre-commit formatting, Stylelint, Oxlint, ESLint, and typecheck
- pre-push Knip check

Refs IR-119 and https://linear.app/comfyorg/issue/BE-8819/desktop-sign-in-completion-fell-70percent-42percent-on-8-august-and