### PR TITLE
fix: hide converted widget controls in Nodes 2.0

### DIFF
--- a/src/renderer/extensions/vueNodes/components/WidgetGrid.test.ts
+++ b/src/renderer/extensions/vueNodes/components/WidgetGrid.test.ts
@@ -22,7 +22,11 @@ const InputSlotStub = defineComponent({
 })
 
 const AppInputStub = defineComponent({
-  template: '<div data-testid="app-input"><slot /></div>'
+  props: {
+    name: { type: String, required: true }
+  },
+  template:
+    '<div data-testid="app-input" :data-widget-name="name"><slot /></div>'
 })
 
 function widget(name: string, type: string, index: number): WidgetGridItem {
@@ -69,6 +73,11 @@ describe('WidgetGrid', () => {
       screen.getAllByTestId('input-slot').map((element) => element.dataset.name)
     ).toEqual(['seed', 'replacement', 'converted-widget-picker'])
     expect(screen.getAllByTestId('node-widget')).toHaveLength(2)
+    expect(
+      screen
+        .getAllByTestId('app-input')
+        .map((element) => element.dataset.widgetName)
+    ).toEqual(['replacement', 'converted-widget-picker'])
     expect(screen.getAllByTestId('widget-control')).toHaveLength(2)
   })
 })

--- a/src/renderer/extensions/vueNodes/components/WidgetGrid.test.ts
+++ b/src/renderer/extensions/vueNodes/components/WidgetGrid.test.ts
@@ -1,0 +1,66 @@
+import { render, screen } from '@testing-library/vue'
+import { defineComponent, markRaw } from 'vue'
+import { describe, expect, it } from 'vitest'
+
+import WidgetGrid from '@/renderer/extensions/vueNodes/components/WidgetGrid.vue'
+import type { WidgetGridItem } from '@/renderer/extensions/vueNodes/types/widgetGrid'
+import { toNodeId } from '@/types/nodeId'
+
+const WidgetStub = markRaw(
+  defineComponent({
+    template: '<div data-testid="widget-control" />'
+  })
+)
+
+const InputSlotStub = defineComponent({
+  props: {
+    index: { type: Number, required: true }
+  },
+  template: '<div data-testid="input-slot" :data-index="index" />'
+})
+
+const AppInputStub = defineComponent({
+  template: '<div data-testid="app-input"><slot /></div>'
+})
+
+function widget(name: string, type: string, index: number): WidgetGridItem {
+  return {
+    renderKey: name,
+    simplified: { name, type, value: 0 },
+    slotMetadata: {
+      index,
+      linked: false,
+      promoted: false,
+      type: 'FLOAT'
+    },
+    visible: true,
+    vueComponent: WidgetStub
+  }
+}
+
+describe('WidgetGrid', () => {
+  it('renders converted widgets as input sockets without controls', () => {
+    render(WidgetGrid, {
+      props: {
+        nodeId: toNodeId(1),
+        nodeType: 'TestNode',
+        processedWidgets: [
+          widget('seed', 'converted-widget', 0),
+          widget('control_after_generate', 'converted-widget:seed', 1),
+          widget('replacement', 'number', 2)
+        ]
+      },
+      global: {
+        directives: { tooltip: {} },
+        stubs: {
+          AppInput: AppInputStub,
+          InputSlot: InputSlotStub
+        }
+      }
+    })
+
+    expect(screen.getAllByTestId('input-slot')).toHaveLength(3)
+    expect(screen.getAllByTestId('node-widget')).toHaveLength(1)
+    expect(screen.getAllByTestId('widget-control')).toHaveLength(1)
+  })
+})

