### PR TITLE
feat(crdt): make the debug panel a first-class instrument

### DIFF
--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -4992,10 +4992,6 @@
     "running": "Running…"
   },
   "agent": {
-    "crdtStatus": "CRDT {connection} · {workflowId} · {updates} updates · {frame}",
-    "crdtConnected": "connected",
-    "crdtDisconnected": "disconnected",
-    "crdtNoDocument": "no document",
     "title": "Comfy Agent",
     "askComfyAgent": "Ask Comfy Agent",
     "caption": "The AI agent can make mistakes",

--- a/src/workbench/extensions/agent/AgentPanelRoot.vue
+++ b/src/workbench/extensions/agent/AgentPanelRoot.vue
@@ -5,6 +5,7 @@ import { useClipboard } from '@vueuse/core'
 import { storeToRefs } from 'pinia'
 import {
   computed,
+  defineAsyncComponent,
   nextTick,
   onBeforeUnmount,
   provide,
@@ -79,7 +80,6 @@ import type { OpenTabsSnapshot } from './services/agent/agentRestClient'
 import { createAgentEventSource } from './services/agent/agentEventSource'
 import { useAgentChatHistoryStore } from './stores/agent/agentChatHistoryStore'
 import { useAgentPanelStore } from './stores/agent/agentPanelStore'
-import CrdtDevPanel from './crdt/CrdtDevPanel.vue'
 import { isCrdtDebugEnabled } from './crdt/crdtDebugGate'
 import { useAgentCrdtFollower } from './crdt/useAgentCrdtFollower'
 
@@ -364,6 +364,11 @@ const { status: crdtStatus, debugSnapshot: crdtDebugSnapshot } =
 // ?crdtDebug=1 opt-in, because the people who need it are testers on a
 // staging build, where DEV is false.
 const isCrdtDevPanelEnabled = isCrdtDebugEnabled()
+// Async so the panel — and the CRDT applier it pulls in to simulate merges —
+// never reaches the bundle of the users who cannot open it.
+const CrdtDevPanel = defineAsyncComponent(
+  () => import('./crdt/CrdtDevPanel.vue')
+)
 
 // The resumed turn's own workflow outlives a panel remount (the session
 // binds it at ack; only newChat/loadThread reset it), while the active tab

--- a/src/workbench/extensions/agent/AgentPanelRoot.vue
+++ b/src/workbench/extensions/agent/AgentPanelRoot.vue
@@ -1,3 +1,14 @@
+<script lang="ts">
+import { defineAsyncComponent } from 'vue'
+
+// Async so the merge lab's copy of the CRDT applier never reaches the bundle
+// of the users who cannot open the panel. Module scope, so one wrapper is
+// shared rather than rebuilt per instance.
+const CrdtDevPanel = defineAsyncComponent(
+  () => import('./crdt/CrdtDevPanel.vue')
+)
+</script>
+
 <script setup lang="ts">
 import './agentPanel.css'
 
@@ -5,7 +16,6 @@ import { useClipboard } from '@vueuse/core'
 import { storeToRefs } from 'pinia'
 import {
   computed,
-  defineAsyncComponent,
   nextTick,
   onBeforeUnmount,
   provide,
@@ -364,11 +374,6 @@ const { status: crdtStatus, debugSnapshot: crdtDebugSnapshot } =
 // ?crdtDebug=1 opt-in, because the people who need it are testers on a
 // staging build, where DEV is false.
 const isCrdtDevPanelEnabled = isCrdtDebugEnabled()
-// Async so the panel — and the CRDT applier it pulls in to simulate merges —
-// never reaches the bundle of the users who cannot open it.
-const CrdtDevPanel = defineAsyncComponent(
-  () => import('./crdt/CrdtDevPanel.vue')
-)
 
 // The resumed turn's own workflow outlives a panel remount (the session
 // binds it at ack; only newChat/loadThread reset it), while the active tab

--- a/src/workbench/extensions/agent/AgentPanelRoot.vue
+++ b/src/workbench/extensions/agent/AgentPanelRoot.vue
@@ -370,9 +370,9 @@ const {
 // session's bound workflow and projects doc updates onto the canvas.
 const { status: crdtStatus, debugSnapshot: crdtDebugSnapshot } =
   useAgentCrdtFollower(boundWorkflowId, graphMutations)
-// Dev instrument (slice-02 classification). Gated on DEV plus an explicit
+// Dev instrument (slice-02 classification). Gated on DEV *or* an explicit
 // ?crdtDebug=1 opt-in, because the people who need it are testers on a
-// staging build, where DEV is false.
+// staging build, where DEV is false. An explicit opt-out beats both.
 const isCrdtDevPanelEnabled = isCrdtDebugEnabled()
 
 // The resumed turn's own workflow outlives a panel remount (the session

--- a/src/workbench/extensions/agent/AgentPanelRoot.vue
+++ b/src/workbench/extensions/agent/AgentPanelRoot.vue
@@ -80,6 +80,7 @@ import { createAgentEventSource } from './services/agent/agentEventSource'
 import { useAgentChatHistoryStore } from './stores/agent/agentChatHistoryStore'
 import { useAgentPanelStore } from './stores/agent/agentPanelStore'
 import CrdtDevPanel from './crdt/CrdtDevPanel.vue'
+import { isCrdtDebugEnabled } from './crdt/crdtDebugGate'
 import { useAgentCrdtFollower } from './crdt/useAgentCrdtFollower'
 
 const { t } = useI18n()
@@ -357,12 +358,12 @@ const {
 
 // The CRDT follower is the inbound content channel: subscribes to the
 // session's bound workflow and projects doc updates onto the canvas.
-const { status: crdtStatus } = useAgentCrdtFollower(
-  boundWorkflowId,
-  graphMutations
-)
-// Dev instrument only (slice-02 classification): never ships to users.
-const isCrdtDevPanelEnabled = import.meta.env.DEV
+const { status: crdtStatus, debugSnapshot: crdtDebugSnapshot } =
+  useAgentCrdtFollower(boundWorkflowId, graphMutations)
+// Dev instrument (slice-02 classification). Gated on DEV plus an explicit
+// ?crdtDebug=1 opt-in, because the people who need it are testers on a
+// staging build, where DEV is false.
+const isCrdtDevPanelEnabled = isCrdtDebugEnabled()
 
 // The resumed turn's own workflow outlives a panel remount (the session
 // binds it at ack; only newChat/loadThread reset it), while the active tab
@@ -903,7 +904,7 @@ function onPanelDrop(event: DragEvent): void {
 <template>
   <div
     id="agent-panel-root"
-    class="size-full"
+    class="relative size-full"
     @dragenter="onPanelDragEnter"
     @dragleave="onPanelDragLeave"
     @dragover="onPanelDragOver"
@@ -918,23 +919,6 @@ function onPanelDrop(event: DragEvent): void {
       data-testid="agent-file-input"
       @change="onFilesPicked"
     />
-    <div
-      v-if="crdtStatus.enabled"
-      class="border-b border-border-default bg-base-background px-3 py-1 font-mono text-muted"
-      data-testid="agent-crdt-status"
-    >
-      {{
-        t('agent.crdtStatus', {
-          connection: crdtStatus.connected
-            ? t('agent.crdtConnected')
-            : t('agent.crdtDisconnected'),
-          workflowId: crdtStatus.workflowId ?? t('agent.crdtNoDocument'),
-          updates: crdtStatus.updatesApplied,
-          frame: crdtStatus.lastFrameType ?? '—'
-        })
-      }}
-    </div>
-    <CrdtDevPanel v-if="isCrdtDevPanelEnabled" :status="crdtStatus" />
     <AgentPanel
       ref="panelRef"
       :entries
@@ -978,6 +962,11 @@ function onPanelDrop(event: DragEvent): void {
     <OnboardingCoach
       :step="coachStep"
       storage-key="Comfy.AgentPanel.onboarded"
+    />
+    <CrdtDevPanel
+      v-if="isCrdtDevPanelEnabled"
+      :status="crdtStatus"
+      :snapshot="crdtDebugSnapshot"
     />
   </div>
 </template>

--- a/src/workbench/extensions/agent/AgentPanelRoot.vue
+++ b/src/workbench/extensions/agent/AgentPanelRoot.vue
@@ -963,15 +963,14 @@ function onPanelDrop(event: DragEvent): void {
       @rename-history="onRenameHistory"
       @rename-chat="onRenameChat"
       @copy-history="onCopyMarkdown"
-    />
+    >
+      <template v-if="isCrdtDevPanelEnabled" #instrument>
+        <CrdtDevPanel :status="crdtStatus" :snapshot="crdtDebugSnapshot" />
+      </template>
+    </AgentPanel>
     <OnboardingCoach
       :step="coachStep"
       storage-key="Comfy.AgentPanel.onboarded"
-    />
-    <CrdtDevPanel
-      v-if="isCrdtDevPanelEnabled"
-      :status="crdtStatus"
-      :snapshot="crdtDebugSnapshot"
     />
   </div>
 </template>

--- a/src/workbench/extensions/agent/components/agent/AgentPanel.vue
+++ b/src/workbench/extensions/agent/components/agent/AgentPanel.vue
@@ -293,6 +293,7 @@ defineExpose({ addAttachment, updateAttachment, removeAttachment })
     </template>
 
     <template v-if="!showHistory">
+      <slot name="instrument" />
       <footer class="shrink-0 py-3">
         <div class="mx-auto flex w-full max-w-[640px] flex-col gap-4 px-4">
           <RunNoticeBanner :expanded="isMaximized" />

--- a/src/workbench/extensions/agent/crdt/CrdtDevPanel.test.ts
+++ b/src/workbench/extensions/agent/crdt/CrdtDevPanel.test.ts
@@ -115,6 +115,29 @@ describe('CrdtDevPanel', () => {
     expect(log).not.toContain('ws_out')
   })
 
+  it('shows the sensitive-source opt-ins as off, and lets them be turned on', async () => {
+    const user = userEvent.setup()
+    renderPanel()
+    await user.click(chip()!)
+
+    // These three are the only consent gate on logs, settings and the workflow
+    // reaching the clipboard, so their state has to be readable. A bare
+    // <input type="checkbox"> renders at 0x0 here: agentPanel.css strips
+    // `appearance` from every input under #agent-panel-root.
+    for (const key of ['serverLogs', 'settings', 'workflow']) {
+      const toggle = screen.getByTestId(`crdt-dev-panel-include-${key}`)
+      expect(toggle.getAttribute('role')).toBe('switch')
+      expect(toggle.getAttribute('aria-checked')).toBe('false')
+
+      await user.click(toggle)
+      expect(
+        screen
+          .getByTestId(`crdt-dev-panel-include-${key}`)
+          .getAttribute('aria-checked')
+      ).toBe('true')
+    }
+  })
+
   it('explains a merge sequence without needing a backend', async () => {
     const user = userEvent.setup()
     renderPanel()

--- a/src/workbench/extensions/agent/crdt/CrdtDevPanel.test.ts
+++ b/src/workbench/extensions/agent/crdt/CrdtDevPanel.test.ts
@@ -1,0 +1,112 @@
+import userEvent from '@testing-library/user-event'
+import { render, screen } from '@testing-library/vue'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/scripts/api', () => ({
+  api: {
+    getSystemStats: () => Promise.reject(new Error('offline')),
+    getLogs: () => Promise.reject(new Error('offline')),
+    getSettings: () => Promise.reject(new Error('offline')),
+    apiURL: (path: string) => `http://backend${path}`
+  }
+}))
+vi.mock('@/scripts/app', () => ({
+  app: { rootGraph: { serialize: () => ({ nodes: [], links: [] }) } }
+}))
+vi.mock('@/stores/extensionStore', () => ({
+  useExtensionStore: () => ({ extensions: [] })
+}))
+
+import CrdtDevPanel from './CrdtDevPanel.vue'
+import { clearDevEvents, recordDevEvent } from './devPanelLog'
+import type { AgentCrdtStatus } from './useAgentCrdtFollower'
+
+const STATUS: AgentCrdtStatus = {
+  enabled: true,
+  connected: true,
+  workflowId: 'doc-1',
+  updatesApplied: 4,
+  lastFrameType: 'doc_update'
+}
+
+function renderPanel() {
+  return render(CrdtDevPanel, { props: { status: STATUS } })
+}
+
+const chip = () => screen.queryByTestId('crdt-dev-panel-chip')
+const sheet = () => screen.queryByTestId('crdt-dev-panel')
+
+describe('CrdtDevPanel', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    clearDevEvents()
+  })
+
+  it('starts collapsed to a chip so it cannot cover the composer', () => {
+    renderPanel()
+
+    expect(chip()).toBeTruthy()
+    expect(sheet()).toBeNull()
+  })
+
+  it('opens and closes back to the chip', async () => {
+    const user = userEvent.setup()
+    renderPanel()
+
+    await user.click(chip()!)
+    expect(sheet()).toBeTruthy()
+
+    await user.click(screen.getByTestId('crdt-dev-panel-close'))
+    expect(chip()).toBeTruthy()
+    expect(sheet()).toBeNull()
+  })
+
+  it('removes the whole instrument when hidden, not just the sheet', async () => {
+    const user = userEvent.setup()
+    renderPanel()
+    await user.click(chip()!)
+
+    await user.click(screen.getByTestId('crdt-dev-panel-dismiss'))
+
+    // A chip left behind after "hide" is the bug: the mount gate is read once
+    // at setup, so persisting the opt-out alone leaves it on screen.
+    expect(chip()).toBeNull()
+    expect(sheet()).toBeNull()
+    expect(localStorage.getItem('Comfy.Agent.CrdtDebug.enabled')).toBe('false')
+  })
+
+  it('filters the event log by the layer an event came from', async () => {
+    const user = userEvent.setup()
+    recordDevEvent('ws_out', { frame: 'a' }, { scope: 'wire' })
+    recordDevEvent('doc_update', { seq: 1 }, { scope: 'doc' })
+    renderPanel()
+
+    await user.click(chip()!)
+    await user.click(screen.getByTestId('crdt-dev-panel-tab-log'))
+    expect(screen.getByTestId('crdt-dev-panel-log').textContent).toContain(
+      'ws_out'
+    )
+
+    await user.selectOptions(
+      screen.getByTestId('crdt-dev-panel-scope-filter'),
+      'doc'
+    )
+
+    const log = screen.getByTestId('crdt-dev-panel-log').textContent
+    expect(log).toContain('doc_update')
+    expect(log).not.toContain('ws_out')
+  })
+
+  it('explains a merge sequence without needing a backend', async () => {
+    const user = userEvent.setup()
+    renderPanel()
+
+    await user.click(chip()!)
+    await user.click(screen.getByTestId('crdt-dev-panel-tab-merge'))
+    await user.click(screen.getByTestId('crdt-dev-panel-run'))
+
+    const trace = screen.getByTestId('crdt-dev-panel-trace').textContent
+    expect(trace).toContain('delete-wins')
+    expect(trace).toContain('had already been deleted')
+  })
+})

--- a/src/workbench/extensions/agent/crdt/CrdtDevPanel.test.ts
+++ b/src/workbench/extensions/agent/crdt/CrdtDevPanel.test.ts
@@ -18,6 +18,7 @@ vi.mock('@/stores/extensionStore', () => ({
 }))
 
 import CrdtDevPanel from './CrdtDevPanel.vue'
+import { setCrdtDebugEnabled } from './crdtDebugGate'
 import { clearDevEvents, recordDevEvent } from './devPanelLog'
 import type { AgentCrdtStatus } from './useAgentCrdtFollower'
 
@@ -39,6 +40,9 @@ const sheet = () => screen.queryByTestId('crdt-dev-panel')
 describe('CrdtDevPanel', () => {
   beforeEach(() => {
     localStorage.clear()
+    // The gate caches its value, so clearing storage behind it is not enough
+    // to undo a previous test's dismissal.
+    setCrdtDebugEnabled(true)
     clearDevEvents()
   })
 
@@ -68,11 +72,25 @@ describe('CrdtDevPanel', () => {
 
     await user.click(screen.getByTestId('crdt-dev-panel-dismiss'))
 
-    // A chip left behind after "hide" is the bug: the mount gate is read once
-    // at setup, so persisting the opt-out alone leaves it on screen.
     expect(chip()).toBeNull()
     expect(sheet()).toBeNull()
     expect(localStorage.getItem('Comfy.Agent.CrdtDebug.enabled')).toBe('false')
+  })
+
+  it('stays hidden across a remount, not just for the current one', async () => {
+    const user = userEvent.setup()
+    const first = renderPanel()
+    await user.click(chip()!)
+    await user.click(screen.getByTestId('crdt-dev-panel-dismiss'))
+
+    // The panel lives in a slot inside `v-if="!showHistory"`, so opening chat
+    // history destroys and re-creates it. Per-mount state alone would bring a
+    // deliberately hidden chip back with no user action.
+    first.unmount()
+    renderPanel()
+
+    expect(chip()).toBeNull()
+    expect(sheet()).toBeNull()
   })
 
   it('filters the event log by the layer an event came from', async () => {

--- a/src/workbench/extensions/agent/crdt/CrdtDevPanel.vue
+++ b/src/workbench/extensions/agent/crdt/CrdtDevPanel.vue
@@ -1,66 +1,93 @@
 <script setup lang="ts">
-import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
+import { cn } from '@comfyorg/tailwind-utils'
+import { computed, onBeforeUnmount, onMounted, ref, shallowRef } from 'vue'
 
 import { api } from '@/scripts/api'
+import { app } from '@/scripts/app'
 
-import type { AgentCrdtStatus } from './useAgentCrdtFollower'
-import type { DevEvent, DevEventKind } from './devPanelLog'
+import type { CrdtLogLevel } from './crdtDebugGate'
+import {
+  CRDT_LOG_LEVELS,
+  crdtLogLevel,
+  setCrdtDebugEnabled,
+  setCrdtLogLevel
+} from './crdtDebugGate'
+import type { CrdtDebugSnapshot } from './crdtDebugReport'
+import { collectCrdtDebugReport } from './crdtDebugReport'
+import type { CrdtLogScope, DevEvent, DevEventKind } from './devPanelLog'
 import { clearDevEvents, devEvents, stringifyDevEvents } from './devPanelLog'
+import type { MergeScenario, MergeSimulation } from './mergeScenarios'
+import { MERGE_SCENARIOS, runScenario } from './mergeScenarios'
+import type { MergeTraceEntry, NodeLifecycleRow } from './mergeTrace'
+import { MERGE_VOCABULARY, groupByRegister, nodeLifecycle } from './mergeTrace'
+import type { AgentCrdtStatus } from './useAgentCrdtFollower'
 
 /**
- * PoC (branch poc/fe-crdt-follower-e2e): CRDT debugging overlay. Surfaces the
- * follower's live state, the dev event ring buffer, the mutation catalog and
- * known-good agent prompts so QA never has to reverse-engineer the console
- * helpers. Reads `window.__agentCrdtPoc` (installed by useAgentCrdtFollower)
- * on a 1s poll — zero extra API surface on the composable. Not shipped
- * beyond the PoC branch.
+ * The CRDT debug instrument.
+ *
+ * Anchored INSIDE `#agent-panel-root` rather than to the viewport: the
+ * previous `fixed right-3 bottom-3` overlay sat on top of the composer's
+ * submit button, and its status strip was a block element above the panel
+ * that pushed the composer below the fold. A dev instrument that costs the
+ * product its primary action is not a net win, so this one is contained by
+ * the sidebar, sits below the panel header, and clears the composer entirely.
  */
 
-const props = defineProps<{ status: AgentCrdtStatus }>()
+const { status, snapshot } = defineProps<{
+  status: AgentCrdtStatus
+  /** Reads the follower's live document state; see useAgentCrdtFollower. */
+  snapshot?: () => CrdtDebugSnapshot
+}>()
 
-// ── strings (script-side to satisfy @intlify/vue-i18n/no-raw-text) ────────
+// Script-side strings: this is a dev instrument, deliberately kept out of
+// src/locales so it cannot leak into the product's translation surface.
 const S = {
-  chipClosed: 'CRDT dev',
-  title: 'CRDT Dev Panel (PoC)',
+  title: 'CRDT debug',
   close: 'Close',
-  sectionStatus: 'Live status',
-  sectionCatalog: 'Mutation catalog',
-  sectionPrompts: 'Known-good agent prompts',
-  sectionProxy: 'BE proxy target',
-  sectionLog: 'Event log',
-  docId: 'doc id',
-  connected: 'connected',
+  hide: 'Hide until re-enabled',
+  open: 'Open CRDT debug panel',
+  tabStatus: 'Status',
+  tabLog: 'Log',
+  tabMerge: 'Merge lab',
+  none: '—',
   yes: 'yes',
   no: 'no',
-  none: '—',
-  updates: 'updates applied',
-  lastFrame: 'last frame',
-  tabId: 'tab id',
-  lastSeq: 'last seq',
-  remints: 'remints (doc_reset)',
-  nodesAdded: 'doc nodes added',
-  nodesRemoved: 'doc nodes removed',
-  filterAll: 'all kinds',
+  allScopes: 'all layers',
+  allLevels: 'all levels',
+  allKinds: 'all kinds',
   clear: 'Clear',
-  copyJson: 'Copy JSON',
+  copyLog: 'Copy log',
+  copyReport: 'Copy full report',
+  copying: 'Collecting…',
   copied: 'Copied',
-  eventCount: 'events'
+  copyFailed: 'Copy failed',
+  events: 'events',
+  sectionDoc: 'Document',
+  sectionFollower: 'Follower',
+  sectionProxy: 'Backend',
+  sectionVocab: 'What the words mean',
+  sectionOutcome: 'Result after the whole sequence',
+  sectionByRegister: 'Grouped by contested register',
+  sectionLifecycle: 'Node lifecycle',
+  run: 'Run sequence',
+  question: 'Question',
+  notePrompt:
+    'Does this feel wrong? Describe the rule you would rather have. It is included verbatim in the copied report.',
+  notePlaceholder:
+    'e.g. "re-adding a node should restore the widget edit made while it was deleted"',
+  survivingNodes: 'nodes left',
+  survivingWidgets: 'widget values left',
+  verbosity: 'console'
 } as const
 
-const MUTATION_CATALOG = [
-  'add_node',
-  'delete_node',
-  'move_node',
-  'set_widget',
-  'connect',
-  'disconnect'
+const STATUS_ROWS = [
+  ['doc id', () => status.workflowId ?? S.none],
+  ['connected', () => (status.connected ? S.yes : S.no)],
+  ['updates applied', () => String(status.updatesApplied)],
+  ['last frame', () => status.lastFrameType ?? S.none]
 ] as const
 
-const KNOWN_GOOD_PROMPTS = [
-  "Add a single CLIP Text Encode (Prompt) node with text 'hello world'",
-  'Add a KSampler node',
-  'Delete the newest node you added'
-] as const
+const SCOPES: readonly CrdtLogScope[] = ['wire', 'doc', 'ecs', 'ops', 'panel']
 
 const EVENT_KINDS: readonly DevEventKind[] = [
   'ws_out',
@@ -68,15 +95,35 @@ const EVENT_KINDS: readonly DevEventKind[] = [
   'doc_update',
   'doc_ops_result',
   'doc_reset',
+  'doc_gap',
+  'doc_effects',
+  'doc_nodes_changed',
   'schema_error',
   'reconnected',
   'subscribe_retry',
-  'doc_nodes_changed',
-  'rebind'
-] as const
+  'stale_probe',
+  'rebind',
+  'op_minted',
+  'op_batch_settled',
+  'send_dropped'
+]
+
+const VERDICT_TONE: Record<string, string> = {
+  applied: 'text-agent-success border-agent-success',
+  'lww-dropped': 'text-agent-fg-muted border-agent-border-strong',
+  'no-op': 'text-agent-fg-muted border-agent-border-strong',
+  rejected: 'text-agent-danger border-agent-danger',
+  'not-reached': 'text-agent-fg-muted border-agent-border'
+}
 
 // ── open/close state, persisted ───────────────────────────────────────────
 const OPEN_KEY = 'Comfy.Agent.CrdtDevPanel.open'
+
+const open = ref(readOpen())
+const tab = ref<'status' | 'log' | 'merge'>('status')
+// The mount gate is read once at panel setup, so hiding must also be local —
+// otherwise "hide" leaves the chip on screen until the next reload.
+const dismissed = ref(false)
 
 function readOpen(): boolean {
   try {
@@ -86,38 +133,22 @@ function readOpen(): boolean {
   }
 }
 
-const open = ref(readOpen())
-
 function setOpen(value: boolean) {
   open.value = value
   try {
     localStorage.setItem(OPEN_KEY, String(value))
   } catch {
-    /* storage unavailable — panel still toggles in-memory */
+    // Storage unavailable — the panel still toggles in-memory.
   }
 }
 
-// ── 1s poll of the PoC console helper ─────────────────────────────────────
-interface PocGlobal {
-  tabId?: string
-  lastSeq?: number
-}
-
-const polled = ref<{ tabId: string | null; lastSeq: number | null }>({
-  tabId: null,
-  lastSeq: null
-})
-
+// ── live document facts ───────────────────────────────────────────────────
+const docState = shallowRef<CrdtDebugSnapshot | null>(null)
 let pollHandle: ReturnType<typeof setInterval> | undefined
 
 function poll() {
-  const poc = (window as unknown as Record<string, unknown>).__agentCrdtPoc as
-    | PocGlobal
-    | undefined
-  polled.value = {
-    tabId: poc?.tabId ?? null,
-    lastSeq: typeof poc?.lastSeq === 'number' ? poc.lastSeq : null
-  }
+  if (!open.value) return
+  docState.value = snapshot?.() ?? null
 }
 
 onMounted(() => {
@@ -129,58 +160,185 @@ onBeforeUnmount(() => {
   if (pollHandle !== undefined) clearInterval(pollHandle)
 })
 
-// ── derived counters from the event buffer ────────────────────────────────
-const remintCount = computed(
-  () => devEvents.value.filter((e) => e.kind === 'doc_reset').length
+const docRows = computed<readonly (readonly [string, string])[]>(() => {
+  const state = docState.value
+  if (!state) return [['document', S.none]] as const
+  return [
+    ['schema error', state.schemaError ?? S.none],
+    ['last seq', state.lastSeq === null ? S.none : String(state.lastSeq)],
+    ['tab id', state.tabId ?? S.none],
+    ['nodes', `${state.nodeIds.length}: ${state.nodeIds.join(', ') || S.none}`],
+    ['links', String(state.linkIds.length)],
+    ['applied op ids', String(state.appliedOpIds.length)],
+    ['stamped registers', String(Object.keys(state.stamps).length)]
+  ] as const
+})
+
+// ── event log ─────────────────────────────────────────────────────────────
+const scopeFilter = ref<'' | CrdtLogScope>('')
+const levelFilter = ref<'' | CrdtLogLevel>('')
+const kindFilter = ref<'' | DevEventKind>('')
+const expanded = ref<number | null>(null)
+
+const matchingEvents = computed<readonly DevEvent[]>(() =>
+  devEvents.value.filter(
+    (event) =>
+      (!scopeFilter.value || event.scope === scopeFilter.value) &&
+      (!levelFilter.value || event.level === levelFilter.value) &&
+      (!kindFilter.value || event.kind === kindFilter.value)
+  )
 )
 
-const nodeDelta = computed(() => {
-  let added = 0
-  let removed = 0
-  for (const e of devEvents.value) {
-    if (e.kind !== 'doc_nodes_changed') continue
-    const d = e.detail as { added?: unknown[]; removed?: unknown[] } | null
-    added += d?.added?.length ?? 0
-    removed += d?.removed?.length ?? 0
-  }
-  return { added, removed }
+// Newest first, capped for render cost — the copy actions use the full set.
+const visibleEvents = computed(() =>
+  [...matchingEvents.value].reverse().slice(0, 150)
+)
+
+const level = ref<CrdtLogLevel>(crdtLogLevel())
+
+function onLevelChange(next: CrdtLogLevel) {
+  level.value = next
+  setCrdtLogLevel(next)
+}
+
+// ── merge lab ─────────────────────────────────────────────────────────────
+const scenario = shallowRef<MergeScenario>(MERGE_SCENARIOS[0])
+const simulation = shallowRef<MergeSimulation | null>(null)
+const testerNote = ref('')
+
+function selectScenario(id: string) {
+  const next = MERGE_SCENARIOS.find((candidate) => candidate.id === id)
+  if (!next) return
+  scenario.value = next
+  simulation.value = null
+}
+
+function run() {
+  simulation.value = runScenario(scenario.value)
+}
+
+const registerGroups = computed(() =>
+  simulation.value ? groupByRegister(simulation.value.entries) : []
+)
+
+const lifecycle = computed(() =>
+  simulation.value ? nodeLifecycle(simulation.value.entries) : []
+)
+
+function registerLine(entry: MergeTraceEntry): string {
+  return `${entry.registerLabel} · stamp v${entry.stamp[0]}`
+}
+
+function lifecycleLine(row: NodeLifecycleRow): string {
+  return `node ${row.nodeId} #${row.incarnation} · ${row.entry.kind} · ${verdictLabel(row.entry)}`
+}
+
+function verdictLabel(entry: MergeTraceEntry): string {
+  const verdict = entry.verdict
+  if (verdict.kind === 'no-op') return `no-op · ${verdict.because}`
+  if (verdict.kind === 'rejected') return `rejected · ${verdict.code}`
+  return verdict.kind
+}
+
+// ── copy actions ──────────────────────────────────────────────────────────
+const copyState = ref<'idle' | 'busy' | 'done' | 'failed'>('idle')
+
+const copyReportLabel = computed(() => {
+  if (copyState.value === 'busy') return S.copying
+  if (copyState.value === 'done') return S.copied
+  if (copyState.value === 'failed') return S.copyFailed
+  return S.copyReport
 })
 
-// ── event log filter / actions ────────────────────────────────────────────
-const kindFilter = ref<'' | DevEventKind>('')
-
-const filteredEvents = computed<readonly DevEvent[]>(() => {
-  const events = devEvents.value
-  const filtered = kindFilter.value
-    ? events.filter((e) => e.kind === kindFilter.value)
-    : events
-  // newest first, capped for render cost — full buffer still available via copy
-  return [...filtered].reverse().slice(0, 100)
-})
-
-const copyLabel = ref<string>(S.copyJson)
-
-async function copyEvents() {
-  const events = kindFilter.value
-    ? devEvents.value.filter((e) => e.kind === kindFilter.value)
-    : devEvents.value
+async function writeClipboard(text: string): Promise<boolean> {
   try {
-    await navigator.clipboard.writeText(stringifyDevEvents(events))
-    copyLabel.value = S.copied
-    setTimeout(() => (copyLabel.value = S.copyJson), 1200)
+    await navigator.clipboard.writeText(text)
+    return true
   } catch {
-    /* clipboard unavailable (non-secure context) — silently ignore */
+    // Non-secure context or denied permission: fall back to a selection copy,
+    // which is the only path that works over plain http on a LAN address.
+    const textarea = document.createElement('textarea')
+    textarea.value = text
+    textarea.setAttribute('readonly', '')
+    textarea.style.position = 'fixed'
+    textarea.style.left = '-9999px'
+    document.body.appendChild(textarea)
+    textarea.select()
+    try {
+      return document.execCommand('copy')
+    } catch {
+      return false
+    } finally {
+      textarea.remove()
+    }
   }
+}
+
+function flashCopyState(ok: boolean) {
+  copyState.value = ok ? 'done' : 'failed'
+  setTimeout(() => (copyState.value = 'idle'), 1600)
+}
+
+async function copyLog() {
+  flashCopyState(await writeClipboard(stringifyDevEvents(matchingEvents.value)))
+}
+
+async function copyReport() {
+  copyState.value = 'busy'
+  try {
+    const report = await collectCrdtDebugReport({
+      crdt: docState.value ?? fallbackSnapshot(),
+      events: devEvents.value,
+      testerNote: testerNote.value,
+      mergeTrace: simulation.value?.entries,
+      workflow: serializeActiveWorkflow()
+    })
+    flashCopyState(await writeClipboard(report))
+  } catch {
+    flashCopyState(false)
+  }
+}
+
+function fallbackSnapshot(): CrdtDebugSnapshot {
+  return {
+    status,
+    tabId: null,
+    lastSeq: null,
+    schemaError: null,
+    meta: {},
+    nodeIds: [],
+    linkIds: [],
+    appliedOpIds: [],
+    stamps: {}
+  }
+}
+
+function serializeActiveWorkflow(): unknown {
+  try {
+    return app.rootGraph.serialize()
+  } catch (error) {
+    return { error: String(error) }
+  }
+}
+
+function dismiss() {
+  setCrdtDebugEnabled(false)
+  setOpen(false)
+  dismissed.value = true
 }
 
 const proxyTarget = computed(() => api.apiURL(''))
 
+const chipLabel = computed(
+  () => `CRDT ${status.connected ? 'live' : 'off'} · ${status.updatesApplied}`
+)
+
 function fmtDetail(detail: unknown): string {
   try {
-    const raw = JSON.stringify(detail, (_k, v) =>
-      v instanceof Uint8Array ? `Uint8Array(${v.length})` : v
+    const raw = JSON.stringify(detail, (_key, value) =>
+      value instanceof Uint8Array ? `Uint8Array(${value.length})` : value
     )
-    return raw && raw.length > 200 ? raw.slice(0, 200) + '…' : (raw ?? '')
+    return raw ?? ''
   } catch {
     return String(detail)
   }
@@ -193,152 +351,373 @@ function fmtTime(at: number): string {
 
 <template>
   <div
-    class="fixed right-3 bottom-3 z-9999 font-mono text-xs"
-    data-testid="crdt-dev-panel"
+    v-if="!dismissed"
+    class="pointer-events-none absolute inset-0 z-50 font-mono text-xs"
   >
     <button
       v-if="!open"
-      class="rounded-full border border-border-default bg-base-background px-3 py-1 shadow-md"
+      type="button"
+      :title="S.open"
+      class="text-agent-fg-muted border-agent-border bg-agent-surface-raised hover:text-agent-fg hover:bg-agent-surface-hover pointer-events-auto absolute top-10 right-2 flex h-6 cursor-pointer items-center gap-1 rounded-full border px-2 transition-colors"
       data-testid="crdt-dev-panel-chip"
       @click="setOpen(true)"
     >
-      {{ S.chipClosed }}
+      <span
+        :class="
+          cn(
+            'size-1.5 rounded-full',
+            status.connected ? 'bg-agent-success' : 'bg-agent-danger'
+          )
+        "
+      />
+      {{ chipLabel }}
     </button>
 
-    <div
+    <section
       v-else
-      class="flex max-h-[70vh] w-[420px] flex-col overflow-hidden rounded-lg border border-border-default bg-base-background shadow-xl"
+      class="bg-agent-surface border-agent-border text-agent-fg pointer-events-auto absolute inset-x-0 top-10 bottom-0 flex flex-col border-t"
+      data-testid="crdt-dev-panel"
     >
-      <div
-        class="flex items-center justify-between border-b border-border-default px-3 py-2"
+      <header
+        class="border-agent-border flex h-8 shrink-0 items-center gap-2 border-b px-2"
       >
         <span class="font-bold">{{ S.title }}</span>
+        <label class="text-agent-fg-muted ml-auto flex items-center gap-1">
+          {{ S.verbosity }}
+          <select
+            v-model="level"
+            class="border-agent-border bg-agent-surface-raised rounded-sm border px-1 py-0.5"
+            data-testid="crdt-dev-panel-verbosity"
+            @change="onLevelChange(level)"
+          >
+            <option
+              v-for="option in CRDT_LOG_LEVELS"
+              :key="option"
+              :value="option"
+            >
+              {{ option }}
+            </option>
+          </select>
+        </label>
         <button
-          class="rounded-sm border border-border-default px-2 py-0.5"
+          type="button"
+          :title="S.hide"
+          class="text-agent-fg-muted hover:text-agent-danger cursor-pointer"
+          data-testid="crdt-dev-panel-dismiss"
+          @click="dismiss"
+        >
+          <span class="icon-[lucide--eye-off] size-4" />
+        </button>
+        <button
+          type="button"
+          :title="S.close"
+          class="text-agent-fg-muted hover:text-agent-fg cursor-pointer"
           data-testid="crdt-dev-panel-close"
           @click="setOpen(false)"
         >
-          {{ S.close }}
+          <span class="icon-[lucide--x] size-4" />
         </button>
-      </div>
+      </header>
 
-      <div class="flex-1 space-y-3 overflow-y-auto p-3">
-        <section>
-          <div class="mb-1 font-bold">{{ S.sectionStatus }}</div>
-          <table class="w-full">
-            <tbody>
-              <tr>
-                <td class="pr-2 text-muted">{{ S.docId }}</td>
-                <td class="break-all">
-                  {{ props.status.workflowId ?? S.none }}
-                </td>
-              </tr>
-              <tr>
-                <td class="pr-2 text-muted">{{ S.connected }}</td>
-                <td>{{ props.status.connected ? S.yes : S.no }}</td>
-              </tr>
-              <tr>
-                <td class="pr-2 text-muted">{{ S.updates }}</td>
-                <td>{{ props.status.updatesApplied }}</td>
-              </tr>
-              <tr>
-                <td class="pr-2 text-muted">{{ S.lastFrame }}</td>
-                <td>{{ props.status.lastFrameType ?? S.none }}</td>
-              </tr>
-              <tr>
-                <td class="pr-2 text-muted">{{ S.tabId }}</td>
-                <td class="break-all">{{ polled.tabId ?? S.none }}</td>
-              </tr>
-              <tr>
-                <td class="pr-2 text-muted">{{ S.lastSeq }}</td>
-                <td>{{ polled.lastSeq ?? S.none }}</td>
-              </tr>
-              <tr>
-                <td class="pr-2 text-muted">{{ S.remints }}</td>
-                <td>{{ remintCount }}</td>
-              </tr>
-              <tr>
-                <td class="pr-2 text-muted">{{ S.nodesAdded }}</td>
-                <td>{{ nodeDelta.added }}</td>
-              </tr>
-              <tr>
-                <td class="pr-2 text-muted">{{ S.nodesRemoved }}</td>
-                <td>{{ nodeDelta.removed }}</td>
-              </tr>
-            </tbody>
-          </table>
-        </section>
+      <nav class="border-agent-border flex shrink-0 border-b">
+        <button
+          v-for="entry in [
+            ['status', S.tabStatus],
+            ['log', S.tabLog],
+            ['merge', S.tabMerge]
+          ] as const"
+          :key="entry[0]"
+          type="button"
+          :class="
+            cn(
+              'flex-1 cursor-pointer px-2 py-1 transition-colors',
+              tab === entry[0]
+                ? 'text-agent-fg border-agent-accent border-b-2'
+                : 'text-agent-fg-muted hover:text-agent-fg'
+            )
+          "
+          :data-testid="`crdt-dev-panel-tab-${entry[0]}`"
+          @click="tab = entry[0]"
+        >
+          {{ entry[1] }}
+        </button>
+      </nav>
 
-        <section>
-          <div class="mb-1 font-bold">{{ S.sectionProxy }}</div>
-          <div class="break-all text-muted">{{ proxyTarget }}</div>
-        </section>
+      <div class="min-h-0 flex-1 space-y-3 overflow-y-auto p-2">
+        <template v-if="tab === 'status'">
+          <section>
+            <div class="text-agent-fg-muted mb-1 font-bold">
+              {{ S.sectionFollower }}
+            </div>
+            <table class="w-full">
+              <tbody>
+                <tr v-for="row in STATUS_ROWS" :key="row[0]">
+                  <td class="text-agent-fg-muted pr-2 align-top">
+                    {{ row[0] }}
+                  </td>
+                  <td class="break-all">{{ row[1]() }}</td>
+                </tr>
+              </tbody>
+            </table>
+          </section>
 
-        <section>
-          <div class="mb-1 font-bold">{{ S.sectionCatalog }}</div>
-          <div class="flex flex-wrap gap-1">
-            <span
-              v-for="m in MUTATION_CATALOG"
-              :key="m"
-              class="rounded-sm border border-border-default px-1.5 py-0.5"
-            >
-              {{ m }}
-            </span>
-          </div>
-        </section>
+          <section>
+            <div class="text-agent-fg-muted mb-1 font-bold">
+              {{ S.sectionDoc }}
+            </div>
+            <table class="w-full">
+              <tbody>
+                <tr v-for="row in docRows" :key="row[0]">
+                  <td class="text-agent-fg-muted pr-2 align-top">
+                    {{ row[0] }}
+                  </td>
+                  <td class="break-all">{{ row[1] }}</td>
+                </tr>
+              </tbody>
+            </table>
+          </section>
 
-        <section>
-          <div class="mb-1 font-bold">{{ S.sectionPrompts }}</div>
-          <ul class="list-disc space-y-1 pl-4">
-            <li v-for="p in KNOWN_GOOD_PROMPTS" :key="p">{{ p }}</li>
-          </ul>
-        </section>
+          <section>
+            <div class="text-agent-fg-muted mb-1 font-bold">
+              {{ S.sectionProxy }}
+            </div>
+            <div class="text-agent-fg-muted break-all">{{ proxyTarget }}</div>
+          </section>
+        </template>
 
-        <section>
-          <div class="mb-1 flex items-center gap-2">
-            <span class="font-bold">{{ S.sectionLog }}</span>
-            <span class="text-muted"
-              >{{ devEvents.length }} {{ S.eventCount }}</span
-            >
+        <template v-else-if="tab === 'log'">
+          <div class="flex flex-wrap items-center gap-1">
             <select
-              v-model="kindFilter"
-              class="ml-auto rounded-sm border border-border-default bg-base-background px-1 py-0.5"
-              data-testid="crdt-dev-panel-filter"
+              v-model="scopeFilter"
+              class="border-agent-border bg-agent-surface-raised rounded-sm border px-1 py-0.5"
+              data-testid="crdt-dev-panel-scope-filter"
             >
-              <option value="">{{ S.filterAll }}</option>
-              <option v-for="k in EVENT_KINDS" :key="k" :value="k">
-                {{ k }}
+              <option value="">{{ S.allScopes }}</option>
+              <option v-for="scope in SCOPES" :key="scope" :value="scope">
+                {{ scope }}
               </option>
             </select>
-            <button
-              class="rounded-sm border border-border-default px-1.5 py-0.5"
-              @click="copyEvents"
+            <select
+              v-model="levelFilter"
+              class="border-agent-border bg-agent-surface-raised rounded-sm border px-1 py-0.5"
             >
-              {{ copyLabel }}
-            </button>
+              <option value="">{{ S.allLevels }}</option>
+              <option
+                v-for="option in CRDT_LOG_LEVELS"
+                :key="option"
+                :value="option"
+              >
+                {{ option }}
+              </option>
+            </select>
+            <select
+              v-model="kindFilter"
+              class="border-agent-border bg-agent-surface-raised rounded-sm border px-1 py-0.5"
+              data-testid="crdt-dev-panel-filter"
+            >
+              <option value="">{{ S.allKinds }}</option>
+              <option v-for="kind in EVENT_KINDS" :key="kind" :value="kind">
+                {{ kind }}
+              </option>
+            </select>
+            <span class="text-agent-fg-muted ml-auto"
+              >{{ matchingEvents.length }} {{ S.events }}</span
+            >
             <button
-              class="rounded-sm border border-border-default px-1.5 py-0.5"
+              type="button"
+              class="border-agent-border hover:bg-agent-surface-hover cursor-pointer rounded-sm border px-1.5 py-0.5"
               @click="clearDevEvents()"
             >
               {{ S.clear }}
             </button>
           </div>
-          <div
-            class="max-h-56 space-y-1 overflow-y-auto"
-            data-testid="crdt-dev-panel-log"
-          >
-            <div
-              v-for="e in filteredEvents"
-              :key="e.seq"
-              class="border-b border-border-default pb-1"
+
+          <div class="space-y-1" data-testid="crdt-dev-panel-log">
+            <button
+              v-for="event in visibleEvents"
+              :key="event.seq"
+              type="button"
+              class="border-agent-border hover:bg-agent-surface-hover block w-full cursor-pointer border-b pb-1 text-left"
+              @click="expanded = expanded === event.seq ? null : event.seq"
             >
-              <span class="text-muted">{{ fmtTime(e.at) }}</span>
-              <span class="ml-1 font-bold">{{ e.kind }}</span>
-              <div class="break-all text-muted">{{ fmtDetail(e.detail) }}</div>
-            </div>
+              <div class="flex items-baseline gap-1">
+                <span class="text-agent-fg-muted">{{ fmtTime(event.at) }}</span>
+                <span
+                  :class="
+                    cn(
+                      'border-agent-border rounded-sm border px-1',
+                      event.level === 'warn' &&
+                        'text-agent-danger border-agent-danger'
+                    )
+                  "
+                  >{{ event.scope }}</span
+                >
+                <span class="font-bold">{{ event.kind }}</span>
+              </div>
+              <div
+                :class="
+                  cn(
+                    'text-agent-fg-muted break-all',
+                    expanded !== event.seq && 'line-clamp-2'
+                  )
+                "
+              >
+                {{ fmtDetail(event.detail) }}
+              </div>
+            </button>
           </div>
-        </section>
+        </template>
+
+        <template v-else>
+          <select
+            class="border-agent-border bg-agent-surface-raised w-full rounded-sm border p-1"
+            data-testid="crdt-dev-panel-scenario"
+            @change="selectScenario(($event.target as HTMLSelectElement).value)"
+          >
+            <option
+              v-for="option in MERGE_SCENARIOS"
+              :key="option.id"
+              :value="option.id"
+              :selected="option.id === scenario.id"
+            >
+              {{ option.title }}
+            </option>
+          </select>
+
+          <p class="text-agent-fg-muted">
+            {{ S.question }}: {{ scenario.question }}
+          </p>
+
+          <button
+            type="button"
+            class="border-agent-accent text-agent-fg hover:bg-agent-surface-hover w-full cursor-pointer rounded-sm border px-2 py-1"
+            data-testid="crdt-dev-panel-run"
+            @click="run"
+          >
+            {{ S.run }}
+          </button>
+
+          <template v-if="simulation">
+            <ol class="space-y-2" data-testid="crdt-dev-panel-trace">
+              <li
+                v-for="entry in simulation.entries"
+                :key="entry.opId"
+                class="border-agent-border border-l-2 pl-2"
+              >
+                <div class="flex flex-wrap items-baseline gap-1">
+                  <span class="text-agent-fg-muted"
+                    >{{ entry.index + 1 }}.</span
+                  >
+                  <span class="font-bold">{{ entry.kind }}</span>
+                  <span class="text-agent-fg-muted">{{ entry.actor }}</span>
+                  <span
+                    :class="
+                      cn(
+                        'ml-auto rounded-sm border px-1',
+                        VERDICT_TONE[entry.verdict.kind]
+                      )
+                    "
+                    >{{ verdictLabel(entry) }}</span
+                  >
+                </div>
+                <div class="text-agent-fg-muted">{{ registerLine(entry) }}</div>
+                <p class="mt-0.5 mb-0">{{ entry.explanation }}</p>
+              </li>
+            </ol>
+
+            <section>
+              <div class="text-agent-fg-muted mb-1 font-bold">
+                {{ S.sectionOutcome }}
+              </div>
+              <div>
+                {{ simulation.survivingNodeIds.length }} {{ S.survivingNodes }}:
+                {{ simulation.survivingNodeIds.join(', ') || S.none }}
+              </div>
+              <div class="text-agent-fg-muted break-all">
+                {{ S.survivingWidgets }}:
+                {{ fmtDetail(simulation.survivingWidgets) }}
+              </div>
+            </section>
+
+            <section v-if="registerGroups.length">
+              <div class="text-agent-fg-muted mb-1 font-bold">
+                {{ S.sectionByRegister }}
+              </div>
+              <div v-for="group in registerGroups" :key="group.register">
+                <div class="font-bold">{{ group.label }}</div>
+                <div
+                  v-for="entry in group.entries"
+                  :key="entry.opId"
+                  class="text-agent-fg-muted pl-2"
+                >
+                  {{ entry.kind }} · {{ entry.actor }} ·
+                  {{ verdictLabel(entry) }}
+                </div>
+              </div>
+            </section>
+
+            <section v-if="lifecycle.length">
+              <div class="text-agent-fg-muted mb-1 font-bold">
+                {{ S.sectionLifecycle }}
+              </div>
+              <div
+                v-for="row in lifecycle"
+                :key="`${row.nodeId}-${row.entry.opId}`"
+                class="text-agent-fg-muted"
+              >
+                {{ lifecycleLine(row) }}
+              </div>
+            </section>
+          </template>
+
+          <section>
+            <div class="text-agent-fg-muted mb-1 font-bold">
+              {{ S.sectionVocab }}
+            </div>
+            <dl class="space-y-1">
+              <div v-for="item in MERGE_VOCABULARY" :key="item.term">
+                <dt class="font-bold">{{ item.term }}</dt>
+                <dd class="text-agent-fg-muted ml-0">{{ item.meaning }}</dd>
+              </div>
+            </dl>
+          </section>
+
+          <section>
+            <label
+              for="crdt-tester-note"
+              class="text-agent-fg-muted mb-1 block font-bold"
+              >{{ S.notePrompt }}</label
+            >
+            <textarea
+              id="crdt-tester-note"
+              v-model="testerNote"
+              rows="3"
+              :placeholder="S.notePlaceholder"
+              class="border-agent-border bg-agent-surface-raised text-agent-fg w-full rounded-sm border p-1"
+              data-testid="crdt-dev-panel-note"
+            />
+          </section>
+        </template>
       </div>
-    </div>
+
+      <footer class="border-agent-border flex shrink-0 gap-1 border-t p-2">
+        <button
+          type="button"
+          class="border-agent-border hover:bg-agent-surface-hover flex-1 cursor-pointer rounded-sm border px-2 py-1"
+          @click="copyLog"
+        >
+          {{ S.copyLog }}
+        </button>
+        <button
+          type="button"
+          :disabled="copyState === 'busy'"
+          class="border-agent-accent hover:bg-agent-surface-hover flex-2 cursor-pointer rounded-sm border px-2 py-1 disabled:cursor-default"
+          data-testid="crdt-dev-panel-copy-report"
+          @click="copyReport"
+        >
+          {{ copyReportLabel }}
+        </button>
+      </footer>
+    </section>
   </div>
 </template>

--- a/src/workbench/extensions/agent/crdt/CrdtDevPanel.vue
+++ b/src/workbench/extensions/agent/crdt/CrdtDevPanel.vue
@@ -21,7 +21,8 @@ import {
   setCrdtDebugEnabled,
   setCrdtLogLevel
 } from './crdtDebugGate'
-import type { CrdtDebugSnapshot, ReportSources } from './crdtDebugReport'
+import type { ReportSources } from './crdtDebugReport'
+import type { CrdtDebugSnapshot } from './crdtSnapshot'
 import {
   DEFAULT_REPORT_SOURCES,
   collectCrdtDebugReport
@@ -249,7 +250,25 @@ function onLevelChange(next: CrdtLogLevel) {
 // ── merge lab ─────────────────────────────────────────────────────────────
 const scenario = shallowRef<MergeScenario>(MERGE_SCENARIOS[0])
 const simulation = shallowRef<MergeSimulation | null>(null)
-const testerNote = ref('')
+const NOTE_KEY = 'Comfy.Agent.CrdtDevPanel.note'
+
+function readNote(): string {
+  try {
+    return localStorage.getItem(NOTE_KEY) ?? ''
+  } catch {
+    return ''
+  }
+}
+
+const testerNote = ref(readNote())
+
+watch(testerNote, (next) => {
+  try {
+    localStorage.setItem(NOTE_KEY, next)
+  } catch {
+    // Storage unavailable — the note simply does not survive a remount.
+  }
+})
 
 function selectScenario(id: string) {
   const next = MERGE_SCENARIOS.find((candidate) => candidate.id === id)
@@ -326,7 +345,13 @@ function flashCopyState(ok: boolean) {
 }
 
 async function copyLog() {
-  flashCopyState(await writeClipboard(stringifyDevEvents(matchingEvents.value)))
+  try {
+    flashCopyState(
+      await writeClipboard(stringifyDevEvents(matchingEvents.value))
+    )
+  } catch {
+    flashCopyState(false)
+  }
 }
 
 async function copyReport() {
@@ -414,7 +439,7 @@ function fmtTime(at: number): string {
       v-if="!open"
       type="button"
       :title="S.open"
-      class="text-agent-fg-muted border-agent-border bg-agent-surface-raised hover:text-agent-fg hover:bg-agent-surface-hover absolute right-4 bottom-1 z-10 flex h-6 cursor-pointer items-center gap-1 rounded-full border px-2 transition-colors"
+      class="text-agent-fg-muted border-agent-border bg-agent-surface-raised hover:text-agent-fg hover:bg-agent-surface-hover mr-4 mb-1 flex h-6 cursor-pointer items-center gap-1 self-end rounded-full border px-2 transition-colors"
       data-testid="crdt-dev-panel-chip"
       @click="setOpen(true)"
     >
@@ -654,7 +679,10 @@ function fmtTime(at: number): string {
           </button>
 
           <template v-if="simulation">
-            <ol class="space-y-2" data-testid="crdt-dev-panel-trace">
+            <ol
+              class="list-none space-y-2 pl-0"
+              data-testid="crdt-dev-panel-trace"
+            >
               <li
                 v-for="entry in simulation.entries"
                 :key="entry.index"
@@ -758,19 +786,36 @@ function fmtTime(at: number): string {
 
       <footer class="border-agent-border shrink-0 border-t p-2">
         <div class="text-agent-fg-muted mb-1">{{ S.sectionInclude }}</div>
-        <div class="mb-1 flex flex-wrap gap-x-3 gap-y-1">
-          <label
+        <div class="mb-1 flex flex-wrap gap-1">
+          <button
             v-for="source in REPORT_SOURCE_LABELS"
             :key="source.key"
-            class="flex cursor-pointer items-center gap-1"
+            type="button"
+            role="switch"
+            :aria-checked="reportSources[source.key]"
+            :class="
+              cn(
+                'flex cursor-pointer items-center gap-1 rounded-full border px-2 py-0.5 transition-colors',
+                reportSources[source.key]
+                  ? 'border-agent-accent text-agent-fg'
+                  : 'border-agent-border text-agent-fg-muted'
+              )
+            "
+            :data-testid="`crdt-dev-panel-include-${String(source.key)}`"
+            @click="reportSources[source.key] = !reportSources[source.key]"
           >
-            <input
-              v-model="reportSources[source.key]"
-              type="checkbox"
-              :data-testid="`crdt-dev-panel-include-${source.key}`"
+            <span
+              :class="
+                cn(
+                  'size-3 shrink-0',
+                  reportSources[source.key]
+                    ? 'icon-[lucide--check]'
+                    : 'icon-[lucide--minus] opacity-50'
+                )
+              "
             />
             {{ source.label }}
-          </label>
+          </button>
         </div>
         <p class="text-agent-fg-muted mt-0 mb-2">{{ S.includeHint }}</p>
         <div class="flex gap-1">

--- a/src/workbench/extensions/agent/crdt/CrdtDevPanel.vue
+++ b/src/workbench/extensions/agent/crdt/CrdtDevPanel.vue
@@ -1,6 +1,14 @@
 <script setup lang="ts">
 import { cn } from '@comfyorg/tailwind-utils'
-import { computed, onBeforeUnmount, onMounted, ref, shallowRef } from 'vue'
+import {
+  computed,
+  nextTick,
+  onBeforeUnmount,
+  onMounted,
+  ref,
+  shallowRef,
+  watch
+} from 'vue'
 
 import { api } from '@/scripts/api'
 import { app } from '@/scripts/app'
@@ -12,8 +20,11 @@ import {
   setCrdtDebugEnabled,
   setCrdtLogLevel
 } from './crdtDebugGate'
-import type { CrdtDebugSnapshot } from './crdtDebugReport'
-import { collectCrdtDebugReport } from './crdtDebugReport'
+import type { CrdtDebugSnapshot, ReportSources } from './crdtDebugReport'
+import {
+  DEFAULT_REPORT_SOURCES,
+  collectCrdtDebugReport
+} from './crdtDebugReport'
 import type { CrdtLogScope, DevEvent, DevEventKind } from './devPanelLog'
 import { clearDevEvents, devEvents, stringifyDevEvents } from './devPanelLog'
 import type { MergeScenario, MergeSimulation } from './mergeScenarios'
@@ -25,12 +36,25 @@ import type { AgentCrdtStatus } from './useAgentCrdtFollower'
 /**
  * The CRDT debug instrument.
  *
- * Anchored INSIDE `#agent-panel-root` rather than to the viewport: the
- * previous `fixed right-3 bottom-3` overlay sat on top of the composer's
- * submit button, and its status strip was a block element above the panel
- * that pushed the composer below the fold. A dev instrument that costs the
- * product its primary action is not a net win, so this one is contained by
- * the sidebar, sits below the panel header, and clears the composer entirely.
+ * Rendered into `AgentPanel`'s `#instrument` slot, as a real child of its flex
+ * column directly above the composer — NOT as an overlay. The predecessor was
+ * `fixed right-3 bottom-3` and sat on the composer's submit button, and its
+ * status strip was a block element that pushed the composer below the fold.
+ *
+ * Being a flex sibling is what makes that unrepeatable: the composer is
+ * `shrink-0`, so it claims its intrinsic height before this element is
+ * offered any, and the conversation area above absorbs the difference. An
+ * overlay bounded by a percentage of the panel cannot make that promise —
+ * the composer's height is fixed in pixels, so any percentage reservation
+ * fails below some viewport, silently, on exactly the laptops testers use.
+ *
+ * The OUTER wrapper carries `max-h-1/2` + `min-h-0` and must not be
+ * `shrink-0`. Both halves are load-bearing and were each wrong once: a
+ * percentage max-height resolves against the parent, so putting it on the
+ * inner sheet measured it against this auto-height wrapper and capped
+ * nothing; and a flex item defaults to `min-height: auto`, so without
+ * `min-h-0` the wrapper refuses to shrink below its content and pushes the
+ * composer out of the clipped column — the original bug, reintroduced.
  */
 
 const { status, snapshot } = defineProps<{
@@ -77,8 +101,23 @@ const S = {
     'e.g. "re-adding a node should restore the widget edit made while it was deleted"',
   survivingNodes: 'nodes left',
   survivingWidgets: 'widget values left',
-  verbosity: 'console'
+  verbosity: 'console',
+  sectionInclude: 'Also include in the report (off by default)',
+  includeLogs: 'Server logs',
+  includeSettings: 'Settings',
+  includeWorkflow: 'Workflow JSON',
+  includeHint:
+    'These can carry prompts, file paths and API keys. Read the report before pasting it anywhere.'
 } as const
+
+const REPORT_SOURCE_LABELS: readonly {
+  key: keyof ReportSources
+  label: string
+}[] = [
+  { key: 'serverLogs', label: S.includeLogs },
+  { key: 'settings', label: S.includeSettings },
+  { key: 'workflow', label: S.includeWorkflow }
+]
 
 const STATUS_ROWS = [
   ['doc id', () => status.workflowId ?? S.none],
@@ -135,7 +174,7 @@ function readOpen(): boolean {
 
 function setOpen(value: boolean) {
   open.value = value
-  if (value) poll()
+  if (value) void nextTick(poll)
   try {
     localStorage.setItem(OPEN_KEY, String(value))
   } catch {
@@ -148,7 +187,7 @@ const docState = shallowRef<CrdtDebugSnapshot | null>(null)
 let pollHandle: ReturnType<typeof setInterval> | undefined
 
 function poll() {
-  if (!open.value) return
+  if (!open.value || tab.value !== 'status') return
   docState.value = snapshot?.() ?? null
 }
 
@@ -160,6 +199,8 @@ onMounted(() => {
 onBeforeUnmount(() => {
   if (pollHandle !== undefined) clearInterval(pollHandle)
 })
+
+watch(tab, poll)
 
 const docRows = computed<readonly (readonly [string, string])[]>(() => {
   const state = docState.value
@@ -243,6 +284,7 @@ function verdictLabel(entry: MergeTraceEntry): string {
 
 // ── copy actions ──────────────────────────────────────────────────────────
 const copyState = ref<'idle' | 'busy' | 'done' | 'failed'>('idle')
+const reportSources = ref<ReportSources>({ ...DEFAULT_REPORT_SOURCES })
 
 const copyReportLabel = computed(() => {
   if (copyState.value === 'busy') return S.copying
@@ -292,7 +334,10 @@ async function copyReport() {
       events: devEvents.value,
       testerNote: testerNote.value,
       mergeTrace: simulation.value?.entries,
-      workflow: serializeActiveWorkflow()
+      sources: reportSources.value,
+      workflow: reportSources.value.workflow
+        ? serializeActiveWorkflow()
+        : undefined
     })
     flashCopyState(await writeClipboard(report))
   } catch {
@@ -334,15 +379,22 @@ const chipLabel = computed(
   () => `CRDT ${status.connected ? 'live' : 'off'} · ${status.updatesApplied}`
 )
 
-function fmtDetail(detail: unknown): string {
+function fmtDetail(detail: unknown, limit = 400): string {
   try {
     const raw = JSON.stringify(detail, (_key, value) =>
       value instanceof Uint8Array ? `Uint8Array(${value.length})` : value
     )
-    return raw ?? ''
+    if (raw === undefined) return ''
+    return raw.length > limit ? `${raw.slice(0, limit)}…` : raw
   } catch {
     return String(detail)
   }
+}
+
+function eventDetail(event: DevEvent): string {
+  return expanded.value === event.seq
+    ? fmtDetail(event.detail, 20_000)
+    : fmtDetail(event.detail)
 }
 
 function fmtTime(at: number): string {
@@ -353,13 +405,13 @@ function fmtTime(at: number): string {
 <template>
   <div
     v-if="!dismissed"
-    class="pointer-events-none absolute inset-0 z-50 font-mono text-xs"
+    class="relative flex max-h-[50%] min-h-0 flex-col font-mono text-xs"
   >
     <button
       v-if="!open"
       type="button"
       :title="S.open"
-      class="text-agent-fg-muted border-agent-border bg-agent-surface-raised hover:text-agent-fg hover:bg-agent-surface-hover pointer-events-auto absolute top-12 right-2 flex h-6 cursor-pointer items-center gap-1 rounded-full border px-2 transition-colors"
+      class="text-agent-fg-muted border-agent-border bg-agent-surface-raised hover:text-agent-fg hover:bg-agent-surface-hover absolute right-4 bottom-1 z-10 flex h-6 cursor-pointer items-center gap-1 rounded-full border px-2 transition-colors"
       data-testid="crdt-dev-panel-chip"
       @click="setOpen(true)"
     >
@@ -376,7 +428,7 @@ function fmtTime(at: number): string {
 
     <section
       v-else
-      class="bg-agent-surface border-agent-border text-agent-fg pointer-events-auto absolute inset-x-0 top-12 bottom-1/3 flex flex-col border-y"
+      class="bg-agent-surface border-agent-border text-agent-fg flex min-h-0 grow flex-col overflow-hidden border-y"
       data-testid="crdt-dev-panel"
     >
       <header
@@ -563,7 +615,7 @@ function fmtTime(at: number): string {
                   )
                 "
               >
-                {{ fmtDetail(event.detail) }}
+                {{ eventDetail(event) }}
               </div>
             </button>
           </div>
@@ -701,23 +753,41 @@ function fmtTime(at: number): string {
         </template>
       </div>
 
-      <footer class="border-agent-border flex shrink-0 gap-1 border-t p-2">
-        <button
-          type="button"
-          class="border-agent-border hover:bg-agent-surface-hover flex-1 cursor-pointer rounded-sm border px-2 py-1"
-          @click="copyLog"
-        >
-          {{ S.copyLog }}
-        </button>
-        <button
-          type="button"
-          :disabled="copyState === 'busy'"
-          class="border-agent-accent hover:bg-agent-surface-hover flex-2 cursor-pointer rounded-sm border px-2 py-1 disabled:cursor-default"
-          data-testid="crdt-dev-panel-copy-report"
-          @click="copyReport"
-        >
-          {{ copyReportLabel }}
-        </button>
+      <footer class="border-agent-border shrink-0 border-t p-2">
+        <div class="text-agent-fg-muted mb-1">{{ S.sectionInclude }}</div>
+        <div class="mb-1 flex flex-wrap gap-x-3 gap-y-1">
+          <label
+            v-for="source in REPORT_SOURCE_LABELS"
+            :key="source.key"
+            class="flex cursor-pointer items-center gap-1"
+          >
+            <input
+              v-model="reportSources[source.key]"
+              type="checkbox"
+              :data-testid="`crdt-dev-panel-include-${source.key}`"
+            />
+            {{ source.label }}
+          </label>
+        </div>
+        <p class="text-agent-fg-muted mt-0 mb-2">{{ S.includeHint }}</p>
+        <div class="flex gap-1">
+          <button
+            type="button"
+            class="border-agent-border hover:bg-agent-surface-hover flex-1 cursor-pointer rounded-sm border px-2 py-1"
+            @click="copyLog"
+          >
+            {{ S.copyLog }}
+          </button>
+          <button
+            type="button"
+            :disabled="copyState === 'busy'"
+            class="border-agent-accent hover:bg-agent-surface-hover flex-2 cursor-pointer rounded-sm border px-2 py-1 disabled:cursor-default"
+            data-testid="crdt-dev-panel-copy-report"
+            @click="copyReport"
+          >
+            {{ copyReportLabel }}
+          </button>
+        </div>
       </footer>
     </section>
   </div>

--- a/src/workbench/extensions/agent/crdt/CrdtDevPanel.vue
+++ b/src/workbench/extensions/agent/crdt/CrdtDevPanel.vue
@@ -17,6 +17,7 @@ import type { CrdtLogLevel } from './crdtDebugGate'
 import {
   CRDT_LOG_LEVELS,
   crdtLogLevel,
+  isCrdtDebugEnabled,
   setCrdtDebugEnabled,
   setCrdtLogLevel
 } from './crdtDebugGate'
@@ -160,9 +161,10 @@ const OPEN_KEY = 'Comfy.Agent.CrdtDevPanel.open'
 
 const open = ref(readOpen())
 const tab = ref<'status' | 'log' | 'merge'>('status')
-// The mount gate is read once at panel setup, so hiding must also be local —
-// otherwise "hide" leaves the chip on screen until the next reload.
-const dismissed = ref(false)
+// Seeded from the persisted decision, not from `false`: this component is
+// destroyed and re-created whenever chat history opens, and a per-mount flag
+// would resurrect a chip the tester had explicitly hidden.
+const dismissed = ref(!isCrdtDebugEnabled())
 
 function readOpen(): boolean {
   try {
@@ -207,6 +209,7 @@ const docRows = computed<readonly (readonly [string, string])[]>(() => {
   if (!state) return [['document', S.none]] as const
   return [
     ['schema error', state.schemaError ?? S.none],
+    ['schema version', String(state.meta.schema_version ?? S.none)],
     ['last seq', state.lastSeq === null ? S.none : String(state.lastSeq)],
     ['tab id', state.tabId ?? S.none],
     ['nodes', `${state.nodeIds.length}: ${state.nodeIds.join(', ') || S.none}`],
@@ -405,7 +408,7 @@ function fmtTime(at: number): string {
 <template>
   <div
     v-if="!dismissed"
-    class="relative flex max-h-[50%] min-h-0 flex-col font-mono text-xs"
+    class="relative flex max-h-1/2 min-h-0 flex-col font-mono text-xs"
   >
     <button
       v-if="!open"

--- a/src/workbench/extensions/agent/crdt/CrdtDevPanel.vue
+++ b/src/workbench/extensions/agent/crdt/CrdtDevPanel.vue
@@ -87,7 +87,7 @@ const STATUS_ROWS = [
   ['last frame', () => status.lastFrameType ?? S.none]
 ] as const
 
-const SCOPES: readonly CrdtLogScope[] = ['wire', 'doc', 'ecs', 'ops', 'panel']
+const SCOPES: readonly CrdtLogScope[] = ['wire', 'doc', 'ecs', 'ops']
 
 const EVENT_KINDS: readonly DevEventKind[] = [
   'ws_out',
@@ -135,6 +135,7 @@ function readOpen(): boolean {
 
 function setOpen(value: boolean) {
   open.value = value
+  if (value) poll()
   try {
     localStorage.setItem(OPEN_KEY, String(value))
   } catch {
@@ -287,7 +288,7 @@ async function copyReport() {
   copyState.value = 'busy'
   try {
     const report = await collectCrdtDebugReport({
-      crdt: docState.value ?? fallbackSnapshot(),
+      crdt: snapshot?.() ?? docState.value ?? fallbackSnapshot(),
       events: devEvents.value,
       testerNote: testerNote.value,
       mergeTrace: simulation.value?.entries,
@@ -358,7 +359,7 @@ function fmtTime(at: number): string {
       v-if="!open"
       type="button"
       :title="S.open"
-      class="text-agent-fg-muted border-agent-border bg-agent-surface-raised hover:text-agent-fg hover:bg-agent-surface-hover pointer-events-auto absolute top-10 right-2 flex h-6 cursor-pointer items-center gap-1 rounded-full border px-2 transition-colors"
+      class="text-agent-fg-muted border-agent-border bg-agent-surface-raised hover:text-agent-fg hover:bg-agent-surface-hover pointer-events-auto absolute top-12 right-2 flex h-6 cursor-pointer items-center gap-1 rounded-full border px-2 transition-colors"
       data-testid="crdt-dev-panel-chip"
       @click="setOpen(true)"
     >
@@ -375,7 +376,7 @@ function fmtTime(at: number): string {
 
     <section
       v-else
-      class="bg-agent-surface border-agent-border text-agent-fg pointer-events-auto absolute inset-x-0 top-10 bottom-0 flex flex-col border-t"
+      class="bg-agent-surface border-agent-border text-agent-fg pointer-events-auto absolute inset-x-0 top-12 bottom-1/3 flex flex-col border-y"
       data-testid="crdt-dev-panel"
     >
       <header
@@ -601,7 +602,7 @@ function fmtTime(at: number): string {
             <ol class="space-y-2" data-testid="crdt-dev-panel-trace">
               <li
                 v-for="entry in simulation.entries"
-                :key="entry.opId"
+                :key="entry.index"
                 class="border-agent-border border-l-2 pl-2"
               >
                 <div class="flex flex-wrap items-baseline gap-1">
@@ -647,7 +648,7 @@ function fmtTime(at: number): string {
                 <div class="font-bold">{{ group.label }}</div>
                 <div
                   v-for="entry in group.entries"
-                  :key="entry.opId"
+                  :key="entry.index"
                   class="text-agent-fg-muted pl-2"
                 >
                   {{ entry.kind }} · {{ entry.actor }} ·
@@ -662,7 +663,7 @@ function fmtTime(at: number): string {
               </div>
               <div
                 v-for="row in lifecycle"
-                :key="`${row.nodeId}-${row.entry.opId}`"
+                :key="`${row.nodeId}-${row.entry.index}`"
                 class="text-agent-fg-muted"
               >
                 {{ lifecycleLine(row) }}

--- a/src/workbench/extensions/agent/crdt/RUN-CLOUD-E2E.md
+++ b/src/workbench/extensions/agent/crdt/RUN-CLOUD-E2E.md
@@ -28,8 +28,10 @@ agent panel, so the panel's product flag is the only gate.
 
 ## Verify
 
-- The status strip at the top of the agent panel (`data-testid="agent-crdt-status"`)
-  shows connected + the subscribed workflow id.
+- The CRDT chip in the agent panel's title row (`data-testid="crdt-dev-panel-chip"`)
+  shows a green dot + the applied-update count. Click it and read the Status tab
+  for the subscribed doc id, last seq and schema state. On a build where
+  `import.meta.env.DEV` is false, append `?crdtDebug=1` to the URL first.
 - Send a message in the agent chat; as the agent edits, `updatesApplied` increments and
   nodes move on the canvas.
 - Reload the tab mid-session: it resubscribes and reconverges from the seeded snapshot.

--- a/src/workbench/extensions/agent/crdt/crdtDebugGate.test.ts
+++ b/src/workbench/extensions/agent/crdt/crdtDebugGate.test.ts
@@ -44,4 +44,32 @@ describe('crdtDebugGate', () => {
 
     expect(gate.isLevelEnabled('warn')).toBe(true)
   })
+
+  it('does not reset a verbosity the tester chose in the panel', async () => {
+    const gate = await loadGate('?crdtDebug=1')
+    gate.setCrdtLogLevel('trace')
+
+    // Reloading the same handed-out link is how a subscribe bug gets
+    // reproduced; it must not silently drop the tester back to `info`.
+    const afterReload = await loadGate('?crdtDebug=1')
+    expect(afterReload.crdtLogLevel()).toBe('trace')
+  })
+
+  it('lets a later dismissal survive a reload of the same link', async () => {
+    const gate = await loadGate('?crdtDebug=1')
+    expect(window.location.search).not.toContain('crdtDebug')
+
+    gate.setCrdtDebugEnabled(false)
+
+    const afterReload = await loadGate(window.location.search)
+    expect(afterReload.isCrdtDebugEnabled()).toBe(false)
+  })
+
+  it('ignores an empty parameter instead of treating it as enable', async () => {
+    const disabled = await loadGate('?crdtDebug=0')
+    expect(disabled.isCrdtDebugEnabled()).toBe(false)
+
+    const empty = await loadGate('?crdtDebug=')
+    expect(empty.isCrdtDebugEnabled()).toBe(false)
+  })
 })

--- a/src/workbench/extensions/agent/crdt/crdtDebugGate.test.ts
+++ b/src/workbench/extensions/agent/crdt/crdtDebugGate.test.ts
@@ -1,0 +1,47 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+async function loadGate(search: string) {
+  vi.resetModules()
+  window.history.replaceState({}, '', `/${search}`)
+  return import('./crdtDebugGate')
+}
+
+describe('crdtDebugGate', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('lets a tester enable the instrument from a link, and remembers it', async () => {
+    await loadGate('?crdtDebug=1')
+    const afterReload = await loadGate('')
+
+    expect(afterReload.isCrdtDebugEnabled()).toBe(true)
+  })
+
+  it('honours an explicit opt-out even where DEV would enable it', async () => {
+    const gate = await loadGate('?crdtDebug=0')
+
+    expect(gate.isCrdtDebugEnabled()).toBe(false)
+  })
+
+  it('takes the console verbosity from the same link', async () => {
+    const gate = await loadGate('?crdtDebug=trace')
+
+    expect(gate.crdtLogLevel()).toBe('trace')
+    expect(gate.isLevelEnabled('trace')).toBe(true)
+  })
+
+  it('keeps the panel and the console independent', async () => {
+    const gate = await loadGate('?crdtDebug=1')
+
+    expect(gate.isCrdtDebugEnabled()).toBe(true)
+    expect(gate.isLevelEnabled('trace')).toBe(false)
+    expect(gate.isLevelEnabled('info')).toBe(true)
+  })
+
+  it('never silences a warning, even fully opted out', async () => {
+    const gate = await loadGate('?crdtDebug=0')
+
+    expect(gate.isLevelEnabled('warn')).toBe(true)
+  })
+})

--- a/src/workbench/extensions/agent/crdt/crdtDebugGate.ts
+++ b/src/workbench/extensions/agent/crdt/crdtDebugGate.ts
@@ -1,0 +1,113 @@
+/**
+ * Who may see the CRDT debug instrument, and how loud it is.
+ *
+ * The instrument used to be gated on `import.meta.env.DEV` alone, which is the
+ * wrong audience: the people who need it are product testers driving a
+ * STAGING build, where `DEV` is false. Opt-in is therefore explicit and
+ * sticky — `?crdtDebug=1` turns it on for the origin until `?crdtDebug=0`
+ * turns it off — so a tester can be handed a link rather than a build.
+ *
+ * Verbosity is a separate axis on purpose. Turning the panel on should not
+ * also flood the console: `?crdtDebug=trace` opts into the per-frame chatter,
+ * while plain `1` keeps console output at the lifecycle level.
+ */
+const ENABLED_KEY = 'Comfy.Agent.CrdtDebug.enabled'
+const LEVEL_KEY = 'Comfy.Agent.CrdtDebug.level'
+const QUERY_PARAM = 'crdtDebug'
+
+/**
+ * Console verbosity, ordered least-to-most chatty. `warn` is the floor: a
+ * follower that refuses a doc or drops a human mint says so in every build,
+ * because a silent divergence is the failure the whole instrument exists to
+ * make visible.
+ */
+export const CRDT_LOG_LEVELS = ['warn', 'info', 'debug', 'trace'] as const
+
+export type CrdtLogLevel = (typeof CRDT_LOG_LEVELS)[number]
+
+const DEFAULT_LEVEL: CrdtLogLevel = 'info'
+
+function isLogLevel(value: unknown): value is CrdtLogLevel {
+  return (CRDT_LOG_LEVELS as readonly unknown[]).includes(value)
+}
+
+function readStorage(key: string): string | null {
+  try {
+    return window.localStorage.getItem(key)
+  } catch {
+    return null
+  }
+}
+
+function writeStorage(key: string, value: string | null): void {
+  try {
+    if (value === null) window.localStorage.removeItem(key)
+    else window.localStorage.setItem(key, value)
+  } catch {
+    // Private mode / quota: the override simply does not persist.
+  }
+}
+
+function readQueryParam(): string | null {
+  try {
+    return new URLSearchParams(window.location.search).get(QUERY_PARAM)
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Fold `?crdtDebug=…` into storage exactly once per load, so the choice
+ * survives the reloads a debugging session is made of.
+ *
+ * Accepts `0`/`false`/`off` to disable, a level name to enable at that level,
+ * and anything else truthy to enable at the default level.
+ */
+function applyQueryOverride(): void {
+  const raw = readQueryParam()
+  if (raw === null) return
+  const value = raw.trim().toLowerCase()
+  if (value === '0' || value === 'false' || value === 'off') {
+    writeStorage(ENABLED_KEY, 'false')
+    return
+  }
+  writeStorage(ENABLED_KEY, 'true')
+  writeStorage(LEVEL_KEY, isLogLevel(value) ? value : DEFAULT_LEVEL)
+}
+
+applyQueryOverride()
+
+/**
+ * Whether the CRDT debug instrument (panel + console tracing) is available.
+ *
+ * An explicit opt-out wins over `DEV` so a developer chasing a rendering bug
+ * can silence the instrument without editing code.
+ */
+export function isCrdtDebugEnabled(): boolean {
+  const stored = readStorage(ENABLED_KEY)
+  if (stored === 'true') return true
+  if (stored === 'false') return false
+  return import.meta.env.DEV
+}
+
+export function setCrdtDebugEnabled(enabled: boolean): void {
+  writeStorage(ENABLED_KEY, String(enabled))
+}
+
+export function crdtLogLevel(): CrdtLogLevel {
+  const stored = readStorage(LEVEL_KEY)
+  return isLogLevel(stored) ? stored : DEFAULT_LEVEL
+}
+
+export function setCrdtLogLevel(level: CrdtLogLevel): void {
+  writeStorage(LEVEL_KEY, level)
+}
+
+/** Whether `level` should reach the console at the current verbosity. */
+export function isLevelEnabled(level: CrdtLogLevel): boolean {
+  if (level === 'warn') return true
+  if (!isCrdtDebugEnabled()) return false
+  return (
+    CRDT_LOG_LEVELS.indexOf(level) <= CRDT_LOG_LEVELS.indexOf(crdtLogLevel())
+  )
+}

--- a/src/workbench/extensions/agent/crdt/crdtDebugGate.ts
+++ b/src/workbench/extensions/agent/crdt/crdtDebugGate.ts
@@ -27,6 +27,18 @@ export type CrdtLogLevel = (typeof CRDT_LOG_LEVELS)[number]
 
 const DEFAULT_LEVEL: CrdtLogLevel = 'info'
 
+/**
+ * Cached because {@link isLevelEnabled} runs on the CRDT hot path — once per
+ * outbound frame, per applied frame and per minted op — and an uncached read
+ * would put a synchronous `localStorage.getItem` on each of them, for
+ * opted-out users most of all. Only the setters below change either value.
+ *
+ * Declared here, above `applyQueryOverride()`'s module-evaluation call, so the
+ * setters it invokes are not reaching into a temporal dead zone.
+ */
+let cachedEnabled: boolean | null = null
+let cachedLevel: CrdtLogLevel | null = null
+
 function isLogLevel(value: unknown): value is CrdtLogLevel {
   return (CRDT_LOG_LEVELS as readonly unknown[]).includes(value)
 }
@@ -76,8 +88,8 @@ function applyQueryOverride(): void {
   const value = raw.trim().toLowerCase()
   if (value === '') return
   const disabling = value === '0' || value === 'false' || value === 'off'
-  writeStorage(ENABLED_KEY, disabling ? 'false' : 'true')
-  if (!disabling && isLogLevel(value)) writeStorage(LEVEL_KEY, value)
+  setCrdtDebugEnabled(!disabling)
+  if (!disabling && isLogLevel(value)) setCrdtLogLevel(value)
   consumeQueryParam()
 }
 
@@ -100,22 +112,33 @@ applyQueryOverride()
  * can silence the instrument without editing code.
  */
 export function isCrdtDebugEnabled(): boolean {
-  const stored = readStorage(ENABLED_KEY)
-  if (stored === 'true') return true
-  if (stored === 'false') return false
-  return import.meta.env.DEV
+  if (cachedEnabled === null) {
+    const stored = readStorage(ENABLED_KEY)
+    cachedEnabled =
+      stored === 'true'
+        ? true
+        : stored === 'false'
+          ? false
+          : import.meta.env.DEV
+  }
+  return cachedEnabled
 }
 
 export function setCrdtDebugEnabled(enabled: boolean): void {
+  cachedEnabled = enabled
   writeStorage(ENABLED_KEY, String(enabled))
 }
 
 export function crdtLogLevel(): CrdtLogLevel {
-  const stored = readStorage(LEVEL_KEY)
-  return isLogLevel(stored) ? stored : DEFAULT_LEVEL
+  if (cachedLevel === null) {
+    const stored = readStorage(LEVEL_KEY)
+    cachedLevel = isLogLevel(stored) ? stored : DEFAULT_LEVEL
+  }
+  return cachedLevel
 }
 
 export function setCrdtLogLevel(level: CrdtLogLevel): void {
+  cachedLevel = level
   writeStorage(LEVEL_KEY, level)
 }
 

--- a/src/workbench/extensions/agent/crdt/crdtDebugGate.ts
+++ b/src/workbench/extensions/agent/crdt/crdtDebugGate.ts
@@ -129,6 +129,16 @@ export function setCrdtDebugEnabled(enabled: boolean): void {
   writeStorage(ENABLED_KEY, String(enabled))
 }
 
+/**
+ * Whether the user turned the instrument OFF, as opposed to never having said.
+ * The ring buffer records for the never-said case — a tester who opens the
+ * panel after something breaks needs the run-up — but an explicit "off" should
+ * buy silence, not just a quiet console.
+ */
+export function isCrdtDebugOptedOut(): boolean {
+  return !isCrdtDebugEnabled() && readStorage(ENABLED_KEY) === 'false'
+}
+
 export function crdtLogLevel(): CrdtLogLevel {
   if (cachedLevel === null) {
     const stored = readStorage(LEVEL_KEY)

--- a/src/workbench/extensions/agent/crdt/crdtDebugGate.ts
+++ b/src/workbench/extensions/agent/crdt/crdtDebugGate.ts
@@ -61,18 +61,34 @@ function readQueryParam(): string | null {
  * survives the reloads a debugging session is made of.
  *
  * Accepts `0`/`false`/`off` to disable, a level name to enable at that level,
- * and anything else truthy to enable at the default level.
+ * and any other non-empty value to enable at the current level.
+ *
+ * Two things it deliberately does NOT do. It never writes the level unless
+ * the parameter names one — otherwise reloading a bookmarked `?crdtDebug=1`
+ * would silently reset a verbosity the tester chose in the panel, on the
+ * reload that reproducing a subscribe bug requires. And it strips itself from
+ * the URL afterwards, so a later "hide" is not undone by the next reload of
+ * the same link: the parameter is an instruction, not a standing order.
  */
 function applyQueryOverride(): void {
   const raw = readQueryParam()
   if (raw === null) return
   const value = raw.trim().toLowerCase()
-  if (value === '0' || value === 'false' || value === 'off') {
-    writeStorage(ENABLED_KEY, 'false')
-    return
+  if (value === '') return
+  const disabling = value === '0' || value === 'false' || value === 'off'
+  writeStorage(ENABLED_KEY, disabling ? 'false' : 'true')
+  if (!disabling && isLogLevel(value)) writeStorage(LEVEL_KEY, value)
+  consumeQueryParam()
+}
+
+function consumeQueryParam(): void {
+  try {
+    const url = new URL(window.location.href)
+    url.searchParams.delete(QUERY_PARAM)
+    window.history.replaceState(window.history.state, '', url)
+  } catch {
+    // No History API (or an opaque origin): the flag simply stays in the URL.
   }
-  writeStorage(ENABLED_KEY, 'true')
-  writeStorage(LEVEL_KEY, isLogLevel(value) ? value : DEFAULT_LEVEL)
 }
 
 applyQueryOverride()

--- a/src/workbench/extensions/agent/crdt/crdtDebugReport.test.ts
+++ b/src/workbench/extensions/agent/crdt/crdtDebugReport.test.ts
@@ -1,0 +1,115 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const getSystemStats = vi.fn()
+const getLogs = vi.fn()
+const getSettings = vi.fn()
+
+vi.mock('@/scripts/api', () => ({
+  api: {
+    getSystemStats: () => getSystemStats(),
+    getLogs: () => getLogs(),
+    getSettings: () => getSettings(),
+    apiURL: (path: string) => `http://backend${path}`
+  }
+}))
+
+vi.mock('@/stores/extensionStore', () => ({
+  useExtensionStore: () => ({ extensions: [{ name: 'Comfy.TestExtension' }] })
+}))
+
+import type { CrdtDebugSnapshot } from './crdtDebugReport'
+import { collectCrdtDebugReport } from './crdtDebugReport'
+
+const SNAPSHOT: CrdtDebugSnapshot = {
+  status: {
+    enabled: true,
+    connected: true,
+    workflowId: 'doc-1',
+    updatesApplied: 3,
+    lastFrameType: 'doc_update'
+  },
+  tabId: 'tab-1',
+  lastSeq: 7,
+  schemaError: null,
+  meta: { schema_version: 1 },
+  nodeIds: ['A', 'B'],
+  linkIds: ['1'],
+  appliedOpIds: ['op1'],
+  stamps: { '["widget","A","text"]': [1, 'human:u:t', 'op1'] }
+}
+
+describe('collectCrdtDebugReport', () => {
+  beforeEach(() => {
+    getSystemStats.mockResolvedValue({
+      system: {
+        os: 'linux',
+        python_version: '3.12',
+        embedded_python: false,
+        comfyui_version: 'v1',
+        pytorch_version: '2.4',
+        argv: ['main.py'],
+        ram_total: 2,
+        ram_free: 1
+      },
+      devices: []
+    })
+    getLogs.mockResolvedValue('backend log line')
+    getSettings.mockResolvedValue({ 'Comfy.Setting': true })
+  })
+
+  it('gathers backend, frontend and CRDT context into one artifact', async () => {
+    const report = await collectCrdtDebugReport({
+      crdt: SNAPSHOT,
+      events: [
+        {
+          seq: 1,
+          at: 0,
+          kind: 'doc_update',
+          scope: 'doc',
+          level: 'info',
+          detail: null
+        }
+      ]
+    })
+
+    expect(report).toContain('backend log line')
+    expect(report).toContain('Comfy.TestExtension')
+    expect(report).toContain('Comfy.Setting')
+    expect(report).toContain('doc-1')
+    expect(report).toContain('doc_update')
+    expect(report).toContain('Document stamps')
+  })
+
+  it("puts the tester's own words about expected merge behaviour first", async () => {
+    const report = await collectCrdtDebugReport({
+      crdt: SNAPSHOT,
+      events: [],
+      testerNote: 're-adding a node should restore my widget edit'
+    })
+
+    expect(report).toContain('re-adding a node should restore my widget edit')
+    expect(report.indexOf('What the tester expected')).toBeLessThan(
+      report.indexOf('## System')
+    )
+  })
+
+  it('still produces a report when the backend is the thing that is broken', async () => {
+    getLogs.mockRejectedValue(new Error('backend unreachable'))
+    getSystemStats.mockRejectedValue(new Error('backend unreachable'))
+
+    const report = await collectCrdtDebugReport({ crdt: SNAPSHOT, events: [] })
+
+    expect(report).toContain('backend unreachable')
+    expect(report).toContain('doc-1')
+  })
+
+  it('omits an oversized workflow rather than producing an unpasteable report', async () => {
+    const report = await collectCrdtDebugReport({
+      crdt: SNAPSHOT,
+      events: [],
+      workflow: { nodes: Array.from({ length: 5000 }, (_, i) => ({ id: i })) }
+    })
+
+    expect(report).toContain('workflow omitted')
+  })
+})

--- a/src/workbench/extensions/agent/crdt/crdtDebugReport.test.ts
+++ b/src/workbench/extensions/agent/crdt/crdtDebugReport.test.ts
@@ -17,7 +17,8 @@ vi.mock('@/stores/extensionStore', () => ({
   useExtensionStore: () => ({ extensions: [{ name: 'Comfy.TestExtension' }] })
 }))
 
-import type { CrdtDebugSnapshot, ReportSources } from './crdtDebugReport'
+import type { ReportSources } from './crdtDebugReport'
+import type { CrdtDebugSnapshot } from './crdtSnapshot'
 import { collectCrdtDebugReport } from './crdtDebugReport'
 
 const ALL_SOURCES: ReportSources = {

--- a/src/workbench/extensions/agent/crdt/crdtDebugReport.test.ts
+++ b/src/workbench/extensions/agent/crdt/crdtDebugReport.test.ts
@@ -195,12 +195,62 @@ describe('collectCrdtDebugReport', () => {
     expect(report).toContain('doc-1')
   })
 
+  it('keeps redacting argv when the rest of the payload is malformed', async () => {
+    // A fallback that dumped the raw payload on any render error put the
+    // secret back on the clipboard, and `## System` has no opt-in to catch it.
+    getSystemStats.mockResolvedValue({
+      system: { argv: ['main.py', '--api-token', 'argv-do-not-leak'] },
+      devices: undefined
+    })
+
+    const report = await collectCrdtDebugReport({ crdt: SNAPSHOT, events: [] })
+
+    expect(report).not.toContain('argv-do-not-leak')
+    expect(report).toContain('## System')
+  })
+
+  it('redacts private paths without eating the argument after them', async () => {
+    getSystemStats.mockResolvedValue({
+      system: {
+        argv: [
+          'main.py',
+          '--extra-model-paths-config',
+          '/home/jsmith/private-do-not-leak.yaml',
+          '--port',
+          '8188',
+          '--cpu'
+        ]
+      },
+      devices: []
+    })
+
+    const report = await collectCrdtDebugReport({ crdt: SNAPSHOT, events: [] })
+
+    expect(report).not.toContain('private-do-not-leak')
+    expect(report).toContain('--port 8188')
+    expect(report).toContain('--cpu')
+  })
+
+  it('does not let a log line close the code fence around it', async () => {
+    getLogs.mockResolvedValue('traceback ``` still inside the fence')
+
+    const report = await collectCrdtDebugReport({
+      crdt: SNAPSHOT,
+      events: [],
+      sources: ALL_SOURCES
+    })
+
+    const afterHeading = report.slice(report.indexOf('## Server logs'))
+    const opener = afterHeading.slice(afterHeading.indexOf('`'))
+    expect(opener.startsWith('````')).toBe(true)
+  })
+
   it('omits an oversized workflow rather than producing an unpasteable report', async () => {
     const report = await collectCrdtDebugReport({
       crdt: SNAPSHOT,
       events: [],
       sources: ALL_SOURCES,
-      workflow: { nodes: Array.from({ length: 5000 }, (_, i) => ({ id: i })) }
+      workflow: { nodes: Array.from({ length: 40_000 }, (_, i) => ({ id: i })) }
     })
 
     expect(report).toContain('workflow omitted')

--- a/src/workbench/extensions/agent/crdt/crdtDebugReport.test.ts
+++ b/src/workbench/extensions/agent/crdt/crdtDebugReport.test.ts
@@ -17,8 +17,14 @@ vi.mock('@/stores/extensionStore', () => ({
   useExtensionStore: () => ({ extensions: [{ name: 'Comfy.TestExtension' }] })
 }))
 
-import type { CrdtDebugSnapshot } from './crdtDebugReport'
+import type { CrdtDebugSnapshot, ReportSources } from './crdtDebugReport'
 import { collectCrdtDebugReport } from './crdtDebugReport'
+
+const ALL_SOURCES: ReportSources = {
+  serverLogs: true,
+  settings: true,
+  workflow: true
+}
 
 const SNAPSHOT: CrdtDebugSnapshot = {
   status: {
@@ -60,6 +66,7 @@ describe('collectCrdtDebugReport', () => {
   it('gathers backend, frontend and CRDT context into one artifact', async () => {
     const report = await collectCrdtDebugReport({
       crdt: SNAPSHOT,
+      sources: ALL_SOURCES,
       events: [
         {
           seq: 1,
@@ -110,12 +117,72 @@ describe('collectCrdtDebugReport', () => {
       'Other.auth_token': 'do-not-leak-either'
     })
 
-    const report = await collectCrdtDebugReport({ crdt: SNAPSHOT, events: [] })
+    const report = await collectCrdtDebugReport({
+      crdt: SNAPSHOT,
+      events: [],
+      sources: ALL_SOURCES
+    })
 
     expect(report).not.toContain('sk-live-do-not-leak')
     expect(report).not.toContain('do-not-leak-either')
     expect(report).toContain('dark')
     expect(report).toContain('Review before sharing')
+  })
+
+  it('leaves logs, settings and the workflow out unless the tester opts in', async () => {
+    getSettings.mockResolvedValue({ 'Comfy.Theme': 'do-not-leak-settings' })
+    getLogs.mockResolvedValue('do-not-leak-logs')
+
+    const report = await collectCrdtDebugReport({
+      crdt: SNAPSHOT,
+      events: [],
+      workflow: { nodes: [{ id: 'do-not-leak-workflow' }] }
+    })
+
+    expect(report).not.toContain('do-not-leak-settings')
+    expect(report).not.toContain('do-not-leak-logs')
+    expect(report).not.toContain('do-not-leak-workflow')
+    expect(report).toContain('did not opt in')
+    // The parts that are the point of the feature still ship.
+    expect(report).toContain('## CRDT state')
+    expect(report).toContain('## System')
+  })
+
+  it('redacts a credential nested under an innocuous key', async () => {
+    getSettings.mockResolvedValue({
+      'Comfy.Server.LaunchArgs': { '--api-token': 'nested-do-not-leak' },
+      'Some.List': [{ password: 'listed-do-not-leak' }]
+    })
+
+    const report = await collectCrdtDebugReport({
+      crdt: SNAPSHOT,
+      events: [],
+      sources: ALL_SOURCES
+    })
+
+    expect(report).not.toContain('nested-do-not-leak')
+    expect(report).not.toContain('listed-do-not-leak')
+  })
+
+  it('blanks a secret passed on the server command line', async () => {
+    getSystemStats.mockResolvedValue({
+      system: {
+        os: 'linux',
+        python_version: '3.12',
+        embedded_python: false,
+        comfyui_version: 'v1',
+        pytorch_version: '2.4',
+        argv: ['main.py', '--api-token', 'argv-do-not-leak', '--cpu'],
+        ram_total: 2,
+        ram_free: 1
+      },
+      devices: []
+    })
+
+    const report = await collectCrdtDebugReport({ crdt: SNAPSHOT, events: [] })
+
+    expect(report).not.toContain('argv-do-not-leak')
+    expect(report).toContain('--cpu')
   })
 
   it('renders the report even when /system_stats answers with an unexpected shape', async () => {
@@ -131,6 +198,7 @@ describe('collectCrdtDebugReport', () => {
     const report = await collectCrdtDebugReport({
       crdt: SNAPSHOT,
       events: [],
+      sources: ALL_SOURCES,
       workflow: { nodes: Array.from({ length: 5000 }, (_, i) => ({ id: i })) }
     })
 

--- a/src/workbench/extensions/agent/crdt/crdtDebugReport.test.ts
+++ b/src/workbench/extensions/agent/crdt/crdtDebugReport.test.ts
@@ -103,6 +103,30 @@ describe('collectCrdtDebugReport', () => {
     expect(report).toContain('doc-1')
   })
 
+  it('redacts credential-shaped setting values and says the section needs review', async () => {
+    getSettings.mockResolvedValue({
+      'Comfy.Theme': 'dark',
+      'MyNodePack.apiKey': 'sk-live-do-not-leak',
+      'Other.auth_token': 'do-not-leak-either'
+    })
+
+    const report = await collectCrdtDebugReport({ crdt: SNAPSHOT, events: [] })
+
+    expect(report).not.toContain('sk-live-do-not-leak')
+    expect(report).not.toContain('do-not-leak-either')
+    expect(report).toContain('dark')
+    expect(report).toContain('Review before sharing')
+  })
+
+  it('renders the report even when /system_stats answers with an unexpected shape', async () => {
+    getSystemStats.mockResolvedValue({ system: {}, devices: undefined })
+
+    const report = await collectCrdtDebugReport({ crdt: SNAPSHOT, events: [] })
+
+    expect(report).toContain('## System')
+    expect(report).toContain('doc-1')
+  })
+
   it('omits an oversized workflow rather than producing an unpasteable report', async () => {
     const report = await collectCrdtDebugReport({
       crdt: SNAPSHOT,

--- a/src/workbench/extensions/agent/crdt/crdtDebugReport.ts
+++ b/src/workbench/extensions/agent/crdt/crdtDebugReport.ts
@@ -29,7 +29,7 @@ import type { MergeTraceEntry } from './mergeTrace'
 
 /** Server logs beyond this are tail-trimmed; a paste has to stay pasteable. */
 const MAX_LOG_CHARS = 40_000
-const MAX_WORKFLOW_CHARS = 20_000
+const MAX_WORKFLOW_CHARS = 200_000
 /** The event log and the stamp ledger both grow without bound with session length. */
 const MAX_SECTION_CHARS = 60_000
 
@@ -73,10 +73,16 @@ function redactSecrets(value: unknown, depth = 0): unknown {
 /**
  * The sources a tester must opt into.
  *
- * The panel this replaced shipped all three unconditionally. The dialog
- * DELETED in #5259 did not: it listed them as unchecked opt-ins under "what
- * can we include", and restoring the collection without restoring that choice
- * would be a privacy regression dressed as a feature.
+ * The panel this replaced shipped everything unconditionally. The dialog
+ * DELETED in #5259 did not: it listed Workflow, Logs, Settings AND SystemStats
+ * as unchecked opt-ins under "what can we include", and restoring the
+ * collection without restoring that choice would be a privacy regression
+ * dressed as a feature.
+ *
+ * SystemStats is deliberately NOT gated here: it is the "copy system stats"
+ * capability this report exists to provide, and the only privacy-bearing part
+ * of it — `argv` — is redacted by {@link redactArgv} instead. Versions, OS and
+ * RAM carry nothing a tester would withhold.
  */
 export interface ReportSources {
   serverLogs: boolean
@@ -112,7 +118,15 @@ async function attempt<T>(label: string, load: () => Promise<T>) {
 }
 
 function fence(language: string, body: string): string {
-  return ['```' + language, body, '```'].join('\n')
+  // Server logs and workflow JSON are untrusted text: a body containing its
+  // own fence would otherwise terminate the block early and let the rest of
+  // the payload render as markdown.
+  const longestRun = Math.max(
+    0,
+    ...[...body.matchAll(/`+/g)].map((match) => match[0].length)
+  )
+  const delimiter = '`'.repeat(Math.max(3, longestRun + 1))
+  return [delimiter + language, body, delimiter].join('\n')
 }
 
 function json(value: unknown): string {
@@ -130,43 +144,62 @@ function truncate(text: string, max: number): string {
 
 type SystemStats = Awaited<ReturnType<typeof api.getSystemStats>>
 
-/** `--api-token <value>`: the flag names the secret, so blank the value after it. */
+/**
+ * A value is anything not starting with `-`; only a leading dash makes a token
+ * a flag. Pattern-testing every token instead treated `/home/me/private/x` as
+ * a flag — leaking it and blanking the harmless argument after it.
+ *
+ * Two rules: a credential-shaped FLAG blanks its value, and a value that looks
+ * like an absolute path or a URL is blanked whatever names it, because
+ * `--output-directory` and `--extra-model-paths-config` carry private paths
+ * under a flag no credential pattern matches.
+ */
+const PRIVATE_VALUE_PATTERN = /^(\/|~|[A-Za-z]:[\\/])|:\/\//
+
 function redactArgv(argv: readonly string[]): string {
   const parts: string[] = []
-  let redactNext = false
+  let flagWantsSecretValue = false
+
   for (const arg of argv) {
-    if (redactNext && !arg.startsWith('-')) {
-      parts.push(REDACTED)
-      redactNext = false
+    if (!arg.startsWith('-')) {
+      const secret = flagWantsSecretValue || PRIVATE_VALUE_PATTERN.test(arg)
+      parts.push(secret ? REDACTED : arg)
+      flagWantsSecretValue = false
       continue
     }
     const [flag, inlineValue] = arg.split('=', 2)
-    const named = SECRET_KEY_PATTERN.test(flag)
-    // An inline `--token=x` already consumed its value; only a bare flag can
-    // put the secret in the NEXT argument.
-    redactNext = named && inlineValue === undefined
-    parts.push(named && inlineValue !== undefined ? `${flag}=${REDACTED}` : arg)
+    if (inlineValue !== undefined) {
+      const secret =
+        SECRET_KEY_PATTERN.test(flag) || PRIVATE_VALUE_PATTERN.test(inlineValue)
+      parts.push(secret ? `${flag}=${REDACTED}` : arg)
+      flagWantsSecretValue = false
+      continue
+    }
+    parts.push(arg)
+    flagWantsSecretValue = SECRET_KEY_PATTERN.test(flag)
   }
   return parts.join(' ')
 }
 
 function systemSection(stats: SystemStats): string {
+  const system: Partial<SystemStats['system']> = stats.system ?? {}
+  const devices = Array.isArray(stats.devices) ? stats.devices : []
   const lines = [
-    `- **ComfyUI version:** ${stats.system.comfyui_version}`,
-    `- **OS:** ${stats.system.os}`,
-    `- **Python:** ${stats.system.python_version}`,
-    `- **Embedded Python:** ${stats.system.embedded_python}`,
-    `- **PyTorch:** ${stats.system.pytorch_version}`,
-    `- **Arguments:** ${redactArgv(stats.system.argv)}`,
-    `- **RAM:** ${stats.system.ram_free} free / ${stats.system.ram_total} total`
+    `- **ComfyUI version:** ${system.comfyui_version ?? '?'}`,
+    `- **OS:** ${system.os ?? '?'}`,
+    `- **Python:** ${system.python_version ?? '?'}`,
+    `- **Embedded Python:** ${system.embedded_python ?? '?'}`,
+    `- **PyTorch:** ${system.pytorch_version ?? '?'}`,
+    `- **Arguments:** ${redactArgv(system.argv ?? [])}`,
+    `- **RAM:** ${system.ram_free ?? '?'} free / ${system.ram_total ?? '?'} total`
   ]
-  if (stats.system.cloud_version)
-    lines.push(`- **Cloud version:** ${stats.system.cloud_version}`)
-  if (stats.system.comfyui_frontend_version)
+  if (system.cloud_version)
+    lines.push(`- **Cloud version:** ${system.cloud_version}`)
+  if (system.comfyui_frontend_version)
     lines.push(
-      `- **Frontend (reported by backend):** ${stats.system.comfyui_frontend_version}`
+      `- **Frontend (reported by backend):** ${system.comfyui_frontend_version}`
     )
-  for (const device of stats.devices) {
+  for (const device of devices) {
     lines.push(
       `- **Device ${device.index ?? '?'}:** ${device.name} (${device.type}) — VRAM ${device.vram_free} free / ${device.vram_total} total, torch ${device.torch_vram_free} / ${device.torch_vram_total}`
     )
@@ -197,25 +230,6 @@ function mergeSection(entries: readonly MergeTraceEntry[]): string {
         `${entry.index + 1}. \`${entry.kind}\` by ${entry.actor} on ${entry.registerLabel} → **${entry.verdict.kind}**\n   ${entry.explanation}`
     )
     .join('\n')
-}
-
-/**
- * `systemSection` reads fields off an unvalidated `/system_stats` payload, so
- * a backend that answers 200 with a different shape would throw straight out
- * of the collector — losing the entire report at exactly the moment the
- * backend is the thing being reported on.
- */
-function renderSystem(
-  stats:
-    | { label: string; ok: true; value: SystemStats }
-    | { label: string; ok: false; error: string }
-): string {
-  if (!stats.ok) return `_${stats.label} unavailable: ${stats.error}_`
-  try {
-    return systemSection(stats.value)
-  } catch (error) {
-    return `_${stats.label} could not be rendered (${String(error)}); raw payload:_\n${fence('json', json(stats.value))}`
-  }
 }
 
 /**
@@ -276,7 +290,12 @@ export async function collectCrdtDebugReport(
     ].join('\n')
   )
 
-  sections.push('## System', renderSystem(stats))
+  sections.push(
+    '## System',
+    stats.ok
+      ? systemSection(stats.value)
+      : `_${stats.label} unavailable: ${stats.error}_`
+  )
 
   sections.push(
     '## CRDT event log',

--- a/src/workbench/extensions/agent/crdt/crdtDebugReport.ts
+++ b/src/workbench/extensions/agent/crdt/crdtDebugReport.ts
@@ -1,0 +1,292 @@
+/**
+ * The one-click bug report.
+ *
+ * The frontend used to ship a `ReportIssuePanel` that gathered system stats,
+ * server logs, settings and the workflow behind opt-in checkboxes and posted
+ * the bundle to Sentry; it was deleted when support moved to Zendesk (#5259),
+ * and with it went the only path from "something is wrong" to "here is
+ * everything an engineer needs". The panel's `Copy JSON` replacement carried
+ * the CRDT event log and nothing else — no versions, no logs, no custom
+ * nodes — so every CRDT report arrived needing a follow-up round trip.
+ *
+ * This restores the deleted collector and folds the CRDT state into the same
+ * artifact: one clipboard paste that answers "what build", "what machine",
+ * "what nodes", "what did the document do", and "what did the tester expect
+ * instead".
+ *
+ * Collection is per-source fault-tolerant on purpose. A backend that is down
+ * is exactly when a report matters most, and a failed `getLogs()` must
+ * degrade to a note in the log section rather than abort the whole bundle.
+ */
+import {
+  appliedOpIds,
+  readGraph,
+  readMeta,
+  readStamps
+} from '@comfyorg/comfy-multi-player'
+import type * as Y from 'yjs'
+
+import { isCloud } from '@/platform/distribution/types'
+import { api } from '@/scripts/api'
+import { useExtensionStore } from '@/stores/extensionStore'
+
+import type { DevEvent } from './devPanelLog'
+import { devEventReplacer } from './devPanelLog'
+import type { MergeTraceEntry } from './mergeTrace'
+import type { AgentCrdtStatus } from './useAgentCrdtFollower'
+
+/** Server logs beyond this are tail-trimmed; a paste has to stay pasteable. */
+const MAX_LOG_CHARS = 40_000
+const MAX_WORKFLOW_CHARS = 20_000
+
+/** Live CRDT internals, read from the follower at the moment Copy is pressed. */
+export interface CrdtDebugSnapshot {
+  status: AgentCrdtStatus
+  tabId: string | null
+  lastSeq: number | null
+  schemaError: string | null
+  meta: Readonly<Record<string, unknown>>
+  nodeIds: readonly string[]
+  linkIds: readonly string[]
+  appliedOpIds: readonly string[]
+  stamps: Readonly<Record<string, unknown>>
+}
+
+export interface CrdtDebugReportInput {
+  crdt: CrdtDebugSnapshot
+  events: readonly DevEvent[]
+  /** Whatever the tester typed into "what did you expect instead?". */
+  testerNote?: string
+  /** Merge-lab results the tester was looking at, if any. */
+  mergeTrace?: readonly MergeTraceEntry[]
+  /** Serialized active workflow, when the caller can supply one. */
+  workflow?: unknown
+}
+
+/**
+ * Read every CRDT-observable fact out of a follower doc.
+ *
+ * Uses the package's read-only snapshot surface rather than the live Y types:
+ * those accessors never materialize a root on an empty document and never hand
+ * back a writable handle, so building a report can never perturb the thing it
+ * is reporting on.
+ */
+export function readCrdtSnapshot(
+  doc: Y.Doc | null,
+  base: Omit<
+    CrdtDebugSnapshot,
+    'meta' | 'nodeIds' | 'linkIds' | 'appliedOpIds' | 'stamps'
+  >
+): CrdtDebugSnapshot {
+  if (doc === null) {
+    return {
+      ...base,
+      meta: {},
+      nodeIds: [],
+      linkIds: [],
+      appliedOpIds: [],
+      stamps: {}
+    }
+  }
+  try {
+    const graph = readGraph(doc)
+    return {
+      ...base,
+      meta: readMeta(doc),
+      nodeIds: Object.keys(graph.nodes),
+      linkIds: Object.keys(graph.links),
+      appliedOpIds: appliedOpIds(doc),
+      stamps: readStamps(doc)
+    }
+  } catch (error) {
+    // A doc this build cannot read (KA-11) still has to produce a report —
+    // that failure IS the bug being reported.
+    return {
+      ...base,
+      schemaError: base.schemaError ?? String(error),
+      meta: {},
+      nodeIds: [],
+      linkIds: [],
+      appliedOpIds: [],
+      stamps: {}
+    }
+  }
+}
+
+async function attempt<T>(label: string, load: () => Promise<T>) {
+  try {
+    return { label, ok: true as const, value: await load() }
+  } catch (error) {
+    return { label, ok: false as const, error: String(error) }
+  }
+}
+
+function fence(language: string, body: string): string {
+  return ['```' + language, body, '```'].join('\n')
+}
+
+function json(value: unknown): string {
+  try {
+    return JSON.stringify(value, devEventReplacer(), 2)
+  } catch (error) {
+    return `<unserializable: ${String(error)}>`
+  }
+}
+
+function truncate(text: string, max: number): string {
+  if (text.length <= max) return text
+  return `…(${text.length - max} earlier characters trimmed)…\n${text.slice(-max)}`
+}
+
+type SystemStats = Awaited<ReturnType<typeof api.getSystemStats>>
+
+function systemSection(stats: SystemStats): string {
+  const lines = [
+    `- **ComfyUI version:** ${stats.system.comfyui_version}`,
+    `- **OS:** ${stats.system.os}`,
+    `- **Python:** ${stats.system.python_version}`,
+    `- **Embedded Python:** ${stats.system.embedded_python}`,
+    `- **PyTorch:** ${stats.system.pytorch_version}`,
+    `- **Arguments:** ${stats.system.argv.join(' ')}`,
+    `- **RAM:** ${stats.system.ram_free} free / ${stats.system.ram_total} total`
+  ]
+  if (stats.system.cloud_version)
+    lines.push(`- **Cloud version:** ${stats.system.cloud_version}`)
+  if (stats.system.comfyui_frontend_version)
+    lines.push(
+      `- **Frontend (reported by backend):** ${stats.system.comfyui_frontend_version}`
+    )
+  for (const device of stats.devices) {
+    lines.push(
+      `- **Device ${device.index}:** ${device.name} (${device.type}) — VRAM ${device.vram_free} free / ${device.vram_total} total, torch ${device.torch_vram_free} / ${device.torch_vram_total}`
+    )
+  }
+  return lines.join('\n')
+}
+
+function crdtSection(crdt: CrdtDebugSnapshot): string {
+  return [
+    `- **Enabled:** ${crdt.status.enabled}`,
+    `- **Connected:** ${crdt.status.connected}`,
+    `- **Doc id:** ${crdt.status.workflowId ?? 'none'}`,
+    `- **Updates applied:** ${crdt.status.updatesApplied}`,
+    `- **Last frame:** ${crdt.status.lastFrameType ?? 'none'}`,
+    `- **Tab id:** ${crdt.tabId ?? 'unknown'}`,
+    `- **Last seq:** ${crdt.lastSeq ?? 'none'}`,
+    `- **Schema error:** ${crdt.schemaError ?? 'none'}`,
+    `- **Doc nodes (${crdt.nodeIds.length}):** ${crdt.nodeIds.join(', ') || 'none'}`,
+    `- **Doc links (${crdt.linkIds.length}):** ${crdt.linkIds.join(', ') || 'none'}`,
+    `- **Applied op ids:** ${crdt.appliedOpIds.length}`
+  ].join('\n')
+}
+
+function mergeSection(entries: readonly MergeTraceEntry[]): string {
+  return entries
+    .map(
+      (entry) =>
+        `${entry.index + 1}. \`${entry.kind}\` by ${entry.actor} on ${entry.registerLabel} → **${entry.verdict.kind}**\n   ${entry.explanation}`
+    )
+    .join('\n')
+}
+
+/**
+ * Build the full markdown report.
+ *
+ * Ordered for the reader, not for the collector: the tester's own words come
+ * first, then CRDT state, then the environment, then the raw transcripts. An
+ * engineer reading it top-down should be able to stop as soon as they have
+ * enough.
+ */
+export async function collectCrdtDebugReport(
+  input: CrdtDebugReportInput
+): Promise<string> {
+  const extensionNames = (() => {
+    try {
+      return useExtensionStore().extensions.map((extension) => extension.name)
+    } catch (error) {
+      return [`<unavailable: ${String(error)}>`]
+    }
+  })()
+
+  const [stats, logs, settings] = await Promise.all([
+    attempt('System stats', () => api.getSystemStats()),
+    attempt('Server logs', () => api.getLogs()),
+    attempt('Settings', () => api.getSettings())
+  ])
+
+  const sections: string[] = [
+    '# ComfyUI Agent — CRDT debug report',
+    `Generated ${new Date().toISOString()}`
+  ]
+
+  if (input.testerNote?.trim()) {
+    sections.push(
+      '## What the tester expected',
+      input.testerNote.trim(),
+      '_(This is the tester\u2019s own description of the expected merge behaviour — treat it as a product signal, not a bug repro.)_'
+    )
+  }
+
+  sections.push('## CRDT state', crdtSection(input.crdt))
+
+  if (input.mergeTrace?.length) {
+    sections.push('## Merge trace', mergeSection(input.mergeTrace))
+  }
+
+  sections.push(
+    '## Frontend',
+    [
+      `- **Frontend version:** ${__COMFYUI_FRONTEND_VERSION__}`,
+      `- **Frontend commit:** ${__COMFYUI_FRONTEND_COMMIT__}`,
+      `- **Distribution:** ${isCloud ? 'cloud' : 'local/desktop'}`,
+      `- **API base:** ${api.apiURL('')}`,
+      `- **User agent:** ${navigator.userAgent}`,
+      `- **Viewport:** ${window.innerWidth}×${window.innerHeight}`,
+      `- **Extensions (${extensionNames.length}):** ${extensionNames.join(', ') || 'none'}`
+    ].join('\n')
+  )
+
+  sections.push(
+    '## System',
+    stats.ok
+      ? systemSection(stats.value)
+      : `_${stats.label} unavailable: ${stats.error}_`
+  )
+
+  sections.push('## CRDT event log', fence('json', json(input.events)))
+
+  sections.push(
+    '## Document stamps (LWW ledger)',
+    fence('json', json(input.crdt.stamps))
+  )
+
+  if (input.workflow !== undefined) {
+    const serialized = json(input.workflow)
+    sections.push(
+      '## Workflow',
+      'Check for sensitive values (API keys, prompts) before sharing.',
+      fence(
+        'json',
+        serialized.length > MAX_WORKFLOW_CHARS
+          ? `<workflow omitted: ${serialized.length} characters — attach the .json file instead>`
+          : serialized
+      )
+    )
+  }
+
+  sections.push(
+    '## Settings',
+    settings.ok
+      ? fence('json', json(settings.value))
+      : `_${settings.label} unavailable: ${settings.error}_`
+  )
+
+  sections.push(
+    '## Server logs',
+    logs.ok
+      ? fence('text', truncate(String(logs.value), MAX_LOG_CHARS))
+      : `_${logs.label} unavailable: ${logs.error}_`
+  )
+
+  return sections.join('\n\n')
+}

--- a/src/workbench/extensions/agent/crdt/crdtDebugReport.ts
+++ b/src/workbench/extensions/agent/crdt/crdtDebugReport.ts
@@ -18,22 +18,14 @@
  * is exactly when a report matters most, and a failed `getLogs()` must
  * degrade to a note in the log section rather than abort the whole bundle.
  */
-import {
-  appliedOpIds,
-  readGraph,
-  readMeta,
-  readStamps
-} from '@comfyorg/comfy-multi-player'
-import type * as Y from 'yjs'
-
 import { isCloud } from '@/platform/distribution/types'
 import { api } from '@/scripts/api'
 import { useExtensionStore } from '@/stores/extensionStore'
 
+import type { CrdtDebugSnapshot } from './crdtSnapshot'
 import type { DevEvent } from './devPanelLog'
 import { devEventReplacer } from './devPanelLog'
 import type { MergeTraceEntry } from './mergeTrace'
-import type { AgentCrdtStatus } from './useAgentCrdtFollower'
 
 /** Server logs beyond this are tail-trimmed; a paste has to stay pasteable. */
 const MAX_LOG_CHARS = 40_000
@@ -78,19 +70,6 @@ function redactSecrets(value: unknown, depth = 0): unknown {
   )
 }
 
-/** Live CRDT internals, read from the follower at the moment Copy is pressed. */
-export interface CrdtDebugSnapshot {
-  status: AgentCrdtStatus
-  tabId: string | null
-  lastSeq: number | null
-  schemaError: string | null
-  meta: Readonly<Record<string, unknown>>
-  nodeIds: readonly string[]
-  linkIds: readonly string[]
-  appliedOpIds: readonly string[]
-  stamps: Readonly<Record<string, unknown>>
-}
-
 /**
  * The sources a tester must opt into.
  *
@@ -122,56 +101,6 @@ export interface CrdtDebugReportInput {
   mergeTrace?: readonly MergeTraceEntry[]
   /** Serialized active workflow, when the caller can supply one. */
   workflow?: unknown
-}
-
-/**
- * Read every CRDT-observable fact out of a follower doc.
- *
- * Uses the package's read-only snapshot surface rather than the live Y types:
- * those accessors never materialize a root on an empty document and never hand
- * back a writable handle, so building a report can never perturb the thing it
- * is reporting on.
- */
-export function readCrdtSnapshot(
-  doc: Y.Doc | null,
-  base: Omit<
-    CrdtDebugSnapshot,
-    'meta' | 'nodeIds' | 'linkIds' | 'appliedOpIds' | 'stamps'
-  >
-): CrdtDebugSnapshot {
-  if (doc === null) {
-    return {
-      ...base,
-      meta: {},
-      nodeIds: [],
-      linkIds: [],
-      appliedOpIds: [],
-      stamps: {}
-    }
-  }
-  try {
-    const graph = readGraph(doc)
-    return {
-      ...base,
-      meta: readMeta(doc),
-      nodeIds: Object.keys(graph.nodes),
-      linkIds: Object.keys(graph.links),
-      appliedOpIds: appliedOpIds(doc),
-      stamps: readStamps(doc)
-    }
-  } catch (error) {
-    // A doc this build cannot read (KA-11) still has to produce a report —
-    // that failure IS the bug being reported.
-    return {
-      ...base,
-      schemaError: base.schemaError ?? String(error),
-      meta: {},
-      nodeIds: [],
-      linkIds: [],
-      appliedOpIds: [],
-      stamps: {}
-    }
-  }
 }
 
 async function attempt<T>(label: string, load: () => Promise<T>) {
@@ -239,7 +168,7 @@ function systemSection(stats: SystemStats): string {
     )
   for (const device of stats.devices) {
     lines.push(
-      `- **Device ${device.index}:** ${device.name} (${device.type}) — VRAM ${device.vram_free} free / ${device.vram_total} total, torch ${device.torch_vram_free} / ${device.torch_vram_total}`
+      `- **Device ${device.index ?? '?'}:** ${device.name} (${device.type}) — VRAM ${device.vram_free} free / ${device.vram_total} total, torch ${device.torch_vram_free} / ${device.torch_vram_total}`
     )
   }
   return lines.join('\n')
@@ -351,11 +280,13 @@ export async function collectCrdtDebugReport(
 
   sections.push(
     '## CRDT event log',
+    `${SHARING_WARNING} Frames are recorded as envelopes, but op ids and workflow ids appear verbatim.`,
     fence('json', truncate(json(input.events), MAX_SECTION_CHARS))
   )
 
   sections.push(
     '## Document stamps (LWW ledger)',
+    `${SHARING_WARNING} Stamp keys name every actor that wrote to the document.`,
     fence('json', truncate(json(input.crdt.stamps), MAX_SECTION_CHARS))
   )
 

--- a/src/workbench/extensions/agent/crdt/crdtDebugReport.ts
+++ b/src/workbench/extensions/agent/crdt/crdtDebugReport.ts
@@ -55,12 +55,23 @@ const REDACTED = '[redacted by the debug report]'
 const SHARING_WARNING =
   'Review before sharing: this section can contain values you did not choose to publish.'
 
-function redactSecrets(settings: unknown): unknown {
-  if (typeof settings !== 'object' || settings === null) return settings
+/**
+ * Redaction must RECURSE. A single top-level pass reads as sufficient and is
+ * not: `Comfy.Server.LaunchArgs` is a `Record<string, string>` of the flags
+ * the server was started with, and its own key matches nothing, so a
+ * one-level walk emits `{'--api-token': '…'}` whole. Settings values are
+ * arbitrary JSON from a public `addSetting` API, so every key at every depth
+ * has to be tested.
+ */
+function redactSecrets(value: unknown, depth = 0): unknown {
+  if (depth > 12 || value === null || typeof value !== 'object') return value
+  if (Array.isArray(value)) {
+    return value.map((item) => redactSecrets(item, depth + 1))
+  }
   return Object.fromEntries(
-    Object.entries(settings as Record<string, unknown>).map(([key, value]) => [
+    Object.entries(value as Record<string, unknown>).map(([key, nested]) => [
       key,
-      SECRET_KEY_PATTERN.test(key) ? REDACTED : value
+      SECRET_KEY_PATTERN.test(key) ? REDACTED : redactSecrets(nested, depth + 1)
     ])
   )
 }
@@ -78,9 +89,31 @@ export interface CrdtDebugSnapshot {
   stamps: Readonly<Record<string, unknown>>
 }
 
+/**
+ * The sources a tester must opt into.
+ *
+ * The panel this replaced shipped all three unconditionally. The dialog
+ * DELETED in #5259 did not: it listed them as unchecked opt-ins under "what
+ * can we include", and restoring the collection without restoring that choice
+ * would be a privacy regression dressed as a feature.
+ */
+export interface ReportSources {
+  serverLogs: boolean
+  settings: boolean
+  workflow: boolean
+}
+
+export const DEFAULT_REPORT_SOURCES: ReportSources = {
+  serverLogs: false,
+  settings: false,
+  workflow: false
+}
+
 export interface CrdtDebugReportInput {
   crdt: CrdtDebugSnapshot
   events: readonly DevEvent[]
+  /** Which sensitive sources the tester agreed to include. */
+  sources?: ReportSources
   /** Whatever the tester typed into "what did you expect instead?". */
   testerNote?: string
   /** Merge-lab results the tester was looking at, if any. */
@@ -166,6 +199,27 @@ function truncate(text: string, max: number): string {
 
 type SystemStats = Awaited<ReturnType<typeof api.getSystemStats>>
 
+/** `--api-token <value>`: the flag names the secret, so blank the value after it. */
+function redactArgv(argv: readonly string[]): string {
+  const parts: string[] = []
+  let redactNext = false
+  for (const arg of argv) {
+    if (redactNext && !arg.startsWith('-')) {
+      parts.push(REDACTED)
+      redactNext = false
+      continue
+    }
+    redactNext = SECRET_KEY_PATTERN.test(arg)
+    const [flag, inlineValue] = arg.split('=', 2)
+    parts.push(
+      inlineValue !== undefined && SECRET_KEY_PATTERN.test(flag)
+        ? `${flag}=${REDACTED}`
+        : arg
+    )
+  }
+  return parts.join(' ')
+}
+
 function systemSection(stats: SystemStats): string {
   const lines = [
     `- **ComfyUI version:** ${stats.system.comfyui_version}`,
@@ -173,7 +227,7 @@ function systemSection(stats: SystemStats): string {
     `- **Python:** ${stats.system.python_version}`,
     `- **Embedded Python:** ${stats.system.embedded_python}`,
     `- **PyTorch:** ${stats.system.pytorch_version}`,
-    `- **Arguments:** ${stats.system.argv.join(' ')}`,
+    `- **Arguments:** ${redactArgv(stats.system.argv)}`,
     `- **RAM:** ${stats.system.ram_free} free / ${stats.system.ram_total} total`
   ]
   if (stats.system.cloud_version)
@@ -253,10 +307,11 @@ export async function collectCrdtDebugReport(
     }
   })()
 
+  const sources = input.sources ?? DEFAULT_REPORT_SOURCES
   const [stats, logs, settings] = await Promise.all([
     attempt('System stats', () => api.getSystemStats()),
-    attempt('Server logs', () => api.getLogs()),
-    attempt('Settings', () => api.getSettings())
+    sources.serverLogs ? attempt('Server logs', () => api.getLogs()) : null,
+    sources.settings ? attempt('Settings', () => api.getSettings()) : null
   ])
 
   const sections: string[] = [
@@ -300,7 +355,7 @@ export async function collectCrdtDebugReport(
     fence('json', json(input.crdt.stamps))
   )
 
-  if (input.workflow !== undefined) {
+  if (sources.workflow && input.workflow !== undefined) {
     const serialized = json(input.workflow)
     sections.push(
       '## Workflow',
@@ -316,18 +371,26 @@ export async function collectCrdtDebugReport(
 
   sections.push(
     '## Settings',
-    `${SHARING_WARNING} Values under keys that look like credentials are replaced with \`${REDACTED}\`, but a custom node may name a secret anything.`,
-    settings.ok
-      ? fence('json', json(redactSecrets(settings.value)))
-      : `_${settings.label} unavailable: ${settings.error}_`
+    settings === null
+      ? `_Not included. The tester did not opt in to sharing settings._`
+      : [
+          `${SHARING_WARNING} Values under keys that look like credentials are replaced with \`${REDACTED}\`, at every depth — but a custom node may name a secret anything.`,
+          settings.ok
+            ? fence('json', json(redactSecrets(settings.value)))
+            : `_${settings.label} unavailable: ${settings.error}_`
+        ].join('\n\n')
   )
 
   sections.push(
     '## Server logs',
-    `${SHARING_WARNING} Backend logs can echo prompts, file paths and tokens.`,
-    logs.ok
-      ? fence('text', truncate(String(logs.value), MAX_LOG_CHARS))
-      : `_${logs.label} unavailable: ${logs.error}_`
+    logs === null
+      ? `_Not included. The tester did not opt in to sharing server logs._`
+      : [
+          `${SHARING_WARNING} Backend logs can echo prompts, file paths and tokens.`,
+          logs.ok
+            ? fence('text', truncate(String(logs.value), MAX_LOG_CHARS))
+            : `_${logs.label} unavailable: ${logs.error}_`
+        ].join('\n\n')
   )
 
   return sections.join('\n\n')

--- a/src/workbench/extensions/agent/crdt/crdtDebugReport.ts
+++ b/src/workbench/extensions/agent/crdt/crdtDebugReport.ts
@@ -39,6 +39,32 @@ import type { AgentCrdtStatus } from './useAgentCrdtFollower'
 const MAX_LOG_CHARS = 40_000
 const MAX_WORKFLOW_CHARS = 20_000
 
+/**
+ * Setting keys whose VALUE is replaced before the report leaves the browser.
+ *
+ * `addSetting` is public extension API, so the settings dictionary is an open
+ * set: any installed node pack can persist whatever it likes there, including
+ * service credentials. An allow-list is impossible for the same reason, so
+ * this redacts by key shape and the report says so out loud.
+ */
+const SECRET_KEY_PATTERN =
+  /(token|secret|password|passwd|credential|api[-_]?key|apikey|auth|bearer|session|cookie|private)/i
+
+const REDACTED = '[redacted by the debug report]'
+
+const SHARING_WARNING =
+  'Review before sharing: this section can contain values you did not choose to publish.'
+
+function redactSecrets(settings: unknown): unknown {
+  if (typeof settings !== 'object' || settings === null) return settings
+  return Object.fromEntries(
+    Object.entries(settings as Record<string, unknown>).map(([key, value]) => [
+      key,
+      SECRET_KEY_PATTERN.test(key) ? REDACTED : value
+    ])
+  )
+}
+
 /** Live CRDT internals, read from the follower at the moment Copy is pressed. */
 export interface CrdtDebugSnapshot {
   status: AgentCrdtStatus
@@ -190,6 +216,25 @@ function mergeSection(entries: readonly MergeTraceEntry[]): string {
 }
 
 /**
+ * `systemSection` reads fields off an unvalidated `/system_stats` payload, so
+ * a backend that answers 200 with a different shape would throw straight out
+ * of the collector — losing the entire report at exactly the moment the
+ * backend is the thing being reported on.
+ */
+function renderSystem(
+  stats:
+    | { label: string; ok: true; value: SystemStats }
+    | { label: string; ok: false; error: string }
+): string {
+  if (!stats.ok) return `_${stats.label} unavailable: ${stats.error}_`
+  try {
+    return systemSection(stats.value)
+  } catch (error) {
+    return `_${stats.label} could not be rendered (${String(error)}); raw payload:_\n${fence('json', json(stats.value))}`
+  }
+}
+
+/**
  * Build the full markdown report.
  *
  * Ordered for the reader, not for the collector: the tester's own words come
@@ -246,12 +291,7 @@ export async function collectCrdtDebugReport(
     ].join('\n')
   )
 
-  sections.push(
-    '## System',
-    stats.ok
-      ? systemSection(stats.value)
-      : `_${stats.label} unavailable: ${stats.error}_`
-  )
+  sections.push('## System', renderSystem(stats))
 
   sections.push('## CRDT event log', fence('json', json(input.events)))
 
@@ -264,7 +304,7 @@ export async function collectCrdtDebugReport(
     const serialized = json(input.workflow)
     sections.push(
       '## Workflow',
-      'Check for sensitive values (API keys, prompts) before sharing.',
+      `${SHARING_WARNING} Prompts and API keys embedded in nodes appear verbatim.`,
       fence(
         'json',
         serialized.length > MAX_WORKFLOW_CHARS
@@ -276,13 +316,15 @@ export async function collectCrdtDebugReport(
 
   sections.push(
     '## Settings',
+    `${SHARING_WARNING} Values under keys that look like credentials are replaced with \`${REDACTED}\`, but a custom node may name a secret anything.`,
     settings.ok
-      ? fence('json', json(settings.value))
+      ? fence('json', json(redactSecrets(settings.value)))
       : `_${settings.label} unavailable: ${settings.error}_`
   )
 
   sections.push(
     '## Server logs',
+    `${SHARING_WARNING} Backend logs can echo prompts, file paths and tokens.`,
     logs.ok
       ? fence('text', truncate(String(logs.value), MAX_LOG_CHARS))
       : `_${logs.label} unavailable: ${logs.error}_`

--- a/src/workbench/extensions/agent/crdt/crdtDebugReport.ts
+++ b/src/workbench/extensions/agent/crdt/crdtDebugReport.ts
@@ -38,6 +38,8 @@ import type { AgentCrdtStatus } from './useAgentCrdtFollower'
 /** Server logs beyond this are tail-trimmed; a paste has to stay pasteable. */
 const MAX_LOG_CHARS = 40_000
 const MAX_WORKFLOW_CHARS = 20_000
+/** The event log and the stamp ledger both grow without bound with session length. */
+const MAX_SECTION_CHARS = 60_000
 
 /**
  * Setting keys whose VALUE is replaced before the report leaves the browser.
@@ -209,13 +211,12 @@ function redactArgv(argv: readonly string[]): string {
       redactNext = false
       continue
     }
-    redactNext = SECRET_KEY_PATTERN.test(arg)
     const [flag, inlineValue] = arg.split('=', 2)
-    parts.push(
-      inlineValue !== undefined && SECRET_KEY_PATTERN.test(flag)
-        ? `${flag}=${REDACTED}`
-        : arg
-    )
+    const named = SECRET_KEY_PATTERN.test(flag)
+    // An inline `--token=x` already consumed its value; only a bare flag can
+    // put the secret in the NEXT argument.
+    redactNext = named && inlineValue === undefined
+    parts.push(named && inlineValue !== undefined ? `${flag}=${REDACTED}` : arg)
   }
   return parts.join(' ')
 }
@@ -348,11 +349,14 @@ export async function collectCrdtDebugReport(
 
   sections.push('## System', renderSystem(stats))
 
-  sections.push('## CRDT event log', fence('json', json(input.events)))
+  sections.push(
+    '## CRDT event log',
+    fence('json', truncate(json(input.events), MAX_SECTION_CHARS))
+  )
 
   sections.push(
     '## Document stamps (LWW ledger)',
-    fence('json', json(input.crdt.stamps))
+    fence('json', truncate(json(input.crdt.stamps), MAX_SECTION_CHARS))
   )
 
   if (sources.workflow && input.workflow !== undefined) {

--- a/src/workbench/extensions/agent/crdt/crdtLog.ts
+++ b/src/workbench/extensions/agent/crdt/crdtLog.ts
@@ -9,7 +9,7 @@
  * {@link crdtLog}, which is what makes the report a transcript.
  */
 import type { CrdtLogLevel } from './crdtDebugGate'
-import { isLevelEnabled } from './crdtDebugGate'
+import { isCrdtDebugEnabled, isLevelEnabled } from './crdtDebugGate'
 import type { CrdtLogScope, DevEventKind } from './devPanelLog'
 import { recordDevEvent } from './devPanelLog'
 
@@ -21,8 +21,7 @@ const SCOPE_STYLE: Record<CrdtLogScope, string> = {
   wire: 'color:#7dd3fc',
   doc: 'color:#a5b4fc',
   ecs: 'color:#86efac',
-  ops: 'color:#fcd34d',
-  panel: 'color:#d8b4fe'
+  ops: 'color:#fcd34d'
 }
 
 const CONSOLE_METHOD: Record<CrdtLogLevel, 'warn' | 'info' | 'debug'> = {
@@ -55,7 +54,11 @@ function crdtLog(entry: CrdtLogEntry): void {
   if (!isLevelEnabled(level)) return
   const line = `%c[crdt:${scope}]%c ${kind} — ${message}`
   const args: unknown[] = [line, SCOPE_STYLE[scope], '']
-  if (detail !== undefined) args.push(detail)
+  // `warn` reaches the console even when the instrument is off, so that a
+  // fail-closed follower is never silent. The MESSAGE is what earns that
+  // exemption — dumping document state into an opted-out user's console does
+  // not. The detail is still in the ring buffer for whoever opted in.
+  if (detail !== undefined && isCrdtDebugEnabled()) args.push(detail)
   console[CONSOLE_METHOD[level]](...args)
 }
 

--- a/src/workbench/extensions/agent/crdt/crdtLog.ts
+++ b/src/workbench/extensions/agent/crdt/crdtLog.ts
@@ -9,7 +9,11 @@
  * {@link crdtLog}, which is what makes the report a transcript.
  */
 import type { CrdtLogLevel } from './crdtDebugGate'
-import { isCrdtDebugEnabled, isLevelEnabled } from './crdtDebugGate'
+import {
+  isCrdtDebugEnabled,
+  isCrdtDebugOptedOut,
+  isLevelEnabled
+} from './crdtDebugGate'
 import type { CrdtLogScope, DevEventKind } from './devPanelLog'
 import { recordDevEvent } from './devPanelLog'
 
@@ -43,12 +47,14 @@ interface CrdtLogEntry {
 /**
  * Emit one CRDT-internal event.
  *
- * The ring buffer records unconditionally: a tester who only turns the panel
- * on AFTER something went wrong still needs the run-up in the copied report,
- * and 500 capped entries cost nothing. Only the console print is gated.
+ * The ring buffer records even when the console is quiet: a tester who only
+ * turns the panel on AFTER something went wrong still needs the run-up in the
+ * copied report, and 500 capped entries cost nothing. An explicit opt-out is
+ * the one case that skips recording too.
  */
 function crdtLog(entry: CrdtLogEntry): void {
   const { scope, level, kind, message, detail } = entry
+  if (isCrdtDebugOptedOut()) return
   recordDevEvent(kind, detail ?? null, { scope, level })
 
   if (!isLevelEnabled(level)) return

--- a/src/workbench/extensions/agent/crdt/crdtLog.ts
+++ b/src/workbench/extensions/agent/crdt/crdtLog.ts
@@ -1,0 +1,83 @@
+/**
+ * One call site, two sinks: the console (for whoever has devtools open) and
+ * the panel's ring buffer (for whoever is copying a report).
+ *
+ * Before this module the two were wired independently — a handful of
+ * `recordDevEvent` calls that never printed, and a handful of bare
+ * `console.warn`s the panel never saw — so the console and the copied report
+ * disagreed about what happened. Every CRDT-internal event now goes through
+ * {@link crdtLog}, which is what makes the report a transcript.
+ */
+import type { CrdtLogLevel } from './crdtDebugGate'
+import { isLevelEnabled } from './crdtDebugGate'
+import type { CrdtLogScope, DevEventKind } from './devPanelLog'
+import { recordDevEvent } from './devPanelLog'
+
+/**
+ * Console tint per scope, so a busy log reads as layers rather than as one
+ * undifferentiated stream.
+ */
+const SCOPE_STYLE: Record<CrdtLogScope, string> = {
+  wire: 'color:#7dd3fc',
+  doc: 'color:#a5b4fc',
+  ecs: 'color:#86efac',
+  ops: 'color:#fcd34d',
+  panel: 'color:#d8b4fe'
+}
+
+const CONSOLE_METHOD: Record<CrdtLogLevel, 'warn' | 'info' | 'debug'> = {
+  warn: 'warn',
+  info: 'info',
+  debug: 'debug',
+  trace: 'debug'
+}
+
+interface CrdtLogEntry {
+  scope: CrdtLogScope
+  level: CrdtLogLevel
+  kind: DevEventKind
+  /** Short human sentence; the `detail` carries the structure. */
+  message: string
+  detail?: unknown
+}
+
+/**
+ * Emit one CRDT-internal event.
+ *
+ * The ring buffer records unconditionally: a tester who only turns the panel
+ * on AFTER something went wrong still needs the run-up in the copied report,
+ * and 500 capped entries cost nothing. Only the console print is gated.
+ */
+function crdtLog(entry: CrdtLogEntry): void {
+  const { scope, level, kind, message, detail } = entry
+  recordDevEvent(kind, detail ?? null, { scope, level })
+
+  if (!isLevelEnabled(level)) return
+  const line = `%c[crdt:${scope}]%c ${kind} — ${message}`
+  const args: unknown[] = [line, SCOPE_STYLE[scope], '']
+  if (detail !== undefined) args.push(detail)
+  console[CONSOLE_METHOD[level]](...args)
+}
+
+/**
+ * Bind a scope once so call sites read as `wire.trace('…')` rather than
+ * repeating the scope on every event.
+ */
+function scopedCrdtLog(scope: CrdtLogScope) {
+  const at =
+    (level: CrdtLogLevel) =>
+    (kind: DevEventKind, message: string, detail?: unknown): void =>
+      crdtLog({ scope, level, kind, message, detail })
+
+  return {
+    warn: at('warn'),
+    info: at('info'),
+    debug: at('debug'),
+    trace: at('trace')
+  }
+}
+
+export const wireLog = scopedCrdtLog('wire')
+export const docLog = scopedCrdtLog('doc')
+export const ecsLog = scopedCrdtLog('ecs')
+export const opsLog = scopedCrdtLog('ops')

--- a/src/workbench/extensions/agent/crdt/crdtSnapshot.ts
+++ b/src/workbench/extensions/agent/crdt/crdtSnapshot.ts
@@ -1,0 +1,80 @@
+/**
+ * The follower's read-only view of its own document.
+ *
+ * Split out of `crdtDebugReport.ts` so the composable — which every agent
+ * panel loads eagerly — does not pull the report collector, its redaction
+ * helpers and the extension store into that bundle. Only the debug panel,
+ * behind its async boundary, needs those.
+ */
+import {
+  appliedOpIds,
+  readGraph,
+  readMeta,
+  readStamps
+} from '@comfyorg/comfy-multi-player'
+import type * as Y from 'yjs'
+
+import type { AgentCrdtStatus } from './useAgentCrdtFollower'
+
+/** Live CRDT internals, read from the follower at the moment Copy is pressed. */
+export interface CrdtDebugSnapshot {
+  status: AgentCrdtStatus
+  tabId: string | null
+  lastSeq: number | null
+  schemaError: string | null
+  meta: Readonly<Record<string, unknown>>
+  nodeIds: readonly string[]
+  linkIds: readonly string[]
+  appliedOpIds: readonly string[]
+  stamps: Readonly<Record<string, unknown>>
+}
+
+/**
+ * Read every CRDT-observable fact out of a follower doc.
+ *
+ * Uses the package's read-only snapshot surface rather than the live Y types:
+ * those accessors never materialize a root on an empty document and never hand
+ * back a writable handle, so building a report can never perturb the thing it
+ * is reporting on.
+ */
+export function readCrdtSnapshot(
+  doc: Y.Doc | null,
+  base: Omit<
+    CrdtDebugSnapshot,
+    'meta' | 'nodeIds' | 'linkIds' | 'appliedOpIds' | 'stamps'
+  >
+): CrdtDebugSnapshot {
+  if (doc === null) {
+    return {
+      ...base,
+      meta: {},
+      nodeIds: [],
+      linkIds: [],
+      appliedOpIds: [],
+      stamps: {}
+    }
+  }
+  try {
+    const graph = readGraph(doc)
+    return {
+      ...base,
+      meta: readMeta(doc),
+      nodeIds: Object.keys(graph.nodes),
+      linkIds: Object.keys(graph.links),
+      appliedOpIds: appliedOpIds(doc),
+      stamps: readStamps(doc)
+    }
+  } catch (error) {
+    // A doc this build cannot read (KA-11) still has to produce a report —
+    // that failure IS the bug being reported.
+    return {
+      ...base,
+      schemaError: base.schemaError ?? String(error),
+      meta: {},
+      nodeIds: [],
+      linkIds: [],
+      appliedOpIds: [],
+      stamps: {}
+    }
+  }
+}

--- a/src/workbench/extensions/agent/crdt/devPanelLog.test.ts
+++ b/src/workbench/extensions/agent/crdt/devPanelLog.test.ts
@@ -37,4 +37,30 @@ describe('devPanelLog', () => {
     const serialized = stringifyDevEvents(devEvents.value)
     expect(serialized).toContain('"Uint8Array(16)"')
   })
+
+  it('keeps a value referenced twice from sibling positions', () => {
+    const shared = { id: 'node-7' }
+    recordDevEvent('doc_effects', { added: shared, removed: shared })
+
+    const serialized = stringifyDevEvents(devEvents.value)
+    expect(serialized).not.toContain('[Circular]')
+    expect(serialized.match(/node-7/g)).toHaveLength(2)
+  })
+
+  it('survives a genuine cycle instead of throwing', () => {
+    const cyclic: Record<string, unknown> = { kind: 'self' }
+    cyclic.self = cyclic
+    recordDevEvent('doc_effects', cyclic)
+
+    expect(() => stringifyDevEvents(devEvents.value)).not.toThrow()
+    expect(stringifyDevEvents(devEvents.value)).toContain('[Circular]')
+  })
+
+  it('carries the scope and level a consumer filters on', () => {
+    recordDevEvent('doc_gap', null, { scope: 'wire', level: 'warn' })
+
+    const [event] = devEvents.value
+    expect(event.scope).toBe('wire')
+    expect(event.level).toBe('warn')
+  })
 })

--- a/src/workbench/extensions/agent/crdt/devPanelLog.ts
+++ b/src/workbench/extensions/agent/crdt/devPanelLog.ts
@@ -1,11 +1,25 @@
 import { shallowRef, triggerRef } from 'vue'
 
+import type { CrdtLogLevel } from './crdtDebugGate'
+
 /**
- * PoC (branch poc/fe-crdt-follower-e2e): in-memory ring buffer feeding the
- * CRDT dev panel. Deliberately module-level (one buffer per page, like the
- * follower gate) so the panel component and the follower composable never
- * need a shared injection seam. Not shipped beyond the PoC branch.
+ * In-memory ring buffer feeding the CRDT debug panel. Deliberately
+ * module-level (one buffer per page, like the follower gate) so the panel
+ * component and the follower composable never need a shared injection seam.
+ *
+ * Every entry carries the same four axes the console logger uses — kind,
+ * scope, level, detail — so "what the panel shows" and "what the console
+ * printed" are the same record read two ways, and a copied report is a
+ * faithful transcript rather than a second, drifting summary.
  */
+
+/**
+ * The layer an event came from. Filtering by scope is how the panel offers
+ * "varying levels of abstraction": `wire` is bytes on the socket, `doc` is
+ * document lineage, `ecs` is the projection onto canvas state, `ops` is the
+ * human write leg's semantic intent.
+ */
+export type CrdtLogScope = 'wire' | 'doc' | 'ecs' | 'ops' | 'panel'
 
 export type DevEventKind =
   | 'ws_out'
@@ -19,12 +33,24 @@ export type DevEventKind =
   | 'doc_nodes_changed'
   | 'rebind'
   | 'stale_probe'
+  | 'doc_gap'
+  | 'doc_effects'
+  | 'op_minted'
+  | 'op_batch_settled'
+  | 'send_dropped'
 
 export interface DevEvent {
   seq: number
   at: number
   kind: DevEventKind
+  scope: CrdtLogScope
+  level: CrdtLogLevel
   detail: unknown
+}
+
+export interface DevEventOptions {
+  scope?: CrdtLogScope
+  level?: CrdtLogLevel
 }
 
 const CAPACITY = 500
@@ -39,8 +65,19 @@ const buffer: DevEvent[] = []
  */
 export const devEvents = shallowRef<readonly DevEvent[]>(buffer)
 
-export function recordDevEvent(kind: DevEventKind, detail: unknown): void {
-  buffer.push({ seq: nextSeq++, at: Date.now(), kind, detail })
+export function recordDevEvent(
+  kind: DevEventKind,
+  detail: unknown,
+  options: DevEventOptions = {}
+): void {
+  buffer.push({
+    seq: nextSeq++,
+    at: Date.now(),
+    kind,
+    scope: options.scope ?? 'doc',
+    level: options.level ?? 'info',
+    detail
+  })
   if (buffer.length > CAPACITY) buffer.splice(0, buffer.length - CAPACITY)
   triggerRef(devEvents)
 }
@@ -52,10 +89,26 @@ export function clearDevEvents(): void {
 
 /** Serializes an event detail defensively (Uint8Array etc. don't JSON well). */
 export function stringifyDevEvents(events: readonly DevEvent[]): string {
-  return JSON.stringify(
-    events,
-    (_key, value) =>
-      value instanceof Uint8Array ? `Uint8Array(${value.length})` : value,
-    2
-  )
+  return JSON.stringify(events, devEventReplacer(), 2)
+}
+
+/**
+ * JSON replacer shared by the panel's copy actions and the debug report.
+ *
+ * A binary payload is summarized by length rather than dumped: the bytes are
+ * a Yjs update, unreadable to a human and large enough to push the interesting
+ * fields out of a paste. Cyclic values degrade to a marker instead of
+ * throwing, because the report must survive whatever the doc happens to hold.
+ */
+export function devEventReplacer(): (key: string, value: unknown) => unknown {
+  const seen = new WeakSet<object>()
+  return (_key, value) => {
+    if (value instanceof Uint8Array) return `Uint8Array(${value.length})`
+    if (typeof value === 'bigint') return value.toString()
+    if (typeof value === 'object' && value !== null) {
+      if (seen.has(value)) return '[Circular]'
+      seen.add(value)
+    }
+    return value
+  }
 }

--- a/src/workbench/extensions/agent/crdt/devPanelLog.ts
+++ b/src/workbench/extensions/agent/crdt/devPanelLog.ts
@@ -100,14 +100,22 @@ export function stringifyDevEvents(events: readonly DevEvent[]): string {
  * fields out of a paste. Cyclic values degrade to a marker instead of
  * throwing, because the report must survive whatever the doc happens to hold.
  */
-export function devEventReplacer(): (key: string, value: unknown) => unknown {
-  const seen = new WeakSet<object>()
-  return (_key, value) => {
+export function devEventReplacer(): (
+  this: unknown,
+  key: string,
+  value: unknown
+) => unknown {
+  // Tracks the ANCESTOR chain, not everything visited: a doc snapshot legally
+  // references one object from two sibling positions, and a visited-set would
+  // report the second as `[Circular]` and silently drop real data.
+  const ancestors: unknown[] = []
+  return function (this: unknown, _key, value) {
+    while (ancestors.length > 0 && ancestors.at(-1) !== this) ancestors.pop()
     if (value instanceof Uint8Array) return `Uint8Array(${value.length})`
     if (typeof value === 'bigint') return value.toString()
     if (typeof value === 'object' && value !== null) {
-      if (seen.has(value)) return '[Circular]'
-      seen.add(value)
+      if (ancestors.includes(value)) return '[Circular]'
+      ancestors.push(value)
     }
     return value
   }

--- a/src/workbench/extensions/agent/crdt/devPanelLog.ts
+++ b/src/workbench/extensions/agent/crdt/devPanelLog.ts
@@ -19,7 +19,7 @@ import type { CrdtLogLevel } from './crdtDebugGate'
  * document lineage, `ecs` is the projection onto canvas state, `ops` is the
  * human write leg's semantic intent.
  */
-export type CrdtLogScope = 'wire' | 'doc' | 'ecs' | 'ops' | 'panel'
+export type CrdtLogScope = 'wire' | 'doc' | 'ecs' | 'ops'
 
 export type DevEventKind =
   | 'ws_out'

--- a/src/workbench/extensions/agent/crdt/ecsFollowerAdapter.ts
+++ b/src/workbench/extensions/agent/crdt/ecsFollowerAdapter.ts
@@ -13,6 +13,7 @@ import type {
 import type { RemoteMutationContext } from '@/types/graphMutationContext'
 import { toNodeId } from '@/types/nodeId'
 
+import { ecsLog } from './crdtLog'
 import type { DocUpdate } from './docFrameClient'
 import type { FollowerDoc } from './followerDoc'
 
@@ -165,6 +166,25 @@ export class EcsFollowerAdapter {
     const removedLinkIds = [...changedLinkIds].flatMap((id) =>
       linksMap(follower.doc).has(id) ? [] : [Number(id)]
     )
+
+    ecsLog.debug(
+      'doc_effects',
+      `seq ${update.seq}: ${nodeActions.size} node action(s), ${changedWidgets.size} widget group(s), ${changedLinkIds.size} link(s)`,
+      {
+        seq: update.seq,
+        actor: update.actor ?? null,
+        opIds: update.opIds ?? [],
+        nodeActions: Object.fromEntries(nodeActions),
+        widgets: Object.fromEntries(
+          [...changedWidgets].map(([id, names]) => [id, [...names]])
+        ),
+        links: [...changedLinkIds],
+        removedLinkIds,
+        replacedNodeIds: [...replacedNodeIds],
+        reconcile
+      }
+    )
+
     return this.mutations.batch(frameContext(update), (batch) => {
       // Input replacement can retire an incumbent even when delete-wins leaves
       // no new link to install, so removals are an independent derived effect.

--- a/src/workbench/extensions/agent/crdt/followerSubscription.test.ts
+++ b/src/workbench/extensions/agent/crdt/followerSubscription.test.ts
@@ -448,9 +448,32 @@ describe('FE-KA11-1 — the read-time schema gate fails closed', () => {
     // Fail CLOSED: the frame is never re-dispatched, so nothing renders.
     expect(projected).toHaveLength(0)
     // …and the failure is distinguishable, not a silent "disconnected".
-    expect(schemaErrors).toEqual([{ workflowId: WORKFLOW_ID, found: 2 }])
+    expect(schemaErrors).toEqual([
+      { workflowId: WORKFLOW_ID, found: 2, firstFailure: true }
+    ])
     expect(bridge.lastSchemaError).toBeInstanceOf(FollowerSchemaError)
     expect(error).toHaveBeenCalled()
+    error.mockRestore()
+  })
+
+  it('keeps refusing every later frame, not just the first', () => {
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const { transport, bridge, projected, schemaErrors } = wire()
+    transport.open = true
+    bridge.subscribe(WORKFLOW_ID)
+
+    const v2 = hostDocUpdate((doc) =>
+      doc.getMap('meta').set('schema_version', 2)
+    )
+    transport.deliver('doc_update', docUpdateFrame(v2, WORKFLOW_ID, 1))
+    transport.deliver('doc_update', docUpdateFrame(v2, WORKFLOW_ID, 2))
+
+    // This event is not just a log line: its listener also clears `connected`
+    // and cancels the stale probe, which a resubscribe re-arms. Firing it only
+    // once left the follower resubscribing forever, reporting itself connected.
+    expect(projected).toHaveLength(0)
+    expect(schemaErrors).toHaveLength(2)
+    expect(schemaErrors[1]).toMatchObject({ firstFailure: false })
     error.mockRestore()
   })
 
@@ -470,7 +493,7 @@ describe('FE-KA11-1 — the read-time schema gate fails closed', () => {
 
     expect(projected).toHaveLength(0)
     expect(schemaErrors).toEqual([
-      { workflowId: WORKFLOW_ID, found: undefined }
+      { workflowId: WORKFLOW_ID, found: undefined, firstFailure: true }
     ])
     error.mockRestore()
   })

--- a/src/workbench/extensions/agent/crdt/layoutFollowerBridge.ts
+++ b/src/workbench/extensions/agent/crdt/layoutFollowerBridge.ts
@@ -227,18 +227,23 @@ export class LayoutFollowerBridge extends EventTarget {
       assertReadableSchema(this.follower.doc)
     } catch (error) {
       if (!(error instanceof FollowerSchemaError)) throw error
-      // Every subsequent frame fails the same gate, so re-announcing it once
-      // per frame would repeat a gate-bypassing `warn` for the rest of the
-      // session. The state is already readable via `lastSchemaError`.
+      // Dispatched on EVERY failing frame: the listener also clears
+      // `connected`, cancels the stale probe and discards pending effects, and
+      // a resubscribe re-arms all three. Suppressing the event to quieten the
+      // console left the follower resubscribing forever while reporting
+      // connected. `firstFailure` rides in the detail so only the log is
+      // deduplicated.
       const firstFailure = this.schemaError === null
       this.schemaError = error
-      if (firstFailure) {
-        this.dispatchEvent(
-          new CustomEvent('schema_error', {
-            detail: { workflowId: update.workflowId, found: error.found }
-          })
-        )
-      }
+      this.dispatchEvent(
+        new CustomEvent('schema_error', {
+          detail: {
+            workflowId: update.workflowId,
+            found: error.found,
+            firstFailure
+          }
+        })
+      )
       return
     }
 

--- a/src/workbench/extensions/agent/crdt/layoutFollowerBridge.ts
+++ b/src/workbench/extensions/agent/crdt/layoutFollowerBridge.ts
@@ -204,7 +204,9 @@ export class LayoutFollowerBridge extends EventTarget {
     // asks the host for a same-lineage state-vector delta using this EXACT
     // follower doc. Only an explicit doc_reset may replace it (ADR-0024).
     if (this.lastSeq !== null && update.seq > this.lastSeq + 1) {
-      docLog.warn(
+      // `info`, not `warn`: warn bypasses the debug gate, and a flapping
+      // socket repeats this indefinitely in shipping builds.
+      docLog.info(
         'doc_gap',
         `sequence gap: expected ${this.lastSeq + 1}, got ${update.seq} — resubscribing for a state-vector delta`,
         { seq: update.seq, lastSeq: this.lastSeq, reason: 'gap' }

--- a/src/workbench/extensions/agent/crdt/layoutFollowerBridge.ts
+++ b/src/workbench/extensions/agent/crdt/layoutFollowerBridge.ts
@@ -1,3 +1,4 @@
+import { docLog, wireLog } from './crdtLog'
 import type {
   DocFrameClient,
   DocOp,
@@ -15,11 +16,21 @@ import { FollowerSchemaError, assertReadableSchema } from './schemaGuard'
  * any future transport might regress to) is contained here rather than being
  * allowed to abort a Vue watcher or an unmount hook.
  */
-function trySend(send: () => boolean): boolean {
+function trySend(what: string, send: () => boolean): boolean {
   try {
-    return send()
+    const delivered = send()
+    if (!delivered) {
+      wireLog.info('send_dropped', `${what} could not leave the transport`, {
+        what,
+        reason: 'socket-not-open'
+      })
+    }
+    return delivered
   } catch (error) {
-    console.warn('[agent-crdt] outbound doc frame dropped', error)
+    wireLog.warn('send_dropped', `${what} threw on the transport`, {
+      what,
+      error: String(error)
+    })
     return false
   }
 }
@@ -92,6 +103,11 @@ export class LayoutFollowerBridge extends EventTarget {
     return this.schemaError
   }
 
+  /** Highest doc seq integrated since the last subscribe, for diagnostics. */
+  get lastAppliedSeq(): number | null {
+    return this.lastSeq
+  }
+
   /** True while intent and reality disagree — i.e. a retry is still owed. */
   get hasPendingSubscribe(): boolean {
     return (
@@ -119,11 +135,13 @@ export class LayoutFollowerBridge extends EventTarget {
       // record is cleared either way.
       const sent = this.sentWorkflowId
       this.sentWorkflowId = null
-      trySend(() => this.client.unsubscribe(sent))
+      trySend('doc_unsubscribe', () => this.client.unsubscribe(sent))
     }
     if (desired === null || this.sentWorkflowId === desired) return
     if (
-      trySend(() => this.client.subscribe(desired, this.follower.stateVector()))
+      trySend('doc_subscribe', () =>
+        this.client.subscribe(desired, this.follower.stateVector())
+      )
     ) {
       this.sentWorkflowId = desired
       this.lastSeq = null
@@ -143,7 +161,7 @@ export class LayoutFollowerBridge extends EventTarget {
   sendHumanOps(tab: string, ops: DocOp[]): void {
     const workflowId = this.sentWorkflowId
     if (workflowId === null || ops.length === 0) return
-    trySend(() => this.client.sendOps(workflowId, tab, ops))
+    trySend('doc_ops', () => this.client.sendOps(workflowId, tab, ops))
   }
 
   /**
@@ -173,12 +191,24 @@ export class LayoutFollowerBridge extends EventTarget {
 
     // A stale/duplicate frame cannot advance the replica. Ignoring it also
     // prevents a replayed Yjs frame from spuriously re-running ECS effects.
-    if (this.lastSeq !== null && update.seq <= this.lastSeq) return
+    if (this.lastSeq !== null && update.seq <= this.lastSeq) {
+      docLog.debug(
+        'doc_gap',
+        `dropped a stale frame at seq ${update.seq} (already at ${this.lastSeq})`,
+        { seq: update.seq, lastSeq: this.lastSeq, reason: 'stale' }
+      )
+      return
+    }
 
     // Seq is only a gap detector. A jump withholds the uncertain frame and
     // asks the host for a same-lineage state-vector delta using this EXACT
     // follower doc. Only an explicit doc_reset may replace it (ADR-0024).
     if (this.lastSeq !== null && update.seq > this.lastSeq + 1) {
+      docLog.warn(
+        'doc_gap',
+        `sequence gap: expected ${this.lastSeq + 1}, got ${update.seq} — resubscribing for a state-vector delta`,
+        { seq: update.seq, lastSeq: this.lastSeq, reason: 'gap' }
+      )
       this.resubscribe()
       return
     }

--- a/src/workbench/extensions/agent/crdt/layoutFollowerBridge.ts
+++ b/src/workbench/extensions/agent/crdt/layoutFollowerBridge.ts
@@ -227,12 +227,18 @@ export class LayoutFollowerBridge extends EventTarget {
       assertReadableSchema(this.follower.doc)
     } catch (error) {
       if (!(error instanceof FollowerSchemaError)) throw error
+      // Every subsequent frame fails the same gate, so re-announcing it once
+      // per frame would repeat a gate-bypassing `warn` for the rest of the
+      // session. The state is already readable via `lastSchemaError`.
+      const firstFailure = this.schemaError === null
       this.schemaError = error
-      this.dispatchEvent(
-        new CustomEvent('schema_error', {
-          detail: { workflowId: update.workflowId, found: error.found }
-        })
-      )
+      if (firstFailure) {
+        this.dispatchEvent(
+          new CustomEvent('schema_error', {
+            detail: { workflowId: update.workflowId, found: error.found }
+          })
+        )
+      }
       return
     }
 

--- a/src/workbench/extensions/agent/crdt/mergeScenarios.test.ts
+++ b/src/workbench/extensions/agent/crdt/mergeScenarios.test.ts
@@ -68,7 +68,7 @@ describe('merge scenarios', () => {
   it('keeps the applied prefix when a batch aborts', () => {
     const { survivingWidgets } = runScenario(scenario('batch-abort'))
 
-    expect(survivingWidgets['B.seed']).toBe(1)
+    expect(survivingWidgets['B.seed']).toBe(99)
     expect(survivingWidgets['B.steps']).toBe(20)
   })
 

--- a/src/workbench/extensions/agent/crdt/mergeScenarios.test.ts
+++ b/src/workbench/extensions/agent/crdt/mergeScenarios.test.ts
@@ -56,11 +56,20 @@ describe('merge scenarios', () => {
   it('reports the ops behind a rejection as never attempted, not as failures', () => {
     const [first, failed, tail] = runScenario(scenario('batch-abort')).entries
 
+    // The applier reports the aborted tail as `rejected/batch_aborted`, the
+    // same outcome as a genuine refusal. A tester must be able to tell "your
+    // edit was refused" from "your edit never got a turn".
     expect(first.verdict).toEqual({ kind: 'applied' })
     expect(failed.verdict.kind).toBe('rejected')
-    // A tester must be able to tell "your edit was refused" from "your edit
-    // never got a turn"; the applier gives both the same `rejected` outcome.
-    expect(tail.verdict.kind).toBe('applied')
+    expect(tail.verdict).toEqual({ kind: 'not-reached', code: 'batch_aborted' })
+    expect(tail.explanation).toContain('Never attempted')
+  })
+
+  it('keeps the applied prefix when a batch aborts', () => {
+    const { survivingWidgets } = runScenario(scenario('batch-abort'))
+
+    expect(survivingWidgets['B.seed']).toBe(1)
+    expect(survivingWidgets['B.steps']).toBe(20)
   })
 
   it('breaks a same-base_version tie on the actor, not on arrival order', () => {

--- a/src/workbench/extensions/agent/crdt/mergeScenarios.test.ts
+++ b/src/workbench/extensions/agent/crdt/mergeScenarios.test.ts
@@ -1,0 +1,99 @@
+/**
+ * These pin the merge SEMANTICS the panel explains to a tester, against the
+ * pinned applier. If the pin moves and a verdict changes, the explanations
+ * shown in the merge lab become wrong — which is worse than showing nothing —
+ * so the vectors fail here rather than misinform someone in the UI.
+ */
+import { describe, expect, it } from 'vitest'
+import { reactive } from 'vue'
+
+import type { MergeScenario } from './mergeScenarios'
+import { MERGE_SCENARIOS, runScenario } from './mergeScenarios'
+
+function scenario(id: string) {
+  const found = MERGE_SCENARIOS.find((candidate) => candidate.id === id)
+  if (!found) throw new Error(`no scenario ${id}`)
+  return found
+}
+
+function verdicts(id: string) {
+  return runScenario(scenario(id)).entries.map((entry) => entry.verdict)
+}
+
+describe('merge scenarios', () => {
+  it('shows a write to a deleted node vanishing, and a re-add NOT restoring it', () => {
+    const simulation = runScenario(scenario('delete-then-write-then-add'))
+
+    expect(simulation.entries.map((entry) => entry.verdict)).toEqual([
+      { kind: 'applied' },
+      { kind: 'no-op', because: 'delete-wins' },
+      { kind: 'applied' }
+    ])
+    // The whole point of the scenario: the widget edit made while the node was
+    // deleted is gone, and the re-added node carries the add's own payload.
+    expect(simulation.survivingWidgets['A.text']).toBe('a dog')
+    expect(simulation.survivingNodeIds).toContain('A')
+  })
+
+  it('names the incumbent stamp when a stale write loses a register', () => {
+    const [winner, loser] = runScenario(scenario('stale-write-loses')).entries
+
+    expect(winner.verdict).toEqual({ kind: 'applied' })
+    expect(loser.verdict.kind).toBe('lww-dropped')
+    expect(
+      loser.verdict.kind === 'lww-dropped' && loser.verdict.incumbent?.[2]
+    ).toBe(winner.opId)
+    expect(loser.explanation).toContain('Last-writer-wins')
+  })
+
+  it('distinguishes an idempotent resend from a conflict', () => {
+    expect(verdicts('idempotent-resend')).toEqual([
+      { kind: 'applied' },
+      { kind: 'no-op', because: 'duplicate-op-id' }
+    ])
+  })
+
+  it('reports the ops behind a rejection as never attempted, not as failures', () => {
+    const [first, failed, tail] = runScenario(scenario('batch-abort')).entries
+
+    expect(first.verdict).toEqual({ kind: 'applied' })
+    expect(failed.verdict.kind).toBe('rejected')
+    // A tester must be able to tell "your edit was refused" from "your edit
+    // never got a turn"; the applier gives both the same `rejected` outcome.
+    expect(tail.verdict.kind).toBe('applied')
+  })
+
+  it('breaks a same-base_version tie on the actor, not on arrival order', () => {
+    const simulation = runScenario(scenario('concurrent-widget-writes'))
+    const [first, second] = simulation.entries
+
+    expect(first.register).toBe(second.register)
+    expect(first.registerLabel).toContain('widget "seed"')
+    // Same base_version, so the actor breaks the tie: `human:bob:tab2` sorts
+    // above `human:alice:tab1` on every replica, arrival order regardless.
+    expect(first.verdict).toEqual({ kind: 'applied' })
+    expect(second.verdict.kind).toBe('lww-dropped')
+    expect(simulation.survivingWidgets['B.seed']).toBe(222)
+  })
+
+  it('runs a scenario held in Vue reactive state', () => {
+    // Regression: a deep reactive proxy reaching mint()'s structuredClone
+    // threw DataCloneError and took the whole merge lab down.
+    const proxied = reactive({
+      ...scenario('delete-then-write-then-add')
+    }) as MergeScenario
+
+    expect(() => runScenario(proxied)).not.toThrow()
+    expect(runScenario(proxied).entries).toHaveLength(3)
+  })
+
+  it('gives every op a register, a stamp and a human explanation', () => {
+    for (const candidate of MERGE_SCENARIOS) {
+      for (const entry of runScenario(candidate).entries) {
+        expect(entry.register).not.toBe('')
+        expect(entry.stamp).toHaveLength(3)
+        expect(entry.explanation.length).toBeGreaterThan(10)
+      }
+    }
+  })
+})

--- a/src/workbench/extensions/agent/crdt/mergeScenarios.ts
+++ b/src/workbench/extensions/agent/crdt/mergeScenarios.ts
@@ -137,21 +137,38 @@ function simulateOpStream(
   let index = 0
 
   for (const batch of batches) {
-    const alreadyApplied = batch.map((op) => hasAppliedOp(doc, op.op_id))
+    const nodeIds = batch.map(opNodeId)
+    // Both facts must be evaluated at the op's OWN position in the batch, not
+    // at the batch boundary: a resend and the op it repeats can share a batch,
+    // and so can a delete and the write it defeats.
+    const spentOpIds = new Set(
+      batch.filter((op) => hasAppliedOp(doc, op.op_id)).map((op) => op.op_id)
+    )
+    const present = new Map<string, boolean>()
+    for (const id of nodeIds) {
+      if (id !== null && !present.has(id)) present.set(id, hasNode(doc, id))
+    }
+
     const result = applyOps(doc, batch, catalog)
     const stampsAfter = readStamps(doc)
 
     batch.forEach((op, position) => {
       const outcome = result.outcomes[position]
-      const nodeId = opNodeId(op)
+      const nodeId = nodeIds[position]
       const verdict: MergeVerdict = outcome
         ? verdictFor(
             outcome,
-            alreadyApplied[position],
-            nodeId === null ? null : hasNode(doc, nodeId),
+            spentOpIds.has(op.op_id),
+            nodeId === null ? null : (present.get(nodeId) ?? false),
             stampKeyOf(stampsAfter[stampTargetKey(op)])
           )
         : { kind: 'no-op', because: 'unknown' }
+
+      spentOpIds.add(op.op_id)
+      if (nodeId !== null && outcome?.outcome === 'applied') {
+        if (op.op === 'add_node') present.set(nodeId, true)
+        else if (op.op === 'delete_node') present.set(nodeId, false)
+      }
 
       entries.push(traceEntry(op, index, verdict))
       index++
@@ -352,7 +369,7 @@ export const MERGE_SCENARIOS: readonly MergeScenario[] = [
     batches: [
       [
         op(
-          { op: 'set_widget', node_id: 'B', widget: 'seed', value: 1 },
+          { op: 'set_widget', node_id: 'B', widget: 'seed', value: 99 },
           ALICE,
           1
         ),

--- a/src/workbench/extensions/agent/crdt/mergeScenarios.ts
+++ b/src/workbench/extensions/agent/crdt/mergeScenarios.ts
@@ -40,8 +40,15 @@ export interface MergeScenario {
   question: string
   workflow: WorkflowJSON
   catalog: WidgetCatalog
-  /** Ops in the order the host would receive them. */
-  ops: Op[]
+  /**
+   * Ops grouped into the batches the host would receive, in arrival order.
+   *
+   * Batching is explicit because it is load-bearing, not incidental: the
+   * applier aborts the remainder of a BATCH on a rejection, so a scenario
+   * about abort-remainder is only honest if its ops actually share one.
+   * `opSender` chunks real traffic the same way.
+   */
+  batches: Op[][]
 }
 
 export interface MergeSimulation {
@@ -76,7 +83,7 @@ function stampKeyOf(value: unknown): StampKey | null {
 function verdictFor(
   outcome: ApplyOutcome,
   wasDuplicate: boolean,
-  nodeWasPresent: boolean | null,
+  nodePresentAfter: boolean | null,
   incumbentStamp: StampKey | null
 ): MergeVerdict {
   switch (outcome.outcome) {
@@ -94,7 +101,7 @@ function verdictFor(
           }
     case 'no-op':
       if (wasDuplicate) return { kind: 'no-op', because: 'duplicate-op-id' }
-      if (nodeWasPresent === false)
+      if (nodePresentAfter === false)
         return { kind: 'no-op', because: 'delete-wins' }
       return { kind: 'no-op', because: 'unknown' }
   }
@@ -111,36 +118,45 @@ function asPlainJson(workflow: WorkflowJSON): WorkflowJSON {
 }
 
 /**
- * Replay `ops` against a fresh document minted from `workflow`.
+ * Replay `batches` against a fresh document minted from `workflow`.
  *
- * Ops are applied ONE AT A TIME rather than as one batch. The verdict for an
- * op depends on the document as it stood immediately before that op — whether
- * the target node still existed, which stamp owned the register — and a batch
- * call collapses those intermediate states. One-at-a-time is also what the
- * real system does across frames, which is the case a tester is asking about.
+ * Duplicate detection reads the doc BEFORE the batch (an op_id already spent
+ * is what makes a resend idempotent), while node presence and register
+ * ownership are read AFTER it. Reading those two afterwards is what lets a
+ * delete and the write it defeats sit in the SAME batch and still be
+ * explained: the question "was there anything left to write to?" is only
+ * answerable once the batch has settled.
  */
 function simulateOpStream(
   workflow: WorkflowJSON,
   catalog: WidgetCatalog,
-  ops: readonly Op[]
+  batches: readonly Op[][]
 ): MergeSimulation {
   const doc = mint(asPlainJson(workflow), catalog)
   const entries: MergeTraceEntry[] = []
+  let index = 0
 
-  ops.forEach((op, index) => {
-    const nodeId = opNodeId(op)
-    const wasDuplicate = hasAppliedOp(doc, op.op_id)
-    const nodeWasPresent = nodeId === null ? null : hasNode(doc, nodeId)
-    const incumbentStamp = stampKeyOf(readStamps(doc)[stampTargetKey(op)])
+  for (const batch of batches) {
+    const alreadyApplied = batch.map((op) => hasAppliedOp(doc, op.op_id))
+    const result = applyOps(doc, batch, catalog)
+    const stampsAfter = readStamps(doc)
 
-    const result = applyOps(doc, [op], catalog)
-    const outcome = result.outcomes[0]
-    const verdict: MergeVerdict = outcome
-      ? verdictFor(outcome, wasDuplicate, nodeWasPresent, incumbentStamp)
-      : { kind: 'no-op', because: 'unknown' }
+    batch.forEach((op, position) => {
+      const outcome = result.outcomes[position]
+      const nodeId = opNodeId(op)
+      const verdict: MergeVerdict = outcome
+        ? verdictFor(
+            outcome,
+            alreadyApplied[position],
+            nodeId === null ? null : hasNode(doc, nodeId),
+            stampKeyOf(stampsAfter[stampTargetKey(op)])
+          )
+        : { kind: 'no-op', because: 'unknown' }
 
-    entries.push(traceEntry(op, index, verdict))
-  })
+      entries.push(traceEntry(op, index, verdict))
+      index++
+    })
+  }
 
   const graph = readGraph(doc)
   const survivingWidgets: Record<string, unknown> = {}
@@ -160,7 +176,12 @@ function simulateOpStream(
 }
 
 export function runScenario(scenario: MergeScenario): MergeSimulation {
-  return simulateOpStream(scenario.workflow, scenario.catalog, scenario.ops)
+  return simulateOpStream(scenario.workflow, scenario.catalog, scenario.batches)
+}
+
+/** Each op arrives in its own batch — the ordinary frame-by-frame case. */
+function separately(...ops: Op[]): Op[][] {
+  return ops.map((op) => [op])
 }
 
 // ── canned scenarios ──────────────────────────────────────────────────────
@@ -239,7 +260,7 @@ export const MERGE_SCENARIOS: readonly MergeScenario[] = [
       'Does an edit made while a node is deleted survive if the node comes back?',
     workflow: SEED_WORKFLOW,
     catalog: CATALOG,
-    ops: [
+    batches: separately(
       op({ op: 'delete_node', node_id: 'A', removed_links: [] }, ALICE, 1),
       op(
         { op: 'set_widget', node_id: 'A', widget: 'text', value: 'a bird' },
@@ -247,7 +268,7 @@ export const MERGE_SCENARIOS: readonly MergeScenario[] = [
         1
       ),
       addNodeA(BOB, 2)
-    ]
+    )
   },
   {
     id: 'write-then-delete-then-write',
@@ -256,7 +277,7 @@ export const MERGE_SCENARIOS: readonly MergeScenario[] = [
       'Where exactly does the delete cut the timeline for a node\u2019s values?',
     workflow: SEED_WORKFLOW,
     catalog: CATALOG,
-    ops: [
+    batches: separately(
       op(
         { op: 'set_widget', node_id: 'A', widget: 'text', value: 'first' },
         ALICE,
@@ -268,7 +289,7 @@ export const MERGE_SCENARIOS: readonly MergeScenario[] = [
         ALICE,
         3
       )
-    ]
+    )
   },
   {
     id: 'concurrent-widget-writes',
@@ -277,7 +298,7 @@ export const MERGE_SCENARIOS: readonly MergeScenario[] = [
       'Both were minted against the same document version, and the one that arrives SECOND loses. What decided it?',
     workflow: SEED_WORKFLOW,
     catalog: CATALOG,
-    ops: [
+    batches: separately(
       op(
         { op: 'set_widget', node_id: 'B', widget: 'seed', value: 222 },
         BOB,
@@ -288,7 +309,7 @@ export const MERGE_SCENARIOS: readonly MergeScenario[] = [
         ALICE,
         4
       )
-    ]
+    )
   },
   {
     id: 'stale-write-loses',
@@ -297,14 +318,14 @@ export const MERGE_SCENARIOS: readonly MergeScenario[] = [
       'Does arrival order or stamp order decide a widget register contest?',
     workflow: SEED_WORKFLOW,
     catalog: CATALOG,
-    ops: [
+    batches: separately(
       op(
         { op: 'set_widget', node_id: 'B', widget: 'steps', value: 50 },
         ALICE,
         9
       ),
       op({ op: 'set_widget', node_id: 'B', widget: 'steps', value: 4 }, BOB, 2)
-    ]
+    )
   },
   {
     id: 'idempotent-resend',
@@ -312,37 +333,40 @@ export const MERGE_SCENARIOS: readonly MergeScenario[] = [
     question: 'Is a retry safe, and how is it distinguishable from a conflict?',
     workflow: SEED_WORKFLOW,
     catalog: CATALOG,
-    ops: (() => {
+    batches: (() => {
       const once = op(
         { op: 'set_widget', node_id: 'B', widget: 'seed', value: 7 },
         ALICE,
         1
       )
-      return [once, once]
+      return separately(once, once)
     })()
   },
   {
     id: 'batch-abort',
-    title: 'a rejected op in the middle of a batch',
-    question: 'What happens to the ops queued behind a rejection?',
+    title: 'a rejected op in the middle of ONE batch',
+    question:
+      'All three ship together. What happens to the ops queued behind the rejection?',
     workflow: SEED_WORKFLOW,
     catalog: CATALOG,
-    ops: [
-      op(
-        { op: 'set_widget', node_id: 'B', widget: 'seed', value: 1 },
-        ALICE,
-        1
-      ),
-      op(
-        { op: 'set_widget', node_id: 'B', widget: 'not_a_widget', value: 1 },
-        ALICE,
-        2
-      ),
-      op(
-        { op: 'set_widget', node_id: 'B', widget: 'steps', value: 3 },
-        ALICE,
-        3
-      )
+    batches: [
+      [
+        op(
+          { op: 'set_widget', node_id: 'B', widget: 'seed', value: 1 },
+          ALICE,
+          1
+        ),
+        op(
+          { op: 'set_widget', node_id: 'B', widget: 'not_a_widget', value: 1 },
+          ALICE,
+          2
+        ),
+        op(
+          { op: 'set_widget', node_id: 'B', widget: 'steps', value: 3 },
+          ALICE,
+          3
+        )
+      ]
     ]
   }
 ]

--- a/src/workbench/extensions/agent/crdt/mergeScenarios.ts
+++ b/src/workbench/extensions/agent/crdt/mergeScenarios.ts
@@ -1,0 +1,348 @@
+/**
+ * A merge laboratory: run an ordered op stream through the REAL applier and
+ * report, per op, what the document decided and why.
+ *
+ * The point is that this is not a model of the merge rules — it IS the merge
+ * rules. `applyOps` here is byte-for-byte the function the cloud doc host
+ * runs, so a verdict shown in the panel is the verdict production would
+ * produce for that arrival order. A simulator that merely *described* the
+ * semantics would drift from them the first time the pin moved, and a tester
+ * shown a drifted explanation is worse off than one shown nothing.
+ *
+ * Everything is local and synchronous: no socket, no backend, no shared doc.
+ */
+import {
+  applyOps,
+  hasAppliedOp,
+  hasNode,
+  mint,
+  readGraph,
+  readStamps,
+  stampTargetKey
+} from '@comfyorg/comfy-multi-player'
+import type {
+  ApplyOutcome,
+  Op,
+  StampKey,
+  WidgetCatalog,
+  WorkflowJSON
+} from '@comfyorg/comfy-multi-player'
+
+import type { MergeTraceEntry, MergeVerdict } from './mergeTrace'
+import { opNodeId, traceEntry } from './mergeTrace'
+import type { GraphOperation } from './graphOperations'
+import { mintWireOps } from './opEnvelope'
+
+export interface MergeScenario {
+  id: string
+  title: string
+  /** What a tester is meant to learn from running it. */
+  question: string
+  workflow: WorkflowJSON
+  catalog: WidgetCatalog
+  /** Ops in the order the host would receive them. */
+  ops: Op[]
+}
+
+export interface MergeSimulation {
+  entries: MergeTraceEntry[]
+  /** Node ids surviving in the document after the whole stream. */
+  survivingNodeIds: string[]
+  /** Widget values that survived, keyed `nodeId.widget`. */
+  survivingWidgets: Record<string, unknown>
+}
+
+function stampKeyOf(value: unknown): StampKey | null {
+  if (!Array.isArray(value) || value.length < 3) return null
+  const [baseVersion, actor, opId] = value
+  if (
+    typeof baseVersion !== 'number' ||
+    typeof actor !== 'string' ||
+    typeof opId !== 'string'
+  ) {
+    return null
+  }
+  return [baseVersion, actor, opId]
+}
+
+/**
+ * Turn the applier's outcome into a verdict that says WHY.
+ *
+ * `applyOps` reports a bare `no-op` both for a resend it has already seen and
+ * for a write to a node someone deleted. The two are distinguishable only
+ * from the document as it stood BEFORE the op, which is why this is probed
+ * per op rather than reconstructed afterwards.
+ */
+function verdictFor(
+  outcome: ApplyOutcome,
+  wasDuplicate: boolean,
+  nodeWasPresent: boolean | null,
+  incumbentStamp: StampKey | null
+): MergeVerdict {
+  switch (outcome.outcome) {
+    case 'applied':
+      return { kind: 'applied' }
+    case 'lww-dropped':
+      return { kind: 'lww-dropped', incumbent: incumbentStamp }
+    case 'rejected':
+      return outcome.reason.code === 'batch_aborted'
+        ? { kind: 'not-reached', code: outcome.reason.code }
+        : {
+            kind: 'rejected',
+            code: outcome.reason.code,
+            message: outcome.reason.message
+          }
+    case 'no-op':
+      if (wasDuplicate) return { kind: 'no-op', because: 'duplicate-op-id' }
+      if (nodeWasPresent === false)
+        return { kind: 'no-op', because: 'delete-wins' }
+      return { kind: 'no-op', because: 'unknown' }
+  }
+}
+
+/**
+ * `mint` clones the workflow with `structuredClone`, which throws on a
+ * Proxy — and a caller holding the scenario in Vue reactive state hands one
+ * over without ever knowing. Round-tripping through JSON is the cheapest way
+ * to guarantee the plain data the applier's contract assumes.
+ */
+function asPlainJson(workflow: WorkflowJSON): WorkflowJSON {
+  return JSON.parse(JSON.stringify(workflow)) as WorkflowJSON
+}
+
+/**
+ * Replay `ops` against a fresh document minted from `workflow`.
+ *
+ * Ops are applied ONE AT A TIME rather than as one batch. The verdict for an
+ * op depends on the document as it stood immediately before that op — whether
+ * the target node still existed, which stamp owned the register — and a batch
+ * call collapses those intermediate states. One-at-a-time is also what the
+ * real system does across frames, which is the case a tester is asking about.
+ */
+function simulateOpStream(
+  workflow: WorkflowJSON,
+  catalog: WidgetCatalog,
+  ops: readonly Op[]
+): MergeSimulation {
+  const doc = mint(asPlainJson(workflow), catalog)
+  const entries: MergeTraceEntry[] = []
+
+  ops.forEach((op, index) => {
+    const nodeId = opNodeId(op)
+    const wasDuplicate = hasAppliedOp(doc, op.op_id)
+    const nodeWasPresent = nodeId === null ? null : hasNode(doc, nodeId)
+    const incumbentStamp = stampKeyOf(readStamps(doc)[stampTargetKey(op)])
+
+    const result = applyOps(doc, [op], catalog)
+    const outcome = result.outcomes[0]
+    const verdict: MergeVerdict = outcome
+      ? verdictFor(outcome, wasDuplicate, nodeWasPresent, incumbentStamp)
+      : { kind: 'no-op', because: 'unknown' }
+
+    entries.push(traceEntry(op, index, verdict))
+  })
+
+  const graph = readGraph(doc)
+  const survivingWidgets: Record<string, unknown> = {}
+  for (const [id, node] of Object.entries(graph.nodes)) {
+    const widgets = node.widgets
+    if (typeof widgets !== 'object' || widgets === null) continue
+    for (const [name, value] of Object.entries(widgets)) {
+      survivingWidgets[`${id}.${name}`] = value
+    }
+  }
+
+  return {
+    entries,
+    survivingNodeIds: Object.keys(graph.nodes),
+    survivingWidgets
+  }
+}
+
+export function runScenario(scenario: MergeScenario): MergeSimulation {
+  return simulateOpStream(scenario.workflow, scenario.catalog, scenario.ops)
+}
+
+// ── canned scenarios ──────────────────────────────────────────────────────
+
+const CATALOG: WidgetCatalog = {
+  types: {
+    CLIPTextEncode: { widget_order: ['text'] },
+    KSampler: { widget_order: ['seed', 'steps'] }
+  }
+}
+
+const SEED_WORKFLOW: WorkflowJSON = {
+  nodes: [
+    {
+      id: 'A',
+      type: 'CLIPTextEncode',
+      pos: [0, 0],
+      widgets_values: ['a cat'],
+      inputs: [],
+      outputs: []
+    },
+    {
+      id: 'B',
+      type: 'KSampler',
+      pos: [200, 0],
+      widgets_values: [1, 20],
+      inputs: [],
+      outputs: []
+    }
+  ],
+  links: []
+}
+
+/**
+ * Mint one scenario op through the SAME envelope code the real write leg
+ * uses, so a scenario cannot accidentally demonstrate stamp semantics the
+ * production sender would never produce.
+ */
+function op(body: GraphOperation, actor: string, baseVersion: number): Op {
+  const [minted] = mintWireOps([body], { actor, baseVersion })
+  return minted
+}
+
+const ALICE = 'human:alice:tab1'
+const BOB = 'human:bob:tab2'
+
+function addNodeA(actor: string, baseVersion: number): Op {
+  return op(
+    {
+      op: 'add_node',
+      node_id: 'A',
+      class_type: 'CLIPTextEncode',
+      pos: [0, 0],
+      node: {
+        id: 'A',
+        type: 'CLIPTextEncode',
+        pos: [0, 0],
+        widgets_values: ['a dog']
+      }
+    },
+    actor,
+    baseVersion
+  )
+}
+
+/**
+ * The scenarios a tester runs to build intuition. Each is a question, not a
+ * demo: the title says what is contested and the `question` says what the
+ * outcome is supposed to teach.
+ */
+export const MERGE_SCENARIOS: readonly MergeScenario[] = [
+  {
+    id: 'delete-then-write-then-add',
+    title: 'delete A → set widget on A → add A',
+    question:
+      'Does an edit made while a node is deleted survive if the node comes back?',
+    workflow: SEED_WORKFLOW,
+    catalog: CATALOG,
+    ops: [
+      op({ op: 'delete_node', node_id: 'A', removed_links: [] }, ALICE, 1),
+      op(
+        { op: 'set_widget', node_id: 'A', widget: 'text', value: 'a bird' },
+        BOB,
+        1
+      ),
+      addNodeA(BOB, 2)
+    ]
+  },
+  {
+    id: 'write-then-delete-then-write',
+    title: 'set widget → delete A → set widget again',
+    question:
+      'Where exactly does the delete cut the timeline for a node\u2019s values?',
+    workflow: SEED_WORKFLOW,
+    catalog: CATALOG,
+    ops: [
+      op(
+        { op: 'set_widget', node_id: 'A', widget: 'text', value: 'first' },
+        ALICE,
+        1
+      ),
+      op({ op: 'delete_node', node_id: 'A', removed_links: [] }, BOB, 2),
+      op(
+        { op: 'set_widget', node_id: 'A', widget: 'text', value: 'second' },
+        ALICE,
+        3
+      )
+    ]
+  },
+  {
+    id: 'concurrent-widget-writes',
+    title: 'two people set the same widget concurrently',
+    question:
+      'Both were minted against the same document version, and the one that arrives SECOND loses. What decided it?',
+    workflow: SEED_WORKFLOW,
+    catalog: CATALOG,
+    ops: [
+      op(
+        { op: 'set_widget', node_id: 'B', widget: 'seed', value: 222 },
+        BOB,
+        4
+      ),
+      op(
+        { op: 'set_widget', node_id: 'B', widget: 'seed', value: 111 },
+        ALICE,
+        4
+      )
+    ]
+  },
+  {
+    id: 'stale-write-loses',
+    title: 'a stale write arrives after a newer one',
+    question:
+      'Does arrival order or stamp order decide a widget register contest?',
+    workflow: SEED_WORKFLOW,
+    catalog: CATALOG,
+    ops: [
+      op(
+        { op: 'set_widget', node_id: 'B', widget: 'steps', value: 50 },
+        ALICE,
+        9
+      ),
+      op({ op: 'set_widget', node_id: 'B', widget: 'steps', value: 4 }, BOB, 2)
+    ]
+  },
+  {
+    id: 'idempotent-resend',
+    title: 'the same op is sent twice',
+    question: 'Is a retry safe, and how is it distinguishable from a conflict?',
+    workflow: SEED_WORKFLOW,
+    catalog: CATALOG,
+    ops: (() => {
+      const once = op(
+        { op: 'set_widget', node_id: 'B', widget: 'seed', value: 7 },
+        ALICE,
+        1
+      )
+      return [once, once]
+    })()
+  },
+  {
+    id: 'batch-abort',
+    title: 'a rejected op in the middle of a batch',
+    question: 'What happens to the ops queued behind a rejection?',
+    workflow: SEED_WORKFLOW,
+    catalog: CATALOG,
+    ops: [
+      op(
+        { op: 'set_widget', node_id: 'B', widget: 'seed', value: 1 },
+        ALICE,
+        1
+      ),
+      op(
+        { op: 'set_widget', node_id: 'B', widget: 'not_a_widget', value: 1 },
+        ALICE,
+        2
+      ),
+      op(
+        { op: 'set_widget', node_id: 'B', widget: 'steps', value: 3 },
+        ALICE,
+        3
+      )
+    ]
+  }
+]

--- a/src/workbench/extensions/agent/crdt/mergeTrace.test.ts
+++ b/src/workbench/extensions/agent/crdt/mergeTrace.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest'
+
+import { MERGE_SCENARIOS, runScenario } from './mergeScenarios'
+import { groupByRegister, nodeLifecycle, registerLabel } from './mergeTrace'
+
+function scenarioEntries(id: string) {
+  const found = MERGE_SCENARIOS.find((candidate) => candidate.id === id)
+  if (!found) throw new Error(`no scenario ${id}`)
+  return runScenario(found).entries
+}
+
+describe('registerLabel', () => {
+  it('names the contested cell in words a tester can act on', () => {
+    expect(registerLabel(['widget', '7', 'seed'])).toBe(
+      'widget "seed" on node 7'
+    )
+    expect(registerLabel(['input', '7', 2])).toBe('input slot 2 on node 7')
+  })
+
+  it('falls back to the raw target rather than hiding an unknown shape', () => {
+    expect(registerLabel(['something_new', 'x'])).toBe('something_new · x')
+  })
+})
+
+describe('nodeLifecycle', () => {
+  it('counts a delete-then-re-add as a NEW incarnation of the same id', () => {
+    const rows = nodeLifecycle(scenarioEntries('delete-then-write-then-add'))
+
+    expect(rows.map((row) => [row.entry.kind, row.incarnation])).toEqual([
+      ['delete_node', 1],
+      ['set_widget', 1],
+      ['add_node', 2]
+    ])
+  })
+
+  it('leaves graph-wide ops out of the per-node story', () => {
+    const rows = nodeLifecycle([
+      {
+        index: 0,
+        opId: 'a',
+        kind: 'clear',
+        actor: 'human:u:t',
+        register: '["clear"]',
+        registerLabel: 'the whole graph',
+        stamp: [1, 'human:u:t', 'a'],
+        nodeId: null,
+        verdict: { kind: 'applied' },
+        explanation: ''
+      }
+    ])
+
+    expect(rows).toEqual([])
+  })
+})
+
+describe('groupByRegister', () => {
+  it('puts the most-contested register first', () => {
+    const groups = groupByRegister(scenarioEntries('concurrent-widget-writes'))
+
+    expect(groups[0].entries).toHaveLength(2)
+    expect(groups[0].label).toContain('widget "seed"')
+  })
+})

--- a/src/workbench/extensions/agent/crdt/mergeTrace.test.ts
+++ b/src/workbench/extensions/agent/crdt/mergeTrace.test.ts
@@ -33,6 +33,37 @@ describe('nodeLifecycle', () => {
     ])
   })
 
+  it('does not let a no-op write inflate the first real incarnation', () => {
+    const rows = nodeLifecycle([
+      {
+        index: 0,
+        opId: 'a',
+        kind: 'set_widget',
+        actor: 'human:u:t',
+        register: '["widget","A","text"]',
+        registerLabel: 'widget "text" on node A',
+        stamp: [1, 'human:u:t', 'a'],
+        nodeId: 'A',
+        verdict: { kind: 'no-op', because: 'delete-wins' },
+        explanation: ''
+      },
+      {
+        index: 1,
+        opId: 'b',
+        kind: 'add_node',
+        actor: 'human:u:t',
+        register: '["node","A"]',
+        registerLabel: 'node A',
+        stamp: [2, 'human:u:t', 'b'],
+        nodeId: 'A',
+        verdict: { kind: 'applied' },
+        explanation: ''
+      }
+    ])
+
+    expect(rows.map((row) => row.incarnation)).toEqual([1, 1])
+  })
+
   it('leaves graph-wide ops out of the per-node story', () => {
     const rows = nodeLifecycle([
       {

--- a/src/workbench/extensions/agent/crdt/mergeTrace.ts
+++ b/src/workbench/extensions/agent/crdt/mergeTrace.ts
@@ -163,7 +163,7 @@ function explainVerdict(
     case 'rejected':
       return `Rejected (${verdict.code}): ${verdict.message}. Everything after it in the same batch was abandoned; everything before it was kept.`
     case 'not-reached':
-      return `Never attempted: an earlier op in this batch was rejected (${verdict.code}), and a batch aborts its remainder.`
+      return 'Never attempted: an earlier op in the same batch was rejected, and a batch abandons everything after the failure. The ops before it are kept, so resending the batch without the bad op converges.'
   }
 }
 

--- a/src/workbench/extensions/agent/crdt/mergeTrace.ts
+++ b/src/workbench/extensions/agent/crdt/mergeTrace.ts
@@ -234,14 +234,18 @@ export function nodeLifecycle(
   for (const entry of entries) {
     if (entry.nodeId === null) continue
     const current = incarnations.get(entry.nodeId) ?? 1
-    const applied = entry.verdict.kind === 'applied'
-    if (entry.kind === 'add_node' && applied) {
+    if (entry.kind === 'add_node' && entry.verdict.kind === 'applied') {
       const next = incarnations.has(entry.nodeId) ? current + 1 : 1
       incarnations.set(entry.nodeId, next)
       rows.push({ nodeId: entry.nodeId, incarnation: next, entry })
       continue
     }
-    incarnations.set(entry.nodeId, current)
+    // Only an op that took effect may seed the map. A write that no-op'd
+    // against a not-yet-existing node would otherwise register the id, and
+    // the add that follows it would be labelled the SECOND incarnation.
+    if (entry.verdict.kind === 'applied') {
+      incarnations.set(entry.nodeId, current)
+    }
     rows.push({ nodeId: entry.nodeId, incarnation: current, entry })
   }
   return rows

--- a/src/workbench/extensions/agent/crdt/mergeTrace.ts
+++ b/src/workbench/extensions/agent/crdt/mergeTrace.ts
@@ -1,0 +1,248 @@
+/**
+ * The shared vocabulary for talking about CRDT merges and sequencing.
+ *
+ * A tester who sees a surprising outcome needs three answers, in this order:
+ * WHICH CELL was contested, WHICH ORDER the contenders sorted in, and WHY the
+ * loser lost. The pinned applier already names all three — `writeTarget` is
+ * the cell, `stampKey` is the order, `ApplyOutcome` is the verdict — so this
+ * module deliberately re-exports that language rather than inventing a
+ * parallel one. Anything the panel renders is a rewording of a fact the
+ * document itself would report.
+ *
+ * Nothing here reads or writes a shared document: these are pure functions
+ * over ops and over a read-only snapshot the caller supplies.
+ */
+import {
+  stampKey,
+  stampTargetKey,
+  writeTarget
+} from '@comfyorg/comfy-multi-player'
+import type { NodeId, StampKey, WireOp } from '@comfyorg/comfy-multi-player'
+
+/**
+ * Why an op ended up with the outcome it did.
+ *
+ * The `because` arm on `no-op` is the one that matters to a tester: the
+ * applier reports a bare `no-op` for two completely different situations — a
+ * resend it has already seen, and a write to a node someone else deleted —
+ * and conflating them is exactly the confusion this instrument exists to end.
+ */
+export type MergeVerdict =
+  | { kind: 'applied' }
+  | { kind: 'no-op'; because: 'duplicate-op-id' | 'delete-wins' | 'unknown' }
+  | { kind: 'lww-dropped'; incumbent: StampKey | null }
+  | { kind: 'rejected'; code: string; message: string }
+  | { kind: 'not-reached'; code: string }
+
+/** One op, placed in the merge story: what it contested and how it fared. */
+export interface MergeTraceEntry {
+  index: number
+  opId: string
+  kind: string
+  actor: string
+  /** The LWW cell this op competes for (`writeTarget`, stably serialized). */
+  register: string
+  /** Human-readable form of the same cell. */
+  registerLabel: string
+  /** `[base_version, actor, op_id]` — the total order the applier sorts by. */
+  stamp: StampKey
+  /** The node this op addresses, when it addresses one. */
+  nodeId: string | null
+  verdict: MergeVerdict
+  /** One sentence a product tester can read without knowing Yjs. */
+  explanation: string
+}
+
+/**
+ * The glossary the panel renders next to the trace, so a bug report and the
+ * code use the same words for the same thing.
+ */
+export const MERGE_VOCABULARY: readonly {
+  term: string
+  meaning: string
+}[] = [
+  {
+    term: 'register',
+    meaning:
+      'The single cell two edits can contest — e.g. one widget on one node, or one input slot. Edits to different registers never conflict.'
+  },
+  {
+    term: 'stamp',
+    meaning:
+      'The total order edits are compared in: [base_version, actor, op_id]. Higher wins; the op_id breaks exact ties so every replica picks the same winner offline.'
+  },
+  {
+    term: 'applied',
+    meaning: 'The edit took effect and now owns its register.'
+  },
+  {
+    term: 'lww-dropped',
+    meaning:
+      'The edit reached the document but an edit with a higher stamp already owned the register, so it was discarded. Last-writer-wins.'
+  },
+  {
+    term: 'no-op (delete-wins)',
+    meaning:
+      'The edit targeted a node that was already deleted. Deletion is not a register contest: once a node is gone, writes to it vanish silently until something re-adds it.'
+  },
+  {
+    term: 'no-op (duplicate)',
+    meaning:
+      'The document had already applied this op_id. Retries are idempotent by design, so a resend changes nothing.'
+  },
+  {
+    term: 'rejected',
+    meaning:
+      'The document refused the edit (unknown op kind, deferred kind, bad payload). The rest of the batch is abandoned; the prefix before it is kept.'
+  },
+  {
+    term: 'not-reached',
+    meaning:
+      'An earlier op in the same batch was rejected, so this one was never attempted (abort-remainder).'
+  }
+]
+
+/** The node an op addresses, or `null` for ops that address the whole graph. */
+export function opNodeId(op: WireOp): string | null {
+  if (op.op === 'clear' || op.op === 'reset_doc') return null
+  const raw = (op as { node_id?: NodeId }).node_id
+  if (raw !== undefined) return String(raw)
+  const target = (op as { to_node?: NodeId }).to_node
+  return target === undefined ? null : String(target)
+}
+
+/**
+ * A human label for the contested cell.
+ *
+ * `writeTarget` returns the applier's own tuple (e.g. `['widget', '7',
+ * 'seed']`); rendering it verbatim is honest but unreadable, so each shape
+ * gets a sentence and anything unrecognised falls back to the raw tuple
+ * rather than being hidden.
+ */
+export function registerLabel(target: readonly unknown[]): string {
+  const [kind, ...rest] = target.map((part) => String(part))
+  switch (kind) {
+    case 'widget':
+      return `widget "${rest[1]}" on node ${rest[0]}`
+    case 'input':
+      return `input slot ${rest[1]} on node ${rest[0]}`
+    case 'node':
+      return `node ${rest[0]}`
+    case 'clear':
+      return 'the whole graph'
+    default:
+      return target.map((part) => String(part)).join(' · ')
+  }
+}
+
+function formatStampKey(key: StampKey): string {
+  const [baseVersion, actor, opId] = key
+  return `v${baseVersion} · ${actor} · ${opId.slice(0, 8)}`
+}
+
+function explainVerdict(
+  op: WireOp,
+  label: string,
+  verdict: MergeVerdict
+): string {
+  switch (verdict.kind) {
+    case 'applied':
+      return `Applied. \`${op.op}\` now owns ${label}.`
+    case 'no-op':
+      if (verdict.because === 'delete-wins') {
+        return `No effect: node ${opNodeId(op) ?? '?'} had already been deleted, so this write had nowhere to land. Deletion is not a stamp contest — it wins over every write that arrives after it, whatever the stamps say. A later add_node re-creates the node as a fresh incarnation and does NOT resurrect this value.`
+      }
+      if (verdict.because === 'duplicate-op-id') {
+        return `No effect: op_id ${op.op_id.slice(0, 8)} had already been applied. Resends are idempotent, which is why the sender never re-mints an op_id.`
+      }
+      return 'No effect. The document had nothing to change for this op.'
+    case 'lww-dropped':
+      return verdict.incumbent
+        ? `Dropped: ${label} was already owned by a higher stamp (${formatStampKey(verdict.incumbent)}) than this op's (${formatStampKey(stampKey(op))}). Last-writer-wins picked the incumbent.`
+        : `Dropped: a higher stamp already owned ${label}. Last-writer-wins picked the incumbent.`
+    case 'rejected':
+      return `Rejected (${verdict.code}): ${verdict.message}. Everything after it in the same batch was abandoned; everything before it was kept.`
+    case 'not-reached':
+      return `Never attempted: an earlier op in this batch was rejected (${verdict.code}), and a batch aborts its remainder.`
+  }
+}
+
+export function traceEntry(
+  op: WireOp,
+  index: number,
+  verdict: MergeVerdict
+): MergeTraceEntry {
+  const label = registerLabel(writeTarget(op))
+  return {
+    index,
+    opId: op.op_id,
+    kind: op.op,
+    actor: op.actor,
+    register: stampTargetKey(op),
+    registerLabel: label,
+    stamp: stampKey(op),
+    nodeId: opNodeId(op),
+    verdict,
+    explanation: explainVerdict(op, label, verdict)
+  }
+}
+
+/**
+ * Group a trace by the register each op contested — the view that answers
+ * "why did these two edits fight?" at a glance.
+ */
+export function groupByRegister(
+  entries: readonly MergeTraceEntry[]
+): { register: string; label: string; entries: MergeTraceEntry[] }[] {
+  const groups = new Map<
+    string,
+    { label: string; entries: MergeTraceEntry[] }
+  >()
+  for (const entry of entries) {
+    const group = groups.get(entry.register) ?? {
+      label: entry.registerLabel,
+      entries: []
+    }
+    group.entries.push(entry)
+    groups.set(entry.register, group)
+  }
+  return [...groups]
+    .map(([register, group]) => ({ register, ...group }))
+    .sort((a, b) => b.entries.length - a.entries.length)
+}
+
+/**
+ * The per-node story: every op that touched a node, in arrival order, with
+ * the incarnation it belonged to.
+ *
+ * Incarnation is the concept the delete/re-add case turns on — a node that is
+ * deleted and re-added under the same id is NOT the same node, and every
+ * widget value from the previous incarnation is gone. Numbering them makes
+ * that visible instead of leaving a tester to infer it.
+ */
+export interface NodeLifecycleRow {
+  nodeId: string
+  incarnation: number
+  entry: MergeTraceEntry
+}
+
+export function nodeLifecycle(
+  entries: readonly MergeTraceEntry[]
+): NodeLifecycleRow[] {
+  const incarnations = new Map<string, number>()
+  const rows: NodeLifecycleRow[] = []
+  for (const entry of entries) {
+    if (entry.nodeId === null) continue
+    const current = incarnations.get(entry.nodeId) ?? 1
+    const applied = entry.verdict.kind === 'applied'
+    if (entry.kind === 'add_node' && applied) {
+      const next = incarnations.has(entry.nodeId) ? current + 1 : 1
+      incarnations.set(entry.nodeId, next)
+      rows.push({ nodeId: entry.nodeId, incarnation: next, entry })
+      continue
+    }
+    incarnations.set(entry.nodeId, current)
+    rows.push({ nodeId: entry.nodeId, incarnation: current, entry })
+  }
+  return rows
+}

--- a/src/workbench/extensions/agent/crdt/opSender.ts
+++ b/src/workbench/extensions/agent/crdt/opSender.ts
@@ -187,14 +187,16 @@ export function createOpSender(deps: OpSenderDeps): OpSender {
         baseVersion: deps.baseVersion()
       })
       for (const op of minted) {
+        // Envelope only. An `add_node` carries a whole serialized node, and
+        // the ring buffer holds 500 entries — retaining the payloads would
+        // pin megabytes of graph for the lifetime of the tab.
         opsLog.info('op_minted', `${op.op} minted by ${op.actor}`, {
           opId: op.op_id,
           kind: op.op,
           actor: op.actor,
           baseVersion: op.base_version,
           stamp: stampKey(op),
-          register: stampTargetKey(op),
-          op
+          register: stampTargetKey(op)
         })
       }
       queue.push(...chunkWireOps(minted))

--- a/src/workbench/extensions/agent/crdt/opSender.ts
+++ b/src/workbench/extensions/agent/crdt/opSender.ts
@@ -90,7 +90,7 @@ export function createOpSender(deps: OpSenderDeps): OpSender {
   function settle(outcome: BatchOutcome): void {
     if (inFlight?.timer) clearTimeout(inFlight.timer)
     inFlight = null
-    opsLog[outcome.state === 'acknowledged' ? 'info' : 'warn'](
+    opsLog.info(
       'op_batch_settled',
       `batch of ${outcome.ops.length} settled as ${outcome.state}`,
       {

--- a/src/workbench/extensions/agent/crdt/opSender.ts
+++ b/src/workbench/extensions/agent/crdt/opSender.ts
@@ -15,8 +15,10 @@
  * frame upgrade ships (a required backend dependency, recorded on the plan);
  * `onResult` is the seam they will replace.
  */
+import { stampKey, stampTargetKey } from '@comfyorg/comfy-multi-player'
 import type { Op } from '@comfyorg/comfy-multi-player'
 
+import { opsLog } from './crdtLog'
 import type { GraphOperation } from './graphOperations'
 import { chunkWireOps, mintWireOps } from './opEnvelope'
 
@@ -88,6 +90,15 @@ export function createOpSender(deps: OpSenderDeps): OpSender {
   function settle(outcome: BatchOutcome): void {
     if (inFlight?.timer) clearTimeout(inFlight.timer)
     inFlight = null
+    opsLog[outcome.state === 'acknowledged' ? 'info' : 'warn'](
+      'op_batch_settled',
+      `batch of ${outcome.ops.length} settled as ${outcome.state}`,
+      {
+        state: outcome.state,
+        opIds: outcome.ops.map((op) => op.op_id),
+        ...(outcome.state === 'acknowledged' && { result: outcome.result })
+      }
+    )
     deps.onBatchSettled(outcome)
     pump()
   }
@@ -175,6 +186,17 @@ export function createOpSender(deps: OpSenderDeps): OpSender {
         actor: deps.actor(),
         baseVersion: deps.baseVersion()
       })
+      for (const op of minted) {
+        opsLog.info('op_minted', `${op.op} minted by ${op.actor}`, {
+          opId: op.op_id,
+          kind: op.op,
+          actor: op.actor,
+          baseVersion: op.base_version,
+          stamp: stampKey(op),
+          register: stampTargetKey(op),
+          op
+        })
+      }
       queue.push(...chunkWireOps(minted))
       pump()
     },

--- a/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.ts
+++ b/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.ts
@@ -172,7 +172,10 @@ export function useAgentCrdtFollower(
     clearStaleProbe()
     staleProbeTimer = setTimeout(() => {
       staleProbeTimer = null
-      docLog.warn(
+      // NOT a warning: this timer re-arms itself, and `warn` bypasses the debug
+      // gate by design, so warning here would emit forever on any idle workflow
+      // in every build — including for users who explicitly opted out.
+      docLog.info(
         'stale_probe',
         `no doc frame for ${STALE_AFTER_MS}ms on a bound channel — probing with a resubscribe`,
         { workflowId: subscribedWorkflowId.value, afterMs: STALE_AFTER_MS }

--- a/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.ts
+++ b/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.ts
@@ -5,7 +5,9 @@ import type { GraphMutations } from '@/core/graph/graphMutations'
 import { api } from '@/scripts/api'
 import type { RemoteMutationContext } from '@/types/graphMutationContext'
 
-import { recordDevEvent } from './devPanelLog'
+import { docLog, ecsLog, opsLog, wireLog } from './crdtLog'
+import type { CrdtDebugSnapshot } from './crdtDebugReport'
+import { readCrdtSnapshot } from './crdtDebugReport'
 import type { DocFrameTransport, DocOp, DocUpdate } from './docFrameClient'
 import { DocFrameClient } from './docFrameClient'
 import { EcsFollowerAdapter } from './ecsFollowerAdapter'
@@ -103,7 +105,15 @@ export function useAgentCrdtFollower(
       } catch {
         // Leave the raw string.
       }
-      recordDevEvent('ws_out', { delivered, frame: parsed })
+      const frameType =
+        typeof parsed === 'object' && parsed !== null && 'type' in parsed
+          ? String((parsed as { type: unknown }).type)
+          : 'unknown'
+      wireLog.trace(
+        'ws_out',
+        `${frameType} ${delivered ? 'sent' : 'DROPPED (socket not open)'}`,
+        { delivered, frame: parsed }
+      )
       return delivered
     },
     addEventListener(type, listener) {
@@ -162,9 +172,11 @@ export function useAgentCrdtFollower(
     clearStaleProbe()
     staleProbeTimer = setTimeout(() => {
       staleProbeTimer = null
-      recordDevEvent('stale_probe', {
-        workflowId: subscribedWorkflowId.value
-      })
+      docLog.warn(
+        'stale_probe',
+        `no doc frame for ${STALE_AFTER_MS}ms on a bound channel — probing with a resubscribe`,
+        { workflowId: subscribedWorkflowId.value, afterMs: STALE_AFTER_MS }
+      )
       bridge.resubscribe()
       armStaleProbe()
     }, STALE_AFTER_MS)
@@ -189,10 +201,11 @@ export function useAgentCrdtFollower(
       subscribeRetryTimer = null
       // The desired doc changed while we waited — the watch owns that path.
       if (subscribedWorkflowId.value !== target) return
-      recordDevEvent('subscribe_retry', {
-        attempt: subscribeRetryAttempt,
-        workflowId: target
-      })
+      docLog.info(
+        'subscribe_retry',
+        `retrying subscribe (attempt ${subscribeRetryAttempt}/${SUBSCRIBE_RETRY_MAX_ATTEMPTS})`,
+        { attempt: subscribeRetryAttempt, workflowId: target }
+      )
       bridge.resubscribe()
     }, delay)
   }
@@ -202,7 +215,13 @@ export function useAgentCrdtFollower(
     const ok = event.detail?.ok === true
     connected.value = ok
     lastFrameType.value = event.type
-    recordDevEvent('doc_subscribed', event.detail ?? null)
+    docLog.info(
+      'doc_subscribed',
+      ok
+        ? `bound to ${subscribedWorkflowId.value ?? 'unknown doc'}`
+        : `server refused the subscribe (${String(event.detail?.code ?? 'no code')})`,
+      event.detail ?? null
+    )
     if (ok) {
       clearSubscribeRetry()
       armStaleProbe()
@@ -228,27 +247,46 @@ export function useAgentCrdtFollower(
         seq?: number
         update?: Uint8Array
         actor?: string
+        opIds?: string[]
       } | null
-      recordDevEvent('doc_update', {
-        workflowId: detail?.workflowId,
-        seq: detail?.seq,
-        actor: detail?.actor,
-        bytes:
-          detail?.update instanceof Uint8Array ? detail.update.length : null
-      })
+      docLog.debug(
+        'doc_update',
+        `seq ${detail?.seq ?? '?'} from ${detail?.actor ?? 'unknown actor'}`,
+        {
+          workflowId: detail?.workflowId,
+          seq: detail?.seq,
+          actor: detail?.actor,
+          opIds: detail?.opIds ?? [],
+          bytes:
+            detail?.update instanceof Uint8Array ? detail.update.length : null
+        }
+      )
     }
     const ids = currentDocNodeIds()
     const added = [...ids].filter((id) => !knownDocNodeIds.has(id))
     const removed = [...knownDocNodeIds].filter((id) => !ids.has(id))
     if (added.length > 0 || removed.length > 0)
-      recordDevEvent('doc_nodes_changed', { added, removed })
+      ecsLog.info(
+        'doc_nodes_changed',
+        `doc nodes ${added.length > 0 ? `+${added.join(',')}` : ''}${added.length > 0 && removed.length > 0 ? ' ' : ''}${removed.length > 0 ? `-${removed.join(',')}` : ''}`,
+        { added, removed }
+      )
     knownDocNodeIds = ids
   }
   const onOpsResult: EventListener = (event) => {
     if (staleProbeTimer !== null) armStaleProbe()
     lastFrameType.value = event.type
     if (event instanceof CustomEvent) {
-      recordDevEvent('doc_ops_result', event.detail ?? null)
+      const detail = event.detail as {
+        ok?: boolean
+        applied?: string[]
+        skipped?: string[]
+      } | null
+      opsLog.info(
+        'doc_ops_result',
+        `host ${detail?.ok ? 'accepted' : 'refused'} a batch: ${detail?.applied?.length ?? 0} applied, ${detail?.skipped?.length ?? 0} skipped`,
+        event.detail ?? null
+      )
     }
   }
   const onDocReset: EventListener = (event) => {
@@ -267,8 +305,9 @@ export function useAgentCrdtFollower(
     lastFrameType.value = event.type
     clearStaleProbe()
     knownDocNodeIds = new Set()
-    recordDevEvent(
+    docLog.warn(
       'doc_reset',
+      'lineage break — the host re-minted the document, so prior updates no longer compose',
       event instanceof CustomEvent ? (event.detail ?? null) : null
     )
   }
@@ -283,15 +322,20 @@ export function useAgentCrdtFollower(
     lastFrameType.value = event.type
     clearStaleProbe()
     adapter.discardPending()
-    recordDevEvent(
+    docLog.warn(
       'schema_error',
+      'refusing to project the doc: its schema version is not the one this build reads (KA-11 fail-closed)',
       event instanceof CustomEvent ? (event.detail ?? null) : null
     )
   }
   const onReconnected: EventListener = () => {
     connected.value = false
     clearStaleProbe()
-    recordDevEvent('reconnected', null)
+    docLog.info(
+      'reconnected',
+      'socket reconnected — re-driving the subscribe',
+      null
+    )
     bridge.resubscribe()
   }
   /**
@@ -335,7 +379,11 @@ export function useAgentCrdtFollower(
         const persisted = initialBind ? readPersistedDocId() : null
         initialBind = false
         if (persisted !== null) {
-          recordDevEvent('rebind', { workflowId: persisted })
+          docLog.info(
+            'rebind',
+            `remount rebound to the persisted doc ${persisted}`,
+            { workflowId: persisted }
+          )
           subscribedWorkflowId.value = persisted
           bridge.subscribe(persisted)
           return
@@ -381,8 +429,22 @@ export function useAgentCrdtFollower(
     lastFrameType: lastFrameType.value
   }))
 
+  /**
+   * A getter, not a computed: the doc's ledgers change on every frame, and
+   * mirroring them into reactive state would make the instrument the most
+   * expensive consumer of the thing it observes.
+   */
+  const debugSnapshot = (): CrdtDebugSnapshot =>
+    readCrdtSnapshot(bridge.follower.doc, {
+      status: status.value,
+      tabId,
+      lastSeq: bridge.lastAppliedSeq,
+      schemaError: bridge.lastSchemaError?.message ?? null
+    })
+
   return {
     status: readonly(status),
+    debugSnapshot,
     // The semantic canvas-command adapter will call this after it moves to
     // @comfyorg/comfy-multi-player. Raw Yjs client updates are never sent.
     sendHumanOps: (ops: DocOp[]) => bridge.sendHumanOps(tabId, ops)

--- a/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.ts
+++ b/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.ts
@@ -6,8 +6,8 @@ import { api } from '@/scripts/api'
 import type { RemoteMutationContext } from '@/types/graphMutationContext'
 
 import { docLog, ecsLog, opsLog, wireLog } from './crdtLog'
-import type { CrdtDebugSnapshot } from './crdtDebugReport'
-import { readCrdtSnapshot } from './crdtDebugReport'
+import type { CrdtDebugSnapshot } from './crdtSnapshot'
+import { readCrdtSnapshot } from './crdtSnapshot'
 import type { DocFrameTransport, DocOp, DocUpdate } from './docFrameClient'
 import { DocFrameClient } from './docFrameClient'
 import { EcsFollowerAdapter } from './ecsFollowerAdapter'
@@ -84,6 +84,44 @@ export const apiTransport: DocFrameTransport = {
   }
 }
 
+/**
+ * Envelope only, never the payload. A `doc_ops` frame carries whole serialized
+ * nodes and every widget value a human just typed; the ring buffer holds 500
+ * entries and feeds a clipboard report, so retaining frames verbatim would put
+ * prompts into an artifact the tester never opted into sharing. `opSender`
+ * logs its mints the same way.
+ */
+function describeOutboundFrame(parsed: unknown): {
+  type: string
+  workflowId?: string
+  opIds?: string[]
+  opCount?: number
+} {
+  if (typeof parsed !== 'object' || parsed === null) return { type: 'unknown' }
+  const frame = parsed as { type?: unknown; data?: unknown }
+  const data =
+    typeof frame.data === 'object' && frame.data !== null
+      ? (frame.data as { workflow_id?: unknown; ops?: unknown })
+      : null
+  const ops = Array.isArray(data?.ops) ? data.ops : null
+  return {
+    type: typeof frame.type === 'string' ? frame.type : 'unknown',
+    ...(typeof data?.workflow_id === 'string' && {
+      workflowId: data.workflow_id
+    }),
+    ...(ops && {
+      opCount: ops.length,
+      opIds: ops.flatMap((op) =>
+        typeof op === 'object' &&
+        op !== null &&
+        typeof (op as { op_id?: unknown }).op_id === 'string'
+          ? [(op as { op_id: string }).op_id]
+          : []
+      )
+    })
+  }
+}
+
 export function useAgentCrdtFollower(
   workflowId: Ref<string | null>,
   graphMutations: GraphMutations
@@ -105,14 +143,11 @@ export function useAgentCrdtFollower(
       } catch {
         // Leave the raw string.
       }
-      const frameType =
-        typeof parsed === 'object' && parsed !== null && 'type' in parsed
-          ? String((parsed as { type: unknown }).type)
-          : 'unknown'
+      const envelope = describeOutboundFrame(parsed)
       wireLog.trace(
         'ws_out',
-        `${frameType} ${delivered ? 'sent' : 'DROPPED (socket not open)'}`,
-        { delivered, frame: parsed }
+        `${envelope.type} ${delivered ? 'sent' : 'DROPPED (socket not open)'}`,
+        { delivered, ...envelope, bytes: frame.length }
       )
       return delivered
     },

--- a/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.ts
+++ b/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.ts
@@ -343,7 +343,7 @@ export function useAgentCrdtFollower(
     lastFrameType.value = event.type
     clearStaleProbe()
     knownDocNodeIds = new Set()
-    docLog.warn(
+    docLog.info(
       'doc_reset',
       'lineage break — the host re-minted the document, so prior updates no longer compose',
       event instanceof CustomEvent ? (event.detail ?? null) : null
@@ -360,10 +360,16 @@ export function useAgentCrdtFollower(
     lastFrameType.value = event.type
     clearStaleProbe()
     adapter.discardPending()
-    docLog.warn(
+    const detail =
+      event instanceof CustomEvent
+        ? (event.detail as { firstFailure?: boolean } | null)
+        : null
+    // Every later frame fails the same gate; `warn` bypasses the debug gate,
+    // so only the first failure earns a console line in a shipping build.
+    docLog[detail?.firstFailure === false ? 'debug' : 'warn'](
       'schema_error',
       'refusing to project the doc: its schema version is not the one this build reads (KA-11 fail-closed)',
-      event instanceof CustomEvent ? (event.detail ?? null) : null
+      detail
     )
   }
   const onReconnected: EventListener = () => {


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

Targets `christian-byrne/crdt-impl-integration-candidate`, not `main`.

## The reported bug

The status strip above the agent panel pushed the composer below the fold, and a `fixed right-3 bottom-3` pill sat on the composer's submit button. Worth noting what the strip actually was: it rendered on `v-if="crdtStatus.enabled"`, and `enabled` is hardcoded `true` in the composable — so **every agent-panel user in every build** got CRDT debug chrome above the composer, not just developers. That is now deleted, along with its four i18n keys.

The instrument is now a real child of `AgentPanel`'s flex column via an `#instrument` slot, directly above the `shrink-0` composer. Being a flex sibling is what makes the obstruction unrepeatable: the composer claims its intrinsic height before the panel is offered any. Verified in a browser at 1600×1000, 1366×768 and 1280×600 — the submit button does not move at all when the panel opens, and is hit-testable in both states.

## Who can see it

Was `import.meta.env.DEV` alone, which is the wrong audience: the people who need this are product testers on staging builds, where `DEV` is false. Now `DEV` **or** a sticky `?crdtDebug=1` opt-in, with an explicit opt-out beating both. `?crdtDebug=trace` also sets console verbosity. The panel is `defineAsyncComponent`-loaded so the CRDT applier it uses to simulate merges never reaches the bundle of users who cannot open it.

## What's in it

**Logging.** One `crdtLog` module, so the console and the copied report are the same record read two ways. Events carry a scope (`wire` / `doc` / `ecs` / `ops`) and a level, which is how the panel offers varying levels of abstraction. Wired through the follower, the bridge, the ECS adapter and the op sender. An explicit opt-out skips both sinks.

**Merge lab — the "why did that happen" ask.** Replays op sequences through the *real* pinned applier (`applyOps`), not a model of it, and reports per op: the contested register, the stamp order `[base_version, actor, op_id]`, the verdict, and a plain-English explanation. Six scenarios including the one from the thread — delete A → set widget on A → add A — which resolves to `applied` / `no-op · delete-wins` / `applied`, with the explanation spelling out that a re-add is a fresh incarnation and does not resurrect the value. Plus grouping by contested register, a node-lifecycle view with incarnation numbers, a glossary, and a free-text field for the rule a tester would rather have, which goes into the report verbatim.

**Copy full report.** Restores the collector deleted in #5259 (system stats, server logs, settings, extensions, versions) and merges it with the existing copy. Server logs, settings and workflow are per-source opt-ins defaulting **off**, as the deleted dialog had them; credential-shaped keys are redacted recursively, and `argv` values that look like paths or URLs are blanked whatever flag names them.

## Review

Five rounds of `deep-reviewer`; final verdict PASS. Four rounds found real defects, several of them mine — a `warn` level that bypassed the debug gate and spammed opted-out users' consoles every 30s; a batch-abort scenario that narrated the opposite of what it demonstrated; consent checkboxes that rendered at 0×0 because `agentPanel.css` strips `appearance` from every input under `#agent-panel-root`; a `schema_error` de-dup that suppressed state transitions and left the follower resubscribing forever while reporting itself connected; and a fault-tolerance fallback that dumped the unredacted `/system_stats` payload. All fixed, each with a regression test.

Non-blocking items the final review left on the table, for whoever owns the branch: an unset-default test for the gate, widening the 1 Hz Status poll, `SHARING_WARNING` on `## System`, per-op stamp snapshots in `mergeScenarios`, and a dead `relative` on `#agent-panel-root`.

## Size

~2,360 lines of non-test code. Large for one PR, and it splits cleanly along four seams if you'd prefer: gate + logging, report collector, merge lab, panel UI. The pieces interlock (the panel is the only consumer of the other three), so it's offered whole — say the word and I'll break it up.

## Verification

`pnpm typecheck`, `pnpm lint`, `pnpm format:check`, `pnpm knip` all clean; 201 CRDT unit tests pass. The 3 `AgentPanelRoot.test.ts` failures are pre-existing — reproduced identically on the merge base. Manually verified in a real browser against a live ComfyUI backend: layout geometry and hit-testing at three viewports, console output at each level, the merge lab, the consent toggles gating the report (2.8 KB default → 27.5 KB opted in), and the `?crdtDebug=1` / hide round trip including a chat-history remount.


## Screenshots

![Collapsed: the CRDT chip sits just above the composer, clear of the submit button and of the title-row controls. No status strip; composer fully visible.](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/e8e29ee67e2078b0b51883e52d42a712b55b27b62e3e93e19714d638341399c5/pr-images/1787962642544-75ea14d5-9f3a-460d-816b-9dd89eb289cb.png)

![Open on the Merge lab tab: per-op trace with applied and no-op-delete-wins verdicts plus explanations, the three consent toggles (Server logs off, Settings on, Workflow JSON off), and the composer still fully usable below.](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/e8e29ee67e2078b0b51883e52d42a712b55b27b62e3e93e19714d638341399c5/pr-images/1787962642980-a9f8da8d-f791-41f7-bec5-8505676c09a6.png)