### PR TITLE
feat(website): sharpen SEO meta titles and descriptions for /learning, /download, and model pages

### DIFF
--- a/apps/website/e2e/learning.spec.ts
+++ b/apps/website/e2e/learning.spec.ts
@@ -30,29 +30,29 @@ const EXPECTED_META = {
     heading: 'ComfyUI Basics',
     description:
       'Beginner ComfyUI tutorials: learn the node graph, LoRAs, style transfer, and ControlNets from the ground up.',
-    title: 'ComfyUI Basics - Tutorials for Beginners'
+    title: 'ComfyUI Basics for Beginners: Node Graph, LoRAs, ControlNet'
   },
   vfx: {
     heading: 'VFX Tutorials',
     description:
       'Hands-on ComfyUI VFX tutorials: cleanplates, sky replacement, de-aging, mattes, and shot work you can open and run yourself.',
-    title: 'ComfyUI VFX Tutorials - Shot Work You Can Run'
+    title: 'ComfyUI VFX Tutorials: Cleanplates, Sky Replacement, Deaging'
   },
   animations: {
     heading: 'Animation Tutorials',
     description:
       'Hands-on ComfyUI animation tutorials: character sheets, keyframes, in-betweening, backgrounds, and compositing you can run yourself.',
-    title: 'ComfyUI Animation Tutorials - Character Sheets to Compositing'
+    title: 'ComfyUI Animation Tutorials: Character Sheets and Keyframes'
   },
   ads: {
     heading: 'Ad Creative Tutorials',
     description:
       'Hands-on ComfyUI ad creative tutorials: moodboards, storyboards, product photography, B-roll, and campaign assets you can run yourself.',
-    title: 'ComfyUI Ad Creative Tutorials - Moodboards to B-Roll'
+    title: 'ComfyUI Ad Creative Tutorials: Moodboards to Product Shots'
   }
 } as const
 
