### PR TITLE
ci: validate action pins in the merge queue

### DIFF
--- a/.github/workflows/ci-validate-action-pins.yaml
+++ b/.github/workflows/ci-validate-action-pins.yaml
@@ -1,7 +1,9 @@
 name: Validate Action SHA Pins
 
 on:
-  # A PR only re-checks the pins it edits, so a stale major merges green and reddens every later workflow PR.
+  # pull_request builds against the base at event time, so a stale base can merge
+  # green; merge_group rebuilds against main's tip and push catches queue bypasses.
+  merge_group:
   push:
     branches:
       - main


### PR DESCRIPTION
## Summary

Adds a `merge_group` trigger so action pins are validated against main's tip before a merge lands, not only after.

## Changes

- **What**: `merge_group` trigger on `Validate Action SHA Pins`, plus a corrected trigger comment.

## Review Focus

Follow-up to #15445, which added the `push: main` trigger. Rebased onto main now that it has landed.

`pull_request` runs build against the base as of the event, so a PR opened before a `.pinact.yaml` change can merge green against a config it never saw. That is how `download-artifact@v7` reached main via #14560 (opened 08-02 on a pre-#14000 base, merged 08-08 two hours after #14000 landed) and reddened later workflow PRs whose authors never touched the file. `ProtectMain` sets `strict_required_status_checks_policy: false`, so GitHub never re-ran it against the moved base. The merge queue rebuilds against main's tip, so `merge_group` catches this before the merge instead of reporting it after.

The comment #15445 added said a PR only re-checks the pins it edits. That is not true of pinact-action v1.3.1: `getTargetFiles()` passes every workflow file plus every `action.yaml` in the repo to `pinact run --check` on every run, and `--diff` is an alias for `-fix=false`, not a git-diff scope. Reworded.

`merge_group` takes no `paths` filter, so the job runs on every merge group (~16s).

Not in this PR: `validate-pins` is not in `ProtectMain`'s required checks (`test`, `lint-and-format`, `e2e-status`, `website-e2e`), so it reports without blocking. Making it blocking is a ruleset change.
