### PR TITLE
test: report Core custom-node exclusions

### DIFF
--- a/.github/workflows/ci-tests-custom-nodes.yaml
+++ b/.github/workflows/ci-tests-custom-nodes.yaml
@@ -248,7 +248,7 @@ jobs:
           restore-keys: cn-packs-v3-${{ env.SHARD_SLUG }}-
 
       - name: Report excluded packs
-        if: always() && env.CUSTOM_NODES_MANIFEST == 'cloud' && matrix.shard == '1/5'
+        if: always() && (matrix.shard == 'core' || (env.CUSTOM_NODES_MANIFEST == 'cloud' && matrix.shard == '1/5'))
         run: pnpm custom-node-quarantine
 
       - name: Prepare manifest custom node sources

--- a/scripts/customNodeQuarantine.test.ts
+++ b/scripts/customNodeQuarantine.test.ts
@@ -1,0 +1,28 @@
+import { spawnSync } from 'node:child_process'
+
+import { expect, it } from 'vitest'
+
+it('reports only exclusions applicable to the Core manifest', () => {
+  const result = spawnSync(
+    'pnpm',
+    ['exec', 'tsx', 'scripts/customNodeQuarantine.ts'],
+    {
+      cwd: process.cwd(),
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        CUSTOM_NODES_MANIFEST: 'core',
+        CUSTOM_NODES_SHARD: '1/1'
+      }
+    }
+  )
+  const output = `${result.stdout}${result.stderr}`
+
+  expect(result.status, output).toBe(0)
+  expect(output).toContain('Pack-level coverage exclusions - **0 of 6 packs**')
+  expect(output).toContain(
+    'S2 - SKIP - NODE NOT EXERCISED - ComfyUI-VideoHelperSuite / VHS_BatchManager'
+  )
+  expect(output).not.toContain('ComfyUI-LivePortraitKJ')
+  expect(output).not.toContain('**PROBLEM**')
+})

--- a/scripts/customNodeQuarantine.ts
+++ b/scripts/customNodeQuarantine.ts
@@ -18,6 +18,7 @@ import { promisify } from 'node:util'
 import type { QuarantinedPack } from '../browser_tests/fixtures/customNode/manifest'
 import { connectivityExpectations } from '../browser_tests/fixtures/customNode/connectivityExpectations'
 import {
+  customNodesManifest,
   FRONTEND_ASSET_EXCLUSIONS,
   loadAllManifestTargets,
   loadFullManifest,
@@ -165,7 +166,7 @@ async function stillBroken(
   }
 }
 
-const quarantine = loadPackQuarantine()
+const quarantine = customNodesManifest() === 'cloud' ? loadPackQuarantine() : {}
 const manifest = new Map(loadFullManifest().map((e) => [e.pack, e]))
 const unjoinedYamlPacks = loadUnjoinedYamlPacks()
 const manifestPackByFoldedName = new Map(
@@ -310,8 +311,9 @@ for (const exclusion of applicableTierNodeExclusions) {
 }
 
 const nodeExclusions = [
-  ...Object.entries(ROUNDTRIP_NODE_LOSS_EXPECTATIONS_LITEGRAPH).flatMap(
-    ([pack, nodes]) =>
+  ...Object.entries(ROUNDTRIP_NODE_LOSS_EXPECTATIONS_LITEGRAPH)
+    .filter(([pack]) => manifest.has(pack))
+    .flatMap(([pack, nodes]) =>
       Object.entries(nodes).map(([nodeType, exclusion]) => ({
         label: `${nodeType} save/reload`,
         pack,
@@ -320,16 +322,18 @@ const nodeExclusions = [
         tier: 'S3' as const,
         mode: 'expected-failure' as const
       }))
-  ),
-  ...Object.entries(FRONTEND_ASSET_EXCLUSIONS).map(([pack, exclusion]) => ({
-    label: `${pack} frontend assets`,
-    pack,
-    reason: exclusion.reason,
-    restore: exclusion.restore,
-    scope: 'frontend asset registration',
-    tier: 'S11' as const,
-    mode: 'expected-failure' as const
-  })),
+    ),
+  ...Object.entries(FRONTEND_ASSET_EXCLUSIONS)
+    .filter(([pack]) => manifest.has(pack))
+    .map(([pack, exclusion]) => ({
+      label: `${pack} frontend assets`,
+      pack,
+      reason: exclusion.reason,
+      restore: exclusion.restore,
+      scope: 'frontend asset registration',
+      tier: 'S11' as const,
+      mode: 'expected-failure' as const
+    })),
   ...consoleErrorExclusionsForPacks([...manifest.keys()]),
   ...connectivityExclusions
 ].sort(


### PR DESCRIPTION
## Summary

Make the exclusion reporter manifest-aware so Core S-tier skips are visible in the Actions summary without evaluating Cloud-only debt.

## Changes

- **What**: Scope pack quarantine and global acceptance ledgers to the selected manifest; run the reporter for Core and Cloud shard 1 under `always()`.

## Review Focus

The reporter remains fail-closed for stale entries applicable to the selected manifest. It does not suppress or reinterpret any exclusion.

## Validation

- Red proof: [32921562407](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/32921562407) failed only because four Cloud packs and two Cloud node ledgers leaked into the Core report.
- Local green: Core reports 0 whole-pack skips plus both VHS S2 node exclusions; Cloud retains 5 whole-pack exclusions and its full acceptance ledger.
- Full green CI is running on the fix commit.