### PR TITLE
fix(billing): retry transient context initialization failures

### DIFF
--- a/src/composables/billing/useBillingContext.test.ts
+++ b/src/composables/billing/useBillingContext.test.ts
@@ -26,6 +26,7 @@ const DEFAULT_BILLING_STATUS: BillingStatusResponse = {
 
 const {
   mockIsPersonal,
+  mockHasActiveWorkspace,
   mockBillingRail,
   mockPlans,
   mockFetchPlans,
@@ -36,9 +37,11 @@ const {
   mockUpdateActiveWorkspace,
   mockSetWorkspaceBillingRail,
   mockLegacyStatus,
-  mockBillingStatus
+  mockBillingStatus,
+  mockReportError
 } = vi.hoisted(() => ({
   mockIsPersonal: { value: true },
+  mockHasActiveWorkspace: { value: true },
   mockBillingRail: { value: undefined as BillingRail | undefined },
   mockPlans: { value: [] as Plan[] },
   mockFetchPlans: vi.fn(async () => undefined),
@@ -62,7 +65,8 @@ const {
       subscription_tier: 'PRO',
       subscription_duration: 'MONTHLY'
     } as Partial<BillingStatusResponse>
-  }
+  },
+  mockReportError: vi.fn()
 }))
 
 vi.mock('@vueuse/core', async (importOriginal) => {
@@ -74,6 +78,10 @@ vi.mock('@vueuse/core', async (importOriginal) => {
 })
 
 vi.mock('@/platform/distribution/types', () => ({ isCloud: true }))
+
+vi.mock('@/platform/telemetry/reportError', () => ({
+  reportError: mockReportError
+}))
 
 vi.mock('@/platform/workspace/stores/teamWorkspaceStore', async () => {
   const { ref } = await import('vue')
@@ -90,6 +98,7 @@ vi.mock('@/platform/workspace/stores/teamWorkspaceStore', async () => {
         return mockIsPersonal.value
       },
       get activeWorkspace() {
+        if (!mockHasActiveWorkspace.value) return undefined
         return mockIsPersonal.value
           ? { id: 'personal-123', type: 'personal' }
           : { id: 'team-456', type: 'team' }
@@ -142,6 +151,7 @@ vi.mock('@/composables/auth/useAuthActions', () => ({
 }))
 
 vi.mock('@/stores/authStore', () => ({
+  AuthStoreError: class extends Error {},
   useAuthStore: () => ({
     balance: { amount_micros: 5000000 },
     fetchBalance: mockLegacyFetchBalance
@@ -162,6 +172,7 @@ vi.mock('@/platform/cloud/subscription/composables/useBillingPlans', () => ({
 }))
 
 vi.mock('@/platform/workspace/api/workspaceApi', () => ({
+  WorkspaceApiError: class extends Error {},
   workspaceApi: {
     getBillingStatus: vi.fn(() =>
       Promise.resolve({ ...DEFAULT_BILLING_STATUS, ...mockBillingStatus.value })
@@ -181,6 +192,7 @@ describe('useBillingContext', () => {
     remoteConfig.value = {}
     remoteConfigState.value = 'unloaded'
     mockIsPersonal.value = true
+    mockHasActiveWorkspace.value = true
     mockBillingRail.value = undefined
     mockSetWorkspaceBillingRail.mockImplementation(
       (_workspaceId: string, billingRail: BillingRail) => {
@@ -270,6 +282,59 @@ describe('useBillingContext', () => {
   it('exposes initialize action', async () => {
     const { initialize } = useBillingContext()
     await expect(initialize()).resolves.toBeUndefined()
+  })
+
+  it('recovers from a transient network failure during initialization', async () => {
+    vi.useFakeTimers()
+    mockHasActiveWorkspace.value = false
+    mockBillingRail.value = 'legacy_stripe'
+    mockLegacyFetchStatus
+      .mockRejectedValueOnce(new TypeError('Failed to fetch'))
+      .mockResolvedValue(undefined)
+
+    const { initialize, isInitialized } = useBillingContext()
+    const initialization = initialize()
+    await vi.advanceTimersByTimeAsync(0)
+    await vi.advanceTimersByTimeAsync(500)
+    await initialization
+
+    expect(mockLegacyFetchStatus).toHaveBeenCalledTimes(2)
+    expect(isInitialized.value).toBe(true)
+    expect(mockReportError).not.toHaveBeenCalled()
+  })
+
+  it('reports a network failure after bounded initialization retries', async () => {
+    vi.useFakeTimers()
+    mockHasActiveWorkspace.value = false
+    mockBillingRail.value = 'legacy_stripe'
+    mockLegacyFetchStatus.mockRejectedValue(new TypeError('Failed to fetch'))
+
+    const { initialize, isInitialized } = useBillingContext()
+    const initialization = initialize()
+    const result = initialization.catch((error: unknown) => error)
+    await vi.advanceTimersByTimeAsync(0)
+    await vi.advanceTimersByTimeAsync(2_500)
+
+    expect(await result).toEqual(expect.any(TypeError))
+    expect(mockLegacyFetchStatus).toHaveBeenCalledTimes(3)
+    expect(isInitialized.value).toBe(false)
+    expect(mockReportError).toHaveBeenCalledOnce()
+    expect(mockReportError).toHaveBeenCalledWith(expect.any(TypeError), {
+      errorType: 'billing_context_initialization_failure',
+      tags: { billing_backend: 'legacy' }
+    })
+  })
+
+  it('does not retry a non-network initialization failure', async () => {
+    mockHasActiveWorkspace.value = false
+    mockBillingRail.value = 'legacy_stripe'
+    mockLegacyFetchStatus.mockRejectedValue(new Error('Forbidden'))
+
+    const { initialize } = useBillingContext()
+
+    await expect(initialize()).rejects.toThrow('Forbidden')
+    expect(mockLegacyFetchStatus).toHaveBeenCalledOnce()
+    expect(mockReportError).toHaveBeenCalledOnce()
   })
 
   it('exposes fetchStatus action', async () => {

--- a/src/composables/billing/useBillingContext.test.ts
+++ b/src/composables/billing/useBillingContext.test.ts
@@ -11,6 +11,7 @@ import {
   remoteConfig,
   remoteConfigState
 } from '@/platform/remoteConfig/remoteConfig'
+import { AuthStoreError } from '@/stores/authStore'
 
 import { useBillingContext } from './useBillingContext'
 
@@ -151,7 +152,15 @@ vi.mock('@/composables/auth/useAuthActions', () => ({
 }))
 
 vi.mock('@/stores/authStore', () => ({
-  AuthStoreError: class extends Error {},
+  AuthStoreError: class extends Error {
+    constructor(
+      message: string,
+      readonly status?: number
+    ) {
+      super(message)
+      this.name = 'AuthStoreError'
+    }
+  },
   useAuthStore: () => ({
     balance: { amount_micros: 5000000 },
     fetchBalance: mockLegacyFetchBalance
@@ -285,7 +294,6 @@ describe('useBillingContext', () => {
   })
 
   it('recovers from a transient network failure during initialization', async () => {
-    vi.useFakeTimers()
     mockHasActiveWorkspace.value = false
     mockBillingRail.value = 'legacy_stripe'
     mockLegacyFetchStatus
@@ -304,7 +312,6 @@ describe('useBillingContext', () => {
   })
 
   it('reports a network failure after bounded initialization retries', async () => {
-    vi.useFakeTimers()
     mockHasActiveWorkspace.value = false
     mockBillingRail.value = 'legacy_stripe'
     mockLegacyFetchStatus.mockRejectedValue(new TypeError('Failed to fetch'))
@@ -331,7 +338,6 @@ describe('useBillingContext', () => {
   })
 
   it('stops retrying when the billing adapter changes during backoff', async () => {
-    vi.useFakeTimers()
     mockBillingRail.value = 'legacy_stripe'
     mockLegacyFetchStatus
       .mockRejectedValueOnce(new TypeError('Failed to fetch'))
@@ -348,10 +354,12 @@ describe('useBillingContext', () => {
     expect(mockReportError).not.toHaveBeenCalled()
   })
 
-  it('does not retry a non-network initialization failure', async () => {
+  it('does not retry a legacy HTTP initialization failure', async () => {
     mockHasActiveWorkspace.value = false
     mockBillingRail.value = 'legacy_stripe'
-    mockLegacyFetchStatus.mockRejectedValue(new Error('Forbidden'))
+    mockLegacyFetchStatus.mockRejectedValue(
+      new AuthStoreError('Forbidden', 403)
+    )
 
     const { initialize } = useBillingContext()
 

--- a/src/composables/billing/useBillingContext.test.ts
+++ b/src/composables/billing/useBillingContext.test.ts
@@ -323,6 +323,29 @@ describe('useBillingContext', () => {
       errorType: 'billing_context_initialization_failure',
       tags: { billing_backend: 'legacy' }
     })
+
+    mockLegacyFetchStatus.mockResolvedValue(undefined)
+    await expect(initialize()).resolves.toBeUndefined()
+    expect(mockLegacyFetchStatus).toHaveBeenCalledTimes(4)
+    expect(isInitialized.value).toBe(true)
+  })
+
+  it('stops retrying when the billing adapter changes during backoff', async () => {
+    vi.useFakeTimers()
+    mockBillingRail.value = 'legacy_stripe'
+    mockLegacyFetchStatus
+      .mockRejectedValueOnce(new TypeError('Failed to fetch'))
+      .mockResolvedValue(undefined)
+
+    useBillingContext()
+    await vi.advanceTimersByTimeAsync(0)
+
+    mockBillingRail.value = undefined
+    await nextTick()
+    await vi.advanceTimersByTimeAsync(500)
+
+    expect(mockLegacyFetchStatus).toHaveBeenCalledOnce()
+    expect(mockReportError).not.toHaveBeenCalled()
   })
 
   it('does not retry a non-network initialization failure', async () => {

--- a/src/composables/billing/useBillingContext.ts
+++ b/src/composables/billing/useBillingContext.ts
@@ -12,6 +12,8 @@ import type {
   PreviewSubscribeOptions,
   SubscribeOptions
 } from '@/platform/workspace/api/workspaceApi'
+import { reportError } from '@/platform/telemetry/reportError'
+import { categorizeBillingApiError } from '@/platform/telemetry/utils/billingFailureCategory'
 import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
 
 import type {
@@ -31,6 +33,7 @@ import { useWorkspaceBilling } from '@/platform/workspace/composables/useWorkspa
 // new sub is never misrouted even before its credit stop is populated.
 const LEGACY_TEAM_PLAN_SLUG_PREFIX = 'team-'
 const PER_CREDIT_TEAM_PLAN_SLUG_PREFIX = 'team_per_credit_'
+const INITIALIZATION_RETRY_DELAYS_MS = [500, 2_000]
 
 function isTeamPlanSlug(planSlug: string | null | undefined): boolean {
   const normalizedSlug = planSlug?.toLowerCase()
@@ -243,15 +246,10 @@ function useBillingContextInternal(): BillingContext {
   // Reset and reinitialize when the active workspace or billing backend changes.
   watch(
     [() => store.activeWorkspace?.id, () => type.value],
-    async ([newWorkspaceId]) => {
+    ([newWorkspaceId]) => {
       resetBillingState()
       if (!newWorkspaceId) return
-
-      try {
-        await initialize()
-      } catch (err) {
-        console.error('Failed to initialize billing context:', err)
-      }
+      void initialize().catch(() => {})
     },
     { immediate: true }
   )
@@ -263,13 +261,32 @@ function useBillingContextInternal(): BillingContext {
     isLoading.value = true
     error.value = null
     try {
-      await adapter.initialize()
+      for (let attempt = 0; ; attempt++) {
+        try {
+          await adapter.initialize()
+          break
+        } catch (err) {
+          if (activeContext.value !== adapter) return
+          const retryDelay = INITIALIZATION_RETRY_DELAYS_MS[attempt]
+          if (
+            retryDelay === undefined ||
+            categorizeBillingApiError(err) !== 'network'
+          ) {
+            throw err
+          }
+          await new Promise((resolve) => setTimeout(resolve, retryDelay))
+        }
+      }
       if (activeContext.value !== adapter) return
       isInitialized.value = true
     } catch (err) {
       if (activeContext.value !== adapter) return
       error.value =
         err instanceof Error ? err.message : 'Failed to initialize billing'
+      reportError(err, {
+        errorType: 'billing_context_initialization_failure',
+        tags: { billing_backend: type.value }
+      })
       throw err
     } finally {
       if (activeContext.value === adapter) isLoading.value = false

--- a/src/composables/billing/useBillingContext.ts
+++ b/src/composables/billing/useBillingContext.ts
@@ -275,6 +275,7 @@ function useBillingContextInternal(): BillingContext {
             throw err
           }
           await new Promise((resolve) => setTimeout(resolve, retryDelay))
+          if (activeContext.value !== adapter) return
         }
       }
       if (activeContext.value !== adapter) return

--- a/src/platform/cloud/subscription/composables/useSubscription.test.ts
+++ b/src/platform/cloud/subscription/composables/useSubscription.test.ts
@@ -3,6 +3,7 @@ import { effectScope } from 'vue'
 
 import { useSubscription } from '@/platform/cloud/subscription/composables/useSubscription'
 import { PENDING_SUBSCRIPTION_CHECKOUT_STORAGE_KEY } from '@/platform/cloud/subscription/utils/subscriptionCheckoutTracker'
+import { WorkspaceApiError } from '@/platform/workspace/api/workspaceApi'
 
 const {
   mockIsLoggedIn,
@@ -142,6 +143,15 @@ vi.mock('@/platform/telemetry/utils/checkoutAttribution', () => ({
 }))
 
 vi.mock('@/platform/workspace/api/workspaceApi', () => ({
+  WorkspaceApiError: class extends Error {
+    constructor(
+      message: string,
+      readonly status?: number
+    ) {
+      super(message)
+      this.name = 'WorkspaceApiError'
+    }
+  },
   workspaceApi: {
     getBillingStatus: mockGetBillingStatus
   }
@@ -174,7 +184,15 @@ vi.mock('@/stores/authStore', () => ({
       return mockUserId.value
     }
   })),
-  AuthStoreError: class extends Error {}
+  AuthStoreError: class extends Error {
+    constructor(
+      message: string,
+      readonly status?: number
+    ) {
+      super(message)
+      this.name = 'AuthStoreError'
+    }
+  }
 }))
 
 // Mock fetch
@@ -342,6 +360,19 @@ describe('useSubscription', () => {
       await expect(fetchStatus()).rejects.toThrow(
         'Failed to fetch subscription status: Subscription not found'
       )
+    })
+
+    it('preserves the HTTP status of a rejected billing status request', async () => {
+      mockGetBillingStatus.mockRejectedValue(
+        new WorkspaceApiError('Forbidden', 403)
+      )
+
+      const { fetchStatus } = useSubscriptionWithScope()
+
+      await expect(fetchStatus()).rejects.toMatchObject({
+        name: 'AuthStoreError',
+        status: 403
+      })
     })
 
     it('updates the active workspace billing rail from status', async () => {

--- a/src/platform/cloud/subscription/composables/useSubscription.ts
+++ b/src/platform/cloud/subscription/composables/useSubscription.ts
@@ -19,7 +19,10 @@ import type {
   ResubscribeClickMetadata
 } from '@/platform/telemetry/types'
 import type { BillingStatusResponse } from '@/platform/workspace/api/workspaceApi'
-import { workspaceApi } from '@/platform/workspace/api/workspaceApi'
+import {
+  WorkspaceApiError,
+  workspaceApi
+} from '@/platform/workspace/api/workspaceApi'
 import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
 import { AuthStoreError, useAuthStore } from '@/stores/authStore'
 import { useDialogService } from '@/services/dialogService'
@@ -394,7 +397,8 @@ function useSubscriptionInternal() {
       throw new AuthStoreError(
         t('toastMessages.failedToFetchSubscription', {
           error: error instanceof Error ? error.message : String(error)
-        })
+        }),
+        error instanceof WorkspaceApiError ? error.status : undefined
       )
     }
     if (

--- a/src/stores/authStore.test.ts
+++ b/src/stores/authStore.test.ts
@@ -372,6 +372,25 @@ describe('useAuthStore', () => {
       expect(await pending).toBeNull()
       expect(store.balance).toBeNull()
     })
+
+    it('preserves the HTTP status when a non-404 balance response fails', async () => {
+      mockFetch.mockImplementation((url: string) => {
+        if (url.endsWith('/customers/balance')) {
+          return Promise.resolve({
+            ok: false,
+            status: 403,
+            statusText: 'Forbidden',
+            text: () => Promise.resolve('')
+          })
+        }
+        return Promise.reject(new Error('Unexpected API call'))
+      })
+
+      await expect(store.fetchBalance()).rejects.toMatchObject({
+        name: 'AuthStoreError',
+        status: 403
+      })
+    })
   })
 
   describe('user-scoped billing endpoints with API-key sessions', () => {

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -453,7 +453,8 @@ export const useAuthStore = defineStore('auth', () => {
         throw new AuthStoreError(
           t('toastMessages.failedToFetchBalance', {
             error: message
-          })
+          }),
+          response.status
         )
       }
 


### PR DESCRIPTION
## Summary

Recover billing context initialization from transient browser transport failures instead of leaving billing unresolved for the remainder of the session.

The production error predates the recent billing telemetry work: the bare `fetch()` and terminal `console.error` path existed before Cloud RUM initialization made it visible. It is a low, steady handled-error baseline rather than a Canary regression or API outage, but the user impact is real because one status-0 request leaves `isInitialized` false with no automatic recovery.

## Changes

- **Retry**: Retry only errors categorized as network failures after 500 ms and 2 seconds; HTTP and other application failures still fail immediately.
- **Classification**: Carry the server-provided HTTP status through the two legacy wrappers that previously dropped it (`authStore.fetchBalance()` and `performFetchSubscriptionStatus()`). Without it, `categorizeBillingApiError()` read a status-less `AuthStoreError` as a transport failure, so legacy 403/500 responses were retried three times instead of failing immediately.
- **Recovery**: Mark the context initialized when a later attempt succeeds, preserving the existing manual retry affordance after all attempts fail.
- **Telemetry**: Replace the raw `console.error` path with `reportError()` using `billing_context_initialization_failure` and the selected billing backend.
- **Breaking**: None.
- **Dependencies**: None.

## Review Focus

- Retry remains at the billing-context boundary so both legacy and workspace adapters benefit without changing global fetch behavior.
- Adapter identity is checked after every failure, preventing retries from completing against a workspace or billing backend that is no longer active.
- Only transport-class failures retry; non-network failures are reported after one attempt.

## Verification

- `pnpm test:unit src/stores/authStore.test.ts src/composables/billing src/platform/cloud/subscription src/platform/workspace src/platform/telemetry` — 122 files, 2245 passed
- The two new status-preservation tests fail on the parent commit with `status: undefined`, confirming they are genuine regression tests
- `pnpm typecheck`
- Type-aware oxlint, ESLint, oxfmt, and knip through repository hooks

## Screenshots

N/A — no UI changes.
