### PR TITLE
ci: schedule E2E coverage aggregation

### DIFF
--- a/.github/workflows/ci-tests-e2e-coverage.yaml
+++ b/.github/workflows/ci-tests-e2e-coverage.yaml
@@ -24,45 +24,54 @@ jobs:
     steps:
       - name: Resolve latest complete main E2E coverage run
         id: source
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v9
+        uses: actions/github-script@v9
         with:
           script: |
             const expectedShards = 16
-            const { data } = await github.rest.actions.listWorkflowRuns({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              workflow_id: 'ci-tests-e2e.yaml',
-              branch: 'main',
-              event: 'push',
-              status: 'completed',
-              per_page: 30
-            })
+            const artifactCutoff = new Date(
+              Date.now() - 26 * 60 * 60 * 1000
+            ).toISOString()
+            const runPages = github.paginate.iterator(
+              github.rest.actions.listWorkflowRuns,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                workflow_id: 'ci-tests-e2e.yaml',
+                branch: 'main',
+                event: 'push',
+                status: 'completed',
+                created: `>=${artifactCutoff}`,
+                per_page: 100
+              }
+            )
 
-            for (const run of data.workflow_runs) {
-              if (run.conclusion === 'cancelled') continue
+            for await (const { data: runs } of runPages) {
+              for (const run of runs) {
+                if (run.conclusion === 'cancelled') continue
 
-              const artifacts = await github.paginate(
-                github.rest.actions.listWorkflowRunArtifacts,
-                {
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  run_id: run.id,
-                  per_page: 100
-                }
-              )
-              const shardCount = artifacts.filter(
-                ({ expired, name }) =>
-                  !expired && /^e2e-coverage-shard-\d+$/.test(name)
-              ).length
-              if (shardCount !== expectedShards) continue
+                const artifacts = await github.paginate(
+                  github.rest.actions.listWorkflowRunArtifacts,
+                  {
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    run_id: run.id,
+                    per_page: 100
+                  }
+                )
+                const shardCount = artifacts.filter(
+                  ({ expired, name }) =>
+                    !expired && /^e2e-coverage-shard-\d+$/.test(name)
+                ).length
+                if (shardCount !== expectedShards) continue
 
-              core.setOutput('run-id', String(run.id))
-              core.setOutput('sha', run.head_sha)
-              core.setOutput('url', run.html_url)
-              core.info(
-                `Using ${run.html_url} at ${run.head_sha} with ${shardCount} coverage shards`
-              )
-              return
+                core.setOutput('run-id', String(run.id))
+                core.setOutput('sha', run.head_sha)
+                core.setOutput('url', run.html_url)
+                core.info(
+                  `Using ${run.html_url} at ${run.head_sha} with ${shardCount} coverage shards`
+                )
+                return
+              }
             }
 
             core.setFailed(
@@ -70,7 +79,7 @@ jobs:
             )
 
       - name: Checkout sources for genhtml
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        uses: actions/checkout@v7
         with:
           ref: ${{ steps.source.outputs.sha }}
           persist-credentials: false
@@ -155,7 +164,7 @@ jobs:
 
       - name: Upload merged coverage data
         if: steps.coverage-shards.outputs.has-coverage == 'true'
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        uses: actions/upload-artifact@v6
         with:
           name: e2e-coverage
           path: coverage/playwright/
@@ -186,7 +195,7 @@ jobs:
 
       - name: Upload HTML report artifact
         if: steps.coverage-shards.outputs.has-coverage == 'true'
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        uses: actions/upload-artifact@v6
         with:
           name: e2e-coverage-html
           path: coverage/html/
@@ -204,7 +213,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Download HTML report
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        uses: actions/download-artifact@v8
         with:
           name: e2e-coverage-html
           path: coverage/html

--- a/.github/workflows/ci-tests-e2e-coverage.yaml
+++ b/.github/workflows/ci-tests-e2e-coverage.yaml
@@ -28,9 +28,6 @@ jobs:
         with:
           script: |
             const expectedShards = 16
-            const artifactCutoff = new Date(
-              Date.now() - 26 * 60 * 60 * 1000
-            ).toISOString()
             const runPages = github.paginate.iterator(
               github.rest.actions.listWorkflowRuns,
               {
@@ -40,7 +37,6 @@ jobs:
                 branch: 'main',
                 event: 'push',
                 status: 'completed',
-                created: `>=${artifactCutoff}`,
                 per_page: 100
               }
             )

--- a/.github/workflows/ci-tests-e2e-coverage.yaml
+++ b/.github/workflows/ci-tests-e2e-coverage.yaml
@@ -1,55 +1,79 @@
 name: 'CI: E2E Coverage'
 
 on:
-  workflow_call:
-    inputs:
-      source_branch:
-        required: true
-        type: string
-      source_pr:
-        required: false
-        type: string
-      source_run_id:
-        required: true
-        type: string
-      source_sha:
-        required: true
-        type: string
-    secrets:
-      CODECOV_TOKEN:
-        required: true
-  workflow_run:
-    workflows: ['CI: Tests E2E']
-    types:
-      - completed
+  schedule:
+    - cron: '17 */3 * * *'
+  workflow_dispatch:
 
 concurrency:
-  group: e2e-coverage-${{ inputs.source_sha || github.event.workflow_run.head_sha }}
+  group: e2e-coverage-scheduled
   cancel-in-progress: true
 
 permissions:
+  actions: read
   contents: read
 
 jobs:
   merge:
-    # Not gated on full success: fail-fast:false means one flaky shard flips the whole run to failure, which would skip merging every other shard's real coverage.
-    if: >
-      github.repository == 'Comfy-Org/ComfyUI_frontend' &&
-      (github.event_name == 'workflow_call' ||
-        github.event.workflow_run.event != 'pull_request' ||
-        github.event.workflow_run.head_repository.full_name != github.repository ||
-        github.event.workflow_run.actor.login == 'dependabot[bot]') &&
-      github.event.workflow_run.conclusion != 'cancelled'
+    if: github.repository == 'Comfy-Org/ComfyUI_frontend'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     outputs:
       has-coverage: ${{ steps.coverage-shards.outputs.has-coverage }}
 
     steps:
-      - name: Checkout sources for genhtml
-        uses: actions/checkout@v7
+      - name: Resolve latest complete main E2E coverage run
+        id: source
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v9
         with:
-          ref: ${{ inputs.source_sha || github.event.workflow_run.head_sha }}
+          script: |
+            const expectedShards = 16
+            const { data } = await github.rest.actions.listWorkflowRuns({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'ci-tests-e2e.yaml',
+              branch: 'main',
+              event: 'push',
+              status: 'completed',
+              per_page: 30
+            })
+
+            for (const run of data.workflow_runs) {
+              if (run.conclusion === 'cancelled') continue
+
+              const artifacts = await github.paginate(
+                github.rest.actions.listWorkflowRunArtifacts,
+                {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  run_id: run.id,
+                  per_page: 100
+                }
+              )
+              const shardCount = artifacts.filter(
+                ({ expired, name }) =>
+                  !expired && /^e2e-coverage-shard-\d+$/.test(name)
+              ).length
+              if (shardCount !== expectedShards) continue
+
+              core.setOutput('run-id', String(run.id))
+              core.setOutput('sha', run.head_sha)
+              core.setOutput('url', run.html_url)
+              core.info(
+                `Using ${run.html_url} at ${run.head_sha} with ${shardCount} coverage shards`
+              )
+              return
+            }
+
+            core.setFailed(
+              `No completed main E2E run has all ${expectedShards} live coverage shard artifacts`
+            )
+
+      - name: Checkout sources for genhtml
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ steps.source.outputs.sha }}
+          persist-credentials: false
           sparse-checkout: |
             src
             packages
