### PR TITLE
fix(billing): reject an empty payment credential alongside a saved one

### DIFF
--- a/src/platform/workspace/api/workspaceApi.test.ts
+++ b/src/platform/workspace/api/workspaceApi.test.ts
@@ -538,6 +538,13 @@ describe('workspaceApi', () => {
       const body = mockAxiosInstance.post.mock.calls[0][1]
       expect(body).not.toHaveProperty('confirmation_token', '')
       expect(body.confirmation_token).toBeUndefined()
+
+      mockAxiosInstance.post.mockResolvedValueOnce({ data: {} })
+      await workspaceApi.subscribe('pro-monthly', { savedPaymentMethodId: '' })
+
+      const savedBody = mockAxiosInstance.post.mock.calls[1][1]
+      expect(savedBody).not.toHaveProperty('saved_payment_method_id', '')
+      expect(savedBody.saved_payment_method_id).toBeUndefined()
     })
 
     it('subscribe() rejects an empty credential alongside a saved one', async () => {

--- a/src/platform/workspace/api/workspaceApi.test.ts
+++ b/src/platform/workspace/api/workspaceApi.test.ts
@@ -530,6 +530,19 @@ describe('workspaceApi', () => {
       expect(mockAxiosInstance.post).not.toHaveBeenCalled()
     })
 
+    it('subscribe() rejects an empty credential alongside a saved one', async () => {
+      await expect(
+        workspaceApi.subscribe('pro-monthly', {
+          confirmationToken: '',
+          savedPaymentMethodId: 'pm_saved'
+        })
+      ).rejects.toThrow(
+        'confirmationToken and savedPaymentMethodId are mutually exclusive'
+      )
+
+      expect(mockAxiosInstance.post).not.toHaveBeenCalled()
+    })
+
     it('previewSubscribe() sends fields defined by the ingest contract', async () => {
       const data = { allowed: true, transition_type: 'new_subscription' }
       mockAxiosInstance.post.mockResolvedValue({ data })

--- a/src/platform/workspace/api/workspaceApi.test.ts
+++ b/src/platform/workspace/api/workspaceApi.test.ts
@@ -530,6 +530,16 @@ describe('workspaceApi', () => {
       expect(mockAxiosInstance.post).not.toHaveBeenCalled()
     })
 
+    it('subscribe() omits an empty credential from the request', async () => {
+      mockAxiosInstance.post.mockResolvedValueOnce({ data: {} })
+
+      await workspaceApi.subscribe('pro-monthly', { confirmationToken: '' })
+
+      const body = mockAxiosInstance.post.mock.calls[0][1]
+      expect(body).not.toHaveProperty('confirmation_token', '')
+      expect(body.confirmation_token).toBeUndefined()
+    })
+
     it('subscribe() rejects an empty credential alongside a saved one', async () => {
       await expect(
         workspaceApi.subscribe('pro-monthly', {

--- a/src/platform/workspace/api/workspaceApi.ts
+++ b/src/platform/workspace/api/workspaceApi.ts
@@ -501,17 +501,21 @@ export const workspaceApi = {
         'confirmationToken and savedPaymentMethodId are mutually exclusive'
       )
     }
+    // JSON drops `undefined` but keeps `''`, so an empty credential would reach
+    // the API as a present-but-meaningless value.
+    const confirmationToken = options.confirmationToken || undefined
+    const savedPaymentMethodId = options.savedPaymentMethodId || undefined
     const headers = await getAuthHeaderOrThrow()
     try {
       const response = await workspaceApiClient.post<SubscribeResponse>(
         workspaceApiUrl('/billing/subscribe'),
         {
           plan_slug: planSlug,
-          confirmation_token: options.confirmationToken,
+          confirmation_token: confirmationToken,
           promotion_code: options.promotionCode,
           quote_id: options.quoteId,
           quote_version: options.quoteVersion,
-          saved_payment_method_id: options.savedPaymentMethodId,
+          saved_payment_method_id: savedPaymentMethodId,
           return_url: options.returnUrl,
           cancel_url: options.cancelUrl,
           team_credit_stop_id: options.teamCreditStopId,

--- a/src/platform/workspace/api/workspaceApi.ts
+++ b/src/platform/workspace/api/workspaceApi.ts
@@ -493,7 +493,10 @@ export const workspaceApi = {
     planSlug: string,
     options: SubscribeOptions = {}
   ): Promise<SubscribeResponse> {
-    if (options.confirmationToken && options.savedPaymentMethodId) {
+    if (
+      options.confirmationToken !== undefined &&
+      options.savedPaymentMethodId !== undefined
+    ) {
       throw new TypeError(
         'confirmationToken and savedPaymentMethodId are mutually exclusive'
       )


### PR DESCRIPTION
## Summary

`workspaceApi.subscribe()` guards `confirmationToken` and `savedPaymentMethodId` as mutually exclusive, but tests truthiness:

```ts
if (options.confirmationToken && options.savedPaymentMethodId) {
  throw new TypeError('confirmationToken and savedPaymentMethodId are mutually exclusive')
}
```

An empty-string `confirmationToken` is falsy, so it slips the guard and **both** credential fields are serialized into the request body — `confirmation_token: ''` alongside `saved_payment_method_id`. Checking presence instead refuses that combination.

## Scope

One condition and one test. Valid single-credential calls are unchanged: passing only a token, only a saved method, or neither all behave exactly as before, since the guard only fires when both keys are present.

Note this makes the guard stricter in one further case — explicitly passing `undefined` for one of them still passes, but passing both keys with *any* defined values now throws, which is what "mutually exclusive" should mean.

## Verification

- The new test `subscribe() rejects an empty credential alongside a saved one` was confirmed to **fail against the unfixed guard** (1 failed / 41 passed) and pass with it (42/42) — not assumed.
- `pnpm typecheck` and `typecheck:browser` clean.
- Full unit suite: **17,727 passed**. The 12 `check-binary-size` failures are pre-existing and environmental.

## Origin

Found by CodeRabbit on #15803, where it landed as an outside-diff-range comment with no thread. The code is not that PR's — it came from #14483 and reached the branch through a merge from `main` — so it is fixed here on its own rather than folded into a capability-migration PR.

**Sequencing note:** #15906 backports #14483 to `cloud/1.51` and carries the same guard. Landing this on `main` first lets that backport pick the fix up, rather than shipping the bug to the release line and needing a second backport.
