### PR TITLE
test(agent): cover AgentMessage fallback branches

### DIFF
--- a/src/workbench/extensions/agent/components/agent/message/AgentMessage.test.ts
+++ b/src/workbench/extensions/agent/components/agent/message/AgentMessage.test.ts
@@ -242,15 +242,17 @@ describe('AgentMessage thinking narration', () => {
 
 describe('AgentMessage fallback content', () => {
   it('groups adjacent workflow links and renders notice severities', () => {
-    const message = thinkingMessage()
-    message.streaming = false
-    message.thinking = false
-    message.parts = [
-      { type: 'tabLink', workflowId: 'workflow-1', name: 'First workflow' },
-      { type: 'tabLink', workflowId: 'workflow-2', name: 'Second workflow' },
-      { type: 'notice', level: 'info', text: 'Saved locally' },
-      { type: 'notice', level: 'error', text: 'Could not publish' }
-    ]
+    const message: AssistantMessage = {
+      ...thinkingMessage(),
+      streaming: false,
+      thinking: false,
+      parts: [
+        { type: 'tabLink', workflowId: 'workflow-1', name: 'First workflow' },
+        { type: 'tabLink', workflowId: 'workflow-2', name: 'Second workflow' },
+        { type: 'notice', level: 'info', text: 'Saved locally' },
+        { type: 'notice', level: 'error', text: 'Could not publish' }
+      ]
+    }
 
     render(AgentMessage, {
       props: { message },
@@ -274,10 +276,12 @@ describe('AgentMessage fallback content', () => {
   })
 
   it('forwards feedback from a completed text response', async () => {
-    const message = thinkingMessage()
-    message.streaming = false
-    message.thinking = false
-    message.parts = [{ type: 'text', text: 'Finished', state: 'done' }]
+    const message: AssistantMessage = {
+      ...thinkingMessage(),
+      streaming: false,
+      thinking: false,
+      parts: [{ type: 'text', text: 'Finished', state: 'done' }]
+    }
 
     const { emitted } = render(AgentMessage, {
       props: { message },

--- a/src/workbench/extensions/agent/components/agent/message/AgentMessage.test.ts
+++ b/src/workbench/extensions/agent/components/agent/message/AgentMessage.test.ts
@@ -239,3 +239,62 @@ describe('AgentMessage thinking narration', () => {
     expect(screen.getByText('Checking the result')).toBeInTheDocument()
   })
 })
+
+describe('AgentMessage fallback content', () => {
+  it('groups adjacent workflow links and renders notice severities', () => {
+    const message = thinkingMessage()
+    message.streaming = false
+    message.thinking = false
+    message.parts = [
+      { type: 'tabLink', workflowId: 'workflow-1', name: 'First workflow' },
+      { type: 'tabLink', workflowId: 'workflow-2', name: 'Second workflow' },
+      { type: 'notice', level: 'info', text: 'Saved locally' },
+      { type: 'notice', level: 'error', text: 'Could not publish' }
+    ]
+
+    render(AgentMessage, {
+      props: { message },
+      global: {
+        plugins: [i18n],
+        stubs: {
+          TabLinkCard: {
+            props: ['workflowId', 'name'],
+            template:
+              '<span data-testid="tab-link">{{ workflowId }}:{{ name }}</span>'
+          }
+        }
+      }
+    })
+
+    expect(screen.getAllByTestId('tab-link')).toHaveLength(2)
+    expect(screen.getByText('workflow-1:First workflow')).toBeInTheDocument()
+    expect(screen.getByText('workflow-2:Second workflow')).toBeInTheDocument()
+    expect(screen.getByText('Saved locally')).toBeInTheDocument()
+    expect(screen.getByText('Could not publish')).toBeInTheDocument()
+  })
+
+  it('forwards feedback from a completed text response', async () => {
+    const message = thinkingMessage()
+    message.streaming = false
+    message.thinking = false
+    message.parts = [{ type: 'text', text: 'Finished', state: 'done' }]
+
+    const { emitted } = render(AgentMessage, {
+      props: { message },
+      global: {
+        plugins: [i18n],
+        stubs: {
+          MessageFeedback: {
+            emits: ['feedback'],
+            template:
+              '<button type="button" @click="$emit(\'feedback\', \'up\')">Vote up</button>'
+          }
+        }
+      }
+    })
+
+    await userEvent.click(screen.getByRole('button', { name: 'Vote up' }))
+
+    expect(emitted().feedback).toEqual([['up']])
+  })
+})


### PR DESCRIPTION
## Summary

Raises `AgentMessage.vue` line coverage above the 85% agent-surface gate by permanently exercising its fallback rendering branches.

## Changes

- **What**: Adds focused component tests for adjacent workflow-link grouping, informational and error notices, and feedback-event forwarding.
- **Breaking**: None.
- **Dependencies**: None.

## Review Focus

Please check that the lightweight child-component stubs preserve the parent behavior under test without coupling this suite to workflow-store setup.

## Verification

- `pnpm exec vitest run src/workbench/extensions/agent/components/agent/message/AgentMessage.test.ts src/workbench/extensions/agent/components/agent/message/ToolCallGroup.test.ts --coverage --coverage.include='src/workbench/extensions/agent/components/agent/message/AgentMessage.vue' --coverage.reporter=text` (19/19; lines 100%, branches 95.55%)
- `pnpm exec eslint src/workbench/extensions/agent/components/agent/message/AgentMessage.test.ts`
- `pnpm exec oxfmt --check src/workbench/extensions/agent/components/agent/message/AgentMessage.test.ts`
- commit hooks: lint-staged, typecheck, and pre-push knip passed

## Screenshots (if applicable)

Not applicable; tests-only change.
