### PR TITLE
fix(billing): gate subscribe-to-run only on Cloud

### DIFF
--- a/src/composables/useCoreCommands.test.ts
+++ b/src/composables/useCoreCommands.test.ts
@@ -55,6 +55,7 @@ vi.mock('@/scripts/app', () => {
         }
       }),
       openClipspace: vi.fn(),
+      queuePrompt: vi.fn().mockResolvedValue(true),
       refreshComboInNodes: vi.fn().mockResolvedValue(undefined),
       canvas: mockCanvas,
       rootGraph: {
@@ -130,7 +131,9 @@ vi.mock('@/services/litegraphService', () => ({
 const mockTrackHelpResourceClicked = vi.hoisted(() => vi.fn())
 vi.mock('@/platform/telemetry', () => ({
   useTelemetry: vi.fn(() => ({
-    trackHelpResourceClicked: mockTrackHelpResourceClicked
+    trackHelpResourceClicked: mockTrackHelpResourceClicked,
+    trackRunButton: vi.fn(),
+    trackWorkflowExecution: vi.fn()
   }))
 }))
 
@@ -205,11 +208,23 @@ vi.mock('@/platform/cloud/subscription/composables/useSubscription', () => ({
   }))
 }))
 
+const mockBillingState = vi.hoisted(() => ({
+  canAccessSubscriptionFeatures: true,
+  showSubscriptionDialog: vi.fn()
+}))
 vi.mock('@/composables/billing/useBillingContext', () => ({
   useBillingContext: vi.fn(() => ({
-    canAccessSubscriptionFeatures: { value: true },
-    showSubscriptionDialog: vi.fn()
+    canAccessSubscriptionFeatures: {
+      get value() {
+        return mockBillingState.canAccessSubscriptionFeatures
+      }
+    },
+    showSubscriptionDialog: mockBillingState.showSubscriptionDialog
   }))
+}))
+
+vi.mock('@/stores/queueSettingsStore', () => ({
+  useQueueSettingsStore: vi.fn(() => ({ batchCount: 1 }))
 }))
 
 describe('useCoreCommands', () => {
@@ -302,6 +317,7 @@ describe('useCoreCommands', () => {
 
   beforeEach(() => {
     mockDistributionState.isCloud = false
+    mockBillingState.canAccessSubscriptionFeatures = true
     vi.mocked(app.refreshComboInNodes).mockResolvedValue(undefined)
     mockModelStoreRefresh.mockResolvedValue(undefined)
     mockMissingModelStoreRefresh.mockResolvedValue(undefined)
@@ -659,6 +675,46 @@ describe('useCoreCommands', () => {
       expect(app.refreshComboInNodes).toHaveBeenCalled()
       expect(mockModelStoreRefresh).toHaveBeenCalled()
       expect(mockMissingModelStoreRefresh).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('Queue commands subscription gate', () => {
+    const findCmd = (id: string) =>
+      useCoreCommands().find((cmd) => cmd.id === id)!
+
+    it.for([
+      ['Comfy.QueuePrompt', 0],
+      ['Comfy.QueuePromptFront', -1]
+    ] as const)(
+      '%s queues on Local without subscription features',
+      async ([id, num]) => {
+        mockBillingState.canAccessSubscriptionFeatures = false
+
+        await findCmd(id).function()
+
+        expect(app.queuePrompt).toHaveBeenCalledWith(num, 1, expect.anything())
+        expect(mockBillingState.showSubscriptionDialog).not.toHaveBeenCalled()
+      }
+    )
+
+    it('Comfy.QueuePrompt shows the subscription dialog on Cloud without an active subscription', async () => {
+      mockDistributionState.isCloud = true
+      mockBillingState.canAccessSubscriptionFeatures = false
+
+      await findCmd('Comfy.QueuePrompt').function()
+
+      expect(app.queuePrompt).not.toHaveBeenCalled()
+      expect(mockBillingState.showSubscriptionDialog).toHaveBeenCalledWith({
+        reason: 'subscribe_to_run'
+      })
+    })
+
+    it('Comfy.QueuePrompt queues on Cloud with an active subscription', async () => {
+      mockDistributionState.isCloud = true
+
+      await findCmd('Comfy.QueuePrompt').function()
+
+      expect(app.queuePrompt).toHaveBeenCalledWith(0, 1, expect.anything())
     })
   })
 

--- a/src/composables/useCoreCommands.test.ts
+++ b/src/composables/useCoreCommands.test.ts
@@ -697,17 +697,35 @@ describe('useCoreCommands', () => {
       }
     )
 
-    it('Comfy.QueuePrompt shows the subscription dialog on Cloud without an active subscription', async () => {
-      mockDistributionState.isCloud = true
+    it('Comfy.QueueSelectedOutputNodes passes the gate on Local without subscription features', async () => {
       mockBillingState.canAccessSubscriptionFeatures = false
 
-      await findCmd('Comfy.QueuePrompt').function()
+      await findCmd('Comfy.QueueSelectedOutputNodes').function()
 
-      expect(app.queuePrompt).not.toHaveBeenCalled()
-      expect(mockBillingState.showSubscriptionDialog).toHaveBeenCalledWith({
-        reason: 'subscribe_to_run'
-      })
+      expect(mockBillingState.showSubscriptionDialog).not.toHaveBeenCalled()
+      expect(mockToastAdd).toHaveBeenCalledWith(
+        expect.objectContaining({ severity: 'error' })
+      )
     })
+
+    it.for([
+      'Comfy.QueuePrompt',
+      'Comfy.QueuePromptFront',
+      'Comfy.QueueSelectedOutputNodes'
+    ] as const)(
+      '%s shows the subscription dialog on Cloud without an active subscription',
+      async (id) => {
+        mockDistributionState.isCloud = true
+        mockBillingState.canAccessSubscriptionFeatures = false
+
+        await findCmd(id).function()
+
+        expect(app.queuePrompt).not.toHaveBeenCalled()
+        expect(mockBillingState.showSubscriptionDialog).toHaveBeenCalledWith({
+          reason: 'subscribe_to_run'
+        })
+      }
+    )
 
     it('Comfy.QueuePrompt queues on Cloud with an active subscription', async () => {
       mockDistributionState.isCloud = true

--- a/src/composables/useCoreCommands.ts
+++ b/src/composables/useCoreCommands.ts
@@ -506,7 +506,7 @@ export function useCoreCommands(): ComfyCommand[] {
         trigger_source?: ExecutionTriggerSource
       }) => {
         trackRunButton(metadata)
-        if (!canAccessSubscriptionFeatures.value) {
+        if (isCloud && !canAccessSubscriptionFeatures.value) {
           showSubscriptionDialog({ reason: 'subscribe_to_run' })
           return
         }
@@ -529,7 +529,7 @@ export function useCoreCommands(): ComfyCommand[] {
         trigger_source?: ExecutionTriggerSource
       }) => {
         trackRunButton(metadata)
-        if (!canAccessSubscriptionFeatures.value) {
+        if (isCloud && !canAccessSubscriptionFeatures.value) {
           showSubscriptionDialog({ reason: 'subscribe_to_run' })
           return
         }
@@ -551,7 +551,7 @@ export function useCoreCommands(): ComfyCommand[] {
         trigger_source?: ExecutionTriggerSource
       }) => {
         trackRunButton(metadata)
-        if (!canAccessSubscriptionFeatures.value) {
+        if (isCloud && !canAccessSubscriptionFeatures.value) {
           showSubscriptionDialog({ reason: 'subscribe_to_run' })
           return
         }


### PR DESCRIPTION
## Summary

On Local, clicking Run silently did nothing when the active workspace has no active subscription (e.g. 0 credits) — for any workflow, with or without API nodes, on any login method. Scope the subscribe-to-run gate in the queue commands to Cloud so Local always queues.

Found during 1.51 QA of the local workspace switcher ([Slack report](https://comfy-organization.slack.com/archives/C0932CGKT5K/p1787740255008649?thread_ts=1787034725.224329&cid=C0932CGKT5K)).

## Root cause

The break is an interaction of three pieces:

1. `Comfy.QueuePrompt` / `Comfy.QueuePromptFront` / `Comfy.QueueSelectedOutputNodes` return early when `canAccessSubscriptionFeatures` is false (`useCoreCommands.ts`), with no distribution check.
2. Since the local workspace switcher (#15558), Local routes billing to the workspace rail once workspace context loads (`useBillingRouting`). `useWorkspaceBilling.canAccessSubscriptionFeatures` is `statusData?.is_active ?? false` — unlike the legacy rail (`useSubscription.ts`), it has no `!isCloud → true` exemption, so an unsubscribed/zero-credit workspace reports false on Local.
3. The gate's fallback `showSubscriptionDialog` → `showPricingTable` starts with `if (!isCloud) return` (`useSubscriptionDialog.ts`), so on Local the block is invisible: no dialog, no toast, nothing.

```mermaid
flowchart LR
    A[Run click] --> B[Comfy.QueuePrompt]
    B --> C{canAccessSubscriptionFeatures?}
    C -- "Local + workspace rail, is_active=false" --> D[showSubscriptionDialog]
    D --> E["showPricingTable: if (!isCloud) return"]
    E --> F[silent no-op — Run does nothing]
    C -- true --> G[app.queuePrompt]
```

## How we change it

Gate the three queue commands with `isCloud && !canAccessSubscriptionFeatures` — subscription gating is a Cloud concept, and this mirrors the legacy rail's own `!isCloud` exemption. The gate flag itself is left untouched: flipping `useWorkspaceBilling.canAccessSubscriptionFeatures` to true on Local would regress the Plan & Credits UI, which intentionally renders the unsubscribed state on Local (#15828).

Insufficient-credit handling for partner nodes is unaffected: the backend still rejects the prompt and the error-catalog path (`insufficient_credits` → top-up dialog) handles it, so Local behavior returns to server-driven.

## AS IS / TO BE

- **AS IS**: Local + workspace with 0 credits → Run click is a silent no-op for every workflow (QA video in the Slack thread above).
- **TO BE**: Local always queues. OSS workflows run; partner-node workflows surface the backend insufficient-credits error with top-up CTA. Cloud gating is unchanged (dialog still shown when unsubscribed).

## Tests

- Unit (`useCoreCommands.test.ts`): Local + `canAccessSubscriptionFeatures=false` queues and shows no dialog (fails against the previous code); Cloud unsubscribed still blocks with the `subscribe_to_run` dialog; Cloud subscribed queues.

## Review Focus

- The guard intentionally keys on distribution (`isCloud`), not on billing-rail internals, so bootstrap-time rail flapping on Local can never block Run.

⚠️ Needs backport to `core/1.51` — this is a 1.51 release blocker.
