### PR TITLE
[backport cloud/1.52] billing: consume the remaining workspace capabilities

### DIFF
--- a/browser_tests/fixtures/data/billingCapabilities.ts
+++ b/browser_tests/fixtures/data/billingCapabilities.ts
@@ -3,6 +3,8 @@ import type {
   BillingCapabilitiesResponse
 } from '@comfyorg/ingest-types'
 
+import type { WorkspaceWithRole } from '@/platform/workspace/api/workspaceApi'
+
 export function createBillingCapabilities(
   workspaceId: string,
   overrides: Partial<BillingCapabilities> = {}
@@ -31,4 +33,28 @@ export function createBillingCapabilities(
     // Far-future expiry so the snapshot never goes stale mid-test.
     expires_at: '2099-01-01T00:00:00Z'
   }
+}
+
+/**
+ * The capability set the server resolves for `ws`: management actions belong
+ * to owners, and downgrade-to-personal only exists on a team workspace.
+ *
+ * `resolved_for.workspace_id` must match the active workspace or the client
+ * discards the read as out-of-scope and falls back to every capability false.
+ */
+export function createWorkspaceBillingCapabilities(
+  ws: WorkspaceWithRole,
+  overrides: Partial<BillingCapabilities> = {}
+): BillingCapabilitiesResponse {
+  const isOwner = ws.role === 'owner'
+  return createBillingCapabilities(ws.id, {
+    can_cancel: isOwner,
+    can_change_seats: isOwner,
+    can_downgrade_to_personal: isOwner && ws.type === 'team',
+    can_invite_members: isOwner,
+    can_reactivate: isOwner,
+    can_subscribe_self_serve: isOwner,
+    can_top_up: isOwner,
+    ...overrides
+  })
 }

--- a/browser_tests/fixtures/helpers/CloudWorkspaceMockHelper.ts
+++ b/browser_tests/fixtures/helpers/CloudWorkspaceMockHelper.ts
@@ -7,6 +7,7 @@ import type {
   WorkspaceWithRole
 } from '@/platform/workspace/api/workspaceApi'
 
