### PR TITLE
test: add privacy-safe perf workload identity

### DIFF
--- a/browser_tests/fixtures/helpers/PerformanceHelper.ts
+++ b/browser_tests/fixtures/helpers/PerformanceHelper.ts
@@ -6,6 +6,12 @@ import {
   parseCdpMetrics,
   requireCdpMetric
 } from '@/utils/cdpPerformanceMetrics'
+import type {
+  PerfActivityIdentity,
+  PerfIdentitySource,
+  PerfWorkloadIdentity
+} from '@e2e/fixtures/helpers/perfWorkloadIdentity'
+import { buildPerfWorkloadIdentity } from '@e2e/fixtures/helpers/perfWorkloadIdentity'
 
 interface PerfSnapshot {
   RecalcStyleCount: number
@@ -78,6 +84,7 @@ export interface PerfMeasurement extends RafIntervalMetrics {
   totalBlockingTimeMs: number
   rafIntervalsMs: number[]
   rejectedRunReason: string | null
+  workloadIdentity: PerfWorkloadIdentity
 }
 
 const RAF_STATE_KEY = '__perfRafCollectorState'
@@ -272,6 +279,7 @@ export class PerformanceHelper {
     }
 
     const totalBlockingTimeMs = await this.collectTBT()
+    const workloadIdentity = await this.collectWorkloadIdentity()
     const taskAccounting = computeCdpTaskAccounting(
       before.cdpMetrics,
       after.cdpMetrics
@@ -311,7 +319,74 @@ export class PerformanceHelper {
       totalBlockingTimeMs,
       rafIntervalsMs,
       rejectedRunReason,
+      workloadIdentity,
       ...summarizeRafIntervals(rafIntervalsMs)
     }
+  }
+
+  private async collectWorkloadIdentity(): Promise<PerfWorkloadIdentity> {
+    const browserVersion =
+      this.page.context().browser()?.version() ?? 'unavailable'
+    const source = await this.page.evaluate(() => {
+      const app = window.app
+      if (!app) throw new Error('window.app is unavailable for perf identity')
+      const graph = app.canvas.graph ?? app.graph
+      const nodes = graph.nodes.map((node) => ({
+        id: String(node.id),
+        inputCount: node.inputs?.length ?? 0,
+        outputCount: node.outputs?.length ?? 0,
+        widgetCount: node.widgets?.length ?? 0
+      }))
+      const links = [...graph.links.values()].map((link) => ({
+        originId: String(link.origin_id),
+        originSlot: link.origin_slot,
+        targetId: String(link.target_id),
+        targetSlot: link.target_slot
+      }))
+      const setting = app.extensionManager?.setting
+      const vueNodesEnabled =
+        setting?.get<boolean>('Comfy.VueNodes.Enabled') ?? false
+      const canvasInfoSetting = setting?.get<boolean>('Comfy.Graph.CanvasInfo')
+      const canvasInfoEnabled =
+        typeof canvasInfoSetting === 'boolean' ? canvasInfoSetting : null
+      const renderer: PerfIdentitySource['renderer'] = vueNodesEnabled
+        ? 'vue'
+        : 'legacy'
+
+      let gpuClass: PerfIdentitySource['gpuClass'] = 'unknown'
+      const canvas = document.createElement('canvas')
+      const gl = canvas.getContext('webgl')
+      if (gl) {
+        const extension = gl.getExtension('WEBGL_debug_renderer_info')
+        const renderer = extension
+          ? String(gl.getParameter(extension.UNMASKED_RENDERER_WEBGL))
+          : ''
+        if (/swiftshader/i.test(renderer)) gpuClass = 'swiftshader'
+        else if (/software|llvmpipe/i.test(renderer)) gpuClass = 'software'
+        else if (renderer) gpuClass = 'hardware'
+        gl.getExtension('WEBGL_lose_context')?.loseContext()
+      }
+
+      return {
+        nodes,
+        links,
+        visibleNodes: app.canvas.visible_nodes.length,
+        renderer,
+        canvasInfoEnabled,
+        viewportWidth: window.innerWidth,
+        viewportHeight: window.innerHeight,
+        devicePixelRatio: window.devicePixelRatio,
+        frontendVersion: __COMFYUI_FRONTEND_VERSION__,
+        frontendCommit: __COMFYUI_FRONTEND_COMMIT__,
+        buildMode: import.meta.env.MODE as PerfIdentitySource['buildMode'],
+        gpuClass
+      }
+    })
+    const activity = await this.page.evaluate(() => {
+      const value = (window as unknown as Record<string, unknown>)
+        .__perfActivityIdentity
+      return (value ?? {}) as Partial<PerfActivityIdentity>
+    })
+    return buildPerfWorkloadIdentity({ ...source, browserVersion }, activity)
   }
 }

