### PR TITLE
test(crdt): fixture harness for follower adapter QA

### DIFF
--- a/src/workbench/extensions/agent/crdt/__fixtures__/add-node.json
+++ b/src/workbench/extensions/agent/crdt/__fixtures__/add-node.json
@@ -1,0 +1,37 @@
+{
+  "scenario": "add-node",
+  "frames": [
+    {
+      "type": "draft_patch",
+      "data": {
+        "base_version": 10,
+        "version": 11,
+        "workflow_id": "fixture-workflow-native-folders",
+        "message_id": "fixture-message-add-node",
+        "thread_id": "fixture-thread",
+        "content": {
+          "last_node_id": 1,
+          "links": [],
+          "nodes": [
+            {
+              "id": 1,
+              "type": "LoadImage",
+              "pos": [100, 100],
+              "size": [315, 314],
+              "flags": {},
+              "order": 0,
+              "mode": 0,
+              "inputs": [],
+              "outputs": [
+                { "name": "IMAGE", "type": "IMAGE", "links": [] },
+                { "name": "MASK", "type": "MASK", "links": [] }
+              ],
+              "properties": {},
+              "widgets_values": ["reference.png", "image"]
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/src/workbench/extensions/agent/crdt/agentFixtureHarness.test.ts
+++ b/src/workbench/extensions/agent/crdt/agentFixtureHarness.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import addNodeFixture from './__fixtures__/add-node.json'
+import type {
+  AgentFixtureAdapter,
+  AgentResponseFixture,
+  FixtureNode,
+  RemoteMutationContext
+} from './agentFixtureHarness'
+import { replayAgentFixture } from './agentFixtureHarness'
+
+class TestGraphAdapter implements AgentFixtureAdapter {
+  readonly nodes = new Map<FixtureNode['id'], FixtureNode>()
+  readonly emitLocalOp = vi.fn()
+  private activeContext: RemoteMutationContext | undefined
+
+  readonly graphMutations = {
+    batch: (context: RemoteMutationContext, apply: () => void): void => {
+      this.activeContext = context
+      try {
+        apply()
+      } finally {
+        this.activeContext = undefined
+      }
+    }
+  }
+
+  applyDraftPatch(
+    workflow: { readonly nodes: readonly FixtureNode[] },
+    context: RemoteMutationContext
+  ): void {
+    expect(context).toBe(this.activeContext)
+    for (const node of workflow.nodes) {
+      this.nodes.set(node.id, node)
+      if (context.source !== 'agent-remote') this.emitLocalOp(node)
+    }
+  }
+}
+
+describe('replayAgentFixture', () => {
+  it('applies an add-node response with call-carried echo suppression', () => {
+    const adapter = new TestGraphAdapter()
+
+    replayAgentFixture(
+      addNodeFixture as AgentResponseFixture,
+      adapter,
+      'fixture-actor'
+    )
+
+    expect(adapter.nodes.get(1)).toMatchObject({
+      type: 'LoadImage',
+      widgets_values: ['reference.png', 'image']
+    })
+    expect(adapter.emitLocalOp).not.toHaveBeenCalled()
+  })
+})

--- a/src/workbench/extensions/agent/crdt/agentFixtureHarness.test.ts
+++ b/src/workbench/extensions/agent/crdt/agentFixtureHarness.test.ts
@@ -5,6 +5,7 @@ import type {
   AgentFixtureAdapter,
   AgentResponseFixture,
   FixtureNode,
+  FixtureWorkflow,
   RemoteMutationContext
 } from './agentFixtureHarness'
 import { replayAgentFixture } from './agentFixtureHarness'
@@ -26,7 +27,7 @@ class TestGraphAdapter implements AgentFixtureAdapter {
   }
 
   applyDraftPatch(
-    workflow: { readonly nodes: readonly FixtureNode[] },
+    workflow: FixtureWorkflow,
     context: RemoteMutationContext
   ): void {
     expect(context).toBe(this.activeContext)

--- a/src/workbench/extensions/agent/crdt/agentFixtureHarness.test.ts
+++ b/src/workbench/extensions/agent/crdt/agentFixtureHarness.test.ts
@@ -3,12 +3,14 @@ import { describe, expect, it, vi } from 'vitest'
 import addNodeFixture from './__fixtures__/add-node.json'
 import type {
   AgentFixtureAdapter,
-  AgentResponseFixture,
   FixtureNode,
   FixtureWorkflow,
   RemoteMutationContext
 } from './agentFixtureHarness'
-import { replayAgentFixture } from './agentFixtureHarness'
+import {
+  parseAgentResponseFixture,
+  replayAgentFixture
+} from './agentFixtureHarness'
 
 class TestGraphAdapter implements AgentFixtureAdapter {
   readonly nodes = new Map<FixtureNode['id'], FixtureNode>()
@@ -43,7 +45,7 @@ describe('replayAgentFixture', () => {
     const adapter = new TestGraphAdapter()
 
     replayAgentFixture(
-      addNodeFixture as AgentResponseFixture,
+      parseAgentResponseFixture(addNodeFixture),
       adapter,
       'fixture-actor'
     )
@@ -53,5 +55,20 @@ describe('replayAgentFixture', () => {
       widgets_values: ['reference.png', 'image']
     })
     expect(adapter.emitLocalOp).not.toHaveBeenCalled()
+  })
+
+  it('rejects an empty frame list', () => {
+    expect(() =>
+      parseAgentResponseFixture({ scenario: 'empty', frames: [] })
+    ).toThrow('frames must be non-empty')
+  })
+
+  it('rejects a frame with missing data', () => {
+    expect(() =>
+      parseAgentResponseFixture({
+        scenario: 'malformed',
+        frames: [{ type: 'draft_patch' }]
+      })
+    ).toThrow('malformed draft_patch frame')
   })
 })

--- a/src/workbench/extensions/agent/crdt/agentFixtureHarness.test.ts
+++ b/src/workbench/extensions/agent/crdt/agentFixtureHarness.test.ts
@@ -71,4 +71,22 @@ describe('replayAgentFixture', () => {
       })
     ).toThrow('malformed draft_patch frame')
   })
+
+  it('rejects a frame with an unknown type', () => {
+    expect(() =>
+      parseAgentResponseFixture({
+        scenario: 'malformed',
+        frames: [
+          {
+            type: 'unknown_frame_type',
+            data: {
+              message_id: 'msg-1',
+              thread_id: 'thread-1',
+              content: { nodes: [] }
+            }
+          }
+        ]
+      })
+    ).toThrow('malformed draft_patch frame')
+  })
 })

--- a/src/workbench/extensions/agent/crdt/agentFixtureHarness.ts
+++ b/src/workbench/extensions/agent/crdt/agentFixtureHarness.ts
@@ -1,0 +1,57 @@
+export interface FixtureNode {
+  readonly id: number | string
+  readonly type: string
+  readonly widgets_values: readonly unknown[]
+}
+
+interface FixtureWorkflow {
+  readonly nodes: readonly FixtureNode[]
+}
+
+interface DraftPatchFrame {
+  readonly type: 'draft_patch'
+  readonly data: {
+    readonly message_id: string
+    readonly thread_id: string
+    readonly content: FixtureWorkflow
+  }
+}
+
+export interface AgentResponseFixture {
+  readonly scenario: string
+  readonly frames: readonly DraftPatchFrame[]
+}
+
+export interface RemoteMutationContext {
+  readonly source: 'agent-remote'
+  readonly actor: string
+  readonly op_id: string
+}
+
+export interface AgentFixtureAdapter {
+  readonly graphMutations: {
+    batch(context: RemoteMutationContext, apply: () => void): void
+  }
+  applyDraftPatch(
+    workflow: FixtureWorkflow,
+    context: RemoteMutationContext
+  ): void
+}
+
+export function replayAgentFixture(
+  fixture: AgentResponseFixture,
+  adapter: AgentFixtureAdapter,
+  actor = 'fixture-agent'
+): void {
+  for (const frame of fixture.frames) {
+    const context: RemoteMutationContext = {
+      source: 'agent-remote',
+      actor,
+      op_id: frame.data.message_id
+    }
+
+    adapter.graphMutations.batch(context, () => {
+      adapter.applyDraftPatch(frame.data.content, context)
+    })
+  }
+}

--- a/src/workbench/extensions/agent/crdt/agentFixtureHarness.ts
+++ b/src/workbench/extensions/agent/crdt/agentFixtureHarness.ts
@@ -4,7 +4,7 @@ export interface FixtureNode {
   readonly widgets_values: readonly unknown[]
 }
 
-interface FixtureWorkflow {
+export interface FixtureWorkflow {
   readonly nodes: readonly FixtureNode[]
 }
 

--- a/src/workbench/extensions/agent/crdt/agentFixtureHarness.ts
+++ b/src/workbench/extensions/agent/crdt/agentFixtureHarness.ts
@@ -22,6 +22,62 @@ export interface AgentResponseFixture {
   readonly frames: readonly DraftPatchFrame[]
 }
 
+export function parseAgentResponseFixture(
+  value: unknown
+): AgentResponseFixture {
+  if (!isRecord(value) || typeof value.scenario !== 'string') {
+    throw new Error('Invalid agent response fixture: scenario must be a string')
+  }
+  if (!Array.isArray(value.frames) || value.frames.length === 0) {
+    throw new Error('Invalid agent response fixture: frames must be non-empty')
+  }
+  if (!value.frames.every(isDraftPatchFrame)) {
+    throw new Error(
+      'Invalid agent response fixture: malformed draft_patch frame'
+    )
+  }
+
+  return { scenario: value.scenario, frames: value.frames }
+}
+
+function isDraftPatchFrame(value: unknown): value is DraftPatchFrame {
+  if (
+    !isRecord(value) ||
+    value.type !== 'draft_patch' ||
+    !isRecord(value.data)
+  ) {
+    return false
+  }
+
+  const { data } = value
+  return (
+    typeof data.message_id === 'string' &&
+    typeof data.thread_id === 'string' &&
+    isFixtureWorkflow(data.content)
+  )
+}
+
+function isFixtureWorkflow(value: unknown): value is FixtureWorkflow {
+  return (
+    isRecord(value) &&
+    Array.isArray(value.nodes) &&
+    value.nodes.every(isFixtureNode)
+  )
+}
+
+function isFixtureNode(value: unknown): value is FixtureNode {
+  return (
+    isRecord(value) &&
+    (typeof value.id === 'number' || typeof value.id === 'string') &&
+    typeof value.type === 'string' &&
+    Array.isArray(value.widgets_values)
+  )
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}
+
 export interface RemoteMutationContext {
   readonly source: 'agent-remote'
   readonly actor: string


### PR DESCRIPTION
## Summary

Draft: CRDT fixture harness (mtg-14.2). Part of the CRDT integration train. Deterministic fixtures for follower-adapter QA; consumed by E2E and agent-browser test lanes. Based on nathaniel/agent-v1/crdt-impl.