-const ROOT_TITLE = 'ComfyUI Tutorials - Learn ComfyUI by Discipline'
+const ROOT_TITLE = 'ComfyUI Tutorials: Free Video Series from Basics to VFX'
 
 test.describe('Learning page @smoke', () => {
   test.beforeEach(async ({ page }) => {
@@ -421,7 +421,7 @@ test.describe('Learning page (zh-CN) @smoke', () => {
   test('renders localized title, sidebar, and tutorials', async ({ page }) => {
     await page.goto('/zh-CN/learning')
 
-    await expect(page).toHaveTitle('ComfyUI 教程 - 按创作领域学习')
+    await expect(page).toHaveTitle('ComfyUI 教程：免费视频系列，从基础到 VFX')
     await expect(page.getByRole('heading', { level: 1 })).toContainText(
       /[一-鿿]/
     )

--- a/apps/website/e2e/learning.spec.ts
+++ b/apps/website/e2e/learning.spec.ts
@@ -29,28 +29,30 @@ const EXPECTED_META = {
   basics: {
     heading: 'ComfyUI Basics',
     description:
-      'Beginner ComfyUI tutorials — learn the node graph, LoRAs, style transfer, and ControlNets from the ground up.',
-    title: 'ComfyUI Basics - Comfy'
+      'Beginner ComfyUI tutorials: learn the node graph, LoRAs, style transfer, and ControlNets from the ground up.',
+    title: 'ComfyUI Basics - Tutorials for Beginners'
   },
   vfx: {
     heading: 'VFX Tutorials',
     description:
-      'Hands-on ComfyUI VFX tutorials — cleanplates, sky replacement, de-aging, mattes, and shot work you can open and run yourself.',
-    title: 'VFX Tutorials - Comfy'
+      'Hands-on ComfyUI VFX tutorials: cleanplates, sky replacement, de-aging, mattes, and shot work you can open and run yourself.',
+    title: 'ComfyUI VFX Tutorials - Shot Work You Can Run'
   },
   animations: {
     heading: 'Animation Tutorials',
     description:
-      'Hands-on ComfyUI animation tutorials — character sheets, keyframes, in-betweening, backgrounds, and compositing you can run yourself.',
-    title: 'Animation Tutorials - Comfy'
+      'Hands-on ComfyUI animation tutorials: character sheets, keyframes, in-betweening, backgrounds, and compositing you can run yourself.',
+    title: 'ComfyUI Animation Tutorials - Character Sheets to Compositing'
   },
   ads: {
     heading: 'Ad Creative Tutorials',
     description:
-      'Hands-on ComfyUI ad creative tutorials — moodboards, storyboards, product photography, B-roll, and campaign assets you can run yourself.',
-    title: 'Ad Creative Tutorials - Comfy'
+      'Hands-on ComfyUI ad creative tutorials: moodboards, storyboards, product photography, B-roll, and campaign assets you can run yourself.',
+    title: 'ComfyUI Ad Creative Tutorials - Moodboards to B-Roll'
   }
 } as const
+
+const ROOT_TITLE = 'ComfyUI Tutorials - Learn ComfyUI by Discipline'
 
 test.describe('Learning page @smoke', () => {
   test.beforeEach(async ({ page }) => {
@@ -58,7 +60,7 @@ test.describe('Learning page @smoke', () => {
   })
 
   test('has correct title', async ({ page }) => {
-    await expect(page).toHaveTitle('Learning - Comfy')
+    await expect(page).toHaveTitle(ROOT_TITLE)
   })
 
   test('sidebar shows the page heading and a link per category', async ({
@@ -204,7 +206,7 @@ test.describe('Learning category pages @smoke', () => {
 
     await page.goBack()
     await expect(page).toHaveURL('/learning')
-    await expect(page).toHaveTitle('Learning - Comfy')
+    await expect(page).toHaveTitle(ROOT_TITLE)
     await expect(
       categoryNav(page).locator('a[href="/learning"]')
     ).toHaveAttribute('aria-current', 'page')
@@ -419,7 +421,7 @@ test.describe('Learning page (zh-CN) @smoke', () => {
   test('renders localized title, sidebar, and tutorials', async ({ page }) => {
     await page.goto('/zh-CN/learning')
 
-    await expect(page).toHaveTitle('学习 - Comfy')
+    await expect(page).toHaveTitle('ComfyUI 教程 - 按创作领域学习')
     await expect(page.getByRole('heading', { level: 1 })).toContainText(
       /[一-鿿]/
     )

--- a/apps/website/e2e/learning.spec.ts
+++ b/apps/website/e2e/learning.spec.ts
@@ -10,6 +10,7 @@ import {
   populatedCategories,
   recommendedFor,
   tutorialDescription,
+  tutorialMetaTitle,
   tutorialPath
 } from '../src/data/learningTutorials'
 import { externalLinks } from '../src/config/routes'
@@ -30,24 +31,32 @@ const EXPECTED_META = {
     heading: 'ComfyUI Basics',
     description:
       'Beginner ComfyUI tutorials: learn the node graph, LoRAs, style transfer, and ControlNets from the ground up.',
+    metaDescription:
+      'Free ComfyUI tutorials for beginners. Learn the node graph first, then add LoRAs, style transfer, and ControlNets, with a workflow to open at every step.',
     title: 'ComfyUI Basics for Beginners: Node Graph, LoRAs, ControlNet'
   },
   vfx: {
     heading: 'VFX Tutorials',
     description:
       'Hands-on ComfyUI VFX tutorials: cleanplates, sky replacement, de-aging, mattes, and shot work you can open and run yourself.',
+    metaDescription:
+      'Free ComfyUI VFX tutorials with the workflows behind them: cleanplates, sky replacement, deaging, mattes, and frame adjustments for your own shots.',
     title: 'ComfyUI VFX Tutorials: Cleanplates, Sky Replacement, Deaging'
   },
   animations: {
     heading: 'Animation Tutorials',
     description:
       'Hands-on ComfyUI animation tutorials: character sheets, keyframes, in-betweening, backgrounds, and compositing you can run yourself.',
+    metaDescription:
+      'Free ComfyUI animation tutorials with workflows: character sheets, keyframes, in-betweening, backgrounds, and compositing, from concept art to final shot.',
     title: 'ComfyUI Animation Tutorials: Character Sheets and Keyframes'
   },
   ads: {
     heading: 'Ad Creative Tutorials',
     description:
       'Hands-on ComfyUI ad creative tutorials: moodboards, storyboards, product photography, B-roll, and campaign assets you can run yourself.',
+    metaDescription:
+      'Free ComfyUI tutorials for ad creative, each with its workflow: moodboards, storyboards, product photography, talent casting, B-roll, and OOH mockups.',
     title: 'ComfyUI Ad Creative Tutorials: Moodboards to Product Shots'
   }
 } as const
@@ -193,7 +202,7 @@ test.describe('Learning category pages @smoke', () => {
     await expect(page).toHaveTitle(EXPECTED_META.vfx.title)
     await expect(page.locator('meta[name="description"]')).toHaveAttribute(
       'content',
-      EXPECTED_META.vfx.description
+      EXPECTED_META.vfx.metaDescription
     )
   })
 
@@ -262,7 +271,7 @@ test.describe('Learning tutorial page @smoke', () => {
       .click()
 
     await expect(page).toHaveURL(tutorialPath(firstTutorial))
-    await expect(page).toHaveTitle(`${firstTutorial.title.en} - Comfy`)
+    await expect(page).toHaveTitle(tutorialMetaTitle(firstTutorial, 'en'))
   })
 
   test('the page exposes an indexable heading and autoplay video', async ({
@@ -371,7 +380,7 @@ test.describe('Learning tutorial page @smoke', () => {
   test('renders under the zh-CN locale', async ({ page }) => {
     const zhPath = `/zh-CN${tutorialPath(firstTutorial)}`
     await page.goto(zhPath)
-    await expect(page).toHaveTitle(`${firstTutorial.title['zh-CN']} - Comfy`)
+    await expect(page).toHaveTitle(tutorialMetaTitle(firstTutorial, 'zh-CN'))
     await expect(page.getByRole('heading', { level: 1 })).toHaveText(
       firstTutorial.title['zh-CN']
     )

--- a/apps/website/src/components/learning/LearningDirectoryPage.astro
+++ b/apps/website/src/components/learning/LearningDirectoryPage.astro
@@ -11,6 +11,7 @@ import {
   categoryLabelKeys,
   filterByCategory,
   learningCrumbs,
+  learningKeywords,
   learningMetaDescription,
   learningMetaTitle,
   tutorialPath
@@ -39,18 +40,7 @@ const learningTitle = t('learning.title', locale)
 const label = category ? t(categoryLabelKeys[category], locale) : undefined
 const title = learningMetaTitle(locale, category)
 const description = learningMetaDescription(locale, category)
-const keywords = category
-  ? undefined
-  : [
-      'comfyui tutorial',
-      'comfyui tutorials',
-      'learn comfyui',
-      'comfyui course',
-      'comfyui training',
-      'comfyui basics',
-      'comfyui vfx',
-      'comfyui animation'
-    ]
+const keywords = learningKeywords(category)
 
 const tutorialList = itemListNode(
   url,

--- a/apps/website/src/components/learning/LearningDirectoryPage.astro
+++ b/apps/website/src/components/learning/LearningDirectoryPage.astro
@@ -11,7 +11,7 @@ import {
   categoryLabelKeys,
   filterByCategory,
   learningCrumbs,
-  learningDescription,
+  learningMetaDescription,
   learningMetaTitle,
   tutorialPath
 } from '../../data/learningTutorials'
@@ -38,7 +38,19 @@ const { locale, url } = pageContext(
 const learningTitle = t('learning.title', locale)
 const label = category ? t(categoryLabelKeys[category], locale) : undefined
 const title = learningMetaTitle(locale, category)
-const description = learningDescription(locale, category)
+const description = learningMetaDescription(locale, category)
+const keywords = category
+  ? undefined
+  : [
+      'comfyui tutorial',
+      'comfyui tutorials',
+      'learn comfyui',
+      'comfyui course',
+      'comfyui training',
+      'comfyui basics',
+      'comfyui vfx',
+      'comfyui animation'
+    ]
 
 const tutorialList = itemListNode(
   url,
@@ -60,6 +72,7 @@ const breadcrumbs = learningCrumbs(locale, category).map((crumb) => ({
 <BaseLayout
   title={title}
   description={description}
+  keywords={keywords}
   pageType="CollectionPage"
   mainEntityId={jsonLdId(url, 'itemlist')}
   breadcrumbs={breadcrumbs}

--- a/apps/website/src/components/learning/LearningTutorialPage.astro
+++ b/apps/website/src/components/learning/LearningTutorialPage.astro
@@ -10,6 +10,7 @@ import type { LearningTutorial } from '../../data/learningTutorials'
 import {
   learningCrumbs,
   tutorialDescription,
+  tutorialMetaTitle,
   youtubeEmbedUrl
 } from '../../data/learningTutorials'
 import type { JsonLdNode } from '../../utils/jsonLd'
@@ -62,7 +63,7 @@ const breadcrumbs = [
 ---
 
 <BaseLayout
-  title={`${title} - Comfy`}
+  title={tutorialMetaTitle(tutorial, locale)}
   description={description}
   ogImage={tutorial.poster}
   mainEntityId={videoId}

--- a/apps/website/src/data/learningTutorials.test.ts
+++ b/apps/website/src/data/learningTutorials.test.ts
@@ -4,6 +4,8 @@ import {
   categoryChapters,
   filterByCategory,
   learningCategories,
+  learningMetaDescription,
+  learningMetaTitle,
   learningTutorials,
   recommendedFor,
   youtubeEmbedUrl
@@ -86,5 +88,33 @@ describe('recommendedFor', () => {
     expect(recommendedFor(firstVfx, learningTutorials.length).length).toBe(
       learningTutorials.length - filterByCategory('vfx').length
     )
+  })
+})
+
+describe('directory meta', () => {
+  const locales = ['en', 'zh-CN'] as const
+  const pages = [undefined, ...learningCategories]
+
+  it('names ComfyUI in every directory page title', () => {
+    for (const locale of locales) {
+      for (const category of pages) {
+        expect(learningMetaTitle(locale, category)).toContain('ComfyUI')
+      }
+    }
+  })
+
+  it('gives every directory page a meta description', () => {
+    for (const locale of locales) {
+      for (const category of pages) {
+        expect(learningMetaDescription(locale, category)).not.toBe('')
+      }
+    }
+  })
+
+  it('keeps en meta copy free of em dashes', () => {
+    for (const category of pages) {
+      expect(learningMetaTitle('en', category)).not.toContain('—')
+      expect(learningMetaDescription('en', category)).not.toContain('—')
+    }
   })
 })

--- a/apps/website/src/data/learningTutorials.test.ts
+++ b/apps/website/src/data/learningTutorials.test.ts
@@ -4,10 +4,12 @@ import {
   categoryChapters,
   filterByCategory,
   learningCategories,
+  learningKeywords,
   learningMetaDescription,
   learningMetaTitle,
   learningTutorials,
   recommendedFor,
+  tutorialMetaTitle,
   youtubeEmbedUrl
 } from './learningTutorials'
 
@@ -92,29 +94,112 @@ describe('recommendedFor', () => {
 })
 
 describe('directory meta', () => {
-  const locales = ['en', 'zh-CN'] as const
-  const pages = [undefined, ...learningCategories]
-
-  it('names ComfyUI in every directory page title', () => {
-    for (const locale of locales) {
-      for (const category of pages) {
-        expect(learningMetaTitle(locale, category)).toContain('ComfyUI')
+  const expected = {
+    en: {
+      root: {
+        title: 'ComfyUI Tutorials: Free Video Series from Basics to VFX',
+        description:
+          'Learn ComfyUI with free video tutorials and the workflows behind them. Start with the node graph basics, then move into VFX, animation, and ad creative.'
+      },
+      basics: {
+        title: 'ComfyUI Basics for Beginners: Node Graph, LoRAs, ControlNet',
+        description:
+          'Free ComfyUI tutorials for beginners. Learn the node graph first, then add LoRAs, style transfer, and ControlNets, with a workflow to open at every step.'
+      },
+      vfx: {
+        title: 'ComfyUI VFX Tutorials: Cleanplates, Sky Replacement, Deaging',
+        description:
+          'Free ComfyUI VFX tutorials with the workflows behind them: cleanplates, sky replacement, deaging, mattes, and frame adjustments for your own shots.'
+      },
+      animations: {
+        title: 'ComfyUI Animation Tutorials: Character Sheets and Keyframes',
+        description:
+          'Free ComfyUI animation tutorials with workflows: character sheets, keyframes, in-betweening, backgrounds, and compositing, from concept art to final shot.'
+      },
+      ads: {
+        title: 'ComfyUI Ad Creative Tutorials: Moodboards to Product Shots',
+        description:
+          'Free ComfyUI tutorials for ad creative, each with its workflow: moodboards, storyboards, product photography, talent casting, B-roll, and OOH mockups.'
+      }
+    },
+    'zh-CN': {
+      root: {
+        title: 'ComfyUI 教程：免费视频系列，从基础到 VFX',
+        description:
+          '通过免费视频教程和配套工作流学习 ComfyUI。从节点图基础开始，再进入 VFX、动画与广告创意。'
+      },
+      basics: {
+        title: 'ComfyUI 基础教程：节点图、LoRA 与 ControlNet 新手入门',
+        description:
+          '面向初学者的免费 ComfyUI 教程。先学节点图，再加入 LoRA、风格迁移与 ControlNet，每一步都有可打开的工作流。'
+      },
+      vfx: {
+        title: 'ComfyUI VFX 教程：净板、天空替换与减龄',
+        description:
+          '免费 ComfyUI VFX 教程与配套工作流：净板、天空替换、减龄、遮罩与帧调整，可用于你自己的镜头。'
+      },
+      animations: {
+        title: 'ComfyUI 动画教程：角色设定表与关键帧',
+        description:
+          '免费 ComfyUI 动画教程与工作流：角色设定表、关键帧、中间帧、背景与合成，从概念美术到完成镜头。'
+      },
+      ads: {
+        title: 'ComfyUI 广告创意教程：从情绪板到产品摄影',
+        description:
+          '面向广告创意的免费 ComfyUI 教程，每个都配有工作流：情绪板、故事板、产品摄影、演员预演、B-Roll 与户外广告样机。'
       }
     }
-  })
+  } as const
 
-  it('gives every directory page a meta description', () => {
-    for (const locale of locales) {
-      for (const category of pages) {
-        expect(learningMetaDescription(locale, category)).not.toBe('')
-      }
+  for (const locale of ['en', 'zh-CN'] as const) {
+    it(`renders the ${locale} root title and description`, () => {
+      expect(learningMetaTitle(locale)).toBe(expected[locale].root.title)
+      expect(learningMetaDescription(locale)).toBe(
+        expected[locale].root.description
+      )
+    })
+
+    for (const category of learningCategories) {
+      it(`renders the ${locale} ${category} title and description`, () => {
+        expect(learningMetaTitle(locale, category)).toBe(
+          expected[locale][category].title
+        )
+        expect(learningMetaDescription(locale, category)).toBe(
+          expected[locale][category].description
+        )
+      })
     }
-  })
+  }
 
   it('keeps en meta copy free of em dashes', () => {
-    for (const category of pages) {
+    for (const category of [undefined, ...learningCategories]) {
       expect(learningMetaTitle('en', category)).not.toContain('—')
       expect(learningMetaDescription('en', category)).not.toContain('—')
     }
+  })
+
+  it('emits keywords for the root page only', () => {
+    expect(learningKeywords()).toContain('comfyui tutorial')
+    for (const category of learningCategories) {
+      expect(learningKeywords(category)).toBeUndefined()
+    }
+  })
+})
+
+describe('tutorialMetaTitle', () => {
+  const basics = filterByCategory('basics')[0]
+
+  it('appends the tutorial suffix per locale', () => {
+    expect(tutorialMetaTitle(firstVfx, 'en')).toBe(
+      `${firstVfx.title.en}: Free ComfyUI Tutorial`
+    )
+    expect(tutorialMetaTitle(firstVfx, 'zh-CN')).toBe(
+      `${firstVfx.title['zh-CN']}：免费 ComfyUI 教程`
+    )
+  })
+
+  it('leaves titles that already name ComfyUI untouched', () => {
+    expect(basics.title.en).toContain('ComfyUI')
+    expect(tutorialMetaTitle(basics, 'en')).toBe(basics.title.en)
   })
 })

--- a/apps/website/src/data/learningTutorials.test.ts
+++ b/apps/website/src/data/learningTutorials.test.ts
@@ -201,5 +201,7 @@ describe('tutorialMetaTitle', () => {
   it('leaves titles that already name ComfyUI untouched', () => {
     expect(basics.title.en).toContain('ComfyUI')
     expect(tutorialMetaTitle(basics, 'en')).toBe(basics.title.en)
+    expect(basics.title['zh-CN']).toContain('ComfyUI')
+    expect(tutorialMetaTitle(basics, 'zh-CN')).toBe(basics.title['zh-CN'])
   })
 })

--- a/apps/website/src/data/learningTutorials.ts
+++ b/apps/website/src/data/learningTutorials.ts
@@ -83,7 +83,7 @@ const categoryHeadingKeys: Record<LearningCategory, TranslationKey> = {
   ads: 'learning.categories.ads.heading'
 }
 
-/** Per-vertical lead-in, reused as the page description / meta description. */
+/** Per-vertical visible lead-in under the h1. */
 const categoryDescriptionKeys: Record<LearningCategory, TranslationKey> = {
   basics: 'learning.categories.basics.description',
   vfx: 'learning.categories.vfx.description',
@@ -100,6 +100,13 @@ const categoryMetaTitleKeys: Record<LearningCategory, TranslationKey> = {
   ads: 'learning.categories.ads.metaTitle'
 }
 
+const categoryMetaDescriptionKeys: Record<LearningCategory, TranslationKey> = {
+  basics: 'learning.categories.basics.metaDescription',
+  vfx: 'learning.categories.vfx.metaDescription',
+  animations: 'learning.categories.animations.metaDescription',
+  ads: 'learning.categories.ads.metaDescription'
+}
+
 /** Visible h1 for a directory page: per-vertical when filtered, else generic. */
 export const learningHeading = (
   locale: Locale,
@@ -107,7 +114,7 @@ export const learningHeading = (
 ): string =>
   t(category ? categoryHeadingKeys[category] : 'learning.title', locale)
 
-/** Lead-in and meta description for a directory page. */
+/** Visible lead-in for a directory page. */
 export const learningDescription = (
   locale: Locale,
   category?: LearningCategory
@@ -121,17 +128,35 @@ export const learningMetaTitle = (
 ): string =>
   t(category ? categoryMetaTitleKeys[category] : 'learning.metaTitle', locale)
 
-/** Meta description for a directory page: the root page gets a fuller
- * description than its one-line visible tagline; category pages reuse their
- * lead-in. */
+/** Meta description for a directory page, written for the SERP rather than
+ * reusing the visible lead-in. */
 export const learningMetaDescription = (
   locale: Locale,
   category?: LearningCategory
 ): string =>
   t(
-    category ? categoryDescriptionKeys[category] : 'learning.metaDescription',
+    category
+      ? categoryMetaDescriptionKeys[category]
+      : 'learning.metaDescription',
     locale
   )
+
+/** Meta keywords for the root directory page only. */
+export const learningKeywords = (
+  category?: LearningCategory
+): string[] | undefined =>
+  category
+    ? undefined
+    : [
+        'comfyui tutorial',
+        'comfyui tutorials',
+        'learn comfyui',
+        'comfyui course',
+        'comfyui training',
+        'comfyui basics',
+        'comfyui vfx',
+        'comfyui animation'
+      ]
 
 const partnerNodesTag: TranslationKey = 'tags.partnerNodes'
 const imageToVideoTag: TranslationKey = 'tags.imageToVideo'
@@ -178,9 +203,9 @@ export const learningTutorials: readonly LearningTutorial[] = [
       'zh-CN': 'ComfyUI 新手教程：完整节点图基础 (2026)'
     },
     description: {
-      en: "A beginner's tour of the ComfyUI node graph — how nodes, links, and the run queue fit together to build your first working pipeline.",
+      en: "A beginner's tour of the ComfyUI node graph: how nodes, links, and the run queue fit together to build your first working pipeline.",
       'zh-CN':
-        '面向初学者的 ComfyUI 节点图入门——了解节点、连线与运行队列如何协同，搭建你的第一条可用流程。'
+        '面向初学者的 ComfyUI 节点图入门：了解节点、连线与运行队列如何协同，搭建你的第一条可用流程。'
     },
     poster: 'https://img.youtube.com/vi/TQhIYT1ZYGQ/maxresdefault.jpg',
     href: externalLinks.cloudCta('learning_basics_node_graph'),
@@ -201,9 +226,9 @@ export const learningTutorials: readonly LearningTutorial[] = [
       'zh-CN': 'ComfyUI 新手教程：LoRA、风格迁移与 ControlNet (2026)'
     },
     description: {
-      en: 'Go further with LoRAs, style transfer, and ControlNets — what each one does and how to wire them into a ComfyUI workflow.',
+      en: 'Go further with LoRAs, style transfer, and ControlNets: what each one does and how to wire them into a ComfyUI workflow.',
       'zh-CN':
-        '进阶了解 LoRA、风格迁移与 ControlNet——各自的作用，以及如何将它们接入 ComfyUI 工作流。'
+        '进阶了解 LoRA、风格迁移与 ControlNet：各自的作用，以及如何将它们接入 ComfyUI 工作流。'
     },
     poster: 'https://img.youtube.com/vi/-igiHGaxKek/maxresdefault.jpg',
     href: externalLinks.cloudCta('learning_basics_loras'),
@@ -361,9 +386,9 @@ export const learningTutorials: readonly LearningTutorial[] = [
     author: shaneFu,
     title: { en: 'Character Sheet', 'zh-CN': '角色设定表' },
     description: {
-      en: 'Turn concept art into a full character sheet with this ComfyUI workflow — GPT Image 2 generates body turnarounds and face close-ups, then auto-stitches them.',
+      en: 'Turn concept art into a full character sheet with this ComfyUI workflow: GPT Image 2 generates body turnarounds and face close-ups, then auto-stitches them.',
       'zh-CN':
-        '用此 ComfyUI 工作流将概念美术转化为完整的角色设定表——GPT Image 2 生成全身转身视图与面部特写，并自动拼接成一张图。'
+        '用此 ComfyUI 工作流将概念美术转化为完整的角色设定表：GPT Image 2 生成全身转身视图与面部特写，并自动拼接成一张图。'
     },
     videoSrc: 'https://media.comfy.org/website/learning/animation1.mp4',
     poster: 'https://media.comfy.org/website/learning/animation1-thumb.jpg',
@@ -388,9 +413,9 @@ export const learningTutorials: readonly LearningTutorial[] = [
     author: shaneFu,
     title: { en: 'Keyframe Exploration', 'zh-CN': '关键帧探索' },
     description: {
-      en: 'Generate a character keyframe at any camera angle with this ComfyUI workflow — set direction, elevation, and distance, then GPT Image 2 renders the shot.',
+      en: 'Generate a character keyframe at any camera angle with this ComfyUI workflow: set direction, elevation, and distance, then GPT Image 2 renders the shot.',
       'zh-CN':
-        '用此 ComfyUI 工作流在任意机位角度生成角色关键帧——设置方向、俯仰和距离，再由 GPT Image 2 渲染出画面。'
+        '用此 ComfyUI 工作流在任意机位角度生成角色关键帧：设置方向、俯仰和距离，再由 GPT Image 2 渲染出画面。'
     },
     videoSrc: 'https://media.comfy.org/website/learning/animation2.mp4',
     poster: 'https://media.comfy.org/website/learning/animation2-thumb.jpg',
@@ -415,9 +440,9 @@ export const learningTutorials: readonly LearningTutorial[] = [
     author: shaneFu,
     title: { en: 'Background and Asset Generation', 'zh-CN': '背景与素材生成' },
     description: {
-      en: 'Apply a production frame’s style to backgrounds and props with this ComfyUI workflow — GPT Image 2 paints sketches to match, with auto background removal.',
+      en: 'Apply a production frame’s style to backgrounds and props with this ComfyUI workflow: GPT Image 2 paints sketches to match, with auto background removal.',
       'zh-CN':
-        '用此 ComfyUI 工作流将制作帧的风格应用到背景与道具——GPT Image 2 将草图绘制成匹配风格，并自动去除背景。'
+        '用此 ComfyUI 工作流将制作帧的风格应用到背景与道具：GPT Image 2 将草图绘制成匹配风格，并自动去除背景。'
     },
     videoSrc: 'https://media.comfy.org/website/learning/animation3.mp4',
     poster: 'https://media.comfy.org/website/learning/animation3-thumb.jpg',
@@ -447,9 +472,9 @@ export const learningTutorials: readonly LearningTutorial[] = [
     author: shaneFu,
     title: { en: 'Concept Exploration', 'zh-CN': '概念探索' },
     description: {
-      en: 'Turn concept art into a poseable 3D proxy with this ComfyUI workflow — Tripo builds the model, then generate a styled still or camera-move video from any angle.',
+      en: 'Turn concept art into a poseable 3D proxy with this ComfyUI workflow: Tripo builds the model, then generate a styled still or camera-move video from any angle.',
       'zh-CN':
-        '用此 ComfyUI 工作流将概念美术转化为可摆姿的 3D 代理——Tripo 生成模型，再从任意角度生成风格化静帧或运镜视频。'
+        '用此 ComfyUI 工作流将概念美术转化为可摆姿的 3D 代理：Tripo 生成模型，再从任意角度生成风格化静帧或运镜视频。'
     },
     videoSrc: 'https://media.comfy.org/website/learning/animation4.mp4',
     poster: 'https://media.comfy.org/website/learning/animation4-thumb.jpg',
@@ -474,9 +499,9 @@ export const learningTutorials: readonly LearningTutorial[] = [
     author: shaneFu,
     title: { en: 'In-Betweening', 'zh-CN': '中间帧绘制' },
     description: {
-      en: 'Generate the in-between frames from a sequence of keyframes with this ComfyUI workflow — Wan 2.2 interpolates each pair into one assembled character animation.',
+      en: 'Generate the in-between frames from a sequence of keyframes with this ComfyUI workflow: Wan 2.2 interpolates each pair into one assembled character animation.',
       'zh-CN':
-        '用此 ComfyUI 工作流从关键帧序列生成中间帧——Wan 2.2 对每一对关键帧进行插值，拼接成一段完整的角色动画。'
+        '用此 ComfyUI 工作流从关键帧序列生成中间帧：Wan 2.2 对每一对关键帧进行插值，拼接成一段完整的角色动画。'
     },
     videoSrc: 'https://media.comfy.org/website/learning/animation5.mp4',
     poster: 'https://media.comfy.org/website/learning/animation5-thumb.jpg',
@@ -501,9 +526,9 @@ export const learningTutorials: readonly LearningTutorial[] = [
     author: shaneFu,
     title: { en: 'Background and Compositing', 'zh-CN': '背景与合成' },
     description: {
-      en: 'Animate backgrounds and composite characters with this ComfyUI workflow — Cdance loops still backgrounds, then blends the character with matched lighting.',
+      en: 'Animate backgrounds and composite characters with this ComfyUI workflow: Cdance loops still backgrounds, then blends the character with matched lighting.',
       'zh-CN':
-        '用此 ComfyUI 工作流让背景动起来并合成角色——Cdance 将静态背景生成循环动画，再以匹配的光照将角色融合其中。'
+        '用此 ComfyUI 工作流让背景动起来并合成角色：Cdance 将静态背景生成循环动画，再以匹配的光照将角色融合其中。'
     },
     videoSrc: 'https://media.comfy.org/website/learning/animation6.mp4',
     poster: 'https://media.comfy.org/website/learning/animation6-thumb.jpg',
@@ -528,9 +553,9 @@ export const learningTutorials: readonly LearningTutorial[] = [
     author: shaneFu,
     title: { en: 'Moodboard Creation', 'zh-CN': '情绪板制作' },
     description: {
-      en: 'Turn mood board selects into fresh, on-brand ad visuals with this ComfyUI workflow — extract a style with Recraft, or alter elements with GPT Image 2.',
+      en: 'Turn mood board selects into fresh, on-brand ad visuals with this ComfyUI workflow: extract a style with Recraft, or alter elements with GPT Image 2.',
       'zh-CN':
-        '通过此 ComfyUI 工作流，将情绪板参考图转化为符合品牌调性的全新广告视觉——用 Recraft 提取风格，或用 GPT Image 2 调整元素。'
+        '通过此 ComfyUI 工作流，将情绪板参考图转化为符合品牌调性的全新广告视觉：用 Recraft 提取风格，或用 GPT Image 2 调整元素。'
     },
     videoSrc: 'https://media.comfy.org/website/learning/advertising1.mp4',
     poster: 'https://media.comfy.org/website/learning/advertising1-thumb.png',
@@ -555,9 +580,9 @@ export const learningTutorials: readonly LearningTutorial[] = [
     author: shaneFu,
     title: { en: 'Storyboard Creation', 'zh-CN': '故事板制作' },
     description: {
-      en: 'Generate an ad storyboard from a shot list, then render polished style frames — a ComfyUI workflow using GPT Image and NanoBanana Pro across two passes.',
+      en: 'Generate an ad storyboard from a shot list, then render polished style frames: a ComfyUI workflow using GPT Image and NanoBanana Pro across two passes.',
       'zh-CN':
-        '通过此 ComfyUI 工作流，从镜头表生成广告故事板，再渲染精致的风格帧——两个阶段分别使用 GPT Image 与 NanoBanana Pro。'
+        '通过此 ComfyUI 工作流，从镜头表生成广告故事板，再渲染精致的风格帧：两个阶段分别使用 GPT Image 与 NanoBanana Pro。'
     },
     videoSrc: 'https://media.comfy.org/website/learning/advertising2.mp4',
     poster: 'https://media.comfy.org/website/learning/advertising2-thumb.png',
@@ -587,9 +612,9 @@ export const learningTutorials: readonly LearningTutorial[] = [
     author: shaneFu,
     title: { en: 'Product Photography', 'zh-CN': '产品摄影' },
     description: {
-      en: 'Generate, retouch, and animate product shots in one ComfyUI workflow — place products with GPT Image, mask-edit details, then create a hero video.',
+      en: 'Generate, retouch, and animate product shots in one ComfyUI workflow: place products with GPT Image, mask-edit details, then create a hero video.',
       'zh-CN':
-        '在一套 ComfyUI 工作流中生成、修饰并让产品照片动起来——用 GPT Image 置入产品，蒙版编辑细节，再生成主打视频。'
+        '在一套 ComfyUI 工作流中生成、修饰并让产品照片动起来：用 GPT Image 置入产品，蒙版编辑细节，再生成主打视频。'
     },
     videoSrc: 'https://media.comfy.org/website/learning/advertising3.mp4',
     poster: 'https://media.comfy.org/website/learning/advertising3-thumb.png',
@@ -619,9 +644,9 @@ export const learningTutorials: readonly LearningTutorial[] = [
     author: shaneFu,
     title: { en: 'Talent Casting', 'zh-CN': '演员选角' },
     description: {
-      en: 'Preview talent in a scene before the shoot with this ComfyUI workflow — generate a previs still with Gemini Image 2, then animate it into a clip with Kling.',
+      en: 'Preview talent in a scene before the shoot with this ComfyUI workflow: generate a previs still with Gemini Image 2, then animate it into a clip with Kling.',
       'zh-CN':
-        '在开拍前用此 ComfyUI 工作流预览演员在场景中的效果——用 Gemini Image 2 生成预演静帧，再用 Kling 将其动画化为短片。'
+        '在开拍前用此 ComfyUI 工作流预览演员在场景中的效果：用 Gemini Image 2 生成预演静帧，再用 Kling 将其动画化为短片。'
     },
     videoSrc: 'https://media.comfy.org/website/learning/advertising4.mp4',
     poster: 'https://media.comfy.org/website/learning/advertising4-thumb.png',
@@ -651,9 +676,9 @@ export const learningTutorials: readonly LearningTutorial[] = [
     author: shaneFu,
     title: { en: 'B-Roll Creation', 'zh-CN': 'B-Roll 素材制作' },
     description: {
-      en: 'Create or edit B-roll three ways in one ComfyUI workflow — generate a clip from a prompt, place a subject into a reference scene, or alter existing footage.',
+      en: 'Create or edit B-roll three ways in one ComfyUI workflow: generate a clip from a prompt, place a subject into a reference scene, or alter existing footage.',
       'zh-CN':
-        '在一套 ComfyUI 工作流中以三种方式创建或编辑 B-Roll 素材——用提示词生成片段、将主体置入参考场景，或修改现有素材。'
+        '在一套 ComfyUI 工作流中以三种方式创建或编辑 B-Roll 素材：用提示词生成片段、将主体置入参考场景，或修改现有素材。'
     },
     videoSrc: 'https://media.comfy.org/website/learning/advertising5.mp4',
     poster: 'https://media.comfy.org/website/learning/advertising5-thumb.png',
@@ -678,9 +703,9 @@ export const learningTutorials: readonly LearningTutorial[] = [
     author: shaneFu,
     title: { en: 'OOH Visualization', 'zh-CN': '户外广告可视化' },
     description: {
-      en: 'Place a poster into real-world outdoor ad spots with this ComfyUI workflow — auto-generate billboard, transit, and building-wrap mockups with Gemini Image 2.',
+      en: 'Place a poster into real-world outdoor ad spots with this ComfyUI workflow: auto-generate billboard, transit, and building-wrap mockups with Gemini Image 2.',
       'zh-CN':
-        '用此 ComfyUI 工作流将海报置入真实的户外广告场景——通过 Gemini Image 2 自动生成广告牌、公交站台和楼体包装样机。'
+        '用此 ComfyUI 工作流将海报置入真实的户外广告场景：通过 Gemini Image 2 自动生成广告牌、公交站台和楼体包装样机。'
     },
     videoSrc: 'https://media.comfy.org/website/learning/advertising6.mp4',
     poster: 'https://media.comfy.org/website/learning/advertising6-thumb.png',
@@ -798,6 +823,19 @@ export const tutorialDescription = (
   const title = tutorial.title[locale]
   const label = t(categoryLabelKeys[tutorial.category], locale)
   return locale === 'zh-CN'
-    ? `观看《${title}》教程——一个可亲自体验的 ComfyUI ${label} 实战工作流。`
-    : `Watch the ${title} tutorial — a hands-on ComfyUI ${label} workflow you can try yourself.`
+    ? `观看《${title}》教程：一个可亲自体验的 ComfyUI ${label} 实战工作流。`
+    : `Watch the ${title} tutorial: a hands-on ComfyUI ${label} workflow you can try yourself.`
+}
+
+/** Document title for a tutorial page. Titles that already name ComfyUI (the
+ * beginner series) stand on their own. */
+export const tutorialMetaTitle = (
+  tutorial: LearningTutorial,
+  locale: Locale
+): string => {
+  const title = tutorial.title[locale]
+  if (title.includes('ComfyUI')) return title
+  return locale === 'zh-CN'
+    ? `${title}：免费 ComfyUI 教程`
+    : `${title}: Free ComfyUI Tutorial`
 }

--- a/apps/website/src/data/learningTutorials.ts
+++ b/apps/website/src/data/learningTutorials.ts
@@ -91,6 +91,15 @@ const categoryDescriptionKeys: Record<LearningCategory, TranslationKey> = {
   ads: 'learning.categories.ads.description'
 }
 
+/** Per-vertical document title, decoupled from the h1 so SERP copy can carry
+ * the queries searchers actually use without changing the page design. */
+const categoryMetaTitleKeys: Record<LearningCategory, TranslationKey> = {
+  basics: 'learning.categories.basics.metaTitle',
+  vfx: 'learning.categories.vfx.metaTitle',
+  animations: 'learning.categories.animations.metaTitle',
+  ads: 'learning.categories.ads.metaTitle'
+}
+
 /** Visible h1 for a directory page: per-vertical when filtered, else generic. */
 export const learningHeading = (
   locale: Locale,
@@ -109,7 +118,20 @@ export const learningDescription = (
 export const learningMetaTitle = (
   locale: Locale,
   category?: LearningCategory
-): string => `${learningHeading(locale, category)} - Comfy`
+): string =>
+  t(category ? categoryMetaTitleKeys[category] : 'learning.metaTitle', locale)
+
+/** Meta description for a directory page: the root page gets a fuller
+ * description than its one-line visible tagline; category pages reuse their
+ * lead-in. */
+export const learningMetaDescription = (
+  locale: Locale,
+  category?: LearningCategory
+): string =>
+  t(
+    category ? categoryDescriptionKeys[category] : 'learning.metaDescription',
+    locale
+  )
 
 const partnerNodesTag: TranslationKey = 'tags.partnerNodes'
 const imageToVideoTag: TranslationKey = 'tags.imageToVideo'

--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -1829,6 +1829,11 @@ const translations = {
     'zh-CN':
       '面向初学者的 ComfyUI 教程：从零开始掌握节点图、LoRA、风格迁移与 ControlNet。'
   },
+  'learning.categories.basics.metaDescription': {
+    en: 'Free ComfyUI tutorials for beginners. Learn the node graph first, then add LoRAs, style transfer, and ControlNets, with a workflow to open at every step.',
+    'zh-CN':
+      '面向初学者的免费 ComfyUI 教程。先学节点图，再加入 LoRA、风格迁移与 ControlNet，每一步都有可打开的工作流。'
+  },
   'learning.categories.vfx.heading': {
     en: 'VFX Tutorials',
     'zh-CN': 'VFX 教程'
@@ -1841,6 +1846,11 @@ const translations = {
     en: 'Hands-on ComfyUI VFX tutorials: cleanplates, sky replacement, de-aging, mattes, and shot work you can open and run yourself.',
     'zh-CN':
       '实战 ComfyUI VFX 教程：净板、天空替换、减龄、遮罩与镜头处理，均可亲自打开并运行。'
+  },
+  'learning.categories.vfx.metaDescription': {
+    en: 'Free ComfyUI VFX tutorials with the workflows behind them: cleanplates, sky replacement, deaging, mattes, and frame adjustments for your own shots.',
+    'zh-CN':
+      '免费 ComfyUI VFX 教程与配套工作流：净板、天空替换、减龄、遮罩与帧调整，可用于你自己的镜头。'
   },
   'learning.categories.animations.heading': {
     en: 'Animation Tutorials',
@@ -1855,6 +1865,11 @@ const translations = {
     'zh-CN':
       '实战 ComfyUI 动画教程：角色设定表、关键帧、中间帧、背景与合成，均可亲自运行。'
   },
+  'learning.categories.animations.metaDescription': {
+    en: 'Free ComfyUI animation tutorials with workflows: character sheets, keyframes, in-betweening, backgrounds, and compositing, from concept art to final shot.',
+    'zh-CN':
+      '免费 ComfyUI 动画教程与工作流：角色设定表、关键帧、中间帧、背景与合成，从概念美术到完成镜头。'
+  },
   'learning.categories.ads.heading': {
     en: 'Ad Creative Tutorials',
     'zh-CN': '广告创意教程'
@@ -1867,6 +1882,11 @@ const translations = {
     en: 'Hands-on ComfyUI ad creative tutorials: moodboards, storyboards, product photography, B-roll, and campaign assets you can run yourself.',
     'zh-CN':
       '实战 ComfyUI 广告创意教程：情绪板、故事板、产品摄影、B-Roll 与广告素材，均可亲自运行。'
+  },
+  'learning.categories.ads.metaDescription': {
+    en: 'Free ComfyUI tutorials for ad creative, each with its workflow: moodboards, storyboards, product photography, talent casting, B-roll, and OOH mockups.',
+    'zh-CN':
+      '面向广告创意的免费 ComfyUI 教程，每个都配有工作流：情绪板、故事板、产品摄影、演员预演、B-Roll 与户外广告样机。'
   },
   // LearningWatchPage
   'learning.watch.nowWatching': { en: 'Now watching', 'zh-CN': '正在观看' },

--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -926,6 +926,14 @@ const translations = {
       '没有功能限制、没有试用期、核心功能没有"专业"层级。没有供应商可以锁定你或强迫你离开平台。构建自己的节点，随心修改 ComfyUI。'
   },
 
+  // Download – meta (decoupled from the hero subtitle so SERP copy can carry
+  // the download queries without changing the visible hero)
+  'download.meta.description': {
+    en: 'Download ComfyUI for Windows or macOS, or install from GitHub. The full open source engine, free forever, running on your own hardware.',
+    'zh-CN':
+      '下载适用于 Windows 或 macOS 的 ComfyUI，也可从 GitHub 安装。完整的开源引擎，永久免费，在你自己的硬件上运行。'
+  },
+
   // Download – HeroSection
   'download.hero.heading': {
     en: 'Run on your hardware.\nFree forever.',
@@ -1766,6 +1774,15 @@ const translations = {
 
   // LearningDirectorySection
   'learning.title': { en: 'Learning', 'zh-CN': '学习' },
+  'learning.metaTitle': {
+    en: 'ComfyUI Tutorials - Learn ComfyUI by Discipline',
+    'zh-CN': 'ComfyUI 教程 - 按创作领域学习'
+  },
+  'learning.metaDescription': {
+    en: 'Free hands-on ComfyUI tutorials with workflows you can open and run. Start with node graph basics, then go deeper into VFX, animation, and ad creative.',
+    'zh-CN':
+      '免费的 ComfyUI 实战教程，工作流可直接打开运行。从节点图基础开始，深入 VFX、动画与广告创意。'
+  },
   'learning.tagline': {
     en: 'Hands-on ComfyUI tutorials and workflows, by discipline.',
     'zh-CN': '按创作领域分类的 ComfyUI 实战教程与工作流。'
@@ -1803,8 +1820,12 @@ const translations = {
     en: 'ComfyUI Basics',
     'zh-CN': 'ComfyUI 基础教程'
   },
+  'learning.categories.basics.metaTitle': {
+    en: 'ComfyUI Basics - Tutorials for Beginners',
+    'zh-CN': 'ComfyUI 基础教程 - 新手入门'
+  },
   'learning.categories.basics.description': {
-    en: 'Beginner ComfyUI tutorials — learn the node graph, LoRAs, style transfer, and ControlNets from the ground up.',
+    en: 'Beginner ComfyUI tutorials: learn the node graph, LoRAs, style transfer, and ControlNets from the ground up.',
     'zh-CN':
       '面向初学者的 ComfyUI 教程——从零开始掌握节点图、LoRA、风格迁移与 ControlNet。'
   },
@@ -1812,8 +1833,12 @@ const translations = {
     en: 'VFX Tutorials',
     'zh-CN': 'VFX 教程'
   },
+  'learning.categories.vfx.metaTitle': {
+    en: 'ComfyUI VFX Tutorials - Shot Work You Can Run',
+    'zh-CN': 'ComfyUI VFX 教程 - 可运行的镜头处理工作流'
+  },
   'learning.categories.vfx.description': {
-    en: 'Hands-on ComfyUI VFX tutorials — cleanplates, sky replacement, de-aging, mattes, and shot work you can open and run yourself.',
+    en: 'Hands-on ComfyUI VFX tutorials: cleanplates, sky replacement, de-aging, mattes, and shot work you can open and run yourself.',
     'zh-CN':
       '实战 ComfyUI VFX 教程——净板、天空替换、减龄、遮罩与镜头处理，均可亲自打开并运行。'
   },
@@ -1821,8 +1846,12 @@ const translations = {
     en: 'Animation Tutorials',
     'zh-CN': '动画教程'
   },
+  'learning.categories.animations.metaTitle': {
+    en: 'ComfyUI Animation Tutorials - Character Sheets to Compositing',
+    'zh-CN': 'ComfyUI 动画教程 - 从角色设定表到合成'
+  },
   'learning.categories.animations.description': {
-    en: 'Hands-on ComfyUI animation tutorials — character sheets, keyframes, in-betweening, backgrounds, and compositing you can run yourself.',
+    en: 'Hands-on ComfyUI animation tutorials: character sheets, keyframes, in-betweening, backgrounds, and compositing you can run yourself.',
     'zh-CN':
       '实战 ComfyUI 动画教程——角色设定表、关键帧、中间帧、背景与合成，均可亲自运行。'
   },
@@ -1830,8 +1859,12 @@ const translations = {
     en: 'Ad Creative Tutorials',
     'zh-CN': '广告创意教程'
   },
+  'learning.categories.ads.metaTitle': {
+    en: 'ComfyUI Ad Creative Tutorials - Moodboards to B-Roll',
+    'zh-CN': 'ComfyUI 广告创意教程 - 从情绪板到 B-Roll'
+  },
   'learning.categories.ads.description': {
-    en: 'Hands-on ComfyUI ad creative tutorials — moodboards, storyboards, product photography, B-roll, and campaign assets you can run yourself.',
+    en: 'Hands-on ComfyUI ad creative tutorials: moodboards, storyboards, product photography, B-roll, and campaign assets you can run yourself.',
     'zh-CN':
       '实战 ComfyUI 广告创意教程——情绪板、故事板、产品摄影、B-Roll 与广告素材，均可亲自运行。'
   },
@@ -5986,8 +6019,8 @@ const translations = {
   // Seedance 2.5 SEO page (/seedance-2.5). zh-CN hand-translated; some body
   // copy carries placeholder intent from Figma and may change (June, CRE-145).
   'seedance.meta.title': {
-    en: 'Seedance 2.5 on Comfy — Cinematic AI Video Model',
-    'zh-CN': 'Comfy 上的 Seedance 2.5 — 电影级 AI 视频模型'
+    en: 'Seedance 2.5 on Comfy: Cinematic AI Video Model',
+    'zh-CN': 'Comfy 上的 Seedance 2.5：电影级 AI 视频模型'
   },
   'seedance.meta.description': {
     en: 'Run ByteDance Seedance 2.5 on Comfy: multi-shot cinematic video with native audio, from text or image. Draft free on Wan 2.2 and spend credits only on the final render.',
@@ -6313,8 +6346,8 @@ const translations = {
   'modelLaunch.tagPremium': { en: 'Premium', 'zh-CN': '高级' },
   // Flux 3 model page (/flux-3)
   'flux3.meta.title': {
-    en: 'Flux 3 on Comfy — Video With Native Audio',
-    'zh-CN': 'Comfy 上的 Flux 3 — 带原生音频的视频模型'
+    en: 'Flux 3 on Comfy: Video With Native Audio',
+    'zh-CN': 'Comfy 上的 Flux 3：带原生音频的视频模型'
   },
   'flux3.meta.description': {
     en: "Run Flux 3 on Comfy: Black Forest Labs' multimodal model generates video with native audio, up to 20 seconds in one generation, from text, image, video or keyframes.",
@@ -6413,8 +6446,8 @@ const translations = {
   'footer.flux3': { en: 'Flux 3', 'zh-CN': 'Flux 3' },
   // Wan Animate 2 model page (/wan-animate-2)
   'wanAnimate2.meta.title': {
-    en: 'Wan Animate 2 on Comfy — Open-Source Character Animation',
-    'zh-CN': 'Comfy 上的 Wan Animate 2 — 开源角色动画模型'
+    en: 'Wan Animate 2 on Comfy: Open-Source Character Animation',
+    'zh-CN': 'Comfy 上的 Wan Animate 2：开源角色动画模型'
   },
   'wanAnimate2.meta.description': {
     en: 'Run Wan Animate 2 on Comfy: upload a reference image of your character plus a driving video, and it transfers that motion onto your character. Open source, on Comfy Cloud or your own hardware.',
@@ -6506,8 +6539,8 @@ const translations = {
   'modelLaunch.copyPrompt': { en: 'Copy prompt', 'zh-CN': '复制提示词' },
   // Wan 3.0 model page (/wan-3.0)
   'wan3.meta.title': {
-    en: 'Wan 3.0 on Comfy — Text, Image and Reference to Video',
-    'zh-CN': 'Comfy 上的 Wan 3.0 — 文生、图生与参考生视频'
+    en: 'Wan 3.0 on Comfy: Text, Image and Reference to Video',
+    'zh-CN': 'Comfy 上的 Wan 3.0：文生、图生与参考生视频'
   },
   'wan3.meta.description': {
     en: 'Run Wan 3.0 on Comfy Cloud. Generate up to 30 seconds of video from a text prompt, an image, or video, image and audio references, with sound produced alongside the picture.',
@@ -6571,8 +6604,8 @@ const translations = {
   'wan3.reviews.highlightCta': { en: 'GET STARTED', 'zh-CN': '开始使用' },
   'footer.wan3': { en: 'Wan 3.0', 'zh-CN': 'Wan 3.0' },
   'minimax.meta.title': {
-    en: 'MiniMax H3 on Comfy — Open-Weight Video Model',
-    'zh-CN': 'Comfy 上的 MiniMax H3 — 开源权重视频模型'
+    en: 'MiniMax H3 on Comfy: Open-Weight Video Model',
+    'zh-CN': 'Comfy 上的 MiniMax H3：开源权重视频模型'
   },
   'minimax.meta.description': {
     en: 'Run MiniMax H3 on Comfy: Open Weights or Partner Nodes, multi-modal in/out, native stereo audio on every clip, up to 2K and 5-15s per generation. Free to start.',
@@ -6582,8 +6615,8 @@ const translations = {
   'minimax.breadcrumb.model': { en: 'MiniMax H3', 'zh-CN': 'MiniMax H3' },
   // MiniMax Music 3 SEO page (/minimax-music-3). zh-CN hand-translated.
   'minimaxMusic3.meta.title': {
-    en: 'MiniMax Music 3 on Comfy — Open-Weights Music Model',
-    'zh-CN': 'Comfy 上的 MiniMax Music 3 — 开源权重音乐模型'
+    en: 'MiniMax Music 3 on Comfy: Open-Weights Music Model',
+    'zh-CN': 'Comfy 上的 MiniMax Music 3：开源权重音乐模型'
   },
   'minimaxMusic3.meta.description': {
     en: 'Run MiniMax Music 3 on Comfy. Open weights for text to music, directed on the canvas alongside every other model, on Comfy Cloud or your own GPU.',

--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -1775,13 +1775,13 @@ const translations = {
   // LearningDirectorySection
   'learning.title': { en: 'Learning', 'zh-CN': '学习' },
   'learning.metaTitle': {
-    en: 'ComfyUI Tutorials - Learn ComfyUI by Discipline',
-    'zh-CN': 'ComfyUI 教程 - 按创作领域学习'
+    en: 'ComfyUI Tutorials: Free Video Series from Basics to VFX',
+    'zh-CN': 'ComfyUI 教程：免费视频系列，从基础到 VFX'
   },
   'learning.metaDescription': {
-    en: 'Free hands-on ComfyUI tutorials with workflows you can open and run. Start with node graph basics, then go deeper into VFX, animation, and ad creative.',
+    en: 'Learn ComfyUI with free video tutorials and the workflows behind them. Start with the node graph basics, then move into VFX, animation, and ad creative.',
     'zh-CN':
-      '免费的 ComfyUI 实战教程，工作流可直接打开运行。从节点图基础开始，深入 VFX、动画与广告创意。'
+      '通过免费视频教程和配套工作流学习 ComfyUI。从节点图基础开始，再进入 VFX、动画与广告创意。'
   },
   'learning.tagline': {
     en: 'Hands-on ComfyUI tutorials and workflows, by discipline.',
@@ -1821,52 +1821,52 @@ const translations = {
     'zh-CN': 'ComfyUI 基础教程'
   },
   'learning.categories.basics.metaTitle': {
-    en: 'ComfyUI Basics - Tutorials for Beginners',
-    'zh-CN': 'ComfyUI 基础教程 - 新手入门'
+    en: 'ComfyUI Basics for Beginners: Node Graph, LoRAs, ControlNet',
+    'zh-CN': 'ComfyUI 基础教程：节点图、LoRA 与 ControlNet 新手入门'
   },
   'learning.categories.basics.description': {
     en: 'Beginner ComfyUI tutorials: learn the node graph, LoRAs, style transfer, and ControlNets from the ground up.',
     'zh-CN':
-      '面向初学者的 ComfyUI 教程——从零开始掌握节点图、LoRA、风格迁移与 ControlNet。'
+      '面向初学者的 ComfyUI 教程：从零开始掌握节点图、LoRA、风格迁移与 ControlNet。'
   },
   'learning.categories.vfx.heading': {
     en: 'VFX Tutorials',
     'zh-CN': 'VFX 教程'
   },
   'learning.categories.vfx.metaTitle': {
-    en: 'ComfyUI VFX Tutorials - Shot Work You Can Run',
-    'zh-CN': 'ComfyUI VFX 教程 - 可运行的镜头处理工作流'
+    en: 'ComfyUI VFX Tutorials: Cleanplates, Sky Replacement, Deaging',
+    'zh-CN': 'ComfyUI VFX 教程：净板、天空替换与减龄'
   },
   'learning.categories.vfx.description': {
     en: 'Hands-on ComfyUI VFX tutorials: cleanplates, sky replacement, de-aging, mattes, and shot work you can open and run yourself.',
     'zh-CN':
-      '实战 ComfyUI VFX 教程——净板、天空替换、减龄、遮罩与镜头处理，均可亲自打开并运行。'
+      '实战 ComfyUI VFX 教程：净板、天空替换、减龄、遮罩与镜头处理，均可亲自打开并运行。'
   },
   'learning.categories.animations.heading': {
     en: 'Animation Tutorials',
     'zh-CN': '动画教程'
   },
   'learning.categories.animations.metaTitle': {
-    en: 'ComfyUI Animation Tutorials - Character Sheets to Compositing',
-    'zh-CN': 'ComfyUI 动画教程 - 从角色设定表到合成'
+    en: 'ComfyUI Animation Tutorials: Character Sheets and Keyframes',
+    'zh-CN': 'ComfyUI 动画教程：角色设定表与关键帧'
   },
   'learning.categories.animations.description': {
     en: 'Hands-on ComfyUI animation tutorials: character sheets, keyframes, in-betweening, backgrounds, and compositing you can run yourself.',
     'zh-CN':
-      '实战 ComfyUI 动画教程——角色设定表、关键帧、中间帧、背景与合成，均可亲自运行。'
+      '实战 ComfyUI 动画教程：角色设定表、关键帧、中间帧、背景与合成，均可亲自运行。'
   },
   'learning.categories.ads.heading': {
     en: 'Ad Creative Tutorials',
     'zh-CN': '广告创意教程'
   },
   'learning.categories.ads.metaTitle': {
-    en: 'ComfyUI Ad Creative Tutorials - Moodboards to B-Roll',
-    'zh-CN': 'ComfyUI 广告创意教程 - 从情绪板到 B-Roll'
+    en: 'ComfyUI Ad Creative Tutorials: Moodboards to Product Shots',
+    'zh-CN': 'ComfyUI 广告创意教程：从情绪板到产品摄影'
   },
   'learning.categories.ads.description': {
     en: 'Hands-on ComfyUI ad creative tutorials: moodboards, storyboards, product photography, B-roll, and campaign assets you can run yourself.',
     'zh-CN':
-      '实战 ComfyUI 广告创意教程——情绪板、故事板、产品摄影、B-Roll 与广告素材，均可亲自运行。'
+      '实战 ComfyUI 广告创意教程：情绪板、故事板、产品摄影、B-Roll 与广告素材，均可亲自运行。'
   },
   // LearningWatchPage
   'learning.watch.nowWatching': { en: 'Now watching', 'zh-CN': '正在观看' },

--- a/apps/website/src/pages/download.astro
+++ b/apps/website/src/pages/download.astro
@@ -25,7 +25,7 @@ const { siteUrl, locale } = pageContext(
 
 <BaseLayout
   title="Download Comfy Desktop - Run AI on Your Hardware"
-  description={t('download.hero.subtitle', 'en')}
+  description={t('download.meta.description', 'en')}
   mainEntityId={comfyUiSoftwareId(siteUrl)}
   breadcrumbs={[
     { name: t('breadcrumb.home', locale), url: absoluteUrl(Astro.site, '/') },

--- a/apps/website/src/pages/zh-CN/download.astro
+++ b/apps/website/src/pages/zh-CN/download.astro
@@ -25,7 +25,7 @@ const { siteUrl, locale } = pageContext(
 
 <BaseLayout
   title="下载 Comfy 桌面版 - 在您的硬件上运行 AI"
-  description={t('download.hero.subtitle', 'zh-CN')}
+  description={t('download.meta.description', 'zh-CN')}
   mainEntityId={comfyUiSoftwareId(siteUrl)}
   breadcrumbs={[
     {


### PR DESCRIPTION
## Summary

GSC (last 28 days) shows the /learning directory shipping title "Learning - Comfy", which carries none of the queries the page ranks for (comfyui tutorial pos 6.0, learn comfyui, comfyui course/training/academy), and /download at 5.4% CTR on 582k impressions at position 2.5. This PR rewrites the SERP-facing metas without touching page design.

### /learning directory pages (en + zh-CN)
- Document titles and meta descriptions are decoupled from the visible h1/lead-in via new i18n keys (`learning.metaTitle`, `learning.metaDescription`, `learning.categories.*.metaTitle`, `learning.categories.*.metaDescription`); h1s and on-page copy are unchanged except punctuation below.
- Titles use a colon and name what the page actually holds, all 60 characters or under:
  - /learning: "ComfyUI Tutorials: Free Video Series from Basics to VFX"
  - /learning/basics: "ComfyUI Basics for Beginners: Node Graph, LoRAs, ControlNet"
  - /learning/vfx: "ComfyUI VFX Tutorials: Cleanplates, Sky Replacement, Deaging"
  - /learning/animations: "ComfyUI Animation Tutorials: Character Sheets and Keyframes"
  - /learning/ads: "ComfyUI Ad Creative Tutorials: Moodboards to Product Shots"
- Meta descriptions are written for the SERP (147 to 154 chars): lead with free video tutorials plus the workflows behind them, then the specific tutorial subjects.
- Root page gets a `keywords` array via a tested `learningKeywords` helper, same pattern as /download and /cli.
- Category lead-ins swap the em dash for a colon in both locales.

### /learning tutorial pages (20 pages, en + zh-CN)
- Titles move from "{name} - Comfy" to "{name}: Free ComfyUI Tutorial" via `tutorialMetaTitle`; the beginner series already names ComfyUI in its titles and is left as is.
- Every authored description and the fallback template drop the em dash for a colon (these double as the visible description paragraph).

### /download (en + zh-CN)
- New `download.meta.description` key with the download queries ("Download ComfyUI for Windows or macOS, or install from GitHub...") instead of reusing the hero subtitle. Visible hero untouched.

### Model page titles
- Six meta titles (Seedance 2.5, Flux 3, Wan Animate 2, Wan 3.0, MiniMax H3, MiniMax Music 3) unify on the colon pattern the LTX 2.5 and Gemini Omni pages already use, removing the em dashes (en + zh-CN).

### Tests
- `learningTutorials.test.ts`: exact-output tables for en and zh-CN titles and descriptions across root and every category, root-only keywords, and `tutorialMetaTitle` behavior.
- `e2e/learning.spec.ts`: pinned literals updated to the new titles and descriptions.

## Open questions
1. /download title keeps "Download Comfy Desktop - Run AI on Your Hardware". Adding "ComfyUI" would match the query but renames the product in the SERP.
2. zh-CN meta strings are hand-written and need a native pass.

## Changed pages
/learning, /learning/{basics,vfx,animations,ads}, all 20 /learning/*/* tutorial pages, /download, /minimax, /minimax-h3, /flux-3, /seedance-2.5, /wan-animate-2, /wan-3.0, /minimax-music-3 (+ zh-CN twins)

## Verification
`pnpm --filter @comfyorg/website build` green (astro check + build); built HTML verified on changed routes; website vitest 23/23; Playwright learning + download specs 48/48 locally (one pre-existing flake in the download FAQ accordion interaction test, unrelated to this diff).