### PR TITLE
fix: use canvas instance when opening prompts

### DIFF
--- a/src/lib/litegraph/src/LGraphCanvas.prompt.test.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.prompt.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { LGraph, LGraphCanvas } from '@/lib/litegraph/src/litegraph'
+import {
+  createMockCanvasPointerEvent,
+  createMockCanvasRenderingContext2D
+} from '@/utils/__tests__/litegraphTestUtils'
+
+describe('LGraphCanvas.prompt', () => {
+  it('appends the dialog beside its canvas without an active canvas', () => {
+    Reflect.deleteProperty(LGraphCanvas, 'active_canvas')
+
+    const parent = document.createElement('div')
+    const canvasElement = document.createElement('canvas')
+    canvasElement.getContext = vi
+      .fn()
+      .mockReturnValue(createMockCanvasRenderingContext2D())
+    parent.append(canvasElement)
+
+    const canvas = new LGraphCanvas(canvasElement, new LGraph(), {
+      skip_render: true
+    })
+    const dialog = canvas.prompt(
+      'Rename Slot',
+      'slot',
+      vi.fn(),
+      createMockCanvasPointerEvent(0, 0, { clientX: 10, clientY: 20 })
+    )
+
+    expect(LGraphCanvas.active_canvas).toBeUndefined()
+    expect(dialog.parentElement).toBe(parent)
+  })
+})

--- a/src/lib/litegraph/src/LGraphCanvas.prompt.test.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.prompt.test.ts
@@ -6,20 +6,34 @@ import {
   createMockCanvasRenderingContext2D
 } from '@/utils/__tests__/litegraphTestUtils'
 
+function createCanvas(
+  rect: Pick<DOMRect, 'left' | 'top' | 'width' | 'height'> = {
+    left: 0,
+    top: 0,
+    width: 800,
+    height: 600
+  }
+) {
+  const parent = document.createElement('div')
+  const element = document.createElement('canvas')
+  element.width = rect.width
+  element.height = rect.height
+  element.getContext = vi
+    .fn()
+    .mockReturnValue(createMockCanvasRenderingContext2D())
+  element.getBoundingClientRect = vi.fn().mockReturnValue(rect)
+  parent.append(element)
+
+  const canvas = new LGraphCanvas(element, new LGraph(), {
+    skip_render: true
+  })
+  return { canvas, element, parent }
+}
+
 describe('LGraphCanvas.prompt', () => {
   it('appends the dialog beside its canvas without an active canvas', () => {
     Reflect.deleteProperty(LGraphCanvas, 'active_canvas')
-
-    const parent = document.createElement('div')
-    const canvasElement = document.createElement('canvas')
-    canvasElement.getContext = vi
-      .fn()
-      .mockReturnValue(createMockCanvasRenderingContext2D())
-    parent.append(canvasElement)
-
-    const canvas = new LGraphCanvas(canvasElement, new LGraph(), {
-      skip_render: true
-    })
+    const { canvas, parent } = createCanvas()
     const dialog = canvas.prompt(
       'Rename Slot',
       'slot',
@@ -29,5 +43,52 @@ describe('LGraphCanvas.prompt', () => {
 
     expect(LGraphCanvas.active_canvas).toBeUndefined()
     expect(dialog.parentElement).toBe(parent)
+  })
+
+  it('uses the invoked canvas when another canvas is active', () => {
+    const owner = createCanvas({
+      left: 100,
+      top: 200,
+      width: 800,
+      height: 600
+    })
+    const active = createCanvas()
+    owner.canvas.ds.scale = 2
+    LGraphCanvas.active_canvas = active.canvas
+
+    const dialog = owner.canvas.prompt(
+      'Rename Slot',
+      'slot',
+      vi.fn(),
+      createMockCanvasPointerEvent(0, 0, { clientX: 150, clientY: 260 })
+    )
+
+    expect(dialog.parentElement).toBe(owner.parent)
+    expect(dialog.parentElement).not.toBe(active.parent)
+    expect(dialog.style.transform).toBe('scale(2)')
+    expect(dialog.style.left).toBe('30px')
+    expect(dialog.style.top).toBe('40px')
+  })
+
+  it('closes only when the invoked canvas is clicked', () => {
+    vi.useFakeTimers()
+    const owner = createCanvas()
+    const active = createCanvas()
+    LGraphCanvas.active_canvas = active.canvas
+
+    const dialog = owner.canvas.prompt(
+      'Rename Slot',
+      'slot',
+      vi.fn(),
+      createMockCanvasPointerEvent(0, 0)
+    )
+    vi.advanceTimersByTime(267)
+
+    active.element.click()
+    expect(dialog.parentElement).toBe(owner.parent)
+
+    owner.element.click()
+    expect(dialog.parentElement).toBeNull()
+    vi.useRealTimers()
   })
 })

--- a/src/lib/litegraph/src/LGraphCanvas.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.ts
@@ -7277,8 +7277,7 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
     const div = document.createElement('div')
     const dialog: PromptDialog = Object.assign(div, customProperties)
 
-    const graphcanvas = LGraphCanvas.active_canvas
-    const { canvas } = graphcanvas
+    const { canvas } = this
     if (!canvas.parentNode)
       throw new TypeError(
         'canvas element parentNode was null when opening a prompt.'


### PR DESCRIPTION
## Summary

`LGraphCanvas.prompt()` read `LGraphCanvas.active_canvas`, so a programmatic prompt before any pointer event failed with:

```
TypeError: Cannot destructure property 'canvas' of 'LGraphCanvas.active_canvas' as it is undefined.
```

This was observed when renaming a slot after entering a subgraph through `setGraph()`.

## Changes

- Resolve the prompt dialog parent from the invoked canvas instance.
- Cover missing and conflicting active canvases, instance-relative placement, and outside-click ownership.