### PR TITLE
test: characterize workflow path hash collision

### DIFF
--- a/src/platform/workflow/persistence/base/hashUtil.test.ts
+++ b/src/platform/workflow/persistence/base/hashUtil.test.ts
@@ -62,12 +62,10 @@ describe('hashPath', () => {
     const hash2 = hashPath('workflows/Untitled (2).json')
     expect(hash1).not.toBe(hash2)
   })
-})
 
-describe('R-78 hash collision characterization', () => {
-  it('documents the known FNV-1a collision pair', () => {
-    // Current-risk characterization for R-78, not desired behavior.
-    expect(hashPath('workflows/ewip.json')).toBe('684dbc71')
-    expect(hashPath('workflows/4hbab.json')).toBe('684dbc71')
+  it.fails('produces different hashes for known collision paths', () => {
+    const hash1 = hashPath('workflows/ewip.json')
+    const hash2 = hashPath('workflows/4hbab.json')
+    expect(hash1).not.toBe(hash2)
   })
 })

--- a/src/platform/workflow/persistence/base/hashUtil.test.ts
+++ b/src/platform/workflow/persistence/base/hashUtil.test.ts
@@ -63,3 +63,11 @@ describe('hashPath', () => {
     expect(hash1).not.toBe(hash2)
   })
 })
+
+describe('R-78 hash collision characterization', () => {
+  it('documents the known FNV-1a collision pair', () => {
+    // Current-risk characterization for R-78, not desired behavior.
+    expect(hashPath('workflows/ewip.json')).toBe('684dbc71')
+    expect(hashPath('workflows/4hbab.json')).toBe('684dbc71')
+  })
+})


### PR DESCRIPTION
## Summary

Characterize the known 32-bit FNV-1a workflow-path collision so the current R-78 storage risk remains visible while the eventual key migration is designed.

## Changes

- **What**: Adds a focused test proving `workflows/ewip.json` and `workflows/4hbab.json` both hash to `684dbc71`.
- **Breaking**: None; this documents current behavior and intentionally does not change the hash or storage scheme.
- **Dependencies**: None.

## Review Focus

Confirm this remains a characterization test, not an assertion that collisions are acceptable. The follow-up storage migration is tracked by #16371 and Linear FE-1952.

Tested with Node 25.9.0 and pnpm 11.13.1:

`pnpm test:unit src/platform/workflow/persistence/base/hashUtil.test.ts` (11/11 passed)

Relates to #16371.

## Screenshots (if applicable)

Not applicable; test-only change.
