### PR TITLE
fix: require Web Crypto for UUID generation

### DIFF
--- a/src/utils/uuid.test.ts
+++ b/src/utils/uuid.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { createUuidv4 } from './uuid'
+
+const UUID_V4_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/
+
+describe('createUuidv4', () => {
+  it('uses crypto.randomUUID when available', () => {
+    const randomUUID = vi.fn(() => '12345678-1234-4abc-8def-123456789abc')
+    const getRandomValues = vi.fn()
+    vi.stubGlobal('crypto', { randomUUID, getRandomValues })
+
+    expect(createUuidv4()).toBe('12345678-1234-4abc-8def-123456789abc')
+    expect(randomUUID).toHaveBeenCalledOnce()
+    expect(getRandomValues).not.toHaveBeenCalled()
+  })
+
+  it('uses crypto.getRandomValues when randomUUID is unavailable', () => {
+    const getRandomValues = vi.fn((values: Uint32Array) => {
+      values.forEach((_, index) => {
+        values[index] = index * 2654435761
+      })
+      return values
+    })
+    vi.stubGlobal('crypto', { randomUUID: undefined, getRandomValues })
+
+    const uuid = createUuidv4()
+
+    expect(getRandomValues).toHaveBeenCalledOnce()
+    expect(uuid).toMatch(UUID_V4_PATTERN)
+  })
+
+  it('throws when Web Crypto is unavailable', () => {
+    vi.stubGlobal('crypto', undefined)
+
+    expect(() => createUuidv4()).toThrow(
+      'Web Crypto is required to generate a UUID'
+    )
+  })
+
+  it('mints unique UUIDv4 values across a sanity sample', () => {
+    const uuids = Array.from({ length: 1_000 }, () => createUuidv4())
+
+    expect(uuids.every((uuid) => UUID_V4_PATTERN.test(uuid))).toBe(true)
+    expect(new Set(uuids).size).toBe(uuids.length)
+  })
+})

--- a/src/utils/uuid.ts
+++ b/src/utils/uuid.ts
@@ -14,12 +14,15 @@ const randomStorage = new Uint32Array(31)
  * Original implementation from https://gist.github.com/jed/982883?permalink_comment_id=852670#gistcomment-852670
  *
  * Prefers the {@link crypto.randomUUID} method if available, falling back to
- * {@link crypto.getRandomValues}, then finally the legacy {@link Math.random} method.
+ * {@link crypto.getRandomValues} for insecure contexts.
  */
 export function createUuidv4(): UUID {
-  if (typeof crypto?.randomUUID === 'function') return crypto.randomUUID()
-  if (typeof crypto?.getRandomValues === 'function') {
-    const random = crypto.getRandomValues(randomStorage)
+  const webCrypto = globalThis.crypto
+  if (typeof webCrypto?.randomUUID === 'function') {
+    return webCrypto.randomUUID()
+  }
+  if (typeof webCrypto?.getRandomValues === 'function') {
+    const random = webCrypto.getRandomValues(randomStorage)
     let i = 0
     return '10000000-1000-4000-8000-100000000000'.replaceAll(/[018]/g, (a) =>
       (
@@ -28,7 +31,5 @@ export function createUuidv4(): UUID {
       ).toString(16)
     )
   }
-  return '10000000-1000-4000-8000-100000000000'.replaceAll(/[018]/g, (a) =>
-    (Number(a) ^ ((Math.random() * 16) >> (Number(a) * 0.25))).toString(16)
-  )
+  throw new Error('Web Crypto is required to generate a UUID')
 }


### PR DESCRIPTION
<!-- authored-by:agent worker-3 -->
TL;DR:
- Removes the `Math.random()` UUID fallback so CRDT `op_id` minting remains collision-resistant.
- Keeps plain-HTTP/insecure-context support through `crypto.getRandomValues()`.
- Adds coverage for both Web Crypto paths, fail-closed behavior, UUIDv4 format, and sanity uniqueness.

<details><summary>Full context for agent readers</summary>

The [ext102-1 audit](https://github.com/christian-byrne/in-app-agent-program/blob/main/reports/audit/ext102-1-uuid4-fallback-opid-invariants.md) found that the final `Math.random()` branch in `createUuidv4()` violated the coordination-free identity requirement in [ADR-007](https://github.com/christian-byrne/in-app-agent-program/blob/main/decisions/ADR-007-op-based-crdt.md). A collision can conflate operations in deduplication and change the final LWW tie-break result.

This change preserves the intended fallback order as `crypto.randomUUID()` then `crypto.getRandomValues()`, which remains available in insecure contexts. Environments without Web Crypto now fail loudly instead of silently minting a weak identifier.

Validation:
- `pnpm test:unit src/utils/uuid.test.ts src/workbench/extensions/agent/crdt/opEnvelope.test.ts` (13 passed)
- `pnpm test:unit src/workbench/extensions/agent/crdt` (203 passed)
- `pnpm typecheck`
- `pnpm lint` (0 errors; inherited warnings only)

</details>