### PR TITLE
feat(graph): reduce crossings in arranged workflows

### DIFF
--- a/src/lib/litegraph/src/LGraph.arrange.test.ts
+++ b/src/lib/litegraph/src/LGraph.arrange.test.ts
@@ -1,0 +1,206 @@
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { LGraph, LGraphNode, LiteGraph } from '@/lib/litegraph/src/litegraph'
+
+beforeEach(() => setActivePinia(createTestingPinia({ stubActions: false })))
+
+function createNode(title: string, position: [number, number]): LGraphNode {
+  const node = new LGraphNode(title)
+  node.addInput('in', '*')
+  node.addOutput('out', '*')
+  node.setPos(...position)
+  node.setSize([140, 80])
+  return node
+}
+
+function createCrossedGraph() {
+  const graph = new LGraph()
+  const sourceA = createNode('Source A', [0, 0])
+  const sourceB = createNode('Source B', [0, 200])
+  const sourceC = createNode('Source C', [0, 400])
+  const targetA = createNode('Target A', [500, 0])
+  const targetB = createNode('Target B', [500, 200])
+  targetA.addInput('in 2', '*')
+  for (const node of [sourceA, sourceB, sourceC, targetA, targetB])
+    graph.add(node)
+  sourceA.connect(0, targetA, 0)
+  sourceC.connect(0, targetA, 1)
+  sourceB.connect(0, targetB, 0)
+  return { graph, sourceA, sourceB, sourceC, targetA, targetB }
+}
+
+describe('LGraph.arrange', () => {
+  it('orders connected branches to remove avoidable crossings', () => {
+    const { graph, sourceA, sourceB, sourceC, targetA, targetB } =
+      createCrossedGraph()
+
+    graph.arrange()
+
+    expect(sourceB.pos[1]).toBeLessThan(sourceA.pos[1])
+    expect(sourceA.pos[1]).toBeLessThan(sourceC.pos[1])
+    expect(targetB.pos[1]).toBeLessThan(targetA.pos[1])
+    expect(targetA.pos[0]).toBeGreaterThan(sourceA.pos[0])
+  })
+
+  it('produces a stable layout when arranged repeatedly', () => {
+    const { graph } = createCrossedGraph()
+
+    graph.arrange()
+    const firstLayout = graph.nodes.map((node) => [...node.pos])
+    graph.arrange()
+
+    expect(graph.nodes.map((node) => [...node.pos])).toEqual(firstLayout)
+  })
+
+  it('keeps disconnected nodes in their original layer slot', () => {
+    const graph = new LGraph()
+    const sourceA = createNode('Source A', [0, 0])
+    const note = createNode('Disconnected note', [0, 100])
+    const sourceB = createNode('Source B', [0, 200])
+    const sourceC = createNode('Source C', [0, 400])
+    const targetA = createNode('Target A', [500, 0])
+    const targetB = createNode('Target B', [500, 200])
+    targetA.addInput('in 2', '*')
+    for (const node of [sourceA, note, sourceB, sourceC, targetA, targetB])
+      graph.add(node)
+    sourceA.connect(0, targetA, 0)
+    sourceC.connect(0, targetA, 1)
+    sourceB.connect(0, targetB, 0)
+
+    graph.arrange()
+
+    const firstLayer = [sourceA, note, sourceB, sourceC].sort(
+      (left, right) => left.pos[1] - right.pos[1]
+    )
+    expect(firstLayer[1]).toBe(note)
+  })
+
+  it('preserves the existing order when the graph is already crossing-free', () => {
+    const graph = new LGraph()
+    const sourceA = createNode('Source A', [0, 0])
+    const sourceB = createNode('Source B', [0, 200])
+    const targetA = createNode('Target A', [500, 0])
+    const targetB = createNode('Target B', [500, 200])
+    for (const node of [sourceA, sourceB, targetA, targetB]) graph.add(node)
+    sourceA.connect(0, targetA, 0)
+    sourceB.connect(0, targetB, 0)
+
+    graph.arrange()
+
+    expect(sourceA.pos[1]).toBeLessThan(sourceB.pos[1])
+    expect(targetA.pos[1]).toBeLessThan(targetB.pos[1])
+  })
+
+  it('keeps an existing branch stable when another branch is added', () => {
+    const graph = new LGraph()
+    const firstSource = createNode('First source', [0, 0])
+    const firstProcess = createNode('First process', [0, 0])
+    const firstOutput = createNode('First output', [0, 0])
+    for (const node of [firstSource, firstProcess, firstOutput]) graph.add(node)
+    firstSource.connect(0, firstProcess, 0)
+    firstProcess.connect(0, firstOutput, 0)
+    graph.arrange()
+    const firstBranchPositions = [firstSource, firstProcess, firstOutput].map(
+      (node) => [...node.pos]
+    )
+
+    const secondSource = createNode('Second source', [0, 0])
+    const secondProcess = createNode('Second process', [0, 0])
+    const secondOutput = createNode('Second output', [0, 0])
+    for (const node of [secondSource, secondProcess, secondOutput])
+      graph.add(node)
+    secondSource.connect(0, secondProcess, 0)
+    secondProcess.connect(0, secondOutput, 0)
+    graph.arrange()
+
+    expect(
+      [firstSource, firstProcess, firstOutput].map((node) => [...node.pos])
+    ).toEqual(firstBranchPositions)
+    expect(secondSource.pos[1]).toBeGreaterThan(firstSource.pos[1])
+    expect(secondProcess.pos[1]).toBeGreaterThan(firstProcess.pos[1])
+    expect(secondOutput.pos[1]).toBeGreaterThan(firstOutput.pos[1])
+  })
+
+  it('counts crossings between skip links and adjacent-layer links', () => {
+    const graph = new LGraph()
+    const skipSource = createNode('Skip source', [0, 0])
+    const fillerSource = createNode('Filler source', [0, 0])
+    const shortSource = createNode('Short source', [0, 0])
+    const lowerSource = createNode('Lower source', [0, 0])
+    const filler = createNode('Filler', [0, 0])
+    const shortOrigin = createNode('Short origin', [0, 0])
+    const lowerOrigin = createNode('Lower origin', [0, 0])
+    const upperTarget = createNode('Upper target', [0, 0])
+    const lowerTarget = createNode('Lower target', [0, 0])
+    lowerTarget.addInput('skip', '*')
+    for (const node of [
+      skipSource,
+      fillerSource,
+      shortSource,
+      lowerSource,
+      filler,
+      shortOrigin,
+      lowerOrigin,
+      upperTarget,
+      lowerTarget
+    ])
+      graph.add(node)
+    skipSource.connect(0, lowerTarget, 1)
+    fillerSource.connect(0, filler, 0)
+    shortSource.connect(0, shortOrigin, 0)
+    lowerSource.connect(0, lowerOrigin, 0)
+    shortOrigin.connect(0, upperTarget, 0)
+    lowerOrigin.connect(0, lowerTarget, 0)
+
+    graph.arrange()
+
+    expect(fillerSource.pos[1]).toBeLessThan(skipSource.pos[1])
+    expect(shortOrigin.pos[1]).toBeLessThan(lowerOrigin.pos[1])
+    expect(upperTarget.pos[1]).toBeLessThan(lowerTarget.pos[1])
+  })
+
+  it('keeps heterogeneous nodes separated within a layer', () => {
+    const graph = new LGraph()
+    const first = createNode('First', [0, 0])
+    const second = createNode('Second', [0, 20])
+    first.setSize([200, 260])
+    second.setSize([120, 60])
+    graph.add(first)
+    graph.add(second)
+
+    graph.arrange(40)
+
+    expect(second.pos[1] - first.pos[1]).toBe(
+      first.size[1] + 40 + LiteGraph.NODE_TITLE_HEIGHT
+    )
+  })
+
+  it('applies the same crossing reduction to vertical layouts', () => {
+    const { graph, sourceA, sourceB, sourceC, targetA, targetB } =
+      createCrossedGraph()
+
+    graph.arrange(80, LiteGraph.VERTICAL_LAYOUT)
+
+    expect(sourceB.pos[0]).toBeLessThan(sourceA.pos[0])
+    expect(sourceA.pos[0]).toBeLessThan(sourceC.pos[0])
+    expect(targetB.pos[0]).toBeLessThan(targetA.pos[0])
+    expect(targetA.pos[1]).toBeGreaterThan(sourceA.pos[1])
+  })
+
+  it('lays out cyclic nodes without overlapping them', () => {
+    const graph = new LGraph()
+    const first = createNode('First', [0, 0])
+    const second = createNode('Second', [0, 0])
+    graph.add(first)
+    graph.add(second)
+    first.connect(0, second, 0)
+    second.connect(0, first, 0)
+
+    graph.arrange()
+
+    expect(first.pos).not.toEqual(second.pos)
+    expect(first.pos[0]).toBe(second.pos[0])
+  })
+})

