### PR TITLE
[backport cloud/1.52] feat: open Settings on Plans & Credits from a ?settings= deep link

### DIFF
--- a/browser_tests/tests/cloud.spec.ts
+++ b/browser_tests/tests/cloud.spec.ts
@@ -3,6 +3,7 @@ import { comfyPageFixture as test } from '@e2e/fixtures/ComfyPage'
 
 const APP_URL = process.env.PLAYWRIGHT_TEST_URL || 'http://localhost:8188'
 const SHARE_AUTH_STORAGE_KEY = 'Comfy.PreservedQuery.share_auth'
+const SETTINGS_STORAGE_KEY = 'Comfy.PreservedQuery.settings'
 
 /**
  * Cloud distribution E2E tests.
@@ -38,6 +39,22 @@ test.describe('Cloud distribution UI', { tag: '@cloud' }, () => {
         )
       )
       .toBe(JSON.stringify({ share: 'abc' }))
+  })
+
+  test('preserves the settings deep link before redirecting logged-out users', async ({
+    page
+  }) => {
+    await page.goto(new URL('/?settings=plan-credits', APP_URL).toString())
+
+    await expect(page).toHaveURL(/\/cloud\/login/, { timeout: 10_000 })
+    await expect
+      .poll(() =>
+        page.evaluate(
+          (key) => sessionStorage.getItem(key),
+          SETTINGS_STORAGE_KEY
+        )
+      )
+      .toBe(JSON.stringify({ settings: 'plan-credits' }))
   })
 
   test('cloud login page renders sign-in options', async ({ page }) => {

--- a/src/composables/useUrlActionLoaders.test.ts
+++ b/src/composables/useUrlActionLoaders.test.ts
@@ -14,12 +14,14 @@ const mocks = vi.hoisted(() => ({
   loadCreateWorkspace: vi.fn(async () => undefined),
   loadPricingTable: vi.fn(async () => undefined),
   loadTopUp: vi.fn(async () => undefined),
+  loadSettings: vi.fn(),
   loadPaymentReturn: vi.fn(async () => undefined),
   resumePendingPricingFlow: vi.fn(async () => undefined),
   useInvite: vi.fn(),
   useCreateWorkspace: vi.fn(),
   usePricingTable: vi.fn(),
   useTopUp: vi.fn(),
+  useSettings: vi.fn(),
   usePaymentReturn: vi.fn(),
   useSubscriptionDialog: vi.fn()
 }))
@@ -34,6 +36,9 @@ mocks.usePricingTable.mockImplementation(() => ({
 }))
 mocks.useTopUp.mockImplementation(() => ({
   loadTopUpFromUrl: mocks.loadTopUp
+}))
+mocks.useSettings.mockImplementation(() => ({
+  loadSettingsFromUrl: mocks.loadSettings
 }))
 mocks.usePaymentReturn.mockImplementation(() => ({
   loadPaymentReturnFromUrl: mocks.loadPaymentReturn
@@ -54,6 +59,9 @@ vi.mock(
 )
 vi.mock('@/platform/cloud/subscription/composables/useTopUpUrlLoader', () => ({
   useTopUpUrlLoader: mocks.useTopUp
+}))
+vi.mock('@/platform/settings/composables/useSettingsUrlLoader', () => ({
+  useSettingsUrlLoader: mocks.useSettings
 }))
 vi.mock(
   '@/platform/cloud/subscription/composables/usePaymentReturnUrlLoader',
@@ -79,6 +87,9 @@ describe('useUrlActionLoaders', () => {
     mocks.useTopUp.mockImplementation(() => ({
       loadTopUpFromUrl: mocks.loadTopUp
     }))
+    mocks.useSettings.mockImplementation(() => ({
+      loadSettingsFromUrl: mocks.loadSettings
+    }))
     mocks.usePaymentReturn.mockImplementation(() => ({
       loadPaymentReturnFromUrl: mocks.loadPaymentReturn
     }))
@@ -97,12 +108,14 @@ describe('useUrlActionLoaders', () => {
     expect(mocks.useCreateWorkspace).not.toHaveBeenCalled()
     expect(mocks.usePricingTable).not.toHaveBeenCalled()
     expect(mocks.useTopUp).not.toHaveBeenCalled()
+    expect(mocks.useSettings).not.toHaveBeenCalled()
     expect(mocks.usePaymentReturn).not.toHaveBeenCalled()
     expect(mocks.useSubscriptionDialog).not.toHaveBeenCalled()
     expect(mocks.loadInvite).not.toHaveBeenCalled()
     expect(mocks.loadCreateWorkspace).not.toHaveBeenCalled()
     expect(mocks.loadPricingTable).not.toHaveBeenCalled()
     expect(mocks.loadTopUp).not.toHaveBeenCalled()
+    expect(mocks.loadSettings).not.toHaveBeenCalled()
     expect(mocks.loadPaymentReturn).not.toHaveBeenCalled()
     expect(mocks.resumePendingPricingFlow).not.toHaveBeenCalled()
   })
@@ -115,6 +128,7 @@ describe('useUrlActionLoaders', () => {
     expect(mocks.loadCreateWorkspace).toHaveBeenCalledOnce()
     expect(mocks.loadPricingTable).toHaveBeenCalledOnce()
     expect(mocks.loadTopUp).toHaveBeenCalledOnce()
+    expect(mocks.loadSettings).toHaveBeenCalledOnce()
     expect(mocks.loadPaymentReturn).toHaveBeenCalledOnce()
   })
 
@@ -155,6 +169,18 @@ describe('useUrlActionLoaders', () => {
     await expect(runUrlActionLoaders()).resolves.toBeUndefined()
 
     expect(mocks.loadPricingTable).toHaveBeenCalledOnce()
+    expect(mocks.loadSettings).toHaveBeenCalledOnce()
+    expect(mocks.loadPaymentReturn).toHaveBeenCalledOnce()
+  })
+
+  it('isolates a settings-loader failure so it does not abort the boot chain', async () => {
+    mocks.loadSettings.mockImplementationOnce(() => {
+      throw new Error('boom')
+    })
+
+    const { runUrlActionLoaders } = useUrlActionLoaders()
+    await expect(runUrlActionLoaders()).resolves.toBeUndefined()
+
     expect(mocks.loadPaymentReturn).toHaveBeenCalledOnce()
     expect(mocks.resumePendingPricingFlow).toHaveBeenCalledOnce()
   })

--- a/src/composables/useUrlActionLoaders.ts
+++ b/src/composables/useUrlActionLoaders.ts
@@ -3,14 +3,15 @@ import { usePricingTableUrlLoader } from '@/platform/cloud/subscription/composab
 import { useSubscriptionDialog } from '@/platform/cloud/subscription/composables/useSubscriptionDialog'
 import { useTopUpUrlLoader } from '@/platform/cloud/subscription/composables/useTopUpUrlLoader'
 import { isCloud } from '@/platform/distribution/types'
+import { useSettingsUrlLoader } from '@/platform/settings/composables/useSettingsUrlLoader'
 import { useCreateWorkspaceUrlLoader } from '@/platform/workspace/composables/useCreateWorkspaceUrlLoader'
 import { useInviteUrlLoader } from '@/platform/workspace/composables/useInviteUrlLoader'
 
 /**
  * Aggregates the query-param "deep link" loaders the cloud app checks on mount
- * (`?invite`, `?create_workspace`, `?pricing`, `?topup`), then recovers an
- * interrupted checkout. The loaders are instantiated in setup so their
- * `useRoute`/`useRouter` resolve; call `runUrlActionLoaders()` from
+ * (`?invite`, `?create_workspace`, `?pricing`, `?topup`, `?settings`), then
+ * recovers an interrupted checkout. The loaders are instantiated in setup so
+ * their `useRoute`/`useRouter` resolve; call `runUrlActionLoaders()` from
  * `onMounted` once the app is ready.
  */
 export function useUrlActionLoaders() {
@@ -20,6 +21,7 @@ export function useUrlActionLoaders() {
     : null
   const pricingTableUrlLoader = isCloud ? usePricingTableUrlLoader() : null
   const topUpUrlLoader = isCloud ? useTopUpUrlLoader() : null
+  const settingsUrlLoader = isCloud ? useSettingsUrlLoader() : null
   const paymentReturnUrlLoader = isCloud ? usePaymentReturnUrlLoader() : null
   const subscriptionDialog = isCloud ? useSubscriptionDialog() : null
 
@@ -61,6 +63,18 @@ export function useUrlActionLoaders() {
       } catch (error) {
         console.error(
           '[UrlActionLoaders] Failed to load top-up dialog from URL:',
+          error
+        )
+      }
+    }
+
+    // Open a Settings panel from URL if present (e.g. ?settings=plan-credits).
+    if (settingsUrlLoader) {
+      try {
+        settingsUrlLoader.loadSettingsFromUrl()
+      } catch (error) {
+        console.error(
+          '[UrlActionLoaders] Failed to load settings panel from URL:',
           error
         )
       }

--- a/src/platform/navigation/preservedQueryNamespaces.ts
+++ b/src/platform/navigation/preservedQueryNamespaces.ts
@@ -7,5 +7,6 @@ export const PRESERVED_QUERY_NAMESPACES = {
   OAUTH: 'oauth',
   PRICING: 'pricing',
   TOPUP: 'topup',
+  SETTINGS: 'settings',
   DESKTOP_LOGIN: 'desktop_login'
 } as const

--- a/src/platform/settings/composables/useSettingsUrlLoader.integration.test.ts
+++ b/src/platform/settings/composables/useSettingsUrlLoader.integration.test.ts
@@ -1,0 +1,109 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as VueRouter from 'vue-router'
+import type { Router } from 'vue-router'
+import { createMemoryHistory, createRouter } from 'vue-router'
+
+import { clearPreservedQuery } from '@/platform/navigation/preservedQueryManager'
+import { PRESERVED_QUERY_NAMESPACES } from '@/platform/navigation/preservedQueryNamespaces'
+import { installPreservedQueryTracker } from '@/platform/navigation/preservedQueryTracker'
+import { useSettingsUrlLoader } from '@/platform/settings/composables/useSettingsUrlLoader'
+
+const STORAGE_KEY = 'Comfy.PreservedQuery.settings'
+
+let testRouter: Router
+
+vi.mock('vue-router', async (importOriginal) => {
+  const actual = await importOriginal<typeof VueRouter>()
+  return {
+    ...actual,
+    useRoute: () => testRouter.currentRoute.value,
+    useRouter: () => testRouter
+  }
+})
+
+const mockShowSettings = vi.hoisted(() => vi.fn())
+
+vi.mock('@/platform/settings/composables/useSettingsDialog', () => ({
+  useSettingsDialog: () => ({
+    show: mockShowSettings
+  })
+}))
+
+function createAppLikeRouter(): Router {
+  const router = createRouter({
+    history: createMemoryHistory(),
+    routes: [{ path: '/:pathMatch(.*)*', component: { template: '<div />' } }]
+  })
+  installPreservedQueryTracker(router, [
+    {
+      namespace: PRESERVED_QUERY_NAMESPACES.SETTINGS,
+      keys: ['settings']
+    }
+  ])
+  return router
+}
+
+describe('useSettingsUrlLoader with real preserved-query boundaries', () => {
+  beforeEach(() => {
+    clearPreservedQuery(PRESERVED_QUERY_NAMESPACES.SETTINGS)
+    sessionStorage.clear()
+    testRouter = createAppLikeRouter()
+  })
+
+  it('opens Plans & Credits and cleans the URL when the param survives to mount', async () => {
+    await testRouter.push('/?settings=plan-credits&keep=1')
+
+    const { loadSettingsFromUrl } = useSettingsUrlLoader()
+    loadSettingsFromUrl()
+
+    expect(mockShowSettings).toHaveBeenCalledExactlyOnceWith('workspace')
+    await vi.waitFor(() =>
+      expect(testRouter.currentRoute.value.fullPath).toBe('/?keep=1')
+    )
+    expect(sessionStorage.getItem(STORAGE_KEY)).toBeNull()
+  })
+
+  it('restores the deep link through a login redirect that drops the query', async () => {
+    await testRouter.push('/?settings=plan-credits')
+    expect(sessionStorage.getItem(STORAGE_KEY)).toBe(
+      JSON.stringify({ settings: 'plan-credits' })
+    )
+
+    await testRouter.push('/cloud/login')
+    await testRouter.push('/')
+
+    const { loadSettingsFromUrl } = useSettingsUrlLoader()
+    loadSettingsFromUrl()
+
+    expect(mockShowSettings).toHaveBeenCalledExactlyOnceWith('workspace')
+    await vi.waitFor(() =>
+      expect(testRouter.currentRoute.value.fullPath).toBe('/')
+    )
+    expect(sessionStorage.getItem(STORAGE_KEY)).toBeNull()
+  })
+
+  it('consumes the stash so a later mount does not reopen the dialog', async () => {
+    await testRouter.push('/?settings=plan-credits')
+    await testRouter.push('/')
+    useSettingsUrlLoader().loadSettingsFromUrl()
+    mockShowSettings.mockClear()
+
+    await testRouter.push('/')
+    useSettingsUrlLoader().loadSettingsFromUrl()
+
+    expect(mockShowSettings).not.toHaveBeenCalled()
+  })
+
+  it('strips an unrecognized value without opening or leaving a stash behind', async () => {
+    await testRouter.push('/?settings=garbage')
+
+    const { loadSettingsFromUrl } = useSettingsUrlLoader()
+    loadSettingsFromUrl()
+
+    expect(mockShowSettings).not.toHaveBeenCalled()
+    await vi.waitFor(() =>
+      expect(testRouter.currentRoute.value.fullPath).toBe('/')
+    )
+    expect(sessionStorage.getItem(STORAGE_KEY)).toBeNull()
+  })
+})

--- a/src/platform/settings/composables/useSettingsUrlLoader.test.ts
+++ b/src/platform/settings/composables/useSettingsUrlLoader.test.ts
@@ -1,0 +1,126 @@
+import { fromAny } from '@total-typescript/shoehorn'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useSettingsUrlLoader } from './useSettingsUrlLoader'
+
+const preservedQueryMocks = vi.hoisted(() => ({
+  clearPreservedQuery: vi.fn(),
+  hydratePreservedQuery: vi.fn(),
+  mergePreservedQueryIntoQuery: vi.fn()
+}))
+
+vi.mock(
+  '@/platform/navigation/preservedQueryManager',
+  () => preservedQueryMocks
+)
+
+const mockRouteQuery = vi.hoisted(() => ({
+  value: {} as Record<string, string>
+}))
+const mockRouterReplace = vi.hoisted(() => vi.fn(async () => undefined))
+
+vi.mock('vue-router', () => ({
+  useRoute: () => ({
+    query: mockRouteQuery.value
+  }),
+  useRouter: () => ({
+    replace: mockRouterReplace
+  })
+}))
+
+const mockShowSettings = vi.hoisted(() => vi.fn())
+
+vi.mock('@/platform/settings/composables/useSettingsDialog', () => ({
+  useSettingsDialog: () => ({
+    show: mockShowSettings
+  })
+}))
+
+describe('useSettingsUrlLoader', () => {
+  beforeEach(() => {
+    mockRouteQuery.value = {}
+    preservedQueryMocks.mergePreservedQueryIntoQuery.mockReturnValue(null)
+  })
+
+  it('does nothing when no settings param present', () => {
+    mockRouteQuery.value = {}
+
+    const { loadSettingsFromUrl } = useSettingsUrlLoader()
+    loadSettingsFromUrl()
+
+    expect(mockShowSettings).not.toHaveBeenCalled()
+    expect(mockRouterReplace).not.toHaveBeenCalled()
+  })
+
+  it('opens the Plans & Credits panel and strips the param', () => {
+    mockRouteQuery.value = { settings: 'plan-credits' }
+
+    const { loadSettingsFromUrl } = useSettingsUrlLoader()
+    loadSettingsFromUrl()
+
+    expect(mockShowSettings).toHaveBeenCalledExactlyOnceWith('workspace')
+    expect(mockRouterReplace).toHaveBeenCalledWith({ query: {} })
+    expect(preservedQueryMocks.clearPreservedQuery).toHaveBeenCalledWith(
+      'settings'
+    )
+  })
+
+  it('preserves unrelated params when stripping', () => {
+    mockRouteQuery.value = { settings: 'plan-credits', other: 'param' }
+
+    const { loadSettingsFromUrl } = useSettingsUrlLoader()
+    loadSettingsFromUrl()
+
+    expect(mockRouterReplace).toHaveBeenCalledWith({
+      query: { other: 'param' }
+    })
+  })
+
+  it('strips but does not open for an unrecognized panel value', () => {
+    mockRouteQuery.value = { settings: 'garbage' }
+
+    const { loadSettingsFromUrl } = useSettingsUrlLoader()
+    loadSettingsFromUrl()
+
+    expect(mockShowSettings).not.toHaveBeenCalled()
+    expect(mockRouterReplace).toHaveBeenCalledWith({ query: {} })
+    expect(preservedQueryMocks.clearPreservedQuery).toHaveBeenCalledWith(
+      'settings'
+    )
+  })
+
+  it('strips but does not open for an empty param', () => {
+    mockRouteQuery.value = { settings: '' }
+
+    const { loadSettingsFromUrl } = useSettingsUrlLoader()
+    loadSettingsFromUrl()
+
+    expect(mockShowSettings).not.toHaveBeenCalled()
+    expect(mockRouterReplace).toHaveBeenCalledWith({ query: {} })
+  })
+
+  it('strips but does not open for a non-string param', () => {
+    mockRouteQuery.value = { settings: fromAny<string, unknown>(['array']) }
+
+    const { loadSettingsFromUrl } = useSettingsUrlLoader()
+    loadSettingsFromUrl()
+
+    expect(mockShowSettings).not.toHaveBeenCalled()
+    expect(mockRouterReplace).toHaveBeenCalledWith({ query: {} })
+  })
+
+  it('restores preserved query and opens the panel', () => {
+    mockRouteQuery.value = {}
+    preservedQueryMocks.mergePreservedQueryIntoQuery.mockReturnValue({
+      settings: 'plan-credits'
+    })
+
+    const { loadSettingsFromUrl } = useSettingsUrlLoader()
+    loadSettingsFromUrl()
+
+    expect(preservedQueryMocks.hydratePreservedQuery).toHaveBeenCalledWith(
+      'settings'
+    )
+    expect(mockShowSettings).toHaveBeenCalledExactlyOnceWith('workspace')
+  })
+})

--- a/src/platform/settings/composables/useSettingsUrlLoader.ts
+++ b/src/platform/settings/composables/useSettingsUrlLoader.ts
@@ -1,0 +1,61 @@
+import { useRoute, useRouter } from 'vue-router'
+
+import {
+  clearPreservedQuery,
+  hydratePreservedQuery,
+  mergePreservedQueryIntoQuery
+} from '@/platform/navigation/preservedQueryManager'
+import { PRESERVED_QUERY_NAMESPACES } from '@/platform/navigation/preservedQueryNamespaces'
+import { useSettingsDialog } from '@/platform/settings/composables/useSettingsDialog'
+import type { SettingPanelType } from '@/platform/settings/types'
+
+const NAMESPACE = PRESERVED_QUERY_NAMESPACES.SETTINGS
+
+const DEEP_LINKABLE_PANELS: Record<string, SettingPanelType> = {
+  'plan-credits': 'workspace'
+}
+
+/**
+ * Opens the Settings dialog on a named panel from a `?settings=` deep link
+ * (e.g. `?settings=plan-credits`), so external surfaces like platform.comfy.org
+ * can land users directly on the tab where they complete billing actions.
+ *
+ * Only values in `DEEP_LINKABLE_PANELS` open a panel; any other value is a
+ * silent no-op with the param stripped. Survives the login redirect via the
+ * preserved-query system, like the top-up URL loader.
+ */
+export function useSettingsUrlLoader() {
+  const route = useRoute()
+  const router = useRouter()
+  const settingsDialog = useSettingsDialog()
+
+  /** Reads `?settings=`, strips it, and opens the mapped Settings panel. */
+  function loadSettingsFromUrl() {
+    hydratePreservedQuery(NAMESPACE)
+    const query =
+      mergePreservedQueryIntoQuery(NAMESPACE, route.query) ?? route.query
+    const param = query.settings
+    if (param === undefined) return
+
+    // Strip any present settings param (even unrecognized or malformed values)
+    // and write the clean URL in a single replace, so a clean URL is
+    // guaranteed even if the replace rejects or no panel matches.
+    const cleanQuery = { ...query }
+    delete cleanQuery.settings
+    router.replace({ query: cleanQuery }).catch((error) => {
+      console.warn('[useSettingsUrlLoader] Failed to clean URL params:', error)
+    })
+    clearPreservedQuery(NAMESPACE)
+
+    if (typeof param !== 'string' || !param) return
+
+    const panel = DEEP_LINKABLE_PANELS[param]
+    if (!panel) return
+
+    settingsDialog.show(panel)
+  }
+
+  return {
+    loadSettingsFromUrl
+  }
+}

--- a/src/router.ts
+++ b/src/router.ts
@@ -130,6 +130,10 @@ installPreservedQueryTracker(router, [
     keys: ['topup']
   },
   {
+    namespace: PRESERVED_QUERY_NAMESPACES.SETTINGS,
+    keys: ['settings']
+  },
+  {
     namespace: PRESERVED_QUERY_NAMESPACES.DESKTOP_LOGIN,
     keys: ['desktop_login_code'],
     stripAfterCapture: true


### PR DESCRIPTION
## Summary
Backports #15808 to \`cloud/1.52\` so \`?settings=plan-credits\` works in the frontend release currently promoted to Cloud production.

## Why
\`cloud/1.52\` branched before #15808 merged, and the original backport labels only covered 1.51. As a result, Cloud production currently strips or ignores the deep-link intent and does not open Plans & Credits.

Slack context: https://comfy-organization.slack.com/archives/C0BNGQG2LCW/p1788190186965279?thread_ts=1787597535.486829&cid=C0BNGQG2LCW

## Changes
- **What**: Manual conflict-resolved cherry-pick of #15808 onto \`cloud/1.52\`
- **Regression coverage**: Preserves the original unit, integration, and browser regression tests

## Verification
- 18 targeted unit/integration tests passed
- \`pnpm typecheck\` passed
- \`pnpm typecheck:browser\` passed
- ESLint/Oxlint/oxfmt passed for changed files
- \`pnpm knip\` passed

## Screenshots
Behavior and UI are unchanged from #15808; see the original PR for AS IS / TO BE evidence.