### PR TITLE
fix(website): add the hub's caret-right icon to public icons

### DIFF
--- a/apps/website/public/icons/caret-right.svg
+++ b/apps/website/public/icons/caret-right.svg
@@ -1,0 +1,3 @@
+<svg preserveAspectRatio="none" overflow="visible" width="5.33333" height="9.33333" viewBox="0 0 5.33333 9.33333" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M0.666667 0.666667L4.66667 4.66667L0.666667 8.66667" stroke="#C2BFB9" stroke-width="1.33333" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>


### PR DESCRIPTION
## Summary

The workflows hub references /icons/caret-right.svg root-relatively, and behind the comfy.org router that path resolves against this app's public dir, where the file did not exist — so every ComfySelect caret on comfy.org/workflows pages 404s. Other hub icons (logomark, node-left, plus) already work only because copies live here.

## Changes

- **What**: Adds the hub's caret-right.svg (1 KB) to apps/website/public/icons/, matching the existing copies of the hub's other icons.

## Review Focus

- Companion to workflow_templates#1208 (the MiniMax H3 demo media fix). Long-term the router should forward hub static prefixes instead of relying on these copies.