### PR TITLE
fix(crdt): re-mint follower doc on cross-workflow subscribe (FEB-5 on main)

### DIFF
--- a/src/workbench/extensions/agent/crdt/followerSubscription.test.ts
+++ b/src/workbench/extensions/agent/crdt/followerSubscription.test.ts
@@ -520,8 +520,22 @@ describe('FEB-5 — switching workflows is a lineage break, never a fold', () =>
   it('replaces the doc and subscribes from an EMPTY state vector on switch', () => {
     const { transport, bridge } = wire()
     const replaced: unknown[] = []
+    const switchEvents: string[] = []
+    const send = transport.send.bind(transport)
+    vi.spyOn(transport, 'send').mockImplementation((frame) => {
+      const { type, data } = JSON.parse(frame) as {
+        type: string
+        data?: { workflow_id?: string }
+      }
+      if (type === 'doc_subscribe' && data?.workflow_id === 'wf-2')
+        switchEvents.push('subscribe')
+      return send(frame)
+    })
     bridge.addEventListener('follower_replaced', (event) => {
-      if (event instanceof CustomEvent) replaced.push(event.detail)
+      if (event instanceof CustomEvent) {
+        replaced.push(event.detail)
+        switchEvents.push('replaced')
+      }
     })
     transport.open = true
     bridge.subscribe(WORKFLOW_ID)
@@ -537,6 +551,7 @@ describe('FEB-5 — switching workflows is a lineage break, never a fold', () =>
     expect(bridge.follower.updatesApplied).toBe(0)
     expect(bridge.follower.doc.getMap('nodes').size).toBe(0)
     expect(replaced).toEqual([{ workflowId: 'wf-2' }])
+    expect(switchEvents).toEqual(['replaced', 'subscribe'])
 
     // The old subscription is released, and the new subscribe carries the
     // FRESH doc's state vector — the empty one — never wf-1's, which the host

--- a/src/workbench/extensions/agent/crdt/followerSubscription.test.ts
+++ b/src/workbench/extensions/agent/crdt/followerSubscription.test.ts
@@ -590,7 +590,7 @@ describe('FEB-5 — switching workflows is a lineage break, never a fold', () =>
   })
 
   it('a switch on a dead socket still replaces the doc and announces it', () => {
-    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
     const { transport, bridge } = wire()
     const replaced: unknown[] = []
     bridge.addEventListener('follower_replaced', (event) => {
@@ -613,6 +613,5 @@ describe('FEB-5 — switching workflows is a lineage break, never a fold', () =>
     transport.open = true
     bridge.reconcile()
     expect(bridge.subscribedWorkflowId).toBe('wf-2')
-    warn.mockRestore()
   })
 })

--- a/src/workbench/extensions/agent/crdt/followerSubscription.test.ts
+++ b/src/workbench/extensions/agent/crdt/followerSubscription.test.ts
@@ -515,3 +515,104 @@ describe('FE-KA11-1 — the read-time schema gate fails closed', () => {
     error.mockRestore()
   })
 })
+
+describe('FEB-5 — switching workflows is a lineage break, never a fold', () => {
+  it('replaces the doc and subscribes from an EMPTY state vector on switch', () => {
+    const { transport, bridge } = wire()
+    const replaced: unknown[] = []
+    bridge.addEventListener('follower_replaced', (event) => {
+      if (event instanceof CustomEvent) replaced.push(event.detail)
+    })
+    transport.open = true
+    bridge.subscribe(WORKFLOW_ID)
+    transport.deliver('doc_update', docUpdateFrame(hostDocUpdate()))
+    const oldDoc = bridge.follower
+    expect(oldDoc.updatesApplied).toBe(1)
+
+    bridge.subscribe('wf-2')
+
+    // The old lineage is dropped wholesale — wf-2's history is never folded
+    // into wf-1's doc, which would put both workflows' nodes on one canvas.
+    expect(bridge.follower).not.toBe(oldDoc)
+    expect(bridge.follower.updatesApplied).toBe(0)
+    expect(bridge.follower.doc.getMap('nodes').size).toBe(0)
+    expect(replaced).toEqual([{ workflowId: 'wf-2' }])
+
+    // The old subscription is released, and the new subscribe carries the
+    // FRESH doc's state vector — the empty one — never wf-1's, which the host
+    // would use to compute a nonsense delta against wf-2's history.
+    expect(transport.framesOfType('doc_unsubscribe')).toHaveLength(1)
+    const subscribes = transport.framesOfType('doc_subscribe') as {
+      data: { workflow_id: string; state_vector_b64: string }
+    }[]
+    expect(subscribes).toHaveLength(2)
+    expect(subscribes[1].data.workflow_id).toBe('wf-2')
+    expect(subscribes[1].data.state_vector_b64).toBe(
+      encodeBase64(Y.encodeStateVector(new Y.Doc()))
+    )
+
+    // The next wf-2 update lands on the fresh lineage.
+    transport.deliver('doc_update', docUpdateFrame(hostDocUpdate(), 'wf-2'))
+    expect(bridge.follower.updatesApplied).toBe(1)
+  })
+
+  it('re-subscribing to the SAME workflow keeps the doc (same-lineage catch-up)', () => {
+    const { transport, bridge } = wire()
+    const replaced: unknown[] = []
+    bridge.addEventListener('follower_replaced', (event) => {
+      replaced.push(event)
+    })
+    transport.open = true
+    bridge.subscribe(WORKFLOW_ID)
+    transport.deliver('doc_update', docUpdateFrame(hostDocUpdate()))
+    const oldDoc = bridge.follower
+
+    bridge.subscribe(WORKFLOW_ID)
+    bridge.resubscribe()
+
+    expect(bridge.follower).toBe(oldDoc)
+    expect(bridge.follower.updatesApplied).toBe(1)
+    expect(replaced).toEqual([])
+  })
+
+  it('a detach then a switch still breaks lineage: unsubscribe does not empty the doc', () => {
+    const { transport, bridge } = wire()
+    transport.open = true
+    bridge.subscribe(WORKFLOW_ID)
+    transport.deliver('doc_update', docUpdateFrame(hostDocUpdate()))
+    const oldDoc = bridge.follower
+
+    bridge.unsubscribe()
+    bridge.subscribe('wf-2')
+
+    expect(bridge.follower).not.toBe(oldDoc)
+    expect(bridge.follower.updatesApplied).toBe(0)
+  })
+
+  it('a switch on a dead socket still replaces the doc and announces it', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const { transport, bridge } = wire()
+    const replaced: unknown[] = []
+    bridge.addEventListener('follower_replaced', (event) => {
+      if (event instanceof CustomEvent) replaced.push(event.detail)
+    })
+    transport.open = true
+    bridge.subscribe(WORKFLOW_ID)
+    transport.deliver('doc_update', docUpdateFrame(hostDocUpdate()))
+
+    transport.open = false
+    bridge.subscribe('wf-2')
+
+    // The lineage break is honoured even though the subscribe cannot leave,
+    // and consumers are told to rebind — the old doc is destroyed.
+    expect(bridge.follower.updatesApplied).toBe(0)
+    expect(replaced).toEqual([{ workflowId: 'wf-2' }])
+    expect(bridge.subscribedWorkflowId).toBeNull()
+    expect(bridge.hasPendingSubscribe).toBe(true)
+
+    transport.open = true
+    bridge.reconcile()
+    expect(bridge.subscribedWorkflowId).toBe('wf-2')
+    warn.mockRestore()
+  })
+})

--- a/src/workbench/extensions/agent/crdt/layoutFollowerBridge.ts
+++ b/src/workbench/extensions/agent/crdt/layoutFollowerBridge.ts
@@ -130,10 +130,10 @@ export class LayoutFollowerBridge extends EventTarget {
     this.desiredWorkflowId = workflowId
     if (lineage !== null && lineage !== workflowId) {
       this.dropDocForNewLineage()
-      this.reconcile()
       this.dispatchEvent(
         new CustomEvent('follower_replaced', { detail: { workflowId } })
       )
+      this.reconcile()
       return
     }
     this.reconcile()

--- a/src/workbench/extensions/agent/crdt/layoutFollowerBridge.ts
+++ b/src/workbench/extensions/agent/crdt/layoutFollowerBridge.ts
@@ -36,11 +36,21 @@ function trySend(send: () => boolean): boolean {
  */
 export class LayoutFollowerBridge extends EventTarget {
   /**
-   * Reassigned only by {@link onDocReset}: a lineage break replaces the doc
-   * wholesale, because folding a re-minted document into the old one merges
-   * two unrelated histories and duplicates every node on the canvas.
+   * Reassigned only on a lineage break — an explicit `doc_reset`
+   * ({@link onDocReset}) or a subscribe to a DIFFERENT workflow
+   * ({@link subscribe}) — because folding one document's history into another
+   * merges two unrelated lineages: the next subscribe would carry the old
+   * doc's state vector, the host would compute a nonsense delta against it,
+   * and both workflows' nodes would land on one canvas (FEB-5).
    */
   private followerDoc = new FollowerDoc()
+  /**
+   * The workflow whose lineage {@link followerDoc} holds — the id passed to
+   * the most recent {@link subscribe}. Unlike {@link desiredWorkflowId} it
+   * survives {@link unsubscribe}, because detaching does not empty the doc:
+   * a later subscribe to a DIFFERENT workflow must still re-mint it.
+   */
+  private lineageWorkflowId: string | null = null
   /**
    * Subscription INTENT — the workflow the app wants followed. Set
    * synchronously by the caller; independent of whether any frame has left the
@@ -104,8 +114,28 @@ export class LayoutFollowerBridge extends EventTarget {
     )
   }
 
+  /**
+   * Follow a workflow. Subscribing to a DIFFERENT workflow than the one this
+   * bridge's doc holds is a lineage break (FEB-5): the doc is re-minted so
+   * the subscribe carries an empty state vector, and `follower_replaced` is
+   * dispatched — unconditionally, even when the send could not leave a closed
+   * socket — so consumers rebind their observers to the new doc rather than
+   * staying attached to the destroyed one. Re-subscribing to the SAME
+   * workflow keeps the doc: that is the same-lineage catch-up path
+   * (ADR-0024), where the state vector makes the delta cheap.
+   */
   subscribe(workflowId: string): void {
+    const lineage = this.lineageWorkflowId
+    this.lineageWorkflowId = workflowId
     this.desiredWorkflowId = workflowId
+    if (lineage !== null && lineage !== workflowId) {
+      this.dropDocForNewLineage()
+      this.reconcile()
+      this.dispatchEvent(
+        new CustomEvent('follower_replaced', { detail: { workflowId } })
+      )
+      return
+    }
     this.reconcile()
   }
 

--- a/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.test.ts
+++ b/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.test.ts
@@ -283,6 +283,11 @@ describe('useAgentCrdtFollower', () => {
     })
 
     dispatchFrame('follower_replaced', { seq: 43 })
+    expect(adapterState.clearForReset).toHaveBeenLastCalledWith('wf-1', {
+      source: 'agent-remote',
+      actor: 'agent-lineage',
+      opId: 'follower-replaced:wf-1'
+    })
     expect(adapterState.bind).toHaveBeenCalledTimes(2)
     expect(adapterState.bind).toHaveBeenLastCalledWith(
       'wf-1',

--- a/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.test.ts
+++ b/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.test.ts
@@ -268,7 +268,7 @@ describe('useAgentCrdtFollower', () => {
   })
 
   it('clears only for an explicit reset and rebinds after replacement', () => {
-    const { unmount } = mountFollower('wf-1')
+    const { unmount, status } = mountFollower('wf-1')
     expect(adapterState.bind).toHaveBeenCalledTimes(1)
 
     dispatchFrame('doc_reset', {
@@ -282,7 +282,12 @@ describe('useAgentCrdtFollower', () => {
       opId: 'doc-reset:43'
     })
 
-    dispatchFrame('follower_replaced', { seq: 43 })
+    bridge().follower.updatesApplied = 3
+    dispatchFrame('doc_update', { workflowId: 'wf-1', seq: 44 })
+    expect(status().updatesApplied).toBe(3)
+
+    dispatchFrame('follower_replaced', { workflowId: 'wf-1' })
+    expect(status().updatesApplied).toBe(0)
     expect(adapterState.clearForReset).toHaveBeenLastCalledWith('wf-1', {
       source: 'agent-remote',
       actor: 'agent-lineage',

--- a/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.test.ts
+++ b/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.test.ts
@@ -286,6 +286,10 @@ describe('useAgentCrdtFollower', () => {
     dispatchFrame('doc_update', { workflowId: 'wf-1', seq: 44 })
     expect(status().updatesApplied).toBe(3)
 
+    dispatchFrame('follower_replaced', { workflowId: 'wf-2' })
+    expect(status().updatesApplied).toBe(3)
+    expect(adapterState.bind).toHaveBeenCalledTimes(1)
+
     dispatchFrame('follower_replaced', { workflowId: 'wf-1' })
     expect(status().updatesApplied).toBe(0)
     expect(adapterState.clearForReset).toHaveBeenLastCalledWith('wf-1', {

--- a/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.ts
+++ b/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.ts
@@ -316,6 +316,7 @@ export function useAgentCrdtFollower(
     // when the socket recovers and updates land in the replacement.
     const workflowId = subscribedWorkflowId.value
     if (isTargetActive.value && workflowId !== null) {
+      updatesApplied.value = 0
       adapter.clearForReset(workflowId, {
         source: 'agent-remote',
         actor: 'agent-lineage',

--- a/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.ts
+++ b/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.ts
@@ -308,14 +308,20 @@ export function useAgentCrdtFollower(
       event instanceof CustomEvent ? (event.detail ?? null) : null
     )
   }
-  const onFollowerReplaced: EventListener = () => {
+  const onFollowerReplaced: EventListener = (event) => {
     // Gate on this composable's own INTENT, not the bridge's send REALITY
     // (`bridge.subscribedWorkflowId`): a doc replacement while the socket is
     // down leaves reality null, but the adapter must still be rebound to the
     // new doc — otherwise it keeps observing the destroyed one and goes deaf
     // when the socket recovers and updates land in the replacement.
-    const workflowId = subscribedWorkflowId.value
-    if (isTargetActive.value && workflowId !== null) {
+    if (!(event instanceof CustomEvent)) return
+    const detail = event.detail as { workflowId?: unknown } | null
+    const workflowId = detail?.workflowId
+    if (
+      isTargetActive.value &&
+      typeof workflowId === 'string' &&
+      workflowId === subscribedWorkflowId.value
+    ) {
       updatesApplied.value = 0
       adapter.clearForReset(workflowId, {
         source: 'agent-remote',

--- a/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.ts
+++ b/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.ts
@@ -309,12 +309,13 @@ export function useAgentCrdtFollower(
     )
   }
   const onFollowerReplaced: EventListener = () => {
-    const workflowId = bridge.subscribedWorkflowId
-    if (
-      isTargetActive.value &&
-      workflowId !== null &&
-      workflowId === subscribedWorkflowId.value
-    )
+    // Gate on this composable's own INTENT, not the bridge's send REALITY
+    // (`bridge.subscribedWorkflowId`): a doc replacement while the socket is
+    // down leaves reality null, but the adapter must still be rebound to the
+    // new doc — otherwise it keeps observing the destroyed one and goes deaf
+    // when the socket recovers and updates land in the replacement.
+    const workflowId = subscribedWorkflowId.value
+    if (isTargetActive.value && workflowId !== null)
       adapter.bind(workflowId, bridge.follower)
   }
   const onSchemaError: EventListener = (event) => {

--- a/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.ts
+++ b/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.ts
@@ -315,8 +315,14 @@ export function useAgentCrdtFollower(
     // new doc — otherwise it keeps observing the destroyed one and goes deaf
     // when the socket recovers and updates land in the replacement.
     const workflowId = subscribedWorkflowId.value
-    if (isTargetActive.value && workflowId !== null)
+    if (isTargetActive.value && workflowId !== null) {
+      adapter.clearForReset(workflowId, {
+        source: 'agent-remote',
+        actor: 'agent-lineage',
+        opId: `follower-replaced:${workflowId}`
+      })
       adapter.bind(workflowId, bridge.follower)
+    }
   }
   const onSchemaError: EventListener = (event) => {
     // KA-11 fail-closed: the bridge refused to propagate an unreadable doc, so


### PR DESCRIPTION
Workflow switch folded two docs into one. Bridge now re-mints on switch. 4 regression tests.

<details><summary>Full context for agent readers</summary>

## What

`LayoutFollowerBridge` replaced its `FollowerDoc` only on an explicit `doc_reset`. A workflow **switch** (subscribe A → B) went through `reconcile()`, which kept the old doc and sent the new subscribe with the **old doc's state vector**:

```
subscribe(B) → reconcile() → client.subscribe(B, follower.stateVector())  ← A's vector
```

Consequences on switch:

1. The host computes a catch-up delta for B against A's state vector — nonsense, so parts of B's history that appear "already known" are skipped.
2. B's updates merge into the Y.Doc still holding A's nodes — both workflows' content lands on one canvas (the FEB-5 lineage fold, previously fixed on the retired `nathaniel/agent-panel-v1` base in #16276; this ports the invariant to the v2 code on main).

`EcsFollowerAdapter` isolates per-workflow sessions correctly, but the composable passes the **same** `bridge.follower` to every `bind()`, so adapter isolation could not prevent the fold.

## Fix

- `subscribe(workflowId)` now treats a different workflow than the doc's current lineage as a lineage break — identical semantics to `doc_reset`: drop the doc (`dropDocForNewLineage()`), reconcile (empty state vector goes out), dispatch `follower_replaced` so consumers rebind.
- New `lineageWorkflowId` field tracks which workflow the doc holds; it survives `unsubscribe()` because detaching does not empty the doc.
- Same-workflow `resubscribe()` / gap-recovery / stale-probe paths are untouched — those are the same-lineage catch-up (ADR-0024) where keeping the state vector is the point.
- `useAgentCrdtFollower`'s `follower_replaced` handler now gates on the composable's own intent rather than `bridge.subscribedWorkflowId` (send reality): a replacement while the socket is down previously skipped the rebind, leaving the adapter observing a **destroyed** doc forever (this latent bug also affected `doc_reset` during an outage).

## Tests

`followerSubscription.test.ts`, new `FEB-5` block (4 tests):

- switch replaces the doc and subscribes from an EMPTY state vector, unsubscribes the old workflow, announces `follower_replaced`
- same-workflow resubscribe keeps the doc (no replacement event)
- detach → switch still breaks lineage
- switch on a dead socket still replaces the doc and announces it; the subscribe lands on the next reconcile

## Verification

- `pnpm vitest run src/workbench/extensions/agent/crdt/` — 16 files, 164 tests, all green (+4 new)
- `pnpm typecheck` — clean
- eslint + oxfmt on touched files — clean

## Diagram

```
BEFORE (switch A→B)                     AFTER (switch A→B)
┌────────────┐                          ┌────────────┐
│ Y.Doc (A)  │──stateVector(A)──▶ sub B │ Y.Doc (A)  │──destroyed
│ keeps A's  │◀──B's updates fold in    └────────────┘
│ nodes      │   (A ∪ B on canvas)      ┌────────────┐
└────────────┘                          │ Y.Doc (new)│──empty sv──▶ sub B
                                        │ B only     │◀──full B state
                                        └────────────┘
                                        + follower_replaced → adapter rebind
```

## Glossary

- **FEB-5** — bug id: follower doc reused across workflow switch (cross-lineage fold)
- **lineage** — the identity of a Y.Doc's history; merging two lineages duplicates content
- **state vector** — Yjs summary of known updates; the host uses it to compute a catch-up delta
- **`follower_replaced`** — bridge event telling consumers the Y.Doc instance changed, rebind observers
- **ADR-0024** — decision: same-lineage gap recovery resubscribes with the existing doc's vector; only a lineage break replaces the doc
- **#16276** — earlier FEB-5 fix PR targeting the retired `nathaniel/agent-panel-v1` base; this PR supersedes it on main

</details>
