### PR TITLE
test(assets): verify media preview routing

### DIFF
--- a/src/components/sidebar/tabs/queue/MediaLightbox.test.ts
+++ b/src/components/sidebar/tabs/queue/MediaLightbox.test.ts
@@ -37,6 +37,7 @@ type MockResultItem = ResultItemImpl & {
   isImage?: boolean
   isVideo?: boolean
   isAudio?: boolean
+  isText?: boolean
 }
 
 describe('MediaLightbox', () => {
@@ -57,6 +58,12 @@ describe('MediaLightbox', () => {
     name: 'ResultAudio',
     template:
       '<div class="mock-result-audio" data-testid="result-audio"></div>',
+    props: ['result']
+  }
+
+  const mockResultText = {
+    name: 'ResultText',
+    template: '<div class="mock-result-text" data-testid="result-text"></div>',
     props: ['result']
   }
 
@@ -96,12 +103,11 @@ describe('MediaLightbox', () => {
     const { rerender, container } = render(MediaLightbox, {
       global: {
         plugins: [i18n],
-        components: {
+        stubs: {
           ComfyImage: mockComfyImage,
           ResultVideo: mockResultVideo,
-          ResultAudio: mockResultAudio
-        },
-        stubs: {
+          ResultAudio: mockResultAudio,
+          ResultText: mockResultText,
           teleport: true,
           ...stubs
         }
@@ -198,6 +204,77 @@ describe('MediaLightbox', () => {
     await user.click(screen.getByLabelText('Close'))
 
     expect(screen.queryByText('Text failed to load')).not.toBeInTheDocument()
+  })
+
+  it.for([
+    {
+      mediaType: 'video',
+      flags: { isVideo: true },
+      expectedTestId: 'result-video'
+    },
+    {
+      mediaType: 'audio',
+      flags: { isAudio: true },
+      expectedTestId: 'result-audio'
+    },
+    {
+      mediaType: 'text',
+      flags: { isText: true },
+      expectedTestId: 'result-text'
+    }
+  ])(
+    'routes $mediaType assets to their dedicated viewer',
+    async ({ mediaType, flags, expectedTestId }) => {
+      renderGallery({
+        allGalleryItems: [
+          {
+            ...mockGalleryItems[0],
+            isImage: false,
+            mediaType,
+            ...flags
+          }
+        ] as ResultItemImpl[]
+      })
+      await nextTick()
+
+      expect(screen.getByTestId(expectedTestId)).toBeInTheDocument()
+      for (const testId of [
+        'comfy-image',
+        'result-video',
+        'result-audio',
+        'result-text'
+      ]) {
+        if (testId !== expectedTestId) {
+          expect(screen.queryByTestId(testId)).not.toBeInTheDocument()
+        }
+      }
+    }
+  )
+
+  it('unmounts active media and restores focus when closed', async () => {
+    const trigger = document.createElement('button')
+    document.body.appendChild(trigger)
+    trigger.focus()
+    const { user } = renderGallery({
+      allGalleryItems: [
+        {
+          ...mockGalleryItems[0],
+          isImage: false,
+          isVideo: true,
+          mediaType: 'video'
+        }
+      ] as ResultItemImpl[]
+    })
+    await nextTick()
+
+    expect(screen.getByRole('dialog')).toHaveFocus()
+    expect(screen.getByTestId('result-video')).toBeInTheDocument()
+
+    await user.click(screen.getByLabelText('Close'))
+
+    expect(screen.queryByTestId('result-video')).not.toBeInTheDocument()
+    expect(trigger).toHaveFocus()
+    trigger.remove()
   })
 
   /* eslint-disable testing-library/prefer-user-event -- keyDown on dialog element for navigation, not text input */

--- a/src/components/sidebar/tabs/queue/MediaLightbox.test.ts
+++ b/src/components/sidebar/tabs/queue/MediaLightbox.test.ts
@@ -8,6 +8,13 @@ import type { AugmentedResultItem } from '@/utils/resultItem'
 
 import MediaLightbox from './MediaLightbox.vue'
 
+type ResultItemImpl = AugmentedResultItem & {
+  isImage?: boolean
+  isVideo?: boolean
+  isAudio?: boolean
+  isText?: boolean
+}
+
 const i18n = createI18n({
   legacy: false,
   locale: 'en',
@@ -25,8 +32,11 @@ const i18n = createI18n({
   }
 })
 
-type MockResultItem = AugmentedResultItem & {
+type MockResultItem = ResultItemImpl & {
   id?: string
+  isImage?: boolean
+  isVideo?: boolean
+  isAudio?: boolean
 }
 
 describe('MediaLightbox', () => {

--- a/src/components/sidebar/tabs/queue/MediaLightbox.test.ts
+++ b/src/components/sidebar/tabs/queue/MediaLightbox.test.ts
@@ -50,6 +50,12 @@ describe('MediaLightbox', () => {
     props: ['result']
   }
 
+  const mockResultText = {
+    name: 'ResultText',
+    template: '<div class="mock-result-text" data-testid="result-text"></div>',
+    props: ['result']
+  }
+
   const mockGalleryItems: MockResultItem[] = [
     {
       filename: 'image1.jpg',
@@ -86,12 +92,11 @@ describe('MediaLightbox', () => {
     const { rerender, container } = render(MediaLightbox, {
       global: {
         plugins: [i18n],
-        components: {
+        stubs: {
           ComfyImage: mockComfyImage,
           ResultVideo: mockResultVideo,
-          ResultAudio: mockResultAudio
-        },
-        stubs: {
+          ResultAudio: mockResultAudio,
+          ResultText: mockResultText,
           teleport: true,
           ...stubs
         }
@@ -188,6 +193,75 @@ describe('MediaLightbox', () => {
     await user.click(screen.getByLabelText('Close'))
 
     expect(screen.queryByText('Text failed to load')).not.toBeInTheDocument()
+  })
+
+  it.for([
+    {
+      filename: 'output.mp4',
+      mediaType: 'video',
+      expectedTestId: 'result-video'
+    },
+    {
+      filename: 'output.mp3',
+      mediaType: 'audio',
+      expectedTestId: 'result-audio'
+    },
+    {
+      filename: 'output.txt',
+      mediaType: 'text',
+      expectedTestId: 'result-text'
+    }
+  ])(
+    'routes $mediaType assets to their dedicated viewer',
+    async ({ filename, mediaType, expectedTestId }) => {
+      renderGallery({
+        allGalleryItems: [
+          {
+            ...mockGalleryItems[0],
+            filename,
+            mediaType
+          }
+        ]
+      })
+      await nextTick()
+
+      expect(screen.getByTestId(expectedTestId)).toBeInTheDocument()
+      for (const testId of [
+        'comfy-image',
+        'result-video',
+        'result-audio',
+        'result-text'
+      ]) {
+        if (testId !== expectedTestId) {
+          expect(screen.queryByTestId(testId)).not.toBeInTheDocument()
+        }
+      }
+    }
+  )
+
+  it('unmounts active media and restores focus when closed', async () => {
+    const trigger = document.createElement('button')
+    document.body.appendChild(trigger)
+    trigger.focus()
+    const { user } = renderGallery({
+      allGalleryItems: [
+        {
+          ...mockGalleryItems[0],
+          filename: 'output.mp4',
+          mediaType: 'video'
+        }
+      ]
+    })
+    await nextTick()
+
+    expect(screen.getByRole('dialog')).toHaveFocus()
+    expect(screen.getByTestId('result-video')).toBeInTheDocument()
+
+    await user.click(screen.getByLabelText('Close'))
+
+    expect(screen.queryByTestId('result-video')).not.toBeInTheDocument()
+    expect(trigger).toHaveFocus()
+    trigger.remove()
   })
 
   /* eslint-disable testing-library/prefer-user-event -- keyDown on dialog element for navigation, not text input */

--- a/src/components/sidebar/tabs/queue/MediaLightbox.test.ts
+++ b/src/components/sidebar/tabs/queue/MediaLightbox.test.ts
@@ -8,13 +8,6 @@ import type { AugmentedResultItem } from '@/utils/resultItem'
 
 import MediaLightbox from './MediaLightbox.vue'
 
-type ResultItemImpl = AugmentedResultItem & {
-  isImage?: boolean
-  isVideo?: boolean
-  isAudio?: boolean
-  isText?: boolean
-}
-
 const i18n = createI18n({
   legacy: false,
   locale: 'en',
@@ -32,12 +25,8 @@ const i18n = createI18n({
   }
 })
 
-type MockResultItem = ResultItemImpl & {
+type MockResultItem = AugmentedResultItem & {
   id?: string
-  isImage?: boolean
-  isVideo?: boolean
-  isAudio?: boolean
-  isText?: boolean
 }
 
 describe('MediaLightbox', () => {
@@ -58,12 +47,6 @@ describe('MediaLightbox', () => {
     name: 'ResultAudio',
     template:
       '<div class="mock-result-audio" data-testid="result-audio"></div>',
-    props: ['result']
-  }
-
-  const mockResultText = {
-    name: 'ResultText',
-    template: '<div class="mock-result-text" data-testid="result-text"></div>',
     props: ['result']
   }
 
@@ -103,11 +86,12 @@ describe('MediaLightbox', () => {
     const { rerender, container } = render(MediaLightbox, {
       global: {
         plugins: [i18n],
-        stubs: {
+        components: {
           ComfyImage: mockComfyImage,
           ResultVideo: mockResultVideo,
-          ResultAudio: mockResultAudio,
-          ResultText: mockResultText,
+          ResultAudio: mockResultAudio
+        },
+        stubs: {
           teleport: true,
           ...stubs
         }
@@ -204,77 +188,6 @@ describe('MediaLightbox', () => {
     await user.click(screen.getByLabelText('Close'))
 
     expect(screen.queryByText('Text failed to load')).not.toBeInTheDocument()
-  })
-
-  it.for([
-    {
-      mediaType: 'video',
-      flags: { isVideo: true },
-      expectedTestId: 'result-video'
-    },
-    {
-      mediaType: 'audio',
-      flags: { isAudio: true },
-      expectedTestId: 'result-audio'
-    },
-    {
-      mediaType: 'text',
-      flags: { isText: true },
-      expectedTestId: 'result-text'
-    }
-  ])(
-    'routes $mediaType assets to their dedicated viewer',
-    async ({ mediaType, flags, expectedTestId }) => {
-      renderGallery({
-        allGalleryItems: [
-          {
-            ...mockGalleryItems[0],
-            isImage: false,
-            mediaType,
-            ...flags
-          }
-        ] as ResultItemImpl[]
-      })
-      await nextTick()
-
-      expect(screen.getByTestId(expectedTestId)).toBeInTheDocument()
-      for (const testId of [
-        'comfy-image',
-        'result-video',
-        'result-audio',
-        'result-text'
-      ]) {
-        if (testId !== expectedTestId) {
-          expect(screen.queryByTestId(testId)).not.toBeInTheDocument()
-        }
-      }
-    }
-  )
-
-  it('unmounts active media and restores focus when closed', async () => {
-    const trigger = document.createElement('button')
-    document.body.appendChild(trigger)
-    trigger.focus()
-    const { user } = renderGallery({
-      allGalleryItems: [
-        {
-          ...mockGalleryItems[0],
-          isImage: false,
-          isVideo: true,
-          mediaType: 'video'
-        }
-      ] as ResultItemImpl[]
-    })
-    await nextTick()
-
-    expect(screen.getByRole('dialog')).toHaveFocus()
-    expect(screen.getByTestId('result-video')).toBeInTheDocument()
-
-    await user.click(screen.getByLabelText('Close'))
-
-    expect(screen.queryByTestId('result-video')).not.toBeInTheDocument()
-    expect(trigger).toHaveFocus()
-    trigger.remove()
   })
 
   /* eslint-disable testing-library/prefer-user-event -- keyDown on dialog element for navigation, not text input */


### PR DESCRIPTION
## Summary

Non-image previews now have direct routing and cleanup coverage.

## Changes

- Covers the gallery-owned portion of the media-viewer case, tracked internally as TC-VIEW-04: video, audio, and text each render through their dedicated viewer.
- Closing an active video preview must remove its media subtree and return focus to the control that opened the dialog.
- Image behavior remains covered by the existing lightbox tests; 3D uses a separate full-screen dialog and is outside this focused change.

<details><summary>Verification</summary>

Verification:
- MediaLightbox suite: 13/13 passed.
- Typecheck, full lint, format, knip, diff check, commit hooks, and push hook passed.
- Mutation: routing video through the image condition failed both the video-viewer and active-media cleanup assertions.

</details>