--- a/src/lib/litegraph/src/LGraph.ts
+++ b/src/lib/litegraph/src/LGraph.ts
@@ -80,6 +80,7 @@ import {
   beginNamedValuesShadowDiffLoad,
   endNamedValuesShadowDiffLoad
 } from './utils/namedValuesShadowDiffTelemetry'
+import { computeLayeredGraphLayout } from './utils/layeredGraphLayout'
 
 import type { DragAndScaleState } from './DragAndScale'
 import { LGraphCanvas } from './LGraphCanvas'
@@ -1110,34 +1111,12 @@ export class LGraph
     margin = margin || 100
 
     const nodes = this.computeExecutionOrder(false, true)
-    const columns: LGraphNode[][] = []
-    for (const node of nodes) {
-      const col = node._level || 1
-      columns[col] ||= []
-      columns[col].push(node)
-    }
-
-    let x = margin
-
-    for (const column of columns) {
-      if (!column) continue
-
-      let max_size = 100
-      let y = margin + LiteGraph.NODE_TITLE_HEIGHT
-      for (const node of column) {
-        node.setPos(
-          layout == LiteGraph.VERTICAL_LAYOUT ? y : x,
-          layout == LiteGraph.VERTICAL_LAYOUT ? x : y
-        )
-        const max_size_index = layout == LiteGraph.VERTICAL_LAYOUT ? 1 : 0
-        if (node.size[max_size_index] > max_size) {
-          max_size = node.size[max_size_index]
-        }
-        const node_size_index = layout == LiteGraph.VERTICAL_LAYOUT ? 0 : 1
-        y += node.size[node_size_index] + margin + LiteGraph.NODE_TITLE_HEIGHT
-      }
-      x += max_size + margin
-    }
+    const positions = computeLayeredGraphLayout(nodes, this.links.values(), {
+      margin,
+      titleHeight: LiteGraph.NODE_TITLE_HEIGHT,
+      vertical: layout == LiteGraph.VERTICAL_LAYOUT
+    })
+    for (const { node, newPos } of positions) node.setPos(newPos.x, newPos.y)
 
     this.setDirtyCanvas(true, true)
   }

