### PR TITLE
fix: preserve legacy widget visibility mutations

### DIFF
--- a/browser_tests/tests/legacyDoNotReplicate/legacyWidgetVisibilityMutation.spec.ts
+++ b/browser_tests/tests/legacyDoNotReplicate/legacyWidgetVisibilityMutation.spec.ts
@@ -1,0 +1,62 @@
+import {
+  comfyExpect as expect,
+  comfyPageFixture as test
+} from '@e2e/fixtures/ComfyPage'
+
+test.describe(
+  'Legacy widget visibility mutation',
+  { tag: ['@vue-nodes', '@widget'] },
+  () => {
+    test.beforeEach(async ({ comfyPage }) => {
+      await comfyPage.workflow.loadWorkflow('nodes/single_ksampler')
+    })
+
+    test('keeps widget.hidden reactive without dropping its serialized value', async ({
+      comfyPage
+    }) => {
+      const widget = comfyPage.vueNodes.getWidgetByName('KSampler', 'steps')
+      await expect(widget).toBeVisible()
+
+      await comfyPage.page.evaluate(() => {
+        const node = window.app!.graph.nodes.find(
+          (candidate) => candidate.type === 'KSampler'
+        )
+        const widget = node?.widgets?.find(
+          (candidate) => candidate.name === 'steps'
+        )
+        if (!widget) throw new Error('KSampler steps widget not found')
+
+        widget.value = 37
+        widget.hidden = true
+      })
+      await comfyPage.nextFrame()
+
+      await expect(widget).toBeHidden()
+      await expect
+        .poll(() =>
+          comfyPage.page.evaluate(() => {
+            const node = window.app!.graph.nodes.find(
+              (candidate) => candidate.type === 'KSampler'
+            )
+            return node?.serialize().widgets_values_named?.steps
+          })
+        )
+        .toBe(37)
+
+      await comfyPage.page.evaluate(() => {
+        const node = window.app!.graph.nodes.find(
+          (candidate) => candidate.type === 'KSampler'
+        )
+        const widget = node?.widgets?.find(
+          (candidate) => candidate.name === 'steps'
+        )
+        if (!widget) throw new Error('KSampler steps widget not found')
+
+        widget.hidden = false
+      })
+      await comfyPage.nextFrame()
+
+      await expect(widget).toBeVisible()
+    })
+  }
+)

--- a/src/lib/litegraph/src/widgets/BaseWidget.test.ts
+++ b/src/lib/litegraph/src/widgets/BaseWidget.test.ts
@@ -224,6 +224,26 @@ describe('BaseWidget store integration', () => {
       ).toBe('number-custom')
     })
 
