### PR TITLE
test(assets): cover flag-off isolation

### DIFF
--- a/browser_tests/tests/sidebar/assetsFlagIsolation.spec.ts
+++ b/browser_tests/tests/sidebar/assetsFlagIsolation.spec.ts
@@ -1,7 +1,14 @@
 import { expect } from '@playwright/test'
 
+import type { ListAssetsResponse } from '@comfyorg/ingest-types'
 import { comfyPageFixture as test } from '@e2e/fixtures/ComfyPage'
 import { createMockJob } from '@e2e/fixtures/helpers/AssetsHelper'
+
+const emptyAssetsResponse: ListAssetsResponse = {
+  assets: [],
+  total: 0,
+  has_more: false
+}
 
 test.describe('Assets sidebar flag-off isolation', { tag: '@oss' }, () => {
   test('uses history without requesting the Asset API', async ({
@@ -12,7 +19,7 @@ test.describe('Assets sidebar flag-off isolation', { tag: '@oss' }, () => {
     await page.route(/\/api\/assets(?:\?.*)?$/, async (route) => {
       assetListRequests.push(route.request().url())
       await route.fulfill({
-        json: { assets: [], total: 0, has_more: false }
+        json: emptyAssetsResponse
       })
     })
     await comfyPage.assets.mockOutputHistory([
@@ -53,7 +60,7 @@ test.describe(
       await page.route(/\/api\/assets(?:\?.*)?$/, async (route) => {
         assetListRequests.push(route.request().url())
         await route.fulfill({
-          json: { assets: [], total: 0, has_more: false }
+          json: emptyAssetsResponse
         })
       })
       await comfyPage.assets.mockOutputHistory([

--- a/browser_tests/tests/sidebar/assetsFlagIsolation.spec.ts
+++ b/browser_tests/tests/sidebar/assetsFlagIsolation.spec.ts
@@ -11,6 +11,8 @@ const emptyAssetsResponse: ListAssetsResponse = {
 }
 
 test.describe('Assets sidebar flag-off isolation', { tag: '@oss' }, () => {
+  test.use({ initialFeatureFlags: { assets: false } })
+
   test('uses history without requesting the Asset API', async ({
     comfyPage,
     page
@@ -26,8 +28,6 @@ test.describe('Assets sidebar flag-off isolation', { tag: '@oss' }, () => {
       createMockJob({ id: 'legacy-output' })
     ])
     await comfyPage.assets.mockInputFiles([])
-    await comfyPage.featureFlags.seedFlags({ assets: false })
-    await comfyPage.setup()
 
     const tab = comfyPage.menu.assetsTab
     await tab.open({ waitForAssets: false })
@@ -45,6 +45,8 @@ test.describe(
   'Assets sidebar flag-off isolation on Cloud',
   { tag: '@cloud' },
   () => {
+    test.use({ initialFeatureFlags: { assets: false } })
+
     test('falls back to history without Asset API controls', async ({
       comfyPage,
       page
@@ -67,8 +69,6 @@ test.describe(
         createMockJob({ id: 'legacy-output' })
       ])
       await comfyPage.assets.mockInputFiles([])
-      await comfyPage.featureFlags.seedFlags({ assets: false })
-      await comfyPage.setup()
 
       const tab = comfyPage.menu.assetsTab
       await tab.open({ waitForAssets: false })

--- a/browser_tests/tests/sidebar/assetsFlagIsolation.spec.ts
+++ b/browser_tests/tests/sidebar/assetsFlagIsolation.spec.ts
@@ -1,0 +1,75 @@
+import { expect } from '@playwright/test'
+
+import { comfyPageFixture as test } from '@e2e/fixtures/ComfyPage'
+import { createMockJob } from '@e2e/fixtures/helpers/AssetsHelper'
+
+test.describe('Assets sidebar flag-off isolation', { tag: '@oss' }, () => {
+  test('uses history without requesting the Asset API', async ({
+    comfyPage,
+    page
+  }) => {
+    const assetListRequests: string[] = []
+    await page.route(/\/api\/assets(?:\?.*)?$/, async (route) => {
+      assetListRequests.push(route.request().url())
+      await route.fulfill({
+        json: { assets: [], total: 0, has_more: false }
+      })
+    })
+    await comfyPage.assets.mockOutputHistory([
+      createMockJob({ id: 'legacy-output' })
+    ])
+    await comfyPage.assets.mockInputFiles([])
+    await comfyPage.featureFlags.seedFlags({ assets: false })
+    await comfyPage.setup()
+
+    const tab = comfyPage.menu.assetsTab
+    await tab.open({ waitForAssets: false })
+    await expect(
+      tab.getAssetCardByName('output_legacy-output').or(tab.emptyStateMessage)
+    ).toBeVisible()
+
+    expect(assetListRequests).toEqual([])
+    await expect(tab.getAssetCardByName('output_legacy-output')).toBeVisible()
+    await expect(tab.filterButton).toHaveCount(0)
+  })
+})
+
+test.describe(
+  'Assets sidebar flag-off isolation on Cloud',
+  { tag: '@cloud' },
+  () => {
+    test('falls back to history without Asset API controls', async ({
+      comfyPage,
+      page
+    }) => {
+      test.fail(
+        true,
+        'Cloud currently enables Assets unconditionally instead of honoring the off flag'
+      )
+
+      const assetListRequests: string[] = []
+      await page.route(/\/api\/assets(?:\?.*)?$/, async (route) => {
+        assetListRequests.push(route.request().url())
+        await route.fulfill({
+          json: { assets: [], total: 0, has_more: false }
+        })
+      })
+      await comfyPage.assets.mockOutputHistory([
+        createMockJob({ id: 'legacy-output' })
+      ])
+      await comfyPage.assets.mockInputFiles([])
+      await comfyPage.featureFlags.seedFlags({ assets: false })
+      await comfyPage.setup()
+
+      const tab = comfyPage.menu.assetsTab
+      await tab.open({ waitForAssets: false })
+      await expect(
+        tab.getAssetCardByName('output_legacy-output').or(tab.emptyStateMessage)
+      ).toBeVisible()
+
+      expect(assetListRequests).toEqual([])
+      await expect(tab.getAssetCardByName('output_legacy-output')).toBeVisible()
+      await expect(tab.filterButton).toHaveCount(0)
+    })
+  }
+)

--- a/browser_tests/tests/sidebar/assetsFlagIsolation.spec.ts
+++ b/browser_tests/tests/sidebar/assetsFlagIsolation.spec.ts
@@ -42,7 +42,9 @@ test.describe(
       comfyPage,
       page
     }) => {
-      test.fail(
+      // Restore the executing assertion after the Cloud flag-off harness is fixed:
+      // https://github.com/Comfy-Org/ComfyUI_frontend/issues/16380
+      test.fixme(
         true,
         'Cloud currently enables Assets unconditionally instead of honoring the off flag'
       )

--- a/browser_tests/tests/sidebar/assetsFlagIsolation.spec.ts
+++ b/browser_tests/tests/sidebar/assetsFlagIsolation.spec.ts
@@ -51,9 +51,9 @@ test.describe(
       comfyPage,
       page
     }) => {
-      // Restore the executing assertion after the Cloud flag-off harness is fixed:
+      // Remove test.fail once the Cloud flag-off harness is fixed:
       // https://github.com/Comfy-Org/ComfyUI_frontend/issues/16380
-      test.fixme(
+      test.fail(
         true,
         'Cloud currently enables Assets unconditionally instead of honoring the off flag'
       )


### PR DESCRIPTION
## Summary

Adds route-mocked browser coverage for the Assets sidebar's initial flag-off isolation contract.

## Changes

- Initial flag-off isolation stays in #16258; runtime on→off fallback stays in #16293.
- OSS proves history rendering with zero Asset API list requests.
- Cloud executes the same contract as an expected failure tracked by #16380.

## Review Focus

**Changes**

- OSS: requires a history-backed output, zero `GET /api/assets` list requests, and no Cloud-only filter control.
- Cloud: executes the same assertions under `test.fail` because `assetsEnabled` currently treats Cloud as unconditionally enabled.
- Scope reconciliation: #16293 is complementary, not containing or conflicting; it starts with Assets enabled and tests a reactive runtime transition to disabled in `assets.spec.ts`.

**Evidence**

- Current head: `427748002fc75249becdbbef967f5755706f9465`.
- CI Cloud Playwright project passed: https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/33763234307/job/100675567815
- Lint/format, typecheck/unit, knip, ecosystem matrix, and remaining browser projects passed.
- The sole red shard is unrelated: `errorsTabExecution.spec.ts` could not find `error-overlay`; #16258 changes only `assetsFlagIsolation.spec.ts`: https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/33763234307/job/100675568140
- All review threads are resolved.

No production code or dependencies changed.
