### PR TITLE
[agent-v1 02b/18] feat(crdt): human write leg for the shared doc

### DIFF
--- a/knip.config.ts
+++ b/knip.config.ts
@@ -55,6 +55,9 @@ const config: KnipConfig = {
     '@iconify/json'
   ],
   ignore: [
+    // TRANSITIONAL (agent-v1 chain): dev-only debug panel with no mount site
+    // until slices 07+ import the crdt tree; removable then. See docs/adr/0024.
+    'src/workbench/extensions/agent/crdt/CrdtDevPanel.vue',
     // Auto generated API types
     'src/workbench/extensions/manager/types/generatedManagerTypes.ts',
     'packages/ingest-types/src/zod.gen.ts',

--- a/src/lib/litegraph/src/LGraph.ts
+++ b/src/lib/litegraph/src/LGraph.ts
@@ -644,7 +644,13 @@ export class LGraph
   }
 
   set last_node_id(value) {
-    this.state.lastNodeId = Math.min(value, MINT_ID_MIN - 1)
+    if (value < MINT_ID_MIN) {
+      this.state.lastNodeId = value
+    } else if (import.meta.env.DEV) {
+      console.warn(
+        `last_node_id write ${value} is in the coordination-free mint range; ignored`
+      )
+    }
   }
 
   /** @deprecated See {@link state}.{@link LGraphState.lastLinkId lastLinkId} */
@@ -653,7 +659,13 @@ export class LGraph
   }
 
   set last_link_id(value) {
-    this.state.lastLinkId = toLinkId(Math.min(value, MINT_ID_MIN - 1))
+    if (value < MINT_ID_MIN) {
+      this.state.lastLinkId = toLinkId(value)
+    } else if (import.meta.env.DEV) {
+      console.warn(
+        `last_link_id write ${value} is in the coordination-free mint range; ignored`
+      )
+    }
   }
 
   onNodeAdded?(node: LGraphNode): void
@@ -2830,25 +2842,19 @@ export class LGraph
         // New schema - one version so far, no check required.
 
         // State - use max to prevent ID collisions across root and subgraphs.