+    it('registers replaced options after graph attachment', () => {
+      const detachedNode = new LGraphNode('DetachedNode')
+      const widget = detachedNode.addWidget(
+        'combo',
+        'resolution',
+        'initial',
+        null,
+        { values: ['initial'] }
+      )
+      widget.hidden = true
+      widget.options = { values: ['replacement'] }
+
+      graph.add(detachedNode)
+
+      expect(
+        store.getWidget(widgetId(graph.id, detachedNode.id, 'resolution'))
+          ?.options
+      ).toEqual({ values: ['replacement'], hidden: true })
+    })
+
     it('registers duplicate widget names under distinct ids', () => {
       const first = createTestWidget(node, { name: 'duplicate' })
       const second = createTestWidget(node, { name: 'duplicate' })

--- a/src/lib/litegraph/src/widgets/BaseWidget.test.ts
+++ b/src/lib/litegraph/src/widgets/BaseWidget.test.ts
@@ -116,8 +116,13 @@ describe('BaseWidget store integration', () => {
     })
 
     it('writes to store when registered', () => {
-      const widget = createTestWidget(node, { name: 'writeWidget' })
-      widget.setNodeId(toNodeId(1))
+      const widget = node.addWidget(
+        'number',
+        'writeWidget',
+        42,
+        () => undefined,
+        {}
+      )
 
       widget.label = 'Updated Label'
       widget.hidden = true
@@ -128,9 +133,13 @@ describe('BaseWidget store integration', () => {
         widgetId(graph.id, toNodeId(1), 'writeWidget')
       )
       expect(state?.label).toBe('Updated Label')
+      expect(state?.options.hidden).toBe(true)
       expect(state?.disabled).toBe(true)
 
-      expect(widget.hidden).toBe(true)
+      widget.hidden = false
+
+      expect(state?.options.hidden).toBe(false)
+      expect(widget.hidden).toBe(false)
       expect(widget.advanced).toBe(true)
     })
 
@@ -173,7 +182,7 @@ describe('BaseWidget store integration', () => {
       expect(state?.value).toBe(100)
       expect(state?.label).toBe('Auto Label')
       expect(state?.disabled).toBe(true)
-      expect(state?.options).toEqual({ min: 0, max: 100 })
+      expect(state?.options).toEqual({ min: 0, max: 100, hidden: true })
 
       expect(widget.hidden).toBe(true)
       expect(widget.advanced).toBe(true)

--- a/src/lib/litegraph/src/widgets/BaseWidget.ts
+++ b/src/lib/litegraph/src/widgets/BaseWidget.ts
@@ -124,7 +124,14 @@ export abstract class BaseWidget<TWidget extends IBaseWidget = IBaseWidget>
     this._state.label = value
   }
 
-  hidden?: boolean
+  get hidden(): boolean | undefined {
+    return (this._state?.options ?? this.options).hidden
+  }
+  set hidden(value: boolean | undefined) {
+    const options = this._state?.options ?? this.options
+    options.hidden = value
+  }
+
   advanced?: boolean
 
   get disabled(): boolean | undefined {

--- a/src/lib/litegraph/src/widgets/BaseWidget.ts
+++ b/src/lib/litegraph/src/widgets/BaseWidget.ts
@@ -14,8 +14,7 @@ import { litegraph } from '@/lib/litegraph/src/litegraphInstance'
 import type { CanvasPointerEvent } from '@/lib/litegraph/src/types/events'
 import type {
   IBaseWidget,
-  NodeBindable,
-  TWidgetType
+  NodeBindable
 } from '@/lib/litegraph/src/types/widgets'
 import { deriveWidgetRenderState } from '@/lib/litegraph/src/utils/widget'
 import { useWidgetValueStore } from '@/stores/widgetValueStore'
@@ -40,6 +39,12 @@ interface DrawTruncatingTextOptions extends DrawWidgetOptions {
   /** The amount of padding to add to the right of the text. */
   rightPadding?: number
 }
+
+type BaseWidgetState<TWidget extends IBaseWidget> = WidgetState<
+  TWidget['value'],
+  TWidget['type'],
+  TWidget['options']
+>
 
 export interface WidgetEventOptions {
   e: CanvasPointerEvent
@@ -107,7 +112,7 @@ export abstract class BaseWidget<TWidget extends IBaseWidget = IBaseWidget>
   }
 
   get options(): TWidget['options'] {
-    return this._state.options as TWidget['options']
+    return this._state.options
   }
   set options(value: TWidget['options']) {
     const hidden = this._state.options.hidden
@@ -122,8 +127,8 @@ export abstract class BaseWidget<TWidget extends IBaseWidget = IBaseWidget>
   computedDisabled?: boolean
   tooltip?: string
 
-  private _state: Omit<WidgetState, 'nodeId'> &
-    Partial<Pick<WidgetState, 'nodeId'>>
+  private _state: Omit<BaseWidgetState<TWidget>, 'nodeId'> &
+    Partial<Pick<BaseWidgetState<TWidget>, 'nodeId'>>
 
   get label(): string | undefined {
     return this._state.label
@@ -169,7 +174,7 @@ export abstract class BaseWidget<TWidget extends IBaseWidget = IBaseWidget>
   ): boolean
 
   get value(): TWidget['value'] {
-    return this._state.value as TWidget['value']
+    return this._state.value
   }
   set value(value: TWidget['value']) {
     this._state.value = value
@@ -253,7 +258,7 @@ export abstract class BaseWidget<TWidget extends IBaseWidget = IBaseWidget>
 
     this._state = {
       name: this.name,
-      type: this.type as TWidgetType,
+      type: this.type,
       value,
       label,
       disabled: disabled ?? false,

--- a/src/lib/litegraph/src/widgets/BaseWidget.ts
+++ b/src/lib/litegraph/src/widgets/BaseWidget.ts
@@ -125,11 +125,10 @@ export abstract class BaseWidget<TWidget extends IBaseWidget = IBaseWidget>
   }
 
   get hidden(): boolean | undefined {
-    return (this._state?.options ?? this.options).hidden
+    return this._state.options.hidden
   }
   set hidden(value: boolean | undefined) {
-    const options = this._state?.options ?? this.options
-    options.hidden = value
+    this._state.options.hidden = value
   }
 
   advanced?: boolean
@@ -191,7 +190,7 @@ export abstract class BaseWidget<TWidget extends IBaseWidget = IBaseWidget>
         disabled: this.disabled,
         label: this.label,
         name: this.name,
-        options: this.options,
+        options: this._state.options,
         serialize: this.serialize,
         type: this.type,
         value: this.value,
@@ -238,6 +237,7 @@ export abstract class BaseWidget<TWidget extends IBaseWidget = IBaseWidget>
       // @ts-expect-error Prevent naming conflicts with custom nodes.
       labelBaseline,
       label,
+      hidden,
       disabled,
       value,
       linkedWidgets,
@@ -253,9 +253,10 @@ export abstract class BaseWidget<TWidget extends IBaseWidget = IBaseWidget>
       label,
       disabled: disabled ?? false,
       serialize: this.serialize,
-      options: this.options,
+      options: this.options ?? {},
       y: this.y
     }
+    if (hidden !== undefined) this.hidden = hidden
   }
 
   getOutlineColor() {

--- a/src/lib/litegraph/src/widgets/BaseWidget.ts
+++ b/src/lib/litegraph/src/widgets/BaseWidget.ts
@@ -106,7 +106,15 @@ export abstract class BaseWidget<TWidget extends IBaseWidget = IBaseWidget>
     this._state = moved
   }
 
-  options: TWidget['options']
+  get options(): TWidget['options'] {
+    return this._state.options as TWidget['options']
+  }
+  set options(value: TWidget['options']) {
+    const hidden = this._state.options.hidden
+    this._state.options = value ?? {}
+    if (hidden !== undefined) this._state.options.hidden = hidden
+  }
+
   type: TWidget['type']
   y: number = 0
   last_y?: number
@@ -207,11 +215,7 @@ export abstract class BaseWidget<TWidget extends IBaseWidget = IBaseWidget>
     // Private fields
     this._node = node ?? widget.node
 
-    // The set and get functions for DOM widget values are hacked on to the options object;
-    // attempting to set value before options will throw.
-    // https://github.com/Comfy-Org/ComfyUI_frontend/blob/df86da3d672628a452baed3df3347a52c0c8d378/src/scripts/domWidget.ts#L125
     this.name = widget.name
-    this.options = widget.options
     this.type = widget.type
 
     // `node` has no setter - Object.assign will throw.
@@ -236,6 +240,7 @@ export abstract class BaseWidget<TWidget extends IBaseWidget = IBaseWidget>
       displayValue,
       // @ts-expect-error Prevent naming conflicts with custom nodes.
       labelBaseline,
+      options,
       label,
       hidden,
       disabled,
@@ -253,7 +258,7 @@ export abstract class BaseWidget<TWidget extends IBaseWidget = IBaseWidget>
       label,
       disabled: disabled ?? false,
       serialize: this.serialize,
-      options: this.options ?? {},
+      options: options ?? {},
       y: this.y
     }
     if (hidden !== undefined) this.hidden = hidden

--- a/src/renderer/extensions/vueNodes/components/WidgetGrid.test.ts
+++ b/src/renderer/extensions/vueNodes/components/WidgetGrid.test.ts
@@ -45,19 +45,20 @@ function widget(name: string, type: string, index: number): WidgetGridItem {
 }
 
 describe('WidgetGrid', () => {
-  it('renders converted widgets as input sockets without controls', () => {
+  it('renders hidden converted widgets as input sockets without controls', () => {
     render(WidgetGrid, {
       props: {
         nodeId: toNodeId(1),
         nodeType: 'TestNode',
         processedWidgets: [
-          widget('seed', 'converted-widget', 0),
+          { ...widget('seed', 'converted-widget', 0), visible: false },
           {
             ...widget('control_after_generate', 'converted-widget:seed', 1),
             slotMetadata: undefined
           },
           widget('replacement', 'number', 2),
-          widget('converted-widget-picker', 'converted-widget-picker', 3)
+          widget('converted-widget-picker', 'converted-widget-picker', 3),
+          { ...widget('hidden', 'number', 4), visible: false }
         ]
       },
       global: {

--- a/src/renderer/extensions/vueNodes/components/WidgetGrid.vue
+++ b/src/renderer/extensions/vueNodes/components/WidgetGrid.vue
@@ -96,7 +96,7 @@ const isConvertedWidget = (widget: WidgetGridItem) =>
   isConvertedWidgetType(widget.simplified.type)
 
 const shouldRenderRow = (widget: WidgetGridItem) =>
-  widget.visible && (!isConvertedWidget(widget) || !!widget.slotMetadata)
+  isConvertedWidget(widget) ? !!widget.slotMetadata : widget.visible
 
 const {
   processedWidgets,

--- a/src/renderer/extensions/vueNodes/composables/processedWidgetRenderModel.ts
+++ b/src/renderer/extensions/vueNodes/composables/processedWidgetRenderModel.ts
@@ -441,8 +441,10 @@ function processWidget(
     widgetId: id,
     renderKey: `${id}:${type}`,
     vueComponent:
-      getComponent(type) ||
-      (renderState?.isDOMWidget ? WidgetDOM : WidgetLegacy),
+      !renderState?.isDOMWidget && typeof liveWidget?.draw === 'function'
+        ? WidgetLegacy
+        : getComponent(type) ||
+          (renderState?.isDOMWidget ? WidgetDOM : WidgetLegacy),
     simplified,
     visible,
     updateHandler,

--- a/src/renderer/extensions/vueNodes/composables/useProcessedWidgets.test.ts
+++ b/src/renderer/extensions/vueNodes/composables/useProcessedWidgets.test.ts
@@ -466,6 +466,23 @@ describe('computeProcessedWidgets', () => {
     expect(result).toEqual([])
   })
 
+  it('uses the legacy renderer for a customized draw method', () => {
+    const id = widgetId(GRAPH_ID, toNodeId(1), 'stack_data')
+    registerWidgetState(id, { type: 'text' })
+    const widget = createMockWidget({
+      widgetId: id,
+      name: 'stack_data',
+      type: 'text',
+      computeSize: () => [0, -4],
+      draw: () => undefined
+    })
+    const { graph } = createGraphWithNode([widget])
+
+    const [result] = processWidgets({ widgetIds: [id], rootGraph: graph })
+
+    expect(result.vueComponent).toBe(WidgetLegacy)
+  })
+
   it('uses widget state nodeId for simplified widget locator', () => {
     const subgraphId = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890'
     const id = widgetId(GRAPH_ID, toNodeId('inner-node'), 'text')

--- a/src/scripts/domWidget.ts
+++ b/src/scripts/domWidget.ts
@@ -122,7 +122,6 @@ abstract class BaseDOMWidgetImpl<V extends object | string>
   implements BaseDOMWidget<V>
 {
   static readonly DEFAULT_MARGIN = 10
-  declare readonly options: DOMWidgetOptions<V>
   declare callback?: (value: V) => void
 
   readonly id: string

--- a/src/stores/widgetValueStore.ts
+++ b/src/stores/widgetValueStore.ts
@@ -9,6 +9,7 @@ import type { WidgetId } from '@/types/widgetId'
 import type { WidgetValue } from '@/types/simplifiedWidget'
 import type { WidgetState, WidgetStateInit } from '@/types/widgetState'
 import type { RemoteMutationContext } from '@/types/graphMutationContext'
+import type { IWidgetOptions } from '@/lib/litegraph/src/types/widgets'
 
 export interface WidgetRenderState {
   advanced?: boolean
@@ -138,12 +139,16 @@ export const useWidgetValueStore = defineStore('widgetValue', () => {
     if (order.length === 0) graphOrders.delete(nodeId)
   }
 
-  function registerWidget<TValue extends WidgetValue = WidgetValue>(
+  function registerWidget<
+    TValue extends WidgetValue = WidgetValue,
+    TType extends string = string,
+    TOptions extends IWidgetOptions = IWidgetOptions
+  >(
     widgetId: WidgetId,
-    init: WidgetStateInit<TValue>,
+    init: WidgetStateInit<TValue, TType, TOptions>,
     renderState: WidgetRenderState = {},
     _context?: RemoteMutationContext
-  ): WidgetState<TValue> | undefined {
+  ): WidgetState<TValue, TType, TOptions> | undefined {
     if (!isWidgetId(widgetId)) {
       console.warn(
         'widgetValueStore.registerWidget: ignoring un-keyable widget id',
@@ -173,10 +178,10 @@ export const useWidgetValueStore = defineStore('widgetValue', () => {
         y: init.y ?? existing.y
       })
       appendNodeWidgetOrder(widgetId)
-      return existing as WidgetState<TValue>
+      return existing as WidgetState<TValue, TType, TOptions>
     }
 
-    const state: WidgetState<TValue> = {
+    const state: WidgetState<TValue, TType, TOptions> = {
       ...init,
       nodeId,
       name: init.name ?? storageName,
@@ -185,7 +190,7 @@ export const useWidgetValueStore = defineStore('widgetValue', () => {
     const widgetStates = getGraphWidgetStates(graphId)
     widgetStates.set(widgetId, state)
     appendNodeWidgetOrder(widgetId)
-    return widgetStates.get(widgetId) as WidgetState<TValue>
+    return widgetStates.get(widgetId) as WidgetState<TValue, TType, TOptions>
   }
 
   function registerWidgetRenderState(

--- a/src/types/widgetState.ts
+++ b/src/types/widgetState.ts
@@ -23,7 +23,11 @@ export interface WidgetState<
   nodeId: NodeId
 }
 
-export type WidgetStateInit<TValue = WidgetValue> = Omit<
-  WidgetState<TValue>,
-  'nodeId' | 'name' | 'y'
-> & { name?: string; y?: number }
+export type WidgetStateInit<
+  TValue = WidgetValue,
+  TType extends string = string,
+  TOptions extends IWidgetOptions = IWidgetOptions
+> = Omit<WidgetState<TValue, TType, TOptions>, 'nodeId' | 'name' | 'y'> & {
+  name?: string
+  y?: number
+}


### PR DESCRIPTION
## Summary

Restore legacy custom-node widget hiding behavior in Vue Nodes while preserving hidden widget values.

## Changes

- **What**: Synchronize `widget.hidden` with reactive widget state, preserve extension-provided custom draw and sizing behavior through the legacy renderer, and add unit plus Playwright characterization coverage.

## Review Focus

Review the `BaseWidget.hidden` compatibility boundary and the non-DOM custom-draw fallback. Hidden widgets remain part of serialization.