@@ -57,7 +81,7 @@ jobs:
       - name: Download all shard coverage data
         uses: dawidd6/action-download-artifact@0bd50d53a6d7fb5cb921e607957e9cc12b4ce392 # v12
         with:
-          run_id: ${{ inputs.source_run_id || github.event.workflow_run.id }}
+          run_id: ${{ steps.source.outputs.run-id }}
           name: e2e-coverage-shard-.*
           name_is_regexp: true
           path: temp/coverage-shards
@@ -131,7 +155,7 @@ jobs:
 
       - name: Upload merged coverage data
         if: steps.coverage-shards.outputs.has-coverage == 'true'
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: e2e-coverage
           path: coverage/playwright/
@@ -144,9 +168,8 @@ jobs:
         with:
           files: coverage/playwright/coverage.lcov
           flags: e2e
-          override_branch: ${{ inputs.source_branch || github.event.workflow_run.head_branch }}
-          override_commit: ${{ inputs.source_sha || github.event.workflow_run.head_sha }}
-          override_pr: ${{ inputs.source_pr || github.event.workflow_run.pull_requests[0].number }}
+          override_branch: main
+          override_commit: ${{ steps.source.outputs.sha }}
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
 
@@ -163,7 +186,7 @@ jobs:
 
       - name: Upload HTML report artifact
         if: steps.coverage-shards.outputs.has-coverage == 'true'
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: e2e-coverage-html
           path: coverage/html/
@@ -171,10 +194,7 @@ jobs:
 
   deploy:
     needs: merge
-    if: >
-      github.event.workflow_run.head_branch == 'main' &&
-      needs.merge.outputs.has-coverage == 'true' &&
-      github.event.workflow_run.event == 'push'
+    if: needs.merge.outputs.has-coverage == 'true'
     runs-on: ubuntu-latest
     permissions:
       pages: write
