### PR TITLE
fix(billing): restore Resubscribe on the legacy rail and centralize the policy

### DIFF
--- a/src/platform/workspace/components/CurrentUserPopoverWorkspace.test.ts
+++ b/src/platform/workspace/components/CurrentUserPopoverWorkspace.test.ts
@@ -77,7 +77,12 @@ vi.mock('@/platform/workspace/composables/useWorkspaceUI', () => ({
     permissions: computed(() => ({
       canManageSubscription: state.canManageSubscription,
       canManageSubscriptionLifecycle: state.canManageSubscriptionLifecycle
-    }))
+    })),
+    canReactivatePlan: computed(() =>
+      state.isCloud && state.shouldUseWorkspaceBilling
+        ? state.canReactivate
+        : state.canManageSubscriptionLifecycle
+    )
   })
 }))
 

--- a/src/platform/workspace/components/CurrentUserPopoverWorkspace.test.ts
+++ b/src/platform/workspace/components/CurrentUserPopoverWorkspace.test.ts
@@ -22,6 +22,7 @@ const state = vi.hoisted(() => ({
   canManageSubscription: false,
   canManageSubscriptionLifecycle: false,
   canReactivate: false,
+  canReactivatePlan: false,
   shouldUseWorkspaceBilling: true,
   showCreateWorkspaceDialog: vi.fn(),
   showTopUpCreditsDialog: vi.fn(),
@@ -78,11 +79,7 @@ vi.mock('@/platform/workspace/composables/useWorkspaceUI', () => ({
       canManageSubscription: state.canManageSubscription,
       canManageSubscriptionLifecycle: state.canManageSubscriptionLifecycle
     })),
-    canReactivatePlan: computed(() =>
-      state.isCloud && state.shouldUseWorkspaceBilling
-        ? state.canReactivate
-        : state.canManageSubscriptionLifecycle
-    )
+    canReactivatePlan: computed(() => state.canReactivatePlan)
   })
 }))
 
