### PR TITLE
feat(agent): add validated workflow planning and route policy

### DIFF
--- a/src/workbench/extensions/agent/schemas/workflowPlanSchema.test.ts
+++ b/src/workbench/extensions/agent/schemas/workflowPlanSchema.test.ts
@@ -344,8 +344,8 @@ describe('workflowPlanSchema', () => {
           {
             id: 'audio',
             intent: 'text-to-audio',
-            dependsOnStageIds: [],
-            inputMediaTypes: [],
+            dependsOnStageIds: ['image'],
+            inputMediaTypes: ['image'],
             outputMediaType: 'audio',
             instruction: 'Create narration'
           }
@@ -354,6 +354,12 @@ describe('workflowPlanSchema', () => {
     })
 
     expect(result.success).toBe(false)
+    if (result.success) throw new Error('expected plan validation to fail')
+    expect(result.error.issues).toContainEqual(
+      expect.objectContaining({
+        message: 'The final pipeline stage must produce the planned output'
+      })
+    )
   })
 
   it('rejects output media that conflicts with the plan intent', () => {

--- a/src/workbench/extensions/agent/schemas/workflowPlanSchema.test.ts
+++ b/src/workbench/extensions/agent/schemas/workflowPlanSchema.test.ts
@@ -24,6 +24,18 @@ describe('workflowPlanSchema', () => {
     expect(zWorkflowPlan.parse(basePlan())).toEqual(basePlan())
   })
 
+  it('accepts the existing text-to-3d product capability', () => {
+    const plan = {
+      ...basePlan(),
+      brief: 'Create a textured chair model from a description',
+      summary: 'Generate a chair model',
+      intent: 'text-to-3d',
+      outputMediaType: '3d'
+    } satisfies WorkflowPlan
+
+    expect(zWorkflowPlan.parse(plan)).toEqual(plan)
+  })
+
   it('keeps quality independent from the allowed execution boundary', () => {
     const plan = {
       ...basePlan(),
@@ -142,6 +154,37 @@ describe('workflowPlanSchema', () => {
     })
 
     expect(result.success).toBe(false)
+  })
+
+  it('rejects a partially timed sequence without a declared total', () => {
+    const result = zWorkflowPlan.safeParse({
+      ...basePlan(),
+      structure: {
+        kind: 'sequence',
+        units: [
+          {
+            id: 'known-duration',
+            label: 'Known duration',
+            instruction: 'A shot whose requested duration must be honored',
+            durationSeconds: 20
+          },
+          {
+            id: 'unknown-duration',
+            label: 'Unknown duration',
+            instruction: 'A shot that still needs a duration'
+          }
+        ],
+        continuityConstraints: ['Keep the subject consistent']
+      }
+    })
+
+    expect(result.success).toBe(false)
+    if (result.success) throw new Error('expected plan validation to fail')
+    expect(result.error.issues).toContainEqual(
+      expect.objectContaining({
+        message: 'A partially timed sequence requires a duration for every unit'
+      })
+    )
   })
 
   it('accepts a multi-stage screenplay pipeline', () => {
@@ -410,6 +453,44 @@ describe('workflowPlanSchema', () => {
         expect.objectContaining({ message: 'image-edit requires image input' }),
         expect.objectContaining({ message: 'image-edit must produce image' })
       ])
+    )
+  })
+
+  it('rejects duplicate media inputs within a pipeline stage', () => {
+    const result = zWorkflowPlan.safeParse({
+      ...basePlan(),
+      intent: 'text-to-video',
+      outputMediaType: 'video',
+      structure: { kind: 'single' },
+      pipeline: {
+        stages: [
+          {
+            id: 'image',
+            intent: 'text-to-image',
+            dependsOnStageIds: [],
+            inputMediaTypes: [],
+            outputMediaType: 'image',
+            instruction: 'Create a keyframe'
+          },
+          {
+            id: 'motion',
+            intent: 'image-to-video',
+            dependsOnStageIds: ['image'],
+            inputMediaTypes: ['image', 'image'],
+            outputMediaType: 'video',
+            instruction: 'Animate the keyframe'
+          }
+        ]
+      }
+    })
+
+    expect(result.success).toBe(false)
+    if (result.success) throw new Error('expected plan validation to fail')
+    expect(result.error.issues).toContainEqual(
+      expect.objectContaining({
+        path: ['pipeline', 'stages', 1, 'inputMediaTypes'],
+        message: 'Values must be unique'
+      })
     )
   })
 

--- a/src/workbench/extensions/agent/schemas/workflowPlanSchema.test.ts
+++ b/src/workbench/extensions/agent/schemas/workflowPlanSchema.test.ts
@@ -1,0 +1,543 @@
+import { describe, expect, it } from 'vitest'
+
+import { zWorkflowPlan } from './workflowPlanSchema'
+import type { WorkflowPlan } from './workflowPlanSchema'
+
+function basePlan(): WorkflowPlan {
+  return {
+    version: 1,
+    brief: 'Create a polished product image',
+    summary: 'Polished product image',
+    intent: 'text-to-image',
+    inputs: [],
+    outputMediaType: 'image',
+    qualityGoal: 'balanced',
+    executionPreference: 'auto',
+    constraints: [],
+    structure: { kind: 'single' },
+    clarification: { status: 'ready' }
+  }
+}
+
+describe('workflowPlanSchema', () => {
+  it('accepts a single image task', () => {
+    expect(zWorkflowPlan.parse(basePlan())).toEqual(basePlan())
+  })
+
+  it('keeps quality independent from the allowed execution boundary', () => {
+    const plan = {
+      ...basePlan(),
+      qualityGoal: 'best',
+      executionPreference: 'local-only'
+    } satisfies WorkflowPlan
+
+    expect(zWorkflowPlan.parse(plan)).toMatchObject({
+      qualityGoal: 'best',
+      executionPreference: 'local-only'
+    })
+  })
+
+  it('accepts a batch plan when its declared count matches its units', () => {
+    const plan = {
+      ...basePlan(),
+      brief: '把 3 张鞋子图统一换成白底',
+      summary: '三张鞋子白底商品图',
+      intent: 'image-edit',
+      inputs: [
+        {
+          id: 'product-images',
+          mediaType: 'image',
+          quantity: 3,
+          purpose: '待处理的鞋子商品图'
+        }
+      ],
+      constraints: ['商品比例不变', '阴影保持一致'],
+      structure: {
+        kind: 'batch',
+        unitCount: 3,
+        units: [
+          { id: 'shoe-1', label: '鞋子 1', instruction: '换成白底' },
+          { id: 'shoe-2', label: '鞋子 2', instruction: '换成白底' },
+          { id: 'shoe-3', label: '鞋子 3', instruction: '换成白底' }
+        ]
+      }
+    } satisfies WorkflowPlan
+
+    expect(zWorkflowPlan.safeParse(plan).success).toBe(true)
+  })
+
+  it('accepts a one-minute storyboard with explicit continuity', () => {
+    const events = [
+      ['play', '小狗和小羊在草地上玩耍'],
+      ['find-ball', '它们发现一个皮球'],
+      ['play-ball', '它们轮流顶球'],
+      ['sheep-rests', '小羊累了，走回羊圈'],
+      ['dog-closes-gate', '小狗关好羊圈门'],
+      ['dog-sleeps', '小狗在门边睡着']
+    ] as const
+    const plan = {
+      ...basePlan(),
+      brief: '用两张参考图生成一分钟的小狗和小羊动画',
+      summary: '小狗和小羊玩球后休息的连续动画',
+      intent: 'image-to-video',
+      inputs: [
+        {
+          id: 'dog-reference',
+          mediaType: 'image',
+          quantity: 1,
+          purpose: '保持小狗外观一致'
+        },
+        {
+          id: 'sheep-reference',
+          mediaType: 'image',
+          quantity: 1,
+          purpose: '保持小羊外观一致'
+        }
+      ],
+      outputMediaType: 'video',
+      qualityGoal: 'best',
+      executionPreference: 'cloud-allowed',
+      constraints: ['小狗和小羊外观一致', '空间方向连续', '镜头衔接自然'],
+      targetDurationSeconds: 60,
+      structure: {
+        kind: 'sequence',
+        units: events.map(([id, instruction]) => ({
+          id,
+          label: id,
+          instruction,
+          durationSeconds: 10
+        })),
+        continuityConstraints: ['角色外观', '草地和羊圈位置', '皮球颜色']
+      }
+    } satisfies WorkflowPlan
+
+    const parsed = zWorkflowPlan.parse(plan)
+    expect(parsed.structure.kind).toBe('sequence')
+    expect(parsed.targetDurationSeconds).toBe(60)
+  })
+
+  it.for([
+    {
+      name: 'a missing unit duration',
+      durations: [30, undefined]
+    },
+    {
+      name: 'durations that do not fill the target',
+      durations: [20, 20]
+    }
+  ])('rejects a timed sequence with $name', ({ durations }) => {
+    const result = zWorkflowPlan.safeParse({
+      ...basePlan(),
+      targetDurationSeconds: 60,
+      structure: {
+        kind: 'sequence',
+        units: durations.map((duration, index) => ({
+          id: `shot-${index}`,
+          label: `Shot ${index}`,
+          instruction: `Story beat ${index}`,
+          ...(duration === undefined ? {} : { durationSeconds: duration })
+        })),
+        continuityConstraints: ['Keep the subject consistent']
+      }
+    })
+
+    expect(result.success).toBe(false)
+  })
+
+  it('accepts a multi-stage screenplay pipeline', () => {
+    const plan = {
+      ...basePlan(),
+      brief: '把剧本做成带配音的竖屏短片',
+      summary: '剧本到带配音短片',
+      intent: 'text-to-video',
+      outputMediaType: 'video',
+      targetDurationSeconds: 30,
+      structure: {
+        kind: 'sequence',
+        units: [
+          {
+            id: 'opening',
+            label: 'Opening',
+            instruction: 'Introduce the character',
+            durationSeconds: 10
+          },
+          {
+            id: 'conflict',
+            label: 'Conflict',
+            instruction: 'Show the central conflict',
+            durationSeconds: 10
+          },
+          {
+            id: 'ending',
+            label: 'Ending',
+            instruction: 'Resolve the story',
+            durationSeconds: 10
+          }
+        ],
+        continuityConstraints: ['Keep the character and setting consistent']
+      },
+      pipeline: {
+        stages: [
+          {
+            id: 'keyframes',
+            intent: 'text-to-image',
+            dependsOnStageIds: [],
+            inputMediaTypes: [],
+            outputMediaType: 'image',
+            instruction: '生成角色一致的分镜关键帧'
+          },
+          {
+            id: 'motion',
+            intent: 'image-to-video',
+            dependsOnStageIds: ['keyframes'],
+            inputMediaTypes: ['image'],
+            outputMediaType: 'video',
+            instruction: '将关键帧制作成连续镜头'
+          },
+          {
+            id: 'narration',
+            intent: 'text-to-audio',
+            dependsOnStageIds: [],
+            inputMediaTypes: [],
+            outputMediaType: 'audio',
+            instruction: 'Generate narration from the screenplay'
+          },
+          {
+            id: 'edit',
+            intent: 'video-edit',
+            dependsOnStageIds: ['motion', 'narration'],
+            inputMediaTypes: ['video', 'audio'],
+            outputMediaType: 'video',
+            instruction: '合并镜头、配音和转场'
+          }
+        ]
+      }
+    } satisfies WorkflowPlan
+
+    const parsed = zWorkflowPlan.parse(plan)
+    expect(parsed.structure.kind).toBe('sequence')
+    expect(parsed.pipeline?.stages).toHaveLength(4)
+  })
+
+  it('requires a question when the plan needs user input', () => {
+    const result = zWorkflowPlan.safeParse({
+      ...basePlan(),
+      clarification: { status: 'needs-input' }
+    })
+
+    expect(result.success).toBe(false)
+  })
+
+  it('accepts an incomplete provisional plan while awaiting user input', () => {
+    const plan = {
+      ...basePlan(),
+      brief: 'Make it better',
+      summary: 'Improve the selected media',
+      intent: 'image-edit',
+      inputs: [],
+      clarification: {
+        status: 'needs-input',
+        question: 'What should I improve, and what result do you want?'
+      }
+    } satisfies WorkflowPlan
+
+    expect(zWorkflowPlan.safeParse(plan).success).toBe(true)
+  })
+
+  it('rejects a batch whose count disagrees with its units', () => {
+    const result = zWorkflowPlan.safeParse({
+      ...basePlan(),
+      structure: {
+        kind: 'batch',
+        unitCount: 3,
+        units: [
+          { id: 'one', label: 'One', instruction: 'First variant' },
+          { id: 'two', label: 'Two', instruction: 'Second variant' }
+        ]
+      }
+    })
+
+    expect(result.success).toBe(false)
+  })
+
+  it.for([
+    {
+      name: 'duplicate input ids',
+      patch: {
+        inputs: [
+          {
+            id: 'reference',
+            mediaType: 'image',
+            quantity: 1,
+            purpose: 'First subject'
+          },
+          {
+            id: 'reference',
+            mediaType: 'image',
+            quantity: 1,
+            purpose: 'Second subject'
+          }
+        ]
+      }
+    },
+    {
+      name: 'duplicate sequence unit ids',
+      patch: {
+        structure: {
+          kind: 'sequence',
+          units: [
+            { id: 'shot', label: 'One', instruction: 'First shot' },
+            { id: 'shot', label: 'Two', instruction: 'Second shot' }
+          ],
+          continuityConstraints: []
+        }
+      }
+    }
+  ])('rejects $name', ({ patch }) => {
+    expect(zWorkflowPlan.safeParse({ ...basePlan(), ...patch }).success).toBe(
+      false
+    )
+  })
+
+  it.for([
+    ['image-edit', 'image'],
+    ['image-upscale', 'image'],
+    ['image-to-video', 'image'],
+    ['video-edit', 'video'],
+    ['audio-edit', 'audio'],
+    ['image-to-3d', 'image']
+  ] as const)(
+    'requires $0 to receive $1 input',
+    ([intent, requiredMediaType]) => {
+      const result = zWorkflowPlan.safeParse({
+        ...basePlan(),
+        intent,
+        inputs: []
+      })
+
+      expect(result.success).toBe(false)
+      if (result.success) throw new Error('expected plan validation to fail')
+      expect(result.error.issues).toContainEqual(
+        expect.objectContaining({
+          message: `${intent} requires ${requiredMediaType} input`
+        })
+      )
+    }
+  )
+
+  it('rejects a pipeline whose final stage has the wrong output type', () => {
+    const result = zWorkflowPlan.safeParse({
+      ...basePlan(),
+      intent: 'text-to-video',
+      outputMediaType: 'video',
+      structure: { kind: 'single' },
+      pipeline: {
+        stages: [
+          {
+            id: 'image',
+            intent: 'text-to-image',
+            dependsOnStageIds: [],
+            inputMediaTypes: [],
+            outputMediaType: 'image',
+            instruction: 'Create a frame'
+          },
+          {
+            id: 'audio',
+            intent: 'text-to-audio',
+            dependsOnStageIds: [],
+            inputMediaTypes: [],
+            outputMediaType: 'audio',
+            instruction: 'Create narration'
+          }
+        ]
+      }
+    })
+
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects output media that conflicts with the plan intent', () => {
+    const result = zWorkflowPlan.safeParse({
+      ...basePlan(),
+      outputMediaType: 'video'
+    })
+
+    expect(result.success).toBe(false)
+    if (result.success) throw new Error('expected plan validation to fail')
+    expect(result.error.issues).toContainEqual(
+      expect.objectContaining({ message: 'text-to-image must produce image' })
+    )
+  })
+
+  it('validates intent compatibility inside every pipeline stage', () => {
+    const result = zWorkflowPlan.safeParse({
+      ...basePlan(),
+      intent: 'text-to-video',
+      outputMediaType: 'video',
+      structure: { kind: 'single' },
+      pipeline: {
+        stages: [
+          {
+            id: 'bad-keyframe',
+            intent: 'image-edit',
+            dependsOnStageIds: [],
+            inputMediaTypes: [],
+            outputMediaType: 'video',
+            instruction: 'Edit a missing image into a video'
+          },
+          {
+            id: 'motion',
+            intent: 'image-to-video',
+            dependsOnStageIds: ['bad-keyframe'],
+            inputMediaTypes: ['image'],
+            outputMediaType: 'video',
+            instruction: 'Animate the keyframe'
+          }
+        ]
+      }
+    })
+
+    expect(result.success).toBe(false)
+    if (result.success) throw new Error('expected plan validation to fail')
+    expect(result.error.issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ message: 'image-edit requires image input' }),
+        expect.objectContaining({ message: 'image-edit must produce image' })
+      ])
+    )
+  })
+
+  it('rejects missing and forward stage dependencies', () => {
+    const result = zWorkflowPlan.safeParse({
+      ...basePlan(),
+      intent: 'text-to-video',
+      outputMediaType: 'video',
+      structure: { kind: 'single' },
+      pipeline: {
+        stages: [
+          {
+            id: 'image',
+            intent: 'text-to-image',
+            dependsOnStageIds: ['motion'],
+            inputMediaTypes: [],
+            outputMediaType: 'image',
+            instruction: 'Create a frame'
+          },
+          {
+            id: 'motion',
+            intent: 'image-to-video',
+            dependsOnStageIds: [],
+            inputMediaTypes: ['image'],
+            outputMediaType: 'video',
+            instruction: 'Animate a frame with no declared source'
+          }
+        ]
+      }
+    })
+
+    expect(result.success).toBe(false)
+    if (result.success) throw new Error('expected plan validation to fail')
+    expect(result.error.issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          message: 'Pipeline stages may depend only on earlier stages'
+        }),
+        expect.objectContaining({
+          message: 'Pipeline stage input image has no source'
+        })
+      ])
+    )
+  })
+
+  it('rejects a dependency whose output is not consumed', () => {
+    const result = zWorkflowPlan.safeParse({
+      ...basePlan(),
+      intent: 'text-to-video',
+      outputMediaType: 'video',
+      structure: { kind: 'single' },
+      pipeline: {
+        stages: [
+          {
+            id: 'narration',
+            intent: 'text-to-audio',
+            dependsOnStageIds: [],
+            inputMediaTypes: [],
+            outputMediaType: 'audio',
+            instruction: 'Create narration'
+          },
+          {
+            id: 'motion',
+            intent: 'text-to-video',
+            dependsOnStageIds: ['narration'],
+            inputMediaTypes: [],
+            outputMediaType: 'video',
+            instruction: 'Create video without using the narration'
+          }
+        ]
+      }
+    })
+
+    expect(result.success).toBe(false)
+    if (result.success) throw new Error('expected plan validation to fail')
+    expect(result.error.issues).toContainEqual(
+      expect.objectContaining({
+        message: 'A stage dependency output must be declared as an input'
+      })
+    )
+  })
+
+  it('rejects a pipeline stage that does not contribute to the final output', () => {
+    const result = zWorkflowPlan.safeParse({
+      ...basePlan(),
+      intent: 'text-to-video',
+      outputMediaType: 'video',
+      structure: { kind: 'single' },
+      pipeline: {
+        stages: [
+          {
+            id: 'unused-image',
+            intent: 'text-to-image',
+            dependsOnStageIds: [],
+            inputMediaTypes: [],
+            outputMediaType: 'image',
+            instruction: 'Create an image that is never used'
+          },
+          {
+            id: 'video',
+            intent: 'text-to-video',
+            dependsOnStageIds: [],
+            inputMediaTypes: [],
+            outputMediaType: 'video',
+            instruction: 'Create an unrelated video'
+          }
+        ]
+      }
+    })
+
+    expect(result.success).toBe(false)
+    if (result.success) throw new Error('expected plan validation to fail')
+    expect(result.error.issues).toContainEqual(
+      expect.objectContaining({
+        message: 'Every pipeline stage must contribute to the final output'
+      })
+    )
+  })
+
+  it('rejects unknown fields and unsafe collection sizes', () => {
+    expect(
+      zWorkflowPlan.safeParse({ ...basePlan(), modelName: 'unverified-model' })
+        .success
+    ).toBe(false)
+    expect(
+      zWorkflowPlan.safeParse({
+        ...basePlan(),
+        structure: { kind: 'batch', unitCount: 65 }
+      }).success
+    ).toBe(false)
+  })
+
+  it('returns a safe result for unknown input', () => {
+    const result = zWorkflowPlan.safeParse('not a structured plan')
+    expect(result.success).toBe(false)
+  })
+})

