### PR TITLE
fix: clarify missing core node version warning

### DIFF
--- a/src/components/rightSidePanel/errors/MissingNodeCard.test.ts
+++ b/src/components/rightSidePanel/errors/MissingNodeCard.test.ts
@@ -95,10 +95,10 @@ const i18n = createI18n({
         }
       },
       loadWorkflowWarning: {
-        outdatedVersion:
-          'Some nodes require a newer version of ComfyUI (current: {version}).',
-        outdatedVersionGeneric:
-          'Some nodes require a newer version of ComfyUI.',
+        newerVersionRequired:
+          'Some nodes require a newer version of ComfyUI (current: {version}). Please update to use all nodes.',
+        newerVersionRequiredGeneric:
+          'Some nodes require a newer version of ComfyUI. Please update to use all nodes.',
         coreNodesFromVersion: 'Requires ComfyUI {version}:',
         unknownVersion: 'unknown'
       }
@@ -311,7 +311,9 @@ describe('MissingNodeCard', () => {
       }
       renderCard()
       expect(
-        screen.getByText('Some nodes require a newer version of ComfyUI.')
+        screen.getByText(
+          'Some nodes require a newer version of ComfyUI. Please update to use all nodes.'
+        )
       ).toBeInTheDocument()
     })
 

--- a/src/components/rightSidePanel/errors/MissingNodeCard.vue
+++ b/src/components/rightSidePanel/errors/MissingNodeCard.vue
@@ -14,10 +14,10 @@
         <p class="m-0">
           {{
             currentComfyUIVersion
-              ? t('loadWorkflowWarning.outdatedVersion', {
+              ? t('loadWorkflowWarning.newerVersionRequired', {
                   version: currentComfyUIVersion
                 })
-              : t('loadWorkflowWarning.outdatedVersionGeneric')
+              : t('loadWorkflowWarning.newerVersionRequiredGeneric')
           }}
         </p>
         <div

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2130,8 +2130,8 @@
     "dismiss": "Dismiss"
   },
   "loadWorkflowWarning": {
-    "outdatedVersion": "This workflow was created with a newer version of ComfyUI ({version}). Some nodes may not work correctly.",
-    "outdatedVersionGeneric": "This workflow was created with a newer version of ComfyUI. Some nodes may not work correctly.",
+    "newerVersionRequired": "Some nodes require a newer version of ComfyUI (current: {version}). Please update to use all nodes.",
+    "newerVersionRequiredGeneric": "Some nodes require a newer version of ComfyUI. Please update to use all nodes.",
     "coreNodesFromVersion": "Core nodes from version {version}:",
     "unknownVersion": "unknown"
   },


### PR DESCRIPTION
## ELI5

The warning says a workflow was created with a newer ComfyUI version, but the number shown is actually the currently installed backend version. This changes the warning to say that some missing core nodes require a newer ComfyUI version and asks the user to update.

## Motivation

MissingNodeCard receives the current ComfyUI version from /system_stats. Describing that value as the workflow creation version is misleading. The new copy matches the actual data source and gives users the appropriate next step.

## Provenance

- **Authored by:** interactive session
- **Verified:** targeted MissingNodeCard tests, format check, lint, typecheck, knip, and locale check
- **Deviations:** none

## Reviewer context

- **Type:** bug fix for missing-core-node guidance
- **Slots into:** right-side-panel workflow issue reporting
- **Not in scope:** core-node metadata detection or workflow serialization

## Summary

Clarify that missing core nodes may require a newer ComfyUI version and that the displayed version is the current installation.

## Changes

- **What:** Replace the misleading workflow-creation wording with update guidance.
- **Localization:** Replace the old keys so the release translation pipeline queues the new copy and prunes the obsolete translations.

## Review Focus

Confirm that the warning distinguishes the current installed version from the required versions listed for missing core nodes.

## Test plan

- MissingNodeCard unit tests: 21 passed
- pnpm format:check
- pnpm lint: 0 errors
- pnpm typecheck
- pnpm knip
- pnpm locale:check: new keys queued for translation; 0 protected-token violations

## Screenshots

Before
<img width="569" height="127" alt="스크린샷 2026-08-28 오후 1 30 32" src="https://github.com/user-attachments/assets/f5d00960-f4f0-4101-92c8-a9206d03539b" />

After
<img width="558" height="111" alt="스크린샷 2026-08-28 오후 1 30 42" src="https://github.com/user-attachments/assets/73767250-d76c-4b11-b2ac-5267502d0bd2" />
