### PR TITLE
fix(website): count past-event cards, not past events

### DIFF
--- a/apps/website/e2e/events.spec.ts
+++ b/apps/website/e2e/events.spec.ts
@@ -6,7 +6,7 @@ import {
   eventPath,
   eventVideoId,
   featuredEvents,
-  pastEvents,
+  pastEventCards,
   upcomingEvents
 } from '../src/data/events'
 import type { Locale } from '../src/i18n/translations'
@@ -306,9 +306,9 @@ test.describe('Events page — desktop @smoke', () => {
       await section.scrollIntoViewIfNeeded()
 
       const cards = section.locator('[data-slot="card"]')
-      await expect(cards).toHaveCount(pastEvents.length)
+      await expect(cards).toHaveCount(pastEventCards.length)
 
-      for (const [i, event] of pastEvents.entries()) {
+      for (const [i, event] of pastEventCards.entries()) {
         const card = cards.nth(i)
         await expect(card).toContainText(event.title[locale])
         const watch = card.getByRole('link', {
@@ -333,7 +333,7 @@ test.describe('Events page — mobile @mobile', () => {
     const section = pastSection(page, 'en')
     await section.scrollIntoViewIfNeeded()
     const cards = section.locator('[data-slot="card"]')
-    await expect(cards).toHaveCount(pastEvents.length)
+    await expect(cards).toHaveCount(pastEventCards.length)
 
     const viewport = page.viewportSize()
     expect(viewport, 'viewport size').not.toBeNull()

--- a/apps/website/src/data/events.test.ts
+++ b/apps/website/src/data/events.test.ts
@@ -3,10 +3,12 @@ import { describe, expect, it } from 'vitest'
 import type { ComfyEvent } from './events'
 import {
   deriveFeaturedEvents,
+  eventCardMedia,
   derivePastEvents,
   deriveUpcomingEvents,
   eventJsonLdNode,
   eventStatus,
+  pastEventCards,
   pastEvents,
   toCalendarEvent,
   upcomingEvents
@@ -141,6 +143,42 @@ describe('event list derivation', () => {
       'done',
       'older'
     ])
+  })
+})
+
+describe('eventCardMedia', () => {
+  const media = {
+    type: 'image',
+    src: '/card.png',
+    alt: { en: 'Card art', 'zh-CN': '卡片图' }
+  } as ComfyEvent['media']
+
+  it('prefers the event media', () => {
+    const event = eventAt('with-media', { media })
+    expect(eventCardMedia(event)).toBe(media)
+  })
+
+  it('falls back to the carousel art', () => {
+    const event = eventAt('featured-only', {
+      featured: { order: 1, media }
+    } as Partial<ComfyEvent>)
+    expect(eventCardMedia(event)).toBe(media)
+  })
+
+  it('is undefined when the event has neither', () => {
+    expect(eventCardMedia(eventAt('bare', {}))).toBeUndefined()
+  })
+})
+
+describe('pastEventCards', () => {
+  it('excludes past events the gallery cannot render', () => {
+    // The gallery skips events without media, so counting every past event
+    // breaks as soon as one without it ages into the section.
+    const unrenderable = pastEvents.filter((event) => !eventCardMedia(event))
+    expect(pastEventCards).toHaveLength(pastEvents.length - unrenderable.length)
+    for (const event of pastEventCards) {
+      expect(eventCardMedia(event)).toBeDefined()
+    }
   })
 })
 

--- a/apps/website/src/data/events.ts
+++ b/apps/website/src/data/events.ts
@@ -620,6 +620,18 @@ export const pastEvents = derivePastEvents(events, NOW)
 
 export const featuredEvents = deriveFeaturedEvents(events, NOW)
 
+// The gallery cannot render a card without media, so a past event without it
+// contributes no card. Exported so the gallery and its tests count the same
+// thing — asserting against every past event breaks the moment one without
+// media ages into the section.
+export function eventCardMedia(event: ComfyEvent) {
+  return event.media ?? event.featured?.media
+}
+
+export const pastEventCards: readonly ComfyEvent[] = pastEvents.filter(
+  (event) => Boolean(eventCardMedia(event))
+)
+
 export const watchablePastEvents: readonly ComfyEvent[] = pastEvents.filter(
   (event) => eventVideoId(event)
 )

--- a/apps/website/src/templates/events/PastEventsSection.vue
+++ b/apps/website/src/templates/events/PastEventsSection.vue
@@ -6,16 +6,21 @@ import type { Locale } from '../../i18n/translations'
 import CardArticleGallery01 from '../../components/blocks/CardArticleGallery01.vue'
 import type { CardArticleGalleryItem } from '../../components/blocks/CardArticleGallery01.vue'
 import { localizeHref } from '../../config/routes'
-import { eventPath, eventVideoId, pastEvents } from '../../data/events'
+import {
+  eventCardMedia,
+  eventPath,
+  eventVideoId,
+  pastEventCards
+} from '../../data/events'
 import { t } from '../../i18n/translations'
 
 const { locale = 'en' } = defineProps<{ locale?: Locale }>()
 
 const items = computed<CardArticleGalleryItem[]>(() =>
-  pastEvents.flatMap((event) => {
+  pastEventCards.flatMap((event) => {
     // Card art falls back to the carousel art for events that became past
     // before dedicated card art was added; a card cannot render without media.
-    const media = event.media ?? event.featured?.media
+    const media = eventCardMedia(event)
     if (!media) return []
     // Events with a recording open their own page (dialog over the directory);
     // the rest link out to the event's external page in a new tab.


### PR DESCRIPTION
**Unblocks the merge queue.** `CI: Website E2E` is currently failing for every PR in the queue — #14876, #15484, #15831, #16043 have all been ejected by `github-merge-queue[bot]`.

### The failure

```
apps/website/e2e/events.spec.ts:309
  past events gallery renders one card per event with WATCH NOW links
  expect(cards).toHaveCount(pastEvents.length)  →  unexpected value "10"
```

### Why

The gallery deliberately skips past events that have no media:

```ts
// PastEventsSection.vue
const media = event.media ?? event.featured?.media
if (!media) return []   // "a card cannot render without media"
```

The spec asserted against **every** past event. `local-mcp` has no `media` and no `featured` block — only a `liveVideoId` — so the counts diverged the moment it aged into the past section (it starts `2026-08-26T10:00:00-07:00` with no `endDateTime`, so `EVENT_DURATION_MS` ended it at 18:00 UTC).

Measured on `main` right now:

```
pastEvents.length     = 11    ← what the spec asserted
pastEventCards.length = 10    ← what the page renders
past events with no media: ["local-mcp"]
```

The `10` matches the failure exactly.

### The fix

Rather than copy the media rule into the spec — which is how the two drifted in the first place — the derivation is exported once and both consume it:

```ts
export function eventCardMedia(event: ComfyEvent) {
  return event.media ?? event.featured?.media
}

export const pastEventCards: readonly ComfyEvent[] = pastEvents.filter((event) =>
  Boolean(eventCardMedia(event))
)
```

`PastEventsSection.vue` iterates it; the spec counts and iterates it. No rendering behaviour changes — the component already skipped these events.

### Note on the alternative

Giving `local-mcp` card art would also go green today, and is probably worth doing on its own merits. It does not prevent recurrence: the next past event without media reproduces this exactly. This change makes the assertion structurally correct either way.

### Verification

- Website unit tests: 18 passing.
- `pnpm typecheck` and `pnpm typecheck:website` clean.
- Counts measured directly against the data module (above) rather than inferred.