--- a/src/workbench/extensions/agent/schemas/workflowPlanSchema.test.ts
+++ b/src/workbench/extensions/agent/schemas/workflowPlanSchema.test.ts
@@ -131,13 +131,15 @@ describe('workflowPlanSchema', () => {
   it.for([
     {
       name: 'a missing unit duration',
-      durations: [30, undefined]
+      durations: [30, undefined],
+      message: 'A timed sequence requires a duration for every unit'
     },
     {
       name: 'durations that do not fill the target',
-      durations: [20, 20]
+      durations: [20, 20],
+      message: 'Sequence unit durations must equal the target duration'
     }
-  ])('rejects a timed sequence with $name', ({ durations }) => {
+  ])('rejects a timed sequence with $name', ({ durations, message }) => {
     const result = zWorkflowPlan.safeParse({
       ...basePlan(),
       targetDurationSeconds: 60,
@@ -154,6 +156,10 @@ describe('workflowPlanSchema', () => {
     })
 
     expect(result.success).toBe(false)
+    if (result.success) throw new Error('expected plan validation to fail')
+    expect(result.error.issues).toContainEqual(
+      expect.objectContaining({ message })
+    )
   })
 
   it('rejects a partially timed sequence without a declared total', () => {
@@ -356,13 +362,17 @@ describe('workflowPlanSchema', () => {
             { id: 'shot', label: 'One', instruction: 'First shot' },
             { id: 'shot', label: 'Two', instruction: 'Second shot' }
           ],
-          continuityConstraints: []
+          continuityConstraints: ['Keep the subject consistent']
         }
       }
     }
   ])('rejects $name', ({ patch }) => {
-    expect(zWorkflowPlan.safeParse({ ...basePlan(), ...patch }).success).toBe(
-      false
+    const result = zWorkflowPlan.safeParse({ ...basePlan(), ...patch })
+
+    expect(result.success).toBe(false)
+    if (result.success) throw new Error('expected plan validation to fail')
+    expect(result.error.issues).toContainEqual(
+      expect.objectContaining({ message: 'Values must be unique' })
     )
   })
 

--- a/src/workbench/extensions/agent/schemas/workflowPlanSchema.test.ts
+++ b/src/workbench/extensions/agent/schemas/workflowPlanSchema.test.ts
@@ -187,6 +187,30 @@ describe('workflowPlanSchema', () => {
     )
   })
 
+  it('rejects an implicit sequence duration above the plan limit', () => {
+    const result = zWorkflowPlan.safeParse({
+      ...basePlan(),
+      structure: {
+        kind: 'sequence',
+        units: Array.from({ length: 7 }, (_, index) => ({
+          id: `shot-${index}`,
+          label: `Shot ${index}`,
+          instruction: `Long story beat ${index}`,
+          durationSeconds: 600
+        })),
+        continuityConstraints: ['Keep the subject consistent']
+      }
+    })
+
+    expect(result.success).toBe(false)
+    if (result.success) throw new Error('expected plan validation to fail')
+    expect(result.error.issues).toContainEqual(
+      expect.objectContaining({
+        message: 'Sequence duration must not exceed 3600 seconds'
+      })
+    )
+  })
+
   it('accepts a multi-stage screenplay pipeline', () => {
     const plan = {
       ...basePlan(),

--- a/src/workbench/extensions/agent/schemas/workflowPlanSchema.test.ts
+++ b/src/workbench/extensions/agent/schemas/workflowPlanSchema.test.ts
@@ -331,6 +331,12 @@ describe('workflowPlanSchema', () => {
     })
 
     expect(result.success).toBe(false)
+    if (result.success) throw new Error('expected plan validation to fail')
+    expect(result.error.issues).toContainEqual(
+      expect.objectContaining({
+        message: 'Batch unitCount must match the number of units'
+      })
+    )
   })
 
   it.for([

--- a/src/workbench/extensions/agent/schemas/workflowPlanSchema.ts
+++ b/src/workbench/extensions/agent/schemas/workflowPlanSchema.ts
@@ -14,6 +14,7 @@ const zWorkflowIntent = z.enum([
   'video-edit',
   'text-to-audio',
   'audio-edit',
+  'text-to-3d',
   'image-to-3d'
 ])
 export type WorkflowIntent = z.infer<typeof zWorkflowIntent>

--- a/src/workbench/extensions/agent/schemas/workflowPlanSchema.ts
+++ b/src/workbench/extensions/agent/schemas/workflowPlanSchema.ts
@@ -1,0 +1,109 @@
+import { z } from 'zod'
+
+import { addWorkflowPlanIssues } from './workflowPlanValidation'
+
+const zWorkflowMediaType = z.enum(['image', 'video', 'audio', '3d'])
+export type WorkflowMediaType = z.infer<typeof zWorkflowMediaType>
+
+const zWorkflowIntent = z.enum([
+  'text-to-image',
+  'image-edit',
+  'image-upscale',
+  'text-to-video',
+  'image-to-video',
+  'video-edit',
+  'text-to-audio',
+  'audio-edit',
+  'image-to-3d'
+])
+export type WorkflowIntent = z.infer<typeof zWorkflowIntent>
+
+const zRequiredText = z.string().trim().min(1)
+const zIdentifier = zRequiredText.max(80)
+
+const zWorkUnit = z
+  .object({
+    id: zIdentifier,
+    label: zRequiredText.max(120),
+    instruction: zRequiredText.max(4_000),
+    durationSeconds: z.number().positive().max(600).optional()
+  })
+  .strict()
+
+const zInputRequirement = z
+  .object({
+    id: zIdentifier,
+    mediaType: zWorkflowMediaType,
+    quantity: z.number().int().min(1).max(64),
+    purpose: zRequiredText.max(500)
+  })
+  .strict()
+
+const zPipelineStage = z
+  .object({
+    id: zIdentifier,
+    intent: zWorkflowIntent,
+    dependsOnStageIds: z.array(zIdentifier).max(16),
+    inputMediaTypes: z.array(zWorkflowMediaType).max(4),
+    outputMediaType: zWorkflowMediaType,
+    instruction: zRequiredText.max(4_000)
+  })
+  .strict()
+
+const zExecutionStructure = z.discriminatedUnion('kind', [
+  z.object({ kind: z.literal('single') }).strict(),
+  z
+    .object({
+      kind: z.literal('batch'),
+      unitCount: z.number().int().min(2).max(64),
+      units: z.array(zWorkUnit).min(2).max(64).optional()
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal('sequence'),
+      units: z.array(zWorkUnit).min(2).max(64),
+      continuityConstraints: z.array(zRequiredText.max(500)).min(1).max(16)
+    })
+    .strict()
+])
+
+const zPipeline = z
+  .object({
+    stages: z.array(zPipelineStage).min(2).max(16)
+  })
+  .strict()
+
+const zClarification = z.discriminatedUnion('status', [
+  z.object({ status: z.literal('ready') }).strict(),
+  z
+    .object({
+      status: z.literal('needs-input'),
+      question: zRequiredText.max(500)
+    })
+    .strict()
+])
+
+const zWorkflowPlanShape = z
+  .object({
+    version: z.literal(1),
+    brief: zRequiredText.max(8_000),
+    summary: zRequiredText.max(500),
+    intent: zWorkflowIntent,
+    inputs: z.array(zInputRequirement).max(16),
+    outputMediaType: zWorkflowMediaType,
+    qualityGoal: z.enum(['draft', 'balanced', 'best']),
+    executionPreference: z.enum(['auto', 'local-only', 'cloud-allowed']),
+    constraints: z.array(zRequiredText.max(500)).max(32),
+    targetDurationSeconds: z.number().positive().max(3_600).optional(),
+    structure: zExecutionStructure,
+    pipeline: zPipeline.optional(),
+    clarification: zClarification
+  })
+  .strict()
+
+export type WorkflowPlan = z.infer<typeof zWorkflowPlanShape>
+
+export const zWorkflowPlan = zWorkflowPlanShape.superRefine(
+  addWorkflowPlanIssues
+)

--- a/src/workbench/extensions/agent/schemas/workflowPlanValidation.ts
+++ b/src/workbench/extensions/agent/schemas/workflowPlanValidation.ts
@@ -1,3 +1,4 @@
+import { sumBy } from 'es-toolkit'
 import { z } from 'zod'
 
 import type {
@@ -130,9 +131,7 @@ function addSequenceDurationIssues(
 }
 
 function sumDurations(durations: readonly (number | undefined)[]): number {
-  let totalDuration = 0
-  for (const duration of durations) totalDuration += duration ?? 0
-  return totalDuration
+  return sumBy(durations, (duration) => duration ?? 0)
 }
 
 function addPipelineIssues(plan: WorkflowPlan, context: z.RefinementCtx): void {

--- a/src/workbench/extensions/agent/schemas/workflowPlanValidation.ts
+++ b/src/workbench/extensions/agent/schemas/workflowPlanValidation.ts
@@ -103,6 +103,13 @@ function addSequenceDurationIssues(
         path: ['structure', 'units']
       })
     }
+    if (!hasMissingDuration && sumDurations(durations) > 3_600) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Sequence duration must not exceed 3600 seconds',
+        path: ['structure', 'units']
+      })
+    }
     return
   }
   if (hasMissingDuration) {
@@ -113,14 +120,19 @@ function addSequenceDurationIssues(
     })
     return
   }
