### PR TITLE
test: consolidate shared module mocks

### DIFF
--- a/__mocks__/firebase/app.ts
+++ b/__mocks__/firebase/app.ts
@@ -1,0 +1,9 @@
+import { vi } from 'vitest'
+
+import type {
+  getApp as GetApp,
+  initializeApp as InitializeApp
+} from 'firebase/app'
+
+export const getApp = vi.fn<typeof GetApp>()
+export const initializeApp = vi.fn<typeof InitializeApp>()

--- a/__mocks__/firebase/auth.ts
+++ b/__mocks__/firebase/auth.ts
@@ -1,0 +1,21 @@
+import { fromPartial } from '@total-typescript/shoehorn'
+import { vi } from 'vitest'
+
+import type {
+  getAuth as GetAuth,
+  onAuthStateChanged as OnAuthStateChanged,
+  Persistence,
+  sendPasswordResetEmail as SendPasswordResetEmail,
+  setPersistence as SetPersistence,
+  signInWithEmailAndPassword as SignInWithEmailAndPassword,
+  signOut as SignOut
+} from 'firebase/auth'
+
+export const browserLocalPersistence = fromPartial<Persistence>({})
+export const getAuth = vi.fn<typeof GetAuth>()
+export const onAuthStateChanged = vi.fn<typeof OnAuthStateChanged>()
+export const sendPasswordResetEmail = vi.fn<typeof SendPasswordResetEmail>()
+export const setPersistence = vi.fn<typeof SetPersistence>()
+export const signInWithEmailAndPassword =
+  vi.fn<typeof SignInWithEmailAndPassword>()
+export const signOut = vi.fn<typeof SignOut>()

--- a/src/base/common/__mocks__/downloadUtil.ts
+++ b/src/base/common/__mocks__/downloadUtil.ts
@@ -1,0 +1,14 @@
+import { vi } from 'vitest'
+
+import type {
+  downloadBlob as DownloadBlob,
+  downloadFile as DownloadFile,
+  extractFilenameFromContentDisposition as ExtractFilenameFromContentDisposition,
+  openFileInNewTab as OpenFileInNewTab
+} from '../downloadUtil'
+
+export const downloadBlob = vi.fn<typeof DownloadBlob>()
+export const downloadFile = vi.fn<typeof DownloadFile>()
+export const extractFilenameFromContentDisposition =
+  vi.fn<typeof ExtractFilenameFromContentDisposition>()
+export const openFileInNewTab = vi.fn<typeof OpenFileInNewTab>()

--- a/src/components/common/UserCredit.test.ts
+++ b/src/components/common/UserCredit.test.ts
@@ -6,19 +6,8 @@ import enMessages from '@/locales/en/main.json' with { type: 'json' }
 
 import UserCredit from './UserCredit.vue'
 
-vi.mock('firebase/app', () => ({
-  initializeApp: vi.fn(),
-  getApp: vi.fn()
-}))
-
-vi.mock('firebase/auth', () => ({
-  getAuth: vi.fn(),
-  setPersistence: vi.fn(),
-  browserLocalPersistence: {},
-  onAuthStateChanged: vi.fn(),
-  signInWithEmailAndPassword: vi.fn(),
-  signOut: vi.fn()
-}))
+vi.mock('firebase/app')
+vi.mock('firebase/auth')
 
 vi.mock('pinia')
 

--- a/src/components/common/__mocks__/LazyImage.vue
+++ b/src/components/common/__mocks__/LazyImage.vue
@@ -1,0 +1,14 @@
+<script setup lang="ts">
+import type { StyleValue } from 'vue'
+
+defineProps<{
+  src: string
+  alt?: string
+  imageClass?: string | Record<string, boolean> | unknown[]
+  imageStyle?: StyleValue
+}>()
+</script>
+
+<template>
+  <img :src :alt :class="imageClass" :style="imageStyle" draggable="false" />
+</template>

--- a/src/components/dialog/content/signin/SignInForm.test.ts
+++ b/src/components/dialog/content/signin/SignInForm.test.ts
@@ -15,21 +15,8 @@ import enMessages from '@/locales/en/main.json' with { type: 'json' }
 
 import SignInForm from './SignInForm.vue'
 
-// Mock firebase auth modules
-vi.mock('firebase/app', () => ({
-  initializeApp: vi.fn(),
-  getApp: vi.fn()
-}))
-
-vi.mock('firebase/auth', () => ({
-  getAuth: vi.fn(),
-  setPersistence: vi.fn(),
-  browserLocalPersistence: {},
-  onAuthStateChanged: vi.fn(),
-  signInWithEmailAndPassword: vi.fn(),
-  signOut: vi.fn(),
-  sendPasswordResetEmail: vi.fn()
-}))
+vi.mock('firebase/app')
+vi.mock('firebase/auth')
 
 // Mock the auth composables and stores
 const mockSendPasswordReset = vi.fn()

