### PR TITLE
feat(billing): fold the plans link into the Plan & Credits footer row

### DIFF
--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2875,7 +2875,6 @@
     "outOfCreditsDescription": "Add more credits to continue generating.",
     "additionalCreditsTooltip": "Credits you add on top of your plan. Used after monthly credits run out. Each expires one year after purchase.",
     "monthlyCreditsInfo": "These credits refresh monthly and don't roll over",
-    "viewMoreDetailsPlans": "View more details about plans & pricing",
     "nextBillingCycle": "next billing cycle",
     "yourPlanIncludes": "Your plan includes:",
     "whatsIncluded": "What's included:",
@@ -2901,7 +2900,6 @@
       "freeRuns": "{count} free run | {count} free runs"
     },
     "viewMoreDetails": "View more details",
-    "learnMore": "Learn more",
     "billedMonthly": "Billed monthly",
     "billedYearly": "{total} Billed yearly",
     "monthly": "Monthly",

--- a/src/platform/cloud/subscription/components/SubscriptionFooterLinks.test.ts
+++ b/src/platform/cloud/subscription/components/SubscriptionFooterLinks.test.ts
@@ -42,7 +42,6 @@ vi.mock(
   () => ({
     useSubscriptionActions: () => ({
       isLoadingSupport: ref(false),
-      handleLearnMoreClick: state.handleLearnMoreClick,
       handleMessageSupport: state.handleMessageSupport
     })
   })
@@ -54,7 +53,7 @@ const i18n = createI18n({
   messages: {
     en: {
       subscription: {
-        learnMore: 'Learn more',
+        plansAndPricing: 'Plans & pricing',
         partnerNodesPricingTable: 'Partner Nodes pricing',
         messageSupport: 'Message support',
         invoiceHistory: 'Invoice history',
@@ -87,6 +86,20 @@ describe('SubscriptionFooterLinks', () => {
     state.isCloud = true
   })
 
+  it('emits viewPlans from the plans link only when enabled', async () => {
+    const user = userEvent.setup()
+    const { emitted, rerender } = renderComponent()
+
+    expect(
+      screen.queryByRole('button', { name: 'Plans & pricing' })
+    ).not.toBeInTheDocument()
+
+    await rerender({ showPlansLink: true })
+    await user.click(screen.getByRole('button', { name: 'Plans & pricing' }))
+
+    expect(emitted()).toHaveProperty('viewPlans')
+  })
+
   it('renders working support links without a duplicate invoice action', async () => {
     const user = userEvent.setup()
     const openSpy = vi.spyOn(window, 'open').mockReturnValue(null)
@@ -96,17 +109,11 @@ describe('SubscriptionFooterLinks', () => {
       screen.queryByRole('button', { name: 'Invoice history' })
     ).not.toBeInTheDocument()
     expect(
-      screen.getByRole('button', { name: 'Learn more' })
-    ).toBeInTheDocument()
-    expect(
       screen.getByRole('button', { name: 'Partner Nodes pricing' })
     ).toBeInTheDocument()
     expect(
       screen.getByRole('button', { name: 'Message support' })
     ).toBeInTheDocument()
-
-    await user.click(screen.getByRole('button', { name: 'Learn more' }))
-    expect(state.handleLearnMoreClick).toHaveBeenCalledOnce()
 
     await user.click(screen.getByRole('button', { name: 'Message support' }))
     expect(state.handleMessageSupport).toHaveBeenCalledOnce()

--- a/src/platform/cloud/subscription/components/SubscriptionFooterLinks.vue
+++ b/src/platform/cloud/subscription/components/SubscriptionFooterLinks.vue
@@ -1,7 +1,5 @@
 <template>
-  <div
-    class="flex items-center justify-between border-t border-interface-stroke pt-3"
-  >
+  <div class="flex items-center justify-between pt-3 pb-6">
     <div class="flex gap-2">
       <Button
         v-if="showUsageActivity"
@@ -13,12 +11,13 @@
         {{ $t('subscription.fullUsageActivity') }}
       </Button>
       <Button
+        v-if="showPlansLink"
         variant="muted-textonly"
         class="text-xs text-text-secondary"
-        @click="handleLearnMoreClick"
+        @click="$emit('viewPlans')"
       >
-        <i class="pi pi-question-circle text-xs text-text-secondary" />
-        {{ $t('subscription.learnMore') }}
+        <i class="pi pi-external-link text-xs text-text-secondary" />
+        {{ $t('subscription.plansAndPricing') }}
       </Button>
       <Button
         variant="muted-textonly"
@@ -59,17 +58,23 @@ import { getComfyPlatformBaseUrl } from '@/config/comfyApi'
 import { useSubscriptionActions } from '@/platform/cloud/subscription/composables/useSubscriptionActions'
 import { isCloud } from '@/platform/distribution/types'
 
-const { showInvoiceHistory = true, showUsageActivity = true } = defineProps<{
+const {
+  showInvoiceHistory = true,
+  showUsageActivity = true,
+  showPlansLink = false
+} = defineProps<{
   showInvoiceHistory?: boolean
   showUsageActivity?: boolean
+  showPlansLink?: boolean
 }>()
+
+defineEmits<{ viewPlans: [] }>()
 
 const { buildDocsUrl, docsPaths } = useExternalLink()
 
 const { manageSubscription } = useBillingContext()
 
-const { isLoadingSupport, handleMessageSupport, handleLearnMoreClick } =
-  useSubscriptionActions()
+const { isLoadingSupport, handleMessageSupport } = useSubscriptionActions()
 
 async function handleInvoiceHistory() {
   if (!showInvoiceHistory) return

--- a/src/platform/workspace/components/SubscriptionPanelContentWorkspace.vue
+++ b/src/platform/workspace/components/SubscriptionPanelContentWorkspace.vue
@@ -382,22 +382,12 @@
         </div>
       </div>
 
-      <!-- View More Details - Outside main content -->
-      <div v-if="canOpenPricingSurface" class="py-6">
-        <Button
-          variant="muted-textonly"
-          class="text-sm text-muted"
-          @click="handleViewMoreDetails"
-        >
-          {{ $t('subscription.viewMoreDetailsPlans') }}
-          <i class="pi pi-external-link text-muted" />
-        </Button>
-      </div>
-
       <SubscriptionFooterLinks
         class="mt-auto pt-6"
+        :show-plans-link="canOpenPricingSurface"
         :show-invoice-history="permissions.canManageSubscription"
         :show-usage-activity="workspaceRole === 'owner'"
+        @view-plans="handleViewMoreDetails"
       />
     </template>
   </div>


### PR DESCRIPTION
## Summary

Tidies the Plan & Credits footer: the plans link joins the footer's action row instead of sitting in its own block above it, the divider goes, and "Learn more" is removed.

## Changes

- **What**:
  - `SubscriptionFooterLinks` gains `showPlansLink` + a `viewPlans` emit, mirroring the existing `showUsageActivity` prop so the `canOpenPricingSurface` gate and handler stay with the panel that owns them.
  - The link renders as **Plans & pricing** (`subscription.plansAndPricing`), styled identically to its neighbours — `text-xs text-text-secondary` with an external-link icon — rather than the longer standalone phrasing.
  - Removes the `border-t` divider above the row.
  - Removes **Learn more**; it did not lead to a useful resource. `handleLearnMoreClick` stays in `useSubscriptionActions` — `ApiNodesSignInContent` still uses it.
  - Drops the now-orphaned `subscription.learnMore` and `subscription.viewMoreDetailsPlans` strings.
- **Breaking**: none. `showPlansLink` defaults to `false`, so the other consumer is unaffected.

## Review Focus

`SubscriptionFooterLinks` has two consumers (`SubscriptionPanelContentWorkspace`, `PlanCreditsPanelContent`), both workspace Plan & Credits — the divider removal is scoped to those.
