### PR TITLE
refactor(widgets): extract a shared node widget value boundary

### DIFF
--- a/src/core/graph/widgets/nodeWidgetValues.test.ts
+++ b/src/core/graph/widgets/nodeWidgetValues.test.ts
@@ -1,0 +1,130 @@
+import { fromPartial } from '@total-typescript/shoehorn'
+import { describe, expect, it } from 'vitest'
+
+import { LGraph, LGraphNode } from '@/lib/litegraph/src/litegraph'
+import type { IBaseWidget } from '@/lib/litegraph/src/types/widgets'
+import { useWidgetValueStore } from '@/stores/widgetValueStore'
+import { toNodeId } from '@/types/nodeId'
+import { widgetId } from '@/types/widgetId'
+import { createMockLGraphNode } from '@/utils/__tests__/litegraphTestUtils'
+
+import {
+  getNodeWidgetValue,
+  nodeWidgetId,
+  setNodeWidgetValue
+} from './nodeWidgetValues'
+
+const GRAPH_ID = 'node-widget-values-test'
+const WIDGET_NAME = 'image'
+
+function makeRegisteredNode(value = 'registered.png'): LGraphNode {
+  const graph = new LGraph()
+  const node = new LGraphNode('Test')
+  graph.add(node)
+  node.addWidget('string', WIDGET_NAME, value, () => undefined)
+  return node
+}
+
+function registeredId(node: LGraphNode) {
+  const id = node.widgets?.[0].widgetId
+  if (!id) throw new Error('Expected a registered widget')
+  return id
+}
+
+function makeMockNode({
+  registered = false,
+  widgetValue = 'legacy.png'
+}: { registered?: boolean; widgetValue?: string } = {}): LGraphNode {
+  const nodeId = toNodeId(1)
+  if (registered) {
+    useWidgetValueStore().registerWidget(
+      widgetId(GRAPH_ID, nodeId, WIDGET_NAME),
+      { type: 'string', value: 'stored.png', options: {} }
+    )
+  }
+  const node = createMockLGraphNode({
+    id: nodeId,
+    graph: { rootGraph: { id: GRAPH_ID } }
+  })
+  node.widgets = [
+    fromPartial<IBaseWidget>({
+      name: WIDGET_NAME,
+      type: 'string',
+      value: widgetValue
+    })
+  ]
+  return node
+}
+
+describe('nodeWidgetId', () => {
+  it('matches the id a registered widget derives for itself', () => {
+    const node = makeRegisteredNode()
+
+    expect(nodeWidgetId(node, WIDGET_NAME)).toBe(registeredId(node))
+  })
+
+  it('returns null for a node outside any graph', () => {
+    const node = new LGraphNode('Test')
+
+    expect(nodeWidgetId(node, WIDGET_NAME)).toBeNull()
+  })
+})
+
+describe('getNodeWidgetValue', () => {
+  it('reads the store value for a registered widget', () => {
+    const node = makeRegisteredNode()
+    useWidgetValueStore().setValue(registeredId(node), 'updated.png')
+
+    expect(getNodeWidgetValue(node, WIDGET_NAME)).toBe('updated.png')
+  })
+
+  it('preserves a nullish store value instead of falling back', () => {
+    const node = makeMockNode({ registered: true, widgetValue: 'stale.png' })
+    useWidgetValueStore().setValue(
+      widgetId(GRAPH_ID, node.id, WIDGET_NAME),
+      null
+    )
+
+    expect(getNodeWidgetValue(node, WIDGET_NAME)).toBeNull()
+  })
+
+  it('falls back to the widget object when the store has no entry', () => {
+    const node = makeMockNode({ widgetValue: 'legacy.png' })
+
+    expect(getNodeWidgetValue(node, WIDGET_NAME)).toBe('legacy.png')
+  })
+
+  it('reads the widget object on a node outside any graph', () => {
+    const node = new LGraphNode('Test')
+    node.addWidget('string', WIDGET_NAME, 'detached.png', () => undefined)
+
+    expect(getNodeWidgetValue(node, WIDGET_NAME)).toBe('detached.png')
+  })
+})
+
+describe('setNodeWidgetValue', () => {
+  it('writes the store value for a registered widget', () => {
+    const node = makeRegisteredNode()
+
+    expect(setNodeWidgetValue(node, WIDGET_NAME, 'next.png')).toBe(true)
+    expect(useWidgetValueStore().getWidget(registeredId(node))?.value).toBe(
+      'next.png'
+    )
+  })
+
+  it('falls back to the widget object when the store has no entry', () => {
+    const node = makeMockNode({ widgetValue: 'legacy.png' })
+
+    expect(setNodeWidgetValue(node, WIDGET_NAME, 'next.png')).toBe(true)
+    expect(node.widgets?.[0].value).toBe('next.png')
+  })
+
+  it('returns false when the widget exists nowhere', () => {
+    const node = createMockLGraphNode({
+      id: toNodeId(1),
+      graph: { rootGraph: { id: GRAPH_ID } }
+    })
+
+    expect(setNodeWidgetValue(node, WIDGET_NAME, 'next.png')).toBe(false)
+  })
+})

