### PR TITLE
[backport cloud/1.52] fix(billing): harden sales-managed rendering against unreadable capabilities

### DIFF
--- a/browser_tests/tests/dialogs/enterpriseTierCloud.spec.ts
+++ b/browser_tests/tests/dialogs/enterpriseTierCloud.spec.ts
@@ -9,6 +9,7 @@ import { cloudAppFixture as test } from '@e2e/fixtures/cloudAppFixture'
 import { TopUpCreditsDialog } from '@e2e/fixtures/components/TopUpCreditsDialog'
 import {
   DEFAULT_TEAM_MEMBERS,
+  INACTIVE_TEAM_BILLING_STATUS,
   TEAM_BILLING_STATUS,
   TEAM_WORKSPACE
 } from '@e2e/fixtures/data/cloudWorkspace'
@@ -207,6 +208,12 @@ test.describe('Enterprise workspace billing', { tag: '@cloud' }, () => {
     await expect(
       page.getByRole('heading', { name: 'Choose a Plan' })
     ).toHaveCount(0)
+    await expect(page.locator('.p-toast-message-warn')).toContainText(
+      'Plan inactive'
+    )
+    await expect(page.locator('.p-toast-message-warn')).toContainText(
+      'Contact your Comfy account manager to restore access.'
+    )
   })
 })
 
@@ -246,6 +253,46 @@ test.describe('Non-Enterprise billing regression', { tag: '@cloud' }, () => {
         .getByTestId('current-user-popover')
         .getByTestId('plans-pricing-menu-item')
     ).toBeVisible()
+  })
+
+  test('keeps the pricing deep link available during a capability outage', async ({
+    page
+  }) => {
+    const workspace = new CloudWorkspaceMockHelper(page)
+    await workspace.setup(DEFAULT_TEAM_MEMBERS, TEAM_WORKSPACE)
+    await page.route('**/api/billing/capabilities', (route) =>
+      route.fulfill({ status: 503 })
+    )
+
+    await page.goto(`${APP_URL}/?pricing=team`)
+
+    await expect(
+      page.getByRole('heading', { name: 'Plans for Team Workspace' })
+    ).toBeVisible({ timeout: 45_000 })
+    await expect(page).not.toHaveURL(/[?&]pricing=/)
+  })
+
+  test('keeps inactive credits disabled during a capability outage', async ({
+    page
+  }) => {
+    const workspace = new CloudWorkspaceMockHelper(page)
+    await workspace.setup(
+      DEFAULT_TEAM_MEMBERS,
+      TEAM_WORKSPACE,
+      INACTIVE_TEAM_BILLING_STATUS
+    )
+    await page.route('**/api/billing/capabilities', (route) =>
+      route.fulfill({ status: 503 })
+    )
+
+    const content = await workspace.openPlanAndCreditsSettings()
+
+    await expect(
+      content.getByText('Reactivate your plan to use these credits')
+    ).toBeVisible()
+    await expect(
+      content.getByRole('button', { name: 'Add credits' })
+    ).toHaveCount(0)
   })
 })
 

