### PR TITLE
test: preserve transcript hydration semantics

### DIFF
--- a/src/workbench/extensions/agent/stores/agent/agentConversationStore.test.ts
+++ b/src/workbench/extensions/agent/stores/agent/agentConversationStore.test.ts
@@ -340,6 +340,43 @@ describe('useAgentConversationStore', () => {
     expect(partTexts(store)).toContain('the awaited reply')
   })
 
+  it('hydrates transcript turns in sequence order', () => {
+    const store = useAgentConversationStore()
+
+    store.hydrate([
+      historyRow(4, 'assistant', 'turn-b', 'Second reply'),
+      historyRow(2, 'assistant', 'turn-a', 'First reply'),
+      historyRow(1, 'user', 'turn-a', 'First prompt'),
+      historyRow(3, 'user', 'turn-b', 'Second prompt')
+    ])
+
+    expect(store.entries.map((entry) => entry.id)).toEqual([
+      'turn-a',
+      'turn-a',
+      'turn-b',
+      'turn-b'
+    ])
+    expect(partTexts(store)).toEqual(['First reply', 'Second reply'])
+  })
+
+  it('keeps hydrated turn identity stable when persisted row ids change', () => {
+    const store = useAgentConversationStore()
+    const firstRows = [
+      historyRow(1, 'user', 'turn-a', 'Prompt', 'user-row-v1'),
+      historyRow(2, 'assistant', 'turn-a', 'Reply', 'assistant-row-v1')
+    ]
+
+    store.hydrate(firstRows)
+    const firstMessage = store.messages[0]
+    store.hydrate([
+      historyRow(1, 'user', 'turn-a', 'Prompt', 'user-row-v2'),
+      historyRow(2, 'assistant', 'turn-a', 'Reply', 'assistant-row-v2')
+    ])
+
+    expect(store.messages[0].id).toBe(firstMessage.id)
+    expect(store.messages[0].id).toBe('turn-a')
+  })
+
   it('keeps an earlier completed turn when a returning live turn repeats its prompt text', () => {
     const store = useAgentConversationStore()
     store.setThreadId('th')


### PR DESCRIPTION
## Summary

Permanently preserves transcript ordering and stable turn identity on the main-based agent conversation store.

## Changes

- **What**: Transplants the frozen-slice transcript hydration assertions onto main’s current `agentConversationStore` surface.

## Review Focus

Please verify that the tests express user-visible transcript behavior rather than persistence-row implementation details.

## Screenshots (if applicable)

Not applicable; test-only change.