### PR TITLE
[backport cloud/1.52] fix(billing): let unsubscribed workspaces add credits on Local

### DIFF
--- a/browser_tests/fixtures/workspaceRailAuthFixture.ts
+++ b/browser_tests/fixtures/workspaceRailAuthFixture.ts
@@ -1,0 +1,77 @@
+import { test as base } from '@playwright/test'
+
+import type { operations } from '@/types/comfyRegistryTypes'
+import { ComfyPage } from '@e2e/fixtures/ComfyPage'
+import {
+  createSubscriptionHelper,
+  withUnsubscribed
+} from '@e2e/fixtures/helpers/SubscriptionHelper'
+import type { SubscriptionOperator } from '@e2e/fixtures/helpers/SubscriptionHelper'
+import { mockWorkspace, workspace } from '@e2e/fixtures/utils/workspaceMocks'
+
+type CreateCustomerResponse =
+  operations['createCustomer']['responses']['201']['content']['application/json']
+
+// The subscription fixture pins billing_rail to legacy_stripe, which routes
+// local billing through the legacy rail and its Local exemption from the
+// subscription gate. The 1.51 QA finding #11 (no way to add credits without
+// an active subscription) only reproduces on the workspace rail, so this
+// fixture overrides the rail; localAuthFixture keeps the legacy-rail
+// coverage.
+const onWorkspaceRail: SubscriptionOperator = (config) => ({
+  ...config,
+  status: { ...config.status, billing_rail: 'stripe' }
+})
+
+/**
+ * Boots the local (non-Cloud) build as a logged-in unsubscribed workspace
+ * owner on the workspace billing rail. See localAuthFixture for the boot
+ * ordering constraints this mirrors.
+ */
+export const workspaceRailAuthFixture = base.extend<{ comfyPage: ComfyPage }>({
+  comfyPage: async ({ page, request }, use, testInfo) => {
+    testInfo.setTimeout(45_000)
+
+    const comfyPage = new ComfyPage(page, request)
+    const userId = await comfyPage.setupUser(
+      `playwright-workspace-rail-${testInfo.parallelIndex}`
+    )
+    await comfyPage.setupSettings({
+      'Comfy.TutorialCompleted': true,
+      'Comfy.userId': userId
+    })
+
+    await comfyPage.cloudAuth.mockAuth()
+    await mockWorkspace(page, workspace('personal', 'owner'), [])
+    await page.route('**/customers', (route) =>
+      route.fulfill({
+        status: 201,
+        json: { id: 'test-user-e2e' } satisfies CreateCustomerResponse
+      })
+    )
+    await page.route('**/api/billing/balance', (route) =>
+      route.fulfill({
+        json: { amount_micros: 0, currency: 'usd', effective_balance_micros: 0 }
+      })
+    )
+    const subscriptionHelper = createSubscriptionHelper(
+      page,
+      withUnsubscribed(),
+      onWorkspaceRail
+    )
+    await subscriptionHelper.mock()
+
+    await page.evaluate((id) => {
+      localStorage.clear()
+      sessionStorage.clear()
+      localStorage.setItem('Comfy.userId', id)
+    }, userId)
+
+    await comfyPage.goto()
+    await page.waitForFunction(() => document.fonts.ready)
+    await comfyPage.waitForAppReady()
+
+    await use(comfyPage)
+    await subscriptionHelper.clearMocks()
+  }
+})

