### PR TITLE
test(assets): cover successful deletion lifecycle

### DIFF
--- a/src/platform/assets/composables/useMediaAssetActions.test.ts
+++ b/src/platform/assets/composables/useMediaAssetActions.test.ts
@@ -1264,6 +1264,55 @@ describe('useMediaAssetActions', () => {
     })
   })
 
+  describe('deleteAssets - success', () => {
+    beforeEach(() => {
+      mockIsCloud.value = true
+      vi.mocked(api.getServerFeature).mockReturnValue(true)
+      mockGetAssetType.mockReturnValue('input')
+      mockDeleteAsset.mockResolvedValue(undefined)
+      mockShowDialog.mockImplementation(
+        ({ props }: { props: { onConfirm: (confirmed: boolean) => void } }) => {
+          props.onConfirm(true)
+        }
+      )
+      mockAppGraph.value = { _nodes: [] }
+    })
+
+    it('completes the lifecycle for one confirmed asset record', async () => {
+      const { actions, unmount } = mountMediaActions()
+      const asset = createMockAsset({
+        id: '1cbe0b07-8aef-4f28-8188-dfba48c8fbda',
+        name: 'confirmed.png'
+      })
+      mockInputAssets.items = [asset]
+
+      await expect(actions.deleteAssets(asset)).resolves.toBe(true)
+
+      expect(mockDeleteAsset).toHaveBeenCalledOnce()
+      expect(mockDeleteAsset.mock.calls.map(([id]) => id)).toEqual([asset.id])
+      expect(api.deleteItem).not.toHaveBeenCalled()
+      expect(mockSetAssetDeleting.mock.calls).toEqual([
+        [asset.id, true],
+        [asset.id, false]
+      ])
+      expect(mockInputAssets.items).toEqual([])
+      expect(mockSetAssetDeleting.mock.invocationCallOrder[0]).toBeLessThan(
+        mockDeleteAsset.mock.invocationCallOrder[0]
+      )
+      expect(mockDeleteAsset.mock.invocationCallOrder[0]).toBeLessThan(
+        mockSetAssetDeleting.mock.invocationCallOrder[1]
+      )
+      expect(useToast().add).toHaveBeenCalledWith({
+        severity: 'success',
+        summary: 'mediaAsset.assetDelete.success',
+        detail: 'mediaAsset.assetsDeleted',
+        life: 2000
+      })
+
+      unmount()
+    })
+  })
+
   describe('deleteAssets - confirmation dialog item names', () => {
     beforeEach(() => {
       mockIsCloud.value = true


### PR DESCRIPTION
- Covers the successful-deletion lifecycle case from the internal assets QA plan.
- Proves the confirmed single-record success lifecycle.
- Stacked on #16231.

<details><summary>Full context for agent readers</summary>

## Summary

Adds one orchestration test for successful deletion of a real input Asset record.

## Changes

- Asserts the exact record ID reaches `assetService.deleteAsset` once.
- Separately proves no history deletion occurs for the input record.
- Proves the deleting overlay wraps the request and successful-ID invalidation.
- Proves the successful deletion toast is emitted.

## Review Focus

This closes the frontend orchestration portion of that case. Endpoint construction remains covered by `assetService.test.ts`; backend lifecycle semantics remain separate contract cases.

Validation:
- `useMediaAssetActions.test.ts`: 48/48 passed
- `pnpm typecheck`: passed
- targeted ESLint, type-aware oxlint, and oxfmt: passed
- `pnpm knip`: passed
- mutation removing successful-ID invalidation: new test failed at the intended assertion

</details>
