### PR TITLE
docs: clarify ADR-0018 reminting contracts

### DIFF
--- a/docs/adr/0018-node-id-reminting-at-the-merge-boundary.md
+++ b/docs/adr/0018-node-id-reminting-at-the-merge-boundary.md
@@ -166,17 +166,12 @@ Tag colliding entries with an epoch/namespace and reconcile lazily.
 - Every local remint must be observable so telemetry can count real-world
   collision frequency and inform the actor-scoped refactor's priority. That
   warning is pending in #15720; current `main` does not yet emit it.
-- **Known deliberate gap (open at time of writing):** the remint loop does
-  not yet record an old→new id map, and `LGraph.configure` restores links
-  before nodes are added. A serialized link endpoint that references the old
-  id can therefore remain attached to the incumbent node or dangle after a
-  remint. ADR-0008 (as amended in #15761) documents two candidate fixes:
-  (a) record the map and remap the payload's link endpoints before nodes
-  configure their connections, or (b) reject ambiguous payloads outright.
-  Pending #15882 implements option (a). Reroutes reference link ids, and
-  groups do not store node endpoints, so neither requires node-id remapping.
-  Until #15882 lands, reminting is correct for node identity but incomplete
-  for link references.
+- `LGraph.configure` records each unambiguous requested→final node-id remint
+  and repoints link endpoints added by that payload before nodes configure
+  their connections (#15882). If multiple payload nodes request the same id,
+  there is no unambiguous mapping and the first claimant keeps the links.
+  Reroutes reference link ids, and groups do not store node endpoints, so
+  neither requires node-id remapping.
 - Imports/pastes of colliding content mutate the incoming copy's id. Any
   external system that memorized the old id (e.g. a URL fragment or a test
   fixture) will miss; this is inherent to any rejection-based scheme and is
@@ -187,14 +182,14 @@ Tag colliding entries with an epoch/namespace and reconcile lazily.
 - ADR-0003 — Centralized Layout Management with CRDT (merge-boundary
   reconciliation amendment, 2026-08-23). Cite ADR-0003 externally; this ADR
   is the derivation record.
-- ADR-0008 — Entity Component System (collision-contract and remint-gap
-  amendments via #15761).
-- ADR-0017 — ID-Based Slot Records Are the Slot Destination (the same
+- ADR-0008 — Entity Component System (identity and structural collision
+  contracts).
+- ADR-0017 — ID-Based Slot Records Own Slot State (the same
   identity-vs-structural key taxonomy, applied to slots).
 - #15720 — pending collision-contract invariant test suite (registry rejection
   and remint warning).
 - #15761 — pending collision-contract documentation fold.
-- #15882 — pending serialized-reference remap after a local node-id remint.
+- #15882 — serialized-reference remap after a local node-id remint (merged).
 - Program decisions D-gl-A2 (no silent remints), D-gl-A4 (identity keys
   reject / structural keys resolve), D-gl-A6 (this decision).
 

--- a/docs/adr/0018-node-id-reminting-at-the-merge-boundary.md
+++ b/docs/adr/0018-node-id-reminting-at-the-merge-boundary.md
@@ -7,10 +7,11 @@ Date: 2026-08-25
 Proposed
 
 Derivation record for program decision D-gl-A6. The direction is already
-carried in practice by ADR-0003's merge-boundary reconciliation amendment
-(2026-08-23) and by the collision contracts pinned in the D-dq-04 bundle
-(#15720 tests + #15761 docs); this ADR models the reminting question in full
-so the reasoning is reviewable independently of those PRs.
+carried by ADR-0003's merge-boundary reconciliation amendment (2026-08-23).
+The current local-import behavior and the future CRDT behavior use different
+materialization paths; this ADR models both so the responsibility boundary is
+reviewable independently of the pending D-dq-04 bundle (#15720 tests + #15761
+docs).
 
 ## Context
 
@@ -25,9 +26,10 @@ only authority over it.
 The CRDT-based collaboration direction (ADR-0003) and the ECS store migration
 (ADR-0008) break that assumption. Two replicas can each independently mint
 node id `7` for two **different** entities. When one replica's content reaches
-the other — via CRDT sync, workflow import, subgraph paste, or any other
-merge-shaped operation — both entities claim the same key in every id-keyed
-registry.
+the other through a future semantic-operation applier, both entities would
+claim the same key in every id-keyed registry. The same collision already
+occurs locally when workflow import, paste, subgraph materialization, or
+another merge-shaped operation inserts externally minted content.
 
 ### What a collision means
 
@@ -56,16 +58,21 @@ Concretely:
    event: reject, never silently remap. (Same raw object re-registered under
    the same owner is idempotent and returns the incumbent — see
    `linkStore.ts` registration.)
-2. The **merge boundary** — the code path where external content enters a
-   replica (`nodeShellLifecycle` remint loop for node shells) — detects the
-   collision _before_ store registration, mints a fresh id for the incoming
-   copy, and emits a `console.warn` naming the old id, the replacement id,
-   and the root graph id. The warning is required by D-gl-A2: no silent
-   remints, ever — telemetry and debugging depend on collisions being
-   observable.
-3. The reminted id is drawn from a space that cannot re-collide (fresh with
-   respect to the local registry, and unique going forward), so reminting
-   terminates and never ping-pongs.
+2. The **current local-content boundary** is `LGraph.add` →
+   `attachNodeToStores`. Workflow load, paste, and subgraph materialization
+   reach that path. Its `nodeShellLifecycle` loop detects the collision
+   _before_ store registration and mints a fresh id for the incoming local
+   copy. The warning required by D-gl-A2 — naming the old id, replacement id,
+   and root graph id — is pending in #15720; current `main` still remints
+   silently. This local adapter does not receive remote semantic operations
+   and does not emit a CRDT operation.
+3. The **future CRDT boundary** is the semantic-operation applier described by
+   ADR-0003. Nodes, widgets, links, and reroutes are not yet CRDT-replicated.
+   When they are, the applier must reconcile concurrent identity collisions
+   deterministically before calling the registration layer. The current
+   `nodeShellLifecycle` loop is not that applier.
+4. A replacement id must come from a space that cannot re-collide, so
+   reconciliation terminates and never ping-pongs.
 
 ### Echo-back semantics (why this converges)
 
@@ -187,8 +194,10 @@ Tag colliding entries with an epoch/namespace and reconcile lazily.
 ## Glossary
 
 - **Merge boundary** — any code path where content minted outside the local
-  replica enters it: CRDT sync apply, workflow import, paste, subgraph
-  instantiation from a serialized payload.
+  authority is materialized: today, local workflow import, paste, and subgraph
+  instantiation reach `LGraph.add`; in the future, replicated semantic
+  operations will reach a separate CRDT applier. The current node-shell path
+  does not apply CRDT node operations.
 - **Remint** — assigning a fresh id to an _incoming copy_ of an entity whose
   claimed id is already registered locally. Never applied to the incumbent.
 - **Identity key** — a key whose collision means two different entities claim

--- a/docs/adr/0018-node-id-reminting-at-the-merge-boundary.md
+++ b/docs/adr/0018-node-id-reminting-at-the-merge-boundary.md
@@ -60,12 +60,12 @@ Concretely:
    `linkStore.ts` registration.)
 2. The **current local-content boundary** is `LGraph.add` →
    `attachNodeToStores`. Workflow load, paste, and subgraph materialization
-   reach that path. Its `nodeShellLifecycle` loop detects the collision
-   _before_ store registration and mints a fresh id for the incoming local
-   copy. The warning required by D-gl-A2 — naming the old id, replacement id,
-   and root graph id — is pending in #15720; current `main` still remints
-   silently. This local adapter does not receive remote semantic operations
-   and does not emit a CRDT operation.
+   reach that path. Its `nodeShellLifecycle` loop attempts registration; after
+   the registry rejects a collision, the loop mints a fresh id for the
+   incoming local copy and retries. The warning required by D-gl-A2 — naming
+   the old id, replacement id, and root graph id — is pending in #15720;
+   current `main` still remints silently. This local adapter does not receive
+   remote semantic operations and does not emit a CRDT operation.
 3. The **future CRDT boundary** is the semantic-operation applier described by
    ADR-0003. Nodes, widgets, links, and reroutes are not yet CRDT-replicated.
    When they are, the applier must reconcile concurrent identity collisions

--- a/docs/adr/0018-node-id-reminting-at-the-merge-boundary.md
+++ b/docs/adr/0018-node-id-reminting-at-the-merge-boundary.md
@@ -34,7 +34,8 @@ another merge-shaped operation inserts externally minted content.
 ### What a collision means
 
 Per the collision-contract taxonomy (D-gl-A4, with pending test coverage in
-#15720 and a pending ADR-0003/ADR-0008 documentation fold in #15761):
+pull request 15720 and a pending ADR-0003/ADR-0008 documentation fold in
+pull request 15761):
 
 - **Identity keys reject.** A collision on an identity key is two different
   entities claiming one name. They must never be merged; merging silently
@@ -78,7 +79,7 @@ Concretely:
 The two materialization paths do not share propagation semantics. Today's
 local adapter remints only the copy being inserted into one graph:
 
-```
+```text
 incoming local node id 7
           |
           v
@@ -100,7 +101,7 @@ belongs to that applier, but it must be deterministic and collision-free; for
 example, it can retain the raw id for the winning stamp and derive an
 actor-scoped replacement from the losing stamp:
 
-```
+```text
 Replica A operation                 Replica B operation
 add alpha, id 7, stamp A:1          add beta, id 7, stamp B:1
                  \                    /
@@ -203,7 +204,7 @@ Tag colliding entries with an epoch/namespace and reconcile lazily.
 - ADR-0017 — ID-Based Slot Records Are the Slot Destination (the same
   identity-vs-structural key taxonomy, applied to slots).
 - #15720 — pending collision-contract invariant test suite (registry rejection
-  + remint warning).
+  and remint warning).
 - #15761 — pending collision-contract documentation fold.
 - #15882 — pending serialized-reference remap after a local node-id remint.
 - Program decisions D-gl-A2 (no silent remints), D-gl-A4 (identity keys

--- a/docs/adr/0018-node-id-reminting-at-the-merge-boundary.md
+++ b/docs/adr/0018-node-id-reminting-at-the-merge-boundary.md
@@ -6,22 +6,22 @@ Date: 2026-08-25
 
 Proposed
 
-Derivation record for program decision D-gl-A6. The direction is already
-carried by ADR-0003's merge-boundary reconciliation amendment (2026-08-23).
-The current local-import behavior and the future CRDT behavior use different
-materialization paths; this ADR models both so the responsibility boundary is
-reviewable independently of the pending D-dq-04 bundle (#15720 tests + #15761
-docs).
+This ADR records program decision D-gl-A6. ADR-0003's merge-boundary
+reconciliation amendment (2026-08-23) already carries the direction. This ADR
+separates the current local-import behavior from the future CRDT behavior so
+their different materialization paths and responsibilities are explicit.
+Formal sign-off remains pending.
 
 ## Context
 
 ### The id space is the problem, not the CRDT
 
-ComfyUI node ids (`NodeId`) are small bare integers assigned per graph and
-persisted in serialized workflows. They are **not actor-scoped**: nothing in
-the id encodes which client (or which historical workflow file) minted it. In
-a single-client world this is harmless — the graph that mints an id is the
-only authority over it.
+ComfyUI mints node ids (`NodeId`) from a graph-local numeric counter. The
+internal type is a branded string, while serialized workflows accept numbers
+or strings. Neither representation is **actor-scoped**: nothing in the id
+encodes which client or historical workflow file minted it. In a single-client
+world this is harmless because the graph that mints an id is its only
+authority.
 
 The CRDT-based collaboration direction (ADR-0003) and the ECS store migration
 (ADR-0008) break that assumption. Two replicas can each independently mint
@@ -33,15 +33,14 @@ another merge-shaped operation inserts externally minted content.
 
 ### What a collision means
 
-Per the collision-contract taxonomy (D-gl-A4, with pending test coverage in
-pull request 15720 and a pending ADR-0003/ADR-0008 documentation fold in
-pull request 15761):
+ADR-0008 defines two collision contracts:
 
 - **Identity keys reject.** A collision on an identity key is two different
   entities claiming one name. They must never be merged; merging silently
   destroys one entity's history.
-- **Structural keys resolve.** Same position + same type is the same logical
-  slot; carry the value.
+- **Structural keys resolve.** The same derived key and type identify the same
+  logical slot, so the registry carries the existing value forward. For
+  widgets, the key is `graphId:nodeId:name`.
 
 A duplicate `NodeId` is an identity-key collision. The question this ADR
 answers is _where_ the rejection-and-recovery happens.
@@ -71,8 +70,9 @@ Concretely:
    When they are, the applier must reconcile concurrent identity collisions
    deterministically before calling the registration layer. The current
    `nodeShellLifecycle` loop is not that applier.
-4. A replacement id must come from a space that cannot re-collide, so
-   reconciliation terminates and never ping-pongs.
+4. Future CRDT replacements must come from a globally collision-free space so
+   every replica derives the same mapping and reconciliation terminates. The
+   local path instead retries graph-local ids until registration succeeds.
 
 ### Local reminting and future CRDT convergence
 
@@ -182,13 +182,15 @@ Tag colliding entries with an epoch/namespace and reconcile lazily.
   warning is pending in #15720; current `main` does not yet emit it.
 - **Known deliberate gap (open at time of writing):** the remint loop does
   not yet record an old→new id map, and `LGraph.configure` restores links
-  before nodes are added — so serialized link endpoints referencing the old
-  id dangle after a remint. ADR-0008 (as amended in #15761) documents the gap
-  and its two candidate fixes: (a) record the map during the remint loop and
-  remap serialized link/reroute/group endpoints before `configure` restores
-  connections, or (b) reject ambiguous payloads outright. Pending #15882
-  implements option (a). Until it lands, reminting is correct for node
-  identity but incomplete for references.
+  before nodes are added. A serialized link endpoint that references the old
+  id can therefore remain attached to the incumbent node or dangle after a
+  remint. ADR-0008 (as amended in #15761) documents two candidate fixes:
+  (a) record the map and remap the payload's link endpoints before nodes
+  configure their connections, or (b) reject ambiguous payloads outright.
+  Pending #15882 implements option (a). Reroutes reference link ids, and
+  groups do not store node endpoints, so neither requires node-id remapping.
+  Until #15882 lands, reminting is correct for node identity but incomplete
+  for link references.
 - Imports/pastes of colliding content mutate the incoming copy's id. Any
   external system that memorized the old id (e.g. a URL fragment or a test
   fixture) will miss; this is inherent to any rejection-based scheme and is
@@ -221,12 +223,13 @@ Tag colliding entries with an epoch/namespace and reconcile lazily.
   claimed id is already registered locally. Never applied to the incumbent.
 - **Identity key** — a key whose collision means two different entities claim
   one name (e.g. `NodeId`). Contract: reject.
-- **Structural key** — a key derived from position/shape where collision
-  means "same logical slot" (e.g. widget slot index + type). Contract:
-  resolve.
+- **Structural key** — a key computed from an entity's context rather than
+  minted. A collision means "same logical slot." `WidgetId`, for example, is
+  derived from `graphId:nodeId:name`, with widget type used to choose the
+  resolution. Contract: resolve.
 - **Actor-scoped id** — an id embedding the minting client's identity
   (actor id + counter), collision-free by construction; the eventual
-  replacement for bare-integer node ids.
+  replacement for graph-local node ids.
 - **Operation stamp** — immutable actor and sequence metadata used to order
   concurrent semantic operations deterministically on every replica.
 - **Registry no-collision invariant** — a store never holds two different

--- a/docs/adr/0018-node-id-reminting-at-the-merge-boundary.md
+++ b/docs/adr/0018-node-id-reminting-at-the-merge-boundary.md
@@ -1,0 +1,205 @@
+# 18. Node-ID Reminting at the Merge Boundary
+
+Date: 2026-08-25
+
+## Status
+
+Proposed
+
+Derivation record for program decision D-gl-A6. The direction is already
+carried in practice by ADR-0003's merge-boundary reconciliation amendment
+(2026-08-23) and by the collision contracts pinned in the D-dq-04 bundle
+(#15720 tests + #15761 docs); this ADR models the reminting question in full
+so the reasoning is reviewable independently of those PRs.
+
+## Context
+
+### The id space is the problem, not the CRDT
+
+ComfyUI node ids (`NodeId`) are small bare integers assigned per graph and
+persisted in serialized workflows. They are **not actor-scoped**: nothing in
+the id encodes which client (or which historical workflow file) minted it. In
+a single-client world this is harmless — the graph that mints an id is the
+only authority over it.
+
+The CRDT-based collaboration direction (ADR-0003) and the ECS store migration
+(ADR-0008) break that assumption. Two replicas can each independently mint
+node id `7` for two **different** entities. When one replica's content reaches
+the other — via CRDT sync, workflow import, subgraph paste, or any other
+merge-shaped operation — both entities claim the same key in every id-keyed
+registry.
+
+### What a collision means
+
+Per the collision-contract taxonomy (D-gl-A4, pinned by the #15720 test suite
+and documented in the ADR-0003/ADR-0008 amendments of #15761):
+
+- **Identity keys reject.** A collision on an identity key is two different
+  entities claiming one name. They must never be merged; merging silently
+  destroys one entity's history.
+- **Structural keys resolve.** Same position + same type is the same logical
+  slot; carry the value.
+
+A duplicate `NodeId` is an identity-key collision. The question this ADR
+answers is *where* the rejection-and-recovery happens.
+
+## Decision
+
+**CRDT duplicate-id reconciliation lives at the merge boundary. Registries
+keep a strict no-collision invariant.**
+
+Concretely:
+
+1. Stores and registries (nodeStore, linkStore, rerouteStore,
+   widgetValueStore, and any future id-keyed registry) treat a second
+   *different* object claiming a registered id as a programming-error-grade
+   event: reject, never silently remap. (Same raw object re-registered under
+   the same owner is idempotent and returns the incumbent — see
+   `linkStore.ts` registration.)
+2. The **merge boundary** — the code path where external content enters a
+   replica (`nodeShellLifecycle` remint loop for node shells) — detects the
+   collision *before* store registration, mints a fresh id for the incoming
+   copy, and emits a `console.warn` naming the old id, the replacement id,
+   and the root graph id. The warning is required by D-gl-A2: no silent
+   remints, ever — telemetry and debugging depend on collisions being
+   observable.
+3. The reminted id is drawn from a space that cannot re-collide (fresh with
+   respect to the local registry, and unique going forward), so reminting
+   terminates and never ping-pongs.
+
+### Echo-back semantics (why this converges)
+
+The most common confusion: "if client B remints client A's node, doesn't that
+conflict with A's copy when it syncs back?" No — because B remints **its
+imported copy**, never A's original.
+
+```
+Client A                          Client B
++-----------------+               +-----------------+
+| mints node id 7 |               | mints node id 7 |   two DIFFERENT entities,
+| (its own node)  |               | (its own node)  |   same id -- by accident
++--------+--------+               +--------+--------+
+         |  A's ops sync to B              |
+         v                                 |
++--------------------------------+         |
+| B's MERGE BOUNDARY             |         |
+| registry: "7 is taken"         |<--------+
+| -> remint A's copy to 7'       |
+| -> console.warn(old, new, root)|
++--------+-----------------------+
+         | remint is an ordinary local edit on B's replica
+         | -> becomes a normal CRDT op -> syncs back to A
+         v
++-----------------+               +-----------------+
+| A: own 7 + B's  |               | B: own 7 + A's  |
+| copy of A-node  |               | copy of A-node  |
+| stays 7; B-node |               | as 7'; own      |
+| arrives as its  |               | B-node stays 7  |
+| own id          |               |                 |
++-----------------+               +-----------------+
+     converged: same two nodes, same two ids, everywhere
+```
+
+The remint is a local edit that propagates like any other operation. Neither
+replica ever holds two live entities under one id, so the registry invariant
+holds on both sides at all times, and both replicas converge on the same
+(node, id) pairs.
+
+### Relationship to CRDT creator-minting
+
+CRDT practice says the creator mints ids, actor-scoped (actor id + counter),
+making collisions impossible by construction. Merge-boundary reminting does
+not violate that principle — it **compensates for an id space that predates
+it**. The importer is, in CRDT terms, the creator of the imported copy inside
+its replica, and it mints accordingly.
+
+**Future work (recorded, not scheduled):** make node ids actor-scoped at
+creation. Once that lands, merge-boundary reminting decays to dead code for
+new content and is retained only as the import adapter for legacy serialized
+workflows. This is the durable fix; reminting is the bridge.
+
+### Revisit trigger
+
+If a Yjs document ever keys a **shared** map by raw `NodeId` across clients,
+this decision stops being sufficient: ids would need to be globally unique at
+creation time, which forces the actor-scoped refactor immediately rather than
+eventually.
+
+## Alternatives considered
+
+### Store-side remap (rejected)
+
+Let stores absorb collisions by remapping ids internally on registration.
+
+- Violates D-gl-A2 directly: the remap is exactly the silent remint that
+  decision forbids.
+- Smears merge logic across every store instead of one boundary; every
+  future store must reimplement it.
+- Hides real data-model bugs behind auto-repair — a duplicate id caused by a
+  lifecycle bug would be silently "fixed" instead of surfaced.
+- Breaks the identity-keys-reject contract already pinned by the #15720
+  suite.
+
+### Hybrid: registries tolerate duplicates temporarily (rejected)
+
+Tag colliding entries with an epoch/namespace and reconcile lazily.
+
+- Ids stop being unique within a replica window, which poisons every
+  id-keyed map, cache, and lookup in the codebase for the duration.
+- Largest implementation surface of the three options with the least
+  predictable failure modes.
+
+## Consequences
+
+- Registries stay simple and their no-collision invariant is test-pinned
+  (#15720). Collision handling is localized to one auditable boundary.
+- Every collision is observable (the required warning), so telemetry can
+  count real-world collision frequency and inform the actor-scoped refactor's
+  priority.
+- **Known deliberate gap (open at time of writing):** the remint loop does
+  not yet record an old→new id map, and `LGraph.configure` restores links
+  before nodes are added — so serialized link endpoints referencing the old
+  id dangle after a remint. ADR-0008 (as amended in #15761) documents the gap
+  and its two candidate fixes: (a) record the map during the remint loop and
+  remap serialized link/reroute/group endpoints before `configure` restores
+  connections, or (b) reject ambiguous payloads outright. Until one lands,
+  reminting is correct for node identity but incomplete for references.
+- Imports/pastes of colliding content mutate the incoming copy's id. Any
+  external system that memorized the old id (e.g. a URL fragment or a test
+  fixture) will miss; this is inherent to any rejection-based scheme and is
+  the cost of never merging two distinct entities.
+
+## References
+
+- ADR-0003 — Centralized Layout Management with CRDT (merge-boundary
+  reconciliation amendment, 2026-08-23). Cite ADR-0003 externally; this ADR
+  is the derivation record.
+- ADR-0008 — Entity Component System (collision-contract and remint-gap
+  amendments via #15761).
+- ADR-0017 — ID-Based Slot Records Are the Slot Destination (the same
+  identity-vs-structural key taxonomy, applied to slots).
+- #15720 — collision-contract invariant test suite (registry rejection +
+  remint warning pinned).
+- #15761 — collision-contract documentation fold.
+- Program decisions D-gl-A2 (no silent remints), D-gl-A4 (identity keys
+  reject / structural keys resolve), D-gl-A6 (this decision).
+
+## Glossary
+
+- **Merge boundary** — any code path where content minted outside the local
+  replica enters it: CRDT sync apply, workflow import, paste, subgraph
+  instantiation from a serialized payload.
+- **Remint** — assigning a fresh id to an *incoming copy* of an entity whose
+  claimed id is already registered locally. Never applied to the incumbent.
+- **Identity key** — a key whose collision means two different entities claim
+  one name (e.g. `NodeId`). Contract: reject.
+- **Structural key** — a key derived from position/shape where collision
+  means "same logical slot" (e.g. widget slot index + type). Contract:
+  resolve.
+- **Actor-scoped id** — an id embedding the minting client's identity
+  (actor id + counter), collision-free by construction; the eventual
+  replacement for bare-integer node ids.
+- **Echo-back** — the reminted copy propagating back to the originating
+  client as an ordinary CRDT operation, converging both replicas.
+- **Registry no-collision invariant** — a store never holds two different
+  live objects under one id; second different claimant is rejected.

--- a/docs/adr/0018-node-id-reminting-at-the-merge-boundary.md
+++ b/docs/adr/0018-node-id-reminting-at-the-merge-boundary.md
@@ -33,8 +33,8 @@ another merge-shaped operation inserts externally minted content.
 
 ### What a collision means
 
-Per the collision-contract taxonomy (D-gl-A4, pinned by the #15720 test suite
-and documented in the ADR-0003/ADR-0008 amendments of #15761):
+Per the collision-contract taxonomy (D-gl-A4, with pending test coverage in
+#15720 and a pending ADR-0003/ADR-0008 documentation fold in #15761):
 
 - **Identity keys reject.** A collision on an identity key is two different
   entities claiming one name. They must never be merged; merging silently
@@ -52,12 +52,11 @@ keep a strict no-collision invariant.**
 
 Concretely:
 
-1. Stores and registries (nodeStore, linkStore, rerouteStore,
-   widgetValueStore, and any future id-keyed registry) treat a second
-   _different_ object claiming a registered id as a programming-error-grade
-   event: reject, never silently remap. (Same raw object re-registered under
-   the same owner is idempotent and returns the incumbent — see
-   `linkStore.ts` registration.)
+1. Identity-keyed registries (`nodeDataStore`, `linkStore`, `rerouteStore`, and
+   any future minted-id registry) reject a second _different_ object claiming
+   a registered id; they never silently remap it. Idempotent re-registration
+   may return the incumbent. Structural-keyed registries such as
+   `widgetValueStore` keep their separate resolve-and-reuse contract.
 2. The **current local-content boundary** is `LGraph.add` →
    `attachNodeToStores`. Workflow load, paste, and subgraph materialization
    reach that path. Its `nodeShellLifecycle` loop attempts registration; after
@@ -74,51 +73,67 @@ Concretely:
 4. A replacement id must come from a space that cannot re-collide, so
    reconciliation terminates and never ping-pongs.
 
-### Echo-back semantics (why this converges)
+### Local reminting and future CRDT convergence
 
-The most common confusion: "if client B remints client A's node, doesn't that
-conflict with A's copy when it syncs back?" No — because B remints **its
-imported copy**, never A's original.
+The two materialization paths do not share propagation semantics. Today's
+local adapter remints only the copy being inserted into one graph:
 
 ```
-Client A                          Client B
-+-----------------+               +-----------------+
-| mints node id 7 |               | mints node id 7 |   two DIFFERENT entities,
-| (its own node)  |               | (its own node)  |   same id -- by accident
-+--------+--------+               +--------+--------+
-         |  A's ops sync to B              |
-         v                                 |
-+--------------------------------+         |
-| B's MERGE BOUNDARY             |         |
-| registry: "7 is taken"         |<--------+
-| -> remint A's copy to 7'       |
-| -> console.warn(old, new, root)|
-+--------+-----------------------+
-         | remint is an ordinary local edit on B's replica
-         | -> becomes a normal CRDT op -> syncs back to A
-         v
-+-----------------+               +-----------------+
-| A: own 7 + B's  |               | B: own 7 + A's  |
-| copy of A-node  |               | copy of A-node  |
-| stays 7; B-node |               | as 7'; own      |
-| arrives as its  |               | B-node stays 7  |
-| own id          |               |                 |
-+-----------------+               +-----------------+
-     converged: same two nodes, same two ids, everywhere
+incoming local node id 7
+          |
+          v
+      LGraph.add
+          |
+          v
+registry rejects: local id 7 is occupied
+          |
+          v
+remint incoming copy to local id 8; retry succeeds
+          |
+          +---- no CRDT operation is emitted
 ```
 
-The remint is a local edit that propagates like any other operation. Neither
-replica ever holds two live entities under one id, so the registry invariant
-holds on both sides at all times, and both replicas converge on the same
-(node, id) pairs.
+A future semantic-operation applier must instead derive one canonical mapping
+from the same merged operation set on every replica. ADR-0003 requires
+op-stamp ordering before registration. The concrete replacement encoding
+belongs to that applier, but it must be deterministic and collision-free; for
+example, it can retain the raw id for the winning stamp and derive an
+actor-scoped replacement from the losing stamp:
+
+```
+Replica A operation                 Replica B operation
+add alpha, id 7, stamp A:1          add beta, id 7, stamp B:1
+                 \                    /
+                  \                  /
+             same merged operation set
+                          |
+                          v
+               semantic-operation applier
+               order collision by op stamp
+               alpha -> 7
+               beta  -> replacement(B:1)
+                          |
+                          v
+             register collision-free entities
+                          |
+                          v
+        both replicas materialize the same two mappings
+```
+
+This model has no replica-local echo-back step. Both original entities survive,
+the same operation keeps id `7` everywhere, and the same losing operation gets
+the same replacement everywhere. No raw duplicate reaches an in-memory
+registry.
 
 ### Relationship to CRDT creator-minting
 
 CRDT practice says the creator mints ids, actor-scoped (actor id + counter),
 making collisions impossible by construction. Merge-boundary reminting does
 not violate that principle — it **compensates for an id space that predates
-it**. The importer is, in CRDT terms, the creator of the imported copy inside
-its replica, and it mints accordingly.
+it**. For local imports, `LGraph.add` creates a local copy and may assign that
+copy a fresh local id; this mutation is not replicated. For future semantic
+operations, the creator's immutable operation stamp gives every replica the
+same input for choosing the incumbent and deriving the replacement.
 
 **Future work (recorded, not scheduled):** make node ids actor-scoped at
 creation. Once that lands, merge-boundary reminting decays to dead code for
@@ -144,7 +159,7 @@ Let stores absorb collisions by remapping ids internally on registration.
   future store must reimplement it.
 - Hides real data-model bugs behind auto-repair — a duplicate id caused by a
   lifecycle bug would be silently "fixed" instead of surfaced.
-- Breaks the identity-keys-reject contract already pinned by the #15720
+- Breaks the identity-keys-reject contract exercised by the pending #15720
   suite.
 
 ### Hybrid: registries tolerate duplicates temporarily (rejected)
@@ -158,19 +173,21 @@ Tag colliding entries with an epoch/namespace and reconcile lazily.
 
 ## Consequences
 
-- Registries stay simple and their no-collision invariant is test-pinned
-  (#15720). Collision handling is localized to one auditable boundary.
-- Every collision is observable (the required warning), so telemetry can
-  count real-world collision frequency and inform the actor-scoped refactor's
-  priority.
+- Registries stay simple and their no-collision invariant is covered by the
+  pending #15720 suite. Local collision handling stays in `LGraph.add`; future
+  replicated collision handling stays in one semantic-operation applier.
+- Every local remint must be observable so telemetry can count real-world
+  collision frequency and inform the actor-scoped refactor's priority. That
+  warning is pending in #15720; current `main` does not yet emit it.
 - **Known deliberate gap (open at time of writing):** the remint loop does
   not yet record an old→new id map, and `LGraph.configure` restores links
   before nodes are added — so serialized link endpoints referencing the old
   id dangle after a remint. ADR-0008 (as amended in #15761) documents the gap
   and its two candidate fixes: (a) record the map during the remint loop and
   remap serialized link/reroute/group endpoints before `configure` restores
-  connections, or (b) reject ambiguous payloads outright. Until one lands,
-  reminting is correct for node identity but incomplete for references.
+  connections, or (b) reject ambiguous payloads outright. Pending #15882
+  implements option (a). Until it lands, reminting is correct for node
+  identity but incomplete for references.
 - Imports/pastes of colliding content mutate the incoming copy's id. Any
   external system that memorized the old id (e.g. a URL fragment or a test
   fixture) will miss; this is inherent to any rejection-based scheme and is
@@ -185,9 +202,10 @@ Tag colliding entries with an epoch/namespace and reconcile lazily.
   amendments via #15761).
 - ADR-0017 — ID-Based Slot Records Are the Slot Destination (the same
   identity-vs-structural key taxonomy, applied to slots).
-- #15720 — collision-contract invariant test suite (registry rejection +
-  remint warning pinned).
-- #15761 — collision-contract documentation fold.
+- #15720 — pending collision-contract invariant test suite (registry rejection
+  + remint warning).
+- #15761 — pending collision-contract documentation fold.
+- #15882 — pending serialized-reference remap after a local node-id remint.
 - Program decisions D-gl-A2 (no silent remints), D-gl-A4 (identity keys
   reject / structural keys resolve), D-gl-A6 (this decision).
 
@@ -208,7 +226,7 @@ Tag colliding entries with an epoch/namespace and reconcile lazily.
 - **Actor-scoped id** — an id embedding the minting client's identity
   (actor id + counter), collision-free by construction; the eventual
   replacement for bare-integer node ids.
-- **Echo-back** — the reminted copy propagating back to the originating
-  client as an ordinary CRDT operation, converging both replicas.
+- **Operation stamp** — immutable actor and sequence metadata used to order
+  concurrent semantic operations deterministically on every replica.
 - **Registry no-collision invariant** — a store never holds two different
   live objects under one id; second different claimant is rejected.

--- a/docs/adr/0018-node-id-reminting-at-the-merge-boundary.md
+++ b/docs/adr/0018-node-id-reminting-at-the-merge-boundary.md
@@ -41,7 +41,7 @@ and documented in the ADR-0003/ADR-0008 amendments of #15761):
   slot; carry the value.
 
 A duplicate `NodeId` is an identity-key collision. The question this ADR
-answers is *where* the rejection-and-recovery happens.
+answers is _where_ the rejection-and-recovery happens.
 
 ## Decision
 
@@ -52,13 +52,13 @@ Concretely:
 
 1. Stores and registries (nodeStore, linkStore, rerouteStore,
    widgetValueStore, and any future id-keyed registry) treat a second
-   *different* object claiming a registered id as a programming-error-grade
+   _different_ object claiming a registered id as a programming-error-grade
    event: reject, never silently remap. (Same raw object re-registered under
    the same owner is idempotent and returns the incumbent — see
    `linkStore.ts` registration.)
 2. The **merge boundary** — the code path where external content enters a
    replica (`nodeShellLifecycle` remint loop for node shells) — detects the
-   collision *before* store registration, mints a fresh id for the incoming
+   collision _before_ store registration, mints a fresh id for the incoming
    copy, and emits a `console.warn` naming the old id, the replacement id,
    and the root graph id. The warning is required by D-gl-A2: no silent
    remints, ever — telemetry and debugging depend on collisions being
@@ -189,7 +189,7 @@ Tag colliding entries with an epoch/namespace and reconcile lazily.
 - **Merge boundary** — any code path where content minted outside the local
   replica enters it: CRDT sync apply, workflow import, paste, subgraph
   instantiation from a serialized payload.
-- **Remint** — assigning a fresh id to an *incoming copy* of an entity whose
+- **Remint** — assigning a fresh id to an _incoming copy_ of an entity whose
   claimed id is already registered locally. Never applied to the incumbent.
 - **Identity key** — a key whose collision means two different entities claim
   one name (e.g. `NodeId`). Contract: reject.

--- a/docs/adr/0018-node-id-reminting-at-the-merge-boundary.md
+++ b/docs/adr/0018-node-id-reminting-at-the-merge-boundary.md
@@ -79,19 +79,12 @@ Concretely:
 The two materialization paths do not share propagation semantics. Today's
 local adapter remints only the copy being inserted into one graph:
 
-```text
-incoming local node id 7
-          |
-          v
-      LGraph.add
-          |
-          v
-registry rejects: local id 7 is occupied
-          |
-          v
-remint incoming copy to local id 8; retry succeeds
-          |
-          +---- no CRDT operation is emitted
+```mermaid
+flowchart TD
+  incoming["Incoming local node, id 7"] --> add[LGraph.add]
+  add --> rejected["Registry rejects: local id 7 is occupied"]
+  rejected --> remint["Remint incoming copy to local id 8; retry succeeds"]
+  remint --> local["No CRDT operation is emitted"]
 ```
 
 A future semantic-operation applier must instead derive one canonical mapping
@@ -101,24 +94,17 @@ belongs to that applier, but it must be deterministic and collision-free; for
 example, it can retain the raw id for the winning stamp and derive an
 actor-scoped replacement from the losing stamp:
 
-```text
-Replica A operation                 Replica B operation
-add alpha, id 7, stamp A:1          add beta, id 7, stamp B:1
-                 \                    /
-                  \                  /
-             same merged operation set
-                          |
-                          v
-               semantic-operation applier
-               order collision by op stamp
-               alpha -> 7
-               beta  -> replacement(B:1)
-                          |
-                          v
-             register collision-free entities
-                          |
-                          v
-        both replicas materialize the same two mappings
+```mermaid
+flowchart TD
+  replicaA["Replica A: add alpha, id 7, stamp A:1"]
+  replicaB["Replica B: add beta, id 7, stamp B:1"]
+  merged["Same merged operation set"]
+  replicaA --> merged
+  replicaB --> merged
+  merged --> applier["Semantic-operation applier orders collision by op stamp"]
+  applier --> mappings["alpha → 7; beta → replacement(B:1)"]
+  mappings --> register["Register collision-free entities"]
+  register --> replicas["Both replicas materialize the same two mappings"]
 ```
 
 This model has no replica-local echo-back step. Both original entities survive,

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -26,6 +26,7 @@ An Architecture Decision Record captures an important architectural decision mad
 | [0014](0014-billing-telemetry-attempt-correlation-and-workspace-scoping.md) | Billing Telemetry Attempt Correlation and Workspace Scoping | Proposed | 2026-07-28 |
 | [0015](0015-adopt-fallow.md)                                                | Adopt Fallow                                                | Proposed | 2026-06-29 |
 | [0017](0017-id-based-slot-records-are-the-slot-destination.md)              | ID-Based Slot Records Own Slot State                        | Accepted | 2026-08-24 |
+| [0018](0018-node-id-reminting-at-the-merge-boundary.md)                     | Node-ID Reminting at the Merge Boundary                     | Proposed | 2026-08-25 |
 
 ## Creating a New ADR
 


### PR DESCRIPTION
## Summary

Clarifies ADR-0018's current local remint path, future CRDT requirements, and known link-remapping gap without changing the decision.

## Changes

- **What**: Correct the `NodeId` representation, separate local retry behavior from globally collision-free CRDT replacement, and describe the link-remapping failure and #15882 scope accurately.
- Convert both text-based flow diagrams to Mermaid.

## Review Focus

Check that the revised wording preserves D-gl-A6 while distinguishing implemented behavior from the future semantic-operation applier.

Child of #15920.