-        // Node/link restores also clamp below the mint floor: a pre-guard
-        // save could have absorbed a minted id into its serialized counters
-        // (subgraph definitions serialize the root state), and restoring it
-        // verbatim would re-poison a fixed build.
+        // Node/link restores route through the observers, which IGNORE
+        // mint-range values outright: a pre-guard save could have absorbed a
+        // minted id into its serialized counters (subgraph definitions
+        // serialize the root state), and any restored floor-or-above value
+        // would put the next ++counter allocation inside the mint range.
         if (data.state) {
           const { lastGroupId, lastLinkId, lastNodeId, lastRerouteId } =
             data.state
           const { state } = this
           if (lastGroupId != null)
             state.lastGroupId = Math.max(state.lastGroupId, lastGroupId)
-          if (lastLinkId != null)
-            state.lastLinkId = toLinkId(
-              Math.min(Math.max(state.lastLinkId, lastLinkId), MINT_ID_MIN - 1)
-            )
-          if (lastNodeId != null)
-            state.lastNodeId = Math.min(
-              Math.max(state.lastNodeId, lastNodeId),
-              MINT_ID_MIN - 1
-            )
+          if (lastLinkId != null) observeLinkId(state, toLinkId(lastLinkId))
+          if (lastNodeId != null) observeNodeId(state, toNodeId(lastNodeId))
           if (lastRerouteId != null)
             state.lastRerouteId = toRerouteId(
               Math.max(state.lastRerouteId, lastRerouteId)

--- a/src/lib/litegraph/src/LGraph.ts
+++ b/src/lib/litegraph/src/LGraph.ts
@@ -34,6 +34,7 @@ import { isFloatingTopology } from '@/types/linkTopology'
 import { toRerouteId } from '@/types/rerouteId'
 import { graphScopeOf, toRootGraphId } from '@/types/graphScopeId'
 import {
+  MINT_ID_MIN,
   createLGraphState,
   mintGroupId,
   mintLinkId,
@@ -643,7 +644,7 @@ export class LGraph
   }
 
   set last_node_id(value) {
-    this.state.lastNodeId = value
+    this.state.lastNodeId = Math.min(value, MINT_ID_MIN - 1)
   }
 
   /** @deprecated See {@link state}.{@link LGraphState.lastLinkId lastLinkId} */
@@ -652,7 +653,7 @@ export class LGraph
   }
 
   set last_link_id(value) {
-    this.state.lastLinkId = toLinkId(value)
+    this.state.lastLinkId = toLinkId(Math.min(value, MINT_ID_MIN - 1))
   }
 
   onNodeAdded?(node: LGraphNode): void
@@ -2828,7 +2829,11 @@ export class LGraph
       } else {
         // New schema - one version so far, no check required.
 
-        // State - use max to prevent ID collisions across root and subgraphs
+        // State - use max to prevent ID collisions across root and subgraphs.
+        // Node/link restores also clamp below the mint floor: a pre-guard
+        // save could have absorbed a minted id into its serialized counters
+        // (subgraph definitions serialize the root state), and restoring it
+        // verbatim would re-poison a fixed build.
         if (data.state) {
           const { lastGroupId, lastLinkId, lastNodeId, lastRerouteId } =
             data.state
@@ -2836,9 +2841,14 @@ export class LGraph
           if (lastGroupId != null)
             state.lastGroupId = Math.max(state.lastGroupId, lastGroupId)
           if (lastLinkId != null)
-            state.lastLinkId = toLinkId(Math.max(state.lastLinkId, lastLinkId))
+            state.lastLinkId = toLinkId(
+              Math.min(Math.max(state.lastLinkId, lastLinkId), MINT_ID_MIN - 1)
+            )
           if (lastNodeId != null)
-            state.lastNodeId = Math.max(state.lastNodeId, lastNodeId)
+            state.lastNodeId = Math.min(
+              Math.max(state.lastNodeId, lastNodeId),
+              MINT_ID_MIN - 1
+            )
           if (lastRerouteId != null)
             state.lastRerouteId = toRerouteId(
               Math.max(state.lastRerouteId, lastRerouteId)

--- a/src/lib/litegraph/src/LGraph.ts
+++ b/src/lib/litegraph/src/LGraph.ts
@@ -644,11 +644,12 @@ export class LGraph
   }
 
   set last_node_id(value) {
-    if (value < MINT_ID_MIN) {
-      this.state.lastNodeId = value
+    const numeric = Number(value)
+    if (Number.isInteger(numeric) && numeric < MINT_ID_MIN - 1) {
+      this.state.lastNodeId = numeric
     } else if (import.meta.env.DEV) {
       console.warn(
-        `last_node_id write ${value} is in the coordination-free mint range; ignored`
+        `last_node_id write ${value} is not a counter-range integer; ignored`
       )
     }
   }
@@ -659,11 +660,12 @@ export class LGraph
   }
 
   set last_link_id(value) {
-    if (value < MINT_ID_MIN) {
-      this.state.lastLinkId = toLinkId(value)
+    const numeric = Number(value)
+    if (Number.isInteger(numeric) && numeric < MINT_ID_MIN - 1) {
+      this.state.lastLinkId = toLinkId(numeric)
     } else if (import.meta.env.DEV) {
       console.warn(
-        `last_link_id write ${value} is in the coordination-free mint range; ignored`
+        `last_link_id write ${value} is not a counter-range integer; ignored`
       )
     }
   }

--- a/src/lib/litegraph/src/idAllocation.test.ts
+++ b/src/lib/litegraph/src/idAllocation.test.ts
@@ -92,6 +92,17 @@ describe('idAllocation', () => {
     expect(state.lastNodeId).toBe(MINT_ID_MIN - 2)
     expect(Number(state.lastLinkId)).toBe(MINT_ID_MIN - 2)
   })
+
+  it('fails before sequential counters enter the coordination-free range', () => {
+    const state = createLGraphState()
+    state.lastNodeId = MINT_ID_MIN - 2
+    state.lastLinkId = toLinkId(MINT_ID_MIN - 2)
+
+    expect(mintNodeId(state)).toBe(String(MINT_ID_MIN - 1))
+    expect(mintLinkId(state)).toBe(MINT_ID_MIN - 1)
+    expect(() => mintNodeId(state)).toThrow(RangeError)
+    expect(() => mintLinkId(state)).toThrow(RangeError)
+  })
 })
 
 describe('coordination-free (doc-bound) allocation', () => {

--- a/src/lib/litegraph/src/idAllocation.test.ts
+++ b/src/lib/litegraph/src/idAllocation.test.ts
@@ -1,8 +1,11 @@
 import * as fc from 'fast-check'
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterAll, describe, expect, it } from 'vitest'
 
 import {
+  MINT_ID_CEILING,
+  MINT_ID_MIN,
   createLGraphState,
+  mintCoordinationFreeId,
   mintGroupId,
   mintLinkId,
   mintNodeId,
@@ -13,7 +16,7 @@ import {
   observeRerouteId,
   setCoordinationFreeIds
 } from '@/lib/litegraph/src/idAllocation'
-import { LGraph, LGraphNode } from '@/lib/litegraph/src/litegraph'
+import { LGraph, LGraphNode, LiteGraph } from '@/lib/litegraph/src/litegraph'
 import { toGroupId } from '@/types/groupId'
 import { toLinkId } from '@/types/linkId'
 import { toNodeId } from '@/types/nodeId'
@@ -57,76 +60,163 @@ describe('idAllocation', () => {
 
     expect(state.lastNodeId).toBe(12)
   })
+
+  it('never seeds a counter from a mint-range id', () => {
+    const state = createLGraphState()
+    state.lastNodeId = 7
+    state.lastLinkId = toLinkId(9)
+
+    observeNodeId(state, toNodeId(MINT_ID_MIN))
+    observeNodeId(state, toNodeId(String(MINT_ID_MIN + 5)))
+    observeLinkId(state, toLinkId(MINT_ID_MIN))
+
+    // Absorbing a minted id would advance the counter into the mint range,
+    // so a later counter allocation could alias a minted entry.
+    expect(state.lastNodeId).toBe(7)
+    expect(Number(state.lastLinkId)).toBe(9)
+
+    observeNodeId(state, toNodeId(MINT_ID_MIN - 1))
+    observeLinkId(state, toLinkId(MINT_ID_MIN - 1))
+    expect(state.lastNodeId).toBe(MINT_ID_MIN - 1)
+    expect(Number(state.lastLinkId)).toBe(MINT_ID_MIN - 1)
+  })
 })
 
 describe('coordination-free (doc-bound) allocation', () => {
-  afterEach(() => {
-    setCoordinationFreeIds(false)
-  })
+  // Branded-id construction makes the 100-run sweep slow under a loaded
+  // parallel suite; the work is constant per run, so only the budget moves.
+  it(
+    'two replicas seeded from one snapshot allocate disjoint node and link ids',
+    { timeout: 20_000 },
+    () => {
+      fc.assert(
+        fc.property(fc.integer({ min: 1, max: 200 }), (count) => {
+          // Both replicas resume from the SAME snapshot counters - the exact
+          // aliasing setup from the review finding. Disjointness is statistical
+          // (independent draws from a 2^53-wide range), so the draws stay on
+          // the real entropy source.
+          const replicaA = createLGraphState()
+          const replicaB = createLGraphState()
+          for (const state of [replicaA, replicaB]) {
+            state.lastNodeId = 7
+            state.lastLinkId = toLinkId(9)
+            setCoordinationFreeIds(state, true)
+          }
 
-  const MINT_ID_MIN = 2 ** 40
+          const minted = [
+            ...Array.from({ length: count }, () =>
+              String(mintNodeId(replicaA))
+            ),
+            ...Array.from({ length: count }, () =>
+              String(mintNodeId(replicaB))
+            ),
+            ...Array.from({ length: count }, () =>
+              String(mintLinkId(replicaA))
+            ),
+            ...Array.from({ length: count }, () => String(mintLinkId(replicaB)))
+          ]
 
-  it('two replicas seeded from one snapshot allocate disjoint node and link ids', () => {
+          expect(new Set(minted).size).toBe(minted.length)
+          for (const id of minted) {
+            const numeric = Number(id)
+            expect(Number.isSafeInteger(numeric)).toBe(true)
+            expect(numeric).toBeGreaterThanOrEqual(MINT_ID_MIN)
+          }
+        })
+      )
+    }
+  )
+
+  it('maps the whole random domain into [2^40, 2^53) integers', () => {
     fc.assert(
-      fc.property(fc.integer({ min: 1, max: 200 }), (count) => {
-        // Both replicas resume from the SAME snapshot counters - the exact
-        // aliasing setup from the review finding.
-        const replicaA = createLGraphState()
-        const replicaB = createLGraphState()
-        for (const state of [replicaA, replicaB]) {
-          state.lastNodeId = 7
-          state.lastLinkId = toLinkId(9)
-        }
-        setCoordinationFreeIds(true)
+      fc.property(
+        fc.double({ min: 0, max: 1, maxExcluded: true, noNaN: true }),
+        (draw) => {
+          const minted = mintCoordinationFreeId(() => draw)
 
-        const minted = [
-          ...Array.from({ length: count }, () => String(mintNodeId(replicaA))),
-          ...Array.from({ length: count }, () => String(mintNodeId(replicaB))),
-          ...Array.from({ length: count }, () => String(mintLinkId(replicaA))),
-          ...Array.from({ length: count }, () => String(mintLinkId(replicaB)))
-        ]
-
-        expect(new Set(minted).size).toBe(minted.length)
-        for (const id of minted) {
-          const numeric = Number(id)
-          expect(Number.isSafeInteger(numeric)).toBe(true)
-          expect(numeric).toBeGreaterThanOrEqual(MINT_ID_MIN)
+          expect(Number.isSafeInteger(minted)).toBe(true)
+          expect(minted).toBeGreaterThanOrEqual(MINT_ID_MIN)
+          expect(minted).toBeLessThan(MINT_ID_CEILING)
         }
-      })
+      )
     )
   })
 
-  it('unbound allocation stays byte-identical: counters untouched while armed, sequential after', () => {
+  it('arming scopes to the given state: other states keep counters', () => {
+    const armed = createLGraphState()
+    const unbound = createLGraphState()
+    setCoordinationFreeIds(armed, true)
+
+    expect(Number(mintNodeId(armed))).toBeGreaterThanOrEqual(MINT_ID_MIN)
+    expect([mintNodeId(unbound), mintLinkId(unbound)]).toEqual(['1', 1])
+  })
+
+  it('armed mints leave the counters untouched; disarming restores the sequential run', () => {
     const state = createLGraphState()
 
-    setCoordinationFreeIds(true)
+    setCoordinationFreeIds(state, true)
     mintNodeId(state)
     mintLinkId(state)
     // Armed mints never advance the counters.
     expect(state.lastNodeId).toBe(0)
     expect(Number(state.lastLinkId)).toBe(0)
 
-    setCoordinationFreeIds(false)
+    setCoordinationFreeIds(state, false)
     // Exactly the unbound sequence - the same values the unarmed pin above
     // produces from a fresh state.
     expect([mintNodeId(state), mintNodeId(state)]).toEqual(['1', '2'])
     expect([mintLinkId(state), mintLinkId(state)]).toEqual([1, 2])
   })
 
-  it('a minted id survives a serialize/configure round-trip', () => {
-    setCoordinationFreeIds(true)
-    const graph = new LGraph()
-    const node = new LGraphNode('Test Node')
-    graph.add(node)
-    const minted = String(node.id)
-    expect(Number(minted)).toBeGreaterThanOrEqual(MINT_ID_MIN)
+  it('groups and reroutes stay on counters while armed', () => {
+    const state = createLGraphState()
+    setCoordinationFreeIds(state, true)
 
-    setCoordinationFreeIds(false)
+    expect([mintGroupId(state), mintGroupId(state)]).toEqual([1, 2])
+    expect([mintRerouteId(state), mintRerouteId(state)]).toEqual([1, 2])
+  })
+})
+
+describe('coordination-free ids across a serialize/configure round-trip', () => {
+  class WiredNode extends LGraphNode {
+    constructor(title?: string) {
+      super(title ?? 'WiredNode')
+      this.addInput('in', 'number')
+      this.addOutput('out', 'number')
+    }
+  }
+  LiteGraph.registerNodeType('test/wired', WiredNode)
+
+  afterAll(() => {
+    LiteGraph.unregisterNodeType('test/wired')
+  })
+
+  it('minted node and link ids survive the round-trip without seeding the counters', () => {
+    const graph = new LGraph()
+    setCoordinationFreeIds(graph.state, true)
+    const source = LiteGraph.createNode('test/wired')!
+    const target = LiteGraph.createNode('test/wired')!
+    graph.add(source)
+    graph.add(target)
+    const link = source.connect(0, target, 0)
+    if (!link) throw new Error('connect failed')
+
+    const mintedNode = Number(source.id)
+    const mintedLink = Number(link.id)
+    expect(mintedNode).toBeGreaterThanOrEqual(MINT_ID_MIN)
+    expect(mintedLink).toBeGreaterThanOrEqual(MINT_ID_MIN)
+
     const reloaded = new LGraph()
     reloaded.configure(graph.serialize())
 
-    expect(reloaded._nodes.map((candidate) => String(candidate.id))).toContain(
-      minted
+    expect(reloaded._nodes.map((candidate) => Number(candidate.id))).toContain(
+      mintedNode
     )
+    // LinkId is a raw number brand on its own serialize path.
+    expect(reloaded.links.get(toLinkId(mintedLink))).toBeTruthy()
+    // The observers refuse mint-range ids, so the reloaded counters stay
+    // pristine instead of being dragged into the mint range.
+    expect(reloaded.state.lastNodeId).toBe(0)
+    expect(Number(reloaded.state.lastLinkId)).toBe(0)
   })
 })

--- a/src/lib/litegraph/src/idAllocation.test.ts
+++ b/src/lib/litegraph/src/idAllocation.test.ts
@@ -80,10 +80,17 @@ describe('idAllocation', () => {
     expect(state.lastNodeId).toBe(7)
     expect(Number(state.lastLinkId)).toBe(9)
 
+    // The boundary value is ignored too: its own next ++ would allocate
+    // exactly the floor (and the round-3 clamp build saved this value).
     observeNodeId(state, toNodeId(MINT_ID_MIN - 1))
     observeLinkId(state, toLinkId(MINT_ID_MIN - 1))
-    expect(state.lastNodeId).toBe(MINT_ID_MIN - 1)
-    expect(Number(state.lastLinkId)).toBe(MINT_ID_MIN - 1)
+    expect(state.lastNodeId).toBe(7)
+    expect(Number(state.lastLinkId)).toBe(9)
+
+    observeNodeId(state, toNodeId(MINT_ID_MIN - 2))
+    observeLinkId(state, toLinkId(MINT_ID_MIN - 2))
+    expect(state.lastNodeId).toBe(MINT_ID_MIN - 2)
+    expect(Number(state.lastLinkId)).toBe(MINT_ID_MIN - 2)
   })
 })
 
@@ -228,7 +235,7 @@ describe('coordination-free ids across a serialize/configure round-trip', () => 
   })
 })
 
-describe('counter restores clamp below the mint floor', () => {
+describe('counter restores ignore mint-range values', () => {
   const POISONED = MINT_ID_MIN + 5
 
   it('a poisoned root state restore cannot seed the counters', () => {
@@ -315,5 +322,20 @@ describe('counter restores clamp below the mint floor', () => {
     graph.last_link_id = toLinkId(5)
     expect(graph.state.lastNodeId).toBe(5)
     expect(Number(graph.state.lastLinkId)).toBe(5)
+  })
+
+  it('the deprecated setters coerce numeric strings and drop non-numerics', () => {
+    const graph = new LGraph()
+
+    // The untyped 0.4 configure loop feeds these raw JSON values, and
+    // subgraphStore payloads carry string ids.
+    graph.last_node_id = '21' as unknown as number
+    graph.last_link_id = '34' as unknown as ReturnType<typeof toLinkId>
+
+    expect(graph.state.lastNodeId).toBe(21)
+    expect(Number(graph.state.lastLinkId)).toBe(34)
+
+    graph.last_node_id = 'bogus' as unknown as number
+    expect(graph.state.lastNodeId).toBe(21)
   })
 })

--- a/src/lib/litegraph/src/idAllocation.test.ts
+++ b/src/lib/litegraph/src/idAllocation.test.ts
@@ -2,6 +2,11 @@ import * as fc from 'fast-check'
 import { afterAll, describe, expect, it } from 'vitest'
 
 import {
+  SUBGRAPH_INPUT_ID,
+  SUBGRAPH_OUTPUT_ID
+} from '@/lib/litegraph/src/constants'
+
+import {
   MINT_ID_CEILING,
   MINT_ID_MIN,
   createLGraphState,
@@ -201,15 +206,16 @@ describe('coordination-free ids across a serialize/configure round-trip', () => 
     const link = source.connect(0, target, 0)
     if (!link) throw new Error('connect failed')
 
-    const mintedNode = Number(source.id)
+    const mintedNode = String(source.id)
     const mintedLink = Number(link.id)
-    expect(mintedNode).toBeGreaterThanOrEqual(MINT_ID_MIN)
+    expect(Number(mintedNode)).toBeGreaterThanOrEqual(MINT_ID_MIN)
     expect(mintedLink).toBeGreaterThanOrEqual(MINT_ID_MIN)
 
     const reloaded = new LGraph()
     reloaded.configure(graph.serialize())
 
-    expect(reloaded._nodes.map((candidate) => Number(candidate.id))).toContain(
+    // NodeId is a string brand: pin the serialized form.
+    expect(reloaded._nodes.map((candidate) => String(candidate.id))).toContain(
       mintedNode
     )
     // LinkId is a raw number brand on its own serialize path.
@@ -218,5 +224,79 @@ describe('coordination-free ids across a serialize/configure round-trip', () => 
     // pristine instead of being dragged into the mint range.
     expect(reloaded.state.lastNodeId).toBe(0)
     expect(Number(reloaded.state.lastLinkId)).toBe(0)
+  })
+})
+
+describe('counter restores clamp below the mint floor', () => {
+  const POISONED = MINT_ID_MIN + 5
+
+  it('a poisoned root state restore cannot seed the counters', () => {
+    const graph = new LGraph()
+
+    // asSerialisable is the new-schema payload; the legacy 0.4 branch
+    // ignores `state` entirely, so only this shape reaches the restore.
+    graph.configure({
+      ...new LGraph().asSerialisable(),
+      state: {
+        lastGroupId: 0,
+        lastLinkId: toLinkId(POISONED),
+        lastNodeId: POISONED,
+        lastRerouteId: toRerouteId(0)
+      }
+    })
+
+    // A pre-guard client whose counter absorbed a minted id saved that
+    // counter; restoring it verbatim would re-poison a fixed build.
+    expect(graph.state.lastNodeId).toBeLessThan(MINT_ID_MIN)
+    expect(Number(graph.state.lastLinkId)).toBeLessThan(MINT_ID_MIN)
+  })
+
+  it('a poisoned subgraph definition cannot seed any counter', () => {
+    const graph = new LGraph()
+
+    graph.configure({
+      ...new LGraph().asSerialisable(),
+      definitions: {
+        subgraphs: [
+          {
+            id: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+            name: 'poisoned',
+            version: 1,
+            revision: 0,
+            state: {
+              lastGroupId: 0,
+              lastLinkId: toLinkId(POISONED),
+              lastNodeId: POISONED,
+              lastRerouteId: toRerouteId(0)
+            },
+            nodes: [],
+            links: [],
+            groups: [],
+            inputNode: { id: SUBGRAPH_INPUT_ID, bounding: [0, 0, 100, 100] },
+            outputNode: { id: SUBGRAPH_OUTPUT_ID, bounding: [0, 0, 100, 100] },
+            inputs: [],
+            outputs: [],
+            widgets: []
+          }
+        ]
+      }
+    })
+
+    expect(graph.state.lastNodeId).toBeLessThan(MINT_ID_MIN)
+    expect(Number(graph.state.lastLinkId)).toBeLessThan(MINT_ID_MIN)
+    for (const subgraph of graph.subgraphs.values()) {
+      expect(subgraph.state.lastNodeId).toBeLessThan(MINT_ID_MIN)
+      expect(Number(subgraph.state.lastLinkId)).toBeLessThan(MINT_ID_MIN)
+    }
+  })
+
+  it('the deprecated counter setters clamp below the mint floor', () => {
+    const graph = new LGraph()
+
+    graph.last_node_id = POISONED
+    graph.last_link_id = toLinkId(POISONED)
+
+    expect(graph.state.lastNodeId).toBeLessThan(MINT_ID_MIN)
+    expect(Number(graph.state.lastLinkId)).toBeLessThan(MINT_ID_MIN)
   })
 })

--- a/src/lib/litegraph/src/idAllocation.test.ts
+++ b/src/lib/litegraph/src/idAllocation.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it } from 'vitest'
+import * as fc from 'fast-check'
+import { afterEach, describe, expect, it } from 'vitest'
 
 import {
   createLGraphState,
@@ -9,8 +10,10 @@ import {
   observeGroupId,
   observeLinkId,
   observeNodeId,
-  observeRerouteId
+  observeRerouteId,
+  setCoordinationFreeIds
 } from '@/lib/litegraph/src/idAllocation'
+import { LGraph, LGraphNode } from '@/lib/litegraph/src/litegraph'
 import { toGroupId } from '@/types/groupId'
 import { toLinkId } from '@/types/linkId'
 import { toNodeId } from '@/types/nodeId'
@@ -53,5 +56,77 @@ describe('idAllocation', () => {
     observeNodeId(state, toNodeId('named'))
 
     expect(state.lastNodeId).toBe(12)
+  })
+})
+
+describe('coordination-free (doc-bound) allocation', () => {
+  afterEach(() => {
+    setCoordinationFreeIds(false)
+  })
+
+  const MINT_ID_MIN = 2 ** 40
+
+  it('two replicas seeded from one snapshot allocate disjoint node and link ids', () => {
+    fc.assert(
+      fc.property(fc.integer({ min: 1, max: 200 }), (count) => {
+        // Both replicas resume from the SAME snapshot counters - the exact
+        // aliasing setup from the review finding.
+        const replicaA = createLGraphState()
+        const replicaB = createLGraphState()
+        for (const state of [replicaA, replicaB]) {
+          state.lastNodeId = 7
+          state.lastLinkId = toLinkId(9)
+        }
+        setCoordinationFreeIds(true)
+
+        const minted = [
+          ...Array.from({ length: count }, () => String(mintNodeId(replicaA))),
+          ...Array.from({ length: count }, () => String(mintNodeId(replicaB))),
+          ...Array.from({ length: count }, () => String(mintLinkId(replicaA))),
+          ...Array.from({ length: count }, () => String(mintLinkId(replicaB)))
+        ]
+
+        expect(new Set(minted).size).toBe(minted.length)
+        for (const id of minted) {
+          const numeric = Number(id)
+          expect(Number.isSafeInteger(numeric)).toBe(true)
+          expect(numeric).toBeGreaterThanOrEqual(MINT_ID_MIN)
+        }
+      })
+    )
+  })
+
+  it('unbound allocation stays byte-identical: counters untouched while armed, sequential after', () => {
+    const state = createLGraphState()
+
+    setCoordinationFreeIds(true)
+    mintNodeId(state)
+    mintLinkId(state)
+    // Armed mints never advance the counters.
+    expect(state.lastNodeId).toBe(0)
+    expect(Number(state.lastLinkId)).toBe(0)
+
+    setCoordinationFreeIds(false)
+    // Exactly the unbound sequence - the same values the unarmed pin above
+    // produces from a fresh state.
+    expect([mintNodeId(state), mintNodeId(state)]).toEqual(['1', '2'])
+    expect([mintLinkId(state), mintLinkId(state)]).toEqual([1, 2])
+  })
+
+  it('a minted id survives a serialize/configure round-trip', () => {
+    setCoordinationFreeIds(true)
+    const graph = new LGraph()
+    const node = new LGraphNode('Test Node')
+    graph.add(node)
+    const minted = String(node.id)
+    expect(Number(minted)).toBeGreaterThanOrEqual(MINT_ID_MIN)
+
+    setCoordinationFreeIds(false)
+    const reloaded = new LGraph()
+    reloaded.configure(graph.serialize())
+
+    expect(reloaded._nodes.map((candidate) => String(candidate.id))).toContain(
+      minted
+    )
   })
 })

--- a/src/lib/litegraph/src/idAllocation.test.ts
+++ b/src/lib/litegraph/src/idAllocation.test.ts
@@ -90,9 +90,10 @@ describe('idAllocation', () => {
 describe('coordination-free (doc-bound) allocation', () => {
   // Branded-id construction makes the 100-run sweep slow under a loaded
   // parallel suite; the work is constant per run, so only the budget moves.
+  // The printed seed replays the counts, not the draws (real entropy).
   it(
     'two replicas seeded from one snapshot allocate disjoint node and link ids',
-    { timeout: 20_000 },
+    { timeout: 5_000 },
     () => {
       fc.assert(
         fc.property(fc.integer({ min: 1, max: 200 }), (count) => {
@@ -246,9 +247,12 @@ describe('counter restores clamp below the mint floor', () => {
     })
 
     // A pre-guard client whose counter absorbed a minted id saved that
-    // counter; restoring it verbatim would re-poison a fixed build.
-    expect(graph.state.lastNodeId).toBeLessThan(MINT_ID_MIN)
-    expect(Number(graph.state.lastLinkId)).toBeLessThan(MINT_ID_MIN)
+    // counter; the restore IGNORES it, so the next ALLOCATION stays out of
+    // the mint range (a clamp to the floor would not - 2^40 - 1 + 1 = 2^40).
+    expect(graph.state.lastNodeId).toBe(0)
+    expect(Number(graph.state.lastLinkId)).toBe(0)
+    expect(Number(mintNodeId(graph.state))).toBeLessThan(MINT_ID_MIN)
+    expect(Number(mintLinkId(graph.state))).toBeLessThan(MINT_ID_MIN)
   })
 
   it('a poisoned subgraph definition cannot seed any counter', () => {
@@ -282,21 +286,34 @@ describe('counter restores clamp below the mint floor', () => {
       }
     })
 
-    expect(graph.state.lastNodeId).toBeLessThan(MINT_ID_MIN)
-    expect(Number(graph.state.lastLinkId)).toBeLessThan(MINT_ID_MIN)
+    expect(Number(mintNodeId(graph.state))).toBeLessThan(MINT_ID_MIN)
+    expect(Number(mintLinkId(graph.state))).toBeLessThan(MINT_ID_MIN)
+    // Subgraph.state aliases the root state (the getter returns
+    // _rootGraph.state), so these run the same guard through the
+    // subgraph-definition restore path.
     for (const subgraph of graph.subgraphs.values()) {
-      expect(subgraph.state.lastNodeId).toBeLessThan(MINT_ID_MIN)
-      expect(Number(subgraph.state.lastLinkId)).toBeLessThan(MINT_ID_MIN)
+      expect(Number(mintNodeId(subgraph.state))).toBeLessThan(MINT_ID_MIN)
+      expect(Number(mintLinkId(subgraph.state))).toBeLessThan(MINT_ID_MIN)
     }
   })
 
-  it('the deprecated counter setters clamp below the mint floor', () => {
+  it('the deprecated counter setters ignore mint-range writes but still lower', () => {
     const graph = new LGraph()
+    graph.last_node_id = 10
+    graph.last_link_id = toLinkId(10)
 
     graph.last_node_id = POISONED
     graph.last_link_id = toLinkId(POISONED)
 
-    expect(graph.state.lastNodeId).toBeLessThan(MINT_ID_MIN)
-    expect(Number(graph.state.lastLinkId)).toBeLessThan(MINT_ID_MIN)
+    // The poisoned write is dropped outright; the next allocation stays
+    // out of the mint range.
+    expect(Number(mintNodeId(graph.state))).toBeLessThan(MINT_ID_MIN)
+    expect(Number(mintLinkId(graph.state))).toBeLessThan(MINT_ID_MIN)
+
+    // Lowering is an assignment, not an observation - it must still work.
+    graph.last_node_id = 5
+    graph.last_link_id = toLinkId(5)
+    expect(graph.state.lastNodeId).toBe(5)
+    expect(Number(graph.state.lastLinkId)).toBe(5)
   })
 })

--- a/src/lib/litegraph/src/idAllocation.ts
+++ b/src/lib/litegraph/src/idAllocation.ts
@@ -24,7 +24,38 @@ export function createLGraphState(): LGraphState {
   }
 }
 
+/**
+ * The shared-doc contract's coordination-free id range: comfy-cli's
+ * `mint_id()` draws integers in `[2^40, 2^53)` (see the `NodeId` note in
+ * `@comfyorg/comfy-multi-player`'s types). The floor keeps minted ids
+ * disjoint from every counter-allocated id, and the ceiling stays inside
+ * `Number.MAX_SAFE_INTEGER`.
+ */
+const MINT_ID_MIN = 2 ** 40
+const MINT_ID_SPAN = 2 ** 53 - MINT_ID_MIN
+
+let coordinationFreeIds = false
+
+/**
+ * Arm the contract's coordination-free id scheme for node and link
+ * allocation. Armed only while a semantic doc is bound to the active
+ * workflow: two replicas seeded from one snapshot then cannot allocate the
+ * same next id, so concurrent `add_node`/`add_link` operations never alias
+ * one document entry. While armed, the sequential counters are not
+ * advanced; unbound graphs keep counter allocation byte-identically.
+ * Groups and reroutes are canvas-local (not shared-doc entities) and stay
+ * on counters in both modes.
+ */
+export function setCoordinationFreeIds(enabled: boolean): void {
+  coordinationFreeIds = enabled
+}
+
+function mintCoordinationFreeId(): number {
+  return MINT_ID_MIN + Math.floor(Math.random() * MINT_ID_SPAN)
+}
+
 export function mintNodeId(state: LGraphState): NodeId {
+  if (coordinationFreeIds) return toNodeId(mintCoordinationFreeId())
   return toNodeId(++state.lastNodeId)
 }
 
@@ -33,6 +64,7 @@ export function mintGroupId(state: LGraphState): GroupId {
 }
 
 export function mintLinkId(state: LGraphState): LinkId {
+  if (coordinationFreeIds) return toLinkId(mintCoordinationFreeId())
   state.lastLinkId = toLinkId(Number(state.lastLinkId) + 1)
   return state.lastLinkId
 }

--- a/src/lib/litegraph/src/idAllocation.ts
+++ b/src/lib/litegraph/src/idAllocation.ts
@@ -25,37 +25,49 @@ export function createLGraphState(): LGraphState {
 }
 
 /**
- * The shared-doc contract's coordination-free id range: comfy-cli's
- * `mint_id()` draws integers in `[2^40, 2^53)` (see the `NodeId` note in
- * `@comfyorg/comfy-multi-player`'s types). The floor keeps minted ids
- * disjoint from every counter-allocated id, and the ceiling stays inside
+ * The shared-doc contract's coordination-free id range, quoted from the
+ * pinned `@comfyorg/comfy-multi-player` `NodeId` doc: "comfy-cli mints ints
+ * (`mint_id()`, `[2^40, 2^53)`)". The floor keeps minted ids disjoint from
+ * every counter-allocated id, and the ceiling stays inside
  * `Number.MAX_SAFE_INTEGER`.
  */
-const MINT_ID_MIN = 2 ** 40
-const MINT_ID_SPAN = 2 ** 53 - MINT_ID_MIN
+export const MINT_ID_MIN = 2 ** 40
+export const MINT_ID_CEILING = 2 ** 53
+const MINT_ID_SPAN = MINT_ID_CEILING - MINT_ID_MIN
 
-let coordinationFreeIds = false
+const coordinationFreeStates = new WeakSet<LGraphState>()
 
 /**
  * Arm the contract's coordination-free id scheme for node and link
- * allocation. Armed only while a semantic doc is bound to the active
- * workflow: two replicas seeded from one snapshot then cannot allocate the
- * same next id, so concurrent `add_node`/`add_link` operations never alias
- * one document entry. While armed, the sequential counters are not
- * advanced; unbound graphs keep counter allocation byte-identically.
- * Groups and reroutes are canvas-local (not shared-doc entities) and stay
- * on counters in both modes.
+ * allocation against ONE graph's state. Armed only while a semantic doc is
+ * bound to that graph: two replicas seeded from one snapshot then cannot
+ * allocate the same next id, so concurrent `add_node`/`add_link` operations
+ * never alias one document entry. Every allocation against an armed state
+ * mints - load, paste, and collision remints included by design, since any
+ * id born on a doc-bound graph must be alias-free. While armed, the
+ * sequential counters are not advanced; every other graph state keeps
+ * counter allocation byte-identically, and `LGraph.clear()` replaces the
+ * state object, so a swapped-in graph starts unarmed (fails closed) until
+ * its owner re-arms it. Groups and reroutes are canvas-local (not
+ * shared-doc entities) and stay on counters in both modes.
  */
-export function setCoordinationFreeIds(enabled: boolean): void {
-  coordinationFreeIds = enabled
+export function setCoordinationFreeIds(
+  state: LGraphState,
+  enabled: boolean
+): void {
+  if (enabled) coordinationFreeStates.add(state)
+  else coordinationFreeStates.delete(state)
 }
 
-function mintCoordinationFreeId(): number {
-  return MINT_ID_MIN + Math.floor(Math.random() * MINT_ID_SPAN)
+export function mintCoordinationFreeId(
+  random: () => number = Math.random
+): number {
+  return MINT_ID_MIN + Math.floor(random() * MINT_ID_SPAN)
 }
 
 export function mintNodeId(state: LGraphState): NodeId {
-  if (coordinationFreeIds) return toNodeId(mintCoordinationFreeId())
+  if (coordinationFreeStates.has(state))
+    return toNodeId(mintCoordinationFreeId())
   return toNodeId(++state.lastNodeId)
 }
 
@@ -64,7 +76,8 @@ export function mintGroupId(state: LGraphState): GroupId {
 }
 
 export function mintLinkId(state: LGraphState): LinkId {
-  if (coordinationFreeIds) return toLinkId(mintCoordinationFreeId())
+  if (coordinationFreeStates.has(state))
+    return toLinkId(mintCoordinationFreeId())
   state.lastLinkId = toLinkId(Number(state.lastLinkId) + 1)
   return state.lastLinkId
 }
@@ -74,9 +87,19 @@ export function mintRerouteId(state: LGraphState): RerouteId {
   return state.lastRerouteId
 }
 
+/**
+ * Ids at or above `MINT_ID_MIN` never seed a counter: absorbing a minted id
+ * would advance `lastNodeId`/`lastLinkId` into the mint range, and the next
+ * counter allocation on any replica could then alias a minted entry - the
+ * disjointness the range exists to guarantee, in the other direction.
+ */
 export function observeNodeId(state: LGraphState, id: NodeId): void {
   const numericId = Number(id)
-  if (Number.isInteger(numericId) && numericId > state.lastNodeId) {
+  if (
+    Number.isInteger(numericId) &&
+    numericId < MINT_ID_MIN &&
+    numericId > state.lastNodeId
+  ) {
     state.lastNodeId = numericId
   }
 }
@@ -86,7 +109,8 @@ export function observeGroupId(state: LGraphState, id: GroupId): void {
 }
 
 export function observeLinkId(state: LGraphState, id: LinkId): void {
-  if (id > state.lastLinkId) state.lastLinkId = id
+  if (Number.isInteger(Number(id)) && id < MINT_ID_MIN && id > state.lastLinkId)
+    state.lastLinkId = id
 }
 
 export function observeRerouteId(state: LGraphState, id: RerouteId): void {

--- a/src/lib/litegraph/src/idAllocation.ts
+++ b/src/lib/litegraph/src/idAllocation.ts
@@ -88,7 +88,8 @@ export function mintRerouteId(state: LGraphState): RerouteId {
 }
 
 /**
- * Ids at or above `MINT_ID_MIN` never seed a counter: absorbing a minted id
+ * Ids at or above `MINT_ID_MIN - 1` never seed a counter (the boundary
+ * value's own next ++ would allocate exactly the floor): absorbing a minted id
  * would advance `lastNodeId`/`lastLinkId` into the mint range, and the next
  * counter allocation on any replica could then alias a minted entry - the
  * disjointness the range exists to guarantee, in the other direction.
@@ -97,7 +98,7 @@ export function observeNodeId(state: LGraphState, id: NodeId): void {
   const numericId = Number(id)
   if (
     Number.isInteger(numericId) &&
-    numericId < MINT_ID_MIN &&
+    numericId < MINT_ID_MIN - 1 &&
     numericId > state.lastNodeId
   ) {
     state.lastNodeId = numericId
@@ -109,7 +110,11 @@ export function observeGroupId(state: LGraphState, id: GroupId): void {
 }
 
 export function observeLinkId(state: LGraphState, id: LinkId): void {
-  if (Number.isInteger(Number(id)) && id < MINT_ID_MIN && id > state.lastLinkId)
+  if (
+    Number.isInteger(Number(id)) &&
+    id < MINT_ID_MIN - 1 &&
+    id > state.lastLinkId
+  )
     state.lastLinkId = id
 }
 

--- a/src/lib/litegraph/src/idAllocation.ts
+++ b/src/lib/litegraph/src/idAllocation.ts
@@ -68,6 +68,11 @@ export function mintCoordinationFreeId(
 export function mintNodeId(state: LGraphState): NodeId {
   if (coordinationFreeStates.has(state))
     return toNodeId(mintCoordinationFreeId())
+  if (state.lastNodeId + 1 >= MINT_ID_MIN) {
+    throw new RangeError(
+      'Node id counter exhausted below coordination-free range'
+    )
+  }
   return toNodeId(++state.lastNodeId)
 }
 
@@ -78,6 +83,11 @@ export function mintGroupId(state: LGraphState): GroupId {
 export function mintLinkId(state: LGraphState): LinkId {
   if (coordinationFreeStates.has(state))
     return toLinkId(mintCoordinationFreeId())
+  if (Number(state.lastLinkId) + 1 >= MINT_ID_MIN) {
+    throw new RangeError(
+      'Link id counter exhausted below coordination-free range'
+    )
+  }
   state.lastLinkId = toLinkId(Number(state.lastLinkId) + 1)
   return state.lastLinkId
 }

--- a/src/lib/litegraph/src/subgraph/subgraphDeduplication.test.ts
+++ b/src/lib/litegraph/src/subgraph/subgraphDeduplication.test.ts
@@ -17,6 +17,12 @@ import type {
 } from '../types/serialisation'
 
 import {
+  MINT_ID_CEILING,
+  MINT_ID_MIN,
+  setCoordinationFreeIds
+} from '@/lib/litegraph/src/idAllocation'
+
+import {
   deduplicateSubgraphGroupIds,
   deduplicateSubgraphLinkIds,
   deduplicateSubgraphNodeIds,
@@ -130,6 +136,19 @@ describe('deduplicateSubgraphNodeIds', () => {
     expect(result.subgraphs[0].floatingLinks?.[0].origin_id).toBe(
       remappedNodeId
     )
+  })
+
+  it('remints collisions inside the coordination-free range while armed', () => {
+    const subgraph = makeSubgraph('sg', ['dummy'])
+    const state = freshState()
+    setCoordinationFreeIds(state, true)
+
+    const result = deduplicateSubgraphNodeIds([subgraph], new Set([1]), state)
+
+    const remappedNodeId = Number(result.subgraphs[0].nodes?.[0].id)
+    expect(remappedNodeId).toBeGreaterThanOrEqual(MINT_ID_MIN)
+    expect(remappedNodeId).toBeLessThan(MINT_ID_CEILING)
+    expect(state.lastNodeId).toBe(0)
   })
 })
 

--- a/src/lib/litegraph/src/subgraph/subgraphDeduplication.ts
+++ b/src/lib/litegraph/src/subgraph/subgraphDeduplication.ts
@@ -2,6 +2,8 @@ import type { LGraph } from '../LGraph'
 import { isUuidShapedSubgraphId } from '@/schemas/subgraphIdSchema'
 import { toGroupId } from '@/types/groupId'
 import {
+  MINT_ID_CEILING,
+  MINT_ID_MIN,
   mintGroupId,
   mintLinkId,
   mintNodeId,
@@ -166,7 +168,7 @@ function firstById<T, Id>(
  * Dedupes node IDs across serialized subgraph definitions to prevent widget
  * store key collisions, and patches any root-level legacy proxyWidgets that
  * reference the remapped inner IDs. Returns deep clones; inputs are not
- * mutated. `state.lastNodeId` is advanced.
+ * mutated. New IDs come from `mintNodeId(state)`.
  *
  * `GraphCanvas.vue` also keys Vue node instances by bare `NodeId`, so
  * collisions could reuse a component across graph changes instead of
@@ -234,8 +236,8 @@ function deduplicateClonedSubgraphNodeIds(
 }
 
 /**
- * Remaps duplicate node IDs to unique values, updating `usedNodeIds`
- * and `state.lastNodeId` as new IDs are allocated.
+ * Remaps duplicate node IDs to unique values, updating `usedNodeIds` as
+ * new IDs are allocated via `mintNodeId(state)`.
  *
  * @returns A map of old ID → new ID for nodes that were remapped.
  */
@@ -294,7 +296,9 @@ function findNextAvailableId(
 ): number {
   while (true) {
     const nextId = advance()
-    if (nextId > MAX_ID) {
+    const inCounterRange = nextId <= MAX_ID
+    const inMintRange = nextId >= MINT_ID_MIN && nextId < MINT_ID_CEILING
+    if (!inCounterRange && !inMintRange) {
       throw new Error('Node ID space exhausted')
     }
     if (!usedIds.has(nextId)) return nextId

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -4759,6 +4759,22 @@
       "prompt_outputs_failed_validation": {
         "title": "Prompt validation failed",
         "desc": "The workflow has invalid node inputs. Fix the highlighted nodes before running it again."
+      },
+      "op_rejected": {
+        "title": "Agent edit rejected",
+        "desc": "The workflow document refused an agent edit. The canvas and the shared document may briefly differ until the next update."
+      },
+      "prefix_abort": {
+        "title": "Agent edits partially applied",
+        "desc": "A batch of agent edits stopped partway. The remaining edits are retried automatically."
+      },
+      "guard_trip": {
+        "title": "Agent update blocked",
+        "desc": "An incoming agent update did not match the expected workflow document shape and was blocked."
+      },
+      "apply_failed": {
+        "title": "Agent edit failed",
+        "desc": "An agent edit could not be applied to the workflow document."
       }
     }
   },

--- a/src/platform/errorCatalog/errorMessageResolver.test.ts
+++ b/src/platform/errorCatalog/errorMessageResolver.test.ts
@@ -624,6 +624,78 @@ describe('errorMessageResolver', () => {
     })
   })
 
+  it('resolves an agent transport failure to overlay copy', () => {
+    expect(
+      resolveRunErrorMessage({
+        kind: 'prompt',
+        isCloud: true,
+        error: {
+          type: 'apply_failed',
+          message: 'An agent edit could not be applied',
+          details: 'op_rejected: unknown_widget at seed'
+        }
+      })
+    ).toEqual({
+      displayTitle: 'Agent edit failed',
+      displayMessage:
+        'An agent edit could not be applied to the workflow document.'
+    })
+  })
+
+  it('resolves a rejected agent edit to overlay copy', () => {
+    expect(
+      resolveRunErrorMessage({
+        kind: 'prompt',
+        isCloud: true,
+        error: {
+          type: 'op_rejected',
+          message: 'The document refused an edit',
+          details: ''
+        }
+      })
+    ).toEqual({
+      displayTitle: 'Agent edit rejected',
+      displayMessage:
+        'The workflow document refused an agent edit. The canvas and the shared document may briefly differ until the next update.'
+    })
+  })
+
+  it('resolves a partial agent batch to overlay copy', () => {
+    expect(
+      resolveRunErrorMessage({
+        kind: 'prompt',
+        isCloud: true,
+        error: {
+          type: 'prefix_abort',
+          message: 'A batch stopped partway',
+          details: ''
+        }
+      })
+    ).toEqual({
+      displayTitle: 'Agent edits partially applied',
+      displayMessage:
+        'A batch of agent edits stopped partway. The remaining edits are retried automatically.'
+    })
+  })
+
+  it('resolves a blocked agent update to overlay copy', () => {
+    expect(
+      resolveRunErrorMessage({
+        kind: 'prompt',
+        isCloud: true,
+        error: {
+          type: 'guard_trip',
+          message: 'An incoming update was blocked',
+          details: ''
+        }
+      })
+    ).toEqual({
+      displayTitle: 'Agent update blocked',
+      displayMessage:
+        'An incoming agent update did not match the expected workflow document shape and was blocked.'
+    })
+  })
+
   it('resolves server_error prompt copy by environment', () => {
     const error = {
       type: 'server_error',

--- a/src/platform/errorCatalog/promptErrorResolver.ts
+++ b/src/platform/errorCatalog/promptErrorResolver.ts
@@ -13,7 +13,11 @@ const KNOWN_PROMPT_ERROR_TYPES = new Set([
   'no_prompt',
   'server_error',
   'missing_node_type',
-  'prompt_outputs_failed_validation'
+  'prompt_outputs_failed_validation',
+  'op_rejected',
+  'prefix_abort',
+  'guard_trip',
+  'apply_failed'
 ])
 
 function getPromptExceptionMessage(

--- a/src/renderer/core/layout/store/layoutStore.ts
+++ b/src/renderer/core/layout/store/layoutStore.ts
@@ -3,6 +3,7 @@ import { computed, ref, shallowReactive } from 'vue'
 import type { ComputedRef } from 'vue'
 import * as Y from 'yjs'
 
+import { assert } from '@/base/assert'
 import { toGroupId } from '@/types/groupId'
 import { toNodeId } from '@/types/nodeId'
 import type { GroupId } from '@/types/groupId'
@@ -746,6 +747,36 @@ class LayoutStoreImpl {
     return operation.actor === undefined
       ? { ...operation, actor: this.currentActor }
       : operation
+  }
+
+  /**
+   * Runs `fn` with every actor-less operation stamped as `actor` instead of
+   * this session's actor. The per-mutation command source remote appliers and
+   * provenance-aware listeners key on: stamping happens synchronously at
+   * apply time, so deferred change delivery still carries the scoped actor on
+   * `change.operation.actor`. Asserts when `fn` returns a thenable: the
+   * scope ends when the call returns, so work after an await would be
+   * stamped with the session actor. DEV throws; production reports through
+   * the assert seam and returns the thenable, leaving that continuation
+   * session-stamped.
+   */
+  withActor<T>(actor: string, fn: () => T): T {
+    const previous = this.currentActor
+    this.currentActor = actor
+    try {
+      const result = fn()
+      const thenable =
+        typeof (result as { then?: unknown } | null | undefined)?.then ===
+        'function'
+      if (result instanceof Promise) void result.catch(() => {})
+      assert(
+        !thenable,
+        'withActor requires a synchronous callback: work after an await would be stamped with the session actor'
+      )
+      return result
+    } finally {
+      this.currentActor = previous
+    }
   }
 
   /**

--- a/src/renderer/core/layout/store/layoutStore.withActor.test.ts
+++ b/src/renderer/core/layout/store/layoutStore.withActor.test.ts
@@ -1,0 +1,102 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { layoutStore } from '@/renderer/core/layout/store/layoutStore'
+import { LayoutSource } from '@/renderer/core/layout/types'
+import type { LayoutChange } from '@/renderer/core/layout/types'
+import { toNodeId } from '@/types/nodeId'
+import { createUuidv4 } from '@/utils/uuid'
+
+const GRAPH = createUuidv4()
+
+function createNodeOp(id: string) {
+  return {
+    type: 'createNode' as const,
+    graphId: GRAPH,
+    nodeId: toNodeId(id),
+    layout: {
+      id: toNodeId(id),
+      position: { x: 0, y: 0 },
+      size: { width: 100, height: 60 },
+      zIndex: 0,
+      visible: true,
+      bounds: { x: 0, y: 0, width: 100, height: 60 }
+    },
+    timestamp: Date.now(),
+    source: LayoutSource.Canvas
+  }
+}
+
+async function deliveredChanges(apply: () => void): Promise<LayoutChange[]> {
+  const changes: LayoutChange[] = []
+  const unsubscribe = layoutStore.onChange((change) => changes.push(change))
+  apply()
+  await Promise.resolve()
+  await Promise.resolve()
+  unsubscribe()
+  return changes
+}
+
+describe('layoutStore.withActor', () => {
+  beforeEach(() => {
+    layoutStore.resetForTests()
+  })
+
+  it('stamps operations applied inside the scope with the scoped actor', async () => {
+    const changes = await deliveredChanges(() => {
+      layoutStore.withActor('agent-remote', () => {
+        layoutStore.applyOperation(createNodeOp('1'))
+      })
+    })
+
+    expect(changes).toHaveLength(1)
+    expect(changes[0].operation.actor).toBe('agent-remote')
+  })
+
+  it('restores the session actor after the scope, including on throw', async () => {
+    expect(() =>
+      layoutStore.withActor('agent-remote', () => {
+        throw new Error('boom')
+      })
+    ).toThrow('boom')
+
+    const changes = await deliveredChanges(() => {
+      layoutStore.applyOperation(createNodeOp('2'))
+    })
+
+    expect(changes).toHaveLength(1)
+    expect(changes[0].operation.actor).toMatch(/^user-/)
+  })
+
+  it('rejects an async callback whose work would outlive the scope', async () => {
+    expect(
+      () => void layoutStore.withActor('agent-remote', async () => {})
+    ).toThrow('synchronous callback')
+
+    expect(
+      () => void layoutStore.withActor('agent-remote', () => Promise.resolve(1))
+    ).toThrow('synchronous callback')
+
+    expect(
+      () =>
+        void layoutStore.withActor('agent-remote', () => ({ then: () => {} }))
+    ).toThrow('synchronous callback')
+
+    const changes = await deliveredChanges(() => {
+      layoutStore.applyOperation(createNodeOp('9'))
+    })
+
+    expect(changes).toHaveLength(1)
+    expect(changes[0].operation.actor).toMatch(/^user-/)
+  })
+
+  it('honours an actor already carried by the operation', async () => {
+    const changes = await deliveredChanges(() => {
+      layoutStore.withActor('agent-remote', () => {
+        layoutStore.applyOperation({ ...createNodeOp('3'), actor: 'user-pre' })
+      })
+    })
+
+    expect(changes).toHaveLength(1)
+    expect(changes[0].operation.actor).toBe('user-pre')
+  })
+})

--- a/src/renderer/core/layout/store/layoutStoreMintDelivery.test.ts
+++ b/src/renderer/core/layout/store/layoutStoreMintDelivery.test.ts
@@ -1,0 +1,243 @@
+/**
+ * The write-leg delivery-primitive pins (F2/F5): the agent mint ports assume
+ * the layout store delivers queued changes on ONE microtask - the
+ * intentional-clear capture and the severance sweep both time against it.
+ * These tests run the REAL store through the REAL wiring so a future change
+ * to the delivery primitive fails here, by name, instead of silently
+ * emptying `delete_node.removed_links` or leaking clear captures.
+ *
+ * Lives in renderer (not workbench) because it imports the real layout store;
+ * workbench must not import renderer, so the wiring takes the store's seams
+ * injected - exactly as the composition root will inject them.
+ */
+import { createPinia, setActivePinia } from 'pinia'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
+import type { GraphScope } from '@/types/graphScopeId'
+import type { LinkTopology } from '@/types/linkTopology'
+import type { GraphOperation } from '@/workbench/extensions/agent/crdt/graphOperations'
+import type {
+  MintPortWiring,
+  MintableGraph
+} from '@/workbench/extensions/agent/crdt/mintPortWiring'
+
+import { layoutStore } from '@/renderer/core/layout/store/layoutStore'
+import { LayoutSource } from '@/renderer/core/layout/types'
+import { useLinkStore } from '@/stores/linkStore'
+import { toOwningGraphId, toRootGraphId } from '@/types/graphScopeId'
+import { toLinkId } from '@/types/linkId'
+import { toNodeId } from '@/types/nodeId'
+import { createUuidv4 } from '@/utils/uuid'
+import { attachMintPortWiring } from '@/workbench/extensions/agent/crdt/mintPortWiring'
+
+function createNodeOp(graphId: string, id: string) {
+  return {
+    type: 'createNode' as const,
+    graphId,
+    nodeId: toNodeId(id),
+    layout: {
+      id: toNodeId(id),
+      position: { x: 10, y: 20 },
+      size: { width: 100, height: 60 },
+      zIndex: 0,
+      visible: true,
+      bounds: { x: 10, y: 20, width: 100, height: 60 }
+    },
+    timestamp: Date.now(),
+    source: LayoutSource.Canvas
+  }
+}
+
+function deleteNodeOp(graphId: string, id: string) {
+  return {
+    type: 'deleteNode' as const,
+    graphId,
+    nodeId: toNodeId(id),
+    timestamp: Date.now(),
+    source: LayoutSource.Canvas
+  }
+}
+
+/** Structural stand-in for the two LGraphNode members the wiring reads. */
+interface FakeGraphNode {
+  id?: unknown
+  serialize?: () => unknown
+  widgets?: { name: string; type: string; serialize?: boolean }[]
+}
+
+async function realDelivery(): Promise<void> {
+  // The store's queued flush plus the ports' double-microtask sweep.
+  for (let tick = 0; tick < 4; tick++) await Promise.resolve()
+}
+
+describe('mint ports against the real layout store delivery', () => {
+  let minted: GraphOperation[]
+  let wiring: MintPortWiring
+  let graphId: string
+  let scope: GraphScope
+  let graphNodes: Map<string, FakeGraphNode>
+
+  function linkTopology(id: number, targetId: string): LinkTopology {
+    return {
+      id: toLinkId(id),
+      graphId: toOwningGraphId(graphId),
+      originNodeId: toNodeId('1'),
+      originSlot: 0,
+      targetNodeId: toNodeId(targetId),
+      targetSlot: 0,
+      type: 'IMAGE'
+    }
+  }
+
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    minted = []
+    graphId = createUuidv4()
+    scope = {
+      rootGraphId: toRootGraphId(graphId),
+      owningGraphId: toOwningGraphId(graphId)
+    }
+    graphNodes = new Map()
+    const graph: MintableGraph = {
+      id: graphId,
+      rootGraph: { id: graphId },
+      getNodeById: (id) =>
+        (graphNodes.get(String(id)) as unknown as LGraphNode | undefined) ??
+        null,
+      get _nodes() {
+        return [...graphNodes.values()] as LGraphNode[]
+      }
+    }
+    wiring = attachMintPortWiring({
+      isEnabled: () => true,
+      isDocBound: () => true,
+      enqueue: (operations) => minted.push(...operations),
+      layoutChanges: (listener) => layoutStore.onChange(listener),
+      withLayoutActor: (actor, fn) => {
+        layoutStore.withActor(actor, fn)
+      },
+      localActorPrefix: 'user-',
+      getGraph: () => graph
+    })
+  })
+
+  afterEach(() => {
+    wiring.detach()
+  })
+
+  it('delivers a local createNode as add_node with the mint-time snapshot', async () => {
+    graphNodes.set('5', {
+      id: toNodeId('5'),
+      serialize: () => ({
+        id: 5,
+        type: 'TestNode',
+        widgets_values: [7]
+      })
+    })
+
+    layoutStore.applyOperation(createNodeOp(graphId, '5'))
+    await realDelivery()
+
+    expect(minted).toEqual([
+      {
+        op: 'add_node',
+        node_id: toNodeId('5'),
+        class_type: 'TestNode',
+        pos: [10, 20],
+        node: { id: 5, type: 'TestNode', widgets_values: [7] }
+      }
+    ])
+  })
+
+  it('F5: the severance capture survives until the real deleteNode delivery', async () => {
+    layoutStore.applyOperation(createNodeOp(graphId, '2'))
+    await realDelivery()
+    const linkStore = useLinkStore()
+    const severed = linkTopology(41, '2')
+    linkStore.registerLink(scope, severed)
+    minted.length = 0
+    const consoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined)
+
+    // The real teardown order: litegraph severs the node's links
+    // synchronously, then the layout deleteNode queues and delivers on the
+    // store's own microtask. If delivery ever slips past the ports'
+    // double-microtask sweep, removed_links comes back EMPTY here and a
+    // false disconnect-divergence error fires - both assertions below
+    // are the alarm.
+    linkStore.deleteLink(scope, severed)
+    layoutStore.applyOperation(deleteNodeOp(graphId, '2'))
+    await realDelivery()
+
+    expect(minted).toEqual([
+      {
+        op: 'delete_node',
+        node_id: '2',
+        removed_links: [toLinkId(41)]
+      }
+    ])
+    expect(consoleError).not.toHaveBeenCalled()
+    consoleError.mockRestore()
+  })
+
+  it('F2: the intentional-clear capture is consumed by the real clearGraph delivery', async () => {
+    graphNodes.set('5', { id: toNodeId('5') })
+    graphNodes.set('6', { id: toNodeId('6') })
+    layoutStore.applyOperation(createNodeOp(graphId, '5'))
+    layoutStore.applyOperation(createNodeOp(graphId, '6'))
+    await realDelivery()
+    minted.length = 0
+
+    wiring.runIntentionalClear(() => {
+      layoutStore.clearGraph(graphId)
+    })
+    await realDelivery()
+
+    expect(minted).toEqual([
+      { op: 'clear', removed_nodes: [toNodeId('5'), toNodeId('6')] }
+    ])
+  })
+
+  it('a bare clearGraph outside the window stays inert through real delivery', async () => {
+    layoutStore.applyOperation(createNodeOp(graphId, '5'))
+    await realDelivery()
+    minted.length = 0
+
+    layoutStore.clearGraph(graphId)
+    await realDelivery()
+
+    expect(minted).toEqual([])
+  })
+
+  it('the remote scope suppresses a real layout apply end to end', async () => {
+    graphNodes.set('5', {
+      id: toNodeId('5'),
+      serialize: () => ({ id: 5, type: 'TestNode' })
+    })
+
+    wiring.runRemoteScope(() => {
+      layoutStore.applyOperation(createNodeOp(graphId, '5'))
+    })
+    await realDelivery()
+
+    expect(minted).toEqual([])
+  })
+
+  it('surfaces a real bare disconnect as divergence after the sweep', async () => {
+    const linkStore = useLinkStore()
+    const dangling = linkTopology(43, '9')
+    linkStore.registerLink(scope, dangling)
+    minted.length = 0
+    const consoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined)
+
+    linkStore.deleteLink(scope, dangling)
+    await realDelivery()
+
+    expect(consoleError).toHaveBeenCalledOnce()
+    consoleError.mockRestore()
+  })
+})

--- a/src/scripts/app.test.ts
+++ b/src/scripts/app.test.ts
@@ -386,6 +386,13 @@ describe('ComfyApp', () => {
       await app.loadApiJson({}, 'empty.json').catch(() => undefined)
 
       expect(mockWorkflowService.beforeLoadNewGraph).toHaveBeenCalledWith(false)
+      expect(
+        mockExtensionService.invokeExtensionsAsync.mock.calls
+          .map(([hook]) => hook)
+          .filter((hook) =>
+            ['beforeLoadGraph', 'afterLoadGraph'].includes(hook)
+          )
+      ).toEqual(['beforeLoadGraph'])
     })
 
     it('notifies extensions once on each side of a graph load, in order', async () => {
@@ -1323,6 +1330,23 @@ describe('ComfyApp', () => {
         expect(mockCanvas.setGraph).toHaveBeenCalledWith(graph)
         expect(mockCanvas.graph).toBe(graph)
         expect(mockCanvas.subgraph).toBeNull()
+        expect(
+          mockExtensionService.invokeExtensionsAsync.mock.calls
+            .map(([hook]) => hook)
+            .filter((hook) =>
+              [
+                'beforeLoadGraph',
+                'beforeConfigureGraph',
+                'afterConfigureGraph',
+                'afterLoadGraph'
+              ].includes(hook)
+            )
+        ).toEqual([
+          'beforeLoadGraph',
+          'beforeConfigureGraph',
+          'afterConfigureGraph',
+          'afterLoadGraph'
+        ])
       } finally {
         LiteGraph.unregisterNodeType(nodeType)
       }
@@ -1724,7 +1748,7 @@ describe('ComfyApp', () => {
       })
       mockImportA1111.mockImplementation(
         async (_graph, _parameters, beforeGraphClear) => {
-          beforeGraphClear?.()
+          await beforeGraphClear?.()
           return 'imported'
         }
       )
@@ -2363,7 +2387,7 @@ describe('ComfyApp', () => {
       vi.mocked(getWorkflowDataFromFile).mockResolvedValue({ parameters })
       mockImportA1111.mockImplementation(
         async (_graph, _parameters, beforeGraphClear) => {
-          beforeGraphClear?.()
+          await beforeGraphClear?.()
           return 'imported'
         }
       )
@@ -2389,10 +2413,30 @@ describe('ComfyApp', () => {
       expect(
         mockWorkflowService.beforeLoadNewGraph.mock.invocationCallOrder[0]
       ).toBeLessThan(vi.mocked(mockCanvas.setGraph).mock.invocationCallOrder[0])
+      expect(mockExtensionService.invokeExtensionsAsync).toHaveBeenCalledWith(
+        'beforeLoadGraph'
+      )
+      expect(mockExtensionService.invokeExtensionsAsync).toHaveBeenCalledWith(
+        'beforeConfigureGraph',
+        graph,
+        parameters
+      )
+      expect(
+        mockExtensionService.invokeExtensionsAsync
+      ).not.toHaveBeenCalledWith('afterLoadGraph')
       expect(settled).toBe(false)
 
       resolveAfterLoad?.()
       await handleFile
+      expect(mockExtensionService.invokeExtensionsAsync).toHaveBeenCalledWith(
+        'afterConfigureGraph',
+        parameters,
+        undefined,
+        graph
+      )
+      expect(mockExtensionService.invokeExtensionsAsync).toHaveBeenCalledWith(
+        'afterLoadGraph'
+      )
       expect(settled).toBe(true)
     })
   })

--- a/src/scripts/app.test.ts
+++ b/src/scripts/app.test.ts
@@ -387,6 +387,52 @@ describe('ComfyApp', () => {
 
       expect(mockWorkflowService.beforeLoadNewGraph).toHaveBeenCalledWith(false)
     })
+
+    it('notifies extensions once on each side of a graph load, in order', async () => {
+      app.canvasElRef.value = document.createElement('canvas')
+      Reflect.set(app, 'rootGraphInternal', new LGraph())
+
+      await app.loadGraphData(createWorkflowGraphData(), false)
+
+      const loadHookCalls =
+        mockExtensionService.invokeExtensionsAsync.mock.calls
+          .map(([hook]) => hook)
+          .filter((hook) =>
+            [
+              'beforeLoadGraph',
+              'beforeConfigureGraph',
+              'afterConfigureGraph',
+              'afterLoadGraph'
+            ].includes(hook)
+          )
+      expect(loadHookCalls).toEqual([
+        'beforeLoadGraph',
+        'beforeConfigureGraph',
+        'afterConfigureGraph',
+        'afterLoadGraph'
+      ])
+    })
+
+    it('skips both after-hooks when graph configure fails', async () => {
+      app.canvasElRef.value = document.createElement('canvas')
+      const graph = new LGraph()
+      Reflect.set(app, 'rootGraphInternal', graph)
+      vi.spyOn(graph, 'configure').mockImplementation(() => {
+        throw new Error('bad workflow json')
+      })
+
+      await expect(
+        app.loadGraphData(createWorkflowGraphData(), false)
+      ).resolves.toBe(false)
+
+      const invokedHooks =
+        mockExtensionService.invokeExtensionsAsync.mock.calls.map(
+          ([hook]) => hook
+        )
+      expect(invokedHooks).toContain('beforeLoadGraph')
+      expect(invokedHooks).not.toContain('afterConfigureGraph')
+      expect(invokedHooks).not.toContain('afterLoadGraph')
+    })
   })
 
   describe('nodeOutputs', () => {

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -1269,6 +1269,7 @@ export class ComfyApp {
       workflowNavigationId
     } = options
     useWorkflowService().beforeLoadNewGraph(clean !== false)
+    await useExtensionService().invokeExtensionsAsync('beforeLoadGraph')
 
     if (skipAssetScans) {
       // Only reset candidates; preserve UI state (fileSizes, etc.)
@@ -1553,6 +1554,7 @@ export class ComfyApp {
         this.rootGraph.serialize() as unknown as ComfyWorkflowJSON,
         effectiveShareId
       )
+      await useExtensionService().invokeExtensionsAsync('afterLoadGraph')
 
       // If the canvas was not visible and we're a fresh load, resize the canvas and fit the view
       // This fixes switching from app mode to a new graph mode workflow (e.g. load template)

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -2099,15 +2099,25 @@ export class ComfyApp {
 
     // Use parameters strictly as the final fallback
     if (parameters && typeof parameters === 'string') {
-      const outcome = await importA1111(this.rootGraph, parameters, () => {
-        try {
-          // false: final destination; no later load republishes the hash.
-          useWorkflowService().beforeLoadNewGraph(false)
-        } finally {
-          useMissingNodesErrorStore().setMissingNodeTypes([])
+      const outcome = await importA1111(
+        this.rootGraph,
+        parameters,
+        async () => {
+          try {
+            // false: final destination; no later load republishes the hash.
+            useWorkflowService().beforeLoadNewGraph(false)
+            await useExtensionService().invokeExtensionsAsync('beforeLoadGraph')
+            await useExtensionService().invokeExtensionsAsync(
+              'beforeConfigureGraph',
+              this.rootGraph,
+              parameters
+            )
+          } finally {
+            useMissingNodesErrorStore().setMissingNodeTypes([])
+          }
+          this.canvas.setGraph(this.rootGraph)
         }
-        this.canvas.setGraph(this.rootGraph)
-      })
+      )
       switch (outcome) {
         case 'core-nodes-unavailable':
           useToastStore().addAlert(t('toastMessages.a1111CoreNodesUnavailable'))
@@ -2131,10 +2141,17 @@ export class ComfyApp {
           )
         }
       }
+      await useExtensionService().invokeExtensionsAsync(
+        'afterConfigureGraph',
+        parameters,
+        undefined,
+        this.rootGraph
+      )
       await useWorkflowService().afterLoadNewGraph(
         fileName,
         this.rootGraph.serialize() as unknown as ComfyWorkflowJSON
       )
+      await useExtensionService().invokeExtensionsAsync('afterLoadGraph')
       return
     }
 
@@ -2270,6 +2287,12 @@ export class ComfyApp {
   ): Promise<void> {
     // false: no workflow load follows to republish the hash.
     useWorkflowService().beforeLoadNewGraph(false)
+    await useExtensionService().invokeExtensionsAsync('beforeLoadGraph')
+    await useExtensionService().invokeExtensionsAsync(
+      'beforeConfigureGraph',
+      this.rootGraph,
+      apiData
+    )
     this.canvas.setGraph(this.rootGraph)
     this.clean()
 
@@ -2412,11 +2435,18 @@ export class ComfyApp {
     app.rootGraph.arrange()
     for (const id of ids) processNodeInputs(id)
     app.rootGraph.arrange()
+    await useExtensionService().invokeExtensionsAsync(
+      'afterConfigureGraph',
+      apiData,
+      undefined,
+      this.rootGraph
+    )
 
     await useWorkflowService().afterLoadNewGraph(
       fileName,
       this.rootGraph.serialize() as unknown as ComfyWorkflowJSON
     )
+    await useExtensionService().invokeExtensionsAsync('afterLoadGraph')
     if (missingNodeTypes.length) {
       this.showMissingNodesError(missingNodeTypes, options)
     }

--- a/src/scripts/pnginfo.test.ts
+++ b/src/scripts/pnginfo.test.ts
@@ -318,6 +318,28 @@ describe('importA1111', () => {
     )
   })
 
+  it('awaits the pre-clear hook before mutating the graph', async () => {
+    const graph = new LGraph()
+    const clear = vi.spyOn(graph, 'clear')
+    vi.mocked(api.getEmbeddings).mockResolvedValue([])
+    mockAvailableCoreNodes(graph)
+    let release: (() => void) | undefined
+    const beforeGraphClear = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          release = resolve
+        })
+    )
+
+    const imported = importA1111(graph, parameters, beforeGraphClear)
+    await vi.waitFor(() => expect(beforeGraphClear).toHaveBeenCalledOnce())
+    expect(clear).not.toHaveBeenCalled()
+
+    release?.()
+    await expect(imported).resolves.toBe('imported')
+    expect(clear).toHaveBeenCalledOnce()
+  })
+
   it.each([
     ['with a negative prompt', parameters, 'negative'],
     ['without a negative prompt', parametersWithoutNegativePrompt, '']

--- a/src/scripts/pnginfo.ts
+++ b/src/scripts/pnginfo.ts
@@ -203,7 +203,7 @@ export type A1111ImportOutcome =
 export async function importA1111(
   graph: LGraph,
   parameters: string,
-  beforeGraphClear?: () => void
+  beforeGraphClear?: () => void | Promise<void>
 ): Promise<A1111ImportOutcome> {
   const normalizedParameters = normalizeA1111Parameters(parameters)
   const p = normalizedParameters.lastIndexOf('\nSteps:')
@@ -362,7 +362,7 @@ export async function importA1111(
           return { embeddings: [], embeddingsLoaded: false }
         })
 
-      beforeGraphClear?.()
+      await beforeGraphClear?.()
       graph.clear()
       graph.add(ckptNode)
       graph.add(clipSkipNode)

--- a/src/types/comfy.ts
+++ b/src/types/comfy.ts
@@ -227,6 +227,25 @@ export interface ComfyExtension {
   nodeCreated?(node: LGraphNode, app: ComfyApp): void
 
   /**
+   * Runs when a graph load begins, before the load mutates workflow state.
+   * A rejection is caught and logged per extension; it never aborts the load.
+   * @param app The app instance
+   */
+  beforeLoadGraph?(app: ComfyApp): Promise<void> | void
+
+  /**
+   * Runs when a graph load completes. Fires only after a successful load.
+   * Neither this hook nor `afterConfigureGraph` fires when `configure`
+   * throws, so no hook balances a failed load: design brackets
+   * fail-closed, reset at the next load's `beforeLoadGraph` and closed at
+   * its `afterConfigureGraph` (which also survives post-configure
+   * failures this hook does not).
+   * A rejection is caught and logged per extension.
+   * @param app The app instance
+   */
+  afterLoadGraph?(app: ComfyApp): Promise<void> | void
+
+  /**
    * Allows the extension to modify the graph data before it is configured.
    * @param graphData The graph data
    * @param missingNodeTypes The missing node types

--- a/src/utils/graphTraversalUtil.test.ts
+++ b/src/utils/graphTraversalUtil.test.ts
@@ -146,6 +146,28 @@ describe('graphTraversalUtil', () => {
 
       expect(findSubgraphNodePathById(root, 'unreachable-uuid')).toBeNull()
     })
+
+    it('fails closed when one subgraph definition has multiple instances', () => {
+      const shared = createMockSubgraph('shared-uuid', [])
+      const root = createMockGraph([
+        createMockNode('1', { isSubgraph: true, subgraph: shared }),
+        createMockNode('2', { isSubgraph: true, subgraph: shared })
+      ])
+
+      expect(findSubgraphNodePathById(root, 'shared-uuid')).toBeNull()
+    })
+
+    it('terminates on a cyclic subgraph definition', () => {
+      const cyclic = createMockSubgraph('cyclic-uuid', [])
+      cyclic._nodes = [
+        createMockNode('self', { isSubgraph: true, subgraph: cyclic })
+      ]
+      const root = createMockGraph([
+        createMockNode('1', { isSubgraph: true, subgraph: cyclic })
+      ])
+
+      expect(findSubgraphNodePathById(root, 'missing-uuid')).toBeNull()
+    })
   })
 
   describe('Pure utility functions', () => {

--- a/src/utils/graphTraversalUtil.test.ts
+++ b/src/utils/graphTraversalUtil.test.ts
@@ -34,7 +34,8 @@ import {
   isAncestorPathActive,
   isCandidateScopeActive,
   isExecutionPathActive,
-  isMissingCandidateActive
+  isMissingCandidateActive,
+  findSubgraphNodePathById
 } from '@/utils/graphTraversalUtil'
 import { LGraphEventMode } from '@/lib/litegraph/src/types/globalEnums'
 import { toNodeId } from '@/types/nodeId'
@@ -106,6 +107,44 @@ describe('graphTraversalUtil', () => {
           graphId: ROOT_GRAPH_ID
         })
       ).toBeNull()
+    })
+  })
+
+  describe('findSubgraphNodePathById', () => {
+    it('returns the subgraph-NODE id chain, not the subgraph uuids', () => {
+      const inner = createMockSubgraph('inner-uuid', [])
+      const innerNode = createMockNode('27', {
+        isSubgraph: true,
+        subgraph: inner
+      })
+      const outer = createMockSubgraph('outer-uuid', [innerNode])
+      const outerNode = createMockNode('57', {
+        isSubgraph: true,
+        subgraph: outer
+      })
+      const root = createMockGraph([outerNode])
+
+      expect(findSubgraphNodePathById(root, 'inner-uuid')).toEqual(['57', '27'])
+      expect(findSubgraphNodePathById(root, 'outer-uuid')).toEqual(['57'])
+    })
+
+    it('returns null for a definition not reachable from the root', () => {
+      const root = createMockGraph([createMockNode('1')])
+
+      expect(findSubgraphNodePathById(root, 'nowhere-uuid')).toBeNull()
+    })
+
+    it('skips a subgraph without a node array instead of throwing', () => {
+      const malformed = {
+        id: 'broken-uuid'
+      } satisfies Partial<Subgraph> as Subgraph
+      const brokenNode = createMockNode('9', {
+        isSubgraph: true,
+        subgraph: malformed
+      })
+      const root = createMockGraph([brokenNode])
+
+      expect(findSubgraphNodePathById(root, 'unreachable-uuid')).toBeNull()
     })
   })
 

--- a/src/utils/graphTraversalUtil.ts
+++ b/src/utils/graphTraversalUtil.ts
@@ -329,6 +329,16 @@ export function findSubgraphPathById(
   rootGraph: LGraph,
   targetId: string
 ): string[] | null {
+  return findSubgraphPathBy(rootGraph, targetId, (_node, subgraph) =>
+    String(subgraph.id)
+  )
+}
+
+function findSubgraphPathBy(
+  rootGraph: LGraph,
+  targetId: string,
+  segment: (node: LGraphNode, subgraph: Subgraph) => string
+): string[] | null {
   const stack: { graph: LGraph | Subgraph; path: string[] }[] = [
     { graph: rootGraph, path: [] }
   ]
@@ -336,14 +346,13 @@ export function findSubgraphPathById(
   while (stack.length > 0) {
     const { graph, path } = stack.pop()!
 
-    // Check if graph exists and has _nodes property
     if (!graph || !graph._nodes || !Array.isArray(graph._nodes)) {
       continue
     }
 
     for (const node of graph._nodes) {
       if (node.isSubgraphNode?.() && node.subgraph) {
-        const newPath = [...path, String(node.subgraph.id)]
+        const newPath = [...path, segment(node, node.subgraph)]
         if (node.subgraph.id === targetId) {
           return newPath
         }
@@ -353,6 +362,23 @@ export function findSubgraphPathById(
   }
 
   return null
+}
+
+/**
+ * Iteratively finds the path of subgraph NODE ids (not subgraph UUIDs) to a
+ * target subgraph - the address form node-scoped consumers need (e.g. the
+ * agent write leg's interior `set_widget`, whose wire `path` is a resolved
+ * node-id chain).
+ * @param rootGraph The graph to start searching from.
+ * @param targetUuid The UUID of the subgraph to find.
+ * @returns Subgraph-node ids from the root down to the node whose definition
+ * is the target, or `null` if not found.
+ */
+export function findSubgraphNodePathById(
+  rootGraph: LGraph,
+  targetUuid: string
+): string[] | null {
+  return findSubgraphPathBy(rootGraph, targetUuid, (node) => String(node.id))
 }
 
 /**

--- a/src/utils/graphTraversalUtil.ts
+++ b/src/utils/graphTraversalUtil.ts
@@ -342,9 +342,13 @@ function findSubgraphPathBy(
   const stack: { graph: LGraph | Subgraph; path: string[] }[] = [
     { graph: rootGraph, path: [] }
   ]
+  const visited = new Set<LGraph | Subgraph>()
 
   while (stack.length > 0) {
     const { graph, path } = stack.pop()!
+
+    if (visited.has(graph)) continue
+    visited.add(graph)
 
     if (!graph || !graph._nodes || !Array.isArray(graph._nodes)) {
       continue
@@ -378,7 +382,37 @@ export function findSubgraphNodePathById(
   rootGraph: LGraph,
   targetUuid: string
 ): string[] | null {
-  return findSubgraphPathBy(rootGraph, targetUuid, (node) => String(node.id))
+  const stack: {
+    graph: LGraph | Subgraph
+    path: string[]
+    ancestors: ReadonlySet<LGraph | Subgraph>
+  }[] = [{ graph: rootGraph, path: [], ancestors: new Set() }]
+  let match: string[] | null = null
+
+  while (stack.length > 0) {
+    const { graph, path, ancestors } = stack.pop()!
+    if (ancestors.has(graph) || !Array.isArray(graph?._nodes)) continue
+    const nextAncestors = new Set(ancestors).add(graph)
+
+    for (const node of graph._nodes) {
+      if (!node.isSubgraphNode?.() || !node.subgraph) continue
+      const nextPath = [...path, String(node.id)]
+      if (node.subgraph.id === targetUuid) {
+        // A definition can have multiple instances. Its UUID alone cannot
+        // choose an instance path, so fail closed rather than write a sibling.
+        if (match !== null) return null
+        match = nextPath
+      } else {
+        stack.push({
+          graph: node.subgraph,
+          path: nextPath,
+          ancestors: nextAncestors
+        })
+      }
+    }
+  }
+
+  return match
 }
 
 /**

--- a/src/workbench/extensions/agent/crdt/CrdtDevPanel.vue
+++ b/src/workbench/extensions/agent/crdt/CrdtDevPanel.vue
@@ -1,0 +1,349 @@
+<script setup lang="ts">
+import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
+
+import { api } from '@/scripts/api'
+
+import type { AgentCrdtStatus } from './useAgentCrdtFollower'
+import type { DevEvent, DevEventKind } from './devPanelLog'
+import { clearDevEvents, devEvents, stringifyDevEvents } from './devPanelLog'
+
+/**
+ * Dev instrumentation: CRDT debugging overlay. Surfaces the follower's live
+ * state, the dev event ring buffer, the mutation catalog and known-good agent
+ * prompts so QA never has to reverse-engineer the console helpers. Reads
+ * `window.__agentCrdtPoc` (installed by useAgentCrdtFollower under
+ * import.meta.env.DEV) on a 1s poll, zero extra API surface on the
+ * composable. Has no mount site until the agent-panel slice lands; removable
+ * once real status UI ships.
+ */
+
+const props = defineProps<{ status: AgentCrdtStatus }>()
+
+const isDevBuild = import.meta.env.DEV
+
+// ── strings (dev-only debug surface, intentionally untranslated) ──────────
+const S = {
+  chipClosed: 'CRDT dev',
+  title: 'CRDT Dev Panel (PoC)',
+  close: 'Close',
+  sectionStatus: 'Live status',
+  sectionCatalog: 'Mutation catalog',
+  sectionPrompts: 'Known-good agent prompts',
+  sectionProxy: 'BE proxy target',
+  sectionLog: 'Event log',
+  docId: 'doc id',
+  connected: 'connected',
+  yes: 'yes',
+  no: 'no',
+  none: '—',
+  updates: 'updates applied',
+  lastFrame: 'last frame',
+  tabId: 'tab id',
+  lastSeq: 'last seq',
+  remints: 'remints (doc_reset)',
+  nodesAdded: 'doc nodes added',
+  nodesRemoved: 'doc nodes removed',
+  filterAll: 'all kinds',
+  clear: 'Clear',
+  copyJson: 'Copy JSON',
+  copied: 'Copied',
+  eventCount: 'events'
+} as const
+
+const MUTATION_CATALOG = [
+  'add_node',
+  'delete_node',
+  'move_node',
+  'set_widget',
+  'connect',
+  'disconnect'
+] as const
+
+const KNOWN_GOOD_PROMPTS = [
+  "Add a single CLIP Text Encode (Prompt) node with text 'hello world'",
+  'Add a KSampler node',
+  'Delete the newest node you added'
+] as const
+
+const EVENT_KINDS: readonly DevEventKind[] = [
+  'ws_out',
+  'doc_subscribed',
+  'doc_update',
+  'doc_ops_result',
+  'doc_reset',
+  'schema_error',
+  'reconnected',
+  'subscribe_retry',
+  'doc_nodes_changed',
+  'rebind'
+] as const
+
+// ── open/close state, persisted ───────────────────────────────────────────
+const OPEN_KEY = 'Comfy.Agent.CrdtDevPanel.open'
+
+function readOpen(): boolean {
+  try {
+    return localStorage.getItem(OPEN_KEY) === 'true'
+  } catch {
+    return false
+  }
+}
+
+const open = ref(isDevBuild && readOpen())
+
+function setOpen(value: boolean) {
+  open.value = value
+  try {
+    localStorage.setItem(OPEN_KEY, String(value))
+  } catch {
+    /* storage unavailable — panel still toggles in-memory */
+  }
+}
+
+// ── 1s poll of the PoC console helper ─────────────────────────────────────
+interface PocGlobal {
+  tabId?: string
+  lastSeq?: number
+}
+
+const polled = ref<{ tabId: string | null; lastSeq: number | null }>({
+  tabId: null,
+  lastSeq: null
+})
+
+let pollHandle: ReturnType<typeof setInterval> | undefined
+
+function poll() {
+  const poc = (window as unknown as Record<string, unknown>).__agentCrdtPoc as
+    | PocGlobal
+    | undefined
+  polled.value = {
+    tabId: poc?.tabId ?? null,
+    lastSeq: typeof poc?.lastSeq === 'number' ? poc.lastSeq : null
+  }
+}
+
+onMounted(() => {
+  if (!isDevBuild) return
+  poll()
+  pollHandle = setInterval(poll, 1000)
+})
+
+onBeforeUnmount(() => {
+  if (pollHandle !== undefined) clearInterval(pollHandle)
+})
+
+// ── derived counters from the event buffer ────────────────────────────────
+const remintCount = computed(
+  () => devEvents.value.filter((e) => e.kind === 'doc_reset').length
+)
+
+const nodeDelta = computed(() => {
+  let added = 0
+  let removed = 0
+  for (const e of devEvents.value) {
+    if (e.kind !== 'doc_nodes_changed') continue
+    const d = e.detail as { added?: unknown[]; removed?: unknown[] } | null
+    added += d?.added?.length ?? 0
+    removed += d?.removed?.length ?? 0
+  }
+  return { added, removed }
+})
+
+// ── event log filter / actions ────────────────────────────────────────────
+const kindFilter = ref<'' | DevEventKind>('')
+
+const filteredEvents = computed<readonly DevEvent[]>(() => {
+  const events = devEvents.value
+  const filtered = kindFilter.value
+    ? events.filter((e) => e.kind === kindFilter.value)
+    : events
+  // newest first, capped for render cost — full buffer still available via copy
+  return [...filtered].reverse().slice(0, 100)
+})
+
+const copyLabel = ref<string>(S.copyJson)
+
+async function copyEvents() {
+  const events = kindFilter.value
+    ? devEvents.value.filter((e) => e.kind === kindFilter.value)
+    : devEvents.value
+  try {
+    await navigator.clipboard.writeText(stringifyDevEvents(events))
+    copyLabel.value = S.copied
+    setTimeout(() => (copyLabel.value = S.copyJson), 1200)
+  } catch {
+    /* clipboard unavailable (non-secure context) — silently ignore */
+  }
+}
+
+const proxyTarget = computed(() => api.apiURL(''))
+
+function fmtDetail(detail: unknown): string {
+  try {
+    const raw = JSON.stringify(detail, (_k, v) =>
+      v instanceof Uint8Array ? `Uint8Array(${v.length})` : v
+    )
+    return raw && raw.length > 200 ? raw.slice(0, 200) + '…' : (raw ?? '')
+  } catch {
+    return String(detail)
+  }
+}
+
+function fmtTime(at: number): string {
+  return new Date(at).toLocaleTimeString()
+}
+</script>
+
+<template>
+  <div
+    v-if="isDevBuild"
+    class="fixed right-3 bottom-3 z-9999 font-mono text-xs"
+    data-testid="crdt-dev-panel"
+  >
+    <button
+      v-if="!open"
+      class="rounded-full border border-border-default bg-base-background px-3 py-1 shadow-md"
+      data-testid="crdt-dev-panel-chip"
+      @click="setOpen(true)"
+    >
+      {{ S.chipClosed }}
+    </button>
+
+    <div
+      v-else
+      class="flex max-h-[70vh] w-[420px] flex-col overflow-hidden rounded-lg border border-border-default bg-base-background shadow-xl"
+    >
+      <div
+        class="flex items-center justify-between border-b border-border-default px-3 py-2"
+      >
+        <span class="font-bold">{{ S.title }}</span>
+        <button
+          class="rounded-sm border border-border-default px-2 py-0.5"
+          data-testid="crdt-dev-panel-close"
+          @click="setOpen(false)"
+        >
+          {{ S.close }}
+        </button>
+      </div>
+
+      <div class="flex-1 space-y-3 overflow-y-auto p-3">
+        <section>
+          <div class="mb-1 font-bold">{{ S.sectionStatus }}</div>
+          <table class="w-full">
+            <tbody>
+              <tr>
+                <td class="pr-2 text-muted">{{ S.docId }}</td>
+                <td class="break-all">
+                  {{ props.status.workflowId ?? S.none }}
+                </td>
+              </tr>
+              <tr>
+                <td class="pr-2 text-muted">{{ S.connected }}</td>
+                <td>{{ props.status.connected ? S.yes : S.no }}</td>
+              </tr>
+              <tr>
+                <td class="pr-2 text-muted">{{ S.updates }}</td>
+                <td>{{ props.status.updatesApplied }}</td>
+              </tr>
+              <tr>
+                <td class="pr-2 text-muted">{{ S.lastFrame }}</td>
+                <td>{{ props.status.lastFrameType ?? S.none }}</td>
+              </tr>
+              <tr>
+                <td class="pr-2 text-muted">{{ S.tabId }}</td>
+                <td class="break-all">{{ polled.tabId ?? S.none }}</td>
+              </tr>
+              <tr>
+                <td class="pr-2 text-muted">{{ S.lastSeq }}</td>
+                <td>{{ polled.lastSeq ?? S.none }}</td>
+              </tr>
+              <tr>
+                <td class="pr-2 text-muted">{{ S.remints }}</td>
+                <td>{{ remintCount }}</td>
+              </tr>
+              <tr>
+                <td class="pr-2 text-muted">{{ S.nodesAdded }}</td>
+                <td>{{ nodeDelta.added }}</td>
+              </tr>
+              <tr>
+                <td class="pr-2 text-muted">{{ S.nodesRemoved }}</td>
+                <td>{{ nodeDelta.removed }}</td>
+              </tr>
+            </tbody>
+          </table>
+        </section>
+
+        <section>
+          <div class="mb-1 font-bold">{{ S.sectionProxy }}</div>
+          <div class="break-all text-muted">{{ proxyTarget }}</div>
+        </section>
+
+        <section>
+          <div class="mb-1 font-bold">{{ S.sectionCatalog }}</div>
+          <div class="flex flex-wrap gap-1">
+            <span
+              v-for="m in MUTATION_CATALOG"
+              :key="m"
+              class="rounded-sm border border-border-default px-1.5 py-0.5"
+            >
+              {{ m }}
+            </span>
+          </div>
+        </section>
+
+        <section>
+          <div class="mb-1 font-bold">{{ S.sectionPrompts }}</div>
+          <ul class="list-disc space-y-1 pl-4">
+            <li v-for="p in KNOWN_GOOD_PROMPTS" :key="p">{{ p }}</li>
+          </ul>
+        </section>
+
+        <section>
+          <div class="mb-1 flex items-center gap-2">
+            <span class="font-bold">{{ S.sectionLog }}</span>
+            <span class="text-muted"
+              >{{ devEvents.length }} {{ S.eventCount }}</span
+            >
+            <select
+              v-model="kindFilter"
+              class="ml-auto rounded-sm border border-border-default bg-base-background px-1 py-0.5"
+              data-testid="crdt-dev-panel-filter"
+            >
+              <option value="">{{ S.filterAll }}</option>
+              <option v-for="k in EVENT_KINDS" :key="k" :value="k">
+                {{ k }}
+              </option>
+            </select>
+            <button
+              class="rounded-sm border border-border-default px-1.5 py-0.5"
+              @click="copyEvents"
+            >
+              {{ copyLabel }}
+            </button>
+            <button
+              class="rounded-sm border border-border-default px-1.5 py-0.5"
+              @click="clearDevEvents()"
+            >
+              {{ S.clear }}
+            </button>
+          </div>
+          <div
+            class="max-h-56 space-y-1 overflow-y-auto"
+            data-testid="crdt-dev-panel-log"
+          >
+            <div
+              v-for="e in filteredEvents"
+              :key="e.seq"
+              class="border-b border-border-default pb-1"
+            >
+              <span class="text-muted">{{ fmtTime(e.at) }}</span>
+              <span class="ml-1 font-bold">{{ e.kind }}</span>
+              <div class="break-all text-muted">{{ fmtDetail(e.detail) }}</div>
+            </div>
+          </div>
+        </section>
+      </div>
+    </div>
+  </div>
+</template>

--- a/src/workbench/extensions/agent/crdt/RUN-CLOUD-E2E.md
+++ b/src/workbench/extensions/agent/crdt/RUN-CLOUD-E2E.md
@@ -1,0 +1,40 @@
+# Cloud CRDT follower - run sheet
+
+Point this branch's follower at a CRDT-enabled cloud backend and watch the agent's
+graph edits land on the canvas.
+
+Note: at this slice the follower has no mount site - nothing in the app imports
+this tree yet, and the agent panel that mounts it lands in a later slice. Until
+then the Verify section below cannot be executed from a build of this branch; the
+sheet documents the procedure for the slice that ships the mount.
+
+## What this proves
+
+Agent turn (backend) -> semantic ops -> doc applier -> host Yjs `update_b64`
+-> relayed over `/ws` -> FE follower Y.Doc -> `layoutStore` -> canvas moves. The
+follower is read-only: it never writes the shared doc (host is the sole writer).
+
+## Prerequisites
+
+- A backend with the CRDT document path enabled.
+- Network reachability to that backend from the machine running the dev server.
+- A logged-in session / API key (the agent API returns 401 otherwise).
+- The target workflow must be crdt-enabled on the backend.
+
+## Run
+
+    DEV_SERVER_COMFYUI_URL=https://<your-crdt-enabled-backend>/ pnpm dev
+
+Any `*.comfy.org` `DEV_SERVER_COMFYUI_URL` auto-selects the cloud distribution and
+proxies `/api` + `/ws` to that host, so no other flag is needed to retarget a
+different backend. The follower itself has no dedicated flag: it mounts with the
+agent panel, so the panel's product flag is the only gate.
+
+## Verify (requires the agent-panel slice that mounts the follower)
+
+- Click the CRDT dev chip (bottom right, dev builds only) to open the panel;
+  the Live status table shows connected: yes and the subscribed workflow id in
+  the doc id row.
+- Send a message in the agent chat; as the agent edits, `updatesApplied` increments and
+  nodes move on the canvas.
+- Reload the tab mid-session: it resubscribes and reconverges from the seeded snapshot.

--- a/src/workbench/extensions/agent/crdt/applierConformance.test.ts
+++ b/src/workbench/extensions/agent/crdt/applierConformance.test.ts
@@ -1,0 +1,322 @@
+/**
+ * Conformance vectors against the PINNED package (plan 3.5): every assumption
+ * the write leg builds on, asserted against the applier the doc host actually
+ * runs. These were staged "once the compatible pin lands" - the 0.2.0 pin
+ * exposes the outcome union, so they run now and re-assert automatically at
+ * any future pin swap.
+ *
+ * Each vector names the leg behavior that depends on it. Applier facts the
+ * probes established and these tests pin: a write to a MISSING node is a
+ * protocol-level `no-op` (delete-wins), never a rejection; `reset_doc` is
+ * rejected `op_deferred` (vocabulary §1.6); `readGraph` projects nodes as an
+ * id-keyed record with NAME-KEYED widgets.
+ */
+import { describe, expect, it } from 'vitest'
+
+import type {
+  Op,
+  SetWidgetOp,
+  WidgetCatalog,
+  WireOp,
+  WorkflowJSON
+} from '@comfyorg/comfy-multi-player'
+
+import {
+  applyOps,
+  compareStampKeys,
+  hasAppliedOp,
+  mint,
+  readGraph,
+  stampKey
+} from '@comfyorg/comfy-multi-player'
+
+import type { GraphOperation } from './graphOperations'
+import { mintOpId, mintWireOps } from './opEnvelope'
+
+const CATALOG: WidgetCatalog = {
+  types: {
+    TestNode: { widget_order: ['seed'] },
+    OtherNode: { widget_order: ['text'] }
+  }
+}
+
+const SEED_WORKFLOW: WorkflowJSON = {
+  nodes: [
+    {
+      id: 1,
+      type: 'TestNode',
+      pos: [0, 0],
+      widgets_values: [3],
+      inputs: [{ name: 'in', type: 'IMAGE', link: null }],
+      outputs: []
+    },
+    {
+      id: 2,
+      type: 'OtherNode',
+      pos: [9, 9],
+      widgets_values: ['hi'],
+      inputs: [],
+      outputs: [{ name: 'out', type: 'IMAGE', links: [] }]
+    }
+  ],
+  links: []
+}
+
+function seedDoc() {
+  return mint(SEED_WORKFLOW, CATALOG)
+}
+
+function envelope(actor = 'human:u1:tab', baseVersion = 1) {
+  return {
+    op_id: mintOpId(),
+    actor,
+    base_version: baseVersion,
+    stamp: [baseVersion, actor] as [number, string]
+  }
+}
+
+function setWidget(
+  value: unknown,
+  overrides: Partial<SetWidgetOp> = {}
+): SetWidgetOp {
+  return {
+    ...envelope(),
+    op: 'set_widget',
+    node_id: 1,
+    widget: 'seed',
+    value,
+    ...overrides
+  } as SetWidgetOp
+}
+
+function addNode(id: number): Op {
+  return {
+    ...envelope(),
+    op: 'add_node',
+    node_id: id,
+    class_type: 'OtherNode',
+    pos: [10, 10],
+    node: { id, type: 'OtherNode', pos: [10, 10], widgets_values: ['hi'] }
+  }
+}
+
+/** A guaranteed-rejecting wire op: `reset_doc` is deferred (vocabulary §1.6). */
+function deferredResetDoc(): WireOp {
+  return {
+    ...envelope(),
+    op: 'reset_doc',
+    workflow: { nodes: [], links: [] }
+  }
+}
+
+type ProjectedNodes = Record<string, { widgets?: Record<string, unknown> }>
+
+function nodesOf(doc: ReturnType<typeof seedDoc>): ProjectedNodes {
+  return readGraph(doc).nodes as ProjectedNodes
+}
+
+function seedWidgetValue(doc: ReturnType<typeof seedDoc>): unknown {
+  return nodesOf(doc)['1']?.widgets?.seed
+}
+
+describe('applier conformance (the pinned package the doc host runs)', () => {
+  it('converges under both arrival orders (the follower can trail the sender)', () => {
+    const opA = setWidget(10)
+    const opB = addNode(7)
+
+    const forward = seedDoc()
+    applyOps(forward, [opA], CATALOG)
+    applyOps(forward, [opB], CATALOG)
+
+    const reversed = seedDoc()
+    applyOps(reversed, [opB], CATALOG)
+    applyOps(reversed, [opA], CATALOG)
+
+    expect(readGraph(forward)).toEqual(readGraph(reversed))
+  })
+
+  it('treats a byte-identical op_id resend as a no-op (the sender retry contract)', () => {
+    const doc = seedDoc()
+    const op = setWidget(10)
+
+    const first = applyOps(doc, [op], CATALOG)
+    const second = applyOps(doc, [op], CATALOG)
+
+    expect(first.outcomes).toEqual([{ op_id: op.op_id, outcome: 'applied' }])
+    expect(second.outcomes).toEqual([{ op_id: op.op_id, outcome: 'no-op' }])
+  })
+
+  it('rejects changed-payload op_id reuse (why the sender never re-mints)', () => {
+    const doc = seedDoc()
+    const op = setWidget(10)
+    applyOps(doc, [op], CATALOG)
+
+    const tampered = { ...op, value: 999 } as SetWidgetOp
+    const result = applyOps(doc, [tampered], CATALOG)
+
+    expect(result.outcomes[0].outcome).toBe('rejected')
+    expect(seedWidgetValue(doc)).toBe(10)
+  })
+
+  it('rejects the deferred reset_doc with doc state unchanged (vocabulary §1.6)', () => {
+    const doc = seedDoc()
+    const before = readGraph(doc)
+
+    const result = applyOps(doc, [deferredResetDoc() as Op], CATALOG)
+
+    expect(result.outcomes[0].outcome).toBe('rejected')
+    expect(
+      result.outcomes[0].outcome === 'rejected' &&
+        result.outcomes[0].reason.code
+    ).toBe('op_deferred')
+    expect(readGraph(doc)).toEqual(before)
+  })
+
+  it.for([
+    ['FIRST', 0],
+    ['MIDDLE', 1],
+    ['LAST', 2]
+  ] as const)(
+    'aborts the remainder with the valid prefix kept - failure at %s',
+    ([_position, failingIndex]) => {
+      const doc = seedDoc()
+      const good = [addNode(7), addNode(8), addNode(9)]
+      const bad = deferredResetDoc()
+      const batch = [...good] as Op[]
+      batch.splice(failingIndex, 0, bad as Op)
+
+      const result = applyOps(doc, batch, CATALOG)
+
+      // Every submitted op gets an outcome: the failure by its own code, the
+      // unprocessed tail as `batch_aborted` - the code the sender's future
+      // prefix-abort reconcile keys on to tell the tail from real rejections.
+      expect(result.outcomes).toHaveLength(batch.length)
+      expect(result.outcomes[failingIndex].outcome).toBe('rejected')
+      for (let index = 0; index < failingIndex; index++) {
+        expect(result.outcomes[index].outcome).toBe('applied')
+        expect(hasAppliedOp(doc, batch[index].op_id)).toBe(true)
+      }
+      for (let index = failingIndex + 1; index < batch.length; index++) {
+        const outcome = result.outcomes[index]
+        expect(outcome.outcome === 'rejected' && outcome.reason.code).toBe(
+          'batch_aborted'
+        )
+        expect(hasAppliedOp(doc, batch[index].op_id)).toBe(false)
+      }
+
+      // The sender's reconcile contract: resend the WHOLE batch minus the
+      // fixed op with the SAME op_ids - the prefix converges via the op_id
+      // gate, the tail applies exactly once.
+      const resend = batch.filter((op) => op !== bad)
+      const retried = applyOps(doc, resend, CATALOG)
+      expect(retried.outcomes.map((outcome) => outcome.outcome)).toEqual([
+        ...Array(failingIndex).fill('no-op'),
+        ...Array(resend.length - failingIndex).fill('applied')
+      ])
+    }
+  )
+
+  it('drops the older stamp on a contested register and says so (lww-dropped)', () => {
+    const doc = seedDoc()
+    const newer = setWidget(20, {
+      stamp: [5, 'human:u1:tab']
+    } as Partial<SetWidgetOp>)
+    const older = setWidget(10, {
+      stamp: [2, 'human:u1:tab']
+    } as Partial<SetWidgetOp>)
+
+    applyOps(doc, [newer], CATALOG)
+    const result = applyOps(doc, [older], CATALOG)
+
+    expect(result.outcomes[0].outcome).toBe('lww-dropped')
+    expect(seedWidgetValue(doc)).toBe(20)
+  })
+
+  it('orders by the stamp FIELD, exact ties broken by op_id (KA-2 offline order)', () => {
+    const actor = 'human:u1:tab'
+    const low = setWidget(1, { stamp: [3, actor] } as Partial<SetWidgetOp>)
+    const high = setWidget(2, { stamp: [3, actor] } as Partial<SetWidgetOp>)
+
+    const winner =
+      compareStampKeys(stampKey(low), stampKey(high)) > 0 ? low : high
+    const doc = seedDoc()
+    applyOps(doc, [low], CATALOG)
+    applyOps(doc, [high], CATALOG)
+
+    expect(seedWidgetValue(doc)).toBe(winner.value)
+  })
+
+  it('treats a write to a deleted node as a protocol-level no-op (delete-wins)', () => {
+    const doc = seedDoc()
+    const del: Op = {
+      ...envelope('human:u1:tab', 5),
+      op: 'delete_node',
+      node_id: 2,
+      removed_links: []
+    }
+    applyOps(doc, [del], CATALOG)
+
+    const lateWrite = {
+      ...envelope('human:u2:tab', 2),
+      op: 'set_widget',
+      node_id: 2,
+      widget: 'text',
+      value: 'late'
+    } as SetWidgetOp
+    const result = applyOps(doc, [lateWrite], CATALOG)
+
+    // Delete-wins is an apply, never an error: the sender must not treat it
+    // as a failure, and the op_id is consumed (a retry stays idempotent).
+    expect(result.outcomes[0].outcome).toBe('no-op')
+    expect(nodesOf(doc)['2']).toBeUndefined()
+    expect(hasAppliedOp(doc, lateWrite.op_id)).toBe(true)
+  })
+
+  it('accepts every op family the mint ports emit, end to end through our envelope', () => {
+    const doc = seedDoc()
+    const context = { actor: 'human:u1:tab', baseVersion: 1 }
+    const legOps: GraphOperation[] = [
+      {
+        op: 'connect',
+        link_id: 41,
+        from_node: 2,
+        from_slot: 0,
+        to_node: 1,
+        to_slot: 0,
+        link_type: 'IMAGE'
+      },
+      { op: 'set_widget', node_id: 1, widget: 'seed', value: 42, old: 3 },
+      { op: 'delete_node', node_id: 2, removed_links: [41] },
+      {
+        op: 'add_node',
+        node_id: 7,
+        class_type: 'OtherNode',
+        pos: [5, 5],
+        node: { id: 7, type: 'OtherNode', pos: [5, 5], widgets_values: ['x'] }
+      }
+    ]
+    // The clear mints against a LATER observed seq, as the real leg would
+    // (lastSeq advances on every doc_update): an equal-stamp clear can LOSE
+    // the per-node register to a same-base add by op_id tiebreak - that is
+    // LWW working, not a bug, and the leg avoids it by construction.
+    const clearOps: GraphOperation[] = [{ op: 'clear', removed_nodes: [1, 7] }]
+
+    const result = applyOps(doc, mintWireOps(legOps, context), CATALOG)
+    const clearResult = applyOps(
+      doc,
+      mintWireOps(clearOps, { ...context, baseVersion: 2 }),
+      CATALOG
+    )
+
+    expect(result.outcomes.map((outcome) => outcome.outcome)).toEqual([
+      'applied',
+      'applied',
+      'applied',
+      'applied'
+    ])
+    expect(clearResult.outcomes.map((outcome) => outcome.outcome)).toEqual([
+      'applied'
+    ])
+    expect(nodesOf(doc)).toEqual({})
+  })
+})

--- a/src/workbench/extensions/agent/crdt/devPanelLog.test.ts
+++ b/src/workbench/extensions/agent/crdt/devPanelLog.test.ts
@@ -1,0 +1,40 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import {
+  clearDevEvents,
+  devEvents,
+  recordDevEvent,
+  stringifyDevEvents
+} from './devPanelLog'
+
+describe('devPanelLog', () => {
+  beforeEach(() => {
+    clearDevEvents()
+  })
+
+  it('records events with monotonically increasing sequence numbers', () => {
+    recordDevEvent('ws_out', { frame: 'a' })
+    recordDevEvent('doc_update', { seq: 1 })
+
+    const [first, second] = devEvents.value
+    expect(first.kind).toBe('ws_out')
+    expect(second.kind).toBe('doc_update')
+    expect(second.seq).toBeGreaterThan(first.seq)
+  })
+
+  it('caps the ring buffer, dropping the oldest entries', () => {
+    for (let count = 0; count < 505; count++) {
+      recordDevEvent('doc_update', { seq: count })
+    }
+
+    expect(devEvents.value).toHaveLength(500)
+    expect(devEvents.value[0].detail).toEqual({ seq: 5 })
+  })
+
+  it('stringifies binary payloads defensively', () => {
+    recordDevEvent('doc_update', { update: new Uint8Array(16) })
+
+    const serialized = stringifyDevEvents(devEvents.value)
+    expect(serialized).toContain('"Uint8Array(16)"')
+  })
+})

--- a/src/workbench/extensions/agent/crdt/devPanelLog.ts
+++ b/src/workbench/extensions/agent/crdt/devPanelLog.ts
@@ -1,0 +1,61 @@
+import { shallowRef, triggerRef } from 'vue'
+
+/**
+ * Dev instrumentation: in-memory ring buffer feeding the CRDT dev panel.
+ * Deliberately module-level (one buffer per page, like the follower gate) so
+ * the panel component and the follower composable never need a shared
+ * injection seam. No mount site until the agent-panel slice lands.
+ */
+
+export type DevEventKind =
+  | 'ws_out'
+  | 'doc_subscribed'
+  | 'doc_update'
+  | 'doc_ops_result'
+  | 'doc_reset'
+  | 'schema_error'
+  | 'reconnected'
+  | 'subscribe_retry'
+  | 'doc_nodes_changed'
+  | 'rebind'
+  | 'stale_probe'
+
+export interface DevEvent {
+  seq: number
+  at: number
+  kind: DevEventKind
+  detail: unknown
+}
+
+const CAPACITY = 500
+
+let nextSeq = 1
+const buffer: DevEvent[] = []
+
+/**
+ * Shallow ref over the ring buffer. Consumers get a stable array identity;
+ * mutations are announced via triggerRef so a 500-entry log never churns
+ * deep reactivity.
+ */
+export const devEvents = shallowRef<readonly DevEvent[]>(buffer)
+
+export function recordDevEvent(kind: DevEventKind, detail: unknown): void {
+  buffer.push({ seq: nextSeq++, at: Date.now(), kind, detail })
+  if (buffer.length > CAPACITY) buffer.splice(0, buffer.length - CAPACITY)
+  triggerRef(devEvents)
+}
+
+export function clearDevEvents(): void {
+  buffer.length = 0
+  triggerRef(devEvents)
+}
+
+/** Serializes an event detail defensively (Uint8Array etc. don't JSON well). */
+export function stringifyDevEvents(events: readonly DevEvent[]): string {
+  return JSON.stringify(
+    events,
+    (_key, value) =>
+      value instanceof Uint8Array ? `Uint8Array(${value.length})` : value,
+    2
+  )
+}

--- a/src/workbench/extensions/agent/crdt/graphOperations.ts
+++ b/src/workbench/extensions/agent/crdt/graphOperations.ts
@@ -1,0 +1,17 @@
+/**
+ * The semantic type at the human-edit mint seam (plan 3.3; ADR 0003/0008
+ * command pattern): systems and mint ports speak `GraphOperation`; ONLY the
+ * transport layer (`opEnvelope.ts`) attaches wire identity (`op_id`, `actor`,
+ * `base_version`, `stamp`) and speaks the frozen wire vocabulary.
+ *
+ * Derived from the pinned package's own op union rather than re-declared, so
+ * the payload shapes cannot drift from what the applier accepts: a
+ * `GraphOperation` IS a wire op minus its envelope.
+ */
+import type { Op, OpBase } from '@comfyorg/comfy-multi-player'
+
+type DistributiveOmit<T, K extends PropertyKey> = T extends unknown
+  ? Omit<T, K>
+  : never
+
+export type GraphOperation = DistributiveOmit<Op, keyof OpBase>

--- a/src/workbench/extensions/agent/crdt/layoutMintPort.test.ts
+++ b/src/workbench/extensions/agent/crdt/layoutMintPort.test.ts
@@ -10,6 +10,7 @@ import type { MintSession } from './mintSession'
 
 const LOCAL_PREFIX = 'user-'
 const LOCAL_ACTOR = 'user-abc123def'
+const ROOT_GRAPH_ID = 'root-uuid'
 
 function createNodeChange(
   id: string,
@@ -19,6 +20,7 @@ function createNodeChange(
     operation: {
       type: 'createNode',
       actor,
+      graphId: ROOT_GRAPH_ID,
       nodeId: id,
       layout: { position: { x: 128, y: 96 } }
     }
@@ -26,14 +28,18 @@ function createNodeChange(
 }
 
 function clearChange(actor: string = LOCAL_ACTOR): LayoutChangeView {
-  return { operation: { type: 'clearGraph', actor } }
+  return {
+    operation: { type: 'clearGraph', actor, graphId: ROOT_GRAPH_ID }
+  }
 }
 
 function deleteChange(
   id: string,
   actor: string = LOCAL_ACTOR
 ): LayoutChangeView {
-  return { operation: { type: 'deleteNode', actor, nodeId: id } }
+  return {
+    operation: { type: 'deleteNode', actor, graphId: ROOT_GRAPH_ID, nodeId: id }
+  }
 }
 
 describe('attachLayoutMintPort', () => {
@@ -73,6 +79,7 @@ describe('attachLayoutMintPort', () => {
       isEnabled: () => enabled,
       isDocBound: () => bound,
       source: {
+        rootGraphId: () => ROOT_GRAPH_ID,
         serializeNode: (id) => graphNodes.get(id) ?? null,
         nodeIds: () => [...graphNodes.keys()]
       },
@@ -160,6 +167,27 @@ describe('attachLayoutMintPort', () => {
     deliver(deleteChange('1'))
     session.endGraphTeardown()
     deliver(deleteChange('2', AGENT_REMOTE_ACTOR))
+
+    expect(minted).toEqual([])
+  })
+
+  it('never mints root operations for a node inside a subgraph', () => {
+    const create = createNodeChange('1')
+    create.operation.graphId = 'subgraph-uuid'
+    const remove = deleteChange('1')
+    remove.operation.graphId = 'subgraph-uuid'
+
+    deliver(create)
+    deliver(remove)
+    port.runIntentionalClear(() =>
+      deliver({
+        operation: {
+          type: 'clearGraph',
+          actor: LOCAL_ACTOR,
+          graphId: 'subgraph-uuid'
+        }
+      })
+    )
 
     expect(minted).toEqual([])
   })

--- a/src/workbench/extensions/agent/crdt/layoutMintPort.test.ts
+++ b/src/workbench/extensions/agent/crdt/layoutMintPort.test.ts
@@ -1,0 +1,232 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { WorkflowNode } from '@comfyorg/comfy-multi-player'
+
+import type { GraphOperation } from './graphOperations'
+import { AGENT_REMOTE_ACTOR, attachLayoutMintPort } from './layoutMintPort'
+import type { LayoutChangeView, LayoutMintPort } from './layoutMintPort'
+import { createMintSession } from './mintSession'
+import type { MintSession } from './mintSession'
+
+const LOCAL_PREFIX = 'user-'
+const LOCAL_ACTOR = 'user-abc123def'
+
+function createNodeChange(
+  id: string,
+  actor: string = LOCAL_ACTOR
+): LayoutChangeView {
+  return {
+    operation: {
+      type: 'createNode',
+      actor,
+      nodeId: id,
+      layout: { position: { x: 128, y: 96 } }
+    }
+  }
+}
+
+function clearChange(actor: string = LOCAL_ACTOR): LayoutChangeView {
+  return { operation: { type: 'clearGraph', actor } }
+}
+
+function deleteChange(
+  id: string,
+  actor: string = LOCAL_ACTOR
+): LayoutChangeView {
+  return { operation: { type: 'deleteNode', actor, nodeId: id } }
+}
+
+describe('attachLayoutMintPort', () => {
+  let minted: GraphOperation[]
+  let port: LayoutMintPort
+  let enabled: boolean
+  let bound: boolean
+  let graphNodes: Map<string, WorkflowNode>
+  let listeners: Set<(change: LayoutChangeView) => void>
+  let session: MintSession
+  let severed: Map<string, (string | number)[]>
+
+  function deliver(change: LayoutChangeView): void {
+    for (const listener of listeners) listener(change)
+  }
+
+  beforeEach(() => {
+    minted = []
+    enabled = true
+    bound = true
+    listeners = new Set()
+    session = createMintSession()
+    severed = new Map()
+    graphNodes = new Map([
+      ['1', { id: 1, type: 'TestNode', pos: [128, 96], widgets_values: [7] }]
+    ])
+    port = attachLayoutMintPort({
+      changes: {
+        onChange: (listener) => {
+          listeners.add(listener)
+          return () => listeners.delete(listener)
+        }
+      },
+      session,
+      severedLinks: { take: (nodeId) => severed.get(nodeId) ?? [] },
+      localActorPrefix: LOCAL_PREFIX,
+      isEnabled: () => enabled,
+      isDocBound: () => bound,
+      source: {
+        serializeNode: (id) => graphNodes.get(id) ?? null,
+        nodeIds: () => [...graphNodes.keys()]
+      },
+      enqueue: (operations) => minted.push(...operations)
+    })
+  })
+
+  it('mints add_node with the mint-time snapshot for a local createNode', () => {
+    deliver(createNodeChange('1'))
+
+    expect(minted).toEqual([
+      {
+        op: 'add_node',
+        node_id: '1',
+        class_type: 'TestNode',
+        pos: [128, 96],
+        node: { id: 1, type: 'TestNode', pos: [128, 96], widgets_values: [7] }
+      }
+    ])
+  })
+
+  it('never mints an agent-remote echo (KA-6 sender half)', () => {
+    deliver(createNodeChange('1', AGENT_REMOTE_ACTOR))
+
+    expect(minted).toEqual([])
+  })
+
+  it('never mints an actor-less change (no call-carried provenance)', () => {
+    const change = createNodeChange('1')
+    delete change.operation.actor
+    deliver(change)
+
+    expect(minted).toEqual([])
+  })
+
+  it('never mints with the product flag off', () => {
+    enabled = false
+    deliver(createNodeChange('1'))
+
+    expect(minted).toEqual([])
+  })
+
+  it('never mints without a bound doc', () => {
+    bound = false
+    deliver(createNodeChange('1'))
+
+    expect(minted).toEqual([])
+  })
+
+  it('never mints inside a graph-teardown bracket', () => {
+    session.beginGraphTeardown()
+    deliver(createNodeChange('1'))
+    session.endGraphTeardown()
+
+    expect(minted).toEqual([])
+  })
+
+  it('mints again after the teardown bracket closes', () => {
+    session.beginGraphTeardown()
+    session.endGraphTeardown()
+    deliver(createNodeChange('1'))
+
+    expect(minted).toHaveLength(1)
+  })
+
+  it('mints delete_node carrying the severed link ids from the capture', () => {
+    severed.set('1', [17, 18])
+    deliver(deleteChange('1'))
+
+    expect(minted).toEqual([
+      { op: 'delete_node', node_id: '1', removed_links: [17, 18] }
+    ])
+  })
+
+  it('mints delete_node with no severances as an empty removed_links', () => {
+    deliver(deleteChange('1'))
+
+    expect(minted).toEqual([
+      { op: 'delete_node', node_id: '1', removed_links: [] }
+    ])
+  })
+
+  it('never mints a teardown-bracketed or agent-remote deleteNode', () => {
+    session.beginGraphTeardown()
+    deliver(deleteChange('1'))
+    session.endGraphTeardown()
+    deliver(deleteChange('2', AGENT_REMOTE_ACTOR))
+
+    expect(minted).toEqual([])
+  })
+
+  it('drops a snapshot-less mint observably, never silently', () => {
+    const consoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined)
+    graphNodes.clear()
+    deliver(createNodeChange('1'))
+
+    expect(minted).toEqual([])
+    expect(consoleError).toHaveBeenCalledOnce()
+    consoleError.mockRestore()
+  })
+
+  it('treats a bare clearGraph as teardown (a tab switch mints no clear storm)', () => {
+    deliver(clearChange())
+
+    expect(minted).toEqual([])
+  })
+
+  it('mints clear with the pre-captured node set for an intentional clear', () => {
+    port.runIntentionalClear(() => {
+      graphNodes.clear()
+      deliver(clearChange())
+    })
+
+    expect(minted).toEqual([{ op: 'clear', removed_nodes: ['1'] }])
+  })
+
+  it('drops the intentional-clear capture if no clear reaches the store', async () => {
+    port.runIntentionalClear(() => {})
+    await Promise.resolve()
+
+    deliver(clearChange())
+
+    expect(minted).toEqual([])
+  })
+
+  it.for([
+    'moveNode',
+    'resizeNode',
+    'setNodeZIndex',
+    'batchUpdateBounds',
+    'createReroute',
+    'deleteReroute',
+    'moveReroute',
+    'createGroup',
+    'setGroupBounds',
+    'deleteGroup'
+  ] as const)('never mints the non-semantic %s operation', (type) => {
+    deliver({
+      operation: {
+        type,
+        actor: LOCAL_ACTOR,
+        nodeId: '1',
+        layout: { position: { x: 1, y: 2 } }
+      }
+    })
+    expect(minted).toEqual([])
+  })
+
+  it('stops minting after detach', () => {
+    port.detach()
+    deliver(createNodeChange('1'))
+
+    expect(minted).toEqual([])
+  })
+})

--- a/src/workbench/extensions/agent/crdt/layoutMintPort.ts
+++ b/src/workbench/extensions/agent/crdt/layoutMintPort.ts
@@ -1,0 +1,155 @@
+/**
+ * Layout-store mint port over the injected change feed (both applyOperation
+ * entries funnel through it). Provenance rides operation.actor - stamped at
+ * apply, so deferred delivery still carries it; remote applies run as
+ * AGENT_REMOTE_ACTOR and never re-mint (KA-6). Teardown clears are inert
+ * outside runIntentionalClear, whose capture is the authoritative pre-clear
+ * node set; delete_node consumes the link port's severance capture.
+ */
+import type { NodeId, WorkflowNode } from '@comfyorg/comfy-multi-player'
+
+import type { GraphOperation } from './graphOperations'
+import type { SeveranceLog } from './linkMintPort'
+import { shouldMint } from './mintGate'
+import type { MintSession } from './mintSession'
+
+export const AGENT_REMOTE_ACTOR = 'agent-remote'
+
+/**
+ * The structural slice of the layout store's LayoutChange this port reads.
+ * Structural on purpose: the real feed passes the store's own change objects
+ * through without this module importing renderer types.
+ */
+export interface LayoutChangeView {
+  operation: {
+    type: string
+    actor?: string
+    nodeId?: NodeId
+    layout?: { position: { x: number; y: number } }
+  }
+}
+
+interface LayoutChangeFeed {
+  onChange(listener: (change: LayoutChangeView) => void): () => void
+}
+
+/** The workflow-JSON node snapshot an `add_node` carries, read at mint time. */
+interface MintSnapshotSource {
+  /** Serialized workflow-JSON node for `id`, or null when unavailable. */
+  serializeNode(id: string): WorkflowNode | null
+  /** Every node id currently on the graph (clear's authoritative target set). */
+  nodeIds(): NodeId[]
+}
+
+export interface LayoutMintPortDeps {
+  changes: LayoutChangeFeed
+  /** Shared teardown brackets (held by the load path around every graph load). */
+  session: MintSession
+  /** The link port's capture of a deleted node's severed link ids. */
+  severedLinks: SeveranceLog
+  /** The session's local layout-actor prefix (`ACTOR_CONFIG.USER_PREFIX`). */
+  localActorPrefix: string
+  /** Slice 00's product gate. */
+  isEnabled(): boolean
+  /** A semantic doc is bound for the active workflow. */
+  isDocBound(): boolean
+  source: MintSnapshotSource
+  /** Receives minted semantic operations (the sender's inbox). */
+  enqueue(operations: GraphOperation[]): void
+}
+
+export interface LayoutMintPort {
+  /**
+   * Marks `fn`'s clear as an intentional human clear: captures the
+   * authoritative pre-clear node set and mints ONE `clear` op when the
+   * store's clearGraph change arrives from a local actor.
+   */
+  runIntentionalClear<T>(fn: () => T): T
+  detach(): void
+}
+
+export function attachLayoutMintPort(deps: LayoutMintPortDeps): LayoutMintPort {
+  let intentionalClearNodes: NodeId[] | null = null
+
+  function gate(change: LayoutChangeView, teardown: boolean): boolean {
+    const actor = change.operation.actor
+    return shouldMint({
+      flagEnabled: deps.isEnabled(),
+      docBound: deps.isDocBound(),
+      localProvenance:
+        actor !== undefined && actor.startsWith(deps.localActorPrefix),
+      teardown
+    })
+  }
+
+  function onChange(change: LayoutChangeView): void {
+    const operation = change.operation
+    const inTeardown = deps.session.inTeardown()
+    switch (operation.type) {
+      case 'createNode': {
+        if (!gate(change, inTeardown)) return
+        if (operation.nodeId === undefined || !operation.layout) return
+        const node = deps.source.serializeNode(String(operation.nodeId))
+        if (!node) {
+          // A dropped human mint is a local-graph-vs-doc divergence; it must
+          // be observable, never silent (the surfacing-honesty principle).
+          console.error(
+            '[agent-crdt] add_node mint dropped: no snapshot for node',
+            operation.nodeId
+          )
+          return
+        }
+        deps.enqueue([
+          {
+            op: 'add_node',
+            node_id: operation.nodeId,
+            class_type: String(node.type),
+            pos: [operation.layout.position.x, operation.layout.position.y],
+            node
+          }
+        ])
+        return
+      }
+      case 'deleteNode': {
+        if (!gate(change, inTeardown)) return
+        if (operation.nodeId === undefined) return
+        deps.enqueue([
+          {
+            op: 'delete_node',
+            node_id: operation.nodeId,
+            removed_links: deps.severedLinks.take(String(operation.nodeId))
+          }
+        ])
+        return
+      }
+      case 'clearGraph': {
+        const captured = intentionalClearNodes
+        intentionalClearNodes = null
+        if (!gate(change, inTeardown || captured === null)) return
+        deps.enqueue([{ op: 'clear', removed_nodes: captured ?? [] }])
+        return
+      }
+      default:
+        return
+    }
+  }
+
+  const unsubscribe = deps.changes.onChange(onChange)
+
+  return {
+    runIntentionalClear<T>(fn: () => T): T {
+      intentionalClearNodes = deps.source.nodeIds()
+      try {
+        return fn()
+      } finally {
+        // The clearGraph change consumes the capture at delivery; if the
+        // clear never reached the store, drop it so an unrelated later
+        // clearGraph cannot borrow it.
+        queueMicrotask(() => {
+          intentionalClearNodes = null
+        })
+      }
+    },
+    detach: unsubscribe
+  }
+}

--- a/src/workbench/extensions/agent/crdt/layoutMintPort.ts
+++ b/src/workbench/extensions/agent/crdt/layoutMintPort.ts
@@ -24,6 +24,7 @@ export interface LayoutChangeView {
   operation: {
     type: string
     actor?: string
+    graphId?: string
     nodeId?: NodeId
     layout?: { position: { x: number; y: number } }
   }
@@ -35,6 +36,8 @@ interface LayoutChangeFeed {
 
 /** The workflow-JSON node snapshot an `add_node` carries, read at mint time. */
 interface MintSnapshotSource {
+  /** Active root graph id; interior graph operations are not root doc ops. */
+  rootGraphId(): string | null
   /** Serialized workflow-JSON node for `id`, or null when unavailable. */
   serializeNode(id: string): WorkflowNode | null
   /** Every node id currently on the graph (clear's authoritative target set). */
@@ -85,9 +88,12 @@ export function attachLayoutMintPort(deps: LayoutMintPortDeps): LayoutMintPort {
   function onChange(change: LayoutChangeView): void {
     const operation = change.operation
     const inTeardown = deps.session.inTeardown()
+    const inRootGraph =
+      operation.graphId !== undefined &&
+      operation.graphId === deps.source.rootGraphId()
     switch (operation.type) {
       case 'createNode': {
-        if (!gate(change, inTeardown)) return
+        if (!inRootGraph || !gate(change, inTeardown)) return
         if (operation.nodeId === undefined || !operation.layout) return
         const node = deps.source.serializeNode(String(operation.nodeId))
         if (!node) {
@@ -111,7 +117,7 @@ export function attachLayoutMintPort(deps: LayoutMintPortDeps): LayoutMintPort {
         return
       }
       case 'deleteNode': {
-        if (!gate(change, inTeardown)) return
+        if (!inRootGraph || !gate(change, inTeardown)) return
         if (operation.nodeId === undefined) return
         deps.enqueue([
           {
@@ -125,7 +131,8 @@ export function attachLayoutMintPort(deps: LayoutMintPortDeps): LayoutMintPort {
       case 'clearGraph': {
         const captured = intentionalClearNodes
         intentionalClearNodes = null
-        if (!gate(change, inTeardown || captured === null)) return
+        if (!inRootGraph || !gate(change, inTeardown || captured === null))
+          return
         deps.enqueue([{ op: 'clear', removed_nodes: captured ?? [] }])
         return
       }

--- a/src/workbench/extensions/agent/crdt/linkMintPort.test.ts
+++ b/src/workbench/extensions/agent/crdt/linkMintPort.test.ts
@@ -1,0 +1,201 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { GraphOperation } from './graphOperations'
+import { attachLinkMintPort } from './linkMintPort'
+import type {
+  LinkMintPort,
+  LinkScopeView,
+  LinkTopologyView
+} from './linkMintPort'
+import { createMintSession } from './mintSession'
+import type { MintSession } from './mintSession'
+
+const ROOT_SCOPE: LinkScopeView = {
+  rootGraphId: 'root-uuid',
+  owningGraphId: 'root-uuid'
+}
+const SUBGRAPH_SCOPE: LinkScopeView = {
+  rootGraphId: 'root-uuid',
+  owningGraphId: 'subgraph-uuid'
+}
+
+function topology(id: number): LinkTopologyView {
+  return {
+    id,
+    originNodeId: 1,
+    originSlot: 0,
+    targetNodeId: 2,
+    targetSlot: 3,
+    type: 'IMAGE'
+  }
+}
+
+async function afterSweep(): Promise<void> {
+  await Promise.resolve()
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
+describe('attachLinkMintPort', () => {
+  let minted: GraphOperation[]
+  let port: LinkMintPort
+  let enabled: boolean
+  let bound: boolean
+  let session: MintSession
+  let placedListeners: Set<
+    (scope: LinkScopeView, topology: LinkTopologyView) => void
+  >
+  let deletedListeners: Set<
+    (scope: LinkScopeView, topology: LinkTopologyView) => void
+  >
+
+  function place(scope: LinkScopeView, link: LinkTopologyView): void {
+    for (const listener of placedListeners) listener(scope, link)
+  }
+
+  function remove(scope: LinkScopeView, link: LinkTopologyView): void {
+    for (const listener of deletedListeners) listener(scope, link)
+  }
+
+  beforeEach(() => {
+    minted = []
+    enabled = true
+    bound = true
+    session = createMintSession()
+    placedListeners = new Set()
+    deletedListeners = new Set()
+    port = attachLinkMintPort({
+      events: {
+        onPlaced: (listener) => {
+          placedListeners.add(listener)
+          return () => placedListeners.delete(listener)
+        },
+        onDeleted: (listener) => {
+          deletedListeners.add(listener)
+          return () => deletedListeners.delete(listener)
+        }
+      },
+      session,
+      isEnabled: () => enabled,
+      isDocBound: () => bound,
+      enqueue: (operations) => minted.push(...operations)
+    })
+  })
+
+  it('mints a concrete connect for a local link placement', () => {
+    place(ROOT_SCOPE, topology(41))
+
+    expect(minted).toEqual([
+      {
+        op: 'connect',
+        link_id: 41,
+        from_node: 1,
+        from_slot: 0,
+        to_node: 2,
+        to_slot: 3,
+        link_type: 'IMAGE'
+      }
+    ])
+  })
+
+  it('never mints inside the remote-apply scope (KA-6 sender half)', () => {
+    session.runRemoteApply(() => place(ROOT_SCOPE, topology(41)))
+
+    expect(minted).toEqual([])
+  })
+
+  it('never mints with the product flag off', () => {
+    enabled = false
+    place(ROOT_SCOPE, topology(41))
+
+    expect(minted).toEqual([])
+  })
+
+  it('never mints without a bound doc', () => {
+    bound = false
+    place(ROOT_SCOPE, topology(41))
+
+    expect(minted).toEqual([])
+  })
+
+  it('never mints inside a graph-teardown bracket (a load registers no storm)', () => {
+    session.beginGraphTeardown()
+    place(ROOT_SCOPE, topology(41))
+    session.endGraphTeardown()
+
+    expect(minted).toEqual([])
+  })
+
+  it('surfaces a subgraph-interior placement observably instead of minting', () => {
+    const consoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined)
+    place(SUBGRAPH_SCOPE, topology(41))
+
+    expect(minted).toEqual([])
+    expect(consoleError).toHaveBeenCalledOnce()
+    consoleError.mockRestore()
+  })
+
+  it('captures a severed link under both endpoints, consumed exactly once', () => {
+    remove(ROOT_SCOPE, topology(41))
+
+    expect(port.severances.take('2')).toEqual([41])
+    expect(port.severances.take('1')).toEqual([])
+  })
+
+  it('surfaces an unconsumed local disconnect as divergence after the sweep', async () => {
+    const consoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined)
+    remove(ROOT_SCOPE, topology(41))
+    await afterSweep()
+
+    expect(consoleError).toHaveBeenCalledOnce()
+    expect(consoleError.mock.calls[0][1]).toBe(41)
+    consoleError.mockRestore()
+  })
+
+  it('stays silent for a consumed severance (the delete carried it)', async () => {
+    const consoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined)
+    remove(ROOT_SCOPE, topology(41))
+    port.severances.take('1')
+    await afterSweep()
+
+    expect(consoleError).not.toHaveBeenCalled()
+    consoleError.mockRestore()
+  })
+
+  it('stays silent for non-mintable severances (teardown and remote deletes)', async () => {
+    const consoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined)
+    session.beginGraphTeardown()
+    remove(ROOT_SCOPE, topology(41))
+    session.endGraphTeardown()
+    session.runRemoteApply(() => remove(ROOT_SCOPE, topology(42)))
+    await afterSweep()
+
+    expect(consoleError).not.toHaveBeenCalled()
+    consoleError.mockRestore()
+  })
+
+  it('sweeps the capture window: a later take finds nothing', async () => {
+    session.beginGraphTeardown()
+    remove(ROOT_SCOPE, topology(41))
+    session.endGraphTeardown()
+    await afterSweep()
+
+    expect(port.severances.take('1')).toEqual([])
+    expect(port.severances.take('2')).toEqual([])
+  })
+
+  it('stops minting after detach', () => {
+    port.detach()
+    place(ROOT_SCOPE, topology(41))
+
+    expect(minted).toEqual([])
+  })
+})

--- a/src/workbench/extensions/agent/crdt/linkMintPort.ts
+++ b/src/workbench/extensions/agent/crdt/linkMintPort.ts
@@ -1,0 +1,190 @@
+/**
+ * The blessed connect port: litegraph's registerLinkTopology bridge calls
+ * linkStore synchronously for EVERY link change, so nothing escapes this seam.
+ * Register/replace mint a CONCRETE connect (a replace displaces the incumbent
+ * register by LWW - no severance). Deletes cannot mint (no disconnect op in
+ * the frozen vocabulary): they feed the severance log for delete_node, and an
+ * unconsumed local severance surfaces as observable divergence after a double
+ * microtask (strictly after the layout store's single-microtask delivery).
+ */
+import type { NodeId as WireNodeId } from '@comfyorg/comfy-multi-player'
+
+import type { GraphOperation } from './graphOperations'
+import { shouldMint } from './mintGate'
+import type { MintSession } from './mintSession'
+
+/** The structural slice of the store's GraphScope this port reads. */
+export interface LinkScopeView {
+  rootGraphId: string
+  owningGraphId: string
+}
+
+/**
+ * The structural slice of `LinkTopology` this port reads. A floating
+ * topology (either end unassigned) is reroute-chain bookkeeping, not a
+ * link - the wiring feed filters those out before this port sees them.
+ */
+export interface LinkTopologyView {
+  id: string | number
+  originNodeId: string | number
+  originSlot: number
+  targetNodeId: string | number
+  targetSlot: number
+  type: string | number
+}
+
+interface LinkEventFeed {
+  /** Fires after a successful `registerLink` or `replaceLink`. */
+  onPlaced(
+    listener: (scope: LinkScopeView, topology: LinkTopologyView) => void
+  ): () => void
+  /** Fires after `deleteLink` removes a registered topology. */
+  onDeleted(
+    listener: (scope: LinkScopeView, topology: LinkTopologyView) => void
+  ): () => void
+}
+
+/**
+ * The delete_node capture seam: the layout port takes a deleted node's
+ * severed link ids from here at mint time.
+ */
+export interface SeveranceLog {
+  /**
+   * Link ids severed for `nodeId` in the current capture window, each
+   * consumed globally (a link touches two nodes; only one delete carries it).
+   */
+  take(nodeId: string): WireNodeId[]
+}
+
+export interface LinkMintPortDeps {
+  events: LinkEventFeed
+  session: MintSession
+  /** Slice 00's product gate. */
+  isEnabled(): boolean
+  /** A semantic doc is bound for the active workflow. */
+  isDocBound(): boolean
+  /** Receives minted semantic operations (the sender's inbox). */
+  enqueue(operations: GraphOperation[]): void
+}
+
+export interface LinkMintPort {
+  severances: SeveranceLog
+  detach(): void
+}
+
+interface SeveranceEntry {
+  linkId: WireNodeId
+  /** The gate was open at severance: unconsumed means a real divergence. */
+  mintable: boolean
+}
+
+function isRootScope(scope: LinkScopeView): boolean {
+  return String(scope.owningGraphId) === String(scope.rootGraphId)
+}
+
+export function attachLinkMintPort(deps: LinkMintPortDeps): LinkMintPort {
+  const severancesByNode = new Map<string, SeveranceEntry[]>()
+  const consumedLinkIds = new Set<string>()
+  let sweepScheduled = false
+
+  function gateOpen(): boolean {
+    return shouldMint({
+      flagEnabled: deps.isEnabled(),
+      docBound: deps.isDocBound(),
+      localProvenance: !deps.session.inRemoteApply(),
+      teardown: deps.session.inTeardown()
+    })
+  }
+
+  function surfaceUnrepresentable(what: string, id: string | number): void {
+    // A doc that no longer matches the local graph must be observable,
+    // never silent (the surfacing-honesty principle).
+    console.error(
+      `[agent-crdt] ${what} has no wire op; the bound doc diverges from the local graph`,
+      id
+    )
+  }
+
+  function onPlaced(scope: LinkScopeView, topology: LinkTopologyView): void {
+    if (!gateOpen()) return
+    if (!isRootScope(scope)) {
+      surfaceUnrepresentable('subgraph-interior connect', topology.id)
+      return
+    }
+    deps.enqueue([
+      {
+        op: 'connect',
+        link_id: topology.id,
+        from_node: topology.originNodeId,
+        from_slot: topology.originSlot,
+        to_node: topology.targetNodeId,
+        to_slot: topology.targetSlot,
+        link_type: String(topology.type)
+      }
+    ])
+  }
+
+  function scheduleSweep(): void {
+    if (sweepScheduled) return
+    sweepScheduled = true
+    // Double microtask: the layout store delivers its queued changes on ONE
+    // microtask, so the delete_node mint consumes its capture before this
+    // sweep decides what was left dangling.
+    queueMicrotask(() => {
+      queueMicrotask(() => {
+        sweepScheduled = false
+        const surfaced = new Set<string>()
+        for (const entries of severancesByNode.values()) {
+          for (const entry of entries) {
+            const key = String(entry.linkId)
+            if (!entry.mintable || consumedLinkIds.has(key)) continue
+            if (surfaced.has(key)) continue
+            surfaced.add(key)
+            surfaceUnrepresentable('link disconnect', entry.linkId)
+          }
+        }
+        severancesByNode.clear()
+        consumedLinkIds.clear()
+      })
+    })
+  }
+
+  function capture(nodeId: string | number, entry: SeveranceEntry): void {
+    const key = String(nodeId)
+    const bucket = severancesByNode.get(key)
+    if (bucket) bucket.push(entry)
+    else severancesByNode.set(key, [entry])
+  }
+
+  function onDeleted(scope: LinkScopeView, topology: LinkTopologyView): void {
+    const entry: SeveranceEntry = {
+      linkId: topology.id,
+      mintable: gateOpen() && isRootScope(scope)
+    }
+    capture(topology.originNodeId, entry)
+    capture(topology.targetNodeId, entry)
+    scheduleSweep()
+  }
+
+  const detachPlaced = deps.events.onPlaced(onPlaced)
+  const detachDeleted = deps.events.onDeleted(onDeleted)
+
+  return {
+    severances: {
+      take(nodeId: string): WireNodeId[] {
+        const taken: WireNodeId[] = []
+        for (const entry of severancesByNode.get(nodeId) ?? []) {
+          const key = String(entry.linkId)
+          if (consumedLinkIds.has(key)) continue
+          consumedLinkIds.add(key)
+          taken.push(entry.linkId)
+        }
+        return taken
+      }
+    },
+    detach() {
+      detachPlaced()
+      detachDeleted()
+    }
+  }
+}

--- a/src/workbench/extensions/agent/crdt/mintGate.test.ts
+++ b/src/workbench/extensions/agent/crdt/mintGate.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+
+import { shouldMint } from './mintGate'
+
+const OPEN = {
+  flagEnabled: true,
+  docBound: true,
+  localProvenance: true,
+  teardown: false
+}
+
+describe('shouldMint (the four-way zero-mint battery)', () => {
+  it('mints only when every conjunct holds', () => {
+    expect(shouldMint(OPEN)).toBe(true)
+  })
+
+  it('never mints with the product flag off', () => {
+    expect(shouldMint({ ...OPEN, flagEnabled: false })).toBe(false)
+  })
+
+  it('never mints without a bound doc', () => {
+    expect(shouldMint({ ...OPEN, docBound: false })).toBe(false)
+  })
+
+  it('never mints for non-local provenance (agent-remote or load-driven)', () => {
+    expect(shouldMint({ ...OPEN, localProvenance: false })).toBe(false)
+  })
+
+  it('never mints for graph teardown (workflow load/switch/close clearing)', () => {
+    expect(shouldMint({ ...OPEN, teardown: true })).toBe(false)
+  })
+})

--- a/src/workbench/extensions/agent/crdt/mintGate.ts
+++ b/src/workbench/extensions/agent/crdt/mintGate.ts
@@ -1,0 +1,26 @@
+/**
+ * The mint gate (plan 3.3): every human-edit mint hook is a no-op unless ALL
+ * four conjuncts hold. Teardown is a first-class case — workflow load/switch/
+ * close drives `clearGraph` and plural delete paths with no call-carried
+ * provenance, and an ungated hook would mint a clear storm into the bound
+ * doc on an ordinary tab switch.
+ */
+export interface MintGateInput {
+  /** Slice 00's product gate (`agent-in-app-experience` via the panel store). */
+  flagEnabled: boolean
+  /** A semantic doc is bound for the active workflow. */
+  docBound: boolean
+  /** The mutation originates from a LOCAL human edit (not agent-remote, not load-driven). */
+  localProvenance: boolean
+  /** The mutation is graph teardown (workflow load/switch/close clearing). */
+  teardown: boolean
+}
+
+export function shouldMint(input: MintGateInput): boolean {
+  return (
+    input.flagEnabled &&
+    input.docBound &&
+    input.localProvenance &&
+    !input.teardown
+  )
+}

--- a/src/workbench/extensions/agent/crdt/mintPortWiring.test.ts
+++ b/src/workbench/extensions/agent/crdt/mintPortWiring.test.ts
@@ -138,7 +138,12 @@ describe('attachMintPortWiring', () => {
 
     linkStore.deleteLink(ROOT_SCOPE, severed)
     deliverLayoutChange({
-      operation: { type: 'deleteNode', actor: 'user-abc', nodeId: toNodeId(2) }
+      operation: {
+        type: 'deleteNode',
+        actor: 'user-abc',
+        graphId: ROOT_ID,
+        nodeId: toNodeId(2)
+      }
     })
     await afterSweep()
 
@@ -187,19 +192,21 @@ describe('attachMintPortWiring', () => {
     expect(minted).toEqual([])
   })
 
-  it('suppresses mints between the load-bracket hooks, fail-closed on a failed load', () => {
+  it('keeps mints suppressed until every overlapping load bracket closes', () => {
     wiring.onBeforeGraphLoad()
     useLinkStore().registerLink(ROOT_SCOPE, topology(41))
     expect(minted).toEqual([])
 
-    // A failed load never fires afterConfigureGraph: the bracket stays open
-    // (still no mints), and the NEXT load's paired hooks close it.
     wiring.onBeforeGraphLoad()
     useLinkStore().registerLink(ROOT_SCOPE, topology(42))
     expect(minted).toEqual([])
 
     wiring.onAfterGraphConfigure()
     useLinkStore().registerLink(ROOT_SCOPE, topology(43, 4))
+    expect(minted).toEqual([])
+
+    wiring.onAfterGraphConfigure()
+    useLinkStore().registerLink(ROOT_SCOPE, topology(44, 5))
     expect(minted).toHaveLength(1)
   })
 
@@ -221,6 +228,7 @@ describe('attachMintPortWiring', () => {
       operation: {
         type: 'createNode',
         actor: 'user-abc',
+        graphId: ROOT_ID,
         nodeId: toNodeId(5),
         layout: { position: { x: 10, y: 20 } }
       }

--- a/src/workbench/extensions/agent/crdt/mintPortWiring.test.ts
+++ b/src/workbench/extensions/agent/crdt/mintPortWiring.test.ts
@@ -1,0 +1,273 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
+import type { GraphScope } from '@/types/graphScopeId'
+import type { LinkTopology } from '@/types/linkTopology'
+
+import { useLinkStore } from '@/stores/linkStore'
+import { useWidgetValueStore } from '@/stores/widgetValueStore'
+import { toOwningGraphId, toRootGraphId } from '@/types/graphScopeId'
+import { toLinkId } from '@/types/linkId'
+import { toNodeId } from '@/types/nodeId'
+import { widgetId } from '@/types/widgetId'
+
+import type { GraphOperation } from './graphOperations'
+import type { LayoutChangeView } from './layoutMintPort'
+import { attachMintPortWiring } from './mintPortWiring'
+import type { MintPortWiring, MintableGraph } from './mintPortWiring'
+
+const ROOT_ID = 'root-uuid'
+
+/** Structural stand-in for the two LGraphNode members the wiring reads. */
+interface FakeGraphNode {
+  id?: unknown
+  serialize?: () => unknown
+  widgets?: { name: string; type: string; serialize?: boolean }[]
+}
+
+const ROOT_SCOPE: GraphScope = {
+  rootGraphId: toRootGraphId(ROOT_ID),
+  owningGraphId: toOwningGraphId(ROOT_ID)
+}
+
+function topology(id: number, targetSlot = 3): LinkTopology {
+  return {
+    id: toLinkId(id),
+    graphId: toOwningGraphId(ROOT_ID),
+    originNodeId: toNodeId(1),
+    originSlot: 0,
+    targetNodeId: toNodeId(2),
+    targetSlot,
+    type: 'IMAGE'
+  }
+}
+
+async function afterSweep(): Promise<void> {
+  await Promise.resolve()
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
+describe('attachMintPortWiring', () => {
+  let minted: GraphOperation[]
+  let wiring: MintPortWiring
+  let enabled: boolean
+  let bound: boolean
+  let layoutListeners: Set<(change: LayoutChangeView) => void>
+  let graphNodes: Map<string, FakeGraphNode>
+
+  function deliverLayoutChange(change: LayoutChangeView): void {
+    for (const listener of layoutListeners) listener(change)
+  }
+
+  const graph: MintableGraph = {
+    id: ROOT_ID,
+    rootGraph: { id: ROOT_ID },
+    getNodeById: (id) =>
+      (graphNodes.get(String(id)) as unknown as LGraphNode | undefined) ?? null,
+    get _nodes() {
+      return [...graphNodes.values()] as LGraphNode[]
+    }
+  }
+
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    minted = []
+    enabled = true
+    bound = true
+    layoutListeners = new Set()
+    graphNodes = new Map()
+    wiring = attachMintPortWiring({
+      isEnabled: () => enabled,
+      isDocBound: () => bound,
+      enqueue: (operations) => minted.push(...operations),
+      layoutChanges: (listener) => {
+        layoutListeners.add(listener)
+        return () => layoutListeners.delete(listener)
+      },
+      withLayoutActor: (_actor, fn) => fn(),
+      localActorPrefix: 'user-',
+      getGraph: () => graph
+    })
+  })
+
+  it('mints a concrete connect when the real link store places a link', () => {
+    useLinkStore().registerLink(ROOT_SCOPE, topology(41))
+
+    expect(minted).toEqual([
+      {
+        op: 'connect',
+        link_id: 41,
+        // The store's NodeId brand normalizes to strings; the wire vocabulary
+        // treats node ids as opaque, so they pass through verbatim.
+        from_node: toNodeId(1),
+        from_slot: 0,
+        to_node: toNodeId(2),
+        to_slot: 3,
+        link_type: 'IMAGE'
+      }
+    ])
+  })
+
+  it('maps a replace to PLACED, never DELETED (no false disconnect surfaces)', async () => {
+    const consoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined)
+    const linkStore = useLinkStore()
+    const incumbent = topology(41)
+    linkStore.registerLink(ROOT_SCOPE, incumbent)
+
+    // A rewire claims the same input slot: the store displaces the incumbent
+    // internally with no deleteLink action, so the wire story is exactly one
+    // new connect and zero severances.
+    linkStore.replaceLink(ROOT_SCOPE, incumbent, topology(42))
+    await afterSweep()
+
+    const connects = minted.filter((operation) => operation.op === 'connect')
+    expect(connects.map((operation) => operation.link_id)).toEqual([41, 42])
+    expect(consoleError).not.toHaveBeenCalled()
+    consoleError.mockRestore()
+  })
+
+  it('carries a real severed link into the delete_node mint', async () => {
+    const linkStore = useLinkStore()
+    const severed = topology(41)
+    linkStore.registerLink(ROOT_SCOPE, severed)
+    minted.length = 0
+
+    linkStore.deleteLink(ROOT_SCOPE, severed)
+    deliverLayoutChange({
+      operation: { type: 'deleteNode', actor: 'user-abc', nodeId: toNodeId(2) }
+    })
+    await afterSweep()
+
+    expect(minted).toEqual([
+      { op: 'delete_node', node_id: '2', removed_links: [toLinkId(41)] }
+    ])
+  })
+
+  it('mints a name-keyed set_widget with the pre-write value from the real store', () => {
+    const widgetStore = useWidgetValueStore()
+    const id = widgetId(ROOT_ID, toNodeId(7), 'seed')
+    widgetStore.registerWidget(id, { type: 'number', value: 3 } as Parameters<
+      typeof widgetStore.registerWidget
+    >[1])
+
+    widgetStore.setValue(id, 42)
+
+    expect(minted).toEqual([
+      {
+        op: 'set_widget',
+        node_id: toNodeId(7),
+        widget: 'seed',
+        value: 42,
+        old: 3
+      }
+    ])
+  })
+
+  it('mints nothing for a setValue that did not apply', () => {
+    useWidgetValueStore().setValue(widgetId(ROOT_ID, toNodeId(9), 'missing'), 1)
+
+    expect(minted).toEqual([])
+  })
+
+  it('suppresses every port inside the remote scope', () => {
+    wiring.runRemoteScope(() => {
+      useLinkStore().registerLink(ROOT_SCOPE, topology(41))
+      const widgetStore = useWidgetValueStore()
+      const id = widgetId(ROOT_ID, toNodeId(7), 'seed')
+      widgetStore.registerWidget(id, { type: 'number', value: 3 } as Parameters<
+        typeof widgetStore.registerWidget
+      >[1])
+      widgetStore.setValue(id, 42)
+    })
+
+    expect(minted).toEqual([])
+  })
+
+  it('suppresses mints between the load-bracket hooks, fail-closed on a failed load', () => {
+    wiring.onBeforeGraphLoad()
+    useLinkStore().registerLink(ROOT_SCOPE, topology(41))
+    expect(minted).toEqual([])
+
+    // A failed load never fires afterConfigureGraph: the bracket stays open
+    // (still no mints), and the NEXT load's paired hooks close it.
+    wiring.onBeforeGraphLoad()
+    useLinkStore().registerLink(ROOT_SCOPE, topology(42))
+    expect(minted).toEqual([])
+
+    wiring.onAfterGraphConfigure()
+    useLinkStore().registerLink(ROOT_SCOPE, topology(43, 4))
+    expect(minted).toHaveLength(1)
+  })
+
+  it('serializes add_node snapshots name-keyed, dropping non-value widgets', () => {
+    graphNodes.set('5', {
+      serialize: () => ({
+        id: 5,
+        type: 'LoadImage',
+        widgets_values: ['positional'],
+        widgets_values_named: { image: 'cat.png', upload: 'button-slot' }
+      }),
+      widgets: [
+        { name: 'image', type: 'combo' },
+        { name: 'upload', type: 'button' }
+      ]
+    })
+
+    deliverLayoutChange({
+      operation: {
+        type: 'createNode',
+        actor: 'user-abc',
+        nodeId: toNodeId(5),
+        layout: { position: { x: 10, y: 20 } }
+      }
+    })
+
+    expect(minted).toEqual([
+      {
+        op: 'add_node',
+        node_id: toNodeId(5),
+        class_type: 'LoadImage',
+        pos: [10, 20],
+        node: {
+          id: 5,
+          type: 'LoadImage',
+          widgets_values: { image: 'cat.png' }
+        }
+      }
+    ])
+  })
+
+  it('positive control: an unbound workflow runs normally, zero mint and zero blockage', () => {
+    bound = false
+    const widgetStore = useWidgetValueStore()
+    const id = widgetId(ROOT_ID, toNodeId(7), 'seed')
+    widgetStore.registerWidget(id, { type: 'number', value: 3 } as Parameters<
+      typeof widgetStore.registerWidget
+    >[1])
+
+    const placed = useLinkStore().registerLink(ROOT_SCOPE, topology(41))
+    const applied = widgetStore.setValue(id, 42)
+
+    expect(minted).toEqual([])
+    expect(placed).toBeDefined()
+    expect(applied).toBe(true)
+    expect(widgetStore.getWidget(id)?.value).toBe(42)
+  })
+
+  it('stops observing both stores after detach', () => {
+    wiring.detach()
+    useLinkStore().registerLink(ROOT_SCOPE, topology(41))
+    const widgetStore = useWidgetValueStore()
+    const id = widgetId(ROOT_ID, toNodeId(7), 'seed')
+    widgetStore.registerWidget(id, { type: 'number', value: 3 } as Parameters<
+      typeof widgetStore.registerWidget
+    >[1])
+    widgetStore.setValue(id, 42)
+
+    expect(minted).toEqual([])
+  })
+})

--- a/src/workbench/extensions/agent/crdt/mintPortWiring.ts
+++ b/src/workbench/extensions/agent/crdt/mintPortWiring.ts
@@ -1,0 +1,241 @@
+/**
+ * Composition seam for the three mint ports. Layout pieces are injected
+ * (workbench must not import renderer); link/widget adapt via Pinia $onAction,
+ * which fires synchronously around each action. A replace maps to PLACED and
+ * never DELETED (the store displaces incumbents internally). Load brackets
+ * are a fail-closed boolean over beforeLoadGraph/afterConfigureGraph: a
+ * failed load leaves mints suppressed until the next load's pair recloses.
+ */
+import type { LGraph } from '@/lib/litegraph/src/LGraph'
+import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
+import type { NodeId } from '@/types/nodeId'
+import type { WidgetId } from '@/types/widgetId'
+import type { WorkflowNode } from '@comfyorg/comfy-multi-player'
+
+import { useLinkStore } from '@/stores/linkStore'
+import { useWidgetValueStore } from '@/stores/widgetValueStore'
+import { isFloatingTopology } from '@/types/linkTopology'
+import { parseWidgetId } from '@/types/widgetId'
+import { findSubgraphNodePathById } from '@/utils/graphTraversalUtil'
+
+import type { GraphOperation } from './graphOperations'
+import { AGENT_REMOTE_ACTOR, attachLayoutMintPort } from './layoutMintPort'
+import type { LayoutChangeView, LayoutMintPort } from './layoutMintPort'
+import { attachLinkMintPort } from './linkMintPort'
+import { attachWidgetMintPort } from './widgetMintPort'
+import { createMintSession } from './mintSession'
+import type { MintSession } from './mintSession'
+
+/** The graph surface the wiring reads for snapshots and scope. */
+export interface MintableGraph {
+  id: string
+  rootGraph?: { id: string }
+  getNodeById(id: NodeId | string): LGraphNode | null
+  _nodes: LGraphNode[]
+}
+
+export interface MintPortWiringDeps {
+  /** Slice 00's product gate. */
+  isEnabled(): boolean
+  /** A semantic doc is bound for the active workflow. */
+  isDocBound(): boolean
+  /** Receives minted semantic operations (the sender's inbox). */
+  enqueue(operations: GraphOperation[]): void
+  /** The layout store's `onChange`, injected by the composition root. */
+  layoutChanges(listener: (change: LayoutChangeView) => void): () => void
+  /** The layout store's `withActor`, injected by the composition root. */
+  withLayoutActor(actor: string, fn: () => void): void
+  /** `ACTOR_CONFIG.USER_PREFIX`, injected by the composition root. */
+  localActorPrefix: string
+  /** The live root graph, or null when no workflow is open. */
+  getGraph(): MintableGraph | null
+}
+
+export interface MintPortWiring {
+  session: MintSession
+  /** Hand to {@link LitegraphMutator}'s `runRemoteScope` dep verbatim. */
+  runRemoteScope(apply: () => void): void
+  /** The layout port's intentional-clear window (human clear paths only). */
+  runIntentionalClear<T>(fn: () => T): T
+  /** Forward from the app extension's `beforeLoadGraph` hook. */
+  onBeforeGraphLoad(): void
+  /** Forward from the app extension's `afterConfigureGraph` hook. */
+  onAfterGraphConfigure(): void
+  detach(): void
+}
+
+/**
+ * Serialized save-format node, `widgets_values` NAME-KEYED via the node's own
+ * `widgets_values_named` minus non-value widgets (FE-1904: the doc host's
+ * sidecar projection accepts only the pinned catalog's `widget_order` names;
+ * control widgets like a `button` serialize a named entry but are not in
+ * `widget_order`, and any extra key is an opaque server-side 500).
+ */
+function serializeForMint(node: LGraphNode): WorkflowNode | null {
+  let serialized: Record<string, unknown>
+  try {
+    serialized = node.serialize() as unknown as Record<string, unknown>
+  } catch {
+    return null
+  }
+  const named = serialized.widgets_values_named
+  if (named != null && typeof named === 'object') {
+    const filtered: Record<string, unknown> = {}
+    for (const [name, value] of Object.entries(named)) {
+      const widget = node.widgets?.find((candidate) => candidate.name === name)
+      if (widget && widget.type !== 'button' && widget.serialize !== false) {
+        filtered[name] = value
+      }
+    }
+    serialized.widgets_values = filtered
+    delete serialized.widgets_values_named
+  }
+  return serialized as unknown as WorkflowNode
+}
+
+export function attachMintPortWiring(deps: MintPortWiringDeps): MintPortWiring {
+  const session = createMintSession()
+
+  type PlacedListener = Parameters<
+    Parameters<typeof attachLinkMintPort>[0]['events']['onPlaced']
+  >[0]
+  type DeletedListener = Parameters<
+    Parameters<typeof attachLinkMintPort>[0]['events']['onDeleted']
+  >[0]
+  type SetListener = Parameters<
+    Parameters<typeof attachWidgetMintPort>[0]['events']['onSet']
+  >[0]
+  const placedListeners = new Set<PlacedListener>()
+  const deletedListeners = new Set<DeletedListener>()
+  const setListeners = new Set<SetListener>()
+
+  const linkPort = attachLinkMintPort({
+    events: {
+      onPlaced(listener) {
+        placedListeners.add(listener)
+        return () => placedListeners.delete(listener)
+      },
+      onDeleted(listener) {
+        deletedListeners.add(listener)
+        return () => deletedListeners.delete(listener)
+      }
+    },
+    session,
+    isEnabled: deps.isEnabled,
+    isDocBound: deps.isDocBound,
+    enqueue: deps.enqueue
+  })
+
+  const layoutPort: LayoutMintPort = attachLayoutMintPort({
+    changes: { onChange: deps.layoutChanges },
+    session,
+    severedLinks: linkPort.severances,
+    localActorPrefix: deps.localActorPrefix,
+    isEnabled: deps.isEnabled,
+    isDocBound: deps.isDocBound,
+    source: {
+      serializeNode(id) {
+        const node = deps.getGraph()?.getNodeById(id)
+        return node ? serializeForMint(node) : null
+      },
+      nodeIds() {
+        return (deps.getGraph()?._nodes ?? []).map((node) => node.id)
+      }
+    },
+    enqueue: deps.enqueue
+  })
+
+  const widgetPort = attachWidgetMintPort({
+    events: {
+      onSet(listener) {
+        setListeners.add(listener)
+        return () => setListeners.delete(listener)
+      }
+    },
+    session,
+    isEnabled: deps.isEnabled,
+    isDocBound: deps.isDocBound,
+    rootGraphId() {
+      const graph = deps.getGraph()
+      if (!graph) return null
+      return String(graph.rootGraph?.id ?? graph.id)
+    },
+    resolveInteriorPath(owningGraphId) {
+      const graph = deps.getGraph()
+      if (!graph) return null
+      return findSubgraphNodePathById(graph as unknown as LGraph, owningGraphId)
+    },
+    enqueue: deps.enqueue
+  })
+
+  const linkStore = useLinkStore()
+  const widgetStore = useWidgetValueStore()
+
+  const detachLinkActions = linkStore.$onAction(({ name, args, after }) => {
+    if (name === 'registerLink' || name === 'replaceLink') {
+      const scope = args[0]
+      after((placed) => {
+        if (!placed || isFloatingTopology(placed)) return
+        for (const listener of placedListeners) listener(scope, placed)
+      })
+      return
+    }
+    if (name === 'deleteLink') {
+      const [scope, topology] = args
+      after((removed) => {
+        if (!removed || isFloatingTopology(topology)) return
+        for (const listener of deletedListeners) listener(scope, topology)
+      })
+    }
+  })
+
+  const detachWidgetActions = widgetStore.$onAction(({ name, args, after }) => {
+    if (name !== 'setValue') return
+    const widgetId = args[0] as WidgetId
+    const old = widgetStore.getWidget(widgetId)?.value
+    after((applied) => {
+      if (!applied) return
+      const { graphId, nodeId, name: widgetName } = parseWidgetId(widgetId)
+      for (const listener of setListeners) {
+        listener({
+          graphId: String(graphId),
+          nodeId,
+          name: widgetName,
+          value: args[1],
+          old
+        })
+      }
+    })
+  })
+
+  let loadBracketOpen = false
+
+  return {
+    session,
+    runRemoteScope(apply) {
+      session.runRemoteApply(() => {
+        deps.withLayoutActor(AGENT_REMOTE_ACTOR, apply)
+      })
+    },
+    runIntentionalClear(fn) {
+      return layoutPort.runIntentionalClear(fn)
+    },
+    onBeforeGraphLoad() {
+      if (loadBracketOpen) return
+      loadBracketOpen = true
+      session.beginGraphTeardown()
+    },
+    onAfterGraphConfigure() {
+      if (!loadBracketOpen) return
+      loadBracketOpen = false
+      session.endGraphTeardown()
+    },
+    detach() {
+      detachLinkActions()
+      detachWidgetActions()
+      widgetPort.detach()
+      layoutPort.detach()
+      linkPort.detach()
+    }
+  }
+}

--- a/src/workbench/extensions/agent/crdt/mintPortWiring.ts
+++ b/src/workbench/extensions/agent/crdt/mintPortWiring.ts
@@ -3,8 +3,8 @@
  * (workbench must not import renderer); link/widget adapt via Pinia $onAction,
  * which fires synchronously around each action. A replace maps to PLACED and
  * never DELETED (the store displaces incumbents internally). Load brackets
- * are a fail-closed boolean over beforeLoadGraph/afterConfigureGraph: a
- * failed load leaves mints suppressed until the next load's pair recloses.
+ * are depth-counted over beforeLoadGraph/afterConfigureGraph so overlapping
+ * loads cannot reopen minting while either graph is still configuring.
  */
 import type { LGraph } from '@/lib/litegraph/src/LGraph'
 import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
@@ -134,6 +134,10 @@ export function attachMintPortWiring(deps: MintPortWiringDeps): MintPortWiring {
     isEnabled: deps.isEnabled,
     isDocBound: deps.isDocBound,
     source: {
+      rootGraphId() {
+        const graph = deps.getGraph()
+        return graph ? String(graph.rootGraph?.id ?? graph.id) : null
+      },
       serializeNode(id) {
         const node = deps.getGraph()?.getNodeById(id)
         return node ? serializeForMint(node) : null
@@ -208,8 +212,6 @@ export function attachMintPortWiring(deps: MintPortWiringDeps): MintPortWiring {
     })
   })
 
-  let loadBracketOpen = false
-
   return {
     session,
     runRemoteScope(apply) {
@@ -221,13 +223,9 @@ export function attachMintPortWiring(deps: MintPortWiringDeps): MintPortWiring {
       return layoutPort.runIntentionalClear(fn)
     },
     onBeforeGraphLoad() {
-      if (loadBracketOpen) return
-      loadBracketOpen = true
       session.beginGraphTeardown()
     },
     onAfterGraphConfigure() {
-      if (!loadBracketOpen) return
-      loadBracketOpen = false
       session.endGraphTeardown()
     },
     detach() {

--- a/src/workbench/extensions/agent/crdt/mintSession.test.ts
+++ b/src/workbench/extensions/agent/crdt/mintSession.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { createMintSession } from './mintSession'
+
+describe('createMintSession', () => {
+  it('nests teardown brackets: the scope closes only at the outermost end', () => {
+    const session = createMintSession()
+    session.beginGraphTeardown()
+    session.beginGraphTeardown()
+    session.endGraphTeardown()
+
+    expect(session.inTeardown()).toBe(true)
+
+    session.endGraphTeardown()
+    expect(session.inTeardown()).toBe(false)
+  })
+
+  it('surfaces an async remote-apply fn loudly (continuations escape the scope)', () => {
+    const consoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined)
+    const session = createMintSession()
+
+    void session.runRemoteApply(async () => {})
+
+    expect(consoleError).toHaveBeenCalledOnce()
+    expect(session.inRemoteApply()).toBe(false)
+    consoleError.mockRestore()
+  })
+
+  it('stays silent for a synchronous remote-apply fn', () => {
+    const consoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined)
+    const session = createMintSession()
+
+    session.runRemoteApply(() => 42)
+
+    expect(consoleError).not.toHaveBeenCalled()
+    consoleError.mockRestore()
+  })
+
+  it('closes the remote-apply scope even when the body throws', () => {
+    const session = createMintSession()
+
+    expect(() =>
+      session.runRemoteApply(() => {
+        expect(session.inRemoteApply()).toBe(true)
+        throw new Error('applier rejected')
+      })
+    ).toThrow('applier rejected')
+    expect(session.inRemoteApply()).toBe(false)
+  })
+})

--- a/src/workbench/extensions/agent/crdt/mintSession.ts
+++ b/src/workbench/extensions/agent/crdt/mintSession.ts
@@ -1,0 +1,54 @@
+/**
+ * Shared mint scopes: ONE teardown bracket for all ports (a port missing a
+ * bracket call is a mint storm), and a synchronous remote-apply flag for the
+ * actor-less link/widget stores (layout keeps actor stamping instead).
+ */
+export interface MintSession {
+  beginGraphTeardown(): void
+  endGraphTeardown(): void
+  inTeardown(): boolean
+  runRemoteApply<T>(fn: () => T): T
+  inRemoteApply(): boolean
+}
+
+export function createMintSession(): MintSession {
+  let teardownDepth = 0
+  let remoteApplyDepth = 0
+
+  return {
+    beginGraphTeardown() {
+      teardownDepth++
+    },
+    endGraphTeardown() {
+      teardownDepth = Math.max(0, teardownDepth - 1)
+    },
+    inTeardown() {
+      return teardownDepth > 0
+    },
+    runRemoteApply<T>(fn: () => T): T {
+      remoteApplyDepth++
+      try {
+        const result = fn()
+        if (
+          result !== null &&
+          typeof result === 'object' &&
+          'then' in result &&
+          typeof (result as { then: unknown }).then === 'function'
+        ) {
+          // The scope is synchronous by contract: any continuation after an
+          // await runs OUTSIDE it, and remote echoes there would mint straight
+          // into the bound doc. Surface the contract break loudly.
+          console.error(
+            '[agent-crdt] runRemoteApply received an async fn; continuations after the first await escape the remote scope'
+          )
+        }
+        return result
+      } finally {
+        remoteApplyDepth--
+      }
+    },
+    inRemoteApply() {
+      return remoteApplyDepth > 0
+    }
+  }
+}

--- a/src/workbench/extensions/agent/crdt/opEnvelope.test.ts
+++ b/src/workbench/extensions/agent/crdt/opEnvelope.test.ts
@@ -1,0 +1,139 @@
+import { applyOps, mint, nodesMap } from '@comfyorg/comfy-multi-player'
+import type { Op } from '@comfyorg/comfy-multi-player'
+import { describe, expect, it } from 'vitest'
+
+import type { GraphOperation } from './graphOperations'
+import {
+  WIRE_MAX_BATCH_BYTES,
+  WIRE_MAX_OPS_PER_BATCH,
+  chunkWireOps,
+  mintOpId,
+  mintWireOps
+} from './opEnvelope'
+
+const MINT = { actor: 'human:test-user:tab-1', baseVersion: 7 }
+
+// The mint seam's vocabulary is the five implemented kinds only: the deferred
+// reset_doc stays outside GraphOperation (plan §2), pinned at compile time -
+// if the derivation ever admits it, this @ts-expect-error goes unused and
+// typecheck fails.
+// @ts-expect-error reset_doc is DeferredOp, not a mintable GraphOperation
+const REJECTED_RESET_DOC: GraphOperation = { op: 'reset_doc' }
+void REJECTED_RESET_DOC
+
+function addNode(id: number): GraphOperation {
+  return {
+    op: 'add_node',
+    node_id: id,
+    class_type: 'TestNode',
+    pos: [10, 20],
+    node: { id, type: 'TestNode', pos: [10, 20] }
+  }
+}
+
+describe('mintOpId', () => {
+  it('mints 32 lowercase hex chars, unique per call', () => {
+    const a = mintOpId()
+    const b = mintOpId()
+    expect(a).toMatch(/^[0-9a-f]{32}$/)
+    expect(b).toMatch(/^[0-9a-f]{32}$/)
+    expect(a).not.toBe(b)
+  })
+})
+
+describe('mintWireOps', () => {
+  it('attaches the full envelope and preserves the payload verbatim', () => {
+    const [op] = mintWireOps([addNode(1)], MINT)
+
+    expect(op.op_id).toMatch(/^[0-9a-f]{32}$/)
+    expect(op.actor).toBe(MINT.actor)
+    expect(op.base_version).toBe(7)
+    expect(op.stamp).toEqual([7, MINT.actor])
+    expect(op.op).toBe('add_node')
+    expect(op).toMatchObject(addNode(1))
+  })
+
+  it('mints a distinct op_id per operation in one batch', () => {
+    const ops = mintWireOps([addNode(1), addNode(2), addNode(3)], MINT)
+    const ids = new Set(ops.map((op) => op.op_id))
+    expect(ids.size).toBe(3)
+  })
+
+  it('produces ops the real applier accepts and applies', () => {
+    const doc = mint({ nodes: [], links: [] }, { types: {} })
+    const ops = mintWireOps([addNode(1)], MINT)
+
+    const result = applyOps(doc, ops)
+
+    expect(result.outcomes).toEqual([
+      { op_id: ops[0].op_id, outcome: 'applied' }
+    ])
+    expect(nodesMap(doc).has('1')).toBe(true)
+  })
+
+  it('re-sending the same minted ops is idempotent at the applier', () => {
+    const doc = mint({ nodes: [], links: [] }, { types: {} })
+    const ops = mintWireOps([addNode(1)], MINT)
+
+    applyOps(doc, ops)
+    const retry = applyOps(doc, ops)
+
+    expect(retry.outcomes).toEqual([{ op_id: ops[0].op_id, outcome: 'no-op' }])
+    expect(nodesMap(doc).has('1')).toBe(true)
+  })
+})
+
+describe('chunkWireOps', () => {
+  it('splits on the per-batch op cap, order preserved', () => {
+    const ops = mintWireOps(
+      Array.from({ length: 600 }, (_, i) => addNode(i)),
+      MINT
+    )
+    const batches = chunkWireOps(ops)
+
+    expect(batches.map((b) => b.length)).toEqual([256, 256, 88])
+    expect(batches.flat()).toEqual(ops)
+    expect(WIRE_MAX_OPS_PER_BATCH).toBe(256)
+  })
+
+  it('isolates clear in a batch of exactly one', () => {
+    const clear: GraphOperation = { op: 'clear', removed_nodes: [1, 2] }
+    const ops = mintWireOps([addNode(1), clear, addNode(2)], MINT)
+
+    const batches = chunkWireOps(ops)
+
+    expect(batches.map((b) => b.map((op) => op.op))).toEqual([
+      ['add_node'],
+      ['clear'],
+      ['add_node']
+    ])
+  })
+
+  it('splits on the per-batch byte cap', () => {
+    const bigValue = 'x'.repeat(Math.ceil(WIRE_MAX_BATCH_BYTES / 2))
+    const setWidget = (id: number): GraphOperation => ({
+      op: 'set_widget',
+      node_id: id,
+      widget: 'text',
+      value: bigValue
+    })
+    const ops = mintWireOps([setWidget(1), setWidget(2), setWidget(3)], MINT)
+
+    const batches = chunkWireOps(ops)
+
+    expect(batches.length).toBe(3)
+    expect(batches.every((b) => b.length === 1)).toBe(true)
+  })
+
+  it('ships a single oversize op alone rather than dropping it', () => {
+    const huge: GraphOperation = {
+      op: 'set_widget',
+      node_id: 1,
+      widget: 'text',
+      value: 'x'.repeat(WIRE_MAX_BATCH_BYTES + 16)
+    }
+    const ops: Op[] = mintWireOps([huge], MINT)
+
+    expect(chunkWireOps(ops)).toEqual([ops])
+  })
+})

--- a/src/workbench/extensions/agent/crdt/opEnvelope.test.ts
+++ b/src/workbench/extensions/agent/crdt/opEnvelope.test.ts
@@ -39,6 +39,20 @@ describe('mintOpId', () => {
     expect(b).toMatch(/^[0-9a-f]{32}$/)
     expect(a).not.toBe(b)
   })
+
+  it('works when randomUUID is unavailable on an insecure origin', () => {
+    const descriptor = Object.getOwnPropertyDescriptor(crypto, 'randomUUID')
+    Object.defineProperty(crypto, 'randomUUID', {
+      configurable: true,
+      value: undefined
+    })
+
+    try {
+      expect(mintOpId()).toMatch(/^[0-9a-f]{32}$/)
+    } finally {
+      if (descriptor) Object.defineProperty(crypto, 'randomUUID', descriptor)
+    }
+  })
 })
 
 describe('mintWireOps', () => {

--- a/src/workbench/extensions/agent/crdt/opEnvelope.ts
+++ b/src/workbench/extensions/agent/crdt/opEnvelope.ts
@@ -9,6 +9,8 @@
 import { BATCHABLE_OPS } from '@comfyorg/comfy-multi-player'
 import type { Actor, Op, Stamp } from '@comfyorg/comfy-multi-player'
 
+import { createUuidv4 } from '@/utils/uuid'
+
 import type { GraphOperation } from './graphOperations'
 
 export const WIRE_MAX_OPS_PER_BATCH = 256
@@ -18,20 +20,32 @@ export interface MintContext {
   actor: Actor
   /** Doc version the ops are minted against (`base_version` on every op). */
   baseVersion: number
+  /** Optional sender-owned monotonic identity source for same-stamp writes. */
+  nextOpId?: () => string
 }
 
 /** uuid4 hex: 32 lowercase `[0-9a-f]` chars (vocabulary §8.2). */
 export function mintOpId(): string {
-  return crypto.randomUUID().replaceAll('-', '')
+  return createUuidv4().replaceAll('-', '')
+}
+
+/**
+ * A sender-local sequence in the high half makes later operations from the
+ * same actor sort after earlier operations when their base version ties. The
+ * random low half keeps identities disjoint across sender lifetimes.
+ */
+export function mintOrderedOpId(sequence: number): string {
+  const order = sequence.toString(16).padStart(16, '0')
+  return `${order}${mintOpId().slice(16)}`
 }
 
 function withEnvelope<T extends GraphOperation>(
   operation: T,
-  { actor, baseVersion }: MintContext
+  { actor, baseVersion, nextOpId }: MintContext
 ): T & { op_id: string; actor: Actor; base_version: number; stamp: Stamp } {
   return {
     ...operation,
-    op_id: mintOpId(),
+    op_id: nextOpId?.() ?? mintOpId(),
     actor,
     base_version: baseVersion,
     stamp: [baseVersion, actor]

--- a/src/workbench/extensions/agent/crdt/opEnvelope.ts
+++ b/src/workbench/extensions/agent/crdt/opEnvelope.ts
@@ -1,0 +1,95 @@
+/**
+ * The transport boundary of the human write leg (plan 3.3): mints wire
+ * identity onto semantic {@link GraphOperation}s and chunks batches to the
+ * wire caps clients respect (contract layer, verified against comfy-cli's
+ * vocabulary): 256 ops and 4 MiB per batch, under the package's own library
+ * budgets. `clear` is catastrophic-by-nature and never rides inside a batch
+ * (plan D4): it always ships as a batch of exactly one.
+ */
+import { BATCHABLE_OPS } from '@comfyorg/comfy-multi-player'
+import type { Actor, Op, Stamp } from '@comfyorg/comfy-multi-player'
+
+import type { GraphOperation } from './graphOperations'
+
+export const WIRE_MAX_OPS_PER_BATCH = 256
+export const WIRE_MAX_BATCH_BYTES = 4 * 1024 * 1024
+
+export interface MintContext {
+  actor: Actor
+  /** Doc version the ops are minted against (`base_version` on every op). */
+  baseVersion: number
+}
+
+/** uuid4 hex: 32 lowercase `[0-9a-f]` chars (vocabulary §8.2). */
+export function mintOpId(): string {
+  return crypto.randomUUID().replaceAll('-', '')
+}
+
+function withEnvelope<T extends GraphOperation>(
+  operation: T,
+  { actor, baseVersion }: MintContext
+): T & { op_id: string; actor: Actor; base_version: number; stamp: Stamp } {
+  return {
+    ...operation,
+    op_id: mintOpId(),
+    actor,
+    base_version: baseVersion,
+    stamp: [baseVersion, actor]
+  }
+}
+
+/**
+ * Attach wire identity to every operation. `op_id` is minted exactly once
+ * here — a retry re-sends the SAME minted ops (the sender never re-mints;
+ * changed-payload reuse rejects host-side).
+ */
+export function mintWireOps(
+  operations: GraphOperation[],
+  context: MintContext
+): Op[] {
+  return operations.map((operation) => withEnvelope(operation, context))
+}
+
+function isBatchable(op: Op): boolean {
+  return (BATCHABLE_OPS as readonly string[]).includes(op.op)
+}
+
+function wireSize(op: Op): number {
+  return new TextEncoder().encode(JSON.stringify(op)).length
+}
+
+/**
+ * Split minted ops into wire batches: order-preserving, at most
+ * {@link WIRE_MAX_OPS_PER_BATCH} ops and {@link WIRE_MAX_BATCH_BYTES} bytes
+ * per batch; every non-batchable op (`clear`) is a batch of one. A single op
+ * larger than the byte cap still ships alone — the host, not the chunker,
+ * owns rejecting it.
+ */
+export function chunkWireOps(ops: Op[]): Op[][] {
+  const batches: Op[][] = []
+  let current: Op[] = []
+  let currentBytes = 0
+
+  const flush = (): void => {
+    if (current.length > 0) batches.push(current)
+    current = []
+    currentBytes = 0
+  }
+
+  for (const op of ops) {
+    if (!isBatchable(op)) {
+      flush()
+      batches.push([op])
+      continue
+    }
+    const bytes = wireSize(op)
+    const overOps = current.length + 1 > WIRE_MAX_OPS_PER_BATCH
+    const overBytes =
+      current.length > 0 && currentBytes + bytes > WIRE_MAX_BATCH_BYTES
+    if (overOps || overBytes) flush()
+    current.push(op)
+    currentBytes += bytes
+  }
+  flush()
+  return batches
+}

--- a/src/workbench/extensions/agent/crdt/opSender.test.ts
+++ b/src/workbench/extensions/agent/crdt/opSender.test.ts
@@ -99,6 +99,18 @@ describe('createOpSender', () => {
     expect(settled).toHaveLength(2)
   })
 
+  it('orders same-base writes from one actor by their op ids', () => {
+    sender.enqueue([addNode(1)])
+    sender.enqueue([addNode(2)])
+    const firstId = sent[0].ops[0].op_id
+
+    ackInFlight()
+
+    expect(sent[1].ops[0].base_version).toBe(sent[0].ops[0].base_version)
+    expect(sent[1].ops[0].actor).toBe(sent[0].ops[0].actor)
+    expect(sent[1].ops[0].op_id > firstId).toBe(true)
+  })
+
   it('retries a down transport with the SAME minted ops and never re-mints', () => {
     transportUp = false
     sender.enqueue([addNode(1)])
@@ -116,6 +128,18 @@ describe('createOpSender', () => {
       settled[0].state === 'acknowledged' &&
         settled[0].ops.map((op) => op.op_id)
     ).toEqual(firstIds)
+  })
+
+  it('cancels a pending transport retry when the batch settles', () => {
+    transportUp = false
+    sender.enqueue([addNode(1)])
+    resultListener?.({ ok: false, applied: [], skipped: [] })
+
+    transportUp = true
+    vi.advanceTimersByTime(500)
+
+    expect(settled).toHaveLength(1)
+    expect(sent).toHaveLength(0)
   })
 
   it('settles undeliverable after the transport retry budget', () => {
@@ -239,6 +263,19 @@ describe('createOpSender', () => {
     resultListener?.({ ok: false, applied: [], skipped: [] })
     resultListener?.({ ok: false, applied: [], skipped: [] })
 
+    sender.enqueue([addNode(2)])
+    resultListener?.({ ok: false, applied: [], skipped: [] })
+
+    expect(settled).toHaveLength(2)
+    expect(settled[1].state).toBe('acknowledged')
+  })
+
+  it('expires stale anonymous credits before a later batch', () => {
+    sender.enqueue([addNode(1)])
+    vi.advanceTimersByTime(20_000)
+    expect(settled[0].state).toBe('unacknowledged')
+
+    vi.advanceTimersByTime(10_001)
     sender.enqueue([addNode(2)])
     resultListener?.({ ok: false, applied: [], skipped: [] })
 

--- a/src/workbench/extensions/agent/crdt/opSender.test.ts
+++ b/src/workbench/extensions/agent/crdt/opSender.test.ts
@@ -2,7 +2,7 @@ import type { Op } from '@comfyorg/comfy-multi-player'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { GraphOperation } from './graphOperations'
-import { createOpSender } from './opSender'
+import { createOpSender, toOpsResultView } from './opSender'
 import type { BatchOutcome, OpsResultView } from './opSender'
 
 const WORKFLOW = 'wf-1'
@@ -253,5 +253,109 @@ describe('createOpSender', () => {
     sender.enqueue([addNode(2)])
 
     expect(sent).toHaveLength(1)
+  })
+
+  it('invalidates an in-flight batch instead of resending it after a rebind', () => {
+    sender.enqueue([addNode(1)])
+    expect(sent).toHaveLength(1)
+
+    boundWorkflow = 'wf-2'
+    vi.advanceTimersByTime(10_000)
+
+    // The silent-result resend re-checks the batch's minted workflow: the
+    // ops (and their wf-1 base_version) are never routed to wf-2.
+    expect(sent).toHaveLength(1)
+    expect(settled).toHaveLength(1)
+    expect(settled[0].state).toBe('undeliverable')
+  })
+
+  it('invalidates a queued batch minted before a rebind', () => {
+    sender.enqueue([addNode(1)])
+    sender.enqueue([addNode(2)])
+    expect(sent).toHaveLength(1)
+
+    boundWorkflow = 'wf-2'
+    ackInFlight()
+
+    expect(sent).toHaveLength(1)
+    expect(settled.map((s) => s.state)).toEqual([
+      'acknowledged',
+      'undeliverable'
+    ])
+  })
+
+  it('ignores a result naming a different workflow', () => {
+    sender.enqueue([addNode(1)])
+
+    resultListener?.({
+      workflowId: 'wf-other',
+      ok: false,
+      applied: [],
+      skipped: []
+    })
+    expect(settled).toHaveLength(0)
+
+    resultListener?.({
+      workflowId: WORKFLOW,
+      ok: true,
+      applied: sent[0].ops.map((op) => op.op_id),
+      skipped: []
+    })
+    expect(settled).toHaveLength(1)
+    expect(settled[0].state).toBe('acknowledged')
+  })
+})
+
+describe('toOpsResultView', () => {
+  it('carries the workflow and normalizes the single-object failed shape', () => {
+    const view = toOpsResultView({
+      workflowId: 'wf-1',
+      ok: false,
+      applied: ['a'],
+      skipped: [],
+      failed: { op_id: 'op-9', code: 'rejected', message: 'no' }
+    })
+
+    expect(view).toEqual({
+      workflowId: 'wf-1',
+      ok: false,
+      applied: ['a'],
+      skipped: [],
+      failure: { op_id: 'op-9' }
+    })
+  })
+
+  it('resolves the op_id from the newer index/op failed shape', () => {
+    const view = toOpsResultView({
+      ok: false,
+      applied: [],
+      skipped: [],
+      failed: { index: 2, op: { op_id: 'op-7' }, code: 'x', message: 'y' }
+    })
+
+    expect(view.failure).toEqual({ op_id: 'op-7' })
+  })
+
+  it('takes the first entry of an array failed shape', () => {
+    const view = toOpsResultView({
+      ok: false,
+      applied: [],
+      skipped: [],
+      failed: [{ op_id: 'op-3' }, { op_id: 'op-4' }]
+    })
+
+    expect(view.failure).toEqual({ op_id: 'op-3' })
+  })
+
+  it('keeps an anonymous failure anonymous and drops non-string ids', () => {
+    const view = toOpsResultView({
+      ok: false,
+      applied: ['a', 7 as unknown as string],
+      skipped: [],
+      failed: 'boom'
+    })
+
+    expect(view.applied).toEqual(['a'])
+    expect(view.failure).toEqual({})
   })
 })

--- a/src/workbench/extensions/agent/crdt/opSender.test.ts
+++ b/src/workbench/extensions/agent/crdt/opSender.test.ts
@@ -1,0 +1,257 @@
+import type { Op } from '@comfyorg/comfy-multi-player'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { GraphOperation } from './graphOperations'
+import { createOpSender } from './opSender'
+import type { BatchOutcome, OpsResultView } from './opSender'
+
+const WORKFLOW = 'wf-1'
+const TAB = 'tab-1'
+const ACTOR = 'human:test-user:tab-1'
+
+function addNode(id: number): GraphOperation {
+  return {
+    op: 'add_node',
+    node_id: id,
+    class_type: 'TestNode',
+    pos: [0, 0],
+    node: { id, type: 'TestNode' }
+  }
+}
+
+describe('createOpSender', () => {
+  let sent: Array<{ workflowId: string; tab: string; ops: Op[] }>
+  let settled: BatchOutcome[]
+  let resultListener: ((result: OpsResultView) => void) | null
+  let transportUp: boolean
+  let boundWorkflow: string | null
+  let sender: ReturnType<typeof createOpSender>
+
+  function ackInFlight(): void {
+    const last = sent[sent.length - 1]
+    resultListener?.({
+      ok: true,
+      applied: last.ops.map((op) => op.op_id),
+      skipped: []
+    })
+  }
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    sent = []
+    settled = []
+    resultListener = null
+    transportUp = true
+    boundWorkflow = WORKFLOW
+    sender = createOpSender({
+      sendOps: (workflowId, tab, ops) => {
+        if (!transportUp) return false
+        sent.push({ workflowId, tab, ops })
+        return true
+      },
+      onOpsResult: (listener) => {
+        resultListener = listener
+        return () => {
+          resultListener = null
+        }
+      },
+      workflowId: () => boundWorkflow,
+      tab: TAB,
+      actor: () => ACTOR,
+      baseVersion: () => 41,
+      onBatchSettled: (outcome) => settled.push(outcome)
+    })
+  })
+
+  afterEach(() => {
+    sender.detach()
+  })
+
+  it('mints once and sends a doc_ops batch with the wire envelope', () => {
+    sender.enqueue([addNode(1), addNode(2)])
+
+    expect(sent).toHaveLength(1)
+    expect(sent[0].workflowId).toBe(WORKFLOW)
+    expect(sent[0].tab).toBe(TAB)
+    expect(sent[0].ops).toHaveLength(2)
+    for (const op of sent[0].ops) {
+      expect(op.op_id).toMatch(/^[0-9a-f]{32}$/)
+      expect(op.actor).toBe(ACTOR)
+      expect(op.base_version).toBe(41)
+      expect(op.stamp).toEqual([41, ACTOR])
+    }
+  })
+
+  it('serializes batches: the next sends only after the result settles the first', () => {
+    sender.enqueue([addNode(1)])
+    sender.enqueue([addNode(2)])
+    expect(sent).toHaveLength(1)
+    expect(sender.pending()).toBe(2)
+
+    ackInFlight()
+
+    expect(sent).toHaveLength(2)
+    expect(settled).toHaveLength(1)
+    expect(settled[0].state).toBe('acknowledged')
+
+    ackInFlight()
+    expect(sender.pending()).toBe(0)
+    expect(settled).toHaveLength(2)
+  })
+
+  it('retries a down transport with the SAME minted ops and never re-mints', () => {
+    transportUp = false
+    sender.enqueue([addNode(1)])
+    expect(sent).toHaveLength(0)
+
+    transportUp = true
+    vi.advanceTimersByTime(500)
+
+    expect(sent).toHaveLength(1)
+    const firstIds = sent[0].ops.map((op) => op.op_id)
+
+    ackInFlight()
+    expect(settled[0].state).toBe('acknowledged')
+    expect(
+      settled[0].state === 'acknowledged' &&
+        settled[0].ops.map((op) => op.op_id)
+    ).toEqual(firstIds)
+  })
+
+  it('settles undeliverable after the transport retry budget', () => {
+    transportUp = false
+    sender.enqueue([addNode(1)])
+
+    vi.advanceTimersByTime(500 * 6)
+
+    expect(settled).toEqual([
+      { state: 'undeliverable', ops: expect.any(Array) }
+    ])
+  })
+
+  it('drops a batch as undeliverable when no doc is bound', () => {
+    boundWorkflow = null
+    sender.enqueue([addNode(1)])
+
+    expect(sent).toHaveLength(0)
+    expect(settled[0].state).toBe('undeliverable')
+  })
+
+  it('resends the same ops exactly once after result silence, then reports unacknowledged', () => {
+    sender.enqueue([addNode(1)])
+    expect(sent).toHaveLength(1)
+
+    vi.advanceTimersByTime(10_000)
+    expect(sent).toHaveLength(2)
+    expect(sent[1].ops.map((op) => op.op_id)).toEqual(
+      sent[0].ops.map((op) => op.op_id)
+    )
+
+    vi.advanceTimersByTime(10_000)
+    expect(settled).toEqual([
+      { state: 'unacknowledged', ops: expect.any(Array) }
+    ])
+  })
+
+  it('a late result after the resend still acknowledges the batch', () => {
+    sender.enqueue([addNode(1)])
+    vi.advanceTimersByTime(10_000)
+    expect(sent).toHaveLength(2)
+
+    ackInFlight()
+
+    expect(settled).toHaveLength(1)
+    expect(settled[0].state).toBe('acknowledged')
+  })
+
+  it('splits an oversized enqueue into serialized wire batches', () => {
+    sender.enqueue(Array.from({ length: 300 }, (_, index) => addNode(index)))
+
+    expect(sent).toHaveLength(1)
+    expect(sent[0].ops).toHaveLength(256)
+    expect(sender.pending()).toBe(2)
+
+    ackInFlight()
+    expect(sent[1].ops).toHaveLength(44)
+  })
+
+  it('ignores a result for other ops while a batch is in flight', () => {
+    sender.enqueue([addNode(1)])
+
+    resultListener?.({ ok: true, applied: ['ffff'.repeat(8)], skipped: [] })
+
+    expect(settled).toHaveLength(0)
+  })
+
+  it('a late anonymous failure from an unacknowledged batch never settles the next batch', () => {
+    sender.enqueue([addNode(1)])
+    vi.advanceTimersByTime(10_000)
+    vi.advanceTimersByTime(10_000)
+    expect(settled).toEqual([
+      { state: 'unacknowledged', ops: expect.any(Array) }
+    ])
+
+    sender.enqueue([addNode(2)])
+    expect(sent).toHaveLength(3)
+
+    resultListener?.({ ok: false, applied: [], skipped: [] })
+    expect(settled).toHaveLength(1)
+
+    ackInFlight()
+    expect(settled).toHaveLength(2)
+    expect(settled[1].state).toBe('acknowledged')
+  })
+
+  it('an identified empty-list failure settles the batch it names via failure.op_id', () => {
+    sender.enqueue([addNode(1)])
+    const opId = sent[0].ops[0].op_id
+
+    resultListener?.({
+      ok: false,
+      applied: [],
+      skipped: [],
+      failure: { op_id: opId }
+    })
+
+    expect(settled).toHaveLength(1)
+    expect(settled[0].state).toBe('acknowledged')
+  })
+
+  it('an identified failure for other ops never settles the in-flight batch', () => {
+    sender.enqueue([addNode(1)])
+
+    resultListener?.({
+      ok: false,
+      applied: [],
+      skipped: [],
+      failure: { op_id: 'ffff'.repeat(8) }
+    })
+
+    expect(settled).toHaveLength(0)
+  })
+
+  it('idle late results drain the stale credits so a fresh batch can settle anonymously', () => {
+    sender.enqueue([addNode(1)])
+    vi.advanceTimersByTime(10_000)
+    vi.advanceTimersByTime(10_000)
+    expect(settled).toHaveLength(1)
+
+    resultListener?.({ ok: false, applied: [], skipped: [] })
+    resultListener?.({ ok: false, applied: [], skipped: [] })
+
+    sender.enqueue([addNode(2)])
+    resultListener?.({ ok: false, applied: [], skipped: [] })
+
+    expect(settled).toHaveLength(2)
+    expect(settled[1].state).toBe('acknowledged')
+  })
+
+  it('stops sending after detach', () => {
+    sender.enqueue([addNode(1)])
+    ackInFlight()
+    sender.detach()
+    sender.enqueue([addNode(2)])
+
+    expect(sent).toHaveLength(1)
+  })
+})

--- a/src/workbench/extensions/agent/crdt/opSender.ts
+++ b/src/workbench/extensions/agent/crdt/opSender.ts
@@ -25,11 +25,59 @@ const SEND_RETRY_INTERVAL_MS = 500
 const RESULT_TIMEOUT_MS = 10_000
 
 export interface OpsResultView {
+  /** The workflow the frame names; results for other workflows are ignored. */
+  workflowId?: string
   ok: boolean
   applied: string[]
   skipped: string[]
   /** Failed-batch diagnostics when the host provides them; `op_id` correlates an otherwise empty-list failure to its batch. */
   failure?: { op_id?: string }
+}
+
+/**
+ * Boundary adapter: normalize a raw `doc_ops_result` frame into the sender's
+ * view. The wire's `failed` detail has shipped in two shapes (a single
+ * `{op_id, code, message}` object, and the newer `{index, op, code, message}`
+ * where `op` carries the op_id) and may arrive as an array; all of them
+ * resolve to the `failure.op_id` the sender correlates on, so a host
+ * rejection with empty applied/skipped lists keeps its batch identity.
+ */
+export function toOpsResultView(frame: {
+  workflowId?: string
+  ok: boolean
+  applied?: unknown
+  skipped?: unknown
+  failed?: unknown
+}): OpsResultView {
+  const ids = (value: unknown): string[] =>
+    Array.isArray(value)
+      ? value.filter((item): item is string => typeof item === 'string')
+      : []
+  const failure = normalizeFailure(frame.failed)
+  return {
+    ...(frame.workflowId !== undefined && { workflowId: frame.workflowId }),
+    ok: frame.ok,
+    applied: ids(frame.applied),
+    skipped: ids(frame.skipped),
+    ...(failure !== undefined && { failure })
+  }
+}
+
+function normalizeFailure(failed: unknown): { op_id?: string } | undefined {
+  if (failed == null) return undefined
+  const single: unknown = Array.isArray(failed) ? failed[0] : failed
+  if (typeof single !== 'object' || single === null) return {}
+  const detail = single as { op_id?: unknown; op?: unknown }
+  if (typeof detail.op_id === 'string') return { op_id: detail.op_id }
+  const op = detail.op
+  if (
+    typeof op === 'object' &&
+    op !== null &&
+    typeof (op as { op_id?: unknown }).op_id === 'string'
+  ) {
+    return { op_id: (op as { op_id: string }).op_id }
+  }
+  return {}
 }
 
 export interface OpSenderDeps {
@@ -65,15 +113,25 @@ export interface OpSender {
   detach(): void
 }
 
-interface InFlight {
+interface QueuedBatch {
   ops: Op[]
+  /**
+   * The workflow the batch was minted for. Captured at mint time so a rebind
+   * can never route already-minted ops (carrying the old doc's base_version)
+   * to a different workflow: retries and queued delivery stay
+   * document-scoped, and a rebind invalidates them as undeliverable.
+   */
+  workflowId: string | null
+}
+
+interface InFlight extends QueuedBatch {
   opIds: Set<string>
   resent: boolean
   timer: ReturnType<typeof setTimeout> | null
 }
 
 export function createOpSender(deps: OpSenderDeps): OpSender {
-  const queue: Op[][] = []
+  const queue: QueuedBatch[] = []
   let inFlight: InFlight | null = null
   let detached = false
   // Late-result credits: a batch that settled 'unacknowledged' was
@@ -92,14 +150,16 @@ export function createOpSender(deps: OpSenderDeps): OpSender {
     pump()
   }
 
-  function transmit(batch: Op[], attempt: number): void {
+  function transmit(batch: QueuedBatch, attempt: number): void {
     if (detached) return
-    const workflowId = deps.workflowId()
-    if (workflowId === null) {
+    // Delivery is document-scoped: the batch carries the workflow it was
+    // minted for, and a rebind since then invalidates it rather than routing
+    // the old doc's ops (and base_version) to the new workflow.
+    if (batch.workflowId === null || deps.workflowId() !== batch.workflowId) {
       settleUndeliverable(batch)
       return
     }
-    if (!deps.sendOps(workflowId, deps.tab, batch)) {
+    if (!deps.sendOps(batch.workflowId, deps.tab, batch.ops)) {
       if (attempt < SEND_RETRY_LIMIT) {
         setTimeout(() => transmit(batch, attempt + 1), SEND_RETRY_INTERVAL_MS)
       } else {
@@ -110,19 +170,19 @@ export function createOpSender(deps: OpSenderDeps): OpSender {
     armResultTimeout(batch)
   }
 
-  function settleUndeliverable(batch: Op[]): void {
-    if (inFlight?.ops === batch) {
-      settle({ state: 'undeliverable', ops: batch })
+  function settleUndeliverable(batch: QueuedBatch): void {
+    if (inFlight?.ops === batch.ops) {
+      settle({ state: 'undeliverable', ops: batch.ops })
     }
   }
 
-  function armResultTimeout(batch: Op[]): void {
-    if (inFlight?.ops !== batch) return
+  function armResultTimeout(batch: QueuedBatch): void {
+    if (inFlight?.ops !== batch.ops) return
     inFlight.timer = setTimeout(() => {
-      if (inFlight?.ops !== batch) return
+      if (inFlight?.ops !== batch.ops) return
       if (inFlight.resent) {
         staleAnonymousBudget += 2
-        settle({ state: 'unacknowledged', ops: batch })
+        settle({ state: 'unacknowledged', ops: batch.ops })
         return
       }
       // One silent-result resend of the SAME minted ops: idempotent at the
@@ -137,15 +197,24 @@ export function createOpSender(deps: OpSenderDeps): OpSender {
     const batch = queue.shift()
     if (!batch) return
     inFlight = {
-      ops: batch,
-      opIds: new Set(batch.map((op) => op.op_id)),
+      ops: batch.ops,
+      workflowId: batch.workflowId,
+      opIds: new Set(batch.ops.map((op) => op.op_id)),
       resent: false,
       timer: null
     }
-    transmit(batch, 0)
+    transmit(inFlight, 0)
   }
 
   const unsubscribe = deps.onOpsResult((result) => {
+    // A result naming a different workflow can never be this sender's: it
+    // neither settles the in-flight batch nor drains a stale credit.
+    if (
+      result.workflowId !== undefined &&
+      result.workflowId !== (inFlight?.workflowId ?? deps.workflowId())
+    ) {
+      return
+    }
     if (!inFlight) {
       // A late result with no batch waiting: drain a credit if one is
       // outstanding so it cannot swallow a future batch's own result.
@@ -171,11 +240,12 @@ export function createOpSender(deps: OpSenderDeps): OpSender {
   return {
     enqueue(operations) {
       if (detached || operations.length === 0) return
+      const workflowId = deps.workflowId()
       const minted = mintWireOps(operations, {
         actor: deps.actor(),
         baseVersion: deps.baseVersion()
       })
-      queue.push(...chunkWireOps(minted))
+      queue.push(...chunkWireOps(minted).map((ops) => ({ ops, workflowId })))
       pump()
     },
     pending() {

--- a/src/workbench/extensions/agent/crdt/opSender.ts
+++ b/src/workbench/extensions/agent/crdt/opSender.ts
@@ -1,0 +1,192 @@
+/**
+ * The human write leg's sender (plan 3.2/3.3): takes semantic
+ * {@link GraphOperation}s from the mint ports, mints wire identity ONCE, and
+ * drives `doc_ops` frames through the doc frame client with bounded retries
+ * that never re-mint an `op_id` (changed-payload reuse rejects host-side;
+ * an unchanged resend converges through the applier's idempotency gate).
+ *
+ * Batches are strictly serialized: one in-flight batch at a time, FIFO, so
+ * op order on the wire matches mint order. `base_version` is read at mint
+ * time from the follower's last observed sequence.
+ *
+ * Outcome handling is deliberately the TODAY contract: `doc_ops_result` is a
+ * binary applied/skipped split. The prefix-abort reconcile and per-op
+ * outcome-union surfacing (lww-dropped, op_rejected, ...) land when the host
+ * frame upgrade ships (a required backend dependency, recorded on the plan);
+ * `onResult` is the seam they will replace.
+ */
+import type { Op } from '@comfyorg/comfy-multi-player'
+
+import type { GraphOperation } from './graphOperations'
+import { chunkWireOps, mintWireOps } from './opEnvelope'
+
+const SEND_RETRY_LIMIT = 5
+const SEND_RETRY_INTERVAL_MS = 500
+const RESULT_TIMEOUT_MS = 10_000
+
+export interface OpsResultView {
+  ok: boolean
+  applied: string[]
+  skipped: string[]
+  /** Failed-batch diagnostics when the host provides them; `op_id` correlates an otherwise empty-list failure to its batch. */
+  failure?: { op_id?: string }
+}
+
+export interface OpSenderDeps {
+  /** `DocFrameClient.sendOps` shape: false = the transport cannot carry it now. */
+  sendOps(workflowId: string, tab: string, ops: Op[]): boolean
+  /** Subscribe to `doc_ops_result` frames; returns unsubscribe. */
+  onOpsResult(listener: (result: OpsResultView) => void): () => void
+  /** The bound workflow id, or null when no doc is bound (drops the batch). */
+  workflowId(): string | null
+  tab: string
+  /** `human:<user>:<tab>` (vocabulary §7). */
+  actor(): string
+  /** The follower's last observed doc sequence (stamps `base_version`). */
+  baseVersion(): number
+  /**
+   * Terminal per-batch report: 'acknowledged' carries the host's result;
+   * 'unacknowledged' means one resend after silence also drew no result;
+   * 'undeliverable' means the transport never carried it within the retry
+   * budget or no doc was bound.
+   */
+  onBatchSettled(outcome: BatchOutcome): void
+}
+
+export type BatchOutcome =
+  | { state: 'acknowledged'; ops: Op[]; result: OpsResultView }
+  | { state: 'unacknowledged'; ops: Op[] }
+  | { state: 'undeliverable'; ops: Op[] }
+
+export interface OpSender {
+  enqueue(operations: GraphOperation[]): void
+  /** In-flight + queued batch count (observability; 0 = drained). */
+  pending(): number
+  detach(): void
+}
+
+interface InFlight {
+  ops: Op[]
+  opIds: Set<string>
+  resent: boolean
+  timer: ReturnType<typeof setTimeout> | null
+}
+
+export function createOpSender(deps: OpSenderDeps): OpSender {
+  const queue: Op[][] = []
+  let inFlight: InFlight | null = null
+  let detached = false
+  // Late-result credits: a batch that settled 'unacknowledged' was
+  // transmitted twice, so up to two of its results may still arrive - as
+  // ANONYMOUS failures (empty id lists, no failure op_id) they are
+  // indistinguishable from the current batch's. Swallowing up to the credit
+  // beats mis-attribution: a swallowed own-result only costs the idempotent
+  // resend cycle, while a mis-attributed settle poisons everything
+  // downstream of this seam.
+  let staleAnonymousBudget = 0
+
+  function settle(outcome: BatchOutcome): void {
+    if (inFlight?.timer) clearTimeout(inFlight.timer)
+    inFlight = null
+    deps.onBatchSettled(outcome)
+    pump()
+  }
+
+  function transmit(batch: Op[], attempt: number): void {
+    if (detached) return
+    const workflowId = deps.workflowId()
+    if (workflowId === null) {
+      settleUndeliverable(batch)
+      return
+    }
+    if (!deps.sendOps(workflowId, deps.tab, batch)) {
+      if (attempt < SEND_RETRY_LIMIT) {
+        setTimeout(() => transmit(batch, attempt + 1), SEND_RETRY_INTERVAL_MS)
+      } else {
+        settleUndeliverable(batch)
+      }
+      return
+    }
+    armResultTimeout(batch)
+  }
+
+  function settleUndeliverable(batch: Op[]): void {
+    if (inFlight?.ops === batch) {
+      settle({ state: 'undeliverable', ops: batch })
+    }
+  }
+
+  function armResultTimeout(batch: Op[]): void {
+    if (inFlight?.ops !== batch) return
+    inFlight.timer = setTimeout(() => {
+      if (inFlight?.ops !== batch) return
+      if (inFlight.resent) {
+        staleAnonymousBudget += 2
+        settle({ state: 'unacknowledged', ops: batch })
+        return
+      }
+      // One silent-result resend of the SAME minted ops: idempotent at the
+      // applier through the op_id gate.
+      inFlight.resent = true
+      transmit(batch, 0)
+    }, RESULT_TIMEOUT_MS)
+  }
+
+  function pump(): void {
+    if (detached || inFlight !== null) return
+    const batch = queue.shift()
+    if (!batch) return
+    inFlight = {
+      ops: batch,
+      opIds: new Set(batch.map((op) => op.op_id)),
+      resent: false,
+      timer: null
+    }
+    transmit(batch, 0)
+  }
+
+  const unsubscribe = deps.onOpsResult((result) => {
+    if (!inFlight) {
+      // A late result with no batch waiting: drain a credit if one is
+      // outstanding so it cannot swallow a future batch's own result.
+      if (staleAnonymousBudget > 0) staleAnonymousBudget--
+      return
+    }
+    const identified = [...result.applied, ...result.skipped]
+    if (result.failure?.op_id) identified.push(result.failure.op_id)
+    if (identified.length > 0) {
+      if (!identified.some((opId) => inFlight!.opIds.has(opId))) return
+      settle({ state: 'acknowledged', ops: inFlight.ops, result })
+      return
+    }
+    // Anonymous failure (empty lists, no failure op_id): only attribute it
+    // to the in-flight batch once no stale credit could explain it.
+    if (staleAnonymousBudget > 0) {
+      staleAnonymousBudget--
+      return
+    }
+    settle({ state: 'acknowledged', ops: inFlight.ops, result })
+  })
+
+  return {
+    enqueue(operations) {
+      if (detached || operations.length === 0) return
+      const minted = mintWireOps(operations, {
+        actor: deps.actor(),
+        baseVersion: deps.baseVersion()
+      })
+      queue.push(...chunkWireOps(minted))
+      pump()
+    },
+    pending() {
+      return queue.length + (inFlight ? 1 : 0)
+    },
+    detach() {
+      detached = true
+      if (inFlight?.timer) clearTimeout(inFlight.timer)
+      inFlight = null
+      queue.length = 0
+      unsubscribe()
+    }
+  }
+}

--- a/src/workbench/extensions/agent/crdt/opSender.ts
+++ b/src/workbench/extensions/agent/crdt/opSender.ts
@@ -18,7 +18,7 @@
 import type { Op } from '@comfyorg/comfy-multi-player'
 
 import type { GraphOperation } from './graphOperations'
-import { chunkWireOps, mintWireOps } from './opEnvelope'
+import { chunkWireOps, mintOrderedOpId, mintWireOps } from './opEnvelope'
 
 const SEND_RETRY_LIMIT = 5
 const SEND_RETRY_INTERVAL_MS = 500
@@ -127,13 +127,15 @@ interface QueuedBatch {
 interface InFlight extends QueuedBatch {
   opIds: Set<string>
   resent: boolean
-  timer: ReturnType<typeof setTimeout> | null
+  resultTimer: ReturnType<typeof setTimeout> | null
+  deliveryTimer: ReturnType<typeof setTimeout> | null
 }
 
 export function createOpSender(deps: OpSenderDeps): OpSender {
   const queue: QueuedBatch[] = []
   let inFlight: InFlight | null = null
   let detached = false
+  let opOrder = 0
   // Late-result credits: a batch that settled 'unacknowledged' was
   // transmitted twice, so up to two of its results may still arrive - as
   // ANONYMOUS failures (empty id lists, no failure op_id) they are
@@ -141,17 +143,31 @@ export function createOpSender(deps: OpSenderDeps): OpSender {
   // beats mis-attribution: a swallowed own-result only costs the idempotent
   // resend cycle, while a mis-attributed settle poisons everything
   // downstream of this seam.
-  let staleAnonymousBudget = 0
+  const staleAnonymousExpiries: number[] = []
+
+  function consumeStaleAnonymousCredit(): boolean {
+    const now = Date.now()
+    while (
+      staleAnonymousExpiries.length > 0 &&
+      staleAnonymousExpiries[0] <= now
+    ) {
+      staleAnonymousExpiries.shift()
+    }
+    if (staleAnonymousExpiries.length === 0) return false
+    staleAnonymousExpiries.shift()
+    return true
+  }
 
   function settle(outcome: BatchOutcome): void {
-    if (inFlight?.timer) clearTimeout(inFlight.timer)
+    if (inFlight?.resultTimer) clearTimeout(inFlight.resultTimer)
+    if (inFlight?.deliveryTimer) clearTimeout(inFlight.deliveryTimer)
     inFlight = null
     deps.onBatchSettled(outcome)
     pump()
   }
 
   function transmit(batch: QueuedBatch, attempt: number): void {
-    if (detached) return
+    if (detached || inFlight?.ops !== batch.ops) return
     // Delivery is document-scoped: the batch carries the workflow it was
     // minted for, and a rebind since then invalidates it rather than routing
     // the old doc's ops (and base_version) to the new workflow.
@@ -161,7 +177,11 @@ export function createOpSender(deps: OpSenderDeps): OpSender {
     }
     if (!deps.sendOps(batch.workflowId, deps.tab, batch.ops)) {
       if (attempt < SEND_RETRY_LIMIT) {
-        setTimeout(() => transmit(batch, attempt + 1), SEND_RETRY_INTERVAL_MS)
+        inFlight.deliveryTimer = setTimeout(() => {
+          if (inFlight?.ops !== batch.ops) return
+          inFlight.deliveryTimer = null
+          transmit(batch, attempt + 1)
+        }, SEND_RETRY_INTERVAL_MS)
       } else {
         settleUndeliverable(batch)
       }
@@ -178,10 +198,11 @@ export function createOpSender(deps: OpSenderDeps): OpSender {
 
   function armResultTimeout(batch: QueuedBatch): void {
     if (inFlight?.ops !== batch.ops) return
-    inFlight.timer = setTimeout(() => {
+    inFlight.resultTimer = setTimeout(() => {
       if (inFlight?.ops !== batch.ops) return
       if (inFlight.resent) {
-        staleAnonymousBudget += 2
+        const expiry = Date.now() + RESULT_TIMEOUT_MS
+        staleAnonymousExpiries.push(expiry, expiry)
         settle({ state: 'unacknowledged', ops: batch.ops })
         return
       }
@@ -201,7 +222,8 @@ export function createOpSender(deps: OpSenderDeps): OpSender {
       workflowId: batch.workflowId,
       opIds: new Set(batch.ops.map((op) => op.op_id)),
       resent: false,
-      timer: null
+      resultTimer: null,
+      deliveryTimer: null
     }
     transmit(inFlight, 0)
   }
@@ -218,7 +240,7 @@ export function createOpSender(deps: OpSenderDeps): OpSender {
     if (!inFlight) {
       // A late result with no batch waiting: drain a credit if one is
       // outstanding so it cannot swallow a future batch's own result.
-      if (staleAnonymousBudget > 0) staleAnonymousBudget--
+      consumeStaleAnonymousCredit()
       return
     }
     const identified = [...result.applied, ...result.skipped]
@@ -230,10 +252,7 @@ export function createOpSender(deps: OpSenderDeps): OpSender {
     }
     // Anonymous failure (empty lists, no failure op_id): only attribute it
     // to the in-flight batch once no stale credit could explain it.
-    if (staleAnonymousBudget > 0) {
-      staleAnonymousBudget--
-      return
-    }
+    if (consumeStaleAnonymousCredit()) return
     settle({ state: 'acknowledged', ops: inFlight.ops, result })
   })
 
@@ -243,7 +262,8 @@ export function createOpSender(deps: OpSenderDeps): OpSender {
       const workflowId = deps.workflowId()
       const minted = mintWireOps(operations, {
         actor: deps.actor(),
-        baseVersion: deps.baseVersion()
+        baseVersion: deps.baseVersion(),
+        nextOpId: () => mintOrderedOpId(++opOrder)
       })
       queue.push(...chunkWireOps(minted).map((ops) => ({ ops, workflowId })))
       pump()
@@ -253,7 +273,8 @@ export function createOpSender(deps: OpSenderDeps): OpSender {
     },
     detach() {
       detached = true
-      if (inFlight?.timer) clearTimeout(inFlight.timer)
+      if (inFlight?.resultTimer) clearTimeout(inFlight.resultTimer)
+      if (inFlight?.deliveryTimer) clearTimeout(inFlight.deliveryTimer)
       inFlight = null
       queue.length = 0
       unsubscribe()

--- a/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.test.ts
+++ b/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.test.ts
@@ -68,6 +68,15 @@ vi.mock('./docFrameClient', () => ({
   }
 }))
 
+const idAllocationState = vi.hoisted(() => ({
+  setCoordinationFreeIds: vi.fn()
+}))
+
+vi.mock('@/lib/litegraph/src/idAllocation', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  setCoordinationFreeIds: idAllocationState.setCoordinationFreeIds
+}))
+
 const projectorState = vi.hoisted(() => ({
   current: null as {
     project: ReturnType<typeof vi.fn>
@@ -142,6 +151,7 @@ describe('useAgentCrdtFollower', () => {
     sessionStorage.clear()
     bridgeState.current = null
     projectorState.current = null
+    idAllocationState.setCoordinationFreeIds.mockClear()
     clientState.destroy.mockClear()
     apiState.api.removeEventListener.mockClear()
   })
@@ -241,6 +251,32 @@ describe('useAgentCrdtFollower', () => {
     expect(bridge().subscribe).toHaveBeenCalledWith('wf-persisted')
     expect(status().workflowId).toBe('wf-persisted')
     unmount()
+  })
+
+  it('arms contract-scheme id allocation while bound and restores counters on detach and unmount', async () => {
+    const { unmount, workflowId } = mountFollower('wf-1')
+
+    // Bound: local node/link creation allocates coordination-free ids.
+    expect(idAllocationState.setCoordinationFreeIds).toHaveBeenLastCalledWith(
+      true
+    )
+
+    workflowId.value = null
+    await nextTick()
+    expect(idAllocationState.setCoordinationFreeIds).toHaveBeenLastCalledWith(
+      false
+    )
+
+    workflowId.value = 'wf-2'
+    await nextTick()
+    expect(idAllocationState.setCoordinationFreeIds).toHaveBeenLastCalledWith(
+      true
+    )
+
+    unmount()
+    expect(idAllocationState.setCoordinationFreeIds).toHaveBeenLastCalledWith(
+      false
+    )
   })
 
   it('FE-1902: a real detach clears the persisted binding and unsubscribes', async () => {

--- a/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.test.ts
+++ b/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.test.ts
@@ -379,6 +379,56 @@ describe('useAgentCrdtFollower', () => {
     unmount()
   })
 
+  it('a stale confirm does not arm the stale probe on a detached panel', () => {
+    vi.useFakeTimers()
+    const { unmount, workflowId } = mountFollower('wf-1')
+
+    workflowId.value = null
+    return Promise.resolve().then(async () => {
+      await Promise.resolve()
+      dispatchFrame('doc_subscribed', { ok: true })
+      vi.advanceTimersByTime(STALE_AFTER_MS + 1)
+
+      // An armed probe would fire resubscribe on the self-re-arming timer.
+      expect(bridge().resubscribe).not.toHaveBeenCalled()
+      unmount()
+    })
+  })
+
+  it('warns in dev when a second follower mounts concurrently', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const first = mountFollower('wf-1')
+    const second = mountFollower('wf-2')
+
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('second concurrent instance')
+    )
+    second.unmount()
+    first.unmount()
+    warn.mockRestore()
+  })
+
+  it('a doc_update cancels the silent-server failsafe', () => {
+    vi.useFakeTimers()
+    const boundState = appState.app.graph!.state
+    const { unmount } = mountFollower('wf-1')
+
+    for (let attempt = 0; attempt < 6; attempt++) {
+      dispatchFrame('doc_subscribed', { ok: false })
+      vi.advanceTimersByTime(500 * 2 ** attempt)
+    }
+    // Updates flow without a confirm; one proves the binding is live.
+    dispatchFrame('doc_update', { seq: 1 })
+    idAllocationState.setCoordinationFreeIds.mockClear()
+    vi.advanceTimersByTime(500 * 2 ** 6)
+
+    expect(idAllocationState.setCoordinationFreeIds).not.toHaveBeenCalledWith(
+      boundState,
+      false
+    )
+    unmount()
+  })
+
   it('disarms when the subscribe retry budget is exhausted', () => {
     vi.useFakeTimers()
     const boundState = appState.app.graph!.state

--- a/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.test.ts
+++ b/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.test.ts
@@ -398,6 +398,7 @@ describe('useAgentCrdtFollower', () => {
   it('warns in dev when a second follower mounts concurrently', () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
     const first = mountFollower('wf-1')
+    expect(warn).not.toHaveBeenCalled()
     const second = mountFollower('wf-2')
 
     expect(warn).toHaveBeenCalledWith(

--- a/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.test.ts
+++ b/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.test.ts
@@ -85,6 +85,10 @@ vi.mock('./semanticProjector', () => ({
   }
 }))
 
+vi.mock('./devPanelLog', () => ({
+  recordDevEvent: vi.fn()
+}))
+
 vi.mock('@/scripts/api', () => ({ api: apiState.api }))
 vi.mock('@/scripts/app', () => ({ app: { graph: null, canvas: null } }))
 vi.mock('@/stores/authStore', () => ({

--- a/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.test.ts
+++ b/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.test.ts
@@ -99,7 +99,17 @@ vi.mock('./devPanelLog', () => ({
 }))
 
 vi.mock('@/scripts/api', () => ({ api: apiState.api }))
-vi.mock('@/scripts/app', () => ({ app: { graph: null, canvas: null } }))
+
+const appState = vi.hoisted(() => ({
+  app: {
+    graph: { state: { lastNodeId: 0 } } as {
+      state: Record<string, unknown>
+    } | null,
+    canvas: null
+  }
+}))
+
+vi.mock('@/scripts/app', () => ({ app: appState.app }))
 vi.mock('@/stores/authStore', () => ({
   useAuthStore: () => ({ userId: 'user-1' })
 }))
@@ -149,6 +159,7 @@ describe('useAgentCrdtFollower', () => {
   beforeEach(() => {
     setActivePinia(createPinia())
     sessionStorage.clear()
+    appState.app.graph = { state: { lastNodeId: 0 } }
     bridgeState.current = null
     projectorState.current = null
     idAllocationState.setCoordinationFreeIds.mockClear()
@@ -250,33 +261,102 @@ describe('useAgentCrdtFollower', () => {
 
     expect(bridge().subscribe).toHaveBeenCalledWith('wf-persisted')
     expect(status().workflowId).toBe('wf-persisted')
+    // The rebound doc is a live binding: the panel-remount/reload path must
+    // arm coordination-free allocation exactly like a fresh bind.
+    expect(idAllocationState.setCoordinationFreeIds).toHaveBeenLastCalledWith(
+      appState.app.graph!.state,
+      true
+    )
     unmount()
   })
 
-  it('arms contract-scheme id allocation while bound and restores counters on detach and unmount', async () => {
+  it('arms the bound graph state and restores counters on detach and unmount', async () => {
+    const boundState = appState.app.graph!.state
     const { unmount, workflowId } = mountFollower('wf-1')
 
-    // Bound: local node/link creation allocates coordination-free ids.
+    // Bound: local node/link creation on THIS graph allocates
+    // coordination-free ids; every other graph state stays on counters.
     expect(idAllocationState.setCoordinationFreeIds).toHaveBeenLastCalledWith(
+      boundState,
       true
     )
 
+    // A persisted id must not hijack a LATER null into a rebind - only the
+    // mount-time null rebinds; this one is a real detach.
+    sessionStorage.setItem('Comfy.Agent.CrdtDocId', 'wf-stale')
     workflowId.value = null
     await nextTick()
     expect(idAllocationState.setCoordinationFreeIds).toHaveBeenLastCalledWith(
+      boundState,
       false
     )
 
     workflowId.value = 'wf-2'
     await nextTick()
     expect(idAllocationState.setCoordinationFreeIds).toHaveBeenLastCalledWith(
+      boundState,
       true
     )
 
     unmount()
     expect(idAllocationState.setCoordinationFreeIds).toHaveBeenLastCalledWith(
+      boundState,
       false
     )
+  })
+
+  it('re-arms the swapped-in graph state on the next doc frame', () => {
+    const initialState = appState.app.graph!.state
+    const { unmount } = mountFollower('wf-1')
+    expect(idAllocationState.setCoordinationFreeIds).toHaveBeenLastCalledWith(
+      initialState,
+      true
+    )
+
+    // A workflow load replaces the graph state (LGraph.clear()), dropping
+    // the arm. The subscribe confirm re-arms the new state and releases the
+    // old one; a doc_update does the same for later swaps.
+    const confirmState = { lastNodeId: 0 }
+    appState.app.graph = { state: confirmState }
+    dispatchFrame('doc_subscribed', { ok: true })
+    expect(idAllocationState.setCoordinationFreeIds).toHaveBeenCalledWith(
+      initialState,
+      false
+    )
+    expect(idAllocationState.setCoordinationFreeIds).toHaveBeenLastCalledWith(
+      confirmState,
+      true
+    )
+
+    const updateState = { lastNodeId: 0 }
+    appState.app.graph = { state: updateState }
+    dispatchFrame('doc_update', { seq: 1 })
+    expect(idAllocationState.setCoordinationFreeIds).toHaveBeenLastCalledWith(
+      updateState,
+      true
+    )
+    unmount()
+  })
+
+  it('disarms when the subscribe retry budget is exhausted', () => {
+    vi.useFakeTimers()
+    const boundState = appState.app.graph!.state
+    const { unmount } = mountFollower('wf-1')
+
+    for (let attempt = 0; attempt < 6; attempt++) {
+      dispatchFrame('doc_subscribed', { ok: false })
+      vi.advanceTimersByTime(500 * 2 ** attempt)
+    }
+    idAllocationState.setCoordinationFreeIds.mockClear()
+    dispatchFrame('doc_subscribed', { ok: false })
+
+    // Definitive binding failure: the doc is not coming, so counter
+    // allocation is restored instead of stranding the arm.
+    expect(idAllocationState.setCoordinationFreeIds).toHaveBeenLastCalledWith(
+      boundState,
+      false
+    )
+    unmount()
   })
 
   it('FE-1902: a real detach clears the persisted binding and unsubscribes', async () => {
@@ -372,6 +452,12 @@ describe('useAgentCrdtFollower', () => {
 
     expect(status().connected).toBe(false)
     expect(status().workflowId).toBe('wf-1')
+    // Fail-closed for allocation too: nothing projects from an unreadable
+    // doc, so nothing should mint against it.
+    expect(idAllocationState.setCoordinationFreeIds).toHaveBeenLastCalledWith(
+      appState.app.graph!.state,
+      false
+    )
     unmount()
   })
 

--- a/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.test.ts
+++ b/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.test.ts
@@ -338,6 +338,47 @@ describe('useAgentCrdtFollower', () => {
     unmount()
   })
 
+  it('a stale confirm for a just-dropped workflow does not arm', async () => {
+    const boundState = appState.app.graph!.state
+    const { unmount, workflowId } = mountFollower('wf-1')
+
+    workflowId.value = null
+    await nextTick()
+    // The bridge re-dispatches confirms unconditionally; one in flight for
+    // the dropped workflow must not arm the unbound graph.
+    dispatchFrame('doc_subscribed', { ok: true })
+
+    expect(
+      idAllocationState.setCoordinationFreeIds
+    ).not.toHaveBeenLastCalledWith(boundState, true)
+    expect(idAllocationState.setCoordinationFreeIds).toHaveBeenLastCalledWith(
+      boundState,
+      false
+    )
+    unmount()
+  })
+
+  it('disarms when the server stays silent after the last retry', () => {
+    vi.useFakeTimers()
+    const boundState = appState.app.graph!.state
+    const { unmount } = mountFollower('wf-1')
+
+    for (let attempt = 0; attempt < 6; attempt++) {
+      dispatchFrame('doc_subscribed', { ok: false })
+      vi.advanceTimersByTime(500 * 2 ** attempt)
+    }
+    // The sixth retry has fired its resubscribe; the server never answers,
+    // so no refusal arrives to trigger the exhaustion disarm.
+    idAllocationState.setCoordinationFreeIds.mockClear()
+    vi.advanceTimersByTime(500 * 2 ** 6)
+
+    expect(idAllocationState.setCoordinationFreeIds).toHaveBeenLastCalledWith(
+      boundState,
+      false
+    )
+    unmount()
+  })
+
   it('disarms when the subscribe retry budget is exhausted', () => {
     vi.useFakeTimers()
     const boundState = appState.app.graph!.state

--- a/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.test.ts
+++ b/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.test.ts
@@ -95,7 +95,11 @@ vi.mock('@/stores/authStore', () => ({
   useAuthStore: () => ({ userId: 'user-1' })
 }))
 
-import { STALE_AFTER_MS, useAgentCrdtFollower } from './useAgentCrdtFollower'
+import {
+  STALE_AFTER_MS,
+  summarizeOutboundDocFrame,
+  useAgentCrdtFollower
+} from './useAgentCrdtFollower'
 import type { AgentCrdtStatus } from './useAgentCrdtFollower'
 
 function mountFollower(initial: string | null = null): {
@@ -458,5 +462,45 @@ describe('useAgentCrdtFollower', () => {
       'status',
       expect.any(Function)
     )
+  })
+})
+
+describe('summarizeOutboundDocFrame', () => {
+  it('records metadata only, never the doc_ops payload', () => {
+    const frame = JSON.stringify({
+      type: 'doc_ops',
+      data: {
+        v: 1,
+        workflow_id: 'wf-1',
+        tab: 'tab-1',
+        ops: [
+          {
+            op_id: 'op-1',
+            op: 'set_widget',
+            actor: 'human:u:t',
+            value: 'a private prompt string'
+          },
+          { op_id: 'op-2', op: 'add_node', actor: 'human:u:t' }
+        ]
+      }
+    })
+
+    const summary = summarizeOutboundDocFrame(frame)
+
+    expect(summary).toEqual({
+      bytes: frame.length,
+      type: 'doc_ops',
+      workflow_id: 'wf-1',
+      op_count: 2,
+      ops: [
+        { op_id: 'op-1', op: 'set_widget' },
+        { op_id: 'op-2', op: 'add_node' }
+      ]
+    })
+    expect(JSON.stringify(summary)).not.toContain('private prompt')
+  })
+
+  it('degrades to byte size alone for a non-JSON frame', () => {
+    expect(summarizeOutboundDocFrame('not json')).toEqual({ bytes: 8 })
   })
 })

--- a/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.ts
+++ b/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.ts
@@ -1,6 +1,7 @@
 import { computed, onBeforeUnmount, readonly, ref, watch } from 'vue'
 import type { Ref } from 'vue'
 
+import { setCoordinationFreeIds } from '@/lib/litegraph/src/idAllocation'
 import { LiteGraph } from '@/lib/litegraph/src/litegraph'
 import { api } from '@/scripts/api'
 import { app } from '@/scripts/app'
@@ -411,11 +412,13 @@ export function useAgentCrdtFollower(workflowId: Ref<string | null>) {
           recordDevEvent('rebind', { workflowId: persisted })
           subscribedWorkflowId.value = persisted
           bridge.subscribe(persisted)
+          setCoordinationFreeIds(true)
           return
         }
         clearPersistedDocId()
         subscribedWorkflowId.value = null
         bridge.unsubscribe()
+        setCoordinationFreeIds(false)
         return
       }
       initialBind = false
@@ -429,6 +432,10 @@ export function useAgentCrdtFollower(workflowId: Ref<string | null>) {
       projectedWorkflowId = next
       subscribedWorkflowId.value = next
       bridge.subscribe(next)
+      // Doc-bound workflows allocate contract-scheme (coordination-free) node
+      // and link ids at local creation, so replicas seeded from one snapshot
+      // cannot mint colliding ids; a real detach restores the counters.
+      setCoordinationFreeIds(true)
     },
     { immediate: true }
   )
@@ -440,6 +447,7 @@ export function useAgentCrdtFollower(workflowId: Ref<string | null>) {
     // failure-tolerant by construction now, but the try/finally makes the
     // "client.destroy() always runs" guarantee local and readable.
     try {
+      setCoordinationFreeIds(false)
       clearSubscribeRetry()
       clearStaleProbe()
       if (import.meta.env.DEV) {

--- a/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.ts
+++ b/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.ts
@@ -136,7 +136,18 @@ export function summarizeOutboundDocFrame(
   return summary
 }
 
+// One follower instance per tab: id arming is graph-scoped, not
+// refcounted, so a second concurrent instance would disarm the first's
+// graph state on its own teardown.
+let followerInstanceMounted = false
+
 export function useAgentCrdtFollower(workflowId: Ref<string | null>) {
+  if (import.meta.env.DEV && followerInstanceMounted) {
+    console.warn(
+      'useAgentCrdtFollower: second concurrent instance; id arming assumes one per tab'
+    )
+  }
+  followerInstanceMounted = true
   const connected = ref(false)
   const updatesApplied = ref(0)
   const lastFrameType = ref<string | null>(null)
@@ -228,6 +239,9 @@ export function useAgentCrdtFollower(workflowId: Ref<string | null>) {
   const SUBSCRIBE_RETRY_MAX_ATTEMPTS = 6
   let subscribeRetryTimer: ReturnType<typeof setTimeout> | null = null
   let subscribeRetryAttempt = 0
+  // Failsafe for a silent server: the last retry's resubscribe may get NO
+  // answer at all, leaving no refusal to trigger the exhaustion disarm.
+  let subscribeFailsafeTimer: ReturnType<typeof setTimeout> | null = null
 
   // The recency heartbeat: armed only while a subscribe is CONFIRMED (bound +
   // healthy by definition), slid forward by every doc-scoped frame, cancelled
@@ -260,6 +274,10 @@ export function useAgentCrdtFollower(workflowId: Ref<string | null>) {
       clearTimeout(subscribeRetryTimer)
       subscribeRetryTimer = null
     }
+    if (subscribeFailsafeTimer !== null) {
+      clearTimeout(subscribeFailsafeTimer)
+      subscribeFailsafeTimer = null
+    }
     subscribeRetryAttempt = 0
   }
 
@@ -284,6 +302,15 @@ export function useAgentCrdtFollower(workflowId: Ref<string | null>) {
         workflowId: target
       })
       bridge.resubscribe()
+      if (subscribeRetryAttempt >= SUBSCRIBE_RETRY_MAX_ATTEMPTS) {
+        subscribeFailsafeTimer = setTimeout(
+          () => {
+            subscribeFailsafeTimer = null
+            disarmCoordinationFreeIds()
+          },
+          SUBSCRIBE_RETRY_BASE_MS * 2 ** SUBSCRIBE_RETRY_MAX_ATTEMPTS
+        )
+      }
     }, delay)
   }
 
@@ -297,11 +324,14 @@ export function useAgentCrdtFollower(workflowId: Ref<string | null>) {
     if (ok) {
       clearSubscribeRetry()
       armStaleProbe()
-      armCoordinationFreeIds()
       // FE-1902 (poc-3): only a CONFIRMED binding is worth rebinding to after
-      // a remount — persist on ok, not on intent.
-      if (subscribedWorkflowId.value !== null)
+      // a remount — persist on ok, not on intent. The arm applies the same
+      // rule: the bridge re-dispatches a confirm even when the workflow was
+      // just dropped, and a stale confirm must not arm an unbound graph.
+      if (subscribedWorkflowId.value !== null) {
+        armCoordinationFreeIds()
         persistDocId(subscribedWorkflowId.value)
+      }
     } else {
       clearStaleProbe()
       scheduleSubscribeRetry()
@@ -480,6 +510,7 @@ export function useAgentCrdtFollower(workflowId: Ref<string | null>) {
     // failure-tolerant by construction now, but the try/finally makes the
     // "client.destroy() always runs" guarantee local and readable.
     try {
+      followerInstanceMounted = false
       disarmCoordinationFreeIds()
       clearSubscribeRetry()
       clearStaleProbe()

--- a/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.ts
+++ b/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.ts
@@ -4,7 +4,9 @@ import type { Ref } from 'vue'
 import { LiteGraph } from '@/lib/litegraph/src/litegraph'
 import { api } from '@/scripts/api'
 import { app } from '@/scripts/app'
+import { useAuthStore } from '@/stores/authStore'
 
+import { recordDevEvent } from './devPanelLog'
 import type { DocFrameTransport, DocOp } from './docFrameClient'
 import { DocFrameClient } from './docFrameClient'
 import { LayoutFollowerBridge } from './layoutFollowerBridge'
@@ -99,9 +101,20 @@ export function useAgentCrdtFollower(workflowId: Ref<string | null>) {
   const lastFrameType = ref<string | null>(null)
   const subscribedWorkflowId = ref<string | null>(null)
 
+  // Dev-panel tap (poc-4): log every outbound frame with its delivery result.
+  // Wraps locally instead of modifying the exported apiTransport, whose
+  // never-throw contract is covered by tests.
   const transport: DocFrameTransport = {
     send(frame) {
-      return apiTransport.send(frame)
+      const delivered = apiTransport.send(frame)
+      let parsed: unknown = frame
+      try {
+        parsed = JSON.parse(frame)
+      } catch {
+        // Leave the raw string.
+      }
+      recordDevEvent('ws_out', { delivered, frame: parsed })
+      return delivered
     },
     addEventListener(type, listener) {
       apiTransport.addEventListener(type, listener)
@@ -113,6 +126,11 @@ export function useAgentCrdtFollower(workflowId: Ref<string | null>) {
   const client = new DocFrameClient(transport)
   const bridge = new LayoutFollowerBridge(client)
   const tabId = crypto.randomUUID()
+  // Highest doc_update seq seen — used as base_version for human-minted ops.
+  // The ws path has no ceiling gate; this only feeds LWW stamps, so a slightly
+  // stale value is safe (ties break by [base_version, actor, op_id]).
+  let lastSeq = 0
+  let lastOpsResult: unknown = null
   // Post-ECS main removed the global layout source scope
   // (`LayoutSource.External` / `layoutStore.setSource`), so remote batches
   // apply directly. Echo suppression becomes load-bearing only when the
@@ -123,6 +141,21 @@ export function useAgentCrdtFollower(workflowId: Ref<string | null>) {
     createNode: (type) => LiteGraph.createNode(type)
   })
   const projector = new SemanticProjector(mutator, { actor: tabId })
+
+  // Dev-panel tap (poc-4): track the doc's node-id set so the panel can show
+  // exactly which nodes each doc_update added/removed. Rebuilt from zero on
+  // doc_reset (remint) because the lineage broke.
+  let knownDocNodeIds: Set<string> = new Set()
+  const currentDocNodeIds = (): Set<string> => {
+    try {
+      const doc = bridge.follower.doc as unknown as {
+        getMap: (k: string) => { toJSON: () => Record<string, unknown> }
+      }
+      return new Set(Object.keys(doc.getMap('nodes').toJSON()))
+    } catch {
+      return new Set()
+    }
+  }
 
   // FE-1901 (poc-2): a `doc_subscribed {ok:false}` is a SERVER refusal — e.g.
   // the subscribe raced the doc-host before the turn ack minted the doc. The
@@ -152,6 +185,9 @@ export function useAgentCrdtFollower(workflowId: Ref<string | null>) {
     clearStaleProbe()
     staleProbeTimer = setTimeout(() => {
       staleProbeTimer = null
+      recordDevEvent('stale_probe', {
+        workflowId: subscribedWorkflowId.value
+      })
       bridge.resubscribe()
       armStaleProbe()
     }, STALE_AFTER_MS)
@@ -176,6 +212,10 @@ export function useAgentCrdtFollower(workflowId: Ref<string | null>) {
       subscribeRetryTimer = null
       // The desired doc changed while we waited — the watch owns that path.
       if (subscribedWorkflowId.value !== target) return
+      recordDevEvent('subscribe_retry', {
+        attempt: subscribeRetryAttempt,
+        workflowId: target
+      })
       bridge.resubscribe()
     }, delay)
   }
@@ -186,6 +226,7 @@ export function useAgentCrdtFollower(workflowId: Ref<string | null>) {
     const ok = detail.ok === true
     connected.value = ok
     lastFrameType.value = event.type
+    recordDevEvent('doc_subscribed', detail)
     if (ok) {
       clearSubscribeRetry()
       armStaleProbe()
@@ -203,12 +244,39 @@ export function useAgentCrdtFollower(workflowId: Ref<string | null>) {
     if (staleProbeTimer !== null) armStaleProbe()
     updatesApplied.value = bridge.follower.updatesApplied
     lastFrameType.value = event.type
+    if (event instanceof CustomEvent && typeof event.detail?.seq === 'number')
+      lastSeq = Math.max(lastSeq, event.detail.seq)
     projector.project(bridge.follower.doc)
+    if (event instanceof CustomEvent) {
+      const detail = event.detail as {
+        workflowId?: string
+        seq?: number
+        update?: Uint8Array
+        actor?: string
+      } | null
+      recordDevEvent('doc_update', {
+        workflowId: detail?.workflowId,
+        seq: detail?.seq,
+        actor: detail?.actor,
+        bytes:
+          detail?.update instanceof Uint8Array ? detail.update.length : null
+      })
+    }
+    const ids = currentDocNodeIds()
+    const added = [...ids].filter((id) => !knownDocNodeIds.has(id))
+    const removed = [...knownDocNodeIds].filter((id) => !ids.has(id))
+    if (added.length > 0 || removed.length > 0)
+      recordDevEvent('doc_nodes_changed', { added, removed })
+    knownDocNodeIds = ids
   }
   const onOpsResult: EventListener = (event) => {
     if (boundFrameDetail(event, subscribedWorkflowId.value) === null) return
     if (staleProbeTimer !== null) armStaleProbe()
     lastFrameType.value = event.type
+    if (event instanceof CustomEvent) {
+      lastOpsResult = event.detail ?? null
+      recordDevEvent('doc_ops_result', event.detail ?? null)
+    }
   }
   const onDocReset: EventListener = (event) => {
     if (boundFrameDetail(event, subscribedWorkflowId.value) === null) return
@@ -223,6 +291,11 @@ export function useAgentCrdtFollower(workflowId: Ref<string | null>) {
     updatesApplied.value = 0
     lastFrameType.value = event.type
     clearStaleProbe()
+    knownDocNodeIds = new Set()
+    recordDevEvent(
+      'doc_reset',
+      event instanceof CustomEvent ? (event.detail ?? null) : null
+    )
   }
   const onSchemaError: EventListener = (event) => {
     if (boundFrameDetail(event, subscribedWorkflowId.value) === null) return
@@ -232,6 +305,10 @@ export function useAgentCrdtFollower(workflowId: Ref<string | null>) {
     connected.value = false
     lastFrameType.value = event.type
     clearStaleProbe()
+    recordDevEvent(
+      'schema_error',
+      event instanceof CustomEvent ? (event.detail ?? null) : null
+    )
   }
   const onReconnected: EventListener = () => {
     // Same-lineage recovery: the bridge keeps its doc and catches up via its
@@ -240,6 +317,8 @@ export function useAgentCrdtFollower(workflowId: Ref<string | null>) {
     // EMPTY -> full against the already-materialized canvas and let LiteGraph
     // reassign IDs for duplicate adds.
     connected.value = false
+    clearStaleProbe()
+    recordDevEvent('reconnected', null)
     bridge.resubscribe()
     // The server might never acknowledge this subscribe. Keep probing until a
     // bound frame confirms the channel or lifecycle teardown cancels it.
@@ -293,6 +372,7 @@ export function useAgentCrdtFollower(workflowId: Ref<string | null>) {
         initialBind = false
         if (persisted !== null) {
           projectedWorkflowId = persisted
+          recordDevEvent('rebind', { workflowId: persisted })
           subscribedWorkflowId.value = persisted
           bridge.subscribe(persisted)
           return
@@ -306,8 +386,10 @@ export function useAgentCrdtFollower(workflowId: Ref<string | null>) {
       // A detach does not clear the user's active graph, so retaining this
       // snapshot prevents a same-workflow rebind from re-adding every node.
       // A true workflow change replaces the canvas and needs a fresh baseline.
-      if (projectedWorkflowId !== null && projectedWorkflowId !== next)
+      if (projectedWorkflowId !== null && projectedWorkflowId !== next) {
         projector.reset()
+        knownDocNodeIds = new Set()
+      }
       projectedWorkflowId = next
       subscribedWorkflowId.value = next
       bridge.subscribe(next)
@@ -324,6 +406,9 @@ export function useAgentCrdtFollower(workflowId: Ref<string | null>) {
     try {
       clearSubscribeRetry()
       clearStaleProbe()
+      if (import.meta.env.DEV) {
+        delete (window as unknown as Record<string, unknown>).__agentCrdtPoc
+      }
       api.removeEventListener('reconnected', onReconnected)
       api.removeEventListener('status', onSocketActivity)
       bridge.removeEventListener('doc_subscribed', onSubscribed)
@@ -337,6 +422,160 @@ export function useAgentCrdtFollower(workflowId: Ref<string | null>) {
       client.destroy()
     }
   })
+
+  // ── Dev-only console helper (installed only under import.meta.env.DEV) ───
+  // Lets the e2e proof mint a REAL human add_node op from the devtools console
+  // / Playwright without waiting for the canvas-command adapter. Mints the
+  // exact envelope the doc-host validates: op_id 32-hex, actor
+  // `human:<firebase-uid>:<tab>` (server recomputes and rejects mismatches),
+  // base_version = last doc_update seq, stamp [base_version, actor], and the
+  // full save-format node payload (inserted verbatim by the host applier).
+  // The sender tab does NOT apply locally — the doc_update echo is the only
+  // application, so there is no double-apply on this path.
+  const mintOpId = (): string => {
+    const bytes = crypto.getRandomValues(new Uint8Array(16))
+    return Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('')
+  }
+  const mintNodeId = (): number =>
+    2 ** 40 + Math.floor(Math.random() * (2 ** 52 - 2 ** 40))
+  const pocAddNode = (
+    classType: string,
+    pos: [number, number] = [100, 100],
+    nodeOverride?: Record<string, unknown>
+  ): DocOp => {
+    const userId = useAuthStore().userId ?? 'anonymous'
+    const actor = `human:${userId}:${tabId}`
+    const nodeId = mintNodeId()
+    let node: Record<string, unknown>
+    if (nodeOverride) {
+      node = { ...nodeOverride, id: nodeId, type: classType, pos }
+    } else {
+      let serialized: Record<string, unknown> | null = null
+      try {
+        const lgNode = LiteGraph.createNode(classType)
+        if (lgNode) {
+          lgNode.id = nodeId as unknown as typeof lgNode.id
+          lgNode.pos = [...pos]
+          serialized = lgNode.serialize() as unknown as Record<string, unknown>
+          // The doc host name-keys widgets via the pinned catalog's
+          // widget_order; litegraph's positional serialize() can emit MORE
+          // entries than the catalog names (e.g. LoadImage's upload-button
+          // slot), which the host rejects (invalid_node_payload). Name-keyed
+          // objects are accepted as-is (widgetsToYMap), and this litegraph
+          // already emits widgets_values_named alongside the positional
+          // array — send the named form and drop the extra key.
+          if (serialized.widgets_values_named != null) {
+            // Filter to real value-bearing widgets: the host's projection
+            // throws (opaque 500) on ANY key outside the pinned catalog's
+            // widget_order, and control widgets (e.g. LoadImage's `upload`
+            // button) serialize a named entry but are not in widget_order.
+            const named = serialized.widgets_values_named as Record<
+              string,
+              unknown
+            >
+            const filtered: Record<string, unknown> = {}
+            for (const [name, value] of Object.entries(named)) {
+              const w = lgNode.widgets?.find((x) => x.name === name)
+              if (w && w.type !== 'button' && w.serialize !== false) {
+                filtered[name] = value
+              }
+            }
+            serialized.widgets_values = filtered
+            delete serialized.widgets_values_named
+          }
+        }
+      } catch {
+        serialized = null
+      }
+      node = serialized
+        ? { ...serialized, id: nodeId, type: classType, pos }
+        : { id: nodeId, type: classType, pos, size: [270, 100] }
+    }
+    const baseVersion = lastSeq
+    const op: DocOp = {
+      op: 'add_node',
+      op_id: mintOpId(),
+      actor,
+      base_version: baseVersion,
+      stamp: [baseVersion, actor],
+      node_id: nodeId,
+      class_type: classType,
+      pos,
+      node
+    }
+    bridge.sendHumanOps(tabId, [op])
+    return op
+  }
+  // Same envelope/actor path as pocAddNode, for the delete_node op. The host
+  // rejects actors whose userId doesn't match the authenticated session, so
+  // this must mint from useAuthStore() exactly like pocAddNode does.
+  const pocDeleteNode = (
+    nodeId: number,
+    removedLinks: number[] = []
+  ): DocOp => {
+    const userId = useAuthStore().userId ?? 'anonymous'
+    const actor = `human:${userId}:${tabId}`
+    const baseVersion = lastSeq
+    const op: DocOp = {
+      op: 'delete_node',
+      op_id: mintOpId(),
+      actor,
+      base_version: baseVersion,
+      stamp: [baseVersion, actor],
+      node_id: nodeId,
+      removed_links: removedLinks
+    }
+    bridge.sendHumanOps(tabId, [op])
+    return op
+  }
+  const pocHelpers = {
+    addNode: pocAddNode,
+    deleteNode: pocDeleteNode,
+    // Bind a fresh tab to an existing doc without waiting for a turn ack
+    // (gap #2: doc id is otherwise in-memory only, set on turn ack). Drives
+    // the same watch → bridge.subscribe path as the real binding.
+    bindDoc: (id: string) => {
+      // Mirror the watch path so status/persistence agree with the binding
+      // (otherwise the dev panel shows "no document" on a live subscription).
+      clearSubscribeRetry()
+      subscribedWorkflowId.value = id
+      bridge.subscribe(id)
+    },
+    sendOps: (ops: DocOp[]) => bridge.sendHumanOps(tabId, ops),
+    resubscribe: () => bridge.resubscribe(),
+    reconcile: () => bridge.reconcile(),
+    project: () => projector.project(bridge.follower.doc),
+    tabId,
+    get lastSeq() {
+      return lastSeq
+    },
+    get lastOpsResult() {
+      return lastOpsResult
+    },
+    docNodes: () => {
+      const doc = bridge.follower.doc as unknown as {
+        getMap: (k: string) => { toJSON: () => Record<string, unknown> }
+      }
+      try {
+        return doc.getMap('nodes').toJSON()
+      } catch {
+        return null
+      }
+    },
+    get status() {
+      return {
+        enabled: true,
+        connected: connected.value,
+        workflowId: subscribedWorkflowId.value,
+        updatesApplied: updatesApplied.value,
+        lastFrameType: lastFrameType.value
+      }
+    }
+  }
+  if (import.meta.env.DEV) {
+    ;(window as unknown as Record<string, unknown>).__agentCrdtPoc = pocHelpers
+  }
+  // ──────────────────────────────────────────────────────────────────────────
 
   const status = computed<AgentCrdtStatus>(() => ({
     enabled: true,

--- a/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.ts
+++ b/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.ts
@@ -323,12 +323,12 @@ export function useAgentCrdtFollower(workflowId: Ref<string | null>) {
     recordDevEvent('doc_subscribed', detail)
     if (ok) {
       clearSubscribeRetry()
-      armStaleProbe()
-      // FE-1902 (poc-3): only a CONFIRMED binding is worth rebinding to after
-      // a remount — persist on ok, not on intent. The arm applies the same
-      // rule: the bridge re-dispatches a confirm even when the workflow was
-      // just dropped, and a stale confirm must not arm an unbound graph.
+      // FE-1902 (poc-3): only a CONFIRMED binding is worth acting on after a
+      // remount — the bridge re-dispatches a confirm even when the workflow
+      // was just dropped, so the stale probe, the id arm, and the persist
+      // all apply the same currently-bound rule.
       if (subscribedWorkflowId.value !== null) {
+        armStaleProbe()
         armCoordinationFreeIds()
         persistDocId(subscribedWorkflowId.value)
       }
@@ -340,6 +340,9 @@ export function useAgentCrdtFollower(workflowId: Ref<string | null>) {
   const onUpdate: EventListener = (event) => {
     if (boundFrameDetail(event, subscribedWorkflowId.value) === null) return
     if (staleProbeTimer !== null) armStaleProbe()
+    // An update proves the binding is live: the retry budget and the
+    // silent-server failsafe must not outlive it.
+    clearSubscribeRetry()
     armCoordinationFreeIds()
     updatesApplied.value = bridge.follower.updatesApplied
     lastFrameType.value = event.type

--- a/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.ts
+++ b/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.ts
@@ -95,6 +95,42 @@ export const apiTransport: DocFrameTransport = {
   }
 }
 
+/**
+ * Frame type, workflow correlation, op ids/types, counts, and byte size -
+ * never the payload itself.
+ */
+export function summarizeOutboundDocFrame(
+  frame: string
+): Record<string, unknown> {
+  const summary: Record<string, unknown> = { bytes: frame.length }
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(frame)
+  } catch {
+    return summary
+  }
+  if (typeof parsed !== 'object' || parsed === null) return summary
+  const { type, data } = parsed as { type?: unknown; data?: unknown }
+  if (typeof type === 'string') summary.type = type
+  if (typeof data !== 'object' || data === null) return summary
+  const { workflow_id, ops } = data as { workflow_id?: unknown; ops?: unknown }
+  if (typeof workflow_id === 'string') summary.workflow_id = workflow_id
+  if (Array.isArray(ops)) {
+    summary.op_count = ops.length
+    summary.ops = ops.map((op) => {
+      const record =
+        typeof op === 'object' && op !== null
+          ? (op as { op_id?: unknown; op?: unknown })
+          : {}
+      return {
+        ...(typeof record.op_id === 'string' && { op_id: record.op_id }),
+        ...(typeof record.op === 'string' && { op: record.op })
+      }
+    })
+  }
+  return summary
+}
+
 export function useAgentCrdtFollower(workflowId: Ref<string | null>) {
   const connected = ref(false)
   const updatesApplied = ref(0)
@@ -103,17 +139,17 @@ export function useAgentCrdtFollower(workflowId: Ref<string | null>) {
 
   // Dev-panel tap (poc-4): log every outbound frame with its delivery result.
   // Wraps locally instead of modifying the exported apiTransport, whose
-  // never-throw contract is covered by tests.
+  // never-throw contract is covered by tests. Only frame METADATA is
+  // recorded: a doc_ops payload carries node and widget values (prompts,
+  // filenames), which is more user data than the debugging panel needs even
+  // in a development build.
   const transport: DocFrameTransport = {
     send(frame) {
       const delivered = apiTransport.send(frame)
-      let parsed: unknown = frame
-      try {
-        parsed = JSON.parse(frame)
-      } catch {
-        // Leave the raw string.
-      }
-      recordDevEvent('ws_out', { delivered, frame: parsed })
+      recordDevEvent('ws_out', {
+        delivered,
+        ...summarizeOutboundDocFrame(frame)
+      })
       return delivered
     },
     addEventListener(type, listener) {

--- a/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.ts
+++ b/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.ts
@@ -1,7 +1,11 @@
 import { computed, onBeforeUnmount, readonly, ref, watch } from 'vue'
 import type { Ref } from 'vue'
 
-import { setCoordinationFreeIds } from '@/lib/litegraph/src/idAllocation'
+import {
+  mintCoordinationFreeId,
+  setCoordinationFreeIds
+} from '@/lib/litegraph/src/idAllocation'
+import type { LGraphState } from '@/lib/litegraph/src/idAllocation'
 import { LiteGraph } from '@/lib/litegraph/src/litegraph'
 import { api } from '@/scripts/api'
 import { app } from '@/scripts/app'
@@ -179,6 +183,27 @@ export function useAgentCrdtFollower(workflowId: Ref<string | null>) {
   })
   const projector = new SemanticProjector(mutator, { actor: tabId })
 
+  // Arming is graph-scoped: the doc projects onto `app.graph`, so only THAT
+  // graph's state mints coordination-free ids. `LGraph.clear()` replaces the
+  // state object on every workflow load, which drops the arm (fails closed);
+  // re-arming rides the frames that prove the binding is live - the
+  // subscribe confirm and every doc_update - so a swapped-in graph is armed
+  // again by the next doc frame and an unbound graph is never armed at all.
+  let armedIdState: LGraphState | null = null
+
+  function armCoordinationFreeIds(): void {
+    const state = app.graph?.state ?? null
+    if (armedIdState !== null && armedIdState !== state)
+      setCoordinationFreeIds(armedIdState, false)
+    armedIdState = state
+    if (state !== null) setCoordinationFreeIds(state, true)
+  }
+
+  function disarmCoordinationFreeIds(): void {
+    if (armedIdState !== null) setCoordinationFreeIds(armedIdState, false)
+    armedIdState = null
+  }
+
   // Dev-panel tap (poc-4): track the doc's node-id set so the panel can show
   // exactly which nodes each doc_update added/removed. Rebuilt from zero on
   // doc_reset (remint) because the lineage broke.
@@ -240,7 +265,12 @@ export function useAgentCrdtFollower(workflowId: Ref<string | null>) {
 
   const scheduleSubscribeRetry = (): void => {
     if (subscribeRetryTimer !== null) return
-    if (subscribeRetryAttempt >= SUBSCRIBE_RETRY_MAX_ATTEMPTS) return
+    if (subscribeRetryAttempt >= SUBSCRIBE_RETRY_MAX_ATTEMPTS) {
+      // Definitive binding failure: the budget is spent, so the doc is not
+      // coming. Restore counter allocation until a later confirm re-arms.
+      disarmCoordinationFreeIds()
+      return
+    }
     const target = subscribedWorkflowId.value
     if (target === null) return
     const delay = SUBSCRIBE_RETRY_BASE_MS * 2 ** subscribeRetryAttempt
@@ -267,6 +297,7 @@ export function useAgentCrdtFollower(workflowId: Ref<string | null>) {
     if (ok) {
       clearSubscribeRetry()
       armStaleProbe()
+      armCoordinationFreeIds()
       // FE-1902 (poc-3): only a CONFIRMED binding is worth rebinding to after
       // a remount — persist on ok, not on intent.
       if (subscribedWorkflowId.value !== null)
@@ -279,6 +310,7 @@ export function useAgentCrdtFollower(workflowId: Ref<string | null>) {
   const onUpdate: EventListener = (event) => {
     if (boundFrameDetail(event, subscribedWorkflowId.value) === null) return
     if (staleProbeTimer !== null) armStaleProbe()
+    armCoordinationFreeIds()
     updatesApplied.value = bridge.follower.updatesApplied
     lastFrameType.value = event.type
     if (event instanceof CustomEvent && typeof event.detail?.seq === 'number')
@@ -342,6 +374,7 @@ export function useAgentCrdtFollower(workflowId: Ref<string | null>) {
     connected.value = false
     lastFrameType.value = event.type
     clearStaleProbe()
+    disarmCoordinationFreeIds()
     recordDevEvent(
       'schema_error',
       event instanceof CustomEvent ? (event.detail ?? null) : null
@@ -412,13 +445,13 @@ export function useAgentCrdtFollower(workflowId: Ref<string | null>) {
           recordDevEvent('rebind', { workflowId: persisted })
           subscribedWorkflowId.value = persisted
           bridge.subscribe(persisted)
-          setCoordinationFreeIds(true)
+          armCoordinationFreeIds()
           return
         }
         clearPersistedDocId()
         subscribedWorkflowId.value = null
         bridge.unsubscribe()
-        setCoordinationFreeIds(false)
+        disarmCoordinationFreeIds()
         return
       }
       initialBind = false
@@ -435,7 +468,7 @@ export function useAgentCrdtFollower(workflowId: Ref<string | null>) {
       // Doc-bound workflows allocate contract-scheme (coordination-free) node
       // and link ids at local creation, so replicas seeded from one snapshot
       // cannot mint colliding ids; a real detach restores the counters.
-      setCoordinationFreeIds(true)
+      armCoordinationFreeIds()
     },
     { immediate: true }
   )
@@ -447,7 +480,7 @@ export function useAgentCrdtFollower(workflowId: Ref<string | null>) {
     // failure-tolerant by construction now, but the try/finally makes the
     // "client.destroy() always runs" guarantee local and readable.
     try {
-      setCoordinationFreeIds(false)
+      disarmCoordinationFreeIds()
       clearSubscribeRetry()
       clearStaleProbe()
       if (import.meta.env.DEV) {
@@ -480,8 +513,6 @@ export function useAgentCrdtFollower(workflowId: Ref<string | null>) {
     const bytes = crypto.getRandomValues(new Uint8Array(16))
     return Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('')
   }
-  const mintNodeId = (): number =>
-    2 ** 40 + Math.floor(Math.random() * (2 ** 52 - 2 ** 40))
   const pocAddNode = (
     classType: string,
     pos: [number, number] = [100, 100],
@@ -489,7 +520,7 @@ export function useAgentCrdtFollower(workflowId: Ref<string | null>) {
   ): DocOp => {
     const userId = useAuthStore().userId ?? 'anonymous'
     const actor = `human:${userId}:${tabId}`
-    const nodeId = mintNodeId()
+    const nodeId = mintCoordinationFreeId()
     let node: Record<string, unknown>
     if (nodeOverride) {
       node = { ...nodeOverride, id: nodeId, type: classType, pos }

--- a/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.ts
+++ b/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.ts
@@ -10,6 +10,7 @@ import { LiteGraph } from '@/lib/litegraph/src/litegraph'
 import { api } from '@/scripts/api'
 import { app } from '@/scripts/app'
 import { useAuthStore } from '@/stores/authStore'
+import { createUuidv4 } from '@/utils/uuid'
 
 import { recordDevEvent } from './devPanelLog'
 import type { DocFrameTransport, DocOp } from './docFrameClient'
@@ -177,7 +178,7 @@ export function useAgentCrdtFollower(workflowId: Ref<string | null>) {
   }
   const client = new DocFrameClient(transport)
   const bridge = new LayoutFollowerBridge(client)
-  const tabId = crypto.randomUUID()
+  const tabId = createUuidv4()
   // Highest doc_update seq seen — used as base_version for human-minted ops.
   // The ws path has no ceiling gate; this only feeds LWW stamps, so a slightly
   // stale value is safe (ties break by [base_version, actor, op_id]).

--- a/src/workbench/extensions/agent/crdt/widgetMintPort.test.ts
+++ b/src/workbench/extensions/agent/crdt/widgetMintPort.test.ts
@@ -1,0 +1,144 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { GraphOperation } from './graphOperations'
+import { createMintSession } from './mintSession'
+import type { MintSession } from './mintSession'
+import { attachWidgetMintPort } from './widgetMintPort'
+import type { WidgetMintPort, WidgetSetView } from './widgetMintPort'
+
+const ROOT = 'root-uuid'
+
+function widgetSet(overrides: Partial<WidgetSetView> = {}): WidgetSetView {
+  return {
+    graphId: ROOT,
+    nodeId: '7',
+    name: 'seed',
+    value: 42,
+    old: 3,
+    ...overrides
+  }
+}
+
+describe('attachWidgetMintPort', () => {
+  let minted: GraphOperation[]
+  let port: WidgetMintPort
+  let enabled: boolean
+  let bound: boolean
+  let root: string | null
+  let interiorPaths: Map<string, string[]>
+  let session: MintSession
+  let listeners: Set<(set: WidgetSetView) => void>
+
+  function deliver(set: WidgetSetView): void {
+    for (const listener of listeners) listener(set)
+  }
+
+  beforeEach(() => {
+    minted = []
+    enabled = true
+    bound = true
+    root = ROOT
+    interiorPaths = new Map()
+    session = createMintSession()
+    listeners = new Set()
+    port = attachWidgetMintPort({
+      events: {
+        onSet: (listener) => {
+          listeners.add(listener)
+          return () => listeners.delete(listener)
+        }
+      },
+      session,
+      isEnabled: () => enabled,
+      isDocBound: () => bound,
+      rootGraphId: () => root,
+      resolveInteriorPath: (owningGraphId) =>
+        interiorPaths.get(owningGraphId) ?? null,
+      enqueue: (operations) => minted.push(...operations)
+    })
+  })
+
+  it('mints a name-keyed top-level set_widget with the old value', () => {
+    deliver(widgetSet())
+
+    expect(minted).toEqual([
+      { op: 'set_widget', node_id: '7', widget: 'seed', value: 42, old: 3 }
+    ])
+  })
+
+  it('never mints inside the remote-apply scope (KA-6 sender half)', () => {
+    session.runRemoteApply(() => deliver(widgetSet()))
+
+    expect(minted).toEqual([])
+  })
+
+  it('never mints with the product flag off', () => {
+    enabled = false
+    deliver(widgetSet())
+
+    expect(minted).toEqual([])
+  })
+
+  it('never mints without a bound doc', () => {
+    bound = false
+    deliver(widgetSet())
+
+    expect(minted).toEqual([])
+  })
+
+  it('never mints inside a graph-teardown bracket (restoration writes are inert)', () => {
+    session.beginGraphTeardown()
+    deliver(widgetSet())
+    session.endGraphTeardown()
+
+    expect(minted).toEqual([])
+  })
+
+  it('mints an interior set_widget with the resolved node path', () => {
+    interiorPaths.set('subgraph-uuid', ['57'])
+
+    deliver(widgetSet({ graphId: 'subgraph-uuid', nodeId: '27' }))
+
+    expect(minted).toEqual([
+      {
+        op: 'set_widget',
+        node_id: '27',
+        widget: 'seed',
+        value: 42,
+        old: 3,
+        path: ['57', '27'],
+        inner_widget: 'seed'
+      }
+    ])
+  })
+
+  it('surfaces an unresolvable interior write observably instead of minting', () => {
+    const consoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined)
+    deliver(widgetSet({ graphId: 'subgraph-uuid' }))
+
+    expect(minted).toEqual([])
+    expect(consoleError).toHaveBeenCalledOnce()
+    consoleError.mockRestore()
+  })
+
+  it('surfaces a write with no open root graph observably', () => {
+    const consoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined)
+    root = null
+    deliver(widgetSet())
+
+    expect(minted).toEqual([])
+    expect(consoleError).toHaveBeenCalledOnce()
+    consoleError.mockRestore()
+  })
+
+  it('stops minting after detach', () => {
+    port.detach()
+    deliver(widgetSet())
+
+    expect(minted).toEqual([])
+  })
+})

--- a/src/workbench/extensions/agent/crdt/widgetMintPort.ts
+++ b/src/workbench/extensions/agent/crdt/widgetMintPort.ts
@@ -1,0 +1,103 @@
+/**
+ * set_widget from the widgetValueStore setValue seam - NAME-KEYED by
+ * construction (WidgetId is graphId:nodeId:name; FE-1904). Subgraph-owned
+ * writes mint the interior form (path = resolved node-id chain,
+ * inner_widget = the name); an unresolvable owner surfaces, never drops.
+ */
+import type { GraphOperation } from './graphOperations'
+import { shouldMint } from './mintGate'
+import type { MintSession } from './mintSession'
+
+export interface WidgetSetView {
+  /** Owning (sub)graph uuid from the widget id. */
+  graphId: string
+  /** Node id local to the owning graph, decoded from the widget id. */
+  nodeId: string | number
+  /** Widget NAME, decoded from the widget id - never an index. */
+  name: string
+  value: unknown
+  /** Value before the write (informational `old` on the wire op). */
+  old: unknown
+}
+
+interface WidgetEventFeed {
+  /** Fires after a `setValue` that actually applied (the action returned true). */
+  onSet(listener: (set: WidgetSetView) => void): () => void
+}
+
+export interface WidgetMintPortDeps {
+  events: WidgetEventFeed
+  session: MintSession
+  /** Slice 00's product gate. */
+  isEnabled(): boolean
+  /** A semantic doc is bound for the active workflow. */
+  isDocBound(): boolean
+  /** The active root graph id, or null when no workflow is open. */
+  rootGraphId(): string | null
+  /**
+   * Subgraph-node id chain from the root to the definition owning
+   * `owningGraphId`, or null when unreachable (wiring resolves it over the
+   * live graph).
+   */
+  resolveInteriorPath(owningGraphId: string): string[] | null
+  /** Receives minted semantic operations (the sender's inbox). */
+  enqueue(operations: GraphOperation[]): void
+}
+
+export interface WidgetMintPort {
+  detach(): void
+}
+
+export function attachWidgetMintPort(deps: WidgetMintPortDeps): WidgetMintPort {
+  function onSet(set: WidgetSetView): void {
+    const mintable = shouldMint({
+      flagEnabled: deps.isEnabled(),
+      docBound: deps.isDocBound(),
+      localProvenance: !deps.session.inRemoteApply(),
+      teardown: deps.session.inTeardown()
+    })
+    if (!mintable) return
+
+    const root = deps.rootGraphId()
+    if (root !== null && set.graphId === root) {
+      deps.enqueue([
+        {
+          op: 'set_widget',
+          node_id: set.nodeId,
+          widget: set.name,
+          value: set.value,
+          old: set.old
+        }
+      ])
+      return
+    }
+
+    const subgraphNodePath =
+      root === null ? null : deps.resolveInteriorPath(set.graphId)
+    if (subgraphNodePath === null || subgraphNodePath.length === 0) {
+      // The doc no longer matches the local graph; observable, never silent
+      // (the surfacing-honesty principle).
+      console.error(
+        '[agent-crdt] set_widget with an unresolvable owner not minted; the bound doc diverges from the local graph',
+        `${set.graphId}:${String(set.nodeId)}:${set.name}`
+      )
+      return
+    }
+
+    const [head, ...rest] = subgraphNodePath
+    deps.enqueue([
+      {
+        op: 'set_widget',
+        node_id: set.nodeId,
+        widget: set.name,
+        value: set.value,
+        old: set.old,
+        path: [head, ...rest, String(set.nodeId)],
+        inner_widget: set.name
+      }
+    ])
+  }
+
+  const detach = deps.events.onSet(onSet)
+  return { detach }
+}

--- a/src/workbench/extensions/agent/crdt/writeLegInvariants.property.test.ts
+++ b/src/workbench/extensions/agent/crdt/writeLegInvariants.property.test.ts
@@ -1,0 +1,147 @@
+import type { Op } from '@comfyorg/comfy-multi-player'
+import * as fc from 'fast-check'
+import { describe, expect, it, vi } from 'vitest'
+
+import type { GraphOperation } from './graphOperations'
+import { mintWireOps } from './opEnvelope'
+import type { OpsResultView } from './opSender'
+import { createOpSender } from './opSender'
+
+const WORKFLOW_ID = 'property-workflow'
+const TAB = 'property-tab'
+const ACTOR = 'human:property-user:property-tab'
+
+type AddNodeOperation = Extract<GraphOperation, { op: 'add_node' }>
+
+function addNode(id: number): AddNodeOperation {
+  return {
+    op: 'add_node',
+    node_id: id,
+    class_type: 'PropertyNode',
+    pos: [id, -id],
+    node: { id, type: 'PropertyNode', marker: id }
+  }
+}
+
+const arbOperations = fc
+  .uniqueArray(fc.integer({ min: 1, max: 1_000_000 }), {
+    minLength: 1,
+    maxLength: 40
+  })
+  .map((ids) => ids.map(addNode))
+
+describe('CRDT human write-leg invariants (property)', () => {
+  it('mints one unique complete causal identity per operation', () => {
+    fc.assert(
+      fc.property(
+        arbOperations,
+        fc.nat({ max: Number.MAX_SAFE_INTEGER }),
+        (operations, baseVersion) => {
+          const minted = mintWireOps(operations, {
+            actor: ACTOR,
+            baseVersion
+          })
+
+          expect(new Set(minted.map((op) => op.op_id))).toHaveLength(
+            operations.length
+          )
+          for (const op of minted) {
+            expect(op.op_id).toMatch(/^[0-9a-f]{32}$/)
+            expect(op.actor).toBe(ACTOR)
+            expect(op.base_version).toBe(baseVersion)
+            expect(op.stamp).toEqual([baseVersion, ACTOR])
+          }
+        }
+      )
+    )
+  })
+
+  it('serializes arbitrary operation sequences in causal mint order', () => {
+    fc.assert(
+      fc.property(arbOperations, (operations) => {
+        const sent: Op[][] = []
+        let resultListener = (_result: OpsResultView): void => {
+          throw new Error('Expected an operation-result listener')
+        }
+        const sender = createOpSender({
+          sendOps: (_workflowId, _tab, ops) => {
+            sent.push(ops)
+            return true
+          },
+          onOpsResult: (listener) => {
+            resultListener = listener
+            return () => {}
+          },
+          workflowId: () => WORKFLOW_ID,
+          tab: TAB,
+          actor: () => ACTOR,
+          baseVersion: () => 41,
+          onBatchSettled: () => {}
+        })
+
+        for (const operation of operations) {
+          sender.enqueue([operation])
+          const latest = sent.at(-1)
+          if (!latest) throw new Error('Expected an in-flight operation')
+          resultListener({
+            workflowId: WORKFLOW_ID,
+            ok: true,
+            applied: [latest[0].op_id],
+            skipped: []
+          })
+        }
+
+        const delivered = sent.flat()
+        expect(
+          delivered.map((op) => {
+            if (op.op !== 'add_node') throw new Error('Expected add_node')
+            return op.node_id
+          })
+        ).toEqual(operations.map((operation) => operation.node_id))
+        for (let index = 1; index < delivered.length; index++) {
+          expect(delivered[index].op_id > delivered[index - 1].op_id).toBe(true)
+        }
+        expect(sender.pending()).toBe(0)
+        sender.detach()
+      })
+    )
+  })
+
+  it('retries transport failures and result silence without reminting', () => {
+    vi.useFakeTimers()
+    fc.assert(
+      fc.property(
+        arbOperations,
+        fc.integer({ min: 1, max: 4 }),
+        (operations, failedAttempts) => {
+          const attempts: Op[][] = []
+          let callCount = 0
+          const sender = createOpSender({
+            sendOps: (_workflowId, _tab, ops) => {
+              attempts.push(ops)
+              callCount += 1
+              return callCount > failedAttempts
+            },
+            onOpsResult: () => () => {},
+            workflowId: () => WORKFLOW_ID,
+            tab: TAB,
+            actor: () => ACTOR,
+            baseVersion: () => 73,
+            onBatchSettled: () => {}
+          })
+
+          sender.enqueue(operations)
+          vi.advanceTimersByTime(failedAttempts * 500)
+          expect(attempts).toHaveLength(failedAttempts + 1)
+          const minted = attempts[0]
+          for (const attempt of attempts) expect(attempt).toEqual(minted)
+
+          vi.advanceTimersByTime(10_000)
+          expect(attempts.at(-1)).toEqual(minted)
+          expect(attempts).toHaveLength(failedAttempts + 2)
+          sender.detach()
+        }
+      )
+    )
+  })
+})


### PR DESCRIPTION
Merge after: #16135 (02a) - stacked on its branch; retargets when it lands.
Decisions: [Agent V1 Decision Log](https://app.notion.com/p/3c96d73d36508190b607d51ed9eeb3af)

## Summary

The human write leg of the CRDT foundation, split out of #16135 so the follower (read leg) and the write leg get separate reviews. This branch restores the write-leg half of the reviewed integration state: the union of this branch and #16135 is byte-identical to the pre-split head (tree-hash verified).

## Changes

- **What**:
  - Nine write-leg modules under `src/workbench/extensions/agent/crdt/`: op envelope minting, mint gate and session, layout/link/widget mint ports, port wiring, serialized op sender - human edits mint semantic ops into the shared doc.
  - Their seams: the two documented `ComfyExtension` load hooks, `layoutStore.withActor`, a graph-traversal helper, four agent prompt-error registrations (resolver + en locale).
  - Dev instrumentation beside what it debugs: the CRDT dev panel + event log (dev builds only) and the cloud E2E run sheet.

## Review Focus

- This half is new design relative to the follower: it is the fix for the agent-goes-stale bug class (human edits reaching the agent's model). The follower PR carries the lineage you proposed; this one is the part that needs design review.
- Nothing mounts or activates at this head: zero production importers; activation rides the later agent slices behind the product flag.
- The load hooks fire on every graph load but nothing registers them (no-ops); the mint bracket fails closed and recovers on the next successful load.
- CRDT protocol semantics herein describe what shipped; protocol decisions ride Christian's decision stream - divergences from his stream are open questions for him, not this PR's calls.

## Linear tickets

* [FE-1330](https://linear.app/comfyorg/issue/FE-1330) - CRDT architecture implementation, frontend (human write leg)
* [FE-1770](https://linear.app/comfyorg/issue/FE-1770) - registers the four transport error types this slice adds; the recognition and grouping work lands in 06
