### PR TITLE
test: characterize draft cache hash collision aliasing

### DIFF
--- a/src/platform/workflow/persistence/base/draftCacheV2.property.test.ts
+++ b/src/platform/workflow/persistence/base/draftCacheV2.property.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest'
 
 import {
   createEmptyIndex,
+  getEntryByPath,
   removeEntry,
   touchOrder,
   upsertEntry
@@ -19,6 +20,28 @@ const arbMeta = fc.record({
 })
 
 describe('draftCacheV2 properties', () => {
+  it('characterizes R-78 draft cache aliasing for known colliding paths', () => {
+    let index = createEmptyIndex()
+    index = upsertEntry(index, 'workflows/ewip.json', {
+      name: 'draft-a',
+      isTemporary: true,
+      updatedAt: 1
+    }).index
+    index = upsertEntry(index, 'workflows/4hbab.json', {
+      name: 'draft-b',
+      isTemporary: true,
+      updatedAt: 2
+    }).index
+
+    // R-78 current-risk characterization: these paths share the same 32-bit draft key.
+    expect(index.order).toEqual(['684dbc71'])
+    expect(Object.keys(index.entries)).toHaveLength(1)
+    expect(getEntryByPath(index, 'workflows/ewip.json')).toMatchObject({
+      name: 'draft-b',
+      path: 'workflows/4hbab.json'
+    })
+  })
+
   it('order length never exceeds limit after arbitrary upserts', () => {
     fc.assert(
       fc.property(


### PR DESCRIPTION
## Summary

Adds a permanent characterization test for R-78 draft-cache aliasing. The test documents the current behavior for the known FNV-1a 32-bit collision pair `workflows/ewip.json` / `workflows/4hbab.json`: both map to draft key `684dbc71`, so the second `upsertEntry` overwrites the first index entry and `getEntryByPath` for the first path returns the second draft metadata.

This is intentionally a current-risk characterization, not a behavior fix. It does not change the hash function, add collision detection, or migrate draft keys.

## Context

Trace: R-78 in the in-app-agent risk register, OPP-25 determinism audit, FE issue https://github.com/Comfy-Org/ComfyUI_frontend/issues/16371, Linear FE-1952.

Stale-main policy: this branch is based on current FE `main` at `f954e479a37b168a9596aa05a1ce1dec1e9a93b4`. The change is isolated to the workflow draft cache test surface and does not depend on the open CRDT integration heads.

## Verification

- `pnpm test:unit src/platform/workflow/persistence/base/draftCacheV2.property.test.ts` -> 1 file passed, 9 tests passed
- `pnpm exec oxfmt --check src/platform/workflow/persistence/base/draftCacheV2.property.test.ts` -> passed
- `pnpm lint:unstaged` -> passed
- normal pre-commit hook -> lint-staged and `pnpm typecheck` passed
- normal pre-push hook -> `knip --cache` passed