-  let totalDuration = 0
-  for (const duration of durations) totalDuration += duration ?? 0
+  const totalDuration = sumDurations(durations)
   if (Math.abs(totalDuration - plan.targetDurationSeconds) < 0.001) return
   context.addIssue({
     code: z.ZodIssueCode.custom,
     message: 'Sequence unit durations must equal the target duration',
     path: ['structure', 'units']
   })
+}
+
+function sumDurations(durations: readonly (number | undefined)[]): number {
+  let totalDuration = 0
+  for (const duration of durations) totalDuration += duration ?? 0
+  return totalDuration
 }
 
 function addPipelineIssues(plan: WorkflowPlan, context: z.RefinementCtx): void {

--- a/src/workbench/extensions/agent/schemas/workflowPlanValidation.ts
+++ b/src/workbench/extensions/agent/schemas/workflowPlanValidation.ts
@@ -1,0 +1,259 @@
+import { z } from 'zod'
+
+import type {
+  WorkflowIntent,
+  WorkflowMediaType,
+  WorkflowPlan
+} from './workflowPlanSchema'
+
+type PipelineStage = NonNullable<WorkflowPlan['pipeline']>['stages'][number]
+
+const OUTPUT_MEDIA_BY_INTENT: Record<WorkflowIntent, WorkflowMediaType> = {
+  'text-to-image': 'image',
+  'image-edit': 'image',
+  'image-upscale': 'image',
+  'text-to-video': 'video',
+  'image-to-video': 'video',
+  'video-edit': 'video',
+  'text-to-audio': 'audio',
+  'audio-edit': 'audio',
+  'image-to-3d': '3d'
+}
+
+const INPUT_MEDIA_BY_INTENT: Partial<
+  Record<WorkflowIntent, WorkflowMediaType>
+> = {
+  'image-edit': 'image',
+  'image-upscale': 'image',
+  'image-to-video': 'image',
+  'video-edit': 'video',
+  'audio-edit': 'audio',
+  'image-to-3d': 'image'
+}
+
+export function addWorkflowPlanIssues(
+  plan: WorkflowPlan,
+  context: z.RefinementCtx
+): void {
+  addDuplicateIssue(
+    plan.inputs.map((input) => input.id),
+    ['inputs'],
+    context
+  )
+  if (plan.clarification.status === 'needs-input') return
+
+  addIntentCompatibilityIssues(
+    plan.intent,
+    plan.inputs.map((input) => input.mediaType),
+    plan.outputMediaType,
+    ['inputs'],
+    ['outputMediaType'],
+    context
+  )
+  addStructureIssues(plan, context)
+  if (plan.pipeline !== undefined) addPipelineIssues(plan, context)
+}
+
+function addStructureIssues(
+  plan: WorkflowPlan,
+  context: z.RefinementCtx
+): void {
+  if (plan.structure.kind === 'batch') {
+    const { units, unitCount } = plan.structure
+    if (units !== undefined && units.length !== unitCount) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Batch unitCount must match the number of units',
+        path: ['structure', 'units']
+      })
+    }
+    if (units !== undefined)
+      addDuplicateIssue(
+        units.map((unit) => unit.id),
+        ['structure', 'units'],
+        context
+      )
+  }
+  if (plan.structure.kind !== 'sequence') return
+  addDuplicateIssue(
+    plan.structure.units.map((unit) => unit.id),
+    ['structure', 'units'],
+    context
+  )
+  addSequenceDurationIssues(plan, context)
+}
+
+function addSequenceDurationIssues(
+  plan: WorkflowPlan,
+  context: z.RefinementCtx
+): void {
+  if (
+    plan.structure.kind !== 'sequence' ||
+    plan.targetDurationSeconds === undefined
+  )
+    return
+  const durations = plan.structure.units.map((unit) => unit.durationSeconds)
+  if (durations.some((duration) => duration === undefined)) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: 'A timed sequence requires a duration for every unit',
+      path: ['structure', 'units']
+    })
+    return
+  }
+  let totalDuration = 0
+  for (const duration of durations) totalDuration += duration ?? 0
+  if (Math.abs(totalDuration - plan.targetDurationSeconds) < 0.001) return
+  context.addIssue({
+    code: z.ZodIssueCode.custom,
+    message: 'Sequence unit durations must equal the target duration',
+    path: ['structure', 'units']
+  })
+}
+
+function addPipelineIssues(plan: WorkflowPlan, context: z.RefinementCtx): void {
+  const stages = plan.pipeline?.stages
+  if (stages === undefined) return
+  addDuplicateIssue(
+    stages.map((stage) => stage.id),
+    ['pipeline', 'stages'],
+    context
+  )
+  stages.forEach((stage, index) => {
+    addDuplicateIssue(
+      stage.dependsOnStageIds,
+      ['pipeline', 'stages', index, 'dependsOnStageIds'],
+      context
+    )
+    addIntentCompatibilityIssues(
+      stage.intent,
+      stage.inputMediaTypes,
+      stage.outputMediaType,
+      ['pipeline', 'stages', index, 'inputMediaTypes'],
+      ['pipeline', 'stages', index, 'outputMediaType'],
+      context
+    )
+    addStageDependencyIssues(stages, index, plan.inputs, context)
+  })
+  if (stages.at(-1)?.outputMediaType !== plan.outputMediaType) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: 'The final pipeline stage must produce the planned output',
+      path: ['pipeline', 'stages']
+    })
+  }
+  addOrphanStageIssues(stages, context)
+}
+
+function addStageDependencyIssues(
+  stages: readonly PipelineStage[],
+  stageIndex: number,
+  inputs: WorkflowPlan['inputs'],
+  context: z.RefinementCtx
+): void {
+  const stage = stages[stageIndex]
+  if (stage === undefined) return
+  const priorStages = new Map(
+    stages
+      .slice(0, stageIndex)
+      .map((candidate) => [candidate.id, candidate] as const)
+  )
+  const dependencyOutputs: WorkflowMediaType[] = []
+  for (const dependencyId of stage.dependsOnStageIds) {
+    const dependency = priorStages.get(dependencyId)
+    if (dependency === undefined) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Pipeline stages may depend only on earlier stages',
+        path: ['pipeline', 'stages', stageIndex, 'dependsOnStageIds']
+      })
+      continue
+    }
+    dependencyOutputs.push(dependency.outputMediaType)
+    if (!stage.inputMediaTypes.includes(dependency.outputMediaType)) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'A stage dependency output must be declared as an input',
+        path: ['pipeline', 'stages', stageIndex, 'inputMediaTypes']
+      })
+    }
+  }
+
+  const availableInputs = new Set<WorkflowMediaType>([
+    ...inputs.map((input) => input.mediaType),
+    ...dependencyOutputs
+  ])
+  for (const mediaType of stage.inputMediaTypes) {
+    if (availableInputs.has(mediaType)) continue
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: `Pipeline stage input ${mediaType} has no source`,
+      path: ['pipeline', 'stages', stageIndex, 'inputMediaTypes']
+    })
+  }
+}
+
+function addOrphanStageIssues(
+  stages: readonly PipelineStage[],
+  context: z.RefinementCtx
+): void {
+  const finalStage = stages.at(-1)
+  if (finalStage === undefined) return
+  const stagesById = new Map(stages.map((stage) => [stage.id, stage] as const))
+  const contributingStageIds = new Set<string>()
+  const pendingIds = [...finalStage.dependsOnStageIds]
+  while (pendingIds.length > 0) {
+    const stageId = pendingIds.pop()
+    if (stageId === undefined || contributingStageIds.has(stageId)) continue
+    const stage = stagesById.get(stageId)
+    if (stage === undefined) continue
+    contributingStageIds.add(stageId)
+    pendingIds.push(...stage.dependsOnStageIds)
+  }
+  stages.slice(0, -1).forEach((stage, index) => {
+    if (contributingStageIds.has(stage.id)) return
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: 'Every pipeline stage must contribute to the final output',
+      path: ['pipeline', 'stages', index]
+    })
+  })
+}
+
+function addDuplicateIssue(
+  values: readonly string[],
+  path: Array<string | number>,
+  context: z.RefinementCtx
+): void {
+  if (new Set(values).size === values.length) return
+  context.addIssue({
+    code: z.ZodIssueCode.custom,
+    message: 'Values must be unique',
+    path
+  })
+}
+
+function addIntentCompatibilityIssues(
+  intent: WorkflowIntent,
+  inputMediaTypes: readonly WorkflowMediaType[],
+  outputMediaType: WorkflowMediaType,
+  inputPath: Array<string | number>,
+  outputPath: Array<string | number>,
+  context: z.RefinementCtx
+): void {
+  const requiredInput = INPUT_MEDIA_BY_INTENT[intent]
+  if (requiredInput !== undefined && !inputMediaTypes.includes(requiredInput)) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: `${intent} requires ${requiredInput} input`,
+      path: inputPath
+    })
+  }
+  const expectedOutput = OUTPUT_MEDIA_BY_INTENT[intent]
+  if (outputMediaType === expectedOutput) return
+  context.addIssue({
+    code: z.ZodIssueCode.custom,
+    message: `${intent} must produce ${expectedOutput}`,
+    path: outputPath
+  })
+}

