### PR TITLE
fix(agent): track CRDT subscribe ack seq apart from the applied baseline

### DIFF
--- a/src/workbench/extensions/agent/crdt/followerSubscription.test.ts
+++ b/src/workbench/extensions/agent/crdt/followerSubscription.test.ts
@@ -525,6 +525,66 @@ describe('FE-GAP-1 — a seq jump means a dropped frame and forces a resync', ()
     expect(transport.framesOfType('doc_subscribe')).toHaveLength(1)
   })
 
+  it('still applies the catch-up (seq == ack) after a live frame beat the ack, then stays live', () => {
+    const { transport, bridge, projected } = wire()
+    transport.open = true
+    bridge.subscribe(WORKFLOW_ID)
+
+    // doc_relay.go handleDocSubscribe: join the fanout, THEN ack (seq=N), THEN
+    // the catch-up carrying that same seq N. The fanout writes from another
+    // goroutine, so live N+1 can reach the follower before the ack. The
+    // catch-up is the only frame holding what the follower's state vector
+    // lacked; dropping it as "stale" (N <= N+1) leaves a hole no later seq
+    // ever reveals.
+    transport.deliver(
+      'doc_update',
+      docUpdateFrame(
+        hostDocUpdate((doc) => {
+          const node = new Y.Map<unknown>()
+          node.set('type', 'SaveImage')
+          nodesMap(doc).set('2', node)
+        }),
+        WORKFLOW_ID,
+        5
+      )
+    )
+    expect(bridge.lastSequence).toBe(5)
+
+    transport.deliver('doc_subscribed', {
+      v: 1,
+      workflow_id: WORKFLOW_ID,
+      ok: true,
+      seq: 4
+    })
+    expect(bridge.lastSequence).toBe(5)
+
+    const catchUp = hostDocUpdate((doc) => {
+      const node = new Y.Map<unknown>()
+      node.set('type', 'PreviewImage')
+      nodesMap(doc).set('3', node)
+    })
+    transport.deliver('doc_update', docUpdateFrame(catchUp, WORKFLOW_ID, 4))
+    expect(bridge.follower.updatesApplied).toBe(2)
+    expect(nodesMap(bridge.follower.doc).get('3')?.toJSON()).toEqual({
+      type: 'PreviewImage'
+    })
+    // The catch-up never rewinds the applied baseline.
+    expect(bridge.lastSequence).toBe(5)
+
+    // The catch-up window is one frame: a second seq-4 replay is stale again.
+    transport.deliver('doc_update', docUpdateFrame(catchUp, WORKFLOW_ID, 4))
+    expect(bridge.follower.updatesApplied).toBe(2)
+
+    // 6 is contiguous with the applied baseline — no spurious resync.
+    transport.deliver(
+      'doc_update',
+      docUpdateFrame(hostDocUpdate(), WORKFLOW_ID, 6)
+    )
+    expect(projected).toHaveLength(3)
+    expect(bridge.lastSequence).toBe(6)
+    expect(transport.framesOfType('doc_subscribe')).toHaveLength(1)
+  })
+
   it('a resubscribe forgets the previous ack so the new catch-up re-baselines', () => {
     const { transport, bridge, projected } = wire()
     transport.open = true

--- a/src/workbench/extensions/agent/crdt/followerSubscription.test.ts
+++ b/src/workbench/extensions/agent/crdt/followerSubscription.test.ts
@@ -409,6 +409,26 @@ describe('doc_reset — a lineage break drops the doc and resubscribes from zero
 })
 
 describe('FE-GAP-1 — a seq jump means a dropped frame and forces a resync', () => {
+  it('applies the catch-up update when its seq equals the preceding subscribe acknowledgement', () => {
+    const { transport, bridge, projected } = wire()
+    transport.open = true
+    bridge.subscribe(WORKFLOW_ID)
+    transport.deliver('doc_subscribed', {
+      v: 1,
+      workflow_id: WORKFLOW_ID,
+      ok: true,
+      seq: 1
+    })
+
+    transport.deliver(
+      'doc_update',
+      docUpdateFrame(hostDocUpdate(), WORKFLOW_ID, 1)
+    )
+
+    expect(projected).toHaveLength(1)
+    expect(bridge.follower.updatesApplied).toBe(1)
+  })
+
   it('applies contiguous seqs without resubscribing', () => {
     const { transport, bridge, projected } = wire()
     transport.open = true

--- a/src/workbench/extensions/agent/crdt/followerSubscription.test.ts
+++ b/src/workbench/extensions/agent/crdt/followerSubscription.test.ts
@@ -427,6 +427,10 @@ describe('FE-GAP-1 — a seq jump means a dropped frame and forces a resync', ()
 
     expect(projected).toHaveLength(1)
     expect(bridge.follower.updatesApplied).toBe(1)
+    expect(nodesMap(bridge.follower.doc).get('1')?.toJSON()).toEqual({
+      type: 'LoadImage',
+      pos: [10, 20]
+    })
   })
 
   it('applies contiguous seqs without resubscribing', () => {

--- a/src/workbench/extensions/agent/crdt/followerSubscription.test.ts
+++ b/src/workbench/extensions/agent/crdt/followerSubscription.test.ts
@@ -419,7 +419,13 @@ describe('FE-GAP-1 — a seq jump means a dropped frame and forces a resync', ()
       ok: true,
       seq: 1
     })
+    // The ack alone already tells the follower where the host is…
+    expect(bridge.lastSequence).toBe(1)
 
+    // …but the host then sends the catch-up AT that seq, and it must land:
+    // treating the ack as an applied baseline dropped this frame as stale and
+    // left the follower with an empty doc (the KA-11 schema_version=undefined
+    // symptom on nightly).
     transport.deliver(
       'doc_update',
       docUpdateFrame(hostDocUpdate(), WORKFLOW_ID, 1)
@@ -427,10 +433,127 @@ describe('FE-GAP-1 — a seq jump means a dropped frame and forces a resync', ()
 
     expect(projected).toHaveLength(1)
     expect(bridge.follower.updatesApplied).toBe(1)
+    expect(bridge.lastSequence).toBe(1)
+    expect(transport.framesOfType('doc_subscribe')).toHaveLength(1)
     expect(nodesMap(bridge.follower.doc).get('1')?.toJSON()).toEqual({
       type: 'LoadImage',
       pos: [10, 20]
     })
+  })
+
+  it('an already-current follower gets an ack and no catch-up, and stays live from the ack seq', () => {
+    const { transport, bridge, projected } = wire()
+    transport.open = true
+    bridge.subscribe(WORKFLOW_ID)
+    transport.deliver('doc_subscribed', {
+      v: 1,
+      workflow_id: WORKFLOW_ID,
+      ok: true,
+      seq: 7
+    })
+
+    // No doc_update follows (the state vector already covered everything), so
+    // the outbound op baseVersion must come from the ack, not sit at 0.
+    expect(bridge.lastSequence).toBe(7)
+
+    // The next LIVE frame is contiguous with the ack: applied, no resubscribe.
+    transport.deliver(
+      'doc_update',
+      docUpdateFrame(hostDocUpdate(), WORKFLOW_ID, 8)
+    )
+    expect(projected).toHaveLength(1)
+    expect(bridge.lastSequence).toBe(8)
+    expect(transport.framesOfType('doc_subscribe')).toHaveLength(1)
+  })
+
+  it('arms the gap detector from the ack: a first frame beyond ack+1 forces a resync', () => {
+    const { transport, bridge, projected } = wire()
+    transport.open = true
+    bridge.subscribe(WORKFLOW_ID)
+    transport.deliver('doc_subscribed', {
+      v: 1,
+      workflow_id: WORKFLOW_ID,
+      ok: true,
+      seq: 1
+    })
+
+    // Both the catch-up (1) and the first live frame (2) were lost.
+    transport.deliver(
+      'doc_update',
+      docUpdateFrame(hostDocUpdate(), WORKFLOW_ID, 3)
+    )
+
+    expect(projected).toHaveLength(0)
+    expect(bridge.follower.updatesApplied).toBe(0)
+    expect(transport.framesOfType('doc_subscribe')).toHaveLength(2)
+    expect(bridge.subscribedWorkflowId).toBe(WORKFLOW_ID)
+  })
+
+  it('an update that beats the ack to the follower keeps its baseline when the ack lands', () => {
+    const { transport, bridge, projected } = wire()
+    transport.open = true
+    bridge.subscribe(WORKFLOW_ID)
+
+    // The host joined the fanout before acking, so a live frame can overtake
+    // the acknowledgement on the wire.
+    transport.deliver(
+      'doc_update',
+      docUpdateFrame(hostDocUpdate(), WORKFLOW_ID, 5)
+    )
+    expect(bridge.lastSequence).toBe(5)
+
+    transport.deliver('doc_subscribed', {
+      v: 1,
+      workflow_id: WORKFLOW_ID,
+      ok: true,
+      seq: 4
+    })
+
+    // The ack never rewinds an applied baseline…
+    expect(bridge.lastSequence).toBe(5)
+    // …so the frame it announced is a duplicate here, and 6 is the next one.
+    transport.deliver(
+      'doc_update',
+      docUpdateFrame(hostDocUpdate(), WORKFLOW_ID, 5)
+    )
+    transport.deliver(
+      'doc_update',
+      docUpdateFrame(hostDocUpdate(), WORKFLOW_ID, 6)
+    )
+    expect(projected).toHaveLength(2)
+    expect(bridge.lastSequence).toBe(6)
+    expect(transport.framesOfType('doc_subscribe')).toHaveLength(1)
+  })
+
+  it('a resubscribe forgets the previous ack so the new catch-up re-baselines', () => {
+    const { transport, bridge, projected } = wire()
+    transport.open = true
+    bridge.subscribe(WORKFLOW_ID)
+    transport.deliver('doc_subscribed', {
+      v: 1,
+      workflow_id: WORKFLOW_ID,
+      ok: true,
+      seq: 10
+    })
+    expect(bridge.lastSequence).toBe(10)
+
+    bridge.resubscribe()
+    expect(bridge.lastSequence).toBe(0)
+
+    // Whatever the new ack says is the new arming point.
+    transport.deliver('doc_subscribed', {
+      v: 1,
+      workflow_id: WORKFLOW_ID,
+      ok: true,
+      seq: 12
+    })
+    transport.deliver(
+      'doc_update',
+      docUpdateFrame(hostDocUpdate(), WORKFLOW_ID, 12)
+    )
+    expect(projected).toHaveLength(1)
+    expect(bridge.lastSequence).toBe(12)
+    expect(transport.framesOfType('doc_subscribe')).toHaveLength(2)
   })
 
   it('applies contiguous seqs without resubscribing', () => {

--- a/src/workbench/extensions/agent/crdt/layoutFollowerBridge.ts
+++ b/src/workbench/extensions/agent/crdt/layoutFollowerBridge.ts
@@ -72,12 +72,22 @@ export class LayoutFollowerBridge extends EventTarget {
   /** Set once a merged doc failed the KA-11 read gate; never rendered after. */
   private schemaError: FollowerSchemaError | null = null
   /**
-   * Highest doc seq seen since the last subscribe left the transport; `null`
-   * until the first post-subscribe frame, so catch-up re-baselines instead of
-   * being compared across a resubscribe. See the gap detector in
+   * Highest doc seq APPLIED since the last subscribe left the transport;
+   * `null` until the first post-subscribe update, so catch-up re-baselines
+   * instead of being compared across a resubscribe. See the gap detector in
    * {@link onDocUpdate}.
    */
   private lastSeq: number | null = null
+  /**
+   * The host's seq at the moment it acknowledged the current subscribe
+   * (`doc_subscribed.seq`); `null` until that ack lands. It is NOT an applied
+   * baseline — the catch-up carrying that very seq may still be in flight, or
+   * may never come when the follower was already current — so it never gates
+   * a frame as stale. It only arms the gap detector before the first applied
+   * update and stands in for {@link lastSeq} in {@link lastSequence} while no
+   * update has been applied.
+   */
+  private ackSeq: number | null = null
 
   constructor(private readonly client: DocFrameClient) {
     super()
@@ -97,8 +107,15 @@ export class LayoutFollowerBridge extends EventTarget {
     return this.sentWorkflowId
   }
 
+  /**
+   * The host seq this follower is known to be at: the last applied update, or
+   * — before any update has been applied for the current subscribe — the seq
+   * the host acknowledged. An already-current follower receives an ack and no
+   * catch-up, so without the fallback the outbound op `baseVersion` would sit
+   * at 0 until the next live frame.
+   */
   get lastSequence(): number {
-    return this.lastSeq ?? 0
+    return this.lastSeq ?? this.ackSeq ?? 0
   }
 
   /** The KA-11 read-gate failure that closed this bridge's read path, if any. */
@@ -161,6 +178,7 @@ export class LayoutFollowerBridge extends EventTarget {
     ) {
       this.sentWorkflowId = desired
       this.lastSeq = null
+      this.ackSeq = null
     }
   }
 
@@ -212,7 +230,13 @@ export class LayoutFollowerBridge extends EventTarget {
     // Seq is only a gap detector. A jump withholds the uncertain frame and
     // asks the host for a same-lineage state-vector delta using this EXACT
     // follower doc. Only an explicit doc_reset may replace it (ADR-0024).
-    if (this.lastSeq !== null && update.seq > this.lastSeq + 1) {
+    //
+    // Before the first applied update the detector is armed from the ack seq
+    // N instead: the catch-up (seq N) and the first live frame (seq N+1) are
+    // both contiguous with it, so neither trips it, while a first frame at
+    // N+2 or beyond is a real drop. Nothing arms it before the ack lands.
+    const baseline = this.lastSeq ?? this.ackSeq
+    if (baseline !== null && update.seq > baseline + 1) {
       this.resubscribe()
       return
     }
@@ -268,10 +292,14 @@ export class LayoutFollowerBridge extends EventTarget {
 
   /**
    * `ok: true` confirms the subscription but does not mean its catch-up update
-   * has already been integrated. The host sends `doc_subscribed(seq=N)` before
-   * `doc_update(seq=N)`, so treating the acknowledgement as the applied
-   * baseline drops the snapshot as stale and leaves a fresh follower empty.
-   * The first actual update establishes the baseline instead.
+   * has already been integrated. The host sends `doc_subscribed(seq=N)` and
+   * THEN `doc_update(seq=N)` — and sends no catch-up at all when the follower
+   * was already current — so recording N as the applied baseline drops the
+   * snapshot as stale and leaves a fresh follower empty (the KA-11
+   * `schema_version=undefined` symptom). The ack seq is kept apart in
+   * {@link ackSeq}: it arms the gap detector and backs {@link lastSequence},
+   * but only an applied update ever moves {@link lastSeq}. The ack therefore
+   * never rewinds a baseline established by an update that arrived first.
    *
    * `ok: false` means the server refused: clearing REALITY re-opens
    * the intent/reality disagreement so the next `reconcile()` (any status
@@ -282,7 +310,7 @@ export class LayoutFollowerBridge extends EventTarget {
     if (!(event instanceof CustomEvent)) return
     const subscribed = event.detail as DocSubscribed
     if (subscribed.workflowId !== this.sentWorkflowId) return
-    if (subscribed.ok) this.lastSeq = null
+    if (subscribed.ok) this.ackSeq = subscribed.seq ?? null
     else this.sentWorkflowId = null
     this.dispatchEvent(new CustomEvent(event.type, { detail: event.detail }))
   }

--- a/src/workbench/extensions/agent/crdt/layoutFollowerBridge.ts
+++ b/src/workbench/extensions/agent/crdt/layoutFollowerBridge.ts
@@ -267,8 +267,13 @@ export class LayoutFollowerBridge extends EventTarget {
   }
 
   /**
-   * `ok: true` carries the seq of the catch-up snapshot — the gap detector's
-   * baseline. `ok: false` means the server refused: clearing REALITY re-opens
+   * `ok: true` confirms the subscription but does not mean its catch-up update
+   * has already been integrated. The host sends `doc_subscribed(seq=N)` before
+   * `doc_update(seq=N)`, so treating the acknowledgement as the applied
+   * baseline drops the snapshot as stale and leaves a fresh follower empty.
+   * The first actual update establishes the baseline instead.
+   *
+   * `ok: false` means the server refused: clearing REALITY re-opens
    * the intent/reality disagreement so the next `reconcile()` (any status
    * frame) retries, instead of the bridge holding a subscription that does not
    * exist server-side and going silently deaf.
@@ -277,7 +282,7 @@ export class LayoutFollowerBridge extends EventTarget {
     if (!(event instanceof CustomEvent)) return
     const subscribed = event.detail as DocSubscribed
     if (subscribed.workflowId !== this.sentWorkflowId) return
-    if (subscribed.ok) this.lastSeq = subscribed.seq ?? null
+    if (subscribed.ok) this.lastSeq = null
     else this.sentWorkflowId = null
     this.dispatchEvent(new CustomEvent(event.type, { detail: event.detail }))
   }

--- a/src/workbench/extensions/agent/crdt/layoutFollowerBridge.ts
+++ b/src/workbench/extensions/agent/crdt/layoutFollowerBridge.ts
@@ -88,6 +88,18 @@ export class LayoutFollowerBridge extends EventTarget {
    * update has been applied.
    */
   private ackSeq: number | null = null
+  /**
+   * Armed by the ack, disarmed by the first applied frame whose seq equals
+   * {@link ackSeq}. The relay joins the fanout BEFORE it acks, so a live frame
+   * N+1 can reach the follower ahead of `doc_subscribed(seq=N)` and the
+   * catch-up `doc_update(seq=N)`. The catch-up is the only frame carrying what
+   * this follower's state vector lacked; if the stale check judged it against
+   * the already-applied N+1 it would be dropped and the hole would never show
+   * up as a gap. While armed, exactly one frame at seq == ackSeq bypasses the
+   * stale check (Yjs integration is idempotent, so a true duplicate is
+   * harmless). It never moves {@link lastSeq} backwards.
+   */
+  private catchUpPending = false
 
   constructor(private readonly client: DocFrameClient) {
     super()
@@ -179,6 +191,7 @@ export class LayoutFollowerBridge extends EventTarget {
       this.sentWorkflowId = desired
       this.lastSeq = null
       this.ackSeq = null
+      this.catchUpPending = false
     }
   }
 
@@ -225,7 +238,11 @@ export class LayoutFollowerBridge extends EventTarget {
 
     // A stale/duplicate frame cannot advance the replica. Ignoring it also
     // prevents a replayed Yjs frame from spuriously re-running ECS effects.
-    if (this.lastSeq !== null && update.seq <= this.lastSeq) return
+    // The one exception is the subscribe's own catch-up (seq == ackSeq) when
+    // a live frame overtook the ack: see {@link catchUpPending}.
+    const isCatchUp = this.catchUpPending && update.seq === this.ackSeq
+    if (!isCatchUp && this.lastSeq !== null && update.seq <= this.lastSeq)
+      return
 
     // Seq is only a gap detector. A jump withholds the uncertain frame and
     // asks the host for a same-lineage state-vector delta using this EXACT
@@ -242,6 +259,7 @@ export class LayoutFollowerBridge extends EventTarget {
     }
     if (this.lastSeq === null || update.seq > this.lastSeq)
       this.lastSeq = update.seq
+    if (isCatchUp) this.catchUpPending = false
     this.follower.applyRemoteUpdate(update.update)
 
     // KA-11 read-time gate. The merge itself is unconditional — Yjs bytes are
@@ -310,8 +328,10 @@ export class LayoutFollowerBridge extends EventTarget {
     if (!(event instanceof CustomEvent)) return
     const subscribed = event.detail as DocSubscribed
     if (subscribed.workflowId !== this.sentWorkflowId) return
-    if (subscribed.ok) this.ackSeq = subscribed.seq ?? null
-    else this.sentWorkflowId = null
+    if (subscribed.ok) {
+      this.ackSeq = subscribed.seq ?? null
+      this.catchUpPending = this.ackSeq !== null
+    } else this.sentWorkflowId = null
     this.dispatchEvent(new CustomEvent(event.type, { detail: event.detail }))
   }
 

--- a/src/workbench/extensions/agent/crdt/layoutFollowerBridge.ts
+++ b/src/workbench/extensions/agent/crdt/layoutFollowerBridge.ts
@@ -240,6 +240,9 @@ export class LayoutFollowerBridge extends EventTarget {
     // prevents a replayed Yjs frame from spuriously re-running ECS effects.
     // The one exception is the subscribe's own catch-up (seq == ackSeq) when
     // a live frame overtook the ack: see {@link catchUpPending}.
+    // Deliberately compares against lastSeq, never ackSeq: while lastSeq is
+    // null the catch-up arrives AT ackSeq, so `<= ackSeq` would drop it and
+    // leave the follower on an empty doc (KA-11).
     const isCatchUp = this.catchUpPending && update.seq === this.ackSeq
     if (!isCatchUp && this.lastSeq !== null && update.seq <= this.lastSeq)
       return


### PR DESCRIPTION
## Summary

Fixes the nightly `[Assertion failed]: CRDT follower: doc meta.schema_version=undefined ... KA-11` on agent open: the follower dropped its own catch-up frame as stale and projected an empty doc.

- Ack seq is not an applied baseline. Tracked separately as `ackSeq`; only an applied `doc_update` moves `lastSeq`.
- Catch-up at seq N (sent right after `doc_subscribed(seq=N)`) now lands.
- `lastSequence` (outbound op `baseVersion`) falls back to the ack seq when the host sends no catch-up.
- Gap detector is armed from the ack seq before the first applied update.

<details><summary>Full context for agent readers</summary>

### Root cause

`onDocSubscribed` set `lastSeq = subscribed.seq`. The host ([`doc_relay.go`](https://github.com/Comfy-Org/cloud/blob/main/services/ingest/server/services/websocket/doc_relay.go) `handleDocSubscribe`) sends `doc_subscribed{seq: N}` and THEN, only if the follower's state vector lacked bytes, `doc_update{seq: N}`. The stale check `update.seq <= lastSeq` dropped that catch-up, so a fresh follower's Y.Doc had no `meta` map and `assertReadableSchema` failed closed with `schema_version=undefined`.

### Why not `lastSeq = null` on ack (previous revision) or `lastSeq = seq - 1`

- `null` disarmed the gap detector for the first frame after every subscribe and left `lastSequence` at 0 after an already-current resubscribe (no catch-up ever arrives), so outbound ops were minted with `baseVersion` 0. Both flagged by the multi-model reviewer.
- `seq - 1` handles the catch-up but breaks the already-current case: the next live frame is N+1, which is a "gap" relative to N-1, forcing a spurious resubscribe on every such frame, and `baseVersion` is off by one.

### Design

`layoutFollowerBridge.ts`:

- `ackSeq: number | null`, set from `doc_subscribed.seq` on `ok: true`, reset with `lastSeq` when a subscribe leaves the transport. Never written by `onDocUpdate`.
- `lastSequence = lastSeq ?? ackSeq ?? 0`.
- Gap detector baseline `lastSeq ?? ackSeq`: catch-up N and live N+1 are both contiguous with ack N; N+2 or beyond resubscribes. Nothing armed before the ack.
- Stale check unchanged (`lastSeq` only), so the catch-up at N is applied after ack N, and a late/repeated ack cannot rewind a baseline an earlier update established.

### Tests (`followerSubscription.test.ts`, FE-GAP-1)

- catch-up at ack seq applied, `lastSequence` asserted after ack and after update
- ack with no catch-up: `lastSequence` = ack seq, live N+1 applied, no resubscribe
- first frame beyond ack+1 resubscribes, frame withheld
- update that beats the ack keeps its baseline
- resubscribe forgets the previous ack

Mutation check: 5 of these fail against the previous `lastSeq = null` revision, 3 fail against `origin/main`.

### Validation

- `pnpm vitest --run` on `followerSubscription.test.ts`, `useAgentCrdtFollower.test.ts`, `docFrameClient.test.ts`: 52 passed
- `pnpm typecheck`, eslint, oxlint, oxfmt on touched files: clean
- pre-commit hooks passed

### Overtake race (fixed in 44179c5062)

A live fanout frame N+1 can overtake the ack and catch-up N on the wire (host joins the fanout before acking). Without special handling the catch-up is dropped as stale. An ok ack now arms a one-shot `catchUpPending` window: exactly one frame with `seq === ackSeq` bypasses the stale check, and `reconcile()` clears the window. Test: live 5 -> ack 4 -> catch-up 4 applies once.

### Sequencing with #16452

#16452 touches the same handlers with an incompatible `catchUpSeq`/rewind model. Plan: land this PR first, then rebase #16452 down to bounded-retry refusal + `missing_sequence`, dropping its rewind.

</details>

