### PR TITLE
test: establish render-order complexity baseline

### DIFF
--- a/src/lib/litegraph/src/LGraphCanvas.drawConnections.test.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.drawConnections.test.ts
@@ -199,6 +199,38 @@ describe('drawConnections', () => {
     expect([...canvas.renderedPaths]).toEqual([secondLink, firstLink])
   })
 
+  it.for([245, 500, 1_000])(
+    'rebuilds render order independently for both passes at %i nodes',
+    (nodeCount) => {
+      for (let index = 0; index < nodeCount; index++) {
+        const node = new LGraphNode(`Node ${index}`)
+        vi.spyOn(node, 'updateArea').mockImplementation(() => {})
+        graph.add(node)
+      }
+      canvas.visible_area.set([0, 0, 800, 600])
+      vi.mocked(layoutStore.getNodeLayout).mockClear()
+      const sort = vi.spyOn(Array.prototype, 'sort')
+
+      canvas.computeVisibleNodes()
+      const foregroundLayoutReads = vi.mocked(layoutStore.getNodeLayout).mock
+        .calls.length
+      const foregroundSorts = sort.mock.calls.length
+
+      canvas.drawConnections(createMockCtx())
+      const totalLayoutReads = vi.mocked(layoutStore.getNodeLayout).mock.calls
+        .length
+
+      expect(foregroundLayoutReads).toBe(nodeCount)
+      expect(totalLayoutReads - foregroundLayoutReads).toBe(nodeCount)
+      expect(foregroundSorts).toBe(1)
+      expect(
+        sort.mock.instances.filter(
+          (items) => (items as unknown[]).length === nodeCount
+        )
+      ).toHaveLength(2)
+    }
+  )
+
   it('connects, draws, and serializes without deprecation warnings', () => {
     const sourceNode = new LGraphNode('Source')
     sourceNode.pos = [100, 100]

--- a/src/lib/litegraph/src/LGraphCanvas.drawConnections.test.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.drawConnections.test.ts
@@ -201,6 +201,7 @@ describe('drawConnections', () => {
 
   it.for([245, 500, 1_000])(
     'rebuilds render order independently for both passes at %i nodes',
+    { timeout: 10_000 },
     (nodeCount) => {
       for (let index = 0; index < nodeCount; index++) {
         const node = new LGraphNode(`Node ${index}`)

--- a/src/lib/litegraph/src/LGraphCanvas.drawConnections.test.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.drawConnections.test.ts
@@ -225,7 +225,7 @@ describe('drawConnections', () => {
       expect(foregroundSorts).toBe(1)
       expect(
         sort.mock.instances.filter(
-          (items) => (items as unknown[]).length === nodeCount
+          (items) => Array.isArray(items) && items.length === nodeCount
         )
       ).toHaveLength(2)
     }


### PR DESCRIPTION
## Why

The #15924 ECS renderer change correctly stopped mutating authoritative graph membership order, but foreground and background rendering now independently rebuild the same render order with `map(getNodeLayout) -> sort -> map`.

## Proof

This deterministic baseline verifies both-layer redraw cost without noisy wall-clock timing:

- 245 nodes: 490 layout reads and 2 full sorts
- 500 nodes: 1,000 layout reads and 2 full sorts
- 1,000 nodes: 2,000 layout reads and 2 full sorts

## Follow-up

The safest first optimization is frame-local sharing through `LGraphCanvas.draw()`. A persistent revision cache is intentionally out of scope because reading graph/layout revision refs may expand reactive dependencies and requires a broader compatibility proof.

## Verification

Focused tests, formatting, lint, full typecheck, and commit hooks pass.

Related: #15977

<!-- perf-proof-evidence:start -->
## Performance proof status

**Role:** deterministic baseline for #15995.

- Exact tested and merged head: `b59aed261e108dc27ce51b18c221926f0b8bd2ed`.
- `node_modules/.bin/vitest run src/lib/litegraph/src/LGraphCanvas.drawConnections.test.ts` passed 1 file / 8 tests in 2.55 s (3.33 s wall).
- This establishes operation-count evidence for render-order layout reads and sorts, not a wall-clock or frame-budget claim.
- Live status: merged 2026-08-26; no unresolved threads; CodeRabbit approved the merged head. The unrelated comfy-cms Vercel context is red, while repository test gates completed.
- Browser screenshots are not applicable to this test-only baseline.
<!-- perf-proof-evidence:end -->