--- a/browser_tests/fixtures/helpers/PerformanceHelper.ts
+++ b/browser_tests/fixtures/helpers/PerformanceHelper.ts
@@ -376,9 +376,9 @@ export class PerformanceHelper {
         viewportWidth: window.innerWidth,
         viewportHeight: window.innerHeight,
         devicePixelRatio: window.devicePixelRatio,
-        frontendVersion: __COMFYUI_FRONTEND_VERSION__,
-        frontendCommit: __COMFYUI_FRONTEND_COMMIT__,
-        buildMode: import.meta.env.MODE as PerfIdentitySource['buildMode'],
+        frontendVersion: window.__COMFYUI_FRONTEND_VERSION__,
+        frontendCommit: window.__COMFYUI_FRONTEND_COMMIT__,
+        buildMode: window.__COMFYUI_BUILD_MODE__,
         gpuClass
       }
     })

--- a/browser_tests/fixtures/helpers/perfWorkloadIdentity.ts
+++ b/browser_tests/fixtures/helpers/perfWorkloadIdentity.ts
@@ -174,3 +174,33 @@ export function buildPerfWorkloadIdentity(
       .sort()
   }
 }
+
+function comparisonIdentity(identity: PerfWorkloadIdentity): string {
+  const { topology, environment } = identity
+  return stableSerialize({
+    schemaVersion: identity.schemaVersion,
+    topology,
+    environment: {
+      renderer: environment.renderer,
+      canvasInfoEnabled: environment.canvasInfoEnabled,
+      viewportWidth: environment.viewportWidth,
+      viewportHeight: environment.viewportHeight,
+      devicePixelRatio: environment.devicePixelRatio,
+      buildMode: environment.buildMode,
+      browserVersion: environment.browserVersion,
+      gpuClass: environment.gpuClass
+    }
+  })
+}
+
+export function filterComparableWorkloads<
+  T extends { workloadIdentity?: PerfWorkloadIdentity }
+>(reference: T, candidates: T[]): T[] {
+  if (!reference.workloadIdentity) return []
+  const referenceIdentity = comparisonIdentity(reference.workloadIdentity)
+  return candidates.filter(
+    ({ workloadIdentity }) =>
+      workloadIdentity &&
+      comparisonIdentity(workloadIdentity) === referenceIdentity
+  )
+}

