### PR TITLE
fix(billing): treat a rollout-defaulted capability as an unresolved policy

### DIFF
--- a/browser_tests/fixtures/data/billingCapabilities.ts
+++ b/browser_tests/fixtures/data/billingCapabilities.ts
@@ -7,7 +7,10 @@ import type { WorkspaceWithRole } from '@/platform/workspace/api/workspaceApi'
 
 export function createBillingCapabilities(
   workspaceId: string,
-  overrides: Partial<BillingCapabilities> = {}
+  overrides: Partial<BillingCapabilities> = {},
+  rolloutDefaults: Partial<
+    BillingCapabilitiesResponse['rollout_defaults_applied']
+  > = {}
 ): BillingCapabilitiesResponse {
   return {
     resolved_for: {
@@ -27,7 +30,8 @@ export function createBillingCapabilities(
     rollout_defaults_applied: {
       can_downgrade_to_personal: false,
       can_subscribe_self_serve: false,
-      can_top_up: false
+      can_top_up: false,
+      ...rolloutDefaults
     },
     revision: 1,
     // Far-future expiry so the snapshot never goes stale mid-test.

--- a/browser_tests/tests/dialogs/enterpriseTierCloud.spec.ts
+++ b/browser_tests/tests/dialogs/enterpriseTierCloud.spec.ts
@@ -7,6 +7,7 @@ import type {
 
 import { cloudAppFixture as test } from '@e2e/fixtures/cloudAppFixture'
 import { TopUpCreditsDialog } from '@e2e/fixtures/components/TopUpCreditsDialog'
+import { createBillingCapabilities } from '@e2e/fixtures/data/billingCapabilities'
 import {
   DEFAULT_TEAM_MEMBERS,
   INACTIVE_TEAM_BILLING_STATUS,
@@ -262,6 +263,33 @@ test.describe('Non-Enterprise billing regression', { tag: '@cloud' }, () => {
     await workspace.setup(DEFAULT_TEAM_MEMBERS, TEAM_WORKSPACE)
     await page.route('**/api/billing/capabilities', (route) =>
       route.fulfill({ status: 503 })
+    )
+
+    await page.goto(`${APP_URL}/?pricing=team`)
+
+    await expect(
+      page.getByRole('heading', { name: 'Plans for Team Workspace' })
+    ).toBeVisible({ timeout: 45_000 })
+    await expect(page).not.toHaveURL(/[?&]pricing=/)
+  })
+
+  test('keeps the pricing surface usable when the server answers with a rollout default', async ({
+    page
+  }) => {
+    const workspace = new CloudWorkspaceMockHelper(page)
+    await workspace.setup(DEFAULT_TEAM_MEMBERS, TEAM_WORKSPACE)
+    await page.route('**/api/billing/capabilities', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(
+          createBillingCapabilities(
+            TEAM_WORKSPACE.id,
+            { can_subscribe_self_serve: false },
+            { can_subscribe_self_serve: true }
+          )
+        )
+      })
     )
 
     await page.goto(`${APP_URL}/?pricing=team`)

--- a/src/platform/workspace/composables/useBillingCapabilities.test.ts
+++ b/src/platform/workspace/composables/useBillingCapabilities.test.ts
@@ -67,7 +67,10 @@ function capabilitiesResponse(
   workspaceId = 'workspace-1',
   canSubscribeSelfServe = true,
   freshness: { expiresAt?: string; revision?: number } = {},
-  overrides: Partial<BillingCapabilitiesResponse['capabilities']> = {}
+  overrides: Partial<BillingCapabilitiesResponse['capabilities']> = {},
+  rolloutDefaults: Partial<
+    BillingCapabilitiesResponse['rollout_defaults_applied']
+  > = {}
 ): BillingCapabilitiesResponse {
   return {
     resolved_for: {
@@ -87,7 +90,8 @@ function capabilitiesResponse(
     rollout_defaults_applied: {
       can_downgrade_to_personal: false,
       can_subscribe_self_serve: false,
-      can_top_up: false
+      can_top_up: false,
+      ...rolloutDefaults
     },
     revision: freshness.revision ?? 1,
     expires_at: freshness.expiresAt ?? '2099-01-01T00:00:00Z'
@@ -272,18 +276,19 @@ describe('useBillingCapabilities', () => {
     )
   })
 
-  it('keeps top-up available for owners when the endpoint is unavailable', async () => {
+  it('keeps rollout-defaulted capabilities available for owners when the endpoint is unavailable', async () => {
     mockGetBillingCapabilities.mockRejectedValueOnce(new Error('unavailable'))
 
     await billingCapabilities.initialize()
 
     expect(billingCapabilities.canTopUp.value).toBe(true)
-    expect(billingCapabilities.canSubscribeSelfServe.value).toBe(false)
+    expect(billingCapabilities.canSubscribeSelfServe.value).toBe(true)
+    expect(billingCapabilities.canDowngradeToPersonal.value).toBe(true)
+    // Deterministic policy results carry no rollout default to fall back on.
     expect(billingCapabilities.canCancel.value).toBe(false)
     expect(billingCapabilities.canReactivate.value).toBe(false)
     expect(billingCapabilities.canChangeSeats.value).toBe(false)
     expect(billingCapabilities.canInviteMembers.value).toBe(false)
-    expect(billingCapabilities.canDowngradeToPersonal.value).toBe(false)
     expect(billingCapabilities.isReady.value).toBe(true)
     expect(billingCapabilities.snapshotAuthoritative.value).toBe(false)
     expect(mockReportError).toHaveBeenCalledOnce()
@@ -299,6 +304,54 @@ describe('useBillingCapabilities', () => {
     expect(billingCapabilities.canSubscribeSelfServe.value).toBe(false)
     expect(billingCapabilities.isReady.value).toBe(true)
     expect(billingCapabilities.snapshotAuthoritative.value).toBe(false)
+  })
+
+  it('keeps self-serve open for owners when the server answers with a rollout default', async () => {
+    mockGetBillingCapabilities.mockResolvedValueOnce(
+      capabilitiesResponse(
+        true,
+        'workspace-1',
+        false,
+        {},
+        {},
+        { can_subscribe_self_serve: true }
+      )
+    )
+
+    await billingCapabilities.initialize()
+
+    expect(billingCapabilities.canSubscribeSelfServe.value).toBe(true)
+    // The snapshot is authoritative, so an authoritativeness guard alone leaves
+    // the defaulted value reading as a policy deny.
+    expect(billingCapabilities.snapshotAuthoritative.value).toBe(true)
+  })
+
+  it('withholds a rollout-defaulted capability from members', async () => {
+    mockScope.role = 'member'
+    mockGetBillingCapabilities.mockResolvedValueOnce(
+      capabilitiesResponse(
+        true,
+        'workspace-1',
+        false,
+        {},
+        {},
+        { can_subscribe_self_serve: true }
+      )
+    )
+
+    await billingCapabilities.initialize()
+
+    expect(billingCapabilities.canSubscribeSelfServe.value).toBe(false)
+  })
+
+  it('closes self-serve for owners when the server resolves a real policy deny', async () => {
+    mockGetBillingCapabilities.mockResolvedValueOnce(
+      capabilitiesResponse(true, 'workspace-1', false)
+    )
+
+    await billingCapabilities.initialize()
+
+    expect(billingCapabilities.canSubscribeSelfServe.value).toBe(false)
   })
 
   it('fails closed when the endpoint denies the current actor', async () => {
@@ -346,12 +399,12 @@ describe('useBillingCapabilities', () => {
 
     expect(mockGetBillingCapabilities).toHaveBeenCalledOnce()
     expect(billingCapabilities.canTopUp.value).toBe(true)
-    expect(billingCapabilities.canSubscribeSelfServe.value).toBe(false)
+    expect(billingCapabilities.canSubscribeSelfServe.value).toBe(true)
+    expect(billingCapabilities.canDowngradeToPersonal.value).toBe(true)
     expect(billingCapabilities.canCancel.value).toBe(false)
     expect(billingCapabilities.canReactivate.value).toBe(false)
     expect(billingCapabilities.canChangeSeats.value).toBe(false)
     expect(billingCapabilities.canInviteMembers.value).toBe(false)
-    expect(billingCapabilities.canDowngradeToPersonal.value).toBe(false)
   })
 
   it('discards a stale response after the active workspace changes', async () => {
@@ -883,12 +936,12 @@ describe('useBillingCapabilities', () => {
       .mockResolvedValueOnce(capabilitiesResponse(true))
 
     await billingCapabilities.initialize()
-    expect(billingCapabilities.canSubscribeSelfServe.value).toBe(false)
+    expect(billingCapabilities.canCancel.value).toBe(false)
 
     await vi.advanceTimersByTimeAsync(31_000)
 
     expect(mockGetBillingCapabilities).toHaveBeenCalledTimes(2)
-    expect(billingCapabilities.canSubscribeSelfServe.value).toBe(true)
+    expect(billingCapabilities.canCancel.value).toBe(true)
   })
 
   it('backs off between retries and reports the outage once', async () => {

--- a/src/platform/workspace/composables/useBillingCapabilities.ts
+++ b/src/platform/workspace/composables/useBillingCapabilities.ts
@@ -1,4 +1,7 @@
-import type { BillingCapabilitiesResponse } from '@comfyorg/ingest-types'
+import type {
+  BillingCapabilitiesResponse,
+  BillingCapabilityRolloutDefaults
+} from '@comfyorg/ingest-types'
 import {
   createSharedComposable,
   defaultDocument,
@@ -68,7 +71,7 @@ function useBillingCapabilitiesInternal() {
   let readFailures = 0
   let invalidatedRequestId = 0
 
-  const capabilities = computed(() => {
+  const resolvedResponse = computed(() => {
     const userId = authStore.currentUser?.uid
     const workspaceId = workspaceStore.activeWorkspaceId
     const state = readState.value
@@ -83,8 +86,11 @@ function useBillingCapabilitiesInternal() {
       return null
     }
 
-    return state.response.capabilities
+    return state.response
   })
+  const capabilities = computed(
+    () => resolvedResponse.value?.capabilities ?? null
+  )
   const readUnavailableForCurrentScope = computed(() => {
     const state = readState.value
     return (
@@ -93,19 +99,43 @@ function useBillingCapabilitiesInternal() {
       state.workspaceId === workspaceStore.activeWorkspaceId
     )
   })
+  const isWorkspaceOwner = computed(
+    () => workspaceStore.activeWorkspace?.role === 'owner'
+  )
+
+  // rollout_defaults_applied marks a field the server answered with a safe
+  // default because its rollout is incomplete — "UI guidance, not evidence that
+  // the corresponding write will succeed". It carries no policy decision, so it
+  // is treated exactly like an unreadable snapshot rather than as a deny.
+  function policyResult(
+    field: keyof BillingCapabilityRolloutDefaults
+  ): boolean | null {
+    const response = resolvedResponse.value
+    if (!response || response.rollout_defaults_applied[field]) return null
+    return response.capabilities[field]
+  }
+
+  // Without a policy answer only owners keep the capability, so a rollout gap
+  // or transient outage does not strand the one role that can act on it. Every
+  // other role — including an unresolved one — fails closed.
+  function ownerFallback(
+    field: keyof BillingCapabilityRolloutDefaults
+  ): boolean {
+    const awaitingPolicy =
+      readUnavailableForCurrentScope.value ||
+      resolvedResponse.value?.rollout_defaults_applied[field] === true
+    return awaitingPolicy && isWorkspaceOwner.value
+  }
+
   const canTopUp = computed(() => {
     if (!isCloud) return workspaceStore.activeWorkspace?.role !== 'member'
-    // An unreadable capability keeps top-up available only for owners, so a
-    // transient outage does not strand the one role that can actually top up.
-    // Every other role - including an unresolved one - fails closed.
-    return (
-      capabilities.value?.can_top_up ??
-      (readUnavailableForCurrentScope.value &&
-        workspaceStore.activeWorkspace?.role === 'owner')
-    )
+    return policyResult('can_top_up') ?? ownerFallback('can_top_up')
   })
   const canSubscribeSelfServe = computed(
-    () => isCloud && (capabilities.value?.can_subscribe_self_serve ?? false)
+    () =>
+      isCloud &&
+      (policyResult('can_subscribe_self_serve') ??
+        ownerFallback('can_subscribe_self_serve'))
   )
   const canCancel = computed(
     () => isCloud && (capabilities.value?.can_cancel ?? false)
@@ -120,7 +150,10 @@ function useBillingCapabilitiesInternal() {
     () => isCloud && (capabilities.value?.can_invite_members ?? false)
   )
   const canDowngradeToPersonal = computed(
-    () => isCloud && (capabilities.value?.can_downgrade_to_personal ?? false)
+    () =>
+      isCloud &&
+      (policyResult('can_downgrade_to_personal') ??
+        ownerFallback('can_downgrade_to_personal'))
   )
   const isReady = computed(() => {
     if (!isCloud) return true


### PR DESCRIPTION
## Summary

`rollout_defaults_applied` was never read, so a capability the server answered with a rollout default was indistinguishable from a policy deny — which is what closed every pricing entry point in prod during IR-120.

## Root cause

`BillingCapabilitiesResponse` carries two things: the capability values, and `rollout_defaults_applied` marking which of them came from a rollout default rather than a policy decision. The generated contract is explicit about what a defaulted value means:

> capability values currently using safe rollout defaults instead of deterministic policy results. A true value is UI guidance, not evidence that the corresponding write will succeed.

The client only ever read the first half. `capabilities` returned `state.response.capabilities` and dropped the marker, so every consumer collapsed a defaulted value into a plain boolean:

```ts
const canSubscribeSelfServe = computed(
  () => isCloud && (capabilities.value?.can_subscribe_self_serve ?? false)
)
```

With the capabilities rollout flags off in production, billing-api returned **200** with `can_subscribe_self_serve: false` and `rollout_defaults_applied.can_subscribe_self_serve: true` — "no answer yet, here is a safe default". The client read it as "the server says no" and removed the profile-menu item, the settings link and the `?pricing=` deep link at once. Staging was unaffected because its flags were on, so it received real policy results.

This is not the same failure #16100 fixed. That one guards on `snapshotAuthoritative`, which is derived from the read *state* — and a 200 with rollout defaults is `resolved`, so the guard passes and the defaulted value still reads as a deny. The new unit test asserts `snapshotAuthoritative === true` in exactly this scenario to pin that down.

## Changes

- **What**: the three fields in `BillingCapabilityRolloutDefaults` (`can_subscribe_self_serve`, `can_top_up`, `can_downgrade_to_personal`) now go through `policyResult()`, which returns `null` when the field carries no policy decision — unreadable snapshot or rollout default alike. `ownerFallback()` then applies the ownership fallback `canTopUp` already had. Deterministic fields (`can_cancel`, `can_reactivate`, `can_change_seats`, `can_invite_members`) are untouched and still fail closed.
- **Breaking**: during a rollout gap or outage, an owner now keeps the pricing surface and downgrade action instead of losing them. Opening the catalog is navigation, not a billing write, and every checkout endpoint enforces its own policy — per the contract's own "these values do not authorize billing writes". A real policy deny (marker `false`, value `false`) still closes, so sales-managed Enterprise is unchanged; there is a test for that.

## Review Focus

Whether ownership is the right fallback for `can_downgrade_to_personal`. It is rollout-defaulted and had no fallback at all, so it is included for consistency, but it is a destructive-ish action and a reviewer may want it to keep failing closed. Happy to drop it from this PR.

Also worth a second opinion: `ownerFallback` keys off `activeWorkspace.role === 'owner'`, matching the existing `canTopUp` fallback rather than `permissions.canManageSubscription`. If a non-owner role can ever manage a subscription, these disagree.

## Tests

- `useBillingCapabilities.test.ts`: 42 passing. Three added — owner keeps self-serve on a rollout-defaulted answer (with `snapshotAuthoritative === true` asserted), a member does not, and a real policy deny still closes for an owner.
- Three existing tests changed. They asserted `canSubscribeSelfServe === false` for an **owner** on an unreadable snapshot — the production symptom, encoded as the expectation. They were correct for the contract as consumed at the time; they are updated, not deleted.
- Wider regression run: 116 files / 2056 tests across `src/platform/workspace`, `src/platform/cloud/subscription`, `src/components/topbar`, `src/services`. All pass.
- E2E: the pricing deep link stays available when capabilities come back rollout-defaulted, mirroring the existing 503 test next to it.
- `pnpm typecheck`, `pnpm lint` (0 errors), `pnpm knip` clean.

## Follow-ups not in this PR

- The rollout-defaults condition still has no fixture coverage at the CTA level. `UnifiedPricingTable` re-derives its own `canSubscribeSelfServe`/`canChangeSeats`/`canDowngradeToPersonal`, and `isTeamButtonDisabled` reads them directly — this fix reaches those via the composable, but a surface-level test needs an unsubscribed-workspace fixture that does not exist yet.
- Overlaps `dante/centralize-billing-ui-policy`, which moves `canOpenPricingSurface` into this composable. Complementary, but they will conflict textually in `useBillingCapabilities.ts`.

## Screenshots

Captured against the production cloud build (`pnpm build:cloud`) served locally, with `/api/billing/capabilities` returning **HTTP 200** and `rollout_defaults_applied.can_subscribe_self_serve: true` — the exact shape prod returned while the rollout flags were off. Same mock both times; only the build differs.

**AS IS** (`origin/main`, before this change) — `?pricing=team` is inert. No dialog, no error, nothing: the deep link silently does nothing because the defaulted value read as a policy deny.

**TO BE** (this branch) — the same deep link opens "Plans for Team Workspace" with Standard / Creator / Pro selectable.

Images attached below. (The red node borders in the AS IS shot are unrelated mock-environment artifacts — the mocked workspace has no models installed; the relevant part is the absence of the pricing dialog.)
