### PR TITLE
fix: preserve unknown billing poll failures

### DIFF
--- a/src/platform/workspace/stores/billingOperationStore.test.ts
+++ b/src/platform/workspace/stores/billingOperationStore.test.ts
@@ -756,15 +756,36 @@ describe('billingOperationStore', () => {
         cycle: undefined,
         checkout_type: undefined,
         payment_intent_source: undefined,
-        failure_category: 'provider_decline',
+        failure_category: 'unknown',
         duration_ms: expect.any(Number)
       })
     })
 
-    it('categorizes a topup poll failure as a provider decline too', async () => {
+    it('categorizes an unclassified topup poll failure as unknown', async () => {
       vi.mocked(workspaceApi.getBillingOpStatus).mockResolvedValue({
         id: 'op-1',
         status: 'failed',
+        started_at: new Date().toISOString()
+      })
+
+      const store = useBillingOperationStore()
+      void store.startOperation('op-1', 'topup')
+
+      await vi.advanceTimersByTimeAsync(0)
+
+      expect(mockTrackBillingEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          operation_type: 'topup',
+          failure_category: 'unknown'
+        })
+      )
+    })
+
+    it('uses a structured decline reason for provider declines', async () => {
+      vi.mocked(workspaceApi.getBillingOpStatus).mockResolvedValue({
+        id: 'op-1',
+        status: 'failed',
+        decline_reason: 'card_declined',
         started_at: new Date().toISOString()
       })
 

--- a/src/platform/workspace/stores/billingOperationStore.ts
+++ b/src/platform/workspace/stores/billingOperationStore.ts
@@ -301,7 +301,11 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
       }
 
       if (response.status === 'failed') {
-        handleFailure(opId, response.error_message ?? null)
+        handleFailure(
+          opId,
+          response.error_message ?? null,
+          response.decline_reason
+        )
         return
       }
 
@@ -733,7 +737,11 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
     resolveTerminal(opId)
   }
 
-  function handleFailure(opId: string, errorMessage: string | null) {
+  function handleFailure(
+    opId: string,
+    errorMessage: string | null,
+    declineReason?: BillingDeclineReason
+  ) {
     const operation = operations.value.get(opId)
     if (!operation) return
 
@@ -751,7 +759,8 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
       : categorizePollFailure(
           operation.type,
           errorMessage,
-          Boolean(operation.downgradeToPersonal)
+          Boolean(operation.downgradeToPersonal),
+          declineReason
         )
     telemetry?.trackBillingEvent({
       operation: 'operation',
@@ -958,27 +967,23 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
     resolveTerminal(opId)
   }
 
-  /**
-   * No caught JS error here — only the backend's free-form `error_message`, if
-   * any. `cancel` and zero-payment operations (e.g. downgrade-to-personal,
-   * which removes members / changes tier but never touches a card) can't be a
-   * provider decline, so they're always an api rejection. For payment-bearing
-   * `subscription`/`topup` polls, a message naming a connectivity/system
-   * failure isn't a decline either; only fall back to `provider_decline` when
-   * the backend gave no more specific signal.
-   */
   function categorizePollFailure(
     type: OperationType,
     errorMessage: string | null,
-    isZeroPaymentOperation: boolean
+    isZeroPaymentOperation: boolean,
+    declineReason?: BillingDeclineReason
   ): BillingFailure['failure_category'] {
     if (type === 'cancel' || isZeroPaymentOperation) return 'api_rejected'
+
+    if (declineReason && declineReason !== 'generic') {
+      return 'provider_decline'
+    }
 
     if (errorMessage && /network|connection|unreachable/i.test(errorMessage)) {
       return 'network'
     }
 
-    return 'provider_decline'
+    return 'unknown'
   }
 
   function failureMessage(type: OperationType) {


### PR DESCRIPTION
## Summary

Preserve ambiguous billing poll failures as unknown instead of counting them as provider declines.

## Changes

- **What**: Use the backend decline_reason to identify provider declines; keep missing or generic reasons unknown.
- **Tests**: Cover both ambiguous failures and a structured card_declined response.

## Review Focus

Confirm the telemetry categories match the backend contract in BE-4805.