### PR TITLE
fix(load3d): gate camera custom up on explicit useCustomUp flag

### DIFF
--- a/src/components/load3d/menubar/CameraMenuGroup.test.ts
+++ b/src/components/load3d/menubar/CameraMenuGroup.test.ts
@@ -46,4 +46,27 @@ describe('CameraMenuGroup', () => {
       screen.getByRole('button', { name: 'Orthographic' })
     ).toBeInTheDocument()
   })
+
+  it('hides the up toggle when the camera has no custom up', () => {
+    renderGroup()
+
+    expect(
+      screen.queryByRole('button', { name: /custom up|natural up/i })
+    ).not.toBeInTheDocument()
+  })
+
+  it('toggles between the custom and natural up', async () => {
+    const config: CameraConfig = {
+      ...makeConfig(),
+      hasCustomUp: true,
+      useCustomUp: true
+    }
+    const { user } = renderGroup(config)
+
+    await user.click(screen.getByRole('button', { name: 'Custom up' }))
+    expect(config.useCustomUp).toBe(false)
+
+    await user.click(screen.getByRole('button', { name: 'Natural up' }))
+    expect(config.useCustomUp).toBe(true)
+  })
 })

--- a/src/components/load3d/menubar/CameraMenuGroup.test.ts
+++ b/src/components/load3d/menubar/CameraMenuGroup.test.ts
@@ -19,9 +19,9 @@ function makeConfig(
   return { cameraType: 'perspective', fov: 75, ...overrides }
 }
 
-function renderGroup(config = makeConfig()) {
+function renderGroup(config = makeConfig(), compact = false) {
   const result = render(CameraMenuGroup, {
-    props: { config },
+    props: { config, compact },
     global: { plugins: [i18n], directives: { tooltip: () => {} } }
   })
   return { ...result, user: userEvent.setup(), config }
@@ -68,5 +68,23 @@ describe('CameraMenuGroup', () => {
 
     await user.click(screen.getByRole('button', { name: 'Natural up' }))
     expect(config.useCustomUp).toBe(true)
+  })
+
+  it('announces the up toggle as an action in compact mode', async () => {
+    const config: CameraConfig = {
+      ...makeConfig(),
+      hasCustomUp: true,
+      useCustomUp: true
+    }
+    const { user } = renderGroup(config, true)
+
+    await user.click(
+      screen.getByRole('button', { name: 'Reset camera up to Y' })
+    )
+
+    expect(config.useCustomUp).toBe(false)
+    expect(
+      screen.getByRole('button', { name: 'Restore camera up from input' })
+    ).toBeInTheDocument()
   })
 })

--- a/src/components/load3d/menubar/CameraMenuGroup.vue
+++ b/src/components/load3d/menubar/CameraMenuGroup.vue
@@ -10,6 +10,27 @@
     <span v-if="!compact">{{ cameraTypeLabel }}</span>
   </button>
 
+  <button
+    v-if="hasCustomUp"
+    v-tooltip.bottom="
+      tip(useCustomUp ? t('load3d.useNaturalUp') : t('load3d.useCustomUp'))
+    "
+    :class="actionClass(false)"
+    type="button"
+    :aria-label="compact ? upLabel : undefined"
+    @click="toggleUp"
+  >
+    <i
+      :class="
+        cn(
+          useCustomUp ? 'icon-[lucide--compass]' : 'icon-[lucide--rotate-ccw]',
+          'size-4'
+        )
+      "
+    />
+    <span v-if="!compact">{{ upLabel }}</span>
+  </button>
+
   <Popover v-if="isPerspective" v-model:open="fovOpen">
     <PopoverTrigger as-child>
       <button
@@ -76,6 +97,21 @@ const cameraTypeLabel = computed(() =>
   cameraType.value ? t(`load3d.cameraType.${cameraType.value}`) : ''
 )
 const fov = computed(() => config.value?.fov ?? 0)
