### PR TITLE
fix(assets): register SAM3DBody_Loader in model node mappings

### DIFF
--- a/src/platform/assets/mappings/modelNodeMappings.ts
+++ b/src/platform/assets/mappings/modelNodeMappings.ts
@@ -23,7 +23,7 @@ export const MODEL_NODE_MAPPINGS: ReadonlyArray<
   // Also unmapped: segformer_b2_clothes, segformer_b3_clothes,
   // segformer_b3_fashion, lama, layer_model, LLM/llava-llama-3-8b-*,
   // LLM/Llama-3.2-3B-Instruct, LLM/Florence-2-large-PromptGen-v2.0
-  // (id widgets); sam3, sharp, BEN, BiRefNet/pth (node/widget names don't
+  // (id widgets); sharp, BEN, BiRefNet/pth (node/widget names don't
   // exist); depthanything, CogVideo/GGUF, checkpoints/dynamicrafter/*,
   // transparent-background (asset names not accepted by the node's enum);
   // interpolation, clip, onnx (empty or unreachable dirs).
@@ -96,6 +96,7 @@ export const MODEL_NODE_MAPPINGS: ReadonlyArray<
 
   // ---- Detection models (vitpose, yolo) ----
   ['detection', 'OnnxDetectionModelLoader', 'yolo_model'],
+  ['detection', 'SAM3DBody_Loader', 'model_file'],
 
   // ---- CogVideoX (comfyui-cogvideoxwrapper) ----
   ['CogVideo', 'DownloadAndLoadCogVideoModel', ''],


### PR DESCRIPTION
## Summary

`SAM3DBody_Loader` is missing from `MODEL_NODE_MAPPINGS`, so on cloud its model widget is treated as asset-browser ineligible and the missing-model panel files it under "Import Not Supported" — telling users a core node is a custom node.

## Changes

- **What**: add `['detection', 'SAM3DBody_Loader', 'model_file']` to `MODEL_NODE_MAPPINGS`, and drop the now-stale `sam3` entry from the "node/widget names don't exist" comment.

### Repro

Latest SAM3D Body template, `Load SAM3D Body Model` node, with the model present:

> **Import Not Supported** — Nodes that reference the models below do not support imported models. Open the node to choose a supported built-in model, or replace it with a standard node that supports imported models.
> `sam_3d_body_dinov3_bf16.safetensors`

### Why it happens

```
missingModelPipeline.ts:114  isAssetBrowserWidget = assetService.shouldUseAssetBrowser
assetService.ts:559          isAssetBrowserEligible →
                             getRegisteredNodeTypes()[nodeType] === widgetName
                             → SAM3DBody_Loader absent → false
missingModelGrouping.ts:29   !isAssetSupported && isCloud → UNSUPPORTED
MissingModelCard.vue:52      renders `customNodeDownloadDisabled`
```

The copy on that branch is the only string available, which is why a core node is described as a custom one.

### Values verified against ComfyUI v0.34.0

`comfy_extras/nodes_sam3d_body.py` (added in comfyanonymous/ComfyUI#14370):

- `node_id="SAM3DBody_Loader"` — note `"Load SAM3D Body Model"` is only `display_name`; this table keys on comfyClass
- widget: `io.Combo.Input("model_file", options=folder_paths.get_filename_list("detection"))`
- folder: `detection`, also used by `get_full_path_or_raise("detection", model_file)`

Cross-checked against this repo's own generated `src/locales/en/nodeDefs.json`, which already lists `SAM3DBody_Loader` with a single `model_file` input — confirming the frontend knows it as a core node and only the mapping was missing.

## Review Focus

- `detection` already maps to `OnnxDetectionModelLoader`/`yolo_model`. This is additive: `modelToNodeMap` stores an array per folder, and `registeredNodeTypes` flattens to `nodeDef.name → provider.key`, so both nodes register independently.
- Sibling nodes `SAM3DBody_Predict` and `SAM3DBody_FaceExpression` take the model over a link rather than a widget, so they correctly need no entry.
- **Testing note**: `assetService.test.ts` and `startModelNodeDragFromAsset.test.ts` report 22 failed / 44 passed both with and without this change — identical on `origin/main` at `a31f654248`, so those failures are pre-existing and unrelated. Flagging rather than hiding it; worth a look separately.