--- a/browser_tests/fixtures/helpers/perfWorkloadIdentity.ts
+++ b/browser_tests/fixtures/helpers/perfWorkloadIdentity.ts
@@ -1,0 +1,176 @@
+import { createHash } from 'node:crypto'
+
+const PERF_IDENTITY_SCHEMA_VERSION = 1 as const
+
+export interface PerfTopologyNode {
+  id: string
+  inputCount: number
+  outputCount: number
+  widgetCount: number
+}
+
+export interface PerfTopologyLink {
+  originId: string
+  originSlot: number
+  targetId: string
+  targetSlot: number
+}
+
+export interface PerfIdentitySource {
+  nodes: PerfTopologyNode[]
+  links: PerfTopologyLink[]
+  visibleNodes: number
+  renderer: 'legacy' | 'vue'
+  canvasInfoEnabled: boolean | null
+  viewportWidth: number
+  viewportHeight: number
+  devicePixelRatio: number
+  frontendVersion: string
+  frontendCommit: string
+  buildMode: 'development' | 'production' | 'test'
+  browserVersion: string
+  gpuClass: 'hardware' | 'software' | 'swiftshader' | 'unknown'
+}
+
+export interface PerfActivityIdentity {
+  activeProgressEntries: number | null
+  progressEventsEmitted: number | null
+  progressEventsReceived: number | null
+  progressEventsApplied: number | null
+  dirtyReasons: Record<string, number> | null
+  foregroundDraws: number | null
+  backgroundDraws: number | null
+}
+
+export interface PerfWorkloadIdentity {
+  schemaVersion: typeof PERF_IDENTITY_SCHEMA_VERSION
+  topology: {
+    hash: string
+    nodes: number
+    visibleNodes: number
+    inputs: number
+    outputs: number
+    links: number
+    maxFanOut: number
+    widgets: number
+  }
+  activity: PerfActivityIdentity
+  environment: Omit<PerfIdentitySource, 'nodes' | 'links' | 'visibleNodes'>
+  missingOptionalFields: string[]
+}
+
+const ALLOWED_DIRTY_REASONS = [
+  'animation',
+  'background',
+  'foreground',
+  'layout',
+  'progress',
+  'unknown'
+] as const
+
+function normalizeCount(value: number | null | undefined): number | null {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0
+    ? value
+    : null
+}
+
+function normalizeDirtyReasons(
+  value: Record<string, number> | null | undefined
+): Record<string, number> | null {
+  if (!value) return null
+  const entries = ALLOWED_DIRTY_REASONS.flatMap((reason) => {
+    const count = normalizeCount(value[reason])
+    return count === null ? [] : [[reason, count]]
+  })
+  return entries.length ? Object.fromEntries(entries) : null
+}
+
+export function stableSerialize(value: unknown): string {
+  if (value === null || typeof value !== 'object') return JSON.stringify(value)
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => stableSerialize(item)).join(',')}]`
+  }
+  const record = value as Record<string, unknown>
+  return `{${Object.keys(record)
+    .sort()
+    .map((key) => `${JSON.stringify(key)}:${stableSerialize(record[key])}`)
+    .join(',')}}`
+}
+
+export function hashTopology(
+  nodes: PerfTopologyNode[],
+  links: PerfTopologyLink[]
+): string {
+  const sortedIds = [...new Set(nodes.map((node) => node.id))].sort()
+  const aliases = new Map(sortedIds.map((id, index) => [id, index]))
+  const topology = {
+    nodes: [...nodes]
+      .map((node) => ({
+        id: aliases.get(node.id),
+        inputs: node.inputCount,
+        outputs: node.outputCount
+      }))
+      .sort((a, b) => (a.id ?? 0) - (b.id ?? 0)),
+    links: [...links]
+      .map((link) => ({
+        origin: aliases.get(link.originId),
+        originSlot: link.originSlot,
+        target: aliases.get(link.targetId),
+        targetSlot: link.targetSlot
+      }))
+      .sort((a, b) => stableSerialize(a).localeCompare(stableSerialize(b)))
+  }
+  return `sha256:${createHash('sha256')
+    .update(stableSerialize(topology))
+    .digest('hex')}`
+}
+
+export function buildPerfWorkloadIdentity(
+  source: PerfIdentitySource,
+  activity: Partial<PerfActivityIdentity> = {}
+): PerfWorkloadIdentity {
+  const fanOut = new Map<string, number>()
+  for (const link of source.links) {
+    const key = `${link.originId}:${link.originSlot}`
+    fanOut.set(key, (fanOut.get(key) ?? 0) + 1)
+  }
+  const normalizedActivity: PerfActivityIdentity = {
+    activeProgressEntries: normalizeCount(activity.activeProgressEntries),
+    progressEventsEmitted: normalizeCount(activity.progressEventsEmitted),
+    progressEventsReceived: normalizeCount(activity.progressEventsReceived),
+    progressEventsApplied: normalizeCount(activity.progressEventsApplied),
+    dirtyReasons: normalizeDirtyReasons(activity.dirtyReasons),
+    foregroundDraws: normalizeCount(activity.foregroundDraws),
+    backgroundDraws: normalizeCount(activity.backgroundDraws)
+  }
+  return {
+    schemaVersion: PERF_IDENTITY_SCHEMA_VERSION,
+    topology: {
+      hash: hashTopology(source.nodes, source.links),
+      nodes: source.nodes.length,
+      visibleNodes: source.visibleNodes,
+      inputs: source.nodes.reduce((sum, node) => sum + node.inputCount, 0),
+      outputs: source.nodes.reduce((sum, node) => sum + node.outputCount, 0),
+      links: source.links.length,
+      maxFanOut: Math.max(0, ...fanOut.values()),
+      widgets: source.nodes.reduce((sum, node) => sum + node.widgetCount, 0)
+    },
+    activity: normalizedActivity,
+    environment: {
+      renderer: source.renderer,
+      canvasInfoEnabled: source.canvasInfoEnabled,
+      viewportWidth: source.viewportWidth,
+      viewportHeight: source.viewportHeight,
+      devicePixelRatio: source.devicePixelRatio,
+      frontendVersion: source.frontendVersion,
+      frontendCommit: source.frontendCommit,
+      buildMode: source.buildMode,
+      browserVersion: source.browserVersion,
+      gpuClass: source.gpuClass
+    },
+    missingOptionalFields: Object.entries(normalizedActivity)
+      .filter(([, value]) => value === null)
+      .map(([key]) => `activity.${key}`)
+      .sort()
+  }
+}

--- a/browser_tests/fixtures/utils/perfReporter.ts
+++ b/browser_tests/fixtures/utils/perfReporter.ts
@@ -4,7 +4,7 @@ import { join } from 'path'
 import type { PerfMeasurement } from '@e2e/fixtures/helpers/PerformanceHelper'
 
 interface PerfReport {
-  schemaVersion: 3
+  schemaVersion: 4
   timestamp: string
   gitSha: string
   branch: string
@@ -78,7 +78,7 @@ export function writePerfReport(
   )
 
   const report: PerfReport = {
-    schemaVersion: 3,
+    schemaVersion: 4,
     timestamp: new Date().toISOString(),
     gitSha,
     branch,

--- a/browser_tests/tests/performance/harness.spec.ts
+++ b/browser_tests/tests/performance/harness.spec.ts
@@ -50,6 +50,15 @@ test.describe('Performance measurement controls', { tag: ['@perf'] }, () => {
     expect(measurement.rafIntervalsMs).toHaveLength(
       measurement.rafIntervalCount
     )
+    expect(measurement.workloadIdentity).toMatchObject({
+      schemaVersion: 1,
+      environment: {
+        frontendVersion: expect.any(String),
+        frontendCommit: expect.any(String),
+        buildMode: expect.stringMatching(/^(development|production|test)$/)
+      }
+    })
+    expect(measurement.workloadIdentity.topology.hash).toMatch(/^sha256:/)
   })
 
   test('records a blocked main-thread gap before stop', async ({

--- a/global.d.ts
+++ b/global.d.ts
@@ -64,6 +64,9 @@ interface SyftDisabledClient {
 }
 
 interface Window {
+  __COMFYUI_FRONTEND_VERSION__: string
+  __COMFYUI_FRONTEND_COMMIT__: string
+  __COMFYUI_BUILD_MODE__: 'development' | 'production' | 'test'
   __CONFIG__: {
     gtm_container_id?: string
     ga_measurement_id?: string

--- a/scripts/perf-report.ts
+++ b/scripts/perf-report.ts
@@ -53,6 +53,13 @@ interface PerfMeasurement {
   rafIntervalsOver33_3Ms?: number
   rafIntervalsOver50Ms?: number
   rejectedRunReason?: string | null
+  workloadIdentity?: {
+    schemaVersion: number
+    topology: Record<string, number | string>
+    activity: Record<string, number | Record<string, number> | null>
+    environment: Record<string, boolean | number | string | null>
+    missingOptionalFields: string[]
+  }
 }
 
 interface PerfReport {
@@ -603,9 +610,30 @@ function main() {
         measurement
     )
   }
+  const serializedCommentData = JSON.stringify(commentData, null, 2)
+  const boundedCommentData =
+    serializedCommentData.length <= 48_000
+      ? serializedCommentData
+      : JSON.stringify(
+          {
+            schemaVersion: current.schemaVersion,
+            timestamp: current.timestamp,
+            gitSha: current.gitSha,
+            branch: current.branch,
+            summaryTruncated: true,
+            fullArtifact: CURRENT_PATH,
+            measurementIdentities: current.measurements.map((measurement) => ({
+              name: measurement.name,
+              rejectedRunReason: measurement.rejectedRunReason,
+              workloadIdentity: measurement.workloadIdentity
+            }))
+          },
+          null,
+          2
+        )
   lines.push('\n<details><summary>Summary data</summary>\n')
   lines.push('```json')
