### PR TITLE
perf: skip unchanged progress canvas writes

### DIFF
--- a/src/components/graph/GraphCanvas.test.ts
+++ b/src/components/graph/GraphCanvas.test.ts
@@ -262,8 +262,8 @@ describe('GraphCanvas execution progress updates', () => {
     useCanvasStore().canvas = canvas
 
     const workflowStore = useWorkflowStore()
-    vi.mocked(workflowStore.nodeIdToNodeLocatorId).mockImplementation((id) =>
-      createNodeLocatorId(null, id)
+    vi.mocked(workflowStore.nodeToNodeLocatorId).mockImplementation((node) =>
+      createNodeLocatorId(null, node.id)
     )
 
     const executionStore = useExecutionStore()
@@ -288,7 +288,7 @@ describe('GraphCanvas execution progress updates', () => {
     await nextTick()
     progressWrites = 0
     mocks.setDirty.mockClear()
-    vi.mocked(workflowStore.nodeIdToNodeLocatorId).mockClear()
+    vi.mocked(workflowStore.nodeToNodeLocatorId).mockClear()
 
     return {
       executionStore,
@@ -391,7 +391,7 @@ describe('GraphCanvas execution progress updates', () => {
     expect(mocks.setDirty).toHaveBeenCalledWith(true, false)
   })
 
-  it.fails('does no node work for structurally equal progress', async () => {
+  it('does no node work for structurally equal progress', async () => {
     const harness = await mountProgressHarness()
 
     harness.executionStore.nodeProgressStates = Object.fromEntries(
@@ -402,12 +402,12 @@ describe('GraphCanvas execution progress updates', () => {
     )
     await nextTick()
 
-    expect(harness.workflowStore.nodeIdToNodeLocatorId).not.toHaveBeenCalled()
+    expect(harness.workflowStore.nodeToNodeLocatorId).not.toHaveBeenCalled()
     expect(harness.progressWrites).toBe(0)
     expect(mocks.setDirty).not.toHaveBeenCalled()
   })
 
-  it.fails('updates only the node whose progress changed', async () => {
+  it('updates only the node whose progress changed', async () => {
     const harness = await mountProgressHarness()
 
     const clonedProgressState = Object.fromEntries(
@@ -422,7 +422,7 @@ describe('GraphCanvas execution progress updates', () => {
     }
     await nextTick()
 
-    expect(harness.workflowStore.nodeIdToNodeLocatorId).toHaveBeenCalledOnce()
+    expect(harness.workflowStore.nodeToNodeLocatorId).not.toHaveBeenCalled()
     expect(harness.progressWrites).toBe(1)
     expect(harness.progressValues[0]).toBe(0.5)
     expect(mocks.setDirty).toHaveBeenCalledOnce()

--- a/src/components/graph/GraphCanvas.test.ts
+++ b/src/components/graph/GraphCanvas.test.ts
@@ -299,6 +299,8 @@ describe('GraphCanvas execution progress updates', () => {
       workflowStore,
       progressState,
       progressValues,
+      totalNodes,
+      activeEntries,
       get progressWrites() {
         return progressWrites
       }
@@ -323,11 +325,9 @@ describe('GraphCanvas execution progress updates', () => {
       )
       await nextTick()
 
-      expect(harness.workflowStore.nodeIdToNodeLocatorId).toHaveBeenCalledTimes(
-        totalNodes
-      )
-      expect(harness.progressWrites).toBe(totalNodes)
-      expect(mocks.setDirty).toHaveBeenCalledOnce()
+      expect(harness.workflowStore.nodeToNodeLocatorId).not.toHaveBeenCalled()
+      expect(harness.progressWrites).toBe(0)
+      expect(mocks.setDirty).not.toHaveBeenCalled()
     }
   )
 
@@ -352,10 +352,8 @@ describe('GraphCanvas execution progress updates', () => {
       }
       await nextTick()
 
-      expect(harness.workflowStore.nodeIdToNodeLocatorId).toHaveBeenCalledTimes(
-        totalNodes
-      )
-      expect(harness.progressWrites).toBe(totalNodes)
+      expect(harness.workflowStore.nodeToNodeLocatorId).not.toHaveBeenCalled()
+      expect(harness.progressWrites).toBe(1)
       expect(harness.progressValues[0]).toBe(0.5)
       expect(mocks.setDirty).toHaveBeenCalledOnce()
     }
@@ -435,7 +433,7 @@ describe('GraphCanvas execution progress updates', () => {
 
   it('clears only the node whose progress was removed', async () => {
     const harness = await mountProgressHarness()
-    const removedNodeId = String(activeEntries)
+    const removedNodeId = String(harness.activeEntries)
     const removedState = Object.fromEntries(
       Object.entries(harness.progressState).filter(
         ([nodeId]) => nodeId !== removedNodeId
@@ -446,7 +444,7 @@ describe('GraphCanvas execution progress updates', () => {
     await nextTick()
 
     expect(harness.progressWrites).toBe(1)
-    expect(harness.progressValues[activeEntries - 1]).toBeUndefined()
+    expect(harness.progressValues[harness.activeEntries - 1]).toBeUndefined()
     expect(mocks.setDirty).toHaveBeenCalledOnce()
     expect(mocks.setDirty).toHaveBeenCalledWith(true, false)
     expect(harness.workflowStore.nodeToNodeLocatorId).not.toHaveBeenCalled()
@@ -454,7 +452,7 @@ describe('GraphCanvas execution progress updates', () => {
 
   it('ignores progress for a node outside the graph', async () => {
     const harness = await mountProgressHarness()
-    const unmatchedNodeId = String(totalNodes + 1)
+    const unmatchedNodeId = String(harness.totalNodes + 1)
 
     harness.executionStore.nodeProgressStates = {
       ...harness.progressState,

--- a/src/components/graph/GraphCanvas.test.ts
+++ b/src/components/graph/GraphCanvas.test.ts
@@ -286,9 +286,13 @@ describe('GraphCanvas execution progress updates', () => {
 
     executionStore.nodeProgressStates = progressState
     await nextTick()
-    progressWrites = 0
-    mocks.setDirty.mockClear()
-    vi.mocked(workflowStore.nodeToNodeLocatorId).mockClear()
+
+    function resetObservedWork() {
+      progressWrites = 0
+      mocks.setDirty.mockClear()
+      vi.mocked(workflowStore.nodeToNodeLocatorId).mockClear()
+    }
+    resetObservedWork()
 
     return {
       executionStore,
@@ -391,7 +395,7 @@ describe('GraphCanvas execution progress updates', () => {
     expect(mocks.setDirty).toHaveBeenCalledWith(true, false)
   })
 
-  it('does no node work for structurally equal progress', async () => {
+  it('does no graph work for structurally equal progress', async () => {
     const harness = await mountProgressHarness()
 
     harness.executionStore.nodeProgressStates = Object.fromEntries(
@@ -402,9 +406,9 @@ describe('GraphCanvas execution progress updates', () => {
     )
     await nextTick()
 
-    expect(harness.workflowStore.nodeToNodeLocatorId).not.toHaveBeenCalled()
     expect(harness.progressWrites).toBe(0)
     expect(mocks.setDirty).not.toHaveBeenCalled()
+    expect(harness.workflowStore.nodeToNodeLocatorId).not.toHaveBeenCalled()
   })
 
   it('updates only the node whose progress changed', async () => {
@@ -422,10 +426,51 @@ describe('GraphCanvas execution progress updates', () => {
     }
     await nextTick()
 
-    expect(harness.workflowStore.nodeToNodeLocatorId).not.toHaveBeenCalled()
     expect(harness.progressWrites).toBe(1)
     expect(harness.progressValues[0]).toBe(0.5)
     expect(mocks.setDirty).toHaveBeenCalledOnce()
     expect(mocks.setDirty).toHaveBeenCalledWith(true, false)
+    expect(harness.workflowStore.nodeToNodeLocatorId).not.toHaveBeenCalled()
+  })
+
+  it('clears only the node whose progress was removed', async () => {
+    const harness = await mountProgressHarness()
+    const removedNodeId = String(activeEntries)
+    const removedState = Object.fromEntries(
+      Object.entries(harness.progressState).filter(
+        ([nodeId]) => nodeId !== removedNodeId
+      )
+    )
+
+    harness.executionStore.nodeProgressStates = removedState
+    await nextTick()
+
+    expect(harness.progressWrites).toBe(1)
+    expect(harness.progressValues[activeEntries - 1]).toBeUndefined()
+    expect(mocks.setDirty).toHaveBeenCalledOnce()
+    expect(mocks.setDirty).toHaveBeenCalledWith(true, false)
+    expect(harness.workflowStore.nodeToNodeLocatorId).not.toHaveBeenCalled()
+  })
+
+  it('ignores progress for a node outside the graph', async () => {
+    const harness = await mountProgressHarness()
+    const unmatchedNodeId = String(totalNodes + 1)
+
+    harness.executionStore.nodeProgressStates = {
+      ...harness.progressState,
+      [unmatchedNodeId]: {
+        display_node_id: unmatchedNodeId,
+        node_id: unmatchedNodeId,
+        prompt_id: 'job',
+        state: 'running',
+        value: 25,
+        max: 100
+      }
+    }
+    await nextTick()
+
+    expect(harness.progressWrites).toBe(0)
+    expect(mocks.setDirty).not.toHaveBeenCalled()
+    expect(harness.workflowStore.nodeToNodeLocatorId).not.toHaveBeenCalled()
   })
 })

--- a/src/components/graph/GraphCanvas.test.ts
+++ b/src/components/graph/GraphCanvas.test.ts
@@ -422,6 +422,7 @@ describe('GraphCanvas execution progress updates', () => {
     }
     await nextTick()
 
+    expect(harness.workflowStore.nodeIdToNodeLocatorId).toHaveBeenCalledOnce()
     expect(harness.progressWrites).toBe(1)
     expect(harness.progressValues[0]).toBe(0.5)
     expect(mocks.setDirty).toHaveBeenCalledOnce()

--- a/src/components/graph/GraphCanvas.vue
+++ b/src/components/graph/GraphCanvas.vue
@@ -148,6 +148,7 @@ import VueNodeSwitchPopup from '@/components/builder/VueNodeSwitchPopup.vue'
 import ExtensionSlot from '@/components/common/ExtensionSlot.vue'
 import DomWidgets from '@/components/graph/DomWidgets.vue'
 import GraphCanvasMenu from '@/components/graph/GraphCanvasMenu.vue'
+import { createNodeProgressCanvasSync } from '@/components/graph/nodeProgressCanvasSync'
 import LinkOverlayCanvas from '@/components/graph/LinkOverlayCanvas.vue'
 import NodeTooltip from '@/components/graph/NodeTooltip.vue'
 import NodeContextMenu from '@/components/graph/NodeContextMenu.vue'
@@ -234,6 +235,9 @@ const { isBuilderMode } = useAppMode()
 const agentNodeSelectionStore = useAgentNodeSelectionStore()
 const canvasStore = useCanvasStore()
 const workflowStore = useWorkflowStore()
+const nodeProgressCanvasSync = createNodeProgressCanvasSync(
+  workflowStore.nodeToNodeLocatorId
+)
 const { linearMode } = storeToRefs(canvasStore)
 const { docked: agentDocked, DockedAgentPanel } = useAgentDockMount()
 const executionStore = useExecutionStore()
@@ -436,21 +440,15 @@ watch(
       canvasStore.currentGraph
     ] as const,
   ([nodeLocationProgressStates, canvas]) => {
-    if (!canvas?.graph) return
-    for (const node of canvas.graph.nodes) {
-      const nodeLocatorId = useWorkflowStore().nodeIdToNodeLocatorId(node.id)
-      const progressState = nodeLocationProgressStates[nodeLocatorId]
-      if (progressState && progressState.state === 'running') {
-        node.progress = progressState.value / progressState.max
-      } else {
-        node.progress = undefined
-      }
-    }
-
-    // Force canvas redraw to ensure progress updates are visible
-    canvas.setDirty(true, false)
+    nodeProgressCanvasSync.sync(
+      nodeLocationProgressStates,
+      canvas,
+      canvas?.graph ?? canvasStore.currentGraph
+    )
   }
 )
+
+onUnmounted(nodeProgressCanvasSync.dispose)
 
 // Repaint canvas when node errors change.
 // Slot error flags are reconciled by reconcileNodeErrorFlags in executionErrorStore.

--- a/src/components/graph/nodeProgressCanvasSync.test.ts
+++ b/src/components/graph/nodeProgressCanvasSync.test.ts
@@ -1,76 +1,237 @@
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
 import { expect, it, vi } from 'vitest'
 
-import type {
-  LGraph,
-  LGraphCanvas,
-  LGraphNode
-} from '@/lib/litegraph/src/litegraph'
+import { LGraph, LGraphNode } from '@/lib/litegraph/src/litegraph'
+import type { LGraphCanvas } from '@/lib/litegraph/src/litegraph'
+import type { NodeProgressState } from '@/schemas/apiSchema'
 import { createNodeLocatorId } from '@/types/nodeIdentification'
+import type { NodeLocatorId } from '@/types/nodeIdentification'
 import { toNodeId } from '@/types/nodeId'
 
-import type { NodeProgressCanvasSync } from './nodeProgressCanvasSync'
 import { createNodeProgressCanvasSync } from './nodeProgressCanvasSync'
 
-type ProgressStates = Parameters<NodeProgressCanvasSync['sync']>[0]
+const SUBGRAPH_ID = '00000000-0000-0000-0000-000000000001'
 
-function runningState(id: string, value: number) {
+function runningState(id: string, value: number): NodeProgressState {
   return {
     display_node_id: id,
     node_id: id,
     prompt_id: 'job',
-    state: 'running' as const,
+    state: 'running',
     value,
     max: 100
   }
 }
 
-it('builds once, skips equal state, and looks up only the changed locator', () => {
-  const writes = Array.from({ length: 1_000 }, () => vi.fn())
-  const nodes = writes.map((write, index) => {
-    let progress: number | undefined
-    return {
-      id: toNodeId(index + 1),
-      get progress() {
-        return progress
-      },
-      set progress(value: number | undefined) {
-        write(value)
-        progress = value
-      }
-    } as unknown as LGraphNode
-  })
+function createNode(id: number) {
+  let progress: number | undefined
+  const reads = vi.fn()
+  const writes = vi.fn()
+  const node = {
+    id,
+    graph: null,
+    get progress() {
+      reads()
+      return progress
+    },
+    set progress(value: number | undefined) {
+      writes(value)
+      progress = value
+    }
+  } as unknown as LGraphNode
+  return {
+    node,
+    reads,
+    writes,
+    value() {
+      return progress
+    }
+  }
+}
+
+function createGraph(nodes: LGraphNode[], subgraphId?: string) {
+  const events = new EventTarget()
   const graph = {
+    id: subgraphId,
     nodes,
-    events: new EventTarget()
+    events
   } as unknown as LGraph
-  const setDirty = vi.fn()
-  const canvas = { setDirty } as unknown as LGraphCanvas
-  const conversions = vi.fn((node: LGraphNode) =>
-    createNodeLocatorId(null, node.id)
+  for (const node of nodes) node.graph = graph
+  return {
+    graph,
+    add(node: LGraphNode) {
+      node.graph = graph
+      nodes.push(node)
+      events.dispatchEvent(new CustomEvent('node:added', { detail: { node } }))
+    },
+    remove(node: LGraphNode) {
+      events.dispatchEvent(
+        new CustomEvent('node:before-removed', { detail: { node } })
+      )
+      const index = nodes.indexOf(node)
+      if (index !== -1) nodes.splice(index, 1)
+      node.graph = null
+    }
+  }
+}
+
+function createCanvas() {
+  return { setDirty: vi.fn() } as unknown as LGraphCanvas
+}
+
+function locatorForNode(node: LGraphNode): NodeLocatorId {
+  return createNodeLocatorId(
+    node.graph?.id === SUBGRAPH_ID ? SUBGRAPH_ID : null,
+    node.id
   )
+}
+
+it('does one graph build, then only looks up changed and removed keys', () => {
+  const nodes = Array.from({ length: 1_000 }, (_, index) =>
+    createNode(index + 1)
+  )
+  const { graph } = createGraph(nodes.map(({ node }) => node))
+  const canvas = createCanvas()
+  const conversions = vi.fn(locatorForNode)
   const lookups = vi.fn()
   const sync = createNodeProgressCanvasSync(conversions, lookups)
   const locator = createNodeLocatorId(null, toNodeId(1))
-  const initial = { [locator]: runningState('1', 25) } satisfies ProgressStates
+  const equalStates = { [locator]: runningState('1', 25) }
 
-  sync.sync(initial, canvas, graph)
+  sync.sync(equalStates, canvas, graph)
   expect(conversions).toHaveBeenCalledTimes(1_000)
+  expect(nodes[0].value()).toBe(0.25)
 
   conversions.mockClear()
   lookups.mockClear()
-  setDirty.mockClear()
-  writes.forEach((write) => write.mockClear())
+  nodes.forEach(({ reads, writes }) => {
+    reads.mockClear()
+    writes.mockClear()
+  })
 
-  sync.sync({ ...initial }, canvas, graph)
+  sync.sync({ ...equalStates }, canvas, graph)
   expect(conversions).not.toHaveBeenCalled()
   expect(lookups).not.toHaveBeenCalled()
-  expect(writes.every((write) => !write.mock.calls.length)).toBe(true)
-  expect(setDirty).not.toHaveBeenCalled()
+  expect(
+    nodes.every(
+      ({ reads, writes }) =>
+        !reads.mock.calls.length && !writes.mock.calls.length
+    )
+  ).toBe(true)
 
   sync.sync({ [locator]: runningState('1', 50) }, canvas, graph)
+  expect(lookups).toHaveBeenCalledTimes(1)
+  expect(nodes[0].writes).toHaveBeenCalledExactlyOnceWith(0.5)
+  expect(nodes.slice(1).every(({ writes }) => !writes.mock.calls.length)).toBe(
+    true
+  )
+
+  lookups.mockClear()
+  nodes[0].writes.mockClear()
+  sync.sync({}, canvas, graph)
+  expect(lookups).toHaveBeenCalledTimes(1)
+  expect(nodes[0].writes).toHaveBeenCalledExactlyOnceWith(undefined)
+
+  lookups.mockClear()
+  nodes[0].writes.mockClear()
+  const unmatched = createNodeLocatorId(null, toNodeId(1_001))
+  sync.sync({ [unmatched]: runningState('1001', 25) }, canvas, graph)
+  expect(lookups).toHaveBeenCalledTimes(1)
+  expect(nodes.every(({ writes }) => !writes.mock.calls.length)).toBe(true)
+
+  lookups.mockClear()
+  sync.sync({ [locator]: runningState('1', 75) }, canvas, graph)
+  expect(lookups).toHaveBeenCalledTimes(2)
+  expect(nodes[0].writes).toHaveBeenCalledExactlyOnceWith(0.75)
+})
+
+it('keeps duplicate locator entries and node add/remove lifecycle in sync', () => {
+  const first = createNode(1)
+  const duplicate = createNode(1)
+  const graphFixture = createGraph([first.node])
+  const canvas = createCanvas()
+  const conversions = vi.fn(locatorForNode)
+  const sync = createNodeProgressCanvasSync(conversions)
+  const locator = createNodeLocatorId(null, toNodeId(1))
+
+  sync.sync({ [locator]: runningState('1', 25) }, canvas, graphFixture.graph)
+  conversions.mockClear()
+  graphFixture.add(duplicate.node)
+  expect(conversions).toHaveBeenCalledExactlyOnceWith(duplicate.node)
+  expect(duplicate.value()).toBe(0.25)
+
+  first.writes.mockClear()
+  duplicate.writes.mockClear()
+  sync.sync({ [locator]: runningState('1', 50) }, canvas, graphFixture.graph)
+  expect(first.writes).toHaveBeenCalledExactlyOnceWith(0.5)
+  expect(duplicate.writes).toHaveBeenCalledExactlyOnceWith(0.5)
+
+  graphFixture.remove(first.node)
+  first.writes.mockClear()
+  duplicate.writes.mockClear()
+  sync.sync({ [locator]: runningState('1', 75) }, canvas, graphFixture.graph)
+  expect(first.writes).not.toHaveBeenCalled()
+  expect(duplicate.writes).toHaveBeenCalledExactlyOnceWith(0.75)
+})
+
+it('evicts detached nodes when a real graph is cleared and reused', () => {
+  setActivePinia(createTestingPinia({ stubActions: false }))
+  const graph = new LGraph()
+  const staleNode = new LGraphNode('stale')
+  staleNode.id = toNodeId(1)
+  graph.add(staleNode)
+  const canvas = createCanvas()
+  const sync = createNodeProgressCanvasSync(locatorForNode)
+  const locator = createNodeLocatorId(null, staleNode.id)
+
+  sync.sync({ [locator]: runningState('1', 25) }, canvas, graph)
+  expect(staleNode.progress).toBe(0.25)
+
+  graph.clear()
+  const replacementNode = new LGraphNode('replacement')
+  replacementNode.id = toNodeId(1)
+  graph.add(replacementNode)
+  sync.sync({ [locator]: runningState('1', 50) }, canvas, graph)
+
+  expect(staleNode.progress).toBe(0.25)
+  expect(replacementNode.progress).toBe(0.5)
+})
+
+it('rebuilds scope on graph replacement and detaches old graph listeners', () => {
+  const rootNode = createNode(1)
+  const subgraphNode = createNode(1)
+  const oldLateNode = createNode(2)
+  const root = createGraph([rootNode.node])
+  const subgraph = createGraph([subgraphNode.node], SUBGRAPH_ID)
+  const canvas = createCanvas()
+  const conversions = vi.fn(locatorForNode)
+  const sync = createNodeProgressCanvasSync(conversions)
+  const rootLocator = createNodeLocatorId(null, toNodeId(1))
+  const subgraphLocator = createNodeLocatorId(SUBGRAPH_ID, toNodeId(1))
+
+  sync.sync({ [rootLocator]: runningState('1', 25) }, canvas, root.graph)
+  expect(rootNode.value()).toBe(0.25)
+
+  conversions.mockClear()
+  sync.sync(
+    { [subgraphLocator]: runningState('1', 50) },
+    canvas,
+    subgraph.graph
+  )
+  expect(conversions).toHaveBeenCalledExactlyOnceWith(subgraphNode.node)
+  expect(subgraphNode.value()).toBe(0.5)
+
+  conversions.mockClear()
+  root.add(oldLateNode.node)
   expect(conversions).not.toHaveBeenCalled()
-  expect(lookups).toHaveBeenCalledOnce()
-  expect(writes[0]).toHaveBeenCalledExactlyOnceWith(0.5)
-  expect(writes.slice(1).every((write) => !write.mock.calls.length)).toBe(true)
-  expect(setDirty).toHaveBeenCalledExactlyOnceWith(true, false)
+
+  sync.sync({}, canvas, root.graph)
+  expect(rootNode.value()).toBeUndefined()
+  expect(oldLateNode.value()).toBeUndefined()
+
+  conversions.mockClear()
+  sync.dispose()
+  root.add(createNode(3).node)
+  expect(conversions).not.toHaveBeenCalled()
 })

--- a/src/components/graph/nodeProgressCanvasSync.test.ts
+++ b/src/components/graph/nodeProgressCanvasSync.test.ts
@@ -85,32 +85,33 @@ function locatorForNode(node: LGraphNode): NodeLocatorId {
   )
 }
 
-it('does one graph build, then only looks up changed and removed keys', () => {
+it('does one graph build, then only touches changed and removed nodes', () => {
   const nodes = Array.from({ length: 1_000 }, (_, index) =>
     createNode(index + 1)
   )
   const { graph } = createGraph(nodes.map(({ node }) => node))
   const canvas = createCanvas()
   const conversions = vi.fn(locatorForNode)
-  const lookups = vi.fn()
-  const sync = createNodeProgressCanvasSync(conversions, lookups)
+  const sync = createNodeProgressCanvasSync(conversions)
   const locator = createNodeLocatorId(null, toNodeId(1))
   const equalStates = { [locator]: runningState('1', 25) }
+
+  function clearNodeWork() {
+    nodes.forEach(({ reads, writes }) => {
+      reads.mockClear()
+      writes.mockClear()
+    })
+  }
 
   sync.sync(equalStates, canvas, graph)
   expect(conversions).toHaveBeenCalledTimes(1_000)
   expect(nodes[0].value()).toBe(0.25)
 
   conversions.mockClear()
-  lookups.mockClear()
-  nodes.forEach(({ reads, writes }) => {
-    reads.mockClear()
-    writes.mockClear()
-  })
+  clearNodeWork()
 
   sync.sync({ ...equalStates }, canvas, graph)
   expect(conversions).not.toHaveBeenCalled()
-  expect(lookups).not.toHaveBeenCalled()
   expect(
     nodes.every(
       ({ reads, writes }) =>
@@ -119,28 +120,35 @@ it('does one graph build, then only looks up changed and removed keys', () => {
   ).toBe(true)
 
   sync.sync({ [locator]: runningState('1', 50) }, canvas, graph)
-  expect(lookups).toHaveBeenCalledTimes(1)
+  expect(nodes[0].reads).toHaveBeenCalledOnce()
   expect(nodes[0].writes).toHaveBeenCalledExactlyOnceWith(0.5)
-  expect(nodes.slice(1).every(({ writes }) => !writes.mock.calls.length)).toBe(
-    true
-  )
+  expect(
+    nodes
+      .slice(1)
+      .every(
+        ({ reads, writes }) =>
+          !reads.mock.calls.length && !writes.mock.calls.length
+      )
+  ).toBe(true)
 
-  lookups.mockClear()
-  nodes[0].writes.mockClear()
+  clearNodeWork()
   sync.sync({}, canvas, graph)
-  expect(lookups).toHaveBeenCalledTimes(1)
+  expect(nodes[0].reads).toHaveBeenCalledOnce()
   expect(nodes[0].writes).toHaveBeenCalledExactlyOnceWith(undefined)
 
-  lookups.mockClear()
-  nodes[0].writes.mockClear()
+  clearNodeWork()
   const unmatched = createNodeLocatorId(null, toNodeId(1_001))
   sync.sync({ [unmatched]: runningState('1001', 25) }, canvas, graph)
-  expect(lookups).toHaveBeenCalledTimes(1)
-  expect(nodes.every(({ writes }) => !writes.mock.calls.length)).toBe(true)
+  expect(
+    nodes.every(
+      ({ reads, writes }) =>
+        !reads.mock.calls.length && !writes.mock.calls.length
+    )
+  ).toBe(true)
 
-  lookups.mockClear()
+  clearNodeWork()
   sync.sync({ [locator]: runningState('1', 75) }, canvas, graph)
-  expect(lookups).toHaveBeenCalledTimes(2)
+  expect(nodes[0].reads).toHaveBeenCalledOnce()
   expect(nodes[0].writes).toHaveBeenCalledExactlyOnceWith(0.75)
 })
 

--- a/src/components/graph/nodeProgressCanvasSync.test.ts
+++ b/src/components/graph/nodeProgressCanvasSync.test.ts
@@ -1,19 +1,28 @@
+import { fromPartial } from '@total-typescript/shoehorn'
 import { createTestingPinia } from '@pinia/testing'
 import { setActivePinia } from 'pinia'
-import { expect, it, vi } from 'vitest'
+import { beforeEach, expect, it, vi } from 'vitest'
 
 import { LGraph, LGraphNode } from '@/lib/litegraph/src/litegraph'
 import type { LGraphCanvas } from '@/lib/litegraph/src/litegraph'
-import type { NodeProgressState } from '@/schemas/apiSchema'
 import { createNodeLocatorId } from '@/types/nodeIdentification'
 import type { NodeLocatorId } from '@/types/nodeIdentification'
 import { toNodeId } from '@/types/nodeId'
 
 import { createNodeProgressCanvasSync } from './nodeProgressCanvasSync'
+import type { NodeProgressCanvasSync } from './nodeProgressCanvasSync'
 
 const SUBGRAPH_ID = '00000000-0000-0000-0000-000000000001'
 
-function runningState(id: string, value: number): NodeProgressState {
+type ProgressState = Parameters<
+  NodeProgressCanvasSync['sync']
+>[0][NodeLocatorId]
+
+beforeEach(() => {
+  setActivePinia(createTestingPinia({ stubActions: false }))
+})
+
+function runningState(id: string, value: number): ProgressState {
   return {
     display_node_id: id,
     node_id: id,
@@ -28,18 +37,18 @@ function createNode(id: number) {
   let progress: number | undefined
   const reads = vi.fn()
   const writes = vi.fn()
-  const node = {
-    id,
-    graph: null,
-    get progress() {
+  const node = new LGraphNode(`Test node ${id}`)
+  node.id = toNodeId(id)
+  Object.defineProperty(node, 'progress', {
+    get() {
       reads()
       return progress
     },
-    set progress(value: number | undefined) {
+    set(value: number | undefined) {
       writes(value)
       progress = value
     }
-  } as unknown as LGraphNode
+  })
   return {
     node,
     reads,
@@ -51,33 +60,22 @@ function createNode(id: number) {
 }
 
 function createGraph(nodes: LGraphNode[], subgraphId?: string) {
-  const events = new EventTarget()
-  const graph = {
-    id: subgraphId,
-    nodes,
-    events
-  } as unknown as LGraph
-  for (const node of nodes) node.graph = graph
+  const graph = new LGraph()
+  if (subgraphId) graph.id = subgraphId
+  for (const node of nodes) graph.add(node, { skipComputeOrder: true })
   return {
     graph,
     add(node: LGraphNode) {
-      node.graph = graph
-      nodes.push(node)
-      events.dispatchEvent(new CustomEvent('node:added', { detail: { node } }))
+      graph.add(node, { skipComputeOrder: true })
     },
     remove(node: LGraphNode) {
-      events.dispatchEvent(
-        new CustomEvent('node:before-removed', { detail: { node } })
-      )
-      const index = nodes.indexOf(node)
-      if (index !== -1) nodes.splice(index, 1)
-      node.graph = null
+      graph.remove(node)
     }
   }
 }
 
 function createCanvas() {
-  return { setDirty: vi.fn() } as unknown as LGraphCanvas
+  return fromPartial<LGraphCanvas>({ setDirty: vi.fn() })
 }
 
 function locatorForNode(node: LGraphNode): NodeLocatorId {
@@ -148,12 +146,12 @@ it('does one graph build, then only looks up changed and removed keys', () => {
 
 it('keeps duplicate locator entries and node add/remove lifecycle in sync', () => {
   const first = createNode(1)
-  const duplicate = createNode(1)
+  const duplicate = createNode(2)
   const graphFixture = createGraph([first.node])
   const canvas = createCanvas()
-  const conversions = vi.fn(locatorForNode)
-  const sync = createNodeProgressCanvasSync(conversions)
   const locator = createNodeLocatorId(null, toNodeId(1))
+  const conversions = vi.fn(() => locator)
+  const sync = createNodeProgressCanvasSync(conversions)
 
   sync.sync({ [locator]: runningState('1', 25) }, canvas, graphFixture.graph)
   conversions.mockClear()
@@ -176,7 +174,6 @@ it('keeps duplicate locator entries and node add/remove lifecycle in sync', () =
 })
 
 it('evicts detached nodes when a real graph is cleared and reused', () => {
-  setActivePinia(createTestingPinia({ stubActions: false }))
   const graph = new LGraph()
   const staleNode = new LGraphNode('stale')
   staleNode.id = toNodeId(1)

--- a/src/components/graph/nodeProgressCanvasSync.test.ts
+++ b/src/components/graph/nodeProgressCanvasSync.test.ts
@@ -1,0 +1,76 @@
+import { expect, it, vi } from 'vitest'
+
+import type {
+  LGraph,
+  LGraphCanvas,
+  LGraphNode
+} from '@/lib/litegraph/src/litegraph'
+import { createNodeLocatorId } from '@/types/nodeIdentification'
+import { toNodeId } from '@/types/nodeId'
+
+import type { NodeProgressCanvasSync } from './nodeProgressCanvasSync'
+import { createNodeProgressCanvasSync } from './nodeProgressCanvasSync'
+
+type ProgressStates = Parameters<NodeProgressCanvasSync['sync']>[0]
+
+function runningState(id: string, value: number) {
+  return {
+    display_node_id: id,
+    node_id: id,
+    prompt_id: 'job',
+    state: 'running' as const,
+    value,
+    max: 100
+  }
+}
+
+it('builds once, skips equal state, and looks up only the changed locator', () => {
+  const writes = Array.from({ length: 1_000 }, () => vi.fn())
+  const nodes = writes.map((write, index) => {
+    let progress: number | undefined
+    return {
+      id: toNodeId(index + 1),
+      get progress() {
+        return progress
+      },
+      set progress(value: number | undefined) {
+        write(value)
+        progress = value
+      }
+    } as unknown as LGraphNode
+  })
+  const graph = {
+    nodes,
+    events: new EventTarget()
+  } as unknown as LGraph
+  const setDirty = vi.fn()
+  const canvas = { setDirty } as unknown as LGraphCanvas
+  const conversions = vi.fn((node: LGraphNode) =>
+    createNodeLocatorId(null, node.id)
+  )
+  const lookups = vi.fn()
+  const sync = createNodeProgressCanvasSync(conversions, lookups)
+  const locator = createNodeLocatorId(null, toNodeId(1))
+  const initial = { [locator]: runningState('1', 25) } satisfies ProgressStates
+
+  sync.sync(initial, canvas, graph)
+  expect(conversions).toHaveBeenCalledTimes(1_000)
+
+  conversions.mockClear()
+  lookups.mockClear()
+  setDirty.mockClear()
+  writes.forEach((write) => write.mockClear())
+
+  sync.sync({ ...initial }, canvas, graph)
+  expect(conversions).not.toHaveBeenCalled()
+  expect(lookups).not.toHaveBeenCalled()
+  expect(writes.every((write) => !write.mock.calls.length)).toBe(true)
+  expect(setDirty).not.toHaveBeenCalled()
+
+  sync.sync({ [locator]: runningState('1', 50) }, canvas, graph)
+  expect(conversions).not.toHaveBeenCalled()
+  expect(lookups).toHaveBeenCalledOnce()
+  expect(writes[0]).toHaveBeenCalledExactlyOnceWith(0.5)
+  expect(writes.slice(1).every((write) => !write.mock.calls.length)).toBe(true)
+  expect(setDirty).toHaveBeenCalledExactlyOnceWith(true, false)
+})

--- a/src/components/graph/nodeProgressCanvasSync.ts
+++ b/src/components/graph/nodeProgressCanvasSync.ts
@@ -24,11 +24,8 @@ function progressValue(state: ProgressState | undefined) {
   return state?.state === 'running' ? state.value / state.max : undefined
 }
 
-function noOp() {}
-
 export function createNodeProgressCanvasSync(
-  nodeToLocator: (node: LGraphNode) => NodeLocatorId,
-  onIndexLookup: () => void = noOp
+  nodeToLocator: (node: LGraphNode) => NodeLocatorId
 ): NodeProgressCanvasSync {
   let activeCanvas: LGraphCanvas | null = null
   let activeGraph: LGraph | null = null
@@ -126,7 +123,6 @@ export function createNodeProgressCanvasSync(
       const previousProgress = progressValue(previousStates[locator])
       const nextProgress = progressValue(states[locator])
       if (Object.is(previousProgress, nextProgress)) continue
-      onIndexLookup()
       for (const node of nodesByLocator.get(locator) ?? []) {
         progressChanged = setNodeProgress(node, nextProgress) || progressChanged
       }

--- a/src/components/graph/nodeProgressCanvasSync.ts
+++ b/src/components/graph/nodeProgressCanvasSync.ts
@@ -3,21 +3,24 @@ import type {
   LGraphCanvas,
   LGraphNode
 } from '@/lib/litegraph/src/litegraph'
-import type { NodeProgressState } from '@/schemas/apiSchema'
+import type { useExecutionStore } from '@/stores/executionStore'
 import type { NodeLocatorId } from '@/types/nodeIdentification'
+
+type ProgressStates = Readonly<
+  ReturnType<typeof useExecutionStore>['nodeLocationProgressStates']
+>
+type ProgressState = ProgressStates[NodeLocatorId]
 
 export interface NodeProgressCanvasSync {
   dispose: () => void
   sync: (
-    states: Readonly<Record<NodeLocatorId, NodeProgressState>>,
+    states: ProgressStates,
     canvas: LGraphCanvas | null,
     graph: LGraph | null
   ) => void
 }
 
-type ProgressStates = Parameters<NodeProgressCanvasSync['sync']>[0]
-
-function progressValue(state: NodeProgressState | undefined) {
+function progressValue(state: ProgressState | undefined) {
   return state?.state === 'running' ? state.value / state.max : undefined
 }
 

--- a/src/components/graph/nodeProgressCanvasSync.ts
+++ b/src/components/graph/nodeProgressCanvasSync.ts
@@ -1,0 +1,144 @@
+import type {
+  LGraph,
+  LGraphCanvas,
+  LGraphNode
+} from '@/lib/litegraph/src/litegraph'
+import type { NodeProgressState } from '@/schemas/apiSchema'
+import type { NodeLocatorId } from '@/types/nodeIdentification'
+
+export interface NodeProgressCanvasSync {
+  dispose: () => void
+  sync: (
+    states: Readonly<Record<NodeLocatorId, NodeProgressState>>,
+    canvas: LGraphCanvas | null,
+    graph: LGraph | null
+  ) => void
+}
+
+type ProgressStates = Parameters<NodeProgressCanvasSync['sync']>[0]
+
+function progressValue(state: NodeProgressState | undefined) {
+  return state?.state === 'running' ? state.value / state.max : undefined
+}
+
+function noOp() {}
+
+export function createNodeProgressCanvasSync(
+  nodeToLocator: (node: LGraphNode) => NodeLocatorId,
+  onIndexLookup: () => void = noOp
+): NodeProgressCanvasSync {
+  let activeCanvas: LGraphCanvas | null = null
+  let activeGraph: LGraph | null = null
+  let activeStates: ProgressStates = {}
+  let nodeLocators = new WeakMap<LGraphNode, NodeLocatorId>()
+  const nodesByLocator = new Map<NodeLocatorId, LGraphNode[]>()
+
+  function markDirty() {
+    activeCanvas?.setDirty(true, false)
+  }
+
+  function setNodeProgress(node: LGraphNode, nextProgress: number | undefined) {
+    if (Object.is(node.progress, nextProgress)) return false
+    node.progress = nextProgress
+    return true
+  }
+
+  function addNode(node: LGraphNode) {
+    const locator = nodeToLocator(node)
+    nodeLocators.set(node, locator)
+    const nodes = nodesByLocator.get(locator)
+    if (nodes) nodes.push(node)
+    else nodesByLocator.set(locator, [node])
+    return locator
+  }
+
+  function removeNode(node: LGraphNode) {
+    const locator = nodeLocators.get(node)
+    if (!locator) return
+    const nodes = nodesByLocator.get(locator)
+    if (!nodes) return
+    const nextNodes = nodes.filter((candidate) => candidate !== node)
+    if (nextNodes.length) nodesByLocator.set(locator, nextNodes)
+    else nodesByLocator.delete(locator)
+    nodeLocators.delete(node)
+  }
+
+  function onNodeAdded(event: CustomEvent<{ node: LGraphNode }>) {
+    const node = event.detail.node
+    const locator = addNode(node)
+    if (setNodeProgress(node, progressValue(activeStates[locator]))) markDirty()
+  }
+
+  function onNodeRemoved(event: CustomEvent<{ node: LGraphNode }>) {
+    removeNode(event.detail.node)
+  }
+
+  function detachGraph() {
+    activeGraph?.events.removeEventListener('node:added', onNodeAdded)
+    activeGraph?.events.removeEventListener(
+      'node:before-removed',
+      onNodeRemoved
+    )
+  }
+
+  function replaceGraph(graph: LGraph | null) {
+    detachGraph()
+    activeGraph = graph
+    nodesByLocator.clear()
+    nodeLocators = new WeakMap()
+    if (!graph) return false
+
+    let progressChanged = false
+    for (const node of graph.nodes) {
+      const locator = addNode(node)
+      progressChanged =
+        setNodeProgress(node, progressValue(activeStates[locator])) ||
+        progressChanged
+    }
+    graph.events.addEventListener('node:added', onNodeAdded)
+    graph.events.addEventListener('node:before-removed', onNodeRemoved)
+    return progressChanged
+  }
+
+  function sync(
+    states: ProgressStates,
+    canvas: LGraphCanvas | null,
+    graph: LGraph | null
+  ) {
+    const previousStates = activeStates
+    activeCanvas = canvas
+    activeStates = states
+
+    if (graph !== activeGraph) {
+      if (replaceGraph(graph)) markDirty()
+      return
+    }
+
+    let progressChanged = false
+    const changedLocators = new Set([
+      ...Object.keys(previousStates),
+      ...Object.keys(states)
+    ] as NodeLocatorId[])
+    for (const locator of changedLocators) {
+      const previousProgress = progressValue(previousStates[locator])
+      const nextProgress = progressValue(states[locator])
+      if (Object.is(previousProgress, nextProgress)) continue
+      onIndexLookup()
+      for (const node of nodesByLocator.get(locator) ?? []) {
+        progressChanged = setNodeProgress(node, nextProgress) || progressChanged
+      }
+    }
+    if (progressChanged) markDirty()
+  }
+
+  function dispose() {
+    detachGraph()
+    activeCanvas = null
+    activeGraph = null
+    activeStates = {}
+    nodesByLocator.clear()
+    nodeLocators = new WeakMap()
+  }
+
+  return { dispose, sync }
+}


### PR DESCRIPTION
## Summary

Stacked on the deterministic baseline PR. Retain the compatible visible-node scan, but skip `node.progress` assignments when `Object.is` says the value is unchanged and only dirty the foreground canvas if at least one visual changed.

## Deterministic effect at 1,000 visible nodes

- equal event: 1,000 lookups / 1,000 writes / 1 dirty → **1,000 / 0 / 0**
- one changed node: 1,000 / 1,000 / 1 → **1,000 / 1 / 1**

Semantics remain pinned across 1/100/500 active entries. A later graph-scoped locator index + key diff can remove the residual O(N) scan after broader compatibility proof.

## Verification

Focused 7/7 tests, full Vue typecheck, formatting, type-aware lint, ESLint, and Stylelint pass.

<!-- perf-proof-evidence:start -->
## Performance proof status

**Role:** runtime indexed progress-update fix paired with #15998.

- Earlier proof at `e32094cfcdc7` established zero unchanged writes/dirty requests and one write for a one-node change; the original focused suite passed 7/7.
- Current head `8a3d2619d7` normally merges refreshed parent `171c2f77c2` into the indexed implementation and extended locator detector. The scoped test conflict was resolved by preserving zero conversion/write/dirty work for equal payloads, one indexed write for a changed node, cloned progress objects, and minimal/empty/all-active boundary coverage.
- Current-head gates: `node_modules/.bin/vitest run src/components/graph/GraphCanvas.test.ts src/components/graph/nodeProgressCanvasSync.test.ts` — **2 files / 16 tests passed** in 6.07 s; direct type-aware Oxlint and formatting passed.
- Live status: open, mergeable/clean, all checks terminal non-failing, zero unresolved threads, and human approval retained. CodeRabbit has not reviewed current head `8a3d2619d7`.
- No browser timing or paired progress-state screenshot is claimed.
<!-- perf-proof-evidence:end -->

<!-- shepherd-20260828:start -->
### 2026-08-28 shepherd update

Exact head `b69e530df8` reconciles the fix with the updated #15998 stacked base while retaining zero unchanged writes/dirty requests and one changed-node write. Formatting, type-aware Oxlint, and diff validation passed locally. The sole hosted failure was an unrelated mask-editor Chromium screenshot mismatch; that failed shard passed on retry, leaving all current-head checks terminal and non-failing.
<!-- shepherd-20260828:end -->