### PR TITLE
test(website): align the FDCT hero unit test with the autoplaying video

### DIFF
--- a/apps/website/src/templates/fdct/HeroSection.test.ts
+++ b/apps/website/src/templates/fdct/HeroSection.test.ts
@@ -10,9 +10,12 @@ describe('fdct HeroSection', () => {
     render(HeroSection)
 
     const video = screen.getByLabelText(t('fdct.hero.title', 'en'))
-    expect(video.hasAttribute('autoplay')).toBe(true)
-    expect(video.hasAttribute('loop')).toBe(true)
-    expect((video as HTMLVideoElement).muted).toBe(true)
+    if (!(video instanceof HTMLVideoElement)) {
+      throw new Error('hero label is not on a <video>')
+    }
+    expect(video.autoplay).toBe(true)
+    expect(video.loop).toBe(true)
+    expect(video.muted).toBe(true)
     expect(video.getAttribute('poster')).toContain('FDCT_V4_thumb')
   })
 

--- a/apps/website/src/templates/fdct/HeroSection.test.ts
+++ b/apps/website/src/templates/fdct/HeroSection.test.ts
@@ -2,20 +2,18 @@
 import { render, screen } from '@testing-library/vue'
 import { describe, expect, it } from 'vitest'
 
+import { t } from '../../i18n/translations'
 import HeroSection from './HeroSection.vue'
 
 describe('fdct HeroSection', () => {
-  it('renders the split hero with a click-to-play video behind its poster', () => {
+  it('renders the split hero with an autoplaying, looping hero video', () => {
     render(HeroSection)
 
-    // Click-to-play: the hero video must not autoplay and rests on its poster
-    const video = screen.getByLabelText('Forward Deployed Creatives')
-    expect(video.hasAttribute('autoplay')).toBe(false)
+    const video = screen.getByLabelText(t('fdct.hero.title', 'en'))
+    expect(video.hasAttribute('autoplay')).toBe(true)
+    expect(video.hasAttribute('loop')).toBe(true)
+    expect(video.hasAttribute('muted')).toBe(true)
     expect(video.getAttribute('poster')).toContain('FDCT_V4_thumb')
-
-    // The centered overlay play button floats over the poster
-    const play = screen.getByRole('button', { name: 'Play' })
-    expect(play.classList.contains('backdrop-blur-[9px]')).toBe(true)
   })
 
   it('renders the contact CTA', () => {

--- a/apps/website/src/templates/fdct/HeroSection.test.ts
+++ b/apps/website/src/templates/fdct/HeroSection.test.ts
@@ -12,7 +12,7 @@ describe('fdct HeroSection', () => {
     const video = screen.getByLabelText(t('fdct.hero.title', 'en'))
     expect(video.hasAttribute('autoplay')).toBe(true)
     expect(video.hasAttribute('loop')).toBe(true)
-    expect(video.hasAttribute('muted')).toBe(true)
+    expect((video as HTMLVideoElement).muted).toBe(true)
     expect(video.getAttribute('poster')).toContain('FDCT_V4_thumb')
   })
 


### PR DESCRIPTION
#16205 switched the FDCT hero to `video-autoplay` / `video-loop` and updated the e2e spec, but left the Vitest unit test asserting the old click-to-play contract (`autoplay === false`, an overlay Play button). `website-unit` has been red on main since.

Aligns the unit test with the SSR-rendered attributes the e2e spec already covers: `autoplay`, `loop`, `muted`, and the poster. The unmute control depends on happy-dom-unavailable media state, so it stays an e2e concern.