### PR TITLE
feat: report cmp event sink failures

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
   "dependencies": {
     "@alloc/quick-lru": "catalog:",
     "@atlaskit/pragmatic-drag-and-drop": "^1.3.1",
-    "@comfyorg/comfy-multi-player": "github:Comfy-Org/comfy-multi-player#58e2333ce3bb6375fd2efbc1e9d7df17327f37e0",
+    "@comfyorg/comfy-multi-player": "github:Comfy-Org/comfy-multi-player#743bfd03a6852e9f70ba4cbcfb1c0075dda86c04",
     "@comfyorg/comfyui-desktop-bridge-types": "catalog:",
     "@comfyorg/comfyui-electron-types": "catalog:",
     "@comfyorg/design-system": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -473,8 +473,8 @@ importers:
         specifier: ^1.3.1
         version: 1.8.1
       '@comfyorg/comfy-multi-player':
-        specifier: github:Comfy-Org/comfy-multi-player#58e2333ce3bb6375fd2efbc1e9d7df17327f37e0
-        version: https://codeload.github.com/Comfy-Org/comfy-multi-player/tar.gz/58e2333ce3bb6375fd2efbc1e9d7df17327f37e0
+        specifier: github:Comfy-Org/comfy-multi-player#743bfd03a6852e9f70ba4cbcfb1c0075dda86c04
+        version: https://codeload.github.com/Comfy-Org/comfy-multi-player/tar.gz/743bfd03a6852e9f70ba4cbcfb1c0075dda86c04
       '@comfyorg/comfyui-desktop-bridge-types':
         specifier: 'catalog:'
         version: 0.2.0
@@ -1590,8 +1590,8 @@ packages:
     resolution: {integrity: sha512-y7/yvZ2TPAnR9+jnc00klvNNLkJiXFFrQA/hlLCcxA9a2A4zQIOimyFQ9XfwYKiGD1fb5GY8vbKIIgO8d5Tb2A==}
     engines: {node: '>= 20.12.0'}
 
-  '@comfyorg/comfy-multi-player@https://codeload.github.com/Comfy-Org/comfy-multi-player/tar.gz/58e2333ce3bb6375fd2efbc1e9d7df17327f37e0':
-    resolution: {gitHosted: true, integrity: sha512-Ez2PfcoGthskb/eOhIjXJYrGV5vkEbGRXKFLzlAiaqZMnPjfgqd9ppQ48IExReXJtpGZVPdZPVr1J3IPB/voUg==, tarball: https://codeload.github.com/Comfy-Org/comfy-multi-player/tar.gz/58e2333ce3bb6375fd2efbc1e9d7df17327f37e0}
+  '@comfyorg/comfy-multi-player@https://codeload.github.com/Comfy-Org/comfy-multi-player/tar.gz/743bfd03a6852e9f70ba4cbcfb1c0075dda86c04':
+    resolution: {gitHosted: true, integrity: sha512-eKYhLkPvZ95BrmlvHAFmZB3rDj8XaCZ46ltqEdBlJepCJYKexQ3V8vgXWQDcF2XzjxRmGQsd+iQRW35ZvvBpoA==, tarball: https://codeload.github.com/Comfy-Org/comfy-multi-player/tar.gz/743bfd03a6852e9f70ba4cbcfb1c0075dda86c04}
     version: 0.2.0
 
   '@comfyorg/comfyui-desktop-bridge-types@0.2.0':
@@ -10032,7 +10032,7 @@ snapshots:
       fast-wrap-ansi: 0.2.2
       sisteransi: 1.0.5
 
-  '@comfyorg/comfy-multi-player@https://codeload.github.com/Comfy-Org/comfy-multi-player/tar.gz/58e2333ce3bb6375fd2efbc1e9d7df17327f37e0':
+  '@comfyorg/comfy-multi-player@https://codeload.github.com/Comfy-Org/comfy-multi-player/tar.gz/743bfd03a6852e9f70ba4cbcfb1c0075dda86c04':
     dependencies:
       yjs: 13.6.31
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -162,7 +162,7 @@ catalog:
 cleanupUnusedCatalogs: true
 
 allowBuilds:
-  '@comfyorg/comfy-multi-player@https://codeload.github.com/Comfy-Org/comfy-multi-player/tar.gz/58e2333ce3bb6375fd2efbc1e9d7df17327f37e0': true
+  '@comfyorg/comfy-multi-player@https://codeload.github.com/Comfy-Org/comfy-multi-player/tar.gz/743bfd03a6852e9f70ba4cbcfb1c0075dda86c04': true
   '@firebase/util': false
   '@sentry/cli': true
   '@tailwindcss/oxide': true

--- a/src/platform/telemetry/cmpEventSink.test.ts
+++ b/src/platform/telemetry/cmpEventSink.test.ts
@@ -1,0 +1,52 @@
+import type { CmpEvent } from '@comfyorg/comfy-multi-player'
+
+import { reportError } from './reportError'
+import { cmpEventSink } from './cmpEventSink'
+
+vi.mock('./reportError', () => ({ reportError: vi.fn() }))
+
+const event: CmpEvent = {
+  schema_version: 1,
+  type: 'op_rejected',
+  source: 'applyOps',
+  code: 'unknown_widget',
+  message: 'widget write rejected',
+  error_name: 'OpRejectedError',
+  op_id: '0123456789abcdef0123456789abcdef',
+  batch_index: 2
+}
+
+describe('cmpEventSink', () => {
+  it('maps a cmp event to the generic error reporter', () => {
+    expect(cmpEventSink(event)).toBeUndefined()
+
+    expect(reportError).toHaveBeenCalledWith(
+      expect.objectContaining({ message: event.message }),
+      {
+        errorType: 'cmp_event',
+        tags: {
+          cmp_event_schema_version: 1,
+          cmp_event_type: 'op_rejected',
+          cmp_event_source: 'applyOps',
+          cmp_event_code: 'unknown_widget',
+          cmp_event_error_name: 'OpRejectedError'
+        },
+        context: {
+          op_id: event.op_id,
+          batch_index: 2
+        }
+      }
+    )
+  })
+
+  it('bounds diagnostic messages and accepts additive event names', () => {
+    cmpEventSink({ ...event, type: 'future_event', message: 'x'.repeat(2_000) })
+
+    expect(reportError).toHaveBeenLastCalledWith(
+      expect.objectContaining({ message: 'x'.repeat(1_024) }),
+      expect.objectContaining({
+        tags: expect.objectContaining({ cmp_event_type: 'future_event' })
+      })
+    )
+  })
+})

--- a/src/platform/telemetry/cmpEventSink.ts
+++ b/src/platform/telemetry/cmpEventSink.ts
@@ -1,0 +1,23 @@
+import type { CmpEventSink } from '@comfyorg/comfy-multi-player'
+
+import { reportError } from './reportError'
+
+const MAX_MESSAGE_LENGTH = 1_024
+
+export const cmpEventSink: CmpEventSink = (event) => {
+  reportError(new Error(event.message.slice(0, MAX_MESSAGE_LENGTH)), {
+    errorType: 'cmp_event',
+    tags: {
+      cmp_event_schema_version: event.schema_version,
+      cmp_event_type: event.type,
+      cmp_event_source: event.source,
+      cmp_event_code: event.code,
+      cmp_event_error_name: event.error_name
+    },
+    context: {
+      op_id: event.op_id,
+      batch_index: event.batch_index
+    }
+  })
+  return undefined
+}


### PR DESCRIPTION
<!-- authored-by:agent worker-3 -->
Pins merged cmp event-sink contract and maps its failures to the generic FE reporter. Green locally. Operator review needed: this follower base has no production applyOps call, so the adapter is intentionally not attached to a forbidden follower write path.

<details><summary>Full context and validation</summary>

## Summary

Adds the frontend-owned CmpEventSink adapter selected by cmp ADR-008 without introducing package-global registration.

## Changes

- **What**: cmpEventSink bounds diagnostic messages, keeps machine fields as stable tags, and keeps op_id/batch_index in non-indexed context.
- **Dependencies**: advances @comfyorg/comfy-multi-player to merged SHA 743bfd03a6852e9f70ba4cbcfb1c0075dda86c04, including its exact supply-chain allowlist identity.
- **Authority boundary**: does not call applyOps from the follower. The target base only consumes host-owned Yjs updates, so manufacturing a browser applier call would violate the follower contract.

## Review Focus

- Confirm the reporter mapping and message bound.
- Decide where a future browser-owned cmp applier should receive the event sink; there is no legal production call site on this base.

## Validation

- pnpm test:unit src/platform/telemetry/cmpEventSink.test.ts --run — 2 passed.
- pnpm typecheck — passed.
- pnpm lint — passed with 187 pre-existing warnings and zero errors.

</details>