--- a/browser_tests/tests/localCreditsWorkspaceRail.spec.ts
+++ b/browser_tests/tests/localCreditsWorkspaceRail.spec.ts
@@ -1,0 +1,55 @@
+import { expect } from '@playwright/test'
+
+import { TopUpCreditsDialog } from '@e2e/fixtures/components/TopUpCreditsDialog'
+import { TestIds } from '@e2e/fixtures/selectors'
+import { workspaceRailAuthFixture as test } from '@e2e/fixtures/workspaceRailAuthFixture'
+
+/**
+ * Regression coverage for 1.51 QA finding #11: on a local (non-Cloud)
+ * distribution, a workspace without an active subscription had no way to add
+ * credits — the subscribe CTA is hidden on Local and both Add credits entry
+ * points were gated on an active subscription. Only reproduces on the
+ * workspace billing rail; localCreditsNoSubscribeUi.spec.ts covers the
+ * legacy rail.
+ */
+test.describe('Local credits surfaces on the workspace billing rail', () => {
+  test('lets an unsubscribed workspace owner reach the top-up dialog', async ({
+    comfyPage
+  }) => {
+    const page = comfyPage.page
+    const topUpDialog = new TopUpCreditsDialog(page)
+
+    await page.getByTestId(TestIds.user.currentUserButton).click()
+    const popover = page.getByTestId(TestIds.user.currentUserPopover)
+    await expect(popover).toBeVisible()
+    await expect(popover.getByTestId('add-credits-button')).toBeVisible()
+    await expect(
+      popover.getByTestId('upgrade-to-add-credits-button')
+    ).toHaveCount(0)
+    await expect(
+      popover.getByRole('button', { name: 'Subscribe', exact: true })
+    ).toHaveCount(0)
+
+    await popover.getByTestId('add-credits-button').click()
+    await expect(topUpDialog.heading).toBeVisible()
+    await topUpDialog.close()
+
+    await page.getByTestId(TestIds.user.currentUserButton).click()
+    await page
+      .getByTestId(TestIds.user.currentUserPopover)
+      .getByTestId('plans-credits-menu-item')
+      .click()
+
+    const settingsDialog = comfyPage.settingDialog
+    await settingsDialog.waitForVisible()
+    const settingsAddCredits = settingsDialog.contentArea.getByRole('button', {
+      name: 'Add credits'
+    })
+    await expect(settingsAddCredits).toBeVisible()
+    await expect(
+      settingsDialog.contentArea.getByText('Upgrade to add credits')
+    ).toHaveCount(0)
+    await settingsAddCredits.click()
+    await expect(topUpDialog.heading).toBeVisible()
+  })
+})

--- a/src/platform/cloud/subscription/components/CreditsTile.test.ts
+++ b/src/platform/cloud/subscription/components/CreditsTile.test.ts
@@ -367,6 +367,27 @@ describe('CreditsTile', () => {
     expect(screen.queryByText('Add credits')).toBeNull()
   })
 
