### PR TITLE
refactor: derive DOM widget styles

### DIFF
--- a/src/components/graph/widgets/DomWidget.test.ts
+++ b/src/components/graph/widgets/DomWidget.test.ts
@@ -51,7 +51,9 @@ vi.mock('@/renderer/core/canvas/canvasStore', () => ({
 
 vi.mock('@/platform/settings/settingStore', () => ({
   useSettingStore: () => ({
-    get: vi.fn(() => mockDomClippingEnabled.value)
+    get: vi.fn((key: string) =>
+      key === 'Comfy.DOMClippingEnabled' ? mockDomClippingEnabled.value : false
+    )
   })
 }))
 
@@ -121,7 +123,7 @@ describe('DomWidget style', () => {
     expect(root.style.opacity).toBe('0.5')
   })
 
-  it('applies asynchronous clipping style updates', async () => {
+  it('applies clipping style when DOM clipping is enabled', async () => {
     mockDomClippingEnabled.value = true
     const widgetState = createWidgetState(false)
     const { container } = render(DomWidget, {
@@ -136,6 +138,37 @@ describe('DomWidget style', () => {
     // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
     const root = container.querySelector('.dom-widget') as HTMLElement
     expect(root.style.clipPath).toBe('inset(1px)')
+  })
+
+  it('updates clipping when DOM clipping is enabled', async () => {
+    const widgetState = createWidgetState(false)
+    render(DomWidget, {
+      props: {
+        widgetState
+      }
+    })
+    mockUpdateClipPath.mockClear()
+
+    mockDomClippingEnabled.value = true
+    await nextTick()
+
+    expect(mockUpdateClipPath).toHaveBeenCalled()
+  })
+
+  it('ignores clipping style when DOM clipping is disabled', async () => {
+    const widgetState = createWidgetState(false)
+    const { container } = render(DomWidget, {
+      props: {
+        widgetState
+      }
+    })
+
+    mockClippingStyle.value = { clipPath: 'inset(1px)' }
+    await nextTick()
+
+    // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+    const root = container.querySelector('.dom-widget') as HTMLElement
+    expect(root.style.clipPath).toBe('')
   })
 
   it('disables pointer events when widget is not visible', async () => {

--- a/src/components/graph/widgets/DomWidget.test.ts
+++ b/src/components/graph/widgets/DomWidget.test.ts
@@ -1,7 +1,7 @@
 import { render } from '@testing-library/vue'
 import { fromPartial } from '@total-typescript/shoehorn'
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { nextTick, reactive } from 'vue'
+import { nextTick, reactive, ref } from 'vue'
 
 import type { BaseDOMWidget } from '@/scripts/domWidget'
 import type { DomWidgetState } from '@/stores/domWidgetStore'
@@ -11,6 +11,9 @@ import DomWidget from './DomWidget.vue'
 
 const mockUpdatePosition = vi.fn()
 const mockUpdateClipPath = vi.fn()
+const mockPositionStyle = ref<Record<string, string>>({})
+const mockClippingStyle = ref<Record<string, string>>({})
+const mockDomClippingEnabled = ref(false)
 const mockCanvasElement = document.createElement('canvas')
 const mockCanvasStore = {
   canvas: {
@@ -30,14 +33,14 @@ const mockCanvasStore = {
 
 vi.mock('@/composables/element/useAbsolutePosition', () => ({
   useAbsolutePosition: () => ({
-    style: reactive<Record<string, string>>({}),
+    style: mockPositionStyle,
     updatePosition: mockUpdatePosition
   })
 }))
 
 vi.mock('@/composables/element/useDomClipping', () => ({
   useDomClipping: () => ({
-    style: reactive<Record<string, string>>({}),
+    style: mockClippingStyle,
     updateClipPath: mockUpdateClipPath
   })
 }))
@@ -48,7 +51,7 @@ vi.mock('@/renderer/core/canvas/canvasStore', () => ({
 
 vi.mock('@/platform/settings/settingStore', () => ({
   useSettingStore: () => ({
-    get: vi.fn(() => false)
+    get: vi.fn(() => mockDomClippingEnabled.value)
   })
 }))
 
@@ -85,6 +88,9 @@ function createWidgetState(disabled: boolean): DomWidgetState {
 describe('DomWidget style', () => {
   afterEach(() => {
     useDomWidgetStore().clear()
+    mockDomClippingEnabled.value = false
+    mockPositionStyle.value = {}
+    mockClippingStyle.value = {}
   })
 
   it('positions a newly mounted widget', () => {
@@ -113,6 +119,23 @@ describe('DomWidget style', () => {
     const root = container.querySelector('.dom-widget') as HTMLElement
     expect(root.style.pointerEvents).toBe('none')
     expect(root.style.opacity).toBe('0.5')
+  })
+
+  it('applies asynchronous clipping style updates', async () => {
+    mockDomClippingEnabled.value = true
+    const widgetState = createWidgetState(false)
+    const { container } = render(DomWidget, {
+      props: {
+        widgetState
+      }
+    })
+
+    mockClippingStyle.value = { clipPath: 'inset(1px)' }
+    await nextTick()
+
+    // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+    const root = container.querySelector('.dom-widget') as HTMLElement
+    expect(root.style.clipPath).toBe('inset(1px)')
   })
 
   it('disables pointer events when widget is not visible', async () => {

--- a/src/components/graph/widgets/DomWidget.vue
+++ b/src/components/graph/widgets/DomWidget.vue
@@ -40,13 +40,6 @@ const emit = defineEmits<{
 }>()
 
 const widgetElement = ref<HTMLElement | undefined>()
-
-/**
- * @note Do NOT convert style to a computed value, as it will cause lag when
- * updating the style on different animation frames. Vue's computed value is
- * evaluated asynchronously.
- */
-const style = ref<CSSProperties>({})
 const { style: positionStyle, updatePosition } = useAbsolutePosition({
   useTransform: true
 })
@@ -57,6 +50,20 @@ const settingStore = useSettingStore()
 const enableDomClipping = computed(() =>
   settingStore.get('Comfy.DOMClippingEnabled')
 )
+const style = computed<CSSProperties>(() => {
+  const isDisabled = widget.computedDisabled
+
+  return {
+    ...positionStyle.value,
+    ...(enableDomClipping.value ? clippingStyle.value : {}),
+    zIndex: widgetState.zIndex,
+    pointerEvents:
+      !widgetState.visible || widgetState.readonly || isDisabled
+        ? 'none'
+        : 'auto',
+    opacity: isDisabled ? 0.5 : 1
+  }
+})
 
 const updateDomClipping = () => {
   const lgCanvas = canvasStore.canvas
@@ -99,21 +106,6 @@ const updateDomClipping = () => {
  */
 const { left, top } = useElementBounding(canvasStore.getCanvas().canvas)
 
-function composeStyle() {
-  const isDisabled = widget.computedDisabled
-
-  style.value = {
-    ...positionStyle.value,
-    ...(enableDomClipping.value ? clippingStyle.value : {}),
-    zIndex: widgetState.zIndex,
-    pointerEvents:
-      !widgetState.visible || widgetState.readonly || isDisabled
-        ? 'none'
-        : 'auto',
-    opacity: isDisabled ? 0.5 : 1
-  }
-}
-
 watch(
   [
     () => widgetState.pos,
@@ -124,33 +116,17 @@ watch(
     // re-run against the current viewport when the widget reappears.
     () => widgetState.visible,
     left,
-    top
+    top,
+    enableDomClipping
   ],
   () => {
     updatePosition(widgetState)
     if (enableDomClipping.value) {
       updateDomClipping()
     }
-    composeStyle()
   },
   { immediate: true }
 )
-
-watch(
-  [() => widgetState.zIndex, () => widgetState.readonly, enableDomClipping],
-  () => {
-    if (enableDomClipping.value) {
-      updateDomClipping()
-    }
-    composeStyle()
-  }
-)
-
-// Recompose style when clippingStyle updates asynchronously via RAF.
-// updateClipPath() schedules clip-path calculation in a requestAnimationFrame,
-// so clippingStyle.value updates after the main watcher has already composed
-// style. This watcher ensures the new clip-path is applied to the DOM.
-watch(clippingStyle, composeStyle, { deep: true })
 
 watch(
   () => widgetState.visible,

--- a/src/composables/element/useAbsolutePosition.ts
+++ b/src/composables/element/useAbsolutePosition.ts
@@ -41,11 +41,6 @@ export function useAbsolutePosition(
     { flush: 'post' }
   )
 
-  /**
-   * @note Do NOT convert style to a computed value, as it will cause lag when
-   * updating the style on different animation frames. Vue's computed value is
-   * evaluated asynchronously.
-   */
   const style = ref<CSSProperties>({})
 
   /**


### PR DESCRIPTION
## Summary

Derive DOM widget styles with Vue computed state instead of synchronizing derived styles through watchers.

This revisits #3714 after measuring both scheduling paths in Chromium with source mutations inside `requestAnimationFrame`. Across three 300-frame runs, computed style and watch + style ref both committed at 0.2 ms median and 0.3–0.4 ms p95, with zero next-frame misses. Computed getters run synchronously when read by Vue's render effect; DOM rendering remains batched in either implementation.

## Changes

- **What**: Replace style composition and clipping-style watchers with one computed style; retain the focused watcher only for imperative positioning and clipping updates.
- **Tests**: Correct composable mocks and cover clipping style propagation, disabled clipping, and enabling clipping at runtime.
- **Breaking**: None.
- **Dependencies**: None.

## Review Focus

Verify clipping setting transitions and immediate positioning on mount.