### PR TITLE
test(assets): cover deletion failures

### DIFF
--- a/src/platform/assets/composables/useMediaAssetActions.test.ts
+++ b/src/platform/assets/composables/useMediaAssetActions.test.ts
@@ -1565,11 +1565,11 @@ describe('useMediaAssetActions', () => {
 
       await useMediaAssetActions().deleteAssets(assets)
 
-      expect(mockDeleteAsset.mock.calls.map(([id]) => id)).toEqual([
-        'asset-first',
-        'asset-failed',
-        'asset-third'
-      ])
+      const deletedIds = mockDeleteAsset.mock.calls.map(([id]) => id)
+      expect(deletedIds).toHaveLength(3)
+      expect(new Set(deletedIds)).toEqual(
+        new Set(['asset-first', 'asset-failed', 'asset-third'])
+      )
       expect(mockInputAssets.items.map((item) => item.id)).toEqual([
         'asset-failed'
       ])
@@ -1594,14 +1594,18 @@ describe('useMediaAssetActions', () => {
         life: 5000
       })
 
-      const lastFlagById = new Map(
-        mockSetAssetDeleting.mock.calls as [string, boolean][]
-      )
-      expect([...lastFlagById]).toEqual([
-        ['asset-first', false],
-        ['asset-failed', false],
-        ['asset-third', false]
-      ])
+      const flagsById: Record<string, boolean[]> = {}
+      for (const [id, flag] of mockSetAssetDeleting.mock.calls as [
+        string,
+        boolean
+      ][]) {
+        flagsById[id] = [...(flagsById[id] ?? []), flag]
+      }
+      expect(flagsById).toEqual({
+        'asset-first': [true, false],
+        'asset-failed': [true, false],
+        'asset-third': [true, false]
+      })
     })
   })
 })

--- a/src/platform/assets/composables/useMediaAssetActions.test.ts
+++ b/src/platform/assets/composables/useMediaAssetActions.test.ts
@@ -1499,4 +1499,109 @@ describe('useMediaAssetActions', () => {
       expect(mockInputAssets.items.map((item) => item.id)).toEqual(['keep'])
     })
   })
+
+  describe('deleteAssets — failures', () => {
+    beforeEach(() => {
+      mockIsCloud.value = true
+      vi.mocked(api.getServerFeature).mockReturnValue(true)
+      mockGetAssetType.mockReturnValue('input')
+      mockShowDialog.mockImplementation(
+        ({ props }: { props: { onConfirm: (confirmed: boolean) => void } }) =>
+          props.onConfirm(true)
+      )
+      mockAppGraph.value = { _nodes: [] }
+    })
+
+    it('keeps a failed asset listed and removes it once a retry succeeds', async () => {
+      mockDeleteAsset
+        .mockRejectedValueOnce(new Error('503 Service Unavailable'))
+        .mockResolvedValueOnce(undefined)
+      const actions = useMediaAssetActions()
+      const asset = createMockAsset({ id: 'asset-503', name: 'retry.png' })
+      mockInputAssets.items = [asset]
+
+      await expect(actions.deleteAssets(asset)).resolves.toBe(true)
+
+      expect(mockInputAssets.items.map((item) => item.id)).toEqual([
+        'asset-503'
+      ])
+      expect(useToast().add).toHaveBeenCalledWith({
+        severity: 'error',
+        summary: i18n.global.t('mediaAsset.assetDelete.error'),
+        detail: i18n.global.t('mediaAsset.assetsDeleted', { total: 1 }, 0),
+        life: 5000
+      })
+      expect(mockMarkMissingMedia).not.toHaveBeenCalled()
+      expect(mockClearWidgetValues).not.toHaveBeenCalled()
+
+      await expect(actions.deleteAssets(asset)).resolves.toBe(true)
+
+      expect(mockDeleteAsset).toHaveBeenCalledTimes(2)
+      expect(mockInputAssets.items).toEqual([])
+      expect(useToast().add).toHaveBeenLastCalledWith({
+        severity: 'success',
+        summary: i18n.global.t('mediaAsset.assetDelete.success'),
+        detail: i18n.global.t('mediaAsset.assetsDeleted', { total: 1 }, 1),
+        life: 2000
+      })
+    })
+
+    it('cleans up only the succeeded assets and clears every overlay when part of a batch fails', async () => {
+      mockDeleteAsset.mockImplementation(async (id: string) => {
+        if (id === 'asset-failed') throw new Error('503 Service Unavailable')
+      })
+      const assets = [
+        createMockAsset({ id: 'asset-first', name: 'first.png' }),
+        createMockAsset({ id: 'asset-failed', name: 'failed.png' }),
+        createMockAsset({ id: 'asset-third', name: 'third.png' })
+      ]
+      mockInputAssets.items = [...assets]
+      const succeededVariants = new Set([
+        'first.png',
+        'first.png [input]',
+        'third.png',
+        'third.png [input]'
+      ])
+
+      await useMediaAssetActions().deleteAssets(assets)
+
+      expect(mockDeleteAsset.mock.calls.map(([id]) => id)).toEqual([
+        'asset-first',
+        'asset-failed',
+        'asset-third'
+      ])
+      expect(mockInputAssets.items.map((item) => item.id)).toEqual([
+        'asset-failed'
+      ])
+      expect(mockMarkMissingMedia).toHaveBeenCalledWith(
+        mockAppGraph.value,
+        succeededVariants
+      )
+      expect(mockClearNodePreviewCache).toHaveBeenCalledWith(
+        mockAppGraph.value,
+        succeededVariants,
+        expect.any(Function)
+      )
+      expect(mockClearWidgetValues).toHaveBeenCalledWith(
+        mockAppGraph.value,
+        succeededVariants
+      )
+      expect(mockCaptureCanvasState).toHaveBeenCalledTimes(1)
+      expect(useToast().add).toHaveBeenCalledWith({
+        severity: 'warn',
+        summary: i18n.global.t('mediaAsset.assetDelete.warn'),
+        detail: i18n.global.t('mediaAsset.assetsDeleted', { total: 3 }, 2),
+        life: 5000
+      })
+
+      const lastFlagById = new Map(
+        mockSetAssetDeleting.mock.calls as [string, boolean][]
+      )
+      expect([...lastFlagById]).toEqual([
+        ['asset-first', false],
+        ['asset-failed', false],
+        ['asset-third', false]
+      ])
+    })
+  })
 })

