### PR TITLE
fix(agent): surface host op nacks and projection failures (FEB-6)

### DIFF
--- a/src/renderer/extensions/vueNodes/composables/processedWidgetRenderModel.ts
+++ b/src/renderer/extensions/vueNodes/composables/processedWidgetRenderModel.ts
@@ -459,7 +459,7 @@ export function computeProcessedWidgets({
   forceDisabled = false,
   isGraphReady,
   rootGraph,
-  ui,
+  ui
 }: ComputeProcessedWidgetsOptions): ProcessedWidget[] {
   if (!nodeData) return []
 
@@ -512,7 +512,7 @@ export function computeProcessedWidgets({
     missingModelStore,
     missingMediaStore,
     nodeDefStore,
-    ui,
+    ui
   }
 
   return Array.from(new Set(ids))

--- a/src/workbench/extensions/agent/crdt/devPanelLog.ts
+++ b/src/workbench/extensions/agent/crdt/devPanelLog.ts
@@ -18,6 +18,8 @@ export type DevEventKind =
   | 'subscribe_retry'
   | 'doc_nodes_changed'
   | 'rebind'
+  | 'op_nack'
+  | 'projection_error'
 
 export interface DevEvent {
   seq: number

--- a/src/workbench/extensions/agent/crdt/docFrameClient.ts
+++ b/src/workbench/extensions/agent/crdt/docFrameClient.ts
@@ -21,7 +21,7 @@ export interface DocSubscribed {
   message?: string
 }
 
-interface DocOpsResult {
+export interface DocOpsResult {
   workflowId: string
   ok: boolean
   seq?: number

--- a/src/workbench/extensions/agent/crdt/opOutcome.test.ts
+++ b/src/workbench/extensions/agent/crdt/opOutcome.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Op-outcome surfacing (FEB-6 / s1-D). The behaviour under test: a host
+ * `doc_ops_result` with `ok:false` classifies into a visible nack summary
+ * (never a rollback — the applied prefix stays applied), and a projection
+ * throw is reported instead of vanishing inside the EventTarget dispatch.
+ */
+import { describe, expect, it, vi } from 'vitest'
+
+import { classifyOpsResult, runProjection } from './opOutcome'
+
+describe('classifyOpsResult', () => {
+  it('returns null for a clean result', () => {
+    expect(
+      classifyOpsResult({
+        workflowId: 'wf-1',
+        ok: true,
+        applied: ['op-1'],
+        skipped: []
+      })
+    ).toBeNull()
+  })
+
+  it('returns null for malformed payloads', () => {
+    expect(classifyOpsResult(null)).toBeNull()
+    expect(classifyOpsResult(undefined)).toBeNull()
+    expect(classifyOpsResult('ok')).toBeNull()
+    expect(classifyOpsResult(42)).toBeNull()
+    // ok missing entirely → not a nack (only an explicit ok:false is)
+    expect(classifyOpsResult({ workflowId: 'wf-1' })).toBeNull()
+  })
+
+  it('summarizes an ok:false result, counting the applied prefix and skips', () => {
+    const nack = classifyOpsResult({
+      workflowId: 'wf-1',
+      ok: false,
+      applied: ['op-1', 'op-2'],
+      skipped: ['op-3'],
+      code: 'invalid_node_payload',
+      message: 'node payload failed schema check',
+      failed: { op_id: 'op-4', code: 'invalid_node_payload' }
+    })
+    expect(nack).toEqual({
+      workflowId: 'wf-1',
+      code: 'invalid_node_payload',
+      message: 'node payload failed schema check',
+      failed: { op_id: 'op-4', code: 'invalid_node_payload' },
+      applied: 2,
+      skipped: 1
+    })
+  })
+
+  it('tolerates missing optional fields on a nack', () => {
+    expect(classifyOpsResult({ ok: false })).toEqual({
+      workflowId: null,
+      code: null,
+      message: null,
+      failed: null,
+      applied: 0,
+      skipped: 0
+    })
+  })
+})
+
+describe('runProjection', () => {
+  it('passes the mutation count through on success without reporting', () => {
+    const report = vi.fn()
+    expect(runProjection(() => 3, report)).toBe(3)
+    expect(report).not.toHaveBeenCalled()
+  })
+
+  it('reports an Error throw with its message and returns 0', () => {
+    const report = vi.fn()
+    const boom = new Error('mutator exploded')
+    expect(
+      runProjection(() => {
+        throw boom
+      }, report)
+    ).toBe(0)
+    expect(report).toHaveBeenCalledOnce()
+    expect(report).toHaveBeenCalledWith({ message: 'mutator exploded' }, boom)
+  })
+
+  it('reports a non-Error throw stringified', () => {
+    const report = vi.fn()
+    expect(
+      runProjection(() => {
+        throw 'string failure'
+      }, report)
+    ).toBe(0)
+    expect(report).toHaveBeenCalledWith(
+      { message: 'string failure' },
+      'string failure'
+    )
+  })
+})

--- a/src/workbench/extensions/agent/crdt/opOutcome.ts
+++ b/src/workbench/extensions/agent/crdt/opOutcome.ts
@@ -1,0 +1,79 @@
+/**
+ * Op-outcome surfacing (FEB-6 / s1-D): the pure classification behind the
+ * composable's error path for host op results and canvas projection failures.
+ *
+ * A `doc_ops_result` with `ok:false` means "a failure exists", NOT "nothing
+ * landed": the host applies the valid prefix, records the failure, and still
+ * broadcasts the update (see the docwire batch contract). Surfacing therefore
+ * NEVER implies rollback — the applied prefix stays applied; this module only
+ * turns the outcome into something visible (status field, metric, console).
+ * The pending-op ledger (CRDT-RM-3) consumes this same seam later, with
+ * `op_id` as its correlation key.
+ */
+import type { DocOpsResult } from './docFrameClient'
+
+/** Visible summary of a host-rejected op batch. */
+export interface OpNack {
+  workflowId: string | null
+  /** Host failure code (e.g. `invalid_node_payload`), when provided. */
+  code: string | null
+  message: string | null
+  /** The wire `failed` object (`{op_id, code, message}`), verbatim. */
+  failed: unknown
+  /** How many ops of the batch the host DID apply (prefix — still applied). */
+  applied: number
+  /** Duplicate/no-op op ids the host skipped. */
+  skipped: number
+}
+
+/**
+ * Classify a `doc_ops_result` payload. Returns the nack summary when the host
+ * rejected part of the batch (`ok:false`), `null` for a clean result or a
+ * malformed payload (the frame parser already dropped truly unreadable
+ * frames, so a non-object here is a programming error upstream, not a nack).
+ */
+export function classifyOpsResult(detail: unknown): OpNack | null {
+  if (typeof detail !== 'object' || detail === null) return null
+  const d = detail as Partial<DocOpsResult>
+  if (d.ok !== false) return null
+  return {
+    workflowId: typeof d.workflowId === 'string' ? d.workflowId : null,
+    code: typeof d.code === 'string' ? d.code : null,
+    message: typeof d.message === 'string' ? d.message : null,
+    failed: d.failed ?? null,
+    applied: Array.isArray(d.applied) ? d.applied.length : 0,
+    skipped: Array.isArray(d.skipped) ? d.skipped.length : 0
+  }
+}
+
+/** Visible summary of a projection (doc → canvas) failure. */
+export interface ProjectionFailure {
+  message: string
+}
+
+/**
+ * Run a projection, converting a throw into a reported failure instead of an
+ * unhandled listener error (which the EventTarget dispatch path swallows from
+ * every caller's perspective — the exact FEB-6 silence). Returns the
+ * projection's mutation count, or 0 on failure.
+ *
+ * Recovery is deliberately NOT attempted here: the projector advances its
+ * snapshot before applying, so a retry would double-apply the batch's
+ * successful prefix. A failed projection means the canvas may lag the doc
+ * until the next update or resubscribe re-materializes it; making that
+ * visible is this seam's whole job (observability floor for CRDT-RM-3/RM-6).
+ */
+export function runProjection(
+  project: () => number,
+  report: (failure: ProjectionFailure, error: unknown) => void
+): number {
+  try {
+    return project()
+  } catch (error) {
+    report(
+      { message: error instanceof Error ? error.message : String(error) },
+      error
+    )
+    return 0
+  }
+}

--- a/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.ts
+++ b/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.ts
@@ -12,6 +12,8 @@ import { DocFrameClient } from './docFrameClient'
 import { resolveFollowerEnabled } from './followerGate'
 import { LayoutFollowerBridge } from './layoutFollowerBridge'
 import { LitegraphMutator } from './litegraphMutator'
+import type { OpNack } from './opOutcome'
+import { classifyOpsResult, runProjection } from './opOutcome'
 import { SemanticProjector } from './semanticProjector'
 
 // Resolved once per page load ("per session"): build-time env, overridable at
@@ -74,6 +76,12 @@ export interface AgentCrdtStatus {
   workflowId: string | null
   updatesApplied: number
   lastFrameType: string | null
+  /** Host-rejected op batches this mount (FEB-6). Monotonic; never rolls back. */
+  opNacks: number
+  /** Most recent host nack, until the next one replaces it. */
+  lastOpNack: OpNack | null
+  /** Doc→canvas projection failures this mount (FEB-6). */
+  projectionErrors: number
 }
 
 export const apiTransport: DocFrameTransport = {
@@ -98,6 +106,12 @@ export function useAgentCrdtFollower(workflowId: Ref<string | null>) {
   const updatesApplied = ref(0)
   const lastFrameType = ref<string | null>(null)
   const subscribedWorkflowId = ref<string | null>(null)
+  // FEB-6 (s1-D): op-outcome surfacing. Counters are per-mount and monotonic —
+  // they measure "how noisy has this session been", not doc state, so neither
+  // workflow switch nor doc_reset clears them.
+  const opNacks = ref(0)
+  const lastOpNack = ref<OpNack | null>(null)
+  const projectionErrors = ref(0)
 
   if (!enabled) {
     return {
@@ -107,7 +121,10 @@ export function useAgentCrdtFollower(workflowId: Ref<string | null>) {
           connected: false,
           workflowId: null,
           updatesApplied: 0,
-          lastFrameType: null
+          lastFrameType: null,
+          opNacks: 0,
+          lastOpNack: null,
+          projectionErrors: 0
         })
       ),
       sendHumanOps: (_ops: DocOp[]) => undefined
@@ -154,6 +171,21 @@ export function useAgentCrdtFollower(workflowId: Ref<string | null>) {
     createNode: (type) => LiteGraph.createNode(type)
   })
   const projector = new SemanticProjector(mutator, { actor: tabId })
+  // FEB-6 (s1-D): a projection throw used to vanish inside the EventTarget
+  // dispatch — no status, no metric, canvas silently lagging the doc. Surface
+  // it; recovery stays with resubscribe/doc_reset paths (see runProjection).
+  const projectDoc = (): number =>
+    runProjection(
+      () => projector.project(bridge.follower.doc),
+      (failure, error) => {
+        projectionErrors.value += 1
+        recordDevEvent('projection_error', failure)
+        console.error(
+          '[agent-crdt] projection failed — canvas may lag the doc until the next update or resubscribe',
+          error
+        )
+      }
+    )
 
   // Dev-panel tap (poc-4): track the doc's node-id set so the panel can show
   // exactly which nodes each doc_update added/removed. Rebuilt from zero on
@@ -228,7 +260,7 @@ export function useAgentCrdtFollower(workflowId: Ref<string | null>) {
     lastFrameType.value = event.type
     if (event instanceof CustomEvent && typeof event.detail?.seq === 'number')
       lastSeq = Math.max(lastSeq, event.detail.seq)
-    projector.project(bridge.follower.doc)
+    projectDoc()
     if (event instanceof CustomEvent) {
       const detail = event.detail as {
         workflowId?: string
@@ -256,6 +288,16 @@ export function useAgentCrdtFollower(workflowId: Ref<string | null>) {
     if (event instanceof CustomEvent) {
       lastOpsResult = event.detail ?? null
       recordDevEvent('doc_ops_result', event.detail ?? null)
+      // FEB-6 (s1-D): ok:false means "a failure exists", not "nothing landed" —
+      // the host applies the valid prefix before nacking, so never roll back.
+      // Promote the nack out of the dev-panel-only tap into a real error path.
+      const nack = classifyOpsResult(event.detail)
+      if (nack) {
+        opNacks.value += 1
+        lastOpNack.value = nack
+        recordDevEvent('op_nack', nack)
+        console.error('[agent-crdt] host rejected op batch', nack)
+      }
     }
   }
   const onDocReset: EventListener = (event) => {
@@ -491,7 +533,7 @@ export function useAgentCrdtFollower(workflowId: Ref<string | null>) {
     sendOps: (ops: DocOp[]) => bridge.sendHumanOps(tabId, ops),
     resubscribe: () => bridge.resubscribe(),
     reconcile: () => bridge.reconcile(),
-    project: () => projector.project(bridge.follower.doc),
+    project: () => projectDoc(),
     tabId,
     get lastSeq() {
       return lastSeq
@@ -515,7 +557,10 @@ export function useAgentCrdtFollower(workflowId: Ref<string | null>) {
         connected: connected.value,
         workflowId: subscribedWorkflowId.value,
         updatesApplied: updatesApplied.value,
-        lastFrameType: lastFrameType.value
+        lastFrameType: lastFrameType.value,
+        opNacks: opNacks.value,
+        lastOpNack: lastOpNack.value,
+        projectionErrors: projectionErrors.value
       }
     }
   }
@@ -526,7 +571,10 @@ export function useAgentCrdtFollower(workflowId: Ref<string | null>) {
     connected: connected.value,
     workflowId: subscribedWorkflowId.value,
     updatesApplied: updatesApplied.value,
-    lastFrameType: lastFrameType.value
+    lastFrameType: lastFrameType.value,
+    opNacks: opNacks.value,
+    lastOpNack: lastOpNack.value,
+    projectionErrors: projectionErrors.value
   }))
 
   return {


### PR DESCRIPTION
- Host op nacks (`ok:false`) now surface: status field + dev-panel metric + console.error — no more silent drops
- Projection throws no longer vanish in EventTarget dispatch — reported, counted, canvas-lag made visible
- Never rolls back: host applies the valid prefix before nacking; this PR only adds observability

<details><summary>Full context for agent readers</summary>

## Problem (FEB-6 / s1-D)

Two silent failure paths in the CRDT follower:

1. **Host op nack**: `doc_ops_result` with `ok:false` was recorded into a dev-panel-only tap (`lastOpsResult` + `doc_ops_result` dev event) and nothing else. No status change, no error path, no metric. An agent or human whose ops were rejected saw nothing.
2. **Projection throw**: `projector.project(...)` ran bare inside EventTarget listeners; a throw was swallowed by the dispatch path from every caller's perspective — canvas silently lagging the doc.

## Fix

New pure module `opOutcome.ts`:

- `classifyOpsResult(detail): OpNack | null` — nack summary (workflowId, code, message, verbatim `failed`, applied-prefix count, skipped count) on `ok:false`; null on clean/malformed.
- `runProjection(project, report)` — try/catch wrapper; reports and returns 0 on throw. **No retry**: `SemanticProjector` advances its snapshot before applying, so a retry would double-apply the successful prefix.

Wired into `useAgentCrdtFollower.ts`:

- `onOpsResult` promotes nacks: `opNacks` counter, `lastOpNack` in status, `op_nack` dev event, `console.error`.
- Both projection call sites (`onUpdate`, `pocGlobal.project`) go through `projectDoc()` → `projection_error` dev event + `projectionErrors` counter + `console.error`.
- `AgentCrdtStatus` gains `opNacks`, `lastOpNack`, `projectionErrors` (poc status getter + composable computed both updated).

### Semantics (deliberate)

`ok:false` means **"a failure exists"**, not "nothing landed". The host applies the valid prefix, then broadcasts. The applied prefix is NEVER rolled back — this PR is pure observability. Counters are per-mount and monotonic (not cleared on workflow switch/reset) so a nack that raced a switch stays visible. This seam is the ledger input for the future pending-op ledger (`op_id` = correlation key); a failed projection means the canvas may lag until the next update/resubscribe — recovery is that later work's territory, deliberately out of scope here.

```diagram
host doc_ops_result (ok:false, applied prefix kept)
        │
        ▼
onOpsResult ──▶ classifyOpsResult ──▶ OpNack
        │                               ├─▶ status.opNacks / lastOpNack
        │                               ├─▶ dev event 'op_nack'
        │                               └─▶ console.error
doc_update ──▶ projectDoc() = runProjection(projector.project)
        │            └─ throw ─▶ status.projectionErrors
        │                        dev event 'projection_error'
        │                        console.error (canvas may lag)
        ▼
   (no rollback, no retry — observability only)
```

## Files

- `src/workbench/extensions/agent/crdt/opOutcome.ts` (new) + `opOutcome.test.ts` (new, 7 tests)
- `src/workbench/extensions/agent/crdt/useAgentCrdtFollower.ts` — wiring + status fields
- `src/workbench/extensions/agent/crdt/devPanelLog.ts` — `op_nack`, `projection_error` event kinds
- `src/workbench/extensions/agent/crdt/docFrameClient.ts` — export `DocOpsResult`

## Verification

- `pnpm vitest run src/workbench/extensions/agent/crdt/` — 71/71 green (10 files)
- `vue-tsc --noEmit` — clean
- eslint + oxfmt clean on all touched files
- Pre-existing base issues untouched: `processedWidgetRenderModel.ts` format-check failure exists on base

## Provenance

Branch cut from `583ad3b400` (`nathaniel/agent-panel-v1` head). Fix designed from the recut audit of the merged CRDT source only; no external design material consulted. KA-6 respected: no follower writes introduced.

## Glossary

- **FEB-6 / s1-D**: follower error-budget audit item — op-outcome surfacing slice
- **nack**: host rejection of (part of) an op batch, `ok:false` on `doc_ops_result`
- **applied prefix**: ops the host DID apply before the failing one — kept, never rolled back
- **projection**: folding the Yjs doc into litegraph canvas mutations (`SemanticProjector`)
- **poc global**: `window.__agentCrdtPoc` dev handle mirroring composable status
- **KA-6**: invariant — the follower never writes to the doc

</details>
