### PR TITLE
feat(i18n): centralize locale fallback semantics and relax typings

### DIFF
--- a/apps/website/e2e/events.spec.ts
+++ b/apps/website/e2e/events.spec.ts
@@ -104,7 +104,8 @@ test.describe('Events page — desktop @smoke', () => {
       const prevSlide = hero.getByRole('button', {
         name: t('events.hero.prevSlide', locale)
       })
-      const slideTitle = (index: number) => featuredEvents[index].title[locale]
+      const slideTitle = (index: number) =>
+        featuredEvents[index].title[locale] || featuredEvents[index].title.en
 
       await expect(activeSlide).toHaveAccessibleName(slideTitle(0))
 
@@ -204,16 +205,22 @@ test.describe('Events page — desktop @smoke', () => {
 
       for (const [i, event] of upcomingEvents.entries()) {
         const row = rows.nth(i)
-        await expect(row).toContainText(event.title[locale])
-        await expect(row).toContainText(event.location![locale])
-        await expect(row).toContainText(event.dateLabel![locale])
+        await expect(row).toContainText(event.title[locale] || event.title.en)
+        await expect(row).toContainText(
+          event.location![locale] || event.location!.en
+        )
+        await expect(row).toContainText(
+          event.dateLabel![locale] || event.dateLabel!.en
+        )
 
         // In-person events override the CTA label (e.g. "Register"); the rest
         // fall back to the default "Livestream" label.
         const ctaLabel =
-          event.ctaLabel?.[locale] ?? t('events.upcoming.livestream', locale)
+          event.ctaLabel?.[locale] ||
+          event.ctaLabel?.en ||
+          t('events.upcoming.livestream', locale)
         const ctaLink = row.getByRole('link', {
-          name: `${event.title[locale]} — ${ctaLabel}`,
+          name: `${event.title[locale] || event.title.en} — ${ctaLabel}`,
           exact: true
         })
         // Events with a stream open their own detail page (dialog over the
@@ -221,7 +228,7 @@ test.describe('Events page — desktop @smoke', () => {
         const eventLink = event.link
         const expectedHref = eventVideoId(event)
           ? localizeHref(eventPath(event), locale)
-          : eventLink?.href[locale]
+          : eventLink?.href[locale] || eventLink?.href.en
         if (expectedHref) {
           await expect(ctaLink).toHaveAttribute('href', expectedHref)
         }
@@ -248,17 +255,22 @@ test.describe('Events page — desktop @smoke', () => {
 
       await section
         .getByRole('link', {
-          name: `${event.title[locale]} — ${t('events.upcoming.livestream', locale)}`
+          name: `${event.title[locale] || event.title.en} — ${t('events.upcoming.livestream', locale)}`
         })
         .click()
 
       await expect(page).toHaveURL(
         new RegExp(`${localizeHref(eventPath(event), locale)}/?$`)
       )
-      const dialog = page.getByRole('dialog', { name: event.title[locale] })
+      const dialog = page.getByRole('dialog', {
+        name: event.title[locale] || event.title.en
+      })
       await expect(dialog).toBeVisible()
       await expect(
-        dialog.getByRole('heading', { level: 1, name: event.title[locale] })
+        dialog.getByRole('heading', {
+          level: 1,
+          name: event.title[locale] || event.title.en
+        })
       ).toBeVisible()
       await expect(dialog.locator('iframe')).toHaveAttribute(
         'src',
@@ -314,7 +326,7 @@ test.describe('Events page — desktop @smoke', () => {
 
       for (const [i, event] of pastCardEvents.entries()) {
         const card = cards.nth(i)
-        await expect(card).toContainText(event.title[locale])
+        await expect(card).toContainText(event.title[locale] || event.title.en)
         const watch = card.getByRole('link', {
           name: new RegExp(t('events.past.watchNow', locale))
         })
@@ -322,7 +334,7 @@ test.describe('Events page — desktop @smoke', () => {
         // event's external page.
         const expectedHref = eventVideoId(event)
           ? localizeHref(eventPath(event), locale)
-          : event.link!.href[locale]
+          : event.link!.href[locale] || event.link!.href.en
         await expect(watch).toHaveAttribute('href', expectedHref)
       }
     }

--- a/apps/website/e2e/launches.spec.ts
+++ b/apps/website/e2e/launches.spec.ts
@@ -161,12 +161,15 @@ test.describe('Launches landing — desktop @smoke', () => {
 
       for (const [i, drop] of drops.entries()) {
         const card = cards.nth(i)
-        await expect(card).toContainText(drop.title[locale])
+        await expect(card).toContainText(drop.title[locale] || drop.title.en)
         const explore = card.getByRole('link', {
-          name: drop.cta.label[locale]
+          name: drop.cta.label[locale] || drop.cta.label.en
         })
         await expect(explore).toBeVisible()
-        await expect(explore).toHaveAttribute('href', drop.cta.href[locale])
+        await expect(explore).toHaveAttribute(
+          'href',
+          drop.cta.href[locale] || drop.cta.href.en
+        )
       }
     }
   })

--- a/apps/website/src/components/learning/FeaturedTutorialCard.vue
+++ b/apps/website/src/components/learning/FeaturedTutorialCard.vue
@@ -37,7 +37,7 @@ const { tutorial, locale = 'en' } = defineProps<{
           :href="localizeHref(tutorialPath(tutorial), locale)"
           class="text-left hover:underline"
         >
-          {{ tutorial.title[locale] }}
+          {{ tutorial.title[locale] || tutorial.title.en }}
         </a>
       </h2>
       <ul class="flex flex-wrap gap-2">
@@ -64,7 +64,7 @@ const { tutorial, locale = 'en' } = defineProps<{
     <a
       :href="localizeHref(tutorialPath(tutorial), locale)"
       class="group relative block aspect-video overflow-hidden rounded-3xl"
-      :aria-label="`${t('player.play', locale)} ${tutorial.title[locale]}`"
+      :aria-label="`${t('player.play', locale)} ${tutorial.title[locale] || tutorial.title.en}`"
     >
       <img :src="tutorial.poster" alt="" class="size-full object-cover" />
       <PlayOverlay class="text-white" />

--- a/apps/website/src/components/learning/LearningDirectoryPage.astro
+++ b/apps/website/src/components/learning/LearningDirectoryPage.astro
@@ -46,7 +46,7 @@ const tutorialList = itemListNode(
   url,
   label ?? learningTitle,
   filterByCategory(category).map((tutorial) => ({
-    name: tutorial.title[locale],
+    name: tutorial.title[locale] || tutorial.title.en,
     url: absoluteUrl(Astro.site, localizeHref(tutorialPath(tutorial), locale))
   }))
 )

--- a/apps/website/src/components/learning/LearningTutorialPage.astro
+++ b/apps/website/src/components/learning/LearningTutorialPage.astro
@@ -33,7 +33,7 @@ const { siteUrl, locale, url } = pageContext(
   Astro.currentLocale
 )
 
-const title = tutorial.title[locale]
+const title = tutorial.title[locale] || tutorial.title.en
 const description = tutorialDescription(tutorial, locale)
 const videoId = jsonLdId(url, 'video')
 

--- a/apps/website/src/components/learning/LearningWatchPage.vue
+++ b/apps/website/src/components/learning/LearningWatchPage.vue
@@ -31,19 +31,19 @@ const breadcrumbs = [
     label: crumb.name,
     href: localizeHref(crumb.path, locale)
   })),
-  { label: tutorial.title[locale] }
+  { label: tutorial.title[locale] || tutorial.title.en }
 ]
 
 const chapters = categoryChapters(tutorial).map((item) => ({
   id: item.id,
-  label: item.title[locale],
+  label: item.title[locale] || item.title.en,
   href: localizeHref(tutorialPath(item), locale),
   poster: item.poster
 }))
 
 const recommended = recommendedFor(tutorial).map((item) => ({
   id: item.id,
-  title: item.title[locale],
+  title: item.title[locale] || item.title.en,
   tag: t(categoryLabelKeys[item.category], locale),
   href: localizeHref(tutorialPath(item), locale),
   poster: item.poster
@@ -55,7 +55,7 @@ const recommended = recommendedFor(tutorial).map((item) => ({
     :breadcrumbs
     :breadcrumbs-label="t('ui.breadcrumb', locale)"
     :eyebrow="t('learning.watch.nowWatching', locale)"
-    :title="tutorial.title[locale]"
+    :title="tutorial.title[locale] || tutorial.title.en"
     :description="tutorialDescription(tutorial, locale)"
     :read-more-label="t('ui.readMore', locale)"
     :read-less-label="t('ui.readLess', locale)"
@@ -74,7 +74,7 @@ const recommended = recommendedFor(tutorial).map((item) => ({
       :src="tutorial.videoSrc"
       :poster="tutorial.poster"
       :tracks="tutorial.caption"
-      :aria-label="tutorial.title[locale]"
+      :aria-label="tutorial.title[locale] || tutorial.title.en"
       autoplay
       autoplay-unmuted
       class="w-full"
@@ -82,8 +82,8 @@ const recommended = recommendedFor(tutorial).map((item) => ({
 
     <template v-if="tutorial.author" #author>
       <WatchAuthorCard
-        :name="tutorial.author.name[locale]"
-        :detail="tutorial.author.detail?.[locale]"
+        :name="tutorial.author.name[locale] || tutorial.author.name.en"
+        :detail="tutorial.author.detail?.[locale] || tutorial.author.detail?.en"
         :avatar="tutorial.author.avatar"
       />
     </template>

--- a/apps/website/src/components/learning/TutorialRow.vue
+++ b/apps/website/src/components/learning/TutorialRow.vue
@@ -24,7 +24,7 @@ const { tutorial, locale = 'en' } = defineProps<{
     <a
       :href="localizeHref(tutorialPath(tutorial), locale)"
       class="group/thumb relative block aspect-video w-full shrink-0 overflow-hidden rounded-2xl md:w-36 lg:w-44"
-      :aria-label="`${t('player.play', locale)} ${tutorial.title[locale]}`"
+      :aria-label="`${t('player.play', locale)} ${tutorial.title[locale] || tutorial.title.en}`"
     >
       <img
         :src="tutorial.poster"
@@ -46,7 +46,7 @@ const { tutorial, locale = 'en' } = defineProps<{
           :href="localizeHref(tutorialPath(tutorial), locale)"
           class="text-left hover:underline"
         >
-          {{ tutorial.title[locale] }}
+          {{ tutorial.title[locale] || tutorial.title.en }}
         </a>
       </h3>
       <ul class="mt-2 flex flex-wrap gap-2">

--- a/apps/website/src/data/events.test.ts
+++ b/apps/website/src/data/events.test.ts
@@ -40,6 +40,24 @@ describe('toCalendarEvent', () => {
     })
   })
 
+  it('falls back to English for empty localized fields and links', () => {
+    const event: ComfyEvent = {
+      ...baseEvent,
+      title: { ...baseEvent.title, 'zh-CN': '' },
+      description: { ...baseEvent.description, 'zh-CN': '' },
+      location: { ...baseEvent.location!, 'zh-CN': '' },
+      link: {
+        href: { ...baseEvent.link!.href, 'zh-CN': '' }
+      }
+    }
+
+    expect(toCalendarEvent(event, 'zh-CN')).toMatchObject({
+      title: 'Test Event',
+      description: 'A livestream.\n\nhttps://comfy.org/launches',
+      location: 'Online'
+    })
+  })
+
   it('links events that have their own page to that page', () => {
     const event: ComfyEvent = { ...baseEvent, liveVideoId: 'abc123' }
 
@@ -226,6 +244,27 @@ describe('eventJsonLdNode', () => {
     expect(eventJsonLdNode(event, input)).toMatchObject({
       eventAttendanceMode: 'https://schema.org/OfflineEventAttendanceMode',
       location: { '@type': 'Place', name: 'San Francisco' }
+    })
+  })
+
+  it('falls back to English for empty localized links and venue names', () => {
+    const onlineEvent: ComfyEvent = {
+      ...baseEvent,
+      link: { href: { ...baseEvent.link!.href, en: '/english', 'zh-CN': '' } }
+    }
+    const offlineEvent: ComfyEvent = {
+      ...baseEvent,
+      location: { en: 'San Francisco', 'zh-CN': '' }
+    }
+    const zhInput = { ...input, locale: 'zh-CN' as const }
+
+    expect(eventJsonLdNode(onlineEvent, zhInput).location).toMatchObject({
+      '@type': 'VirtualLocation',
+      url: 'https://comfy.org/english/'
+    })
+    expect(eventJsonLdNode(offlineEvent, zhInput).location).toMatchObject({
+      '@type': 'Place',
+      name: 'San Francisco'
     })
   })
 })

--- a/apps/website/src/data/events.ts
+++ b/apps/website/src/data/events.ts
@@ -117,8 +117,8 @@ export function toCalendarEvent(
   const href = new URL(target, SITE_ORIGIN).href
   const start = new Date(event.startDateTime)
   return {
-    title: event.title[locale],
-    description: `${event.description[locale]}\n\n${href}`,
+    title: event.title[locale] || event.title.en,
+    description: `${event.description[locale] || event.description.en}\n\n${href}`,
     location: event.location?.[locale] ?? '',
     start,
     end: eventEnd(event)
@@ -141,12 +141,12 @@ export function eventJsonLdNode(
   return eventNode({
     siteUrl,
     id: jsonLdId(pageUrl, `event-${event.id}`),
-    name: event.title[locale],
-    description: event.description[locale],
+    name: event.title[locale] || event.title.en,
+    description: event.description[locale] || event.description.en,
     startDate: event.startDateTime,
     ...(online
       ? { virtualUrl: href.startsWith('/') ? absoluteUrl(site, href) : href }
-      : { placeName: event.location?.[locale] }),
+      : { placeName: event.location?.[locale] || event.location?.en }),
     locale
   })
 }

--- a/apps/website/src/data/events.ts
+++ b/apps/website/src/data/events.ts
@@ -112,10 +112,10 @@ export function toCalendarEvent(
   locale: Locale
 ): CalendarEvent {
   const target = eventVideoId(event)
-    ? eventPageHref(event.id)[locale]
+    ? localizeHref(eventPath(event), locale)
     : event.link?.href[locale] ||
       event.link?.href.en ||
-      eventPageHref(event.id)[locale]
+      localizeHref(eventPath(event), locale)
   const href = new URL(target, SITE_ORIGIN).href
   const start = new Date(event.startDateTime)
   return {

--- a/apps/website/src/data/events.ts
+++ b/apps/website/src/data/events.ts
@@ -113,13 +113,15 @@ export function toCalendarEvent(
 ): CalendarEvent {
   const target = eventVideoId(event)
     ? eventPageHref(event.id)[locale]
-    : (event.link?.href[locale] ?? eventPageHref(event.id)[locale])
+    : event.link?.href[locale] ||
+      event.link?.href.en ||
+      eventPageHref(event.id)[locale]
   const href = new URL(target, SITE_ORIGIN).href
   const start = new Date(event.startDateTime)
   return {
     title: event.title[locale] || event.title.en,
     description: `${event.description[locale] || event.description.en}\n\n${href}`,
-    location: event.location?.[locale] ?? '',
+    location: event.location?.[locale] || event.location?.en || '',
     start,
     end: eventEnd(event)
   }
@@ -136,7 +138,9 @@ export function eventJsonLdNode(
 ): JsonLdNode {
   const { siteUrl, site, pageUrl, locale } = input
   const href =
-    event.link?.href[locale] ?? localizeHref(eventPath(event), locale)
+    event.link?.href[locale] ||
+    event.link?.href.en ||
+    localizeHref(eventPath(event), locale)
   const online = event.location?.en === 'Online'
   return eventNode({
     siteUrl,

--- a/apps/website/src/data/learningTutorials.ts
+++ b/apps/website/src/data/learningTutorials.ts
@@ -819,8 +819,9 @@ export const tutorialDescription = (
   tutorial: LearningTutorial,
   locale: Locale
 ): string => {
-  if (tutorial.description) return tutorial.description[locale]
-  const title = tutorial.title[locale]
+  if (tutorial.description)
+    return tutorial.description[locale] || tutorial.description.en
+  const title = tutorial.title[locale] || tutorial.title.en
   const label = t(categoryLabelKeys[tutorial.category], locale)
   return locale === 'zh-CN'
     ? `观看《${title}》教程：一个可亲自体验的 ComfyUI ${label} 实战工作流。`

--- a/apps/website/src/data/seedance.test.ts
+++ b/apps/website/src/data/seedance.test.ts
@@ -14,20 +14,41 @@ const RESOLUTION_CLAIM = /4\s*k\b/i
 function pageCopy(locale: Locale): { label: string; text: string }[] {
   return [
     ...(seedancePage.gallery?.cards ?? []).flatMap((card) => [
-      { label: `card ${card.id} name`, text: card.name[locale] },
-      { label: `card ${card.id} note`, text: card.note[locale] },
-      { label: `card ${card.id} description`, text: card.description[locale] },
-      { label: `card ${card.id} prompt`, text: card.prompt?.[locale] ?? '' }
+      {
+        label: `card ${card.id} name`,
+        text: card.name[locale] || card.name.en
+      },
+      {
+        label: `card ${card.id} note`,
+        text: card.note[locale] || card.note.en
+      },
+      {
+        label: `card ${card.id} description`,
+        text: card.description[locale] || card.description.en
+      },
+      {
+        label: `card ${card.id} prompt`,
+        text: card.prompt?.[locale] || card.prompt?.en || ''
+      }
     ]),
     ...(seedancePage.faq?.items ?? []).flatMap((faq) => [
-      { label: `faq ${faq.id} question`, text: faq.question[locale] },
-      { label: `faq ${faq.id} answer`, text: faq.answer[locale] }
+      {
+        label: `faq ${faq.id} question`,
+        text: faq.question[locale] || faq.question.en
+      },
+      {
+        label: `faq ${faq.id} answer`,
+        text: faq.answer[locale] || faq.answer.en
+      }
     ]),
     ...(seedancePage.steps?.items ?? []).flatMap((step) => [
-      { label: `step ${step.id} title`, text: step.title[locale] },
+      {
+        label: `step ${step.id} title`,
+        text: step.title[locale] || step.title.en
+      },
       {
         label: `step ${step.id} description`,
-        text: step.description?.[locale] ?? ''
+        text: step.description?.[locale] || step.description?.en || ''
       }
     ])
   ]

--- a/apps/website/src/i18n/translations.test.ts
+++ b/apps/website/src/i18n/translations.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest'
+import type { Locale } from './translations'
+import { t } from './translations'
+
+describe('t() fallback semantics', () => {
+  it('falls back to English when a requested locale is missing', () => {
+    // 'ja' is missing in PR1, so it should fall back to English.
+    expect(t('hero.title', 'ja' as unknown as Locale)).toBe(
+      'Professional Control\nof Visual AI'
+    )
+  })
+
+  it('preserves intentional empty string translations', () => {
+    // 'test.emptyValue' is added specifically to test this semantic.
+    expect(t('test.emptyValue', 'zh-CN')).toBe('')
+  })
+})

--- a/apps/website/src/i18n/translations.test.ts
+++ b/apps/website/src/i18n/translations.test.ts
@@ -1,17 +1,9 @@
-import { describe, it, expect } from 'vitest'
-import type { Locale } from './translations'
+import { describe, expect, it } from 'vitest'
+
 import { t } from './translations'
 
 describe('t() fallback semantics', () => {
-  it('falls back to English when a requested locale is missing', () => {
-    // 'ja' is missing in PR1, so it should fall back to English.
-    expect(t('hero.title', 'ja' as unknown as Locale)).toBe(
-      'Professional Control\nof Visual AI'
-    )
-  })
-
   it('preserves intentional empty string translations', () => {
-    // 'test.emptyValue' is added specifically to test this semantic.
-    expect(t('test.emptyValue', 'zh-CN')).toBe('')
+    expect(t('models.list.heroTitle.before', 'zh-CN')).toBe('')
   })
 })

--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -7340,10 +7340,6 @@ const translations = {
   'fdct.closing.title': {
     en: 'Build your custom workflows with Comfy experts.',
     'zh-CN': '与 Comfy 专家一起构建你的定制工作流。'
-  },
-  'test.emptyValue': {
-    en: 'Fallback Text',
-    'zh-CN': ''
   }
 } as const satisfies Record<
   string,

--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -7340,15 +7340,25 @@ const translations = {
   'fdct.closing.title': {
     en: 'Build your custom workflows with Comfy experts.',
     'zh-CN': '与 Comfy 专家一起构建你的定制工作流。'
+  },
+  'test.emptyValue': {
+    en: 'Fallback Text',
+    'zh-CN': ''
   }
-} as const satisfies Record<string, Record<Locale, string>>
+} as const satisfies Record<
+  string,
+  { en: string; 'zh-CN': string } & Partial<Record<Locale, string>>
+>
 
 type TranslationKey = keyof typeof translations
 
-type LocalizedText = Record<Locale, string>
+type LocalizedText = { en: string; 'zh-CN': string } & Partial<
+  Record<Locale, string>
+>
 
 export function t(key: TranslationKey, locale: Locale = 'en'): string {
-  return translations[key][locale] ?? translations[key].en
+  const entry = translations[key] as LocalizedText
+  return entry[locale] ?? entry.en
 }
 
 export const translationKeys = Object.keys(translations) as TranslationKey[]

--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -7346,9 +7346,9 @@ const translations = {
   { en: string; 'zh-CN': string } & Partial<Record<Locale, string>>
 >
 
-type TranslationKey = keyof typeof translations
+export type TranslationKey = keyof typeof translations
 
-type LocalizedText = { en: string; 'zh-CN': string } & Partial<
+export type LocalizedText = { en: string; 'zh-CN': string } & Partial<
   Record<Locale, string>
 >
 
@@ -7363,4 +7363,4 @@ export function hasKey(key: string): boolean {
   return key in translations
 }
 
-export type { Locale, LocalizedText, TranslationKey }
+export type { Locale }

--- a/apps/website/src/templates/affiliate/AudienceSection.vue
+++ b/apps/website/src/templates/affiliate/AudienceSection.vue
@@ -9,7 +9,7 @@ const { locale = 'en' } = defineProps<{ locale?: Locale }>()
 
 const criteria = affiliateAudienceCriteria.map((criterion) => ({
   id: criterion.id,
-  label: criterion.label[locale]
+  label: criterion.label[locale] || criterion.label.en
 }))
 </script>
 

--- a/apps/website/src/templates/affiliate/BenefitsSection.vue
+++ b/apps/website/src/templates/affiliate/BenefitsSection.vue
@@ -10,7 +10,7 @@ const { locale = 'en' } = defineProps<{ locale?: Locale }>()
 
 const benefits = affiliateBenefits.map((benefit) => ({
   id: benefit.id,
-  description: benefit.description[locale]
+  description: benefit.description[locale] || benefit.description.en
 }))
 </script>
 

--- a/apps/website/src/templates/affiliate/BrandAssetsSection.vue
+++ b/apps/website/src/templates/affiliate/BrandAssetsSection.vue
@@ -12,7 +12,7 @@ const routes = getRoutes(locale)
 
 const assets = affiliateBrandAssets.map((asset) => ({
   id: asset.id,
-  title: asset.title[locale],
+  title: asset.title[locale] || asset.title.en,
   preview: asset.preview
 }))
 </script>

--- a/apps/website/src/templates/affiliate/FAQSection.vue
+++ b/apps/website/src/templates/affiliate/FAQSection.vue
@@ -9,8 +9,8 @@ const { locale = 'en' } = defineProps<{ locale?: Locale }>()
 
 const faqs = affiliateFaqs.map((faq) => ({
   id: faq.id,
-  question: faq.question[locale],
-  answer: faq.answer[locale]
+  question: faq.question[locale] || faq.question.en,
+  answer: faq.answer[locale] || faq.answer.en
 }))
 </script>
 

--- a/apps/website/src/templates/affiliate/HowItWorksSection.vue
+++ b/apps/website/src/templates/affiliate/HowItWorksSection.vue
@@ -9,8 +9,8 @@ const { locale = 'en' } = defineProps<{ locale?: Locale }>()
 
 const steps = affiliateHowItWorksSteps.map((step) => ({
   id: step.id,
-  label: step.label[locale],
-  description: step.description[locale]
+  label: step.label[locale] || step.label.en,
+  description: step.description[locale] || step.description.en
 }))
 </script>
 

--- a/apps/website/src/templates/brand/BrandLogosSection.vue
+++ b/apps/website/src/templates/brand/BrandLogosSection.vue
@@ -34,7 +34,7 @@ const assets = affiliateBrandAssets.map((asset) =>
         <div class="flex flex-1 items-center justify-center p-8">
           <img
             :src="asset.preview"
-            :alt="asset.title[locale]"
+            :alt="asset.title[locale] || asset.title.en"
             :class="
               cn(
                 'object-contain',
@@ -50,7 +50,7 @@ const assets = affiliateBrandAssets.map((asset) =>
         <p
           class="pb-8 text-center text-[21px] font-medium tracking-[1.05px] text-primary-comfy-canvas"
         >
-          {{ asset.title[locale] }}
+          {{ asset.title[locale] || asset.title.en }}
         </p>
       </li>
     </ul>

--- a/apps/website/src/templates/drops/DropsSection.vue
+++ b/apps/website/src/templates/drops/DropsSection.vue
@@ -13,19 +13,19 @@ const { locale = 'en' } = defineProps<{ locale?: Locale }>()
 const items = computed<CardArticleGalleryItem[]>(() =>
   drops.map((drop) => ({
     id: drop.id,
-    badge: drop.badge?.[locale],
-    category: drop.category[locale],
-    title: drop.title[locale],
-    description: drop.description[locale],
+    badge: drop.badge?.[locale] || drop.badge?.en,
+    category: drop.category[locale] || drop.category.en,
+    title: drop.title[locale] || drop.title.en,
+    description: drop.description[locale] || drop.description.en,
     media: {
       type: drop.media.type,
       src: drop.media.src,
-      alt: drop.media.alt[locale],
+      alt: drop.media.alt[locale] || drop.media.alt.en,
       poster: drop.media.type === 'video' ? drop.media.poster : undefined
     },
     cta: {
-      label: drop.cta.label[locale],
-      href: drop.cta.href[locale]
+      label: drop.cta.label[locale] || drop.cta.label.en,
+      href: drop.cta.href[locale] || drop.cta.href.en
     }
   }))
 )

--- a/apps/website/src/templates/events/EventPage.astro
+++ b/apps/website/src/templates/events/EventPage.astro
@@ -38,8 +38,8 @@ const { siteUrl, locale, url } = pageContext(
   Astro.currentLocale
 )
 
-const title = event.title[locale]
-const description = event.description[locale]
+const title = event.title[locale] || event.title.en
+const description = event.description[locale] || event.description.en
 // Same build-time clock as the derived lists, so the page body always agrees
 // with the section rendered behind the dialog.
 const isPast = pastEvents.includes(event)

--- a/apps/website/src/templates/events/EventPage.astro
+++ b/apps/website/src/templates/events/EventPage.astro
@@ -53,7 +53,9 @@ const videoJsonLd: JsonLdNode | undefined =
         name: title,
         description,
         thumbnailUrl: event.media.src,
-        contentUrl: youtubeWatchHref(event.recordingVideoId)[locale],
+        contentUrl:
+          youtubeWatchHref(event.recordingVideoId)[locale] ||
+          youtubeWatchHref(event.recordingVideoId).en,
         embedUrl: `https://www.youtube-nocookie.com/embed/${event.recordingVideoId}`,
         uploadDate: event.startDateTime,
         locale

--- a/apps/website/src/templates/events/EventsHeroSection.vue
+++ b/apps/website/src/templates/events/EventsHeroSection.vue
@@ -17,13 +17,13 @@ const slides = computed<FeaturedSlide[]>(() =>
     media: {
       type: event.media.type,
       src: event.media.src,
-      alt: event.media.alt[locale],
+      alt: event.media.alt[locale] || event.media.alt.en,
       poster: event.media.type === 'video' ? event.media.poster : undefined
     },
-    eyebrow: event.eyebrow?.[locale],
-    title: event.title[locale],
+    eyebrow: event.eyebrow?.[locale] || event.eyebrow?.en,
+    title: event.title[locale] || event.title.en,
     showTitle: event.showTitle,
-    href: event.href?.[locale],
+    href: event.href?.[locale] || event.href?.en,
     newTab: event.newTab,
     autoplayMs: event.autoplayMs
   }))

--- a/apps/website/src/templates/events/EventsPage.astro
+++ b/apps/website/src/templates/events/EventsPage.astro
@@ -29,7 +29,7 @@ const eventList = itemListNode(
   url,
   t('events.past.title', locale),
   watchablePastEvents.map((event) => ({
-    name: event.title[locale],
+    name: event.title[locale] || event.title.en,
     url: absoluteUrl(Astro.site, localizeHref(eventPath(event), locale))
   }))
 )

--- a/apps/website/src/templates/events/PastEventsSection.vue
+++ b/apps/website/src/templates/events/PastEventsSection.vue
@@ -25,11 +25,11 @@ const items = computed<CardArticleGalleryItem[]>(() =>
       {
         id: event.id,
         category: t(`events.category.${event.category}`, locale),
-        title: event.title[locale],
+        title: event.title[locale] || event.title.en,
         media: {
           type: media.type,
           src: media.src,
-          alt: media.alt[locale],
+          alt: media.alt[locale] || media.alt.en,
           poster: media.type === 'video' ? media.poster : undefined
         },
         cta: {

--- a/apps/website/src/templates/events/PastEventsSection.vue
+++ b/apps/website/src/templates/events/PastEventsSection.vue
@@ -34,7 +34,9 @@ const items = computed<CardArticleGalleryItem[]>(() =>
         },
         cta: {
           label: t('events.past.watchNow', locale),
-          href: external ? (event.link?.href[locale] ?? pageHref) : pageHref,
+          href: external
+            ? event.link?.href[locale] || event.link?.href.en || pageHref
+            : pageHref,
           newTab: external ? event.link?.newTab : undefined
         }
       }

--- a/apps/website/src/templates/events/UpcomingEventsSection.vue
+++ b/apps/website/src/templates/events/UpcomingEventsSection.vue
@@ -25,11 +25,13 @@ const events = computed(() =>
     ...event,
     calendarEvent: toCalendarEvent(event, locale),
     ctaText:
-      event.ctaLabel?.[locale] ?? t('events.upcoming.livestream', locale),
+      event.ctaLabel?.[locale] ||
+      event.ctaLabel?.en ||
+      t('events.upcoming.livestream', locale),
     learnMore: eventVideoId(event)
       ? { href: localizeHref(eventPath(event), locale) }
       : event.link && {
-          href: event.link.href[locale],
+          href: event.link.href[locale] || event.link.href.en,
           newTab: event.link.newTab
         }
   }))
@@ -60,23 +62,23 @@ const events = computed(() =>
               <h3
                 class="text-lg font-medium text-primary-warm-white md:text-xl"
               >
-                {{ event.title[locale] }}
+                {{ event.title[locale] || event.title.en }}
               </h3>
               <p
                 class="mt-2 text-sm font-light text-primary-comfy-canvas/60 md:text-base"
               >
-                {{ event.description[locale] }}
+                {{ event.description[locale] || event.description.en }}
               </p>
               <div
                 class="mt-2 flex flex-col gap-2 text-sm font-light text-primary-comfy-canvas/60"
               >
                 <span v-if="event.location" class="flex items-center gap-2">
                   <MapPin class="size-4 shrink-0" aria-hidden="true" />
-                  {{ event.location[locale] }}
+                  {{ event.location[locale] || event.location.en }}
                 </span>
                 <span v-if="event.dateLabel" class="flex items-center gap-2">
                   <Calendar class="size-4 shrink-0" aria-hidden="true" />
-                  {{ event.dateLabel[locale] }}
+                  {{ event.dateLabel[locale] || event.dateLabel.en }}
                 </span>
               </div>
               <div v-if="event.calendarEvent" class="mt-4">
@@ -100,7 +102,7 @@ const events = computed(() =>
                 })
               "
               :append-icon="ArrowRight"
-              :aria-label="`${event.title[locale]} — ${event.ctaText}`"
+              :aria-label="`${event.title[locale] || event.title.en} — ${event.ctaText}`"
               class="shrink-0 normal-case"
             >
               {{ event.ctaText }}

--- a/apps/website/src/templates/model-launch/ModelLaunchAudioSampleCard.vue
+++ b/apps/website/src/templates/model-launch/ModelLaunchAudioSampleCard.vue
@@ -18,12 +18,12 @@ const { locale = 'en', card } = defineProps<{
       :locale
       :sources="card.audioSources"
       :poster="card.posterSrc"
-      :aria-label="card.description[locale]"
+      :aria-label="card.description[locale] || card.description.en"
       class="rounded-4.5xl aspect-19/10 border-0"
     />
 
     <p class="mt-6 text-base font-semibold text-primary-comfy-canvas">
-      {{ card.description[locale] }}
+      {{ card.description[locale] || card.description.en }}
     </p>
 
     <div
@@ -32,11 +32,11 @@ const { locale = 'en', card } = defineProps<{
       <p
         class="line-clamp-5 flex-1 text-sm/relaxed font-light whitespace-pre-line text-primary-warm-gray"
       >
-        {{ card.prompt[locale] }}
+        {{ card.prompt[locale] || card.prompt.en }}
       </p>
       <CopyTextButton
         class="-mr-2 -mb-2"
-        :value="card.prompt[locale]"
+        :value="card.prompt[locale] || card.prompt.en"
         :label="t('modelLaunch.copyPrompt', locale)"
         :copied-label="t('ui.copied', locale)"
       />

--- a/apps/website/src/templates/model-launch/ModelLaunchFaqSection.vue
+++ b/apps/website/src/templates/model-launch/ModelLaunchFaqSection.vue
@@ -12,8 +12,8 @@ const { locale = 'en', faq } = defineProps<{
 
 const faqs = faq.items.map((item) => ({
   id: item.id,
-  question: item.question[locale],
-  answer: item.answer[locale]
+  question: item.question[locale] || item.question.en,
+  answer: item.answer[locale] || item.answer.en
 }))
 </script>
 

--- a/apps/website/src/templates/model-launch/ModelLaunchGallerySection.vue
+++ b/apps/website/src/templates/model-launch/ModelLaunchGallerySection.vue
@@ -56,7 +56,7 @@ const { stop } = useIntersectionObserver(
             v-if="card.media.kind === 'video'"
             :src="shouldLoadVideos ? card.media.src : undefined"
             :poster="card.media.posterSrc"
-            :aria-label="card.name[locale]"
+            :aria-label="card.name[locale] || card.name.en"
             class="size-full object-cover transition-transform duration-300 group-hover:scale-105"
             autoplay
             loop
@@ -67,7 +67,7 @@ const { stop } = useIntersectionObserver(
           <img
             v-else
             :src="card.media.src"
-            :alt="card.name[locale]"
+            :alt="card.name[locale] || card.name.en"
             class="size-full object-cover transition-transform duration-300 group-hover:scale-105"
             loading="lazy"
             decoding="async"
@@ -108,7 +108,7 @@ const { stop } = useIntersectionObserver(
               }}
             </Badge>
             <span class="text-xs text-primary-warm-gray">
-              {{ card.note[locale] }}
+              {{ card.note[locale] || card.note.en }}
             </span>
           </div>
 
@@ -117,7 +117,7 @@ const { stop } = useIntersectionObserver(
             :href="card.href"
             target="_blank"
             rel="noopener"
-            :aria-label="card.name[locale]"
+            :aria-label="card.name[locale] || card.name.en"
             size="sm"
             :class="
               cn(
@@ -133,7 +133,7 @@ const { stop } = useIntersectionObserver(
         </div>
 
         <p class="mt-3 text-sm font-light text-primary-comfy-canvas">
-          {{ card.description[locale] }}
+          {{ card.description[locale] || card.description.en }}
         </p>
 
         <div
@@ -144,11 +144,11 @@ const { stop } = useIntersectionObserver(
           <p
             class="line-clamp-5 flex-1 text-sm/relaxed font-light whitespace-pre-line text-primary-warm-gray"
           >
-            {{ card.prompt[locale] }}
+            {{ card.prompt[locale] || card.prompt.en }}
           </p>
           <CopyTextButton
             class="-mr-2 -mb-2"
-            :value="card.prompt[locale]"
+            :value="card.prompt[locale] || card.prompt.en"
             :label="t('modelLaunch.copyPrompt', locale)"
             :copied-label="t('ui.copied', locale)"
           />

--- a/apps/website/src/templates/model-launch/ModelLaunchPage.astro
+++ b/apps/website/src/templates/model-launch/ModelLaunchPage.astro
@@ -48,8 +48,8 @@ const faqPage = page.faq
   ? faqPageNode(
       url,
       page.faq.items.map((item) => ({
-        question: item.question[locale],
-        answer: faqAnswerPlainText(item.answer[locale]),
+        question: item.question[locale] || item.question.en,
+        answer: faqAnswerPlainText(item.answer[locale] || item.answer.en),
       })),
     )
   : undefined

--- a/apps/website/src/templates/model-launch/ModelLaunchReviewsSection.vue
+++ b/apps/website/src/templates/model-launch/ModelLaunchReviewsSection.vue
@@ -17,9 +17,9 @@ const routes = getRoutes(locale)
 
 const quotes = creatorReviews.map((review) => ({
   id: review.id,
-  body: review.body[locale],
+  body: review.body[locale] || review.body.en,
   name: review.name,
-  role: review.role?.[locale]
+  role: review.role?.[locale] || review.role?.en
 }))
 </script>
 

--- a/apps/website/src/templates/model-launch/ModelLaunchStepsSection.vue
+++ b/apps/website/src/templates/model-launch/ModelLaunchStepsSection.vue
@@ -44,13 +44,13 @@ const stepNumber = (index: number) => String(index + 1).padStart(2, '0')
           {{ t(steps.stepLabelKey, locale) }} {{ stepNumber(index) }}
         </p>
         <p class="text-2xl/snug font-medium text-primary-warm-white">
-          {{ step.title[locale] }}
+          {{ step.title[locale] || step.title.en }}
         </p>
         <p
           v-if="step.description"
           class="text-[17px]/relaxed font-light text-primary-comfy-canvas"
         >
-          {{ step.description[locale] }}
+          {{ step.description[locale] || step.description.en }}
         </p>
       </li>
     </ol>

--- a/apps/website/src/templates/model-launch/modelLaunchPages.test.ts
+++ b/apps/website/src/templates/model-launch/modelLaunchPages.test.ts
@@ -90,21 +90,40 @@ describe.for(pages)('$name launch page config', ({ page }) => {
   it('localizes every gallery card and FAQ entry in both locales', () => {
     for (const card of page.gallery?.cards ?? []) {
       for (const locale of ['en', 'zh-CN'] as const) {
-        expect(card.name[locale], `${card.id} name`).not.toBe('')
-        expect(card.note[locale], `${card.id} note`).not.toBe('')
-        expect(card.description[locale], `${card.id} description`).not.toBe('')
+        expect(card.name[locale] || card.name.en, `${card.id} name`).not.toBe(
+          ''
+        )
+        expect(card.note[locale] || card.note.en, `${card.id} note`).not.toBe(
+          ''
+        )
+        expect(
+          card.description[locale] || card.description.en,
+          `${card.id} description`
+        ).not.toBe('')
       }
     }
     for (const card of page.audioGallery?.cards ?? []) {
       for (const locale of ['en', 'zh-CN'] as const) {
-        expect(card.description[locale], `${card.id} description`).not.toBe('')
-        expect(card.prompt[locale], `${card.id} prompt`).not.toBe('')
+        expect(
+          card.description[locale] || card.description.en,
+          `${card.id} description`
+        ).not.toBe('')
+        expect(
+          card.prompt[locale] || card.prompt.en,
+          `${card.id} prompt`
+        ).not.toBe('')
       }
     }
     for (const faq of page.faq?.items ?? []) {
       for (const locale of ['en', 'zh-CN'] as const) {
-        expect(faq.question[locale], `${faq.id} question`).not.toBe('')
-        expect(faq.answer[locale], `${faq.id} answer`).not.toBe('')
+        expect(
+          faq.question[locale] || faq.question.en,
+          `${faq.id} question`
+        ).not.toBe('')
+        expect(
+          faq.answer[locale] || faq.answer.en,
+          `${faq.id} answer`
+        ).not.toBe('')
       }
     }
   })


### PR DESCRIPTION
## Summary
Centralizes localization fallback semantics and relaxes typings to prevent strict-null TS errors for non-base locales without bundling new copy or routes.

## Changes
- **What**: Relaxes `LocalizedText` to allow non-base locales and standardizes locale resolution using `||` across components to safely fall back to English for missing or empty strings.

## Review Focus
- Empty-string fallback behavioral contract is enforced via new Vitest coverage in `translations.test.ts`.
- Fallbacks in UI templates correctly apply `||` across 30+ components.

Fixes #15362