@@ -184,7 +204,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Download HTML report
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: e2e-coverage-html
           path: coverage/html

--- a/.github/workflows/ci-tests-e2e.yaml
+++ b/.github/workflows/ci-tests-e2e.yaml
@@ -223,25 +223,6 @@ jobs:
           [[ "$SHARDED" != "success" || "$BROWSERS" != "success" || ( "$VIDEO" != "success" && "$VIDEO" != "skipped" ) ]] && echo "E2E failed" && exit 1
           echo "E2E passed"
 
-  upload-e2e-coverage:
-    needs: [changes, playwright-tests-chromium-sharded]
-    if: >-
-      ${{
-        always() &&
-        needs.changes.outputs.should-run == 'true' &&
-        github.event_name == 'pull_request' &&
-        github.event.pull_request.head.repo.fork == false &&
-        github.event.pull_request.user.login != 'dependabot[bot]' &&
-        needs.playwright-tests-chromium-sharded.result != 'cancelled'
-      }}
-    uses: ./.github/workflows/ci-tests-e2e-coverage.yaml
-    with:
-      source_branch: ${{ github.head_ref || github.ref_name }}
-      source_pr: ${{ format('{0}', github.event.pull_request.number) }}
-      source_run_id: ${{ format('{0}', github.run_id) }}
-      source_sha: ${{ github.event.pull_request.head.sha || github.sha }}
-    secrets: inherit
-
   # Records video only for spec files newly added in this PR, to keep cost bounded.
   playwright-video-new-tests:
     needs: setup

--- a/.github/workflows/pr-report.yaml
+++ b/.github/workflows/pr-report.yaml
@@ -2,7 +2,7 @@ name: 'PR: Unified Report'
 
 on:
   workflow_run:
-    workflows: ['CI: Size Data', 'CI: Performance Report', 'CI: E2E Coverage']
+    workflows: ['CI: Size Data', 'CI: Performance Report']
     types:
       - completed
     branches-ignore:
@@ -72,25 +72,6 @@ jobs:
           path: temp/size-prev
           if_no_artifact_found: warn
 
-      - name: Find coverage workflow run
-        if: steps.pr-meta.outputs.skip != 'true'
-        id: find-coverage
-        uses: ./.github/actions/find-workflow-run
-        with:
-          workflow-id: ci-tests-e2e-coverage.yaml
-          head-sha: ${{ steps.pr-meta.outputs.head-sha }}
-          not-found-status: skip
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Download coverage data
-        if: steps.pr-meta.outputs.skip != 'true' && steps.find-coverage.outputs.status == 'ready'
-        uses: dawidd6/action-download-artifact@0bd50d53a6d7fb5cb921e607957e9cc12b4ce392 # v12
-        with:
-          name: e2e-coverage
-          run_id: ${{ steps.find-coverage.outputs.run-id }}
-          path: temp/coverage
-          if_no_artifact_found: warn
-
       - name: Download perf metrics (current)
         if: steps.pr-meta.outputs.skip != 'true' && steps.find-perf.outputs.status == 'ready'
         uses: dawidd6/action-download-artifact@0bd50d53a6d7fb5cb921e607957e9cc12b4ce392 # v12
@@ -129,7 +110,6 @@ jobs:
           pnpm exec tsx scripts/unified-report.ts
           --size-status=${{ steps.find-size.outputs.status }}
           --perf-status=${{ steps.find-perf.outputs.status }}
-          --coverage-status=${{ steps.find-coverage.outputs.status }}
           > pr-report.md
 
       - name: Remove legacy separate comments
@@ -171,7 +151,7 @@ jobs:
         with:
           path: ./pr-report.md
 
-      - name: Upsert bundle/perf/coverage section into unified report
+      - name: Upsert bundle/perf section into unified report
         if: steps.pr-meta.outputs.skip != 'true'
         uses: ./.github/actions/upsert-comment-section
         with:


### PR DESCRIPTION
## Summary

Runs E2E coverage aggregation every three hours or on manual dispatch instead of after every E2E/PR completion.

## Changes

- **What**: Removes `workflow_run` and `workflow_call`, removes the PR-owned coverage job and report lookup, and schedules aggregation at minute 17 every three hours.
- **Source selection**: Uses the newest completed `main` push E2E run with all 16 unexpired shard artifacts, then checks out and attributes coverage to that exact SHA.
- **Security**: Eliminates the privileged fork checkout path and disables persisted checkout credentials.

## Review Focus

- The cron no longer creates a coverage run for every PR, push, merge-group, or E2E completion.
- Functional E2E remains unchanged; only its coverage aggregation/reporting cadence changes.
- Exact per-PR E2E coverage deltas are intentionally removed; Codecov, HTML, and main coverage consumers remain.