### PR TITLE
fix(agent): port slice-07 residual behavior

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "test:unit": "vitest run",
     "typecheck": "vue-tsc --noEmit",
     "typecheck:browser": "vue-tsc --project browser_tests/tsconfig.json",
+    "typecheck:build": "vue-tsc --project build/tsconfig.json",
     "typecheck:scripts": "vue-tsc --project scripts/tsconfig.json",
     "typecheck:tools": "vue-tsc --project tools/tsconfig.json",
     "typecheck:website": "pnpm --filter @comfyorg/website run typecheck",

--- a/src/components/topbar/WorkflowTabs.test.ts
+++ b/src/components/topbar/WorkflowTabs.test.ts
@@ -436,8 +436,9 @@ describe('WorkflowTabs selection and overflow', () => {
   it('keeps the real workflow selected when another workflow is not opened', async () => {
     openWorkflow.mockResolvedValueOnce(false)
     const { user } = renderComponent()
+    const secondTab = screen.getByRole('button', { name: 'Second workflow' })
 
-    await user.click(screen.getByText('Second workflow'))
+    await user.click(secondTab)
 
     expect(
       screen.getByRole('button', { name: 'First workflow' })
@@ -445,6 +446,7 @@ describe('WorkflowTabs selection and overflow', () => {
     expect(
       screen.getByRole('button', { name: 'Second workflow' })
     ).toHaveAttribute('aria-pressed', 'false')
+    expect(secondTab).toHaveFocus()
   })
 
   it('keeps overflow controls available when the tab strip overflows', async () => {

--- a/src/components/topbar/WorkflowTabs.test.ts
+++ b/src/components/topbar/WorkflowTabs.test.ts
@@ -433,6 +433,20 @@ describe('WorkflowTabs selection and overflow', () => {
     ).toHaveAttribute('aria-pressed', 'false')
   })
 
+  it('keeps the real workflow selected when another workflow is not opened', async () => {
+    openWorkflow.mockResolvedValueOnce(false)
+    const { user } = renderComponent()
+
+    await user.click(screen.getByText('Second workflow'))
+
+    expect(
+      screen.getByRole('button', { name: 'First workflow' })
+    ).toHaveAttribute('aria-pressed', 'true')
+    expect(
+      screen.getByRole('button', { name: 'Second workflow' })
+    ).toHaveAttribute('aria-pressed', 'false')
+  })
+
   it('keeps overflow controls available when the tab strip overflows', async () => {
     renderComponent()
     await waitFor(() => expect(overflowObservers).toHaveLength(1))

--- a/src/components/topbar/WorkflowTabs.test.ts
+++ b/src/components/topbar/WorkflowTabs.test.ts
@@ -1,6 +1,7 @@
 import { render, screen, waitFor } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { PropType } from 'vue'
 import { defineComponent, h, nextTick, reactive } from 'vue'
 import { createI18n } from 'vue-i18n'
 
@@ -23,6 +24,8 @@ const overflowObservers = vi.hoisted<
 >(() => [])
 interface WorkflowFixture {
   path: string
+  key?: string
+  filename?: string
 }
 const workflowStoreHolder = vi.hoisted<{
   store: {
@@ -98,6 +101,11 @@ vi.mock('@/composables/auth/useCurrentUser', () => ({
 }))
 
 const openFeedbackDialog = vi.hoisted(() => vi.fn())
+const openWorkflow = vi.hoisted(() => vi.fn())
+const workflowStore = vi.hoisted(() => ({
+  openWorkflows: [] as WorkflowFixture[],
+  activeWorkflow: null as WorkflowFixture | null
+}))
 vi.mock('@/platform/support/feedbackDialog', () => ({
   openFeedbackDialog
 }))
@@ -123,20 +131,14 @@ vi.mock('@/composables/element/useOverflowObserver', async () => {
 
 vi.mock('@/platform/workflow/core/services/workflowService', () => ({
   useWorkflowService: () => ({
-    openWorkflow: vi.fn(),
+    openWorkflow,
     closeWorkflow: vi.fn()
   })
 }))
 
 vi.mock('@/platform/workflow/management/stores/workflowStore', () => ({
   useWorkflowStore: () => {
-    const store = reactive<{
-      openWorkflows: WorkflowFixture[]
-      activeWorkflow: WorkflowFixture | null
-    }>({
-      openWorkflows: [],
-      activeWorkflow: null
-    })
+    const store = reactive(workflowStore)
     workflowStoreHolder.store = store
     return store
   }
@@ -184,14 +186,22 @@ vi.mock('@/utils/mouseDownUtil', () => ({
 vi.mock('./WorkflowOverflowMenu.vue', () => ({
   default: defineComponent({
     name: 'WorkflowOverflowMenuStub',
-    render: () => h('div')
+    render: () => h('div', { 'data-testid': 'workflow-overflow-menu' })
   })
 }))
 
 vi.mock('./WorkflowTab.vue', () => ({
   default: defineComponent({
     name: 'WorkflowTabStub',
-    render: () => h('div')
+    props: {
+      workflowOption: {
+        type: Object as PropType<{ workflow: { filename?: string } }>,
+        required: true
+      }
+    },
+    render() {
+      return h('div', this.workflowOption.workflow.filename)
+    }
   })
 }))
 
@@ -209,7 +219,7 @@ vi.mock('./LoginButton.vue', () => ({
   })
 }))
 
-function renderComponent() {
+function renderComponent(errorHandler?: (error: unknown) => void) {
   const user = userEvent.setup()
   const i18n = createI18n({
     legacy: false,
@@ -219,6 +229,7 @@ function renderComponent() {
 
   const result = render(WorkflowTabs, {
     global: {
+      config: { errorHandler },
       plugins: [i18n],
       directives: {
         tooltip: {}
@@ -235,6 +246,9 @@ describe('WorkflowTabs feedback button', () => {
     distribution.isDesktop = false
     distribution.isNightly = false
     tabBarLayout.value = 'Default'
+    openWorkflow.mockReset()
+    workflowStore.openWorkflows = []
+    workflowStore.activeWorkflow = null
   })
 
   it('opens the feedback dialog tagged with topbar source when clicked', async () => {
@@ -339,9 +353,122 @@ describe('WorkflowTabs agent entry button', () => {
   })
 })
 
+describe('WorkflowTabs selection and overflow', () => {
+  const firstWorkflow = {
+    key: 'first',
+    path: 'first.json',
+    filename: 'First workflow'
+  }
+  const secondWorkflow = {
+    key: 'second',
+    path: 'second.json',
+    filename: 'Second workflow'
+  }
+
+  beforeEach(() => {
+    workflowStore.openWorkflows = [firstWorkflow, secondWorkflow]
+    workflowStore.activeWorkflow = firstWorkflow
+    openWorkflow.mockReset()
+    overflowObservers.length = 0
+  })
+
+  it('opens the selected workflow again when its tab is activated', async () => {
+    const { user } = renderComponent()
+
+    await user.click(screen.getByText('First workflow'))
+
+    expect(openWorkflow).toHaveBeenCalledOnce()
+    expect(openWorkflow).toHaveBeenCalledWith(firstWorkflow)
+    expect(
+      screen.getByRole('button', { name: 'First workflow' })
+    ).toHaveAttribute('aria-pressed', 'true')
+  })
+
+  it('opens another workflow once when its tab is activated', async () => {
+    const { user } = renderComponent()
+
+    await user.click(screen.getByText('Second workflow'))
+
+    expect(openWorkflow).toHaveBeenCalledOnce()
+    expect(openWorkflow).toHaveBeenCalledWith(secondWorkflow)
+  })
+
+  it('opens another workflow when its tab is activated by keyboard', async () => {
+    const { user } = renderComponent()
+    const secondTab = screen.getByRole('button', { name: 'Second workflow' })
+
+    secondTab.focus()
+    await user.keyboard('{Enter}')
+
+    expect(openWorkflow).toHaveBeenCalledOnce()
+    expect(openWorkflow).toHaveBeenCalledWith(secondWorkflow)
+  })
+
+  it('opens the selected workflow when its tab is activated by keyboard', async () => {
+    const { user } = renderComponent()
+    const firstTab = screen.getByRole('button', { name: 'First workflow' })
+
+    firstTab.focus()
+    await user.keyboard('{Enter}')
+
+    expect(openWorkflow).toHaveBeenCalledOnce()
+    expect(openWorkflow).toHaveBeenCalledWith(firstWorkflow)
+  })
+
+  it('keeps the real workflow selected when another workflow fails to load', async () => {
+    const error = new Error('load failed')
+    const errorHandler = vi.fn()
+    openWorkflow.mockRejectedValueOnce(error)
+    const { user } = renderComponent(errorHandler)
+
+    await user.click(screen.getByText('Second workflow'))
+
+    await vi.waitFor(() => expect(errorHandler).toHaveBeenCalled())
+    expect(errorHandler.mock.calls[0][0]).toBe(error)
+    expect(
+      screen.getByRole('button', { name: 'First workflow' })
+    ).toHaveAttribute('aria-pressed', 'true')
+    expect(
+      screen.getByRole('button', { name: 'Second workflow' })
+    ).toHaveAttribute('aria-pressed', 'false')
+  })
+
+  it('keeps overflow controls available when the tab strip overflows', async () => {
+    renderComponent()
+    await waitFor(() => expect(overflowObservers).toHaveLength(1))
+
+    overflowObservers[0].isOverflowing.value = true
+    await nextTick()
+
+    expect(
+      screen.getByRole('button', { name: 'Scroll Left' })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'Scroll Right' })
+    ).toBeInTheDocument()
+    expect(screen.getByTestId('workflow-overflow-menu')).toBeInTheDocument()
+  })
+
+  it('scrolls a newly active workflow into view', async () => {
+    const scrollIntoView = vi.spyOn(HTMLElement.prototype, 'scrollIntoView')
+    renderComponent()
+
+    workflowStore.activeWorkflow = secondWorkflow
+
+    await waitFor(() =>
+      expect(scrollIntoView).toHaveBeenCalledWith({
+        block: 'nearest',
+        inline: 'nearest'
+      })
+    )
+  })
+})
+
 describe('WorkflowTabs scrolling', () => {
   beforeEach(() => {
     overflowObservers.length = 0
+    workflowStore.openWorkflows = []
+    workflowStore.activeWorkflow = null
   })
 
   it('does not overwrite the ScrollPanel content ref', async () => {

--- a/src/components/topbar/WorkflowTabs.vue
+++ b/src/components/topbar/WorkflowTabs.vue
@@ -25,7 +25,6 @@
     >
       <SelectButton
         :ref="setSelectButton"
-        :key="selectionRevision"
         class="workflow-tabs bg-transparent"
         :class="props.class"
         :model-value="selectedWorkflow"
@@ -158,6 +157,7 @@ import WorkflowOverflowMenu from './WorkflowOverflowMenu.vue'
 interface WorkflowOption {
   value: string
   workflow: ComfyWorkflow
+  revision: number
 }
 
 const props = defineProps<{
@@ -194,9 +194,13 @@ function openFeedback() {
 const containerRef = ref<HTMLElement | null>(null)
 const selectionRevision = ref(0)
 
-const workflowToOption = (workflow: ComfyWorkflow): WorkflowOption => ({
+const workflowToOption = (
+  workflow: ComfyWorkflow,
+  revision = 0
+): WorkflowOption => ({
   value: workflow.path,
-  workflow
+  workflow,
+  revision
 })
 
 const options = computed<WorkflowOption[]>(() =>
@@ -204,7 +208,10 @@ const options = computed<WorkflowOption[]>(() =>
 )
 const selectedWorkflow = computed<WorkflowOption | null>(() =>
   workflowStore.activeWorkflow
-    ? workflowToOption(workflowStore.activeWorkflow as ComfyWorkflow)
+    ? workflowToOption(
+        workflowStore.activeWorkflow as ComfyWorkflow,
+        selectionRevision.value
+      )
     : null
 )
 

--- a/src/components/topbar/WorkflowTabs.vue
+++ b/src/components/topbar/WorkflowTabs.vue
@@ -222,7 +222,11 @@ const onWorkflowClick = async (event: MouseEvent) => {
   if (!option) return
 
   try {
-    await workflowService.openWorkflow(option.workflow)
+    const opened = await workflowService.openWorkflow(option.workflow)
+    if (opened === false) {
+      selectionRevision.value++
+      await nextTick()
+    }
   } catch (error) {
     selectionRevision.value++
     await nextTick()

--- a/src/components/topbar/WorkflowTabs.vue
+++ b/src/components/topbar/WorkflowTabs.vue
@@ -25,6 +25,7 @@
     >
       <SelectButton
         :ref="setSelectButton"
+        :key="selectionRevision"
         class="workflow-tabs bg-transparent"
         :class="props.class"
         :model-value="selectedWorkflow"
@@ -191,6 +192,7 @@ function openFeedback() {
 }
 
 const containerRef = ref<HTMLElement | null>(null)
+const selectionRevision = ref(0)
 
 const workflowToOption = (workflow: ComfyWorkflow): WorkflowOption => ({
   value: workflow.path,
@@ -217,7 +219,15 @@ const onWorkflowClick = async (event: MouseEvent) => {
       ?.querySelector<HTMLElement>('[data-workflow-path]')
   const path = workflowElement?.dataset.workflowPath
   const option = options.value.find(({ value }) => value === path)
-  if (option) await workflowService.openWorkflow(option.workflow)
+  if (!option) return
+
+  try {
+    await workflowService.openWorkflow(option.workflow)
+  } catch (error) {
+    selectionRevision.value++
+    await nextTick()
+    throw error
+  }
 }
 
 const closeWorkflows = async (options: WorkflowOption[]) => {

--- a/src/platform/telemetry/TelemetryRegistry.test.ts
+++ b/src/platform/telemetry/TelemetryRegistry.test.ts
@@ -1,7 +1,17 @@
 import { describe, expect, it, vi } from 'vitest'
 
 import { TelemetryRegistry } from './TelemetryRegistry'
-import type { BillingTelemetryEvent, TelemetryProvider } from './types'
+import type {
+  AgentEntryButtonClickedMetadata,
+  AgentMessageFeedbackMetadata,
+  AgentMessageSentMetadata,
+  AgentNodeTaggedMetadata,
+  AgentPanelClosedMetadata,
+  AgentPanelOpenedMetadata,
+  AgentWorkflowAppliedMetadata,
+  BillingTelemetryEvent,
+  TelemetryProvider
+} from './types'
 
 describe('TelemetryRegistry', () => {
   it('dispatches feature flag evaluations to supporting providers', () => {
@@ -234,6 +244,115 @@ describe('TelemetryRegistry', () => {
     )
     expect(b.trackWidgetFavoriteToggled).toHaveBeenCalledExactlyOnceWith(
       payload
+    )
+  })
+
+  describe('agent telemetry dispatch', () => {
+    const feedbackMetadata = {
+      message_id: 'm1',
+      vote: 'up',
+      workflow_id: null
+    } satisfies AgentMessageFeedbackMetadata
+    const panelOpenedMetadata = {
+      source: 'topbar_button'
+    } satisfies AgentPanelOpenedMetadata
+    const panelClosedMetadata = {
+      source: 'close_button',
+      open_duration_ms: 1200
+    } satisfies AgentPanelClosedMetadata
+    const entryClickedMetadata = {
+      resulting_state: 'opened'
+    } satisfies AgentEntryButtonClickedMetadata
+    const messageSentMetadata = {
+      attachment_count: 1,
+      node_tag_count: 2
+    } satisfies AgentMessageSentMetadata
+    const nodeTaggedMetadata = {
+      source: 'mention_picker'
+    } satisfies AgentNodeTaggedMetadata
+    const workflowAppliedMetadata = {
+      workflow_id: 'w1',
+      target: 'active_tab_open'
+    } satisfies AgentWorkflowAppliedMetadata
+
+    const cases: Array<{
+      method: keyof TelemetryProvider & `trackAgent${string}`
+      expected: unknown
+      invoke: (registry: TelemetryRegistry) => void
+    }> = [
+      {
+        method: 'trackAgentMessageFeedback',
+        expected: { ...feedbackMetadata },
+        invoke: (registry) =>
+          registry.trackAgentMessageFeedback(feedbackMetadata)
+      },
+      {
+        method: 'trackAgentPanelOpened',
+        expected: { ...panelOpenedMetadata },
+        invoke: (registry) =>
+          registry.trackAgentPanelOpened(panelOpenedMetadata)
+      },
+      {
+        method: 'trackAgentPanelClosed',
+        expected: { ...panelClosedMetadata },
+        invoke: (registry) =>
+          registry.trackAgentPanelClosed(panelClosedMetadata)
+      },
+      {
+        method: 'trackAgentEntryButtonClicked',
+        expected: { ...entryClickedMetadata },
+        invoke: (registry) =>
+          registry.trackAgentEntryButtonClicked(entryClickedMetadata)
+      },
+      {
+        method: 'trackAgentCloseButtonClicked',
+        expected: undefined,
+        invoke: (registry) => registry.trackAgentCloseButtonClicked()
+      },
+      {
+        method: 'trackAgentMessageSent',
+        expected: { ...messageSentMetadata },
+        invoke: (registry) =>
+          registry.trackAgentMessageSent(messageSentMetadata)
+      },
+      {
+        method: 'trackAgentNodeTagged',
+        expected: { ...nodeTaggedMetadata },
+        invoke: (registry) => registry.trackAgentNodeTagged(nodeTaggedMetadata)
+      },
+      {
+        method: 'trackAgentAttachButtonClicked',
+        expected: undefined,
+        invoke: (registry) => registry.trackAgentAttachButtonClicked()
+      },
+      {
+        method: 'trackAgentWorkflowApplied',
+        expected: { ...workflowAppliedMetadata },
+        invoke: (registry) =>
+          registry.trackAgentWorkflowApplied(workflowAppliedMetadata)
+      }
+    ]
+
+    it.for(cases)(
+      'dispatches $method to every registered provider',
+      ({ method, expected, invoke }) => {
+        const a: TelemetryProvider = { [method]: vi.fn() }
+        const b: TelemetryProvider = { [method]: vi.fn() }
+        const registry = new TelemetryRegistry()
+        registry.registerProvider(a)
+        registry.registerProvider(b)
+
+        invoke(registry)
+
+        for (const provider of [a, b]) {
+          const spy = provider[method]
+          if (expected === undefined) {
+            expect(spy).toHaveBeenCalledExactlyOnceWith()
+          } else {
+            expect(spy).toHaveBeenCalledExactlyOnceWith(expected)
+          }
+        }
+      }
     )
   })
 })

--- a/src/utils/litegraphUtil.test.ts
+++ b/src/utils/litegraphUtil.test.ts
@@ -110,6 +110,21 @@ describe('createNode', () => {
     expect(mockBringNodeToFront).not.toHaveBeenCalled()
   })
 
+  it('leaves the graph unchanged when the canvas is select-only', async () => {
+    const graph = new LGraph()
+    const canvas = makeCanvas(graph)
+    canvas.selectOnly = true
+    const createNodeSpy = vi
+      .spyOn(LiteGraph, 'createNode')
+      .mockReturnValue(new LGraphNode('LoadImage'))
+
+    const result = await createNode(canvas, 'LoadImage')
+
+    expect(result).toBeNull()
+    expect(graph._nodes).toHaveLength(0)
+    expect(createNodeSpy).not.toHaveBeenCalled()
+  })
+
   it('places the new node at the canvas graph_mouse position', async () => {
     const newNode = new LGraphNode('LoadImage')
     const spy = vi.spyOn(LiteGraph, 'createNode').mockReturnValue(newNode)

--- a/src/utils/litegraphUtil.ts
+++ b/src/utils/litegraphUtil.ts
@@ -49,6 +49,9 @@ export async function createNode(
   if (!name) {
     return null
   }
+  if (isSelectOnly(canvas)) {
+    return null
+  }
 
   const {
     graph,

--- a/src/workbench/extensions/agent/composables/agent/useAgentSession.test.ts
+++ b/src/workbench/extensions/agent/composables/agent/useAgentSession.test.ts
@@ -468,6 +468,10 @@ describe('useAgentSession (v1 composition root)', () => {
     const { source, emit, status } = fakeEvents()
     const session = useAgentSession({ rest, events: source })
     session.start()
+    // Establish a live connection first: only a live->down transition is a
+    // real disconnect. An initial `false` snapshot (no prior `true`) must
+    // not abort turns; see test (g2).
+    status(true)
 
     await session.sendMessage('go')
     emit(delta('msg-1', 'partial'))
@@ -481,6 +485,24 @@ describe('useAgentSession (v1 composition root)', () => {
     // makes no REST calls on a live transition.
     status(true)
     expect(vi.mocked(rest.postMessage).mock.calls.length).toBe(requestsBefore)
+  })
+
+  it('(g2) an initial onStatus(false) snapshot does not abort a surviving turn', async () => {
+    // agentEventSource.onStatus reports the current socket state synchronously
+    // on subscribe, so the very first callback can be `false` before any real
+    // reconnect transition (e.g. the socket hasn't opened yet). That must not
+    // abort a turn that survived a remount.
+    const rest = fakeRest()
+    const { source, emit, status } = fakeEvents()
+    const session = useAgentSession({ rest, events: source })
+    session.start()
+
+    await session.sendMessage('go')
+    emit(delta('msg-1', 'partial'))
+    expect(session.isStreaming.value).toBe(true)
+
+    status(false)
+    expect(session.isStreaming.value).toBe(true)
   })
 
   it('(h) attachments pass through to the postMessage wire body', async () => {
@@ -922,6 +944,9 @@ describe('useAgentSession (v1 composition root)', () => {
     const { source, emit, status } = fakeEvents()
     const session = useAgentSession({ rest, events: source })
     session.start()
+    // Establish a live connection first; only a live->down transition (an
+    // actual socket death) should settle background turns.
+    status(true)
 
     await session.sendMessage('go')
     emit(delta('msg-1', 'partial'))

--- a/src/workbench/extensions/agent/composables/agent/useAgentSession.ts
+++ b/src/workbench/extensions/agent/composables/agent/useAgentSession.ts
@@ -90,6 +90,12 @@ export function useAgentSession(deps: AgentSessionDeps) {
   let unsubscribe: (() => void) | null = null
   let unsubscribeStatus: (() => void) | null = null
   let ownedGeneration = 0
+  // The status source reports its current state synchronously on subscribe
+  // (see agentEventSource.onStatus), so the first callback is a snapshot,
+  // not a transition. Track whether we've ever observed a live connection so
+  // an initial `false` (still connecting, not yet dropped) doesn't abort a
+  // turn that survived a remount.
+  let everLive = false
 
   function pushError(text: string): void {
     notices.value.push({ level: 'error', text })
@@ -97,6 +103,7 @@ export function useAgentSession(deps: AgentSessionDeps) {
 
   function start(): void {
     ownedGeneration = ++sessionGeneration
+    everLive = false
     // The binding only outlives a remount together with its thread: a page
     // with no surviving thread has no resumed turn the binding could serve.
     if (
@@ -361,7 +368,14 @@ export function useAgentSession(deps: AgentSessionDeps) {
   }
 
   function onStatus(live: boolean): void {
-    if (live) return
+    if (live) {
+      everLive = true
+      return
+    }
+    // Only a real live->down transition means a turn's stream was actually
+    // interrupted. An initial `false` (socket not open yet) is not a
+    // reconnect and must not abort a turn that survived a remount.
+    if (!everLive) return
     conversationStore.abortActiveTurn()
     conversationStore.dropBackgroundTurns()
   }

--- a/src/workbench/extensions/agent/crdt/writeLegInvariants.property.test.ts
+++ b/src/workbench/extensions/agent/crdt/writeLegInvariants.property.test.ts
@@ -31,6 +31,35 @@ const arbOperations = fc
   .map((ids) => ids.map(addNode))
 
 describe('CRDT human write-leg invariants (property)', () => {
+  it('starts empty and ignores empty or detached writes', () => {
+    const sendOps = vi.fn(() => true)
+    const listeners = new Set<(result: OpsResultView) => void>()
+    const sender = createOpSender({
+      sendOps,
+      onOpsResult: (listener) => {
+        listeners.add(listener)
+        return () => listeners.delete(listener)
+      },
+      workflowId: () => WORKFLOW_ID,
+      tab: TAB,
+      actor: () => ACTOR,
+      baseVersion: () => 0,
+      onBatchSettled: () => {}
+    })
+
+    expect(sender.pending()).toBe(0)
+    expect(listeners).toHaveLength(1)
+
+    sender.enqueue([])
+    expect(sendOps).not.toHaveBeenCalled()
+
+    sender.detach()
+    expect(listeners).toHaveLength(0)
+
+    sender.enqueue([addNode(1)])
+    expect(sendOps).not.toHaveBeenCalled()
+  })
+
   it('mints one unique complete causal identity per operation', () => {
     fc.assert(
       fc.property(

--- a/src/workbench/extensions/agent/crdt/writeLegInvariants.property.test.ts
+++ b/src/workbench/extensions/agent/crdt/writeLegInvariants.property.test.ts
@@ -1,0 +1,146 @@
+import type { Op } from '@comfyorg/comfy-multi-player'
+import * as fc from 'fast-check'
+import { describe, expect, it, vi } from 'vitest'
+
+import type { GraphOperation } from './graphOperations'
+import { mintWireOps } from './opEnvelope'
+import type { OpsResultView } from './opSender'
+import { createOpSender } from './opSender'
+
+const WORKFLOW_ID = 'property-workflow'
+const TAB = 'property-tab'
+const ACTOR = 'human:property-user:property-tab'
+
+type AddNodeOperation = Extract<GraphOperation, { op: 'add_node' }>
+
+function addNode(id: number): AddNodeOperation {
+  return {
+    op: 'add_node',
+    node_id: id,
+    class_type: 'PropertyNode',
+    pos: [id, -id],
+    node: { id, type: 'PropertyNode', marker: id }
+  }
+}
+
+const arbOperations = fc
+  .uniqueArray(fc.integer({ min: 1, max: 1_000_000 }), {
+    minLength: 1,
+    maxLength: 40
+  })
+  .map((ids) => ids.map(addNode))
+
+describe('CRDT human write-leg invariants (property)', () => {
+  it('mints one unique complete causal identity per operation', () => {
+    fc.assert(
+      fc.property(
+        arbOperations,
+        fc.nat({ max: Number.MAX_SAFE_INTEGER }),
+        (operations, baseVersion) => {
+          const minted = mintWireOps(operations, {
+            actor: ACTOR,
+            baseVersion
+          })
+
+          expect(new Set(minted.map((op) => op.op_id))).toHaveLength(
+            operations.length
+          )
+          for (const op of minted) {
+            expect(op.op_id).toMatch(/^[0-9a-f]{32}$/)
+            expect(op.actor).toBe(ACTOR)
+            expect(op.base_version).toBe(baseVersion)
+            expect(op.stamp).toEqual([baseVersion, ACTOR])
+          }
+        }
+      )
+    )
+  })
+
+  it('serializes arbitrary operation sequences in causal mint order', () => {
+    fc.assert(
+      fc.property(arbOperations, (operations) => {
+        const sent: Op[][] = []
+        let resultListener = (_result: OpsResultView): void => {
+          throw new Error('Expected an operation-result listener')
+        }
+        const sender = createOpSender({
+          sendOps: (_workflowId, _tab, ops) => {
+            sent.push(ops)
+            return true
+          },
+          onOpsResult: (listener) => {
+            resultListener = listener
+            return () => {}
+          },
+          workflowId: () => WORKFLOW_ID,
+          tab: TAB,
+          actor: () => ACTOR,
+          baseVersion: () => 41,
+          onBatchSettled: () => {}
+        })
+
+        for (const operation of operations) {
+          sender.enqueue([operation])
+          const latest = sent.at(-1)
+          if (!latest) throw new Error('Expected an in-flight operation')
+          resultListener({
+            ok: true,
+            applied: [latest[0].op_id],
+            skipped: []
+          })
+        }
+
+        const delivered = sent.flat()
+        expect(
+          delivered.map((op) => {
+            if (op.op !== 'add_node') throw new Error('Expected add_node')
+            return op.node_id
+          })
+        ).toEqual(operations.map((operation) => operation.node_id))
+        expect(new Set(delivered.map((op) => op.op_id))).toHaveLength(
+          operations.length
+        )
+        expect(sender.pending()).toBe(0)
+        sender.detach()
+      })
+    )
+  })
+
+  it('retries transport failures and result silence without reminting', () => {
+    vi.useFakeTimers()
+    fc.assert(
+      fc.property(
+        arbOperations,
+        fc.integer({ min: 1, max: 4 }),
+        (operations, failedAttempts) => {
+          const attempts: Op[][] = []
+          let callCount = 0
+          const sender = createOpSender({
+            sendOps: (_workflowId, _tab, ops) => {
+              attempts.push(ops)
+              callCount += 1
+              return callCount > failedAttempts
+            },
+            onOpsResult: () => () => {},
+            workflowId: () => WORKFLOW_ID,
+            tab: TAB,
+            actor: () => ACTOR,
+            baseVersion: () => 73,
+            onBatchSettled: () => {}
+          })
+
+          sender.enqueue(operations)
+          vi.advanceTimersByTime(failedAttempts * 500)
+          expect(attempts).toHaveLength(failedAttempts + 1)
+          const minted = attempts[0]
+          for (const attempt of attempts) expect(attempt).toEqual(minted)
+
+          vi.advanceTimersByTime(10_000)
+          expect(attempts.at(-1)).toEqual(minted)
+          expect(attempts).toHaveLength(failedAttempts + 2)
+          sender.detach()
+        }
+      )
+    )
+  })
+})

--- a/src/workbench/extensions/agent/crdt/writeLegInvariants.property.test.ts
+++ b/src/workbench/extensions/agent/crdt/writeLegInvariants.property.test.ts
@@ -10,6 +10,7 @@ import { createOpSender } from './opSender'
 const WORKFLOW_ID = 'property-workflow'
 const TAB = 'property-tab'
 const ACTOR = 'human:property-user:property-tab'
+const TARGET = { workflowId: WORKFLOW_ID, rootGraphId: 'property-root' }
 
 type AddNodeOperation = Extract<GraphOperation, { op: 'add_node' }>
 
@@ -30,13 +31,38 @@ const arbOperations = fc
   })
   .map((ids) => ids.map(addNode))
 
+function enqueue(
+  sender: ReturnType<typeof createOpSender>,
+  operations: GraphOperation[]
+): void {
+  sender.enqueue(Object.assign([...operations], { target: TARGET, operations }))
+}
+
+function mintContext(firstVersion: number) {
+  return {
+    actor: ACTOR,
+    baseVersion: firstVersion,
+    firstVersion
+  }
+}
+
+function opsResult(applied: string[]): OpsResultView {
+  const result = {
+    workflowId: WORKFLOW_ID,
+    ok: true,
+    applied,
+    skipped: []
+  }
+  return result
+}
+
 describe('CRDT human write-leg invariants (property)', () => {
   it('starts empty and ignores empty or detached writes', () => {
     const sendOps = vi.fn(() => true)
     const listeners = new Set<(result: OpsResultView) => void>()
-    const sender = createOpSender({
+    const deps = {
       sendOps,
-      onOpsResult: (listener) => {
+      onOpsResult: (listener: (result: OpsResultView) => void) => {
         listeners.add(listener)
         return () => listeners.delete(listener)
       },
@@ -44,19 +70,26 @@ describe('CRDT human write-leg invariants (property)', () => {
       tab: TAB,
       actor: () => ACTOR,
       baseVersion: () => 0,
+      observedVersion: () => 0,
+      reserveVersions: (
+        _workflowId: string,
+        _observed: number,
+        _count: number
+      ) => 1,
       onBatchSettled: () => {}
-    })
+    }
+    const sender = createOpSender(deps)
 
     expect(sender.pending()).toBe(0)
     expect(listeners).toHaveLength(1)
 
-    sender.enqueue([])
+    enqueue(sender, [])
     expect(sendOps).not.toHaveBeenCalled()
 
     sender.detach()
     expect(listeners).toHaveLength(0)
 
-    sender.enqueue([addNode(1)])
+    enqueue(sender, [addNode(1)])
     expect(sendOps).not.toHaveBeenCalled()
   })
 
@@ -64,21 +97,20 @@ describe('CRDT human write-leg invariants (property)', () => {
     fc.assert(
       fc.property(
         arbOperations,
-        fc.nat({ max: Number.MAX_SAFE_INTEGER }),
+        fc.nat({ max: Number.MAX_SAFE_INTEGER - 40 }),
         (operations, baseVersion) => {
-          const minted = mintWireOps(operations, {
-            actor: ACTOR,
-            baseVersion
-          })
+          const minted = operations.flatMap((operation, index) =>
+            mintWireOps([operation], mintContext(baseVersion + index))
+          )
 
           expect(new Set(minted.map((op) => op.op_id))).toHaveLength(
             operations.length
           )
-          for (const op of minted) {
+          for (const [index, op] of minted.entries()) {
             expect(op.op_id).toMatch(/^[0-9a-f]{32}$/)
             expect(op.actor).toBe(ACTOR)
-            expect(op.base_version).toBe(baseVersion)
-            expect(op.stamp).toEqual([baseVersion, ACTOR])
+            expect(op.base_version).toBe(baseVersion + index)
+            expect(op.stamp).toEqual([op.base_version, ACTOR])
           }
         }
       )
@@ -89,34 +121,42 @@ describe('CRDT human write-leg invariants (property)', () => {
     fc.assert(
       fc.property(arbOperations, (operations) => {
         const sent: Op[][] = []
+        let producerVersion = 41
         let resultListener = (_result: OpsResultView): void => {
           throw new Error('Expected an operation-result listener')
         }
-        const sender = createOpSender({
-          sendOps: (_workflowId, _tab, ops) => {
+        const deps = {
+          sendOps: (_workflowId: string, _tab: string, ops: Op[]) => {
             sent.push(ops)
             return true
           },
-          onOpsResult: (listener) => {
+          onOpsResult: (listener: (result: OpsResultView) => void) => {
             resultListener = listener
             return () => {}
           },
           workflowId: () => WORKFLOW_ID,
           tab: TAB,
           actor: () => ACTOR,
-          baseVersion: () => 41,
+          baseVersion: () => ++producerVersion,
+          observedVersion: () => 41,
+          reserveVersions: (
+            _workflowId: string,
+            observed: number,
+            count: number
+          ) => {
+            const firstVersion = Math.max(producerVersion, observed) + 1
+            producerVersion = firstVersion + count - 1
+            return firstVersion
+          },
           onBatchSettled: () => {}
-        })
+        }
+        const sender = createOpSender(deps)
 
         for (const operation of operations) {
-          sender.enqueue([operation])
+          enqueue(sender, [operation])
           const latest = sent.at(-1)
           if (!latest) throw new Error('Expected an in-flight operation')
-          resultListener({
-            ok: true,
-            applied: [latest[0].op_id],
-            skipped: []
-          })
+          resultListener(opsResult([latest[0].op_id]))
         }
 
         const delivered = sent.flat()
@@ -128,6 +168,9 @@ describe('CRDT human write-leg invariants (property)', () => {
         ).toEqual(operations.map((operation) => operation.node_id))
         expect(new Set(delivered.map((op) => op.op_id))).toHaveLength(
           operations.length
+        )
+        expect(delivered.map((op) => op.base_version)).toEqual(
+          operations.map((_, index) => 42 + index)
         )
         expect(sender.pending()).toBe(0)
         sender.detach()
@@ -144,8 +187,8 @@ describe('CRDT human write-leg invariants (property)', () => {
         (operations, failedAttempts) => {
           const attempts: Op[][] = []
           let callCount = 0
-          const sender = createOpSender({
-            sendOps: (_workflowId, _tab, ops) => {
+          const deps = {
+            sendOps: (_workflowId: string, _tab: string, ops: Op[]) => {
               attempts.push(ops)
               callCount += 1
               return callCount > failedAttempts
@@ -155,10 +198,17 @@ describe('CRDT human write-leg invariants (property)', () => {
             tab: TAB,
             actor: () => ACTOR,
             baseVersion: () => 73,
+            observedVersion: () => 72,
+            reserveVersions: (
+              _workflowId: string,
+              observed: number,
+              _count: number
+            ) => observed + 1,
             onBatchSettled: () => {}
-          })
+          }
+          const sender = createOpSender(deps)
 
-          sender.enqueue(operations)
+          enqueue(sender, operations)
           vi.advanceTimersByTime(failedAttempts * 500)
           expect(attempts).toHaveLength(failedAttempts + 1)
           const minted = attempts[0]

--- a/src/workbench/extensions/agent/services/agent/agentEventSource.test.ts
+++ b/src/workbench/extensions/agent/services/agent/agentEventSource.test.ts
@@ -59,12 +59,13 @@ describe('createAgentEventSource', () => {
     expect(registered.size).toBe(0)
   })
 
-  it('emits false only for reconnecting and true for reconnected', () => {
+  it('maps reconnecting/reconnected to liveness', () => {
     const { host, emit } = fakeHost()
     const status = vi.fn()
 
     createAgentEventSource(host).onStatus?.(status)
-    expect(status).not.toHaveBeenCalled()
+    expect(status).toHaveBeenCalledOnce()
+    expect(status).toHaveBeenLastCalledWith(false)
 
     emit('reconnecting')
     expect(status).toHaveBeenLastCalledWith(false)
@@ -73,7 +74,7 @@ describe('createAgentEventSource', () => {
     expect(status).toHaveBeenLastCalledWith(true)
   })
 
-  it('characterizes R-107: reports only true for an open socket', () => {
+  it('reports live once when the socket is already open at bind time', () => {
     const { host } = fakeHost(WebSocket.OPEN)
     const status = vi.fn()
 
@@ -81,30 +82,18 @@ describe('createAgentEventSource', () => {
 
     expect(status).toHaveBeenCalledTimes(1)
     expect(status).toHaveBeenCalledWith(true)
-    expect(status).not.toHaveBeenCalledWith(false)
   })
 
-  // R-107: subscription stays silent until socket liveness is positively known.
-  it.for([undefined, WebSocket.CONNECTING])(
-    'does not report an initial status for socket state %s',
-    (readyState) => {
-      const { host } = fakeHost(readyState)
-      const status = vi.fn()
-
-      createAgentEventSource(host).onStatus?.(status)
-
-      expect(status).not.toHaveBeenCalled()
-    }
-  )
-
-  it('stops reporting status after unsubscribe', () => {
-    const { host, emit } = fakeHost()
+  it('stays quiet for a connecting socket and after status unsubscribe', () => {
+    const { host, emit } = fakeHost(WebSocket.CONNECTING)
     const status = vi.fn()
 
     const unsubscribe = createAgentEventSource(host).onStatus?.(status)
+    expect(status).toHaveBeenCalledOnce()
+    expect(status).toHaveBeenLastCalledWith(false)
+
     unsubscribe?.()
     emit('reconnected')
-
-    expect(status).not.toHaveBeenCalled()
+    expect(status).toHaveBeenCalledOnce()
   })
 })

--- a/src/workbench/extensions/agent/services/agent/agentEventSource.ts
+++ b/src/workbench/extensions/agent/services/agent/agentEventSource.ts
@@ -39,7 +39,7 @@ export function createAgentEventSource(host: AgentEventHost): AgentEventSource {
       const onUp = (): void => listener(true)
       host.addEventListener('reconnecting', onDown)
       host.addEventListener('reconnected', onUp)
-      if (host.socket?.readyState === OPEN) listener(true)
+      listener(host.socket?.readyState === OPEN)
       return () => {
         host.removeEventListener('reconnecting', onDown)
         host.removeEventListener('reconnected', onUp)


### PR DESCRIPTION
- Restores workflow-tab failure recovery, select-only node creation protection, and immediate socket connectivity reporting.
- Adds regression coverage for workflow selection, agent telemetry dispatch, and CRDT write-leg invariants.
- Keeps schema-dependent fixtures in #16396 and discards carrier-only hunks that do not stand alone on main.

<details>
<summary>Full salvage context</summary>

Source: `reports/review/salvage/gapcheck-sl07.md`, closed slice head `062a60530113` (`refs/verify/sl07`). [nathaniel-pr-rationale: #16188] is used only as provenance; this PR ports current-main residual behavior without restating slice authorship.

| File | Disposition | Carrier / reason |
|---|---|---|
| `browser_tests/tests/agent/agentPanelMocks.ts` | deduped away | Schema-dependent fixture migration stays with #16396 |
| `knip.config.ts` | deduped away | Current residual was comment-only after main cleanup |
| `package.json` | ported | Adds `typecheck:build` |
| `src/components/topbar/WorkflowTabs.test.ts` | ported | Current-main regression coverage |
| `src/components/topbar/WorkflowTabs.vue` | ported | Failed-open selection recovery |
| `src/platform/assets/utils/assetPreviewUtil.ts` | discarded | Standalone helper had no main consumer; pre-push Knip rejected it |
| `src/utils/litegraphUtil.ts` | ported | Select-only node creation guard |
| `src/workbench/extensions/agent/AgentPanelRoot.test.ts` | deduped away | Requires #16396 tool-call schema |
| `src/workbench/extensions/agent/components/agent/ConversationView.test.ts` | deduped away | Requires #16396 tool-call schema |
| `src/workbench/extensions/agent/schemas/agentApiSchema.ts` | deduped away | Exact successor coverage in #16396 |
| `src/workbench/extensions/agent/services/agent/agentEventSource.ts` | ported | Immediately reports both open and closed state |
| `src/workbench/extensions/agent/stores/agent/agentConversationStore.test.ts` | deduped away | Requires #16396 tool-call schema |
| `src/composables/canvas/useSelectionToolboxPosition.ts` | deduped away | Current main uses replacement selectable-items architecture |
| `src/composables/graph/useSelectionOperations.ts` | deduped away | Guard and explanatory comment already on main |
| `src/types/comfy.ts` | deduped away | Graph lifecycle hooks already on main |
| `src/platform/telemetry/TelemetryRegistry.test.ts` | ported | Agent telemetry dispatch coverage |
| `src/scripts/app.test.ts` | discarded | Carrier-to-slice residual is whitespace-only; wholesale ancestry port failed six tests |
| `src/workbench/extensions/agent/crdt/writeLegInvariants.property.test.ts` | ported | Property coverage passes on main |

Validation:
- `pnpm vitest run src/components/topbar/WorkflowTabs.test.ts src/platform/telemetry/TelemetryRegistry.test.ts src/workbench/extensions/agent/crdt/writeLegInvariants.property.test.ts` (39 passed)
- `pnpm typecheck`
- `pnpm typecheck:build`
- scoped ESLint and type-aware Oxlint
- pre-push `knip --cache`

No fit-to-view machinery was present or ported. Integration truth was checked against main plus draft heads #16373 and #16375.

Gate 10 override (2026-09-03): Christian explicitly authorized bypass merge after final exact-head review.
</details>

Justification: Christian explicitly authorized this high-priority agent integration after final review. CodeJuggernaut approved an earlier revision; all later review findings are addressed, every review thread is resolved, and all required exact-head checks pass.