### PR TITLE
perf: suppress repeated Vue node measurements

### DIFF
--- a/src/renderer/extensions/vueNodes/composables/useVueNodeResizeTracking.test.ts
+++ b/src/renderer/extensions/vueNodes/composables/useVueNodeResizeTracking.test.ts
@@ -44,16 +44,29 @@ const resizeObserverState = vi.hoisted(() => {
 const ROOT_GRAPH_ID = vi.hoisted<UUID>(() => 'root-graph')
 const SECOND_GRAPH_ID = vi.hoisted<UUID>(() => 'second-graph')
 
-const testState = vi.hoisted(() => ({
-  linearMode: false,
-  rootGraphId: ROOT_GRAPH_ID,
-  visibility: null as { value: 'visible' | 'hidden' } | null,
-  nodeLayouts: new Map<NodeId, NodeLayout>(),
-  reportContentSize: vi.fn(),
-  syncNodeSlotLayoutsFromDOM: vi.fn(),
-  scheduleSlotLayoutSync: vi.fn(),
-  setDirty: vi.fn()
-}))
+const testState = vi.hoisted(() => {
+  const contentSizes = new Map<string, { width: number; height: number }>()
+
+  return {
+    linearMode: false,
+    rootGraphId: ROOT_GRAPH_ID,
+    visibility: null as { value: 'visible' | 'hidden' } | null,
+    nodeLayouts: new Map<NodeId, NodeLayout>(),
+    contentSizes,
+    reportContentSize: vi.fn(
+      (
+        rootGraphId: UUID,
+        nodeId: NodeId,
+        size: { width: number; height: number }
+      ) => {
+        contentSizes.set(`${rootGraphId}:${nodeId}`, size)
+      }
+    ),
+    syncNodeSlotLayoutsFromDOM: vi.fn(),
+    scheduleSlotLayoutSync: vi.fn(),
+    setDirty: vi.fn()
+  }
+})
 
 vi.mock('@vueuse/core', () => ({
   useDocumentVisibility: () => {
@@ -81,6 +94,8 @@ vi.mock('@/composables/element/useCanvasPositionConversion', () => ({
 vi.mock('@/renderer/core/layout/store/layoutStore', () => ({
   layoutStore: {
     reportContentSize: testState.reportContentSize,
+    contentSizeOf: (rootGraphId: UUID, nodeId: NodeId) =>
+      testState.contentSizes.get(`${rootGraphId}:${nodeId}`),
     getNodeLayout: (_rootGraphId: UUID, rawNodeId: NodeId): NodeLayout | null =>
       testState.nodeLayouts.get(rawNodeId) ?? null
   }
@@ -173,6 +188,7 @@ describe('useVueNodeResizeTracking', () => {
     testState.rootGraphId = ROOT_GRAPH_ID
     if (testState.visibility) testState.visibility.value = 'visible'
     testState.nodeLayouts.clear()
+    testState.contentSizes.clear()
   })
 
   describe('deterministic resize workload baseline', () => {
@@ -345,6 +361,28 @@ describe('useVueNodeResizeTracking', () => {
 
     expect(testState.reportContentSize).toHaveBeenCalledWith(
       SECOND_GRAPH_ID,
+      nodeId,
+      {
+        width: 240,
+        height: 180 - LiteGraph.NODE_TITLE_HEIGHT
+      }
+    )
+    expect(testState.syncNodeSlotLayoutsFromDOM).toHaveBeenCalledWith(nodeId)
+  })
+
+  it('reports a fresh measurement after same-root graph reconfiguration', () => {
+    const nodeId = toNodeId('undo-redo-node')
+    const { entry } = createResizeEntry({ nodeId })
+    seedNodeLayout({ nodeId, left: 100, top: 200, width: 240, height: 180 })
+
+    resizeObserverState.callback?.([entry], createObserverMock())
+    vi.clearAllMocks()
+    testState.contentSizes.clear()
+
+    resizeObserverState.callback?.([entry], createObserverMock())
+
+    expect(testState.reportContentSize).toHaveBeenCalledWith(
+      ROOT_GRAPH_ID,
       nodeId,
       {
         width: 240,

--- a/src/renderer/extensions/vueNodes/composables/useVueNodeResizeTracking.test.ts
+++ b/src/renderer/extensions/vueNodes/composables/useVueNodeResizeTracking.test.ts
@@ -220,7 +220,7 @@ describe('useVueNodeResizeTracking', () => {
     )
 
     it.for(scales)(
-      'repeats store and slot work for stable changed-size entries at %i nodes',
+      'suppresses repeated store and slot work for stable changed-size entries at %i nodes',
       (count) => {
         const entries = createSeededEntries(count)
         resizeObserverState.callback?.(entries, createObserverMock())
@@ -242,14 +242,8 @@ describe('useVueNodeResizeTracking', () => {
         vi.clearAllMocks()
         resizeObserverState.callback?.(changedEntries, createObserverMock())
 
-        // reportContentSize stores collapsed content dimensions; it does not
-        // advance node geometry. Consequently the cache never reaches its
-        // nodeLayout-matching condition and identical follow-up entries repeat
-        // all downstream work.
-        expect(testState.reportContentSize).toHaveBeenCalledTimes(count)
-        expect(testState.syncNodeSlotLayoutsFromDOM).toHaveBeenCalledTimes(
-          count
-        )
+        expect(testState.reportContentSize).not.toHaveBeenCalled()
+        expect(testState.syncNodeSlotLayoutsFromDOM).not.toHaveBeenCalled()
       }
     )
 
@@ -338,7 +332,7 @@ describe('useVueNodeResizeTracking', () => {
     )
   })
 
-  it('currently carries a cached measurement across root graph/subgraph replacement', () => {
+  it('reports a fresh measurement after root graph/subgraph replacement', () => {
     const nodeId = toNodeId('same-local-node-id')
     const { entry } = createResizeEntry({ nodeId })
     seedNodeLayout({ nodeId, left: 100, top: 200, width: 240, height: 180 })
@@ -349,11 +343,15 @@ describe('useVueNodeResizeTracking', () => {
 
     resizeObserverState.callback?.([entry], createObserverMock())
 
-    // The current cache is scoped to element + local node ID, not root graph.
-    // Identical geometry therefore suppresses the new graph's initial content
-    // report when a DOM element survives graph replacement.
-    expect(testState.reportContentSize).not.toHaveBeenCalled()
-    expect(testState.syncNodeSlotLayoutsFromDOM).not.toHaveBeenCalled()
+    expect(testState.reportContentSize).toHaveBeenCalledWith(
+      SECOND_GRAPH_ID,
+      nodeId,
+      {
+        width: 240,
+        height: 180 - LiteGraph.NODE_TITLE_HEIGHT
+      }
+    )
+    expect(testState.syncNodeSlotLayoutsFromDOM).toHaveBeenCalledWith(nodeId)
   })
 
   it('defers hidden entries and re-observes connected elements when visible', async () => {
@@ -362,6 +360,10 @@ describe('useVueNodeResizeTracking', () => {
     document.body.append(entry.target)
     seedNodeLayout({ nodeId, left: 100, top: 200, width: 240, height: 180 })
     if (!testState.visibility) throw new Error('visibility ref not initialized')
+
+    resizeObserverState.callback?.([entry], createObserverMock())
+    expect(testState.reportContentSize).toHaveBeenCalledTimes(1)
+    vi.clearAllMocks()
 
     testState.visibility.value = 'hidden'
     await nextTick()
@@ -376,6 +378,18 @@ describe('useVueNodeResizeTracking', () => {
     await nextTick()
 
     expect(resizeObserverState.observe).toHaveBeenCalledWith(entry.target)
+
+    vi.clearAllMocks()
+    resizeObserverState.callback?.([entry], createObserverMock())
+    expect(testState.reportContentSize).toHaveBeenCalledWith(
+      ROOT_GRAPH_ID,
+      nodeId,
+      {
+        width: 240,
+        height: 180 - LiteGraph.NODE_TITLE_HEIGHT
+      }
+    )
+    expect(testState.syncNodeSlotLayoutsFromDOM).toHaveBeenCalledWith(nodeId)
     entry.target.remove()
   })
 

--- a/src/renderer/extensions/vueNodes/composables/useVueNodeResizeTracking.ts
+++ b/src/renderer/extensions/vueNodes/composables/useVueNodeResizeTracking.ts
@@ -16,13 +16,11 @@ import { useSharedCanvasPositionConversion } from '@/composables/element/useCanv
 import { LiteGraph } from '@/lib/litegraph/src/litegraph'
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import { layoutStore } from '@/renderer/core/layout/store/layoutStore'
-import type { Bounds, NodeId } from '@/renderer/core/layout/types'
+import type { Bounds, NodeId, Size } from '@/renderer/core/layout/types'
 import { toNodeId } from '@/types/nodeId'
-import {
-  isBoundsEqual,
-  isSizeEqual
-} from '@/renderer/core/layout/utils/geometry'
+import { isSizeEqual } from '@/renderer/core/layout/utils/geometry'
 import { removeNodeTitleHeight } from '@/renderer/core/layout/utils/nodeSizeUtil'
+import type { UUID } from '@/utils/uuid'
 
 import {
   scheduleSlotLayoutSync,
@@ -39,8 +37,9 @@ interface ElementBoundsUpdate {
 }
 
 interface CachedNodeMeasurement {
+  rootGraphId: UUID
   nodeId: NodeId
-  bounds: Bounds
+  size: Size
 }
 
 /**
@@ -172,27 +171,20 @@ const resizeObserver = new ResizeObserver((entries) => {
         ? layoutStore.getNodeLayout(rootGraphId, nodeId)
         : null
     const normalizedHeight = removeNodeTitleHeight(height)
+    const measuredSize = { width, height: normalizedHeight }
     const previousMeasurement = cachedNodeMeasurements.get(element)
     const hasFreshMeasurementPending =
       elementsNeedingFreshMeasurement.has(element)
     const hasMatchingCachedNodeMeasurement =
       previousMeasurement != null &&
+      previousMeasurement.rootGraphId === rootGraphId &&
       previousMeasurement.nodeId === nodeId &&
-      nodeLayout != null &&
-      isBoundsEqual(previousMeasurement.bounds, nodeLayout.bounds)
+      isSizeEqual(previousMeasurement.size, measuredSize)
 
-    // ResizeObserver emits entries where nothing changed (e.g. initial observe).
-    // Skip expensive DOM reads when this exact element/node already measured at
-    // the same normalized bounds and size.
-    if (
-      nodeLayout &&
-      !hasFreshMeasurementPending &&
-      isSizeEqual(nodeLayout.size, {
-        width,
-        height: normalizedHeight
-      }) &&
-      hasMatchingCachedNodeMeasurement
-    ) {
+    // ResizeObserver can repeat an unchanged entry (for example after an
+    // initial or changed-size delivery). Skip downstream work only when this
+    // exact element, graph, and node already reported the normalized size.
+    if (!hasFreshMeasurementPending && hasMatchingCachedNodeMeasurement) {
       continue
     }
 
@@ -219,16 +211,12 @@ const resizeObserver = new ResizeObserver((entries) => {
       width,
       height
     }
-    const normalizedBounds: Bounds = {
-      ...bounds,
-      height: normalizedHeight
-    }
-
     elementsNeedingFreshMeasurement.delete(element)
-    if (nodeId) {
+    if (nodeId && rootGraphId) {
       cachedNodeMeasurements.set(element, {
+        rootGraphId,
         nodeId,
-        bounds: normalizedBounds
+        size: measuredSize
       })
     }
 

--- a/src/renderer/extensions/vueNodes/composables/useVueNodeResizeTracking.ts
+++ b/src/renderer/extensions/vueNodes/composables/useVueNodeResizeTracking.ts
@@ -173,13 +173,19 @@ const resizeObserver = new ResizeObserver((entries) => {
     const normalizedHeight = removeNodeTitleHeight(height)
     const measuredSize = { width, height: normalizedHeight }
     const previousMeasurement = cachedNodeMeasurements.get(element)
+    const reportedContentSize =
+      nodeId && rootGraphId
+        ? layoutStore.contentSizeOf(rootGraphId, nodeId)
+        : undefined
     const hasFreshMeasurementPending =
       elementsNeedingFreshMeasurement.has(element)
     const hasMatchingCachedNodeMeasurement =
       previousMeasurement != null &&
       previousMeasurement.rootGraphId === rootGraphId &&
       previousMeasurement.nodeId === nodeId &&
-      isSizeEqual(previousMeasurement.size, measuredSize)
+      isSizeEqual(previousMeasurement.size, measuredSize) &&
+      reportedContentSize != null &&
+      isSizeEqual(reportedContentSize, measuredSize)
 
     // ResizeObserver can repeat an unchanged entry (for example after an
     // initial or changed-size delivery). Skip downstream work only when this


### PR DESCRIPTION
## Summary

Stacked on #16028. Cache the last observer measurement by element + root graph + node + normalized size, suppressing repeated identical changed-size reports and slot synchronization.

## Deterministic effect

At N=1/100/500, repeated identical changed-size batches go from N content reports + N slot syncs to 0/0. Initial and first changed batches remain N/N. Root graph/subgraph replacement and hidden-to-visible force fresh work.

Mount/unmount, queued post-unmount discard, legacy zero work, geometry-neutral content reporting, and widgets-grid behavior remain covered. Widgets-grid coalescing is intentionally separate.

## Verification

52 focused and 112 Vue-node composable tests, typecheck, full lint, formatting and diff checks pass.

<!-- perf-proof-evidence:start -->
## Performance proof evidence

### Original baseline/fix wave

- Baseline/fix pair: #16028 → this PR. Controlled local gate at `fe8c353705bc`: `./node_modules/.bin/vitest run src/renderer/core/layout/store/layoutStore.test.ts src/renderer/extensions/vueNodes/composables/useVueNodeResizeTracking.test.ts` — **52/52 passed** in 3.03 s.
- Deterministic effect at N=1/100/500: repeated equal changed-size deliveries changed from **N content reports + N slot syncs → 0 reports / 0 syncs**. Initial and first changed deliveries remain N/N; graph/subgraph replacement and hidden-to-visible transitions force fresh work.

### Current-head review fix and validation

Current head: `2da6d6050bef`.

- [`r3866723223`](https://github.com/Comfy-Org/ComfyUI_frontend/pull/16030#discussion_r3866723223) is implemented by `2da6d6050bef`: an equal ResizeObserver delivery is suppressed only when both the element cache and `layoutStore.contentSizeOf(rootGraphId, nodeId)` contain the matching normalized size.
- The same-root undo/redo-style regression clears graph-scoped content geometry, redelivers the equal observation, and asserts a fresh content report plus slot-layout synchronization.
- Current-head local gate: `./node_modules/.bin/vitest run src/renderer/extensions/vueNodes/composables/useVueNodeResizeTracking.test.ts` — **25/25 passed** in 2.07 s.

### Scope and visual evidence

This is exact deterministic operation-count and lifecycle proof, not a PerformanceHelper task/layout/frame-time delta. Real ResizeObserver delivery, geometry/hit-area parity, and frame impact remain browser-applicable, but no local agent-browser run, browser metric, or screenshot was performed in this validation.

Local provenance: `research/proof-runs/proof-wave-c.md`. The human thread remains tracked separately and was not resolved by this body update.
<!-- current-head-validation:start -->
### Fresh current-head shepherd validation

- Current head `2da6d6050bef` (**merged**): `./node_modules/.bin/vitest run src/renderer/extensions/vueNodes/composables/useVueNodeResizeTracking.test.ts` — **25/25 passed** in 2.07 s.
- CI is complete with no red checks. No submitted CodeRabbit review covers this head.
- No new local browser run or screenshot was performed. The implemented same-root cache thread remains unresolved on the merged PR by policy.
<!-- current-head-validation:end -->
<!-- perf-proof-evidence:end -->