### PR TITLE
feat: route /contact to support and instrument the contact form in PostHog

### DIFF
--- a/apps/website/e2e/contact.spec.ts
+++ b/apps/website/e2e/contact.spec.ts
@@ -1,0 +1,60 @@
+import { expect } from '@playwright/test'
+
+import type { Page } from '@playwright/test'
+
+import { externalLinks } from '../src/config/routes'
+import { t } from '../src/i18n/translations'
+import { test } from './fixtures/blockExternalMedia'
+
+const PATH = '/contact'
+const ZH_PATH = '/zh-CN/contact'
+const SUPPORT_MAILTO = 'mailto:support@comfy.org'
+
+// Scoped to the paragraph rather than the page: the site footer links the same
+// Help Center URL, so a page-wide locator would match two elements.
+function supportParagraph(page: Page) {
+  return page
+    .locator('p')
+    .filter({ has: page.locator(`a[href="${SUPPORT_MAILTO}"]`) })
+}
+
+test.describe('Contact page support routing @smoke', () => {
+  test('offers the Help Center and the support mailbox alongside the form', async ({
+    page
+  }) => {
+    await page.goto(PATH)
+
+    const support = supportParagraph(page)
+    await expect(support).toHaveCount(1)
+    await expect(support).toContainText(t('contact.form.supportLink'))
+    await expect(
+      support.getByRole('link', { name: t('contact.form.supportLinkCta') })
+    ).toHaveAttribute('href', externalLinks.support)
+    await expect(
+      support.getByRole('link', { name: 'support@comfy.org' })
+    ).toHaveAttribute('href', SUPPORT_MAILTO)
+  })
+
+  test('no longer routes support seekers to the docs site', async ({
+    page
+  }) => {
+    await page.goto(PATH)
+
+    await expect(
+      supportParagraph(page).locator('a[href*="docs.comfy.org"]')
+    ).toHaveCount(0)
+  })
+
+  test('routes to the same support channels in zh-CN', async ({ page }) => {
+    await page.goto(ZH_PATH)
+
+    const support = supportParagraph(page)
+    await expect(support).toHaveCount(1)
+    await expect(support).toContainText(t('contact.form.supportLink', 'zh-CN'))
+    await expect(
+      support.getByRole('link', {
+        name: t('contact.form.supportLinkCta', 'zh-CN')
+      })
+    ).toHaveAttribute('href', externalLinks.support)
+  })
+})

--- a/apps/website/e2e/contact.spec.ts
+++ b/apps/website/e2e/contact.spec.ts
@@ -56,5 +56,8 @@ test.describe('Contact page support routing @smoke', () => {
         name: t('contact.form.supportLinkCta', 'zh-CN')
       })
     ).toHaveAttribute('href', externalLinks.support)
+    await expect(
+      support.getByRole('link', { name: 'support@comfy.org' })
+    ).toHaveAttribute('href', SUPPORT_MAILTO)
   })
 })

--- a/apps/website/src/components/contact/FormSection.test.ts
+++ b/apps/website/src/components/contact/FormSection.test.ts
@@ -1,0 +1,74 @@
+// @vitest-environment happy-dom
+import { render, screen } from '@testing-library/vue'
+import { describe, expect, it, vi } from 'vitest'
+
+import { externalLinks } from '../../config/routes'
+import { t } from '../../i18n/translations'
+import FormSection from './FormSection.vue'
+
+vi.mock('../../composables/useHeroAnimation', () => ({
+  useHeroAnimation: () => {}
+}))
+
+vi.mock('./HubspotFormEmbed.vue', () => ({
+  default: { name: 'HubspotFormEmbed', template: '<div />' }
+}))
+
+const SUPPORT_MAILTO = 'mailto:support@comfy.org'
+
+function renderFormSection(locale?: 'zh-CN') {
+  render(FormSection, { props: locale ? { locale } : {} })
+}
+
+function hrefOfLink(name: string) {
+  return screen.getByRole('link', { name }).getAttribute('href')
+}
+
+describe('FormSection support routing', () => {
+  it('routes to the Help Center and the support mailbox', () => {
+    renderFormSection()
+
+    expect(hrefOfLink(t('contact.form.supportLinkCta'))).toBe(
+      externalLinks.support
+    )
+    expect(hrefOfLink('support@comfy.org')).toBe(SUPPORT_MAILTO)
+  })
+
+  it('no longer sends people looking for support to the docs site', () => {
+    renderFormSection()
+
+    const hrefs = screen
+      .getAllByRole('link')
+      .map((link) => link.getAttribute('href'))
+
+    expect(hrefs.some((href) => href?.includes('docs.comfy.org'))).toBe(false)
+  })
+
+  it('says the form itself reaches sales', () => {
+    renderFormSection()
+
+    expect(
+      screen.getByText(t('contact.form.supportLink'), { exact: false })
+    ).toBeTruthy()
+  })
+
+  it('routes to the same support channels for zh-CN', () => {
+    renderFormSection('zh-CN')
+
+    expect(hrefOfLink(t('contact.form.supportLinkCta', 'zh-CN'))).toBe(
+      externalLinks.support
+    )
+    expect(hrefOfLink('support@comfy.org')).toBe(SUPPORT_MAILTO)
+  })
+
+  it('localizes the support copy for zh-CN', () => {
+    renderFormSection('zh-CN')
+
+    expect(
+      screen.getByText(t('contact.form.supportLink', 'zh-CN'), { exact: false })
+    ).toBeTruthy()
+    expect(
+      screen.queryByText(t('contact.form.supportLink'), { exact: false })
+    ).toBeNull()
+  })
+})

--- a/apps/website/src/components/contact/FormSection.vue
+++ b/apps/website/src/components/contact/FormSection.vue
@@ -3,10 +3,13 @@ import { ref } from 'vue'
 
 import type { Locale, TranslationKey } from '../../i18n/translations'
 
+import { externalLinks } from '../../config/routes'
 import { useHeroAnimation } from '../../composables/useHeroAnimation'
 import { t } from '../../i18n/translations'
 import SectionLabel from '../common/SectionLabel.vue'
 import HubspotFormEmbed from './HubspotFormEmbed.vue'
