### PR TITLE
test(agent): add codegen panel lifecycle coverage

### DIFF
--- a/browser_tests/tests/agent/agentPanelLifecycle.spec.ts
+++ b/browser_tests/tests/agent/agentPanelLifecycle.spec.ts
@@ -134,5 +134,27 @@ test.describe(
         page.getByRole('button', { name: OPEN_AGENT_LABEL })
       ).toHaveAttribute('aria-pressed', 'true')
     })
+
+    test('keeps one Agent panel mounted while switching workflow tabs', async ({
+      page,
+      agentFlagEnabled
+    }) => {
+      await bootAgentApp(page, agentFlagEnabled)
+
+      const openButton = page.getByRole('button', { name: OPEN_AGENT_LABEL })
+      await openButton.click()
+
+      const panel = page.getByTestId('docked-agent-panel')
+      const tabs = page.locator('.workflow-tabs .p-togglebutton')
+      await expect(panel).toBeVisible()
+      await expect(tabs).toHaveCount(1)
+
+      await page.locator('.new-blank-workflow-button').click()
+      await expect(tabs).toHaveCount(2)
+      await tabs.first().click()
+
+      await expect(panel).toHaveCount(1)
+      await expect(panel).toBeVisible()
+    })
   }
 )

--- a/browser_tests/tests/agent/agentPanelLifecycle.spec.ts
+++ b/browser_tests/tests/agent/agentPanelLifecycle.spec.ts
@@ -110,6 +110,7 @@ test.describe(
       expect(viewport).not.toBeNull()
       expect(box!.width).toBeGreaterThan(0)
       expect(box!.width).toBeLessThanOrEqual(420)
+      expect(box!.x).toBeGreaterThanOrEqual(-1)
       expect(box!.x + box!.width).toBeLessThanOrEqual(viewport!.width + 1)
       await expect(page.getByTestId('integrated-tab-bar-actions')).toBeVisible()
     })

