### PR TITLE
refactor(widgets): make bbox field controls projections of the parent Bounds

### DIFF
--- a/src/renderer/extensions/vueNodes/widgets/composables/useBoundingBoxWidget.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useBoundingBoxWidget.test.ts
@@ -1,0 +1,126 @@
+import { fromPartial } from '@total-typescript/shoehorn'
+import { describe, expect, it } from 'vitest'
+
+import { LGraphNode } from '@/lib/litegraph/src/litegraph'
+import type { NumberWidget } from '@/lib/litegraph/src/widgets/NumberWidget'
+import type { Bounds } from '@/renderer/core/layout/types'
+import { useWidgetValueStore } from '@/stores/widgetValueStore'
+import { toNodeId } from '@/types/nodeId'
+import { widgetId } from '@/types/widgetId'
+
+import { useBoundingBoxWidget } from './useBoundingBoxWidget'
+
+const GRAPH_ID = 'bbox-widget-test'
+
+let nodeCounter = 0
+
+function makeNode(): LGraphNode {
+  nodeCounter += 1
+  const node = new LGraphNode('TestNode')
+  node.id = toNodeId(nodeCounter)
+  node.graph = fromPartial({
+    rootGraph: { id: GRAPH_ID },
+    incrementVersion: () => {}
+  })
+  return node
+}
+
+function construct(node: LGraphNode, component?: string) {
+  const widget = useBoundingBoxWidget()(
+    node,
+    fromPartial({ name: 'bounds', type: 'BOUNDINGBOX', component })
+  )
+  return { widget, fields: widget.linkedWidgets as NumberWidget[] }
+}
+
+const parentId = (node: LGraphNode) => widgetId(GRAPH_ID, node.id, 'bounds')
+
+const storeBounds = (node: LGraphNode) =>
+  useWidgetValueStore().getWidget(parentId(node))?.value
+
+describe('useBoundingBoxWidget', () => {
+  it('creates the composite widget with four linked field controls', () => {
+    const node = makeNode()
+    const { widget, fields } = construct(node)
+
+    expect(widget.type).toBe('boundingbox')
+    expect(fields.map((w) => w.name)).toEqual(['x', 'y', 'width', 'height'])
+  })
+
+  it('creates an imagecrop widget for the ImageCrop component', () => {
+    const { widget } = construct(makeNode(), 'ImageCrop')
+    expect(widget.type).toBe('imagecrop')
+  })
+
+  it('registers only the parent bounds value in the store', () => {
+    const node = makeNode()
+    construct(node)
+
+    expect(storeBounds(node)).toEqual({ x: 0, y: 0, width: 512, height: 512 })
+    const store = useWidgetValueStore()
+    for (const field of ['x', 'y', 'width', 'height']) {
+      expect(
+        store.getWidget(widgetId(GRAPH_ID, node.id, field))
+      ).toBeUndefined()
+    }
+  })
+
+  it('reads field values through the parent bounds', () => {
+    const node = makeNode()
+    const { fields } = construct(node)
+
+    useWidgetValueStore().setValue(parentId(node), {
+      x: 10,
+      y: 20,
+      width: 30,
+      height: 40
+    })
+
+    expect(fields.map((w) => w.value)).toEqual([10, 20, 30, 40])
+  })
+
+  it('writes a field edit as one rounded atomic bounds replacement', () => {
+    const node = makeNode()
+    const { fields } = construct(node)
+    const before = storeBounds(node)
+
+    fields[0].value = 3.7
+
+    expect(storeBounds(node)).toEqual({ x: 4, y: 0, width: 512, height: 512 })
+    expect(storeBounds(node)).not.toBe(before)
+  })
+
+  it('clamps edits made through the numeric widget setValue path', () => {
+    const node = makeNode()
+    const { fields } = construct(node)
+
+    fields[2].setValue(
+      999999,
+      fromPartial({ node, canvas: { graph_mouse: [0, 0] } })
+    )
+
+    expect(storeBounds(node)).toMatchObject({ width: 8192 })
+  })
+
+  it('falls back to spec defaults when the stored bounds are malformed', () => {
+    const node = makeNode()
+    const { fields } = construct(node)
+
+    useWidgetValueStore().setValue(parentId(node), 'legacy-garbage')
+    expect(fields.map((w) => w.value)).toEqual([0, 0, 512, 512])
+
+    fields[0].value = 5
+    expect(storeBounds(node)).toEqual({ x: 5, y: 0, width: 512, height: 512 })
+  })
+
+  it('routes field edits to the parent while the node is detached from a graph', () => {
+    nodeCounter += 1
+    const node = new LGraphNode('TestNode')
+    node.id = toNodeId(nodeCounter)
+    const { widget, fields } = construct(node)
+
+    fields[1].value = 12
+
+    expect((widget.value as Bounds).y).toBe(12)
+  })
+})

