### PR TITLE
test(assets): cover 3D filter remount

### DIFF
--- a/browser_tests/tests/sidebar/assets-filter.spec.ts
+++ b/browser_tests/tests/sidebar/assets-filter.spec.ts
@@ -275,9 +275,14 @@ test.describe('Assets sidebar - attribute filters', { tag: '@cloud' }, () => {
     await expect(tab.removeFilterButton('Past 7 days')).toHaveCount(0)
   })
 
-  test('Unchecking the active filter restores previously hidden cards', async ({
+  test('Unchecking the active filter restores every hidden preview', async ({
     comfyPage
   }) => {
+    test.fail(
+      true,
+      'The 3D preview card currently remains unmounted after its filter is cleared'
+    )
+
     const tab = comfyPage.menu.assetsTab
     await tab.open()
     await tab.waitForAssets()
@@ -288,14 +293,13 @@ test.describe('Assets sidebar - attribute filters', { tag: '@cloud' }, () => {
 
     await tab.toggleMediaTypeFilter('image')
 
-    // TODO(#11635): the 3D preview card does not remount after a filter
-    // toggle restores it (only image/video/audio reappear). Image, video,
-    // and audio cover the restoration path; once #11635 is fixed, add the
-    // 3D card back to this assertion list.
     await expect(tab.getAssetCardByName(imageCardName)).toBeVisible({
       timeout: 10_000
     })
     await expect(tab.getAssetCardByName(videoCardName)).toBeVisible()
     await expect(tab.getAssetCardByName(audioCardName)).toBeVisible()
+    const threeDCard = tab.getAssetCardByName(threeDCardName)
+    await expect(threeDCard).toBeVisible()
+    await expect(threeDCard.getByText('3D Model')).toHaveCount(1)
   })
 })


### PR DESCRIPTION
## Summary

Adds the missing 3D filter-remount detector. Current regression is recorded as an expected failure. Extends the Cloud Assets filter journey so clearing the Image filter must restore the hidden 3D card and initialize exactly one 3D preview placeholder. This covers the 3D filter-remount case, tracked internally as TC-VIEW-08, and replaces the assertion omission associated with issue #11635.

## Review Focus

The expectation is marked with `test.fail` because the 3D virtual item currently remains unmounted after filtering. The same test first proves image, video, and audio restoration, while the other five tests in the file provide passing fixture controls.

<details><summary>Verification</summary>

Verification:
- browser TypeScript: pass
- root TypeScript: pass
- ESLint and type-aware Oxlint: pass (3 unrelated baseline warnings in full ESLint)
- format and knip: pass
- Playwright collection: 6 tests in 1 Cloud file
- local Cloud execution: blocked by the local backend resetting `/api/users`; CI is the execution gate

</details>