--- a/src/components/dialog/content/signin/SignUpForm.test.ts
+++ b/src/components/dialog/content/signin/SignUpForm.test.ts
@@ -13,19 +13,8 @@ import enMessages from '@/locales/en/main.json' with { type: 'json' }
 
 import SignUpForm from './SignUpForm.vue'
 
-vi.mock('firebase/app', () => ({
-  initializeApp: vi.fn(),
-  getApp: vi.fn()
-}))
-
-vi.mock('firebase/auth', () => ({
-  getAuth: vi.fn(),
-  setPersistence: vi.fn(),
-  browserLocalPersistence: {},
-  onAuthStateChanged: vi.fn(),
-  signInWithEmailAndPassword: vi.fn(),
-  signOut: vi.fn()
-}))
+vi.mock('firebase/app')
+vi.mock('firebase/auth')
 
 const mockLoadingRef = ref(false)
 vi.mock('@/stores/authStore', () => ({

--- a/src/components/hdr/HdrViewerContent.test.ts
+++ b/src/components/hdr/HdrViewerContent.test.ts
@@ -6,7 +6,7 @@ import { createI18n } from 'vue-i18n'
 
 import HdrViewerContent from './HdrViewerContent.vue'
 
-vi.mock('@/base/common/downloadUtil', () => ({ downloadFile: vi.fn() }))
+vi.mock('@/base/common/downloadUtil')
 
 const holder = vi.hoisted(() => ({ viewer: undefined as unknown }))
 vi.mock('@/composables/useHdrViewer', () => ({

--- a/src/components/templates/thumbnails/CompareSliderThumbnail.test.ts
+++ b/src/components/templates/thumbnails/CompareSliderThumbnail.test.ts
@@ -12,14 +12,7 @@ vi.mock('@/components/templates/thumbnails/BaseThumbnail.vue', () => ({
   }
 }))
 
-vi.mock('@/components/common/LazyImage.vue', () => ({
-  default: {
-    name: 'LazyImage',
-    template:
-      '<img :src="src" :alt="alt" :class="imageClass" :style="imageStyle" draggable="false" />',
-    props: ['src', 'alt', 'imageClass', 'imageStyle']
-  }
-}))
+vi.mock('@/components/common/LazyImage.vue')
 
 const mockRect = (el: HTMLElement, width: number) => {
   vi.spyOn(el, 'getBoundingClientRect').mockReturnValue({

--- a/src/components/templates/thumbnails/DefaultThumbnail.test.ts
+++ b/src/components/templates/thumbnails/DefaultThumbnail.test.ts
@@ -11,14 +11,7 @@ vi.mock('@/components/templates/thumbnails/BaseThumbnail.vue', () => ({
   }
 }))
 
-vi.mock('@/components/common/LazyImage.vue', () => ({
-  default: {
-    name: 'LazyImage',
-    template:
-      '<img :src="src" :alt="alt" :class="imageClass" :style="imageStyle" draggable="false" />',
-    props: ['src', 'alt', 'imageClass', 'imageStyle']
-  }
-}))
+vi.mock('@/components/common/LazyImage.vue')
 
 describe('DefaultThumbnail', () => {
   function renderThumbnail(props = {}) {

--- a/src/components/templates/thumbnails/HoverDissolveThumbnail.test.ts
+++ b/src/components/templates/thumbnails/HoverDissolveThumbnail.test.ts
@@ -11,14 +11,7 @@ vi.mock('@/components/templates/thumbnails/BaseThumbnail.vue', () => ({
   }
 }))
 
-vi.mock('@/components/common/LazyImage.vue', () => ({
-  default: {
-    name: 'LazyImage',
-    template:
-      '<img :src="src" :alt="alt" :class="imageClass" :style="imageStyle" draggable="false" />',
-    props: ['src', 'alt', 'imageClass', 'imageStyle']
-  }
-}))
+vi.mock('@/components/common/LazyImage.vue')
 
 describe('HoverDissolveThumbnail', () => {
   const renderThumbnail = (props = {}) => {

--- a/src/components/topbar/CurrentUserButton.test.ts
+++ b/src/components/topbar/CurrentUserButton.test.ts
@@ -16,20 +16,8 @@ const mockTeamWorkspaceStore = vi.hoisted(() => ({
 
 const mockIsCloud = vi.hoisted(() => ({ value: false }))
 
-// Mock all firebase modules
-vi.mock('firebase/app', () => ({
-  initializeApp: vi.fn(),
-  getApp: vi.fn()
-}))
-
-vi.mock('firebase/auth', () => ({
-  getAuth: vi.fn(),
-  setPersistence: vi.fn(),
-  browserLocalPersistence: {},
-  onAuthStateChanged: vi.fn(),
-  signInWithEmailAndPassword: vi.fn(),
-  signOut: vi.fn()
-}))
+vi.mock('firebase/app')
+vi.mock('firebase/auth')
 
 // Mock pinia
 vi.mock('pinia', () => ({

--- a/src/components/topbar/TopbarSubscribeButton.test.ts
+++ b/src/components/topbar/TopbarSubscribeButton.test.ts
@@ -34,18 +34,8 @@ vi.mock('@/composables/billing/useBillingContext', () => ({
 
 vi.mock('pinia')
 
-vi.mock('firebase/app', () => ({
-  initializeApp: vi.fn(),
-  getApp: vi.fn()
-}))
-
-vi.mock('firebase/auth', () => ({
-  getAuth: vi.fn(),
-  setPersistence: vi.fn(),
-  browserLocalPersistence: {},
-  onAuthStateChanged: vi.fn(),
-  signOut: vi.fn()
-}))
+vi.mock('firebase/app')
+vi.mock('firebase/auth')
 
 function renderComponent() {
   const i18n = createI18n({

--- a/src/extensions/core/load3d/ModelExporter.test.ts
+++ b/src/extensions/core/load3d/ModelExporter.test.ts
@@ -1,17 +1,17 @@
 import * as THREE from 'three'
 import { describe, expect, it, vi } from 'vitest'
 
+import { downloadBlob } from '@/base/common/downloadUtil'
+
 import { ModelExporter } from './ModelExporter'
 
 const {
-  downloadBlobMock,
   addAlertMock,
   gltfParseMock,
   objParseMock,
   stlParseMock,
   fbxParseAsyncMock
 } = vi.hoisted(() => ({
-  downloadBlobMock: vi.fn(),
   addAlertMock: vi.fn(),
   gltfParseMock: vi.fn(),
   objParseMock: vi.fn(),
@@ -19,9 +19,7 @@ const {
   fbxParseAsyncMock: vi.fn()
 }))
 
-vi.mock('@/base/common/downloadUtil', () => ({
-  downloadBlob: downloadBlobMock
-}))
+vi.mock('@/base/common/downloadUtil')
 
 vi.mock('@/i18n', () => ({
   t: (key: string, vars?: Record<string, unknown>) =>
@@ -133,7 +131,7 @@ describe('ModelExporter', () => {
         'cube.glb'
       )
 
-      expect(downloadBlobMock).toHaveBeenCalledWith('cube.glb', blob)
+      expect(downloadBlob).toHaveBeenCalledWith('cube.glb', blob)
       vi.unstubAllGlobals()
     })
 
@@ -164,7 +162,7 @@ describe('ModelExporter', () => {
       await expect(
         ModelExporter.downloadFromURL('http://example.com/cube.glb', 'cube.glb')
       ).rejects.toThrow('HTTP 404')
-      expect(downloadBlobMock).not.toHaveBeenCalled()
+      expect(downloadBlob).not.toHaveBeenCalled()
       expect(addAlertMock).toHaveBeenCalledWith(
         'toastMessages.failedToDownloadFile'
       )
@@ -189,7 +187,7 @@ describe('ModelExporter', () => {
         'http://example.com/api/view?filename=src.glb'
       )
 
-      expect(downloadBlobMock).toHaveBeenCalledWith('out.glb', blob)
+      expect(downloadBlob).toHaveBeenCalledWith('out.glb', blob)
       expect(gltfParseMock).not.toHaveBeenCalled()
       vi.unstubAllGlobals()
     })
@@ -212,7 +210,7 @@ describe('ModelExporter', () => {
       await promise
 
       expect(gltfParseMock).toHaveBeenCalled()
-      expect(downloadBlobMock).toHaveBeenCalledWith('out.glb', expect.any(Blob))
+      expect(downloadBlob).toHaveBeenCalledWith('out.glb', expect.any(Blob))
     })
 
     it('alerts and rethrows when GLTFExporter rejects', async () => {
@@ -248,7 +246,7 @@ describe('ModelExporter', () => {
         'http://example.com/api/view?filename=src.obj'
       )
 
-      expect(downloadBlobMock).toHaveBeenCalledWith('out.obj', blob)
+      expect(downloadBlob).toHaveBeenCalledWith('out.obj', blob)
       expect(objParseMock).not.toHaveBeenCalled()
       vi.unstubAllGlobals()
     })
@@ -261,7 +259,7 @@ describe('ModelExporter', () => {
       await promise
 
       expect(objParseMock).toHaveBeenCalled()
-      expect(downloadBlobMock).toHaveBeenCalledWith('out.obj', expect.any(Blob))
+      expect(downloadBlob).toHaveBeenCalledWith('out.obj', expect.any(Blob))
     })
 
     it('alerts and rethrows when OBJExporter throws', async () => {
@@ -296,7 +294,7 @@ describe('ModelExporter', () => {
         'http://example.com/api/view?filename=src.stl'
       )
 
-      expect(downloadBlobMock).toHaveBeenCalledWith('out.stl', blob)
+      expect(downloadBlob).toHaveBeenCalledWith('out.stl', blob)
       expect(stlParseMock).not.toHaveBeenCalled()
       vi.unstubAllGlobals()
     })
@@ -309,7 +307,7 @@ describe('ModelExporter', () => {
       await promise
 
       expect(stlParseMock).toHaveBeenCalled()
-      expect(downloadBlobMock).toHaveBeenCalledWith('out.stl', expect.any(Blob))
+      expect(downloadBlob).toHaveBeenCalledWith('out.stl', expect.any(Blob))
     })
 
     it('alerts and rethrows when STLExporter throws', async () => {
@@ -344,7 +342,7 @@ describe('ModelExporter', () => {
         'ply'
       )
 
-      expect(downloadBlobMock).toHaveBeenCalledWith('out.ply', blob)
+      expect(downloadBlob).toHaveBeenCalledWith('out.ply', blob)
       vi.unstubAllGlobals()
     })
 
@@ -352,7 +350,7 @@ describe('ModelExporter', () => {
       await expect(
         ModelExporter.exportDirect(null, 'out.spz', 'spz')
       ).rejects.toThrow('No source file available to export as spz')
-      expect(downloadBlobMock).not.toHaveBeenCalled()
+      expect(downloadBlob).not.toHaveBeenCalled()
       expect(addAlertMock).not.toHaveBeenCalled()
     })
   })
@@ -373,7 +371,7 @@ describe('ModelExporter', () => {
         'http://example.com/api/view?filename=src.fbx'
       )
 
-      expect(downloadBlobMock).toHaveBeenCalledWith('out.fbx', blob)
+      expect(downloadBlob).toHaveBeenCalledWith('out.fbx', blob)
       expect(fbxParseAsyncMock).not.toHaveBeenCalled()
       vi.unstubAllGlobals()
     })
@@ -387,7 +385,7 @@ describe('ModelExporter', () => {
       await promise
 
       expect(fbxParseAsyncMock).toHaveBeenCalled()
-      expect(downloadBlobMock).toHaveBeenCalledWith('out.fbx', expect.any(Blob))
+      expect(downloadBlob).toHaveBeenCalledWith('out.fbx', expect.any(Blob))
     })
 
     it('alerts and rethrows when FBXExporter throws', async () => {

--- a/src/extensions/core/load3d/RecordingManager.test.ts
+++ b/src/extensions/core/load3d/RecordingManager.test.ts
@@ -1,16 +1,12 @@
 import * as THREE from 'three'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { downloadBlob } from '@/base/common/downloadUtil'
+
 import type { EventManagerInterface } from './interfaces'
 import { RecordingManager } from './RecordingManager'
 
-const { downloadBlobMock } = vi.hoisted(() => ({
-  downloadBlobMock: vi.fn()
-}))
-
-vi.mock('@/base/common/downloadUtil', () => ({
-  downloadBlob: downloadBlobMock
-}))
+vi.mock('@/base/common/downloadUtil')
 
 vi.mock('three', async (importOriginal) => {
   const actual = await importOriginal<typeof THREE>()
@@ -240,7 +236,7 @@ describe('RecordingManager', () => {
         'recordingError',
         expect.any(Error)
       )
-      expect(downloadBlobMock).not.toHaveBeenCalled()
+      expect(downloadBlob).not.toHaveBeenCalled()
     })
 
     it('downloads the blob with the requested filename and emits exportingRecording then recordingExported', async () => {
@@ -249,10 +245,7 @@ describe('RecordingManager', () => {
 
       manager.exportRecording('clip.webm')
 
-      expect(downloadBlobMock).toHaveBeenCalledWith(
-        'clip.webm',
-        expect.any(Blob)
-      )
+      expect(downloadBlob).toHaveBeenCalledWith('clip.webm', expect.any(Blob))
       expect(events.emitEvent).toHaveBeenCalledWith('exportingRecording', null)
       expect(events.emitEvent).toHaveBeenCalledWith('recordingExported', null)
     })
@@ -263,7 +256,7 @@ describe('RecordingManager', () => {
 
       manager.exportRecording()
 
-      expect(downloadBlobMock).toHaveBeenCalledWith(
+      expect(downloadBlob).toHaveBeenCalledWith(
         'scene-recording.mp4',
         expect.any(Blob)
       )

--- a/src/platform/cloud/subscription/composables/useSubscriptionActions.test.ts
+++ b/src/platform/cloud/subscription/composables/useSubscriptionActions.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { useSubscriptionActions } from '@/platform/cloud/subscription/composables/useSubscriptionActions'
+import { reportError } from '@/platform/telemetry/reportError'
 
 const mockBillingFetchBalance = vi.fn()
 const mockAuthFetchBalance = vi.fn()
@@ -9,13 +10,7 @@ const mockShowTopUpCreditsDialog = vi.fn()
 const mockExecute = vi.fn()
 const mockToastAdd = vi.fn()
 
-const { mockReportError } = vi.hoisted(() => ({
-  mockReportError: vi.fn()
-}))
-
-vi.mock('@/platform/telemetry/reportError', () => ({
-  reportError: mockReportError
-}))
+vi.mock('@/platform/telemetry/reportError')
 
 vi.mock('@/platform/updates/common/toastStore', () => ({
   useToastStore: () => ({ add: mockToastAdd })
@@ -77,7 +72,6 @@ Object.defineProperty(window, 'open', {
 describe('useSubscriptionActions', () => {
   beforeEach(() => {
     mockIsCloud.value = true
-    mockReportError.mockReset()
   })
 
   describe('handleAddApiCredits', () => {
@@ -150,7 +144,7 @@ describe('useSubscriptionActions', () => {
 
       await handleMessageSupport()
 
-      expect(mockReportError).toHaveBeenCalledWith(failure, {
+      expect(reportError).toHaveBeenCalledWith(failure, {
         errorType: 'contact_support_failed'
       })
     })
@@ -165,7 +159,7 @@ describe('useSubscriptionActions', () => {
 
       await handleMessageSupport()
 
-      expect(mockReportError).toHaveBeenCalledWith('Command failed', {
+      expect(reportError).toHaveBeenCalledWith('Command failed', {
         errorType: 'contact_support_failed'
       })
     })

--- a/src/platform/telemetry/__mocks__/reportError.ts
+++ b/src/platform/telemetry/__mocks__/reportError.ts
@@ -1,0 +1,5 @@
+import { vi } from 'vitest'
+
+import type { reportError as ReportError } from '../reportError'
+
+export const reportError = vi.fn<typeof ReportError>()

--- a/src/platform/workspace/auth/WorkspaceAuthGate.test.ts
+++ b/src/platform/workspace/auth/WorkspaceAuthGate.test.ts
@@ -5,6 +5,7 @@ import { ref } from 'vue'
 import { createI18n } from 'vue-i18n'
 
 import enMessages from '@/locales/en/main.json' with { type: 'json' }
+import { reportError } from '@/platform/telemetry/reportError'
 
 import WorkspaceAuthGate from './WorkspaceAuthGate.vue'
 
@@ -12,10 +13,7 @@ async function flushPromises() {
   await new Promise((r) => setTimeout(r, 0))
 }
 
-const mockReportError = vi.hoisted(() => vi.fn())
-vi.mock('@/platform/telemetry/reportError', () => ({
-  reportError: mockReportError
-}))
+vi.mock('@/platform/telemetry/reportError')
 
 const mockIsInitialized = ref(false)
 const mockCurrentUser = ref<object | null>(null)
@@ -302,7 +300,7 @@ describe('WorkspaceAuthGate', () => {
       expect(
         screen.getByText("Couldn't load your workspace")
       ).toBeInTheDocument()
-      expect(mockReportError).toHaveBeenCalledOnce()
+      expect(reportError).toHaveBeenCalledOnce()
     })
   })
 
@@ -377,7 +375,7 @@ describe('WorkspaceAuthGate', () => {
 
       expect(signal).toBeInstanceOf(AbortSignal)
       expect(signal.aborted).toBe(true)
-      expect(mockReportError).not.toHaveBeenCalled()
+      expect(reportError).not.toHaveBeenCalled()
     })
 
     it('stops initialization when unmounted', async () => {
@@ -400,7 +398,7 @@ describe('WorkspaceAuthGate', () => {
 
       expect(signal.aborted).toBe(true)
       expect(mockWorkspaceStoreInitialize).not.toHaveBeenCalled()
-      expect(mockReportError).not.toHaveBeenCalled()
+      expect(reportError).not.toHaveBeenCalled()
     })
 
     it('skips workspace init when store is already initialized', async () => {
@@ -438,7 +436,7 @@ describe('WorkspaceAuthGate', () => {
       ).toBeInTheDocument()
       expect(screen.getByRole('alert')).toHaveFocus()
       expect(splashLoader).not.toBeInTheDocument()
-      expect(mockReportError).toHaveBeenCalledWith(error, {
+      expect(reportError).toHaveBeenCalledWith(error, {
         errorType: 'workspace_auth_gate_initialization_failure'
       })
     })

--- a/src/platform/workspace/composables/useBillingCapabilities.test.ts
+++ b/src/platform/workspace/composables/useBillingCapabilities.test.ts
@@ -5,12 +5,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { effectScope } from 'vue'
 import type { EffectScope } from 'vue'
 
+import { reportError } from '@/platform/telemetry/reportError'
 import { attachCapabilityRevisionInterceptor } from '@/platform/workspace/api/capabilityRevision'
 
 import { useBillingCapabilities } from './useBillingCapabilities'
 
 const mockGetBillingCapabilities = vi.hoisted(() => vi.fn())
-const mockReportError = vi.hoisted(() => vi.fn())
 const mockIsCloud = vi.hoisted(() => ({ value: true }))
 const mockScope = vi.hoisted(() => ({
   workspaceId: 'workspace-1' as string | null,
@@ -31,9 +31,7 @@ vi.mock('@/platform/workspace/api/workspaceApi', () => ({
   workspaceApi: { getBillingCapabilities: mockGetBillingCapabilities }
 }))
 
-vi.mock('@/platform/telemetry/reportError', () => ({
-  reportError: mockReportError
-}))
+vi.mock('@/platform/telemetry/reportError')
 
 vi.mock('@/platform/distribution/types', () => ({
   get isCloud() {
@@ -283,7 +281,7 @@ describe('useBillingCapabilities', () => {
     expect(billingCapabilities.canInviteMembers.value).toBe(false)
     expect(billingCapabilities.canDowngradeToPersonal.value).toBe(false)
     expect(billingCapabilities.isReady.value).toBe(true)
-    expect(mockReportError).toHaveBeenCalledOnce()
+    expect(reportError).toHaveBeenCalledOnce()
   })
 
   it('withholds top-up from members when the endpoint is unavailable', async () => {
@@ -328,7 +326,7 @@ describe('useBillingCapabilities', () => {
 
     expect(billingCapabilities.canTopUp.value).toBe(false)
     expect(billingCapabilities.isReady.value).toBe(false)
-    expect(mockReportError).not.toHaveBeenCalled()
+    expect(reportError).not.toHaveBeenCalled()
   })
 
   it('discards a response resolved for a different workspace', async () => {
@@ -663,7 +661,7 @@ describe('useBillingCapabilities', () => {
     expect(billingCapabilities.canTopUp.value).toBe(true)
     expect(billingCapabilities.canSubscribeSelfServe.value).toBe(true)
     expect(billingCapabilities.isReady.value).toBe(true)
-    expect(mockReportError).toHaveBeenCalledOnce()
+    expect(reportError).toHaveBeenCalledOnce()
   })
 
   it('retries on a fixed interval after a background refresh fails', async () => {
@@ -910,7 +908,7 @@ describe('useBillingCapabilities', () => {
     await vi.advanceTimersByTimeAsync(2_000)
     expect(mockGetBillingCapabilities).toHaveBeenCalledTimes(4)
 
-    expect(mockReportError).toHaveBeenCalledOnce()
+    expect(reportError).toHaveBeenCalledOnce()
   })
 
   it('keeps the owner top-up fallback readable while a retry is in flight', async () => {

--- a/src/platform/workspace/composables/useWorkspaceBilling.test.ts
+++ b/src/platform/workspace/composables/useWorkspaceBilling.test.ts
@@ -5,6 +5,7 @@ import type {
   BillingStatusResponse,
   SubscribeResponse
 } from '@/platform/workspace/api/workspaceApi'
+import { reportError } from '@/platform/telemetry/reportError'
 import { useWorkspaceBilling } from '@/platform/workspace/composables/useWorkspaceBilling'
 
 const mockWorkspaceApi = vi.hoisted(() => ({
@@ -30,7 +31,6 @@ const mockShow = vi.hoisted(() => vi.fn())
 const mockStartOperation = vi.hoisted(() => vi.fn())
 const mockGetOperation = vi.hoisted(() => vi.fn())
 const mockSetWorkspaceBillingRail = vi.hoisted(() => vi.fn())
-const mockReportError = vi.hoisted(() => vi.fn())
 const mockActiveWorkspaceId = vi.hoisted(() => ({ value: 'workspace-1' }))
 
 // Hoisted so the vi.mock factory below can reference it: a plain top-level
@@ -75,9 +75,7 @@ vi.mock('@/platform/workspace/stores/billingOperationStore', () => ({
   })
 }))
 
-vi.mock('@/platform/telemetry/reportError', () => ({
-  reportError: mockReportError
-}))
+vi.mock('@/platform/telemetry/reportError')
 
 vi.mock('@/platform/workspace/stores/teamWorkspaceStore', () => ({
   useTeamWorkspaceStore: () => ({
@@ -320,7 +318,7 @@ describe('useWorkspaceBilling', () => {
         undefined,
         actionUrl
       )
-      expect(mockReportError).not.toHaveBeenCalled()
+      expect(reportError).not.toHaveBeenCalled()
     })
 
     it('recovers a pending top-up as a top-up, not a subscription', async () => {
@@ -357,7 +355,7 @@ describe('useWorkspaceBilling', () => {
       const billing = setupBilling()
       await billing.fetchStatus()
 
-      expect(mockReportError).toHaveBeenCalledWith(
+      expect(reportError).toHaveBeenCalledWith(
         expect.objectContaining({
           message: expect.stringContaining('seat_change')
         }),

--- a/src/renderer/extensions/compositor/composables/useCompositorPsdDownload.test.ts
+++ b/src/renderer/extensions/compositor/composables/useCompositorPsdDownload.test.ts
@@ -1,19 +1,20 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { ref } from 'vue'
 
+import { downloadBlob } from '@/base/common/downloadUtil'
 import type { LayerEditorSession } from '@/renderer/extensions/layerEditor/composables/useLayerEditorSession'
 import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
 import { toNodeId } from '@/types/nodeId'
 
 import { useCompositorPsdDownload } from './useCompositorPsdDownload'
 
-const { buildSessionPsdBlob, downloadBlob, loadCompositorSession, toastAdd } =
-  vi.hoisted(() => ({
+const { buildSessionPsdBlob, loadCompositorSession, toastAdd } = vi.hoisted(
+  () => ({
     buildSessionPsdBlob: vi.fn(async () => new Blob(['psd'])),
-    downloadBlob: vi.fn(),
     loadCompositorSession: vi.fn().mockResolvedValue(0),
     toastAdd: vi.fn()
-  }))
+  })
+)
 
 vi.mock(
   '@/renderer/extensions/compositor/composables/compositorSession',
@@ -28,7 +29,7 @@ vi.mock(
     psdExportFilename: () => 'comfyui-layers-test.psd'
   })
 )
-vi.mock('@/base/common/downloadUtil', () => ({ downloadBlob }))
+vi.mock('@/base/common/downloadUtil')
 vi.mock('@/platform/updates/common/toastStore', () => ({
   useToastStore: () => ({ add: toastAdd })
 }))

--- a/src/renderer/extensions/layerEditor/composables/useLayerEditorExport.test.ts
+++ b/src/renderer/extensions/layerEditor/composables/useLayerEditorExport.test.ts
@@ -3,6 +3,7 @@ import { ref } from 'vue'
 
 import type { Psd } from 'ag-psd'
 
+import { downloadBlob } from '@/base/common/downloadUtil'
 import type { Document } from '@/renderer/extensions/layerEditor/engine/document'
 import { registerBuiltinKinds } from '@/renderer/extensions/layerEditor/engine/kinds'
 import { defaultMode } from '@/renderer/extensions/layerEditor/engine/mode'
@@ -15,14 +16,13 @@ import type {
 import { useLayerEditorExport } from './useLayerEditorExport'
 import type { LayerEditorSession } from './useLayerEditorSession'
 
-const { writePsd, downloadBlob, toastAdd } = vi.hoisted(() => ({
+const { writePsd, toastAdd } = vi.hoisted(() => ({
   writePsd: vi.fn((_psd: unknown) => new ArrayBuffer(4)),
-  downloadBlob: vi.fn(),
   toastAdd: vi.fn()
 }))
 
 vi.mock('ag-psd', () => ({ writePsd }))
-vi.mock('@/base/common/downloadUtil', () => ({ downloadBlob }))
+vi.mock('@/base/common/downloadUtil')
 vi.mock('@/platform/updates/common/toastStore', () => ({
   useToastStore: () => ({ add: toastAdd })
 }))
@@ -176,7 +176,7 @@ describe('useLayerEditorExport', () => {
     })
 
     expect(downloadBlob).toHaveBeenCalledTimes(1)
-    const [filename, blob] = downloadBlob.mock.calls[0] as [string, Blob]
+    const [filename, blob] = vi.mocked(downloadBlob).mock.calls[0]
     expect(filename).toMatch(/^comfyui-layers-\d{8}-\d{6}\.psd$/)
     expect(blob).toBeInstanceOf(Blob)
     expect(exporting.value).toBe(false)

--- a/src/renderer/extensions/vueNodes/VideoPreview.test.ts
+++ b/src/renderer/extensions/vueNodes/VideoPreview.test.ts
@@ -8,9 +8,7 @@ import type { ComponentProps } from 'vue-component-type-helpers'
 
 import VideoPreview from '@/renderer/extensions/vueNodes/VideoPreview.vue'
 
-vi.mock('@/base/common/downloadUtil', () => ({
-  downloadFile: vi.fn()
-}))
+vi.mock('@/base/common/downloadUtil')
 
 const i18n = createI18n({
   legacy: false,

--- a/src/renderer/extensions/vueNodes/components/ImagePreview.test.ts
+++ b/src/renderer/extensions/vueNodes/components/ImagePreview.test.ts
@@ -10,10 +10,7 @@ import { createI18n } from 'vue-i18n'
 import { downloadFile } from '@/base/common/downloadUtil'
 import ImagePreview from '@/renderer/extensions/vueNodes/components/ImagePreview.vue'
 
-// Mock downloadFile to avoid DOM errors
-vi.mock('@/base/common/downloadUtil', () => ({
-  downloadFile: vi.fn()
-}))
+vi.mock('@/base/common/downloadUtil')
 
 vi.mock('@/services/hdrViewerService', () => ({
   openHdrViewer: vi.fn()

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetTextPreview.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetTextPreview.test.ts
@@ -7,6 +7,7 @@ import userEvent from '@testing-library/user-event'
 import { createPinia, setActivePinia } from 'pinia'
 import { describe, expect, it, vi } from 'vitest'
 
+import { downloadFile } from '@/base/common/downloadUtil'
 import type { NodeOutputWith, ResultItem } from '@/schemas/apiSchema'
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import { useNodeOutputStore } from '@/stores/nodeOutputStore'
@@ -35,19 +36,14 @@ vi.hoisted(() => {
   } as unknown as typeof ResizeObserver
 })
 
-const { downloadFileMock, copyMock } = vi.hoisted(() => ({
-  downloadFileMock: vi.fn(),
-  copyMock: vi.fn()
-}))
+const { copyMock } = vi.hoisted(() => ({ copyMock: vi.fn() }))
 
 vi.mock('vue-i18n', async (importOriginal) => ({
   ...(await importOriginal<typeof VueI18n>()),
   useI18n: () => ({ t: (key: string) => key })
 }))
 
-vi.mock('@/base/common/downloadUtil', () => ({
-  downloadFile: downloadFileMock
-}))
+vi.mock('@/base/common/downloadUtil')
 
 vi.mock('@/composables/useCopyToClipboard', () => ({
   useCopyToClipboard: () => ({ copyToClipboard: copyMock })
@@ -145,8 +141,8 @@ describe('WidgetTextPreview', () => {
 
     await userEvent.click(screen.getByRole('button', { name: 'g.download' }))
 
-    expect(downloadFileMock).toHaveBeenCalledTimes(1)
-    const [url, filename] = downloadFileMock.mock.calls[0]
+    expect(downloadFile).toHaveBeenCalledTimes(1)
+    const [url, filename] = vi.mocked(downloadFile).mock.calls[0]
     expect(url).toContain('/view?')
     expect(url).toContain('filename=result_00001.txt')
     expect(url).toContain('subfolder=sub')

--- a/src/renderer/extensions/vueNodes/widgets/components/audio/AudioPreviewPlayer.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/components/audio/AudioPreviewPlayer.test.ts
@@ -12,9 +12,7 @@ vi.mock('primevue/usetoast', () => ({
   useToast: () => ({ add: mockToastAdd })
 }))
 
-vi.mock('@/base/common/downloadUtil', () => ({
-  downloadFile: vi.fn()
-}))
+vi.mock('@/base/common/downloadUtil')
 
 const i18n = createI18n({
   legacy: false,

--- a/src/stores/bootstrapStore.test.ts
+++ b/src/stores/bootstrapStore.test.ts
@@ -5,6 +5,7 @@ import { ref } from 'vue'
 
 import { mergeCustomNodesI18n } from '@/i18n'
 import { useSettingStore } from '@/platform/settings/settingStore'
+import { reportError } from '@/platform/telemetry/reportError'
 import { api } from '@/scripts/api'
 
 import { useBootstrapStore } from './bootstrapStore'
@@ -66,10 +67,7 @@ const mockDistributionTypes = vi.hoisted(() => ({
 }))
 vi.mock('@/platform/distribution/types', () => mockDistributionTypes)
 
-const mockReportError = vi.hoisted(() => vi.fn())
-vi.mock('@/platform/telemetry/reportError', () => ({
-  reportError: mockReportError
-}))
+vi.mock('@/platform/telemetry/reportError')
 
 function requestFailure(status: number) {
   const error = new AxiosError(`Request failed with status code ${status}`)
@@ -136,7 +134,6 @@ describe('bootstrapStore', () => {
   describe('cloud mode', () => {
     beforeEach(() => {
       mockDistributionTypes.isCloud = true
-      mockReportError.mockReset()
     })
 
     it('waits for Firebase init before loading stores, then proceeds regardless of auth state', async () => {
@@ -176,7 +173,7 @@ describe('bootstrapStore', () => {
         await bootstrapPromise
 
         expect(settingStore.isReady).toBe(true)
-        expect(mockReportError).not.toHaveBeenCalled()
+        expect(reportError).not.toHaveBeenCalled()
       } finally {
         vi.useRealTimers()
       }
@@ -193,8 +190,8 @@ describe('bootstrapStore', () => {
         await vi.advanceTimersByTimeAsync(16_000 + 3_000 + 16_001)
         await bootstrapPromise
 
-        expect(mockReportError).toHaveBeenCalledOnce()
-        expect(mockReportError).toHaveBeenCalledWith(expect.anything(), {
+        expect(reportError).toHaveBeenCalledOnce()
+        expect(reportError).toHaveBeenCalledWith(expect.anything(), {
           errorType: 'bootstrap_auth_wait_timeout'
         })
         // Bootstrap must not stay stuck: stores load even when Firebase never fires.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -41,6 +41,7 @@
     "rootDir": "./"
   },
   "include": [
+    "__mocks__/**/*",
     ".storybook/**/*",
     "eslint.config.ts",
     "global.d.ts",


### PR DESCRIPTION
## Summary

Consolidates repeated module mocks beyond the asset tests into typed Vitest automocks.

## Changes

- **What**: Adds shared mocks for Firebase, download utilities, telemetry error reporting, and `LazyImage`; migrates repeated local factories.
- **Breaking**: None.
- **Dependencies**: None.

## Review Focus

Confirm the shared mocks preserve each suite's existing boundary while keeping scenario-specific behavior local.