### PR TITLE
feat: redesign developer platform beta pages

### DIFF
--- a/apps/website/src/components/home/DeveloperPlatformSection.test.ts
+++ b/apps/website/src/components/home/DeveloperPlatformSection.test.ts
@@ -2,7 +2,7 @@
 import { render, screen } from '@testing-library/vue'
 import { describe, expect, it } from 'vitest'
 
-import { externalLinks } from '../../config/routes'
+import { externalLinks, getRoutes } from '../../config/routes'
 import { t } from '../../i18n/translations'
 import DeveloperPlatformSection from './DeveloperPlatformSection.vue'
 
@@ -21,8 +21,12 @@ describe('DeveloperPlatformSection', () => {
     const hrefOf = (name: string) =>
       screen.getByRole('link', { name }).getAttribute('href')
     expect(hrefOf(t('platform.hero.getStarted', 'en'))).toBe(
-      externalLinks.platform
+      getRoutes('en').platform
     )
+    const getStartedLink = screen.getByRole('link', {
+      name: t('platform.hero.getStarted', 'en')
+    })
+    expect(getStartedLink.getAttribute('target')).toBeNull()
     expect(hrefOf(t('platform.hero.readDocs', 'en'))).toBe(
       externalLinks.docsPlatform
     )
@@ -37,9 +41,11 @@ describe('DeveloperPlatformSection', () => {
       })
     ).toBeTruthy()
     expect(
-      screen.getByRole('link', {
-        name: t('platform.hero.getStarted', 'zh-CN')
-      })
-    ).toBeTruthy()
+      screen
+        .getByRole('link', {
+          name: t('platform.hero.getStarted', 'zh-CN')
+        })
+        .getAttribute('href')
+    ).toBe(getRoutes('zh-CN').platform)
   })
 })

--- a/apps/website/src/components/home/DeveloperPlatformSection.test.ts
+++ b/apps/website/src/components/home/DeveloperPlatformSection.test.ts
@@ -2,40 +2,44 @@
 import { render, screen } from '@testing-library/vue'
 import { describe, expect, it } from 'vitest'
 
