### PR TITLE
feat(billing): make the checkout funnel joinable and the 3DS step visible

### DIFF
--- a/docs/adr/0014-billing-telemetry-attempt-correlation-and-workspace-scoping.md
+++ b/docs/adr/0014-billing-telemetry-attempt-correlation-and-workspace-scoping.md
@@ -175,6 +175,25 @@ be stamped on the billing-op row, which is what lets a pre-op-ID failure
 join backend records rather than only its own outcome. The deferral
 reasoning above stands for the rails that still lack it.
 
+**Two rails the attempt id does not reach yet.** The team-to-personal
+downgrade delegates its preview, subscribe and telemetry to
+`useDowngradeToPersonal`, which owns its own `startOperation()` calls and
+never receives the attempt context, so that flow's events carry no
+`checkout_attempt_id`. It is a coverage gap rather than a correctness one —
+the events are internally consistent, just unjoinable to the attempt that
+opened them. Closing it means the downgrade composable either receives the
+context or mints its own attempt.
+
+**`quote_minted` tracks quotes shown, not quotes minted.** It fires from
+`installPreview()`, so the internal re-quote in
+`assertReactivationAmountUnchanged()` — which re-runs `preview-subscribe`
+purely to confirm the amount has not drifted — produces a backend quote row
+carrying the attempt id with no matching client event. That asymmetry is
+deliberate: the stage is the denominator for preview-to-subscribe
+conversion, and a quote the customer never saw would inflate it. A
+backend-side reconciliation should expect strictly more quote rows than
+`quote_minted` events.
+
 Open follow-ups: what fraction of billing failures are pre- vs.
 post-response (determines whether the backend-coordinated attempt-ID is
 worth pursuing); whether it should reuse an existing correlation-ID

--- a/docs/adr/0014-billing-telemetry-attempt-correlation-and-workspace-scoping.md
+++ b/docs/adr/0014-billing-telemetry-attempt-correlation-and-workspace-scoping.md
@@ -157,6 +157,24 @@ actions, are workspace-segmentable.
 
 ## Notes
 
+**Implemented as `checkout_attempt_id`, not `billing_attempt_id`.** The
+subscription-checkout rail ships this decision under the name
+`checkout_attempt_id`, for two reasons. The field already exists in this
+codebase under that name on the legacy GA4 path
+(`subscriptionCheckoutTracker.ts`, `BeginCheckoutMetadata`,
+`SubscriptionSuccessMetadata`), so a second name for the same concept would
+have been the only ambiguity in the schema. It is also the name in the
+cross-service billing-telemetry schema that the backend and the rollout
+dashboard are being built against, and a correlation key is worth nothing if
+the two sides spell it differently. Rails other than subscription checkout
+are not yet retrofitted.
+
+The same work also takes the step this ADR deferred: `checkout_attempt_id`
+is now sent to the backend on `preview-subscribe` and `subscribe` so it can
+be stamped on the billing-op row, which is what lets a pre-op-ID failure
+join backend records rather than only its own outcome. The deferral
+reasoning above stands for the rails that still lack it.
+
 Open follow-ups: what fraction of billing failures are pre- vs.
 post-response (determines whether the backend-coordinated attempt-ID is
 worth pursuing); whether it should reuse an existing correlation-ID

--- a/docs/adr/0014-billing-telemetry-attempt-correlation-and-workspace-scoping.md
+++ b/docs/adr/0014-billing-telemetry-attempt-correlation-and-workspace-scoping.md
@@ -175,6 +175,17 @@ be stamped on the billing-op row, which is what lets a pre-op-ID failure
 join backend records rather than only its own outcome. The deferral
 reasoning above stands for the rails that still lack it.
 
+**An attempt id spans retries of the same quote, not just one subscribe
+call.** `beginCheckoutAttempt()` mints once when the customer picks a plan;
+a subsequent retry of the same plan choice — including a reactivation retry
+or a `handleConfirmTransition` retry after a failed subscribe — reuses it
+rather than minting a fresh one. One `checkout_attempt_id` can therefore
+carry two `started`/terminal pairs. That is intended: the id identifies the
+plan choice, not the individual subscribe call, and is the more useful
+definition for measuring abandonment. A consumer joining on
+`checkout_attempt_id` should read a repeated `started` as a retry of the
+same attempt, not a duplicate.
+
 **Two rails the attempt id does not reach yet.** The team-to-personal
 downgrade delegates its preview, subscribe and telemetry to
 `useDowngradeToPersonal`, which owns its own `startOperation()` calls and

--- a/src/platform/cloud/subscription/utils/subscriptionCheckoutTracker.ts
+++ b/src/platform/cloud/subscription/utils/subscriptionCheckoutTracker.ts
@@ -70,7 +70,7 @@ const dispatchPendingCheckoutChangeEvent = () => {
   window.dispatchEvent(new Event(PENDING_SUBSCRIPTION_CHECKOUT_EVENT))
 }
 
