### PR TITLE
fix(crdt): reconcile in-place widget key removal (FEC-3)

### DIFF
--- a/src/workbench/extensions/agent/crdt/ecsFollowerAdapter.integration.test.ts
+++ b/src/workbench/extensions/agent/crdt/ecsFollowerAdapter.integration.test.ts
@@ -1,4 +1,4 @@
-import { applyOps, mint } from '@comfyorg/comfy-multi-player'
+import { applyOps, mint, nodesMap } from '@comfyorg/comfy-multi-player'
 import type { WidgetCatalog } from '@comfyorg/comfy-multi-player'
 import { createTestingPinia } from '@pinia/testing'
 import { setActivePinia } from 'pinia'
@@ -697,6 +697,83 @@ describe('EcsFollowerAdapter integration', () => {
       [toNodeId(2)],
       expect.objectContaining({ source: 'agent-remote', opId: 'op-8' })
     )
+
+    adapter.destroy()
+    follower.destroy()
+    host.destroy()
+  })
+
+  it('drops the stale value when a single widget key is removed in place (FEC-3)', () => {
+    // Unlike a set_widget update (covered above), this host deletes ONE key
+    // from the *same* widgets Y.Map instance rather than swapping the whole
+    // map or changing a surviving key's value. onNodesChanged detects the
+    // 'delete' action inside the widgets map's own YMapEvent and routes
+    // this node through reconcileNode instead of the per-name setWidget
+    // loop, so the removed key is actually cleared from the widget store.
+    const host = mint(
+      {
+        nodes: [
+          {
+            id: 1,
+            type: 'Source',
+            pos: [10, 20],
+            widgets_values: { seed: 1, stale: 9 },
+            inputs: [],
+            outputs: []
+          }
+        ],
+        links: []
+      },
+      catalog
+    )
+    const follower = new FollowerDoc()
+    const mutations = createGraphMutations({
+      getScope: () => scope,
+      layout: { createNode: vi.fn(), deleteNodes: vi.fn() }
+    })
+    const adapter = new EcsFollowerAdapter(mutations)
+    adapter.bind('wf', follower)
+
+    const initial = Y.encodeStateAsUpdate(host)
+    follower.applyRemoteUpdate(initial)
+    expect(
+      adapter.applyFrame({
+        workflowId: 'wf',
+        seq: 1,
+        update: initial,
+        actor: 'agent:test',
+        opIds: ['add']
+      })
+    ).toBe(true)
+
+    expect(
+      useWidgetValueStore().getWidget(widgetId('root', toNodeId(1), 'stale'))
+        ?.value
+    ).toBe(9)
+
+    const beforeRemoval = Y.encodeStateVector(host)
+    const widgets = nodesMap(host).get('1')?.get('widgets')
+    expect(widgets).toBeInstanceOf(Y.Map)
+    ;(widgets as Y.Map<unknown>).delete('stale')
+    const update = Y.encodeStateAsUpdate(host, beforeRemoval)
+    follower.applyRemoteUpdate(update)
+    expect(
+      adapter.applyFrame({
+        workflowId: 'wf',
+        seq: 2,
+        update,
+        actor: 'agent:test',
+        opIds: ['remove-widget-key']
+      })
+    ).toBe(true)
+
+    expect(
+      useWidgetValueStore().getWidget(widgetId('root', toNodeId(1), 'stale'))
+    ).toBeUndefined()
+    expect(
+      useWidgetValueStore().getWidget(widgetId('root', toNodeId(1), 'seed'))
+        ?.value
+    ).toBe(1)
 
     adapter.destroy()
     follower.destroy()

--- a/src/workbench/extensions/agent/crdt/ecsFollowerAdapter.ts
+++ b/src/workbench/extensions/agent/crdt/ecsFollowerAdapter.ts
@@ -111,6 +111,7 @@ interface TargetSession {
   readonly mutations: GraphMutations
   readonly nodeActions: Map<string, NodeRootAction>
   readonly changedWidgets: Map<string, Set<string>>
+  readonly widgetsWithRemovals: Set<string>
   readonly changedLinks: Set<string>
   readonly frameQueue: DocUpdate[]
   onNodesChanged: (events: Y.YEvent<Y.AbstractType<unknown>>[]) => void
@@ -197,6 +198,7 @@ export class EcsFollowerAdapter {
           : this.mutations,
       nodeActions: new Map<string, NodeRootAction>(),
       changedWidgets: new Map<string, Set<string>>(),
+      widgetsWithRemovals: new Set<string>(),
       changedLinks: new Set<string>(),
       frameQueue: [],
       reconcileNextFrame: true,
@@ -215,6 +217,7 @@ export class EcsFollowerAdapter {
     const changedWidgets = new Map(
       [...session.changedWidgets].map(([id, names]) => [id, new Set(names)])
     )
+    const widgetsWithRemovals = new Set(session.widgetsWithRemovals)
     const changedLinkIds = new Set(session.changedLinks)
     const reconcile = session.reconcileNextFrame
     this.discardSessionPending(session)
@@ -270,8 +273,13 @@ export class EcsFollowerAdapter {
         if (!payload) continue
         batch.addNode(payload)
       }
-      for (const [id, names] of changedWidgets) {
+      for (const id of widgetsWithRemovals) {
         if (nodeActions.has(id)) continue
+        const payload = readSemanticNode(session.follower.doc, id)
+        if (payload) batch.reconcileNode(payload)
+      }
+      for (const [id, names] of changedWidgets) {
+        if (nodeActions.has(id) || widgetsWithRemovals.has(id)) continue
         const node = session.nodes.get(id)
         const widgets = node?.get('widgets')
         if (!(widgets instanceof Y.Map)) continue
@@ -297,6 +305,7 @@ export class EcsFollowerAdapter {
   private discardSessionPending(session: TargetSession): void {
     session.nodeActions.clear()
     session.changedWidgets.clear()
+    session.widgetsWithRemovals.clear()
     session.changedLinks.clear()
   }
 
@@ -316,7 +325,15 @@ export class EcsFollowerAdapter {
       if (!id) continue
       if (event.path[1] === 'widgets') {
         const names = session.changedWidgets.get(id) ?? new Set<string>()
-        for (const name of event.keysChanged) names.add(name)
+        for (const name of event.keysChanged) {
+          names.add(name)
+          // A key deleted in place can't be expressed by setWidget alone
+          // (it only fires `if (widgets.has(name))`) -- route this node
+          // through reconcileNode so the removed key is actually cleared
+          // from the widget store instead of silently surviving (FEC-3).
+          if (event.changes.keys.get(name)?.action === 'delete')
+            session.widgetsWithRemovals.add(id)
+        }
         session.changedWidgets.set(id, names)
         continue
       }


### PR DESCRIPTION
## Summary
- Fixes the FEC-3 gap where the CRDT follower's incremental apply path silently dropped an in-place widget key removal: `onNodesChanged` tracked *changed* widget names but the apply loop only called `setWidget` `if (widgets.has(name))`, so a deleted key never emitted any mutation and the stale value survived in the widget store until the next full reconcile.
- Detects a `delete` action inside the widgets map's own `YMapEvent` and routes that node through `batch.reconcileNode(payload)` (the same convergent path the reconcile branch already uses), instead of the per-name `setWidget` loop, so the removed key is actually cleared.
- Rebased onto current `main` after `#16345` landed a broader reconcile-batch rework; this PR now carries only the widget-key-removal fix plus its regression test (the reset-preservation coverage from earlier commits on this branch was superseded by `#16345` and dropped from this diff).

## Verification
- `pnpm test:unit src/workbench/extensions/agent/crdt/ecsFollowerAdapter.integration.test.ts` (9 passed)
- `pnpm test:unit src/workbench/extensions/agent/crdt` (236 passed)
- Confirmed the new regression test fails on the pre-fix code and passes with the fix
- `pnpm exec oxfmt --check` (2 files)
- `pnpm exec eslint` (2 files, clean)
- pre-commit hook: lint-staged + `pnpm typecheck`

<!-- authored-by:agent lane-evfail-19 -->