### PR TITLE
feat(billing): render sales-managed tiers through server capabilities

### DIFF
--- a/browser_tests/fixtures/helpers/CloudWorkspaceMockHelper.ts
+++ b/browser_tests/fixtures/helpers/CloudWorkspaceMockHelper.ts
@@ -1,5 +1,8 @@
 import type { Locator, Page, Route } from '@playwright/test'
-import type { BillingStatusResponse } from '@comfyorg/ingest-types'
+import type {
+  BillingCapabilities,
+  BillingStatusResponse
+} from '@comfyorg/ingest-types'
 
 import type {
   Member,
@@ -74,9 +77,15 @@ export class CloudWorkspaceMockHelper {
   async setup(
     members: Member[] = DEFAULT_TEAM_MEMBERS,
     activeWorkspace: WorkspaceWithRole = TEAM_WORKSPACE,
-    billingStatus: BillingStatusResponse = TEAM_BILLING_STATUS
+    billingStatus: BillingStatusResponse = TEAM_BILLING_STATUS,
+    capabilityOverrides: Partial<BillingCapabilities> = {}
   ): Promise<MemberMockState> {
-    const state = await this.mockBoot(members, activeWorkspace, billingStatus)
+    const state = await this.mockBoot(
+      members,
+      activeWorkspace,
+      billingStatus,
+      capabilityOverrides
+    )
     await new CloudAuthHelper(this.page).mockAuth()
     await this.page.addInitScript((workspaceId) => {
       localStorage.setItem('Comfy.userId', 'test-user-e2e')
@@ -88,7 +97,8 @@ export class CloudWorkspaceMockHelper {
   private async mockBoot(
     members: Member[],
     activeWorkspace: WorkspaceWithRole,
-    billingStatus: BillingStatusResponse
+    billingStatus: BillingStatusResponse,
+    capabilityOverrides: Partial<BillingCapabilities> = {}
   ): Promise<MemberMockState> {
     const state: MemberMockState = {
       members: members.map((m) => ({ ...m })),
@@ -167,7 +177,12 @@ export class CloudWorkspaceMockHelper {
     await page.route('**/api/billing/capabilities', (r) => {
       if (r.request().method() !== 'GET') return r.fallback()
       return r.fulfill(
-        jsonRoute(createWorkspaceBillingCapabilities(activeWorkspace))
+        jsonRoute(
+          createWorkspaceBillingCapabilities(
+            activeWorkspace,
+            capabilityOverrides
+          )
+        )
       )
     })
     await page.route('**/api/billing/payment-portal', (r) =>

--- a/browser_tests/tests/dialogs/endedSubscription.spec.ts
+++ b/browser_tests/tests/dialogs/endedSubscription.spec.ts
@@ -81,6 +81,9 @@ test.describe('Inactive Team subscription billing', { tag: '@cloud' }, () => {
     await expect(
       content.getByRole('heading', { name: 'Inactive team subscription' })
     ).toBeVisible()
+    await expect(
+      content.getByRole('button', { name: 'Reactivate plan' })
+    ).toBeVisible()
     await content.getByRole('button', { name: 'Billing & invoices' }).click()
     await expect
       .poll(() => page.locator('html').getAttribute('data-opened-url'))

--- a/browser_tests/tests/dialogs/enterpriseTierCloud.spec.ts
+++ b/browser_tests/tests/dialogs/enterpriseTierCloud.spec.ts
@@ -1,0 +1,280 @@
+import { expect } from '@playwright/test'
+import type { Locator, Page } from '@playwright/test'
+import type {
+  BillingCapabilities,
+  BillingStatusResponse
+} from '@comfyorg/ingest-types'
+
+import { cloudAppFixture as test } from '@e2e/fixtures/cloudAppFixture'
+import { TopUpCreditsDialog } from '@e2e/fixtures/components/TopUpCreditsDialog'
+import {
+  DEFAULT_TEAM_MEMBERS,
+  TEAM_BILLING_STATUS,
+  TEAM_WORKSPACE
+} from '@e2e/fixtures/data/cloudWorkspace'
+import { CloudWorkspaceMockHelper } from '@e2e/fixtures/helpers/CloudWorkspaceMockHelper'
+
+const APP_URL = process.env.PLAYWRIGHT_TEST_URL || 'http://localhost:8188'
+
+// The capability shape billing-api resolves for sales-managed tiers
+// (hideLifecycleCapabilities): the self-serve catalog and lifecycle actions
+// close, credit top-up stays open.
+const SALES_MANAGED_CAPABILITIES: Partial<BillingCapabilities> = {
+  can_subscribe_self_serve: false,
+  can_cancel: false,
+  can_reactivate: false,
+  can_change_seats: false,
+  can_downgrade_to_personal: false,
+  can_top_up: true
+}
+
+const ACTIVE_ENTERPRISE_STATUS = {
+  ...TEAM_BILLING_STATUS,
+  subscription_tier: 'ENTERPRISE',
+  plan_slug: 'enterprise_monthly',
+  renewal_date: '2027-04-25T00:00:00Z'
+} satisfies BillingStatusResponse
+
+const ENDED_ENTERPRISE_STATUS = {
+  ...ACTIVE_ENTERPRISE_STATUS,
+  billing_status: 'inactive',
+  is_active: false,
+  subscription_status: 'ended'
+} satisfies BillingStatusResponse
+
+const CANCELLED_ACTIVE_ENTERPRISE_STATUS = {
+  ...ACTIVE_ENTERPRISE_STATUS,
+  cancel_at: '2027-04-25T00:00:00Z',
+  subscription_status: 'canceled'
+} satisfies BillingStatusResponse
+
+const ACTIVE_UNRECOGNIZED_TIER_STATUS = {
+  ...TEAM_BILLING_STATUS,
+  subscription_tier: 'FUTURE_TIER',
+  plan_slug: 'future-tier-monthly'
+}
+
+async function setupSalesManagedWorkspace(
+  page: Page,
+  billingStatus: BillingStatusResponse
+) {
+  const workspace = new CloudWorkspaceMockHelper(page)
+  await workspace.setup(
+    DEFAULT_TEAM_MEMBERS,
+    TEAM_WORKSPACE,
+    billingStatus,
+    SALES_MANAGED_CAPABILITIES
+  )
+  return workspace
+}
+
+async function captureOpenedUrls(page: Page) {
+  await page.addInitScript(() => {
+    window.open = (url) => {
+      document.documentElement.dataset.openedUrl = String(url)
+      return window
+    }
+  })
+}
+
+async function expectNoSelfServicePlanActions(content: Locator) {
+  await expect(
+    content.getByRole('button', {
+      name: /Change plan|Cancel|Subscribe|Reactivate/i
+    })
+  ).toHaveCount(0)
+  await expect(
+    content.getByText('View more details about plans & pricing')
+  ).toHaveCount(0)
+}
+
+test.describe('Enterprise workspace billing', { tag: '@cloud' }, () => {
+  test.describe.configure({ timeout: 60_000 })
+
+  test('shows sales-managed plan details without catalog or lifecycle controls', async ({
+    page
+  }) => {
+    const workspace = await setupSalesManagedWorkspace(
+      page,
+      ACTIVE_ENTERPRISE_STATUS
+    )
+    const content = await workspace.openPlanAndCreditsSettings()
+
+    await expect(
+      content.getByRole('heading', { name: 'Enterprise' })
+    ).toBeVisible()
+    await expect(content.getByText('Renews on Apr 25, 2027')).toBeVisible()
+    await expect(content.getByText('Your plan includes:')).toHaveCount(0)
+    await expectNoSelfServicePlanActions(content)
+  })
+
+  test('keeps credit top-up and billing portal access available', async ({
+    page
+  }) => {
+    await captureOpenedUrls(page)
+    const workspace = await setupSalesManagedWorkspace(
+      page,
+      ACTIVE_ENTERPRISE_STATUS
+    )
+    const content = await workspace.openPlanAndCreditsSettings()
+
+    await content.getByRole('button', { name: 'Billing & invoices' }).click()
+    await expect
+      .poll(() => page.locator('html').getAttribute('data-opened-url'))
+      .toBe('https://billing.example/portal')
+
+    await content.getByRole('button', { name: 'Add credits' }).click()
+    await new TopUpCreditsDialog(page).waitForVisible()
+  })
+
+  test('removes pricing entry points from the profile menu and deep links', async ({
+    page
+  }) => {
+    await setupSalesManagedWorkspace(page, ACTIVE_ENTERPRISE_STATUS)
+    await page.goto(`${APP_URL}/?pricing=team`)
+    await page.waitForFunction(() => !!window.app?.extensionManager, null, {
+      timeout: 45_000
+    })
+
+    await expect(page).not.toHaveURL(/[?&]pricing=/)
+    await expect(
+      page.getByRole('heading', { name: 'Choose a Plan' })
+    ).toHaveCount(0)
+
+    await page.getByTestId('current-user-button').click()
+    const popover = page.getByTestId('current-user-popover')
+    await expect(popover.getByTestId('add-credits-button')).toBeVisible()
+    await expect(popover.getByTestId('manage-plan-menu-item')).toBeVisible()
+    await expect(popover.getByTestId('plans-pricing-menu-item')).toHaveCount(0)
+  })
+
+  test('keeps a cancelled active Enterprise workspace sales-managed', async ({
+    page
+  }) => {
+    const workspace = await setupSalesManagedWorkspace(
+      page,
+      CANCELLED_ACTIVE_ENTERPRISE_STATUS
+    )
+    const content = await workspace.openPlanAndCreditsSettings()
+
+    await expect(
+      content.getByRole('heading', { name: 'Enterprise' })
+    ).toBeVisible()
+    await expect(content.getByText('Canceled', { exact: true })).toBeVisible()
+    await expectNoSelfServicePlanActions(content)
+
+    await page
+      .getByTestId('settings-dialog')
+      .getByRole('button', { name: 'Close dialog' })
+      .click()
+    await page.getByTestId('current-user-button').click()
+    const popover = page.getByTestId('current-user-popover')
+    await expect(
+      popover.getByRole('button', { name: 'Resubscribe' })
+    ).toHaveCount(0)
+    await expect(popover.getByTestId('plans-pricing-menu-item')).toHaveCount(0)
+  })
+
+  test('keeps an ended Enterprise workspace out of self-service recovery', async ({
+    page
+  }) => {
+    const workspace = await setupSalesManagedWorkspace(
+      page,
+      ENDED_ENTERPRISE_STATUS
+    )
+    const content = await workspace.openPlanAndCreditsSettings()
+
+    await expect(content.getByText('Your subscription has ended')).toBeVisible()
+    await expect(
+      content.getByRole('heading', { name: 'Enterprise' })
+    ).toBeVisible()
+    await expect(
+      content.getByRole('button', { name: 'Add credits' })
+    ).toBeVisible()
+    await expect(
+      content.getByRole('button', { name: 'Billing & invoices' })
+    ).toBeVisible()
+    await expectNoSelfServicePlanActions(content)
+
+    await expect(page.getByTestId('queue-button')).toBeVisible()
+    await expect(page.getByTestId('subscribe-to-run-button')).toHaveCount(0)
+
+    await page
+      .getByTestId('settings-dialog')
+      .getByRole('button', { name: 'Close dialog' })
+      .click()
+    await page.getByTestId('queue-button').click()
+    await expect(
+      page.getByRole('heading', { name: 'Choose a Plan' })
+    ).toHaveCount(0)
+  })
+})
+
+test.describe('Non-Enterprise billing regression', { tag: '@cloud' }, () => {
+  test('keeps self-service controls and catalog details for a Pro team', async ({
+    page
+  }) => {
+    const workspace = new CloudWorkspaceMockHelper(page)
+    await workspace.setup(DEFAULT_TEAM_MEMBERS, TEAM_WORKSPACE)
+    const content = await workspace.openPlanAndCreditsSettings()
+
+    await expect(
+      content.getByRole('heading', { name: 'Team', exact: true })
+    ).toBeVisible()
+    await expect(
+      content.getByRole('button', { name: 'Change plan' })
+    ).toBeVisible()
+    await expect(
+      content.getByText('Your plan includes everything in Pro, plus:', {
+        exact: false
+      })
+    ).toBeVisible()
+    await expect(
+      content.getByRole('button', { name: 'Add credits' })
+    ).toBeVisible()
+    await expect(
+      content.getByRole('button', { name: 'Billing & invoices' })
+    ).toBeVisible()
+
+    await page
+      .getByTestId('settings-dialog')
+      .getByRole('button', { name: 'Close dialog' })
+      .click()
+    await page.getByTestId('current-user-button').click()
+    await expect(
+      page
+        .getByTestId('current-user-popover')
+        .getByTestId('plans-pricing-menu-item')
+    ).toBeVisible()
+  })
+})
+
+test.describe('Unrecognized billing tier regression', { tag: '@cloud' }, () => {
+  test.describe.configure({ timeout: 60_000 })
+
+  test('keeps an active subscription usable when its tier is unrecognized', async ({
+    page
+  }) => {
+    const pageErrors: string[] = []
+    page.on('pageerror', (error) => pageErrors.push(error.message))
+
+    const workspace = await setupSalesManagedWorkspace(
+      page,
+      TEAM_BILLING_STATUS
+    )
+    await page.route('**/api/billing/status', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(ACTIVE_UNRECOGNIZED_TIER_STATUS)
+      })
+    )
+    const content = await workspace.openPlanAndCreditsSettings()
+
+    await expect(content.getByText('Total credits')).toBeVisible()
+    await expect(
+      content.getByRole('button', { name: 'Add credits' })
+    ).toBeVisible()
+    expect(pageErrors).toEqual([])
+  })
+})

--- a/src/components/actionbar/ComfyRunButton/CloudRunButtonWrapper.test.ts
+++ b/src/components/actionbar/ComfyRunButton/CloudRunButtonWrapper.test.ts
@@ -8,6 +8,7 @@ import CloudRunButtonWrapper from './CloudRunButtonWrapper.vue'
 const mockCanRunWorkflows = ref(true)
 const mockIsInitialized = ref(true)
 const mockBillingStatus = ref<string | null>('paid')
+const mockSubscriptionTier = ref<string | null>(null)
 const state = vi.hoisted(() => ({
   v1PaymentRecovery: true,
   canManageSubscription: true,
@@ -29,6 +30,9 @@ vi.mock('@/composables/billing/useBillingContext', async () => {
         () => mockIsInitialized.value && !mockCanRunWorkflows.value
       ),
       billingStatus: mockBillingStatus,
+      subscription: computed(() =>
+        mockSubscriptionTier.value ? { tier: mockSubscriptionTier.value } : null
+      ),
       manageSubscription: state.manageSubscription,
       fetchStatus: state.fetchStatus,
       fetchBalance: state.fetchBalance
@@ -98,6 +102,7 @@ describe('CloudRunButtonWrapper', () => {
     mockCanRunWorkflows.value = true
     mockIsInitialized.value = true
     mockBillingStatus.value = 'paid'
+    mockSubscriptionTier.value = null
     state.v1PaymentRecovery = true
     state.canManageSubscription = true
   })
@@ -129,6 +134,28 @@ describe('CloudRunButtonWrapper', () => {
 
     expect(screen.getByTestId('subscribe-to-run-button')).toBeInTheDocument()
     expect(screen.queryByTestId('queue-button')).not.toBeInTheDocument()
+  })
+
+  it('keeps the run button without a subscribe upsell on a sales-managed plan', () => {
+    mockCanRunWorkflows.value = false
+    mockSubscriptionTier.value = 'ENTERPRISE'
+    renderWrapper()
+
+    expect(screen.getByTestId('queue-button')).toBeInTheDocument()
+    expect(
+      screen.queryByTestId('subscribe-to-run-button')
+    ).not.toBeInTheDocument()
+  })
+
+  it('keeps the run button without a subscribe upsell on an unrecognized tier', () => {
+    mockCanRunWorkflows.value = false
+    mockSubscriptionTier.value = 'GALACTIC'
+    renderWrapper()
+
+    expect(screen.getByTestId('queue-button')).toBeInTheDocument()
+    expect(
+      screen.queryByTestId('subscribe-to-run-button')
+    ).not.toBeInTheDocument()
   })
 
   it('refreshes stale billing state on focus and restores Run', async () => {

--- a/src/components/actionbar/ComfyRunButton/CloudRunButtonWrapper.vue
+++ b/src/components/actionbar/ComfyRunButton/CloudRunButtonWrapper.vue
@@ -1,6 +1,8 @@
 <template>
   <ComfyQueueButton
-    v-if="!showsSubscribeToRunPrompt || paymentRecoveryLock"
+    v-if="
+      !showsSubscribeToRunPrompt || paymentRecoveryLock || isSalesManagedPlan
+    "
     :payment-recovery-lock="paymentRecoveryLock"
     @payment-recovery-click="showPaymentRecoveryDialog"
   />
@@ -15,6 +17,7 @@ import { useBillingContext } from '@/composables/billing/useBillingContext'
 import { useErrorHandling } from '@/composables/useErrorHandling'
 import { useFeatureFlags } from '@/composables/useFeatureFlags'
 import SubscribeToRunButton from '@/platform/cloud/subscription/components/SubscribeToRun.vue'
+import { isSalesManagedTier } from '@/platform/cloud/subscription/constants/tierPricing'
 import SubscriptionPausedDialog from '@/platform/workspace/components/SubscriptionPausedDialog.vue'
 import { useWorkspaceUI } from '@/platform/workspace/composables/useWorkspaceUI'
 import { useDialogService } from '@/services/dialogService'
@@ -24,10 +27,17 @@ const DIALOG_KEY = 'subscription-paused'
 const {
   showsSubscribeToRunPrompt,
   billingStatus,
+  subscription,
   manageSubscription,
   fetchStatus,
   fetchBalance
 } = useBillingContext()
+
+// A sales-managed plan has no self-serve checkout to upsell into; the run
+// button stays a run button and lapsed access routes through sales.
+const isSalesManagedPlan = computed(() =>
+  isSalesManagedTier(subscription.value?.tier)
+)
 const { flags } = useFeatureFlags()
 const { permissions } = useWorkspaceUI()
 const dialogService = useDialogService()

--- a/src/composables/useCoreCommands.test.ts
+++ b/src/composables/useCoreCommands.test.ts
@@ -210,6 +210,7 @@ vi.mock('@/platform/cloud/subscription/composables/useSubscription', () => ({
 
 const mockBillingState = vi.hoisted(() => ({
   canAccessSubscriptionFeatures: true,
+  subscriptionTier: null as string | null,
   showSubscriptionDialog: vi.fn()
 }))
 vi.mock('@/composables/billing/useBillingContext', () => ({
@@ -217,6 +218,13 @@ vi.mock('@/composables/billing/useBillingContext', () => ({
     canAccessSubscriptionFeatures: {
       get value() {
         return mockBillingState.canAccessSubscriptionFeatures
+      }
+    },
+    subscription: {
+      get value() {
+        return mockBillingState.subscriptionTier
+          ? { tier: mockBillingState.subscriptionTier }
+          : null
       }
     },
     showSubscriptionDialog: mockBillingState.showSubscriptionDialog
@@ -318,6 +326,7 @@ describe('useCoreCommands', () => {
   beforeEach(() => {
     mockDistributionState.isCloud = false
     mockBillingState.canAccessSubscriptionFeatures = true
+    mockBillingState.subscriptionTier = null
     vi.mocked(app.refreshComboInNodes).mockResolvedValue(undefined)
     mockModelStoreRefresh.mockResolvedValue(undefined)
     mockMissingModelStoreRefresh.mockResolvedValue(undefined)
@@ -724,6 +733,20 @@ describe('useCoreCommands', () => {
         expect(mockBillingState.showSubscriptionDialog).toHaveBeenCalledWith({
           reason: 'subscribe_to_run'
         })
+      }
+    )
+
+    it.for(['ENTERPRISE', 'GALACTIC'] as const)(
+      'blocks the run without a subscribe dialog on a sales-managed %s plan',
+      async (tier) => {
+        mockDistributionState.isCloud = true
+        mockBillingState.canAccessSubscriptionFeatures = false
+        mockBillingState.subscriptionTier = tier
+
+        await findCmd('Comfy.QueuePrompt').function()
+
+        expect(app.queuePrompt).not.toHaveBeenCalled()
+        expect(mockBillingState.showSubscriptionDialog).not.toHaveBeenCalled()
       }
     )
 

--- a/src/composables/useCoreCommands.ts
+++ b/src/composables/useCoreCommands.ts
@@ -22,6 +22,7 @@ import {
 import type { Point } from '@/lib/litegraph/src/litegraph'
 import { useBillingContext } from '@/composables/billing/useBillingContext'
 import { useAssetBrowserDialog } from '@/platform/assets/composables/useAssetBrowserDialog'
+import { isSalesManagedTier } from '@/platform/cloud/subscription/constants/tierPricing'
 import { isCloud } from '@/platform/distribution/types'
 import { useMissingModelStore } from '@/platform/missingModel/missingModelStore'
 import { useSettingStore } from '@/platform/settings/settingStore'
@@ -73,8 +74,19 @@ import { useDialogStore } from '@/stores/dialogStore'
 
 const moveSelectedNodesVersionAdded = '1.22.2'
 export function useCoreCommands(): ComfyCommand[] {
-  const { canAccessSubscriptionFeatures, showSubscriptionDialog } =
-    useBillingContext()
+  const {
+    canAccessSubscriptionFeatures,
+    showSubscriptionDialog,
+    subscription
+  } = useBillingContext()
+
+  function blockRunWithoutSubscription(): boolean {
+    if (!isCloud || canAccessSubscriptionFeatures.value) return false
+    if (!isSalesManagedTier(subscription.value?.tier)) {
+      showSubscriptionDialog({ reason: 'subscribe_to_run' })
+    }
+    return true
+  }
   const workflowService = useWorkflowService()
   const workflowStore = useWorkflowStore()
   const settingsDialog = useSettingsDialog()
@@ -506,10 +518,7 @@ export function useCoreCommands(): ComfyCommand[] {
         trigger_source?: ExecutionTriggerSource
       }) => {
         trackRunButton(metadata)
-        if (isCloud && !canAccessSubscriptionFeatures.value) {
-          showSubscriptionDialog({ reason: 'subscribe_to_run' })
-          return
-        }
+        if (blockRunWithoutSubscription()) return
 
         const batchCount = useQueueSettingsStore().batchCount
 
@@ -529,10 +538,7 @@ export function useCoreCommands(): ComfyCommand[] {
         trigger_source?: ExecutionTriggerSource
       }) => {
         trackRunButton(metadata)
-        if (isCloud && !canAccessSubscriptionFeatures.value) {
-          showSubscriptionDialog({ reason: 'subscribe_to_run' })
-          return
-        }
+        if (blockRunWithoutSubscription()) return
 
         const batchCount = useQueueSettingsStore().batchCount
 
@@ -551,10 +557,7 @@ export function useCoreCommands(): ComfyCommand[] {
         trigger_source?: ExecutionTriggerSource
       }) => {
         trackRunButton(metadata)
-        if (isCloud && !canAccessSubscriptionFeatures.value) {
-          showSubscriptionDialog({ reason: 'subscribe_to_run' })
-          return
-        }
+        if (blockRunWithoutSubscription()) return
 
         const batchCount = useQueueSettingsStore().batchCount
         const selectedNodes = getSelectedNodes()

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2874,6 +2874,7 @@
     "planLoadError": "We couldn't load your plan details.",
     "planLoadErrorRetry": "Try again",
     "teamPlanName": "Team",
+    "unknownTierName": "Current plan",
     "teamPlanIncludes": "Your plan includes everything in {plan}, plus:",
     "inactiveTeamTitle": "Inactive team subscription",
     "inactiveTeamDescription": "Reactivate your team plan to add more members and run workflows",

--- a/src/platform/cloud/subscription/components/CreditsTile.test.ts
+++ b/src/platform/cloud/subscription/components/CreditsTile.test.ts
@@ -355,6 +355,9 @@ describe('CreditsTile', () => {
 
   it('shows disabled credit details for an inactive plan', () => {
     activeProSubscription()
+    // Lapsed self-serve plans withhold top-up server-side
+    // (lapsedSelfServeCapabilities), which is what zeroes the tile.
+    state.canTopUp = false
     const { container } = renderTile({ inactivePlan: true })
 
     expect(container.textContent).toContain('0remaining')
@@ -363,6 +366,52 @@ describe('CreditsTile', () => {
       'Reactivate your plan to use these credits'
     )
     expect(screen.queryByText('Add credits')).toBeNull()
+  })
+
+  it('keeps Add credits and the real balance on an inactive sales-managed plan', () => {
+    activeProSubscription()
+    // hideLifecycleCapabilities keeps top-up open for Enterprise whatever the
+    // subscription row says, so the inactive zero-state must not apply.
+    state.canTopUp = true
+    state.tier = 'ENTERPRISE'
+    state.subscription = {
+      tier: 'ENTERPRISE',
+      duration: 'MONTHLY',
+      renewalDate: '2026-02-20T12:00:00Z'
+    }
+    const { container } = renderTile({ inactivePlan: true })
+
+    expect(container.textContent).not.toContain(
+      'Reactivate your plan to use these credits'
+    )
+    expect(screen.getByText('Add credits')).toBeInTheDocument()
+  })
+
+  it('does not borrow a catalog monthly pool for an Enterprise plan', () => {
+    activeProSubscription()
+    state.tier = 'ENTERPRISE'
+    state.subscription = {
+      tier: 'ENTERPRISE',
+      duration: 'MONTHLY',
+      renewalDate: '2026-02-20T12:00:00Z'
+    }
+    const { container } = renderTile()
+
+    expect(container.textContent).not.toContain('left of')
+  })
+
+  it('does not borrow a catalog monthly pool for an unrecognized tier', () => {
+    activeProSubscription()
+    const galactic = 'GALACTIC' as unknown as SubscriptionInfo['tier']
+    state.tier = galactic
+    state.subscription = {
+      tier: galactic,
+      duration: 'MONTHLY',
+      renewalDate: '2026-02-20T12:00:00Z'
+    }
+    const { container } = renderTile()
+
+    expect(container.textContent).not.toContain('left of')
   })
 
   it('keeps top-up available without an active subscription', () => {

--- a/src/platform/cloud/subscription/components/CreditsTile.vue
+++ b/src/platform/cloud/subscription/components/CreditsTile.vue
@@ -156,7 +156,7 @@
       </div>
     </template>
 
-    <template v-else-if="inactivePlan">
+    <template v-else-if="showsInactivePlanState">
       <div class="h-px w-full bg-interface-stroke" />
       <div class="flex flex-col gap-2">
         <div class="flex items-center justify-between gap-2 text-sm">
@@ -230,6 +230,7 @@ import { useSubscriptionCredits } from '@/platform/cloud/subscription/composable
 import { useSubscriptionDialog } from '@/platform/cloud/subscription/composables/useSubscriptionDialog'
 import {
   DEFAULT_TIER_KEY,
+  isSalesManagedTier,
   toTierKey,
   getTierCredits
 } from '@/platform/cloud/subscription/constants/tierPricing'
@@ -282,12 +283,21 @@ const tierKey = computed(() => {
 const creditPoolTotalCredits = computed<number | null>(() => {
   const monthlyCredits =
     currentTeamCreditStop.value?.credits_monthly ??
-    getTierCredits(tierKey.value)
+    (isSalesManagedTier(subscription.value?.tier)
+      ? null
+      : getTierCredits(tierKey.value))
   if (monthlyCredits === null) return null
   return subscription.value?.duration === 'ANNUAL'
     ? monthlyCredits * 12
     : monthlyCredits
 })
+
+// The server keeps top-up open for sales-managed plans whatever their
+// subscription row says, so their real balance must never be zeroed into the
+// reactivate-to-use-credits treatment reserved for lapsed self-serve plans.
+const showsInactivePlanState = computed(
+  () => inactivePlan === true && !canTopUp.value
+)
 
 const usage = computed(() =>
   computeMonthlyUsage(
@@ -339,10 +349,14 @@ const creditPoolTotalCompact = computed(() => {
 })
 
 const displayTotal = computed(() =>
-  zeroState || inactivePlan ? formatCreditCount(0) : totalCredits.value
+  zeroState || showsInactivePlanState.value
+    ? formatCreditCount(0)
+    : totalCredits.value
 )
 const displayPrepaid = computed(() =>
-  zeroState || inactivePlan ? formatCreditCount(0) : prepaidCredits.value
+  zeroState || showsInactivePlanState.value
+    ? formatCreditCount(0)
+    : prepaidCredits.value
 )
 const usedBarWidth = computed(
   () => `${(usage.value.usedFraction * 100).toFixed(2)}%`
@@ -355,7 +369,10 @@ const monthlyUsageLabel = computed(() =>
 )
 
 const showBreakdown = computed(
-  () => canAccessSubscriptionFeatures.value && !zeroState && !inactivePlan
+  () =>
+    canAccessSubscriptionFeatures.value &&
+    !zeroState &&
+    !showsInactivePlanState.value
 )
 // The monthly allowance bar is a Cloud-only presentation; Local/Desktop shows
 // only the total and additional-credit balances.
@@ -370,7 +387,7 @@ const showActionButton = computed(
   () =>
     (canTopUp.value || canSubscribeSelfServe.value) &&
     !zeroState &&
-    !inactivePlan
+    !showsInactivePlanState.value
 )
 
 const isMonthlyDepleted = computed(

--- a/src/platform/cloud/subscription/composables/usePricingTableUrlLoader.test.ts
+++ b/src/platform/cloud/subscription/composables/usePricingTableUrlLoader.test.ts
@@ -56,8 +56,22 @@ vi.mock('@/composables/billing/useBillingContext', () => ({
   })
 }))
 
+const mockCanOpenPricingSurface = vi.hoisted(() => ({ value: true }))
+const mockInitializeCapabilities = vi.hoisted(() =>
+  vi.fn(async () => undefined)
+)
+
 vi.mock('@/platform/workspace/composables/useWorkspaceUI', () => ({
-  useWorkspaceUI: () => ({ permissions: mockPermissions })
+  useWorkspaceUI: () => ({
+    permissions: mockPermissions,
+    canOpenPricingSurface: mockCanOpenPricingSurface
+  })
+}))
+
+vi.mock('@/platform/workspace/composables/useBillingCapabilities', () => ({
+  useBillingCapabilities: () => ({
+    initialize: mockInitializeCapabilities
+  })
 }))
 
 const TEAM_CREDIT_STOPS = {
@@ -80,6 +94,9 @@ describe('usePricingTableUrlLoader', () => {
   beforeEach(() => {
     mockRouteQuery.value = {}
     mockPermissions.value = { canManageSubscription: true }
+    mockCanOpenPricingSurface.value = true
+    mockInitializeCapabilities.mockClear()
+    mockInitializeCapabilities.mockResolvedValue(undefined)
     mockTeamCreditStops.value = TEAM_CREDIT_STOPS
     mockFetchPlans.mockResolvedValue(undefined)
     mockShowPricingTable.mockResolvedValue(undefined)
@@ -106,6 +123,31 @@ describe('usePricingTableUrlLoader', () => {
       expect.objectContaining({ reason: 'deep_link' })
     )
     expect(mockRouterReplace).toHaveBeenCalledWith({ query: {} })
+  })
+
+  it('never opens for a sales-managed workspace, even from a deep link', async () => {
+    mockRouteQuery.value = { pricing: '1' }
+    mockCanOpenPricingSurface.value = false
+
+    const { loadPricingTableFromUrl } = usePricingTableUrlLoader()
+    await loadPricingTableFromUrl()
+
+    expect(mockShowPricingTable).not.toHaveBeenCalled()
+    expect(mockRouterReplace).toHaveBeenCalledWith({ query: {} })
+  })
+
+  it('resolves the capability snapshot before deciding', async () => {
+    mockRouteQuery.value = { pricing: '1' }
+    mockCanOpenPricingSurface.value = true
+    mockInitializeCapabilities.mockImplementation(async () => {
+      mockCanOpenPricingSurface.value = false
+    })
+
+    const { loadPricingTableFromUrl } = usePricingTableUrlLoader()
+    await loadPricingTableFromUrl()
+
+    expect(mockInitializeCapabilities).toHaveBeenCalledOnce()
+    expect(mockShowPricingTable).not.toHaveBeenCalled()
   })
 
   it('opens on the team tab for ?pricing=team', async () => {

--- a/src/platform/cloud/subscription/composables/usePricingTableUrlLoader.ts
+++ b/src/platform/cloud/subscription/composables/usePricingTableUrlLoader.ts
@@ -10,6 +10,7 @@ import {
 import { PRESERVED_QUERY_NAMESPACES } from '@/platform/navigation/preservedQueryNamespaces'
 import type { TeamCreditStops } from '@/platform/workspace/api/workspaceApi'
 import type { SubscriptionCheckoutSelection } from '@/platform/workspace/composables/useSubscriptionCheckout'
+import { useBillingCapabilities } from '@/platform/workspace/composables/useBillingCapabilities'
 import { useWorkspaceUI } from '@/platform/workspace/composables/useWorkspaceUI'
 
 const NAMESPACE = PRESERVED_QUERY_NAMESPACES.PRICING
@@ -103,7 +104,8 @@ export function usePricingTableUrlLoader() {
   const router = useRouter()
   const subscriptionDialog = useSubscriptionDialog()
   const { teamCreditStops, fetchPlans } = useBillingContext()
-  const { permissions } = useWorkspaceUI()
+  const { permissions, canOpenPricingSurface } = useWorkspaceUI()
+  const { initialize: initializeCapabilities } = useBillingCapabilities()
 
   /** Reads `?pricing=`, strips it, and opens the table when the gate allows. */
   async function loadPricingTableFromUrl() {
@@ -139,6 +141,11 @@ export function usePricingTableUrlLoader() {
     if (typeof param !== 'string' || !param) return
 
     if (!permissions.value.canManageSubscription) return
+
+    // The loader can run before the capability snapshot resolves; a
+    // sales-managed workspace must not see the table through that gap.
+    await initializeCapabilities()
+    if (!canOpenPricingSurface.value) return
 
     const teamCheckoutRequest = getTeamCheckoutRequest(
       param,

--- a/src/platform/cloud/subscription/constants/tierPricing.test.ts
+++ b/src/platform/cloud/subscription/constants/tierPricing.test.ts
@@ -1,7 +1,13 @@
 import { describe, expect, it } from 'vitest'
 
 import type { IngestSubscriptionTier } from './tierPricing'
-import { hasActivePaidPlan, toTierKey } from './tierPricing'
+import {
+  hasActivePaidPlan,
+  isEnterprisePlanSlug,
+  isSalesManagedTier,
+  isUnknownTier,
+  toTierKey
+} from './tierPricing'
 
 describe('toTierKey', () => {
   it('maps every personal-catalog tier to its key', () => {
@@ -57,5 +63,43 @@ describe('hasActivePaidPlan', () => {
     expect(hasActivePaidPlan('FREE')).toBe(false)
     expect(hasActivePaidPlan(null)).toBe(false)
     expect(hasActivePaidPlan(undefined)).toBe(false)
+  })
+})
+
+describe('isEnterprisePlanSlug', () => {
+  it('matches enterprise slugs in either case', () => {
+    expect(isEnterprisePlanSlug('enterprise_monthly')).toBe(true)
+    expect(isEnterprisePlanSlug('ENTERPRISE_ANNUAL')).toBe(true)
+  })
+
+  it('rejects catalog slugs and absent values', () => {
+    expect(isEnterprisePlanSlug('team-monthly')).toBe(false)
+    expect(isEnterprisePlanSlug(null)).toBe(false)
+    expect(isEnterprisePlanSlug(undefined)).toBe(false)
+  })
+})
+
+describe('isUnknownTier', () => {
+  it('flags only tiers outside the catalog and the workspace-level set', () => {
+    expect(isUnknownTier('GALACTIC' as unknown as IngestSubscriptionTier)).toBe(
+      true
+    )
+    expect(isUnknownTier('PRO')).toBe(false)
+    expect(isUnknownTier('TEAM')).toBe(false)
+    expect(isUnknownTier('ENTERPRISE')).toBe(false)
+    expect(isUnknownTier(null)).toBe(false)
+    expect(isUnknownTier(undefined)).toBe(false)
+  })
+})
+
+describe('isSalesManagedTier', () => {
+  it('covers Enterprise and unrecognised tiers, nothing else', () => {
+    expect(isSalesManagedTier('ENTERPRISE')).toBe(true)
+    expect(
+      isSalesManagedTier('GALACTIC' as unknown as IngestSubscriptionTier)
+    ).toBe(true)
+    expect(isSalesManagedTier('PRO')).toBe(false)
+    expect(isSalesManagedTier('TEAM')).toBe(false)
+    expect(isSalesManagedTier(null)).toBe(false)
   })
 })

--- a/src/platform/cloud/subscription/constants/tierPricing.ts
+++ b/src/platform/cloud/subscription/constants/tierPricing.ts
@@ -79,6 +79,33 @@ export function toTierKey(tier: IngestSubscriptionTier): TierKey | null {
   return isRegistrySubscriptionTier(tier) ? TIER_TO_KEY[tier] : null
 }
 
+// Enterprise plans are intentionally absent from the self-serve catalog, so a
+// scheduled change to one cannot be resolved through `plans` and carries no
+// tier to read. The slug is the only signal on that path; everywhere a tier
+// exists, compare it to 'ENTERPRISE' directly.
+export function isEnterprisePlanSlug(slug: string | null | undefined): boolean {
+  return slug?.toLowerCase().startsWith('enterprise') === true
+}
+
+// A tier the frontend cannot map to its catalog and that is not one of the
+// workspace-level tiers it knows about. Price and feature claims must never be
+// borrowed for a plan we cannot identify (FE-1662 story 6).
+export function isUnknownTier(
+  tier: IngestSubscriptionTier | null | undefined
+): boolean {
+  if (tier == null || tier === 'TEAM' || tier === 'ENTERPRISE') return false
+  return toTierKey(tier) === null
+}
+
+// Enterprise and unrecognized tiers share one presentation: no catalog price,
+// benefits, or pricing surfaces. The server hides their lifecycle capabilities
+// (billing-api hideLifecycleCapabilities); this helper only drives rendering.
+export function isSalesManagedTier(
+  tier: IngestSubscriptionTier | null | undefined
+): boolean {
+  return tier === 'ENTERPRISE' || isUnknownTier(tier)
+}
+
 // Includes the workspace-level TEAM, which toTierKey maps to null: a catalog
 // key is not a usable test for "is on a paid plan".
 export function hasActivePaidPlan(

--- a/src/platform/workspace/components/CurrentUserPopoverWorkspace.test.ts
+++ b/src/platform/workspace/components/CurrentUserPopoverWorkspace.test.ts
@@ -23,6 +23,7 @@ const state = vi.hoisted(() => ({
   canManageSubscriptionLifecycle: false,
   canReactivate: false,
   canReactivatePlan: false,
+  canOpenPricingSurface: false,
   shouldUseWorkspaceBilling: true,
   showCreateWorkspaceDialog: vi.fn(),
   showTopUpCreditsDialog: vi.fn(),
@@ -79,7 +80,8 @@ vi.mock('@/platform/workspace/composables/useWorkspaceUI', () => ({
       canManageSubscription: state.canManageSubscription,
       canManageSubscriptionLifecycle: state.canManageSubscriptionLifecycle
     })),
-    canReactivatePlan: computed(() => state.canReactivatePlan)
+    canReactivatePlan: computed(() => state.canReactivatePlan),
+    canOpenPricingSurface: computed(() => state.canOpenPricingSurface)
   })
 }))
 
@@ -198,6 +200,7 @@ describe('CurrentUserPopoverWorkspace', () => {
     state.canSubscribeSelfServe = false
     state.canManageSubscription = false
     state.canManageSubscriptionLifecycle = false
+    state.canOpenPricingSurface = false
     state.canReactivate = false
     state.shouldUseWorkspaceBilling = true
   })
@@ -537,6 +540,7 @@ describe('CurrentUserPopoverWorkspace', () => {
     state.canManageSubscription = true
     state.canManageSubscriptionLifecycle = true
     state.canReactivatePlan = true
+    state.canOpenPricingSurface = true
     renderComponent('team')
 
     expect(screen.getByTestId('add-credits-button')).toBeInTheDocument()
@@ -546,6 +550,33 @@ describe('CurrentUserPopoverWorkspace', () => {
     await user.click(screen.getByRole('button', { name: 'Resubscribe' }))
 
     expect(state.showPricingTable).toHaveBeenCalledOnce()
+  })
+
+  it('hides Plans & pricing on a sales-managed plan but keeps Manage plan', () => {
+    // Server-resolved for Enterprise/unrecognized tiers: no self-serve
+    // catalog, so canOpenPricingSurface resolves false while the plan is
+    // still manageable through settings.
+    state.canManageSubscription = true
+    state.canOpenPricingSurface = false
+    renderComponent('team')
+
+    expect(
+      screen.queryByTestId('plans-pricing-menu-item')
+    ).not.toBeInTheDocument()
+    expect(screen.getByTestId('manage-plan-menu-item')).toBeInTheDocument()
+  })
+
+  it('hides Resubscribe for a cancelled sales-managed plan', () => {
+    state.isCancelled = true
+    state.canManageSubscription = true
+    state.canManageSubscriptionLifecycle = true
+    state.canReactivate = false
+    state.canReactivatePlan = false
+    renderComponent('team')
+
+    expect(
+      screen.queryByRole('button', { name: 'Resubscribe' })
+    ).not.toBeInTheDocument()
   })
 
   it('reads the derived reactivate policy, not the raw server capability', () => {

--- a/src/platform/workspace/components/CurrentUserPopoverWorkspace.vue
+++ b/src/platform/workspace/components/CurrentUserPopoverWorkspace.vue
@@ -281,7 +281,8 @@ const {
   workspaceName,
   isInPersonalWorkspace: isPersonalWorkspace
 } = storeToRefs(workspaceStore)
-const { permissions, canReactivatePlan } = useWorkspaceUI()
+const { permissions, canReactivatePlan, canOpenPricingSurface } =
+  useWorkspaceUI()
 const { canTopUp, canSubscribeSelfServe } = useBillingCapabilities()
 const isWorkspaceSwitcherOpen = ref(false)
 const workspaceSwitcherTrigger = useTemplateRef('workspaceSwitcherTrigger')
@@ -345,9 +346,7 @@ const displayedCredits = computed(() => {
   })
 })
 
-const showPlansAndPricing = computed(
-  () => permissions.value.canManageSubscription
-)
+const showPlansAndPricing = canOpenPricingSurface
 // Subscribing is a Cloud-only concept: Local users manage plan/credits
 // through settings instead (see showLocalPlansAndCredits below), regardless
 // of subscription status.

--- a/src/platform/workspace/components/SubscriptionPanelContentWorkspace.test.ts
+++ b/src/platform/workspace/components/SubscriptionPanelContentWorkspace.test.ts
@@ -86,6 +86,7 @@ const mockCanManageSubscriptionLifecycle = ref(true)
 const mockCanCancel = ref(true)
 const mockCanReactivate = ref(true)
 const mockCanReactivatePlan = ref(true)
+const mockCanOpenPricingSurface = ref(true)
 const mockShouldUseWorkspaceBilling = ref(true)
 const mockCanChangeSeats = ref(true)
 const mockCanSubscribeSelfServe = ref(true)
@@ -225,6 +226,7 @@ vi.mock('@/platform/workspace/composables/useWorkspaceUI', () => ({
       canLeaveWorkspace: mockCanLeaveWorkspace.value
     })),
     canReactivatePlan: mockCanReactivatePlan,
+    canOpenPricingSurface: mockCanOpenPricingSurface,
     uiConfig: computed(() => mockUiConfig.value),
     isInPersonalWorkspace: mockIsInPersonalWorkspace,
     isActiveSubscription: computed(() => mockIsActiveSubscription.value),
@@ -346,9 +348,11 @@ describe('SubscriptionPanelContentWorkspace', () => {
     mockCanManageSubscriptionLifecycle.value = true
     mockCanCancel.value = true
     mockCanReactivate.value = true
+    mockCanReactivatePlan.value = true
     mockShouldUseWorkspaceBilling.value = true
     mockCanChangeSeats.value = true
     mockCanSubscribeSelfServe.value = true
+    mockCanOpenPricingSurface.value = true
     mockCanLeaveWorkspace.value = true
     mockUiConfig.value = ownerUiConfig
     mockSubscriptionTier.value = 'PRO'
@@ -418,6 +422,111 @@ describe('SubscriptionPanelContentWorkspace', () => {
       'data-show-invoice-history',
       'true'
     )
+  })
+
+  describe('sales-managed tiers (FE-1662)', () => {
+    const runtimeTier = (tier: string) =>
+      tier as unknown as SubscriptionInfo['tier']
+
+    // Mirrors billing-api hideLifecycleCapabilities: lifecycle actions and the
+    // self-serve catalog close, credit top-up stays open.
+    function useSalesManagedCapabilities() {
+      mockCanCancel.value = false
+      mockCanReactivate.value = false
+      mockCanReactivatePlan.value = false
+      mockCanChangeSeats.value = false
+      mockCanSubscribeSelfServe.value = false
+      mockCanOpenPricingSurface.value = false
+    }
+
+    function useEnterprisePlan() {
+      mockHasTeamPlan.value = false
+      mockSubscriptionTier.value = 'ENTERPRISE'
+      mockPlanSlug.value = 'enterprise_monthly'
+      mockCurrentTeamCreditStop.value = null
+      useSalesManagedCapabilities()
+    }
+
+    it('renders Enterprise without price, benefits, or a plan-change action', () => {
+      useEnterprisePlan()
+      renderComponent()
+
+      expect(screen.getByText('Enterprise')).toBeInTheDocument()
+      expect(screen.queryByText('$665')).not.toBeInTheDocument()
+      expect(screen.queryByText('USD / mo')).not.toBeInTheDocument()
+      expect(screen.queryByText('Your plan includes:')).not.toBeInTheDocument()
+      expect(
+        screen.queryByText('View more details about plans & pricing')
+      ).not.toBeInTheDocument()
+      expect(
+        screen.queryByRole('button', { name: /change plan|upgrade plan/i })
+      ).not.toBeInTheDocument()
+      expect(
+        screen.getByText(`Renews on ${formatPanelDate(RENEWAL_DATE_ISO)}`)
+      ).toBeInTheDocument()
+    })
+
+    it('keeps Billing & invoices open on an Enterprise plan', () => {
+      useEnterprisePlan()
+      renderComponent()
+
+      expect(
+        screen.getByRole('button', { name: 'Billing & invoices' })
+      ).toBeInTheDocument()
+    })
+
+    it('hides Reactivate for a cancelled Enterprise plan', () => {
+      useEnterprisePlan()
+      mockSubscriptionStatus.value = 'canceled'
+      renderComponent()
+
+      expect(
+        screen.queryByRole('button', { name: /reactivate/i })
+      ).not.toBeInTheDocument()
+    })
+
+    it('offers no subscribe or reactivate path for an ended Enterprise plan', () => {
+      useEnterprisePlan()
+      mockSubscriptionStatus.value = 'ended'
+      mockIsActiveSubscription.value = false
+      renderComponent()
+
+      expect(screen.getByText('Enterprise')).toBeInTheDocument()
+      expect(
+        screen.queryByRole('button', { name: /subscribe|reactivate/i })
+      ).not.toBeInTheDocument()
+    })
+
+    it('renders an unrecognized tier as Current plan without catalog content', () => {
+      mockHasTeamPlan.value = false
+      mockSubscriptionTier.value = runtimeTier('GALACTIC')
+      mockPlanSlug.value = 'galactic_monthly'
+      mockCurrentTeamCreditStop.value = null
+      useSalesManagedCapabilities()
+      renderComponent()
+
+      expect(screen.getByText('Current plan')).toBeInTheDocument()
+      expect(screen.queryByText('$665')).not.toBeInTheDocument()
+      expect(screen.queryByText('USD / mo')).not.toBeInTheDocument()
+      expect(
+        screen.queryByRole('button', { name: /change plan|upgrade plan/i })
+      ).not.toBeInTheDocument()
+      expect(
+        screen.getByText(`Renews on ${formatPanelDate(RENEWAL_DATE_ISO)}`)
+      ).toBeInTheDocument()
+    })
+
+    it('labels a scheduled change to Enterprise outside the self-serve catalog', () => {
+      mockScheduledPlanSlug.value = 'enterprise_monthly'
+      mockChangeAt.value = END_DATE_ISO
+      renderComponent()
+
+      expect(
+        screen.getByText(
+          `Changes to Enterprise on ${formatPanelDate(END_DATE_ISO)}`
+        )
+      ).toBeInTheDocument()
+    })
   })
 
   it('shows a scheduled plan change instead of the renewal date', () => {

--- a/src/platform/workspace/components/SubscriptionPanelContentWorkspace.vue
+++ b/src/platform/workspace/components/SubscriptionPanelContentWorkspace.vue
@@ -225,7 +225,10 @@
                     severity="warn"
                   />
                 </div>
-                <div class="flex items-baseline gap-1 font-inter">
+                <div
+                  v-if="!isNonCatalogPlan"
+                  class="flex items-baseline gap-1 font-inter"
+                >
                   <span class="text-2xl font-semibold">{{ displayPrice }}</span>
                   <span class="text-base">{{ priceUnitLabel }}</span>
                 </div>
@@ -317,9 +320,10 @@
 
           <div
             v-if="
-              canAccessSubscriptionFeatures ||
-              isPersonalFree ||
-              showInactiveTeamSubscription
+              !isNonCatalogPlan &&
+              (canAccessSubscriptionFeatures ||
+                isPersonalFree ||
+                showInactiveTeamSubscription)
             "
             class="flex flex-col gap-2"
           >
@@ -379,7 +383,7 @@
       </div>
 
       <!-- View More Details - Outside main content -->
-      <div v-if="permissions.canManageSubscription" class="py-6">
+      <div v-if="canOpenPricingSurface" class="py-6">
         <Button
           variant="muted-textonly"
           class="text-sm text-muted"
@@ -413,6 +417,11 @@ import Button from '@/components/ui/button/Button.vue'
 import { useBillingContext } from '@/composables/billing/useBillingContext'
 import { useSubscriptionDialog } from '@/platform/cloud/subscription/composables/useSubscriptionDialog'
 import { useFreeTierQuota } from '@/platform/cloud/subscription/composables/useFreeTierQuota'
+import {
+  isEnterprisePlanSlug,
+  isSalesManagedTier,
+  isUnknownTier
+} from '@/platform/cloud/subscription/constants/tierPricing'
 import type { TierBenefit } from '@/platform/cloud/subscription/utils/tierBenefits'
 import { getCommonTierBenefits } from '@/platform/cloud/subscription/utils/tierBenefits'
 import { isCloud } from '@/platform/distribution/types'
@@ -435,7 +444,8 @@ const {
   permissions,
   isSubscriptionCancelled,
   workspaceRole,
-  canReactivatePlan
+  canReactivatePlan,
+  canOpenPricingSurface
 } = useWorkspaceUI()
 const { canChangeSeats, canSubscribeSelfServe } = useBillingCapabilities()
 const { maxAvailable: freeRunsAllowance, quotaEnabled: freeRunsQuotaEnabled } =
@@ -581,12 +591,22 @@ const formattedChangeDate = computed(() =>
 )
 
 const scheduledPlanName = computed(() => {
+  const scheduledPlanSlug = subscription.value?.scheduledPlanSlug
+  if (isEnterprisePlanSlug(scheduledPlanSlug)) {
+    return t('subscription.tiers.enterprise.name')
+  }
   const scheduledPlan = plans.value.find(
-    (plan) => plan.slug === subscription.value?.scheduledPlanSlug
+    (plan) => plan.slug === scheduledPlanSlug
   )
   if (!scheduledPlan) return ''
+  if (scheduledPlan.tier === 'ENTERPRISE') {
+    return t('subscription.tiers.enterprise.name')
+  }
   if (scheduledPlan.slug.startsWith('team')) {
     return t('subscription.teamPlanName')
+  }
+  if (isUnknownTier(scheduledPlan.tier)) {
+    return t('subscription.unknownTierName')
   }
   return t(
     `subscription.tiers.${resolveSubscriptionTierKey(scheduledPlan.tier)}.name`
@@ -646,9 +666,21 @@ const subscriptionTierName = computed(() => {
     : baseName
 })
 
-const planDisplayName = computed(() =>
-  isTeamPlan.value ? t('subscription.teamPlanName') : subscriptionTierName.value
+const isEnterprisePlan = computed(
+  () => subscription.value?.tier === 'ENTERPRISE'
 )
+
+const isNonCatalogPlan = computed(() =>
+  isSalesManagedTier(subscription.value?.tier)
+)
+
+const planDisplayName = computed(() => {
+  if (isEnterprisePlan.value) return t('subscription.tiers.enterprise.name')
+  if (isNonCatalogPlan.value) return t('subscription.unknownTierName')
+  return isTeamPlan.value
+    ? t('subscription.teamPlanName')
+    : subscriptionTierName.value
+})
 
 const tierKey = computed(() =>
   resolveSubscriptionTierKey(subscription.value?.tier)
@@ -662,6 +694,7 @@ const TEAM_PERK_KEYS = [
 ] as const
 
 const tierBenefits = computed((): TierBenefit[] => {
+  if (isNonCatalogPlan.value) return []
   if (isTeamActive.value || showInactiveTeamSubscription.value) {
     return TEAM_PERK_KEYS.map((key) => ({
       key,

--- a/src/platform/workspace/components/SubscriptionTransitionPreviewWorkspace.vue
+++ b/src/platform/workspace/components/SubscriptionTransitionPreviewWorkspace.vue
@@ -373,7 +373,7 @@ const emit = defineEmits<{
   retryAuthentication: []
 }>()
 
-const { locale, n, t } = useI18n()
+const { locale, n, t, te } = useI18n()
 const verificationRecoveryActive = computed(
   () =>
     embeddedCheckoutEnabled &&
@@ -405,7 +405,10 @@ function openVerification() {
 }
 
 function formatTierName(tier: string): string {
-  return t(`subscription.tiers.${tier.toLowerCase()}.name`)
+  const nameKey = `subscription.tiers.${tier.toLowerCase()}.name`
+  if (te(nameKey)) return t(nameKey)
+  const lower = tier.toLowerCase()
+  return lower.charAt(0).toUpperCase() + lower.slice(1)
 }
 
 function isTeamTier(tier: string): boolean {

--- a/src/platform/workspace/composables/useWorkspaceMenuItems.test.ts
+++ b/src/platform/workspace/composables/useWorkspaceMenuItems.test.ts
@@ -14,6 +14,7 @@ const state = vi.hoisted(() => ({
   isFreeTier: false,
   isInPersonalWorkspace: false,
   planSlug: 'pro-monthly' as string | null,
+  tier: null as string | null,
   shouldUseWorkspaceBilling: true,
   isSubscriptionCancelled: false
 }))
@@ -35,7 +36,8 @@ vi.mock('@/composables/billing/useBillingContext', () => ({
     isFreeTier: computed(() => state.isFreeTier),
     subscription: computed(() => ({
       endDate: '2026-08-01T00:00:00Z',
-      planSlug: state.planSlug
+      planSlug: state.planSlug,
+      tier: state.tier
     }))
   })
 }))
@@ -102,6 +104,7 @@ describe('useWorkspaceMenuItems', () => {
     state.isFreeTier = false
     state.isInPersonalWorkspace = false
     state.planSlug = 'pro-monthly'
+    state.tier = null
     state.shouldUseWorkspaceBilling = true
     state.isSubscriptionCancelled = false
   })
@@ -154,6 +157,45 @@ describe('useWorkspaceMenuItems', () => {
     expect(menuItems.value.map((item) => item.label)).toContain(
       'subscription.cancelPlan'
     )
+  })
+
+  it.for(['ENTERPRISE', 'GALACTIC'] as const)(
+    'withholds cancellation from a sales-managed %s plan on the legacy rail',
+    (tier) => {
+      state.shouldUseWorkspaceBilling = false
+      state.canManageSubscriptionLifecycle = true
+      state.tier = tier
+
+      const { menuItems } = useWorkspaceMenuItems()
+
+      expect(menuItems.value.map((item) => item.label)).not.toContain(
+        'subscription.cancelPlan'
+      )
+    }
+  )
+
+  it('hides Delete for an Enterprise workspace owner', () => {
+    state.canManageSubscription = true
+    state.planSlug = 'enterprise_monthly'
+    state.tier = 'ENTERPRISE'
+
+    const { menuItems } = useWorkspaceMenuItems()
+
+    expect(menuItems.value.map((item) => item.label)).not.toContain(
+      'workspacePanel.menu.deleteWorkspace'
+    )
+  })
+
+  it('keeps Leave available for an Enterprise workspace member', () => {
+    state.canLeaveWorkspace = true
+    state.planSlug = 'enterprise_monthly'
+    state.tier = 'ENTERPRISE'
+
+    const { menuItems } = useWorkspaceMenuItems()
+
+    expect(menuItems.value.map((item) => item.label)).toEqual([
+      'workspacePanel.menu.leaveWorkspace'
+    ])
   })
 
   it('withholds cancellation for an already-cancelled plan', () => {

--- a/src/platform/workspace/composables/useWorkspaceMenuItems.ts
+++ b/src/platform/workspace/composables/useWorkspaceMenuItems.ts
@@ -5,6 +5,7 @@ import type { MenuItem } from 'primevue/menuitem'
 
 import { useBillingContext } from '@/composables/billing/useBillingContext'
 import { useBillingRouting } from '@/composables/billing/useBillingRouting'
+import { isSalesManagedTier } from '@/platform/cloud/subscription/constants/tierPricing'
 import { isCloud } from '@/platform/distribution/types'
 import { useBillingCapabilities } from '@/platform/workspace/composables/useBillingCapabilities'
 import { useWorkspaceUI } from '@/platform/workspace/composables/useWorkspaceUI'
@@ -76,13 +77,19 @@ export function useWorkspaceMenuItems() {
           billingStatus.value === 'paused') &&
           Boolean(subscription.value?.planSlug))) &&
       !isSubscriptionCancelled.value &&
-      !isFreeTier.value
+      !isFreeTier.value &&
+      !isSalesManagedTier(subscription.value?.tier)
     )
   })
 
+  // Deleting a workspace requires cancelling its plan first, and an Enterprise
+  // plan only ends through sales — so Delete would be a permanently disabled
+  // dead end. Hidden entirely per DES-782.
   const canDeleteWorkspace = computed(
     () =>
-      permissions.value.canManageSubscription && !isInPersonalWorkspace.value
+      permissions.value.canManageSubscription &&
+      !isInPersonalWorkspace.value &&
+      subscription.value?.tier !== 'ENTERPRISE'
   )
 
   const deleteTooltip = computed(() => {

--- a/src/platform/workspace/composables/useWorkspaceUI.test.ts
+++ b/src/platform/workspace/composables/useWorkspaceUI.test.ts
@@ -12,6 +12,7 @@ const mockStore = vi.hoisted(() => ({
 const mockIsCloud = ref(true)
 const mockShouldUseWorkspaceBilling = ref(true)
 const mockCanReactivate = ref(false)
+const mockCanSubscribeSelfServe = ref(true)
 const mockIsActiveSubscription = vi.hoisted(() => ({ value: false }))
 const mockIsCancelled = vi.hoisted(() => ({ value: false }))
 const mockIsTeamPlan = vi.hoisted(() => ({ value: false }))
@@ -54,7 +55,8 @@ vi.mock('@/composables/billing/useBillingRouting', () => ({
 
 vi.mock('@/platform/workspace/composables/useBillingCapabilities', () => ({
   useBillingCapabilities: () => ({
-    canReactivate: computed(() => mockCanReactivate.value)
+    canReactivate: computed(() => mockCanReactivate.value),
+    canSubscribeSelfServe: computed(() => mockCanSubscribeSelfServe.value)
   })
 }))
 
@@ -126,6 +128,7 @@ function resetStore() {
   mockIsCloud.value = true
   mockShouldUseWorkspaceBilling.value = true
   mockCanReactivate.value = false
+  mockCanSubscribeSelfServe.value = true
 }
 
 describe('useWorkspaceUI', () => {
@@ -510,6 +513,46 @@ describe('useWorkspaceUI', () => {
 
       const ui = await loadComposable()
       expect(ui.canReactivatePlan.value).toBe(true)
+    })
+  })
+
+  describe('canOpenPricingSurface', () => {
+    beforeEach(() => {
+      mockStore.activeWorkspace = personalWorkspace
+    })
+
+    it('closes the catalog when the server resolves a sales-managed plan', async () => {
+      mockShouldUseWorkspaceBilling.value = true
+      mockCanSubscribeSelfServe.value = false
+
+      const ui = await loadComposable()
+      expect(ui.canOpenPricingSurface.value).toBe(false)
+    })
+
+    it('opens the catalog when the server allows self-serve subscribing', async () => {
+      mockShouldUseWorkspaceBilling.value = true
+      mockCanSubscribeSelfServe.value = true
+
+      const ui = await loadComposable()
+      expect(ui.canOpenPricingSurface.value).toBe(true)
+    })
+
+    it('falls back to membership on the legacy rail, where no capability row exists', async () => {
+      mockShouldUseWorkspaceBilling.value = false
+      mockCanSubscribeSelfServe.value = false
+
+      const ui = await loadComposable()
+      expect(ui.permissions.value.canManageSubscription).toBe(true)
+      expect(ui.canOpenPricingSurface.value).toBe(true)
+    })
+
+    it('falls back to membership off Cloud, where the endpoint is never called', async () => {
+      mockIsCloud.value = false
+      mockShouldUseWorkspaceBilling.value = true
+      mockCanSubscribeSelfServe.value = false
+
+      const ui = await loadComposable()
+      expect(ui.canOpenPricingSurface.value).toBe(true)
     })
   })
 })

--- a/src/platform/workspace/composables/useWorkspaceUI.ts
+++ b/src/platform/workspace/composables/useWorkspaceUI.ts
@@ -169,7 +169,7 @@ function useWorkspaceUIInternal() {
   )
 
   const { shouldUseWorkspaceBilling } = useBillingRouting()
-  const { canReactivate } = useBillingCapabilities()
+  const { canReactivate, canSubscribeSelfServe } = useBillingCapabilities()
 
   const permissions = computed<WorkspacePermissions>(() =>
     getPermissions(
@@ -194,6 +194,18 @@ function useWorkspaceUIInternal() {
     isCloud && shouldUseWorkspaceBilling.value
       ? canReactivate.value
       : permissions.value.canManageSubscriptionLifecycle
+  )
+
+  // Whether the self-serve pricing catalog applies to this workspace at all.
+  // The server resolves can_subscribe_self_serve false for sales-managed tiers
+  // (Enterprise, unrecognized), so every pricing-table entry point — menu
+  // items, settings links, and the ?pricing= deep link — reads this one value.
+  // Same rail split as canReactivatePlan: legacy_stripe has no capability
+  // projection row and stays on the membership check.
+  const canOpenPricingSurface = computed(() =>
+    isCloud && shouldUseWorkspaceBilling.value
+      ? canSubscribeSelfServe.value
+      : permissions.value.canManageSubscription
   )
 
   const uiConfig = computed<WorkspaceUIConfig>(() => {
@@ -238,6 +250,7 @@ function useWorkspaceUIInternal() {
     // Permissions and config
     permissions,
     canReactivatePlan,
+    canOpenPricingSurface,
     uiConfig,
     workspaceType,
     workspaceRole,


### PR DESCRIPTION
## Why this is needed

Enterprise workspaces exist in production (`enterprise_monthly` / `enterprise_annual`, provisioned through the comfy-admin console) but the frontend still renders them as a self-serve catalog plan. FE-1662 verified three gaps against the tree, and re-verification after the capabilities migration (#15803/#15804/#15675) and the ENTERPRISE contract landing (#15855) found the surviving surface smaller but real.

Supersedes #15403 — same behavioral spec and design of record ([Figma 4404-13011](https://www.figma.com/design/CkFTD4c20PyRGpNVAJgpfV/Team-Plan---Workspaces?node-id=4404-13011), DES-782), rebuilt on the server-capabilities architecture that merged underneath it. Co-authored with @comfydesigner, whose branch this replaces.

- Fixes FE-1662

## Root cause

Three distinct causes, one per change group:

1. **Label fallbacks assume the catalog is total.** `resolveSubscriptionTierKey` falls back to `'standard'` for any unmapped tier, so an ENTERPRISE workspace's plan card renders **"Standard"**, Standard's **$20 USD/mo** price (`useWorkspacePlanPricing` has the same fallback), Standard's feature list, and the credits bar borrows Standard's 4,200-credit monthly pool (`CreditsTile.tierKey ?? DEFAULT_TIER_KEY`). A scheduled change to an enterprise plan falls through the `team`-prefix check and labels itself "Standard".
2. **Pricing-table entry points gate on membership, not on whether a catalog exists.** The `?pricing=` deep link (`usePricingTableUrlLoader`), the profile menu's "Plans & pricing", and settings' "View more details about plans & pricing" all gate on `canManageSubscription` (owner), so an Enterprise owner can still open the self-serve pricing table. The subscribe-to-run upsell (`CloudRunButtonWrapper`, `useCoreCommands`) gates only on `canAccessSubscriptionFeatures`, so a lapsed Enterprise workspace is offered a self-serve checkout it must not use.
3. **No representation for a tier outside the catalog.** A tier the build doesn't recognize (server ahead of client) borrowed all of the above from Standard — price and feature claims for a plan the frontend cannot identify.

Lifecycle actions (cancel / reactivate / plan change / member invites) are **not** part of this PR's policy surface: the server already resolves them (`hideLifecycleCapabilities` in billing-api keeps `can_top_up=true` and closes the rest), and main already consumes those capabilities. This PR covers rendering and the pricing-catalog entry points only.

## How

**One derived policy for every pricing-table entry point.** `useWorkspaceUI.canOpenPricingSurface` reads the server-resolved `can_subscribe_self_serve` on the workspace rail and falls back to membership on `legacy_stripe` — the exact shape of `canReactivatePlan` (#15967), so the legacy-rail regression class that #15967/#16043/#16046 fixed cannot recur here. Consumers: profile-menu "Plans & pricing", settings "View more details", and the `?pricing=` deep link (which now awaits capability initialization before deciding, like the `?topup=` loader, so a pre-load deep link can't slip through).

**Tier drives rendering only.** `isSalesManagedTier` (ENTERPRISE or unmapped) hides the catalog price row, benefits list, and borrowed credit pool; `planDisplayName` renders "Enterprise" / "Current plan"; the scheduled-change label resolves enterprise slugs (the only signal on that path — enterprise plans are absent from `plans`); `formatTierName` gains a `te()` guard so an unknown tier degrades to a capitalized string instead of a raw i18n key. The subscribe-to-run upsell and the run-command dialog stay hidden on sales-managed plans (`SubscribeToRun` requires a catalog to sell into); the run button remains a run button.

**Capability-driven credits tile.** The inactive-plan zero-state now applies only when the server also withholds top-up (`inactivePlan && !canTopUp`): lapsed self-serve plans keep today's reactivate-to-use-credits treatment (`lapsedSelfServeCapabilities` withholds top-up), while a sales-managed plan — whose top-up stays open whatever the subscription row says — keeps its real balance and Add credits.

**Delete workspace hides on Enterprise** (DES-782): deletion requires a cancellation only sales can perform, so the disabled menu item was a permanent dead end.

## Behavioral spec (from #15403, verified by tests)

1. Enterprise owner cannot self-serve any plan change — no upgrade, downgrade, cancel, or reactivate (server capabilities; regression-tested here).
2. The pricing table never appears for an Enterprise workspace — settings, profile menu, or `?pricing=` deep link (quiet no-op).
3. The plan reads "Enterprise" with its renewal date — never another tier's name, price, credits, or feature list.
4. Money-in stays open: top-up and Billing & invoices always reachable.
5. A cancelled or ended Enterprise subscription shows the standard state with no Reactivate/Subscribe action.
6. An unrecognized tier renders as "Current plan" with no borrowed catalog content and no self-serve actions; credits, top-up, and runs keep working, no crash.

> Story 5's amended form (ended Enterprise → Subscribe returns, per the 2026-08-21 decision with Justin) is **deliberately out of scope**: billing-api resolves `can_subscribe_self_serve=false` for any enterprise subscription row including ended ones, so that behavior needs a backend change first (contract-first). Tracked as a follow-up.

## Tests

- **Unit (321 passing across the 11 touched suites):** new coverage in `tierPricing` (helpers), `useWorkspaceUI` (`canOpenPricingSurface` rail split), `SubscriptionPanelContentWorkspace` (stories 1, 3, 4, 5, 6 + scheduled-change label), `CurrentUserPopoverWorkspace` (menu entry + resubscribe), `usePricingTableUrlLoader` (deep-link no-op + pre-load race), `CreditsTile` (sales-managed pool + inactive state), `CloudRunButtonWrapper` / `useCoreCommands` (upsell suppression), `useWorkspaceMenuItems` (cancel/delete/leave).
- **E2E (`browser_tests/tests/dialogs/enterpriseTierCloud.spec.ts`, 7 tests, @cloud):** one per user story against the real cloud build with server-shaped capability mocks (`hideLifecycleCapabilities` shape), plus a Pro-team self-serve regression and an unrecognized-tier no-crash regression. `endedSubscription.spec.ts` additionally pins that a non-enterprise inactive team keeps its Reactivate button. All 10 pass locally against a ComfyUI server serving the cloud dist.
- `CloudWorkspaceMockHelper` gained an optional capability-overrides parameter so specs can mock the server's sales-managed shape.

## AS IS / TO BE

Captured from the real app — the cloud dist served by a ComfyUI server, with the billing endpoints mocked to an ENTERPRISE workspace and the server's sales-managed capability shape. AS IS is a build of `main` (`ebc5a40`), TO BE is this branch.

**Plan & Credits panel** — AS IS renders Standard's name, $20/mo price, feature list, and borrows Standard's 4,200-credit monthly pool (producing the impossible "10,550 left of 4,200"); TO BE renders the Enterprise card with its renewal date, real balance, top-up, and Billing & invoices, and no self-serve plan actions.

| AS IS | TO BE |
| --- | --- |
| ![asis-plan-credits](https://raw.githubusercontent.com/Comfy-Org/ComfyUI_frontend/assets/pr-16067-shots/asis-plan-credits.png) | ![tobe-plan-credits](https://raw.githubusercontent.com/Comfy-Org/ComfyUI_frontend/assets/pr-16067-shots/tobe-plan-credits.png) |

**Profile menu** — AS IS offers "Plans & pricing" (opens the self-serve pricing table); TO BE removes it while keeping credits, top-up, and Manage plan.

| AS IS | TO BE |
| --- | --- |
| ![asis-popover](https://raw.githubusercontent.com/Comfy-Org/ComfyUI_frontend/assets/pr-16067-shots/asis-popover.png) | ![tobe-popover](https://raw.githubusercontent.com/Comfy-Org/ComfyUI_frontend/assets/pr-16067-shots/tobe-popover.png) |

**Ended Enterprise workspace, action bar** — AS IS replaces Run with a "Subscribe to Run" upsell into a checkout an Enterprise customer must not use; TO BE keeps the run button.

| AS IS | TO BE |
| --- | --- |
| ![asis-ended-run](https://raw.githubusercontent.com/Comfy-Org/ComfyUI_frontend/assets/pr-16067-shots/asis-ended-run.png) | ![tobe-ended-run](https://raw.githubusercontent.com/Comfy-Org/ComfyUI_frontend/assets/pr-16067-shots/tobe-ended-run.png) |

The `assets/pr-16067-shots` branch exists only to host these images (no image files are committed to this PR's branch) and can be deleted after review.

