### PR TITLE
test: consolidate repeated asset mocks

### DIFF
--- a/src/platform/assets/components/MediaAssetCard.test.ts
+++ b/src/platform/assets/components/MediaAssetCard.test.ts
@@ -16,8 +16,6 @@ vi.mock('@/stores/assetsStore', () => ({
   useAssetsStore: () => ({ isAssetDeleting: () => false })
 }))
 
-vi.mock('@/scripts/app', () => ({ app: {} }))
-
 vi.mock('../composables/useMediaAssetActions', () => ({
   useMediaAssetActions: () => ({ downloadAssets })
 }))

--- a/src/platform/assets/composables/media/assetMappers.test.ts
+++ b/src/platform/assets/composables/media/assetMappers.test.ts
@@ -13,8 +13,6 @@ vi.mock('@/scripts/api', () => ({
   }
 }))
 
-vi.mock('@/scripts/app', () => ({ app: {} }))
-
 vi.mock('@/platform/distribution/cloudPreviewUtil', () => ({
   appendCloudResParam: vi.fn()
 }))

--- a/src/platform/assets/composables/useOutputStacks.property.test.ts
+++ b/src/platform/assets/composables/useOutputStacks.property.test.ts
@@ -6,9 +6,7 @@ import { ref } from 'vue'
 
 import type { AssetItem } from '@/platform/assets/schemas/assetSchema'
 
