### PR TITLE
test(assets): cover runtime flag fallback

### DIFF
--- a/browser_tests/tests/sidebar/assets.spec.ts
+++ b/browser_tests/tests/sidebar/assets.spec.ts
@@ -193,8 +193,16 @@ test.describe('Assets sidebar remote flag lifecycle', { tag: '@oss' }, () => {
     await apiCard.click()
     await expect(tab.selectionFooter).toBeVisible()
     const requestCountBeforeFlagOff = assetListRequests.length
+    const fallbackHistoryResponse = page.waitForResponse((response) => {
+      const url = new URL(response.url())
+      return (
+        url.pathname === '/api/jobs' &&
+        url.searchParams.get('status') === 'completed,failed,cancelled'
+      )
+    })
 
     await comfyPage.featureFlags.setServerFlags({ assets: false })
+    await fallbackHistoryResponse
 
     await expect(
       tab.getAssetCardByName('output_legacy-after-flag-off')

--- a/browser_tests/tests/sidebar/assets.spec.ts
+++ b/browser_tests/tests/sidebar/assets.spec.ts
@@ -153,6 +153,7 @@ test.describe('Assets sidebar remote flag lifecycle', { tag: '@oss' }, () => {
     comfyPage,
     page
   }) => {
+    test.setTimeout(30_000)
     test.fail(
       true,
       'The Assets sidebar does not refresh history after a runtime flag change'

--- a/browser_tests/tests/sidebar/assets.spec.ts
+++ b/browser_tests/tests/sidebar/assets.spec.ts
@@ -1,6 +1,6 @@
 import { expect, mergeTests } from '@playwright/test'
 
-import type { Asset } from '@comfyorg/ingest-types'
+import type { Asset, ListAssetsResponse } from '@comfyorg/ingest-types'
 import { assetApiFixture } from '@e2e/fixtures/assetApiFixture'
 import { comfyPageFixture } from '@e2e/fixtures/ComfyPage'
 import {
@@ -147,6 +147,63 @@ const JOB_GAMMA_DETAIL: JobDetail = {
     }
   }
 }
+
+test.describe('Assets sidebar remote flag lifecycle', { tag: '@oss' }, () => {
+  test('falls back to settled history state when the flag turns off', async ({
+    comfyPage,
+    page
+  }) => {
+    test.fail(
+      true,
+      'The Assets sidebar does not refresh history after a runtime flag change'
+    )
+
+    const assetListRequests: string[] = []
+    const apiAsset = {
+      id: 'remote-enabled-output',
+      name: 'remote-enabled.png',
+      mime_type: 'image/png',
+      tags: ['output'],
+      preview_url: '/api/view?filename=remote-enabled.png&type=output',
+      created_at: '2026-08-29T00:00:00.000Z',
+      updated_at: '2026-08-29T00:00:00.000Z'
+    } satisfies Asset
+    await page.route(/\/api\/assets(?:\?.*)?$/, async (route) => {
+      assetListRequests.push(route.request().url())
+      await route.fulfill({
+        json: {
+          assets: [apiAsset],
+          total: 1,
+          has_more: false
+        } satisfies ListAssetsResponse
+      })
+    })
+    await comfyPage.assets.mockOutputHistory([
+      createMockJob({ id: 'legacy-after-flag-off' })
+    ])
+    await comfyPage.assets.mockInputFiles([])
+    await comfyPage.setup()
+    await comfyPage.featureFlags.setServerFlags({ assets: true })
+
+    const tab = comfyPage.menu.assetsTab
+    await tab.open({ waitForAssets: false })
+    const apiCard = tab.getAssetCardByName('remote-enabled')
+    await expect(apiCard).toBeVisible()
+    await apiCard.click()
+    await expect(tab.selectionFooter).toBeVisible()
+    const requestCountBeforeFlagOff = assetListRequests.length
+
+    await comfyPage.featureFlags.setServerFlags({ assets: false })
+
+    await expect(
+      tab.getAssetCardByName('output_legacy-after-flag-off')
+    ).toBeVisible()
+    await expect(apiCard).toHaveCount(0)
+    await expect(tab.selectionFooter).toHaveCount(0)
+    await expect(tab.filterButton).toHaveCount(0)
+    expect(assetListRequests).toHaveLength(requestCountBeforeFlagOff)
+  })
+})
 
 // ==========================================================================
 // 1. Empty states

--- a/browser_tests/tests/sidebar/assets.spec.ts
+++ b/browser_tests/tests/sidebar/assets.spec.ts
@@ -193,24 +193,15 @@ test.describe('Assets sidebar remote flag lifecycle', { tag: '@oss' }, () => {
     await apiCard.click()
     await expect(tab.selectionFooter).toBeVisible()
     const requestCountBeforeFlagOff = assetListRequests.length
-    const fallbackHistoryResponse = page.waitForResponse((response) => {
-      const url = new URL(response.url())
-      return (
-        url.pathname === '/api/jobs' &&
-        url.searchParams.get('status') === 'completed,failed,cancelled'
-      )
-    })
 
     await comfyPage.featureFlags.setServerFlags({ assets: false })
-    await fallbackHistoryResponse
-
-    await expect(
-      tab.getAssetCardByName('output_legacy-after-flag-off')
-    ).toBeVisible()
     await expect(apiCard).toHaveCount(0)
     await expect(tab.selectionFooter).toHaveCount(0)
     await expect(tab.filterButton).toHaveCount(0)
     expect(assetListRequests).toHaveLength(requestCountBeforeFlagOff)
+    await expect(
+      tab.getAssetCardByName('output_legacy-after-flag-off')
+    ).toBeVisible()
   })
 })
 


### PR DESCRIPTION
## Summary

Adds runtime Assets kill-switch coverage. Adds an OSS browser contract for changing the server-provided Assets flag from enabled to disabled while the sidebar is open and an API-backed asset is selected.

## Changes

- Verifies API-only cards, actions, and requests do not leak after fallback.
- Requires history-backed output readiness after the flag turns off.
- Covers the runtime flag on-to-off case, tracked internally as TC-ELG-06.

## Review Focus

**Changes**

- **What**: Loads an Asset API card, selects it, flips the reactive server flag off, then requires a history-backed card, cleared selection/actions, absent API-only filtering, and no additional Asset API requests.
- **Expected failure**: The detector remains expected-failing because the current sidebar swaps to a fresh history list without invalidating it after the runtime flag transition.
- **Retarget**: Rebased onto `main` after the assets rewrite landed and moved the detector into the surviving `assets.spec.ts` carrier. The obsolete stacked carrier and its unrelated 85-file history were not revived.

**Review Focus**

The flag is changed through the same reactive `serverFeatureFlags` ref populated by the WebSocket handshake, without a development local-storage override.

**Evidence**

- `pnpm typecheck` — passed.
- `pnpm exec playwright test --list browser_tests/tests/sidebar/assets.spec.ts --grep 'falls back to settled history state when the flag turns off'` — collected exactly 1 test.
- `pnpm exec oxfmt --check browser_tests/tests/sidebar/assets.spec.ts` — passed.
- `pnpm exec oxlint --type-aware browser_tests/tests/sidebar/assets.spec.ts` — passed with 0 warnings/errors.
- Push hook: `pnpm knip --cache` — passed.
- CI follow-up `ae7ec57eca9284c902e4a447763a3ac1f292fcdc`: the prior shard retried the expected-failure detector four times as `timedOut`, which Playwright classifies as unexpected instead of the declared failed status. The test now has a 30s budget so its default 5s assertion can settle as the intended expected failure. Test collection, Oxfmt, ESLint, root/browser typechecks, commit hooks, and Knip pass. This worker lacks the Playwright Chromium binary, so hosted exact-head E2E is the browser verification.
- `git range-diff 3ee44bf27..2d96c2424 origin/main..7a978ea4c` — original detector preserved; only carrier path/import and required explicit `comfyPage.setup()` changed.

<!-- authored-by:agent lane-act-fe-16293-rebase-86aa2dd8 -->
