### PR TITLE
fix(billing): detach checkout recovery from the boot chain

### DIFF
--- a/browser_tests/tests/dialogs/checkoutRecovery.spec.ts
+++ b/browser_tests/tests/dialogs/checkoutRecovery.spec.ts
@@ -116,6 +116,13 @@ const SUCCEEDED_RECOVERY_OPERATION = {
   completed_at: '2026-07-20T00:00:01Z'
 } satisfies BillingOpStatusResponse
 
+const PENDING_RECOVERY_OPERATION = {
+  id: RECOVERY_OPERATION_ID,
+  status: 'pending',
+  action_url: 'https://pay.stripe.example/authorize/op-e2e-recover',
+  started_at: '2026-07-20T00:00:00Z'
+} satisfies BillingOpStatusResponse
+
 // The recovery loader runs at the tail of GraphCanvas onMounted, so the boot
 // chain must not throw before it: a missing settings subpath, prompt exec_info,
 // or queue status each abort that chain.
@@ -181,6 +188,27 @@ function trackBillingOpRequests(page: Page) {
 
 const confirmPaymentHeading = (page: Page) =>
   page.getByRole('heading', { name: 'Confirm your payment' })
+
+// GraphView posts a tab-count heartbeat on this channel once the graph emits
+// `ready` — the boot milestone `waitForCloudApp` cannot see, since
+// `window.app` is assigned before the URL-action loaders run.
+async function trackGraphReadyHeartbeat(page: Page) {
+  await page.addInitScript(() => {
+    new BroadcastChannel('comfyui-tab-count').onmessage = () => {
+      ;(
+        window as unknown as { __graphReadyHeartbeat?: boolean }
+      ).__graphReadyHeartbeat = true
+    }
+  })
+}
+
+function graphReadyHeartbeatSeen(page: Page) {
+  return page.evaluate(
+    () =>
+      (window as unknown as { __graphReadyHeartbeat?: boolean })
+        .__graphReadyHeartbeat === true
+  )
+}
 
 test.describe('Redirect checkout recovery', { tag: '@cloud' }, () => {
   test('reopens checkout for the attempted plan when reconciliation fails', async ({
@@ -249,6 +277,32 @@ test.describe('Redirect checkout recovery', { tag: '@cloud' }, () => {
       .poll(() => operationPollRequests.length)
       .toBeGreaterThan(0)
     await expect.poll(() => readPendingCheckout(page)).toBeNull()
+    await expect(confirmPaymentHeading(page)).toBeHidden()
+    await expect(
+      page.getByRole('heading', { name: 'Choose a Plan' })
+    ).toBeHidden()
+  })
+
+  test('finishes booting while the recovered operation stays pending', async ({
+    page
+  }) => {
+    const operationPollRequests: Request[] = []
+    await seedPendingCheckout(page, PENDING_CREATOR_CHECKOUT)
+    await trackGraphReadyHeartbeat(page)
+    await setupCloudApp(page)
+    await page.route(`**/api/billing/ops/${RECOVERY_OPERATION_ID}`, (route) => {
+      operationPollRequests.push(route.request())
+      return route.fulfill(jsonRoute(PENDING_RECOVERY_OPERATION))
+    })
+
+    await page.goto(APP_URL)
+
+    await waitForCloudApp(page)
+    await cloudAppExpect
+      .poll(() => operationPollRequests.length)
+      .toBeGreaterThan(0)
+    await cloudAppExpect.poll(() => graphReadyHeartbeatSeen(page)).toBe(true)
+    expect(await readPendingCheckout(page)).not.toBeNull()
     await expect(confirmPaymentHeading(page)).toBeHidden()
     await expect(
       page.getByRole('heading', { name: 'Choose a Plan' })

--- a/src/composables/useUrlActionLoaders.test.ts
+++ b/src/composables/useUrlActionLoaders.test.ts
@@ -10,6 +10,7 @@ vi.mock('@/platform/distribution/types', () => ({
 }))
 
 const mocks = vi.hoisted(() => ({
+  reportError: vi.fn(),
   loadInvite: vi.fn(async () => undefined),
   loadCreateWorkspace: vi.fn(async () => undefined),
   loadPricingTable: vi.fn(async () => undefined),
@@ -71,6 +72,9 @@ vi.mock(
   '@/platform/cloud/subscription/composables/useSubscriptionDialog',
   () => ({ useSubscriptionDialog: mocks.useSubscriptionDialog })
 )
+vi.mock('@/platform/telemetry/reportError', () => ({
+  reportError: mocks.reportError
+}))
 
 describe('useUrlActionLoaders', () => {
   beforeEach(() => {
@@ -153,10 +157,7 @@ describe('useUrlActionLoaders', () => {
     expect(mocks.resumePendingPricingFlow).toHaveBeenCalledOnce()
   })
 
-  it('logs a checkout-recovery failure instead of rejecting unhandled', async () => {
-    const consoleErrorSpy = vi
-      .spyOn(console, 'error')
-      .mockImplementation(() => {})
+  it('reports a checkout-recovery failure instead of rejecting unhandled', async () => {
     const failure = new Error('boom')
     mocks.resumePendingPricingFlow.mockRejectedValueOnce(failure)
 
@@ -165,12 +166,10 @@ describe('useUrlActionLoaders', () => {
 
     expect(mocks.loadPaymentReturn).toHaveBeenCalledOnce()
     await vi.waitFor(() => {
-      expect(consoleErrorSpy).toHaveBeenCalledWith(
-        '[UrlActionLoaders] Failed to resume pending billing flow:',
-        failure
-      )
+      expect(mocks.reportError).toHaveBeenCalledWith(failure, {
+        errorType: 'billing_pending_checkout_resume_failure'
+      })
     })
-    consoleErrorSpy.mockRestore()
   })
 
   it('isolates a pricing-loader failure so it does not abort the boot chain', async () => {

--- a/src/composables/useUrlActionLoaders.test.ts
+++ b/src/composables/useUrlActionLoaders.test.ts
@@ -142,13 +142,35 @@ describe('useUrlActionLoaders', () => {
     ).toBeGreaterThan(mocks.loadPaymentReturn.mock.invocationCallOrder[0])
   })
 
-  it('isolates a checkout-recovery failure so it does not abort the boot chain', async () => {
-    mocks.resumePendingPricingFlow.mockRejectedValueOnce(new Error('boom'))
+  it('resolves without waiting for checkout recovery to settle', async () => {
+    mocks.resumePendingPricingFlow.mockImplementationOnce(
+      () => new Promise<undefined>(() => {})
+    )
+
+    const { runUrlActionLoaders } = useUrlActionLoaders()
+    await expect(runUrlActionLoaders()).resolves.toBeUndefined()
+
+    expect(mocks.resumePendingPricingFlow).toHaveBeenCalledOnce()
+  })
+
+  it('logs a checkout-recovery failure instead of rejecting unhandled', async () => {
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {})
+    const failure = new Error('boom')
+    mocks.resumePendingPricingFlow.mockRejectedValueOnce(failure)
 
     const { runUrlActionLoaders } = useUrlActionLoaders()
     await expect(runUrlActionLoaders()).resolves.toBeUndefined()
 
     expect(mocks.loadPaymentReturn).toHaveBeenCalledOnce()
+    await vi.waitFor(() => {
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        '[UrlActionLoaders] Failed to resume pending billing flow:',
+        failure
+      )
+    })
+    consoleErrorSpy.mockRestore()
   })
 
   it('isolates a pricing-loader failure so it does not abort the boot chain', async () => {

--- a/src/composables/useUrlActionLoaders.ts
+++ b/src/composables/useUrlActionLoaders.ts
@@ -96,16 +96,19 @@ export function useUrlActionLoaders() {
 
     // Reopen a checkout that was interrupted by a redirect payment. Runs here,
     // not during workspace init, so the first-run and Templates overlays are
-    // already settled and the recovered dialog is reachable.
+    // already settled and the recovered dialog is reachable. Deliberately not
+    // awaited: the resume only settles once the recovered operation reaches a
+    // terminal status, which for an abandoned checkout can take hours, and the
+    // boot chain (emit('ready'), the tour, telemetry) must not wait on it.
     if (subscriptionDialog) {
-      try {
-        await subscriptionDialog.resumePendingPricingFlow()
-      } catch (error) {
-        console.error(
-          '[UrlActionLoaders] Failed to resume pending billing flow:',
-          error
-        )
-      }
+      void (async () => subscriptionDialog.resumePendingPricingFlow())().catch(
+        (error) => {
+          console.error(
+            '[UrlActionLoaders] Failed to resume pending billing flow:',
+            error
+          )
+        }
+      )
     }
   }
 

--- a/src/composables/useUrlActionLoaders.ts
+++ b/src/composables/useUrlActionLoaders.ts
@@ -4,6 +4,7 @@ import { useSubscriptionDialog } from '@/platform/cloud/subscription/composables
 import { useTopUpUrlLoader } from '@/platform/cloud/subscription/composables/useTopUpUrlLoader'
 import { isCloud } from '@/platform/distribution/types'
 import { useSettingsUrlLoader } from '@/platform/settings/composables/useSettingsUrlLoader'
+import { reportError } from '@/platform/telemetry/reportError'
 import { useCreateWorkspaceUrlLoader } from '@/platform/workspace/composables/useCreateWorkspaceUrlLoader'
 import { useInviteUrlLoader } from '@/platform/workspace/composables/useInviteUrlLoader'
 
@@ -103,10 +104,9 @@ export function useUrlActionLoaders() {
     if (subscriptionDialog) {
       void (async () => subscriptionDialog.resumePendingPricingFlow())().catch(
         (error) => {
-          console.error(
-            '[UrlActionLoaders] Failed to resume pending billing flow:',
-            error
-          )
+          reportError(error, {
+            errorType: 'billing_pending_checkout_resume_failure'
+          })
         }
       )
     }


### PR DESCRIPTION
## Summary

`resumePendingPricingFlow` only settles once the recovered billing operation reaches a terminal status — for an abandoned redirect checkout that can take hours. Awaiting it in `runUrlActionLoaders` held up the tail of the boot chain (`emit('ready')`, the tour, telemetry) for that entire window.

This detaches the resume from the boot chain: it is fired without awaiting, and failures are reported through `reportError()` (`billing_pending_checkout_resume_failure`) instead of rejecting unhandled.

## Testing

- Unit: `useUrlActionLoaders.test.ts` — boot resolves without waiting for recovery to settle; a recovery failure reaches `reportError()` instead of rejecting unhandled.
- E2E: `checkoutRecovery.spec.ts` — new case `finishes booting while the recovered operation stays pending` asserts the graph-ready heartbeat fires while the operation is still polling and the pending entry is preserved; all 4 cases pass against a cloud-mode dev server.
- `vue-tsc` (src + browser_tests), eslint, oxlint, oxfmt all clean.