### PR TITLE
feat: add post-first-run discovery actions

### DIFF
--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -5062,6 +5062,22 @@
         }
       },
       "nudge": {
+        "title": "Your first output. Here's what's next.",
+        "body": "Each one starts from the image you just made.",
+        "animate": {
+          "title": "Animate it",
+          "detail": "Image to video · 5s"
+        },
+        "upscale": {
+          "title": "Upscale it",
+          "detail": "Same image, more detail",
+          "badge": "4x"
+        },
+        "restyle": {
+          "title": "Restyle with Nano Banana",
+          "detail": "Partner model · Any paid plan"
+        },
+        "loadFailed": "That template couldn't be loaded. Please try again.",
         "ran": {
           "title": "That was one of hundreds",
           "body": "You just made your first. Explore what else you can build."
@@ -5071,7 +5087,7 @@
           "body": "Browse the templates and pick something to build."
         },
         "dismiss": "Not now",
-        "explore": "Explore templates"
+        "explore": "Browse all templates"
       }
     }
   }

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -5078,15 +5078,6 @@
           "detail": "Partner model · Any paid plan"
         },
         "loadFailed": "That template couldn't be loaded. Please try again.",
-        "ran": {
-          "title": "That was one of hundreds",
-          "body": "You just made your first. Explore what else you can build."
-        },
-        "noTour": {
-          "title": "Hundreds more where that came from",
-          "body": "Browse the templates and pick something to build."
-        },
-        "dismiss": "Not now",
         "explore": "Browse all templates"
       }
     }

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -5077,6 +5077,10 @@
           "title": "Restyle with Nano Banana",
           "detail": "Partner model · Any paid plan"
         },
+        "fallback": {
+          "title": "Hundreds more where that came from",
+          "body": "Browse the templates and pick something to build."
+        },
         "loadFailed": "That template couldn't be loaded. Please try again.",
         "explore": "Browse all templates"
       }

