### PR TITLE
docs(extensions): tighten ECS migration guidance

### DIFF
--- a/docs/extensions/connection-callbacks-migration.md
+++ b/docs/extensions/connection-callbacks-migration.md
@@ -57,14 +57,10 @@ Removing a node fires, in order:
 5. `onNodeRemoved(node)`, then `node:removed`, both seeing an already-detached
    node.
 
-Test coverage backs this only in pieces: one test asserts the
-`before-removed → onRemoved → onNodeRemoved` order (steps 1, 3, 5's first
-half); a separate test asserts `node:removed` fires with the node already
-detached (step 4 relative to step 5's second half). The placement of
-`onConnectionsChange` (step 2) relative to the rest of the sequence, and the
-full five-step order end to end, are observed from source, not exercised by
-a single test. Treat step 2's position as documented-but-not-test-guaranteed
-until a discriminating test exists.
+Tests cover `node:before-removed → node.onRemoved() → onNodeRemoved(node)` and
+separately verify that `node:removed` sees a detached node. The complete
+sequence, including step 2, is observed from source rather than guaranteed by
+one end-to-end test.
 
 To resolve the removed node from a peer's `onConnectionsChange` handler, do it
 at step 2 via `graph.getNodeById()`. By `node:removed`, the node is gone.

--- a/docs/extensions/node-geometry-migration.md
+++ b/docs/extensions/node-geometry-migration.md
@@ -10,10 +10,8 @@
    requested value.
 4. Use the node/group geometry APIs, not the backing store; don't import
    `layoutStore` or depend on its internal format.
-5. Writes through a removed node reference update only that detached
-   object's own fields, not an error and not a clobbered live node: expect
-   the live/shared layout state to stay untouched, not the detached
-   object itself to be a no-op.
+5. Writes through a removed reference update the detached object, not shared
+   layout state.
 
 ## What changed
 
@@ -67,21 +65,8 @@ in the node list, and its execution order. It's now always draw order. If
 your extension inferred stacking or hit-test order from execution order,
 switch to draw order.
 
-## Writes through removed node, group, or reroute references don't propagate, but do land locally
+## Writes through removed references stay local
 
-The write API differs per entity: `LGraphNode` exposes `setPos()`/`setSize()`
-(backed by `pos`/`size` setters). `LGraphGroup` exposes `pos`/`size` setters
-only, with no separate methods. `Reroute` exposes a `pos` setter only; it has
-no `size` at all.
-
-If you hold a node, group, or reroute reference after it's removed from the
-graph (a detached clone, or a reference captured before an async callback
-resolves), writing through one of these setters still updates that object's
-own local position/size fields — the write lands unconditionally before the
-missing-graph guard runs. What's guaranteed is narrower than a full no-op:
-the write never reaches the shared layout store and never affects whatever
-entity now owns that ID. Being detached does not make the write throw (a
-malformed value passed to `Reroute.pos` still throws, detached or not, but
-for that reason, not because of detachment). Don't rely on a detached
-reference's position/size staying unchanged after you write to it; only the
-live/shared state is protected.
+After removal, geometry setters update only the detached node, group, or
+reroute object. They do not update shared layout state or another entity that
+now owns the same ID.

--- a/docs/extensions/serialization-callbacks-migration.md
+++ b/docs/extensions/serialization-callbacks-migration.md
@@ -8,15 +8,8 @@ active Pinia now fails outright instead of silently producing an empty
 graph. This is the same requirement documented in
 [Link registration migration](link-registration-migration.md).
 
-Vue applications can register Pinia with the application as usual. Standalone
-consumers must activate it before constructing or configuring a root graph:
-
-```ts
-import { createPinia, setActivePinia } from 'pinia'
-
-setActivePinia(createPinia())
-const graph = new LGraph(data)
-```
+Extensions running in ComfyUI use the application's active Pinia instance.
+Do not create or activate a separate Pinia instance from extension code.
 
 `node.onConfigure`, `node.onSerialize`, `graph.onConfigure`, and
 `graph.onSerialize` keep their existing signatures and firing order. For

--- a/docs/extensions/serialization-callbacks-migration.md
+++ b/docs/extensions/serialization-callbacks-migration.md
@@ -8,6 +8,16 @@ active Pinia now fails outright instead of silently producing an empty
 graph. This is the same requirement documented in
 [Link registration migration](link-registration-migration.md).
 
+Vue applications can register Pinia with the application as usual. Standalone
+consumers must activate it before constructing or configuring a root graph:
+
+```ts
+import { createPinia, setActivePinia } from 'pinia'
+
+setActivePinia(createPinia())
+const graph = new LGraph(data)
+```
+
 `node.onConfigure`, `node.onSerialize`, `graph.onConfigure`, and
 `graph.onSerialize` keep their existing signatures and firing order. For
 connection-timing hooks see


### PR DESCRIPTION
## Summary

Tightens three passages in the ECS extension migration guides so readers can reach the required action faster.

## Changes

- **What**: Condenses the callback test-coverage note and detached-geometry behavior, and clarifies that extensions use ComfyUI's active Pinia instance rather than creating their own.

## Review Focus

This is a child of #15857. Please verify that the shorter callback and geometry wording preserves the documented contracts and that the Pinia guidance keeps extensions on the host application's instance.