### PR TITLE
test: cover widget visibility compatibility

### DIFF
--- a/browser_tests/tests/legacyDoNotReplicate/legacyWidgetVisibilityMutation.spec.ts
+++ b/browser_tests/tests/legacyDoNotReplicate/legacyWidgetVisibilityMutation.spec.ts
@@ -1,0 +1,70 @@
+import {
+  comfyExpect as expect,
+  comfyPageFixture as test
+} from '@e2e/fixtures/ComfyPage'
+
+test.describe(
+  'Legacy widget visibility mutation',
+  { tag: '@vue-nodes' },
+  () => {
+    test('reacts to options.hidden writes and deletes', async ({
+      comfyPage
+    }) => {
+      const widget = comfyPage.vueNodes.getWidgetByName('KSampler', 'steps')
+
+      await expect(widget).toBeVisible()
+      await comfyPage.page.evaluate(() => {
+        const node = window.app!.graph.nodes.find(
+          (candidate) => candidate.type === 'KSampler'
+        )
+        const widget = node?.widgets?.find(
+          (candidate) => candidate.name === 'steps'
+        )
+        if (!widget) throw new Error('KSampler steps widget not found')
+        widget.options.hidden = true
+      })
+      await expect(widget).toBeHidden()
+
+      await comfyPage.page.evaluate(() => {
+        const node = window.app!.graph.nodes.find(
+          (candidate) => candidate.type === 'KSampler'
+        )
+        const widget = node?.widgets?.find(
+          (candidate) => candidate.name === 'steps'
+        )
+        if (!widget) throw new Error('KSampler steps widget not found')
+        delete widget.options.hidden
+      })
+      await expect(widget).toBeVisible()
+    })
+
+    test('reacts to legacy hidden type mutations', async ({ comfyPage }) => {
+      const widget = comfyPage.vueNodes.getWidgetByName('KSampler', 'steps')
+
+      await expect(widget).toBeVisible()
+      await comfyPage.page.evaluate(() => {
+        const node = window.app!.graph.nodes.find(
+          (candidate) => candidate.type === 'KSampler'
+        )
+        const widget = node?.widgets?.find(
+          (candidate) => candidate.name === 'steps'
+        )
+        if (!widget) throw new Error('KSampler steps widget not found')
+        widget.type = 'tschide_number'
+      })
+      await expect(widget).toBeHidden()
+
+      await comfyPage.page.evaluate(() => {
+        const node = window.app!.graph.nodes.find(
+          (candidate) => candidate.type === 'KSampler'
+        )
+        const widget = node?.widgets?.find(
+          (candidate) => candidate.name === 'steps'
+        )
+        if (!widget) throw new Error('KSampler steps widget not found')
+        widget.type = 'number'
+      })
+      await expect(widget).toBeVisible()
+    })
+  }
+)

--- a/browser_tests/tests/painter.spec.ts
+++ b/browser_tests/tests/painter.spec.ts
@@ -40,6 +40,21 @@ test.describe('Painter', { tag: ['@widget', '@vue-nodes'] }, () => {
       for (const widgetName of HIDDEN_PAINTER_WIDGET_NAMES) {
         await expect(node.getByLabel(widgetName, { exact: true })).toBeHidden()
       }
+
+      await comfyPage.page.evaluate(() => {
+        const painter = window.app!.graph.nodes.find(
+          (candidate) => candidate.type === 'Painter'
+        )
+        if (!painter) throw new Error('Painter node not found')
+        window.app!.canvas.selectNode(painter)
+      })
+      await comfyPage.actionbar.propertiesButton.click()
+      const parameters = comfyPage.menu.propertiesPanel.root
+      for (const widgetName of HIDDEN_PAINTER_WIDGET_NAMES) {
+        await expect(
+          parameters.getByLabel(widgetName, { exact: true })
+        ).toBeHidden()
+      }
     })
   })
 

--- a/browser_tests/tests/propertiesPanel/nodeSelection.spec.ts
+++ b/browser_tests/tests/propertiesPanel/nodeSelection.spec.ts
@@ -36,6 +36,46 @@ test.describe('Properties panel - Node selection', () => {
     })
 
     test(
+      'hideInPanel keeps a widget on the node but removes it from Parameters',
+      { tag: '@vue-nodes' },
+      async ({ comfyPage }) => {
+        const node = comfyPage.vueNodes.getNodeByTitle('KSampler')
+        await comfyPage.page.evaluate(() => {
+          const kSampler = window.app!.graph.nodes.find(
+            (candidate) => candidate.type === 'KSampler'
+          )
+          if (!kSampler) throw new Error('KSampler node not found')
+          window.app!.canvas.selectNode(kSampler)
+        })
+        await expect(panel.panelTitle).toContainText('KSampler')
+        await panel.getTab('Parameters').click()
+        const nodeWidget = node.getByLabel('steps', { exact: true })
+        const panelWidget = panel.contentArea.getByText('steps', {
+          exact: true
+        })
+
+        await expect(nodeWidget).toBeVisible()
+        await expect(panelWidget).toBeVisible()
+
+        await comfyPage.page.evaluate(() => {
+          const node = window.app!.graph.nodes.find(
+            (candidate) => candidate.type === 'KSampler'
+          )
+          const widget = node?.widgets?.find(
+            (candidate) => candidate.name === 'steps'
+          )
+          if (!widget) throw new Error('KSampler steps widget not found')
+          widget.options.hideInPanel = true
+        })
+
+        await panel.getTab('Info').click()
+        await panel.getTab('Parameters').click()
+        await expect(nodeWidget).toBeVisible()
+        await expect(panelWidget).toBeHidden()
+      }
+    )
+
+    test(
       'should not display canvasOnly widgets',
       { tag: '@vue-nodes' },
       async ({ comfyPage }) => {


### PR DESCRIPTION
## Summary

Add Playwright coverage for first-party and legacy widget visibility paths introduced by #16312.

## Changes

- **What**: Covers Painter hidden metadata in Vue, panel, and legacy canvas rendering; verifies `hideInPanel`; and quarantines supported `options.hidden` and hidden-type mutations under `legacyDoNotReplicate`.
- **Dependencies**: Stacked on #16312.

## Review Focus

The quarantined post-registration `options.hidden` test currently fails against the parent branch. `adoptConcreteWidget()` preserves the original widget's `options` data property, so the `BaseWidget` compatibility proxy is not retained. The other four targeted Playwright cases pass.