### PR TITLE
test: delete redundant templates thumbnail media check

### DIFF
--- a/browser_tests/tests/templates.spec.ts
+++ b/browser_tests/tests/templates.spec.ts
@@ -32,47 +32,6 @@ test.describe('Templates', { tag: ['@slow', '@workflow'] }, () => {
     }
   })
 
-  // Flaky: /templates is proxied to an external server, so thumbnail
-  // availability varies across CI runs.
-  // FIX: Make hermetic — fixture index.json and thumbnail responses via
-  // page.route(), and change checkTemplateFileExists to use browser-context
-  // fetch (page.request.head bypasses Playwright routing).
-  // https://github.com/Comfy-Org/ComfyUI_frontend/issues/3992
-  // oxlint-disable-next-line playwright/no-skipped-test -- https://github.com/Comfy-Org/ComfyUI_frontend/issues/3992
-  test.skip('should have all required thumbnail media for each template', async ({
-    comfyPage
-  }) => {
-    test.slow()
-    const templates = await comfyPage.templates.getAllTemplates()
-    for (const template of templates) {
-      const { name, mediaSubtype, thumbnailVariant } = template
-      const baseMedia = `${name}-1.${mediaSubtype}`
-
-      // Check base thumbnail
-      const baseExists = await checkTemplateFileExists(
-        comfyPage.page,
-        baseMedia
-      )
-      expect(baseExists, `Missing base thumbnail: ${baseMedia}`).toBe(true)
-
-      // Check second thumbnail for variants that need it
-      if (
-        thumbnailVariant === 'compareSlider' ||
-        thumbnailVariant === 'hoverDissolve'
-      ) {
-        const secondMedia = `${name}-2.${mediaSubtype}`
-        const secondExists = await checkTemplateFileExists(
-          comfyPage.page,
-          secondMedia
-        )
-        expect(
-          secondExists,
-          `Missing second thumbnail: ${secondMedia} required for ${thumbnailVariant}`
-        ).toBe(true)
-      }
-    }
-  })
-
   test('Can load template workflows', async ({ comfyPage }) => {
     // Clear the workflow
     await comfyPage.menu.workflowsTab.open()


### PR DESCRIPTION
Deletes the skipped thumbnail detector; template-repository CI owns this validation.
No running coverage is removed. Human review still required.

<details><summary>Full context for agent readers</summary>

## Summary

Deletes `should have all required thumbnail media for each template`, skipped since #3994. `comfyui-workflow-templates` validates the same indexed thumbnail contract in its own CI, where fixes belong.

## Changes

- Removes only the skipped detector and its stale comments from `browser_tests/tests/templates.spec.ts`.
- Preserves the sibling workflow-JSON check and shared helpers.
- Accepts the existing narrow package-bundling gap; this deletion does not widen it because the detector does not run on `main`.

## Verification

Exact head `a771d31fc0b40153429a86d85b33b549d039f3e4` changes one file with 41 deletions. Required checks are terminal green. Automated review found no actionable comments; human review remains required.

Fixes #3992

</details>