### PR TITLE
test(assets): cover 3D viewer routing

### DIFF
--- a/src/components/sidebar/tabs/AssetsSidebarTab.test.ts
+++ b/src/components/sidebar/tabs/AssetsSidebarTab.test.ts
@@ -1,7 +1,7 @@
 import { render, screen, within } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import { createPinia } from 'pinia'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createI18n } from 'vue-i18n'
 
 import AssetsSidebarTab from './AssetsSidebarTab.vue'
@@ -195,6 +195,10 @@ function renderTab() {
     }
   })
 }
+
+beforeEach(() => {
+  storeControls.setOutputItems([folderAsset])
+})
 
 describe('AssetsSidebarTab folder navigation', () => {
   it('places accessible folder actions beside the job ID', async () => {

--- a/src/components/sidebar/tabs/AssetsSidebarTab.test.ts
+++ b/src/components/sidebar/tabs/AssetsSidebarTab.test.ts
@@ -18,12 +18,21 @@ const folderAsset = vi.hoisted(() => ({
   }
 }))
 
+const storeControls = vi.hoisted(() => ({
+  outputItems: [folderAsset] as (typeof folderAsset)[],
+  setOutputItems(items: (typeof folderAsset)[]) {
+    this.outputItems.splice(0, this.outputItems.length, ...items)
+  }
+}))
+
+const showDialogMock = vi.hoisted(() => vi.fn())
+
 vi.mock('@/stores/assetsStore', async () => {
   const { ref } = await import('vue')
 
   const store = {
     outputAssets: {
-      items: ref([folderAsset]),
+      items: ref(storeControls.outputItems),
       isLoading: ref(false),
       hasMore: ref(false),
       loadMore: vi.fn(),
@@ -93,6 +102,10 @@ vi.mock('primevue/usetoast', () => ({
   useToast: () => ({ add: vi.fn() })
 }))
 
+vi.mock('@/stores/dialogStore', () => ({
+  useDialogStore: () => ({ showDialog: showDialogMock })
+}))
+
 const i18n = createI18n({
   legacy: false,
   locale: 'en',
@@ -123,12 +136,24 @@ const sidebarTabTemplateStub = {
 
 const assetsGridStub = {
   props: ['assets'],
-  emits: ['output-count-click'],
+  emits: ['output-count-click', 'zoom'],
   template: `
-    <button
-      aria-label="Enter output folder"
-      @click="$emit('output-count-click', assets[0])"
-    />
+    <div>
+      <button
+        v-if="assets.length"
+        aria-label="Enter output folder"
+        @click="$emit('output-count-click', assets[0])"
+      />
+      <button
+        v-for="asset in assets"
+        :key="asset.id + '-preview'"
+        :aria-label="'Preview ' + asset.name"
+        @click="$emit('zoom', asset)"
+      />
+      <span v-for="asset in assets" :key="asset.id" data-testid="asset-id">
+        {{ asset.id }}
+      </span>
+    </div>
   `
 }
 
@@ -187,5 +212,44 @@ describe('AssetsSidebarTab folder navigation', () => {
       screen.queryByRole('button', { name: 'Back to all assets' })
     ).not.toBeInTheDocument()
     expect(screen.queryByText('multi-output-job')).not.toBeInTheDocument()
+  })
+})
+
+describe('AssetsSidebarTab 3D preview', () => {
+  async function openMeshPreview(previewUrl?: string) {
+    const asset = {
+      ...folderAsset,
+      id: 'mesh-asset',
+      name: 'mesh.glb',
+      preview_url: previewUrl,
+      user_metadata: undefined
+    }
+    storeControls.setOutputItems([asset])
+
+    renderTab()
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Preview mesh.glb' })
+    )
+
+    expect(showDialogMock).toHaveBeenCalledOnce()
+    expect(showDialogMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        key: 'asset-3d-viewer',
+        title: 'mesh.glb',
+        props: {
+          modelUrl: expect.stringContaining(
+            '/api/view?filename=mesh.glb&type=output'
+          )
+        }
+      })
+    )
+  }
+
+  it('opens the original 3D asset when no thumbnail exists', async () => {
+    await openMeshPreview()
+  })
+
+  it.fails('does not send the thumbnail image to the 3D viewer', async () => {
+    await openMeshPreview('https://example.com/previews/mesh.png')
   })
 })

--- a/src/components/sidebar/tabs/AssetsSidebarTab.test.ts
+++ b/src/components/sidebar/tabs/AssetsSidebarTab.test.ts
@@ -18,9 +18,21 @@ const folderAsset = vi.hoisted(() => ({
   }
 }))
 
+type MockAsset = {
+  id: string
+  name: string
+  tags: string[]
+  user_metadata?: {
+    jobId: string
+    nodeId: string
+    subfolder: string
+    outputCount: number
+  }
+}
+
 const storeControls = vi.hoisted(() => ({
-  outputItems: [folderAsset] as (typeof folderAsset)[],
-  setOutputItems(items: (typeof folderAsset)[]) {
+  outputItems: [folderAsset] as MockAsset[],
+  setOutputItems(items: MockAsset[]) {
     this.outputItems.splice(0, this.outputItems.length, ...items)
   }
 }))


### PR DESCRIPTION
## Summary

Covers 3D viewer routing and the missing-thumbnail fallback. Captures the current thumbnail-as-model defect as an expected failure.

## Changes

- Verifies a generated `.glb` asset opens the dedicated full-size 3D viewer.
- Verifies the original Asset API view URL is used when no thumbnail exists.
- Requires the original model URL even when a thumbnail is present; this detector is expected-failing because the current code sends the thumbnail image to the model loader.
- Covers the 3D and missing-preview portion of the media-viewer matrix, tracked internally as TC-VIEW-04.

<details><summary>Verification</summary>

Verification:
- `pnpm test:unit src/components/sidebar/tabs/AssetsSidebarTab.test.ts`: 2 passed, 2 expected failures (one inherited folder-refresh detector).
- Converting the new expected failure to a normal test fails at the exact model URL assertion: the viewer receives `https://example.com/previews/mesh.png` instead of the `.glb` view URL.
- Changing the 3D routing branch to another media type fails both new routing tests.
- Typecheck, ESLint, type-aware Oxlint, format, knip, diff check, commit hooks, and push hook passed.

</details>