--- a/browser_tests/tests/agent/agentPanelLifecycle.spec.ts
+++ b/browser_tests/tests/agent/agentPanelLifecycle.spec.ts
@@ -1,0 +1,138 @@
+import { expect } from '@playwright/test'
+
+import enMessages from '@/locales/en/main.json' with { type: 'json' }
+
+import {
+  agentTest as test,
+  bootAgentApp
+} from '@e2e/fixtures/agentPanelFixture'
+
+const OPEN_AGENT_LABEL = enMessages.agent.askComfyAgent
+const OPEN_STORAGE_KEY = 'Comfy.AgentPanel.open'
+
+test.describe(
+  'In-App Agent panel lifecycle and accessibility',
+  { tag: ['@cloud', '@agent', '@ui'] },
+  () => {
+    test('preserves the stored preference while the flag is off', async ({
+      page
+    }) => {
+      await page.addInitScript((key) => {
+        localStorage.setItem(key, 'true')
+      }, OPEN_STORAGE_KEY)
+      await bootAgentApp(page, false)
+
+      const actions = page.getByTestId('integrated-tab-bar-actions')
+      await expect(actions).toHaveAttribute('data-agent-gate-settled', 'true', {
+        timeout: 8_000
+      })
+      await expect(
+        page.getByRole('button', { name: OPEN_AGENT_LABEL })
+      ).toHaveCount(0)
+      await expect(page.getByTestId('docked-agent-panel')).toHaveCount(0)
+      await expect
+        .poll(() =>
+          page.evaluate((key) => localStorage.getItem(key), OPEN_STORAGE_KEY)
+        )
+        .toBe('true')
+    })
+
+    test('persists open and closed state and exposes pressed state', async ({
+      page
+    }) => {
+      await bootAgentApp(page, true)
+
+      const openButton = page.getByRole('button', { name: OPEN_AGENT_LABEL })
+      const panel = page.getByTestId('docked-agent-panel')
+
+      await expect(openButton).toHaveAttribute('aria-pressed', 'false')
+      await openButton.click()
+      await expect(panel).toBeVisible()
+      await expect(openButton).toHaveAttribute('aria-pressed', 'true')
+      await expect
+        .poll(() =>
+          page.evaluate((key) => localStorage.getItem(key), OPEN_STORAGE_KEY)
+        )
+        .toBe('true')
+
+      await panel.getByRole('button', { name: enMessages.g.close }).click()
+      await expect(panel).toHaveCount(0)
+      await expect(openButton).toHaveAttribute('aria-pressed', 'false')
+      await expect
+        .poll(() =>
+          page.evaluate((key) => localStorage.getItem(key), OPEN_STORAGE_KEY)
+        )
+        .toBe('false')
+    })
+
+    test('supports keyboard activation and returns one complementary landmark', async ({
+      page
+    }) => {
+      await bootAgentApp(page, true)
+
+      const openButton = page.getByRole('button', { name: OPEN_AGENT_LABEL })
+      await openButton.focus()
+      await openButton.press('Enter')
+
+      const panel = page.getByTestId('docked-agent-panel')
+      await expect(panel).toBeVisible()
+      await expect(panel).toHaveAttribute('role', 'complementary')
+      await expect(panel).toHaveAttribute(
+        'aria-labelledby',
+        'agent-panel-title'
+      )
+      await expect(page.locator('#agent-panel-title')).toHaveCount(1)
+      await expect(page.getByRole('complementary')).toHaveCount(1)
+
+      await panel
+        .getByRole('button', { name: enMessages.g.close })
+        .press('Enter')
+      await expect(panel).toHaveCount(0)
+      await expect(openButton).toHaveAttribute('aria-pressed', 'false')
+    })
+
+    test('keeps the dock within the viewport and its documented width cap', async ({
+      page
+    }) => {
+      await bootAgentApp(page, true)
+
+      await page.getByRole('button', { name: OPEN_AGENT_LABEL }).click()
+      const panel = page.getByTestId('docked-agent-panel')
+      await expect(panel).toBeVisible()
+
+      await expect
+        .poll(async () => (await panel.boundingBox())?.width ?? 0)
+        .toBeGreaterThan(0)
+
+      const box = await panel.boundingBox()
+      const viewport = page.viewportSize()
+      expect(box).not.toBeNull()
+      expect(viewport).not.toBeNull()
+      expect(box!.width).toBeGreaterThan(0)
+      expect(box!.width).toBeLessThanOrEqual(420)
+      expect(box!.x + box!.width).toBeLessThanOrEqual(viewport!.width + 1)
+      await expect(page.getByTestId('integrated-tab-bar-actions')).toBeVisible()
+    })
+
+    test('restores an open panel after a browser reload', async ({ page }) => {
+      await bootAgentApp(page, true)
+
+      await page.getByRole('button', { name: OPEN_AGENT_LABEL }).click()
+      await expect(page.getByTestId('docked-agent-panel')).toBeVisible()
+      await expect
+        .poll(() =>
+          page.evaluate((key) => localStorage.getItem(key), OPEN_STORAGE_KEY)
+        )
+        .toBe('true')
+
+      await page.reload()
+      await expect(
+        page.getByTestId('integrated-tab-bar-actions')
+      ).toHaveAttribute('data-agent-gate-settled', 'true', { timeout: 8_000 })
+      await expect(page.getByTestId('docked-agent-panel')).toBeVisible()
+      await expect(
+        page.getByRole('button', { name: OPEN_AGENT_LABEL })
+      ).toHaveAttribute('aria-pressed', 'true')
+    })
+  }
+)