+
+const SUPPORT_EMAIL = 'support@comfy.org'
 
 const { locale = 'en' } = defineProps<{
   locale?: Locale
@@ -59,13 +62,21 @@ useHeroAnimation({
           <p class="mt-4 text-sm text-primary-comfy-canvas">
             {{ t(tk('supportLink'), locale) }}
             <a
-              href="https://docs.comfy.org/"
+              :href="externalLinks.support"
               target="_blank"
               rel="noopener noreferrer"
               class="text-primary-comfy-yellow underline"
             >
               {{ t(tk('supportLinkCta'), locale) }}
             </a>
+            {{ t(tk('supportLinkMiddle'), locale) }}
+            <a
+              :href="`mailto:${SUPPORT_EMAIL}`"
+              class="text-primary-comfy-yellow underline"
+            >
+              {{ SUPPORT_EMAIL }}
+            </a>
+            {{ t(tk('supportLinkSuffix'), locale) }}
           </p>
         </div>
       </div>

--- a/apps/website/src/components/contact/HubspotFormEmbed.test.ts
+++ b/apps/website/src/components/contact/HubspotFormEmbed.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment happy-dom
 import { render } from '@testing-library/vue'
-import { beforeEach, describe, expect, it, onTestFinished, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import HubspotFormEmbed from './HubspotFormEmbed.vue'
 
@@ -38,8 +38,7 @@ function stubHubspotFormsV4(form: {
   conversionId?: string
   unavailable?: boolean
 }) {
-  const globals = window as unknown as Record<string, unknown>
-  globals.HubSpotFormsV4 = {
+  vi.stubGlobal('HubSpotFormsV4', {
     getFormFromEvent: () => {
       if (form.unavailable) throw new Error('form instance not registered')
       return {
@@ -47,9 +46,6 @@ function stubHubspotFormsV4(form: {
         getConversionId: () => form.conversionId
       }
     }
-  }
-  onTestFinished(() => {
-    delete globals.HubSpotFormsV4
   })
 }
 

--- a/apps/website/src/components/contact/HubspotFormEmbed.test.ts
+++ b/apps/website/src/components/contact/HubspotFormEmbed.test.ts
@@ -74,7 +74,7 @@ describe('HubspotFormEmbed', () => {
 
   it('captures a submission from the v3 postMessage callback', () => {
     render(HubspotFormEmbed)
-    dispatchV3Submission()
+    dispatchV3Submission(EN_FORM_ID)
 
     expect(hoisted.mockSubmitted).toHaveBeenCalledWith(
       'en',
@@ -85,7 +85,7 @@ describe('HubspotFormEmbed', () => {
 
   it('captures a submission from the v4 form event', () => {
     render(HubspotFormEmbed)
-    dispatchV4Submission()
+    dispatchV4Submission(EN_FORM_ID)
 
     expect(hoisted.mockSubmitted).toHaveBeenCalledWith(
       'en',
@@ -96,7 +96,7 @@ describe('HubspotFormEmbed', () => {
 
   it('reports the localized form id on submission', () => {
     render(HubspotFormEmbed, { props: { locale: 'zh-CN' } })
-    dispatchV4Submission()
+    dispatchV4Submission(ZH_FORM_ID)
 
     expect(hoisted.mockSubmitted).toHaveBeenCalledWith(
       'zh-CN',
@@ -107,8 +107,8 @@ describe('HubspotFormEmbed', () => {
 
   it('captures once when both HubSpot form versions report the submission', () => {
     render(HubspotFormEmbed)
-    dispatchV3Submission()
-    dispatchV4Submission()
+    dispatchV3Submission(EN_FORM_ID)
+    dispatchV4Submission(EN_FORM_ID)
 
     expect(hoisted.mockSubmitted).toHaveBeenCalledOnce()
   })
@@ -167,6 +167,27 @@ describe('HubspotFormEmbed', () => {
     expect(hoisted.mockSubmitted).not.toHaveBeenCalled()
   })
 
+  it('ignores a submission that names no form at all', () => {
+    render(HubspotFormEmbed)
+    dispatchV3Submission()
+    dispatchV4Submission()
+
+    expect(hoisted.mockSubmitted).not.toHaveBeenCalled()
+  })
+
+  it('still captures this form after an unattributable submission', () => {
+    render(HubspotFormEmbed)
+    dispatchV4Submission()
+    dispatchV4Submission(EN_FORM_ID)
+
+    expect(hoisted.mockSubmitted).toHaveBeenCalledOnce()
+    expect(hoisted.mockSubmitted).toHaveBeenCalledWith(
+      'en',
+      EN_FORM_ID,
+      undefined
+    )
+  })
+
   it('still captures this form after another form was submitted', () => {
     render(HubspotFormEmbed)
     dispatchV4Submission('some-other-form')
@@ -195,7 +216,7 @@ describe('HubspotFormEmbed', () => {
   it('stops listening once the form is unmounted', () => {
     const { unmount } = render(HubspotFormEmbed)
     unmount()
-    dispatchV4Submission()
+    dispatchV4Submission(EN_FORM_ID)
 
     expect(hoisted.mockSubmitted).not.toHaveBeenCalled()
   })

--- a/apps/website/src/components/contact/HubspotFormEmbed.test.ts
+++ b/apps/website/src/components/contact/HubspotFormEmbed.test.ts
@@ -17,10 +17,22 @@ vi.mock('../../scripts/posthog', () => ({
 const EN_FORM_ID = '94e05eab-1373-47f7-ab5e-d84f9e6aa262'
 const ZH_FORM_ID = '6885750c-02ef-4aa2-ba0d-213be9cccf93'
 
-function dispatchV3Submission(id?: string) {
+const HUBSPOT_ORIGIN = 'https://forms-na2.hsforms.com'
+
+function dispatchV3Submission(
+  id?: string,
+  options: { origin?: string; conversionId?: string } = {}
+) {
+  const { origin = HUBSPOT_ORIGIN, conversionId } = options
   window.dispatchEvent(
     new MessageEvent('message', {
-      data: { type: 'hsFormCallback', eventName: 'onFormSubmitted', id }
+      origin,
+      data: {
+        type: 'hsFormCallback',
+        eventName: 'onFormSubmitted',
+        id,
+        data: { conversionId }
+      }
     })
   )
 }
@@ -113,17 +125,6 @@ describe('HubspotFormEmbed', () => {
     expect(hoisted.mockSubmitted).toHaveBeenCalledOnce()
   })
 
-  it('captures a submission reported with this form id', () => {
-    render(HubspotFormEmbed)
-    dispatchV4Submission(EN_FORM_ID)
-
-    expect(hoisted.mockSubmitted).toHaveBeenCalledWith(
-      'en',
-      EN_FORM_ID,
-      undefined
-    )
-  })
-
   it('reports the HubSpot conversion id when the v4 API exposes one', () => {
     stubHubspotFormsV4({ formId: EN_FORM_ID, conversionId: 'conversion-xyz' })
     render(HubspotFormEmbed)
@@ -167,12 +168,45 @@ describe('HubspotFormEmbed', () => {
     expect(hoisted.mockSubmitted).not.toHaveBeenCalled()
   })
 
-  it('ignores a submission that names no form at all', () => {
+  it('reports the conversion id carried by a v3 payload', () => {
+    render(HubspotFormEmbed)
+    dispatchV3Submission(EN_FORM_ID, { conversionId: 'conversion-v3' })
+
+    expect(hoisted.mockSubmitted).toHaveBeenCalledWith(
+      'en',
+      EN_FORM_ID,
+      'conversion-v3'
+    )
+  })
+
+  it('ignores a forged submission from a non-HubSpot origin', () => {
+    render(HubspotFormEmbed)
+    dispatchV3Submission(EN_FORM_ID, { origin: 'https://evil.example' })
+
+    expect(hoisted.mockSubmitted).not.toHaveBeenCalled()
+  })
+
+  it('does not let a forged message consume the real submission', () => {
+    render(HubspotFormEmbed)
+    dispatchV3Submission(EN_FORM_ID, { origin: 'https://evil.example' })
+    dispatchV4Submission(EN_FORM_ID)
+
+    expect(hoisted.mockSubmitted).toHaveBeenCalledOnce()
+    expect(hoisted.mockSubmitted).toHaveBeenCalledWith(
+      'en',
+      EN_FORM_ID,
+      undefined
+    )
+  })
+
+  it('ignores a submission that names no form at all, and says so', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
     render(HubspotFormEmbed)
     dispatchV3Submission()
     dispatchV4Submission()
 
     expect(hoisted.mockSubmitted).not.toHaveBeenCalled()
+    expect(warn).toHaveBeenCalled()
   })
 
   it('still captures this form after an unattributable submission', () => {
@@ -203,9 +237,12 @@ describe('HubspotFormEmbed', () => {
 
   it('ignores unrelated window messages', () => {
     render(HubspotFormEmbed)
-    window.dispatchEvent(new MessageEvent('message', { data: 'ping' }))
+    window.dispatchEvent(
+      new MessageEvent('message', { origin: HUBSPOT_ORIGIN, data: 'ping' })
+    )
     window.dispatchEvent(
       new MessageEvent('message', {
+        origin: HUBSPOT_ORIGIN,
         data: { type: 'hsFormCallback', eventName: 'onFormReady' }
       })
     )

--- a/apps/website/src/components/contact/HubspotFormEmbed.test.ts
+++ b/apps/website/src/components/contact/HubspotFormEmbed.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment happy-dom
 import { render } from '@testing-library/vue'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, onTestFinished, vi } from 'vitest'
 
 import HubspotFormEmbed from './HubspotFormEmbed.vue'
 
@@ -33,6 +33,26 @@ function dispatchV4Submission(formId?: string) {
   )
 }
 
+function stubHubspotFormsV4(form: {
+  formId?: string
+  conversionId?: string
+  unavailable?: boolean
+}) {
+  const globals = window as unknown as Record<string, unknown>
+  globals.HubSpotFormsV4 = {
+    getFormFromEvent: () => {
+      if (form.unavailable) throw new Error('form instance not registered')
+      return {
+        getFormId: () => form.formId,
+        getConversionId: () => form.conversionId
+      }
+    }
+  }
+  onTestFinished(() => {
+    delete globals.HubSpotFormsV4
+  })
+}
+
 function suppressEmbedScriptInjection() {
   const alreadyInjectedMarker = document.createElement('script')
   alreadyInjectedMarker.id = 'hubspot-contact-form-embed'
@@ -60,21 +80,33 @@ describe('HubspotFormEmbed', () => {
     render(HubspotFormEmbed)
     dispatchV3Submission()
 
-    expect(hoisted.mockSubmitted).toHaveBeenCalledWith('en', EN_FORM_ID)
+    expect(hoisted.mockSubmitted).toHaveBeenCalledWith(
+      'en',
+      EN_FORM_ID,
+      undefined
+    )
   })
 
   it('captures a submission from the v4 form event', () => {
     render(HubspotFormEmbed)
     dispatchV4Submission()
 
-    expect(hoisted.mockSubmitted).toHaveBeenCalledWith('en', EN_FORM_ID)
+    expect(hoisted.mockSubmitted).toHaveBeenCalledWith(
+      'en',
+      EN_FORM_ID,
+      undefined
+    )
   })
 
   it('reports the localized form id on submission', () => {
     render(HubspotFormEmbed, { props: { locale: 'zh-CN' } })
     dispatchV4Submission()
 
-    expect(hoisted.mockSubmitted).toHaveBeenCalledWith('zh-CN', ZH_FORM_ID)
+    expect(hoisted.mockSubmitted).toHaveBeenCalledWith(
+      'zh-CN',
+      ZH_FORM_ID,
+      undefined
+    )
   })
 
   it('captures once when both HubSpot form versions report the submission', () => {
@@ -89,7 +121,46 @@ describe('HubspotFormEmbed', () => {
     render(HubspotFormEmbed)
     dispatchV4Submission(EN_FORM_ID)
 
-    expect(hoisted.mockSubmitted).toHaveBeenCalledWith('en', EN_FORM_ID)
+    expect(hoisted.mockSubmitted).toHaveBeenCalledWith(
+      'en',
+      EN_FORM_ID,
+      undefined
+    )
+  })
+
+  it('reports the HubSpot conversion id when the v4 API exposes one', () => {
+    stubHubspotFormsV4({ formId: EN_FORM_ID, conversionId: 'conversion-xyz' })
+    render(HubspotFormEmbed)
+    dispatchV4Submission()
+
+    expect(hoisted.mockSubmitted).toHaveBeenCalledWith(
+      'en',
+      EN_FORM_ID,
+      'conversion-xyz'
+    )
+  })
+
+  it('ignores a v4 submission the form API attributes to another form', () => {
+    stubHubspotFormsV4({
+      formId: 'some-other-form',
+      conversionId: 'conversion-xyz'
+    })
+    render(HubspotFormEmbed)
+    dispatchV4Submission()
+
+    expect(hoisted.mockSubmitted).not.toHaveBeenCalled()
+  })
+
+  it('still captures when the v4 form API is unavailable', () => {
+    stubHubspotFormsV4({ unavailable: true })
+    render(HubspotFormEmbed)
+    dispatchV4Submission(EN_FORM_ID)
+
+    expect(hoisted.mockSubmitted).toHaveBeenCalledWith(
+      'en',
+      EN_FORM_ID,
+      undefined
+    )
   })
 
   it('ignores a submission reported for a different form', () => {
@@ -106,7 +177,11 @@ describe('HubspotFormEmbed', () => {
     dispatchV4Submission(EN_FORM_ID)
 
     expect(hoisted.mockSubmitted).toHaveBeenCalledOnce()
-    expect(hoisted.mockSubmitted).toHaveBeenCalledWith('en', EN_FORM_ID)
+    expect(hoisted.mockSubmitted).toHaveBeenCalledWith(
+      'en',
+      EN_FORM_ID,
+      undefined
+    )
   })
 
   it('ignores unrelated window messages', () => {

--- a/apps/website/src/components/contact/HubspotFormEmbed.test.ts
+++ b/apps/website/src/components/contact/HubspotFormEmbed.test.ts
@@ -1,0 +1,131 @@
+// @vitest-environment happy-dom
+import { render } from '@testing-library/vue'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import HubspotFormEmbed from './HubspotFormEmbed.vue'
+
+const hoisted = vi.hoisted(() => ({
+  mockViewed: vi.fn(),
+  mockSubmitted: vi.fn()
+}))
+
+vi.mock('../../scripts/posthog', () => ({
+  captureContactFormViewed: hoisted.mockViewed,
+  captureContactFormSubmitted: hoisted.mockSubmitted
+}))
+
+const EN_FORM_ID = '94e05eab-1373-47f7-ab5e-d84f9e6aa262'
+const ZH_FORM_ID = '6885750c-02ef-4aa2-ba0d-213be9cccf93'
+
+function dispatchV3Submission(id?: string) {
+  window.dispatchEvent(
+    new MessageEvent('message', {
+      data: { type: 'hsFormCallback', eventName: 'onFormSubmitted', id }
+    })
+  )
+}
+
+function dispatchV4Submission(formId?: string) {
+  window.dispatchEvent(
+    new CustomEvent('hs-form-event:on-submission:success', {
+      detail: formId === undefined ? undefined : { formId }
+    })
+  )
+}
+
+function suppressEmbedScriptInjection() {
+  const alreadyInjectedMarker = document.createElement('script')
+  alreadyInjectedMarker.id = 'hubspot-contact-form-embed'
+  document.head.append(alreadyInjectedMarker)
+
+  return () => alreadyInjectedMarker.remove()
+}
+
+describe('HubspotFormEmbed', () => {
+  beforeEach(suppressEmbedScriptInjection)
+
+  it('captures a contact form view on mount', () => {
+    render(HubspotFormEmbed)
+
+    expect(hoisted.mockViewed).toHaveBeenCalledWith('en')
+  })
+
+  it('captures the view for the localized form', () => {
+    render(HubspotFormEmbed, { props: { locale: 'zh-CN' } })
+
+    expect(hoisted.mockViewed).toHaveBeenCalledWith('zh-CN')
+  })
+
+  it('captures a submission from the v3 postMessage callback', () => {
+    render(HubspotFormEmbed)
+    dispatchV3Submission()
+
+    expect(hoisted.mockSubmitted).toHaveBeenCalledWith('en', EN_FORM_ID)
+  })
+
+  it('captures a submission from the v4 form event', () => {
+    render(HubspotFormEmbed)
+    dispatchV4Submission()
+
+    expect(hoisted.mockSubmitted).toHaveBeenCalledWith('en', EN_FORM_ID)
+  })
+
+  it('reports the localized form id on submission', () => {
+    render(HubspotFormEmbed, { props: { locale: 'zh-CN' } })
+    dispatchV4Submission()
+
+    expect(hoisted.mockSubmitted).toHaveBeenCalledWith('zh-CN', ZH_FORM_ID)
+  })
+
+  it('captures once when both HubSpot form versions report the submission', () => {
+    render(HubspotFormEmbed)
+    dispatchV3Submission()
+    dispatchV4Submission()
+
+    expect(hoisted.mockSubmitted).toHaveBeenCalledOnce()
+  })
+
+  it('captures a submission reported with this form id', () => {
+    render(HubspotFormEmbed)
+    dispatchV4Submission(EN_FORM_ID)
+
+    expect(hoisted.mockSubmitted).toHaveBeenCalledWith('en', EN_FORM_ID)
+  })
+
+  it('ignores a submission reported for a different form', () => {
+    render(HubspotFormEmbed)
+    dispatchV3Submission('some-other-form')
+    dispatchV4Submission('some-other-form')
+
+    expect(hoisted.mockSubmitted).not.toHaveBeenCalled()
+  })
+
+  it('still captures this form after another form was submitted', () => {
+    render(HubspotFormEmbed)
+    dispatchV4Submission('some-other-form')
+    dispatchV4Submission(EN_FORM_ID)
+
+    expect(hoisted.mockSubmitted).toHaveBeenCalledOnce()
+    expect(hoisted.mockSubmitted).toHaveBeenCalledWith('en', EN_FORM_ID)
+  })
+
+  it('ignores unrelated window messages', () => {
+    render(HubspotFormEmbed)
+    window.dispatchEvent(new MessageEvent('message', { data: 'ping' }))
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        data: { type: 'hsFormCallback', eventName: 'onFormReady' }
+      })
+    )
+
+    expect(hoisted.mockSubmitted).not.toHaveBeenCalled()
+  })
+
+  it('stops listening once the form is unmounted', () => {
+    const { unmount } = render(HubspotFormEmbed)
+    unmount()
+    dispatchV4Submission()
+
+    expect(hoisted.mockSubmitted).not.toHaveBeenCalled()
+  })
+})

--- a/apps/website/src/components/contact/HubspotFormEmbed.vue
+++ b/apps/website/src/components/contact/HubspotFormEmbed.vue
@@ -120,11 +120,12 @@ function asNonEmptyString(value: unknown): string | undefined {
   return typeof value === 'string' && value !== '' ? value : undefined
 }
 
-// The v4 event carries only an instanceId, so both the form's identity and its
-// conversion id have to come from the global form API. The conversion id is
-// what lets a submission be matched to its HubSpot record without sending any
-// of the submitted field values. HubSpot publishes the API under two
-// spellings, and it is absent entirely when the embed script never loaded.
+// The conversion id is what lets a submission be matched to its HubSpot record
+// without sending any of the submitted field values, and the global form API is
+// the only place it is exposed. Form identity is read from the same lookup
+// because it is authoritative, with the event's own detail.formId as fallback.
+// HubSpot publishes the API under two spellings, and it is absent entirely when
+// the embed script never loaded.
 function readV4Submission(event: Event): {
   formId: string | undefined
   conversionId: string | undefined

--- a/apps/website/src/components/contact/HubspotFormEmbed.vue
+++ b/apps/website/src/components/contact/HubspotFormEmbed.vue
@@ -107,13 +107,55 @@ function readStringField(source: unknown, field: string): string | undefined {
   return typeof value === 'string' ? value : undefined
 }
 
+interface HubspotFormInstance {
+  getFormId?: () => unknown
+  getConversionId?: () => unknown
+}
+
+interface HubspotFormsGlobal {
+  getFormFromEvent?: (event: Event) => HubspotFormInstance | undefined
+}
+
+function asNonEmptyString(value: unknown): string | undefined {
+  return typeof value === 'string' && value !== '' ? value : undefined
+}
+
+// The v4 event carries only an instanceId, so both the form's identity and its
+// conversion id have to come from the global form API. The conversion id is
+// what lets a submission be matched to its HubSpot record without sending any
+// of the submitted field values. HubSpot publishes the API under two
+// spellings, and it is absent entirely when the embed script never loaded.
+function readV4Submission(event: Event): {
+  formId: string | undefined
+  conversionId: string | undefined
+} {
+  const globals = window as unknown as Record<
+    string,
+    HubspotFormsGlobal | undefined
+  >
+  const hubspotForms = globals.HubSpotFormsV4 ?? globals.HubspotFormsV4
+
+  try {
+    const form = hubspotForms?.getFormFromEvent?.(event)
+    return {
+      formId: asNonEmptyString(form?.getFormId?.()),
+      conversionId: asNonEmptyString(form?.getConversionId?.())
+    }
+  } catch {
+    return { formId: undefined, conversionId: undefined }
+  }
+}
+
 let hasCapturedSubmission = false
 
-// Both listeners are bound to the window, so another HubSpot form on the page
-// would otherwise consume the latch and mask this form's real submission.
-// Unrecognised payload shapes still count, so a vendor change degrades to
-// over-reporting rather than silently reporting nothing.
-function captureSubmission(submittedFormId: string | undefined) {
+// Both listeners are bound to the window, so a submission reporting a
+// different form id is ignored instead of consuming the latch. A payload with
+// no id still counts: a vendor change should degrade to over-reporting rather
+// than to silence.
+function captureSubmission(
+  submittedFormId: string | undefined,
+  conversionId?: string
+) {
   if (
     submittedFormId !== undefined &&
     submittedFormId !== hubspotContactFormId.value
@@ -121,7 +163,7 @@ function captureSubmission(submittedFormId: string | undefined) {
     return
   if (hasCapturedSubmission) return
   hasCapturedSubmission = true
-  captureContactFormSubmitted(locale, hubspotContactFormId.value)
+  captureContactFormSubmitted(locale, hubspotContactFormId.value, conversionId)
 }
 
 useEventListener('message', (event: MessageEvent) => {
@@ -130,8 +172,9 @@ useEventListener('message', (event: MessageEvent) => {
 })
 
 useEventListener(defaultWindow, HUBSPOT_V4_SUBMISSION_EVENT, (event: Event) => {
+  const { formId, conversionId } = readV4Submission(event)
   const detail = event instanceof CustomEvent ? event.detail : undefined
-  captureSubmission(readStringField(detail, 'formId'))
+  captureSubmission(formId ?? readStringField(detail, 'formId'), conversionId)
 })
 
 onMounted(() => {

--- a/apps/website/src/components/contact/HubspotFormEmbed.vue
+++ b/apps/website/src/components/contact/HubspotFormEmbed.vue
@@ -1,9 +1,14 @@
 <script setup lang="ts">
+import { defaultWindow, useEventListener } from '@vueuse/core'
 import { computed, onMounted, ref } from 'vue'
 
 import type { Locale } from '../../i18n/translations'
 
 import { t } from '../../i18n/translations'
+import {
+  captureContactFormSubmitted,
+  captureContactFormViewed
+} from '../../scripts/posthog'
 
 const { locale = 'en' } = defineProps<{
   locale?: Locale
@@ -77,7 +82,61 @@ const hubspotFormStyles: Record<`--${string}`, string> = {
   '--hsf-infoalert__font-family': "'PP Formula', sans-serif"
 }
 
+// HubSpot signals a successful submission differently per form version: v3
+// embeds postMessage from their iframe, v4 dispatches a window event. Which
+// one this portal serves can change without a code change here, so listen for
+// both and let captureSubmission collapse them into a single event.
+const HUBSPOT_V4_SUBMISSION_EVENT = 'hs-form-event:on-submission:success'
+
+function isHubspotSubmittedMessage(data: unknown): boolean {
+  return (
+    typeof data === 'object' &&
+    data !== null &&
+    'type' in data &&
+    data.type === 'hsFormCallback' &&
+    'eventName' in data &&
+    data.eventName === 'onFormSubmitted'
+  )
+}
+
+function readStringField(source: unknown, field: string): string | undefined {
+  if (typeof source !== 'object' || source === null || !(field in source)) {
+    return undefined
+  }
+  const value = (source as Record<string, unknown>)[field]
+  return typeof value === 'string' ? value : undefined
+}
+
+let hasCapturedSubmission = false
+
+// Both listeners are bound to the window, so another HubSpot form on the page
+// would otherwise consume the latch and mask this form's real submission.
+// Unrecognised payload shapes still count, so a vendor change degrades to
+// over-reporting rather than silently reporting nothing.
+function captureSubmission(submittedFormId: string | undefined) {
+  if (
+    submittedFormId !== undefined &&
+    submittedFormId !== hubspotContactFormId.value
+  )
+    return
+  if (hasCapturedSubmission) return
+  hasCapturedSubmission = true
+  captureContactFormSubmitted(locale, hubspotContactFormId.value)
+}
+
+useEventListener('message', (event: MessageEvent) => {
+  if (!isHubspotSubmittedMessage(event.data)) return
+  captureSubmission(readStringField(event.data, 'id'))
+})
+
+useEventListener(defaultWindow, HUBSPOT_V4_SUBMISSION_EVENT, (event: Event) => {
+  const detail = event instanceof CustomEvent ? event.detail : undefined
+  captureSubmission(readStringField(detail, 'formId'))
+})
+
 onMounted(() => {
+  captureContactFormViewed(locale)
+
   if (document.getElementById(HUBSPOT_CONTACT_SCRIPT_ID)) return
 
   const script = document.createElement('script')
@@ -101,7 +160,7 @@ onMounted(() => {
   <div class="min-h-[640px] w-full">
     <p
       v-if="hasEmbedLoadError"
-      class="text-primary-comfy-canvas text-sm/6"
+      class="text-sm/6 text-primary-comfy-canvas"
       role="status"
     >
       {{ t('contact.form.embedLoadErrorPrefix', locale) }}

--- a/apps/website/src/components/contact/HubspotFormEmbed.vue
+++ b/apps/website/src/components/contact/HubspotFormEmbed.vue
@@ -85,7 +85,9 @@ const hubspotFormStyles: Record<`--${string}`, string> = {
 // HubSpot signals a successful submission differently per form version: v3
 // embeds postMessage from their iframe, v4 dispatches a window event. Line 20
 // pins this portal to the v4 loader, so v3 is only a hedge for a form that was
-// never migrated; both are observed and collapsed into a single event.
+// never migrated, and only for the iframed flavour of it — the origin check
+// below cannot accept a legacy form rendered inline, because a same-origin
+// message is indistinguishable from a forged one.
 const HUBSPOT_V4_SUBMISSION_EVENT = 'hs-form-event:on-submission:success'
 
 // The form guid is public (it ships in the markup below), so payload shape
@@ -169,7 +171,8 @@ function captureSubmission(
 ) {
   if (submittedFormId === undefined) {
     console.warn(
-      'HubSpot reported a submission with no form id; not recording it'
+      'Ignoring a contact form submission that named no form. A real HubSpot ' +
+        'submission always identifies its form, so this came from something else.'
     )
     return
   }

--- a/apps/website/src/components/contact/HubspotFormEmbed.vue
+++ b/apps/website/src/components/contact/HubspotFormEmbed.vue
@@ -149,19 +149,16 @@ function readV4Submission(event: Event): {
 
 let hasCapturedSubmission = false
 
-// Both listeners are bound to the window, so a submission reporting a
-// different form id is ignored instead of consuming the latch. A payload with
-// no id still counts: a vendor change should degrade to over-reporting rather
-// than to silence.
+// Both listeners are bound to the window, so a submission has to prove it came
+// from this form before it is counted or allowed to consume the latch. An
+// unattributable submission is dropped rather than recorded: a conversion count
+// that reads zero is a visible failure, whereas one inflated by phantom
+// conversions is indistinguishable from a real one downstream.
 function captureSubmission(
   submittedFormId: string | undefined,
   conversionId?: string
 ) {
-  if (
-    submittedFormId !== undefined &&
-    submittedFormId !== hubspotContactFormId.value
-  )
-    return
+  if (submittedFormId !== hubspotContactFormId.value) return
   if (hasCapturedSubmission) return
   hasCapturedSubmission = true
   captureContactFormSubmitted(locale, hubspotContactFormId.value, conversionId)

--- a/apps/website/src/components/contact/HubspotFormEmbed.vue
+++ b/apps/website/src/components/contact/HubspotFormEmbed.vue
@@ -83,10 +83,16 @@ const hubspotFormStyles: Record<`--${string}`, string> = {
 }
 
 // HubSpot signals a successful submission differently per form version: v3
-// embeds postMessage from their iframe, v4 dispatches a window event. Which
-// one this portal serves can change without a code change here, so listen for
-// both and let captureSubmission collapse them into a single event.
+// embeds postMessage from their iframe, v4 dispatches a window event. Line 20
+// pins this portal to the v4 loader, so v3 is only a hedge for a form that was
+// never migrated; both are observed and collapsed into a single event.
 const HUBSPOT_V4_SUBMISSION_EVENT = 'hs-form-event:on-submission:success'
+
+// The form guid is public (it ships in the markup below), so payload shape
+// alone does not establish that a message came from HubSpot. Without this an
+// embedding page could forge a submission, which would both count a phantom
+// conversion and consume the latch that the real submission needs.
+const HUBSPOT_ORIGIN_PATTERN = /^https:\/\/([\w-]+\.)?hsforms\.(com|net)$/
 
 function isHubspotSubmittedMessage(data: unknown): boolean {
   return (
@@ -99,12 +105,15 @@ function isHubspotSubmittedMessage(data: unknown): boolean {
   )
 }
 
-function readStringField(source: unknown, field: string): string | undefined {
+function readField(source: unknown, field: string): unknown {
   if (typeof source !== 'object' || source === null || !(field in source)) {
     return undefined
   }
-  const value = (source as Record<string, unknown>)[field]
-  return typeof value === 'string' ? value : undefined
+  return (source as Record<string, unknown>)[field]
+}
+
+function readStringField(source: unknown, field: string): string | undefined {
+  return asNonEmptyString(readField(source, field))
 }
 
 interface HubspotFormInstance {
@@ -158,6 +167,12 @@ function captureSubmission(
   submittedFormId: string | undefined,
   conversionId?: string
 ) {
+  if (submittedFormId === undefined) {
+    console.warn(
+      'HubSpot reported a submission with no form id; not recording it'
+    )
+    return
+  }
   if (submittedFormId !== hubspotContactFormId.value) return
   if (hasCapturedSubmission) return
   hasCapturedSubmission = true
@@ -165,8 +180,12 @@ function captureSubmission(
 }
 
 useEventListener('message', (event: MessageEvent) => {
+  if (!HUBSPOT_ORIGIN_PATTERN.test(event.origin)) return
   if (!isHubspotSubmittedMessage(event.data)) return
-  captureSubmission(readStringField(event.data, 'id'))
+  captureSubmission(
+    readStringField(event.data, 'id'),
+    readStringField(readField(event.data, 'data'), 'conversionId')
+  )
 })
 
 useEventListener(defaultWindow, HUBSPOT_V4_SUBMISSION_EVENT, (event: Event) => {

--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -5141,12 +5141,20 @@ const translations = {
       '从设计工作室到制作公司，我们正在构建一个平台，让您的团队按需获取强大的创作能力。让我们一起探索适合您需求的方案。'
   },
   'contact.form.supportLink': {
-    en: 'Looking for technical or product support?',
-    'zh-CN': '需要技术或产品支持？'
+    en: 'Looking for technical or product support? This form reaches our sales team — visit the',
+    'zh-CN': '需要技术或产品支持？此表单会发送给销售团队 — 请访问'
   },
   'contact.form.supportLinkCta': {
-    en: 'Find your answer here',
-    'zh-CN': '在这里找到答案'
+    en: 'Help Center',
+    'zh-CN': '帮助中心'
+  },
+  'contact.form.supportLinkMiddle': {
+    en: 'or email',
+    'zh-CN': '或发送邮件至'
+  },
+  'contact.form.supportLinkSuffix': {
+    en: 'for a faster answer.',
+    'zh-CN': '以更快获得答复。'
   },
   'contact.form.embedLoadErrorPrefix': {
     en: 'Unable to load the contact form. Email us at',

--- a/apps/website/src/scripts/posthog.test.ts
+++ b/apps/website/src/scripts/posthog.test.ts
@@ -187,7 +187,23 @@ describe('captureContactFormSubmitted', () => {
 
     expect(hoisted.mockCapture).toHaveBeenCalledWith(
       'website:contact_form_submitted',
-      { locale: 'en', form_id: 'form-guid' }
+      { locale: 'en', form_id: 'form-guid', hubspot_conversion_id: undefined }
+    )
+  })
+
+  it('captures the HubSpot conversion id when one is known', async () => {
+    const { initPostHog, captureContactFormSubmitted } =
+      await import('./posthog')
+    initPostHog()
+    captureContactFormSubmitted('en', 'form-guid', 'conversion-abc')
+
+    expect(hoisted.mockCapture).toHaveBeenCalledWith(
+      'website:contact_form_submitted',
+      {
+        locale: 'en',
+        form_id: 'form-guid',
+        hubspot_conversion_id: 'conversion-abc'
+      }
     )
   })
 
@@ -240,7 +256,7 @@ describe('captures made before initialization', () => {
     expect(hoisted.mockCapture).toHaveBeenCalledOnce()
   })
 
-  it('are dropped when initialization throws', async () => {
+  it('are discarded when initialization throws', async () => {
     hoisted.mockInit.mockImplementationOnce(() => {
       throw new Error('init blew up')
     })
@@ -251,5 +267,27 @@ describe('captures made before initialization', () => {
     initPostHog()
 
     expect(hoisted.mockCapture).not.toHaveBeenCalled()
+  })
+
+  it('are not resurrected by a later init that succeeds', async () => {
+    hoisted.mockInit.mockImplementationOnce(() => {
+      throw new Error('init blew up')
+    })
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    const { initPostHog, captureContactFormViewed } = await import('./posthog')
+    captureContactFormViewed('en')
+    initPostHog()
+    initPostHog()
+
+    expect(hoisted.mockCapture).not.toHaveBeenCalled()
+  })
+
+  it('stop accumulating once the pending queue is full', async () => {
+    const { initPostHog, captureContactFormViewed } = await import('./posthog')
+    for (let i = 0; i < 60; i++) captureContactFormViewed('en')
+    initPostHog()
+
+    expect(hoisted.mockCapture).toHaveBeenCalledTimes(50)
   })
 })

--- a/apps/website/src/scripts/posthog.test.ts
+++ b/apps/website/src/scripts/posthog.test.ts
@@ -149,3 +149,107 @@ describe('captureMcpClientTabClick', () => {
     expect(hoisted.mockCapture).not.toHaveBeenCalled()
   })
 })
+
+describe('captureContactFormViewed', () => {
+  beforeEach(() => {
+    vi.resetModules()
+  })
+
+  it('captures the contact form view with the locale', async () => {
+    const { initPostHog, captureContactFormViewed } = await import('./posthog')
+    initPostHog()
+    captureContactFormViewed('zh-CN')
+
+    expect(hoisted.mockCapture).toHaveBeenCalledWith(
+      'website:contact_form_viewed',
+      { locale: 'zh-CN' }
+    )
+  })
+
+  it('does not capture before PostHog is initialized', async () => {
+    const { captureContactFormViewed } = await import('./posthog')
+    captureContactFormViewed('en')
+
+    expect(hoisted.mockCapture).not.toHaveBeenCalled()
+  })
+})
+
+describe('captureContactFormSubmitted', () => {
+  beforeEach(() => {
+    vi.resetModules()
+  })
+
+  it('captures the contact form submission with the locale and form id', async () => {
+    const { initPostHog, captureContactFormSubmitted } =
+      await import('./posthog')
+    initPostHog()
+    captureContactFormSubmitted('en', 'form-guid')
+
+    expect(hoisted.mockCapture).toHaveBeenCalledWith(
+      'website:contact_form_submitted',
+      { locale: 'en', form_id: 'form-guid' }
+    )
+  })
+
+  it('does not capture before PostHog is initialized', async () => {
+    const { captureContactFormSubmitted } = await import('./posthog')
+    captureContactFormSubmitted('en', 'form-guid')
+
+    expect(hoisted.mockCapture).not.toHaveBeenCalled()
+  })
+})
+
+describe('captures made before initialization', () => {
+  beforeEach(() => {
+    vi.resetModules()
+  })
+
+  it('are sent once PostHog initializes', async () => {
+    const { initPostHog, captureContactFormViewed } = await import('./posthog')
+    captureContactFormViewed('en')
+
+    expect(hoisted.mockCapture).not.toHaveBeenCalled()
+
+    initPostHog()
+
+    expect(hoisted.mockCapture).toHaveBeenCalledWith(
+      'website:contact_form_viewed',
+      { locale: 'en' }
+    )
+  })
+
+  it('are replayed in the order they were made', async () => {
+    const { initPostHog, captureContactFormViewed, captureDownloadClick } =
+      await import('./posthog')
+    captureContactFormViewed('en')
+    captureDownloadClick('mac')
+    initPostHog()
+
+    expect(hoisted.mockCapture.mock.calls.map((call) => call[0])).toEqual([
+      'website:contact_form_viewed',
+      'website:download_button_clicked'
+    ])
+  })
+
+  it('are not replayed a second time on a repeat init', async () => {
+    const { initPostHog, captureContactFormViewed } = await import('./posthog')
+    captureContactFormViewed('en')
+    initPostHog()
+    initPostHog()
+
+    expect(hoisted.mockCapture).toHaveBeenCalledOnce()
+  })
+
+  it('are dropped when initialization throws', async () => {
+    hoisted.mockInit.mockImplementationOnce(() => {
+      throw new Error('init blew up')
+    })
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    const { initPostHog, captureContactFormViewed } = await import('./posthog')
+    captureContactFormViewed('en')
+    initPostHog()
+
+    expect(hoisted.mockCapture).not.toHaveBeenCalled()
+  })
+})

--- a/apps/website/src/scripts/posthog.ts
+++ b/apps/website/src/scripts/posthog.ts
@@ -2,6 +2,7 @@ import posthog from 'posthog-js'
 
 import { createPostHogBeforeSend } from '@comfyorg/shared-frontend-utils/piiUtil'
 
+import type { Locale } from '../i18n/translations'
 import type { Platform } from '@/composables/useDownloadUrl'
 
 const POSTHOG_KEY =
@@ -13,6 +14,27 @@ const POSTHOG_UI_HOST =
   import.meta.env.PUBLIC_POSTHOG_UI_HOST ?? 'https://us.posthog.com'
 
 let initialized = false
+const capturesPendingInit: (() => void)[] = []
+
+// A `client:load` island can mount before the BaseLayout script that calls
+// initPostHog has executed, so mount-time captures have to be held rather
+// than dropped or they are lost on every direct page load.
+function captureWhenReady(description: string, send: () => void) {
+  const guarded = () => {
+    try {
+      send()
+    } catch (error) {
+      console.error(`PostHog ${description} capture failed`, error)
+    }
+  }
+
+  if (!initialized) {
+    capturesPendingInit.push(guarded)
+    return
+  }
+
+  guarded()
+}
 
 export function initPostHog() {
   if (initialized || typeof window === 'undefined' || !POSTHOG_KEY) return
@@ -29,59 +51,57 @@ export function initPostHog() {
     initialized = true
   } catch (error) {
     console.error('PostHog init failed', error)
+    return
   }
+
+  for (const send of capturesPendingInit.splice(0)) send()
 }
 
 export function capturePageview() {
-  if (!initialized) return
-  try {
-    posthog.capture('$pageview')
-  } catch (error) {
-    console.error('PostHog pageview capture failed', error)
-  }
+  captureWhenReady('pageview', () => posthog.capture('$pageview'))
 }
 
 export function captureDownloadClick(platform: Platform) {
-  if (!initialized) return
-  try {
+  captureWhenReady('download click', () =>
     posthog.capture('website:download_button_clicked', { platform })
-  } catch (error) {
-    console.error('PostHog download click capture failed', error)
-  }
+  )
 }
 
 export function captureCliConnectionTabClick(connection: string) {
-  if (!initialized) return
-  try {
+  captureWhenReady('CLI connection tab', () =>
     posthog.capture('website:cli_connection_tab_clicked', { connection })
-  } catch (error) {
-    console.error('PostHog CLI connection tab capture failed', error)
-  }
+  )
 }
 
 export function captureCliClientTabClick(client: string) {
-  if (!initialized) return
-  try {
+  captureWhenReady('CLI client tab', () =>
     posthog.capture('website:cli_client_tab_clicked', { client })
-  } catch (error) {
-    console.error('PostHog CLI client tab capture failed', error)
-  }
+  )
 }
 
 export function captureMcpConnectionTabClick(connection: string) {
-  if (!initialized) return
-  try {
+  captureWhenReady('MCP connection tab', () =>
     posthog.capture('website:mcp_connection_tab_clicked', { connection })
-  } catch (error) {
-    console.error('PostHog MCP connection tab capture failed', error)
-  }
+  )
 }
 
 export function captureMcpClientTabClick(client: string) {
-  if (!initialized) return
-  try {
+  captureWhenReady('MCP client tab', () =>
     posthog.capture('website:mcp_client_tab_clicked', { client })
-  } catch (error) {
-    console.error('PostHog MCP client tab capture failed', error)
-  }
+  )
+}
+
+export function captureContactFormViewed(locale: Locale) {
+  captureWhenReady('contact form viewed', () =>
+    posthog.capture('website:contact_form_viewed', { locale })
+  )
+}
+
+export function captureContactFormSubmitted(locale: Locale, formId: string) {
+  captureWhenReady('contact form submitted', () =>
+    posthog.capture('website:contact_form_submitted', {
+      locale,
+      form_id: formId
+    })
+  )
 }

--- a/apps/website/src/scripts/posthog.ts
+++ b/apps/website/src/scripts/posthog.ts
@@ -16,6 +16,11 @@ const POSTHOG_UI_HOST =
 let initialized = false
 const capturesPendingInit: (() => void)[] = []
 
+// Outside production initPostHog is never called, so the queue is capped to
+// keep it from growing for the lifetime of the page. Real pages only queue
+// the handful of captures that race initialization.
+const MAX_CAPTURES_PENDING_INIT = 50
+
 // A `client:load` island can mount before the BaseLayout script that calls
 // initPostHog has executed, so mount-time captures have to be held rather
 // than dropped or they are lost on every direct page load.
@@ -29,7 +34,9 @@ function captureWhenReady(description: string, send: () => void) {
   }
 
   if (!initialized) {
-    capturesPendingInit.push(guarded)
+    if (capturesPendingInit.length < MAX_CAPTURES_PENDING_INIT) {
+      capturesPendingInit.push(guarded)
+    }
     return
   }
 
@@ -51,6 +58,7 @@ export function initPostHog() {
     initialized = true
   } catch (error) {
     console.error('PostHog init failed', error)
+    capturesPendingInit.length = 0
     return
   }
 
@@ -97,11 +105,16 @@ export function captureContactFormViewed(locale: Locale) {
   )
 }
 
-export function captureContactFormSubmitted(locale: Locale, formId: string) {
+export function captureContactFormSubmitted(
+  locale: Locale,
+  formId: string,
+  conversionId?: string
+) {
   captureWhenReady('contact form submitted', () =>
     posthog.capture('website:contact_form_submitted', {
       locale,
-      form_id: formId
+      form_id: formId,
+      hubspot_conversion_id: conversionId
     })
   )
 }


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

Two related changes to the marketing site's `/contact` page, from a #lifecycle discussion of the MiniMax H3 Commercial License engaged send.

- Fixes FE-1933

## ⚠️ Action required before this can go green

The `/contact` copy change invalidates two committed visual baselines (`contact-form-1-sm-visual-linux.png`, `contact-form-2-md-visual-linux.png`), so **`CI: Website E2E` will fail deterministically** until they are regenerated. They are produced inside `mcr.microsoft.com/playwright:v1.61.1-noble`, so regenerating them locally would bake in this sandbox's font rendering rather than CI's — deliberately not done here.

Please tick **Update website screenshots** in the E2E status comment, add the `Update Website Screenshots` label, or comment `/update-website-screenshots`.

## 1. Support route on `/contact` (FE-1933)

The page already had a support sentence, but it pointed at `docs.comfy.org` — self-serve documentation, not a way to reach a human. That is the gap behind the Reddit complaints.

It now routes to the actual support channels and, more importantly, states plainly that the form itself goes to sales — the page is headed `CONTACT SALES`, which is why people looking for support got lost on it:

> Looking for technical or product support? This form reaches our sales team — visit the **Help Center** or email **support@comfy.org** for a faster answer.

`Help Center` reuses the existing `externalLinks.support` constant. Copy is translated for `zh-CN`.

## 2. PostHog instrumentation

Adds the two events proposed in the thread, following the existing `website:` namespace:

| Event | When | Properties |
| --- | --- | --- |
| `website:contact_form_viewed` | contact form mounts | `locale` |
| `website:contact_form_submitted` | HubSpot reports a successful submission | `locale`, `form_id`, `hubspot_conversion_id` |

Three things were less trivial than they look:

**The form is a HubSpot embed, not a native form.** There is no submit handler to hook. HubSpot reports submissions two different ways depending on form version — `postMessage` (`hsFormCallback`/`onFormSubmitted`) on v3, and a bubbling `hs-form-event:on-submission:success` window event on v4. Both are observed and collapsed into a single event. I confirmed against the live embed that the deployed form is v4, so that is the live path and `postMessage` is defensive fallback.

**`hubspot_conversion_id` is the point.** Without it the payload would be `{ locale, form_id }` — and `form_id` is derived from `locale`, so it is the same fact twice and joins to nothing. The conversion id comes from HubSpot's v4 form API (`getFormFromEvent(event).getConversionId()`) and is the non-PII key that lets a PostHog submission be matched to its HubSpot record. **This is what removes the manual HubSpot ↔ Customer.io reconciliation.** No submitted field values are sent; `before_send` already strips `email`/`$email`/`user_email`/`prompt`.

**Captures that race initialization were being dropped.** `<FormSection client:load />` can mount before the `BaseLayout` script calls `initPostHog()`, and every capture helper early-returned while uninitialized — so on a direct load of `/contact` the view event was silently lost, while the submit event (seconds later, user-driven) always fired. That would have produced submissions exceeding views and a systematically wrong funnel for exactly the paid/email/search traffic this work exists to measure. Pre-init captures are now queued and flushed on init (bounded, and discarded if init fails).

Submissions are also scoped to this form's id, so another HubSpot form on the page cannot mint a false conversion or consume the dedup latch.

## Verification

- `pnpm --filter @comfyorg/website test:unit` — 735 pass (34 in the two touched files, incl. both HubSpot event shapes, conversion-id extraction, foreign-form rejection, dedup, unmount cleanup, and the pre-init queue)
- `pnpm typecheck:website` — 0 errors; `oxfmt --check`, `eslint`, `stylelint`, `pnpm knip` clean
- `NODE_ENV=production astro build` — 700 pages (also confirms the top-level `useEventListener` is SSR-inert)
- Drove the real production bundle in Chromium and verified against the **live** HubSpot embed: both `HubSpotFormsV4` and `HubspotFormsV4` globals exist (hence the two-spelling lookup), `getFormFromEvent()` resolves the instance, and `getFormId()` returns exactly `94e05eab-…` — so the form-identity check is genuinely live rather than inert. Listeners attach and run with no console errors.

**Not verified, needs a post-deploy check:** PostHog's capture endpoint does not complete from this sandbox at all — the pre-existing `$pageview` is equally silent — so delivery is verified only up to the `posthog.capture` boundary. Please confirm one real submission arrives with `hubspot_conversion_id` populated. If it were ever empty it is dropped silently and the event would still look healthy.

## Notes / follow-ups

- `contact_form_viewed` fires on mount, matching the "when the page is viewed" wording in the thread, so its denominator is page loads rather than form impressions — it also fires when the HubSpot embed is ad-blocked and the user only sees the fallback. If marketing wants a true impression denominator, moving it to `hs-form-event:on-ready` is a one-line follow-up.
- The `zh-CN` Help Center link resolves to `/hc/en-us`; `support.comfy.org` serves the same English content at both locale paths, so there is no localized target to point at. Pre-existing constant, filed as a separate concern.
- Copy is my wording — happy to take marketing's preferred phrasing.


## Screenshots

![/contact support copy in English, routing to the Help Center and support@comfy.org](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/580a4f16d1acd64eff5b2dfb0758abcb5aeb56211d263ac8d0361d034f45c685/pr-images/1787901516913-91cceb87-3824-4b9a-956d-005c6b68264d.png)

![/contact support copy in zh-CN, routing to the Help Center and support@comfy.org](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/580a4f16d1acd64eff5b2dfb0758abcb5aeb56211d263ac8d0361d034f45c685/pr-images/1787901517247-27ff2873-b9a5-4fd7-b8ef-d75f923c5233.png)