### PR TITLE
[backport cloud/1.52] fix(billing): align pricing-dialog reactivation with the centralized rail policy

### DIFF
--- a/src/platform/workspace/components/CurrentUserPopoverWorkspace.test.ts
+++ b/src/platform/workspace/components/CurrentUserPopoverWorkspace.test.ts
@@ -22,6 +22,8 @@ const state = vi.hoisted(() => ({
   canManageSubscription: false,
   canManageSubscriptionLifecycle: false,
   canReactivate: false,
+  canReactivatePlan: false,
+  shouldUseWorkspaceBilling: true,
   showCreateWorkspaceDialog: vi.fn(),
   showTopUpCreditsDialog: vi.fn(),
   showPricingTable: vi.fn(),
@@ -76,7 +78,8 @@ vi.mock('@/platform/workspace/composables/useWorkspaceUI', () => ({
     permissions: computed(() => ({
       canManageSubscription: state.canManageSubscription,
       canManageSubscriptionLifecycle: state.canManageSubscriptionLifecycle
-    }))
+    })),
+    canReactivatePlan: computed(() => state.canReactivatePlan)
   })
 }))
 
@@ -85,6 +88,12 @@ vi.mock('@/platform/workspace/composables/useBillingCapabilities', () => ({
     canTopUp: computed(() => state.canTopUp),
     canSubscribeSelfServe: computed(() => state.canSubscribeSelfServe),
     canReactivate: computed(() => state.canReactivate)
+  })
+}))
+
+vi.mock('@/composables/billing/useBillingRouting', () => ({
+  useBillingRouting: () => ({
+    shouldUseWorkspaceBilling: computed(() => state.shouldUseWorkspaceBilling)
   })
 }))
 
