### PR TITLE
refactor(dialog): route the Getting Started takeover through the dialog stack

### DIFF
--- a/src/components/dialog/GlobalDialog.test.ts
+++ b/src/components/dialog/GlobalDialog.test.ts
@@ -6,6 +6,7 @@ import { defineComponent, h, nextTick } from 'vue'
 import { createI18n } from 'vue-i18n'
 
 import GlobalDialog from '@/components/dialog/GlobalDialog.vue'
+import { BACKDROP_Z } from '@/components/dialog/vRekaZIndex'
 import {
   onRekaFocusOutside,
   onRekaPointerDownOutside
@@ -648,5 +649,50 @@ describe('shouldPreventRekaDismiss', () => {
 
     expect(event.defaultPrevented).toBe(true)
     portal.remove()
+  })
+})
+
+describe('GlobalDialog backdrop tier', () => {
+  it('keeps a priority-0 dialog below the modal band even when it mounts last', async () => {
+    mountDialog()
+    const store = useDialogStore()
+
+    store.showDialog({
+      key: 'backdrop-real-dialog',
+      title: 'Real dialog',
+      component: Body
+    })
+    await nextTick()
+
+    store.showDialog({
+      key: 'backdrop-takeover',
+      component: Body,
+      priority: 0,
+      dialogComponentProps: { headless: true, modal: false }
+    })
+    await nextTick()
+
+    const content = (key: string) =>
+      screen
+        .getAllByRole('dialog')
+        .find((el) => el.getAttribute('aria-labelledby') === key)
+    const contentZ = (key: string) => Number(content(key)?.style.zIndex)
+
+    expect(
+      contentZ('backdrop-takeover'),
+      'a takeover that mounts after an open dialog must still render under it'
+    ).toBe(BACKDROP_Z)
+    expect(contentZ('backdrop-real-dialog')).toBeGreaterThan(BACKDROP_Z)
+    expect(
+      store.activeKey,
+      'the real dialog keeps Escape and focus ownership'
+    ).toBe('backdrop-real-dialog')
+
+    await nextTick()
+    await nextTick()
+    expect(
+      content('backdrop-takeover'),
+      'a takeover mounting under an open dialog must not pull focus from it'
+    ).not.toHaveFocus()
   })
 })

--- a/src/components/dialog/GlobalDialog.vue
+++ b/src/components/dialog/GlobalDialog.vue
@@ -9,11 +9,11 @@
     >
       <DialogPortal>
         <DialogOverlay
-          v-reka-z-index
+          v-reka-z-index="item.priority"
           :class="item.dialogComponentProps.overlayClass"
         />
         <DialogContent
-          v-reka-z-index
+          v-reka-z-index="item.priority"
           :size="item.dialogComponentProps.size ?? 'md'"
           :maximized="!!item.dialogComponentProps.maximized"
           :class="item.dialogComponentProps.contentClass"
