### PR TITLE
refactor(bbox): read and write editor widget values through widgetValueStore

### DIFF
--- a/src/composables/boundingBoxes/useBoundingBoxes.test.ts
+++ b/src/composables/boundingBoxes/useBoundingBoxes.test.ts
@@ -4,8 +4,12 @@ import type { Ref, ShallowRef } from 'vue'
 import { defineComponent, h, nextTick, ref, shallowRef } from 'vue'
 
 import { useBoundingBoxes } from './useBoundingBoxes'
+import { useWidgetValueStore } from '@/stores/widgetValueStore'
 import type { BoundingBox } from '@/types/boundingBoxes'
 import { toNodeId } from '@/types/nodeId'
+import type { NodeId } from '@/types/nodeId'
+import type { WidgetValue } from '@/types/simplifiedWidget'
+import { widgetId } from '@/types/widgetId'
 
 const { appState, outputState } = vi.hoisted(() => {
   const appState: { node: MockNode | null } = { node: null }
@@ -81,30 +85,45 @@ function makeCanvas(): HTMLCanvasElement {
   return el
 }
 
+const GRAPH_ID = 'bbox-test-graph'
+const NODE_ID = toNodeId('1')
+
 interface MockNode {
-  widgets: { name: string; value: unknown }[]
+  id: NodeId
+  graph: { rootGraph: { id: string } }
   findInputSlot: (name: string) => number
   getInputNode: () => null
   isInputConnected?: () => boolean
 }
 
 function makeNode(): MockNode {
+  const store = useWidgetValueStore()
+  const register = (name: string, type: string, value: WidgetValue) =>
+    store.registerWidget(widgetId(GRAPH_ID, NODE_ID, name), {
+      type,
+      value,
+      options: {}
+    })
+  register('width', 'number', 512)
+  register('height', 'number', 512)
+  register('last_incoming', 'custom', [])
   return {
-    widgets: [
-      { name: 'width', value: 512 },
-      { name: 'height', value: 512 },
-      { name: 'last_incoming', value: [] }
-    ],
+    id: NODE_ID,
+    graph: { rootGraph: { id: GRAPH_ID } },
     findInputSlot: () => -1,
     getInputNode: () => null
   }
 }
 
-const lastIncomingOf = (node: MockNode) =>
-  node.widgets.find((w) => w.name === 'last_incoming')!.value
+const lastIncomingOf = () =>
+  useWidgetValueStore().getWidget(widgetId(GRAPH_ID, NODE_ID, 'last_incoming'))
+    ?.value
 
-const setLastIncomingOf = (node: MockNode, value: BoundingBox[]) => {
-  node.widgets.find((w) => w.name === 'last_incoming')!.value = value
+const setLastIncomingOf = (value: BoundingBox[]) => {
+  useWidgetValueStore().setValue(
+    widgetId(GRAPH_ID, NODE_ID, 'last_incoming'),
+    value
+  )
 }
 
 const pe = (
@@ -255,13 +274,13 @@ describe('useBoundingBoxes region editing', () => {
 
   it('clears all regions and invalidates the applied upstream input', async () => {
     const node = makeNode()
-    setLastIncomingOf(node, [box()])
+    setLastIncomingOf([box()])
     appState.node = node
     const c = setup([box(), box({ x: 0 })])
     c.clearAll()
     await flush()
     expect(modelBoxes(c)).toHaveLength(0)
-    expect(lastIncomingOf(node)).toEqual([])
+    expect(lastIncomingOf()).toEqual([])
   })
 })
 
@@ -297,13 +316,13 @@ describe('useBoundingBoxes incoming bboxes input', () => {
     const c = setup([box({ x: 200, width: 300 })])
     expect(modelBoxes(c)).toHaveLength(1)
     expect(modelBoxes(c)[0].width).toBe(300)
-    expect(lastIncomingOf(node)).toEqual(incoming)
+    expect(lastIncomingOf()).toEqual(incoming)
   })
 
   it('does not re-apply an already applied output after a remount', async () => {
     const node = makeConnectedNode()
     const incoming = [box({ x: 0, width: 100 })]
-    setLastIncomingOf(node, incoming)
+    setLastIncomingOf(incoming)
     appState.node = node
     outputState.outputs = { input_bboxes: incoming }
     const c = setup([box({ x: 200, width: 300 })])
@@ -328,7 +347,7 @@ describe('useBoundingBoxes incoming bboxes input', () => {
     const c = setup([])
 
     expect(modelBoxes(c)).toHaveLength(0)
-    expect(lastIncomingOf(node)).toEqual([])
+    expect(lastIncomingOf()).toEqual([])
   })
 
   it('repopulates from the next run after clearing the canvas', async () => {
@@ -403,12 +422,12 @@ describe('useBoundingBoxes incoming bboxes input', () => {
 
     expect(modelBoxes(c)).toHaveLength(1)
     expect(modelBoxes(c)[0].width).toBe(100)
-    expect(lastIncomingOf(node)).toEqual(incoming)
+    expect(lastIncomingOf()).toEqual(incoming)
   })
 
   it('re-seeds the canvas over user edits when the upstream value changes', async () => {
     const node = makeConnectedNode()
-    setLastIncomingOf(node, [box({ x: 0, width: 100 })])
+    setLastIncomingOf([box({ x: 0, width: 100 })])
     appState.node = node
     const c = setup([box({ x: 200, width: 300 })])
 
@@ -418,7 +437,7 @@ describe('useBoundingBoxes incoming bboxes input', () => {
     await flush()
 
     expect(modelBoxes(c)[0].width).toBe(128)
-    expect(lastIncomingOf(node)).toEqual(changed)
+    expect(lastIncomingOf()).toEqual(changed)
   })
 })
 

--- a/src/composables/boundingBoxes/useBoundingBoxes.ts
+++ b/src/composables/boundingBoxes/useBoundingBoxes.ts
@@ -16,11 +16,15 @@ import type {
   HitMode,
   Region
 } from '@/composables/boundingBoxes/boundingBoxesUtil'
+import { setNodeWidgetValue } from '@/core/graph/widgets/nodeWidgetValues'
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import { app } from '@/scripts/app'
 import { useNodeOutputStore } from '@/stores/nodeOutputStore'
+import { useWidgetValueStore } from '@/stores/widgetValueStore'
 import type { BoundingBox } from '@/types/boundingBoxes'
 import type { NodeId } from '@/types/nodeId'
+import type { WidgetId } from '@/types/widgetId'
+import { widgetId } from '@/types/widgetId'
 import { readableTextColor, textOnColor } from '@/utils/colorUtil'
 
 const HANDLE_PX = 8
@@ -73,8 +77,27 @@ export function useBoundingBoxes(
   const { selectedNodeIds } = storeToRefs(useCanvasStore())
   const isNodeSelected = computed(() => selectedNodeIds.value.has(nodeId))
 
+  const widgetValueStore = useWidgetValueStore()
+
+  function bboxWidgetId(name: string): WidgetId | null {
+    const node = litegraphNode.value
+    if (!node) return null
+    const graphId = node.graph?.rootGraph?.id
+    return graphId ? widgetId(graphId, node.id, name) : null
+  }
+
+  function widgetValue(name: string): unknown {
+    const id = bboxWidgetId(name)
+    return id ? widgetValueStore.getWidget(id)?.value : undefined
+  }
+
+  function setWidgetValue(name: string, value: number | BoundingBox[]): void {
+    const node = litegraphNode.value
+    if (node) setNodeWidgetValue(node, name, value)
+  }
+
   function dimWidget(name: 'width' | 'height'): number | undefined {
-    const v = litegraphNode.value?.widgets?.find((w) => w.name === name)?.value
+    const v = widgetValue(name)
     return typeof v === 'number' && v > 0 ? v : undefined
   }
   const widthValue = computed(() => dimWidget('width') ?? 1024)
@@ -642,22 +665,12 @@ export function useBoundingBoxes(
 
   const nodeOutputStore = useNodeOutputStore()
   function applyImageDimensions(naturalWidth: number, naturalHeight: number) {
-    const node = litegraphNode.value
-    if (!node) return
     const snap = (v: number) =>
       Math.max(DIMENSION_STEP, Math.round(v / DIMENSION_STEP) * DIMENSION_STEP)
     const targetW = snap(naturalWidth)
     const targetH = snap(naturalHeight)
-    const widthWidget = node.widgets?.find((w) => w.name === 'width')
-    const heightWidget = node.widgets?.find((w) => w.name === 'height')
-    if (widthWidget && widthWidget.value !== targetW) {
-      widthWidget.value = targetW
-      widthWidget.callback?.(targetW)
-    }
-    if (heightWidget && heightWidget.value !== targetH) {
-      heightWidget.value = targetH
-      heightWidget.callback?.(targetH)
-    }
+    if (widgetValue('width') !== targetW) setWidgetValue('width', targetW)
+    if (widgetValue('height') !== targetH) setWidgetValue('height', targetH)
   }
 
   let lastBgUrl = ''
@@ -690,21 +703,13 @@ export function useBoundingBoxes(
     }
     img.src = url
   }
-  function lastIncomingWidget() {
-    return litegraphNode.value?.widgets?.find((w) => w.name === 'last_incoming')
-  }
-
   function lastIncomingValue(): BoundingBox[] {
-    const value = lastIncomingWidget()?.value
+    const value = widgetValue('last_incoming')
     return Array.isArray(value) ? (value as BoundingBox[]) : []
   }
 
   function setLastIncoming(boxes: BoundingBox[]) {
-    const widget = lastIncomingWidget()
-    if (!widget) return
-    const next = cloneDeep(boxes)
-    widget.value = next
-    widget.callback?.(next)
+    setWidgetValue('last_incoming', cloneDeep(boxes))
   }
 
   function applyIncomingBoxes(apply = true) {


### PR DESCRIPTION
ECS followup for create bounding boxes node

## Summary
The bbox editor resolved width/height/last_incoming by traversing node.widgets, mutating widget.value, and invoking widget.callback to propagate writes. Post-ECS, BaseWidget.value already delegates to widgetValueStore, so the traversal read a copy of state the store owns and the callback invocation re-triggered sync work the store performs itself.

Replace the widget-object plumbing with a feature-owned WidgetId boundary (graphId:nodeId:name): width/height computeds read the store directly, applyImageDimensions and last_incoming write via store.setValue. No widget-object fallback is needed - the editor operates its own core node, whose widgets are registered on graph.add.

last_incoming intentionally stays a one-shot command write persisted through workflow serialization; remodeling it as "applied output revision" editor state is a follow-up.