### PR TITLE
test(e2e): cover Run through the real button on an unsubscribed Local workspace

### DIFF
--- a/browser_tests/tests/workspace/localWorkspaceSwitcher.spec.ts
+++ b/browser_tests/tests/workspace/localWorkspaceSwitcher.spec.ts
@@ -96,6 +96,26 @@ test.describe('Local workspace switcher', { tag: '@auth' }, () => {
     ).toBe('original')
   })
 
+  test('Run button queues while the workspace has no active subscription', async ({
+    comfyPage
+  }) => {
+    const page = comfyPage.page
+    await comfyPage.settings.setSetting('Comfy.UseNewMenu', 'Top')
+    await comfyPage.workflow.loadWorkflow('default')
+    await comfyPage.toast.closeToasts()
+
+    const promptRequest = page.waitForRequest(
+      (request) =>
+        request.method() === 'POST' &&
+        new URL(request.url()).pathname.endsWith('/api/prompt')
+    )
+    await comfyPage.runButton.click()
+
+    expect((await promptRequest).postDataJSON()).toEqual(
+      expect.objectContaining({ prompt: expect.anything() })
+    )
+  })
+
   test('queues with the target workspace after a delayed switch', async ({
     comfyPage,
     workspaceSwitchTokenGate


### PR DESCRIPTION
## Summary

Adds the E2E regression test for #16032 (Run silently doing nothing on Local at 0 credits), driven through the real Run button.

## Why this was missed by E2E

`workspaceSwitcherFixture` already models the exact failing state (`is_active: false`, balance 0, Local), but the existing queue test calls `window.app.queuePrompt(0)` directly — bypassing the `Comfy.QueuePrompt` command where the subscribe-to-run gate lives. The QA-reported bug (thread: 1.51 local workspace switcher QA) lived precisely in that skipped layer.

## Changes

- **What**: New test in `localWorkspaceSwitcher.spec.ts` that loads the default workflow on an unsubscribed/zero-balance Local workspace, clicks the actual Run button, and asserts `POST /api/prompt` is issued.

## Verification

- Passes against current main (real ComfyUI backend + dev server).
- Fails against the pre-#16032 gate (`if (!canAccessSubscriptionFeatures.value)` reverted locally): Run click produces no prompt request, test times out — reproducing the QA report.
- Full `localWorkspaceSwitcher.spec.ts` (3 tests) green.

## Review Focus

- Coverage audit of this QA round: every other reported case already has unit + E2E coverage (race condition → `localWorkspaceSwitcher.spec.ts`; API-key billing → `apiKeyLoginBilling.spec.ts`; Add credits on Local → `localCreditsWorkspaceRail.spec.ts`; billing routes → `localCreditsNoSubscribeUi.spec.ts` / `cloud.spec.ts`; Cloud subscribe-to-run → `subscription.spec.ts` + unit gate tests in `useCoreCommands.test.ts`). This was the last gap.
