### PR TITLE
fix(billing): align pricing-dialog reactivation with the centralized rail policy

### DIFF
--- a/src/platform/workspace/components/UnifiedPricingTable.test.ts
+++ b/src/platform/workspace/components/UnifiedPricingTable.test.ts
@@ -29,6 +29,10 @@ const mockCurrentTeamCreditStop = ref<MockTeamStop | null>(null)
 const mockIsTeamPlan = ref(false)
 const mockCanManageSubscription = ref(true)
 const mockCanDowngradeToPersonal = ref(true)
+const mockCanReactivatePlan = ref(true)
+// the raw server capability, kept separate so a test can prove the component
+// follows the derived policy rather than this value
+const mockRawCanReactivate = ref(true)
 const mockPermissions = ref({
   canManageSubscription: true,
   canManageSubscriptionLifecycle: true,
@@ -53,7 +57,7 @@ vi.mock('@/platform/distribution/types', () => mockDistributionTypes)
 vi.mock('@/platform/workspace/composables/useBillingCapabilities', () => ({
   useBillingCapabilities: () => ({
     canSubscribeSelfServe: computed(() => mockCanManageSubscription.value),
-    canReactivate: computed(() => mockCanManageSubscription.value),
+    canReactivate: computed(() => mockRawCanReactivate.value),
     canChangeSeats: computed(() => mockCanManageSubscription.value),
     canDowngradeToPersonal: computed(() => mockCanDowngradeToPersonal.value)
   })
@@ -61,7 +65,8 @@ vi.mock('@/platform/workspace/composables/useBillingCapabilities', () => ({
 
 vi.mock('@/platform/workspace/composables/useWorkspaceUI', () => ({
   useWorkspaceUI: () => ({
-    permissions: computed(() => mockPermissions.value)
+    permissions: computed(() => mockPermissions.value),
+    canReactivatePlan: computed(() => mockCanReactivatePlan.value)
   })
 }))
 
@@ -93,6 +98,8 @@ function renderComponent(props: Record<string, unknown> = {}) {
 
 describe('UnifiedPricingTable plan CTA labels', () => {
   beforeEach(() => {
+    mockCanReactivatePlan.value = true
+    mockRawCanReactivate.value = true
     mockSubscription.value = null
     mockSubscriptionStatus.value = null
     mockCurrentPlanSlug.value = null
@@ -222,6 +229,8 @@ describe('UnifiedPricingTable team plan CTA', () => {
   }
 
   beforeEach(() => {
+    mockCanReactivatePlan.value = true
+    mockRawCanReactivate.value = true
     mockSubscription.value = null
     mockSubscriptionStatus.value = null
     mockCurrentPlanSlug.value = null
@@ -309,6 +318,20 @@ describe('UnifiedPricingTable team plan CTA', () => {
     expect(emitted().resubscribe).toBeTruthy()
   })
 
+  it('disables Resubscribe when the workspace may not reactivate', () => {
+    mockSubscription.value = {
+      tier: 'TEAM',
+      duration: 'ANNUAL',
+      isCancelled: true
+    }
+    mockCurrentTeamCreditStop.value = TEAM_STOP
+    mockCanReactivatePlan.value = false
+
+    renderComponent({ initialPlanMode: 'team' })
+
+    expect(screen.getByRole('button', { name: 'Resubscribe' })).toBeDisabled()
+  })
+
   it('lets a cancelled sub change to a different stop (not re-subscribe)', async () => {
     const user = userEvent.setup()
     mockSubscription.value = {
@@ -368,6 +391,8 @@ describe('UnifiedPricingTable outside Cloud', () => {
   }
 
   beforeEach(() => {
+    mockCanReactivatePlan.value = true
+    mockRawCanReactivate.value = true
     mockSubscription.value = null
     mockSubscriptionStatus.value = null
     mockCurrentPlanSlug.value = null

--- a/src/platform/workspace/components/UnifiedPricingTable.vue
+++ b/src/platform/workspace/components/UnifiedPricingTable.vue
@@ -469,17 +469,12 @@ const emit = defineEmits<{
 
 const { t, n } = useI18n()
 const capabilities = useBillingCapabilities()
-const { permissions } = useWorkspaceUI()
+const { permissions, canReactivatePlan } = useWorkspaceUI()
 
 const canSubscribeSelfServe = computed(() =>
   isCloud
     ? capabilities.canSubscribeSelfServe.value
     : permissions.value.canManageSubscription
-)
-const canReactivate = computed(() =>
-  isCloud
-    ? capabilities.canReactivate.value
-    : permissions.value.canManageSubscriptionLifecycle
 )
 const canChangeSeats = computed(() =>
   isCloud
@@ -770,7 +765,7 @@ const isTeamButtonDisabled = computed(() => {
   if (isLoading) return true
   if (!isTeamSubscribed.value) return !canSubscribeSelfServe.value
   if (isTeamCurrentPlanSelected.value) {
-    return !isCancelled.value || !canReactivate.value
+    return !isCancelled.value || !canReactivatePlan.value
   }
   return !canChangeSeats.value
 })
@@ -861,7 +856,7 @@ const canUsePersonalPlanAction = (tierKey: CheckoutTierKey): boolean => {
   if (!canSelectPersonalPlan.value) return false
   if (isTeamPlan.value) return canDowngradeToPersonal.value
   if (isCurrentPlan(tierKey)) {
-    return isCancelled.value && canReactivate.value
+    return isCancelled.value && canReactivatePlan.value
   }
   return hasActivePaidPlan(currentAccountTier.value)
     ? canChangeSeats.value

--- a/src/platform/workspace/composables/useSubscriptionCheckout.test.ts
+++ b/src/platform/workspace/composables/useSubscriptionCheckout.test.ts
@@ -3890,9 +3890,16 @@ describe('useSubscriptionCheckout', () => {
       mockCapabilities.value.canReactivate = false
       mockCanReactivatePlan.value = true
       const checkout = await setup()
+      mockResubscribe.mockResolvedValueOnce({
+        billing_op_id: 'op-legacy-rail',
+        status: 'active'
+      })
+      mockFetchStatus.mockResolvedValueOnce(undefined)
+      mockFetchBalance.mockResolvedValueOnce(undefined)
 
       await checkout.handleResubscribe()
 
+      expect(emit).toHaveBeenCalledWith('close', true)
       expect(mockResubscribe).toHaveBeenCalled()
     })
 

--- a/src/platform/workspace/composables/useSubscriptionCheckout.test.ts
+++ b/src/platform/workspace/composables/useSubscriptionCheckout.test.ts
@@ -175,6 +175,7 @@ const {
   mockSetActiveWorkspaceIdImpl,
   mockSetActiveWorkspaceId,
   mockPermissions,
+  mockCanReactivatePlan,
   mockCapabilities,
   mockSubscription
 } = vi.hoisted(() => ({
@@ -218,6 +219,7 @@ const {
       canDowngradeToPersonal: true
     }
   },
+  mockCanReactivatePlan: { value: true },
   mockCapabilities: {
     value: {
       canSubscribeSelfServe: true,
@@ -281,6 +283,11 @@ vi.mock('@/platform/workspace/composables/useWorkspaceUI', () => ({
     permissions: {
       get value() {
         return mockPermissions.value
+      }
+    },
+    canReactivatePlan: {
+      get value() {
+        return mockCanReactivatePlan.value
       }
     }
   })
@@ -503,6 +510,7 @@ describe('useSubscriptionCheckout', () => {
       canChangeSeats: true,
       canDowngradeToPersonal: true
     }
+    mockCanReactivatePlan.value = true
     mockSubscription.value = null
     sessionStorage.clear()
     emit = vi.fn()
@@ -3876,9 +3884,22 @@ describe('useSubscriptionCheckout', () => {
       })
     })
 
+    it('resubscribes on the legacy rail even though the server withholds can_reactivate', async () => {
+      // legacy_stripe workspaces have no capability projection row, so the
+      // raw capability is false while the workspace may still reactivate.
+      mockCapabilities.value.canReactivate = false
+      mockCanReactivatePlan.value = true
+      const checkout = await setup()
+
+      await checkout.handleResubscribe()
+
+      expect(mockResubscribe).toHaveBeenCalled()
+    })
+
     it('does not resubscribe for a member', async () => {
       mockPermissions.value.canManageSubscriptionLifecycle = false
       mockCapabilities.value.canReactivate = false
+      mockCanReactivatePlan.value = false
       const checkout = await setup()
 
       await checkout.handleResubscribe()
@@ -3889,6 +3910,7 @@ describe('useSubscriptionCheckout', () => {
 
     it('does not resubscribe when the server denies reactivation to a client-side owner', async () => {
       mockCapabilities.value.canReactivate = false
+      mockCanReactivatePlan.value = false
       const checkout = await setup()
 
       await checkout.handleResubscribe()

--- a/src/platform/workspace/composables/useSubscriptionCheckout.ts
+++ b/src/platform/workspace/composables/useSubscriptionCheckout.ts
@@ -137,13 +137,9 @@ export function useSubscriptionCheckout(
     subscription
   } = useBillingContext()
   const { shouldUseWorkspaceBilling } = useBillingRouting()
-  const {
-    canSubscribeSelfServe,
-    canReactivate,
-    canChangeSeats,
-    canDowngradeToPersonal
-  } = useBillingCapabilities()
-  const { permissions } = useWorkspaceUI()
+  const { canSubscribeSelfServe, canChangeSeats, canDowngradeToPersonal } =
+    useBillingCapabilities()
+  const { permissions, canReactivatePlan } = useWorkspaceUI()
   const telemetry = useTelemetry()
   const billingOperationStore = useBillingOperationStore()
   const workspaceStore = useTeamWorkspaceStore()
@@ -1459,12 +1455,7 @@ export function useSubscriptionCheckout(
   }
 
   async function handleResubscribe() {
-    if (
-      !(isCloud
-        ? canReactivate.value
-        : permissions.value.canManageSubscriptionLifecycle)
-    )
-      return
+    if (!canReactivatePlan.value) return
 
     const source = 'pricing_dialog' as const
 


### PR DESCRIPTION
Closes #16033.

### The bug

`UnifiedPricingTable` and `useSubscriptionCheckout.handleResubscribe` gated reactivation on `isCloud` plus the **raw** `can_reactivate`, ignoring the billing rail:

```ts
const canReactivate = computed(() =>
  isCloud ? capabilities.canReactivate.value : permissions.value.canManageSubscriptionLifecycle
)
```

`legacy_stripe` workspaces have no capability projection row, so on Cloud the raw capability is `false` for them. A cancelled `legacy_stripe` customer therefore saw the pricing dialog's reactivate CTA **disabled**, and `handleResubscribe` returned early even if they got there.

This is the same defect #15967 fixed for the workspace surfaces — the pricing dialog is the primary resubscribe path, so it matters more.

### The fix

Both sites now consume `canReactivatePlan` from `useWorkspaceUI`, the shared rail-aware policy introduced in #15967. Both files already imported `useWorkspaceUI`, so this removes code rather than adding a layer.

### Verification

Each new test was checked against the unfixed code, not just run green:

- **`useSubscriptionCheckout`** — new case: raw `can_reactivate` false, derived policy true → resubscribe proceeds. Fails against the old expression.
- **`UnifiedPricingTable`** — new case: derived policy false → the Resubscribe CTA is disabled. Fails against the old expression.
- Two existing checkout cases drove the raw capability and now drive the derived value; their intent is unchanged.
- The pricing-table mock previously wired `canReactivate` to the same ref as `canSubscribeSelfServe`, so raw and derived could not diverge. It now has its own ref, which is what makes the new case meaningful.

I also wrote and then **removed** a third test — a legacy-rail pricing case that passed against the unfixed code because its scenario never reached the reactivate branch. A test that passes against the bug is worse than no test.

`pnpm typecheck` clean; 150 passing across the two affected files; full suite 1317/1318 with only the 12 pre-existing `check-binary-size` environment failures.
