### PR TITLE
refactor: defer editor startup to GraphView

### DIFF
--- a/scripts/splashScreenBoundary.test.ts
+++ b/scripts/splashScreenBoundary.test.ts
@@ -1,0 +1,22 @@
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+
+import { globSync } from 'glob'
+import { describe, expect, it } from 'vitest'
+
+const workspaceRoot = path.resolve(import.meta.dirname, '..')
+
+describe('splash screen ownership', () => {
+  it('keeps direct DOM access inside the splash screen service', () => {
+    const directOwners = globSync('src/**/*.{ts,vue}', {
+      cwd: workspaceRoot,
+      ignore: ['src/**/*.{test,spec,stories}.ts']
+    }).filter((filename) =>
+      readFileSync(path.join(workspaceRoot, filename), 'utf8').includes(
+        "getElementById('splash-loader')"
+      )
+    )
+
+    expect(directOwners).toEqual(['src/services/splashScreenService.ts'])
+  })
+})

--- a/scripts/startupBoundary.test.ts
+++ b/scripts/startupBoundary.test.ts
@@ -1,0 +1,28 @@
+import path from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+import { findStartupBoundaryViolations } from './startupBoundary'
+
+const workspaceRoot = path.resolve(import.meta.dirname, '..')
+const forbiddenEditorModules = [
+  'src/core/graph/subgraph/migration/proxyWidgetMigration.ts',
+  'src/core/graph/subgraph/promotionUtils.ts',
+  'src/lib/litegraph/public/css/litegraph.css',
+  'src/lib/litegraph/src/litegraph.ts',
+  'src/platform/workflow/management/stores/workflowStore.ts',
+  'src/renderer/core/canvas/canvasStore.ts',
+  'src/scripts/app.ts'
+]
+
+describe('shared startup boundary', () => {
+  it('does not statically import Editor-owned modules', () => {
+    const violations = findStartupBoundaryViolations({
+      workspaceRoot,
+      roots: ['src/main.ts', 'src/App.vue'],
+      isForbidden: (filename) => forbiddenEditorModules.includes(filename)
+    })
+
+    expect(violations).toEqual([])
+  })
+})

--- a/scripts/startupBoundary.ts
+++ b/scripts/startupBoundary.ts
@@ -1,7 +1,16 @@
 import { existsSync, readFileSync, statSync } from 'node:fs'
 import path from 'node:path'
 
-import ts from 'typescript'
+import {
+  ScriptKind,
+  ScriptTarget,
+  createSourceFile,
+  isExportDeclaration,
+  isImportDeclaration,
+  isNamespaceImport,
+  isStringLiteral
+} from 'typescript'
+import type { ImportDeclaration } from 'typescript'
 import { parse } from 'vue/compiler-sfc'
 
 const SOURCE_EXTENSIONS = ['.ts', '.tsx', '.js', '.mjs', '.vue', '.css']
@@ -16,7 +25,7 @@ export type StartupBoundaryViolation = {
   importChain: string[]
 }
 
