### PR TITLE
docs: ADR-0018 — node-id reminting at the merge boundary

### DIFF
--- a/docs/adr/0018-node-id-reminting-at-the-merge-boundary.md
+++ b/docs/adr/0018-node-id-reminting-at-the-merge-boundary.md
@@ -6,11 +6,10 @@ Date: 2026-08-25
 
 Proposed
 
-This ADR records program decision D-gl-A6. ADR-0003's merge-boundary
-reconciliation amendment (2026-08-23) already carries the direction. This ADR
-separates the current local-import behavior from the future CRDT behavior so
-their different materialization paths and responsibilities are explicit.
-Formal sign-off remains pending.
+ADR-0003's merge-boundary reconciliation amendment (2026-08-23) already
+carries the direction. This ADR separates the current local-import behavior
+from the future CRDT behavior so their different materialization paths and
+responsibilities are explicit. Formal sign-off remains pending.
 
 ## Context
 
@@ -61,10 +60,11 @@ Concretely:
    `attachNodeToStores`. Workflow load, paste, and subgraph materialization
    reach that path. Its `nodeShellLifecycle` loop attempts registration; after
    the registry rejects a collision, the loop mints a fresh id for the
-   incoming local copy and retries. The warning required by D-gl-A2 — naming
-   the old id, replacement id, and root graph id — is pending in #15720;
-   current `main` still remints silently. This local adapter does not receive
-   remote semantic operations and does not emit a CRDT operation.
+   incoming local copy and retries. The warning required by the project's
+   no-silent-remint rule — naming the old id, replacement id, and root graph
+   id — is pending in #15720; current `main` still remints silently. This local
+   adapter does not receive remote semantic operations and does not emit a
+   CRDT operation.
 3. The **future CRDT boundary** is the semantic-operation applier described by
    ADR-0003. Nodes, widgets, links, and reroutes are not yet CRDT-replicated.
    When they are, the applier must reconcile concurrent identity collisions
@@ -140,8 +140,8 @@ eventually.
 
 Let stores absorb collisions by remapping ids internally on registration.
 
-- Violates D-gl-A2 directly: the remap is exactly the silent remint that
-  decision forbids.
+- Violates the no-silent-remint rule directly: the remap is exactly the silent
+  remint that rule forbids.
 - Smears merge logic across every store instead of one boundary; every
   future store must reimplement it.
 - Hides real data-model bugs behind auto-repair — a duplicate id caused by a
@@ -190,8 +190,10 @@ Tag colliding entries with an epoch/namespace and reconcile lazily.
   and remint warning).
 - #15761 — pending collision-contract documentation fold.
 - #15882 — serialized-reference remap after a local node-id remint (merged).
-- Program decisions D-gl-A2 (no silent remints), D-gl-A4 (identity keys
-  reject / structural keys resolve), D-gl-A6 (this decision).
+- Team decision log (internal, Comfy-Org only): D-gl-A2, D-gl-A4, D-gl-A6.
+  These ids are provenance pointers for maintainers with access to the
+  internal program log; the full content of each decision is restated in this
+  ADR, so external readers need nothing beyond this document.
 
 ## Glossary
 


### PR DESCRIPTION
## Summary

Adds **ADR-0018: Node-ID Reminting at the Merge Boundary** — the full decision model for program decision **D-gl-A6** ("CRDT duplicate-id reconciliation lives at the merge boundary; registries keep a strict no-collision invariant").

The *direction* is already carried by ADR-0003's merge-boundary reconciliation amendment and pinned in practice by the #15720 invariant test suite (with docs folded in #15761). What was missing was an independently reviewable derivation: **why** the merge boundary and not the stores, how echo-back converges, and how reminting squares with CRDT creator-minting.

## What the ADR covers

- **Context** — bare-integer, non-actor-scoped `NodeId`s meet multi-replica CRDT sync; duplicate `NodeId` = identity-key collision (reject, per the D-gl-A4 taxonomy in ADR-0017/#15761).
- **Echo-back semantics** with a diagram — the boundary remints the *imported copy only*; the remint is an ordinary local edit that syncs back, so both replicas converge and no ping-pong is possible.
- **Creator-minting tension resolved** — reminting is the import-time adapter for a legacy id space, not a violation; the importer is the creator of the copy in its replica. Actor-scoped ids recorded as the durable future fix.
- **Rejected alternatives** — store-side remap (violates the no-silent-remint rule, smears merge logic, hides bugs) and tolerant-hybrid registries (non-unique ids poison every id-keyed map).
- **Known deliberate gap** — serialized link endpoints are not yet remapped after a remint (no old→new map; `LGraph.configure` restores links before nodes are added). Documented in ADR-0008 via #15761 with two candidate fixes; tracked as a follow-up.
- **Revisit trigger** — any Yjs shared map keyed by raw `NodeId` across clients forces the actor-scoped refactor immediately.
- Glossary + cross-references (ADR-0003/0008/0017, #15720, #15761, D-gl-A2/A4/A6).

## Status

Proposed — this is the derivation record; D-gl-A6 formal sign-off is pending, but everything already landed conforms to it, so accepting this ADR changes no code.

Docs-only: two files (new ADR + README index row).