### PR TITLE
fix(agent): apply CRDT catch-up at acknowledged sequence

### DIFF
--- a/src/workbench/extensions/agent/crdt/followerSubscription.test.ts
+++ b/src/workbench/extensions/agent/crdt/followerSubscription.test.ts
@@ -309,6 +309,26 @@ describe('doc_reset — a lineage break drops the doc and resubscribes from zero
 })
 
 describe('FE-GAP-1 — a seq jump means a dropped frame and forces a resync', () => {
+  it('applies the catch-up update when its seq equals the preceding subscribe acknowledgement', () => {
+    const { transport, bridge, projected } = wire()
+    transport.open = true
+    bridge.subscribe(WORKFLOW_ID)
+    transport.deliver('doc_subscribed', {
+      v: 1,
+      workflow_id: WORKFLOW_ID,
+      ok: true,
+      seq: 1
+    })
+
+    transport.deliver(
+      'doc_update',
+      docUpdateFrame(hostDocUpdate(), WORKFLOW_ID, 1)
+    )
+
+    expect(projected).toHaveLength(1)
+    expect(bridge.follower.updatesApplied).toBe(1)
+  })
+
   it('applies contiguous seqs without resubscribing', () => {
     const { transport, bridge, projected } = wire()
     transport.open = true

--- a/src/workbench/extensions/agent/crdt/layoutFollowerBridge.ts
+++ b/src/workbench/extensions/agent/crdt/layoutFollowerBridge.ts
@@ -276,8 +276,13 @@ export class LayoutFollowerBridge extends EventTarget {
   }
 
   /**
-   * `ok: true` carries the seq of the catch-up snapshot — the gap detector's
-   * baseline. `ok: false` means the server refused: clearing REALITY re-opens
+   * `ok: true` confirms the subscription but does not mean its catch-up update
+   * has already been integrated. The host sends `doc_subscribed(seq=N)` before
+   * `doc_update(seq=N)`, so treating the acknowledgement as the applied
+   * baseline drops the snapshot as stale and leaves a fresh follower empty.
+   * The first actual update establishes the baseline instead.
+   *
+   * `ok: false` means the server refused: clearing REALITY re-opens
    * the intent/reality disagreement so the next `reconcile()` (any status
    * frame) retries, instead of the bridge holding a subscription that does not
    * exist server-side and going silently deaf.
@@ -286,7 +291,7 @@ export class LayoutFollowerBridge extends EventTarget {
     if (!(event instanceof CustomEvent)) return
     const subscribed = event.detail as DocSubscribed
     if (subscribed.workflowId === this.sentWorkflowId) {
-      if (subscribed.ok) this.lastSeq = subscribed.seq ?? null
+      if (subscribed.ok) this.lastSeq = null
       else this.sentWorkflowId = null
     }
     this.dispatchEvent(new CustomEvent(event.type, { detail: event.detail }))


### PR DESCRIPTION
**TL;DR:** agent edits dead on dev1 — follower dropped seed catch-up; fixed, gates green.

<details><summary>Full context for agent readers</summary>

<!-- authored-by:agent worker-3 -->

Root cause (fearca-1 RCA, qa-48/qa-49): `LayoutFollowerBridge.onDocSubscribed` treated the `doc_subscribed(seq=N)` acknowledgement as already-applied, so the host's catch-up `doc_update(seq=N)` was discarded as stale. A fresh follower never seeded `meta.schema_version`, and every subsequent agent `doc_update` failed closed (`schema_version=undefined`) — agent reports success, graph never changes (Christian's qa-49 'Load Image' repro).

Fix: acknowledgement confirms subscription only; the first integrated `doc_update` establishes the applied-sequence baseline. Typecheck/lint green, 18/18 focused tests. Based on served head 915e46afef (ci-fix tip), fast-forward.

RCA report: in-app-agent-program `reports/qa/rca/fearca-1-apply-leg.md`.
</details>