-const createAttemptId = (): string => {
+export const createAttemptId = (): string => {
   if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) {
     return crypto.randomUUID()
   }

--- a/src/platform/telemetry/types.ts
+++ b/src/platform/telemetry/types.ts
@@ -827,9 +827,64 @@ export interface BillingFailure {
   error_code?: BillingErrorCode
 }
 
+export type BillingFlagState =
+  | 'embedded_checkout_on'
+  | 'embedded_checkout_off'
+  /**
+   * The embedded-checkout flag arrives only on the WebSocket handshake and
+   * reads `false` until it lands, so an attempt that has not yet seen a flag
+   * map is genuinely unknown rather than off. Splitting a rollout dashboard on
+   * a defaulted `off` would bank gated traffic in the ungated bucket.
+   */
+  | 'embedded_checkout_unknown'
+
+/**
+ * Correlation and rollout dimensions shared by every billing event.
+ * `checkout_attempt_id` is minted client-side at attempt start because
+ * `started` precedes the billing op's existence; `billing_op_id` joins the same
+ * attempt to the backend from the first event that knows one.
+ */
+type BillingAttemptContext = {
+  checkout_attempt_id?: string
+  flag_state?: BillingFlagState
+  workspace_id?: string
+  quote_id?: string
+}
+
 type BillingStarted = {
   stage: 'started'
   outcome: 'pending'
+}
+
+type BillingQuoteMinted = {
+  stage: 'quote_minted'
+  outcome: 'pending'
+}
+
+type BillingChallengePresented = {
+  stage: 'challenge_presented'
+  outcome: 'pending'
+}
+
+type BillingChallengeReturned = {
+  stage: 'challenge_returned'
+  /**
+   * `abandoned` covers a challenge the customer never came back from. A closed
+   * tab is not observable in this client, so nothing here emits it — the value
+   * exists so the backend and the challenge-funnel panels share one vocabulary.
+   */
+  outcome: 'succeeded' | 'failed' | 'abandoned'
+  /**
+   * Why the challenge landed where it did. `intent_status_unavailable` is the
+   * honest case: the browser step resolved without an error and without
+   * reporting an intent, so the client cannot tell a completed challenge from
+   * one that changed nothing. Exclude it from a success numerator.
+   */
+  reason:
+    | 'intent_advanced'
+    | 'challenge_not_completed'
+    | 'stripe_error'
+    | 'intent_status_unavailable'
 }
 
 type BillingSucceeded = {
@@ -860,7 +915,14 @@ type SubscriptionCheckoutBillingEvent = {
    * `started` event through to this terminal event.
    */
   duration_ms?: number
-} & (BillingStarted | BillingSucceeded | BillingFailed)
+} & (
+  | BillingStarted
+  | BillingSucceeded
+  | BillingFailed
+  | BillingQuoteMinted
+  | BillingChallengePresented
+  | BillingChallengeReturned
+)
 
 type BillingOperationBillingEvent = {
   operation: 'operation'
@@ -909,12 +971,14 @@ type DowngradeToPersonalBillingEvent = {
   duration_ms?: number
 } & (BillingStarted | BillingSucceeded | BillingFailed)
 
-export type BillingTelemetryEvent =
+export type BillingTelemetryEvent = (
   | SubscriptionCheckoutBillingEvent
   | BillingOperationBillingEvent
   | ResubscribeBillingEvent
   | TopupBillingEvent
   | DowngradeToPersonalBillingEvent
+) &
+  BillingAttemptContext
 
 type BillingTelemetryEventNameFor<T extends BillingTelemetryEvent> =
   T extends BillingTelemetryEvent
@@ -939,6 +1003,14 @@ export function getBillingTelemetryEventPayload(event: BillingTelemetryEvent) {
       event.billing_op_id !== undefined && {
         billing_op_id: event.billing_op_id
       }),
+    ...(event.checkout_attempt_id !== undefined && {
+      checkout_attempt_id: event.checkout_attempt_id
+    }),
+    ...(event.flag_state !== undefined && { flag_state: event.flag_state }),
+    ...(event.workspace_id !== undefined && {
+      workspace_id: event.workspace_id
+    }),
+    ...(event.quote_id !== undefined && { quote_id: event.quote_id }),
     ...('operation_type' in event && {
       operation_type: event.operation_type
     }),
@@ -957,6 +1029,7 @@ export function getBillingTelemetryEventPayload(event: BillingTelemetryEvent) {
     ...('failure_category' in event && {
       failure_category: event.failure_category
     }),
+    ...('reason' in event && { reason: event.reason }),
     ...('error_code' in event &&
       event.error_code !== undefined && { error_code: event.error_code }),
     ...('member_removal_count' in event && {
@@ -1163,6 +1236,12 @@ export const TelemetryEvents = {
   BILLING_SUBSCRIPTION_CHECKOUT_SUCCEEDED:
     'billing.subscription_checkout.succeeded',
   BILLING_SUBSCRIPTION_CHECKOUT_FAILED: 'billing.subscription_checkout.failed',
+  BILLING_SUBSCRIPTION_CHECKOUT_QUOTE_MINTED:
+    'billing.subscription_checkout.quote_minted',
+  BILLING_SUBSCRIPTION_CHECKOUT_CHALLENGE_PRESENTED:
+    'billing.subscription_checkout.challenge_presented',
+  BILLING_SUBSCRIPTION_CHECKOUT_CHALLENGE_RETURNED:
+    'billing.subscription_checkout.challenge_returned',
   BILLING_OPERATION_STARTED: 'billing.operation.started',
   BILLING_OPERATION_SUCCEEDED: 'billing.operation.succeeded',
   BILLING_OPERATION_FAILED: 'billing.operation.failed',

--- a/src/platform/telemetry/utils/billingFlagState.test.ts
+++ b/src/platform/telemetry/utils/billingFlagState.test.ts
@@ -1,0 +1,40 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { mockGetServerFeatures } = vi.hoisted(() => ({
+  mockGetServerFeatures: vi.fn()
+}))
+
+vi.mock('@/scripts/api', () => ({
+  api: {
+    getServerFeatures: mockGetServerFeatures
+  }
+}))
+
+import { resolveBillingFlagState } from './billingFlagState'
+
+describe('resolveBillingFlagState', () => {
+  beforeEach(() => {
+    mockGetServerFeatures.mockReset()
+  })
+
+  it('reports the gated arm when the flag resolved true', () => {
+    mockGetServerFeatures.mockReturnValue({ embedded_checked_enabled: true })
+
+    expect(resolveBillingFlagState(true)).toBe('embedded_checkout_on')
+  })
+
+  it('reports the ungated arm once a flag map has actually arrived', () => {
+    mockGetServerFeatures.mockReturnValue({ embedded_checked_enabled: false })
+
+    expect(resolveBillingFlagState(false)).toBe('embedded_checkout_off')
+  })
+
+  // The flag only lands on the WebSocket handshake, so a false read before it
+  // arrives is absence of an answer. Filing that as `off` would bank
+  // pre-handshake traffic in the ungated arm of the rollout dashboard.
+  it('reports unknown rather than off before any flag map has arrived', () => {
+    mockGetServerFeatures.mockReturnValue({})
+
+    expect(resolveBillingFlagState(false)).toBe('embedded_checkout_unknown')
+  })
+})

--- a/src/platform/telemetry/utils/billingFlagState.test.ts
+++ b/src/platform/telemetry/utils/billingFlagState.test.ts
@@ -1,12 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { mockGetServerFeatures } = vi.hoisted(() => ({
-  mockGetServerFeatures: vi.fn()
+const { mockHasReceivedServerFeatureFlags } = vi.hoisted(() => ({
+  mockHasReceivedServerFeatureFlags: vi.fn()
 }))
 
 vi.mock('@/scripts/api', () => ({
   api: {
-    getServerFeatures: mockGetServerFeatures
+    hasReceivedServerFeatureFlags: mockHasReceivedServerFeatureFlags
   }
 }))
 
@@ -14,17 +14,17 @@ import { resolveBillingFlagState } from './billingFlagState'
 
 describe('resolveBillingFlagState', () => {
   beforeEach(() => {
-    mockGetServerFeatures.mockReset()
+    mockHasReceivedServerFeatureFlags.mockReset()
   })
 
   it('reports the gated arm when the flag resolved true', () => {
-    mockGetServerFeatures.mockReturnValue({ embedded_checked_enabled: true })
+    mockHasReceivedServerFeatureFlags.mockReturnValue(true)
 
     expect(resolveBillingFlagState(true)).toBe('embedded_checkout_on')
   })
 
-  it('reports the ungated arm once a flag map has actually arrived', () => {
-    mockGetServerFeatures.mockReturnValue({ embedded_checked_enabled: false })
+  it('reports the ungated arm once the handshake has been answered', () => {
+    mockHasReceivedServerFeatureFlags.mockReturnValue(true)
 
     expect(resolveBillingFlagState(false)).toBe('embedded_checkout_off')
   })
@@ -32,8 +32,8 @@ describe('resolveBillingFlagState', () => {
   // The flag only lands on the WebSocket handshake, so a false read before it
   // arrives is absence of an answer. Filing that as `off` would bank
   // pre-handshake traffic in the ungated arm of the rollout dashboard.
-  it('reports unknown rather than off before any flag map has arrived', () => {
-    mockGetServerFeatures.mockReturnValue({})
+  it('reports unknown rather than off before the handshake is answered', () => {
+    mockHasReceivedServerFeatureFlags.mockReturnValue(false)
 
     expect(resolveBillingFlagState(false)).toBe('embedded_checkout_unknown')
   })

--- a/src/platform/telemetry/utils/billingFlagState.ts
+++ b/src/platform/telemetry/utils/billingFlagState.ts
@@ -5,8 +5,13 @@ import { api } from '@/scripts/api'
  * The embedded-checkout flag is delivered only on the WebSocket `feature_flags`
  * handshake, and its resolver reads `false` until that map lands. Reporting
  * that `false` as `embedded_checkout_off` would file every pre-handshake
- * attempt under the ungated arm of the rollout dashboard, so a session that has
- * seen no flag map at all reports `unknown` instead.
+ * attempt under the ungated arm of the rollout dashboard, so a session whose
+ * handshake has not been answered reports `unknown` instead.
+ *
+ * Keyed off the handshake itself rather than an inhabited flag map: a server
+ * that advertises no flags is a legitimate ungated arm, and reading that as
+ * `unknown` would empty both arms of the dashboard in a way indistinguishable
+ * from no traffic.
  *
  * Resolve this once at attempt start and carry the result on the attempt's
  * later events: a reconnect can replace the flag map mid-attempt, but the
@@ -16,7 +21,7 @@ export function resolveBillingFlagState(
   embeddedCheckoutEnabled: boolean
 ): BillingFlagState {
   if (embeddedCheckoutEnabled) return 'embedded_checkout_on'
-  return Object.keys(api.getServerFeatures()).length > 0
+  return api.hasReceivedServerFeatureFlags()
     ? 'embedded_checkout_off'
     : 'embedded_checkout_unknown'
 }

--- a/src/platform/telemetry/utils/billingFlagState.ts
+++ b/src/platform/telemetry/utils/billingFlagState.ts
@@ -1,0 +1,22 @@
+import type { BillingFlagState } from '@/platform/telemetry/types'
+import { api } from '@/scripts/api'
+
+/**
+ * The embedded-checkout flag is delivered only on the WebSocket `feature_flags`
+ * handshake, and its resolver reads `false` until that map lands. Reporting
+ * that `false` as `embedded_checkout_off` would file every pre-handshake
+ * attempt under the ungated arm of the rollout dashboard, so a session that has
+ * seen no flag map at all reports `unknown` instead.
+ *
+ * Resolve this once at attempt start and carry the result on the attempt's
+ * later events: a reconnect can replace the flag map mid-attempt, but the
+ * attempt still ran under the state it started with.
+ */
+export function resolveBillingFlagState(
+  embeddedCheckoutEnabled: boolean
+): BillingFlagState {
+  if (embeddedCheckoutEnabled) return 'embedded_checkout_on'
+  return Object.keys(api.getServerFeatures()).length > 0
+    ? 'embedded_checkout_off'
+    : 'embedded_checkout_unknown'
+}

--- a/src/platform/workspace/api/workspaceApi.ts
+++ b/src/platform/workspace/api/workspaceApi.ts
@@ -97,12 +97,21 @@ export interface SubscribeOptions {
   billingCycle?: SubscribeBillingCycle
   confirmReactivation?: boolean
   prorationAt?: string
+  checkoutAttemptId?: string
 }
 
 export interface PreviewSubscribeOptions {
   teamCreditStopId?: string
   promotionCode?: string
+  checkoutAttemptId?: string
 }
+
+/**
+ * `checkout_attempt_id` is the client-minted key that joins an abandoned
+ * attempt's frontend events to its billing op. It is not yet in the generated
+ * request schemas; drop these once `@comfyorg/ingest-types` ships it.
+ */
+type WithCheckoutAttemptId<T> = T & { checkout_attempt_id?: string }
 
 export type { SubscribeResponse }
 
@@ -518,8 +527,9 @@ export const workspaceApi = {
         {
           plan_slug: planSlug,
           team_credit_stop_id: options.teamCreditStopId,
-          promotion_code: options.promotionCode
-        } satisfies PreviewSubscribeRequest,
+          promotion_code: options.promotionCode,
+          checkout_attempt_id: options.checkoutAttemptId
+        } satisfies WithCheckoutAttemptId<PreviewSubscribeRequest>,
         { headers }
       )
       return response.data
@@ -564,8 +574,9 @@ export const workspaceApi = {
           team_credit_stop_id: options.teamCreditStopId,
           billing_cycle: options.billingCycle,
           confirm_reactivation: options.confirmReactivation,
-          proration_at: options.prorationAt
-        } satisfies SubscribeRequest,
+          proration_at: options.prorationAt,
+          checkout_attempt_id: options.checkoutAttemptId
+        } satisfies WithCheckoutAttemptId<SubscribeRequest>,
         { headers }
       )
       return response.data

--- a/src/platform/workspace/api/workspaceApi.ts
+++ b/src/platform/workspace/api/workspaceApi.ts
@@ -108,8 +108,13 @@ export interface PreviewSubscribeOptions {
 
 /**
  * `checkout_attempt_id` is the client-minted key that joins an abandoned
- * attempt's frontend events to its billing op. It is not yet in the generated
- * request schemas; drop these once `@comfyorg/ingest-types` ships it.
+ * attempt's frontend events to its billing op. It is a wire field, not an
+ * FE-only extension, so this shim is a stopgap and not the intersection
+ * exemption in `docs/guidance/typescript.md`.
+ *
+ * Comfy-Org/cloud#7644 adds it to `services/ingest/openapi.yaml`. This PR stays
+ * in draft until that merges and `@comfyorg/ingest-types` regenerates; drop
+ * this type then and let the generated requests carry the field.
  */
 type WithCheckoutAttemptId<T> = T & { checkout_attempt_id?: string }
 

--- a/src/platform/workspace/api/workspaceApi.ts
+++ b/src/platform/workspace/api/workspaceApi.ts
@@ -112,9 +112,10 @@ export interface PreviewSubscribeOptions {
  * FE-only extension, so this shim is a stopgap and not the intersection
  * exemption in `docs/guidance/typescript.md`.
  *
- * Comfy-Org/cloud#7644 adds it to `services/ingest/openapi.yaml`. This PR stays
- * in draft until that merges and `@comfyorg/ingest-types` regenerates; drop
- * this type then and let the generated requests carry the field.
+ * Comfy-Org/cloud#7644 has merged and added it to `services/ingest/openapi.yaml`,
+ * but the automated `@comfyorg/ingest-types` regeneration PR has not landed
+ * (open, failing its own checks as of this writing). Drop this type once that
+ * regeneration merges and let the generated requests carry the field.
  */
 type WithCheckoutAttemptId<T> = T & { checkout_attempt_id?: string }
 

--- a/src/platform/workspace/composables/useSubscriptionCheckout.test.ts
+++ b/src/platform/workspace/composables/useSubscriptionCheckout.test.ts
@@ -3241,6 +3241,7 @@ describe('useSubscriptionCheckout', () => {
         {
           checkoutAttemptId: expect.any(String),
           flagState: 'embedded_checkout_on',
+          attemptWorkspaceId: 'workspace-1',
           quoteId: undefined,
           tier: 'standard',
           cycle: 'yearly',
@@ -3275,6 +3276,7 @@ describe('useSubscriptionCheckout', () => {
         {
           checkoutAttemptId: expect.any(String),
           flagState: 'embedded_checkout_on',
+          attemptWorkspaceId: 'workspace-1',
           quoteId: undefined,
           tier: 'standard',
           cycle: 'yearly',
@@ -4017,6 +4019,30 @@ describe('useSubscriptionCheckout', () => {
         source: 'pricing_dialog',
         payment_intent_source: 'subscribe_to_run'
       })
+    })
+
+    // Each reactivation is its own funnel entry: reusing the previous id would
+    // put two started/terminal pairs under one attempt.
+    it('mints a fresh attempt id per reactivation', async () => {
+      const checkout = await setup('subscribe_to_run')
+      mockFetchStatus.mockResolvedValue(undefined)
+      mockFetchBalance.mockResolvedValue(undefined)
+
+      mockResubscribe.mockRejectedValueOnce(new Error('card declined'))
+      await checkout.handleResubscribe()
+      mockResubscribe.mockResolvedValueOnce({
+        billing_op_id: 'op-4',
+        status: 'active'
+      })
+      await checkout.handleResubscribe()
+
+      const attemptIds = mockTrackBillingEvent.mock.calls
+        .map(([event]) => event)
+        .filter((event) => event.operation === 'resubscribe')
+        .map((event) => event.checkout_attempt_id)
+
+      expect(attemptIds.length).toBeGreaterThan(1)
+      expect(new Set(attemptIds).size).toBe(2)
     })
 
     it('emits close on success', async () => {

--- a/src/platform/workspace/composables/useSubscriptionCheckout.test.ts
+++ b/src/platform/workspace/composables/useSubscriptionCheckout.test.ts
@@ -519,6 +519,105 @@ describe('useSubscriptionCheckout', () => {
     for (const scope of scopes.splice(0)) scope.stop()
   })
 
+  describe('attempt correlation', () => {
+    it('reports the minted quote with its identity', async () => {
+      mockPreviewSubscribe.mockResolvedValue({
+        allowed: true,
+        transition_type: 'new_subscription',
+        requires_reactivation_confirmation: false,
+        quote_id: 'quote-9',
+        quote_version: 2
+      })
+      const checkout = await setup()
+
+      await checkout.handleSubscribeClick({
+        tierKey: 'standard',
+        billingCycle: 'yearly'
+      })
+
+      expect(mockTrackBillingEvent).toHaveBeenCalledWith({
+        operation: 'subscription_checkout',
+        stage: 'quote_minted',
+        outcome: 'pending',
+        payment_intent_source: undefined,
+        checkout_attempt_id: expect.any(String),
+        flag_state: 'embedded_checkout_on',
+        workspace_id: 'workspace-1',
+        quote_id: 'quote-9'
+      })
+    })
+
+    // The join the funnel is missing today: `started` fires before subscribe
+    // returns, so it can never carry a billing_op_id. One client-minted key on
+    // every event of the attempt is what makes an abandoned attempt countable.
+    it('carries one attempt id from the quote through to the terminal event', async () => {
+      mockSubscribe.mockResolvedValueOnce({
+        status: 'subscribed',
+        billing_op_id: 'op-join'
+      })
+      const checkout = await setup()
+
+      await checkout.handleSubscribeClick({
+        tierKey: 'standard',
+        billingCycle: 'yearly'
+      })
+      await checkout.handleConfirmTransition()
+
+      const stages = ['quote_minted', 'started', 'succeeded']
+      const attemptIds = stages.map(
+        (stage) =>
+          mockTrackBillingEvent.mock.calls
+            .map(([event]) => event)
+            .find(
+              (event) =>
+                event.operation === 'subscription_checkout' &&
+                event.stage === stage
+            )?.checkout_attempt_id
+      )
+
+      expect(attemptIds[0]).toEqual(expect.any(String))
+      expect(new Set(attemptIds).size).toBe(1)
+    })
+
+    it('sends the attempt id to the backend on both checkout calls', async () => {
+      mockSubscribe.mockResolvedValueOnce({
+        status: 'subscribed',
+        billing_op_id: 'op-wire'
+      })
+      const checkout = await setup()
+
+      await checkout.handleSubscribeClick({
+        tierKey: 'standard',
+        billingCycle: 'yearly'
+      })
+      await checkout.handleConfirmTransition()
+
+      const previewAttemptId =
+        mockPreviewSubscribe.mock.calls[0][1].checkoutAttemptId
+      expect(previewAttemptId).toEqual(expect.any(String))
+      expect(mockSubscribe).toHaveBeenCalledWith(
+        'standard-yearly',
+        expect.objectContaining({ checkoutAttemptId: previewAttemptId })
+      )
+    })
+
+    it('reports the ungated arm as unknown when no flag map has arrived', async () => {
+      const checkout = await setup(undefined, 'personal', false)
+
+      await checkout.handleSubscribeClick({
+        tierKey: 'standard',
+        billingCycle: 'yearly'
+      })
+
+      expect(mockTrackBillingEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          stage: 'quote_minted',
+          flag_state: 'embedded_checkout_unknown'
+        })
+      )
+    })
+  })
+
   describe('handleSubscribeClick', () => {
     it('keeps embedded endpoints and request fields unreachable while disabled', async () => {
       const checkout = await setup(undefined, 'personal', false)
@@ -538,7 +637,9 @@ describe('useSubscriptionCheckout', () => {
 
       expect(mockListSavedPaymentMethods).not.toHaveBeenCalled()
       expect(mockPreviewSubscribe).toHaveBeenCalledOnce()
-      expect(mockPreviewSubscribe).toHaveBeenCalledWith('standard-yearly')
+      expect(mockPreviewSubscribe).toHaveBeenCalledWith('standard-yearly', {
+        checkoutAttemptId: expect.any(String)
+      })
       expect(mockSubscribe).toHaveBeenCalledWith(
         'standard-yearly',
         expect.not.objectContaining({
@@ -638,6 +739,7 @@ describe('useSubscriptionCheckout', () => {
 
       await checkout.applyPromotionCode(' SAVE20 ')
       expect(mockPreviewSubscribe).toHaveBeenLastCalledWith('standard-yearly', {
+        checkoutAttemptId: expect.any(String),
         promotionCode: 'SAVE20'
       })
 
@@ -1063,7 +1165,9 @@ describe('useSubscriptionCheckout', () => {
       await checkoutPromise
 
       expect(mockFetchPlans).toHaveBeenCalledOnce()
-      expect(mockPreviewSubscribe).toHaveBeenCalledWith('creator-monthly')
+      expect(mockPreviewSubscribe).toHaveBeenCalledWith('creator-monthly', {
+        checkoutAttemptId: expect.any(String)
+      })
       expect(checkout.checkoutStep.value).toBe('preview')
       expect(mockSubscribe).not.toHaveBeenCalled()
     })
@@ -1097,7 +1201,9 @@ describe('useSubscriptionCheckout', () => {
         billingCycle: 'monthly'
       })
 
-      expect(mockPreviewSubscribe).toHaveBeenCalledWith('creator-monthly')
+      expect(mockPreviewSubscribe).toHaveBeenCalledWith('creator-monthly', {
+        checkoutAttemptId: expect.any(String)
+      })
     })
 
     it('does not preview a plan for a member', async () => {
@@ -1183,7 +1289,9 @@ describe('useSubscriptionCheckout', () => {
         billingCycle: 'yearly'
       })
 
-      expect(mockPreviewSubscribe).toHaveBeenCalledWith('standard-yearly')
+      expect(mockPreviewSubscribe).toHaveBeenCalledWith('standard-yearly', {
+        checkoutAttemptId: expect.any(String)
+      })
       expect(checkout.checkoutStep.value).toBe('preview')
     })
 
@@ -1420,7 +1528,10 @@ describe('useSubscriptionCheckout', () => {
 
       expect(mockPreviewSubscribe).toHaveBeenCalledWith(
         'team_per_credit_monthly',
-        { teamCreditStopId: 'team_1400' }
+        {
+          checkoutAttemptId: expect.any(String),
+          teamCreditStopId: 'team_1400'
+        }
       )
       expect(checkout.previewData.value).toStrictEqual(transition)
     })
@@ -1635,6 +1746,7 @@ describe('useSubscriptionCheckout', () => {
       expect(mockPreviewSubscribe).toHaveBeenCalledWith(
         'team_per_credit_monthly',
         {
+          checkoutAttemptId: expect.any(String),
           teamCreditStopId: 'team_700'
         }
       )
@@ -1673,6 +1785,7 @@ describe('useSubscriptionCheckout', () => {
       expect(mockPreviewSubscribe).toHaveBeenCalledWith(
         'team_per_credit_monthly',
         {
+          checkoutAttemptId: expect.any(String),
           teamCreditStopId: 'team_700'
         }
       )
@@ -1950,6 +2063,9 @@ describe('useSubscriptionCheckout', () => {
       await checkout.handleTeamSubscribe()
 
       expect(mockTrackBillingEvent).toHaveBeenCalledWith({
+        checkout_attempt_id: expect.any(String),
+        flag_state: 'embedded_checkout_on',
+        workspace_id: 'workspace-1',
         operation: 'subscription_checkout',
         stage: 'started',
         outcome: 'pending',
@@ -1959,6 +2075,9 @@ describe('useSubscriptionCheckout', () => {
         payment_intent_source: undefined
       })
       expect(mockTrackBillingEvent).toHaveBeenCalledWith({
+        checkout_attempt_id: expect.any(String),
+        flag_state: 'embedded_checkout_on',
+        workspace_id: 'workspace-1',
         operation: 'operation',
         stage: 'started',
         outcome: 'pending',
@@ -1991,6 +2110,7 @@ describe('useSubscriptionCheckout', () => {
       await checkout.handleTeamSubscribe()
 
       expect(mockSubscribe).toHaveBeenCalledWith('team_per_credit_monthly', {
+        checkoutAttemptId: expect.any(String),
         teamCreditStopId: 'team_700',
         billingCycle: 'monthly',
         returnUrl: 'https://app.test/subscribe',
@@ -2247,8 +2367,10 @@ describe('useSubscriptionCheckout', () => {
       )
       // Regression guard: this reactivation-consent guard is not a checkout
       // attempt, so it must not open a funnel entry no terminal event will
-      // ever close.
-      expect(mockTrackBillingEvent).not.toHaveBeenCalled()
+      // ever close. The preview it already resolved still reports its quote.
+      expect(mockTrackBillingEvent).not.toHaveBeenCalledWith(
+        expect.objectContaining({ stage: 'started' })
+      )
     })
 
     it('refuses to bill a team reactivation when a fresh preview no longer matches the confirmed charge', async () => {
@@ -2346,7 +2468,11 @@ describe('useSubscriptionCheckout', () => {
           detail: 'status unavailable'
         })
       )
-      expect(mockTrackBillingEvent).not.toHaveBeenCalled()
+      // The attempt never reached subscribe, so no lifecycle opened; the
+      // preview that already resolved still reports its quote.
+      expect(mockTrackBillingEvent).not.toHaveBeenCalledWith(
+        expect.objectContaining({ stage: 'started' })
+      )
     })
 
     it('bounces to pricing when a required reactivation refresh cannot collect consent', async () => {
@@ -2574,6 +2700,9 @@ describe('useSubscriptionCheckout', () => {
       )
       expect(mockTrackBeginCheckout).not.toHaveBeenCalled()
       expect(mockTrackBillingEvent).toHaveBeenCalledWith({
+        checkout_attempt_id: expect.any(String),
+        flag_state: 'embedded_checkout_on',
+        workspace_id: 'workspace-1',
         operation: 'subscription_checkout',
         stage: 'failed',
         outcome: 'failure',
@@ -2909,6 +3038,9 @@ describe('useSubscriptionCheckout', () => {
       await checkout.handleAddCreditCard()
 
       expect(mockTrackBillingEvent).toHaveBeenCalledWith({
+        checkout_attempt_id: expect.any(String),
+        flag_state: 'embedded_checkout_on',
+        workspace_id: 'workspace-1',
         operation: 'subscription_checkout',
         stage: 'started',
         outcome: 'pending',
@@ -2918,6 +3050,9 @@ describe('useSubscriptionCheckout', () => {
         payment_intent_source: undefined
       })
       expect(mockTrackBillingEvent).toHaveBeenCalledWith({
+        checkout_attempt_id: expect.any(String),
+        flag_state: 'embedded_checkout_on',
+        workspace_id: 'workspace-1',
         operation: 'operation',
         stage: 'started',
         outcome: 'pending',
@@ -2943,12 +3078,16 @@ describe('useSubscriptionCheckout', () => {
       await checkout.handleAddCreditCard()
 
       expect(mockSubscribe).toHaveBeenCalledWith('standard-yearly', {
+        checkoutAttemptId: expect.any(String),
         returnUrl: 'https://app.test/subscribe',
         cancelUrl: 'https://platform.comfy.org/payment/failed',
         confirmReactivation: false
       })
       expect(checkout.checkoutStep.value).toBe('success')
       expect(mockTrackBillingEvent).toHaveBeenCalledWith({
+        checkout_attempt_id: expect.any(String),
+        flag_state: 'embedded_checkout_on',
+        workspace_id: 'workspace-1',
         operation: 'subscription_checkout',
         stage: 'succeeded',
         outcome: 'success',
@@ -3100,6 +3239,9 @@ describe('useSubscriptionCheckout', () => {
         'op-async-1',
         'subscription',
         {
+          checkoutAttemptId: expect.any(String),
+          flagState: 'embedded_checkout_on',
+          quoteId: undefined,
           tier: 'standard',
           cycle: 'yearly',
           checkoutType: 'new',
@@ -3131,6 +3273,9 @@ describe('useSubscriptionCheckout', () => {
         'op-async-2',
         'subscription',
         {
+          checkoutAttemptId: expect.any(String),
+          flagState: 'embedded_checkout_on',
+          quoteId: undefined,
           tier: 'standard',
           cycle: 'yearly',
           checkoutType: 'new',
@@ -3253,6 +3398,9 @@ describe('useSubscriptionCheckout', () => {
       )
       expect(mockTrackBeginCheckout).not.toHaveBeenCalled()
       expect(mockTrackBillingEvent).toHaveBeenCalledWith({
+        checkout_attempt_id: expect.any(String),
+        flag_state: 'embedded_checkout_on',
+        workspace_id: 'workspace-1',
         operation: 'subscription_checkout',
         stage: 'failed',
         outcome: 'failure',
@@ -3274,6 +3422,9 @@ describe('useSubscriptionCheckout', () => {
       await checkout.handleAddCreditCard()
 
       expect(mockTrackBillingEvent).toHaveBeenCalledWith({
+        checkout_attempt_id: expect.any(String),
+        flag_state: 'embedded_checkout_on',
+        workspace_id: 'workspace-1',
         operation: 'subscription_checkout',
         stage: 'failed',
         outcome: 'failure',
@@ -3669,8 +3820,10 @@ describe('useSubscriptionCheckout', () => {
       )
       // Regression guard: this reactivation-consent guard is not a checkout
       // attempt, so it must not open a funnel entry no terminal event will
-      // ever close.
-      expect(mockTrackBillingEvent).not.toHaveBeenCalled()
+      // ever close. The preview it already resolved still reports its quote.
+      expect(mockTrackBillingEvent).not.toHaveBeenCalledWith(
+        expect.objectContaining({ stage: 'started' })
+      )
     })
 
     it('refuses to bill when a fresh preview no longer matches the confirmed charge', async () => {
@@ -3855,6 +4008,9 @@ describe('useSubscriptionCheckout', () => {
       await checkout.handleResubscribe()
 
       expect(mockTrackBillingEvent).toHaveBeenCalledWith({
+        checkout_attempt_id: expect.any(String),
+        flag_state: 'embedded_checkout_on',
+        workspace_id: 'workspace-1',
         operation: 'resubscribe',
         stage: 'started',
         outcome: 'pending',
@@ -3881,6 +4037,9 @@ describe('useSubscriptionCheckout', () => {
         payment_intent_source: 'subscribe_to_run'
       })
       expect(mockTrackBillingEvent).toHaveBeenCalledWith({
+        checkout_attempt_id: expect.any(String),
+        flag_state: 'embedded_checkout_on',
+        workspace_id: 'workspace-1',
         operation: 'resubscribe',
         stage: 'succeeded',
         outcome: 'success',
@@ -3904,6 +4063,9 @@ describe('useSubscriptionCheckout', () => {
         })
       )
       expect(mockTrackBillingEvent).toHaveBeenCalledWith({
+        checkout_attempt_id: expect.any(String),
+        flag_state: 'embedded_checkout_on',
+        workspace_id: 'workspace-1',
         operation: 'resubscribe',
         stage: 'failed',
         outcome: 'failure',
@@ -3926,6 +4088,9 @@ describe('useSubscriptionCheckout', () => {
         expect.objectContaining({ stage: 'succeeded' })
       )
       expect(mockTrackBillingEvent).toHaveBeenCalledWith({
+        checkout_attempt_id: expect.any(String),
+        flag_state: 'embedded_checkout_on',
+        workspace_id: 'workspace-1',
         operation: 'resubscribe',
         stage: 'started',
         outcome: 'pending',
@@ -3946,6 +4111,9 @@ describe('useSubscriptionCheckout', () => {
       await checkout.handleResubscribe()
 
       expect(mockTrackBillingEvent).toHaveBeenCalledWith({
+        checkout_attempt_id: expect.any(String),
+        flag_state: 'embedded_checkout_on',
+        workspace_id: 'workspace-1',
         operation: 'resubscribe',
         stage: 'failed',
         outcome: 'failure',

--- a/src/platform/workspace/composables/useSubscriptionCheckout.test.ts
+++ b/src/platform/workspace/composables/useSubscriptionCheckout.test.ts
@@ -1417,7 +1417,10 @@ describe('useSubscriptionCheckout', () => {
 
         expect(mockPreviewSubscribe).toHaveBeenCalledWith(
           'team_per_credit_monthly',
-          { teamCreditStopId: 'team_1400' }
+          {
+            teamCreditStopId: 'team_1400',
+            checkoutAttemptId: expect.any(String)
+          }
         )
         expect(checkout.previewData.value?.allowed).toBe(true)
         expect(checkout.checkoutStep.value).toBe('preview')

--- a/src/platform/workspace/composables/useSubscriptionCheckout.ts
+++ b/src/platform/workspace/composables/useSubscriptionCheckout.ts
@@ -1383,6 +1383,7 @@ export function useSubscriptionCheckout(
       attemptStartedAt: context.attemptStartedAt,
       checkoutAttemptId: activeCheckoutAttemptId,
       flagState: activeCheckoutFlagState,
+      attemptWorkspaceId: activeCheckoutWorkspaceId,
       quoteId: previewData.value?.quote_id,
       ...(embeddedCheckoutEnabled && {
         suppressProcessingToast: true,
@@ -1532,6 +1533,11 @@ export function useSubscriptionCheckout(
     if (!canReactivatePlan.value) return
 
     const source = 'pricing_dialog' as const
+
+    // A reactivation is its own attempt: without this it would inherit the id
+    // of whatever checkout ran earlier in the dialog, and a retry after a
+    // failed reactivation would emit a second started/terminal pair under it.
+    beginCheckoutAttempt()
 
     telemetry?.trackResubscribeClicked({
       source,

--- a/src/platform/workspace/composables/useSubscriptionCheckout.ts
+++ b/src/platform/workspace/composables/useSubscriptionCheckout.ts
@@ -12,12 +12,15 @@ import type { TeamPlanSelection } from '@/platform/cloud/subscription/constants/
 import type { TierKey } from '@/platform/cloud/subscription/constants/tierPricing'
 import type { BillingCycle } from '@/platform/cloud/subscription/utils/subscriptionTierRank'
 import { isCloud } from '@/platform/distribution/types'
+import { createAttemptId } from '@/platform/cloud/subscription/utils/subscriptionCheckoutTracker'
 import { useTelemetry } from '@/platform/telemetry'
 import type {
+  BillingFlagState,
   PaymentIntentSource,
   SubscriptionCheckoutType
 } from '@/platform/telemetry/types'
 import { categorizeBillingApiError } from '@/platform/telemetry/utils/billingFailureCategory'
+import { resolveBillingFlagState } from '@/platform/telemetry/utils/billingFlagState'
 import { useAuthStore } from '@/stores/authStore'
 import type {
   Plan,
@@ -161,6 +164,12 @@ export function useSubscriptionCheckout(
   let checkoutMutationLocked = false
   let refreshStatusOnFocus = false
   let activeCheckoutAttemptStartedAt: number | undefined
+  // Minted when the customer picks a plan, before the preview call, so every
+  // event of the attempt — including the quote mint and a `started` that
+  // precedes the billing op's existence — carries one joinable key.
+  let activeCheckoutAttemptId: string | undefined
+  let activeCheckoutFlagState: BillingFlagState | undefined
+  let activeCheckoutWorkspaceId: string | null = null
   useEventListener(window, 'focus', () => {
     if (!refreshStatusOnFocus) return
     refreshStatusOnFocus = false
@@ -215,6 +224,28 @@ export function useSubscriptionCheckout(
       operation.authenticationState !== 'requires_action'
     )
   })
+  function beginCheckoutAttempt(): void {
+    activeCheckoutAttemptId = createAttemptId()
+    activeCheckoutFlagState = resolveBillingFlagState(embeddedCheckoutEnabled)
+    activeCheckoutWorkspaceId = workspaceStore.activeWorkspaceId
+  }
+
+  // Snapshotted at attempt start, never read live: events fire after awaits,
+  // so a mid-attempt workspace switch would otherwise label this attempt's
+  // terminal event with the workspace the customer moved to (ADR 0014).
+  function attemptTelemetryContext() {
+    if (activeCheckoutAttemptId === undefined) beginCheckoutAttempt()
+    const quoteId = previewData.value?.quote_id
+    return {
+      checkout_attempt_id: activeCheckoutAttemptId,
+      flag_state: activeCheckoutFlagState,
+      ...(activeCheckoutWorkspaceId && {
+        workspace_id: activeCheckoutWorkspaceId
+      }),
+      ...(quoteId && { quote_id: quoteId })
+    }
+  }
+
   function beginCheckoutMutation(): boolean {
     if (checkoutMutationLocked) return false
     checkoutMutationLocked = true
@@ -249,7 +280,19 @@ export function useSubscriptionCheckout(
         preview.requires_reactivation_confirmation ?? true
     }
     quoteIsCurrent.value = true
+    trackQuoteMinted()
     return true
+  }
+
+  function trackQuoteMinted(): void {
+    if (!shouldUseWorkspaceBilling.value) return
+    telemetry?.trackBillingEvent({
+      operation: 'subscription_checkout',
+      stage: 'quote_minted',
+      outcome: 'pending',
+      payment_intent_source: paymentIntentSource,
+      ...attemptTelemetryContext()
+    })
   }
 
   function requiresReactivationConfirmation(): boolean {
@@ -305,6 +348,20 @@ export function useSubscriptionCheckout(
 
   function invalidateQuote(): void {
     quoteIsCurrent.value = false
+  }
+
+  // Every quote this attempt mints is reported to the backend under the same
+  // attempt key, so a preview that never becomes a subscribe is still joinable.
+  function previewSubscribeForAttempt(
+    planSlug: string,
+    options: PreviewSubscribeOptions = {}
+  ): Promise<PreviewSubscribeResponse | null> {
+    return previewSubscribe(planSlug, {
+      ...options,
+      ...(activeCheckoutAttemptId && {
+        checkoutAttemptId: activeCheckoutAttemptId
+      })
+    })
   }
 
   function withCurrentPromotion(
@@ -401,7 +458,7 @@ export function useSubscriptionCheckout(
     options?: PreviewSubscribeOptions
   ): Promise<void> {
     const confirmedPreview = previewData.value
-    const freshPreview = await previewSubscribe(
+    const freshPreview = await previewSubscribeForAttempt(
       planSlug,
       withCurrentPromotion(options)
     )
@@ -520,7 +577,7 @@ export function useSubscriptionCheckout(
 
     let freshPreview: PreviewSubscribeResponse | null
     try {
-      freshPreview = await previewSubscribe(
+      freshPreview = await previewSubscribeForAttempt(
         planSlug,
         withCurrentPromotion(options)
       )
@@ -561,7 +618,7 @@ export function useSubscriptionCheckout(
   ): Promise<void> {
     let freshPreview: PreviewSubscribeResponse | null = null
     try {
-      freshPreview = await previewSubscribe(
+      freshPreview = await previewSubscribeForAttempt(
         planSlug,
         withCurrentPromotion(options)
       )
@@ -681,6 +738,7 @@ export function useSubscriptionCheckout(
     const { tierKey, billingCycle } = payload
     promotionPreviewRequestId += 1
 
+    beginCheckoutAttempt()
     reactivationRequired.value = false
     isLoadingPreview.value = true
     loadingTier.value = tierKey
@@ -705,11 +763,11 @@ export function useSubscriptionCheckout(
       const response = embeddedCheckoutEnabled
         ? (
             await Promise.all([
-              previewSubscribe(planSlug),
+              previewSubscribeForAttempt(planSlug),
               loadSavedPaymentMethods()
             ])
           )[0]
-        : await previewSubscribe(planSlug)
+        : await previewSubscribeForAttempt(planSlug)
 
       if (!response || !response.allowed) {
         toast.add({
@@ -759,6 +817,7 @@ export function useSubscriptionCheckout(
 
     const previewRequestId = ++teamPreviewRequestId
     promotionPreviewRequestId += 1
+    beginCheckoutAttempt()
     reactivationRequired.value = false
     selectedTeamCheckout.value = {
       stop: payload.stop,
@@ -785,7 +844,7 @@ export function useSubscriptionCheckout(
       let response: PreviewSubscribeResponse | null = null
       let previewError: unknown
       try {
-        response = await previewSubscribe(
+        response = await previewSubscribeForAttempt(
           getTeamPlanSlug(payload.billingCycle),
           { teamCreditStopId }
         )
@@ -833,7 +892,7 @@ export function useSubscriptionCheckout(
     try {
       const planSlug = getTeamPlanSlug(payload.billingCycle)
       ;[response] = await Promise.all([
-        previewSubscribe(planSlug, {
+        previewSubscribeForAttempt(planSlug, {
           teamCreditStopId: payload.stop.id
         }),
         loadSavedPaymentMethods()
@@ -960,7 +1019,10 @@ export function useSubscriptionCheckout(
         confirmReactivation,
         prorationAt: previewData.value?.is_immediate
           ? previewData.value.proration_at
-          : undefined
+          : undefined,
+        ...(activeCheckoutAttemptId && {
+          checkoutAttemptId: activeCheckoutAttemptId
+        })
       })
 
       if (response) {
@@ -1076,7 +1138,7 @@ export function useSubscriptionCheckout(
     }
     quoteIsCurrent.value = false
     try {
-      const response = await previewSubscribe(planSlug, options)
+      const response = await previewSubscribeForAttempt(planSlug, options)
       if (!response?.allowed) {
         throw new Error(response?.reason || t('subscription.subscribeFailed'))
       }
@@ -1118,6 +1180,7 @@ export function useSubscriptionCheckout(
 
     activeCheckoutAttemptStartedAt = Date.now()
 
+    const attemptContext = attemptTelemetryContext()
     telemetry?.trackBillingEvent({
       operation: 'subscription_checkout',
       stage: 'started',
@@ -1125,7 +1188,8 @@ export function useSubscriptionCheckout(
       tier: context.tier,
       cycle: context.cycle,
       checkout_type: context.checkoutType,
-      payment_intent_source: paymentIntentSource
+      payment_intent_source: paymentIntentSource,
+      ...attemptContext
     })
     telemetry?.trackBillingEvent({
       operation: 'operation',
@@ -1135,7 +1199,8 @@ export function useSubscriptionCheckout(
       tier: context.tier,
       cycle: context.cycle,
       checkout_type: context.checkoutType,
-      payment_intent_source: paymentIntentSource
+      payment_intent_source: paymentIntentSource,
+      ...attemptContext
     })
     return activeCheckoutAttemptStartedAt
   }
@@ -1152,6 +1217,7 @@ export function useSubscriptionCheckout(
       ? 'unknown'
       : categorizeBillingApiError(error)
 
+    const attemptContext = attemptTelemetryContext()
     telemetry?.trackBillingEvent({
       operation: 'subscription_checkout',
       stage: 'failed',
@@ -1162,7 +1228,8 @@ export function useSubscriptionCheckout(
       payment_intent_source: paymentIntentSource,
       failure_category: failureCategory,
       ...(errorCode && { error_code: errorCode }),
-      duration_ms: Date.now() - context.attemptStartedAt
+      duration_ms: Date.now() - context.attemptStartedAt,
+      ...attemptContext
     })
     telemetry?.trackBillingEvent({
       operation: 'operation',
@@ -1175,7 +1242,8 @@ export function useSubscriptionCheckout(
       payment_intent_source: paymentIntentSource,
       failure_category: failureCategory,
       ...(errorCode && { error_code: errorCode }),
-      duration_ms: Date.now() - context.attemptStartedAt
+      duration_ms: Date.now() - context.attemptStartedAt,
+      ...attemptContext
     })
   }
 
@@ -1202,6 +1270,7 @@ export function useSubscriptionCheckout(
         // already restores trackMonthlySubscriptionSucceeded for the
         // providers that need it (Mixpanel, GTM); this call site doesn't need
         // a second one.
+        const attemptContext = attemptTelemetryContext()
         telemetry?.trackBillingEvent({
           operation: 'subscription_checkout',
           stage: 'succeeded',
@@ -1211,7 +1280,8 @@ export function useSubscriptionCheckout(
           checkout_type: context.checkoutType,
           payment_intent_source: paymentIntentSource,
           billing_op_id: response.billing_op_id,
-          duration_ms: durationMs
+          duration_ms: durationMs,
+          ...attemptContext
         })
         telemetry?.trackBillingEvent({
           operation: 'operation',
@@ -1223,7 +1293,8 @@ export function useSubscriptionCheckout(
           checkout_type: context.checkoutType,
           payment_intent_source: paymentIntentSource,
           billing_op_id: response.billing_op_id,
-          duration_ms: durationMs
+          duration_ms: durationMs,
+          ...attemptContext
         })
       }
       checkoutStep.value = 'success'
@@ -1310,6 +1381,9 @@ export function useSubscriptionCheckout(
       checkoutType: context.checkoutType,
       paymentIntentSource,
       attemptStartedAt: context.attemptStartedAt,
+      checkoutAttemptId: activeCheckoutAttemptId,
+      flagState: activeCheckoutFlagState,
+      quoteId: previewData.value?.quote_id,
       ...(embeddedCheckoutEnabled && {
         suppressProcessingToast: true,
         autoHandleRequiresAction: true
@@ -1400,7 +1474,10 @@ export function useSubscriptionCheckout(
         confirmReactivation,
         prorationAt: previewData.value?.is_immediate
           ? previewData.value.proration_at
-          : undefined
+          : undefined,
+        ...(activeCheckoutAttemptId && {
+          checkoutAttemptId: activeCheckoutAttemptId
+        })
       })
 
       if (response) {
@@ -1468,7 +1545,8 @@ export function useSubscriptionCheckout(
       stage: 'started',
       outcome: 'pending',
       source,
-      payment_intent_source: paymentIntentSource
+      payment_intent_source: paymentIntentSource,
+      ...attemptTelemetryContext()
     })
     isResubscribing.value = true
     try {
@@ -1484,7 +1562,8 @@ export function useSubscriptionCheckout(
           stage: 'succeeded',
           outcome: 'success',
           source,
-          payment_intent_source: paymentIntentSource
+          payment_intent_source: paymentIntentSource,
+          ...attemptTelemetryContext()
         })
       }
       toast.add({
@@ -1502,7 +1581,8 @@ export function useSubscriptionCheckout(
         outcome: 'failure',
         source,
         payment_intent_source: paymentIntentSource,
-        failure_category: categorizeBillingApiError(error)
+        failure_category: categorizeBillingApiError(error),
+        ...attemptTelemetryContext()
       })
       toast.add({
         severity: 'error',

--- a/src/platform/workspace/stores/billingOperationStore.test.ts
+++ b/src/platform/workspace/stores/billingOperationStore.test.ts
@@ -1640,6 +1640,70 @@ describe('billingOperationStore', () => {
         expect(challengeEvents('challenge_presented')).toHaveLength(1)
       })
 
+      // The operation opens only once subscribe() has returned, so reading the
+      // workspace live here would label the attempt with wherever the customer
+      // navigated while it was in flight.
+      it('reports the workspace the attempt started in, not the live one', async () => {
+        vi.mocked(workspaceApi.getBillingOpStatus).mockResolvedValue({
+          id: 'op-ws',
+          status: 'pending',
+          started_at: new Date().toISOString()
+        })
+        const store = useBillingOperationStore()
+        mockActiveWorkspaceId.value = 'workspace-2'
+        void store.startOperation('op-ws', 'subscription', {
+          suppressProcessingToast: true,
+          checkoutAttemptId: 'attempt-1',
+          attemptWorkspaceId: 'workspace-1'
+        })
+        await vi.advanceTimersByTimeAsync(0)
+
+        expect(
+          mockTrackBillingEvent.mock.calls
+            .map(([event]) => event)
+            .filter((event) => event.stage === 'started')
+        ).toEqual([
+          expect.objectContaining({
+            billing_op_id: 'op-ws',
+            checkout_attempt_id: 'attempt-1',
+            workspace_id: 'workspace-1'
+          })
+        ])
+        expect(store.getOperation('op-ws')?.workspaceId).toBe('workspace-2')
+      })
+
+      // A `needs_payment_method` response hands its collection page to
+      // startOperation as the action url. That is not a 3DS challenge, and
+      // counting it as one would also latch out the real presentation below.
+      it('does not open the funnel for a payment-method collection page', async () => {
+        vi.mocked(workspaceApi.getBillingOpStatus).mockResolvedValue({
+          id: 'op-pm',
+          status: 'pending',
+          started_at: new Date().toISOString()
+        })
+        const store = useBillingOperationStore()
+        void store.startOperation(
+          'op-pm',
+          'subscription',
+          { suppressProcessingToast: true, checkoutAttemptId: 'attempt-1' },
+          'https://billing.stripe.com/collect-payment-method'
+        )
+        await vi.advanceTimersByTimeAsync(0)
+
+        expect(challengeEvents('challenge_presented')).toEqual([])
+
+        vi.mocked(workspaceApi.getBillingOpStatus).mockResolvedValue({
+          id: 'op-pm',
+          status: 'pending',
+          authentication_state: 'requires_action',
+          payment_intent_client_secret: 'pi_secret_pm',
+          started_at: new Date().toISOString()
+        })
+        await vi.advanceTimersByTimeAsync(31_000)
+
+        expect(challengeEvents('challenge_presented')).toHaveLength(1)
+      })
+
       it('reports a completed challenge as succeeded', async () => {
         mockHandleNextAction.mockResolvedValue({
           paymentIntent: { status: 'succeeded' }

--- a/src/platform/workspace/stores/billingOperationStore.test.ts
+++ b/src/platform/workspace/stores/billingOperationStore.test.ts
@@ -1673,12 +1673,15 @@ describe('billingOperationStore', () => {
       })
 
       // A `needs_payment_method` response hands its collection page to
-      // startOperation as the action url. That is not a 3DS challenge, and
-      // counting it as one would also latch out the real presentation below.
+      // startOperation as the action url AND keeps echoing it on every poll for
+      // as long as the customer is on the Stripe page. Neither is a 3DS
+      // challenge, and counting either would also latch out the real
+      // presentation that follows.
       it('does not open the funnel for a payment-method collection page', async () => {
         vi.mocked(workspaceApi.getBillingOpStatus).mockResolvedValue({
           id: 'op-pm',
           status: 'pending',
+          action_url: 'https://billing.stripe.com/collect-payment-method',
           started_at: new Date().toISOString()
         })
         const store = useBillingOperationStore()
@@ -1689,6 +1692,7 @@ describe('billingOperationStore', () => {
           'https://billing.stripe.com/collect-payment-method'
         )
         await vi.advanceTimersByTimeAsync(0)
+        await vi.advanceTimersByTimeAsync(31_000)
 
         expect(challengeEvents('challenge_presented')).toEqual([])
 
@@ -1701,7 +1705,44 @@ describe('billingOperationStore', () => {
         })
         await vi.advanceTimersByTimeAsync(31_000)
 
-        expect(challengeEvents('challenge_presented')).toHaveLength(1)
+        expect(challengeEvents('challenge_presented')).toEqual([
+          expect.objectContaining({
+            billing_op_id: 'op-pm',
+            checkout_attempt_id: 'attempt-1'
+          })
+        ])
+        expect(store.getOperation('op-pm')?.authenticationState).toBe(
+          'requires_action'
+        )
+      })
+
+      // `updateAuthenticationState` is skipped entirely in the ungated arm, so
+      // an `action_url` call site would give that arm a looser definition of
+      // `challenge_presented` than the gated one — in exactly the dimension the
+      // rollout dashboard splits on. Reporting nothing there is the intent.
+      it('emits no presentation in the ungated arm for a hosted action url', async () => {
+        mockFeatureFlags.embeddedCheckoutEnabled = false
+        vi.mocked(workspaceApi.getBillingOpStatus).mockResolvedValue({
+          id: 'op-ungated',
+          status: 'pending',
+          authentication_state: 'requires_action',
+          payment_intent_client_secret: 'pi_secret_ungated',
+          action_url: 'https://invoice.stripe.com/i/auth',
+          started_at: new Date().toISOString()
+        })
+
+        const store = useBillingOperationStore()
+        void store.startOperation('op-ungated', 'subscription', {
+          suppressProcessingToast: true,
+          checkoutAttemptId: 'attempt-1'
+        })
+        await vi.advanceTimersByTimeAsync(0)
+        await vi.advanceTimersByTimeAsync(31_000)
+
+        expect(store.getOperation('op-ungated')?.actionUrl).toBe(
+          'https://invoice.stripe.com/i/auth'
+        )
+        expect(challengeEvents('challenge_presented')).toEqual([])
       })
 
       it('reports a completed challenge as succeeded', async () => {
@@ -1776,6 +1817,39 @@ describe('billingOperationStore', () => {
             reason: 'intent_status_unavailable'
           })
         ])
+      })
+
+      // `canRetryAuthentication` is also true for a plain `failed_retryable`
+      // decline, so the retry button reaches the same Stripe call without any
+      // challenge ever having been presented. Reporting its return would put
+      // the operation in the funnel's numerator and not its denominator.
+      it('reports no return for a decline retry that presented no challenge', async () => {
+        mockHandleNextAction.mockResolvedValue({
+          paymentIntent: { status: 'succeeded' }
+        })
+        vi.mocked(workspaceApi.getBillingOpStatus).mockResolvedValue({
+          id: 'op-declined',
+          status: 'pending',
+          authentication_state: 'failed_retryable',
+          decline_reason: 'card_declined',
+          payment_intent_client_secret: 'pi_secret_declined',
+          started_at: new Date().toISOString()
+        })
+
+        const store = useBillingOperationStore()
+        void store.startOperation('op-declined', 'subscription', {
+          suppressProcessingToast: true,
+          checkoutAttemptId: 'attempt-1'
+        })
+        await vi.advanceTimersByTimeAsync(0)
+
+        expect(challengeEvents('challenge_presented')).toEqual([])
+        await expect(
+          store.retryPaymentAuthentication('op-declined')
+        ).resolves.toBe(true)
+
+        expect(mockHandleNextAction).toHaveBeenCalledOnce()
+        expect(challengeEvents('challenge_returned')).toEqual([])
       })
 
       it('reports the ungated arm as unknown when no flag map has arrived', async () => {

--- a/src/platform/workspace/stores/billingOperationStore.test.ts
+++ b/src/platform/workspace/stores/billingOperationStore.test.ts
@@ -1763,11 +1763,10 @@ describe('billingOperationStore', () => {
         ])
       })
 
-      // Regression guard for the failure that shipped: handleNextAction
-      // resolves with no error and an intent that never moved, the store keeps
-      // the operation on `processing`, and nothing distinguished it from a
-      // completed challenge. The state machine still reads `processing` here —
-      // this event is what makes the difference observable.
+      // handleNextAction resolves with no error and an intent that never
+      // moved past its pre-challenge status. The store reports that as
+      // failed_retryable, not processing; this event is the telemetry side
+      // of the same distinction.
       it('reports a challenge that resolved cleanly without advancing as failed', async () => {
         mockHandleNextAction.mockResolvedValue({
           paymentIntent: { status: 'requires_payment_method' }
@@ -1777,7 +1776,7 @@ describe('billingOperationStore', () => {
 
         expect(mockHandleNextAction).toHaveBeenCalledOnce()
         expect(store.getOperation('op-3ds')?.authenticationState).toBe(
-          'processing'
+          'failed_retryable'
         )
         expect(challengeEvents('challenge_returned')).toEqual([
           expect.objectContaining({
@@ -1819,14 +1818,12 @@ describe('billingOperationStore', () => {
         ])
       })
 
-      // `canRetryAuthentication` is also true for a plain `failed_retryable`
-      // decline, so the retry button reaches the same Stripe call without any
-      // challenge ever having been presented. Reporting its return would put
-      // the operation in the funnel's numerator and not its denominator.
+      // A decline's authenticationState is failed_retryable, never
+      // requires_action, so retryPaymentAuthentication's own gate stops it
+      // before Stripe is ever called. trackChallengeReturned's presented-latch
+      // check is a second guard against the same case if that gate is ever
+      // loosened.
       it('reports no return for a decline retry that presented no challenge', async () => {
-        mockHandleNextAction.mockResolvedValue({
-          paymentIntent: { status: 'succeeded' }
-        })
         vi.mocked(workspaceApi.getBillingOpStatus).mockResolvedValue({
           id: 'op-declined',
           status: 'pending',
@@ -1846,9 +1843,9 @@ describe('billingOperationStore', () => {
         expect(challengeEvents('challenge_presented')).toEqual([])
         await expect(
           store.retryPaymentAuthentication('op-declined')
-        ).resolves.toBe(true)
+        ).resolves.toBe(false)
 
-        expect(mockHandleNextAction).toHaveBeenCalledOnce()
+        expect(mockHandleNextAction).not.toHaveBeenCalled()
         expect(challengeEvents('challenge_returned')).toEqual([])
       })
 

--- a/src/platform/workspace/stores/billingOperationStore.test.ts
+++ b/src/platform/workspace/stores/billingOperationStore.test.ts
@@ -283,7 +283,10 @@ describe('billingOperationStore', () => {
             operation: 'operation',
             stage: 'started',
             outcome: 'pending',
-            operation_type: 'subscription'
+            operation_type: 'subscription',
+            billing_op_id: 'op-recovered',
+            flag_state: 'embedded_checkout_on',
+            workspace_id: 'workspace-1'
           }
         ],
         [
@@ -297,7 +300,9 @@ describe('billingOperationStore', () => {
             cycle: undefined,
             checkout_type: undefined,
             payment_intent_source: undefined,
-            duration_ms: 0
+            duration_ms: 0,
+            flag_state: 'embedded_checkout_on',
+            workspace_id: 'workspace-1'
           }
         ]
       ])
@@ -332,7 +337,9 @@ describe('billingOperationStore', () => {
             cycle: 'monthly',
             checkout_type: 'new',
             payment_intent_source: undefined,
-            duration_ms: 0
+            duration_ms: 0,
+            flag_state: 'embedded_checkout_on',
+            workspace_id: 'workspace-1'
           }
         ],
         [
@@ -345,7 +352,9 @@ describe('billingOperationStore', () => {
             checkout_type: 'new',
             payment_intent_source: undefined,
             billing_op_id: 'op-initiated',
-            duration_ms: 0
+            duration_ms: 0,
+            flag_state: 'embedded_checkout_on',
+            workspace_id: 'workspace-1'
           }
         ]
       ])
@@ -446,6 +455,8 @@ describe('billingOperationStore', () => {
       await vi.advanceTimersByTimeAsync(0)
 
       expect(mockTrackBillingEvent).toHaveBeenCalledWith({
+        flag_state: 'embedded_checkout_on',
+        workspace_id: 'workspace-1',
         operation: 'subscription_checkout',
         stage: 'succeeded',
         outcome: 'success',
@@ -556,6 +567,8 @@ describe('billingOperationStore', () => {
       await vi.advanceTimersByTimeAsync(0)
 
       expect(mockTrackBillingEvent).toHaveBeenCalledWith({
+        flag_state: 'embedded_checkout_on',
+        workspace_id: 'workspace-1',
         operation: 'downgrade_to_personal',
         stage: 'succeeded',
         outcome: 'success',
@@ -581,6 +594,8 @@ describe('billingOperationStore', () => {
       await vi.advanceTimersByTimeAsync(0)
 
       expect(mockTrackBillingEvent).toHaveBeenCalledWith({
+        flag_state: 'embedded_checkout_on',
+        workspace_id: 'workspace-1',
         operation: 'topup',
         stage: 'succeeded',
         outcome: 'success',
@@ -612,6 +627,8 @@ describe('billingOperationStore', () => {
         await vi.advanceTimersByTimeAsync(0)
 
         expect(mockTrackBillingEvent).toHaveBeenCalledWith({
+          flag_state: 'embedded_checkout_on',
+          workspace_id: 'workspace-1',
           operation: 'operation',
           stage: 'succeeded',
           outcome: 'success',
@@ -747,6 +764,8 @@ describe('billingOperationStore', () => {
         life: 7000
       })
       expect(mockTrackBillingEvent).toHaveBeenCalledWith({
+        flag_state: 'embedded_checkout_on',
+        workspace_id: 'workspace-1',
         operation: 'operation',
         stage: 'failed',
         outcome: 'failure',
@@ -1559,6 +1578,163 @@ describe('billingOperationStore', () => {
       expect((await terminal).status).toBe('succeeded')
     })
 
+    describe('challenge telemetry', () => {
+      const startChallengedOperation = async (
+        opId = 'op-3ds',
+        secret = 'pi_secret_current'
+      ) => {
+        vi.mocked(workspaceApi.getBillingOpStatus).mockResolvedValue({
+          id: opId,
+          status: 'pending',
+          authentication_state: 'requires_action',
+          payment_intent_client_secret: secret,
+          started_at: new Date().toISOString()
+        })
+        const store = useBillingOperationStore()
+        void store.startOperation(opId, 'subscription', {
+          autoHandleRequiresAction: true,
+          suppressProcessingToast: true,
+          checkoutAttemptId: 'attempt-1',
+          flagState: 'embedded_checkout_on'
+        })
+        await vi.advanceTimersByTimeAsync(0)
+        return store
+      }
+
+      const challengeEvents = (stage: string) =>
+        mockTrackBillingEvent.mock.calls
+          .map(([event]) => event)
+          .filter((event) => event.stage === stage)
+
+      it('opens the challenge funnel when a challenge is first required', async () => {
+        await startChallengedOperation()
+
+        expect(challengeEvents('challenge_presented')).toEqual([
+          {
+            operation: 'subscription_checkout',
+            stage: 'challenge_presented',
+            outcome: 'pending',
+            billing_op_id: 'op-3ds',
+            tier: undefined,
+            cycle: undefined,
+            checkout_type: undefined,
+            payment_intent_source: undefined,
+            checkout_attempt_id: 'attempt-1',
+            flag_state: 'embedded_checkout_on',
+            workspace_id: 'workspace-1'
+          }
+        ])
+      })
+
+      // The presented event is the denominator for "attempts that hit a
+      // challenge", so a server that keeps reporting the same challenge must
+      // not inflate it.
+      it('counts one presentation however often the server repeats it', async () => {
+        const store = await startChallengedOperation()
+        await vi.advanceTimersByTimeAsync(31_000)
+        await vi.advanceTimersByTimeAsync(31_000)
+
+        expect(store.getOperation('op-3ds')?.authenticationRequiredSeen).toBe(
+          true
+        )
+        expect(challengeEvents('challenge_presented')).toHaveLength(1)
+      })
+
+      it('reports a completed challenge as succeeded', async () => {
+        mockHandleNextAction.mockResolvedValue({
+          paymentIntent: { status: 'succeeded' }
+        })
+
+        await startChallengedOperation()
+
+        expect(challengeEvents('challenge_returned')).toEqual([
+          expect.objectContaining({
+            outcome: 'succeeded',
+            reason: 'intent_advanced',
+            billing_op_id: 'op-3ds',
+            checkout_attempt_id: 'attempt-1',
+            flag_state: 'embedded_checkout_on'
+          })
+        ])
+      })
+
+      // Regression guard for the failure that shipped: handleNextAction
+      // resolves with no error and an intent that never moved, the store keeps
+      // the operation on `processing`, and nothing distinguished it from a
+      // completed challenge. The state machine still reads `processing` here —
+      // this event is what makes the difference observable.
+      it('reports a challenge that resolved cleanly without advancing as failed', async () => {
+        mockHandleNextAction.mockResolvedValue({
+          paymentIntent: { status: 'requires_payment_method' }
+        })
+
+        const store = await startChallengedOperation()
+
+        expect(mockHandleNextAction).toHaveBeenCalledOnce()
+        expect(store.getOperation('op-3ds')?.authenticationState).toBe(
+          'processing'
+        )
+        expect(challengeEvents('challenge_returned')).toEqual([
+          expect.objectContaining({
+            outcome: 'failed',
+            reason: 'challenge_not_completed',
+            billing_op_id: 'op-3ds'
+          })
+        ])
+      })
+
+      it('reports a browser-reported challenge error as failed', async () => {
+        mockHandleNextAction.mockResolvedValue({
+          error: { message: 'authentication failed' }
+        })
+
+        await startChallengedOperation()
+
+        expect(challengeEvents('challenge_returned')).toEqual([
+          expect.objectContaining({
+            outcome: 'failed',
+            reason: 'stripe_error'
+          })
+        ])
+      })
+
+      // Stripe reported neither an error nor an intent, so the client cannot
+      // tell the two apart. The reason keeps that ambiguity out of a clean
+      // success rate instead of hiding it.
+      it('marks a challenge with no reported intent as unverifiable', async () => {
+        mockHandleNextAction.mockResolvedValue({})
+
+        await startChallengedOperation()
+
+        expect(challengeEvents('challenge_returned')).toEqual([
+          expect.objectContaining({
+            outcome: 'succeeded',
+            reason: 'intent_status_unavailable'
+          })
+        ])
+      })
+
+      it('reports the ungated arm as unknown when no flag map has arrived', async () => {
+        mockFeatureFlags.embeddedCheckoutEnabled = false
+        vi.mocked(workspaceApi.getBillingOpStatus).mockResolvedValue({
+          id: 'op-flagless',
+          status: 'succeeded',
+          started_at: new Date().toISOString()
+        })
+
+        const store = useBillingOperationStore()
+        await store.startOperation('op-flagless', 'topup')
+
+        expect(mockTrackBillingEvent).toHaveBeenCalledWith(
+          expect.objectContaining({
+            stage: 'started',
+            billing_op_id: 'op-flagless',
+            flag_state: 'embedded_checkout_unknown'
+          })
+        )
+      })
+    })
+
     it('keeps a completed challenge processing when the server echoes requires_action', async () => {
       vi.mocked(workspaceApi.getBillingOpStatus)
         .mockResolvedValueOnce({
@@ -1721,6 +1897,8 @@ describe('billingOperationStore', () => {
       await vi.advanceTimersByTimeAsync(60_000)
       expect(workspaceApi.getBillingOpStatus).toHaveBeenCalledOnce()
       expect(mockTrackBillingEvent).toHaveBeenCalledWith({
+        flag_state: 'embedded_checkout_on',
+        workspace_id: 'workspace-1',
         operation: 'operation',
         stage: 'failed',
         outcome: 'failure',
@@ -1743,7 +1921,9 @@ describe('billingOperationStore', () => {
         payment_intent_source: undefined,
         billing_op_id: 'op-reconcile',
         failure_category: 'reconciliation_needed',
-        duration_ms: 0
+        duration_ms: 0,
+        flag_state: 'embedded_checkout_on',
+        workspace_id: 'workspace-1'
       })
     })
 
@@ -2275,6 +2455,8 @@ describe('billingOperationStore', () => {
         isSubscribed: false
       })
       expect(mockTrackBillingEvent).toHaveBeenCalledWith({
+        flag_state: 'embedded_checkout_on',
+        workspace_id: 'workspace-1',
         operation: 'operation',
         stage: 'succeeded',
         outcome: 'success',

--- a/src/platform/workspace/stores/billingOperationStore.ts
+++ b/src/platform/workspace/stores/billingOperationStore.ts
@@ -92,6 +92,12 @@ export interface StartOperationMetadata {
   checkoutAttemptId?: string
   flagState?: BillingFlagState
   quoteId?: string
+  /**
+   * The workspace the attempt started in, for telemetry only. `workspaceId`
+   * below is read live to gate UI against the workspace the customer is
+   * looking at now; this is the one they were subscribing for (ADR 0014).
+   */
+  attemptWorkspaceId?: string | null
 }
 
 interface BillingOperation {
@@ -122,6 +128,7 @@ interface BillingOperation {
   checkoutAttemptId?: string
   flagState: BillingFlagState
   quoteId?: string
+  attemptWorkspaceId?: string | null
 }
 
 type TerminalResolver = (operation: BillingOperation) => void
@@ -233,21 +240,27 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
   }
 
   function operationTelemetryContext(operation: BillingOperation) {
+    const workspaceId = operation.attemptWorkspaceId ?? operation.workspaceId
     return {
       ...(operation.checkoutAttemptId && {
         checkout_attempt_id: operation.checkoutAttemptId
       }),
       flag_state: operation.flagState,
-      ...(operation.workspaceId && { workspace_id: operation.workspaceId }),
+      ...(workspaceId && { workspace_id: workspaceId }),
       ...(operation.quoteId && { quote_id: operation.quoteId })
     }
   }
 
   /**
-   * `authenticationRequiredSeen` is a latch, so this is the denominator for
-   * "attempts that hit a challenge" — one per operation, however many times the
-   * customer retries. Pair it with `challenge_returned` per operation, not per
-   * event: a manual retry emits a second return against this one presentation.
+   * The denominator for "attempts that hit a challenge" — latched to one per
+   * operation, however many times the customer retries. Pair it with
+   * `challenge_returned` per operation, not per event: a manual retry emits a
+   * second return against this one presentation.
+   *
+   * Driven by an `authentication_state` of `requires_action`, never by
+   * `actionUrl`: a `needs_payment_method` response puts a payment-method
+   * collection page in `actionUrl` too, and counting that as a challenge would
+   * both inflate this denominator and latch out the real 3DS presentation.
    */
   function trackChallengePresented(opId: string) {
     const operation = operations.value.get(opId)
@@ -307,7 +320,8 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
       flagState:
         metadata?.flagState ??
         resolveBillingFlagState(flags.embeddedCheckoutEnabled),
-      quoteId: metadata?.quoteId
+      quoteId: metadata?.quoteId,
+      attemptWorkspaceId: metadata?.attemptWorkspaceId
     }
 
     operations.value = new Map(operations.value).set(opId, operation)
@@ -323,8 +337,6 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
         ...operationTelemetryContext(operation)
       })
     }
-
-    if (operation.authenticationRequiredSeen) trackChallengePresented(opId)
 
     if (type !== 'cancel' && !metadata?.suppressProcessingToast) {
       showProgressToast(opId, type, operation.actionUrl !== null)

--- a/src/platform/workspace/stores/billingOperationStore.ts
+++ b/src/platform/workspace/stores/billingOperationStore.ts
@@ -15,10 +15,12 @@ import { isCloud } from '@/platform/distribution/types'
 import { useTelemetry } from '@/platform/telemetry'
 import type {
   BillingFailure,
+  BillingFlagState,
   PaymentIntentSource,
   SubscriptionCheckoutTier,
   SubscriptionCheckoutType
 } from '@/platform/telemetry/types'
+import { resolveBillingFlagState } from '@/platform/telemetry/utils/billingFlagState'
 import { useToastStore } from '@/platform/updates/common/toastStore'
 import { workspaceApi } from '@/platform/workspace/api/workspaceApi'
 import type {
@@ -82,6 +84,14 @@ export interface StartOperationMetadata {
    * e.g. recovering a pending operation on page load.
    */
   attemptStartedAt?: number
+  /**
+   * The client-minted key for the checkout attempt that opened this operation,
+   * carried so the poller's terminal events join back to a `started` that could
+   * not yet know the billing op id.
+   */
+  checkoutAttemptId?: string
+  flagState?: BillingFlagState
+  quoteId?: string
 }
 
 interface BillingOperation {
@@ -109,6 +119,9 @@ interface BillingOperation {
   // over — only the server decides that — so it keeps polling and can still
   // resolve normally; this only hides it from the selectors a dialog reads.
   dismissed: boolean
+  checkoutAttemptId?: string
+  flagState: BillingFlagState
+  quoteId?: string
 }
 
 type TerminalResolver = (operation: BillingOperation) => void
@@ -123,6 +136,7 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
   const terminalResolvers = new Map<string, TerminalResolver>()
   const terminalPromises = new Map<string, Promise<BillingOperation>>()
   const autoHandledPaymentActions = new Set<string>()
+  const challengePresentedOps = new Set<string>()
   const paymentIntentClientSecrets = new Map<string, string>()
   const inFlightPolls = new Map<string, Promise<void>>()
 
@@ -218,6 +232,42 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
     toastStore.add(toastMessage)
   }
 
+  function operationTelemetryContext(operation: BillingOperation) {
+    return {
+      ...(operation.checkoutAttemptId && {
+        checkout_attempt_id: operation.checkoutAttemptId
+      }),
+      flag_state: operation.flagState,
+      ...(operation.workspaceId && { workspace_id: operation.workspaceId }),
+      ...(operation.quoteId && { quote_id: operation.quoteId })
+    }
+  }
+
+  /**
+   * `authenticationRequiredSeen` is a latch, so this is the denominator for
+   * "attempts that hit a challenge" — one per operation, however many times the
+   * customer retries. Pair it with `challenge_returned` per operation, not per
+   * event: a manual retry emits a second return against this one presentation.
+   */
+  function trackChallengePresented(opId: string) {
+    const operation = operations.value.get(opId)
+    if (!operation || operation.type !== 'subscription') return
+    if (challengePresentedOps.has(opId)) return
+    challengePresentedOps.add(opId)
+
+    useTelemetry()?.trackBillingEvent({
+      operation: 'subscription_checkout',
+      stage: 'challenge_presented',
+      outcome: 'pending',
+      billing_op_id: opId,
+      tier: operation.tier,
+      cycle: operation.cycle,
+      checkout_type: operation.checkoutType,
+      payment_intent_source: operation.paymentIntentSource,
+      ...operationTelemetryContext(operation)
+    })
+  }
+
   function startOperation(
     opId: string,
     type: OperationType,
@@ -252,7 +302,12 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
       paymentIntentSource: metadata?.paymentIntentSource,
       autoHandleRequiresAction: metadata?.autoHandleRequiresAction ?? false,
       downgradeToPersonal: metadata?.downgradeToPersonal,
-      dismissed: false
+      dismissed: false,
+      checkoutAttemptId: metadata?.checkoutAttemptId,
+      flagState:
+        metadata?.flagState ??
+        resolveBillingFlagState(flags.embeddedCheckoutEnabled),
+      quoteId: metadata?.quoteId
     }
 
     operations.value = new Map(operations.value).set(opId, operation)
@@ -263,9 +318,13 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
         operation: 'operation',
         stage: 'started',
         outcome: 'pending',
-        operation_type: type
+        operation_type: type,
+        billing_op_id: opId,
+        ...operationTelemetryContext(operation)
       })
     }
+
+    if (operation.authenticationRequiredSeen) trackChallengePresented(opId)
 
     if (type !== 'cancel' && !metadata?.suppressProcessingToast) {
       showProgressToast(opId, type, operation.actionUrl !== null)
@@ -473,6 +532,7 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
         operation.authenticationRequiredSeen || state === 'requires_action',
       ...(declineDetail && { errorMessage: declineDetail })
     })
+    if (state === 'requires_action') trackChallengePresented(opId)
 
     // Neither authentication state is terminal for a pending operation: the
     // customer may complete the challenge on a hosted page or another device,
@@ -524,6 +584,7 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
       const publishableKey = import.meta.env.VITE_STRIPE_PUBLISHABLE_KEY
       const stripe = publishableKey ? await loadStripe(publishableKey) : null
       if (!stripe) {
+        trackChallengeReturned(opId, 'failed', 'stripe_error')
         setAuthenticationFailed(
           opId,
           t('billingOperation.authenticationUnavailable')
@@ -534,6 +595,7 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
         clientSecret
       })
       if (error) {
+        trackChallengeReturned(opId, 'failed', 'stripe_error')
         setAuthenticationFailed(
           opId,
           error.message || t('billingOperation.authenticationFailedDetail')
@@ -543,12 +605,18 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
       // With no action left to resume the call succeeds and changes nothing, so
       // an intent still sitting on its pre-challenge status has not paid.
       if (paymentIntent && UNMOVED_INTENT_STATUSES.has(paymentIntent.status)) {
+        trackChallengeReturned(opId, 'failed', 'challenge_not_completed')
         setAuthenticationFailed(
           opId,
           t('billingOperation.authenticationFailedDetail')
         )
         return false
       }
+      trackChallengeReturned(
+        opId,
+        'succeeded',
+        paymentIntent ? 'intent_advanced' : 'intent_status_unavailable'
+      )
       updateOperation(opId, {
         authenticationState: 'processing',
         isAuthenticating: false,
@@ -560,6 +628,7 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
       intervals.set(opId, INITIAL_INTERVAL_MS)
       return true
     } catch (error) {
+      trackChallengeReturned(opId, 'failed', 'stripe_error')
       setAuthenticationFailed(
         opId,
         error instanceof Error
@@ -568,6 +637,32 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
       )
       return false
     }
+  }
+
+  function trackChallengeReturned(
+    opId: string,
+    outcome: 'succeeded' | 'failed',
+    reason:
+      | 'intent_advanced'
+      | 'challenge_not_completed'
+      | 'stripe_error'
+      | 'intent_status_unavailable'
+  ) {
+    const operation = operations.value.get(opId)
+    if (!operation || operation.type !== 'subscription') return
+
+    useTelemetry()?.trackBillingEvent({
+      operation: 'subscription_checkout',
+      stage: 'challenge_returned',
+      outcome,
+      reason,
+      billing_op_id: opId,
+      tier: operation.tier,
+      cycle: operation.cycle,
+      checkout_type: operation.checkoutType,
+      payment_intent_source: operation.paymentIntentSource,
+      ...operationTelemetryContext(operation)
+    })
   }
 
   function setAuthenticationFailed(opId: string, errorMessage: string) {
@@ -627,6 +722,7 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
       authenticationRequiredSeen:
         operation.authenticationRequiredSeen || actionUrl !== null
     })
+    if (actionUrl !== null) trackChallengePresented(opId)
     // Tracks the CURRENT action_url, which the contract defines as present
     // exactly while the operation cannot proceed without the customer — so the
     // toast never outlives the verification action it points at. Swapped only
@@ -658,7 +754,8 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
       cycle: operation.cycle,
       checkout_type: operation.checkoutType,
       payment_intent_source: operation.paymentIntentSource,
-      duration_ms: operationDurationMs
+      duration_ms: operationDurationMs,
+      ...operationTelemetryContext(operation)
     })
 
     if (
@@ -675,7 +772,8 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
         checkout_type: operation.checkoutType,
         payment_intent_source: operation.paymentIntentSource,
         billing_op_id: opId,
-        duration_ms: durationMs
+        duration_ms: durationMs,
+        ...operationTelemetryContext(operation)
       })
       // Also fires the legacy event for providers (Mixpanel, GTM) that don't
       // implement trackBillingEvent. Gated to actual new/upgraded
@@ -699,7 +797,8 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
         stage: 'succeeded',
         outcome: 'success',
         billing_op_id: opId,
-        duration_ms: now - operation.businessAttemptStartedAt
+        duration_ms: now - operation.businessAttemptStartedAt,
+        ...operationTelemetryContext(operation)
       })
     }
     // Mirrors handleFailure's structure: not gated on businessAttemptStartedAt,
@@ -713,7 +812,8 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
         member_removal_failures:
           operation.downgradeToPersonal.memberRemovalFailures,
         target_tier: operation.downgradeToPersonal.targetTier,
-        duration_ms: now - operation.downgradeToPersonal.startedAt
+        duration_ms: now - operation.downgradeToPersonal.startedAt,
+        ...operationTelemetryContext(operation)
       })
     }
 
@@ -791,7 +891,8 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
       checkout_type: operation.checkoutType,
       payment_intent_source: operation.paymentIntentSource,
       failure_category: failureCategory,
-      duration_ms: now - operation.operationStartedAt
+      duration_ms: now - operation.operationStartedAt,
+      ...operationTelemetryContext(operation)
     })
     if (
       operation.type === 'subscription' &&
@@ -807,7 +908,8 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
         payment_intent_source: operation.paymentIntentSource,
         billing_op_id: opId,
         failure_category: failureCategory,
-        duration_ms: now - operation.businessAttemptStartedAt
+        duration_ms: now - operation.businessAttemptStartedAt,
+        ...operationTelemetryContext(operation)
       })
     } else if (
       operation.type === 'topup' &&
@@ -819,7 +921,8 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
         outcome: 'failure',
         billing_op_id: opId,
         failure_category: failureCategory,
-        duration_ms: now - operation.businessAttemptStartedAt
+        duration_ms: now - operation.businessAttemptStartedAt,
+        ...operationTelemetryContext(operation)
       })
     }
     if (operation.downgradeToPersonal) {
@@ -832,7 +935,8 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
           operation.downgradeToPersonal.memberRemovalFailures,
         target_tier: operation.downgradeToPersonal.targetTier,
         failure_category: failureCategory,
-        duration_ms: now - operation.downgradeToPersonal.startedAt
+        duration_ms: now - operation.downgradeToPersonal.startedAt,
+        ...operationTelemetryContext(operation)
       })
     }
 
@@ -874,7 +978,8 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
       checkout_type: operation.checkoutType,
       payment_intent_source: operation.paymentIntentSource,
       failure_category: 'reconciliation_needed',
-      duration_ms: now - operation.operationStartedAt
+      duration_ms: now - operation.operationStartedAt,
+      ...operationTelemetryContext(operation)
     })
     if (
       operation.type === 'subscription' &&
@@ -890,7 +995,8 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
         payment_intent_source: operation.paymentIntentSource,
         billing_op_id: opId,
         failure_category: 'reconciliation_needed',
-        duration_ms: now - operation.businessAttemptStartedAt
+        duration_ms: now - operation.businessAttemptStartedAt,
+        ...operationTelemetryContext(operation)
       })
     } else if (
       operation.type === 'topup' &&
@@ -902,7 +1008,8 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
         outcome: 'failure',
         billing_op_id: opId,
         failure_category: 'reconciliation_needed',
-        duration_ms: now - operation.businessAttemptStartedAt
+        duration_ms: now - operation.businessAttemptStartedAt,
+        ...operationTelemetryContext(operation)
       })
     }
     resolveTerminal(opId)
@@ -930,7 +1037,8 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
       checkout_type: operation.checkoutType,
       payment_intent_source: operation.paymentIntentSource,
       failure_category: 'poll_timeout',
-      duration_ms: now - operation.operationStartedAt
+      duration_ms: now - operation.operationStartedAt,
+      ...operationTelemetryContext(operation)
     })
     if (
       operation.type === 'subscription' &&
@@ -946,7 +1054,8 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
         payment_intent_source: operation.paymentIntentSource,
         billing_op_id: opId,
         failure_category: 'poll_timeout',
-        duration_ms: now - operation.businessAttemptStartedAt
+        duration_ms: now - operation.businessAttemptStartedAt,
+        ...operationTelemetryContext(operation)
       })
     } else if (
       operation.type === 'topup' &&
@@ -958,7 +1067,8 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
         outcome: 'failure',
         billing_op_id: opId,
         failure_category: 'poll_timeout',
-        duration_ms: now - operation.businessAttemptStartedAt
+        duration_ms: now - operation.businessAttemptStartedAt,
+        ...operationTelemetryContext(operation)
       })
     }
     if (operation.downgradeToPersonal) {
@@ -971,7 +1081,8 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
           operation.downgradeToPersonal.memberRemovalFailures,
         target_tier: operation.downgradeToPersonal.targetTier,
         failure_category: 'poll_timeout',
-        duration_ms: now - operation.downgradeToPersonal.startedAt
+        duration_ms: now - operation.downgradeToPersonal.startedAt,
+        ...operationTelemetryContext(operation)
       })
     }
 
@@ -1107,6 +1218,7 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
     }
     intervals.delete(opId)
     autoHandledPaymentActions.delete(opId)
+    challengePresentedOps.delete(opId)
     paymentIntentClientSecrets.delete(opId)
 
     // Remove the "received" toast

--- a/src/platform/workspace/stores/billingOperationStore.ts
+++ b/src/platform/workspace/stores/billingOperationStore.ts
@@ -261,6 +261,10 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
    * `actionUrl`: a `needs_payment_method` response puts a payment-method
    * collection page in `actionUrl` too, and counting that as a challenge would
    * both inflate this denominator and latch out the real 3DS presentation.
+   *
+   * `authentication_state` is only read under the embedded-checkout flag, so
+   * the ungated arm reports no presentation rather than a looser one. An empty
+   * challenge funnel there is intended; a differently-defined one is not.
    */
   function trackChallengePresented(opId: string) {
     const operation = operations.value.get(opId)
@@ -651,6 +655,13 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
     }
   }
 
+  /**
+   * The numerator against `challenge_presented`. Gated on the same latch, so a
+   * return is only reported for a challenge this client actually presented:
+   * `retryPaymentAuthentication` also runs for a `failed_retryable` decline
+   * that was never `requires_action`, and counting that return would put an
+   * operation in the numerator that is absent from the denominator.
+   */
   function trackChallengeReturned(
     opId: string,
     outcome: 'succeeded' | 'failed',
@@ -662,6 +673,7 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
   ) {
     const operation = operations.value.get(opId)
     if (!operation || operation.type !== 'subscription') return
+    if (!challengePresentedOps.has(opId)) return
 
     useTelemetry()?.trackBillingEvent({
       operation: 'subscription_checkout',
@@ -734,7 +746,6 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
       authenticationRequiredSeen:
         operation.authenticationRequiredSeen || actionUrl !== null
     })
-    if (actionUrl !== null) trackChallengePresented(opId)
     // Tracks the CURRENT action_url, which the contract defines as present
     // exactly while the operation cannot proceed without the customer — so the
     // toast never outlives the verification action it points at. Swapped only

--- a/src/scripts/api.featureFlags.test.ts
+++ b/src/scripts/api.featureFlags.test.ts
@@ -420,6 +420,39 @@ describe('API Feature Flags', () => {
     expect(autoQueueGraphChanged).toHaveBeenCalledTimes(2)
   })
 
+  // A server is free to advertise no flags, so an empty map is a real answer.
+  // Callers that must not read a defaulted flag as a deliberate `off` — the
+  // billing rollout arms — need that apart from an unanswered handshake.
+  it('distinguishes an empty server flag map from an unanswered handshake', async () => {
+    const readyStatus = JSON.stringify({
+      type: 'status',
+      data: {
+        status: { exec_info: { queue_remaining: 0 } },
+        sid: 'test-sid'
+      }
+    })
+
+    const answeredApi = new ComfyApi()
+    const answeredInit = answeredApi.init()
+    wsEventHandlers['open'](new Event('open'))
+    wsEventHandlers['message']({ data: readyStatus })
+    wsEventHandlers['message']({
+      data: JSON.stringify({ type: 'feature_flags', data: {} })
+    })
+    await answeredInit
+
+    expect(answeredApi.getServerFeatures()).toEqual({})
+    expect(answeredApi.hasReceivedServerFeatureFlags()).toBe(true)
+
+    const unansweredApi = new ComfyApi()
+    const unansweredInit = unansweredApi.init()
+    wsEventHandlers['open'](new Event('open'))
+    wsEventHandlers['message']({ data: readyStatus })
+    await unansweredInit
+
+    expect(unansweredApi.hasReceivedServerFeatureFlags()).toBe(false)
+  })
+
   /**
    * Pins the resolution behaviour `getServerFeature` had before any override
    * layer was placed in front of it, so a future layer cannot quietly change

--- a/src/scripts/api.ts
+++ b/src/scripts/api.ts
@@ -410,6 +410,14 @@ export class ComfyApi extends EventTarget {
   serverFeatureFlags = ref<Record<string, unknown>>({})
 
   /**
+   * Whether the server has answered the `feature_flags` handshake this session.
+   * Distinct from an empty {@link serverFeatureFlags}: a server is free to
+   * advertise no flags, and callers that must not read a defaulted flag as a
+   * deliberate `off` need to tell those two states apart.
+   */
+  #receivedServerFeatureFlags = false
+
+  /**
    * The auth token for the comfy org account if the user is logged in.
    * This is only used for {@link queuePrompt} now. It is not directly
    * passed as parameter to the function because some custom nodes are hijacking
@@ -916,6 +924,7 @@ export class ComfyApi extends EventTarget {
               break
             case 'feature_flags':
               this.serverFeatureFlags.value = msg.data
+              this.#receivedServerFeatureFlags = true
               this.dispatchCustomEvent('feature_flags', msg.data)
               break
             default:
@@ -1658,6 +1667,14 @@ export class ComfyApi extends EventTarget {
    */
   getServerFeatures(): Record<string, unknown> {
     return { ...this.serverFeatureFlags.value }
+  }
+
+  /**
+   * Whether the `feature_flags` handshake has been answered this session.
+   * @returns true once a server flag map has arrived, empty or not
+   */
+  hasReceivedServerFeatureFlags(): boolean {
+    return this.#receivedServerFeatureFlags
   }
 }
 


### PR DESCRIPTION
## Summary

Makes the subscription-checkout funnel joinable end to end and puts the third-party-hosted 3DS step on the map, so the embedded-checkout rollout dashboard can split gated from ungated traffic and measure challenge success. Implements gaps 1, 2, 4 and 6 (frontend halves) of the billing-telemetry schema; the backend half and the dashboard are landing in parallel against the same field names.

## Changes

- **What**:
  - Mint a `checkout_attempt_id` (UUID) when the customer picks a plan — before the preview call — and carry it on every event of that attempt. `billing.*.started` fires before subscribe returns and so can never carry a `billing_op_id` (live: 0 of 618 `started` events had one, against 294/294 `succeeded`), which left abandoned attempts unjoinable in both directions.
  - Send `checkout_attempt_id` to the backend on `preview-subscribe` and `subscribe` so it can be stamped on the op row.
  - `billing.operation.started` now emits the `opId` it already had in scope and dropped (`billingOperationStore.ts:239`).
  - New properties on every billing event: `flag_state`, `workspace_id`, `quote_id`.
  - New stages: `billing.subscription_checkout.quote_minted`, `.challenge_presented`, `.challenge_returned`.
- **Breaking**: none. No behaviour change — the operation state machine is untouched.

## Schema

New properties, on every billing event unless noted:

| Field | Values | Notes |
|---|---|---|
| `checkout_attempt_id` | UUID | Client-minted at attempt start. Also sent on the wire as `checkout_attempt_id`. |
| `billing_op_id` | opaque id | Already on terminal events; now also on `operation.started` and both challenge events. |
| `flag_state` | `embedded_checkout_on` / `embedded_checkout_off` / `embedded_checkout_unknown` | Snapshotted at attempt start. |
| `workspace_id` | workspace id | Snapshotted at attempt start, never read live (ADR 0014). |
| `quote_id` | quote id | Present once a preview has resolved. |

New stages on `billing.subscription_checkout.*`:

| Stage | `outcome` | `reason` |
|---|---|---|
| `quote_minted` | `pending` | — |
| `challenge_presented` | `pending` | — |
| `challenge_returned` | `succeeded` / `failed` / `abandoned` | `intent_advanced` / `challenge_not_completed` / `stripe_error` / `intent_status_unavailable` |

### Three deliberate deviations from the shared schema

1. **`embedded_checkout_unknown` is a third `flag_state` value.** The schema names only `on`/`off`. But the flag is delivered *only* on the WebSocket handshake and its resolver reads `false` until that lands, so a pre-handshake attempt reported as `off` would bank gated traffic in the ungated arm. **Dashboard: exclude `unknown` from both arms rather than folding it into `off`.**
2. **Existing `stage` values are unchanged.** The schema's tag vocabulary lists `attempt_started` / `terminal`; renaming would break `billing_frontend_rum_dashboard.tf:126`, which filters `@context.stage:started`. The schema's own rule 4 says to keep the existing scheme and *add* stages, so that is what this does. `attempt_started`/`terminal` should stay the backend StatsD vocabulary.
3. **`reason` on `challenge_returned` is new.** Needed to keep the ambiguous case (below) out of a clean success rate.

## Which panels this unblocks

- **Attempt volume and outcome mix by flag state** — `flag_state` on every event; the first split of gated vs ungated that exists on either side.
- **Funnel and abandonment** — `checkout_attempt_id` joins `quote_minted` → `started` → terminal. An attempt that emits `started` and nothing else is now countable as abandoned instead of unjoinable.
- **Preview → subscribe conversion** — `quote_minted` with `quote_id`.
- **Challenge success rate** — `challenge_presented` is the denominator that did not exist.
- **Cross-layer joins** — `workspace_id` closes the creator-vs-actor key mismatch ADR 0014 describes; `billing_op_id` on `started` closes the other direction.

**Compute challenge success rate per operation, not per event.** `challenge_presented` latches once per operation (it tracks `authenticationRequiredSeen`, per the schema), but a manual retry emits a second `challenge_returned`. A raw event ratio can exceed 100%.

## What stays dark

- **`outcome: abandoned` is never emitted here.** A closed tab is not observable client-side. The value exists so this and the backend share one vocabulary; only the backend can populate it.
- **Upgrade-path 3DS outcomes** stay invisible until Track A1 — `reason:upgrade_not_authenticated` still does not exist, so any panel splitting challenge failure by flow will show initial-subscription and top-up only.
- **User cancellation** stays invisible until Track A2 — the cancel endpoint does not exist.
- **Top-up 3DS challenges** are not instrumented: the schema scopes the challenge stages to `billing.subscription_checkout.*` and this PR follows it. Worth a follow-up if the top-up rail needs the same denominator.
- **The team-to-personal downgrade rail carries no `checkout_attempt_id`.** `showTeamToPersonalDowngrade()` delegates preview, subscribe and telemetry to `useDowngradeToPersonal`, which owns its own `startOperation()` calls and never receives the attempt context. Its events are internally consistent but unjoinable to the attempt that opened them. Recorded in ADR 0014.
- **`quote_minted` counts quotes *shown*, not quotes minted.** It fires from `installPreview()`, so the internal re-quote in `assertReactivationAmountUnchanged()` produces a backend quote row carrying the attempt id with no matching client event. Deliberate — the stage is the preview-to-subscribe denominator, and a quote the customer never saw would inflate it. **Backend reconciliation should expect strictly more quote rows than `quote_minted` events.**

## Review Focus

**The failed-challenge case is the point of the 3DS work.** After a failed challenge `stripe.handleNextAction` resolves with **no error and no effect**, and the store moves the operation to `processing` — indistinguishable from success. That is the bug that shipped. `challenge_returned` now separates them by inspecting `paymentIntent.status`:

- advanced (`succeeded`/`processing`/`requires_capture`) → `succeeded` / `intent_advanced`
- present but not advanced → `failed` / `challenge_not_completed`
- an error → `failed` / `stripe_error`
- **no intent reported at all** → `succeeded` / `intent_status_unavailable`

That last case is honest rather than convenient: Stripe returned neither an error nor an intent, so the client genuinely cannot tell. It is reported the way the app behaves (it proceeds) with a `reason` that lets a dashboard exclude it from a clean numerator. **This PR does not change the state machine** — it still reads `processing`. Fixing that is Track A1/B7; this makes the difference observable first.

Also worth a look:
- `types.ts` `getBillingTelemetryEventPayload()` is the frontend's property allow-list — anything not spread there is silently dropped, so new fields must be registered in two places (the payload builder and the `TelemetryEvents` name map). Both updated.
- `workspaceApi.ts` carries a local `WithCheckoutAttemptId<T>` wrapper because `checkout_attempt_id` is not yet in `@comfyorg/ingest-types`. **Delete it once the regenerated package ships the field.** The field is sent now and harmlessly ignored — the subscribe route has no strict request validator (only provider-policy routes do), so it lands ahead of the backend without risk.
- ADR 0014 called this field `billing_attempt_id`. It ships as `checkout_attempt_id`: that name already exists in this codebase for the same concept on the legacy GA4 path, and it is the name the backend and dashboard are being built against. Recorded in the ADR's Notes rather than left as a silent divergence.

## Test evidence

New tests cover every new emission, including the regression guard for the failed challenge (`billingOperationStore.test.ts` → `challenge telemetry`).

```
$ pnpm vitest run src/platform/telemetry src/platform/workspace src/platform/cloud/subscription
 Test Files  117 passed (117)
      Tests  2079 passed (2079)
```

```
$ pnpm typecheck
$ vue-tsc --noEmit
(clean)
```

```
$ pnpm lint
✖ 79 problems (0 errors, 79 warnings)
```
All 79 are the pre-existing `apiSchema is deprecated` notice in files this PR does not touch; none are in the changed files. `origin/main` reports the same 79, so this branch adds none.

```
$ pnpm knip
$ knip --cache
(clean)
```



## Review round 2 (`a82031a`)

Three defects the adversarial review surfaced in the commit above, all in the new telemetry rather than in behaviour:

1. **`challenge_presented` fired for payment-method collection.** It was driven by `authenticationRequiredSeen`, which `startOperation()` latches from any initial action url — and a `needs_payment_method` response passes its Stripe *collection* page there. That counted card collection as a bank challenge and, because the event latches to one per operation, **suppressed the real `requires_action` presentation that followed** — so the challenge denominator was both inflated and, on exactly the operations that hit 3DS after collecting a card, missing. Now driven only by the authentication state. Regression test asserts the collection page emits nothing and does not latch out the later 3DS event.
2. **`workspace_id` on the poller's events was read live.** The operation opens only after `subscribe()` returns, so a mid-attempt workspace switch labelled `quote_minted`/`started` with one workspace and the challenge/terminal events with another — the exact split ADR 0014 says not to have. The attempt snapshot now rides through as `attemptWorkspaceId` and wins for telemetry. `workspaceId` stays live-read deliberately: nine call sites gate UI on it against the workspace the customer is looking at *now*, and `pollOnce()` defers on it, so repointing it would have been a behaviour change.
3. **Reactivation reused a stale attempt id.** `handleResubscribe()` never called `beginCheckoutAttempt()` and `attemptTelemetryContext()` only mints lazily, so a reactivation inherited whatever id an earlier checkout in the same dialog left behind, and a retry after a failed reactivation emitted a second started/terminal pair under it.

Two further review points are **deliberate, now documented in ADR 0014 and under "What stays dark"** rather than changed: the downgrade rail's missing attempt id, and `quote_minted` tracking shown-quotes. A third — that a manual retry yields two `challenge_returned` against one `challenge_presented` — was already called out above; compute that rate per operation.
