### PR TITLE
test: add CRDT follower property baselines

### DIFF
--- a/src/workbench/extensions/agent/crdt/CrdtDevPanel.vue
+++ b/src/workbench/extensions/agent/crdt/CrdtDevPanel.vue
@@ -164,7 +164,8 @@ const EVENT_KINDS: readonly DevEventKind[] = [
   'stale_probe',
   'rebind',
   'doc_gap',
-  'doc_stale'
+  'doc_stale',
+  'scope_ready_retry'
 ]
 
 const VERDICT_TONE: Record<string, string> = {

--- a/src/workbench/extensions/agent/crdt/devPanelLog.ts
+++ b/src/workbench/extensions/agent/crdt/devPanelLog.ts
@@ -36,6 +36,7 @@ export type DevEventKind =
   | 'stale_probe'
   | 'doc_gap'
   | 'doc_stale'
+  | 'scope_ready_retry'
 
 export interface DevEvent {
   seq: number

--- a/src/workbench/extensions/agent/crdt/ecsFollowerAdapter.ts
+++ b/src/workbench/extensions/agent/crdt/ecsFollowerAdapter.ts
@@ -118,6 +118,13 @@ interface TargetSession {
   onLinksChanged: (event: Y.YMapEvent<unknown>) => void
   reconcileNextFrame: boolean
   applying: boolean
+  /**
+   * Last frame whose batch was rejected (typically: graph scope not ready).
+   * The Yjs bytes are already merged into the follower doc, so nothing else
+   * will ever re-project them unless {@link EcsFollowerAdapter.retryProjection}
+   * replays this frame once scope becomes available.
+   */
+  pendingRetryFrame: DocUpdate | undefined
 }
 
 /**
@@ -205,6 +212,7 @@ export class EcsFollowerAdapter {
       changedLinks: new Set<string>(),
       frameQueue: [],
       reconcileNextFrame: true,
+      pendingRetryFrame: undefined,
       applying: false,
       onNodesChanged: (_events): void => undefined,
       onLinksChanged: (_event): void => undefined
@@ -305,9 +313,32 @@ export class EcsFollowerAdapter {
     // A rejected batch (no scope, or validation failure) must leave
     // reconcileNextFrame set so the next frame retries authoritative
     // cleanup instead of falling through to incremental handling with
-    // stale local-only graph state still present.
-    if (committed) session.reconcileNextFrame = false
+    // stale local-only graph state still present. The rejected frame is
+    // remembered so `retryProjection` can re-run it once scope is ready
+    // without waiting for a later frame to arrive.
+    session.reconcileNextFrame = !committed
+    session.pendingRetryFrame = committed ? undefined : update
     return committed
+  }
+
+  /**
+   * Re-run the last rejected projection for a target once the caller
+   * believes the graph scope is ready. Returns true only if a retry ran
+   * and committed; returns false when nothing is pending, the target is
+   * unbound, or a drain is already in progress.
+   */
+  retryProjection(workflowId: string): boolean {
+    const session = this.targets.get(workflowId)
+    if (!session || session.applying || session.frameQueue.length > 0)
+      return false
+    const frame = session.pendingRetryFrame
+    if (!frame) return false
+    session.applying = true
+    try {
+      return this.applyQueuedFrame(session, frame)
+    } finally {
+      session.applying = false
+    }
   }
 
   private discardSessionPending(session: TargetSession): void {
@@ -315,6 +346,7 @@ export class EcsFollowerAdapter {
     session.changedWidgets.clear()
     session.replacedWidgetMaps.clear()
     session.changedLinks.clear()
+    session.pendingRetryFrame = undefined
   }
 
   private onNodesChanged(

--- a/src/workbench/extensions/agent/crdt/followerInvariants.property.test.ts
+++ b/src/workbench/extensions/agent/crdt/followerInvariants.property.test.ts
@@ -1,0 +1,231 @@
+import { SCHEMA_VERSION, mint } from '@comfyorg/comfy-multi-player'
+import * as fc from 'fast-check'
+import { describe, expect, it, vi } from 'vitest'
+import * as Y from 'yjs'
+
+const reportError = vi.hoisted(() => vi.fn())
+vi.mock('@/platform/telemetry/reportError', () => ({ reportError }))
+
+import type { DocFrameTransport } from './docFrameClient'
+import { DocFrameClient, encodeBase64 } from './docFrameClient'
+import { FollowerDoc } from './followerDoc'
+import { LayoutFollowerBridge } from './layoutFollowerBridge'
+import { FollowerSchemaError, assertReadableSchema } from './schemaGuard'
+
+const WORKFLOW_ID = 'property-workflow'
+
+class PropertyTransport extends EventTarget implements DocFrameTransport {
+  readonly sent: string[] = []
+
+  send(frame: string): boolean {
+    this.sent.push(frame)
+    return true
+  }
+
+  deliver(type: string, data: unknown): void {
+    this.dispatchEvent(new CustomEvent(type, { detail: data }))
+  }
+}
+
+function updateFrame(update: Uint8Array, seq: number) {
+  return {
+    v: 1,
+    workflow_id: WORKFLOW_ID,
+    seq,
+    update_b64: encodeBase64(update)
+  }
+}
+
+function validHostUpdate(value: unknown): Uint8Array {
+  const doc = mint({ nodes: [], links: [] }, { types: {} })
+  doc.getMap('property').set('value', value)
+  return Y.encodeStateAsUpdate(doc)
+}
+
+function incrementalUpdates(
+  entries: ReadonlyArray<readonly [string, number]>
+): { source: Y.Doc; updates: Uint8Array[] } {
+  const source = new Y.Doc()
+  const values = source.getMap<number>('values')
+  const updates = entries.map(([key, value]) => {
+    const before = Y.encodeStateVector(source)
+    values.set(key, value)
+    return Y.encodeStateAsUpdate(source, before)
+  })
+  return { source, updates }
+}
+
+function sentTypes(transport: PropertyTransport): string[] {
+  return transport.sent.map((frame) => {
+    const parsed = JSON.parse(frame) as { type: string }
+    return parsed.type
+  })
+}
+
+const arbEntries = fc.uniqueArray(
+  fc.tuple(fc.string({ minLength: 1, maxLength: 12 }), fc.integer()),
+  { minLength: 1, maxLength: 20, selector: ([key]) => key }
+)
+
+describe('CRDT follower invariants (property)', () => {
+  it('is byte-idempotent under duplicate remote application', () => {
+    fc.assert(
+      fc.property(
+        arbEntries,
+        fc.integer({ min: 1, max: 8 }),
+        (entries, repeats) => {
+          const { source } = incrementalUpdates(entries)
+          const update = Y.encodeStateAsUpdate(source)
+          const follower = new FollowerDoc()
+
+          follower.applyRemoteUpdate(update)
+          const once = Y.encodeStateAsUpdate(follower.doc)
+          for (let index = 0; index < repeats; index++) {
+            follower.applyRemoteUpdate(update)
+          }
+
+          expect(Y.encodeStateAsUpdate(follower.doc)).toEqual(once)
+        }
+      )
+    )
+  })
+
+  it('converges under arbitrary reordering and duplication', () => {
+    fc.assert(
+      fc.property(
+        arbEntries.chain((entries) =>
+          fc
+            .tuple(
+              fc.shuffledSubarray(
+                entries.map((_, index) => index),
+                { minLength: entries.length, maxLength: entries.length }
+              ),
+              fc.array(fc.integer({ min: 0, max: entries.length - 1 }), {
+                maxLength: entries.length * 2
+              })
+            )
+            .map(([order, duplicates]) => ({
+              entries,
+              delivery: [...order, ...duplicates]
+            }))
+        ),
+        ({ entries, delivery }) => {
+          const { source, updates } = incrementalUpdates(entries)
+          const follower = new FollowerDoc()
+
+          for (const index of delivery)
+            follower.applyRemoteUpdate(updates[index])
+
+          expect(Y.encodeStateAsUpdate(follower.doc)).toEqual(
+            Y.encodeStateAsUpdate(source)
+          )
+        }
+      )
+    )
+  })
+
+  it('withholds causal gaps and requests replay from the retained state vector', () => {
+    fc.assert(
+      fc.property(
+        fc.jsonValue(),
+        fc.integer({ min: 3, max: 1000 }),
+        (value, gapSeq) => {
+          const transport = new PropertyTransport()
+          const bridge = new LayoutFollowerBridge(new DocFrameClient(transport))
+          bridge.subscribe(WORKFLOW_ID)
+          transport.deliver(
+            'doc_update',
+            updateFrame(validHostUpdate(value), 1)
+          )
+          const retained = bridge.follower
+          const retainedVector = encodeBase64(retained.stateVector())
+
+          transport.deliver(
+            'doc_update',
+            updateFrame(validHostUpdate(value), gapSeq)
+          )
+
+          expect(bridge.follower).toBe(retained)
+          expect(retained.updatesApplied).toBe(1)
+          const subscriptions = transport.sent
+            .map(
+              (frame) =>
+                JSON.parse(frame) as {
+                  type: string
+                  data: Record<string, unknown>
+                }
+            )
+            .filter((frame) => frame.type === 'doc_subscribe')
+          expect(subscriptions).toHaveLength(2)
+          expect(subscriptions[1].data.state_vector_b64).toBe(retainedVector)
+        }
+      )
+    )
+  })
+
+  it('never turns remote updates into leader-bound semantic writes', () => {
+    fc.assert(
+      fc.property(
+        fc.jsonValue(),
+        fc.integer({ min: 1, max: 20 }),
+        (value, repeats) => {
+          const transport = new PropertyTransport()
+          const bridge = new LayoutFollowerBridge(new DocFrameClient(transport))
+          bridge.subscribe(WORKFLOW_ID)
+          const update = validHostUpdate(value)
+
+          for (let seq = 1; seq <= repeats; seq++) {
+            transport.deliver('doc_update', updateFrame(update, seq))
+          }
+
+          expect(sentTypes(transport)).not.toContain('doc_ops')
+          expect(sentTypes(transport)).toEqual(['doc_subscribe'])
+        }
+      )
+    )
+  })
+
+  it('keeps arbitrary awareness state ephemeral', () => {
+    fc.assert(
+      fc.property(fc.dictionary(fc.string(), fc.jsonValue()), (state) => {
+        const transport = new PropertyTransport()
+        const bridge = new LayoutFollowerBridge(new DocFrameClient(transport))
+        bridge.subscribe(WORKFLOW_ID)
+        transport.deliver(
+          'doc_update',
+          updateFrame(validHostUpdate('semantic'), 1)
+        )
+        const before = Y.encodeStateAsUpdate(bridge.follower.doc)
+
+        transport.deliver('awareness', {
+          v: 1,
+          workflow_id: WORKFLOW_ID,
+          actor: 'human:user:tab',
+          state
+        })
+
+        expect(Y.encodeStateAsUpdate(bridge.follower.doc)).toEqual(before)
+        expect(sentTypes(transport)).toEqual(['doc_subscribe'])
+      })
+    )
+  })
+
+  it('fails closed on every incompatible schema version without mutating the doc', () => {
+    const incompatibleVersion = fc.oneof(
+      fc.integer().filter((version) => version !== SCHEMA_VERSION),
+      fc.string(),
+      fc.boolean(),
+      fc.constant(null)
+    )
+    fc.assert(
+      fc.property(incompatibleVersion, (version) => {
+        const doc = mint({ nodes: [], links: [] }, { types: {} })
+        doc.getMap('meta').set('schema_version', version)
+        const before = Y.encodeStateAsUpdate(doc)
+
+        expect(() => assertReadableSchema(doc)).toThrow(FollowerSchemaError)
+        expect(Y.encodeStateAsUpdate(doc)).toEqual(before)
+      })
+    )
+  })
+})

--- a/src/workbench/extensions/agent/crdt/followerInvariants.property.test.ts
+++ b/src/workbench/extensions/agent/crdt/followerInvariants.property.test.ts
@@ -1,4 +1,8 @@
-import { SCHEMA_VERSION, mint } from '@comfyorg/comfy-multi-player'
+import {
+  SCHEMA_VERSION,
+  mint,
+  readSchemaVersion
+} from '@comfyorg/comfy-multi-player'
 import * as fc from 'fast-check'
 import { describe, expect, it, vi } from 'vitest'
 import * as Y from 'yjs'
@@ -10,7 +14,6 @@ import type { DocFrameTransport } from './docFrameClient'
 import { DocFrameClient, encodeBase64 } from './docFrameClient'
 import { FollowerDoc } from './followerDoc'
 import { LayoutFollowerBridge } from './layoutFollowerBridge'
-import { FollowerSchemaError, assertReadableSchema } from './schemaGuard'
 
 const WORKFLOW_ID = 'property-workflow'
 
@@ -38,8 +41,12 @@ function updateFrame(update: Uint8Array, seq: number) {
 
 function validHostUpdate(value: unknown): Uint8Array {
   const doc = mint({ nodes: [], links: [] }, { types: {} })
-  doc.getMap('property').set('value', value)
-  return Y.encodeStateAsUpdate(doc)
+  try {
+    doc.getMap('property').set('value', value)
+    return Y.encodeStateAsUpdate(doc)
+  } finally {
+    doc.destroy()
+  }
 }
 
 function incrementalUpdates(
@@ -77,14 +84,18 @@ describe('CRDT follower invariants (property)', () => {
           const { source } = incrementalUpdates(entries)
           const update = Y.encodeStateAsUpdate(source)
           const follower = new FollowerDoc()
-
-          follower.applyRemoteUpdate(update)
-          const once = Y.encodeStateAsUpdate(follower.doc)
-          for (let index = 0; index < repeats; index++) {
+          try {
             follower.applyRemoteUpdate(update)
-          }
+            const once = Y.encodeStateAsUpdate(follower.doc)
+            for (let index = 0; index < repeats; index++) {
+              follower.applyRemoteUpdate(update)
+            }
 
-          expect(Y.encodeStateAsUpdate(follower.doc)).toEqual(once)
+            expect(Y.encodeStateAsUpdate(follower.doc)).toEqual(once)
+          } finally {
+            follower.destroy()
+            source.destroy()
+          }
         }
       )
     )
@@ -112,13 +123,17 @@ describe('CRDT follower invariants (property)', () => {
         ({ entries, delivery }) => {
           const { source, updates } = incrementalUpdates(entries)
           const follower = new FollowerDoc()
+          try {
+            for (const index of delivery)
+              follower.applyRemoteUpdate(updates[index])
 
-          for (const index of delivery)
-            follower.applyRemoteUpdate(updates[index])
-
-          expect(Y.encodeStateAsUpdate(follower.doc)).toEqual(
-            Y.encodeStateAsUpdate(source)
-          )
+            expect(Y.encodeStateAsUpdate(follower.doc)).toEqual(
+              Y.encodeStateAsUpdate(source)
+            )
+          } finally {
+            follower.destroy()
+            source.destroy()
+          }
         }
       )
     )
@@ -131,33 +146,39 @@ describe('CRDT follower invariants (property)', () => {
         fc.integer({ min: 3, max: 1000 }),
         (value, gapSeq) => {
           const transport = new PropertyTransport()
-          const bridge = new LayoutFollowerBridge(new DocFrameClient(transport))
-          bridge.subscribe(WORKFLOW_ID)
-          transport.deliver(
-            'doc_update',
-            updateFrame(validHostUpdate(value), 1)
-          )
-          const retained = bridge.follower
-          const retainedVector = encodeBase64(retained.stateVector())
-
-          transport.deliver(
-            'doc_update',
-            updateFrame(validHostUpdate(value), gapSeq)
-          )
-
-          expect(bridge.follower).toBe(retained)
-          expect(retained.updatesApplied).toBe(1)
-          const subscriptions = transport.sent
-            .map(
-              (frame) =>
-                JSON.parse(frame) as {
-                  type: string
-                  data: Record<string, unknown>
-                }
+          const client = new DocFrameClient(transport)
+          const bridge = new LayoutFollowerBridge(client)
+          try {
+            bridge.subscribe(WORKFLOW_ID)
+            transport.deliver(
+              'doc_update',
+              updateFrame(validHostUpdate(value), 1)
             )
-            .filter((frame) => frame.type === 'doc_subscribe')
-          expect(subscriptions).toHaveLength(2)
-          expect(subscriptions[1].data.state_vector_b64).toBe(retainedVector)
+            const retained = bridge.follower
+            const retainedVector = encodeBase64(retained.stateVector())
+
+            transport.deliver(
+              'doc_update',
+              updateFrame(validHostUpdate(value), gapSeq)
+            )
+
+            expect(bridge.follower).toBe(retained)
+            expect(retained.updatesApplied).toBe(1)
+            const subscriptions = transport.sent
+              .map(
+                (frame) =>
+                  JSON.parse(frame) as {
+                    type: string
+                    data: Record<string, unknown>
+                  }
+              )
+              .filter((frame) => frame.type === 'doc_subscribe')
+            expect(subscriptions).toHaveLength(2)
+            expect(subscriptions[1].data.state_vector_b64).toBe(retainedVector)
+          } finally {
+            bridge.destroy()
+            client.destroy()
+          }
         }
       )
     )
@@ -170,16 +191,22 @@ describe('CRDT follower invariants (property)', () => {
         fc.integer({ min: 1, max: 20 }),
         (value, repeats) => {
           const transport = new PropertyTransport()
-          const bridge = new LayoutFollowerBridge(new DocFrameClient(transport))
-          bridge.subscribe(WORKFLOW_ID)
-          const update = validHostUpdate(value)
+          const client = new DocFrameClient(transport)
+          const bridge = new LayoutFollowerBridge(client)
+          try {
+            bridge.subscribe(WORKFLOW_ID)
+            const update = validHostUpdate(value)
 
-          for (let seq = 1; seq <= repeats; seq++) {
-            transport.deliver('doc_update', updateFrame(update, seq))
+            for (let seq = 1; seq <= repeats; seq++) {
+              transport.deliver('doc_update', updateFrame(update, seq))
+            }
+
+            expect(sentTypes(transport)).not.toContain('doc_ops')
+            expect(sentTypes(transport)).toEqual(['doc_subscribe'])
+          } finally {
+            bridge.destroy()
+            client.destroy()
           }
-
-          expect(sentTypes(transport)).not.toContain('doc_ops')
-          expect(sentTypes(transport)).toEqual(['doc_subscribe'])
         }
       )
     )
@@ -189,28 +216,46 @@ describe('CRDT follower invariants (property)', () => {
     fc.assert(
       fc.property(fc.dictionary(fc.string(), fc.jsonValue()), (state) => {
         const transport = new PropertyTransport()
-        const bridge = new LayoutFollowerBridge(new DocFrameClient(transport))
-        bridge.subscribe(WORKFLOW_ID)
-        transport.deliver(
-          'doc_update',
-          updateFrame(validHostUpdate('semantic'), 1)
-        )
-        const before = Y.encodeStateAsUpdate(bridge.follower.doc)
-
-        transport.deliver('awareness', {
-          v: 1,
-          workflow_id: WORKFLOW_ID,
-          actor: 'human:user:tab',
-          state
+        const client = new DocFrameClient(transport)
+        const bridge = new LayoutFollowerBridge(client)
+        const observed: unknown[] = []
+        client.addEventListener('awareness', (event) => {
+          if (event instanceof CustomEvent) observed.push(event.detail)
         })
+        try {
+          bridge.subscribe(WORKFLOW_ID)
+          transport.deliver(
+            'doc_update',
+            updateFrame(validHostUpdate('semantic'), 1)
+          )
+          const before = Y.encodeStateAsUpdate(bridge.follower.doc)
 
-        expect(Y.encodeStateAsUpdate(bridge.follower.doc)).toEqual(before)
-        expect(sentTypes(transport)).toEqual(['doc_subscribe'])
+          transport.deliver('awareness', {
+            v: 1,
+            workflow_id: WORKFLOW_ID,
+            actor: 'human:user:tab',
+            state
+          })
+
+          expect(observed).toEqual([
+            {
+              workflowId: WORKFLOW_ID,
+              actor: 'human:user:tab',
+              state
+            }
+          ])
+          expect(Y.encodeStateAsUpdate(bridge.follower.doc)).toEqual(before)
+          expect(sentTypes(transport)).toEqual(['doc_subscribe'])
+        } finally {
+          bridge.destroy()
+          client.destroy()
+        }
       })
     )
   })
 
-  it('fails closed on every incompatible schema version without mutating the doc', () => {
+  it('withholds every incompatible schema version from projection', () => {
+    vi.spyOn(console, 'error').mockImplementation(() => undefined)
     const incompatibleVersion = fc.oneof(
       fc.integer().filter((version) => version !== SCHEMA_VERSION),
       fc.string(),
@@ -219,12 +264,35 @@ describe('CRDT follower invariants (property)', () => {
     )
     fc.assert(
       fc.property(incompatibleVersion, (version) => {
+        const transport = new PropertyTransport()
+        const client = new DocFrameClient(transport)
+        const bridge = new LayoutFollowerBridge(client)
         const doc = mint({ nodes: [], links: [] }, { types: {} })
-        doc.getMap('meta').set('schema_version', version)
-        const before = Y.encodeStateAsUpdate(doc)
+        const projected: unknown[] = []
+        const schemaErrors: unknown[] = []
+        bridge.addEventListener('doc_update', (event) => {
+          if (event instanceof CustomEvent) projected.push(event.detail)
+        })
+        bridge.addEventListener('schema_error', (event) => {
+          if (event instanceof CustomEvent) schemaErrors.push(event.detail)
+        })
+        try {
+          bridge.subscribe(WORKFLOW_ID)
+          doc.getMap('meta').set('schema_version', version)
+          const before = Y.encodeStateAsUpdate(doc)
+          const found = readSchemaVersion(doc)
 
-        expect(() => assertReadableSchema(doc)).toThrow(FollowerSchemaError)
-        expect(Y.encodeStateAsUpdate(doc)).toEqual(before)
+          transport.deliver('doc_update', updateFrame(before, 1))
+
+          expect(projected).toEqual([])
+          expect(schemaErrors).toEqual([{ workflowId: WORKFLOW_ID, found }])
+          expect(bridge.lastSchemaError?.found).toEqual(found)
+          expect(Y.encodeStateAsUpdate(doc)).toEqual(before)
+        } finally {
+          doc.destroy()
+          bridge.destroy()
+          client.destroy()
+        }
       })
     )
   })

--- a/src/workbench/extensions/agent/crdt/followerInvariants.property.test.ts
+++ b/src/workbench/extensions/agent/crdt/followerInvariants.property.test.ts
@@ -115,10 +115,15 @@ describe('CRDT follower invariants (property)', () => {
                 maxLength: entries.length * 2
               })
             )
-            .map(([order, duplicates]) => ({
-              entries,
-              delivery: [...order, ...duplicates]
-            }))
+            .chain(([order, duplicates]) => {
+              const deliveries = [...order, ...duplicates]
+              return fc
+                .shuffledSubarray(deliveries, {
+                  minLength: deliveries.length,
+                  maxLength: deliveries.length
+                })
+                .map((delivery) => ({ entries, delivery }))
+            })
         ),
         ({ entries, delivery }) => {
           const { source, updates } = incrementalUpdates(entries)

--- a/src/workbench/extensions/agent/crdt/followerSeam.integration.test.ts
+++ b/src/workbench/extensions/agent/crdt/followerSeam.integration.test.ts
@@ -35,57 +35,74 @@ class FrameTransport extends EventTarget implements DocFrameTransport {
 
 function hostUpdate(): Uint8Array {
   const host = mint({ nodes: [], links: [] }, { types: {} })
-  const result = applyOps(
-    host,
-    [
-      {
-        op: 'add_node',
-        op_id: '00000000000000000000000000000001',
-        actor: 'agent:test',
-        base_version: 1,
-        stamp: [1, 'agent:test'],
-        node_id: 1,
-        class_type: 'FollowerSeamNode',
-        pos: [128, 96],
-        node: {
-          id: 1,
-          type: 'FollowerSeamNode',
+  try {
+    const result = applyOps(
+      host,
+      [
+        {
+          op: 'add_node',
+          op_id: '00000000000000000000000000000001',
+          actor: 'agent:test',
+          base_version: 1,
+          stamp: [1, 'agent:test'],
+          node_id: 1,
+          class_type: 'FollowerSeamNode',
           pos: [128, 96],
-          inputs: [],
-          outputs: []
+          node: {
+            id: 1,
+            type: 'FollowerSeamNode',
+            pos: [128, 96],
+            inputs: [],
+            outputs: []
+          }
         }
+      ],
+      { types: {} }
+    )
+    expect(result.outcomes).toEqual([
+      {
+        op_id: '00000000000000000000000000000001',
+        outcome: 'applied'
       }
-    ],
-    { types: {} }
-  )
-  expect(result.outcomes).toEqual([
-    {
-      op_id: '00000000000000000000000000000001',
-      outcome: 'applied'
-    }
-  ])
-  const update = Y.encodeStateAsUpdate(host)
-  host.destroy()
-  return update
+    ])
+    return Y.encodeStateAsUpdate(host)
+  } finally {
+    host.destroy()
+  }
 }
 
-function setup() {
+function setup(getScope: () => typeof scope | null = () => scope) {
   const transport = new FrameTransport()
   const client = new DocFrameClient(transport)
   const bridge = new LayoutFollowerBridge(client)
   const createLayout = vi.fn()
   const mutations = createGraphMutations({
-    getScope: () => scope,
+    getScope,
     layout: { createNode: createLayout, deleteNodes: vi.fn() }
   })
   const adapter = new EcsFollowerAdapter(mutations)
+  const redispatched = vi.fn()
+  const applyResults: boolean[] = []
   adapter.bind(WORKFLOW_ID, bridge.follower)
   bridge.addEventListener('doc_update', (event) => {
-    if (event instanceof CustomEvent)
-      adapter.applyFrame(event.detail as DocUpdate)
+    if (!(event instanceof CustomEvent)) return
+    const update = event.detail as DocUpdate
+    redispatched(update)
+    applyResults.push(adapter.applyFrame(update))
   })
   bridge.subscribe(WORKFLOW_ID)
-  return { adapter, bridge, client, createLayout, transport }
+  return {
+    applyResults,
+    bridge,
+    createLayout,
+    redispatched,
+    transport,
+    destroy() {
+      adapter.destroy()
+      bridge.destroy()
+      client.destroy()
+    }
+  }
 }
 
 describe('follower seam integration', () => {
@@ -95,66 +112,93 @@ describe('follower seam integration', () => {
 
   it('projects a real shared-applier update into the ECS graph stores', () => {
     const seam = setup()
-    seam.transport.deliver('doc_update', {
-      v: 1,
-      workflow_id: WORKFLOW_ID,
-      seq: 1,
-      actor: 'agent:test',
-      op_ids: ['00000000000000000000000000000001'],
-      update_b64: encodeBase64(hostUpdate())
-    })
+    try {
+      seam.transport.deliver('doc_update', {
+        v: 1,
+        workflow_id: WORKFLOW_ID,
+        seq: 1,
+        actor: 'agent:test',
+        op_ids: ['00000000000000000000000000000001'],
+        update_b64: encodeBase64(hostUpdate())
+      })
 
-    expect(useNodeDataStore().getGraphNodesFor('root', 'root')).toEqual([
-      expect.objectContaining({
-        id: toNodeId(1),
-        type: 'FollowerSeamNode'
-      })
-    ])
-    expect(seam.createLayout).toHaveBeenCalledWith(
-      scope,
-      toNodeId(1),
-      expect.objectContaining({ position: { x: 128, y: 96 } }),
-      expect.objectContaining({
-        source: 'agent-remote',
-        opId: '00000000000000000000000000000001'
-      })
-    )
-    seam.adapter.destroy()
-    seam.bridge.destroy()
-    seam.client.destroy()
+      expect(useNodeDataStore().getGraphNodesFor('root', 'root')).toEqual([
+        expect.objectContaining({
+          id: toNodeId(1),
+          type: 'FollowerSeamNode'
+        })
+      ])
+      expect(seam.createLayout).toHaveBeenCalledWith(
+        scope,
+        toNodeId(1),
+        expect.objectContaining({ position: { x: 128, y: 96 } }),
+        expect.objectContaining({
+          source: 'agent-remote',
+          opId: '00000000000000000000000000000001'
+        })
+      )
+    } finally {
+      seam.destroy()
+    }
   })
 
   it('does not project frames for another workflow', () => {
     const seam = setup()
-    seam.transport.deliver('doc_update', {
-      v: 1,
-      workflow_id: 'other-workflow',
-      seq: 1,
-      update_b64: encodeBase64(hostUpdate())
-    })
+    try {
+      seam.transport.deliver('doc_update', {
+        v: 1,
+        workflow_id: 'other-workflow',
+        seq: 1,
+        update_b64: encodeBase64(hostUpdate())
+      })
 
-    expect(useNodeDataStore().getGraphNodesFor('root', 'root')).toEqual([])
-    expect(seam.createLayout).not.toHaveBeenCalled()
-    seam.adapter.destroy()
-    seam.bridge.destroy()
-    seam.client.destroy()
+      expect(useNodeDataStore().getGraphNodesFor('root', 'root')).toEqual([])
+      expect(seam.createLayout).not.toHaveBeenCalled()
+      expect(seam.redispatched).not.toHaveBeenCalled()
+    } finally {
+      seam.destroy()
+    }
   })
 
   it('does not replay ECS effects for a duplicate sequence', () => {
     const seam = setup()
-    const frame = {
-      v: 1,
-      workflow_id: WORKFLOW_ID,
-      seq: 1,
-      update_b64: encodeBase64(hostUpdate())
-    }
-    seam.transport.deliver('doc_update', frame)
-    seam.transport.deliver('doc_update', frame)
+    try {
+      const frame = {
+        v: 1,
+        workflow_id: WORKFLOW_ID,
+        seq: 1,
+        update_b64: encodeBase64(hostUpdate())
+      }
+      seam.transport.deliver('doc_update', frame)
+      seam.transport.deliver('doc_update', frame)
 
-    expect(useNodeDataStore().getGraphNodesFor('root', 'root')).toHaveLength(1)
-    expect(seam.createLayout).toHaveBeenCalledTimes(1)
-    seam.adapter.destroy()
-    seam.bridge.destroy()
-    seam.client.destroy()
+      expect(useNodeDataStore().getGraphNodesFor('root', 'root')).toHaveLength(
+        1
+      )
+      expect(seam.createLayout).toHaveBeenCalledTimes(1)
+      expect(seam.redispatched).toHaveBeenCalledTimes(1)
+    } finally {
+      seam.destroy()
+    }
+  })
+
+  it('consumes an update without projecting it while graph scope is unavailable', () => {
+    const seam = setup(() => null)
+    try {
+      seam.transport.deliver('doc_update', {
+        v: 1,
+        workflow_id: WORKFLOW_ID,
+        seq: 1,
+        update_b64: encodeBase64(hostUpdate())
+      })
+
+      expect(seam.bridge.lastSequence).toBe(1)
+      expect(seam.bridge.follower.updatesApplied).toBe(1)
+      expect(seam.applyResults).toEqual([true])
+      expect(useNodeDataStore().getGraphNodesFor('root', 'root')).toEqual([])
+      expect(seam.createLayout).not.toHaveBeenCalled()
+    } finally {
+      seam.destroy()
+    }
   })
 })

--- a/src/workbench/extensions/agent/crdt/followerSeam.integration.test.ts
+++ b/src/workbench/extensions/agent/crdt/followerSeam.integration.test.ts
@@ -194,7 +194,7 @@ describe('follower seam integration', () => {
 
       expect(seam.bridge.lastSequence).toBe(1)
       expect(seam.bridge.follower.updatesApplied).toBe(1)
-      expect(seam.applyResults).toEqual([true])
+      expect(seam.applyResults).toEqual([false])
       expect(useNodeDataStore().getGraphNodesFor('root', 'root')).toEqual([])
       expect(seam.createLayout).not.toHaveBeenCalled()
     } finally {

--- a/src/workbench/extensions/agent/crdt/followerSeam.integration.test.ts
+++ b/src/workbench/extensions/agent/crdt/followerSeam.integration.test.ts
@@ -1,0 +1,160 @@
+import { applyOps, mint } from '@comfyorg/comfy-multi-player'
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import * as Y from 'yjs'
+
+import { createGraphMutations } from '@/core/graph/graphMutations'
+import { useNodeDataStore } from '@/stores/nodeDataStore'
+import { toOwningGraphId, toRootGraphId } from '@/types/graphScopeId'
+import { toNodeId } from '@/types/nodeId'
+
+import type { DocFrameTransport, DocUpdate } from './docFrameClient'
+import { DocFrameClient, encodeBase64 } from './docFrameClient'
+import { EcsFollowerAdapter } from './ecsFollowerAdapter'
+import { LayoutFollowerBridge } from './layoutFollowerBridge'
+
+const WORKFLOW_ID = 'follower-seam-workflow'
+const scope = {
+  rootGraphId: toRootGraphId('root'),
+  owningGraphId: toOwningGraphId('root')
+}
+
+class FrameTransport extends EventTarget implements DocFrameTransport {
+  readonly sent: string[] = []
+
+  send(frame: string): boolean {
+    this.sent.push(frame)
+    return true
+  }
+
+  deliver(type: string, data: unknown): void {
+    this.dispatchEvent(new CustomEvent(type, { detail: data }))
+  }
+}
+
+function hostUpdate(): Uint8Array {
+  const host = mint({ nodes: [], links: [] }, { types: {} })
+  const result = applyOps(
+    host,
+    [
+      {
+        op: 'add_node',
+        op_id: '00000000000000000000000000000001',
+        actor: 'agent:test',
+        base_version: 1,
+        stamp: [1, 'agent:test'],
+        node_id: 1,
+        class_type: 'FollowerSeamNode',
+        pos: [128, 96],
+        node: {
+          id: 1,
+          type: 'FollowerSeamNode',
+          pos: [128, 96],
+          inputs: [],
+          outputs: []
+        }
+      }
+    ],
+    { types: {} }
+  )
+  expect(result.outcomes).toEqual([
+    {
+      op_id: '00000000000000000000000000000001',
+      outcome: 'applied'
+    }
+  ])
+  const update = Y.encodeStateAsUpdate(host)
+  host.destroy()
+  return update
+}
+
+function setup() {
+  const transport = new FrameTransport()
+  const client = new DocFrameClient(transport)
+  const bridge = new LayoutFollowerBridge(client)
+  const createLayout = vi.fn()
+  const mutations = createGraphMutations({
+    getScope: () => scope,
+    layout: { createNode: createLayout, deleteNodes: vi.fn() }
+  })
+  const adapter = new EcsFollowerAdapter(mutations)
+  adapter.bind(WORKFLOW_ID, bridge.follower)
+  bridge.addEventListener('doc_update', (event) => {
+    if (event instanceof CustomEvent)
+      adapter.applyFrame(event.detail as DocUpdate)
+  })
+  bridge.subscribe(WORKFLOW_ID)
+  return { adapter, bridge, client, createLayout, transport }
+}
+
+describe('follower seam integration', () => {
+  beforeEach(() => {
+    setActivePinia(createTestingPinia({ stubActions: false }))
+  })
+
+  it('projects a real shared-applier update into the ECS graph stores', () => {
+    const seam = setup()
+    seam.transport.deliver('doc_update', {
+      v: 1,
+      workflow_id: WORKFLOW_ID,
+      seq: 1,
+      actor: 'agent:test',
+      op_ids: ['00000000000000000000000000000001'],
+      update_b64: encodeBase64(hostUpdate())
+    })
+
+    expect(useNodeDataStore().getGraphNodesFor('root', 'root')).toEqual([
+      expect.objectContaining({
+        id: toNodeId(1),
+        type: 'FollowerSeamNode'
+      })
+    ])
+    expect(seam.createLayout).toHaveBeenCalledWith(
+      scope,
+      toNodeId(1),
+      expect.objectContaining({ position: { x: 128, y: 96 } }),
+      expect.objectContaining({
+        source: 'agent-remote',
+        opId: '00000000000000000000000000000001'
+      })
+    )
+    seam.adapter.destroy()
+    seam.bridge.destroy()
+    seam.client.destroy()
+  })
+
+  it('does not project frames for another workflow', () => {
+    const seam = setup()
+    seam.transport.deliver('doc_update', {
+      v: 1,
+      workflow_id: 'other-workflow',
+      seq: 1,
+      update_b64: encodeBase64(hostUpdate())
+    })
+
+    expect(useNodeDataStore().getGraphNodesFor('root', 'root')).toEqual([])
+    expect(seam.createLayout).not.toHaveBeenCalled()
+    seam.adapter.destroy()
+    seam.bridge.destroy()
+    seam.client.destroy()
+  })
+
+  it('does not replay ECS effects for a duplicate sequence', () => {
+    const seam = setup()
+    const frame = {
+      v: 1,
+      workflow_id: WORKFLOW_ID,
+      seq: 1,
+      update_b64: encodeBase64(hostUpdate())
+    }
+    seam.transport.deliver('doc_update', frame)
+    seam.transport.deliver('doc_update', frame)
+
+    expect(useNodeDataStore().getGraphNodesFor('root', 'root')).toHaveLength(1)
+    expect(seam.createLayout).toHaveBeenCalledTimes(1)
+    seam.adapter.destroy()
+    seam.bridge.destroy()
+    seam.client.destroy()
+  })
+})

--- a/src/workbench/extensions/agent/crdt/followerSeam.integration.test.ts
+++ b/src/workbench/extensions/agent/crdt/followerSeam.integration.test.ts
@@ -33,41 +33,63 @@ class FrameTransport extends EventTarget implements DocFrameTransport {
   }
 }
 
-function hostUpdate(): Uint8Array {
+function opIdFor(nodeId: number): string {
+  return String(nodeId).padStart(32, '0')
+}
+
+/**
+ * A host doc that emits one update per added node: the first carries the whole
+ * state (including the schema meta the read gate requires), each later one only
+ * the delta, exactly as the relay fans out a live session.
+ */
+function hostSession() {
   const host = mint({ nodes: [], links: [] }, { types: {} })
-  try {
-    const result = applyOps(
-      host,
-      [
-        {
-          op: 'add_node',
-          op_id: '00000000000000000000000000000001',
-          actor: 'agent:test',
-          base_version: 1,
-          stamp: [1, 'agent:test'],
-          node_id: 1,
-          class_type: 'FollowerSeamNode',
-          pos: [128, 96],
-          node: {
-            id: 1,
-            type: 'FollowerSeamNode',
+  let emitted = 0
+  return {
+    add(nodeId: number): Uint8Array {
+      const before = Y.encodeStateVector(host)
+      const result = applyOps(
+        host,
+        [
+          {
+            op: 'add_node',
+            op_id: opIdFor(nodeId),
+            actor: 'agent:test',
+            base_version: nodeId,
+            stamp: [nodeId, 'agent:test'],
+            node_id: nodeId,
+            class_type: 'FollowerSeamNode',
             pos: [128, 96],
-            inputs: [],
-            outputs: []
+            node: {
+              id: nodeId,
+              type: 'FollowerSeamNode',
+              pos: [128, 96],
+              inputs: [],
+              outputs: []
+            }
           }
-        }
-      ],
-      { types: {} }
-    )
-    expect(result.outcomes).toEqual([
-      {
-        op_id: '00000000000000000000000000000001',
-        outcome: 'applied'
-      }
-    ])
-    return Y.encodeStateAsUpdate(host)
+        ],
+        { types: {} }
+      )
+      expect(result.outcomes).toEqual([
+        { op_id: opIdFor(nodeId), outcome: 'applied' }
+      ])
+      return emitted++ === 0
+        ? Y.encodeStateAsUpdate(host)
+        : Y.encodeStateAsUpdate(host, before)
+    },
+    destroy(): void {
+      host.destroy()
+    }
+  }
+}
+
+function hostUpdate(): Uint8Array {
+  const session = hostSession()
+  try {
+    return session.add(1)
   } finally {
-    host.destroy()
+    session.destroy()
   }
 }
 
@@ -182,14 +204,16 @@ describe('follower seam integration', () => {
     }
   })
 
-  it('consumes an update without projecting it while graph scope is unavailable', () => {
-    const seam = setup(() => null)
+  it('projects an update withheld for missing scope once scope returns', () => {
+    let liveScope: typeof scope | null = null
+    const seam = setup(() => liveScope)
+    const host = hostSession()
     try {
       seam.transport.deliver('doc_update', {
         v: 1,
         workflow_id: WORKFLOW_ID,
         seq: 1,
-        update_b64: encodeBase64(hostUpdate())
+        update_b64: encodeBase64(host.add(1))
       })
 
       expect(seam.bridge.lastSequence).toBe(1)
@@ -197,7 +221,24 @@ describe('follower seam integration', () => {
       expect(seam.applyResults).toEqual([false])
       expect(useNodeDataStore().getGraphNodesFor('root', 'root')).toEqual([])
       expect(seam.createLayout).not.toHaveBeenCalled()
+
+      liveScope = scope
+      seam.transport.deliver('doc_update', {
+        v: 1,
+        workflow_id: WORKFLOW_ID,
+        seq: 2,
+        update_b64: encodeBase64(host.add(2))
+      })
+
+      expect(seam.applyResults).toEqual([false, true])
+      expect(
+        useNodeDataStore()
+          .getGraphNodesFor('root', 'root')
+          .map((node) => node.id)
+      ).toEqual([toNodeId(1), toNodeId(2)])
+      expect(seam.createLayout).toHaveBeenCalledTimes(2)
     } finally {
+      host.destroy()
       seam.destroy()
     }
   })

--- a/src/workbench/extensions/agent/crdt/followerSeam.integration.test.ts
+++ b/src/workbench/extensions/agent/crdt/followerSeam.integration.test.ts
@@ -114,6 +114,7 @@ function setup(getScope: () => typeof scope | null = () => scope) {
   })
   bridge.subscribe(WORKFLOW_ID)
   return {
+    adapter,
     applyResults,
     bridge,
     createLayout,
@@ -230,6 +231,59 @@ describe('follower seam integration', () => {
         update_b64: encodeBase64(host.add(2))
       })
 
+      expect(seam.applyResults).toEqual([false, true])
+      expect(
+        useNodeDataStore()
+          .getGraphNodesFor('root', 'root')
+          .map((node) => node.id)
+      ).toEqual([toNodeId(1), toNodeId(2)])
+      expect(seam.createLayout).toHaveBeenCalledTimes(2)
+    } finally {
+      host.destroy()
+      seam.destroy()
+    }
+  })
+
+  it('recovers a withheld update via retryProjection without a later frame', () => {
+    let liveScope: typeof scope | null = null
+    const seam = setup(() => liveScope)
+    const host = hostSession()
+    try {
+      seam.transport.deliver('doc_update', {
+        v: 1,
+        workflow_id: WORKFLOW_ID,
+        seq: 1,
+        update_b64: encodeBase64(host.add(1))
+      })
+      expect(seam.applyResults).toEqual([false])
+      expect(useNodeDataStore().getGraphNodesFor('root', 'root')).toEqual([])
+
+      // Scope still missing: retry must not commit or touch the graph.
+      expect(seam.adapter.retryProjection(WORKFLOW_ID)).toBe(false)
+      expect(useNodeDataStore().getGraphNodesFor('root', 'root')).toEqual([])
+      expect(seam.createLayout).not.toHaveBeenCalled()
+
+      // Scope returns with no further frame: retry projects node 1 alone.
+      liveScope = scope
+      expect(seam.adapter.retryProjection(WORKFLOW_ID)).toBe(true)
+      expect(
+        useNodeDataStore()
+          .getGraphNodesFor('root', 'root')
+          .map((node) => node.id)
+      ).toEqual([toNodeId(1)])
+      expect(seam.createLayout).toHaveBeenCalledTimes(1)
+
+      // Nothing left pending after a committed retry.
+      expect(seam.adapter.retryProjection(WORKFLOW_ID)).toBe(false)
+      expect(seam.createLayout).toHaveBeenCalledTimes(1)
+
+      // A later frame still applies incrementally on top of the recovery.
+      seam.transport.deliver('doc_update', {
+        v: 1,
+        workflow_id: WORKFLOW_ID,
+        seq: 2,
+        update_b64: encodeBase64(host.add(2))
+      })
       expect(seam.applyResults).toEqual([false, true])
       expect(
         useNodeDataStore()

--- a/src/workbench/extensions/agent/crdt/resetDispatchOrder.property.test.ts
+++ b/src/workbench/extensions/agent/crdt/resetDispatchOrder.property.test.ts
@@ -1,9 +1,10 @@
+import { mint } from '@comfyorg/comfy-multi-player'
 import * as fc from 'fast-check'
 import { describe, expect, it } from 'vitest'
 import * as Y from 'yjs'
 
 import type { DocFrameTransport } from './docFrameClient'
-import { DocFrameClient } from './docFrameClient'
+import { DocFrameClient, encodeBase64 } from './docFrameClient'
 import { LayoutFollowerBridge } from './layoutFollowerBridge'
 
 const WORKFLOW_ID = 'reset-order-workflow'
@@ -13,38 +14,76 @@ class ResetTransport extends EventTarget implements DocFrameTransport {
     return true
   }
 
-  deliverReset(seq: number): void {
-    this.dispatchEvent(
-      new CustomEvent('doc_reset', {
-        detail: { v: 1, workflow_id: WORKFLOW_ID, seq }
-      })
-    )
+  deliver(type: string, data: unknown): void {
+    this.dispatchEvent(new CustomEvent(type, { detail: data }))
+  }
+}
+
+function hostUpdate(value: unknown): Uint8Array {
+  const doc = mint({ nodes: [], links: [] }, { types: {} })
+  try {
+    doc.getMap('reset-property').set('value', value)
+    return Y.encodeStateAsUpdate(doc)
+  } finally {
+    doc.destroy()
   }
 }
 
 describe('doc_reset dispatch order (property)', () => {
   it('notifies every consumer while the old follower lineage is still live', () => {
     fc.assert(
-      fc.property(fc.nat(), (seq) => {
+      fc.property(fc.jsonValue(), fc.nat(), (value, seq) => {
         const transport = new ResetTransport()
         const client = new DocFrameClient(transport)
         const bridge = new LayoutFollowerBridge(client)
-        bridge.subscribe(WORKFLOW_ID)
-        const oldFollower = bridge.follower
-        let observedFollower = null as typeof oldFollower | null
+        try {
+          bridge.subscribe(WORKFLOW_ID)
+          transport.deliver('doc_update', {
+            v: 1,
+            workflow_id: WORKFLOW_ID,
+            seq: 1,
+            update_b64: encodeBase64(hostUpdate(value))
+          })
+          const oldFollower = bridge.follower
+          const oldStateVector = oldFollower.stateVector()
+          let oldFollowerDestroyed = false
+          let destroyedDuringDispatch: boolean | null = null
+          let observedFollower = null as typeof oldFollower | null
+          let observedReset: unknown
+          let observedStateVector: Uint8Array | null = null
+          let readError: unknown
+          oldFollower.doc.on('destroy', () => {
+            oldFollowerDestroyed = true
+          })
+          bridge.addEventListener('doc_reset', (event) => {
+            observedFollower = bridge.follower
+            observedReset = event instanceof CustomEvent ? event.detail : null
+            destroyedDuringDispatch = oldFollowerDestroyed
+            try {
+              observedStateVector = oldFollower.stateVector()
+            } catch (error) {
+              readError = error
+            }
+          })
 
-        bridge.addEventListener('doc_reset', () => {
-          observedFollower = bridge.follower
-        })
-        transport.deliverReset(seq)
+          transport.deliver('doc_reset', {
+            v: 1,
+            workflow_id: WORKFLOW_ID,
+            seq
+          })
 
-        expect(observedFollower).toBe(oldFollower)
-        expect(bridge.follower).not.toBe(oldFollower)
-        expect(bridge.follower.stateVector()).toEqual(
-          Y.encodeStateVector(new Y.Doc())
-        )
-        bridge.destroy()
-        client.destroy()
+          expect(observedReset).toEqual({ workflowId: WORKFLOW_ID, seq })
+          expect(observedFollower).toBe(oldFollower)
+          expect(destroyedDuringDispatch).toBe(false)
+          expect(readError).toBeUndefined()
+          expect(observedStateVector).toEqual(oldStateVector)
+          expect(oldFollowerDestroyed).toBe(true)
+          expect(bridge.follower).not.toBe(oldFollower)
+          expect(bridge.follower.updatesApplied).toBe(0)
+        } finally {
+          bridge.destroy()
+          client.destroy()
+        }
       })
     )
   })

--- a/src/workbench/extensions/agent/crdt/resetDispatchOrder.property.test.ts
+++ b/src/workbench/extensions/agent/crdt/resetDispatchOrder.property.test.ts
@@ -1,0 +1,51 @@
+import * as fc from 'fast-check'
+import { describe, expect, it } from 'vitest'
+import * as Y from 'yjs'
+
+import type { DocFrameTransport } from './docFrameClient'
+import { DocFrameClient } from './docFrameClient'
+import { LayoutFollowerBridge } from './layoutFollowerBridge'
+
+const WORKFLOW_ID = 'reset-order-workflow'
+
+class ResetTransport extends EventTarget implements DocFrameTransport {
+  send(): boolean {
+    return true
+  }
+
+  deliverReset(seq: number): void {
+    this.dispatchEvent(
+      new CustomEvent('doc_reset', {
+        detail: { v: 1, workflow_id: WORKFLOW_ID, seq }
+      })
+    )
+  }
+}
+
+describe('doc_reset dispatch order (property)', () => {
+  it('notifies every consumer while the old follower lineage is still live', () => {
+    fc.assert(
+      fc.property(fc.nat(), (seq) => {
+        const transport = new ResetTransport()
+        const client = new DocFrameClient(transport)
+        const bridge = new LayoutFollowerBridge(client)
+        bridge.subscribe(WORKFLOW_ID)
+        const oldFollower = bridge.follower
+        let observedFollower = null as typeof oldFollower | null
+
+        bridge.addEventListener('doc_reset', () => {
+          observedFollower = bridge.follower
+        })
+        transport.deliverReset(seq)
+
+        expect(observedFollower).toBe(oldFollower)
+        expect(bridge.follower).not.toBe(oldFollower)
+        expect(bridge.follower.stateVector()).toEqual(
+          Y.encodeStateVector(new Y.Doc())
+        )
+        bridge.destroy()
+        client.destroy()
+      })
+    )
+  })
+})

--- a/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.ts
+++ b/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.ts
@@ -285,6 +285,15 @@ export function useAgentCrdtFollower(
   let subscribeRetryTimer: ReturnType<typeof setTimeout> | null = null
   let subscribeRetryAttempt = 0
 
+  // Scope-ready recovery: a frame the adapter withheld because the layout
+  // scope was not yet available must not stay absent until the NEXT frame
+  // happens to arrive. Poll the adapter's retained frame at a fixed interval
+  // until it projects (scope became ready) or the bounded budget runs out.
+  const SCOPE_RETRY_INTERVAL_MS = 250
+  const SCOPE_RETRY_MAX_ATTEMPTS = 40
+  let scopeRetryTimer: ReturnType<typeof setTimeout> | null = null
+  let scopeRetryAttempt = 0
+
   // The recency heartbeat: armed only while a subscribe is CONFIRMED (bound +
   // healthy by definition), slid forward by every doc-scoped frame, cancelled
   // by the same lifecycle exits as the subscribe retry. The probe is
@@ -354,6 +363,57 @@ export function useAgentCrdtFollower(
     }, delay)
   }
 
+  const clearScopeRetry = (): void => {
+    if (scopeRetryTimer !== null) {
+      clearTimeout(scopeRetryTimer)
+      scopeRetryTimer = null
+    }
+    scopeRetryAttempt = 0
+  }
+
+  const publishDocNodeIds = (): void => {
+    const ids = currentDocNodeIds()
+    const added = [...ids].filter((id) => !knownDocNodeIds.has(id))
+    const removed = [...knownDocNodeIds].filter((id) => !ids.has(id))
+    if (added.length > 0 || removed.length > 0)
+      recordDevEvent('doc_nodes_changed', { added, removed })
+    knownDocNodeIds = ids
+  }
+
+  // A frame withheld because the workflow scope was not yet live must not wait
+  // for the next remote update: if the author goes idle, the node it carried
+  // would stay absent indefinitely. Poll the adapter until scope resolves.
+  const scheduleScopeRetry = (target: string): void => {
+    if (scopeRetryTimer !== null) return
+    if (scopeRetryAttempt >= SCOPE_RETRY_MAX_ATTEMPTS) return
+    scopeRetryAttempt += 1
+    scopeRetryTimer = setTimeout(() => {
+      scopeRetryTimer = null
+      if (subscribedWorkflowId.value !== target || !isTargetActive.value) return
+      const applied = adapter.retryProjection(target)
+      if (applied) {
+        recordDevEvent('scope_ready_retry', {
+          workflowId: target,
+          attempt: scopeRetryAttempt
+        })
+        outcomes.value = {
+          ...outcomes.value,
+          applied: outcomes.value.applied + 1,
+          skipped: outcomes.value.skipped - 1
+        }
+        updatesApplied.value = bridge.follower.updatesApplied
+        publishDocNodeIds()
+        clearScopeRetry()
+        return
+      }
+      if (scopeRetryAttempt < SCOPE_RETRY_MAX_ATTEMPTS) {
+        scheduleScopeRetry(target)
+        return
+      }
+      clearScopeRetry()
+    }, SCOPE_RETRY_INTERVAL_MS)
+  }
+
   const onSubscribed: EventListener = (event) => {
     if (!(event instanceof CustomEvent)) return
     if (!isTargetActive.value) return
@@ -402,18 +462,15 @@ export function useAgentCrdtFollower(
     outcomes.value = applied
       ? { ...outcomes.value, applied: outcomes.value.applied + 1 }
       : { ...outcomes.value, skipped: outcomes.value.skipped + 1 }
+    if (applied) clearScopeRetry()
+    else scheduleScopeRetry(update.workflowId)
     recordDevEvent('doc_update', {
       workflowId: update.workflowId,
       seq: update.seq,
       actor: update.actor,
       bytes: update.update instanceof Uint8Array ? update.update.length : null
     })
-    const ids = currentDocNodeIds()
-    const added = [...ids].filter((id) => !knownDocNodeIds.has(id))
-    const removed = [...knownDocNodeIds].filter((id) => !ids.has(id))
-    if (added.length > 0 || removed.length > 0)
-      recordDevEvent('doc_nodes_changed', { added, removed })
-    knownDocNodeIds = ids
+    publishDocNodeIds()
   }
   const onOpsResult: EventListener = (event) => {
     if (staleProbeTimer !== null) {
@@ -454,6 +511,7 @@ export function useAgentCrdtFollower(
     updatesApplied.value = 0
     lastFrameType.value = event.type
     clearStaleProbe()
+    clearScopeRetry()
     knownDocNodeIds = new Set()
     recordDevEvent(
       'doc_reset',
@@ -490,6 +548,7 @@ export function useAgentCrdtFollower(
     connected.value = false
     lastFrameType.value = event.type
     clearStaleProbe()
+    clearScopeRetry()
     const detail =
       event instanceof CustomEvent
         ? (event.detail as { workflowId?: string } | null)
@@ -526,6 +585,7 @@ export function useAgentCrdtFollower(
   const onReconnected: EventListener = () => {
     connected.value = false
     clearStaleProbe()
+    clearScopeRetry()
     recordDevEvent('reconnected', null)
     bridge.resubscribe()
   }
@@ -576,6 +636,7 @@ export function useAgentCrdtFollower(
     ([next, active]) => {
       clearSubscribeRetry()
       clearStaleProbe()
+      clearScopeRetry()
       connected.value = false
       knownDocNodeIds = new Set()
       if (!active) {
@@ -629,6 +690,7 @@ export function useAgentCrdtFollower(
     try {
       clearSubscribeRetry()
       clearStaleProbe()
+      clearScopeRetry()
       api.removeEventListener('reconnected', onReconnected)
       api.removeEventListener('status', onSocketActivity)
       bridge.removeEventListener('doc_subscribed', onSubscribed)

--- a/src/workbench/extensions/agent/crdt/writeLegInvariants.property.test.ts
+++ b/src/workbench/extensions/agent/crdt/writeLegInvariants.property.test.ts
@@ -179,50 +179,54 @@ describe('CRDT human write-leg invariants (property)', () => {
   })
 
   it('retries transport failures and result silence without reminting', () => {
-    vi.useFakeTimers()
-    fc.assert(
-      fc.property(
-        arbOperations,
-        fc.integer({ min: 1, max: 4 }),
-        (operations, failedAttempts) => {
-          const attempts: Op[][] = []
-          const attemptIdentities: string[][] = []
-          let callCount = 0
-          const deps = {
-            sendOps: (_workflowId: string, _tab: string, ops: Op[]) => {
-              attempts.push(ops)
-              attemptIdentities.push(ops.map((op) => op.op_id))
-              callCount += 1
-              return callCount > failedAttempts
-            },
-            onOpsResult: () => () => {},
-            workflowId: () => WORKFLOW_ID,
-            tab: TAB,
-            actor: () => ACTOR,
-            baseVersion: () => 73,
-            observedVersion: () => 72,
-            reserveVersions: (
-              _workflowId: string,
-              observed: number,
-              _count: number
-            ) => observed + 1,
-            onBatchSettled: () => {}
+    vi.useFakeTimers({ shouldAdvanceTime: false })
+    try {
+      fc.assert(
+        fc.property(
+          arbOperations,
+          fc.integer({ min: 1, max: 4 }),
+          (operations, failedAttempts) => {
+            const attempts: Op[][] = []
+            const attemptIdentities: string[][] = []
+            let callCount = 0
+            const deps = {
+              sendOps: (_workflowId: string, _tab: string, ops: Op[]) => {
+                attempts.push(ops)
+                attemptIdentities.push(ops.map((op) => op.op_id))
+                callCount += 1
+                return callCount > failedAttempts
+              },
+              onOpsResult: () => () => {},
+              workflowId: () => WORKFLOW_ID,
+              tab: TAB,
+              actor: () => ACTOR,
+              baseVersion: () => 73,
+              observedVersion: () => 72,
+              reserveVersions: (
+                _workflowId: string,
+                observed: number,
+                _count: number
+              ) => observed + 1,
+              onBatchSettled: () => {}
+            }
+            const sender = createOpSender(deps)
+
+            enqueue(sender, operations)
+            vi.advanceTimersByTime(failedAttempts * 500)
+            expect(attempts).toHaveLength(failedAttempts + 1)
+            const mintedIdentities = attemptIdentities[0]
+            for (const identities of attemptIdentities)
+              expect(identities).toEqual(mintedIdentities)
+
+            vi.advanceTimersByTime(10_000)
+            expect(attemptIdentities.at(-1)).toEqual(mintedIdentities)
+            expect(attempts).toHaveLength(failedAttempts + 2)
+            sender.detach()
           }
-          const sender = createOpSender(deps)
-
-          enqueue(sender, operations)
-          vi.advanceTimersByTime(failedAttempts * 500)
-          expect(attempts).toHaveLength(failedAttempts + 1)
-          const mintedIdentities = attemptIdentities[0]
-          for (const identities of attemptIdentities)
-            expect(identities).toEqual(mintedIdentities)
-
-          vi.advanceTimersByTime(10_000)
-          expect(attemptIdentities.at(-1)).toEqual(mintedIdentities)
-          expect(attempts).toHaveLength(failedAttempts + 2)
-          sender.detach()
-        }
+        )
       )
-    )
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })

--- a/src/workbench/extensions/agent/crdt/writeLegInvariants.property.test.ts
+++ b/src/workbench/extensions/agent/crdt/writeLegInvariants.property.test.ts
@@ -186,10 +186,12 @@ describe('CRDT human write-leg invariants (property)', () => {
         fc.integer({ min: 1, max: 4 }),
         (operations, failedAttempts) => {
           const attempts: Op[][] = []
+          const attemptIdentities: string[][] = []
           let callCount = 0
           const deps = {
             sendOps: (_workflowId: string, _tab: string, ops: Op[]) => {
               attempts.push(ops)
+              attemptIdentities.push(ops.map((op) => op.op_id))
               callCount += 1
               return callCount > failedAttempts
             },
@@ -211,11 +213,12 @@ describe('CRDT human write-leg invariants (property)', () => {
           enqueue(sender, operations)
           vi.advanceTimersByTime(failedAttempts * 500)
           expect(attempts).toHaveLength(failedAttempts + 1)
-          const minted = attempts[0]
-          for (const attempt of attempts) expect(attempt).toEqual(minted)
+          const mintedIdentities = attemptIdentities[0]
+          for (const identities of attemptIdentities)
+            expect(identities).toEqual(mintedIdentities)
 
           vi.advanceTimersByTime(10_000)
-          expect(attempts.at(-1)).toEqual(minted)
+          expect(attemptIdentities.at(-1)).toEqual(mintedIdentities)
           expect(attempts).toHaveLength(failedAttempts + 2)
           sender.detach()
         }

--- a/src/workbench/extensions/agent/crdt/writeLegInvariants.property.test.ts
+++ b/src/workbench/extensions/agent/crdt/writeLegInvariants.property.test.ts
@@ -151,29 +151,31 @@ describe('CRDT human write-leg invariants (property)', () => {
           onBatchSettled: () => {}
         }
         const sender = createOpSender(deps)
+        try {
+          for (const operation of operations) {
+            enqueue(sender, [operation])
+            const latest = sent.at(-1)
+            if (!latest) throw new Error('Expected an in-flight operation')
+            resultListener(opsResult([latest[0].op_id]))
+          }
 
-        for (const operation of operations) {
-          enqueue(sender, [operation])
-          const latest = sent.at(-1)
-          if (!latest) throw new Error('Expected an in-flight operation')
-          resultListener(opsResult([latest[0].op_id]))
+          const delivered = sent.flat()
+          expect(
+            delivered.map((op) => {
+              if (op.op !== 'add_node') throw new Error('Expected add_node')
+              return op.node_id
+            })
+          ).toEqual(operations.map((operation) => operation.node_id))
+          expect(new Set(delivered.map((op) => op.op_id))).toHaveLength(
+            operations.length
+          )
+          expect(delivered.map((op) => op.base_version)).toEqual(
+            operations.map((_, index) => 42 + index)
+          )
+          expect(sender.pending()).toBe(0)
+        } finally {
+          sender.detach()
         }
-
-        const delivered = sent.flat()
-        expect(
-          delivered.map((op) => {
-            if (op.op !== 'add_node') throw new Error('Expected add_node')
-            return op.node_id
-          })
-        ).toEqual(operations.map((operation) => operation.node_id))
-        expect(new Set(delivered.map((op) => op.op_id))).toHaveLength(
-          operations.length
-        )
-        expect(delivered.map((op) => op.base_version)).toEqual(
-          operations.map((_, index) => 42 + index)
-        )
-        expect(sender.pending()).toBe(0)
-        sender.detach()
       })
     )
   })
@@ -186,13 +188,20 @@ describe('CRDT human write-leg invariants (property)', () => {
           arbOperations,
           fc.integer({ min: 1, max: 4 }),
           (operations, failedAttempts) => {
-            const attempts: Op[][] = []
-            const attemptIdentities: string[][] = []
+            const attemptIdentities: Array<
+              Array<Pick<Op, 'op_id' | 'actor' | 'base_version' | 'stamp'>>
+            > = []
             let callCount = 0
             const deps = {
               sendOps: (_workflowId: string, _tab: string, ops: Op[]) => {
-                attempts.push(ops)
-                attemptIdentities.push(ops.map((op) => op.op_id))
+                attemptIdentities.push(
+                  ops.map(({ op_id, actor, base_version, stamp }) => ({
+                    op_id,
+                    actor,
+                    base_version,
+                    stamp: structuredClone(stamp)
+                  }))
+                )
                 callCount += 1
                 return callCount > failedAttempts
               },
@@ -210,18 +219,20 @@ describe('CRDT human write-leg invariants (property)', () => {
               onBatchSettled: () => {}
             }
             const sender = createOpSender(deps)
+            try {
+              enqueue(sender, operations)
+              vi.advanceTimersByTime(failedAttempts * 500)
+              expect(attemptIdentities).toHaveLength(failedAttempts + 1)
+              const mintedIdentities = attemptIdentities[0]
+              for (const identities of attemptIdentities)
+                expect(identities).toEqual(mintedIdentities)
 
-            enqueue(sender, operations)
-            vi.advanceTimersByTime(failedAttempts * 500)
-            expect(attempts).toHaveLength(failedAttempts + 1)
-            const mintedIdentities = attemptIdentities[0]
-            for (const identities of attemptIdentities)
-              expect(identities).toEqual(mintedIdentities)
-
-            vi.advanceTimersByTime(10_000)
-            expect(attemptIdentities.at(-1)).toEqual(mintedIdentities)
-            expect(attempts).toHaveLength(failedAttempts + 2)
-            sender.detach()
+              vi.advanceTimersByTime(10_000)
+              expect(attemptIdentities.at(-1)).toEqual(mintedIdentities)
+              expect(attemptIdentities).toHaveLength(failedAttempts + 2)
+            } finally {
+              sender.detach()
+            }
           }
         )
       )


### PR DESCRIPTION
## Summary

Adds permanent property and integration baselines for the main v2 CRDT follower and human write leg.

## Changes

- **What**: Covers duplicate/reordered update convergence, state-vector gap recovery, awareness isolation, schema fail-closed behavior, op identity/retry invariants, reset ordering, and the real shared-applier → frame → ECS-store follower seam.
- **Dependencies**: None.

## Review Focus

Please verify the properties match the current main v2 follower contract, especially random `op_id` identity versus causal delivery order and reset-before-lineage-replacement ordering.

## Evidence

- Scope-ready recovery: [`e9adbcb6857d78c167451a6055f1c17af934ab1c`](https://github.com/Comfy-Org/ComfyUI_frontend/pull/16353/commits/e9adbcb6857d78c167451a6055f1c17af934ab1c) — `retryProjection` in `ecsFollowerAdapter.ts`, polling + `clearScopeRetry` in `useAgentCrdtFollower.ts`, `scope_ready_retry` dev event.
- Regression test: `followerSeam.integration.test.ts` › `recovers a withheld update via retryProjection without a later frame` (fails without the adapter change: `retryProjection is not a function`).
- `pnpm exec vitest run src/workbench/extensions/agent/crdt`: 30 files, 340/340 passed on `e9adbcb6857d78c167451a6055f1c17af934ab1c`.
- Scoped eslint clean; `vue-tsc --noEmit` exit 0 on `e9adbcb6857d78c167451a6055f1c17af934ab1c`.
