### PR TITLE
refactor(image-compare): drop the dead widget callback invocation

### DIFF
--- a/src/extensions/core/imageCompare.ts
+++ b/src/extensions/core/imageCompare.ts
@@ -40,7 +40,6 @@ useExtensionService().registerExtension({
 
       if (widget) {
         widget.value = { beforeImages, afterImages }
-        widget.callback?.(widget.value)
       }
     }
   }


### PR DESCRIPTION
## Summary
The imagecompare widget is created with a no-op callback and nothing assigns another one; the store-backed value write already propagates to the Vue component, so invoking the callback after the write does nothing.