### PR TITLE
test: cover websocket fixture isolation

### DIFF
--- a/browser_tests/fixtures/ws.factory.test.ts
+++ b/browser_tests/fixtures/ws.factory.test.ts
@@ -1,0 +1,44 @@
+import type { WebSocketRoute } from '@playwright/test'
+import { describe, expect, it, vi } from 'vitest'
+
+import { createWebSocketRouteHandler } from '@e2e/fixtures/ws'
+
+function fakeRoute() {
+  const server = { onMessage: vi.fn() }
+  return {
+    connectToServer: vi.fn(() => server),
+    send: vi.fn(),
+    server
+  }
+}
+
+describe('createWebSocketRouteHandler', () => {
+  it('keeps an isolated routed socket disconnected from the server', () => {
+    const route = fakeRoute()
+    const onRouted = vi.fn()
+
+    createWebSocketRouteHandler(
+      false,
+      onRouted
+    )(route as unknown as WebSocketRoute)
+
+    expect(route.connectToServer).not.toHaveBeenCalled()
+    expect(onRouted).toHaveBeenCalledExactlyOnceWith(route)
+  })
+
+  it('forwards server messages to the routed socket when connected', () => {
+    const route = fakeRoute()
+    const onRouted = vi.fn()
+
+    createWebSocketRouteHandler(
+      true,
+      onRouted
+    )(route as unknown as WebSocketRoute)
+
+    expect(route.connectToServer).toHaveBeenCalledOnce()
+    const forward = route.server.onMessage.mock.calls[0][0]
+    forward('frame-1')
+    expect(route.send).toHaveBeenCalledExactlyOnceWith('frame-1')
+    expect(onRouted).toHaveBeenCalledExactlyOnceWith(route)
+  })
+})

--- a/browser_tests/fixtures/ws.ts
+++ b/browser_tests/fixtures/ws.ts
@@ -1,6 +1,22 @@
 import { test as base } from '@playwright/test'
 import type { WebSocketRoute } from '@playwright/test'
 
+export function createWebSocketRouteHandler(
+  connectWebSocketToServer: boolean,
+  onRouted: (ws: WebSocketRoute) => void
+) {
+  return (ws: WebSocketRoute) => {
+    if (connectWebSocketToServer) {
+      const server = ws.connectToServer()
+      server.onMessage((message) => {
+        ws.send(message)
+      })
+    }
+
+    onRouted(ws)
+  }
+}
+
 export const webSocketFixture = base.extend<{
   connectWebSocketToServer: boolean
   getWebSocket: () => Promise<WebSocketRoute>
@@ -11,17 +27,13 @@ export const webSocketFixture = base.extend<{
       let latest: WebSocketRoute | undefined
       let resolve: ((ws: WebSocketRoute) => void) | undefined
 
-      await context.routeWebSocket(/\/ws/, (ws) => {
-        if (connectWebSocketToServer) {
-          const server = ws.connectToServer()
-          server.onMessage((message) => {
-            ws.send(message)
-          })
-        }
-
-        latest = ws
-        resolve?.(ws)
-      })
+      await context.routeWebSocket(
+        /\/ws/,
+        createWebSocketRouteHandler(connectWebSocketToServer, (ws) => {
+          latest = ws
+          resolve?.(ws)
+        })
+      )
 
       await use(() => {
         if (latest) return Promise.resolve(latest)


### PR DESCRIPTION
## Summary

Adds permanent regression coverage for the browser WebSocket fixture isolation boundary carried forward by the W10 semantic-transplant queue.

## Changes

- **What**: Extracts the existing route callback into `createWebSocketRouteHandler` and tests disconnected isolation plus connected server-to-page forwarding.

## Review Focus

Please verify the extraction preserves the existing fixture lifecycle and that the unit seam accurately represents Playwright `WebSocketRoute` forwarding.
