### PR TITLE
Add accessible save workflow dialog labels

### DIFF
--- a/browser_tests/fixtures/helpers/BuilderSaveAsHelper.ts
+++ b/browser_tests/fixtures/helpers/BuilderSaveAsHelper.ts
@@ -3,7 +3,7 @@ import type { Locator, Page } from '@playwright/test'
 import type { ComfyPage } from '@e2e/fixtures/ComfyPage'
 
 export class BuilderSaveAsHelper {
-  /** The save-as dialog (scoped by aria-labelledby). */
+  /** The save-as dialog (scoped by its stable dialog key). */
   public readonly dialog: Locator
   /** The post-save success dialog (scoped by aria-labelledby). */
   public readonly successDialog: Locator
@@ -21,7 +21,7 @@ export class BuilderSaveAsHelper {
   public readonly overwriteButton: Locator
 
   constructor(private readonly comfyPage: ComfyPage) {
-    this.dialog = this.page.locator('[aria-labelledby="builder-save"]')
+    this.dialog = this.page.locator('[data-dialog-key="builder-save"]')
     this.successDialog = this.page.locator(
       '[aria-labelledby="builder-save-success"]'
     )

--- a/src/components/builder/BuilderDialog.vue
+++ b/src/components/builder/BuilderDialog.vue
@@ -6,9 +6,12 @@
     >
       <div class="flex items-center gap-2">
         <slot name="header-icon" />
-        <h2 class="m-0 text-sm font-normal text-base-foreground">
+        <DialogTitle
+          as="h2"
+          class="m-0 text-sm font-normal text-base-foreground"
+        >
           <slot name="title" />
-        </h2>
+        </DialogTitle>
       </div>
       <Button
         v-if="showClose"
@@ -35,6 +38,7 @@
 
 <script setup lang="ts">
 import Button from '@/components/ui/button/Button.vue'
+import DialogTitle from '@/components/ui/dialog/DialogTitle.vue'
 
 const { showClose = true } = defineProps<{
   showClose?: boolean

--- a/src/components/builder/BuilderSaveDialogContent.vue
+++ b/src/components/builder/BuilderSaveDialogContent.vue
@@ -5,9 +5,11 @@
     </template>
 
     <div class="flex flex-col gap-2">
-      <label :for="inputId" class="text-sm text-muted-foreground">
-        {{ $t('builderToolbar.filename') }}
-      </label>
+      <DialogDescription as-child>
+        <label :for="inputId" class="text-sm text-muted-foreground">
+          {{ $t('builderToolbar.filename') }}
+        </label>
+      </DialogDescription>
       <input
         :id="inputId"
         v-model="filename"
@@ -50,6 +52,7 @@
 import { ref, useId } from 'vue'
 
 import Button from '@/components/ui/button/Button.vue'
+import DialogDescription from '@/components/ui/dialog/DialogDescription.vue'
 
 import BuilderDialog from './BuilderDialog.vue'
 import ViewTypeRadioGroup from './ViewTypeRadioGroup.vue'

--- a/src/components/builder/useBuilderSave.test.ts
+++ b/src/components/builder/useBuilderSave.test.ts
@@ -157,10 +157,12 @@ describe('useBuilderSave', () => {
       saveAs()
 
       expect(mockShowLayoutDialog).toHaveBeenCalledOnce()
-      const { key, props } = mockShowLayoutDialog.mock.calls[0][0]
+      const { key, props, dialogComponentProps } =
+        mockShowLayoutDialog.mock.calls[0][0]
       expect(key).toBe(SAVE_DIALOG_KEY)
       expect(props.defaultFilename).toBe('my-workflow')
       expect(props.defaultOpenAsApp).toBe(true)
+      expect(dialogComponentProps.useAutomaticLabeling).toBe(true)
     })
 
     it('passes defaultOpenAsApp: false when initialMode is graph', () => {

--- a/src/components/builder/useBuilderSave.ts
+++ b/src/components/builder/useBuilderSave.ts
@@ -58,7 +58,8 @@ export function useBuilderSave() {
         defaultOpenAsApp: workflow.initialMode !== 'graph',
         onSave: handleSaveAs,
         onClose: () => closeDialog(SAVE_DIALOG_KEY)
-      }
+      },
+      dialogComponentProps: { useAutomaticLabeling: true }
     })
   }
 

--- a/src/components/dialog/GlobalDialog.test.ts
+++ b/src/components/dialog/GlobalDialog.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it, vi } from 'vitest'
 import { defineComponent, h, nextTick } from 'vue'
 import { createI18n } from 'vue-i18n'
 
+import BuilderSaveDialogContent from '@/components/builder/BuilderSaveDialogContent.vue'
 import GlobalDialog from '@/components/dialog/GlobalDialog.vue'
 import {
   onRekaFocusOutside,
@@ -72,7 +73,17 @@ const i18n = createI18n({
       g: {
         cancel: 'Cancel',
         close: 'Close',
-        maximizeDialog: 'Maximize'
+        maximizeDialog: 'Maximize',
+        save: 'Save'
+      },
+      builderToolbar: {
+        app: 'App',
+        appDescription: 'Opens as an app by default',
+        defaultViewLabel: 'By default, this workflow will open as:',
+        filename: 'Filename',
+        nodeGraph: 'Node graph',
+        nodeGraphDescription: 'Opens as node graph by default',
+        saveAs: 'Save as'
       },
       workspacePanel: {
         members: {
@@ -261,6 +272,28 @@ describe('GlobalDialog Reka parity with PrimeVue', () => {
         name: 'Set a monthly credit limit for Jane'
       })
     ).toBeInTheDocument()
+  })
+
+  it('opens the save dialog with an accessible name and description', async () => {
+    const warn = vi.spyOn(console, 'warn')
+    mountDialog()
+    const store = useDialogStore()
+
+    store.showDialog({
+      key: 'builder-save',
+      component: BuilderSaveDialogContent,
+      props: { defaultFilename: 'workflow.json' },
+      dialogComponentProps: {
+        renderer: 'reka',
+        headless: true,
+        useAutomaticLabeling: true
+      }
+    })
+
+    const dialog = await screen.findByRole('dialog', { name: 'Save as' })
+    expect(dialog).toHaveAccessibleDescription('Filename')
+    expect(screen.getByLabelText('Filename')).toHaveFocus()
+    expect(warn).not.toHaveBeenCalled()
   })
 
   it('closes the dialog on Escape by default', async () => {

--- a/src/components/dialog/GlobalDialog.vue
+++ b/src/components/dialog/GlobalDialog.vue
@@ -14,10 +14,15 @@
         />
         <DialogContent
           v-reka-z-index
+          v-bind="
+            item.dialogComponentProps.useAutomaticLabeling
+              ? {}
+              : { 'aria-labelledby': item.key }
+          "
           :size="item.dialogComponentProps.size ?? 'md'"
           :maximized="!!item.dialogComponentProps.maximized"
           :class="item.dialogComponentProps.contentClass"
-          :aria-labelledby="item.key"
+          :data-dialog-key="item.key"
           @open-auto-focus="(e) => onRekaOpenAutoFocus(e, item.key)"
           @escape-key-down="
             (e) =>
@@ -166,7 +171,7 @@ function onRekaOpenChange(key: string, open: boolean) {
 // Reka's default auto-focus when one is present.
 function onRekaOpenAutoFocus(event: Event, key: string) {
   const content = document.querySelector<HTMLElement>(
-    `[aria-labelledby="${CSS.escape(key)}"]`
+    `[data-dialog-key="${CSS.escape(key)}"]`
   )
   const autofocusEl = content?.querySelector<HTMLElement>('[autofocus]')
   if (autofocusEl) {

--- a/src/stores/dialogStore.ts
+++ b/src/stores/dialogStore.ts
@@ -54,6 +54,7 @@ interface CustomDialogComponentProps {
   unstyled?: boolean
   headless?: boolean
   renderer?: DialogRenderer
+  useAutomaticLabeling?: boolean
   size?: DialogContentSize
   /**
    * Class applied to the Reka-UI `DialogContent` element. Ignored on the


### PR DESCRIPTION
- Gives the save dialog a visible accessible name.
- Wires its filename description into the dialog contract.
- Preserves autofocus and adds warning coverage.

<details><summary>Full context for agent readers</summary>

## Summary

The builder save dialog now registers its visible heading with `DialogTitle` and its filename label with `DialogDescription`. Headless global dialogs can opt into Reka's automatic title and description registration instead of the legacy key label.

## Changes

- **What**: Add title and description primitives, enable automatic labeling for the save flow, preserve autofocus through a stable dialog data key, and add component coverage.

## Review Focus

Confirm the opt-in leaves existing headless dialogs unchanged while the save dialog exposes `Save as` and `Filename` to assistive technology.

## Verification

- `pnpm test:unit src/components/dialog/GlobalDialog.test.ts src/components/builder/useBuilderSave.test.ts` (54 passed)
- targeted ESLint and oxfmt checks
- `pnpm typecheck`
- push hook `pnpm knip --cache`

</details>