### PR TITLE
fix(billing): stop claiming a saved card exists in the top-up confirm step

### DIFF
--- a/browser_tests/tests/dialogs/topUpNoPaymentMethod.spec.ts
+++ b/browser_tests/tests/dialogs/topUpNoPaymentMethod.spec.ts
@@ -1,6 +1,11 @@
 import { expect } from '@playwright/test'
 import type { Page } from '@playwright/test'
 
+import type {
+  PaymentPortalResponse,
+  SavedPaymentMethod
+} from '@comfyorg/ingest-types'
+
 import { TopUpCreditsDialog } from '@e2e/fixtures/components/TopUpCreditsDialog'
 import { TestIds } from '@e2e/fixtures/selectors'
 import { workspaceRailAuthFixture as test } from '@e2e/fixtures/workspaceRailAuthFixture'
@@ -32,8 +37,20 @@ test.describe('Top-up without a saved payment method', () => {
   }) => {
     const page = comfyPage.page
     await page.route('**/api/billing/payment-methods', (route) =>
-      route.fulfill({ json: [] })
+      route.fulfill({ json: [] satisfies SavedPaymentMethod[] })
     )
+    await page.route('**/api/billing/payment-portal', (route) =>
+      route.fulfill({
+        json: {
+          url: 'https://billing.example/portal'
+        } satisfies PaymentPortalResponse
+      })
+    )
+    await page
+      .context()
+      .route('https://billing.example/**', (route) =>
+        route.fulfill({ contentType: 'text/html', body: 'portal stub' })
+      )
     await page.route('**/api/billing/topup', (route) =>
       route.fulfill({
         status: 400,
@@ -56,9 +73,12 @@ test.describe('Top-up without a saved payment method', () => {
         "You'll be asked to add a payment method to complete this purchase."
       )
     ).toBeVisible()
-    await expect(
-      topUpDialog.root.getByRole('button', { name: 'Manage billing' })
-    ).toBeVisible()
+    const [portalPage] = await Promise.all([
+      page.context().waitForEvent('page'),
+      topUpDialog.root.getByRole('button', { name: 'Manage billing' }).click()
+    ])
+    expect(portalPage.url()).toBe('https://billing.example/portal')
+    await portalPage.close()
 
     await topUpDialog.root.getByRole('button', { name: 'Pay $50.00' }).click()
 
@@ -75,7 +95,15 @@ test.describe('Top-up without a saved payment method', () => {
     const page = comfyPage.page
     await page.route('**/api/billing/payment-methods', (route) =>
       route.fulfill({
-        json: [{ id: 'pm-1', brand: 'visa', last4: '4242', is_default: true }]
+        json: [
+          {
+            id: 'pm-1',
+            type: 'card',
+            brand: 'visa',
+            last4: '4242',
+            is_default: true
+          }
+        ] satisfies SavedPaymentMethod[]
       })
     )
 

--- a/browser_tests/tests/dialogs/topUpNoPaymentMethod.spec.ts
+++ b/browser_tests/tests/dialogs/topUpNoPaymentMethod.spec.ts
@@ -77,7 +77,7 @@ test.describe('Top-up without a saved payment method', () => {
       page.context().waitForEvent('page'),
       topUpDialog.root.getByRole('button', { name: 'Manage billing' }).click()
     ])
-    expect(portalPage.url()).toBe('https://billing.example/portal')
+    await expect(portalPage).toHaveURL('https://billing.example/portal')
     await portalPage.close()
 
     await topUpDialog.root.getByRole('button', { name: 'Pay $50.00' }).click()

--- a/browser_tests/tests/dialogs/topUpNoPaymentMethod.spec.ts
+++ b/browser_tests/tests/dialogs/topUpNoPaymentMethod.spec.ts
@@ -1,0 +1,97 @@
+import { expect } from '@playwright/test'
+import type { Page } from '@playwright/test'
+
+import { TopUpCreditsDialog } from '@e2e/fixtures/components/TopUpCreditsDialog'
+import { TestIds } from '@e2e/fixtures/selectors'
+import { workspaceRailAuthFixture as test } from '@e2e/fixtures/workspaceRailAuthFixture'
+
+/**
+ * Regression coverage for the 1.51 QA finding: with no payment method saved,
+ * the confirm step claimed "Your saved payment method is charged immediately"
+ * and a refused purchase surfaced the raw NO_PAYMENT_METHOD server error with
+ * no path forward (FE-1908).
+ *
+ * Entered through the user popover like a real user: workspace-rail routing
+ * needs the billing context loaded before the dialog opens, and the popover's
+ * Add credits button only renders once it is.
+ */
+test.describe('Top-up without a saved payment method', () => {
+  async function openTopUpDialog(page: Page) {
+    const topUpDialog = new TopUpCreditsDialog(page)
+    await page.getByTestId(TestIds.user.currentUserButton).click()
+    await page
+      .getByTestId(TestIds.user.currentUserPopover)
+      .getByTestId('add-credits-button')
+      .click()
+    await expect(topUpDialog.heading).toBeVisible()
+    return topUpDialog
+  }
+
+  test('offers Manage billing and explains a refused purchase', async ({
+    comfyPage
+  }) => {
+    const page = comfyPage.page
+    await page.route('**/api/billing/payment-methods', (route) =>
+      route.fulfill({ json: [] })
+    )
+    await page.route('**/api/billing/topup', (route) =>
+      route.fulfill({
+        status: 400,
+        json: {
+          code: 'NO_PAYMENT_METHOD',
+          message:
+            'No default payment method is selected. Please select one in the payment portal.'
+        }
+      })
+    )
+
+    const topUpDialog = await openTopUpDialog(page)
+
+    await topUpDialog.root
+      .getByRole('button', { name: 'Add credits', exact: true })
+      .click()
+
+    await expect(
+      topUpDialog.root.getByText(
+        "You'll be asked to add a payment method to complete this purchase."
+      )
+    ).toBeVisible()
+    await expect(
+      topUpDialog.root.getByRole('button', { name: 'Manage billing' })
+    ).toBeVisible()
+
+    await topUpDialog.root.getByRole('button', { name: 'Pay $50.00' }).click()
+
+    await expect(
+      page
+        .locator('.p-toast-message.p-toast-message-error')
+        .getByText(/Add one via Settings → Plan & Credits → Manage billing/)
+    ).toBeVisible()
+  })
+
+  test('keeps the saved-card note when a payment method is on file', async ({
+    comfyPage
+  }) => {
+    const page = comfyPage.page
+    await page.route('**/api/billing/payment-methods', (route) =>
+      route.fulfill({
+        json: [{ id: 'pm-1', brand: 'visa', last4: '4242', is_default: true }]
+      })
+    )
+
+    const topUpDialog = await openTopUpDialog(page)
+
+    await topUpDialog.root
+      .getByRole('button', { name: 'Add credits', exact: true })
+      .click()
+
+    await expect(
+      topUpDialog.root.getByText(
+        'Your saved payment method is charged immediately.'
+      )
+    ).toBeVisible()
+    await expect(
+      topUpDialog.root.getByRole('button', { name: 'Manage billing' })
+    ).toHaveCount(0)
+  })
+})

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2689,6 +2689,7 @@
       "chargedImmediatelyNote": "Your saved payment method is charged immediately.",
       "paymentDetailsRequiredNote": "You'll be asked to add a payment method to complete this purchase.",
       "noPaymentMethodError": "No payment method is saved for this workspace. Add one via Settings → Plan & Credits → Manage billing, then retry the top-up.",
+      "manageBillingError": "Failed to open the billing portal. Please try again.",
       "confirmSubtitle": "Credits are added to this workspace as soon as payment completes.",
       "confirmTitle": "Confirm",
       "howManyCredits": "How many credits would you like to add?",

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2687,6 +2687,7 @@
       "insufficientWorkflowMessage": "You don't have enough credits to run this workflow.",
       "creditsDescription": "Credits are used to run workflows or partner nodes.",
       "chargedImmediatelyNote": "Your saved payment method is charged immediately.",
+      "paymentDetailsRequiredNote": "You'll be asked to add a payment method to complete this purchase.",
       "confirmSubtitle": "Credits are added to this workspace as soon as payment completes.",
       "confirmTitle": "Confirm",
       "howManyCredits": "How many credits would you like to add?",

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2688,6 +2688,7 @@
       "creditsDescription": "Credits are used to run workflows or partner nodes.",
       "chargedImmediatelyNote": "Your saved payment method is charged immediately.",
       "paymentDetailsRequiredNote": "You'll be asked to add a payment method to complete this purchase.",
+      "noPaymentMethodError": "No payment method is saved for this workspace. Add one via Settings → Plan & Credits → Manage billing, then retry the top-up.",
       "confirmSubtitle": "Credits are added to this workspace as soon as payment completes.",
       "confirmTitle": "Confirm",
       "howManyCredits": "How many credits would you like to add?",

--- a/src/platform/workspace/components/TopUpCreditsDialogContentWorkspace.test.ts
+++ b/src/platform/workspace/components/TopUpCreditsDialogContentWorkspace.test.ts
@@ -11,7 +11,12 @@ import TopUpCreditsDialogContentWorkspace from './TopUpCreditsDialogContentWorks
 
 const mockFetchBalance = vi.fn()
 const mockFetchStatus = vi.fn()
-const mockManageSubscription = vi.fn()
+const mockManageSubscription = vi.fn<() => Promise<void>>()
+const mockReportError = vi.hoisted(() => vi.fn())
+
+vi.mock('@/platform/telemetry/reportError', () => ({
+  reportError: mockReportError
+}))
 const mockTopup =
   vi.fn<(amountCents: number) => Promise<CreateTopupResponse | void>>()
 const mockStartOperation = vi.fn()
@@ -169,6 +174,8 @@ const i18n = createI18n({
             "You'll be asked to add a payment method to complete this purchase.",
           noPaymentMethodError:
             'No payment method is saved for this workspace. Add one via Settings → Plan & Credits → Manage billing, then retry the top-up.',
+          manageBillingError:
+            'Failed to open the billing portal. Please try again.',
           confirmSubtitle:
             'Credits are added to this workspace as soon as payment completes.',
           confirmTitle: 'Confirm',
@@ -353,6 +360,30 @@ describe('TopUpCreditsDialogContentWorkspace', () => {
     )
 
     expect(mockManageSubscription).toHaveBeenCalledTimes(1)
+  })
+
+  it('reports and surfaces a billing-portal opening failure', async () => {
+    setHasSavedPaymentMethod(false)
+    const failure = new Error('portal down')
+    mockManageSubscription.mockRejectedValue(failure)
+
+    renderDialog()
+    await clickAddCredits()
+
+    await userEvent.click(
+      await screen.findByRole('button', { name: 'Manage billing' })
+    )
+
+    await waitFor(() =>
+      expect(mockReportError).toHaveBeenCalledWith(failure, {
+        errorType: 'billing_portal_open_failure'
+      })
+    )
+    expect(mockToastAdd).toHaveBeenCalledWith(
+      expect.objectContaining({
+        summary: 'Failed to open the billing portal. Please try again.'
+      })
+    )
   })
 
   it('explains how to add a payment method when the purchase is refused', async () => {

--- a/src/platform/workspace/components/TopUpCreditsDialogContentWorkspace.test.ts
+++ b/src/platform/workspace/components/TopUpCreditsDialogContentWorkspace.test.ts
@@ -4,6 +4,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
 import { createI18n } from 'vue-i18n'
 
+import enMessages from '@/locales/en/main.json' with { type: 'json' }
+
 import { WorkspaceApiError } from '@/platform/workspace/api/workspaceApi'
 import type { CreateTopupResponse } from '@/platform/workspace/api/workspaceApi'
 
@@ -141,58 +143,7 @@ vi.mock('@/base/credits/comfyCredits', () => ({
 const i18n = createI18n({
   legacy: false,
   locale: 'en',
-  messages: {
-    en: {
-      g: { back: 'Back', close: 'Close' },
-      subscription: {
-        addCredits: 'Add credits',
-        manageBilling: 'Manage billing',
-        preview: {
-          completeVerification: 'Complete verification',
-          totalDueToday: 'Total due today'
-        }
-      },
-      credits: {
-        topUp: {
-          addMoreCredits: 'Add more credits',
-          addMoreCreditsToRun: 'Add more credits to run',
-          selectAmount: 'Select amount',
-          youPay: 'You pay',
-          youGet: 'You get',
-          purchaseSuccess: 'Credits added successfully!',
-          purchaseError: 'Purchase Failed',
-          purchaseErrorDetail: 'Failed to purchase credits: {error}',
-          unknownError: 'An unknown error occurred',
-          minRequired: 'Minimum required',
-          maxAllowed: 'Maximum allowed',
-          needMore: 'Need more?',
-          contactUs: 'Contact us',
-          viewPricing: 'View pricing',
-          insufficientWorkflowMessage: 'Insufficient credits',
-          chargedImmediatelyNote: 'Your saved card is charged immediately.',
-          paymentDetailsRequiredNote:
-            "You'll be asked to add a payment method to complete this purchase.",
-          noPaymentMethodError:
-            'No payment method is saved for this workspace. Add one via Settings → Plan & Credits → Manage billing, then retry the top-up.',
-          manageBillingError:
-            'Failed to open the billing portal. Please try again.',
-          confirmSubtitle:
-            'Credits are added to this workspace as soon as payment completes.',
-          confirmTitle: 'Confirm',
-          payAmount: 'Pay {amount}',
-          verifyBody:
-            'Your bank requires additional verification to complete this payment.',
-          verifyTitle: 'Verify your payment'
-        }
-      },
-      billingOperation: {
-        authenticationFailedDetail: 'Verification failed.',
-        authenticationManagerRequired: 'Ask a workspace manager for help.',
-        retryVerification: 'Try verification again',
-        reconciliationDetail: 'Contact support with operation ID'
-      }
-    }
-  }
+  messages: { en: enMessages }
 })
 
 function topupResponse(
@@ -331,7 +282,9 @@ describe('TopUpCreditsDialogContentWorkspace', () => {
     await clickAddCredits()
 
     expect(
-      await screen.findByText('Your saved card is charged immediately.')
+      await screen.findByText(
+        'Your saved payment method is charged immediately.'
+      )
     ).toBeInTheDocument()
   })
 
@@ -417,7 +370,9 @@ describe('TopUpCreditsDialogContentWorkspace', () => {
     await clickAddCredits()
 
     expect(
-      await screen.findByText('Your saved card is charged immediately.')
+      await screen.findByText(
+        'Your saved payment method is charged immediately.'
+      )
     ).toBeInTheDocument()
   })
 
@@ -524,7 +479,7 @@ describe('TopUpCreditsDialogContentWorkspace', () => {
       screen.getByText('Your bank rejected the verification.')
     ).toBeInTheDocument()
     await userEvent.click(
-      screen.getByRole('button', { name: 'Try verification again' })
+      screen.getByRole('button', { name: 'Retry verification' })
     )
     expect(mockRetryPaymentAuthentication).toHaveBeenCalledWith('op-retry')
   })
@@ -539,7 +494,7 @@ describe('TopUpCreditsDialogContentWorkspace', () => {
     renderDialog()
 
     expect(
-      screen.getByText('Contact support with operation ID')
+      screen.getByText(/Contact support and include this operation ID/)
     ).toBeInTheDocument()
     expect(screen.getByText('op-reconcile')).toBeInTheDocument()
     expect(

--- a/src/platform/workspace/components/TopUpCreditsDialogContentWorkspace.test.ts
+++ b/src/platform/workspace/components/TopUpCreditsDialogContentWorkspace.test.ts
@@ -363,19 +363,6 @@ describe('TopUpCreditsDialogContentWorkspace', () => {
     )
   })
 
-  it('keeps the saved-card note when the payment method lookup fails', async () => {
-    setHasSavedPaymentMethod(null)
-
-    renderDialog()
-    await clickAddCredits()
-
-    expect(
-      await screen.findByText(
-        'Your saved payment method is charged immediately.'
-      )
-    ).toBeInTheDocument()
-  })
-
   it('allows returning to amount selection before payment', async () => {
     renderDialog()
     await clickAddCredits()

--- a/src/platform/workspace/components/TopUpCreditsDialogContentWorkspace.test.ts
+++ b/src/platform/workspace/components/TopUpCreditsDialogContentWorkspace.test.ts
@@ -168,7 +168,7 @@ const i18n = createI18n({
           paymentDetailsRequiredNote:
             "You'll be asked to add a payment method to complete this purchase.",
           noPaymentMethodError:
-            'No payment method is saved for this workspace. Add one via Manage billing, then retry.',
+            'No payment method is saved for this workspace. Add one via Settings → Plan & Credits → Manage billing, then retry the top-up.',
           confirmSubtitle:
             'Credits are added to this workspace as soon as payment completes.',
           confirmTitle: 'Confirm',
@@ -373,7 +373,7 @@ describe('TopUpCreditsDialogContentWorkspace', () => {
       expect(mockToastAdd).toHaveBeenCalledWith(
         expect.objectContaining({
           detail:
-            'No payment method is saved for this workspace. Add one via Manage billing, then retry.'
+            'No payment method is saved for this workspace. Add one via Settings → Plan & Credits → Manage billing, then retry the top-up.'
         })
       )
     )

--- a/src/platform/workspace/components/TopUpCreditsDialogContentWorkspace.test.ts
+++ b/src/platform/workspace/components/TopUpCreditsDialogContentWorkspace.test.ts
@@ -11,6 +11,7 @@ import TopUpCreditsDialogContentWorkspace from './TopUpCreditsDialogContentWorks
 
 const mockFetchBalance = vi.fn()
 const mockFetchStatus = vi.fn()
+const mockManageSubscription = vi.fn()
 const mockTopup =
   vi.fn<(amountCents: number) => Promise<CreateTopupResponse | void>>()
 const mockStartOperation = vi.fn()
@@ -65,6 +66,7 @@ vi.mock('@/composables/billing/useBillingContext', () => ({
   useBillingContext: () => ({
     fetchBalance: mockFetchBalance,
     fetchStatus: mockFetchStatus,
+    manageSubscription: mockManageSubscription,
     topup: (amountCents: number) => mockTopup(amountCents)
   })
 }))
@@ -139,6 +141,7 @@ const i18n = createI18n({
       g: { back: 'Back', close: 'Close' },
       subscription: {
         addCredits: 'Add credits',
+        manageBilling: 'Manage billing',
         preview: {
           completeVerification: 'Complete verification',
           totalDueToday: 'Total due today'
@@ -164,6 +167,8 @@ const i18n = createI18n({
           chargedImmediatelyNote: 'Your saved card is charged immediately.',
           paymentDetailsRequiredNote:
             "You'll be asked to add a payment method to complete this purchase.",
+          noPaymentMethodError:
+            'No payment method is saved for this workspace. Add one via Manage billing, then retry.',
           confirmSubtitle:
             'Credits are added to this workspace as soon as payment completes.',
           confirmTitle: 'Confirm',
@@ -334,6 +339,44 @@ describe('TopUpCreditsDialogContentWorkspace', () => {
         "You'll be asked to add a payment method to complete this purchase."
       )
     ).toBeInTheDocument()
+  })
+
+  it('opens the billing portal from the no-payment-method note', async () => {
+    setHasSavedPaymentMethod(false)
+    mockManageSubscription.mockResolvedValue(undefined)
+
+    renderDialog()
+    await clickAddCredits()
+
+    await userEvent.click(
+      await screen.findByRole('button', { name: 'Manage billing' })
+    )
+
+    expect(mockManageSubscription).toHaveBeenCalledTimes(1)
+  })
+
+  it('explains how to add a payment method when the purchase is refused', async () => {
+    setHasSavedPaymentMethod(false)
+    mockTopup.mockRejectedValue(
+      new WorkspaceApiError(
+        'No default payment method is selected.',
+        400,
+        'NO_PAYMENT_METHOD'
+      )
+    )
+
+    renderDialog()
+    await clickAddCredits()
+    await userEvent.click(screen.getByRole('button', { name: 'Pay $50.00' }))
+
+    await waitFor(() =>
+      expect(mockToastAdd).toHaveBeenCalledWith(
+        expect.objectContaining({
+          detail:
+            'No payment method is saved for this workspace. Add one via Manage billing, then retry.'
+        })
+      )
+    )
   })
 
   it('keeps the saved-card note when the payment method lookup fails', async () => {

--- a/src/platform/workspace/components/TopUpCreditsDialogContentWorkspace.test.ts
+++ b/src/platform/workspace/components/TopUpCreditsDialogContentWorkspace.test.ts
@@ -27,6 +27,23 @@ const mockDistributionTypes = vi.hoisted(() => ({ isCloud: true }))
 
 vi.mock('@/platform/distribution/types', () => mockDistributionTypes)
 
+const mockHasSavedPaymentMethod = vi.hoisted(() => ({
+  ref: undefined as { value: boolean | null } | undefined
+}))
+
+vi.mock(
+  '@/platform/workspace/composables/useHasSavedPaymentMethod',
+  async () => {
+    const { ref } = await import('vue')
+    mockHasSavedPaymentMethod.ref = ref<boolean | null>(null)
+    return {
+      useHasSavedPaymentMethod: () => ({
+        hasSavedPaymentMethod: mockHasSavedPaymentMethod.ref
+      })
+    }
+  }
+)
+
 interface MockTopupOperation {
   opId: string
   status: 'pending' | 'reconciliation_needed'
@@ -145,6 +162,8 @@ const i18n = createI18n({
           viewPricing: 'View pricing',
           insufficientWorkflowMessage: 'Insufficient credits',
           chargedImmediatelyNote: 'Your saved card is charged immediately.',
+          paymentDetailsRequiredNote:
+            "You'll be asked to add a payment method to complete this purchase.",
           confirmSubtitle:
             'Credits are added to this workspace as soon as payment completes.',
           confirmTitle: 'Confirm',
@@ -209,6 +228,13 @@ function setTopupActionOperation(operation: MockTopupOperation | undefined) {
   mockBillingOperationState.topupActionOperation.value = operation
 }
 
+function setHasSavedPaymentMethod(value: boolean | null) {
+  if (!mockHasSavedPaymentMethod.ref) {
+    throw new Error('Payment method mock not initialized')
+  }
+  mockHasSavedPaymentMethod.ref.value = value
+}
+
 async function clickAddCredits() {
   const user = userEvent.setup()
   await user.click(screen.getByRole('button', { name: 'Add credits' }))
@@ -222,6 +248,7 @@ describe('TopUpCreditsDialogContentWorkspace', () => {
     setTopupActionOperation(undefined)
     mockFetchBalance.mockResolvedValue(undefined)
     mockFetchStatus.mockResolvedValue(undefined)
+    setHasSavedPaymentMethod(true)
     mockStartOperation.mockImplementation(() => {
       setIsAddingCredits(true)
       return new Promise(() => {})
@@ -284,6 +311,40 @@ describe('TopUpCreditsDialogContentWorkspace', () => {
     expect(screen.getByText('$50.00')).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Pay $50.00' })).toBeEnabled()
     expect(mockTopup).not.toHaveBeenCalled()
+  })
+
+  it('shows the saved-card note when a payment method is on file', async () => {
+    renderDialog()
+
+    await clickAddCredits()
+
+    expect(
+      await screen.findByText('Your saved card is charged immediately.')
+    ).toBeInTheDocument()
+  })
+
+  it('asks for payment details when no payment method is saved', async () => {
+    setHasSavedPaymentMethod(false)
+
+    renderDialog()
+    await clickAddCredits()
+
+    expect(
+      await screen.findByText(
+        "You'll be asked to add a payment method to complete this purchase."
+      )
+    ).toBeInTheDocument()
+  })
+
+  it('keeps the saved-card note when the payment method lookup fails', async () => {
+    setHasSavedPaymentMethod(null)
+
+    renderDialog()
+    await clickAddCredits()
+
+    expect(
+      await screen.findByText('Your saved card is charged immediately.')
+    ).toBeInTheDocument()
   })
 
   it('allows returning to amount selection before payment', async () => {

--- a/src/platform/workspace/components/TopUpCreditsDialogContentWorkspace.vue
+++ b/src/platform/workspace/components/TopUpCreditsDialogContentWorkspace.vue
@@ -287,6 +287,7 @@ import { isCloud } from '@/platform/distribution/types'
 import { clearTopupTracking } from '@/platform/telemetry/topupTracker'
 import { categorizeBillingApiError } from '@/platform/telemetry/utils/billingFailureCategory'
 import { useSettingsDialog } from '@/platform/settings/composables/useSettingsDialog'
+import { reportError } from '@/platform/telemetry/reportError'
 import { WorkspaceApiError } from '@/platform/workspace/api/workspaceApi'
 import { useBillingCapabilities } from '@/platform/workspace/composables/useBillingCapabilities'
 import { useHasSavedPaymentMethod } from '@/platform/workspace/composables/useHasSavedPaymentMethod'
@@ -443,7 +444,14 @@ function handlePrimaryAction() {
 }
 
 function openManageBilling() {
-  void manageSubscription().catch(() => {})
+  void manageSubscription().catch((error) => {
+    reportError(error, { errorType: 'billing_portal_open_failure' })
+    toast.add({
+      severity: 'error',
+      summary: t('credits.topUp.manageBillingError'),
+      life: 5000
+    })
+  })
 }
 
 function openTopupVerification() {

--- a/src/platform/workspace/components/TopUpCreditsDialogContentWorkspace.vue
+++ b/src/platform/workspace/components/TopUpCreditsDialogContentWorkspace.vue
@@ -65,7 +65,10 @@
             {{ displayTotal }}
           </span>
         </div>
-        <p class="m-0 text-xs text-muted-foreground">
+        <p
+          v-if="hasSavedPaymentMethod !== null"
+          class="m-0 text-xs text-muted-foreground"
+        >
           {{ paymentNote }}
           <button
             v-if="hasSavedPaymentMethod === false"
@@ -353,9 +356,9 @@ const pricingUrl = computed(() =>
 )
 
 const paymentNote = computed(() =>
-  hasSavedPaymentMethod.value === false
-    ? t('credits.topUp.paymentDetailsRequiredNote')
-    : t('credits.topUp.chargedImmediatelyNote')
+  hasSavedPaymentMethod.value
+    ? t('credits.topUp.chargedImmediatelyNote')
+    : t('credits.topUp.paymentDetailsRequiredNote')
 )
 
 const creditsModel = computed({

--- a/src/platform/workspace/components/TopUpCreditsDialogContentWorkspace.vue
+++ b/src/platform/workspace/components/TopUpCreditsDialogContentWorkspace.vue
@@ -67,6 +67,13 @@
         </div>
         <p class="m-0 text-xs text-muted-foreground">
           {{ paymentNote }}
+          <button
+            v-if="hasSavedPaymentMethod === false"
+            class="cursor-pointer border-none bg-transparent p-0 text-xs text-base-foreground underline"
+            @click="openManageBilling"
+          >
+            {{ $t('subscription.manageBilling') }}
+          </button>
         </p>
       </div>
     </template>
@@ -280,6 +287,7 @@ import { isCloud } from '@/platform/distribution/types'
 import { clearTopupTracking } from '@/platform/telemetry/topupTracker'
 import { categorizeBillingApiError } from '@/platform/telemetry/utils/billingFailureCategory'
 import { useSettingsDialog } from '@/platform/settings/composables/useSettingsDialog'
+import { WorkspaceApiError } from '@/platform/workspace/api/workspaceApi'
 import { useBillingCapabilities } from '@/platform/workspace/composables/useBillingCapabilities'
 import { useHasSavedPaymentMethod } from '@/platform/workspace/composables/useHasSavedPaymentMethod'
 import { useBillingOperationStore } from '@/platform/workspace/stores/billingOperationStore'
@@ -296,7 +304,8 @@ const settingsDialog = useSettingsDialog()
 const telemetry = useTelemetry()
 const toast = useToast()
 const { buildDocsUrl, docsPaths } = useExternalLink()
-const { fetchBalance, fetchStatus, topup } = useBillingContext()
+const { fetchBalance, fetchStatus, manageSubscription, topup } =
+  useBillingContext()
 const { canTopUp } = useBillingCapabilities()
 
 const billingOperationStore = useBillingOperationStore()
@@ -431,6 +440,10 @@ function handlePrimaryAction() {
     return
   }
   void handleBuy()
+}
+
+function openManageBilling() {
+  void manageSubscription().catch(() => {})
 }
 
 function openTopupVerification() {
@@ -591,13 +604,19 @@ function reportPurchaseError(
       error === undefined ? 'unknown' : categorizeBillingApiError(error),
     duration_ms: Date.now() - attemptStartedAt
   })
+  const missingPaymentMethod =
+    error instanceof WorkspaceApiError && error.code === 'NO_PAYMENT_METHOD'
   toast.add({
     severity: 'error',
     summary: t('credits.topUp.purchaseError'),
-    detail: t('credits.topUp.purchaseErrorDetail', {
-      error:
-        error instanceof Error ? error.message : t('credits.topUp.unknownError')
-    })
+    detail: missingPaymentMethod
+      ? t('credits.topUp.noPaymentMethodError')
+      : t('credits.topUp.purchaseErrorDetail', {
+          error:
+            error instanceof Error
+              ? error.message
+              : t('credits.topUp.unknownError')
+        })
   })
 }
 </script>

--- a/src/platform/workspace/components/TopUpCreditsDialogContentWorkspace.vue
+++ b/src/platform/workspace/components/TopUpCreditsDialogContentWorkspace.vue
@@ -66,7 +66,7 @@
           </span>
         </div>
         <p class="m-0 text-xs text-muted-foreground">
-          {{ $t('credits.topUp.chargedImmediatelyNote') }}
+          {{ paymentNote }}
         </p>
       </div>
     </template>
@@ -281,6 +281,7 @@ import { clearTopupTracking } from '@/platform/telemetry/topupTracker'
 import { categorizeBillingApiError } from '@/platform/telemetry/utils/billingFailureCategory'
 import { useSettingsDialog } from '@/platform/settings/composables/useSettingsDialog'
 import { useBillingCapabilities } from '@/platform/workspace/composables/useBillingCapabilities'
+import { useHasSavedPaymentMethod } from '@/platform/workspace/composables/useHasSavedPaymentMethod'
 import { useBillingOperationStore } from '@/platform/workspace/stores/billingOperationStore'
 import { useDialogStore } from '@/stores/dialogStore'
 import { cn } from '@comfyorg/tailwind-utils'
@@ -334,9 +335,17 @@ const step = ref<'amount' | 'confirm' | 'verifying'>(
   topupOperation.value && canTopUp.value ? 'verifying' : 'amount'
 )
 
+const { hasSavedPaymentMethod } = useHasSavedPaymentMethod()
+
 // Computed
 const pricingUrl = computed(() =>
   buildDocsUrl(docsPaths.partnerNodesPricing, { includeLocale: true })
+)
+
+const paymentNote = computed(() =>
+  hasSavedPaymentMethod.value === false
+    ? t('credits.topUp.paymentDetailsRequiredNote')
+    : t('credits.topUp.chargedImmediatelyNote')
 )
 
 const creditsModel = computed({

--- a/src/platform/workspace/composables/useHasSavedPaymentMethod.test.ts
+++ b/src/platform/workspace/composables/useHasSavedPaymentMethod.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from 'vitest'
+import { nextTick } from 'vue'
+
+import { useHasSavedPaymentMethod } from './useHasSavedPaymentMethod'
+
+const mockListSavedPaymentMethods = vi.hoisted(() =>
+  vi.fn<() => Promise<{ id: string }[]>>()
+)
+
+vi.mock('@/platform/workspace/api/workspaceApi', () => ({
+  workspaceApi: {
+    listSavedPaymentMethods: mockListSavedPaymentMethods
+  }
+}))
+
+async function flushLookup() {
+  await Promise.resolve()
+  await nextTick()
+}
+
+describe('useHasSavedPaymentMethod', () => {
+  it('starts unknown before the lookup resolves', () => {
+    mockListSavedPaymentMethods.mockResolvedValue([])
+
+    const { hasSavedPaymentMethod } = useHasSavedPaymentMethod()
+
+    expect(hasSavedPaymentMethod.value).toBeNull()
+  })
+
+  it('resolves true when a payment method is on file', async () => {
+    mockListSavedPaymentMethods.mockResolvedValue([{ id: 'pm-1' }])
+
+    const { hasSavedPaymentMethod } = useHasSavedPaymentMethod()
+    await flushLookup()
+
+    expect(hasSavedPaymentMethod.value).toBe(true)
+  })
+
+  it('resolves false when no payment methods are saved', async () => {
+    mockListSavedPaymentMethods.mockResolvedValue([])
+
+    const { hasSavedPaymentMethod } = useHasSavedPaymentMethod()
+    await flushLookup()
+
+    expect(hasSavedPaymentMethod.value).toBe(false)
+  })
+
+  it('stays unknown when the lookup fails', async () => {
+    mockListSavedPaymentMethods.mockRejectedValue(new Error('network'))
+
+    const { hasSavedPaymentMethod } = useHasSavedPaymentMethod()
+    await flushLookup()
+
+    expect(hasSavedPaymentMethod.value).toBeNull()
+  })
+})

--- a/src/platform/workspace/composables/useHasSavedPaymentMethod.test.ts
+++ b/src/platform/workspace/composables/useHasSavedPaymentMethod.test.ts
@@ -1,16 +1,23 @@
 import { describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
 
+import type { SavedPaymentMethod } from '@/platform/workspace/api/workspaceApi'
+
 import { useHasSavedPaymentMethod } from './useHasSavedPaymentMethod'
 
 const mockListSavedPaymentMethods = vi.hoisted(() =>
-  vi.fn<() => Promise<{ id: string }[]>>()
+  vi.fn<() => Promise<SavedPaymentMethod[]>>()
 )
+const mockReportError = vi.hoisted(() => vi.fn())
 
 vi.mock('@/platform/workspace/api/workspaceApi', () => ({
   workspaceApi: {
     listSavedPaymentMethods: mockListSavedPaymentMethods
   }
+}))
+
+vi.mock('@/platform/telemetry/reportError', () => ({
+  reportError: mockReportError
 }))
 
 async function flushLookup() {
@@ -28,7 +35,9 @@ describe('useHasSavedPaymentMethod', () => {
   })
 
   it('resolves true when a payment method is on file', async () => {
-    mockListSavedPaymentMethods.mockResolvedValue([{ id: 'pm-1' }])
+    mockListSavedPaymentMethods.mockResolvedValue([
+      { id: 'pm-1', type: 'card', is_default: true }
+    ])
 
     const { hasSavedPaymentMethod } = useHasSavedPaymentMethod()
     await flushLookup()
@@ -45,12 +54,16 @@ describe('useHasSavedPaymentMethod', () => {
     expect(hasSavedPaymentMethod.value).toBe(false)
   })
 
-  it('stays unknown when the lookup fails', async () => {
-    mockListSavedPaymentMethods.mockRejectedValue(new Error('network'))
+  it('stays unknown and reports when the lookup fails', async () => {
+    const failure = new Error('network')
+    mockListSavedPaymentMethods.mockRejectedValue(failure)
 
     const { hasSavedPaymentMethod } = useHasSavedPaymentMethod()
     await flushLookup()
 
     expect(hasSavedPaymentMethod.value).toBeNull()
+    expect(mockReportError).toHaveBeenCalledWith(failure, {
+      errorType: 'saved_payment_methods_read_failure'
+    })
   })
 })

--- a/src/platform/workspace/composables/useHasSavedPaymentMethod.test.ts
+++ b/src/platform/workspace/composables/useHasSavedPaymentMethod.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
 
+import type { reportError } from '@/platform/telemetry/reportError'
 import type { SavedPaymentMethod } from '@/platform/workspace/api/workspaceApi'
 
 import { useHasSavedPaymentMethod } from './useHasSavedPaymentMethod'
@@ -8,7 +9,7 @@ import { useHasSavedPaymentMethod } from './useHasSavedPaymentMethod'
 const mockListSavedPaymentMethods = vi.hoisted(() =>
   vi.fn<() => Promise<SavedPaymentMethod[]>>()
 )
-const mockReportError = vi.hoisted(() => vi.fn())
+const mockReportError = vi.hoisted(() => vi.fn<typeof reportError>())
 
 vi.mock('@/platform/workspace/api/workspaceApi', () => ({
   workspaceApi: {

--- a/src/platform/workspace/composables/useHasSavedPaymentMethod.test.ts
+++ b/src/platform/workspace/composables/useHasSavedPaymentMethod.test.ts
@@ -47,6 +47,17 @@ describe('useHasSavedPaymentMethod', () => {
     expect(hasSavedPaymentMethod.value).toBe(true)
   })
 
+  it('resolves false when only non-default methods are saved', async () => {
+    mockListSavedPaymentMethods.mockResolvedValue([
+      { id: 'pm-1', type: 'card', is_default: false }
+    ])
+
+    const { hasSavedPaymentMethod } = useHasSavedPaymentMethod()
+    await flushLookup()
+
+    expect(hasSavedPaymentMethod.value).toBe(false)
+  })
+
   it('resolves false when no payment methods are saved', async () => {
     mockListSavedPaymentMethods.mockResolvedValue([])
 

--- a/src/platform/workspace/composables/useHasSavedPaymentMethod.test.ts
+++ b/src/platform/workspace/composables/useHasSavedPaymentMethod.test.ts
@@ -23,6 +23,7 @@ vi.mock('@/platform/telemetry/reportError', () => ({
 
 async function flushLookup() {
   await Promise.resolve()
+  await Promise.resolve()
   await nextTick()
 }
 

--- a/src/platform/workspace/composables/useHasSavedPaymentMethod.ts
+++ b/src/platform/workspace/composables/useHasSavedPaymentMethod.ts
@@ -1,25 +1,28 @@
-import { ref } from 'vue'
+import { useAsyncState } from '@vueuse/core'
+import { computed } from 'vue'
 
-import { workspaceApi } from '@/platform/workspace/api/workspaceApi'
 import { reportError } from '@/platform/telemetry/reportError'
+import { workspaceApi } from '@/platform/workspace/api/workspaceApi'
 
 /**
  * Reports whether the active workspace has a saved payment method.
- * `null` until the lookup resolves, and stays `null` when it fails so
- * callers fall back to their default copy instead of claiming certainty.
+ * `hasSavedPaymentMethod` is `null` until the lookup resolves, and stays
+ * `null` when it fails so callers fall back to their default copy instead
+ * of claiming certainty.
  */
 export function useHasSavedPaymentMethod() {
-  const hasSavedPaymentMethod = ref<boolean | null>(null)
-  void workspaceApi
-    .listSavedPaymentMethods()
-    .then((methods) => {
-      hasSavedPaymentMethod.value = methods.length > 0
-    })
-    .catch((error) => {
-      reportError(error, {
-        errorType: 'saved_payment_methods_read_failure'
-      })
-      hasSavedPaymentMethod.value = null
-    })
-  return { hasSavedPaymentMethod }
+  const { state, error, isLoading, isReady, execute } = useAsyncState(
+    () => workspaceApi.listSavedPaymentMethods(),
+    null,
+    {
+      onError: (lookupError) =>
+        reportError(lookupError, {
+          errorType: 'saved_payment_methods_read_failure'
+        })
+    }
+  )
+  const hasSavedPaymentMethod = computed(() =>
+    state.value === null ? null : state.value.length > 0
+  )
+  return { hasSavedPaymentMethod, error, isLoading, isReady, refresh: execute }
 }

--- a/src/platform/workspace/composables/useHasSavedPaymentMethod.ts
+++ b/src/platform/workspace/composables/useHasSavedPaymentMethod.ts
@@ -5,10 +5,10 @@ import { reportError } from '@/platform/telemetry/reportError'
 import { workspaceApi } from '@/platform/workspace/api/workspaceApi'
 
 /**
- * Reports whether the active workspace has a saved payment method.
- * `hasSavedPaymentMethod` is `null` until the lookup resolves, and stays
- * `null` when it fails so callers fall back to their default copy instead
- * of claiming certainty.
+ * Reports whether the active workspace has a usable (default) saved payment
+ * method — the same predicate the top-up endpoint enforces. It is `null`
+ * until the lookup resolves, and stays `null` when it fails so callers can
+ * withhold payment-method claims instead of asserting one.
  */
 export function useHasSavedPaymentMethod() {
   const { state, error, isLoading, isReady, execute } = useAsyncState(
@@ -22,7 +22,9 @@ export function useHasSavedPaymentMethod() {
     }
   )
   const hasSavedPaymentMethod = computed(() =>
-    state.value === null ? null : state.value.length > 0
+    state.value === null
+      ? null
+      : state.value.some((method) => method.is_default)
   )
   return { hasSavedPaymentMethod, error, isLoading, isReady, refresh: execute }
 }

--- a/src/platform/workspace/composables/useHasSavedPaymentMethod.ts
+++ b/src/platform/workspace/composables/useHasSavedPaymentMethod.ts
@@ -1,6 +1,7 @@
 import { ref } from 'vue'
 
 import { workspaceApi } from '@/platform/workspace/api/workspaceApi'
+import { reportError } from '@/platform/telemetry/reportError'
 
 /**
  * Reports whether the active workspace has a saved payment method.
@@ -14,7 +15,10 @@ export function useHasSavedPaymentMethod() {
     .then((methods) => {
       hasSavedPaymentMethod.value = methods.length > 0
     })
-    .catch(() => {
+    .catch((error) => {
+      reportError(error, {
+        errorType: 'saved_payment_methods_read_failure'
+      })
       hasSavedPaymentMethod.value = null
     })
   return { hasSavedPaymentMethod }

--- a/src/platform/workspace/composables/useHasSavedPaymentMethod.ts
+++ b/src/platform/workspace/composables/useHasSavedPaymentMethod.ts
@@ -1,0 +1,21 @@
+import { ref } from 'vue'
+
+import { workspaceApi } from '@/platform/workspace/api/workspaceApi'
+
+/**
+ * Reports whether the active workspace has a saved payment method.
+ * `null` until the lookup resolves, and stays `null` when it fails so
+ * callers fall back to their default copy instead of claiming certainty.
+ */
+export function useHasSavedPaymentMethod() {
+  const hasSavedPaymentMethod = ref<boolean | null>(null)
+  void workspaceApi
+    .listSavedPaymentMethods()
+    .then((methods) => {
+      hasSavedPaymentMethod.value = methods.length > 0
+    })
+    .catch(() => {
+      hasSavedPaymentMethod.value = null
+    })
+  return { hasSavedPaymentMethod }
+}


### PR DESCRIPTION
- Fixes the QA finding from the 1.51 workspace-switcher pass; implements the quick improvement requested in FE-1908

## Why

1.51 QA reported two related problems on the top-up dialog for workspaces with **no saved payment method**:
1. The confirm step claims "Your saved payment method is charged immediately." — no such card exists ([QA report](https://comfy-organization.slack.com/archives/C0932CGKT5K/p1787766696082089?thread_ts=1787034725.224329&cid=C0932CGKT5K))
2. When the purchase is refused (`400 NO_PAYMENT_METHOD`), the raw server error gives no path forward; QA asked for the steps to appear in the error itself

## Root cause

`TopUpCreditsDialogContentWorkspace.vue` renders the note as static copy and echoes raw server errors. The server already exposes payment-method state (`GET /api/billing/payment-methods`), so the frontend was asserting server state it never fetched.

## How

- New `useHasSavedPaymentMethod` composable resolves `boolean | null` from the server's payment-method list (`null` until resolved or on lookup failure — the confirmation note is withheld while the state is unknown).
- Confirm-step note branches on it:
  - no saved method → "You'll be asked to add a payment method to complete this purchase." + an inline **Manage billing** action that opens the payment portal directly (one click instead of instructions)
  - usable default method on file → existing saved-card copy, unchanged
  - lookup unresolved (loading or failed) → the payment-method note is withheld entirely — no claim is made until the server answers
- A `NO_PAYMENT_METHOD` refusal now shows actionable guidance ("Add one via Settings → Plan & Credits → Manage billing, then retry") instead of the raw server message.

## AS IS / TO BE

Captured in the real app (local build, team-workspace owner session) with the workspace billing API pinned to the QA state: `GET /api/billing/payment-methods` returns `[]` and `POST /api/billing/topup` returns the ingest server's `400 NO_PAYMENT_METHOD` refusal verbatim ("No default payment method is selected. Please select one in the payment portal.").

| | AS IS | TO BE |
|---|---|---|
| Confirm step (no saved card) | claims "Your saved payment method is charged immediately." — no such card exists | "You'll be asked to add a payment method to complete this purchase." + inline **Manage billing** action that opens the payment portal |
| On Pay (400 `NO_PAYMENT_METHOD`) | raw server error echoed into the toast | toast explains where to add a card (Settings → Plan & Credits → Manage billing) and to retry |
| Saved card present | unchanged | unchanged |

### Confirm step

| AS IS | TO BE |
|---|---|
| <img src="https://raw.githubusercontent.com/dante01yoon/ComfyUI_frontend/assets/pr-16049-screenshots/docs-assets/pr-16049/asis-confirm.png" width="420" alt="AS IS confirm step: note claims a saved payment method is charged immediately" /> | <img src="https://raw.githubusercontent.com/dante01yoon/ComfyUI_frontend/assets/pr-16049-screenshots/docs-assets/pr-16049/tobe-confirm.png" width="420" alt="TO BE confirm step: note says a payment method will be requested, with a Manage billing link" /> |

### Purchase refused (`400 NO_PAYMENT_METHOD`)

| AS IS | TO BE |
|---|---|
| <img src="https://raw.githubusercontent.com/dante01yoon/ComfyUI_frontend/assets/pr-16049-screenshots/docs-assets/pr-16049/asis-error-toast.png" width="420" alt="AS IS error toast: raw server error 'No default payment method is selected. Please select one in the payment portal.'" /> | <img src="https://raw.githubusercontent.com/dante01yoon/ComfyUI_frontend/assets/pr-16049-screenshots/docs-assets/pr-16049/tobe-error-toast.png" width="420" alt="TO BE error toast: 'No payment method is saved for this workspace. Add one via Settings → Plan & Credits → Manage billing, then retry the top-up.'" /> |

(Matches the QA finding in the [Slack report](https://comfy-organization.slack.com/archives/C0932CGKT5K/p1787766696082089?thread_ts=1787034725.224329&cid=C0932CGKT5K).)

## Tests

- Component: note branches (saved / none), Manage billing click opens the portal, `NO_PAYMENT_METHOD` refusal shows the guidance toast (`TopUpCreditsDialogContentWorkspace.test.ts`)
- Composable: resolves true/false, stays `null` before resolution and on failure (`useHasSavedPaymentMethod.test.ts`)
- `pnpm typecheck`, `pnpm lint` (0 errors), `pnpm format` clean

Found during the same QA pass as Comfy-Org/cloud#7548 (team-workspace top-up rollback). Needs backport to `core/1.51`.

