### PR TITLE
test(website): match past event card eligibility

### DIFF
--- a/apps/website/e2e/events.spec.ts
+++ b/apps/website/e2e/events.spec.ts
@@ -21,6 +21,10 @@ const LOCALES: ReadonlyArray<readonly [string, Locale]> = [
   [PATH_ZH, 'zh-CN']
 ]
 
+const pastCardEvents = pastEvents.filter(
+  (event) => event.media ?? event.featured?.media
+)
+
 function heroSection(page: Page, locale: Locale) {
   return page.locator('section').filter({
     has: page.getByRole('heading', {
@@ -297,7 +301,7 @@ test.describe('Events page — desktop @smoke', () => {
     }
   })
 
-  test('past events gallery renders one card per event with WATCH NOW links', async ({
+  test('past events gallery renders one card per renderable event with WATCH NOW links', async ({
     page
   }) => {
     for (const [path, locale] of LOCALES) {
@@ -306,9 +310,9 @@ test.describe('Events page — desktop @smoke', () => {
       await section.scrollIntoViewIfNeeded()
 
       const cards = section.locator('[data-slot="card"]')
-      await expect(cards).toHaveCount(pastEvents.length)
+      await expect(cards).toHaveCount(pastCardEvents.length)
 
-      for (const [i, event] of pastEvents.entries()) {
+      for (const [i, event] of pastCardEvents.entries()) {
         const card = cards.nth(i)
         await expect(card).toContainText(event.title[locale])
         const watch = card.getByRole('link', {
@@ -333,7 +337,7 @@ test.describe('Events page — mobile @mobile', () => {
     const section = pastSection(page, 'en')
     await section.scrollIntoViewIfNeeded()
     const cards = section.locator('[data-slot="card"]')
-    await expect(cards).toHaveCount(pastEvents.length)
+    await expect(cards).toHaveCount(pastCardEvents.length)
 
     const viewport = page.viewportSize()
     expect(viewport, 'viewport size').not.toBeNull()


### PR DESCRIPTION
- Fixes deterministic Website E2E failures.
- Keeps exact card assertions.
- Focused checks green.

<details><summary>Full context for agent readers</summary>

## Summary

Align the events E2E fixture with the gallery's existing renderability contract: past events without card media are intentionally omitted from the gallery.

## Changes

- Derive `pastCardEvents` from past events that have dedicated or featured media, matching `PastEventsSection.vue`.
- Keep exact card count, localized title, WATCH NOW href, and mobile layout assertions against the renderable set.

## Review Focus

`local-mcp` became past-dated but has no card media. Production intentionally skips it because `CardArticle01` cannot render without media; this test-only change does not alter event content or page behavior.

## Testing

- `pnpm exec playwright test e2e/events.spec.ts` — 9 passed
- `pnpm typecheck:website` — 0 errors
- `pnpm exec eslint apps/website/e2e/events.spec.ts` — passed
- `pnpm exec oxfmt --check apps/website/e2e/events.spec.ts` — passed
- Commit hooks: oxfmt, oxlint, ESLint, root typecheck, website typecheck — passed
- Push hook: knip — passed

</details>
