### PR TITLE
fix: reject malformed registry node names

### DIFF
--- a/src/services/comfyRegistryService.test.ts
+++ b/src/services/comfyRegistryService.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it, vi } from 'vitest'
+
+const mockRegistryApiClient = vi.hoisted(() => ({
+  get: vi.fn(),
+  post: vi.fn()
+}))
+
+vi.mock('axios', () => ({
+  default: {
+    create: vi.fn(() => mockRegistryApiClient),
+    isAxiosError: vi.fn(() => false)
+  }
+}))
+
+import { useComfyRegistryService } from '@/services/comfyRegistryService'
+
+describe('useComfyRegistryService', () => {
+  it.for([undefined, ''])(
+    'does not query for node name %s',
+    async (nodeName) => {
+      const result = await Reflect.apply(
+        useComfyRegistryService().inferPackFromNodeName,
+        undefined,
+        [nodeName]
+      )
+
+      expect(result).toBeNull()
+      expect(mockRegistryApiClient.get).not.toHaveBeenCalled()
+    }
+  )
+})

--- a/src/services/comfyRegistryService.test.ts
+++ b/src/services/comfyRegistryService.test.ts
@@ -15,7 +15,7 @@ vi.mock('axios', () => ({
 import { useComfyRegistryService } from '@/services/comfyRegistryService'
 
 describe('useComfyRegistryService', () => {
-  it.for([undefined, ''])(
+  it.for([null, undefined, ''])(
     'does not query for node name %s',
     async (nodeName) => {
       const result = await Reflect.apply(
@@ -28,4 +28,18 @@ describe('useComfyRegistryService', () => {
       expect(mockRegistryApiClient.get).not.toHaveBeenCalled()
     }
   )
+
+  it('returns registry data for a valid node name', async () => {
+    const expected = { id: 'pack-id' }
+    mockRegistryApiClient.get.mockResolvedValueOnce({ data: expected })
+
+    const result =
+      await useComfyRegistryService().inferPackFromNodeName('KSampler')
+
+    expect(result).toEqual(expected)
+    expect(mockRegistryApiClient.get).toHaveBeenCalledExactlyOnceWith(
+      '/comfy-nodes/KSampler/node',
+      { signal: undefined }
+    )
+  })
 })

--- a/src/services/comfyRegistryService.test.ts
+++ b/src/services/comfyRegistryService.test.ts
@@ -15,7 +15,7 @@ vi.mock('axios', () => ({
 import { useComfyRegistryService } from '@/services/comfyRegistryService'
 
 describe('useComfyRegistryService', () => {
-  it.for([null, undefined, ''])(
+  it.for([null, undefined, '', 'undefined'])(
     'does not query for node name %s',
     async (nodeName) => {
       const result = await Reflect.apply(

--- a/src/services/comfyRegistryService.ts
+++ b/src/services/comfyRegistryService.ts
@@ -347,7 +347,7 @@ export const useComfyRegistryService = () => {
       | undefined,
     signal?: AbortSignal
   ) => {
-    if (!nodeName) return null
+    if (!nodeName || nodeName === 'undefined') return null
 
     const endpoint = `/comfy-nodes/${nodeName}/node`
     const errorContext = 'Failed to infer pack from comfy node name'

--- a/src/services/comfyRegistryService.ts
+++ b/src/services/comfyRegistryService.ts
@@ -341,9 +341,14 @@ export const useComfyRegistryService = () => {
    * ```
    */
   const inferPackFromNodeName = async (
-    nodeName: operations['getNodeByComfyNodeName']['parameters']['path']['comfyNodeName'],
+    nodeName:
+      | operations['getNodeByComfyNodeName']['parameters']['path']['comfyNodeName']
+      | null
+      | undefined,
     signal?: AbortSignal
   ) => {
+    if (!nodeName) return null
+
     const endpoint = `/comfy-nodes/${nodeName}/node`
     const errorContext = 'Failed to infer pack from comfy node name'
     const routeSpecificErrors = {


### PR DESCRIPTION
## Summary

Prevent malformed `/comfy-nodes/undefined/node` and `/comfy-nodes//node` registry requests when a runtime workflow node has no usable type.

## Changes

- Return `null` at the registry-service boundary for null, undefined, empty, and the observed literal `undefined` sentinel.
- Preserve valid node-name lookups unchanged.

## Red/green proof

- Red: [run 32918542864](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/32918542864) fails exactly because the literal sentinel performs `GET /comfy-nodes/undefined/node`.
- Green: [run 32919679830](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/32919679830) passes the full unit workflow on the source-only fix; all 5 focused service tests pass.

## Review Focus

The guard is at the network boundary so every caller gets the same fail-closed behavior. It rejects only the malformed values proven by tests and does not introduce guessed whitespace or sentinel rules. This was surfaced by the pinned ComfyUI_Fill-Nodes S3 and connectivity run.

Linear: https://linear.app/comfyorg/issue/FE-1866/e2e-nodes-tests-avoid-registry-lookup-for-untyped-workflow-nodes