### PR TITLE
fix(website): add card art to Local MCP livestream

### DIFF
--- a/apps/website/src/data/events.ts
+++ b/apps/website/src/data/events.ts
@@ -367,7 +367,11 @@ const events: readonly ComfyEvent[] = [
       'zh-CN': '2026年8月26日 · 上午10点（PT）'
     },
     startDateTime: '2026-08-26T10:00:00-07:00',
-    liveVideoId: '6yH_15XSd0w'
+    liveVideoId: '6yH_15XSd0w',
+    media: eventImage('august-26-2026-local-mcp.jpg', {
+      en: 'Local MCP: Run ComfyUI with Your Agent & Hardware livestream',
+      'zh-CN': '本地 MCP：用你的智能体与硬件运行 ComfyUI 直播'
+    })
   },
   {
     id: 'beyond-the-models',


### PR DESCRIPTION
## Summary

The Local MCP livestream (Aug 26) disappeared from /events entirely once it ended — it left the upcoming list but never arrived in the past gallery.

## Changes

- **What**: Added `media` to the `local-mcp` event entry. `PastEventsSection` builds its cards with a `flatMap` that drops any event lacking `media ?? featured.media`, since a card cannot render without art. The entry had neither, so the correct past classification produced no card.

## Review Focus

Two deliberate omissions:

- No `recordingVideoId` yet, so `eventVideoId()` still falls back to `liveVideoId` for the `/events/local-mcp` page. Should be added once the edited recording is published.
- No `featured` block, so this stays out of the homepage carousel. The uploaded asset is a still; the current featured slides are video.

Note the card only appears after the next deploy — the past/upcoming split re-derives on hydration, but the card list is baked at build time.

On e2e coverage: no new spec is needed. `apps/website/e2e/events.spec.ts` already derives its expectations from the data — `pastCardEvents` filters `pastEvents` by `media ?? featured?.media`, and "past events gallery renders one card per renderable event with WATCH NOW links" asserts the card count plus each card's title and href across both locales. Adding `media` moves this event into that set, so the existing test covers it.

## Screenshots (if applicable)

Card art: https://media.comfy.org/website/events/august-26-2026-local-mcp.jpg