### PR TITLE
fix(website): restore card art for the Local MCP past event

### DIFF
--- a/apps/website/src/data/events.ts
+++ b/apps/website/src/data/events.ts
@@ -335,7 +335,11 @@ const events: readonly ComfyEvent[] = [
       'zh-CN': '2026年8月26日 · 上午10点（PT）'
     },
     startDateTime: '2026-08-26T10:00:00-07:00',
-    liveVideoId: '6yH_15XSd0w'
+    liveVideoId: '6yH_15XSd0w',
+    media: eventImage('august-26-2026-local-mcp.jpg', {
+      en: 'Local MCP: Run ComfyUI with Your Agent & Hardware livestream',
+      'zh-CN': '本地 MCP：用你的智能体与硬件运行 ComfyUI 直播'
+    })
   },
   {
     id: 'beyond-the-models',


### PR DESCRIPTION
`website-e2e` has been failing on `cloud/1.52` since 2026-08-26 18:00 UTC. Two tests in `apps/website/e2e/events.spec.ts`:

```
past events gallery renders one card per event with WATCH NOW links  [desktop]
past event cards stack in a single column at mobile width            [mobile]

Expected: 11
Received: 10
```

## Root cause

`PastEventsSection.vue` drops any past event that has no artwork — a card cannot render without media:

```ts
const media = event.media ?? event.featured?.media
if (!media) return []
```

The spec asserts against the unfiltered list instead: `expect(cards).toHaveCount(pastEvents.length)`. The two agree only while every past event has media.

The `local-mcp` livestream ended `2026-08-26T18:00:00Z` and carries no `media` on this branch, so from that moment the page rendered 10 cards against 11 past events. `main` already has the entry; `cloud/1.52` does not.

## Why it surfaced only now

`website-e2e` is path-filtered. The cloud PRs that merged after 18:00 UTC (#16084, #16059) touch neither `apps/website` nor `packages/**`, so the job was `SKIPPED` on both. #16085 touches `packages/ingest-types`, which is inside the filter — it is the first PR since 18:00 UTC to actually run the job, so it inherited the red.

## Changes

Adds the `media` entry `main` already carries, verbatim. `eventImage` resolves to `https://media.comfy.org/website/events/…`, so no asset is added to the repo.

## Verification

Replaying the component's own derivation (past events, then media filter) at the failing run's timestamp:

```
cloud/1.52 (base)      test expects 11 | page renders 10 | FAIL   <- reproduces CI exactly
this fix               test expects 11 | page renders 11 | PASS
main (reference)       test expects 11 | page renders 11 | PASS
```

## Follow-up for `main` (not this PR)

The spec is load-bearing on content: any livestream that ends before its card art is added breaks CI, which is precisely the case `PastEventsSection.vue` comments about ("events that became past before dedicated card art was added"). Asserting against the media-bearing subset the component actually renders would remove the whole class of failure. That belongs on `main` and should flow down rather than be invented on a release branch.

## Related

`cloud/1.52` is also failing typecheck on a duplicate identifier in the generated ingest types — separate breakage, fixed in #16085. This PR and that one are independent; both target `cloud/1.52`.