+import { createWorkspaceBillingCapabilities } from '@e2e/fixtures/data/billingCapabilities'
 import { mockSystemStats } from '@e2e/fixtures/data/systemStats'
 import {
   CLOUD_REMOTE_CONFIG,
@@ -163,6 +164,12 @@ export class CloudWorkspaceMockHelper {
     await page.route('**/api/billing/status', (r) =>
       r.fulfill(jsonRoute(billingStatus))
     )
+    await page.route('**/api/billing/capabilities', (r) => {
+      if (r.request().method() !== 'GET') return r.fallback()
+      return r.fulfill(
+        jsonRoute(createWorkspaceBillingCapabilities(activeWorkspace))
+      )
+    })
     await page.route('**/api/billing/payment-portal', (r) =>
       r.fulfill(jsonRoute({ url: 'https://billing.example/portal' }))
     )

--- a/browser_tests/tests/currentUserPopoverCredits.spec.ts
+++ b/browser_tests/tests/currentUserPopoverCredits.spec.ts
@@ -7,6 +7,7 @@ import type {
 } from '@/platform/workspace/api/workspaceApi'
 import type { WorkspaceTokenResponse } from '@/platform/workspace/stores/workspaceAuthStore'
 import type { operations } from '@/types/comfyRegistryTypes'
+import { createWorkspaceBillingCapabilities } from '@e2e/fixtures/data/billingCapabilities'
 import { comfyPageFixture } from '@e2e/fixtures/ComfyPage'
 import { APP_URL, setupCloudApp } from '@e2e/fixtures/utils/cloudAppSetup'
 import { workspace } from '@e2e/fixtures/utils/workspaceMocks'
@@ -113,6 +114,19 @@ const test = comfyPageFixture.extend({
     )
 
     // The popover sources its data from the workspace billing endpoints.
+    await page.route('**/api/billing/capabilities', (route) => {
+      if (route.request().method() !== 'GET') return route.fallback()
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(
+          createWorkspaceBillingCapabilities(
+            mockListWorkspacesResponse.workspaces[0]
+          )
+        )
+      })
+    })
+
     await page.route('**/api/billing/status', (route) =>
       route.fulfill({
         status: 200,

--- a/browser_tests/tests/dialogs/creditsTile.spec.ts
+++ b/browser_tests/tests/dialogs/creditsTile.spec.ts
@@ -10,6 +10,7 @@ import type {
 
 import { comfyPageFixture as test } from '@e2e/fixtures/ComfyPage'
 import { TopUpCreditsDialog } from '@e2e/fixtures/components/TopUpCreditsDialog'
+import { createWorkspaceBillingCapabilities } from '@e2e/fixtures/data/billingCapabilities'
 import { mockSystemStats } from '@e2e/fixtures/data/systemStats'
 import { CloudAuthHelper } from '@e2e/fixtures/helpers/CloudAuthHelper'
 import {
@@ -178,6 +179,14 @@ async function mockCloudBoot(
   await page.route('**/api/billing/plans', (r) =>
     r.fulfill(jsonRoute({ plans: [] }))
   )
+  await page.route('**/api/billing/capabilities', (r) => {
+    if (r.request().method() !== 'GET') return r.fallback()
+    return r.fulfill(
+      jsonRoute(
+        createWorkspaceBillingCapabilities(workspace('personal', 'owner'))
+      )
+    )
+  })
 }
 
 async function mockBalance(

--- a/browser_tests/tests/dialogs/pricingTableDeepLink.spec.ts
+++ b/browser_tests/tests/dialogs/pricingTableDeepLink.spec.ts
@@ -23,6 +23,7 @@ import {
   cloudAppFixture as test,
   waitForCloudApp
 } from '@e2e/fixtures/cloudAppFixture'
+import { createWorkspaceBillingCapabilities } from '@e2e/fixtures/data/billingCapabilities'
 import { mockBilling } from '@e2e/fixtures/utils/cloudBillingMocks'
 import { bootCloud, mockCloudBoot } from '@e2e/fixtures/utils/cloudBootMocks'
 import { jsonRoute } from '@e2e/fixtures/utils/jsonRoute'
@@ -341,7 +342,10 @@ async function setupCloudApp(
     settings: BOOT_SETTINGS
   })
   await mockGraphBootExtras(page)
-  await mockBilling(page)
+  await mockBilling(page, {
+    workspaceId: ws.id,
+    billingCapabilities: createWorkspaceBillingCapabilities(ws)
+  })
   await mockWorkspace(page, ws, members)
   await bootCloud(page)
 }

--- a/src/components/dialog/content/subscription/CancelSubscriptionDialogContent.test.ts
+++ b/src/components/dialog/content/subscription/CancelSubscriptionDialogContent.test.ts
@@ -55,7 +55,9 @@ const mockToastAdd = vi.hoisted(() => vi.fn())
 const mockTier = vi.hoisted(() => ({ value: 'STANDARD' as string | null }))
 const mockTrackCancellation = vi.hoisted(() => vi.fn())
 const mockShouldUseWorkspaceBilling = vi.hoisted(() => ({ value: false }))
+const mockCanCancel = vi.hoisted(() => ({ value: true }))
 const mockCanManageSubscriptionLifecycle = vi.hoisted(() => ({ value: true }))
+const mockDistributionTypes = vi.hoisted(() => ({ isCloud: true }))
 
 vi.mock('@/composables/billing/useBillingContext', () => ({
   useBillingContext: vi.fn(() => ({
@@ -69,6 +71,14 @@ vi.mock('@/composables/billing/useBillingContext', () => ({
 vi.mock('@/composables/billing/useBillingRouting', () => ({
   useBillingRouting: () => ({
     shouldUseWorkspaceBilling: mockShouldUseWorkspaceBilling
+  })
+}))
+
+vi.mock('@/platform/distribution/types', () => mockDistributionTypes)
+
+vi.mock('@/platform/workspace/composables/useBillingCapabilities', () => ({
+  useBillingCapabilities: () => ({
+    canCancel: mockCanCancel
   })
 }))
 
@@ -130,7 +140,9 @@ describe('CancelSubscriptionDialogContent', () => {
   beforeEach(() => {
     mockTier.value = 'STANDARD'
     mockShouldUseWorkspaceBilling.value = false
+    mockCanCancel.value = true
     mockCanManageSubscriptionLifecycle.value = true
+    mockDistributionTypes.isCloud = true
   })
 
   describe('cancellation telemetry', () => {
@@ -303,10 +315,10 @@ describe('CancelSubscriptionDialogContent', () => {
     it('does not cancel after the workspace role loses permission', async () => {
       mockSubscription.value = null
       mockShouldUseWorkspaceBilling.value = true
-      mockCanManageSubscriptionLifecycle.value = true
+      mockCanCancel.value = true
 
       renderComponent()
-      mockCanManageSubscriptionLifecycle.value = false
+      mockCanCancel.value = false
       await userEvent.click(
         screen.getByRole('button', { name: /^cancel subscription$/i })
       )
@@ -318,6 +330,41 @@ describe('CancelSubscriptionDialogContent', () => {
       )
       expect(mockToastAdd).not.toHaveBeenCalled()
       expect(mockCloseDialog).not.toHaveBeenCalled()
+    })
+
+    it('cancels off Cloud on the workspace permission, ignoring the Cloud-only capability', async () => {
+      mockSubscription.value = null
+      mockShouldUseWorkspaceBilling.value = true
+      mockDistributionTypes.isCloud = false
+      mockCanCancel.value = false
+      mockCanManageSubscriptionLifecycle.value = true
+      mockCancelSubscription.mockResolvedValueOnce(undefined)
+
+      renderComponent()
+      await userEvent.click(
+        screen.getByRole('button', { name: /^cancel subscription$/i })
+      )
+
+      await waitFor(() => expect(mockCancelSubscription).toHaveBeenCalled())
+    })
+
+    it('blocks cancelling off Cloud when the workspace permission is missing', async () => {
+      mockSubscription.value = null
+      mockShouldUseWorkspaceBilling.value = true
+      mockDistributionTypes.isCloud = false
+      mockCanCancel.value = true
+      mockCanManageSubscriptionLifecycle.value = false
+
+      renderComponent()
+      await userEvent.click(
+        screen.getByRole('button', { name: /^cancel subscription$/i })
+      )
+
+      expect(mockCancelSubscription).not.toHaveBeenCalled()
+      expect(mockTrackCancellation).not.toHaveBeenCalledWith(
+        'confirmed',
+        expect.anything()
+      )
     })
 
     it('does not track cancellation failure when status refresh fails after cancellation succeeds', async () => {

--- a/src/components/dialog/content/subscription/CancelSubscriptionDialogContent.vue
+++ b/src/components/dialog/content/subscription/CancelSubscriptionDialogContent.vue
@@ -52,7 +52,9 @@ import Button from '@/components/ui/button/Button.vue'
 import { useBillingContext } from '@/composables/billing/useBillingContext'
 import { useBillingRouting } from '@/composables/billing/useBillingRouting'
 import { getSubscriptionCancellationMetadata } from '@/platform/cloud/subscription/utils/subscriptionCancellationTelemetry'
+import { isCloud } from '@/platform/distribution/types'
 import { useTelemetry } from '@/platform/telemetry'
+import { useBillingCapabilities } from '@/platform/workspace/composables/useBillingCapabilities'
 import { useWorkspaceUI } from '@/platform/workspace/composables/useWorkspaceUI'
 import { useDialogStore } from '@/stores/dialogStore'
 import { parseIsoDateSafe } from '@/utils/dateTimeUtil'
@@ -69,6 +71,7 @@ const toast = useToast()
 const { cancelSubscription, fetchStatus, subscription, tier } =
   useBillingContext()
 const { shouldUseWorkspaceBilling } = useBillingRouting()
+const { canCancel } = useBillingCapabilities()
 const { permissions } = useWorkspaceUI()
 const telemetry = useTelemetry()
 
@@ -119,7 +122,9 @@ function onClose() {
 async function onConfirmCancel() {
   if (
     shouldUseWorkspaceBilling.value &&
-    !permissions.value.canManageSubscriptionLifecycle
+    !(isCloud
+      ? canCancel.value
+      : permissions.value.canManageSubscriptionLifecycle)
   ) {
     return
   }

--- a/src/platform/workspace/components/CurrentUserPopoverWorkspace.test.ts
+++ b/src/platform/workspace/components/CurrentUserPopoverWorkspace.test.ts
@@ -21,6 +21,7 @@ const state = vi.hoisted(() => ({
   canSubscribeSelfServe: false,
   canManageSubscription: false,
   canManageSubscriptionLifecycle: false,
+  canReactivate: false,
   showCreateWorkspaceDialog: vi.fn(),
   showTopUpCreditsDialog: vi.fn(),
   showPricingTable: vi.fn(),
@@ -82,7 +83,8 @@ vi.mock('@/platform/workspace/composables/useWorkspaceUI', () => ({
 vi.mock('@/platform/workspace/composables/useBillingCapabilities', () => ({
   useBillingCapabilities: () => ({
     canTopUp: computed(() => state.canTopUp),
-    canSubscribeSelfServe: computed(() => state.canSubscribeSelfServe)
+    canSubscribeSelfServe: computed(() => state.canSubscribeSelfServe),
+    canReactivate: computed(() => state.canReactivate)
   })
 }))
 
@@ -187,6 +189,7 @@ describe('CurrentUserPopoverWorkspace', () => {
     state.canSubscribeSelfServe = false
     state.canManageSubscription = false
     state.canManageSubscriptionLifecycle = false
+    state.canReactivate = false
   })
 
   it('toggles the workspace switcher panel from the selector row', async () => {
@@ -325,6 +328,7 @@ describe('CurrentUserPopoverWorkspace', () => {
     state.billingStatus = 'payment_failed'
     state.canAccessSubscriptionFeatures = false
     state.canManageSubscription = true
+    state.canSubscribeSelfServe = true
     state.planSlug = null
 
     renderComponent('team')
@@ -421,6 +425,7 @@ describe('CurrentUserPopoverWorkspace', () => {
     state.isCloud = false
     state.isCancelled = true
     state.canManageSubscriptionLifecycle = true
+    state.canReactivate = true
 
     renderComponent('team')
 
@@ -436,6 +441,8 @@ describe('CurrentUserPopoverWorkspace', () => {
       isCancelled: true,
       canManageSubscription: false,
       canManageSubscriptionLifecycle: true,
+      canReactivate: true,
+      canSubscribeSelfServe: false,
       action: 'Resubscribe',
       visible: true
     },
@@ -445,6 +452,19 @@ describe('CurrentUserPopoverWorkspace', () => {
       isCancelled: true,
       canManageSubscription: true,
       canManageSubscriptionLifecycle: false,
+      canReactivate: false,
+      canSubscribeSelfServe: false,
+      action: 'Resubscribe',
+      visible: false
+    },
+    {
+      name: 'does not resubscribe a cancelled plan when the server denies reactivation to a client-side owner',
+      canAccessSubscriptionFeatures: true,
+      isCancelled: true,
+      canManageSubscription: true,
+      canManageSubscriptionLifecycle: true,
+      canReactivate: false,
+      canSubscribeSelfServe: false,
       action: 'Resubscribe',
       visible: false
     },
@@ -454,6 +474,8 @@ describe('CurrentUserPopoverWorkspace', () => {
       isCancelled: false,
       canManageSubscription: true,
       canManageSubscriptionLifecycle: false,
+      canReactivate: false,
+      canSubscribeSelfServe: true,
       action: 'Subscribe',
       visible: true
     },
@@ -463,6 +485,8 @@ describe('CurrentUserPopoverWorkspace', () => {
       isCancelled: false,
       canManageSubscription: false,
       canManageSubscriptionLifecycle: true,
+      canReactivate: true,
+      canSubscribeSelfServe: false,
       action: 'Subscribe',
       visible: false
     }
@@ -473,6 +497,8 @@ describe('CurrentUserPopoverWorkspace', () => {
       isCancelled,
       canManageSubscription,
       canManageSubscriptionLifecycle,
+      canReactivate,
+      canSubscribeSelfServe,
       action,
       visible
     }) => {
@@ -480,6 +506,8 @@ describe('CurrentUserPopoverWorkspace', () => {
       state.isCancelled = isCancelled
       state.canManageSubscription = canManageSubscription
       state.canManageSubscriptionLifecycle = canManageSubscriptionLifecycle
+      state.canReactivate = canReactivate
+      state.canSubscribeSelfServe = canSubscribeSelfServe
 
       renderComponent('team')
 
@@ -498,6 +526,7 @@ describe('CurrentUserPopoverWorkspace', () => {
     state.canTopUp = true
     state.canManageSubscription = true
     state.canManageSubscriptionLifecycle = true
+    state.canReactivate = true
     renderComponent('team')
 
     expect(screen.getByTestId('add-credits-button')).toBeInTheDocument()

--- a/src/platform/workspace/components/CurrentUserPopoverWorkspace.vue
+++ b/src/platform/workspace/components/CurrentUserPopoverWorkspace.vue
@@ -282,7 +282,8 @@ const {
   isInPersonalWorkspace: isPersonalWorkspace
 } = storeToRefs(workspaceStore)
 const { permissions } = useWorkspaceUI()
-const { canTopUp, canSubscribeSelfServe } = useBillingCapabilities()
+const { canTopUp, canSubscribeSelfServe, canReactivate } =
+  useBillingCapabilities()
 const isWorkspaceSwitcherOpen = ref(false)
 const workspaceSwitcherTrigger = useTemplateRef('workspaceSwitcherTrigger')
 const workspaceSwitcherPanel = useTemplateRef('workspaceSwitcherPanel')
@@ -367,11 +368,13 @@ const showManagePlan = computed(
 )
 const showSubscribeAction = computed(
   () =>
+    // Subscribing is Cloud-only, so the whole action stays gated on isCloud;
+    // inside it the server-resolved capabilities are authoritative.
     isCloud &&
-    ((isCancelled.value && permissions.value.canManageSubscriptionLifecycle) ||
+    ((isCancelled.value && canReactivate.value) ||
       (!canAccessSubscriptionFeatures.value &&
         !hasDelinquentSubscription.value &&
-        permissions.value.canManageSubscription))
+        canSubscribeSelfServe.value))
 )
 
 const handleOpenUserSettings = () => {

--- a/src/platform/workspace/components/SubscriptionPanelContentWorkspace.test.ts
+++ b/src/platform/workspace/components/SubscriptionPanelContentWorkspace.test.ts
@@ -26,6 +26,12 @@ const { mockIsSettingUp, mockSubscriptionActionOperation } = vi.hoisted(() => ({
 }))
 const mockDistributionState = vi.hoisted(() => ({ isCloud: true }))
 
+vi.mock('@/composables/billing/useBillingRouting', () => ({
+  useBillingRouting: () => ({
+    shouldUseWorkspaceBilling: mockShouldUseWorkspaceBilling
+  })
+}))
+
 vi.mock('@/platform/distribution/types', () => ({
   get isCloud() {
     return mockDistributionState.isCloud
@@ -77,6 +83,11 @@ const mockIsInPersonalWorkspace = ref(false)
 const mockIsWorkspaceSubscribed = ref(true)
 const mockCanManageSubscription = ref(true)
 const mockCanManageSubscriptionLifecycle = ref(true)
+const mockCanCancel = ref(true)
+const mockCanReactivate = ref(true)
+const mockShouldUseWorkspaceBilling = ref(true)
+const mockCanChangeSeats = ref(true)
+const mockCanSubscribeSelfServe = ref(true)
 const mockCanLeaveWorkspace = ref(true)
 const mockTeamCreditStops = ref<TeamCreditStops | null>(teamCreditStops)
 const mockCurrentTeamCreditStop = ref<TeamCreditStopSummary | null>({
@@ -226,6 +237,15 @@ vi.mock('@/platform/workspace/composables/useWorkspaceUI', () => ({
   })
 }))
 
+vi.mock('@/platform/workspace/composables/useBillingCapabilities', () => ({
+  useBillingCapabilities: () => ({
+    canCancel: mockCanCancel,
+    canReactivate: mockCanReactivate,
+    canChangeSeats: mockCanChangeSeats,
+    canSubscribeSelfServe: mockCanSubscribeSelfServe
+  })
+}))
+
 vi.mock('@/platform/workspace/stores/billingOperationStore', () => ({
   useBillingOperationStore: () => ({
     get isSettingUp() {
@@ -322,6 +342,11 @@ describe('SubscriptionPanelContentWorkspace', () => {
     mockIsWorkspaceSubscribed.value = true
     mockCanManageSubscription.value = true
     mockCanManageSubscriptionLifecycle.value = true
+    mockCanCancel.value = true
+    mockCanReactivate.value = true
+    mockShouldUseWorkspaceBilling.value = true
+    mockCanChangeSeats.value = true
+    mockCanSubscribeSelfServe.value = true
     mockCanLeaveWorkspace.value = true
     mockUiConfig.value = ownerUiConfig
     mockSubscriptionTier.value = 'PRO'
@@ -362,6 +387,8 @@ describe('SubscriptionPanelContentWorkspace', () => {
   it('hides verification from users without billing permission', () => {
     mockIsSettingUp.value = true
     mockCanManageSubscription.value = false
+    mockCanChangeSeats.value = false
+    mockCanSubscribeSelfServe.value = false
     mockSubscriptionActionOperation.value = {
       actionUrl: 'https://verify.example/sensitive-token'
     }
@@ -488,6 +515,19 @@ describe('SubscriptionPanelContentWorkspace', () => {
     expect(mockShowSubscriptionDialog).toHaveBeenCalledOnce()
   })
 
+  it('hides Change plan when the server denies seat changes to a client-side owner', () => {
+    mockCanManageSubscription.value = true
+    mockCanChangeSeats.value = false
+    renderComponent()
+
+    expect(
+      screen.getByRole('button', { name: 'Billing & invoices' })
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: 'Change plan' })
+    ).not.toBeInTheDocument()
+  })
+
   it('preserves local Manage billing and Invoice history actions', async () => {
     const user = userEvent.setup()
     mockDistributionState.isCloud = false
@@ -506,6 +546,10 @@ describe('SubscriptionPanelContentWorkspace', () => {
     mockIsInPersonalWorkspace.value = true
     mockCanManageSubscription.value = false
     mockCanManageSubscriptionLifecycle.value = false
+    mockCanCancel.value = false
+    mockCanReactivate.value = false
+    mockCanChangeSeats.value = false
+    mockCanSubscribeSelfServe.value = false
     mockCanLeaveWorkspace.value = true
     mockUiConfig.value = memberUiConfig
     renderComponent()
@@ -771,6 +815,22 @@ describe('SubscriptionPanelContentWorkspace', () => {
     ).not.toBeInTheDocument()
   })
 
+  it('hides Reactivate plan when the server denies reactivation to a client-side owner', () => {
+    mockSubscriptionStatus.value = 'canceled'
+    mockHasTeamPlan.value = false
+    mockIsWorkspaceSubscribed.value = false
+    mockCanManageSubscriptionLifecycle.value = true
+    mockCanReactivate.value = false
+    renderComponent()
+
+    expect(
+      screen.getByText(`Ends on ${formatPanelDate(END_DATE_ISO)}`)
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: 'Reactivate plan' })
+    ).not.toBeInTheDocument()
+  })
+
   it('keeps Billing & invoices available to unsubscribed team owners', async () => {
     const user = userEvent.setup()
     mockIsActiveSubscription.value = false
@@ -837,12 +897,29 @@ describe('SubscriptionPanelContentWorkspace', () => {
     expect(mockInitialize).toHaveBeenCalledOnce()
   })
 
+  it('hides Subscribe Now when the server denies self-serve to a client-side owner', () => {
+    mockIsActiveSubscription.value = false
+    mockIsWorkspaceSubscribed.value = false
+    mockHasSubscription.value = false
+    mockCanManageSubscription.value = true
+    mockCanSubscribeSelfServe.value = false
+    renderComponent()
+
+    expect(
+      screen.queryByRole('button', { name: 'Subscribe Now' })
+    ).not.toBeInTheDocument()
+  })
+
   it('shows the zero-state contact-owner view to unsubscribed members', () => {
     mockIsActiveSubscription.value = false
     mockIsWorkspaceSubscribed.value = false
     mockHasSubscription.value = false
     mockCanManageSubscription.value = false
     mockCanManageSubscriptionLifecycle.value = false
+    mockCanCancel.value = false
+    mockCanReactivate.value = false
+    mockCanChangeSeats.value = false
+    mockCanSubscribeSelfServe.value = false
     renderComponent()
 
     expect(
@@ -917,6 +994,9 @@ describe('SubscriptionPanelContentWorkspace', () => {
   it('lets a Free personal workspace only rename itself (no Cancel or Delete)', async () => {
     const user = userEvent.setup()
     mockIsInPersonalWorkspace.value = true
+    // A Free personal workspace routes to legacy billing, where lifecycle
+    // authorization stays on the client.
+    mockShouldUseWorkspaceBilling.value = false
     mockIsActiveSubscription.value = false
     mockHasSubscription.value = false
     mockIsWorkspaceSubscribed.value = false
@@ -1021,6 +1101,10 @@ describe('SubscriptionPanelContentWorkspace', () => {
   it('offers members only Leave Workspace in the menu', () => {
     mockCanManageSubscription.value = false
     mockCanManageSubscriptionLifecycle.value = false
+    mockCanCancel.value = false
+    mockCanReactivate.value = false
+    mockCanChangeSeats.value = false
+    mockCanSubscribeSelfServe.value = false
     mockUiConfig.value = memberUiConfig
     renderComponent()
 
@@ -1042,6 +1126,10 @@ describe('SubscriptionPanelContentWorkspace', () => {
     const user = userEvent.setup()
     mockCanManageSubscription.value = false
     mockCanManageSubscriptionLifecycle.value = false
+    mockCanCancel.value = false
+    mockCanReactivate.value = false
+    mockCanChangeSeats.value = false
+    mockCanSubscribeSelfServe.value = false
     mockUiConfig.value = memberUiConfig
     renderComponent()
 

--- a/src/platform/workspace/components/SubscriptionPanelContentWorkspace.vue
+++ b/src/platform/workspace/components/SubscriptionPanelContentWorkspace.vue
@@ -260,10 +260,7 @@
                   }}
                 </Button>
                 <Button
-                  v-if="
-                    isSubscriptionCancelled &&
-                    permissions.canManageSubscriptionLifecycle
-                  "
+                  v-if="isSubscriptionCancelled && canReactivatePlan"
                   size="lg"
                   variant="primary"
                   class="rounded-lg px-4 text-sm font-normal"
@@ -276,7 +273,7 @@
                   v-else-if="
                     !isSubscriptionCancelled &&
                     canAccessSubscriptionFeatures &&
-                    permissions.canManageSubscription
+                    canChangePlan
                   "
                   size="lg"
                   variant="secondary"
@@ -420,6 +417,8 @@ import type { TierBenefit } from '@/platform/cloud/subscription/utils/tierBenefi
 import { getCommonTierBenefits } from '@/platform/cloud/subscription/utils/tierBenefits'
 import { isCloud } from '@/platform/distribution/types'
 import { useResubscribe } from '@/platform/workspace/composables/useResubscribe'
+import { useBillingRouting } from '@/composables/billing/useBillingRouting'
+import { useBillingCapabilities } from '@/platform/workspace/composables/useBillingCapabilities'
 import { useWorkspaceMenuItems } from '@/platform/workspace/composables/useWorkspaceMenuItems'
 import { useWorkspacePlanPricing } from '@/platform/workspace/composables/useWorkspacePlanPricing'
 import { useWorkspaceUI } from '@/platform/workspace/composables/useWorkspaceUI'
@@ -434,6 +433,9 @@ const workspaceStore = useTeamWorkspaceStore()
 const { isWorkspaceSubscribed, isInPersonalWorkspace } =
   storeToRefs(workspaceStore)
 const { permissions, isSubscriptionCancelled, workspaceRole } = useWorkspaceUI()
+const { shouldUseWorkspaceBilling } = useBillingRouting()
+const { canReactivate, canChangeSeats, canSubscribeSelfServe } =
+  useBillingCapabilities()
 const { maxAvailable: freeRunsAllowance, quotaEnabled: freeRunsQuotaEnabled } =
   useFreeTierQuota()
 const { t, n, locale } = useI18n()
@@ -482,7 +484,12 @@ const isSubscriptionEnded = computed(() => {
 // Show subscribe prompt to owners without active subscription. A cancelled plan
 // stays active until its end date, so it keeps the subscribed treatment.
 const showSubscribePrompt = computed(() => {
-  if (!permissions.value.canManageSubscription) return false
+  if (
+    !(isCloud
+      ? canSubscribeSelfServe.value
+      : permissions.value.canManageSubscription)
+  )
+    return false
   if (isSubscriptionEnded.value) return true
   if (isSubscriptionCancelled.value) return false
   if (
@@ -494,6 +501,18 @@ const showSubscribePrompt = computed(() => {
   if (isInPersonalWorkspace.value) return !canAccessSubscriptionFeatures.value
   return !isWorkspaceSubscribed.value
 })
+
+// The legacy rail keeps lifecycle authorization on the client, and
+// handleResubscribe() skips its capability guard there, so the affordance has
+// to follow the same three-way condition or it hides a working action.
+const canReactivatePlan = computed(() =>
+  isCloud && shouldUseWorkspaceBilling.value
+    ? canReactivate.value
+    : permissions.value.canManageSubscriptionLifecycle
+)
+const canChangePlan = computed(() =>
+  isCloud ? canChangeSeats.value : permissions.value.canManageSubscription
+)
 
 // The never-subscribed upsell is Cloud-only; on Local the policy table keeps
 // top-up available instead. An ended Team plan keeps its inactive treatment

--- a/src/platform/workspace/components/UnifiedPricingTable.test.ts
+++ b/src/platform/workspace/components/UnifiedPricingTable.test.ts
@@ -29,6 +29,12 @@ const mockCurrentTeamCreditStop = ref<MockTeamStop | null>(null)
 const mockIsTeamPlan = ref(false)
 const mockCanManageSubscription = ref(true)
 const mockCanDowngradeToPersonal = ref(true)
+const mockPermissions = ref({
+  canManageSubscription: true,
+  canManageSubscriptionLifecycle: true,
+  canDowngradeToPersonal: true
+})
+const mockDistributionTypes = vi.hoisted(() => ({ isCloud: true }))
 
 vi.mock('@/composables/billing/useBillingContext', () => ({
   useBillingContext: () => ({
@@ -42,12 +48,20 @@ vi.mock('@/composables/billing/useBillingContext', () => ({
   })
 }))
 
+vi.mock('@/platform/distribution/types', () => mockDistributionTypes)
+
+vi.mock('@/platform/workspace/composables/useBillingCapabilities', () => ({
+  useBillingCapabilities: () => ({
+    canSubscribeSelfServe: computed(() => mockCanManageSubscription.value),
+    canReactivate: computed(() => mockCanManageSubscription.value),
+    canChangeSeats: computed(() => mockCanManageSubscription.value),
+    canDowngradeToPersonal: computed(() => mockCanDowngradeToPersonal.value)
+  })
+}))
+
 vi.mock('@/platform/workspace/composables/useWorkspaceUI', () => ({
   useWorkspaceUI: () => ({
-    permissions: computed(() => ({
-      canManageSubscription: mockCanManageSubscription.value,
-      canDowngradeToPersonal: mockCanDowngradeToPersonal.value
-    }))
+    permissions: computed(() => mockPermissions.value)
   })
 }))
 
@@ -86,6 +100,12 @@ describe('UnifiedPricingTable plan CTA labels', () => {
     mockIsTeamPlan.value = false
     mockCanManageSubscription.value = true
     mockCanDowngradeToPersonal.value = true
+    mockPermissions.value = {
+      canManageSubscription: true,
+      canManageSubscriptionLifecycle: true,
+      canDowngradeToPersonal: true
+    }
+    mockDistributionTypes.isCloud = true
   })
 
   it('prompts free-tier users to subscribe, never to "change"', () => {
@@ -209,6 +229,12 @@ describe('UnifiedPricingTable team plan CTA', () => {
     mockIsTeamPlan.value = false
     mockCanManageSubscription.value = true
     mockCanDowngradeToPersonal.value = true
+    mockPermissions.value = {
+      canManageSubscription: true,
+      canManageSubscriptionLifecycle: true,
+      canDowngradeToPersonal: true
+    }
+    mockDistributionTypes.isCloud = true
   })
 
   it('disables the CTA while sitting on the active current plan', () => {
@@ -329,5 +355,164 @@ describe('UnifiedPricingTable team plan CTA', () => {
     expect(
       screen.getByRole('button', { name: 'Subscribe to Team Yearly' })
     ).toBeTruthy()
+  })
+})
+
+// Server billing capabilities only resolve on Cloud, so Local/Desktop keeps
+// authorizing from the client-side workspace permissions.
+describe('UnifiedPricingTable outside Cloud', () => {
+  const TEAM_STOP = {
+    id: 'team_2500',
+    credits_monthly: 527_500,
+    stop_usd: 2_500
+  }
+
+  beforeEach(() => {
+    mockSubscription.value = null
+    mockSubscriptionStatus.value = null
+    mockCurrentPlanSlug.value = null
+    mockCurrentTeamCreditStop.value = null
+    mockIsTeamPlan.value = false
+    mockCanManageSubscription.value = false
+    mockCanDowngradeToPersonal.value = false
+    mockPermissions.value = {
+      canManageSubscription: true,
+      canManageSubscriptionLifecycle: true,
+      canDowngradeToPersonal: true
+    }
+    mockDistributionTypes.isCloud = false
+  })
+
+  it('keeps the personal subscribe CTA usable', async () => {
+    const user = userEvent.setup()
+
+    const { emitted } = renderComponent()
+
+    const cta = screen.getByRole('button', {
+      name: 'Subscribe to Standard Yearly'
+    })
+    expect(cta).toBeEnabled()
+    await user.click(cta)
+    expect(emitted().subscribe).toBeTruthy()
+  })
+
+  it('keeps the personal change-plan CTA usable', async () => {
+    const user = userEvent.setup()
+    mockSubscription.value = { tier: 'STANDARD', duration: 'ANNUAL' }
+
+    const { emitted } = renderComponent()
+
+    const cta = screen.getByRole('button', { name: 'Change to Creator Yearly' })
+    expect(cta).toBeEnabled()
+    await user.click(cta)
+    expect(emitted().subscribe).toBeTruthy()
+  })
+
+  it('keeps the personal reactivate CTA usable', async () => {
+    const user = userEvent.setup()
+    mockSubscription.value = {
+      tier: 'CREATOR',
+      duration: 'ANNUAL',
+      isCancelled: true
+    }
+
+    const { emitted } = renderComponent()
+
+    const cta = screen.getByRole('button', {
+      name: 'Resubscribe to Creator Yearly'
+    })
+    expect(cta).toBeEnabled()
+    await user.click(cta)
+    expect(emitted().resubscribe).toBeTruthy()
+  })
+
+  it('keeps team-to-personal selection available to the original owner', () => {
+    mockSubscription.value = { tier: 'TEAM', duration: 'ANNUAL' }
+    mockCurrentTeamCreditStop.value = TEAM_STOP
+    mockIsTeamPlan.value = true
+
+    renderComponent()
+
+    expect(
+      screen.getByRole('button', { name: 'Change to Standard Yearly' })
+    ).toBeEnabled()
+  })
+
+  it('keeps the team subscribe CTA usable', async () => {
+    const user = userEvent.setup()
+
+    const { emitted } = renderComponent({ initialPlanMode: 'team' })
+
+    const cta = screen.getByRole('button', { name: 'Subscribe to Team Yearly' })
+    expect(cta).toBeEnabled()
+    await user.click(cta)
+    expect(emitted().subscribeTeam).toBeTruthy()
+  })
+
+  it('keeps the team change-plan CTA usable', async () => {
+    const user = userEvent.setup()
+    mockSubscription.value = {
+      tier: 'TEAM',
+      duration: 'ANNUAL',
+      isCancelled: false
+    }
+    mockCurrentTeamCreditStop.value = TEAM_STOP
+
+    const { emitted } = renderComponent({ initialPlanMode: 'team' })
+
+    await user.click(screen.getByTestId('team-slider'))
+
+    const cta = screen.getByRole('button', { name: 'Change plan' })
+    expect(cta).toBeEnabled()
+    await user.click(cta)
+    expect(emitted().subscribeTeam).toBeTruthy()
+  })
+
+  it('keeps the team reactivate CTA usable', async () => {
+    const user = userEvent.setup()
+    mockSubscription.value = {
+      tier: 'TEAM',
+      duration: 'ANNUAL',
+      isCancelled: true
+    }
+    mockCurrentTeamCreditStop.value = TEAM_STOP
+
+    const { emitted } = renderComponent({ initialPlanMode: 'team' })
+
+    const cta = screen.getByRole('button', { name: 'Resubscribe' })
+    expect(cta).toBeEnabled()
+    await user.click(cta)
+    expect(emitted().resubscribe).toBeTruthy()
+  })
+
+  it('still blocks the CTAs when the workspace permission is missing', () => {
+    mockPermissions.value = {
+      canManageSubscription: false,
+      canManageSubscriptionLifecycle: false,
+      canDowngradeToPersonal: false
+    }
+
+    renderComponent()
+
+    expect(
+      screen.getByRole('button', { name: 'Subscribe to Standard Yearly' })
+    ).toBeDisabled()
+  })
+
+  it('normalizes a member without the downgrade permission away from personal plans', () => {
+    mockSubscription.value = { tier: 'TEAM', duration: 'ANNUAL' }
+    mockCurrentTeamCreditStop.value = TEAM_STOP
+    mockIsTeamPlan.value = true
+    mockPermissions.value = {
+      canManageSubscription: true,
+      canManageSubscriptionLifecycle: true,
+      canDowngradeToPersonal: false
+    }
+
+    renderComponent({ initialPlanMode: 'personal' })
+
+    expect(
+      screen.queryByRole('button', { name: 'Change to Standard Yearly' })
+    ).toBeNull()
   })
 })

--- a/src/platform/workspace/components/UnifiedPricingTable.vue
+++ b/src/platform/workspace/components/UnifiedPricingTable.vue
@@ -434,7 +434,9 @@ import {
 } from '@/platform/cloud/subscription/constants/teamPlanCreditStops'
 import type { TeamPlanSelection } from '@/platform/cloud/subscription/constants/teamPlanCreditStops'
 import type { BillingCycle } from '@/platform/cloud/subscription/utils/subscriptionTierRank'
+import { isCloud } from '@/platform/distribution/types'
 import type { Plan } from '@/platform/workspace/api/workspaceApi'
+import { useBillingCapabilities } from '@/platform/workspace/composables/useBillingCapabilities'
 import { useWorkspaceUI } from '@/platform/workspace/composables/useWorkspaceUI'
 
 type CheckoutTierKey = Exclude<TierKey, 'free' | 'founder'>
@@ -466,7 +468,29 @@ const emit = defineEmits<{
 }>()
 
 const { t, n } = useI18n()
+const capabilities = useBillingCapabilities()
 const { permissions } = useWorkspaceUI()
+
+const canSubscribeSelfServe = computed(() =>
+  isCloud
+    ? capabilities.canSubscribeSelfServe.value
+    : permissions.value.canManageSubscription
+)
+const canReactivate = computed(() =>
+  isCloud
+    ? capabilities.canReactivate.value
+    : permissions.value.canManageSubscriptionLifecycle
+)
+const canChangeSeats = computed(() =>
+  isCloud
+    ? capabilities.canChangeSeats.value
+    : permissions.value.canManageSubscription
+)
+const canDowngradeToPersonal = computed(() =>
+  isCloud
+    ? capabilities.canDowngradeToPersonal.value
+    : permissions.value.canDowngradeToPersonal
+)
 
 const planMode = ref<'personal' | 'team'>(initialPlanMode)
 
@@ -614,7 +638,7 @@ const {
 } = useBillingContext()
 
 const canSelectPersonalPlan = computed(
-  () => !isTeamPlan.value || permissions.value.canDowngradeToPersonal
+  () => !isTeamPlan.value || canDowngradeToPersonal.value
 )
 
 const planScopeOptions = computed(() =>
@@ -742,14 +766,14 @@ const teamButtonLabel = computed(() => {
   return t('subscription.teamPlan.changePlan')
 })
 
-const isTeamButtonDisabled = computed(
-  () =>
-    !permissions.value.canManageSubscription ||
-    isLoading ||
-    (isTeamSubscribed.value &&
-      isTeamCurrentPlanSelected.value &&
-      !isCancelled.value)
-)
+const isTeamButtonDisabled = computed(() => {
+  if (isLoading) return true
+  if (!isTeamSubscribed.value) return !canSubscribeSelfServe.value
+  if (isTeamCurrentPlanSelected.value) {
+    return !isCancelled.value || !canReactivate.value
+  }
+  return !canChangeSeats.value
+})
 
 // A subscriber moving off their current plan is a prorated change rather than a
 // fresh subscribe; re-subscribe and the locked current plan exit before the
@@ -833,18 +857,19 @@ const getButtonSeverity = (
   return 'secondary'
 }
 
-const isButtonDisabled = (tier: PricingTierConfig): boolean => {
-  if (
-    isLoading ||
-    !permissions.value.canManageSubscription ||
-    !canSelectPersonalPlan.value
-  )
-    return true
-  if (isCurrentPlan(tier.key)) {
-    return !isCancelled.value
+const canUsePersonalPlanAction = (tierKey: CheckoutTierKey): boolean => {
+  if (!canSelectPersonalPlan.value) return false
+  if (isTeamPlan.value) return canDowngradeToPersonal.value
+  if (isCurrentPlan(tierKey)) {
+    return isCancelled.value && canReactivate.value
   }
-  return false
+  return hasActivePaidPlan(currentAccountTier.value)
+    ? canChangeSeats.value
+    : canSubscribeSelfServe.value
 }
+
+const isButtonDisabled = (tier: PricingTierConfig): boolean =>
+  isLoading || !canUsePersonalPlanAction(tier.key)
 
 const getButtonTextClass = (tier: PricingTierConfig): string =>
   tier.key === 'creator'
@@ -865,12 +890,7 @@ const getAnnualTotal = (tier: PricingTierConfig): number => {
 }
 
 function handleSubscribe(tierKey: CheckoutTierKey) {
-  if (
-    isLoading ||
-    !permissions.value.canManageSubscription ||
-    !canSelectPersonalPlan.value
-  )
-    return
+  if (isLoading || !canUsePersonalPlanAction(tierKey)) return
   if (isCurrentPlan(tierKey)) {
     if (isCancelled.value) {
       emit('resubscribe')

--- a/src/platform/workspace/components/dialogs/settings/BillingStatusBanner.test.ts
+++ b/src/platform/workspace/components/dialogs/settings/BillingStatusBanner.test.ts
@@ -31,11 +31,19 @@ const state = vi.hoisted(() => ({
   workspaceType: 'team' as string,
   canManageSubscription: true,
   canManageSubscriptionLifecycle: true,
+  canReactivate: true,
+  shouldUseWorkspaceBilling: true,
   canTopUp: true,
   canSubscribeSelfServe: false,
   showTopUpCreditsDialog: vi.fn(),
   manageSubscription: vi.fn(),
   handleResubscribe: vi.fn()
+}))
+
+vi.mock('@/composables/billing/useBillingRouting', () => ({
+  useBillingRouting: () => ({
+    shouldUseWorkspaceBilling: computed(() => state.shouldUseWorkspaceBilling)
+  })
 }))
 
 vi.mock('@/platform/distribution/types', () => ({ isCloud: true }))
@@ -79,7 +87,8 @@ vi.mock('@/platform/workspace/composables/useWorkspaceUI', () => ({
 vi.mock('@/platform/workspace/composables/useBillingCapabilities', () => ({
   useBillingCapabilities: () => ({
     canTopUp: computed(() => state.canTopUp),
-    canSubscribeSelfServe: computed(() => state.canSubscribeSelfServe)
+    canSubscribeSelfServe: computed(() => state.canSubscribeSelfServe),
+    canReactivate: computed(() => state.canReactivate)
   })
 }))
 
@@ -185,6 +194,8 @@ describe('BillingStatusBanner', () => {
     state.workspaceType = 'team'
     state.canManageSubscription = true
     state.canManageSubscriptionLifecycle = true
+    state.canReactivate = true
+    state.shouldUseWorkspaceBilling = true
     state.canTopUp = true
     state.canSubscribeSelfServe = false
   })
@@ -350,6 +361,25 @@ describe('BillingStatusBanner', () => {
     expect(state.handleResubscribe).toHaveBeenCalledTimes(1)
   })
 
+  it('keeps reactivation on the legacy rail where the capability does not apply', async () => {
+    // Cloud personal on legacy_stripe: handleResubscribe skips its capability
+    // guard, so the affordance must follow the client permission instead.
+    state.shouldUseWorkspaceBilling = false
+    state.canReactivate = false
+    state.canManageSubscriptionLifecycle = true
+    state.subscription = {
+      hasFunds: true,
+      isCancelled: true,
+      endDate: '2026-08-01T00:00:00Z'
+    }
+    renderBanner()
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Reactivate plan' })
+    )
+    expect(state.handleResubscribe).toHaveBeenCalledTimes(1)
+  })
+
   it('does not expose reactivation controls to a member', () => {
     state.subscription = {
       hasFunds: true,
@@ -358,9 +388,29 @@ describe('BillingStatusBanner', () => {
     }
     state.canManageSubscription = false
     state.canManageSubscriptionLifecycle = false
+    state.canReactivate = false
     renderBanner()
 
     expect(screen.queryByRole('status')).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: 'Reactivate plan' })
+    ).not.toBeInTheDocument()
+  })
+
+  it('hides reactivation when the server denies it to a client-side owner', () => {
+    state.subscription = {
+      hasFunds: true,
+      isCancelled: true,
+      endDate: '2026-08-01T00:00:00Z'
+    }
+    state.canManageSubscription = true
+    state.canManageSubscriptionLifecycle = true
+    state.canReactivate = false
+    renderBanner()
+
+    expect(screen.getByRole('status')).toHaveTextContent(
+      'Your team plan ends on'
+    )
     expect(
       screen.queryByRole('button', { name: 'Reactivate plan' })
     ).not.toBeInTheDocument()

--- a/src/platform/workspace/components/dialogs/settings/BillingStatusBanner.vue
+++ b/src/platform/workspace/components/dialogs/settings/BillingStatusBanner.vue
@@ -74,6 +74,8 @@ import { useI18n } from 'vue-i18n'
 import Button from '@/components/ui/button/Button.vue'
 import { useBillingContext } from '@/composables/billing/useBillingContext'
 import { useBillingBanner } from '@/platform/workspace/composables/useBillingBanner'
+import { isCloud } from '@/platform/distribution/types'
+import { useBillingRouting } from '@/composables/billing/useBillingRouting'
 import { useBillingCapabilities } from '@/platform/workspace/composables/useBillingCapabilities'
 import { useResubscribe } from '@/platform/workspace/composables/useResubscribe'
 import { useWorkspaceUI } from '@/platform/workspace/composables/useWorkspaceUI'
@@ -84,14 +86,21 @@ type BannerAction = 'addCredits' | 'reactivate' | 'updatePayment'
 const { t, d } = useI18n()
 const { renewalDate, subscription, manageSubscription } = useBillingContext()
 const { permissions } = useWorkspaceUI()
-const { canTopUp, canSubscribeSelfServe } = useBillingCapabilities()
+const { shouldUseWorkspaceBilling } = useBillingRouting()
+const { canTopUp, canSubscribeSelfServe, canReactivate } =
+  useBillingCapabilities()
 const { kind, dismiss } = useBillingBanner()
 const { isResubscribing, handleResubscribe } = useResubscribe()
 const dialogService = useDialogService()
 
 const canManage = computed(() => permissions.value.canManageSubscription)
-const canManageLifecycle = computed(
-  () => permissions.value.canManageSubscriptionLifecycle
+// The legacy rail keeps lifecycle authorization on the client, and
+// handleResubscribe() skips its capability guard there, so the affordance has
+// to follow the same three-way condition or it hides a working action.
+const canReactivatePlan = computed(() =>
+  isCloud && shouldUseWorkspaceBilling.value
+    ? canReactivate.value
+    : permissions.value.canManageSubscriptionLifecycle
 )
 const cycleResetDate = computed(() => {
   const raw = renewalDate.value
@@ -153,7 +162,7 @@ const banner = computed<BannerView | null>(() => {
         muted: true,
         title: t(`${bs}.ending.title`, { date: planEndDate.value }),
         body: t(`${bs}.ending.body`),
-        action: canManageLifecycle.value ? 'reactivate' : null,
+        action: canReactivatePlan.value ? 'reactivate' : null,
         dismissible: false
       }
     default:

--- a/src/platform/workspace/composables/useBillingCapabilities.test.ts
+++ b/src/platform/workspace/composables/useBillingCapabilities.test.ts
@@ -66,7 +66,8 @@ function capabilitiesResponse(
   canTopUp: boolean,
   workspaceId = 'workspace-1',
   canSubscribeSelfServe = true,
-  freshness: { expiresAt?: string; revision?: number } = {}
+  freshness: { expiresAt?: string; revision?: number } = {},
+  overrides: Partial<BillingCapabilitiesResponse['capabilities']> = {}
 ): BillingCapabilitiesResponse {
   return {
     resolved_for: {
@@ -80,7 +81,8 @@ function capabilitiesResponse(
       can_reactivate: true,
       can_change_seats: true,
       can_invite_members: true,
-      can_downgrade_to_personal: false
+      can_downgrade_to_personal: true,
+      ...overrides
     },
     rollout_defaults_applied: {
       can_downgrade_to_personal: false,
@@ -196,6 +198,11 @@ describe('useBillingCapabilities', () => {
 
     expect(billingCapabilities.canTopUp.value).toBe(false)
     expect(billingCapabilities.canSubscribeSelfServe.value).toBe(false)
+    expect(billingCapabilities.canCancel.value).toBe(false)
+    expect(billingCapabilities.canReactivate.value).toBe(false)
+    expect(billingCapabilities.canChangeSeats.value).toBe(false)
+    expect(billingCapabilities.canInviteMembers.value).toBe(false)
+    expect(billingCapabilities.canDowngradeToPersonal.value).toBe(false)
 
     const initialization = billingCapabilities.initialize()
     expect(billingCapabilities.canTopUp.value).toBe(false)
@@ -205,6 +212,37 @@ describe('useBillingCapabilities', () => {
     await initialization
     expect(billingCapabilities.canTopUp.value).toBe(true)
     expect(billingCapabilities.canSubscribeSelfServe.value).toBe(true)
+    expect(billingCapabilities.canCancel.value).toBe(true)
+    expect(billingCapabilities.canReactivate.value).toBe(true)
+    expect(billingCapabilities.canChangeSeats.value).toBe(true)
+    expect(billingCapabilities.canInviteMembers.value).toBe(true)
+    expect(billingCapabilities.canDowngradeToPersonal.value).toBe(true)
+  })
+
+  it('applies denied server capabilities without client-side inference', async () => {
+    mockGetBillingCapabilities.mockResolvedValueOnce(
+      capabilitiesResponse(
+        true,
+        'workspace-1',
+        false,
+        {},
+        {
+          can_cancel: false,
+          can_reactivate: false,
+          can_change_seats: false,
+          can_invite_members: false,
+          can_downgrade_to_personal: false
+        }
+      )
+    )
+
+    await billingCapabilities.initialize()
+
+    expect(billingCapabilities.canCancel.value).toBe(false)
+    expect(billingCapabilities.canReactivate.value).toBe(false)
+    expect(billingCapabilities.canChangeSeats.value).toBe(false)
+    expect(billingCapabilities.canInviteMembers.value).toBe(false)
+    expect(billingCapabilities.canDowngradeToPersonal.value).toBe(false)
   })
 
   it('applies changed capabilities when the current scope is refreshed', async () => {
@@ -239,6 +277,11 @@ describe('useBillingCapabilities', () => {
 
     expect(billingCapabilities.canTopUp.value).toBe(true)
     expect(billingCapabilities.canSubscribeSelfServe.value).toBe(false)
+    expect(billingCapabilities.canCancel.value).toBe(false)
+    expect(billingCapabilities.canReactivate.value).toBe(false)
+    expect(billingCapabilities.canChangeSeats.value).toBe(false)
+    expect(billingCapabilities.canInviteMembers.value).toBe(false)
+    expect(billingCapabilities.canDowngradeToPersonal.value).toBe(false)
     expect(billingCapabilities.isReady.value).toBe(true)
     expect(mockReportError).toHaveBeenCalledOnce()
   })
@@ -298,6 +341,11 @@ describe('useBillingCapabilities', () => {
     expect(mockGetBillingCapabilities).toHaveBeenCalledOnce()
     expect(billingCapabilities.canTopUp.value).toBe(true)
     expect(billingCapabilities.canSubscribeSelfServe.value).toBe(false)
+    expect(billingCapabilities.canCancel.value).toBe(false)
+    expect(billingCapabilities.canReactivate.value).toBe(false)
+    expect(billingCapabilities.canChangeSeats.value).toBe(false)
+    expect(billingCapabilities.canInviteMembers.value).toBe(false)
+    expect(billingCapabilities.canDowngradeToPersonal.value).toBe(false)
   })
 
   it('discards a stale response after the active workspace changes', async () => {

--- a/src/platform/workspace/composables/useBillingCapabilities.ts
+++ b/src/platform/workspace/composables/useBillingCapabilities.ts
@@ -107,6 +107,21 @@ function useBillingCapabilitiesInternal() {
   const canSubscribeSelfServe = computed(
     () => isCloud && (capabilities.value?.can_subscribe_self_serve ?? false)
   )
+  const canCancel = computed(
+    () => isCloud && (capabilities.value?.can_cancel ?? false)
+  )
+  const canReactivate = computed(
+    () => isCloud && (capabilities.value?.can_reactivate ?? false)
+  )
+  const canChangeSeats = computed(
+    () => isCloud && (capabilities.value?.can_change_seats ?? false)
+  )
+  const canInviteMembers = computed(
+    () => isCloud && (capabilities.value?.can_invite_members ?? false)
+  )
+  const canDowngradeToPersonal = computed(
+    () => isCloud && (capabilities.value?.can_downgrade_to_personal ?? false)
+  )
   const isReady = computed(() => {
     if (!isCloud) return true
     const state = readState.value
@@ -392,7 +407,18 @@ function useBillingCapabilitiesInternal() {
     }
   )
 
-  return { canTopUp, canSubscribeSelfServe, isReady, initialize, refresh }
+  return {
+    canTopUp,
+    canSubscribeSelfServe,
+    canCancel,
+    canReactivate,
+    canChangeSeats,
+    canInviteMembers,
+    canDowngradeToPersonal,
+    isReady,
+    initialize,
+    refresh
+  }
 }
 
 export const useBillingCapabilities = createSharedComposable(

--- a/src/platform/workspace/composables/useDowngradeToPersonal.test.ts
+++ b/src/platform/workspace/composables/useDowngradeToPersonal.test.ts
@@ -26,6 +26,7 @@ const mockPermissions = vi.hoisted(() => ({
     canDowngradeToPersonal: true
   }
 }))
+const mockCanDowngradeToPersonal = vi.hoisted(() => ({ value: true }))
 
 vi.mock('pinia', async (importOriginal) => {
   const actual = await importOriginal()
@@ -51,6 +52,14 @@ vi.mock('@/platform/workspace/stores/billingOperationStore', () => ({
 
 vi.mock('@/platform/workspace/composables/useWorkspaceUI', () => ({
   useWorkspaceUI: () => ({ permissions: mockPermissions })
+}))
+
+vi.mock('@/platform/distribution/types', () => ({ isCloud: true }))
+
+vi.mock('@/platform/workspace/composables/useBillingCapabilities', () => ({
+  useBillingCapabilities: () => ({
+    canDowngradeToPersonal: mockCanDowngradeToPersonal
+  })
 }))
 
 vi.mock('@/composables/billing/useBillingContext', () => ({
@@ -132,6 +141,7 @@ describe('useDowngradeToPersonal', () => {
       canManageSubscription: true,
       canDowngradeToPersonal: true
     }
+    mockCanDowngradeToPersonal.value = true
     windowOpen = vi.spyOn(window, 'open').mockReturnValue({} as Window)
   })
 
@@ -195,6 +205,21 @@ describe('useDowngradeToPersonal', () => {
   describe('downgradeToPersonal', () => {
     it('rejects a promoted owner before previewing or removing members', async () => {
       mockPermissions.value.canDowngradeToPersonal = false
+      mockCanDowngradeToPersonal.value = false
+      mockMembers.value = teamWithOwnerAnd('m1')
+      const { downgradeToPersonal } = useDowngradeToPersonal()
+
+      await expect(downgradeToPersonal('founder-monthly')).rejects.toThrow(
+        'subscription.downgrade.notAllowed'
+      )
+      expect(mockPreviewSubscribe).not.toHaveBeenCalled()
+      expect(mockRemoveMember).not.toHaveBeenCalled()
+      expect(mockSubscribe).not.toHaveBeenCalled()
+    })
+
+    it('rejects a client-side owner when the server denies the downgrade', async () => {
+      mockPermissions.value.canDowngradeToPersonal = true
+      mockCanDowngradeToPersonal.value = false
       mockMembers.value = teamWithOwnerAnd('m1')
       const { downgradeToPersonal } = useDowngradeToPersonal()
 
@@ -210,6 +235,7 @@ describe('useDowngradeToPersonal', () => {
       mockMembers.value = teamWithOwnerAnd('m1')
       mockPreviewSubscribe.mockImplementation(async () => {
         mockPermissions.value.canDowngradeToPersonal = false
+        mockCanDowngradeToPersonal.value = false
         return { allowed: true }
       })
       const { downgradeToPersonal } = useDowngradeToPersonal()
@@ -225,6 +251,7 @@ describe('useDowngradeToPersonal', () => {
       mockMembers.value = teamWithOwnerAnd('m1', 'm2')
       mockRemoveMember.mockImplementation(async () => {
         mockPermissions.value.canDowngradeToPersonal = false
+        mockCanDowngradeToPersonal.value = false
       })
       const { downgradeToPersonal } = useDowngradeToPersonal()
 
@@ -912,6 +939,7 @@ describe('useDowngradeToPersonal', () => {
         canManageSubscription: false,
         canDowngradeToPersonal: false
       }
+      mockCanDowngradeToPersonal.value = false
       const { refreshMembers } = useDowngradeToPersonal()
 
       await expect(refreshMembers()).rejects.toThrow(
@@ -922,6 +950,7 @@ describe('useDowngradeToPersonal', () => {
 
     it('rejects a promoted owner after refreshing the original-owner signal', async () => {
       mockPermissions.value.canDowngradeToPersonal = false
+      mockCanDowngradeToPersonal.value = false
       const { refreshMembers } = useDowngradeToPersonal()
 
       await expect(refreshMembers()).rejects.toThrow(

--- a/src/platform/workspace/composables/useDowngradeToPersonal.ts
+++ b/src/platform/workspace/composables/useDowngradeToPersonal.ts
@@ -8,6 +8,7 @@ import { t } from '@/i18n'
 import type { TierKey } from '@/platform/cloud/subscription/constants/tierPricing'
 import { toTierKey } from '@/platform/cloud/subscription/constants/tierPricing'
 import type { BillingCycle } from '@/platform/cloud/subscription/utils/subscriptionTierRank'
+import { isCloud } from '@/platform/distribution/types'
 import { useTelemetry } from '@/platform/telemetry'
 import type { BillingFailure } from '@/platform/telemetry/types'
 import { categorizeBillingApiError } from '@/platform/telemetry/utils/billingFailureCategory'
@@ -15,6 +16,7 @@ import type {
   PreviewSubscribeResponse,
   SubscribeResponse
 } from '@/platform/workspace/api/workspaceApi'
+import { useBillingCapabilities } from '@/platform/workspace/composables/useBillingCapabilities'
 import { useWorkspaceUI } from '@/platform/workspace/composables/useWorkspaceUI'
 import { useBillingOperationStore } from '@/platform/workspace/stores/billingOperationStore'
 import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
@@ -65,6 +67,7 @@ export function useDowngradeToPersonal() {
   const billingOperationStore = useBillingOperationStore()
   const { userEmail } = useCurrentUser()
   const { permissions } = useWorkspaceUI()
+  const { canDowngradeToPersonal } = useBillingCapabilities()
   const telemetry = useTelemetry()
 
   const removableMembers = computed(() => {
@@ -79,7 +82,11 @@ export function useDowngradeToPersonal() {
   const hasOtherMembers = computed(() => removableMembers.value.length > 0)
 
   function ensureCanDowngrade(): void {
-    if (!permissions.value.canDowngradeToPersonal) {
+    if (
+      !(isCloud
+        ? canDowngradeToPersonal.value
+        : permissions.value.canDowngradeToPersonal)
+    ) {
       throw new Error(t('subscription.downgrade.notAllowed'))
     }
   }

--- a/src/platform/workspace/composables/useMembersPanel.test.ts
+++ b/src/platform/workspace/composables/useMembersPanel.test.ts
@@ -272,7 +272,9 @@ const {
   mockIsTeamPlan,
   mockSubscriptionStatus,
   mockWorkspaceRole,
-  mockSubscription
+  mockSubscription,
+  mockCanChangeSeats,
+  mockCanInviteMembers
 } = vi.hoisted(() => {
   // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/consistent-type-imports
   const { ref } = require('vue') as typeof import('vue')
@@ -314,6 +316,8 @@ const {
     mockIsTeamPlan: ref(true),
     mockSubscriptionStatus: ref<string | null>('active'),
     mockWorkspaceRole: ref<'owner' | 'member'>('owner'),
+    mockCanChangeSeats: ref(true),
+    mockCanInviteMembers: ref(true),
     mockSubscription: ref<{ tier: string; isCancelled?: boolean } | null>({
       tier: 'PRO',
       isCancelled: false
@@ -352,6 +356,15 @@ vi.mock('@/platform/workspace/composables/useWorkspaceUI', () => ({
     permissions: mockPermissions,
     uiConfig: mockUiConfig,
     workspaceRole: mockWorkspaceRole
+  })
+}))
+
+vi.mock('@/platform/distribution/types', () => ({ isCloud: true }))
+
+vi.mock('@/platform/workspace/composables/useBillingCapabilities', () => ({
+  useBillingCapabilities: () => ({
+    canChangeSeats: mockCanChangeSeats,
+    canInviteMembers: mockCanInviteMembers
   })
 }))
 
@@ -436,6 +449,8 @@ describe('useMembersPanel', () => {
     mockIsTeamPlan.value = true
     mockSubscriptionStatus.value = 'active'
     mockWorkspaceRole.value = 'owner'
+    mockCanChangeSeats.value = true
+    mockCanInviteMembers.value = true
     mockSubscription.value = { tier: 'PRO', isCancelled: false }
     mockPermissions.value = {
       canViewOtherMembers: true,
@@ -799,6 +814,7 @@ describe('useMembersPanel', () => {
 
     it('returns no actions without member-management permission', async () => {
       mockWorkspaceRole.value = 'member'
+      mockCanChangeSeats.value = false
       const panel = await setup()
 
       expect(panel.memberMenuItems(createMember())).toEqual([])
@@ -986,8 +1002,36 @@ describe('useMembersPanel', () => {
 
     it('hides the invite button for workspace members', async () => {
       mockWorkspaceRole.value = 'member'
+      mockCanInviteMembers.value = false
       const panel = await setup()
       expect(panel.showInviteButton.value).toBe(false)
+    })
+
+    it('hides invite actions when the server denies invitations', async () => {
+      mockCanInviteMembers.value = false
+      const panel = await setup()
+
+      expect(panel.showInviteButton.value).toBe(false)
+      await panel.handleResendInvite(createInvite({ id: 'inv-1' }))
+      panel.handleRevokeInvite(createInvite({ id: 'inv-1' }))
+      panel.handleInviteMember()
+
+      expect(mockResendInvite).not.toHaveBeenCalled()
+      expect(mockShowRevokeInviteDialog).not.toHaveBeenCalled()
+      expect(mockShowInviteMemberDialog).not.toHaveBeenCalled()
+    })
+
+    it('hides member management when the server denies seat changes', async () => {
+      mockCanChangeSeats.value = false
+      const panel = await setup()
+      const member = createMember({ id: 'member-1' })
+
+      expect(panel.permissions.value.canManageMembers).toBe(false)
+      panel.handleRemoveMember(member)
+      panel.handleChangeRole(member, 'owner')
+
+      expect(mockShowRemoveMemberDialog).not.toHaveBeenCalled()
+      expect(mockShowChangeMemberRoleDialog).not.toHaveBeenCalled()
     })
 
     it('keeps invite disabled while billing is initializing', async () => {

--- a/src/platform/workspace/composables/useMembersPanel.ts
+++ b/src/platform/workspace/composables/useMembersPanel.ts
@@ -8,7 +8,9 @@ import { useCurrentUser } from '@/composables/auth/useCurrentUser'
 import { useBillingContext } from '@/composables/billing/useBillingContext'
 import { useFeatureFlags } from '@/composables/useFeatureFlags'
 import { useSubscriptionDialog } from '@/platform/cloud/subscription/composables/useSubscriptionDialog'
+import { isCloud } from '@/platform/distribution/types'
 import type { WorkspaceRole } from '@/platform/workspace/api/workspaceApi'
+import { useBillingCapabilities } from '@/platform/workspace/composables/useBillingCapabilities'
 import { useTeamPlan } from '@/platform/workspace/composables/useTeamPlan'
 import { useWorkspaceUI } from '@/platform/workspace/composables/useWorkspaceUI'
 import type {
@@ -124,17 +126,22 @@ export function useMembersPanel() {
   } = useTeamPlan()
   const subscriptionDialog = useSubscriptionDialog()
   const { maxSeats, occupiedSeats } = useBillingContext()
+  const { canChangeSeats, canInviteMembers } = useBillingCapabilities()
 
   const permissions = computed(() => {
     const canManageMembers =
-      hasMemberSeats.value && workspaceRole.value === 'owner'
+      hasMemberSeats.value &&
+      (isCloud ? canChangeSeats.value : workspaceRole.value === 'owner')
+    const canManageInvites =
+      hasMemberSeats.value &&
+      (isCloud ? canInviteMembers.value : workspaceRole.value === 'owner')
 
     return {
       ...workspacePermissions.value,
       canViewOtherMembers: hasMemberSeats.value,
-      canViewPendingInvites: canManageMembers,
-      canInviteMembers: canManageMembers && !isCancelled.value,
-      canManageInvites: canManageMembers,
+      canViewPendingInvites: canManageInvites,
+      canInviteMembers: canManageInvites && !isCancelled.value,
+      canManageInvites,
       canManageMembers
     }
   })
@@ -195,7 +202,9 @@ export function useMembersPanel() {
       (hasMultipleMembers.value || pendingInvites.value.length > 0)
   )
 
-  const showInviteButton = computed(() => workspaceRole.value === 'owner')
+  const showInviteButton = computed(() =>
+    isCloud ? canInviteMembers.value : workspaceRole.value === 'owner'
+  )
 
   const isMemberLimitReached = computed(
     () =>
@@ -208,6 +217,7 @@ export function useMembersPanel() {
   const isInviteDisabled = computed(
     () =>
       isPlanLoading.value ||
+      !permissions.value.canInviteMembers ||
       isCancelled.value ||
       maxSeats.value === null ||
       occupiedSeats.value === null ||
@@ -223,6 +233,8 @@ export function useMembersPanel() {
   })
 
   function handleInviteMember() {
+    if (isCloud ? !canInviteMembers.value : workspaceRole.value !== 'owner')
+      return
     if (
       isPlanLoading.value ||
       maxSeats.value === null ||
@@ -342,6 +354,7 @@ export function useMembersPanel() {
   }
 
   async function handleResendInvite(invite: WorkspacePendingInvite) {
+    if (!permissions.value.canManageInvites) return
     try {
       await resendInvite(invite.id)
       toast.add({
@@ -358,10 +371,12 @@ export function useMembersPanel() {
   }
 
   function handleRevokeInvite(invite: WorkspacePendingInvite) {
+    if (!permissions.value.canManageInvites) return
     void showRevokeInviteDialog(invite.id)
   }
 
   function handleRemoveMember(member: WorkspaceMember) {
+    if (!permissions.value.canManageMembers) return
     void showRemoveMemberDialog(member.id)
   }
 
@@ -369,6 +384,7 @@ export function useMembersPanel() {
     member: WorkspaceMember,
     targetRole: WorkspaceRole
   ) {
+    if (!permissions.value.canManageMembers) return
     if (member.role === targetRole) return
     void showChangeMemberRoleDialog({
       memberId: member.id,

--- a/src/platform/workspace/composables/useResubscribe.test.ts
+++ b/src/platform/workspace/composables/useResubscribe.test.ts
@@ -7,6 +7,7 @@ import { useResubscribe } from './useResubscribe'
 const state = vi.hoisted(() => ({
   shouldUseWorkspaceBilling: true,
   canManageSubscriptionLifecycle: true,
+  canReactivate: true,
   resubscribe: vi.fn(),
   toastAdd: vi.fn(),
   trackResubscribeClicked: vi.fn(),
@@ -22,6 +23,18 @@ vi.mock('@/composables/billing/useBillingRouting', () => ({
     shouldUseWorkspaceBilling: {
       get value() {
         return state.shouldUseWorkspaceBilling
+      }
+    }
+  })
+}))
+
+vi.mock('@/platform/distribution/types', () => ({ isCloud: true }))
+
+vi.mock('@/platform/workspace/composables/useBillingCapabilities', () => ({
+  useBillingCapabilities: () => ({
+    canReactivate: {
+      get value() {
+        return state.canReactivate
       }
     }
   })
@@ -69,12 +82,27 @@ describe('useResubscribe', () => {
   beforeEach(() => {
     state.shouldUseWorkspaceBilling = true
     state.canManageSubscriptionLifecycle = true
+    state.canReactivate = true
     state.resubscribe.mockResolvedValue(undefined)
   })
 
   it('does not resubscribe after the workspace role loses permission', async () => {
     const { handleResubscribe, isResubscribing } = useResubscribe()
     state.canManageSubscriptionLifecycle = false
+    state.canReactivate = false
+
+    await handleResubscribe()
+
+    expect(state.resubscribe).not.toHaveBeenCalled()
+    expect(state.trackResubscribeClicked).not.toHaveBeenCalled()
+    expect(state.toastAdd).not.toHaveBeenCalled()
+    expect(isResubscribing.value).toBe(false)
+  })
+
+  it('does not resubscribe when the server denies reactivation to a client-side owner', async () => {
+    state.canManageSubscriptionLifecycle = true
+    state.canReactivate = false
+    const { handleResubscribe, isResubscribing } = useResubscribe()
 
     await handleResubscribe()
 

--- a/src/platform/workspace/composables/useResubscribe.ts
+++ b/src/platform/workspace/composables/useResubscribe.ts
@@ -4,8 +4,10 @@ import { useI18n } from 'vue-i18n'
 
 import { useBillingContext } from '@/composables/billing/useBillingContext'
 import { useBillingRouting } from '@/composables/billing/useBillingRouting'
+import { isCloud } from '@/platform/distribution/types'
 import { useTelemetry } from '@/platform/telemetry'
 import { categorizeBillingApiError } from '@/platform/telemetry/utils/billingFailureCategory'
+import { useBillingCapabilities } from '@/platform/workspace/composables/useBillingCapabilities'
 import { useWorkspaceUI } from '@/platform/workspace/composables/useWorkspaceUI'
 
 /**
@@ -17,6 +19,7 @@ export function useResubscribe() {
   const toast = useToast()
   const { resubscribe } = useBillingContext()
   const { shouldUseWorkspaceBilling } = useBillingRouting()
+  const { canReactivate } = useBillingCapabilities()
   const { permissions } = useWorkspaceUI()
 
   const isResubscribing = ref(false)
@@ -24,7 +27,9 @@ export function useResubscribe() {
   async function handleResubscribe() {
     if (
       shouldUseWorkspaceBilling.value &&
-      !permissions.value.canManageSubscriptionLifecycle
+      !(isCloud
+        ? canReactivate.value
+        : permissions.value.canManageSubscriptionLifecycle)
     ) {
       return
     }

--- a/src/platform/workspace/composables/useSubscriptionCheckout.test.ts
+++ b/src/platform/workspace/composables/useSubscriptionCheckout.test.ts
@@ -175,6 +175,7 @@ const {
   mockSetActiveWorkspaceIdImpl,
   mockSetActiveWorkspaceId,
   mockPermissions,
+  mockCapabilities,
   mockSubscription
 } = vi.hoisted(() => ({
   mockSubscribe: vi.fn(),
@@ -214,6 +215,14 @@ const {
     value: {
       canManageSubscription: true,
       canManageSubscriptionLifecycle: true,
+      canDowngradeToPersonal: true
+    }
+  },
+  mockCapabilities: {
+    value: {
+      canSubscribeSelfServe: true,
+      canReactivate: true,
+      canChangeSeats: true,
       canDowngradeToPersonal: true
     }
   },
@@ -272,6 +281,33 @@ vi.mock('@/platform/workspace/composables/useWorkspaceUI', () => ({
     permissions: {
       get value() {
         return mockPermissions.value
+      }
+    }
+  })
+}))
+
+vi.mock('@/platform/distribution/types', () => ({ isCloud: true }))
+
+vi.mock('@/platform/workspace/composables/useBillingCapabilities', () => ({
+  useBillingCapabilities: () => ({
+    canSubscribeSelfServe: {
+      get value() {
+        return mockCapabilities.value.canSubscribeSelfServe
+      }
+    },
+    canReactivate: {
+      get value() {
+        return mockCapabilities.value.canReactivate
+      }
+    },
+    canChangeSeats: {
+      get value() {
+        return mockCapabilities.value.canChangeSeats
+      }
+    },
+    canDowngradeToPersonal: {
+      get value() {
+        return mockCapabilities.value.canDowngradeToPersonal
       }
     }
   })
@@ -459,6 +495,12 @@ describe('useSubscriptionCheckout', () => {
     mockPermissions.value = {
       canManageSubscription: true,
       canManageSubscriptionLifecycle: true,
+      canDowngradeToPersonal: true
+    }
+    mockCapabilities.value = {
+      canSubscribeSelfServe: true,
+      canReactivate: true,
+      canChangeSeats: true,
       canDowngradeToPersonal: true
     }
     mockSubscription.value = null
@@ -1057,6 +1099,26 @@ describe('useSubscriptionCheckout', () => {
         canManageSubscriptionLifecycle: false,
         canDowngradeToPersonal: false
       }
+      mockCapabilities.value = {
+        canSubscribeSelfServe: false,
+        canReactivate: false,
+        canChangeSeats: false,
+        canDowngradeToPersonal: false
+      }
+      const checkout = await setup()
+
+      await checkout.handleSubscribeClick({
+        tierKey: 'standard',
+        billingCycle: 'yearly'
+      })
+
+      expect(mockPreviewSubscribe).not.toHaveBeenCalled()
+      expect(checkout.checkoutStep.value).toBe('pricing')
+    })
+
+    it('does not preview a plan when the server denies checkout to a client-side owner', async () => {
+      mockCapabilities.value.canSubscribeSelfServe = false
+      mockCapabilities.value.canChangeSeats = false
       const checkout = await setup()
 
       await checkout.handleSubscribeClick({
@@ -1071,6 +1133,7 @@ describe('useSubscriptionCheckout', () => {
     it('does not preview a personal plan for a promoted owner on a team plan', async () => {
       mockIsTeamPlan.value = true
       mockPermissions.value.canDowngradeToPersonal = false
+      mockCapabilities.value.canDowngradeToPersonal = false
       const checkout = await setup()
 
       await checkout.handleSubscribeClick({
@@ -1078,6 +1141,22 @@ describe('useSubscriptionCheckout', () => {
         billingCycle: 'yearly'
       })
 
+      expect(mockShowDowngradeToPersonalDialog).not.toHaveBeenCalled()
+      expect(mockPreviewSubscribe).not.toHaveBeenCalled()
+      expect(checkout.checkoutStep.value).toBe('pricing')
+    })
+
+    it('does not start the Team-to-personal downgrade when the server denies it to a client-side owner', async () => {
+      mockIsTeamPlan.value = true
+      mockCapabilities.value.canDowngradeToPersonal = false
+      const checkout = await setup()
+
+      await checkout.handleSubscribeClick({
+        tierKey: 'standard',
+        billingCycle: 'yearly'
+      })
+
+      expect(mockShowDowngradeToPersonalDialog).not.toHaveBeenCalled()
       expect(mockPreviewSubscribe).not.toHaveBeenCalled()
       expect(checkout.checkoutStep.value).toBe('pricing')
     })
@@ -1085,6 +1164,7 @@ describe('useSubscriptionCheckout', () => {
     it('allows a promoted owner to preview a legacy Team-plan change', async () => {
       mockIsTeamPlan.value = true
       mockPermissions.value.canDowngradeToPersonal = false
+      mockCapabilities.value.canDowngradeToPersonal = false
       mockPreviewSubscribe.mockResolvedValueOnce({
         allowed: true,
         transition_type: 'upgrade'
@@ -1641,6 +1721,28 @@ describe('useSubscriptionCheckout', () => {
 
     it('does not prepare a team checkout for a member', async () => {
       mockPermissions.value.canManageSubscription = false
+      mockCapabilities.value.canChangeSeats = false
+      mockCapabilities.value.canSubscribeSelfServe = false
+      const checkout = await setup()
+
+      await checkout.handleSubscribeTeamClick({
+        stop: {
+          id: 'team_700',
+          usd: 700,
+          credits: 147_700,
+          discountedUsd: 665
+        },
+        billingCycle: 'monthly',
+        isChange: true
+      })
+
+      expect(mockPreviewSubscribe).not.toHaveBeenCalled()
+      expect(checkout.selectedTeamStop.value).toBeNull()
+      expect(checkout.checkoutStep.value).toBe('pricing')
+    })
+
+    it('does not prepare a team checkout when the server denies seat changes to a client-side owner', async () => {
+      mockCapabilities.value.canChangeSeats = false
       const checkout = await setup()
 
       await checkout.handleSubscribeTeamClick({
@@ -3123,6 +3225,8 @@ describe('useSubscriptionCheckout', () => {
       checkout.selectedTierKey.value = 'standard'
       checkout.selectedBillingCycle.value = 'yearly'
       mockPermissions.value.canManageSubscription = false
+      mockCapabilities.value.canChangeSeats = false
+      mockCapabilities.value.canSubscribeSelfServe = false
 
       await checkout.handleAddCreditCard()
 
@@ -3592,6 +3696,8 @@ describe('useSubscriptionCheckout', () => {
       })
       expect(checkout.checkoutStep.value).toBe('preview')
       mockPermissions.value.canManageSubscription = false
+      mockCapabilities.value.canChangeSeats = false
+      mockCapabilities.value.canSubscribeSelfServe = false
 
       await checkout.handleConfirmTransition()
 
@@ -3772,6 +3878,17 @@ describe('useSubscriptionCheckout', () => {
 
     it('does not resubscribe for a member', async () => {
       mockPermissions.value.canManageSubscriptionLifecycle = false
+      mockCapabilities.value.canReactivate = false
+      const checkout = await setup()
+
+      await checkout.handleResubscribe()
+
+      expect(mockResubscribe).not.toHaveBeenCalled()
+      expect(mockTrackResubscribeClicked).not.toHaveBeenCalled()
+    })
+
+    it('does not resubscribe when the server denies reactivation to a client-side owner', async () => {
+      mockCapabilities.value.canReactivate = false
       const checkout = await setup()
 
       await checkout.handleResubscribe()

--- a/src/platform/workspace/composables/useSubscriptionCheckout.ts
+++ b/src/platform/workspace/composables/useSubscriptionCheckout.ts
@@ -11,6 +11,7 @@ import { getTeamPlanSlug } from '@/platform/cloud/subscription/constants/teamPla
 import type { TeamPlanSelection } from '@/platform/cloud/subscription/constants/teamPlanCreditStops'
 import type { TierKey } from '@/platform/cloud/subscription/constants/tierPricing'
 import type { BillingCycle } from '@/platform/cloud/subscription/utils/subscriptionTierRank'
+import { isCloud } from '@/platform/distribution/types'
 import { useTelemetry } from '@/platform/telemetry'
 import type {
   PaymentIntentSource,
@@ -27,6 +28,7 @@ import type {
   SubscribeResponse
 } from '@/platform/workspace/api/workspaceApi'
 import { workspaceApi } from '@/platform/workspace/api/workspaceApi'
+import { useBillingCapabilities } from '@/platform/workspace/composables/useBillingCapabilities'
 import { useWorkspaceUI } from '@/platform/workspace/composables/useWorkspaceUI'
 import { useBillingOperationStore } from '@/platform/workspace/stores/billingOperationStore'
 import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
@@ -135,6 +137,12 @@ export function useSubscriptionCheckout(
     subscription
   } = useBillingContext()
   const { shouldUseWorkspaceBilling } = useBillingRouting()
+  const {
+    canSubscribeSelfServe,
+    canReactivate,
+    canChangeSeats,
+    canDowngradeToPersonal
+  } = useBillingCapabilities()
   const { permissions } = useWorkspaceUI()
   const telemetry = useTelemetry()
   const billingOperationStore = useBillingOperationStore()
@@ -585,8 +593,17 @@ export function useSubscriptionCheckout(
     return (
       tierPlanType === 'team' ||
       !isTeamPlan.value ||
-      permissions.value.canDowngradeToPersonal
+      (isCloud
+        ? canDowngradeToPersonal.value
+        : permissions.value.canDowngradeToPersonal)
     )
+  }
+
+  function canPerformCheckout(checkoutType: SubscriptionCheckoutType): boolean {
+    if (!isCloud) return permissions.value.canManageSubscription
+    return checkoutType === 'change'
+      ? canChangeSeats.value
+      : canSubscribeSelfServe.value
   }
 
   async function showTeamToPersonalDowngrade(
@@ -651,8 +668,12 @@ export function useSubscriptionCheckout(
   }) {
     if (
       isSubscribing.value ||
-      !permissions.value.canManageSubscription ||
-      !canSelectTierPlan()
+      !canSelectTierPlan() ||
+      (isTeamPlan.value && tierPlanType !== 'team'
+        ? !(isCloud
+            ? canDowngradeToPersonal.value
+            : permissions.value.canDowngradeToPersonal)
+        : isCloud && !canSubscribeSelfServe.value && !canChangeSeats.value)
     ) {
       return
     }
@@ -698,6 +719,9 @@ export function useSubscriptionCheckout(
         })
         return
       }
+      const checkoutType =
+        response.transition_type === 'new_subscription' ? 'new' : 'change'
+      if (!canPerformCheckout(checkoutType)) return
 
       installPreview(response)
       checkoutStep.value = 'preview'
@@ -730,14 +754,15 @@ export function useSubscriptionCheckout(
     billingCycle: BillingCycle
     isChange?: boolean
   }) {
-    if (isSubscribing.value || !permissions.value.canManageSubscription) return
+    const checkoutType = payload.isChange ? 'change' : 'new'
+    if (isSubscribing.value || !canPerformCheckout(checkoutType)) return
 
     const previewRequestId = ++teamPreviewRequestId
     promotionPreviewRequestId += 1
     reactivationRequired.value = false
     selectedTeamCheckout.value = {
       stop: payload.stop,
-      checkoutType: payload.isChange ? 'change' : 'new'
+      checkoutType
     }
     selectedBillingCycle.value = payload.billingCycle
     selectedTierKey.value = null
@@ -878,7 +903,7 @@ export function useSubscriptionCheckout(
     confirmationToken?: string,
     promotionCode?: string
   ) {
-    if (!permissions.value.canManageSubscription || !canSelectTierPlan()) return
+    if (!canSelectTierPlan()) return
     if (!beginCheckoutMutation()) return
 
     const tierKey = selectedTierKey.value
@@ -898,6 +923,10 @@ export function useSubscriptionCheckout(
       previewData.value.transition_type !== 'new_subscription'
         ? 'change'
         : 'new'
+    if (!canPerformCheckout(checkoutType)) {
+      finishCheckoutMutation()
+      return
+    }
 
     isSubscribing.value = true
     try {
@@ -1321,7 +1350,8 @@ export function useSubscriptionCheckout(
     if (
       isLoadingPreview.value ||
       isSubscribing.value ||
-      !permissions.value.canManageSubscription
+      !selectedTeamCheckout.value ||
+      !canPerformCheckout(selectedTeamCheckout.value.checkoutType)
     ) {
       return
     }
@@ -1429,7 +1459,12 @@ export function useSubscriptionCheckout(
   }
 
   async function handleResubscribe() {
-    if (!permissions.value.canManageSubscriptionLifecycle) return
+    if (
+      !(isCloud
+        ? canReactivate.value
+        : permissions.value.canManageSubscriptionLifecycle)
+    )
+      return
 
     const source = 'pricing_dialog' as const
 

--- a/src/platform/workspace/composables/useWorkspaceMenuItems.test.ts
+++ b/src/platform/workspace/composables/useWorkspaceMenuItems.test.ts
@@ -5,6 +5,7 @@ import { useWorkspaceMenuItems } from './useWorkspaceMenuItems'
 
 const state = vi.hoisted(() => ({
   billingStatus: 'paid',
+  canCancel: false,
   canLeaveWorkspace: false,
   canManageSubscription: false,
   canManageSubscriptionLifecycle: false,
@@ -13,6 +14,7 @@ const state = vi.hoisted(() => ({
   isFreeTier: false,
   isInPersonalWorkspace: false,
   planSlug: 'pro-monthly' as string | null,
+  shouldUseWorkspaceBilling: true,
   isSubscriptionCancelled: false
 }))
 
@@ -35,6 +37,24 @@ vi.mock('@/composables/billing/useBillingContext', () => ({
       endDate: '2026-08-01T00:00:00Z',
       planSlug: state.planSlug
     }))
+  })
+}))
+
+vi.mock('@/composables/billing/useBillingRouting', () => ({
+  useBillingRouting: () => ({
+    shouldUseWorkspaceBilling: computed(() => state.shouldUseWorkspaceBilling)
+  })
+}))
+
+vi.mock('@/platform/distribution/types', () => ({ isCloud: true }))
+
+vi.mock('@/platform/workspace/composables/useBillingCapabilities', () => ({
+  useBillingCapabilities: () => ({
+    canCancel: {
+      get value() {
+        return state.canCancel
+      }
+    }
   })
 }))
 
@@ -73,6 +93,7 @@ vi.mock('@/services/dialogService', () => ({
 describe('useWorkspaceMenuItems', () => {
   beforeEach(() => {
     state.billingStatus = 'paid'
+    state.canCancel = false
     state.canLeaveWorkspace = false
     state.canManageSubscription = false
     state.canManageSubscriptionLifecycle = false
@@ -81,11 +102,12 @@ describe('useWorkspaceMenuItems', () => {
     state.isFreeTier = false
     state.isInPersonalWorkspace = false
     state.planSlug = 'pro-monthly'
+    state.shouldUseWorkspaceBilling = true
     state.isSubscriptionCancelled = false
   })
 
   it('allows a promoted owner to cancel an active plan', () => {
-    state.canManageSubscriptionLifecycle = true
+    state.canCancel = true
 
     const { menuItems } = useWorkspaceMenuItems()
     const cancelItem = menuItems.value.find(
@@ -110,7 +132,32 @@ describe('useWorkspaceMenuItems', () => {
     )
   })
 
+  it('withholds cancellation for a free plan the capability still allows', () => {
+    state.canCancel = true
+    state.isFreeTier = true
+
+    const { menuItems } = useWorkspaceMenuItems()
+
+    expect(menuItems.value.map((item) => item.label)).not.toContain(
+      'subscription.cancelPlan'
+    )
+  })
+
+  it('defers to the capability for subscription state it already encodes', () => {
+    state.canCancel = true
+    state.isSubscriptionCancelled = true
+    state.isActiveSubscription = false
+    state.planSlug = null
+
+    const { menuItems } = useWorkspaceMenuItems()
+
+    expect(menuItems.value.map((item) => item.label)).toContain(
+      'subscription.cancelPlan'
+    )
+  })
+
   it('withholds cancellation for an already-cancelled plan', () => {
+    state.shouldUseWorkspaceBilling = false
     state.canManageSubscriptionLifecycle = true
     state.isSubscriptionCancelled = true
 
@@ -122,6 +169,7 @@ describe('useWorkspaceMenuItems', () => {
   })
 
   it('allows cancellation while a payment_failed plan needs payment recovery', () => {
+    state.shouldUseWorkspaceBilling = false
     state.billingStatus = 'payment_failed'
     state.canManageSubscriptionLifecycle = true
     state.isActiveSubscription = false
@@ -134,6 +182,7 @@ describe('useWorkspaceMenuItems', () => {
   })
 
   it('allows cancellation while an existing plan is paused', () => {
+    state.shouldUseWorkspaceBilling = false
     state.billingStatus = 'paused'
     state.canManageSubscriptionLifecycle = true
     state.isActiveSubscription = false
@@ -146,6 +195,7 @@ describe('useWorkspaceMenuItems', () => {
   })
 
   it('withholds cancellation when payment_failed has no subscription plan', () => {
+    state.shouldUseWorkspaceBilling = false
     state.billingStatus = 'payment_failed'
     state.canManageSubscriptionLifecycle = true
     state.isActiveSubscription = false
@@ -159,6 +209,7 @@ describe('useWorkspaceMenuItems', () => {
   })
 
   it('withholds cancellation for payment_failed without lifecycle permission', () => {
+    state.shouldUseWorkspaceBilling = false
     state.billingStatus = 'payment_failed'
     state.canManageSubscriptionLifecycle = false
     state.isActiveSubscription = false
@@ -170,14 +221,26 @@ describe('useWorkspaceMenuItems', () => {
     )
   })
 
-  it('rechecks eligibility before opening the cancellation dialog', () => {
+  it('withholds cancellation for a free plan on the legacy path', () => {
+    state.shouldUseWorkspaceBilling = false
     state.canManageSubscriptionLifecycle = true
+    state.isFreeTier = true
+
+    const { menuItems } = useWorkspaceMenuItems()
+
+    expect(menuItems.value.map((item) => item.label)).not.toContain(
+      'subscription.cancelPlan'
+    )
+  })
+
+  it('rechecks eligibility before opening the cancellation dialog', () => {
+    state.canCancel = true
     const { menuItems } = useWorkspaceMenuItems()
     const cancelItem = menuItems.value.find(
       (item) => item.label === 'subscription.cancelPlan'
     )
 
-    state.canManageSubscriptionLifecycle = false
+    state.canCancel = false
     cancelItem?.command?.({
       originalEvent: new Event('click'),
       item: cancelItem

--- a/src/platform/workspace/composables/useWorkspaceMenuItems.ts
+++ b/src/platform/workspace/composables/useWorkspaceMenuItems.ts
@@ -4,6 +4,9 @@ import { useI18n } from 'vue-i18n'
 import type { MenuItem } from 'primevue/menuitem'
 
 import { useBillingContext } from '@/composables/billing/useBillingContext'
+import { useBillingRouting } from '@/composables/billing/useBillingRouting'
+import { isCloud } from '@/platform/distribution/types'
+import { useBillingCapabilities } from '@/platform/workspace/composables/useBillingCapabilities'
 import { useWorkspaceUI } from '@/platform/workspace/composables/useWorkspaceUI'
 import { useDialogService } from '@/services/dialogService'
 
@@ -16,6 +19,8 @@ import { useDialogService } from '@/services/dialogService'
 export function useWorkspaceMenuItems() {
   const { t } = useI18n()
   const { billingStatus, isFreeTier, subscription } = useBillingContext()
+  const { shouldUseWorkspaceBilling } = useBillingRouting()
+  const { canCancel } = useBillingCapabilities()
   const {
     permissions,
     uiConfig,
@@ -37,12 +42,8 @@ export function useWorkspaceMenuItems() {
   }
 
   function cancelSubscription() {
-    if (
-      !permissions.value.canManageSubscriptionLifecycle ||
-      !canCancelPlan.value
-    ) {
-      return
-    }
+    if (isCloud && shouldUseWorkspaceBilling.value && !canCancel.value) return
+    if (!canCancelPlan.value) return
     void showCancelSubscriptionFlow(subscription.value?.endDate ?? undefined)
   }
 
@@ -62,8 +63,13 @@ export function useWorkspaceMenuItems() {
     void showLeaveWorkspaceDialog()
   }
 
-  const canCancelPlan = computed(
-    () =>
+  const canCancelPlan = computed(() => {
+    // can_cancel already encodes role, subscription presence/status and a
+    // scheduled cancellation, but not tier: it stays true for an active FREE
+    // plan, so the free-tier guard has to remain client-side.
+    if (isCloud && shouldUseWorkspaceBilling.value)
+      return canCancel.value && !isFreeTier.value
+    return (
       permissions.value.canManageSubscriptionLifecycle &&
       (isActiveSubscription.value ||
         ((billingStatus.value === 'payment_failed' ||
@@ -71,7 +77,8 @@ export function useWorkspaceMenuItems() {
           Boolean(subscription.value?.planSlug))) &&
       !isSubscriptionCancelled.value &&
       !isFreeTier.value
-  )
+    )
+  })
 
   const canDeleteWorkspace = computed(
     () =>

--- a/src/platform/workspace/composables/useWorkspaceUI.test.ts
+++ b/src/platform/workspace/composables/useWorkspaceUI.test.ts
@@ -136,7 +136,7 @@ describe('useWorkspaceUI', () => {
       mockStore.activeWorkspace = personalWorkspace
     })
 
-    it('grants billing access but disables team management', async () => {
+    it('grants billing access with personal workspace visibility', async () => {
       const ui = await loadComposable()
 
       expect(ui.workspaceType.value).toBe('personal')
@@ -146,9 +146,6 @@ describe('useWorkspaceUI', () => {
         canDowngradeToPersonal: false,
         canViewOtherMembers: false,
         canViewPendingInvites: false,
-        canInviteMembers: false,
-        canManageInvites: false,
-        canManageMembers: false,
         canLeaveWorkspace: false,
         canAccessWorkspaceMenu: false
       })
@@ -162,9 +159,6 @@ describe('useWorkspaceUI', () => {
       expect(ui.permissions.value).toMatchObject({
         canViewOtherMembers: true,
         canViewPendingInvites: false,
-        canInviteMembers: false,
-        canManageInvites: false,
-        canManageMembers: false,
         canLeaveWorkspace: true,
         canAccessWorkspaceMenu: true,
         canManageSubscription: false,
@@ -250,9 +244,6 @@ describe('useWorkspaceUI', () => {
       expect(ui.permissions.value).toMatchObject({
         canViewOtherMembers: true,
         canViewPendingInvites: true,
-        canInviteMembers: true,
-        canManageInvites: true,
-        canManageMembers: true,
         canLeaveWorkspace: true,
         canAccessWorkspaceMenu: true,
         canManageSubscription: true,
@@ -305,9 +296,6 @@ describe('useWorkspaceUI', () => {
       expect(ui.permissions.value).toMatchObject({
         canViewOtherMembers: true,
         canViewPendingInvites: false,
-        canInviteMembers: false,
-        canManageInvites: false,
-        canManageMembers: false,
         canLeaveWorkspace: true,
         canAccessWorkspaceMenu: true,
         canManageSubscription: false,

--- a/src/platform/workspace/composables/useWorkspaceUI.ts
+++ b/src/platform/workspace/composables/useWorkspaceUI.ts
@@ -11,9 +11,6 @@ import { useTeamWorkspaceStore } from '../stores/teamWorkspaceStore'
 interface WorkspacePermissions {
   canViewOtherMembers: boolean
   canViewPendingInvites: boolean
-  canInviteMembers: boolean
-  canManageInvites: boolean
-  canManageMembers: boolean
   canLeaveWorkspace: boolean
   canAccessWorkspaceMenu: boolean
   canManageSubscription: boolean
@@ -62,9 +59,6 @@ function getPermissions(
     return {
       canViewOtherMembers: true,
       canViewPendingInvites: false,
-      canInviteMembers: false,
-      canManageInvites: false,
-      canManageMembers: false,
       canLeaveWorkspace,
       canAccessWorkspaceMenu: canLeaveWorkspace,
       ...billingPermissions
@@ -75,9 +69,6 @@ function getPermissions(
     return {
       canViewOtherMembers: false,
       canViewPendingInvites: false,
-      canInviteMembers: false,
-      canManageInvites: false,
-      canManageMembers: false,
       canLeaveWorkspace,
       canAccessWorkspaceMenu: canLeaveWorkspace,
       ...billingPermissions
@@ -87,9 +78,6 @@ function getPermissions(
   return {
     canViewOtherMembers: true,
     canViewPendingInvites: true,
-    canInviteMembers: true,
-    canManageInvites: true,
-    canManageMembers: true,
     canLeaveWorkspace,
     canAccessWorkspaceMenu: true,
     ...billingPermissions

--- a/src/storybook/mocks/useBillingCapabilities.ts
+++ b/src/storybook/mocks/useBillingCapabilities.ts
@@ -1,20 +1,54 @@
-import { computed, ref } from 'vue'
+import { computed, reactive, ref } from 'vue'
+
+interface BillingCapabilitiesMockState {
+  canSubscribeSelfServe: boolean
+  canCancel: boolean
+  canReactivate: boolean
+  canChangeSeats: boolean
+  canInviteMembers: boolean
+  canDowngradeToPersonal: boolean
+}
 
 const canTopUpState = ref(true)
-const canSubscribeSelfServeState = ref(false)
+const defaultCapabilityState: BillingCapabilitiesMockState = {
+  canSubscribeSelfServe: false,
+  canCancel: true,
+  canReactivate: true,
+  canChangeSeats: true,
+  canInviteMembers: true,
+  canDowngradeToPersonal: true
+}
+const capabilityState = reactive<BillingCapabilitiesMockState>({
+  ...defaultCapabilityState
+})
 
 export function setCanTopUpMock(canTopUp: boolean) {
   canTopUpState.value = canTopUp
 }
 
+export function setBillingCapabilitiesMock(
+  capabilities: Partial<BillingCapabilitiesMockState>
+) {
+  Object.assign(capabilityState, defaultCapabilityState, capabilities)
+}
+
 export function setCanSubscribeSelfServeMock(canSubscribeSelfServe: boolean) {
-  canSubscribeSelfServeState.value = canSubscribeSelfServe
+  capabilityState.canSubscribeSelfServe = canSubscribeSelfServe
 }
 
 export function useBillingCapabilities() {
   return {
     canTopUp: computed(() => canTopUpState.value),
-    canSubscribeSelfServe: computed(() => canSubscribeSelfServeState.value),
+    canSubscribeSelfServe: computed(
+      () => capabilityState.canSubscribeSelfServe
+    ),
+    canCancel: computed(() => capabilityState.canCancel),
+    canReactivate: computed(() => capabilityState.canReactivate),
+    canChangeSeats: computed(() => capabilityState.canChangeSeats),
+    canInviteMembers: computed(() => capabilityState.canInviteMembers),
+    canDowngradeToPersonal: computed(
+      () => capabilityState.canDowngradeToPersonal
+    ),
     isReady: computed(() => true),
     initialize: () => undefined,
     refresh: () => undefined


### PR DESCRIPTION
Backport of #15675 to `cloud/1.52`.

## Merge order — this PR is stacked

Base is deliberately `backport-15804-to-cloud-1.52`, not `cloud/1.52`. GitHub retargets this PR to `cloud/1.52` once its parent merges.

`cloud/1.52` → #15799 → #15803 → #15804 → #15675 → #15967 → #16043 → #16046 → #16067

Every commit in this chain cherry-picks cleanly; there are no hand-resolved conflicts anywhere in the stack.

## Verification

Run at the tip of the full stack: 93 unit test files, 1745 tests, 0 failures (`src/platform/workspace`, `src/platform/cloud/subscription`, `src/composables/useCoreCommands.test.ts`, `src/components/actionbar`).