### PR TITLE
Fix unresolved cloud waitlist skeleton

### DIFF
--- a/src/platform/cloud/onboarding/UserCheckView.test.ts
+++ b/src/platform/cloud/onboarding/UserCheckView.test.ts
@@ -1,0 +1,48 @@
+import { render, screen } from '@testing-library/vue'
+import { describe, expect, it, vi } from 'vitest'
+import { createI18n } from 'vue-i18n'
+
+import UserCheckView from './UserCheckView.vue'
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ replace: vi.fn() })
+}))
+
+vi.mock('@/composables/useErrorHandling', () => ({
+  useErrorHandling: () => ({
+    wrapWithErrorHandlingAsync:
+      <T extends (...args: never[]) => unknown>(fn: T) =>
+      (...args: Parameters<T>) =>
+        fn(...args)
+  })
+}))
+
+vi.mock('@/composables/useFeatureFlags', () => ({
+  useFeatureFlags: () => ({
+    flags: { onboardingSurveyEnabled: true }
+  })
+}))
+
+vi.mock('@/platform/cloud/onboarding/auth', () => ({
+  getUserCloudStatus: () => new Promise(() => {}),
+  getSurveyCompletedStatus: () => new Promise(() => {})
+}))
+
+describe('UserCheckView', () => {
+  it('renders bootstrap state without unresolved component warnings', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    render(UserCheckView, {
+      global: {
+        plugins: [
+          createI18n({ legacy: false, locale: 'en', messages: { en: {} } })
+        ]
+      }
+    })
+
+    expect(screen.getByRole('progressbar')).toBeInTheDocument()
+    expect(warn.mock.calls.flat().join(' ')).not.toContain(
+      'Failed to resolve component: CloudWaitlistViewSkeleton'
+    )
+  })
+})

--- a/src/platform/cloud/onboarding/UserCheckView.vue
+++ b/src/platform/cloud/onboarding/UserCheckView.vue
@@ -1,7 +1,6 @@
 <template>
   <CloudLoginViewSkeleton v-if="skeletonType === 'login'" />
   <CloudSurveyViewSkeleton v-else-if="skeletonType === 'survey'" />
-  <CloudWaitlistViewSkeleton v-else-if="skeletonType === 'waitlist'" />
   <div v-else-if="error" class="flex h-full items-center justify-center p-8">
     <div class="max-w-[100vw] p-2 text-center lg:w-96">
       <p class="mb-4 text-red-500">{{ errorMessage }}</p>
@@ -43,7 +42,7 @@ const onboardingSurveyEnabled = computed(
   () => flags.onboardingSurveyEnabled ?? true
 )
 
-const skeletonType = ref<'login' | 'survey' | 'waitlist' | 'loading'>('loading')
+const skeletonType = ref<'login' | 'survey' | 'loading'>('loading')
 
 const {
   isLoading,


### PR DESCRIPTION
Removes an unresolved bootstrap component.
Adds focused regression coverage.
Targeted checks are green.

<details><summary>Full context for agent readers</summary>

## Summary

`UserCheckView` referenced `CloudWaitlistViewSkeleton`, but no such component exists and the waitlist state is unreachable. Vue still attempted component resolution during render and emitted a warning during authenticated cloud bootstrap.

## Changes

- **What**: Removed the stale template branch and unreachable `waitlist` state; added a component test that renders bootstrap and rejects unresolved-component warnings.

## Review Focus

Confirm the removed branch is obsolete rather than awaiting a replacement waitlist skeleton.

## Verification

- `pnpm test:unit src/platform/cloud/onboarding/UserCheckView.test.ts`
- `pnpm exec oxfmt --check src/platform/cloud/onboarding/UserCheckView.vue src/platform/cloud/onboarding/UserCheckView.test.ts`
- `pnpm exec eslint src/platform/cloud/onboarding/UserCheckView.vue src/platform/cloud/onboarding/UserCheckView.test.ts`
- `pnpm typecheck`
- pre-push `pnpm knip --cache`

</details>