### PR TITLE
fix: unify widget visibility state

### DIFF
--- a/src/components/rightSidePanel/parameters/TabNormalInputs.vue
+++ b/src/components/rightSidePanel/parameters/TabNormalInputs.vue
@@ -39,11 +39,8 @@ const advancedWidgetsSectionDataList = computed((): NodeWidgetsListList => {
       const advancedWidgets = widgets
         .filter(
           (w) =>
-            !(
-              w.options?.canvasOnly ||
-              w.options?.hidden ||
-              w.options?.hideInPanel
-            ) && w.options?.advanced
+            !(w.options?.canvasOnly || w.hidden || w.options?.hideInPanel) &&
+            w.options?.advanced
         )
         .map((widget) => ({ node, widget }))
       return { widgets: advancedWidgets, node }

--- a/src/components/rightSidePanel/shared.ts
+++ b/src/components/rightSidePanel/shared.ts
@@ -262,7 +262,7 @@ export function computedSectionDataList(nodes: MaybeRefOrGetter<LGraphNode[]>) {
           (w) =>
             !(
               w.options?.canvasOnly ||
-              w.options?.hidden ||
+              w.hidden ||
               w.options?.hideInPanel ||
               (w.options?.advanced && !includesAdvanced.value)
             )

--- a/src/extensions/core/createBoundingBoxes.test.ts
+++ b/src/extensions/core/createBoundingBoxes.test.ts
@@ -1,9 +1,8 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 const { state } = vi.hoisted(() => ({
   state: {
-    extension: null as { nodeCreated: (node: unknown) => void } | null,
-    widgetState: undefined as { options: Record<string, unknown> } | undefined
+    extension: null as { nodeCreated: (node: unknown) => void } | null
   }
 }))
 
@@ -13,10 +12,6 @@ vi.mock('@/services/extensionService', () => ({
       state.extension = ext
     }
   })
-}))
-
-vi.mock('@/stores/widgetValueStore', () => ({
-  useWidgetValueStore: () => ({ getWidget: () => state.widgetState })
 }))
 
 await import('./createBoundingBoxes')
@@ -46,10 +41,6 @@ function makeNode(connected: boolean, comfyClass = 'CreateBoundingBoxes') {
   }
 }
 
