### PR TITLE
feat(website): add the Gemini Omni 1.1 Flash launch page

### DIFF
--- a/apps/website/e2e/gemini-omni.spec.ts
+++ b/apps/website/e2e/gemini-omni.spec.ts
@@ -1,0 +1,312 @@
+import { expect } from '@playwright/test'
+import type { Page } from '@playwright/test'
+
+import { getRoutes } from '../src/config/routes'
+import { creatorReviews } from '../src/data/creatorReviews'
+import { geminiOmniPage } from '../src/data/geminiOmni'
+import { t } from '../src/i18n/translations'
+import type { ModelLaunchCta } from '../src/templates/model-launch/types'
+import { test } from './fixtures/blockExternalMedia'
+
+const PATH = '/gemini-omni'
+const ZH_PATH = '/zh-CN/gemini-omni'
+const HERO_TITLE = `${t('geminiOmni.hero.titleModel', 'en')}${t('geminiOmni.hero.titleRest', 'en')}`
+const MODELS_HEADING = t('geminiOmni.models.heading', 'en')
+const STEPS_HEADING = t('geminiOmni.steps.heading', 'en')
+const STEPS_CTA = t('geminiOmni.steps.secondaryCta', 'en')
+const REVIEWS_HEADING = t('geminiOmni.reviews.heading', 'en')
+const HIGHLIGHT_CTA = t('geminiOmni.reviews.highlightCta', 'en')
+const COPY_PROMPT = t('modelLaunch.copyPrompt', 'en')
+const MODELS_ROUTE = getRoutes('en').models
+const MCP_ROUTE = getRoutes('en').mcp
+const FIRST_REVIEW = creatorReviews[0]
+
+// The Figma's launch requirement, not a snapshot of the config: deriving these
+// would let a dropped badge, card or step pass silently.
+const REQUIRED_BADGES = 4
+const REQUIRED_CARDS = 6
+const REQUIRED_STEPS = 3
+
+const RUN_TEMPLATE =
+  'https://cloud.comfy.org/?template=api_google_gemini_omni_flash_1_1_t2v'
+// Not /workflows/model/gemini-omni: the hub API returns `models: null` for
+// every Gemini Omni entry, so that family page is never generated.
+const HUB_OVERVIEW = 'https://comfy.org/workflows/a0e9a3b16f63-a0e9a3b16f63/'
+
+const BADGE_KEYS = geminiOmniPage.hero.badgeKeys ?? []
+
+const GALLERY = geminiOmniPage.gallery
+if (!GALLERY) throw new Error('geminiOmniPage must configure a gallery')
+
+const STEPS = geminiOmniPage.steps
+if (!STEPS) throw new Error('geminiOmniPage must configure a steps section')
+
+const HERO_PRIMARY_CTA: ModelLaunchCta | undefined =
+  geminiOmniPage.hero.primaryCta
+if (!HERO_PRIMARY_CTA)
+  throw new Error('geminiOmniPage must configure a hero primary CTA')
+
+const gallerySection = (page: Page) =>
+  page.locator('section').filter({
+    has: page.getByRole('heading', { level: 2, name: MODELS_HEADING })
+  })
+
+const heroSection = (page: Page) =>
+  page.locator('section').filter({
+    has: page.getByRole('heading', { level: 1, name: HERO_TITLE })
+  })
+
+test.describe('Gemini Omni page — desktop @smoke', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(PATH)
+  })
+
+  test('renders the hero heading and is indexable', async ({ page }) => {
+    await expect(
+      page.getByRole('heading', { level: 1, name: HERO_TITLE })
+    ).toBeVisible()
+
+    await expect(page.locator('meta[name="robots"]')).toHaveCount(0)
+  })
+
+  test('renders all four hero badges', async ({ page }) => {
+    expect(BADGE_KEYS).toHaveLength(REQUIRED_BADGES)
+
+    for (const key of BADGE_KEYS) {
+      await expect(
+        heroSection(page).getByText(t(key, 'en'), { exact: true })
+      ).toBeVisible()
+    }
+  })
+
+  test('renders the reviews section heading and first quote', async ({
+    page
+  }) => {
+    const heading = page.getByRole('heading', {
+      level: 2,
+      name: REVIEWS_HEADING
+    })
+    await heading.scrollIntoViewIfNeeded()
+    await expect(heading).toBeVisible()
+    await expect(page.getByText(FIRST_REVIEW.name)).toBeVisible()
+  })
+})
+
+test.describe('Gemini Omni page — link targets', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(PATH)
+  })
+
+  test('breadcrumb trail links to the models catalog', async ({ page }) => {
+    const modelsCrumb = page
+      .getByRole('navigation', { name: t('ui.breadcrumb', 'en') })
+      .getByRole('link', { name: t('models.breadcrumb.models', 'en') })
+    await expect(modelsCrumb).toHaveAttribute('href', MODELS_ROUTE)
+  })
+
+  test('hero CTAs open the run template and the hub workflow', async ({
+    page
+  }) => {
+    const hero = heroSection(page)
+
+    const runCta = hero.getByRole('link', {
+      name: t('geminiOmni.hero.primaryCta', 'en')
+    })
+    await expect(runCta).toHaveAttribute('href', HERO_PRIMARY_CTA.href)
+    await expect(runCta).toHaveAttribute('href', RUN_TEMPLATE)
+    await expect(runCta).toHaveAttribute('target', '_blank')
+
+    const secondary = hero.getByRole('link', {
+      name: t('geminiOmni.hero.secondaryCta', 'en')
+    })
+    await expect(secondary).toHaveAttribute(
+      'href',
+      geminiOmniPage.hero.secondaryCta?.href ?? ''
+    )
+    await expect(secondary).toHaveAttribute('href', HUB_OVERVIEW)
+  })
+
+  test('MCP highlight card CTA links to the MCP page', async ({ page }) => {
+    const reviewsSection = page.locator('section').filter({
+      has: page.getByRole('heading', { level: 2, name: REVIEWS_HEADING })
+    })
+    const cta = reviewsSection.getByRole('link', { name: HIGHLIGHT_CTA })
+    await cta.scrollIntoViewIfNeeded()
+    await expect(cta).toHaveAttribute('href', MCP_ROUTE)
+  })
+})
+
+test.describe('Gemini Omni gallery', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(PATH)
+    await page
+      .getByRole('heading', { level: 2, name: MODELS_HEADING })
+      .scrollIntoViewIfNeeded()
+  })
+
+  test('ships all six cards, described as the Figma describes them', async ({
+    page
+  }) => {
+    // Scoped to the gallery: the testimonial carousel below also uses <article>.
+    const gallery = gallerySection(page)
+    await expect(gallery.locator('article')).toHaveCount(REQUIRED_CARDS)
+
+    for (const card of GALLERY.cards) {
+      await expect(
+        gallery.getByText(card.description.en, { exact: true })
+      ).toBeVisible()
+    }
+  })
+
+  test('every gallery clip carries a poster', async ({ page }) => {
+    const gallery = gallerySection(page)
+    await expect(gallery.locator('video')).toHaveCount(REQUIRED_CARDS)
+
+    for (const card of GALLERY.cards) {
+      if (card.media.kind !== 'video') continue
+      expect(card.media.posterSrc, `${card.id} needs a poster`).toBeTruthy()
+      await expect(
+        gallery.locator(`video[poster="${card.media.posterSrc}"]`)
+      ).toHaveCount(1)
+    }
+  })
+
+  // The Figma puts a prompt box under every card, which is what makes this page
+  // useful: a reader copies the prompt and runs it. A card that loses its prompt
+  // still renders, so nothing else would catch it.
+  test('every card offers its prompt with a copy button', async ({ page }) => {
+    const gallery = gallerySection(page)
+    const prompts = gallery.getByTestId('gallery-card-prompt')
+    await expect(prompts).toHaveCount(REQUIRED_CARDS)
+    await expect(
+      gallery.getByRole('button', { name: COPY_PROMPT })
+    ).toHaveCount(REQUIRED_CARDS)
+
+    for (const card of GALLERY.cards) {
+      expect(card.prompt, `${card.id} needs a prompt`).toBeDefined()
+    }
+  })
+})
+
+test.describe('Gemini Omni — how to direct your shot', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(PATH)
+    await page
+      .getByRole('heading', { level: 2, name: STEPS_HEADING })
+      .scrollIntoViewIfNeeded()
+  })
+
+  test('renders three numbered steps', async ({ page }) => {
+    const steps = page
+      .locator('section')
+      .filter({
+        has: page.getByRole('heading', { level: 2, name: STEPS_HEADING })
+      })
+      .locator('ol > li')
+
+    await expect(steps).toHaveCount(REQUIRED_STEPS)
+
+    for (const step of STEPS.items) {
+      await expect(page.getByText(step.title.en, { exact: true })).toBeVisible()
+    }
+  })
+
+  test('the single steps CTA opens the run template', async ({ page }) => {
+    const cta = page
+      .locator('section')
+      .filter({
+        has: page.getByRole('heading', { level: 2, name: STEPS_HEADING })
+      })
+      .getByRole('link', { name: STEPS_CTA })
+
+    await expect(cta).toHaveAttribute('href', RUN_TEMPLATE)
+    await expect(cta).toHaveAttribute('target', '_blank')
+  })
+})
+
+test.describe('Gemini Omni — Q&A', () => {
+  // Asserts the render agrees with the config rather than pinning either state,
+  // so this keeps working when Rob's Q&A copy lands and `faq` is filled in.
+  // Until then the page deliberately ships no Q&A: the Figma's block is still
+  // Seedance 2.0 placeholder text, and rendering it would publish those answers
+  // to search engines as FAQPage structured data.
+  test('FAQ structured data matches the page config', async ({ page }) => {
+    await page.goto(PATH)
+
+    const faqJsonLd = await page.evaluate(() => {
+      const scripts = Array.from(
+        document.querySelectorAll<HTMLScriptElement>(
+          'script[type="application/ld+json"]'
+        )
+      )
+      return (
+        scripts.find((s) => (s.textContent ?? '').includes('FAQPage'))
+          ?.textContent ?? null
+      )
+    })
+
+    const faq = geminiOmniPage.faq
+    if (!faq) {
+      expect(faqJsonLd, 'no Q&A configured, so no FAQPage node').toBeNull()
+      return
+    }
+
+    expect(faqJsonLd, 'FAQ JSON-LD script').not.toBeNull()
+    const graph = JSON.parse(faqJsonLd!)['@graph'] as {
+      '@type': string
+      mainEntity?: unknown[]
+    }[]
+    const faqPage = graph.find((node) => node['@type'] === 'FAQPage')
+    expect(faqPage, 'FAQPage node in @graph').toBeDefined()
+    expect(faqPage!.mainEntity!.length).toBe(faq.items.length)
+  })
+})
+
+test.describe('Gemini Omni page — zh-CN', () => {
+  test('renders the localized hero and reviews', async ({ page }) => {
+    await page.goto(ZH_PATH)
+
+    const heading = page.getByRole('heading', { level: 1 })
+    await expect(heading).toBeVisible()
+    // Chinese present and the English title absent, so serving the en copy under
+    // the zh route fails here rather than passing on a key lookup.
+    await expect(heading).toContainText(/[一-鿿]/)
+    await expect(heading).not.toHaveText(HERO_TITLE)
+
+    const reviews = page.getByRole('heading', {
+      level: 2,
+      name: t('geminiOmni.reviews.heading', 'zh-CN')
+    })
+    await reviews.scrollIntoViewIfNeeded()
+    await expect(reviews).toBeVisible()
+  })
+})
+
+test.describe('Gemini Omni page — mobile @mobile', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(PATH)
+  })
+
+  test('renders the hero heading at narrow viewports', async ({ page }) => {
+    await expect(
+      page.getByRole('heading', { level: 1, name: HERO_TITLE })
+    ).toBeVisible()
+  })
+
+  test('hero CTA stays within the viewport width', async ({ page }) => {
+    const cta = heroSection(page).getByRole('link', {
+      name: t('geminiOmni.hero.primaryCta', 'en')
+    })
+
+    await expect(cta).toBeVisible()
+
+    const box = await cta.boundingBox()
+    const viewport = page.viewportSize()
+    if (!box || !viewport) throw new Error('hero CTA has no layout box')
+
+    // Both edges, so a CTA overflowing left cannot pass. One pixel of tolerance
+    // for subpixel rounding.
+    expect(box.x).toBeGreaterThanOrEqual(-1)
+    expect(box.x + box.width).toBeLessThanOrEqual(viewport.width + 1)
+  })
+})

