### PR TITLE
fix(dynamic-widgets): preserve saved node height when applying values

### DIFF
--- a/src/core/graph/widgets/dynamicWidgets.test.ts
+++ b/src/core/graph/widgets/dynamicWidgets.test.ts
@@ -142,6 +142,30 @@ describe('Dynamic Combos', () => {
       node.inputs[1]
     )
   })
+  test('Restoring serialised state preserves the saved node height', () => {
+    const node = testNode()
+    node.serialize_widgets = true
+    addDynamicCombo(node, [['INT'], ['INT', 'STRING']])
+    node.widgets[0].value = '1'
+    node.setSize([node.size[0], 500])
+    const data = node.serialize()
+
+    const restored = testNode()
+    addDynamicCombo(restored, [['INT'], ['INT', 'STRING']])
+    restored.configure(data)
+
+    expect(restored.widgets[0].value).toBe('1')
+    expect(restored.widgets.length).toBe(3)
+    expect(restored.size[1]).toBe(500)
+  })
+  test('Interactive combo selection still refits the node height', () => {
+    const node = testNode()
+    addDynamicCombo(node, [['INT'], ['INT', 'STRING']])
+    node.setSize([node.size[0], 500])
+    node.widgets[0].value = '1'
+    node.widgets[0].callback?.('1')
+    expect(node.size[1]).toBeLessThan(500)
+  })
   test('Dynamically added widgets have tooltips', () => {
     const node = testNode()
     addDynamicCombo(node, [['INT'], ['STRING']])

--- a/src/core/graph/widgets/dynamicWidgets.ts
+++ b/src/core/graph/widgets/dynamicWidgets.ts
@@ -209,12 +209,18 @@ function dynamicComboWidget(
       node.onConnectionsChange?.(LiteGraph.INPUT, slot, true, link, input)
     }
 
-    node.size = [node.size[0], node.computeSize([...node.size])[1]]
     if (!node.graph) return
     node._setConcreteSlots()
     node.arrange()
     app.canvas?.setDirty(true, true)
   }
+  //Refit height on the callback channel: interaction fires it after the value
+  //setter, while configure (load, clone, paste) only fires the setter and must
+  //keep the serialised height.
+  widget.callback = useChainCallback(widget.callback, () => {
+    node.size = [node.size[0], node.computeSize([...node.size])[1]]
+    app.canvas?.setDirty(true, true)
+  })
   //A little hacky, but onConfigure won't work.
   //It fires too late and is overly disruptive
   let widgetValue = widget.value


### PR DESCRIPTION
## Summary
DynamicCombo refit node height inside updateWidgets, so any value write (graph configure, clone, copy/paste) recomputed the height and clobbered the size the user saved. Move the refit to the widget callback, which both render paths fire only on user interaction, so restoring serialised state never resizes while interactive selection still refits.

## Screenshots
before
https://github.com/user-attachments/assets/7fb0a643-f683-45f0-a7f9-b9b06f2d3e37

after
https://github.com/user-attachments/assets/3261a264-bb24-46da-8914-d36f30d64b18