-  lines.push(JSON.stringify(commentData, null, 2))
+  lines.push(boundedCommentData)
   lines.push('```')
   lines.push('\n</details>')
 

--- a/scripts/perf-report.ts
+++ b/scripts/perf-report.ts
@@ -1,6 +1,8 @@
 import { existsSync, readFileSync, readdirSync } from 'node:fs'
 import { join } from 'node:path'
 
+import type { PerfWorkloadIdentity } from '../browser_tests/fixtures/helpers/perfWorkloadIdentity'
+import { filterComparableWorkloads } from '../browser_tests/fixtures/helpers/perfWorkloadIdentity'
 import type { MetricStats } from './perf-stats'
 import {
   classifyChange,
@@ -53,13 +55,7 @@ interface PerfMeasurement {
   rafIntervalsOver33_3Ms?: number
   rafIntervalsOver50Ms?: number
   rejectedRunReason?: string | null
-  workloadIdentity?: {
-    schemaVersion: number
-    topology: Record<string, number | string>
-    activity: Record<string, number | Record<string, number> | null>
-    environment: Record<string, boolean | number | string | null>
-    missingOptionalFields: string[]
-  }
+  workloadIdentity?: PerfWorkloadIdentity
 }
 
 interface PerfReport {
@@ -197,12 +193,16 @@ function loadHistoricalReports(): PerfReport[] {
 function getHistoricalStats(
   reports: PerfReport[],
   testName: string,
-  metric: MetricKey
+  metric: MetricKey,
+  reference: PerfMeasurement
 ): MetricStats {
   const values: number[] = []
   for (const r of reports) {
     const group = groupByName(r.measurements)
-    const samples = group.get(testName)
+    const samples = filterComparableWorkloads(
+      reference,
+      group.get(testName) ?? []
+    )
     if (samples) {
       const mean = meanMetric(samples, metric)
       if (mean !== null) values.push(mean)
@@ -214,7 +214,8 @@ function getHistoricalStats(
 function getHistoricalTimeSeries(
   reports: PerfReport[],
   testName: string,
-  metric: MetricKey
+  metric: MetricKey,
+  reference: PerfMeasurement
 ): number[] {
   const sorted = [...reports].sort(
     (a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime()
@@ -222,7 +223,10 @@ function getHistoricalTimeSeries(
   const values: number[] = []
   for (const r of sorted) {
     const group = groupByName(r.measurements)
-    const samples = group.get(testName)
+    const samples = filterComparableWorkloads(
+      reference,
+      group.get(testName) ?? []
+    )
     if (samples) {
       const mean = meanMetric(samples, metric)
       if (mean !== null) values.push(mean)
@@ -358,13 +362,17 @@ function renderFullReport(
   const allRows: string[] = []
 
   for (const [testName, prSamples] of prGroups) {
-    const baseSamples = baselineGroups.get(testName)
+    const reference = prSamples[0]
+    const baseSamples = filterComparableWorkloads(
+      reference,
+      baselineGroups.get(testName) ?? []
+    )
 
     for (const { key, label, unit, minAbsDelta } of REPORTED_METRICS) {
       // Use median for PR values — robust to outlier runs in CI
       const prVal = medianMetric(prSamples, key)
       if (prVal === null) continue
-      const histStats = getHistoricalStats(historical, testName, key)
+      const histStats = getHistoricalStats(historical, testName, key, reference)
       const cv = computeCV(histStats)
 
       if (!baseSamples?.length) {
@@ -431,9 +439,10 @@ function renderFullReport(
     '| Metric | μ | σ | CV |',
     '|--------|---|---|-----|'
   )
-  for (const [testName] of prGroups) {
+  for (const [testName, prSamples] of prGroups) {
+    const reference = prSamples[0]
     for (const { key, label, unit } of REPORTED_METRICS) {
-      const stats = getHistoricalStats(historical, testName, key)
+      const stats = getHistoricalStats(historical, testName, key, reference)
       if (stats.n < 2) continue
       const cv = computeCV(stats)
       lines.push(
@@ -444,9 +453,15 @@ function renderFullReport(
   lines.push('', '</details>')
 
   const trendRows: string[] = []
-  for (const [testName] of prGroups) {
+  for (const [testName, prSamples] of prGroups) {
+    const reference = prSamples[0]
     for (const { key, label, unit } of REPORTED_METRICS) {
-      const series = getHistoricalTimeSeries(historical, testName, key)
+      const series = getHistoricalTimeSeries(
+        historical,
+        testName,
+        key,
+        reference
+      )
       if (series.length < 3) continue
       const dir = trendDirection(series)
       const arrow = trendArrow(dir)
@@ -491,7 +506,10 @@ function renderColdStartReport(
   )
 
   for (const [testName, prSamples] of prGroups) {
-    const baseSamples = baselineGroups.get(testName)
+    const baseSamples = filterComparableWorkloads(
+      prSamples[0],
+      baselineGroups.get(testName) ?? []
+    )
 
     for (const { key, label, unit } of REPORTED_METRICS) {
       const prVal = medianMetric(prSamples, key)

--- a/scripts/perf-workload-identity.test.ts
+++ b/scripts/perf-workload-identity.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest'
+
+import type { PerfIdentitySource } from '../browser_tests/fixtures/helpers/perfWorkloadIdentity'
+import {
+  buildPerfWorkloadIdentity,
+  hashTopology,
+  stableSerialize
+} from '../browser_tests/fixtures/helpers/perfWorkloadIdentity'
+
+const source: PerfIdentitySource = {
+  nodes: [
+    { id: '20', inputCount: 1, outputCount: 0, widgetCount: 2 },
+    { id: '10', inputCount: 0, outputCount: 1, widgetCount: 1 }
+  ],
+  links: [{ originId: '10', originSlot: 0, targetId: '20', targetSlot: 0 }],
+  visibleNodes: 2,
+  renderer: 'legacy',
+  canvasInfoEnabled: false,
+  viewportWidth: 1280,
+  viewportHeight: 720,
+  devicePixelRatio: 1,
+  frontendVersion: '1.2.3',
+  frontendCommit: 'abc123',
+  buildMode: 'test',
+  browserVersion: 'Chromium 140',
+  gpuClass: 'swiftshader'
+}
+
+describe('perf workload identity', () => {
+  it('serializes objects deterministically', () => {
+    expect(stableSerialize({ z: 1, a: { y: 2, x: 3 } })).toBe(
+      stableSerialize({ a: { x: 3, y: 2 }, z: 1 })
+    )
+  })
+
+  it('hashes topology independently of source ordering', () => {
+    expect(hashTopology(source.nodes, source.links)).toBe(
+      hashTopology([...source.nodes].reverse(), [...source.links].reverse())
+    )
+  })
+
+  it('exports counts without workflow content or source node ids', () => {
+    const identity = buildPerfWorkloadIdentity(source)
+    const serialized = JSON.stringify(identity)
+
+    expect(identity.topology).toMatchObject({
+      nodes: 2,
+      visibleNodes: 2,
+      inputs: 1,
+      outputs: 1,
+      links: 1,
+      maxFanOut: 1,
+      widgets: 3
+    })
+    expect(serialized).not.toContain('"10"')
+    expect(serialized).not.toContain('"20"')
+  })
+
+  it('marks unavailable activity instrumentation explicitly', () => {
+    const identity = buildPerfWorkloadIdentity(source, {
+      progressEventsReceived: 12,
+      foregroundDraws: 4,
+      dirtyReasons: { progress: 3, 'workflow secret': 99 }
+    })
+
+    expect(identity.activity.progressEventsReceived).toBe(12)
+    expect(identity.missingOptionalFields).not.toContain(
+      'activity.progressEventsReceived'
+    )
+    expect(identity.missingOptionalFields).toContain(
+      'activity.progressEventsApplied'
+    )
+    expect(identity.activity.dirtyReasons).toEqual({ progress: 3 })
+    expect(JSON.stringify(identity)).not.toContain('workflow secret')
+  })
+})

--- a/scripts/perf-workload-identity.test.ts
+++ b/scripts/perf-workload-identity.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest'
 import type { PerfIdentitySource } from '../browser_tests/fixtures/helpers/perfWorkloadIdentity'
 import {
   buildPerfWorkloadIdentity,
+  filterComparableWorkloads,
   hashTopology,
   stableSerialize
 } from '../browser_tests/fixtures/helpers/perfWorkloadIdentity'
@@ -72,5 +73,37 @@ describe('perf workload identity', () => {
     )
     expect(identity.activity.dirtyReasons).toEqual({ progress: 3 })
     expect(JSON.stringify(identity)).not.toContain('workflow secret')
+  })
+
+  it('filters samples by topology and execution environment', () => {
+    const reference = { workloadIdentity: buildPerfWorkloadIdentity(source) }
+    const sameWorkloadNewBuild = {
+      workloadIdentity: buildPerfWorkloadIdentity({
+        ...source,
+        frontendVersion: '9.9.9',
+        frontendCommit: 'different-commit'
+      })
+    }
+    const differentTopology = {
+      workloadIdentity: buildPerfWorkloadIdentity({
+        ...source,
+        links: []
+      })
+    }
+    const differentEnvironment = {
+      workloadIdentity: buildPerfWorkloadIdentity({
+        ...source,
+        devicePixelRatio: 2
+      })
+    }
+
+    expect(
+      filterComparableWorkloads(reference, [
+        sameWorkloadNewBuild,
+        differentTopology,
+        differentEnvironment,
+        {}
+      ])
+    ).toEqual([sameWorkloadNewBuild])
   })
 })

--- a/src/App.vue
+++ b/src/App.vue
@@ -58,6 +58,11 @@ function handleResourceError(url: string, tagName: string) {
 
 onMounted(() => {
   window['__COMFYUI_FRONTEND_VERSION__'] = config.app_version
+  window['__COMFYUI_FRONTEND_COMMIT__'] = __COMFYUI_FRONTEND_COMMIT__
+  window['__COMFYUI_BUILD_MODE__'] = import.meta.env.MODE as
+    | 'development'
+    | 'production'
+    | 'test'
 
   if (isDesktop) {
     document.addEventListener('contextmenu', showContextMenu)

--- a/src/utils/cdpPerformanceMetrics.ts
+++ b/src/utils/cdpPerformanceMetrics.ts
@@ -3,7 +3,7 @@ export interface CdpPerformanceMetric {
   value: number
 }
 
-export const TASK_COMPONENT_METRICS = [
+const TASK_COMPONENT_METRICS = [
   'ScriptDuration',
   'V8CompileDuration',
   'RecalcStyleDuration',
@@ -11,8 +11,6 @@ export const TASK_COMPONENT_METRICS = [
   'DevToolsCommandDuration',
   'TaskOtherDuration'
 ] as const
-
-export type TaskComponentMetric = (typeof TASK_COMPONENT_METRICS)[number]
 
 export interface CdpTaskAccounting {
   taskOtherDurationMs: number | null


### PR DESCRIPTION
## Summary

Stacked on #16016/#15997. Add schema-v4, per-measurement workload identity so results are comparable only when topology and environment denominators match.

## Identity and privacy

Includes anonymized topology hash/counts, renderer/settings, viewport/DPR, frontend/build/browser identity, coarse GPU classification, and explicit nullable activity fields. Raw node IDs, types, labels, widget values, prompts, paths, workflow content, and raw GPU strings are excluded. Dirty-reason keys are allowlisted and counts sanitized.

## Verification

Identity + CDP tests 9/9; Knip; browser/scripts typechecks; formatting; hooks and diff checks pass.

<!-- perf-proof-evidence:start -->
## Performance proof evidence

- **Role:** privacy-safe performance-harness identity/schema infrastructure, not a runtime optimization.
- **Local proof recorded at `52f3f5d82f29a01bb6efb6179e95c5a7d3d61e6d`:**
  ```bash
  PATH=/home/c_byrne/.nvm/versions/node/v25.9.0/bin:$PATH \
  NODE_OPTIONS=--localstorage-file=/tmp/codex-proof-wave-b-localstorage \
  node_modules/.bin/vitest run \
    scripts/perf-workload-identity.test.ts \
    src/utils/cdpPerformanceMetrics.test.ts
  ```
  Result: 2 files, 9/9 tests passed; Vitest 285 ms, wall 0.89 s.
- **Controls covered:** deterministic serialization/hash, topology-order independence, privacy exclusions, unavailable activity markers, and inherited CDP accounting.
- **Current-head caveat:** the head has advanced since that local run.
- **Browser/screenshots:** product-browser visual QA and screenshots are not applicable. A future harness smoke should attach a sanitized schema-v4 artifact to prove real measurement identity propagation.
- **Final GitHub state:** merged at final head `469632ad225f2facb59ad174aa842fc1d6796f33`; the fresh audit found no red or pending checks. The exact local command above was run on the cited earlier revision.
<!-- perf-proof-evidence:end -->
