### PR TITLE
Parse optional doc_update.op_ids for per-op effect attribution (DQ-9 FE leg)

### DIFF
--- a/src/renderer/extensions/vueNodes/composables/processedWidgetRenderModel.ts
+++ b/src/renderer/extensions/vueNodes/composables/processedWidgetRenderModel.ts
@@ -459,7 +459,7 @@ export function computeProcessedWidgets({
   forceDisabled = false,
   isGraphReady,
   rootGraph,
-  ui,
+  ui
 }: ComputeProcessedWidgetsOptions): ProcessedWidget[] {
   if (!nodeData) return []
 
@@ -512,7 +512,7 @@ export function computeProcessedWidgets({
     missingModelStore,
     missingMediaStore,
     nodeDefStore,
-    ui,
+    ui
   }
 
   return Array.from(new Set(ids))

--- a/src/workbench/extensions/agent/crdt/docFrameClient.test.ts
+++ b/src/workbench/extensions/agent/crdt/docFrameClient.test.ts
@@ -55,6 +55,50 @@ describe('doc frame client', () => {
     )
   })
 
+  it('parses well-formed doc_update op_ids into opIds (DQ-9 attribution)', () => {
+    const source = new Y.Doc()
+    source.getMap('nodes').set('one', { x: 10 })
+    const frame = parseServerDocFrame({
+      type: 'doc_update',
+      data: {
+        v: 1,
+        workflow_id: 'wf-1',
+        seq: 1,
+        update_b64: encodeBase64(Y.encodeStateAsUpdate(source)),
+        op_ids: ['op-1', 'op-2']
+      }
+    })
+    if (frame?.type !== 'doc_update') throw new Error('Expected doc_update')
+    expect(frame.data.opIds).toEqual(['op-1', 'op-2'])
+  })
+
+  it('reads absent or malformed op_ids as unattributed, never rejecting the frame', () => {
+    const source = new Y.Doc()
+    source.getMap('nodes').set('one', { x: 10 })
+    const update_b64 = encodeBase64(Y.encodeStateAsUpdate(source))
+    const base = { v: 1, workflow_id: 'wf-1', seq: 1, update_b64 }
+
+    // Catch-up frames and pre-DQ-9 hosts legally omit the field entirely.
+    for (const op_ids of [
+      undefined,
+      'op-1', // non-array
+      42,
+      { 0: 'op-1' },
+      ['op-1', 7], // mixed-type array
+      [null]
+    ]) {
+      const frame = parseServerDocFrame({
+        type: 'doc_update',
+        data: op_ids === undefined ? base : { ...base, op_ids }
+      })
+      expect(frame?.type).toBe('doc_update')
+      if (frame?.type !== 'doc_update') throw new Error('Expected doc_update')
+      expect(frame.data.opIds).toBeUndefined()
+      // The update bytes still ride along untouched.
+      expect(frame.data.update.length).toBeGreaterThan(0)
+    }
+  })
+
   it('replaying an update is idempotent', () => {
     const source = new Y.Doc()
     source.getArray('items').push(['a'])

--- a/src/workbench/extensions/agent/crdt/docFrameClient.ts
+++ b/src/workbench/extensions/agent/crdt/docFrameClient.ts
@@ -11,6 +11,14 @@ export interface DocUpdate {
   seq: number
   update: Uint8Array
   actor?: string
+  /**
+   * Authoritative per-op effect attribution (DQ-9): the `op_id`s whose effects
+   * this update frame carries. Absent on catch-up frames (which legally fold
+   * many ops into one snapshot) and on hosts that predate DQ-9 — absence means
+   * "unattributed", never "no ops". A frame missing or malforming this field
+   * still applies; attribution is diagnostic, not a gate.
+   */
+  opIds?: string[]
 }
 
 export interface DocSubscribed {
@@ -85,6 +93,7 @@ interface WireData {
   workflow_id?: unknown
   seq?: unknown
   update_b64?: unknown
+  op_ids?: unknown
   actor?: unknown
   ok?: unknown
   code?: unknown
@@ -109,6 +118,16 @@ export function encodeBase64(value: Uint8Array): string {
 
 function parseWireData(value: unknown): WireData | null {
   return typeof value === 'object' && value !== null ? value : null
+}
+
+/**
+ * Tolerant `op_ids` guard: anything other than an array of strings — absent,
+ * non-array, or an array with a non-string member — reads as "unattributed"
+ * rather than rejecting the frame. Update bytes are the contract; attribution
+ * is best-effort metadata a malformed field must never take down.
+ */
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((item) => typeof item === 'string')
 }
 
 function parseRecord(value: unknown): Record<string, unknown> | null {
@@ -139,7 +158,8 @@ export function parseServerDocFrame(value: unknown): ServerDocFrame | null {
         workflowId: data.workflow_id,
         seq: data.seq,
         update: decodeBase64(data.update_b64),
-        ...(typeof data.actor === 'string' && { actor: data.actor })
+        ...(typeof data.actor === 'string' && { actor: data.actor }),
+        ...(isStringArray(data.op_ids) && { opIds: [...data.op_ids] })
       }
     }
   }

--- a/src/workbench/extensions/agent/crdt/followerSubscription.test.ts
+++ b/src/workbench/extensions/agent/crdt/followerSubscription.test.ts
@@ -168,6 +168,24 @@ describe('FE-SUBSCRIBE-1 — a subscribe raced against socket startup recovers',
   })
 })
 
+describe('DQ-9 — op attribution rides the re-dispatched frame', () => {
+  it('opIds pass through the bridge to doc_update listeners untouched', () => {
+    const { transport, bridge, projected } = wire()
+    transport.open = true
+    bridge.subscribe(WORKFLOW_ID)
+
+    transport.deliver('doc_update', {
+      ...docUpdateFrame(hostDocUpdate()),
+      op_ids: ['op-1', 'op-2']
+    })
+
+    expect(projected).toHaveLength(1)
+    expect(projected[0].opIds).toEqual(['op-1', 'op-2'])
+    // Attribution is metadata: the update itself was still applied.
+    expect(bridge.follower.updatesApplied).toBe(1)
+  })
+})
+
 describe('FE-TEARDOWN-1 — teardown completes with a dead socket', () => {
   it('releases every transport listener and the doc when unsubscribe cannot send', () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})


### PR DESCRIPTION
- New optional `doc_update.op_ids[]` → `DocUpdate.opIds` (tolerant parse)
- Backward-compatible: absent/malformed field never rejects a frame
- Green: 67/67 crdt tests, typecheck, lint, format

<details><summary>Full context for agent readers</summary>

## What

FE alignment leg of DQ-9 (per-op effect attribution). The cloud relay will emit `op_ids: string[]` on `doc_update` frames so followers can attribute Yjs update effects to the specific `doc_ops` batch entries that produced them. This PR teaches the FE parser to carry that field:

- `DocUpdate` gains optional `opIds?: string[]` — doc comment states absence means "unattributed", never "no ops" (catch-up frames legally fold many ops into one snapshot; pre-DQ-9 hosts never send it).
- `WireData` gains `op_ids?: unknown`; `parseServerDocFrame` accepts it only when it is an array whose every member is a string (`isStringArray` guard), following the existing spread-conditional house pattern used for `actor`.
- Malformed field (non-array, mixed-type array, `[null]`) → `opIds` omitted, frame still parses and applies. Attribution is diagnostic metadata, not a gate.
- `LayoutFollowerBridge` re-dispatches the parsed `DocUpdate` object as-is, so `opIds` propagates to `doc_update` listeners with zero bridge changes — covered by a pass-through test.

Deliberately NOT in this PR: pending-op ledger clearing keyed on `opIds` (owned by a separate task in the dispatcher stack).

## Ordering vs cloud

The cloud emit leg is staged on cloud branch `christian-byrne/gap1-doc-update-op-ids@5c30160062` (stacked on #7870). The FE leg is safe to land first: with no `op_ids` on the wire, `opIds` is simply `undefined` everywhere, which is the pre-existing behavior.

## Diagram

```
cloud relay ──doc_update {v, workflow_id, seq, update_b64, op_ids?}──▶ apiTransport
                                                                          │
                                                    parseServerDocFrame(…)│  tolerant:
                                                    op_ids string[] → opIds; else omit
                                                                          ▼
                                              LayoutFollowerBridge.onDocUpdate
                                        (seq gap check → apply → KA-11 schema gate)
                                                                          │
                                       re-dispatch CustomEvent('doc_update', {detail})
                                                                          ▼
                                          listeners see DocUpdate.opIds unchanged
```

## Test evidence

`pnpm vitest run src/workbench/extensions/agent/crdt/` → 9 files, 67/67 passed. `pnpm typecheck`, eslint, `oxfmt --check` on changed files all clean.

## Glossary

- **DQ-9** — design question ruling: relay emits per-frame `op_ids` for effect attribution.
- **opIds / op_ids** — IDs of the `doc_ops` batch entries whose effects a `doc_update` frame carries.
- **catch-up frame** — the snapshot-style update sent after (re)subscribe; folds many ops, so it carries no attribution.
- **KA-11** — read-time schema gate: a follower may not project a doc whose declared schema version this build was not written against.
- **LayoutFollowerBridge** — FE component that subscribes to a workflow doc, applies remote updates to the follower Yjs doc, and re-dispatches frames.

</details>