--- a/src/lib/litegraph/src/utils/layeredGraphLayout.ts
+++ b/src/lib/litegraph/src/utils/layeredGraphLayout.ts
@@ -1,0 +1,261 @@
+import type { LGraphNode } from '../LGraphNode'
+import type { LLink } from '../LLink'
+import type { NewNodePosition } from '../interfaces'
+
+interface LayeredGraphLayoutOptions {
+  margin: number
+  titleHeight: number
+  vertical: boolean
+}
+
+interface GraphTopology {
+  predecessors: Map<LGraphNode['id'], LGraphNode[]>
+  successors: Map<LGraphNode['id'], LGraphNode[]>
+  edges: GraphEdge[]
+}
+
+interface GraphEdge {
+  origin: LGraphNode
+  target: LGraphNode
+  originLayer: number
+  targetLayer: number
+}
+
+interface LayerBoundarySegment {
+  startOrder: number
+  endOrder: number
+}
+
+function buildTopology(
+  nodes: readonly LGraphNode[],
+  links: Iterable<LLink>,
+  layerByNode: ReadonlyMap<LGraphNode['id'], number>
+): GraphTopology {
+  const nodeById = new Map(nodes.map((node) => [node.id, node]))
+  const predecessors = new Map(
+    nodes.map((node) => [node.id, [] as LGraphNode[]])
+  )
+  const successors = new Map(nodes.map((node) => [node.id, [] as LGraphNode[]]))
+  const edges: GraphEdge[] = []
+
+  for (const link of links) {
+    const origin = nodeById.get(link.origin_id)
+    const target = nodeById.get(link.target_id)
+    if (!origin || !target) continue
+    const originLayer = layerByNode.get(origin.id) ?? 1
+    const targetLayer = layerByNode.get(target.id) ?? 1
+    if (originLayer >= targetLayer) continue
+    predecessors.get(target.id)?.push(origin)
+    successors.get(origin.id)?.push(target)
+    edges.push({ origin, target, originLayer, targetLayer })
+  }
+
+  return { predecessors, successors, edges }
+}
+
+function barycenter(
+  nodes: readonly LGraphNode[],
+  order: ReadonlyMap<LGraphNode['id'], number>
+): number {
+  let sum = 0
+  let count = 0
+  for (const node of nodes) {
+    const position = order.get(node.id)
+    if (position === undefined) continue
+    sum += position
+    count++
+  }
+  return count === 0 ? Number.POSITIVE_INFINITY : sum / count
+}
+
+function reorderLayer(
+  nodes: LGraphNode[],
+  adjacent: (node: LGraphNode) => readonly LGraphNode[],
+  order: ReadonlyMap<LGraphNode['id'], number>
+): void {
+  const entries = nodes.map((node, index) => ({
+    adjacent: adjacent(node),
+    node,
+    previousOrder: index
+  }))
+  const connected = entries.filter(({ adjacent }) => adjacent.length > 0)
+  connected.sort((left, right) => {
+    const leftCenter = barycenter(left.adjacent, order)
+    const rightCenter = barycenter(right.adjacent, order)
+    if (leftCenter !== rightCenter) return leftCenter - rightCenter
+    return left.previousOrder - right.previousOrder
+  })
+
+  let connectedIndex = 0
+  for (const [index, entry] of entries.entries()) {
+    // A node with no neighbours in this sweep has no evidence-based position.
+    // Keep its slot instead of pushing notes and incomplete branches aside.
+    if (entry.adjacent.length === 0) continue
+    nodes[index] = connected[connectedIndex++].node
+  }
+}
+
+function addToFenwick(tree: number[], index: number): void {
+  for (let cursor = index + 1; cursor < tree.length; cursor += cursor & -cursor)
+    tree[cursor]++
+}
+
+function queryFenwick(tree: readonly number[], index: number): number {
+  let total = 0
+  for (let cursor = index + 1; cursor > 0; cursor -= cursor & -cursor)
+    total += tree[cursor] ?? 0
+  return total
+}
+
+function crossingCount(
+  edges: readonly GraphEdge[],
+  order: ReadonlyMap<LGraphNode['id'], number>
+): number {
+  const segmentsByBoundary = new Map<number, LayerBoundarySegment[]>()
+  for (const edge of edges) {
+    const originOrder = order.get(edge.origin.id) ?? 0
+    const targetOrder = order.get(edge.target.id) ?? 0
+    const layerSpan = edge.targetLayer - edge.originLayer
+    // Split skip links into virtual straight segments so links with different
+    // spans still share a crossing score at each layer boundary.
+    for (
+      let boundary = edge.originLayer;
+      boundary < edge.targetLayer;
+      boundary++
+    ) {
+      const startProgress = (boundary - edge.originLayer) / layerSpan
+      const endProgress = (boundary + 1 - edge.originLayer) / layerSpan
+      const segment = {
+        startOrder: originOrder + startProgress * (targetOrder - originOrder),
+        endOrder: originOrder + endProgress * (targetOrder - originOrder)
+      }
+      const segments = segmentsByBoundary.get(boundary)
+      if (segments) segments.push(segment)
+      else segmentsByBoundary.set(boundary, [segment])
+    }
+  }
+
+  let crossings = 0
+  for (const segments of segmentsByBoundary.values()) {
+    segments.sort(
+      (left, right) =>
+        left.startOrder - right.startOrder || left.endOrder - right.endOrder
+    )
+    const orderedEnds = [
+      ...new Set(segments.map(({ endOrder }) => endOrder))
+    ].sort((left, right) => left - right)
+    const endRank = new Map(orderedEnds.map((value, index) => [value, index]))
+    const tree = new Array<number>(orderedEnds.length + 1).fill(0)
+    let processed = 0
+    for (let start = 0; start < segments.length;) {
+      const startOrder = segments[start].startOrder
+      let end = start
+      // Query equal starts as one batch, and use an inclusive end sum, so
+      // fan-out and fan-in links do not count as crossing each other.
+      while (end < segments.length && segments[end].startOrder === startOrder) {
+        const targetRank = endRank.get(segments[end].endOrder) ?? 0
+        crossings += processed - queryFenwick(tree, targetRank)
+        end++
+      }
+      for (let index = start; index < end; index++)
+        addToFenwick(tree, endRank.get(segments[index].endOrder) ?? 0)
+      processed += end - start
+      start = end
+    }
+  }
+  return crossings
+}
+
+function reduceCrossings(
+  layers: Map<number, LGraphNode[]>,
+  layerNumbers: readonly number[],
+  topology: GraphTopology
+): void {
+  const order = new Map<LGraphNode['id'], number>()
+  const refreshLayerOrder = (layer: number) => {
+    layers.get(layer)?.forEach((node, index) => order.set(node.id, index))
+  }
+  for (const layer of layerNumbers) refreshLayerOrder(layer)
+
+  // A sweep is a heuristic, so retain only strict improvements. This keeps an
+  // already crossing-free workflow in its original execution order.
+  let bestCrossingCount = crossingCount(topology.edges, order)
+  let bestLayers = new Map(
+    [...layers].map(([layer, nodes]) => [layer, [...nodes]])
+  )
+  const retainImprovement = () => {
+    const currentCrossingCount = crossingCount(topology.edges, order)
+    if (currentCrossingCount >= bestCrossingCount) return
+    bestCrossingCount = currentCrossingCount
+    bestLayers = new Map(
+      [...layers].map(([layer, nodes]) => [layer, [...nodes]])
+    )
+  }
+
+  for (let sweep = 0; sweep < 4; sweep++) {
+    for (const layer of layerNumbers.slice(1)) {
+      reorderLayer(
+        layers.get(layer) ?? [],
+        (node) => topology.predecessors.get(node.id) ?? [],
+        order
+      )
+      refreshLayerOrder(layer)
+    }
+    retainImprovement()
+
+    for (const layer of [...layerNumbers].reverse().slice(1)) {
+      reorderLayer(
+        layers.get(layer) ?? [],
+        (node) => topology.successors.get(node.id) ?? [],
+        order
+      )
+      refreshLayerOrder(layer)
+    }
+    retainImprovement()
+  }
+
+  for (const [layer, nodes] of bestLayers) layers.set(layer, nodes)
+}
+
+export function computeLayeredGraphLayout(
+  nodes: readonly LGraphNode[],
+  links: Iterable<LLink>,
+  { margin, titleHeight, vertical }: LayeredGraphLayoutOptions
+): NewNodePosition[] {
+  const layerByNode = new Map(nodes.map((node) => [node.id, node._level || 1]))
+  const layers = new Map<number, LGraphNode[]>()
+  for (const node of nodes) {
+    const layer = layerByNode.get(node.id) ?? 1
+    const layerNodes = layers.get(layer)
+    if (layerNodes) layerNodes.push(node)
+    else layers.set(layer, [node])
+  }
+
+  const layerNumbers = [...layers.keys()].sort((left, right) => left - right)
+  reduceCrossings(
+    layers,
+    layerNumbers,
+    buildTopology(nodes, links, layerByNode)
+  )
+
+  const positions: NewNodePosition[] = []
+  let primary = margin
+  for (const layer of layerNumbers) {
+    const layerNodes = layers.get(layer) ?? []
+    let maxPrimarySize = 100
+    let secondary = margin + titleHeight
+    for (const node of layerNodes) {
+      positions.push({
+        node,
+        newPos: vertical
+          ? { x: secondary, y: primary }
+          : { x: primary, y: secondary }
+      })
+      maxPrimarySize = Math.max(maxPrimarySize, node.size[vertical ? 1 : 0])
+      secondary += node.size[vertical ? 0 : 1] + margin + titleHeight
+    }
+    primary += maxPrimarySize + margin
+  }
+
+  return positions
+}


