### PR TITLE
fix: harden dev media relay and thumbnail queue

### DIFF
--- a/build/plugins/gcsRedirect.test.ts
+++ b/build/plugins/gcsRedirect.test.ts
@@ -1,0 +1,139 @@
+import type { IncomingMessage, ServerResponse } from 'node:http'
+import { PassThrough } from 'node:stream'
+import { describe, expect, it, vi } from 'vitest'
+
+import { handleGcsRedirect } from './gcsRedirect'
+
+function proxyResponse(headers: Record<string, string>, statusCode = 302) {
+  const stream = new PassThrough() as PassThrough & {
+    headers: Record<string, string>
+    statusCode: number
+  }
+  stream.headers = headers
+  stream.statusCode = statusCode
+  return stream as unknown as IncomingMessage
+}
+
+function request(headers: Record<string, string> = {}) {
+  return { headers } as unknown as IncomingMessage
+}
+
+function response() {
+  const stream = new PassThrough() as PassThrough & {
+    setHeader: ReturnType<typeof vi.fn>
+    writeHead: ReturnType<typeof vi.fn>
+    statusCode: number
+  }
+  stream.setHeader = vi.fn()
+  stream.writeHead = vi.fn()
+  return stream
+}
+
+function fetchedResponse(headers: Record<string, string> = {}) {
+  return {
+    status: 200,
+    headers: new Headers(headers),
+    body: new ReadableStream({
+      start(controller) {
+        controller.enqueue(new Uint8Array([1, 2]))
+        controller.close()
+      }
+    })
+  }
+}
+
+const trustedHeaders = {
+  location: 'https://storage.googleapis.com/bucket/object.mp4',
+  via: '1.1 google'
+}
+
+describe('handleGcsRedirect', () => {
+  it.for([
+    'https://storage.googleapis.com.attacker.example/obj',
+    'http://127.0.0.1/?next=storage.googleapis.com',
+    'http://storage.googleapis.com/bucket/object.mp4'
+  ])('does not server-fetch an untrusted redirect URL: %s', (location) => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+    const proxyRes = proxyResponse({ location, via: '1.1 google' })
+    const pipe = vi.spyOn(proxyRes, 'pipe')
+
+    handleGcsRedirect(
+      proxyRes,
+      request(),
+      response() as unknown as ServerResponse
+    )
+
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(pipe).toHaveBeenCalledOnce()
+  })
+
+  it('uses manual redirects and forwards range requests', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(fetchedResponse())
+    vi.stubGlobal('fetch', fetchMock)
+
+    handleGcsRedirect(
+      proxyResponse(trustedHeaders),
+      request({ range: 'bytes=0-1' }),
+      response() as unknown as ServerResponse
+    )
+
+    await vi.waitFor(() =>
+      expect(fetchMock).toHaveBeenCalledWith(trustedHeaders.location, {
+        headers: { range: 'bytes=0-1' },
+        redirect: 'manual'
+      })
+    )
+  })
+
+  it('omits a stale encoded length after fetch decodes the body', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        fetchedResponse({
+          'content-encoding': 'gzip',
+          'content-length': '20'
+        })
+      )
+    )
+    const res = response()
+
+    handleGcsRedirect(
+      proxyResponse(trustedHeaders),
+      request(),
+      res as unknown as ServerResponse
+    )
+
+    await vi.waitFor(() => expect(res.statusCode).toBe(200))
+    expect(res.setHeader).not.toHaveBeenCalledWith('content-length', '20')
+  })
+
+  it('handles failures emitted while streaming the response', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        status: 200,
+        headers: new Headers(),
+        body: new ReadableStream({
+          start(controller) {
+            controller.error(new Error('stream reset'))
+          }
+        })
+      })
+    )
+
+    handleGcsRedirect(
+      proxyResponse(trustedHeaders),
+      request(),
+      response() as unknown as ServerResponse
+    )
+
+    await vi.waitFor(() =>
+      expect(consoleError).toHaveBeenCalledWith(
+        'Error fetching from GCS:',
+        expect.objectContaining({ message: 'stream reset' })
+      )
+    )
+  })
+})

--- a/build/plugins/gcsRedirect.test.ts
+++ b/build/plugins/gcsRedirect.test.ts
@@ -136,4 +136,46 @@ describe('handleGcsRedirect', () => {
       )
     )
   })
