### PR TITLE
test: detect foreign widget prototype loss

### DIFF
--- a/scripts/registry-census/README.md
+++ b/scripts/registry-census/README.md
@@ -279,7 +279,7 @@ the aggregate passes only after all expensive dependencies report skipped.
 
 ## Detection proof (counter-evidence)
 
-`detection-proof/corpus/` is a synthetic corpus of seven poison packs, each
+`detection-proof/corpus/` is a synthetic corpus of eight poison packs, each
 broken in exactly one measured way, plus three clean controls. The
 `matrix-detection-proof` job runs the real matrix over it and passes only if
 `verify_detection.py` sees every channel fire with its exact poison message
@@ -300,6 +300,7 @@ delta criteria are exempted there and covered by verdict unit tests.
 | poison-op-break          | `onNodeCreated` throws          | `load`/`addNode` op errs (gated) |
 | poison-serialize-throw   | `onSerialize` throws            | `serialize` op err (gated)       |
 | poison-desync            | drops a live widget's store row | signature drift (`wn`, counts)   |
+| poison-foreign-widget    | erases prototype methods        | operation error (gated)          |
 | poison-store-read-throw  | widget-store read throws        | operation desync (gated)         |
 | clean-control            | nothing                         | fully clean row (specificity)    |
 | clean-mjs-control        | nothing                         | `.mjs` entry loads (glob cover)  |

--- a/scripts/registry-census/detection-proof/corpus/registry_js/poison-foreign-widget/js/main.js
+++ b/scripts/registry-census/detection-proof/corpus/registry_js/poison-foreign-widget/js/main.js
@@ -1,0 +1,18 @@
+import { app } from '../../scripts/app.js'
+
+app.registerExtension({
+  name: 'poison.foreign.widget',
+  beforeRegisterNodeDef(nodeType) {
+    const original = nodeType.prototype.addCustomWidget
+    nodeType.prototype.addCustomWidget = function (widget, ...args) {
+      const added = original.call(this, widget, ...args)
+      if (widget?.name === 'XFOREIGN') {
+        delete added.draw
+        delete added.mouse
+        delete added.computeSize
+        Object.setPrototypeOf(added, Object.prototype)
+      }
+      return added
+    }
+  }
+})

