### PR TITLE
ci: protect release branches from merge skew

### DIFF
--- a/.github/actions/lint-format-verify/action.yml
+++ b/.github/actions/lint-format-verify/action.yml
@@ -9,6 +9,10 @@ description: >
 runs:
   using: composite
   steps:
+    - name: Typecheck application
+      shell: bash
+      run: pnpm typecheck
+
     - name: Verify lint and format
       shell: bash
       run: |

--- a/.github/workflows/release-branch-ci-alert.yaml
+++ b/.github/workflows/release-branch-ci-alert.yaml
@@ -1,0 +1,48 @@
+# Alerts the release owners when a post-merge release branch no longer
+# typechecks or passes the shared lint/format invariants.
+name: 'Release branch CI alert'
+
+on:
+  workflow_run:
+    workflows: ['CI: Lint Format']
+    types: [completed]
+    branches:
+      - 'cloud/**'
+      - 'core/**'
+
+permissions:
+  contents: read
+
+jobs:
+  notify:
+    if: >-
+      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.conclusion == 'failure'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post failure to frontend releases
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          SLACK_CHANNEL_ID: ${{ vars.SLACK_FRONTEND_RELEASES_CHANNEL_ID }}
+          BRANCH: ${{ github.event.workflow_run.head_branch }}
+          RUN_URL: ${{ github.event.workflow_run.html_url }}
+          SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          if [ -z "$SLACK_CHANNEL_ID" ]; then
+            echo "::warning::SLACK_FRONTEND_RELEASES_CHANNEL_ID is unset — skipping Slack notification."
+            exit 0
+          fi
+
+          TEXT="Post-merge CI failed on ${BRANCH} at ${SHA:0:7}. ${RUN_URL}"
+          BODY=$(jq -n --arg ch "$SLACK_CHANNEL_ID" --arg text "$TEXT" \
+            '{channel: $ch, text: $text}')
+          RESPONSE=$(curl -sS -X POST \
+            --connect-timeout 10 --max-time 30 \
+            -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
+            -H 'Content-Type: application/json' \
+            -d "$BODY" \
+            https://slack.com/api/chat.postMessage)
+          if ! jq -e '.ok == true' <<<"$RESPONSE" >/dev/null; then
+            echo "Slack rejected the notification: $(jq -r '.error // "unparseable response"' <<<"$RESPONSE")"
+            exit 1
+          fi

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -11,6 +11,19 @@ All releases use `release-version-bump.yaml`. Effects differ by bump type:
 | Patch      | `core/X.Y` | No                                    | **Draft** (uncheck "latest") |
 | Prerelease | any        | No                                    | Draft + prerelease           |
 
+## Generated API types on release branches
+
+Never hand-edit files under `packages/ingest-types/src`, including in a
+backport. The Cloud repository owns the source OpenAPI contract and generates
+the frontend package for `main` and every active `cloud/x.y` line named in its
+`frontend-version.json`. A release branch must accept that generated contract
+or a newer one; unrelated generated changes are expected when a release line
+has fallen behind.
+
+If a backport needs a generated type, update the Cloud OpenAPI source and use
+the typegen automation. Do not copy or recreate one declaration in a generated
+file.
+
 **Minor bump** (e.g. 1.41→1.42): freezes the previous minor into `core/1.41`
 and `cloud/1.41`, branched from the commit _before_ the bump. Nightly patch
 bumps on `main` are convenience snapshots — no branches created.


### PR DESCRIPTION
## Summary

Prevent release branches from accepting merge-skew type failures without ownership.

## Changes

- run the application typecheck in the shared PR, merge-queue, and post-merge verification path
- alert `#frontend-releases` when that check fails after a release-branch push
- document that ingest types must be generated from the Cloud contract, never hand-written during backports

## Review Focus

The alert is limited to failed push runs on `cloud/**` and `core/**`; PR and merge-queue failures do not notify Slack.

## Verification

- `pnpm typecheck`
- oxfmt check on changed files
- actionlint on the new workflow

Related: #16085
