### PR TITLE
test(agent): cover dock mount async panel loader

### DIFF
--- a/src/workbench/extensions/agent/composables/useAgentDockMount.test.ts
+++ b/src/workbench/extensions/agent/composables/useAgentDockMount.test.ts
@@ -11,7 +11,7 @@ const { loadDockedAgentPanel } = vi.hoisted(() => ({
 }))
 vi.mock(
   '@/workbench/extensions/agent/components/agent/DockedAgentPanel.vue',
-  () => ({ default: loadDockedAgentPanel() })
+  () => ({ __esModule: true, default: loadDockedAgentPanel() })
 )
 
 function getAsyncLoader(component: unknown): () => Promise<unknown> {
@@ -55,7 +55,10 @@ describe('useAgentDockMount', () => {
     expect(docked.value).toBe(false)
     store.isOpen = true
     expect(docked.value).toBe(true)
-    await getAsyncLoader(DockedAgentPanel)()
+    const resolvedPanel = await getAsyncLoader(DockedAgentPanel)()
+    const { default: expectedPanel } =
+      await import('@/workbench/extensions/agent/components/agent/DockedAgentPanel.vue')
+    expect(resolvedPanel).toBe(expectedPanel)
     expect(loadDockedAgentPanel).toHaveBeenCalledOnce()
     store.close('close_button')
     expect(docked.value).toBe(false)

--- a/src/workbench/extensions/agent/composables/useAgentDockMount.test.ts
+++ b/src/workbench/extensions/agent/composables/useAgentDockMount.test.ts
@@ -22,13 +22,18 @@ describe('useAgentDockMount', () => {
     expect(DockedAgentPanel).toBeNull()
   })
 
-  it('docks only once the gate enables and the panel opens on cloud', () => {
+  it('docks only once the gate enables and the panel opens on cloud', async () => {
     vi.stubGlobal('__DISTRIBUTION__', 'cloud')
     const store = useAgentPanelStore()
 
     const { docked, DockedAgentPanel } = useAgentDockMount()
 
     expect(DockedAgentPanel).not.toBeNull()
+    await expect(
+      (
+        DockedAgentPanel as { __asyncLoader: () => Promise<unknown> }
+      ).__asyncLoader()
+    ).resolves.toMatchObject({ __name: 'DockedAgentPanel' })
     expect(docked.value).toBe(false)
     store.enabled = true
     expect(docked.value).toBe(false)

--- a/src/workbench/extensions/agent/composables/useAgentDockMount.test.ts
+++ b/src/workbench/extensions/agent/composables/useAgentDockMount.test.ts
@@ -6,6 +6,13 @@ import { useAgentPanelStore } from '@/workbench/extensions/agent/stores/agent/ag
 import { useAgentDockMount } from './useAgentDockMount'
 
 vi.mock('@/platform/telemetry', () => ({ useTelemetry: () => undefined }))
+const { loadDockedAgentPanel } = vi.hoisted(() => ({
+  loadDockedAgentPanel: vi.fn(() => ({ name: 'DockedAgentPanel' }))
+}))
+vi.mock(
+  '@/workbench/extensions/agent/components/agent/DockedAgentPanel.vue',
+  () => ({ default: loadDockedAgentPanel() })
+)
 
 describe('useAgentDockMount', () => {
   beforeEach(() => {
@@ -29,16 +36,17 @@ describe('useAgentDockMount', () => {
     const { docked, DockedAgentPanel } = useAgentDockMount()
 
     expect(DockedAgentPanel).not.toBeNull()
-    await expect(
-      (
-        DockedAgentPanel as { __asyncLoader: () => Promise<unknown> }
-      ).__asyncLoader()
-    ).resolves.toMatchObject({ __name: 'DockedAgentPanel' })
+    expect(loadDockedAgentPanel).not.toHaveBeenCalled()
     expect(docked.value).toBe(false)
     store.enabled = true
+    expect(loadDockedAgentPanel).not.toHaveBeenCalled()
     expect(docked.value).toBe(false)
     store.isOpen = true
     expect(docked.value).toBe(true)
+    await (
+      DockedAgentPanel as { __asyncLoader: () => Promise<unknown> }
+    ).__asyncLoader()
+    expect(loadDockedAgentPanel).toHaveBeenCalledOnce()
     store.close('close_button')
     expect(docked.value).toBe(false)
   })

--- a/src/workbench/extensions/agent/composables/useAgentDockMount.test.ts
+++ b/src/workbench/extensions/agent/composables/useAgentDockMount.test.ts
@@ -14,6 +14,18 @@ vi.mock(
   () => ({ default: loadDockedAgentPanel() })
 )
 
+function getAsyncLoader(component: unknown): () => Promise<unknown> {
+  if (
+    component === null ||
+    typeof component !== 'object' ||
+    !('__asyncLoader' in component) ||
+    typeof component.__asyncLoader !== 'function'
+  ) {
+    throw new TypeError('Expected DockedAgentPanel to be an async component')
+  }
+  return component.__asyncLoader as () => Promise<unknown>
+}
+
 describe('useAgentDockMount', () => {
   beforeEach(() => {
     setActivePinia(createPinia())
@@ -43,9 +55,7 @@ describe('useAgentDockMount', () => {
     expect(docked.value).toBe(false)
     store.isOpen = true
     expect(docked.value).toBe(true)
-    await (
-      DockedAgentPanel as { __asyncLoader: () => Promise<unknown> }
-    ).__asyncLoader()
+    await getAsyncLoader(DockedAgentPanel)()
     expect(loadDockedAgentPanel).toHaveBeenCalledOnce()
     store.close('close_button')
     expect(docked.value).toBe(false)


### PR DESCRIPTION
## Summary

- cover the cloud async component loader in `useAgentDockMount.test.ts`
- raises `src/workbench/extensions/agent/composables/useAgentDockMount.ts` focused coverage from 83.33% lines to 100%

## Validation

- `pnpm exec vitest run --coverage src/workbench/extensions/agent/composables/useAgentDockMount.test.ts src/workbench/extensions/agent/stores/agent/agentPanelStoreId.test.ts --coverage.include='src/workbench/extensions/agent/composables/useAgentDockMount.ts' --coverage.reporter=text`
- `pnpm exec eslint src/workbench/extensions/agent/composables/useAgentDockMount.test.ts`
- pre-commit hook: staged `oxfmt`, `oxlint`, `eslint`, `pnpm typecheck`
- pre-push hook: `knip --cache`

Program row: `satcov-5`