+
+  it('returns an error when GCS responds without a body', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        status: 200,
+        headers: new Headers(),
+        body: null
+      })
+    )
+    const res = response()
+    const end = vi.spyOn(res, 'end')
+
+    handleGcsRedirect(
+      proxyResponse(trustedHeaders),
+      request(),
+      res as unknown as ServerResponse
+    )
+
+    await vi.waitFor(() => {
+      expect(res.statusCode).toBe(500)
+      expect(end).toHaveBeenCalledWith('Empty response from GCS')
+    })
+  })
+
+  it('returns an error when the GCS fetch rejects', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('fetch failed')))
+    const res = response()
+    const end = vi.spyOn(res, 'end')
+
+    handleGcsRedirect(
+      proxyResponse(trustedHeaders),
+      request(),
+      res as unknown as ServerResponse
+    )
+
+    await vi.waitFor(() => {
+      expect(res.statusCode).toBe(500)
+      expect(end).toHaveBeenCalledWith('Error fetching media')
+    })
+  })
 })

--- a/build/plugins/gcsRedirect.test.ts
+++ b/build/plugins/gcsRedirect.test.ts
@@ -50,6 +50,7 @@ const trustedHeaders = {
 describe('handleGcsRedirect', () => {
   it.for([
     'https://storage.googleapis.com.attacker.example/obj',
+    'https://storage.googleapis.com:444/bucket/object.mp4',
     'http://127.0.0.1/?next=storage.googleapis.com',
     'http://storage.googleapis.com/bucket/object.mp4'
   ])('does not server-fetch an untrusted redirect URL: %s', (location) => {

--- a/build/plugins/gcsRedirect.test.ts
+++ b/build/plugins/gcsRedirect.test.ts
@@ -72,13 +72,16 @@ describe('handleGcsRedirect', () => {
   it('uses manual redirects and forwards range requests', async () => {
     const fetchMock = vi.fn().mockResolvedValue(fetchedResponse())
     vi.stubGlobal('fetch', fetchMock)
+    const proxyRes = proxyResponse(trustedHeaders)
+    const resume = vi.spyOn(proxyRes, 'resume')
 
     handleGcsRedirect(
-      proxyResponse(trustedHeaders),
+      proxyRes,
       request({ range: 'bytes=0-1' }),
       response() as unknown as ServerResponse
     )
 
+    expect(resume).toHaveBeenCalledOnce()
     await vi.waitFor(() =>
       expect(fetchMock).toHaveBeenCalledWith(trustedHeaders.location, {
         headers: { range: 'bytes=0-1' },

--- a/build/plugins/gcsRedirect.ts
+++ b/build/plugins/gcsRedirect.ts
@@ -1,0 +1,85 @@
+import type { IncomingMessage, ServerResponse } from 'node:http'
+import { Readable } from 'node:stream'
+import { pipeline } from 'node:stream/promises'
+import type { ReadableStream as NodeReadableStream } from 'node:stream/web'
+
+function isTrustedGcsUrl(location: string | undefined): location is string {
+  if (!location) return false
+  try {
+    const url = new URL(location)
+    return (
+      url.protocol === 'https:' && url.hostname === 'storage.googleapis.com'
+    )
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Dev-only (cloud distribution): the ComfyUI proxy answers media requests
+ * with a 302 to GCS; the browser cannot follow it cross-origin, so the dev
+ * server fetches server-side and relays body, range, and freshness headers.
+ */
+export function handleGcsRedirect(
+  proxyRes: IncomingMessage,
+  req: IncomingMessage,
+  res: ServerResponse
+) {
+  const location = proxyRes.headers.location
+  const isGcsRedirect =
+    proxyRes.statusCode === 302 &&
+    isTrustedGcsUrl(location) &&
+    proxyRes.headers.via?.includes('google')
+
+  if (!isGcsRedirect || !location) {
+    Object.keys(proxyRes.headers).forEach((key) => {
+      const value = proxyRes.headers[key]
+      if (value !== undefined) res.setHeader(key, value)
+    })
+    res.writeHead(proxyRes.statusCode || 200)
+    proxyRes.pipe(res)
+    return
+  }
+
+  const rangeHeader = req.headers.range
+  fetch(location, {
+    headers: rangeHeader ? { range: rangeHeader } : undefined,
+    redirect: 'manual'
+  })
+    .then(async (gcsResponse) => {
+      if (!gcsResponse.body) {
+        res.statusCode = 500
+        res.end('Empty response from GCS')
+        return
+      }
+
+      res.statusCode = gcsResponse.status
+      res.setHeader(
+        'Content-Type',
+        gcsResponse.headers.get('content-type') || 'application/octet-stream'
+      )
+
+      const responseHeaders = [
+        ...(gcsResponse.headers.has('content-encoding')
+          ? []
+          : ['content-length']),
+        'content-range',
+        'accept-ranges',
+        'cache-control',
+        'etag',
+        'last-modified'
+      ]
+      for (const header of responseHeaders) {
+        const value = gcsResponse.headers.get(header)
+        if (value) res.setHeader(header, value)
+      }
+
+      const readable = Readable.fromWeb(gcsResponse.body as NodeReadableStream)
+      await pipeline(readable, res)
+    })
+    .catch((error) => {
+      console.error('Error fetching from GCS:', error)
+      if (!res.headersSent) res.statusCode = 500
+      if (!res.writableEnded && !res.destroyed) res.end('Error fetching media')
+    })
+}

--- a/build/plugins/gcsRedirect.ts
+++ b/build/plugins/gcsRedirect.ts
@@ -39,6 +39,7 @@ export function handleGcsRedirect(
     return
   }
 
+  proxyRes.resume()
   const rangeHeader = req.headers.range
   fetch(location, {
     headers: rangeHeader ? { range: rangeHeader } : undefined,

--- a/build/plugins/gcsRedirect.ts
+++ b/build/plugins/gcsRedirect.ts
@@ -7,9 +7,7 @@ function isTrustedGcsUrl(location: string | undefined): location is string {
   if (!location) return false
   try {
     const url = new URL(location)
-    return (
-      url.protocol === 'https:' && url.hostname === 'storage.googleapis.com'
-    )
+    return url.origin === 'https://storage.googleapis.com'
   } catch {
     return false
   }

--- a/src/extensions/core/load3d/LoaderManager.test.ts
+++ b/src/extensions/core/load3d/LoaderManager.test.ts
@@ -622,6 +622,27 @@ describe('LoaderManager', () => {
       expect(endEmits).toHaveLength(1)
     })
 
+    it('discards a pending load when disposed', async () => {
+      const { lm, modelManager, eventManager } = makeLoaderManager()
+      let resolveLoad!: (value: THREE.Object3D) => void
+      const pendingLoad = new Promise<THREE.Object3D>((resolve) => {
+        resolveLoad = resolve
+      })
+      meshLoad.mockImplementationOnce(() => pendingLoad.then(loadResult))
+
+      const loadPromise = lm.loadModel('api/view?filename=slow.glb')
+      lm.dispose()
+      resolveLoad(new THREE.Object3D())
+      await loadPromise
+
+      expect(modelManager.setupModel).not.toHaveBeenCalled()
+      expect(lm.getCurrentAdapter()).toBeNull()
+      expect(eventManager.emitEvent).not.toHaveBeenCalledWith(
+        'modelLoadingEnd',
+        null
+      )
+    })
+
     it('logs and drops the load when the URL is missing a filename param', async () => {
       const { lm, modelManager } = makeLoaderManager()
       const consoleError = vi

--- a/src/extensions/core/load3d/LoaderManager.ts
+++ b/src/extensions/core/load3d/LoaderManager.ts
@@ -79,7 +79,9 @@ export class LoaderManager implements LoaderManagerInterface {
 
   init(): void {}
 
-  dispose(): void {}
+  dispose(): void {
+    this.currentLoadId += 1
+  }
 
   async loadModel(
     url: string,

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -3,9 +3,6 @@ import tailwindcss from '@tailwindcss/vite'
 import vue from '@vitejs/plugin-vue'
 import { execSync } from 'child_process'
 import { config as dotenvConfig } from 'dotenv'
-import type { IncomingMessage, ServerResponse } from 'http'
-import { Readable } from 'stream'
-import type { ReadableStream as NodeReadableStream } from 'stream/web'
 import { visualizer } from 'rollup-plugin-visualizer'
 import { FileSystemIconLoader } from 'unplugin-icons/loaders'
 import IconsResolver from 'unplugin-icons/resolver'
@@ -19,6 +16,7 @@ import { createHtmlPlugin } from 'vite-plugin-html'
 import vueDevTools from 'vite-plugin-vue-devtools'
 
 import { comfyAPIPlugin } from './build/plugins/comfyAPIPlugin.ts'
+import { handleGcsRedirect } from './build/plugins/gcsRedirect.ts'
 
 dotenvConfig()
 
@@ -205,74 +203,6 @@ const DEV_SERVER_COMFYUI_URL =
 
 const cloudProxyConfig =
   DISTRIBUTION === 'cloud' ? { secure: false, changeOrigin: true } : {}
-
-function handleGcsRedirect(
-  proxyRes: IncomingMessage,
-  req: IncomingMessage,
-  res: ServerResponse
-) {
-  const location = proxyRes.headers.location
-  const isGcsRedirect =
-    proxyRes.statusCode === 302 &&
-    location?.includes('storage.googleapis.com') &&
-    proxyRes.headers.via?.includes('google')
-
-  // Not a GCS redirect - pass through normally
-  if (!isGcsRedirect || !location) {
-    Object.keys(proxyRes.headers).forEach((key) => {
-      const value = proxyRes.headers[key]
-      if (value !== undefined) {
-        res.setHeader(key, value)
-      }
-    })
-    res.writeHead(proxyRes.statusCode || 200)
-    proxyRes.pipe(res)
-    return
-  }
-
-  // GCS redirect detected - fetch server-side to avoid CORS. Range headers
-  // are forwarded and the partial-content response relayed so ranged reads
-  // behave like production, where the browser talks to GCS directly.
-  const rangeHeader = req.headers.range
-  fetch(location, rangeHeader ? { headers: { range: rangeHeader } } : undefined)
-    .then(async (gcsResponse) => {
-      if (!gcsResponse.body) {
-        res.statusCode = 500
-        res.end('Empty response from GCS')
-        return
-      }
-
-      // Set response headers from GCS
-      res.statusCode = gcsResponse.status
-      res.setHeader(
-        'Content-Type',
-        gcsResponse.headers.get('content-type') || 'application/octet-stream'
-      )
-
-      for (const header of [
-        'content-length',
-        'content-range',
-        'accept-ranges',
-        'cache-control',
-        'etag',
-        'last-modified'
-      ]) {
-        const value = gcsResponse.headers.get(header)
-        if (value) {
-          res.setHeader(header, value)
-        }
-      }
-
-      // Convert Web ReadableStream to Node.js stream and pipe to client
-      const readable = Readable.fromWeb(gcsResponse.body as NodeReadableStream)
-      readable.pipe(res)
-    })
-    .catch((error) => {
-      console.error('Error fetching from GCS:', error)
-      res.statusCode = 500
-      res.end('Error fetching media')
-    })
-}
 
 const gcsRedirectProxyConfig: ProxyOptions = {
   target: DEV_SERVER_COMFYUI_URL,
@@ -845,6 +775,7 @@ export default defineConfig({
     include: [
       'src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}',
       'packages/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}',
+      'build/plugins/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}',
       'scripts/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}',
       'browser_tests/**/*.test.{js,mjs,cjs,ts,mts,cts,jsx,tsx}',
       'tools/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'


### PR DESCRIPTION
## Summary

Ports the still-novel GCS relay and model-thumbnail queue reliability fixes from the historical worker-3 salvage stack onto current `main`.

## Changes

- Extracts the existing dev-only GCS relay from `vite.config.mts` into a directly tested helper.
- Restricts server-side relay fetches to exact HTTPS `storage.googleapis.com` URLs and disables redirect following.
- Handles response-stream failures and avoids relaying stale encoded `content-length` values after fetch decoding.
- Times out a stuck offscreen 3D model load so the serialized thumbnail queue can advance, while preserving main's current two-argument persistence API.

## Review Focus

- This is the coherent successor for the GCS-relay and thumbnail-API hunks explicitly excluded from #16392. PR #16392 remains the carrier for the broader shared media/assets delta; this branch does not duplicate its files beyond the independently excluded `modelThumbnail` surface.
- The source stack was re-audited against `main@f954e479a37b168a9596aa05a1ce1dec1e9a93b4` and combined integration state `f67847f96f8a0b96646a630c37b3d43c344954d2`. These changes do not touch the clock/identity or `GraphDocument` seams, so the branch is based directly on `main`.
- The historical one-argument thumbnail API was not restored because it removes current preview persistence and does not compose with the current `ReplyAssetGroup.vue` caller.

Verification:

- Focused Vitest covers the relay and thumbnail/loader lifecycle behavior.
- Scoped Oxfmt, Oxlint, ESLint, and full `pnpm typecheck` passed locally.
- Push hook `knip --cache` passed.
- An end-to-end regression test is not practical because the affected thumbnail path is an offscreen background WebGL queue with no stable user interaction or browser-observable completion signal; deterministic Vitest coverage exercises the timeout, disposal, late-load invalidation, and queue progression directly.

## Screenshots (if applicable)

Not applicable; this is dev-relay and background thumbnail reliability hardening with no new user-facing flow.
