### PR TITLE
feat(website): dev platform GA launch

### DIFF
--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -7686,8 +7686,8 @@ Enterprise`
     'zh-CN': '企业版：托管构建'
   },
   'platform.products.models.title': {
-    en: 'Models API',
-    'zh-CN': 'Models API'
+    en: 'Comfy Router',
+    'zh-CN': 'Comfy Router'
   },
   'platform.products.models.description': {
     en: 'Call partner models including Seedance, Minimax H3, Nano Banana, and GPT-Image-2. Access the latest models with a single API key.',
@@ -7975,9 +7975,9 @@ Enterprise`
     'zh-CN': '示例：500 GB 模型存放在标准网络存储上 = 每月 $45.50 + GPU 时间。'
   },
   'platform.pricing.modelsNote': {
-    en: 'Models API usage shows per-output prices on each model card and draws from the same credit pool.',
+    en: 'Comfy Router usage shows per-output prices on each model card and draws from the same credit pool.',
     'zh-CN':
-      'Models API 用量在每个模型卡片上标注单次输出价格，并从同一积分池扣费。'
+      'Comfy Router 用量在每个模型卡片上标注单次输出价格，并从同一积分池扣费。'
   },
   'platform.faq.betaBanner': {
     en: 'Limited beta: builds can take up to 3 hours and may fail. You get a direct support line while we harden the pipeline.',

--- a/apps/website/src/pages/platform.astro
+++ b/apps/website/src/pages/platform.astro
@@ -4,6 +4,8 @@ import BrandBackground from '../templates/brand/BrandBackground.vue'
 import ProductCardsSection from '../components/common/ProductCardsSection.vue'
 import SocialProofBarSection from '../components/common/SocialProofBarSection.vue'
 import ClosingCtaSection from '../templates/platform/ClosingCtaSection.vue'
+import CustomersSection from '../templates/platform/CustomersSection.vue'
+import ExamplesSection from '../templates/platform/ExamplesSection.vue'
 import HeroSection from '../templates/platform/HeroSection.vue'
 import PricingSection from '../templates/platform/PricingSection.vue'
 import ProductsSection from '../templates/platform/ProductsSection.vue'
@@ -20,6 +22,8 @@ import { t } from '../i18n/translations'
     <ProductsSection locale="en" client:visible />
   </div>
   <SocialProofBarSection />
+  <ExamplesSection locale="en" />
+  <CustomersSection locale="en" />
   <PricingSection locale="en" />
   <ClosingCtaSection
     locale="en"

--- a/apps/website/src/pages/zh-CN/platform.astro
+++ b/apps/website/src/pages/zh-CN/platform.astro
@@ -3,6 +3,8 @@ import BaseLayout from '../../layouts/BaseLayout.astro'
 import ProductCardsSection from '../../components/common/ProductCardsSection.vue'
 import SocialProofBarSection from '../../components/common/SocialProofBarSection.vue'
 import ClosingCtaSection from '../../templates/platform/ClosingCtaSection.vue'
+import CustomersSection from '../../templates/platform/CustomersSection.vue'
+import ExamplesSection from '../../templates/platform/ExamplesSection.vue'
 import HeroSection from '../../templates/platform/HeroSection.vue'
 import PricingSection from '../../templates/platform/PricingSection.vue'
 import ProductsSection from '../../templates/platform/ProductsSection.vue'
@@ -16,6 +18,8 @@ import { t } from '../../i18n/translations'
   <HeroSection locale="zh-CN" client:load />
   <ProductsSection locale="zh-CN" client:visible />
   <SocialProofBarSection />
+  <ExamplesSection locale="zh-CN" />
+  <CustomersSection locale="zh-CN" />
   <PricingSection locale="zh-CN" />
   <ClosingCtaSection
     locale="zh-CN"

--- a/apps/website/src/templates/platform/CustomersSection.vue
+++ b/apps/website/src/templates/platform/CustomersSection.vue
@@ -1,0 +1,104 @@
+<script setup lang="ts">
+import SectionHeader from '../../components/common/SectionHeader.vue'
+import Button from '../../components/ui/button/Button.vue'
+import { externalLinks, getRoutes } from '../../config/routes'
+import type { Locale } from '../../i18n/translations'
+import { t } from '../../i18n/translations'
+import { resolveRel } from '../../utils/cta'
+
+const { locale = 'en' } = defineProps<{ locale?: Locale }>()
+
+const routes = getRoutes(locale)
+
+interface TierCta {
+  label: string
+  href: string
+  target?: '_blank'
+}
+
+interface Tier {
+  id: string
+  title: string
+  description: string
+  cta: TierCta
+}
+
+const tiers: Tier[] = [
+  {
+    id: 'solo',
+    title: t('platform.customers.solo.title', locale),
+    description: t('platform.customers.solo.description', locale),
+    cta: {
+      label: t('platform.customers.solo.cta', locale),
+      href: externalLinks.platform,
+      target: '_blank'
+    }
+  },
+  {
+    id: 'studio',
+    title: t('platform.customers.studio.title', locale),
+    description: t('platform.customers.studio.description', locale),
+    cta: {
+      label: t('platform.customers.studio.cta', locale),
+      href: routes.customers
+    }
+  },
+  {
+    id: 'enterprise',
+    title: t('platform.customers.enterprise.title', locale),
+    description: t('platform.customers.enterprise.description', locale),
+    cta: {
+      label: t('platform.customers.enterprise.cta', locale),
+      href: routes.contact
+    }
+  }
+]
+</script>
+
+<template>
+  <section
+    id="customers"
+    class="max-w-9xl mx-auto scroll-mt-24 px-6 py-10 lg:scroll-mt-36 lg:py-14"
+  >
+    <SectionHeader max-width="xl" heading-size="compact">
+      {{ t('platform.customers.heading', locale) }}
+    </SectionHeader>
+
+    <figure class="mx-auto mt-8 max-w-2xl text-center">
+      <blockquote
+        class="text-base/relaxed font-light text-primary-warm-white lg:text-lg/relaxed"
+      >
+        {{ t('platform.customers.quote', locale) }}
+      </blockquote>
+      <figcaption class="mt-3 text-xs text-smoke-700">
+        {{ t('platform.customers.quoteAttribution', locale) }}
+      </figcaption>
+    </figure>
+
+    <div class="mt-8 grid grid-cols-1 gap-6 md:grid-cols-3 lg:mt-10">
+      <article
+        v-for="tier in tiers"
+        :key="tier.id"
+        class="bg-transparency-white-t4 flex flex-col rounded-3xl p-6 lg:p-8"
+      >
+        <h3 class="text-base font-normal text-primary-warm-white lg:text-lg">
+          {{ tier.title }}
+        </h3>
+        <p class="mt-3 text-xs/relaxed font-light text-primary-comfy-canvas">
+          {{ tier.description }}
+        </p>
+        <div class="mt-auto pt-6">
+          <Button
+            as="a"
+            :href="tier.cta.href"
+            :target="tier.cta.target"
+            :rel="resolveRel(tier.cta)"
+            variant="outline"
+          >
+            {{ tier.cta.label }}
+          </Button>
+        </div>
+      </article>
+    </div>
+  </section>
+</template>

--- a/apps/website/src/templates/platform/ExamplesSection.vue
+++ b/apps/website/src/templates/platform/ExamplesSection.vue
@@ -1,0 +1,174 @@
+<script setup lang="ts">
+import { cn } from '@comfyorg/tailwind-utils'
+
+import SectionHeader from '../../components/common/SectionHeader.vue'
+import Button from '../../components/ui/button/Button.vue'
+import { externalLinks } from '../../config/routes'
+import type { Locale } from '../../i18n/translations'
+import { t } from '../../i18n/translations'
+
+const { locale = 'en' } = defineProps<{ locale?: Locale }>()
+
+interface Example {
+  id: string
+  title: string
+  description: string
+  tags: string[]
+  bg: string
+}
+
+const featured: Example[] = [
+  {
+    id: 'try-on',
+    title: t('platform.examples.tryOn.title', locale),
+    description: t('platform.examples.tryOn.description', locale),
+    tags: ['Next.js', 'Serverless API'],
+    bg: 'bg-primary-comfy-plum'
+  },
+  {
+    id: 'higgsfield',
+    title: t('platform.examples.higgsfield.title', locale),
+    description: t('platform.examples.higgsfield.description', locale),
+    tags: ['Comfy Router', 'Seedance', 'Next.js'],
+    bg: 'bg-secondary-mauve'
+  }
+]
+
+const more: Omit<Example, 'bg'>[] = [
+  {
+    id: 'emoji',
+    title: t('platform.examples.emoji.title', locale),
+    description: t('platform.examples.emoji.description', locale),
+    tags: ['JavaScript', 'Cloud API']
+  },
+  {
+    id: 'dcc',
+    title: t('platform.examples.dcc.title', locale),
+    description: t('platform.examples.dcc.description', locale),
+    tags: ['Photoshop', 'Blender', 'Serverless API']
+  },
+  {
+    id: 'agent',
+    title: t('platform.examples.agent.title', locale),
+    description: t('platform.examples.agent.description', locale),
+    tags: ['comfy-cli', 'MCP', 'Builder']
+  },
+  {
+    id: 'sprite',
+    title: t('platform.examples.sprite.title', locale),
+    description: t('platform.examples.sprite.description', locale),
+    tags: ['Python', 'Serverless API']
+  },
+  {
+    id: 'discord',
+    title: t('platform.examples.discord.title', locale),
+    description: t('platform.examples.discord.description', locale),
+    tags: ['Webhooks', 'Serverless API']
+  },
+  {
+    id: 'hub',
+    title: t('platform.examples.hub.title', locale),
+    description: t('platform.examples.hub.description', locale),
+    tags: ['Hub', 'Serverless API']
+  }
+]
+</script>
+
+<template>
+  <section
+    id="examples"
+    class="max-w-9xl mx-auto scroll-mt-24 px-6 py-10 lg:scroll-mt-36 lg:py-14"
+  >
+    <div class="flex flex-wrap items-end justify-between gap-x-8 gap-y-4">
+      <SectionHeader max-width="xl" heading-size="compact" align="start">
+        {{ t('platform.examples.heading', locale) }}
+        <template #subtitle>
+          <p class="mt-4 text-sm text-smoke-700">
+            {{ t('platform.examples.subtitle', locale) }}
+          </p>
+        </template>
+      </SectionHeader>
+      <Button
+        as="a"
+        :href="externalLinks.docsPlatformExamples"
+        target="_blank"
+        rel="noopener noreferrer"
+        variant="underlineLink"
+      >
+        {{ t('platform.examples.viewAll', locale) }}
+      </Button>
+    </div>
+
+    <!-- Featured: the flagship builds, with their output front and center -->
+    <div class="mt-8 grid grid-cols-1 gap-6 lg:grid-cols-2">
+      <a
+        v-for="example in featured"
+        :key="example.id"
+        :href="externalLinks.docsPlatformExamples"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="focus-visible:ring-primary-comfy-yellow/50 group flex flex-col overflow-hidden rounded-3xl border border-white/10 transition-colors hover:border-white/25 focus-visible:ring-2 focus-visible:outline-none"
+      >
+        <div
+          :class="
+            cn(
+              'flex aspect-2/1 items-end p-4 transition-opacity group-hover:opacity-90',
+              example.bg
+            )
+          "
+        >
+          <div class="flex flex-wrap gap-1.5">
+            <span
+              v-for="tag in example.tags"
+              :key="tag"
+              class="rounded-full bg-primary-comfy-ink/70 px-2.5 py-1 font-mono text-[10px] text-primary-comfy-canvas"
+            >
+              {{ tag }}
+            </span>
+          </div>
+        </div>
+        <div class="bg-transparency-white-t4 flex flex-1 flex-col p-6">
+          <h3 class="text-base font-normal text-primary-warm-white">
+            {{ example.title }}
+          </h3>
+          <p class="mt-2 text-xs/relaxed font-light text-primary-comfy-canvas">
+            {{ example.description }}
+          </p>
+          <span
+            class="text-primary-comfy-yellow mt-auto pt-4 text-xs font-bold tracking-wider uppercase"
+          >
+            {{ t('platform.examples.cookbook', locale) }}
+          </span>
+        </div>
+      </a>
+    </div>
+
+    <!-- The rest of the gallery, compact -->
+    <div class="mt-6 grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
+      <a
+        v-for="example in more"
+        :key="example.id"
+        :href="externalLinks.docsPlatformExamples"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="focus-visible:ring-primary-comfy-yellow/50 bg-transparency-white-t4 flex flex-col rounded-3xl border border-white/10 p-5 transition-colors hover:border-white/25 focus-visible:ring-2 focus-visible:outline-none"
+      >
+        <div class="flex flex-wrap gap-1.5">
+          <span
+            v-for="tag in example.tags"
+            :key="tag"
+            class="rounded-full bg-primary-comfy-ink/70 px-2.5 py-1 font-mono text-[10px] text-primary-comfy-canvas"
+          >
+            {{ tag }}
+          </span>
+        </div>
+        <h3 class="mt-4 text-base font-normal text-primary-warm-white">
+          {{ example.title }}
+        </h3>
+        <p class="mt-2 text-xs/relaxed font-light text-primary-comfy-canvas">
+          {{ example.description }}
+        </p>
+      </a>
+    </div>
+  </section>
+</template>

--- a/apps/website/src/templates/platform/ProductsSection.vue
+++ b/apps/website/src/templates/platform/ProductsSection.vue
@@ -43,7 +43,7 @@ const modelsTabs = modelsApiCodeTabs
       <ServerlessIsometricStudy :locale />
     </article>
 
-    <!-- Models API and Builder, side by side -->
+    <!-- Comfy Router and Builder, side by side -->
     <div class="mt-6 grid grid-cols-1 gap-6 lg:grid-cols-2">
       <article
         id="models"

--- a/apps/website/src/templates/platform/codeSamples.ts
+++ b/apps/website/src/templates/platform/codeSamples.ts
@@ -34,7 +34,7 @@ export const modelsApiCodeTabs: Record<string, CodeTab> = {
       "')"
     ]
   },
-  // Models API run route — POST /v1/models/{provider}/{model}: native JSON in, native JSON out
+  // Comfy Router run route — POST /v1/models/{provider}/{model}: native JSON in, native JSON out
   // (services/comfy-api/docs/router-quickstart.mdx in Comfy-Org/cloud).
   curl: {
     name: 'cURL',


### PR DESCRIPTION
Stacked on the limited-beta PR. Restores the customer proof tier section ("From one GPU to a render farm") on /platform for GA, once design-partner quotes and case tiles are ready.