### PR TITLE
[backport cloud/1.52] fix(billing): gate subscribe-to-run only on Cloud

### DIFF
--- a/src/composables/useCoreCommands.test.ts
+++ b/src/composables/useCoreCommands.test.ts
@@ -55,6 +55,7 @@ vi.mock('@/scripts/app', () => {
         }
       }),
       openClipspace: vi.fn(),
+      queuePrompt: vi.fn().mockResolvedValue(true),
       refreshComboInNodes: vi.fn().mockResolvedValue(undefined),
       canvas: mockCanvas,
       rootGraph: {
@@ -130,7 +131,9 @@ vi.mock('@/services/litegraphService', () => ({
 const mockTrackHelpResourceClicked = vi.hoisted(() => vi.fn())
 vi.mock('@/platform/telemetry', () => ({
   useTelemetry: vi.fn(() => ({
-    trackHelpResourceClicked: mockTrackHelpResourceClicked
+    trackHelpResourceClicked: mockTrackHelpResourceClicked,
+    trackRunButton: vi.fn(),
+    trackWorkflowExecution: vi.fn()
   }))
 }))
 
@@ -205,11 +208,23 @@ vi.mock('@/platform/cloud/subscription/composables/useSubscription', () => ({
   }))
 }))
 
+const mockBillingState = vi.hoisted(() => ({
+  canAccessSubscriptionFeatures: true,
+  showSubscriptionDialog: vi.fn()
+}))
 vi.mock('@/composables/billing/useBillingContext', () => ({
   useBillingContext: vi.fn(() => ({
-    canAccessSubscriptionFeatures: { value: true },
-    showSubscriptionDialog: vi.fn()
+    canAccessSubscriptionFeatures: {
+      get value() {
+        return mockBillingState.canAccessSubscriptionFeatures
+      }
+    },
+    showSubscriptionDialog: mockBillingState.showSubscriptionDialog
   }))
+}))
+
+vi.mock('@/stores/queueSettingsStore', () => ({
+  useQueueSettingsStore: vi.fn(() => ({ batchCount: 1 }))
 }))
 
 describe('useCoreCommands', () => {
@@ -302,6 +317,7 @@ describe('useCoreCommands', () => {
 
   beforeEach(() => {
     mockDistributionState.isCloud = false
+    mockBillingState.canAccessSubscriptionFeatures = true
     vi.mocked(app.refreshComboInNodes).mockResolvedValue(undefined)
     mockModelStoreRefresh.mockResolvedValue(undefined)
     mockMissingModelStoreRefresh.mockResolvedValue(undefined)
@@ -659,6 +675,64 @@ describe('useCoreCommands', () => {
       expect(app.refreshComboInNodes).toHaveBeenCalled()
       expect(mockModelStoreRefresh).toHaveBeenCalled()
       expect(mockMissingModelStoreRefresh).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('Queue commands subscription gate', () => {
+    const findCmd = (id: string) =>
+      useCoreCommands().find((cmd) => cmd.id === id)!
+
+    it.for([
+      ['Comfy.QueuePrompt', 0],
+      ['Comfy.QueuePromptFront', -1]
+    ] as const)(
+      '%s queues on Local without subscription features',
+      async ([id, num]) => {
+        mockBillingState.canAccessSubscriptionFeatures = false
+
+        await findCmd(id).function()
+
+        expect(app.queuePrompt).toHaveBeenCalledWith(num, 1, expect.anything())
+        expect(mockBillingState.showSubscriptionDialog).not.toHaveBeenCalled()
+      }
+    )
+
+    it('Comfy.QueueSelectedOutputNodes passes the gate on Local without subscription features', async () => {
+      mockBillingState.canAccessSubscriptionFeatures = false
+
+      await findCmd('Comfy.QueueSelectedOutputNodes').function()
+
+      expect(mockBillingState.showSubscriptionDialog).not.toHaveBeenCalled()
+      expect(mockToastAdd).toHaveBeenCalledWith(
+        expect.objectContaining({ severity: 'error' })
+      )
+    })
+
+    it.for([
+      'Comfy.QueuePrompt',
+      'Comfy.QueuePromptFront',
+      'Comfy.QueueSelectedOutputNodes'
+    ] as const)(
+      '%s shows the subscription dialog on Cloud without an active subscription',
+      async (id) => {
+        mockDistributionState.isCloud = true
+        mockBillingState.canAccessSubscriptionFeatures = false
+
+        await findCmd(id).function()
+
+        expect(app.queuePrompt).not.toHaveBeenCalled()
+        expect(mockBillingState.showSubscriptionDialog).toHaveBeenCalledWith({
+          reason: 'subscribe_to_run'
+        })
+      }
+    )
+
+    it('Comfy.QueuePrompt queues on Cloud with an active subscription', async () => {
+      mockDistributionState.isCloud = true
+
+      await findCmd('Comfy.QueuePrompt').function()
+
+      expect(app.queuePrompt).toHaveBeenCalledWith(0, 1, expect.anything())
     })
   })
 

--- a/src/composables/useCoreCommands.ts
+++ b/src/composables/useCoreCommands.ts
@@ -506,7 +506,7 @@ export function useCoreCommands(): ComfyCommand[] {
         trigger_source?: ExecutionTriggerSource
       }) => {
         trackRunButton(metadata)
-        if (!canAccessSubscriptionFeatures.value) {
+        if (isCloud && !canAccessSubscriptionFeatures.value) {
           showSubscriptionDialog({ reason: 'subscribe_to_run' })
           return
         }
@@ -529,7 +529,7 @@ export function useCoreCommands(): ComfyCommand[] {
         trigger_source?: ExecutionTriggerSource
       }) => {
         trackRunButton(metadata)
-        if (!canAccessSubscriptionFeatures.value) {
+        if (isCloud && !canAccessSubscriptionFeatures.value) {
           showSubscriptionDialog({ reason: 'subscribe_to_run' })
           return
         }
@@ -551,7 +551,7 @@ export function useCoreCommands(): ComfyCommand[] {
         trigger_source?: ExecutionTriggerSource
       }) => {
         trackRunButton(metadata)
-        if (!canAccessSubscriptionFeatures.value) {
+        if (isCloud && !canAccessSubscriptionFeatures.value) {
           showSubscriptionDialog({ reason: 'subscribe_to_run' })
           return
         }


### PR DESCRIPTION
Backport of #16032 to `cloud/1.52`. Manual — the automated backport silently lost this target (see below).

## Why this is needed

On Local, clicking **Run** silently does nothing when the active workspace has no active subscription (0 credits) — any workflow, any login method. That bug is still live on `cloud/1.52`, and it shipped in the `1.52.6` cut (#15976).

It is also **blocking #16059**, the backport of the regression test for this exact bug. That PR's only CI failure is the test it adds:

```
browser_tests/tests/workspace/localWorkspaceSwitcher.spec.ts:99
› Run button queues while the workspace has no active subscription @auth
Error: page.waitForRequest: Test timeout of 60000ms exceeded.
```

Initial run plus all 3 retries — deterministic, not flake. The test is correct; the fix underneath it is missing.

## Root cause

`Comfy.QueuePrompt` / `Comfy.QueuePromptFront` / `Comfy.QueueSelectedOutputNodes` in `useCoreCommands.ts` return early when `canAccessSubscriptionFeatures` is false, with no distribution check. On Cloud that gate is intended; on Local it swallows the run.

| branch | `useCoreCommands.ts:509` |
| --- | --- |
| `main`, `core/1.51`, `core/1.52` | `if (isCloud && !canAccessSubscriptionFeatures.value)` |
| `cloud/1.52` (before this PR) | `if (!canAccessSubscriptionFeatures.value)` |

With no `isCloud` guard, the Run click opens the subscription dialog and returns before ever issuing `POST /api/prompt`.

## Why the automated backport didn't produce this

#16032 carries the `cloud/1.52` label, but only #16039 (`core/1.51`) and #16040 (`core/1.52`) were ever opened. The re-run at 02:45 UTC ([run 33034284539](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/33034284539)) shows why:

```
Found backport targets: core/1.51 core/1.52 cloud/1.52
...
##[group]Backporting to cloud/1.52
[backport-16032-to-cloud-1.52 f2f6c513ae] fix(billing): gate subscribe-to-run only on Cloud (#16032)
 2 files changed, 80 insertions(+), 6 deletions(-)
 * [new branch] backport-16032-to-cloud-1.52 -> backport-16032-to-cloud-1.52
Successfully created backport branch
##[error]Process completed with exit code 1.
```

The `cloud/1.52` cherry-pick **succeeded and was pushed**. But `core/1.51` and `core/1.52` conflicted (the commit is already on both), so `FAILED` was non-empty and the step exited 1. That skipped `Create backport PRs` (gated on `steps.backport.outputs.success`), and then `Cleanup stranded backport branches` deleted the branch that had just succeeded.

Net effect: in `pr-backport.yaml`, one failing target discards every succeeding target. Re-adding the label will keep reproducing this as long as any already-applied target is in the list. Worth splitting success/failure per target so partial progress survives — happy to open that separately.

## Changes

Cherry-pick of `4a67eb43149bf633d522bd9b5311b6f6f28a6a76`, clean, no conflicts:

- `src/composables/useCoreCommands.ts` — scope the subscribe-to-run gate to Cloud in all three queue commands (3 lines)
- `src/composables/useCoreCommands.test.ts` — unit coverage for the Local-queues / Cloud-gates split

No behavior change on Cloud.

## Verification

- Cherry-pick applies cleanly onto `cloud/1.52`; the three gates now read `isCloud && !canAccessSubscriptionFeatures.value`.
- Unit coverage rides along in the same commit.
- E2E proof is #16059 itself: it is red on `cloud/1.52` today and should go green once this merges. **Merge this first, then re-run #16059.**

## Regression / E2E coverage

Covered. Unit: `useCoreCommands.test.ts` (in this commit). E2E: `localWorkspaceSwitcher.spec.ts` via #16059, which is the dedicated regression test for this bug driven through the real Run button.
