### PR TITLE
perf: reuse link lookup scope while drawing

### DIFF
--- a/src/lib/litegraph/src/LGraphCanvas.drawConnections.test.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.drawConnections.test.ts
@@ -267,6 +267,91 @@ describe('drawConnections', () => {
     }
   )
 
+  it.for([
+    { connectedRatio: 0, fanOut: 1, hiddenEvery: 0 },
+    { connectedRatio: 0.25, fanOut: 1, hiddenEvery: 2 },
+    { connectedRatio: 1, fanOut: 8, hiddenEvery: 3 }
+  ])(
+    'scans inputs once and preserves rendered link identity at $connectedRatio occupancy and $fanOut fan-out',
+    ({ connectedRatio, fanOut, hiddenEvery }) => {
+      const nodeCount = 8
+      const inputsPerNode = 4
+      const targets = Array.from({ length: nodeCount }, (_, nodeIndex) => {
+        const target = new LGraphNode(`Target ${nodeIndex}`)
+        target.pos = [300, nodeIndex * 80]
+        for (let slot = 0; slot < inputsPerNode; slot++) {
+          target.addInput(`in ${slot}`, 'INT')
+        }
+        graph.add(target)
+        return target
+      })
+      const allInputs = targets.flatMap((target) =>
+        target.inputs.map((_, slot) => ({ target, slot }))
+      )
+      const connectedCount = Math.floor(allInputs.length * connectedRatio)
+      const sources = Array.from(
+        { length: Math.ceil(connectedCount / fanOut) },
+        (_, sourceIndex) => {
+          const source = new LGraphNode(`Source ${sourceIndex}`)
+          source.pos = [0, sourceIndex * 80]
+          source.addOutput('out', 'INT')
+          graph.add(source)
+          return source
+        }
+      )
+      const expectedLinks = allInputs
+        .slice(0, connectedCount)
+        .map(({ target, slot }, index) =>
+          createTestLink(
+            graph,
+            sources[Math.floor(index / fanOut)],
+            0,
+            target,
+            slot
+          )
+        )
+
+      vi.mocked(layoutStore.getNodeLayout).mockImplementation(
+        (_graphId, nodeId) => {
+          const nodeIndex = targets.findIndex((node) => node.id === nodeId)
+          return {
+            id: nodeId,
+            position: { x: 0, y: 0 },
+            size: { width: 100, height: 100 },
+            zIndex: nodeIndex,
+            visible:
+              !hiddenEvery || nodeIndex < 0 || nodeIndex % hiddenEvery !== 0,
+            bounds: { x: 0, y: 0, width: 100, height: 100 }
+          }
+        }
+      )
+      const linkStore = useLinkStore()
+      const inputLookup = vi.spyOn(linkStore, 'getInputSlotLink')
+      const resolveLink = vi.spyOn(graph, 'getLink')
+      canvas.visible_area.set([0, 0, 800, 3_000])
+      vi.spyOn(canvas, 'renderLink').mockImplementation(() => {})
+
+      canvas.drawConnections(createMockCtx())
+
+      const scannedInputs = allInputs.length
+      const scopes = new Set(inputLookup.mock.calls.map(([scope]) => scope))
+      expect(inputLookup).toHaveBeenCalledTimes(scannedInputs)
+      expect(resolveLink).toHaveBeenCalledTimes(connectedCount)
+      expect([...canvas.renderedPaths]).toEqual(expectedLinks)
+      expect(scopes.size).toBe(scannedInputs)
+      expect(new Set(expectedLinks.map((link) => link.origin_id)).size).toBe(
+        connectedCount ? Math.ceil(connectedCount / fanOut) : 0
+      )
+
+      const compatibilityIds = allInputs.map(
+        ({ target, slot }) => target.inputs[slot].link
+      )
+      expect(compatibilityIds.filter((id) => id != null)).toEqual(
+        expectedLinks.map((link) => link.id)
+      )
+    }
+  )
+
   it('connects, draws, and serializes without deprecation warnings', () => {
     const sourceNode = new LGraphNode('Source')
     sourceNode.pos = [100, 100]

--- a/src/lib/litegraph/src/LGraphCanvas.drawConnections.test.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.drawConnections.test.ts
@@ -9,6 +9,7 @@ import {
   LiteGraph
 } from '@/lib/litegraph/src/litegraph'
 import { LLink } from '@/lib/litegraph/src/LLink'
+import { createTestSubgraph } from '@/lib/litegraph/src/subgraph/__fixtures__/subgraphHelpers'
 import { layoutStore } from '@/renderer/core/layout/store/layoutStore'
 import { useLinkStore } from '@/stores/linkStore'
 import { toLinkId } from '@/types/linkId'
@@ -231,7 +232,7 @@ describe('drawConnections', () => {
     }
 
     const scopes = inputLookup.mock.calls.map(([scope]) => scope)
-    expect(new Set(scopes).size).toBe(4)
+    expect(new Set(scopes).size).toBe(1)
   })
 
   it.for([245, 500, 1_000])(
@@ -338,7 +339,7 @@ describe('drawConnections', () => {
       expect(inputLookup).toHaveBeenCalledTimes(scannedInputs)
       expect(resolveLink).toHaveBeenCalledTimes(connectedCount)
       expect([...canvas.renderedPaths]).toEqual(expectedLinks)
-      expect(scopes.size).toBe(scannedInputs)
+      expect(scopes.size).toBe(1)
       expect(new Set(expectedLinks.map((link) => link.origin_id)).size).toBe(
         connectedCount ? Math.ceil(connectedCount / fanOut) : 0
       )
@@ -383,6 +384,33 @@ describe('drawConnections', () => {
     } finally {
       warningCallbacks.mockRestore()
     }
+  })
+
+  it('isolates subgraph rendering from root-graph topology', () => {
+    const subgraph = createTestSubgraph({ nodeCount: 2 })
+    const [subgraphSource, subgraphTarget] = subgraph.nodes
+    const subgraphLink = subgraphSource.connect(0, subgraphTarget, 0)!
+
+    const rootSource = new LGraphNode('Root source')
+    rootSource.addOutput('out', '*')
+    subgraph.rootGraph.add(rootSource)
+    const rootTarget = new LGraphNode('Root target')
+    rootTarget.addInput('in', '*')
+    subgraph.rootGraph.add(rootTarget)
+    const rootLink = rootSource.connect(0, rootTarget, 0)!
+    canvas.setGraph(subgraph)
+    canvas.visible_area.set([0, 0, 800, 600])
+    const inputLookup = vi.spyOn(useLinkStore(), 'getInputSlotLink')
+    vi.spyOn(canvas, 'renderLink').mockImplementation(() => {})
+    inputLookup.mockClear()
+
+    canvas.drawConnections(createMockCtx())
+
+    expect([...canvas.renderedPaths]).toEqual([subgraphLink])
+    expect(canvas.renderedPaths).not.toContain(rootLink)
+    expect(
+      new Set(inputLookup.mock.calls.map(([scope]) => scope.owningGraphId))
+    ).toEqual(new Set([subgraph.id]))
   })
   it('positions widget-input slots when display name differs from slot.widget.name', () => {
     const sourceNode = new LGraphNode('Source')

--- a/src/lib/litegraph/src/LGraphCanvas.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.ts
@@ -13,6 +13,8 @@ import { getSlotPosition } from '@/renderer/core/canvas/litegraph/slotCalculatio
 import { useLayoutMutations } from '@/renderer/core/layout/operations/layoutMutations'
 import { layoutStore } from '@/renderer/core/layout/store/layoutStore'
 import { LayoutSource } from '@/renderer/core/layout/types'
+import { useLinkStore } from '@/stores/linkStore'
+import { graphScopeOf } from '@/types/graphScopeId'
 import { toLinkId } from '@/types/linkId'
 import { toRerouteId } from '@/types/rerouteId'
 import { forEachNode } from '@/utils/graphTraversalUtil'
@@ -33,7 +35,6 @@ import type { SerializedNodeId } from '@/types/nodeId'
 import { LLink, slotFloatingLinks } from './LLink'
 import {
   inputHasLink,
-  inputLink,
   inputLinkId,
   outputLinkIds,
   outputLinks
@@ -6053,6 +6054,8 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
     ctx.globalAlpha = this.editor_alpha
     // for every node
     const nodes = nodesInRenderOrder(graph)
+    const linkStore = useLinkStore()
+    const graphScope = graphScopeOf(graph)
 
     // Ensure widget-input slot positions are computed before rendering links.
     // arrange() sets input.pos for widget-backed slots, but is normally called
@@ -6068,7 +6071,12 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
 
     for (const node of nodes) {
       for (const [inputSlot, input] of node.inputs.entries()) {
-        const link = inputLink(graph, node.id, inputSlot)
+        const topology = linkStore.getInputSlotLink(
+          graphScope,
+          node.id,
+          inputSlot
+        )
+        const link = topology ? graph.getLink(topology.id) : undefined
         if (!link) continue
 
         const endPos: Point = LiteGraph.vueNodesMode // TODO: still use LG get pos if vue nodes is off until stable


### PR DESCRIPTION
## Summary

Stacked on the deterministic link-traversal proof. Hoist `useLinkStore()` and `graphScopeOf(graph)` once per `drawConnections()` call while retaining one indexed lookup per input.

## Deterministic effect

- 32-input cells: 32 distinct scope/store acquisitions → 1
- representative 245×16 graph: 3,920 → 1
- link lookups and graph resolutions unchanged
- rendered link identities and legacy slot IDs unchanged
- root/subgraph ownership remains isolated

This is a safe allocation cleanup, not presented as the primary frame-budget cause. Geometry and topology indexing remain separate work.

## Verification

26 focused tests, full typecheck, Oxlint/ESLint, formatting, diff checks, and hooks pass.

<!-- perf-proof-evidence:start -->
## Performance proof status

**Role:** runtime link-scope allocation cleanup paired with #16004.

- Exact local proof at `162fe9019921`: `node_modules/.bin/vitest run src/lib/litegraph/src/LGraphCanvas.drawConnections.test.ts` passed 1 file / 9 tests in 1.07 s (1.72 s wall), proving one scope/store acquisition per draw while preserving traversal, identity, and root/subgraph isolation.
- Merged head: `822b4fb089bb0d2a73118d1b6586c982ad98fdb2`; the local proof predates the final stacked/merged SHA, so it is not presented as exact-head certification.
- Live status: merged 2026-08-26, no unresolved threads, checks terminal non-failing, and CodeRabbit approved the merged head.
- This cleanup is not presented as the primary frame-budget cause. No browser timing or paired canvas screenshot is claimed.
<!-- perf-proof-evidence:end -->

