### PR TITLE
fix(cloud): let dialogs win over the Getting Started takeover

### DIFF
--- a/src/platform/cloud/onboarding/desktopLoginRedemption.test.ts
+++ b/src/platform/cloud/onboarding/desktopLoginRedemption.test.ts
@@ -161,6 +161,7 @@ describe('installDesktopLoginRedemption', () => {
 
     expect(mockConfirm).toHaveBeenCalledTimes(1)
     expect(mockConfirm).toHaveBeenCalledWith({
+      key: 'global-desktop-login-confirm',
       title: 'desktopLogin.confirmSummary',
       message: 'desktopLogin.confirmMessage'
     })

--- a/src/platform/cloud/onboarding/desktopLoginRedemption.ts
+++ b/src/platform/cloud/onboarding/desktopLoginRedemption.ts
@@ -117,6 +117,7 @@ async function confirmRedemption(
 ): Promise<boolean> {
   if (state.approvedUserUid === uid) return true
   const confirmed = await useDialogService().confirm({
+    key: 'global-desktop-login-confirm',
     title: t('desktopLogin.confirmSummary'),
     message: t('desktopLogin.confirmMessage')
   })

--- a/src/renderer/extensions/firstRunTour/gettingStarted/GettingStartedScreen.test.ts
+++ b/src/renderer/extensions/firstRunTour/gettingStarted/GettingStartedScreen.test.ts
@@ -78,9 +78,15 @@ const FocusScopeStub = {
     '<div data-testid="focus-scope-stub" :data-trapped="trapped"><slot /></div>'
 }
 
-async function renderScreen({ stubFocusScope = false } = {}) {
+async function renderScreen({
+  stubFocusScope = false,
+  withOpenDialog = false
+} = {}) {
   const pinia = createPinia()
   setActivePinia(pinia)
+  if (withOpenDialog) {
+    useDialogStore().showDialog({ component: { template: '<div />' } })
+  }
   const { default: GettingStartedScreen } =
     await import('./GettingStartedScreen.vue')
   return render(GettingStartedScreen, {
@@ -236,6 +242,27 @@ describe('GettingStartedScreen', () => {
   })
 
   describe('dialog arbitration', () => {
+    it('takes focus and modal semantics when it mounts with no dialog open', async () => {
+      await renderScreen()
+      await nextTick()
+
+      const takeover = screen.getByRole('dialog')
+      expect(takeover).toHaveFocus()
+      expect(takeover.getAttribute('aria-modal')).toBe('true')
+    })
+
+    it('leaves focus and modality with a dialog that was open before it mounted', async () => {
+      await renderScreen({ withOpenDialog: true })
+      await nextTick()
+
+      const takeover = screen.getByRole('dialog')
+      expect(
+        takeover,
+        'stealing focus on mount would pull the user out of the open dialog (desktop sign-in approval)'
+      ).not.toHaveFocus()
+      expect(takeover.getAttribute('aria-modal')).toBe('false')
+    })
+
     it('releases its focus trap while a dialog is open and re-arms after', async () => {
       await renderScreen({ stubFocusScope: true })
       const dialogStore = useDialogStore()

--- a/src/renderer/extensions/firstRunTour/gettingStarted/GettingStartedScreen.test.ts
+++ b/src/renderer/extensions/firstRunTour/gettingStarted/GettingStartedScreen.test.ts
@@ -1,9 +1,12 @@
 import userEvent from '@testing-library/user-event'
 import { render, screen, waitFor } from '@testing-library/vue'
+import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { nextTick } from 'vue'
 import { createI18n } from 'vue-i18n'
 
 import enMessages from '@/locales/en/main.json' with { type: 'json' }
+import { useDialogStore } from '@/stores/dialogStore'
 
 import { CURATED_TEMPLATE_IDS, FALLBACK_TEMPLATE_IDS } from './tutorialCards'
 
@@ -69,10 +72,23 @@ const i18n = createI18n({
   messages: { en: enMessages }
 })
 
-async function renderScreen() {
+const FocusScopeStub = {
+  props: ['trapped', 'asChild', 'loop'],
+  template:
+    '<div data-testid="focus-scope-stub" :data-trapped="trapped"><slot /></div>'
+}
+
+async function renderScreen({ stubFocusScope = false } = {}) {
+  const pinia = createPinia()
+  setActivePinia(pinia)
   const { default: GettingStartedScreen } =
     await import('./GettingStartedScreen.vue')
-  return render(GettingStartedScreen, { global: { plugins: [i18n] } })
+  return render(GettingStartedScreen, {
+    global: {
+      plugins: [i18n, pinia],
+      stubs: stubFocusScope ? { FocusScope: FocusScopeStub } : {}
+    }
+  })
 }
 
 describe('GettingStartedScreen', () => {
@@ -216,6 +232,33 @@ describe('GettingStartedScreen', () => {
         mocks.dismiss,
         'Escape must follow the same safe dismissal path as the blank-canvas action'
       ).toHaveBeenCalled()
+    })
+  })
+
+  describe('dialog arbitration', () => {
+    it('releases its focus trap while a dialog is open and re-arms after', async () => {
+      await renderScreen({ stubFocusScope: true })
+      const dialogStore = useDialogStore()
+      const trapped = () =>
+        screen.getByTestId('focus-scope-stub').getAttribute('data-trapped')
+
+      expect(trapped()).toBe('true')
+
+      const dialog = dialogStore.showDialog({
+        component: { template: '<div />' }
+      })
+      await nextTick()
+      expect(
+        trapped(),
+        'a trapped takeover under an open dialog (desktop sign-in approval, invite links) makes the dialog unreachable'
+      ).toBe('false')
+
+      dialogStore.closeDialog({ key: dialog.key })
+      await nextTick()
+      expect(
+        trapped(),
+        'the takeover must re-arm once the dialog stack empties'
+      ).toBe('true')
     })
   })
 

--- a/src/renderer/extensions/firstRunTour/gettingStarted/GettingStartedScreen.vue
+++ b/src/renderer/extensions/firstRunTour/gettingStarted/GettingStartedScreen.vue
@@ -1,9 +1,9 @@
 <template>
   <Teleport to="body">
-    <FocusScope as-child trapped loop>
+    <FocusScope as-child :trapped="!dialogOpen" loop>
       <div
         ref="screenRef"
-        class="fixed inset-0 z-2000 flex overflow-y-auto bg-base-background focus:outline-none"
+        class="fixed inset-0 z-1600 flex overflow-y-auto bg-base-background focus:outline-none"
         role="dialog"
         aria-modal="true"
         :aria-label="t('gettingStarted.title')"
@@ -134,6 +134,7 @@ import Button from '@/components/ui/button/Button.vue'
 import { useToastStore } from '@/platform/updates/common/toastStore'
 import { useTemplateWorkflows } from '@/platform/workflow/templates/composables/useTemplateWorkflows'
 import { useWorkflowTemplatesStore } from '@/platform/workflow/templates/repositories/workflowTemplatesStore'
+import { useDialogStore } from '@/stores/dialogStore'
 
 import GettingStartedCard from './GettingStartedCard.vue'
 import GettingStartedTemplateCard from './GettingStartedTemplateCard.vue'
@@ -167,6 +168,10 @@ const { t } = useI18n()
 const { dismissGettingStarted } = useFirstRunEntry()
 const { beginTour } = useFirstRunTourController()
 const templatesStore = useWorkflowTemplatesStore()
+const dialogStore = useDialogStore()
+
+/** The dialog layer starts at z-1700; sitting below it and releasing the trap keeps any dialog (desktop sign-in approval, invite links) reachable. */
+const dialogOpen = computed(() => dialogStore.dialogStack.length > 0)
 const { loadWorkflowTemplate, getTemplateThumbnailUrl, loadingTemplateId } =
   useTemplateWorkflows()
 

--- a/src/renderer/extensions/firstRunTour/gettingStarted/GettingStartedScreen.vue
+++ b/src/renderer/extensions/firstRunTour/gettingStarted/GettingStartedScreen.vue
@@ -5,7 +5,7 @@
         ref="screenRef"
         class="fixed inset-0 z-1600 flex overflow-y-auto bg-base-background focus:outline-none"
         role="dialog"
-        aria-modal="true"
+        :aria-modal="!dialogOpen"
         :aria-label="t('gettingStarted.title')"
         tabindex="-1"
         @keydown.escape.capture.prevent="dismissGettingStarted()"
@@ -211,7 +211,9 @@ async function loadCatalog() {
 // Nothing else loads the catalog on this path, so load it (and take focus) on open.
 onMounted(() => {
   if (!templatesStore.isLoaded) void loadCatalog()
-  void nextTick(() => screenRef.value?.focus())
+  void nextTick(() => {
+    if (!dialogOpen.value) screenRef.value?.focus()
+  })
 })
 
 function tutorialThumbnail(

--- a/src/services/dialogService.renderer.test.ts
+++ b/src/services/dialogService.renderer.test.ts
@@ -49,6 +49,20 @@ describe('dialogService Reka renderer opt-in', () => {
     expect(args.dialogComponentProps.size).toBe('md')
   })
 
+  it('confirm() opens under its own stack key when the caller passes one', () => {
+    void useDialogService().confirm({ title: 'T', message: 'M' })
+    void useDialogService().confirm({
+      key: 'global-desktop-login-confirm',
+      title: 'T2',
+      message: 'M2'
+    })
+    const keys = showDialog.mock.calls.slice(-2).map(([args]) => args.key)
+    expect(
+      keys,
+      'a shared key would make showDialog reuse the open prompt and drop the second resolver, leaving its promise pending forever'
+    ).toEqual(['global-prompt', 'global-desktop-login-confirm'])
+  })
+
   it("showBillingComingSoonDialog() sets renderer 'reka', size 'sm', and 360px contentClass", () => {
     useDialogService().showBillingComingSoonDialog()
     const [args] = showDialog.mock.calls[0]

--- a/src/services/dialogService.ts
+++ b/src/services/dialogService.ts
@@ -71,6 +71,13 @@ interface BaseConfirmOptions {
   /** Displayed as an unordered list immediately below the message body */
   itemList?: string[]
   hint?: string
+  /**
+   * Dialog-stack key, defaulting to the shared `global-prompt`. `showDialog`
+   * reuses an existing entry with the same key and discards the new resolver,
+   * leaving the caller's promise pending forever — a flow whose confirmation
+   * must survive an already-open shared prompt passes its own key.
+   */
+  key?: string
 }
 
 type ConfirmOptions = BaseConfirmOptions &
@@ -305,11 +312,12 @@ export const useDialogService = () => {
     type = 'default',
     itemList = [],
     hint,
-    denyLabel
+    denyLabel,
+    key = 'global-prompt'
   }: ConfirmOptions): Promise<boolean | null> {
     return new Promise((resolve) => {
       const options: ShowDialogOptions = {
-        key: 'global-prompt',
+        key,
         title,
         component: ConfirmationDialogContent,
         props: {


### PR DESCRIPTION
## Summary

Make the Getting Started takeover yield to any dialog: it now sits below the shared modal layer and releases its focus trap while the dialog stack is non-empty. Replaces #15894 with a flow-agnostic incident fix.

## Root cause

The Getting Started screen is a full-screen teleported takeover with two hard-coded claims on the screen: `z-2000` (above the shared modal stacking sequence, base 1700) and an unconditional reka `FocusScope` `trapped`. Any dialog opened while it is up — the desktop sign-in approval in IR-119, but equally the `?invite`, `?create_workspace`, `?pricing`, `?topup`, and `?settings` deep-link dialogs that fire in the same startup window — rendered underneath it with its focus stolen, so the user could not complete the flow.

## Changes

- **What**: `GettingStartedScreen` drops from `z-2000` to `z-1600` (below the modal base, so dialogs always paint above it regardless of mount order) and binds `FocusScope` `trapped` to the dialog stack being empty, mirroring the conditional-trap pattern in `TourSpotlight` and the nudge's stack deference. The trap re-arms when the stack empties; reka's dialog close restores focus into the takeover.

## Review Focus

- Unlike #15894, the approval dialog now appears *over* the onboarding backdrop instead of the onboarding screen disappearing while approval is pending.
- No coupling to the desktop-login flow: the same arbitration covers every dialog-stack entry. The follow-up stacked on this one — #15896 — moves Getting Started into the dialog stack itself so the special case disappears entirely.

## Rollout

1. Keep the production onboarding flag disabled via https://github.com/Comfy-Org/cloud/pull/7416.
2. Ship this fix and smoke-test new-user desktop sign-in.
3. Re-enable onboarding in production in a separate dynamic-config PR.

Refs IR-119 and https://linear.app/comfyorg/issue/BE-8819/desktop-sign-in-completion-fell-70percent-42percent-on-8-august-and



## Review hardenings (db7a18d)

- Mount-order robustness: when a dialog is already open before the takeover mounts, `onMounted` no longer steals focus, and `aria-modal` tracks the trap (`false` while a dialog is active).
- The desktop-login approval confirms under its own dialog-stack key (`global-desktop-login-confirm`) instead of the shared `global-prompt`, so an already-open shared prompt can no longer swallow its resolver and leave the redemption pending forever.
