### PR TITLE
fix(agent): scope human-op base_version to the live binding (FEB-3)

### DIFF
--- a/src/renderer/extensions/vueNodes/composables/processedWidgetRenderModel.ts
+++ b/src/renderer/extensions/vueNodes/composables/processedWidgetRenderModel.ts
@@ -459,7 +459,7 @@ export function computeProcessedWidgets({
   forceDisabled = false,
   isGraphReady,
   rootGraph,
-  ui,
+  ui
 }: ComputeProcessedWidgetsOptions): ProcessedWidget[] {
   if (!nodeData) return []
 
@@ -512,7 +512,7 @@ export function computeProcessedWidgets({
     missingModelStore,
     missingMediaStore,
     nodeDefStore,
-    ui,
+    ui
   }
 
   return Array.from(new Set(ids))

--- a/src/workbench/extensions/agent/crdt/followerSubscription.test.ts
+++ b/src/workbench/extensions/agent/crdt/followerSubscription.test.ts
@@ -468,3 +468,112 @@ describe('FE-KA11-1 — the read-time schema gate fails closed', () => {
     error.mockRestore()
   })
 })
+
+describe('FEB-3 — base_version baseline is scoped to the current subscribe', () => {
+  // `bridge.lastKnownSeq` is what human-minted ops stamp as `base_version`.
+  // A baseline that survives a workflow switch or a doc_reset mints stamps
+  // from a DEAD lineage's high-water mark, and those stamps dominate every
+  // fresh-lineage op (LWW ties break by [base_version, actor, op_id]) — the
+  // DQ-11 stamp-domination family. These tests pin the scoping: the baseline
+  // is nulled whenever a subscribe leaves and re-baselined only by the new
+  // binding's ack and in-order updates.
+
+  it('baselines from the subscribe ack and advances with in-order updates', () => {
+    const { transport, bridge } = wire()
+    transport.open = true
+    bridge.subscribe(WORKFLOW_ID)
+    expect(bridge.lastKnownSeq).toBeNull()
+
+    transport.deliver('doc_subscribed', {
+      v: 1,
+      workflow_id: WORKFLOW_ID,
+      ok: true,
+      seq: 41
+    })
+    expect(bridge.lastKnownSeq).toBe(41)
+
+    transport.deliver(
+      'doc_update',
+      docUpdateFrame(hostDocUpdate(), WORKFLOW_ID, 42)
+    )
+    expect(bridge.lastKnownSeq).toBe(42)
+  })
+
+  it('a workflow switch nulls the baseline — no stamp minted from the dead binding', () => {
+    const { transport, bridge } = wire()
+    transport.open = true
+    bridge.subscribe(WORKFLOW_ID)
+    transport.deliver('doc_subscribed', {
+      v: 1,
+      workflow_id: WORKFLOW_ID,
+      ok: true,
+      seq: 41
+    })
+    transport.deliver(
+      'doc_update',
+      docUpdateFrame(hostDocUpdate(), WORKFLOW_ID, 42)
+    )
+    expect(bridge.lastKnownSeq).toBe(42)
+
+    // Switch to a different workflow: the old high-water mark must not
+    // survive into the new binding's stamps.
+    bridge.subscribe('wf-2')
+    expect(bridge.lastKnownSeq).toBeNull()
+
+    // The new binding baselines from ITS ack, not the dead doc's seq 42.
+    transport.deliver('doc_subscribed', {
+      v: 1,
+      workflow_id: 'wf-2',
+      ok: true,
+      seq: 3
+    })
+    expect(bridge.lastKnownSeq).toBe(3)
+  })
+
+  it('a doc_reset nulls the baseline through the resubscribe', () => {
+    const { transport, bridge } = wire()
+    transport.open = true
+    bridge.subscribe(WORKFLOW_ID)
+    transport.deliver('doc_subscribed', {
+      v: 1,
+      workflow_id: WORKFLOW_ID,
+      ok: true,
+      seq: 41
+    })
+    transport.deliver(
+      'doc_update',
+      docUpdateFrame(hostDocUpdate(), WORKFLOW_ID, 42)
+    )
+    expect(bridge.lastKnownSeq).toBe(42)
+
+    // Lineage break: the host re-minted the document. The resubscribe leaves
+    // immediately (socket open), so the baseline is nulled with it — seq 42
+    // belongs to the dead lineage and may not stamp post-reset ops.
+    transport.deliver('doc_reset', { v: 1, workflow_id: WORKFLOW_ID, seq: 43 })
+    expect(bridge.lastKnownSeq).toBeNull()
+
+    transport.deliver('doc_subscribed', {
+      v: 1,
+      workflow_id: WORKFLOW_ID,
+      ok: true,
+      seq: 5
+    })
+    expect(bridge.lastKnownSeq).toBe(5)
+  })
+
+  it('an unacked subscribe leaves the baseline null (base_version floors to 0)', () => {
+    const { transport, bridge } = wire()
+    transport.open = true
+    bridge.subscribe(WORKFLOW_ID)
+    transport.deliver('doc_subscribed', {
+      v: 1,
+      workflow_id: WORKFLOW_ID,
+      ok: true,
+      seq: 41
+    })
+    bridge.subscribe('wf-2')
+
+    // No ack for wf-2 yet: a stamp minted NOW must floor to 0, never reuse 41.
+    expect(bridge.lastKnownSeq).toBeNull()
+  })
+})

