### PR TITLE
test: prove broken deferred thumbnail rendering

### DIFF
--- a/src/renderer/extensions/vueNodes/widgets/composables/useImagePreviewWidget.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useImagePreviewWidget.test.ts
@@ -413,6 +413,28 @@ describe('useImagePreviewWidget', () => {
       expect(node.imageRects).toHaveLength(2)
     })
 
+    it('does not draw thumbnails that break before deferred rendering', async () => {
+      const constructor = useImagePreviewWidget()
+      const imgs = [createMockImage(100, 100), createMockImage(100, 100)]
+      const node = createMockNode({ imgs, imageIndex: null })
+      constructor(node, defaultInputSpec)
+
+      const widget = getWidget(node)
+      widget.computedHeight = 220
+      const ctx = createMockCtx()
+
+      widget.drawWidget(ctx, { width: 300 })
+      for (const img of imgs) {
+        Object.defineProperties(img, {
+          naturalHeight: { value: 0 },
+          naturalWidth: { value: 0 }
+        })
+      }
+      await Promise.resolve()
+
+      expect(ctx.drawImage).not.toHaveBeenCalled()
+    })
+
     it('uses non-compact mode for mixed aspect ratios', () => {
       vi.mocked(is_all_same_aspect_ratio).mockReturnValue(false)
 

--- a/src/renderer/extensions/vueNodes/widgets/composables/useImagePreviewWidget.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useImagePreviewWidget.test.ts
@@ -250,6 +250,29 @@ describe('useImagePreviewWidget', () => {
       })
     })
 
+    it('does not draw an image that breaks before deferred rendering', async () => {
+      const constructor = useImagePreviewWidget()
+      const img = createMockImage(200, 100)
+      const node = createMockNode({
+        imgs: [img],
+        imageIndex: 0
+      })
+      constructor(node, defaultInputSpec)
+
+      const widget = getWidget(node)
+      widget.computedHeight = 220
+      const ctx = createMockCtx()
+
+      widget.drawWidget(ctx, { width: 300 })
+      Object.defineProperties(img, {
+        naturalHeight: { value: 0 },
+        naturalWidth: { value: 0 }
+      })
+      await Promise.resolve()
+
+      expect(ctx.drawImage).not.toHaveBeenCalled()
+    })
+
     it('auto-sets imageIndex to 0 for single image with null index', () => {
       const constructor = useImagePreviewWidget()
       const img = createMockImage(200, 100)

--- a/src/renderer/extensions/vueNodes/widgets/composables/useImagePreviewWidget.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useImagePreviewWidget.ts
@@ -262,6 +262,7 @@ const renderPreview = (
   // Defer image rendering to work around Chrome GPU bug
   const transform = ctx.getTransform()
   deferredImageRenders.push(() => {
+    if (!img.naturalWidth || !img.naturalHeight) return
     ctx.save()
     ctx.setTransform(transform)
     ctx.drawImage(img, x, y, w, h)


### PR DESCRIPTION
## Summary

Temporary red-proof branch for the multi-image thumbnail path in #15960.

The single-image deferred draw is guarded, while the thumbnail-grid callback remains deliberately unfixed. The new test must fail only because two invalidated thumbnails still reach canvas draw calls. This PR will be closed after CI records that attributable failure; the immutable test will then be added to #15960 with the existing production guard.