### PR TITLE
perf: index visible nodes for progress updates

### DIFF
--- a/src/components/graph/GraphCanvas.firstRunEntry.test.ts
+++ b/src/components/graph/GraphCanvas.firstRunEntry.test.ts
@@ -237,7 +237,7 @@ describe('GraphCanvas execution progress fanout complexity', () => {
     { totalNodes: 1_000, activeEntries: 100 },
     { totalNodes: 1_000, activeEntries: 500 }
   ])(
-    'scans all $totalNodes visible nodes with $activeEntries active entries for equal, changed, removed, and unmatched events',
+    'indexes $totalNodes visible nodes once with $activeEntries active entries',
     async ({ totalNodes, activeEntries }) => {
       await mountGraphCanvas()
 
@@ -260,13 +260,17 @@ describe('GraphCanvas execution progress fanout complexity', () => {
       mocks.graphNodes.push(...nodes)
 
       const canvas = app.canvas!
-      canvas.graph = { nodes } as typeof canvas.graph
+      canvas.graph = { nodes, events: new EventTarget() } as typeof canvas.graph
       useCanvasStore().canvas = canvas
 
       const workflowStore = useWorkflowStore()
       vi.mocked(workflowStore.nodeIdToNodeLocatorId).mockImplementation((id) =>
         createNodeLocatorId(null, id)
       )
+      vi.mocked(workflowStore.nodeToNodeLocatorId).mockImplementation((node) =>
+        createNodeLocatorId(null, node.id)
+      )
+      vi.mocked(workflowStore.nodeToNodeLocatorId).mockClear()
 
       const executionStore = useExecutionStore()
       const equalState = Object.fromEntries(
@@ -293,26 +297,27 @@ describe('GraphCanvas execution progress fanout complexity', () => {
       if (activeEntries < totalNodes) {
         expect(progressValues[activeEntries]).toBeUndefined()
       }
+      expect(workflowStore.nodeToNodeLocatorId).toHaveBeenCalledTimes(
+        totalNodes
+      )
 
       progressWrites = 0
       mocks.setDirty.mockClear()
-      vi.mocked(workflowStore.nodeIdToNodeLocatorId).mockClear()
+      vi.mocked(workflowStore.nodeToNodeLocatorId).mockClear()
 
-      // A structurally equal WebSocket payload still scans, but does no work.
+      // A structurally equal WebSocket payload neither scans nor mutates nodes.
       executionStore.nodeProgressStates = { ...equalState }
       await nextTick()
 
-      expect(workflowStore.nodeIdToNodeLocatorId).toHaveBeenCalledTimes(
-        totalNodes
-      )
+      expect(workflowStore.nodeToNodeLocatorId).not.toHaveBeenCalled()
       expect(progressWrites).toBe(0)
       expect(mocks.setDirty).not.toHaveBeenCalled()
 
       progressWrites = 0
       mocks.setDirty.mockClear()
-      vi.mocked(workflowStore.nodeIdToNodeLocatorId).mockClear()
+      vi.mocked(workflowStore.nodeToNodeLocatorId).mockClear()
 
-      // A real one-node change scans all nodes but mutates only that node.
+      // A real one-node change uses the index and mutates only that node.
       executionStore.nodeProgressStates = {
         ...equalState,
         '1': {
@@ -325,9 +330,7 @@ describe('GraphCanvas execution progress fanout complexity', () => {
       }
       await nextTick()
 
-      expect(workflowStore.nodeIdToNodeLocatorId).toHaveBeenCalledTimes(
-        totalNodes
-      )
+      expect(workflowStore.nodeToNodeLocatorId).not.toHaveBeenCalled()
       expect(progressWrites).toBe(1)
       expect(progressValues[0]).toBe(0.5)
       expect(mocks.setDirty).toHaveBeenCalledTimes(1)
@@ -335,7 +338,7 @@ describe('GraphCanvas execution progress fanout complexity', () => {
 
       progressWrites = 0
       mocks.setDirty.mockClear()
-      vi.mocked(workflowStore.nodeIdToNodeLocatorId).mockClear()
+      vi.mocked(workflowStore.nodeToNodeLocatorId).mockClear()
 
       const changedState: typeof equalState = {
         ...equalState,
@@ -351,16 +354,14 @@ describe('GraphCanvas execution progress fanout complexity', () => {
       executionStore.nodeProgressStates = changedState
       await nextTick()
 
-      expect(workflowStore.nodeIdToNodeLocatorId).toHaveBeenCalledTimes(
-        totalNodes
-      )
+      expect(workflowStore.nodeToNodeLocatorId).not.toHaveBeenCalled()
       expect(progressWrites).toBe(1)
       expect(progressValues[activeEntries - 1]).toBeUndefined()
       expect(mocks.setDirty).toHaveBeenCalledTimes(1)
 
       progressWrites = 0
       mocks.setDirty.mockClear()
-      vi.mocked(workflowStore.nodeIdToNodeLocatorId).mockClear()
+      vi.mocked(workflowStore.nodeToNodeLocatorId).mockClear()
 
       executionStore.nodeProgressStates = {
         ...changedState,
@@ -375,9 +376,7 @@ describe('GraphCanvas execution progress fanout complexity', () => {
       }
       await nextTick()
 
-      expect(workflowStore.nodeIdToNodeLocatorId).toHaveBeenCalledTimes(
-        totalNodes
-      )
+      expect(workflowStore.nodeToNodeLocatorId).not.toHaveBeenCalled()
       expect(progressWrites).toBe(0)
       expect(mocks.setDirty).not.toHaveBeenCalled()
     }

--- a/src/components/graph/GraphCanvas.vue
+++ b/src/components/graph/GraphCanvas.vue
@@ -138,6 +138,7 @@ import VueNodeSwitchPopup from '@/components/builder/VueNodeSwitchPopup.vue'
 import ExtensionSlot from '@/components/common/ExtensionSlot.vue'
 import DomWidgets from '@/components/graph/DomWidgets.vue'
 import GraphCanvasMenu from '@/components/graph/GraphCanvasMenu.vue'
+import { createNodeProgressCanvasSync } from '@/components/graph/nodeProgressCanvasSync'
 import LinkOverlayCanvas from '@/components/graph/LinkOverlayCanvas.vue'
 import NodeTooltip from '@/components/graph/NodeTooltip.vue'
 import NodeContextMenu from '@/components/graph/NodeContextMenu.vue'
@@ -221,6 +222,9 @@ const workspaceStore = useWorkspaceStore()
 const { isBuilderMode } = useAppMode()
 const canvasStore = useCanvasStore()
 const workflowStore = useWorkflowStore()
+const nodeProgressCanvasSync = createNodeProgressCanvasSync(
+  workflowStore.nodeToNodeLocatorId
+)
 const { linearMode } = storeToRefs(canvasStore)
 const executionStore = useExecutionStore()
 const executionErrorStore = useExecutionErrorStore()
@@ -437,25 +441,15 @@ watch(
       canvasStore.currentGraph
     ] as const,
   ([nodeLocationProgressStates, canvas]) => {
-    if (!canvas?.graph) return
-    let progressChanged = false
-    for (const node of canvas.graph.nodes) {
-      const nodeLocatorId = useWorkflowStore().nodeIdToNodeLocatorId(node.id)
-      const progressState = nodeLocationProgressStates[nodeLocatorId]
-      const nextProgress =
-        progressState && progressState.state === 'running'
-          ? progressState.value / progressState.max
-          : undefined
-      if (!Object.is(node.progress, nextProgress)) {
-        node.progress = nextProgress
-        progressChanged = true
-      }
-    }
-
-    // Repaint only when the progress visuals actually changed.
-    if (progressChanged) canvas.setDirty(true, false)
+    nodeProgressCanvasSync.sync(
+      nodeLocationProgressStates,
+      canvas,
+      canvas?.graph ?? canvasStore.currentGraph
+    )
   }
 )
+
+onUnmounted(nodeProgressCanvasSync.dispose)
 
 // Repaint canvas when node errors change.
 // Slot error flags are reconciled by reconcileNodeErrorFlags in executionErrorStore.

--- a/src/components/graph/nodeProgressCanvasSync.test.ts
+++ b/src/components/graph/nodeProgressCanvasSync.test.ts
@@ -1,0 +1,205 @@
+import { expect, it, vi } from 'vitest'
+
+import type {
+  LGraph,
+  LGraphCanvas,
+  LGraphNode
+} from '@/lib/litegraph/src/litegraph'
+import type { NodeProgressState } from '@/schemas/apiSchema'
+import { createNodeLocatorId } from '@/types/nodeIdentification'
+import type { NodeLocatorId } from '@/types/nodeIdentification'
+import { toNodeId } from '@/types/nodeId'
+
+import { createNodeProgressCanvasSync } from './nodeProgressCanvasSync'
+
+const SUBGRAPH_ID = '00000000-0000-0000-0000-000000000001'
+
+function runningState(id: string, value: number): NodeProgressState {
+  return {
+    display_node_id: id,
+    node_id: id,
+    prompt_id: 'job',
+    state: 'running',
+    value,
+    max: 100
+  }
+}
+
+function createNode(id: number) {
+  let progress: number | undefined
+  const reads = vi.fn()
+  const writes = vi.fn()
+  const node = {
+    id,
+    graph: null,
+    get progress() {
+      reads()
+      return progress
+    },
+    set progress(value: number | undefined) {
+      writes(value)
+      progress = value
+    }
+  } as unknown as LGraphNode
+  return { node, reads, writes, value: () => progress }
+}
+
+function createGraph(nodes: LGraphNode[], subgraphId?: string) {
+  const events = new EventTarget()
+  const graph = {
+    id: subgraphId,
+    nodes,
+    events
+  } as unknown as LGraph
+  for (const node of nodes) node.graph = graph
+  return {
+    graph,
+    add(node: LGraphNode) {
+      node.graph = graph
+      nodes.push(node)
+      events.dispatchEvent(new CustomEvent('node:added', { detail: { node } }))
+    },
+    remove(node: LGraphNode) {
+      const index = nodes.indexOf(node)
+      if (index !== -1) nodes.splice(index, 1)
+      node.graph = null
+      events.dispatchEvent(
+        new CustomEvent('node:removed', { detail: { node } })
+      )
+    }
+  }
+}
+
+const createCanvas = () => ({ setDirty: vi.fn() }) as unknown as LGraphCanvas
+
+const locatorForNode = (node: LGraphNode): NodeLocatorId =>
+  createNodeLocatorId(
+    node.graph?.id === SUBGRAPH_ID ? SUBGRAPH_ID : null,
+    node.id
+  )
+
+it('does one graph build, then only looks up changed and removed keys', () => {
+  const nodes = Array.from({ length: 1_000 }, (_, index) =>
+    createNode(index + 1)
+  )
+  const { graph } = createGraph(nodes.map(({ node }) => node))
+  const canvas = createCanvas()
+  const conversions = vi.fn(locatorForNode)
+  const lookups = vi.fn()
+  const sync = createNodeProgressCanvasSync(conversions, lookups)
+  const locator = createNodeLocatorId(null, toNodeId(1))
+  const equalStates = { [locator]: runningState('1', 25) }
+
+  sync.sync(equalStates, canvas, graph)
+  expect(conversions).toHaveBeenCalledTimes(1_000)
+  expect(nodes[0].value()).toBe(0.25)
+
+  conversions.mockClear()
+  lookups.mockClear()
+  nodes.forEach(({ reads, writes }) => {
+    reads.mockClear()
+    writes.mockClear()
+  })
+
+  sync.sync({ ...equalStates }, canvas, graph)
+  expect(conversions).not.toHaveBeenCalled()
+  expect(lookups).not.toHaveBeenCalled()
+  expect(
+    nodes.every(
+      ({ reads, writes }) =>
+        !reads.mock.calls.length && !writes.mock.calls.length
+    )
+  ).toBe(true)
+
+  sync.sync({ [locator]: runningState('1', 50) }, canvas, graph)
+  expect(lookups).toHaveBeenCalledTimes(1)
+  expect(nodes[0].writes).toHaveBeenCalledExactlyOnceWith(0.5)
+  expect(nodes.slice(1).every(({ writes }) => !writes.mock.calls.length)).toBe(
+    true
+  )
+
+  lookups.mockClear()
+  nodes[0].writes.mockClear()
+  sync.sync({}, canvas, graph)
+  expect(lookups).toHaveBeenCalledTimes(1)
+  expect(nodes[0].writes).toHaveBeenCalledExactlyOnceWith(undefined)
+
+  lookups.mockClear()
+  nodes[0].writes.mockClear()
+  const unmatched = createNodeLocatorId(null, toNodeId(1_001))
+  sync.sync({ [unmatched]: runningState('1001', 25) }, canvas, graph)
+  expect(lookups).toHaveBeenCalledTimes(1)
+  expect(nodes.every(({ writes }) => !writes.mock.calls.length)).toBe(true)
+
+  lookups.mockClear()
+  sync.sync({ [locator]: runningState('1', 75) }, canvas, graph)
+  expect(lookups).toHaveBeenCalledTimes(2)
+  expect(nodes[0].writes).toHaveBeenCalledExactlyOnceWith(0.75)
+})
+
+it('keeps duplicate locator entries and node add/remove lifecycle in sync', () => {
+  const first = createNode(1)
+  const duplicate = createNode(1)
+  const graphFixture = createGraph([first.node])
+  const canvas = createCanvas()
+  const conversions = vi.fn(locatorForNode)
+  const sync = createNodeProgressCanvasSync(conversions)
+  const locator = createNodeLocatorId(null, toNodeId(1))
+
+  sync.sync({ [locator]: runningState('1', 25) }, canvas, graphFixture.graph)
+  conversions.mockClear()
+  graphFixture.add(duplicate.node)
+  expect(conversions).toHaveBeenCalledExactlyOnceWith(duplicate.node)
+  expect(duplicate.value()).toBe(0.25)
+
+  first.writes.mockClear()
+  duplicate.writes.mockClear()
+  sync.sync({ [locator]: runningState('1', 50) }, canvas, graphFixture.graph)
+  expect(first.writes).toHaveBeenCalledExactlyOnceWith(0.5)
+  expect(duplicate.writes).toHaveBeenCalledExactlyOnceWith(0.5)
+
+  graphFixture.remove(first.node)
+  first.writes.mockClear()
+  duplicate.writes.mockClear()
+  sync.sync({ [locator]: runningState('1', 75) }, canvas, graphFixture.graph)
+  expect(first.writes).not.toHaveBeenCalled()
+  expect(duplicate.writes).toHaveBeenCalledExactlyOnceWith(0.75)
+})
+
+it('rebuilds scope on graph replacement and detaches old graph listeners', () => {
+  const rootNode = createNode(1)
+  const subgraphNode = createNode(1)
+  const oldLateNode = createNode(2)
+  const root = createGraph([rootNode.node])
+  const subgraph = createGraph([subgraphNode.node], SUBGRAPH_ID)
+  const canvas = createCanvas()
+  const conversions = vi.fn(locatorForNode)
+  const sync = createNodeProgressCanvasSync(conversions)
+  const rootLocator = createNodeLocatorId(null, toNodeId(1))
+  const subgraphLocator = createNodeLocatorId(SUBGRAPH_ID, toNodeId(1))
+
+  sync.sync({ [rootLocator]: runningState('1', 25) }, canvas, root.graph)
+  expect(rootNode.value()).toBe(0.25)
+
+  conversions.mockClear()
+  sync.sync(
+    { [subgraphLocator]: runningState('1', 50) },
+    canvas,
+    subgraph.graph
+  )
+  expect(conversions).toHaveBeenCalledExactlyOnceWith(subgraphNode.node)
+  expect(subgraphNode.value()).toBe(0.5)
+
+  conversions.mockClear()
+  root.add(oldLateNode.node)
+  expect(conversions).not.toHaveBeenCalled()
+
+  sync.sync({}, canvas, root.graph)
+  expect(rootNode.value()).toBeUndefined()
+  expect(oldLateNode.value()).toBeUndefined()
+
+  conversions.mockClear()
+  sync.dispose()
+  root.add(createNode(3).node)
+  expect(conversions).not.toHaveBeenCalled()
+})

--- a/src/components/graph/nodeProgressCanvasSync.test.ts
+++ b/src/components/graph/nodeProgressCanvasSync.test.ts
@@ -1,10 +1,9 @@
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
 import { expect, it, vi } from 'vitest'
 
-import type {
-  LGraph,
-  LGraphCanvas,
-  LGraphNode
-} from '@/lib/litegraph/src/litegraph'
+import { LGraph, LGraphNode } from '@/lib/litegraph/src/litegraph'
+import type { LGraphCanvas } from '@/lib/litegraph/src/litegraph'
 import type { NodeProgressState } from '@/schemas/apiSchema'
 import { createNodeLocatorId } from '@/types/nodeIdentification'
 import type { NodeLocatorId } from '@/types/nodeIdentification'
@@ -60,12 +59,12 @@ function createGraph(nodes: LGraphNode[], subgraphId?: string) {
       events.dispatchEvent(new CustomEvent('node:added', { detail: { node } }))
     },
     remove(node: LGraphNode) {
+      events.dispatchEvent(
+        new CustomEvent('node:before-removed', { detail: { node } })
+      )
       const index = nodes.indexOf(node)
       if (index !== -1) nodes.splice(index, 1)
       node.graph = null
-      events.dispatchEvent(
-        new CustomEvent('node:removed', { detail: { node } })
-      )
     }
   }
 }
@@ -164,6 +163,29 @@ it('keeps duplicate locator entries and node add/remove lifecycle in sync', () =
   sync.sync({ [locator]: runningState('1', 75) }, canvas, graphFixture.graph)
   expect(first.writes).not.toHaveBeenCalled()
   expect(duplicate.writes).toHaveBeenCalledExactlyOnceWith(0.75)
+})
+
+it('evicts detached nodes when a real graph is cleared and reused', () => {
+  setActivePinia(createTestingPinia({ stubActions: false }))
+  const graph = new LGraph()
+  const staleNode = new LGraphNode('stale')
+  staleNode.id = toNodeId(1)
+  graph.add(staleNode)
+  const canvas = createCanvas()
+  const sync = createNodeProgressCanvasSync(locatorForNode)
+  const locator = createNodeLocatorId(null, staleNode.id)
+
+  sync.sync({ [locator]: runningState('1', 25) }, canvas, graph)
+  expect(staleNode.progress).toBe(0.25)
+
+  graph.clear()
+  const replacementNode = new LGraphNode('replacement')
+  replacementNode.id = toNodeId(1)
+  graph.add(replacementNode)
+  sync.sync({ [locator]: runningState('1', 50) }, canvas, graph)
+
+  expect(staleNode.progress).toBe(0.25)
+  expect(replacementNode.progress).toBe(0.5)
 })
 
 it('rebuilds scope on graph replacement and detaches old graph listeners', () => {

--- a/src/components/graph/nodeProgressCanvasSync.ts
+++ b/src/components/graph/nodeProgressCanvasSync.ts
@@ -1,0 +1,130 @@
+import type {
+  LGraph,
+  LGraphCanvas,
+  LGraphNode
+} from '@/lib/litegraph/src/litegraph'
+import type { NodeProgressState } from '@/schemas/apiSchema'
+import type { NodeLocatorId } from '@/types/nodeIdentification'
+
+type ProgressStates = Readonly<Record<NodeLocatorId, NodeProgressState>>
+
+const progressValue = (state: NodeProgressState | undefined) =>
+  state?.state === 'running' ? state.value / state.max : undefined
+
+export function createNodeProgressCanvasSync(
+  nodeToLocator: (node: LGraphNode) => NodeLocatorId,
+  onIndexLookup: () => void = () => {}
+) {
+  let activeCanvas: LGraphCanvas | null = null
+  let activeGraph: LGraph | null = null
+  let activeStates: ProgressStates = {}
+  let nodeLocators = new WeakMap<LGraphNode, NodeLocatorId>()
+  const nodesByLocator = new Map<NodeLocatorId, LGraphNode[]>()
+
+  const markDirty = () => activeCanvas?.setDirty(true, false)
+
+  const setNodeProgress = (
+    node: LGraphNode,
+    nextProgress: number | undefined
+  ) => {
+    if (Object.is(node.progress, nextProgress)) return false
+    node.progress = nextProgress
+    return true
+  }
+
+  const addNode = (node: LGraphNode) => {
+    const locator = nodeToLocator(node)
+    nodeLocators.set(node, locator)
+    const nodes = nodesByLocator.get(locator)
+    if (nodes) nodes.push(node)
+    else nodesByLocator.set(locator, [node])
+    return locator
+  }
+
+  const removeNode = (node: LGraphNode) => {
+    const locator = nodeLocators.get(node)
+    if (!locator) return
+    const nodes = nodesByLocator.get(locator)
+    if (!nodes) return
+    const nextNodes = nodes.filter((candidate) => candidate !== node)
+    if (nextNodes.length) nodesByLocator.set(locator, nextNodes)
+    else nodesByLocator.delete(locator)
+    nodeLocators.delete(node)
+  }
+
+  const onNodeAdded = (event: CustomEvent<{ node: LGraphNode }>) => {
+    const node = event.detail.node
+    const locator = addNode(node)
+    if (setNodeProgress(node, progressValue(activeStates[locator]))) markDirty()
+  }
+
+  const onNodeRemoved = (event: CustomEvent<{ node: LGraphNode }>) => {
+    removeNode(event.detail.node)
+  }
+
+  const detachGraph = () => {
+    activeGraph?.events.removeEventListener('node:added', onNodeAdded)
+    activeGraph?.events.removeEventListener('node:removed', onNodeRemoved)
+  }
+
+  const replaceGraph = (graph: LGraph | null) => {
+    detachGraph()
+    activeGraph = graph
+    nodesByLocator.clear()
+    nodeLocators = new WeakMap()
+    if (!graph) return false
+
+    let progressChanged = false
+    for (const node of graph.nodes) {
+      const locator = addNode(node)
+      progressChanged =
+        setNodeProgress(node, progressValue(activeStates[locator])) ||
+        progressChanged
+    }
+    graph.events.addEventListener('node:added', onNodeAdded)
+    graph.events.addEventListener('node:removed', onNodeRemoved)
+    return progressChanged
+  }
+
+  const sync = (
+    states: ProgressStates,
+    canvas: LGraphCanvas | null,
+    graph: LGraph | null
+  ) => {
+    const previousStates = activeStates
+    activeCanvas = canvas
+    activeStates = states
+
+    if (graph !== activeGraph) {
+      if (replaceGraph(graph)) markDirty()
+      return
+    }
+
+    let progressChanged = false
+    const changedLocators = new Set([
+      ...Object.keys(previousStates),
+      ...Object.keys(states)
+    ] as NodeLocatorId[])
+    for (const locator of changedLocators) {
+      const previousProgress = progressValue(previousStates[locator])
+      const nextProgress = progressValue(states[locator])
+      if (Object.is(previousProgress, nextProgress)) continue
+      onIndexLookup()
+      for (const node of nodesByLocator.get(locator) ?? []) {
+        progressChanged = setNodeProgress(node, nextProgress) || progressChanged
+      }
+    }
+    if (progressChanged) markDirty()
+  }
+
+  const dispose = () => {
+    detachGraph()
+    activeCanvas = null
+    activeGraph = null
+    activeStates = {}
+    nodesByLocator.clear()
+    nodeLocators = new WeakMap()
+  }
+
+  return { dispose, sync }
+}

--- a/src/components/graph/nodeProgressCanvasSync.ts
+++ b/src/components/graph/nodeProgressCanvasSync.ts
@@ -73,7 +73,10 @@ export function createNodeProgressCanvasSync(
 
   const detachGraph = () => {
     activeGraph?.events.removeEventListener('node:added', onNodeAdded)
-    activeGraph?.events.removeEventListener('node:removed', onNodeRemoved)
+    activeGraph?.events.removeEventListener(
+      'node:before-removed',
+      onNodeRemoved
+    )
   }
 
   const replaceGraph = (graph: LGraph | null) => {
@@ -91,7 +94,7 @@ export function createNodeProgressCanvasSync(
         progressChanged
     }
     graph.events.addEventListener('node:added', onNodeAdded)
-    graph.events.addEventListener('node:removed', onNodeRemoved)
+    graph.events.addEventListener('node:before-removed', onNodeRemoved)
     return progressChanged
   }
 

--- a/src/components/graph/nodeProgressCanvasSync.ts
+++ b/src/components/graph/nodeProgressCanvasSync.ts
@@ -6,7 +6,16 @@ import type {
 import type { NodeProgressState } from '@/schemas/apiSchema'
 import type { NodeLocatorId } from '@/types/nodeIdentification'
 
-type ProgressStates = Readonly<Record<NodeLocatorId, NodeProgressState>>
+export interface NodeProgressCanvasSync {
+  dispose: () => void
+  sync: (
+    states: Readonly<Record<NodeLocatorId, NodeProgressState>>,
+    canvas: LGraphCanvas | null,
+    graph: LGraph | null
+  ) => void
+}
+
+type ProgressStates = Parameters<NodeProgressCanvasSync['sync']>[0]
 
 const progressValue = (state: NodeProgressState | undefined) =>
   state?.state === 'running' ? state.value / state.max : undefined
@@ -14,7 +23,7 @@ const progressValue = (state: NodeProgressState | undefined) =>
 export function createNodeProgressCanvasSync(
   nodeToLocator: (node: LGraphNode) => NodeLocatorId,
   onIndexLookup: () => void = () => {}
-) {
+): NodeProgressCanvasSync {
   let activeCanvas: LGraphCanvas | null = null
   let activeGraph: LGraph | null = null
   let activeStates: ProgressStates = {}


### PR DESCRIPTION
## Summary

Build a graph-scoped locator index once, then synchronize only the union of previous/current changed progress keys. Maintain the index incrementally across node add/remove and rebuild it on graph replacement.

## Deterministic effect

- equal payload: N conversions → 0 conversions / 0 lookups
- one changed or removed key: N conversions → 1 lookup
- remove A + add B: N conversions → 2 lookups
- graph replacement remains one O(N) index build

## Safety coverage

Root/subgraph replacement, stale clearing, node add/remove, duplicate locators, unmatched keys, old-listener detachment, disposal, exact writes, and dirty requests are covered.

## Verification

10 focused tests, typecheck, formatting, Oxlint, ESLint, and Stylelint pass.

<!-- perf-proof-evidence:start -->
## Performance proof evidence

- **Role:** runtime fix paired with the deterministic baseline in #16014.
- **Deterministic effect:** equal payloads go from N locator conversions to 0 lookups; a single changed or removed key goes from N conversions to 1 lookup; remove A plus add B requires 2 lookups. Graph replacement remains one O(N) index build.
- **Local proof recorded at `7463da668f7c59139b27694ba7d674446824121b`:**
  ```bash
  PATH=/home/c_byrne/.nvm/versions/node/v25.9.0/bin:$PATH \
  NODE_OPTIONS=--localstorage-file=/tmp/codex-proof-wave-b-localstorage \
  node_modules/.bin/vitest run \
    src/components/graph/GraphCanvas.firstRunEntry.test.ts \
    src/components/graph/nodeProgressCanvasSync.test.ts
  ```
  Result: 2 files, 10/10 tests passed; Vitest 6.13 s, wall 6.82 s.
- **Current-head caveat:** the PR head has advanced since that local run; the command and result above are not represented as an exact-current-head rerun.
- **Browser/screenshots:** no local browser measurement or screenshot is claimed. A complete browser proof should compare this head with #16014 using an identical 1,000-node/500-active-entry workload and report task duration, rAF intervals over 16.67 ms, style/layout work, and heap delta.
- **Final GitHub state:** merged at final head `21a7a57be9b4afd0d000035f245d20b80dc4f674`; the fresh audit found no red or pending checks. The exact local command above was run on the cited earlier revision and is not relabeled as a final-head run.
<!-- perf-proof-evidence:end -->
