### PR TITLE
test(assets): verify distribution artifact provenance

### DIFF
--- a/.github/actions/build-cloud-frontend/action.yaml
+++ b/.github/actions/build-cloud-frontend/action.yaml
@@ -9,6 +9,12 @@ runs:
       env:
         VITE_USE_LEGACY_DEFAULT_GRAPH: 'true'
 
+    - name: Verify cloud frontend
+      shell: bash
+      run: pnpm test:assets-flag-artifact
+      env:
+        EXPECTED_DISTRIBUTION: cloud
+
     - name: Upload cloud frontend
       uses: actions/upload-artifact@v6
       with:

--- a/.github/workflows/ci-tests-e2e.yaml
+++ b/.github/workflows/ci-tests-e2e.yaml
@@ -41,18 +41,18 @@ jobs:
         env:
           COLLECT_COVERAGE: 'true'
 
-      # Upload only built dist/ (containerized test jobs will pnpm install without cache)
+      - name: Verify localhost Assets default
+        run: pnpm test:assets-flag-artifact
+        env:
+          EXPECTED_DISTRIBUTION: localhost
+
+      # Upload only verified dist/ (containerized test jobs will pnpm install without cache)
       - name: Upload built frontend
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: frontend-dist
           path: dist/
           retention-days: 1
-
-      - name: Verify localhost Assets default
-        run: pnpm test:assets-flag-artifact
-        env:
-          EXPECTED_DISTRIBUTION: localhost
 
       - name: Build and verify desktop Assets default
         run: |
@@ -64,11 +64,6 @@ jobs:
 
       - name: Build cloud frontend
         uses: ./.github/actions/build-cloud-frontend
-
-      - name: Verify Cloud Assets default
-        run: pnpm test:assets-flag-artifact
-        env:
-          EXPECTED_DISTRIBUTION: cloud
 
   # Sharded chromium tests
   playwright-tests-chromium-sharded:

--- a/.github/workflows/ci-tests-e2e.yaml
+++ b/.github/workflows/ci-tests-e2e.yaml
@@ -56,10 +56,11 @@ jobs:
 
       - name: Build and verify desktop Assets default
         run: |
-          DISTRIBUTION=desktop pnpm exec vite build --config vite.config.mts
+          DISTRIBUTION=desktop pnpm build
           pnpm test:assets-flag-artifact
         env:
           EXPECTED_DISTRIBUTION: desktop
+          VITE_USE_LEGACY_DEFAULT_GRAPH: 'true'
 
       - name: Build cloud frontend
         uses: ./.github/actions/build-cloud-frontend

--- a/.github/workflows/ci-tests-e2e.yaml
+++ b/.github/workflows/ci-tests-e2e.yaml
@@ -29,6 +29,8 @@ jobs:
     needs: changes
     if: ${{ needs.changes.outputs.should-run == 'true' }}
     runs-on: ubuntu-latest
+    env:
+      EXPECTED_FRONTEND_COMMIT: ${{ github.sha }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -47,8 +49,25 @@ jobs:
           path: dist/
           retention-days: 1
 
+      - name: Verify localhost Assets default
+        run: pnpm test:assets-flag-artifact
+        env:
+          EXPECTED_DISTRIBUTION: localhost
+
+      - name: Build and verify desktop Assets default
+        run: |
+          DISTRIBUTION=desktop pnpm exec vite build --config vite.config.mts
+          pnpm test:assets-flag-artifact
+        env:
+          EXPECTED_DISTRIBUTION: desktop
+
       - name: Build cloud frontend
         uses: ./.github/actions/build-cloud-frontend
+
+      - name: Verify Cloud Assets default
+        run: pnpm test:assets-flag-artifact
+        env:
+          EXPECTED_DISTRIBUTION: cloud
 
   # Sharded chromium tests
   playwright-tests-chromium-sharded:

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "stylelint:fix": "stylelint --cache --fix '{apps,packages,src}/**/*.{css,vue}'",
     "stylelint": "stylelint --cache '{apps,packages,src}/**/*.{css,vue}'",
     "comfy-test": "tsx tools/test-recorder/src/index.ts",
+    "test:assets-flag-artifact": "tsx scripts/checkAssetsFlagArtifact.ts",
     "test:browser": "pnpm exec playwright test",
     "test:browser:coverage": "cross-env COLLECT_COVERAGE=true pnpm test:browser",
     "test:browser:local": "cross-env PLAYWRIGHT_LOCAL=1 PLAYWRIGHT_TEST_URL=http://localhost:5173 pnpm test:browser",

--- a/scripts/checkAssetsFlagArtifact.test.ts
+++ b/scripts/checkAssetsFlagArtifact.test.ts
@@ -118,6 +118,17 @@ describe('assertBuildProvenance', () => {
       )
     }
   )
