### PR TITLE
feat(telemetry): instrument unified auth lifecycle and image load failures

### DIFF
--- a/src/platform/auth/session/useSessionCookie.test.ts
+++ b/src/platform/auth/session/useSessionCookie.test.ts
@@ -27,6 +27,11 @@ vi.mock('@/scripts/api', () => ({
   }
 }))
 
+const mockReportError = vi.fn()
+vi.mock('@/platform/telemetry/reportError', () => ({
+  reportError: mockReportError
+}))
+
 describe('useSessionCookie', () => {
   beforeEach(() => {
     vi.resetModules()
@@ -120,6 +125,24 @@ describe('useSessionCookie', () => {
     await expect(useSessionCookie().ensureSessionCookie()).rejects.toThrow(
       'session denied'
     )
+  })
+
+  it('reports a swallowed createSession failure as session_cookie_creation_failure', async () => {
+    mockGetIdToken.mockResolvedValue('firebase-id-token')
+    vi.mocked(globalThis.fetch).mockResolvedValue(
+      new Response(JSON.stringify({ message: 'session denied' }), {
+        status: 500,
+        headers: { 'Content-Type': 'application/json' }
+      })
+    )
+    const { useSessionCookie } =
+      await import('@/platform/auth/session/useSessionCookie')
+
+    await useSessionCookie().createSession()
+
+    expect(mockReportError).toHaveBeenCalledExactlyOnceWith(expect.any(Error), {
+      errorType: 'session_cookie_creation_failure'
+    })
   })
 
   it('serializes strict session creation after the previous user response', async () => {

--- a/src/platform/auth/session/useSessionCookie.ts
+++ b/src/platform/auth/session/useSessionCookie.ts
@@ -1,4 +1,5 @@
 import { isCloud } from '@/platform/distribution/types'
+import { reportError } from '@/platform/telemetry/reportError'
 import { api } from '@/scripts/api'
 import { useAuthStore } from '@/stores/authStore'
 
@@ -123,6 +124,9 @@ export const useSessionCookie = () => {
     try {
       await establishSession(currentOwnerUidOrThrow(), true)
     } catch (error) {
+      // The session cookie is the only credential <img>/media loads carry, so
+      // a swallowed creation failure means images break with no other signal.
+      reportError(error, { errorType: 'session_cookie_creation_failure' })
       console.warn('Failed to create session cookie:', error)
     }
   }

--- a/src/platform/telemetry/TelemetryRegistry.ts
+++ b/src/platform/telemetry/TelemetryRegistry.ts
@@ -12,6 +12,7 @@ import type {
   HelpCenterClosedMetadata,
   HelpCenterOpenedMetadata,
   HelpResourceClickedMetadata,
+  ImageLoadFailureMetadata,
   NamedValuesShadowDiffMismatchMetadata,
   NamedValuesShadowDiffSummaryMetadata,
   NodeAddedMetadata,
@@ -45,6 +46,7 @@ import type {
   TemplateLibraryMetadata,
   TemplateMetadata,
   UiButtonClickMetadata,
+  UnifiedAuthRefreshMetadata,
   UnifiedAuthRetryMetadata,
   WidgetFavoriteToggledMetadata,
   WorkflowCreatedMetadata,
@@ -93,6 +95,14 @@ export class TelemetryRegistry implements TelemetryDispatcher {
 
   trackUnifiedAuthRetry(metadata: UnifiedAuthRetryMetadata): void {
     this.dispatch((provider) => provider.trackUnifiedAuthRetry?.(metadata))
+  }
+
+  trackUnifiedAuthRefresh(metadata: UnifiedAuthRefreshMetadata): void {
+    this.dispatch((provider) => provider.trackUnifiedAuthRefresh?.(metadata))
+  }
+
+  trackImageLoadFailed(metadata: ImageLoadFailureMetadata): void {
+    this.dispatch((provider) => provider.trackImageLoadFailed?.(metadata))
   }
 
   trackUserLoggedIn(): void {

--- a/src/platform/telemetry/providers/cloud/DatadogRumTelemetryProvider.test.ts
+++ b/src/platform/telemetry/providers/cloud/DatadogRumTelemetryProvider.test.ts
@@ -38,6 +38,29 @@ describe('DatadogRumTelemetryProvider', () => {
     )
   })
 
+  it('records proactive unified refresh lifecycle outcomes', () => {
+    new DatadogRumTelemetryProvider().trackUnifiedAuthRefresh({
+      outcome: 'retries_exhausted',
+      retry_count: 3
+    })
+
+    expect(addAction).toHaveBeenCalledExactlyOnceWith(
+      TelemetryEvents.UNIFIED_AUTH_REFRESH_FAILED,
+      { outcome: 'retries_exhausted', retry_count: 3 }
+    )
+  })
+
+  it('records image load failures by source', () => {
+    new DatadogRumTelemetryProvider().trackImageLoadFailed({
+      source: 'node_image_preview'
+    })
+
+    expect(addAction).toHaveBeenCalledExactlyOnceWith(
+      TelemetryEvents.IMAGE_LOAD_FAILED,
+      { source: 'node_image_preview' }
+    )
+  })
+
   it('records the same canonical billing name and context as PostHog', () => {
     const event: BillingTelemetryEvent = {
       operation: 'operation',

--- a/src/platform/telemetry/providers/cloud/DatadogRumTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/DatadogRumTelemetryProvider.ts
@@ -4,7 +4,9 @@ import { datadogRum } from '@datadog/browser-rum'
 import type {
   BillingTelemetryEvent,
   ExecutionOutcomeMetadata,
+  ImageLoadFailureMetadata,
   TelemetryProvider,
+  UnifiedAuthRefreshMetadata,
   UnifiedAuthRetryMetadata
 } from '../../types'
 import {
@@ -21,6 +23,19 @@ export class DatadogRumTelemetryProvider implements TelemetryProvider {
         : TelemetryEvents.UNIFIED_AUTH_RETRY_FAILED,
       metadata
     )
+  }
+
+  trackUnifiedAuthRefresh(metadata: UnifiedAuthRefreshMetadata): void {
+    datadogRum.addAction(
+      metadata.outcome === 'succeeded'
+        ? TelemetryEvents.UNIFIED_AUTH_REFRESH_SUCCEEDED
+        : TelemetryEvents.UNIFIED_AUTH_REFRESH_FAILED,
+      metadata
+    )
+  }
+
+  trackImageLoadFailed(metadata: ImageLoadFailureMetadata): void {
+    datadogRum.addAction(TelemetryEvents.IMAGE_LOAD_FAILED, metadata)
   }
 
   trackBillingEvent(event: BillingTelemetryEvent): void {

--- a/src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.test.ts
+++ b/src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.test.ts
@@ -427,6 +427,18 @@ describe('PostHogTelemetryProvider', () => {
       )
     })
 
+    it('captures image load failures', async () => {
+      const provider = createProvider()
+      await vi.dynamicImportSettled()
+
+      provider.trackImageLoadFailed({ source: 'node_image_preview' })
+
+      expect(hoisted.mockCapture).toHaveBeenCalledWith(
+        TelemetryEvents.IMAGE_LOAD_FAILED,
+        { source: 'node_image_preview' }
+      )
+    })
+
     it('captures enriched execution starts with client attribution', async () => {
       const provider = createProvider()
       await vi.dynamicImportSettled()

--- a/src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.test.ts
+++ b/src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.test.ts
@@ -399,6 +399,34 @@ describe('PostHogTelemetryProvider', () => {
       )
     })
 
+    it('captures unified auth retry and refresh outcomes', async () => {
+      const provider = createProvider()
+      await vi.dynamicImportSettled()
+
+      provider.trackUnifiedAuthRetry({
+        transport: 'ws',
+        outcome: 'failed',
+        failure_reason: 'token_unavailable'
+      })
+      provider.trackUnifiedAuthRefresh({
+        outcome: 'retry_scheduled',
+        retry_count: 1
+      })
+
+      expect(hoisted.mockCapture).toHaveBeenCalledWith(
+        TelemetryEvents.UNIFIED_AUTH_RETRY_FAILED,
+        {
+          transport: 'ws',
+          outcome: 'failed',
+          failure_reason: 'token_unavailable'
+        }
+      )
+      expect(hoisted.mockCapture).toHaveBeenCalledWith(
+        TelemetryEvents.UNIFIED_AUTH_REFRESH_FAILED,
+        { outcome: 'retry_scheduled', retry_count: 1 }
+      )
+    })
+
     it('captures enriched execution starts with client attribution', async () => {
       const provider = createProvider()
       await vi.dynamicImportSettled()

--- a/src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.ts
@@ -14,6 +14,7 @@ import type {
   AddCreditsClickMetadata,
   AuthErrorMetadata,
   AuthMetadata,
+  ImageLoadFailureMetadata,
   UnifiedAuthRefreshMetadata,
   UnifiedAuthRetryMetadata,
   BeginCheckoutMetadata,
@@ -396,6 +397,10 @@ export class PostHogTelemetryProvider implements TelemetryProvider {
         : TelemetryEvents.UNIFIED_AUTH_REFRESH_FAILED,
       metadata
     )
+  }
+
+  trackImageLoadFailed(metadata: ImageLoadFailureMetadata): void {
+    this.trackEvent(TelemetryEvents.IMAGE_LOAD_FAILED, metadata)
   }
 
   trackUserLoggedIn(): void {

--- a/src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.ts
@@ -14,6 +14,8 @@ import type {
   AddCreditsClickMetadata,
   AuthErrorMetadata,
   AuthMetadata,
+  UnifiedAuthRefreshMetadata,
+  UnifiedAuthRetryMetadata,
   BeginCheckoutMetadata,
   BillingTelemetryEvent,
   DefaultViewSetMetadata,
@@ -376,6 +378,24 @@ export class PostHogTelemetryProvider implements TelemetryProvider {
 
   trackAuthFailed(metadata: AuthErrorMetadata): void {
     this.trackEvent(TelemetryEvents.USER_AUTH_FAILED, metadata)
+  }
+
+  trackUnifiedAuthRetry(metadata: UnifiedAuthRetryMetadata): void {
+    this.trackEvent(
+      metadata.outcome === 'succeeded'
+        ? TelemetryEvents.UNIFIED_AUTH_RETRY_SUCCEEDED
+        : TelemetryEvents.UNIFIED_AUTH_RETRY_FAILED,
+      metadata
+    )
+  }
+
+  trackUnifiedAuthRefresh(metadata: UnifiedAuthRefreshMetadata): void {
+    this.trackEvent(
+      metadata.outcome === 'succeeded'
+        ? TelemetryEvents.UNIFIED_AUTH_REFRESH_SUCCEEDED
+        : TelemetryEvents.UNIFIED_AUTH_REFRESH_FAILED,
+      metadata
+    )
   }
 
   trackUserLoggedIn(): void {

--- a/src/platform/telemetry/types.ts
+++ b/src/platform/telemetry/types.ts
@@ -75,12 +75,33 @@ export type UnifiedAuthRetryFailureReason =
   | 'remint_failed'
   | 'retry_rejected'
   | 'retry_request_failed'
+  | 'token_unavailable'
 
 export interface UnifiedAuthRetryMetadata {
-  transport: 'axios' | 'fetch'
+  transport: 'axios' | 'fetch' | 'ws'
   outcome: 'succeeded' | 'failed'
   final_status?: number
   failure_reason?: UnifiedAuthRetryFailureReason
+}
+
+export type UnifiedAuthRefreshOutcome =
+  | 'succeeded'
+  | 'retry_scheduled'
+  | 'retries_exhausted'
+  | 'permanent_failure'
+
+/**
+ * Outcome of one proactive unified Cloud-JWT refresh attempt. This lifecycle
+ * drives session-cookie rotation, so a dead refresh chain breaks every
+ * cookie-authenticated <img>/media load (FE-1595).
+ */
+export interface UnifiedAuthRefreshMetadata {
+  outcome: UnifiedAuthRefreshOutcome
+  retry_count?: number
+}
+
+export interface ImageLoadFailureMetadata {
+  source: 'node_image_preview'
 }
 
 /**
@@ -905,6 +926,8 @@ export interface TelemetryProvider {
   trackAuth?(metadata: AuthMetadata): void
   trackAuthFailed?(metadata: AuthErrorMetadata): void
   trackUnifiedAuthRetry?(metadata: UnifiedAuthRetryMetadata): void
+  trackUnifiedAuthRefresh?(metadata: UnifiedAuthRefreshMetadata): void
+  trackImageLoadFailed?(metadata: ImageLoadFailureMetadata): void
   trackUserLoggedIn?(): void
 
   // Subscription flow events
@@ -1041,6 +1064,9 @@ export const TelemetryEvents = {
   USER_LOGGED_IN: 'app:user_logged_in',
   UNIFIED_AUTH_RETRY_SUCCEEDED: 'auth.unified.request_retry.succeeded',
   UNIFIED_AUTH_RETRY_FAILED: 'auth.unified.request_retry.failed',
+  UNIFIED_AUTH_REFRESH_SUCCEEDED: 'auth.unified.refresh.succeeded',
+  UNIFIED_AUTH_REFRESH_FAILED: 'auth.unified.refresh.failed',
+  IMAGE_LOAD_FAILED: 'app:image_load_failed',
 
   // Subscription Flow
   RUN_BUTTON_CLICKED: 'app:run_button_click',
@@ -1216,6 +1242,8 @@ export type TelemetryEventProperties =
   | OnboardingTourMetadata
   | AuthErrorMetadata
   | UnifiedAuthRetryMetadata
+  | UnifiedAuthRefreshMetadata
+  | ImageLoadFailureMetadata
   | SurveyResponses
   | TemplateMetadata
   | ExecutionContext

--- a/src/platform/workspace/stores/useWorkspaceAuth.test.ts
+++ b/src/platform/workspace/stores/useWorkspaceAuth.test.ts
@@ -14,6 +14,7 @@ import { WORKSPACE_STORAGE_KEYS } from '@/platform/workspace/workspaceConstants'
 
 const mockGetIdToken = vi.fn()
 const mockNotifyTokenRefreshed = vi.fn()
+const mockTrackUnifiedAuthRefresh = vi.fn()
 const mockToastAdd = vi.fn()
 const mockEnsureSessionCookie = vi.fn()
 const mockCurrentUser = vi.hoisted((): { value: { uid: string } | null } => ({
@@ -55,6 +56,12 @@ vi.mock('@/platform/workflow/persistence/base/storageIO', () => ({
 vi.mock('@/platform/auth/session/useSessionCookie', () => ({
   useSessionCookie: () => ({
     ensureSessionCookie: mockEnsureSessionCookie
+  })
+}))
+
+vi.mock('@/platform/telemetry', () => ({
+  useTelemetry: () => ({
+    trackUnifiedAuthRefresh: mockTrackUnifiedAuthRefresh
   })
 }))
 
@@ -2627,6 +2634,10 @@ describe('useWorkspaceAuthStore', () => {
         expect(mockToastAdd).toHaveBeenCalledWith(
           expect.objectContaining({ severity: 'error', detail: detailKey })
         )
+        expect(mockTrackUnifiedAuthRefresh).toHaveBeenLastCalledWith({
+          outcome: 'permanent_failure',
+          retry_count: 0
+        })
         expect(unifiedToken.value).toBeNull()
       }
     )
@@ -2756,11 +2767,18 @@ describe('useWorkspaceAuthStore', () => {
       await vi.advanceTimersByTimeAsync(refreshDelay)
       expect(mockFetch).toHaveBeenCalledTimes(2)
       expect(mockNotifyTokenRefreshed).not.toHaveBeenCalled()
+      expect(mockTrackUnifiedAuthRefresh).toHaveBeenLastCalledWith({
+        outcome: 'retry_scheduled',
+        retry_count: 1
+      })
 
       await vi.advanceTimersByTimeAsync(5000)
 
       expect(mockFetch).toHaveBeenCalledTimes(3)
       expect(mockNotifyTokenRefreshed).toHaveBeenCalledTimes(1)
+      expect(mockTrackUnifiedAuthRefresh).toHaveBeenLastCalledWith({
+        outcome: 'succeeded'
+      })
       expect(unifiedToken.value).toBe('unified-token-1')
 
       // The successful retry re-arms the normal proactive schedule.
@@ -2805,6 +2823,10 @@ describe('useWorkspaceAuthStore', () => {
 
       expect(mockFetch).toHaveBeenCalledTimes(5)
       expect(mockToastAdd).not.toHaveBeenCalled()
+      expect(mockTrackUnifiedAuthRefresh).toHaveBeenLastCalledWith({
+        outcome: 'retries_exhausted',
+        retry_count: 3
+      })
       expect(unifiedToken.value).toBe('unified-token-1')
     })
 

--- a/src/platform/workspace/stores/workspaceAuthStore.ts
+++ b/src/platform/workspace/stores/workspaceAuthStore.ts
@@ -887,8 +887,8 @@ export const useWorkspaceAuthStore = defineStore('workspaceAuth', () => {
       // workspace switches establish it themselves. A stale (discarded)
       // re-mint does not rotate either.
       if (minted) {
-        trackUnifiedRefresh('succeeded')
         useAuthStore().notifyTokenRefreshed()
+        trackUnifiedRefresh('succeeded')
       } else if (unifiedRefreshTimerId === null) {
         // A mint failure while the owner uid is momentarily null (Firebase
         // re-initializing post-wake) resolves false instead of throwing. Only

--- a/src/platform/workspace/stores/workspaceAuthStore.ts
+++ b/src/platform/workspace/stores/workspaceAuthStore.ts
@@ -5,6 +5,8 @@ import { z } from 'zod'
 import { fromZodError } from 'zod-validation-error'
 
 import { t } from '@/i18n'
+import { useTelemetry } from '@/platform/telemetry'
+import type { UnifiedAuthRefreshOutcome } from '@/platform/telemetry/types'
 import { prepareWorkflowWorkspaceTransition } from '@/platform/workflow/persistence/base/storageIO'
 import {
   TOKEN_REFRESH_BUFFER_MS,
@@ -863,6 +865,13 @@ export const useWorkspaceAuthStore = defineStore('workspaceAuth', () => {
     }
   }
 
+  function trackUnifiedRefresh(outcome: UnifiedAuthRefreshOutcome): void {
+    useTelemetry()?.trackUnifiedAuthRefresh({
+      outcome,
+      ...(outcome !== 'succeeded' && { retry_count: unifiedRefreshRetryCount })
+    })
+  }
+
   async function refreshUnified(): Promise<void> {
     if (!flags.unifiedCloudAuthEnabled) {
       return
@@ -878,18 +887,24 @@ export const useWorkspaceAuthStore = defineStore('workspaceAuth', () => {
       // workspace switches establish it themselves. A stale (discarded)
       // re-mint does not rotate either.
       if (minted) {
+        trackUnifiedRefresh('succeeded')
         useAuthStore().notifyTokenRefreshed()
       } else if (unifiedRefreshTimerId === null) {
         // A mint failure while the owner uid is momentarily null (Firebase
         // re-initializing post-wake) resolves false instead of throwing. Only
         // a false with no armed timer is a dead chain: a superseding mint has
         // already scheduled its own refresh.
-        scheduleUnifiedRefreshRetry()
+        trackUnifiedRefresh(
+          scheduleUnifiedRefreshRetry()
+            ? 'retry_scheduled'
+            : 'retries_exhausted'
+        )
       }
     } catch (err) {
       // Guard the toast on a live token so concurrent permanent failures across
       // the proactive + reactive paths alarm the user once, not once per caller.
       if (isPermanentAuthError(err)) {
+        trackUnifiedRefresh('permanent_failure')
         if (getUnifiedToken()) surfacePermanentAuthError(err)
         endWorkspaceSession(
           isWorkspaceSelectionInvalid(err)
@@ -898,6 +913,9 @@ export const useWorkspaceAuthStore = defineStore('workspaceAuth', () => {
         )
       } else {
         const retryScheduled = scheduleUnifiedRefreshRetry()
+        trackUnifiedRefresh(
+          retryScheduled ? 'retry_scheduled' : 'retries_exhausted'
+        )
         console.warn(
           retryScheduled
             ? 'Unified token refresh failed; retrying shortly:'

--- a/src/renderer/extensions/vueNodes/components/ImagePreview.test.ts
+++ b/src/renderer/extensions/vueNodes/components/ImagePreview.test.ts
@@ -19,6 +19,13 @@ vi.mock('@/services/hdrViewerService', () => ({
   openHdrViewer: vi.fn()
 }))
 
+const mockTrackImageLoadFailed = vi.fn()
+vi.mock('@/platform/telemetry', () => ({
+  useTelemetry: () => ({
+    trackImageLoadFailed: mockTrackImageLoadFailed
+  })
+}))
+
 const i18n = createI18n({
   legacy: false,
   locale: 'en',
@@ -168,6 +175,9 @@ describe('ImagePreview', () => {
     expect(
       screen.queryByRole('button', { name: 'Download image' })
     ).not.toBeInTheDocument()
+    expect(mockTrackImageLoadFailed).toHaveBeenCalledExactlyOnceWith({
+      source: 'node_image_preview'
+    })
   })
 
   it('handles download button click', async () => {

--- a/src/renderer/extensions/vueNodes/components/ImagePreview.vue
+++ b/src/renderer/extensions/vueNodes/components/ImagePreview.vue
@@ -214,6 +214,7 @@ import { downloadFile } from '@/base/common/downloadUtil'
 import Button from '@/components/ui/button/Button.vue'
 import Skeleton from '@/components/ui/skeleton/Skeleton.vue'
 import { useMaskEditor } from '@/composables/maskeditor/useMaskEditor'
+import { useTelemetry } from '@/platform/telemetry'
 import { useToastStore } from '@/platform/updates/common/toastStore'
 import { openHdrViewer } from '@/services/hdrViewerService'
 import { useNodeOutputStore } from '@/stores/nodeOutputStore'
@@ -335,6 +336,7 @@ function handleImageError() {
   stopDelayedLoader()
   showLoader.value = false
   imageError.value = true
+  useTelemetry()?.trackImageLoadFailed({ source: 'node_image_preview' })
   actualDimensions.value = null
 }
 

--- a/src/scripts/api.ts
+++ b/src/scripts/api.ts
@@ -693,6 +693,14 @@ export class ComfyApi extends EventTarget {
           params.set('token', authToken)
         }
       } catch (error) {
+        if (await shouldRemintCloudRequest()) {
+          const { useTelemetry } = await import('@/platform/telemetry')
+          useTelemetry()?.trackUnifiedAuthRetry({
+            transport: 'ws',
+            outcome: 'failed',
+            failure_reason: 'token_unavailable'
+          })
+        }
         // Continue without auth token if there's an error
         console.warn(
           'Could not get auth token for WebSocket connection:',

--- a/src/scripts/api.ts
+++ b/src/scripts/api.ts
@@ -287,6 +287,24 @@ function addHeaderEntry(headers: HeadersInit, key: string, value: string) {
   }
 }
 
+/**
+ * Fire-and-forget: a telemetry chunk-load failure must never prevent the
+ * token-less WebSocket connect fallback from proceeding.
+ */
+async function trackWsTokenUnavailable(): Promise<void> {
+  try {
+    if (!(await shouldRemintCloudRequest())) return
+    const { useTelemetry } = await import('@/platform/telemetry')
+    useTelemetry()?.trackUnifiedAuthRetry({
+      transport: 'ws',
+      outcome: 'failed',
+      failure_reason: 'token_unavailable'
+    })
+  } catch (err) {
+    console.warn('Failed to report WebSocket token unavailability:', err)
+  }
+}
+
 /** EventTarget typing has no generic capability. */
 export interface ComfyApi extends EventTarget {
   addEventListener<TEvent extends keyof ApiEvents>(
@@ -693,14 +711,7 @@ export class ComfyApi extends EventTarget {
           params.set('token', authToken)
         }
       } catch (error) {
-        if (await shouldRemintCloudRequest()) {
-          const { useTelemetry } = await import('@/platform/telemetry')
-          useTelemetry()?.trackUnifiedAuthRetry({
-            transport: 'ws',
-            outcome: 'failed',
-            failure_reason: 'token_unavailable'
-          })
-        }
+        void trackWsTokenUnavailable()
         // Continue without auth token if there's an error
         console.warn(
           'Could not get auth token for WebSocket connection:',


### PR DESCRIPTION
## Summary

Follow-up to #16063: the unified-auth incident (FE-1595) was invisible in telemetry — every path that killed image loads only `console.warn`ed. This instruments the lifecycle so the fix's effect is measurable and a recurrence alerts instead of waiting on customer reports.

## Why this is needed

Diagnosing FE-1595 required the artist's Network tab because none of the failing seams emit telemetry:

- The proactive `refreshUnified()` failure — the moment the session-cookie rotation chain dies — was `console.warn` only.
- Session-cookie creation failure (`useSessionCookie.createSession`) was swallowed with a warn; that cookie is the only credential `<img>`/media loads carry.
- The user-facing symptom itself (`ImagePreview` load error) set local state only, so affected-user counts were unknowable.
- `trackUnifiedAuthRetry` covered only axios/fetch transports and only reached Datadog RUM, so PostHog could not query or alert on any of it.

## Changes

- **What**: `trackUnifiedAuthRefresh` lifecycle event (`succeeded` / `retry_scheduled` / `retries_exhausted` / `permanent_failure`, with `retry_count`) emitted from `refreshUnified()`; measures the retry/backoff added in #16063.
- **What**: `reportError(..., { errorType: 'session_cookie_creation_failure' })` on swallowed `createSession` failures (dual-sink per repo convention).
- **What**: `trackImageLoadFailed({ source: 'node_image_preview' })` from `ImagePreview`'s error handler — no filenames/PII, source tag only.
- **What**: `'ws'` transport + `'token_unavailable'` reason on `UnifiedAuthRetryMetadata`, emitted when WebSocket connect cannot obtain a token under unified auth.
- **What**: PostHog provider now implements `trackUnifiedAuthRetry`/`trackUnifiedAuthRefresh` (previously Datadog-only), enabling PostHog queries and alerts.

## Review Focus

- Event volume: `auth.unified.refresh.succeeded` fires ~once per 85min per active session; `app:image_load_failed` fires per failed `<img>` render in node previews. Both go to Datadog actions; only the unified-auth events go to PostHog.
- `retry_count` is attached to non-succeeded outcomes only.

## Tests

- Refresh lifecycle outcomes asserted across the existing retry/backoff/permanent-failure store tests.
- `session_cookie_creation_failure` report on swallowed createSession failure.
- Image-error telemetry asserted in the existing ImagePreview failure test.
- Both providers' new methods covered. 216 tests green across the five touched suites; typecheck/lint/knip clean.

No UI change (telemetry only), so no screenshots.

Related: FE-1595 (linear.app/comfyorg/issue/FE-1595)