### PR DESCRIPTION
## Summary

Improve `LGraph.arrange()` so imported, programmatically generated, and Agent-generated workflows keep a readable layered structure with fewer avoidable link crossings.

## Changes

- Extract layered position calculation into a focused helper.
- Run bounded forward/backward barycentric sweeps to keep connected branches near each other.
- Count inversions at every adjacent-layer boundary, including links that skip layers, and accept only strict improvements.
- Keep disconnected notes and incomplete branches in their original layer slots instead of moving them without layout evidence.
- Preserve the current margin, horizontal/vertical direction, heterogeneous node sizing, and cycle fallback behavior.
- Add focused coverage for fan-in crossings, skip links, stable repeated and incremental arrangement, disconnected nodes, crossing-free baselines, mixed node heights, vertical layout, and cycles.

## Review Focus

- Long links are split into virtual straight segments only for crossing measurement; no graph nodes or links are created.
- Equal segment starts are queried as a batch and equal ends are excluded, so fan-out and fan-in links do not count as crossing each other.
- Backward and same-layer links remain in the existing cycle fallback rather than influencing the DAG ordering heuristic.
- `LGraph.arrange()` still applies positions through the existing `node.setPos()` call; the helper only computes positions, so this does not introduce a new direct spatial mutation path.
- The production diff is 268 lines; the existing `arrange()` entry point and callers are unchanged.