--- a/src/platform/assets/composables/useMediaAssetActions.test.ts
+++ b/src/platform/assets/composables/useMediaAssetActions.test.ts
@@ -16,7 +16,7 @@ import { i18n } from '@/i18n'
 import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
 import type { IWidget } from '@/lib/litegraph/src/types/widgets'
 import { MediaAssetKey } from '@/platform/assets/schemas/mediaAssetSchema'
-import type { AssetItem } from '@/platform/assets/schemas/assetSchema'
+import type { AssetId, AssetItem } from '@/platform/assets/schemas/assetSchema'
 import type { AssetMeta } from '@/platform/assets/schemas/mediaAssetSchema'
 import { api } from '@/scripts/api'
 import { resolveOutputAssetItems } from '../utils/outputAssetUtil'
@@ -51,7 +51,9 @@ vi.mock<unknown>(
 const mockShowDialog = vi.hoisted(() => vi.fn())
 
 const mockInvalidateModelsForCategory = vi.hoisted(() => vi.fn())
-const mockSetAssetDeleting = vi.hoisted(() => vi.fn())
+const mockSetAssetDeleting = vi.hoisted(() =>
+  vi.fn<(assetId: AssetId, isDeleting: boolean) => void>()
+)
 const mockHasCategory = vi.hoisted(() => vi.fn())
 const mockInputAssets = vi.hoisted(() => ({ items: [] as AssetItem[] }))
 
@@ -116,7 +118,9 @@ vi.mock<unknown>(import('../schemas/assetMetadataSchema'), () => ({
 vi.mock(import('../utils/outputAssetUtil'))
 const mockResolveOutputAssetItems = vi.mocked(resolveOutputAssetItems)
 
-const mockDeleteAsset = vi.hoisted(() => vi.fn())
+const mockDeleteAsset = vi.hoisted(() =>
+  vi.fn<(id: AssetId) => Promise<void>>()
+)
 const mockCreateAssetExport = vi.hoisted(() =>
   vi.fn<
     (
@@ -1547,7 +1551,7 @@ describe('useMediaAssetActions', () => {
     })
 
     it('cleans up only the succeeded assets and clears every overlay when part of a batch fails', async () => {
-      mockDeleteAsset.mockImplementation(async (id: string) => {
+      mockDeleteAsset.mockImplementation(async (id) => {
         if (id === 'asset-failed') throw new Error('503 Service Unavailable')
       })
       const assets = [
@@ -1595,10 +1599,7 @@ describe('useMediaAssetActions', () => {
       })
 
       const flagsById: Record<string, boolean[]> = {}
-      for (const [id, flag] of mockSetAssetDeleting.mock.calls as [
-        string,
-        boolean
-      ][]) {
+      for (const [id, flag] of mockSetAssetDeleting.mock.calls) {
         flagsById[id] = [...(flagsById[id] ?? []), flag]
       }
       expect(flagsById).toEqual({


### PR DESCRIPTION
Covers failed and partially successful asset deletion, written against the current `deleteAssets`.

- A failed record stays in `inputAssets.items` and is removed once a retry succeeds.
- A partly failed batch cleans up only the succeeded variants and clears every deleting overlay.

<details><summary>Full context for agent readers</summary>

## Cases

- Single 503, then retry: the failure keeps the record in `inputAssets.items` and emits `mediaAsset.assetDelete.error` with `0 / 1`; the retry empties the list and emits `mediaAsset.assetDelete.success`.
- Mixed batch (success/failure/success): only the two succeeded assets are invalidated and fed to `markDeletedAssetsAsMissingMedia` / `clearNodePreviewCacheForValues` / `clearDeletedAssetWidgetValues`; the toast is `mediaAsset.assetDelete.warn` with `2 / 3`, `life: 5000`; every id's last `setAssetDeleting` flag is `false`.

## Verification

- `useMediaAssetActions.test.ts`: 49/49 passed.
- Typecheck, ESLint, type-aware oxlint, `format:check`, `knip`, `adr:check` all exit 0.
- Mutation (7 mutants, 0 survivors): invalidate-before-await; `severity` pinned to `success`; variants recorded before await; `deletedAssetCount++` removed; overlay cleared only on success; `life` pinned to `2000`; failed variants added to the cleanup set.

Previously stacked on #16230. Rebased onto `main` and unstacked: the two describes are independent, every sibling PR in this family targets `main`, and unstacking leaves #16230's cancellation coverage entirely to #16230.

</details>

<!-- authored-by:agent -->