-function isRuntimeImport(node: ts.ImportDeclaration): boolean {
+function isRuntimeImport(node: ImportDeclaration): boolean {
   const clause = node.importClause
   if (!clause) return true
   if (clause.isTypeOnly) return false
@@ -24,32 +33,32 @@ function isRuntimeImport(node: ts.ImportDeclaration): boolean {
 
   const bindings = clause.namedBindings
   if (!bindings) return true
-  if (ts.isNamespaceImport(bindings)) return true
+  if (isNamespaceImport(bindings)) return true
   return bindings.elements.some((element) => !element.isTypeOnly)
 }
 
 function getTypeScriptImports(source: string, filename: string): string[] {
-  const sourceFile = ts.createSourceFile(
+  const sourceFile = createSourceFile(
     filename,
     source,
-    ts.ScriptTarget.Latest,
+    ScriptTarget.Latest,
     true,
-    filename.endsWith('.tsx') ? ts.ScriptKind.TSX : ts.ScriptKind.TS
+    filename.endsWith('.tsx') ? ScriptKind.TSX : ScriptKind.TS
   )
   const imports: string[] = []
 
   for (const statement of sourceFile.statements) {
     if (
-      ts.isImportDeclaration(statement) &&
+      isImportDeclaration(statement) &&
       isRuntimeImport(statement) &&
-      ts.isStringLiteral(statement.moduleSpecifier)
+      isStringLiteral(statement.moduleSpecifier)
     ) {
       imports.push(statement.moduleSpecifier.text)
     } else if (
-      ts.isExportDeclaration(statement) &&
+      isExportDeclaration(statement) &&
       !statement.isTypeOnly &&
       statement.moduleSpecifier &&
-      ts.isStringLiteral(statement.moduleSpecifier)
+      isStringLiteral(statement.moduleSpecifier)
     ) {
       imports.push(statement.moduleSpecifier.text)
     }

--- a/scripts/startupBoundary.ts
+++ b/scripts/startupBoundary.ts
@@ -1,0 +1,153 @@
+import { existsSync, readFileSync, statSync } from 'node:fs'
+import path from 'node:path'
+
+import ts from 'typescript'
+import { parse } from 'vue/compiler-sfc'
+
+const SOURCE_EXTENSIONS = ['.ts', '.tsx', '.js', '.mjs', '.vue', '.css']
+
+type ImportEdge = {
+  importer: string
+  imported: string
+}
+
+export type StartupBoundaryViolation = {
+  forbiddenModule: string
+  importChain: string[]
+}
+
+function isRuntimeImport(node: ts.ImportDeclaration): boolean {
+  const clause = node.importClause
+  if (!clause) return true
+  if (clause.isTypeOnly) return false
+  if (clause.name) return true
+
+  const bindings = clause.namedBindings
+  if (!bindings) return true
+  if (ts.isNamespaceImport(bindings)) return true
+  return bindings.elements.some((element) => !element.isTypeOnly)
+}
+
+function getTypeScriptImports(source: string, filename: string): string[] {
+  const sourceFile = ts.createSourceFile(
+    filename,
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+    filename.endsWith('.tsx') ? ts.ScriptKind.TSX : ts.ScriptKind.TS
+  )
+  const imports: string[] = []
+
+  for (const statement of sourceFile.statements) {
+    if (
+      ts.isImportDeclaration(statement) &&
+      isRuntimeImport(statement) &&
+      ts.isStringLiteral(statement.moduleSpecifier)
+    ) {
+      imports.push(statement.moduleSpecifier.text)
+    } else if (
+      ts.isExportDeclaration(statement) &&
+      !statement.isTypeOnly &&
+      statement.moduleSpecifier &&
+      ts.isStringLiteral(statement.moduleSpecifier)
+    ) {
+      imports.push(statement.moduleSpecifier.text)
+    }
+  }
+
+  return imports
+}
+
+function getStaticImports(filename: string): string[] {
+  const source = readFileSync(filename, 'utf8')
+
+  if (filename.endsWith('.css')) {
+    return [...source.matchAll(/@import\s+(?:url\()?['"]([^'"]+)['"]/g)].map(
+      (match) => match[1]
+    )
+  }
+
+  if (!filename.endsWith('.vue')) {
+    return getTypeScriptImports(source, filename)
+  }
+
+  const { descriptor } = parse(source, { filename })
+  return [descriptor.script?.content, descriptor.scriptSetup?.content]
+    .filter((script): script is string => script !== undefined)
+    .flatMap((script) => getTypeScriptImports(script, filename))
+}
+
+function resolveSourceImport(
+  workspaceRoot: string,
+  importer: string,
+  specifier: string
+): string | undefined {
+  const withoutQuery = specifier.split('?', 1)[0]
+  let candidate: string
+
+  if (withoutQuery.startsWith('@/')) {
+    candidate = path.join(workspaceRoot, 'src', withoutQuery.slice(2))
+  } else if (withoutQuery.startsWith('.')) {
+    candidate = path.resolve(path.dirname(importer), withoutQuery)
+  } else {
+    return
+  }
+
+  const candidates = [
+    candidate,
+    ...SOURCE_EXTENSIONS.map((extension) => `${candidate}${extension}`),
+    ...SOURCE_EXTENSIONS.map((extension) =>
+      path.join(candidate, `index${extension}`)
+    )
+  ]
+  return candidates.find(
+    (resolved) => existsSync(resolved) && statSync(resolved).isFile()
+  )
+}
+
+function getImportEdges(workspaceRoot: string, importer: string): ImportEdge[] {
+  return getStaticImports(importer).flatMap((specifier) => {
+    const imported = resolveSourceImport(workspaceRoot, importer, specifier)
+    return imported ? [{ importer, imported }] : []
+  })
+}
+
+export function findStartupBoundaryViolations({
+  workspaceRoot,
+  roots,
+  isForbidden
+}: {
+  workspaceRoot: string
+  roots: string[]
+  isForbidden: (relativePath: string) => boolean
+}): StartupBoundaryViolation[] {
+  const absoluteRoots = roots.map((root) => path.join(workspaceRoot, root))
+  const queue = absoluteRoots.map((root) => ({ module: root, chain: [root] }))
+  const visited = new Set<string>()
+  const violations = new Map<string, StartupBoundaryViolation>()
+
+  while (queue.length) {
+    const current = queue.shift()
+    if (!current || visited.has(current.module)) continue
+    visited.add(current.module)
+
+    for (const edge of getImportEdges(workspaceRoot, current.module)) {
+      const chain = [...current.chain, edge.imported]
+      const relativePath = path.relative(workspaceRoot, edge.imported)
+      if (isForbidden(relativePath)) {
+        if (!violations.has(relativePath)) {
+          violations.set(relativePath, {
+            forbiddenModule: relativePath,
+            importChain: chain.map((filename) =>
+              path.relative(workspaceRoot, filename)
+            )
+          })
+        }
+        continue
+      }
+      queue.push({ module: edge.imported, chain })
+    }
+  }
+
+  return [...violations.values()]
+}

--- a/scripts/startupChunkBoundary.test.ts
+++ b/scripts/startupChunkBoundary.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+
+import viteConfig from '../vite.config.mts'
+
+type ChunkGroup = {
+  name: string
+  test: RegExp
+}
+
+const output = viteConfig.build?.rolldownOptions?.output
+if (!output || Array.isArray(output)) {
+  throw new Error('Expected one Rolldown output configuration')
+}
+const chunkGroups = (output as { codeSplitting?: { groups?: ChunkGroup[] } })
+  .codeSplitting?.groups
+
+function getChunkGroup(name: string): ChunkGroup {
+  const group = chunkGroups?.find((candidate) => candidate.name === name)
+  if (!group) throw new Error(`Missing chunk group: ${name}`)
+  return group
+}
+
+describe('startup chunk boundary', () => {
+  it.for([
+    ['vendor-three', '/node_modules/three/src/Three.js'],
+    ['vendor-three', '/node_modules/@sparkjsdev/spark/dist/index.js'],
+    [
+      'vendor-three',
+      '/node_modules/@comfyorg/fbx-exporter-three/dist/index.js'
+    ],
+    ['vendor-three', '/node_modules/wwobjloader2/dist/index.js'],
+    ['vendor-tiptap', '/node_modules/@tiptap/core/dist/index.js'],
+    ['vendor-tiptap', '/node_modules/tiptap-markdown/dist/index.js']
+  ])('$0 owns every package in its optional capability', ([groupName, id]) => {
+    expect(getChunkGroup(groupName).test.test(id)).toBe(true)
+  })
+})

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,38 +1,17 @@
 <template>
   <router-view />
   <GlobalDialog />
-  <BlockUI full-screen :blocked="isLoading" />
 </template>
 
 <script setup lang="ts">
-import BlockUI from 'primevue/blockui'
-import { computed, onMounted, watch } from 'vue'
+import { onMounted } from 'vue'
 
 import GlobalDialog from '@/components/dialog/GlobalDialog.vue'
 import config from '@/config'
 import { isDesktop } from '@/platform/distribution/types'
 import { reportError } from '@/platform/telemetry/reportError'
-import { app } from '@/scripts/app'
-import { useWorkspaceStore } from '@/stores/workspaceStore'
 import { electronAPI } from '@/utils/envUtil'
 import { parsePreloadError } from '@/utils/preloadErrorUtil'
-import { useConflictDetection } from '@/workbench/extensions/manager/composables/useConflictDetection'
-
-const workspaceStore = useWorkspaceStore()
-app.extensionManager = useWorkspaceStore()
-
-const conflictDetection = useConflictDetection()
-const isLoading = computed<boolean>(() => workspaceStore.spinner)
-
-watch(
-  isLoading,
-  (loading, prevLoading) => {
-    if (prevLoading && !loading) {
-      document.getElementById('splash-loader')?.remove()
-    }
-  },
-  { flush: 'post' }
-)
 
 const showContextMenu = (event: MouseEvent) => {
   const { target } = event
@@ -119,9 +98,5 @@ onMounted(() => {
       true
     )
   }
-
-  // Initialize conflict detection in background
-  // This runs async and doesn't block UI setup
-  void conflictDetection.initializeConflictDetection()
 })
 </script>

--- a/src/assets/css/editor.css
+++ b/src/assets/css/editor.css
@@ -1,1 +1,1 @@
-@import '@/lib/litegraph/public/css/litegraph.css' layer(editor-base);
+@import '../../lib/litegraph/public/css/litegraph.css' layer(editor-base);

--- a/src/assets/css/editor.css
+++ b/src/assets/css/editor.css
@@ -1,0 +1,1 @@
+@import '@/lib/litegraph/public/css/litegraph.css' layer(editor-base);

--- a/src/composables/useEditorStartup.test.ts
+++ b/src/composables/useEditorStartup.test.ts
@@ -43,7 +43,7 @@ vi.mock(
 import { useEditorStartup } from './useEditorStartup'
 
 describe('useEditorStartup', () => {
-  it('installs legacy bridges and starts Editor-owned work once', () => {
+  it('installs legacy bridges and starts Editor-owned work once', async () => {
     const TestComponent = defineComponent(() => {
       useEditorStartup()
       return () => h('div')
@@ -55,14 +55,18 @@ describe('useEditorStartup', () => {
 
     expect(mocks.app.extensionManager).toBe(mocks.workspaceStore)
     expect(mocks.startStoreBootstrap).toHaveBeenCalledOnce()
-    expect(mocks.initializeConflictDetection).toHaveBeenCalledOnce()
+    await vi.waitFor(() => {
+      expect(mocks.initializeConflictDetection).toHaveBeenCalledOnce()
+    })
 
     const hostNode = {}
-    const nodeData = { widgets_values: ['value'] }
+    const nodeData: { widgets_values: string[] } = {
+      widgets_values: ['value']
+    }
     const proxyWidgetMigrationFlush = mocks.lGraph
       .proxyWidgetMigrationFlush as (
       hostNode: object,
-      nodeData: typeof nodeData
+      nodeData: { widgets_values: string[] }
     ) => void
     proxyWidgetMigrationFlush(hostNode, nodeData)
     expect(mocks.flushProxyWidgetMigration).toHaveBeenCalledWith({

--- a/src/composables/useEditorStartup.test.ts
+++ b/src/composables/useEditorStartup.test.ts
@@ -1,0 +1,79 @@
+import { render } from '@testing-library/vue'
+import { defineComponent, h } from 'vue'
+import { describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  app: { extensionManager: undefined as unknown },
+  autoExposeKnownPreviewNodes: vi.fn(),
+  flushProxyWidgetMigration: vi.fn(),
+  initializeConflictDetection: vi.fn().mockResolvedValue(undefined),
+  lGraph: {
+    autoExposePreviewNodes: undefined as unknown,
+    proxyWidgetMigrationFlush: undefined as unknown
+  },
+  startStoreBootstrap: vi.fn().mockResolvedValue(undefined),
+  workspaceStore: { spinner: false }
+}))
+
+vi.mock('@/core/graph/subgraph/migration/proxyWidgetMigration', () => ({
+  flushProxyWidgetMigration: mocks.flushProxyWidgetMigration
+}))
+vi.mock('@/core/graph/subgraph/promotionUtils', () => ({
+  autoExposeKnownPreviewNodes: mocks.autoExposeKnownPreviewNodes
+}))
+vi.mock('@/lib/litegraph/src/litegraph', () => ({ LGraph: mocks.lGraph }))
+vi.mock('@/scripts/app', () => ({ app: mocks.app }))
+vi.mock('@/stores/bootstrapStore', () => ({
+  useBootstrapStore: () => ({
+    startStoreBootstrap: mocks.startStoreBootstrap
+  })
+}))
+vi.mock('@/stores/workspaceStore', () => ({
+  useWorkspaceStore: () => mocks.workspaceStore
+}))
+vi.mock(
+  '@/workbench/extensions/manager/composables/useConflictDetection',
+  () => ({
+    useConflictDetection: () => ({
+      initializeConflictDetection: mocks.initializeConflictDetection
+    })
+  })
+)
+
+import { useEditorStartup } from './useEditorStartup'
+
+describe('useEditorStartup', () => {
+  it('installs legacy bridges and starts Editor-owned work once', () => {
+    const TestComponent = defineComponent(() => {
+      useEditorStartup()
+      return () => h('div')
+    })
+
+    const first = render(TestComponent)
+    first.unmount()
+    render(TestComponent)
+
+    expect(mocks.app.extensionManager).toBe(mocks.workspaceStore)
+    expect(mocks.startStoreBootstrap).toHaveBeenCalledOnce()
+    expect(mocks.initializeConflictDetection).toHaveBeenCalledOnce()
+
+    const hostNode = {}
+    const nodeData = { widgets_values: ['value'] }
+    const proxyWidgetMigrationFlush = mocks.lGraph
+      .proxyWidgetMigrationFlush as (
+      hostNode: object,
+      nodeData: typeof nodeData
+    ) => void
+    proxyWidgetMigrationFlush(hostNode, nodeData)
+    expect(mocks.flushProxyWidgetMigration).toHaveBeenCalledWith({
+      hostNode,
+      hostWidgetValues: nodeData.widgets_values
+    })
+
+    const autoExposePreviewNodes = mocks.lGraph.autoExposePreviewNodes as (
+      hostNode: object
+    ) => void
+    autoExposePreviewNodes(hostNode)
+    expect(mocks.autoExposeKnownPreviewNodes).toHaveBeenCalledWith(hostNode)
+  })
+})

--- a/src/composables/useEditorStartup.test.ts
+++ b/src/composables/useEditorStartup.test.ts
@@ -1,5 +1,5 @@
-import { render } from '@testing-library/vue'
-import { defineComponent, h } from 'vue'
+import { render, screen } from '@testing-library/vue'
+import { defineComponent, h, nextTick } from 'vue'
 import { describe, expect, it, vi } from 'vitest'
 
 const mocks = vi.hoisted(() => ({
@@ -12,7 +12,7 @@ const mocks = vi.hoisted(() => ({
     proxyWidgetMigrationFlush: undefined as unknown
   },
   startStoreBootstrap: vi.fn().mockResolvedValue(undefined),
-  workspaceStore: { spinner: false }
+  workspaceStore: undefined as unknown as { spinner: boolean }
 }))
 
 vi.mock('@/core/graph/subgraph/migration/proxyWidgetMigration', () => ({
@@ -28,9 +28,11 @@ vi.mock('@/stores/bootstrapStore', () => ({
     startStoreBootstrap: mocks.startStoreBootstrap
   })
 }))
-vi.mock('@/stores/workspaceStore', () => ({
-  useWorkspaceStore: () => mocks.workspaceStore
-}))
+vi.mock('@/stores/workspaceStore', async () => {
+  const { reactive } = await import('vue')
+  mocks.workspaceStore = reactive({ spinner: false })
+  return { useWorkspaceStore: () => mocks.workspaceStore }
+})
 vi.mock(
   '@/workbench/extensions/manager/composables/useConflictDetection',
   () => ({
@@ -79,5 +81,25 @@ describe('useEditorStartup', () => {
     ) => void
     autoExposePreviewNodes(hostNode)
     expect(mocks.autoExposeKnownPreviewNodes).toHaveBeenCalledWith(hostNode)
+  })
+
+  it('dismisses the splash only when Editor loading becomes ready', async () => {
+    document.body.innerHTML =
+      '<div id="splash-loader" data-testid="splash-loader"></div>'
+    mocks.workspaceStore.spinner = false
+
+    const TestComponent = defineComponent(() => {
+      useEditorStartup()
+      return () => h('div')
+    })
+    render(TestComponent)
+
+    mocks.workspaceStore.spinner = true
+    await nextTick()
+    expect(screen.getByTestId('splash-loader')).not.toBeNull()
+
+    mocks.workspaceStore.spinner = false
+    await nextTick()
+    expect(screen.queryByTestId('splash-loader')).toBeNull()
   })
 })

--- a/src/composables/useEditorStartup.ts
+++ b/src/composables/useEditorStartup.ts
@@ -4,6 +4,7 @@ import { flushProxyWidgetMigration } from '@/core/graph/subgraph/migration/proxy
 import { autoExposeKnownPreviewNodes } from '@/core/graph/subgraph/promotionUtils'
 import { LGraph } from '@/lib/litegraph/src/litegraph'
 import { app } from '@/scripts/app'
+import { hideSplashScreen } from '@/services/splashScreenService'
 import { useBootstrapStore } from '@/stores/bootstrapStore'
 import { useWorkspaceStore } from '@/stores/workspaceStore'
 
@@ -47,9 +48,7 @@ export function useEditorStartup() {
   watch(
     isLoading,
     (loading, previousLoading) => {
-      if (previousLoading && !loading) {
-        document.getElementById('splash-loader')?.remove()
-      }
+      if (previousLoading && !loading) hideSplashScreen()
     },
     { flush: 'post' }
   )

--- a/src/composables/useEditorStartup.ts
+++ b/src/composables/useEditorStartup.ts
@@ -1,0 +1,58 @@
+import { computed, onMounted, watch } from 'vue'
+
+import { flushProxyWidgetMigration } from '@/core/graph/subgraph/migration/proxyWidgetMigration'
+import { autoExposeKnownPreviewNodes } from '@/core/graph/subgraph/promotionUtils'
+import { LGraph } from '@/lib/litegraph/src/litegraph'
+import { app } from '@/scripts/app'
+import { useBootstrapStore } from '@/stores/bootstrapStore'
+import { useWorkspaceStore } from '@/stores/workspaceStore'
+
+import '@/assets/css/editor.css'
+
+let storeBootstrapStarted = false
+let backgroundStartup: Promise<void> | undefined
+
+function startBackgroundEditorTasks(): Promise<void> {
+  backgroundStartup ??=
+    import('@/workbench/extensions/manager/composables/useConflictDetection').then(
+      ({ useConflictDetection }) =>
+        useConflictDetection().initializeConflictDetection()
+    )
+  return backgroundStartup
+}
+
+export function useEditorStartup() {
+  const workspaceStore = useWorkspaceStore()
+  const bootstrapStore = useBootstrapStore()
+
+  app.extensionManager = workspaceStore
+  LGraph.proxyWidgetMigrationFlush = (hostNode, nodeData) =>
+    flushProxyWidgetMigration({
+      hostNode,
+      hostWidgetValues: nodeData?.widgets_values
+    })
+  LGraph.autoExposePreviewNodes = (hostNode) =>
+    autoExposeKnownPreviewNodes(hostNode)
+
+  if (!storeBootstrapStarted) {
+    storeBootstrapStarted = true
+    void bootstrapStore.startStoreBootstrap()
+  }
+
+  onMounted(() => {
+    void startBackgroundEditorTasks()
+  })
+
+  const isLoading = computed(() => workspaceStore.spinner)
+  watch(
+    isLoading,
+    (loading, previousLoading) => {
+      if (previousLoading && !loading) {
+        document.getElementById('splash-loader')?.remove()
+      }
+    },
+    { flush: 'post' }
+  )
+
+  return { isLoading }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -16,24 +16,17 @@ import { VueFire, VueFireAuth } from 'vuefire'
 
 import { setAssertReporter } from '@/base/assert'
 import { getFirebaseConfig } from '@/config/firebase'
-import { flushProxyWidgetMigration } from '@/core/graph/subgraph/migration/proxyWidgetMigration'
-import { autoExposeKnownPreviewNodes } from '@/core/graph/subgraph/promotionUtils'
-import { LGraph } from '@/lib/litegraph/src/litegraph'
 import {
   configValueOrDefault,
   remoteConfig
 } from '@/platform/remoteConfig/remoteConfig'
-import { syncHostUserIdWithFirebaseAuth } from '@/platform/telemetry/hostUserIdSync'
 import { flushErrorReports } from '@/platform/telemetry/reportError'
-import '@/lib/litegraph/public/css/litegraph.css'
 import router from '@/router'
 import { isDesktop, isNightly } from '@/platform/distribution/types'
 import { stripPaymentReturnParams } from '@/platform/cloud/subscription/utils/paymentReturnUrl'
 import { useToastStore } from '@/platform/updates/common/toastStore'
-import { useBootstrapStore } from '@/stores/bootstrapStore'
 
 import App from './App.vue'
-// Intentionally relative import to ensure the CSS is loaded in the right order (after litegraph.css)
 import './assets/css/style.css'
 import { i18n } from './i18n'
 
@@ -160,19 +153,9 @@ app
   })
 
 if (isCloud && hasHostTelemetryBridge) {
+  const { syncHostUserIdWithFirebaseAuth } =
+    await import('@/platform/telemetry/hostUserIdSync')
   syncHostUserIdWithFirebaseAuth()
 }
-
-LGraph.proxyWidgetMigrationFlush = (hostNode, nodeData) =>
-  flushProxyWidgetMigration({
-    hostNode,
-    hostWidgetValues: nodeData?.widgets_values
-  })
-
-LGraph.autoExposePreviewNodes = (hostNode) =>
-  autoExposeKnownPreviewNodes(hostNode)
-
-const bootstrapStore = useBootstrapStore(pinia)
-void bootstrapStore.startStoreBootstrap()
 
 app.mount('#vue-app')

--- a/src/platform/cloud/onboarding/CloudSubscriptionRedirectView.vue
+++ b/src/platform/cloud/onboarding/CloudSubscriptionRedirectView.vue
@@ -12,6 +12,7 @@ import type { TierKey } from '@/platform/cloud/subscription/constants/tierPricin
 import { useSubscriptionDialog } from '@/platform/cloud/subscription/composables/useSubscriptionDialog'
 import { getPricingCheckoutSelection } from '@/platform/cloud/subscription/composables/usePricingTableUrlLoader'
 import type { CheckoutTierKey } from '@/platform/workspace/composables/useSubscriptionCheckout'
+import { hideSplashScreen } from '@/services/splashScreenService'
 
 import type { BillingCycle } from '../subscription/utils/subscriptionTierRank'
 
@@ -157,7 +158,7 @@ const runRedirect = wrapWithErrorHandlingAsync(async () => {
 }, reportError)
 
 onMounted(() => {
-  document.getElementById('splash-loader')?.remove()
+  hideSplashScreen()
   void runRedirect()
 })
 </script>

--- a/src/platform/cloud/onboarding/components/CloudLayoutView.vue
+++ b/src/platform/cloud/onboarding/components/CloudLayoutView.vue
@@ -12,10 +12,11 @@ import { onMounted } from 'vue'
 import { RouterView } from 'vue-router'
 
 import GlobalToast from '@/components/toast/GlobalToast.vue'
+import { hideSplashScreen } from '@/services/splashScreenService'
 
 import CloudTemplate from './CloudTemplate.vue'
 
 onMounted(() => {
-  document.getElementById('splash-loader')?.remove()
+  hideSplashScreen()
 })
 </script>

--- a/src/platform/cloud/onboarding/components/OAuthLayoutView.vue
+++ b/src/platform/cloud/onboarding/components/OAuthLayoutView.vue
@@ -16,8 +16,9 @@ import { onMounted } from 'vue'
 import { RouterView } from 'vue-router'
 
 import GlobalToast from '@/components/toast/GlobalToast.vue'
+import { hideSplashScreen } from '@/services/splashScreenService'
 
 onMounted(() => {
-  document.getElementById('splash-loader')?.remove()
+  hideSplashScreen()
 })
 </script>

--- a/src/platform/cloud/onboarding/desktopLoginRedemption.ts
+++ b/src/platform/cloud/onboarding/desktopLoginRedemption.ts
@@ -9,7 +9,6 @@ import {
 import { PRESERVED_QUERY_NAMESPACES } from '@/platform/navigation/preservedQueryNamespaces'
 import { useToastStore } from '@/platform/updates/common/toastStore'
 import { api } from '@/scripts/api'
-import { useDialogService } from '@/services/dialogService'
 import { useAuthStore } from '@/stores/authStore'
 
 const NAMESPACE = PRESERVED_QUERY_NAMESPACES.DESKTOP_LOGIN
@@ -116,6 +115,7 @@ async function confirmRedemption(
   uid: string
 ): Promise<boolean> {
   if (state.approvedUserUid === uid) return true
+  const { useDialogService } = await import('@/services/dialogService')
   const confirmed = await useDialogService().confirm({
     key: 'global-desktop-login-confirm',
     title: t('desktopLogin.confirmSummary'),

--- a/src/platform/workspace/auth/WorkspaceAuthGate.vue
+++ b/src/platform/workspace/auth/WorkspaceAuthGate.vue
@@ -69,7 +69,6 @@ import {
 } from 'vue'
 
 import Button from '@/components/ui/button/Button.vue'
-import { useAuthActions } from '@/composables/auth/useAuthActions'
 import { useFeatureFlags } from '@/composables/useFeatureFlags'
 import { isCloud } from '@/platform/distribution/types'
 import {
@@ -213,6 +212,7 @@ async function retryInitialization(): Promise<void> {
 
 async function handleSignOut(): Promise<void> {
   cancelInitialization()
+  const { useAuthActions } = await import('@/composables/auth/useAuthActions')
   await useAuthActions().logout()
 }
 

--- a/src/platform/workspace/auth/WorkspaceAuthGate.vue
+++ b/src/platform/workspace/auth/WorkspaceAuthGate.vue
@@ -80,6 +80,7 @@ import { reportError } from '@/platform/telemetry/reportError'
 import { useWorkspaceAuthStore } from '@/platform/workspace/stores/workspaceAuthStore'
 import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
 import { useBillingCapabilities } from '@/platform/workspace/composables/useBillingCapabilities'
+import { hideSplashScreen } from '@/services/splashScreenService'
 import { useApiKeyAuthStore } from '@/stores/apiKeyAuthStore'
 import { useAuthStore } from '@/stores/authStore'
 
@@ -186,7 +187,7 @@ async function initialize(): Promise<void> {
     })
     initializationRetryable.value = isRetryableInitializationError(error)
     initializationState.value = 'error'
-    document.getElementById('splash-loader')?.remove()
+    hideSplashScreen()
     await nextTick()
     if (generation !== initializationGeneration) return
     errorPanel.value?.focus()

--- a/src/router.ts
+++ b/src/router.ts
@@ -10,7 +10,6 @@ import type { RouteLocationNormalized } from 'vue-router'
 import { useFeatureFlags } from '@/composables/useFeatureFlags'
 import { isCloud, isDesktop } from '@/platform/distribution/types'
 import { useTelemetry } from '@/platform/telemetry'
-import { useDialogService } from '@/services/dialogService'
 import { useAuthStore } from '@/stores/authStore'
 import { useUserStore } from '@/stores/userStore'
 import LayoutDefault from '@/views/layouts/LayoutDefault.vue'
@@ -229,6 +228,7 @@ if (isCloud) {
     if (!isLoggedIn) {
       // For Electron, use dialog
       if (isDesktop) {
+        const { useDialogService } = await import('@/services/dialogService')
         const dialogService = useDialogService()
         const loginSuccess = await dialogService.showSignInDialog()
         return loginSuccess ? next() : next(false)

--- a/src/services/splashScreenService.test.ts
+++ b/src/services/splashScreenService.test.ts
@@ -1,0 +1,16 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { hideSplashScreen } from './splashScreenService'
+
+describe('hideSplashScreen', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '<div id="splash-loader"></div>'
+  })
+
+  it('is safe to call after the splash is already gone', () => {
+    hideSplashScreen()
+    hideSplashScreen()
+
+    expect(document.getElementById('splash-loader')).toBeNull()
+  })
+})

--- a/src/services/splashScreenService.ts
+++ b/src/services/splashScreenService.ts
@@ -1,0 +1,3 @@
+export function hideSplashScreen(): void {
+  document.getElementById('splash-loader')?.remove()
+}

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -32,7 +32,6 @@ import { PRESERVED_QUERY_NAMESPACES } from '@/platform/navigation/preservedQuery
 import { invalidateRemoteConfig } from '@/platform/remoteConfig/refreshRemoteConfig'
 import { useTelemetry } from '@/platform/telemetry'
 import { api } from '@/scripts/api'
-import { useDialogService } from '@/services/dialogService'
 import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
 import { useWorkspaceAuthStore } from '@/platform/workspace/stores/workspaceAuthStore'
 import { useApiKeyAuthStore } from '@/stores/apiKeyAuthStore'
@@ -226,6 +225,7 @@ export const useAuthStore = defineStore('auth', () => {
         return
       }
 
+      const { useDialogService } = await import('@/services/dialogService')
       useDialogService().showErrorDialog(error, {
         title: t('errorDialog.defaultTitle'),
         reportType: 'authenticationError'

--- a/src/views/GraphView.test.ts
+++ b/src/views/GraphView.test.ts
@@ -45,6 +45,9 @@ vi.mock('@/composables/useBrowserTabTitle', () => ({
   useBrowserTabTitle: vi.fn()
 }))
 vi.mock('@/composables/useCoreCommands', () => ({ useCoreCommands: () => [] }))
+vi.mock('@/composables/useEditorStartup', () => ({
+  useEditorStartup: () => ({ isLoading: ref(false) })
+}))
 vi.mock('@/platform/remote/comfyui/useQueuePolling', () => ({
   useQueuePolling: vi.fn()
 }))
@@ -190,6 +193,7 @@ vi.mock('@/components/toast/RerouteMigrationToast.vue', () => stubModule)
 vi.mock('@/components/MenuHamburger.vue', () => stubModule)
 vi.mock('@/components/dialog/UnloadWindowConfirmDialog.vue', () => stubModule)
 vi.mock('@/renderer/extensions/firstRunTour/FirstRunTour.vue', () => stubModule)
+vi.mock('primevue/blockui', () => stubModule)
 
 // Imported at module scope, not inside the test. `vi.mock` is hoisted above
 // every import, so the stubs above still apply — but compiling GraphView.vue

--- a/src/views/GraphView.vue
+++ b/src/views/GraphView.vue
@@ -31,11 +31,13 @@
   <MenuHamburger />
   <TourOverlay v-if="graphReady" />
   <FirstRunTour />
+  <BlockUI full-screen :blocked="isLoading" />
 </template>
 
 <script setup lang="ts">
 import { useEventListener, useIntervalFn } from '@vueuse/core'
 import { storeToRefs } from 'pinia'
+import BlockUI from 'primevue/blockui'
 
 import {
   computed,
@@ -58,6 +60,7 @@ import InviteAcceptedToast from '@/platform/workspace/components/toasts/InviteAc
 import RerouteMigrationToast from '@/components/toast/RerouteMigrationToast.vue'
 import { useBrowserTabTitle } from '@/composables/useBrowserTabTitle'
 import { useCoreCommands } from '@/composables/useCoreCommands'
+import { useEditorStartup } from '@/composables/useEditorStartup'
 import { useQueuePolling } from '@/platform/remote/comfyui/useQueuePolling'
 import { useErrorHandling } from '@/composables/useErrorHandling'
 import { useReconnectQueueRefresh } from '@/composables/useReconnectQueueRefresh'
@@ -103,6 +106,8 @@ import BuilderMenu from '@/components/builder/BuilderMenu.vue'
 import BuilderToolbar from '@/components/builder/BuilderToolbar.vue'
 import LinearView from '@/views/LinearView.vue'
 import ManagerProgressToast from '@/workbench/extensions/manager/components/ManagerProgressToast.vue'
+
+const { isLoading } = useEditorStartup()
 
 setupAutoQueueHandler()
 useProgressFavicon()

--- a/src/views/UserSelectView.vue
+++ b/src/views/UserSelectView.vue
@@ -50,6 +50,7 @@ import { computed, onMounted, ref } from 'vue'
 import { useRouter } from 'vue-router'
 
 import Button from '@/components/ui/button/Button.vue'
+import { hideSplashScreen } from '@/services/splashScreenService'
 import type { User } from '@/stores/userStore'
 import { useUserStore } from '@/stores/userStore'
 import BaseViewTemplate from '@/views/templates/BaseViewTemplate.vue'
@@ -87,7 +88,7 @@ const login = async () => {
 }
 
 onMounted(async () => {
-  document.getElementById('splash-loader')?.remove()
+  hideSplashScreen()
 
   await userStore.initialize()
 })

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -650,12 +650,12 @@ export default defineConfig({
             // Heavy optional features
             {
               name: 'vendor-three',
-              test: /[\\/]node_modules[\\/](three|@sparkjsdev)[\\/]/,
+              test: /[\\/]node_modules[\\/](three|@sparkjsdev|@comfyorg[\\/]fbx-exporter-three|wwobjloader2)[\\/]/,
               priority: 15
             },
             {
               name: 'vendor-tiptap',
-              test: /[\\/]node_modules[\\/]@tiptap[\\/]/,
+              test: /[\\/]node_modules[\\/](@tiptap|tiptap-markdown)[\\/]/,
               priority: 15
             },
             {


### PR DESCRIPTION
## Summary

Establish a hard shared-entry/Editor startup boundary so Home and focused routes can render without loading the Editor runtime.

## Changes

- **What**: Move Editor startup, blocking UI, conflict detection, LiteGraph CSS, and legacy app bridges behind `GraphView`; centralize destination splash readiness.
- **Dependencies**: No new dependencies.
- Add source-graph, optional-vendor ownership, and splash-ownership regression guards.
- Verify the generated Cloud bootstrap preload map excludes `GraphView`, `settingStore`, Three, Tiptap, and Yjs chunks.

## Review Focus

- Confirm `GraphView` is the right owner for Editor startup and the legacy app/store bridges.
- Confirm route-owned LiteGraph CSS preserves existing Editor styling.
- This intentionally does not add Home or change `/`; Home data, destination routing, and the dedicated Desktop auth-code page remain follow-ups.

## Validation

- 15 Vitest files / 260 tests
- Typecheck, lint, formatting, and Knip
- Cloud production build and generated bootstrap preload ownership check
- Five Cloud startup/login browser tests