## Validation

- LiteGraph suite: 105 files passed, 1501 tests passed, 5 skipped.
- Focused `LGraph.arrange.test.ts` plus `LGraph.test.ts`: 116 tests passed.
- Focused coverage for `layeredGraphLayout.ts`: 100% lines, 100% functions, 98.62% statements, 72.41% branches.
- Repository fixture scan: 163 JSON files, 225 workflow-shaped objects, 127 non-trivial graphs (728 nodes / 562 links); 2 improved, 125 unchanged, 0 regressed, all positions finite and separated, repeated arrangement stable; max layout time about 11.4 ms.
- Deterministic stress matrix: 700 DAGs across 2-50 nodes, five densities, mixed node sizes, horizontal/vertical/repeated layout; 237 improved, 463 unchanged, 0 regressed. Straight-line crossings decreased from 236,755 to 185,537 (about 21.6%); p95 about 3.55 ms, max about 8.25 ms.
- Cycle stress: 100 dense cyclic graphs remained finite, separated, and stable across repeated arrangement; max about 2.60 ms.
- Full repository Vitest on Windows: 18,446 passed and 7 skipped. The remaining 28 failures are confined to four unrelated Windows/tooling specs (`customNodeQuarantine`, `comfyIngestTypes`, `check-binary-size`, and `reconcile-latest-release`).
- Main, browser-tests, scripts, and tools TypeScript checks: passed.
- Targeted ESLint, Oxfmt, Oxlint, and Knip: passed.
- Standard and cloud production Vite builds: passed (6508 and 6633 modules; about 10.3 s and 11.35 s locally) with existing build warnings.
- Production artifact verification: all 997 generated files returned HTTP 200 from a static server with exact byte lengths; Vite preview entry assets and SPA fallback also returned 200.

## Screenshots

Not applicable: this changes the existing Arrange behavior without adding a new UI surface. Node-order assertions cover horizontal and vertical results, and repository fixtures cover real workflow topology.