### PR TITLE
test: cover progress canvas redraw performance

### DIFF
--- a/browser_tests/fixtures/helpers/PerformanceHelper.ts
+++ b/browser_tests/fixtures/helpers/PerformanceHelper.ts
@@ -32,6 +32,8 @@ export interface PerfMeasurement {
   frameDurationMs: number
   p95FrameDurationMs: number
   allFrameDurationsMs: number[]
+  canvasForegroundDraws?: number
+  canvasBackgroundDraws?: number
 }
 
 export class PerformanceHelper {

--- a/browser_tests/tests/performance.spec.ts
+++ b/browser_tests/tests/performance.spec.ts
@@ -1,10 +1,14 @@
-import { expect } from '@playwright/test'
+import { expect, mergeTests } from '@playwright/test'
 
 import { comfyPageFixture as test } from '@e2e/fixtures/ComfyPage'
+import { ExecutionHelper } from '@e2e/fixtures/helpers/ExecutionHelper'
 import {
   logMeasurement,
   recordMeasurement
 } from '@e2e/fixtures/utils/perfReporter'
+import { webSocketFixture } from '@e2e/fixtures/ws'
+
+const executionPerfTest = mergeTests(test, webSocketFixture)
 
 test.describe('Performance', { tag: ['@perf'] }, () => {
   test('canvas idle style recalculations', async ({ comfyPage }) => {
@@ -462,4 +466,118 @@ test.describe('Performance', { tag: ['@perf'] }, () => {
       `Workflow execution: ${m.durationMs.toFixed(0)}ms total, ${m.layouts} layouts, TBT=${m.totalBlockingTimeMs.toFixed(0)}ms`
     )
   })
+})
+
+executionPerfTest.describe('Execution performance', { tag: ['@perf'] }, () => {
+  executionPerfTest(
+    'progress canvas redraws',
+    async ({ comfyPage, getWebSocket }) => {
+      await comfyPage.workflow.loadWorkflow('large-graph-workflow')
+      const execution = new ExecutionHelper(comfyPage, await getWebSocket())
+      const jobId = await execution.run()
+      const nodeId = String(
+        await comfyPage.page.evaluate(() => window.app?.graph.nodes[0]?.id)
+      )
+
+      await comfyPage.page.evaluate(() => {
+        const win = window as unknown as Record<string, unknown>
+        const canvas = window.app?.canvas
+        if (!canvas) throw new Error('Canvas is not available')
+        const api = window.app?.api
+        if (!api) throw new Error('API event target is not available')
+        const state = {
+          foreground: 0,
+          background: 0,
+          progressEvents: 0,
+          reset() {
+            state.foreground = 0
+            state.background = 0
+            state.progressEvents = 0
+          },
+          cleanup() {
+            canvas.drawFrontCanvas = drawFrontCanvas
+            canvas.drawBackCanvas = drawBackCanvas
+            api.removeEventListener('progress', onProgress)
+          }
+        }
+        const drawFrontCanvas = canvas.drawFrontCanvas.bind(canvas)
+        const drawBackCanvas = canvas.drawBackCanvas.bind(canvas)
+        const onProgress = () => state.progressEvents++
+        canvas.drawFrontCanvas = () => {
+          state.foreground++
+          drawFrontCanvas()
+        }
+        canvas.drawBackCanvas = () => {
+          state.background++
+          drawBackCanvas()
+        }
+        api.addEventListener('progress', onProgress)
+        win.__progressCanvasDraws = state
+      })
+
+      execution.executionStart(jobId)
+      execution.executing(jobId, nodeId)
+      await comfyPage.nextFrame()
+      await comfyPage.page.evaluate(() => {
+        const state = (window as unknown as Record<string, unknown>)
+          .__progressCanvasDraws as { reset?: () => void } | undefined
+        if (!state?.reset)
+          throw new Error('Canvas draw counters are unavailable')
+        state.reset()
+      })
+      await comfyPage.perf.startMeasuring()
+
+      for (let value = 1; value <= 60; value++) {
+        execution.progress(jobId, nodeId, value, 60)
+        await comfyPage.nextFrame()
+      }
+
+      const measurement = await comfyPage.perf.stopMeasuring(
+        'progress-canvas-redraws'
+      )
+      const draws = await comfyPage.page.evaluate(() => {
+        const state = (window as unknown as Record<string, unknown>)
+          .__progressCanvasDraws
+        if (
+          !state ||
+          typeof state !== 'object' ||
+          !('foreground' in state) ||
+          !('background' in state) ||
+          !('progressEvents' in state) ||
+          !('cleanup' in state)
+        ) {
+          throw new Error('Canvas draw counters are unavailable')
+        }
+        const counters = state as {
+          foreground: number
+          background: number
+          progressEvents: number
+          cleanup: () => void
+        }
+        counters.cleanup()
+        delete (window as unknown as Record<string, unknown>)
+          .__progressCanvasDraws
+        return {
+          foreground: counters.foreground,
+          background: counters.background,
+          progressEvents: counters.progressEvents
+        }
+      })
+
+      expect(draws.progressEvents).toBe(60)
+      expect(draws.background).toBe(0)
+      expect(draws.foreground).toBe(60)
+
+      const result = {
+        ...measurement,
+        canvasForegroundDraws: draws.foreground,
+        canvasBackgroundDraws: draws.background
+      }
+      recordMeasurement(result)
+      logMeasurement('Progress canvas redraws', result, [
+        'taskDurationMs',
+        'scriptDurationMs'
+      ])
+    }
+  )
 })

--- a/browser_tests/tests/performance.spec.ts
+++ b/browser_tests/tests/performance.spec.ts
@@ -485,27 +485,52 @@ executionPerfTest.describe('Execution performance', { tag: ['@perf'] }, () => {
         if (!canvas) throw new Error('Canvas is not available')
         const api = window.app?.api
         if (!api) throw new Error('API event target is not available')
+        const node = canvas.visible_nodes.find((node) => node.widgets?.length)
+        const widget = node?.widgets?.[0]
+        if (!node || !widget)
+          throw new Error('No visible widget-backed node is available')
+        const widgetSlot = node.addInput('__perf_widget_input', '*', {
+          widget: { name: widget.name }
+        })
         const state = {
           foreground: 0,
           background: 0,
           progressEvents: 0,
+          widgetSlotPosAssignments: 0,
+          activationProof() {
+            const concreteInputs = (
+              node as unknown as { _concreteInputs?: unknown[] }
+            )._concreteInputs
+            return {
+              visible: canvas.visible_nodes.includes(node),
+              concrete: concreteInputs?.includes(widgetSlot) === true,
+              reactive:
+                (widgetSlot as unknown as { __v_isReactive?: boolean })
+                  .__v_isReactive === true,
+              widgetBacked: !!widgetSlot.widget
+            }
+          },
           reset() {
             state.foreground = 0
             state.background = 0
             state.progressEvents = 0
+            state.widgetSlotPosAssignments = 0
           },
           cleanup() {
             canvas.drawFrontCanvas = drawFrontCanvas
             canvas.drawBackCanvas = drawBackCanvas
             api.removeEventListener('progress', onProgress)
+            node.removeInput(node.inputs.indexOf(widgetSlot))
           }
         }
         const drawFrontCanvas = canvas.drawFrontCanvas.bind(canvas)
         const drawBackCanvas = canvas.drawBackCanvas.bind(canvas)
         const onProgress = () => state.progressEvents++
         canvas.drawFrontCanvas = () => {
+          const previousPos = widgetSlot.pos
           state.foreground++
           drawFrontCanvas()
+          if (widgetSlot.pos !== previousPos) state.widgetSlotPosAssignments++
         }
         canvas.drawBackCanvas = () => {
           state.background++
@@ -513,6 +538,7 @@ executionPerfTest.describe('Execution performance', { tag: ['@perf'] }, () => {
         }
         api.addEventListener('progress', onProgress)
         win.__progressCanvasDraws = state
+        canvas.draw(true, false)
       })
 
       execution.executionStart(jobId)
@@ -520,9 +546,26 @@ executionPerfTest.describe('Execution performance', { tag: ['@perf'] }, () => {
       await comfyPage.nextFrame()
       await comfyPage.page.evaluate(() => {
         const state = (window as unknown as Record<string, unknown>)
-          .__progressCanvasDraws as { reset?: () => void } | undefined
+          .__progressCanvasDraws as
+          | {
+              reset?: () => void
+              activationProof?: () => Record<string, boolean>
+              widgetSlotPosAssignments?: number
+            }
+          | undefined
         if (!state?.reset)
           throw new Error('Canvas draw counters are unavailable')
+        const proof = state.activationProof?.()
+        if (!proof || Object.values(proof).some((value) => !value)) {
+          throw new Error(
+            `Widget slot activation preconditions failed: ${JSON.stringify(proof)}`
+          )
+        }
+        if (!state.widgetSlotPosAssignments) {
+          throw new Error(
+            'The visible reactive widget slot was not arranged during activation'
+          )
+        }
         state.reset()
       })
       await comfyPage.perf.startMeasuring()
@@ -544,6 +587,7 @@ executionPerfTest.describe('Execution performance', { tag: ['@perf'] }, () => {
           !('foreground' in state) ||
           !('background' in state) ||
           !('progressEvents' in state) ||
+          !('widgetSlotPosAssignments' in state) ||
           !('cleanup' in state)
         ) {
           throw new Error('Canvas draw counters are unavailable')
@@ -552,6 +596,7 @@ executionPerfTest.describe('Execution performance', { tag: ['@perf'] }, () => {
           foreground: number
           background: number
           progressEvents: number
+          widgetSlotPosAssignments: number
           cleanup: () => void
         }
         counters.cleanup()
@@ -560,13 +605,15 @@ executionPerfTest.describe('Execution performance', { tag: ['@perf'] }, () => {
         return {
           foreground: counters.foreground,
           background: counters.background,
-          progressEvents: counters.progressEvents
+          progressEvents: counters.progressEvents,
+          widgetSlotPosAssignments: counters.widgetSlotPosAssignments
         }
       })
 
       expect(draws.progressEvents).toBe(60)
       expect(draws.background).toBe(0)
       expect(draws.foreground).toBe(60)
+      expect(draws.widgetSlotPosAssignments).toBe(60)
 
       const result = {
         ...measurement,

--- a/scripts/perf-report.ts
+++ b/scripts/perf-report.ts
@@ -31,6 +31,8 @@ interface PerfMeasurement {
   frameDurationMs: number
   p95FrameDurationMs: number
   allFrameDurationsMs?: number[]
+  canvasForegroundDraws?: number
+  canvasBackgroundDraws?: number
 }
 
 interface PerfReport {
@@ -57,6 +59,8 @@ type MetricKey =
   | 'frameDurationMs'
   | 'p95FrameDurationMs'
   | 'heapUsedBytes'
+  | 'canvasForegroundDraws'
+  | 'canvasBackgroundDraws'
 
 interface MetricDef {
   key: MetricKey
@@ -83,6 +87,18 @@ const REPORTED_METRICS: MetricDef[] = [
     minAbsDelta: 5
   },
   { key: 'taskDurationMs', label: 'task duration', unit: 'ms' },
+  {
+    key: 'canvasForegroundDraws',
+    label: 'canvas foreground draws',
+    unit: '',
+    minAbsDelta: 5
+  },
+  {
+    key: 'canvasBackgroundDraws',
+    label: 'canvas background draws',
+    unit: '',
+    minAbsDelta: 5
+  },
   { key: 'scriptDurationMs', label: 'script duration', unit: 'ms' },
   { key: 'totalBlockingTimeMs', label: 'TBT', unit: 'ms' },
   { key: 'heapUsedBytes', label: 'heap used', unit: 'bytes' },
@@ -153,9 +169,8 @@ function getHistoricalTimeSeries(
     const group = groupByName(r.measurements)
     const samples = group.get(testName)
     if (samples) {
-      values.push(
-        samples.reduce((sum, s) => sum + s[metric], 0) / samples.length
-      )
+      const mean = meanMetric(samples, metric)
+      if (mean !== null) values.push(mean)
     }
   }
   return values
@@ -182,7 +197,7 @@ function getMetricValue(
   key: MetricKey
 ): number | null {
   const value = sample[key]
-  return Number.isFinite(value) ? value : null
+  return typeof value === 'number' && Number.isFinite(value) ? value : null
 }
 
 function meanMetric(samples: PerfMeasurement[], key: MetricKey): number | null {


### PR DESCRIPTION
## Summary

Adds a deterministic performance regression test for progress-driven LiteGraph canvas redraws.

## Changes

- **What**: Sends 60 progress events through the WebSocket fixture, records foreground/background canvas draw counts in the performance report, and asserts current-main behavior of approximately one foreground and no background draw per event.

## Review Focus

The draw-count assertions intentionally allow one setup/settling pass. Frontend 1.53.1 at the ECS merge produced approximately two foreground and one background draw per event; current main produces 61/0 for 60 events.

Related to #15977. This is the test/baseline PR; no production behavior changes.
