### PR TITLE
fix: simplify litegraph ECS compatibility paths

### DIFF
--- a/src/lib/litegraph/src/LGraph.ts
+++ b/src/lib/litegraph/src/LGraph.ts
@@ -2191,8 +2191,10 @@ export class LGraph
       // Special handling: Subgraph input node
       i++
       if (link.origin_id === SUBGRAPH_INPUT_ID) {
-        link.target_id = subgraphNode.id
-        link.target_slot = i - 1
+        link.updateEndpoints({
+          targetNodeId: subgraphNode.id,
+          targetSlot: i - 1
+        })
         if (subgraphInput instanceof SubgraphInput) {
           subgraphInput.connect(
             subgraphNode.findInputSlotByType(link.type, true, true),

--- a/src/lib/litegraph/src/LGraphNode.test.ts
+++ b/src/lib/litegraph/src/LGraphNode.test.ts
@@ -16,13 +16,15 @@ import {
   LGraphNode,
   LiteGraph,
   LGraph,
+  LLink,
   NodeInputSlot,
   NodeOutputSlot
 } from '@/lib/litegraph/src/litegraph'
 
 import { test } from './__fixtures__/testExtensions'
 import { createMockLGraphNodeWithArrayBoundingRect } from '@/utils/__tests__/litegraphTestUtils'
-import { toNodeId } from '@/types/nodeId'
+import { toLinkId } from '@/types/linkId'
+import { UNASSIGNED_NODE_ID, toNodeId } from '@/types/nodeId'
 
 interface NodeConstructorWithSlotOffset {
   slot_start_y?: number
@@ -364,6 +366,26 @@ describe('LGraphNode', () => {
       // Test disconnecting already disconnected output
       const alreadyDisconnected = sourceNode.disconnectOutput(0)
       expect(alreadyDisconnected).toBe(false)
+    })
+
+    test('preserves floating links during a targeted output disconnect', () => {
+      const { graph, sourceNode } = createConnectedPair()
+      const unrelated = new LGraphNode('unrelated')
+      unrelated.addInput('input', '*')
+      graph.add(unrelated)
+      const floating = new LLink(
+        toLinkId(-1),
+        '*',
+        sourceNode.id,
+        0,
+        UNASSIGNED_NODE_ID,
+        -1
+      )
+      graph.addFloatingLink(floating)
+
+      expect(sourceNode.disconnectOutput(0, unrelated)).toBe(false)
+      expect(graph.floatingLinks.get(floating.id)).toBe(floating)
+      expect(sourceNode.isOutputConnected(0)).toBe(true)
     })
   })
 

--- a/src/lib/litegraph/src/LGraphNode.ts
+++ b/src/lib/litegraph/src/LGraphNode.ts
@@ -1188,7 +1188,11 @@ export class LGraphNode
       )
     }
 