--- a/apps/website/e2e/gemini-omni.spec.ts
+++ b/apps/website/e2e/gemini-omni.spec.ts
@@ -211,6 +211,56 @@ test.describe('Gemini Omni — how to direct your shot', () => {
     }
   })
 
+  // `description` is optional on a step and this page is the first to omit one.
+  // The step-count and title assertions above pass whether the paragraph is
+  // absent or rendered empty, so target the step itself: each step renders a
+  // "Step 0N" label and a title, and a third paragraph only when it configures
+  // a description.
+  test('a step configuring no description renders no paragraph', async ({
+    page
+  }) => {
+    const without = STEPS.items.filter((step) => !step.description)
+    const withDescription = STEPS.items.filter((step) => step.description)
+    expect(
+      without.length,
+      'vacuous unless at least one step omits its description'
+    ).toBeGreaterThan(0)
+
+    const stepsList = page
+      .locator('section')
+      .filter({
+        has: page.getByRole('heading', { level: 2, name: STEPS_HEADING })
+      })
+      .locator('ol > li')
+
+    for (const step of without) {
+      await expect(
+        stepsList.filter({ hasText: step.title.en }).locator('p')
+      ).toHaveCount(2)
+    }
+    for (const step of withDescription) {
+      await expect(
+        stepsList.filter({ hasText: step.title.en }).locator('p')
+      ).toHaveCount(3)
+    }
+  })
+
+  test('footer links back to this page in both locales', async ({ page }) => {
+    const footerLink = page
+      .locator('footer')
+      .getByRole('link', { name: t('footer.geminiOmni', 'en') })
+    await expect(footerLink).toHaveAttribute('href', getRoutes('en').geminiOmni)
+
+    await page.goto(ZH_PATH)
+    const zhFooterLink = page
+      .locator('footer')
+      .getByRole('link', { name: t('footer.geminiOmni', 'zh-CN') })
+    await expect(zhFooterLink).toHaveAttribute(
+      'href',
+      getRoutes('zh-CN').geminiOmni
+    )
+  })
+
   test('the single steps CTA opens the run template', async ({ page }) => {
     const cta = page
       .locator('section')

--- a/apps/website/src/components/common/SiteFooter.vue
+++ b/apps/website/src/components/common/SiteFooter.vue
@@ -53,6 +53,7 @@ const topColumns: { title: string; links: FooterLink[] }[] = [
       { label: t('footer.seedance', locale), href: routes.seedance },
       { label: t('footer.wanAnimate2', locale), href: routes.wanAnimate2 },
       { label: t('footer.ltx', locale), href: routes.ltx },
+      { label: t('footer.geminiOmni', locale), href: routes.geminiOmni },
       { label: t('footer.wan3', locale), href: routes.wan3 },
       { label: t('footer.flux3', locale), href: routes.flux3 }
     ]

--- a/apps/website/src/config/routes.test.ts
+++ b/apps/website/src/config/routes.test.ts
@@ -58,6 +58,16 @@ describe('getRoutes ltx', () => {
   })
 })
 
