### PR TITLE
fix: retry filmstrip frame capture when the video frame is not yet decodable

### DIFF
--- a/src/composables/video/useVideoFilmstrip.test.ts
+++ b/src/composables/video/useVideoFilmstrip.test.ts
@@ -375,6 +375,45 @@ describe('useVideoFilmstrip', () => {
     expect(createImageBitmapMock.mock.calls.length).toBeGreaterThan(1)
     expect(thumbnail.value).toBe('')
     expect(error.value).toBeNull()
+
+    const attemptsAtTimeout = createImageBitmapMock.mock.calls.length
+    await vi.advanceTimersByTimeAsync(5000)
+    expect(createImageBitmapMock.mock.calls.length).toBe(attemptsAtTimeout)
+  })
+
+  it('stops polling for a frame when the load is superseded', async () => {
+    const bitmap = { width: 171, height: 96, close: vi.fn() }
+    const videos: MockVideoElement[] = []
+    const createImageBitmapMock = vi.fn(async () => {
+      if (videos.length === 1) throw new Error('decode failed')
+      return bitmap
+    })
+    vi.stubGlobal('createImageBitmap', createImageBitmapMock)
+    vi.stubGlobal('OffscreenCanvas', MockOffscreenCanvas)
+    installVideoMocks({
+      onVideoCreated: (video) => {
+        videos.push(video)
+      }
+    })
+
+    const videoUrl = ref('https://example.com/first.mp4')
+    const { thumbnail, error, loading } = runWithScope(() =>
+      useVideoFilmstrip(videoUrl)
+    )
+    await vi.advanceTimersByTimeAsync(500)
+    const attemptsBeforeSwitch = createImageBitmapMock.mock.calls.length
+    expect(attemptsBeforeSwitch).toBeGreaterThan(1)
+
+    videoUrl.value = 'https://example.com/second.mp4'
+    await vi.waitFor(() => expect(loading.value).toBe(false))
+
+    expect(videos[0].src).toBe('')
+    expect(error.value).toBeNull()
+    expect(thumbnail.value).not.toBe('')
+
+    const attemptsAfterSettle = createImageBitmapMock.mock.calls.length
+    await vi.advanceTimersByTimeAsync(5000)
+    expect(createImageBitmapMock.mock.calls.length).toBe(attemptsAfterSettle)
   })
 
   it('retries the capture when the frame is not yet decodable', async () => {

--- a/src/composables/video/useVideoFilmstrip.test.ts
+++ b/src/composables/video/useVideoFilmstrip.test.ts
@@ -356,13 +356,11 @@ describe('useVideoFilmstrip', () => {
     expect(bitmap.close).toHaveBeenCalledTimes(1)
   })
 
-  it('leaves the thumbnail empty when the capture fails', async () => {
-    vi.stubGlobal(
-      'createImageBitmap',
-      vi.fn(async () => {
-        throw new Error('decode failed')
-      })
-    )
+  it('leaves the thumbnail empty when every capture attempt fails', async () => {
+    const createImageBitmapMock = vi.fn(async () => {
+      throw new Error('decode failed')
+    })
+    vi.stubGlobal('createImageBitmap', createImageBitmapMock)
     vi.stubGlobal('OffscreenCanvas', MockOffscreenCanvas)
     installVideoMocks()
 
@@ -371,10 +369,34 @@ describe('useVideoFilmstrip', () => {
       useVideoFilmstrip(videoUrl)
     )
 
+    await vi.advanceTimersByTimeAsync(6000)
     await vi.waitFor(() => expect(loading.value).toBe(false))
 
+    expect(createImageBitmapMock.mock.calls.length).toBeGreaterThan(1)
     expect(thumbnail.value).toBe('')
     expect(error.value).toBeNull()
+  })
+
+  it('retries the capture when the frame is not yet decodable', async () => {
+    const bitmap = { width: 171, height: 96, close: vi.fn() }
+    const createImageBitmapMock = vi
+      .fn(async () => bitmap)
+      .mockRejectedValueOnce(new Error('The image source is not usable.'))
+      .mockRejectedValueOnce(new Error('The image source is not usable.'))
+    vi.stubGlobal('createImageBitmap', createImageBitmapMock)
+    vi.stubGlobal('OffscreenCanvas', MockOffscreenCanvas)
+    installVideoMocks()
+
+    const videoUrl = ref('https://example.com/video.mp4')
+    const { thumbnail, loading } = runWithScope(() =>
+      useVideoFilmstrip(videoUrl)
+    )
+
+    await vi.advanceTimersByTimeAsync(3000)
+    await vi.waitFor(() => expect(loading.value).toBe(false))
+
+    expect(createImageBitmapMock).toHaveBeenCalledTimes(3)
+    expect(thumbnail.value).not.toBe('')
   })
 
   it('downscales the captured thumbnail to the filmstrip height', async () => {

--- a/src/composables/video/useVideoFilmstrip.ts
+++ b/src/composables/video/useVideoFilmstrip.ts
@@ -1,3 +1,4 @@
+import { delay } from 'es-toolkit'
 import { onScopeDispose, ref, watch } from 'vue'
 import type { Ref } from 'vue'
 
@@ -9,6 +10,8 @@ export const FILMSTRIP_THUMBNAIL_MAX_WIDTH = 384
 
 const METADATA_EVENT_TIMEOUT_MS = 15000
 const SEEK_EVENT_TIMEOUT_MS = 5000
+const FRAME_DECODE_TIMEOUT_MS = 5000
+const FRAME_DECODE_RETRY_INTERVAL_MS = 250
 
 export type FilmstripError = 'canvas-unavailable' | 'load-failed'
 
@@ -152,6 +155,28 @@ function representativeFrameTime(duration: number): number {
     : 0
 }
 
+async function waitForDecodableFrame(
+  video: HTMLVideoElement,
+  canvas: HTMLCanvasElement,
+  context: CanvasRenderingContext2D,
+  signal: AbortSignal
+): Promise<string> {
+  for (
+    let waitedMs = 0;
+    waitedMs < FRAME_DECODE_TIMEOUT_MS;
+    waitedMs += FRAME_DECODE_RETRY_INTERVAL_MS
+  ) {
+    try {
+      await delay(FRAME_DECODE_RETRY_INTERVAL_MS, { signal })
+    } catch {
+      throw new LoadAbortedError('Aborted waiting for a decodable frame')
+    }
+    const frame = await captureFrame(video, canvas, context)
+    if (frame) return frame
+  }
+  return ''
+}
+
 async function captureRepresentativeFrame(
   video: HTMLVideoElement,
   canvas: HTMLCanvasElement,
@@ -168,7 +193,8 @@ async function captureRepresentativeFrame(
       if (!(waitError instanceof EventTimeoutError)) throw waitError
     }
   }
-  return captureFrame(video, canvas, context)
+  const frame = await captureFrame(video, canvas, context)
+  return frame || waitForDecodableFrame(video, canvas, context, signal)
 }
 
 export function useVideoFilmstrip(

--- a/src/composables/video/useVideoFilmstrip.ts
+++ b/src/composables/video/useVideoFilmstrip.ts
@@ -161,11 +161,8 @@ async function waitForDecodableFrame(
   context: CanvasRenderingContext2D,
   signal: AbortSignal
 ): Promise<string> {
-  for (
-    let waitedMs = 0;
-    waitedMs < FRAME_DECODE_TIMEOUT_MS;
-    waitedMs += FRAME_DECODE_RETRY_INTERVAL_MS
-  ) {
+  const deadlineMs = Date.now() + FRAME_DECODE_TIMEOUT_MS
+  while (Date.now() < deadlineMs) {
     try {
       await delay(FRAME_DECODE_RETRY_INTERVAL_MS, { signal })
     } catch {


### PR DESCRIPTION
## Summary
createImageBitmap(video) can transiently throw InvalidStateError right after workflow execution, when node preview videos compete for decoder resources. 
The failure was swallowed, leaving the trim timeline permanently blank with no error or skeleton. Poll for a decodable frame before giving up.

Perf: the poll only starts after an empty capture, so the happy path is unchanged. A failing createImageBitmap call costs ~5us and does not trigger decoding, so worst case is ~20 no-op calls per node spread over the 5s budget, and the poll aborts with the load. Measured 48 concurrent filmstrip loads succeeding on first attempt in ~0.8s with no main-thread long tasks; the transient failure only appears under decoder contention spikes, not from filmstrip count.

After a seek the element can report HAVE_ENOUGH_DATA while the decoder has not produced the frame yet (decoder contention), making captureFrame come back empty. No event announces the frame becoming available, so poll for it.