-    this.onConfigure?.(extensionConfigureView(this, info))
+    try {
+      this.onConfigure?.(extensionConfigureView(this, info))
+    } finally {
+      useWidgetValueStore().clearNodeWidgetRestoration(graphId, this.id)
+    }
   }
 
   /**
@@ -3351,7 +3355,7 @@ export class LGraphNode
     const output = this.outputs[slot]
     if (!output) return false
 
-    if (this.graph) {
+    if (!target_node && this.graph) {
       for (const link of slotFloatingLinks(
         this.graph,
         'output',

--- a/src/lib/litegraph/src/LGraphNode.widgetOrder.test.ts
+++ b/src/lib/litegraph/src/LGraphNode.widgetOrder.test.ts
@@ -126,7 +126,7 @@ describe('LGraphNode widget ordering', () => {
       ])
     })
 
-    it('restores positional values for widgets created after configure', () => {
+    it('does not retain positional restoration after configure', () => {
       node.configure({
         id: 1,
         type: 'TestNode',
@@ -141,9 +141,7 @@ describe('LGraphNode widget ordering', () => {
       node.addWidget('number', 'steps', 0, null, {})
       node.addWidget('number', 'seed', 0, null, {})
 
-      expect(node.widgets!.map((widget) => widget.value)).toStrictEqual([
-        30, 12345
-      ])
+      expect(node.widgets!.map((widget) => widget.value)).toStrictEqual([0, 0])
     })
   })
 
@@ -206,20 +204,31 @@ describe('LGraphNode widget ordering', () => {
       expect(node.widgets!.map((w) => w.value)).toStrictEqual([1, 5, 'test'])
     })
 
-    it('restores delayed widgets by name and preserves the wire roundtrip', () => {
+    it('does not restore delayed widgets by name', () => {
       node.configure(mockNode([30, 12345], { steps: 30, seed: 12345 }))
 
       node.addWidget('number', 'seed', 0, null, {})
       node.addWidget('number', 'steps', 0, null, {})
       node.serialize_widgets = true
 
-      expect(node.widgets!.map((widget) => widget.value)).toStrictEqual([
-        12345, 30
-      ])
+      expect(node.widgets!.map((widget) => widget.value)).toStrictEqual([0, 0])
       expect(node.serialize()).toMatchObject({
-        widgets_values: [12345, 30],
-        widgets_values_named: { seed: 12345, steps: 30 }
+        widgets_values: [0, 0],
+        widgets_values_named: { seed: 0, steps: 0 }
       })
+    })
+
+    it('clears restoration when onConfigure throws', () => {
+      node.onConfigure = () => {
+        throw new Error('configure failed')
+      }
+
+      expect(() =>
+        node.configure(mockNode(undefined, { seed: 12345 }))
+      ).toThrow('configure failed')
+      node.addWidget('number', 'seed', 0, null, {})
+
+      expect(node.widgets![0].value).toBe(0)
     })
 
     it('should support restoration even when order has changed', () => {

--- a/src/lib/litegraph/src/LLink.store.test.ts
+++ b/src/lib/litegraph/src/LLink.store.test.ts
@@ -558,13 +558,14 @@ describe('LLink ↔ linkStore integration', () => {
     expect(first.target_slot).toBe(0)
   })
 
-  it('applies split endpoint writes atomically once they form a valid target', () => {
+  it('does not replay a rejected endpoint write', () => {
     const graph = new LGraph()
     const source = new LGraphNode('Source')
     const firstTarget = new LGraphNode('First target')
     const secondTarget = new LGraphNode('Second target')
     source.addOutput('out', 'INT')
-    firstTarget.addInput('in', 'INT')
+    firstTarget.addInput('first', 'INT')
+    firstTarget.addInput('second', 'INT')
     secondTarget.addInput('occupied', 'INT')
     secondTarget.addInput('destination', 'INT')
     graph.add(source)
@@ -581,10 +582,11 @@ describe('LLink ↔ linkStore integration', () => {
     expect(moving.target_id).toBe(firstTarget.id)
     moving.target_slot = 1
 
-    expect(moving.target_id).toBe(secondTarget.id)
+    expect(moving.target_id).toBe(firstTarget.id)
     expect(moving.target_slot).toBe(1)
     expect(firstTarget.inputs[0].link).toBeNull()
-    expect(secondTarget.inputs[1].link).toBe(moving.id)
+    expect(firstTarget.inputs[1].link).toBe(moving.id)
+    expect(secondTarget.inputs[1].link).toBeNull()
   })
 
   it('updates regular and floating views after endpoint changes', () => {

--- a/src/lib/litegraph/src/LLink.ts
+++ b/src/lib/litegraph/src/LLink.ts
@@ -45,7 +45,6 @@ export type SerialisedLLinkArray = [
 ]
 
 const linkByTopology = new WeakMap<LinkTopology, LLink>()
-const pendingEndpointPatches = new WeakMap<LLink, EndpointPatch>()
 
 let topologyFacadeDescriptors: PropertyDescriptorMap | undefined
 
@@ -126,26 +125,6 @@ type BasicReadonlyNetwork = Pick<
   'getNodeById' | 'links' | 'getLink' | 'inputNode' | 'outputNode'
 >
 
-/** Routes an endpoint patch through {@link useLinkStore} if the link is registered, otherwise writes {@link LLink._state} directly. */
-function applyEndpointPatch(link: LLink, patch: EndpointPatch): void {
-  if (link._graphScope) {
-    const combinedPatch = { ...pendingEndpointPatches.get(link), ...patch }
-    const result = useLinkStore().updateEndpoint(
-      link._graphScope,
-      link._state,
-      combinedPatch
-    )
-    if (!result.ok) {
-      pendingEndpointPatches.set(link, combinedPatch)
-      console.error('Failed to update link endpoints', result.error)
-    } else {
-      pendingEndpointPatches.delete(link)
-    }
-  } else {
-    Object.assign(link._state, patch)
-  }
-}
-
 // this is the class in charge of storing link information
 export class LLink implements LinkSegment, Serialisable<SerialisableLLink> {
   static _drawDebug = false
@@ -188,7 +167,7 @@ export class LLink implements LinkSegment, Serialisable<SerialisableLLink> {
   }
 
   set origin_id(value: NodeId) {
-    applyEndpointPatch(this, { originNodeId: value })
+    this.updateEndpoints({ originNodeId: value })
   }
 
   /** Output slot index */
@@ -197,7 +176,7 @@ export class LLink implements LinkSegment, Serialisable<SerialisableLLink> {
   }
 
   set origin_slot(value: number) {
-    applyEndpointPatch(this, { originSlot: value })
+    this.updateEndpoints({ originSlot: value })
   }
 
   /** Input node ID */
@@ -206,7 +185,7 @@ export class LLink implements LinkSegment, Serialisable<SerialisableLLink> {
   }
 
   set target_id(value: NodeId) {
-    applyEndpointPatch(this, { targetNodeId: value })
+    this.updateEndpoints({ targetNodeId: value })
   }
 
   /** Input slot index */
@@ -215,7 +194,22 @@ export class LLink implements LinkSegment, Serialisable<SerialisableLLink> {
   }
 
   set target_slot(value: number) {
-    applyEndpointPatch(this, { targetSlot: value })
+    this.updateEndpoints({ targetSlot: value })
+  }
+
+  updateEndpoints(patch: EndpointPatch): void {
+    if (!this._graphScope) {
+      Object.assign(this._state, patch)
+      return
+    }
+
+    const result = useLinkStore().updateEndpoint(
+      this._graphScope,
+      this._state,
+      patch
+    )
+    if (!result.ok)
+      console.error('Failed to update link endpoints', result.error)
   }
 
   get parentId() {
@@ -481,18 +475,22 @@ export class LLink implements LinkSegment, Serialisable<SerialisableLLink> {
   configure(o: LLink | SerialisedLLinkArray) {
     if (Array.isArray(o)) {
       this.id = toLinkId(o[0])
-      this.origin_id = toNodeId(o[1])
-      this.origin_slot = o[2]
-      this.target_id = toNodeId(o[3])
-      this.target_slot = o[4]
+      this.updateEndpoints({
+        originNodeId: toNodeId(o[1]),
+        originSlot: o[2],
+        targetNodeId: toNodeId(o[3]),
+        targetSlot: o[4]
+      })
       this.type = o[5]
     } else {
       this.id = o.id
       this.type = o.type
-      this.origin_id = o.origin_id
-      this.origin_slot = o.origin_slot
-      this.target_id = o.target_id
-      this.target_slot = o.target_slot
+      this.updateEndpoints({
+        originNodeId: o.origin_id,
+        originSlot: o.origin_slot,
+        targetNodeId: o.target_id,
+        targetSlot: o.target_slot
+      })
       this.parentId = o.parentId
     }
   }
@@ -713,7 +711,6 @@ export function unregisterLinkTopology(link: LLink): void {
   if (!link._graphScope) return
   useLinkStore().deleteLink(link._graphScope, link._state)
   linkByTopology.delete(toRaw(link._state))
-  pendingEndpointPatches.delete(link)
   link._graphScope = undefined
 }
 

--- a/src/lib/litegraph/src/Reroute.ts
+++ b/src/lib/litegraph/src/Reroute.ts
@@ -434,8 +434,7 @@ export class Reroute
     }
 
     for (const link of floatingOutLinks) {
-      link.origin_id = node.id
-      link.origin_slot = index
+      link.updateEndpoints({ originNodeId: node.id, originSlot: index })
     }
   }
 

--- a/src/lib/litegraph/src/canvas/FloatingRenderLink.ts
+++ b/src/lib/litegraph/src/canvas/FloatingRenderLink.ts
@@ -152,8 +152,10 @@ export class FloatingRenderLink implements RenderLink {
     node.disconnectInput(node.inputs.indexOf(input))
 
     const floatingLink = this.link
-    floatingLink.target_id = node.id
-    floatingLink.target_slot = node.inputs.indexOf(input)
+    floatingLink.updateEndpoints({
+      targetNodeId: node.id,
+      targetSlot: node.inputs.indexOf(input)
+    })
   }
 
   connectToOutput(
@@ -162,8 +164,10 @@ export class FloatingRenderLink implements RenderLink {
     _events?: CustomEventTarget<LinkConnectorEventMap>
   ): void {
     const floatingLink = this.link
-    floatingLink.origin_id = node.id
-    floatingLink.origin_slot = node.outputs.indexOf(output)
+    floatingLink.updateEndpoints({
+      originNodeId: node.id,
+      originSlot: node.outputs.indexOf(output)
+    })
   }
 
   connectToSubgraphInput(
@@ -171,8 +175,10 @@ export class FloatingRenderLink implements RenderLink {
     _events?: CustomEventTarget<LinkConnectorEventMap>
   ): void {
     const floatingLink = this.link
-    floatingLink.origin_id = SUBGRAPH_INPUT_ID
-    floatingLink.origin_slot = input.parent.slots.indexOf(input)
+    floatingLink.updateEndpoints({
+      originNodeId: SUBGRAPH_INPUT_ID,
+      originSlot: input.parent.slots.indexOf(input)
+    })
   }
 
   connectToSubgraphOutput(
@@ -180,8 +186,10 @@ export class FloatingRenderLink implements RenderLink {
     _events?: CustomEventTarget<LinkConnectorEventMap>
   ): void {
     const floatingLink = this.link
-    floatingLink.target_id = SUBGRAPH_OUTPUT_ID
-    floatingLink.target_slot = output.parent.slots.indexOf(output)
+    floatingLink.updateEndpoints({
+      targetNodeId: SUBGRAPH_OUTPUT_ID,
+      targetSlot: output.parent.slots.indexOf(output)
+    })
   }
 
   connectToRerouteInput(
@@ -191,8 +199,10 @@ export class FloatingRenderLink implements RenderLink {
     events: CustomEventTarget<LinkConnectorEventMap>
   ) {
     const floatingLink = this.link
-    floatingLink.target_id = inputNode.id
-    floatingLink.target_slot = inputNode.inputs.indexOf(input)
+    floatingLink.updateEndpoints({
+      targetNodeId: inputNode.id,
+      targetSlot: inputNode.inputs.indexOf(input)
+    })
 
     events.dispatch('input-moved', this)
   }
@@ -205,8 +215,10 @@ export class FloatingRenderLink implements RenderLink {
     events: CustomEventTarget<LinkConnectorEventMap>
   ) {
     const floatingLink = this.link
-    floatingLink.origin_id = outputNode.id
-    floatingLink.origin_slot = outputNode.outputs.indexOf(output)
+    floatingLink.updateEndpoints({
+      originNodeId: outputNode.id,
+      originSlot: outputNode.outputs.indexOf(output)
+    })
 
     events.dispatch('output-moved', this)
   }

--- a/src/lib/litegraph/src/widgets/BaseWidget.test.ts
+++ b/src/lib/litegraph/src/widgets/BaseWidget.test.ts
@@ -229,7 +229,7 @@ describe('BaseWidget store integration', () => {
       )
       expect(node.widgets.map(({ name }) => name)).toEqual([
         'duplicate',
-        'duplicate'
+        'duplicate#1'
       ])
       expect(store.getNodeWidgetIds(graph.id, toNodeId(1))).toEqual([
         first.widgetId,
@@ -259,10 +259,10 @@ describe('BaseWidget store integration', () => {
       )
       expect(
         ids.map((id) => (id ? store.getWidget(id)?.name : undefined))
-      ).toEqual(['duplicate', 'duplicate', 'duplicate#1'])
+      ).toEqual(['duplicate', 'duplicate#2', 'duplicate#1'])
       expect(node.widgets.map(({ name }) => name).reverse()).toEqual([
         'duplicate',
-        'duplicate',
+        'duplicate#2',
         'duplicate#1'
       ])
     })

--- a/src/lib/litegraph/src/widgets/BaseWidget.ts
+++ b/src/lib/litegraph/src/widgets/BaseWidget.ts
@@ -20,7 +20,7 @@ import type {
 import { deriveWidgetRenderState } from '@/lib/litegraph/src/utils/widget'
 import { useWidgetValueStore } from '@/stores/widgetValueStore'
 import type { WidgetId } from '@/types/widgetId'
-import { widgetId } from '@/types/widgetId'
+import { ensureUniqueWidgetNames, widgetId } from '@/types/widgetId'
 import type { WidgetState } from '@/types/widgetState'
 
 export interface DrawWidgetOptions {
@@ -45,33 +45,6 @@ export interface WidgetEventOptions {
   e: CanvasPointerEvent
   node: LGraphNode
   canvas: LGraphCanvas
-}
-
-const widgetStorageNames = new WeakMap<object, string>()
-
-function assignWidgetStorageNames(widgets: readonly IBaseWidget[]): void {
-  const reserved = new Set(widgets.map(({ name }) => name))
-  const used = new Set<string>()
-  const seen = new Set<IBaseWidget>()
-
-  for (const widget of widgets) {
-    if (seen.has(widget)) continue
-    seen.add(widget)
-    const assigned = widgetStorageNames.get(widget)
-    if (assigned) {
-      used.add(assigned)
-      continue
-    }
-
-    let storageName = widget.name
-    let index = 1
-    while (used.has(storageName)) {
-      do storageName = `${widget.name}#${index++}`
-      while (used.has(storageName) || reserved.has(storageName))
-    }
-    widgetStorageNames.set(widget, storageName)
-    used.add(storageName)
-  }
 }
 
 export abstract class BaseWidget<TWidget extends IBaseWidget = IBaseWidget>
@@ -123,15 +96,13 @@ export abstract class BaseWidget<TWidget extends IBaseWidget = IBaseWidget>
       return
     }
 
-    const previousStorageName = widgetStorageNames.get(this) ?? previous
     const moved = useWidgetValueStore().renameWidget(
-      widgetId(graphId, nodeId, previousStorageName),
+      widgetId(graphId, nodeId, previous),
       widgetId(graphId, nodeId, value)
     )
     if (!moved) return
 
     this._name = value
-    widgetStorageNames.set(this, value)
     this._state = moved
   }
 
@@ -194,8 +165,8 @@ export abstract class BaseWidget<TWidget extends IBaseWidget = IBaseWidget>
     const graphId = this.node.graph?.rootGraph.id
     const nodeId = this._state.nodeId
     if (!graphId || nodeId === undefined) return undefined
-    assignWidgetStorageNames(this.node.widgets ?? [this])
-    return widgetId(graphId, nodeId, widgetStorageNames.get(this) ?? this.name)
+    if (!ensureUniqueWidgetNames(this.node.widgets ?? [this])) return undefined
+    return widgetId(graphId, nodeId, this.name)
   }
 
   /**
@@ -205,11 +176,10 @@ export abstract class BaseWidget<TWidget extends IBaseWidget = IBaseWidget>
   setNodeId(nodeId: NodeId): void {
     const graphId = this.node.graph?.rootGraph.id
     if (!graphId) return
-    assignWidgetStorageNames(this.node.widgets ?? [this])
-    const storageName = widgetStorageNames.get(this) ?? this.name
+    if (!ensureUniqueWidgetNames(this.node.widgets ?? [this])) return
 
     const registered = useWidgetValueStore().registerWidget(
-      widgetId(graphId, nodeId, storageName),
+      widgetId(graphId, nodeId, this.name),
       {
         disabled: this.disabled,
         label: this.label,


### PR DESCRIPTION
## Summary

Addresses the remaining review findings on #16235 by removing two hidden state mechanisms and restoring one source of truth for each behavior.

## Reasoning

#16235 added a private widget-name alias to preserve duplicate public names. It also retained rejected link endpoint writes so a later setter could complete them. Both mechanisms made behavior depend on state that callers and other subsystems could not observe. The alias disagreed with rendering and serialization. The retained endpoint patch made an unrelated future write replay an earlier failure.

This PR removes both mechanisms. Code that changes multiple endpoint fields now states that intent with one atomic operation. Widget registration returns to the existing canonical-name contract. The other two fixes narrow temporary state and disconnect behavior to their intended lifetimes and targets.

## Design invariants

1. **One widget identity.** `WidgetId` is `graphId:nodeId:name`, so widget names are unique within a node. Registration, rendering, restoration, and named serialization use that same name. `label` remains the display value. Duplicate names receive deterministic `#N` suffixes.
2. **Restoration lasts only for configuration.** `configure()` installs restoration before existing widgets and `onConfigure` consume it. A `finally` block clears it before `configure()` returns, including when an extension callback throws. Widgets added later start with their declared defaults.
3. **Failed mutations have no future effect.** A rejected endpoint setter leaves the link unchanged and stores nothing. A node-and-slot move uses `updateEndpoints()` so the link store validates and applies the complete destination once.
4. **Targeted disconnects affect only the target.** `disconnectOutput(slot, target)` removes regular links to that target. Output-side floating links have no target and remain attached. `disconnectOutput(slot)` still removes both regular and floating links.

## Changes

- Delete `widgetStorageNames` and reuse `ensureUniqueWidgetNames()`.
- Delete `pendingEndpointPatches` and migrate paired first-party writes to `LLink.updateEndpoints()`.
- Clear widget restoration after `onConfigure` with `finally`.
- Skip floating-link cleanup during targeted output disconnects.

## Compatibility

Extensions that create duplicate widget names now observe deterministic suffixes such as `name#1`. This restores the documented `WidgetId` invariant and prevents duplicate renderer keys and named-value collisions.

Individual legacy endpoint setters remain non-throwing. Callers that need to change both the node and slot must use the atomic operation instead of relying on a failed write being replayed later.

## Test plan

- Test-only commit reproduces all four regressions: 7 failures and 94 passes.
- Fix commit: 8 focused files and 285 tests pass.
- `pnpm typecheck`
- `pnpm lint` with 0 errors and existing warnings only
- `pnpm format:check`
- `pnpm knip`
- Fallow diff audit passes with no introduced findings