### PR TITLE
test: remove redundant WidgetCompositor mock cleanup

### DIFF
--- a/src/renderer/extensions/compositor/components/WidgetCompositor.test.ts
+++ b/src/renderer/extensions/compositor/components/WidgetCompositor.test.ts
@@ -73,7 +73,6 @@ function renderWidget() {
 
 describe('WidgetCompositor', () => {
   beforeEach(() => {
-    vi.clearAllMocks()
     clearCompositorLayers(graphNode)
     getNodeById.mockReturnValue(undefined)
   })


### PR DESCRIPTION
## Summary

Remove redundant WidgetCompositor mock cleanup that currently breaks the main branch lint job.

## Changes

- **What**: Delete vi.clearAllMocks() from beforeEach and rely on the project-wide Vitest mockReset and restoreMocks configuration.

## Review Focus

Confirm test-local compositor cleanup and the getNodeById default remain explicit while Vitest owns mock cleanup.

## Validation

- mise exec -- pnpm test:unit src/renderer/extensions/compositor/components/WidgetCompositor.test.ts
- mise exec -- pnpm oxlint:main
- mise exec -- pnpm exec oxfmt --check src/renderer/extensions/compositor/components/WidgetCompositor.test.ts