--- a/src/composables/useCoreCommands.test.ts
+++ b/src/composables/useCoreCommands.test.ts
@@ -737,7 +737,7 @@ describe('useCoreCommands', () => {
     )
 
     it.for(['ENTERPRISE', 'GALACTIC'] as const)(
-      'blocks the run without a subscribe dialog on a sales-managed %s plan',
+      'explains the block instead of a subscribe dialog on a sales-managed %s plan',
       async (tier) => {
         mockDistributionState.isCloud = true
         mockBillingState.canAccessSubscriptionFeatures = false
@@ -747,6 +747,9 @@ describe('useCoreCommands', () => {
 
         expect(app.queuePrompt).not.toHaveBeenCalled()
         expect(mockBillingState.showSubscriptionDialog).not.toHaveBeenCalled()
+        expect(mockToastAdd).toHaveBeenCalledWith(
+          expect.objectContaining({ severity: 'warn' })
+        )
       }
     )
 

--- a/src/composables/useCoreCommands.ts
+++ b/src/composables/useCoreCommands.ts
@@ -82,7 +82,14 @@ export function useCoreCommands(): ComfyCommand[] {
 
   function blockRunWithoutSubscription(): boolean {
     if (!isCloud || canAccessSubscriptionFeatures.value) return false
-    if (!isSalesManagedTier(subscription.value?.tier)) {
+    if (isSalesManagedTier(subscription.value?.tier)) {
+      toastStore.add({
+        severity: 'warn',
+        summary: t('subscription.salesManagedRunBlockedTitle'),
+        detail: t('subscription.salesManagedRunBlockedDetail'),
+        life: 5000
+      })
+    } else {
       showSubscriptionDialog({ reason: 'subscribe_to_run' })
     }
     return true

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2869,6 +2869,8 @@
     "planLoadErrorRetry": "Try again",
     "teamPlanName": "Team",
     "unknownTierName": "Current plan",
+    "salesManagedRunBlockedTitle": "Plan inactive",
+    "salesManagedRunBlockedDetail": "This workspace's plan is no longer active. Contact your Comfy account manager to restore access.",
     "teamPlanIncludes": "Your plan includes everything in {plan}, plus:",
     "inactiveTeamTitle": "Inactive team subscription",
     "inactiveTeamDescription": "Reactivate your team plan to add more members and run workflows",

--- a/src/platform/cloud/subscription/components/CreditsTile.test.ts
+++ b/src/platform/cloud/subscription/components/CreditsTile.test.ts
@@ -348,11 +348,11 @@ describe('CreditsTile', () => {
     expect(screen.queryByText('Add credits')).toBeNull()
   })
 
-  it('shows disabled credit details for an inactive plan', () => {
+  it('shows disabled credit details for an inactive plan even while top-up reads open', () => {
     activeProSubscription()
-    // Lapsed self-serve plans withhold top-up server-side
-    // (lapsedSelfServeCapabilities), which is what zeroes the tile.
-    state.canTopUp = false
+    // canTopUp fails open for owners on an unreadable snapshot, so a lapsed
+    // self-serve plan must keep this state on tier alone.
+    state.canTopUp = true
     const { container } = renderTile({ inactivePlan: true })
 
     expect(container.textContent).toContain('0remaining')
@@ -365,8 +365,8 @@ describe('CreditsTile', () => {
 
   it('keeps Add credits and the real balance on an inactive sales-managed plan', () => {
     activeProSubscription()
-    // hideLifecycleCapabilities keeps top-up open for Enterprise whatever the
-    // subscription row says, so the inactive zero-state must not apply.
+    // A sales-managed plan has no self-serve reactivation to sell, so the
+    // reactivate-to-use-credits treatment must not apply.
     state.canTopUp = true
     state.tier = 'ENTERPRISE'
     state.subscription = {

--- a/src/platform/cloud/subscription/components/CreditsTile.vue
+++ b/src/platform/cloud/subscription/components/CreditsTile.vue
@@ -291,11 +291,13 @@ const creditPoolTotalCredits = computed<number | null>(() => {
     : monthlyCredits
 })
 
-// The server keeps top-up open for sales-managed plans whatever their
-// subscription row says, so their real balance must never be zeroed into the
-// reactivate-to-use-credits treatment reserved for lapsed self-serve plans.
+// The reactivate-to-use-credits treatment sells a self-serve reactivation, so
+// it applies only where one exists. Tier decides that, as it does for the
+// credit pool above: can_top_up is a rollout-defaulted capability that also
+// fails open for owners on an unreadable snapshot, which would drop a lapsed
+// self-serve team out of this state during a capabilities outage.
 const showsInactivePlanState = computed(
-  () => inactivePlan === true && !canTopUp.value
+  () => inactivePlan === true && !isSalesManagedTier(subscription.value?.tier)
 )
 
 const usage = computed(() =>

--- a/src/platform/cloud/subscription/constants/tierPricing.ts
+++ b/src/platform/cloud/subscription/constants/tierPricing.ts
@@ -127,7 +127,7 @@ export function getTierPrice(tierKey: TierKey, isYearly = false): number {
 export function getTierCredits(tierKey: TierKey): number | null {
   if (tierKey === 'free') return remoteConfig.value.free_tier_credits ?? null
   if (tierKey === 'founder') return FOUNDER_MONTHLY_CREDITS
-  return TIER_PRICING[tierKey].credits
+  return TIER_PRICING[tierKey]?.credits ?? null
 }
 
 export function getTierFeatures(tierKey: TierKey): TierFeatures {

--- a/src/platform/workspace/components/SubscriptionPanelContentWorkspace.test.ts
+++ b/src/platform/workspace/components/SubscriptionPanelContentWorkspace.test.ts
@@ -884,6 +884,19 @@ describe('SubscriptionPanelContentWorkspace', () => {
     expect(mockResubscribe).not.toHaveBeenCalled()
   })
 
+  it('keeps ended Team credits inactive when self-serve capabilities are unavailable', () => {
+    mockSubscriptionStatus.value = 'canceled'
+    mockIsActiveSubscription.value = false
+    mockIsWorkspaceSubscribed.value = false
+    mockCanSubscribeSelfServe.value = false
+    renderComponent()
+
+    expect(screen.getByTestId('credits-tile')).toHaveAttribute(
+      'data-inactive-plan',
+      'true'
+    )
+  })
+
   it('does not show stale renewal copy for an explicitly ended active state', () => {
     mockSubscriptionStatus.value = 'ended'
     renderComponent()

--- a/src/platform/workspace/components/SubscriptionPanelContentWorkspace.vue
+++ b/src/platform/workspace/components/SubscriptionPanelContentWorkspace.vue
@@ -530,7 +530,8 @@ const showTeamSubscribePrompt = computed(
 
 const showInactiveTeamSubscription = computed(
   () =>
-    showTeamSubscribePrompt.value &&
+    permissions.value.canManageSubscription &&
+    !isInPersonalWorkspace.value &&
     isSubscriptionEnded.value &&
     isTeamPlan.value
 )

--- a/src/platform/workspace/components/SubscriptionTransitionPreviewWorkspace.test.ts
+++ b/src/platform/workspace/components/SubscriptionTransitionPreviewWorkspace.test.ts
@@ -274,4 +274,40 @@ describe('SubscriptionTransitionPreviewWorkspace', () => {
     ).toBeTruthy()
     expect(screen.getByText('$12,600.00')).toBeTruthy()
   })
+
+  it('renders a Founders Edition refill without borrowing a catalog lookup', () => {
+    render(SubscriptionTransitionPreviewWorkspace, {
+      props: {
+        previewData: preview({
+          transition_type: 'upgrade',
+          is_immediate: true,
+          cost_today_cents: 1000,
+          current_plan: plan('STANDARD', 'MONTHLY', 2000),
+          new_plan: plan('FOUNDERS_EDITION', 'MONTHLY', 10_000)
+        })
+      },
+      global: globalOptions
+    })
+    expect(screen.getByText(/Founders Edition/)).toBeTruthy()
+  })
+
+  it('renders a tier the catalog does not know as readable words', () => {
+    render(SubscriptionTransitionPreviewWorkspace, {
+      props: {
+        previewData: preview({
+          transition_type: 'upgrade',
+          is_immediate: true,
+          cost_today_cents: 1000,
+          current_plan: plan('PRO', 'MONTHLY', 10_000),
+          new_plan: plan(
+            'SOME_FUTURE_TIER' as SubscriptionTier,
+            'MONTHLY',
+            20_000
+          )
+        })
+      },
+      global: globalOptions
+    })
+    expect(screen.getByText(/Some Future Tier/)).toBeTruthy()
+  })
 })

--- a/src/platform/workspace/components/SubscriptionTransitionPreviewWorkspace.vue
+++ b/src/platform/workspace/components/SubscriptionTransitionPreviewWorkspace.vue
@@ -317,7 +317,11 @@ import { formatUsdFromCents } from '@/base/credits/comfyCredits'
 import Button from '@/components/ui/button/Button.vue'
 import { useBillingContext } from '@/composables/billing/useBillingContext'
 import type { TeamPlanSelection } from '@/platform/cloud/subscription/constants/teamPlanCreditStops'
-import { getTierCredits } from '@/platform/cloud/subscription/constants/tierPricing'
+import type { IngestSubscriptionTier } from '@/platform/cloud/subscription/constants/tierPricing'
+import {
+  getTierCredits,
+  toTierKey
+} from '@/platform/cloud/subscription/constants/tierPricing'
 import { isAnnualDuration } from '@/platform/cloud/subscription/utils/planDuration'
 import { formatQuoteMoney } from '@/platform/cloud/subscription/utils/subscriptionQuoteFormatting'
 import type {
@@ -326,8 +330,6 @@ import type {
 } from '@/platform/workspace/api/workspaceApi'
 
 import SubscriptionTermsNote from './SubscriptionTermsNote.vue'
-
-type PersonalTierKey = 'standard' | 'creator' | 'pro'
 
 const {
   previewData,
@@ -407,8 +409,12 @@ function openVerification() {
 function formatTierName(tier: string): string {
   const nameKey = `subscription.tiers.${tier.toLowerCase()}.name`
   if (te(nameKey)) return t(nameKey)
-  const lower = tier.toLowerCase()
-  return lower.charAt(0).toUpperCase() + lower.slice(1)
+  return tier
+    .toLowerCase()
+    .split(/[_-]+/)
+    .filter(Boolean)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ')
 }
 
 function isTeamTier(tier: string): boolean {
@@ -428,8 +434,11 @@ function moneyShort(usd: number): string {
   return `$${n(usd)}`
 }
 
+// Lowercasing the tier is not a catalog lookup: FOUNDERS_EDITION keys as
+// 'founder', and TEAM/ENTERPRISE/unrecognized tiers key as nothing at all.
 function tierMonthlyCredits(tier: string): number {
-  return getTierCredits(tier.toLowerCase() as PersonalTierKey) ?? 0
+  const tierKey = toTierKey(tier as IngestSubscriptionTier)
+  return tierKey ? (getTierCredits(tierKey) ?? 0) : 0
 }
 
 const isImmediate = computed(() => previewData.is_immediate)

--- a/src/platform/workspace/composables/useBillingCapabilities.test.ts
+++ b/src/platform/workspace/composables/useBillingCapabilities.test.ts
@@ -203,6 +203,7 @@ describe('useBillingCapabilities', () => {
     expect(billingCapabilities.canChangeSeats.value).toBe(false)
     expect(billingCapabilities.canInviteMembers.value).toBe(false)
     expect(billingCapabilities.canDowngradeToPersonal.value).toBe(false)
+    expect(billingCapabilities.snapshotAuthoritative.value).toBe(false)
 
     const initialization = billingCapabilities.initialize()
     expect(billingCapabilities.canTopUp.value).toBe(false)
@@ -217,6 +218,7 @@ describe('useBillingCapabilities', () => {
     expect(billingCapabilities.canChangeSeats.value).toBe(true)
     expect(billingCapabilities.canInviteMembers.value).toBe(true)
     expect(billingCapabilities.canDowngradeToPersonal.value).toBe(true)
+    expect(billingCapabilities.snapshotAuthoritative.value).toBe(true)
   })
 
   it('applies denied server capabilities without client-side inference', async () => {
@@ -283,6 +285,7 @@ describe('useBillingCapabilities', () => {
     expect(billingCapabilities.canInviteMembers.value).toBe(false)
     expect(billingCapabilities.canDowngradeToPersonal.value).toBe(false)
     expect(billingCapabilities.isReady.value).toBe(true)
+    expect(billingCapabilities.snapshotAuthoritative.value).toBe(false)
     expect(mockReportError).toHaveBeenCalledOnce()
   })
 
@@ -295,6 +298,7 @@ describe('useBillingCapabilities', () => {
     expect(billingCapabilities.canTopUp.value).toBe(false)
     expect(billingCapabilities.canSubscribeSelfServe.value).toBe(false)
     expect(billingCapabilities.isReady.value).toBe(true)
+    expect(billingCapabilities.snapshotAuthoritative.value).toBe(false)
   })
 
   it('fails closed when the endpoint denies the current actor', async () => {
@@ -309,6 +313,7 @@ describe('useBillingCapabilities', () => {
     expect(billingCapabilities.canTopUp.value).toBe(false)
     expect(billingCapabilities.canSubscribeSelfServe.value).toBe(false)
     expect(billingCapabilities.isReady.value).toBe(true)
+    expect(billingCapabilities.snapshotAuthoritative.value).toBe(true)
   })
 
   it('does not fail open when capability loading is aborted', async () => {
@@ -328,6 +333,7 @@ describe('useBillingCapabilities', () => {
 
     expect(billingCapabilities.canTopUp.value).toBe(false)
     expect(billingCapabilities.isReady.value).toBe(false)
+    expect(billingCapabilities.snapshotAuthoritative.value).toBe(false)
     expect(mockReportError).not.toHaveBeenCalled()
   })
 

--- a/src/platform/workspace/composables/useBillingCapabilities.ts
+++ b/src/platform/workspace/composables/useBillingCapabilities.ts
@@ -132,6 +132,16 @@ function useBillingCapabilitiesInternal() {
     )
   })
 
+  const snapshotAuthoritative = computed(() => {
+    if (!isCloud) return true
+    const state = readState.value
+    if (state.status !== 'resolved' && state.status !== 'denied') return false
+    return (
+      state.authUid === authStore.currentUser?.uid &&
+      state.workspaceId === workspaceStore.activeWorkspaceId
+    )
+  })
+
   function clearRefreshTimer(): void {
     if (refreshTimer === null) return
     clearTimeout(refreshTimer)
@@ -416,6 +426,7 @@ function useBillingCapabilitiesInternal() {
     canInviteMembers,
     canDowngradeToPersonal,
     isReady,
+    snapshotAuthoritative,
     initialize,
     refresh
   }

--- a/src/platform/workspace/composables/useWorkspaceUI.test.ts
+++ b/src/platform/workspace/composables/useWorkspaceUI.test.ts
@@ -13,6 +13,7 @@ const mockIsCloud = ref(true)
 const mockShouldUseWorkspaceBilling = ref(true)
 const mockCanReactivate = ref(false)
 const mockCanSubscribeSelfServe = ref(true)
+const mockSnapshotAuthoritative = ref(true)
 const mockIsActiveSubscription = vi.hoisted(() => ({ value: false }))
 const mockIsCancelled = vi.hoisted(() => ({ value: false }))
 const mockIsTeamPlan = vi.hoisted(() => ({ value: false }))
@@ -56,7 +57,8 @@ vi.mock('@/composables/billing/useBillingRouting', () => ({
 vi.mock('@/platform/workspace/composables/useBillingCapabilities', () => ({
   useBillingCapabilities: () => ({
     canReactivate: computed(() => mockCanReactivate.value),
-    canSubscribeSelfServe: computed(() => mockCanSubscribeSelfServe.value)
+    canSubscribeSelfServe: computed(() => mockCanSubscribeSelfServe.value),
+    snapshotAuthoritative: computed(() => mockSnapshotAuthoritative.value)
   })
 }))
 
@@ -129,6 +131,7 @@ function resetStore() {
   mockShouldUseWorkspaceBilling.value = true
   mockCanReactivate.value = false
   mockCanSubscribeSelfServe.value = true
+  mockSnapshotAuthoritative.value = true
 }
 
 describe('useWorkspaceUI', () => {
@@ -553,6 +556,24 @@ describe('useWorkspaceUI', () => {
 
       const ui = await loadComposable()
       expect(ui.canOpenPricingSurface.value).toBe(true)
+    })
+
+    it('falls back to membership when the snapshot is not authoritative', async () => {
+      mockSnapshotAuthoritative.value = false
+      mockCanSubscribeSelfServe.value = false
+
+      const ui = await loadComposable()
+      expect(ui.canOpenPricingSurface.value).toBe(true)
+    })
+
+    it('keeps the catalog closed for a non-owner with no readable snapshot', async () => {
+      mockStore.activeWorkspace = teamMemberWorkspace
+      mockSnapshotAuthoritative.value = false
+      mockCanSubscribeSelfServe.value = false
+
+      const ui = await loadComposable()
+      expect(ui.permissions.value.canManageSubscription).toBe(false)
+      expect(ui.canOpenPricingSurface.value).toBe(false)
     })
   })
 })

--- a/src/platform/workspace/composables/useWorkspaceUI.ts
+++ b/src/platform/workspace/composables/useWorkspaceUI.ts
@@ -169,7 +169,8 @@ function useWorkspaceUIInternal() {
   )
 
   const { shouldUseWorkspaceBilling } = useBillingRouting()
-  const { canReactivate, canSubscribeSelfServe } = useBillingCapabilities()
+  const { canReactivate, canSubscribeSelfServe, snapshotAuthoritative } =
+    useBillingCapabilities()
 
   const permissions = computed<WorkspacePermissions>(() =>
     getPermissions(
@@ -202,11 +203,18 @@ function useWorkspaceUIInternal() {
   // items, settings links, and the ?pricing= deep link — reads this one value.
   // Same rail split as canReactivatePlan: legacy_stripe has no capability
   // projection row and stays on the membership check.
-  const canOpenPricingSurface = computed(() =>
-    isCloud && shouldUseWorkspaceBilling.value
+  //
+  // Opening the catalog is navigation, not a billing write — every checkout
+  // endpoint enforces its own policy — so an absent snapshot falls back to
+  // membership rather than stranding a self-serve owner with no route to a
+  // plan. This mirrors canTopUp, which already fails open for owners.
+  const canOpenPricingSurface = computed(() => {
+    if (!isCloud || !shouldUseWorkspaceBilling.value)
+      return permissions.value.canManageSubscription
+    return snapshotAuthoritative.value
       ? canSubscribeSelfServe.value
       : permissions.value.canManageSubscription
-  )
+  })
 
   const uiConfig = computed<WorkspaceUIConfig>(() => {
     const base = getUIConfig(workspaceType.value, workspaceRole.value)


### PR DESCRIPTION
Backport of #16100 to `cloud/1.52`.

The automated backport cleaned up its successful Cloud branch after the parallel `core/1.52` target conflicted. This recreates the Cloud backport from the merged target branch.

## Verification

- 6 affected unit suites: 215 tests passed
- `git diff --check` passed