--- a/src/core/graph/widgets/nodeWidgetValues.ts
+++ b/src/core/graph/widgets/nodeWidgetValues.ts
@@ -1,0 +1,30 @@
+import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
+import { useWidgetValueStore } from '@/stores/widgetValueStore'
+import type { WidgetValue } from '@/types/simplifiedWidget'
+import type { WidgetId } from '@/types/widgetId'
+import { widgetId } from '@/types/widgetId'
+
+export function nodeWidgetId(node: LGraphNode, name: string): WidgetId | null {
+  const graphId = node.graph?.rootGraph?.id
+  return graphId ? widgetId(graphId, node.id, name) : null
+}
+
+export function getNodeWidgetValue(node: LGraphNode, name: string): unknown {
+  const id = nodeWidgetId(node, name)
+  const state = id ? useWidgetValueStore().getWidget(id) : undefined
+  if (state) return state.value
+  return node.widgets?.find((w) => w.name === name)?.value
+}
+
+export function setNodeWidgetValue(
+  node: LGraphNode,
+  name: string,
+  value: WidgetValue
+): boolean {
+  const id = nodeWidgetId(node, name)
+  if (id && useWidgetValueStore().setValue(id, value)) return true
+  const widget = node.widgets?.find((w) => w.name === name)
+  if (!widget) return false
+  widget.value = value
+  return true
+}

--- a/src/renderer/extensions/compositor/composables/compositorWidgets.test.ts
+++ b/src/renderer/extensions/compositor/composables/compositorWidgets.test.ts
@@ -91,6 +91,23 @@ describe('getCompositorWidgetValue', () => {
 
     expect(getCompositorWidgetValue(makeNode({ registered: false }))).toBeNull()
   })
+
+  it('does not fall back to a stale widget object over a nullish store value', () => {
+    const node = makeNode()
+    node.widgets = [
+      fromPartial<ICompositorWidget>({
+        name: 'compositor',
+        type: 'compositor',
+        value: { layers: [] }
+      })
+    ]
+    useWidgetValueStore().setValue(
+      widgetId(GRAPH_ID, node.id, 'compositor'),
+      null
+    )
+
+    expect(getCompositorWidgetValue(node)).toBeNull()
+  })
 })
 
 describe('resetCompositorStateWidgets', () => {

--- a/src/renderer/extensions/compositor/composables/compositorWidgets.ts
+++ b/src/renderer/extensions/compositor/composables/compositorWidgets.ts
@@ -1,37 +1,27 @@
+import {
+  getNodeWidgetValue,
+  setNodeWidgetValue
+} from '@/core/graph/widgets/nodeWidgetValues'
 import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
 import {
   emptyCompositorWidgetValue,
   isCompositorWidgetValue
 } from '@/renderer/extensions/compositor/components/types'
 import type { CompositorWidgetValue } from '@/renderer/extensions/compositor/components/types'
-import { useWidgetValueStore } from '@/stores/widgetValueStore'
-import type { WidgetId } from '@/types/widgetId'
-import { widgetId } from '@/types/widgetId'
 
 const COMPOSITOR_WIDGET = 'compositor'
-
-function compositorWidgetId(node: LGraphNode): WidgetId | null {
-  const graphId = node.graph?.rootGraph?.id
-  return graphId ? widgetId(graphId, node.id, COMPOSITOR_WIDGET) : null
-}
 
 export function setCompositorWidgetValue(
   node: LGraphNode,
   value: CompositorWidgetValue
 ): void {
-  const id = compositorWidgetId(node)
-  if (id && useWidgetValueStore().setValue(id, value)) return
-  const widget = node.widgets?.find((w) => w.name === COMPOSITOR_WIDGET)
-  if (widget) widget.value = value
+  setNodeWidgetValue(node, COMPOSITOR_WIDGET, value)
 }
 
 export function getCompositorWidgetValue(
   node: LGraphNode
 ): CompositorWidgetValue | null {
-  const id = compositorWidgetId(node)
-  const value =
-    (id ? useWidgetValueStore().getWidget(id)?.value : undefined) ??
-    node.widgets?.find((w) => w.name === COMPOSITOR_WIDGET)?.value
+  const value = getNodeWidgetValue(node, COMPOSITOR_WIDGET)
   return isCompositorWidgetValue(value) ? value : null
 }
 


### PR DESCRIPTION
## Summary
Every rich-widget feature boundary that talks to widgetValueStore has been hand-writing the same three steps: derive the WidgetId from graphId:nodeId:name, read or write the store, and fall back to the live widget object for nodes whose widgets are not registered. 
Extract that into core/graph/widgets/nodeWidgetValues and adopt it in the compositor boundary, which keeps its typed CompositorWidgetValue surface and delegates the plumbing.

The read resolves the entity first, store state when registered, the widget object only when the store has no entry, so a registered-but-nullish store value is preserved instead of resurrecting a stale widget object value (same distinction as the maskeditor adapter in #15962, suggested by review on #15964).

Follow-ups migrate the remaining feature boundaries (painter, bbox editor, camera-info, maskeditor) to the same helper.