-vi.mock('@/platform/assets/utils/outputAssetUtil', () => ({
-  resolveOutputAssetItems: () => Promise.resolve([])
-}))
+vi.mock('@/platform/assets/utils/outputAssetUtil')
 
 vi.mock('@/platform/assets/schemas/assetMetadataSchema', () => ({
   getOutputAssetMetadata: (metadata: Record<string, unknown> | undefined) => {

--- a/src/platform/assets/utils/__mocks__/outputAssetUtil.ts
+++ b/src/platform/assets/utils/__mocks__/outputAssetUtil.ts
@@ -1,0 +1,7 @@
+import { vi } from 'vitest'
+
+import type { resolveOutputAssetItems as ResolveOutputAssetItems } from '../outputAssetUtil'
+
+export const resolveOutputAssetItems = vi.fn<typeof ResolveOutputAssetItems>(
+  async () => []
+)

--- a/src/renderer/extensions/linearMode/linearOutputStore.test.ts
+++ b/src/renderer/extensions/linearMode/linearOutputStore.test.ts
@@ -3,7 +3,6 @@ import { ref } from 'vue'
 
 import { useLinearOutputStore } from '@/renderer/extensions/linearMode/linearOutputStore'
 import type { ExecutedWsMessage } from '@/schemas/apiSchema'
-import { ResultItemImpl } from '@/stores/queueStore'
 
 const activeJobIdRef = ref<string | null>(null)
 const previewsRef = ref<Record<string, { url: string; nodeId?: string }>>({})
@@ -66,23 +65,6 @@ vi.mock('@/scripts/api', () => ({
   api: Object.assign(apiTarget, {
     apiURL: (path: string) => path
   })
-}))
-
-vi.mock('@/renderer/extensions/linearMode/flattenNodeOutput', () => ({
-  flattenNodeOutput: ([nodeId, output]: [
-    string | number,
-    Record<string, unknown>
-  ]) => {
-    if (!output.images) return []
-    return (output.images as Array<Record<string, string>>).map(
-      (img) =>
-        new ResultItemImpl({
-          ...img,
-          nodeId: String(nodeId),
-          mediaType: 'images'
-        })
-    )
-  }
 }))
 
 function setJobWorkflowPath(jobId: string, path: string) {

--- a/src/renderer/extensions/linearMode/useOutputHistory.test.ts
+++ b/src/renderer/extensions/linearMode/useOutputHistory.test.ts
@@ -100,23 +100,6 @@ vi.mock('@/services/jobOutputCache', () => ({
     Promise.resolve(jobDetailResults.get(jobId) ?? undefined)
 }))
 
-vi.mock('@/renderer/extensions/linearMode/flattenNodeOutput', () => ({
-  flattenNodeOutput: ([nodeId, output]: [
-    string | number,
-    Record<string, unknown>
-  ]) => {
-    if (!output.images) return []
-    return (output.images as Array<Record<string, string>>).map(
-      (img) =>
-        new ResultItemImpl({
-          ...img,
-          nodeId: String(nodeId),
-          mediaType: 'images'
-        })
-    )
-  }
-}))
-
 function makeAsset(
   id: string,
   jobId: string,

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetSelectDropdown.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetSelectDropdown.test.ts
@@ -33,15 +33,7 @@ vi.mock('@/platform/workflow/management/stores/workflowStore', async () => {
   }
 })
 
-vi.mock('@/scripts/api', () => ({
-  api: {
-    fetchApi: vi.fn(),
-    apiURL: vi.fn((url: string) => url),
-    addEventListener: vi.fn(),
-    removeEventListener: vi.fn(),
-    getServerFeature: vi.fn()
-  }
-}))
+vi.mock('@/scripts/api')
 
 vi.mock(
   '@/renderer/extensions/vueNodes/widgets/composables/useAssetWidgetData',
@@ -55,9 +47,7 @@ vi.mock(
   })
 )
 
-vi.mock('@/platform/assets/utils/outputAssetUtil', () => ({
-  resolveOutputAssetItems: vi.fn().mockResolvedValue([])
-}))
+vi.mock('@/platform/assets/utils/outputAssetUtil')
 
 const mockUpdateSelectedItems = vi.hoisted(() => vi.fn())
 const mockHandleFilesUpdate = vi.hoisted(() => vi.fn())

--- a/src/renderer/extensions/vueNodes/widgets/composables/useWidgetSelectActions.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useWidgetSelectActions.test.ts
@@ -25,15 +25,7 @@ vi.mock('@/platform/workflow/management/stores/workflowStore', async () => {
   }
 })
 
-vi.mock('@/scripts/api', () => ({
-  api: {
-    fetchApi: vi.fn(),
-    apiURL: vi.fn((url: string) => url),
-    addEventListener: vi.fn(),
-    removeEventListener: vi.fn(),
-    getServerFeature: vi.fn()
-  }
-}))
+vi.mock('@/scripts/api')
 
 function createItems(...names: string[]): FormDropdownItem[] {
   return names.map((name, i) => ({

--- a/src/renderer/extensions/vueNodes/widgets/composables/useWidgetSelectItems.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useWidgetSelectItems.test.ts
@@ -3,6 +3,7 @@ import { computed, nextTick, ref } from 'vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { AssetItem } from '@/platform/assets/schemas/assetSchema'
+import { resolveOutputAssetItems } from '@/platform/assets/utils/outputAssetUtil'
 import { useWidgetSelectItems } from '@/renderer/extensions/vueNodes/widgets/composables/useWidgetSelectItems'
 import type { UseWidgetSelectItemsOptions } from '@/renderer/extensions/vueNodes/widgets/composables/useWidgetSelectItems'
 
@@ -20,7 +21,7 @@ vi.mock(
   })
 )
 
-const mockResolveOutputAssetItems = vi.fn()
+const mockResolveOutputAssetItems = vi.mocked(resolveOutputAssetItems)
 
 function createMockMediaAssets() {
   return {
@@ -43,10 +44,20 @@ vi.mock('@/platform/assets/composables/useAssetFilterOptions', () => ({
   })
 }))
 
-vi.mock('@/platform/assets/utils/outputAssetUtil', () => ({
-  resolveOutputAssetItems: (...args: unknown[]) =>
-    mockResolveOutputAssetItems(...args)
-}))
+vi.mock('@/platform/assets/utils/outputAssetUtil')
+
+function makeResolvedOutput(
+  id: string,
+  name: string,
+  previewUrl = ''
+): AssetItem {
+  return fromPartial({
+    id,
+    name,
+    preview_url: previewUrl,
+    tags: ['output']
+  })
+}
 
 function createDefaultOptions(
   overrides: Partial<UseWidgetSelectItemsOptions> = {}
@@ -451,24 +462,21 @@ describe('useWidgetSelectItems', () => {
       ]
 
       mockResolveOutputAssetItems.mockResolvedValue([
-        {
-          id: 'job-1-5-output_001.png',
-          name: 'output_001.png',
-          preview_url: '/api/view?filename=output_001.png&type=output',
-          tags: ['output']
-        },
-        {
-          id: 'job-1-5-output_002.png',
-          name: 'output_002.png',
-          preview_url: '/api/view?filename=output_002.png&type=output',
-          tags: ['output']
-        },
-        {
-          id: 'job-1-5-output_003.png',
-          name: 'output_003.png',
-          preview_url: '/api/view?filename=output_003.png&type=output',
-          tags: ['output']
-        }
+        makeResolvedOutput(
+          'job-1-5-output_001.png',
+          'output_001.png',
+          '/api/view?filename=output_001.png&type=output'
+        ),
+        makeResolvedOutput(
+          'job-1-5-output_002.png',
+          'output_002.png',
+          '/api/view?filename=output_002.png&type=output'
+        ),
+        makeResolvedOutput(
+          'job-1-5-output_003.png',
+          'output_003.png',
+          '/api/view?filename=output_003.png&type=output'
+        )
       ])
 
       const { dropdownItems, filterSelected } = useWidgetSelectItems(
@@ -515,40 +523,18 @@ describe('useWidgetSelectItems', () => {
         makeMultiOutputAsset('job-B', 'previewB.png', '2', 2)
       ]
 
-      mockResolveOutputAssetItems.mockImplementation(
-        async (meta: { jobId: string }) => {
-          if (meta.jobId === 'job-A') {
-            return [
-              {
-                id: 'A-1',
-                name: 'a1.png',
-                preview_url: '',
-                tags: ['output']
-              },
-              {
-                id: 'A-2',
-                name: 'a2.png',
-                preview_url: '',
-                tags: ['output']
-              }
-            ]
-          }
+      mockResolveOutputAssetItems.mockImplementation(async (meta) => {
+        if (meta.jobId === 'job-A') {
           return [
-            {
-              id: 'B-1',
-              name: 'b1.png',
-              preview_url: '',
-              tags: ['output']
-            },
-            {
-              id: 'B-2',
-              name: 'b2.png',
-              preview_url: '',
-              tags: ['output']
-            }
+            makeResolvedOutput('A-1', 'a1.png'),
+            makeResolvedOutput('A-2', 'a2.png')
           ]
         }
-      )
+        return [
+          makeResolvedOutput('B-1', 'b1.png'),
+          makeResolvedOutput('B-2', 'b2.png')
+        ]
+      })
 
       const { dropdownItems, filterSelected } = useWidgetSelectItems(
         createDefaultOptions({
@@ -602,18 +588,8 @@ describe('useWidgetSelectItems', () => {
       ]
 
       mockResolveOutputAssetItems.mockResolvedValue([
-        {
-          id: 'c-1',
-          name: 'out1.png',
-          preview_url: '',
-          tags: ['output']
-        },
-        {
-          id: 'c-2',
-          name: 'out2.png',
-          preview_url: '',
-          tags: ['output']
-        }
+        makeResolvedOutput('c-1', 'out1.png'),
+        makeResolvedOutput('c-2', 'out2.png')
       ])
 
       const { dropdownItems, filterSelected } = useWidgetSelectItems(

--- a/src/scripts/__mocks__/api.ts
+++ b/src/scripts/__mocks__/api.ts
@@ -1,0 +1,11 @@
+import { vi } from 'vitest'
+
+import type { api as RealApi } from '../api'
+
+export const api = {
+  addEventListener: vi.fn<typeof RealApi.addEventListener>(),
+  apiURL: vi.fn<typeof RealApi.apiURL>((url) => url),
+  fetchApi: vi.fn<typeof RealApi.fetchApi>(),
+  getServerFeature: vi.fn<typeof RealApi.getServerFeature>(),
+  removeEventListener: vi.fn<typeof RealApi.removeEventListener>()
+}

--- a/src/scripts/__mocks__/api.ts
+++ b/src/scripts/__mocks__/api.ts
@@ -1,11 +1,12 @@
+import { fromPartial } from '@total-typescript/shoehorn'
 import { vi } from 'vitest'
 
 import type { api as RealApi } from '../api'
 
-export const api = {
-  addEventListener: vi.fn<typeof RealApi.addEventListener>(),
-  apiURL: vi.fn<typeof RealApi.apiURL>((url) => url),
-  fetchApi: vi.fn<typeof RealApi.fetchApi>(),
-  getServerFeature: vi.fn<typeof RealApi.getServerFeature>(),
-  removeEventListener: vi.fn<typeof RealApi.removeEventListener>()
-}
+export const api = fromPartial<typeof RealApi>({
+  addEventListener: vi.fn(),
+  apiURL: vi.fn((url: string) => url),
+  fetchApi: vi.fn(),
+  getServerFeature: vi.fn(),
+  removeEventListener: vi.fn()
+})


### PR DESCRIPTION
## Summary

Already incorporated into `main` by [#15381](https://github.com/Comfy-Org/ComfyUI_frontend/pull/15381), merged September 2, 2026. This historical proposal still targets `amp/pr-15381-review-proposals`; it does not need another merge.

## Changes

- The adjacent `api` and `outputAssetUtil` manual mocks are identical on `main`. Their adopters now use typed, factory-free `vi.mock(import(...))` calls.
- `resolveOutputAssetItems` already uses a constructor-supplied async default that survives mock resets.
- Further cleanup belongs to [FE-2343](https://linear.app/comfyorg/issue/FE-2343), following the conventions in [#17714](https://github.com/Comfy-Org/ComfyUI_frontend/pull/17714).

## Review Focus

The shared API mock still uses `fromPartial<typeof RealApi>`, and `makeResolvedOutput` in `useWidgetSelectItems.test.ts` uses partial asset fixtures. These do not meet the current effort's complete-fixture standard. Address them against current `main`, preserving scenario results and rejection behavior; do not broaden the partial API mock to consolidate additional consumers.

Keep real imports with `vi.mocked`, constructor-supplied defaults, and scenario-local overrides. Prefer the real collaborator when a mock is unnecessary. Do not merge this stale proposal branch to reintroduce changes already on `main`.