@@ -519,7 +516,7 @@ describe('CurrentUserPopoverWorkspace', () => {
       state.isCancelled = isCancelled
       state.canManageSubscription = canManageSubscription
       state.canManageSubscriptionLifecycle = canManageSubscriptionLifecycle
-      state.canReactivate = canReactivate
+      state.canReactivatePlan = canReactivate
       state.canSubscribeSelfServe = canSubscribeSelfServe
 
       renderComponent('team')
@@ -539,7 +536,7 @@ describe('CurrentUserPopoverWorkspace', () => {
     state.canTopUp = true
     state.canManageSubscription = true
     state.canManageSubscriptionLifecycle = true
-    state.canReactivate = true
+    state.canReactivatePlan = true
     renderComponent('team')
 
     expect(screen.getByTestId('add-credits-button')).toBeInTheDocument()
@@ -551,13 +548,14 @@ describe('CurrentUserPopoverWorkspace', () => {
     expect(state.showPricingTable).toHaveBeenCalledOnce()
   })
 
-  it('keeps Resubscribe available on the legacy rail when the server withholds can_reactivate', () => {
+  it('reads the derived reactivate policy, not the raw server capability', () => {
     state.isCancelled = true
     state.canManageSubscriptionLifecycle = true
-    // legacy_stripe workspaces have no capability projection row, so the
-    // server-resolved can_reactivate stays false and must not gate the button.
+    // The legacy rail resolves can_reactivate false but still permits
+    // reactivation, so the button must follow canReactivatePlan. Rail
+    // selection itself is covered in useWorkspaceUI.test.ts.
     state.canReactivate = false
-    state.shouldUseWorkspaceBilling = false
+    state.canReactivatePlan = true
 
     renderComponent('personal')
 

--- a/src/platform/workspace/components/CurrentUserPopoverWorkspace.test.ts
+++ b/src/platform/workspace/components/CurrentUserPopoverWorkspace.test.ts
@@ -22,6 +22,7 @@ const state = vi.hoisted(() => ({
   canManageSubscription: false,
   canManageSubscriptionLifecycle: false,
   canReactivate: false,
+  shouldUseWorkspaceBilling: true,
   showCreateWorkspaceDialog: vi.fn(),
   showTopUpCreditsDialog: vi.fn(),
   showPricingTable: vi.fn(),
@@ -85,6 +86,12 @@ vi.mock('@/platform/workspace/composables/useBillingCapabilities', () => ({
     canTopUp: computed(() => state.canTopUp),
     canSubscribeSelfServe: computed(() => state.canSubscribeSelfServe),
     canReactivate: computed(() => state.canReactivate)
+  })
+}))
+
+vi.mock('@/composables/billing/useBillingRouting', () => ({
+  useBillingRouting: () => ({
+    shouldUseWorkspaceBilling: computed(() => state.shouldUseWorkspaceBilling)
   })
 }))
 
@@ -190,6 +197,7 @@ describe('CurrentUserPopoverWorkspace', () => {
     state.canManageSubscription = false
     state.canManageSubscriptionLifecycle = false
     state.canReactivate = false
+    state.shouldUseWorkspaceBilling = true
   })
 
   it('toggles the workspace switcher panel from the selector row', async () => {
@@ -536,6 +544,21 @@ describe('CurrentUserPopoverWorkspace', () => {
     await user.click(screen.getByRole('button', { name: 'Resubscribe' }))
 
     expect(state.showPricingTable).toHaveBeenCalledOnce()
+  })
+
+  it('keeps Resubscribe available on the legacy rail when the server withholds can_reactivate', () => {
+    state.isCancelled = true
+    state.canManageSubscriptionLifecycle = true
+    // legacy_stripe workspaces have no capability projection row, so the
+    // server-resolved can_reactivate stays false and must not gate the button.
+    state.canReactivate = false
+    state.shouldUseWorkspaceBilling = false
+
+    renderComponent('personal')
+
+    expect(
+      screen.getByRole('button', { name: 'Resubscribe' })
+    ).toBeInTheDocument()
   })
 
   for (const workspaceType of ['personal', 'team'] as const) {

--- a/src/platform/workspace/components/CurrentUserPopoverWorkspace.vue
+++ b/src/platform/workspace/components/CurrentUserPopoverWorkspace.vue
@@ -269,7 +269,6 @@ import SubscribeButton from '@/platform/cloud/subscription/components/SubscribeB
 import { useSubscriptionDialog } from '@/platform/cloud/subscription/composables/useSubscriptionDialog'
 import { isCloud } from '@/platform/distribution/types'
 import { useTelemetry } from '@/platform/telemetry'
-import { useBillingRouting } from '@/composables/billing/useBillingRouting'
 import { useBillingCapabilities } from '@/platform/workspace/composables/useBillingCapabilities'
 import { useWorkspaceUI } from '@/platform/workspace/composables/useWorkspaceUI'
 import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
@@ -282,10 +281,8 @@ const {
   workspaceName,
   isInPersonalWorkspace: isPersonalWorkspace
 } = storeToRefs(workspaceStore)
-const { permissions } = useWorkspaceUI()
-const { shouldUseWorkspaceBilling } = useBillingRouting()
-const { canTopUp, canSubscribeSelfServe, canReactivate } =
-  useBillingCapabilities()
+const { permissions, canReactivatePlan } = useWorkspaceUI()
+const { canTopUp, canSubscribeSelfServe } = useBillingCapabilities()
 const isWorkspaceSwitcherOpen = ref(false)
 const workspaceSwitcherTrigger = useTemplateRef('workspaceSwitcherTrigger')
 const workspaceSwitcherPanel = useTemplateRef('workspaceSwitcherPanel')
@@ -367,13 +364,6 @@ const showManagePlan = computed(
   () =>
     permissions.value.canManageSubscription &&
     (canAccessSubscriptionFeatures.value || hasDelinquentSubscription.value)
-)
-// The legacy rail keeps lifecycle authorization on the client, matching
-// SubscriptionPanelContentWorkspace and BillingStatusBanner.
-const canReactivatePlan = computed(() =>
-  isCloud && shouldUseWorkspaceBilling.value
-    ? canReactivate.value
-    : permissions.value.canManageSubscriptionLifecycle
 )
 
 const showSubscribeAction = computed(

--- a/src/platform/workspace/components/CurrentUserPopoverWorkspace.vue
+++ b/src/platform/workspace/components/CurrentUserPopoverWorkspace.vue
@@ -269,6 +269,7 @@ import SubscribeButton from '@/platform/cloud/subscription/components/SubscribeB
 import { useSubscriptionDialog } from '@/platform/cloud/subscription/composables/useSubscriptionDialog'
 import { isCloud } from '@/platform/distribution/types'
 import { useTelemetry } from '@/platform/telemetry'
+import { useBillingRouting } from '@/composables/billing/useBillingRouting'
 import { useBillingCapabilities } from '@/platform/workspace/composables/useBillingCapabilities'
 import { useWorkspaceUI } from '@/platform/workspace/composables/useWorkspaceUI'
 import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
@@ -282,6 +283,7 @@ const {
   isInPersonalWorkspace: isPersonalWorkspace
 } = storeToRefs(workspaceStore)
 const { permissions } = useWorkspaceUI()
+const { shouldUseWorkspaceBilling } = useBillingRouting()
 const { canTopUp, canSubscribeSelfServe, canReactivate } =
   useBillingCapabilities()
 const isWorkspaceSwitcherOpen = ref(false)
@@ -366,12 +368,20 @@ const showManagePlan = computed(
     permissions.value.canManageSubscription &&
     (canAccessSubscriptionFeatures.value || hasDelinquentSubscription.value)
 )
+// The legacy rail keeps lifecycle authorization on the client, matching
+// SubscriptionPanelContentWorkspace and BillingStatusBanner.
+const canReactivatePlan = computed(() =>
+  isCloud && shouldUseWorkspaceBilling.value
+    ? canReactivate.value
+    : permissions.value.canManageSubscriptionLifecycle
+)
+
 const showSubscribeAction = computed(
   () =>
     // Subscribing is Cloud-only, so the whole action stays gated on isCloud;
     // inside it the server-resolved capabilities are authoritative.
     isCloud &&
-    ((isCancelled.value && canReactivate.value) ||
+    ((isCancelled.value && canReactivatePlan.value) ||
       (!canAccessSubscriptionFeatures.value &&
         !hasDelinquentSubscription.value &&
         canSubscribeSelfServe.value))

--- a/src/platform/workspace/components/CurrentUserPopoverWorkspace.vue
+++ b/src/platform/workspace/components/CurrentUserPopoverWorkspace.vue
@@ -378,8 +378,8 @@ const canReactivatePlan = computed(() =>
 
 const showSubscribeAction = computed(
   () =>
-    // Subscribing is Cloud-only, so the whole action stays gated on isCloud;
-    // inside it the server-resolved capabilities are authoritative.
+    // Subscribing is Cloud-only, so the whole action stays gated on isCloud.
+    // Self-serve subscribe is server-authoritative; reactivation is not.
     isCloud &&
     ((isCancelled.value && canReactivatePlan.value) ||
       (!canAccessSubscriptionFeatures.value &&

--- a/src/platform/workspace/components/SubscriptionPanelContentWorkspace.test.ts
+++ b/src/platform/workspace/components/SubscriptionPanelContentWorkspace.test.ts
@@ -85,6 +85,7 @@ const mockCanManageSubscription = ref(true)
 const mockCanManageSubscriptionLifecycle = ref(true)
 const mockCanCancel = ref(true)
 const mockCanReactivate = ref(true)
+const mockCanReactivatePlan = ref(true)
 const mockShouldUseWorkspaceBilling = ref(true)
 const mockCanChangeSeats = ref(true)
 const mockCanSubscribeSelfServe = ref(true)
@@ -223,11 +224,7 @@ vi.mock('@/platform/workspace/composables/useWorkspaceUI', () => ({
       canManageSubscriptionLifecycle: mockCanManageSubscriptionLifecycle.value,
       canLeaveWorkspace: mockCanLeaveWorkspace.value
     })),
-    canReactivatePlan: computed(() =>
-      mockDistributionState.isCloud && mockShouldUseWorkspaceBilling.value
-        ? mockCanReactivate.value
-        : mockCanManageSubscriptionLifecycle.value
-    ),
+    canReactivatePlan: mockCanReactivatePlan,
     uiConfig: computed(() => mockUiConfig.value),
     isInPersonalWorkspace: mockIsInPersonalWorkspace,
     isActiveSubscription: computed(() => mockIsActiveSubscription.value),
@@ -825,7 +822,7 @@ describe('SubscriptionPanelContentWorkspace', () => {
     mockHasTeamPlan.value = false
     mockIsWorkspaceSubscribed.value = false
     mockCanManageSubscriptionLifecycle.value = true
-    mockCanReactivate.value = false
+    mockCanReactivatePlan.value = false
     renderComponent()
 
     expect(

--- a/src/platform/workspace/components/SubscriptionPanelContentWorkspace.test.ts
+++ b/src/platform/workspace/components/SubscriptionPanelContentWorkspace.test.ts
@@ -223,6 +223,11 @@ vi.mock('@/platform/workspace/composables/useWorkspaceUI', () => ({
       canManageSubscriptionLifecycle: mockCanManageSubscriptionLifecycle.value,
       canLeaveWorkspace: mockCanLeaveWorkspace.value
     })),
+    canReactivatePlan: computed(() =>
+      mockDistributionState.isCloud && mockShouldUseWorkspaceBilling.value
+        ? mockCanReactivate.value
+        : mockCanManageSubscriptionLifecycle.value
+    ),
     uiConfig: computed(() => mockUiConfig.value),
     isInPersonalWorkspace: mockIsInPersonalWorkspace,
     isActiveSubscription: computed(() => mockIsActiveSubscription.value),

--- a/src/platform/workspace/components/SubscriptionPanelContentWorkspace.vue
+++ b/src/platform/workspace/components/SubscriptionPanelContentWorkspace.vue
@@ -417,7 +417,6 @@ import type { TierBenefit } from '@/platform/cloud/subscription/utils/tierBenefi
 import { getCommonTierBenefits } from '@/platform/cloud/subscription/utils/tierBenefits'
 import { isCloud } from '@/platform/distribution/types'
 import { useResubscribe } from '@/platform/workspace/composables/useResubscribe'
-import { useBillingRouting } from '@/composables/billing/useBillingRouting'
 import { useBillingCapabilities } from '@/platform/workspace/composables/useBillingCapabilities'
 import { useWorkspaceMenuItems } from '@/platform/workspace/composables/useWorkspaceMenuItems'
 import { useWorkspacePlanPricing } from '@/platform/workspace/composables/useWorkspacePlanPricing'
@@ -432,10 +431,13 @@ import {
 const workspaceStore = useTeamWorkspaceStore()
 const { isWorkspaceSubscribed, isInPersonalWorkspace } =
   storeToRefs(workspaceStore)
-const { permissions, isSubscriptionCancelled, workspaceRole } = useWorkspaceUI()
-const { shouldUseWorkspaceBilling } = useBillingRouting()
-const { canReactivate, canChangeSeats, canSubscribeSelfServe } =
-  useBillingCapabilities()
+const {
+  permissions,
+  isSubscriptionCancelled,
+  workspaceRole,
+  canReactivatePlan
+} = useWorkspaceUI()
+const { canChangeSeats, canSubscribeSelfServe } = useBillingCapabilities()
 const { maxAvailable: freeRunsAllowance, quotaEnabled: freeRunsQuotaEnabled } =
   useFreeTierQuota()
 const { t, n, locale } = useI18n()
@@ -505,11 +507,6 @@ const showSubscribePrompt = computed(() => {
 // The legacy rail keeps lifecycle authorization on the client, and
 // handleResubscribe() skips its capability guard there, so the affordance has
 // to follow the same three-way condition or it hides a working action.
-const canReactivatePlan = computed(() =>
-  isCloud && shouldUseWorkspaceBilling.value
-    ? canReactivate.value
-    : permissions.value.canManageSubscriptionLifecycle
-)
 const canChangePlan = computed(() =>
   isCloud ? canChangeSeats.value : permissions.value.canManageSubscription
 )

--- a/src/platform/workspace/components/dialogs/settings/BillingStatusBanner.test.ts
+++ b/src/platform/workspace/components/dialogs/settings/BillingStatusBanner.test.ts
@@ -80,7 +80,12 @@ vi.mock('@/platform/workspace/composables/useWorkspaceUI', () => ({
       canManageSubscription: state.canManageSubscription,
       canManageSubscriptionLifecycle: state.canManageSubscriptionLifecycle
     })),
-    workspaceType: computed(() => state.workspaceType as WorkspaceType)
+    workspaceType: computed(() => state.workspaceType as WorkspaceType),
+    canReactivatePlan: computed(() =>
+      state.shouldUseWorkspaceBilling
+        ? state.canReactivate
+        : state.canManageSubscriptionLifecycle
+    )
   })
 }))
 

--- a/src/platform/workspace/components/dialogs/settings/BillingStatusBanner.test.ts
+++ b/src/platform/workspace/components/dialogs/settings/BillingStatusBanner.test.ts
@@ -28,10 +28,11 @@ const state = vi.hoisted(() => ({
     endDate: null
   } as Subscription | null,
   renewalDate: null as string | null,
-  workspaceType: 'team' as string,
+  workspaceType: 'team' as WorkspaceType,
   canManageSubscription: true,
   canManageSubscriptionLifecycle: true,
   canReactivate: true,
+  canReactivatePlan: true,
   shouldUseWorkspaceBilling: true,
   canTopUp: true,
   canSubscribeSelfServe: false,
@@ -80,12 +81,8 @@ vi.mock('@/platform/workspace/composables/useWorkspaceUI', () => ({
       canManageSubscription: state.canManageSubscription,
       canManageSubscriptionLifecycle: state.canManageSubscriptionLifecycle
     })),
-    workspaceType: computed(() => state.workspaceType as WorkspaceType),
-    canReactivatePlan: computed(() =>
-      state.shouldUseWorkspaceBilling
-        ? state.canReactivate
-        : state.canManageSubscriptionLifecycle
-    )
+    workspaceType: computed(() => state.workspaceType),
+    canReactivatePlan: computed(() => state.canReactivatePlan)
   })
 }))
 
@@ -410,7 +407,7 @@ describe('BillingStatusBanner', () => {
     }
     state.canManageSubscription = true
     state.canManageSubscriptionLifecycle = true
-    state.canReactivate = false
+    state.canReactivatePlan = false
     renderBanner()
 
     expect(screen.getByRole('status')).toHaveTextContent(

--- a/src/platform/workspace/components/dialogs/settings/BillingStatusBanner.vue
+++ b/src/platform/workspace/components/dialogs/settings/BillingStatusBanner.vue
@@ -74,8 +74,6 @@ import { useI18n } from 'vue-i18n'
 import Button from '@/components/ui/button/Button.vue'
 import { useBillingContext } from '@/composables/billing/useBillingContext'
 import { useBillingBanner } from '@/platform/workspace/composables/useBillingBanner'
-import { isCloud } from '@/platform/distribution/types'
-import { useBillingRouting } from '@/composables/billing/useBillingRouting'
 import { useBillingCapabilities } from '@/platform/workspace/composables/useBillingCapabilities'
 import { useResubscribe } from '@/platform/workspace/composables/useResubscribe'
 import { useWorkspaceUI } from '@/platform/workspace/composables/useWorkspaceUI'
@@ -85,10 +83,8 @@ type BannerAction = 'addCredits' | 'reactivate' | 'updatePayment'
 
 const { t, d } = useI18n()
 const { renewalDate, subscription, manageSubscription } = useBillingContext()
-const { permissions } = useWorkspaceUI()
-const { shouldUseWorkspaceBilling } = useBillingRouting()
-const { canTopUp, canSubscribeSelfServe, canReactivate } =
-  useBillingCapabilities()
+const { permissions, canReactivatePlan } = useWorkspaceUI()
+const { canTopUp, canSubscribeSelfServe } = useBillingCapabilities()
 const { kind, dismiss } = useBillingBanner()
 const { isResubscribing, handleResubscribe } = useResubscribe()
 const dialogService = useDialogService()
@@ -97,11 +93,6 @@ const canManage = computed(() => permissions.value.canManageSubscription)
 // The legacy rail keeps lifecycle authorization on the client, and
 // handleResubscribe() skips its capability guard there, so the affordance has
 // to follow the same three-way condition or it hides a working action.
-const canReactivatePlan = computed(() =>
-  isCloud && shouldUseWorkspaceBilling.value
-    ? canReactivate.value
-    : permissions.value.canManageSubscriptionLifecycle
-)
 const cycleResetDate = computed(() => {
   const raw = renewalDate.value
   return raw ? d(new Date(raw), { month: 'short', day: 'numeric' }) : ''

--- a/src/platform/workspace/composables/useWorkspaceUI.test.ts
+++ b/src/platform/workspace/composables/useWorkspaceUI.test.ts
@@ -1,4 +1,4 @@
-import { ref } from 'vue'
+import { computed, ref } from 'vue'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { WorkspaceWithRole } from '@/platform/workspace/api/workspaceApi'
@@ -9,6 +9,9 @@ const mockStore = vi.hoisted(() => ({
   originalOwnerId: null as string | null,
   ensureMembersLoaded: vi.fn()
 }))
+const mockIsCloud = ref(true)
+const mockShouldUseWorkspaceBilling = ref(true)
+const mockCanReactivate = ref(false)
 const mockIsActiveSubscription = vi.hoisted(() => ({ value: false }))
 const mockIsCancelled = vi.hoisted(() => ({ value: false }))
 const mockIsTeamPlan = vi.hoisted(() => ({ value: false }))
@@ -32,6 +35,26 @@ vi.mock('@/platform/workspace/stores/teamWorkspaceStore', () => ({
       return mockStore.originalOwnerId
     },
     ensureMembersLoaded: mockStore.ensureMembersLoaded
+  })
+}))
+
+vi.mock('@/platform/distribution/types', () => ({
+  get isCloud() {
+    return mockIsCloud.value
+  }
+}))
+
+vi.mock('@/composables/billing/useBillingRouting', () => ({
+  useBillingRouting: () => ({
+    shouldUseWorkspaceBilling: computed(
+      () => mockShouldUseWorkspaceBilling.value
+    )
+  })
+}))
+
+vi.mock('@/platform/workspace/composables/useBillingCapabilities', () => ({
+  useBillingCapabilities: () => ({
+    canReactivate: computed(() => mockCanReactivate.value)
   })
 }))
 
@@ -100,6 +123,9 @@ function resetStore() {
   mockIsCancelled.value = false
   mockIsTeamPlan.value = false
   mockBillingControlEnabled.value = false
+  mockIsCloud.value = true
+  mockShouldUseWorkspaceBilling.value = true
+  mockCanReactivate.value = false
 }
 
 describe('useWorkspaceUI', () => {
@@ -448,6 +474,42 @@ describe('useWorkspaceUI', () => {
 
       expect(second.permissions).toBe(first.permissions)
       expect(second.uiConfig).toBe(first.uiConfig)
+    })
+  })
+  describe('canReactivatePlan', () => {
+    beforeEach(() => {
+      mockStore.activeWorkspace = personalWorkspace
+    })
+
+    it('uses the server capability on the consolidated rail', async () => {
+      mockShouldUseWorkspaceBilling.value = true
+      mockCanReactivate.value = false
+
+      const denied = await loadComposable()
+      expect(denied.canReactivatePlan.value).toBe(false)
+
+      vi.resetModules()
+      mockCanReactivate.value = true
+      const allowed = await loadComposable()
+      expect(allowed.canReactivatePlan.value).toBe(true)
+    })
+
+    it('falls back to membership on the legacy rail, where no capability row exists', async () => {
+      mockShouldUseWorkspaceBilling.value = false
+      mockCanReactivate.value = false
+
+      const ui = await loadComposable()
+      expect(ui.permissions.value.canManageSubscriptionLifecycle).toBe(true)
+      expect(ui.canReactivatePlan.value).toBe(true)
+    })
+
+    it('falls back to membership off Cloud, where the endpoint is never called', async () => {
+      mockIsCloud.value = false
+      mockShouldUseWorkspaceBilling.value = true
+      mockCanReactivate.value = false
+
+      const ui = await loadComposable()
+      expect(ui.canReactivatePlan.value).toBe(true)
     })
   })
 })

--- a/src/platform/workspace/composables/useWorkspaceUI.ts
+++ b/src/platform/workspace/composables/useWorkspaceUI.ts
@@ -2,7 +2,10 @@ import { computed, watch } from 'vue'
 import { createSharedComposable } from '@vueuse/core'
 
 import { useBillingContext } from '@/composables/billing/useBillingContext'
+import { useBillingRouting } from '@/composables/billing/useBillingRouting'
 import { useFeatureFlags } from '@/composables/useFeatureFlags'
+import { isCloud } from '@/platform/distribution/types'
+import { useBillingCapabilities } from '@/platform/workspace/composables/useBillingCapabilities'
 
 import type { WorkspaceRole, WorkspaceType } from '../api/workspaceApi'
 import { useTeamWorkspaceStore } from '../stores/teamWorkspaceStore'
@@ -165,6 +168,9 @@ function useWorkspaceUIInternal() {
     { immediate: true }
   )
 
+  const { shouldUseWorkspaceBilling } = useBillingRouting()
+  const { canReactivate } = useBillingCapabilities()
+
   const permissions = computed<WorkspacePermissions>(() =>
     getPermissions(
       workspaceType.value,
@@ -174,6 +180,15 @@ function useWorkspaceUIInternal() {
       store.activeWorkspace !== null,
       isTeamPlan.value
     )
+  )
+
+  // legacy_stripe workspaces have no capability projection row, so the
+  // server-resolved can_reactivate is false for them and cannot gate the
+  // action; that rail stays on the membership check.
+  const canReactivatePlan = computed(() =>
+    isCloud && shouldUseWorkspaceBilling.value
+      ? canReactivate.value
+      : permissions.value.canManageSubscriptionLifecycle
   )
 
   const uiConfig = computed<WorkspaceUIConfig>(() => {
@@ -217,6 +232,7 @@ function useWorkspaceUIInternal() {
   return {
     // Permissions and config
     permissions,
+    canReactivatePlan,
     uiConfig,
     workspaceType,
     workspaceRole,


### PR DESCRIPTION
### The bug

The cancelled-plan **Resubscribe** action was gated on the server-resolved `can_reactivate`. `legacy_stripe` workspaces have no capability projection row, so it resolves `false` for them and the button disappears for customers who should have it.

`CurrentUserPopoverWorkspace` was the third and last site with this problem — the follow-up promised on the #15675 review thread, which deliberately left this file out of scope.

### The refactor (added in review)

Fixing the third site would have made a third verbatim copy of the same expression, so per review feedback the policy is now centralized instead of duplicated in views.

`useWorkspaceUI` — which already owns `permissions` — exposes one derived value:

```ts
// legacy_stripe workspaces have no capability projection row, so the
// server-resolved can_reactivate is false for them and cannot gate the
// action; that rail stays on the membership check.
const canReactivatePlan = computed(() =>
  isCloud && shouldUseWorkspaceBilling.value
    ? canReactivate.value
    : permissions.value.canManageSubscriptionLifecycle
)
```

`SubscriptionPanelContentWorkspace`, `BillingStatusBanner` and `CurrentUserPopoverWorkspace` all consume it; their local copies and now-unused `useBillingRouting` / `isCloud` imports are gone. So the third site is fixed **and** the pre-existing duplication is removed.

No import cycle — neither `useBillingRouting` nor `useBillingCapabilities` imports `useWorkspaceUI`.

### Deliberately not folded in

`useWorkspaceMenuItems` has a similar-looking expression for **cancel**, but it carries an extra free-tier guard (`can_cancel` stays true for an active FREE plan). Same shape, different policy — left alone.

### Verification

- Policy tests live in `useWorkspaceUI.test.ts` now, where the policy does: consolidated rail (uses the capability), legacy rail, and off-Cloud (both fall back to membership). Verified they actually bite by stubbing the policy out — **2 failed**.
- The off-Cloud case is new: `isCloud` is `false` by default under vitest and the composable test wasn't mocking it, so that branch had never been exercised.
- Component tests keep their behavioural cases and drive the shared value.
- On this head: `pnpm typecheck` clean; **127 passing** across the four affected files; full suite `1317/1318` files green — the only failures are 12 pre-existing `check-binary-size` cases that fail independently of this change.
