### PR TITLE
perf: animate queue progress with transforms

### DIFF
--- a/browser_tests/fixtures/components/QueuePanel.ts
+++ b/browser_tests/fixtures/components/QueuePanel.ts
@@ -6,12 +6,16 @@ import { TestIds } from '@e2e/fixtures/selectors'
 export class QueuePanel {
   readonly overlayToggle: Locator
   readonly overlay: Locator
+  readonly progressNodeFill: Locator
   readonly moreOptionsButton: Locator
   readonly jobAssetsList: Locator
 
   constructor(readonly page: Page) {
     this.overlayToggle = page.getByTestId(TestIds.queue.overlayToggle)
     this.overlay = page.getByTestId(TestIds.queue.progressOverlay)
+    this.progressNodeFill = this.overlay.getByTestId(
+      TestIds.queue.progressNodeFill
+    )
     this.moreOptionsButton = this.overlay.getByLabel(/More options/i)
     this.jobAssetsList = page.getByTestId(TestIds.queue.jobAssetsList)
   }

--- a/browser_tests/fixtures/selectors.ts
+++ b/browser_tests/fixtures/selectors.ts
@@ -266,6 +266,7 @@ export const TestIds = {
   queue: {
     jobHistorySidebar: 'job-history-sidebar',
     progressOverlay: 'queue-progress-overlay',
+    progressNodeFill: 'queue-progress-node-fill',
     overlayToggle: 'queue-overlay-toggle',
     dockedJobHistoryAction: 'docked-job-history-action',
     jobDetailsPopover: 'queue-job-details-popover',

--- a/browser_tests/tests/queue/runProgressBar.spec.ts
+++ b/browser_tests/tests/queue/runProgressBar.spec.ts
@@ -49,3 +49,62 @@ wstest.describe('Docked actionbar run progress bar', { tag: ['@ui'] }, () => {
     }
   )
 })
+
+wstest.describe('Queue progress overlay', { tag: ['@ui'] }, () => {
+  wstest.use({
+    initialSettings: {
+      'Comfy.Queue.QPOV2': false
+    }
+  })
+
+  wstest(
+    'updates visual progress without changing layout width',
+    async ({ comfyPage, getWebSocket }) => {
+      const execution = new ExecutionHelper(comfyPage, await getWebSocket())
+      const jobId = await execution.run()
+      execution.executionStart(jobId)
+      execution.nodeRunning(jobId, '3', 5, 20)
+
+      const { progressNodeFill } = comfyPage.queuePanel
+      await expect(progressNodeFill).toBeVisible()
+      await expect
+        .poll(() =>
+          progressNodeFill.evaluate(
+            (element) =>
+              element.getBoundingClientRect().width /
+              (element as HTMLElement).offsetWidth
+          )
+        )
+        .toBeCloseTo(0.25, 1)
+
+      const initialLayoutWidth = await progressNodeFill.evaluate(
+        (element) => (element as HTMLElement).offsetWidth
+      )
+
+      const transitionProperties = await progressNodeFill.evaluate((element) =>
+        getComputedStyle(element).transitionProperty.split(', ')
+      )
+      expect(transitionProperties).toContain('transform')
+      expect(transitionProperties).not.toContain('width')
+
+      execution.nodeRunning(jobId, '3', 18, 20)
+      await expect
+        .poll(() =>
+          progressNodeFill.evaluate(
+            (element) =>
+              element.getBoundingClientRect().width /
+              (element as HTMLElement).offsetWidth
+          )
+        )
+        .toBeCloseTo(0.9, 1)
+
+      await expect
+        .poll(() =>
+          progressNodeFill.evaluate(
+            (element) => (element as HTMLElement).offsetWidth
+          )
+        )
+        .toBe(initialLayoutWidth)
+    }
+  )
+})

--- a/src/components/queue/QueueOverlayActive.test.ts
+++ b/src/components/queue/QueueOverlayActive.test.ts
@@ -34,8 +34,8 @@ const tooltipDirectiveStub = {
 }
 
 const defaultProps = {
-  totalProgressStyle: { width: '65%' },
-  currentNodeProgressStyle: { width: '40%' },
+  totalProgressStyle: { transform: 'scaleX(0.65)' },
+  currentNodeProgressStyle: { transform: 'scaleX(0.4)' },
   totalPercentFormatted: '65%',
   currentNodePercentFormatted: '40%',
   currentNodeName: 'Sampler',
@@ -72,8 +72,18 @@ describe('QueueOverlayActive', () => {
 
     // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
     const progressBars = container.querySelectorAll('.absolute.inset-0')
-    expect(progressBars[0]).toHaveStyle({ width: '65%' })
-    expect(progressBars[1]).toHaveStyle({ width: '40%' })
+    expect(progressBars).toHaveLength(2)
+    for (const progressBar of progressBars) {
+      expect(progressBar).toHaveClass(
+        'origin-left',
+        'will-change-transform',
+        'motion-safe:transition-transform'
+      )
+      expect(progressBar).not.toHaveClass('transition-[width]')
+      expect((progressBar as HTMLElement).style.width).toBe('')
+    }
+    expect(progressBars[0]).toHaveStyle({ transform: 'scaleX(0.65)' })
+    expect(progressBars[1]).toHaveStyle({ transform: 'scaleX(0.4)' })
 
     expect(screen.getByText('65%')).toBeInTheDocument()
 

--- a/src/components/queue/QueueOverlayActive.test.ts
+++ b/src/components/queue/QueueOverlayActive.test.ts
@@ -73,15 +73,6 @@ describe('QueueOverlayActive', () => {
     // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
     const progressBars = container.querySelectorAll('.absolute.inset-0')
     expect(progressBars).toHaveLength(2)
-    for (const progressBar of progressBars) {
-      expect(progressBar).toHaveClass(
-        'origin-left',
-        'will-change-transform',
-        'motion-safe:transition-transform'
-      )
-      expect(progressBar).not.toHaveClass('transition-[width]')
-      expect((progressBar as HTMLElement).style.width).toBe('')
-    }
     expect(progressBars[0]).toHaveStyle({ transform: 'scaleX(0.65)' })
     expect(progressBars[1]).toHaveStyle({ transform: 'scaleX(0.4)' })
 

--- a/src/components/queue/QueueOverlayActive.vue
+++ b/src/components/queue/QueueOverlayActive.vue
@@ -5,11 +5,11 @@
         class="relative h-2 w-full overflow-hidden rounded-full border border-interface-stroke bg-interface-panel-surface"
       >
         <div
-          class="absolute inset-0 h-full rounded-full transition-[width]"
+          class="absolute inset-0 h-full origin-left rounded-full will-change-transform motion-safe:transition-transform"
           :style="totalProgressStyle"
         />
         <div
-          class="absolute inset-0 h-full rounded-full transition-[width]"
+          class="absolute inset-0 h-full origin-left rounded-full will-change-transform motion-safe:transition-transform"
           :style="currentNodeProgressStyle"
         />
       </div>

--- a/src/components/queue/QueueOverlayActive.vue
+++ b/src/components/queue/QueueOverlayActive.vue
@@ -9,6 +9,7 @@
           :style="totalProgressStyle"
         />
         <div
+          data-testid="queue-progress-node-fill"
           class="absolute inset-0 h-full origin-left rounded-full will-change-transform motion-safe:transition-transform"
           :style="currentNodeProgressStyle"
         />

--- a/src/composables/queue/useQueueProgress.test.ts
+++ b/src/composables/queue/useQueueProgress.test.ts
@@ -134,11 +134,11 @@ describe('useQueueProgress', () => {
     const { composable } = mountUseQueueProgress()
 
     expect(composable.totalProgressStyle.value).toEqual({
-      width: '10%',
+      transform: 'scaleX(0.1)',
       background: 'var(--color-interface-panel-job-progress-primary)'
     })
     expect(composable.currentNodeProgressStyle.value).toEqual({
-      width: '25%',
+      transform: 'scaleX(0.25)',
       background: 'var(--color-interface-panel-job-progress-secondary)'
     })
 
@@ -146,7 +146,27 @@ describe('useQueueProgress', () => {
     setExecutingNodeProgress(0.02)
     await nextTick()
 
-    expect(composable.totalProgressStyle.value.width).toBe('76%')
-    expect(composable.currentNodeProgressStyle.value.width).toBe('2%')
+    expect(composable.totalProgressStyle.value.transform).toBe('scaleX(0.76)')
+    expect(composable.currentNodeProgressStyle.value.transform).toBe(
+      'scaleX(0.02)'
+    )
+  })
+
+  it('maps progress endpoints exactly to hidden and full-width transforms', async () => {
+    const { composable } = mountUseQueueProgress()
+
+    expect(composable.totalProgressStyle.value.transform).toBe('scaleX(0)')
+    expect(composable.currentNodeProgressStyle.value.transform).toBe(
+      'scaleX(0)'
+    )
+
+    setExecutionProgress(1)
+    setExecutingNodeProgress(1)
+    await nextTick()
+
+    expect(composable.totalProgressStyle.value.transform).toBe('scaleX(1)')
+    expect(composable.currentNodeProgressStyle.value.transform).toBe(
+      'scaleX(1)'
+    )
   })
 })

--- a/src/composables/queue/useQueueProgress.test.ts
+++ b/src/composables/queue/useQueueProgress.test.ts
@@ -151,22 +151,4 @@ describe('useQueueProgress', () => {
       'scaleX(0.02)'
     )
   })
-
-  it('maps progress endpoints exactly to hidden and full-width transforms', async () => {
-    const { composable } = mountUseQueueProgress()
-
-    expect(composable.totalProgressStyle.value.transform).toBe('scaleX(0)')
-    expect(composable.currentNodeProgressStyle.value.transform).toBe(
-      'scaleX(0)'
-    )
-
-    setExecutionProgress(1)
-    setExecutingNodeProgress(1)
-    await nextTick()
-
-    expect(composable.totalProgressStyle.value.transform).toBe('scaleX(1)')
-    expect(composable.currentNodeProgressStyle.value.transform).toBe(
-      'scaleX(1)'
-    )
-  })
 })

--- a/src/composables/queue/useQueueProgress.ts
+++ b/src/composables/queue/useQueueProgress.ts
@@ -30,12 +30,12 @@ export function useQueueProgress() {
   )
 
   const totalProgressStyle = computed(() => ({
-    width: `${totalPercent.value}%`,
+    transform: `scaleX(${totalPercent.value / 100})`,
     background: 'var(--color-interface-panel-job-progress-primary)'
   }))
 
   const currentNodeProgressStyle = computed(() => ({
-    width: `${currentNodePercent.value}%`,
+    transform: `scaleX(${currentNodePercent.value / 100})`,
     background: 'var(--color-interface-panel-job-progress-secondary)'
   }))
 


### PR DESCRIPTION
## Why

At 10 Hz execution progress, the queue overlay continuously restarts a CSS `width` transition. A bounded CDP invalidation trace names the progress fill as the initiator of nearly one full-document layout per frame.

Controlled 3-second, 245-node cells:

- idle / timer-only: 0 layouts
- current width animation: 179 layouts
- transform treatment: 34 layouts (**81% fewer**)
- directional main-thread task reduction: about 10%

Vue nodes, minimap, and DOM widget visibility were independently falsified as initiators.

## What

- animate full-width fills with left-origin `scaleX()`
- use `motion-safe:transition-transform` and preserve clipping/rounding
- add deterministic tests proving no width animation, intermediate update parity, and exact 0/100 mapping

## Verification

10 focused tests, Vue typecheck, ESLint, type-aware Oxlint, Stylelint, Oxfmt, and diff checks pass.

Related: #15977

<!-- perf-proof-evidence:start -->
## Performance proof status

**Role:** runtime layout fix.

- Controlled browser A/B: baseline `b8ebda372e8f` versus candidate `34396a055d06`, same isolated ComfyUI 0.30.0 CPU backend, 245-node workflow, Chromium viewport, disabled Vue DevTools overlay, synthetic 10 Hz progress, and four accepted three-second runs per arm after warm-up rejection.
- Layouts were `179,179,179,179` before and `34,34,34,35` after (median **-81.0%**). Median task duration was 605.7 → 544.3 ms (-10.1%); timing remains directional because four runs are below the seven-run target. rAF callbacks remained 184–187 and DOM mutations 84–86.
- Current head `fdb0de0dbe15` removes the criticized serialization-only endpoint test and adds a live-WebSocket browser regression checking 25%→90% progress, stable layout width, and transform-not-width transition behavior. Recorded gates: browser 3/3 and focused Vitest 9/9, with lint and typechecks green.
- Live status: open, mergeable, CI terminal non-failing. The human serialization-test thread is outdated and already has the browser-test implementation reply. Current-head CodeRabbit requests exact `scaleX(0)`/`scaleX(1)` unit assertions; this was not implemented because it directly recreates the style-serialization change detector the human reviewer and repository test guidance reject. The rationale is posted on the bot thread, which remains unresolved for verification.
- Agent-browser established dev-server health only. No paired screenshot is claimed as behavioral or performance proof.
<!-- perf-proof-evidence:end -->


