### PR TITLE
test(assets): cover distribution cohorts

### DIFF
--- a/src/composables/useFeatureFlags.test.ts
+++ b/src/composables/useFeatureFlags.test.ts
@@ -310,6 +310,26 @@ describe('useFeatureFlags', () => {
     })
   })
 
+  describe('assetsEnabled', () => {
+    it.for([
+      ['stable cohort without the flag', undefined, false],
+      ['beta cohort with the flag', true, true],
+      ['beta cohort after the kill switch', false, false]
+    ] as const)(
+      'maps the %s response to the expected state',
+      ([, servedValue, expected]) => {
+        vi.mocked(api.getServerFeature).mockImplementation(
+          (path, defaultValue) =>
+            path === 'assets' && servedValue !== undefined
+              ? servedValue
+              : defaultValue
+        )
+
+        expect(useFeatureFlags().flags.assetsEnabled).toBe(expected)
+      }
+    )
+  })
+
   describe('partnerNodeGovernanceEnabled', () => {
     afterEach(() => {
       remoteConfig.value = {}


### PR DESCRIPTION
## Summary

Stable stays off. Beta turns on. The kill switch turns it back off.

## Review Focus

**What this covers**

Adds parameterized feature-flag coverage for the Assets distribution-cohort smoke case, tracked internally as TC-ELG-07:

- a stable cohort with no served flag remains disabled
- a beta cohort with the served flag becomes enabled
- an explicit false value disables the beta cohort again

The test runs through the real `useFeatureFlags` resolver and varies only the owned server-feature boundary.

<details><summary>Verification</summary>

- `src/composables/useFeatureFlags.test.ts`: 53/53 passed
- `pnpm typecheck`: exit 0
- ESLint, type-aware Oxlint, format, knip, and diff checks: green
- Mutation: bypassing the resolver with `false` failed the beta assertion; forcing `true` failed the stable and kill-switch assertions

</details>
