### PR TITLE
test(assets): cover paginated queue focus

### DIFF
--- a/browser_tests/fixtures/queueAssetFocusFixture.ts
+++ b/browser_tests/fixtures/queueAssetFocusFixture.ts
@@ -28,7 +28,7 @@ function outputPage(after: string | null): ListAssetsResponse {
     return {
       assets: [
         createOutputAsset(
-          '10000000-0000-4000-8000-000000000003',
+          TARGET_JOB_ID,
           TARGET_JOB_ID,
           'queue-focus-target.png'
         )

--- a/browser_tests/fixtures/queueAssetFocusFixture.ts
+++ b/browser_tests/fixtures/queueAssetFocusFixture.ts
@@ -1,0 +1,112 @@
+import type { Page, Route } from '@playwright/test'
+import type { Asset, ListAssetsResponse } from '@comfyorg/ingest-types'
+
+import { comfyPageFixture } from '@e2e/fixtures/ComfyPage'
+import {
+  createRouteMockJob,
+  JobsRouteMocker
+} from '@e2e/fixtures/jobsRouteFixture'
+
+const ASSETS_ROUTE_PATTERN = /\/api\/assets(?:\?.*)?$/
+export const TARGET_JOB_ID = '00000000-0000-4000-8000-000000000003'
+const requestsByPage = new WeakMap<Page, string[]>()
+
+function createOutputAsset(id: string, jobId: string, name: string): Asset {
+  return {
+    id,
+    name,
+    mime_type: 'image/png',
+    tags: ['output'],
+    job_id: jobId,
+    created_at: '2026-08-29T00:00:00Z',
+    updated_at: '2026-08-29T00:00:00Z'
+  }
+}
+
+function outputPage(after: string | null): ListAssetsResponse {
+  if (after === 'queue-focus-page-2') {
+    return {
+      assets: [
+        createOutputAsset(
+          '10000000-0000-4000-8000-000000000003',
+          TARGET_JOB_ID,
+          'queue-focus-target.png'
+        )
+      ],
+      total: 3,
+      has_more: false
+    }
+  }
+
+  if (after === 'queue-focus-page-1') {
+    return {
+      assets: [
+        createOutputAsset(
+          '10000000-0000-4000-8000-000000000002',
+          '00000000-0000-4000-8000-000000000002',
+          'queue-focus-middle.png'
+        )
+      ],
+      total: 3,
+      has_more: true,
+      next_cursor: 'queue-focus-page-2'
+    }
+  }
+
+  return {
+    assets: [
+      createOutputAsset(
+        '10000000-0000-4000-8000-000000000001',
+        '00000000-0000-4000-8000-000000000001',
+        'queue-focus-newest.png'
+      )
+    ],
+    total: 3,
+    has_more: true,
+    next_cursor: 'queue-focus-page-1'
+  }
+}
+
+function requestsOutputAssets(url: URL): boolean {
+  return (url.searchParams.get('tags_any') ?? '').split(',').includes('output')
+}
+
+export const queueAssetFocusTest = comfyPageFixture.extend<{
+  outputAssetRequests: string[]
+}>({
+  page: async ({ page }, use) => {
+    const outputAssetRequests: string[] = []
+    requestsByPage.set(page, outputAssetRequests)
+    const jobsRoutes = new JobsRouteMocker(page)
+
+    await jobsRoutes.mockJobsScenario({
+      history: [createRouteMockJob({ id: TARGET_JOB_ID })],
+      queue: []
+    })
+
+    const assetsRouteHandler = async (route: Route) => {
+      const url = new URL(route.request().url())
+      if (!requestsOutputAssets(url)) {
+        await route.fulfill({
+          json: {
+            assets: [],
+            total: 0,
+            has_more: false
+          } satisfies ListAssetsResponse
+        })
+        return
+      }
+
+      outputAssetRequests.push(url.toString())
+      await route.fulfill({ json: outputPage(url.searchParams.get('after')) })
+    }
+
+    await page.route(ASSETS_ROUTE_PATTERN, assetsRouteHandler)
+    await use(page)
+    await page.unroute(ASSETS_ROUTE_PATTERN, assetsRouteHandler)
+    requestsByPage.delete(page)
+  },
+  outputAssetRequests: async ({ page }, use) => {
+    await use(requestsByPage.get(page) ?? [])
+  }
+})

--- a/browser_tests/tests/queue/queueAssetFocus.spec.ts
+++ b/browser_tests/tests/queue/queueAssetFocus.spec.ts
@@ -1,0 +1,43 @@
+import { expect } from '@playwright/test'
+
+import {
+  queueAssetFocusTest as test,
+  TARGET_JOB_ID
+} from '@e2e/fixtures/queueAssetFocusFixture'
+import { TestIds } from '@e2e/fixtures/selectors'
+
+test.use({
+  initialFeatureFlags: { assets: true },
+  initialSettings: {
+    'Comfy.Assets.UseAssetAPI': true,
+    'Comfy.Queue.QPOV2': false
+  }
+})
+
+test.describe('Queue asset focus', { tag: '@ui' }, () => {
+  test('loads later asset pages before selecting a queued output', async ({
+    comfyPage,
+    outputAssetRequests
+  }) => {
+    await comfyPage.page.getByTestId(TestIds.queue.overlayToggle).click()
+
+    const targetJob = comfyPage.page.locator(`[data-job-id="${TARGET_JOB_ID}"]`)
+    await expect(targetJob).toBeVisible()
+    await targetJob.hover()
+    await targetJob.getByRole('button', { name: 'View' }).click()
+
+    const assetsTab = comfyPage.menu.assetsTab
+    const targetAsset = assetsTab.getAssetCardByName('queue-focus-target')
+    await expect
+      .poll(() =>
+        outputAssetRequests.map((request) =>
+          new URL(request).searchParams.get('after')
+        )
+      )
+      .toEqual([null, null, 'queue-focus-page-1', 'queue-focus-page-2'])
+    await expect(assetsTab.generatedTab).toBeVisible()
+    await expect(targetAsset).toBeVisible()
+    await expect(targetAsset).toHaveAttribute('data-selected', 'true')
+    await expect(assetsTab.selectedCards).toHaveCount(1)
+  })
+})

--- a/browser_tests/tests/queue/queueAssetFocus.spec.ts
+++ b/browser_tests/tests/queue/queueAssetFocus.spec.ts
@@ -34,7 +34,7 @@ test.describe('Queue asset focus', { tag: ['@cloud', '@ui'] }, () => {
           new URL(request).searchParams.get('after')
         )
       )
-      .toEqual([null, null, 'queue-focus-page-1', 'queue-focus-page-2'])
+      .toEqual([null, 'queue-focus-page-1', 'queue-focus-page-2'])
     await expect(assetsTab.generatedTab).toBeVisible()
     await expect(targetAsset).toBeVisible()
     await expect(targetAsset).toHaveAttribute('data-selected', 'true')

--- a/browser_tests/tests/queue/queueAssetFocus.spec.ts
+++ b/browser_tests/tests/queue/queueAssetFocus.spec.ts
@@ -14,7 +14,7 @@ test.use({
   }
 })
 
-test.describe('Queue asset focus', { tag: '@ui' }, () => {
+test.describe('Queue asset focus', { tag: ['@cloud', '@ui'] }, () => {
   test('loads later asset pages before selecting a queued output', async ({
     comfyPage,
     outputAssetRequests


### PR DESCRIPTION
Adds browser coverage for paginated queue focus.
Proves queue View loads page 3 before selecting exactly one asset.
Green locally; removing paginated lookup fails the new assertion.

<details><summary>Full context for agent readers</summary>

## Coverage

- Stack base: #16070 (`drjkl/fix-assets-pagination-review`)
- Exercises the real queue overlay, Assets sidebar, Pinia stores, and cursor-shaped `/api/assets` route responses.
- Asserts the target is requested through two later cursors, rendered, and uniquely selected.
- Uses schema-valid UUID-backed Asset fixtures so route mocks fail on contract drift.

## Verification

- Playwright Chromium: 3/3 repeated runs passed.
- Browser typecheck: passed.
- Root typecheck: passed, exit 0 with 8 GB heap.
- Lint: passed with 3 unrelated existing warnings.
- Format check: passed.
- Knip: passed.
- `git diff --check`: passed.

## Detection proof

Replacing `assetsStore.loadOutputAsset(assetId)` with a constant success result made the test fail at the exact cursor-sequence assertion: only the two initial requests occurred; the page-2/page-3 requests were absent.

</details>