@@ -163,8 +163,14 @@ function onRekaOpenChange(key: string, open: boolean) {
 // or footer button). Dialog content that marks an input with `autofocus` (e.g.
 // the keybinding capture input, the prompt input) relied on PrimeVue honoring
 // that attribute, so honor it here: focus the autofocus target and cancel
-// Reka's default auto-focus when one is present.
+// Reka's default auto-focus when one is present. A dialog that mounts below
+// the top of the stack (a backdrop-tier takeover under an open dialog) must
+// not pull focus from the active dialog at all.
 function onRekaOpenAutoFocus(event: Event, key: string) {
+  if (dialogStore.activeKey !== key) {
+    event.preventDefault()
+    return
+  }
   const content = document.querySelector<HTMLElement>(
     `[aria-labelledby="${CSS.escape(key)}"]`
   )

--- a/src/components/dialog/vRekaZIndex.ts
+++ b/src/components/dialog/vRekaZIndex.ts
@@ -5,17 +5,32 @@ import type { Directive } from 'vue'
 export const MODAL_Z_KEY = 'modal'
 export const MODAL_Z_BASE = 1700
 
+/** Backdrop-tier surfaces (dialog priority < 1) sit below every modal-band dialog. */
+export const BACKDROP_Z = MODAL_Z_BASE - 100
+
+const isBackdropTier = (priority: number | undefined) => (priority ?? 1) < 1
+
 // Both Reka and PrimeVue dialogs can appear at any depth in dialogStack, in
 // any order. PrimeVue auto-increments a per-key z-index counter so later
 // dialogs always cover earlier ones; Reka uses a static z-1700 class which
 // can lose to an already-open PrimeVue dialog. Registering Reka's content
 // element with the same ZIndex counter (key 'modal', base 1700) makes both
 // renderers share one stacking sequence: whichever dialog opens last wins.
-export const vRekaZIndex: Directive<HTMLElement> = {
-  mounted(el) {
+//
+// The optional binding value is the dialog's stack priority. A priority < 1
+// marks a backdrop takeover (e.g. Getting Started) that must never cover a
+// real dialog whatever the mount order, so it gets a static z below the band
+// instead of joining the counter.
+export const vRekaZIndex: Directive<HTMLElement, number | undefined> = {
+  mounted(el, binding) {
+    if (isBackdropTier(binding.value)) {
+      el.style.zIndex = String(BACKDROP_Z)
+      return
+    }
     ZIndex.set(MODAL_Z_KEY, el, MODAL_Z_BASE)
   },
-  beforeUnmount(el) {
+  beforeUnmount(el, binding) {
+    if (isBackdropTier(binding.value)) return
     ZIndex.clear(el)
   }
 }

--- a/src/renderer/extensions/firstRunTour/FirstRunTour.vue
+++ b/src/renderer/extensions/firstRunTour/FirstRunTour.vue
@@ -1,15 +1,10 @@
 <template>
-  <GettingStartedScreen v-if="gettingStartedVisible" />
   <FirstRunTourNudge />
 </template>
 
 <script setup lang="ts">
-import GettingStartedScreen from './gettingStarted/GettingStartedScreen.vue'
-import { useFirstRunEntry } from './gettingStarted/firstRunEntry'
 import FirstRunTourNudge from './nudge/FirstRunTourNudge.vue'
 import { useFirstRunTourController } from './tour/useFirstRunTourController'
-
-const { gettingStartedVisible } = useFirstRunEntry()
 
 useFirstRunTourController()
 </script>

--- a/src/renderer/extensions/firstRunTour/gettingStarted/GettingStartedScreen.test.ts
+++ b/src/renderer/extensions/firstRunTour/gettingStarted/GettingStartedScreen.test.ts
@@ -22,6 +22,7 @@ const mocks = vi.hoisted(() => ({
 }))
 
 vi.mock('./firstRunEntry', () => ({
+  GETTING_STARTED_DIALOG_KEY: 'global-getting-started',
   useFirstRunEntry: () => ({ dismissGettingStarted: mocks.dismiss })
 }))
 
@@ -80,12 +81,20 @@ const FocusScopeStub = {
 
 async function renderScreen({
   stubFocusScope = false,
-  withOpenDialog = false
+  withOpenDialog = false,
+  withTakeoverEntry = false
 } = {}) {
   const pinia = createPinia()
   setActivePinia(pinia)
   if (withOpenDialog) {
     useDialogStore().showDialog({ component: { template: '<div />' } })
+  }
+  if (withTakeoverEntry) {
+    useDialogStore().showDialog({
+      key: 'global-getting-started',
+      component: { template: '<div />' },
+      priority: 0
+    })
   }
   const { default: GettingStartedScreen } =
     await import('./GettingStartedScreen.vue')
@@ -228,50 +237,49 @@ describe('GettingStartedScreen', () => {
         'A first-run user must always have a visible way out of the takeover'
       ).toHaveBeenCalled()
     })
-
-    it('exits on Escape', async () => {
-      await renderScreen()
-
-      await userEvent.keyboard('{Escape}')
-
-      expect(
-        mocks.dismiss,
-        'Escape must follow the same safe dismissal path as the blank-canvas action'
-      ).toHaveBeenCalled()
-    })
   })
 
   describe('dialog arbitration', () => {
-    it('takes focus and modal semantics when it mounts with no dialog open', async () => {
-      await renderScreen()
+    it('takes focus when it mounts as the top of the stack', async () => {
+      await renderScreen({ withTakeoverEntry: true })
+
+      await nextTick()
+      await nextTick()
       await nextTick()
 
-      const takeover = screen.getByRole('dialog')
-      expect(takeover).toHaveFocus()
-      expect(takeover.getAttribute('aria-modal')).toBe('true')
+      expect(screen.getByRole('tab', { name: /templates/i })).toHaveFocus()
     })
 
-    it('leaves focus and modality with a dialog that was open before it mounted', async () => {
-      await renderScreen({ withOpenDialog: true })
+    it('leaves focus with a dialog that was open before it mounted', async () => {
+      await renderScreen({
+        withOpenDialog: true,
+        withTakeoverEntry: true
+      })
+      await nextTick()
+      await nextTick()
       await nextTick()
 
-      const takeover = screen.getByRole('dialog')
       expect(
-        takeover,
+        screen.getByRole('tab', { name: /templates/i }),
         'stealing focus on mount would pull the user out of the open dialog (desktop sign-in approval)'
       ).not.toHaveFocus()
-      expect(takeover.getAttribute('aria-modal')).toBe('false')
     })
 
-    it('releases its focus trap while a dialog is open and re-arms after', async () => {
+    it('owns the focus trap only while it is the top of the dialog stack', async () => {
       await renderScreen({ stubFocusScope: true })
       const dialogStore = useDialogStore()
       const trapped = () =>
         screen.getByTestId('focus-scope-stub').getAttribute('data-trapped')
 
+      dialogStore.showDialog({
+        key: 'global-getting-started',
+        component: { template: '<div />' },
+        priority: 0
+      })
+      await nextTick()
       expect(trapped()).toBe('true')
 
-      const dialog = dialogStore.showDialog({
+      const above = dialogStore.showDialog({
         component: { template: '<div />' }
       })
       await nextTick()
@@ -280,11 +288,11 @@ describe('GettingStartedScreen', () => {
         'a trapped takeover under an open dialog (desktop sign-in approval, invite links) makes the dialog unreachable'
       ).toBe('false')
 
-      dialogStore.closeDialog({ key: dialog.key })
+      dialogStore.closeDialog({ key: above.key })
       await nextTick()
       expect(
         trapped(),
-        'the takeover must re-arm once the dialog stack empties'
+        'the takeover must re-arm once it is the top of the stack again'
       ).toBe('true')
     })
   })

--- a/src/renderer/extensions/firstRunTour/gettingStarted/GettingStartedScreen.vue
+++ b/src/renderer/extensions/firstRunTour/gettingStarted/GettingStartedScreen.vue
@@ -1,128 +1,127 @@
 <template>
-  <Teleport to="body">
-    <FocusScope as-child :trapped="!dialogOpen" loop>
-      <div
-        ref="screenRef"
-        class="fixed inset-0 z-1600 flex overflow-y-auto bg-base-background focus:outline-none"
-        role="dialog"
-        :aria-modal="!dialogOpen"
-        :aria-label="t('gettingStarted.title')"
-        tabindex="-1"
-        @keydown.escape.capture.prevent="dismissGettingStarted()"
-      >
-        <div class="m-auto flex w-full flex-col items-center gap-8 px-8 py-16">
-          <div class="flex flex-col items-center gap-3">
-            <h1
-              class="m-0 text-center text-4xl/11 font-medium text-base-foreground"
-            >
-              {{ t('gettingStarted.title') }}
-            </h1>
-            <p class="m-0 text-center text-base/5 text-muted-foreground">
-              {{ t('gettingStarted.subtitle') }}
-            </p>
-          </div>
-
-          <TabList
-            v-model="activeTab"
-            class="w-auto gap-1 rounded-full border border-border-subtle p-0.5"
-            :aria-label="t('gettingStarted.tabsLabel')"
+  <FocusScope
+    as-child
+    :trapped="isActiveTakeover"
+    loop
+    @mount-auto-focus="onMountAutoFocus"
+  >
+    <div
+      class="flex size-full overflow-y-auto bg-base-background focus:outline-none"
+      tabindex="-1"
+    >
+      <div class="m-auto flex w-full flex-col items-center gap-8 px-8 py-16">
+        <div class="flex flex-col items-center gap-3">
+          <h1
+            :id="GETTING_STARTED_DIALOG_KEY"
+            class="m-0 text-center text-4xl/11 font-medium text-base-foreground"
           >
-            <Tab
-              v-for="tab in tabs"
-              :key="tab.value"
-              :value="tab.value"
-              class="gap-2.5 rounded-full px-3 text-xs font-medium text-base-foreground hover:opacity-100 data-[state=active]:bg-tertiary-background data-[state=inactive]:opacity-70"
-            >
-              <i :class="cn(tab.icon, 'size-3.5')" aria-hidden="true" />
-              {{ t(tab.labelKey) }}
-            </Tab>
-          </TabList>
-
-          <div class="w-full max-w-5xl">
-            <TabPanel
-              v-for="tab in tabs"
-              :key="tab.value"
-              :value="tab.value"
-              :model-value="activeTab"
-            >
-              <div
-                v-if="tab.value === 'templates'"
-                class="grid grid-cols-2 gap-5 sm:grid-cols-3 lg:grid-cols-4"
-              >
-                <template v-if="templatesStore.isLoaded">
-                  <GettingStartedTemplateCard
-                    v-for="template in cards"
-                    :key="template.name"
-                    :template
-                    :loading="loadingTemplateId === template.name"
-                    :failed="failedTemplateId === template.name"
-                    class="min-w-0"
-                    @select="onSelectTemplate"
-                  />
-                </template>
-                <div
-                  v-else-if="catalogFailed"
-                  class="col-span-full flex flex-col items-center gap-4 py-16"
-                >
-                  <p class="m-0 text-center text-sm text-muted-foreground">
-                    {{ t('gettingStarted.loadFailed') }}
-                  </p>
-                  <Button
-                    variant="secondary"
-                    data-testid="getting-started-retry-catalog"
-                    @click="loadCatalog"
-                  >
-                    {{ t('gettingStarted.retry') }}
-                  </Button>
-                </div>
-                <template v-else>
-                  <GettingStartedCard
-                    v-for="id in CURATED_TEMPLATE_IDS"
-                    :key="id"
-                    skeleton
-                    :testid="`getting-started-card-skeleton-${id}`"
-                    class="min-w-0"
-                  />
-                </template>
-              </div>
-
-              <div
-                v-else
-                class="grid grid-cols-2 gap-5 sm:grid-cols-3 lg:grid-cols-4"
-              >
-                <GettingStartedCard
-                  v-for="(tutorial, index) in tutorialCards"
-                  :key="tutorial.id"
-                  :image-src="
-                    tutorialThumbnail(tutorial.thumbnailTemplate, index)
-                  "
-                  :title="t(tutorial.titleKey)"
-                  :badge-icon="TUTORIAL_BADGE_ICON"
-                  :testid="`getting-started-tutorial-${tutorial.id}`"
-                  class="min-w-0"
-                  @select="openTutorial(tutorial.url)"
-                />
-              </div>
-            </TabPanel>
-          </div>
-
-          <Button
-            variant="muted-textonly"
-            data-testid="getting-started-blank"
-            @click="dismissGettingStarted()"
-          >
-            {{ t('gettingStarted.startBlank') }}
-          </Button>
+            {{ t('gettingStarted.title') }}
+          </h1>
+          <p class="m-0 text-center text-base/5 text-muted-foreground">
+            {{ t('gettingStarted.subtitle') }}
+          </p>
         </div>
+
+        <TabList
+          v-model="activeTab"
+          class="w-auto gap-1 rounded-full border border-border-subtle p-0.5"
+          :aria-label="t('gettingStarted.tabsLabel')"
+        >
+          <Tab
+            v-for="tab in tabs"
+            :key="tab.value"
+            :value="tab.value"
+            class="gap-2.5 rounded-full px-3 text-xs font-medium text-base-foreground hover:opacity-100 data-[state=active]:bg-tertiary-background data-[state=inactive]:opacity-70"
+          >
+            <i :class="cn(tab.icon, 'size-3.5')" aria-hidden="true" />
+            {{ t(tab.labelKey) }}
+          </Tab>
+        </TabList>
+
+        <div class="w-full max-w-5xl">
+          <TabPanel
+            v-for="tab in tabs"
+            :key="tab.value"
+            :value="tab.value"
+            :model-value="activeTab"
+          >
+            <div
+              v-if="tab.value === 'templates'"
+              class="grid grid-cols-2 gap-5 sm:grid-cols-3 lg:grid-cols-4"
+            >
+              <template v-if="templatesStore.isLoaded">
+                <GettingStartedTemplateCard
+                  v-for="template in cards"
+                  :key="template.name"
+                  :template
+                  :loading="loadingTemplateId === template.name"
+                  :failed="failedTemplateId === template.name"
+                  class="min-w-0"
+                  @select="onSelectTemplate"
+                />
+              </template>
+              <div
+                v-else-if="catalogFailed"
+                class="col-span-full flex flex-col items-center gap-4 py-16"
+              >
+                <p class="m-0 text-center text-sm text-muted-foreground">
+                  {{ t('gettingStarted.loadFailed') }}
+                </p>
+                <Button
+                  variant="secondary"
+                  data-testid="getting-started-retry-catalog"
+                  @click="loadCatalog"
+                >
+                  {{ t('gettingStarted.retry') }}
+                </Button>
+              </div>
+              <template v-else>
+                <GettingStartedCard
+                  v-for="id in CURATED_TEMPLATE_IDS"
+                  :key="id"
+                  skeleton
+                  :testid="`getting-started-card-skeleton-${id}`"
+                  class="min-w-0"
+                />
+              </template>
+            </div>
+
+            <div
+              v-else
+              class="grid grid-cols-2 gap-5 sm:grid-cols-3 lg:grid-cols-4"
+            >
+              <GettingStartedCard
+                v-for="(tutorial, index) in tutorialCards"
+                :key="tutorial.id"
+                :image-src="
+                  tutorialThumbnail(tutorial.thumbnailTemplate, index)
+                "
+                :title="t(tutorial.titleKey)"
+                :badge-icon="TUTORIAL_BADGE_ICON"
+                :testid="`getting-started-tutorial-${tutorial.id}`"
+                class="min-w-0"
+                @select="openTutorial(tutorial.url)"
+              />
+            </div>
+          </TabPanel>
+        </div>
+
+        <Button
+          variant="muted-textonly"
+          data-testid="getting-started-blank"
+          @click="dismissGettingStarted()"
+        >
+          {{ t('gettingStarted.startBlank') }}
+        </Button>
       </div>
-    </FocusScope>
-  </Teleport>
+    </div>
+  </FocusScope>
 </template>
 
 <script setup lang="ts">
 import { take, uniqBy } from 'es-toolkit'
 import { FocusScope } from 'reka-ui'
-import { computed, nextTick, onMounted, ref, useTemplateRef } from 'vue'
+import { computed, onMounted, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import { cn } from '@comfyorg/tailwind-utils'
@@ -139,7 +138,7 @@ import { useDialogStore } from '@/stores/dialogStore'
 import GettingStartedCard from './GettingStartedCard.vue'
 import GettingStartedTemplateCard from './GettingStartedTemplateCard.vue'
 import { useFirstRunTourController } from '../tour/useFirstRunTourController'
-import { useFirstRunEntry } from './firstRunEntry'
+import { GETTING_STARTED_DIALOG_KEY, useFirstRunEntry } from './firstRunEntry'
 import type { TutorialCard } from './tutorialCards'
 import {
   CURATED_TEMPLATE_IDS,
@@ -170,16 +169,16 @@ const { beginTour } = useFirstRunTourController()
 const templatesStore = useWorkflowTemplatesStore()
 const dialogStore = useDialogStore()
 
-/** The dialog layer starts at z-1700; sitting below it and releasing the trap keeps any dialog (desktop sign-in approval, invite links) reachable. */
-const dialogOpen = computed(() => dialogStore.dialogStack.length > 0)
+/** Non-modal Reka content does not trap focus; own the trap only while this takeover is the top dialog. */
+const isActiveTakeover = computed(
+  () => dialogStore.activeKey === GETTING_STARTED_DIALOG_KEY
+)
 const { loadWorkflowTemplate, getTemplateThumbnailUrl, loadingTemplateId } =
   useTemplateWorkflows()
 
 const activeTab = ref<TabValue>('templates')
 const failedTemplateId = ref<string | null>(null)
 const catalogFailed = ref(false)
-
-const screenRef = useTemplateRef<HTMLElement>('screenRef')
 
 function resolveTemplates(ids: readonly string[]) {
   return ids
@@ -208,13 +207,15 @@ async function loadCatalog() {
   catalogFailed.value = !templatesStore.isLoaded
 }
 
-// Nothing else loads the catalog on this path, so load it (and take focus) on open.
+// Nothing else loads the catalog on this path, so load it on open.
 onMounted(() => {
   if (!templatesStore.isLoaded) void loadCatalog()
-  void nextTick(() => {
-    if (!dialogOpen.value) screenRef.value?.focus()
-  })
 })
+
+/** Under an open dialog (desktop sign-in approval, invite links), mounting must not pull focus from it. */
+function onMountAutoFocus(event: Event) {
+  if (!isActiveTakeover.value) event.preventDefault()
+}
 
 function tutorialThumbnail(
   id: TutorialCard['thumbnailTemplate'],
@@ -236,7 +237,7 @@ async function onSelectTemplate(id: string) {
   failedTemplateId.value = null
 
   if (await loadWorkflowTemplate(id, 'default')) {
-    await dismissGettingStarted()
+    dismissGettingStarted()
     try {
       await beginTour(id)
     } catch (error) {

--- a/src/renderer/extensions/firstRunTour/gettingStarted/firstRunEntry.test.ts
+++ b/src/renderer/extensions/firstRunTour/gettingStarted/firstRunEntry.test.ts
@@ -1,3 +1,4 @@
+import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type * as VueUseCoreModule from '@vueuse/core'
@@ -74,6 +75,7 @@ vi.mock('../tour/useFirstRunTourController', () => ({
 // createSharedComposable caches across calls; each test needs its own instance.
 async function freshEntry() {
   vi.resetModules()
+  setActivePinia(createPinia())
   const { useFirstRunEntry } = await import('./firstRunEntry')
   return useFirstRunEntry()
 }
@@ -460,12 +462,27 @@ describe('useFirstRunEntry', () => {
       'Showing the screen must not persist completion; the user has not chosen anything yet'
     ).not.toHaveBeenCalled()
 
-    await entry.dismissGettingStarted()
+    entry.dismissGettingStarted()
 
     expect(entry.gettingStartedVisible.value).toBe(false)
     expect(mocks.setSetting).toHaveBeenCalledWith(
       'Comfy.TutorialCompleted',
       true
     )
+  })
+
+  it('marks the tutorial completed on any dialog-stack close path, not just its own button', async () => {
+    const entry = await freshEntry()
+    await entry.handleStartupOutcome('fresh')
+    const { GETTING_STARTED_DIALOG_KEY } = await import('./firstRunEntry')
+    const { useDialogStore } = await import('@/stores/dialogStore')
+
+    useDialogStore().closeDialog({ key: GETTING_STARTED_DIALOG_KEY })
+
+    expect(entry.gettingStartedVisible.value).toBe(false)
+    expect(
+      mocks.setSetting,
+      'Escape lands here via GlobalDialog closing the entry; skipping the write would reopen onboarding forever'
+    ).toHaveBeenCalledWith('Comfy.TutorialCompleted', true)
   })
 })

--- a/src/renderer/extensions/firstRunTour/gettingStarted/firstRunEntry.ts
+++ b/src/renderer/extensions/firstRunTour/gettingStarted/firstRunEntry.ts
@@ -3,7 +3,7 @@ import {
   createSharedComposable,
   useBreakpoints
 } from '@vueuse/core'
-import { readonly, ref } from 'vue'
+import { computed, defineAsyncComponent } from 'vue'
 
 import { useFeatureFlags } from '@/composables/useFeatureFlags'
 import { useSubscription } from '@/platform/cloud/subscription/composables/useSubscription'
@@ -13,8 +13,15 @@ import type { StartupOutcome } from '@/platform/workflow/persistence/base/draftT
 import type { SharedWorkflowUrlLoadStatus } from '@/platform/workflow/sharing/composables/useSharedWorkflowUrlLoader'
 import { useNewUserService } from '@/services/useNewUserService'
 import { useCommandStore } from '@/stores/commandStore'
+import { useDialogStore } from '@/stores/dialogStore'
 
 import { useFirstRunTourController } from '../tour/useFirstRunTourController'
+
+export const GETTING_STARTED_DIALOG_KEY = 'global-getting-started'
+
+const GettingStartedScreen = defineAsyncComponent(
+  () => import('./GettingStartedScreen.vue')
+)
 
 /**
  * Decides what a first-time user sees once startup reports its outcome: the
@@ -23,9 +30,35 @@ import { useFirstRunTourController } from '../tour/useFirstRunTourController'
  */
 export const useFirstRunEntry = createSharedComposable(() => {
   const settingStore = useSettingStore()
-  const gettingStartedVisible = ref(false)
+  const dialogStore = useDialogStore()
+  const gettingStartedVisible = computed(() =>
+    dialogStore.isDialogOpen(GETTING_STARTED_DIALOG_KEY)
+  )
   const isDesktopWidth =
     useBreakpoints(breakpointsTailwind).greaterOrEqual('md')
+
+  /**
+   * A backdrop-tier (priority 0) dialog-stack entry: real dialogs (desktop
+   * sign-in approval, invite links) always stack above it and own focus while
+   * they are up. Any close path — Escape, programmatic — lands in `onClose`.
+   */
+  function showGettingStarted() {
+    dialogStore.showDialog({
+      key: GETTING_STARTED_DIALOG_KEY,
+      component: GettingStartedScreen,
+      priority: 0,
+      dialogComponentProps: {
+        headless: true,
+        modal: false,
+        showCloseButton: false,
+        dismissableMask: false,
+        dismissOnFocusOutside: false,
+        contentClass:
+          'inset-0 top-0 left-0 size-full max-h-none max-w-none translate-none rounded-none border-none shadow-none sm:max-w-none',
+        onClose: () => void markTutorialCompleted()
+      }
+    })
+  }
 
   /**
    * `defer` is ineligibility a later boot can lift — the tour flag, the
@@ -66,7 +99,7 @@ export const useFirstRunEntry = createSharedComposable(() => {
     }
 
     if (decision === 'getting-started') {
-      gettingStartedVisible.value = true
+      showGettingStarted()
       return
     }
 
@@ -108,13 +141,12 @@ export const useFirstRunEntry = createSharedComposable(() => {
     }
   }
 
-  async function dismissGettingStarted() {
-    gettingStartedVisible.value = false
-    await markTutorialCompleted()
+  function dismissGettingStarted() {
+    dialogStore.closeDialog({ key: GETTING_STARTED_DIALOG_KEY })
   }
 
   return {
-    gettingStartedVisible: readonly(gettingStartedVisible),
+    gettingStartedVisible,
     handleStartupOutcome,
     handleUrlWorkflow,
     dismissGettingStarted

--- a/src/stores/dialogStore.ts
+++ b/src/stores/dialogStore.ts
@@ -3,7 +3,7 @@
 import { merge } from 'es-toolkit/compat'
 import { defineStore } from 'pinia'
 import type { DialogPassThroughOptions } from 'primevue/dialog'
-import { markRaw, ref } from 'vue'
+import { computed, markRaw, ref } from 'vue'
 import type { Component, HTMLAttributes, Ref } from 'vue'
 
 import type { DialogContentSize } from '@/components/ui/dialog/dialog.variants'
@@ -132,10 +132,10 @@ export const useDialogStore = defineStore('dialog', () => {
   const dialogStack: Ref<DialogInstance[]> = ref([])
 
   /**
-   * The key of the currently active (top-most) dialog.
-   * Only the active dialog can be closed with the ESC key.
+   * The key of the top dialog: highest priority, newest among equals. Only the
+   * top dialog can be closed with the ESC key or an outside pointer.
    */
-  const activeKey = ref<string | null>(null)
+  const activeKey = computed(() => dialogStack.value[0]?.key ?? null)
 
   const genDialogKey = () => `dialog-${Math.random().toString(36).slice(2, 9)}`
 
@@ -161,7 +161,6 @@ export const useDialogStore = defineStore('dialog', () => {
     if (index !== -1) {
       const [dialog] = dialogStack.value.splice(index, 1)
       insertDialogByPriority(dialog)
-      activeKey.value = dialogKey
       updateCloseOnEscapeStates()
     }
   }
@@ -175,11 +174,6 @@ export const useDialogStore = defineStore('dialog', () => {
     targetDialog.dialogComponentProps?.onClose?.()
     const index = dialogStack.value.findIndex((d) => d.key === targetDialog.key)
     if (index !== -1) dialogStack.value.splice(index, 1)
-
-    activeKey.value =
-      dialogStack.value.length > 0
-        ? dialogStack.value[dialogStack.value.length - 1].key
-        : null
 
     updateCloseOnEscapeStates()
   }
@@ -237,7 +231,6 @@ export const useDialogStore = defineStore('dialog', () => {
     }
 
     insertDialogByPriority(dialog)
-    activeKey.value = options.key
     updateCloseOnEscapeStates()
 
     return dialog


### PR DESCRIPTION
## Summary

Route the Getting Started takeover through the dialog stack so one system owns stacking and focus for every blocking surface. #15895 (merged) special-cased dialogs above the takeover; this deletes that special-casing.

## Changes

- **What**:
  - `GettingStartedScreen` is now a headless, non-modal dialog-stack entry (`priority: 0`) shown by `firstRunEntry` instead of a bespoke body teleport mounted by `FirstRunTour.vue`. Escape and every other close path land in the entry's `onClose`, which marks the tutorial completed.
  - `dialogStore.activeKey` is now derived (top of the priority-ordered stack) instead of hand-maintained. This fixes two latent bugs: `closeDialog` previously activated the *oldest* dialog in 3-deep stacks, and `createDialog`/`riseDialog` let a lower-priority dialog steal Escape ownership from a higher-priority one.
  - `vRekaZIndex` takes the dialog's priority: entries below priority 1 form a backdrop tier pinned at `z-1600`, under the shared modal band (base 1700), so a real dialog paints above the takeover regardless of mount order. Priority ≥ 1 behavior is unchanged.
  - The takeover keeps a `FocusScope` of its own (Reka's non-modal content never traps) but arms it only while it is the top of the stack — the incident arbitration from #15895, now driven by stack membership instead of a side-channel.
  - Mount focus follows the same rule: `GlobalDialog` cancels Reka's mount auto-focus for any dialog that mounts below the top of the stack, and the takeover's own scope defers likewise — #15895's no-focus-steal-on-mount fix, restated in stack terms. As the top, the takeover takes focus the way every other Reka dialog does (first tabbable).

## Review Focus

- `activeKey` becoming derived changes which dialog Escape closes in stacks 3+ deep (now the visually-top one). All existing dialogStore priority tests pass unchanged.
- Reka's `DialogContentModal` hard-codes `trap-focus`, which is why the takeover is non-modal with its own scope; a comment marks this.
- The first-run flow tests now run against the real dialog store (pinia) rather than a `ref`, so they cover the arbitration end to end.
- The takeover no longer sets `role="dialog"`/`aria-modal` itself — Reka's `DialogContent` provides the dialog role, consistent with every other stack entry.

Refs IR-119.
