### PR TITLE
docs: cross-reference offscreen graph ADR

### DIFF
--- a/docs/adr/0024-in-app-agent-offscreen-graphs.md
+++ b/docs/adr/0024-in-app-agent-offscreen-graphs.md
@@ -18,10 +18,13 @@ The missing abstraction is larger than an offscreen queue: a workflow graph need
 a first-class domain document that exists independently of a tab and renderer. Activation
 then becomes an explicit binding between that document and the active canvas. This ADR is
 the self-contained frontend contract for target routing, document ownership, and lifecycle;
-its requirements do not depend on access to a separate program repository. It also mirrors
-the cross-repository target-routing contract recorded in the program repository's
-[ADR-015](https://github.com/christian-byrne/in-app-agent-program/blob/main/decisions/ADR-015-target-graph-addressing-and-offscreen-queues.md),
-so frontend-local implementation work stays aligned with the shared agent/CRDT invariants.
+its requirements do not depend on access to a separate program repository. Its
+target-routing and offscreen-queue rules align with the cross-repository contract recorded
+in the program repository's
+[ADR-015](https://github.com/christian-byrne/in-app-agent-program/blob/f3175059413d3ce4d22f53fc2b77107b475f9afb/decisions/ADR-015-target-graph-addressing-and-offscreen-queues.md).
+That ADR uses canonical wire `workflow_id` as the V1 agent frame target; this frontend ADR
+keeps a separately minted `document_id` for local document ownership and maps cloud-backed
+documents to their `workflow_id` explicitly.
 
 The current `ChangeTracker` is important prior art. It stores serialized state during
 tab deactivation, allowing transient graph state to survive a tab switch, but its

--- a/docs/adr/0024-in-app-agent-offscreen-graphs.md
+++ b/docs/adr/0024-in-app-agent-offscreen-graphs.md
@@ -18,7 +18,10 @@ The missing abstraction is larger than an offscreen queue: a workflow graph need
 a first-class domain document that exists independently of a tab and renderer. Activation
 then becomes an explicit binding between that document and the active canvas. This ADR is
 the self-contained frontend contract for target routing, document ownership, and lifecycle;
-its requirements do not depend on access to a separate program repository.
+its requirements do not depend on access to a separate program repository. It also mirrors
+the cross-repository target-routing contract recorded in the program repository's
+[ADR-015](https://github.com/christian-byrne/in-app-agent-program/blob/main/decisions/ADR-015-target-graph-addressing-and-offscreen-queues.md),
+so frontend-local implementation work stays aligned with the shared agent/CRDT invariants.
 
 The current `ChangeTracker` is important prior art. It stores serialized state during
 tab deactivation, allowing transient graph state to survive a tab switch, but its
@@ -370,6 +373,7 @@ document registry and target-aware tracker seam are the intended follow-up.
 - [Subgraph Boundaries and Widget Promotion](../architecture/subgraph-boundaries-and-promotion.md)
 - [PR #15721: graph-level atomicity audit](https://github.com/Comfy-Org/ComfyUI_frontend/pull/15721)
 - [PR #15421: canonical architecture knowledge and domain glossary](https://github.com/Comfy-Org/ComfyUI_frontend/pull/15421)
+- [Program ADR-015: target-graph addressing and offscreen queues](https://github.com/christian-byrne/in-app-agent-program/blob/main/decisions/ADR-015-target-graph-addressing-and-offscreen-queues.md)
 
 ## Glossary
 


### PR DESCRIPTION
TL;DR: salvages the remaining useful piece from `christian-byrne/offscreen-graphs-adr` after `main` already absorbed the ADR body through #16195.
This keeps the stronger `main` version and only adds the missing cross-repo ADR-015 provenance link.
<!-- authored-by:agent operator-8d -->

<details><summary>Full context for agent readers</summary>

Source branch: `christian-byrne/offscreen-graphs-adr`.

Salvage decision: `main` already contains `docs/adr/0024-in-app-agent-offscreen-graphs.md` via #16195, and direct diffing showed the source branch would regress newer `main` text around stable `document_id`, in-flight save revisions, activation generation cancellation, and the document-scoped commit coordinator. This PR therefore drops the older body changes and ports only the missing provenance: a context sentence and reference link to the program repository's ADR-015 target-routing contract.

Verification:

- `pnpm exec oxfmt --check docs/adr/0024-in-app-agent-offscreen-graphs.md docs/adr/README.md`
- normal `git commit` hook ran `pnpm exec oxfmt --write --no-error-on-unmatched-pattern "docs/adr/0024-in-app-agent-offscreen-graphs.md"`

Node caveat: this worker has `/usr/bin/node` v22.22.1; the FE repo warns it wants Node >=25 <26. This docs-only formatter still completed cleanly.

</details>
