### PR TITLE
fix: address context menu review findings

### DIFF
--- a/browser_tests/fixtures/utils/contextMenuTestHelpers.ts
+++ b/browser_tests/fixtures/utils/contextMenuTestHelpers.ts
@@ -31,7 +31,8 @@ export async function openContextMenu(
  */
 export async function openMultiNodeContextMenu(
   comfyPage: ComfyPage,
-  titles: string[]
+  titles: string[],
+  contextTitle = titles[0]
 ): Promise<Locator> {
   if (titles.length === 0) {
     throw new Error('openMultiNodeContextMenu requires at least one title')
@@ -48,9 +49,10 @@ export async function openMultiNodeContextMenu(
   }
   await comfyPage.nextFrame()
 
-  const firstFixture = await comfyPage.vueNodes.getFixtureByTitle(titles[0])
-  const box = await firstFixture.header.boundingBox()
-  if (!box) throw new Error(`Header for "${titles[0]}" not found`)
+  const contextFixture =
+    await comfyPage.vueNodes.getFixtureByTitle(contextTitle)
+  const box = await contextFixture.header.boundingBox()
+  if (!box) throw new Error(`Header for "${contextTitle}" not found`)
   await comfyPage.page.mouse.click(
     box.x + box.width / 2,
     box.y + box.height / 2,

--- a/browser_tests/tests/vueNodes/interactions/node/contextMenuCoverage.spec.ts
+++ b/browser_tests/tests/vueNodes/interactions/node/contextMenuCoverage.spec.ts
@@ -69,6 +69,7 @@ test.describe(
       test('should not show Run Branch for non-output nodes', async ({
         comfyPage
       }) => {
+        await comfyPage.workflow.loadWorkflow('default')
         const menu = await openContextMenu(comfyPage, 'Load Checkpoint')
         await expect(menu).toBeVisible()
         await expect(
@@ -77,6 +78,19 @@ test.describe(
             exact: true
           })
         ).toBeHidden()
+      })
+      test('should show Run Branch for output nodes', async ({ comfyPage }) => {
+        await comfyPage.workflow.loadWorkflow('default')
+        const nodeRef = await getNodeRef(comfyPage, 'Save Image')
+        await comfyPage.nodeOps.panToNode(nodeRef)
+
+        await openContextMenu(comfyPage, 'Save Image')
+        await expect(
+          comfyPage.contextMenu.primeVueMenu.getByRole('menuitem', {
+            name: 'Run Branch',
+            exact: true
+          })
+        ).toBeVisible()
       })
     })
 

--- a/browser_tests/tests/vueNodes/interactions/node/contextMenuCoverage.spec.ts
+++ b/browser_tests/tests/vueNodes/interactions/node/contextMenuCoverage.spec.ts
@@ -131,22 +131,23 @@ test.describe(
     })
 
     test.describe('Multi-Node Actions', () => {
-      const nodeTitles = ['Load Checkpoint', 'KSampler']
+      const nodeTitles = ['KSampler', 'Load Checkpoint', 'Empty Latent Image']
 
-      test('should align selected nodes via Align Selected To submenu', async ({
+      test('should align selected nodes to the context node', async ({
         comfyPage
       }) => {
-        const nodeRef0 = await getNodeRef(comfyPage, nodeTitles[0])
-        const nodeRef1 = await getNodeRef(comfyPage, nodeTitles[1])
+        await comfyPage.workflow.loadWorkflow('default')
+        const nodeRefs = await Promise.all(
+          nodeTitles.map((title) => getNodeRef(comfyPage, title))
+        )
+        const contextNode = nodeRefs[1]
+        const contextNodeInitialY = (await contextNode.getPosition()).y
 
-        const initialPos0 = await nodeRef0.getPosition()
-        const initialPos1 = await nodeRef1.getPosition()
-        expect(
-          initialPos0.y !== initialPos1.y,
-          'Nodes should start at different y positions'
-        ).toBe(true)
+        expect((await nodeRefs[0].getPosition()).y).not.toBe(
+          contextNodeInitialY
+        )
 
-        await openMultiNodeContextMenu(comfyPage, nodeTitles)
+        await openMultiNodeContextMenu(comfyPage, nodeTitles, nodeTitles[1])
         const menu = comfyPage.contextMenu.primeVueMenu
         await menu
           .getByRole('menuitem', {
@@ -163,16 +164,18 @@ test.describe(
 
         await expect
           .poll(async () => {
-            const pos0 = await nodeRef0.getPosition()
-            const pos1 = await nodeRef1.getPosition()
-            return Math.abs(pos0.y - pos1.y)
+            const positions = await Promise.all(
+              nodeRefs.map((node) => node.getPosition())
+            )
+            return positions.map(({ y }) => y)
           })
-          .toBeLessThanOrEqual(1)
+          .toEqual(nodeRefs.map(() => contextNodeInitialY))
       })
 
       test('should distribute selected nodes via Distribute Nodes submenu', async ({
         comfyPage
       }) => {
+        await comfyPage.workflow.loadWorkflow('default')
         const threeNodes = ['Load Checkpoint', 'KSampler', 'Empty Latent Image']
 
         await openMultiNodeContextMenu(comfyPage, threeNodes)

--- a/browser_tests/tests/vueNodes/interactions/node/contextMenuCoverage.spec.ts
+++ b/browser_tests/tests/vueNodes/interactions/node/contextMenuCoverage.spec.ts
@@ -79,6 +79,7 @@ test.describe(
           })
         ).toBeHidden()
       })
+
       test('should show Run Branch for output nodes', async ({ comfyPage }) => {
         await comfyPage.workflow.loadWorkflow('default')
         const nodeRef = await getNodeRef(comfyPage, 'Save Image')

--- a/src/composables/graph/useMoreOptionsMenu.ts
+++ b/src/composables/graph/useMoreOptionsMenu.ts
@@ -9,7 +9,7 @@ import {
 } from '@/renderer/extensions/vueNodes/utils/linkedCoreMediaUtils'
 import { getExtraOptionsForWidget } from '@/services/litegraphService'
 import { useNodeOutputStore } from '@/stores/nodeOutputStore'
-import type { SerializedNodeId } from '@/types/nodeId'
+import type { NodeId, SerializedNodeId } from '@/types/nodeId'
 import { filterUnavailableCoreMediaMenuActions } from '@/utils/coreMediaMenuActionUtils'
 import type { CoreMediaMenuActionKind } from '@/utils/coreMediaMenuActionUtils'
 import { isLGraphGroup } from '@/utils/litegraphUtil'
@@ -55,12 +55,15 @@ export enum BadgeVariant {
 let nodeOptionsInstance: null | NodeOptionsInstance = null
 
 const hoveredWidget = ref<[string, SerializedNodeId | undefined]>()
+const contextNodeId = ref<NodeId>()
 
 /**
  * Toggle the node options popover
  * @param event - The trigger event
  */
 export function toggleNodeOptions(event: Event) {
+  hoveredWidget.value = undefined
+  contextNodeId.value = undefined
   if (nodeOptionsInstance?.toggle) {
     nodeOptionsInstance.toggle(event)
   }
@@ -74,9 +77,10 @@ export function toggleNodeOptions(event: Event) {
 export function showNodeOptions(
   event: MouseEvent,
   widgetName?: string,
-  nodeId?: SerializedNodeId
+  nodeId?: NodeId
 ) {
   hoveredWidget.value = widgetName ? [widgetName, nodeId] : undefined
+  contextNodeId.value = nodeId
   if (nodeOptionsInstance?.show) {
     nodeOptionsInstance.show(event)
   }
@@ -156,6 +160,7 @@ export function useMoreOptionsMenu() {
     getBasicSelectionOptions,
     getMultipleNodesOptions,
     getSubgraphOptions,
+    getAlignmentOptions,
     getDeleteOption
   } = useSelectionMenuOptions()
 
@@ -185,7 +190,11 @@ export function useMoreOptionsMenu() {
 
     // For node selection, also get LiteGraph menu items to merge
     const litegraphOptions: MenuOption[] = []
-    const node: LGraphNode | undefined = selectedNodes.value[0]
+    const node: LGraphNode | undefined =
+      (contextNodeId.value === undefined
+        ? undefined
+        : canvasStore.currentGraph?.getNodeById(contextNodeId.value)) ??
+      selectedNodes.value[0]
     const hideLinkedInputActions = node
       ? shouldHideLinkedCoreMediaInputActions(node)
       : false
@@ -250,6 +259,7 @@ export function useMoreOptionsMenu() {
     )
     if (hasMultipleNodes.value) {
       options.push(...getMultipleNodesOptions())
+      options.push(...getAlignmentOptions(node))
     }
     if (groupContext) {
       options.push(getFitGroupToNodesOption(groupContext))

--- a/src/composables/graph/useMoreOptionsMenu.ts
+++ b/src/composables/graph/useMoreOptionsMenu.ts
@@ -302,14 +302,13 @@ export function useMoreOptionsMenu() {
       }
     }
 
-    const deleteOption = getDeleteOption()
-    const litegraphDeleteOption = litegraphOptions.find(
-      (option) => option.label === 'Delete' || option.label === 'Remove'
+    options.push(
+      getDeleteOption(
+        selectedNodes.value.some(
+          (node) => node.removable === false || node.block_delete
+        )
+      )
     )
-    if (litegraphDeleteOption) {
-      deleteOption.disabled = litegraphDeleteOption.disabled
-    }
-    options.push(deleteOption)
 
     // Section 6 & 7: Extensions and Delete are handled by buildStructuredMenu
 

--- a/src/composables/graph/useNodeArrangement.ts
+++ b/src/composables/graph/useNodeArrangement.ts
@@ -1,6 +1,7 @@
 import { useI18n } from 'vue-i18n'
 
 import type { Direction } from '@/lib/litegraph/src/interfaces'
+import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
 import { alignNodes, distributeNodes } from '@/lib/litegraph/src/utils/arrange'
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import { isLGraphNode } from '@/utils/litegraphUtil'
@@ -70,7 +71,7 @@ export function useNodeArrangement() {
     }
   ]
 
-  const applyAlign = (alignOption: AlignOption) => {
+  const applyAlign = (alignOption: AlignOption, alignTo?: LGraphNode) => {
     const selectedNodes = Array.from(canvasStore.selectedItems).filter((item) =>
       isLGraphNode(item)
     )
@@ -79,7 +80,7 @@ export function useNodeArrangement() {
       return
     }
 
-    const newPositions = alignNodes(selectedNodes, alignOption.value)
+    const newPositions = alignNodes(selectedNodes, alignOption.value, alignTo)
     canvasStore.canvas?.applyNodePositions(newPositions)
 
     canvasRefresh.refreshCanvas()

--- a/src/composables/graph/useSelectionMenuOptions.ts
+++ b/src/composables/graph/useSelectionMenuOptions.ts
@@ -1,5 +1,6 @@
-import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
+
+import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
 
 import { useFrameNodes } from './useFrameNodes'
 import { BadgeVariant } from './useMoreOptionsMenu'
@@ -27,22 +28,6 @@ export function useSelectionMenuOptions() {
     useSubgraphOperations()
 
   const { frameNodes } = useFrameNodes()
-
-  const alignSubmenu = computed(() =>
-    alignOptions.map((align) => ({
-      label: align.localizedName,
-      icon: align.icon,
-      action: () => applyAlign(align)
-    }))
-  )
-
-  const distributeSubmenu = computed(() =>
-    distributeOptions.map((distribute) => ({
-      label: distribute.localizedName,
-      icon: distribute.icon,
-      action: () => applyDistribute(distribute)
-    }))
-  )
 
   const getBasicSelectionOptions = (): MenuOption[] => [
     {
@@ -108,19 +93,27 @@ export function useSelectionMenuOptions() {
     }
   ]
 
-  const getAlignmentOptions = (): MenuOption[] => [
+  const getAlignmentOptions = (alignTo?: LGraphNode): MenuOption[] => [
     {
       label: t('contextMenu.Align Selected To'),
       icon: 'icon-[lucide--align-start-horizontal]',
       hasSubmenu: true,
-      submenu: alignSubmenu.value,
+      submenu: alignOptions.map((align) => ({
+        label: align.localizedName,
+        icon: align.icon,
+        action: () => applyAlign(align, alignTo)
+      })),
       action: () => {}
     },
     {
       label: t('contextMenu.Distribute Nodes'),
       icon: 'icon-[lucide--align-center-horizontal]',
       hasSubmenu: true,
-      submenu: distributeSubmenu.value,
+      submenu: distributeOptions.map((distribute) => ({
+        label: distribute.localizedName,
+        icon: distribute.icon,
+        action: () => applyDistribute(distribute)
+      })),
       action: () => {}
     }
   ]
@@ -138,8 +131,6 @@ export function useSelectionMenuOptions() {
     getSubgraphOptions,
     getMultipleNodesOptions,
     getDeleteOption,
-    getAlignmentOptions,
-    alignSubmenu,
-    distributeSubmenu
+    getAlignmentOptions
   }
 }

--- a/src/composables/graph/useSelectionMenuOptions.ts
+++ b/src/composables/graph/useSelectionMenuOptions.ts
@@ -125,10 +125,11 @@ export function useSelectionMenuOptions() {
     }
   ]
 
-  const getDeleteOption = (): MenuOption => ({
+  const getDeleteOption = (disabled: boolean): MenuOption => ({
     label: t('contextMenu.Delete'),
     icon: 'icon-[lucide--trash-2]',
     shortcut: 'Delete',
+    disabled,
     action: deleteSelection
   })
 

--- a/src/renderer/extensions/vueNodes/components/LGraphNode.vue
+++ b/src/renderer/extensions/vueNodes/components/LGraphNode.vue
@@ -440,7 +440,7 @@ const handleContextMenu = (event: MouseEvent) => {
   handleNodeRightClick(event as PointerEvent, nodeData.id)
 
   // Show the node options menu at the cursor position
-  showNodeOptions(event)
+  showNodeOptions(event, undefined, nodeData.id)
 }
 
 const baseResizeHandleClasses =

--- a/src/renderer/extensions/vueNodes/composables/processedWidgetRenderModel.ts
+++ b/src/renderer/extensions/vueNodes/composables/processedWidgetRenderModel.ts
@@ -421,7 +421,7 @@ function processWidget(
     e.preventDefault()
     e.stopPropagation()
     ctx.ui.handleNodeRightClick(e, ctx.nodeData.id)
-    showNodeOptions(e, widgetState.name)
+    showNodeOptions(e, widgetState.name, ctx.nodeData.id)
   }
 
   return {


### PR DESCRIPTION
## Summary

Addresses review findings from #12007 and #12008 while preserving the context-menu callback fix.

## Changes

- **What**: Preserve Delete's disabled state for protected nodes, use unambiguous E2E locators, enable deterministic Run Branch coverage, and replace redundant property tests with one typed regression test.

## Review Focus

This PR is stacked on #12008. Please verify protected-node deletion behavior and the updated context-menu E2E coverage.