--- a/src/workbench/extensions/agent/crdt/layoutFollowerBridge.ts
+++ b/src/workbench/extensions/agent/crdt/layoutFollowerBridge.ts
@@ -93,6 +93,18 @@ export class LayoutFollowerBridge extends EventTarget {
     return this.schemaError
   }
 
+  /**
+   * The gap detector's baseline, exposed as the ONLY legitimate source for
+   * `base_version` on human-minted ops (FEB-3). It is scoped to the current
+   * subscribe — nulled whenever a subscribe frame leaves, re-baselined from
+   * the `doc_subscribed` ack — so a stamp can never be minted from a dead
+   * binding's high-water mark (DQ-11 stamp-domination family). `null` means
+   * "no post-subscribe baseline yet"; callers floor it to 0.
+   */
+  get lastKnownSeq(): number | null {
+    return this.lastSeq
+  }
+
   /** True while intent and reality disagree — i.e. a retry is still owed. */
   get hasPendingSubscribe(): boolean {
     return (

--- a/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.ts
+++ b/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.ts
@@ -139,10 +139,15 @@ export function useAgentCrdtFollower(workflowId: Ref<string | null>) {
   const client = new DocFrameClient(transport)
   const bridge = new LayoutFollowerBridge(client)
   const tabId = crypto.randomUUID()
-  // Highest doc_update seq seen — used as base_version for human-minted ops.
-  // The ws path has no ceiling gate; this only feeds LWW stamps, so a slightly
-  // stale value is safe (ties break by [base_version, actor, op_id]).
-  let lastSeq = 0
+  // base_version for human-minted ops derives from the bridge's per-subscribe
+  // seq baseline (`bridge.lastKnownSeq`), NOT a composable-lifetime counter: a
+  // parallel counter survives workflow switches and doc_resets, so it minted
+  // stamps from a dead lineage's high-water mark and those stamps dominated
+  // every fresh-lineage op (FEB-3, DQ-11 stamp-domination family). The ws path
+  // has no ceiling gate; this only feeds LWW stamps, so a slightly stale value
+  // within the SAME lineage is safe (ties break by [base_version, actor,
+  // op_id]).
+  const currentBaseVersion = (): number => bridge.lastKnownSeq ?? 0
   let lastOpsResult: unknown = null
   // Post-ECS main removed the global layout source scope
   // (`LayoutSource.External` / `layoutStore.setSource`), so remote batches
@@ -226,8 +231,6 @@ export function useAgentCrdtFollower(workflowId: Ref<string | null>) {
   const onUpdate: EventListener = (event) => {
     updatesApplied.value = bridge.follower.updatesApplied
     lastFrameType.value = event.type
-    if (event instanceof CustomEvent && typeof event.detail?.seq === 'number')
-      lastSeq = Math.max(lastSeq, event.detail.seq)
     projector.project(bridge.follower.doc)
     if (event instanceof CustomEvent) {
       const detail = event.detail as {
@@ -437,7 +440,7 @@ export function useAgentCrdtFollower(workflowId: Ref<string | null>) {
         ? { ...serialized, id: nodeId, type: classType, pos }
         : { id: nodeId, type: classType, pos, size: [270, 100] }
     }
-    const baseVersion = lastSeq
+    const baseVersion = currentBaseVersion()
     const op: DocOp = {
       op: 'add_node',
       op_id: mintOpId(),
@@ -461,7 +464,7 @@ export function useAgentCrdtFollower(workflowId: Ref<string | null>) {
   ): DocOp => {
     const userId = useAuthStore().userId ?? 'anonymous'
     const actor = `human:${userId}:${tabId}`
-    const baseVersion = lastSeq
+    const baseVersion = currentBaseVersion()
     const op: DocOp = {
       op: 'delete_node',
       op_id: mintOpId(),
@@ -494,7 +497,7 @@ export function useAgentCrdtFollower(workflowId: Ref<string | null>) {
     project: () => projector.project(bridge.follower.doc),
     tabId,
     get lastSeq() {
-      return lastSeq
+      return currentBaseVersion()
     },
     get lastOpsResult() {
       return lastOpsResult


### PR DESCRIPTION
- Human-op `base_version` now derived from the live binding, not a composable-lifetime counter
- Parallel `lastSeq` counter deleted; bridge exposes `lastKnownSeq` (nulled on unsubscribe, baselined from `doc_subscribed` ack, in-order advance)
- Green: 4 new regression tests, crdt suite 68/68, tsc/lint clean

<details><summary>Full context for agent readers</summary>

## Problem (FEB-3)

The composable kept its own `lastSeq` counter with composable lifetime. After unsubscribe/resubscribe or a workflow switch, human ops could be stamped with a stale `base_version` from the previous binding — the server would judge concurrency against the wrong baseline.

## Fix (single source of truth)

Deleted the composable's parallel counter. The bridge — the component that actually owns the subscription — now exposes one getter:

- `lastKnownSeq: number | null`
  - `null` when no live subscription
  - baselined from the `doc_subscribed` ack
  - advances only on in-order updates

Composable derives: `currentBaseVersion() = bridge.lastKnownSeq ?? 0`. Dev-panel getter shape preserved.

```diagram
before:  composable ──(own lastSeq counter, composable lifetime)──▶ base_version
after:   bridge.lastKnownSeq (binding lifetime) ──derive──▶ composable.currentBaseVersion()
```

## Files

- `src/workbench/extensions/agent/crdt/layoutFollowerBridge.ts`
- `src/workbench/extensions/agent/crdt/followerSubscription.test.ts` (FEB-3 describe block, 4 tests: null before subscribe, ack baseline, in-order advance, null after leave)

## Verification

- `pnpm vitest run src/workbench/extensions/agent/crdt/` — 68/68
- `tsc` — zero crdt diagnostics
- eslint / oxlint / oxfmt clean; committed with hooks enabled

## Provenance

Cut from `origin/nathaniel/agent-panel-v1` @ `583ad3b400`. Design per our internal CRDT lane (todo.md FEB-3 / slice s1-C), DERIVE variant per program decision log; no Nathaniel design material consulted (COR-8). Verify report: `reports/audit/verify-FEB-3-lastseq-scoping-2026-08-29.md` in the program workspace.

## Glossary

- **FEB-3**: Frontend Extension Bug 3 — stale base_version on human ops after resubscribe (program todo.md CRDT lane)
- **s1-C**: slice 1, item C of the agent-panel CRDT follower work
- **base_version**: sequence number a human op claims as its concurrency baseline
- **doc_subscribed ack**: server ack carrying the authoritative seq at subscription time
- **DERIVE variant**: chosen design — derive base_version from bridge state instead of storing a second counter
- **COR-8**: program correction rule — Nathaniel's CRDT design surface is quarantined; our design is authoritative

</details>

Note: shares two files with #16276 (`fix/feb5-follower-doc-remint`); diffs are small and disjoint — merges cleanly in either order.
