### PR TITLE
refactor(painter): project widget values instead of synchronizing copies

### DIFF
--- a/src/composables/maskeditor/imageWidgetAdapter.test.ts
+++ b/src/composables/maskeditor/imageWidgetAdapter.test.ts
@@ -5,10 +5,7 @@ import { LGraph, LGraphNode } from '@/lib/litegraph/src/litegraph'
 import { useWidgetValueStore } from '@/stores/widgetValueStore'
 import { toNodeId } from '@/types/nodeId'
 
-import {
-  readImageWidgetValue,
-  writeImageWidgetValue
-} from './imageWidgetAdapter'
+import { writeImageWidgetValue } from './imageWidgetAdapter'
 
 const GRAPH_ID = 'image-widget-adapter-test'
 
@@ -44,37 +41,6 @@ function registeredWidgetId(node: LGraphNode) {
 function storedValue(node: LGraphNode): unknown {
   return useWidgetValueStore().getWidget(registeredWidgetId(node))?.value
 }
-
-describe('readImageWidgetValue', () => {
-  it('reads the store value for a registered widget', () => {
-    const node = makeNode()
-    useWidgetValueStore().setValue(
-      registeredWidgetId(node),
-      'updated.png [input]'
-    )
-
-    expect(readImageWidgetValue(node)).toBe('updated.png [input]')
-  })
-
-  it('preserves a null store value instead of falling back', () => {
-    const node = makeNode()
-    useWidgetValueStore().setValue(registeredWidgetId(node), null)
-
-    expect(readImageWidgetValue(node)).toBeNull()
-  })
-
-  it('falls back to the widget object when the store has no entry', () => {
-    const node = makeNode({ registered: false, widgetValue: 'legacy.png' })
-
-    expect(readImageWidgetValue(node)).toBe('legacy.png')
-  })
-
-  it('returns undefined when the widget exists nowhere', () => {
-    const node = makeNode({ registered: false, hasWidget: false })
-
-    expect(readImageWidgetValue(node)).toBeUndefined()
-  })
-})
 
 describe('writeImageWidgetValue', () => {
   it('writes the store value and mirrors it into properties.image', () => {

--- a/src/composables/maskeditor/imageWidgetAdapter.ts
+++ b/src/composables/maskeditor/imageWidgetAdapter.ts
@@ -1,29 +1,9 @@
+import { setNodeWidgetValue } from '@/core/graph/widgets/nodeWidgetValues'
 import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
-import { useWidgetValueStore } from '@/stores/widgetValueStore'
-import type { WidgetId } from '@/types/widgetId'
-import { widgetId } from '@/types/widgetId'
 
-const IMAGE_WIDGET = 'image'
-
-function imageWidgetId(node: LGraphNode): WidgetId | null {
-  const graphId = node.graph?.rootGraph?.id
-  return graphId ? widgetId(graphId, node.id, IMAGE_WIDGET) : null
-}
-
-export function readImageWidgetValue(node: LGraphNode): unknown {
-  const id = imageWidgetId(node)
-  const storedWidget = id ? useWidgetValueStore().getWidget(id) : undefined
-  return storedWidget
-    ? storedWidget.value
-    : node.widgets?.find((w) => w.name === IMAGE_WIDGET)?.value
-}
+export const IMAGE_WIDGET = 'image'
 
 export function writeImageWidgetValue(node: LGraphNode, value: string): void {
-  const id = imageWidgetId(node)
-  if (!id || !useWidgetValueStore().setValue(id, value)) {
-    const widget = node.widgets?.find((w) => w.name === IMAGE_WIDGET)
-    if (!widget) return
-    widget.value = value
-  }
+  if (!setNodeWidgetValue(node, IMAGE_WIDGET, value)) return
   if (node.properties) node.properties[IMAGE_WIDGET] = value
 }

--- a/src/composables/maskeditor/useMaskEditorLoader.ts
+++ b/src/composables/maskeditor/useMaskEditorLoader.ts
@@ -1,4 +1,5 @@
-import { readImageWidgetValue } from '@/composables/maskeditor/imageWidgetAdapter'
+import { IMAGE_WIDGET } from '@/composables/maskeditor/imageWidgetAdapter'
+import { getNodeWidgetValue } from '@/core/graph/widgets/nodeWidgetValues'
 import { useMaskEditorDataStore } from '@/stores/maskEditorDataStore'
 import type { ImageRef, ImageLayer } from '@/stores/maskEditorDataStore'
 import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
@@ -99,7 +100,7 @@ export function useMaskEditorLoader() {
       let nodeImageRef = parseImageRef(nodeImageUrl)
 
       const widgetFilename = extractWidgetStringValue(
-        readImageWidgetValue(node)
+        getNodeWidgetValue(node, IMAGE_WIDGET)
       )
 
       // If we have a widget filename, we should prioritize it over the node image

--- a/src/composables/painter/usePainter.test.ts
+++ b/src/composables/painter/usePainter.test.ts
@@ -1,7 +1,8 @@
+import { fromAny, fromPartial } from '@total-typescript/shoehorn'
 import { render } from '@testing-library/vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { defineComponent, nextTick, ref } from 'vue'
-import type * as VueI18n from 'vue-i18n'
+import { createI18n } from 'vue-i18n'
 
 import type { IBaseWidget } from '@/lib/litegraph/src/types/widgets'
 import { api } from '@/scripts/api'
@@ -13,17 +14,6 @@ import { widgetId } from '@/types/widgetId'
 import { createMockLGraphNode } from '@/utils/__tests__/litegraphTestUtils'
 
 import { usePainter } from './usePainter'
-
-vi.mock('vue-i18n', async (importOriginal) => {
-  const actual = await importOriginal<typeof VueI18n>()
-  return {
-    ...actual,
-    useI18n: vi.fn(() => ({
-      t: (key: string, params?: Record<string, unknown>) =>
-        params ? `${key}:${JSON.stringify(params)}` : key
-    }))
-  }
-})
 
 vi.mock('@vueuse/core', () => ({
   useElementSize: vi.fn(() => ({
@@ -138,7 +128,8 @@ function mountPainter(
     }
   })
 
-  render(Wrapper)
+  const i18n = createI18n({ legacy: false, locale: 'en', messages: { en: {} } })
+  render(Wrapper, { global: { plugins: [i18n] } })
   return { painter, canvasEl, cursorEl, modelValue }
 }
 
@@ -172,20 +163,30 @@ describe('usePainter', () => {
 
     it('resizes the canvas and preserves its content on external store writes', async () => {
       registerWidgetState('width', 'number', 512)
-      const mainCtx = { drawImage: vi.fn() }
-      const fakeCanvas = {
+      const mainCtx = fromPartial<CanvasRenderingContext2D>({
+        drawImage: vi.fn()
+      })
+      const fakeCanvas = fromPartial<HTMLCanvasElement>({
         width: 4,
         height: 4,
-        getContext: () => mainCtx
-      } as unknown as HTMLCanvasElement
+        getContext: fromAny<HTMLCanvasElement['getContext'], unknown>(
+          () => mainCtx
+        )
+      })
       const { painter, canvasEl } = mountPainter()
       canvasEl.value = fakeCanvas
 
-      const tmpCtx = { drawImage: vi.fn() }
-      const tmpCanvas = { width: 0, height: 0, getContext: () => tmpCtx }
+      const tmpCtx = fromPartial<CanvasRenderingContext2D>({
+        drawImage: vi.fn()
+      })
+      const tmpCanvas = fromPartial<HTMLCanvasElement>({
+        getContext: fromAny<HTMLCanvasElement['getContext'], unknown>(
+          () => tmpCtx
+        )
+      })
       const createElement = vi
         .spyOn(document, 'createElement')
-        .mockReturnValue(tmpCanvas as unknown as HTMLElement)
+        .mockReturnValue(tmpCanvas)
 
       useWidgetValueStore().setValue(painterWidgetId('width'), 2048)
       await nextTick()
@@ -285,6 +286,17 @@ describe('usePainter', () => {
       expect(store.getWidget(painterWidgetId('bg_color'))?.value).toBe(
         '#ff00ff'
       )
+    })
+
+    it('projects external background color store writes', async () => {
+      const store = useWidgetValueStore()
+      registerWidgetState('bg_color', 'color', '#000000')
+      const { painter } = mountPainter()
+
+      store.setValue(painterWidgetId('bg_color'), '#123456')
+      await nextTick()
+
+      expect(painter.backgroundColor.value).toBe('#123456')
     })
   })
 

--- a/src/composables/painter/usePainter.test.ts
+++ b/src/composables/painter/usePainter.test.ts
@@ -199,11 +199,12 @@ describe('usePainter', () => {
       expect(mainCtx.drawImage).toHaveBeenCalledWith(tmpCanvas, 0, 0)
     })
 
-    it('writes size edits through the widget and notifies its callback', async () => {
-      const { callbacks } = makePaintNode([
+    it('writes size edits through the widget notification lifecycle', async () => {
+      const { node, callbacks } = makePaintNode([
         { name: 'width', type: 'number', value: 512 },
         { name: 'height', type: 'number', value: 512 }
       ])
+      node.onWidgetChanged = vi.fn()
 
       const { painter } = mountPainter()
 
@@ -215,6 +216,12 @@ describe('usePainter', () => {
       expect(storedValue('height')).toBe(600)
       expect(callbacks['width']).toHaveBeenCalledWith(800)
       expect(callbacks['height']).toHaveBeenCalledWith(600)
+      expect(node.onWidgetChanged).toHaveBeenCalledWith(
+        'width',
+        800,
+        512,
+        widgetOf('width')
+      )
     })
 
     it('skips the widget callback when the value is unchanged', () => {

--- a/src/composables/painter/usePainter.test.ts
+++ b/src/composables/painter/usePainter.test.ts
@@ -4,14 +4,12 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { defineComponent, nextTick, ref } from 'vue'
 import { createI18n } from 'vue-i18n'
 
+import { LGraph, LGraphNode } from '@/lib/litegraph/src/litegraph'
 import type { IBaseWidget } from '@/lib/litegraph/src/types/widgets'
 import { api } from '@/scripts/api'
 import { useWidgetValueStore } from '@/stores/widgetValueStore'
 import { toNodeId } from '@/types/nodeId'
 import type { NodeId } from '@/types/nodeId'
-import type { WidgetValue } from '@/types/simplifiedWidget'
-import { widgetId } from '@/types/widgetId'
-import { createMockLGraphNode } from '@/utils/__tests__/litegraphTestUtils'
 
 import { usePainter } from './usePainter'
 
@@ -54,53 +52,57 @@ vi.mock('@/scripts/api', () => ({
   }
 }))
 
-const GRAPH_ID = 'painter-test'
+const fixture = vi.hoisted(() => ({ node: null as unknown }))
 
-const mockWidgets: IBaseWidget[] = []
-const mockProperties: Record<string, unknown> = {}
+vi.mock('@/scripts/app', () => ({
+  app: { canvas: { graph: { getNodeById: () => fixture.node } } }
+}))
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: { en: {} }
+})
+
 const mockIsInputConnected = vi.fn(() => false)
 const mockGetInputNode = vi.fn(() => null)
 
-vi.mock('@/scripts/app', () => ({
-  app: {
-    canvas: {
-      graph: {
-        getNodeById: vi.fn((id: NodeId) =>
-          createMockLGraphNode({
-            id,
-            graph: { rootGraph: { id: GRAPH_ID } },
-            widgets: mockWidgets,
-            properties: mockProperties,
-            isInputConnected: mockIsInputConnected,
-            getInputNode: mockGetInputNode
-          })
-        )
-      }
-    }
+interface PaintWidgetSpec {
+  name: string
+  type: 'number' | 'string' | 'color'
+  value: string | number
+}
+
+function makePaintNode(widgets: PaintWidgetSpec[] = []) {
+  const graph = new LGraph()
+  const node = new LGraphNode('PainterTestNode')
+  graph.add(node)
+  const callbacks: Record<string, ReturnType<typeof vi.fn>> = {}
+  for (const { name, type, value } of widgets) {
+    const callback = vi.fn()
+    callbacks[name] = callback
+    node.addWidget(type, name, value, callback)
   }
-}))
+  node.isInputConnected = mockIsInputConnected
+  node.getInputNode = mockGetInputNode
+  fixture.node = node
+  return { node, callbacks }
+}
+
+function widgetOf(name: string): IBaseWidget {
+  const widget = (fixture.node as LGraphNode).widgets?.find(
+    (w) => w.name === name
+  )
+  if (!widget) throw new Error(`Expected a '${name}' widget on the paint node`)
+  return widget
+}
+
+function storedValue(name: string): unknown {
+  const id = widgetOf(name).widgetId
+  return id ? useWidgetValueStore().getWidget(id)?.value : undefined
+}
 
 type PainterResult = ReturnType<typeof usePainter>
-
-function makeWidget(name: string, value: unknown = null): IBaseWidget {
-  return {
-    name,
-    value,
-    serializeValue: undefined
-  } as unknown as IBaseWidget
-}
-
-function painterWidgetId(name: string, nodeId: NodeId = toNodeId('test-node')) {
-  return widgetId(GRAPH_ID, nodeId, name)
-}
-
-function registerWidgetState(name: string, type: string, value: WidgetValue) {
-  useWidgetValueStore().registerWidget(painterWidgetId(name), {
-    type,
-    value,
-    options: {}
-  })
-}
 
 /**
  * Mounts a thin wrapper component so Vue lifecycle hooks fire.
@@ -128,25 +130,23 @@ function mountPainter(
     }
   })
 
-  const i18n = createI18n({ legacy: false, locale: 'en', messages: { en: {} } })
   render(Wrapper, { global: { plugins: [i18n] } })
   return { painter, canvasEl, cursorEl, modelValue }
 }
 
 describe('usePainter', () => {
   beforeEach(() => {
-    mockWidgets.length = 0
-    for (const key of Object.keys(mockProperties)) {
-      delete mockProperties[key]
-    }
+    makePaintNode()
     mockIsInputConnected.mockReturnValue(false)
     mockGetInputNode.mockReturnValue(null)
   })
 
-  describe('syncCanvasSizeFromWidgets', () => {
+  describe('canvas size projections', () => {
     it('reads width/height from widget values on initialization', () => {
-      registerWidgetState('width', 'number', 1024)
-      registerWidgetState('height', 'number', 768)
+      makePaintNode([
+        { name: 'width', type: 'number', value: 1024 },
+        { name: 'height', type: 'number', value: 768 }
+      ])
 
       const { painter } = mountPainter()
 
@@ -162,7 +162,7 @@ describe('usePainter', () => {
     })
 
     it('resizes the canvas and preserves its content on external store writes', async () => {
-      registerWidgetState('width', 'number', 512)
+      makePaintNode([{ name: 'width', type: 'number', value: 512 }])
       const mainCtx = fromPartial<CanvasRenderingContext2D>({
         drawImage: vi.fn()
       })
@@ -188,7 +188,7 @@ describe('usePainter', () => {
         .spyOn(document, 'createElement')
         .mockReturnValue(tmpCanvas)
 
-      useWidgetValueStore().setValue(painterWidgetId('width'), 2048)
+      useWidgetValueStore().setValue(widgetOf('width').widgetId!, 2048)
       await nextTick()
       createElement.mockRestore()
 
@@ -198,15 +198,46 @@ describe('usePainter', () => {
       expect(tmpCtx.drawImage).toHaveBeenCalledWith(fakeCanvas, 0, 0)
       expect(mainCtx.drawImage).toHaveBeenCalledWith(tmpCanvas, 0, 0)
     })
+
+    it('writes size edits through the widget and notifies its callback', async () => {
+      const { callbacks } = makePaintNode([
+        { name: 'width', type: 'number', value: 512 },
+        { name: 'height', type: 'number', value: 512 }
+      ])
+
+      const { painter } = mountPainter()
+
+      painter.canvasWidth.value = 800
+      painter.canvasHeight.value = 600
+      await nextTick()
+
+      expect(storedValue('width')).toBe(800)
+      expect(storedValue('height')).toBe(600)
+      expect(callbacks['width']).toHaveBeenCalledWith(800)
+      expect(callbacks['height']).toHaveBeenCalledWith(600)
+    })
+
+    it('skips the widget callback when the value is unchanged', () => {
+      const { callbacks } = makePaintNode([
+        { name: 'width', type: 'number', value: 512 }
+      ])
+
+      const { painter } = mountPainter()
+
+      painter.canvasWidth.value = 512
+
+      expect(callbacks['width']).not.toHaveBeenCalled()
+    })
   })
 
   describe('restoreSettingsFromProperties', () => {
     it('restores tool and brush settings from node properties on init', () => {
-      mockProperties.painterTool = 'eraser'
-      mockProperties.painterBrushSize = 42
-      mockProperties.painterBrushColor = '#ff0000'
-      mockProperties.painterBrushOpacity = 0.5
-      mockProperties.painterBrushHardness = 0.8
+      const { node } = makePaintNode()
+      node.properties.painterTool = 'eraser'
+      node.properties.painterBrushSize = 42
+      node.properties.painterBrushColor = '#ff0000'
+      node.properties.painterBrushOpacity = 0.5
+      node.properties.painterBrushHardness = 0.8
 
       const { painter } = mountPainter()
 
@@ -217,8 +248,8 @@ describe('usePainter', () => {
       expect(painter.brushHardness.value).toBe(0.8)
     })
 
-    it('restores backgroundColor from bg_color widget', () => {
-      registerWidgetState('bg_color', 'color', '#123456')
+    it('restores backgroundColor from the bg_color widget', () => {
+      makePaintNode([{ name: 'bg_color', type: 'color', value: '#123456' }])
 
       const { painter } = mountPainter()
 
@@ -238,6 +269,7 @@ describe('usePainter', () => {
 
   describe('saveSettingsToProperties', () => {
     it('persists tool settings to node properties when they change', async () => {
+      const { node } = makePaintNode()
       const { painter } = mountPainter()
 
       painter.tool.value = 'eraser'
@@ -248,52 +280,34 @@ describe('usePainter', () => {
 
       await nextTick()
 
-      expect(mockProperties.painterTool).toBe('eraser')
-      expect(mockProperties.painterBrushSize).toBe(50)
-      expect(mockProperties.painterBrushColor).toBe('#00ff00')
-      expect(mockProperties.painterBrushOpacity).toBe(0.7)
-      expect(mockProperties.painterBrushHardness).toBe(0.3)
+      expect(node.properties.painterTool).toBe('eraser')
+      expect(node.properties.painterBrushSize).toBe(50)
+      expect(node.properties.painterBrushColor).toBe('#00ff00')
+      expect(node.properties.painterBrushOpacity).toBe(0.7)
+      expect(node.properties.painterBrushHardness).toBe(0.3)
     })
   })
 
-  describe('syncCanvasSizeToWidgets', () => {
-    it('syncs canvas dimensions to widget store when size changes', async () => {
-      const store = useWidgetValueStore()
-      registerWidgetState('width', 'number', 512)
-      registerWidgetState('height', 'number', 512)
-
-      const { painter } = mountPainter()
-
-      painter.canvasWidth.value = 800
-      painter.canvasHeight.value = 600
-      await nextTick()
-
-      expect(store.getWidget(painterWidgetId('width'))?.value).toBe(800)
-      expect(store.getWidget(painterWidgetId('height'))?.value).toBe(600)
-    })
-  })
-
-  describe('syncBackgroundColorToWidget', () => {
-    it('syncs background color to widget store when color changes', async () => {
-      const store = useWidgetValueStore()
-      registerWidgetState('bg_color', 'color', '#000000')
+  describe('background color projection', () => {
+    it('writes color edits through the widget and notifies its callback', async () => {
+      const { callbacks } = makePaintNode([
+        { name: 'bg_color', type: 'color', value: '#000000' }
+      ])
 
       const { painter } = mountPainter()
 
       painter.backgroundColor.value = '#ff00ff'
       await nextTick()
 
-      expect(store.getWidget(painterWidgetId('bg_color'))?.value).toBe(
-        '#ff00ff'
-      )
+      expect(storedValue('bg_color')).toBe('#ff00ff')
+      expect(callbacks['bg_color']).toHaveBeenCalledWith('#ff00ff')
     })
 
     it('projects external background color store writes', async () => {
-      const store = useWidgetValueStore()
-      registerWidgetState('bg_color', 'color', '#000000')
+      makePaintNode([{ name: 'bg_color', type: 'color', value: '#000000' }])
       const { painter } = mountPainter()
 
-      store.setValue(painterWidgetId('bg_color'), '#123456')
+      useWidgetValueStore().setValue(widgetOf('bg_color').widgetId!, '#123456')
       await nextTick()
 
       expect(painter.backgroundColor.value).toBe('#123456')
@@ -318,10 +332,11 @@ describe('usePainter', () => {
   })
 
   describe('handleInputImageLoad', () => {
-    it('updates canvas size and widgets from loaded image dimensions', () => {
-      const store = useWidgetValueStore()
-      registerWidgetState('width', 'number', 512)
-      registerWidgetState('height', 'number', 512)
+    it('updates canvas size widgets from loaded image dimensions', () => {
+      const { callbacks } = makePaintNode([
+        { name: 'width', type: 'number', value: 512 },
+        { name: 'height', type: 'number', value: 512 }
+      ])
 
       const { painter } = mountPainter()
 
@@ -336,8 +351,10 @@ describe('usePainter', () => {
 
       expect(painter.canvasWidth.value).toBe(1920)
       expect(painter.canvasHeight.value).toBe(1080)
-      expect(store.getWidget(painterWidgetId('width'))?.value).toBe(1920)
-      expect(store.getWidget(painterWidgetId('height'))?.value).toBe(1080)
+      expect(storedValue('width')).toBe(1920)
+      expect(storedValue('height')).toBe(1080)
+      expect(callbacks['width']).toHaveBeenCalledWith(1920)
+      expect(callbacks['height']).toHaveBeenCalledWith(1080)
     })
   })
 
@@ -401,29 +418,26 @@ describe('usePainter', () => {
 
   describe('registerWidgetSerialization', () => {
     it('attaches serializeValue to the mask widget on init', () => {
-      const maskWidget = makeWidget('mask', '')
-      mockWidgets.push(maskWidget)
+      makePaintNode([{ name: 'mask', type: 'string', value: '' }])
 
       mountPainter()
 
-      expect(maskWidget.serializeValue).toBeTypeOf('function')
+      expect(widgetOf('mask').serializeValue).toBeTypeOf('function')
     })
   })
 
   describe('serializeValue', () => {
     it('returns existing modelValue when not dirty (preserves workflow-restored mask reference across WidgetPainter remount)', async () => {
-      const maskWidget = makeWidget('mask', '')
-      mockWidgets.push(maskWidget)
+      makePaintNode([{ name: 'mask', type: 'string', value: '' }])
 
       mountPainter(toNodeId('test-node'), 'painter/existing.png [temp]')
 
-      const result = await maskWidget.serializeValue!({}, 0)
+      const result = await widgetOf('mask').serializeValue!({} as LGraphNode, 0)
       expect(result).toBe('painter/existing.png [temp]')
     })
 
     it('uploads the current canvas when no cached modelValue is present, even if nothing has been painted yet', async () => {
-      const maskWidget = makeWidget('mask', '')
-      mockWidgets.push(maskWidget)
+      makePaintNode([{ name: 'mask', type: 'string', value: '' }])
 
       const fetchApiMock = vi.mocked(api.fetchApi)
       fetchApiMock.mockResolvedValueOnce({
@@ -431,17 +445,17 @@ describe('usePainter', () => {
         json: async () => ({ name: 'uploaded.png' })
       } as Response)
 
-      const fakeCanvas = {
+      const fakeCanvas = fromPartial<HTMLCanvasElement>({
         width: 4,
         height: 4,
         toBlob: (cb: BlobCallback) => cb(new Blob(['x']))
-      } as unknown as HTMLCanvasElement
+      })
 
       const { canvasEl } = mountPainter(toNodeId('test-node'), '')
       canvasEl.value = fakeCanvas
       await nextTick()
 
-      const result = await maskWidget.serializeValue!({}, 0)
+      const result = await widgetOf('mask').serializeValue!({} as LGraphNode, 0)
       expect(fetchApiMock).toHaveBeenCalledWith(
         '/upload/image',
         expect.objectContaining({ method: 'POST' })
@@ -456,32 +470,30 @@ describe('usePainter', () => {
     })
 
     it('throws when the upload response is missing a name', async () => {
-      const maskWidget = makeWidget('mask', '')
-      mockWidgets.push(maskWidget)
+      makePaintNode([{ name: 'mask', type: 'string', value: '' }])
 
       vi.mocked(api.fetchApi).mockResolvedValueOnce({
         status: 200,
         json: async () => ({})
       } as Response)
 
-      const fakeCanvas = {
+      const fakeCanvas = fromPartial<HTMLCanvasElement>({
         width: 4,
         height: 4,
         toBlob: (cb: BlobCallback) => cb(new Blob(['x']))
-      } as unknown as HTMLCanvasElement
+      })
 
       const { canvasEl } = mountPainter(toNodeId('test-node'), '')
       canvasEl.value = fakeCanvas
       await nextTick()
 
-      await expect(maskWidget.serializeValue!({}, 0)).rejects.toThrow(
-        /missing 'name'/
-      )
+      await expect(
+        widgetOf('mask').serializeValue!({} as LGraphNode, 0)
+      ).rejects.toThrow(/missing 'name'/)
     })
 
     it('throws when the upload response body is not valid JSON', async () => {
-      const maskWidget = makeWidget('mask', '')
-      mockWidgets.push(maskWidget)
+      makePaintNode([{ name: 'mask', type: 'string', value: '' }])
 
       vi.mocked(api.fetchApi).mockResolvedValueOnce({
         status: 200,
@@ -490,42 +502,40 @@ describe('usePainter', () => {
         }
       } as unknown as Response)
 
-      const fakeCanvas = {
+      const fakeCanvas = fromPartial<HTMLCanvasElement>({
         width: 4,
         height: 4,
         toBlob: (cb: BlobCallback) => cb(new Blob(['x']))
-      } as unknown as HTMLCanvasElement
+      })
 
       const { canvasEl } = mountPainter(toNodeId('test-node'), '')
       canvasEl.value = fakeCanvas
       await nextTick()
 
-      await expect(maskWidget.serializeValue!({}, 0)).rejects.toThrow(
-        /painter\.uploadError/
-      )
+      await expect(
+        widgetOf('mask').serializeValue!({} as LGraphNode, 0)
+      ).rejects.toThrow(/painter\.uploadError/)
     })
 
     it('returns existing modelValue when canvas element is unmounted at serialize time', async () => {
-      const maskWidget = makeWidget('mask', '')
-      mockWidgets.push(maskWidget)
+      makePaintNode([{ name: 'mask', type: 'string', value: '' }])
 
       mountPainter(toNodeId('test-node'), 'painter/cached.png [temp]')
 
-      const result = await maskWidget.serializeValue!({}, 0)
+      const result = await widgetOf('mask').serializeValue!({} as LGraphNode, 0)
       expect(result).toBe('painter/cached.png [temp]')
     })
 
     it('clears the cached upload reference when the user clears the canvas', () => {
-      const maskWidget = makeWidget('mask', '')
-      mockWidgets.push(maskWidget)
+      makePaintNode([{ name: 'mask', type: 'string', value: '' }])
 
-      const fakeCanvas = {
+      const fakeCanvas = fromPartial<HTMLCanvasElement>({
         width: 4,
         height: 4,
-        getContext: vi.fn(() => ({
-          clearRect: vi.fn()
-        }))
-      } as unknown as HTMLCanvasElement
+        getContext: fromAny<HTMLCanvasElement['getContext'], unknown>(() =>
+          fromPartial<CanvasRenderingContext2D>({ clearRect: vi.fn() })
+        )
+      })
 
       const { painter, canvasEl, modelValue } = mountPainter(
         toNodeId('test-node'),

--- a/src/composables/painter/usePainter.test.ts
+++ b/src/composables/painter/usePainter.test.ts
@@ -52,7 +52,7 @@ vi.mock('@/scripts/api', () => ({
   }
 }))
 
-const fixture = vi.hoisted(() => ({ node: null as unknown }))
+const fixture = vi.hoisted((): { node: LGraphNode | null } => ({ node: null }))
 
 vi.mock('@/scripts/app', () => ({
   app: { canvas: { graph: { getNodeById: () => fixture.node } } }
@@ -89,10 +89,13 @@ function makePaintNode(widgets: PaintWidgetSpec[] = []) {
   return { node, callbacks }
 }
 
+function paintNode(): LGraphNode {
+  if (!fixture.node) throw new Error('Expected a paint node')
+  return fixture.node
+}
+
 function widgetOf(name: string): IBaseWidget {
-  const widget = (fixture.node as LGraphNode).widgets?.find(
-    (w) => w.name === name
-  )
+  const widget = paintNode().widgets?.find((w) => w.name === name)
   if (!widget) throw new Error(`Expected a '${name}' widget on the paint node`)
   return widget
 }
@@ -439,7 +442,7 @@ describe('usePainter', () => {
 
       mountPainter(toNodeId('test-node'), 'painter/existing.png [temp]')
 
-      const result = await widgetOf('mask').serializeValue!({} as LGraphNode, 0)
+      const result = await widgetOf('mask').serializeValue!(paintNode(), 0)
       expect(result).toBe('painter/existing.png [temp]')
     })
 
@@ -462,7 +465,7 @@ describe('usePainter', () => {
       canvasEl.value = fakeCanvas
       await nextTick()
 
-      const result = await widgetOf('mask').serializeValue!({} as LGraphNode, 0)
+      const result = await widgetOf('mask').serializeValue!(paintNode(), 0)
       expect(fetchApiMock).toHaveBeenCalledWith(
         '/upload/image',
         expect.objectContaining({ method: 'POST' })
@@ -495,7 +498,7 @@ describe('usePainter', () => {
       await nextTick()
 
       await expect(
-        widgetOf('mask').serializeValue!({} as LGraphNode, 0)
+        widgetOf('mask').serializeValue!(paintNode(), 0)
       ).rejects.toThrow(/missing 'name'/)
     })
 
@@ -520,7 +523,7 @@ describe('usePainter', () => {
       await nextTick()
 
       await expect(
-        widgetOf('mask').serializeValue!({} as LGraphNode, 0)
+        widgetOf('mask').serializeValue!(paintNode(), 0)
       ).rejects.toThrow(/painter\.uploadError/)
     })
 
@@ -529,7 +532,7 @@ describe('usePainter', () => {
 
       mountPainter(toNodeId('test-node'), 'painter/cached.png [temp]')
 
-      const result = await widgetOf('mask').serializeValue!({} as LGraphNode, 0)
+      const result = await widgetOf('mask').serializeValue!(paintNode(), 0)
       expect(result).toBe('painter/cached.png [temp]')
     })
 

--- a/src/composables/painter/usePainter.test.ts
+++ b/src/composables/painter/usePainter.test.ts
@@ -1,20 +1,29 @@
 import { render } from '@testing-library/vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { defineComponent, nextTick, ref } from 'vue'
+import type * as VueI18n from 'vue-i18n'
 
 import type { IBaseWidget } from '@/lib/litegraph/src/types/widgets'
 import { api } from '@/scripts/api'
+import { useWidgetValueStore } from '@/stores/widgetValueStore'
 import { toNodeId } from '@/types/nodeId'
 import type { NodeId } from '@/types/nodeId'
+import type { WidgetValue } from '@/types/simplifiedWidget'
+import { widgetId } from '@/types/widgetId'
+import { createMockLGraphNode } from '@/utils/__tests__/litegraphTestUtils'
 
 import { usePainter } from './usePainter'
 
-vi.mock('vue-i18n', () => ({
-  useI18n: vi.fn(() => ({
-    t: (key: string, params?: Record<string, unknown>) =>
-      params ? `${key}:${JSON.stringify(params)}` : key
-  }))
-}))
+vi.mock('vue-i18n', async (importOriginal) => {
+  const actual = await importOriginal<typeof VueI18n>()
+  return {
+    ...actual,
+    useI18n: vi.fn(() => ({
+      t: (key: string, params?: Record<string, unknown>) =>
+        params ? `${key}:${JSON.stringify(params)}` : key
+    }))
+  }
+})
 
 vi.mock('@vueuse/core', () => ({
   useElementSize: vi.fn(() => ({
@@ -55,6 +64,8 @@ vi.mock('@/scripts/api', () => ({
   }
 }))
 
+const GRAPH_ID = 'painter-test'
+
 const mockWidgets: IBaseWidget[] = []
 const mockProperties: Record<string, unknown> = {}
 const mockIsInputConnected = vi.fn(() => false)
@@ -64,16 +75,16 @@ vi.mock('@/scripts/app', () => ({
   app: {
     canvas: {
       graph: {
-        getNodeById: vi.fn(() => ({
-          get widgets() {
-            return mockWidgets
-          },
-          get properties() {
-            return mockProperties
-          },
-          isInputConnected: mockIsInputConnected,
-          getInputNode: mockGetInputNode
-        }))
+        getNodeById: vi.fn((id: NodeId) =>
+          createMockLGraphNode({
+            id,
+            graph: { rootGraph: { id: GRAPH_ID } },
+            widgets: mockWidgets,
+            properties: mockProperties,
+            isInputConnected: mockIsInputConnected,
+            getInputNode: mockGetInputNode
+          })
+        )
       }
     }
   }
@@ -85,9 +96,20 @@ function makeWidget(name: string, value: unknown = null): IBaseWidget {
   return {
     name,
     value,
-    callback: vi.fn(),
     serializeValue: undefined
   } as unknown as IBaseWidget
+}
+
+function painterWidgetId(name: string, nodeId: NodeId = toNodeId('test-node')) {
+  return widgetId(GRAPH_ID, nodeId, name)
+}
+
+function registerWidgetState(name: string, type: string, value: WidgetValue) {
+  useWidgetValueStore().registerWidget(painterWidgetId(name), {
+    type,
+    value,
+    options: {}
+  })
 }
 
 /**
@@ -132,7 +154,8 @@ describe('usePainter', () => {
 
   describe('syncCanvasSizeFromWidgets', () => {
     it('reads width/height from widget values on initialization', () => {
-      mockWidgets.push(makeWidget('width', 1024), makeWidget('height', 768))
+      registerWidgetState('width', 'number', 1024)
+      registerWidgetState('height', 'number', 768)
 
       const { painter } = mountPainter()
 
@@ -145,6 +168,34 @@ describe('usePainter', () => {
 
       expect(painter.canvasWidth.value).toBe(512)
       expect(painter.canvasHeight.value).toBe(512)
+    })
+
+    it('resizes the canvas and preserves its content on external store writes', async () => {
+      registerWidgetState('width', 'number', 512)
+      const mainCtx = { drawImage: vi.fn() }
+      const fakeCanvas = {
+        width: 4,
+        height: 4,
+        getContext: () => mainCtx
+      } as unknown as HTMLCanvasElement
+      const { painter, canvasEl } = mountPainter()
+      canvasEl.value = fakeCanvas
+
+      const tmpCtx = { drawImage: vi.fn() }
+      const tmpCanvas = { width: 0, height: 0, getContext: () => tmpCtx }
+      const createElement = vi
+        .spyOn(document, 'createElement')
+        .mockReturnValue(tmpCanvas as unknown as HTMLElement)
+
+      useWidgetValueStore().setValue(painterWidgetId('width'), 2048)
+      await nextTick()
+      createElement.mockRestore()
+
+      expect(painter.canvasWidth.value).toBe(2048)
+      expect(fakeCanvas.width).toBe(2048)
+      expect(fakeCanvas.height).toBe(512)
+      expect(tmpCtx.drawImage).toHaveBeenCalledWith(fakeCanvas, 0, 0)
+      expect(mainCtx.drawImage).toHaveBeenCalledWith(tmpCanvas, 0, 0)
     })
   })
 
@@ -166,7 +217,7 @@ describe('usePainter', () => {
     })
 
     it('restores backgroundColor from bg_color widget', () => {
-      mockWidgets.push(makeWidget('bg_color', '#123456'))
+      registerWidgetState('bg_color', 'color', '#123456')
 
       const { painter } = mountPainter()
 
@@ -205,10 +256,10 @@ describe('usePainter', () => {
   })
 
   describe('syncCanvasSizeToWidgets', () => {
-    it('syncs canvas dimensions to widgets when size changes', async () => {
-      const widthWidget = makeWidget('width', 512)
-      const heightWidget = makeWidget('height', 512)
-      mockWidgets.push(widthWidget, heightWidget)
+    it('syncs canvas dimensions to widget store when size changes', async () => {
+      const store = useWidgetValueStore()
+      registerWidgetState('width', 'number', 512)
+      registerWidgetState('height', 'number', 512)
 
       const { painter } = mountPainter()
 
@@ -216,25 +267,24 @@ describe('usePainter', () => {
       painter.canvasHeight.value = 600
       await nextTick()
 
-      expect(widthWidget.value).toBe(800)
-      expect(heightWidget.value).toBe(600)
-      expect(widthWidget.callback).toHaveBeenCalledWith(800)
-      expect(heightWidget.callback).toHaveBeenCalledWith(600)
+      expect(store.getWidget(painterWidgetId('width'))?.value).toBe(800)
+      expect(store.getWidget(painterWidgetId('height'))?.value).toBe(600)
     })
   })
 
   describe('syncBackgroundColorToWidget', () => {
-    it('syncs background color to widget when color changes', async () => {
-      const bgWidget = makeWidget('bg_color', '#000000')
-      mockWidgets.push(bgWidget)
+    it('syncs background color to widget store when color changes', async () => {
+      const store = useWidgetValueStore()
+      registerWidgetState('bg_color', 'color', '#000000')
 
       const { painter } = mountPainter()
 
       painter.backgroundColor.value = '#ff00ff'
       await nextTick()
 
-      expect(bgWidget.value).toBe('#ff00ff')
-      expect(bgWidget.callback).toHaveBeenCalledWith('#ff00ff')
+      expect(store.getWidget(painterWidgetId('bg_color'))?.value).toBe(
+        '#ff00ff'
+      )
     })
   })
 
@@ -257,9 +307,9 @@ describe('usePainter', () => {
 
   describe('handleInputImageLoad', () => {
     it('updates canvas size and widgets from loaded image dimensions', () => {
-      const widthWidget = makeWidget('width', 512)
-      const heightWidget = makeWidget('height', 512)
-      mockWidgets.push(widthWidget, heightWidget)
+      const store = useWidgetValueStore()
+      registerWidgetState('width', 'number', 512)
+      registerWidgetState('height', 'number', 512)
 
       const { painter } = mountPainter()
 
@@ -274,8 +324,8 @@ describe('usePainter', () => {
 
       expect(painter.canvasWidth.value).toBe(1920)
       expect(painter.canvasHeight.value).toBe(1080)
-      expect(widthWidget.value).toBe(1920)
-      expect(heightWidget.value).toBe(1080)
+      expect(store.getWidget(painterWidgetId('width'))?.value).toBe(1920)
+      expect(store.getWidget(painterWidgetId('height'))?.value).toBe(1080)
     })
   })
 

--- a/src/composables/painter/usePainter.ts
+++ b/src/composables/painter/usePainter.ts
@@ -15,6 +15,10 @@ import type { IBaseWidget } from '@/lib/litegraph/src/types/widgets'
 import { useToastStore } from '@/platform/updates/common/toastStore'
 import { api } from '@/scripts/api'
 import { app } from '@/scripts/app'
+import {
+  getNodeWidgetValue,
+  setNodeWidgetValue
+} from '@/core/graph/widgets/nodeWidgetValues'
 import { useNodeOutputStore } from '@/stores/nodeOutputStore'
 import type { NodeId } from '@/types/nodeId'
 
@@ -38,9 +42,6 @@ export function usePainter(nodeId: NodeId, options: UsePainterOptions) {
   const toastStore = useToastStore()
 
   const isDirty = ref(false)
-
-  const canvasWidth = ref(512)
-  const canvasHeight = ref(512)
 
   const cursorVisible = ref(false)
 
@@ -83,18 +84,31 @@ export function usePainter(nodeId: NodeId, options: UsePainterOptions) {
     return app.canvas.graph.getNodeById(nodeId)
   })
 
-  function getWidgetByName(name: string): IBaseWidget | undefined {
-    return litegraphNode.value?.widgets?.find(
-      (w: IBaseWidget) => w.name === name
-    )
+  function numberWidgetProjection(name: string, fallback: number) {
+    return computed<number>({
+      get: () => {
+        const v = getNodeWidgetValue(litegraphNode.value, name)
+        return typeof v === 'number' && v > 0 ? v : fallback
+      },
+      set: (v) => setNodeWidgetValue(litegraphNode.value, name, v)
+    })
   }
+
+  const canvasWidth = numberWidgetProjection('width', 512)
+  const canvasHeight = numberWidgetProjection('height', 512)
+  const backgroundColor = computed<string>({
+    get: () => {
+      const v = getNodeWidgetValue(litegraphNode.value, 'bg_color')
+      return typeof v === 'string' ? v : '#000000'
+    },
+    set: (v) => setNodeWidgetValue(litegraphNode.value, 'bg_color', v)
+  })
 
   const tool = ref<PainterTool>(PAINTER_TOOLS.BRUSH)
   const brushSize = ref(20)
   const brushColor = ref('#ffffff')
   const brushOpacity = ref(1)
   const brushHardness = ref(1)
-  const backgroundColor = ref('#000000')
 
   function restoreSettingsFromProperties() {
     const node = litegraphNode.value
@@ -110,9 +124,6 @@ export function usePainter(nodeId: NodeId, options: UsePainterOptions) {
       brushOpacity.value = props.painterBrushOpacity as number
     if (props.painterBrushHardness != null)
       brushHardness.value = props.painterBrushHardness as number
-
-    const bgColorWidget = getWidgetByName('bg_color')
-    if (bgColorWidget) backgroundColor.value = bgColorWidget.value as string
   }
 
   function saveSettingsToProperties() {
@@ -124,28 +135,6 @@ export function usePainter(nodeId: NodeId, options: UsePainterOptions) {
     node.properties.painterBrushColor = brushColor.value
     node.properties.painterBrushOpacity = brushOpacity.value
     node.properties.painterBrushHardness = brushHardness.value
-  }
-
-  function syncCanvasSizeToWidgets() {
-    const widthWidget = getWidgetByName('width')
-    const heightWidget = getWidgetByName('height')
-
-    if (widthWidget && widthWidget.value !== canvasWidth.value) {
-      widthWidget.value = canvasWidth.value
-      widthWidget.callback?.(canvasWidth.value)
-    }
-    if (heightWidget && heightWidget.value !== canvasHeight.value) {
-      heightWidget.value = canvasHeight.value
-      heightWidget.callback?.(canvasHeight.value)
-    }
-  }
-
-  function syncBackgroundColorToWidget() {
-    const bgColorWidget = getWidgetByName('bg_color')
-    if (bgColorWidget && bgColorWidget.value !== backgroundColor.value) {
-      bgColorWidget.value = backgroundColor.value
-      bgColorWidget.callback?.(backgroundColor.value)
-    }
   }
 
   function updateInputImageUrl() {
@@ -166,13 +155,6 @@ export function usePainter(nodeId: NodeId, options: UsePainterOptions) {
 
     const urls = nodeOutputStore.getNodeImageUrls(inputNode)
     inputImageUrl.value = urls?.length ? urls[0] : null
-  }
-
-  function syncCanvasSizeFromWidgets() {
-    const w = getWidgetByName('width')
-    const h = getWidgetByName('height')
-    canvasWidth.value = (w?.value as number) ?? 512
-    canvasHeight.value = (h?.value as number) ?? 512
   }
 
   function activeHardness(): number {
@@ -583,16 +565,6 @@ export function usePainter(nodeId: NodeId, options: UsePainterOptions) {
 
   function handleInputImageLoad(e: Event) {
     const img = e.target as HTMLImageElement
-    const widthWidget = getWidgetByName('width')
-    const heightWidget = getWidgetByName('height')
-    if (widthWidget) {
-      widthWidget.value = img.naturalWidth
-      widthWidget.callback?.(img.naturalWidth)
-    }
-    if (heightWidget) {
-      heightWidget.value = img.naturalHeight
-      heightWidget.callback?.(img.naturalHeight)
-    }
     canvasWidth.value = img.naturalWidth
     canvasHeight.value = img.naturalHeight
   }
@@ -731,12 +703,7 @@ export function usePainter(nodeId: NodeId, options: UsePainterOptions) {
     saveSettingsToProperties
   )
 
-  watch([canvasWidth, canvasHeight], syncCanvasSizeToWidgets)
-
-  watch(backgroundColor, syncBackgroundColorToWidget)
-
   function initialize() {
-    syncCanvasSizeFromWidgets()
     resizeCanvas()
     registerWidgetSerialization()
     restoreSettingsFromProperties()

--- a/src/composables/painter/usePainter.ts
+++ b/src/composables/painter/usePainter.ts
@@ -15,12 +15,10 @@ import type { IBaseWidget } from '@/lib/litegraph/src/types/widgets'
 import { useToastStore } from '@/platform/updates/common/toastStore'
 import { api } from '@/scripts/api'
 import { app } from '@/scripts/app'
-import {
-  getNodeWidgetValue,
-  setNodeWidgetValue
-} from '@/core/graph/widgets/nodeWidgetValues'
 import { useNodeOutputStore } from '@/stores/nodeOutputStore'
+import { useWidgetValueStore } from '@/stores/widgetValueStore'
 import type { NodeId } from '@/types/nodeId'
+import { widgetId } from '@/types/widgetId'
 
 type PainterTool = 'brush' | 'eraser'
 
@@ -84,22 +82,31 @@ export function usePainter(nodeId: NodeId, options: UsePainterOptions) {
     return app.canvas.graph.getNodeById(nodeId)
   })
 
+  const widgetValueStore = useWidgetValueStore()
+
+  function storedWidgetValue(name: string): unknown {
+    const node = litegraphNode.value
+    if (!node) return undefined
+    const graphId = node.graph?.rootGraph?.id
+    return graphId
+      ? widgetValueStore.getWidget(widgetId(graphId, node.id, name))?.value
+      : undefined
+  }
+
+  function writeWidgetValue(name: string, value: number | string): void {
+    const widget = litegraphNode.value?.widgets?.find((w) => w.name === name)
+    if (!widget || widget.value === value) return
+    widget.value = value
+    widget.callback?.(value)
+  }
+
   function numberWidgetProjection(name: string, fallback: number) {
-    const fallbackValue = ref(fallback)
     return computed<number>({
       get: () => {
-        const node = litegraphNode.value
-        if (!node) return fallbackValue.value
-        const value = getNodeWidgetValue(node, name)
-        return typeof value === 'number' && value > 0
-          ? value
-          : fallbackValue.value
+        const v = storedWidgetValue(name)
+        return typeof v === 'number' && v > 0 ? v : fallback
       },
-      set: (value) => {
-        fallbackValue.value = value
-        const node = litegraphNode.value
-        if (node) setNodeWidgetValue(node, name, value)
-      }
+      set: (v) => writeWidgetValue(name, v)
     })
   }
 
@@ -107,15 +114,10 @@ export function usePainter(nodeId: NodeId, options: UsePainterOptions) {
   const canvasHeight = numberWidgetProjection('height', 512)
   const backgroundColor = computed<string>({
     get: () => {
-      const node = litegraphNode.value
-      if (!node) return '#000000'
-      const v = getNodeWidgetValue(node, 'bg_color')
+      const v = storedWidgetValue('bg_color')
       return typeof v === 'string' ? v : '#000000'
     },
-    set: (v) => {
-      const node = litegraphNode.value
-      if (node) setNodeWidgetValue(node, 'bg_color', v)
-    }
+    set: (v) => writeWidgetValue('bg_color', v)
   })
 
   const tool = ref<PainterTool>(PAINTER_TOOLS.BRUSH)

--- a/src/composables/painter/usePainter.ts
+++ b/src/composables/painter/usePainter.ts
@@ -85,12 +85,21 @@ export function usePainter(nodeId: NodeId, options: UsePainterOptions) {
   })
 
   function numberWidgetProjection(name: string, fallback: number) {
+    const fallbackValue = ref(fallback)
     return computed<number>({
       get: () => {
-        const v = getNodeWidgetValue(litegraphNode.value, name)
-        return typeof v === 'number' && v > 0 ? v : fallback
+        const node = litegraphNode.value
+        if (!node) return fallbackValue.value
+        const value = getNodeWidgetValue(node, name)
+        return typeof value === 'number' && value > 0
+          ? value
+          : fallbackValue.value
       },
-      set: (v) => setNodeWidgetValue(litegraphNode.value, name, v)
+      set: (value) => {
+        fallbackValue.value = value
+        const node = litegraphNode.value
+        if (node) setNodeWidgetValue(node, name, value)
+      }
     })
   }
 
@@ -98,10 +107,15 @@ export function usePainter(nodeId: NodeId, options: UsePainterOptions) {
   const canvasHeight = numberWidgetProjection('height', 512)
   const backgroundColor = computed<string>({
     get: () => {
-      const v = getNodeWidgetValue(litegraphNode.value, 'bg_color')
+      const node = litegraphNode.value
+      if (!node) return '#000000'
+      const v = getNodeWidgetValue(node, 'bg_color')
       return typeof v === 'string' ? v : '#000000'
     },
-    set: (v) => setNodeWidgetValue(litegraphNode.value, 'bg_color', v)
+    set: (v) => {
+      const node = litegraphNode.value
+      if (node) setNodeWidgetValue(node, 'bg_color', v)
+    }
   })
 
   const tool = ref<PainterTool>(PAINTER_TOOLS.BRUSH)

--- a/src/composables/painter/usePainter.ts
+++ b/src/composables/painter/usePainter.ts
@@ -9,6 +9,7 @@ import {
   getEffectiveHardness
 } from '@/composables/maskeditor/brushUtils'
 import { StrokeProcessor } from '@/composables/maskeditor/StrokeProcessor'
+import { setNodeWidgetValue } from '@/core/graph/widgets/nodeWidgetValues'
 import { hexToRgb } from '@/utils/colorUtil'
 import type { Point } from '@/extensions/core/maskeditor/types'
 import type { IBaseWidget } from '@/lib/litegraph/src/types/widgets'
@@ -94,10 +95,10 @@ export function usePainter(nodeId: NodeId, options: UsePainterOptions) {
   }
 
   function writeWidgetValue(name: string, value: number | string): void {
-    const widget = litegraphNode.value?.widgets?.find((w) => w.name === name)
-    if (!widget || widget.value === value) return
-    widget.value = value
-    widget.callback?.(value)
+    const node = litegraphNode.value
+    const widget = node?.widgets?.find((w) => w.name === name)
+    if (!node || !widget || widget.value === value) return
+    setNodeWidgetValue(node, name, value)
   }
 
   function numberWidgetProjection(name: string, fallback: number) {

--- a/src/core/graph/widgets/nodeWidgetValues.test.ts
+++ b/src/core/graph/widgets/nodeWidgetValues.test.ts
@@ -8,11 +8,7 @@ import { toNodeId } from '@/types/nodeId'
 import { widgetId } from '@/types/widgetId'
 import { createMockLGraphNode } from '@/utils/__tests__/litegraphTestUtils'
 
-import {
-  getNodeWidgetValue,
-  nodeWidgetId,
-  setNodeWidgetValue
-} from './nodeWidgetValues'
+import { getNodeWidgetValue, setNodeWidgetValue } from './nodeWidgetValues'
 
 const GRAPH_ID = 'node-widget-values-test'
 const WIDGET_NAME = 'image'
@@ -56,20 +52,6 @@ function makeMockNode({
   return node
 }
 
-describe('nodeWidgetId', () => {
-  it('matches the id a registered widget derives for itself', () => {
-    const node = makeRegisteredNode()
-
-    expect(nodeWidgetId(node, WIDGET_NAME)).toBe(registeredId(node))
-  })
-
-  it('returns null for a node outside any graph', () => {
-    const node = new LGraphNode('Test')
-
-    expect(nodeWidgetId(node, WIDGET_NAME)).toBeNull()
-  })
-})
-
 describe('getNodeWidgetValue', () => {
   it('reads the store value for a registered widget', () => {
     const node = makeRegisteredNode()
@@ -106,7 +88,8 @@ describe('setNodeWidgetValue', () => {
   it('writes the store value for a registered widget', () => {
     const node = makeRegisteredNode()
 
-    expect(setNodeWidgetValue(node, WIDGET_NAME, 'next.png')).toBe(true)
+    setNodeWidgetValue(node, WIDGET_NAME, 'next.png')
+
     expect(useWidgetValueStore().getWidget(registeredId(node))?.value).toBe(
       'next.png'
     )
@@ -115,16 +98,21 @@ describe('setNodeWidgetValue', () => {
   it('falls back to the widget object when the store has no entry', () => {
     const node = makeMockNode({ widgetValue: 'legacy.png' })
 
-    expect(setNodeWidgetValue(node, WIDGET_NAME, 'next.png')).toBe(true)
+    setNodeWidgetValue(node, WIDGET_NAME, 'next.png')
+
     expect(node.widgets?.[0].value).toBe('next.png')
   })
 
-  it('returns false when the widget exists nowhere', () => {
+  it('is a no-op when the widget exists nowhere', () => {
     const node = createMockLGraphNode({
       id: toNodeId(1),
       graph: { rootGraph: { id: GRAPH_ID } }
     })
 
-    expect(setNodeWidgetValue(node, WIDGET_NAME, 'next.png')).toBe(false)
+    setNodeWidgetValue(node, WIDGET_NAME, 'next.png')
+
+    expect(
+      useWidgetValueStore().getWidget(widgetId(GRAPH_ID, node.id, WIDGET_NAME))
+    ).toBeUndefined()
   })
 })

--- a/src/core/graph/widgets/nodeWidgetValues.test.ts
+++ b/src/core/graph/widgets/nodeWidgetValues.test.ts
@@ -88,7 +88,7 @@ describe('setNodeWidgetValue', () => {
   it('writes the store value for a registered widget', () => {
     const node = makeRegisteredNode()
 
-    setNodeWidgetValue(node, WIDGET_NAME, 'next.png')
+    expect(setNodeWidgetValue(node, WIDGET_NAME, 'next.png')).toBe(true)
 
     expect(useWidgetValueStore().getWidget(registeredId(node))?.value).toBe(
       'next.png'
@@ -98,7 +98,7 @@ describe('setNodeWidgetValue', () => {
   it('falls back to the widget object when the store has no entry', () => {
     const node = makeMockNode({ widgetValue: 'legacy.png' })
 
-    setNodeWidgetValue(node, WIDGET_NAME, 'next.png')
+    expect(setNodeWidgetValue(node, WIDGET_NAME, 'next.png')).toBe(true)
 
     expect(node.widgets?.[0].value).toBe('next.png')
   })
@@ -109,7 +109,7 @@ describe('setNodeWidgetValue', () => {
       graph: { rootGraph: { id: GRAPH_ID } }
     })
 
-    setNodeWidgetValue(node, WIDGET_NAME, 'next.png')
+    expect(setNodeWidgetValue(node, WIDGET_NAME, 'next.png')).toBe(false)
 
     expect(
       useWidgetValueStore().getWidget(widgetId(GRAPH_ID, node.id, WIDGET_NAME))

--- a/src/core/graph/widgets/nodeWidgetValues.ts
+++ b/src/core/graph/widgets/nodeWidgetValues.ts
@@ -4,12 +4,16 @@ import type { WidgetValue } from '@/types/simplifiedWidget'
 import type { WidgetId } from '@/types/widgetId'
 import { widgetId } from '@/types/widgetId'
 
-export function nodeWidgetId(node: LGraphNode, name: string): WidgetId | null {
+function nodeWidgetId(node: LGraphNode, name: string): WidgetId | null {
   const graphId = node.graph?.rootGraph?.id
   return graphId ? widgetId(graphId, node.id, name) : null
 }
 
-export function getNodeWidgetValue(node: LGraphNode, name: string): unknown {
+export function getNodeWidgetValue(
+  node: LGraphNode | null | undefined,
+  name: string
+): unknown {
+  if (!node) return undefined
   const id = nodeWidgetId(node, name)
   const state = id ? useWidgetValueStore().getWidget(id) : undefined
   if (state) return state.value
@@ -17,10 +21,11 @@ export function getNodeWidgetValue(node: LGraphNode, name: string): unknown {
 }
 
 export function setNodeWidgetValue(
-  node: LGraphNode,
+  node: LGraphNode | null | undefined,
   name: string,
   value: WidgetValue
 ): boolean {
+  if (!node) return false
   const id = nodeWidgetId(node, name)
   if (id && useWidgetValueStore().setValue(id, value)) return true
   const widget = node.widgets?.find((w) => w.name === name)

--- a/src/core/graph/widgets/nodeWidgetValues.ts
+++ b/src/core/graph/widgets/nodeWidgetValues.ts
@@ -9,11 +9,7 @@ function nodeWidgetId(node: LGraphNode, name: string): WidgetId | null {
   return graphId ? widgetId(graphId, node.id, name) : null
 }
 
-export function getNodeWidgetValue(
-  node: LGraphNode | null | undefined,
-  name: string
-): unknown {
-  if (!node) return undefined
+export function getNodeWidgetValue(node: LGraphNode, name: string): unknown {
   const id = nodeWidgetId(node, name)
   const state = id ? useWidgetValueStore().getWidget(id) : undefined
   if (state) return state.value
@@ -21,15 +17,23 @@ export function getNodeWidgetValue(
 }
 
 export function setNodeWidgetValue(
-  node: LGraphNode | null | undefined,
+  node: LGraphNode,
   name: string,
   value: WidgetValue
 ): boolean {
-  if (!node) return false
   const id = nodeWidgetId(node, name)
-  if (id && useWidgetValueStore().setValue(id, value)) return true
   const widget = node.widgets?.find((w) => w.name === name)
+  const previousValue = getNodeWidgetValue(node, name)
+  if (id && useWidgetValueStore().setValue(id, value)) {
+    if (widget) {
+      widget.callback?.(value)
+      node.onWidgetChanged?.(name, value, previousValue, widget)
+    }
+    return true
+  }
   if (!widget) return false
   widget.value = value
+  widget.callback?.(value)
+  node.onWidgetChanged?.(name, value, previousValue, widget)
   return true
 }


### PR DESCRIPTION
ECS followup for painter

## Summary
canvasWidth, canvasHeight, and backgroundColor were local refs seeded from the widgets once at mount and copied back through two store-synchronization watches, with image loads writing both sides by hand. 
They are now writable computed projections over widgetValueStore (graphId:nodeId:name), so there is one source of truth: reads are reactive (external widget edits now reach the canvas without a remount, which the seeded copies never did), writes go straight to the store, and the initial copy, both sync functions, both sync watches, and the manual widget.callback invocations disappear. The canvas resize/redraw watch remains as the one imperative DOM boundary.
