### PR TITLE
fix: use trusted sources for fork coverage reports

### DIFF
--- a/.github/workflows/ci-tests-e2e-coverage.yaml
+++ b/.github/workflows/ci-tests-e2e-coverage.yaml
@@ -49,7 +49,7 @@ jobs:
       - name: Checkout sources for genhtml
         uses: actions/checkout@v7
         with:
-          ref: ${{ inputs.source_sha || github.event.workflow_run.head_sha }}
+          ref: ${{ inputs.source_sha || (github.event.workflow_run.head_repository.full_name == github.repository && github.event.workflow_run.head_sha) || github.event.repository.default_branch }}
           sparse-checkout: |
             src
             packages


### PR DESCRIPTION
- Fork runs checkout trusted base sources.
- LCOV mapping and Codecov attribution stay intact.
- Fixes #16002.

<details><summary>Full context for agent readers</summary>

## Summary

`workflow_run` has base-repository credentials, so checkout v7 correctly rejects a fork PR head SHA. This change uses the repository default branch as `genhtml` source text only for fork-triggered runs. Reusable calls and same-repository runs continue checking out the tested SHA.

## Changes

- **What**: Select the checkout ref by trust boundary: explicit reusable-workflow SHA first, same-repository `workflow_run` SHA second, trusted default branch otherwise.
- **Breaking**: None.
- **Dependencies**: None.

The downloaded LCOV remains authoritative. Its `SF:src/...` and `SF:packages/...` source-map paths are merged and validated unchanged. The existing `override_branch`, `override_commit`, and `override_pr` values still attribute uploads to the triggering PR head.

## Security

The privileged workflow never opts into unsafe PR checkout and never fetches fork source. Checkout v7 receives an explicit base-repository branch for fork events, which does not match the fork repository, a PR ref, or the fork head SHA rejected by its pwn-request guard.

## Overlap with #15339

Current `main` already contains #15339's three Codecov attribution inputs via #15225. This PR does not duplicate or alter them; it changes only the `genhtml` checkout ref.

## Verification

- `yamllint --config-file .yamllint .github/workflows/ci-tests-e2e-coverage.yaml`: pass
- `pnpm dlx oxfmt@0.59.0 --check .github/workflows/ci-tests-e2e-coverage.yaml`: pass
- YAML parse and ref-selection trust matrix: pass
- `git diff --check`: pass
- `actionlint`: zero new findings versus `origin/main`; both report the same pre-existing SC2086 and SC2129 notices in unchanged shell blocks

## Review focus

For fork reports, the browsable HTML uses trusted default-branch source text. Codecov still maps LCOV to the exact fork head through `override_commit`; the HTML can show line drift when the fork changes covered source files, but no coverage records or attribution are changed.

</details>
