### PR TITLE
test: cover offset canvas viewport framing

### DIFF
--- a/src/lib/litegraph/src/DragAndScale.animateToBounds.test.ts
+++ b/src/lib/litegraph/src/DragAndScale.animateToBounds.test.ts
@@ -18,6 +18,10 @@ function screenCenterX(ds: DragAndScale, bounds: Bounds) {
   return (bounds[0] + bounds[2] * 0.5 + ds.offset[0]) * ds.scale
 }
 
+function screenCenterY(ds: DragAndScale, bounds: Bounds) {
+  return (bounds[1] + bounds[3] * 0.5 + ds.offset[1]) * ds.scale
+}
+
 describe('DragAndScale.animateToBounds', () => {
   beforeEach(() => {
     pendingFrame = undefined
@@ -53,12 +57,42 @@ describe('DragAndScale.animateToBounds', () => {
     expect(ds.scale).toBeCloseTo(2.25)
   })
 
+  it('centers on an offset, width-constrained viewport', () => {
+    const ds = createDragAndScale()
+    const bounds: Bounds = [0, 0, 100, 100]
+
+    ds.animateToBounds(bounds, vi.fn(), {
+      zoom: 0.75,
+      viewport: [400, 0, 600, 900]
+    })
+    settle()
+
+    expect(screenCenterX(ds, bounds)).toBeCloseTo(700)
+    expect(ds.scale).toBeCloseTo(1.5)
+  })
+
+  it('centers on an offset, height-constrained viewport', () => {
+    const ds = createDragAndScale()
+    const bounds: Bounds = [0, 0, 100, 100]
+
+    ds.animateToBounds(bounds, vi.fn(), {
+      zoom: 0.75,
+      viewport: [0, 300, 1600, 600]
+    })
+    settle()
+
+    expect(screenCenterY(ds, bounds)).toBeCloseTo(600)
+    expect(ds.scale).toBeCloseTo(1.5)
+  })
+
   it.for([
     ['width', [0, 0, 0, 900]],
     ['height', [0, 0, 1600, 0]]
   ] as const)('ignores a viewport with no visible $0', ([, viewport]) => {
     const ds = createDragAndScale()
     const setDirty = vi.fn()
+    const offsetBefore = [...ds.offset]
+    const scaleBefore = ds.scale
 
     ds.animateToBounds([0, 0, 100, 100], setDirty, {
       viewport
@@ -66,7 +100,7 @@ describe('DragAndScale.animateToBounds', () => {
 
     expect(pendingFrame).toBeUndefined()
     expect(setDirty).not.toHaveBeenCalled()
-    expect(ds.offset.every(Number.isFinite)).toBe(true)
-    expect(Number.isFinite(ds.scale)).toBe(true)
+    expect([...ds.offset]).toEqual(offsetBefore)
+    expect(ds.scale).toBe(scaleBefore)
   })
 })


### PR DESCRIPTION
## Summary

Adds permanent regression coverage for canvas framing inside offset viewports, preserving the focus/canvas semantic-transplant behavior from the retired slice stack on current `main`.

## Changes

- **What**: Tests horizontal and vertical viewport offsets, and strengthens zero-size viewport assertions to require byte-for-byte view-state preservation.

## Review Focus

Please verify the expected screen-center calculations for width- and height-constrained viewports. This is test-only and intentionally does not overlap the navigation-store refactor in #16342.

## Screenshots (if applicable)

Not applicable; test-only change.

## EVX re-audit mapping

Historical offset-framing coverage from `949abe26`, `511b87ed`, and `ff9ea5e5` is terminally carried here at `1ffcdfb43fc9` for [#16386](https://github.com/Comfy-Org/ComfyUI_frontend/issues/16386). The generic inset/occlusion implementation remains `NEEDS-REDESIGN` under the existing `port-3` disposition; this PR does not implement that redesign or any post-agent-edit fit behavior.