### PR TITLE
test: add clean-room extension performance fixture

### DIFF
--- a/src/lib/litegraph/src/node/cleanExtensionCompatFixture.test.ts
+++ b/src/lib/litegraph/src/node/cleanExtensionCompatFixture.test.ts
@@ -3,10 +3,7 @@ import { setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { LGraph, LGraphNode, LiteGraph } from '@/lib/litegraph/src/litegraph'
-import {
-  CLEAN_EXTENSION_FIXTURE_IDENTITY,
-  installCleanExtensionFixture
-} from '@/lib/litegraph/test/fixtures/cleanExtensionCompatFixture'
+import { installCleanExtensionFixture } from '@/lib/litegraph/test/fixtures/cleanExtensionCompatFixture'
 import type {
   CleanExtensionCounters,
   CleanExtensionDrawContext,
@@ -161,7 +158,20 @@ describe('clean extension compatibility fixture', () => {
       })
       expect(result.coreDraws).toHaveBeenCalledTimes(result.nodes.length)
       expect(result.after).toEqual(result.before)
-      expect(result.fixture.identity).toBe(CLEAN_EXTENSION_FIXTURE_IDENTITY)
+      expect(result.fixture.identity).toEqual({
+        fixture: 'comfy.clean-extension-compat.v1',
+        emulationPatternSha256:
+          'a8603d20ae82775a902553058e1cea4e72ea10c0ab1664cd57ab6b5fc573a719',
+        labelPatternSource:
+          'rgthree-comfy@13b4399c00b5ef5a97b1b6800fc1185874740f5d',
+        labelPatternSha256:
+          '5a0f8d72d0be3c6573477943a18295310f82dd4b1d99a506517bb6956af1790d',
+        reroutePatternSource: 'rgthree-comfy@629c514a',
+        reroutePatternSha256:
+          'fea80b78a4e055446ad69628c2ea436f06eda52a31382e005a5476f1a6e65b24',
+        compatibilityPatternSource:
+          'ComfyUI-KJNodes@3f20054214fec9f9234fd3841ae6f1e4287948f6'
+      })
 
       if (mode === 'loaded-inactive') {
         expect(result.fixture.counters).toMatchObject({

--- a/src/lib/litegraph/src/node/cleanExtensionCompatFixture.test.ts
+++ b/src/lib/litegraph/src/node/cleanExtensionCompatFixture.test.ts
@@ -1,0 +1,244 @@
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { LGraph, LGraphNode, LiteGraph } from '@/lib/litegraph/src/litegraph'
+import {
+  CLEAN_EXTENSION_FIXTURE_IDENTITY,
+  installCleanExtensionFixture
+} from '@/lib/litegraph/test/fixtures/cleanExtensionCompatFixture'
+import type {
+  CleanExtensionCounters,
+  CleanExtensionDrawContext,
+  CleanExtensionHost,
+  CleanExtensionMode,
+  CleanExtensionScheduler
+} from '@/lib/litegraph/test/fixtures/cleanExtensionCompatFixture'
+
+class ManualScheduler implements CleanExtensionScheduler {
+  private readonly callbacks = new Set<() => void>()
+
+  setInterval(callback: () => void, _delay: number): () => void {
+    this.callbacks.add(callback)
+    return () => this.callbacks.delete(callback)
+  }
+
+  tick(): void {
+    for (const callback of this.callbacks) callback()
+  }
+
+  get activeTimers(): number {
+    return this.callbacks.size
+  }
+}
+
+interface MatrixSetup {
+  graph: LGraph
+  nodes: LGraphNode[]
+  label: LGraphNode
+  reroute: LGraphNode
+  host: CleanExtensionHost
+  context: CleanExtensionDrawContext
+  scheduler: ManualScheduler
+  coreDraws: ReturnType<typeof vi.fn>
+  dirtyRequests: ReturnType<typeof vi.fn>
+  measurements: ReturnType<typeof vi.fn>
+}
+
+function createMatrixSetup(): MatrixSetup {
+  const graph = new LGraph()
+  const source = new LGraphNode('Source')
+  source.addOutput('out', 'INT')
+  const target = new LGraphNode('Target')
+  target.addInput('in', 'INT')
+  const label = new LGraphNode('First line\nSecond line')
+  label.type = 'fixture/label'
+  const reroute = new LGraphNode('Reroute')
+  reroute.type = 'fixture/reroute'
+  reroute.addInput('in', 'INT')
+  reroute.addOutput('out', 'INT')
+  const nodes = [source, target, label, reroute]
+  nodes.forEach((node) => graph.add(node))
+  source.connect(0, target, 0)
+  source.connect(0, reroute, 0)
+
+  const coreDraws = vi.fn()
+  const dirtyRequests = vi.fn()
+  const measurements = vi.fn()
+  const host: CleanExtensionHost = {
+    drawNode: coreDraws,
+    setDirty: dirtyRequests,
+    events: new EventTarget()
+  }
+  return {
+    graph,
+    nodes,
+    label,
+    reroute,
+    host,
+    context: { measureText: measurements },
+    scheduler: new ManualScheduler(),
+    coreDraws,
+    dirtyRequests,
+    measurements
+  }
+}
+
+function topology(graph: LGraph) {
+  return graph.serialize()
+}
+
+function runMode(mode: CleanExtensionMode) {
+  const setup = createMatrixSetup()
+  const before = topology(setup.graph)
+  const fixture = installCleanExtensionFixture(
+    setup.host,
+    setup.scheduler,
+    mode
+  )
+  for (const node of setup.nodes) setup.host.drawNode(node, setup.context)
+  fixture.sweepLegacyFacades(setup.nodes, setup.graph)
+  setup.scheduler.tick()
+  setup.host.events.dispatchEvent(new Event('fixture:refresh'))
+  return { ...setup, before, fixture, after: topology(setup.graph) }
+}
+
+describe('clean extension compatibility fixture', () => {
+  beforeEach(() => {
+    setActivePinia(createTestingPinia({ stubActions: false }))
+    LiteGraph.onDeprecationWarning = []
+  })
+
+  it('keeps the unloaded control free of registrations and wrappers', () => {
+    const setup = createMatrixSetup()
+    for (const node of setup.nodes) setup.host.drawNode(node, setup.context)
+    setup.scheduler.tick()
+
+    expect(setup.coreDraws).toHaveBeenCalledTimes(setup.nodes.length)
+    expect(setup.dirtyRequests).not.toHaveBeenCalled()
+    expect(setup.scheduler.activeTimers).toBe(0)
+  })
+
+  it.for([
+    {
+      mode: 'loaded-inactive',
+      expected: { labelHookCalls: 0, rerouteHookCalls: 0, dirtyTimerTicks: 0 }
+    },
+    {
+      mode: 'label',
+      expected: { labelHookCalls: 1, rerouteHookCalls: 0, dirtyTimerTicks: 0 }
+    },
+    {
+      mode: 'reroute',
+      expected: { labelHookCalls: 0, rerouteHookCalls: 1, dirtyTimerTicks: 0 }
+    },
+    {
+      mode: 'dirty-timer',
+      expected: { labelHookCalls: 0, rerouteHookCalls: 0, dirtyTimerTicks: 1 }
+    },
+    {
+      mode: 'legacy-facade',
+      expected: { labelHookCalls: 0, rerouteHookCalls: 0, dirtyTimerTicks: 0 }
+    },
+    {
+      mode: 'combined',
+      expected: { labelHookCalls: 1, rerouteHookCalls: 1, dirtyTimerTicks: 1 }
+    }
+  ] satisfies {
+    mode: CleanExtensionMode
+    expected: Partial<CleanExtensionCounters>
+  }[])(
+    'attributes the $mode arm without charging forwarded core draws',
+    ({ mode, expected }) => {
+      const result = runMode(mode)
+
+      expect(result.fixture.counters).toMatchObject({
+        registrations: 1,
+        wrapperCalls: result.nodes.length,
+        forwardedCoreDraws: result.nodes.length,
+        listenerCalls: 1,
+        ...expected
+      })
+      expect(result.coreDraws).toHaveBeenCalledTimes(result.nodes.length)
+      expect(result.after).toEqual(result.before)
+      expect(result.fixture.identity).toBe(CLEAN_EXTENSION_FIXTURE_IDENTITY)
+
+      if (mode === 'loaded-inactive') {
+        expect(result.fixture.counters).toMatchObject({
+          labelMeasurements: 0,
+          inputLinkReads: 0,
+          outputLinksReads: 0,
+          dirtyRequests: 0
+        })
+      }
+      if (mode === 'label' || mode === 'combined') {
+        expect(result.measurements).toHaveBeenCalledTimes(2)
+      }
+      if (mode === 'dirty-timer' || mode === 'combined') {
+        expect(result.dirtyRequests).toHaveBeenCalledExactlyOnceWith(true, true)
+      }
+    }
+  )
+
+  it('counts facade accesses, stable views, and graph resolution separately', () => {
+    const result = runMode('legacy-facade')
+    const { counters } = result.fixture
+
+    expect(counters).toMatchObject({
+      inputLinkReads: 2,
+      outputLinksReads: 2,
+      outputLinkViewAllocations: 1,
+      graphLinkReads: 4,
+      positionComponentReads: 8,
+      sizeComponentReads: 8
+    })
+
+    result.fixture.sweepLegacyFacades(result.nodes, result.graph)
+    expect(counters.outputLinksReads).toBe(4)
+    expect(counters.outputLinkViewAllocations).toBe(1)
+    expect(topology(result.graph)).toEqual(result.before)
+  })
+
+  it('registers once on reload and disposes wrappers, timers, and listeners', () => {
+    const setup = createMatrixSetup()
+    const originalDrawNode = setup.host.drawNode
+    const first = installCleanExtensionFixture(
+      setup.host,
+      setup.scheduler,
+      'combined'
+    )
+    const reload = installCleanExtensionFixture(
+      setup.host,
+      setup.scheduler,
+      'combined'
+    )
+
+    expect(reload).toBe(first)
+    expect(first.counters.registrations).toBe(1)
+    expect(setup.scheduler.activeTimers).toBe(1)
+
+    first.dispose()
+    first.dispose()
+    setup.scheduler.tick()
+    setup.host.events.dispatchEvent(new Event('fixture:refresh'))
+    setup.host.drawNode(setup.label, setup.context)
+
+    expect(setup.host.drawNode).toBe(originalDrawNode)
+    expect(setup.scheduler.activeTimers).toBe(0)
+    expect(first.counters.dirtyTimerTicks).toBe(0)
+    expect(first.counters.listenerCalls).toBe(0)
+    expect(first.counters.wrapperCalls).toBe(0)
+    expect(setup.coreDraws).toHaveBeenCalledExactlyOnceWith(
+      setup.label,
+      setup.context
+    )
+
+    const reinstalled = installCleanExtensionFixture(
+      setup.host,
+      setup.scheduler,
+      'loaded-inactive'
+    )
+    expect(reinstalled).not.toBe(first)
+    expect(reinstalled.counters.registrations).toBe(1)
+  })
+})

--- a/src/lib/litegraph/src/node/cleanExtensionCompatFixture.test.ts
+++ b/src/lib/litegraph/src/node/cleanExtensionCompatFixture.test.ts
@@ -3,6 +3,7 @@ import { setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { LGraph, LGraphNode, LiteGraph } from '@/lib/litegraph/src/litegraph'
+import { MapProxyHandler } from '@/lib/litegraph/src/MapProxyHandler'
 import { installCleanExtensionFixture } from '@/lib/litegraph/test/fixtures/cleanExtensionCompatFixture'
 import type {
   CleanExtensionCounters,
@@ -191,8 +192,12 @@ describe('clean extension compatibility fixture', () => {
   )
 
   it('counts facade accesses, stable views, and graph resolution separately', () => {
+    const linkFacadeReads = vi.spyOn(MapProxyHandler.prototype, 'get')
     const result = runMode('legacy-facade')
     const { counters } = result.fixture
+    const indexedLinkReads = linkFacadeReads.mock.calls.filter(
+      ([, property]) => typeof property === 'string' && /^\d+$/.test(property)
+    )
 
     expect(counters).toMatchObject({
       inputLinkReads: 2,
@@ -202,6 +207,7 @@ describe('clean extension compatibility fixture', () => {
       positionComponentReads: 8,
       sizeComponentReads: 8
     })
+    expect(indexedLinkReads).toHaveLength(counters.graphLinkReads)
 
     result.fixture.sweepLegacyFacades(result.nodes, result.graph)
     expect(counters.outputLinksReads).toBe(4)

--- a/src/lib/litegraph/test/fixtures/cleanExtensionCompatFixture.ts
+++ b/src/lib/litegraph/test/fixtures/cleanExtensionCompatFixture.ts
@@ -179,7 +179,7 @@ function sweepNodeFacades(
   for (const input of node.inputs) {
     const linkId = input.link
     counters.inputLinkReads++
-    if (linkId != null && graph?.links.get(linkId)) counters.graphLinkReads++
+    if (linkId != null && graph?.links[linkId]) counters.graphLinkReads++
   }
   for (const output of node.outputs) {
     const linkIds = output.links
@@ -189,7 +189,7 @@ function sweepNodeFacades(
       counters.outputLinkViewAllocations++
     }
     for (const linkId of linkIds ?? []) {
-      if (graph?.links.get(linkId)) counters.graphLinkReads++
+      if (graph?.links[linkId]) counters.graphLinkReads++
     }
   }
 }

--- a/src/lib/litegraph/test/fixtures/cleanExtensionCompatFixture.ts
+++ b/src/lib/litegraph/test/fixtures/cleanExtensionCompatFixture.ts
@@ -1,0 +1,195 @@
+import type { LGraph } from '@/lib/litegraph/src/LGraph'
+import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
+
+export const CLEAN_EXTENSION_FIXTURE_IDENTITY = Object.freeze({
+  fixture: 'comfy.clean-extension-compat.v1',
+  emulationPatternSha256:
+    'a8603d20ae82775a902553058e1cea4e72ea10c0ab1664cd57ab6b5fc573a719',
+  labelPatternSource: 'rgthree-comfy@13b4399c00b5ef5a97b1b6800fc1185874740f5d',
+  labelPatternSha256:
+    '5a0f8d72d0be3c6573477943a18295310f82dd4b1d99a506517bb6956af1790d',
+  reroutePatternSource: 'rgthree-comfy@629c514a',
+  reroutePatternSha256:
+    'fea80b78a4e055446ad69628c2ea436f06eda52a31382e005a5476f1a6e65b24',
+  compatibilityPatternSource:
+    'ComfyUI-KJNodes@3f20054214fec9f9234fd3841ae6f1e4287948f6'
+})
+
+export type CleanExtensionMode =
+  | 'loaded-inactive'
+  | 'label'
+  | 'reroute'
+  | 'dirty-timer'
+  | 'legacy-facade'
+  | 'combined'
+
+export interface CleanExtensionCounters {
+  registrations: number
+  wrapperCalls: number
+  forwardedCoreDraws: number
+  labelHookCalls: number
+  labelMeasurements: number
+  rerouteHookCalls: number
+  dirtyTimerTicks: number
+  dirtyRequests: number
+  listenerCalls: number
+  inputLinkReads: number
+  outputLinksReads: number
+  outputLinkViewAllocations: number
+  graphLinkReads: number
+  positionComponentReads: number
+  sizeComponentReads: number
+}
+
+export interface CleanExtensionDrawContext {
+  measureText(text: string): void
+}
+
+export interface CleanExtensionHost {
+  drawNode(node: LGraphNode, context: CleanExtensionDrawContext): void
+  setDirty(foreground: boolean, background: boolean): void
+  events: EventTarget
+}
+
+export interface CleanExtensionScheduler {
+  setInterval(callback: () => void, delay: number): () => void
+}
+
+export interface CleanExtensionInstallation {
+  readonly counters: CleanExtensionCounters
+  readonly identity: typeof CLEAN_EXTENSION_FIXTURE_IDENTITY
+  sweepLegacyFacades(nodes: readonly LGraphNode[], graph: LGraph): void
+  dispose(): void
+}
+
+interface ActiveInstallation extends CleanExtensionInstallation {
+  disposed: boolean
+}
+
+const activeInstallations = new WeakMap<
+  CleanExtensionHost,
+  ActiveInstallation
+>()
+
+export function installCleanExtensionFixture(
+  host: CleanExtensionHost,
+  scheduler: CleanExtensionScheduler,
+  mode: CleanExtensionMode
+): CleanExtensionInstallation {
+  const active = activeInstallations.get(host)
+  if (active && !active.disposed) return active
+
+  const counters = createCounters()
+  counters.registrations++
+  const originalDrawNode = host.drawNode
+  const outputViews = new WeakMap<object, object>()
+  const labelActive = mode === 'label' || mode === 'combined'
+  const rerouteActive = mode === 'reroute' || mode === 'combined'
+  const facadeActive = mode === 'legacy-facade' || mode === 'combined'
+  const timerActive = mode === 'dirty-timer' || mode === 'combined'
+
+  host.drawNode = function cleanExtensionDrawNode(node, context) {
+    counters.wrapperCalls++
+    originalDrawNode.call(host, node, context)
+    counters.forwardedCoreDraws++
+
+    if (labelActive && node.type === 'fixture/label') {
+      counters.labelHookCalls++
+      for (const line of node.title.split('\n')) {
+        context.measureText(line)
+        counters.labelMeasurements++
+      }
+    }
+
+    if (rerouteActive && node.type === 'fixture/reroute') {
+      counters.rerouteHookCalls++
+      sweepNodeFacades(node, node.graph, counters, outputViews)
+    }
+  }
+
+  const onRefresh = () => {
+    counters.listenerCalls++
+  }
+  host.events.addEventListener('fixture:refresh', onRefresh)
+
+  const cancelTimer = timerActive
+    ? scheduler.setInterval(() => {
+        counters.dirtyTimerTicks++
+        host.setDirty(true, true)
+        counters.dirtyRequests++
+      }, 250)
+    : undefined
+
+  const installation: ActiveInstallation = {
+    counters,
+    identity: CLEAN_EXTENSION_FIXTURE_IDENTITY,
+    disposed: false,
+    sweepLegacyFacades(nodes, graph) {
+      if (!facadeActive) return
+      for (const node of nodes) {
+        sweepNodeFacades(node, graph, counters, outputViews)
+      }
+    },
+    dispose() {
+      if (installation.disposed) return
+      installation.disposed = true
+      host.drawNode = originalDrawNode
+      host.events.removeEventListener('fixture:refresh', onRefresh)
+      cancelTimer?.()
+      activeInstallations.delete(host)
+    }
+  }
+  activeInstallations.set(host, installation)
+  return installation
+}
+
+function createCounters(): CleanExtensionCounters {
+  return {
+    registrations: 0,
+    wrapperCalls: 0,
+    forwardedCoreDraws: 0,
+    labelHookCalls: 0,
+    labelMeasurements: 0,
+    rerouteHookCalls: 0,
+    dirtyTimerTicks: 0,
+    dirtyRequests: 0,
+    listenerCalls: 0,
+    inputLinkReads: 0,
+    outputLinksReads: 0,
+    outputLinkViewAllocations: 0,
+    graphLinkReads: 0,
+    positionComponentReads: 0,
+    sizeComponentReads: 0
+  }
+}
+
+function sweepNodeFacades(
+  node: LGraphNode,
+  graph: LGraph | null,
+  counters: CleanExtensionCounters,
+  outputViews: WeakMap<object, object>
+): void {
+  void node.pos[0]
+  void node.pos[1]
+  void node.size[0]
+  void node.size[1]
+  counters.positionComponentReads += 2
+  counters.sizeComponentReads += 2
+
+  for (const input of node.inputs) {
+    const linkId = input.link
+    counters.inputLinkReads++
+    if (linkId != null && graph?.links.get(linkId)) counters.graphLinkReads++
+  }
+  for (const output of node.outputs) {
+    const linkIds = output.links
+    counters.outputLinksReads++
+    if (linkIds && outputViews.get(output) !== linkIds) {
+      outputViews.set(output, linkIds)
+      counters.outputLinkViewAllocations++
+    }
+    for (const linkId of linkIds ?? []) {
+      if (graph?.links.get(linkId)) counters.graphLinkReads++
+    }
+  }
+}

--- a/src/lib/litegraph/test/fixtures/cleanExtensionCompatFixture.ts
+++ b/src/lib/litegraph/test/fixtures/cleanExtensionCompatFixture.ts
@@ -1,7 +1,7 @@
 import type { LGraph } from '@/lib/litegraph/src/LGraph'
 import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
 
-export const CLEAN_EXTENSION_FIXTURE_IDENTITY = Object.freeze({
+const CLEAN_EXTENSION_FIXTURE_IDENTITY = Object.freeze({
   fixture: 'comfy.clean-extension-compat.v1',
   emulationPatternSha256:
     'a8603d20ae82775a902553058e1cea4e72ea10c0ab1664cd57ab6b5fc573a719',


### PR DESCRIPTION
## Summary

Add a deterministic clean-room compatibility-extension fixture covering unloaded, loaded-inactive, Label, reroute, dirty timer, legacy facade sweep, and combined modes.

## Proof surface

- separates wrapper/self activation from forwarded core draws
- counts registrations, listeners, timers, dirty work, facade reads, view allocations, link resolutions, and geometry reads
- asserts exact fixture revision/SHA identity
- uses real LGraph/NodeSlot facades
- preserves serialized topology and output parity
- proves idempotent install/reload, double disposal, function restoration, and timer/listener cleanup

Initial characterization shows inactive wrappers forward 1:1 with zero feature/facade work; repeated legacy sweeps retain one stable output-view identity while reads/resolutions scale.

## Verification

9/9 tests, full typecheck, Oxlint/ESLint/format, and precommit pass. Actual KJNodes/rgthree/browser cells remain follow-ups.

<!-- perf-proof-evidence:start -->
## Performance proof evidence

- Controlled local gate at `9a7a1806728b`: `./node_modules/.bin/vitest run src/lib/litegraph/src/node/cleanExtensionCompatFixture.test.ts` — **9/9 passed** in 1.76 s.
- Deterministic evidence: inactive wrappers forward core draws 1:1 with zero feature/facade work; repeated legacy sweeps retain one output-view identity while facade reads and link resolutions scale. Lifecycle counters also cover registration, listeners, timers, dirty requests, reload, and disposal.
- Scope: synthetic compatibility-fixture characterization using real LGraph/NodeSlot facades. It is not a browser frame-time measurement and does not integrate actual KJNodes or rgthree packages.
- Browser/visual evidence: applicable as a later compatibility and output-parity check, but no agent-browser run or screenshot is included. The fixture asserts serialized topology and output parity instead.
- Provenance: `research/proof-runs/proof-wave-c.md`. The tested SHA predates the current PR head; current-head CI is tracked separately.
<!-- current-head-validation:start -->
### Fresh current-head shepherd validation

- Current head `174a9cc01f02` (open): `./node_modules/.bin/vitest run src/lib/litegraph/src/node/cleanExtensionCompatFixture.test.ts` — **9/9 passed** in 2.42 s.
- CI is complete with no red checks. CodeRabbit approved this exact head.
- This is deterministic fixture validation only; no new local browser run, screenshot, or actual-extension integration was performed.
<!-- current-head-validation:end -->
<!-- perf-proof-evidence:end -->