### PR TITLE
Ignore ARIA dialogs hidden by ancestors in shortcut gate

### DIFF
--- a/src/platform/keybindings/keybindingService.dialog.test.ts
+++ b/src/platform/keybindings/keybindingService.dialog.test.ts
@@ -146,6 +146,26 @@ describe('keybindingService - dialog gate', () => {
     }
   })
 
+  it('executes Ctrl+S while an ARIA modal is inside an aria-hidden ancestor', async () => {
+    const wrapper = document.createElement('div')
+    wrapper.setAttribute('aria-hidden', 'true')
+    const dialog = document.createElement('div')
+    dialog.setAttribute('role', 'dialog')
+    dialog.setAttribute('aria-modal', 'true')
+    wrapper.appendChild(dialog)
+    document.body.appendChild(wrapper)
+
+    try {
+      const event = createKeyboardEvent('s', document.body, { ctrlKey: true })
+      await keybindingService.keybindHandler(event)
+
+      expect(mockCommandExecute).toHaveBeenCalledWith('Comfy.SaveWorkflow')
+      expect(event.defaultPrevented).toBe(true)
+    } finally {
+      document.body.removeChild(wrapper)
+    }
+  })
+
   it('does NOT execute a global keybinding while a reka dialog is open', async () => {
     const dialog = document.createElement('div')
     dialog.setAttribute('role', 'dialog')

--- a/src/utils/modalUtil.ts
+++ b/src/utils/modalUtil.ts
@@ -10,6 +10,12 @@ function hasOpenNativeDialog(): boolean {
   return document.querySelector('dialog[open]') !== null
 }
 
+function hasVisibleAriaModal(): boolean {
+  return Array.from(
+    document.querySelectorAll('[role="dialog"][aria-modal="true"]')
+  ).some((dialog) => dialog.closest('[hidden], [aria-hidden="true"]') === null)
+}
+
 /** ComfyDialog toggles visibility via inline display ('flex' / 'none'). */
 function hasVisibleLegacyModal(): boolean {
   return Array.from(
@@ -22,9 +28,7 @@ function hasVisibleLegacyModal(): boolean {
 export function isModalOpen(managedDialogCount: number): boolean {
   return (
     managedDialogCount > 0 ||
-    document.querySelector(
-      '[role="dialog"][aria-modal="true"]:not([hidden])'
-    ) !== null ||
+    hasVisibleAriaModal() ||
     hasOpenRekaDialog() ||
     hasOpenNativeDialog() ||
     hasVisibleLegacyModal()


### PR DESCRIPTION
## Summary

Treat a generic ARIA modal as closed when it is inside a `hidden` or `aria-hidden="true"` ancestor.

## Regression

#16056 fixed one false-positive form by ignoring a dialog that carries its own native `hidden` attribute. A second real custom-node pattern still breaks global shortcuts:

```html
<div aria-hidden="true" style="display:none">
  <section role="dialog" aria-modal="true">...</section>
</div>
```

The dialog itself is not `hidden`, so the current selector still treats it as open even though its entire containing UI is closed.

This is currently reproducible with H3 Prompt Writer. Its studio DOM remains mounted after first use; the closed root is `aria-hidden="true"` / CSS-hidden while its nested dialog retained `aria-modal="true"`. In the affected browser, that nested `section.h3ps-modal` was the only ARIA-modal candidate left while Ctrl+S was a no-op.

Extension-side correction: xmarre/ComfyUI-MiniMaxH3-Prompt-Writer#3.

## Fix

Replace the direct selector check with a small ARIA-modal helper that ignores candidates beneath either:

- a native `[hidden]` ancestor; or
- an `[aria-hidden="true"]` ancestor.

This remains semantic/attribute based; it does not add layout/style measurement to the keydown path.

Other modal sources are unchanged:

- managed dialog stack;
- open Reka dialogs;
- native `<dialog open>`;
- visible legacy `.comfy-modal` elements.

## Regression coverage

Add a keybinding-service regression that mounts exactly the ancestor-hidden pattern above, sends Ctrl+S, and verifies `Comfy.SaveWorkflow` executes while browser default handling is suppressed.

## Related

- #16056
- xmarre/ComfyUI-Image-Conveyor#42
- xmarre/ComfyUI-MiniMaxH3-Prompt-Writer#3