### PR TITLE
feat(agent): presentation-only pending-op shadow surface for the CRDT overlay

### DIFF
--- a/src/workbench/extensions/agent/crdt/pendingOpShadow.test.ts
+++ b/src/workbench/extensions/agent/crdt/pendingOpShadow.test.ts
@@ -1,0 +1,159 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+import type {
+  PendingShadow,
+  ShadowChange,
+  ShadowTarget
+} from './pendingOpShadow'
+import { createPendingOpShadowSurface } from './pendingOpShadow'
+
+const node = (nodeId: string): ShadowTarget => ({ kind: 'node', nodeId })
+const link = (linkId: string): ShadowTarget => ({ kind: 'link', linkId })
+const widget = (nodeId: string, widgetName: string): ShadowTarget => ({
+  kind: 'widget',
+  nodeId,
+  widgetName
+})
+
+describe('pendingOpShadow (s3-opt-5 presentation surface)', () => {
+  it('shows a shadow exactly once per op id and never overwrites', () => {
+    const surface = createPendingOpShadowSurface()
+    expect(surface.show('op-1', [node('n1')])).toBe(true)
+    expect(surface.show('op-1', [node('n2')])).toBe(false)
+    expect(surface.get('op-1')?.targets).toEqual([node('n1')])
+    expect(surface.size()).toBe(1)
+  })
+
+  it('tracks node, link, and widget targets for one op', () => {
+    const surface = createPendingOpShadowSurface()
+    surface.show('op-1', [node('n1'), link('l1'), widget('n1', 'seed')])
+    expect(surface.isPending(node('n1'))).toBe(true)
+    expect(surface.isPending(link('l1'))).toBe(true)
+    expect(surface.isPending(widget('n1', 'seed'))).toBe(true)
+    expect(surface.isPending(widget('n1', 'steps'))).toBe(false)
+    expect(surface.isPending(node('n2'))).toBe(false)
+  })
+
+  it('revert removes the shadow and returns it; unknown id is a no-op', () => {
+    const surface = createPendingOpShadowSurface()
+    surface.show('op-1', [node('n1')])
+    const removed = surface.revert('op-1')
+    expect(removed?.opId).toBe('op-1')
+    expect(surface.get('op-1')).toBeUndefined()
+    expect(surface.isPending(node('n1'))).toBe(false)
+    expect(surface.revert('op-1')).toBeUndefined()
+    expect(surface.revert('never-shown')).toBeUndefined()
+  })
+
+  it('clear removes the shadow on effect (KA-9) and returns it', () => {
+    const surface = createPendingOpShadowSurface()
+    surface.show('op-1', [widget('n1', 'seed')])
+    const removed = surface.clear('op-1')
+    expect(removed?.targets).toEqual([widget('n1', 'seed')])
+    expect(surface.isPending(widget('n1', 'seed'))).toBe(false)
+    expect(surface.clear('op-1')).toBeUndefined()
+  })
+
+  it('refcounts a target shared by two ops across revert and clear', () => {
+    const surface = createPendingOpShadowSurface()
+    surface.show('op-1', [node('n1')])
+    surface.show('op-2', [node('n1'), node('n2')])
+    expect(surface.isPending(node('n1'))).toBe(true)
+
+    surface.revert('op-1')
+    expect(surface.isPending(node('n1'))).toBe(true)
+    expect(surface.isPending(node('n2'))).toBe(true)
+
+    surface.clear('op-2')
+    expect(surface.isPending(node('n1'))).toBe(false)
+    expect(surface.isPending(node('n2'))).toBe(false)
+  })
+
+  it('deduplicates shared targets in pendingTargets()', () => {
+    const surface = createPendingOpShadowSurface()
+    surface.show('op-1', [node('n1'), link('l1')])
+    surface.show('op-2', [node('n1')])
+    expect(surface.pendingTargets()).toEqual([node('n1'), link('l1')])
+  })
+
+  it('clearAll drops every shadow in insertion order (FEB-5)', () => {
+    const surface = createPendingOpShadowSurface()
+    surface.show('op-1', [node('n1')])
+    surface.show('op-2', [link('l1')])
+    const removed = surface.clearAll()
+    expect(removed.map((s: PendingShadow) => s.opId)).toEqual(['op-1', 'op-2'])
+    expect(surface.size()).toBe(0)
+    expect(surface.pendingTargets()).toEqual([])
+    expect(surface.isPending(node('n1'))).toBe(false)
+    expect(surface.clearAll()).toEqual([])
+  })
+
+  it('notifies subscribers with the distinct verb per mutation', () => {
+    const surface = createPendingOpShadowSurface()
+    const changes: ShadowChange[] = []
+    const unsubscribe = surface.subscribe((change) => changes.push(change))
+
+    surface.show('op-1', [node('n1')])
+    surface.show('op-2', [node('n2')])
+    surface.revert('op-1')
+    surface.clear('op-2')
+    surface.show('op-3', [node('n3')])
+    surface.clearAll()
+
+    expect(changes).toEqual([
+      { type: 'show', opId: 'op-1' },
+      { type: 'show', opId: 'op-2' },
+      { type: 'revert', opId: 'op-1' },
+      { type: 'clear', opId: 'op-2' },
+      { type: 'show', opId: 'op-3' },
+      { type: 'clear-all', opIds: ['op-3'] }
+    ])
+
+    unsubscribe()
+    surface.show('op-4', [node('n4')])
+    expect(changes).toHaveLength(6)
+  })
+
+  it('does not notify on rejected or no-op mutations', () => {
+    const surface = createPendingOpShadowSurface()
+    const changes: ShadowChange[] = []
+    surface.subscribe((change) => changes.push(change))
+
+    surface.revert('unknown')
+    surface.clear('unknown')
+    surface.clearAll()
+    surface.show('op-1', [node('n1')])
+    surface.show('op-1', [node('n1')])
+
+    expect(changes).toEqual([{ type: 'show', opId: 'op-1' }])
+  })
+
+  it('snapshots are decoupled from caller input and internal state', () => {
+    const surface = createPendingOpShadowSurface()
+    const input = [node('n1')]
+    surface.show('op-1', input)
+    input.push(node('n2'))
+    expect(surface.get('op-1')?.targets).toEqual([node('n1')])
+
+    const shadow = surface.get('op-1')
+    expect(shadow && Object.isFrozen(shadow)).toBe(true)
+    expect(shadow && Object.isFrozen(shadow.targets)).toBe(true)
+
+    const listed = surface.pendingShadows()
+    listed.pop()
+    expect(surface.pendingShadows()).toHaveLength(1)
+  })
+
+  it('never touches Yjs or the shared doc: the module has zero imports', () => {
+    // FORECLOSE #5 guard: the overlay must stay presentation-only. Importing
+    // yjs (or anything else) from this module would be the first step toward
+    // encoding shadows into the shared doc, so pin the import surface itself.
+    const source = readFileSync(
+      'src/workbench/extensions/agent/crdt/pendingOpShadow.ts',
+      'utf8'
+    )
+    expect(source).not.toMatch(/^\s*import /m)
+    expect(source).not.toMatch(/from 'yjs'/)
+  })
+})

