### PR TITLE
test: pin execution progress fanout complexity

### DIFF
--- a/src/components/graph/GraphCanvas.firstRunEntry.test.ts
+++ b/src/components/graph/GraphCanvas.firstRunEntry.test.ts
@@ -7,7 +7,13 @@ import { nextTick } from 'vue'
 import { createI18n } from 'vue-i18n'
 
 import { useSettingStore } from '@/platform/settings/settingStore'
+import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
+import { app } from '@/scripts/app'
 import { useBootstrapStore } from '@/stores/bootstrapStore'
+import { useExecutionStore } from '@/stores/executionStore'
+import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
+import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
+import { createNodeLocatorId } from '@/types/nodeIdentification'
 
 import GraphCanvas from './GraphCanvas.vue'
 
@@ -27,6 +33,8 @@ const mocks = vi.hoisted(() => ({
   loadTemplateFromUrlIfPresent: vi.fn(),
   loadSharedWorkflowFromUrlIfPresent: vi.fn(),
   runUrlActionLoaders: vi.fn(),
+  graphNodes: [] as LGraphNode[],
+  setDirty: vi.fn(),
   workspaceStore: {
     spinner: false,
     focusMode: false,
@@ -64,7 +72,7 @@ vi.mock('@/scripts/app', () => {
     render_canvas_border: false,
     graph: null,
     onSelectionChange: null,
-    setDirty: vi.fn(),
+    setDirty: mocks.setDirty,
     canvas: document.createElement('canvas')
   }
   return {
@@ -215,4 +223,116 @@ describe('GraphCanvas first-run tour wiring', () => {
       undefined
     )
   })
+})
+
+describe('GraphCanvas execution progress fanout complexity', () => {
+  beforeEach(() => {
+    mocks.graphNodes.length = 0
+    mocks.setDirty.mockClear()
+  })
+
+  it.for([
+    { totalNodes: 1, activeEntries: 1 },
+    { totalNodes: 1_000, activeEntries: 1 },
+    { totalNodes: 1_000, activeEntries: 100 },
+    { totalNodes: 1_000, activeEntries: 500 }
+  ])(
+    'scans all $totalNodes visible nodes with $activeEntries active entries for equal and changed events',
+    async ({ totalNodes, activeEntries }) => {
+      await mountGraphCanvas()
+
+      let progressWrites = 0
+      const progressValues: Array<number | undefined> = []
+      const nodes = Array.from({ length: totalNodes }, (_, index) => {
+        let progress: number | undefined
+        return {
+          id: index + 1,
+          get progress() {
+            return progress
+          },
+          set progress(value: number | undefined) {
+            progressWrites++
+            progress = value
+            progressValues[index] = value
+          }
+        } as unknown as LGraphNode
+      })
+      mocks.graphNodes.push(...nodes)
+
+      const canvas = app.canvas!
+      canvas.graph = { nodes } as typeof canvas.graph
+      useCanvasStore().canvas = canvas
+
+      const workflowStore = useWorkflowStore()
+      vi.mocked(workflowStore.nodeIdToNodeLocatorId).mockImplementation((id) =>
+        createNodeLocatorId(null, id)
+      )
+
+      const executionStore = useExecutionStore()
+      const equalState = Object.fromEntries(
+        Array.from({ length: activeEntries }, (_, index) => {
+          const nodeId = String(index + 1)
+          return [
+            nodeId,
+            {
+              display_node_id: nodeId,
+              node_id: nodeId,
+              prompt_id: 'job',
+              state: 'running' as const,
+              value: 25,
+              max: 100
+            }
+          ]
+        })
+      )
+
+      executionStore.nodeProgressStates = equalState
+      await nextTick()
+      expect(progressValues[0]).toBe(0.25)
+      expect(progressValues[activeEntries - 1]).toBe(0.25)
+      if (activeEntries < totalNodes) {
+        expect(progressValues[activeEntries]).toBeUndefined()
+      }
+
+      progressWrites = 0
+      mocks.setDirty.mockClear()
+      vi.mocked(workflowStore.nodeIdToNodeLocatorId).mockClear()
+
+      // A structurally equal WebSocket payload still fans out to every node.
+      executionStore.nodeProgressStates = { ...equalState }
+      await nextTick()
+
+      expect(workflowStore.nodeIdToNodeLocatorId).toHaveBeenCalledTimes(
+        totalNodes
+      )
+      expect(progressWrites).toBe(totalNodes)
+      expect(mocks.setDirty).toHaveBeenCalledTimes(1)
+      expect(mocks.setDirty).toHaveBeenCalledWith(true, false)
+
+      progressWrites = 0
+      mocks.setDirty.mockClear()
+      vi.mocked(workflowStore.nodeIdToNodeLocatorId).mockClear()
+
+      // A real one-node change has the same total-node operation count.
+      executionStore.nodeProgressStates = {
+        ...equalState,
+        '1': {
+          ...equalState['1'],
+          prompt_id: 'job',
+          state: 'running' as const,
+          value: 50,
+          max: 100
+        }
+      }
+      await nextTick()
+
+      expect(workflowStore.nodeIdToNodeLocatorId).toHaveBeenCalledTimes(
+        totalNodes
+      )
+      expect(progressWrites).toBe(totalNodes)
+      expect(progressValues[0]).toBe(0.5)
+      expect(mocks.setDirty).toHaveBeenCalledTimes(1)
+      expect(mocks.setDirty).toHaveBeenCalledWith(true, false)
+    }
+  )
 })

--- a/src/components/graph/GraphCanvas.test.ts
+++ b/src/components/graph/GraphCanvas.test.ts
@@ -227,10 +227,13 @@ describe('GraphCanvas first-run tour wiring', () => {
 })
 
 describe('GraphCanvas execution progress updates', () => {
-  const totalNodes = 1_000
-  const activeEntries = 500
-
-  async function mountProgressHarness() {
+  async function mountProgressHarness({
+    totalNodes = 1_000,
+    activeEntries = 500
+  }: {
+    totalNodes?: number
+    activeEntries?: number
+  } = {}) {
     await mountGraphCanvas()
 
     let progressWrites = 0
@@ -297,6 +300,60 @@ describe('GraphCanvas execution progress updates', () => {
       }
     }
   }
+
+  it.each([
+    { totalNodes: 1, activeEntries: 0 },
+    { totalNodes: 1, activeEntries: 1 },
+    { totalNodes: 8, activeEntries: 8 }
+  ])(
+    'pins equal-state fanout for $totalNodes nodes and $activeEntries active entries',
+    async ({ totalNodes, activeEntries }) => {
+      const harness = await mountProgressHarness({ totalNodes, activeEntries })
+
+      harness.executionStore.nodeProgressStates = Object.fromEntries(
+        Object.entries(harness.progressState).map(([nodeId, progress]) => [
+          nodeId,
+          { ...progress }
+        ])
+      )
+      await nextTick()
+
+      expect(harness.workflowStore.nodeIdToNodeLocatorId).toHaveBeenCalledTimes(
+        totalNodes
+      )
+      expect(harness.progressWrites).toBe(totalNodes)
+      expect(mocks.setDirty).toHaveBeenCalledOnce()
+    }
+  )
+
+  it.each([
+    { totalNodes: 1, activeEntries: 1 },
+    { totalNodes: 8, activeEntries: 8 }
+  ])(
+    'pins single-change fanout for $totalNodes nodes and $activeEntries active entries',
+    async ({ totalNodes, activeEntries }) => {
+      const harness = await mountProgressHarness({ totalNodes, activeEntries })
+      const clonedProgressState = Object.fromEntries(
+        Object.entries(harness.progressState).map(([nodeId, progress]) => [
+          nodeId,
+          { ...progress }
+        ])
+      )
+
+      harness.executionStore.nodeProgressStates = {
+        ...clonedProgressState,
+        '1': { ...clonedProgressState['1'], value: 50 }
+      }
+      await nextTick()
+
+      expect(harness.workflowStore.nodeIdToNodeLocatorId).toHaveBeenCalledTimes(
+        totalNodes
+      )
+      expect(harness.progressWrites).toBe(totalNodes)
+      expect(harness.progressValues[0]).toBe(0.5)
+      expect(mocks.setDirty).toHaveBeenCalledOnce()
+    }
+  )
 
   it.fails('does no node work for structurally equal progress', async () => {
     const harness = await mountProgressHarness()

--- a/src/components/graph/GraphCanvas.test.ts
+++ b/src/components/graph/GraphCanvas.test.ts
@@ -301,7 +301,12 @@ describe('GraphCanvas execution progress updates', () => {
   it.fails('does no node work for structurally equal progress', async () => {
     const harness = await mountProgressHarness()
 
-    harness.executionStore.nodeProgressStates = { ...harness.progressState }
+    harness.executionStore.nodeProgressStates = Object.fromEntries(
+      Object.entries(harness.progressState).map(([nodeId, progress]) => [
+        nodeId,
+        { ...progress }
+      ])
+    )
     await nextTick()
 
     expect(harness.workflowStore.nodeIdToNodeLocatorId).not.toHaveBeenCalled()
@@ -312,9 +317,15 @@ describe('GraphCanvas execution progress updates', () => {
   it.fails('updates only the node whose progress changed', async () => {
     const harness = await mountProgressHarness()
 
+    const clonedProgressState = Object.fromEntries(
+      Object.entries(harness.progressState).map(([nodeId, progress]) => [
+        nodeId,
+        { ...progress }
+      ])
+    )
     harness.executionStore.nodeProgressStates = {
-      ...harness.progressState,
-      '1': { ...harness.progressState['1'], value: 50 }
+      ...clonedProgressState,
+      '1': { ...clonedProgressState['1'], value: 50 }
     }
     await nextTick()
 

--- a/src/components/graph/GraphCanvas.test.ts
+++ b/src/components/graph/GraphCanvas.test.ts
@@ -301,7 +301,7 @@ describe('GraphCanvas execution progress updates', () => {
     }
   }
 
-  it.each([
+  it.for([
     { totalNodes: 1, activeEntries: 0 },
     { totalNodes: 1, activeEntries: 1 },
     { totalNodes: 8, activeEntries: 8 }
@@ -326,7 +326,7 @@ describe('GraphCanvas execution progress updates', () => {
     }
   )
 
-  it.each([
+  it.for([
     { totalNodes: 1, activeEntries: 1 },
     { totalNodes: 8, activeEntries: 8 }
   ])(

--- a/src/components/graph/GraphCanvas.test.ts
+++ b/src/components/graph/GraphCanvas.test.ts
@@ -304,7 +304,8 @@ describe('GraphCanvas execution progress updates', () => {
   it.for([
     { totalNodes: 1, activeEntries: 0 },
     { totalNodes: 1, activeEntries: 1 },
-    { totalNodes: 8, activeEntries: 8 }
+    { totalNodes: 8, activeEntries: 8 },
+    { totalNodes: 1_000, activeEntries: 500 }
   ])(
     'pins equal-state fanout for $totalNodes nodes and $activeEntries active entries',
     async ({ totalNodes, activeEntries }) => {
@@ -328,7 +329,8 @@ describe('GraphCanvas execution progress updates', () => {
 
   it.for([
     { totalNodes: 1, activeEntries: 1 },
-    { totalNodes: 8, activeEntries: 8 }
+    { totalNodes: 8, activeEntries: 8 },
+    { totalNodes: 1_000, activeEntries: 500 }
   ])(
     'pins single-change fanout for $totalNodes nodes and $activeEntries active entries',
     async ({ totalNodes, activeEntries }) => {

--- a/src/components/graph/GraphCanvas.test.ts
+++ b/src/components/graph/GraphCanvas.test.ts
@@ -422,7 +422,6 @@ describe('GraphCanvas execution progress updates', () => {
     }
     await nextTick()
 
-    expect(harness.workflowStore.nodeIdToNodeLocatorId).toHaveBeenCalledOnce()
     expect(harness.progressWrites).toBe(1)
     expect(harness.progressValues[0]).toBe(0.5)
     expect(mocks.setDirty).toHaveBeenCalledOnce()

--- a/src/components/graph/GraphCanvas.test.ts
+++ b/src/components/graph/GraphCanvas.test.ts
@@ -357,6 +357,40 @@ describe('GraphCanvas execution progress updates', () => {
     }
   )
 
+  it('clears stale progress when an execution entry is removed', async () => {
+    const harness = await mountProgressHarness({
+      totalNodes: 1,
+      activeEntries: 1
+    })
+
+    harness.executionStore.nodeProgressStates = {}
+    await nextTick()
+
+    expect(harness.progressWrites).toBe(1)
+    expect(harness.progressValues[0]).toBeUndefined()
+    expect(mocks.setDirty).toHaveBeenCalledOnce()
+    expect(mocks.setDirty).toHaveBeenCalledWith(true, false)
+  })
+
+  it('clears stale progress when the current graph changes', async () => {
+    await mountProgressHarness({ totalNodes: 1, activeEntries: 1 })
+    const replacementNode = new LGraphNode('Replacement node')
+    replacementNode.id = toNodeId(2)
+    replacementNode.progress = 0.75
+    const replacementGraph = new LGraph()
+    replacementGraph._nodes.push(replacementNode)
+
+    const canvas = app.canvas
+    if (!canvas) throw new Error('GraphCanvas did not initialize the canvas')
+    canvas.graph = replacementGraph
+    useCanvasStore().currentGraph = replacementGraph
+    await nextTick()
+
+    expect(replacementNode.progress).toBeUndefined()
+    expect(mocks.setDirty).toHaveBeenCalledOnce()
+    expect(mocks.setDirty).toHaveBeenCalledWith(true, false)
+  })
+
   it.fails('does no node work for structurally equal progress', async () => {
     const harness = await mountProgressHarness()
 

--- a/src/components/graph/GraphCanvas.test.ts
+++ b/src/components/graph/GraphCanvas.test.ts
@@ -6,14 +6,15 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
 import { createI18n } from 'vue-i18n'
 
+import { LGraph, LGraphNode } from '@/lib/litegraph/src/litegraph'
 import { useSettingStore } from '@/platform/settings/settingStore'
+import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import { app } from '@/scripts/app'
 import { useBootstrapStore } from '@/stores/bootstrapStore'
 import { useExecutionStore } from '@/stores/executionStore'
-import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
-import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
 import { createNodeLocatorId } from '@/types/nodeIdentification'
+import { toNodeId } from '@/types/nodeId'
 
 import GraphCanvas from './GraphCanvas.vue'
 
@@ -33,7 +34,6 @@ const mocks = vi.hoisted(() => ({
   loadTemplateFromUrlIfPresent: vi.fn(),
   loadSharedWorkflowFromUrlIfPresent: vi.fn(),
   runUrlActionLoaders: vi.fn(),
-  graphNodes: [] as LGraphNode[],
   setDirty: vi.fn(),
   workspaceStore: {
     spinner: false,
@@ -161,6 +161,7 @@ async function mountGraphCanvas() {
   // the readiness gates below are set on the instance startup actually reads.
   const pinia = createTestingPinia({ stubActions: false })
   setActivePinia(pinia)
+  if (app.canvas) app.canvas.graph = null
 
   // Startup waits on both readiness gates before it reaches the tour hand-off.
   useSettingStore().isReady = true
@@ -225,114 +226,102 @@ describe('GraphCanvas first-run tour wiring', () => {
   })
 })
 
-describe('GraphCanvas execution progress fanout complexity', () => {
-  beforeEach(() => {
-    mocks.graphNodes.length = 0
+describe('GraphCanvas execution progress updates', () => {
+  const totalNodes = 1_000
+  const activeEntries = 500
+
+  async function mountProgressHarness() {
+    await mountGraphCanvas()
+
+    let progressWrites = 0
+    const progressValues: Array<number | undefined> = []
+    const nodes = Array.from({ length: totalNodes }, (_, index) => {
+      const node = new LGraphNode(`Test node ${index + 1}`)
+      node.id = toNodeId(index + 1)
+      let progress: number | undefined
+      Object.defineProperty(node, 'progress', {
+        get: () => progress,
+        set: (value: number | undefined) => {
+          progressWrites++
+          progress = value
+          progressValues[index] = value
+        }
+      })
+      return node
+    })
+
+    const graph = new LGraph()
+    graph._nodes.push(...nodes)
+
+    const canvas = app.canvas
+    if (!canvas) throw new Error('GraphCanvas did not initialize the canvas')
+    canvas.graph = graph
+    useCanvasStore().canvas = canvas
+
+    const workflowStore = useWorkflowStore()
+    vi.mocked(workflowStore.nodeIdToNodeLocatorId).mockImplementation((id) =>
+      createNodeLocatorId(null, id)
+    )
+
+    const executionStore = useExecutionStore()
+    const progressState = Object.fromEntries(
+      Array.from({ length: activeEntries }, (_, index) => {
+        const nodeId = String(index + 1)
+        return [
+          nodeId,
+          {
+            display_node_id: nodeId,
+            node_id: nodeId,
+            prompt_id: 'job',
+            state: 'running' as const,
+            value: 25,
+            max: 100
+          }
+        ]
+      })
+    )
+
+    executionStore.nodeProgressStates = progressState
+    await nextTick()
+    progressWrites = 0
     mocks.setDirty.mockClear()
+    vi.mocked(workflowStore.nodeIdToNodeLocatorId).mockClear()
+
+    return {
+      executionStore,
+      workflowStore,
+      progressState,
+      progressValues,
+      get progressWrites() {
+        return progressWrites
+      }
+    }
+  }
+
+  it.fails('does no node work for structurally equal progress', async () => {
+    const harness = await mountProgressHarness()
+
+    harness.executionStore.nodeProgressStates = { ...harness.progressState }
+    await nextTick()
+
+    expect(harness.workflowStore.nodeIdToNodeLocatorId).not.toHaveBeenCalled()
+    expect(harness.progressWrites).toBe(0)
+    expect(mocks.setDirty).not.toHaveBeenCalled()
   })
 
-  it.for([
-    { totalNodes: 1, activeEntries: 1 },
-    { totalNodes: 1_000, activeEntries: 1 },
-    { totalNodes: 1_000, activeEntries: 100 },
-    { totalNodes: 1_000, activeEntries: 500 }
-  ])(
-    'scans all $totalNodes visible nodes with $activeEntries active entries for equal and changed events',
-    async ({ totalNodes, activeEntries }) => {
-      await mountGraphCanvas()
+  it.fails('updates only the node whose progress changed', async () => {
+    const harness = await mountProgressHarness()
 
-      let progressWrites = 0
-      const progressValues: Array<number | undefined> = []
-      const nodes = Array.from({ length: totalNodes }, (_, index) => {
-        let progress: number | undefined
-        return {
-          id: index + 1,
-          get progress() {
-            return progress
-          },
-          set progress(value: number | undefined) {
-            progressWrites++
-            progress = value
-            progressValues[index] = value
-          }
-        } as unknown as LGraphNode
-      })
-      mocks.graphNodes.push(...nodes)
-
-      const canvas = app.canvas!
-      canvas.graph = { nodes } as typeof canvas.graph
-      useCanvasStore().canvas = canvas
-
-      const workflowStore = useWorkflowStore()
-      vi.mocked(workflowStore.nodeIdToNodeLocatorId).mockImplementation((id) =>
-        createNodeLocatorId(null, id)
-      )
-
-      const executionStore = useExecutionStore()
-      const equalState = Object.fromEntries(
-        Array.from({ length: activeEntries }, (_, index) => {
-          const nodeId = String(index + 1)
-          return [
-            nodeId,
-            {
-              display_node_id: nodeId,
-              node_id: nodeId,
-              prompt_id: 'job',
-              state: 'running' as const,
-              value: 25,
-              max: 100
-            }
-          ]
-        })
-      )
-
-      executionStore.nodeProgressStates = equalState
-      await nextTick()
-      expect(progressValues[0]).toBe(0.25)
-      expect(progressValues[activeEntries - 1]).toBe(0.25)
-      if (activeEntries < totalNodes) {
-        expect(progressValues[activeEntries]).toBeUndefined()
-      }
-
-      progressWrites = 0
-      mocks.setDirty.mockClear()
-      vi.mocked(workflowStore.nodeIdToNodeLocatorId).mockClear()
-
-      // A structurally equal WebSocket payload still fans out to every node.
-      executionStore.nodeProgressStates = { ...equalState }
-      await nextTick()
-
-      expect(workflowStore.nodeIdToNodeLocatorId).toHaveBeenCalledTimes(
-        totalNodes
-      )
-      expect(progressWrites).toBe(totalNodes)
-      expect(mocks.setDirty).toHaveBeenCalledTimes(1)
-      expect(mocks.setDirty).toHaveBeenCalledWith(true, false)
-
-      progressWrites = 0
-      mocks.setDirty.mockClear()
-      vi.mocked(workflowStore.nodeIdToNodeLocatorId).mockClear()
-
-      // A real one-node change has the same total-node operation count.
-      executionStore.nodeProgressStates = {
-        ...equalState,
-        '1': {
-          ...equalState['1'],
-          prompt_id: 'job',
-          state: 'running' as const,
-          value: 50,
-          max: 100
-        }
-      }
-      await nextTick()
-
-      expect(workflowStore.nodeIdToNodeLocatorId).toHaveBeenCalledTimes(
-        totalNodes
-      )
-      expect(progressWrites).toBe(totalNodes)
-      expect(progressValues[0]).toBe(0.5)
-      expect(mocks.setDirty).toHaveBeenCalledTimes(1)
-      expect(mocks.setDirty).toHaveBeenCalledWith(true, false)
+    harness.executionStore.nodeProgressStates = {
+      ...harness.progressState,
+      '1': { ...harness.progressState['1'], value: 50 }
     }
-  )
+    await nextTick()
+
+    expect(harness.workflowStore.nodeIdToNodeLocatorId).toHaveBeenCalledOnce()
+    expect(harness.progressWrites).toBe(1)
+    expect(harness.progressValues[0]).toBe(0.5)
+    expect(mocks.setDirty).toHaveBeenCalledOnce()
+    expect(mocks.setDirty).toHaveBeenCalledWith(true, false)
+  })
 })


### PR DESCRIPTION
## Why

Execution progress currently scans every visible node, writes every `node.progress` value even when unchanged/undefined, and dirties the foreground canvas for structurally equal payloads.

## Deterministic baseline

Across 1/1,000 visible nodes × 1/100/500 active progress entries, this test pins semantics and exact work counts. At 1,000 visible nodes, both an equal event and a one-node change currently produce:

- 1,000 locator lookups
- 1,000 progress writes
- 1 dirty request

No wall-clock threshold is used. Minimap behavior is separately bounded and does not fan out per WS event.

## Verification

Focused 7/7 tests, full Vue typecheck, formatting, type-aware lint, ESLint, and Stylelint pass.

<!-- perf-proof-evidence:start -->
## Performance proof status

**Role:** deterministic baseline for #15999.

- Original proof at `ce9e010e80a6`: the focused progress gate passed 1 file / 7 tests in 6.52 s and pinned exact locator, write, and dirty-request counts.
- Current head `171c2f77c20c` adds cloned-state protection plus minimal, empty, and all-active boundary cells. Review mapping: `e79f08ac76` ([clone entries](https://github.com/Comfy-Org/ComfyUI_frontend/pull/15998#discussion_r3867263773)), `c91a9fa60f` ([boundary coverage](https://github.com/Comfy-Org/ComfyUI_frontend/pull/15998#discussion_r3867263763)), `171c2f77c2` ([required `it.for` syntax](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/33034457485/job/98394021259)).
- Current-head gate: `node_modules/.bin/vitest run src/components/graph/GraphCanvas.test.ts` — **8 passed + 2 expected-fail (10 total)** in 5.34 s; direct type-aware Oxlint passed.
- Live status: open, mergeable, CI terminal non-failing, zero unresolved threads. CodeRabbit's changes-requested review predates the fixes.
- This is operation-count baseline evidence, not browser timing; no screenshot proof is claimed.
<!-- perf-proof-evidence:end -->

<!-- shepherd-20260828:start -->
### 2026-08-28 shepherd update

Exact head `29b132486c` adds the requested 1,000-node / 500-active boundary to both current-behavior matrices. Formatting, type-aware Oxlint, ESLint, and diff validation passed locally. CodeRabbit approved this exact head. Hosted tests passed all 1,353 files / 18,293 tests before an unrelated delayed auth-token socket callback fired after environment teardown; the failed job was rerun and is still in progress at this capture.
<!-- shepherd-20260828:end -->