### PR TITLE
[Backport cloud/1.52] feat: open Settings on Plans & Credits from a ?settings= deep link

### DIFF
--- a/backport-sync.txt
+++ b/backport-sync.txt
@@ -1,0 +1,1 @@
+Temporary marker used to sync this fork branch with cloud/1.52.


### PR DESCRIPTION
## Summary

Backports #15808 to `cloud/1.52` so `?settings=plan-credits` works in the frontend release currently promoted to Cloud production.

## Why

`cloud/1.52` branched before #15808 merged, and the original backport labels only covered 1.51. As a result, Cloud production currently strips or ignores the deep-link intent and does not open Plans & Credits.

Slack context: https://comfy-organization.slack.com/archives/C0BNGQG2LCW/p1787597535486829

## Changes

- **What**: Clean cherry-pick of #15808 onto `cloud/1.52`
- **Regression coverage**: Preserves the original unit, integration, and browser regression tests

## Verification

- 18 targeted unit/integration tests passed
- `pnpm typecheck` passed
- ESLint passed for all changed source files
- Pre-push `pnpm knip` passed

## Screenshots

Behavior and UI are unchanged from #15808; see the original PR for AS IS / TO BE evidence.