### PR TITLE
fix: preserve replacement geometry through ownership transfer

### DIFF
--- a/src/platform/nodeReplacement/useNodeReplacement.test.ts
+++ b/src/platform/nodeReplacement/useNodeReplacement.test.ts
@@ -36,7 +36,13 @@ vi.mock('@/lib/litegraph/src/litegraph', async (importOriginal) => {
 
 vi.mock('@/core/graph/nodeShell/nodeShellState', () => ({
   canTransferReplacementOwnership: vi.fn(() => true),
-  transferReplacementOwnership: vi.fn(() => true)
+  transferReplacementOwnership: vi.fn(
+    (node: LGraphNode, replacement: LGraphNode) => {
+      replacement.pos = [...node.pos]
+      replacement.size = [...node.size]
+      return true
+    }
+  )
 }))
 
 vi.mock('@/scripts/app', () => ({
@@ -895,6 +901,21 @@ describe('useNodeReplacement', () => {
         [{ name: 'control_net_name', link: null }],
         []
       )
+      const replacementGeometryBeforeTransfer: Array<{
+        pos: LGraphNode['pos']
+        size: LGraphNode['size']
+      }> = []
+      vi.mocked(transferReplacementOwnership).mockImplementationOnce(
+        (node, replacement) => {
+          replacementGeometryBeforeTransfer.push({
+            pos: [...replacement.pos],
+            size: [...replacement.size]
+          })
+          replacement.pos = [...node.pos]
+          replacement.size = [...node.size]
+          return true
+        }
+      )
       vi.mocked(LiteGraph.createNode).mockReturnValue(newNode)
 
       const { replaceNodesInPlace } = useNodeReplacement()
@@ -911,6 +932,9 @@ describe('useNodeReplacement', () => {
       ])
 
       expect(newNode.id).toBe(42)
+      expect(replacementGeometryBeforeTransfer).toEqual([
+        { pos: [0, 0], size: [100, 50] }
+      ])
       expect(newNode.pos).toEqual([300, 400])
       expect(newNode.size).toEqual([250, 150])
       expect(newNode.order).toBe(6)

--- a/src/platform/nodeReplacement/useNodeReplacement.ts
+++ b/src/platform/nodeReplacement/useNodeReplacement.ts
@@ -244,8 +244,6 @@ function replaceWithMapping(
 ): boolean {
   const order = node.order
   newNode.id = node.id
-  newNode.pos = [...node.pos]
-  newNode.size = [...node.size]
   newNode.order = order
   newNode.mode = node.mode
   if (node.flags) newNode.flags = { ...node.flags }


### PR DESCRIPTION
## Summary

Remove detached replacement-node geometry writes; layout ownership transfer remains the sole geometry authority.

Fixes #15933

<details><summary>Full context for agent readers</summary>

## Changes

- remove direct `newNode.pos` and `newNode.size` assignments before ownership transfer
- model geometry inheritance in the ownership-transfer test double
- assert replacement geometry remains untouched until ownership transfer

## Verification

- `pnpm typecheck`
- `pnpm lint` (0 errors; 187 existing warnings)
- `pnpm test:unit` (1,365 files; 18,419 passed; 7 skipped)
- `pnpm knip`
- `pnpm format:check`
- mutation check: restoring the direct assignments fails the intended geometry-boundary assertion

Current `main` already places endpoint updates before `onRemoved`, isolates `onNodeAdded` from `node:added`, and excludes rejected replacements from `replacedTypes`; those behaviors retain focused tests in `useNodeReplacement.test.ts`.

</details>