+  it('keeps add-credits available on local without an active subscription', async () => {
+    mockIsCloud.value = false
+    state.canAccessSubscriptionFeatures = false
+    state.balance = { amountMicros: 500 }
+    renderTile()
+    expect(screen.queryByText('Upgrade to add credits')).toBeNull()
+    await userEvent.click(screen.getByText('Add credits'))
+    expect(state.showTopUpCreditsDialog).toHaveBeenCalledOnce()
+  })
+
+  it('keeps add-credits available on local for an unsubscribed team workspace', async () => {
+    mockIsCloud.value = false
+    state.canAccessSubscriptionFeatures = false
+    state.isTeamPlan = true
+    state.balance = { amountMicros: 500 }
+    renderTile()
+    expect(screen.queryByText('Upgrade to add credits')).toBeNull()
+    await userEvent.click(screen.getByText('Add credits'))
+    expect(state.showTopUpCreditsDialog).toHaveBeenCalledOnce()
+  })
+
   it('shows no depletion notice or in-use badge while monthly credits remain', () => {
     activeProSubscription()
     const { container } = renderTile()

--- a/src/platform/cloud/subscription/components/CreditsTile.vue
+++ b/src/platform/cloud/subscription/components/CreditsTile.vue
@@ -370,7 +370,9 @@ const showBar = computed(
 // including local/desktop) accounts have no workspace concept to gate on.
 const showActionButton = computed(
   () =>
-    canAccessSubscriptionFeatures.value &&
+    (billingPolicyCapabilities.value.topUpAccess === 'allowed' ||
+      (billingPolicyCapabilities.value.showsSubscribeUpsellUI &&
+        canAccessSubscriptionFeatures.value)) &&
     !zeroState &&
     !inactivePlan &&
     (type.value !== 'workspace' || permissions.value.canTopUp)

--- a/src/platform/workspace/components/CurrentUserPopoverWorkspace.test.ts
+++ b/src/platform/workspace/components/CurrentUserPopoverWorkspace.test.ts
@@ -16,6 +16,8 @@ const state = vi.hoisted(() => ({
   billingStatus: 'paid',
   canAccessSubscriptionFeatures: true,
   isFreeTier: false,
+  isTeamPlan: false,
+  tier: 'PRO' as 'PRO' | 'FREE' | null,
   isCancelled: false,
   planSlug: 'pro-monthly' as string | null,
   canTopUp: false,
@@ -61,6 +63,8 @@ vi.mock('@/composables/billing/useBillingContext', () => ({
       () => state.canAccessSubscriptionFeatures
     ),
     isFreeTier: computed(() => state.isFreeTier),
+    isTeamPlan: computed(() => state.isTeamPlan),
+    tier: computed(() => state.tier),
     subscription: computed(() => ({
       isCancelled: state.isCancelled,
       planSlug: state.planSlug
@@ -177,6 +181,8 @@ describe('CurrentUserPopoverWorkspace', () => {
     state.billingStatus = 'paid'
     state.canAccessSubscriptionFeatures = true
     state.isFreeTier = false
+    state.isTeamPlan = false
+    state.tier = 'PRO'
     state.isCancelled = false
     state.planSlug = 'pro-monthly'
     state.canTopUp = false
@@ -341,6 +347,67 @@ describe('CurrentUserPopoverWorkspace', () => {
     expect(
       screen.queryByRole('button', { name: 'Subscribe' })
     ).not.toBeInTheDocument()
+  })
+
+  it('lets an owner add credits on Local without an active subscription', async () => {
+    const user = userEvent.setup()
+    state.isCloud = false
+    state.canAccessSubscriptionFeatures = false
+    state.tier = null
+    state.canTopUp = true
+
+    renderComponent('personal')
+
+    expect(
+      screen.queryByTestId('upgrade-to-add-credits-button')
+    ).not.toBeInTheDocument()
+    await user.click(screen.getByTestId('add-credits-button'))
+
+    expect(state.showTopUpCreditsDialog).toHaveBeenCalledOnce()
+  })
+
+  it('keeps add-credits hidden for an unsubscribed Cloud owner', () => {
+    state.canAccessSubscriptionFeatures = false
+    state.tier = null
+    state.canTopUp = true
+    state.canManageSubscription = true
+
+    renderComponent('personal')
+
+    expect(screen.queryByTestId('add-credits-button')).not.toBeInTheDocument()
+    expect(
+      screen.queryByTestId('upgrade-to-add-credits-button')
+    ).not.toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'Subscribe' })
+    ).toBeInTheDocument()
+  })
+
+  it('offers add-credits instead of the upgrade upsell on the Local free tier', () => {
+    state.isCloud = false
+    state.isFreeTier = true
+    state.tier = 'FREE'
+    state.canTopUp = true
+
+    renderComponent('personal')
+
+    expect(
+      screen.queryByTestId('upgrade-to-add-credits-button')
+    ).not.toBeInTheDocument()
+    expect(screen.getByTestId('add-credits-button')).toBeInTheDocument()
+  })
+
+  it('keeps the upgrade upsell for the Cloud free tier', () => {
+    state.isFreeTier = true
+    state.tier = 'FREE'
+    state.canTopUp = true
+
+    renderComponent('personal')
+
+    expect(
+      screen.getByTestId('upgrade-to-add-credits-button')
+    ).toBeInTheDocument()
+    expect(screen.queryByTestId('add-credits-button')).not.toBeInTheDocument()
   })
 
   it('keeps Resubscribe hidden on Local for a cancelled plan', () => {

--- a/src/platform/workspace/components/CurrentUserPopoverWorkspace.vue
+++ b/src/platform/workspace/components/CurrentUserPopoverWorkspace.vue
@@ -110,7 +110,9 @@
       <!-- Upgrade to add credits (free tier) -->
       <Button
         v-if="
-          canAccessSubscriptionFeatures && permissions.canTopUp && isFreeTier
+          billingPolicyCapabilities.showsSubscribeUpsellUI &&
+          permissions.canTopUp &&
+          isFreeTier
         "
         variant="subscribe"
         size="sm"
@@ -120,7 +122,10 @@
         {{ $t('subscription.upgradeToAddCredits') }}
       </Button>
       <Button
-        v-else-if="canAccessSubscriptionFeatures && permissions.canTopUp"
+        v-else-if="
+          billingPolicyCapabilities.topUpAccess === 'allowed' &&
+          permissions.canTopUp
+        "
         variant="secondary"
         size="sm"
         class="text-base-foreground"
@@ -269,6 +274,7 @@ import { useCurrentUser } from '@/composables/auth/useCurrentUser'
 import { useExternalLink } from '@/composables/useExternalLink'
 import { useBillingContext } from '@/composables/billing/useBillingContext'
 import SubscribeButton from '@/platform/cloud/subscription/components/SubscribeButton.vue'
+import { useBillingPolicyCapabilities } from '@/platform/cloud/subscription/composables/useBillingPolicyCapabilities'
 import { useSubscriptionDialog } from '@/platform/cloud/subscription/composables/useSubscriptionDialog'
 import { isCloud } from '@/platform/distribution/types'
 import { useTelemetry } from '@/platform/telemetry'
@@ -324,6 +330,8 @@ const {
   isLoading,
   fetchBalance
 } = useBillingContext()
+
+const { billingPolicyCapabilities } = useBillingPolicyCapabilities()
 
 const isCancelled = computed(() => subscription.value?.isCancelled ?? false)
 const subscriptionDialog = useSubscriptionDialog()

--- a/src/platform/workspace/components/SubscriptionPanelContentWorkspace.test.ts
+++ b/src/platform/workspace/components/SubscriptionPanelContentWorkspace.test.ts
@@ -793,6 +793,25 @@ describe('SubscriptionPanelContentWorkspace', () => {
     expect(mockManageSubscription).toHaveBeenCalledOnce()
   })
 
+  it('lets a never-subscribed team workspace top up on Local instead of upselling', () => {
+    mockDistributionState.isCloud = false
+    mockIsActiveSubscription.value = false
+    mockIsWorkspaceSubscribed.value = false
+    mockHasSubscription.value = false
+    renderComponent()
+
+    expect(
+      screen.queryByText('This workspace is not on a subscription')
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: 'Subscribe Now' })
+    ).not.toBeInTheDocument()
+    expect(screen.getByTestId('credits-tile')).toHaveAttribute(
+      'data-zero-state',
+      'false'
+    )
+  })
+
   it('shows a loading indicator instead of a false Free plan while billing loads', () => {
     mockHasSubscription.value = false
     mockIsLoading.value = true

--- a/src/platform/workspace/components/SubscriptionPanelContentWorkspace.vue
+++ b/src/platform/workspace/components/SubscriptionPanelContentWorkspace.vue
@@ -495,8 +495,14 @@ const showSubscribePrompt = computed(() => {
   return !isWorkspaceSubscribed.value
 })
 
+// The never-subscribed upsell is Cloud-only; on Local the policy table keeps
+// top-up available instead. An ended Team plan keeps its inactive treatment
+// everywhere so billing, invoices, and reactivation stay reachable.
 const showTeamSubscribePrompt = computed(
-  () => showSubscribePrompt.value && !isInPersonalWorkspace.value
+  () =>
+    showSubscribePrompt.value &&
+    !isInPersonalWorkspace.value &&
+    (isCloud || (isSubscriptionEnded.value && isTeamPlan.value))
 )
 
 const showInactiveTeamSubscription = computed(


### PR DESCRIPTION
Backport of #15799 to `cloud/1.52`.

## Merge order — this PR is stacked

Base is deliberately `cloud/1.52`, not `cloud/1.52`. GitHub retargets this PR to `cloud/1.52` once its parent merges.

`cloud/1.52` → #15799 → #15803 → #15804 → #15675 → #15967 → #16043 → #16046 → #16067

Every commit in this chain cherry-picks cleanly; there are no hand-resolved conflicts anywhere in the stack.

## Verification

Run at the tip of the full stack: 93 unit test files, 1745 tests, 0 failures (`src/platform/workspace`, `src/platform/cloud/subscription`, `src/composables/useCoreCommands.test.ts`, `src/components/actionbar`).

## Why this is in the chain

Prerequisite found while backporting #16067. `cloud/1.52` carries `useBillingPolicyCapabilities.ts` but never adopted it in `CurrentUserPopoverWorkspace.vue` / `CreditsTile.vue`. Without this commit #15804 conflicts in both files.