### PR TITLE
fix(agent): re-mint follower doc on workflow switch (FEB-5)

### DIFF
--- a/src/renderer/extensions/vueNodes/composables/processedWidgetRenderModel.ts
+++ b/src/renderer/extensions/vueNodes/composables/processedWidgetRenderModel.ts
@@ -459,7 +459,7 @@ export function computeProcessedWidgets({
   forceDisabled = false,
   isGraphReady,
   rootGraph,
-  ui,
+  ui
 }: ComputeProcessedWidgetsOptions): ProcessedWidget[] {
   if (!nodeData) return []
 
@@ -512,7 +512,7 @@ export function computeProcessedWidgets({
     missingModelStore,
     missingMediaStore,
     nodeDefStore,
-    ui,
+    ui
   }
 
   return Array.from(new Set(ids))

--- a/src/workbench/extensions/agent/crdt/followerSubscription.test.ts
+++ b/src/workbench/extensions/agent/crdt/followerSubscription.test.ts
@@ -399,6 +399,85 @@ describe('FE-GAP-1 — a seq jump means a dropped frame and forces a resync', ()
   })
 })
 
+describe('FEB-5 — a workflow switch re-mints the doc: its lifetime is the binding lifetime', () => {
+  it('drops the old doc on switch and subscribes with the FRESH (empty) state vector', () => {
+    const { transport, bridge, projected } = wire()
+    transport.open = true
+    bridge.subscribe('wf-a')
+    transport.deliver('doc_update', docUpdateFrame(hostDocUpdate(), 'wf-a'))
+    const oldDoc = bridge.follower
+    expect(oldDoc.updatesApplied).toBe(1)
+
+    bridge.subscribe('wf-b')
+
+    // wf-a's history is dropped wholesale, never folded into wf-b's doc.
+    expect(bridge.follower).not.toBe(oldDoc)
+    expect(bridge.follower.updatesApplied).toBe(0)
+    expect(bridge.follower.doc.getMap('nodes').size).toBe(0)
+
+    // The wf-b subscribe carries the fresh doc's EMPTY vector — a vector
+    // minted from wf-a's doc must never scope wf-b's catch-up.
+    const subscribes = transport.framesOfType('doc_subscribe') as {
+      data: { workflow_id: string; state_vector_b64: string }
+    }[]
+    expect(subscribes).toHaveLength(2)
+    expect(subscribes[1].data.workflow_id).toBe('wf-b')
+    expect(subscribes[1].data.state_vector_b64).toBe(
+      encodeBase64(Y.encodeStateVector(new Y.Doc()))
+    )
+
+    // wf-b's updates land on the fresh doc.
+    transport.deliver('doc_update', docUpdateFrame(hostDocUpdate(), 'wf-b'))
+    expect(bridge.follower.updatesApplied).toBe(1)
+    expect(projected).toHaveLength(2)
+  })
+
+  it('re-subscribing to the SAME workflow keeps the doc, so catch-up stays incremental', () => {
+    const { transport, bridge } = wire()
+    transport.open = true
+    bridge.subscribe(WORKFLOW_ID)
+    transport.deliver('doc_update', docUpdateFrame(hostDocUpdate()))
+    const oldDoc = bridge.follower
+
+    bridge.subscribe(WORKFLOW_ID)
+
+    expect(bridge.follower).toBe(oldDoc)
+    expect(bridge.follower.updatesApplied).toBe(1)
+    expect(transport.framesOfType('doc_subscribe')).toHaveLength(1)
+  })
+
+  it('a detach does not launder the doc identity: unsubscribe then switch still re-mints', () => {
+    const { transport, bridge } = wire()
+    transport.open = true
+    bridge.subscribe('wf-a')
+    transport.deliver('doc_update', docUpdateFrame(hostDocUpdate(), 'wf-a'))
+    const oldDoc = bridge.follower
+
+    bridge.unsubscribe()
+    bridge.subscribe('wf-b')
+
+    expect(bridge.follower).not.toBe(oldDoc)
+    expect(bridge.follower.updatesApplied).toBe(0)
+  })
+
+  it('a schema failure latched on one workflow does not close the read path of the next', () => {
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const { transport, bridge, projected } = wire()
+    transport.open = true
+    bridge.subscribe('wf-a')
+    const v2 = hostDocUpdate((doc) => metaMap(doc).set('schema_version', 2))
+    transport.deliver('doc_update', docUpdateFrame(v2, 'wf-a'))
+    expect(bridge.lastSchemaError).toBeInstanceOf(FollowerSchemaError)
+
+    bridge.subscribe('wf-b')
+
+    expect(bridge.lastSchemaError).toBeNull()
+    transport.deliver('doc_update', docUpdateFrame(hostDocUpdate(), 'wf-b'))
+    expect(projected).toHaveLength(1)
+    error.mockRestore()
+  })
+})
+
 describe('FE-KA11-1 — the read-time schema gate fails closed', () => {
   it('accepts a doc the shared package seeded at the version this build reads', () => {
     const { transport, bridge, projected, schemaErrors } = wire()

--- a/src/workbench/extensions/agent/crdt/layoutFollowerBridge.ts
+++ b/src/workbench/extensions/agent/crdt/layoutFollowerBridge.ts
@@ -37,11 +37,23 @@ function trySend(send: () => boolean): boolean {
  */
 export class LayoutFollowerBridge extends EventTarget {
   /**
-   * Reassigned only by {@link onDocReset}: a lineage break replaces the doc
-   * wholesale, because folding a re-minted document into the old one merges
-   * two unrelated histories and duplicates every node on the canvas.
+   * Reassigned only when the document it holds stops being the document being
+   * followed: a lineage break ({@link onDocReset}) or a binding change
+   * ({@link subscribe} with a different workflow). In both cases the doc is
+   * replaced wholesale, because folding one document's history into another's
+   * merges two unrelated histories and duplicates every node on the canvas.
    */
   private followerDoc = new FollowerDoc()
+  /**
+   * The workflow {@link followerDoc}'s contents belong to — the doc's
+   * IDENTITY, distinct from subscription intent below, which can move to
+   * another workflow (or to null and back) while the doc still holds the old
+   * workflow's state. Compared on every {@link subscribe} so a binding change
+   * re-mints the doc instead of folding the new workflow's lineage into the
+   * old one (FEB-5): `reconcile()` sends `this.follower.stateVector()`, and a
+   * vector minted from workflow A must never scope workflow B's catch-up.
+   */
+  private docWorkflowId: string | null = null
   /**
    * Subscription INTENT — the workflow the app wants followed. Set
    * synchronously by the caller; independent of whether any frame has left the
@@ -101,7 +113,23 @@ export class LayoutFollowerBridge extends EventTarget {
     )
   }
 
+  /**
+   * Follow a workflow. A doc's lifetime is its BINDING's lifetime (FEB-5): on
+   * a change of workflow the held doc is dropped and re-minted exactly as
+   * {@link onDocReset} does, so the subscribe that follows carries the fresh
+   * (empty) state vector and the server's ordinary catch-up returns the new
+   * workflow's full folded state. Without the re-mint, the new workflow's
+   * updates fold into the OLD workflow's Y.Doc — a cross-workflow lineage
+   * merge on every switch. Re-subscribing to the SAME workflow keeps the doc,
+   * so a warm re-attach still catches up incrementally.
+   */
   subscribe(workflowId: string): void {
+    if (this.docWorkflowId !== null && this.docWorkflowId !== workflowId) {
+      this.followerDoc.destroy()
+      this.followerDoc = new FollowerDoc()
+      this.schemaError = null
+    }
+    this.docWorkflowId = workflowId
     this.desiredWorkflowId = workflowId
     this.reconcile()
   }


### PR DESCRIPTION
- Follower doc now re-minted on workflow switch — no more cross-workflow state bleed
- Bridge tracks `docWorkflowId`; `subscribe()` re-mints doc + clears schemaError when binding changes
- Green: 4 new regression tests, crdt suite passing, tsc/lint clean

<details><summary>Full context for agent readers</summary>

## Problem (FEB-5)

The follower CRDT doc was minted once per composable lifetime. When the user switched workflows while the agent panel stayed mounted, the old doc — carrying the previous workflow's state and any `schemaError` — was reused for the new binding. Follower state from workflow A could bleed into workflow B.

## Fix

Doc lifetime = binding lifetime. `layoutFollowerBridge` now records which workflow the current doc was minted for (`docWorkflowId`). On `subscribe()`:

- same workflow id → keep the existing doc (no churn on re-subscribe)
- different workflow id → mint a fresh FollowerDoc and clear `schemaError`

```diagram
┌────────────────────┐   subscribe(wfB)    ┌─────────────────────────┐
│ layoutFollowerBridge│───────────────────▶│ docWorkflowId == wfB ?  │
│  doc (minted wfA)  │                     └───────┬────────────┬────┘
└────────────────────┘                        yes  │            │ no
                                                   ▼            ▼
                                            keep doc      re-mint doc,
                                                           clear schemaError
</diagram — rendered as code block>
```

## Files

- `src/workbench/extensions/agent/crdt/layoutFollowerBridge.ts`
- `src/workbench/extensions/agent/crdt/followerSubscription.test.ts` (4 regression tests: re-mint on switch, keep on same id, schemaError cleared, doc identity)

## Verification

- `pnpm vitest run src/workbench/extensions/agent/crdt/` — full crdt suite green
- `tsc` — zero diagnostics in crdt scope
- eslint / oxlint / oxfmt clean

## Provenance

Cut from `origin/nathaniel/agent-panel-v1` @ `583ad3b400`. Design per our internal CRDT lane (todo.md FEB-5 / slice s1-B); no Nathaniel design material consulted (COR-8). Verify report: `reports/audit/` in the program workspace.

## Glossary

- **FEB-5**: Frontend Extension Bug 5 — follower doc reused across workflow switches (program todo.md CRDT lane)
- **s1-B**: slice 1, item B of the agent-panel CRDT follower work
- **FollowerDoc**: client-side CRDT document mirroring the layout the agent manipulates
- **binding**: (workflow, subscription) pair the bridge serves at any moment
- **COR-8**: program correction rule — Nathaniel's CRDT design surface is quarantined; our design is authoritative

</details>
