### PR TITLE
perf: break the CanvasInfo watcher redraw feedback loop

### DIFF
--- a/src/lib/litegraph/src/LGraphNode.arrangeWidgetInputSlots.test.ts
+++ b/src/lib/litegraph/src/LGraphNode.arrangeWidgetInputSlots.test.ts
@@ -1,0 +1,69 @@
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { nextTick, watch } from 'vue'
+
+import { LGraph, LGraphNode } from '@/lib/litegraph/src/litegraph'
+
+function createWidgetInputNode(graph: LGraph): LGraphNode {
+  const node = new LGraphNode('WidgetInput')
+  node.pos = [0, 0]
+  node.size = [200, 120]
+  node.addWidget('number', 'value', 0, () => {})
+  const input = node.addInput('value', 'FLOAT')
+  input.widget = { name: 'value' }
+  graph.add(node)
+  node._setConcreteSlots()
+  return node
+}
+
+describe('LGraphNode widget input slot arrangement', () => {
+  let graph: LGraph
+  let node: LGraphNode
+
+  beforeEach(() => {
+    setActivePinia(createTestingPinia({ stubActions: false }))
+    graph = new LGraph()
+    node = createWidgetInputNode(graph)
+  })
+
+  it('keeps the same pos array when the widget row has not moved', () => {
+    node.arrange()
+    const firstPos = node.inputs[0].pos
+
+    node.arrange()
+
+    expect(node.inputs[0].pos).toBe(firstPos)
+  })
+
+  it('does not notify slot position subscribers on an unchanged re-arrange', async () => {
+    node.arrange()
+    await nextTick()
+
+    let notifications = 0
+    const stop = watch(
+      () => node.inputs[0].pos,
+      () => {
+        notifications++
+      }
+    )
+
+    node.arrange()
+    await nextTick()
+    stop()
+
+    expect(notifications).toBe(0)
+  })
+
+  it('writes a new pos when the widget row actually moves', async () => {
+    node.arrange()
+    const firstPos = node.inputs[0].pos
+
+    node.widgets_start_y = (node.widgets_start_y ?? 0) + 40
+    node.arrange()
+    await nextTick()
+
+    expect(node.inputs[0].pos).not.toBe(firstPos)
+    expect(node.inputs[0].pos![1]).not.toBe(firstPos![1])
+  })
+})

--- a/src/lib/litegraph/src/LGraphNode.ts
+++ b/src/lib/litegraph/src/LGraphNode.ts
@@ -4414,9 +4414,23 @@ export class LGraphNode
       if (!widget) continue
 
       const offset = LiteGraph.NODE_SLOT_HEIGHT * 0.5
-      const pos: [number, number] = [offset, widget.y + offset]
-      slot.pos = pos
-      this.inputs[i].pos = pos
+      const x = offset
+      const y = widget.y + offset
+      const input = this.inputs[i]
+
+      // Slots are shallowReactive; a fresh array for unchanged coordinates
+      // triggers every slot-position subscriber once per frame.
+      const unchanged =
+        slot.pos?.[0] === x &&
+        slot.pos?.[1] === y &&
+        input.pos?.[0] === x &&
+        input.pos?.[1] === y
+
+      if (!unchanged) {
+        const pos: [number, number] = [x, y]
+        slot.pos = pos
+        input.pos = pos
+      }
       this._measureSlot(slot, i, true)
     }
   }

