### PR TITLE
Pin @comfyorg/comfy-multi-player to npm 0.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
   "dependencies": {
     "@alloc/quick-lru": "catalog:",
     "@atlaskit/pragmatic-drag-and-drop": "^1.3.1",
-    "@comfyorg/comfy-multi-player": "github:Comfy-Org/comfy-multi-player#58e2333ce3bb6375fd2efbc1e9d7df17327f37e0",
+    "@comfyorg/comfy-multi-player": "0.2.0",
     "@comfyorg/comfyui-desktop-bridge-types": "catalog:",
     "@comfyorg/comfyui-electron-types": "catalog:",
     "@comfyorg/design-system": "workspace:*",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
   "dependencies": {
     "@alloc/quick-lru": "catalog:",
     "@atlaskit/pragmatic-drag-and-drop": "^1.3.1",
-    "@comfyorg/comfy-multi-player": "0.2.0",
+    "@comfyorg/comfy-multi-player": "0.2.1",
     "@comfyorg/comfyui-desktop-bridge-types": "catalog:",
     "@comfyorg/comfyui-electron-types": "catalog:",
     "@comfyorg/design-system": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -473,8 +473,8 @@ importers:
         specifier: ^1.3.1
         version: 1.8.1
       '@comfyorg/comfy-multi-player':
-        specifier: github:Comfy-Org/comfy-multi-player#58e2333ce3bb6375fd2efbc1e9d7df17327f37e0
-        version: https://codeload.github.com/Comfy-Org/comfy-multi-player/tar.gz/58e2333ce3bb6375fd2efbc1e9d7df17327f37e0
+        specifier: 0.2.0
+        version: 0.2.0
       '@comfyorg/comfyui-desktop-bridge-types':
         specifier: 'catalog:'
         version: 0.2.0
@@ -1593,9 +1593,8 @@ packages:
     resolution: {integrity: sha512-y7/yvZ2TPAnR9+jnc00klvNNLkJiXFFrQA/hlLCcxA9a2A4zQIOimyFQ9XfwYKiGD1fb5GY8vbKIIgO8d5Tb2A==}
     engines: {node: '>= 20.12.0'}
 
-  '@comfyorg/comfy-multi-player@https://codeload.github.com/Comfy-Org/comfy-multi-player/tar.gz/58e2333ce3bb6375fd2efbc1e9d7df17327f37e0':
-    resolution: {gitHosted: true, integrity: sha512-Ez2PfcoGthskb/eOhIjXJYrGV5vkEbGRXKFLzlAiaqZMnPjfgqd9ppQ48IExReXJtpGZVPdZPVr1J3IPB/voUg==, tarball: https://codeload.github.com/Comfy-Org/comfy-multi-player/tar.gz/58e2333ce3bb6375fd2efbc1e9d7df17327f37e0}
-    version: 0.2.0
+  '@comfyorg/comfy-multi-player@0.2.0':
+    resolution: {integrity: sha512-fdYjkKsZT9oeBgVaCc0pQISYCBHnUbnUDO6d2eXLksTBcKE1CaTJUoSRfVup6B0uwtwrdZPKnn6V9m/hUra6bw==}
 
   '@comfyorg/comfyui-desktop-bridge-types@0.2.0':
     resolution: {integrity: sha512-V5Wj5KXDzTDm5GJAa0xBISjmndNIY5P79pRHQbLkkqJxgp/GPb/QGvcI+xG4ogol0ODJ4j/UBnUmkzpSafw8Aw==}
@@ -10035,7 +10034,7 @@ snapshots:
       fast-wrap-ansi: 0.2.2
       sisteransi: 1.0.5
 
-  '@comfyorg/comfy-multi-player@https://codeload.github.com/Comfy-Org/comfy-multi-player/tar.gz/58e2333ce3bb6375fd2efbc1e9d7df17327f37e0':
+  '@comfyorg/comfy-multi-player@0.2.0':
     dependencies:
       yjs: 13.6.31
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -473,8 +473,8 @@ importers:
         specifier: ^1.3.1
         version: 1.8.1
       '@comfyorg/comfy-multi-player':
-        specifier: 0.2.0
-        version: 0.2.0
+        specifier: 0.2.1
+        version: 0.2.1
       '@comfyorg/comfyui-desktop-bridge-types':
         specifier: 'catalog:'
         version: 0.2.0
@@ -1593,8 +1593,8 @@ packages:
     resolution: {integrity: sha512-y7/yvZ2TPAnR9+jnc00klvNNLkJiXFFrQA/hlLCcxA9a2A4zQIOimyFQ9XfwYKiGD1fb5GY8vbKIIgO8d5Tb2A==}
     engines: {node: '>= 20.12.0'}
 
-  '@comfyorg/comfy-multi-player@0.2.0':
-    resolution: {integrity: sha512-fdYjkKsZT9oeBgVaCc0pQISYCBHnUbnUDO6d2eXLksTBcKE1CaTJUoSRfVup6B0uwtwrdZPKnn6V9m/hUra6bw==}
+  '@comfyorg/comfy-multi-player@0.2.1':
+    resolution: {integrity: sha512-ReaO6GIKUv8ONwhFk/hjJPYiLU7aqbSgjtSaS754gUZqu8ouqLJiKIAJMqk76N92RnPeXALLjBH5bFugkaI3YQ==}
 
   '@comfyorg/comfyui-desktop-bridge-types@0.2.0':
     resolution: {integrity: sha512-V5Wj5KXDzTDm5GJAa0xBISjmndNIY5P79pRHQbLkkqJxgp/GPb/QGvcI+xG4ogol0ODJ4j/UBnUmkzpSafw8Aw==}
@@ -10034,7 +10034,7 @@ snapshots:
       fast-wrap-ansi: 0.2.2
       sisteransi: 1.0.5
 
-  '@comfyorg/comfy-multi-player@0.2.0':
+  '@comfyorg/comfy-multi-player@0.2.1':
     dependencies:
       yjs: 13.6.31
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -198,4 +198,4 @@ overrides:
 # Transitional - drop once 0.2.0 is older than the release-age gate.
 minimumReleaseAgeExclude:
   - '@comfyorg/comfyui-desktop-bridge-types@0.2.0'
-  - '@comfyorg/comfy-multi-player@0.2.0'
+  - '@comfyorg/comfy-multi-player@0.2.0 || 0.2.1'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -198,3 +198,4 @@ overrides:
 # Transitional - drop once 0.2.0 is older than the release-age gate.
 minimumReleaseAgeExclude:
   - '@comfyorg/comfyui-desktop-bridge-types@0.2.0'
+  - '@comfyorg/comfy-multi-player@0.2.0'


### PR DESCRIPTION
## Summary

Repins `@comfyorg/comfy-multi-player` from the temporary git SHA used by [#16198](https://github.com/Comfy-Org/ComfyUI_frontend/pull/16198) to the published exact npm version `0.2.1`.

This executes the approved repin follow-up in [bbc #98, ruling L2:A](https://github.com/christian-byrne/blocked-on-christian/issues/98) and includes the canonical concurrent-grow ordering fix from [comfy-multi-player #140](https://github.com/Comfy-Org/comfy-multi-player/pull/140).

## Changes

- Pin `@comfyorg/comfy-multi-player` to exact `0.2.1`.
- Regenerate `pnpm-lock.yaml` with the npm registry resolution and integrity.
- Temporarily exempt `0.2.1` from the release-age gate so installs remain reproducible while the release is new.

## Validation

- `pnpm typecheck`
- 7 CRDT/multiplayer test files, 89 tests passed
