### PR TITLE
fix: bound asset pagination and resolve queued outputs

### DIFF
--- a/src/components/queue/QueueProgressOverlay.test.ts
+++ b/src/components/queue/QueueProgressOverlay.test.ts
@@ -202,4 +202,28 @@ describe('QueueProgressOverlay', () => {
     expect(assetSelectionStore.selectedIdsArray).toEqual([])
     expect(sidebarTabStore.activeSidebarTabId).toBe('assets')
   })
+
+  it('only selects the latest asset when focus requests overlap', async () => {
+    let resolveFirst!: (found: boolean) => void
+    outputAssetsMock.loadOutputAsset
+      .mockImplementationOnce(
+        () => new Promise<boolean>((resolve) => (resolveFirst = resolve))
+      )
+      .mockResolvedValueOnce(true)
+    const { assetSelectionStore, user } = renderComponent([], [])
+
+    itemToView = createCompletedJobView('older-request')
+    await user.click(screen.getByTestId('view-item-button'))
+    itemToView = createCompletedJobView('latest-request')
+    await user.click(screen.getByTestId('view-item-button'))
+
+    await waitFor(() =>
+      expect(assetSelectionStore.selectedIdsArray).toEqual(['latest-request'])
+    )
+    resolveFirst(true)
+    await waitFor(() =>
+      expect(outputAssetsMock.loadOutputAsset).toHaveBeenCalledTimes(2)
+    )
+    expect(assetSelectionStore.selectedIdsArray).toEqual(['latest-request'])
+  })
 })

