### PR TITLE
[backport cloud/1.52] fix(billing): route useResubscribe through the centralized rail policy

### DIFF
--- a/src/platform/workspace/components/SubscriptionPanelContentWorkspace.vue
+++ b/src/platform/workspace/components/SubscriptionPanelContentWorkspace.vue
@@ -504,9 +504,6 @@ const showSubscribePrompt = computed(() => {
   return !isWorkspaceSubscribed.value
 })
 
-// The legacy rail keeps lifecycle authorization on the client, and
-// handleResubscribe() skips its capability guard there, so the affordance has
-// to follow the same three-way condition or it hides a working action.
 const canChangePlan = computed(() =>
   isCloud ? canChangeSeats.value : permissions.value.canManageSubscription
 )

--- a/src/platform/workspace/components/dialogs/settings/BillingStatusBanner.vue
+++ b/src/platform/workspace/components/dialogs/settings/BillingStatusBanner.vue
@@ -90,9 +90,6 @@ const { isResubscribing, handleResubscribe } = useResubscribe()
 const dialogService = useDialogService()
 
 const canManage = computed(() => permissions.value.canManageSubscription)
-// The legacy rail keeps lifecycle authorization on the client, and
-// handleResubscribe() skips its capability guard there, so the affordance has
-// to follow the same three-way condition or it hides a working action.
 const cycleResetDate = computed(() => {
   const raw = renewalDate.value
   return raw ? d(new Date(raw), { month: 'short', day: 'numeric' }) : ''

--- a/src/platform/workspace/composables/useResubscribe.test.ts
+++ b/src/platform/workspace/composables/useResubscribe.test.ts
@@ -8,6 +8,7 @@ const state = vi.hoisted(() => ({
   shouldUseWorkspaceBilling: true,
   canManageSubscriptionLifecycle: true,
   canReactivate: true,
+  canReactivatePlan: true,
   resubscribe: vi.fn(),
   toastAdd: vi.fn(),
   trackResubscribeClicked: vi.fn(),
@@ -48,6 +49,11 @@ vi.mock('@/platform/workspace/composables/useWorkspaceUI', () => ({
           canManageSubscriptionLifecycle: state.canManageSubscriptionLifecycle
         }
       }
+    },
+    canReactivatePlan: {
+      get value() {
+        return state.canReactivatePlan
+      }
     }
   })
 }))
@@ -83,6 +89,7 @@ describe('useResubscribe', () => {
     state.shouldUseWorkspaceBilling = true
     state.canManageSubscriptionLifecycle = true
     state.canReactivate = true
+    state.canReactivatePlan = true
     state.resubscribe.mockResolvedValue(undefined)
   })
 
