### PR TITLE
[slice-16] add target-aware graph references and navigation

### DIFF
--- a/src/workbench/extensions/agent/AgentPanelRoot.vue
+++ b/src/workbench/extensions/agent/AgentPanelRoot.vue
@@ -178,6 +178,7 @@ const {
   replace: replaceSelectionTags
 } = useCanvasSelection({
   selection: selectedNodes,
+  enabled: agentEnabled,
   isLive: () => agentPanelStore.isOpen,
   isTracking: () => agentNodeSelectionStore.isActive,
   isPaused: () => agentNodeSelectionStore.isLoadingWorkflow,

--- a/src/workbench/extensions/agent/components/agent/message/AgentMessage.vue
+++ b/src/workbench/extensions/agent/components/agent/message/AgentMessage.vue
@@ -82,6 +82,7 @@ const hasTools = computed(() =>
           v-for="(link, linkIndex) in group.parts"
           :key="linkIndex"
           :workflow-id="link.workflowId"
+          :locator-id="link.locatorId"
           :name="link.name"
         />
       </div>

--- a/src/workbench/extensions/agent/components/agent/message/TabLinkCard.test.ts
+++ b/src/workbench/extensions/agent/components/agent/message/TabLinkCard.test.ts
@@ -18,7 +18,22 @@ const mocks = vi.hoisted(() => ({
   api: new EventTarget(),
   activeWorkflow: undefined as FakeTab | undefined,
   openWorkflow: vi.fn(),
-  openWorkflows: [] as unknown[]
+  navigate: vi.fn(),
+  openWorkflows: [] as unknown[],
+  agentEnabled: true
+}))
+
+vi.mock('../../../composables/agent/useAgentFeatureGate', () => ({
+  useAgentFeatureGate: () => ({
+    __v_isRef: true,
+    get value() {
+      return mocks.agentEnabled
+    }
+  })
+}))
+
+vi.mock('../../../composables/agent/useAgentTargetNavigation', () => ({
+  useAgentTargetNavigation: () => ({ navigate: mocks.navigate })
 }))
 
 vi.mock('@/scripts/api', () => ({ api: mocks.api }))
@@ -58,7 +73,9 @@ describe('TabLinkCard', () => {
     setActivePinia(createPinia())
     useAgentWorkflowTabBindingStore().setSubject('user-1')
     mocks.openWorkflow.mockClear()
+    mocks.navigate.mockClear()
     mocks.activeWorkflow = undefined
+    mocks.agentEnabled = true
     openTabs()
   })
 
@@ -182,5 +199,39 @@ describe('TabLinkCard', () => {
     mount('wf-unbound', 'Never opened')
 
     expect(screen.queryByRole('button')).not.toBeInTheDocument()
+  })
+
+  it('renders no reference and performs no action while the flag is off', () => {
+    const tab = { path: 'flows/portrait.json', filename: 'portrait' }
+    openTabs(tab)
+    useAgentWorkflowTabBindingStore().bind('wf-1', tab.path)
+    mocks.agentEnabled = false
+
+    mount('wf-1', 'Portrait upscale')
+
+    expect(screen.queryByRole('button')).not.toBeInTheDocument()
+    expect(mocks.openWorkflow).not.toHaveBeenCalled()
+  })
+
+  it('navigates an explicit node reference through its target workflow', async () => {
+    const tab = { path: 'flows/portrait.json', filename: 'portrait' }
+    openTabs(tab)
+    useAgentWorkflowTabBindingStore().bind('wf-1', tab.path)
+
+    render(TabLinkCard, {
+      props: {
+        workflowId: 'wf-1',
+        locatorId: 'root-a:42',
+        name: 'Portrait upscale'
+      },
+      global: { plugins: [i18n] }
+    })
+    await userEvent.click(screen.getByRole('button'))
+
+    expect(mocks.navigate).toHaveBeenCalledWith({
+      workflowId: 'wf-1',
+      locatorId: 'root-a:42'
+    })
+    expect(mocks.openWorkflow).not.toHaveBeenCalled()
   })
 })

--- a/src/workbench/extensions/agent/components/agent/message/TabLinkCard.vue
+++ b/src/workbench/extensions/agent/components/agent/message/TabLinkCard.vue
@@ -3,14 +3,17 @@ import { useEventListener } from '@vueuse/core'
 import { computed, ref, useId, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 
+import { useAgentFeatureGate } from '../../../composables/agent/useAgentFeatureGate'
+import { useAgentTargetNavigation } from '../../../composables/agent/useAgentTargetNavigation'
 import { useWorkflowService } from '@/platform/workflow/core/services/workflowService'
 import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
 import type { ComfyWorkflowJSON } from '@/platform/workflow/validation/schemas/workflowSchema'
 import { api } from '@/scripts/api'
 import { useAgentWorkflowTabBindingStore } from '../../../stores/agent/agentWorkflowTabBindingStore'
 
-const { workflowId, name } = defineProps<{
+const { workflowId, locatorId, name } = defineProps<{
   workflowId: string
+  locatorId?: string
   name?: string
 }>()
 
@@ -18,6 +21,8 @@ const { t } = useI18n()
 const workflowStore = useWorkflowStore()
 const workflowService = useWorkflowService()
 const bindingStore = useAgentWorkflowTabBindingStore()
+const agentEnabled = useAgentFeatureGate()
+const targetNavigation = useAgentTargetNavigation()
 
 const tab = computed(() => {
   const path = bindingStore.tabPathFor(workflowId)
@@ -51,13 +56,15 @@ useEventListener(
 
 async function open(): Promise<void> {
   const target = tab.value
-  if (target) await workflowService.openWorkflow(target)
+  if (!target) return
+  if (locatorId === undefined) await workflowService.openWorkflow(target)
+  else await targetNavigation.navigate({ workflowId, locatorId })
 }
 </script>
 
 <template>
   <button
-    v-if="tab"
+    v-if="agentEnabled && tab"
     type="button"
     :aria-label="t('agent.openWorkflowTab', { name: label })"
     :aria-describedby="nodeCount === undefined ? undefined : nodeCountId"

--- a/src/workbench/extensions/agent/composables/agent/useAgentTargetNavigation.ts
+++ b/src/workbench/extensions/agent/composables/agent/useAgentTargetNavigation.ts
@@ -1,0 +1,35 @@
+import { useFocusNode } from '@/composables/canvas/useFocusNode'
+import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
+import { useWorkflowService } from '@/platform/workflow/core/services/workflowService'
+import type { ComfyWorkflow } from '@/platform/workflow/management/stores/comfyWorkflow'
+import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
+import { app } from '@/scripts/app'
+import { getNodeByLocatorId } from '@/utils/graphTraversalUtil'
+
+import { useAgentWorkflowTabBindingStore } from '../../stores/agent/agentWorkflowTabBindingStore'
+import { createTargetAwareAgentNavigation } from '../../services/agent/targetAwareAgentNavigation'
+
+export function useAgentTargetNavigation() {
+  const bindingStore = useAgentWorkflowTabBindingStore()
+  const workflowStore = useWorkflowStore()
+  const workflowService = useWorkflowService()
+  const { focusNodeInstance } = useFocusNode()
+
+  return createTargetAwareAgentNavigation<ComfyWorkflow, LGraphNode>({
+    // STAND-IN(slice-15): replace on rebase with the GraphDocument registry.
+    tabForWorkflow: (workflowId) => {
+      const path = bindingStore.tabPathFor(workflowId)
+      return path === undefined
+        ? undefined
+        : (workflowStore.getWorkflowByPath(path) ?? undefined)
+    },
+    isOpen: (tab) => workflowStore.openWorkflows.includes(tab),
+    activate: (tab) => workflowService.openWorkflow(tab),
+    activeTab: () => workflowStore.activeWorkflow ?? undefined,
+    resolveIn: (tab, locatorId) =>
+      workflowStore.activeWorkflow === tab
+        ? (getNodeByLocatorId(app.rootGraph, locatorId) ?? undefined)
+        : undefined,
+    focus: focusNodeInstance
+  })
+}

--- a/src/workbench/extensions/agent/composables/agent/useCanvasSelection.test.ts
+++ b/src/workbench/extensions/agent/composables/agent/useCanvasSelection.test.ts
@@ -21,6 +21,23 @@ describe('useCanvasSelection', () => {
     expect(staged.value).toEqual([nodeA])
   })
 
+  it('does not track selection while the agent flag is disabled', () => {
+    const selection = ref<SelectedNode[]>([nodeA])
+    const enabled = ref(false)
+    const { staged } = useCanvasSelection({
+      selection,
+      isLive: ref(true),
+      enabled
+    })
+
+    expect(staged.value).toEqual([])
+    selection.value = [nodeB]
+    expect(staged.value).toEqual([])
+
+    enabled.value = true
+    expect(staged.value).toEqual([nodeB])
+  })
+
   it('clears on submit and does not re-stage the same selection', async () => {
     const selection = ref<SelectedNode[]>([nodeA])
     const { staged, consume } = useCanvasSelection({

--- a/src/workbench/extensions/agent/composables/agent/useCanvasSelection.ts
+++ b/src/workbench/extensions/agent/composables/agent/useCanvasSelection.ts
@@ -1,6 +1,6 @@
 import { ref, toValue, watch } from 'vue'
 
-import type { MaybeRefOrGetter, Ref } from 'vue'
+import type { MaybeRefOrGetter, Ref, WatchStopHandle } from 'vue'
 import type { NodeLocatorId } from '@/types/nodeIdentification'
 
 export interface SelectedNode {
@@ -16,6 +16,7 @@ export function selectedNodeKey(node: SelectedNode): string {
 export interface UseCanvasSelectionOptions {
   selection: MaybeRefOrGetter<SelectedNode[]>
   isLive: MaybeRefOrGetter<boolean>
+  enabled?: MaybeRefOrGetter<boolean>
   isTracking?: MaybeRefOrGetter<boolean>
   isPaused?: MaybeRefOrGetter<boolean>
   scope?: MaybeRefOrGetter<string | null>
@@ -33,43 +34,60 @@ export function useCanvasSelection(options: UseCanvasSelectionOptions) {
   const dismissedSig = options.dismissedSignature ?? ref<string | null>(null)
   let lastLiveSig: string | null = null
 
+  let stopSelectionWatch: WatchStopHandle | undefined
+
   watch(
-    () =>
-      [
-        toValue(options.isLive),
-        toValue(options.isTracking ?? true),
-        toValue(options.isPaused ?? false),
-        toValue(options.scope ?? null),
-        toValue(options.selection)
-      ] as const,
-    ([isLive, isTracking, isPaused, scope, nodes]) => {
-      if (isPaused) return
-      if (!isLive) {
+    () => toValue(options.enabled ?? true),
+    (enabled) => {
+      stopSelectionWatch?.()
+      stopSelectionWatch = undefined
+      if (!enabled) {
         staged.value = []
         consumedSig.value = null
         stagedSig.value = null
         lastLiveSig = null
         return
       }
-      if (!isTracking) return
-      if (nodes.length === 0) {
-        staged.value = []
-        consumedSig.value = null
-        stagedSig.value = null
-        if (lastLiveSig !== null) dismissedSig.value = null
-        lastLiveSig = null
-        return
-      }
-      const sig = signature(scope, nodes)
-      lastLiveSig = sig
-      if (sig !== dismissedSig.value) dismissedSig.value = null
-      if (sig === dismissedSig.value) return
-      if (sig === consumedSig.value || sig === stagedSig.value) return
-      consumedSig.value = null
-      stagedSig.value = sig
-      staged.value = [...nodes]
+      stopSelectionWatch = watch(
+        () =>
+          [
+            toValue(options.isLive),
+            toValue(options.isTracking ?? true),
+            toValue(options.isPaused ?? false),
+            toValue(options.scope ?? null),
+            toValue(options.selection)
+          ] as const,
+        ([isLive, isTracking, isPaused, scope, nodes]) => {
+          if (isPaused) return
+          if (!isLive) {
+            staged.value = []
+            consumedSig.value = null
+            stagedSig.value = null
+            lastLiveSig = null
+            return
+          }
+          if (!isTracking) return
+          if (nodes.length === 0) {
+            staged.value = []
+            consumedSig.value = null
+            stagedSig.value = null
+            if (lastLiveSig !== null) dismissedSig.value = null
+            lastLiveSig = null
+            return
+          }
+          const sig = signature(scope, nodes)
+          lastLiveSig = sig
+          if (sig !== dismissedSig.value) dismissedSig.value = null
+          if (sig === dismissedSig.value) return
+          if (sig === consumedSig.value || sig === stagedSig.value) return
+          consumedSig.value = null
+          stagedSig.value = sig
+          staged.value = [...nodes]
+        },
+        { immediate: true, deep: true, flush: 'sync' }
+      )
     },
-    { immediate: true, deep: true, flush: 'sync' }
+    { immediate: true, flush: 'sync' }
   )
 
   function currentSignature(): string {

--- a/src/workbench/extensions/agent/schemas/agentApiSchema.test.ts
+++ b/src/workbench/extensions/agent/schemas/agentApiSchema.test.ts
@@ -171,12 +171,18 @@ describe('agentApiSchema contract subtleties', () => {
     )
   })
 
-  it('parses agent_active_tab with an optional name and rejects a missing workflow_id', () => {
+  it('parses agent_active_tab with an optional stable locator and rejects a missing workflow_id', () => {
     const parsed = zAgentWsEvent.safeParse({
       type: 'agent_active_tab',
-      data: { workflow_id: 'wf-1', thread_id: 'th-1' }
+      data: {
+        workflow_id: 'wf-1',
+        node_locator_id: 'root-a:42',
+        thread_id: 'th-1'
+      }
     })
     expect(parsed.success).toBe(true)
+    if (parsed.success)
+      expect(parsed.data.data).toMatchObject({ node_locator_id: 'root-a:42' })
     expect(
       zAgentWsEvent.safeParse({
         type: 'agent_active_tab',

--- a/src/workbench/extensions/agent/schemas/agentApiSchema.ts
+++ b/src/workbench/extensions/agent/schemas/agentApiSchema.ts
@@ -119,6 +119,7 @@ const zAgentMessageDoneData = z
 const zAgentActiveTabData = z
   .object({
     workflow_id: z.string(),
+    node_locator_id: z.string().optional(),
     name: z.string().optional(),
     thread_id: z.string().optional(),
     message_id: z.string().optional()

--- a/src/workbench/extensions/agent/services/agent/agentEventTransport.test.ts
+++ b/src/workbench/extensions/agent/services/agent/agentEventTransport.test.ts
@@ -84,10 +84,20 @@ function delta(text: string): AgentChatEvent {
   }
 }
 
-function activeTab(workflow_id: string, name?: string): AgentChatEvent {
+function activeTab(
+  workflow_id: string,
+  name?: string,
+  node_locator_id?: string
+): AgentChatEvent {
   return {
     type: 'agent_active_tab',
-    data: { workflow_id, name, message_id: 'm', thread_id: 't' }
+    data: {
+      workflow_id,
+      name,
+      node_locator_id,
+      message_id: 'm',
+      thread_id: 't'
+    }
   }
 }
 
@@ -336,10 +346,10 @@ describe('agentEventTransport settle lifecycle', () => {
     expect(toolParts(message)).toHaveLength(0)
   })
 
-  it('records an in-line tab link when the agent switches workflow tabs', () => {
+  it('records an explicitly targeted node link when the agent switches workflow tabs', () => {
     const message = drive([
       delta('opening it now'),
-      activeTab('wf-1', 'Portrait upscale'),
+      activeTab('wf-1', 'Portrait upscale', 'root-a:42'),
       delta('and here it is')
     ])
 
@@ -353,6 +363,7 @@ describe('agentEventTransport settle lifecycle', () => {
     expect(parts(message)[1]).toEqual({
       type: 'tabLink',
       workflowId: 'wf-1',
+      locatorId: 'root-a:42',
       name: 'Portrait upscale'
     })
   })

--- a/src/workbench/extensions/agent/services/agent/agentEventTransport.ts
+++ b/src/workbench/extensions/agent/services/agent/agentEventTransport.ts
@@ -106,6 +106,7 @@ export function createAgentEventTransport(
         message.parts.push({
           type: 'tabLink',
           workflowId: event.data.workflow_id,
+          locatorId: event.data.node_locator_id,
           name: event.data.name
         })
         break

--- a/src/workbench/extensions/agent/services/agent/agentMessageParts.ts
+++ b/src/workbench/extensions/agent/services/agent/agentMessageParts.ts
@@ -33,6 +33,7 @@ export interface NoticePart {
 export interface TabLinkPart {
   type: 'tabLink'
   workflowId: string
+  locatorId?: string
   name?: string
 }
 

--- a/src/workbench/extensions/agent/services/agent/targetAwareAgentNavigation.test.ts
+++ b/src/workbench/extensions/agent/services/agent/targetAwareAgentNavigation.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  AgentTargetNavigationError,
+  createTargetAwareAgentNavigation
+} from './targetAwareAgentNavigation'
+
+interface TestNode {
+  id: string
+  graph: string
+}
+
+interface TestTab {
+  path: string
+}
+
+function harness() {
+  const tabA = { path: 'workflows/a.json' }
+  const tabB = { path: 'workflows/b.json' }
+  const nodeA = { id: 'shared', graph: 'a' }
+  const nodeB = { id: 'shared', graph: 'b' }
+  let active = tabB
+  const graphs = new Map<TestTab, Map<string, TestNode>>([
+    [tabA, new Map([['root-a:shared', nodeA]])],
+    [tabB, new Map([['root-b:shared', nodeB]])]
+  ])
+  const focus = vi.fn()
+  const open = vi.fn(async (tab: TestTab) => {
+    active = tab
+    return true
+  })
+  const tabs = new Map([
+    ['wf-a', tabA],
+    ['wf-b', tabB]
+  ])
+  const navigation = createTargetAwareAgentNavigation<TestTab, TestNode>({
+    tabForWorkflow: (workflowId) => tabs.get(workflowId),
+    isOpen: (tab) => graphs.has(tab),
+    activate: open,
+    activeTab: () => active,
+    resolveIn: (tab, locatorId) => graphs.get(tab)?.get(locatorId),
+    focus
+  })
+
+  return { focus, navigation, nodeA, nodeB, open, tabA, tabB, tabs }
+}
+
+describe('target-aware agent navigation', () => {
+  it('resolves an A reference against A even while B is active', async () => {
+    const { focus, navigation, nodeA, nodeB, open, tabA } = harness()
+
+    const result = await navigation.navigate({
+      workflowId: 'wf-a',
+      locatorId: 'root-a:shared'
+    })
+
+    expect(result).toBe(nodeA)
+    expect(result).not.toBe(nodeB)
+    expect(open).toHaveBeenCalledWith(tabA)
+    expect(focus).toHaveBeenCalledWith(nodeA)
+  })
+
+  it('does not activate or focus while resolving a background effect', () => {
+    const { focus, navigation, nodeA, open } = harness()
+
+    expect(
+      navigation.resolveBackground({
+        workflowId: 'wf-a',
+        locatorId: 'root-a:shared'
+      })
+    ).toBe(nodeA)
+    expect(open).not.toHaveBeenCalled()
+    expect(focus).not.toHaveBeenCalled()
+  })
+
+  it('reports a missing binding as a typed recoverable error', async () => {
+    const { navigation } = harness()
+
+    await expect(
+      navigation.navigate({ workflowId: 'missing', locatorId: 'root:1' })
+    ).rejects.toMatchObject({ code: 'missing_target', recoverable: true })
+  })
+
+  it('reports a closed target as a typed recoverable error', async () => {
+    const { navigation, tabA, tabs } = harness()
+    tabs.set('closed', { ...tabA })
+
+    await expect(
+      navigation.navigate({ workflowId: 'closed', locatorId: 'root:1' })
+    ).rejects.toBeInstanceOf(AgentTargetNavigationError)
+    await expect(
+      navigation.navigate({ workflowId: 'closed', locatorId: 'root:1' })
+    ).rejects.toMatchObject({ code: 'closed_target', recoverable: true })
+  })
+
+  it('does not focus when the locator is stale after activation', async () => {
+    const { focus, navigation } = harness()
+
+    await expect(
+      navigation.navigate({
+        workflowId: 'wf-a',
+        locatorId: 'root-a:stale'
+      })
+    ).rejects.toMatchObject({ code: 'missing_node', recoverable: true })
+    expect(focus).not.toHaveBeenCalled()
+  })
+})

--- a/src/workbench/extensions/agent/services/agent/targetAwareAgentNavigation.ts
+++ b/src/workbench/extensions/agent/services/agent/targetAwareAgentNavigation.ts
@@ -1,0 +1,92 @@
+export type AgentTargetNavigationErrorCode =
+  | 'missing_target'
+  | 'closed_target'
+  | 'activation_failed'
+  | 'missing_node'
+
+export class AgentTargetNavigationError extends Error {
+  readonly recoverable = true
+
+  constructor(
+    readonly code: AgentTargetNavigationErrorCode,
+    readonly workflowId: string,
+    readonly locatorId?: string
+  ) {
+    super(`Agent navigation failed: ${code}`)
+    this.name = 'AgentTargetNavigationError'
+  }
+}
+
+export interface AgentGraphReference {
+  workflowId: string
+  locatorId: string
+}
+
+interface TargetAwareAgentNavigationDependencies<Tab, Node> {
+  tabForWorkflow(workflowId: string): Tab | undefined
+  isOpen(tab: Tab): boolean
+  activate(tab: Tab): Promise<boolean>
+  activeTab(): Tab | undefined
+  resolveIn(tab: Tab, locatorId: string): Node | undefined
+  focus(node: Node): void | Promise<void>
+}
+
+export function createTargetAwareAgentNavigation<Tab, Node>(
+  dependencies: TargetAwareAgentNavigationDependencies<Tab, Node>
+) {
+  function target(reference: AgentGraphReference): Tab {
+    const tab = dependencies.tabForWorkflow(reference.workflowId)
+    if (tab === undefined)
+      throw new AgentTargetNavigationError(
+        'missing_target',
+        reference.workflowId,
+        reference.locatorId
+      )
+    if (!dependencies.isOpen(tab))
+      throw new AgentTargetNavigationError(
+        'closed_target',
+        reference.workflowId,
+        reference.locatorId
+      )
+    return tab
+  }
+
+  function resolveBackground(reference: AgentGraphReference): Node {
+    const tab = target(reference)
+    const node = dependencies.resolveIn(tab, reference.locatorId)
+    if (node === undefined)
+      throw new AgentTargetNavigationError(
+        'missing_node',
+        reference.workflowId,
+        reference.locatorId
+      )
+    return node
+  }
+
+  async function navigate(reference: AgentGraphReference): Promise<Node> {
+    const tab = target(reference)
+    if (!(await dependencies.activate(tab)))
+      throw new AgentTargetNavigationError(
+        'activation_failed',
+        reference.workflowId,
+        reference.locatorId
+      )
+    if (dependencies.activeTab() !== tab)
+      throw new AgentTargetNavigationError(
+        'activation_failed',
+        reference.workflowId,
+        reference.locatorId
+      )
+    const node = dependencies.resolveIn(tab, reference.locatorId)
+    if (node === undefined)
+      throw new AgentTargetNavigationError(
+        'missing_node',
+        reference.workflowId,
+        reference.locatorId
+      )
+    await dependencies.focus(node)
+    return node
+  }
+
+  return { navigate, resolveBackground }
+}


### PR DESCRIPTION
TL;DR

- Routes graph references by explicit `workflowId` plus stable `node_locator_id`; never resolves against the active canvas by fallback.
- Activates only on a user click, verifies the target became active, then resolves and focuses; background resolution has no activation/focus side effect.
- Fail-closes reference rendering and canvas-selection watchers behind `AGENT_IN_APP_EXPERIENCE`.

<details><summary>Full context for agent readers</summary>

## Contract

This is chain slice 16, stacked on `christian-byrne/slice-15` at `fb0493305abe3fc21154125aaa05cec2bcf637ac`. It introduces a typed target resolver with recoverable `missing_target`, `closed_target`, `activation_failed`, and `missing_node` outcomes. `TabLinkCard` carries the stable locator from `agent_active_tab` and delegates explicit node clicks to the resolver. Plain workflow links retain their existing behavior.

Target identity flow:

```text
{workflowId, locatorId}
        |
workflow/tab binding registry
        |
explicit click -> activate bound tab -> verify active target -> resolve locator in target -> focus
        |
background resolve -------------------------------> no activation / no focus
```

## G1 scorecard

- Exact base: `fb0493305abe3fc21154125aaa05cec2bcf637ac`
- Rebase: remote slice-15 re-fetched immediately before commit; unchanged, no rebase required
- Flag off: `TabLinkCard` renders no action; `useCanvasSelection` does not install its selection watcher until enabled
- Target isolation: duplicate local node IDs in workflows A/B resolve by target graph fixture; A never samples active B
- Background behavior: resolver test proves no activation or focus side effect
- Recoverability: typed errors cover missing/closed target, failed activation, and stale locator
- Core regression: no core workflow helper changes and no unconditional agent branch
- Tests: 62 agent-extension files / 715 tests green
- Typecheck: green
- Lint: green with 187 pre-existing warnings and zero errors
- E2E: not run locally; browser environment was not started

## Slice-15 integration

`useAgentTargetNavigation.ts` contains one marked `STAND-IN(slice-15)` over the shipped workflow/tab binding store because slice 15 does not yet expose a separate GraphDocument registry. Replace that adapter on rebase when the registry lands; the pure resolver contract and tests remain unchanged.

## Scope / invariants

No semantic op application, queue, awareness, presence, automatic focus, or slice-17 activation surface is added. Follower behavior and CRDT reset/resync code are unchanged; the complete existing follower suite remains green.

## Glossary

- Graph reference: explicit workflow identity plus stable graph-aware node locator.
- Target resolver: maps workflow identity to its bound open document without consulting the active canvas as fallback.
- Background resolution: target lookup used by non-navigation effects; it cannot activate or focus.
- Slice-15 stand-in: narrow adapter to the current binding registry, designed to be replaced by the final GraphDocument registry seam.

</details>

<!-- authored-by:agent worker-3-lane -->