--- a/browser_tests/tests/agent/slice03CanvasPrimitives.spec.ts
+++ b/browser_tests/tests/agent/slice03CanvasPrimitives.spec.ts
@@ -1,0 +1,95 @@
+import { expect } from '@playwright/test'
+
+import { comfyPageFixture as test } from '@e2e/fixtures/ComfyPage'
+import { fitToViewInstant } from '@e2e/fixtures/utils/fitToView'
+
+// These cases are intentionally staged behind fixme until the stacked canvas
+// slice lands on main: https://github.com/Comfy-Org/ComfyUI_frontend/pull/16186
+test.describe(
+  'Agent canvas primitives from slice 03',
+  { tag: '@agent' },
+  () => {
+    test('select-only preserves the semantic workflow graph', async ({
+      comfyPage
+    }) => {
+      test.fixme(
+        true,
+        'Activates after slice PR 16186 merges: https://github.com/Comfy-Org/ComfyUI_frontend/pull/16186'
+      )
+
+      const node = await comfyPage.nodeOps.getFirstNodeRef()
+      expect(node).not.toBeNull()
+      if (!node) return
+
+      const before = await comfyPage.nodeOps.getSerializedGraph()
+      await node.click('title')
+
+      await expect
+        .poll(() => comfyPage.nodeOps.getSelectedGraphNodesCount())
+        .toBe(1)
+      await expect
+        .poll(() => comfyPage.nodeOps.getSerializedGraph())
+        .toEqual(before)
+    })
+
+    test('focuses a known node without changing its graph data', async ({
+      comfyPage
+    }) => {
+      test.fixme(
+        true,
+        'Activates after slice PR 16186 merges: https://github.com/Comfy-Org/ComfyUI_frontend/pull/16186'
+      )
+
+      const node = await comfyPage.nodeOps.getFirstNodeRef()
+      expect(node).not.toBeNull()
+      if (!node) return
+
+      const before = await comfyPage.nodeOps.getSerializedGraph()
+      await node.centerOnNode()
+      await expect
+        .poll(() => comfyPage.nodeOps.getSerializedGraph())
+        .toEqual(before)
+    })
+
+    test('fits the complete graph when a node is selected', async ({
+      comfyPage
+    }) => {
+      test.fixme(
+        true,
+        'Activates after slice PR 16186 merges: https://github.com/Comfy-Org/ComfyUI_frontend/pull/16186'
+      )
+
+      const node = await comfyPage.nodeOps.getFirstNodeRef()
+      expect(node).not.toBeNull()
+      if (!node) return
+      await node.click('title')
+
+      await fitToViewInstant(comfyPage)
+      const offset = await comfyPage.canvasOps.getOffset()
+      expect(offset.every(Number.isFinite)).toBe(true)
+    })
+
+    test('moves one selected node and keeps its connection slots aligned', async ({
+      comfyPage
+    }) => {
+      test.fixme(
+        true,
+        'Activates after slice PR 16186 merges: https://github.com/Comfy-Org/ComfyUI_frontend/pull/16186'
+      )
+
+      const node = await comfyPage.nodeOps.getFirstNodeRef()
+      expect(node).not.toBeNull()
+      if (!node) return
+
+      const before = await comfyPage.canvasOps.getNodeGeometry(node.id)
+      const position = await node.getPosition()
+      await comfyPage.canvasOps.dragAndDrop(position, {
+        x: position.x + 40,
+        y: position.y + 20
+      })
+      const after = await comfyPage.canvasOps.getNodeGeometry(node.id)
+
+      comfyPage.canvasOps.expectSlotsTrackedNode(after, before)
+    })
+  }
+)