--- a/src/workbench/extensions/agent/schemas/workflowPlanValidation.ts
+++ b/src/workbench/extensions/agent/schemas/workflowPlanValidation.ts
@@ -17,6 +17,7 @@ const OUTPUT_MEDIA_BY_INTENT: Record<WorkflowIntent, WorkflowMediaType> = {
   'video-edit': 'video',
   'text-to-audio': 'audio',
   'audio-edit': 'audio',
+  'text-to-3d': '3d',
   'image-to-3d': '3d'
 }
 
@@ -87,13 +88,24 @@ function addSequenceDurationIssues(
   plan: WorkflowPlan,
   context: z.RefinementCtx
 ): void {
-  if (
-    plan.structure.kind !== 'sequence' ||
-    plan.targetDurationSeconds === undefined
-  )
-    return
+  if (plan.structure.kind !== 'sequence') return
   const durations = plan.structure.units.map((unit) => unit.durationSeconds)
-  if (durations.some((duration) => duration === undefined)) {
+  const hasDuration = durations.some((duration) => duration !== undefined)
+  const hasMissingDuration = durations.some(
+    (duration) => duration === undefined
+  )
+  if (plan.targetDurationSeconds === undefined) {
+    if (hasDuration && hasMissingDuration) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          'A partially timed sequence requires a duration for every unit',
+        path: ['structure', 'units']
+      })
+    }
+    return
+  }
+  if (hasMissingDuration) {
     context.addIssue({
       code: z.ZodIssueCode.custom,
       message: 'A timed sequence requires a duration for every unit',
@@ -123,6 +135,11 @@ function addPipelineIssues(plan: WorkflowPlan, context: z.RefinementCtx): void {
     addDuplicateIssue(
       stage.dependsOnStageIds,
       ['pipeline', 'stages', index, 'dependsOnStageIds'],
+      context
+    )
+    addDuplicateIssue(
+      stage.inputMediaTypes,
+      ['pipeline', 'stages', index, 'inputMediaTypes'],
       context
     )
     addIntentCompatibilityIssues(

--- a/src/workbench/extensions/agent/services/agent/selectWorkflowRoute.test.ts
+++ b/src/workbench/extensions/agent/services/agent/selectWorkflowRoute.test.ts
@@ -1,0 +1,421 @@
+import { describe, expect, it } from 'vitest'
+
+import { selectWorkflowRoute } from './selectWorkflowRoute'
+import type { WorkflowRouteCandidate } from './selectWorkflowRoute'
+import type { WorkflowPlan } from '../../schemas/workflowPlanSchema'
+
+function plan(overrides: Partial<WorkflowPlan> = {}): WorkflowPlan {
+  return {
+    version: 1,
+    brief: 'Generate an image',
+    summary: 'Image generation',
+    intent: 'text-to-image',
+    inputs: [],
+    outputMediaType: 'image',
+    qualityGoal: 'balanced',
+    executionPreference: 'auto',
+    constraints: [],
+    structure: { kind: 'single' },
+    clarification: { status: 'ready' },
+    ...overrides
+  }
+}
+
+function route(
+  id: string,
+  overrides: Partial<WorkflowRouteCandidate> = {}
+): WorkflowRouteCandidate {
+  return {
+    id,
+    title: id,
+    intents: ['text-to-image'],
+    inputCapacity: {},
+    outputMediaType: 'image',
+    supportedStructures: ['single'],
+    supportedPipelineIntents: [],
+    maxOutputUnits: 1,
+    executionMode: 'local',
+    isPaid: false,
+    taskFitScore: 80,
+    qualityScore: 80,
+    speedScore: 80,
+    availability: { status: 'ready' },
+    ...overrides
+  }
+}
+
+describe('selectWorkflowRoute', () => {
+  it('waits for required user input before evaluating routes', () => {
+    const selection = selectWorkflowRoute(
+      plan({
+        clarification: {
+          status: 'needs-input',
+          question: 'Which aspect ratio should the result use?'
+        }
+      }),
+      [route('otherwise-ready')]
+    )
+
+    expect(selection).toEqual({ status: 'needs-input' })
+  })
+
+  it('selects the highest-quality route for a best-quality plan', () => {
+    const selection = selectWorkflowRoute(plan({ qualityGoal: 'best' }), [
+      route('fast', { qualityScore: 60, speedScore: 100 }),
+      route('quality', { qualityScore: 95, speedScore: 40 })
+    ])
+
+    expect(selection).toMatchObject({
+      status: 'ready',
+      route: { id: 'quality' }
+    })
+  })
+
+  it('selects the fastest route for a draft plan with equal task fit', () => {
+    const selection = selectWorkflowRoute(plan({ qualityGoal: 'draft' }), [
+      route('slow', { qualityScore: 95, speedScore: 30 }),
+      route('fast', { qualityScore: 60, speedScore: 100 })
+    ])
+
+    expect(selection).toMatchObject({ status: 'ready', route: { id: 'fast' } })
+  })
+
+  it('does not trade task suitability for a generic quality score', () => {
+    const selection = selectWorkflowRoute(plan(), [
+      route('specialist', { taskFitScore: 81, qualityScore: 1 }),
+      route('generic', { taskFitScore: 80, qualityScore: 100 })
+    ])
+
+    expect(selection).toMatchObject({
+      status: 'ready',
+      route: { id: 'specialist' }
+    })
+  })
+
+  it('recommends setup for the best route instead of silently downgrading', () => {
+    const selection = selectWorkflowRoute(plan({ qualityGoal: 'best' }), [
+      route('installed-fallback', { qualityScore: 70 }),
+      route('best-local', {
+        qualityScore: 98,
+        availability: {
+          status: 'setup-required',
+          missingModels: ['best-model.safetensors'],
+          missingNodeTypes: ['BestSampler']
+        }
+      })
+    ])
+
+    expect(selection).toMatchObject({
+      status: 'setup-required',
+      route: { id: 'best-local' },
+      readyFallback: { id: 'installed-fallback' }
+    })
+  })
+
+  it('requires approval before selecting a ready paid cloud route', () => {
+    const selection = selectWorkflowRoute(plan({ qualityGoal: 'best' }), [
+      route('local', { qualityScore: 70 }),
+      route('cloud', {
+        executionMode: 'cloud',
+        isPaid: true,
+        qualityScore: 99
+      })
+    ])
+
+    expect(selection).toMatchObject({
+      status: 'approval-required',
+      route: { id: 'cloud' }
+    })
+  })
+
+  it('requires approval for any paid route', () => {
+    const selection = selectWorkflowRoute(plan(), [
+      route('licensed-local-service', { isPaid: true })
+    ])
+
+    expect(selection).toMatchObject({
+      status: 'approval-required',
+      route: { id: 'licensed-local-service' }
+    })
+  })
+
+  it('excludes cloud routes when the plan is local-only', () => {
+    const selection = selectWorkflowRoute(
+      plan({ executionPreference: 'local-only', qualityGoal: 'best' }),
+      [
+        route('local', { qualityScore: 60 }),
+        route('cloud', {
+          executionMode: 'cloud',
+          isPaid: true,
+          qualityScore: 100
+        })
+      ]
+    )
+
+    expect(selection).toMatchObject({ status: 'ready', route: { id: 'local' } })
+  })
+
+  it('prefers local when otherwise-identical routes tie', () => {
+    const selection = selectWorkflowRoute(plan(), [
+      route('cloud', { executionMode: 'cloud' }),
+      route('local')
+    ])
+
+    expect(selection).toMatchObject({ status: 'ready', route: { id: 'local' } })
+  })
+
+  it('requires enough capacity for every referenced input', () => {
+    const twoReferences = plan({
+      intent: 'image-to-video',
+      inputs: [
+        {
+          id: 'dog',
+          mediaType: 'image',
+          quantity: 1,
+          purpose: 'Dog reference'
+        },
+        {
+          id: 'sheep',
+          mediaType: 'image',
+          quantity: 1,
+          purpose: 'Sheep reference'
+        }
+      ],
+      outputMediaType: 'video'
+    })
+    const selection = selectWorkflowRoute(twoReferences, [
+      route('single-reference', {
+        intents: ['image-to-video'],
+        inputCapacity: { image: 1 },
+        outputMediaType: 'video',
+        qualityScore: 100
+      }),
+      route('multi-reference', {
+        intents: ['image-to-video'],
+        inputCapacity: { image: 4 },
+        outputMediaType: 'video',
+        qualityScore: 80
+      })
+    ])
+
+    expect(selection).toMatchObject({
+      status: 'ready',
+      route: { id: 'multi-reference' }
+    })
+  })
+
+  it('does not substitute a single clip route for a long sequence', () => {
+    const minuteSequence = plan({
+      intent: 'image-to-video',
+      inputs: [
+        {
+          id: 'characters',
+          mediaType: 'image',
+          quantity: 2,
+          purpose: 'Character references'
+        }
+      ],
+      outputMediaType: 'video',
+      targetDurationSeconds: 60,
+      structure: {
+        kind: 'sequence',
+        units: Array.from({ length: 6 }, (_, index) => ({
+          id: `shot-${index + 1}`,
+          label: `Shot ${index + 1}`,
+          instruction: `Story beat ${index + 1}`,
+          durationSeconds: 10
+        })),
+        continuityConstraints: ['Keep both characters consistent']
+      }
+    })
+    const selection = selectWorkflowRoute(minuteSequence, [
+      route('five-second-clip', {
+        intents: ['image-to-video'],
+        inputCapacity: { image: 2 },
+        outputMediaType: 'video',
+        maxDurationSeconds: 5,
+        qualityScore: 100
+      }),
+      route('minute-story', {
+        intents: ['image-to-video'],
+        inputCapacity: { image: 2 },
+        outputMediaType: 'video',
+        supportedStructures: ['sequence'],
+        maxOutputUnits: 8,
+        maxDurationSeconds: 60,
+        qualityScore: 80
+      })
+    ])
+
+    expect(selection).toMatchObject({
+      status: 'ready',
+      route: { id: 'minute-story' }
+    })
+  })
+
+  it('requires a route to support the requested batch size', () => {
+    const batch = plan({
+      structure: { kind: 'batch', unitCount: 8 }
+    })
+    const selection = selectWorkflowRoute(batch, [
+      route('four-variants', {
+        supportedStructures: ['batch'],
+        maxOutputUnits: 4
+      }),
+      route('eight-variants', {
+        supportedStructures: ['batch'],
+        maxOutputUnits: 8
+      })
+    ])
+
+    expect(selection).toMatchObject({
+      status: 'ready',
+      route: { id: 'eight-variants' }
+    })
+  })
+
+  it('requires explicit pipeline support for a multi-capability plan', () => {
+    const pipeline = plan({
+      intent: 'text-to-video',
+      outputMediaType: 'video',
+      structure: { kind: 'single' },
+      pipeline: {
+        stages: [
+          {
+            id: 'image',
+            intent: 'text-to-image',
+            dependsOnStageIds: [],
+            inputMediaTypes: [],
+            outputMediaType: 'image',
+            instruction: 'Create the keyframe'
+          },
+          {
+            id: 'motion',
+            intent: 'image-to-video',
+            dependsOnStageIds: ['image'],
+            inputMediaTypes: ['image'],
+            outputMediaType: 'video',
+            instruction: 'Animate the keyframe'
+          }
+        ]
+      }
+    })
+    const selection = selectWorkflowRoute(pipeline, [
+      route('single-video', {
+        intents: ['text-to-video'],
+        outputMediaType: 'video'
+      }),
+      route('composed-video', {
+        intents: ['text-to-video'],
+        outputMediaType: 'video',
+        supportedPipelineIntents: ['text-to-image', 'image-to-video']
+      })
+    ])
+
+    expect(selection).toMatchObject({
+      status: 'ready',
+      route: { id: 'composed-video' }
+    })
+  })
+
+  it('requires support for every capability in a pipeline', () => {
+    const production = plan({
+      intent: 'text-to-video',
+      outputMediaType: 'video',
+      pipeline: {
+        stages: [
+          {
+            id: 'keyframe',
+            intent: 'text-to-image',
+            dependsOnStageIds: [],
+            inputMediaTypes: [],
+            outputMediaType: 'image',
+            instruction: 'Create a keyframe'
+          },
+          {
+            id: 'motion',
+            intent: 'image-to-video',
+            dependsOnStageIds: ['keyframe'],
+            inputMediaTypes: ['image'],
+            outputMediaType: 'video',
+            instruction: 'Animate the keyframe'
+          },
+          {
+            id: 'narration',
+            intent: 'text-to-audio',
+            dependsOnStageIds: [],
+            inputMediaTypes: [],
+            outputMediaType: 'audio',
+            instruction: 'Generate narration'
+          },
+          {
+            id: 'edit',
+            intent: 'video-edit',
+            dependsOnStageIds: ['motion', 'narration'],
+            inputMediaTypes: ['video', 'audio'],
+            outputMediaType: 'video',
+            instruction: 'Combine the video and narration'
+          }
+        ]
+      }
+    })
+    const selection = selectWorkflowRoute(production, [
+      route('no-audio', {
+        intents: ['text-to-video'],
+        outputMediaType: 'video',
+        supportedPipelineIntents: [
+          'text-to-image',
+          'image-to-video',
+          'video-edit'
+        ],
+        taskFitScore: 100
+      }),
+      route('complete-production', {
+        intents: ['text-to-video'],
+        outputMediaType: 'video',
+        supportedPipelineIntents: [
+          'text-to-image',
+          'image-to-video',
+          'text-to-audio',
+          'video-edit'
+        ]
+      })
+    ])
+
+    expect(selection).toMatchObject({
+      status: 'ready',
+      route: { id: 'complete-production' }
+    })
+  })
+
+  it('does not assume an unknown duration limit can satisfy a timed task', () => {
+    const selection = selectWorkflowRoute(
+      plan({
+        intent: 'text-to-video',
+        outputMediaType: 'video',
+        targetDurationSeconds: 10
+      }),
+      [
+        route('unknown-limit', {
+          intents: ['text-to-video'],
+          outputMediaType: 'video'
+        })
+      ]
+    )
+
+    expect(selection).toEqual({ status: 'no-match' })
+  })
+
+  it('ignores unavailable and incompatible routes', () => {
+    const selection = selectWorkflowRoute(plan(), [
+      route('unavailable', {
+        qualityScore: 100,
+        availability: { status: 'unavailable', reason: 'No supported GPU' }
+      }),
+      route('wrong-output', { outputMediaType: 'video' }),
+      route('wrong-intent', { intents: ['text-to-video'] })
+    ])
+
+    expect(selection).toEqual({ status: 'no-match' })
+  })
+})

--- a/src/workbench/extensions/agent/services/agent/selectWorkflowRoute.test.ts
+++ b/src/workbench/extensions/agent/services/agent/selectWorkflowRoute.test.ts
@@ -323,6 +323,8 @@ describe('selectWorkflowRoute', () => {
         intents: ['image-to-video'],
         inputCapacity: { image: 2 },
         outputMediaType: 'video',
+        supportedStructures: ['sequence'],
+        maxWorkUnits: 8,
         maxDurationSeconds: 5,
         qualityScore: 100
       }),

--- a/src/workbench/extensions/agent/services/agent/selectWorkflowRoute.test.ts
+++ b/src/workbench/extensions/agent/services/agent/selectWorkflowRoute.test.ts
@@ -156,12 +156,18 @@ describe('selectWorkflowRoute', () => {
   })
 
   it('prefers local when otherwise-identical routes tie', () => {
-    const selection = selectWorkflowRoute(plan(), [
-      route('cloud', { executionMode: 'cloud' }),
-      route('local')
-    ])
+    const local = route('local')
+    const cloud = route('cloud', { executionMode: 'cloud' })
 
-    expect(selection).toMatchObject({ status: 'ready', route: { id: 'local' } })
+    for (const candidates of [
+      [cloud, local],
+      [local, cloud]
+    ]) {
+      expect(selectWorkflowRoute(plan(), candidates)).toMatchObject({
+        status: 'ready',
+        route: { id: 'local' }
+      })
+    }
   })
 
   it('requires enough capacity for every referenced input', () => {

--- a/src/workbench/extensions/agent/services/agent/selectWorkflowRoute.test.ts
+++ b/src/workbench/extensions/agent/services/agent/selectWorkflowRoute.test.ts
@@ -200,6 +200,21 @@ describe('selectWorkflowRoute', () => {
     }
   })
 
+  it('prefers a free route when otherwise-identical routes tie', () => {
+    const free = route('free')
+    const paid = route('paid', { isPaid: true })
+
+    for (const candidates of [
+      [free, paid],
+      [paid, free]
+    ]) {
+      expect(selectWorkflowRoute(plan(), candidates)).toMatchObject({
+        status: 'ready',
+        route: { id: 'free' }
+      })
+    }
+  })
+
   it('uses a locale-independent id tie-breaker', () => {
     const alpha = route('alpha')
     const zulu = route('zulu')
@@ -322,6 +337,54 @@ describe('selectWorkflowRoute', () => {
     expect(selection).toMatchObject({
       status: 'ready',
       route: { id: 'eight-variants' }
+    })
+  })
+
+  it('requires a route to support every explicit batch item duration', () => {
+    const batch = plan({
+      intent: 'text-to-video',
+      outputMediaType: 'video',
+      structure: {
+        kind: 'batch',
+        unitCount: 2,
+        units: [
+          {
+            id: 'short',
+            label: 'Short clip',
+            instruction: 'Create a short variant',
+            durationSeconds: 5
+          },
+          {
+            id: 'long',
+            label: 'Long clip',
+            instruction: 'Create a long variant',
+            durationSeconds: 30
+          }
+        ]
+      }
+    })
+    const selection = selectWorkflowRoute(batch, [
+      route('short-clips', {
+        intents: ['text-to-video'],
+        outputMediaType: 'video',
+        supportedStructures: ['batch'],
+        maxWorkUnits: 2,
+        maxDurationSeconds: 5,
+        qualityScore: 100
+      }),
+      route('long-clips', {
+        intents: ['text-to-video'],
+        outputMediaType: 'video',
+        supportedStructures: ['batch'],
+        maxWorkUnits: 2,
+        maxDurationSeconds: 30,
+        qualityScore: 80
+      })
+    ])
+
+    expect(selection).toMatchObject({
+      status: 'ready',
+      route: { id: 'long-clips' }
     })
   })
 

--- a/src/workbench/extensions/agent/services/agent/selectWorkflowRoute.test.ts
+++ b/src/workbench/extensions/agent/services/agent/selectWorkflowRoute.test.ts
@@ -1,8 +1,16 @@
 import { describe, expect, it } from 'vitest'
 
 import { selectWorkflowRoute } from './selectWorkflowRoute'
-import type { WorkflowRouteCandidate } from './selectWorkflowRoute'
+import type {
+  RunnableWorkflowRouteSelection,
+  WorkflowRouteAvailability,
+  WorkflowRouteCandidate
+} from './selectWorkflowRoute'
 import type { WorkflowPlan } from '../../schemas/workflowPlanSchema'
+
+const readyAvailability = {
+  status: 'ready'
+} satisfies WorkflowRouteAvailability
 
 function plan(overrides: Partial<WorkflowPlan> = {}): WorkflowPlan {
   return {
@@ -39,7 +47,7 @@ function route(
     taskFitScore: 80,
     qualityScore: 80,
     speedScore: 80,
-    availability: { status: 'ready' },
+    availability: readyAvailability,
     ...overrides
   }
 }
@@ -152,10 +160,11 @@ describe('selectWorkflowRoute', () => {
       })
     ])
 
-    expect(selection).toMatchObject({
-      status: 'approval-required',
-      route: { id: 'cloud' }
-    })
+    expect(selection.status).toBe('approval-required')
+    if (selection.status !== 'approval-required')
+      throw new Error('expected approval to be required')
+    const runnableSelection: RunnableWorkflowRouteSelection = selection
+    expect(runnableSelection.route.id).toBe('cloud')
   })
 
   it('requires approval for any paid route', () => {
@@ -231,16 +240,16 @@ describe('selectWorkflowRoute', () => {
   })
 
   it('uses a locale-independent id tie-breaker', () => {
-    const alpha = route('alpha')
-    const zulu = route('zulu')
+    const upperCase = route('Zebra')
+    const lowerCase = route('alpha')
 
     for (const candidates of [
-      [zulu, alpha],
-      [alpha, zulu]
+      [lowerCase, upperCase],
+      [upperCase, lowerCase]
     ]) {
       expect(selectWorkflowRoute(plan(), candidates)).toMatchObject({
         status: 'ready',
-        route: { id: 'alpha' }
+        route: { id: 'Zebra' }
       })
     }
   })

--- a/src/workbench/extensions/agent/services/agent/selectWorkflowRoute.test.ts
+++ b/src/workbench/extensions/agent/services/agent/selectWorkflowRoute.test.ts
@@ -215,6 +215,21 @@ describe('selectWorkflowRoute', () => {
     }
   })
 
+  it('does not charge for a local route when an equivalent cloud route is free', () => {
+    const paidLocal = route('paid-local', { isPaid: true })
+    const freeCloud = route('free-cloud', { executionMode: 'cloud' })
+
+    for (const candidates of [
+      [paidLocal, freeCloud],
+      [freeCloud, paidLocal]
+    ]) {
+      expect(selectWorkflowRoute(plan(), candidates)).toMatchObject({
+        status: 'ready',
+        route: { id: 'free-cloud' }
+      })
+    }
+  })
+
   it('uses a locale-independent id tie-breaker', () => {
     const alpha = route('alpha')
     const zulu = route('zulu')
@@ -344,6 +359,7 @@ describe('selectWorkflowRoute', () => {
     const batch = plan({
       intent: 'text-to-video',
       outputMediaType: 'video',
+      targetDurationSeconds: 5,
       structure: {
         kind: 'batch',
         unitCount: 2,

--- a/src/workbench/extensions/agent/services/agent/selectWorkflowRoute.test.ts
+++ b/src/workbench/extensions/agent/services/agent/selectWorkflowRoute.test.ts
@@ -33,7 +33,7 @@ function route(
     outputMediaType: 'image',
     supportedStructures: ['single'],
     supportedPipelineIntents: [],
-    maxOutputUnits: 1,
+    maxWorkUnits: 1,
     executionMode: 'local',
     isPaid: false,
     taskFitScore: 80,
@@ -61,8 +61,8 @@ describe('selectWorkflowRoute', () => {
 
   it('selects the highest-quality route for a best-quality plan', () => {
     const selection = selectWorkflowRoute(plan({ qualityGoal: 'best' }), [
-      route('fast', { qualityScore: 60, speedScore: 100 }),
-      route('quality', { qualityScore: 95, speedScore: 40 })
+      route('fast', { qualityScore: 94, speedScore: 100 }),
+      route('quality', { qualityScore: 95, speedScore: 0 })
     ])
 
     expect(selection).toMatchObject({
@@ -73,8 +73,8 @@ describe('selectWorkflowRoute', () => {
 
   it('selects the fastest route for a draft plan with equal task fit', () => {
     const selection = selectWorkflowRoute(plan({ qualityGoal: 'draft' }), [
-      route('slow', { qualityScore: 95, speedScore: 30 }),
-      route('fast', { qualityScore: 60, speedScore: 100 })
+      route('slow', { qualityScore: 100, speedScore: 94 }),
+      route('fast', { qualityScore: 0, speedScore: 95 })
     ])
 
     expect(selection).toMatchObject({ status: 'ready', route: { id: 'fast' } })
@@ -108,7 +108,37 @@ describe('selectWorkflowRoute', () => {
     expect(selection).toMatchObject({
       status: 'setup-required',
       route: { id: 'best-local' },
-      readyFallback: { id: 'installed-fallback' }
+      fallback: {
+        status: 'ready',
+        route: { id: 'installed-fallback' }
+      }
+    })
+  })
+
+  it('preserves approval for a paid fallback', () => {
+    const selection = selectWorkflowRoute(plan({ qualityGoal: 'best' }), [
+      route('paid-cloud-fallback', {
+        executionMode: 'cloud',
+        isPaid: true,
+        qualityScore: 70
+      }),
+      route('best-local', {
+        qualityScore: 98,
+        availability: {
+          status: 'setup-required',
+          missingModels: ['best-model.safetensors'],
+          missingNodeTypes: []
+        }
+      })
+    ])
+
+    expect(selection).toMatchObject({
+      status: 'setup-required',
+      route: { id: 'best-local' },
+      fallback: {
+        status: 'approval-required',
+        route: { id: 'paid-cloud-fallback' }
+      }
     })
   })
 
@@ -166,6 +196,21 @@ describe('selectWorkflowRoute', () => {
       expect(selectWorkflowRoute(plan(), candidates)).toMatchObject({
         status: 'ready',
         route: { id: 'local' }
+      })
+    }
+  })
+
+  it('uses a locale-independent id tie-breaker', () => {
+    const alpha = route('alpha')
+    const zulu = route('zulu')
+
+    for (const candidates of [
+      [zulu, alpha],
+      [alpha, zulu]
+    ]) {
+      expect(selectWorkflowRoute(plan(), candidates)).toMatchObject({
+        status: 'ready',
+        route: { id: 'alpha' }
       })
     }
   })
@@ -247,7 +292,7 @@ describe('selectWorkflowRoute', () => {
         inputCapacity: { image: 2 },
         outputMediaType: 'video',
         supportedStructures: ['sequence'],
-        maxOutputUnits: 8,
+        maxWorkUnits: 8,
         maxDurationSeconds: 60,
         qualityScore: 80
       })
@@ -266,11 +311,11 @@ describe('selectWorkflowRoute', () => {
     const selection = selectWorkflowRoute(batch, [
       route('four-variants', {
         supportedStructures: ['batch'],
-        maxOutputUnits: 4
+        maxWorkUnits: 4
       }),
       route('eight-variants', {
         supportedStructures: ['batch'],
-        maxOutputUnits: 8
+        maxWorkUnits: 8
       })
     ])
 

--- a/src/workbench/extensions/agent/services/agent/selectWorkflowRoute.ts
+++ b/src/workbench/extensions/agent/services/agent/selectWorkflowRoute.ts
@@ -4,7 +4,7 @@ import type {
   WorkflowPlan
 } from '../../schemas/workflowPlanSchema'
 
-type WorkflowRouteAvailability =
+export type WorkflowRouteAvailability =
   | { status: 'ready' }
   | {
       status: 'setup-required'
@@ -31,7 +31,7 @@ export interface WorkflowRouteCandidate {
   availability: WorkflowRouteAvailability
 }
 
-type RunnableWorkflowRouteSelection =
+export type RunnableWorkflowRouteSelection =
   | { status: 'ready'; route: WorkflowRouteCandidate }
   | { status: 'approval-required'; route: WorkflowRouteCandidate }
 

--- a/src/workbench/extensions/agent/services/agent/selectWorkflowRoute.ts
+++ b/src/workbench/extensions/agent/services/agent/selectWorkflowRoute.ts
@@ -1,0 +1,160 @@
+import type {
+  WorkflowIntent,
+  WorkflowMediaType,
+  WorkflowPlan
+} from '../../schemas/workflowPlanSchema'
+
+type WorkflowRouteAvailability =
+  | { status: 'ready' }
+  | {
+      status: 'setup-required'
+      missingModels: readonly string[]
+      missingNodeTypes: readonly string[]
+    }
+  | { status: 'unavailable'; reason: string }
+
+export interface WorkflowRouteCandidate {
+  id: string
+  title: string
+  intents: readonly WorkflowIntent[]
+  inputCapacity: Partial<Record<WorkflowMediaType, number>>
+  outputMediaType: WorkflowMediaType
+  supportedStructures: readonly WorkflowPlan['structure']['kind'][]
+  supportedPipelineIntents: readonly WorkflowIntent[]
+  maxOutputUnits: number
+  maxDurationSeconds?: number
+  executionMode: 'local' | 'cloud'
+  isPaid: boolean
+  taskFitScore: number
+  qualityScore: number
+  speedScore: number
+  availability: WorkflowRouteAvailability
+}
+
+export type WorkflowRouteSelection =
+  | { status: 'needs-input' }
+  | { status: 'no-match' }
+  | { status: 'ready'; route: WorkflowRouteCandidate }
+  | { status: 'approval-required'; route: WorkflowRouteCandidate }
+  | {
+      status: 'setup-required'
+      route: WorkflowRouteCandidate
+      readyFallback?: WorkflowRouteCandidate
+    }
+
+export function selectWorkflowRoute(
+  plan: WorkflowPlan,
+  candidates: readonly WorkflowRouteCandidate[]
+): WorkflowRouteSelection {
+  if (plan.clarification.status === 'needs-input')
+    return { status: 'needs-input' }
+  const ranked = candidates
+    .filter((candidate) => isEligible(candidate, plan))
+    .toSorted((left, right) => compareRoutes(left, right, plan.qualityGoal))
+  const route = ranked[0]
+  if (route === undefined) return { status: 'no-match' }
+
+  if (route.availability.status === 'setup-required') {
+    const readyFallback = ranked.find(
+      (candidate) => candidate.availability.status === 'ready'
+    )
+    return {
+      status: 'setup-required',
+      route,
+      ...(readyFallback === undefined ? {} : { readyFallback })
+    }
+  }
+
+  if (route.isPaid) return { status: 'approval-required', route }
+  return { status: 'ready', route }
+}
+
+function isEligible(
+  candidate: WorkflowRouteCandidate,
+  plan: WorkflowPlan
+): boolean {
+  if (candidate.availability.status === 'unavailable') return false
+  if (!candidate.intents.includes(plan.intent)) return false
+  if (candidate.outputMediaType !== plan.outputMediaType) return false
+  if (!candidate.supportedStructures.includes(plan.structure.kind)) return false
+  if (
+    plan.pipeline !== undefined &&
+    !plan.pipeline.stages.every((stage) =>
+      candidate.supportedPipelineIntents.includes(stage.intent)
+    )
+  )
+    return false
+  if (requiredOutputUnits(plan) > candidate.maxOutputUnits) return false
+  const durationSeconds = requestedDurationSeconds(plan)
+  if (
+    durationSeconds !== undefined &&
+    (candidate.maxDurationSeconds === undefined ||
+      durationSeconds > candidate.maxDurationSeconds)
+  )
+    return false
+  if (
+    plan.executionPreference === 'local-only' &&
+    candidate.executionMode !== 'local'
+  )
+    return false
+
+  const inputTotals = new Map<WorkflowMediaType, number>()
+  for (const input of plan.inputs) {
+    inputTotals.set(
+      input.mediaType,
+      (inputTotals.get(input.mediaType) ?? 0) + input.quantity
+    )
+  }
+  return [...inputTotals].every(
+    ([mediaType, quantity]) =>
+      quantity <= (candidate.inputCapacity[mediaType] ?? 0)
+  )
+}
+
+function requiredOutputUnits(plan: WorkflowPlan): number {
+  if (plan.structure.kind === 'batch') return plan.structure.unitCount
+  if (plan.structure.kind === 'sequence') return plan.structure.units.length
+  return 1
+}
+
+function requestedDurationSeconds(plan: WorkflowPlan): number | undefined {
+  if (plan.targetDurationSeconds !== undefined)
+    return plan.targetDurationSeconds
+  if (plan.structure.kind !== 'sequence') return undefined
+  const durations = plan.structure.units.map((unit) => unit.durationSeconds)
+  if (durations.some((duration) => duration === undefined)) return undefined
+  let totalDuration = 0
+  for (const duration of durations) totalDuration += duration ?? 0
+  return totalDuration
+}
+
+function compareRoutes(
+  left: WorkflowRouteCandidate,
+  right: WorkflowRouteCandidate,
+  qualityGoal: WorkflowPlan['qualityGoal']
+): number {
+  const taskFitDifference = right.taskFitScore - left.taskFitScore
+  if (taskFitDifference !== 0) return taskFitDifference
+  const scoreDifference =
+    scoreExperience(right, qualityGoal) - scoreExperience(left, qualityGoal)
+  if (scoreDifference !== 0) return scoreDifference
+  if (left.availability.status === 'ready') return -1
+  if (right.availability.status === 'ready') return 1
+  if (left.executionMode === 'local' && right.executionMode !== 'local')
+    return -1
+  if (right.executionMode === 'local' && left.executionMode !== 'local')
+    return 1
+  return left.id.localeCompare(right.id)
+}
+
+function scoreExperience(
+  candidate: WorkflowRouteCandidate,
+  qualityGoal: WorkflowPlan['qualityGoal']
+): number {
+  const qualityWeight = qualityGoal === 'best' ? 8 : 4
+  const speedWeight =
+    qualityGoal === 'draft' ? 8 : qualityGoal === 'best' ? 1 : 4
+  return (
+    candidate.qualityScore * qualityWeight + candidate.speedScore * speedWeight
+  )
+}

--- a/src/workbench/extensions/agent/services/agent/selectWorkflowRoute.ts
+++ b/src/workbench/extensions/agent/services/agent/selectWorkflowRoute.ts
@@ -21,7 +21,7 @@ export interface WorkflowRouteCandidate {
   outputMediaType: WorkflowMediaType
   supportedStructures: readonly WorkflowPlan['structure']['kind'][]
   supportedPipelineIntents: readonly WorkflowIntent[]
-  maxOutputUnits: number
+  maxWorkUnits: number
   maxDurationSeconds?: number
   executionMode: 'local' | 'cloud'
   isPaid: boolean
@@ -31,15 +31,18 @@ export interface WorkflowRouteCandidate {
   availability: WorkflowRouteAvailability
 }
 
+type RunnableWorkflowRouteSelection =
+  | { status: 'ready'; route: WorkflowRouteCandidate }
+  | { status: 'approval-required'; route: WorkflowRouteCandidate }
+
 export type WorkflowRouteSelection =
   | { status: 'needs-input' }
   | { status: 'no-match' }
-  | { status: 'ready'; route: WorkflowRouteCandidate }
-  | { status: 'approval-required'; route: WorkflowRouteCandidate }
+  | RunnableWorkflowRouteSelection
   | {
       status: 'setup-required'
       route: WorkflowRouteCandidate
-      readyFallback?: WorkflowRouteCandidate
+      fallback?: RunnableWorkflowRouteSelection
     }
 
 export function selectWorkflowRoute(
@@ -55,18 +58,27 @@ export function selectWorkflowRoute(
   if (route === undefined) return { status: 'no-match' }
 
   if (route.availability.status === 'setup-required') {
-    const readyFallback = ranked.find(
+    const fallbackRoute = ranked.find(
       (candidate) => candidate.availability.status === 'ready'
     )
     return {
       status: 'setup-required',
       route,
-      ...(readyFallback === undefined ? {} : { readyFallback })
+      ...(fallbackRoute === undefined
+        ? {}
+        : { fallback: selectRunnableRoute(fallbackRoute) })
     }
   }
 
-  if (route.isPaid) return { status: 'approval-required', route }
-  return { status: 'ready', route }
+  return selectRunnableRoute(route)
+}
+
+function selectRunnableRoute(
+  route: WorkflowRouteCandidate
+): RunnableWorkflowRouteSelection {
+  return route.isPaid
+    ? { status: 'approval-required', route }
+    : { status: 'ready', route }
 }
 
 function isEligible(
@@ -84,7 +96,7 @@ function isEligible(
     )
   )
     return false
-  if (requiredOutputUnits(plan) > candidate.maxOutputUnits) return false
+  if (requiredWorkUnits(plan) > candidate.maxWorkUnits) return false
   const durationSeconds = requestedDurationSeconds(plan)
   if (
     durationSeconds !== undefined &&
@@ -111,7 +123,7 @@ function isEligible(
   )
 }
 
-function requiredOutputUnits(plan: WorkflowPlan): number {
+function requiredWorkUnits(plan: WorkflowPlan): number {
   if (plan.structure.kind === 'batch') return plan.structure.unitCount
   if (plan.structure.kind === 'sequence') return plan.structure.units.length
   return 1
@@ -135,9 +147,8 @@ function compareRoutes(
 ): number {
   const taskFitDifference = right.taskFitScore - left.taskFitScore
   if (taskFitDifference !== 0) return taskFitDifference
-  const scoreDifference =
-    scoreExperience(right, qualityGoal) - scoreExperience(left, qualityGoal)
-  if (scoreDifference !== 0) return scoreDifference
+  const experienceDifference = compareExperience(left, right, qualityGoal)
+  if (experienceDifference !== 0) return experienceDifference
   const availabilityDifference =
     Number(left.availability.status !== 'ready') -
     Number(right.availability.status !== 'ready')
@@ -146,17 +157,28 @@ function compareRoutes(
     return -1
   if (right.executionMode === 'local' && left.executionMode !== 'local')
     return 1
-  return left.id.localeCompare(right.id)
+  if (left.id === right.id) return 0
+  return left.id < right.id ? -1 : 1
 }
 
-function scoreExperience(
-  candidate: WorkflowRouteCandidate,
+function compareExperience(
+  left: WorkflowRouteCandidate,
+  right: WorkflowRouteCandidate,
   qualityGoal: WorkflowPlan['qualityGoal']
 ): number {
-  const qualityWeight = qualityGoal === 'best' ? 8 : 4
-  const speedWeight =
-    qualityGoal === 'draft' ? 8 : qualityGoal === 'best' ? 1 : 4
+  if (qualityGoal === 'best') {
+    const qualityDifference = right.qualityScore - left.qualityScore
+    return qualityDifference === 0
+      ? right.speedScore - left.speedScore
+      : qualityDifference
+  }
+  if (qualityGoal === 'draft') {
+    const speedDifference = right.speedScore - left.speedScore
+    return speedDifference === 0
+      ? right.qualityScore - left.qualityScore
+      : speedDifference
+  }
   return (
-    candidate.qualityScore * qualityWeight + candidate.speedScore * speedWeight
+    right.qualityScore + right.speedScore - left.qualityScore - left.speedScore
   )
 }

--- a/src/workbench/extensions/agent/services/agent/selectWorkflowRoute.ts
+++ b/src/workbench/extensions/agent/services/agent/selectWorkflowRoute.ts
@@ -130,22 +130,26 @@ function requiredWorkUnits(plan: WorkflowPlan): number {
 }
 
 function requestedDurationSeconds(plan: WorkflowPlan): number | undefined {
-  if (plan.targetDurationSeconds !== undefined)
-    return plan.targetDurationSeconds
+  let structureDurationSeconds: number | undefined
   if (plan.structure.kind === 'batch') {
     const durations = plan.structure.units?.flatMap((unit) =>
       unit.durationSeconds === undefined ? [] : [unit.durationSeconds]
     )
-    return durations === undefined || durations.length === 0
-      ? undefined
-      : Math.max(...durations)
+    structureDurationSeconds =
+      durations === undefined || durations.length === 0
+        ? undefined
+        : Math.max(...durations)
+  } else if (plan.structure.kind === 'sequence') {
+    const durations = plan.structure.units.map((unit) => unit.durationSeconds)
+    if (!durations.some((duration) => duration === undefined)) {
+      structureDurationSeconds = 0
+      for (const duration of durations)
+        structureDurationSeconds += duration ?? 0
+    }
   }
-  if (plan.structure.kind === 'single') return undefined
-  const durations = plan.structure.units.map((unit) => unit.durationSeconds)
-  if (durations.some((duration) => duration === undefined)) return undefined
-  let totalDuration = 0
-  for (const duration of durations) totalDuration += duration ?? 0
-  return totalDuration
+  if (plan.targetDurationSeconds === undefined) return structureDurationSeconds
+  if (structureDurationSeconds === undefined) return plan.targetDurationSeconds
+  return Math.max(plan.targetDurationSeconds, structureDurationSeconds)
 }
 
 function compareRoutes(
@@ -161,12 +165,12 @@ function compareRoutes(
     Number(left.availability.status !== 'ready') -
     Number(right.availability.status !== 'ready')
   if (availabilityDifference !== 0) return availabilityDifference
+  if (!left.isPaid && right.isPaid) return -1
+  if (!right.isPaid && left.isPaid) return 1
   if (left.executionMode === 'local' && right.executionMode !== 'local')
     return -1
   if (right.executionMode === 'local' && left.executionMode !== 'local')
     return 1
-  if (!left.isPaid && right.isPaid) return -1
-  if (!right.isPaid && left.isPaid) return 1
   if (left.id === right.id) return 0
   return left.id < right.id ? -1 : 1
 }

--- a/src/workbench/extensions/agent/services/agent/selectWorkflowRoute.ts
+++ b/src/workbench/extensions/agent/services/agent/selectWorkflowRoute.ts
@@ -132,7 +132,15 @@ function requiredWorkUnits(plan: WorkflowPlan): number {
 function requestedDurationSeconds(plan: WorkflowPlan): number | undefined {
   if (plan.targetDurationSeconds !== undefined)
     return plan.targetDurationSeconds
-  if (plan.structure.kind !== 'sequence') return undefined
+  if (plan.structure.kind === 'batch') {
+    const durations = plan.structure.units?.flatMap((unit) =>
+      unit.durationSeconds === undefined ? [] : [unit.durationSeconds]
+    )
+    return durations === undefined || durations.length === 0
+      ? undefined
+      : Math.max(...durations)
+  }
+  if (plan.structure.kind === 'single') return undefined
   const durations = plan.structure.units.map((unit) => unit.durationSeconds)
   if (durations.some((duration) => duration === undefined)) return undefined
   let totalDuration = 0
@@ -157,6 +165,8 @@ function compareRoutes(
     return -1
   if (right.executionMode === 'local' && left.executionMode !== 'local')
     return 1
+  if (!left.isPaid && right.isPaid) return -1
+  if (!right.isPaid && left.isPaid) return 1
   if (left.id === right.id) return 0
   return left.id < right.id ? -1 : 1
 }

--- a/src/workbench/extensions/agent/services/agent/selectWorkflowRoute.ts
+++ b/src/workbench/extensions/agent/services/agent/selectWorkflowRoute.ts
@@ -53,7 +53,7 @@ export function selectWorkflowRoute(
     return { status: 'needs-input' }
   const ranked = candidates
     .filter((candidate) => isEligible(candidate, plan))
-    .toSorted((left, right) => compareRoutes(left, right, plan.qualityGoal))
+    .sort((left, right) => compareRoutes(left, right, plan.qualityGoal))
   const route = ranked[0]
   if (route === undefined) return { status: 'no-match' }
 

--- a/src/workbench/extensions/agent/services/agent/selectWorkflowRoute.ts
+++ b/src/workbench/extensions/agent/services/agent/selectWorkflowRoute.ts
@@ -138,8 +138,10 @@ function compareRoutes(
   const scoreDifference =
     scoreExperience(right, qualityGoal) - scoreExperience(left, qualityGoal)
   if (scoreDifference !== 0) return scoreDifference
-  if (left.availability.status === 'ready') return -1
-  if (right.availability.status === 'ready') return 1
+  const availabilityDifference =
+    Number(left.availability.status !== 'ready') -
+    Number(right.availability.status !== 'ready')
+  if (availabilityDifference !== 0) return availabilityDifference
   if (left.executionMode === 'local' && right.executionMode !== 'local')
     return -1
   if (right.executionMode === 'local' && left.executionMode !== 'local')


### PR DESCRIPTION
## Summary

Add a strict workflow-plan contract and deterministic route-selection policy for the existing Comfy Agent. This creates a reviewable boundary between free-form model output and the workflow/template ComfyUI may propose.

This PR is intentionally a pure planning foundation: it does not add UI, make API calls, mutate a graph, download models, spend credits, or change the existing Agent transport.

## What changes

- Defines a Zod contract for media intent, output type, required inputs, reference counts, quality/speed preference, execution preference, clarification state, target duration, work-unit counts, and single/batch/sequence/multi-stage structure.
- Adds semantic validation beyond shape parsing:
  - unique stage and unit IDs;
  - intent, input, and output compatibility;
  - exact sequence duration;
  - backward-only dependencies;
  - declared media flow and final-output agreement;
  - no orphaned pipeline stages.
- Adds a pure route selector that filters candidates by task capability, structure, pipeline support, input capacity, output count, duration, execution preference, and availability.
- Ranks candidates by:
  1. task and quality fit;
  2. requested experience;
  3. readiness;
  4. free before paid when otherwise equivalent;
  5. local and stable ID tie-breakers.
- Returns explicit outcomes for clarification, no compatible route, setup required with an optional runnable fallback, paid-route approval, and ready-to-run selection.
- Preserves the best task match even if setup is required instead of silently selecting a weaker route.
- Treats explicit long sequence/batch requirements as authoritative, so a one-minute multi-shot request cannot collapse into a short single generation.

## Product boundaries

- local-only is respected as an explicit user choice.
- Cloud remains eligible for auto / Cloud-allowed requests.
- Every paid winner requires explicit approval.
- Missing local setup does not automatically promote a weaker paid route.
- No Comfy account, API key, provider, credit, installation, or execution behavior is bypassed.

A follow-up integration can use:

Agent response -> workflow plan schema -> route selector -> review UI -> existing execution transport

## Validation

- Focused schema/selector suite: **2 files, 51 tests passed**.
- TypeScript check passed.
- Full repository lint passed with no errors (existing repository warnings only).
- Production build passed.
- git diff --check and the pre-push knip hook passed.

## Review focus

- Is the plan contract the right stable boundary between model output and graph mutation?
- Is task/quality fit correctly ranked ahead of mere availability?
- Are setup-required, runnable fallback, and paid approval the right separate states?
- Are sequence and pipeline invariants strict enough for long-form and multi-stage workflows?

## Screenshots

Not applicable. This PR adds a pure schema and selection-policy layer with no UI changes.