### PR TITLE
test: cover agent follower canvas convergence

### DIFF
--- a/browser_tests/fixtures/ws.ts
+++ b/browser_tests/fixtures/ws.ts
@@ -20,20 +20,35 @@ function createWebSocketRouteHandler(
 export const webSocketFixture = base.extend<{
   connectWebSocketToServer: boolean
   getWebSocket: () => Promise<WebSocketRoute>
+  webSocketMessages: string[]
 }>({
   connectWebSocketToServer: [true, { option: true }],
+  webSocketMessages: async ({}, use) => {
+    await use([])
+  },
   getWebSocket: [
-    async ({ context, connectWebSocketToServer }, use) => {
+    async ({ context, connectWebSocketToServer, webSocketMessages }, use) => {
       let latest: WebSocketRoute | undefined
       let resolve: ((ws: WebSocketRoute) => void) | undefined
 
-      await context.routeWebSocket(
-        /\/ws/,
-        createWebSocketRouteHandler(connectWebSocketToServer, (ws) => {
-          latest = ws
-          resolve?.(ws)
+      await context.routeWebSocket(/\/ws/, (ws) => {
+        const server = connectWebSocketToServer
+          ? ws.connectToServer()
+          : undefined
+
+        ws.onMessage((message) => {
+          if (typeof message === 'string') webSocketMessages.push(message)
+          server?.send(message)
         })
-      )
+        if (server) {
+          server.onMessage((message) => {
+            ws.send(message)
+          })
+        }
+
+        latest = ws
+        resolve?.(ws)
+      })
 
       await use(() => {
         if (latest) return Promise.resolve(latest)

--- a/browser_tests/fixtures/ws.ts
+++ b/browser_tests/fixtures/ws.ts
@@ -1,22 +1,6 @@
 import { test as base } from '@playwright/test'
 import type { WebSocketRoute } from '@playwright/test'
 
-function createWebSocketRouteHandler(
-  connectWebSocketToServer: boolean,
-  onRouted: (ws: WebSocketRoute) => void
-) {
-  return (ws: WebSocketRoute) => {
-    if (connectWebSocketToServer) {
-      const server = ws.connectToServer()
-      server.onMessage((message) => {
-        ws.send(message)
-      })
-    }
-
-    onRouted(ws)
-  }
-}
-
 export const webSocketFixture = base.extend<{
   connectWebSocketToServer: boolean
   getWebSocket: () => Promise<WebSocketRoute>

--- a/browser_tests/tests/agent/agentPanel.spec.ts
+++ b/browser_tests/tests/agent/agentPanel.spec.ts
@@ -217,9 +217,11 @@ test.describe('In-App Agent panel', { tag: '@cloud' }, () => {
     await composer.fill('Add a node to this workflow')
     await panel.getByRole('button', { name: 'Send' }).click()
 
-    await expect.poll(() => postedMessages.length).toBe(1)
+    await expect.poll(() => postedMessages.length, { timeout: 10_000 }).toBe(1)
     await expect
-      .poll(() => webSocketMessages.some(isWorkflowSubscribe))
+      .poll(() => webSocketMessages.some(isWorkflowSubscribe), {
+        timeout: 10_000
+      })
       .toBe(true)
 
     const ws = await getWebSocket()
@@ -228,13 +230,15 @@ test.describe('In-App Agent panel', { tag: '@cloud' }, () => {
     pushEvent(ws, updates.initial)
 
     await expect
-      .poll(() =>
-        page.evaluate(() =>
-          window.app!.graph._nodes.some(
-            (node) =>
-              String(node.id) === '41' && node.title === 'Agent-created node'
-          )
-        )
+      .poll(
+        () =>
+          page.evaluate(() =>
+            window.app!.graph._nodes.some(
+              (node) =>
+                String(node.id) === '41' && node.title === 'Agent-created node'
+            )
+          ),
+        { timeout: 10_000 }
       )
       .toBe(true)
 
@@ -245,7 +249,8 @@ test.describe('In-App Agent panel', { tag: '@cloud' }, () => {
         () =>
           webSocketMessages
             .slice(messagesBeforeReconnect)
-            .filter(isWorkflowSubscribe).length
+            .filter(isWorkflowSubscribe).length,
+        { timeout: 10_000 }
       )
       .toBeGreaterThanOrEqual(1)
 
@@ -260,16 +265,20 @@ test.describe('In-App Agent panel', { tag: '@cloud' }, () => {
     pushEvent(reconnectedWs, updates.reconnectDelta)
 
     await expect(panel.getByTestId('agent-crdt-status')).toContainText(
-      '2 updates'
+      '2 updates',
+      { timeout: 10_000 }
     )
 
     await expect
-      .poll(() =>
-        page.evaluate(
-          () =>
-            window.app!.graph._nodes.filter((node) => String(node.id) === '41')
-              .length
-        )
+      .poll(
+        () =>
+          page.evaluate(
+            () =>
+              window.app!.graph._nodes.filter(
+                (node) => String(node.id) === '41'
+              ).length
+          ),
+        { timeout: 10_000 }
       )
       .toBe(1)
   })

--- a/browser_tests/tests/agent/agentPanel.spec.ts
+++ b/browser_tests/tests/agent/agentPanel.spec.ts
@@ -214,6 +214,10 @@ test.describe('In-App Agent panel', { tag: '@cloud' }, () => {
     await page.getByRole('button', { name: OPEN_AGENT_LABEL }).click()
     const panel = page.locator('#agent-panel-root')
     const composer = panel.getByRole('textbox', { name: /^Describe ideas/ })
+    const ws = await getWebSocket()
+    await expect
+      .poll(() => webSocketMessages.length, { timeout: 10_000 })
+      .toBeGreaterThan(0)
     await composer.fill('Add a node to this workflow')
     await panel.getByRole('button', { name: 'Send' }).click()
 
@@ -224,7 +228,6 @@ test.describe('In-App Agent panel', { tag: '@cloud' }, () => {
       })
       .toBe(true)
 
-    const ws = await getWebSocket()
     pushEvent(ws, agentDocSubscribed())
     const updates = agentWorkflowUpdates()
     pushEvent(ws, updates.initial)

--- a/browser_tests/tests/agent/agentPanel.spec.ts
+++ b/browser_tests/tests/agent/agentPanel.spec.ts
@@ -269,11 +269,6 @@ test.describe('In-App Agent panel', { tag: '@cloud' }, () => {
     pushEvent(reconnectedWs, agentDocSubscribed())
     pushEvent(reconnectedWs, updates.reconnectDelta)
 
-    await expect(panel.getByTestId('agent-crdt-status')).toContainText(
-      '2 updates',
-      { timeout: 10_000 }
-    )
-
     await expect
       .poll(
         () =>

--- a/browser_tests/tests/agent/agentPanel.spec.ts
+++ b/browser_tests/tests/agent/agentPanel.spec.ts
@@ -16,15 +16,46 @@ import {
   THINKING_EVENT,
   THINKING_TEXT,
   TOOL_CALL_EVENT,
+  WORKFLOW_ID,
+  agentDocSubscribed,
+  agentWorkflowUpdates,
   agentTest
 } from '@e2e/tests/agent/agentPanelMocks'
+import type { AgentDocWireFrame } from '@e2e/tests/agent/agentPanelMocks'
 
 const test = mergeTests(agentTest, webSocketFixture)
 
 const OPEN_AGENT_LABEL = enMessages.agent.askComfyAgent
 
-function pushEvent(ws: WebSocketRoute, event: AgentWsEvent): void {
+function pushEvent(
+  ws: WebSocketRoute,
+  event: AgentWsEvent | AgentDocWireFrame
+): void {
   ws.send(JSON.stringify(event))
+}
+
+function isWorkflowSubscribe(message: string): boolean {
+  return workflowSubscribeStateVector(message) !== undefined
+}
+
+function workflowSubscribeStateVector(message: string): string | undefined {
+  try {
+    const frame: unknown = JSON.parse(message)
+    if (typeof frame !== 'object' || frame === null) return
+    const { type, data } = frame as { type?: unknown; data?: unknown }
+    if (type !== 'doc_subscribe' || typeof data !== 'object' || data === null)
+      return
+    const subscribe = data as {
+      workflow_id?: unknown
+      state_vector_b64?: unknown
+    }
+    if (subscribe.workflow_id !== WORKFLOW_ID) return
+    return typeof subscribe.state_vector_b64 === 'string'
+      ? subscribe.state_vector_b64
+      : undefined
+  } catch {
+    return
+  }
 }
 
 test.describe('In-App Agent panel', { tag: '@cloud' }, () => {
@@ -169,6 +200,78 @@ test.describe('In-App Agent panel', { tag: '@cloud' }, () => {
       panel.getByRole('button', { name: /ran 2 tool calls/i })
     ).toHaveAttribute('aria-expanded', 'false')
     await expect(firstSummary).toHaveAttribute('aria-expanded', 'false')
+  })
+
+  test('retains the agent doc and requests a delta after reconnect', async ({
+    comfyPage,
+    getWebSocket,
+    postedMessages,
+    webSocketMessages
+  }) => {
+    test.setTimeout(30_000)
+
+    const page = comfyPage.page
+    await page.getByRole('button', { name: OPEN_AGENT_LABEL }).click()
+    const panel = page.locator('#agent-panel-root')
+    const composer = panel.getByRole('textbox', { name: /^Describe ideas/ })
+    await composer.fill('Add a node to this workflow')
+    await panel.getByRole('button', { name: 'Send' }).click()
+
+    await expect.poll(() => postedMessages.length).toBe(1)
+    await expect
+      .poll(() => webSocketMessages.some(isWorkflowSubscribe))
+      .toBe(true)
+
+    const ws = await getWebSocket()
+    pushEvent(ws, agentDocSubscribed())
+    const updates = agentWorkflowUpdates()
+    pushEvent(ws, updates.initial)
+
+    await expect
+      .poll(() =>
+        page.evaluate(() =>
+          window.app!.graph._nodes.some(
+            (node) =>
+              String(node.id) === '41' && node.title === 'Agent-created node'
+          )
+        )
+      )
+      .toBe(true)
+
+    const messagesBeforeReconnect = webSocketMessages.length
+    await ws.close()
+    await expect
+      .poll(
+        () =>
+          webSocketMessages
+            .slice(messagesBeforeReconnect)
+            .filter(isWorkflowSubscribe).length
+      )
+      .toBeGreaterThanOrEqual(1)
+
+    const reconnectSubscribe = webSocketMessages
+      .slice(messagesBeforeReconnect)
+      .map(workflowSubscribeStateVector)
+      .find((stateVector) => stateVector !== undefined)
+    expect(reconnectSubscribe).toBeTruthy()
+
+    const reconnectedWs = await getWebSocket()
+    pushEvent(reconnectedWs, agentDocSubscribed())
+    pushEvent(reconnectedWs, updates.reconnectDelta)
+
+    await expect(panel.getByTestId('agent-crdt-status')).toContainText(
+      '2 updates'
+    )
+
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () =>
+            window.app!.graph._nodes.filter((node) => String(node.id) === '41')
+              .length
+        )
+      )
+      .toBe(1)
   })
 
   test.describe('composer sizing', () => {

--- a/browser_tests/tests/agent/agentPanel.spec.ts
+++ b/browser_tests/tests/agent/agentPanel.spec.ts
@@ -260,7 +260,7 @@ test.describe('In-App Agent panel', { tag: '@cloud' }, () => {
       .slice(messagesBeforeReconnect)
       .map(workflowSubscribeStateVector)
       .find((stateVector) => stateVector !== undefined)
-    expect(reconnectSubscribe).toBeTruthy()
+    expect(reconnectSubscribe).toBe(updates.initialStateVector)
 
     const reconnectedWs = await getWebSocket()
     pushEvent(reconnectedWs, agentDocSubscribed())

--- a/browser_tests/tests/agent/agentPanel.spec.ts
+++ b/browser_tests/tests/agent/agentPanel.spec.ts
@@ -212,6 +212,7 @@ test.describe('In-App Agent panel', { tag: '@cloud' }, () => {
     test.setTimeout(30_000)
 
     const page = comfyPage.page
+    await comfyPage.workflow.loadWorkflow('default')
     await page.getByRole('button', { name: OPEN_AGENT_LABEL }).click()
     const panel = page.locator('#agent-panel-root')
     const composer = panel.getByRole('textbox', { name: /^Describe ideas/ })

--- a/browser_tests/tests/agent/agentPanel.spec.ts
+++ b/browser_tests/tests/agent/agentPanel.spec.ts
@@ -220,6 +220,7 @@ test.describe('In-App Agent panel', { tag: '@cloud' }, () => {
     await panel.getByRole('button', { name: 'Send' }).click()
 
     await expect.poll(() => postedMessages.length, { timeout: 10_000 }).toBe(1)
+    await expect(panel.getByRole('button', { name: 'Stop' })).toBeVisible()
     pushEvent(ws, SOCKET_READY_EVENT)
     await expect
       .poll(() => webSocketMessages.some(isWorkflowSubscribe), {

--- a/browser_tests/tests/agent/agentPanel.spec.ts
+++ b/browser_tests/tests/agent/agentPanel.spec.ts
@@ -213,6 +213,7 @@ test.describe('In-App Agent panel', { tag: '@cloud' }, () => {
 
     const page = comfyPage.page
     await comfyPage.workflow.loadWorkflow('default')
+    await comfyPage.menu.topbar.saveWorkflow('default')
     await page.getByRole('button', { name: OPEN_AGENT_LABEL }).click()
     const panel = page.locator('#agent-panel-root')
     const composer = panel.getByRole('textbox', { name: /^Describe ideas/ })

--- a/browser_tests/tests/agent/agentPanel.spec.ts
+++ b/browser_tests/tests/agent/agentPanel.spec.ts
@@ -13,6 +13,7 @@ import {
   OPEN_TAB_TOOL_EVENT,
   RESIZE_IMAGE_TOOL_EVENT,
   RESUMED_THINKING_EVENT,
+  SOCKET_READY_EVENT,
   THINKING_EVENT,
   THINKING_TEXT,
   TOOL_CALL_EVENT,
@@ -21,7 +22,7 @@ import {
   agentWorkflowUpdates,
   agentTest
 } from '@e2e/tests/agent/agentPanelMocks'
-import type { AgentDocWireFrame } from '@e2e/tests/agent/agentPanelMocks'
+import type { AgentWireFrame } from '@e2e/tests/agent/agentPanelMocks'
 
 const test = mergeTests(agentTest, webSocketFixture)
 
@@ -29,7 +30,7 @@ const OPEN_AGENT_LABEL = enMessages.agent.askComfyAgent
 
 function pushEvent(
   ws: WebSocketRoute,
-  event: AgentWsEvent | AgentDocWireFrame
+  event: AgentWsEvent | AgentWireFrame
 ): void {
   ws.send(JSON.stringify(event))
 }
@@ -215,13 +216,11 @@ test.describe('In-App Agent panel', { tag: '@cloud' }, () => {
     const panel = page.locator('#agent-panel-root')
     const composer = panel.getByRole('textbox', { name: /^Describe ideas/ })
     const ws = await getWebSocket()
-    await expect
-      .poll(() => webSocketMessages.length, { timeout: 10_000 })
-      .toBeGreaterThan(0)
     await composer.fill('Add a node to this workflow')
     await panel.getByRole('button', { name: 'Send' }).click()
 
     await expect.poll(() => postedMessages.length, { timeout: 10_000 }).toBe(1)
+    pushEvent(ws, SOCKET_READY_EVENT)
     await expect
       .poll(() => webSocketMessages.some(isWorkflowSubscribe), {
         timeout: 10_000

--- a/browser_tests/tests/agent/agentPanelMocks.ts
+++ b/browser_tests/tests/agent/agentPanelMocks.ts
@@ -20,9 +20,15 @@ const THREAD_ID = 'd4c016c4-3b8c-44cf-97de-1ae27e43e718'
 const TURN_ID = '3818ba00-d772-4a3f-98c1-9312725b577d'
 export const WORKFLOW_ID = 'a81718a4-02ae-41e6-ae85-c33b7bb880f6'
 
-export type AgentDocWireFrame =
+export type AgentWireFrame =
   | ReturnType<typeof agentWorkflowUpdates>['initial']
   | ReturnType<typeof agentDocSubscribed>
+  | typeof SOCKET_READY_EVENT
+
+export const SOCKET_READY_EVENT = {
+  type: 'status',
+  data: { status: { exec_info: { queue_remaining: 0 } } }
+} as const
 
 export function agentDocSubscribed() {
   return {

--- a/browser_tests/tests/agent/agentPanelMocks.ts
+++ b/browser_tests/tests/agent/agentPanelMocks.ts
@@ -239,9 +239,38 @@ async function mockAgentBoot(
       })
     )
   )
-  await page.route('**/api/userdata**', (r) => r.fulfill(jsonRoute([])))
+  await page.route('**/api/userdata**', (route) =>
+    route.fulfill(
+      jsonRoute(
+        route.request().method() === 'POST'
+          ? {
+              path: 'workflows/default.json',
+              size: 1024,
+              modified: Date.now()
+            }
+          : []
+      )
+    )
+  )
   await page.route('**/api/extensions', (r) => r.fulfill(jsonRoute([])))
-  await page.route('**/api/object_info', (r) => r.fulfill(jsonRoute({})))
+  await page.route('**/api/object_info', (r) =>
+    r.fulfill(
+      jsonRoute({
+        AgentE2ENode: {
+          input: { required: {} },
+          output: [],
+          output_is_list: [],
+          output_name: [],
+          name: 'AgentE2ENode',
+          display_name: 'Agent E2E Node',
+          description: '',
+          category: 'testing',
+          output_node: false,
+          python_module: 'tests'
+        }
+      })
+    )
+  )
   await page.route('**/api/global_subgraphs', (r) => r.fulfill(jsonRoute({})))
   await page.route('**/api/i18n', (r) => r.fulfill(jsonRoute({})))
   await page.route('**/api/auth/session', (r) =>

--- a/browser_tests/tests/agent/agentPanelMocks.ts
+++ b/browser_tests/tests/agent/agentPanelMocks.ts
@@ -1,4 +1,6 @@
 import type { Page, Route } from '@playwright/test'
+import { mint } from '@comfyorg/comfy-multi-player'
+import * as Y from 'yjs'
 
 import { comfyPageFixture } from '@e2e/fixtures/ComfyPage'
 
@@ -8,6 +10,7 @@ import type {
   AgentTurnAccepted,
   AgentWsEvent
 } from '@/workbench/extensions/agent/schemas/agentApiSchema'
+import { encodeBase64 } from '@/workbench/extensions/agent/crdt/docFrameClient'
 
 import { mockSystemStats } from '@e2e/fixtures/data/systemStats'
 import { mockBilling } from '@e2e/fixtures/utils/cloudBillingMocks'
@@ -15,7 +18,67 @@ import { jsonRoute } from '@e2e/fixtures/utils/jsonRoute'
 
 const THREAD_ID = 'd4c016c4-3b8c-44cf-97de-1ae27e43e718'
 const TURN_ID = '3818ba00-d772-4a3f-98c1-9312725b577d'
-const WORKFLOW_ID = 'a81718a4-02ae-41e6-ae85-c33b7bb880f6'
+export const WORKFLOW_ID = 'a81718a4-02ae-41e6-ae85-c33b7bb880f6'
+
+export type AgentDocWireFrame =
+  | ReturnType<typeof agentWorkflowUpdates>['initial']
+  | ReturnType<typeof agentDocSubscribed>
+
+export function agentDocSubscribed() {
+  return {
+    type: 'doc_subscribed' as const,
+    data: { v: 1 as const, workflow_id: WORKFLOW_ID, ok: true }
+  }
+}
+
+export function agentWorkflowUpdates() {
+  const doc = mint(
+    {
+      nodes: [
+        {
+          id: 41,
+          type: 'AgentE2ENode',
+          title: 'Agent-created node',
+          pos: [160, 120],
+          size: [220, 100],
+          inputs: [],
+          outputs: []
+        }
+      ],
+      links: []
+    },
+    { types: {} }
+  )
+  const initialUpdate = Y.encodeStateAsUpdate(doc)
+  const initialStateVector = Y.encodeStateVector(doc)
+  doc.getMap('_e2e').set('reconnected', true)
+  const reconnectDelta = Y.encodeStateAsUpdate(doc, initialStateVector)
+  doc.destroy()
+  return {
+    initial: {
+      type: 'doc_update' as const,
+      data: {
+        v: 1,
+        workflow_id: WORKFLOW_ID,
+        seq: 1,
+        update_b64: encodeBase64(initialUpdate),
+        actor: 'agent:e2e',
+        op_ids: ['agent-e2e-add-node']
+      }
+    },
+    reconnectDelta: {
+      type: 'doc_update' as const,
+      data: {
+        v: 1,
+        workflow_id: WORKFLOW_ID,
+        seq: 2,
+        update_b64: encodeBase64(reconnectDelta),
+        actor: 'agent:e2e',
+        op_ids: ['agent-e2e-reconnect-delta']
+      }
+    }
+  }
+}
 
 const TURN_ACCEPTED: AgentTurnAccepted = {
   message_id: TURN_ID,

--- a/browser_tests/tests/agent/agentPanelMocks.ts
+++ b/browser_tests/tests/agent/agentPanelMocks.ts
@@ -273,6 +273,19 @@ async function mockAgentBoot(
       })
     )
   )
+  await page.route('**/api/workflows?limit=100', (r) =>
+    r.fulfill(
+      jsonRoute({
+        data: [{ id: WORKFLOW_ID, name: 'default.json' }],
+        pagination: {
+          offset: 0,
+          limit: 100,
+          total: 1,
+          has_more: false
+        }
+      })
+    )
+  )
 
   await page.route('**/api/agent/threads/*/messages', (route: Route) => {
     const request = route.request()

--- a/browser_tests/tests/agent/agentPanelMocks.ts
+++ b/browser_tests/tests/agent/agentPanelMocks.ts
@@ -276,7 +276,7 @@ async function mockAgentBoot(
   await page.route('**/api/workflows?limit=100', (r) =>
     r.fulfill(
       jsonRoute({
-        data: [{ id: WORKFLOW_ID, name: 'default.json' }],
+        data: [{ id: WORKFLOW_ID, name: 'default' }],
         pagination: {
           offset: 0,
           limit: 100,

--- a/browser_tests/tests/agent/agentPanelMocks.ts
+++ b/browser_tests/tests/agent/agentPanelMocks.ts
@@ -33,7 +33,7 @@ export const SOCKET_READY_EVENT = {
 export function agentDocSubscribed() {
   return {
     type: 'doc_subscribed' as const,
-    data: { v: 1 as const, workflow_id: WORKFLOW_ID, ok: true }
+    data: { v: 1 as const, workflow_id: WORKFLOW_ID, ok: true, seq: 1 }
   }
 }
 
@@ -68,7 +68,7 @@ export function agentWorkflowUpdates() {
         workflow_id: WORKFLOW_ID,
         seq: 1,
         update_b64: encodeBase64(initialUpdate),
-        actor: 'agent:e2e',
+        actor: 'agent:e2e:tab-a',
         op_ids: ['agent-e2e-add-node']
       }
     },
@@ -79,7 +79,7 @@ export function agentWorkflowUpdates() {
         workflow_id: WORKFLOW_ID,
         seq: 2,
         update_b64: encodeBase64(reconnectDelta),
-        actor: 'agent:e2e',
+        actor: 'agent:e2e:tab-a',
         op_ids: ['agent-e2e-reconnect-delta']
       }
     }

--- a/browser_tests/tests/agent/agentPanelMocks.ts
+++ b/browser_tests/tests/agent/agentPanelMocks.ts
@@ -72,6 +72,7 @@ export function agentWorkflowUpdates() {
         op_ids: ['agent-e2e-add-node']
       }
     },
+    initialStateVector: encodeBase64(initialStateVector),
     reconnectDelta: {
       type: 'doc_update' as const,
       data: {


### PR DESCRIPTION
## Summary

Add a main-targeted Playwright regression for agent turn to CRDT follower to canvas projection and reload convergence.

## Changes

- **What**: Captures outbound WebSocket frames, seeds a real shared-package Yjs snapshot, verifies the agent-bound follower projects one node, then reloads and proves replay is idempotent.
- **Dependencies**: None.

## Review Focus

Please focus on whether the mocked doc_subscribed / doc_update sequence matches the backend wire contract and whether the reload assertion is a sufficient browser-level convergence boundary.

## Screenshots (if applicable)

Not applicable; behavior is asserted in Playwright.