--- a/src/platform/telemetry/TelemetryRegistry.ts
+++ b/src/platform/telemetry/TelemetryRegistry.ts
@@ -24,6 +24,8 @@ import type {
   OnboardingTourStage,
   OnboardingTourStepMetadata,
   OnboardingTourStepStage,
+  OnboardingTourSuggestionMetadata,
+  OnboardingTourSuggestionStage,
   SearchQueryMetadata,
   PageViewMetadata,
   PageVisibilityMetadata,
@@ -191,6 +193,10 @@ export class TelemetryRegistry implements TelemetryDispatcher {
   trackOnboardingTour(
     stage: OnboardingTourNudgeStage,
     metadata: OnboardingTourNudgeMetadata
+  ): void
+  trackOnboardingTour(
+    stage: OnboardingTourSuggestionStage,
+    metadata: OnboardingTourSuggestionMetadata
   ): void
   trackOnboardingTour(
     stage: OnboardingTourStage,

--- a/src/platform/telemetry/types.ts
+++ b/src/platform/telemetry/types.ts
@@ -177,9 +177,16 @@ export interface OnboardingTourStepMetadata {
   not_started_reason?: OnboardingTourNotStartedReason
 }
 
-/** The nudge is post-tour, so it reports no step and no count. */
+/** The nudge is post-tour, so it reports no step and no step count. */
 export interface OnboardingTourNudgeMetadata {
   tour: string
+  /**
+   * How many continuations the card could offer. Zero is the card falling back
+   * to the template browser — either the run produced no image, or the
+   * install's pinned template package serves none of them. Without it that
+   * case is indistinguishable from a nudge that never appeared.
+   */
+  suggestion_count: number
 }
 
 /**

--- a/src/platform/telemetry/types.ts
+++ b/src/platform/telemetry/types.ts
@@ -141,9 +141,13 @@ export type OnboardingTourNudgeStage =
   | 'nudge_shown'
   | 'explore_templates_clicked'
 
+/** A continuation action on the nudge, which reports its own outcome. */
+export type OnboardingTourSuggestionStage = 'nudge_suggestion_clicked'
+
 export type OnboardingTourStage =
   | OnboardingTourStepStage
   | OnboardingTourNudgeStage
+  | OnboardingTourSuggestionStage
 
 export type OnboardingTourSkipReason =
   | 'user'
@@ -176,18 +180,22 @@ export interface OnboardingTourStepMetadata {
 /** The nudge is post-tour, so it reports no step and no count. */
 export interface OnboardingTourNudgeMetadata {
   tour: string
-  /**
-   * Whether the tour was walked to the end. Without it `nudge_shown` and
-   * `explore_templates_clicked` cannot be split by how the tour ended, so a
-   * conversion from a completed tour and one from a tour that never started
-   * land in the same bucket.
-   */
-  tour_completed?: boolean
+}
+
+/**
+ * Which continuation the card converted on. `loaded` separates a chosen action
+ * from one that reached a template the install could not open, which otherwise
+ * reads as a successful conversion.
+ */
+export interface OnboardingTourSuggestionMetadata extends OnboardingTourNudgeMetadata {
+  suggestion: string
+  loaded: boolean
 }
 
 export type OnboardingTourMetadata =
   | OnboardingTourStepMetadata
   | OnboardingTourNudgeMetadata
+  | OnboardingTourSuggestionMetadata
 
 export interface SurveyResponsesNormalized extends SurveyResponses {
   industry_normalized?: string
@@ -966,6 +974,10 @@ export interface TelemetryProvider {
     stage: OnboardingTourNudgeStage,
     metadata: OnboardingTourNudgeMetadata
   ): void
+  trackOnboardingTour?(
+    stage: OnboardingTourSuggestionStage,
+    metadata: OnboardingTourSuggestionMetadata
+  ): void
 
   // Email verification events
   trackEmailVerification?(stage: 'opened' | 'requested' | 'completed'): void
@@ -1120,6 +1132,8 @@ export const TelemetryEvents = {
   ONBOARDING_TOUR_COMPLETED: 'app:onboarding_tour_completed',
   ONBOARDING_TOUR_SKIPPED: 'app:onboarding_tour_skipped',
   ONBOARDING_TOUR_NUDGE_SHOWN: 'app:onboarding_tour_nudge_shown',
+  ONBOARDING_TOUR_NUDGE_SUGGESTION_CLICKED:
+    'app:onboarding_tour_nudge_suggestion_clicked',
   ONBOARDING_TOUR_EXPLORE_TEMPLATES_CLICKED:
     'app:onboarding_tour_explore_templates_clicked',
 
@@ -1203,6 +1217,8 @@ export const OnboardingTourEvents: Record<
   completed: TelemetryEvents.ONBOARDING_TOUR_COMPLETED,
   skipped: TelemetryEvents.ONBOARDING_TOUR_SKIPPED,
   nudge_shown: TelemetryEvents.ONBOARDING_TOUR_NUDGE_SHOWN,
+  nudge_suggestion_clicked:
+    TelemetryEvents.ONBOARDING_TOUR_NUDGE_SUGGESTION_CLICKED,
   explore_templates_clicked:
     TelemetryEvents.ONBOARDING_TOUR_EXPLORE_TEMPLATES_CLICKED
 }

--- a/src/platform/workflow/templates/composables/useTemplateWorkflows.test.ts
+++ b/src/platform/workflow/templates/composables/useTemplateWorkflows.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { useTemplateWorkflows } from '@/platform/workflow/templates/composables/useTemplateWorkflows'
 import { useWorkflowTemplatesStore } from '@/platform/workflow/templates/repositories/workflowTemplatesStore'
+import { app } from '@/scripts/app'
 
 async function flushPromises() {
   await new Promise((r) => setTimeout(r, 0))
@@ -74,6 +75,27 @@ describe('useTemplateWorkflows', () => {
     mockWorkflowTemplatesStore = {
       isLoaded: false,
       loadWorkflowTemplates: vi.fn().mockResolvedValue(true),
+      getTemplateByName: vi.fn((name: string) =>
+        name === 'template1'
+          ? {
+              name,
+              mediaType: 'image',
+              mediaSubtype: 'jpg',
+              sourceModule: 'default',
+              description: 'Template 1 description',
+              io: {
+                inputs: [
+                  {
+                    nodeId: 2,
+                    nodeType: 'LoadImage',
+                    file: 'starter.png',
+                    mediaType: 'image'
+                  }
+                ]
+              }
+            }
+          : undefined
+      ),
       groupedTemplates: [
         {
           label: 'ComfyUI Examples',
@@ -296,6 +318,47 @@ describe('useTemplateWorkflows', () => {
 
     expect(result).toBe(true)
     expect(fetch).toHaveBeenCalledWith('mock-file-url/templates/template1.json')
+  })
+
+  it('seeds a result into the template before loading the workflow', async () => {
+    const { loadWorkflowTemplate } = useTemplateWorkflows()
+    mockWorkflowTemplatesStore.isLoaded = true
+    vi.mocked(fetch).mockResolvedValueOnce({
+      json: vi.fn().mockResolvedValue({
+        nodes: [
+          {
+            id: 2,
+            type: 'LoadImage',
+            widgets_values: ['starter.png', 'image']
+          }
+        ]
+      })
+    } as Partial<Response> as Response)
+
+    const result = await loadWorkflowTemplate('template1', 'default', {
+      input: {
+        filename: 'first-output.png',
+        subfolder: 'tour',
+        type: 'output'
+      }
+    })
+
+    expect(result).toBe(true)
+    expect(app.loadGraphData).toHaveBeenCalledWith(
+      {
+        nodes: [
+          {
+            id: 2,
+            type: 'LoadImage',
+            widgets_values: ['tour/first-output.png [output]', 'image']
+          }
+        ]
+      },
+      true,
+      true,
+      'template1',
+      { openSource: 'template' }
+    )
   })
 
   it('tracks template telemetry on load in cloud builds', async () => {

--- a/src/platform/workflow/templates/composables/useTemplateWorkflows.test.ts
+++ b/src/platform/workflow/templates/composables/useTemplateWorkflows.test.ts
@@ -148,6 +148,7 @@ describe('useTemplateWorkflows', () => {
 
     // Mock fetch response
     vi.mocked(fetch).mockResolvedValue({
+      ok: true,
       json: vi.fn().mockResolvedValue({ workflow: 'data' })
     } as Partial<Response> as Response)
   })
@@ -324,6 +325,7 @@ describe('useTemplateWorkflows', () => {
     const { loadWorkflowTemplate } = useTemplateWorkflows()
     mockWorkflowTemplatesStore.isLoaded = true
     vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
       json: vi.fn().mockResolvedValue({
         nodes: [
           {

--- a/src/platform/workflow/templates/composables/useTemplateWorkflows.ts
+++ b/src/platform/workflow/templates/composables/useTemplateWorkflows.ts
@@ -17,7 +17,6 @@ import { useDialogStore } from '@/stores/dialogStore'
 
 interface LoadWorkflowTemplateOptions {
   input?: ResultItem
-  transformWorkflow?: (workflow: ComfyWorkflowJSON) => ComfyWorkflowJSON
 }
 
 export function useTemplateWorkflows() {
@@ -143,8 +142,6 @@ export function useTemplateWorkflows() {
         if (!template || template.sourceModule !== sourceModule) return false
         json = replaceTemplateImageInput(json, template, options.input)
       }
-
-      if (options.transformWorkflow) json = options.transformWorkflow(json)
 
       const workflowName =
         sourceModule === 'default'

--- a/src/platform/workflow/templates/composables/useTemplateWorkflows.ts
+++ b/src/platform/workflow/templates/composables/useTemplateWorkflows.ts
@@ -174,14 +174,22 @@ export function useTemplateWorkflows() {
     id: string,
     sourceModule: string
   ): Promise<ComfyWorkflowJSON> => {
-    if (sourceModule === 'default') {
-      // Default templates provided by frontend are served on this separate endpoint
-      return fetch(api.fileURL(`/templates/${id}.json`)).then((r) => r.json())
-    } else {
-      return fetch(
-        api.apiURL(`/workflow_templates/${sourceModule}/${id}.json`)
-      ).then((r) => r.json())
-    }
+    // Default templates provided by frontend are served on this separate endpoint
+    const url =
+      sourceModule === 'default'
+        ? api.fileURL(`/templates/${id}.json`)
+        : api.apiURL(`/workflow_templates/${sourceModule}/${id}.json`)
+
+    const response = await fetch(url)
+    // An install pinning an older template package serves an error page here,
+    // which parses as neither JSON nor a workflow. Separating that from a
+    // template whose metadata drifted is the difference between a bad pin and
+    // a bad template.
+    if (!response.ok)
+      throw new Error(
+        `Template ${id} is not served by this install (${response.status})`
+      )
+    return response.json()
   }
 
   return {

--- a/src/platform/workflow/templates/composables/useTemplateWorkflows.ts
+++ b/src/platform/workflow/templates/composables/useTemplateWorkflows.ts
@@ -8,9 +8,17 @@ import type {
   TemplateInfo,
   WorkflowTemplates
 } from '@/platform/workflow/templates/types/template'
+import { replaceTemplateImageInput } from '@/platform/workflow/templates/utils/templateWorkflowTransforms'
+import type { ComfyWorkflowJSON } from '@/platform/workflow/validation/schemas/workflowSchema'
+import type { ResultItem } from '@/schemas/apiSchema'
 import { api } from '@/scripts/api'
 import { app } from '@/scripts/app'
 import { useDialogStore } from '@/stores/dialogStore'
+
+interface LoadWorkflowTemplateOptions {
+  input?: ResultItem
+  transformWorkflow?: (workflow: ComfyWorkflowJSON) => ComfyWorkflowJSON
+}
 
 export function useTemplateWorkflows() {
   const { t } = useI18n()
@@ -97,11 +105,15 @@ export function useTemplateWorkflows() {
   /**
    * Loads a workflow template
    */
-  const loadWorkflowTemplate = async (id: string, sourceModule: string) => {
+  const loadWorkflowTemplate = async (
+    id: string,
+    sourceModule: string,
+    options: LoadWorkflowTemplateOptions = {}
+  ) => {
     if (!isTemplatesLoaded.value) return false
 
     loadingTemplateId.value = id
-    let json
+    let json: ComfyWorkflowJSON
 
     try {
       // Handle "All" category as a special case
@@ -125,6 +137,14 @@ export function useTemplateWorkflows() {
 
       // Regular case for normal categories
       json = await fetchTemplateJson(id, sourceModule)
+
+      if (options.input) {
+        const template = workflowTemplatesStore.getTemplateByName(id)
+        if (!template || template.sourceModule !== sourceModule) return false
+        json = replaceTemplateImageInput(json, template, options.input)
+      }
+
+      if (options.transformWorkflow) json = options.transformWorkflow(json)
 
       const workflowName =
         sourceModule === 'default'
@@ -153,7 +173,10 @@ export function useTemplateWorkflows() {
   /**
    * Fetches template JSON from the appropriate endpoint
    */
-  const fetchTemplateJson = async (id: string, sourceModule: string) => {
+  const fetchTemplateJson = async (
+    id: string,
+    sourceModule: string
+  ): Promise<ComfyWorkflowJSON> => {
     if (sourceModule === 'default') {
       // Default templates provided by frontend are served on this separate endpoint
       return fetch(api.fileURL(`/templates/${id}.json`)).then((r) => r.json())

--- a/src/platform/workflow/templates/types/template.ts
+++ b/src/platform/workflow/templates/types/template.ts
@@ -5,11 +5,12 @@ export interface LogoInfo {
   position?: string
 }
 
-interface TemplateMediaInfo {
-  nodeId: string | number
-  nodeType: string
-  file: string
-  mediaType: string
+/** Served by an external `index.json`, so every field may be absent or stale. */
+export interface TemplateMediaInfo {
+  nodeId?: string | number
+  nodeType?: string
+  file?: string
+  mediaType?: string
 }
 
 interface TemplateIoInfo {

--- a/src/platform/workflow/templates/types/template.ts
+++ b/src/platform/workflow/templates/types/template.ts
@@ -5,6 +5,18 @@ export interface LogoInfo {
   position?: string
 }
 
+interface TemplateMediaInfo {
+  nodeId: string | number
+  nodeType: string
+  file: string
+  mediaType: string
+}
+
+interface TemplateIoInfo {
+  inputs?: TemplateMediaInfo[]
+  outputs?: TemplateMediaInfo[]
+}
+
 export interface TemplateInfo {
   name: string
   /**
@@ -67,6 +79,8 @@ export interface TemplateInfo {
    * Logo overlays to display on the template thumbnail.
    */
   logos?: LogoInfo[]
+  /** Declared media entry and exit points for continuing from another result. */
+  io?: TemplateIoInfo
 }
 
 export enum TemplateIncludeOnDistributionEnum {

--- a/src/platform/workflow/templates/utils/templateWorkflowTransforms.test.ts
+++ b/src/platform/workflow/templates/utils/templateWorkflowTransforms.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest'
+
+import type { TemplateInfo } from '../types/template'
+import {
+  replaceTemplateImageInput,
+  replaceUniqueTemplateWidgetValue
+} from './templateWorkflowTransforms'
+
+const template: TemplateInfo = {
+  name: 'image-template',
+  description: 'Image template',
+  mediaType: 'image',
+  mediaSubtype: 'png',
+  io: {
+    inputs: [
+      {
+        nodeId: 2,
+        nodeType: 'LoadImage',
+        file: 'starter.png',
+        mediaType: 'image'
+      }
+    ]
+  }
+}
+
+describe('template workflow transforms', () => {
+  it('seeds a declared image input with an output asset', () => {
+    const workflow = {
+      nodes: [
+        {
+          id: 2,
+          type: 'LoadImage',
+          widgets_values: ['starter.png', 'image']
+        }
+      ]
+    }
+
+    const continued = replaceTemplateImageInput(workflow, template, {
+      filename: 'first-output.png',
+      subfolder: 'tour',
+      type: 'output'
+    })
+
+    expect(continued.nodes[0].widgets_values).toEqual([
+      'tour/first-output.png [output]',
+      'image'
+    ])
+    expect(workflow.nodes[0].widgets_values).toEqual(['starter.png', 'image'])
+  })
+
+  it('configures a unique template widget without relying on its node id', () => {
+    const workflow = {
+      nodes: [
+        {
+          id: 37,
+          type: 'ImageScaleBy',
+          widgets_values: ['lanczos', 2]
+        }
+      ]
+    }
+
+    const configured = replaceUniqueTemplateWidgetValue(
+      workflow,
+      'ImageScaleBy',
+      2,
+      4
+    )
+
+    expect(configured.nodes[0].widgets_values).toEqual(['lanczos', 4])
+  })
+
+  it('rejects drift between declared input metadata and workflow widgets', () => {
+    const workflow = {
+      nodes: [
+        {
+          id: 2,
+          type: 'LoadImage',
+          widgets_values: ['different.png', 'image']
+        }
+      ]
+    }
+
+    expect(() =>
+      replaceTemplateImageInput(workflow, template, {
+        filename: 'first-output.png'
+      })
+    ).toThrow('Expected one matching template widget value')
+  })
+})

--- a/src/platform/workflow/templates/utils/templateWorkflowTransforms.test.ts
+++ b/src/platform/workflow/templates/utils/templateWorkflowTransforms.test.ts
@@ -1,10 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import type { TemplateInfo } from '../types/template'
-import {
-  replaceTemplateImageInput,
-  replaceUniqueTemplateWidgetValue
-} from './templateWorkflowTransforms'
+import { replaceTemplateImageInput } from './templateWorkflowTransforms'
 
 const template: TemplateInfo = {
   name: 'image-template',
@@ -48,27 +45,6 @@ describe('template workflow transforms', () => {
     expect(workflow.nodes[0].widgets_values).toEqual(['starter.png', 'image'])
   })
 
-  it('configures a unique template widget without relying on its node id', () => {
-    const workflow = {
-      nodes: [
-        {
-          id: 37,
-          type: 'ImageScaleBy',
-          widgets_values: ['lanczos', 2]
-        }
-      ]
-    }
-
-    const configured = replaceUniqueTemplateWidgetValue(
-      workflow,
-      'ImageScaleBy',
-      2,
-      4
-    )
-
-    expect(configured.nodes[0].widgets_values).toEqual(['lanczos', 4])
-  })
-
   it('rejects drift between declared input metadata and workflow widgets', () => {
     const workflow = {
       nodes: [
@@ -86,4 +62,30 @@ describe('template workflow transforms', () => {
       })
     ).toThrow('Expected one matching template widget value')
   })
+
+  it.for(['nodeId', 'nodeType', 'file'] as const)(
+    'rejects an image input without %s',
+    (field) => {
+      const incompleteTemplate = structuredClone(template)
+      const input = incompleteTemplate.io?.inputs?.[0]
+      if (!input) throw new Error('Expected template image input')
+      Object.defineProperty(input, field, { value: undefined })
+      const workflow = {
+        nodes: [
+          {
+            id: 2,
+            type: 'LoadImage',
+            widgets_values: ['starter.png', 'image']
+          }
+        ]
+      }
+
+      expect(() =>
+        replaceTemplateImageInput(workflow, incompleteTemplate, {
+          filename: 'first-output.png'
+        })
+      ).toThrow('Template image input declaration is invalid')
+      expect(workflow.nodes[0].widgets_values).toEqual(['starter.png', 'image'])
+    }
+  )
 })

--- a/src/platform/workflow/templates/utils/templateWorkflowTransforms.test.ts
+++ b/src/platform/workflow/templates/utils/templateWorkflowTransforms.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from 'vitest'
 
 import type { TemplateInfo } from '../types/template'
-import { replaceTemplateImageInput } from './templateWorkflowTransforms'
+import {
+  acceptsTemplateImageInput,
+  replaceTemplateImageInput
+} from './templateWorkflowTransforms'
 
 const template: TemplateInfo = {
   name: 'image-template',
@@ -63,13 +66,30 @@ describe('template workflow transforms', () => {
     ).toThrow('Expected one matching template widget value')
   })
 
+  it('rejects an output with no filename', () => {
+    const workflow = {
+      nodes: [
+        {
+          id: 2,
+          type: 'LoadImage',
+          widgets_values: ['starter.png', 'image']
+        }
+      ]
+    }
+
+    expect(() =>
+      replaceTemplateImageInput(workflow, template, { type: 'output' })
+    ).toThrow('Image output has no filename')
+    expect(workflow.nodes[0].widgets_values).toEqual(['starter.png', 'image'])
+  })
+
   it.for(['nodeId', 'nodeType', 'file'] as const)(
     'rejects an image input without %s',
     (field) => {
       const incompleteTemplate = structuredClone(template)
       const input = incompleteTemplate.io?.inputs?.[0]
       if (!input) throw new Error('Expected template image input')
-      Object.defineProperty(input, field, { value: undefined })
+      input[field] = undefined
       const workflow = {
         nodes: [
           {
@@ -80,6 +100,7 @@ describe('template workflow transforms', () => {
         ]
       }
 
+      expect(acceptsTemplateImageInput(incompleteTemplate)).toBe(false)
       expect(() =>
         replaceTemplateImageInput(workflow, incompleteTemplate, {
           filename: 'first-output.png'
@@ -88,4 +109,11 @@ describe('template workflow transforms', () => {
       expect(workflow.nodes[0].widgets_values).toEqual(['starter.png', 'image'])
     }
   )
+
+  it('reports a template with no declared image input as unusable', () => {
+    expect(acceptsTemplateImageInput(template)).toBe(true)
+    expect(acceptsTemplateImageInput({ ...template, io: undefined })).toBe(
+      false
+    )
+  })
 })

--- a/src/platform/workflow/templates/utils/templateWorkflowTransforms.ts
+++ b/src/platform/workflow/templates/utils/templateWorkflowTransforms.ts
@@ -18,40 +18,33 @@ interface NodeSelector {
   nodeType: string
 }
 
+/**
+ * Both serializations of `widgets_values` — the positional array and the
+ * name-keyed object — replace the one entry holding the template's declared
+ * file, so they differ only in how the entries are taken apart and put back.
+ */
 function replaceWidgetValue(
   widgetValues: unknown,
   currentValue: unknown,
   nextValue: unknown
 ): unknown {
-  if (Array.isArray(widgetValues)) {
-    const matchingIndexes = widgetValues.flatMap((value, index) =>
-      value === currentValue ? [index] : []
-    )
-    if (matchingIndexes.length !== 1)
-      throw new Error('Expected one matching template widget value')
+  const isArray = Array.isArray(widgetValues)
+  if (!isArray && (typeof widgetValues !== 'object' || widgetValues === null))
+    throw new Error('Template input node has no configurable widgets')
 
-    return widgetValues.map((value, index) =>
-      index === matchingIndexes[0] ? nextValue : value
-    )
-  }
+  const entries = Object.entries(widgetValues)
+  const matches = entries.filter(([, value]) => value === currentValue)
+  if (matches.length !== 1)
+    throw new Error('Expected one matching template widget value')
 
-  if (typeof widgetValues === 'object' && widgetValues !== null) {
-    const entries = Object.entries(widgetValues)
-    const matchingKeys = entries.flatMap(([key, value]) =>
-      value === currentValue ? [key] : []
-    )
-    if (matchingKeys.length !== 1)
-      throw new Error('Expected one matching template widget value')
-
-    return Object.fromEntries(
-      entries.map(([key, value]) => [
-        key,
-        key === matchingKeys[0] ? nextValue : value
-      ])
-    )
-  }
-
-  throw new Error('Template input node has no configurable widgets')
+  const [matchedKey] = matches[0]
+  const replaced = entries.map(([key, value]) => [
+    key,
+    key === matchedKey ? nextValue : value
+  ])
+  return isArray
+    ? replaced.map(([, value]) => value)
+    : Object.fromEntries(replaced)
 }
 
 function replaceNodeWidgetValue<T extends TransformableWorkflow>(
@@ -60,6 +53,11 @@ function replaceNodeWidgetValue<T extends TransformableWorkflow>(
   currentValue: unknown,
   nextValue: unknown
 ): T {
+  // The fetched JSON is unvalidated, so say what is wrong with it rather than
+  // letting a served error page reach `.filter` as an anonymous TypeError.
+  if (!Array.isArray(workflow.nodes))
+    throw new Error('Template workflow has no nodes')
+
   const matchingNodes = workflow.nodes.filter(
     (node) =>
       node.type === selector.nodeType &&

--- a/src/platform/workflow/templates/utils/templateWorkflowTransforms.ts
+++ b/src/platform/workflow/templates/utils/templateWorkflowTransforms.ts
@@ -1,7 +1,7 @@
 import type { ResultItem } from '@/schemas/apiSchema'
 import { createAnnotatedPath } from '@/utils/createAnnotatedPath'
 
-import type { TemplateInfo } from '../types/template'
+import type { TemplateInfo, TemplateMediaInfo } from '../types/template'
 
 interface TransformableNode {
   id: string | number
@@ -86,6 +86,38 @@ function replaceNodeWidgetValue<T extends TransformableWorkflow>(
   }
 }
 
+interface SeedableMediaInput extends NodeSelector {
+  file: string
+}
+
+function findImageInput(template: TemplateInfo) {
+  return template.io?.inputs?.find(({ mediaType }) => mediaType === 'image')
+}
+
+function isSeedable(input: TemplateMediaInfo): input is SeedableMediaInput {
+  const { nodeId, nodeType, file } = input
+  const hasNodeId =
+    typeof nodeId === 'number' ? Number.isFinite(nodeId) : Boolean(nodeId)
+  return hasNodeId && Boolean(nodeType) && Boolean(file)
+}
+
+/**
+ * Whether `replaceTemplateImageInput` has enough metadata to seed this
+ * template, so a caller can hide an action rather than fail it on click.
+ */
+export function acceptsTemplateImageInput(template: TemplateInfo): boolean {
+  const input = findImageInput(template)
+  return input !== undefined && isSeedable(input)
+}
+
+/**
+ * Continues `image` into `template` by rewriting the widget value its declared
+ * image input currently holds.
+ *
+ * The declared node has to live in `workflow.nodes`: a node nested inside
+ * `definitions.subgraphs` is not reachable from `io.inputs`, and a template
+ * that declares one throws here rather than loading unseeded.
+ */
 export function replaceTemplateImageInput<T extends TransformableWorkflow>(
   workflow: T,
   template: TemplateInfo,
@@ -93,20 +125,9 @@ export function replaceTemplateImageInput<T extends TransformableWorkflow>(
 ): T {
   if (!image.filename) throw new Error('Image output has no filename')
 
-  const input = template.io?.inputs?.find(
-    ({ mediaType }) => mediaType === 'image'
-  )
+  const input = findImageInput(template)
   if (!input) throw new Error('Template has no declared image input')
-  const hasNodeId =
-    (typeof input.nodeId === 'number' && Number.isFinite(input.nodeId)) ||
-    (typeof input.nodeId === 'string' && input.nodeId.length > 0)
-  if (
-    !hasNodeId ||
-    typeof input.nodeType !== 'string' ||
-    input.nodeType.length === 0 ||
-    typeof input.file !== 'string' ||
-    input.file.length === 0
-  )
+  if (!isSeedable(input))
     throw new Error('Template image input declaration is invalid')
 
   return replaceNodeWidgetValue(

--- a/src/platform/workflow/templates/utils/templateWorkflowTransforms.ts
+++ b/src/platform/workflow/templates/utils/templateWorkflowTransforms.ts
@@ -14,7 +14,7 @@ interface TransformableWorkflow {
 }
 
 interface NodeSelector {
-  nodeId?: string | number
+  nodeId: string | number
   nodeType: string
 }
 
@@ -63,8 +63,7 @@ function replaceNodeWidgetValue<T extends TransformableWorkflow>(
   const matchingNodes = workflow.nodes.filter(
     (node) =>
       node.type === selector.nodeType &&
-      (selector.nodeId === undefined ||
-        String(node.id) === String(selector.nodeId))
+      String(node.id) === String(selector.nodeId)
   )
   if (matchingNodes.length !== 1)
     throw new Error('Expected one matching template node')
@@ -98,6 +97,17 @@ export function replaceTemplateImageInput<T extends TransformableWorkflow>(
     ({ mediaType }) => mediaType === 'image'
   )
   if (!input) throw new Error('Template has no declared image input')
+  const hasNodeId =
+    (typeof input.nodeId === 'number' && Number.isFinite(input.nodeId)) ||
+    (typeof input.nodeId === 'string' && input.nodeId.length > 0)
+  if (
+    !hasNodeId ||
+    typeof input.nodeType !== 'string' ||
+    input.nodeType.length === 0 ||
+    typeof input.file !== 'string' ||
+    input.file.length === 0
+  )
+    throw new Error('Template image input declaration is invalid')
 
   return replaceNodeWidgetValue(
     workflow,
@@ -105,10 +115,4 @@ export function replaceTemplateImageInput<T extends TransformableWorkflow>(
     input.file,
     createAnnotatedPath({ ...image, type: image.type ?? 'output' })
   )
-}
-
-export function replaceUniqueTemplateWidgetValue<
-  T extends TransformableWorkflow
->(workflow: T, nodeType: string, currentValue: unknown, nextValue: unknown): T {
-  return replaceNodeWidgetValue(workflow, { nodeType }, currentValue, nextValue)
 }

--- a/src/platform/workflow/templates/utils/templateWorkflowTransforms.ts
+++ b/src/platform/workflow/templates/utils/templateWorkflowTransforms.ts
@@ -1,0 +1,114 @@
+import type { ResultItem } from '@/schemas/apiSchema'
+import { createAnnotatedPath } from '@/utils/createAnnotatedPath'
+
+import type { TemplateInfo } from '../types/template'
+
+interface TransformableNode {
+  id: string | number
+  type: string
+  widgets_values?: unknown
+}
+
+interface TransformableWorkflow {
+  nodes: TransformableNode[]
+}
+
+interface NodeSelector {
+  nodeId?: string | number
+  nodeType: string
+}
+
+function replaceWidgetValue(
+  widgetValues: unknown,
+  currentValue: unknown,
+  nextValue: unknown
+): unknown {
+  if (Array.isArray(widgetValues)) {
+    const matchingIndexes = widgetValues.flatMap((value, index) =>
+      value === currentValue ? [index] : []
+    )
+    if (matchingIndexes.length !== 1)
+      throw new Error('Expected one matching template widget value')
+
+    return widgetValues.map((value, index) =>
+      index === matchingIndexes[0] ? nextValue : value
+    )
+  }
+
+  if (typeof widgetValues === 'object' && widgetValues !== null) {
+    const entries = Object.entries(widgetValues)
+    const matchingKeys = entries.flatMap(([key, value]) =>
+      value === currentValue ? [key] : []
+    )
+    if (matchingKeys.length !== 1)
+      throw new Error('Expected one matching template widget value')
+
+    return Object.fromEntries(
+      entries.map(([key, value]) => [
+        key,
+        key === matchingKeys[0] ? nextValue : value
+      ])
+    )
+  }
+
+  throw new Error('Template input node has no configurable widgets')
+}
+
+function replaceNodeWidgetValue<T extends TransformableWorkflow>(
+  workflow: T,
+  selector: NodeSelector,
+  currentValue: unknown,
+  nextValue: unknown
+): T {
+  const matchingNodes = workflow.nodes.filter(
+    (node) =>
+      node.type === selector.nodeType &&
+      (selector.nodeId === undefined ||
+        String(node.id) === String(selector.nodeId))
+  )
+  if (matchingNodes.length !== 1)
+    throw new Error('Expected one matching template node')
+
+  const target = matchingNodes[0]
+  return {
+    ...workflow,
+    nodes: workflow.nodes.map((node) =>
+      node === target
+        ? {
+            ...node,
+            widgets_values: replaceWidgetValue(
+              node.widgets_values,
+              currentValue,
+              nextValue
+            )
+          }
+        : node
+    )
+  }
+}
+
+export function replaceTemplateImageInput<T extends TransformableWorkflow>(
+  workflow: T,
+  template: TemplateInfo,
+  image: ResultItem
+): T {
+  if (!image.filename) throw new Error('Image output has no filename')
+
+  const input = template.io?.inputs?.find(
+    ({ mediaType }) => mediaType === 'image'
+  )
+  if (!input) throw new Error('Template has no declared image input')
+
+  return replaceNodeWidgetValue(
+    workflow,
+    { nodeId: input.nodeId, nodeType: input.nodeType },
+    input.file,
+    createAnnotatedPath({ ...image, type: image.type ?? 'output' })
+  )
+}
+
+export function replaceUniqueTemplateWidgetValue<
+  T extends TransformableWorkflow
+>(workflow: T, nodeType: string, currentValue: unknown, nextValue: unknown): T {
+  return replaceNodeWidgetValue(workflow, { nodeType }, currentValue, nextValue)
+}

--- a/src/renderer/extensions/firstRunTour/nudge/FirstRunTourNudge.test.ts
+++ b/src/renderer/extensions/firstRunTour/nudge/FirstRunTourNudge.test.ts
@@ -13,6 +13,26 @@ const FIRST_OUTPUT = {
   subfolder: 'tour',
   type: 'output' as const
 }
+type SuggestionId = 'animate' | 'upscale' | 'restyle'
+
+const SUGGESTION_TITLES: Record<SuggestionId, string> = {
+  animate: enMessages.onboardingCoachmarks.firstRun.nudge.animate.title,
+  upscale: enMessages.onboardingCoachmarks.firstRun.nudge.upscale.title,
+  restyle: enMessages.onboardingCoachmarks.firstRun.nudge.restyle.title
+}
+
+type Deferred<T> = {
+  promise: Promise<T>
+  resolve: (value: T) => void
+}
+
+function createDeferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((resolveFn) => {
+    resolve = resolveFn
+  })
+  return { promise, resolve }
+}
 
 const mocks = await vi.hoisted(async () => {
   const { ref, shallowRef } = await import('vue')
@@ -89,6 +109,12 @@ function nudge() {
   return screen.queryByTestId('first-run-nudge')
 }
 
+function suggestionButton(id: SuggestionId) {
+  return screen.getByRole('button', {
+    name: new RegExp(SUGGESTION_TITLES[id], 'i')
+  })
+}
+
 async function showNudge() {
   mocks.nudgeArmed.value = true
   renderNudge()
@@ -153,48 +179,72 @@ describe('FirstRunTourNudge', () => {
   it.for([
     {
       id: 'animate',
-      templateId: 'video_wan2_2_14B_i2v'
+      templateId: 'video_minimax_h3_i2v_continuation'
     },
     {
       id: 'upscale',
-      templateId: 'utility_interpolation_image_upscale'
+      templateId: 'utility_interpolation_image_upscale_4x'
     },
     {
       id: 'restyle',
-      templateId: 'api_google_nano_banana2_image_edit'
+      templateId: 'api_google_nano_banana2_image_edit_continuation'
     }
-  ])('continues the first output through $id', async ({ id, templateId }) => {
+  ] as const)(
+    'continues the first output through $id',
+    async ({ id, templateId }) => {
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+      await showNudge()
+
+      await user.click(suggestionButton(id))
+
+      expect(mocks.loadTemplates).toHaveBeenCalled()
+      expect(mocks.loadWorkflowTemplate).toHaveBeenCalledWith(
+        templateId,
+        'default',
+        { input: FIRST_OUTPUT }
+      )
+      expect(mocks.dismissNudge).toHaveBeenCalled()
+    }
+  )
+
+  it('exposes the pending continuation and blocks competing actions', async () => {
     const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+    const templatesLoaded = createDeferred<boolean>()
+    mocks.loadTemplates.mockReturnValueOnce(templatesLoaded.promise)
     await showNudge()
 
-    await user.click(screen.getByTestId(`first-run-nudge-${id}`))
+    const animate = suggestionButton('animate')
+    await user.click(animate)
 
-    expect(mocks.loadTemplates).toHaveBeenCalled()
-    expect(mocks.loadWorkflowTemplate).toHaveBeenCalledWith(
-      templateId,
-      'default',
-      expect.objectContaining({ input: FIRST_OUTPUT })
-    )
-    expect(mocks.dismissNudge).toHaveBeenCalled()
+    expect(animate).toHaveAttribute('aria-busy', 'true')
+    expect(animate).toBeDisabled()
+    expect(suggestionButton('upscale')).toBeDisabled()
+    expect(suggestionButton('restyle')).toBeDisabled()
+    expect(
+      screen.getByRole('button', {
+        name: enMessages.onboardingCoachmarks.firstRun.nudge.explore
+      })
+    ).toBeDisabled()
+
+    templatesLoaded.resolve(true)
+    await vi.waitFor(() => {
+      expect(mocks.loadWorkflowTemplate).toHaveBeenCalled()
+      expect(mocks.dismissNudge).toHaveBeenCalled()
+    })
   })
 
-  it('configures the upscale action for 4x', async () => {
+  it('keeps the card open when the template catalog fails to load', async () => {
     const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+    mocks.loadTemplates.mockResolvedValue(false)
     await showNudge()
 
-    await user.click(screen.getByTestId('first-run-nudge-upscale'))
-    const options = mocks.loadWorkflowTemplate.mock.calls[0][2]
-    const transformed = options.transformWorkflow({
-      nodes: [
-        {
-          id: 3,
-          type: 'ImageScaleBy',
-          widgets_values: ['lanczos', 2]
-        }
-      ]
-    })
+    await user.click(suggestionButton('animate'))
 
-    expect(transformed.nodes[0].widgets_values).toEqual(['lanczos', 4])
+    expect(mocks.loadWorkflowTemplate).not.toHaveBeenCalled()
+    expect(mocks.dismissNudge).not.toHaveBeenCalled()
+    expect(mocks.addToast).toHaveBeenCalledWith(
+      expect.objectContaining({ severity: 'error' })
+    )
   })
 
   it('keeps the card open and reports a template load failure', async () => {
@@ -202,7 +252,7 @@ describe('FirstRunTourNudge', () => {
     mocks.loadWorkflowTemplate.mockResolvedValue(false)
     await showNudge()
 
-    await user.click(screen.getByTestId('first-run-nudge-animate'))
+    await user.click(suggestionButton('animate'))
 
     expect(mocks.dismissNudge).not.toHaveBeenCalled()
     expect(mocks.addToast).toHaveBeenCalledWith(
@@ -214,7 +264,11 @@ describe('FirstRunTourNudge', () => {
     const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
     await showNudge()
 
-    await user.click(screen.getByTestId('first-run-nudge-explore'))
+    await user.click(
+      screen.getByRole('button', {
+        name: enMessages.onboardingCoachmarks.firstRun.nudge.explore
+      })
+    )
 
     expect(mocks.showTemplates).toHaveBeenCalledWith('first_run_nudge')
     expect(mocks.trackOnboardingTour).toHaveBeenCalledWith(

--- a/src/renderer/extensions/firstRunTour/nudge/FirstRunTourNudge.test.ts
+++ b/src/renderer/extensions/firstRunTour/nudge/FirstRunTourNudge.test.ts
@@ -8,24 +8,38 @@ import enMessages from '@/locales/en/main.json' with { type: 'json' }
 import FirstRunTourNudge from './FirstRunTourNudge.vue'
 
 const APPEAR_DELAY_MS = 1500
+const FIRST_OUTPUT = {
+  filename: 'first-output.png',
+  subfolder: 'tour',
+  type: 'output' as const
+}
 
 const mocks = await vi.hoisted(async () => {
-  const { ref } = await import('vue')
+  const { ref, shallowRef } = await import('vue')
   return {
     nudgeArmed: ref(false),
+    nudgeOutput: shallowRef({
+      filename: 'first-output.png',
+      subfolder: 'tour',
+      type: 'output' as const
+    }),
     tourWasCompleted: ref(true),
     openDialogs: ref<string[]>([]),
     dismissNudge: vi.fn(() => {
       mocks.nudgeArmed.value = false
     }),
     showTemplates: vi.fn(),
-    trackOnboardingTour: vi.fn()
+    trackOnboardingTour: vi.fn(),
+    loadTemplates: vi.fn().mockResolvedValue(true),
+    loadWorkflowTemplate: vi.fn().mockResolvedValue(true),
+    addToast: vi.fn()
   }
 })
 
 vi.mock('../tour/useFirstRunTourController', () => ({
   useFirstRunTourController: () => ({
     nudgeArmed: mocks.nudgeArmed,
+    nudgeOutput: mocks.nudgeOutput,
     tourWasCompleted: mocks.tourWasCompleted,
     dismissNudge: mocks.dismissNudge
   })
@@ -43,6 +57,20 @@ vi.mock('@/composables/useWorkflowTemplateSelectorDialog', () => ({
   useWorkflowTemplateSelectorDialog: () => ({ show: mocks.showTemplates })
 }))
 
+vi.mock(
+  '@/platform/workflow/templates/composables/useTemplateWorkflows',
+  () => ({
+    useTemplateWorkflows: () => ({
+      loadTemplates: mocks.loadTemplates,
+      loadWorkflowTemplate: mocks.loadWorkflowTemplate
+    })
+  })
+)
+
+vi.mock('primevue/usetoast', () => ({
+  useToast: () => ({ add: mocks.addToast })
+}))
+
 vi.mock('@/platform/telemetry', () => ({
   useTelemetry: () => ({ trackOnboardingTour: mocks.trackOnboardingTour })
 }))
@@ -57,196 +85,142 @@ function renderNudge() {
   return render(FirstRunTourNudge, { global: { plugins: [i18n] } })
 }
 
-const nudgeCopy = enMessages.onboardingCoachmarks.firstRun.nudge
-
 function nudge() {
   return screen.queryByTestId('first-run-nudge')
+}
+
+async function showNudge() {
+  mocks.nudgeArmed.value = true
+  renderNudge()
+  await vi.advanceTimersByTimeAsync(APPEAR_DELAY_MS)
 }
 
 describe('FirstRunTourNudge', () => {
   beforeEach(() => {
     mocks.nudgeArmed.value = false
+    mocks.nudgeOutput.value = FIRST_OUTPUT
     mocks.tourWasCompleted.value = true
     mocks.openDialogs.value = []
+    mocks.loadTemplates.mockResolvedValue(true)
+    mocks.loadWorkflowTemplate.mockResolvedValue(true)
   })
 
-  it('shows a nudge that came due before it mounted', async () => {
+  it('appears after the result has had time to land', async () => {
     mocks.nudgeArmed.value = true
     renderNudge()
 
     await vi.advanceTimersByTimeAsync(APPEAR_DELAY_MS - 1)
-    expect(
-      nudge(),
-      'arriving on top of the result the user just made buries it'
-    ).toBeNull()
+    expect(nudge()).toBeNull()
 
     await vi.advanceTimersByTimeAsync(1)
 
     expect(
-      nudge(),
-      'a nudge armed before this mounted still has to appear'
-    ).not.toBeNull()
+      screen.getByText(enMessages.onboardingCoachmarks.firstRun.nudge.title)
+    ).toBeTruthy()
     expect(mocks.trackOnboardingTour).toHaveBeenCalledWith('nudge_shown', {
       tour: 'firstRun',
       tour_completed: true
     })
   })
 
-  it('waits out a dialog that is already open', async () => {
+  it('waits until the modal stack is clear', async () => {
     mocks.nudgeArmed.value = true
     mocks.openDialogs.value = ['some-dialog']
     renderNudge()
 
     await vi.advanceTimersByTimeAsync(APPEAR_DELAY_MS)
-    expect(
-      nudge(),
-      'the nudge sits below the modal stack, so under a dialog it is invisible'
-    ).toBeNull()
+    expect(nudge()).toBeNull()
 
     mocks.openDialogs.value = []
     await vi.advanceTimersByTimeAsync(APPEAR_DELAY_MS)
 
-    expect(
-      nudge(),
-      'the dialog was already open at mount, so no open-to-closed edge ever fired'
-    ).not.toBeNull()
+    expect(nudge()).not.toBeNull()
   })
 
-  it('waits out a dialog that opens while it is still on its way', async () => {
-    mocks.nudgeArmed.value = true
-    renderNudge()
-
-    await vi.advanceTimersByTimeAsync(APPEAR_DELAY_MS - 500)
-    mocks.openDialogs.value = ['some-dialog']
-    await vi.advanceTimersByTimeAsync(500 + APPEAR_DELAY_MS)
-
-    expect(
-      nudge(),
-      'a nudge that came due behind a dialog would land on top of the modal'
-    ).toBeNull()
-    expect(
-      mocks.trackOnboardingTour,
-      'a nudge nobody can see has not been shown'
-    ).not.toHaveBeenCalledWith('nudge_shown', expect.anything())
-  })
-
-  it('reports one nudge once, however often it comes and goes', async () => {
-    mocks.nudgeArmed.value = true
-    renderNudge()
-    await vi.advanceTimersByTimeAsync(APPEAR_DELAY_MS)
-
-    mocks.openDialogs.value = ['some-dialog']
-    await vi.advanceTimersByTimeAsync(APPEAR_DELAY_MS)
-    mocks.openDialogs.value = []
-    await vi.advanceTimersByTimeAsync(APPEAR_DELAY_MS)
-
-    const shown = mocks.trackOnboardingTour.mock.calls.filter(
-      ([stage]) => stage === 'nudge_shown'
-    )
-    expect(
-      shown,
-      'the funnel counts nudges, so a reappearance is not a second one'
-    ).toHaveLength(1)
-  })
-
-  it('congratulates a tour the user walked to the end', async () => {
-    mocks.tourWasCompleted.value = true
-    mocks.nudgeArmed.value = true
-    renderNudge()
-    await vi.advanceTimersByTimeAsync(APPEAR_DELAY_MS)
-
-    expect(screen.getByText(nudgeCopy.ran.title)).toBeTruthy()
-  })
-
-  it('offers no congratulation for a tour nobody finished', async () => {
-    mocks.tourWasCompleted.value = false
-    mocks.nudgeArmed.value = true
-    renderNudge()
-    await vi.advanceTimersByTimeAsync(APPEAR_DELAY_MS)
-
-    expect(
-      screen.queryByText(nudgeCopy.ran.title),
-      'a user who skipped, was cut off or saw no tour made no first result'
-    ).toBeNull()
-    expect(screen.getByText(nudgeCopy.noTour.title)).toBeTruthy()
-  })
-
-  it.for([{ finished: true }, { finished: false }])(
-    'appears whether or not the tour finished ($finished)',
-    async ({ finished }) => {
-      mocks.tourWasCompleted.value = finished
-      mocks.nudgeArmed.value = true
-      renderNudge()
-      await vi.advanceTimersByTimeAsync(APPEAR_DELAY_MS)
-
-      expect(
-        nudge(),
-        'the copy is all that the ending changes; the way forward is offered either way'
-      ).not.toBeNull()
-    }
-  )
-
-  it('stays gone once the user closes it', async () => {
+  it('closes from the full close control and Escape', async () => {
     const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
-    mocks.nudgeArmed.value = true
-    renderNudge()
-    await vi.advanceTimersByTimeAsync(APPEAR_DELAY_MS)
+    await showNudge()
 
     await user.click(screen.getByRole('button', { name: enMessages.g.close }))
-
     expect(mocks.dismissNudge).toHaveBeenCalled()
-    expect(nudge()).toBeNull()
+
+    mocks.nudgeArmed.value = true
+    await vi.advanceTimersByTimeAsync(APPEAR_DELAY_MS)
+    await user.keyboard('{Escape}')
+    expect(mocks.dismissNudge).toHaveBeenCalledTimes(2)
   })
 
-  it('stays gone once the user waves it away', async () => {
+  it.for([
+    {
+      id: 'animate',
+      templateId: 'video_wan2_2_14B_i2v'
+    },
+    {
+      id: 'upscale',
+      templateId: 'utility_interpolation_image_upscale'
+    },
+    {
+      id: 'restyle',
+      templateId: 'api_google_nano_banana2_image_edit'
+    }
+  ])('continues the first output through $id', async ({ id, templateId }) => {
     const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
-    mocks.nudgeArmed.value = true
-    renderNudge()
-    await vi.advanceTimersByTimeAsync(APPEAR_DELAY_MS)
+    await showNudge()
 
-    await user.click(screen.getByText(nudgeCopy.dismiss))
+    await user.click(screen.getByTestId(`first-run-nudge-${id}`))
 
-    expect(nudge()).toBeNull()
+    expect(mocks.loadTemplates).toHaveBeenCalled()
+    expect(mocks.loadWorkflowTemplate).toHaveBeenCalledWith(
+      templateId,
+      'default',
+      expect.objectContaining({ input: FIRST_OUTPUT })
+    )
+    expect(mocks.dismissNudge).toHaveBeenCalled()
   })
 
-  it('takes the user to the templates it is pointing at', async () => {
+  it('configures the upscale action for 4x', async () => {
     const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
-    mocks.nudgeArmed.value = true
-    renderNudge()
-    await vi.advanceTimersByTimeAsync(APPEAR_DELAY_MS)
+    await showNudge()
+
+    await user.click(screen.getByTestId('first-run-nudge-upscale'))
+    const options = mocks.loadWorkflowTemplate.mock.calls[0][2]
+    const transformed = options.transformWorkflow({
+      nodes: [
+        {
+          id: 3,
+          type: 'ImageScaleBy',
+          widgets_values: ['lanczos', 2]
+        }
+      ]
+    })
+
+    expect(transformed.nodes[0].widgets_values).toEqual(['lanczos', 4])
+  })
+
+  it('keeps the card open and reports a template load failure', async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+    mocks.loadWorkflowTemplate.mockResolvedValue(false)
+    await showNudge()
+
+    await user.click(screen.getByTestId('first-run-nudge-animate'))
+
+    expect(mocks.dismissNudge).not.toHaveBeenCalled()
+    expect(mocks.addToast).toHaveBeenCalledWith(
+      expect.objectContaining({ severity: 'error' })
+    )
+  })
+
+  it('opens the existing template browser from the footer', async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+    await showNudge()
 
     await user.click(screen.getByTestId('first-run-nudge-explore'))
 
-    expect(
-      mocks.showTemplates,
-      'the source is what separates a nudge conversion from a command-palette one, and it defaults to command'
-    ).toHaveBeenCalledWith('first_run_nudge')
-    expect(mocks.dismissNudge).toHaveBeenCalled()
+    expect(mocks.showTemplates).toHaveBeenCalledWith('first_run_nudge')
     expect(mocks.trackOnboardingTour).toHaveBeenCalledWith(
       'explore_templates_clicked',
       { tour: 'firstRun', tour_completed: true }
     )
-  })
-
-  it('separates a conversion from a completed tour from one that never ran', async () => {
-    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
-    mocks.tourWasCompleted.value = false
-    mocks.nudgeArmed.value = true
-    renderNudge()
-    await vi.advanceTimersByTimeAsync(APPEAR_DELAY_MS)
-
-    await user.click(screen.getByTestId('first-run-nudge-explore'))
-
-    // Both events carry it, so the funnel can be read end to end: without it
-    // a conversion from a finished tour and one from a tour that never
-    // started are indistinguishable.
-    expect(mocks.trackOnboardingTour).toHaveBeenCalledWith('nudge_shown', {
-      tour: 'firstRun',
-      tour_completed: false
-    })
-    expect(mocks.trackOnboardingTour).toHaveBeenCalledWith(
-      'explore_templates_clicked',
-      { tour: 'firstRun', tour_completed: false }
-    )
+    expect(mocks.dismissNudge).toHaveBeenCalled()
   })
 })

--- a/src/renderer/extensions/firstRunTour/nudge/FirstRunTourNudge.test.ts
+++ b/src/renderer/extensions/firstRunTour/nudge/FirstRunTourNudge.test.ts
@@ -1,6 +1,7 @@
 import userEvent from '@testing-library/user-event'
 import { render, screen } from '@testing-library/vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { nextTick } from 'vue'
 import { createI18n } from 'vue-i18n'
 
 import enMessages from '@/locales/en/main.json' with { type: 'json' }
@@ -8,6 +9,7 @@ import enMessages from '@/locales/en/main.json' with { type: 'json' }
 import FirstRunTourNudge from './FirstRunTourNudge.vue'
 
 const APPEAR_DELAY_MS = 1500
+const CATALOG_WAIT_MS = 3000
 const FIRST_OUTPUT = {
   filename: 'first-output.png',
   subfolder: 'tour',
@@ -257,6 +259,80 @@ describe('FirstRunTourNudge', () => {
       expect(mocks.dismissNudge).toHaveBeenCalled()
     }
   )
+
+  it('waits for the catalog rather than rewriting itself under the user', async () => {
+    const catalogLoaded = createDeferred<boolean>()
+    mocks.catalog.value = []
+    mocks.loadTemplates.mockReturnValueOnce(catalogLoaded.promise)
+    mocks.nudgeArmed.value = true
+    renderNudge()
+
+    await vi.advanceTimersByTimeAsync(APPEAR_DELAY_MS)
+    expect(
+      nudge(),
+      'the fallback copy would be shown, then rewritten into the continuations'
+    ).toBeNull()
+
+    mocks.catalog.value = CATALOG_TEMPLATE_IDS
+    catalogLoaded.resolve(true)
+    await vi.waitFor(() => {
+      expect(nudge()).not.toBeNull()
+    })
+
+    expect(suggestionButton('animate')).toBeTruthy()
+    expect(mocks.trackOnboardingTour).toHaveBeenCalledWith('nudge_shown', {
+      tour: 'firstRun',
+      suggestion_count: 3
+    })
+  })
+
+  it('gives up on a stalled catalog rather than withholding the card', async () => {
+    mocks.catalog.value = []
+    mocks.loadTemplates.mockReturnValueOnce(createDeferred<boolean>().promise)
+    mocks.nudgeArmed.value = true
+    renderNudge()
+
+    await vi.advanceTimersByTimeAsync(CATALOG_WAIT_MS)
+
+    expect(
+      screen.getByText(
+        enMessages.onboardingCoachmarks.firstRun.nudge.fallback.title
+      ),
+      'the way forward is what the card is for (#14144)'
+    ).toBeTruthy()
+    expect(mocks.trackOnboardingTour).toHaveBeenCalledWith('nudge_shown', {
+      tour: 'firstRun',
+      suggestion_count: 0
+    })
+  })
+
+  it('reports one nudge per tour, however often it comes and goes', async () => {
+    await showNudge()
+
+    mocks.openDialogs.value = ['some-dialog']
+    await vi.advanceTimersByTimeAsync(APPEAR_DELAY_MS)
+    mocks.openDialogs.value = []
+    await vi.advanceTimersByTimeAsync(APPEAR_DELAY_MS)
+
+    const shown = () =>
+      mocks.trackOnboardingTour.mock.calls.filter(
+        ([stage]) => stage === 'nudge_shown'
+      )
+    expect(
+      shown(),
+      'the funnel counts nudges, so a reappearance is not a second one'
+    ).toHaveLength(1)
+
+    mocks.nudgeArmed.value = false
+    await nextTick()
+    mocks.nudgeArmed.value = true
+    await vi.advanceTimersByTimeAsync(APPEAR_DELAY_MS)
+
+    expect(
+      shown(),
+      'a second tour ends in a second nudge, which the funnel has to see'
+    ).toHaveLength(2)
+  })
 
   it('offers only the continuations the install actually serves', async () => {
     mocks.catalog.value = ['utility_seedvr2_7b_int8_upscale_image']

--- a/src/renderer/extensions/firstRunTour/nudge/FirstRunTourNudge.test.ts
+++ b/src/renderer/extensions/firstRunTour/nudge/FirstRunTourNudge.test.ts
@@ -286,9 +286,10 @@ describe('FirstRunTourNudge', () => {
     })
   })
 
-  it('gives up on a stalled catalog rather than withholding the card', async () => {
+  it('freezes the fallback when the catalog resolves after the deadline', async () => {
+    const catalogLoaded = createDeferred<boolean>()
     mocks.catalog.value = []
-    mocks.loadTemplates.mockReturnValueOnce(createDeferred<boolean>().promise)
+    mocks.loadTemplates.mockReturnValueOnce(catalogLoaded.promise)
     mocks.nudgeArmed.value = true
     renderNudge()
 
@@ -304,6 +305,24 @@ describe('FirstRunTourNudge', () => {
       tour: 'firstRun',
       suggestion_count: 0
     })
+
+    mocks.catalog.value = CATALOG_TEMPLATE_IDS
+    catalogLoaded.resolve(true)
+    await catalogLoaded.promise
+    await nextTick()
+
+    expect(
+      screen.queryByRole('button', {
+        name: new RegExp(SUGGESTION_TITLES.animate, 'i')
+      }),
+      'the catalog deadline already decided what the card showed and reported'
+    ).toBeNull()
+    expect(
+      screen.getByText(
+        enMessages.onboardingCoachmarks.firstRun.nudge.fallback.title
+      )
+    ).toBeTruthy()
+    expect(mocks.trackOnboardingTour).toHaveBeenCalledTimes(1)
   })
 
   it('reports one nudge per tour, however often it comes and goes', async () => {

--- a/src/renderer/extensions/firstRunTour/nudge/FirstRunTourNudge.test.ts
+++ b/src/renderer/extensions/firstRunTour/nudge/FirstRunTourNudge.test.ts
@@ -34,6 +34,32 @@ function createDeferred<T>(): Deferred<T> {
   return { promise, resolve }
 }
 
+const CATALOG_TEMPLATE_IDS = [
+  'video_minimax_h3_i2v_continuation',
+  'utility_seedvr2_7b_int8_upscale_image',
+  'api_google_nano_banana2_image_edit_continuation'
+]
+
+/** Stands in for what the install's template package actually serves. */
+function catalogEntry(name: string, withIo: boolean) {
+  return {
+    name,
+    sourceModule: 'default',
+    io: withIo
+      ? {
+          inputs: [
+            {
+              nodeId: 1,
+              nodeType: 'LoadImage',
+              file: 'starter.png',
+              mediaType: 'image'
+            }
+          ]
+        }
+      : undefined
+  }
+}
+
 const mocks = await vi.hoisted(async () => {
   const { ref, shallowRef } = await import('vue')
   return {
@@ -43,8 +69,9 @@ const mocks = await vi.hoisted(async () => {
       subfolder: 'tour',
       type: 'output' as const
     }),
-    tourWasCompleted: ref(true),
     openDialogs: ref<string[]>([]),
+    catalog: ref<string[]>([]),
+    catalogHasIo: ref(true),
     dismissNudge: vi.fn(() => {
       mocks.nudgeArmed.value = false
     }),
@@ -60,10 +87,21 @@ vi.mock('../tour/useFirstRunTourController', () => ({
   useFirstRunTourController: () => ({
     nudgeArmed: mocks.nudgeArmed,
     nudgeOutput: mocks.nudgeOutput,
-    tourWasCompleted: mocks.tourWasCompleted,
     dismissNudge: mocks.dismissNudge
   })
 }))
+
+vi.mock(
+  '@/platform/workflow/templates/repositories/workflowTemplatesStore',
+  () => ({
+    useWorkflowTemplatesStore: () => ({
+      getTemplateByName: (name: string) =>
+        mocks.catalog.value.includes(name)
+          ? catalogEntry(name, mocks.catalogHasIo.value)
+          : undefined
+    })
+  })
+)
 
 vi.mock('@/stores/dialogStore', () => ({
   useDialogStore: () => ({
@@ -125,8 +163,9 @@ describe('FirstRunTourNudge', () => {
   beforeEach(() => {
     mocks.nudgeArmed.value = false
     mocks.nudgeOutput.value = FIRST_OUTPUT
-    mocks.tourWasCompleted.value = true
     mocks.openDialogs.value = []
+    mocks.catalog.value = CATALOG_TEMPLATE_IDS
+    mocks.catalogHasIo.value = true
     mocks.loadTemplates.mockResolvedValue(true)
     mocks.loadWorkflowTemplate.mockResolvedValue(true)
   })
@@ -144,8 +183,7 @@ describe('FirstRunTourNudge', () => {
       screen.getByText(enMessages.onboardingCoachmarks.firstRun.nudge.title)
     ).toBeTruthy()
     expect(mocks.trackOnboardingTour).toHaveBeenCalledWith('nudge_shown', {
-      tour: 'firstRun',
-      tour_completed: true
+      tour: 'firstRun'
     })
   })
 
@@ -183,7 +221,7 @@ describe('FirstRunTourNudge', () => {
     },
     {
       id: 'upscale',
-      templateId: 'utility_interpolation_image_upscale_4x'
+      templateId: 'utility_seedvr2_7b_int8_upscale_image'
     },
     {
       id: 'restyle',
@@ -197,20 +235,54 @@ describe('FirstRunTourNudge', () => {
 
       await user.click(suggestionButton(id))
 
-      expect(mocks.loadTemplates).toHaveBeenCalled()
       expect(mocks.loadWorkflowTemplate).toHaveBeenCalledWith(
         templateId,
         'default',
         { input: FIRST_OUTPUT }
       )
+      expect(mocks.trackOnboardingTour).toHaveBeenCalledWith(
+        'nudge_suggestion_clicked',
+        { tour: 'firstRun', suggestion: id, loaded: true }
+      )
       expect(mocks.dismissNudge).toHaveBeenCalled()
     }
   )
 
+  it('offers only the continuations the install actually serves', async () => {
+    mocks.catalog.value = ['utility_seedvr2_7b_int8_upscale_image']
+    await showNudge()
+
+    expect(suggestionButton('upscale')).toBeTruthy()
+    expect(
+      screen.queryByRole('button', {
+        name: new RegExp(SUGGESTION_TITLES.animate, 'i')
+      }),
+      'this build knows the id, but the pinned template package does not serve it'
+    ).toBeNull()
+  })
+
+  it.for([
+    { named: 'serves none of them', catalog: [] as string[] },
+    {
+      named: 'serves them without the metadata to seed them',
+      catalog: CATALOG_TEMPLATE_IDS,
+      stripIo: true
+    }
+  ])('shows nothing when the install $named', async ({ catalog, stripIo }) => {
+    mocks.catalog.value = catalog
+    mocks.catalogHasIo.value = !stripIo
+    await showNudge()
+
+    expect(
+      nudge(),
+      'every action would be a dead end found by clicking it'
+    ).toBeNull()
+  })
+
   it('exposes the pending continuation and blocks competing actions', async () => {
     const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
-    const templatesLoaded = createDeferred<boolean>()
-    mocks.loadTemplates.mockReturnValueOnce(templatesLoaded.promise)
+    const workflowLoaded = createDeferred<boolean>()
+    mocks.loadWorkflowTemplate.mockReturnValueOnce(workflowLoaded.promise)
     await showNudge()
 
     const animate = suggestionButton('animate')
@@ -226,25 +298,10 @@ describe('FirstRunTourNudge', () => {
       })
     ).toBeDisabled()
 
-    templatesLoaded.resolve(true)
+    workflowLoaded.resolve(true)
     await vi.waitFor(() => {
-      expect(mocks.loadWorkflowTemplate).toHaveBeenCalled()
       expect(mocks.dismissNudge).toHaveBeenCalled()
     })
-  })
-
-  it('keeps the card open when the template catalog fails to load', async () => {
-    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
-    mocks.loadTemplates.mockResolvedValue(false)
-    await showNudge()
-
-    await user.click(suggestionButton('animate'))
-
-    expect(mocks.loadWorkflowTemplate).not.toHaveBeenCalled()
-    expect(mocks.dismissNudge).not.toHaveBeenCalled()
-    expect(mocks.addToast).toHaveBeenCalledWith(
-      expect.objectContaining({ severity: 'error' })
-    )
   })
 
   it('keeps the card open and reports a template load failure', async () => {
@@ -257,6 +314,10 @@ describe('FirstRunTourNudge', () => {
     expect(mocks.dismissNudge).not.toHaveBeenCalled()
     expect(mocks.addToast).toHaveBeenCalledWith(
       expect.objectContaining({ severity: 'error' })
+    )
+    expect(mocks.trackOnboardingTour).toHaveBeenCalledWith(
+      'nudge_suggestion_clicked',
+      { tour: 'firstRun', suggestion: 'animate', loaded: false }
     )
   })
 
@@ -273,7 +334,7 @@ describe('FirstRunTourNudge', () => {
     expect(mocks.showTemplates).toHaveBeenCalledWith('first_run_nudge')
     expect(mocks.trackOnboardingTour).toHaveBeenCalledWith(
       'explore_templates_clicked',
-      { tour: 'firstRun', tour_completed: true }
+      { tour: 'firstRun' }
     )
     expect(mocks.dismissNudge).toHaveBeenCalled()
   })

--- a/src/renderer/extensions/firstRunTour/nudge/FirstRunTourNudge.test.ts
+++ b/src/renderer/extensions/firstRunTour/nudge/FirstRunTourNudge.test.ts
@@ -64,10 +64,14 @@ const mocks = await vi.hoisted(async () => {
   const { ref, shallowRef } = await import('vue')
   return {
     nudgeArmed: ref(false),
-    nudgeOutput: shallowRef({
+    nudgeOutput: shallowRef<{
+      filename: string
+      subfolder: string
+      type: 'output'
+    } | null>({
       filename: 'first-output.png',
       subfolder: 'tour',
-      type: 'output' as const
+      type: 'output'
     }),
     openDialogs: ref<string[]>([]),
     catalog: ref<string[]>([]),
@@ -183,7 +187,8 @@ describe('FirstRunTourNudge', () => {
       screen.getByText(enMessages.onboardingCoachmarks.firstRun.nudge.title)
     ).toBeTruthy()
     expect(mocks.trackOnboardingTour).toHaveBeenCalledWith('nudge_shown', {
-      tour: 'firstRun'
+      tour: 'firstRun',
+      suggestion_count: 3
     })
   })
 
@@ -242,7 +247,12 @@ describe('FirstRunTourNudge', () => {
       )
       expect(mocks.trackOnboardingTour).toHaveBeenCalledWith(
         'nudge_suggestion_clicked',
-        { tour: 'firstRun', suggestion: id, loaded: true }
+        {
+          tour: 'firstRun',
+          suggestion_count: 3,
+          suggestion: id,
+          loaded: true
+        }
       )
       expect(mocks.dismissNudge).toHaveBeenCalled()
     }
@@ -268,15 +278,66 @@ describe('FirstRunTourNudge', () => {
       catalog: CATALOG_TEMPLATE_IDS,
       stripIo: true
     }
-  ])('shows nothing when the install $named', async ({ catalog, stripIo }) => {
-    mocks.catalog.value = catalog
-    mocks.catalogHasIo.value = !stripIo
+  ])(
+    'falls back to the template browser when the install $named',
+    async ({ catalog, stripIo }) => {
+      mocks.catalog.value = catalog
+      mocks.catalogHasIo.value = !stripIo
+      await showNudge()
+
+      expect(
+        screen.queryByRole('button', {
+          name: new RegExp(SUGGESTION_TITLES.animate, 'i')
+        }),
+        'every action would be a dead end found by clicking it'
+      ).toBeNull()
+      expect(
+        screen.getByText(
+          enMessages.onboardingCoachmarks.firstRun.nudge.fallback.title
+        ),
+        'the way forward is what the card is for (#14144)'
+      ).toBeTruthy()
+      expect(mocks.trackOnboardingTour).toHaveBeenCalledWith('nudge_shown', {
+        tour: 'firstRun',
+        suggestion_count: 0
+      })
+    }
+  )
+
+  it('falls back to the template browser when the run made no image', async () => {
+    mocks.nudgeOutput.value = null
     await showNudge()
 
     expect(
-      nudge(),
-      'every action would be a dead end found by clicking it'
+      screen.getByText(
+        enMessages.onboardingCoachmarks.firstRun.nudge.fallback.title
+      )
+    ).toBeTruthy()
+    expect(
+      screen.queryByRole('button', {
+        name: new RegExp(SUGGESTION_TITLES.animate, 'i')
+      }),
+      'there is nothing to seed a continuation with'
     ).toBeNull()
+  })
+
+  it('keeps the card while a continuation is loading', async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+    mocks.loadWorkflowTemplate.mockReturnValueOnce(
+      createDeferred<boolean>().promise
+    )
+    await showNudge()
+
+    await user.click(suggestionButton('animate'))
+    await user.keyboard('{Escape}')
+
+    expect(
+      mocks.dismissNudge,
+      'the graph is about to be replaced, so there is nothing to dismiss out of'
+    ).not.toHaveBeenCalled()
+    expect(
+      screen.getByRole('button', { name: enMessages.g.close })
+    ).toBeDisabled()
   })
 
   it('exposes the pending continuation and blocks competing actions', async () => {
@@ -317,7 +378,12 @@ describe('FirstRunTourNudge', () => {
     )
     expect(mocks.trackOnboardingTour).toHaveBeenCalledWith(
       'nudge_suggestion_clicked',
-      { tour: 'firstRun', suggestion: 'animate', loaded: false }
+      {
+        tour: 'firstRun',
+        suggestion_count: 3,
+        suggestion: 'animate',
+        loaded: false
+      }
     )
   })
 
@@ -334,7 +400,7 @@ describe('FirstRunTourNudge', () => {
     expect(mocks.showTemplates).toHaveBeenCalledWith('first_run_nudge')
     expect(mocks.trackOnboardingTour).toHaveBeenCalledWith(
       'explore_templates_clicked',
-      { tour: 'firstRun' }
+      { tour: 'firstRun', suggestion_count: 3 }
     )
     expect(mocks.dismissNudge).toHaveBeenCalled()
   })

--- a/src/renderer/extensions/firstRunTour/nudge/FirstRunTourNudge.vue
+++ b/src/renderer/extensions/firstRunTour/nudge/FirstRunTourNudge.vue
@@ -169,7 +169,7 @@ const titleId = useId()
 const subtitleId = useId()
 const loadingSuggestionId = ref<SuggestionId | null>(null)
 const delayElapsed = ref(false)
-const catalogDecided = ref(false)
+const decidedSuggestions = ref<Suggestion[] | null>(null)
 let reported = false
 
 /**
@@ -178,7 +178,7 @@ let reported = false
  * the `io` metadata the continuation needs. Either way the button would be a
  * dead end found by clicking it, seconds after the user's first success.
  */
-const availableSuggestions = computed(() =>
+const catalogSuggestions = computed(() =>
   nudgeOutput.value === null
     ? []
     : SUGGESTIONS.filter(({ templateId }) => {
@@ -189,6 +189,12 @@ const availableSuggestions = computed(() =>
         )
       })
 )
+const availableSuggestions = computed(() => decidedSuggestions.value ?? [])
+
+function decideSuggestions() {
+  if (decidedSuggestions.value !== null) return
+  decidedSuggestions.value = catalogSuggestions.value
+}
 
 // A run that produced no image, and an install serving none of the
 // continuations, both leave the card with nothing to continue from. Neither is
@@ -207,7 +213,10 @@ const screenIsClear = computed(
  * continuations under the user — and reports a count it never showed.
  */
 const onScreen = computed(
-  () => screenIsClear.value && delayElapsed.value && catalogDecided.value
+  () =>
+    screenIsClear.value &&
+    delayElapsed.value &&
+    decidedSuggestions.value !== null
 )
 
 const { start: scheduleAppearance, stop: cancelAppearance } = useTimeoutFn(
@@ -219,9 +228,7 @@ const { start: scheduleAppearance, stop: cancelAppearance } = useTimeoutFn(
 )
 
 const { start: startCatalogWait, stop: stopCatalogWait } = useTimeoutFn(
-  () => {
-    catalogDecided.value = true
-  },
+  decideSuggestions,
   CATALOG_WAIT_MS,
   { immediate: false }
 )
@@ -235,15 +242,21 @@ useEventListener(document, 'keydown', (event: KeyboardEvent) => {
 // its own impression, rather than inheriting the first tour's answers.
 watch(
   nudgeArmed,
-  (armed) => {
+  (armed, _previous, onCleanup) => {
     stopCatalogWait()
-    catalogDecided.value = false
+    decidedSuggestions.value = null
     reported = false
     if (!armed) return
+
+    let active = true
+    onCleanup(() => {
+      active = false
+    })
     startCatalogWait()
     void loadTemplates().finally(() => {
+      if (!active) return
       stopCatalogWait()
-      catalogDecided.value = true
+      decideSuggestions()
     })
   },
   { immediate: true }

--- a/src/renderer/extensions/firstRunTour/nudge/FirstRunTourNudge.vue
+++ b/src/renderer/extensions/firstRunTour/nudge/FirstRunTourNudge.vue
@@ -102,8 +102,6 @@ import Button from '@/components/ui/button/Button.vue'
 import { useWorkflowTemplateSelectorDialog } from '@/composables/useWorkflowTemplateSelectorDialog'
 import { useTelemetry } from '@/platform/telemetry'
 import { useTemplateWorkflows } from '@/platform/workflow/templates/composables/useTemplateWorkflows'
-import { replaceUniqueTemplateWidgetValue } from '@/platform/workflow/templates/utils/templateWorkflowTransforms'
-import type { ComfyWorkflowJSON } from '@/platform/workflow/validation/schemas/workflowSchema'
 import { useDialogStore } from '@/stores/dialogStore'
 
 import { useFirstRunTourController } from '../tour/useFirstRunTourController'
@@ -118,29 +116,26 @@ interface Suggestion {
   titleKey: string
   detailKey: string
   icon: string
-  transformWorkflow?: (workflow: ComfyWorkflowJSON) => ComfyWorkflowJSON
 }
 
 const suggestions: Suggestion[] = [
   {
     id: 'animate',
-    templateId: 'video_wan2_2_14B_i2v',
+    templateId: 'video_minimax_h3_i2v_continuation',
     titleKey: 'onboardingCoachmarks.firstRun.nudge.animate.title',
     detailKey: 'onboardingCoachmarks.firstRun.nudge.animate.detail',
     icon: 'icon-[lucide--film]'
   },
   {
     id: 'upscale',
-    templateId: 'utility_interpolation_image_upscale',
+    templateId: 'utility_interpolation_image_upscale_4x',
     titleKey: 'onboardingCoachmarks.firstRun.nudge.upscale.title',
     detailKey: 'onboardingCoachmarks.firstRun.nudge.upscale.detail',
-    icon: 'icon-[lucide--maximize-2]',
-    transformWorkflow: (workflow) =>
-      replaceUniqueTemplateWidgetValue(workflow, 'ImageScaleBy', 2, 4)
+    icon: 'icon-[lucide--maximize-2]'
   },
   {
     id: 'restyle',
-    templateId: 'api_google_nano_banana2_image_edit',
+    templateId: 'api_google_nano_banana2_image_edit_continuation',
     titleKey: 'onboardingCoachmarks.firstRun.nudge.restyle.title',
     detailKey: 'onboardingCoachmarks.firstRun.nudge.restyle.detail',
     icon: 'icon-[ph--swatches]'
@@ -201,8 +196,7 @@ async function onSuggestion(suggestion: Suggestion) {
     const workflowLoaded =
       templatesLoaded &&
       (await loadWorkflowTemplate(suggestion.templateId, 'default', {
-        input,
-        transformWorkflow: suggestion.transformWorkflow
+        input
       }))
 
     if (workflowLoaded) {

--- a/src/renderer/extensions/firstRunTour/nudge/FirstRunTourNudge.vue
+++ b/src/renderer/extensions/firstRunTour/nudge/FirstRunTourNudge.vue
@@ -62,7 +62,7 @@
               </span>
               <span
                 v-if="suggestion.badgeKey"
-                class="shrink-0 rounded-sm border border-border-subtle px-1.25 py-0.25 text-[10px] text-muted-foreground"
+                class="shrink-0 rounded-sm border border-border-subtle px-1.25 py-0.25 text-2xs/5 text-muted-foreground"
               >
                 {{ t(suggestion.badgeKey) }}
               </span>
@@ -111,6 +111,13 @@ import { useFirstRunTourController } from '../tour/useFirstRunTourController'
 
 const APPEAR_DELAY_MS = 1500
 
+/**
+ * How long the card waits on the catalog before showing what it already knows.
+ * Capped, because a stalled fetch must not take the card away from the user it
+ * is for (#14144).
+ */
+const CATALOG_WAIT_MS = 3000
+
 type SuggestionId = 'animate' | 'upscale' | 'restyle'
 
 interface Suggestion {
@@ -125,7 +132,7 @@ interface Suggestion {
   paid?: boolean
 }
 
-const suggestions: Suggestion[] = [
+const SUGGESTIONS: Suggestion[] = [
   {
     id: 'animate',
     templateId: 'video_minimax_h3_i2v_continuation',
@@ -162,7 +169,7 @@ const titleId = useId()
 const subtitleId = useId()
 const loadingSuggestionId = ref<SuggestionId | null>(null)
 const delayElapsed = ref(false)
-const catalogSettled = ref(false)
+const catalogDecided = ref(false)
 let reported = false
 
 /**
@@ -174,7 +181,7 @@ let reported = false
 const availableSuggestions = computed(() =>
   nudgeOutput.value === null
     ? []
-    : suggestions.filter(({ templateId }) => {
+    : SUGGESTIONS.filter(({ templateId }) => {
         const template = templatesStore.getTemplateByName(templateId)
         return (
           template?.sourceModule === 'default' &&
@@ -194,7 +201,14 @@ const copyKey = computed(
 const screenIsClear = computed(
   () => nudgeArmed.value && dialogStore.dialogStack.length === 0
 )
-const onScreen = computed(() => screenIsClear.value && delayElapsed.value)
+/**
+ * The catalog decides what the card can offer, so the card cannot render before
+ * it. Without this the card paints the fallback, then rewrites itself into the
+ * continuations under the user — and reports a count it never showed.
+ */
+const onScreen = computed(
+  () => screenIsClear.value && delayElapsed.value && catalogDecided.value
+)
 
 const { start: scheduleAppearance, stop: cancelAppearance } = useTimeoutFn(
   () => {
@@ -204,17 +218,32 @@ const { start: scheduleAppearance, stop: cancelAppearance } = useTimeoutFn(
   { immediate: false }
 )
 
+const { start: startCatalogWait, stop: stopCatalogWait } = useTimeoutFn(
+  () => {
+    catalogDecided.value = true
+  },
+  CATALOG_WAIT_MS,
+  { immediate: false }
+)
+
 useEventListener(document, 'keydown', (event: KeyboardEvent) => {
   if (onScreen.value && !loadingSuggestionId.value && event.key === 'Escape')
     dismissNudge()
 })
 
+// Each nudge is a fresh one: a second tour asks the catalog again and reports
+// its own impression, rather than inheriting the first tour's answers.
 watch(
   nudgeArmed,
   (armed) => {
+    stopCatalogWait()
+    catalogDecided.value = false
+    reported = false
     if (!armed) return
+    startCatalogWait()
     void loadTemplates().finally(() => {
-      catalogSettled.value = true
+      stopCatalogWait()
+      catalogDecided.value = true
     })
   },
   { immediate: true }
@@ -230,10 +259,8 @@ watch(
   { immediate: true }
 )
 
-// Reported once the catalog has settled, so a card that beat the fetch to the
-// screen does not report the empty case the fetch was about to fill.
-watch([onScreen, catalogSettled], ([visible, settled]) => {
-  if (!visible || !settled || reported) return
+watch(onScreen, (visible) => {
+  if (!visible || reported) return
   reported = true
   telemetry?.trackOnboardingTour('nudge_shown', {
     tour: 'firstRun',

--- a/src/renderer/extensions/firstRunTour/nudge/FirstRunTourNudge.vue
+++ b/src/renderer/extensions/firstRunTour/nudge/FirstRunTourNudge.vue
@@ -3,88 +3,163 @@
     v-if="onScreen"
     role="region"
     :aria-labelledby="titleId"
+    :aria-describedby="subtitleId"
     data-testid="first-run-nudge"
-    class="fixed right-0 bottom-0 z-1000 flex w-80 animate-in flex-col overflow-hidden rounded-tl-xl border-t border-l border-border-default/50 bg-base-background shadow-lg duration-500 fade-in-0"
+    class="fixed right-6 bottom-8 z-1000 flex w-103.25 animate-in flex-col gap-4 overflow-hidden rounded-xl border border-border-subtle bg-base-background p-5 shadow-lg duration-500 fade-in-0"
   >
-    <div class="relative h-50 w-full bg-secondary-background">
-      <img :src="NUDGE_IMAGE" alt="" class="size-full object-cover" />
-      <Button
-        class="absolute top-2 right-2 opacity-50 hover:opacity-100"
-        variant="secondary"
-        size="icon"
-        :aria-label="t('g.close')"
-        @click="dismissNudge"
-      >
-        <i class="icon-[lucide--x] size-4" aria-hidden="true" />
-      </Button>
+    <div class="flex flex-col gap-6">
+      <div class="relative flex items-start justify-between overflow-hidden">
+        <div class="flex min-w-0 flex-1 flex-col gap-1 pr-10">
+          <p :id="titleId" class="m-0 text-lg font-medium text-base-foreground">
+            {{ t('onboardingCoachmarks.firstRun.nudge.title') }}
+          </p>
+          <p :id="subtitleId" class="m-0 text-sm text-muted-foreground">
+            {{ t('onboardingCoachmarks.firstRun.nudge.body') }}
+          </p>
+        </div>
+        <Button
+          class="absolute top-0 right-0 opacity-50 hover:opacity-100"
+          variant="secondary"
+          size="icon"
+          :aria-label="t('g.close')"
+          @click="dismissNudge"
+        >
+          <i class="icon-[lucide--x] size-4" aria-hidden="true" />
+        </Button>
+      </div>
+
+      <div class="flex flex-col gap-1.5">
+        <button
+          v-for="suggestion in suggestions"
+          :key="suggestion.id"
+          type="button"
+          :data-testid="`first-run-nudge-${suggestion.id}`"
+          :disabled="loadingSuggestionId !== null"
+          :aria-busy="loadingSuggestionId === suggestion.id || undefined"
+          class="group focus-visible:ring-ring flex h-13 w-full cursor-pointer items-center gap-3 rounded-lg border-none bg-secondary-background p-2 text-left font-inter text-base-foreground transition-colors hover:bg-secondary-background-hover focus-visible:ring-1 focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50"
+          @click="onSuggestion(suggestion)"
+        >
+          <span
+            class="flex size-9 shrink-0 items-center justify-center rounded-md bg-secondary-background-hover"
+          >
+            <i
+              v-if="loadingSuggestionId === suggestion.id"
+              class="pi pi-spin pi-spinner size-4.5"
+              aria-hidden="true"
+            />
+            <i
+              v-else
+              :class="suggestion.icon"
+              class="size-4.5"
+              aria-hidden="true"
+            />
+          </span>
+          <span class="flex min-w-0 flex-1 flex-col gap-0.5">
+            <span class="flex items-center gap-1.5 text-sm font-medium">
+              <span class="min-w-0 flex-1 truncate">
+                {{ t(suggestion.titleKey) }}
+              </span>
+              <span
+                v-if="suggestion.id === 'upscale'"
+                class="shrink-0 rounded-sm border border-border-subtle px-1.25 py-0.25 text-[10px] text-muted-foreground"
+              >
+                {{ t('onboardingCoachmarks.firstRun.nudge.upscale.badge') }}
+              </span>
+              <i
+                v-if="suggestion.id === 'restyle'"
+                class="icon-[tabler--crown-filled] size-4 shrink-0 text-brand-yellow"
+                aria-hidden="true"
+              />
+            </span>
+            <span class="truncate text-xs text-muted-foreground">
+              {{ t(suggestion.detailKey) }}
+            </span>
+          </span>
+        </button>
+      </div>
     </div>
 
-    <div
-      class="flex flex-col gap-2 border-t border-border-default px-4 pt-6 pb-4"
+    <Button
+      variant="inverted"
+      size="md"
+      class="w-full font-medium"
+      data-testid="first-run-nudge-explore"
+      :disabled="loadingSuggestionId !== null"
+      @click="onExplore"
     >
-      <p :id="titleId" class="m-0 text-sm/5 font-bold text-base-foreground">
-        {{ t(`${copyKey}.title`) }}
-      </p>
-      <p class="m-0 text-sm text-muted-foreground">
-        {{ t(`${copyKey}.body`) }}
-      </p>
-    </div>
-
-    <div class="flex items-center justify-end gap-4 px-4 pb-4">
-      <Button
-        variant="link"
-        size="unset"
-        class="h-6 text-sm font-normal"
-        @click="dismissNudge"
-      >
-        {{ t('onboardingCoachmarks.firstRun.nudge.dismiss') }}
-      </Button>
-      <Button
-        variant="inverted"
-        size="lg"
-        class="font-normal"
-        data-testid="first-run-nudge-explore"
-        @click="onExplore"
-      >
-        {{ t('onboardingCoachmarks.firstRun.nudge.explore') }}
-      </Button>
-    </div>
+      {{ t('onboardingCoachmarks.firstRun.nudge.explore') }}
+    </Button>
   </div>
 </template>
 
 <script setup lang="ts">
 import { useEventListener, useTimeoutFn } from '@vueuse/core'
-import { computed, ref, useId, watch } from 'vue'
+import { useToast } from 'primevue/usetoast'
+import { ref, useId, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import Button from '@/components/ui/button/Button.vue'
 import { useWorkflowTemplateSelectorDialog } from '@/composables/useWorkflowTemplateSelectorDialog'
 import { useTelemetry } from '@/platform/telemetry'
+import { useTemplateWorkflows } from '@/platform/workflow/templates/composables/useTemplateWorkflows'
+import { replaceUniqueTemplateWidgetValue } from '@/platform/workflow/templates/utils/templateWorkflowTransforms'
+import type { ComfyWorkflowJSON } from '@/platform/workflow/validation/schemas/workflowSchema'
 import { useDialogStore } from '@/stores/dialogStore'
 
 import { useFirstRunTourController } from '../tour/useFirstRunTourController'
 
-const NUDGE_IMAGE = '/assets/images/og-image.png'
-
-/** Delayed, so the finished workflow is seen before this fades in over it. */
 const APPEAR_DELAY_MS = 1500
 
+type SuggestionId = 'animate' | 'upscale' | 'restyle'
+
+interface Suggestion {
+  id: SuggestionId
+  templateId: string
+  titleKey: string
+  detailKey: string
+  icon: string
+  transformWorkflow?: (workflow: ComfyWorkflowJSON) => ComfyWorkflowJSON
+}
+
+const suggestions: Suggestion[] = [
+  {
+    id: 'animate',
+    templateId: 'video_wan2_2_14B_i2v',
+    titleKey: 'onboardingCoachmarks.firstRun.nudge.animate.title',
+    detailKey: 'onboardingCoachmarks.firstRun.nudge.animate.detail',
+    icon: 'icon-[lucide--film]'
+  },
+  {
+    id: 'upscale',
+    templateId: 'utility_interpolation_image_upscale',
+    titleKey: 'onboardingCoachmarks.firstRun.nudge.upscale.title',
+    detailKey: 'onboardingCoachmarks.firstRun.nudge.upscale.detail',
+    icon: 'icon-[lucide--maximize-2]',
+    transformWorkflow: (workflow) =>
+      replaceUniqueTemplateWidgetValue(workflow, 'ImageScaleBy', 2, 4)
+  },
+  {
+    id: 'restyle',
+    templateId: 'api_google_nano_banana2_image_edit',
+    titleKey: 'onboardingCoachmarks.firstRun.nudge.restyle.title',
+    detailKey: 'onboardingCoachmarks.firstRun.nudge.restyle.detail',
+    icon: 'icon-[ph--swatches]'
+  }
+]
+
 const { t } = useI18n()
-const { nudgeArmed, tourWasCompleted, dismissNudge } =
+const toast = useToast()
+const { nudgeArmed, nudgeOutput, tourWasCompleted, dismissNudge } =
   useFirstRunTourController()
+const { loadTemplates, loadWorkflowTemplate } = useTemplateWorkflows()
 const dialogStore = useDialogStore()
 const telemetry = useTelemetry()
 const titleId = useId()
-
-// Only a tour walked to the end made a first result to congratulate; every
-// other ending still gets a nudge, pointing at the templates instead.
-const copyKey = computed(
-  () =>
-    `onboardingCoachmarks.firstRun.nudge.${tourWasCompleted.value ? 'ran' : 'noTour'}`
-)
-
+const subtitleId = useId()
+const loadingSuggestionId = ref<SuggestionId | null>(null)
 const onScreen = ref(false)
 let reported = false
+
 const { start: scheduleAppearance, stop: cancelAppearance } = useTimeoutFn(
   () => {
     onScreen.value = true
@@ -103,7 +178,6 @@ useEventListener(document, 'keydown', (event: KeyboardEvent) => {
   if (onScreen.value && event.key === 'Escape') dismissNudge()
 })
 
-/** The nudge sits below the modal stack, so it waits for a clear screen. */
 watch(
   () => nudgeArmed.value && dialogStore.dialogStack.length === 0,
   (screenIsClear) => {
@@ -116,6 +190,36 @@ watch(
   },
   { immediate: true }
 )
+
+async function onSuggestion(suggestion: Suggestion) {
+  const input = nudgeOutput.value
+  if (!input || loadingSuggestionId.value) return
+
+  loadingSuggestionId.value = suggestion.id
+  try {
+    const templatesLoaded = await loadTemplates()
+    const workflowLoaded =
+      templatesLoaded &&
+      (await loadWorkflowTemplate(suggestion.templateId, 'default', {
+        input,
+        transformWorkflow: suggestion.transformWorkflow
+      }))
+
+    if (workflowLoaded) {
+      dismissNudge()
+      return
+    }
+
+    toast.add({
+      severity: 'error',
+      summary: t('g.error'),
+      detail: t('onboardingCoachmarks.firstRun.nudge.loadFailed'),
+      life: 5000
+    })
+  } finally {
+    loadingSuggestionId.value = null
+  }
+}
 
 function onExplore() {
   useWorkflowTemplateSelectorDialog().show('first_run_nudge')

--- a/src/renderer/extensions/firstRunTour/nudge/FirstRunTourNudge.vue
+++ b/src/renderer/extensions/firstRunTour/nudge/FirstRunTourNudge.vue
@@ -30,7 +30,7 @@
 
       <div class="flex flex-col gap-1.5">
         <button
-          v-for="suggestion in suggestions"
+          v-for="suggestion in availableSuggestions"
           :key="suggestion.id"
           type="button"
           :data-testid="`first-run-nudge-${suggestion.id}`"
@@ -44,7 +44,7 @@
           >
             <i
               v-if="loadingSuggestionId === suggestion.id"
-              class="pi pi-spin pi-spinner size-4.5"
+              class="icon-[lucide--loader-circle] size-4.5 animate-spin"
               aria-hidden="true"
             />
             <i
@@ -95,13 +95,15 @@
 <script setup lang="ts">
 import { useEventListener, useTimeoutFn } from '@vueuse/core'
 import { useToast } from 'primevue/usetoast'
-import { ref, useId, watch } from 'vue'
+import { computed, ref, useId, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import Button from '@/components/ui/button/Button.vue'
 import { useWorkflowTemplateSelectorDialog } from '@/composables/useWorkflowTemplateSelectorDialog'
 import { useTelemetry } from '@/platform/telemetry'
 import { useTemplateWorkflows } from '@/platform/workflow/templates/composables/useTemplateWorkflows'
+import { useWorkflowTemplatesStore } from '@/platform/workflow/templates/repositories/workflowTemplatesStore'
+import { acceptsTemplateImageInput } from '@/platform/workflow/templates/utils/templateWorkflowTransforms'
 import { useDialogStore } from '@/stores/dialogStore'
 
 import { useFirstRunTourController } from '../tour/useFirstRunTourController'
@@ -128,7 +130,7 @@ const suggestions: Suggestion[] = [
   },
   {
     id: 'upscale',
-    templateId: 'utility_interpolation_image_upscale_4x',
+    templateId: 'utility_seedvr2_7b_int8_upscale_image',
     titleKey: 'onboardingCoachmarks.firstRun.nudge.upscale.title',
     detailKey: 'onboardingCoachmarks.firstRun.nudge.upscale.detail',
     icon: 'icon-[lucide--maximize-2]'
@@ -144,26 +146,46 @@ const suggestions: Suggestion[] = [
 
 const { t } = useI18n()
 const toast = useToast()
-const { nudgeArmed, nudgeOutput, tourWasCompleted, dismissNudge } =
-  useFirstRunTourController()
+const { nudgeArmed, nudgeOutput, dismissNudge } = useFirstRunTourController()
 const { loadTemplates, loadWorkflowTemplate } = useTemplateWorkflows()
+const templatesStore = useWorkflowTemplatesStore()
 const dialogStore = useDialogStore()
 const telemetry = useTelemetry()
 const titleId = useId()
 const subtitleId = useId()
 const loadingSuggestionId = ref<SuggestionId | null>(null)
-const onScreen = ref(false)
+const delayElapsed = ref(false)
 let reported = false
+
+/**
+ * The template package is pinned by the install, not by this build, so an id
+ * this card knows can be absent from the served catalog — or present without
+ * the `io` metadata the continuation needs. Either way the button would be a
+ * dead end found by clicking it, seconds after the user's first success.
+ */
+const availableSuggestions = computed(() =>
+  suggestions.filter(({ templateId }) => {
+    const template = templatesStore.getTemplateByName(templateId)
+    return (
+      template?.sourceModule === 'default' &&
+      acceptsTemplateImageInput(template)
+    )
+  })
+)
+
+const screenIsClear = computed(
+  () => nudgeArmed.value && dialogStore.dialogStack.length === 0
+)
+const onScreen = computed(
+  () =>
+    screenIsClear.value &&
+    delayElapsed.value &&
+    availableSuggestions.value.length > 0
+)
 
 const { start: scheduleAppearance, stop: cancelAppearance } = useTimeoutFn(
   () => {
-    onScreen.value = true
-    if (reported) return
-    reported = true
-    telemetry?.trackOnboardingTour('nudge_shown', {
-      tour: 'firstRun',
-      tour_completed: tourWasCompleted.value
-    })
+    delayElapsed.value = true
   },
   APPEAR_DELAY_MS,
   { immediate: false }
@@ -174,17 +196,28 @@ useEventListener(document, 'keydown', (event: KeyboardEvent) => {
 })
 
 watch(
-  () => nudgeArmed.value && dialogStore.dialogStack.length === 0,
-  (screenIsClear) => {
-    cancelAppearance()
-    if (!screenIsClear) {
-      onScreen.value = false
-      return
-    }
-    scheduleAppearance()
+  nudgeArmed,
+  (armed) => {
+    if (armed) void loadTemplates()
   },
   { immediate: true }
 )
+
+watch(
+  screenIsClear,
+  (clear) => {
+    cancelAppearance()
+    delayElapsed.value = false
+    if (clear) scheduleAppearance()
+  },
+  { immediate: true }
+)
+
+watch(onScreen, (visible) => {
+  if (!visible || reported) return
+  reported = true
+  telemetry?.trackOnboardingTour('nudge_shown', { tour: 'firstRun' })
+})
 
 async function onSuggestion(suggestion: Suggestion) {
   const input = nudgeOutput.value
@@ -192,14 +225,20 @@ async function onSuggestion(suggestion: Suggestion) {
 
   loadingSuggestionId.value = suggestion.id
   try {
-    const templatesLoaded = await loadTemplates()
-    const workflowLoaded =
-      templatesLoaded &&
-      (await loadWorkflowTemplate(suggestion.templateId, 'default', {
+    const loaded = await loadWorkflowTemplate(
+      suggestion.templateId,
+      'default',
+      {
         input
-      }))
+      }
+    )
+    telemetry?.trackOnboardingTour('nudge_suggestion_clicked', {
+      tour: 'firstRun',
+      suggestion: suggestion.id,
+      loaded
+    })
 
-    if (workflowLoaded) {
+    if (loaded) {
       dismissNudge()
       return
     }
@@ -218,8 +257,7 @@ async function onSuggestion(suggestion: Suggestion) {
 function onExplore() {
   useWorkflowTemplateSelectorDialog().show('first_run_nudge')
   telemetry?.trackOnboardingTour('explore_templates_clicked', {
-    tour: 'firstRun',
-    tour_completed: tourWasCompleted.value
+    tour: 'firstRun'
   })
   dismissNudge()
 }

--- a/src/renderer/extensions/firstRunTour/nudge/FirstRunTourNudge.vue
+++ b/src/renderer/extensions/firstRunTour/nudge/FirstRunTourNudge.vue
@@ -11,10 +11,10 @@
       <div class="relative flex items-start justify-between overflow-hidden">
         <div class="flex min-w-0 flex-1 flex-col gap-1 pr-10">
           <p :id="titleId" class="m-0 text-lg font-medium text-base-foreground">
-            {{ t('onboardingCoachmarks.firstRun.nudge.title') }}
+            {{ t(`${copyKey}.title`) }}
           </p>
           <p :id="subtitleId" class="m-0 text-sm text-muted-foreground">
-            {{ t('onboardingCoachmarks.firstRun.nudge.body') }}
+            {{ t(`${copyKey}.body`) }}
           </p>
         </div>
         <Button
@@ -22,6 +22,7 @@
           variant="secondary"
           size="icon"
           :aria-label="t('g.close')"
+          :disabled="loadingSuggestionId !== null"
           @click="dismissNudge"
         >
           <i class="icon-[lucide--x] size-4" aria-hidden="true" />
@@ -60,13 +61,13 @@
                 {{ t(suggestion.titleKey) }}
               </span>
               <span
-                v-if="suggestion.id === 'upscale'"
+                v-if="suggestion.badgeKey"
                 class="shrink-0 rounded-sm border border-border-subtle px-1.25 py-0.25 text-[10px] text-muted-foreground"
               >
-                {{ t('onboardingCoachmarks.firstRun.nudge.upscale.badge') }}
+                {{ t(suggestion.badgeKey) }}
               </span>
               <i
-                v-if="suggestion.id === 'restyle'"
+                v-if="suggestion.paid"
                 class="icon-[tabler--crown-filled] size-4 shrink-0 text-brand-yellow"
                 aria-hidden="true"
               />
@@ -118,6 +119,10 @@ interface Suggestion {
   titleKey: string
   detailKey: string
   icon: string
+  /** A qualifier on the action itself, such as the upscale's multiplier. */
+  badgeKey?: string
+  /** Marks the action a paid plan is required to run, so the card says so. */
+  paid?: boolean
 }
 
 const suggestions: Suggestion[] = [
@@ -133,14 +138,16 @@ const suggestions: Suggestion[] = [
     templateId: 'utility_seedvr2_7b_int8_upscale_image',
     titleKey: 'onboardingCoachmarks.firstRun.nudge.upscale.title',
     detailKey: 'onboardingCoachmarks.firstRun.nudge.upscale.detail',
-    icon: 'icon-[lucide--maximize-2]'
+    icon: 'icon-[lucide--maximize-2]',
+    badgeKey: 'onboardingCoachmarks.firstRun.nudge.upscale.badge'
   },
   {
     id: 'restyle',
     templateId: 'api_google_nano_banana2_image_edit_continuation',
     titleKey: 'onboardingCoachmarks.firstRun.nudge.restyle.title',
     detailKey: 'onboardingCoachmarks.firstRun.nudge.restyle.detail',
-    icon: 'icon-[ph--swatches]'
+    icon: 'icon-[ph--swatches]',
+    paid: true
   }
 ]
 
@@ -155,6 +162,7 @@ const titleId = useId()
 const subtitleId = useId()
 const loadingSuggestionId = ref<SuggestionId | null>(null)
 const delayElapsed = ref(false)
+const catalogSettled = ref(false)
 let reported = false
 
 /**
@@ -164,24 +172,29 @@ let reported = false
  * dead end found by clicking it, seconds after the user's first success.
  */
 const availableSuggestions = computed(() =>
-  suggestions.filter(({ templateId }) => {
-    const template = templatesStore.getTemplateByName(templateId)
-    return (
-      template?.sourceModule === 'default' &&
-      acceptsTemplateImageInput(template)
-    )
-  })
+  nudgeOutput.value === null
+    ? []
+    : suggestions.filter(({ templateId }) => {
+        const template = templatesStore.getTemplateByName(templateId)
+        return (
+          template?.sourceModule === 'default' &&
+          acceptsTemplateImageInput(template)
+        )
+      })
+)
+
+// A run that produced no image, and an install serving none of the
+// continuations, both leave the card with nothing to continue from. Neither is
+// a reason to take away the way forward, so the card falls back to the browser.
+const copyKey = computed(
+  () =>
+    `onboardingCoachmarks.firstRun.nudge${availableSuggestions.value.length > 0 ? '' : '.fallback'}`
 )
 
 const screenIsClear = computed(
   () => nudgeArmed.value && dialogStore.dialogStack.length === 0
 )
-const onScreen = computed(
-  () =>
-    screenIsClear.value &&
-    delayElapsed.value &&
-    availableSuggestions.value.length > 0
-)
+const onScreen = computed(() => screenIsClear.value && delayElapsed.value)
 
 const { start: scheduleAppearance, stop: cancelAppearance } = useTimeoutFn(
   () => {
@@ -192,13 +205,17 @@ const { start: scheduleAppearance, stop: cancelAppearance } = useTimeoutFn(
 )
 
 useEventListener(document, 'keydown', (event: KeyboardEvent) => {
-  if (onScreen.value && event.key === 'Escape') dismissNudge()
+  if (onScreen.value && !loadingSuggestionId.value && event.key === 'Escape')
+    dismissNudge()
 })
 
 watch(
   nudgeArmed,
   (armed) => {
-    if (armed) void loadTemplates()
+    if (!armed) return
+    void loadTemplates().finally(() => {
+      catalogSettled.value = true
+    })
   },
   { immediate: true }
 )
@@ -213,10 +230,15 @@ watch(
   { immediate: true }
 )
 
-watch(onScreen, (visible) => {
-  if (!visible || reported) return
+// Reported once the catalog has settled, so a card that beat the fetch to the
+// screen does not report the empty case the fetch was about to fill.
+watch([onScreen, catalogSettled], ([visible, settled]) => {
+  if (!visible || !settled || reported) return
   reported = true
-  telemetry?.trackOnboardingTour('nudge_shown', { tour: 'firstRun' })
+  telemetry?.trackOnboardingTour('nudge_shown', {
+    tour: 'firstRun',
+    suggestion_count: availableSuggestions.value.length
+  })
 })
 
 async function onSuggestion(suggestion: Suggestion) {
@@ -234,6 +256,7 @@ async function onSuggestion(suggestion: Suggestion) {
     )
     telemetry?.trackOnboardingTour('nudge_suggestion_clicked', {
       tour: 'firstRun',
+      suggestion_count: availableSuggestions.value.length,
       suggestion: suggestion.id,
       loaded
     })
@@ -257,7 +280,8 @@ async function onSuggestion(suggestion: Suggestion) {
 function onExplore() {
   useWorkflowTemplateSelectorDialog().show('first_run_nudge')
   telemetry?.trackOnboardingTour('explore_templates_clicked', {
-    tour: 'firstRun'
+    tour: 'firstRun',
+    suggestion_count: availableSuggestions.value.length
   })
   dismissNudge()
 }

--- a/src/renderer/extensions/firstRunTour/tour/useFirstRunTourController.test.ts
+++ b/src/renderer/extensions/firstRunTour/tour/useFirstRunTourController.test.ts
@@ -191,19 +191,26 @@ const UNFINISHED_ENDINGS: { named: string; ending: TourEnding }[] = [
   { named: 'a lost context ended', ending: skippedBecause('trigger_lost') }
 ]
 
-const EVERY_ENDING: { named: string; ending: TourEnding }[] = [
-  { named: 'the user walked to the end', ending: COMPLETED },
-  ...UNFINISHED_ENDINGS
-]
-
 /** The queue storing a job, which is what acceptance actually looks like. */
-function acceptRun(workflow: unknown) {
-  mocks.queuedJobs.value = { 'job-1': { workflow } }
+function acceptRun(workflow: unknown, jobId = 'job-1') {
+  mocks.queuedJobs.value = {
+    ...mocks.queuedJobs.value,
+    [jobId]: { workflow }
+  }
   return nextTick()
 }
 
 /** The queue letting a job go, which `resetExecutionState` does silently. */
 function removeRun() {
+  mocks.queuedJobs.value = {}
+  return nextTick()
+}
+
+function acceptThenRemoveRun(workflow: unknown, jobId = 'job-1') {
+  mocks.queuedJobs.value = {
+    ...mocks.queuedJobs.value,
+    [jobId]: { workflow }
+  }
   mocks.queuedJobs.value = {}
   return nextTick()
 }
@@ -217,6 +224,7 @@ function finishRun(workflow: unknown, status: string) {
 }
 
 async function captureFirstImage(promptId = 'tour-job') {
+  await acceptRun(TOUR_WORKFLOW, promptId)
   const { api } = await import('@/scripts/api')
   api.dispatchCustomEvent('execution_start', {
     prompt_id: promptId,
@@ -624,6 +632,15 @@ describe('useFirstRunTourController', () => {
       ).toBe('failed')
     })
 
+    it('stops when accepted job metadata is removed in the same tick', async () => {
+      await tourOnRunStep()
+      mountRunButton('queue-button', () => {}).click()
+
+      await acceptThenRemoveRun(TOUR_WORKFLOW)
+
+      expect(mocks.runState.value).toBe('failed')
+    })
+
     it('stops promising a result when a running job is dropped mid-run', async () => {
       // `handleServiceLevelError` ("Job has stagnated") is the live path: it
       // drops the job and records a prompt error but never touches
@@ -958,6 +975,7 @@ describe('useFirstRunTourController', () => {
     it('ignores image output from a different job', async () => {
       const { controller } = await tourOnRunStep()
       mountRunButton('queue-button', () => {}).click()
+      await acceptRun(TOUR_WORKFLOW, 'tour-job')
       const { api } = await import('@/scripts/api')
       api.dispatchCustomEvent('execution_start', {
         prompt_id: 'tour-job',
@@ -975,6 +993,49 @@ describe('useFirstRunTourController', () => {
       await endTour(COMPLETED)
 
       expect(controller.nudgeArmed.value).toBe(false)
+    })
+
+    it('correlates output after an unrelated execution starts first', async () => {
+      const { controller } = await tourOnRunStep()
+      mountRunButton('queue-button', () => {}).click()
+      const { api } = await import('@/scripts/api')
+      api.dispatchCustomEvent('execution_start', {
+        prompt_id: 'other-job',
+        timestamp: 1
+      })
+      api.dispatchCustomEvent('executed', {
+        prompt_id: 'other-job',
+        node: 1,
+        display_node: 1,
+        output: {
+          images: [{ filename: 'other.png', type: 'output' }]
+        }
+      })
+      await nextTick()
+
+      await captureFirstImage()
+      await endTour(COMPLETED)
+
+      expect(controller.nudgeOutput.value?.filename).toBe('first-output.png')
+    })
+
+    it('captures output that arrives before accepted job metadata', async () => {
+      const { controller } = await tourOnRunStep()
+      mountRunButton('queue-button', () => {}).click()
+      const { api } = await import('@/scripts/api')
+      api.dispatchCustomEvent('executed', {
+        prompt_id: 'tour-job',
+        node: 1,
+        display_node: 1,
+        output: {
+          images: [{ filename: 'early.png', type: 'output' }]
+        }
+      })
+
+      await acceptRun(TOUR_WORKFLOW, 'tour-job')
+      await endTour(COMPLETED)
+
+      expect(controller.nudgeOutput.value?.filename).toBe('early.png')
     })
 
     it('takes an armed nudge off the screen when a second tour starts', async () => {

--- a/src/renderer/extensions/firstRunTour/tour/useFirstRunTourController.test.ts
+++ b/src/renderer/extensions/firstRunTour/tour/useFirstRunTourController.test.ts
@@ -1039,6 +1039,32 @@ describe('useFirstRunTourController', () => {
       ).toEqual({ filename: 'preview.png', subfolder: '', type: 'temp' })
     })
 
+    it('replaces a buffered preview when the saved result also beats the queue', async () => {
+      const { controller } = await tourOnRunStep()
+      mountRunButton('queue-button', () => {}).click()
+      const { api } = await import('@/scripts/api')
+      api.dispatchCustomEvent('executed', {
+        prompt_id: 'tour-job',
+        node: 1,
+        display_node: 1,
+        output: { images: [{ filename: 'preview.png', type: 'temp' }] }
+      })
+      api.dispatchCustomEvent('executed', {
+        prompt_id: 'tour-job',
+        node: 2,
+        display_node: 2,
+        output: { images: [{ filename: 'saved.png', type: 'output' }] }
+      })
+
+      await acceptRun(TOUR_WORKFLOW, 'tour-job')
+      await endTour(COMPLETED)
+
+      expect(
+        controller.nudgeOutput.value?.filename,
+        'a preview that beat the queue metadata must not lock out the saved result'
+      ).toBe('saved.png')
+    })
+
     it('replaces a preview output with the saved result', async () => {
       const { controller } = await tourOnRunStep()
       mountRunButton('queue-button', () => {}).click()

--- a/src/renderer/extensions/firstRunTour/tour/useFirstRunTourController.test.ts
+++ b/src/renderer/extensions/firstRunTour/tour/useFirstRunTourController.test.ts
@@ -972,6 +972,36 @@ describe('useFirstRunTourController', () => {
       }
     )
 
+    it('skips a preview output in favour of the saved result', async () => {
+      const { controller } = await tourOnRunStep()
+      mountRunButton('queue-button', () => {}).click()
+      await acceptRun(TOUR_WORKFLOW, 'tour-job')
+      const { api } = await import('@/scripts/api')
+      api.dispatchCustomEvent('execution_start', {
+        prompt_id: 'tour-job',
+        timestamp: 1
+      })
+      api.dispatchCustomEvent('executed', {
+        prompt_id: 'tour-job',
+        node: 1,
+        display_node: 1,
+        output: { images: [{ filename: 'preview.png', type: 'temp' }] }
+      })
+      api.dispatchCustomEvent('executed', {
+        prompt_id: 'tour-job',
+        node: 2,
+        display_node: 2,
+        output: { images: [{ filename: 'saved.png', type: 'output' }] }
+      })
+
+      await endTour(COMPLETED)
+
+      expect(
+        controller.nudgeOutput.value?.filename,
+        'a temp file is collected away, so continuing from it seeds a path the backend has forgotten'
+      ).toBe('saved.png')
+    })
+
     it('ignores image output from a different job', async () => {
       const { controller } = await tourOnRunStep()
       mountRunButton('queue-button', () => {}).click()
@@ -1055,28 +1085,6 @@ describe('useFirstRunTourController', () => {
       ).toBe(false)
     })
 
-    it('congratulates a tour the user walked to the end', async () => {
-      const { controller } = await tourOnRunStep()
-
-      await endTour(COMPLETED)
-
-      expect(controller.tourWasCompleted.value).toBe(true)
-    })
-
-    it.for(UNFINISHED_ENDINGS)(
-      'congratulates nobody for a tour $named',
-      async ({ ending }) => {
-        const { controller } = await tourOnRunStep()
-
-        await endTour(ending)
-
-        expect(
-          controller.tourWasCompleted.value,
-          'a tour the user never walked to the end made no first result to congratulate'
-        ).toBe(false)
-      }
-    )
-
     it('offers no continuation when the tour never appeared', async () => {
       mocks.steps = []
       mocks.activeWorkflow.value = TOUR_WORKFLOW
@@ -1096,10 +1104,6 @@ describe('useFirstRunTourController', () => {
       await starting
       await nextTick()
 
-      expect(
-        controller.tourWasCompleted.value,
-        'a tour that resolved no steps made nothing for the nudge to celebrate'
-      ).toBe(false)
       expect(
         controller.nudgeArmed.value,
         'there is no first output to seed into any suggestion'

--- a/src/renderer/extensions/firstRunTour/tour/useFirstRunTourController.test.ts
+++ b/src/renderer/extensions/firstRunTour/tour/useFirstRunTourController.test.ts
@@ -949,17 +949,20 @@ describe('useFirstRunTourController', () => {
       })
     })
 
-    it('does not arm when a completed tour produced no image', async () => {
+    it('arms with nothing to continue when the tour produced no image', async () => {
       const { controller } = await tourOnRunStep()
 
       await endTour(COMPLETED)
 
-      expect(controller.nudgeArmed.value).toBe(false)
+      expect(
+        controller.nudgeArmed.value,
+        'suppressing the nudge takes the way forward from the user who most needs it (#14144)'
+      ).toBe(true)
       expect(controller.nudgeOutput.value).toBeNull()
     })
 
     it.for(UNFINISHED_ENDINGS)(
-      'does not arm after a tour $named',
+      'offers the image to continue after a tour $named',
       async ({ ending }) => {
         const { controller } = await tourOnRunStep()
         mountRunButton('queue-button', () => {}).click()
@@ -967,12 +970,76 @@ describe('useFirstRunTourController', () => {
 
         await endTour(ending)
 
-        expect(controller.nudgeArmed.value).toBe(false)
-        expect(controller.nudgeOutput.value).toBeNull()
+        expect(controller.nudgeArmed.value).toBe(true)
+        expect(controller.nudgeOutput.value?.filename).toBe('first-output.png')
       }
     )
 
-    it('skips a preview output in favour of the saved result', async () => {
+    it('keeps correlating a run the user walked past', async () => {
+      const { controller } = await tourOnRunStep()
+      mountRunButton('queue-button', () => {}).click()
+      await acceptRun(TOUR_WORKFLOW, 'tour-job')
+
+      await endTour(COMPLETED)
+      expect(controller.nudgeOutput.value).toBeNull()
+
+      const { api } = await import('@/scripts/api')
+      api.dispatchCustomEvent('executed', {
+        prompt_id: 'tour-job',
+        node: 1,
+        display_node: 1,
+        output: { images: [{ filename: 'late.png', type: 'output' }] }
+      })
+      await nextTick()
+
+      expect(
+        controller.nudgeOutput.value?.filename,
+        'clicking Done during a long generation must not throw the result away'
+      ).toBe('late.png')
+    })
+
+    it('continues from a video run through the template browser only', async () => {
+      const { controller } = await tourOnRunStep()
+      mountRunButton('queue-button', () => {}).click()
+      await acceptRun(TOUR_WORKFLOW, 'tour-job')
+      const { api } = await import('@/scripts/api')
+      api.dispatchCustomEvent('executed', {
+        prompt_id: 'tour-job',
+        node: 1,
+        display_node: 1,
+        output: { video: [{ filename: 'result.mp4', type: 'output' }] }
+      })
+
+      await endTour(COMPLETED)
+
+      expect(controller.nudgeArmed.value).toBe(true)
+      expect(
+        controller.nudgeOutput.value,
+        'no image-input continuation can be seeded from a video'
+      ).toBeNull()
+    })
+
+    it('takes a preview temp file when nothing saved one', async () => {
+      const { controller } = await tourOnRunStep()
+      mountRunButton('queue-button', () => {}).click()
+      await acceptRun(TOUR_WORKFLOW, 'tour-job')
+      const { api } = await import('@/scripts/api')
+      api.dispatchCustomEvent('executed', {
+        prompt_id: 'tour-job',
+        node: 1,
+        display_node: 1,
+        output: { images: [{ filename: 'preview.png', type: 'temp' }] }
+      })
+
+      await endTour(COMPLETED)
+
+      expect(
+        controller.nudgeOutput.value,
+        'a PreviewImage sink is the whole result, and the backend still serves it'
+      ).toEqual({ filename: 'preview.png', subfolder: '', type: 'temp' })
+    })
+
+    it('replaces a preview output with the saved result', async () => {
       const { controller } = await tourOnRunStep()
       mountRunButton('queue-button', () => {}).click()
       await acceptRun(TOUR_WORKFLOW, 'tour-job')
@@ -998,7 +1065,7 @@ describe('useFirstRunTourController', () => {
 
       expect(
         controller.nudgeOutput.value?.filename,
-        'a temp file is collected away, so continuing from it seeds a path the backend has forgotten'
+        'the saved result is the one the user was shown, so it wins the seed'
       ).toBe('saved.png')
     })
 
@@ -1022,7 +1089,7 @@ describe('useFirstRunTourController', () => {
 
       await endTour(COMPLETED)
 
-      expect(controller.nudgeArmed.value).toBe(false)
+      expect(controller.nudgeOutput.value).toBeNull()
     })
 
     it('correlates output after an unrelated execution starts first', async () => {
@@ -1106,8 +1173,12 @@ describe('useFirstRunTourController', () => {
 
       expect(
         controller.nudgeArmed.value,
+        'a user who saw no tour is the one who most needs somewhere to go next'
+      ).toBe(true)
+      expect(
+        controller.nudgeOutput.value,
         'there is no first output to seed into any suggestion'
-      ).toBe(false)
+      ).toBeNull()
     })
 
     it('stops offering the nudge once it is waved away', async () => {

--- a/src/renderer/extensions/firstRunTour/tour/useFirstRunTourController.test.ts
+++ b/src/renderer/extensions/firstRunTour/tour/useFirstRunTourController.test.ts
@@ -216,6 +216,29 @@ function finishRun(workflow: unknown, status: string) {
   return nextTick()
 }
 
+async function captureFirstImage(promptId = 'tour-job') {
+  const { api } = await import('@/scripts/api')
+  api.dispatchCustomEvent('execution_start', {
+    prompt_id: promptId,
+    timestamp: 1
+  })
+  api.dispatchCustomEvent('executed', {
+    prompt_id: promptId,
+    node: 1,
+    display_node: 1,
+    output: {
+      images: [
+        {
+          filename: 'first-output.png',
+          subfolder: 'tour',
+          type: 'output'
+        }
+      ]
+    }
+  })
+  await nextTick()
+}
+
 /** A user stop, which drops the status instead of reporting an outcome. */
 function dropRun(workflow: unknown) {
   const next = new Map(mocks.workflowStatus.value)
@@ -889,37 +912,76 @@ describe('useFirstRunTourController', () => {
   })
 
   describe('the nudge', () => {
-    it('arms only once the tour is over', async () => {
+    it('arms after a completed tour produced an image', async () => {
       const { controller } = await tourOnRunStep()
+      mountRunButton('queue-button', () => {}).click()
+      await captureFirstImage()
+
       expect(
         controller.nudgeArmed.value,
         'a nudge fighting a live tour for the screen helps nobody'
       ).toBe(false)
 
-      mocks.engine.activeTour = null
-      await nextTick()
+      await endTour(COMPLETED)
 
       expect(controller.nudgeArmed.value).toBe(true)
+      expect(controller.nudgeOutput.value).toEqual({
+        filename: 'first-output.png',
+        subfolder: 'tour',
+        type: 'output'
+      })
     })
 
-    it('arms whatever the run did', async () => {
+    it('does not arm when a completed tour produced no image', async () => {
+      const { controller } = await tourOnRunStep()
+
+      await endTour(COMPLETED)
+
+      expect(controller.nudgeArmed.value).toBe(false)
+      expect(controller.nudgeOutput.value).toBeNull()
+    })
+
+    it.for(UNFINISHED_ENDINGS)(
+      'does not arm after a tour $named',
+      async ({ ending }) => {
+        const { controller } = await tourOnRunStep()
+        mountRunButton('queue-button', () => {}).click()
+        await captureFirstImage()
+
+        await endTour(ending)
+
+        expect(controller.nudgeArmed.value).toBe(false)
+        expect(controller.nudgeOutput.value).toBeNull()
+      }
+    )
+
+    it('ignores image output from a different job', async () => {
       const { controller } = await tourOnRunStep()
       mountRunButton('queue-button', () => {}).click()
-      await finishRun(TOUR_WORKFLOW, 'failed')
+      const { api } = await import('@/scripts/api')
+      api.dispatchCustomEvent('execution_start', {
+        prompt_id: 'tour-job',
+        timestamp: 1
+      })
+      api.dispatchCustomEvent('executed', {
+        prompt_id: 'other-job',
+        node: 1,
+        display_node: 1,
+        output: {
+          images: [{ filename: 'other.png', type: 'output' }]
+        }
+      })
 
-      mocks.engine.activeTour = null
-      await nextTick()
+      await endTour(COMPLETED)
 
-      expect(
-        controller.nudgeArmed.value,
-        'the user who most needs somewhere to go next is the one whose first run failed'
-      ).toBe(true)
+      expect(controller.nudgeArmed.value).toBe(false)
     })
 
     it('takes an armed nudge off the screen when a second tour starts', async () => {
       const { controller } = await tourOnRunStep()
-      mocks.engine.activeTour = null
-      await nextTick()
+      mountRunButton('queue-button', () => {}).click()
+      await captureFirstImage()
+      await endTour(COMPLETED)
       expect(controller.nudgeArmed.value).toBe(true)
 
       const starting = controller.beginTour('image_z_image_turbo')
@@ -954,21 +1016,7 @@ describe('useFirstRunTourController', () => {
       }
     )
 
-    it.for(EVERY_ENDING)(
-      'still offers the nudge after a tour $named',
-      async ({ ending }) => {
-        const { controller } = await tourOnRunStep()
-
-        await endTour(ending)
-
-        expect(
-          controller.nudgeArmed.value,
-          'suppressing the nudge takes the way forward from the user who most needs it (#14144)'
-        ).toBe(true)
-      }
-    )
-
-    it('congratulates nobody when the tour never appeared', async () => {
+    it('offers no continuation when the tour never appeared', async () => {
       mocks.steps = []
       mocks.activeWorkflow.value = TOUR_WORKFLOW
       mocks.engine.startTour.mockImplementation(async () => {
@@ -993,14 +1041,15 @@ describe('useFirstRunTourController', () => {
       ).toBe(false)
       expect(
         controller.nudgeArmed.value,
-        'a user who saw no tour is the one who most needs somewhere to go next'
-      ).toBe(true)
+        'there is no first output to seed into any suggestion'
+      ).toBe(false)
     })
 
     it('stops offering the nudge once it is waved away', async () => {
       const { controller } = await tourOnRunStep()
-      mocks.engine.activeTour = null
-      await nextTick()
+      mountRunButton('queue-button', () => {}).click()
+      await captureFirstImage()
+      await endTour(COMPLETED)
 
       controller.dismissNudge()
 

--- a/src/renderer/extensions/firstRunTour/tour/useFirstRunTourController.ts
+++ b/src/renderer/extensions/firstRunTour/tour/useFirstRunTourController.ts
@@ -14,6 +14,11 @@ import { useSettingStore } from '@/platform/settings/settingStore'
 import type { ComfyWorkflow } from '@/platform/workflow/management/stores/workflowStore'
 import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
+import type {
+  ExecutedWsMessage,
+  ExecutionStartWsMessage,
+  ResultItem
+} from '@/schemas/apiSchema'
 import { api } from '@/scripts/api'
 import { useExecutionErrorStore } from '@/stores/executionErrorStore'
 import { useExecutionStore } from '@/stores/executionStore'
@@ -46,8 +51,10 @@ function useFirstRunTourControllerInternal() {
   const desktopLayout = useBreakpoints(breakpointsTailwind).greaterOrEqual('md')
   const tourWorkflow = shallowRef<ComfyWorkflow | null>(null)
   const nudgeArmed = ref(false)
-  /** Only a tour walked to the end made a first result to be congratulated for. */
   const tourWasCompleted = ref(false)
+  const nudgeOutput = shallowRef<ResultItem | null>(null)
+  const firstRunOutput = shallowRef<ResultItem | null>(null)
+  let tourJobId: string | null = null
 
   /**
    * The half of the tour's context that exists before the tour does: a canvas
@@ -186,6 +193,24 @@ function useFirstRunTourControllerInternal() {
   })
   useEventListener(api, 'reconnected', stopOfflineGrace)
 
+  useEventListener(api, 'execution_start', (event) => {
+    const { detail } = event as CustomEvent<ExecutionStartWsMessage>
+    if (
+      engine.activeTour !== 'firstRun' ||
+      runState.value !== 'generating' ||
+      tourJobId
+    )
+      return
+    tourJobId = detail.prompt_id
+  })
+
+  useEventListener(api, 'executed', (event) => {
+    const { detail } = event as CustomEvent<ExecutedWsMessage>
+    if (detail.prompt_id !== tourJobId || firstRunOutput.value) return
+    const image = detail.output.images?.find(({ filename }) => filename)
+    if (image) firstRunOutput.value = { ...image, type: image.type ?? 'output' }
+  })
+
   /**
    * A run outlives the step that starts it, so the click moves the tour on. One
    * the paywall will refuse never queues, so the tour parks and leaves the
@@ -215,16 +240,17 @@ function useFirstRunTourControllerInternal() {
     () => engine.activeTour === 'firstRun',
     (active) => {
       if (active) return
-      // Every ending leaves the user somewhere to go next, so every ending arms
-      // the nudge; only what it says depends on how the tour ended.
       const ending = engine.lastEnding
       tourWasCompleted.value =
         ending?.tour === 'firstRun' && ending.outcome === 'completed'
-      nudgeArmed.value = true
+      nudgeOutput.value = tourWasCompleted.value ? firstRunOutput.value : null
+      nudgeArmed.value = nudgeOutput.value !== null
       stopOfflineGrace()
       stopAcceptDeadline()
       releaseFirstRunTargets()
       tourWorkflow.value = null
+      firstRunOutput.value = null
+      tourJobId = null
       runState.value = 'idle'
     }
   )
@@ -248,6 +274,9 @@ function useFirstRunTourControllerInternal() {
     tourWorkflow.value = workflowStore.activeWorkflow ?? null
     runState.value = 'idle'
     nudgeArmed.value = false
+    nudgeOutput.value = null
+    firstRunOutput.value = null
+    tourJobId = null
     registerTour(
       'firstRun',
       () => firstRunTourSteps(templateId, runState),
@@ -270,6 +299,7 @@ function useFirstRunTourControllerInternal() {
   return {
     beginTour,
     nudgeArmed: readonly(nudgeArmed),
+    nudgeOutput: readonly(nudgeOutput),
     tourWasCompleted: readonly(tourWasCompleted),
     dismissNudge
   }

--- a/src/renderer/extensions/firstRunTour/tour/useFirstRunTourController.ts
+++ b/src/renderer/extensions/firstRunTour/tour/useFirstRunTourController.ts
@@ -52,8 +52,24 @@ function useFirstRunTourControllerInternal() {
   const firstRunOutput = shallowRef<ResultItem | null>(null)
   const tourJobId = ref<string | null>(null)
   const runCorrelationActive = ref(false)
-  let queuedJobIdsBeforeRun = new Set<string>()
+  const queuedJobIdsBeforeRun = shallowRef(new Set<string>())
   const pendingRunOutputs = new Map<string, ResultItem>()
+
+  /**
+   * The state that ties an accepted job back to this tour's run, reset as a
+   * unit so the three callers cannot drift apart. Starting a run is the one
+   * difference: it snapshots the queue the new job has to be absent from, and
+   * keeps the image an earlier run in the same tour already produced.
+   */
+  function resetRunCorrelation({ forNewRun = false } = {}) {
+    queuedJobIdsBeforeRun.value = new Set(
+      forNewRun ? Object.keys(executionStore.queuedJobs) : []
+    )
+    pendingRunOutputs.clear()
+    tourJobId.value = null
+    runCorrelationActive.value = forNewRun
+    if (!forNewRun) firstRunOutput.value = null
+  }
 
   /**
    * The half of the tour's context that exists before the tour does: a canvas
@@ -126,7 +142,7 @@ function useFirstRunTourControllerInternal() {
       (runCorrelationActive.value
         ? Object.entries(executionStore.queuedJobs).find(
             ([jobId, job]) =>
-              !queuedJobIdsBeforeRun.has(jobId) &&
+              !queuedJobIdsBeforeRun.value.has(jobId) &&
               job.workflow === tourWorkflow.value
           )?.[0]
         : undefined) ?? null
@@ -226,10 +242,15 @@ function useFirstRunTourControllerInternal() {
     if (
       engine.activeTour !== 'firstRun' ||
       runState.value !== 'generating' ||
-      queuedJobIdsBeforeRun.has(detail.prompt_id)
+      queuedJobIdsBeforeRun.value.has(detail.prompt_id)
     )
       return
-    const image = detail.output.images?.find(({ filename }) => filename)
+    // A preview node ahead of the save node emits first, and its item is
+    // garbage-collected rather than kept — seeding it would hand the
+    // continuation a path the backend has already forgotten.
+    const image = detail.output.images?.find(
+      ({ filename, type }) => filename && type !== 'temp'
+    )
     if (!image) return
     const output = { ...image, type: image.type ?? 'output' }
     if (detail.prompt_id === tourJobId.value) {
@@ -258,10 +279,7 @@ function useFirstRunTourControllerInternal() {
         return
       }
 
-      queuedJobIdsBeforeRun = new Set(Object.keys(executionStore.queuedJobs))
-      pendingRunOutputs.clear()
-      tourJobId.value = null
-      runCorrelationActive.value = true
+      resetRunCorrelation({ forNewRun: true })
       runState.value = 'generating'
       startAcceptDeadline()
       engine.next()
@@ -282,11 +300,7 @@ function useFirstRunTourControllerInternal() {
       stopAcceptDeadline()
       releaseFirstRunTargets()
       tourWorkflow.value = null
-      firstRunOutput.value = null
-      pendingRunOutputs.clear()
-      queuedJobIdsBeforeRun.clear()
-      runCorrelationActive.value = false
-      tourJobId.value = null
+      resetRunCorrelation()
       runState.value = 'idle'
     }
   )
@@ -311,11 +325,7 @@ function useFirstRunTourControllerInternal() {
     runState.value = 'idle'
     nudgeArmed.value = false
     nudgeOutput.value = null
-    firstRunOutput.value = null
-    pendingRunOutputs.clear()
-    queuedJobIdsBeforeRun.clear()
-    runCorrelationActive.value = false
-    tourJobId.value = null
+    resetRunCorrelation()
     registerTour(
       'firstRun',
       () => firstRunTourSteps(templateId, runState),
@@ -339,7 +349,6 @@ function useFirstRunTourControllerInternal() {
     beginTour,
     nudgeArmed: readonly(nudgeArmed),
     nudgeOutput: readonly(nudgeOutput),
-    tourWasCompleted: readonly(tourWasCompleted),
     dismissNudge
   }
 }

--- a/src/renderer/extensions/firstRunTour/tour/useFirstRunTourController.ts
+++ b/src/renderer/extensions/firstRunTour/tour/useFirstRunTourController.ts
@@ -14,11 +14,7 @@ import { useSettingStore } from '@/platform/settings/settingStore'
 import type { ComfyWorkflow } from '@/platform/workflow/management/stores/workflowStore'
 import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
-import type {
-  ExecutedWsMessage,
-  ExecutionStartWsMessage,
-  ResultItem
-} from '@/schemas/apiSchema'
+import type { ExecutedWsMessage, ResultItem } from '@/schemas/apiSchema'
 import { api } from '@/scripts/api'
 import { useExecutionErrorStore } from '@/stores/executionErrorStore'
 import { useExecutionStore } from '@/stores/executionStore'
@@ -54,7 +50,10 @@ function useFirstRunTourControllerInternal() {
   const tourWasCompleted = ref(false)
   const nudgeOutput = shallowRef<ResultItem | null>(null)
   const firstRunOutput = shallowRef<ResultItem | null>(null)
-  let tourJobId: string | null = null
+  const tourJobId = ref<string | null>(null)
+  const runCorrelationActive = ref(false)
+  let queuedJobIdsBeforeRun = new Set<string>()
+  const pendingRunOutputs = new Map<string, ResultItem>()
 
   /**
    * The half of the tour's context that exists before the tour does: a canvas
@@ -122,10 +121,34 @@ function useFirstRunTourControllerInternal() {
    * while a worker is allocated. Allocation routinely outlasts any deadline
    * short enough to be useful, so keying on status would fail healthy runs.
    */
-  const tourRunAccepted = computed(() =>
-    Object.values(executionStore.queuedJobs).some(
-      (job) => job.workflow === tourWorkflow.value
-    )
+  const acceptedTourJobId = computed(
+    () =>
+      (runCorrelationActive.value
+        ? Object.entries(executionStore.queuedJobs).find(
+            ([jobId, job]) =>
+              !queuedJobIdsBeforeRun.has(jobId) &&
+              job.workflow === tourWorkflow.value
+          )?.[0]
+        : undefined) ?? null
+  )
+  const tourRunAccepted = computed(() => tourJobId.value !== null)
+  const tourRunPresent = computed(
+    () =>
+      tourJobId.value !== null &&
+      runCorrelationActive.value &&
+      executionStore.queuedJobs[tourJobId.value]?.workflow ===
+        tourWorkflow.value
+  )
+
+  watch(
+    acceptedTourJobId,
+    (jobId) => {
+      if (!jobId || tourJobId.value) return
+      tourJobId.value = jobId
+      firstRunOutput.value ??= pendingRunOutputs.get(jobId) ?? null
+      stopAcceptDeadline()
+    },
+    { flush: 'sync' }
   )
 
   /**
@@ -160,10 +183,15 @@ function useFirstRunTourControllerInternal() {
    * same flush, and the terminal branches above overwrite unconditionally — so
    * the outcome wins whichever watcher runs first.
    */
-  watch(tourRunAccepted, (accepted) => {
-    if (accepted) stopAcceptDeadline()
-    else if (runState.value === 'generating') runState.value = 'failed'
-  })
+  watch(
+    tourRunPresent,
+    (present, wasPresent) => {
+      if (present) stopAcceptDeadline()
+      else if (wasPresent && runState.value === 'generating')
+        runState.value = 'failed'
+    },
+    { flush: 'sync' }
+  )
 
   let acceptTimer: ReturnType<typeof setTimeout> | undefined
   function stopAcceptDeadline() {
@@ -193,22 +221,23 @@ function useFirstRunTourControllerInternal() {
   })
   useEventListener(api, 'reconnected', stopOfflineGrace)
 
-  useEventListener(api, 'execution_start', (event) => {
-    const { detail } = event as CustomEvent<ExecutionStartWsMessage>
+  useEventListener(api, 'executed', (event) => {
+    const { detail } = event as CustomEvent<ExecutedWsMessage>
     if (
       engine.activeTour !== 'firstRun' ||
       runState.value !== 'generating' ||
-      tourJobId
+      queuedJobIdsBeforeRun.has(detail.prompt_id)
     )
       return
-    tourJobId = detail.prompt_id
-  })
-
-  useEventListener(api, 'executed', (event) => {
-    const { detail } = event as CustomEvent<ExecutedWsMessage>
-    if (detail.prompt_id !== tourJobId || firstRunOutput.value) return
     const image = detail.output.images?.find(({ filename }) => filename)
-    if (image) firstRunOutput.value = { ...image, type: image.type ?? 'output' }
+    if (!image) return
+    const output = { ...image, type: image.type ?? 'output' }
+    if (detail.prompt_id === tourJobId.value) {
+      firstRunOutput.value ??= output
+      return
+    }
+    if (!pendingRunOutputs.has(detail.prompt_id))
+      pendingRunOutputs.set(detail.prompt_id, output)
   })
 
   /**
@@ -229,6 +258,10 @@ function useFirstRunTourControllerInternal() {
         return
       }
 
+      queuedJobIdsBeforeRun = new Set(Object.keys(executionStore.queuedJobs))
+      pendingRunOutputs.clear()
+      tourJobId.value = null
+      runCorrelationActive.value = true
       runState.value = 'generating'
       startAcceptDeadline()
       engine.next()
@@ -250,7 +283,10 @@ function useFirstRunTourControllerInternal() {
       releaseFirstRunTargets()
       tourWorkflow.value = null
       firstRunOutput.value = null
-      tourJobId = null
+      pendingRunOutputs.clear()
+      queuedJobIdsBeforeRun.clear()
+      runCorrelationActive.value = false
+      tourJobId.value = null
       runState.value = 'idle'
     }
   )
@@ -276,7 +312,10 @@ function useFirstRunTourControllerInternal() {
     nudgeArmed.value = false
     nudgeOutput.value = null
     firstRunOutput.value = null
-    tourJobId = null
+    pendingRunOutputs.clear()
+    queuedJobIdsBeforeRun.clear()
+    runCorrelationActive.value = false
+    tourJobId.value = null
     registerTour(
       'firstRun',
       () => firstRunTourSteps(templateId, runState),

--- a/src/renderer/extensions/firstRunTour/tour/useFirstRunTourController.ts
+++ b/src/renderer/extensions/firstRunTour/tour/useFirstRunTourController.ts
@@ -14,10 +14,12 @@ import { useSettingStore } from '@/platform/settings/settingStore'
 import type { ComfyWorkflow } from '@/platform/workflow/management/stores/workflowStore'
 import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
+import { resultItemType } from '@/schemas/apiSchema'
 import type { ExecutedWsMessage, ResultItem } from '@/schemas/apiSchema'
 import { api } from '@/scripts/api'
 import { useExecutionErrorStore } from '@/stores/executionErrorStore'
 import { useExecutionStore } from '@/stores/executionStore'
+import { parseNodeOutput } from '@/stores/resultItemParsing'
 
 import {
   firstRunTourSteps,
@@ -47,8 +49,6 @@ function useFirstRunTourControllerInternal() {
   const desktopLayout = useBreakpoints(breakpointsTailwind).greaterOrEqual('md')
   const tourWorkflow = shallowRef<ComfyWorkflow | null>(null)
   const nudgeArmed = ref(false)
-  const tourWasCompleted = ref(false)
-  const nudgeOutput = shallowRef<ResultItem | null>(null)
   const firstRunOutput = shallowRef<ResultItem | null>(null)
   const tourJobId = ref<string | null>(null)
   const runCorrelationActive = ref(false)
@@ -57,7 +57,7 @@ function useFirstRunTourControllerInternal() {
 
   /**
    * The state that ties an accepted job back to this tour's run, reset as a
-   * unit so the three callers cannot drift apart. Starting a run is the one
+   * unit so the callers cannot drift apart. Starting a run is the one
    * difference: it snapshots the queue the new job has to be absent from, and
    * keeps the image an earlier run in the same tour already produced.
    */
@@ -69,6 +69,19 @@ function useFirstRunTourControllerInternal() {
     tourJobId.value = null
     runCorrelationActive.value = forNewRun
     if (!forNewRun) firstRunOutput.value = null
+  }
+
+  /**
+   * A run outlives the tour that started it, so ending the tour cannot end the
+   * correlation: the user who walks to the end while the image is still
+   * generating would lose it. An uncorrelated run can never be correlated once
+   * the tour's workflow is gone, so that one is dropped instead of leaked.
+   */
+  function releaseRunCorrelation() {
+    pendingRunOutputs.clear()
+    if (tourJobId.value !== null) return
+    queuedJobIdsBeforeRun.value = new Set()
+    runCorrelationActive.value = false
   }
 
   /**
@@ -147,7 +160,6 @@ function useFirstRunTourControllerInternal() {
           )?.[0]
         : undefined) ?? null
   )
-  const tourRunAccepted = computed(() => tourJobId.value !== null)
   const tourRunPresent = computed(
     () =>
       tourJobId.value !== null &&
@@ -216,7 +228,6 @@ function useFirstRunTourControllerInternal() {
   }
   function startAcceptDeadline() {
     stopAcceptDeadline()
-    if (tourRunAccepted.value) return
     acceptTimer = setTimeout(() => {
       stopAcceptDeadline()
       if (runState.value === 'generating') runState.value = 'failed'
@@ -237,27 +248,38 @@ function useFirstRunTourControllerInternal() {
   })
   useEventListener(api, 'reconnected', stopOfflineGrace)
 
+  /** A preview's temp file still seeds; the saved result behind it is better. */
+  const awaitingSavedOutput = computed(
+    () => firstRunOutput.value === null || firstRunOutput.value.type === 'temp'
+  )
+
   useEventListener(api, 'executed', (event) => {
     const { detail } = event as CustomEvent<ExecutedWsMessage>
     if (
-      engine.activeTour !== 'firstRun' ||
-      runState.value !== 'generating' ||
+      !runCorrelationActive.value ||
+      !awaitingSavedOutput.value ||
       queuedJobIdsBeforeRun.value.has(detail.prompt_id)
     )
       return
-    // A preview node ahead of the save node emits first, and its item is
-    // garbage-collected rather than kept — seeding it would hand the
-    // continuation a path the backend has already forgotten.
-    const image = detail.output.images?.find(
-      ({ filename, type }) => filename && type !== 'temp'
+    // Every media key, not just `images`: a template can save under `video` or
+    // under a key only its custom node knows, and only the item itself says
+    // whether what came back is an image the continuations can be seeded with.
+    const images = parseNodeOutput(detail.node, detail.output).filter(
+      (item) => item.isImage
     )
+    const image = images.find(({ type }) => type !== 'temp') ?? images[0]
     if (!image) return
-    const output = { ...image, type: image.type ?? 'output' }
+    const parsedType = resultItemType.safeParse(image.type)
+    const output: ResultItem = {
+      filename: image.filename,
+      subfolder: image.subfolder,
+      type: parsedType.success ? parsedType.data : 'output'
+    }
     if (detail.prompt_id === tourJobId.value) {
-      firstRunOutput.value ??= output
+      firstRunOutput.value = output
       return
     }
-    if (!pendingRunOutputs.has(detail.prompt_id))
+    if (tourJobId.value === null && !pendingRunOutputs.has(detail.prompt_id))
       pendingRunOutputs.set(detail.prompt_id, output)
   })
 
@@ -291,17 +313,15 @@ function useFirstRunTourControllerInternal() {
     () => engine.activeTour === 'firstRun',
     (active) => {
       if (active) return
-      const ending = engine.lastEnding
-      tourWasCompleted.value =
-        ending?.tour === 'firstRun' && ending.outcome === 'completed'
-      nudgeOutput.value = tourWasCompleted.value ? firstRunOutput.value : null
-      nudgeArmed.value = nudgeOutput.value !== null
+      // Every ending leaves the user somewhere to go next, so every ending arms
+      // the nudge; only what it can offer depends on what the run produced.
+      nudgeArmed.value = true
       stopOfflineGrace()
       stopAcceptDeadline()
       releaseFirstRunTargets()
-      tourWorkflow.value = null
-      resetRunCorrelation()
       runState.value = 'idle'
+      tourWorkflow.value = null
+      releaseRunCorrelation()
     }
   )
 
@@ -324,7 +344,6 @@ function useFirstRunTourControllerInternal() {
     tourWorkflow.value = workflowStore.activeWorkflow ?? null
     runState.value = 'idle'
     nudgeArmed.value = false
-    nudgeOutput.value = null
     resetRunCorrelation()
     registerTour(
       'firstRun',
@@ -348,7 +367,7 @@ function useFirstRunTourControllerInternal() {
   return {
     beginTour,
     nudgeArmed: readonly(nudgeArmed),
-    nudgeOutput: readonly(nudgeOutput),
+    nudgeOutput: readonly(firstRunOutput),
     dismissNudge
   }
 }

--- a/src/renderer/extensions/firstRunTour/tour/useFirstRunTourController.ts
+++ b/src/renderer/extensions/firstRunTour/tour/useFirstRunTourController.ts
@@ -258,7 +258,8 @@ function useFirstRunTourControllerInternal() {
     if (
       !runCorrelationActive.value ||
       !awaitingSavedOutput.value ||
-      queuedJobIdsBeforeRun.value.has(detail.prompt_id)
+      queuedJobIdsBeforeRun.value.has(detail.prompt_id) ||
+      (tourJobId.value !== null && detail.prompt_id !== tourJobId.value)
     )
       return
     // Every media key, not just `images`: a template can save under `video` or
@@ -275,11 +276,14 @@ function useFirstRunTourControllerInternal() {
       subfolder: image.subfolder,
       type: parsedType.success ? parsedType.data : 'output'
     }
-    if (detail.prompt_id === tourJobId.value) {
+    if (tourJobId.value !== null) {
       firstRunOutput.value = output
       return
     }
-    if (tourJobId.value === null && !pendingRunOutputs.has(detail.prompt_id))
+    // Buffered under the same preference as the direct branch: a preview that
+    // beat the queue metadata must not lock out the saved result behind it.
+    const buffered = pendingRunOutputs.get(detail.prompt_id)
+    if (!buffered || buffered.type === 'temp')
       pendingRunOutputs.set(detail.prompt_id, output)
   })
 


### PR DESCRIPTION
## Summary

Adds the DES-550 post-first-output discovery card and continues the generated image into three dedicated continuation workflows.

## Changes

- Shows the card after every first-run tour ending, and adds Animate, 4× Upscale, Nano Banana restyle, and Browse all templates actions.
- Seeds the captured output through each template's declared `io.inputs` metadata and fails closed if catalog/workflow metadata is incomplete or drifts.
- Filters the three actions against the served catalog, so an install on an older template package hides an action instead of failing it on click.
- Falls back to the template browser when nothing is seedable — an install serving none of the three, or a run that produced no image. Suppressing the card there would take the way forward from the users who most need it (#14144).
- Correlates output to the newly accepted first-run job across every media key, including WebSocket output arriving before HTTP job metadata, and outliving the tour so walking to the end during a long generation does not discard the result.
- Prefers a saved result over a preview on both the direct and the buffered path, but seeds a preview's `temp` file when nothing saved one — a `PreviewImage` sink is the whole result and the backend still serves it.
- Holds the card open while a continuation loads, so dismissing it cannot leave a graph swap or an error toast behind.
- Waits for the served catalog before rendering, so the card cannot paint the fallback and then rewrite itself into the continuations under the user. Capped at 3s, because a stalled fetch must not withhold the card from the user it is for (#14144).
- Preserves delayed display, dialog deferral, close/Escape behavior, no-auto-run, and loading/error feedback.

## Template dependency

Workflow templates: [Comfy-Org/workflow_templates#1184](https://github.com/Comfy-Org/workflow_templates/pull/1184) (merged).

Static mappings:

- `video_minimax_h3_i2v_continuation`
- `utility_seedvr2_7b_int8_upscale_image` (existing template; 4× multiplier)
- `api_google_nano_banana2_image_edit_continuation`

The paid action continues to rely on the existing execution-time auth and billing guard. Installs pin `comfyui_workflow_templates` independently of the frontend, so the catalog filter above is what keeps an older package from producing dead buttons.

Linear: [FE-1355](https://linear.app/comfyorg/issue/FE-1355/e-22-fe-post-nux-discovery-everything-you-can-do-free-paid)

## Telemetry

`tour_completed` is dropped from `nudge_shown` and `explore_templates_clicked`. `nudge_suggestion_clicked` is added, carrying the chosen action and whether its template opened.

All three nudge events now carry `suggestion_count` — this is a schema change for anyone querying them. Zero means the card fell back to the template browser, which is the only signal distinguishing template-package skew from a nudge that never appeared. The count reported is always the one rendered: the card and the event share a single catalog gate, so neither can describe a state the other never showed. Each tour reports its own impression — a second first-run tour is a second nudge, not a repeat of the first.

## Testing

- Focused unit/component tests across four suites, including catalog skew, a catalog that lands late and one that stalls, per-tour impression reporting, missing `io` metadata, the temp/saved output preference on both the direct and the buffered path, video output, late output after the tour ends, and the missing-filename path.
- `pnpm test:unit`, clean-install `vue-tsc --noEmit`, ESLint, type-aware Oxlint, formatting, and `knip --cache`.

## Screenshots (if applicable)

[Figma reference](https://www.figma.com/design/SSo9GcILgQhAV3uoa4r1xJ/Onboarding?node-id=2602-18740)

## Native GitHub stack

This is the bottom product layer. The E2E contract layer is #16136.

Supersedes #15319, which was closed so this replacement can participate in GitHub's first-party stacked pull request feature.