### PR TITLE
[backport cloud/1.52] billing: add the server-resolved capabilities source

### DIFF
--- a/browser_tests/fixtures/workspaceRailAuthFixture.ts
+++ b/browser_tests/fixtures/workspaceRailAuthFixture.ts
@@ -1,0 +1,77 @@
+import { test as base } from '@playwright/test'
+
+import type { operations } from '@/types/comfyRegistryTypes'
+import { ComfyPage } from '@e2e/fixtures/ComfyPage'
+import {
+  createSubscriptionHelper,
+  withUnsubscribed
+} from '@e2e/fixtures/helpers/SubscriptionHelper'
+import type { SubscriptionOperator } from '@e2e/fixtures/helpers/SubscriptionHelper'
+import { mockWorkspace, workspace } from '@e2e/fixtures/utils/workspaceMocks'
+
+type CreateCustomerResponse =
+  operations['createCustomer']['responses']['201']['content']['application/json']
+
+// The subscription fixture pins billing_rail to legacy_stripe, which routes
+// local billing through the legacy rail and its Local exemption from the
+// subscription gate. The 1.51 QA finding #11 (no way to add credits without
+// an active subscription) only reproduces on the workspace rail, so this
+// fixture overrides the rail; localAuthFixture keeps the legacy-rail
+// coverage.
+const onWorkspaceRail: SubscriptionOperator = (config) => ({
+  ...config,
+  status: { ...config.status, billing_rail: 'stripe' }
+})
+
+/**
+ * Boots the local (non-Cloud) build as a logged-in unsubscribed workspace
+ * owner on the workspace billing rail. See localAuthFixture for the boot
+ * ordering constraints this mirrors.
+ */
+export const workspaceRailAuthFixture = base.extend<{ comfyPage: ComfyPage }>({
+  comfyPage: async ({ page, request }, use, testInfo) => {
+    testInfo.setTimeout(45_000)
+
+    const comfyPage = new ComfyPage(page, request)
+    const userId = await comfyPage.setupUser(
+      `playwright-workspace-rail-${testInfo.parallelIndex}`
+    )
+    await comfyPage.setupSettings({
+      'Comfy.TutorialCompleted': true,
+      'Comfy.userId': userId
+    })
+
+    await comfyPage.cloudAuth.mockAuth()
+    await mockWorkspace(page, workspace('personal', 'owner'), [])
+    await page.route('**/customers', (route) =>
+      route.fulfill({
+        status: 201,
+        json: { id: 'test-user-e2e' } satisfies CreateCustomerResponse
+      })
+    )
+    await page.route('**/api/billing/balance', (route) =>
+      route.fulfill({
+        json: { amount_micros: 0, currency: 'usd', effective_balance_micros: 0 }
+      })
+    )
+    const subscriptionHelper = createSubscriptionHelper(
+      page,
+      withUnsubscribed(),
+      onWorkspaceRail
+    )
+    await subscriptionHelper.mock()
+
+    await page.evaluate((id) => {
+      localStorage.clear()
+      sessionStorage.clear()
+      localStorage.setItem('Comfy.userId', id)
+    }, userId)
+
+    await comfyPage.goto()
+    await page.waitForFunction(() => document.fonts.ready)
+    await comfyPage.waitForAppReady()
+
+    await use(comfyPage)
+    await subscriptionHelper.clearMocks()
+  }
+})

--- a/browser_tests/tests/localCreditsWorkspaceRail.spec.ts
+++ b/browser_tests/tests/localCreditsWorkspaceRail.spec.ts
@@ -1,0 +1,55 @@
+import { expect } from '@playwright/test'
+
+import { TopUpCreditsDialog } from '@e2e/fixtures/components/TopUpCreditsDialog'
+import { TestIds } from '@e2e/fixtures/selectors'
+import { workspaceRailAuthFixture as test } from '@e2e/fixtures/workspaceRailAuthFixture'
+
+/**
+ * Regression coverage for 1.51 QA finding #11: on a local (non-Cloud)
+ * distribution, a workspace without an active subscription had no way to add
+ * credits — the subscribe CTA is hidden on Local and both Add credits entry
+ * points were gated on an active subscription. Only reproduces on the
+ * workspace billing rail; localCreditsNoSubscribeUi.spec.ts covers the
+ * legacy rail.
+ */
+test.describe('Local credits surfaces on the workspace billing rail', () => {
+  test('lets an unsubscribed workspace owner reach the top-up dialog', async ({
+    comfyPage
+  }) => {
+    const page = comfyPage.page
+    const topUpDialog = new TopUpCreditsDialog(page)
+
+    await page.getByTestId(TestIds.user.currentUserButton).click()
+    const popover = page.getByTestId(TestIds.user.currentUserPopover)
+    await expect(popover).toBeVisible()
+    await expect(popover.getByTestId('add-credits-button')).toBeVisible()
+    await expect(
+      popover.getByTestId('upgrade-to-add-credits-button')
+    ).toHaveCount(0)
+    await expect(
+      popover.getByRole('button', { name: 'Subscribe', exact: true })
+    ).toHaveCount(0)
+
+    await popover.getByTestId('add-credits-button').click()
+    await expect(topUpDialog.heading).toBeVisible()
+    await topUpDialog.close()
+
+    await page.getByTestId(TestIds.user.currentUserButton).click()
+    await page
+      .getByTestId(TestIds.user.currentUserPopover)
+      .getByTestId('plans-credits-menu-item')
+      .click()
+
+    const settingsDialog = comfyPage.settingDialog
+    await settingsDialog.waitForVisible()
+    const settingsAddCredits = settingsDialog.contentArea.getByRole('button', {
+      name: 'Add credits'
+    })
+    await expect(settingsAddCredits).toBeVisible()
+    await expect(
+      settingsDialog.contentArea.getByText('Upgrade to add credits')
+    ).toHaveCount(0)
+    await settingsAddCredits.click()
+    await expect(topUpDialog.heading).toBeVisible()
+  })
+})

--- a/src/platform/cloud/subscription/components/CreditsTile.test.ts
+++ b/src/platform/cloud/subscription/components/CreditsTile.test.ts
@@ -367,6 +367,27 @@ describe('CreditsTile', () => {
     expect(screen.queryByText('Add credits')).toBeNull()
   })
 
