### PR TITLE
test(assets): cover mobile touch actions

### DIFF
--- a/browser_tests/tests/sidebar/assetsSidebarTab.spec.ts
+++ b/browser_tests/tests/sidebar/assetsSidebarTab.spec.ts
@@ -13,6 +13,7 @@ import {
 import { TestIds } from '@e2e/fixtures/selectors'
 import { mockViewFiles } from '@e2e/fixtures/utils/viewFileMocks'
 import { PropertiesPanelHelper } from '@e2e/tests/propertiesPanel/PropertiesPanelHelper'
+import type { AssetResponse } from '@/platform/assets/schemas/assetSchema'
 import type {
   JobDetail,
   RawJobListItem
@@ -153,22 +154,27 @@ async function mockInputFiles(page: Page, files: readonly string[]) {
 
 async function mockAssetApiFiles(page: Page) {
   await page.route(/\/api\/assets(?:\?.*)?$/, async (route) => {
-    await route.fulfill({
-      json: {
-        assets: generatedJobs.map((job, index) => ({
-          id: job.id,
-          name: job.preview_output!.filename,
+    const response = {
+      assets: generatedJobs.map((job, index) => {
+        const filename = job.preview_output?.filename
+        if (!filename) throw new Error(`Missing preview filename for ${job.id}`)
+
+        return {
+          id: `00000000-0000-4000-a000-${String(index + 1).padStart(12, '0')}`,
+          name: filename,
           job_id: `00000000-0000-4000-a000-${String(index + 1).padStart(12, '0')}`,
           mime_type: 'image/png',
           tags: ['output'],
-          preview_url: `/api/view?filename=${job.preview_output!.filename}&type=output`,
+          preview_url: `/api/view?filename=${filename}&type=output`,
           created_at: new Date(job.create_time).toISOString(),
           updated_at: new Date(job.create_time).toISOString()
-        })),
-        total: generatedJobs.length,
-        has_more: false
-      }
-    })
+        }
+      }),
+      total: generatedJobs.length,
+      has_more: false
+    } satisfies AssetResponse
+
+    await route.fulfill({ json: response })
   })
 }
 async function verifyMobileTouchActions(comfyPage: ComfyPage) {

--- a/browser_tests/tests/sidebar/assetsSidebarTab.spec.ts
+++ b/browser_tests/tests/sidebar/assetsSidebarTab.spec.ts
@@ -151,10 +151,29 @@ async function mockInputFiles(page: Page, files: readonly string[]) {
   })
 }
 
+async function mockAssetApiFiles(page: Page) {
+  await page.route(/\/api\/assets(?:\?.*)?$/, async (route) => {
+    await route.fulfill({
+      json: {
+        assets: generatedJobs.map((job, index) => ({
+          id: job.id,
+          name: job.preview_output!.filename,
+          job_id: `00000000-0000-4000-a000-${String(index + 1).padStart(12, '0')}`,
+          mime_type: 'image/png',
+          tags: ['output'],
+          preview_url: `/api/view?filename=${job.preview_output!.filename}&type=output`,
+          created_at: new Date(job.create_time).toISOString(),
+          updated_at: new Date(job.create_time).toISOString()
+        })),
+        total: generatedJobs.length,
+        has_more: false
+      }
+    })
+  })
+}
 async function verifyMobileTouchActions(comfyPage: ComfyPage) {
   const tab = comfyPage.menu.assetsTab
 
-  await comfyPage.setup()
   await tab.open()
 
   await tab.getAssetCardByName('alpha').tap()
@@ -193,6 +212,7 @@ test.describe('FE-130 assets sidebar route mocks', () => {
   test.beforeEach(async ({ jobsRoutes, page }) => {
     await jobsRoutes.mockJobsQueue([])
     await jobsRoutes.mockJobsHistory(generatedJobs)
+    await mockAssetApiFiles(page)
     await mockInputFiles(page, ['imported.png'])
     await mockViewFiles(page, viewFiles)
   })
@@ -277,7 +297,7 @@ test.describe('FE-130 assets sidebar route mocks', () => {
     await verifyMobileTouchActions(comfyPage)
   })
 
-  test('@mobile-ios touch selection keeps actions reachable', async ({
+  test('@mobile-ios @cloud touch selection keeps actions reachable', async ({
     comfyPage
   }) => {
     await verifyMobileTouchActions(comfyPage)

--- a/browser_tests/tests/sidebar/assetsSidebarTab.spec.ts
+++ b/browser_tests/tests/sidebar/assetsSidebarTab.spec.ts
@@ -2,6 +2,7 @@ import { expect, mergeTests } from '@playwright/test'
 import type { Page, Response } from '@playwright/test'
 
 import { comfyPageFixture } from '@e2e/fixtures/ComfyPage'
+import type { ComfyPage } from '@e2e/fixtures/ComfyPage'
 import { expectNoErrorUiAfterVerification } from '@e2e/fixtures/helpers/ErrorsTabHelper'
 import {
   createRouteMockJob,
@@ -150,6 +151,23 @@ async function mockInputFiles(page: Page, files: readonly string[]) {
   })
 }
 
+async function verifyMobileTouchActions(comfyPage: ComfyPage) {
+  const tab = comfyPage.menu.assetsTab
+
+  await comfyPage.setup()
+  await tab.open()
+
+  await tab.getAssetCardByName('alpha').tap()
+  await expect(tab.selectedCards).toHaveCount(1)
+  await expect(tab.selectionFooter).toBeInViewport({ ratio: 1 })
+  await expect(tab.downloadSelectedButton).toBeInViewport({ ratio: 1 })
+  await expect(tab.deleteSelectedButton).toBeInViewport({ ratio: 1 })
+
+  await tab.deleteSelectedButton.tap()
+  await expect(comfyPage.confirmDialog.root).toBeVisible()
+  await expect(comfyPage.confirmDialog.delete).toBeInViewport({ ratio: 1 })
+  await expect(comfyPage.confirmDialog.reject).toBeInViewport({ ratio: 1 })
+}
 function isGeneratedAssetVerificationResponse(response: Response): boolean {
   const url = new URL(response.url())
   return (
@@ -251,6 +269,18 @@ test.describe('FE-130 assets sidebar route mocks', () => {
     await expect(tab.selectionCountButton).toHaveText(/\b2 selected\b/)
     await expect(tab.deleteSelectedButton).toBeVisible()
     await expect(tab.downloadSelectedButton).toBeVisible()
+  })
+
+  test('@mobile touch selection keeps actions reachable', async ({
+    comfyPage
+  }) => {
+    await verifyMobileTouchActions(comfyPage)
+  })
+
+  test('@mobile-ios touch selection keeps actions reachable', async ({
+    comfyPage
+  }) => {
+    await verifyMobileTouchActions(comfyPage)
   })
 
   test('loads full generated job outputs from job detail', async ({


### PR DESCRIPTION
## Summary

Pixel 5 and iPhone 15 coverage. Touch selection and actions stay reachable. Adds route-mocked mobile coverage for selecting a generated asset by touch, reaching the complete selection footer, and opening a delete confirmation whose actions remain fully inside the viewport.

## Review Focus

Covers mobile touch selection and action reachability, tracked internally as TC-SEL-06.

<details><summary>Verification</summary>

Verification:
- Playwright collection: 1 Pixel 5 Chromium test and 1 iPhone 15 WebKit test
- Typecheck: green, exit 0
- ESLint, type-aware Oxlint, formatting, and knip: green
- Commit and push hooks: green
- Local execution could not pass harness setup because the local test backend returns 404 for its settings endpoint; WebKit is also absent locally. CI is the execution gate.

</details>
