### PR TITLE
test: cover workflow tab overflow controls

### DIFF
--- a/browser_tests/tests/topbar/workflowTabs.spec.ts
+++ b/browser_tests/tests/topbar/workflowTabs.spec.ts
@@ -4,12 +4,10 @@ import type { Locator, Page } from '@playwright/test'
 import { comfyPageFixture as test } from '@e2e/fixtures/ComfyPage'
 
 test.describe('Workflow tabs', () => {
-  test.beforeEach(async ({ comfyPage }) => {
-    await comfyPage.settings.setSetting(
-      'Comfy.Workflow.WorkflowTabsPosition',
-      'Topbar'
-    )
-    await comfyPage.setup()
+  test.use({
+    initialSettings: {
+      'Comfy.Workflow.WorkflowTabsPosition': 'Topbar'
+    }
   })
 
   test('Default workflow tab is visible on load', async ({ comfyPage }) => {
@@ -191,6 +189,36 @@ test.describe('Workflow tabs', () => {
     await topbar.closeWorkflowTab('Unsaved Workflow (2)')
     await expect.poll(() => topbar.getTabNames()).toHaveLength(2)
   })
+
+  test(
+    'Scroll arrows navigate overflowing workflow tabs',
+    { tag: '@ui' },
+    async ({ comfyPage }) => {
+      await comfyPage.page.setViewportSize({ width: 800, height: 720 })
+      const topbar = comfyPage.menu.topbar
+
+      for (let index = 0; index < 8; index++) {
+        await topbar.newWorkflowButton.click()
+      }
+      await expect.poll(() => topbar.getTabNames()).toHaveLength(9)
+
+      const scrollLeft = topbar.workflowTabs.getByRole('button', {
+        name: 'Scroll Left'
+      })
+      const scrollRight = topbar.workflowTabs.getByRole('button', {
+        name: 'Scroll Right'
+      })
+      await expect(scrollLeft).toBeVisible()
+      await expect(scrollLeft).toBeEnabled()
+      await expect(scrollRight).toBeDisabled()
+
+      const activeTabName = await topbar.getActiveTabName()
+      await scrollLeft.dispatchEvent('mousedown')
+      await expect(scrollRight).toBeEnabled()
+      await scrollLeft.dispatchEvent('mouseup')
+      await expect.poll(() => topbar.getActiveTabName()).toBe(activeTabName)
+    }
+  )
 
   test.describe('Closing a modified workflow tab (FE-419)', () => {
     async function modifyActiveWorkflow(page: Page, activeTab: Locator) {


### PR DESCRIPTION
## Summary

Adds Playwright coverage for the workflow-tab overflow controls introduced in #16158.

## Changes

- **What**: Verifies overflow arrows, boundary disabled states, scrolling, and active-tab preservation.
- **Dependencies**: Stacked on #16158.

## Review Focus

Confirm the 800 px viewport reliably exercises horizontal overflow.

## Video

[![Workflow tab overflow Playwright recording](https://ampcode.com/user-content/artifacts/0a3c90c605df421f9a6095b1c7cc8c37382e5722b41d9ce6db2e69d31a4d7847-file.gif)](https://ampcode.com/user-content/artifacts/df954a8fcdd8de9076cbb098fbdb5556140dd73f8f192e1c5d9b578443750a67-file.mp4)