--- a/scripts/registry-census/matrix_runner.ts
+++ b/scripts/registry-census/matrix_runner.ts
@@ -584,20 +584,14 @@ export async function runPack(
     const k = byType('KSampler')
     if (!k) return
     const foreignWidget = new ForeignWidget()
-    const expectedMethods = Object.fromEntries(
-      ['draw', 'mouse', 'computeSize'].map((method) => [
-        method,
-        (foreignWidget as unknown as Record<string, unknown>)[method]
-      ])
-    )
+    const expectedWidget = new ForeignWidget()
+    const widgetMethods = ['draw', 'mouse', 'computeSize'] as const
     k.addCustomWidget(foreignWidget)
     mangled.add(`${k.id}:XFOREIGN`)
 
     const widget = k.widgets?.find((item) => item.name === 'XFOREIGN')
-    const prototypeMethods = ['draw', 'mouse', 'computeSize'].filter(
-      (method) =>
-        (widget as unknown as Record<string, unknown> | undefined)?.[method] !==
-        expectedMethods[method]
+    const prototypeMethods = widgetMethods.filter(
+      (method) => widget?.[method] !== expectedWidget[method]
     )
     if (prototypeMethods.length)
       throw new Error(

--- a/scripts/registry-census/matrix_runner.ts
+++ b/scripts/registry-census/matrix_runner.ts
@@ -559,6 +559,50 @@ export async function runPack(
     },
     false
   )
+  await op('wPushForeignClass', () => {
+    class ForeignWidget {
+      name = 'XFOREIGN'
+      type = 'X.FOREIGN'
+      value = 1
+      options = {}
+      y = 0
+
+      draw() {
+        return 'draw'
+      }
+
+      mouse() {
+        return true
+      }
+
+      computeSize() {
+        return [101, 21] as [number, number]
+      }
+    }
+
+    const k = byType('KSampler')
+    if (!k) return
+    const foreignWidget = new ForeignWidget()
+    const expectedMethods = Object.fromEntries(
+      ['draw', 'mouse', 'computeSize'].map((method) => [
+        method,
+        (foreignWidget as unknown as Record<string, unknown>)[method]
+      ])
+    )
+    k.addCustomWidget(foreignWidget)
+    mangled.add(`${k.id}:XFOREIGN`)
+
+    const widget = k.widgets?.find((item) => item.name === 'XFOREIGN')
+    const prototypeMethods = ['draw', 'mouse', 'computeSize'].filter(
+      (method) =>
+        (widget as unknown as Record<string, unknown> | undefined)?.[method] !==
+        expectedMethods[method]
+    )
+    if (prototypeMethods.length)
+      throw new Error(
+        `foreign widget prototype methods lost: ${prototypeMethods.join(',')}`
+      )
+  })
   await op('addNode', () => {
     const n = LiteGraph.createNode('EmptyLatentImage')
     if (n) {

--- a/scripts/registry-census/matrix_runner.ts
+++ b/scripts/registry-census/matrix_runner.ts
@@ -561,6 +561,7 @@ export async function runPack(
   )
   await op('wPushForeignClass', () => {
     class ForeignWidget {
+      [symbol: symbol]: boolean
       name = 'XFOREIGN'
       type = 'X.FOREIGN'
       value = 1

--- a/scripts/registry-census/verify_detection.py
+++ b/scripts/registry-census/verify_detection.py
@@ -54,6 +54,7 @@ GATES = {
     'poison-op-break': (CRITERION_LABELS['op_clean'],),
     'poison-serialize-throw': (CRITERION_LABELS['op_clean'],),
     'poison-desync': (CRITERION_LABELS['op_clean'],),
+    'poison-foreign-widget': (CRITERION_LABELS['op_clean'],),
     'poison-store-read-throw': (CRITERION_LABELS['op_clean'],),
 }
 
@@ -190,6 +191,14 @@ def main() -> int:
         'serialize: serialize op err carries the poison',
         'poison: onSerialize throws'
         in (ops('poison-serialize-throw').get('serialize') or {}).get('err', ''),
+    )
+    check(
+        'foreign-widget: prototype method loss is recorded despite the'
+        ' mangled-row exclusion',
+        'foreign widget prototype methods lost:'
+        in (ops('poison-foreign-widget').get('wPushForeignClass') or {}).get(
+            'err', ''
+        ),
     )
 
     check(

--- a/scripts/registry-census/verify_detection.py
+++ b/scripts/registry-census/verify_detection.py
@@ -195,10 +195,11 @@ def main() -> int:
     check(
         'foreign-widget: prototype method loss is recorded despite the'
         ' mangled-row exclusion',
-        'foreign widget prototype methods lost:'
-        in (ops('poison-foreign-widget').get('wPushForeignClass') or {}).get(
+        (ops('poison-foreign-widget').get('wPushForeignClass') or {}).get(
             'err', ''
-        ),
+        )
+        == 'Error: foreign widget prototype methods lost:'
+        ' draw,mouse,computeSize',
     )
 
     check(


### PR DESCRIPTION
## Summary

Teach the custom-node registry census to detect recurrence of foreign widget prototype behavior loss.

- add `wPushForeignClass` with prototype-backed `draw`, `mouse`, and `computeSize`
- assert the methods survive `addCustomWidget` even though battery-mutated rows are excluded from store-desync judgment
- add a dedicated poison pack that erases those methods
- require the poison to fire and breach the operation-clean gate

## Dependency

Stacked on #16097 because the new clean-control assertion is intentionally red on current `main`. This PR contains no production widget code and can be retargeted to `main` after #16097 lands.

## Red proof on main

```json
{
  "err": "Error: foreign widget prototype methods lost: draw,mouse,computeSize",
  "dispatching": true,
  "desync": ""
}
```

The clean-control verifier then fails `every operation clean (worst: wPushForeignClass) 0.0% < 99%`.

## Green proof on #16097

- detection matrix: 11/11 packs passed
- exact foreign-widget poison observation passed
- clean control remained fully clean
- poison breached `every operation clean` at 75.0% < 99%
- complete detection verifier passed
- census Python tests: 52/52
- matrix-runner Vitest: 2/2
- Oxlint, oxfmt, ESLint, full typecheck, and pre-push Knip passed