+const hasCustomUp = computed(() => config.value?.hasCustomUp === true)
+const useCustomUp = computed(
+  () => config.value?.hasCustomUp === true && config.value.useCustomUp
+)
+const upLabel = computed(() =>
+  useCustomUp.value
+    ? t('load3d.menuBar.customUp')
+    : t('load3d.menuBar.naturalUp')
+)
+
+function toggleUp() {
+  const current = config.value
+  if (!current?.hasCustomUp) return
+  current.useCustomUp = !current.useCustomUp
+}
 
 function switchCamera() {
   if (!config.value) return

--- a/src/components/load3d/menubar/CameraMenuGroup.vue
+++ b/src/components/load3d/menubar/CameraMenuGroup.vue
@@ -12,12 +12,10 @@
 
   <button
     v-if="hasCustomUp"
-    v-tooltip.bottom="
-      tip(useCustomUp ? t('load3d.useNaturalUp') : t('load3d.useCustomUp'))
-    "
+    v-tooltip.bottom="tip(upActionLabel)"
     :class="actionClass(false)"
     type="button"
-    :aria-label="compact ? upLabel : undefined"
+    :aria-label="compact ? upActionLabel : undefined"
     @click="toggleUp"
   >
     <i
@@ -100,6 +98,9 @@ const fov = computed(() => config.value?.fov ?? 0)
 const hasCustomUp = computed(() => config.value?.hasCustomUp === true)
 const useCustomUp = computed(
   () => config.value?.hasCustomUp === true && config.value.useCustomUp
+)
+const upActionLabel = computed(() =>
+  useCustomUp.value ? t('load3d.useNaturalUp') : t('load3d.useCustomUp')
 )
 const upLabel = computed(() =>
   useCustomUp.value

--- a/src/extensions/core/load3d/CameraManager.test.ts
+++ b/src/extensions/core/load3d/CameraManager.test.ts
@@ -360,6 +360,33 @@ describe('CameraManager', () => {
       expect(manager.activeCamera.up.toArray()).toEqual([0, 1, 0])
     })
 
+    it('clears a captured custom up when a later state omits the flag', () => {
+      manager.setCameraState(rolledState())
+      events.emitEvent.mockClear()
+
+      const { useCustomUp: _useCustomUp, ...plainState } = rolledState()
+      manager.setCameraState(plainState)
+
+      expect(manager.activeCamera.up.toArray()).toEqual([0, 1, 0])
+      expect(events.emitEvent).toHaveBeenCalledWith('cameraUpStateChange', {
+        hasCustomUp: false,
+        usingCustomUp: false
+      })
+    })
+
+    it('round-trips the captured up through persistence after toggling custom up off', () => {
+      manager.setCameraState(rolledState())
+      manager.setUseCustomUp(false)
+
+      const saved = manager.getCameraState()
+      manager.setCameraState(saved)
+      manager.setUseCustomUp(true)
+
+      expect(saved.customUp?.x).toBeCloseTo(-1)
+      expect(manager.activeCamera.up.x).toBeCloseTo(-1)
+      expect(manager.activeCamera.up.y).toBeCloseTo(0)
+    })
+
     it('restores a state saved after toggling custom up off with it still off', () => {
       manager.setCameraState(rolledState())
       manager.setUseCustomUp(false)

--- a/src/extensions/core/load3d/CameraManager.test.ts
+++ b/src/extensions/core/load3d/CameraManager.test.ts
@@ -277,9 +277,21 @@ describe('CameraManager', () => {
         target: new THREE.Vector3(0, 0, 0),
         zoom: 1,
         cameraType: 'perspective',
-        quaternion: { x: q.x, y: q.y, z: q.z, w: q.w }
+        quaternion: { x: q.x, y: q.y, z: q.z, w: q.w },
+        useCustomUp: true
       }
     }
+
+    it('keeps the world up when the state does not request a custom up', () => {
+      const { useCustomUp: _useCustomUp, ...plainState } = rolledState()
+      manager.setCameraState(plainState)
+
+      expect(manager.activeCamera.up.toArray()).toEqual([0, 1, 0])
+      expect(events.emitEvent).not.toHaveBeenCalledWith(
+        'cameraUpStateChange',
+        expect.anything()
+      )
+    })
 
     it('derives the camera up from an incoming quaternion and flags custom up', () => {
       manager.setCameraState(rolledState())
@@ -348,18 +360,28 @@ describe('CameraManager', () => {
       expect(manager.activeCamera.up.toArray()).toEqual([0, 1, 0])
     })
 
-    it('does not re-enable custom up on a later state restore after toggling it off', () => {
+    it('restores a state saved after toggling custom up off with it still off', () => {
       manager.setCameraState(rolledState())
       manager.setUseCustomUp(false)
+      const saved = manager.getCameraState()
       events.emitEvent.mockClear()
 
-      manager.setCameraState(rolledState())
+      manager.setCameraState(saved)
 
+      expect(saved.useCustomUp).toBe(false)
       expect(manager.activeCamera.up.toArray()).toEqual([0, 1, 0])
       expect(events.emitEvent).toHaveBeenCalledWith('cameraUpStateChange', {
         hasCustomUp: true,
         usingCustomUp: false
       })
+    })
+
+    it('omits useCustomUp from the state until a custom up is captured', () => {
+      expect(manager.getCameraState().useCustomUp).toBeUndefined()
+
+      manager.setCameraState(rolledState())
+
+      expect(manager.getCameraState().useCustomUp).toBe(true)
     })
   })
 })

--- a/src/extensions/core/load3d/CameraManager.test.ts
+++ b/src/extensions/core/load3d/CameraManager.test.ts
@@ -293,6 +293,20 @@ describe('CameraManager', () => {
       )
     })
 
+    it('does not fabricate a custom up when the state disables it without a stored up', () => {
+      manager.setCameraState({ ...rolledState(), useCustomUp: false })
+
+      expect(manager.activeCamera.up.toArray()).toEqual([0, 1, 0])
+      expect(manager.getCameraState().customUp).toBeUndefined()
+      expect(events.emitEvent).not.toHaveBeenCalledWith(
+        'cameraUpStateChange',
+        expect.anything()
+      )
+
+      manager.setUseCustomUp(true)
+      expect(manager.activeCamera.up.toArray()).toEqual([0, 1, 0])
+    })
+
     it('derives the camera up from an incoming quaternion and flags custom up', () => {
       manager.setCameraState(rolledState())
 

--- a/src/extensions/core/load3d/CameraManager.test.ts
+++ b/src/extensions/core/load3d/CameraManager.test.ts
@@ -417,6 +417,20 @@ describe('CameraManager', () => {
       })
     })
 
+    it('restores a stored custom up without a quaternion', () => {
+      const { quaternion: _quaternion, ...noQuaternion } = rolledState()
+      manager.setCameraState({
+        ...noQuaternion,
+        customUp: { x: 0, y: 0, z: 1 }
+      })
+
+      expect(manager.activeCamera.up.toArray()).toEqual([0, 0, 1])
+      expect(events.emitEvent).toHaveBeenCalledWith('cameraUpStateChange', {
+        hasCustomUp: true,
+        usingCustomUp: true
+      })
+    })
+
     it('omits useCustomUp from the state until a custom up is captured', () => {
       expect(manager.getCameraState().useCustomUp).toBeUndefined()
 

--- a/src/extensions/core/load3d/CameraManager.ts
+++ b/src/extensions/core/load3d/CameraManager.ts
@@ -162,6 +162,7 @@ export class CameraManager implements CameraManagerInterface {
           : (this.activeCamera as THREE.PerspectiveCamera).zoom,
       cameraType: this.getCurrentCameraType(),
       quaternion: { x, y, z, w },
+      ...(this.customUp !== null && { useCustomUp: this.usingCustomUp }),
       fov: this.perspectiveCamera.fov,
       aspect: this.perspectiveCamera.aspect,
       near: activeCamera.near,
@@ -199,7 +200,7 @@ export class CameraManager implements CameraManagerInterface {
       this.activeCamera.updateProjectionMatrix()
     }
 
-    if (state.quaternion) {
+    if (state.quaternion && state.useCustomUp !== undefined) {
       const q = new THREE.Quaternion(
         state.quaternion.x,
         state.quaternion.y,
@@ -208,10 +209,11 @@ export class CameraManager implements CameraManagerInterface {
       )
       if (q.lengthSq() === 0) q.identity()
       const appliedUp = new THREE.Vector3(0, 1, 0).applyQuaternion(q)
-      const isFirstDerivation = this.customUp === null
       this.customUp = appliedUp.clone()
-      if (isFirstDerivation) this.usingCustomUp = true
-      if (this.usingCustomUp) this.activeCamera.up.copy(appliedUp)
+      this.usingCustomUp = state.useCustomUp
+      this.activeCamera.up.copy(
+        this.usingCustomUp ? appliedUp : new THREE.Vector3(0, 1, 0)
+      )
       this.eventManager.emitEvent('cameraUpStateChange', {
         hasCustomUp: true,
         usingCustomUp: this.usingCustomUp

--- a/src/extensions/core/load3d/CameraManager.ts
+++ b/src/extensions/core/load3d/CameraManager.ts
@@ -162,7 +162,14 @@ export class CameraManager implements CameraManagerInterface {
           : (this.activeCamera as THREE.PerspectiveCamera).zoom,
       cameraType: this.getCurrentCameraType(),
       quaternion: { x, y, z, w },
-      ...(this.customUp !== null && { useCustomUp: this.usingCustomUp }),
+      ...(this.customUp !== null && {
+        useCustomUp: this.usingCustomUp,
+        customUp: {
+          x: this.customUp.x,
+          y: this.customUp.y,
+          z: this.customUp.z
+        }
+      }),
       fov: this.perspectiveCamera.fov,
       aspect: this.perspectiveCamera.aspect,
       near: activeCamera.near,
@@ -208,7 +215,17 @@ export class CameraManager implements CameraManagerInterface {
         state.quaternion.w
       )
       if (q.lengthSq() === 0) q.identity()
-      const appliedUp = new THREE.Vector3(0, 1, 0).applyQuaternion(q)
+      const storedUp = state.customUp
+        ? new THREE.Vector3(
+            state.customUp.x,
+            state.customUp.y,
+            state.customUp.z
+          )
+        : null
+      const appliedUp =
+        storedUp && storedUp.lengthSq() > 0
+          ? storedUp
+          : new THREE.Vector3(0, 1, 0).applyQuaternion(q)
       this.customUp = appliedUp.clone()
       this.usingCustomUp = state.useCustomUp
       this.activeCamera.up.copy(

--- a/src/extensions/core/load3d/CameraManager.ts
+++ b/src/extensions/core/load3d/CameraManager.ts
@@ -9,12 +9,12 @@ import {
 } from './interfaces'
 
 function resolveIncomingCustomUp(state: CameraState): THREE.Vector3 | null {
-  if (!state.quaternion || state.useCustomUp === undefined) return null
+  if (state.useCustomUp === undefined) return null
   const storedUp = state.customUp
     ? new THREE.Vector3(state.customUp.x, state.customUp.y, state.customUp.z)
     : null
   if (storedUp && storedUp.lengthSq() > 0) return storedUp
-  if (!state.useCustomUp) return null
+  if (!state.useCustomUp || !state.quaternion) return null
   const q = new THREE.Quaternion(
     state.quaternion.x,
     state.quaternion.y,

--- a/src/extensions/core/load3d/CameraManager.ts
+++ b/src/extensions/core/load3d/CameraManager.ts
@@ -8,6 +8,23 @@ import {
   type EventManagerInterface
 } from './interfaces'
 
+function resolveIncomingCustomUp(state: CameraState): THREE.Vector3 | null {
+  if (!state.quaternion || state.useCustomUp === undefined) return null
+  const storedUp = state.customUp
+    ? new THREE.Vector3(state.customUp.x, state.customUp.y, state.customUp.z)
+    : null
+  if (storedUp && storedUp.lengthSq() > 0) return storedUp
+  if (!state.useCustomUp) return null
+  const q = new THREE.Quaternion(
+    state.quaternion.x,
+    state.quaternion.y,
+    state.quaternion.z,
+    state.quaternion.w
+  )
+  if (q.lengthSq() === 0) q.identity()
+  return new THREE.Vector3(0, 1, 0).applyQuaternion(q)
+}
+
 export class CameraManager implements CameraManagerInterface {
   perspectiveCamera: THREE.PerspectiveCamera
   orthographicCamera: THREE.OrthographicCamera
@@ -207,29 +224,12 @@ export class CameraManager implements CameraManagerInterface {
       this.activeCamera.updateProjectionMatrix()
     }
 
-    if (state.quaternion && state.useCustomUp !== undefined) {
-      const q = new THREE.Quaternion(
-        state.quaternion.x,
-        state.quaternion.y,
-        state.quaternion.z,
-        state.quaternion.w
-      )
-      if (q.lengthSq() === 0) q.identity()
-      const storedUp = state.customUp
-        ? new THREE.Vector3(
-            state.customUp.x,
-            state.customUp.y,
-            state.customUp.z
-          )
-        : null
-      const appliedUp =
-        storedUp && storedUp.lengthSq() > 0
-          ? storedUp
-          : new THREE.Vector3(0, 1, 0).applyQuaternion(q)
-      this.customUp = appliedUp.clone()
-      this.usingCustomUp = state.useCustomUp
+    const incomingUp = resolveIncomingCustomUp(state)
+    if (incomingUp) {
+      this.customUp = incomingUp
+      this.usingCustomUp = state.useCustomUp === true
       this.activeCamera.up.copy(
-        this.usingCustomUp ? appliedUp : new THREE.Vector3(0, 1, 0)
+        this.usingCustomUp ? incomingUp : new THREE.Vector3(0, 1, 0)
       )
       this.eventManager.emitEvent('cameraUpStateChange', {
         hasCustomUp: true,

--- a/src/extensions/core/load3d/interfaces.ts
+++ b/src/extensions/core/load3d/interfaces.ts
@@ -38,6 +38,7 @@ export interface CameraState {
   cameraType: CameraType
   quaternion?: CameraQuaternion
   useCustomUp?: boolean
+  customUp?: { x: number; y: number; z: number }
   fov?: number
   aspect?: number
   near?: number

--- a/src/extensions/core/load3d/interfaces.ts
+++ b/src/extensions/core/load3d/interfaces.ts
@@ -37,6 +37,7 @@ export interface CameraState {
   zoom: number
   cameraType: CameraType
   quaternion?: CameraQuaternion
+  useCustomUp?: boolean
   fov?: number
   aspect?: number
   near?: number

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2244,7 +2244,9 @@
       "deleteRecording": "Delete Recording",
       "videoRecordingTooltip": "Video recording of the scene [mp4]",
       "switchProjection": "Switch projection",
-      "originalMaterialOnly": "Original material only"
+      "originalMaterialOnly": "Original material only",
+      "customUp": "Custom up",
+      "naturalUp": "Natural up"
     },
     "materialModes": {
       "normal": "Normal",


### PR DESCRIPTION
## Summary
setCameraState treated any quaternion-bearing state as a custom up and auto-enabled it, so restoring a node's own saved orbit state tilted the camera up vector and compounded roll on every save/restore cycle.

Custom up now applies only when the state explicitly carries useCustomUp, which getCameraState round-trips once a custom up has been captured. The camera_info producer (CreateCameraInfo backend) sets the flag. Add the Custom up / Natural up toggle to the menubar camera group so flagged states can be switched back to the world up.

Need BE https://github.com/Comfy-Org/ComfyUI/pull/14964