### PR TITLE
test(agent): exercise reference chip focus integration

### DIFF
--- a/src/workbench/extensions/agent/AgentPanelRoot.test.ts
+++ b/src/workbench/extensions/agent/AgentPanelRoot.test.ts
@@ -41,7 +41,7 @@ vi.mock('@/composables/canvas/useFocusNode', async (importOriginal) => {
     useFocusNode: () =>
       focusNodeMode.useRealImplementation
         ? actual.useFocusNode()
-        : { focusNodeInstance }
+        : { ...actual.useFocusNode(), focusNodeInstance }
   }
 })
 

--- a/src/workbench/extensions/agent/AgentPanelRoot.test.ts
+++ b/src/workbench/extensions/agent/AgentPanelRoot.test.ts
@@ -473,6 +473,7 @@ function setupNodeSelectionCanvas() {
   appMock.graph.nodes = nodes
   const canvas = {
     graph,
+    subgraph: undefined as unknown,
     selectedItems,
     selectItems,
     deselect,
@@ -520,12 +521,14 @@ function showRootGraph(
   nodes: SelectionTestNode[] = []
 ) {
   const graph = {
+    isRootGraph: true,
     nodes,
     getNodeById: (id: string | number) =>
       nodes.find((node) => String(node.id) === String(id)) ?? null
   }
   state.canvas.graph = graph
   hostStores.canvas.currentGraph = graph
+  return graph
 }
 
 function renderCanvasNodeButtons(
@@ -2970,18 +2973,15 @@ describe('AgentPanelRoot workflow binding', () => {
   })
 
   it('navigates and frames a retained subgraph node through the real focus composable', async () => {
+    vi.stubGlobal('devicePixelRatio', 1)
     makeTab()
     const state = setupNodeSelectionCanvas()
     nestSelectionCanvasInSubgraph(state)
     const subgraph = state.canvas.graph
     const referencedNode = state.nodes[1]
     referencedNode.graph = subgraph
+    referencedNode.boundingRect = [1, 2, 3, 4]
 
-    const rootGraph = {
-      isRootGraph: true,
-      nodes: [],
-      getNodeById: () => null
-    }
     const setGraph = vi.fn((graph: typeof subgraph) => {
       state.canvas.graph = graph
     })
@@ -2993,8 +2993,14 @@ describe('AgentPanelRoot workflow binding', () => {
     })
     hostStores.canvas.canvas = markRaw(state.canvas)
     focusNodeMode.useRealImplementation = true
-    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) =>
-      callback(0)
+    let rafHandle = 0
+    vi.stubGlobal(
+      'requestAnimationFrame',
+      (callback: FrameRequestCallback): number => {
+        rafHandle += 1
+        setTimeout(() => callback(0), 0)
+        return rafHandle
+      }
     )
 
     render(AgentPanelRoot, { global: { plugins: [i18n] } })
@@ -3003,17 +3009,19 @@ describe('AgentPanelRoot workflow binding', () => {
 
     await openMentionPicker()
     await userEvent.click(await screen.findByText('KSampler'))
-    state.canvas.graph = rootGraph
-    hostStores.canvas.currentGraph = rootGraph
+    const rootGraph = showRootGraph(state)
     await nextTick()
     await userEvent.click(
       screen.getByRole('button', { name: 'Show KSampler #12 on canvas' })
     )
 
     expect(setGraph).toHaveBeenCalledWith(subgraph)
+    expect(state.canvas.graph).toBe(subgraph)
+    expect(state.canvas.subgraph).toBe(subgraph)
     expect(animateToBounds).toHaveBeenCalledWith(referencedNode.boundingRect, {
       viewport: [0, 0, 1000 - useAgentPanelStore().width, 600]
     })
+    expect(rootGraph.isRootGraph).toBe(true)
   })
 
   it('uses graph-scoped identity for focus, removal, and picker exclusion', async () => {

--- a/src/workbench/extensions/agent/AgentPanelRoot.test.ts
+++ b/src/workbench/extensions/agent/AgentPanelRoot.test.ts
@@ -7,6 +7,8 @@ import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { defineComponent, h, nextTick } from 'vue'
 
+import type * as FocusNodeModule from '@/composables/canvas/useFocusNode'
+
 // jsdom does not implement ResizeObserver (happy-dom does); stub it before the
 // Vue node preview chain constructs its module-level observer at import time.
 vi.hoisted(() => {
@@ -31,10 +33,17 @@ const getServerFeature = vi.hoisted(() =>
   vi.fn((_name: string, defaultValue?: unknown) => defaultValue)
 )
 const focusNodeInstance = vi.hoisted(() => vi.fn())
+const focusNodeMode = vi.hoisted(() => ({ useRealImplementation: false }))
 
-vi.mock('@/composables/canvas/useFocusNode', () => ({
-  useFocusNode: () => ({ focusNodeInstance })
-}))
+vi.mock('@/composables/canvas/useFocusNode', async (importOriginal) => {
+  const actual = await importOriginal<typeof FocusNodeModule>()
+  return {
+    useFocusNode: () =>
+      focusNodeMode.useRealImplementation
+        ? actual.useFocusNode()
+        : { focusNodeInstance }
+  }
+})
 
 const ws = vi.hoisted(() => {
   type Listener = (event: { detail?: unknown }) => void
@@ -313,6 +322,7 @@ beforeEach(() => {
   workflowService.saveWorkflowAs.mockClear()
   workflowService.openWorkflow.mockClear()
   focusNodeInstance.mockReset()
+  focusNodeMode.useRealImplementation = false
 })
 
 const zAgentWsEventForTest = (raw: unknown): AgentChatEvent =>
@@ -434,7 +444,11 @@ type SelectionTestNode = {
   id: number | string
   title: string
   boundingRect: object
-  graph?: { id?: string }
+  graph?: {
+    id?: string
+    nodes?: SelectionTestNode[]
+    getNodeById?: (id: string | number) => SelectionTestNode | null
+  }
 }
 
 function setupNodeSelectionCanvas() {
@@ -2952,6 +2966,53 @@ describe('AgentPanelRoot workflow binding', () => {
 
     expect(focusNodeInstance).toHaveBeenCalledWith(state.nodes[1])
     expect(screen.getByText('KSampler')).toBeInTheDocument()
+  })
+
+  it('navigates and frames a retained subgraph node through the real focus composable', async () => {
+    makeTab()
+    const state = setupNodeSelectionCanvas()
+    nestSelectionCanvasInSubgraph(state)
+    const subgraph = state.canvas.graph
+    const referencedNode = state.nodes[1]
+    referencedNode.graph = subgraph
+
+    const rootGraph = {
+      isRootGraph: true,
+      nodes: [],
+      getNodeById: () => null
+    }
+    const setGraph = vi.fn((graph: typeof subgraph) => {
+      state.canvas.graph = graph
+    })
+    const animateToBounds = vi.fn()
+    Object.assign(state.canvas, {
+      setGraph,
+      animateToBounds,
+      canvas: { focus: state.focus, width: 1000, height: 600 }
+    })
+    hostStores.canvas.canvas = state.canvas
+    focusNodeMode.useRealImplementation = true
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) =>
+      callback(0)
+    )
+
+    render(AgentPanelRoot, { global: { plugins: [i18n] } })
+    useAgentPanelStore().enabled = true
+    useAgentPanelStore().isOpen = true
+
+    await openMentionPicker()
+    await userEvent.click(await screen.findByText('KSampler'))
+    state.canvas.graph = rootGraph
+    hostStores.canvas.currentGraph = rootGraph
+    await nextTick()
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Show KSampler #12 on canvas' })
+    )
+
+    expect(setGraph).toHaveBeenCalledWith(subgraph)
+    expect(animateToBounds).toHaveBeenCalledWith(referencedNode.boundingRect, {
+      viewport: [0, 0, 1000 - useAgentPanelStore().width, 600]
+    })
   })
 
   it('uses graph-scoped identity for focus, removal, and picker exclusion', async () => {

--- a/src/workbench/extensions/agent/AgentPanelRoot.test.ts
+++ b/src/workbench/extensions/agent/AgentPanelRoot.test.ts
@@ -5,7 +5,7 @@ import { render, screen, within } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { defineComponent, h, nextTick } from 'vue'
+import { defineComponent, h, markRaw, nextTick } from 'vue'
 
 import type * as FocusNodeModule from '@/composables/canvas/useFocusNode'
 
@@ -2991,7 +2991,7 @@ describe('AgentPanelRoot workflow binding', () => {
       animateToBounds,
       canvas: { focus: state.focus, width: 1000, height: 600 }
     })
-    hostStores.canvas.canvas = state.canvas
+    hostStores.canvas.canvas = markRaw(state.canvas)
     focusNodeMode.useRealImplementation = true
     vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) =>
       callback(0)

--- a/src/workbench/extensions/agent/AgentPanelRoot.test.ts
+++ b/src/workbench/extensions/agent/AgentPanelRoot.test.ts
@@ -314,6 +314,7 @@ beforeEach(() => {
   hostStores.workflow.activeWorkflow = null
   hostStores.canvas.selectedItems = []
   hostStores.canvas.currentGraph = null
+  hostStores.canvas.canvas = undefined
   appMock.graph.nodes = []
   appMock.graph.arrange.mockClear()
   Object.assign(appMock.rootGraph, { subgraphs: new Map() })


### PR DESCRIPTION
## Summary

Adds component-level integration coverage proving an agent reference chip invokes the real focus composable through subgraph navigation and panel-aware camera framing.

## Changes

- **What**: Lets the existing component suite opt into the real `useFocusNode` implementation for one focused case, then asserts `setGraph` and `animateToBounds` behavior from the chip click.

## Review Focus

Please check that the partial mock keeps the other 112 component tests isolated while this case crosses the production focus seam.

## Screenshots (if applicable)

Not applicable; test-only change.