### PR TITLE
chore: make CodeRabbit reviews informational

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -4,7 +4,7 @@ issue_enrichment:
 reviews:
   profile: assertive
   high_level_summary: false
-  request_changes_workflow: true
+  request_changes_workflow: false
   # Without this, a review that never happened (rate limit, internal error)
   # still reports green, so an unreviewed PR is indistinguishable from a
   # cleanly reviewed one.


### PR DESCRIPTION
## Summary

Keep CodeRabbit review findings informational by preventing CodeRabbit from submitting formal Approve or Request changes review states.

## Changes

- **What**: Set `reviews.request_changes_workflow` to `false`.
- **Preserved**: CodeRabbit reviews, inline comments, walkthrough and pre-merge findings, and the status that detects when a review fails to run.

## Review Focus

The setting was enabled in #9987 so missing end-to-end regression coverage could block fix-like PRs, but the workflow applies globally to all CodeRabbit findings. Confirm that CodeRabbit should no longer act as a formal or informal merge gate.

If the missing-E2E policy should remain a hard gate, enforce it separately with deterministic CI rather than retaining CodeRabbit review-state authority.