### PR TITLE
fix: preserve custom-node initialization diagnostics

### DIFF
--- a/browser_tests/fixtures/customNode/valueDrift.test.ts
+++ b/browser_tests/fixtures/customNode/valueDrift.test.ts
@@ -113,7 +113,7 @@ it('roundtrip initialization waits for pack-owned ready values', () => {
 
   const unavailableValues: Record<string, unknown> | undefined = undefined
   expect(
-    pendingRoundtripInitializations(signals, unavailableValues!, false)
+    pendingRoundtripInitializations(signals, unavailableValues, false)
   ).toEqual([
     'LoadAudioUI (litegraph: expected false, observed undefined)',
     'SAM3VideoSegmentation (litegraph: expected defined, observed undefined)',

--- a/browser_tests/fixtures/customNode/valueDrift.test.ts
+++ b/browser_tests/fixtures/customNode/valueDrift.test.ts
@@ -110,6 +110,16 @@ it('roundtrip initialization waits for pack-owned ready values', () => {
       false
     )
   ).toEqual([])
+
+  const unavailableValues: Record<string, unknown> | undefined = undefined
+  expect(
+    pendingRoundtripInitializations(signals, unavailableValues!, false)
+  ).toEqual([
+    'LoadAudioUI (litegraph: expected false, observed undefined)',
+    'SAM3VideoSegmentation (litegraph: expected defined, observed undefined)',
+    'iToolsPaintNode (litegraph: expected 33 widgets, observed undefined)',
+    'ImageTransformKJ (litegraph: expected bboxes = "{\\"fillColor\\":\\"#000000\\"}", observed undefined)'
+  ])
 })
 
 it('roundtrip initialization signals apply only to their node batch', () => {

--- a/browser_tests/fixtures/customNode/valueDrift.ts
+++ b/browser_tests/fixtures/customNode/valueDrift.ts
@@ -114,21 +114,22 @@ function expectedInitializationValue(
 
 export function pendingRoundtripInitializations(
   signals: Record<string, RoundtripInitializationSignal>,
-  values: Record<string, unknown>,
+  values: Record<string, unknown> | undefined,
   vueNodesEnabled: boolean
 ): string[] {
   return Object.entries(signals)
     .filter(([node, signal]) => {
-      if (signal.predicate === 'defined') return values[node] === undefined
+      const observed = values?.[node]
+      if (signal.predicate === 'defined') return observed === undefined
       if (signal.predicate === 'minimum-widget-count')
-        return typeof values[node] !== 'number' || values[node] < signal.value
+        return typeof observed !== 'number' || observed < signal.value
       if (signal.predicate === 'widget-count')
-        return !Object.is(values[node], signal.value)
-      return !Object.is(values[node], signal.value)
+        return !Object.is(observed, signal.value)
+      return !Object.is(observed, signal.value)
     })
     .map(
       ([node, signal]) =>
-        `${node} (${vueNodesEnabled ? 'vue' : 'litegraph'}: expected ${expectedInitializationValue(signal)}, observed ${JSON.stringify(values[node])})`
+        `${node} (${vueNodesEnabled ? 'vue' : 'litegraph'}: expected ${expectedInitializationValue(signal)}, observed ${JSON.stringify(values?.[node])})`
     )
 }
 

--- a/browser_tests/fixtures/customNode/valueDrift.ts
+++ b/browser_tests/fixtures/customNode/valueDrift.ts
@@ -112,10 +112,6 @@ function expectedInitializationValue(
   return JSON.stringify(signal.value)
 }
 
-// Each pending entry carries what it wanted and what it saw. The poll that
-// consumes this reports only the returned strings on timeout, so a bare node
-// name costs a CI round trip to learn the one number that identifies whether
-// the pack is slow or the contract is wrong.
 export function pendingRoundtripInitializations(
   signals: Record<string, RoundtripInitializationSignal>,
   values: Record<string, unknown>,


### PR DESCRIPTION
## Summary

Preserve the attributable S3 readiness failure when the browser snapshot is unavailable instead of replacing it with a TypeError.

## Changes

- Accept a missing initialization snapshot and report each pending node with an observed value of undefined.
- Keep the readiness predicates, exact expected values, and timeout unchanged.

## Red/green proof

- Red: [run 32918166425](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/32918166425) fails exactly in `pendingRoundtripInitializations` while reading `LoadAudioUI` from the missing snapshot.
- Green: [run 32919291301](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/32919291301) passes the full unit workflow on the source-only fix; focused coverage passes 14 of 14 tests.

## Review Focus

The missing snapshot is artifact-proven in custom-node run 32917494329. Verify the formatter preserves all pending-node diagnostics without changing what S3 accepts.