--- a/src/components/queue/QueueProgressOverlay.test.ts
+++ b/src/components/queue/QueueProgressOverlay.test.ts
@@ -84,7 +84,7 @@ function createCompletedJobView(id: string): JobListViewItem {
     state: 'completed',
     taskRef: task,
     title: id
-  } as JobListViewItem
+  }
 }
 
 function renderComponent(

--- a/src/components/queue/QueueProgressOverlay.test.ts
+++ b/src/components/queue/QueueProgressOverlay.test.ts
@@ -18,15 +18,12 @@ vi.mock('@/platform/distribution/types', () => ({
 
 const { outputAssetsMock } = vi.hoisted(() => ({
   outputAssetsMock: {
-    hasMore: false,
-    items: [] as Array<{ id: string }>,
-    loadMore: vi.fn<() => Promise<void>>(),
-    loadMoreWithProgress: vi.fn<() => Promise<boolean>>()
+    loadOutputAsset: vi.fn<(id: string) => Promise<boolean>>()
   }
 }))
 
 vi.mock('@/stores/assetsStore', () => ({
-  useAssetsStore: () => ({ outputAssets: outputAssetsMock })
+  useAssetsStore: () => outputAssetsMock
 }))
 
 let itemToView: JobListViewItem | undefined
@@ -127,10 +124,7 @@ describe('QueueProgressOverlay', () => {
   beforeEach(() => {
     i18n.global.locale.value = 'en'
     itemToView = undefined
-    outputAssetsMock.hasMore = false
-    outputAssetsMock.items = []
-    outputAssetsMock.loadMore.mockReset()
-    outputAssetsMock.loadMoreWithProgress.mockReset()
+    outputAssetsMock.loadOutputAsset.mockReset()
   })
 
   it('shows expanded header with running and queued labels', () => {
@@ -173,17 +167,7 @@ describe('QueueProgressOverlay', () => {
 
   it('loads older pages before selecting a job asset', async () => {
     itemToView = createCompletedJobView('target-job')
-    outputAssetsMock.hasMore = true
-    outputAssetsMock.loadMoreWithProgress
-      .mockImplementationOnce(async () => {
-        outputAssetsMock.items.push({ id: 'other-job' })
-        return true
-      })
-      .mockImplementationOnce(async () => {
-        outputAssetsMock.items.push({ id: 'target-job' })
-        outputAssetsMock.hasMore = false
-        return true
-      })
+    outputAssetsMock.loadOutputAsset.mockResolvedValue(true)
     const { assetSelectionStore, sidebarTabStore, user } = renderComponent(
       [],
       []
@@ -192,7 +176,9 @@ describe('QueueProgressOverlay', () => {
     await user.click(screen.getByTestId('view-item-button'))
 
     await waitFor(() => {
-      expect(outputAssetsMock.loadMoreWithProgress).toHaveBeenCalledTimes(2)
+      expect(outputAssetsMock.loadOutputAsset).toHaveBeenCalledWith(
+        'target-job'
+      )
       expect(assetSelectionStore.selectedIdsArray).toEqual(['target-job'])
     })
     expect(sidebarTabStore.activeSidebarTabId).toBe('assets')
@@ -200,8 +186,7 @@ describe('QueueProgressOverlay', () => {
 
   it('does not select a missing job asset when pagination cannot advance', async () => {
     itemToView = createCompletedJobView('missing-job')
-    outputAssetsMock.hasMore = true
-    outputAssetsMock.loadMoreWithProgress.mockResolvedValue(false)
+    outputAssetsMock.loadOutputAsset.mockResolvedValue(false)
     const { assetSelectionStore, sidebarTabStore, user } = renderComponent(
       [],
       []
@@ -210,7 +195,9 @@ describe('QueueProgressOverlay', () => {
     await user.click(screen.getByTestId('view-item-button'))
 
     await waitFor(() =>
-      expect(outputAssetsMock.loadMoreWithProgress).toHaveBeenCalledTimes(1)
+      expect(outputAssetsMock.loadOutputAsset).toHaveBeenCalledWith(
+        'missing-job'
+      )
     )
     expect(assetSelectionStore.selectedIdsArray).toEqual([])
     expect(sidebarTabStore.activeSidebarTabId).toBe('assets')

--- a/src/components/queue/QueueProgressOverlay.test.ts
+++ b/src/components/queue/QueueProgressOverlay.test.ts
@@ -1,11 +1,13 @@
 import { createTestingPinia } from '@pinia/testing'
-import { render, screen } from '@testing-library/vue'
+import { render, screen, waitFor } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { defineComponent } from 'vue'
 
 import QueueProgressOverlay from '@/components/queue/QueueProgressOverlay.vue'
+import type { JobListItem as JobListViewItem } from '@/composables/queue/useJobList'
 import { i18n } from '@/i18n'
+import { useAssetSelectionStore } from '@/platform/assets/composables/useAssetSelectionStore'
 import type { JobStatus } from '@/platform/remote/comfyui/jobs/jobTypes'
 import { TaskItemImpl, useQueueStore } from '@/stores/queueStore'
 import { useSidebarTabStore } from '@/stores/workspace/sidebarTabStore'
@@ -13,6 +15,21 @@ import { useSidebarTabStore } from '@/stores/workspace/sidebarTabStore'
 vi.mock('@/platform/distribution/types', () => ({
   isCloud: false
 }))
+
+const { outputAssetsMock } = vi.hoisted(() => ({
+  outputAssetsMock: {
+    hasMore: false,
+    items: [] as Array<{ id: string }>,
+    loadMore: vi.fn<() => Promise<void>>(),
+    loadMoreWithProgress: vi.fn<() => Promise<boolean>>()
+  }
+}))
+
+vi.mock('@/stores/assetsStore', () => ({
+  useAssetsStore: () => ({ outputAssets: outputAssetsMock })
+}))
+
+let itemToView: JobListViewItem | undefined
 
 const QueueOverlayExpandedStub = defineComponent({
   name: 'QueueOverlayExpanded',
@@ -22,10 +39,17 @@ const QueueOverlayExpandedStub = defineComponent({
       required: true
     }
   },
+  emits: ['viewItem'],
+  setup(_, { emit }) {
+    return {
+      viewItem: () => itemToView && emit('viewItem', itemToView)
+    }
+  },
   template: `
     <div>
       <div data-testid="expanded-title">{{ headerTitle }}</div>
       <button data-testid="show-assets-button" @click="$emit('show-assets')" />
+      <button data-testid="view-item-button" @click="viewItem" />
     </div>
   `
 })
@@ -39,6 +63,30 @@ function createTask(id: string, status: JobStatus): TaskItemImpl {
   })
 }
 
+function createCompletedJobView(id: string): JobListViewItem {
+  const task = new TaskItemImpl({
+    id,
+    status: 'completed',
+    create_time: 0,
+    priority: 0,
+    preview_output: {
+      filename: `${id}.png`,
+      mediaType: 'images',
+      nodeId: '1',
+      subfolder: '',
+      type: 'output'
+    }
+  })
+  return {
+    id,
+    meta: '',
+    showClear: false,
+    state: 'completed',
+    taskRef: task,
+    title: id
+  } as JobListViewItem
+}
+
 function renderComponent(
   runningTasks: TaskItemImpl[],
   pendingTasks: TaskItemImpl[]
@@ -48,6 +96,7 @@ function renderComponent(
     stubActions: false
   })
   const queueStore = useQueueStore(pinia)
+  const assetSelectionStore = useAssetSelectionStore(pinia)
   const sidebarTabStore = useSidebarTabStore(pinia)
   queueStore.runningTasks = runningTasks
   queueStore.pendingTasks = pendingTasks
@@ -71,12 +120,17 @@ function renderComponent(
     }
   })
 
-  return { sidebarTabStore, user }
+  return { assetSelectionStore, sidebarTabStore, user }
 }
 
 describe('QueueProgressOverlay', () => {
   beforeEach(() => {
     i18n.global.locale.value = 'en'
+    itemToView = undefined
+    outputAssetsMock.hasMore = false
+    outputAssetsMock.items = []
+    outputAssetsMock.loadMore.mockReset()
+    outputAssetsMock.loadMoreWithProgress.mockReset()
   })
 
   it('shows expanded header with running and queued labels', () => {
@@ -115,5 +169,50 @@ describe('QueueProgressOverlay', () => {
 
     await user.click(screen.getByTestId('show-assets-button'))
     expect(sidebarTabStore.activeSidebarTabId).toBe(null)
+  })
+
+  it('loads older pages before selecting a job asset', async () => {
+    itemToView = createCompletedJobView('target-job')
+    outputAssetsMock.hasMore = true
+    outputAssetsMock.loadMoreWithProgress
+      .mockImplementationOnce(async () => {
+        outputAssetsMock.items.push({ id: 'other-job' })
+        return true
+      })
+      .mockImplementationOnce(async () => {
+        outputAssetsMock.items.push({ id: 'target-job' })
+        outputAssetsMock.hasMore = false
+        return true
+      })
+    const { assetSelectionStore, sidebarTabStore, user } = renderComponent(
+      [],
+      []
+    )
+
+    await user.click(screen.getByTestId('view-item-button'))
+
+    await waitFor(() => {
+      expect(outputAssetsMock.loadMoreWithProgress).toHaveBeenCalledTimes(2)
+      expect(assetSelectionStore.selectedIdsArray).toEqual(['target-job'])
+    })
+    expect(sidebarTabStore.activeSidebarTabId).toBe('assets')
+  })
+
+  it('does not select a missing job asset when pagination cannot advance', async () => {
+    itemToView = createCompletedJobView('missing-job')
+    outputAssetsMock.hasMore = true
+    outputAssetsMock.loadMoreWithProgress.mockResolvedValue(false)
+    const { assetSelectionStore, sidebarTabStore, user } = renderComponent(
+      [],
+      []
+    )
+
+    await user.click(screen.getByTestId('view-item-button'))
+
+    await waitFor(() =>
+      expect(outputAssetsMock.loadMoreWithProgress).toHaveBeenCalledTimes(1)
+    )
+    expect(assetSelectionStore.selectedIdsArray).toEqual([])
+    expect(sidebarTabStore.activeSidebarTabId).toBe('assets')
   })
 })

--- a/src/components/queue/QueueProgressOverlay.vue
+++ b/src/components/queue/QueueProgressOverlay.vue
@@ -236,7 +236,9 @@ const openAssetsSidebar = () => {
   sidebarTabStore.activeSidebarTabId = 'assets'
 }
 
+let focusRequest = 0
 const focusAssetInSidebar = async (item: JobListItem) => {
+  const request = ++focusRequest
   const task = item.taskRef
   const jobId = task?.jobId
   const preview = task?.previewOutput
@@ -246,7 +248,8 @@ const focusAssetInSidebar = async (item: JobListItem) => {
   openAssetsSidebar()
   await nextTick()
 
-  if (!(await assetsStore.loadOutputAsset(assetId))) return
+  if (!(await assetsStore.loadOutputAsset(assetId)) || request !== focusRequest)
+    return
 
   assetSelectionStore.setSelection([assetId])
   assetSelectionStore.setLastSelectedAssetId(assetId)

--- a/src/components/queue/QueueProgressOverlay.vue
+++ b/src/components/queue/QueueProgressOverlay.vue
@@ -53,7 +53,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, nextTick, ref } from 'vue'
+import { computed, nextTick, ref, toValue } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import QueueOverlayActive from '@/components/queue/QueueOverlayActive.vue'
@@ -71,6 +71,7 @@ import { api } from '@/scripts/api'
 import { useCommandStore } from '@/stores/commandStore'
 import { useExecutionStore } from '@/stores/executionStore'
 import { useQueueStore } from '@/stores/queueStore'
+import { useAssetsStore } from '@/stores/assetsStore'
 import { useSidebarTabStore } from '@/stores/workspace/sidebarTabStore'
 
 type OverlayState = 'hidden' | 'active' | 'expanded'
@@ -88,6 +89,7 @@ const { t, n } = useI18n()
 const queueStore = useQueueStore()
 const commandStore = useCommandStore()
 const executionStore = useExecutionStore()
+const assetsStore = useAssetsStore()
 const sidebarTabStore = useSidebarTabStore()
 const assetSelectionStore = useAssetSelectionStore()
 const { showQueueClearHistoryDialog } = useQueueClearHistoryDialog()
@@ -243,6 +245,28 @@ const focusAssetInSidebar = async (item: JobListItem) => {
   const assetId = String(jobId)
   openAssetsSidebar()
   await nextTick()
+
+  const outputAssets = toValue(assetsStore.outputAssets)
+  const hasTarget = () =>
+    toValue(outputAssets.items).some(({ id }) => id === assetId)
+  while (!hasTarget() && toValue(outputAssets.hasMore)) {
+    const previousSize = toValue(outputAssets.items).length
+    let advanced: boolean | undefined
+    if (outputAssets.loadMoreWithProgress) {
+      advanced = await outputAssets.loadMoreWithProgress()
+    } else {
+      await outputAssets.loadMore()
+    }
+    if (
+      advanced === false ||
+      (advanced === undefined &&
+        toValue(outputAssets.items).length === previousSize)
+    ) {
+      break
+    }
+  }
+  if (!hasTarget()) return
+
   assetSelectionStore.setSelection([assetId])
   assetSelectionStore.setLastSelectedAssetId(assetId)
 }

--- a/src/components/queue/QueueProgressOverlay.vue
+++ b/src/components/queue/QueueProgressOverlay.vue
@@ -53,7 +53,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, nextTick, ref, toValue } from 'vue'
+import { computed, nextTick, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import QueueOverlayActive from '@/components/queue/QueueOverlayActive.vue'
@@ -246,26 +246,7 @@ const focusAssetInSidebar = async (item: JobListItem) => {
   openAssetsSidebar()
   await nextTick()
 
-  const outputAssets = toValue(assetsStore.outputAssets)
-  const hasTarget = () =>
-    toValue(outputAssets.items).some(({ id }) => id === assetId)
-  while (!hasTarget() && toValue(outputAssets.hasMore)) {
-    const previousSize = toValue(outputAssets.items).length
-    let advanced: boolean | undefined
-    if (outputAssets.loadMoreWithProgress) {
-      advanced = await outputAssets.loadMoreWithProgress()
-    } else {
-      await outputAssets.loadMore()
-    }
-    if (
-      advanced === false ||
-      (advanced === undefined &&
-        toValue(outputAssets.items).length === previousSize)
-    ) {
-      break
-    }
-  }
-  if (!hasTarget()) return
+  if (!(await assetsStore.loadOutputAsset(assetId))) return
 
   assetSelectionStore.setSelection([assetId])
   assetSelectionStore.setLastSelectedAssetId(assetId)

--- a/src/platform/assets/composables/useAssetsQuery.test.ts
+++ b/src/platform/assets/composables/useAssetsQuery.test.ts
@@ -44,6 +44,14 @@ function response(
   })
 }
 
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((res) => {
+    resolve = res
+  })
+  return { promise, resolve }
+}
+
 async function createList(
   key: string,
   initialIds: string[],
@@ -229,5 +237,31 @@ describe('useAssetsQuery loadMore pagination', () => {
 
     expect(toValue(list.hasMore)).toBe(true)
     expect(toValue(list.items).map(({ id }) => id)).toEqual(['newest'])
+  })
+
+  it('discards a delayed page when invalidation resets the list', async () => {
+    const list = await createList('invalidate-race', ['old-head'], {
+      hasMore: true,
+      nextCursor: 'old-page-2'
+    })
+    const delayedPage = deferred<Response>()
+    fetchApiMock
+      .mockReturnValueOnce(delayedPage.promise)
+      .mockResolvedValueOnce(
+        response(['reset-head'], { hasMore: true, nextCursor: 'reset-page-2' })
+      )
+
+    const loadMorePromise = list.loadMore()
+    await vi.waitFor(() => expect(fetchApiMock).toHaveBeenCalledTimes(2))
+    const delayedSignal = fetchApiMock.mock.calls[1][1]?.signal
+
+    const invalidatePromise = list.invalidate()
+    expect(delayedSignal?.aborted).toBe(true)
+    delayedPage.resolve(response(['stale-tail'], { hasMore: false }))
+    await Promise.all([loadMorePromise, invalidatePromise])
+
+    expect(toValue(list.items).map(({ id }) => id)).toEqual(['reset-head'])
+    expect(toValue(list.hasMore)).toBe(true)
+    expect(requestedAfterCursors()).toEqual(['old-page-2', null])
   })
 })

--- a/src/platform/assets/composables/useAssetsQuery.test.ts
+++ b/src/platform/assets/composables/useAssetsQuery.test.ts
@@ -38,10 +38,10 @@ function response(
     has_more: hasMore,
     ...(nextCursor === undefined ? {} : { next_cursor: nextCursor })
   }
-  return {
-    ok: true,
-    json: vi.fn().mockResolvedValue(body)
-  } as unknown as Response
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' }
+  })
 }
 
 async function createList(

--- a/src/platform/assets/composables/useAssetsQuery.test.ts
+++ b/src/platform/assets/composables/useAssetsQuery.test.ts
@@ -1,0 +1,159 @@
+import { effectScope, toValue } from 'vue'
+import { describe, expect, it, onTestFinished, vi } from 'vitest'
+
+import { useAssetsQuery } from '@/platform/assets/composables/useAssetsQuery'
+import type {
+  AssetItem,
+  AssetResponse
+} from '@/platform/assets/schemas/assetSchema'
+import { api } from '@/scripts/api'
+
+vi.mock('@/scripts/api', () => ({
+  api: { fetchApi: vi.fn() }
+}))
+
+const fetchApiMock = vi.mocked(api.fetchApi)
+
+function asset(id: string): AssetItem {
+  return {
+    id,
+    name: `${id}.png`,
+    loader_path: `${id}.png`,
+    tags: ['output'],
+    created_at: '2026-08-26T00:00:00Z',
+    updated_at: '2026-08-26T00:00:00Z'
+  }
+}
+
+function response(
+  ids: string[],
+  {
+    hasMore = false,
+    nextCursor
+  }: { hasMore?: boolean; nextCursor?: string } = {}
+): Response {
+  const body: AssetResponse = {
+    assets: ids.map(asset),
+    total: ids.length,
+    has_more: hasMore,
+    ...(nextCursor === undefined ? {} : { next_cursor: nextCursor })
+  }
+  return {
+    ok: true,
+    json: vi.fn().mockResolvedValue(body)
+  } as unknown as Response
+}
+
+async function createList(key: string, initialIds: string[]) {
+  fetchApiMock.mockResolvedValueOnce(response(initialIds))
+  const scope = effectScope()
+  const list = scope.run(() => useAssetsQuery({ name_contains: key }))!
+  onTestFinished(() => scope.stop())
+  await vi.waitFor(() => expect(toValue(list.isLoading)).toBe(false))
+  return list
+}
+
+function requestedAfterCursors() {
+  return fetchApiMock.mock.calls.slice(1).map(([url]) => {
+    const requestUrl = new URL(String(url), 'http://localhost')
+    return requestUrl.searchParams.get('after')
+  })
+}
+
+describe('useAssetsQuery loadNew pagination', () => {
+  it('prepends multiple pages in newest-to-oldest order', async () => {
+    const list = await createList('order', ['known'])
+    fetchApiMock
+      .mockResolvedValueOnce(
+        response(['newest', 'newer'], { hasMore: true, nextCursor: 'page-2' })
+      )
+      .mockResolvedValueOnce(
+        response(['new'], { hasMore: true, nextCursor: 'page-3' })
+      )
+      .mockResolvedValueOnce(response(['newish'], { hasMore: false }))
+
+    await list.loadNew()
+
+    expect(toValue(list.items).map(({ id }) => id)).toEqual([
+      'newest',
+      'newer',
+      'new',
+      'newish',
+      'known'
+    ])
+    expect(requestedAfterCursors()).toEqual([null, 'page-2', 'page-3'])
+  })
+
+  it('stops at a known id without inserting duplicates from overlapping pages', async () => {
+    const list = await createList('known-id', ['known', 'old'])
+    fetchApiMock
+      .mockResolvedValueOnce(
+        response(['new'], { hasMore: true, nextCursor: 'page-2' })
+      )
+      .mockResolvedValueOnce(
+        response(['new', 'known', 'older-unseen'], {
+          hasMore: true,
+          nextCursor: 'page-3'
+        })
+      )
+      .mockRejectedValue(new Error('unexpected page after known id'))
+
+    await list.loadNew()
+
+    expect(fetchApiMock).toHaveBeenCalledTimes(3)
+    expect(toValue(list.items).map(({ id }) => id)).toEqual([
+      'new',
+      'known',
+      'old'
+    ])
+    expect(requestedAfterCursors()).toEqual([null, 'page-2'])
+  })
+
+  it('terminates when the cursor does not advance', async () => {
+    const list = await createList('stuck-cursor', ['known'])
+    fetchApiMock
+      .mockResolvedValueOnce(
+        response(['newest'], { hasMore: true, nextCursor: 'stuck' })
+      )
+      .mockResolvedValueOnce(
+        response(['newer'], { hasMore: true, nextCursor: 'stuck' })
+      )
+      .mockRejectedValue(new Error('unexpected extra page'))
+
+    await list.loadNew()
+
+    expect(fetchApiMock).toHaveBeenCalledTimes(3)
+    expect(toValue(list.items).map(({ id }) => id)).toEqual([
+      'newest',
+      'newer',
+      'known'
+    ])
+    expect(requestedAfterCursors()).toEqual([null, 'stuck'])
+  })
+
+  it('terminates when cursors cycle', async () => {
+    const list = await createList('cycling-cursor', ['known'])
+    fetchApiMock
+      .mockResolvedValueOnce(
+        response(['newest'], { hasMore: true, nextCursor: 'A' })
+      )
+      .mockResolvedValueOnce(
+        response(['newer'], { hasMore: true, nextCursor: 'B' })
+      )
+      .mockResolvedValueOnce(
+        response(['new'], { hasMore: true, nextCursor: 'A' })
+      )
+      .mockRejectedValue(new Error('unexpected page after cursor cycle'))
+
+    await list.loadNew()
+
+    expect(fetchApiMock).toHaveBeenCalledTimes(4)
+    expect(toValue(list.items).map(({ id }) => id)).toEqual([
+      'newest',
+      'newer',
+      'new',
+      'known'
+    ])
+    expect(requestedAfterCursors()).toEqual([null, 'A', 'B'])
+  })
+})

--- a/src/platform/assets/composables/useAssetsQuery.test.ts
+++ b/src/platform/assets/composables/useAssetsQuery.test.ts
@@ -172,7 +172,7 @@ describe('useAssetsQuery loadMore pagination', () => {
       response(['overlap', 'older'], { hasMore: false })
     )
 
-    await expect(list.loadMoreWithProgress?.()).resolves.toBe(true)
+    await list.loadMore()
 
     expect(toValue(list.items).map(({ id }) => id)).toEqual([
       'newest',
@@ -190,10 +190,10 @@ describe('useAssetsQuery loadMore pagination', () => {
       response(['older'], { hasMore: true, nextCursor: 'stuck' })
     )
 
-    await expect(list.loadMoreWithProgress?.()).resolves.toBe(true)
+    await list.loadMore()
 
     expect(toValue(list.hasMore)).toBe(false)
-    await expect(list.loadMoreWithProgress?.()).resolves.toBe(false)
+    await list.loadMore()
     expect(fetchApiMock).toHaveBeenCalledTimes(2)
   })
 
@@ -210,11 +210,11 @@ describe('useAssetsQuery loadMore pagination', () => {
         response(['oldest'], { hasMore: true, nextCursor: 'A' })
       )
 
-    await expect(list.loadMoreWithProgress?.()).resolves.toBe(true)
-    await expect(list.loadMoreWithProgress?.()).resolves.toBe(true)
+    await list.loadMore()
+    await list.loadMore()
 
     expect(toValue(list.hasMore)).toBe(false)
-    await expect(list.loadMoreWithProgress?.()).resolves.toBe(false)
+    await list.loadMore()
     expect(fetchApiMock).toHaveBeenCalledTimes(3)
   })
 
@@ -225,7 +225,7 @@ describe('useAssetsQuery loadMore pagination', () => {
     })
     fetchApiMock.mockRejectedValueOnce(new Error('network failed'))
 
-    await expect(list.loadMoreWithProgress?.()).resolves.toBe(false)
+    await list.loadMore()
 
     expect(toValue(list.hasMore)).toBe(true)
     expect(toValue(list.items).map(({ id }) => id)).toEqual(['newest'])

--- a/src/platform/assets/composables/useAssetsQuery.test.ts
+++ b/src/platform/assets/composables/useAssetsQuery.test.ts
@@ -44,8 +44,12 @@ function response(
   } as unknown as Response
 }
 
-async function createList(key: string, initialIds: string[]) {
-  fetchApiMock.mockResolvedValueOnce(response(initialIds))
+async function createList(
+  key: string,
+  initialIds: string[],
+  options: { hasMore?: boolean; nextCursor?: string } = {}
+) {
+  fetchApiMock.mockResolvedValueOnce(response(initialIds, options))
   const scope = effectScope()
   const list = scope.run(() => useAssetsQuery({ name_contains: key }))!
   onTestFinished(() => scope.stop())
@@ -155,5 +159,75 @@ describe('useAssetsQuery loadNew pagination', () => {
       'known'
     ])
     expect(requestedAfterCursors()).toEqual([null, 'A', 'B'])
+  })
+})
+
+describe('useAssetsQuery loadMore pagination', () => {
+  it('deduplicates overlapping pages and reports successful progress', async () => {
+    const list = await createList('load-more', ['newest', 'overlap'], {
+      hasMore: true,
+      nextCursor: 'page-2'
+    })
+    fetchApiMock.mockResolvedValueOnce(
+      response(['overlap', 'older'], { hasMore: false })
+    )
+
+    await expect(list.loadMoreWithProgress?.()).resolves.toBe(true)
+
+    expect(toValue(list.items).map(({ id }) => id)).toEqual([
+      'newest',
+      'overlap',
+      'older'
+    ])
+  })
+
+  it('stops pagination when a cursor does not advance', async () => {
+    const list = await createList('stuck-load-more', ['newest'], {
+      hasMore: true,
+      nextCursor: 'stuck'
+    })
+    fetchApiMock.mockResolvedValueOnce(
+      response(['older'], { hasMore: true, nextCursor: 'stuck' })
+    )
+
+    await expect(list.loadMoreWithProgress?.()).resolves.toBe(true)
+
+    expect(toValue(list.hasMore)).toBe(false)
+    await expect(list.loadMoreWithProgress?.()).resolves.toBe(false)
+    expect(fetchApiMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('stops pagination when cursors cycle across calls', async () => {
+    const list = await createList('cycling-load-more', ['newest'], {
+      hasMore: true,
+      nextCursor: 'A'
+    })
+    fetchApiMock
+      .mockResolvedValueOnce(
+        response(['older'], { hasMore: true, nextCursor: 'B' })
+      )
+      .mockResolvedValueOnce(
+        response(['oldest'], { hasMore: true, nextCursor: 'A' })
+      )
+
+    await expect(list.loadMoreWithProgress?.()).resolves.toBe(true)
+    await expect(list.loadMoreWithProgress?.()).resolves.toBe(true)
+
+    expect(toValue(list.hasMore)).toBe(false)
+    await expect(list.loadMoreWithProgress?.()).resolves.toBe(false)
+    expect(fetchApiMock).toHaveBeenCalledTimes(3)
+  })
+
+  it('reports a request failure without consuming pagination state', async () => {
+    const list = await createList('failed-load-more', ['newest'], {
+      hasMore: true,
+      nextCursor: 'page-2'
+    })
+    fetchApiMock.mockRejectedValueOnce(new Error('network failed'))
+
+    await expect(list.loadMoreWithProgress?.()).resolves.toBe(false)
+
+    expect(toValue(list.hasMore)).toBe(true)
+    expect(toValue(list.items).map(({ id }) => id)).toEqual(['newest'])
   })
 })

--- a/src/platform/assets/composables/useAssetsQuery.ts
+++ b/src/platform/assets/composables/useAssetsQuery.ts
@@ -25,9 +25,7 @@ function assetsQueryInternal(
   const onError = options.onError ?? console.error
 
   let nextCursor: string | undefined
-  const seenCursors = new Set(
-    params.after === undefined ? [] : [params.after]
-  )
+  const seenCursors = new Set(params.after === undefined ? [] : [params.after])
   const hasMore = ref(true)
   const items = ref<AssetItem[]>([])
 

--- a/src/platform/assets/composables/useAssetsQuery.ts
+++ b/src/platform/assets/composables/useAssetsQuery.ts
@@ -25,7 +25,6 @@ function assetsQueryInternal(
   const onError = options.onError ?? console.error
 
   let nextCursor: string | undefined
-  let loadGeneration = 0
   const seenCursors = new Set(
     params.after === undefined ? [] : [params.after]
   )
@@ -58,19 +57,12 @@ function assetsQueryInternal(
       !seenCursors.has(nextCursor)
     if (nextCursor !== undefined) seenCursors.add(nextCursor)
     items.value.push(...newItems)
-    loadGeneration++
-  }
-
-  async function loadMoreWithProgress() {
-    const startingGeneration = loadGeneration
-    await enqueue('loadMore', async (signal) => {
-      await doLoadMore(signal)
-    })
-    return loadGeneration > startingGeneration
   }
 
   async function loadMore() {
-    await loadMoreWithProgress()
+    await enqueue('loadMore', async (signal) => {
+      await doLoadMore(signal)
+    })
   }
 
   function loadNew() {
@@ -164,7 +156,6 @@ function assetsQueryInternal(
     isLoading,
     items,
     loadMore,
-    loadMoreWithProgress,
     loadNew
   }
 }

--- a/src/platform/assets/composables/useAssetsQuery.ts
+++ b/src/platform/assets/composables/useAssetsQuery.ts
@@ -25,19 +25,17 @@ function assetsQueryInternal(
   const onError = options.onError ?? console.error
 
   let nextCursor: string | undefined
-  const seenCursors = new Set<string | undefined>()
+  let loadGeneration = 0
+  const seenCursors = new Set(
+    params.after === undefined ? [] : [params.after]
+  )
   const hasMore = ref(true)
   const items = ref<AssetItem[]>([])
 
   const { enqueue, preempt, running: isLoading } = usePreemptableQueue()
   async function doLoadMore(signal?: AbortSignal) {
-    if (!hasMore.value || seenCursors.has(nextCursor)) return
-    if (seenCursors.has(nextCursor)) {
-      hasMore.value = false
-      return
-    }
-    seenCursors.add(nextCursor)
-
+    if (!hasMore.value) return
+    const previousCursor = nextCursor
     const assetResponse = await doQuery(
       {
         after: nextCursor ?? params.after
@@ -45,13 +43,34 @@ function assetsQueryInternal(
       signal
     )
     if (!assetResponse) return
+
+    const knownIds = new Set(items.value.map(({ id }) => id))
+    const newItems = assetResponse.assets.filter(({ id }) => {
+      if (knownIds.has(id)) return false
+      knownIds.add(id)
+      return true
+    })
     nextCursor = assetResponse.next_cursor
-    hasMore.value = assetResponse.has_more
-    items.value.push(...assetResponse.assets)
+    hasMore.value =
+      assetResponse.has_more &&
+      nextCursor !== undefined &&
+      nextCursor !== previousCursor &&
+      !seenCursors.has(nextCursor)
+    if (nextCursor !== undefined) seenCursors.add(nextCursor)
+    items.value.push(...newItems)
+    loadGeneration++
   }
 
-  function loadMore() {
-    return enqueue('loadMore', doLoadMore)
+  async function loadMoreWithProgress() {
+    const startingGeneration = loadGeneration
+    await enqueue('loadMore', async (signal) => {
+      await doLoadMore(signal)
+    })
+    return loadGeneration > startingGeneration
+  }
+
+  async function loadMore() {
+    await loadMoreWithProgress()
   }
 
   function loadNew() {
@@ -103,6 +122,7 @@ function assetsQueryInternal(
       hasMore.value = true
       nextCursor = undefined
       seenCursors.clear()
+      if (params.after !== undefined) seenCursors.add(params.after)
       items.value = []
       await doLoadMore()
     })
@@ -138,7 +158,15 @@ function assetsQueryInternal(
   }
 
   void loadMore()
-  return { hasMore, invalidate, isLoading, items, loadMore, loadNew }
+  return {
+    hasMore,
+    invalidate,
+    isLoading,
+    items,
+    loadMore,
+    loadMoreWithProgress,
+    loadNew
+  }
 }
 
 export const { constructor: useAssetsQuery, invalidateAll } =

--- a/src/platform/assets/composables/useAssetsQuery.ts
+++ b/src/platform/assets/composables/useAssetsQuery.ts
@@ -57,21 +57,37 @@ function assetsQueryInternal(
   function loadNew() {
     return enqueue('loadNew', async function (signal: AbortSignal) {
       const knownIds = new Set(items.value.map((item) => item.id))
+      const seenIds = new Set(knownIds)
+      const seenHeadCursors = new Set<string>()
       const newItems: AssetItem[] = []
       let headCursor: string | undefined
-      const seenHeadCursors = new Set<string | undefined>()
       while (true) {
-        if (seenHeadCursors.has(headCursor)) break
-        seenHeadCursors.add(headCursor)
-
         const assetResponse = await doQuery({ after: headCursor }, signal)
         if (!assetResponse) return
 
         const { assets, has_more, next_cursor } = assetResponse
+        let reachedKnownId = false
+        for (const asset of assets) {
+          if (knownIds.has(asset.id)) {
+            reachedKnownId = true
+            break
+          }
+          if (seenIds.has(asset.id)) {
+            continue
+          }
+          seenIds.add(asset.id)
+          newItems.push(asset)
+        }
+        if (
+          reachedKnownId ||
+          !has_more ||
+          next_cursor === undefined ||
+          seenHeadCursors.has(next_cursor)
+        ) {
+          break
+        }
+        seenHeadCursors.add(next_cursor)
         headCursor = next_cursor
-        const newFromPage = assets.filter(({ id }) => !knownIds.has(id))
-        newItems.push(...newFromPage)
-        if (newFromPage.length !== assets.length || !has_more) break
       }
       items.value.splice(0, 0, ...newItems)
     })

--- a/src/stores/assetsStore.outputLookup.test.ts
+++ b/src/stores/assetsStore.outputLookup.test.ts
@@ -1,0 +1,91 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+
+import type { AssetItem } from '@/platform/assets/schemas/assetSchema'
+import type { PagedList } from '@/utils/pagedList'
+
+const query = vi.hoisted(() => ({
+  current: undefined as PagedList<AssetItem> | undefined
+}))
+
+vi.mock('@/composables/useFeatureFlags', () => ({
+  useFeatureFlags: () => ({ flags: { assetsEnabled: true } })
+}))
+
+vi.mock('@/platform/assets/composables/useAssetsQuery', () => ({
+  invalidateAll: vi.fn(),
+  useAssetsQuery: vi.fn(() => query.current)
+}))
+
+vi.mock('@/stores/assetDownloadStore', () => ({
+  useAssetDownloadStore: () => ({})
+}))
+
+vi.mock('@/stores/modelToNodeStore', () => ({
+  useModelToNodeStore: () => ({})
+}))
+
+import { useAssetsStore } from '@/stores/assetsStore'
+
+function asset(id: string): AssetItem {
+  return {
+    id,
+    name: `${id}.png`,
+    size: 1,
+    created_at: '2026-08-29T00:00:00Z',
+    updated_at: '2026-08-29T00:00:00Z',
+    tags: ['output']
+  }
+}
+
+function pagedList(
+  items: AssetItem[],
+  loadMore: () => Promise<void>,
+  hasMore = ref(true)
+): PagedList<AssetItem> {
+  return {
+    hasMore,
+    invalidate: vi.fn(),
+    isLoading: ref(false),
+    items: ref(items),
+    loadMore,
+    loadNew: vi.fn()
+  }
+}
+
+describe('assetsStore output lookup', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('loads pages until the requested output is found', async () => {
+    const items = ref([asset('first-page')])
+    const loadMore = vi.fn(async () => {
+      items.value.push(
+        loadMore.mock.calls.length === 2
+          ? asset('requested-output')
+          : asset('second-page')
+      )
+    })
+    query.current = {
+      ...pagedList([], loadMore),
+      items
+    }
+
+    const found = await useAssetsStore().loadOutputAsset('requested-output')
+
+    expect(found).toBe(true)
+    expect(loadMore).toHaveBeenCalledTimes(2)
+  })
+
+  it('stops after 1,000 pages when the requested output is absent', async () => {
+    const loadMore = vi.fn(async () => {})
+    query.current = pagedList([], loadMore)
+
+    const found = await useAssetsStore().loadOutputAsset('missing-output')
+
+    expect(found).toBe(false)
+    expect(loadMore).toHaveBeenCalledTimes(1_000)
+  })
+})

--- a/src/stores/assetsStore.ts
+++ b/src/stores/assetsStore.ts
@@ -90,6 +90,7 @@ function mapHistoryToAssets(historyItems: JobListItem[]): AssetItem[] {
 
 const BATCH_SIZE = 200
 const MAX_HISTORY_ITEMS = 1000 // Maximum items to keep in memory
+const MAX_OUTPUT_ASSET_PAGES = 1000
 
 export const useAssetsStore = defineStore('assets', () => {
   const assetDownloadStore = useAssetDownloadStore()
@@ -285,6 +286,22 @@ export const useAssetsStore = defineStore('assets', () => {
     const flatAssets = useAssetsQuery({ tags_any: outputDirs.value })
     return wrapPagedList(flatAssets, unflattenOutputAssets)
   })
+
+  async function loadOutputAsset(id: string): Promise<boolean> {
+    const assets = toValue(outputAssets)
+    const hasAsset = () =>
+      toValue(assets.items).some((asset) => asset.id === id)
+    let pagesLoaded = 0
+    while (
+      !hasAsset() &&
+      toValue(assets.hasMore) &&
+      pagesLoaded < MAX_OUTPUT_ASSET_PAGES
+    ) {
+      await assets.loadMore()
+      pagesLoaded++
+    }
+    return hasAsset()
+  }
 
   /**
    * Map of asset hash filename to asset item for O(1) lookup
@@ -893,6 +910,9 @@ export const useAssetsStore = defineStore('assets', () => {
     inputAssets,
     outputAssets,
     invalidateAll,
+
+    // Actions
+    loadOutputAsset,
 
     // Deletion tracking
     deletingAssetIds,

--- a/src/utils/pagedList.ts
+++ b/src/utils/pagedList.ts
@@ -7,6 +7,8 @@ export interface PagedList<T> {
   isLoading: Readonly<MaybeRef<boolean>>
   items: Readonly<MaybeRef<T[]>>
   loadMore: () => Promise<void>
+  /** False when the source could not advance. */
+  loadMoreWithProgress?: () => Promise<boolean>
   loadNew: () => Promise<void>
 }
 

--- a/src/utils/pagedList.ts
+++ b/src/utils/pagedList.ts
@@ -7,8 +7,6 @@ export interface PagedList<T> {
   isLoading: Readonly<MaybeRef<boolean>>
   items: Readonly<MaybeRef<T[]>>
   loadMore: () => Promise<void>
-  /** False when the source could not advance. */
-  loadMoreWithProgress?: () => Promise<boolean>
   loadNew: () => Promise<void>
 }
 


### PR DESCRIPTION
- Bounds and invalidates asset cursor walks safely.
- Loads older pages for queue-targeted outputs.
- Preserves API order without overlap duplicates.

<details><summary>Full context for agent readers</summary>

## Summary

Fixes merge-readiness gaps found while validating #15381, including dossier cases TC-PAG-11, TC-PAG-12, and TC-PAG-13.

## Changes

- Stops refresh pagination at the first originally known asset.
- Deduplicates overlapping pages while preserving newest-first API order.
- Terminates repeated or cycling cursors and deduplicates concurrent load-more requests.
- Lets queue-result focus fetch older output pages until the target appears, pagination stops advancing, or a request fails.
- Selects the queue target only after its grouped job exists.
- Proves invalidation aborts a delayed tail request and leaves only reset-page rows.

## Review focus

Please verify cursor termination, queue-target acquisition, and delayed-tail invalidation.

## Verification

- Pagination, output lookup, and preemption suites: 23 passed.
- TC-PAG-13 mutation proof: removing reset-state clearing fails on stale `old-head` and `stale-tail` rows.
- Format, lint, typecheck, and knip: green.
- Full local suite at the earlier implementation head: 17,379 passed, 20 expected failures, 14 skipped. One unrelated `load3dLazy.test.ts` case timed out under full-suite load and passed immediately in isolation.
- Exact candidate QA at prior head `298b763ac9b2d3b54c8da6084deb4e4754f74555`: generated, imported, model, upload, three-page cursor, restart persistence, backend-push, and manual-refresh checks passed against Core `b133e48368d0f52bb014f0dd7ae1adb7403d515b`.
- Current head: `76f982c2f19535753f71cd9f09db81bedbc79300`.

</details>