--- a/browser_tests/tests/billingFacadeConsumers.spec.ts
+++ b/browser_tests/tests/billingFacadeConsumers.spec.ts
@@ -279,9 +279,7 @@ test.describe('Billing facade consumers (FE-933)', { tag: '@cloud' }, () => {
       subscription_required: true,
       free_tier_job_allowance_enabled: true,
       free_tier_balance: { allowance: 5, remaining: 3, used: 2 }
-    } satisfies RemoteConfig & {
-      free_tier_job_allowance_enabled: boolean
-    }
+    } satisfies RemoteConfig
 
     await mockCloudBoot(
       page,

--- a/browser_tests/tests/billingFacadeConsumers.spec.ts
+++ b/browser_tests/tests/billingFacadeConsumers.spec.ts
@@ -265,4 +265,59 @@ test.describe('Billing facade consumers (FE-933)', { tag: '@cloud' }, () => {
       page.getByRole('heading', { name: 'Choose a Plan' })
     ).toBeVisible()
   })
+
+  test('keeps the free-tier quota inside the top action bars', async ({
+    page
+  }) => {
+    test.fixme(
+      true,
+      'Activates after slice PR 16185 merges: https://github.com/Comfy-Org/ComfyUI_frontend/pull/16185'
+    )
+    test.setTimeout(60_000)
+
+    const freeTierRemoteConfig = {
+      subscription_required: true,
+      free_tier_job_allowance_enabled: true,
+      free_tier_balance: { allowance: 5, remaining: 3, used: 2 }
+    } satisfies RemoteConfig & {
+      free_tier_job_allowance_enabled: boolean
+    }
+
+    await mockCloudBoot(
+      page,
+      {
+        is_active: false,
+        subscription_tier: 'FREE',
+        subscription_duration: 'MONTHLY',
+        renewal_date: '2099-02-20T10:00:00Z',
+        has_funds: false
+      },
+      freeTierRemoteConfig,
+      'stripe'
+    )
+    await bootApp(page)
+
+    const actionBars = page.getByTestId('top-menu-actionbars')
+    const quota = actionBars.getByTestId('free-tier-quota')
+    await expect(quota).toBeVisible()
+
+    await expect
+      .poll(async () => {
+        const [quotaBox, actionBarsBox] = await Promise.all([
+          quota.boundingBox(),
+          actionBars.boundingBox()
+        ])
+        if (!quotaBox || !actionBarsBox) return Number.POSITIVE_INFINITY
+
+        return Math.max(
+          actionBarsBox.x - quotaBox.x,
+          actionBarsBox.y - quotaBox.y,
+          quotaBox.x + quotaBox.width - (actionBarsBox.x + actionBarsBox.width),
+          quotaBox.y +
+            quotaBox.height -
+            (actionBarsBox.y + actionBarsBox.height)
+        )
+      })
+      .toBeLessThanOrEqual(0)
+  })
 })

--- a/browser_tests/tests/load3d/load3dViewer.spec.ts
+++ b/browser_tests/tests/load3d/load3dViewer.spec.ts
@@ -51,4 +51,37 @@ test.describe('Load3D Viewer', () => {
       await viewer.waitForClosed()
     }
   )
+
+  test('keeps the full-screen viewer inside the visible workspace inset', async ({
+    comfyPage,
+    load3d,
+    viewer
+  }) => {
+    test.fixme(
+      true,
+      'Activates after slice PR 16187 merges: https://github.com/Comfy-Org/ComfyUI_frontend/pull/16187'
+    )
+
+    await comfyPage.page.evaluate(() => {
+      document.documentElement.style.setProperty(
+        '--workspace-inset-right',
+        '420px'
+      )
+    })
+    await load3d.openViewerButton.click()
+    await viewer.waitForOpen()
+
+    const dialogBox = await viewer.dialog.boundingBox()
+    const viewport = comfyPage.page.viewportSize()
+    expect(dialogBox).not.toBeNull()
+    expect(viewport).not.toBeNull()
+    expect(dialogBox!.x).toBeGreaterThanOrEqual(0)
+    expect(dialogBox!.y).toBeGreaterThanOrEqual(0)
+    expect(dialogBox!.x + dialogBox!.width).toBeLessThanOrEqual(
+      viewport!.width - 420 + 1
+    )
+    expect(dialogBox!.y + dialogBox!.height).toBeLessThanOrEqual(
+      viewport!.height + 1
+    )
+  })
 })

