### PR TITLE
fix: apply control_after_generate during partial execution

### DIFF
--- a/browser_tests/tests/selectionToolboxActions.spec.ts
+++ b/browser_tests/tests/selectionToolboxActions.spec.ts
@@ -1,5 +1,7 @@
 import type { Locator } from '@playwright/test'
 
+import type { PromptResponse } from '@/schemas/apiSchema'
+
 import {
   comfyExpect as expect,
   comfyPageFixture as test
@@ -277,5 +279,55 @@ test.describe('Selection Toolbox - Button Actions', { tag: '@ui' }, () => {
       name: /Execute to selected output nodes/i
     })
     await expect(executeButton).toBeHidden()
+  })
+
+  test('partial execution applies control_after_generate to seeds', async ({
+    comfyPage
+  }) => {
+    await comfyPage.workflow.loadWorkflow('default')
+
+    const readSeed = () =>
+      comfyPage.page.evaluate(() => {
+        const sampler = window.app!.graph!._nodes.find(
+          (node) => node.type === 'KSampler'
+        )
+        return sampler!.widgets!.find((widget) => widget.name === 'seed')!.value
+      })
+
+    await comfyPage.page.evaluate(() => {
+      const sampler = window.app!.graph!._nodes.find(
+        (node) => node.type === 'KSampler'
+      )
+      const control = sampler?.widgets?.find(
+        (widget) => widget.name === 'control_after_generate'
+      )
+      if (!control) throw new Error('seed control widget missing')
+      control.value = 'randomize'
+    })
+    const seedBefore = await readSeed()
+
+    await comfyPage.page.route('**/api/prompt', async (route) => {
+      const promptResponse: PromptResponse = {
+        prompt_id: '1',
+        node_errors: {},
+        error: ''
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(promptResponse)
+      })
+    })
+
+    const saveImageRef = (
+      await comfyPage.nodeOps.getNodeRefsByTitle('Save Image')
+    )[0]
+    await selectNodeWithPan(comfyPage, saveImageRef)
+
+    await comfyPage.page
+      .getByRole('button', { name: /Execute to selected output nodes/i })
+      .click()
+
+    await expect.poll(readSeed).not.toBe(seedBefore)
   })
 })

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -1726,9 +1726,7 @@ export class ComfyApp {
             for (const widget of node.widgets ?? []) {
               widget.beforeQueued?.({ isPartialExecution })
             }
-            applyPromotedWidgetControl(node, 'beforeQueued', {
-              isPartialExecution
-            })
+            applyPromotedWidgetControl(node, 'beforeQueued')
           })
 
           // Capture workflow before await — activeWorkflow may change if the
@@ -1932,9 +1930,7 @@ export class ComfyApp {
             isPartialExecution
           })
           for (const node of queuedNodes) {
-            applyPromotedWidgetControl(node, 'afterQueued', {
-              isPartialExecution
-            })
+            applyPromotedWidgetControl(node, 'afterQueued')
           }
           useFreeTierQuota().trackRun()
           this.canvas.draw(true, true)

--- a/src/scripts/promotedWidgetControl.ts
+++ b/src/scripts/promotedWidgetControl.ts
@@ -52,16 +52,11 @@ function collectPromotedControlTargets(
   return targets
 }
 
-function applyTarget(
-  target: PromotedControlTarget,
-  nodeId: unknown,
-  isPartialExecution: boolean | undefined
-): void {
+function applyTarget(target: PromotedControlTarget, nodeId: unknown): void {
   const next = nextValueForLinkedTarget({
     target: target.hostWidget,
     linkedWidgets: target.linkedWidgets,
-    nodeId,
-    isPartialExecution
+    nodeId
   })
   if (next === undefined) return
 
@@ -92,8 +87,7 @@ const executedWidgets = new WeakSet<IBaseWidget>()
  */
 export function applyPromotedWidgetControl(
   node: LGraphNode,
-  phase: 'beforeQueued' | 'afterQueued',
-  { isPartialExecution }: { isPartialExecution?: boolean } = {}
+  phase: 'beforeQueued' | 'afterQueued'
 ): void {
   const runBefore = controlValueRunBefore()
   if (phase === 'beforeQueued' && !runBefore) return
@@ -101,12 +95,12 @@ export function applyPromotedWidgetControl(
 
   for (const target of collectPromotedControlTargets(node)) {
     if (phase === 'afterQueued') {
-      applyTarget(target, node.id, isPartialExecution)
+      applyTarget(target, node.id)
       continue
     }
 
     if (executedWidgets.has(target.hostWidget)) {
-      applyTarget(target, node.id, isPartialExecution)
+      applyTarget(target, node.id)
     }
     executedWidgets.add(target.hostWidget)
   }

--- a/src/scripts/valueControl.ts
+++ b/src/scripts/valueControl.ts
@@ -14,9 +14,7 @@ export function nextValueForLinkedTarget(params: {
   target: IBaseWidget
   linkedWidgets: IBaseWidget[] | undefined
   nodeId: unknown
-  isPartialExecution: boolean | undefined
 }): IBaseWidget['value'] | undefined {
-  if (params.isPartialExecution) return undefined
   const linked = params.linkedWidgets
   if (!linked) return undefined
 

--- a/src/scripts/widgets.ts
+++ b/src/scripts/widgets.ts
@@ -181,7 +181,7 @@ export function addValueControlWidgets(
     widgets.push(comboFilter)
   }
 
-  function applyWidgetControl(isPartialExecution: boolean | undefined) {
+  function applyWidgetControl() {
     if (
       node.inputs?.some(
         (input, index) =>
@@ -194,8 +194,7 @@ export function addValueControlWidgets(
     const next = nextValueForLinkedTarget({
       target: targetWidget,
       linkedWidgets: targetWidget.linkedWidgets,
-      nodeId: node.id,
-      isPartialExecution
+      nodeId: node.id
     })
     if (next === undefined) return
 
@@ -203,19 +202,19 @@ export function addValueControlWidgets(
     targetWidget.callback?.(next)
   }
 
-  valueControl.beforeQueued = ({ isPartialExecution } = {}) => {
+  valueControl.beforeQueued = () => {
     if (controlValueRunBefore()) {
       // Don't run on first execution
       if (valueControl[HAS_EXECUTED]) {
-        applyWidgetControl(isPartialExecution)
+        applyWidgetControl()
       }
     }
     valueControl[HAS_EXECUTED] = true
   }
 
-  valueControl.afterQueued = ({ isPartialExecution } = {}) => {
+  valueControl.afterQueued = () => {
     if (!controlValueRunBefore()) {
-      applyWidgetControl(isPartialExecution)
+      applyWidgetControl()
     }
   }
 


### PR DESCRIPTION
## Summary
Partial execution silently froze all control_after_generate widgets, so seeds set to randomize executed as fixed with no UI indication. 
Users repeatedly reported this as a bug (the canvas said randomize but the run reused the previous seed and hit the backend cache). 
Stop acting on the isPartialExecution guard so widget controls behave the same for partial and full runs. The WidgetCallbackOptions API surface is kept and the flag is still passed to widget callbacks so extensions retain the signal.
