### PR TITLE
feat: autoplay FDCT hero video

### DIFF
--- a/apps/website/e2e/fdct.spec.ts
+++ b/apps/website/e2e/fdct.spec.ts
@@ -259,18 +259,21 @@ test.describe('FDCT page @smoke', () => {
 })
 
 test.describe('FDCT hero @mobile', () => {
-  test('shows the eyebrow and the click-to-play hero video', async ({
+  test('shows the uppercase eyebrow and autoplaying hero video', async ({
     page
   }) => {
     await page.goto('/forward-deployed-creatives')
-    await expect(page.getByText(t('fdct.hero.eyebrow', 'en'))).toBeVisible()
-    // The hero video rests on its poster and only plays on demand.
+    await expect(
+      page.getByText(t('fdct.hero.eyebrow', 'en').toLocaleUpperCase('en'))
+    ).toBeVisible()
     const video = page.getByLabel(t('fdct.hero.title', 'en'))
     await expect(video).toBeVisible()
     await expect(video).toHaveAttribute('poster', /FDCT_V4_thumb/)
-    await expect(video).not.toHaveAttribute('autoplay')
+    await expect(video).toHaveAttribute('autoplay')
+    await expect(video).toHaveAttribute('loop')
+    await expect(video).toHaveAttribute('muted')
     await expect(
-      page.getByRole('button', { name: t('player.play', 'en') })
+      page.getByRole('button', { name: t('player.unmute', 'en') })
     ).toBeVisible()
     const hero = page.locator('section', {
       has: page.getByRole('heading', { level: 1 })

--- a/apps/website/src/templates/fdct/HeroSection.vue
+++ b/apps/website/src/templates/fdct/HeroSection.vue
@@ -12,15 +12,15 @@ const { locale = 'en' } = defineProps<{ locale?: Locale }>()
 <template>
   <HeroSplit01
     :locale
-    :badge-text="t('fdct.hero.eyebrow', locale)"
+    :badge-text="t('fdct.hero.eyebrow', locale).toLocaleUpperCase(locale)"
     :title="t('fdct.hero.title', locale)"
     :subtitle="t('fdct.hero.subtitle', locale)"
     :primary-cta="{
       label: t('fdct.hero.contactCta', locale),
       href: localizeHref(fdctPage.ctas.contact, locale)
     }"
-    video-minimal
-    video-play-button-variant="overlay"
+    video-autoplay
+    video-loop
     :video-aria-label="t('fdct.hero.title', locale)"
     video-src="https://media.comfy.org/website/fdct/FDCT_V4.mp4"
     video-poster="https://media.comfy.org/website/fdct/FDCT_V4_thumb.jpeg"


### PR DESCRIPTION
## Summary

Updates the Forward Deployed Creatives hero to match the reviewed browser feedback.

## Changes

- **What**: Uppercases the creative-services eyebrow and makes the hero video autoplay muted on a loop with the full player controls.
- **Dependencies**: None.

## Review Focus

Confirm the hero video starts muted, loops continuously, and retains pause, volume, seek, and fullscreen controls.

## Testing

- `pnpm --dir apps/website typecheck`
- Focused FDCT mobile Playwright test
- `pnpm exec oxfmt --check apps/website/src/templates/fdct/HeroSection.vue apps/website/e2e/fdct.spec.ts`
- `git diff --check`