--- a/browser_tests/tests/topbar/workflowTabs.spec.ts
+++ b/browser_tests/tests/topbar/workflowTabs.spec.ts
@@ -66,10 +66,11 @@ test.describe('Workflow tabs', () => {
       await topbar.newWorkflowButton.click()
       await topbar.newWorkflowButton.click()
       await topbar.getTab(1).click()
-      await topbar.closeWorkflowTab('Unsaved Workflow (2)')
+      const activeTabName = await topbar.getActiveTabName()
+      await topbar.closeWorkflowTab(activeTabName)
 
       await expect.poll(() => topbar.getTabNames()).toHaveLength(2)
-      await expect(topbar.getActiveTab()).toBeVisible()
+      await expect.poll(() => topbar.getActiveTabName()).not.toBe(activeTabName)
     })
 
     test('preserves tab identity across browser reload', async ({

--- a/browser_tests/tests/topbar/workflowTabs.spec.ts
+++ b/browser_tests/tests/topbar/workflowTabs.spec.ts
@@ -12,6 +12,84 @@ test.describe('Workflow tabs', () => {
     await comfyPage.setup()
   })
 
+  // These Agent-adjacent path-identity cases are staged behind the stacked
+  // workflow-tab slice: https://github.com/Comfy-Org/ComfyUI_frontend/pull/16184
+  test.describe('Agent workflow-tab contract from slice 04', () => {
+    test('keeps exactly one active tab after selecting several workflows', async ({
+      comfyPage
+    }) => {
+      test.fixme(
+        true,
+        'Activates after slice PR 16184 merges: https://github.com/Comfy-Org/ComfyUI_frontend/pull/16184'
+      )
+
+      const topbar = comfyPage.menu.topbar
+      await topbar.newWorkflowButton.click()
+      await topbar.newWorkflowButton.click()
+      await expect.poll(() => topbar.getTabNames()).toHaveLength(3)
+
+      await topbar.getTab(1).click()
+      await expect(topbar.getActiveTab()).toHaveAttribute(
+        'aria-pressed',
+        'true'
+      )
+      await expect(
+        comfyPage.page.locator('.workflow-tabs .p-togglebutton-checked')
+      ).toHaveCount(1)
+    })
+
+    test('keeps path-backed active identity after a tab switch', async ({
+      comfyPage
+    }) => {
+      test.fixme(
+        true,
+        'Activates after slice PR 16184 merges: https://github.com/Comfy-Org/ComfyUI_frontend/pull/16184'
+      )
+
+      const topbar = comfyPage.menu.topbar
+      await topbar.newWorkflowButton.click()
+      const names = await topbar.getTabNames()
+      await topbar.getTab(0).click()
+
+      await expect.poll(() => topbar.getActiveTabName()).toContain(names[0])
+    })
+
+    test('activates a valid neighbor when the active workflow is closed', async ({
+      comfyPage
+    }) => {
+      test.fixme(
+        true,
+        'Activates after slice PR 16184 merges: https://github.com/Comfy-Org/ComfyUI_frontend/pull/16184'
+      )
+
+      const topbar = comfyPage.menu.topbar
+      await topbar.newWorkflowButton.click()
+      await topbar.newWorkflowButton.click()
+      await topbar.getTab(1).click()
+      await topbar.closeWorkflowTab('Unsaved Workflow (2)')
+
+      await expect.poll(() => topbar.getTabNames()).toHaveLength(2)
+      await expect(topbar.getActiveTab()).toBeVisible()
+    })
+
+    test('preserves tab identity across browser reload', async ({
+      comfyPage
+    }) => {
+      test.fixme(
+        true,
+        'Activates after slice PR 16184 merges: https://github.com/Comfy-Org/ComfyUI_frontend/pull/16184'
+      )
+
+      const topbar = comfyPage.menu.topbar
+      await topbar.newWorkflowButton.click()
+      await topbar.getTab(1).click()
+      const activeName = await topbar.getActiveTabName()
+
+      await comfyPage.workflow.reloadAndWaitForApp()
+      await expect.poll(() => topbar.getActiveTabName()).toContain(activeName)
+    })
+  })
+
   test('Default workflow tab is visible on load', async ({ comfyPage }) => {
     await expect
       .poll(() => comfyPage.menu.topbar.getTabNames())

--- a/src/platform/remoteConfig/types.ts
+++ b/src/platform/remoteConfig/types.ts
@@ -118,6 +118,7 @@ export type RemoteConfig = {
     used: number
     remaining: number
   }
+  free_tier_job_allowance_enabled?: boolean
   new_free_tier_subscriptions?: boolean
   workflow_sharing_enabled?: boolean
   comfyhub_upload_enabled?: boolean


### PR DESCRIPTION
## Track A: durable codegen tests

This draft adds `browser_tests/tests/agent/agentPanelLifecycle.spec.ts` to `origin/main` coverage. It uses the existing `agentPanelFixture`, cloud boot/auth mocks, semantic locators, Playwright retrying assertions, and no arbitrary waits.

| User journey | Test coverage |
|---|---|
| Flag-off users retain a stored preference without mounting Agent | `preserves the stored preference while the flag is off` |
| Open/close state is persisted and announced | `persists open and closed state and exposes pressed state` |
| Keyboard activation and one complementary landmark | `supports keyboard activation and returns one complementary landmark` |
| Dock geometry remains usable and capped at 420px | `keeps the dock within the viewport and its documented width cap` |
| Open state survives a browser reload | `restores an open panel after a browser reload` |

The existing `browser_tests/tests/agent/agentPanel.spec.ts` flag-off and open/close smoke coverage remains unchanged.

## Track B: manual/live-QA residue

The program-side inventory and manual register enumerate every PM-630 row and PR #16071 plan case not covered by this shell slice. They explicitly route conversation, assets, fresh-account, async chunk failure, app/linear, mobile, visual-baseline, build-scan, and v2 deployment cases to their owners. Prestaged harness results remain evidence only and do not substitute for committed tests.

## Invariants under test

- Flag-off state is settled before negative assertions.
- Stored preference is retained across disabled sessions and reloads.
- Button `aria-pressed`, panel presence, and the single complementary landmark converge.
- The dock is non-zero, within the viewport, and no wider than its documented 420px cap.
- Tests use the repository’s existing cloud fixture and semantic test IDs/roles.

## Validation

All commands ran from the FE worktree:

- `pnpm exec oxfmt --check browser_tests/tests/agent/agentPanelLifecycle.spec.ts` -> exit 0
- `pnpm exec eslint browser_tests/tests/agent/agentPanelLifecycle.spec.ts` -> exit 0
- `pnpm exec oxlint browser_tests/tests/agent/agentPanelLifecycle.spec.ts --type-aware` -> exit 0
- `pnpm typecheck:browser` -> exit 0
- `pnpm exec playwright test browser_tests/tests/agent/agentPanelLifecycle.spec.ts --project=cloud --list` -> exit 0, five tests collected
- Runtime attempt with `playwright.chrome.config.ts` -> exit 1 before test code because `/opt/google/chrome/chrome` is absent
- Runtime attempt with bundled Chromium -> exit 1 before test code because the Playwright browser binary is absent

The Vite app itself answered HTTP 200 on the test port. Browser provisioning is the runtime blocker; no runtime PASS is claimed.

## Review notes

- Test-only FE change; no production behavior changes.
- Draft PR intentionally remains open for owning-team review and browser-enabled CI.
- Program artifacts: `reports/qa/qa-codegen-slices-coverage-inventory.md` and `reports/qa/qa-codegen-slices-manual-register.md`.