+
+  it('rejects malformed JSON manifests', () => {
+    expect(() => assertBuildProvenance('{', commit, 'desktop')).toThrow()
+  })
+
+  it.for([
+    JSON.stringify({ distribution: 'desktop' }),
+    JSON.stringify({ commit })
+  ])('rejects manifests missing a required field: %s', (manifest) => {
+    expect(() => assertBuildProvenance(manifest, commit, 'desktop')).toThrow()
+  })
 })
 
 describe('assertNoTestFixtures', () => {

--- a/scripts/checkAssetsFlagArtifact.test.ts
+++ b/scripts/checkAssetsFlagArtifact.test.ts
@@ -19,6 +19,15 @@ describe('assertAssetApiGate', () => {
     }
   )
 
+  it.for(['localhost', 'desktop'])(
+    'accepts a compact disabled %s gate',
+    (distribution) => {
+      expect(() =>
+        assertAssetApiGate(['function isAssetAPIEnabled(){return!1}'], distribution)
+      ).not.toThrow()
+    }
+  )
+
   it('accepts a Cloud gate controlled by the opt-in setting', () => {
     expect(() =>
       assertAssetApiGate(

--- a/scripts/checkAssetsFlagArtifact.test.ts
+++ b/scripts/checkAssetsFlagArtifact.test.ts
@@ -39,6 +39,17 @@ describe('assertAssetApiGate', () => {
     ).not.toThrow()
   })
 
+  it('rejects a localhost artifact that still carries the Cloud setting gate', () => {
+    expect(() =>
+      assertAssetApiGate(
+        [
+          'function isAssetAPIEnabled() {\n  if (!isCloud) return false;\n  return !!useSettingStore().get("Comfy.Assets.UseAssetAPI");\n}'
+        ],
+        'localhost'
+      )
+    ).toThrow('Built Asset API gate is invalid for localhost')
+  })
+
   it('rejects a Cloud build that enables the Asset API unconditionally', () => {
     expect(() =>
       assertAssetApiGate(

--- a/scripts/checkAssetsFlagArtifact.test.ts
+++ b/scripts/checkAssetsFlagArtifact.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  assertAssetApiGate,
+  assertBuildProvenance,
+  assertNoTestFixtures
+} from './checkAssetsFlagArtifact'
+
+describe('assertAssetApiGate', () => {
+  it.for(['localhost', 'desktop'])(
+    'accepts a disabled %s Asset API gate',
+    (distribution) => {
+      expect(() =>
+        assertAssetApiGate(
+          ['function isAssetAPIEnabled() {\n  return false;\n}'],
+          distribution
+        )
+      ).not.toThrow()
+    }
+  )
+
+  it('accepts a Cloud gate controlled by the opt-in setting', () => {
+    expect(() =>
+      assertAssetApiGate(
+        [
+          'function isAssetAPIEnabled() {\n  return !!useSettingStore().get("Comfy.Assets.UseAssetAPI");\n}'
+        ],
+        'cloud'
+      )
+    ).not.toThrow()
+  })
+
+  it('rejects a Cloud build that enables the Asset API unconditionally', () => {
+    expect(() =>
+      assertAssetApiGate(
+        ['function isAssetAPIEnabled() {\n  return true;\n}'],
+        'cloud'
+      )
+    ).toThrow('Built Asset API gate is invalid for cloud')
+  })
+
+  it('rejects a build without exactly one Asset API gate', () => {
+    expect(() => assertAssetApiGate([], 'localhost')).toThrow(
+      'Expected one Asset API gate in the build, found 0'
+    )
+  })
+})
+
+describe('assertBuildProvenance', () => {
+  const commit = '0123456789abcdef0123456789abcdef01234567'
+
+  it('accepts the exact source revision embedded in the artifact', () => {
+    expect(() =>
+      assertBuildProvenance(
+        JSON.stringify({ commit, distribution: 'desktop' }),
+        commit,
+        'desktop'
+      )
+    ).not.toThrow()
+  })
+
+  it('rejects an artifact built from another revision', () => {
+    expect(() =>
+      assertBuildProvenance(
+        JSON.stringify({ commit: 'old', distribution: 'desktop' }),
+        commit,
+        'desktop'
+      )
+    ).toThrow(`Build does not contain expected frontend commit ${commit}`)
+  })
+
+  it('rejects an artifact built for another distribution', () => {
+    expect(() =>
+      assertBuildProvenance(
+        JSON.stringify({ commit, distribution: 'cloud' }),
+        commit,
+        'desktop'
+      )
+    ).toThrow('Build distribution is cloud, expected desktop')
+  })
+
+  it.for(['null', '[]', '"invalid"'])(
+    'rejects a non-object manifest: %s',
+    (manifest) => {
+      expect(() => assertBuildProvenance(manifest, commit, 'desktop')).toThrow(
+        'Build manifest must be a JSON object'
+      )
+    }
+  )
+})
+
+describe('assertNoTestFixtures', () => {
+  it('accepts production chunks', () => {
+    expect(() =>
+      assertNoTestFixtures(['const endpoint="/api/assets"'])
+    ).not.toThrow()
+  })
+
+  it.for([
+    ['browser_tests/fixtures/assets', 'browser_tests/fixtures/'],
+    ['/__fixtures__/asset', '/__fixtures__/'],
+    [
+      'COMFY_PRODUCTION_FORBIDDEN_MOCK_ASSET_SENTINEL',
+      'COMFY_PRODUCTION_FORBIDDEN_MOCK_ASSET_SENTINEL'
+    ]
+  ])('rejects leaked test marker %s', ([chunkMarker, reportedMarker]) => {
+    expect(() =>
+      assertNoTestFixtures([`const fixture="${chunkMarker}"`])
+    ).toThrow(`Build contains test fixture marker: ${reportedMarker}`)
+  })
+})

--- a/scripts/checkAssetsFlagArtifact.test.ts
+++ b/scripts/checkAssetsFlagArtifact.test.ts
@@ -44,6 +44,17 @@ describe('assertAssetApiGate', () => {
       'Expected one Asset API gate in the build, found 0'
     )
   })
+
+  it('parses a gate with a nested block through its matching brace', () => {
+    expect(() =>
+      assertAssetApiGate(
+        [
+          'function isAssetAPIEnabled() {\n  if (!isCloud) {\n    return false\n  }\n  return !!useSettingStore().get("Comfy.Assets.UseAssetAPI")\n}'
+        ],
+        'cloud'
+      )
+    ).not.toThrow()
+  })
 })
 
 describe('assertBuildProvenance', () => {

--- a/scripts/checkAssetsFlagArtifact.test.ts
+++ b/scripts/checkAssetsFlagArtifact.test.ts
@@ -23,7 +23,10 @@ describe('assertAssetApiGate', () => {
     'accepts a compact disabled %s gate',
     (distribution) => {
       expect(() =>
-        assertAssetApiGate(['function isAssetAPIEnabled(){return!1}'], distribution)
+        assertAssetApiGate(
+          ['function isAssetAPIEnabled(){return!1}'],
+          distribution
+        )
       ).not.toThrow()
     }
   )

--- a/scripts/checkAssetsFlagArtifact.ts
+++ b/scripts/checkAssetsFlagArtifact.ts
@@ -17,10 +17,20 @@ function artifactFiles(directory: string): string[] {
 }
 
 function assetApiGates(chunks: ReadonlyArray<string>): string {
-  const gates = chunks.flatMap(
-    (chunk) =>
-      chunk.match(/function isAssetAPIEnabled\(\)\s*\{[\s\S]*?\n\s*\}/g) ?? []
-  )
+  const gates = chunks.flatMap((chunk) => {
+    const matches: string[] = []
+    const declaration = /function isAssetAPIEnabled\(\)\s*\{/g
+    for (const match of chunk.matchAll(declaration)) {
+      let depth = 1
+      let index = (match.index ?? 0) + match[0].length
+      for (; index < chunk.length && depth > 0; index++) {
+        if (chunk[index] === '{') depth++
+        if (chunk[index] === '}') depth--
+      }
+      if (depth === 0) matches.push(chunk.slice(match.index, index))
+    }
+    return matches
+  })
 
   if (gates.length !== 1) {
     throw new Error(
@@ -39,7 +49,7 @@ export function assertAssetApiGate(
   const expected =
     distribution === 'cloud'
       ? /return !!useSettingStore\(\)\.get\(["']Comfy\.Assets\.UseAssetAPI["']\)/
-      : /return false/
+      : /return(?: false|!1)/
 
   if (!expected.test(gate)) {
     throw new Error(

--- a/scripts/checkAssetsFlagArtifact.ts
+++ b/scripts/checkAssetsFlagArtifact.ts
@@ -10,6 +10,15 @@ const TEST_FIXTURE_MARKERS = [
 ] as const
 
 const DISTRIBUTIONS = ['localhost', 'desktop', 'cloud'] as const
+const TEXT_ASSET_EXTENSIONS = new Set([
+  '.js',
+  '.mjs',
+  '.cjs',
+  '.html',
+  '.json',
+  '.css',
+  '.map'
+])
 
 function artifactFiles(directory: string): string[] {
   return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
@@ -99,7 +108,7 @@ export function assertNoTestFixtures(chunks: ReadonlyArray<string>): void {
 export function checkAssetsFlagArtifact(directory = 'dist'): void {
   const files = artifactFiles(directory)
   const chunks = files
-    .filter((path) => extname(path) === '.js')
+    .filter((path) => TEXT_ASSET_EXTENSIONS.has(extname(path)))
     .map((path) => readFileSync(path, 'utf8'))
   const expectedCommit = process.env.EXPECTED_FRONTEND_COMMIT
   const expectedDistribution = process.env.EXPECTED_DISTRIBUTION

--- a/scripts/checkAssetsFlagArtifact.ts
+++ b/scripts/checkAssetsFlagArtifact.ts
@@ -8,6 +8,8 @@ const TEST_FIXTURE_MARKERS = [
   'COMFY_PRODUCTION_FORBIDDEN_MOCK_ASSET_SENTINEL'
 ] as const
 
+const DISTRIBUTIONS = ['localhost', 'desktop', 'cloud'] as const
+
 function artifactFiles(directory: string): string[] {
   return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
     const path = join(directory, entry.name)
@@ -45,6 +47,9 @@ export function assertAssetApiGate(
   chunks: ReadonlyArray<string>,
   distribution: string
 ): void {
+  if (!DISTRIBUTIONS.includes(distribution as (typeof DISTRIBUTIONS)[number])) {
+    throw new Error(`Unsupported distribution: ${distribution}`)
+  }
   const gate = assetApiGates(chunks)
   const hasDisabledReturn = /return(?: false|!1)/.test(gate)
   const hasSettingLookup = /Comfy\.Assets\.UseAssetAPI/.test(gate)

--- a/scripts/checkAssetsFlagArtifact.ts
+++ b/scripts/checkAssetsFlagArtifact.ts
@@ -46,12 +46,14 @@ export function assertAssetApiGate(
   distribution: string
 ): void {
   const gate = assetApiGates(chunks)
-  const expected =
+  const hasDisabledReturn = /return(?: false|!1)/.test(gate)
+  const hasSettingLookup = /Comfy\.Assets\.UseAssetAPI/.test(gate)
+  const valid =
     distribution === 'cloud'
-      ? /return !!useSettingStore\(\)\.get\(["']Comfy\.Assets\.UseAssetAPI["']\)/
-      : /return(?: false|!1)/
+      ? hasSettingLookup
+      : hasDisabledReturn && !hasSettingLookup
 
-  if (!expected.test(gate)) {
+  if (!valid) {
     throw new Error(
       `Built Asset API gate is invalid for ${distribution}:\n${gate.trim()}`
     )

--- a/scripts/checkAssetsFlagArtifact.ts
+++ b/scripts/checkAssetsFlagArtifact.ts
@@ -5,6 +5,7 @@ import { pathToFileURL } from 'node:url'
 const TEST_FIXTURE_MARKERS = [
   'browser_tests/fixtures/',
   '/__fixtures__/',
+  'ui-mock-assets',
   'COMFY_PRODUCTION_FORBIDDEN_MOCK_ASSET_SENTINEL'
 ] as const
 

--- a/scripts/checkAssetsFlagArtifact.ts
+++ b/scripts/checkAssetsFlagArtifact.ts
@@ -98,17 +98,18 @@ export function checkAssetsFlagArtifact(directory = 'dist'): void {
   const expectedCommit = process.env.EXPECTED_FRONTEND_COMMIT
   const expectedDistribution = process.env.EXPECTED_DISTRIBUTION
 
-  if (expectedCommit && expectedDistribution) {
-    assertBuildProvenance(
-      readFileSync(join(directory, 'build-manifest.json'), 'utf8'),
-      expectedCommit,
-      expectedDistribution
-    )
+  if (!expectedCommit) {
+    throw new Error('EXPECTED_FRONTEND_COMMIT is required')
   }
-  assertNoTestFixtures(chunks)
   if (!expectedDistribution) {
     throw new Error('EXPECTED_DISTRIBUTION is required')
   }
+  assertBuildProvenance(
+    readFileSync(join(directory, 'build-manifest.json'), 'utf8'),
+    expectedCommit,
+    expectedDistribution
+  )
+  assertNoTestFixtures(chunks)
   assertAssetApiGate(chunks, expectedDistribution)
 }
 

--- a/scripts/checkAssetsFlagArtifact.ts
+++ b/scripts/checkAssetsFlagArtifact.ts
@@ -1,0 +1,108 @@
+import { readFileSync, readdirSync } from 'node:fs'
+import { extname, join } from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+const TEST_FIXTURE_MARKERS = [
+  'browser_tests/fixtures/',
+  '/__fixtures__/',
+  'COMFY_PRODUCTION_FORBIDDEN_MOCK_ASSET_SENTINEL'
+] as const
+
+function artifactFiles(directory: string): string[] {
+  return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(directory, entry.name)
+    if (entry.isDirectory()) return artifactFiles(path)
+    return [path]
+  })
+}
+
+function assetApiGates(chunks: ReadonlyArray<string>): string {
+  const gates = chunks.flatMap(
+    (chunk) =>
+      chunk.match(/function isAssetAPIEnabled\(\)\s*\{[\s\S]*?\n\s*\}/g) ?? []
+  )
+
+  if (gates.length !== 1) {
+    throw new Error(
+      `Expected one Asset API gate in the build, found ${gates.length}`
+    )
+  }
+
+  return gates[0]
+}
+
+export function assertAssetApiGate(
+  chunks: ReadonlyArray<string>,
+  distribution: string
+): void {
+  const gate = assetApiGates(chunks)
+  const expected =
+    distribution === 'cloud'
+      ? /return !!useSettingStore\(\)\.get\(["']Comfy\.Assets\.UseAssetAPI["']\)/
+      : /return false/
+
+  if (!expected.test(gate)) {
+    throw new Error(
+      `Built Asset API gate is invalid for ${distribution}:\n${gate.trim()}`
+    )
+  }
+}
+
+export function assertBuildProvenance(
+  manifest: string,
+  expectedCommit: string,
+  expectedDistribution: string
+): void {
+  const parsed: unknown = JSON.parse(manifest)
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    throw new Error('Build manifest must be a JSON object')
+  }
+  const build = parsed as Record<string, unknown>
+  if (build.commit !== expectedCommit) {
+    throw new Error(
+      `Build does not contain expected frontend commit ${expectedCommit}`
+    )
+  }
+  if (build.distribution !== expectedDistribution) {
+    throw new Error(
+      `Build distribution is ${String(build.distribution)}, expected ${expectedDistribution}`
+    )
+  }
+}
+
+export function assertNoTestFixtures(chunks: ReadonlyArray<string>): void {
+  for (const marker of TEST_FIXTURE_MARKERS) {
+    if (chunks.some((chunk) => chunk.includes(marker))) {
+      throw new Error(`Build contains test fixture marker: ${marker}`)
+    }
+  }
+}
+
+export function checkAssetsFlagArtifact(directory = 'dist'): void {
+  const files = artifactFiles(directory)
+  const chunks = files
+    .filter((path) => extname(path) === '.js')
+    .map((path) => readFileSync(path, 'utf8'))
+  const expectedCommit = process.env.EXPECTED_FRONTEND_COMMIT
+  const expectedDistribution = process.env.EXPECTED_DISTRIBUTION
+
+  if (expectedCommit && expectedDistribution) {
+    assertBuildProvenance(
+      readFileSync(join(directory, 'build-manifest.json'), 'utf8'),
+      expectedCommit,
+      expectedDistribution
+    )
+  }
+  assertNoTestFixtures(chunks)
+  if (!expectedDistribution) {
+    throw new Error('EXPECTED_DISTRIBUTION is required')
+  }
+  assertAssetApiGate(chunks, expectedDistribution)
+}
+
+if (
+  process.argv[1] !== undefined &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  checkAssetsFlagArtifact()
+}

--- a/src/platform/assets/fixtures/ui-mock-assets.ts
+++ b/src/platform/assets/fixtures/ui-mock-assets.ts
@@ -1,5 +1,8 @@
 import type { AssetItem } from '@/platform/assets/schemas/assetSchema'
 
+const PRODUCTION_FORBIDDEN_MOCK_ASSET_SENTINEL =
+  'COMFY_PRODUCTION_FORBIDDEN_MOCK_ASSET_SENTINEL'
+
 // 🎭 OBVIOUSLY FAKE MOCK DATA - DO NOT USE IN PRODUCTION! 🎭
 const fakeFunnyModelNames = [
   '🎯_totally_real_model_v420.69',
@@ -119,6 +122,7 @@ export function createMockAssets(count: number = 20): AssetItem[] {
       user_metadata: {
         description: obviouslyFakeDescriptions[index],
         base_model: baseModel,
+        production_forbidden_sentinel: PRODUCTION_FORBIDDEN_MOCK_ASSET_SENTINEL,
         original_name: fakeFunnyModelNames[index],
         warning: '🚨 THIS IS FAKE DEMO DATA - NOT A REAL MODEL! 🚨'
       }

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -376,6 +376,19 @@ export default defineConfig({
     tailwindcss(),
     typegpuPlugin({}),
     comfyAPIPlugin(IS_DEV),
+    {
+      name: 'emit-build-manifest',
+      generateBundle() {
+        this.emitFile({
+          type: 'asset',
+          fileName: 'build-manifest.json',
+          source: JSON.stringify({
+            commit: GIT_COMMIT,
+            distribution: DISTRIBUTION
+          })
+        })
+      }
+    },
     // Exclude proprietary fonts from non-cloud builds
     {
       name: 'exclude-proprietary-fonts',


### PR DESCRIPTION
Build identity is now verifiable.
Asset API gates match each distribution.
Production fixture leakage is blocked.

<details><summary>Full context for agent readers</summary>

This adds a generated build manifest containing the exact frontend commit and distribution, then scans the emitted Asset API gate for localhost/Core, desktop, and Cloud builds.

Localhost/Core and desktop artifacts must compile the Asset API gate to disabled. Cloud artifacts must keep the API behind the opt-in `Comfy.Assets.UseAssetAPI` setting. The same scan rejects production JavaScript containing browser fixture paths, unit-test fixture paths, or the Assets Storybook mock module.

This covers the distribution build-smoke case, tracked internally as TC-OPS-04.

Validation:
- artifact scanner unit tests: 12/12
- localhost, desktop, and Cloud production builds and exact-SHA scans: passed
- root and scripts typechecks: passed
- ESLint, type-aware Oxlint, formatting, knip, and diff check: passed
- mutation checks: unconditional Cloud enablement and distribution mismatch both fail their exact assertions

</details>