+import { externalLinks } from '../../config/routes'
 import { t } from '../../i18n/translations'
 import DeveloperPlatformSection from './DeveloperPlatformSection.vue'
 
 describe('DeveloperPlatformSection', () => {
-  it('links the three products and the landing page', () => {
+  it('reuses the Developer Platform closing callout', () => {
     render(DeveloperPlatformSection, { props: { locale: 'en' } })
 
     expect(
-      screen.getByRole('heading', { name: t('home.platform.heading', 'en') })
+      screen.getByRole('heading', {
+        name: `${t('home.platform.heading', 'en')} ${t('platform.hero.badge', 'en')} ${t('nav.badgeBeta', 'en')}`
+      })
     ).toBeTruthy()
     expect(screen.getByText(t('home.platform.body', 'en'))).toBeTruthy()
+    expect(screen.getByText(t('platform.hero.badge', 'en'))).toBeTruthy()
 
     const hrefOf = (name: string) =>
       screen.getByRole('link', { name }).getAttribute('href')
-    expect(hrefOf(t('platform.products.serverless.title', 'en'))).toBe(
-      '/platform/serverless'
+    expect(hrefOf(t('platform.hero.getStarted', 'en'))).toBe(
+      externalLinks.platform
     )
-    expect(hrefOf(t('platform.products.models.title', 'en'))).toBe(
-      '/platform/models'
+    expect(hrefOf(t('platform.hero.readDocs', 'en'))).toBe(
+      externalLinks.docsPlatform
     )
-    expect(hrefOf(t('platform.products.builder.title', 'en'))).toBe(
-      '/platform/builder'
-    )
-    expect(hrefOf('Explore the Developer Platform')).toBe('/platform')
   })
 
-  it('localizes links for zh-CN', () => {
+  it('passes the Chinese locale through to the shared callout', () => {
     render(DeveloperPlatformSection, { props: { locale: 'zh-CN' } })
 
     expect(
-      screen.getByRole('link', { name: '了解开发者平台' }).getAttribute('href')
-    ).toBe('/zh-CN/platform')
+      screen.getByRole('heading', {
+        name: `${t('home.platform.heading', 'zh-CN')} ${t('platform.hero.badge', 'zh-CN')} ${t('nav.badgeBeta', 'zh-CN')}`
+      })
+    ).toBeTruthy()
     expect(
-      screen.getByRole('link', { name: 'Builder' }).getAttribute('href')
-    ).toBe('/zh-CN/platform/builder')
+      screen.getByRole('link', {
+        name: t('platform.hero.getStarted', 'zh-CN')
+      })
+    ).toBeTruthy()
   })
 })

--- a/apps/website/src/components/home/DeveloperPlatformSection.test.ts
+++ b/apps/website/src/components/home/DeveloperPlatformSection.test.ts
@@ -12,7 +12,7 @@ describe('DeveloperPlatformSection', () => {
 
     expect(
       screen.getByRole('heading', {
-        name: `${t('home.platform.heading', 'en')} ${t('platform.hero.badge', 'en')} ${t('nav.badgeBeta', 'en')}`
+        name: `${t('platform.hero.badge', 'en')} ${t('nav.badgeBeta', 'en')}`
       })
     ).toBeTruthy()
     expect(screen.getByText(t('home.platform.body', 'en'))).toBeTruthy()
@@ -33,7 +33,7 @@ describe('DeveloperPlatformSection', () => {
 
     expect(
       screen.getByRole('heading', {
-        name: `${t('home.platform.heading', 'zh-CN')} ${t('platform.hero.badge', 'zh-CN')} ${t('nav.badgeBeta', 'zh-CN')}`
+        name: `${t('platform.hero.badge', 'zh-CN')} ${t('nav.badgeBeta', 'zh-CN')}`
       })
     ).toBeTruthy()
     expect(

--- a/apps/website/src/components/home/DeveloperPlatformSection.test.ts
+++ b/apps/website/src/components/home/DeveloperPlatformSection.test.ts
@@ -9,6 +9,11 @@ describe('DeveloperPlatformSection', () => {
   it('links the three products and the landing page', () => {
     render(DeveloperPlatformSection, { props: { locale: 'en' } })
 
+    expect(
+      screen.getByRole('heading', { name: t('home.platform.heading', 'en') })
+    ).toBeTruthy()
+    expect(screen.getByText(t('home.platform.body', 'en'))).toBeTruthy()
+
     const hrefOf = (name: string) =>
       screen.getByRole('link', { name }).getAttribute('href')
     expect(hrefOf(t('platform.products.serverless.title', 'en'))).toBe(

--- a/apps/website/src/components/home/DeveloperPlatformSection.vue
+++ b/apps/website/src/components/home/DeveloperPlatformSection.vue
@@ -10,7 +10,7 @@ const { locale = 'en' } = defineProps<{ locale?: Locale }>()
   <ClosingCtaSection
     :locale="locale"
     visual="columns"
-    :heading-lead="t('home.platform.heading', locale)"
+    badge-only
     :subtitle="t('home.platform.body', locale)"
   />
 </template>

--- a/apps/website/src/components/home/DeveloperPlatformSection.vue
+++ b/apps/website/src/components/home/DeveloperPlatformSection.vue
@@ -1,90 +1,16 @@
 <script setup lang="ts">
-import Badge from '../ui/badge/Badge.vue'
-import Button from '../ui/button/Button.vue'
-import { externalLinks, getRoutes } from '../../config/routes'
 import type { Locale } from '../../i18n/translations'
 import { t } from '../../i18n/translations'
-import DeployTerminal from '../../templates/platform/DeployTerminal.vue'
+import ClosingCtaSection from '../../templates/platform/ClosingCtaSection.vue'
 
 const { locale = 'en' } = defineProps<{ locale?: Locale }>()
-
-const routes = getRoutes(locale)
-
-const products = [
-  {
-    label: t('platform.products.serverless.title', locale),
-    href: routes.platformServerless
-  },
-  {
-    label: t('platform.products.models.title', locale),
-    href: routes.platformModels
-  },
-  {
-    label: t('platform.products.builder.title', locale),
-    href: routes.platformBuilder
-  }
-]
 </script>
 
 <template>
-  <section class="max-w-9xl mx-auto px-6 py-14 md:py-20 lg:px-12">
-    <div
-      class="bg-transparency-white-t4 lg:rounded-5xl grid grid-cols-1 gap-6 rounded-4xl p-2 lg:grid-cols-2 lg:gap-8"
-    >
-      <div class="flex flex-col justify-center gap-5 p-6 lg:p-10">
-        <div class="flex items-center gap-3">
-          <p
-            class="text-primary-comfy-yellow text-sm font-bold tracking-[0.7px] uppercase"
-          >
-            {{ t('home.platform.eyebrow', locale) }}
-          </p>
-          <Badge variant="accent" size="xs">
-            {{ t('nav.badgeBeta', locale) }}
-          </Badge>
-        </div>
-
-        <h2
-          class="text-3xl leading-[125%] font-light text-primary-comfy-canvas lg:text-4xl"
-        >
-          {{ t('home.platform.heading', locale) }}
-        </h2>
-
-        <p
-          class="max-w-xl text-base/relaxed font-light text-primary-comfy-canvas"
-        >
-          {{ t('home.platform.body', locale) }}
-        </p>
-
-        <ul class="flex flex-wrap gap-2">
-          <li v-for="product in products" :key="product.href">
-            <a
-              :href="product.href"
-              class="focus-visible:ring-primary-comfy-yellow/50 inline-flex items-center rounded-full border border-white/15 bg-white/4 px-3.5 py-1.5 font-mono text-xs text-primary-comfy-canvas transition-colors hover:border-white/30 hover:bg-white/8 focus-visible:ring-2 focus-visible:outline-none"
-            >
-              {{ product.label }}
-            </a>
-          </li>
-        </ul>
-
-        <div class="mt-2 flex flex-wrap gap-3 xl:flex-nowrap">
-          <Button as="a" :href="routes.platform" class="whitespace-nowrap">
-            {{ t('home.platform.cta', locale) }}
-          </Button>
-          <Button
-            as="a"
-            :href="externalLinks.docsPlatform"
-            target="_blank"
-            rel="noopener noreferrer"
-            variant="outline"
-          >
-            {{ t('home.platform.docs', locale) }}
-          </Button>
-        </div>
-      </div>
-
-      <div class="flex items-center p-2 lg:p-4">
-        <DeployTerminal :locale="locale" class="w-full" />
-      </div>
-    </div>
-  </section>
+  <ClosingCtaSection
+    :locale="locale"
+    visual="columns"
+    :heading-lead="t('home.platform.heading', locale)"
+    :subtitle="t('home.platform.body', locale)"
+  />
 </template>

--- a/apps/website/src/components/home/DeveloperPlatformSection.vue
+++ b/apps/website/src/components/home/DeveloperPlatformSection.vue
@@ -1,9 +1,11 @@
 <script setup lang="ts">
 import type { Locale } from '../../i18n/translations'
 import { t } from '../../i18n/translations'
+import { getRoutes } from '../../config/routes'
 import ClosingCtaSection from '../../templates/platform/ClosingCtaSection.vue'
 
 const { locale = 'en' } = defineProps<{ locale?: Locale }>()
+const routes = getRoutes(locale)
 </script>
 
 <template>
@@ -11,6 +13,7 @@ const { locale = 'en' } = defineProps<{ locale?: Locale }>()
     :locale="locale"
     visual="columns"
     badge-only
+    :primary-href="routes.platform"
     :subtitle="t('home.platform.body', locale)"
   />
 </template>

--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -7635,15 +7635,6 @@ const translations = {
     'zh-CN':
       '36+ 家合作伙伴——Nano Banana、Veo、Kling、Seedance、Flux、Sora、GPT Image、Runway、Luma、ElevenLabs 等——都在稳定的模型 ID 之后。'
   },
-  'platform.modelsFeatures.2.title': {
-    en: 'Never dropped',
-    'zh-CN': '永不丢弃'
-  },
-  'platform.modelsFeatures.2.description': {
-    en: 'Queued requests never die with a 429. They hold a queue position against your workspace concurrency and start the moment a slot frees.',
-    'zh-CN':
-      '排队中的请求绝不会以 429 告终。它们在你工作区的并发额度内保留队列位置，一有空位立刻开始。'
-  },
   'platform.modelsFeatures.3.title': {
     en: 'One credit pool',
     'zh-CN': '一个积分池'
@@ -7652,14 +7643,6 @@ const translations = {
     en: 'Pay per use from the same balance that powers Cloud workflows and serverless GPUs. No subscription floor.',
     'zh-CN':
       '按用量付费，与 Cloud 工作流和无服务器 GPU 共用同一余额。没有订阅门槛。'
-  },
-  'platform.modelsFeatures.4.title': {
-    en: 'Costs you can attribute',
-    'zh-CN': '可归因的成本'
-  },
-  'platform.modelsFeatures.4.description': {
-    en: 'Every completed request returns the credits it consumed. Failed provider calls are never billed.',
-    'zh-CN': '每个完成的请求都会返回其消耗的积分。失败的调用绝不计费。'
   },
   'platform.modelsFeatures.5.title': {
     en: 'Schemas to generate against',

--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -7622,6 +7622,58 @@ const translations = {
     'zh-CN':
       '调用合作伙伴模型——Seedance、Minimax H3、Nano Banana、GPT-Image-2——用一个 API 密钥即可访问最新模型。'
   },
+  'platform.modelsFeatures.1.title': {
+    en: 'Every frontier media model',
+    'zh-CN': '所有前沿媒体模型'
+  },
+  'platform.modelsFeatures.1.description': {
+    en: '36+ partner providers — Nano Banana, Veo, Kling, Seedance, Flux, Sora, GPT Image, Runway, Luma, ElevenLabs and more — behind stable model IDs.',
+    'zh-CN':
+      '36+ 家合作伙伴——Nano Banana、Veo、Kling、Seedance、Flux、Sora、GPT Image、Runway、Luma、ElevenLabs 等——都在稳定的模型 ID 之后。'
+  },
+  'platform.modelsFeatures.2.title': {
+    en: 'Never dropped',
+    'zh-CN': '永不丢弃'
+  },
+  'platform.modelsFeatures.2.description': {
+    en: 'Queued requests never die with a 429. They hold a queue position against your workspace concurrency and start the moment a slot frees.',
+    'zh-CN':
+      '排队中的请求绝不会以 429 告终。它们在你工作区的并发额度内保留队列位置，一有空位立刻开始。'
+  },
+  'platform.modelsFeatures.3.title': {
+    en: 'One credit pool',
+    'zh-CN': '一个积分池'
+  },
+  'platform.modelsFeatures.3.description': {
+    en: 'Pay per use from the same balance that powers Cloud workflows and serverless GPUs. No subscription floor.',
+    'zh-CN':
+      '按用量付费，与 Cloud 工作流和无服务器 GPU 共用同一余额。没有订阅门槛。'
+  },
+  'platform.modelsFeatures.4.title': {
+    en: 'Costs you can attribute',
+    'zh-CN': '可归因的成本'
+  },
+  'platform.modelsFeatures.4.description': {
+    en: 'Every completed request returns the credits it consumed. Failed provider calls are never billed.',
+    'zh-CN': '每个完成的请求都会返回其消耗的积分。失败的调用绝不计费。'
+  },
+  'platform.modelsFeatures.5.title': {
+    en: 'Schemas to generate against',
+    'zh-CN': '可直接生成代码的 Schema'
+  },
+  'platform.modelsFeatures.5.description': {
+    en: 'Every model publishes its own OpenAPI document — the same one the server validates your call against.',
+    'zh-CN':
+      '每个模型都发布自己的 OpenAPI 文档——服务器校验你的调用时用的正是同一份。'
+  },
+  'platform.modelsFeatures.6.title': {
+    en: 'Cancel anytime',
+    'zh-CN': '随时取消'
+  },
+  'platform.modelsFeatures.6.description': {
+    en: 'A queued request cancels immediately and costs nothing; in-progress calls get a best-effort cancel.',
+    'zh-CN': '排队中的请求立即取消且不产生费用；进行中的调用会尽力取消。'
+  },
   'platform.examples.heading': {
     en: 'Built on the Developer Platform',
     'zh-CN': '基于开发者平台构建'

--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -8128,6 +8128,10 @@ const translations = {
   'platform.closing.headingLead': {
     en: 'Maximize scale and control on',
     'zh-CN': '将规模与控制力最大化'
+  },
+  'platform.closing.headingAfterBadge': {
+    en: 'Scale your custom nodes in your Comfy workflows in custom environments through serverless.',
+    'zh-CN': '通过 Serverless 在自定义环境中扩展你的 Comfy 工作流和自定义节点。'
   }
 } as const satisfies Record<string, Record<Locale, string>>
 

--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -7323,13 +7323,13 @@ const translations = {
     'zh-CN': '开发者平台'
   },
   'home.platform.heading': {
-    en: 'Deploy and scale ComfyUI workflows',
-    'zh-CN': '部署并扩展 ComfyUI 工作流'
+    en: 'Deploy and scale your Comfy workflows with Serverless',
+    'zh-CN': '使用 Serverless 部署并扩展你的 Comfy 工作流'
   },
   'home.platform.body': {
-    en: 'Package your workflow, deploy it to Serverless, and call every frontier model — behind one API key. The fastest way from ComfyUI workflow to production endpoint.',
+    en: 'Bring your custom nodes and custom environments, then scale from zero to millions of generations without managing GPUs.',
     'zh-CN':
-      '打包你的工作流，部署到 Serverless，并调用所有前沿模型——共用一个 API 密钥。从 ComfyUI 工作流到生产端点的最快路径。'
+      '带上你的自定义节点和自定义环境，从零扩展到数百万次生成，无需管理 GPU。'
   },
   'home.platform.cta': {
     en: 'Explore the Developer Platform',
@@ -7507,13 +7507,39 @@ const translations = {
     'zh-CN': 'SDK 是首选入口，纯 HTTP 同样可用。'
   },
   'platform.serverlessDeploy.heading': {
+    en: 'How it works',
+    'zh-CN': '工作原理'
+  },
+  'platform.serverlessDeploy.subtitle': {
+    en: 'Builder packages your ComfyUI workflow and environment into a reproducible build. Deploy that build to serverless and scale it on demand.',
+    'zh-CN':
+      'Builder 将你的 ComfyUI 工作流和环境打包成可复现的构建。将该构建部署到 Serverless，并按需扩展。'
+  },
+  'platform.serverlessDeploy.1.title': {
     en: 'Ship in minutes',
     'zh-CN': '几分钟内上线'
   },
-  'platform.serverlessDeploy.subtitle': {
-    en: 'Easily package up your existing ComfyUI environment — or a single workflow — and deploy to Serverless.',
+  'platform.serverlessDeploy.1.description': {
+    en: 'Start with an existing ComfyUI installation or a single workflow.',
+    'zh-CN': '从现有的 ComfyUI 安装或单个工作流开始。'
+  },
+  'platform.serverlessDeploy.2.title': {
+    en: 'Package the environment',
+    'zh-CN': '打包环境'
+  },
+  'platform.serverlessDeploy.2.description': {
+    en: 'Builder auto-resolves Python dependencies and packages custom nodes and models into one build.',
     'zh-CN':
-      '轻松打包你现有的 ComfyUI 环境——或单个工作流——并部署到 Serverless。'
+      'Builder 自动解析 Python 依赖，并将自定义节点和模型打包到一个构建中。'
+  },
+  'platform.serverlessDeploy.3.title': {
+    en: 'Deploy with confidence',
+    'zh-CN': '放心部署'
+  },
+  'platform.serverlessDeploy.3.description': {
+    en: 'Custom nodes are installed correctly, models are packaged correctly, and the workflow runs in the environment you tested.',
+    'zh-CN':
+      '正确安装自定义节点、正确打包模型，并在经过测试的环境中运行工作流。'
   },
   'platform.serverlessDeploy.tabInstall': {
     en: 'Start with your installation',
@@ -7528,9 +7554,8 @@ const translations = {
     'zh-CN': '为规模而生'
   },
   'platform.serverlessScale.subtitle': {
-    en: 'Deploy on the Developer Platform across thousands of GPUs — autoscaling, logs, and performance controls built in.',
-    'zh-CN':
-      '在开发者平台上跨数千块 GPU 部署——自动扩缩、日志和性能控制开箱即用。'
+    en: 'Deploy across thousands of GPUs with autoscaling, logs, and performance controls built in.',
+    'zh-CN': '跨数千块 GPU 部署，自动扩缩、日志和性能控制开箱即用。'
   },
   'platform.serverlessScale.1.title': {
     en: 'Autoscaling',
@@ -7562,9 +7587,9 @@ const translations = {
     'zh-CN': 'Serverless API'
   },
   'platform.products.serverless.description': {
-    en: "Scale from 0 to millions of generations on Comfy's serverless engine. No GPUs to configure, no cold starts — only pay for what you use.",
+    en: 'Deploy and scale your Comfy workflows with serverless. Bring custom nodes and custom environments, then scale from zero to millions of generations.',
     'zh-CN':
-      '在 Comfy 无服务器引擎上从 0 扩展到数百万次生成。无需配置 GPU，没有冷启动——只为实际用量付费。'
+      '使用 Serverless 部署并扩展你的 Comfy 工作流。带上自定义节点和自定义环境，从零扩展到数百万次生成。'
   },
   'platform.serverlessVisual.ariaLabel': {
     en: 'Animated diagram of a request lighting up RTX 6000 PRO, H100, and B200 GPU workers, with COMFYUI scrolling across the grid.',
@@ -7580,9 +7605,9 @@ const translations = {
     'zh-CN': 'Builder'
   },
   'platform.products.builder.description': {
-    en: 'Package your custom nodes, models, and pinned dependencies into an immutable build. Deploy builds on Serverless or to local workstations. Enterprises govern the fleet with the Managed Builds dashboard.',
+    en: 'Package custom nodes, models, and Python dependencies into a reproducible build. Run it on Comfy Desktop or deploy it to serverless.',
     'zh-CN':
-      '把你的自定义节点、模型和锁定依赖打包成一个不可变构建。构建可部署到 Serverless，也可部署到本地工作站。企业可通过托管构建仪表盘治理整个集群。'
+      '将自定义节点、模型和 Python 依赖打包成可复现的构建。在 Comfy Desktop 上运行，或部署到 Serverless。'
   },
   'platform.products.builder.enterpriseCta': {
     en: 'Enterprise: Managed Builds',
@@ -7954,93 +7979,26 @@ const translations = {
     en: 'Targeting the end of September 2026.',
     'zh-CN': '目标是 2026 年 9 月底。'
   },
-  // ── Serverless API subpage ────────────────────────────────────
-  // ── Router subpage ────────────────────────────────────────────
-  'platform.modelsFeatures.heading': {
-    en: 'One key, every frontier model',
-    'zh-CN': '一个密钥，所有前沿模型'
-  },
-  'platform.modelsFeatures.1.title': {
-    en: 'Every frontier media model',
-    'zh-CN': '所有前沿媒体模型'
-  },
-  'platform.modelsFeatures.1.description': {
-    en: '36+ partner providers — Nano Banana, Veo, Kling, Seedance, Flux, Sora, GPT Image, Runway, Luma, ElevenLabs and more — behind stable model IDs.',
-    'zh-CN':
-      '36+ 家合作伙伴——Nano Banana、Veo、Kling、Seedance、Flux、Sora、GPT Image、Runway、Luma、ElevenLabs 等——都在稳定的模型 ID 之后。'
-  },
-  'platform.modelsFeatures.2.title': {
-    en: 'Never dropped',
-    'zh-CN': '永不丢弃'
-  },
-  'platform.modelsFeatures.2.description': {
-    en: 'Queued requests never die with a 429. They hold a queue position against your workspace concurrency and start the moment a slot frees.',
-    'zh-CN':
-      '排队中的请求绝不会以 429 告终。它们在你工作区的并发额度内保留队列位置，一有空位立刻开始。'
-  },
-  'platform.modelsFeatures.3.title': {
-    en: 'One credit pool',
-    'zh-CN': '一个积分池'
-  },
-  'platform.modelsFeatures.3.description': {
-    en: 'Pay per use from the same balance that powers Cloud workflows and serverless GPUs. No subscription floor.',
-    'zh-CN':
-      '按用量付费，与 Cloud 工作流和无服务器 GPU 共用同一余额。没有订阅门槛。'
-  },
-  'platform.modelsFeatures.4.title': {
-    en: 'Costs you can attribute',
-    'zh-CN': '可归因的成本'
-  },
-  'platform.modelsFeatures.4.description': {
-    en: 'Every completed request returns the credits it consumed. Failed provider calls are never billed.',
-    'zh-CN': '每个完成的请求都会返回其消耗的积分。失败的调用绝不计费。'
-  },
-  'platform.modelsFeatures.5.title': {
-    en: 'Schemas to generate against',
-    'zh-CN': '可直接生成代码的 Schema'
-  },
-  'platform.modelsFeatures.5.description': {
-    en: 'Every model publishes its own OpenAPI document — the same one the server validates your call against.',
-    'zh-CN':
-      '每个模型都发布自己的 OpenAPI 文档——服务器校验你的调用时用的正是同一份。'
-  },
-  'platform.modelsFeatures.6.title': {
-    en: 'Cancel anytime',
-    'zh-CN': '随时取消'
-  },
-  'platform.modelsFeatures.6.description': {
-    en: 'A queued request cancels immediately and costs nothing; in-progress calls get a best-effort cancel.',
-    'zh-CN': '排队中的请求立即取消且不产生费用；进行中的调用会尽力取消。'
-  },
   // ── Builder subpage ───────────────────────────────────────────
   'platform.builderProblem.heading': {
-    en: 'Teams love using Comfy — and hate managing it',
-    'zh-CN': '团队爱用 Comfy——却讨厌管理它'
+    en: 'Build once. Run the same Comfy anywhere.',
+    'zh-CN': '一次构建，在任何地方运行同一个 Comfy。'
   },
   'platform.builderProblem.1': {
-    en: 'The same nodes installed a week apart resolve different dependencies — a workflow works on one machine and fails on the next.',
-    'zh-CN':
-      '相隔一周安装的同一批节点会解析出不同的依赖——工作流在一台机器上能跑，在另一台上却失败。'
+    en: 'The same nodes can resolve different dependencies when installed at different times.',
+    'zh-CN': '同一批节点在不同时间安装时，可能会解析出不同的依赖。'
   },
   'platform.builderProblem.2': {
-    en: 'Environments drift mid-production, and outputs silently change.',
-    'zh-CN': '环境在制作中途悄悄漂移，产出也随之悄悄变化。'
+    en: 'Environments drift during production and outputs change.',
+    'zh-CN': '环境在制作过程中发生漂移，产出也随之变化。'
   },
   'platform.builderProblem.3': {
-    en: 'Workflows get shared over a network drive, but no one can keep everyone on the same version.',
-    'zh-CN': '工作流通过网络硬盘共享，却没人能让所有人保持同一版本。'
+    en: 'Shared workflows break when machines run different versions.',
+    'zh-CN': '当机器运行不同版本时，共享的工作流会失效。'
   },
   'platform.builderProblem.4': {
-    en: 'Whoever runs Comfy for the team spends their time keeping it alive instead of using it.',
-    'zh-CN': '为团队维护 Comfy 的人，把时间都花在维持它运转上，而不是使用它。'
-  },
-  'platform.builderProblem.quote': {
-    en: '“Debugging our GPU cloud has become a bigger job for us than making workflows.”',
-    'zh-CN': '“调试我们的 GPU 云已经变成比制作工作流更大的工作。”'
-  },
-  'platform.builderProblem.quoteAttribution': {
-    en: 'Film production company',
-    'zh-CN': '影视制作公司'
+    en: 'Environment maintenance takes time away from building workflows.',
+    'zh-CN': '环境维护占用了构建工作流的时间。'
   },
   'platform.builderPillars.heading': {
     en: 'Get everyone on the same Comfy',
@@ -8081,13 +8039,45 @@ const translations = {
       '通过界面轻松迁移，或让你的智能体使用我们团队维护的 Skills 完成迁移。'
   },
   'platform.builderEnterprise.heading': {
-    en: 'Need enterprise controls?',
-    'zh-CN': '需要企业级控制？'
+    en: 'Builder vs. Managed Builds',
+    'zh-CN': 'Builder 与托管构建对比'
   },
   'platform.builderEnterprise.subtitle': {
-    en: "Model allowlists, per-partner-node control, and BYOK — run partner models on your organization's own keys. Managed Builds gives your admins governance over every build your organization runs.",
+    en: 'Builder is self-serve for packaging and testing your own environment. Managed Builds adds team sharing and enterprise governance.',
     'zh-CN':
-      '模型白名单、逐个控制合作伙伴节点、BYOK——用组织自己的密钥运行合作伙伴模型。托管构建让管理员治理组织运行的每一个构建。'
+      'Builder 可用于自助打包和测试自己的环境。托管构建增加了团队共享和企业治理。'
+  },
+  'platform.builderEnterprise.feature': {
+    en: 'Feature',
+    'zh-CN': '功能'
+  },
+  'platform.builderEnterprise.included': {
+    en: 'Included',
+    'zh-CN': '包含'
+  },
+  'platform.builderEnterprise.notIncluded': {
+    en: 'Not included',
+    'zh-CN': '不包含'
+  },
+  'platform.builderEnterprise.enterpriseOnly': {
+    en: 'Enterprise only',
+    'zh-CN': '仅限企业版'
+  },
+  'platform.builderEnterprise.customNodes.label': {
+    en: 'Custom nodes packaging',
+    'zh-CN': '自定义节点打包'
+  },
+  'platform.builderEnterprise.teamSharing.label': {
+    en: 'Team sharing',
+    'zh-CN': '团队共享'
+  },
+  'platform.builderEnterprise.governance.label': {
+    en: 'Governance',
+    'zh-CN': '治理'
+  },
+  'platform.builderEnterprise.pythonDependencies.label': {
+    en: 'Python dependency auto-resolution',
+    'zh-CN': 'Python 依赖自动解析'
   },
   'platform.closing.heading': {
     en: 'Maximize scale and control on Developer Platform',

--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -7505,6 +7505,14 @@ const translations = {
     en: 'How it works',
     'zh-CN': '工作原理'
   },
+  'platform.serverlessDeploy.shipHeading': {
+    en: 'Ship in minutes',
+    'zh-CN': '几分钟内上线'
+  },
+  'platform.serverlessDeploy.shipSubtitle': {
+    en: 'Easily package up your existing ComfyUI environment or a single workflow, then deploy it to serverless.',
+    'zh-CN': '轻松打包现有的 ComfyUI 环境或单个工作流，然后部署到 Serverless。'
+  },
   'platform.serverlessDeploy.subtitle': {
     en: 'Builder packages your ComfyUI workflow and environment into a reproducible build. Deploy that build to serverless and scale it on demand.',
     'zh-CN':

--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -7622,6 +7622,10 @@ const translations = {
     'zh-CN':
       '调用合作伙伴模型——Seedance、Minimax H3、Nano Banana、GPT-Image-2——用一个 API 密钥即可访问最新模型。'
   },
+  'platform.modelsFeatures.heading': {
+    en: 'One key, every frontier model',
+    'zh-CN': '一个密钥，所有前沿模型'
+  },
   'platform.modelsFeatures.1.title': {
     en: 'Every frontier media model',
     'zh-CN': '所有前沿媒体模型'

--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -7322,14 +7322,9 @@ const translations = {
     en: 'Developer Platform',
     'zh-CN': '开发者平台'
   },
-  'home.platform.heading': {
-    en: 'Deploy and scale your Comfy workflows with Serverless',
-    'zh-CN': '使用 Serverless 部署并扩展你的 Comfy 工作流'
-  },
   'home.platform.body': {
-    en: 'Bring your custom nodes and custom environments, then scale from zero to millions of generations without managing GPUs.',
-    'zh-CN':
-      '带上你的自定义节点和自定义环境，从零扩展到数百万次生成，无需管理 GPU。'
+    en: 'Deploy and scale your Comfy workflows with Serverless.',
+    'zh-CN': '使用 Serverless 部署并扩展你的 Comfy 工作流。'
   },
   'home.platform.cta': {
     en: 'Explore the Developer Platform',

--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -7578,8 +7578,8 @@ const translations = {
     'zh-CN': '支持 ComfyUI 生态中数以千计的开源模型、自定义节点和合作伙伴模型。'
   },
   'platform.products.serverless.title': {
-    en: 'Serverless API',
-    'zh-CN': 'Serverless API'
+    en: 'Serverless',
+    'zh-CN': 'Serverless'
   },
   'platform.products.serverless.description': {
     en: 'Deploy and scale your Comfy workflows with serverless. Bring custom nodes and custom environments, then scale from zero to millions of generations.',

--- a/apps/website/src/pages/platform.astro
+++ b/apps/website/src/pages/platform.astro
@@ -23,7 +23,7 @@ import { t } from '../i18n/translations'
   <PricingSection locale="en" />
   <ClosingCtaSection
     locale="en"
-    heading-lead={t('platform.closing.headingLead', 'en')}
+    heading-after-badge={t('platform.closing.headingAfterBadge', 'en')}
     client:visible
   />
   <ClosingCtaSection locale="en" visual="columns" client:visible />

--- a/apps/website/src/pages/platform.astro
+++ b/apps/website/src/pages/platform.astro
@@ -21,7 +21,11 @@ import { t } from '../i18n/translations'
   </div>
   <SocialProofBarSection />
   <PricingSection locale="en" />
-  <ClosingCtaSection locale="en" client:visible />
+  <ClosingCtaSection
+    locale="en"
+    heading-lead={t('platform.closing.headingLead', 'en')}
+    client:visible
+  />
   <ClosingCtaSection locale="en" visual="columns" client:visible />
   <ProductCardsSection
     locale="en"

--- a/apps/website/src/pages/platform/models.astro
+++ b/apps/website/src/pages/platform/models.astro
@@ -2,6 +2,7 @@
 import BaseLayout from '../../layouts/BaseLayout.astro'
 import ProductCardsSection from '../../components/common/ProductCardsSection.vue'
 import ClosingCtaSection from '../../templates/platform/ClosingCtaSection.vue'
+import ModelsApiFeaturesSection from '../../templates/platform/ModelsApiFeaturesSection.vue'
 import ModelsApiHero from '../../templates/platform/ModelsApiHero.vue'
 import { t } from '../../i18n/translations'
 ---
@@ -11,6 +12,7 @@ import { t } from '../../i18n/translations'
   description={t('platform.products.models.description', 'en')}
 >
   <ModelsApiHero locale="en" client:load />
+  <ModelsApiFeaturesSection locale="en" />
   <ClosingCtaSection locale="en" client:visible />
   <ProductCardsSection
     locale="en"

--- a/apps/website/src/pages/zh-CN/platform.astro
+++ b/apps/website/src/pages/zh-CN/platform.astro
@@ -17,7 +17,11 @@ import { t } from '../../i18n/translations'
   <ProductsSection locale="zh-CN" client:visible />
   <SocialProofBarSection />
   <PricingSection locale="zh-CN" />
-  <ClosingCtaSection locale="zh-CN" client:visible />
+  <ClosingCtaSection
+    locale="zh-CN"
+    heading-lead={t('platform.closing.headingLead', 'zh-CN')}
+    client:visible
+  />
   <ClosingCtaSection locale="zh-CN" visual="columns" client:visible />
   <ProductCardsSection locale="zh-CN" label-key="products.labelProducts" />
 </BaseLayout>

--- a/apps/website/src/pages/zh-CN/platform.astro
+++ b/apps/website/src/pages/zh-CN/platform.astro
@@ -19,7 +19,7 @@ import { t } from '../../i18n/translations'
   <PricingSection locale="zh-CN" />
   <ClosingCtaSection
     locale="zh-CN"
-    heading-lead={t('platform.closing.headingLead', 'zh-CN')}
+    heading-after-badge={t('platform.closing.headingAfterBadge', 'zh-CN')}
     client:visible
   />
   <ClosingCtaSection locale="zh-CN" visual="columns" client:visible />

--- a/apps/website/src/pages/zh-CN/platform/models.astro
+++ b/apps/website/src/pages/zh-CN/platform/models.astro
@@ -2,6 +2,7 @@
 import BaseLayout from '../../../layouts/BaseLayout.astro'
 import ProductCardsSection from '../../../components/common/ProductCardsSection.vue'
 import ClosingCtaSection from '../../../templates/platform/ClosingCtaSection.vue'
+import ModelsApiFeaturesSection from '../../../templates/platform/ModelsApiFeaturesSection.vue'
 import ModelsApiHero from '../../../templates/platform/ModelsApiHero.vue'
 import { t } from '../../../i18n/translations'
 ---
@@ -11,6 +12,7 @@ import { t } from '../../../i18n/translations'
   description={t('platform.products.models.description', 'zh-CN')}
 >
   <ModelsApiHero locale="zh-CN" client:load />
+  <ModelsApiFeaturesSection locale="zh-CN" />
   <ClosingCtaSection locale="zh-CN" client:visible />
   <ProductCardsSection locale="zh-CN" label-key="products.labelProducts" />
 </BaseLayout>

--- a/apps/website/src/pages/zh-CN/platform/serverless.astro
+++ b/apps/website/src/pages/zh-CN/platform/serverless.astro
@@ -14,7 +14,7 @@ import { t } from '../../../i18n/translations'
 >
   <ServerlessHero locale="zh-CN" client:load />
   <ServerlessDeploySection locale="zh-CN" client:visible />
-  <ServerlessScaleSection locale="zh-CN" />
+  <ServerlessScaleSection locale="zh-CN" client:visible />
   <ClosingCtaSection locale="zh-CN" client:visible />
   <ProductCardsSection locale="zh-CN" label-key="products.labelProducts" />
 </BaseLayout>

--- a/apps/website/src/templates/platform/BuilderEnterpriseSection.test.ts
+++ b/apps/website/src/templates/platform/BuilderEnterpriseSection.test.ts
@@ -6,16 +6,35 @@ import { t } from '../../i18n/translations'
 import BuilderEnterpriseSection from './BuilderEnterpriseSection.vue'
 
 describe('BuilderEnterpriseSection', () => {
-  it('routes to Managed Builds and the contact page', () => {
+  it('compares Builder with Managed Builds', () => {
     render(BuilderEnterpriseSection, { props: { locale: 'en' } })
 
-    const hrefOf = (name: string) =>
-      screen.getByRole('link', { name }).getAttribute('href')
-    expect(hrefOf(t('enterprise.managedBuilds.explore', 'en'))).toBe(
-      '/enterprise/managed-builds'
-    )
-    expect(hrefOf(t('enterprise.managedBuilds.talkToUs', 'en'))).toBe(
-      '/contact'
-    )
+    expect(screen.getAllByRole('row')).toHaveLength(5)
+    expect(
+      screen.getByRole('columnheader', {
+        name: t('platform.products.builder.title', 'en')
+      })
+    ).toBeTruthy()
+    expect(
+      screen.getByRole('columnheader', {
+        name: t('enterprise.managedBuilds.heading', 'en')
+      })
+    ).toBeTruthy()
+    expect(
+      screen
+        .getByRole('link', {
+          name: t('enterprise.managedBuilds.explore', 'en')
+        })
+        .getAttribute('href')
+    ).toBe('/enterprise/managed-builds')
+    expect(
+      screen.getByText(t('platform.builderEnterprise.teamSharing.label', 'en'))
+    ).toBeTruthy()
+    expect(
+      screen.getByText(t('platform.builderEnterprise.governance.label', 'en'))
+    ).toBeTruthy()
+    expect(
+      screen.getAllByText(t('platform.builderEnterprise.enterpriseOnly', 'en'))
+    ).toHaveLength(2)
   })
 })

--- a/apps/website/src/templates/platform/BuilderEnterpriseSection.vue
+++ b/apps/website/src/templates/platform/BuilderEnterpriseSection.vue
@@ -8,6 +8,33 @@ import { t } from '../../i18n/translations'
 const { locale = 'en' } = defineProps<{ locale?: Locale }>()
 
 const routes = getRoutes(locale)
+
+const included = t('platform.builderEnterprise.included', locale)
+const notIncluded = t('platform.builderEnterprise.notIncluded', locale)
+const enterpriseOnly = t('platform.builderEnterprise.enterpriseOnly', locale)
+
+const features = [
+  {
+    label: t('platform.builderEnterprise.customNodes.label', locale),
+    builder: included,
+    managed: included
+  },
+  {
+    label: t('platform.builderEnterprise.teamSharing.label', locale),
+    builder: notIncluded,
+    managed: enterpriseOnly
+  },
+  {
+    label: t('platform.builderEnterprise.governance.label', locale),
+    builder: notIncluded,
+    managed: enterpriseOnly
+  },
+  {
+    label: t('platform.builderEnterprise.pythonDependencies.label', locale),
+    builder: included,
+    managed: included
+  }
+]
 </script>
 
 <template>
@@ -21,12 +48,46 @@ const routes = getRoutes(locale)
       </template>
     </SectionHeader>
 
-    <div class="mt-8 flex flex-wrap justify-center gap-3">
+    <div
+      class="bg-transparency-white-t4 mx-auto mt-8 max-w-5xl overflow-hidden rounded-4xl px-4 py-6 lg:px-8"
+    >
+      <div class="scrollbar-none overflow-x-auto">
+        <table class="w-full min-w-150 text-left text-sm">
+          <thead
+            class="text-primary-comfy-yellow text-xs font-bold tracking-widest uppercase"
+          >
+            <tr>
+              <th class="p-3">
+                {{ t('platform.builderEnterprise.feature', locale) }}
+              </th>
+              <th class="p-3">
+                {{ t('platform.products.builder.title', locale) }}
+              </th>
+              <th class="p-3">
+                {{ t('enterprise.managedBuilds.heading', locale) }}
+              </th>
+            </tr>
+          </thead>
+          <tbody class="divide-y divide-white/10 text-primary-comfy-canvas">
+            <tr v-for="feature in features" :key="feature.label">
+              <th class="px-3 py-4 font-normal">
+                {{ feature.label }}
+              </th>
+              <td class="px-3 py-4 text-smoke-700">
+                {{ feature.builder }}
+              </td>
+              <td class="px-3 py-4 text-smoke-700">
+                {{ feature.managed }}
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+    <div class="mt-8 flex justify-center">
       <Button as="a" :href="routes.enterpriseManagedBuilds" variant="outline">
         {{ t('enterprise.managedBuilds.explore', locale) }}
-      </Button>
-      <Button as="a" :href="routes.contact" variant="link">
-        {{ t('enterprise.managedBuilds.talkToUs', locale) }}
       </Button>
     </div>
   </section>

--- a/apps/website/src/templates/platform/BuilderHero.vue
+++ b/apps/website/src/templates/platform/BuilderHero.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import HeroSplit01 from '../../components/blocks/HeroSplit01.vue'
-import { externalLinks, getRoutes } from '../../config/routes'
+import { externalLinks } from '../../config/routes'
 import type { Locale } from '../../i18n/translations'
 import { t } from '../../i18n/translations'
 import BuilderVisual from './BuilderVisual.vue'
@@ -8,7 +8,6 @@ import { platformCtas } from './ctas'
 
 const { locale = 'en' } = defineProps<{ locale?: Locale }>()
 
-const routes = getRoutes(locale)
 const ctas = platformCtas(locale)
 </script>
 
@@ -26,8 +25,9 @@ const ctas = platformCtas(locale)
       target: '_blank'
     }"
     :secondary-cta="{
-      label: t('platform.products.builder.enterpriseCta', locale),
-      href: routes.enterprise
+      label: ctas.docs.label,
+      href: ctas.docs.href,
+      target: ctas.docs.target
     }"
   >
     <template #media>

--- a/apps/website/src/templates/platform/BuilderProblemSection.test.ts
+++ b/apps/website/src/templates/platform/BuilderProblemSection.test.ts
@@ -2,16 +2,13 @@
 import { render, screen } from '@testing-library/vue'
 import { describe, expect, it } from 'vitest'
 
-import { t } from '../../i18n/translations'
 import BuilderProblemSection from './BuilderProblemSection.vue'
 
 describe('BuilderProblemSection', () => {
-  it('lists the four pains and the customer quote', () => {
+  it('lists the four problems without the placeholder quote', () => {
     render(BuilderProblemSection, { props: { locale: 'en' } })
 
     expect(screen.getAllByRole('listitem')).toHaveLength(4)
-    expect(
-      screen.getByText(t('platform.builderProblem.quote', 'en'))
-    ).toBeTruthy()
+    expect(screen.queryByText(/Debugging our GPU cloud/)).toBeNull()
   })
 })

--- a/apps/website/src/templates/platform/BuilderProblemSection.vue
+++ b/apps/website/src/templates/platform/BuilderProblemSection.vue
@@ -28,16 +28,5 @@ const pains = painNumbers.map((n) => t(`platform.builderProblem.${n}`, locale))
         {{ pain }}
       </li>
     </ul>
-
-    <figure class="mx-auto mt-8 max-w-2xl text-center">
-      <blockquote
-        class="text-base/relaxed font-light text-primary-warm-white lg:text-lg/relaxed"
-      >
-        {{ t('platform.builderProblem.quote', locale) }}
-      </blockquote>
-      <figcaption class="mt-3 text-xs text-smoke-700">
-        {{ t('platform.builderProblem.quoteAttribution', locale) }}
-      </figcaption>
-    </figure>
   </section>
 </template>

--- a/apps/website/src/templates/platform/ClosingCtaSection.vue
+++ b/apps/website/src/templates/platform/ClosingCtaSection.vue
@@ -12,11 +12,13 @@ const {
   locale = 'en',
   visual = 'shader',
   badgeOnly = false,
+  headingAfterBadge,
   headingLead,
   primaryHref,
   subtitle
 } = defineProps<{
   badgeOnly?: boolean
+  headingAfterBadge?: string
   headingLead?: string
   locale?: Locale
   primaryHref?: string
@@ -56,7 +58,9 @@ onMounted(() => {
           ? `${t('platform.hero.badge', locale)} ${t('nav.badgeBeta', locale)}`
           : headingLead
             ? `${headingLead} ${t('platform.hero.badge', locale)} ${t('nav.badgeBeta', locale)}`
-            : t('platform.closing.heading', locale)
+            : headingAfterBadge
+              ? `${t('platform.hero.badge', locale)} ${t('nav.badgeBeta', locale)} ${headingAfterBadge}`
+              : t('platform.closing.heading', locale)
       "
       :subtitle
       :subtitle-class="badgeOnly ? 'mt-6' : undefined"
@@ -78,6 +82,12 @@ onMounted(() => {
         <template v-else-if="headingLead">
           <span class="block">{{ headingLead }}</span>
           <PlatformHeroBadge class="mx-auto -my-2 scale-75" :locale />
+        </template>
+        <template v-else-if="headingAfterBadge">
+          <PlatformHeroBadge class="mx-auto -my-2 scale-75" :locale />
+          <span class="mt-5 block text-base/relaxed lg:text-xl/relaxed">
+            {{ headingAfterBadge }}
+          </span>
         </template>
         <template v-else>
           {{ t('platform.closing.heading', locale) }}

--- a/apps/website/src/templates/platform/ClosingCtaSection.vue
+++ b/apps/website/src/templates/platform/ClosingCtaSection.vue
@@ -52,9 +52,11 @@ onMounted(() => {
       compact
       class="relative z-10 min-h-96 justify-center"
       :heading="
-        headingLead
-          ? `${headingLead} ${t('platform.hero.badge', locale)} ${t('nav.badgeBeta', locale)}`
-          : t('platform.closing.heading', locale)
+        badgeOnly
+          ? `${t('platform.hero.badge', locale)} ${t('nav.badgeBeta', locale)}`
+          : headingLead
+            ? `${headingLead} ${t('platform.hero.badge', locale)} ${t('nav.badgeBeta', locale)}`
+            : t('platform.closing.heading', locale)
       "
       :subtitle
       :subtitle-class="badgeOnly ? 'mt-6' : undefined"

--- a/apps/website/src/templates/platform/ClosingCtaSection.vue
+++ b/apps/website/src/templates/platform/ClosingCtaSection.vue
@@ -26,7 +26,7 @@ const {
 
 const ctas = platformCtas(locale)
 const primaryCta = primaryHref
-  ? { ...ctas.getStarted, href: primaryHref }
+  ? { label: ctas.getStarted.label, href: primaryHref }
   : ctas.getStarted
 const isMounted = ref(false)
 const TerminalAsciiShader = defineAsyncComponent(

--- a/apps/website/src/templates/platform/ClosingCtaSection.vue
+++ b/apps/website/src/templates/platform/ClosingCtaSection.vue
@@ -75,6 +75,10 @@ onMounted(() => {
             :locale
           />
         </template>
+        <template v-else-if="headingLead">
+          <span class="block">{{ headingLead }}</span>
+          <PlatformHeroBadge class="mx-auto -my-2 scale-75" :locale />
+        </template>
         <template v-else>
           {{ t('platform.closing.heading', locale) }}
         </template>

--- a/apps/website/src/templates/platform/ClosingCtaSection.vue
+++ b/apps/website/src/templates/platform/ClosingCtaSection.vue
@@ -12,10 +12,12 @@ const {
   locale = 'en',
   visual = 'shader',
   badgeOnly = false,
+  headingLead,
   primaryHref,
   subtitle
 } = defineProps<{
   badgeOnly?: boolean
+  headingLead?: string
   locale?: Locale
   primaryHref?: string
   subtitle?: string
@@ -49,7 +51,11 @@ onMounted(() => {
     <CtaCenter01
       compact
       class="relative z-10 min-h-96 justify-center"
-      :heading="t('platform.closing.heading', locale)"
+      :heading="
+        headingLead
+          ? `${headingLead} ${t('platform.hero.badge', locale)} ${t('nav.badgeBeta', locale)}`
+          : t('platform.closing.heading', locale)
+      "
       :subtitle
       :subtitle-class="badgeOnly ? 'mt-6' : undefined"
       :primary-cta="primaryCta"
@@ -58,7 +64,7 @@ onMounted(() => {
       <template #heading>
         <template v-if="visual === 'columns'">
           <span v-if="!badgeOnly" class="block">
-            {{ t('platform.closing.headingLead', locale) }}
+            {{ headingLead ?? t('platform.closing.headingLead', locale) }}
           </span>
           <PlatformHeroBadge
             :class="badgeOnly ? 'mx-auto md:my-2' : 'mx-auto -my-2 scale-75'"

--- a/apps/website/src/templates/platform/ModelsApiFeaturesSection.test.ts
+++ b/apps/website/src/templates/platform/ModelsApiFeaturesSection.test.ts
@@ -1,0 +1,32 @@
+// @vitest-environment happy-dom
+import { render, screen } from '@testing-library/vue'
+import { describe, expect, it } from 'vitest'
+
+import { t } from '../../i18n/translations'
+import ModelsApiFeaturesSection from './ModelsApiFeaturesSection.vue'
+
+describe('ModelsApiFeaturesSection', () => {
+  it('renders the supplied Models API value callouts', () => {
+    render(ModelsApiFeaturesSection, { props: { locale: 'en' } })
+
+    expect(screen.getAllByRole('article')).toHaveLength(6)
+    expect(
+      screen.getByText(t('platform.modelsFeatures.1.title', 'en'))
+    ).toBeTruthy()
+    expect(
+      screen.getByText(t('platform.modelsFeatures.2.title', 'en'))
+    ).toBeTruthy()
+    expect(
+      screen.getByText(t('platform.modelsFeatures.3.title', 'en'))
+    ).toBeTruthy()
+    expect(
+      screen.getByText(t('platform.modelsFeatures.4.title', 'en'))
+    ).toBeTruthy()
+    expect(
+      screen.getByText(t('platform.modelsFeatures.5.title', 'en'))
+    ).toBeTruthy()
+    expect(
+      screen.getByText(t('platform.modelsFeatures.6.title', 'en'))
+    ).toBeTruthy()
+  })
+})

--- a/apps/website/src/templates/platform/ModelsApiFeaturesSection.test.ts
+++ b/apps/website/src/templates/platform/ModelsApiFeaturesSection.test.ts
@@ -14,18 +14,12 @@ describe('ModelsApiFeaturesSection', () => {
         name: t('platform.modelsFeatures.heading', 'en')
       })
     ).toBeTruthy()
-    expect(screen.getAllByRole('article')).toHaveLength(6)
+    expect(screen.getAllByRole('article')).toHaveLength(4)
     expect(
       screen.getByText(t('platform.modelsFeatures.1.title', 'en'))
     ).toBeTruthy()
     expect(
-      screen.getByText(t('platform.modelsFeatures.2.title', 'en'))
-    ).toBeTruthy()
-    expect(
       screen.getByText(t('platform.modelsFeatures.3.title', 'en'))
-    ).toBeTruthy()
-    expect(
-      screen.getByText(t('platform.modelsFeatures.4.title', 'en'))
     ).toBeTruthy()
     expect(
       screen.getByText(t('platform.modelsFeatures.5.title', 'en'))
@@ -33,5 +27,7 @@ describe('ModelsApiFeaturesSection', () => {
     expect(
       screen.getByText(t('platform.modelsFeatures.6.title', 'en'))
     ).toBeTruthy()
+    expect(screen.queryByText(/never dropped/i)).toBeNull()
+    expect(screen.queryByText(/costs you can attribute/i)).toBeNull()
   })
 })

--- a/apps/website/src/templates/platform/ModelsApiFeaturesSection.test.ts
+++ b/apps/website/src/templates/platform/ModelsApiFeaturesSection.test.ts
@@ -9,6 +9,11 @@ describe('ModelsApiFeaturesSection', () => {
   it('renders the supplied Models API value callouts', () => {
     render(ModelsApiFeaturesSection, { props: { locale: 'en' } })
 
+    expect(
+      screen.getByRole('heading', {
+        name: t('platform.modelsFeatures.heading', 'en')
+      })
+    ).toBeTruthy()
     expect(screen.getAllByRole('article')).toHaveLength(6)
     expect(
       screen.getByText(t('platform.modelsFeatures.1.title', 'en'))

--- a/apps/website/src/templates/platform/ModelsApiFeaturesSection.vue
+++ b/apps/website/src/templates/platform/ModelsApiFeaturesSection.vue
@@ -11,16 +11,8 @@ const cards = [
     description: t('platform.modelsFeatures.1.description', locale)
   },
   {
-    title: t('platform.modelsFeatures.2.title', locale),
-    description: t('platform.modelsFeatures.2.description', locale)
-  },
-  {
     title: t('platform.modelsFeatures.3.title', locale),
     description: t('platform.modelsFeatures.3.description', locale)
-  },
-  {
-    title: t('platform.modelsFeatures.4.title', locale),
-    description: t('platform.modelsFeatures.4.description', locale)
   },
   {
     title: t('platform.modelsFeatures.5.title', locale),
@@ -43,7 +35,7 @@ const cards = [
     >
       {{ t('platform.modelsFeatures.heading', locale) }}
     </h2>
-    <div class="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
+    <div class="grid grid-cols-1 gap-6 sm:grid-cols-2">
       <FeatureCard
         v-for="card in cards"
         :key="card.title"

--- a/apps/website/src/templates/platform/ModelsApiFeaturesSection.vue
+++ b/apps/website/src/templates/platform/ModelsApiFeaturesSection.vue
@@ -38,6 +38,11 @@ const cards = [
     class="max-w-9xl mx-auto px-6 py-10 lg:py-14"
     :aria-label="t('platform.products.models.title', locale)"
   >
+    <h2
+      class="mb-8 text-center text-3xl/none font-light text-primary-comfy-canvas lg:text-4xl/none"
+    >
+      {{ t('platform.modelsFeatures.heading', locale) }}
+    </h2>
     <div class="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
       <FeatureCard
         v-for="card in cards"

--- a/apps/website/src/templates/platform/ModelsApiFeaturesSection.vue
+++ b/apps/website/src/templates/platform/ModelsApiFeaturesSection.vue
@@ -1,0 +1,50 @@
+<script setup lang="ts">
+import type { Locale } from '../../i18n/translations'
+import { t } from '../../i18n/translations'
+import FeatureCard from './FeatureCard.vue'
+
+const { locale = 'en' } = defineProps<{ locale?: Locale }>()
+
+const cards = [
+  {
+    title: t('platform.modelsFeatures.1.title', locale),
+    description: t('platform.modelsFeatures.1.description', locale)
+  },
+  {
+    title: t('platform.modelsFeatures.2.title', locale),
+    description: t('platform.modelsFeatures.2.description', locale)
+  },
+  {
+    title: t('platform.modelsFeatures.3.title', locale),
+    description: t('platform.modelsFeatures.3.description', locale)
+  },
+  {
+    title: t('platform.modelsFeatures.4.title', locale),
+    description: t('platform.modelsFeatures.4.description', locale)
+  },
+  {
+    title: t('platform.modelsFeatures.5.title', locale),
+    description: t('platform.modelsFeatures.5.description', locale)
+  },
+  {
+    title: t('platform.modelsFeatures.6.title', locale),
+    description: t('platform.modelsFeatures.6.description', locale)
+  }
+]
+</script>
+
+<template>
+  <section
+    class="max-w-9xl mx-auto px-6 py-10 lg:py-14"
+    :aria-label="t('platform.products.models.title', locale)"
+  >
+    <div class="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
+      <FeatureCard
+        v-for="card in cards"
+        :key="card.title"
+        :title="card.title"
+        :description="card.description"
+      />
+    </div>
+  </section>
+</template>

--- a/apps/website/src/templates/platform/ServerlessDeploySection.test.ts
+++ b/apps/website/src/templates/platform/ServerlessDeploySection.test.ts
@@ -10,6 +10,15 @@ describe('ServerlessDeploySection', () => {
   it('walks through the snapshot flow first and the workflow flow on demand', async () => {
     render(ServerlessDeploySection, { props: { locale: 'en' } })
 
+    expect(
+      screen.getByRole('heading', {
+        name: t('platform.serverlessDeploy.heading', 'en')
+      })
+    ).toBeTruthy()
+    expect(screen.getAllByRole('listitem')).toHaveLength(3)
+    expect(
+      screen.getByText(t('platform.serverlessDeploy.2.title', 'en'))
+    ).toBeTruthy()
     expect(screen.getByText(/comfy build init --from-snapshot/)).toBeTruthy()
 
     await userEvent.click(

--- a/apps/website/src/templates/platform/ServerlessDeploySection.test.ts
+++ b/apps/website/src/templates/platform/ServerlessDeploySection.test.ts
@@ -15,6 +15,15 @@ describe('ServerlessDeploySection', () => {
         name: t('platform.serverlessDeploy.heading', 'en')
       })
     ).toBeTruthy()
+    expect(
+      screen.getByRole('heading', {
+        level: 2,
+        name: t('platform.serverlessDeploy.shipHeading', 'en')
+      })
+    ).toBeTruthy()
+    expect(
+      screen.getByText(t('platform.serverlessDeploy.shipSubtitle', 'en'))
+    ).toBeTruthy()
     expect(screen.getAllByRole('listitem')).toHaveLength(3)
     expect(
       screen.getByText(t('platform.serverlessDeploy.2.title', 'en'))

--- a/apps/website/src/templates/platform/ServerlessDeploySection.vue
+++ b/apps/website/src/templates/platform/ServerlessDeploySection.vue
@@ -52,6 +52,17 @@ $ comfy deploy run --workflow workflow_api.json
 </script>
 
 <template>
+  <section class="max-w-9xl mx-auto px-6 pt-10 pb-4 lg:pt-14 lg:pb-6">
+    <SectionHeader max-width="xl" heading-size="compact">
+      {{ t('platform.serverlessDeploy.shipHeading', locale) }}
+      <template #subtitle>
+        <p class="mx-auto mt-4 max-w-2xl text-sm text-smoke-700">
+          {{ t('platform.serverlessDeploy.shipSubtitle', locale) }}
+        </p>
+      </template>
+    </SectionHeader>
+  </section>
+
   <section class="max-w-9xl mx-auto px-6 py-10 lg:py-14">
     <SectionHeader max-width="xl" heading-size="compact">
       {{ t('platform.serverlessDeploy.heading', locale) }}

--- a/apps/website/src/templates/platform/ServerlessDeploySection.vue
+++ b/apps/website/src/templates/platform/ServerlessDeploySection.vue
@@ -7,6 +7,13 @@ import CodeTabs from './CodeTabs.vue'
 
 const { locale = 'en' } = defineProps<{ locale?: Locale }>()
 
+const stepNumbers = [1, 2, 3] as const
+
+const steps = stepNumbers.map((number) => ({
+  title: t(`platform.serverlessDeploy.${number}.title`, locale),
+  description: t(`platform.serverlessDeploy.${number}.description`, locale)
+}))
+
 // Command surface from comfy-cli's build + deploy stack (PRs #801-805):
 // `comfy build init --from-snapshot/--from-workflow`, `build push`, and
 // `deploy up`, which defaults to the current directory.
@@ -53,6 +60,21 @@ $ comfy deploy run --workflow workflow_api.json
         </p>
       </template>
     </SectionHeader>
+
+    <ol class="mx-auto mt-8 grid max-w-5xl gap-4 md:grid-cols-3">
+      <li
+        v-for="step in steps"
+        :key="step.title"
+        class="bg-transparency-white-t4 rounded-3xl p-5"
+      >
+        <h3 class="text-lg font-light text-primary-comfy-canvas">
+          {{ step.title }}
+        </h3>
+        <p class="mt-2 text-sm/relaxed font-light text-smoke-700">
+          {{ step.description }}
+        </p>
+      </li>
+    </ol>
 
     <div class="mx-auto mt-8 max-w-3xl">
       <CodeTabs

--- a/apps/website/src/templates/platform/ServerlessDeploySection.vue
+++ b/apps/website/src/templates/platform/ServerlessDeploySection.vue
@@ -4,6 +4,7 @@ import type { Locale } from '../../i18n/translations'
 import { t } from '../../i18n/translations'
 import type { CodeTab } from './CodeTabs.vue'
 import CodeTabs from './CodeTabs.vue'
+import FeatureCard from './FeatureCard.vue'
 
 const { locale = 'en' } = defineProps<{ locale?: Locale }>()
 
@@ -62,17 +63,12 @@ $ comfy deploy run --workflow workflow_api.json
     </SectionHeader>
 
     <ol class="mx-auto mt-8 grid max-w-5xl gap-4 md:grid-cols-3">
-      <li
-        v-for="step in steps"
-        :key="step.title"
-        class="bg-transparency-white-t4 rounded-3xl p-5"
-      >
-        <h3 class="text-lg font-light text-primary-comfy-canvas">
-          {{ step.title }}
-        </h3>
-        <p class="mt-2 text-sm/relaxed font-light text-smoke-700">
-          {{ step.description }}
-        </p>
+      <li v-for="step in steps" :key="step.title">
+        <FeatureCard
+          class="h-full"
+          :title="step.title"
+          :description="step.description"
+        />
       </li>
     </ol>
 


### PR DESCRIPTION
## Summary
- refine the Developer Platform, Serverless, Models API, and Builder launch pages
- reuse the Developer Platform callout on the homepage
- restore Robin's supplied six-card Models API value section

## Validation
- pnpm --filter @comfyorg/website test:unit
- pnpm --filter @comfyorg/website typecheck
- pnpm --filter @comfyorg/website build
- pnpm knip --cache