### PR TITLE
fix(agent): keep flag gate cloud-only

### DIFF
--- a/src/extensions/core/agentPanel.test.ts
+++ b/src/extensions/core/agentPanel.test.ts
@@ -80,7 +80,9 @@ vi.mock('@/composables/useFeatureFlags', async () => {
 })
 
 async function loadEntryAndSetup(): Promise<void> {
-  await import('./agentPanel')
+  vi.stubGlobal('__DISTRIBUTION__', 'cloud')
+  const { registerAgentPanelExtension } = await import('./agentPanel')
+  registerAgentPanelExtension()
   const ext = mocks.capturedExtensions.find(
     (e) => e.name === 'Comfy.AgentPanel'
   )
@@ -106,6 +108,15 @@ describe('AgentPanel extension flag gate', () => {
     mocks.nodeSelectionStore.isLoadingWorkflow = false
     mocks.workflowStore.activeWorkflow = { path: 'workflows/first.json' }
     vi.resetModules()
+  })
+
+  it('does not register the posthog-backed gate in OSS builds', async () => {
+    vi.stubGlobal('__DISTRIBUTION__', 'localhost')
+    const { registerAgentPanelExtension } = await import('./agentPanel')
+
+    registerAgentPanelExtension()
+
+    expect(mocks.capturedExtensions).toHaveLength(0)
   })
 
   it('forces the panel on in development even while the flag is false', async () => {
@@ -146,7 +157,9 @@ describe('AgentPanel extension flag gate', () => {
   })
 
   it('restores each workflow reference after the shared graph load', async () => {
-    await import('./agentPanel')
+    vi.stubGlobal('__DISTRIBUTION__', 'cloud')
+    const { registerAgentPanelExtension } = await import('./agentPanel')
+    registerAgentPanelExtension()
     const extension = mocks.capturedExtensions.find(
       (item) => item.name === 'Comfy.AgentPanel'
     )
@@ -178,7 +191,9 @@ describe('AgentPanel extension flag gate', () => {
   })
 
   it('restores a subgraph reference by its locator after graph load', async () => {
-    await import('./agentPanel')
+    vi.stubGlobal('__DISTRIBUTION__', 'cloud')
+    const { registerAgentPanelExtension } = await import('./agentPanel')
+    registerAgentPanelExtension()
     const extension = mocks.capturedExtensions.find(
       (item) => item.name === 'Comfy.AgentPanel'
     )
@@ -201,7 +216,9 @@ describe('AgentPanel extension flag gate', () => {
   })
 
   it('finishes restoration when the panel closes during graph load', async () => {
-    await import('./agentPanel')
+    vi.stubGlobal('__DISTRIBUTION__', 'cloud')
+    const { registerAgentPanelExtension } = await import('./agentPanel')
+    registerAgentPanelExtension()
     const extension = mocks.capturedExtensions.find(
       (item) => item.name === 'Comfy.AgentPanel'
     )

--- a/src/extensions/core/agentPanel.ts
+++ b/src/extensions/core/agentPanel.ts
@@ -14,8 +14,13 @@ import { getNodeByLocatorId } from '@/utils/graphTraversalUtil'
 import { isLGraphNode } from '@/utils/litegraphUtil'
 
 let registered = false
+const IS_CLOUD_BUILD = __DISTRIBUTION__ === 'cloud'
 
 export function registerAgentPanelExtension(): void {
+  // Keep the whole flag-gate dependency graph, including posthog-js, out of
+  // OSS builds. Vite replaces the distribution literal at build time and
+  // drops this unreachable branch and its imports.
+  if (!IS_CLOUD_BUILD) return
   if (registered) return
   registered = true
 
@@ -78,5 +83,3 @@ function setupFlagGate(): void {
     agentPanelStore.gateSettled = true
   }
 }
-
-registerAgentPanelExtension()

--- a/src/extensions/core/index.ts
+++ b/src/extensions/core/index.ts
@@ -46,7 +46,6 @@ if (__DISTRIBUTION__ === 'cloud') {
   registerAgentPanelExtension()
   await import('./cloudBadges')
   await import('./cloudSessionCookie')
-  await import('./agentPanel')
 }
 
 // Feedback button for cloud and nightly builds


### PR DESCRIPTION
Restores the compile-time cloud distribution guard for the agent panel gate, removes module-import self-registration, and pins the OSS behavior with a regression test.\n\nVerification:\n- pnpm exec vitest run src/extensions/core/agentPanel.test.ts\n- pnpm typecheck\n- OSS Vite production build plus runtime-bundle scan: no posthog-js or PostHogTelemetryProvider markers\n- commit and push hooks (format, oxlint, eslint, typecheck, knip)\n\nTargets the Christian-owned integration line for review; this does not target main.