### PR TITLE
ci(backport): use a PR-readable token for the whole backport job

### DIFF
--- a/.github/workflows/pr-backport.yaml
+++ b/.github/workflows/pr-backport.yaml
@@ -63,9 +63,11 @@ jobs:
             exit 1
           fi
         env:
-          # Same token the PR-creation step uses; GITHUB_TOKEN was not able to
-          # read the PR here even with pull-requests: write.
-          GH_TOKEN: ${{ secrets.PR_GH_TOKEN || secrets.GITHUB_TOKEN }}
+          # PR_GH_TOKEN is what the PR-creation step below already uses, and
+          # GH_TOKEN is the repo's other configured PAT. The auto-provided
+          # GITHUB_TOKEN could not read the PR here even with
+          # pull-requests: write, so it is not used as a fallback.
+          GH_TOKEN: ${{ secrets.PR_GH_TOKEN || secrets.GH_TOKEN }}
           GH_REPO: ${{ github.repository }}
 
       - name: Checkout repository

--- a/.github/workflows/pr-backport.yaml
+++ b/.github/workflows/pr-backport.yaml
@@ -43,9 +43,11 @@ jobs:
             exit 1
           fi
 
-          # Validate PR exists and is merged
-          if ! gh pr view "${{ inputs.pr_number }}" --json merged >/dev/null 2>&1; then
-            echo "::error::PR #${{ inputs.pr_number }} not found or inaccessible."
+          # Validate PR exists and is merged. The gh error is surfaced rather
+          # than discarded: an auth failure and a genuinely missing PR are
+          # indistinguishable once it is swallowed.
+          if ! PR_VIEW_ERR=$(gh pr view "${{ inputs.pr_number }}" --json merged 2>&1 >/dev/null); then
+            echo "::error::PR #${{ inputs.pr_number }} not found or inaccessible: ${PR_VIEW_ERR}"
             exit 1
           fi
 
@@ -61,7 +63,9 @@ jobs:
             exit 1
           fi
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Same token the PR-creation step uses; GITHUB_TOKEN was not able to
+          # read the PR here even with pull-requests: write.
+          GH_TOKEN: ${{ secrets.PR_GH_TOKEN || secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
 
       - name: Checkout repository

--- a/.github/workflows/pr-backport.yaml
+++ b/.github/workflows/pr-backport.yaml
@@ -33,6 +33,12 @@ jobs:
       pull-requests: write
       issues: write
 
+    # `gh pr view <n>` fails with the auto-provided GITHUB_TOKEN even with
+    # pull-requests: write, which is what silently broke manual dispatch.
+    # Steps needing a different token still set GH_TOKEN themselves.
+    env:
+      GH_TOKEN: ${{ secrets.PR_GH_TOKEN || secrets.GH_TOKEN }}
+
     steps:
       - name: Validate inputs for manual triggers
         if: github.event_name == 'workflow_dispatch'
@@ -63,11 +69,6 @@ jobs:
             exit 1
           fi
         env:
-          # PR_GH_TOKEN is what the PR-creation step below already uses, and
-          # GH_TOKEN is the repo's other configured PAT. The auto-provided
-          # GITHUB_TOKEN could not read the PR here even with
-          # pull-requests: write, so it is not used as a fallback.
-          GH_TOKEN: ${{ secrets.PR_GH_TOKEN || secrets.GH_TOKEN }}
           GH_REPO: ${{ github.repository }}
 
       - name: Checkout repository
@@ -88,7 +89,6 @@ jobs:
       - name: Collect backport targets
         id: targets
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
         run: |
           TARGETS=()
@@ -157,7 +157,6 @@ jobs:
           FORCE_RERUN_INPUT: >-
             ${{ github.event_name == 'workflow_dispatch' && inputs.force_rerun
             || 'false' }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: >-
             ${{ github.event_name == 'workflow_dispatch' && inputs.pr_number
             || github.event.pull_request.number }}
@@ -240,7 +239,6 @@ jobs:
         id: backport
         env:
           PR_NUMBER: ${{ github.event_name == 'workflow_dispatch' && inputs.pr_number || github.event.pull_request.number }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
         run: |
           FAILED=""
@@ -545,5 +543,3 @@ jobs:
       - name: Remove needs-backport label
         if: steps.filter-targets.outputs.skip != 'true' && success()
         run: gh pr edit ${{ github.event_name == 'workflow_dispatch' && inputs.pr_number || github.event.pull_request.number }} --remove-label "needs-backport"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-backport.yaml
+++ b/.github/workflows/pr-backport.yaml
@@ -400,7 +400,6 @@ jobs:
       - name: Comment on failures
         if: steps.filter-targets.outputs.skip != 'true' && failure() && steps.backport.outputs.failed
         env:
-          GH_TOKEN: ${{ github.token }}
           BACKPORT_AGENT_PROMPT_TEMPLATE: |
             Backport PR #${PR_NUMBER} (${PR_URL}) to ${target}.
             Cherry-pick merge commit ${MERGE_COMMIT} onto new branch


### PR DESCRIPTION
Manual backport dispatch has been failing on every PR with a single opaque line: `PR #<n> not found or inaccessible.`

Two causes, both fixed here.

### 1. The error was swallowed
The lookup redirected stderr to `/dev/null`, so an auth failure and a genuinely missing PR produced identical output. The `gh` error is now surfaced in the annotation.

### 2. The job used a token that cannot read PRs
`gh pr view <n>` fails with the auto-provided `GITHUB_TOKEN` **even under `permissions: pull-requests: write`**. Interestingly `gh pr list` and `gh pr comment` work with it — only the PR-number lookups fail, which is why the automatic path kept working and only manual dispatch broke.

Fixing just the validation step would have moved the failure one step later: `Collect backport targets` and `Backport commits` do the same lookup. So the working token is now a **job-level default**, and the two steps that intentionally use a different token still set it themselves.

### Evidence
Runs `32917113697` (#15804) and `32917122198` (#15915) both died in `Validate inputs` with `##[error]PR #<n> not found or inaccessible` — both PRs were merged and carried `needs-backport`.

### One token for the whole job
Five steps were on the automatic token. Rather than repeat the expression, the working token is a job-level default. `Create PR for each successful backport` still pins `PR_GH_TOKEN` deliberately — PR creation must be the bot.

Removing the `github.token` override on `Comment on failures` is safe: it posts as `comfy-pr-bot` instead of `github-actions[bot]` (both bots), and the three `issue_comment` workflows in this repo are gated on specific command bodies (`recheck` and friends), so a failure comment cannot trigger them.

### Not fixed here
This does not make conflicted cherry-picks succeed. A backport whose dependency is not on the target branch still fails on conflict, which is a separate problem.