@@ -190,6 +199,7 @@ describe('CurrentUserPopoverWorkspace', () => {
     state.canManageSubscription = false
     state.canManageSubscriptionLifecycle = false
     state.canReactivate = false
+    state.shouldUseWorkspaceBilling = true
   })
 
   it('toggles the workspace switcher panel from the selector row', async () => {
@@ -506,7 +516,7 @@ describe('CurrentUserPopoverWorkspace', () => {
       state.isCancelled = isCancelled
       state.canManageSubscription = canManageSubscription
       state.canManageSubscriptionLifecycle = canManageSubscriptionLifecycle
-      state.canReactivate = canReactivate
+      state.canReactivatePlan = canReactivate
       state.canSubscribeSelfServe = canSubscribeSelfServe
 
       renderComponent('team')
@@ -526,7 +536,7 @@ describe('CurrentUserPopoverWorkspace', () => {
     state.canTopUp = true
     state.canManageSubscription = true
     state.canManageSubscriptionLifecycle = true
-    state.canReactivate = true
+    state.canReactivatePlan = true
     renderComponent('team')
 
     expect(screen.getByTestId('add-credits-button')).toBeInTheDocument()
@@ -536,6 +546,22 @@ describe('CurrentUserPopoverWorkspace', () => {
     await user.click(screen.getByRole('button', { name: 'Resubscribe' }))
 
     expect(state.showPricingTable).toHaveBeenCalledOnce()
+  })
+
+  it('reads the derived reactivate policy, not the raw server capability', () => {
+    state.isCancelled = true
+    state.canManageSubscriptionLifecycle = true
+    // The legacy rail resolves can_reactivate false but still permits
+    // reactivation, so the button must follow canReactivatePlan. Rail
+    // selection itself is covered in useWorkspaceUI.test.ts.
+    state.canReactivate = false
+    state.canReactivatePlan = true
+
+    renderComponent('personal')
+
+    expect(
+      screen.getByRole('button', { name: 'Resubscribe' })
+    ).toBeInTheDocument()
   })
 
   for (const workspaceType of ['personal', 'team'] as const) {

--- a/src/platform/workspace/components/CurrentUserPopoverWorkspace.vue
+++ b/src/platform/workspace/components/CurrentUserPopoverWorkspace.vue
@@ -281,9 +281,8 @@ const {
   workspaceName,
   isInPersonalWorkspace: isPersonalWorkspace
 } = storeToRefs(workspaceStore)
-const { permissions } = useWorkspaceUI()
-const { canTopUp, canSubscribeSelfServe, canReactivate } =
-  useBillingCapabilities()
+const { permissions, canReactivatePlan } = useWorkspaceUI()
+const { canTopUp, canSubscribeSelfServe } = useBillingCapabilities()
 const isWorkspaceSwitcherOpen = ref(false)
 const workspaceSwitcherTrigger = useTemplateRef('workspaceSwitcherTrigger')
 const workspaceSwitcherPanel = useTemplateRef('workspaceSwitcherPanel')
@@ -366,12 +365,13 @@ const showManagePlan = computed(
     permissions.value.canManageSubscription &&
     (canAccessSubscriptionFeatures.value || hasDelinquentSubscription.value)
 )
+
 const showSubscribeAction = computed(
   () =>
-    // Subscribing is Cloud-only, so the whole action stays gated on isCloud;
-    // inside it the server-resolved capabilities are authoritative.
+    // Subscribing is Cloud-only, so the whole action stays gated on isCloud.
+    // Self-serve subscribe is server-authoritative; reactivation is not.
     isCloud &&
-    ((isCancelled.value && canReactivate.value) ||
+    ((isCancelled.value && canReactivatePlan.value) ||
       (!canAccessSubscriptionFeatures.value &&
         !hasDelinquentSubscription.value &&
         canSubscribeSelfServe.value))

--- a/src/platform/workspace/components/SubscriptionPanelContentWorkspace.test.ts
+++ b/src/platform/workspace/components/SubscriptionPanelContentWorkspace.test.ts
@@ -85,6 +85,7 @@ const mockCanManageSubscription = ref(true)
 const mockCanManageSubscriptionLifecycle = ref(true)
 const mockCanCancel = ref(true)
 const mockCanReactivate = ref(true)
+const mockCanReactivatePlan = ref(true)
 const mockShouldUseWorkspaceBilling = ref(true)
 const mockCanChangeSeats = ref(true)
 const mockCanSubscribeSelfServe = ref(true)
@@ -223,6 +224,7 @@ vi.mock('@/platform/workspace/composables/useWorkspaceUI', () => ({
       canManageSubscriptionLifecycle: mockCanManageSubscriptionLifecycle.value,
       canLeaveWorkspace: mockCanLeaveWorkspace.value
     })),
+    canReactivatePlan: mockCanReactivatePlan,
     uiConfig: computed(() => mockUiConfig.value),
     isInPersonalWorkspace: mockIsInPersonalWorkspace,
     isActiveSubscription: computed(() => mockIsActiveSubscription.value),
@@ -820,7 +822,7 @@ describe('SubscriptionPanelContentWorkspace', () => {
     mockHasTeamPlan.value = false
     mockIsWorkspaceSubscribed.value = false
     mockCanManageSubscriptionLifecycle.value = true
-    mockCanReactivate.value = false
+    mockCanReactivatePlan.value = false
     renderComponent()
 
     expect(

--- a/src/platform/workspace/components/SubscriptionPanelContentWorkspace.vue
+++ b/src/platform/workspace/components/SubscriptionPanelContentWorkspace.vue
@@ -417,7 +417,6 @@ import type { TierBenefit } from '@/platform/cloud/subscription/utils/tierBenefi
 import { getCommonTierBenefits } from '@/platform/cloud/subscription/utils/tierBenefits'
 import { isCloud } from '@/platform/distribution/types'
 import { useResubscribe } from '@/platform/workspace/composables/useResubscribe'
-import { useBillingRouting } from '@/composables/billing/useBillingRouting'
 import { useBillingCapabilities } from '@/platform/workspace/composables/useBillingCapabilities'
 import { useWorkspaceMenuItems } from '@/platform/workspace/composables/useWorkspaceMenuItems'
 import { useWorkspacePlanPricing } from '@/platform/workspace/composables/useWorkspacePlanPricing'
@@ -432,10 +431,13 @@ import {
 const workspaceStore = useTeamWorkspaceStore()
 const { isWorkspaceSubscribed, isInPersonalWorkspace } =
   storeToRefs(workspaceStore)
-const { permissions, isSubscriptionCancelled, workspaceRole } = useWorkspaceUI()
-const { shouldUseWorkspaceBilling } = useBillingRouting()
-const { canReactivate, canChangeSeats, canSubscribeSelfServe } =
-  useBillingCapabilities()
+const {
+  permissions,
+  isSubscriptionCancelled,
+  workspaceRole,
+  canReactivatePlan
+} = useWorkspaceUI()
+const { canChangeSeats, canSubscribeSelfServe } = useBillingCapabilities()
 const { maxAvailable: freeRunsAllowance, quotaEnabled: freeRunsQuotaEnabled } =
   useFreeTierQuota()
 const { t, n, locale } = useI18n()
@@ -505,11 +507,6 @@ const showSubscribePrompt = computed(() => {
 // The legacy rail keeps lifecycle authorization on the client, and
 // handleResubscribe() skips its capability guard there, so the affordance has
 // to follow the same three-way condition or it hides a working action.
-const canReactivatePlan = computed(() =>
-  isCloud && shouldUseWorkspaceBilling.value
-    ? canReactivate.value
-    : permissions.value.canManageSubscriptionLifecycle
-)
 const canChangePlan = computed(() =>
   isCloud ? canChangeSeats.value : permissions.value.canManageSubscription
 )

--- a/src/platform/workspace/components/UnifiedPricingTable.test.ts
+++ b/src/platform/workspace/components/UnifiedPricingTable.test.ts
@@ -29,6 +29,10 @@ const mockCurrentTeamCreditStop = ref<MockTeamStop | null>(null)
 const mockIsTeamPlan = ref(false)
 const mockCanManageSubscription = ref(true)
 const mockCanDowngradeToPersonal = ref(true)
+const mockCanReactivatePlan = ref(true)
+// the raw server capability, kept separate so a test can prove the component
+// follows the derived policy rather than this value
+const mockRawCanReactivate = ref(true)
 const mockPermissions = ref({
   canManageSubscription: true,
   canManageSubscriptionLifecycle: true,
@@ -53,7 +57,7 @@ vi.mock('@/platform/distribution/types', () => mockDistributionTypes)
 vi.mock('@/platform/workspace/composables/useBillingCapabilities', () => ({
   useBillingCapabilities: () => ({
     canSubscribeSelfServe: computed(() => mockCanManageSubscription.value),
-    canReactivate: computed(() => mockCanManageSubscription.value),
+    canReactivate: computed(() => mockRawCanReactivate.value),
     canChangeSeats: computed(() => mockCanManageSubscription.value),
     canDowngradeToPersonal: computed(() => mockCanDowngradeToPersonal.value)
   })
@@ -61,7 +65,8 @@ vi.mock('@/platform/workspace/composables/useBillingCapabilities', () => ({
 
 vi.mock('@/platform/workspace/composables/useWorkspaceUI', () => ({
   useWorkspaceUI: () => ({
-    permissions: computed(() => mockPermissions.value)
+    permissions: computed(() => mockPermissions.value),
+    canReactivatePlan: computed(() => mockCanReactivatePlan.value)
   })
 }))
 
@@ -93,6 +98,8 @@ function renderComponent(props: Record<string, unknown> = {}) {
 
 describe('UnifiedPricingTable plan CTA labels', () => {
   beforeEach(() => {
+    mockCanReactivatePlan.value = true
+    mockRawCanReactivate.value = true
     mockSubscription.value = null
     mockSubscriptionStatus.value = null
     mockCurrentPlanSlug.value = null
@@ -222,6 +229,8 @@ describe('UnifiedPricingTable team plan CTA', () => {
   }
 
   beforeEach(() => {
+    mockCanReactivatePlan.value = true
+    mockRawCanReactivate.value = true
     mockSubscription.value = null
     mockSubscriptionStatus.value = null
     mockCurrentPlanSlug.value = null
@@ -309,6 +318,20 @@ describe('UnifiedPricingTable team plan CTA', () => {
     expect(emitted().resubscribe).toBeTruthy()
   })
 
+  it('disables Resubscribe when the workspace may not reactivate', () => {
+    mockSubscription.value = {
+      tier: 'TEAM',
+      duration: 'ANNUAL',
+      isCancelled: true
+    }
+    mockCurrentTeamCreditStop.value = TEAM_STOP
+    mockCanReactivatePlan.value = false
+
+    renderComponent({ initialPlanMode: 'team' })
+
+    expect(screen.getByRole('button', { name: 'Resubscribe' })).toBeDisabled()
+  })
+
   it('lets a cancelled sub change to a different stop (not re-subscribe)', async () => {
     const user = userEvent.setup()
     mockSubscription.value = {
@@ -368,6 +391,8 @@ describe('UnifiedPricingTable outside Cloud', () => {
   }
 
   beforeEach(() => {
+    mockCanReactivatePlan.value = true
+    mockRawCanReactivate.value = true
     mockSubscription.value = null
     mockSubscriptionStatus.value = null
     mockCurrentPlanSlug.value = null

--- a/src/platform/workspace/components/UnifiedPricingTable.vue
+++ b/src/platform/workspace/components/UnifiedPricingTable.vue
@@ -469,17 +469,12 @@ const emit = defineEmits<{
 
 const { t, n } = useI18n()
 const capabilities = useBillingCapabilities()
-const { permissions } = useWorkspaceUI()
+const { permissions, canReactivatePlan } = useWorkspaceUI()
 
 const canSubscribeSelfServe = computed(() =>
   isCloud
     ? capabilities.canSubscribeSelfServe.value
     : permissions.value.canManageSubscription
-)
-const canReactivate = computed(() =>
-  isCloud
-    ? capabilities.canReactivate.value
-    : permissions.value.canManageSubscriptionLifecycle
 )
 const canChangeSeats = computed(() =>
   isCloud
@@ -770,7 +765,7 @@ const isTeamButtonDisabled = computed(() => {
   if (isLoading) return true
   if (!isTeamSubscribed.value) return !canSubscribeSelfServe.value
   if (isTeamCurrentPlanSelected.value) {
-    return !isCancelled.value || !canReactivate.value
+    return !isCancelled.value || !canReactivatePlan.value
   }
   return !canChangeSeats.value
 })
@@ -861,7 +856,7 @@ const canUsePersonalPlanAction = (tierKey: CheckoutTierKey): boolean => {
   if (!canSelectPersonalPlan.value) return false
   if (isTeamPlan.value) return canDowngradeToPersonal.value
   if (isCurrentPlan(tierKey)) {
-    return isCancelled.value && canReactivate.value
+    return isCancelled.value && canReactivatePlan.value
   }
   return hasActivePaidPlan(currentAccountTier.value)
     ? canChangeSeats.value

--- a/src/platform/workspace/components/dialogs/settings/BillingStatusBanner.test.ts
+++ b/src/platform/workspace/components/dialogs/settings/BillingStatusBanner.test.ts
@@ -28,10 +28,11 @@ const state = vi.hoisted(() => ({
     endDate: null
   } as Subscription | null,
   renewalDate: null as string | null,
-  workspaceType: 'team' as string,
+  workspaceType: 'team' as WorkspaceType,
   canManageSubscription: true,
   canManageSubscriptionLifecycle: true,
   canReactivate: true,
+  canReactivatePlan: true,
   shouldUseWorkspaceBilling: true,
   canTopUp: true,
   canSubscribeSelfServe: false,
@@ -80,7 +81,8 @@ vi.mock('@/platform/workspace/composables/useWorkspaceUI', () => ({
       canManageSubscription: state.canManageSubscription,
       canManageSubscriptionLifecycle: state.canManageSubscriptionLifecycle
     })),
-    workspaceType: computed(() => state.workspaceType as WorkspaceType)
+    workspaceType: computed(() => state.workspaceType),
+    canReactivatePlan: computed(() => state.canReactivatePlan)
   })
 }))
 
@@ -405,7 +407,7 @@ describe('BillingStatusBanner', () => {
     }
     state.canManageSubscription = true
     state.canManageSubscriptionLifecycle = true
-    state.canReactivate = false
+    state.canReactivatePlan = false
     renderBanner()
 
     expect(screen.getByRole('status')).toHaveTextContent(

--- a/src/platform/workspace/components/dialogs/settings/BillingStatusBanner.vue
+++ b/src/platform/workspace/components/dialogs/settings/BillingStatusBanner.vue
@@ -74,8 +74,6 @@ import { useI18n } from 'vue-i18n'
 import Button from '@/components/ui/button/Button.vue'
 import { useBillingContext } from '@/composables/billing/useBillingContext'
 import { useBillingBanner } from '@/platform/workspace/composables/useBillingBanner'
-import { isCloud } from '@/platform/distribution/types'
-import { useBillingRouting } from '@/composables/billing/useBillingRouting'
 import { useBillingCapabilities } from '@/platform/workspace/composables/useBillingCapabilities'
 import { useResubscribe } from '@/platform/workspace/composables/useResubscribe'
 import { useWorkspaceUI } from '@/platform/workspace/composables/useWorkspaceUI'
@@ -85,10 +83,8 @@ type BannerAction = 'addCredits' | 'reactivate' | 'updatePayment'
 
 const { t, d } = useI18n()
 const { renewalDate, subscription, manageSubscription } = useBillingContext()
-const { permissions } = useWorkspaceUI()
-const { shouldUseWorkspaceBilling } = useBillingRouting()
-const { canTopUp, canSubscribeSelfServe, canReactivate } =
-  useBillingCapabilities()
+const { permissions, canReactivatePlan } = useWorkspaceUI()
+const { canTopUp, canSubscribeSelfServe } = useBillingCapabilities()
 const { kind, dismiss } = useBillingBanner()
 const { isResubscribing, handleResubscribe } = useResubscribe()
 const dialogService = useDialogService()
@@ -97,11 +93,6 @@ const canManage = computed(() => permissions.value.canManageSubscription)
 // The legacy rail keeps lifecycle authorization on the client, and
 // handleResubscribe() skips its capability guard there, so the affordance has
 // to follow the same three-way condition or it hides a working action.
-const canReactivatePlan = computed(() =>
-  isCloud && shouldUseWorkspaceBilling.value
-    ? canReactivate.value
-    : permissions.value.canManageSubscriptionLifecycle
-)
 const cycleResetDate = computed(() => {
   const raw = renewalDate.value
   return raw ? d(new Date(raw), { month: 'short', day: 'numeric' }) : ''

--- a/src/platform/workspace/composables/useSubscriptionCheckout.test.ts
+++ b/src/platform/workspace/composables/useSubscriptionCheckout.test.ts
@@ -175,6 +175,7 @@ const {
   mockSetActiveWorkspaceIdImpl,
   mockSetActiveWorkspaceId,
   mockPermissions,
+  mockCanReactivatePlan,
   mockCapabilities,
   mockSubscription
 } = vi.hoisted(() => ({
@@ -218,6 +219,7 @@ const {
       canDowngradeToPersonal: true
     }
   },
+  mockCanReactivatePlan: { value: true },
   mockCapabilities: {
     value: {
       canSubscribeSelfServe: true,
@@ -281,6 +283,11 @@ vi.mock('@/platform/workspace/composables/useWorkspaceUI', () => ({
     permissions: {
       get value() {
         return mockPermissions.value
+      }
+    },
+    canReactivatePlan: {
+      get value() {
+        return mockCanReactivatePlan.value
       }
     }
   })
@@ -503,6 +510,7 @@ describe('useSubscriptionCheckout', () => {
       canChangeSeats: true,
       canDowngradeToPersonal: true
     }
+    mockCanReactivatePlan.value = true
     mockSubscription.value = null
     sessionStorage.clear()
     emit = vi.fn()
@@ -3876,9 +3884,29 @@ describe('useSubscriptionCheckout', () => {
       })
     })
 
+    it('resubscribes on the legacy rail even though the server withholds can_reactivate', async () => {
+      // legacy_stripe workspaces have no capability projection row, so the
+      // raw capability is false while the workspace may still reactivate.
+      mockCapabilities.value.canReactivate = false
+      mockCanReactivatePlan.value = true
+      const checkout = await setup()
+      mockResubscribe.mockResolvedValueOnce({
+        billing_op_id: 'op-legacy-rail',
+        status: 'active'
+      })
+      mockFetchStatus.mockResolvedValueOnce(undefined)
+      mockFetchBalance.mockResolvedValueOnce(undefined)
+
+      await checkout.handleResubscribe()
+
+      expect(emit).toHaveBeenCalledWith('close', true)
+      expect(mockResubscribe).toHaveBeenCalled()
+    })
+
     it('does not resubscribe for a member', async () => {
       mockPermissions.value.canManageSubscriptionLifecycle = false
       mockCapabilities.value.canReactivate = false
+      mockCanReactivatePlan.value = false
       const checkout = await setup()
 
       await checkout.handleResubscribe()
@@ -3889,6 +3917,7 @@ describe('useSubscriptionCheckout', () => {
 
     it('does not resubscribe when the server denies reactivation to a client-side owner', async () => {
       mockCapabilities.value.canReactivate = false
+      mockCanReactivatePlan.value = false
       const checkout = await setup()
 
       await checkout.handleResubscribe()

--- a/src/platform/workspace/composables/useSubscriptionCheckout.ts
+++ b/src/platform/workspace/composables/useSubscriptionCheckout.ts
@@ -137,13 +137,9 @@ export function useSubscriptionCheckout(
     subscription
   } = useBillingContext()
   const { shouldUseWorkspaceBilling } = useBillingRouting()
-  const {
-    canSubscribeSelfServe,
-    canReactivate,
-    canChangeSeats,
-    canDowngradeToPersonal
-  } = useBillingCapabilities()
-  const { permissions } = useWorkspaceUI()
+  const { canSubscribeSelfServe, canChangeSeats, canDowngradeToPersonal } =
+    useBillingCapabilities()
+  const { permissions, canReactivatePlan } = useWorkspaceUI()
   const telemetry = useTelemetry()
   const billingOperationStore = useBillingOperationStore()
   const workspaceStore = useTeamWorkspaceStore()
@@ -1459,12 +1455,7 @@ export function useSubscriptionCheckout(
   }
 
   async function handleResubscribe() {
-    if (
-      !(isCloud
-        ? canReactivate.value
-        : permissions.value.canManageSubscriptionLifecycle)
-    )
-      return
+    if (!canReactivatePlan.value) return
 
     const source = 'pricing_dialog' as const
 

--- a/src/platform/workspace/composables/useWorkspaceUI.test.ts
+++ b/src/platform/workspace/composables/useWorkspaceUI.test.ts
@@ -1,4 +1,4 @@
-import { ref } from 'vue'
+import { computed, ref } from 'vue'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { WorkspaceWithRole } from '@/platform/workspace/api/workspaceApi'
@@ -9,6 +9,9 @@ const mockStore = vi.hoisted(() => ({
   originalOwnerId: null as string | null,
   ensureMembersLoaded: vi.fn()
 }))
+const mockIsCloud = ref(true)
+const mockShouldUseWorkspaceBilling = ref(true)
+const mockCanReactivate = ref(false)
 const mockIsActiveSubscription = vi.hoisted(() => ({ value: false }))
 const mockIsCancelled = vi.hoisted(() => ({ value: false }))
 const mockIsTeamPlan = vi.hoisted(() => ({ value: false }))
@@ -32,6 +35,26 @@ vi.mock('@/platform/workspace/stores/teamWorkspaceStore', () => ({
       return mockStore.originalOwnerId
     },
     ensureMembersLoaded: mockStore.ensureMembersLoaded
+  })
+}))
+
+vi.mock('@/platform/distribution/types', () => ({
+  get isCloud() {
+    return mockIsCloud.value
+  }
+}))
+
+vi.mock('@/composables/billing/useBillingRouting', () => ({
+  useBillingRouting: () => ({
+    shouldUseWorkspaceBilling: computed(
+      () => mockShouldUseWorkspaceBilling.value
+    )
+  })
+}))
+
+vi.mock('@/platform/workspace/composables/useBillingCapabilities', () => ({
+  useBillingCapabilities: () => ({
+    canReactivate: computed(() => mockCanReactivate.value)
   })
 }))
 
@@ -100,6 +123,9 @@ function resetStore() {
   mockIsCancelled.value = false
   mockIsTeamPlan.value = false
   mockBillingControlEnabled.value = false
+  mockIsCloud.value = true
+  mockShouldUseWorkspaceBilling.value = true
+  mockCanReactivate.value = false
 }
 
 describe('useWorkspaceUI', () => {
@@ -448,6 +474,42 @@ describe('useWorkspaceUI', () => {
 
       expect(second.permissions).toBe(first.permissions)
       expect(second.uiConfig).toBe(first.uiConfig)
+    })
+  })
+  describe('canReactivatePlan', () => {
+    beforeEach(() => {
+      mockStore.activeWorkspace = personalWorkspace
+    })
+
+    it('uses the server capability on the consolidated rail', async () => {
+      mockShouldUseWorkspaceBilling.value = true
+      mockCanReactivate.value = false
+
+      const denied = await loadComposable()
+      expect(denied.canReactivatePlan.value).toBe(false)
+
+      vi.resetModules()
+      mockCanReactivate.value = true
+      const allowed = await loadComposable()
+      expect(allowed.canReactivatePlan.value).toBe(true)
+    })
+
+    it('falls back to membership on the legacy rail, where no capability row exists', async () => {
+      mockShouldUseWorkspaceBilling.value = false
+      mockCanReactivate.value = false
+
+      const ui = await loadComposable()
+      expect(ui.permissions.value.canManageSubscriptionLifecycle).toBe(true)
+      expect(ui.canReactivatePlan.value).toBe(true)
+    })
+
+    it('falls back to membership off Cloud, where the endpoint is never called', async () => {
+      mockIsCloud.value = false
+      mockShouldUseWorkspaceBilling.value = true
+      mockCanReactivate.value = false
+
+      const ui = await loadComposable()
+      expect(ui.canReactivatePlan.value).toBe(true)
     })
   })
 })

--- a/src/platform/workspace/composables/useWorkspaceUI.ts
+++ b/src/platform/workspace/composables/useWorkspaceUI.ts
@@ -2,7 +2,10 @@ import { computed, watch } from 'vue'
 import { createSharedComposable } from '@vueuse/core'
 
 import { useBillingContext } from '@/composables/billing/useBillingContext'
+import { useBillingRouting } from '@/composables/billing/useBillingRouting'
 import { useFeatureFlags } from '@/composables/useFeatureFlags'
+import { isCloud } from '@/platform/distribution/types'
+import { useBillingCapabilities } from '@/platform/workspace/composables/useBillingCapabilities'
 
 import type { WorkspaceRole, WorkspaceType } from '../api/workspaceApi'
 import { useTeamWorkspaceStore } from '../stores/teamWorkspaceStore'
@@ -165,6 +168,9 @@ function useWorkspaceUIInternal() {
     { immediate: true }
   )
 
+  const { shouldUseWorkspaceBilling } = useBillingRouting()
+  const { canReactivate } = useBillingCapabilities()
+
   const permissions = computed<WorkspacePermissions>(() =>
     getPermissions(
       workspaceType.value,
@@ -174,6 +180,15 @@ function useWorkspaceUIInternal() {
       store.activeWorkspace !== null,
       isTeamPlan.value
     )
+  )
+
+  // legacy_stripe workspaces have no capability projection row, so the
+  // server-resolved can_reactivate is false for them and cannot gate the
+  // action; that rail stays on the membership check.
+  const canReactivatePlan = computed(() =>
+    isCloud && shouldUseWorkspaceBilling.value
+      ? canReactivate.value
+      : permissions.value.canManageSubscriptionLifecycle
   )
 
   const uiConfig = computed<WorkspaceUIConfig>(() => {
@@ -217,6 +232,7 @@ function useWorkspaceUIInternal() {
   return {
     // Permissions and config
     permissions,
+    canReactivatePlan,
     uiConfig,
     workspaceType,
     workspaceRole,


### PR DESCRIPTION
Backport of #16043 to `cloud/1.52`.

## Merge order — this PR is stacked

Base is deliberately `backport-15967-to-cloud-1.52`, not `cloud/1.52`. GitHub retargets this PR to `cloud/1.52` once its parent merges.

`cloud/1.52` → #15799 → #15803 → #15804 → #15675 → #15967 → #16043 → #16046 → #16067

Every commit in this chain cherry-picks cleanly; there are no hand-resolved conflicts anywhere in the stack.

## Verification

Run at the tip of the full stack: 93 unit test files, 1745 tests, 0 failures (`src/platform/workspace`, `src/platform/cloud/subscription`, `src/composables/useCoreCommands.test.ts`, `src/components/actionbar`).