### PR TITLE
test: align fdct hero test with autoplay hero video

### DIFF
--- a/apps/website/src/templates/fdct/HeroSection.test.ts
+++ b/apps/website/src/templates/fdct/HeroSection.test.ts
@@ -5,17 +5,17 @@ import { describe, expect, it } from 'vitest'
 import HeroSection from './HeroSection.vue'
 
 describe('fdct HeroSection', () => {
-  it('renders the split hero with a click-to-play video behind its poster', () => {
+  it('renders the split hero with a muted autoplay video and poster fallback', () => {
     render(HeroSection)
 
-    // Click-to-play: the hero video must not autoplay and rests on its poster
-    const video = screen.getByLabelText('Forward Deployed Creatives')
-    expect(video.hasAttribute('autoplay')).toBe(false)
+    // Autoplay hero (#16205): the video starts on its own, muted so
+    // browsers allow it, with the poster shown until playback begins
+    const video = screen.getByLabelText<HTMLVideoElement>(
+      'Forward Deployed Creatives'
+    )
+    expect(video.hasAttribute('autoplay')).toBe(true)
+    expect(video.muted).toBe(true)
     expect(video.getAttribute('poster')).toContain('FDCT_V4_thumb')
-
-    // The centered overlay play button floats over the poster
-    const play = screen.getByRole('button', { name: 'Play' })
-    expect(play.classList.contains('backdrop-blur-[9px]')).toBe(true)
   })
 
   it('renders the contact CTA', () => {


### PR DESCRIPTION
#16205 made the fdct hero video autoplay but left the HeroSection unit test asserting the old click-to-play design, so website-unit fails whenever it runs (it is path-filtered and skipped on most PRs, which hid the breakage).

Updates the test to assert the intended behavior: autoplay attribute present, muted (required for browser autoplay), poster fallback retained. Removes the overlay play-button assertion tied to the removed click-to-play affordance.

- Surfaced by website-unit runs on #16259