### PR TITLE
test: share asset mapper automock

### DIFF
--- a/src/composables/queue/useResultGallery.test.ts
+++ b/src/composables/queue/useResultGallery.test.ts
@@ -1,9 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 
-vi.mock('@/platform/assets/composables/media/assetMappers', () => ({
-  mapInputFileToAssetItem: vi.fn(),
-  mapTaskOutputToAssetItem: vi.fn()
-}))
+vi.mock('@/platform/assets/composables/media/assetMappers')
 
 import { useResultGallery } from '@/composables/queue/useResultGallery'
 import type { JobListItem as JobListViewItem } from '@/composables/queue/useJobList'

--- a/src/platform/assets/composables/media/__mocks__/assetMappers.ts
+++ b/src/platform/assets/composables/media/__mocks__/assetMappers.ts
@@ -1,0 +1,9 @@
+import { vi } from 'vitest'
+
+import type {
+  mapInputFileToAssetItem as MapInputFileToAssetItem,
+  mapTaskOutputToAssetItem as MapTaskOutputToAssetItem
+} from '../assetMappers'
+
+export const mapInputFileToAssetItem = vi.fn<typeof MapInputFileToAssetItem>()
+export const mapTaskOutputToAssetItem = vi.fn<typeof MapTaskOutputToAssetItem>()

--- a/src/platform/assets/composables/useAssetSelection.property.test.ts
+++ b/src/platform/assets/composables/useAssetSelection.property.test.ts
@@ -11,10 +11,7 @@ const mockShiftKey = ref(false)
 const mockCtrlKey = ref(false)
 const mockMetaKey = ref(false)
 