+  it('keeps add-credits available on local without an active subscription', async () => {
+    mockIsCloud.value = false
+    state.canAccessSubscriptionFeatures = false
+    state.balance = { amountMicros: 500 }
+    renderTile()
+    expect(screen.queryByText('Upgrade to add credits')).toBeNull()
+    await userEvent.click(screen.getByText('Add credits'))
+    expect(state.showTopUpCreditsDialog).toHaveBeenCalledOnce()
+  })
+
+  it('keeps add-credits available on local for an unsubscribed team workspace', async () => {
+    mockIsCloud.value = false
+    state.canAccessSubscriptionFeatures = false
+    state.isTeamPlan = true
+    state.balance = { amountMicros: 500 }
+    renderTile()
+    expect(screen.queryByText('Upgrade to add credits')).toBeNull()
+    await userEvent.click(screen.getByText('Add credits'))
+    expect(state.showTopUpCreditsDialog).toHaveBeenCalledOnce()
+  })
+
   it('shows no depletion notice or in-use badge while monthly credits remain', () => {
     activeProSubscription()
     const { container } = renderTile()

--- a/src/platform/cloud/subscription/components/CreditsTile.vue
+++ b/src/platform/cloud/subscription/components/CreditsTile.vue
@@ -370,7 +370,9 @@ const showBar = computed(
 // including local/desktop) accounts have no workspace concept to gate on.
 const showActionButton = computed(
   () =>
-    canAccessSubscriptionFeatures.value &&
+    (billingPolicyCapabilities.value.topUpAccess === 'allowed' ||
+      (billingPolicyCapabilities.value.showsSubscribeUpsellUI &&
+        canAccessSubscriptionFeatures.value)) &&
     !zeroState &&
     !inactivePlan &&
     (type.value !== 'workspace' || permissions.value.canTopUp)

--- a/src/platform/workspace/api/capabilityRevision.test.ts
+++ b/src/platform/workspace/api/capabilityRevision.test.ts
@@ -1,0 +1,156 @@
+import type {
+  AxiosInstance,
+  AxiosResponse,
+  InternalAxiosRequestConfig
+} from 'axios'
+import axios, { AxiosError, AxiosHeaders } from 'axios'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  attachCapabilityRevisionInterceptor,
+  onCapabilityRevision
+} from './capabilityRevision'
+
+const unsubscribes: Array<() => void> = []
+
+function subscribe() {
+  const listener = vi.fn()
+  unsubscribes.push(onCapabilityRevision(listener))
+  return listener
+}
+
+function clientRespondingWith(
+  status: number,
+  headers: Record<string, string>
+): AxiosInstance {
+  const client = axios.create()
+  client.defaults.adapter = (config: InternalAxiosRequestConfig) => {
+    const response: AxiosResponse = {
+      data: {},
+      status,
+      statusText: '',
+      headers: new AxiosHeaders(headers),
+      config
+    }
+    return status >= 400
+      ? Promise.reject(
+          new AxiosError(
+            'Request failed',
+            'ERR_BAD_REQUEST',
+            config,
+            {},
+            response
+          )
+        )
+      : Promise.resolve(response)
+  }
+  attachCapabilityRevisionInterceptor(client)
+  return client
+}
+
+afterEach(() => {
+  while (unsubscribes.length) unsubscribes.pop()!()
+})
+
+describe('capabilityRevision', () => {
+  it('publishes the revision reported by a successful mutation', async () => {
+    const listener = subscribe()
+
+    await clientRespondingWith(200, { 'X-Capability-Revision': '42' }).post(
+      '/api/billing/subscribe'
+    )
+
+    expect(listener).toHaveBeenCalledExactlyOnceWith(42)
+  })
+
+  it('publishes the revision reported by a failed mutation', async () => {
+    const listener = subscribe()
+
+    await expect(
+      clientRespondingWith(402, { 'X-Capability-Revision': '43' }).post(
+        '/api/billing/subscribe'
+      )
+    ).rejects.toBeInstanceOf(AxiosError)
+
+    expect(listener).toHaveBeenCalledExactlyOnceWith(43)
+  })
+
+  it.for(['put', 'patch', 'delete'])(
+    'publishes the revision reported by a %s mutation',
+    async (method) => {
+      const listener = subscribe()
+
+      await clientRespondingWith(200, {
+        'X-Capability-Revision': '11'
+      }).request({ method, url: '/api/workspaces/workspace-1' })
+
+      expect(listener).toHaveBeenCalledExactlyOnceWith(11)
+    }
+  )
+
+  it('publishes nothing for a read that reports its own revision', async () => {
+    const listener = subscribe()
+
+    await clientRespondingWith(200, { 'X-Capability-Revision': '44' }).get(
+      '/api/billing/capabilities'
+    )
+
+    expect(listener).not.toHaveBeenCalled()
+  })
+
+  it('reads the revision header case-insensitively', async () => {
+    const listener = subscribe()
+
+    await clientRespondingWith(200, { 'x-capability-revision': '7' }).post(
+      '/api/billing/topup'
+    )
+
+    expect(listener).toHaveBeenCalledExactlyOnceWith(7)
+  })
+
+  it('publishes nothing when the response omits the revision header', async () => {
+    const listener = subscribe()
+
+    await clientRespondingWith(200, {}).post('/api/billing/subscribe')
+
+    expect(listener).not.toHaveBeenCalled()
+  })
+
+  it('publishes nothing when a transport error carries no response', async () => {
+    const listener = subscribe()
+    const client = axios.create()
+    client.defaults.adapter = () =>
+      Promise.reject(new AxiosError('Network Error', 'ERR_NETWORK'))
+    attachCapabilityRevisionInterceptor(client)
+
+    await expect(client.post('/api/billing/subscribe')).rejects.toBeInstanceOf(
+      AxiosError
+    )
+
+    expect(listener).not.toHaveBeenCalled()
+  })
+
+  it.for(['', 'not-a-number', '0', '-1', '1.5', '9007199254740993'])(
+    'publishes nothing for an unusable revision header %j',
+    async (value) => {
+      const listener = subscribe()
+
+      await clientRespondingWith(200, {
+        'X-Capability-Revision': value
+      }).post('/api/billing/subscribe')
+
+      expect(listener).not.toHaveBeenCalled()
+    }
+  )
+
+  it('stops publishing to a listener once it unsubscribes', async () => {
+    const listener = vi.fn()
+    onCapabilityRevision(listener)()
+
+    await clientRespondingWith(200, { 'X-Capability-Revision': '9' }).post(
+      '/api/billing/subscribe'
+    )
+
+    expect(listener).not.toHaveBeenCalled()
+  })
+})

--- a/src/platform/workspace/api/capabilityRevision.ts
+++ b/src/platform/workspace/api/capabilityRevision.ts
@@ -1,0 +1,74 @@
+import type { AxiosInstance, AxiosResponse, RawAxiosHeaders } from 'axios'
+import axios, { AxiosHeaders } from 'axios'
+
+const CAPABILITY_REVISION_HEADER = 'X-Capability-Revision'
+// The capability read echoes the header on its own response, so only a
+// mutation counts as an invalidation signal: publishing a read's own revision
+// would mark that read stale and refetch it forever.
+const MUTATION_METHODS = new Set(['post', 'put', 'patch', 'delete'])
+
+type CapabilityRevisionListener = (revision: number) => void
+
+const listeners = new Set<CapabilityRevisionListener>()
+
+export function onCapabilityRevision(
+  listener: CapabilityRevisionListener
+): () => void {
+  listeners.add(listener)
+  return () => {
+    listeners.delete(listener)
+  }
+}
+
+function isMutationResponse(response: AxiosResponse | undefined): boolean {
+  const method = response?.config?.method
+  return (
+    typeof method === 'string' && MUTATION_METHODS.has(method.toLowerCase())
+  )
+}
+
+function readCapabilityRevision(
+  response: AxiosResponse | undefined
+): number | null {
+  const headers = response?.headers
+  if (!headers) return null
+  const raw = AxiosHeaders.from(headers as RawAxiosHeaders).get(
+    CAPABILITY_REVISION_HEADER
+  )
+  const value = Array.isArray(raw) ? raw[0] : raw
+  if (typeof value !== 'string' && typeof value !== 'number') return null
+  const revision = Number(value)
+  return Number.isSafeInteger(revision) && revision > 0 ? revision : null
+}
+
+/**
+ * Installs a response interceptor that republishes the capability revision a
+ * mutation reports to {@link onCapabilityRevision} subscribers.
+ *
+ * The header is stamped before the handler runs, so a rejected mutation
+ * carries it too and the error arm has to read it as well. It is absent
+ * whenever CORS is bypassed (local desktop origins), so every read degrades to
+ * "no revision reported" rather than assuming presence.
+ */
+export function attachCapabilityRevisionInterceptor(
+  client: AxiosInstance
+): void {
+  const publish = (response: AxiosResponse | undefined) => {
+    if (!isMutationResponse(response)) return
+    const revision = readCapabilityRevision(response)
+    if (revision !== null) {
+      for (const listener of [...listeners]) listener(revision)
+    }
+  }
+
+  client.interceptors.response.use(
+    (response) => {
+      publish(response)
+      return response
+    },
+    (error: unknown) => {
+      publish(axios.isAxiosError(error) ? error.response : undefined)
+      throw error
+    }
+  )
+}

--- a/src/platform/workspace/api/workspaceApi.test.ts
+++ b/src/platform/workspace/api/workspaceApi.test.ts
@@ -382,6 +382,33 @@ describe('workspaceApi', () => {
       expect(result).toEqual(data)
     })
 
+    it('getBillingCapabilities() sends GET /billing/capabilities', async () => {
+      const controller = new AbortController()
+      const data = {
+        resolved_for: { user_id: 'user-1', workspace_id: 'workspace-1' },
+        capabilities: {
+          can_subscribe_self_serve: true,
+          can_top_up: false,
+          can_cancel: true,
+          can_reactivate: true,
+          can_change_seats: true,
+          can_invite_members: true,
+          can_downgrade_to_personal: false
+        }
+      }
+      mockAxiosInstance.get.mockResolvedValue({ data })
+
+      const result = await workspaceApi.getBillingCapabilities(
+        controller.signal
+      )
+
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith(
+        '/api/billing/capabilities',
+        { headers: AUTH_HEADER, timeout: 10_000, signal: controller.signal }
+      )
+      expect(result).toEqual(data)
+    })
+
     it('getBillingPlans() sends GET /billing/plans', async () => {
       const data = { plans: [] }
       mockAxiosInstance.get.mockResolvedValue({ data })

--- a/src/platform/workspace/api/workspaceApi.ts
+++ b/src/platform/workspace/api/workspaceApi.ts
@@ -1,6 +1,7 @@
 import type {
   AcceptInviteResponse,
   BillingBalanceResponse,
+  BillingCapabilitiesResponse,
   BillingEventsResponse,
   BillingOpStatusResponse,
   BillingPlansResponse,
@@ -44,6 +45,7 @@ import {
   UNKNOWN_ERROR_CODE,
   errorResponseFromBody
 } from '@/platform/remote/comfyui/errors'
+import { attachCapabilityRevisionInterceptor } from '@/platform/workspace/api/capabilityRevision'
 import type {
   WorkspaceId,
   WorkspaceInviteId
@@ -114,6 +116,7 @@ export type { BillingStatus }
 export type { BillingStatusResponse }
 
 export type { BillingBalanceResponse }
+export type { BillingCapabilitiesResponse }
 export type { CreateTopupResponse }
 export type { BillingOpStatusResponse }
 export type { SavedPaymentMethod }
@@ -148,6 +151,7 @@ const workspaceApiClient = axios.create({
 
 // acceptInvite opts out via __skipUnifiedRemint (it is deliberately Firebase-authed).
 attachUnifiedRemintInterceptor(workspaceApiClient)
+attachCapabilityRevisionInterceptor(workspaceApiClient)
 
 async function getAuthHeaderOrThrow() {
   return useAuthStore().getWorkspaceAuthHeaderOrThrow()
@@ -443,6 +447,26 @@ export const workspaceApi = {
         workspaceApiUrl('/billing/balance'),
         { headers }
       )
+      return response.data
+    } catch (err) {
+      handleAxiosError(err)
+    }
+  },
+
+  /**
+   * Get billing capabilities for the current workspace
+   * GET /api/billing/capabilities
+   */
+  async getBillingCapabilities(
+    signal?: AbortSignal
+  ): Promise<BillingCapabilitiesResponse> {
+    const headers = await getAuthHeaderOrThrow()
+    try {
+      const response =
+        await workspaceApiClient.get<BillingCapabilitiesResponse>(
+          workspaceApiUrl('/billing/capabilities'),
+          { headers, timeout: 10_000, signal }
+        )
       return response.data
     } catch (err) {
       handleAxiosError(err)

--- a/src/platform/workspace/auth/WorkspaceAuthGate.test.ts
+++ b/src/platform/workspace/auth/WorkspaceAuthGate.test.ts
@@ -74,6 +74,7 @@ vi.mock('@/platform/workspace/stores/workspaceAuthStore', () => ({
 
 const mockWorkspaceStoreInitialize = vi.fn()
 const mockWorkspaceStoreReset = vi.fn()
+const mockBillingCapabilitiesInitialize = vi.hoisted(() => vi.fn())
 const mockWorkspaceStoreInitState = vi.hoisted(() => ({
   value: 'uninitialized' as string
 }))
@@ -103,6 +104,12 @@ vi.mock('@/stores/apiKeyAuthStore', () => ({
   })
 }))
 
+vi.mock('@/platform/workspace/composables/useBillingCapabilities', () => ({
+  useBillingCapabilities: () => ({
+    initialize: mockBillingCapabilitiesInitialize
+  })
+}))
+
 const mockIsCloud = vi.hoisted(() => ({ value: true }))
 vi.mock('@/platform/distribution/types', () => ({
   get isCloud() {
@@ -122,6 +129,7 @@ describe('WorkspaceAuthGate', () => {
     mockWorkspaceStoreInitState.value = 'uninitialized'
     mockActiveWorkspaceId.value = 'workspace-123'
     mockRefreshRemoteConfig.mockResolvedValue(undefined)
+    mockBillingCapabilitiesInitialize.mockResolvedValue(undefined)
     mockWorkspaceStoreInitialize.mockImplementation(async () => {
       mockWorkspaceStoreInitState.value = 'ready'
     })
@@ -167,6 +175,7 @@ describe('WorkspaceAuthGate', () => {
 
       expect(screen.getByTestId('slot-content')).toBeInTheDocument()
       expect(mockWorkspaceStoreInitialize).toHaveBeenCalledOnce()
+      expect(mockBillingCapabilitiesInitialize).not.toHaveBeenCalled()
       expect(mockRefreshRemoteConfig).not.toHaveBeenCalled()
     })
 
@@ -330,7 +339,45 @@ describe('WorkspaceAuthGate', () => {
       await flushPromises()
 
       expect(mockWorkspaceStoreInitialize).toHaveBeenCalled()
+      expect(mockBillingCapabilitiesInitialize).toHaveBeenCalled()
       expect(screen.getByTestId('slot-content')).toBeInTheDocument()
+    })
+
+    it('does not block app rendering on billing capabilities', async () => {
+      mockBillingCapabilitiesInitialize.mockImplementationOnce(
+        () => new Promise<void>(() => {})
+      )
+
+      mountComponent()
+      await vi.waitFor(() =>
+        expect(mockBillingCapabilitiesInitialize).toHaveBeenCalledOnce()
+      )
+
+      await flushPromises()
+
+      expect(screen.getByTestId('slot-content')).toBeInTheDocument()
+    })
+
+    it('aborts capability initialization when unmounted', async () => {
+      mockBillingCapabilitiesInitialize.mockImplementationOnce(
+        (signal: AbortSignal) =>
+          new Promise<void>((resolve) => {
+            signal.addEventListener('abort', () => resolve(), { once: true })
+          })
+      )
+
+      const { unmount } = mountComponent()
+      await vi.waitFor(() =>
+        expect(mockBillingCapabilitiesInitialize).toHaveBeenCalledOnce()
+      )
+      const signal = mockBillingCapabilitiesInitialize.mock.calls[0][0]
+
+      unmount()
+      await flushPromises()
+
+      expect(signal).toBeInstanceOf(AbortSignal)
+      expect(signal.aborted).toBe(true)
+      expect(mockReportError).not.toHaveBeenCalled()
     })
 
     it('stops initialization when unmounted', async () => {

--- a/src/platform/workspace/auth/WorkspaceAuthGate.vue
+++ b/src/platform/workspace/auth/WorkspaceAuthGate.vue
@@ -80,6 +80,7 @@ import { refreshRemoteConfig } from '@/platform/remoteConfig/refreshRemoteConfig
 import { reportError } from '@/platform/telemetry/reportError'
 import { useWorkspaceAuthStore } from '@/platform/workspace/stores/workspaceAuthStore'
 import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
+import { useBillingCapabilities } from '@/platform/workspace/composables/useBillingCapabilities'
 import { useApiKeyAuthStore } from '@/stores/apiKeyAuthStore'
 import { useAuthStore } from '@/stores/authStore'
 
@@ -91,6 +92,7 @@ const initializationState = ref<
 >(isCloud ? 'initializing' : 'ready')
 const initializationRetryable = ref(true)
 const errorPanel = useTemplateRef<HTMLElement>('errorPanel')
+const billingCapabilities = useBillingCapabilities()
 let initializationGeneration = 0
 let initializationController: AbortController | null = null
 let backgroundInitialization: Promise<void> | null = null
@@ -166,6 +168,7 @@ async function initialize(): Promise<void> {
 
     await initializeWorkspaceMode()
     if (generation !== initializationGeneration) return
+    void billingCapabilities.initialize(controller.signal)
     if (
       flags.unifiedCloudAuthEnabled &&
       !workspaceAuthStore.getUnifiedToken()

--- a/src/platform/workspace/components/CurrentUserPopoverWorkspace.test.ts
+++ b/src/platform/workspace/components/CurrentUserPopoverWorkspace.test.ts
@@ -16,6 +16,8 @@ const state = vi.hoisted(() => ({
   billingStatus: 'paid',
   canAccessSubscriptionFeatures: true,
   isFreeTier: false,
+  isTeamPlan: false,
+  tier: 'PRO' as 'PRO' | 'FREE' | null,
   isCancelled: false,
   planSlug: 'pro-monthly' as string | null,
   canTopUp: false,
@@ -61,6 +63,8 @@ vi.mock('@/composables/billing/useBillingContext', () => ({
       () => state.canAccessSubscriptionFeatures
     ),
     isFreeTier: computed(() => state.isFreeTier),
+    isTeamPlan: computed(() => state.isTeamPlan),
+    tier: computed(() => state.tier),
     subscription: computed(() => ({
       isCancelled: state.isCancelled,
       planSlug: state.planSlug
@@ -177,6 +181,8 @@ describe('CurrentUserPopoverWorkspace', () => {
     state.billingStatus = 'paid'
     state.canAccessSubscriptionFeatures = true
     state.isFreeTier = false
+    state.isTeamPlan = false
+    state.tier = 'PRO'
     state.isCancelled = false
     state.planSlug = 'pro-monthly'
     state.canTopUp = false
@@ -341,6 +347,67 @@ describe('CurrentUserPopoverWorkspace', () => {
     expect(
       screen.queryByRole('button', { name: 'Subscribe' })
     ).not.toBeInTheDocument()
+  })
+
+  it('lets an owner add credits on Local without an active subscription', async () => {
+    const user = userEvent.setup()
+    state.isCloud = false
+    state.canAccessSubscriptionFeatures = false
+    state.tier = null
+    state.canTopUp = true
+
+    renderComponent('personal')
+
+    expect(
+      screen.queryByTestId('upgrade-to-add-credits-button')
+    ).not.toBeInTheDocument()
+    await user.click(screen.getByTestId('add-credits-button'))
+
+    expect(state.showTopUpCreditsDialog).toHaveBeenCalledOnce()
+  })
+
+  it('keeps add-credits hidden for an unsubscribed Cloud owner', () => {
+    state.canAccessSubscriptionFeatures = false
+    state.tier = null
+    state.canTopUp = true
+    state.canManageSubscription = true
+
+    renderComponent('personal')
+
+    expect(screen.queryByTestId('add-credits-button')).not.toBeInTheDocument()
+    expect(
+      screen.queryByTestId('upgrade-to-add-credits-button')
+    ).not.toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'Subscribe' })
+    ).toBeInTheDocument()
+  })
+
+  it('offers add-credits instead of the upgrade upsell on the Local free tier', () => {
+    state.isCloud = false
+    state.isFreeTier = true
+    state.tier = 'FREE'
+    state.canTopUp = true
+
+    renderComponent('personal')
+
+    expect(
+      screen.queryByTestId('upgrade-to-add-credits-button')
+    ).not.toBeInTheDocument()
+    expect(screen.getByTestId('add-credits-button')).toBeInTheDocument()
+  })
+
+  it('keeps the upgrade upsell for the Cloud free tier', () => {
+    state.isFreeTier = true
+    state.tier = 'FREE'
+    state.canTopUp = true
+
+    renderComponent('personal')
+
+    expect(
+      screen.getByTestId('upgrade-to-add-credits-button')
+    ).toBeInTheDocument()
+    expect(screen.queryByTestId('add-credits-button')).not.toBeInTheDocument()
   })
 
   it('keeps Resubscribe hidden on Local for a cancelled plan', () => {

--- a/src/platform/workspace/components/CurrentUserPopoverWorkspace.vue
+++ b/src/platform/workspace/components/CurrentUserPopoverWorkspace.vue
@@ -110,7 +110,9 @@
       <!-- Upgrade to add credits (free tier) -->
       <Button
         v-if="
-          canAccessSubscriptionFeatures && permissions.canTopUp && isFreeTier
+          billingPolicyCapabilities.showsSubscribeUpsellUI &&
+          permissions.canTopUp &&
+          isFreeTier
         "
         variant="subscribe"
         size="sm"
@@ -120,7 +122,10 @@
         {{ $t('subscription.upgradeToAddCredits') }}
       </Button>
       <Button
-        v-else-if="canAccessSubscriptionFeatures && permissions.canTopUp"
+        v-else-if="
+          billingPolicyCapabilities.topUpAccess === 'allowed' &&
+          permissions.canTopUp
+        "
         variant="secondary"
         size="sm"
         class="text-base-foreground"
@@ -269,6 +274,7 @@ import { useCurrentUser } from '@/composables/auth/useCurrentUser'
 import { useExternalLink } from '@/composables/useExternalLink'
 import { useBillingContext } from '@/composables/billing/useBillingContext'
 import SubscribeButton from '@/platform/cloud/subscription/components/SubscribeButton.vue'
+import { useBillingPolicyCapabilities } from '@/platform/cloud/subscription/composables/useBillingPolicyCapabilities'
 import { useSubscriptionDialog } from '@/platform/cloud/subscription/composables/useSubscriptionDialog'
 import { isCloud } from '@/platform/distribution/types'
 import { useTelemetry } from '@/platform/telemetry'
@@ -324,6 +330,8 @@ const {
   isLoading,
   fetchBalance
 } = useBillingContext()
+
+const { billingPolicyCapabilities } = useBillingPolicyCapabilities()
 
 const isCancelled = computed(() => subscription.value?.isCancelled ?? false)
 const subscriptionDialog = useSubscriptionDialog()

--- a/src/platform/workspace/components/SubscriptionPanelContentWorkspace.test.ts
+++ b/src/platform/workspace/components/SubscriptionPanelContentWorkspace.test.ts
@@ -793,6 +793,25 @@ describe('SubscriptionPanelContentWorkspace', () => {
     expect(mockManageSubscription).toHaveBeenCalledOnce()
   })
 
+  it('lets a never-subscribed team workspace top up on Local instead of upselling', () => {
+    mockDistributionState.isCloud = false
+    mockIsActiveSubscription.value = false
+    mockIsWorkspaceSubscribed.value = false
+    mockHasSubscription.value = false
+    renderComponent()
+
+    expect(
+      screen.queryByText('This workspace is not on a subscription')
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: 'Subscribe Now' })
+    ).not.toBeInTheDocument()
+    expect(screen.getByTestId('credits-tile')).toHaveAttribute(
+      'data-zero-state',
+      'false'
+    )
+  })
+
   it('shows a loading indicator instead of a false Free plan while billing loads', () => {
     mockHasSubscription.value = false
     mockIsLoading.value = true

--- a/src/platform/workspace/components/SubscriptionPanelContentWorkspace.vue
+++ b/src/platform/workspace/components/SubscriptionPanelContentWorkspace.vue
@@ -495,8 +495,14 @@ const showSubscribePrompt = computed(() => {
   return !isWorkspaceSubscribed.value
 })
 
+// The never-subscribed upsell is Cloud-only; on Local the policy table keeps
+// top-up available instead. An ended Team plan keeps its inactive treatment
+// everywhere so billing, invoices, and reactivation stay reachable.
 const showTeamSubscribePrompt = computed(
-  () => showSubscribePrompt.value && !isInPersonalWorkspace.value
+  () =>
+    showSubscribePrompt.value &&
+    !isInPersonalWorkspace.value &&
+    (isCloud || (isSubscriptionEnded.value && isTeamPlan.value))
 )
 
 const showInactiveTeamSubscription = computed(

--- a/src/platform/workspace/composables/useBillingCapabilities.test.ts
+++ b/src/platform/workspace/composables/useBillingCapabilities.test.ts
@@ -1,0 +1,929 @@
+import type { BillingCapabilitiesResponse } from '@comfyorg/ingest-types'
+import type { AxiosResponse, InternalAxiosRequestConfig } from 'axios'
+import axios, { AxiosError, AxiosHeaders } from 'axios'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { effectScope } from 'vue'
+import type { EffectScope } from 'vue'
+
+import { attachCapabilityRevisionInterceptor } from '@/platform/workspace/api/capabilityRevision'
+
+import { useBillingCapabilities } from './useBillingCapabilities'
+
+const mockGetBillingCapabilities = vi.hoisted(() => vi.fn())
+const mockReportError = vi.hoisted(() => vi.fn())
+const mockIsCloud = vi.hoisted(() => ({ value: true }))
+const mockScope = vi.hoisted(() => ({
+  workspaceId: 'workspace-1' as string | null,
+  authUid: 'firebase-user-1' as string | null,
+  role: 'owner' as 'owner' | 'member'
+}))
+
+vi.mock('@/platform/workspace/api/workspaceApi', () => ({
+  WorkspaceApiError: class WorkspaceApiError extends Error {
+    constructor(
+      message: string,
+      public readonly status?: number
+    ) {
+      super(message)
+      this.name = 'WorkspaceApiError'
+    }
+  },
+  workspaceApi: { getBillingCapabilities: mockGetBillingCapabilities }
+}))
+
+vi.mock('@/platform/telemetry/reportError', () => ({
+  reportError: mockReportError
+}))
+
+vi.mock('@/platform/distribution/types', () => ({
+  get isCloud() {
+    return mockIsCloud.value
+  }
+}))
+
+vi.mock('@/platform/workspace/stores/teamWorkspaceStore', () => ({
+  useTeamWorkspaceStore: () => ({
+    get activeWorkspaceId() {
+      return mockScope.workspaceId
+    },
+    get activeWorkspace() {
+      return mockScope.workspaceId
+        ? { id: mockScope.workspaceId, role: mockScope.role }
+        : null
+    }
+  })
+}))
+
+vi.mock('@/stores/authStore', () => ({
+  useAuthStore: () => ({
+    get currentUser() {
+      return mockScope.authUid ? { uid: mockScope.authUid } : null
+    }
+  })
+}))
+
+function capabilitiesResponse(
+  canTopUp: boolean,
+  workspaceId = 'workspace-1',
+  canSubscribeSelfServe = true,
+  freshness: { expiresAt?: string; revision?: number } = {}
+): BillingCapabilitiesResponse {
+  return {
+    resolved_for: {
+      user_id: 'canonical-user-1',
+      workspace_id: workspaceId
+    },
+    capabilities: {
+      can_subscribe_self_serve: canSubscribeSelfServe,
+      can_top_up: canTopUp,
+      can_cancel: true,
+      can_reactivate: true,
+      can_change_seats: true,
+      can_invite_members: true,
+      can_downgrade_to_personal: false
+    },
+    rollout_defaults_applied: {
+      can_downgrade_to_personal: false,
+      can_subscribe_self_serve: false,
+      can_top_up: false
+    },
+    revision: freshness.revision ?? 1,
+    expires_at: freshness.expiresAt ?? '2099-01-01T00:00:00Z'
+  }
+}
+
+function expiresIn(ms: number): string {
+  return new Date(Date.now() + ms).toISOString()
+}
+
+/** Drives a mutation response through the shared capability-revision interceptor. */
+async function emitMutationRevision(
+  revision: string | undefined,
+  status = 200
+): Promise<void> {
+  const client = axios.create()
+  client.defaults.adapter = (config: InternalAxiosRequestConfig) => {
+    const response: AxiosResponse = {
+      data: {},
+      status,
+      statusText: '',
+      headers: new AxiosHeaders(
+        revision === undefined ? {} : { 'X-Capability-Revision': revision }
+      ),
+      config
+    }
+    return status >= 400
+      ? Promise.reject(
+          new AxiosError(
+            'Request failed',
+            'ERR_BAD_REQUEST',
+            config,
+            {},
+            response
+          )
+        )
+      : Promise.resolve(response)
+  }
+  attachCapabilityRevisionInterceptor(client)
+  await client.post('/api/billing/subscribe').catch(() => {})
+  await vi.advanceTimersByTimeAsync(0)
+}
+
+/**
+ * Serves capability reads through the shared revision interceptor the way the
+ * real client does: the response carries the revision matching its body, and
+ * axios publishes it before the awaited GET resolves. Reads settle only when
+ * released, so a read that invalidates itself surfaces as one extra call
+ * instead of an unbounded loop.
+ */
+function capabilityReadsThroughInterceptor() {
+  const pending: Array<(data: BillingCapabilitiesResponse) => void> = []
+  const client = axios.create()
+  client.defaults.adapter = (config: InternalAxiosRequestConfig) =>
+    new Promise<AxiosResponse>((resolve) => {
+      pending.push((data) =>
+        resolve({
+          data,
+          status: 200,
+          statusText: '',
+          headers: new AxiosHeaders({
+            'X-Capability-Revision': String(data.revision)
+          }),
+          config
+        })
+      )
+    })
+  attachCapabilityRevisionInterceptor(client)
+
+  return {
+    read: async (): Promise<BillingCapabilitiesResponse> =>
+      (
+        await client.get<BillingCapabilitiesResponse>(
+          '/api/billing/capabilities'
+        )
+      ).data,
+    async release(data: BillingCapabilitiesResponse): Promise<void> {
+      await vi.advanceTimersByTimeAsync(0)
+      pending.shift()!(data)
+      await vi.advanceTimersByTimeAsync(0)
+    }
+  }
+}
+
+describe('useBillingCapabilities', () => {
+  let scope: EffectScope
+  let billingCapabilities: ReturnType<typeof useBillingCapabilities>
+
+  beforeEach(() => {
+    mockIsCloud.value = true
+    mockScope.workspaceId = 'workspace-1'
+    mockScope.authUid = 'firebase-user-1'
+    mockScope.role = 'owner'
+    scope = effectScope()
+    billingCapabilities = scope.run(() => useBillingCapabilities())!
+  })
+
+  afterEach(() => scope.stop())
+
+  it('denies Cloud actions while loading, then applies the server capability', async () => {
+    let resolveRequest!: (value: BillingCapabilitiesResponse) => void
+    mockGetBillingCapabilities.mockImplementationOnce(
+      () =>
+        new Promise<BillingCapabilitiesResponse>((resolve) => {
+          resolveRequest = resolve
+        })
+    )
+
+    expect(billingCapabilities.canTopUp.value).toBe(false)
+    expect(billingCapabilities.canSubscribeSelfServe.value).toBe(false)
+
+    const initialization = billingCapabilities.initialize()
+    expect(billingCapabilities.canTopUp.value).toBe(false)
+    expect(billingCapabilities.canSubscribeSelfServe.value).toBe(false)
+
+    resolveRequest(capabilitiesResponse(true))
+    await initialization
+    expect(billingCapabilities.canTopUp.value).toBe(true)
+    expect(billingCapabilities.canSubscribeSelfServe.value).toBe(true)
+  })
+
+  it('applies changed capabilities when the current scope is refreshed', async () => {
+    mockGetBillingCapabilities
+      .mockResolvedValueOnce(capabilitiesResponse(false, 'workspace-1', true))
+      .mockResolvedValueOnce(capabilitiesResponse(true, 'workspace-1', false))
+
+    await billingCapabilities.initialize()
+    expect(billingCapabilities.canTopUp.value).toBe(false)
+    expect(billingCapabilities.canSubscribeSelfServe.value).toBe(true)
+
+    await billingCapabilities.refresh()
+    expect(billingCapabilities.canTopUp.value).toBe(true)
+    expect(billingCapabilities.canSubscribeSelfServe.value).toBe(false)
+  })
+
+  it('forwards the initialization signal to the capability request', async () => {
+    const controller = new AbortController()
+    mockGetBillingCapabilities.mockResolvedValueOnce(capabilitiesResponse(true))
+
+    await billingCapabilities.initialize(controller.signal)
+
+    expect(mockGetBillingCapabilities).toHaveBeenCalledWith(
+      expect.any(AbortSignal)
+    )
+  })
+
+  it('keeps top-up available for owners when the endpoint is unavailable', async () => {
+    mockGetBillingCapabilities.mockRejectedValueOnce(new Error('unavailable'))
+
+    await billingCapabilities.initialize()
+
+    expect(billingCapabilities.canTopUp.value).toBe(true)
+    expect(billingCapabilities.canSubscribeSelfServe.value).toBe(false)
+    expect(billingCapabilities.isReady.value).toBe(true)
+    expect(mockReportError).toHaveBeenCalledOnce()
+  })
+
+  it('withholds top-up from members when the endpoint is unavailable', async () => {
+    mockScope.role = 'member'
+    mockGetBillingCapabilities.mockRejectedValueOnce(new Error('unavailable'))
+
+    await billingCapabilities.initialize()
+
+    expect(billingCapabilities.canTopUp.value).toBe(false)
+    expect(billingCapabilities.canSubscribeSelfServe.value).toBe(false)
+    expect(billingCapabilities.isReady.value).toBe(true)
+  })
+
+  it('fails closed when the endpoint denies the current actor', async () => {
+    const { WorkspaceApiError } =
+      await import('@/platform/workspace/api/workspaceApi')
+    mockGetBillingCapabilities.mockRejectedValueOnce(
+      new WorkspaceApiError('Forbidden', 403)
+    )
+
+    await billingCapabilities.initialize()
+
+    expect(billingCapabilities.canTopUp.value).toBe(false)
+    expect(billingCapabilities.canSubscribeSelfServe.value).toBe(false)
+    expect(billingCapabilities.isReady.value).toBe(true)
+  })
+
+  it('does not fail open when capability loading is aborted', async () => {
+    const controller = new AbortController()
+    mockGetBillingCapabilities.mockImplementationOnce(
+      (signal: AbortSignal) =>
+        new Promise<BillingCapabilitiesResponse>((_, reject) => {
+          signal.addEventListener('abort', () => reject(new Error('aborted')), {
+            once: true
+          })
+        })
+    )
+
+    const initialization = billingCapabilities.initialize(controller.signal)
+    controller.abort()
+    await initialization
+
+    expect(billingCapabilities.canTopUp.value).toBe(false)
+    expect(billingCapabilities.isReady.value).toBe(false)
+    expect(mockReportError).not.toHaveBeenCalled()
+  })
+
+  it('discards a response resolved for a different workspace', async () => {
+    mockGetBillingCapabilities.mockResolvedValueOnce(
+      capabilitiesResponse(false, 'workspace-2')
+    )
+
+    await billingCapabilities.initialize()
+
+    expect(mockGetBillingCapabilities).toHaveBeenCalledOnce()
+    expect(billingCapabilities.canTopUp.value).toBe(true)
+    expect(billingCapabilities.canSubscribeSelfServe.value).toBe(false)
+  })
+
+  it('discards a stale response after the active workspace changes', async () => {
+    let resolveFirstRequest!: (value: BillingCapabilitiesResponse) => void
+    mockGetBillingCapabilities
+      .mockImplementationOnce(
+        () =>
+          new Promise<BillingCapabilitiesResponse>((resolve) => {
+            resolveFirstRequest = resolve
+          })
+      )
+      .mockResolvedValueOnce(capabilitiesResponse(false, 'workspace-2', false))
+
+    const firstInitialization = billingCapabilities.initialize()
+    mockScope.workspaceId = 'workspace-2'
+    await billingCapabilities.initialize()
+
+    resolveFirstRequest(capabilitiesResponse(true, 'workspace-1', true))
+    await firstInitialization
+
+    expect(mockGetBillingCapabilities).toHaveBeenCalledTimes(2)
+    expect(billingCapabilities.canTopUp.value).toBe(false)
+    expect(billingCapabilities.canSubscribeSelfServe.value).toBe(false)
+  })
+
+  it('keeps local top-up available without calling the Cloud endpoint', async () => {
+    mockIsCloud.value = false
+
+    await billingCapabilities.initialize()
+
+    expect(billingCapabilities.canTopUp.value).toBe(true)
+    expect(billingCapabilities.canSubscribeSelfServe.value).toBe(false)
+    expect(mockGetBillingCapabilities).not.toHaveBeenCalled()
+  })
+
+  it('preserves the local role gate for workspace members', async () => {
+    mockIsCloud.value = false
+    mockScope.role = 'member'
+
+    await billingCapabilities.initialize()
+
+    expect(billingCapabilities.canTopUp.value).toBe(false)
+    expect(billingCapabilities.isReady.value).toBe(true)
+    expect(mockGetBillingCapabilities).not.toHaveBeenCalled()
+  })
+
+  it('does not enter pending state without an authenticated scope', async () => {
+    mockScope.workspaceId = null
+
+    await billingCapabilities.initialize()
+
+    expect(billingCapabilities.canTopUp.value).toBe(false)
+    expect(billingCapabilities.isReady.value).toBe(false)
+    expect(mockGetBillingCapabilities).not.toHaveBeenCalled()
+  })
+
+  it('accepts a canonical server user ID distinct from the Firebase UID', async () => {
+    mockGetBillingCapabilities.mockResolvedValueOnce(
+      capabilitiesResponse(false)
+    )
+
+    await billingCapabilities.initialize()
+
+    expect(billingCapabilities.canTopUp.value).toBe(false)
+  })
+
+  it('refetches the capability snapshot once the server snapshot expires', async () => {
+    mockGetBillingCapabilities
+      .mockResolvedValueOnce(
+        capabilitiesResponse(false, 'workspace-1', true, {
+          expiresAt: expiresIn(30_000)
+        })
+      )
+      .mockResolvedValueOnce(
+        capabilitiesResponse(true, 'workspace-1', true, {
+          expiresAt: expiresIn(90_000)
+        })
+      )
+
+    await billingCapabilities.initialize()
+    expect(billingCapabilities.canTopUp.value).toBe(false)
+
+    await vi.advanceTimersByTimeAsync(30_000)
+
+    expect(mockGetBillingCapabilities).toHaveBeenCalledTimes(2)
+    expect(billingCapabilities.canTopUp.value).toBe(true)
+  })
+
+  it('defers the refresh until a hidden tab becomes visible again', async () => {
+    const visibility = vi
+      .spyOn(document, 'visibilityState', 'get')
+      .mockReturnValue('hidden')
+    mockGetBillingCapabilities
+      .mockResolvedValueOnce(
+        capabilitiesResponse(false, 'workspace-1', true, {
+          expiresAt: expiresIn(30_000)
+        })
+      )
+      .mockResolvedValueOnce(capabilitiesResponse(true))
+
+    await billingCapabilities.initialize()
+    await vi.advanceTimersByTimeAsync(120_000)
+    expect(mockGetBillingCapabilities).toHaveBeenCalledOnce()
+
+    visibility.mockReturnValue('visible')
+    document.dispatchEvent(new Event('visibilitychange'))
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(mockGetBillingCapabilities).toHaveBeenCalledTimes(2)
+    expect(billingCapabilities.canTopUp.value).toBe(true)
+  })
+
+  it('reschedules for the remaining lifetime when the tab returns before expiry', async () => {
+    const visibility = vi
+      .spyOn(document, 'visibilityState', 'get')
+      .mockReturnValue('visible')
+    mockGetBillingCapabilities
+      .mockResolvedValueOnce(
+        capabilitiesResponse(false, 'workspace-1', true, {
+          expiresAt: expiresIn(30_000)
+        })
+      )
+      .mockResolvedValueOnce(capabilitiesResponse(true))
+
+    await billingCapabilities.initialize()
+
+    visibility.mockReturnValue('hidden')
+    document.dispatchEvent(new Event('visibilitychange'))
+    await vi.advanceTimersByTimeAsync(10_000)
+
+    visibility.mockReturnValue('visible')
+    document.dispatchEvent(new Event('visibilitychange'))
+
+    await vi.advanceTimersByTimeAsync(19_000)
+    expect(mockGetBillingCapabilities).toHaveBeenCalledOnce()
+
+    await vi.advanceTimersByTimeAsync(2_000)
+    expect(mockGetBillingCapabilities).toHaveBeenCalledTimes(2)
+  })
+
+  it('retimes the refresh for the new workspace after a workspace switch', async () => {
+    mockGetBillingCapabilities
+      .mockResolvedValueOnce(
+        capabilitiesResponse(false, 'workspace-1', true, {
+          expiresAt: expiresIn(30_000)
+        })
+      )
+      .mockResolvedValueOnce(
+        capabilitiesResponse(false, 'workspace-2', true, {
+          expiresAt: expiresIn(120_000)
+        })
+      )
+      .mockResolvedValueOnce(
+        capabilitiesResponse(true, 'workspace-2', true, {
+          expiresAt: expiresIn(600_000)
+        })
+      )
+
+    await billingCapabilities.initialize()
+    mockScope.workspaceId = 'workspace-2'
+    await billingCapabilities.initialize()
+    expect(mockGetBillingCapabilities).toHaveBeenCalledTimes(2)
+
+    await vi.advanceTimersByTimeAsync(60_000)
+    expect(mockGetBillingCapabilities).toHaveBeenCalledTimes(2)
+
+    await vi.advanceTimersByTimeAsync(65_000)
+    expect(mockGetBillingCapabilities).toHaveBeenCalledTimes(3)
+    expect(billingCapabilities.canTopUp.value).toBe(true)
+  })
+
+  it('stops refreshing once the shared composable scope is disposed', async () => {
+    mockGetBillingCapabilities
+      .mockResolvedValueOnce(
+        capabilitiesResponse(false, 'workspace-1', true, {
+          expiresAt: expiresIn(30_000)
+        })
+      )
+      .mockResolvedValueOnce(
+        capabilitiesResponse(true, 'workspace-1', true, {
+          expiresAt: expiresIn(90_000)
+        })
+      )
+
+    await billingCapabilities.initialize()
+    await vi.advanceTimersByTimeAsync(30_000)
+    expect(mockGetBillingCapabilities).toHaveBeenCalledTimes(2)
+
+    scope.stop()
+    await vi.advanceTimersByTimeAsync(300_000)
+
+    expect(mockGetBillingCapabilities).toHaveBeenCalledTimes(2)
+  })
+
+  it('refetches when a mutation reports a different capability revision', async () => {
+    mockGetBillingCapabilities
+      .mockResolvedValueOnce(
+        capabilitiesResponse(false, 'workspace-1', true, { revision: 4 })
+      )
+      .mockResolvedValueOnce(
+        capabilitiesResponse(true, 'workspace-1', true, { revision: 5 })
+      )
+
+    await billingCapabilities.initialize()
+    expect(billingCapabilities.canTopUp.value).toBe(false)
+
+    await emitMutationRevision('5')
+
+    expect(mockGetBillingCapabilities).toHaveBeenCalledTimes(2)
+    expect(billingCapabilities.canTopUp.value).toBe(true)
+  })
+
+  it('refetches when a failed mutation reports a different capability revision', async () => {
+    mockGetBillingCapabilities
+      .mockResolvedValueOnce(
+        capabilitiesResponse(false, 'workspace-1', true, { revision: 4 })
+      )
+      .mockResolvedValueOnce(
+        capabilitiesResponse(true, 'workspace-1', true, { revision: 5 })
+      )
+
+    await billingCapabilities.initialize()
+
+    await emitMutationRevision('5', 402)
+
+    expect(mockGetBillingCapabilities).toHaveBeenCalledTimes(2)
+    expect(billingCapabilities.canTopUp.value).toBe(true)
+  })
+
+  it('ignores a mutation that reports the cached capability revision', async () => {
+    mockGetBillingCapabilities
+      .mockResolvedValueOnce(
+        capabilitiesResponse(false, 'workspace-1', true, { revision: 4 })
+      )
+      .mockResolvedValueOnce(
+        capabilitiesResponse(true, 'workspace-1', true, { revision: 6 })
+      )
+
+    await billingCapabilities.initialize()
+
+    await emitMutationRevision('4')
+    expect(mockGetBillingCapabilities).toHaveBeenCalledOnce()
+
+    await emitMutationRevision('6')
+    expect(mockGetBillingCapabilities).toHaveBeenCalledTimes(2)
+  })
+
+  it('ignores a mutation whose response omits the revision header', async () => {
+    mockGetBillingCapabilities
+      .mockResolvedValueOnce(
+        capabilitiesResponse(false, 'workspace-1', true, { revision: 4 })
+      )
+      .mockResolvedValueOnce(
+        capabilitiesResponse(true, 'workspace-1', true, { revision: 6 })
+      )
+
+    await billingCapabilities.initialize()
+
+    await emitMutationRevision(undefined)
+    expect(mockGetBillingCapabilities).toHaveBeenCalledOnce()
+    expect(billingCapabilities.canTopUp.value).toBe(false)
+
+    await emitMutationRevision('6')
+    expect(mockGetBillingCapabilities).toHaveBeenCalledTimes(2)
+  })
+
+  it('keeps the resolved snapshot readable while a background refresh is in flight', async () => {
+    let resolveRefresh!: (value: BillingCapabilitiesResponse) => void
+    mockGetBillingCapabilities
+      .mockResolvedValueOnce(
+        capabilitiesResponse(true, 'workspace-1', true, {
+          expiresAt: expiresIn(30_000)
+        })
+      )
+      .mockImplementationOnce(
+        () =>
+          new Promise<BillingCapabilitiesResponse>((resolve) => {
+            resolveRefresh = resolve
+          })
+      )
+
+    await billingCapabilities.initialize()
+    expect(billingCapabilities.canTopUp.value).toBe(true)
+
+    await vi.advanceTimersByTimeAsync(30_000)
+    expect(mockGetBillingCapabilities).toHaveBeenCalledTimes(2)
+    expect(billingCapabilities.canTopUp.value).toBe(true)
+    expect(billingCapabilities.canSubscribeSelfServe.value).toBe(true)
+    expect(billingCapabilities.isReady.value).toBe(true)
+
+    resolveRefresh(
+      capabilitiesResponse(false, 'workspace-1', false, {
+        expiresAt: expiresIn(60_000)
+      })
+    )
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(billingCapabilities.canTopUp.value).toBe(false)
+    expect(billingCapabilities.canSubscribeSelfServe.value).toBe(false)
+  })
+
+  it('keeps the last good snapshot when a background refresh fails', async () => {
+    mockGetBillingCapabilities
+      .mockResolvedValueOnce(
+        capabilitiesResponse(true, 'workspace-1', true, {
+          expiresAt: expiresIn(30_000)
+        })
+      )
+      .mockRejectedValueOnce(new Error('unavailable'))
+
+    await billingCapabilities.initialize()
+    await vi.advanceTimersByTimeAsync(30_000)
+
+    expect(mockGetBillingCapabilities).toHaveBeenCalledTimes(2)
+    expect(billingCapabilities.canTopUp.value).toBe(true)
+    expect(billingCapabilities.canSubscribeSelfServe.value).toBe(true)
+    expect(billingCapabilities.isReady.value).toBe(true)
+    expect(mockReportError).toHaveBeenCalledOnce()
+  })
+
+  it('retries on a fixed interval after a background refresh fails', async () => {
+    mockGetBillingCapabilities
+      .mockResolvedValueOnce(
+        capabilitiesResponse(true, 'workspace-1', true, {
+          expiresAt: expiresIn(30_000)
+        })
+      )
+      .mockRejectedValueOnce(new Error('unavailable'))
+      .mockResolvedValueOnce(
+        capabilitiesResponse(false, 'workspace-1', false, {
+          expiresAt: expiresIn(180_000)
+        })
+      )
+
+    await billingCapabilities.initialize()
+    await vi.advanceTimersByTimeAsync(30_000)
+    expect(mockGetBillingCapabilities).toHaveBeenCalledTimes(2)
+
+    await vi.advanceTimersByTimeAsync(59_000)
+    expect(mockGetBillingCapabilities).toHaveBeenCalledTimes(2)
+
+    await vi.advanceTimersByTimeAsync(2_000)
+    expect(mockGetBillingCapabilities).toHaveBeenCalledTimes(3)
+    expect(billingCapabilities.canTopUp.value).toBe(false)
+  })
+
+  it('replaces the snapshot when a background refresh is denied', async () => {
+    const { WorkspaceApiError } =
+      await import('@/platform/workspace/api/workspaceApi')
+    mockGetBillingCapabilities
+      .mockResolvedValueOnce(
+        capabilitiesResponse(true, 'workspace-1', true, {
+          expiresAt: expiresIn(30_000)
+        })
+      )
+      .mockRejectedValueOnce(new WorkspaceApiError('Forbidden', 403))
+
+    await billingCapabilities.initialize()
+    await vi.advanceTimersByTimeAsync(30_000)
+
+    expect(billingCapabilities.canTopUp.value).toBe(false)
+    expect(billingCapabilities.canSubscribeSelfServe.value).toBe(false)
+    expect(billingCapabilities.isReady.value).toBe(true)
+  })
+
+  it('paces the refresh on a fixed interval when the snapshot arrives expired', async () => {
+    mockGetBillingCapabilities.mockResolvedValue(
+      capabilitiesResponse(true, 'workspace-1', true, {
+        expiresAt: expiresIn(-60_000)
+      })
+    )
+
+    await billingCapabilities.initialize()
+    expect(mockGetBillingCapabilities).toHaveBeenCalledOnce()
+
+    await vi.advanceTimersByTimeAsync(59_000)
+    expect(mockGetBillingCapabilities).toHaveBeenCalledOnce()
+
+    await vi.advanceTimersByTimeAsync(2_000)
+    expect(mockGetBillingCapabilities).toHaveBeenCalledTimes(2)
+  })
+
+  it('bounds the refresh interval when the client clock lags the server', async () => {
+    mockGetBillingCapabilities.mockResolvedValue(
+      capabilitiesResponse(true, 'workspace-1', true, {
+        expiresAt: expiresIn(7 * 24 * 60 * 60 * 1000)
+      })
+    )
+
+    await billingCapabilities.initialize()
+
+    await vi.advanceTimersByTimeAsync(60 * 60 * 1000 + 1_000)
+
+    expect(mockGetBillingCapabilities).toHaveBeenCalledTimes(2)
+  })
+
+  it('paces the refresh on a fixed interval when the snapshot expiry is unparseable', async () => {
+    mockGetBillingCapabilities.mockResolvedValue(
+      capabilitiesResponse(true, 'workspace-1', true, {
+        expiresAt: 'not-a-timestamp'
+      })
+    )
+
+    await billingCapabilities.initialize()
+    expect(mockGetBillingCapabilities).toHaveBeenCalledOnce()
+
+    await vi.advanceTimersByTimeAsync(59_000)
+    expect(mockGetBillingCapabilities).toHaveBeenCalledOnce()
+
+    await vi.advanceTimersByTimeAsync(2_000)
+    expect(mockGetBillingCapabilities).toHaveBeenCalledTimes(2)
+  })
+
+  it('refetches a read that a mutation invalidated while it was in flight', async () => {
+    let resolveRefresh!: (value: BillingCapabilitiesResponse) => void
+    mockGetBillingCapabilities
+      .mockResolvedValueOnce(
+        capabilitiesResponse(false, 'workspace-1', true, {
+          revision: 4,
+          expiresAt: expiresIn(30_000)
+        })
+      )
+      .mockImplementationOnce(
+        () =>
+          new Promise<BillingCapabilitiesResponse>((resolve) => {
+            resolveRefresh = resolve
+          })
+      )
+      .mockResolvedValue(
+        capabilitiesResponse(true, 'workspace-1', true, {
+          revision: 8,
+          expiresAt: expiresIn(3_600_000)
+        })
+      )
+
+    await billingCapabilities.initialize()
+    await vi.advanceTimersByTimeAsync(30_000)
+    expect(mockGetBillingCapabilities).toHaveBeenCalledTimes(2)
+
+    await emitMutationRevision('5')
+    expect(mockGetBillingCapabilities).toHaveBeenCalledTimes(2)
+
+    // Serialized after the mutation stamped its header, so it carries a higher
+    // revision than the mutation despite having read pre-mutation data.
+    resolveRefresh(
+      capabilitiesResponse(false, 'workspace-1', true, {
+        revision: 7,
+        expiresAt: expiresIn(3_600_000)
+      })
+    )
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(mockGetBillingCapabilities).toHaveBeenCalledTimes(3)
+    expect(billingCapabilities.canTopUp.value).toBe(true)
+
+    await vi.advanceTimersByTimeAsync(600_000)
+    expect(mockGetBillingCapabilities).toHaveBeenCalledTimes(3)
+  })
+
+  it('refetches when a mutation invalidates the initial read', async () => {
+    let resolveInitial!: (value: BillingCapabilitiesResponse) => void
+    mockGetBillingCapabilities
+      .mockImplementationOnce(
+        () =>
+          new Promise<BillingCapabilitiesResponse>((resolve) => {
+            resolveInitial = resolve
+          })
+      )
+      .mockResolvedValueOnce(
+        capabilitiesResponse(true, 'workspace-1', true, { revision: 9 })
+      )
+
+    const initialization = billingCapabilities.initialize()
+    await emitMutationRevision('5')
+    expect(mockGetBillingCapabilities).toHaveBeenCalledOnce()
+
+    resolveInitial(
+      capabilitiesResponse(false, 'workspace-1', true, { revision: 7 })
+    )
+    await initialization
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(mockGetBillingCapabilities).toHaveBeenCalledTimes(2)
+    expect(billingCapabilities.canTopUp.value).toBe(true)
+  })
+
+  it('does not refetch a read whose own response reports its revision', async () => {
+    const reads = capabilityReadsThroughInterceptor()
+    mockGetBillingCapabilities.mockImplementation(reads.read)
+
+    const initialization = billingCapabilities.initialize()
+    await reads.release(
+      capabilitiesResponse(true, 'workspace-1', true, { revision: 4 })
+    )
+    await initialization
+
+    expect(mockGetBillingCapabilities).toHaveBeenCalledOnce()
+    expect(billingCapabilities.canTopUp.value).toBe(true)
+  })
+
+  it('refetches an interceptor-served read that a mutation invalidated in flight', async () => {
+    const reads = capabilityReadsThroughInterceptor()
+    mockGetBillingCapabilities.mockImplementation(reads.read)
+
+    const initialization = billingCapabilities.initialize()
+    await emitMutationRevision('5')
+    expect(mockGetBillingCapabilities).toHaveBeenCalledOnce()
+
+    // Serialized after the mutation stamped its header, so it carries a higher
+    // revision than the mutation despite having read pre-mutation data.
+    await reads.release(
+      capabilitiesResponse(false, 'workspace-1', true, { revision: 7 })
+    )
+    await initialization
+    expect(mockGetBillingCapabilities).toHaveBeenCalledTimes(2)
+
+    await reads.release(
+      capabilitiesResponse(true, 'workspace-1', true, { revision: 8 })
+    )
+
+    expect(mockGetBillingCapabilities).toHaveBeenCalledTimes(2)
+    expect(billingCapabilities.canTopUp.value).toBe(true)
+  })
+
+  it('retries an unreadable endpoint until the read succeeds', async () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0)
+    mockGetBillingCapabilities
+      .mockRejectedValueOnce(new Error('unavailable'))
+      .mockResolvedValueOnce(capabilitiesResponse(true))
+
+    await billingCapabilities.initialize()
+    expect(billingCapabilities.canSubscribeSelfServe.value).toBe(false)
+
+    await vi.advanceTimersByTimeAsync(31_000)
+
+    expect(mockGetBillingCapabilities).toHaveBeenCalledTimes(2)
+    expect(billingCapabilities.canSubscribeSelfServe.value).toBe(true)
+  })
+
+  it('backs off between retries and reports the outage once', async () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0)
+    mockGetBillingCapabilities.mockRejectedValue(new Error('unavailable'))
+
+    await billingCapabilities.initialize()
+    expect(mockGetBillingCapabilities).toHaveBeenCalledOnce()
+
+    await vi.advanceTimersByTimeAsync(29_000)
+    expect(mockGetBillingCapabilities).toHaveBeenCalledOnce()
+
+    await vi.advanceTimersByTimeAsync(2_000)
+    expect(mockGetBillingCapabilities).toHaveBeenCalledTimes(2)
+
+    await vi.advanceTimersByTimeAsync(58_000)
+    expect(mockGetBillingCapabilities).toHaveBeenCalledTimes(2)
+
+    await vi.advanceTimersByTimeAsync(2_000)
+    expect(mockGetBillingCapabilities).toHaveBeenCalledTimes(3)
+
+    await vi.advanceTimersByTimeAsync(118_000)
+    expect(mockGetBillingCapabilities).toHaveBeenCalledTimes(3)
+
+    await vi.advanceTimersByTimeAsync(2_000)
+    expect(mockGetBillingCapabilities).toHaveBeenCalledTimes(4)
+
+    expect(mockReportError).toHaveBeenCalledOnce()
+  })
+
+  it('keeps the owner top-up fallback readable while a retry is in flight', async () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0)
+    let resolveRetry!: (value: BillingCapabilitiesResponse) => void
+    mockGetBillingCapabilities
+      .mockRejectedValueOnce(new Error('unavailable'))
+      .mockImplementationOnce(
+        () =>
+          new Promise<BillingCapabilitiesResponse>((resolve) => {
+            resolveRetry = resolve
+          })
+      )
+
+    await billingCapabilities.initialize()
+    expect(billingCapabilities.canTopUp.value).toBe(true)
+
+    await vi.advanceTimersByTimeAsync(31_000)
+    expect(mockGetBillingCapabilities).toHaveBeenCalledTimes(2)
+    expect(billingCapabilities.canTopUp.value).toBe(true)
+    expect(billingCapabilities.isReady.value).toBe(true)
+
+    resolveRetry(capabilitiesResponse(true))
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(billingCapabilities.canSubscribeSelfServe.value).toBe(true)
+  })
+
+  it('retries as soon as a hidden tab with an unreadable endpoint returns', async () => {
+    const visibility = vi
+      .spyOn(document, 'visibilityState', 'get')
+      .mockReturnValue('hidden')
+    mockGetBillingCapabilities
+      .mockRejectedValueOnce(new Error('unavailable'))
+      .mockResolvedValueOnce(capabilitiesResponse(true))
+
+    await billingCapabilities.initialize()
+    await vi.advanceTimersByTimeAsync(600_000)
+    expect(mockGetBillingCapabilities).toHaveBeenCalledOnce()
+
+    visibility.mockReturnValue('visible')
+    document.dispatchEvent(new Event('visibilitychange'))
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(mockGetBillingCapabilities).toHaveBeenCalledTimes(2)
+    expect(billingCapabilities.canSubscribeSelfServe.value).toBe(true)
+  })
+
+  it('does not retry a denial', async () => {
+    const { WorkspaceApiError } =
+      await import('@/platform/workspace/api/workspaceApi')
+    mockGetBillingCapabilities.mockRejectedValue(
+      new WorkspaceApiError('Forbidden', 403)
+    )
+
+    await billingCapabilities.initialize()
+    expect(mockGetBillingCapabilities).toHaveBeenCalledOnce()
+
+    await vi.advanceTimersByTimeAsync(600_000)
+
+    expect(mockGetBillingCapabilities).toHaveBeenCalledOnce()
+    expect(billingCapabilities.canTopUp.value).toBe(false)
+  })
+})

--- a/src/platform/workspace/composables/useBillingCapabilities.ts
+++ b/src/platform/workspace/composables/useBillingCapabilities.ts
@@ -1,0 +1,400 @@
+import type { BillingCapabilitiesResponse } from '@comfyorg/ingest-types'
+import {
+  createSharedComposable,
+  defaultDocument,
+  useEventListener
+} from '@vueuse/core'
+import { computed, onScopeDispose, shallowRef, watch } from 'vue'
+
+import { isCloud } from '@/platform/distribution/types'
+import { reportError } from '@/platform/telemetry/reportError'
+import { onCapabilityRevision } from '@/platform/workspace/api/capabilityRevision'
+import {
+  WorkspaceApiError,
+  workspaceApi
+} from '@/platform/workspace/api/workspaceApi'
+import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
+import { useAuthStore } from '@/stores/authStore'
+
+type CapabilityReadState =
+  | { status: 'idle' }
+  | {
+      status: 'pending' | 'denied'
+      authUid: string
+      workspaceId: string
+    }
+  | {
+      status: 'unavailable'
+      authUid: string
+      workspaceId: string
+      retryAt: number
+    }
+  | {
+      status: 'resolved'
+      authUid: string
+      workspaceId: string
+      response: BillingCapabilitiesResponse
+      refreshAt: number
+    }
+
+// A remaining lifetime below the floor means the client clock disagrees with
+// the server's, so it cannot pace the refetch and the fixed interval is used
+// instead; clamping it would only slow the loop. The ceiling bounds the
+// opposite skew, where a lagging clock reads expires_at as far in the future.
+const MIN_REFRESH_DELAY_MS = 5_000
+const MAX_REFRESH_DELAY_MS = 60 * 60 * 1000
+const FALLBACK_REFRESH_DELAY_MS = 60_000
+// An outage fails every visible session at once, so a flat retry interval would
+// keep them retrying in lockstep. Consecutive failures double up to this
+// ceiling, and each delay is jittered to spread the sessions apart.
+const MAX_RETRY_DELAY_MS = 5 * 60 * 1000
+
+interface ActiveCapabilityRequest {
+  requestId: number
+  authUid: string
+  workspaceId: string
+  controller: AbortController
+  promise: Promise<void>
+}
+
+function useBillingCapabilitiesInternal() {
+  const authStore = useAuthStore()
+  const workspaceStore = useTeamWorkspaceStore()
+  const readState = shallowRef<CapabilityReadState>({ status: 'idle' })
+  let initialized = false
+  let latestRequestId = 0
+  let activeRequest: ActiveCapabilityRequest | null = null
+  let refreshTimer: ReturnType<typeof setTimeout> | null = null
+  let readFailures = 0
+  let invalidatedRequestId = 0
+
+  const capabilities = computed(() => {
+    const userId = authStore.currentUser?.uid
+    const workspaceId = workspaceStore.activeWorkspaceId
+    const state = readState.value
+    if (
+      !userId ||
+      !workspaceId ||
+      state.status !== 'resolved' ||
+      state.authUid !== userId ||
+      state.workspaceId !== workspaceId ||
+      state.response.resolved_for.workspace_id !== workspaceId
+    ) {
+      return null
+    }
+
+    return state.response.capabilities
+  })
+  const readUnavailableForCurrentScope = computed(() => {
+    const state = readState.value
+    return (
+      state.status === 'unavailable' &&
+      state.authUid === authStore.currentUser?.uid &&
+      state.workspaceId === workspaceStore.activeWorkspaceId
+    )
+  })
+  const canTopUp = computed(() => {
+    if (!isCloud) return workspaceStore.activeWorkspace?.role !== 'member'
+    // An unreadable capability keeps top-up available only for owners, so a
+    // transient outage does not strand the one role that can actually top up.
+    // Every other role - including an unresolved one - fails closed.
+    return (
+      capabilities.value?.can_top_up ??
+      (readUnavailableForCurrentScope.value &&
+        workspaceStore.activeWorkspace?.role === 'owner')
+    )
+  })
+  const canSubscribeSelfServe = computed(
+    () => isCloud && (capabilities.value?.can_subscribe_self_serve ?? false)
+  )
+  const isReady = computed(() => {
+    if (!isCloud) return true
+    const state = readState.value
+    if (state.status === 'idle' || state.status === 'pending') return false
+    return (
+      state.authUid === authStore.currentUser?.uid &&
+      state.workspaceId === workspaceStore.activeWorkspaceId
+    )
+  })
+
+  function clearRefreshTimer(): void {
+    if (refreshTimer === null) return
+    clearTimeout(refreshTimer)
+    refreshTimer = null
+  }
+
+  function scheduledRefreshAt(state: CapabilityReadState): number | null {
+    if (state.status === 'resolved') return state.refreshAt
+    return state.status === 'unavailable' ? state.retryAt : null
+  }
+
+  /** Requires `readFailures` to already count this failure. */
+  function unavailableState(
+    authUid: string,
+    workspaceId: string
+  ): CapabilityReadState {
+    const delay = Math.min(
+      FALLBACK_REFRESH_DELAY_MS * 2 ** (readFailures - 1),
+      MAX_RETRY_DELAY_MS
+    )
+    return {
+      status: 'unavailable',
+      authUid,
+      workspaceId,
+      retryAt: Date.now() + delay / 2 + Math.random() * (delay / 2)
+    }
+  }
+
+  // NaN from an unparseable timestamp fails the comparison and lands on the
+  // fixed interval.
+  function nextRefreshAt(response: BillingCapabilitiesResponse): number {
+    const now = Date.now()
+    const remaining = Date.parse(response.expires_at) - now
+    if (remaining >= MIN_REFRESH_DELAY_MS) {
+      return now + Math.min(remaining, MAX_REFRESH_DELAY_MS)
+    }
+    return now + FALLBACK_REFRESH_DELAY_MS
+  }
+
+  // `capabilities` is a computed, and wall-clock time is not a reactive
+  // dependency, so expiry has to be pushed rather than read lazily. The timer
+  // runs only while the document is visible: staleness is unobservable in a
+  // hidden tab, and returning to the tab is itself a visibility transition.
+  function scheduleRefresh(): void {
+    clearRefreshTimer()
+    const refreshAt = scheduledRefreshAt(readState.value)
+    if (refreshAt === null) return
+    if (defaultDocument?.visibilityState === 'hidden') return
+
+    const delay = Math.max(0, refreshAt - Date.now())
+    refreshTimer = setTimeout(() => {
+      refreshTimer = null
+      void fetchCapabilities()
+    }, delay)
+  }
+
+  useEventListener(defaultDocument, 'visibilitychange', () => {
+    if (defaultDocument?.visibilityState === 'hidden') {
+      clearRefreshTimer()
+      return
+    }
+    const refreshAt = scheduledRefreshAt(readState.value)
+    if (refreshAt === null) return
+    if (refreshAt <= Date.now()) void fetchCapabilities()
+    else scheduleRefresh()
+  })
+
+  const stopRevisionListener = onCapabilityRevision((revision) => {
+    // A read already in flight may have loaded its data before this mutation
+    // committed, and the revision it returns cannot rule that out: the server
+    // mints that number when it serializes the response, not when it read. So
+    // the read is refetched once it settles - the dedupe below would otherwise
+    // hand back the very request that missed the mutation.
+    if (activeRequest) invalidatedRequestId = activeRequest.requestId
+    const state = readState.value
+    if (state.status !== 'resolved' || state.response.revision === revision) {
+      return
+    }
+    void fetchCapabilities()
+  })
+
+  onScopeDispose(() => {
+    clearRefreshTimer()
+    stopRevisionListener()
+  })
+
+  /** Cancels the in-flight read and its timer, leaving the snapshot in place. */
+  function cancelActiveRead(): void {
+    clearRefreshTimer()
+    latestRequestId++
+    activeRequest?.controller.abort()
+    activeRequest = null
+  }
+
+  function resetRead(): void {
+    cancelActiveRead()
+    readState.value = { status: 'idle' }
+  }
+
+  async function fetchCapabilities(signal?: AbortSignal): Promise<void> {
+    const userId = authStore.currentUser?.uid
+    const workspaceId = workspaceStore.activeWorkspaceId
+    if (!userId || !workspaceId) {
+      resetRead()
+      return
+    }
+
+    if (
+      activeRequest?.authUid === userId &&
+      activeRequest.workspaceId === workspaceId &&
+      !activeRequest.controller.signal.aborted
+    ) {
+      return activeRequest.promise
+    }
+
+    // Refetching the same scope revalidates in the background, keeping the
+    // prior read - a resolved snapshot or the unavailable fallback - readable
+    // so its affordances do not blink out once per refresh. A scope change
+    // makes it wrong, not stale, so it resets.
+    const currentState = readState.value
+    const revalidating =
+      (currentState.status === 'resolved' ||
+        currentState.status === 'unavailable') &&
+      currentState.authUid === userId &&
+      currentState.workspaceId === workspaceId
+    const priorSnapshot =
+      revalidating && currentState.status === 'resolved' ? currentState : null
+
+    if (revalidating) cancelActiveRead()
+    else resetRead()
+
+    const requestId = ++latestRequestId
+    const controller = new AbortController()
+    const abortRequest = () => controller.abort()
+    if (signal?.aborted) controller.abort()
+    else signal?.addEventListener('abort', abortRequest, { once: true })
+    if (!revalidating) {
+      readState.value = {
+        status: 'pending',
+        authUid: userId,
+        workspaceId
+      }
+    }
+
+    const promise = (async () => {
+      let refetchAfterSettle = false
+      try {
+        const response = await workspaceApi.getBillingCapabilities(
+          controller.signal
+        )
+        if (
+          requestId !== latestRequestId ||
+          userId !== authStore.currentUser?.uid ||
+          workspaceId !== workspaceStore.activeWorkspaceId
+        ) {
+          return
+        }
+
+        const resolvedForScope =
+          response.resolved_for.workspace_id === workspaceId
+        if (resolvedForScope) {
+          readFailures = 0
+          readState.value = {
+            status: 'resolved',
+            authUid: userId,
+            workspaceId,
+            response,
+            refreshAt: nextRefreshAt(response)
+          }
+        } else {
+          readFailures++
+          readState.value = unavailableState(userId, workspaceId)
+        }
+        scheduleRefresh()
+        refetchAfterSettle =
+          resolvedForScope && invalidatedRequestId === requestId
+      } catch (error) {
+        if (
+          requestId !== latestRequestId ||
+          userId !== authStore.currentUser?.uid ||
+          workspaceId !== workspaceStore.activeWorkspaceId
+        ) {
+          return
+        }
+        if (controller.signal.aborted) {
+          if (!revalidating) readState.value = { status: 'idle' }
+          return
+        }
+
+        const denied =
+          (error instanceof WorkspaceApiError &&
+            (error.status === 401 || error.status === 403)) ||
+          (error instanceof Error && error.name === 'AuthStoreError')
+        // A transient failure keeps the last good snapshot - stale, not wrong -
+        // and retries. A denial is the server answering about this actor, so it
+        // replaces the snapshot even mid-revalidation.
+        const firstFailure = readFailures === 0
+        if (!denied) readFailures++
+        if (priorSnapshot && !denied) {
+          readState.value = {
+            ...priorSnapshot,
+            refreshAt: Date.now() + FALLBACK_REFRESH_DELAY_MS
+          }
+        } else {
+          readState.value = denied
+            ? { status: 'denied', authUid: userId, workspaceId }
+            : unavailableState(userId, workspaceId)
+        }
+        scheduleRefresh()
+        // A sustained outage retries on a timer, so reporting every attempt
+        // would emit one warning a minute for as long as the tab is open.
+        if (!denied && !firstFailure) return
+        reportError(error, {
+          errorType: 'billing_capabilities_read_failure',
+          level: 'warning',
+          tags: {
+            status:
+              error instanceof WorkspaceApiError
+                ? (error.status ?? 'unknown')
+                : 'unknown',
+            outcome: denied ? 'denied' : 'unavailable'
+          }
+        })
+      } finally {
+        signal?.removeEventListener('abort', abortRequest)
+        if (activeRequest?.requestId === requestId) {
+          activeRequest = null
+          // Deferred to here so the refetch is not deduped onto the request
+          // it replaces. It cannot loop: this one is issued after the revision
+          // that marked it, so only a further mutation can mark it in turn.
+          if (refetchAfterSettle) void fetchCapabilities()
+        }
+      }
+    })()
+
+    activeRequest = {
+      requestId,
+      authUid: userId,
+      workspaceId,
+      controller,
+      promise
+    }
+    return promise
+  }
+
+  async function initialize(signal?: AbortSignal): Promise<void> {
+    initialized = true
+    if (!isCloud) return
+    do {
+      await fetchCapabilities(signal)
+    } while (
+      !signal?.aborted &&
+      !!authStore.currentUser?.uid &&
+      !!workspaceStore.activeWorkspaceId &&
+      !isReady.value
+    )
+  }
+
+  async function refresh(): Promise<void> {
+    await initialize()
+  }
+
+  watch(
+    [
+      () => authStore.currentUser?.uid,
+      () => workspaceStore.activeWorkspaceId,
+      () => workspaceStore.activeWorkspace?.role
+    ],
+    () => {
+      readFailures = 0
+      resetRead()
+      if (initialized && isCloud) void fetchCapabilities()
+    }
+  )
+
+  return { canTopUp, canSubscribeSelfServe, isReady, initialize, refresh }
+}
+
+export const useBillingCapabilities = createSharedComposable(
+  useBillingCapabilitiesInternal
+)

--- a/src/storybook/mocks/useBillingCapabilities.ts
+++ b/src/storybook/mocks/useBillingCapabilities.ts
@@ -1,0 +1,17 @@
+import { computed, ref } from 'vue'
+
+const canTopUpState = ref(true)
+
+export function setCanTopUpMock(canTopUp: boolean) {
+  canTopUpState.value = canTopUp
+}
+
+export function useBillingCapabilities() {
+  return {
+    canTopUp: computed(() => canTopUpState.value),
+    canSubscribeSelfServe: computed(() => false),
+    isReady: computed(() => true),
+    initialize: () => undefined,
+    refresh: () => undefined
+  }
+}


### PR DESCRIPTION
Backport of #15803 to `cloud/1.52`.

## Merge order — this PR is stacked

Base is deliberately `backport-15799-to-cloud-1.52`, not `cloud/1.52`. GitHub retargets this PR to `cloud/1.52` once its parent merges.

`cloud/1.52` → #15799 → #15803 → #15804 → #15675 → #15967 → #16043 → #16046 → #16067

Every commit in this chain cherry-picks cleanly; there are no hand-resolved conflicts anywhere in the stack.

## Verification

Run at the tip of the full stack: 93 unit test files, 1745 tests, 0 failures (`src/platform/workspace`, `src/platform/cloud/subscription`, `src/composables/useCoreCommands.test.ts`, `src/components/actionbar`).