### PR TITLE
Test hidden custom-node ARIA dialogs in Playwright

### DIFF
--- a/browser_tests/fixtures/helpers/BAD_DO_NOT_DO_THIS_LegacyApiHelper.ts
+++ b/browser_tests/fixtures/helpers/BAD_DO_NOT_DO_THIS_LegacyApiHelper.ts
@@ -7,6 +7,18 @@ import type { NodeId } from '@/types/nodeId'
 export class BAD_DO_NOT_DO_THIS_LegacyApiHelper {
   constructor(private readonly page: Page) {}
 
+  addNodeWithMountedHiddenAriaDialog() {
+    return this.page.evaluate(() => {
+      const node = window.LiteGraph!.createNode(
+        'DevToolsNodeWithHiddenAriaDialog'
+      )
+      if (!node) {
+        throw new Error('DevToolsNodeWithHiddenAriaDialog is not registered')
+      }
+      window.app!.graph.add(node)
+    })
+  }
+
   disconnectInputByAssigningNull(nodeType: string, inputIndex: number) {
     return this.page.evaluate(
       ([nodeType, inputIndex]) => {

--- a/browser_tests/tests/legacyDoNotReplicate/legacyHiddenAriaDialog.spec.ts
+++ b/browser_tests/tests/legacyDoNotReplicate/legacyHiddenAriaDialog.spec.ts
@@ -1,0 +1,26 @@
+import {
+  comfyExpect as expect,
+  comfyPageFixture as test
+} from '@e2e/fixtures/ComfyPage'
+import { BAD_DO_NOT_DO_THIS_LegacyApiHelper } from '@e2e/fixtures/helpers/BAD_DO_NOT_DO_THIS_LegacyApiHelper'
+
+test(
+  'Ctrl/Cmd+S works with a mounted hidden ARIA dialog from a legacy custom node',
+  { tag: ['@custom-nodes', '@keyboard'] },
+  async ({ comfyPage }) => {
+    const legacyApi = new BAD_DO_NOT_DO_THIS_LegacyApiHelper(comfyPage.page)
+    await legacyApi.addNodeWithMountedHiddenAriaDialog()
+
+    const hiddenDialog = comfyPage.page.locator(
+      '[data-devtools-hidden-aria-dialog]'
+    )
+    await expect(hiddenDialog).toHaveAttribute('role', 'dialog')
+    await expect(hiddenDialog).toHaveAttribute('aria-modal', 'true')
+    await expect(hiddenDialog).toHaveAttribute('hidden', '')
+
+    await comfyPage.canvas.click()
+    await comfyPage.page.keyboard.press('ControlOrMeta+s')
+
+    await expect(comfyPage.menu.topbar.getSaveDialog()).toBeVisible()
+  }
+)

--- a/tools/devtools/nodes/inputs.py
+++ b/tools/devtools/nodes/inputs.py
@@ -332,6 +332,21 @@ class NodeWithPreAttachLegacyWidgets:
     def node_with_pre_attach_legacy_widgets(self):
         return ()
 
+
+class NodeWithHiddenAriaDialog:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {"required": {}}
+
+    RETURN_TYPES = ()
+    FUNCTION = "node_with_hidden_aria_dialog"
+    CATEGORY = "DevTools"
+    DESCRIPTION = "A node whose web extension keeps a hidden ARIA dialog mounted"
+
+    def node_with_hidden_aria_dialog(self):
+        return ()
+
+
 class NodeWithPriceBadge(IO.ComfyNode):
     @classmethod
     def define_schema(cls):
@@ -419,6 +434,7 @@ NODE_CLASS_MAPPINGS = {
     "DevToolsNodeWithV2ComboInput": NodeWithV2ComboInput,
     "DevToolsNodeWithLegacyWidget": NodeWithLegacyWidget,
     "DevToolsNodeWithPreAttachLegacyWidgets": NodeWithPreAttachLegacyWidgets,
+    "DevToolsNodeWithHiddenAriaDialog": NodeWithHiddenAriaDialog,
     "DevToolsNodeWithPriceBadge": NodeWithPriceBadge,
     "DevToolsNodeWithNumericCombo": NodeWithNumericCombo,
     "DevToolsNodeWithDynamicCombo": NodeWithDynamicCombo,
@@ -441,6 +457,7 @@ NODE_DISPLAY_NAME_MAPPINGS = {
     "DevToolsNodeWithV2ComboInput": "Node With V2 Combo Input",
     "DevToolsNodeWithLegacyWidget": "Node With Legacy Widget",
     "DevToolsNodeWithPreAttachLegacyWidgets": "Node With Pre-Attach Legacy Widgets",
+    "DevToolsNodeWithHiddenAriaDialog": "Node With Hidden ARIA Dialog",
     "DevToolsNodeWithPriceBadge": "Node With Price Badge",
     "DevToolsNodeWithNumericCombo": "Node With Numeric Combo",
     "DevToolsNodeWithDynamicCombo": "Node With Dynamic Combo",

--- a/tools/devtools/web/hiddenAriaDialog.js
+++ b/tools/devtools/web/hiddenAriaDialog.js
@@ -1,0 +1,30 @@
+// eslint-disable-next-line import-x/no-unresolved -- import is correct at time of test execution
+import { app } from '../../scripts/app.js'
+
+const NODE_TYPE = 'DevToolsNodeWithHiddenAriaDialog'
+
+app.registerExtension({
+  name: 'DevTools.HiddenAriaDialog',
+  async beforeRegisterNodeDef(nodeType, nodeData) {
+    if (nodeData.name !== NODE_TYPE) return
+
+    const onNodeCreated = nodeType.prototype.onNodeCreated
+    nodeType.prototype.onNodeCreated = function (...args) {
+      onNodeCreated?.apply(this, args)
+
+      const dialog = document.createElement('div')
+      dialog.setAttribute('role', 'dialog')
+      dialog.setAttribute('aria-modal', 'true')
+      dialog.dataset.devtoolsHiddenAriaDialog = ''
+      dialog.hidden = true
+      dialog.tabIndex = -1
+      document.body.appendChild(dialog)
+
+      const onRemoved = this.onRemoved
+      this.onRemoved = function (...removeArgs) {
+        dialog.remove()
+        onRemoved?.apply(this, removeArgs)
+      }
+    }
+  }
+})


### PR DESCRIPTION
## Summary

Add realistic custom-node Playwright coverage for mounted hidden ARIA dialogs without duplicating extension code in the spec.

## Changes

- **What**: Add a devtools node whose web extension mounts a hidden `role=\"dialog\" aria-modal=\"true\"` element, expose node creation through the legacy API helper, and verify Ctrl/Cmd+S still opens Save As.

## Review Focus

This follows #16056 and should merge after it. The test is routed through the custom-nodes Playwright project so the devtools web extension is loaded.