### PR TITLE
refactor: rehydrate input slots on write

### DIFF
--- a/src/lib/litegraph/src/LGraphNode.reactivity.test.ts
+++ b/src/lib/litegraph/src/LGraphNode.reactivity.test.ts
@@ -46,6 +46,29 @@ describe('_setConcreteSlots', () => {
 
     expect(onChange).toHaveBeenCalledTimes(1)
   })
+
+  test('reading an upgraded slot does not notify again', async () => {
+    const node = new LGraphNode('test')
+    const slots = computed(() => [...node.inputs])
+    const onChange = vi.fn()
+    watch(slots, onChange)
+    expect(slots.value).toEqual([])
+
+    node.inputs[0] = {
+      name: 'input',
+      type: 'INT',
+      link: null,
+      boundingRect: new Float64Array(4)
+    }
+    await nextTick()
+    expect(onChange).toHaveBeenCalledOnce()
+
+    void node.inputs
+    void node.inputs
+    await nextTick()
+
+    expect(onChange).toHaveBeenCalledOnce()
+  })
 })
 
 describe('widgets array reactivity', () => {

--- a/src/lib/litegraph/src/LGraphNode.ts
+++ b/src/lib/litegraph/src/LGraphNode.ts
@@ -61,6 +61,7 @@ import {
   outputHasLinks,
   outputLinks
 } from './node/slotLinks'
+import { createInputSlotView } from './node/slotDescriptorView'
 import { initializeWidgetsView } from './node/widgetsView'
 import {
   extensionConfigureView,
@@ -381,10 +382,6 @@ export class LGraphNode
 
   /** Assignment splices in place: the `shallowReactive` array identity is what the renderer tracks. */
   get inputs(): INodeInputSlot[] {
-    for (const [index, slot] of this._inputs.entries()) {
-      const concrete = toClass(NodeInputSlot, slot, this)
-      if (concrete !== slot) this._inputs[index] = concrete
-    }
     return this._inputs
   }
 
@@ -1010,7 +1007,8 @@ export class LGraphNode
   constructor(title: string, type?: string) {
     initializeWidgetsView(this)
     this._state = createNodeShellState(title, type, this.title_mode)
-    this._inputs = this._state.inputs
+    this._inputs = createInputSlotView(this, this._state.inputs)
+    this._state.inputs = this._inputs
     this._outputs = this._state.outputs
     for (const property of [
       'inputs',

--- a/src/lib/litegraph/src/LGraphNode.ts
+++ b/src/lib/litegraph/src/LGraphNode.ts
@@ -1008,7 +1008,6 @@ export class LGraphNode
     initializeWidgetsView(this)
     this._state = createNodeShellState(title, type, this.title_mode)
     this._inputs = createInputSlotView(this, this._state.inputs)
-    this._state.inputs = this._inputs
     this._outputs = this._state.outputs
     for (const property of [
       'inputs',

--- a/src/lib/litegraph/src/node/slotDescriptorView.test.ts
+++ b/src/lib/litegraph/src/node/slotDescriptorView.test.ts
@@ -44,7 +44,7 @@ describe('slot identity', () => {
     expect(sourceSlot.node).toBe(source)
   })
 
-  it('upgrades extension-assigned inputs when the view is read', () => {
+  it('upgrades extension-assigned inputs when they are written', () => {
     const node = new LGraphNode('Node')
     const input = {
       name: 'input',
@@ -55,8 +55,8 @@ describe('slot identity', () => {
 
     node.inputs = [input]
 
-    expect(node._state.inputs[0]).toBe(input)
     expect(node.inputs[0]).toBeInstanceOf(NodeInputSlot)
+    expect(node._state.inputs[0]).toBe(node.inputs[0])
   })
 
   it('preserves native indexOf behavior for arbitrary values', () => {

--- a/src/lib/litegraph/src/node/slotDescriptorView.test.ts
+++ b/src/lib/litegraph/src/node/slotDescriptorView.test.ts
@@ -55,6 +55,7 @@ describe('slot identity', () => {
 
     node.inputs = [input]
 
+    expect(node._state.inputs).not.toBe(node.inputs)
     expect(node.inputs[0]).toBeInstanceOf(NodeInputSlot)
     expect(node._state.inputs[0]).toBe(node.inputs[0])
   })

--- a/src/lib/litegraph/src/node/slotDescriptorView.ts
+++ b/src/lib/litegraph/src/node/slotDescriptorView.ts
@@ -1,0 +1,39 @@
+import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
+import type { INodeInputSlot } from '@/lib/litegraph/src/interfaces'
+import { NodeInputSlot } from '@/lib/litegraph/src/node/NodeInputSlot'
+import { toClass } from '@/lib/litegraph/src/utils/type'
+
+export function createInputSlotView(
+  node: LGraphNode,
+  inputs: INodeInputSlot[]
+): INodeInputSlot[] {
+  return new Proxy(inputs, {
+    set(target, property, value: unknown, receiver) {
+      const input =
+        isArrayIndex(property) && isInputSlot(value)
+          ? toClass(NodeInputSlot, value, node)
+          : value
+      return Reflect.set(target, property, input, receiver)
+    }
+  })
+}
+
+function isArrayIndex(property: string | symbol): property is string {
+  if (typeof property !== 'string') return false
+  const index = Number(property)
+  return (
+    Number.isInteger(index) &&
+    index >= 0 &&
+    index < 2 ** 32 - 1 &&
+    String(index) === property
+  )
+}
+
+function isInputSlot(value: unknown): value is INodeInputSlot {
+  return (
+    value !== null &&
+    typeof value === 'object' &&
+    'name' in value &&
+    'type' in value
+  )
+}


### PR DESCRIPTION
## Summary

Prototype write-time input-slot rehydration so #15779 keeps PromptChain compatibility without scanning or mutating from the `inputs` getter.

## Changes

- **What**: Add a stable input-slot compatibility view over the store-held container that upgrades plain indexed writes while preserving existing `NodeInputSlot` instances and collection identity.
- **Tests**: Preserve the compatibility suite, assert the compatibility view remains separate from state, and assert repeated reads do not trigger additional reactive updates.

## Review Focus

This is stacked on #15779 as an alternative implementation. Confirm the separate proxy retains native array mutation/reactivity semantics while writes remain reflected in `node._state.inputs`. The parent getter scan measured 3.0× to 17.9× slower than a pure getter across 1 to 32 slots; this prototype moves that work to slot writes.

Verification: 1,429 LiteGraph tests passed (5 skipped); `pnpm typecheck`; targeted oxfmt, oxlint, and ESLint; pre-push knip.

<details>
<summary>Architecture note for agents/posterity</summary>

The [DQ-08 primer](https://app.notion.com/p/comfy-org/DQ-08-Primer-Slot-representation-authority-3c76d73d36508171a2c9f82e231e9c92) and [ADR-0017](https://github.com/Comfy-Org/ComfyUI_frontend/blob/main/docs/adr/0017-id-based-slot-records-are-the-slot-destination.md) establish that ID-keyed store records are the destination authority. Extension-visible slot-class arrays are derived compatibility views, while plain descriptors belong at persistence boundaries.

This PR is only a transitional mitigation under [EX-001](https://github.com/Comfy-Org/ComfyUI_frontend/blob/main/docs/exceptions-log.md#ex-001-slot-metadata-remains-class-owned-during-migration). It deliberately leaves `node._state.inputs` as the store-held container and keeps the stable `node.inputs` compatibility Proxy separate. Extension-assigned plain slots are upgraded on write into the underlying array, avoiding mutation and slot-count-dependent scanning on reads.

The Proxy and class-owned slot array are not a new long-term authority. Once ID-keyed records land, the compatibility view must read and write those records, and this transitional layer must be removed according to EX-001's exit condition.

</details>