### PR TITLE
[slice-14] gate panel activity effects and animation ownership

### DIFF
--- a/src/extensions/core/agentPanel.ts
+++ b/src/extensions/core/agentPanel.ts
@@ -60,7 +60,7 @@ export function registerAgentPanelExtension(): void {
             agentPanelStore ??= useAgentPanelStore()
             agentPanelStore.enabled = true
             agentPanelStore.gateSettled = true
-            disposeTracker ??= registerWorkflowTabActivityTracker()
+            disposeTracker ??= registerWorkflowTabActivityTracker(featureEnabled)
           } else if (agentPanelStore) {
             agentPanelStore.enabled = false
             disposeTracker?.()

--- a/src/extensions/core/agentPanel.ts
+++ b/src/extensions/core/agentPanel.ts
@@ -60,7 +60,8 @@ export function registerAgentPanelExtension(): void {
             agentPanelStore ??= useAgentPanelStore()
             agentPanelStore.enabled = true
             agentPanelStore.gateSettled = true
-            disposeTracker ??= registerWorkflowTabActivityTracker(featureEnabled)
+            disposeTracker ??=
+              registerWorkflowTabActivityTracker(featureEnabled)
           } else if (agentPanelStore) {
             agentPanelStore.enabled = false
             disposeTracker?.()

--- a/src/stores/workflowTabActivityStore.ts
+++ b/src/stores/workflowTabActivityStore.ts
@@ -37,6 +37,12 @@ export const useWorkflowTabActivityStore = defineStore(
         if (!open.has(path)) unseenModifiedPaths.value.delete(path)
     }
 
+    function clearAgentActivity(): void {
+      editingTabPath.value = null
+      creatingTab.value = false
+      unseenModifiedPaths.value.clear()
+    }
+
     return {
       editingTabPath,
       creatingTab,
@@ -45,7 +51,8 @@ export const useWorkflowTabActivityStore = defineStore(
       setCreating,
       markModified,
       markSeen,
-      pruneClosed
+      pruneClosed,
+      clearAgentActivity
     }
   }
 )

--- a/src/workbench/extensions/agent/agentPanel.css
+++ b/src/workbench/extensions/agent/agentPanel.css
@@ -1,30 +1,3 @@
-@keyframes agent-collapsible-down {
-  from {
-    height: 0;
-  }
-  to {
-    height: var(--reka-collapsible-content-height);
-  }
-}
-
-@keyframes agent-collapsible-up {
-  from {
-    height: var(--reka-collapsible-content-height);
-  }
-  to {
-    height: 0;
-  }
-}
-
-@keyframes agent-shimmer {
-  from {
-    background-position: 150% center;
-  }
-  to {
-    background-position: -50% center;
-  }
-}
-
 .agent-shimmer-text {
   background: linear-gradient(
     90deg,
@@ -38,7 +11,7 @@
   animation: agent-shimmer 1.8s linear infinite;
 }
 
-.disable-animations .agent-shimmer-text {
+.disable-animations #agent-panel-root .agent-shimmer-text {
   animation: none;
   color: var(--color-muted-foreground);
   -webkit-text-fill-color: currentcolor;

--- a/src/workbench/extensions/agent/agentPanelStyles.test.ts
+++ b/src/workbench/extensions/agent/agentPanelStyles.test.ts
@@ -1,0 +1,43 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+const themeCss = readFileSync(
+  resolve('src/workbench/extensions/agent/agentTheme.css'),
+  'utf8'
+)
+const panelCss = readFileSync(
+  resolve('src/workbench/extensions/agent/agentPanel.css'),
+  'utf8'
+)
+const loadedAgentCss = `${themeCss}\n${panelCss}`
+
+describe('agent panel styles', () => {
+  it('defines every referenced agent animation in the always-loaded theme', () => {
+    const animationNames = [
+      ...loadedAgentCss.matchAll(
+        /(?:animation:\s*|--animate-agent-[\w-]+:\s*)(agent-[\w-]+)/g
+      )
+    ].map((match) => match[1])
+
+    for (const name of new Set(animationNames)) {
+      expect(themeCss).toContain(`@keyframes ${name}`)
+    }
+  })
+
+  it('keeps selectors scoped to the agent root or agent namespace', () => {
+    const selectors = panelCss
+      .split('\n')
+      .map((line) => line.trimEnd())
+      .filter((line) => /^[^\s@].*\{$/.test(line))
+
+    for (const selector of selectors) {
+      expect(
+        selector.includes('#agent-panel-root') ||
+          selector.startsWith(':where(.agent-scope') ||
+          selector.startsWith('.agent-')
+      ).toBe(true)
+    }
+  })
+})

--- a/src/workbench/extensions/agent/agentTheme.css
+++ b/src/workbench/extensions/agent/agentTheme.css
@@ -22,3 +22,30 @@
   --animate-agent-collapsible-down: agent-collapsible-down 200ms ease-out;
   --animate-agent-collapsible-up: agent-collapsible-up 200ms ease-out;
 }
+
+@keyframes agent-collapsible-down {
+  from {
+    height: 0;
+  }
+  to {
+    height: var(--reka-collapsible-content-height);
+  }
+}
+
+@keyframes agent-collapsible-up {
+  from {
+    height: var(--reka-collapsible-content-height);
+  }
+  to {
+    height: 0;
+  }
+}
+
+@keyframes agent-shimmer {
+  from {
+    background-position: 150% center;
+  }
+  to {
+    background-position: -50% center;
+  }
+}

--- a/src/workbench/extensions/agent/services/agent/workflowTabActivityTracker.test.ts
+++ b/src/workbench/extensions/agent/services/agent/workflowTabActivityTracker.test.ts
@@ -1,6 +1,6 @@
 import { createPinia, setActivePinia } from 'pinia'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { nextTick } from 'vue'
+import { nextTick, ref } from 'vue'
 
 import { useWorkflowTabActivityStore } from '@/stores/workflowTabActivityStore'
 
@@ -32,7 +32,7 @@ describe('registerWorkflowTabActivityTracker', () => {
     setActivePinia(createPinia())
     hostWorkflow.store.activeWorkflow = null
     hostWorkflow.store.openWorkflows = []
-    stop = registerWorkflowTabActivityTracker()
+    stop = registerWorkflowTabActivityTracker(ref(true))
   })
 
   afterEach(() => {
@@ -75,5 +75,40 @@ describe('registerWorkflowTabActivityTracker', () => {
     await nextTick()
 
     expect(activity.unseenModifiedPaths.has('workflows/a.json')).toBe(true)
+  })
+
+  it('does not register tab watchers while the feature is disabled', async () => {
+    stop()
+    const enabled = ref(false)
+    stop = registerWorkflowTabActivityTracker(enabled)
+    const activity = useWorkflowTabActivityStore()
+    activity.markModified('workflows/a.json')
+
+    hostWorkflow.store.activeWorkflow = { path: 'workflows/a.json' }
+    await nextTick()
+
+    expect(activity.unseenModifiedPaths.has('workflows/a.json')).toBe(true)
+  })
+
+  it('registers on enable and removes agent activity on disable', async () => {
+    stop()
+    const enabled = ref(false)
+    stop = registerWorkflowTabActivityTracker(enabled)
+    const activity = useWorkflowTabActivityStore()
+
+    enabled.value = true
+    await nextTick()
+    activity.markModified('workflows/a.json')
+    hostWorkflow.store.activeWorkflow = { path: 'workflows/a.json' }
+    await nextTick()
+    expect(activity.unseenModifiedPaths.has('workflows/a.json')).toBe(false)
+
+    activity.markModified('workflows/b.json')
+    activity.setEditing('workflows/b.json')
+    enabled.value = false
+    await nextTick()
+
+    expect(activity.unseenModifiedPaths).toHaveLength(0)
+    expect(activity.editingTabPath).toBeNull()
   })
 })

--- a/src/workbench/extensions/agent/services/agent/workflowTabActivityTracker.ts
+++ b/src/workbench/extensions/agent/services/agent/workflowTabActivityTracker.ts
@@ -1,4 +1,5 @@
 import { effectScope, watch } from 'vue'
+import type { EffectScope, Ref } from 'vue'
 
 import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
 import { useWorkflowTabActivityStore } from '@/stores/workflowTabActivityStore'
@@ -9,20 +10,40 @@ import { useWorkflowTabActivityStore } from '@/stores/workflowTabActivityStore'
  * closing tabs prunes stale state. Registered once from the extension
  * setup, so the watchers outlive panel close and app-mode switches.
  */
-export function registerWorkflowTabActivityTracker(): () => void {
+export function registerWorkflowTabActivityTracker(
+  enabled: Readonly<Ref<boolean>>
+): () => void {
   const scope = effectScope(true)
   scope.run(() => {
     const workflowStore = useWorkflowStore()
     const tabActivity = useWorkflowTabActivityStore()
+    let trackerScope: EffectScope | undefined
+
     watch(
-      () => workflowStore.activeWorkflow?.path,
-      (path) => {
-        if (path !== undefined) tabActivity.markSeen(path)
-      }
-    )
-    watch(
-      () => workflowStore.openWorkflows.map((tab) => tab.path),
-      (paths) => tabActivity.pruneClosed(paths)
+      enabled,
+      (isEnabled) => {
+        trackerScope?.stop()
+        trackerScope = undefined
+        if (!isEnabled) {
+          tabActivity.clearAgentActivity()
+          return
+        }
+
+        trackerScope = effectScope()
+        trackerScope.run(() => {
+          watch(
+            () => workflowStore.activeWorkflow?.path,
+            (path) => {
+              if (path !== undefined) tabActivity.markSeen(path)
+            }
+          )
+          watch(
+            () => workflowStore.openWorkflows.map((tab) => tab.path),
+            (paths) => tabActivity.pruneClosed(paths)
+          )
+        })
+      },
+      { immediate: true }
     )
   })
   return () => scope.stop()


### PR DESCRIPTION
## TL;DR

- Gates panel mount state and workflow-tab activity tracking through the synchronous `agent-in-app-experience` server flag.
- Clears agent-owned unseen/editing state on disable and disposes tracker watchers deterministically.
- Moves agent keyframes into the always-loaded theme and adds a scoped CSS contract test.

<details><summary>Full context for agent readers</summary>

Implements the approved slice-14 panel/effects contract on the reconciled candidate while slice 13 is not yet published. The shared `useAgentFeatureGate` files are temporary exact-contract stand-ins and must yield to slice 13 during the required rebase. Effects remain presentation-only and do not write semantic or layout Yjs state.

State-to-effect: enabled normalized activity registers target-tab watchers; activation clears the target indicator; tab close prunes state; flag disable stops watchers and clears all agent-owned activity. CSS ownership: animation tokens and their `agent-*` keyframes now ship together in `agentTheme.css`; panel selectors remain agent-root/namespace scoped.

G1 evidence: base `3a0897bf75e618e8fa017ce8b29e6b331961f5b0`; focused unit/component suites 36/36 green; tracker/style suites 7/7 green; `pnpm typecheck` green; commit hooks (format, stylelint, oxlint, ESLint, typecheck) green; pre-push knip green. Full repository ESLint was stopped after stylelint/oxlint because of runtime, with touched-file ESLint green. No dedicated Linear ticket exists per approved spec.

Flag-off proof: the gate defaults false; panel store remains disabled; the tracker creates no inner watchers; disable clears unseen/editing/creating state. No effect telemetry or graph mutation was added.

Follow-up: rebase onto `origin/christian-byrne/slice-13` as soon as desktop publishes it and prefer its shared flag/runtime implementation.

</details>

<!-- authored-by:agent worker-3-lane -->