### PR TITLE
test(assets): cover mobile sidebar smoke

### DIFF
--- a/browser_tests/fixtures/components/SidebarTab.ts
+++ b/browser_tests/fixtures/components/SidebarTab.ts
@@ -2,6 +2,7 @@ import type { Locator, Page } from '@playwright/test'
 import { expect } from '@playwright/test'
 
 import type { WorkspaceStore } from '@e2e/types/globals'
+import { ConfirmDialog } from '@e2e/fixtures/components/ConfirmDialog'
 import { TestIds } from '@e2e/fixtures/selectors'
 
 export class SidebarTab {
@@ -340,8 +341,12 @@ export class AssetsSidebarTab extends SidebarTab {
   // --- Loading ---
   public readonly skeletonLoaders: Locator
 
+  // --- Delete confirmation ---
+  public readonly deleteConfirmDialog: ConfirmDialog
+
   constructor(public override readonly page: Page) {
     super(page, 'assets')
+    this.deleteConfirmDialog = new ConfirmDialog(page)
     this.generatedTab = page.getByRole('tab', { name: 'Generated' })
     this.importedTab = page.getByRole('tab', { name: 'Imported' })
     this.emptyStateMessage = page.getByText(
@@ -420,6 +425,57 @@ export class AssetsSidebarTab extends SidebarTab {
 
   getAssetCardByName(name: string) {
     return this.assetCards.filter({ hasText: name })
+  }
+
+  getListViewItemByName(name: string) {
+    return this.listViewItems.filter({ hasText: name })
+  }
+
+  getSeeMoreOutputsButton(name: string) {
+    return this.getListViewItemByName(name).getByRole('button', {
+      name: 'See more outputs'
+    })
+  }
+
+  /**
+   * Touch-driven pass over list view, search, output grouping and delete
+   * confirmation, asserting every control the sequence touches stays fully
+   * inside the viewport on a phone-sized screen.
+   */
+  async expectTouchControlsUsable({
+    assetName,
+    groupedAssetName
+  }: {
+    assetName: string
+    groupedAssetName: string
+  }) {
+    await this.open()
+    await this.openSettingsMenu()
+    await this.listViewOption.tap()
+
+    const listItem = this.getListViewItemByName(assetName)
+    await expect(listItem).toBeVisible()
+
+    await this.searchInput.fill(assetName)
+    await expect(this.listViewItems).toHaveCount(1)
+    await this.searchInput.clear()
+
+    const groupButton = this.getSeeMoreOutputsButton(assetName)
+    await expect(groupButton).toBeInViewport({ ratio: 1 })
+    await groupButton.tap()
+    await expect(groupButton).toHaveAttribute('aria-expanded', 'true')
+    await expect(this.getListViewItemByName(groupedAssetName)).toBeVisible()
+
+    await this.openSettingsMenu()
+    await this.gridLargeOption.tap()
+    await this.waitForAssets()
+    await this.getAssetCardByName(assetName).tap()
+    await expect(this.deleteSelectedButton).toBeInViewport({ ratio: 1 })
+    await this.deleteSelectedButton.tap()
+    await expect(this.deleteConfirmDialog.delete).toBeInViewport({ ratio: 1 })
+    await expect(this.deleteConfirmDialog.reject).toBeInViewport({ ratio: 1 })
+    await this.deleteConfirmDialog.reject.tap()
+    await expect(this.deleteConfirmDialog.root).toBeHidden()
   }
 
   async getFirstGridItemWidth() {

--- a/browser_tests/tests/sidebar/assetsSidebarTab.spec.ts
+++ b/browser_tests/tests/sidebar/assetsSidebarTab.spec.ts
@@ -2,6 +2,7 @@ import { expect, mergeTests } from '@playwright/test'
 import type { Page, Response } from '@playwright/test'
 
 import { comfyPageFixture } from '@e2e/fixtures/ComfyPage'
+import type { ComfyPage } from '@e2e/fixtures/ComfyPage'
 import { expectNoErrorUiAfterVerification } from '@e2e/fixtures/helpers/ErrorsTabHelper'
 import {
   createRouteMockJob,
@@ -83,7 +84,7 @@ const multiOutputJobDetail: JobDetail = {
 }
 
 const previewableCountJob = createRouteMockJob({
-  id: 'previewable-count-job',
+  id: '00000000-0000-4000-a000-000000000003',
   create_time: routeMockJobTimestamp - 4_000,
   execution_start_time: routeMockJobTimestamp - 4_000,
   execution_end_time: routeMockJobTimestamp,
@@ -149,6 +150,84 @@ async function mockInputFiles(page: Page, files: readonly string[]) {
     await route.fulfill({ json: [...files] })
   })
 }
+
+const mobileCloudAssets = [
+  'previewable-count-a.png',
+  'previewable-count-b.png'
+].map((name, index) => ({
+  id: `mobile-smoke-${index}`,
+  name,
+  job_id: previewableCountJob.id,
+  mime_type: 'image/png',
+  tags: ['output'],
+  preview_url: `/api/view?filename=${name}&type=output`,
+  created_at: new Date(
+    previewableCountJob.create_time - index * 1_000
+  ).toISOString(),
+  updated_at: new Date(
+    previewableCountJob.create_time - index * 1_000
+  ).toISOString()
+}))
+
+async function verifyMobileListFilterGroupDelete(comfyPage: ComfyPage) {
+  const tab = comfyPage.menu.assetsTab
+
+  await tab.open()
+  await tab.openSettingsMenu()
+  await tab.listViewOption.tap()
+  const firstAsset = tab.listViewItems.filter({
+    hasText: 'previewable-count-a'
+  })
+  await expect(firstAsset).toBeVisible()
+
+  await tab.searchInput.fill('previewable-count-a')
+  await expect(tab.listViewItems).toHaveCount(1)
+  await tab.searchInput.clear()
+
+  const groupButton = firstAsset.getByRole('button', {
+    name: 'See more outputs'
+  })
+  await expect(groupButton).toBeInViewport({ ratio: 1 })
+  await groupButton.tap()
+  await expect(groupButton).toHaveAttribute('aria-expanded', 'true')
+  await expect(
+    tab.listViewItems.filter({ hasText: 'previewable-count-b' })
+  ).toBeVisible()
+
+  await tab.openSettingsMenu()
+  await tab.gridLargeOption.tap()
+  await tab.waitForAssets()
+  await tab.getAssetCardByName('previewable-count-a').tap()
+  await expect(tab.deleteSelectedButton).toBeInViewport({ ratio: 1 })
+  await tab.deleteSelectedButton.tap()
+  await expect(comfyPage.confirmDialog.delete).toBeInViewport({ ratio: 1 })
+  await expect(comfyPage.confirmDialog.reject).toBeInViewport({ ratio: 1 })
+  await comfyPage.confirmDialog.reject.tap()
+  await expect(comfyPage.confirmDialog.root).toBeHidden()
+}
+
+const mobileListSmokeTest = comfyPageFixture.extend({
+  page: async ({ page }, use) => {
+    const jobsRoutes = new JobsRouteMocker(page)
+    await jobsRoutes.mockJobsQueue([])
+    await jobsRoutes.mockJobsHistory([previewableCountJob])
+    await jobsRoutes.mockJobDetail(
+      previewableCountJob.id,
+      previewableCountJobDetail
+    )
+    await page.route(/\/api\/assets(?:\?.*)?$/, (route) =>
+      route.fulfill({
+        json: {
+          assets: mobileCloudAssets,
+          total: mobileCloudAssets.length,
+          has_more: false
+        }
+      })
+    )
+    await mockViewFiles(page, viewFiles)
+    await use(page)
+  }
+})
 
 function isGeneratedAssetVerificationResponse(response: Response): boolean {
   const url = new URL(response.url())
@@ -296,7 +375,7 @@ test.describe('FE-130 assets sidebar route mocks', () => {
 
     await jobsRoutes.mockJobsHistory([previewableCountJob])
     await jobsRoutes.mockJobDetail(
-      'previewable-count-job',
+      previewableCountJob.id,
       previewableCountJobDetail
     )
 
@@ -337,6 +416,22 @@ test.describe('FE-130 assets sidebar route mocks', () => {
       'Deletion successful'
     )
   })
+})
+
+mobileListSmokeTest.describe('FE-130 assets sidebar route mocks', () => {
+  mobileListSmokeTest(
+    '@mobile list, filter, group, and delete controls remain usable',
+    async ({ comfyPage }) => {
+      await verifyMobileListFilterGroupDelete(comfyPage)
+    }
+  )
+
+  mobileListSmokeTest(
+    '@mobile-ios @cloud list, filter, group, and delete controls remain usable',
+    async ({ comfyPage }) => {
+      await verifyMobileListFilterGroupDelete(comfyPage)
+    }
+  )
 })
 
 bulkInsertionTest.describe(

--- a/browser_tests/tests/sidebar/assetsSidebarTab.spec.ts
+++ b/browser_tests/tests/sidebar/assetsSidebarTab.spec.ts
@@ -14,6 +14,10 @@ import { TestIds } from '@e2e/fixtures/selectors'
 import { mockViewFiles } from '@e2e/fixtures/utils/viewFileMocks'
 import { PropertiesPanelHelper } from '@e2e/tests/propertiesPanel/PropertiesPanelHelper'
 import type {
+  AssetItem,
+  AssetResponse
+} from '@/platform/assets/schemas/assetSchema'
+import type {
   JobDetail,
   RawJobListItem
 } from '@/platform/remote/comfyui/jobs/jobTypes'
@@ -151,23 +155,30 @@ async function mockInputFiles(page: Page, files: readonly string[]) {
   })
 }
 
-const mobileCloudAssets = [
-  'previewable-count-a.png',
-  'previewable-count-b.png'
-].map((name, index) => ({
-  id: `mobile-smoke-${index}`,
-  name,
-  job_id: previewableCountJob.id,
-  mime_type: 'image/png',
-  tags: ['output'],
-  preview_url: `/api/view?filename=${name}&type=output`,
-  created_at: new Date(
-    previewableCountJob.create_time - index * 1_000
-  ).toISOString(),
-  updated_at: new Date(
-    previewableCountJob.create_time - index * 1_000
-  ).toISOString()
-}))
+const mobileAssetNames = ['previewable-count-a.png', 'previewable-count-b.png']
+
+const mobileAssets = mobileAssetNames.map(
+  (name, index): AssetItem => ({
+    id: `00000000-0000-4000-b000-00000000000${index}`,
+    name,
+    job_id: previewableCountJob.id,
+    mime_type: 'image/png',
+    tags: ['output'],
+    preview_url: `/api/view?filename=${name}&type=output`,
+    created_at: new Date(
+      previewableCountJob.create_time - index * 1_000
+    ).toISOString(),
+    updated_at: new Date(
+      previewableCountJob.create_time - index * 1_000
+    ).toISOString()
+  })
+)
+
+const mobileAssetsResponse: AssetResponse = {
+  assets: mobileAssets,
+  total: mobileAssets.length,
+  has_more: false
+}
 
 async function verifyMobileListFilterGroupDelete(comfyPage: ComfyPage) {
   const tab = comfyPage.menu.assetsTab
@@ -216,13 +227,7 @@ const mobileListSmokeTest = comfyPageFixture.extend({
       previewableCountJobDetail
     )
     await page.route(/\/api\/assets(?:\?.*)?$/, (route) =>
-      route.fulfill({
-        json: {
-          assets: mobileCloudAssets,
-          total: mobileCloudAssets.length,
-          has_more: false
-        }
-      })
+      route.fulfill({ json: mobileAssetsResponse })
     )
     await mockViewFiles(page, viewFiles)
     await use(page)

--- a/browser_tests/tests/sidebar/assetsSidebarTab.spec.ts
+++ b/browser_tests/tests/sidebar/assetsSidebarTab.spec.ts
@@ -401,7 +401,7 @@ mobileListSmokeTest.describe('FE-130 assets sidebar route mocks', () => {
   )
 
   mobileListSmokeTest(
-    '@mobile-ios @cloud list, filter, group, and delete controls remain usable',
+    '@mobile-ios list, filter, group, and delete controls remain usable',
     async ({ comfyPage }) => {
       await comfyPage.menu.assetsTab.expectTouchControlsUsable(
         mobileTouchControlNames

--- a/browser_tests/tests/sidebar/assetsSidebarTab.spec.ts
+++ b/browser_tests/tests/sidebar/assetsSidebarTab.spec.ts
@@ -2,7 +2,6 @@ import { expect, mergeTests } from '@playwright/test'
 import type { Page, Response } from '@playwright/test'
 
 import { comfyPageFixture } from '@e2e/fixtures/ComfyPage'
-import type { ComfyPage } from '@e2e/fixtures/ComfyPage'
 import { expectNoErrorUiAfterVerification } from '@e2e/fixtures/helpers/ErrorsTabHelper'
 import {
   createRouteMockJob,
@@ -180,41 +179,9 @@ const mobileAssetsResponse: AssetResponse = {
   has_more: false
 }
 
-async function verifyMobileListFilterGroupDelete(comfyPage: ComfyPage) {
-  const tab = comfyPage.menu.assetsTab
-
-  await tab.open()
-  await tab.openSettingsMenu()
-  await tab.listViewOption.tap()
-  const firstAsset = tab.listViewItems.filter({
-    hasText: 'previewable-count-a'
-  })
-  await expect(firstAsset).toBeVisible()
-
-  await tab.searchInput.fill('previewable-count-a')
-  await expect(tab.listViewItems).toHaveCount(1)
-  await tab.searchInput.clear()
-
-  const groupButton = firstAsset.getByRole('button', {
-    name: 'See more outputs'
-  })
-  await expect(groupButton).toBeInViewport({ ratio: 1 })
-  await groupButton.tap()
-  await expect(groupButton).toHaveAttribute('aria-expanded', 'true')
-  await expect(
-    tab.listViewItems.filter({ hasText: 'previewable-count-b' })
-  ).toBeVisible()
-
-  await tab.openSettingsMenu()
-  await tab.gridLargeOption.tap()
-  await tab.waitForAssets()
-  await tab.getAssetCardByName('previewable-count-a').tap()
-  await expect(tab.deleteSelectedButton).toBeInViewport({ ratio: 1 })
-  await tab.deleteSelectedButton.tap()
-  await expect(comfyPage.confirmDialog.delete).toBeInViewport({ ratio: 1 })
-  await expect(comfyPage.confirmDialog.reject).toBeInViewport({ ratio: 1 })
-  await comfyPage.confirmDialog.reject.tap()
-  await expect(comfyPage.confirmDialog.root).toBeHidden()
+const mobileTouchControlNames = {
+  assetName: 'previewable-count-a',
+  groupedAssetName: 'previewable-count-b'
 }
 
 const mobileListSmokeTest = comfyPageFixture.extend({
@@ -427,14 +394,18 @@ mobileListSmokeTest.describe('FE-130 assets sidebar route mocks', () => {
   mobileListSmokeTest(
     '@mobile list, filter, group, and delete controls remain usable',
     async ({ comfyPage }) => {
-      await verifyMobileListFilterGroupDelete(comfyPage)
+      await comfyPage.menu.assetsTab.expectTouchControlsUsable(
+        mobileTouchControlNames
+      )
     }
   )
 
   mobileListSmokeTest(
     '@mobile-ios @cloud list, filter, group, and delete controls remain usable',
     async ({ comfyPage }) => {
-      await verifyMobileListFilterGroupDelete(comfyPage)
+      await comfyPage.menu.assetsTab.expectTouchControlsUsable(
+        mobileTouchControlNames
+      )
     }
   )
 })


### PR DESCRIPTION
## Summary

Adds one mobile Assets journey across list, filter, group, and delete controls. This covers the mobile list/filter/group/delete smoke case, tracked internally as TC-OPS-03. Each routed test switches to list view, filters to one named output, clears the filter, opens a two-output group, returns to the list, selects by touch, opens deletion confirmation, verifies both choices are fully in view, and cancels cleanly.

## Changes

- Runs on Pixel 5 Chromium and iPhone 15 WebKit.
- Keeps every touched control fully reachable.

## Review Focus

The tests share typed job, Asset API, job-detail, and media fixtures so the same behavior runs against the OSS-shaped Pixel 5 project and Cloud-shaped iPhone 15 WebKit project.

<details><summary>Verification</summary>

Stacked on #16331. Validation: browser and root typechecks, ESLint, type-aware Oxlint, formatting, Knip, diff checks, commit hooks, push hook, and Playwright collection passed. Local execution reached fixture setup but the shared backend reset `/api/users` with a socket hang-up; CI is the execution gate.

</details>