+describe('getRoutes geminiOmni', () => {
+  it('serves the gemini omni page at its canonical path for en', () => {
+    expect(getRoutes('en').geminiOmni).toBe('/gemini-omni')
+  })
+
+  it('serves a localized gemini omni path for zh-CN', () => {
+    expect(getRoutes('zh-CN').geminiOmni).toBe('/zh-CN/gemini-omni')
+  })
+})
+
 describe('getRoutes minimaxMusic3', () => {
   it('serves the minimax music 3 page at its canonical path for en', () => {
     expect(getRoutes('en').minimaxMusic3).toBe('/minimax-music-3')

--- a/apps/website/src/config/routes.ts
+++ b/apps/website/src/config/routes.ts
@@ -30,6 +30,7 @@ const baseRoutes = {
   seedance: '/seedance-2.5',
   fdct: '/forward-deployed-creatives',
   ltx: '/ltx-2.5',
+  geminiOmni: '/gemini-omni',
   wanAnimate2: '/wan-animate-2',
   wan3: '/wan-3.0',
   brand: '/brand'

--- a/apps/website/src/data/geminiOmni.ts
+++ b/apps/website/src/data/geminiOmni.ts
@@ -13,15 +13,15 @@ import { externalLinks } from '../config/routes'
 // poster is the branded title-card frame rather than frame 0, which is mid-wipe
 // and reads as an empty box.
 //
-// `-v2` is not decoration. hero-poster.webp was first uploaded as a different
-// image, and these objects ship `cache-control: public,max-age=3600`, so the
-// edge keeps serving the old bytes for up to an hour no matter how many times
-// the same key is re-uploaded. A new key is the only same-hour bust. Version
-// the filename again on the next poster swap.
+// The `v2` suffixes are not decoration. Both the hero video and its poster were
+// first uploaded under un-versioned keys, and these objects ship
+// `cache-control: public,max-age=3600`, so the edge keeps serving the old bytes
+// for up to an hour no matter how many times the same key is re-uploaded. A new
+// key is the only same-hour bust. Version the filename again on the next swap.
 const media = {
   hero: {
     kind: 'video',
-    src: 'https://media.comfy.org/website/gemini-omni/hero.mp4',
+    src: 'https://media.comfy.org/website/gemini-omni/hero_v2.mp4',
     posterSrc: 'https://media.comfy.org/website/gemini-omni/hero-poster-v2.webp'
   },
   seasons: {

--- a/apps/website/src/data/geminiOmni.ts
+++ b/apps/website/src/data/geminiOmni.ts
@@ -1,0 +1,372 @@
+import type {
+  ModelLaunchMedia,
+  ModelLaunchPage
+} from '../templates/model-launch/types'
+
+import { externalLinks } from '../config/routes'
+
+// Gemini Omni 1.1 Flash renders, encoded to the site's web video profile and
+// served from media.comfy.org. Each poster is cut from its clip's own opening
+// frame, so it registers exactly with the video that replaces it.
+//
+// `hero` is the launch sizzle (OMNI_FLASH_11_16x9), 1280x720 with audio kept. Its
+// poster is the branded title-card frame rather than frame 0, which is mid-wipe
+// and reads as an empty box.
+//
+// `-v2` is not decoration. hero-poster.webp was first uploaded as a different
+// image, and these objects ship `cache-control: public,max-age=3600`, so the
+// edge keeps serving the old bytes for up to an hour no matter how many times
+// the same key is re-uploaded. A new key is the only same-hour bust. Version
+// the filename again on the next poster swap.
+const media = {
+  hero: {
+    kind: 'video',
+    src: 'https://media.comfy.org/website/gemini-omni/hero.mp4',
+    posterSrc: 'https://media.comfy.org/website/gemini-omni/hero-poster-v2.webp'
+  },
+  seasons: {
+    kind: 'video',
+    src: 'https://media.comfy.org/website/gemini-omni/card-1.webm',
+    posterSrc: 'https://media.comfy.org/website/gemini-omni/card-1.webp'
+  },
+  saxophone: {
+    kind: 'video',
+    src: 'https://media.comfy.org/website/gemini-omni/card-2.webm',
+    posterSrc: 'https://media.comfy.org/website/gemini-omni/card-2.webp'
+  },
+  vacuum: {
+    kind: 'video',
+    src: 'https://media.comfy.org/website/gemini-omni/card-3.webm',
+    posterSrc: 'https://media.comfy.org/website/gemini-omni/card-3.webp'
+  },
+  stoneHead: {
+    kind: 'video',
+    src: 'https://media.comfy.org/website/gemini-omni/card-4.webm',
+    posterSrc: 'https://media.comfy.org/website/gemini-omni/card-4.webp'
+  },
+  cavemen: {
+    kind: 'video',
+    src: 'https://media.comfy.org/website/gemini-omni/card-5.webm',
+    posterSrc: 'https://media.comfy.org/website/gemini-omni/card-5.webp'
+  },
+  hotDogDog: {
+    kind: 'video',
+    src: 'https://media.comfy.org/website/gemini-omni/card-6.webm',
+    posterSrc: 'https://media.comfy.org/website/gemini-omni/card-6.webp'
+  }
+} as const satisfies Record<string, ModelLaunchMedia>
+
+const geminiOmniLinks = {
+  cloudRun:
+    'https://cloud.comfy.org/?template=api_google_gemini_omni_flash_1_1_t2v',
+  cloudRunVideoEdit:
+    'https://cloud.comfy.org/?template=api_google_gemini_omni_flash_1_1_edit',
+  // Deliberately not `${externalLinks.workflows}/model/gemini-omni`, the way
+  // /ltx-2.5 links its hub model page: every Gemini Omni entry comes back from
+  // the live hub API with `models: null`, so no model family page is generated
+  // and that URL 404s. This is the same hub data gap that keeps Wan 3.0 out of
+  // the Models filter, and it is fixed upstream by setting the model field.
+  // Point at the overview workflow, which resolves today.
+  hubOverview: 'https://comfy.org/workflows/a0e9a3b16f63-a0e9a3b16f63/'
+} as const
+
+// Every card is the same model on pay-as-you-go, which is what the Figma shows:
+// the note reads "pay-as-you-go" on all four rather than naming a capability.
+const premiumNote = { en: 'Pay-as-you-go', 'zh-CN': '按量付费' }
+
+// Prompts are literal text a reader pastes into the model, so they are not
+// translated. Same rule as /seedance-2.5.
+const SEASONS_PROMPT =
+  'One continuous shot, an extremely sped up seasonal timelapse of the character sitting in that exact position against the cliff rocks. The background composition remains. Only the climate changes from Snowy Winter to Flowers blooming in Spring to Sunshine in Summer to Leaves in Fall. No shot cuts or transitions. Use image 1 as the exact start frame and use image 1 as the exact end frame for a perfect loop'
+const SAXOPHONE_PROMPT =
+  'Mixed media surreal scene of the man playing the saxophone passionately as he strolls to his right, the camera tracks him. The red graphic elements pulse with each note. He is playing a melody and on the final note his hat flies off his head. 10-second generation.'
+const VACUUM_PROMPT = 'Product advertisement for the robot vacuum'
+const CAVEMEN_PROMPT =
+  'POV: you are a caveman and you and the homies discover fire for the first time. The cavemen speak in Gen Z slang. One continuous shot'
+const HOT_DOG_PROMPT =
+  'a dog with a hot dog costume eating a huge hot dog at the park, documentary style, natgeo'
+const STONE_HEAD_PROMPT =
+  'The floating statue says "Blazing fast speed", the elements orbit slowly as they float. 5 second generation\n\nTranslate this into French'
+
+// Annotated rather than `satisfies`, matching /ltx-2.5: `satisfies` keeps the
+// literal type, so the absent `faq` is not merely undefined but missing, and
+// reading `geminiOmniPage.faq` stops compiling. The e2e spec needs to read it
+// to assert the FAQPage structured data agrees with this config.
+export const geminiOmniPage: ModelLaunchPage = {
+  metaTitleKey: 'geminiOmni.meta.title',
+  metaDescriptionKey: 'geminiOmni.meta.description',
+  breadcrumbLabelKey: 'geminiOmni.breadcrumb.model',
+  breadcrumbUpdatedKey: 'geminiOmni.breadcrumb.updated',
+  hero: {
+    // No `layout`, which is the media-first default the Figma draws: video,
+    // then heading, description, CTAs and badges underneath.
+    videoSrc: media.hero.src,
+    posterSrc: media.hero.posterSrc,
+    logoSrc: '/icons/ai-models/gemini.svg',
+    titleKey: 'geminiOmni.hero.titleModel',
+    titleRestKey: 'geminiOmni.hero.titleRest',
+    descriptionKey: 'geminiOmni.hero.description',
+    primaryCta: {
+      labelKey: 'geminiOmni.hero.primaryCta',
+      href: geminiOmniLinks.cloudRun,
+      target: '_blank'
+    },
+    secondaryCta: {
+      labelKey: 'geminiOmni.hero.secondaryCta',
+      href: geminiOmniLinks.hubOverview,
+      target: '_blank'
+    },
+    badgeKeys: [
+      'geminiOmni.hero.tagPartnerNode',
+      'geminiOmni.hero.tagImageToVideo',
+      'geminiOmni.hero.tagTextToVideo',
+      'geminiOmni.hero.tagReferenceToVideo'
+    ]
+  },
+  gallery: {
+    headingKey: 'geminiOmni.models.heading',
+    // The Figma paints the per-card chevron solid yellow, not the muted
+    // treatment /minimax ships.
+    ctaVariant: 'accent',
+    cards: [
+      {
+        id: 'seasonal-timelapse',
+        name: { en: 'Seasonal timelapse', 'zh-CN': '四季延时' },
+        tier: 'premium',
+        note: premiumNote,
+        description: {
+          en: 'Winter to spring and back again',
+          'zh-CN': '冬去春来，四季轮回'
+        },
+        prompt: { en: SEASONS_PROMPT, 'zh-CN': SEASONS_PROMPT },
+        media: media.seasons,
+        href: geminiOmniLinks.cloudRun
+      },
+      {
+        id: 'saxophone-halftone',
+        name: { en: 'Saxophone solo', 'zh-CN': '萨克斯独奏' },
+        tier: 'premium',
+        note: premiumNote,
+        description: {
+          en: 'Saxophone solo in halftone',
+          'zh-CN': '半调风格的萨克斯独奏'
+        },
+        prompt: { en: SAXOPHONE_PROMPT, 'zh-CN': SAXOPHONE_PROMPT },
+        media: media.saxophone,
+        href: geminiOmniLinks.cloudRun
+      },
+      {
+        id: 'floor-robot',
+        name: { en: 'Floor robot advert', 'zh-CN': '扫地机器人广告' },
+        tier: 'premium',
+        note: premiumNote,
+        description: {
+          en: 'Slow push on a floor robot',
+          'zh-CN': '缓缓推近的扫地机器人'
+        },
+        prompt: { en: VACUUM_PROMPT, 'zh-CN': VACUUM_PROMPT },
+        media: media.vacuum,
+        href: geminiOmniLinks.cloudRun
+      },
+      {
+        id: 'stone-head-speaks',
+        name: { en: 'Stone head speaks', 'zh-CN': '石像开口' },
+        tier: 'premium',
+        note: premiumNote,
+        description: {
+          en: 'Stone head speaks',
+          'zh-CN': '石像开口说话'
+        },
+        prompt: { en: STONE_HEAD_PROMPT, 'zh-CN': STONE_HEAD_PROMPT },
+        media: media.stoneHead,
+        // The only card whose prompt names the workflow that made it: it asks
+        // for a re-voice in French, which is the video edit template.
+        href: geminiOmniLinks.cloudRunVideoEdit
+      },
+      {
+        id: 'cavemen-discover-fire',
+        name: { en: 'Cavemen discover fire', 'zh-CN': '穴居人发现火' },
+        tier: 'premium',
+        note: premiumNote,
+        description: {
+          en: 'Cavemen meet the future',
+          'zh-CN': '穴居人遇见未来'
+        },
+        prompt: { en: CAVEMEN_PROMPT, 'zh-CN': CAVEMEN_PROMPT },
+        media: media.cavemen,
+        href: geminiOmniLinks.cloudRun
+      },
+      {
+        id: 'dog-with-hot-dog',
+        name: { en: 'Dog in a hot dog costume', 'zh-CN': '穿热狗装的狗' },
+        tier: 'premium',
+        note: premiumNote,
+        description: {
+          en: 'A dog with hot dog',
+          'zh-CN': '狗与热狗'
+        },
+        prompt: { en: HOT_DOG_PROMPT, 'zh-CN': HOT_DOG_PROMPT },
+        media: media.hotDogDog,
+        href: geminiOmniLinks.cloudRun
+      }
+    ]
+  },
+  steps: {
+    headingKey: 'geminiOmni.steps.heading',
+    stepLabelKey: 'geminiOmni.steps.step',
+    items: [
+      {
+        id: 'upload-references',
+        title: {
+          en: 'Upload your reference assets',
+          'zh-CN': '上传你的参考素材'
+        }
+      },
+      {
+        id: 'prompt-the-scene',
+        title: { en: 'Prompt the scene', 'zh-CN': '描述你的场景' },
+        description: {
+          en: 'Camera, action, timing, dialogue',
+          'zh-CN': '运镜、动作、节奏、对白'
+        }
+      },
+      {
+        id: 'generate-your-shot',
+        title: { en: 'Generate your shot', 'zh-CN': '生成你的镜头' },
+        description: {
+          en: 'Up to 10 seconds at 4k.',
+          'zh-CN': '最长 10 秒，最高 4K。'
+        }
+      }
+    ],
+    // One button, and the Figma draws it as the outline treatment, which on
+    // this template is the secondary slot. No primary CTA by design.
+    secondaryCta: {
+      labelKey: 'geminiOmni.steps.secondaryCta',
+      href: geminiOmniLinks.cloudRun,
+      target: '_blank'
+    }
+  },
+  pricing: {
+    // The Figma opens this page on monthly, unlike the /pricing page.
+    defaultBillingCycle: 'monthly',
+    banner: {
+      titleKey: 'geminiOmni.pricing.banner.title',
+      subtitleKey: 'geminiOmni.pricing.banner.subtitle',
+      cta: {
+        labelKey: 'geminiOmni.pricing.banner.cta',
+        href: externalLinks.cloud,
+        target: '_blank'
+      }
+    }
+  },
+  // Rob's Q&A copy. The Figma's block was still Seedance 2.0 placeholder text.
+  // The source doc repeats "Can Gemini Omni 1.1 Flash extend a video?" twice with
+  // an identical answer; it appears once here, because this feeds the FAQPage
+  // JSON-LD and a repeated question would be published to search engines twice.
+  faq: {
+    headingKey: 'geminiOmni.faq.heading',
+    items: [
+      {
+        id: 'what-is-omni-flash',
+        question: {
+          en: 'What is Gemini Omni 1.1 Flash?',
+          'zh-CN': '什么是 Gemini Omni 1.1 Flash？'
+        },
+        answer: {
+          en: "Gemini Omni 1.1 Flash is Google's multimodal video model, built for fast video generation, editing, and cinematic control. It processes text, image, audio, and video together, generates clips with an audio track, and edits existing video from plain-language instructions. It replaces earlier versions of Gemini Omni Flash.",
+          'zh-CN':
+            'Gemini Omni 1.1 Flash 是 Google 的多模态视频模型，为快速视频生成、编辑与运镜控制而打造。它同时处理文本、图像、音频与视频，生成自带音轨的片段，并可依据自然语言指令编辑已有视频。它取代了此前各版本的 Gemini Omni Flash。'
+        }
+      },
+      {
+        id: 'extend-a-video',
+        question: {
+          en: 'Can Gemini Omni 1.1 Flash extend a video?',
+          'zh-CN': 'Gemini Omni 1.1 Flash 可以延长视频吗？'
+        },
+        answer: {
+          en: 'Yes. With task type set to extend, Gemini Omni 1.1 Flash reads the prior motion and composition of a clip and continues the shot, holding character identity and lighting steady. A prompt like "continue the shot: the woman finishes the violin solo and takes a bow" picks up where the clip ends.',
+          'zh-CN':
+            '可以。将任务类型设为 extend 后，Gemini Omni 1.1 Flash 会读取片段此前的运动与构图并延续该镜头，同时保持人物特征与光照一致。诸如「continue the shot: the woman finishes the violin solo and takes a bow」这样的提示词，会从片段结束处接续下去。'
+        }
+      },
+      {
+        id: 'commercial-use',
+        question: {
+          en: 'Can I use Gemini Omni 1.1 Flash commercially?',
+          'zh-CN': '我可以将 Gemini Omni 1.1 Flash 用于商业用途吗？'
+        },
+        answer: {
+          en: "Yes. Output generated through ComfyUI partner nodes can be used in commercial work, subject to ComfyUI's terms and Google's usage policies. All videos carry a SynthID watermark, which is invisible to viewers but programmatically detectable for provenance.",
+          'zh-CN':
+            '可以。通过 ComfyUI 合作伙伴节点生成的内容可用于商业作品，但须遵守 ComfyUI 的条款与 Google 的使用政策。所有视频都带有 SynthID 水印，观众无法察觉，但可通过程序检测以追溯来源。'
+        }
+      },
+      {
+        id: 'resolutions-and-aspect-ratios',
+        question: {
+          en: 'What resolutions and aspect ratios does Gemini Omni 1.1 Flash support in ComfyUI?',
+          'zh-CN':
+            '在 ComfyUI 中，Gemini Omni 1.1 Flash 支持哪些分辨率和宽高比？'
+        },
+        answer: {
+          en: 'The Gemini Video Omni node outputs Gemini Omni 1.1 Flash video at 360p, 720p, 1080p, or 4K, in 16:9 or 9:16. Landscape is the default; set 9:16 for vertical clips. Higher resolutions take longer to generate.',
+          'zh-CN':
+            'Gemini Video Omni 节点可输出 360p、720p、1080p 或 4K 的 Gemini Omni 1.1 Flash 视频，宽高比为 16:9 或 9:16。默认是横屏；竖屏片段请设为 9:16。分辨率越高，生成耗时越长。'
+        }
+      },
+      {
+        id: 'edit-an-existing-video',
+        question: {
+          en: 'Can Gemini Omni 1.1 Flash edit an existing video?',
+          'zh-CN': 'Gemini Omni 1.1 Flash 可以编辑已有视频吗？'
+        },
+        answer: {
+          en: 'Yes. Connect a clip to the node\'s video input and describe the change, and Gemini Omni 1.1 Flash applies it while preserving everything else. Short prompts work best: "make this video anime," "change the lighting to be more dramatic." Add "keep everything else the same" when targeting a single element.',
+          'zh-CN':
+            '可以。将片段接入节点的视频输入并描述改动，Gemini Omni 1.1 Flash 会在保留其余部分的前提下应用该改动。简短的提示词效果最好，例如「make this video anime」「change the lighting to be more dramatic」。若只想改动单个元素，可加上「keep everything else the same」。'
+        }
+      },
+      {
+        id: 'compared-to-previous-omni-flash',
+        question: {
+          en: 'How does Gemini Omni 1.1 Flash compare to the previous Omni Flash?',
+          'zh-CN': 'Gemini Omni 1.1 Flash 与上一代 Omni Flash 相比如何？'
+        },
+        answer: {
+          en: 'Gemini Omni 1.1 Flash is a full replacement for earlier Omni Flash versions, with the same generate-and-edit workflow and faster generation. The 1.1 release lets you draft videos more efficiently at 360p, upscale to 4K resolution, and extend scenes for longer storytelling.',
+          'zh-CN':
+            'Gemini Omni 1.1 Flash 完全取代此前各版本的 Omni Flash，沿用同样的生成与编辑工作流，且生成更快。1.1 版本让你能以 360p 更高效地打草稿，放大到 4K 分辨率，并延长场景以讲述更长的故事。'
+        }
+      },
+      {
+        id: 'cost-in-comfyui',
+        question: {
+          en: 'How much does Gemini Omni 1.1 Flash cost in ComfyUI?',
+          'zh-CN': '在 ComfyUI 中使用 Gemini Omni 1.1 Flash 的费用是多少？'
+        },
+        answer: {
+          en: 'Gemini Omni 1.1 Flash is billed per generation through ComfyUI credits, with cost varying by resolution. See the ComfyUI pricing page for current rates. No separate Google subscription is needed.',
+          'zh-CN':
+            'Gemini Omni 1.1 Flash 按每次生成通过 ComfyUI 积分计费，费用随分辨率而变。当前费率请见 ComfyUI 定价页面。无需单独订阅 Google。'
+        }
+      }
+    ]
+  },
+  // June's order: outputs, then how to direct, then Q&A, then pricing.
+  sectionOrder: ['gallery', 'steps', 'faq', 'pricing'],
+  runOptions: {
+    headingKey: 'geminiOmni.runOptions.heading',
+    subtitleKey: 'geminiOmni.runOptions.subtitle',
+    ctaKey: 'geminiOmni.runOptions.cta'
+  },
+  reviews: {
+    headingKey: 'geminiOmni.reviews.heading',
+    highlight: {
+      titleKey: 'geminiOmni.reviews.highlightTitle',
+      descriptionKey: 'geminiOmni.reviews.highlightDescription',
+      ctaKey: 'geminiOmni.reviews.highlightCta'
+    }
+  }
+} satisfies ModelLaunchPage

--- a/apps/website/src/data/geminiOmni.ts
+++ b/apps/website/src/data/geminiOmni.ts
@@ -61,12 +61,13 @@ const geminiOmniLinks = {
     'https://cloud.comfy.org/?template=api_google_gemini_omni_flash_1_1_t2v',
   cloudRunVideoEdit:
     'https://cloud.comfy.org/?template=api_google_gemini_omni_flash_1_1_edit',
-  // Deliberately not `${externalLinks.workflows}/model/gemini-omni`, the way
-  // /ltx-2.5 links its hub model page: every Gemini Omni entry comes back from
-  // the live hub API with `models: null`, so no model family page is generated
-  // and that URL 404s. This is the same hub data gap that keeps Wan 3.0 out of
-  // the Models filter, and it is fixed upstream by setting the model field.
-  // Point at the overview workflow, which resolves today.
+  // Deliberately not a hub model-family page the way /ltx-2.5 links one. The
+  // catalog now tags these entries `models: ['Gemini Omni 1.1 Flash']`, which
+  // slugifies to `gemini-omni-1-1-flash`, but that page is still not generated:
+  // `deriveModelGroups` requires MIN_CLUSTER_SIZE 5 AND MIN_CLUSTER_USAGE 500,
+  // or membership of PRIORITY_MODELS. The cluster has exactly 5 templates and 0
+  // usage, and no Gemini entry is a priority model, so the URL 404s until usage
+  // builds. Point at the overview workflow, which resolves today.
   hubOverview: 'https://comfy.org/workflows/a0e9a3b16f63-a0e9a3b16f63/'
 } as const
 

--- a/apps/website/src/data/seedance.test.ts
+++ b/apps/website/src/data/seedance.test.ts
@@ -25,7 +25,10 @@ function pageCopy(locale: Locale): { label: string; text: string }[] {
     ]),
     ...(seedancePage.steps?.items ?? []).flatMap((step) => [
       { label: `step ${step.id} title`, text: step.title[locale] },
-      { label: `step ${step.id} description`, text: step.description[locale] }
+      {
+        label: `step ${step.id} description`,
+        text: step.description?.[locale] ?? ''
+      }
     ])
   ]
 }

--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -5226,6 +5226,105 @@ const translations = {
   },
   'ltx.reviews.highlightCta': { en: 'GET STARTED', 'zh-CN': '开始使用' },
 
+  // Gemini Omni 1.1 Flash launch page (/gemini-omni). zh-CN hand-translated.
+  // Hero copy is Rob's blog line verbatim; headings and CTA labels are read off
+  // June's Figma (node 12752-37723). No Q&A block yet: the Figma's is still the
+  // Seedance 2.0 placeholder and Rob's copy has not landed.
+  'geminiOmni.meta.title': {
+    en: 'Gemini Omni 1.1 Flash on Comfy: Google AI Video Model',
+    'zh-CN': 'Comfy 上的 Gemini Omni 1.1 Flash：Google AI 视频模型'
+  },
+  'geminiOmni.meta.description': {
+    en: 'Run Gemini Omni 1.1 Flash on Comfy. One node covers text to video, image to video, reference to video, editing and scene extension, with output up to 4K and audio on every clip.',
+    'zh-CN':
+      '在 Comfy 上运行 Gemini Omni 1.1 Flash。一个节点即可覆盖文本生成视频、图像生成视频、参考生成视频、视频编辑与场景延展，输出最高可达 4K，每个片段都带音频。'
+  },
+  'geminiOmni.breadcrumb.model': {
+    en: 'Gemini Omni 1.1 Flash',
+    'zh-CN': 'Gemini Omni 1.1 Flash'
+  },
+  'geminiOmni.breadcrumb.updated': {
+    en: 'Updated August 2026',
+    'zh-CN': '更新于 2026 年 8 月'
+  },
+  'geminiOmni.faq.heading': { en: 'Q&A', 'zh-CN': '问答' },
+  'geminiOmni.hero.titleModel': {
+    en: 'Gemini Omni 1.1 Flash',
+    'zh-CN': 'Gemini Omni 1.1 Flash'
+  },
+  'geminiOmni.hero.titleRest': { en: ' is here', 'zh-CN': ' 已上线' },
+  'geminiOmni.hero.description': {
+    en: "Omni 1.1 Flash is Google's new video model, now on Comfy. It's built for fast generation. One node covers text-to-video, image-to-video, reference-to-video, editing, and scene extension, with output up to 4K and audio on every clip.",
+    'zh-CN':
+      'Omni 1.1 Flash 是 Google 的新一代视频模型，现已登陆 Comfy。它为快速生成而打造。一个节点即可覆盖文本生成视频、图像生成视频、参考生成视频、视频编辑与场景延展，输出最高可达 4K，每个片段都带音频。'
+  },
+  'geminiOmni.hero.primaryCta': { en: 'RUN IT NOW', 'zh-CN': '立即运行' },
+  'geminiOmni.hero.secondaryCta': {
+    en: 'EXPLORE WORKFLOWS',
+    'zh-CN': '探索工作流'
+  },
+  'geminiOmni.hero.tagPartnerNode': {
+    en: 'Partner node',
+    'zh-CN': '合作伙伴节点'
+  },
+  'geminiOmni.hero.tagImageToVideo': {
+    en: 'Image to Video',
+    'zh-CN': '图像转视频'
+  },
+  'geminiOmni.hero.tagTextToVideo': {
+    en: 'Text to Video',
+    'zh-CN': '文本转视频'
+  },
+  'geminiOmni.hero.tagReferenceToVideo': {
+    en: 'Reference to Video',
+    'zh-CN': '参考转视频'
+  },
+  'geminiOmni.models.heading': {
+    en: 'Made with Omni 1.1 Flash',
+    'zh-CN': '用 Omni 1.1 Flash 制作'
+  },
+  'geminiOmni.steps.heading': {
+    en: 'How to direct your shot',
+    'zh-CN': '如何执导你的镜头'
+  },
+  'geminiOmni.steps.step': { en: 'Step', 'zh-CN': '步骤' },
+  'geminiOmni.steps.secondaryCta': {
+    en: 'RUN OMNI 1.1 FLASH',
+    'zh-CN': '运行 Omni 1.1 Flash'
+  },
+  'geminiOmni.pricing.banner.title': {
+    en: "Start Comfy Cloud for free. Upgrade when you're ready.",
+    'zh-CN': '免费开始使用 Comfy Cloud，准备好了再升级。'
+  },
+  'geminiOmni.pricing.banner.subtitle': {
+    en: '5 free runs on real GPUs — no credit card required.',
+    'zh-CN': '在真实 GPU 上免费运行 5 次 — 无需信用卡。'
+  },
+  'geminiOmni.pricing.banner.cta': { en: 'TRY FREE', 'zh-CN': '免费试用' },
+  'geminiOmni.runOptions.heading': {
+    en: 'One engine, every way to run it',
+    'zh-CN': '同一引擎，多种运行方式'
+  },
+  'geminiOmni.runOptions.subtitle': {
+    en: 'Build workflows in the browser today. Batch campaigns with the API, or bring it in-house.',
+    'zh-CN': '今天就在浏览器中构建工作流。用 API 批量制作，或部署到自有环境。'
+  },
+  'geminiOmni.runOptions.cta': { en: 'LEARN MORE', 'zh-CN': '了解更多' },
+  'geminiOmni.reviews.heading': {
+    en: '4+ million Comfy creators say',
+    'zh-CN': '400 万+ Comfy 创作者这样说'
+  },
+  'geminiOmni.reviews.highlightTitle': {
+    en: 'Comfy MCP: now turn your agent into a creative technologist.',
+    'zh-CN': 'Comfy MCP：让你的智能体成为创意技术专家。'
+  },
+  'geminiOmni.reviews.highlightDescription': {
+    en: 'Your AI assistant can access the ecosystem, build workflows, and generate images, video, audio, or 3D.',
+    'zh-CN':
+      '你的 AI 助手可以接入整个生态、构建工作流，并生成图像、视频、音频或 3D 内容。'
+  },
+  'geminiOmni.reviews.highlightCta': { en: 'GET STARTED', 'zh-CN': '开始使用' },
+
   // Seedance 2.5 SEO page (/seedance-2.5). zh-CN hand-translated; some body
   // copy carries placeholder intent from Figma and may change (June, CRE-145).
   'seedance.meta.title': {
@@ -5743,6 +5842,10 @@ const translations = {
   },
   'footer.wanAnimate2': { en: 'Wan Animate 2', 'zh-CN': 'Wan Animate 2' },
   'footer.ltx': { en: 'LTX 2.5', 'zh-CN': 'LTX 2.5' },
+  'footer.geminiOmni': {
+    en: 'Gemini Omni 1.1 Flash',
+    'zh-CN': 'Gemini Omni 1.1 Flash'
+  },
   'modelLaunch.copyPrompt': { en: 'Copy prompt', 'zh-CN': '复制提示词' },
   // Wan 3.0 model page (/wan-3.0)
   'wan3.meta.title': {

--- a/apps/website/src/pages/gemini-omni.astro
+++ b/apps/website/src/pages/gemini-omni.astro
@@ -1,0 +1,6 @@
+---
+import ModelLaunchPage from '../templates/model-launch/ModelLaunchPage.astro'
+import { geminiOmniPage } from '../data/geminiOmni'
+---
+
+<ModelLaunchPage page={geminiOmniPage} />

--- a/apps/website/src/pages/zh-CN/gemini-omni.astro
+++ b/apps/website/src/pages/zh-CN/gemini-omni.astro
@@ -1,0 +1,6 @@
+---
+import ModelLaunchPage from '../../templates/model-launch/ModelLaunchPage.astro'
+import { geminiOmniPage } from '../../data/geminiOmni'
+---
+
+<ModelLaunchPage page={geminiOmniPage} />

--- a/apps/website/src/templates/model-launch/ModelLaunchStepsSection.vue
+++ b/apps/website/src/templates/model-launch/ModelLaunchStepsSection.vue
@@ -39,7 +39,10 @@ const stepNumber = (index: number) => String(index + 1).padStart(2, '0')
         <p class="text-2xl/snug font-medium text-primary-warm-white">
           {{ step.title[locale] }}
         </p>
-        <p class="text-[17px]/relaxed font-light text-primary-comfy-canvas">
+        <p
+          v-if="step.description"
+          class="text-[17px]/relaxed font-light text-primary-comfy-canvas"
+        >
           {{ step.description[locale] }}
         </p>
       </li>

--- a/apps/website/src/templates/model-launch/modelLaunchPages.test.ts
+++ b/apps/website/src/templates/model-launch/modelLaunchPages.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import { flux3Page } from '../../data/flux3'
+import { geminiOmniPage } from '../../data/geminiOmni'
 import { ltxPage } from '../../data/ltx'
 import { minimaxPage } from '../../data/minimax'
 import { minimaxMusic3Page } from '../../data/minimaxMusic3'
@@ -19,6 +20,7 @@ const pages: { name: string; page: ModelLaunchPage }[] = [
   { name: 'flux3', page: flux3Page },
   { name: 'seedance', page: seedancePage },
   { name: 'ltx', page: ltxPage },
+  { name: 'geminiOmni', page: geminiOmniPage },
   { name: 'wanAnimate2', page: wanAnimate2Page },
   { name: 'wan3', page: wan3Page }
 ]

--- a/apps/website/src/templates/model-launch/types.ts
+++ b/apps/website/src/templates/model-launch/types.ts
@@ -144,7 +144,8 @@ export interface ModelLaunchClosingCta {
 interface ModelLaunchStep {
   id: string
   title: LocalizedText
-  description: LocalizedText
+  // Optional: a step can be a title on its own, with no supporting line.
+  description?: LocalizedText
 }
 
 export interface ModelLaunchSteps {


### PR DESCRIPTION
## Summary

Adds the Gemini Omni 1.1 Flash launch page at `/gemini-omni` and `/zh-CN/gemini-omni`, on the shared model-launch template. Ported from the private repo, where it was reviewed in #46.

## Changes

- **What**: `data/geminiOmni.ts` (hero, 6-card gallery, 3 steps, Q&A, pricing), the `geminiOmni.*` keys for both locales, two page stubs, the route and its test, a footer link, and an e2e spec. One template change: a launch step's `description` is now optional, so a step can be a title on its own.
- **Breaking**: none

## Review focus

**The model name changed after the page was built.** The doc the page was written from says "Gemini Omni Flash 1.1"; the final name is **Gemini Omni 1.1 Flash**, confirmed by Google's own announcement. 45 strings were renamed across both locales.

Six mentions were deliberately left as "Omni Flash" because they refer to the **previous** generation: "It replaces earlier versions of Gemini Omni Flash", "How does Gemini Omni 1.1 Flash compare to the previous Omni Flash?", and their zh-CN equivalents. Only the versioned string was replaced, so those stayed correct by construction. A blanket swap would have produced "compare to the previous Omni 1.1 Flash", which compares the model to itself.

**The run CTAs point at the 1.1 templates, not the previous generation's.** Both sets exist in workflow_templates and both return 200 on Cloud, so nothing 404s and the mistake is invisible from the outside. Confirmed against the index the hub serves, by title rather than by slug:

- `api_google_gemini_omni_flash_t2v` opens "Gemini Omni **Flash**: Text to Video"
- `api_google_gemini_omni_flash_1_1_t2v` opens "Gemini Omni **1.1** Flash: Text to Video"

The page wires `_1_1_t2v` and `_1_1_edit`. Three more exist and are unused: `_1_1_i2v`, `_1_1_r2v`, `_1_1_extend`. The copy advertises reference-to-video and scene extension, so pointing the matching gallery cards at them would be a sensible follow-up, but which card demonstrates which capability is a content call.

**The hub link is the canonical URL.** `hubOverview` points at `/workflows/a0e9a3b16f63-a0e9a3b16f63/`. Both that and the shorter `/workflows/a0e9a3b16f63/` return 200, and both declare the doubled form as their canonical, so the shorter one was a non-canonical variant of the same destination.

It deliberately does not use `${externalLinks.workflows}/model/gemini-omni`, the way `/ltx-2.5` links its hub model page: every Gemini Omni entry comes back from the hub API with `models: null`, so no model family page is generated and that URL 404s. Same hub data gap that keeps Wan 3.0 out of the Models filter, fixed upstream by setting the model field.

**4K claims are intentional here.** "Up to 4K Resolution" comes from Google's official announcement, unlike the Wan 3.0 page where 4K had to be removed. The page also carries no percentage speed claim, and says "Google Gemini" rather than DeepMind.

## Outstanding, not blocking review

The hero video is still to come from the creative team, and the gallery is present but its clips are the ones in the design. When the hero video lands it needs `mobileVideoSrc` and `mobileFallbackImageSrc` in the same commit, not a follow-up: omitting `mobileFallbackImageSrc` does not merely skip a still, it makes `!hero.mobileFallbackImageSrc || (isMounted && isDesktopViewport)` permanently true and disables the mobile gate entirely.

## Verification

astro check 0 errors, 651 unit tests, JSON-LD valid across 702 pages, 15 of 15 e2e in both locales at desktop and mobile. Rebased onto current main and re-verified after `chore: remove legacy Desktop UI` landed.