-beforeEach(() => {
-  state.widgetState = undefined
-})
-
 describe('Comfy.CreateBoundingBoxes extension', () => {
   it('ignores nodes of other classes', () => {
     const node = makeNode(true, 'SomethingElse')
@@ -63,7 +54,6 @@ describe('Comfy.CreateBoundingBoxes extension', () => {
     expect(node.setSize).toHaveBeenCalledWith([420, 560])
     expect(node.widgets[0].hidden).toBe(true)
     expect(node.widgets[1].hidden).toBe(true)
-    expect(node.widgets[0].options.hidden).toBe(true)
     expect(node.widgets[2].hidden).toBe(false)
   })
 
@@ -71,7 +61,6 @@ describe('Comfy.CreateBoundingBoxes extension', () => {
     const node = makeNode(false)
     state.extension!.nodeCreated(node)
     expect(node.widgets[0].hidden).toBe(false)
-    expect(node.widgets[0].options.hidden).toBe(false)
   })
 
   it('always hides the internal last_incoming widget', () => {
@@ -79,16 +68,7 @@ describe('Comfy.CreateBoundingBoxes extension', () => {
       const node = makeNode(connected)
       state.extension!.nodeCreated(node)
       expect(node.widgets[3].hidden).toBe(true)
-      expect(node.widgets[3].options.hidden).toBe(true)
     }
-  })
-
-  it('writes visibility through the widget value store when present', () => {
-    state.widgetState = { options: {} }
-    const node = makeNode(true)
-    node.widgets[0].widgetId = 'w-0'
-    state.extension!.nodeCreated(node)
-    expect(state.widgetState.options.hidden).toBe(true)
   })
 
   it('chains a connections-change handler that re-syncs visibility', () => {

--- a/src/extensions/core/createBoundingBoxes.ts
+++ b/src/extensions/core/createBoundingBoxes.ts
@@ -1,6 +1,5 @@
 import { useChainCallback } from '@/composables/functional/useChainCallback'
 import { useExtensionService } from '@/services/extensionService'
-import { useWidgetValueStore } from '@/stores/widgetValueStore'
 
 const DIMENSION_WIDGETS = new Set(['width', 'height'])
 const INTERNAL_WIDGETS = new Set(['last_incoming'])
@@ -14,18 +13,11 @@ useExtensionService().registerExtension({
     const [oldWidth, oldHeight] = node.size
     node.setSize([Math.max(oldWidth, 420), Math.max(oldHeight, 560)])
 
-    const widgetValueStore = useWidgetValueStore()
-
     const setWidgetHidden = (
       widget: NonNullable<typeof node.widgets>[number],
       hidden: boolean
     ) => {
       widget.hidden = hidden
-      const state = widget.widgetId
-        ? widgetValueStore.getWidget(widget.widgetId)
-        : undefined
-      if (state?.options) state.options.hidden = hidden
-      else widget.options.hidden = hidden
     }
 
     const syncDimensionVisibility = () => {

--- a/src/extensions/core/customWidgets.ts
+++ b/src/extensions/core/customWidgets.ts
@@ -141,8 +141,8 @@ function onCustomComboCreated(this: LGraphNode) {
     },
     set value(_) {},
     draw: () => undefined,
-    computeSize: () => [0, -4],
-    options: { hidden: true },
+    hidden: true,
+    options: {},
     y: 0,
     serializeValue: (resolverNode: LGraphNode, _index: number) =>
       widgets

--- a/src/extensions/core/painter.ts
+++ b/src/extensions/core/painter.ts
@@ -15,7 +15,7 @@ useExtensionService().registerExtension({
 
     for (const widget of node.widgets ?? []) {
       if (HIDDEN_WIDGETS.has(widget.name)) {
-        widget.options.hidden = true
+        widget.hidden = true
       }
     }
   }

--- a/src/lib/litegraph/src/utils/widget.ts
+++ b/src/lib/litegraph/src/utils/widget.ts
@@ -5,6 +5,8 @@ import type {
 } from '@/lib/litegraph/src/types/widgets'
 import type { WidgetRenderState } from '@/stores/widgetValueStore'
 import type { WidgetId } from '@/types/widgetId'
+import { isLegacyHiddenWidgetType } from '@/types/widgetVisibility'
+import type { WidgetVisibility } from '@/types/widgetVisibility'
 import type { UUID } from '@/utils/uuid'
 
 import { evaluateMathExpression } from '@/lib/litegraph/src/utils/mathParser'
@@ -55,6 +57,18 @@ export function deriveWidgetRenderState(
     hasLayoutSize: typeof widget.computeLayoutSize === 'function',
     isDOMWidget: isDOMBackedWidget(widget),
     tooltip: widget.tooltip
+  }
+}
+
+export function deriveWidgetVisibility(
+  widget: Readonly<IBaseWidget>
+): WidgetVisibility {
+  return {
+    hidden:
+      widget.hidden ??
+      widget.options?.hidden ??
+      isLegacyHiddenWidgetType(widget.type),
+    hideInPanel: widget.options?.hideInPanel ?? false
   }
 }
 

--- a/src/lib/litegraph/src/widgets/BaseWidget.test.ts
+++ b/src/lib/litegraph/src/widgets/BaseWidget.test.ts
@@ -42,11 +42,14 @@ class MutableTypeWidget extends BaseWidget<IBaseWidget<number, string>> {
   onClick(_options: WidgetEventOptions): void {}
 }
 
-function createMutableTypeWidget(node: LGraphNode): MutableTypeWidget {
+function createMutableTypeWidget(
+  node: LGraphNode,
+  name = 'typeChangedWidget'
+): MutableTypeWidget {
   return new MutableTypeWidget(
     {
       type: 'number',
-      name: 'typeChangedWidget',
+      name,
       value: 42,
       options: { min: 0, max: 100 },
       y: 0
@@ -134,6 +137,41 @@ describe('BaseWidget store integration', () => {
       expect(widget.advanced).toBe(true)
     })
 
+    it('maps legacy visibility APIs to the visibility component', () => {
+      const widget = createMutableTypeWidget(node, 'visibleWidget')
+      widget.setNodeId(toNodeId(1))
+      const id = widgetId(graph.id, toNodeId(1), 'visibleWidget')
+
+      widget.options.hidden = true
+      expect(store.getWidgetVisibility(id)?.hidden).toBe(true)
+      expect(widget.hidden).toBe(true)
+
+      widget.hidden = false
+      expect(store.getWidgetVisibility(id)?.hidden).toBe(false)
+      expect(widget.options.hidden).toBe(false)
+
+      widget.type = 'smZhidden'
+      expect(store.getWidgetVisibility(id)?.hidden).toBe(true)
+      widget.type = 'number'
+      expect(store.getWidgetVisibility(id)?.hidden).toBe(false)
+
+      widget.options.hideInPanel = true
+      expect(store.getWidgetVisibility(id)?.hideInPanel).toBe(true)
+      delete widget.options.hideInPanel
+      expect(store.getWidgetVisibility(id)?.hideInPanel).toBe(false)
+    })
+
+    it('clears stale hidden state when a converted widget is restored', () => {
+      const widget = createMutableTypeWidget(node, 'convertedWidget')
+      widget.setNodeId(toNodeId(1))
+
+      widget.type = 'converted-widget'
+      widget.hidden = true
+      widget.type = 'number'
+
+      expect(widget.hidden).toBe(false)
+    })
+
     it('syncs value with store', () => {
       const widget = createTestWidget(node, { name: 'valueWidget', value: 42 })
       widget.setNodeId(toNodeId(1))
@@ -190,7 +228,7 @@ describe('BaseWidget store integration', () => {
       expect(state?.disabled).toBe(false)
       expect(state?.label).toBeUndefined()
 
-      expect(widget.hidden).toBeUndefined()
+      expect(widget.hidden).toBe(false)
       expect(widget.advanced).toBeUndefined()
     })
 

--- a/src/lib/litegraph/src/widgets/BaseWidget.ts
+++ b/src/lib/litegraph/src/widgets/BaseWidget.ts
@@ -17,11 +17,19 @@ import type {
   NodeBindable,
   TWidgetType
 } from '@/lib/litegraph/src/types/widgets'
-import { deriveWidgetRenderState } from '@/lib/litegraph/src/utils/widget'
+import {
+  deriveWidgetRenderState,
+  deriveWidgetVisibility
+} from '@/lib/litegraph/src/utils/widget'
 import { useWidgetValueStore } from '@/stores/widgetValueStore'
 import type { WidgetId } from '@/types/widgetId'
 import { ensureUniqueWidgetNames, widgetId } from '@/types/widgetId'
 import type { WidgetState } from '@/types/widgetState'
+import {
+  isLegacyHiddenWidgetType,
+  isLegacyWidgetHidingType
+} from '@/types/widgetVisibility'
+import type { WidgetVisibility } from '@/types/widgetVisibility'
 
 export interface DrawWidgetOptions {
   /** The width of the node where this widget will be displayed. */
@@ -107,7 +115,34 @@ export abstract class BaseWidget<TWidget extends IBaseWidget = IBaseWidget>
   }
 
   options: TWidget['options']
-  type: TWidget['type']
+  private _type!: TWidget['type']
+  get type(): TWidget['type'] {
+    return this._type
+  }
+  set type(value: TWidget['type']) {
+    this.setWidgetType(value)
+  }
+
+  private setWidgetType(value: TWidget['type']): void {
+    const wasLegacyHidden =
+      this._type !== undefined && isLegacyWidgetHidingType(this._type)
+    this._type = value
+    if (isLegacyHiddenWidgetType(value)) this.hidden = true
+    else if (wasLegacyHidden) this.hidden = false
+  }
+
+  private installTypeVisibilityShim(): void {
+    const descriptor = Object.getOwnPropertyDescriptor(this, 'type')
+    if (!descriptor || descriptor.get || descriptor.set) return
+
+    this._type = this.type
+    Object.defineProperty(this, 'type', {
+      configurable: true,
+      enumerable: true,
+      get: () => this._type,
+      set: (value: TWidget['type']) => this.setWidgetType(value)
+    })
+  }
   y: number = 0
   last_y?: number
   width?: number
@@ -124,7 +159,17 @@ export abstract class BaseWidget<TWidget extends IBaseWidget = IBaseWidget>
     this._state.label = value
   }
 
-  hidden?: boolean
+  private _visibility: WidgetVisibility = {
+    hidden: false,
+    hideInPanel: false
+  }
+
+  get hidden(): boolean {
+    return this._visibility.hidden
+  }
+  set hidden(value: boolean | undefined) {
+    this._visibility.hidden = value ?? false
+  }
   advanced?: boolean
 
   get disabled(): boolean | undefined {
@@ -174,6 +219,7 @@ export abstract class BaseWidget<TWidget extends IBaseWidget = IBaseWidget>
    * Once set, value reads/writes will be delegated to the store.
    */
   setNodeId(nodeId: NodeId): void {
+    this.installTypeVisibilityShim()
     const graphId = this.node.graph?.rootGraph.id
     if (!graphId) return
     if (!ensureUniqueWidgetNames(this.node.widgets ?? [this])) return
@@ -190,9 +236,15 @@ export abstract class BaseWidget<TWidget extends IBaseWidget = IBaseWidget>
         value: this.value,
         y: this.y
       },
-      deriveWidgetRenderState(this)
+      deriveWidgetRenderState(this),
+      deriveWidgetVisibility(this)
     )
-    if (registered) this._state = registered
+    if (!registered) return
+    this._state = registered
+    const visibility = useWidgetValueStore().getWidgetVisibility(
+      widgetId(graphId, nodeId, this.name)
+    )
+    if (visibility) this._visibility = visibility
   }
 
   constructor(widget: TWidget & { node: LGraphNode })
@@ -201,11 +253,41 @@ export abstract class BaseWidget<TWidget extends IBaseWidget = IBaseWidget>
     // Private fields
     this._node = node ?? widget.node
 
+    this._visibility = deriveWidgetVisibility(widget)
+
     // The set and get functions for DOM widget values are hacked on to the options object;
     // attempting to set value before options will throw.
     // https://github.com/Comfy-Org/ComfyUI_frontend/blob/df86da3d672628a452baed3df3347a52c0c8d378/src/scripts/domWidget.ts#L125
     this.name = widget.name
-    this.options = widget.options
+    this.options = new Proxy(widget.options, {
+      get: (target, property, receiver) => {
+        if (property === 'hidden') return this.hidden
+        if (property === 'hideInPanel') return this._visibility.hideInPanel
+        return Reflect.get(target, property, receiver)
+      },
+      set: (target, property, value, receiver) => {
+        if (property === 'hidden') {
+          this.hidden = value === true
+          return true
+        }
+        if (property === 'hideInPanel') {
+          this._visibility.hideInPanel = value === true
+          return true
+        }
+        return Reflect.set(target, property, value, receiver)
+      },
+      deleteProperty: (target, property) => {
+        if (property === 'hidden') {
+          this.hidden = false
+          return Reflect.deleteProperty(target, property)
+        }
+        if (property === 'hideInPanel') {
+          this._visibility.hideInPanel = false
+          return Reflect.deleteProperty(target, property)
+        }
+        return Reflect.deleteProperty(target, property)
+      }
+    })
     this.type = widget.type
 
     // `node` has no setter - Object.assign will throw.
@@ -234,6 +316,9 @@ export abstract class BaseWidget<TWidget extends IBaseWidget = IBaseWidget>
       disabled,
       value,
       linkedWidgets,
+      name: _name,
+      options: _options,
+      type: _type,
       ...safeValues
     } = widget
 

--- a/src/lib/litegraph/src/widgets/BooleanWidget.ts
+++ b/src/lib/litegraph/src/widgets/BooleanWidget.ts
@@ -7,8 +7,6 @@ export class BooleanWidget
   extends BaseWidget<IBooleanWidget>
   implements IBooleanWidget
 {
-  override type = 'toggle' as const
-
   override drawWidget(
     ctx: CanvasRenderingContext2D,
     options: DrawWidgetOptions

--- a/src/lib/litegraph/src/widgets/BoundingBoxWidget.ts
+++ b/src/lib/litegraph/src/widgets/BoundingBoxWidget.ts
@@ -10,8 +10,6 @@ export class BoundingBoxWidget
   extends BaseWidget<IBoundingBoxWidget>
   implements IBoundingBoxWidget
 {
-  override type = 'boundingbox' as const
-
   drawWidget(ctx: CanvasRenderingContext2D, options: DrawWidgetOptions): void {
     this.drawVueOnlyWarning(ctx, options, 'BoundingBox')
   }

--- a/src/lib/litegraph/src/widgets/BoundingBoxesWidget.ts
+++ b/src/lib/litegraph/src/widgets/BoundingBoxesWidget.ts
@@ -6,8 +6,6 @@ export class BoundingBoxesWidget
   extends BaseWidget<IBoundingBoxesWidget>
   implements IBoundingBoxesWidget
 {
-  override type = 'boundingboxes' as const
-
   drawWidget(ctx: CanvasRenderingContext2D, options: DrawWidgetOptions): void {
     this.drawVueOnlyWarning(ctx, options, 'Bounding Boxes')
   }

--- a/src/lib/litegraph/src/widgets/ButtonWidget.ts
+++ b/src/lib/litegraph/src/widgets/ButtonWidget.ts
@@ -8,7 +8,6 @@ export class ButtonWidget
   extends BaseWidget<IButtonWidget>
   implements IButtonWidget
 {
-  override type = 'button' as const
   clicked: boolean
 
   constructor(widget: IButtonWidget, node: LGraphNode) {

--- a/src/lib/litegraph/src/widgets/ChartWidget.ts
+++ b/src/lib/litegraph/src/widgets/ChartWidget.ts
@@ -12,8 +12,6 @@ export class ChartWidget
   extends BaseWidget<IChartWidget>
   implements IChartWidget
 {
-  override type = 'chart' as const
-
   drawWidget(ctx: CanvasRenderingContext2D, options: DrawWidgetOptions): void {
     const { width } = options
     const { y, height } = this

--- a/src/lib/litegraph/src/widgets/ColorWidget.ts
+++ b/src/lib/litegraph/src/widgets/ColorWidget.ts
@@ -26,8 +26,6 @@ export class ColorWidget
   extends BaseWidget<IColorWidget>
   implements IColorWidget
 {
-  override type = 'color' as const
-
   drawWidget(ctx: CanvasRenderingContext2D, options: DrawWidgetOptions): void {
     const { fillStyle, strokeStyle, textAlign } = ctx
 

--- a/src/lib/litegraph/src/widgets/ColorsWidget.ts
+++ b/src/lib/litegraph/src/widgets/ColorsWidget.ts
@@ -6,8 +6,6 @@ export class ColorsWidget
   extends BaseWidget<IColorsWidget>
   implements IColorsWidget
 {
-  override type = 'colors' as const
-
   drawWidget(ctx: CanvasRenderingContext2D, options: DrawWidgetOptions): void {
     this.drawVueOnlyWarning(ctx, options, 'Colors')
   }

--- a/src/lib/litegraph/src/widgets/ComboWidget.ts
+++ b/src/lib/litegraph/src/widgets/ComboWidget.ts
@@ -30,8 +30,6 @@ export class ComboWidget
   extends BaseSteppedWidget<IStringComboWidget | IComboWidget>
   implements IComboWidget
 {
-  override type = 'combo' as const
-
   override get _displayValue() {
     if (this.computedDisabled) return ''
 

--- a/src/lib/litegraph/src/widgets/CompositorWidget.ts
+++ b/src/lib/litegraph/src/widgets/CompositorWidget.ts
@@ -10,8 +10,6 @@ export class CompositorWidget
   extends BaseWidget<ICompositorWidget>
   implements ICompositorWidget
 {
-  override type = 'compositor' as const
-
   drawWidget(ctx: CanvasRenderingContext2D, options: DrawWidgetOptions): void {
     this.drawVueOnlyWarning(ctx, options, 'Compositor')
   }

--- a/src/lib/litegraph/src/widgets/CurveWidget.ts
+++ b/src/lib/litegraph/src/widgets/CurveWidget.ts
@@ -6,8 +6,6 @@ export class CurveWidget
   extends BaseWidget<ICurveWidget>
   implements ICurveWidget
 {
-  override type = 'curve' as const
-
   drawWidget(ctx: CanvasRenderingContext2D, options: DrawWidgetOptions): void {
     this.drawVueOnlyWarning(ctx, options, 'Curve')
   }

--- a/src/lib/litegraph/src/widgets/FileUploadWidget.ts
+++ b/src/lib/litegraph/src/widgets/FileUploadWidget.ts
@@ -12,8 +12,6 @@ export class FileUploadWidget
   extends BaseWidget<IFileUploadWidget>
   implements IFileUploadWidget
 {
-  override type = 'fileupload' as const
-
   drawWidget(ctx: CanvasRenderingContext2D, options: DrawWidgetOptions): void {
     const { width } = options
     const { y, height } = this

--- a/src/lib/litegraph/src/widgets/GalleriaWidget.ts
+++ b/src/lib/litegraph/src/widgets/GalleriaWidget.ts
@@ -12,8 +12,6 @@ export class GalleriaWidget
   extends BaseWidget<IGalleriaWidget>
   implements IGalleriaWidget
 {
-  override type = 'galleria' as const
-
   drawWidget(ctx: CanvasRenderingContext2D, options: DrawWidgetOptions): void {
     const { width } = options
     const { y, height } = this

--- a/src/lib/litegraph/src/widgets/GradientSliderWidget.ts
+++ b/src/lib/litegraph/src/widgets/GradientSliderWidget.ts
@@ -9,8 +9,6 @@ export class GradientSliderWidget
   extends BaseWidget<IGradientSliderWidget>
   implements IGradientSliderWidget
 {
-  override type = 'gradientslider' as const
-
   override drawWidget(
     ctx: CanvasRenderingContext2D,
     { width, showText = true }: DrawWidgetOptions

--- a/src/lib/litegraph/src/widgets/ImageCompareWidget.ts
+++ b/src/lib/litegraph/src/widgets/ImageCompareWidget.ts
@@ -12,8 +12,6 @@ export class ImageCompareWidget
   extends BaseWidget<IImageCompareWidget>
   implements IImageCompareWidget
 {
-  override type = 'imagecompare' as const
-
   drawWidget(ctx: CanvasRenderingContext2D, options: DrawWidgetOptions): void {
     const { width } = options
     const { y, height } = this

--- a/src/lib/litegraph/src/widgets/ImageCropWidget.ts
+++ b/src/lib/litegraph/src/widgets/ImageCropWidget.ts
@@ -10,8 +10,6 @@ export class ImageCropWidget
   extends BaseWidget<IImageCropWidget>
   implements IImageCropWidget
 {
-  override type = 'imagecrop' as const
-
   drawWidget(ctx: CanvasRenderingContext2D, options: DrawWidgetOptions): void {
     this.drawVueOnlyWarning(ctx, options, 'ImageCrop')
   }

--- a/src/lib/litegraph/src/widgets/KnobWidget.ts
+++ b/src/lib/litegraph/src/widgets/KnobWidget.ts
@@ -7,8 +7,6 @@ import { BaseWidget } from './BaseWidget'
 import type { DrawWidgetOptions, WidgetEventOptions } from './BaseWidget'
 
 export class KnobWidget extends BaseWidget<IKnobWidget> implements IKnobWidget {
-  override type = 'knob' as const
-
   /**
    * Compute the layout size of the widget.
    * @returns The layout size of the widget.

--- a/src/lib/litegraph/src/widgets/MarkdownWidget.ts
+++ b/src/lib/litegraph/src/widgets/MarkdownWidget.ts
@@ -12,8 +12,6 @@ export class MarkdownWidget
   extends BaseWidget<IMarkdownWidget>
   implements IMarkdownWidget
 {
-  override type = 'markdown' as const
-
   drawWidget(ctx: CanvasRenderingContext2D, options: DrawWidgetOptions): void {
     const { width } = options
     const { y, height } = this

--- a/src/lib/litegraph/src/widgets/MultiSelectWidget.ts
+++ b/src/lib/litegraph/src/widgets/MultiSelectWidget.ts
@@ -12,8 +12,6 @@ export class MultiSelectWidget
   extends BaseWidget<IMultiSelectWidget>
   implements IMultiSelectWidget
 {
-  override type = 'multiselect' as const
-
   drawWidget(ctx: CanvasRenderingContext2D, options: DrawWidgetOptions): void {
     const { width } = options
     const { y, height } = this

--- a/src/lib/litegraph/src/widgets/NumberWidget.ts
+++ b/src/lib/litegraph/src/widgets/NumberWidget.ts
@@ -8,8 +8,6 @@ export class NumberWidget
   extends BaseSteppedWidget<INumericWidget>
   implements INumericWidget
 {
-  override type = 'number' as const
-
   override get _displayValue() {
     if (this.computedDisabled) return ''
     return Number(this.value).toFixed(

--- a/src/lib/litegraph/src/widgets/PainterWidget.ts
+++ b/src/lib/litegraph/src/widgets/PainterWidget.ts
@@ -10,8 +10,6 @@ export class PainterWidget
   extends BaseWidget<IPainterWidget>
   implements IPainterWidget
 {
-  override type = 'painter' as const
-
   drawWidget(ctx: CanvasRenderingContext2D, options: DrawWidgetOptions): void {
     this.drawVueOnlyWarning(ctx, options, 'Painter')
   }

--- a/src/lib/litegraph/src/widgets/RangeWidget.ts
+++ b/src/lib/litegraph/src/widgets/RangeWidget.ts
@@ -6,8 +6,6 @@ export class RangeWidget
   extends BaseWidget<IRangeWidget>
   implements IRangeWidget
 {
-  override type = 'range' as const
-
   drawWidget(ctx: CanvasRenderingContext2D, options: DrawWidgetOptions): void {
     this.drawVueOnlyWarning(ctx, options, 'Range')
   }

--- a/src/lib/litegraph/src/widgets/SelectButtonWidget.ts
+++ b/src/lib/litegraph/src/widgets/SelectButtonWidget.ts
@@ -12,8 +12,6 @@ export class SelectButtonWidget
   extends BaseWidget<ISelectButtonWidget>
   implements ISelectButtonWidget
 {
-  override type = 'selectbutton' as const
-
   drawWidget(ctx: CanvasRenderingContext2D, options: DrawWidgetOptions): void {
     const { width } = options
     const { y, height } = this

--- a/src/lib/litegraph/src/widgets/SliderWidget.ts
+++ b/src/lib/litegraph/src/widgets/SliderWidget.ts
@@ -9,8 +9,6 @@ export class SliderWidget
   extends BaseWidget<ISliderWidget>
   implements ISliderWidget
 {
-  override type = 'slider' as const
-
   marker?: number
 
   /**

--- a/src/lib/litegraph/src/widgets/TextareaWidget.ts
+++ b/src/lib/litegraph/src/widgets/TextareaWidget.ts
@@ -10,8 +10,6 @@ export class TextareaWidget
   extends BaseWidget<ITextareaWidget>
   implements ITextareaWidget
 {
-  override type = 'textarea' as const
-
   drawWidget(ctx: CanvasRenderingContext2D, options: DrawWidgetOptions): void {
     this.drawVueOnlyWarning(ctx, options, 'Textarea')
   }

--- a/src/lib/litegraph/src/widgets/TreeSelectWidget.ts
+++ b/src/lib/litegraph/src/widgets/TreeSelectWidget.ts
@@ -10,8 +10,6 @@ export class TreeSelectWidget
   extends BaseWidget<ITreeSelectWidget>
   implements ITreeSelectWidget
 {
-  override type = 'treeselect' as const
-
   drawWidget(ctx: CanvasRenderingContext2D, options: DrawWidgetOptions): void {
     this.drawVueOnlyWarning(ctx, options, 'TreeSelect')
   }

--- a/src/lib/litegraph/src/widgets/VideoEditWidget.ts
+++ b/src/lib/litegraph/src/widgets/VideoEditWidget.ts
@@ -6,8 +6,6 @@ export class VideoEditWidget
   extends BaseWidget<IVideoEditWidget>
   implements IVideoEditWidget
 {
-  override type = 'videoedit' as const
-
   drawWidget(): void {}
 
   onClick(_options: WidgetEventOptions): void {}

--- a/src/renderer/extensions/vueNodes/composables/processedWidgetRenderModel.ts
+++ b/src/renderer/extensions/vueNodes/composables/processedWidgetRenderModel.ts
@@ -160,11 +160,11 @@ function getHostNode(
 }
 
 function isWidgetVisible(
+  hidden: boolean,
   options: IWidgetOptions,
   showAdvanced: boolean,
   ignoreAdvanced = false
 ): boolean {
-  const hidden = options.hidden ?? false
   const advanced = options.advanced ?? false
   return !hidden && (!advanced || showAdvanced || ignoreAdvanced)
 }
@@ -361,6 +361,7 @@ function processWidget(
   const liveWidget = ctx.liveWidgets.get(id)
   const type = liveWidget?.type ?? widgetState.type
   const renderState = ctx.widgetValueStore.getWidgetRenderState(id)
+  const visibility = ctx.widgetValueStore.getWidgetVisibility(id)
   const options: IWidgetOptions = { ...(widgetState.options ?? {}) }
   if (options.advanced === undefined) options.advanced = renderState?.advanced
   if (!shouldRenderAsVue({ type, options })) return null
@@ -370,6 +371,7 @@ function processWidget(
 
   const slotInfo = ctx.slotMetadata.get(widgetState.name)
   const visible = isWidgetVisible(
+    visibility?.hidden ?? false,
     options,
     ctx.showAdvanced,
     slotInfo?.linked || slotInfo?.promoted

--- a/src/services/litegraphService.ts
+++ b/src/services/litegraphService.ts
@@ -329,8 +329,7 @@ export const useLitegraphService = () => {
       )
       widget.options ??= {}
       Object.assign(widget.options, {
-        advanced: inputSpec.advanced,
-        hidden: inputSpec.hidden
+        advanced: inputSpec.advanced
       })
       if (inputSpec.hidden !== undefined) widget.hidden = inputSpec.hidden
       if (dynamic) widget.tooltip = inputSpec.tooltip

--- a/src/stores/widgetValueStore.test.ts
+++ b/src/stores/widgetValueStore.test.ts
@@ -352,6 +352,19 @@ describe('useWidgetValueStore', () => {
       ).toBe(false)
     })
 
+    it('maps legacy option updates to the visibility component', () => {
+      const store = useWidgetValueStore()
+      store.registerWidget(seedA, state('number', 100))
+
+      expect(
+        store.updateOptions(seedA, { hidden: true, hideInPanel: true })
+      ).toBe(true)
+      expect(store.getWidgetVisibility(seedA)).toEqual({
+        hidden: true,
+        hideInPanel: true
+      })
+    })
+
     it('deleteWidget removes registered widgets from node order', () => {
       const store = useWidgetValueStore()
       const steps = widgetId(graphA, toNodeId('node-1'), 'steps')

--- a/src/stores/widgetValueStore.ts
+++ b/src/stores/widgetValueStore.ts
@@ -8,6 +8,8 @@ import { isWidgetId, parseWidgetId } from '@/types/widgetId'
 import type { WidgetId } from '@/types/widgetId'
 import type { WidgetValue } from '@/types/simplifiedWidget'
 import type { WidgetState, WidgetStateInit } from '@/types/widgetState'
+import { isLegacyHiddenWidgetType } from '@/types/widgetVisibility'
+import type { WidgetVisibility } from '@/types/widgetVisibility'
 
 export interface WidgetRenderState {
   advanced?: boolean
@@ -30,6 +32,9 @@ export const useWidgetValueStore = defineStore('widgetValue', () => {
   const graphWidgetStates = ref(new Map<UUID, Map<WidgetId, WidgetState>>())
   const graphWidgetRenderStates = ref(
     new Map<UUID, Map<WidgetId, WidgetRenderState>>()
+  )
+  const graphWidgetVisibilities = ref(
+    new Map<UUID, Map<WidgetId, WidgetVisibility>>()
   )
   const graphNodeWidgetOrders = ref(new Map<UUID, Map<NodeId, WidgetId[]>>())
   const graphWidgetRestorations = new Map<
@@ -100,6 +105,19 @@ export const useWidgetValueStore = defineStore('widgetValue', () => {
     return nextWidgetRenderStates
   }
 
+  function getGraphWidgetVisibilities(
+    graphId: UUID
+  ): Map<WidgetId, WidgetVisibility> {
+    const widgetVisibilities = graphWidgetVisibilities.value.get(graphId)
+    if (widgetVisibilities) return widgetVisibilities
+
+    const nextWidgetVisibilities = reactive(
+      new Map<WidgetId, WidgetVisibility>()
+    )
+    graphWidgetVisibilities.value.set(graphId, nextWidgetVisibilities)
+    return nextWidgetVisibilities
+  }
+
   function getGraphNodeWidgetOrders(graphId: UUID): Map<NodeId, WidgetId[]> {
     const widgetOrders = graphNodeWidgetOrders.value.get(graphId)
     if (widgetOrders) return widgetOrders
@@ -140,7 +158,12 @@ export const useWidgetValueStore = defineStore('widgetValue', () => {
   function registerWidget<TValue extends WidgetValue = WidgetValue>(
     widgetId: WidgetId,
     init: WidgetStateInit<TValue>,
-    renderState: WidgetRenderState = {}
+    renderState: WidgetRenderState = {},
+    visibility: WidgetVisibility = {
+      hidden:
+        init.options.hidden ?? isLegacyHiddenWidgetType(String(init.type)),
+      hideInPanel: init.options.hideInPanel ?? false
+    }
   ): WidgetState<TValue> | undefined {
     if (!isWidgetId(widgetId)) {
       console.warn(
@@ -154,8 +177,10 @@ export const useWidgetValueStore = defineStore('widgetValue', () => {
     const { graphId, nodeId, name: storageName } = parseWidgetId(widgetId)
     if (existing && existing.type !== init.type) {
       getGraphWidgetRenderStates(graphId).delete(widgetId)
+      getGraphWidgetVisibilities(graphId).delete(widgetId)
     }
     registerWidgetRenderState(widgetId, renderState)
+    registerWidgetVisibility(widgetId, visibility)
     // WidgetId is `graphId:nodeId:name`. A node replacement can reuse the same
     // numeric nodeId, so a stale entry from the previous occupant may survive in
     // the store under the same key. The type check distinguishes a live
@@ -203,6 +228,23 @@ export const useWidgetValueStore = defineStore('widgetValue', () => {
     return widgetRenderStates.get(widgetId) as WidgetRenderState
   }
 
+  function registerWidgetVisibility(
+    widgetId: WidgetId,
+    init: WidgetVisibility
+  ): WidgetVisibility {
+    const { graphId } = parseWidgetId(widgetId)
+    const widgetVisibilities = getGraphWidgetVisibilities(graphId)
+    const existing = widgetVisibilities.get(widgetId)
+    if (existing) {
+      Object.assign(existing, init)
+      return existing
+    }
+
+    const visibility = { ...init }
+    widgetVisibilities.set(widgetId, visibility)
+    return widgetVisibilities.get(widgetId) as WidgetVisibility
+  }
+
   function getWidget(widgetId: WidgetId): WidgetState | undefined {
     if (!isWidgetId(widgetId)) return undefined
 
@@ -217,6 +259,15 @@ export const useWidgetValueStore = defineStore('widgetValue', () => {
 
     const { graphId } = parseWidgetId(widgetId)
     return graphWidgetRenderStates.value.get(graphId)?.get(widgetId)
+  }
+
+  function getWidgetVisibility(
+    widgetId: WidgetId
+  ): WidgetVisibility | undefined {
+    if (!isWidgetId(widgetId)) return undefined
+
+    const { graphId } = parseWidgetId(widgetId)
+    return graphWidgetVisibilities.value.get(graphId)?.get(widgetId)
   }
 
   function setValue(widgetId: WidgetId, value: WidgetState['value']): boolean {
@@ -239,6 +290,13 @@ export const useWidgetValueStore = defineStore('widgetValue', () => {
   ): boolean {
     const state = getWidget(widgetId)
     if (!state) return false
+    const visibility = getWidgetVisibility(widgetId)
+    if (visibility) {
+      if (options.hidden !== undefined) visibility.hidden = options.hidden
+      if (options.hideInPanel !== undefined) {
+        visibility.hideInPanel = options.hideInPanel
+      }
+    }
     state.options = { ...state.options, ...options }
     return true
   }
@@ -248,6 +306,7 @@ export const useWidgetValueStore = defineStore('widgetValue', () => {
 
     const { graphId } = parseWidgetId(widgetId)
     graphWidgetRenderStates.value.get(graphId)?.delete(widgetId)
+    graphWidgetVisibilities.value.get(graphId)?.delete(widgetId)
     removeNodeWidgetOrder(widgetId)
     return graphWidgetStates.value.get(graphId)?.delete(widgetId) ?? false
   }
@@ -272,16 +331,20 @@ export const useWidgetValueStore = defineStore('widgetValue', () => {
 
     const renderStates = getGraphWidgetRenderStates(graphId)
     const renderState = renderStates.get(oldId)
+    const visibilities = getGraphWidgetVisibilities(graphId)
+    const visibility = visibilities.get(oldId)
     const order = getNodeWidgetOrder(graphId, nodeId)
     const index = order.indexOf(oldId)
 
     widgetStates.delete(oldId)
     renderStates.delete(oldId)
+    visibilities.delete(oldId)
     if (index !== -1) order.splice(index, 1)
 
     state.name = name
     widgetStates.set(newId, state)
     if (renderState) renderStates.set(newId, renderState)
+    if (visibility) visibilities.set(newId, visibility)
     if (index !== -1) order.splice(index, 0, newId)
     else if (!order.includes(newId)) order.push(newId)
 
@@ -375,6 +438,7 @@ export const useWidgetValueStore = defineStore('widgetValue', () => {
       for (const widgetId of order) {
         graphWidgetStates.value.get(graphId)?.delete(widgetId)
         graphWidgetRenderStates.value.get(graphId)?.delete(widgetId)
+        graphWidgetVisibilities.value.get(graphId)?.delete(widgetId)
       }
     }
     graphOrders.delete(localNodeId)
@@ -384,16 +448,21 @@ export const useWidgetValueStore = defineStore('widgetValue', () => {
     graphWidgetRestorations.get(graphId)?.delete(nodeId)
     const widgetStates = graphWidgetStates.value.get(graphId)
     const widgetRenderStates = graphWidgetRenderStates.value.get(graphId)
+    const widgetVisibilities = graphWidgetVisibilities.value.get(graphId)
     if (widgetStates) {
       for (const [id, state] of widgetStates) {
         if (state.nodeId !== nodeId) continue
         widgetStates.delete(id)
         widgetRenderStates?.delete(id)
+        widgetVisibilities?.delete(id)
       }
       if (widgetStates.size === 0) graphWidgetStates.value.delete(graphId)
     }
     if (widgetRenderStates?.size === 0) {
       graphWidgetRenderStates.value.delete(graphId)
+    }
+    if (widgetVisibilities?.size === 0) {
+      graphWidgetVisibilities.value.delete(graphId)
     }
 
     const widgetOrders = graphNodeWidgetOrders.value.get(graphId)
@@ -404,6 +473,7 @@ export const useWidgetValueStore = defineStore('widgetValue', () => {
   function clearGraph(graphId: UUID): void {
     graphWidgetStates.value.delete(graphId)
     graphWidgetRenderStates.value.delete(graphId)
+    graphWidgetVisibilities.value.delete(graphId)
     graphNodeWidgetOrders.value.delete(graphId)
     graphWidgetRestorations.delete(graphId)
   }
@@ -415,6 +485,7 @@ export const useWidgetValueStore = defineStore('widgetValue', () => {
     getPositionalRestoredWidgetValue,
     getWidget,
     getWidgetRenderState,
+    getWidgetVisibility,
     setValue,
     setLabel,
     updateOptions,

--- a/src/types/widgetVisibility.ts
+++ b/src/types/widgetVisibility.ts
@@ -1,0 +1,17 @@
+export interface WidgetVisibility {
+  hidden: boolean
+  hideInPanel: boolean
+}
+
+export function isLegacyHiddenWidgetType(type: string): boolean {
+  const normalized = type.toLowerCase()
+  return normalized.includes('hidden') || normalized.startsWith('tschide')
+}
+
+export function isLegacyWidgetHidingType(type: string): boolean {
+  return (
+    isLegacyHiddenWidgetType(type) ||
+    type === 'converted-widget' ||
+    type.startsWith('converted-widget:')
+  )
+}


### PR DESCRIPTION
## Summary

Store widget visibility in one Widget Entity component while preserving the hiding APIs used by custom nodes.

## Changes

- **What**: Add a `WidgetVisibility` component keyed by `WidgetId`, and use it for canvas, Vue-node, DOM-widget, and side-panel visibility.
- **Compatibility**: Map `widget.hidden`, `widget.options.hidden`, `hideInPanel`, legacy hidden type markers, and restored converted widgets to the component.
- **Tests**: Cover the compatibility shims, component updates, widget registration, and renderer visibility.

## Review Focus

Check the compatibility boundary in `BaseWidget`. `converted-widget` keeps its input-conversion behavior and only clears stale hidden state when a custom node restores the original widget type.