### PR TITLE
refactor(billing): centralize pricing-surface and inactive-plan policy

### DIFF
--- a/src/platform/cloud/subscription/composables/usePricingTableUrlLoader.test.ts
+++ b/src/platform/cloud/subscription/composables/usePricingTableUrlLoader.test.ts
@@ -63,13 +63,13 @@ const mockInitializeCapabilities = vi.hoisted(() =>
 
 vi.mock('@/platform/workspace/composables/useWorkspaceUI', () => ({
   useWorkspaceUI: () => ({
-    permissions: mockPermissions,
-    canOpenPricingSurface: mockCanOpenPricingSurface
+    permissions: mockPermissions
   })
 }))
 
 vi.mock('@/platform/workspace/composables/useBillingCapabilities', () => ({
   useBillingCapabilities: () => ({
+    canOpenPricingSurface: mockCanOpenPricingSurface,
     initialize: mockInitializeCapabilities
   })
 }))

--- a/src/platform/cloud/subscription/composables/usePricingTableUrlLoader.ts
+++ b/src/platform/cloud/subscription/composables/usePricingTableUrlLoader.ts
@@ -104,8 +104,9 @@ export function usePricingTableUrlLoader() {
   const router = useRouter()
   const subscriptionDialog = useSubscriptionDialog()
   const { teamCreditStops, fetchPlans } = useBillingContext()
-  const { permissions, canOpenPricingSurface } = useWorkspaceUI()
-  const { initialize: initializeCapabilities } = useBillingCapabilities()
+  const { permissions } = useWorkspaceUI()
+  const { canOpenPricingSurface, initialize: initializeCapabilities } =
+    useBillingCapabilities()
 
   /** Reads `?pricing=`, strips it, and opens the table when the gate allows. */
   async function loadPricingTableFromUrl() {

--- a/src/platform/workspace/components/CurrentUserPopoverWorkspace.test.ts
+++ b/src/platform/workspace/components/CurrentUserPopoverWorkspace.test.ts
@@ -80,13 +80,13 @@ vi.mock('@/platform/workspace/composables/useWorkspaceUI', () => ({
       canManageSubscription: state.canManageSubscription,
       canManageSubscriptionLifecycle: state.canManageSubscriptionLifecycle
     })),
-    canReactivatePlan: computed(() => state.canReactivatePlan),
-    canOpenPricingSurface: computed(() => state.canOpenPricingSurface)
+    canReactivatePlan: computed(() => state.canReactivatePlan)
   })
 }))
 
 vi.mock('@/platform/workspace/composables/useBillingCapabilities', () => ({
   useBillingCapabilities: () => ({
+    canOpenPricingSurface: computed(() => state.canOpenPricingSurface),
     canTopUp: computed(() => state.canTopUp),
     canSubscribeSelfServe: computed(() => state.canSubscribeSelfServe),
     canReactivate: computed(() => state.canReactivate)

--- a/src/platform/workspace/components/CurrentUserPopoverWorkspace.vue
+++ b/src/platform/workspace/components/CurrentUserPopoverWorkspace.vue
@@ -281,9 +281,9 @@ const {
   workspaceName,
   isInPersonalWorkspace: isPersonalWorkspace
 } = storeToRefs(workspaceStore)
-const { permissions, canReactivatePlan, canOpenPricingSurface } =
-  useWorkspaceUI()
-const { canTopUp, canSubscribeSelfServe } = useBillingCapabilities()
+const { permissions, canReactivatePlan } = useWorkspaceUI()
+const { canOpenPricingSurface, canTopUp, canSubscribeSelfServe } =
+  useBillingCapabilities()
 const isWorkspaceSwitcherOpen = ref(false)
 const workspaceSwitcherTrigger = useTemplateRef('workspaceSwitcherTrigger')
 const workspaceSwitcherPanel = useTemplateRef('workspaceSwitcherPanel')

--- a/src/platform/workspace/components/SubscriptionPanelContentWorkspace.test.ts
+++ b/src/platform/workspace/components/SubscriptionPanelContentWorkspace.test.ts
@@ -87,6 +87,7 @@ const mockCanCancel = ref(true)
 const mockCanReactivate = ref(true)
 const mockCanReactivatePlan = ref(true)
 const mockCanOpenPricingSurface = ref(true)
+const mockShowInactiveTeamSubscription = ref(false)
 const mockShouldUseWorkspaceBilling = ref(true)
 const mockCanChangeSeats = ref(true)
 const mockCanSubscribeSelfServe = ref(true)
@@ -211,6 +212,14 @@ const mockIsTeamPlanCancelled = computed(
 const mockIsSubscriptionCancelled = computed(
   () => mockSubscription.value?.isCancelled ?? false
 )
+const mockIsSubscriptionEnded = computed(() => {
+  if (mockSubscriptionStatus.value === 'ended') return true
+  if (mockIsActiveSubscription.value) return false
+  return (
+    mockIsSubscriptionCancelled.value ||
+    (mockIsInPersonalWorkspace.value && mockBillingStatus.value === 'inactive')
+  )
+})
 
 const mockIsDeleteDisabled = computed(
   () =>
@@ -226,11 +235,12 @@ vi.mock('@/platform/workspace/composables/useWorkspaceUI', () => ({
       canLeaveWorkspace: mockCanLeaveWorkspace.value
     })),
     canReactivatePlan: mockCanReactivatePlan,
-    canOpenPricingSurface: mockCanOpenPricingSurface,
+    showInactiveTeamSubscription: mockShowInactiveTeamSubscription,
     uiConfig: computed(() => mockUiConfig.value),
     isInPersonalWorkspace: mockIsInPersonalWorkspace,
     isActiveSubscription: computed(() => mockIsActiveSubscription.value),
     isSubscriptionCancelled: mockIsSubscriptionCancelled,
+    isSubscriptionEnded: mockIsSubscriptionEnded,
     isTeamPlanCancelled: mockIsTeamPlanCancelled,
     isDeleteDisabled: mockIsDeleteDisabled,
     deleteDisabledTooltipKey: computed(() =>
@@ -246,6 +256,7 @@ vi.mock('@/platform/workspace/composables/useBillingCapabilities', () => ({
     canCancel: mockCanCancel,
     canReactivate: mockCanReactivate,
     canChangeSeats: mockCanChangeSeats,
+    canOpenPricingSurface: mockCanOpenPricingSurface,
     canSubscribeSelfServe: mockCanSubscribeSelfServe
   })
 }))
@@ -353,6 +364,7 @@ describe('SubscriptionPanelContentWorkspace', () => {
     mockCanChangeSeats.value = true
     mockCanSubscribeSelfServe.value = true
     mockCanOpenPricingSurface.value = true
+    mockShowInactiveTeamSubscription.value = false
     mockCanLeaveWorkspace.value = true
     mockUiConfig.value = ownerUiConfig
     mockSubscriptionTier.value = 'PRO'
@@ -820,6 +832,7 @@ describe('SubscriptionPanelContentWorkspace', () => {
     mockSubscriptionStatus.value = 'canceled'
     mockIsActiveSubscription.value = false
     mockIsWorkspaceSubscribed.value = false
+    mockShowInactiveTeamSubscription.value = true
     renderComponent({ stubFooter: false })
 
     expect(
@@ -835,6 +848,7 @@ describe('SubscriptionPanelContentWorkspace', () => {
     mockSubscriptionStatus.value = 'canceled'
     mockIsActiveSubscription.value = false
     mockIsWorkspaceSubscribed.value = false
+    mockShowInactiveTeamSubscription.value = true
     const user = userEvent.setup()
     renderComponent()
 
@@ -889,6 +903,7 @@ describe('SubscriptionPanelContentWorkspace', () => {
     mockIsActiveSubscription.value = false
     mockIsWorkspaceSubscribed.value = false
     mockCanSubscribeSelfServe.value = false
+    mockShowInactiveTeamSubscription.value = true
     renderComponent()
 
     expect(screen.getByTestId('credits-tile')).toHaveAttribute(

--- a/src/platform/workspace/components/SubscriptionPanelContentWorkspace.vue
+++ b/src/platform/workspace/components/SubscriptionPanelContentWorkspace.vue
@@ -443,11 +443,13 @@ const { isWorkspaceSubscribed, isInPersonalWorkspace } =
 const {
   permissions,
   isSubscriptionCancelled,
+  isSubscriptionEnded,
+  showInactiveTeamSubscription,
   workspaceRole,
-  canReactivatePlan,
-  canOpenPricingSurface
+  canReactivatePlan
 } = useWorkspaceUI()
-const { canChangeSeats, canSubscribeSelfServe } = useBillingCapabilities()
+const { canChangeSeats, canOpenPricingSurface, canSubscribeSelfServe } =
+  useBillingCapabilities()
 const { maxAvailable: freeRunsAllowance, quotaEnabled: freeRunsQuotaEnabled } =
   useFreeTierQuota()
 const { t, n, locale } = useI18n()
@@ -469,8 +471,6 @@ const {
   isTeamPlan,
   subscription,
   plans,
-  billingStatus,
-  subscriptionStatus,
   isLoading,
   error,
   showSubscriptionDialog,
@@ -483,15 +483,6 @@ const { showPricingTable } = useSubscriptionDialog()
 const { isResubscribing, handleResubscribe } = useResubscribe()
 const { displayPrice, priceUnitLabel } = useWorkspacePlanPricing()
 const { menuEntries } = useWorkspaceMenuItems()
-
-const isSubscriptionEnded = computed(() => {
-  if (subscriptionStatus.value === 'ended') return true
-  if (canAccessSubscriptionFeatures.value) return false
-  return (
-    isSubscriptionCancelled.value ||
-    (isInPersonalWorkspace.value && billingStatus.value === 'inactive')
-  )
-})
 
 // Show subscribe prompt to owners without active subscription. A cancelled plan
 // stays active until its end date, so it keeps the subscribed treatment.
@@ -526,14 +517,6 @@ const showTeamSubscribePrompt = computed(
     showSubscribePrompt.value &&
     !isInPersonalWorkspace.value &&
     (isCloud || (isSubscriptionEnded.value && isTeamPlan.value))
-)
-
-const showInactiveTeamSubscription = computed(
-  () =>
-    permissions.value.canManageSubscription &&
-    !isInPersonalWorkspace.value &&
-    isSubscriptionEnded.value &&
-    isTeamPlan.value
 )
 
 const isPersonalFree = computed(

--- a/src/platform/workspace/composables/useBillingCapabilities.test.ts
+++ b/src/platform/workspace/composables/useBillingCapabilities.test.ts
@@ -12,6 +12,7 @@ import { useBillingCapabilities } from './useBillingCapabilities'
 const mockGetBillingCapabilities = vi.hoisted(() => vi.fn())
 const mockReportError = vi.hoisted(() => vi.fn())
 const mockIsCloud = vi.hoisted(() => ({ value: true }))
+const mockShouldUseWorkspaceBilling = vi.hoisted(() => ({ value: true }))
 const mockScope = vi.hoisted(() => ({
   workspaceId: 'workspace-1' as string | null,
   authUid: 'firebase-user-1' as string | null,
@@ -39,6 +40,14 @@ vi.mock('@/platform/distribution/types', () => ({
   get isCloud() {
     return mockIsCloud.value
   }
+}))
+
+vi.mock('@/composables/billing/useBillingRouting', () => ({
+  useBillingRouting: () => ({
+    get shouldUseWorkspaceBilling() {
+      return mockShouldUseWorkspaceBilling
+    }
+  })
 }))
 
 vi.mock('@/platform/workspace/stores/teamWorkspaceStore', () => ({
@@ -178,6 +187,7 @@ describe('useBillingCapabilities', () => {
 
   beforeEach(() => {
     mockIsCloud.value = true
+    mockShouldUseWorkspaceBilling.value = true
     mockScope.workspaceId = 'workspace-1'
     mockScope.authUid = 'firebase-user-1'
     mockScope.role = 'owner'
@@ -198,12 +208,12 @@ describe('useBillingCapabilities', () => {
 
     expect(billingCapabilities.canTopUp.value).toBe(false)
     expect(billingCapabilities.canSubscribeSelfServe.value).toBe(false)
+    expect(billingCapabilities.canOpenPricingSurface.value).toBe(true)
     expect(billingCapabilities.canCancel.value).toBe(false)
     expect(billingCapabilities.canReactivate.value).toBe(false)
     expect(billingCapabilities.canChangeSeats.value).toBe(false)
     expect(billingCapabilities.canInviteMembers.value).toBe(false)
     expect(billingCapabilities.canDowngradeToPersonal.value).toBe(false)
-    expect(billingCapabilities.snapshotAuthoritative.value).toBe(false)
 
     const initialization = billingCapabilities.initialize()
     expect(billingCapabilities.canTopUp.value).toBe(false)
@@ -213,12 +223,12 @@ describe('useBillingCapabilities', () => {
     await initialization
     expect(billingCapabilities.canTopUp.value).toBe(true)
     expect(billingCapabilities.canSubscribeSelfServe.value).toBe(true)
+    expect(billingCapabilities.canOpenPricingSurface.value).toBe(true)
     expect(billingCapabilities.canCancel.value).toBe(true)
     expect(billingCapabilities.canReactivate.value).toBe(true)
     expect(billingCapabilities.canChangeSeats.value).toBe(true)
     expect(billingCapabilities.canInviteMembers.value).toBe(true)
     expect(billingCapabilities.canDowngradeToPersonal.value).toBe(true)
-    expect(billingCapabilities.snapshotAuthoritative.value).toBe(true)
   })
 
   it('applies denied server capabilities without client-side inference', async () => {
@@ -259,6 +269,19 @@ describe('useBillingCapabilities', () => {
     await billingCapabilities.refresh()
     expect(billingCapabilities.canTopUp.value).toBe(true)
     expect(billingCapabilities.canSubscribeSelfServe.value).toBe(false)
+    expect(billingCapabilities.canOpenPricingSurface.value).toBe(false)
+  })
+
+  it('uses workspace ownership for pricing on the legacy billing rail', () => {
+    mockShouldUseWorkspaceBilling.value = false
+
+    expect(billingCapabilities.canOpenPricingSurface.value).toBe(true)
+  })
+
+  it('uses workspace ownership for pricing off Cloud', () => {
+    mockIsCloud.value = false
+
+    expect(billingCapabilities.canOpenPricingSurface.value).toBe(true)
   })
 
   it('forwards the initialization signal to the capability request', async () => {
@@ -279,13 +302,13 @@ describe('useBillingCapabilities', () => {
 
     expect(billingCapabilities.canTopUp.value).toBe(true)
     expect(billingCapabilities.canSubscribeSelfServe.value).toBe(false)
+    expect(billingCapabilities.canOpenPricingSurface.value).toBe(true)
     expect(billingCapabilities.canCancel.value).toBe(false)
     expect(billingCapabilities.canReactivate.value).toBe(false)
     expect(billingCapabilities.canChangeSeats.value).toBe(false)
     expect(billingCapabilities.canInviteMembers.value).toBe(false)
     expect(billingCapabilities.canDowngradeToPersonal.value).toBe(false)
     expect(billingCapabilities.isReady.value).toBe(true)
-    expect(billingCapabilities.snapshotAuthoritative.value).toBe(false)
     expect(mockReportError).toHaveBeenCalledOnce()
   })
 
@@ -297,8 +320,8 @@ describe('useBillingCapabilities', () => {
 
     expect(billingCapabilities.canTopUp.value).toBe(false)
     expect(billingCapabilities.canSubscribeSelfServe.value).toBe(false)
+    expect(billingCapabilities.canOpenPricingSurface.value).toBe(false)
     expect(billingCapabilities.isReady.value).toBe(true)
-    expect(billingCapabilities.snapshotAuthoritative.value).toBe(false)
   })
 
   it('fails closed when the endpoint denies the current actor', async () => {
@@ -312,8 +335,8 @@ describe('useBillingCapabilities', () => {
 
     expect(billingCapabilities.canTopUp.value).toBe(false)
     expect(billingCapabilities.canSubscribeSelfServe.value).toBe(false)
+    expect(billingCapabilities.canOpenPricingSurface.value).toBe(false)
     expect(billingCapabilities.isReady.value).toBe(true)
-    expect(billingCapabilities.snapshotAuthoritative.value).toBe(true)
   })
 
   it('does not fail open when capability loading is aborted', async () => {
@@ -333,7 +356,6 @@ describe('useBillingCapabilities', () => {
 
     expect(billingCapabilities.canTopUp.value).toBe(false)
     expect(billingCapabilities.isReady.value).toBe(false)
-    expect(billingCapabilities.snapshotAuthoritative.value).toBe(false)
     expect(mockReportError).not.toHaveBeenCalled()
   })
 

--- a/src/platform/workspace/composables/useBillingCapabilities.ts
+++ b/src/platform/workspace/composables/useBillingCapabilities.ts
@@ -6,6 +6,7 @@ import {
 } from '@vueuse/core'
 import { computed, onScopeDispose, shallowRef, watch } from 'vue'
 
+import { useBillingRouting } from '@/composables/billing/useBillingRouting'
 import { isCloud } from '@/platform/distribution/types'
 import { reportError } from '@/platform/telemetry/reportError'
 import { onCapabilityRevision } from '@/platform/workspace/api/capabilityRevision'
@@ -60,6 +61,7 @@ interface ActiveCapabilityRequest {
 function useBillingCapabilitiesInternal() {
   const authStore = useAuthStore()
   const workspaceStore = useTeamWorkspaceStore()
+  const { shouldUseWorkspaceBilling } = useBillingRouting()
   const readState = shallowRef<CapabilityReadState>({ status: 'idle' })
   let initialized = false
   let latestRequestId = 0
@@ -93,6 +95,9 @@ function useBillingCapabilitiesInternal() {
       state.workspaceId === workspaceStore.activeWorkspaceId
     )
   })
+  const isWorkspaceOwner = computed(
+    () => workspaceStore.activeWorkspace?.role === 'owner'
+  )
   const canTopUp = computed(() => {
     if (!isCloud) return workspaceStore.activeWorkspace?.role !== 'member'
     // An unreadable capability keeps top-up available only for owners, so a
@@ -100,8 +105,7 @@ function useBillingCapabilitiesInternal() {
     // Every other role - including an unresolved one - fails closed.
     return (
       capabilities.value?.can_top_up ??
-      (readUnavailableForCurrentScope.value &&
-        workspaceStore.activeWorkspace?.role === 'owner')
+      (readUnavailableForCurrentScope.value && isWorkspaceOwner.value)
     )
   })
   const canSubscribeSelfServe = computed(
@@ -140,6 +144,21 @@ function useBillingCapabilitiesInternal() {
       state.authUid === authStore.currentUser?.uid &&
       state.workspaceId === workspaceStore.activeWorkspaceId
     )
+  })
+  // Every pricing-table entry point - menu items, settings links, and the
+  // ?pricing= deep link - reads this one value. legacy_stripe has no capability
+  // projection row, so that rail stays on the ownership check.
+  //
+  // Opening the catalog is navigation, not a billing write, and every checkout
+  // endpoint enforces its own policy - so a snapshot that cannot answer falls
+  // back to ownership rather than stranding a self-serve owner with no route to
+  // a plan. This mirrors canTopUp.
+  const canOpenPricingSurface = computed(() => {
+    if (!isCloud || !shouldUseWorkspaceBilling.value)
+      return isWorkspaceOwner.value
+    return snapshotAuthoritative.value
+      ? canSubscribeSelfServe.value
+      : isWorkspaceOwner.value
   })
 
   function clearRefreshTimer(): void {
@@ -420,13 +439,13 @@ function useBillingCapabilitiesInternal() {
   return {
     canTopUp,
     canSubscribeSelfServe,
+    canOpenPricingSurface,
     canCancel,
     canReactivate,
     canChangeSeats,
     canInviteMembers,
     canDowngradeToPersonal,
     isReady,
-    snapshotAuthoritative,
     initialize,
     refresh
   }

--- a/src/platform/workspace/composables/useWorkspaceUI.test.ts
+++ b/src/platform/workspace/composables/useWorkspaceUI.test.ts
@@ -12,11 +12,12 @@ const mockStore = vi.hoisted(() => ({
 const mockIsCloud = ref(true)
 const mockShouldUseWorkspaceBilling = ref(true)
 const mockCanReactivate = ref(false)
-const mockCanSubscribeSelfServe = ref(true)
-const mockSnapshotAuthoritative = ref(true)
 const mockIsActiveSubscription = vi.hoisted(() => ({ value: false }))
+const mockCanAccessSubscriptionFeatures = vi.hoisted(() => ({ value: false }))
 const mockIsCancelled = vi.hoisted(() => ({ value: false }))
 const mockIsTeamPlan = vi.hoisted(() => ({ value: false }))
+const mockBillingStatus = vi.hoisted(() => ({ value: 'inactive' }))
+const mockSubscriptionStatus = vi.hoisted(() => ({ value: 'ended' }))
 const mockBillingControlEnabled = vi.hoisted(() => ({ value: false }))
 
 vi.mock('@/platform/workspace/stores/teamWorkspaceStore', () => ({
@@ -56,17 +57,18 @@ vi.mock('@/composables/billing/useBillingRouting', () => ({
 
 vi.mock('@/platform/workspace/composables/useBillingCapabilities', () => ({
   useBillingCapabilities: () => ({
-    canReactivate: computed(() => mockCanReactivate.value),
-    canSubscribeSelfServe: computed(() => mockCanSubscribeSelfServe.value),
-    snapshotAuthoritative: computed(() => mockSnapshotAuthoritative.value)
+    canReactivate: computed(() => mockCanReactivate.value)
   })
 }))
 
 vi.mock('@/composables/billing/useBillingContext', () => ({
   useBillingContext: () => ({
+    billingStatus: ref(mockBillingStatus.value),
+    canAccessSubscriptionFeatures: ref(mockCanAccessSubscriptionFeatures.value),
     isActiveSubscription: ref(mockIsActiveSubscription.value),
     isTeamPlan: ref(mockIsTeamPlan.value),
-    subscription: ref({ isCancelled: mockIsCancelled.value })
+    subscription: ref({ isCancelled: mockIsCancelled.value }),
+    subscriptionStatus: ref(mockSubscriptionStatus.value)
   })
 }))
 
@@ -124,14 +126,15 @@ function resetStore() {
   mockStore.originalOwnerId = null
   mockStore.ensureMembersLoaded.mockReset()
   mockIsActiveSubscription.value = false
+  mockCanAccessSubscriptionFeatures.value = false
   mockIsCancelled.value = false
   mockIsTeamPlan.value = false
+  mockBillingStatus.value = 'inactive'
+  mockSubscriptionStatus.value = 'ended'
   mockBillingControlEnabled.value = false
   mockIsCloud.value = true
   mockShouldUseWorkspaceBilling.value = true
   mockCanReactivate.value = false
-  mockCanSubscribeSelfServe.value = true
-  mockSnapshotAuthoritative.value = true
 }
 
 describe('useWorkspaceUI', () => {
@@ -519,61 +522,31 @@ describe('useWorkspaceUI', () => {
     })
   })
 
-  describe('canOpenPricingSurface', () => {
-    beforeEach(() => {
-      mockStore.activeWorkspace = personalWorkspace
-    })
-
-    it('closes the catalog when the server resolves a sales-managed plan', async () => {
-      mockShouldUseWorkspaceBilling.value = true
-      mockCanSubscribeSelfServe.value = false
+  describe('inactive Team subscription', () => {
+    it('shows the inactive state to its owner after the subscription ends', async () => {
+      mockStore.activeWorkspace = teamOwnerWorkspace
+      mockIsTeamPlan.value = true
 
       const ui = await loadComposable()
-      expect(ui.canOpenPricingSurface.value).toBe(false)
+      expect(ui.showInactiveTeamSubscription.value).toBe(true)
     })
 
-    it('opens the catalog when the server allows self-serve subscribing', async () => {
-      mockShouldUseWorkspaceBilling.value = true
-      mockCanSubscribeSelfServe.value = true
-
-      const ui = await loadComposable()
-      expect(ui.canOpenPricingSurface.value).toBe(true)
-    })
-
-    it('falls back to membership on the legacy rail, where no capability row exists', async () => {
-      mockShouldUseWorkspaceBilling.value = false
-      mockCanSubscribeSelfServe.value = false
-
-      const ui = await loadComposable()
-      expect(ui.permissions.value.canManageSubscription).toBe(true)
-      expect(ui.canOpenPricingSurface.value).toBe(true)
-    })
-
-    it('falls back to membership off Cloud, where the endpoint is never called', async () => {
-      mockIsCloud.value = false
-      mockShouldUseWorkspaceBilling.value = true
-      mockCanSubscribeSelfServe.value = false
-
-      const ui = await loadComposable()
-      expect(ui.canOpenPricingSurface.value).toBe(true)
-    })
-
-    it('falls back to membership when the snapshot is not authoritative', async () => {
-      mockSnapshotAuthoritative.value = false
-      mockCanSubscribeSelfServe.value = false
-
-      const ui = await loadComposable()
-      expect(ui.canOpenPricingSurface.value).toBe(true)
-    })
-
-    it('keeps the catalog closed for a non-owner with no readable snapshot', async () => {
+    it('hides the inactive state from Team members', async () => {
       mockStore.activeWorkspace = teamMemberWorkspace
-      mockSnapshotAuthoritative.value = false
-      mockCanSubscribeSelfServe.value = false
+      mockIsTeamPlan.value = true
 
       const ui = await loadComposable()
-      expect(ui.permissions.value.canManageSubscription).toBe(false)
-      expect(ui.canOpenPricingSurface.value).toBe(false)
+      expect(ui.showInactiveTeamSubscription.value).toBe(false)
+    })
+
+    it('does not treat an active Team subscription as inactive', async () => {
+      mockStore.activeWorkspace = teamOwnerWorkspace
+      mockIsTeamPlan.value = true
+      mockCanAccessSubscriptionFeatures.value = true
+      mockSubscriptionStatus.value = 'active'
+
+      const ui = await loadComposable()
+      expect(ui.showInactiveTeamSubscription.value).toBe(false)
     })
   })
 })

--- a/src/platform/workspace/composables/useWorkspaceUI.test.ts
+++ b/src/platform/workspace/composables/useWorkspaceUI.test.ts
@@ -549,4 +549,43 @@ describe('useWorkspaceUI', () => {
       expect(ui.showInactiveTeamSubscription.value).toBe(false)
     })
   })
+
+  describe('isSubscriptionEnded', () => {
+    beforeEach(() => {
+      mockSubscriptionStatus.value = 'canceled'
+    })
+
+    it('ends a cancelled plan once its paid period stops granting access', async () => {
+      mockStore.activeWorkspace = teamOwnerWorkspace
+      mockIsCancelled.value = true
+
+      const ui = await loadComposable()
+      expect(ui.isSubscriptionEnded.value).toBe(true)
+    })
+
+    it('keeps a cancelled plan live while it still grants access', async () => {
+      mockStore.activeWorkspace = teamOwnerWorkspace
+      mockIsCancelled.value = true
+      mockCanAccessSubscriptionFeatures.value = true
+
+      const ui = await loadComposable()
+      expect(ui.isSubscriptionEnded.value).toBe(false)
+    })
+
+    it('ends an uncancelled personal plan once billing goes inactive', async () => {
+      mockStore.activeWorkspace = personalWorkspace
+      mockBillingStatus.value = 'inactive'
+
+      const ui = await loadComposable()
+      expect(ui.isSubscriptionEnded.value).toBe(true)
+    })
+
+    it('leaves an uncancelled Team plan live when personal billing is the only inactive signal', async () => {
+      mockStore.activeWorkspace = teamOwnerWorkspace
+      mockBillingStatus.value = 'inactive'
+
+      const ui = await loadComposable()
+      expect(ui.isSubscriptionEnded.value).toBe(false)
+    })
+  })
 })

--- a/src/platform/workspace/composables/useWorkspaceUI.ts
+++ b/src/platform/workspace/composables/useWorkspaceUI.ts
@@ -144,7 +144,14 @@ function getUIConfig(
  */
 function useWorkspaceUIInternal() {
   const store = useTeamWorkspaceStore()
-  const { isActiveSubscription, isTeamPlan, subscription } = useBillingContext()
+  const {
+    billingStatus,
+    canAccessSubscriptionFeatures,
+    isActiveSubscription,
+    isTeamPlan,
+    subscription,
+    subscriptionStatus
+  } = useBillingContext()
   const { flags } = useFeatureFlags()
 
   const isInPersonalWorkspace = computed(() => store.isInPersonalWorkspace)
@@ -169,8 +176,7 @@ function useWorkspaceUIInternal() {
   )
 
   const { shouldUseWorkspaceBilling } = useBillingRouting()
-  const { canReactivate, canSubscribeSelfServe, snapshotAuthoritative } =
-    useBillingCapabilities()
+  const { canReactivate } = useBillingCapabilities()
 
   const permissions = computed<WorkspacePermissions>(() =>
     getPermissions(
@@ -197,25 +203,6 @@ function useWorkspaceUIInternal() {
       : permissions.value.canManageSubscriptionLifecycle
   )
 
-  // Whether the self-serve pricing catalog applies to this workspace at all.
-  // The server resolves can_subscribe_self_serve false for sales-managed tiers
-  // (Enterprise, unrecognized), so every pricing-table entry point — menu
-  // items, settings links, and the ?pricing= deep link — reads this one value.
-  // Same rail split as canReactivatePlan: legacy_stripe has no capability
-  // projection row and stays on the membership check.
-  //
-  // Opening the catalog is navigation, not a billing write — every checkout
-  // endpoint enforces its own policy — so an absent snapshot falls back to
-  // membership rather than stranding a self-serve owner with no route to a
-  // plan. This mirrors canTopUp, which already fails open for owners.
-  const canOpenPricingSurface = computed(() => {
-    if (!isCloud || !shouldUseWorkspaceBilling.value)
-      return permissions.value.canManageSubscription
-    return snapshotAuthoritative.value
-      ? canSubscribeSelfServe.value
-      : permissions.value.canManageSubscription
-  })
-
   const uiConfig = computed<WorkspaceUIConfig>(() => {
     const base = getUIConfig(workspaceType.value, workspaceRole.value)
     const showCreditsColumn =
@@ -236,6 +223,21 @@ function useWorkspaceUIInternal() {
 
   const isSubscriptionCancelled = computed(
     () => subscription.value?.isCancelled ?? false
+  )
+  const isSubscriptionEnded = computed(() => {
+    if (subscriptionStatus.value === 'ended') return true
+    if (canAccessSubscriptionFeatures.value) return false
+    return (
+      isSubscriptionCancelled.value ||
+      (isInPersonalWorkspace.value && billingStatus.value === 'inactive')
+    )
+  })
+  const showInactiveTeamSubscription = computed(
+    () =>
+      permissions.value.canManageSubscription &&
+      !isInPersonalWorkspace.value &&
+      isSubscriptionEnded.value &&
+      isTeamPlan.value
   )
 
   const isTeamPlanCancelled = computed(
@@ -258,7 +260,6 @@ function useWorkspaceUIInternal() {
     // Permissions and config
     permissions,
     canReactivatePlan,
-    canOpenPricingSurface,
     uiConfig,
     workspaceType,
     workspaceRole,
@@ -267,6 +268,8 @@ function useWorkspaceUIInternal() {
     isActiveSubscription,
     isOriginalOwner,
     isSubscriptionCancelled,
+    isSubscriptionEnded,
+    showInactiveTeamSubscription,
     isTeamPlanCancelled,
     isDeleteDisabled,
     deleteDisabledTooltipKey


### PR DESCRIPTION
Follow-up to #16100, which merged before two review comments from @christian-byrne were addressed. Both ask the same thing: derived billing state was being computed at the call site instead of in the module that owns it.

- Fixes FE-1662 follow-up

## Root cause

**1. `canOpenPricingSurface` lived in `useWorkspaceUI`, one layer above its inputs.**

To answer "may this user open the pricing catalog?", `useWorkspaceUI` had to reach into `useBillingCapabilities` for two separate values and recombine them:

```ts
const { canReactivate, canSubscribeSelfServe, snapshotAuthoritative } =
  useBillingCapabilities()

const canOpenPricingSurface = computed(() => {
  if (!isCloud || !shouldUseWorkspaceBilling.value)
    return permissions.value.canManageSubscription
  return snapshotAuthoritative.value
    ? canSubscribeSelfServe.value
    : permissions.value.canManageSubscription
})
```

`snapshotAuthoritative` is an implementation detail of how a capability read is interpreted — it exists to say "the snapshot can answer for the current scope". Exporting it forced every consumer wanting a fail-open capability to re-derive the same `authoritative ? capability : ownership` shape by hand. That is the "re-deriving new states here, which might need to be derived again elsewhere" the review flagged, and the invalid-state risk is concrete: a future caller that reads `canSubscribeSelfServe` without pairing it with `snapshotAuthoritative` silently gets fail-closed behaviour during an outage, which is the exact defect #16100 set out to fix.

**2. `isSubscriptionEnded` and `showInactiveTeamSubscription` lived in the component.**

`SubscriptionPanelContentWorkspace.vue` pulled `billingStatus` and `subscriptionStatus` off `useBillingContext` for the sole purpose of deriving lifecycle state that `useWorkspaceUI` already owns — it sits directly beside `isSubscriptionCancelled` and `isTeamPlanCancelled`, which are the same kind of value and are already centralized. `showInactiveTeamSubscription` then combined that with `permissions.canManageSubscription`, `isInPersonalWorkspace`, and `isTeamPlan`, all of which the composable also exposes. The component was the only reason two billing-context fields were in its scope at all.

## How

**1. `canOpenPricingSurface` moves into `useBillingCapabilities`** and `snapshotAuthoritative` leaves the public surface. The rail check moves with it, so the composable — not each caller — decides when the capability applies:

```ts
const canOpenPricingSurface = computed(() => {
  if (!isCloud || !shouldUseWorkspaceBilling.value) return isWorkspaceOwner.value
  return snapshotAuthoritative.value
    ? canSubscribeSelfServe.value
    : isWorkspaceOwner.value
})
```

The three call sites (`CurrentUserPopoverWorkspace.vue`, `SubscriptionPanelContentWorkspace.vue`, `usePricingTableUrlLoader.ts`) now read it from the capability module. `useWorkspaceUI` no longer imports `canSubscribeSelfServe` or `snapshotAuthoritative`.

The ownership fallback is `activeWorkspace?.role === 'owner'`, extracted as `isWorkspaceOwner` and shared with `canTopUp`. This is behaviour-preserving: the previous fallback was `permissions.canManageSubscription`, defined as `hasActiveWorkspace && role === 'owner'`, and `activeWorkspace?.role === 'owner'` is already false when there is no active workspace. Using it directly is also what removes the `useWorkspaceUI` → capability-module round trip.

**2. `isSubscriptionEnded` and `showInactiveTeamSubscription` move into `useWorkspaceUI`**, next to `isSubscriptionCancelled`. `SubscriptionPanelContentWorkspace.vue` drops `billingStatus` and `subscriptionStatus` from its `useBillingContext` destructure and consumes the two computeds.

No behaviour change is intended in either move. The fail-open policy, the rail split, and the rendering conditions are the ones #16100 shipped and reviewed.

## Trade-off worth a reviewer's attention

`useBillingCapabilities` now imports `useBillingRouting` to read `shouldUseWorkspaceBilling`. That is a new edge, and it is the price of the capability module answering rail-aware questions instead of exporting a raw discriminant for callers to combine. It does not cycle — `useBillingRouting` depends only on `useFeatureFlags`, `distribution/types`, and `teamWorkspaceStore`, none of which reach back into capabilities.

The alternative, keeping the rail check at each call site, is what produced the duplication in the first place. Push back if you'd rather the rail split stay with the consumer.

## Tests

- Unit: **95 files, 1774 tests, 0 failures** across `src/platform/workspace`, `src/platform/cloud/subscription`, `src/composables/billing`.
- `pnpm typecheck`, `pnpm lint`, `pnpm format:check`, `pnpm knip` all clean.
- `canOpenPricingSurface` coverage moved to `useBillingCapabilities.test.ts` with every case from #16100 preserved and the rail cases added: pending snapshot (owner fallback), resolved-allow, resolved-deny, `unavailable` + owner, `unavailable` + member (closed), `denied` (closed), legacy rail, and off-Cloud.
- `useWorkspaceUI.test.ts` gains direct coverage for `showInactiveTeamSubscription`: shown to a Team owner after the subscription ends, hidden from Team members, and not triggered while the subscription is active.

## AS IS / TO BE

Pure refactor with no user-visible change — the rendering this touches is the surface #16100 already shipped screenshots for. Skipping AS IS / TO BE captures here; say the word if you'd like them anyway.
