### PR TITLE
test(agent): characterize CRDT workflow switch pending ops

### DIFF
--- a/src/workbench/extensions/agent/crdt/crossWorkflowPending.test.ts
+++ b/src/workbench/extensions/agent/crdt/crossWorkflowPending.test.ts
@@ -223,6 +223,7 @@ describe('R-73 cross-workflow pending operation characterization', () => {
     const operationAId = clientState.sent[0].ops[0].op_id
     await switchWorkflow(workflowId, 'wf-b')
     enqueue([deleteNode('b-pending')])
+    expect(clientState.sent).toHaveLength(1)
 
     dispatchOpsResult({
       workflowId: 'wf-a',

--- a/src/workbench/extensions/agent/crdt/crossWorkflowPending.test.ts
+++ b/src/workbench/extensions/agent/crdt/crossWorkflowPending.test.ts
@@ -176,11 +176,10 @@ describe('R-73 cross-workflow pending operation characterization', () => {
     clientState.sent = []
     clientState.sendOps.mockClear()
     devLogState.recordDevEvent.mockClear()
-    vi.useRealTimers()
+    vi.useFakeTimers()
   })
 
   it('does not retarget a transport retry after workflow A switches to workflow B', async () => {
-    vi.useFakeTimers()
     clientState.transportUp = false
     const { workflowId, enqueue } = mountFollower('wf-a')
 

--- a/src/workbench/extensions/agent/crdt/crossWorkflowPending.test.ts
+++ b/src/workbench/extensions/agent/crdt/crossWorkflowPending.test.ts
@@ -214,7 +214,7 @@ describe('R-73 cross-workflow pending operation characterization', () => {
     })
   })
 
-  it('still accepts a late workflow A result by op_id while workflow B is active', async () => {
+  it('documents status contamination from a late workflow A result while workflow B is active', async () => {
     const { workflowId, enqueue, status } = mountFollower('wf-a')
 
     bridge().lastSequence = 41
@@ -236,8 +236,9 @@ describe('R-73 cross-workflow pending operation characterization', () => {
     expect(clientState.sent[1].ops[0]).toMatchObject({ base_version: 0 })
     const operationBId = clientState.sent[1].ops[0].op_id
 
-    // Current risk characterization: result frames carry workflowId, but the
-    // composable/sender path correlates by op_id only.
+    // Documented defect expectation for R-73: result frames carry workflowId,
+    // but the composable updates workflow B's status from workflow A's frame.
+    // Flip this assertion when the result path gates status by workflowId.
     expect(status()).toMatchObject({
       workflowId: 'wf-b',
       lastFrameType: 'doc_ops_result'

--- a/src/workbench/extensions/agent/crdt/crossWorkflowPending.test.ts
+++ b/src/workbench/extensions/agent/crdt/crossWorkflowPending.test.ts
@@ -1,0 +1,244 @@
+import type { Op } from '@comfyorg/comfy-multi-player'
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { defineComponent, nextTick, ref } from 'vue'
+import type { Ref } from 'vue'
+
+import type { GraphMutations } from '@/core/graph/graphMutations'
+import { render } from '@testing-library/vue'
+
+import type { GraphOperation } from './graphOperations'
+
+const bridgeState = vi.hoisted(() => {
+  class FakeBridge extends EventTarget {
+    subscribe = vi.fn((workflowId: string) => {
+      this.subscribedWorkflowId = workflowId
+    })
+
+    unsubscribe = vi.fn((workflowId?: string) => {
+      if (workflowId === undefined || this.subscribedWorkflowId === workflowId)
+        this.subscribedWorkflowId = null
+    })
+
+    resubscribe = vi.fn()
+    reconcile = vi.fn()
+    destroy = vi.fn()
+    subscribedWorkflowId: string | null = null
+    lastSequence = 41
+    follower = {
+      updatesApplied: 0,
+      doc: {
+        getMap: () => ({ toJSON: () => ({}) })
+      }
+    }
+  }
+
+  return { FakeBridge, current: null as InstanceType<typeof FakeBridge> | null }
+})
+
+const clientState = vi.hoisted(() => ({
+  destroy: vi.fn(),
+  transportUp: true,
+  sent: [] as Array<{ workflowId: string; tab: string; ops: Op[] }>,
+  sendOps: vi.fn((workflowId: string, tab: string, ops: Op[]) => {
+    if (!clientState.transportUp) return false
+    clientState.sent.push({ workflowId, tab, ops })
+    return true
+  })
+}))
+
+const adapterState = vi.hoisted(() => ({
+  bind: vi.fn(),
+  unbind: vi.fn(),
+  applyFrame: vi.fn(),
+  clearForReset: vi.fn(),
+  discardPending: vi.fn(),
+  destroy: vi.fn()
+}))
+
+const devLogState = vi.hoisted(() => ({
+  recordDevEvent: vi.fn()
+}))
+
+const apiState = vi.hoisted(() => {
+  const target = new EventTarget()
+  return {
+    target,
+    api: {
+      socket: { readyState: 1, send: vi.fn() },
+      addCustomEventListener: vi.fn(),
+      removeCustomEventListener: vi.fn(),
+      addEventListener: (type: string, listener: EventListener) =>
+        target.addEventListener(type, listener),
+      removeEventListener: vi.fn((type: string, listener: EventListener) =>
+        target.removeEventListener(type, listener)
+      )
+    }
+  }
+})
+
+vi.mock('./layoutFollowerBridge', () => ({
+  LayoutFollowerBridge: class {
+    constructor() {
+      const bridge = new bridgeState.FakeBridge()
+      bridgeState.current = bridge
+      return bridge
+    }
+  }
+}))
+
+vi.mock('./docFrameClient', () => ({
+  DocFrameClient: class {
+    destroy = clientState.destroy
+    sendOps = clientState.sendOps
+  }
+}))
+
+vi.mock('./ecsFollowerAdapter', () => ({
+  EcsFollowerAdapter: class {
+    bind = adapterState.bind
+    unbind = adapterState.unbind
+    applyFrame = adapterState.applyFrame
+    clearForReset = adapterState.clearForReset
+    discardPending = adapterState.discardPending
+    destroy = adapterState.destroy
+  }
+}))
+
+vi.mock('./devPanelLog', () => ({
+  recordDevEvent: devLogState.recordDevEvent
+}))
+
+vi.mock('@/scripts/api', () => ({ api: apiState.api }))
+vi.mock('@/scripts/app', () => ({ app: { graph: null, canvas: null } }))
+
+import { useAgentCrdtFollower } from './useAgentCrdtFollower'
+import type { AgentCrdtStatus } from './useAgentCrdtFollower'
+
+const graphMutations = {} as GraphMutations
+
+function deleteNode(nodeId: string): GraphOperation {
+  return {
+    op: 'delete_node',
+    node_id: nodeId,
+    removed_links: []
+  }
+}
+
+function mountFollower(initial: string): {
+  unmount: () => void
+  workflowId: Ref<string | null>
+  enqueue: (operations: GraphOperation[]) => void
+  status: () => AgentCrdtStatus
+} {
+  const workflowId = ref<string | null>(initial)
+  let enqueue!: (operations: GraphOperation[]) => void
+  let exposedStatus!: () => AgentCrdtStatus
+  const host = defineComponent({
+    setup() {
+      const { enqueueHumanOperations, status } = useAgentCrdtFollower(
+        workflowId,
+        graphMutations
+      )
+      enqueue = enqueueHumanOperations
+      exposedStatus = () => status.value as AgentCrdtStatus
+      return () => null
+    }
+  })
+  const { unmount } = render(host)
+  return { unmount, workflowId, enqueue, status: exposedStatus }
+}
+
+async function switchWorkflow(workflowId: Ref<string | null>, next: string) {
+  workflowId.value = next
+  await nextTick()
+}
+
+function bridge(): InstanceType<(typeof bridgeState)['FakeBridge']> {
+  const current = bridgeState.current
+  if (!current) throw new Error('no bridge constructed')
+  return current
+}
+
+function dispatchOpsResult(detail: unknown): void {
+  bridge().dispatchEvent(new CustomEvent('doc_ops_result', { detail }))
+}
+
+describe('R-73 cross-workflow pending operation characterization', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    bridgeState.current = null
+    clientState.transportUp = true
+    clientState.sent = []
+    clientState.sendOps.mockClear()
+    devLogState.recordDevEvent.mockClear()
+    vi.useRealTimers()
+  })
+
+  it('does not retarget a transport retry after workflow A switches to workflow B', async () => {
+    vi.useFakeTimers()
+    clientState.transportUp = false
+    const { unmount, workflowId, enqueue } = mountFollower('wf-a')
+
+    enqueue([deleteNode('a-queued')])
+    expect(clientState.sent).toHaveLength(0)
+
+    await switchWorkflow(workflowId, 'wf-b')
+    clientState.transportUp = true
+    vi.advanceTimersByTime(500)
+
+    // R-73 was filed against PR #16332's switch site. On main f954e479a,
+    // opSender keeps the workflow captured at enqueue time, so this half of
+    // the suspected A-to-B contamination is already a regression guard.
+    expect(bridge().subscribe).toHaveBeenLastCalledWith('wf-b')
+    expect(clientState.sent).toHaveLength(1)
+    expect(clientState.sent[0]).toMatchObject({ workflowId: 'wf-a' })
+    expect(clientState.sent[0].ops[0]).toMatchObject({
+      op: 'delete_node',
+      node_id: 'a-queued'
+    })
+
+    unmount()
+  })
+
+  it('still accepts a late workflow A result by op_id while workflow B is active', async () => {
+    const { unmount, workflowId, enqueue, status } = mountFollower('wf-a')
+
+    enqueue([deleteNode('a-inflight')])
+    const operationId = clientState.sent[0].ops[0].op_id
+    await switchWorkflow(workflowId, 'wf-b')
+
+    dispatchOpsResult({
+      workflowId: 'wf-a',
+      ok: true,
+      applied: [operationId],
+      skipped: []
+    })
+
+    // Current risk characterization: result frames carry workflowId, but the
+    // composable/sender path correlates by op_id only.
+    expect(status()).toMatchObject({
+      workflowId: 'wf-b',
+      lastFrameType: 'doc_ops_result'
+    })
+    expect(devLogState.recordDevEvent).toHaveBeenCalledWith('doc_ops_result', {
+      workflowId: 'wf-a',
+      ok: true,
+      applied: [operationId],
+      skipped: []
+    })
+    expect(devLogState.recordDevEvent).toHaveBeenCalledWith(
+      'human_ops_settled',
+      expect.objectContaining({
+        state: 'acknowledged',
+        result: expect.objectContaining({
+          ok: true,
+          applied: [operationId],
+          skipped: []
+        })
+      })
+    )
+
+    unmount()
+  })
+})

--- a/src/workbench/extensions/agent/crdt/crossWorkflowPending.test.ts
+++ b/src/workbench/extensions/agent/crdt/crossWorkflowPending.test.ts
@@ -15,6 +15,7 @@ const bridgeState = vi.hoisted(() => {
     subscribe = vi.fn((workflowId: string) => {
       if (!transport.up) return
       this.subscribedWorkflowId = workflowId
+      this.lastSequence = 0
     })
 
     unsubscribe = vi.fn(() => {
@@ -25,7 +26,7 @@ const bridgeState = vi.hoisted(() => {
     reconcile = vi.fn()
     destroy = vi.fn()
     subscribedWorkflowId: string | null = null
-    lastSequence = 41
+    lastSequence = 0
     follower = {
       updatesApplied: 0,
       doc: {
@@ -216,7 +217,9 @@ describe('R-73 cross-workflow pending operation characterization', () => {
   it('still accepts a late workflow A result by op_id while workflow B is active', async () => {
     const { workflowId, enqueue, status } = mountFollower('wf-a')
 
+    bridge().lastSequence = 41
     enqueue([deleteNode('a-inflight')])
+    expect(clientState.sent[0].ops[0]).toMatchObject({ base_version: 41 })
     const operationAId = clientState.sent[0].ops[0].op_id
     await switchWorkflow(workflowId, 'wf-b')
     enqueue([deleteNode('b-pending')])
@@ -230,6 +233,7 @@ describe('R-73 cross-workflow pending operation characterization', () => {
 
     expect(clientState.sent).toHaveLength(2)
     expect(clientState.sent[1]).toMatchObject({ workflowId: 'wf-b' })
+    expect(clientState.sent[1].ops[0]).toMatchObject({ base_version: 0 })
     const operationBId = clientState.sent[1].ops[0].op_id
 
     // Current risk characterization: result frames carry workflowId, but the

--- a/src/workbench/extensions/agent/crdt/crossWorkflowPending.test.ts
+++ b/src/workbench/extensions/agent/crdt/crossWorkflowPending.test.ts
@@ -10,8 +10,10 @@ import { render } from '@testing-library/vue'
 import type { GraphOperation } from './graphOperations'
 
 const bridgeState = vi.hoisted(() => {
+  const transport = { up: true }
   class FakeBridge extends EventTarget {
     subscribe = vi.fn((workflowId: string) => {
+      if (!transport.up) return
       this.subscribedWorkflowId = workflowId
     })
 
@@ -32,7 +34,11 @@ const bridgeState = vi.hoisted(() => {
     }
   }
 
-  return { FakeBridge, current: null as InstanceType<typeof FakeBridge> | null }
+  return {
+    FakeBridge,
+    current: null as InstanceType<typeof FakeBridge> | null,
+    transport
+  }
 })
 
 const clientState = vi.hoisted(() => ({
@@ -170,6 +176,7 @@ describe('R-73 cross-workflow pending operation characterization', () => {
   beforeEach(() => {
     setActivePinia(createPinia())
     bridgeState.current = null
+    bridgeState.transport.up = true
     clientState.transportUp = true
     clientState.attempts = []
     clientState.sent = []
@@ -179,8 +186,9 @@ describe('R-73 cross-workflow pending operation characterization', () => {
   })
 
   it('does not retarget a transport retry after workflow A switches to workflow B', async () => {
-    clientState.transportUp = false
     const { workflowId, enqueue } = mountFollower('wf-a')
+    bridgeState.transport.up = false
+    clientState.transportUp = false
 
     enqueue([deleteNode('a-queued')])
     expect(clientState.sent).toHaveLength(0)
@@ -188,6 +196,7 @@ describe('R-73 cross-workflow pending operation characterization', () => {
     const operationId = clientState.attempts[0].ops[0].op_id
 
     await switchWorkflow(workflowId, 'wf-b')
+    bridgeState.transport.up = true
     clientState.transportUp = true
     vi.advanceTimersByTime(500)
 

--- a/src/workbench/extensions/agent/crdt/crossWorkflowPending.test.ts
+++ b/src/workbench/extensions/agent/crdt/crossWorkflowPending.test.ts
@@ -1,6 +1,6 @@
 import type { Op } from '@comfyorg/comfy-multi-player'
 import { createPinia, setActivePinia } from 'pinia'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, onTestFinished, vi } from 'vitest'
 import { defineComponent, nextTick, ref } from 'vue'
 import type { Ref } from 'vue'
 
@@ -148,6 +148,7 @@ function mountFollower(initial: string): {
     }
   })
   const { unmount } = render(host)
+  onTestFinished(unmount)
   return { unmount, workflowId, enqueue, status: exposedStatus }
 }
 
@@ -181,7 +182,7 @@ describe('R-73 cross-workflow pending operation characterization', () => {
   it('does not retarget a transport retry after workflow A switches to workflow B', async () => {
     vi.useFakeTimers()
     clientState.transportUp = false
-    const { unmount, workflowId, enqueue } = mountFollower('wf-a')
+    const { workflowId, enqueue } = mountFollower('wf-a')
 
     enqueue([deleteNode('a-queued')])
     expect(clientState.sent).toHaveLength(0)
@@ -203,12 +204,10 @@ describe('R-73 cross-workflow pending operation characterization', () => {
       op: 'delete_node',
       node_id: 'a-queued'
     })
-
-    unmount()
   })
 
   it('still accepts a late workflow A result by op_id while workflow B is active', async () => {
-    const { unmount, workflowId, enqueue, status } = mountFollower('wf-a')
+    const { workflowId, enqueue, status } = mountFollower('wf-a')
 
     enqueue([deleteNode('a-inflight')])
     const operationAId = clientState.sent[0].ops[0].op_id
@@ -256,7 +255,5 @@ describe('R-73 cross-workflow pending operation characterization', () => {
       )
     ).toHaveLength(1)
     expect(operationBId).not.toBe(operationAId)
-
-    unmount()
   })
 })

--- a/src/workbench/extensions/agent/crdt/crossWorkflowPending.test.ts
+++ b/src/workbench/extensions/agent/crdt/crossWorkflowPending.test.ts
@@ -15,9 +15,8 @@ const bridgeState = vi.hoisted(() => {
       this.subscribedWorkflowId = workflowId
     })
 
-    unsubscribe = vi.fn((workflowId?: string) => {
-      if (workflowId === undefined || this.subscribedWorkflowId === workflowId)
-        this.subscribedWorkflowId = null
+    unsubscribe = vi.fn(() => {
+      this.subscribedWorkflowId = null
     })
 
     resubscribe = vi.fn()

--- a/src/workbench/extensions/agent/crdt/crossWorkflowPending.test.ts
+++ b/src/workbench/extensions/agent/crdt/crossWorkflowPending.test.ts
@@ -268,4 +268,38 @@ describe('R-73 cross-workflow pending operation characterization', () => {
     ).toHaveLength(1)
     expect(operationBId).not.toBe(operationAId)
   })
+
+  it('documents an anonymous workflow A result settling workflow B in flight', async () => {
+    const { workflowId, enqueue } = mountFollower('wf-a')
+
+    enqueue([deleteNode('a-inflight')])
+    const operationAId = clientState.sent[0].ops[0].op_id
+    await switchWorkflow(workflowId, 'wf-b')
+    enqueue([deleteNode('b-pending')])
+
+    dispatchOpsResult({
+      workflowId: 'wf-a',
+      ok: true,
+      applied: [operationAId],
+      skipped: []
+    })
+    const operationBId = clientState.sent[1].ops[0].op_id
+
+    dispatchOpsResult({
+      workflowId: 'wf-a',
+      ok: false,
+      applied: [],
+      skipped: []
+    })
+
+    const settlements = devLogState.recordDevEvent.mock.calls.filter(
+      ([event]) => event === 'human_ops_settled'
+    )
+    expect(settlements).toHaveLength(2)
+    expect(settlements[1][1]).toMatchObject({
+      state: 'acknowledged',
+      ops: [expect.objectContaining({ op_id: operationBId })],
+      result: { ok: false, applied: [], skipped: [] }
+    })
+  })
 })

--- a/src/workbench/extensions/agent/crdt/crossWorkflowPending.test.ts
+++ b/src/workbench/extensions/agent/crdt/crossWorkflowPending.test.ts
@@ -39,8 +39,10 @@ const bridgeState = vi.hoisted(() => {
 const clientState = vi.hoisted(() => ({
   destroy: vi.fn(),
   transportUp: true,
+  attempts: [] as Array<{ workflowId: string; tab: string; ops: Op[] }>,
   sent: [] as Array<{ workflowId: string; tab: string; ops: Op[] }>,
   sendOps: vi.fn((workflowId: string, tab: string, ops: Op[]) => {
+    clientState.attempts.push({ workflowId, tab, ops })
     if (!clientState.transportUp) return false
     clientState.sent.push({ workflowId, tab, ops })
     return true
@@ -169,6 +171,7 @@ describe('R-73 cross-workflow pending operation characterization', () => {
     setActivePinia(createPinia())
     bridgeState.current = null
     clientState.transportUp = true
+    clientState.attempts = []
     clientState.sent = []
     clientState.sendOps.mockClear()
     devLogState.recordDevEvent.mockClear()
@@ -182,6 +185,8 @@ describe('R-73 cross-workflow pending operation characterization', () => {
 
     enqueue([deleteNode('a-queued')])
     expect(clientState.sent).toHaveLength(0)
+    expect(clientState.attempts).toHaveLength(1)
+    const operationId = clientState.attempts[0].ops[0].op_id
 
     await switchWorkflow(workflowId, 'wf-b')
     clientState.transportUp = true
@@ -194,6 +199,7 @@ describe('R-73 cross-workflow pending operation characterization', () => {
     expect(clientState.sent).toHaveLength(1)
     expect(clientState.sent[0]).toMatchObject({ workflowId: 'wf-a' })
     expect(clientState.sent[0].ops[0]).toMatchObject({
+      op_id: operationId,
       op: 'delete_node',
       node_id: 'a-queued'
     })
@@ -205,15 +211,20 @@ describe('R-73 cross-workflow pending operation characterization', () => {
     const { unmount, workflowId, enqueue, status } = mountFollower('wf-a')
 
     enqueue([deleteNode('a-inflight')])
-    const operationId = clientState.sent[0].ops[0].op_id
+    const operationAId = clientState.sent[0].ops[0].op_id
     await switchWorkflow(workflowId, 'wf-b')
+    enqueue([deleteNode('b-pending')])
 
     dispatchOpsResult({
       workflowId: 'wf-a',
       ok: true,
-      applied: [operationId],
+      applied: [operationAId],
       skipped: []
     })
+
+    expect(clientState.sent).toHaveLength(2)
+    expect(clientState.sent[1]).toMatchObject({ workflowId: 'wf-b' })
+    const operationBId = clientState.sent[1].ops[0].op_id
 
     // Current risk characterization: result frames carry workflowId, but the
     // composable/sender path correlates by op_id only.
@@ -224,20 +235,27 @@ describe('R-73 cross-workflow pending operation characterization', () => {
     expect(devLogState.recordDevEvent).toHaveBeenCalledWith('doc_ops_result', {
       workflowId: 'wf-a',
       ok: true,
-      applied: [operationId],
+      applied: [operationAId],
       skipped: []
     })
     expect(devLogState.recordDevEvent).toHaveBeenCalledWith(
       'human_ops_settled',
-      expect.objectContaining({
+      {
         state: 'acknowledged',
+        ops: [expect.objectContaining({ op_id: operationAId })],
         result: expect.objectContaining({
           ok: true,
-          applied: [operationId],
+          applied: [operationAId],
           skipped: []
         })
-      })
+      }
     )
+    expect(
+      devLogState.recordDevEvent.mock.calls.filter(
+        ([event]) => event === 'human_ops_settled'
+      )
+    ).toHaveLength(1)
+    expect(operationBId).not.toBe(operationAId)
 
     unmount()
   })


### PR DESCRIPTION
## Summary

Adds a focused R-73 characterization test for CRDT follower workflow switches on current `main` (`f954e479a37b`).

The test records the main-line difference from the original PR #16332 risk: transport retries keep the workflow captured when the operation was enqueued, so that half is now a regression guard rather than a live reproducer. It also captures the remaining behavior: a late `doc_ops_result` for workflow A is still forwarded and settles by `op_id` while workflow B is active, because the result path does not gate on `workflowId`.

## Verification

- `pnpm test:unit src/workbench/extensions/agent/crdt/crossWorkflowPending.test.ts`
- pre-commit hook passed: `oxfmt`, `oxlint`, `eslint`, `pnpm typecheck`

## Notes

Test-only change for the CRDT/agent dev-facing seam. No production reset policy or result-frame workflow gate is changed here.
