### PR TITLE
test: establish Vue node resize performance baseline

### DIFF
--- a/browser_tests/tests/performance.spec.ts
+++ b/browser_tests/tests/performance.spec.ts
@@ -369,6 +369,56 @@ test.describe('Performance', { tag: ['@perf'] }, () => {
       )
     })
 
+    test('node resize workload', async ({ comfyPage }) => {
+      const nodeCount = await comfyPage.page
+        .locator('[data-node-id]')
+        .evaluateAll((elements) => {
+          const nodes = elements.slice(0, 100) as HTMLElement[]
+          for (const node of nodes) {
+            node.dataset.perfOriginalWidth = node.style.width
+            node.dataset.perfWidth = `${node.getBoundingClientRect().width}px`
+          }
+          return nodes.length
+        })
+      expect(nodeCount).toBe(100)
+
+      await comfyPage.perf.startMeasuring()
+      for (let index = 0; index < 10; index++) {
+        await comfyPage.page
+          .locator('[data-perf-width]')
+          .evaluateAll((elements) => {
+            for (const element of elements as HTMLElement[]) {
+              const width = Number.parseFloat(element.dataset.perfWidth ?? '')
+              element.style.width = `${width + 1}px`
+            }
+          })
+        await comfyPage.nextFrame()
+        await comfyPage.page
+          .locator('[data-perf-width]')
+          .evaluateAll((elements) => {
+            for (const element of elements as HTMLElement[]) {
+              element.style.width = element.dataset.perfWidth ?? ''
+            }
+          })
+        await comfyPage.nextFrame()
+      }
+
+      const measurement = await comfyPage.perf.stopMeasuring(
+        'vue-node-resize-workload'
+      )
+      recordMeasurement(measurement)
+
+      await comfyPage.page
+        .locator('[data-perf-width]')
+        .evaluateAll((elements) => {
+          for (const element of elements as HTMLElement[]) {
+            element.style.width = element.dataset.perfOriginalWidth ?? ''
+            delete element.dataset.perfOriginalWidth
+            delete element.dataset.perfWidth
+          }
+        })
+    })
+
     test('zoom out culling', async ({ comfyPage }) => {
       await comfyPage.perf.startMeasuring()
 


### PR DESCRIPTION
## Summary

Add the original `vue-node-resize-workload` as a test-only `@perf` workload on current `main`, without the production resize suppression. This reconstructs a true pre-fix baseline for the follow-up to #16028/#16030.

The sole changed file is `browser_tests/tests/performance.spec.ts`; its patch is byte-identical to original workload commit `c267597faf9e`. Current `main` does not contain the #16030 `lastReported`/`contentSizeOf` production cache.

## Local proof

- `oxfmt --check browser_tests/tests/performance.spec.ts` — passed.
- `oxlint --type-aware browser_tests/tests/performance.spec.ts` — passed.
- Unique local server: Vite `127.0.0.1:5197`, existing backend `127.0.0.1:8188`.
- `playwright test browser_tests/tests/performance.spec.ts --project=performance --grep "node resize workload" --workers=1` — 1/1 passed.
- Same command with `--repeat-each=3` — 3/3 passed.

Across four local samples, operation counts were invariant: **20 layouts** and **20 style recalculations** per run, with **0 ms TBT**. Median measured duration was **2,897 ms**, style-recalc duration **42.0 ms**, layout duration **10.7 ms**, task duration **2,718 ms**, average frame interval **16.67 ms**, and p95 frame interval **16.7 ms**.

## Interpretation and limitations

This PR establishes the workload and pre-fix CI history; it does not claim a performance improvement. Four serial local samples on one host are a harness signal, not a stable cross-run baseline. CI must accumulate accepted samples and variance before a separate production-fix PR compares the identical workload. Screenshots are not performance evidence and none are claimed.

## Restack plan

After this baseline merges and accumulates accepted `main` samples, create a fresh fix branch from then-current `main`, port only #16030 production code plus deterministic regressions, and compare identical browser workload/sample policy. Keep #16028/#16030 unchanged; do not open a replacement fix PR before the baseline lands.

<!-- perf-proof-evidence:start -->
## Current performance-proof evidence

- Exact reviewed head: `8ee1087621f3895035567dede6d548e4f0c43d27`; sole diff is `browser_tests/tests/performance.spec.ts`. Full self-review found no production, fixture, debug, or generated-file changes.
- No-install gates: diff check, Oxfmt, type-aware Oxlint, and `vue-tsc --project browser_tests/tsconfig.json --noEmit` passed.
- Independent browser rerun used Vite `127.0.0.1:5199`, backend `127.0.0.1:8188`, performance project, one worker, and `--repeat-each=3`: **3/3 passed**. All samples retained the structural signal of **20 layouts and 20 style recalculations**. Median local values were 3,565 ms duration, 52.8 ms style recalculation, 15.5 ms layout, 3,454 ms task duration, 62 ms TBT, 16.67 ms average frame interval, and 16.7 ms p95 frame interval. The host-dependent timing spread (2,785–3,756 ms) is why this PR establishes baseline history rather than claiming an improvement.
- Hosted CI performance run passed and recorded two pre-fix samples: **56.3 average FPS**, **59.5 P5 FPS**, **20 layouts**, **20 style recalculations**, and **394 ms median TBT**. The raw samples report 6,282/6,503 ms duration, 72.974/74.455 ms style recalculation, 21.943/23.136 ms layout, and 6,170/6,401 ms task duration.
- At evidence capture, all **112** paginated check-runs were terminal success/skipped. CodeRabbit approved this exact head with no actionable comments; zero unresolved inline threads exist. Required human approval remains the only merge blocker.
- This remains a baseline-only test PR. Screenshots are not performance evidence and none are claimed.
<!-- perf-proof-evidence:end -->