-vi.mock('@/platform/assets/composables/media/assetMappers', () => ({
-  mapInputFileToAssetItem: vi.fn(),
-  mapTaskOutputToAssetItem: vi.fn()
-}))
+vi.mock('@/platform/assets/composables/media/assetMappers')
 
 vi.mock('@vueuse/core', async (importOriginal) => {
   const actual = await importOriginal()

--- a/src/platform/assets/composables/useAssetSelection.test.ts
+++ b/src/platform/assets/composables/useAssetSelection.test.ts
@@ -10,10 +10,7 @@ const mockShiftKey = ref(false)
 const mockCtrlKey = ref(false)
 const mockMetaKey = ref(false)
 
-vi.mock('@/platform/assets/composables/media/assetMappers', () => ({
-  mapInputFileToAssetItem: vi.fn(),
-  mapTaskOutputToAssetItem: vi.fn()
-}))
+vi.mock('@/platform/assets/composables/media/assetMappers')
 
 vi.mock('@vueuse/core', async (importOriginal) => {
   const actual = await importOriginal()

--- a/src/renderer/extensions/linearMode/OutputHistoryActiveQueueItem.test.ts
+++ b/src/renderer/extensions/linearMode/OutputHistoryActiveQueueItem.test.ts
@@ -10,10 +10,7 @@ import OutputHistoryActiveQueueItem from './OutputHistoryActiveQueueItem.vue'
 const i18n = createI18n({ legacy: false, locale: 'en' })
 setActivePinia(createTestingPinia({ stubActions: false }))
 
-vi.mock('@/platform/assets/composables/media/assetMappers', () => ({
-  mapInputFileToAssetItem: vi.fn(),
-  mapTaskOutputToAssetItem: vi.fn()
-}))
+vi.mock('@/platform/assets/composables/media/assetMappers')
 
 vi.mock('@/stores/commandStore', () => ({
   useCommandStore: () => ({

--- a/src/renderer/extensions/linearMode/flattenNodeOutput.test.ts
+++ b/src/renderer/extensions/linearMode/flattenNodeOutput.test.ts
@@ -1,10 +1,7 @@
 import { fromPartial } from '@total-typescript/shoehorn'
 import { describe, expect, it, vi } from 'vitest'
 
-vi.mock('@/platform/assets/composables/media/assetMappers', () => ({
-  mapInputFileToAssetItem: vi.fn(),
-  mapTaskOutputToAssetItem: vi.fn()
-}))
+vi.mock('@/platform/assets/composables/media/assetMappers')
 
 import { flattenNodeOutput } from '@/renderer/extensions/linearMode/flattenNodeOutput'
 import type { NodeExecutionOutput } from '@/schemas/apiSchema'

--- a/src/renderer/extensions/linearMode/linearOutputStore.test.ts
+++ b/src/renderer/extensions/linearMode/linearOutputStore.test.ts
@@ -16,10 +16,7 @@ const { apiTarget } = vi.hoisted(() => ({
   apiTarget: new EventTarget()
 }))
 
-vi.mock('@/platform/assets/composables/media/assetMappers', () => ({
-  mapInputFileToAssetItem: vi.fn(),
-  mapTaskOutputToAssetItem: vi.fn()
-}))
+vi.mock('@/platform/assets/composables/media/assetMappers')
 
 vi.mock('@/composables/useAppMode', () => ({
   useAppMode: () => ({

--- a/src/services/autoQueueService.test.ts
+++ b/src/services/autoQueueService.test.ts
@@ -3,10 +3,7 @@ import { setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
 
-vi.mock('@/platform/assets/composables/media/assetMappers', () => ({
-  mapInputFileToAssetItem: vi.fn(),
-  mapTaskOutputToAssetItem: vi.fn()
-}))
+vi.mock('@/platform/assets/composables/media/assetMappers')
 
 const mocks = vi.hoisted(() => ({
   addEventListener:

--- a/src/services/jobOutputCache.test.ts
+++ b/src/services/jobOutputCache.test.ts
@@ -1,9 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 
-vi.mock('@/platform/assets/composables/media/assetMappers', () => ({
-  mapInputFileToAssetItem: vi.fn(),
-  mapTaskOutputToAssetItem: vi.fn()
-}))
+vi.mock('@/platform/assets/composables/media/assetMappers')
 
 import { extractWorkflow } from '@/platform/remote/comfyui/jobs/fetchJobs'
 import { api } from '@/scripts/api'

--- a/src/stores/queueStore.loadWorkflow.test.ts
+++ b/src/stores/queueStore.loadWorkflow.test.ts
@@ -20,10 +20,7 @@ vi.mock('@/stores/assetsStore', () => ({
   useAssetsStore: vi.fn(() => ({}))
 }))
 
-vi.mock('@/platform/assets/composables/media/assetMappers', () => ({
-  mapInputFileToAssetItem: vi.fn(),
-  mapTaskOutputToAssetItem: vi.fn()
-}))
+vi.mock('@/platform/assets/composables/media/assetMappers')
 
 const mockWorkflow: ComfyWorkflowJSON = {
   last_node_id: 5,

--- a/src/stores/resultItemParsing.test.ts
+++ b/src/stores/resultItemParsing.test.ts
@@ -1,10 +1,7 @@
 import { fromPartial } from '@total-typescript/shoehorn'
 import { describe, expect, it, vi } from 'vitest'
 
-vi.mock('@/platform/assets/composables/media/assetMappers', () => ({
-  mapInputFileToAssetItem: vi.fn(),
-  mapTaskOutputToAssetItem: vi.fn()
-}))
+vi.mock('@/platform/assets/composables/media/assetMappers')
 
 import type { NodeExecutionOutput } from '@/schemas/apiSchema'
 import { parseNodeOutput, parseTaskOutput } from '@/stores/resultItemParsing'

--- a/src/stores/workspace/assetsSidebarBadgeStore.test.ts
+++ b/src/stores/workspace/assetsSidebarBadgeStore.test.ts
@@ -1,10 +1,7 @@
 import { nextTick } from 'vue'
 import { describe, expect, it, vi } from 'vitest'
 
-vi.mock('@/platform/assets/composables/media/assetMappers', () => ({
-  mapInputFileToAssetItem: vi.fn(),
-  mapTaskOutputToAssetItem: vi.fn()
-}))
+vi.mock('@/platform/assets/composables/media/assetMappers')
 
 import type { JobListItem } from '@/platform/remote/comfyui/jobs/jobTypes'
 import { TaskItemImpl, useQueueStore } from '@/stores/queueStore'


### PR DESCRIPTION
## Summary

Already incorporated into `main` by [#15381](https://github.com/Comfy-Org/ComfyUI_frontend/pull/15381), merged September 2, 2026. This historical proposal still targets `amp/pr-15381-review-proposals`; it does not need another merge.

## Changes

- The adjacent `assetMappers` manual mock is identical on `main`, and all eleven adopters now use typed, factory-free `vi.mock(import(...))` calls.
- Further mock cleanup belongs to [FE-2343](https://linear.app/comfyorg/issue/FE-2343), following the conventions in [#17714](https://github.com/Comfy-Org/ComfyUI_frontend/pull/17714).

## Review Focus

Preserve tests that configure mapper results through real imports and `vi.mocked`. Prefer removing a mock when the real collaborator works, as in [#17722](https://github.com/Comfy-Org/ComfyUI_frontend/pull/17722). Do not merge this stale proposal branch to reintroduce changes already on `main`.
