### PR TITLE
fix(types): drop duplicate CurrentWorkspaceResponse from ingest types

### DIFF
--- a/packages/ingest-types/src/index.ts
+++ b/packages/ingest-types/src/index.ts
@@ -234,7 +234,6 @@ export type {
   CreateWorkspaceInviteResponses,
   CreateWorkspaceRequest,
   CreateWorkspaceResponse,
-  CurrentWorkspaceResponse,
   CreateWorkspaceResponses,
   CredentialOption,
   CurrentWorkspaceResponse,

--- a/packages/ingest-types/src/types.gen.ts
+++ b/packages/ingest-types/src/types.gen.ts
@@ -3277,20 +3277,6 @@ export type CurrentWorkspaceResponse = {
 /**
  * Request body for creating a new workspace.
  */
-export type CurrentWorkspaceResponse = {
-  /**
-   * How this request authenticated. Known values are firebase, cookie, comfy_api_key, comfy_admin_key, cloud_api_key and cloud_jwt; treat it as an open string so a new auth method is not a breaking change.
-   */
-  auth_method: string
-  id: string
-  name: string
-  /**
-   * The requesting user's role in this workspace. Omitted (absent from the object, never an explicit null) when the credential carries no resolvable user membership.
-   */
-  role?: 'owner' | 'member'
-  type: 'personal' | 'team'
-}
-
 export type CreateWorkspaceRequest = {
   /**
    * Display name for the workspace


### PR DESCRIPTION
`cloud/1.52` does not typecheck. Every PR opened against it is red on a diff it does not own.

```
packages/ingest-types/src/index.ts(237,3):       error TS2300: Duplicate identifier 'CurrentWorkspaceResponse'.
packages/ingest-types/src/index.ts(240,3):       error TS2300: Duplicate identifier 'CurrentWorkspaceResponse'.
packages/ingest-types/src/types.gen.ts(3263,13): error TS2300: Duplicate identifier 'CurrentWorkspaceResponse'.
packages/ingest-types/src/types.gen.ts(3280,13): error TS2300: Duplicate identifier 'CurrentWorkspaceResponse'.
```

Confirmed blocked: #16080 and #16084 are both red solely on this.

## Root cause

A semantic conflict between two backports — clean for git, broken for TypeScript.

| commit | PR | merged (UTC) | `CurrentWorkspaceResponse` declarations after |
| --- | --- | --- | --- |
| `c143e62b5` | #15953 — establish workspace context for API-key sessions | 8/26 04:43 | 1 |
| `d9e00f921` | #15939 — ENTERPRISE tier + `ingest-types` regeneration | 8/26 23:36 | **2** |

#15953 introduced the type. #15939 regenerated the package from the cloud OpenAPI spec and added it again. Neither touched the same lines, so git reported no conflict and the duplicate landed silently.

CI did not catch it because **#15939's checks last ran 8/25 23:33 — roughly 24 hours before it merged, and before #15953 was on the branch.** It was green against a merge ref that no longer described reality.

The second block also swallowed the JSDoc belonging to `CreateWorkspaceRequest`, leaving that type undocumented:

```ts
/**
 * Request body for creating a new workspace.
 */
export type CurrentWorkspaceResponse = {   // <- stray
```

In `index.ts` the stray re-export is visible as a break in the otherwise alphabetical list (`CreateWorkspaceResponse, CurrentWorkspaceResponse, CreateWorkspaceResponses`).

## Changes

Pure deletion, 15 lines, no additions:

- `types.gen.ts` — remove the duplicated `CurrentWorkspaceResponse` block; the `Request body for creating a new workspace.` JSDoc returns to `CreateWorkspaceRequest`
- `index.ts` — remove the duplicated re-export

Both files are generated, so the target was not a judgement call: **both edited regions are now byte-identical to `main`**, which carries exactly one declaration. This restores the generator's real output rather than hand-authoring it. Re-running `pnpm --filter @comfyorg/ingest-types generate` against the spec is the alternative and should produce the same result — happy to swap to that if the team prefers a regeneration commit, though it would pull in unrelated spec drift on a release branch.

## Verification

`tsc` on the package, before and after:

```
### BASE (cloud/1.52)          exit=2   TS2300 x4   <- reproduces the CI failure exactly
### THIS PR                    exit=0   TS2300 x0   total errors 0
```

Also verified `CurrentWorkspaceResponse` is the only duplicated identifier in either file, so this is the whole breakage and not the first of several.

## Follow-ups (not in this PR)

1. **The stale-merge-base gap.** A PR merging on day-old checks is how this shipped. Requiring branches be up to date before merge on `cloud/*`, or re-running checks on merge, would close it.
2. **`pr-backport.yaml` discards partial success.** Separately, one failing target aborts the whole step, so succeeding targets never get a PR and their pushed branches are deleted in cleanup. That is why #16032 never reached `cloud/1.52` and why #16084 had to be made by hand.

## Merge order

This → #16084 (backport of #16032, *Run silently does nothing on Local at 0 credits*) → #16059 (its E2E regression test).
