### PR TITLE
feat(i18n): add German to the translation pipeline

### DIFF
--- a/scripts/i18n/config.ts
+++ b/scripts/i18n/config.ts
@@ -43,6 +43,11 @@ Hebrew is a right-to-left (RTL) language. Keep all interpolation placeholders ({
 Preferred glossary: node = צומת (plural צמתים), workflow = תהליך עבודה, queue = תור, canvas = קנבס, widget = פקד, subgraph = תת-גרף, prompt = פרומפט/הנחיה (per context), bypass = עקיפה, mute = השתקה.
 Keep widely-recognized technical terms in English (Latin script): API, GPU, CUDA, VAE, CLIP, LoRA, ControlNet, Civitai, Hugging Face, Nodes 2.0, etc.`
 
+const germanGuidance = `Use formal German (Sie-Form) consistently for a professional tone throughout the UI. Never mix Sie and du.
+Keep widely-recognized technical terms in English rather than inventing German equivalents, as German creative and developer software does: Node, Workflow, Prompt, Queue, Canvas, Widget, Subgraph, Seed, Sampler, Checkpoint, LoRA, VAE, CLIP, ControlNet.
+German compounds are written closed, not spaced: "Bildgenerierung", not "Bild Generierung". Where a compound joins an English technical term to a German noun, hyphenate: "Node-Editor", "Workflow-Vorlage".
+Prefer the imperative for button labels ("Speichern", "Abbrechen") and avoid the infinitive-with-zu form, which reads like documentation rather than an interface.`
+
 export const translationPipelineConfig: TranslationPipelineConfig = {
   entry: 'src/locales/en',
   output: 'src/locales',
@@ -75,6 +80,7 @@ export const translationPipelineConfig: TranslationPipelineConfig = {
     { code: 'pt-BR', name: 'Brazilian Portuguese' },
     { code: 'fa', name: 'Persian', guidance: persianGuidance },
     { code: 'he', name: 'Hebrew', guidance: hebrewGuidance },
-    { code: 'it', name: 'Italian' }
+    { code: 'it', name: 'Italian' },
+    { code: 'de', name: 'German', guidance: germanGuidance }
   ]
 }


### PR DESCRIPTION
Adds German to the locale translation pipeline.

## Why

German is the one locale this app has never generated. That also blocks the workflows hub from adding it: the hub asserts `SUPPORTED_HUB_LOCALES ⊆ AVAILABLE_APP_LOCALES` and fails the build otherwise, because it harvests its translation glossary from `src/locales/` and deliberately will not advertise a language the product itself does not speak.

`outputLocales` is the whole mechanism, so this is the whole change. The existing workflow generates `main`, `nodeDefs`, `commands` and `settings` for German exactly as it did for Italian, Persian and Hebrew.

## Deliberately NOT registering it in the dropdown yet

`localeConfig.ts` is untouched, and that is the point.

`loadersFor('de')` returns `{ main: undefined, nodeDefs: undefined, ... }` — a **truthy object with undefined members**. So the guard in `src/i18n.ts:59`:

```ts
const loaders = localeDefinitions[locale].loaders
if (!loaders) return
```

does not catch it, and `loaders.main()` on the next line throws `loaders.main is not a function`. Adding the dropdown entry before the JSON exists would list Deutsch in settings and break the app for anyone who picks it.

So: this PR, then run the locale workflow, then a one-line follow-up registers the dropdown once `src/locales/de/` is committed.

Worth flagging separately: that guard is weak for *any* future locale added in the wrong order. Making `loadersFor` return `null` when its files are absent would turn a crash into an English fallback. Happy to do it as its own PR rather than widening this one.

## Guidance

Follows the `fa` / `he` precedent, which are the two locales here that carry any:

- **Formal Sie throughout**, never mixed with du. The single most common inconsistency in German UI translation.
- **Technical vocabulary stays English** (Node, Workflow, Prompt, Queue, Seed, Sampler, LoRA, VAE, ControlNet), which is what German creative and developer tooling actually does.
- **Closed compounds** (`Bildgenerierung`, not `Bild Generierung`), hyphenated where an English term joins a German noun (`Node-Editor`).
- **Imperative button labels** (`Speichern`, `Abbrechen`) rather than the infinitive, which reads like documentation instead of an interface.

## Next step, needs someone with Actions access

Run **i18n: Update Core Locales** after this merges. That generates and commits the German files. Nothing else is needed from a reviewer.