--- a/src/renderer/extensions/vueNodes/components/WidgetGrid.test.ts
+++ b/src/renderer/extensions/vueNodes/components/WidgetGrid.test.ts
@@ -14,9 +14,11 @@ const WidgetStub = markRaw(
 
 const InputSlotStub = defineComponent({
   props: {
-    index: { type: Number, required: true }
+    index: { type: Number, required: true },
+    slotData: { type: Object, required: true }
   },
-  template: '<div data-testid="input-slot" :data-index="index" />'
+  template:
+    '<div data-testid="input-slot" :data-index="index" :data-name="slotData.name" />'
 })
 
 const AppInputStub = defineComponent({
@@ -46,8 +48,12 @@ describe('WidgetGrid', () => {
         nodeType: 'TestNode',
         processedWidgets: [
           widget('seed', 'converted-widget', 0),
-          widget('control_after_generate', 'converted-widget:seed', 1),
-          widget('replacement', 'number', 2)
+          {
+            ...widget('control_after_generate', 'converted-widget:seed', 1),
+            slotMetadata: undefined
+          },
+          widget('replacement', 'number', 2),
+          widget('converted-widget-picker', 'converted-widget-picker', 3)
         ]
       },
       global: {
@@ -59,8 +65,10 @@ describe('WidgetGrid', () => {
       }
     })
 
-    expect(screen.getAllByTestId('input-slot')).toHaveLength(3)
-    expect(screen.getAllByTestId('node-widget')).toHaveLength(1)
-    expect(screen.getAllByTestId('widget-control')).toHaveLength(1)
+    expect(
+      screen.getAllByTestId('input-slot').map((element) => element.dataset.name)
+    ).toEqual(['seed', 'replacement', 'converted-widget-picker'])
+    expect(screen.getAllByTestId('node-widget')).toHaveLength(2)
+    expect(screen.getAllByTestId('widget-control')).toHaveLength(2)
   })
 })

--- a/src/renderer/extensions/vueNodes/components/WidgetGrid.vue
+++ b/src/renderer/extensions/vueNodes/components/WidgetGrid.vue
@@ -9,9 +9,14 @@
   >
     <template v-for="widget in processedWidgets" :key="widget.renderKey">
       <div
-        v-if="widget.visible"
-        data-testid="node-widget"
-        class="lg-node-widget group col-span-full grid grid-cols-subgrid items-stretch"
+        v-if="shouldRenderRow(widget)"
+        :data-testid="isConvertedWidget(widget) ? undefined : 'node-widget'"
+        :class="
+          cn(
+            'group col-span-full grid grid-cols-subgrid items-stretch',
+            !isConvertedWidget(widget) && 'lg-node-widget'
+          )
+        "
       >
         <div
           :class="
@@ -37,6 +42,7 @@
           />
         </div>
         <AppInput
+          v-if="!isConvertedWidget(widget)"
           :widget-id="widget.widgetId"
           :name="widget.simplified.name"
           :enable="canSelectInputs && !widget.simplified.options?.disabled"
@@ -78,6 +84,15 @@ import InputSlot from './InputSlot.vue'
 
 const EMPTY_TOOLTIP: TooltipOptions = {}
 
+const isConvertedWidgetType = (type: string) =>
+  type === 'converted-widget' || type.startsWith('converted-widget:')
+
+const isConvertedWidget = (widget: WidgetGridItem) =>
+  isConvertedWidgetType(widget.simplified.type)
+
+const shouldRenderRow = (widget: WidgetGridItem) =>
+  widget.visible && (!isConvertedWidget(widget) || !!widget.slotMetadata)
+
 const {
   processedWidgets,
   nodeType,
@@ -92,9 +107,10 @@ const {
 
 const gridTemplateRows = computed(() =>
   processedWidgets
-    .filter((widget) => widget.visible)
+    .filter(shouldRenderRow)
     .map((widget) =>
-      shouldExpand(widget.simplified.type) || widget.hasLayoutSize
+      !isConvertedWidget(widget) &&
+      (shouldExpand(widget.simplified.type) || widget.hasLayoutSize)
         ? 'auto'
         : 'min-content'
     )


### PR DESCRIPTION
## Summary

Nodes 2.0 rendered custom-node widgets marked `converted-widget` as duplicate canvas controls. The primary converted widget must retain its input socket; linked converted children must render nothing; normal replacement controls remain.

## Red-Green Verification

- Test-only run 33023674803 failed only the new WidgetGrid regression: 4 controls rendered, 2 expected, on all three attempts.
- Source-only fix `faafdab535` preserves exact and `converted-widget:` socket semantics without matching `converted-widget-picker`.

## Test Plan

- [x] Focused test red on current main
- [x] Exact CI red for the same assertion
- [x] Focused WidgetGrid and preview tests green
- [x] Typecheck, lint, format, and Knip green
- [ ] Full PR CI green
- [ ] Custom-node S2 green for Compositor3, FL_ImageAdjuster, and SAM3 collectors