### PR TITLE
fix: keep non-widget input sockets out of custom widgets

### DIFF
--- a/src/renderer/extensions/vueNodes/composables/processedWidgetRenderModel.ts
+++ b/src/renderer/extensions/vueNodes/composables/processedWidgetRenderModel.ts
@@ -141,8 +141,11 @@ function buildSlotMetadata(
       promoted: input.widgetId !== undefined,
       type: String(input.type)
     }
-    if (input.name) metadata.set(input.name, slotInfo)
-    if (input.widget?.name) metadata.set(input.widget.name, slotInfo)
+    const widgetName = input.widget?.name
+    if (widgetName) metadata.set(widgetName, slotInfo)
+    else if ((input.widgetId !== undefined || linked) && input.name) {
+      metadata.set(input.name, slotInfo)
+    }
   })
   return metadata
 }

--- a/src/renderer/extensions/vueNodes/composables/useProcessedWidgets.test.ts
+++ b/src/renderer/extensions/vueNodes/composables/useProcessedWidgets.test.ts
@@ -145,6 +145,30 @@ function processWidgets({
   })
 }
 
+describe('widget slot ownership', () => {
+  beforeEach(() => {
+    setActivePinia(createTestingPinia({ stubActions: false }))
+  })
+
+  it('does not assign a non-widget input socket to a same-named custom widget', () => {
+    const { graph, node } = createGraphWithNode([])
+    node.addInput('model', 'MODEL')
+    node.addWidget('custom', 'model', null, () => {})
+
+    const [processedWidget] = computeProcessedWidgets({
+      nodeData: node._state,
+      widgetIds: undefined,
+      graphId: GRAPH_ID,
+      showAdvanced: false,
+      isGraphReady: true,
+      rootGraph: graph,
+      ui: noopUi
+    })
+
+    expect(processedWidget.slotMetadata).toBeUndefined()
+  })
+})
+
 describe('widget visibility', () => {
   beforeEach(() => {
     setActivePinia(createTestingPinia({ stubActions: false }))


### PR DESCRIPTION
## Summary

Prevent a custom widget from claiming a same-named non-widget input socket in Nodes 2.0. This fixes the duplicate slot detected by custom-node S2 in #15590.

## Red-green verification

- Test-only `a0a1b3fbf8`: [unit CI failed only on the new assertion](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/33100566398) on all three attempts; current main was green.
- Source-only `5eb7c2abba`: preserves explicit/promoted/linked widget slots while excluding an unlinked ordinary input from a same-named custom widget.

## Test plan

- 91 focused widget, slot, and subgraph tests pass.
- Typecheck, lint, Knip, and format pass.
- Full PR CI must pass on the source-fix commit.