### PR TITLE
test(assets): cover queue focus lifecycle race

### DIFF
--- a/src/components/queue/QueueProgressOverlay.test.ts
+++ b/src/components/queue/QueueProgressOverlay.test.ts
@@ -224,4 +224,40 @@ describe('QueueProgressOverlay', () => {
 
     expect(assetSelectionStore.selectedIdsArray).toEqual(['latest-request'])
   })
+
+  it('keeps the latest sidebar focus after switching tabs during an older request', async () => {
+    let resolveFirst!: (found: boolean) => void
+    const firstLoad = new Promise<boolean>((resolve) => {
+      resolveFirst = resolve
+    })
+    loadOutputAssetMock
+      .mockImplementationOnce(() => firstLoad)
+      .mockResolvedValueOnce(true)
+    itemToView = createCompletedJobView('older-request')
+    const { assetSelectionStore, sidebarTabStore, user } = renderComponent(
+      [],
+      []
+    )
+
+    await user.click(screen.getByTestId('view-item-button'))
+    await waitFor(() =>
+      expect(loadOutputAssetMock).toHaveBeenCalledWith('older-request')
+    )
+
+    sidebarTabStore.activeSidebarTabId = 'queue'
+    itemToView = createCompletedJobView('latest-request')
+    await user.click(screen.getByTestId('view-item-button'))
+    await waitFor(() =>
+      expect(assetSelectionStore.selectedIdsArray).toEqual(['latest-request'])
+    )
+    expect(sidebarTabStore.activeSidebarTabId).toBe('assets')
+
+    sidebarTabStore.activeSidebarTabId = 'queue'
+    resolveFirst(true)
+    await firstLoad
+    await Promise.resolve()
+
+    expect(sidebarTabStore.activeSidebarTabId).toBe('queue')
+    expect(assetSelectionStore.selectedIdsArray).toEqual(['latest-request'])
+  })
 })


### PR DESCRIPTION
- Pins queue focus across sidebar switches.
- Stale requests cannot reopen or reselect.
- Covers the queue-focus lifecycle-race case from the internal assets QA plan.

<details><summary>Full context for agent readers</summary>

Adds a component regression test for overlapping queue “View item” requests when the user switches sidebar tabs while the older lookup is pending. The latest request must open Assets and select its exact job; after the user switches away, completion of the stale request must neither reopen Assets nor overwrite selection.

Validation:
- QueueProgressOverlay suite: 8/8
- Typecheck, ESLint, oxfmt, and knip: green
- Mutation proof: reopening Assets after an awaited stale lookup fails at the final tab assertion

Stacked on #16254 because this component path is introduced by the Assets pagination/focus stack.

</details>