### PR TITLE
[agent-v1 01/18] Serialize workflow loads and track navigation intents (test-led split)

### DIFF
--- a/src/platform/workflow/core/services/workflowService.test.ts
+++ b/src/platform/workflow/core/services/workflowService.test.ts
@@ -79,6 +79,14 @@ const draftStoreMocks = vi.hoisted(() => ({
   markDraftUsed: vi.fn()
 }))
 
+const subgraphNavigationMocks = vi.hoisted(() => ({
+  navigationIntentId: 0,
+  beginWorkflowNavigation: vi.fn(
+    () => ++subgraphNavigationMocks.navigationIntentId
+  ),
+  saveCurrentViewport: vi.fn()
+}))
+
 vi.mock('@/services/dialogService', () => ({
   useDialogService: () => ({
     prompt: vi.fn(),
@@ -131,9 +139,7 @@ vi.mock('@/stores/domWidgetStore', () => ({
 }))
 
 vi.mock('@/stores/subgraphNavigationStore', () => ({
-  useSubgraphNavigationStore: () => ({
-    saveCurrentViewport: vi.fn()
-  })
+  useSubgraphNavigationStore: () => subgraphNavigationMocks
 }))
 
 vi.mock('@/stores/workspaceStore', () => ({
@@ -172,6 +178,7 @@ function enableWarningSettings() {
 describe('useWorkflowService', () => {
   beforeEach(() => {
     draftStoreMocks.saveDraft.mockReturnValue(true)
+    subgraphNavigationMocks.navigationIntentId = 0
   })
 
   describe('showPendingWarnings', () => {
@@ -280,6 +287,16 @@ describe('useWorkflowService', () => {
     beforeEach(() => {
       enableWarningSettings()
       workflowStore = useWorkflowStore()
+    })
+
+    it('does not suppress a root change for a clean-false load', () => {
+      workflowStore.activeWorkflow = createModeTestWorkflow()
+
+      useWorkflowService().beforeLoadNewGraph(false)
+
+      expect(subgraphNavigationMocks.saveCurrentViewport).toHaveBeenCalledWith(
+        false
+      )
     })
 
     it('should cache missingModelCandidates and missingMediaCandidates to activeWorkflow.pendingWarnings', () => {
@@ -414,6 +431,642 @@ describe('useWorkflowService', () => {
       } finally {
         consoleErrorSpy.mockRestore()
       }
+    })
+  })
+
+  describe('openWorkflow ordering', () => {
+    it('serializes rapid workflow opens so the final selection stays active', async () => {
+      const workflowStore = useWorkflowStore()
+      const first = createWorkflow(null, {
+        loadable: true,
+        path: 'workflows/first.json'
+      })
+      const second = createWorkflow(null, {
+        loadable: true,
+        path: 'workflows/second.json'
+      })
+      workflowStore.activeWorkflow = second as LoadedComfyWorkflow
+      let resolveFirst: (() => void) | undefined
+      let concurrentLoads = 0
+      let maxConcurrentLoads = 0
+
+      vi.mocked(app.loadGraphData).mockImplementation(
+        async (_data, _clean, _restore, workflow) => {
+          concurrentLoads++
+          maxConcurrentLoads = Math.max(maxConcurrentLoads, concurrentLoads)
+          if (workflow === first) {
+            await new Promise<void>((resolve) => {
+              resolveFirst = resolve
+            })
+          }
+          workflowStore.activeWorkflow = workflow as LoadedComfyWorkflow
+          concurrentLoads--
+        }
+      )
+
+      const firstOpen = useWorkflowService().openWorkflow(first)
+      await vi.waitFor(() => {
+        expect(app.loadGraphData).toHaveBeenCalledTimes(1)
+      })
+      const secondOpen = useWorkflowService().openWorkflow(second)
+      await Promise.resolve()
+
+      expect(app.loadGraphData).toHaveBeenCalledTimes(1)
+      resolveFirst?.()
+      await Promise.all([firstOpen, secondOpen])
+
+      expect(maxConcurrentLoads).toBe(1)
+      expect(
+        vi.mocked(app.loadGraphData).mock.calls.map((call) => call[3])
+      ).toEqual([first, second])
+      expect(
+        vi
+          .mocked(app.loadGraphData)
+          .mock.calls.map((call) => call[4]?.workflowNavigationId)
+      ).toEqual([1, 2])
+      expect(workflowStore.activeWorkflow?.path).toBe(second.path)
+    })
+
+    it('continues with the next workflow when the previous load fails', async () => {
+      const workflowStore = useWorkflowStore()
+      const first = createWorkflow(null, {
+        loadable: true,
+        path: 'workflows/first.json'
+      })
+      const second = createWorkflow(null, {
+        loadable: true,
+        path: 'workflows/second.json'
+      })
+      const error = new Error('load failed')
+      workflowStore.activeWorkflow = second as LoadedComfyWorkflow
+
+      vi.mocked(app.loadGraphData)
+        .mockRejectedValueOnce(error)
+        .mockImplementationOnce(async (_data, _clean, _restore, workflow) => {
+          workflowStore.activeWorkflow = workflow as LoadedComfyWorkflow
+        })
+
+      const firstOpen = useWorkflowService().openWorkflow(first)
+      const secondOpen = useWorkflowService().openWorkflow(second)
+
+      await expect(firstOpen).rejects.toBe(error)
+      await expect(secondOpen).resolves.toBeUndefined()
+      expect(
+        vi.mocked(app.loadGraphData).mock.calls.map((call) => call[3])
+      ).toEqual([first, second])
+      expect(workflowStore.activeWorkflow?.path).toBe(second.path)
+    })
+
+    it('closes an inactive workflow without waiting for an unrelated load', async () => {
+      const workflowStore = useWorkflowStore()
+      const current = createWorkflow(null, {
+        loadable: true,
+        path: 'workflows/current.json'
+      })
+      const loading = createWorkflow(null, {
+        loadable: true,
+        path: 'workflows/loading.json'
+      })
+      const closing = createWorkflow(null, {
+        loadable: true,
+        path: 'workflows/closing.json'
+      })
+      Object.defineProperty(closing, 'unload', { value: vi.fn() })
+      let resolveLoad: (() => void) | undefined
+
+      workflowStore.attachWorkflow(current, 0)
+      workflowStore.attachWorkflow(loading, 1)
+      workflowStore.attachWorkflow(closing, 2)
+      workflowStore.activeWorkflow = current as LoadedComfyWorkflow
+      vi.mocked(app.loadGraphData).mockImplementation(
+        async (_data, _clean, _restore, workflow) => {
+          if (workflow === loading) {
+            await new Promise<void>((resolve) => {
+              resolveLoad = resolve
+            })
+          }
+          workflowStore.activeWorkflow = workflow as LoadedComfyWorkflow
+        }
+      )
+
+      const service = useWorkflowService()
+      const loadingOpen = service.openWorkflow(loading)
+      await vi.waitFor(() => expect(app.loadGraphData).toHaveBeenCalledOnce())
+
+      await expect(
+        service.closeWorkflow(closing, { warnIfUnsaved: false })
+      ).resolves.toBe(true)
+      expect(workflowStore.openWorkflows).not.toContain(closing)
+
+      resolveLoad?.()
+      await loadingOpen
+    })
+
+    it('waits for a workflow in flight before closing it', async () => {
+      const workflowStore = useWorkflowStore()
+      const current = createWorkflow(null, {
+        loadable: true,
+        path: 'workflows/current.json'
+      })
+      const closing = createWorkflow(null, {
+        loadable: true,
+        path: 'workflows/closing.json'
+      })
+      Object.defineProperty(closing, 'unload', { value: vi.fn() })
+      let resolveLoad: (() => void) | undefined
+
+      workflowStore.attachWorkflow(current, 0)
+      workflowStore.attachWorkflow(closing, 1)
+      workflowStore.activeWorkflow = current as LoadedComfyWorkflow
+      vi.mocked(app.loadGraphData).mockImplementation(
+        async (_data, _clean, _restore, workflow) => {
+          if (workflow === closing) {
+            await new Promise<void>((resolve) => {
+              resolveLoad = resolve
+            })
+          }
+          workflowStore.activeWorkflow = workflow as LoadedComfyWorkflow
+        }
+      )
+
+      const service = useWorkflowService()
+      const opening = service.openWorkflow(closing)
+      await vi.waitFor(() => expect(app.loadGraphData).toHaveBeenCalledOnce())
+      let closeSettled = false
+      const close = service
+        .closeWorkflow(closing, { warnIfUnsaved: false })
+        .finally(() => {
+          closeSettled = true
+        })
+      await Promise.resolve()
+      expect(closeSettled).toBe(false)
+
+      resolveLoad?.()
+      await Promise.all([opening, close])
+      expect(workflowStore.openWorkflows).not.toContain(closing)
+    })
+
+    it('does not extend an inactive close with a later unrelated load', async () => {
+      const workflowStore = useWorkflowStore()
+      const current = createWorkflow(null, {
+        loadable: true,
+        path: 'workflows/current.json'
+      })
+      const closing = createWorkflow(null, {
+        loadable: true,
+        path: 'workflows/closing.json'
+      })
+      const unrelated = createWorkflow(null, {
+        loadable: true,
+        path: 'workflows/unrelated.json'
+      })
+      Object.defineProperty(closing, 'unload', { value: vi.fn() })
+      const closingError = new Error('closing load failed')
+      let rejectClosing: ((error: Error) => void) | undefined
+      let resolveUnrelated: (() => void) | undefined
+      let unrelatedStarted = false
+
+      workflowStore.attachWorkflow(current, 0)
+      workflowStore.attachWorkflow(closing, 1)
+      workflowStore.attachWorkflow(unrelated, 2)
+      workflowStore.activeWorkflow = current as LoadedComfyWorkflow
+      vi.mocked(app.loadGraphData).mockImplementation(
+        async (_data, _clean, _restore, workflow) => {
+          if (workflow === closing) {
+            await new Promise<void>((_resolve, reject) => {
+              rejectClosing = reject
+            })
+          }
+          if (workflow === unrelated) {
+            unrelatedStarted = true
+            await new Promise<void>((resolve) => {
+              resolveUnrelated = resolve
+            })
+          }
+          workflowStore.activeWorkflow = workflow as LoadedComfyWorkflow
+        }
+      )
+
+      const service = useWorkflowService()
+      const opening = service.openWorkflow(closing)
+      const openingResult = opening.catch((error: unknown) => error)
+      await vi.waitFor(() => expect(app.loadGraphData).toHaveBeenCalledOnce())
+
+      let closeSettled = false
+      const close = service
+        .closeWorkflow(closing, { warnIfUnsaved: false })
+        .finally(() => {
+          closeSettled = true
+        })
+      const unrelatedOpen = service.openWorkflow(unrelated)
+
+      rejectClosing?.(closingError)
+      expect(await openingResult).toBe(closingError)
+      await vi.waitFor(() => expect(unrelatedStarted).toBe(true))
+      await vi.waitFor(() => expect(closeSettled).toBe(true))
+      expect(workflowStore.openWorkflows).not.toContain(closing)
+
+      resolveUnrelated?.()
+      await Promise.all([close, unrelatedOpen])
+    })
+
+    it('falls back to the next tab when activation history is empty', async () => {
+      const workflowStore = useWorkflowStore()
+      const first = createWorkflow(null, {
+        loadable: true,
+        path: 'workflows/first.json'
+      })
+      const closing = createWorkflow(null, {
+        loadable: true,
+        path: 'workflows/closing.json'
+      })
+      const next = createWorkflow(null, {
+        loadable: true,
+        path: 'workflows/next.json'
+      })
+      Object.defineProperty(closing, 'unload', { value: vi.fn() })
+
+      workflowStore.attachWorkflow(first, 0)
+      workflowStore.attachWorkflow(closing, 1)
+      workflowStore.attachWorkflow(next, 2)
+      workflowStore.activeWorkflow = closing as LoadedComfyWorkflow
+      vi.spyOn(workflowStore, 'getMostRecentWorkflow').mockReturnValue(null)
+      vi.mocked(app.loadGraphData).mockImplementation(
+        async (_data, _clean, _restore, workflow) => {
+          workflowStore.activeWorkflow = workflow as LoadedComfyWorkflow
+        }
+      )
+
+      await useWorkflowService().closeWorkflow(closing, {
+        warnIfUnsaved: false
+      })
+
+      expect(workflowStore.activeWorkflow?.path).toBe(next.path)
+      expect(app.loadGraphData).toHaveBeenCalledWith(
+        expect.anything(),
+        true,
+        true,
+        next,
+        expect.anything()
+      )
+    })
+
+    it('keeps a workflow closed when its queued open settles later', async () => {
+      const workflowStore = useWorkflowStore()
+      const current = createWorkflow(null, {
+        loadable: true,
+        path: 'workflows/current.json'
+      })
+      const first = createWorkflow(null, {
+        loadable: true,
+        path: 'workflows/first.json'
+      })
+      const second = createWorkflow(null, {
+        loadable: true,
+        path: 'workflows/second.json'
+      })
+      Object.defineProperty(second, 'unload', { value: vi.fn() })
+      let resolveFirst: (() => void) | undefined
+
+      workflowStore.attachWorkflow(current, 0)
+      workflowStore.attachWorkflow(first, 1)
+      workflowStore.attachWorkflow(second, 2)
+      workflowStore.activeWorkflow = current as LoadedComfyWorkflow
+      vi.spyOn(workflowStore, 'getMostRecentWorkflow').mockReturnValue(current)
+      vi.mocked(app.loadGraphData).mockImplementation(
+        async (_data, _clean, _restore, workflow) => {
+          if (workflow === first) {
+            await new Promise<void>((resolve) => {
+              resolveFirst = resolve
+            })
+          }
+          workflowStore.activeWorkflow = workflow as LoadedComfyWorkflow
+        }
+      )
+
+      const service = useWorkflowService()
+      const firstOpen = service.openWorkflow(first)
+      await vi.waitFor(() => expect(app.loadGraphData).toHaveBeenCalledOnce())
+      const secondOpen = service.openWorkflow(second)
+      const close = service.closeWorkflow(second, { warnIfUnsaved: false })
+      resolveFirst?.()
+
+      await Promise.all([firstOpen, secondOpen, close])
+
+      expect(workflowStore.openWorkflows).not.toContain(second)
+      expect(workflowStore.activeWorkflow?.path).toBe(current.path)
+    })
+
+    it('does not let an older close override a newer workflow selection', async () => {
+      const workflowStore = useWorkflowStore()
+      const current = createWorkflow(null, {
+        loadable: true,
+        path: 'workflows/current.json'
+      })
+      const first = createWorkflow(null, {
+        loadable: true,
+        path: 'workflows/first.json'
+      })
+      const second = createWorkflow(null, {
+        loadable: true,
+        path: 'workflows/second.json'
+      })
+      const final = createWorkflow(null, {
+        loadable: true,
+        path: 'workflows/final.json'
+      })
+      Object.defineProperty(second, 'unload', { value: vi.fn() })
+      let resolveFirst: (() => void) | undefined
+
+      workflowStore.attachWorkflow(current, 0)
+      workflowStore.attachWorkflow(first, 1)
+      workflowStore.attachWorkflow(second, 2)
+      workflowStore.attachWorkflow(final, 3)
+      workflowStore.activeWorkflow = current as LoadedComfyWorkflow
+      vi.spyOn(workflowStore, 'getMostRecentWorkflow').mockReturnValue(current)
+      vi.mocked(app.loadGraphData).mockImplementation(
+        async (_data, _clean, _restore, workflow) => {
+          if (workflow === first) {
+            await new Promise<void>((resolve) => {
+              resolveFirst = resolve
+            })
+          }
+          workflowStore.activeWorkflow = workflow as LoadedComfyWorkflow
+        }
+      )
+
+      const service = useWorkflowService()
+      const firstOpen = service.openWorkflow(first)
+      await vi.waitFor(() => expect(app.loadGraphData).toHaveBeenCalledOnce())
+      const secondOpen = service.openWorkflow(second)
+      const close = service.closeWorkflow(second, { warnIfUnsaved: false })
+      const finalOpen = service.openWorkflow(final)
+      resolveFirst?.()
+
+      await Promise.all([firstOpen, secondOpen, close, finalOpen])
+
+      expect(workflowStore.openWorkflows).not.toContain(second)
+      expect(workflowStore.activeWorkflow?.path).toBe(final.path)
+      expect(
+        vi.mocked(app.loadGraphData).mock.calls.map((call) => call[3])
+      ).toEqual([first, second, final])
+    })
+
+    it('falls back after a newer workflow selection fails', async () => {
+      const workflowStore = useWorkflowStore()
+      const current = createWorkflow(null, {
+        loadable: true,
+        path: 'workflows/current.json'
+      })
+      const first = createWorkflow(null, {
+        loadable: true,
+        path: 'workflows/first.json'
+      })
+      const closing = createWorkflow(null, {
+        loadable: true,
+        path: 'workflows/closing.json'
+      })
+      const failing = createWorkflow(null, {
+        loadable: true,
+        path: 'workflows/failing.json'
+      })
+      Object.defineProperty(closing, 'unload', { value: vi.fn() })
+      let resolveFirst: (() => void) | undefined
+
+      workflowStore.attachWorkflow(current, 0)
+      workflowStore.attachWorkflow(first, 1)
+      workflowStore.attachWorkflow(closing, 2)
+      workflowStore.attachWorkflow(failing, 3)
+      workflowStore.activeWorkflow = current as LoadedComfyWorkflow
+      vi.spyOn(workflowStore, 'getMostRecentWorkflow').mockReturnValue(current)
+      vi.mocked(app.loadGraphData).mockImplementation(
+        async (_data, _clean, _restore, workflow) => {
+          if (workflow === first) {
+            await new Promise<void>((resolve) => {
+              resolveFirst = resolve
+            })
+          }
+          if (workflow === failing) throw new Error('load failed')
+          workflowStore.activeWorkflow = workflow as LoadedComfyWorkflow
+        }
+      )
+
+      const service = useWorkflowService()
+      const firstOpen = service.openWorkflow(first)
+      await vi.waitFor(() => expect(app.loadGraphData).toHaveBeenCalledOnce())
+      const closingOpen = service.openWorkflow(closing)
+      const close = service.closeWorkflow(closing, { warnIfUnsaved: false })
+      const failingOpen = service.openWorkflow(failing)
+      resolveFirst?.()
+
+      await Promise.all([
+        firstOpen,
+        closingOpen,
+        close,
+        expect(failingOpen).rejects.toThrow('load failed')
+      ])
+
+      expect(workflowStore.openWorkflows).not.toContain(closing)
+      expect(workflowStore.activeWorkflow?.path).toBe(current.path)
+    })
+
+    it('serializes a newer selection after the last-tab replacement', async () => {
+      const workflowStore = useWorkflowStore()
+      const closing = createWorkflow(null, {
+        loadable: true,
+        path: 'workflows/closing.json'
+      })
+      const replacement = createWorkflow(null, {
+        loadable: true,
+        path: 'workflows/replacement.json'
+      })
+      const final = createWorkflow(null, {
+        loadable: true,
+        path: 'workflows/final.json'
+      })
+      Object.defineProperty(closing, 'unload', { value: vi.fn() })
+      let resolveDefault: (() => void) | undefined
+      let concurrentLoads = 0
+      let maxConcurrentLoads = 0
+
+      workflowStore.attachWorkflow(closing, 0)
+      workflowStore.activeWorkflow = closing as LoadedComfyWorkflow
+      vi.mocked(app.loadGraphData).mockImplementation(
+        async (_data, _clean, _restore, workflow) => {
+          concurrentLoads++
+          maxConcurrentLoads = Math.max(maxConcurrentLoads, concurrentLoads)
+          if (!workflow) {
+            await new Promise<void>((resolve) => {
+              resolveDefault = () => {
+                workflowStore.attachWorkflow(replacement, 1)
+                workflowStore.activeWorkflow =
+                  replacement as LoadedComfyWorkflow
+                resolve()
+              }
+            })
+          } else {
+            workflowStore.attachWorkflow(final, 2)
+            workflowStore.activeWorkflow = final as LoadedComfyWorkflow
+          }
+          concurrentLoads--
+        }
+      )
+
+      const service = useWorkflowService()
+      const close = service.closeWorkflow(closing, { warnIfUnsaved: false })
+      await vi.waitFor(() => expect(app.loadGraphData).toHaveBeenCalledOnce())
+      const finalOpen = service.openWorkflow(final)
+      await Promise.resolve()
+
+      expect(app.loadGraphData).toHaveBeenCalledOnce()
+      resolveDefault?.()
+      await Promise.all([close, finalOpen])
+
+      expect(maxConcurrentLoads).toBe(1)
+      expect(workflowStore.openWorkflows).not.toContain(closing)
+      expect(workflowStore.activeWorkflow?.path).toBe(final.path)
+      expect(
+        vi.mocked(app.loadGraphData).mock.calls.map((call) => call[3])
+      ).toEqual([undefined, final])
+    })
+
+    it('does not reopen the workflow being closed', async () => {
+      const workflowStore = useWorkflowStore()
+      const closing = createWorkflow(null, {
+        loadable: true,
+        path: 'workflows/closing.json'
+      })
+      const replacement = createWorkflow(null, {
+        loadable: true,
+        path: 'workflows/replacement.json'
+      })
+      Object.defineProperty(closing, 'unload', { value: vi.fn() })
+      let resolveDefault: (() => void) | undefined
+
+      workflowStore.attachWorkflow(closing, 0)
+      workflowStore.activeWorkflow = closing as LoadedComfyWorkflow
+      vi.mocked(app.loadGraphData).mockImplementation(
+        async (_data, _clean, _restore, workflow) => {
+          if (workflow) {
+            workflowStore.activeWorkflow = workflow as LoadedComfyWorkflow
+            return
+          }
+          await new Promise<void>((resolve) => {
+            resolveDefault = () => {
+              workflowStore.attachWorkflow(replacement, 1)
+              workflowStore.activeWorkflow = replacement as LoadedComfyWorkflow
+              resolve()
+            }
+          })
+        }
+      )
+
+      const service = useWorkflowService()
+      const close = service.closeWorkflow(closing, { warnIfUnsaved: false })
+      await vi.waitFor(() => expect(app.loadGraphData).toHaveBeenCalledOnce())
+      const staleOpen = service.openWorkflow(closing)
+      resolveDefault?.()
+
+      await Promise.all([close, staleOpen])
+
+      expect(app.loadGraphData).toHaveBeenCalledOnce()
+      expect(workflowStore.openWorkflows).not.toContain(closing)
+      expect(workflowStore.activeWorkflow?.path).toBe(replacement.path)
+    })
+
+    it('keeps a valid active workflow when closing tabs concurrently', async () => {
+      const workflowStore = useWorkflowStore()
+      const first = createWorkflow(null, {
+        loadable: true,
+        path: 'workflows/first.json'
+      })
+      const second = createWorkflow(null, {
+        loadable: true,
+        path: 'workflows/second.json'
+      })
+      const replacement = createWorkflow(null, {
+        loadable: true,
+        path: 'workflows/replacement.json'
+      })
+      Object.defineProperty(first, 'unload', { value: vi.fn() })
+      Object.defineProperty(second, 'unload', { value: vi.fn() })
+
+      workflowStore.attachWorkflow(first, 0)
+      workflowStore.attachWorkflow(second, 1)
+      workflowStore.activeWorkflow = first as LoadedComfyWorkflow
+      vi.mocked(app.loadGraphData).mockImplementation(
+        async (_data, _clean, _restore, workflow) => {
+          if (workflow) return
+          workflowStore.attachWorkflow(replacement, 2)
+          workflowStore.activeWorkflow = replacement as LoadedComfyWorkflow
+        }
+      )
+
+      const service = useWorkflowService()
+      await Promise.all([
+        service.closeWorkflow(first, { warnIfUnsaved: false }),
+        service.closeWorkflow(second, { warnIfUnsaved: false })
+      ])
+
+      expect(app.loadGraphData).toHaveBeenCalledOnce()
+      expect(workflowStore.openWorkflows).not.toContain(first)
+      expect(workflowStore.openWorkflows).not.toContain(second)
+      expect(workflowStore.activeWorkflow?.path).toBe(replacement.path)
+    })
+
+    it('does not reopen a workflow while a duplicate close remains active', async () => {
+      const workflowStore = useWorkflowStore()
+      const closing = createWorkflow(null, {
+        loadable: true,
+        path: 'workflows/closing.json'
+      })
+      const replacement = createWorkflow(null, {
+        loadable: true,
+        path: 'workflows/replacement.json'
+      })
+      Object.defineProperty(closing, 'unload', { value: vi.fn() })
+      let resolveReplacement: (() => void) | undefined
+      let defaultLoadCount = 0
+
+      workflowStore.attachWorkflow(closing, 0)
+      workflowStore.activeWorkflow = closing as LoadedComfyWorkflow
+      vi.mocked(app.loadGraphData).mockImplementation(
+        async (_data, _clean, _restore, workflow) => {
+          if (workflow && typeof workflow !== 'string') {
+            workflowStore.attachWorkflow(workflow, 0)
+            workflowStore.activeWorkflow = workflow as LoadedComfyWorkflow
+            return
+          }
+
+          defaultLoadCount++
+          if (defaultLoadCount === 1) throw new Error('replacement failed')
+          await new Promise<void>((resolve) => {
+            resolveReplacement = () => {
+              workflowStore.attachWorkflow(replacement, 1)
+              workflowStore.activeWorkflow = replacement as LoadedComfyWorkflow
+              resolve()
+            }
+          })
+        }
+      )
+
+      const service = useWorkflowService()
+      const firstClose = service.closeWorkflow(closing, {
+        warnIfUnsaved: false
+      })
+      const secondClose = service.closeWorkflow(closing, {
+        warnIfUnsaved: false
+      })
+
+      await expect(firstClose).rejects.toThrow('replacement failed')
+      await vi.waitFor(() => expect(app.loadGraphData).toHaveBeenCalledTimes(2))
+      const staleOpen = service.openWorkflow(closing)
+      resolveReplacement?.()
+      await Promise.all([secondClose, staleOpen])
+
+      expect(app.loadGraphData).toHaveBeenCalledTimes(2)
+      expect(workflowStore.openWorkflows).not.toContain(closing)
+      expect(workflowStore.activeWorkflow?.path).toBe(replacement.path)
     })
   })
 

--- a/src/platform/workflow/core/services/workflowService.ts
+++ b/src/platform/workflow/core/services/workflowService.ts
@@ -49,6 +49,35 @@ function linearModeToAppMode(linearMode: unknown): AppMode | null {
   return linearMode ? 'app' : 'graph'
 }
 
+let workflowLoadTail: Promise<void> = Promise.resolve()
+let pendingWorkflowLoads = 0
+const pendingWorkflowLoadsByPath = new Map<string, Promise<void>>()
+const closingWorkflowCounts = new Map<string, number>()
+
+function queueWorkflowLoad(
+  load: () => Promise<void>,
+  workflowPath?: string
+): Promise<void> {
+  pendingWorkflowLoads++
+  const result = workflowLoadTail.then(load)
+  const settledResult = result
+    .catch(() => undefined)
+    .finally(() => {
+      pendingWorkflowLoads--
+      if (
+        workflowPath &&
+        pendingWorkflowLoadsByPath.get(workflowPath) === settledResult
+      ) {
+        pendingWorkflowLoadsByPath.delete(workflowPath)
+      }
+    })
+  workflowLoadTail = settledResult
+  if (workflowPath) {
+    pendingWorkflowLoadsByPath.set(workflowPath, settledResult)
+  }
+  return result
+}
+
 export const useWorkflowService = () => {
   const settingStore = useSettingStore()
   const workflowStore = useWorkflowStore()
@@ -280,31 +309,44 @@ export const useWorkflowService = () => {
    * @param workflow The workflow to open
    * @param options The options for opening the workflow
    */
-  const openWorkflow = async (
+  const openWorkflow = (
     workflow: ComfyWorkflow,
-    options: { force: boolean } = { force: false }
-  ) => {
-    if (workflowStore.isActive(workflow) && !options.force) return
-
-    const loadFromRemote = !workflow.isLoaded
-    if (loadFromRemote) {
-      await workflow.load()
+    options: { force?: boolean; navigationIntentId?: number } = {}
+  ): Promise<void> => {
+    if (closingWorkflowCounts.has(workflow.path)) return Promise.resolve()
+    if (
+      pendingWorkflowLoads === 0 &&
+      workflowStore.isActive(workflow) &&
+      !options.force
+    ) {
+      return Promise.resolve()
     }
 
-    await app.loadGraphData(
-      toRaw(workflow.activeState) as ComfyWorkflowJSON,
-      /* clean=*/ true,
-      /* restore_view=*/ true,
-      workflow,
-      {
-        checkForRerouteMigration: false,
-        deferWarnings: true,
-        skipAssetScans: !loadFromRemote && !options.force
+    const navigationIntentId =
+      options.navigationIntentId ??
+      useSubgraphNavigationStore().beginWorkflowNavigation()
+    return queueWorkflowLoad(async () => {
+      const loadFromRemote = !workflow.isLoaded
+      if (loadFromRemote) {
+        await workflow.load()
       }
-    )
-    showPendingWarnings(undefined, {
-      silent: !loadFromRemote && !options.force
-    })
+
+      await app.loadGraphData(
+        toRaw(workflow.activeState) as ComfyWorkflowJSON,
+        /* clean=*/ true,
+        /* restore_view=*/ true,
+        workflow,
+        {
+          checkForRerouteMigration: false,
+          deferWarnings: true,
+          skipAssetScans: !loadFromRemote && !options.force,
+          workflowNavigationId: navigationIntentId
+        }
+      )
+      showPendingWarnings(undefined, {
+        silent: !loadFromRemote && !options.force
+      })
+    }, workflow.path)
   }
 
   /**
@@ -336,26 +378,62 @@ export const useWorkflowService = () => {
       }
     }
 
-    workflowDraftStore.removeDraft(workflow.path)
+    closingWorkflowCounts.set(
+      workflow.path,
+      (closingWorkflowCounts.get(workflow.path) ?? 0) + 1
+    )
+    try {
+      workflowDraftStore.removeDraft(workflow.path)
+      const wasActive = workflowStore.isActive(workflow)
+      const pendingWorkflowLoad = pendingWorkflowLoadsByPath.get(workflow.path)
+      if (!wasActive && pendingWorkflowLoad) await pendingWorkflowLoad
+      if (
+        wasActive ||
+        (pendingWorkflowLoad && workflowStore.isActive(workflow))
+      ) {
+        let observedOpenTail: Promise<void>
+        do {
+          observedOpenTail = workflowLoadTail
+          await observedOpenTail
+        } while (observedOpenTail !== workflowLoadTail)
+      }
 
-    // If this is the last workflow, create a new default temporary workflow
-    if (workflowStore.openWorkflows.length === 1) {
-      await loadDefaultWorkflow()
-    }
-    // If this is the active workflow, load the most recent workflow from history
-    if (workflowStore.isActive(workflow)) {
-      const mostRecentWorkflow = workflowStore.getMostRecentWorkflow()
-      if (mostRecentWorkflow) {
-        await openWorkflow(mostRecentWorkflow)
+      // If this is the active workflow, load the most recent workflow from history
+      if (workflowStore.isActive(workflow)) {
+        const mostRecentWorkflow = workflowStore.getMostRecentWorkflow()
+        let replacementWorkflow =
+          mostRecentWorkflow &&
+          !closingWorkflowCounts.has(mostRecentWorkflow.path)
+            ? mostRecentWorkflow
+            : undefined
+        for (
+          let shift = 1;
+          !replacementWorkflow && shift < workflowStore.openWorkflows.length;
+          shift++
+        ) {
+          const candidate = workflowStore.openedWorkflowIndexShift(shift)
+          if (candidate && !closingWorkflowCounts.has(candidate.path)) {
+            replacementWorkflow = candidate
+          }
+        }
+        if (replacementWorkflow) {
+          await openWorkflow(replacementWorkflow)
+        } else {
+          await queueWorkflowLoad(loadDefaultWorkflow)
+        }
+      }
+
+      await workflowStore.closeWorkflow(workflow)
+      useNodeOutputStore().discardPreviewsForWorkflow(workflow.path)
+      return true
+    } finally {
+      const remainingCloses = closingWorkflowCounts.get(workflow.path) ?? 0
+      if (remainingCloses <= 1) {
+        closingWorkflowCounts.delete(workflow.path)
       } else {
-        // Fallback to next workflow if no history
-        await loadNextOpenedWorkflow()
+        closingWorkflowCounts.set(workflow.path, remainingCloses - 1)
       }
     }
-
-    await workflowStore.closeWorkflow(workflow)
-    useNodeOutputStore().discardPreviewsForWorkflow(workflow.path)
-    return true
   }
 
   const renameWorkflow = async (workflow: ComfyWorkflow, newPath: string) => {
@@ -411,7 +489,7 @@ export const useWorkflowService = () => {
    * This function is used to save the current workflow states before loading
    * a new graph.
    */
-  const beforeLoadNewGraph = () => {
+  const beforeLoadNewGraph = (suppressWorkflowReset = true) => {
     // Use workspaceStore here as it is patched in unit tests.
     const workflowStore = useWorkspaceStore().workflow
     const activeWorkflow = workflowStore.activeWorkflow
@@ -438,7 +516,7 @@ export const useWorkflowService = () => {
       domWidgetStore.clear()
 
       // Save subgraph viewport before the canvas gets overwritten
-      useSubgraphNavigationStore().saveCurrentViewport()
+      useSubgraphNavigationStore().saveCurrentViewport(suppressWorkflowReset)
     }
   }
 

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -1248,6 +1248,7 @@ export class ComfyApp {
       deferWarnings?: boolean
       skipAssetScans?: boolean
       silentAssetErrors?: boolean
+      workflowNavigationId?: number
     } = {}
   ) {
     const {
@@ -1256,9 +1257,10 @@ export class ComfyApp {
       shareId,
       deferWarnings = false,
       skipAssetScans = false,
-      silentAssetErrors = false
+      silentAssetErrors = false,
+      workflowNavigationId
     } = options
-    useWorkflowService().beforeLoadNewGraph()
+    useWorkflowService().beforeLoadNewGraph(clean !== false)
 
     if (skipAssetScans) {
       // Only reset candidates; preserve UI state (fileSizes, etc.)
@@ -1582,7 +1584,10 @@ export class ComfyApp {
         })
       }
 
-      void useSubgraphNavigationStore().updateHash()
+      void useSubgraphNavigationStore().updateHash(
+        'workflow-load',
+        workflowNavigationId
+      )
       requestAnimationFrame(() => {
         this.canvas.setDirty(true, true)
       })

--- a/src/stores/subgraphNavigationStore.test.ts
+++ b/src/stores/subgraphNavigationStore.test.ts
@@ -1,6 +1,10 @@
+import { createTestingPinia } from '@pinia/testing'
 import { fromPartial } from '@total-typescript/shoehorn'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { disposePinia, setActivePinia } from 'pinia'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
+
+import type * as VueRouter from 'vue-router'
 
 import type { Subgraph } from '@/lib/litegraph/src/LGraph'
 import type { ComfyWorkflow } from '@/platform/workflow/management/stores/workflowStore'
@@ -9,6 +13,23 @@ import { app } from '@/scripts/app'
 import { useSubgraphNavigationStore } from '@/stores/subgraphNavigationStore'
 
 type MockSubgraph = Pick<Subgraph, 'id' | 'rootGraph' | '_nodes' | 'nodes'>
+
+const {
+  routeHash,
+  routerPush,
+  routerReplace,
+  routerHistory,
+  mockOpenWorkflow
+} = await vi.hoisted(async () => {
+  const { ref } = await import('vue')
+  return {
+    routeHash: ref(''),
+    routerPush: vi.fn(),
+    routerReplace: vi.fn(),
+    routerHistory: { state: {} as Record<string, unknown> },
+    mockOpenWorkflow: vi.fn()
+  }
+})
 
 function createMockSubgraph(id: string, rootGraph = app.rootGraph): Subgraph {
   const mockSubgraph = {
@@ -21,8 +42,18 @@ function createMockSubgraph(id: string, rootGraph = app.rootGraph): Subgraph {
   return fromPartial<Subgraph>(mockSubgraph)
 }
 
+function getRouteTargetHash(target: VueRouter.RouteLocationRaw): string {
+  return typeof target === 'string' ? target : String(target.hash ?? '')
+}
+
+function applyRouteTarget(target: VueRouter.RouteLocationRaw): void {
+  routerHistory.state = typeof target === 'string' ? {} : (target.state ?? {})
+  routeHash.value = getRouteTargetHash(target)
+}
+
 vi.mock('@/scripts/app', () => {
   const mockCanvas = {
+    graph: null,
     subgraph: null,
     ds: {
       scale: 1,
@@ -32,7 +63,8 @@ vi.mock('@/scripts/app', () => {
         offset: [0, 0]
       }
     },
-    setDirty: vi.fn()
+    setDirty: vi.fn(),
+    setGraph: vi.fn()
   }
 
   const mockGraph = {
@@ -60,18 +92,46 @@ vi.mock('@/renderer/core/canvas/canvasStore', () => ({
 vi.mock('@/utils/graphTraversalUtil', () => ({
   findSubgraphPathById: vi.fn()
 }))
-vi.mock('@vueuse/router', () => ({ useRouteHash: vi.fn() }))
+vi.mock('@vueuse/router', () => ({ useRouteHash: () => routeHash }))
+vi.mock('vue-router', async (importOriginal) => ({
+  ...(await importOriginal<typeof VueRouter>()),
+  useRouter: () => ({
+    push: routerPush,
+    replace: routerReplace,
+    options: { history: routerHistory }
+  })
+}))
+vi.mock('@/platform/workflow/core/services/workflowService', () => ({
+  useWorkflowService: () => ({ openWorkflow: mockOpenWorkflow })
+}))
 
 describe('useSubgraphNavigationStore', () => {
+  let pinia: ReturnType<typeof createTestingPinia>
+
   beforeEach(() => {
+    pinia = createTestingPinia({ stubActions: false })
+    setActivePinia(pinia)
     app.rootGraph.subgraphs.clear()
+    app.rootGraph.id = 'current-root'
+    app.canvas.graph = app.rootGraph
     app.canvas.subgraph = undefined
     app.canvas.ds.scale = 1
     app.canvas.ds.offset = [0, 0]
     app.canvas.ds.state.scale = 1
     app.canvas.ds.state.offset = [0, 0]
     app.graph.getNodeById = vi.fn()
+    routeHash.value = ''
+    routerHistory.state = {}
+    routerPush.mockReset().mockImplementation(async (target) => {
+      applyRouteTarget(target)
+    })
+    routerReplace.mockReset().mockImplementation(async (target) => {
+      applyRouteTarget(target)
+    })
+    mockOpenWorkflow.mockReset()
   })
+
+  afterEach(() => disposePinia(pinia))
 
   it('should not clear navigation stack when workflow internal state changes', async () => {
     const navigationStore = useSubgraphNavigationStore()
@@ -281,5 +341,198 @@ describe('useSubgraphNavigationStore', () => {
 
     // Stack should be cleared when activeSubgraph becomes undefined
     expect(navigationStore.exportState()).toHaveLength(0)
+  })
+
+  it('does not reopen workflows for hashes written during graph changes', async () => {
+    const navigationStore = useSubgraphNavigationStore()
+    const workflowStore = useWorkflowStore()
+    const nextGraph = fromPartial<typeof app.rootGraph>({ id: 'next-root' })
+    const nextWorkflow = fromPartial<ComfyWorkflow>({
+      path: 'next-workflow.json',
+      filename: 'next-workflow.json',
+      activeState: { id: 'next-root' }
+    })
+    workflowStore.attachWorkflow(nextWorkflow, 0)
+
+    await navigationStore.updateHash()
+    app.canvas.graph = nextGraph
+    await navigationStore.updateHash()
+    await nextTick()
+
+    expect(routerReplace).toHaveBeenCalledWith(
+      expect.objectContaining({ hash: '#current-root' })
+    )
+    expect(routerPush).toHaveBeenCalledWith(
+      expect.objectContaining({ hash: '#next-root' })
+    )
+    expect(mockOpenWorkflow).not.toHaveBeenCalled()
+  })
+
+  it('writes the latest graph after an earlier route write settles', async () => {
+    const navigationStore = useSubgraphNavigationStore()
+    const firstId = '11111111-1111-4111-8111-111111111111'
+    const secondId = '22222222-2222-4222-8222-222222222222'
+    const firstGraph = createMockSubgraph(firstId)
+    const secondGraph = createMockSubgraph(secondId)
+    let resolveFirstPush: (() => void) | undefined
+
+    app.rootGraph.subgraphs.set(firstId, firstGraph)
+    app.rootGraph.subgraphs.set(secondId, secondGraph)
+
+    routerPush
+      .mockImplementationOnce((target) => {
+        applyRouteTarget(target)
+        return new Promise<void>((resolve) => {
+          resolveFirstPush = resolve
+        })
+      })
+      .mockImplementationOnce(async (target) => {
+        applyRouteTarget(target)
+      })
+
+    await navigationStore.updateHash()
+    app.canvas.graph = firstGraph
+    const firstUpdate = navigationStore.updateHash()
+    await vi.waitFor(() => {
+      expect(routerPush).toHaveBeenCalledWith(
+        expect.objectContaining({ hash: '#' + firstId })
+      )
+    })
+
+    app.canvas.graph = secondGraph
+    const secondUpdate = navigationStore.updateHash()
+    expect(routerPush).toHaveBeenCalledTimes(1)
+
+    resolveFirstPush?.()
+    await Promise.all([firstUpdate, secondUpdate])
+
+    expect(
+      routerPush.mock.calls.map(([target]) => getRouteTargetHash(target))
+    ).toEqual(['#' + firstId, '#' + secondId])
+    expect(routeHash.value).toBe('#' + secondId)
+    expect(mockOpenWorkflow).not.toHaveBeenCalled()
+  })
+
+  it('handles an external route while an internal write is pending', async () => {
+    const navigationStore = useSubgraphNavigationStore()
+    const nextGraph = fromPartial<typeof app.rootGraph>({ id: 'next-root' })
+    const externalId = '33333333-3333-4333-8333-333333333333'
+    const externalGraph = createMockSubgraph(externalId)
+    let resolvePush: (() => void) | undefined
+
+    app.rootGraph.subgraphs.set(externalId, externalGraph)
+    routerPush.mockImplementation(() => {
+      return new Promise<void>((resolve) => {
+        resolvePush = resolve
+      })
+    })
+    vi.mocked(app.canvas.setGraph).mockImplementation((graph) => {
+      app.canvas.graph = graph
+    })
+
+    await navigationStore.updateHash()
+    app.canvas.graph = nextGraph
+    const internalUpdate = navigationStore.updateHash()
+    await vi.waitFor(() => {
+      expect(routerPush).toHaveBeenCalledWith(
+        expect.objectContaining({ hash: '#next-root' })
+      )
+    })
+
+    routerHistory.state = {}
+    routeHash.value = '#' + externalId
+
+    await vi.waitFor(() =>
+      expect(app.canvas.setGraph).toHaveBeenCalledWith(externalGraph)
+    )
+    resolvePush?.()
+    await internalUpdate
+  })
+
+  it('handles an external return to an internally written hash', async () => {
+    const navigationStore = useSubgraphNavigationStore()
+    const firstId = '11111111-1111-4111-8111-111111111111'
+    const secondId = '22222222-2222-4222-8222-222222222222'
+    const firstGraph = createMockSubgraph(firstId)
+    const secondGraph = createMockSubgraph(secondId)
+    let resolvePush: (() => void) | undefined
+
+    app.rootGraph.subgraphs.set(firstId, firstGraph)
+    app.rootGraph.subgraphs.set(secondId, secondGraph)
+    routerPush.mockImplementation(() => {
+      return new Promise<void>((resolve) => {
+        resolvePush = resolve
+      })
+    })
+    vi.mocked(app.canvas.setGraph).mockImplementation((graph) => {
+      app.canvas.graph = graph
+    })
+
+    await navigationStore.updateHash()
+    app.canvas.graph = firstGraph
+    const internalUpdate = navigationStore.updateHash()
+    await vi.waitFor(() => {
+      expect(routerPush).toHaveBeenCalledWith(
+        expect.objectContaining({ hash: '#' + firstId })
+      )
+    })
+
+    routerHistory.state = {}
+    routeHash.value = '#' + secondId
+    await vi.waitFor(() =>
+      expect(app.canvas.setGraph).toHaveBeenLastCalledWith(secondGraph)
+    )
+    routerHistory.state = {}
+    routeHash.value = '#' + firstId
+
+    await vi.waitFor(() =>
+      expect(app.canvas.setGraph).toHaveBeenLastCalledWith(firstGraph)
+    )
+    expect(app.canvas.graph).toBe(firstGraph)
+    expect(routeHash.value).toBe('#' + firstId)
+    resolvePush?.()
+    await internalUpdate
+  })
+
+  it('keeps a direct external hash that matches an older pending write', async () => {
+    const navigationStore = useSubgraphNavigationStore()
+    const firstId = '11111111-1111-4111-8111-111111111111'
+    const secondId = '22222222-2222-4222-8222-222222222222'
+    const firstGraph = createMockSubgraph(firstId)
+    const secondGraph = createMockSubgraph(secondId)
+    let resolvePush: (() => void) | undefined
+
+    app.rootGraph.subgraphs.set(firstId, firstGraph)
+    app.rootGraph.subgraphs.set(secondId, secondGraph)
+    routerPush.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolvePush = resolve
+        })
+    )
+    vi.mocked(app.canvas.setGraph).mockImplementation((graph) => {
+      app.canvas.graph = graph
+    })
+
+    await navigationStore.updateHash()
+    app.canvas.graph = firstGraph
+    const firstUpdate = navigationStore.updateHash()
+    await vi.waitFor(() =>
+      expect(routerPush).toHaveBeenCalledWith(
+        expect.objectContaining({ hash: '#' + firstId })
+      )
+    )
+
+    app.canvas.graph = secondGraph
+    const secondUpdate = navigationStore.updateHash()
+    routerHistory.state = {}
+    routeHash.value = '#' + firstId
+
+    await vi.waitFor(() => expect(app.canvas.graph).toBe(firstGraph))
+    resolvePush?.()
+    await Promise.all([firstUpdate, secondUpdate])
+
+    expect(routeHash.value).toBe('#' + firstId)
+    expect(routerPush).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/stores/subgraphNavigationStore.ts
+++ b/src/stores/subgraphNavigationStore.ts
@@ -9,7 +9,7 @@ import {
 } from 'vue-router'
 
 import type { DragAndScaleState } from '@/lib/litegraph/src/DragAndScale'
-import type { Subgraph } from '@/lib/litegraph/src/litegraph'
+import type { LGraph, Subgraph } from '@/lib/litegraph/src/litegraph'
 import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
 import { useWorkflowService } from '@/platform/workflow/core/services/workflowService'
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
@@ -211,13 +211,51 @@ export const useSubgraphNavigationStore = defineStore(
     // navigateToHash calls during router.replace().
     let blockNavDepth = 0
     let initialLoad = true
+    let hashUpdateTail: Promise<void> = Promise.resolve()
+    type GraphNavigationIntent = {
+      id: number
+      hash: string
+      source: 'graph' | 'route'
+    }
+    type NavigationIntent =
+      | GraphNavigationIntent
+      | { id: number; source: 'workflow' }
+    const routeWriteStateKey = 'comfySubgraphNavigationWrite'
+    const pendingRouteWrites = new Map<number, string>()
+    let deferredNavigationIntent: GraphNavigationIntent | undefined
+    let latestNavigationIntent: NavigationIntent | undefined
+    let navigationIntentId = 0
+    let routeWriteId = 0
+    let blockedRouteHash: string | undefined
+    let pendingWorkflowResetGraph: typeof app.rootGraph | undefined
 
-    async function withNavBlocked<T>(op: () => Promise<T>): Promise<T> {
+    const createNavigationIntent = (
+      hash: string,
+      source: GraphNavigationIntent['source']
+    ): GraphNavigationIntent => {
+      const intent = { id: ++navigationIntentId, hash, source }
+      latestNavigationIntent = intent
+      return intent
+    }
+
+    function beginWorkflowNavigation(): number {
+      const intent = { id: ++navigationIntentId, source: 'workflow' as const }
+      latestNavigationIntent = intent
+      return intent.id
+    }
+
+    async function withNavBlocked<T>(
+      op: () => Promise<T>,
+      routeHash: string
+    ): Promise<T> {
+      const previousBlockedRouteHash = blockedRouteHash
+      blockedRouteHash = routeHash
       blockNavDepth++
       try {
         return await op()
       } finally {
         blockNavDepth--
+        blockedRouteHash = previousBlockedRouteHash
       }
     }
 
@@ -228,27 +266,19 @@ export const useSubgraphNavigationStore = defineStore(
       if (canvas.graph?.id !== root.id) canvas.setGraph(root)
     }
 
-    async function redirectToRoot(reason: string) {
+    async function redirectToRoot(reason: string, navigationId: number) {
+      if (navigationId !== navigationIntentId) return
       const root = app.rootGraph
+      const rootHash = '#' + root.id
       console.warn(`[subgraphNavigation] ${reason}; redirecting to root graph`)
       try {
-        await withNavBlocked(() => router.replace('#' + root.id))
-      } catch (err) {
-        if (
-          !isNavigationFailure(err, NavigationFailureType.duplicated) &&
-          !isNavigationFailure(err, NavigationFailureType.cancelled)
-        ) {
-          console.warn(
-            '[subgraphNavigation] router.replace rejected during recovery',
-            err
-          )
-        }
+        await withNavBlocked(() => writeRouteHash(rootHash, true), rootHash)
       } finally {
-        ensureCanvasOnRoot()
+        if (navigationId === navigationIntentId) ensureCanvasOnRoot()
       }
     }
 
-    async function navigateToHash(newHash: string) {
+    async function navigateToHash(newHash: string, navigationId: number) {
       const root = app.rootGraph
       const locatorId = newHash?.slice(1) || root.id
       const canvas = canvasStore.getCanvas()
@@ -261,7 +291,9 @@ export const useSubgraphNavigationStore = defineStore(
           : undefined
       if (targetGraph) {
         if (canvas.graph?.id === targetGraph.id) return
-        return canvas.setGraph(targetGraph)
+        return withNavBlocked(async () => {
+          canvas.setGraph(targetGraph)
+        }, newHash)
       }
 
       //Search all open workflows
@@ -276,74 +308,208 @@ export const useSubgraphNavigationStore = defineStore(
           // intentionally re-read app.rootGraph below instead of using the
           // `root` captured at function entry.
           try {
-            await withNavBlocked(() =>
-              useWorkflowService().openWorkflow(workflow)
+            await withNavBlocked(
+              () =>
+                useWorkflowService().openWorkflow(workflow, {
+                  navigationIntentId: navigationId
+                }),
+              newHash
             )
           } catch (err) {
+            if (navigationId !== navigationIntentId) return
             console.warn(
               '[subgraphNavigation] openWorkflow rejected during recovery',
               err
             )
-            return redirectToRoot('workflow load failed')
+            return redirectToRoot('workflow load failed', navigationId)
           }
+          if (navigationId !== navigationIntentId) return
           const loadedGraph =
             app.rootGraph.id === locatorId
               ? app.rootGraph
               : app.rootGraph.subgraphs.get(locatorId)
           if (!loadedGraph) {
-            return redirectToRoot('subgraph not found after workflow load')
+            return redirectToRoot(
+              'subgraph not found after workflow load',
+              navigationId
+            )
           }
           if (canvas.graph?.id === loadedGraph.id) return
-          return canvas.setGraph(loadedGraph)
+          return withNavBlocked(async () => {
+            canvas.setGraph(loadedGraph)
+          }, newHash)
         }
       }
 
-      await redirectToRoot(`subgraph not found: ${locatorId}`)
+      await redirectToRoot(`subgraph not found: ${locatorId}`, navigationId)
     }
 
     async function safeRouterCall(op: () => Promise<unknown>, label: string) {
       try {
         await op()
       } catch (err) {
-        if (!isNavigationFailure(err, NavigationFailureType.duplicated)) {
+        if (
+          !isNavigationFailure(err, NavigationFailureType.duplicated) &&
+          !isNavigationFailure(err, NavigationFailureType.cancelled)
+        ) {
           console.warn(`[subgraphNavigation] ${label} rejected`, err)
         }
       }
     }
 
-    async function updateHash() {
-      if (blockNavDepth > 0) return
-      if (initialLoad) {
-        initialLoad = false
-        if (!routeHash.value) return
-        await navigateToHash(routeHash.value)
-        const graph = canvasStore.getCanvas().graph
-        if (isSubgraph(graph)) workflowStore.activeSubgraph = graph
-        return
+    async function writeRouteHash(hash: string, replace: boolean) {
+      const writeId = ++routeWriteId
+      pendingRouteWrites.set(writeId, hash)
+      const target = {
+        hash,
+        state: { [routeWriteStateKey]: writeId }
       }
-
-      const newId = canvasStore.getCanvas().graph?.id ?? ''
-      if (!routeHash.value) {
+      try {
         await safeRouterCall(
-          () => router.replace('#' + app.rootGraph.id),
-          'router.replace'
+          () => (replace ? router.replace(target) : router.push(target)),
+          replace ? 'router.replace' : 'router.push'
         )
+      } finally {
+        pendingRouteWrites.delete(writeId)
+      }
+    }
+
+    async function syncGraphHash(intent: GraphNavigationIntent) {
+      if (intent.id !== navigationIntentId) return
+      if (!routeHash.value) {
+        const rootHash = '#' + app.rootGraph.id
+        await writeRouteHash(rootHash, true)
+        if (intent.id !== navigationIntentId) return
       }
       const currentId = routeHash.value?.slice(1)
-      if (!newId || newId === currentId) return
+      if (intent.hash.slice(1) === currentId) return
 
-      await safeRouterCall(() => router.push('#' + newId), 'router.push')
+      await writeRouteHash(intent.hash, false)
     }
-    watch(() => canvasStore.currentGraph, updateHash)
-    watch(routeHash, () => {
+
+    function queueGraphHash(intent: GraphNavigationIntent): Promise<void> {
+      const result = hashUpdateTail.then(() => syncGraphHash(intent))
+      hashUpdateTail = result.catch(() => undefined)
+      return result
+    }
+
+    async function applyNavigationIntent(intent: GraphNavigationIntent) {
+      await navigateToHash(intent.hash, intent.id)
       if (blockNavDepth > 0) return
-      void navigateToHash(String(routeHash.value))
-    })
+
+      const deferredIntent = deferredNavigationIntent
+      if (deferredIntent?.id === navigationIntentId) {
+        deferredNavigationIntent = undefined
+        return applyNavigationIntent(deferredIntent)
+      }
+
+      if (intent.source === 'graph' && intent.id === navigationIntentId) {
+        await queueGraphHash(intent)
+      }
+    }
+
+    function updateHash(
+      source: 'graph' | 'workflow-load' = 'graph',
+      workflowNavigationId?: number,
+      currentGraph?: LGraph | null
+    ): Promise<void> {
+      const graph = currentGraph ?? canvasStore.getCanvas().graph
+      if (source === 'workflow-load') {
+        pendingWorkflowResetGraph = undefined
+        if (
+          blockNavDepth > 0 &&
+          workflowNavigationId === navigationIntentId &&
+          latestNavigationIntent?.source === 'workflow' &&
+          graph?.id
+        ) {
+          deferredNavigationIntent = {
+            id: workflowNavigationId,
+            hash: '#' + graph.id,
+            source: 'graph'
+          }
+          return Promise.resolve()
+        }
+        if (blockNavDepth > 0) return Promise.resolve()
+        if (workflowNavigationId !== undefined) {
+          if (workflowNavigationId !== navigationIntentId) {
+            const latestIntent = latestNavigationIntent
+            return latestIntent && latestIntent.source !== 'workflow'
+              ? applyNavigationIntent(latestIntent)
+              : Promise.resolve()
+          }
+        }
+      }
+      if (graph === pendingWorkflowResetGraph) {
+        pendingWorkflowResetGraph = undefined
+        return Promise.resolve()
+      }
+
+      const newId = graph?.id ?? ''
+      if (initialLoad) {
+        initialLoad = false
+        if (!routeHash.value) return Promise.resolve()
+        return applyNavigationIntent(
+          createNavigationIntent(String(routeHash.value), 'route')
+        ).then(() => {
+          const activeGraph = canvasStore.getCanvas().graph
+          if (isSubgraph(activeGraph)) {
+            workflowStore.activeSubgraph = activeGraph
+          }
+        })
+      }
+
+      if (!newId) return Promise.resolve()
+      const newHash = '#' + newId
+      if (newHash === routeHash.value) return Promise.resolve()
+      if (blockNavDepth > 0 && newHash === blockedRouteHash) {
+        return Promise.resolve()
+      }
+
+      const intent = createNavigationIntent(newHash, 'graph')
+      if (blockNavDepth > 0) {
+        deferredNavigationIntent = intent
+        return Promise.resolve()
+      }
+
+      return queueGraphHash(intent)
+    }
+    watch(
+      () => canvasStore.currentGraph,
+      (graph) => void updateHash('graph', undefined, graph),
+      { flush: 'sync' }
+    )
+    watch(
+      routeHash,
+      (newHash) => {
+        initialLoad = false
+        const hash = String(newHash)
+        const stateWriteId = router.options.history.state[routeWriteStateKey]
+        if (
+          typeof stateWriteId === 'number' &&
+          pendingRouteWrites.get(stateWriteId) === hash
+        ) {
+          pendingRouteWrites.delete(stateWriteId)
+          return
+        }
+        const intent = createNavigationIntent(hash, 'route')
+        if (blockNavDepth > 0) {
+          deferredNavigationIntent = intent
+          return
+        }
+        void applyNavigationIntent(intent)
+      },
+      { flush: 'sync' }
+    )
 
     /** Save the current viewport for the active graph/workflow. Called by
      *  workflowService.beforeLoadNewGraph() before the canvas is overwritten. */
-    function saveCurrentViewport(): void {
+    function saveCurrentViewport(suppressWorkflowReset = true): void {
       saveViewport(getActiveGraphId())
+      const graph = canvasStore.getCanvas().graph
+      pendingWorkflowResetGraph =
+        suppressWorkflowReset && graph !== app.rootGraph
+          ? app.rootGraph
+          : undefined
       isWorkflowSwitching = true
       setTimeout(() => {
         isWorkflowSwitching = false
@@ -358,6 +524,7 @@ export const useSubgraphNavigationStore = defineStore(
       saveViewport,
       restoreViewport,
       saveCurrentViewport,
+      beginWorkflowNavigation,
       updateHash,
       /** @internal Exposed for test assertions only. */
       viewportCache

--- a/src/stores/subgraphStore.test.ts
+++ b/src/stores/subgraphStore.test.ts
@@ -49,6 +49,11 @@ vi.mock('@/renderer/core/canvas/canvasStore', () => ({
     getCanvas: () => comfyApp.canvas
   }))
 }))
+vi.mock('@/stores/subgraphNavigationStore', () => ({
+  useSubgraphNavigationStore: () => ({
+    beginWorkflowNavigation: () => 1
+  })
+}))
 
 // Mock comfyApp globally for the store setup
 vi.mock('@/scripts/app', () => ({


### PR DESCRIPTION
Second slice of the Agent V1 landing chain ([Plan J](https://app.notion.com/p/3c86d73d3650818f8230c9e2848da470)); the FE-1769 test-led split. Lands after the shell PR #16071.

- Fixes FE-1769

**Problem:** overlapping workflow opens, closes, and subgraph hash navigations interleave - a slower earlier load can overwrite a newer selection, closing a workflow can re-activate it, and a stale hash navigation can move the canvas after a newer one.

**Change (non-agent hunks only, extracted from the feature branch):**
- `workflowService.ts`: workflow loads run through a serialized queue with per-path pending tracking; close is re-entrant-safe, skips closing workflows when choosing a replacement, and falls back to the default workflow on the last close.
- `subgraphNavigationStore.ts`: hash/graph sync carries navigation intent ids; only the newest intent may write the route or move the canvas; failed navigations recover to the root graph.
- `app.ts`: `loadGraphData` threads the workflow navigation id into the hash update.
- `linearModeToAppMode()` is untouched (regression-pinned only).

**Test-led receipt:** the added `workflowService.test.ts` and `subgraphNavigationStore.test.ts` suites pin the contract; run against the previous implementation, 13 of them fail (races reproduced); with this change 137/137 pass across the four touched suites. Acceptance criteria live on FE-1769 (Gherkin, refined 2026-08-26).

**Boundary note:** the feature branch's new `beforeLoadGraph`/`afterLoadGraph` extension hooks are NOT taken - extension-API surface stays with its consumer on the agent chain.

Verification: `pnpm typecheck` clean, `pnpm lint` 0 errors, `pnpm knip` clean, 137/137 tests on the touched suites.