--- a/src/renderer/extensions/vueNodes/widgets/composables/useBoundingBoxWidget.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useBoundingBoxWidget.ts
@@ -5,6 +5,7 @@ import type {
   IImageCropWidget,
   INumericWidget
 } from '@/lib/litegraph/src/types/widgets'
+import { NumberWidget } from '@/lib/litegraph/src/widgets/NumberWidget'
 import type { Bounds } from '@/renderer/core/layout/types'
 import type {
   BoundingBoxInputSpec,
@@ -18,8 +19,16 @@ function isBoundingBoxLikeWidget(
   return widget.type === 'boundingbox' || widget.type === 'imagecrop'
 }
 
-function isNumericWidget(widget: IBaseWidget): widget is INumericWidget {
-  return widget.type === 'number'
+const FIELDS: (keyof Bounds)[] = ['x', 'y', 'width', 'height']
+
+function isBounds(value: unknown): value is Bounds {
+  return (
+    !!value &&
+    typeof value === 'object' &&
+    FIELDS.every(
+      (field) => typeof (value as Record<string, unknown>)[field] === 'number'
+    )
+  )
 }
 
 export const useBoundingBoxWidget = (): ComfyWidgetConstructorV2 => {
@@ -38,22 +47,11 @@ export const useBoundingBoxWidget = (): ComfyWidgetConstructorV2 => {
 
     const widgetType = component === 'ImageCrop' ? 'imagecrop' : 'boundingbox'
 
-    const fields: (keyof Bounds)[] = ['x', 'y', 'width', 'height']
-    const subWidgets: INumericWidget[] = []
-
     const rawWidget = node.addWidget(
       widgetType,
       name,
       { ...defaultValue },
-      () => {
-        for (let i = 0; i < fields.length; i++) {
-          const field = fields[i]
-          const subWidget = subWidgets[i]
-          if (subWidget) {
-            subWidget.value = widget.value[field]
-          }
-        }
-      },
+      () => {},
       {
         serialize: true,
         canvasOnly: false
@@ -66,33 +64,45 @@ export const useBoundingBoxWidget = (): ComfyWidgetConstructorV2 => {
 
     const widget = rawWidget
 
-    for (const field of fields) {
-      const subWidget = node.addWidget(
-        'number',
-        field,
-        defaultValue[field],
-        function (this: INumericWidget, v: number) {
-          this.value = Math.round(v)
-          widget.value[field] = this.value
-          widget.callback?.(widget.value)
-        },
+    const currentBounds = (): Bounds =>
+      isBounds(widget.value) ? widget.value : defaultValue
+
+    const createFieldProjection = (field: keyof Bounds): NumberWidget => {
+      const subWidget = new NumberWidget(
         {
-          min: field === 'width' || field === 'height' ? 1 : 0,
-          max: 8192,
-          step: 10,
-          step2: 1,
-          precision: 0,
-          serialize: false,
-          canvasOnly: true
-        }
+          type: 'number',
+          name: field,
+          value: defaultValue[field],
+          options: {
+            min: field === 'width' || field === 'height' ? 1 : 0,
+            max: 8192,
+            step: 10,
+            step2: 1,
+            precision: 0,
+            serialize: false,
+            canvasOnly: true
+          },
+          y: 0
+        },
+        node
       )
+      Object.defineProperty(subWidget, 'value', {
+        get: () => currentBounds()[field],
+        set: (v: number) => {
+          widget.value = { ...currentBounds(), [field]: Math.round(v) }
+        }
+      })
+      subWidget.setNodeId = () => {}
+      return subWidget
+    }
 
-      if (!isNumericWidget(subWidget)) {
-        throw new Error(`Unexpected widget type: ${subWidget.type}`)
-      }
-
+    const subWidgets: INumericWidget[] = []
+    for (const field of FIELDS) {
+      const subWidget = createFieldProjection(field)
+      node.addCustomWidget(subWidget)
       subWidgets.push(subWidget)
     }
+    node.expandToFitContent()
 
     widget.linkedWidgets = subWidgets
 


### PR DESCRIPTION
ECS followup for ImageCrop (BBox)

## Summary
The boundingbox/imagecrop composite stored one value as five authorities: the parent Bounds widget plus four numeric field widgets, reconciled by callbacks copying values in both directions. The field callbacks also mutated the store-owned Bounds object in place (widget.value[field] = v), bypassing the widget value store entirely.

Keep only the parent Bounds as the authoritative value. Each canvas field control is now an accessor projection over it: the getter reads bounds[field], the setter atomically replaces the parent object with the rounded field applied, the same shape WidgetBoundingBox.vue already uses on the Vue side. 

The field controls carry no independent state, so they no longer register their own widget values in the store (no-op setNodeId); they are constructed directly and attached via addCustomWidget so the projection is in place before the node binds them.

This removes the bidirectional copy callbacks, the in-place mutation, and the four extra store registrations, and keeps edits from either renderer visible to the other through the single store-backed value.