@@ -90,6 +97,7 @@ describe('useResubscribe', () => {
     const { handleResubscribe, isResubscribing } = useResubscribe()
     state.canManageSubscriptionLifecycle = false
     state.canReactivate = false
+    state.canReactivatePlan = false
 
     await handleResubscribe()
 
@@ -102,6 +110,7 @@ describe('useResubscribe', () => {
   it('does not resubscribe when the server denies reactivation to a client-side owner', async () => {
     state.canManageSubscriptionLifecycle = true
     state.canReactivate = false
+    state.canReactivatePlan = false
     const { handleResubscribe, isResubscribing } = useResubscribe()
 
     await handleResubscribe()
@@ -110,6 +119,31 @@ describe('useResubscribe', () => {
     expect(state.trackResubscribeClicked).not.toHaveBeenCalled()
     expect(state.toastAdd).not.toHaveBeenCalled()
     expect(isResubscribing.value).toBe(false)
+  })
+
+  it('resubscribes when the policy permits it, whatever the raw capability says', async () => {
+    // The legacy rail resolves can_reactivate false while the workspace may
+    // still reactivate; this composable must follow the derived policy. Which
+    // rail produces which value is covered in useWorkspaceUI.test.ts.
+    state.canReactivate = false
+    state.canReactivatePlan = true
+    const { handleResubscribe } = useResubscribe()
+
+    await handleResubscribe()
+
+    expect(state.resubscribe).toHaveBeenCalled()
+  })
+
+  it('refuses whenever the policy denies it', async () => {
+    // Behaviour change: the old gate short-circuited on the legacy rail and ran
+    // no membership check, so a denial there never reached this branch.
+    state.canReactivate = false
+    state.canReactivatePlan = false
+    const { handleResubscribe } = useResubscribe()
+
+    await handleResubscribe()
+
+    expect(state.resubscribe).not.toHaveBeenCalled()
   })
 
   it('fires a started event before resubscribe resolves', async () => {
@@ -128,6 +162,9 @@ describe('useResubscribe', () => {
   it('does not report checkout launch as terminal legacy success', async () => {
     state.shouldUseWorkspaceBilling = false
     state.canManageSubscriptionLifecycle = false
+    // This case is about telemetry staging, not the gate; the workspace is
+    // permitted to reactivate so the flow reaches the checkout launch.
+    state.canReactivatePlan = true
     const { handleResubscribe } = useResubscribe()
 
     await handleResubscribe()

--- a/src/platform/workspace/composables/useResubscribe.ts
+++ b/src/platform/workspace/composables/useResubscribe.ts
@@ -4,10 +4,8 @@ import { useI18n } from 'vue-i18n'
 
 import { useBillingContext } from '@/composables/billing/useBillingContext'
 import { useBillingRouting } from '@/composables/billing/useBillingRouting'
-import { isCloud } from '@/platform/distribution/types'
 import { useTelemetry } from '@/platform/telemetry'
 import { categorizeBillingApiError } from '@/platform/telemetry/utils/billingFailureCategory'
-import { useBillingCapabilities } from '@/platform/workspace/composables/useBillingCapabilities'
 import { useWorkspaceUI } from '@/platform/workspace/composables/useWorkspaceUI'
 
 /**
@@ -19,20 +17,12 @@ export function useResubscribe() {
   const toast = useToast()
   const { resubscribe } = useBillingContext()
   const { shouldUseWorkspaceBilling } = useBillingRouting()
-  const { canReactivate } = useBillingCapabilities()
-  const { permissions } = useWorkspaceUI()
+  const { canReactivatePlan } = useWorkspaceUI()
 
   const isResubscribing = ref(false)
 
   async function handleResubscribe() {
-    if (
-      shouldUseWorkspaceBilling.value &&
-      !(isCloud
-        ? canReactivate.value
-        : permissions.value.canManageSubscriptionLifecycle)
-    ) {
-      return
-    }
+    if (!canReactivatePlan.value) return
 
     const source = 'settings_billing_panel' as const
 

--- a/src/platform/workspace/composables/useWorkspaceUI.ts
+++ b/src/platform/workspace/composables/useWorkspaceUI.ts
@@ -185,6 +185,11 @@ function useWorkspaceUIInternal() {
   // legacy_stripe workspaces have no capability projection row, so the
   // server-resolved can_reactivate is false for them and cannot gate the
   // action; that rail stays on the membership check.
+  //
+  // Every reactivation surface reads this — the affordances and the handlers
+  // that execute them. They must not diverge: an affordance shown on a
+  // condition the handler does not share offers an action that silently fails,
+  // and the reverse hides a working one.
   const canReactivatePlan = computed(() =>
     isCloud && shouldUseWorkspaceBilling.value
       ? canReactivate.value


### PR DESCRIPTION
Backport of #16046 to `cloud/1.52`.

## Merge order — this PR is stacked

Base is deliberately `backport-16043-to-cloud-1.52`, not `cloud/1.52`. GitHub retargets this PR to `cloud/1.52` once its parent merges.

`cloud/1.52` → #15799 → #15803 → #15804 → #15675 → #15967 → #16043 → #16046 → #16067

Every commit in this chain cherry-picks cleanly; there are no hand-resolved conflicts anywhere in the stack.

## Verification

Run at the tip of the full stack: 93 unit test files, 1745 tests, 0 failures (`src/platform/workspace`, `src/platform/cloud/subscription`, `src/composables/useCoreCommands.test.ts`, `src/components/actionbar`).