### PR TITLE
test(assets): cover media load failure

### DIFF
--- a/src/components/sidebar/tabs/queue/MediaLightbox.test.ts
+++ b/src/components/sidebar/tabs/queue/MediaLightbox.test.ts
@@ -29,7 +29,8 @@ const i18n = createI18n({
         gallery: 'Gallery',
         previous: 'Previous',
         next: 'Next',
-        videoFailedToLoad: 'Video failed to load'
+        videoFailedToLoad: 'Video failed to load',
+        textFailedToLoad: 'Text failed to load'
       }
     }
   }
@@ -108,7 +109,7 @@ describe('MediaLightbox', () => {
     }
   ]
 
-  const renderGallery = (props = {}) => {
+  const renderGallery = (props = {}, stubs = {}) => {
     const onUpdateActiveIndex = vi.fn()
     const user = userEvent.setup()
     const { rerender, container } = render(MediaLightbox, {
@@ -120,7 +121,8 @@ describe('MediaLightbox', () => {
           ResultAudio: mockResultAudio
         },
         stubs: {
-          teleport: true
+          teleport: true,
+          ...stubs
         }
       },
       props: {
@@ -187,6 +189,35 @@ describe('MediaLightbox', () => {
     await nextTick()
 
     expect(onUpdateActiveIndex).toHaveBeenCalledWith(-1)
+  })
+
+  it('keeps failed text media actionable until the viewer closes', async () => {
+    const fetchMock = vi.fn(() =>
+      Promise.resolve(new Response(null, { status: 503 }))
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { user } = renderGallery(
+      {
+        allGalleryItems: [
+          {
+            ...mockGalleryItems[0],
+            isImage: false,
+            isText: true,
+            mediaType: 'text',
+            url: '/api/view?filename=failed.txt'
+          }
+        ] as ResultItemImpl[]
+      },
+      { ResultText: false }
+    )
+
+    expect(await screen.findByText('Text failed to load')).toBeInTheDocument()
+    expect(fetchMock).toHaveBeenCalledWith('/api/view?filename=failed.txt')
+
+    await user.click(screen.getByLabelText('Close'))
+
+    expect(screen.queryByText('Text failed to load')).not.toBeInTheDocument()
   })
 
   /* eslint-disable testing-library/prefer-user-event -- keyDown on dialog element for navigation, not text input */


### PR DESCRIPTION
Text failures stay visible and closable.
The real viewer error path is covered.

<details><summary>Full context for agent readers</summary>

Adds component integration coverage for a text asset request returning HTTP 503. The test runs the real text viewer and composable, requires the localized failure state, verifies the exact media request, and proves the close action removes the failed media subtree.

Completes the media-viewer load-error behavior, tracked internally as TC-VIEW-04.

Verification:
- Media lightbox and known-green control suites: 18/18 passed
- Typecheck: green, exit 0
- ESLint, type-aware Oxlint, formatting, knip, and diff check: green
- Mutation: suppressing the real viewer's error branch failed at the intended fallback-text assertion
- Commit and push hooks: green

</details>