--- a/src/platform/settings/composables/useLitegraphSettings.ts
+++ b/src/platform/settings/composables/useLitegraphSettings.ts
@@ -1,4 +1,4 @@
-import { watchEffect } from 'vue'
+import { watch, watchEffect } from 'vue'
 
 import {
   CanvasPointer,
@@ -16,13 +16,21 @@ export const useLitegraphSettings = () => {
   const settingStore = useSettingStore()
   const canvasStore = useCanvasStore()
 
-  watchEffect(() => {
-    const canvasInfoEnabled = settingStore.get('Comfy.Graph.CanvasInfo')
-    if (canvasStore.canvas) {
-      canvasStore.canvas.show_info = canvasInfoEnabled
-      canvasStore.canvas.draw(false, true)
-    }
-  })
+  // Must stay an explicit `watch`: rendering reads reactive slot state, so a
+  // `watchEffect` wrapping draw() adopts every slot it touches as a dependency
+  // and each per-frame slot write then forces another draw.
+  watch(
+    [
+      () => settingStore.get('Comfy.Graph.CanvasInfo'),
+      () => canvasStore.canvas
+    ],
+    ([canvasInfoEnabled, canvas]) => {
+      if (!canvas) return
+      canvas.show_info = canvasInfoEnabled
+      canvas.draw(false, true)
+    },
+    { immediate: true }
+  )
 
   watchEffect(() => {
     const zoomSpeed = settingStore.get('Comfy.Graph.ZoomSpeed')

--- a/src/renderer/core/canvas/canvasRedrawBudget.test.ts
+++ b/src/renderer/core/canvas/canvasRedrawBudget.test.ts
@@ -1,0 +1,167 @@
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { effectScope, nextTick } from 'vue'
+
+import {
+  LGraph,
+  LGraphCanvas,
+  LGraphNode,
+  LiteGraph
+} from '@/lib/litegraph/src/litegraph'
+import { useLitegraphSettings } from '@/platform/settings/composables/useLitegraphSettings'
+import { useSettingStore } from '@/platform/settings/settingStore'
+import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
+import { createMockCanvas2DContext } from '@/utils/__tests__/litegraphTestUtils'
+
+const PROGRESS_EVENTS = 100
+
+async function drawUntilNoLongerDirty(canvas: LGraphCanvas, maxFrames = 5) {
+  for (
+    let i = 0;
+    i < maxFrames && (canvas.dirty_canvas || canvas.dirty_bgcanvas);
+    i++
+  ) {
+    canvas.draw()
+    await nextTick()
+  }
+}
+
+function createMockCtx(owner: HTMLCanvasElement): CanvasRenderingContext2D {
+  return createMockCanvas2DContext({
+    canvas: owner,
+    translate: vi.fn(),
+    scale: vi.fn(),
+    fillText: vi.fn(),
+    measureText: vi.fn().mockReturnValue({ width: 50 }),
+    closePath: vi.fn(),
+    rect: vi.fn(),
+    clip: vi.fn(),
+    setTransform: vi.fn(),
+    getTransform: vi
+      .fn()
+      .mockReturnValue({ a: 1, b: 0, c: 0, d: 1, e: 0, f: 0 }),
+    roundRect: vi.fn(),
+    drawImage: vi.fn(),
+    bezierCurveTo: vi.fn(),
+    quadraticCurveTo: vi.fn(),
+    isPointInStroke: vi.fn().mockReturnValue(false),
+    createLinearGradient: vi.fn().mockReturnValue({ addColorStop: vi.fn() }),
+    createPattern: vi.fn().mockReturnValue(null),
+    globalAlpha: 1,
+    font: '',
+    textAlign: 'left' as CanvasTextAlign,
+    textBaseline: 'alphabetic' as CanvasTextBaseline,
+    shadowColor: '',
+    shadowBlur: 0,
+    shadowOffsetX: 0,
+    shadowOffsetY: 0,
+    imageSmoothingEnabled: true
+  })
+}
+
+function addWidgetInputNode(graph: LGraph, x: number, y: number): LGraphNode {
+  const node = new LGraphNode('WidgetInput')
+  node.pos = [x, y]
+  node.size = [200, 120]
+  node.addWidget('number', 'value', 0, () => {})
+  const input = node.addInput('value', 'FLOAT')
+  input.widget = { name: 'value' }
+  graph.add(node)
+  return node
+}
+
+describe('canvas redraw budget while progress events stream in', () => {
+  let graph: LGraph
+  let canvas: LGraphCanvas
+
+  beforeEach(() => {
+    setActivePinia(createTestingPinia({ stubActions: false }))
+    LiteGraph.vueNodesMode = false
+
+    const canvasElement = document.createElement('canvas')
+    canvasElement.width = 1200
+    canvasElement.height = 800
+    canvasElement.getContext = vi
+      .fn()
+      .mockReturnValue(createMockCtx(canvasElement))
+    canvasElement.getBoundingClientRect = vi.fn().mockReturnValue({
+      left: 0,
+      top: 0,
+      width: 1200,
+      height: 800
+    })
+
+    graph = new LGraph()
+    canvas = new LGraphCanvas(canvasElement, graph, { skip_render: true })
+    canvas.ctx = createMockCtx(canvasElement)
+    canvas.bgctx = createMockCtx(canvas.bgcanvas)
+
+    for (let i = 0; i < 6; i++) {
+      addWidgetInputNode(graph, 20 + i * 220, 20)
+    }
+
+    useSettingStore().settingValues['Comfy.Graph.CanvasInfo'] = false
+    useCanvasStore().canvas = canvas
+  })
+
+  it('draws the foreground once per progress event and never the background', async () => {
+    const scope = effectScope()
+    scope.run(() => useLitegraphSettings())
+    await nextTick()
+    await drawUntilNoLongerDirty(canvas)
+
+    const foreground = vi.spyOn(canvas, 'drawFrontCanvas')
+    const background = vi.spyOn(canvas, 'drawBackCanvas')
+
+    for (let i = 0; i < PROGRESS_EVENTS; i++) {
+      canvas.setDirty(true)
+      canvas.draw()
+      await nextTick()
+    }
+
+    scope.stop()
+
+    expect(foreground).toHaveBeenCalledTimes(PROGRESS_EVENTS)
+    expect(background).not.toHaveBeenCalled()
+  })
+
+  it('does not treat slot positions written during rendering as a redraw trigger', async () => {
+    const scope = effectScope()
+    scope.run(() => useLitegraphSettings())
+    await nextTick()
+    await drawUntilNoLongerDirty(canvas)
+
+    const foreground = vi.spyOn(canvas, 'drawFrontCanvas')
+    const background = vi.spyOn(canvas, 'drawBackCanvas')
+
+    for (const node of graph.nodes) {
+      node.inputs[0].pos = [node.inputs[0].pos![0], node.inputs[0].pos![1] + 1]
+    }
+    await nextTick()
+
+    scope.stop()
+
+    expect(foreground).not.toHaveBeenCalled()
+    expect(background).not.toHaveBeenCalled()
+  })
+
+  it('still redraws immediately when the CanvasInfo setting changes', async () => {
+    const scope = effectScope()
+    scope.run(() => useLitegraphSettings())
+    await nextTick()
+    await drawUntilNoLongerDirty(canvas)
+
+    const foreground = vi.spyOn(canvas, 'drawFrontCanvas')
+    const background = vi.spyOn(canvas, 'drawBackCanvas')
+
+    useSettingStore().settingValues['Comfy.Graph.CanvasInfo'] = true
+    await nextTick()
+
+    scope.stop()
+
+    expect(canvas.show_info).toBe(true)
+    expect(background).toHaveBeenCalledTimes(1)
+    expect(foreground).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/renderer/core/canvas/canvasRedrawBudget.test.ts
+++ b/src/renderer/core/canvas/canvasRedrawBudget.test.ts
@@ -1,6 +1,6 @@
 import { createTestingPinia } from '@pinia/testing'
 import { setActivePinia } from 'pinia'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { effectScope, nextTick } from 'vue'
 
 import {
@@ -74,9 +74,11 @@ function addWidgetInputNode(graph: LGraph, x: number, y: number): LGraphNode {
 describe('canvas redraw budget while progress events stream in', () => {
   let graph: LGraph
   let canvas: LGraphCanvas
+  let previousVueNodesMode: boolean
 
   beforeEach(() => {
     setActivePinia(createTestingPinia({ stubActions: false }))
+    previousVueNodesMode = LiteGraph.vueNodesMode
     LiteGraph.vueNodesMode = false
 
     const canvasElement = document.createElement('canvas')
@@ -105,6 +107,10 @@ describe('canvas redraw budget while progress events stream in', () => {
     useCanvasStore().canvas = canvas
   })
 
+  afterEach(() => {
+    LiteGraph.vueNodesMode = previousVueNodesMode
+  })
+
   it('draws the foreground once per progress event and never the background', async () => {
     const scope = effectScope()
     scope.run(() => useLitegraphSettings())
@@ -114,7 +120,10 @@ describe('canvas redraw budget while progress events stream in', () => {
     const foreground = vi.spyOn(canvas, 'drawFrontCanvas')
     const background = vi.spyOn(canvas, 'drawBackCanvas')
 
+    const nodes = graph.nodes
     for (let i = 0; i < PROGRESS_EVENTS; i++) {
+      const executingNode = nodes[i % nodes.length]
+      executingNode.progress = (i % 10) / 10
       canvas.setDirty(true)
       canvas.draw()
       await nextTick()


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

## Summary

Progress-driven rendering was costing two foreground draws and one background draw per event instead of one foreground draw. This cuts both edges of the feedback loop and adds a redraw-budget regression test.

- Fixes #15977

Full profiling context: [Slack thread](https://comfy-organization.slack.com/archives/C0A4XMHANP3/p1787710583973309).

## Changes

- **What**:
  - `useLitegraphSettings.ts` — the CanvasInfo watcher becomes an explicit `watch` over the setting and the canvas ref. It previously ran `canvas.draw(false, true)` inside a `watchEffect`, so every `shallowReactive` slot the renderer read became a dependency of a *settings* effect. One spurious trigger cost a forced background draw, and `drawBackCanvas()` ends by setting `dirty_canvas = true`, which bought the second foreground pass.
  - `LGraphNode._arrangeWidgetInputSlots()` — skip the `pos` write when both coordinates are unchanged. Foreground layout was allocating a fresh `[x, y]` every frame for slots that had not moved, notifying every slot-position subscriber for nothing.
- **Breaking**: none.

## Measurements

100 `progress` events against the default 10-node graph (19 widget input slots), draw counts attributed by origin:

| | foreground | background | draws originating in `useLitegraphSettings` |
| --- | --- | --- | --- |
| before | 200 | 100 | 100 |
| after | **100** | **0** | **0** |

Reproduced twice: in the new unit test, and in a real browser against a live dev server by instrumenting `drawFrontCanvas`/`drawBackCanvas` and dispatching 100 events through the actual `api` event bus. The live before/after matches the issue's own origin instrumentation, which attributed all forced background draws to this watcher.

## Review Focus

- **The two fixes are independently sufficient, and the tests reflect that.** `canvasRedrawBudget.test.ts` pins the *composite* budget — it only fails when both halves are reverted. Each half therefore has its own dedicated guard: the "does not treat slot positions written during rendering as a redraw trigger" case pins the watcher containment (it writes `pos` directly, bypassing the guard), and `LGraphNode.arrangeWidgetInputSlots.test.ts` pins the guard. Verified by reverting each half in isolation and confirming exactly the expected test fails.

- **One observable contract change.** Slot `pos` array identity is now stable across unchanged re-arranges. An extension that leaned on per-frame `pos` reassignment as an incidental frame tick will stop receiving it. Genuine moves still write a fresh array — covered by a positive-control test, and confirmed live (`[10,36]` → `[10,50]` with a new array identity when the widget row actually moves).

- **`_measureSlot` is deliberately left outside the guard.** `slot.pos` is node-*relative*; `boundingRect` is absolute. Guarding the relative write while re-measuring the absolute rect unconditionally is what keeps hit-boxes correct when a node moves. Confirmed byte-identical geometry before and after the change in a live browser: at node `[1200,650]`, `boundingRect [1200,676,15,20]` and `getInputPos [1210,686]` on both.

- The `watch`-not-`watchEffect` comment is load-bearing: every other watcher in that file is a `watchEffect`, so a consistency-motivated "simplification" would silently reintroduce this regression.

Out of scope, per the issue: the larger geometry-synchronization bypass (recovered only ~5%) and the unattributed native CPU stalls in the original trace.

## Test plan

- [x] `pnpm test:unit` — 1320 files, 17,945 passing. The one full-run failure (`useFirstRunTourController`) is a 5s-timeout flake under suite load: it passes in isolation (61/61) and passed in a separate full run of this same code.
- [x] `pnpm typecheck`, `pnpm lint`, `pnpm knip`, `pnpm format` — all clean
- [x] Live browser verification against ComfyUI backend + dev server (table above)
- [x] Node move while progress streams — no stale canvas, links and slot geometry track correctly


## Screenshots

![Default 10-node graph rendering correctly with the fix applied: widget rows intact, links landing on their slots, canvas-info overlay active bottom-left. Red node borders are expected missing-model validation errors in the sandbox, not rendering artifacts.](https://pub-0c501c1cf38f477fa8efc67068523b33.r2.dev/sessions/7b566142071671e1064a0ca8a750d245b3c3777110405fd4116e2631e695ff4c/pr-images/1787734677687-c290bb3b-7878-4ca1-9bee-563a7a0ce25b.png)