--- a/src/workbench/extensions/agent/crdt/pendingOpShadow.test.ts
+++ b/src/workbench/extensions/agent/crdt/pendingOpShadow.test.ts
@@ -188,6 +188,7 @@ describe('pendingOpShadow (s3-opt-5 presentation surface)', () => {
     const shadow = surface.get('op-1')
     expect(shadow && Object.isFrozen(shadow)).toBe(true)
     expect(shadow && Object.isFrozen(shadow.targets)).toBe(true)
+    expect(shadow && Object.isFrozen(shadow.targets[0])).toBe(true)
 
     const listed = surface.pendingShadows()
     listed.pop()

--- a/src/workbench/extensions/agent/crdt/pendingOpShadow.test.ts
+++ b/src/workbench/extensions/agent/crdt/pendingOpShadow.test.ts
@@ -77,6 +77,16 @@ describe('pendingOpShadow (s3-opt-5 presentation surface)', () => {
     expect(surface.pendingTargets()).toEqual([node('n1'), link('l1')])
   })
 
+  it('keeps widget targets distinct when ids contain separators', () => {
+    const surface = createPendingOpShadowSurface()
+    surface.show('op-1', [widget('a:b', 'c')])
+    surface.show('op-2', [widget('a', 'b:c')])
+
+    surface.clear('op-1')
+    expect(surface.isPending(widget('a:b', 'c'))).toBe(false)
+    expect(surface.isPending(widget('a', 'b:c'))).toBe(true)
+  })
+
   it('clearAll drops every shadow in insertion order (FEB-5)', () => {
     const surface = createPendingOpShadowSurface()
     surface.show('op-1', [node('n1')])

--- a/src/workbench/extensions/agent/crdt/pendingOpShadow.test.ts
+++ b/src/workbench/extensions/agent/crdt/pendingOpShadow.test.ts
@@ -36,6 +36,14 @@ describe('pendingOpShadow (s3-opt-5 presentation surface)', () => {
     expect(surface.isPending(node('n2'))).toBe(false)
   })
 
+  it('rejects malformed target kinds instead of sharing an undefined key', () => {
+    const surface = createPendingOpShadowSurface()
+    const malformed = { kind: 'group', nodeId: 'n1' } as unknown as ShadowTarget
+    expect(() => surface.isPending(malformed)).toThrow(
+      'Unsupported shadow target'
+    )
+  })
+
   it('revert removes the shadow and returns it; unknown id is a no-op', () => {
     const surface = createPendingOpShadowSurface()
     surface.show('op-1', [node('n1')])

--- a/src/workbench/extensions/agent/crdt/pendingOpShadow.test.ts
+++ b/src/workbench/extensions/agent/crdt/pendingOpShadow.test.ts
@@ -152,6 +152,19 @@ describe('pendingOpShadow (s3-opt-5 presentation surface)', () => {
     expect(surface.isPending(node('n1'))).toBe(true)
   })
 
+  it('starts subscriptions added during notification on the next change', () => {
+    const surface = createPendingOpShadowSurface()
+    const lateChanges: ShadowChange[] = []
+    surface.subscribe(() => {
+      surface.subscribe((change) => lateChanges.push(change))
+    })
+
+    surface.show('op-1', [node('n1')])
+    expect(lateChanges).toEqual([])
+    surface.show('op-2', [node('n2')])
+    expect(lateChanges).toEqual([{ type: 'show', opId: 'op-2' }])
+  })
+
   it('snapshots are decoupled from caller input and internal state', () => {
     const surface = createPendingOpShadowSurface()
     const input = [node('n1')]

--- a/src/workbench/extensions/agent/crdt/pendingOpShadow.test.ts
+++ b/src/workbench/extensions/agent/crdt/pendingOpShadow.test.ts
@@ -26,6 +26,15 @@ describe('pendingOpShadow (s3-opt-5 presentation surface)', () => {
     expect(surface.size()).toBe(1)
   })
 
+  it('never reuses an op id after its shadow is removed', () => {
+    const surface = createPendingOpShadowSurface()
+    surface.show('op-1', [node('n1')])
+    surface.clear('op-1')
+
+    expect(surface.show('op-1', [node('n2')])).toBe(false)
+    expect(surface.isPending(node('n2'))).toBe(false)
+  })
+
   it('tracks node, link, and widget targets for one op', () => {
     const surface = createPendingOpShadowSurface()
     surface.show('op-1', [node('n1'), link('l1'), widget('n1', 'seed')])

--- a/src/workbench/extensions/agent/crdt/pendingOpShadow.test.ts
+++ b/src/workbench/extensions/agent/crdt/pendingOpShadow.test.ts
@@ -1,4 +1,5 @@
 import { readFileSync } from 'node:fs'
+import { pathToFileURL } from 'node:url'
 import { describe, expect, it } from 'vitest'
 
 import type {
@@ -186,10 +187,11 @@ describe('pendingOpShadow (s3-opt-5 presentation surface)', () => {
     // yjs (or anything else) from this module would be the first step toward
     // encoding shadows into the shared doc, so pin the import surface itself.
     const source = readFileSync(
-      'src/workbench/extensions/agent/crdt/pendingOpShadow.ts',
+      new URL('./pendingOpShadow.ts', pathToFileURL(import.meta.filename)),
       'utf8'
     )
-    expect(source).not.toMatch(/^\s*import /m)
-    expect(source).not.toMatch(/from 'yjs'/)
+    expect(source).not.toMatch(/\b(?:import|export)\s*(?:\(|\{|\*|["'])/)
+    expect(source).not.toMatch(/\brequire\s*\(/)
+    expect(source).not.toMatch(/\bfrom\s*["']yjs["']/)
   })
 })

--- a/src/workbench/extensions/agent/crdt/pendingOpShadow.test.ts
+++ b/src/workbench/extensions/agent/crdt/pendingOpShadow.test.ts
@@ -53,6 +53,18 @@ describe('pendingOpShadow (s3-opt-5 presentation surface)', () => {
     )
   })
 
+  it('rejects a malformed target in show before recording the op id', () => {
+    const surface = createPendingOpShadowSurface()
+    const malformed = { kind: 'group', nodeId: 'n1' } as unknown as ShadowTarget
+
+    expect(() => surface.show('op-1', [malformed])).toThrow(
+      'Unsupported shadow target'
+    )
+    // A later show with the same op id must not be treated as a duplicate:
+    // the rejected attempt above must not have reached seenOpIds.add/shadows.set.
+    expect(surface.show('op-1', [node('n1')])).toBe(true)
+  })
+
   it('revert removes the shadow and returns it; unknown id is a no-op', () => {
     const surface = createPendingOpShadowSurface()
     surface.show('op-1', [node('n1')])

--- a/src/workbench/extensions/agent/crdt/pendingOpShadow.test.ts
+++ b/src/workbench/extensions/agent/crdt/pendingOpShadow.test.ts
@@ -9,10 +9,23 @@ import type {
 } from './pendingOpShadow'
 import { createPendingOpShadowSurface } from './pendingOpShadow'
 
-const node = (nodeId: string): ShadowTarget => ({ kind: 'node', nodeId })
-const link = (linkId: string): ShadowTarget => ({ kind: 'link', linkId })
-const widget = (nodeId: string, widgetName: string): ShadowTarget => ({
+const node = (nodeId: string, graphId = 'root'): ShadowTarget => ({
+  kind: 'node',
+  graphId,
+  nodeId
+})
+const link = (linkId: string, graphId = 'root'): ShadowTarget => ({
+  kind: 'link',
+  graphId,
+  linkId
+})
+const widget = (
+  nodeId: string,
+  widgetName: string,
+  graphId = 'root'
+): ShadowTarget => ({
   kind: 'widget',
+  graphId,
   nodeId,
   widgetName
 })
@@ -115,6 +128,46 @@ describe('pendingOpShadow (s3-opt-5 presentation surface)', () => {
     surface.clear('op-1')
     expect(surface.isPending(widget('a:b', 'c'))).toBe(false)
     expect(surface.isPending(widget('a', 'b:c'))).toBe(true)
+  })
+
+  it('keeps identical local node/link ids distinct across graph scopes', () => {
+    const surface = createPendingOpShadowSurface()
+    surface.show('op-1', [node('n1', 'graph-a')])
+    surface.show('op-2', [node('n1', 'graph-b'), link('l1', 'graph-b')])
+
+    expect(surface.isPending(node('n1', 'graph-a'))).toBe(true)
+    expect(surface.isPending(node('n1', 'graph-b'))).toBe(true)
+    expect(surface.isPending(link('l1', 'graph-a'))).toBe(false)
+    expect(surface.isPending(link('l1', 'graph-b'))).toBe(true)
+
+    // Resolving one graph's shadow must not touch the other graph's refcount
+    // for the same local id (the bug: an omitted graph scope shares one key).
+    surface.clear('op-1')
+    expect(surface.isPending(node('n1', 'graph-a'))).toBe(false)
+    expect(surface.isPending(node('n1', 'graph-b'))).toBe(true)
+  })
+
+  it('keeps identical local widget ids distinct across graph scopes', () => {
+    const surface = createPendingOpShadowSurface()
+    surface.show('op-1', [widget('n1', 'seed', 'graph-a')])
+    surface.show('op-2', [widget('n1', 'seed', 'graph-b')])
+
+    expect(surface.isPending(widget('n1', 'seed', 'graph-a'))).toBe(true)
+    expect(surface.isPending(widget('n1', 'seed', 'graph-b'))).toBe(true)
+
+    surface.revert('op-1')
+    expect(surface.isPending(widget('n1', 'seed', 'graph-a'))).toBe(false)
+    expect(surface.isPending(widget('n1', 'seed', 'graph-b'))).toBe(true)
+  })
+
+  it('dedupes pendingTargets() by graph scope, not local id alone', () => {
+    const surface = createPendingOpShadowSurface()
+    surface.show('op-1', [node('n1', 'graph-a')])
+    surface.show('op-2', [node('n1', 'graph-b')])
+    expect(surface.pendingTargets()).toEqual([
+      node('n1', 'graph-a'),
+      node('n1', 'graph-b')
+    ])
   })
 
   it('clearAll drops every shadow in insertion order (FEB-5)', () => {

--- a/src/workbench/extensions/agent/crdt/pendingOpShadow.test.ts
+++ b/src/workbench/extensions/agent/crdt/pendingOpShadow.test.ts
@@ -212,16 +212,27 @@ describe('pendingOpShadow (s3-opt-5 presentation surface)', () => {
     expect(surface.pendingShadows()).toHaveLength(1)
   })
 
-  it('never touches Yjs or the shared doc: the module has zero imports', () => {
+  it('never touches Yjs or the shared doc: the only permitted import is @/base/assert', () => {
     // FORECLOSE #5 guard: the overlay must stay presentation-only. Importing
-    // yjs (or anything else) from this module would be the first step toward
-    // encoding shadows into the shared doc, so pin the import surface itself.
+    // yjs (or anything that could reach the shared doc) from this module
+    // would be the first step toward encoding shadows into the shared doc.
+    // @/base/assert is the repo's central invariant channel (ADR 0019) — a
+    // base-layer leaf with no Yjs/DOM/framework coupling.
     const source = readFileSync(
       new URL('./pendingOpShadow.ts', pathToFileURL(import.meta.filename)),
       'utf8'
     )
-    expect(source).not.toMatch(/\b(?:import|export)\s*(?:\(|\{|\*|["'])/)
-    expect(source).not.toMatch(/\brequire\s*\(/)
-    expect(source).not.toMatch(/\bfrom\s*["']yjs["']/)
+    const code = source
+      .replace(/\/\*[\s\S]*?\*\//g, '')
+      .replace(/\/\/.*$/gm, '')
+    expect(code).not.toMatch(/\bimport\s*\(/)
+    expect(code).not.toMatch(/\bimport\s*["']/)
+    expect(code).not.toMatch(/\bexport\s*(?:\{|\*)/)
+    expect(code).not.toMatch(/\brequire\s*\(/)
+    expect(code).not.toMatch(/\bfrom\s*["']yjs["']/)
+    const fromSpecifiers = [...code.matchAll(/\bfrom\s*["']([^"']+)["']/g)].map(
+      (m) => m[1]
+    )
+    expect(fromSpecifiers.every((s) => s === '@/base/assert')).toBe(true)
   })
 })

--- a/src/workbench/extensions/agent/crdt/pendingOpShadow.test.ts
+++ b/src/workbench/extensions/agent/crdt/pendingOpShadow.test.ts
@@ -139,6 +139,19 @@ describe('pendingOpShadow (s3-opt-5 presentation surface)', () => {
     expect(changes).toEqual([{ type: 'show', opId: 'op-1' }])
   })
 
+  it('isolates subscriber failures after committing a change', () => {
+    const surface = createPendingOpShadowSurface()
+    const changes: ShadowChange[] = []
+    surface.subscribe(() => {
+      throw new Error('renderer failed')
+    })
+    surface.subscribe((change) => changes.push(change))
+
+    expect(() => surface.show('op-1', [node('n1')])).not.toThrow()
+    expect(changes).toEqual([{ type: 'show', opId: 'op-1' }])
+    expect(surface.isPending(node('n1'))).toBe(true)
+  })
+
   it('snapshots are decoupled from caller input and internal state', () => {
     const surface = createPendingOpShadowSurface()
     const input = [node('n1')]

--- a/src/workbench/extensions/agent/crdt/pendingOpShadow.test.ts
+++ b/src/workbench/extensions/agent/crdt/pendingOpShadow.test.ts
@@ -166,6 +166,18 @@ describe('pendingOpShadow (s3-opt-5 presentation surface)', () => {
     expect(lateChanges).toEqual([{ type: 'show', opId: 'op-2' }])
   })
 
+  it('keeps duplicate listener registrations independently subscribed', () => {
+    const surface = createPendingOpShadowSurface()
+    const changes: ShadowChange[] = []
+    const listener = (change: ShadowChange) => changes.push(change)
+    const unsubscribeFirst = surface.subscribe(listener)
+    surface.subscribe(listener)
+
+    unsubscribeFirst()
+    surface.show('op-1', [node('n1')])
+    expect(changes).toEqual([{ type: 'show', opId: 'op-1' }])
+  })
+
   it('snapshots are decoupled from caller input and internal state', () => {
     const surface = createPendingOpShadowSurface()
     const input = [node('n1')]

--- a/src/workbench/extensions/agent/crdt/pendingOpShadow.ts
+++ b/src/workbench/extensions/agent/crdt/pendingOpShadow.ts
@@ -1,0 +1,204 @@
+/**
+ * Pending-op presentation shadow (s3-opt-5 / CRDT-RM-3): the render-side
+ * surface of the follower's optimistic overlay. While a locally minted op is
+ * pending (tracked by the s3-opt-1 ledger), this surface remembers WHICH
+ * canvas entities — nodes, links, widgets — should render pending/ghost
+ * styling, keyed by the op's immutable `op_id` (KA-2).
+ *
+ * Contract boundaries this module deliberately encodes:
+ *
+ * - Presentation ONLY. Shadows never touch Yjs, never feed the applier, and
+ *   are never encoded as a Yjs update or merged into the shared doc
+ *   (KEEP-ALIVE #9, FORECLOSE #5). The module has zero imports.
+ * - `show` registers a shadow exactly once per op id — never an overwrite —
+ *   mirroring the ledger's enqueue semantics.
+ * - `revert(opId)` and `clear(opId)` are the two removal verbs consumed by
+ *   s3-opt-2 (failure reconciliation) and s3-opt-3 (KA-9 clear-on-effect).
+ *   They mutate identically but emit distinct change events so a renderer can
+ *   distinguish "op failed, styling rolls back" from "authoritative effect
+ *   landed, pending styling resolves".
+ * - `clearAll` drops every shadow: the `doc_reset` and unmount/workflow-switch
+ *   path (FEB-5).
+ * - Multiple pending ops may shadow the same entity; target pendingness is
+ *   refcounted so reverting one op does not unstyle an entity another op
+ *   still holds.
+ * - Pull-model change notification: subscribers are told THAT the surface
+ *   changed (and which verb/op), then re-derive styling via the snapshot
+ *   queries. No timers, no clocks, no IO.
+ */
+
+/** One canvas entity that renders pending styling while an op is in flight. */
+export type ShadowTarget =
+  | { readonly kind: 'node'; readonly nodeId: string }
+  | { readonly kind: 'link'; readonly linkId: string }
+  | {
+      readonly kind: 'widget'
+      readonly nodeId: string
+      readonly widgetName: string
+    }
+
+/** The shadow registered for one pending op. */
+export interface PendingShadow {
+  /** Immutable caller-minted operation id (KA-2). Never regenerated here. */
+  readonly opId: string
+  readonly targets: readonly ShadowTarget[]
+}
+
+/** Why the surface changed; lets renderers animate removal verbs differently. */
+export type ShadowChange =
+  | { readonly type: 'show'; readonly opId: string }
+  | { readonly type: 'revert'; readonly opId: string }
+  | { readonly type: 'clear'; readonly opId: string }
+  | { readonly type: 'clear-all'; readonly opIds: readonly string[] }
+
+export interface PendingOpShadowSurface {
+  /**
+   * Register pending styling for a minted op exactly once. Returns false
+   * (and changes nothing, notifies nobody) when the op id is already shown.
+   */
+  show(opId: string, targets: readonly ShadowTarget[]): boolean
+  /**
+   * Remove a shadow because the op failed or its send was abandoned
+   * (s3-opt-2/s3-opt-6 policy). Returns the removed shadow, or undefined
+   * (no notification) when the id is not held.
+   */
+  revert(opId: string): PendingShadow | undefined
+  /**
+   * Remove a shadow because its authoritative effect arrived — the KA-9
+   * clear-on-effect path (s3-opt-3). Returns the removed shadow, or
+   * undefined (no notification) when the id is not held.
+   */
+  clear(opId: string): PendingShadow | undefined
+  /**
+   * Drop every shadow (doc_reset / unmount / workflow switch, FEB-5).
+   * Returns the removed shadows in insertion order; no-op on empty.
+   */
+  clearAll(): PendingShadow[]
+  /** True while at least one pending op shadows this entity. */
+  isPending(target: ShadowTarget): boolean
+  /** Deduplicated snapshot of every currently shadowed entity. */
+  pendingTargets(): ShadowTarget[]
+  /** Snapshot of all shadows in insertion order. */
+  pendingShadows(): PendingShadow[]
+  get(opId: string): PendingShadow | undefined
+  size(): number
+  /**
+   * Observe surface changes. The listener runs synchronously after each
+   * mutation that changed state. Returns an unsubscribe function.
+   */
+  subscribe(listener: (change: ShadowChange) => void): () => void
+}
+
+function targetKey(target: ShadowTarget): string {
+  switch (target.kind) {
+    case 'node':
+      return `node:${target.nodeId}`
+    case 'link':
+      return `link:${target.linkId}`
+    case 'widget':
+      return `widget:${target.nodeId}:${target.widgetName}`
+  }
+}
+
+export function createPendingOpShadowSurface(): PendingOpShadowSurface {
+  /** Insertion-ordered by show; op ids are never re-minted or reused. */
+  const shadows = new Map<string, PendingShadow>()
+  /** Refcount of pending ops per target key (several ops may share one). */
+  const targetCounts = new Map<string, number>()
+  /** First-seen target per key, for deduplicated pendingTargets snapshots. */
+  const targetsByKey = new Map<string, ShadowTarget>()
+  const listeners = new Set<(change: ShadowChange) => void>()
+
+  const notify = (change: ShadowChange) => {
+    for (const listener of listeners) listener(change)
+  }
+
+  const retain = (target: ShadowTarget) => {
+    const key = targetKey(target)
+    const count = targetCounts.get(key) ?? 0
+    targetCounts.set(key, count + 1)
+    if (count === 0) targetsByKey.set(key, target)
+  }
+
+  const release = (target: ShadowTarget) => {
+    const key = targetKey(target)
+    const count = targetCounts.get(key) ?? 0
+    if (count <= 1) {
+      targetCounts.delete(key)
+      targetsByKey.delete(key)
+      return
+    }
+    targetCounts.set(key, count - 1)
+  }
+
+  const remove = (opId: string): PendingShadow | undefined => {
+    const shadow = shadows.get(opId)
+    if (!shadow) return undefined
+    shadows.delete(opId)
+    for (const target of shadow.targets) release(target)
+    return shadow
+  }
+
+  return {
+    show(opId, targets) {
+      if (shadows.has(opId)) return false
+      const shadow: PendingShadow = Object.freeze({
+        opId,
+        targets: Object.freeze(targets.map((t) => ({ ...t }) as ShadowTarget))
+      })
+      shadows.set(opId, shadow)
+      for (const target of shadow.targets) retain(target)
+      notify({ type: 'show', opId })
+      return true
+    },
+
+    revert(opId) {
+      const shadow = remove(opId)
+      if (shadow) notify({ type: 'revert', opId })
+      return shadow
+    },
+
+    clear(opId) {
+      const shadow = remove(opId)
+      if (shadow) notify({ type: 'clear', opId })
+      return shadow
+    },
+
+    clearAll() {
+      if (shadows.size === 0) return []
+      const removed = [...shadows.values()]
+      shadows.clear()
+      targetCounts.clear()
+      targetsByKey.clear()
+      notify({ type: 'clear-all', opIds: removed.map((s) => s.opId) })
+      return removed
+    },
+
+    isPending(target) {
+      return targetCounts.has(targetKey(target))
+    },
+
+    pendingTargets() {
+      return [...targetsByKey.values()]
+    },
+
+    pendingShadows() {
+      return [...shadows.values()]
+    },
+
+    get(opId) {
+      return shadows.get(opId)
+    },
+
+    size() {
+      return shadows.size
+    },
+
+    subscribe(listener) {
+      listeners.add(listener)
+      return () => {
+        listeners.delete(listener)
+      }
+    }
+  }
+}

--- a/src/workbench/extensions/agent/crdt/pendingOpShadow.ts
+++ b/src/workbench/extensions/agent/crdt/pendingOpShadow.ts
@@ -109,6 +109,8 @@ function targetKey(target: ShadowTarget): string {
 export function createPendingOpShadowSurface(): PendingOpShadowSurface {
   /** Insertion-ordered by show; op ids are never re-minted or reused. */
   const shadows = new Map<string, PendingShadow>()
+  /** Lifetime uniqueness guard: delayed effects must never hit a replacement. */
+  const seenOpIds = new Set<string>()
   /** Refcount of pending ops per target key (several ops may share one). */
   const targetCounts = new Map<string, number>()
   /** First-seen target per key, for deduplicated pendingTargets snapshots. */
@@ -154,7 +156,7 @@ export function createPendingOpShadowSurface(): PendingOpShadowSurface {
 
   return {
     show(opId, targets) {
-      if (shadows.has(opId)) return false
+      if (seenOpIds.has(opId)) return false
       const shadow: PendingShadow = Object.freeze({
         opId,
         targets: Object.freeze(
@@ -162,6 +164,7 @@ export function createPendingOpShadowSurface(): PendingOpShadowSurface {
         )
       })
       shadows.set(opId, shadow)
+      seenOpIds.add(opId)
       for (const target of shadow.targets) retain(target)
       notify({ type: 'show', opId })
       return true

--- a/src/workbench/extensions/agent/crdt/pendingOpShadow.ts
+++ b/src/workbench/extensions/agent/crdt/pendingOpShadow.ts
@@ -206,9 +206,10 @@ export function createPendingOpShadowSurface(): PendingOpShadowSurface {
     },
 
     subscribe(listener) {
-      listeners.add(listener)
+      const registration = (change: ShadowChange) => listener(change)
+      listeners.add(registration)
       return () => {
-        listeners.delete(listener)
+        listeners.delete(registration)
       }
     }
   }

--- a/src/workbench/extensions/agent/crdt/pendingOpShadow.ts
+++ b/src/workbench/extensions/agent/crdt/pendingOpShadow.ts
@@ -84,7 +84,9 @@ export interface PendingOpShadowSurface {
   size(): number
   /**
    * Observe surface changes. The listener runs synchronously after each
-   * mutation that changed state. Returns an unsubscribe function.
+   * mutation that changed state. Reentrant mutations are delivered
+   * synchronously; listeners added during delivery begin on the next change.
+   * Returns an unsubscribe function.
    */
   subscribe(listener: (change: ShadowChange) => void): () => void
 }

--- a/src/workbench/extensions/agent/crdt/pendingOpShadow.ts
+++ b/src/workbench/extensions/agent/crdt/pendingOpShadow.ts
@@ -99,6 +99,10 @@ function targetKey(target: ShadowTarget): string {
       return `link:${target.linkId}`
     case 'widget':
       return `widget:${encodeURIComponent(target.nodeId)}:${encodeURIComponent(target.widgetName)}`
+    default: {
+      const unsupported: never = target
+      throw new Error(`Unsupported shadow target: ${JSON.stringify(unsupported)}`)
+    }
   }
 }
 

--- a/src/workbench/extensions/agent/crdt/pendingOpShadow.ts
+++ b/src/workbench/extensions/agent/crdt/pendingOpShadow.ts
@@ -101,7 +101,9 @@ function targetKey(target: ShadowTarget): string {
       return `widget:${encodeURIComponent(target.nodeId)}:${encodeURIComponent(target.widgetName)}`
     default: {
       const unsupported: never = target
-      throw new Error(`Unsupported shadow target: ${JSON.stringify(unsupported)}`)
+      throw new Error(
+        `Unsupported shadow target: ${JSON.stringify(unsupported)}`
+      )
     }
   }
 }

--- a/src/workbench/extensions/agent/crdt/pendingOpShadow.ts
+++ b/src/workbench/extensions/agent/crdt/pendingOpShadow.ts
@@ -110,7 +110,14 @@ export function createPendingOpShadowSurface(): PendingOpShadowSurface {
   const listeners = new Set<(change: ShadowChange) => void>()
 
   const notify = (change: ShadowChange) => {
-    for (const listener of listeners) listener(change)
+    for (const listener of [...listeners]) {
+      try {
+        listener(change)
+      } catch {
+        // Presentation observers are isolated: committed shadow state and
+        // later subscribers must not depend on an earlier listener.
+      }
+    }
   }
 
   const retain = (target: ShadowTarget) => {

--- a/src/workbench/extensions/agent/crdt/pendingOpShadow.ts
+++ b/src/workbench/extensions/agent/crdt/pendingOpShadow.ts
@@ -96,7 +96,7 @@ function targetKey(target: ShadowTarget): string {
     case 'link':
       return `link:${target.linkId}`
     case 'widget':
-      return `widget:${target.nodeId}:${target.widgetName}`
+      return `widget:${encodeURIComponent(target.nodeId)}:${encodeURIComponent(target.widgetName)}`
   }
 }
 

--- a/src/workbench/extensions/agent/crdt/pendingOpShadow.ts
+++ b/src/workbench/extensions/agent/crdt/pendingOpShadow.ts
@@ -9,7 +9,8 @@
  *
  * - Presentation ONLY. Shadows never touch Yjs, never feed the applier, and
  *   are never encoded as a Yjs update or merged into the shared doc
- *   (KEEP-ALIVE #9, FORECLOSE #5). The module has zero imports.
+ *   (KEEP-ALIVE #9, FORECLOSE #5). The module's only import is
+ *   `@/base/assert` — a base-layer leaf with no Yjs/DOM/framework coupling.
  * - `show` registers a shadow exactly once per op id — never an overwrite —
  *   mirroring the ledger's enqueue semantics.
  * - `revert(opId)` and `clear(opId)` are the two removal verbs consumed by

--- a/src/workbench/extensions/agent/crdt/pendingOpShadow.ts
+++ b/src/workbench/extensions/agent/crdt/pendingOpShadow.ts
@@ -30,12 +30,22 @@
 
 import { assert } from '@/base/assert'
 
-/** One canvas entity that renders pending styling while an op is in flight. */
+/**
+ * One canvas entity that renders pending styling while an op is in flight.
+ *
+ * `graphId` is the owning (sub)graph uuid, mirroring the `graphId:nodeId:name`
+ * widget-id convention (FE-1904, see `widgetMintPort.ts`). Node/link/widget
+ * ids are graph-LOCAL: two subgraphs can mint the same local node id, so a
+ * shadow key that omits the owning graph collides across subgraphs and
+ * corrupts the refcounted `isPending`/`pendingTargets` index. Every target
+ * must carry the graph that minted its local id.
+ */
 export type ShadowTarget =
-  | { readonly kind: 'node'; readonly nodeId: string }
-  | { readonly kind: 'link'; readonly linkId: string }
+  | { readonly kind: 'node'; readonly graphId: string; readonly nodeId: string }
+  | { readonly kind: 'link'; readonly graphId: string; readonly linkId: string }
   | {
       readonly kind: 'widget'
+      readonly graphId: string
       readonly nodeId: string
       readonly widgetName: string
     }
@@ -95,13 +105,14 @@ export interface PendingOpShadowSurface {
 }
 
 function targetKey(target: ShadowTarget): string {
+  const graphId = encodeURIComponent(target.graphId)
   switch (target.kind) {
     case 'node':
-      return `node:${target.nodeId}`
+      return `node:${graphId}:${encodeURIComponent(target.nodeId)}`
     case 'link':
-      return `link:${target.linkId}`
+      return `link:${graphId}:${encodeURIComponent(target.linkId)}`
     case 'widget':
-      return `widget:${encodeURIComponent(target.nodeId)}:${encodeURIComponent(target.widgetName)}`
+      return `widget:${graphId}:${encodeURIComponent(target.nodeId)}:${encodeURIComponent(target.widgetName)}`
     default: {
       const unsupported: never = target
       assert(false, `Unsupported shadow target: ${JSON.stringify(unsupported)}`)
@@ -112,12 +123,21 @@ function targetKey(target: ShadowTarget): string {
 function cloneTarget(target: ShadowTarget): ShadowTarget {
   switch (target.kind) {
     case 'node':
-      return Object.freeze({ kind: 'node', nodeId: target.nodeId })
+      return Object.freeze({
+        kind: 'node',
+        graphId: target.graphId,
+        nodeId: target.nodeId
+      })
     case 'link':
-      return Object.freeze({ kind: 'link', linkId: target.linkId })
+      return Object.freeze({
+        kind: 'link',
+        graphId: target.graphId,
+        linkId: target.linkId
+      })
     case 'widget':
       return Object.freeze({
         kind: 'widget',
+        graphId: target.graphId,
         nodeId: target.nodeId,
         widgetName: target.widgetName
       })

--- a/src/workbench/extensions/agent/crdt/pendingOpShadow.ts
+++ b/src/workbench/extensions/agent/crdt/pendingOpShadow.ts
@@ -106,6 +106,21 @@ function targetKey(target: ShadowTarget): string {
   }
 }
 
+function cloneTarget(target: ShadowTarget): ShadowTarget {
+  switch (target.kind) {
+    case 'node':
+      return Object.freeze({ kind: 'node', nodeId: target.nodeId })
+    case 'link':
+      return Object.freeze({ kind: 'link', linkId: target.linkId })
+    case 'widget':
+      return Object.freeze({
+        kind: 'widget',
+        nodeId: target.nodeId,
+        widgetName: target.widgetName
+      })
+  }
+}
+
 export function createPendingOpShadowSurface(): PendingOpShadowSurface {
   /** Insertion-ordered by show; op ids are never re-minted or reused. */
   const shadows = new Map<string, PendingShadow>()
@@ -159,9 +174,7 @@ export function createPendingOpShadowSurface(): PendingOpShadowSurface {
       if (seenOpIds.has(opId)) return false
       const shadow: PendingShadow = Object.freeze({
         opId,
-        targets: Object.freeze(
-          targets.map((target) => Object.freeze({ ...target }) as ShadowTarget)
-        )
+        targets: Object.freeze(targets.map(cloneTarget))
       })
       shadows.set(opId, shadow)
       seenOpIds.add(opId)

--- a/src/workbench/extensions/agent/crdt/pendingOpShadow.ts
+++ b/src/workbench/extensions/agent/crdt/pendingOpShadow.ts
@@ -144,7 +144,9 @@ export function createPendingOpShadowSurface(): PendingOpShadowSurface {
       if (shadows.has(opId)) return false
       const shadow: PendingShadow = Object.freeze({
         opId,
-        targets: Object.freeze(targets.map((t) => ({ ...t }) as ShadowTarget))
+        targets: Object.freeze(
+          targets.map((target) => Object.freeze({ ...target }) as ShadowTarget)
+        )
       })
       shadows.set(opId, shadow)
       for (const target of shadow.targets) retain(target)

--- a/src/workbench/extensions/agent/crdt/pendingOpShadow.ts
+++ b/src/workbench/extensions/agent/crdt/pendingOpShadow.ts
@@ -121,6 +121,10 @@ function cloneTarget(target: ShadowTarget): ShadowTarget {
         nodeId: target.nodeId,
         widgetName: target.widgetName
       })
+    default: {
+      const unsupported: never = target
+      assert(false, `Unsupported shadow target: ${JSON.stringify(unsupported)}`)
+    }
   }
 }
 

--- a/src/workbench/extensions/agent/crdt/pendingOpShadow.ts
+++ b/src/workbench/extensions/agent/crdt/pendingOpShadow.ts
@@ -27,6 +27,8 @@
  *   queries. No timers, no clocks, no IO.
  */
 
+import { assert } from '@/base/assert'
+
 /** One canvas entity that renders pending styling while an op is in flight. */
 export type ShadowTarget =
   | { readonly kind: 'node'; readonly nodeId: string }
@@ -101,9 +103,7 @@ function targetKey(target: ShadowTarget): string {
       return `widget:${encodeURIComponent(target.nodeId)}:${encodeURIComponent(target.widgetName)}`
     default: {
       const unsupported: never = target
-      throw new Error(
-        `Unsupported shadow target: ${JSON.stringify(unsupported)}`
-      )
+      assert(false, `Unsupported shadow target: ${JSON.stringify(unsupported)}`)
     }
   }
 }


### PR DESCRIPTION
- Presentation-only shadow surface for pending local ops — never touches Yjs
- Keyed by minted op_id; `revert` (failure) vs `clear` (effect landed) are distinct events
- 11 tests incl. a source-level zero-import guard; green: vitest, vue-tsc, eslint, oxfmt, knip

## What

New pure module `src/workbench/extensions/agent/crdt/pendingOpShadow.ts` plus tests. `createPendingOpShadowSurface()` is a factory holding presentation-only snapshots ("shadows") of targets affected by pending local ops, so the UI can show optimistic state while the op is in flight, without writing anything into the shared document.

## Why

Slice 3 of the optimistic-overlay decomposition needs a place where the panel can render "this node/link/widget is about to change" that:

1. is keyed by the minted op_id (one shadow per op, exactly-once `show`),
2. can be dropped on failure (`revert`), on effect-landed (`clear`), or wholesale on doc reset/unmount (`clearAll`),
3. never mutates or reads Yjs — the shared doc remains the single source of truth; shadows are derived, throwaway view state.

`revert` and `clear` perform the identical mutation but emit distinct `ShadowChange` events so consumers (upcoming slices s3-opt-2/s3-opt-3) can animate failure differently from success.

## Boundaries honored

- **KA-2** — shadows keyed by minted op_id.
- **KA-9** — clearing on effect-landed path; no doc writes.
- **FEB-5** — `clearAll` drops everything on doc_reset/unmount; no-op (no notify) when already empty.
- **FORECLOSE #5** — module has zero imports; a test reads the module source and asserts no `^import` lines and no yjs reference, so a future import regression fails CI.

## Surface

```diagram
┌──────────────┐  show(opId, targets)   ┌─────────────────────┐
│  op minting  │───────────────────────▶│  PendingOpShadow    │
│  (s3-opt-1)  │                        │  ┌───────────────┐  │
└──────────────┘                        │  │ opId → frozen │  │
┌──────────────┐  revert(opId) failure  │  │   snapshots   │  │
│ ack/failure  │───────────────────────▶│  └───────────────┘  │
│  handling    │  clear(opId)  landed   │  refcounted target  │
└──────────────┘                        │  index (isPending)  │
┌──────────────┐  clearAll()            └──────────┬──────────┘
│ doc_reset /  │───────────────────────▶           │ subscribe
│  unmount     │                                   ▼
└──────────────┘                        ┌─────────────────────┐
                                        │ overlay renderers   │
                                        │ (s3-opt-2/s3-opt-3) │
                                        └─────────────────────┘
```

- `show(opId, targets)` — exactly-once per opId; snapshots are copied and frozen.
- `revert(opId)` / `clear(opId)` — same removal, distinct event verbs.
- `clearAll()` — bulk drop, single event, no-op when empty.
- `isPending(target)`, `pendingTargets()` — refcounted index (two ops shadowing the same node keep it pending until both resolve).
- `pendingShadows()`, `get(opId)`, `size()` — inspection.
- `subscribe(listener)` — synchronous pull-model; returns unsubscribe.

## Verification

- `pnpm vitest run src/workbench/extensions/agent/crdt/` — 75/75 (11 new)
- `pnpm typecheck` (vue-tsc) — clean
- `pnpm exec eslint` / `oxfmt --check` on both files — clean
- pre-push `knip --cache` — clean

## Glossary

- **op_id** — unique id minted for each local op before dispatch (slice s3-opt-1, PR #16288).
- **shadow** — frozen presentation-only snapshot of a target (node/link/widget) affected by a pending op.
- **KA-2 / KA-9 / FEB-5** — keep-alive/boundary invariants from the overlay decomposition report: op_id keying, no-Yjs-writes on effect path, drop-all on doc reset.
- **FORECLOSE #5** — foreclosed design option: the shadow layer must not couple to Yjs (zero imports enforced by test).
- **s3-opt-N** — slice IDs from the optimistic-overlay decomposition (slice 3 of the CRDT overlay plan).
