### PR TITLE
fix(agent): wait for first flag delivery in production

### DIFF
--- a/src/extensions/core/agentPanel.test.ts
+++ b/src/extensions/core/agentPanel.test.ts
@@ -125,6 +125,17 @@ describe('AgentPanel extension flag gate', () => {
     expect(mocks.agentStore.enabled).toBe(false)
   })
 
+  it('ignores a stale persisted flag until the first delivery', async () => {
+    mocks.flagEnabled = true
+
+    await loadEntryAndSetup()
+
+    expect(mocks.agentStore.enabled).toBe(false)
+
+    mocks.flagListener!()
+    expect(mocks.agentStore.enabled).toBe(true)
+  })
+
   it('registers the tab-activity tracker once at setup, not gated on the flag', async () => {
     await loadEntryAndSetup()
     expect(mocks.registerTracker).toHaveBeenCalledTimes(1)

--- a/src/extensions/core/agentPanel.ts
+++ b/src/extensions/core/agentPanel.ts
@@ -74,9 +74,12 @@ async function setupFlagGate(): Promise<void> {
       sync()
       settle()
     })
-    sync()
-    if (import.meta.env.MODE === 'development') settle()
-    else setTimeout(settle, FLAG_SETTLE_TIMEOUT_MS)
+    if (import.meta.env.MODE === 'development') {
+      sync()
+      settle()
+    } else {
+      setTimeout(settle, FLAG_SETTLE_TIMEOUT_MS)
+    }
   } catch (error) {
     console.error('[Comfy.AgentPanel] feature-flag gate failed to load', error)
     settle()


### PR DESCRIPTION
## Summary

Wait for the first PostHog feature-flag delivery before enabling the agent panel in production, preventing a stale persisted `true` value from briefly mounting the panel for a de-flagged user.

## Changes

- **What**: Keep immediate synchronization in development, but make production synchronize only from the feature-flag delivery callback.
- **What**: Add a regression test proving cached `true` is ignored until delivery and then applied.

## Review Focus

Please verify that the production gate remains fail-closed before delivery while development retains its immediate force-enable behavior.

## Screenshots (if applicable)

Not applicable; this is feature-gate timing behavior covered by unit tests.
