### PR TITLE
test: simplify coverage follow-up for #16381

### DIFF
--- a/src/lib/litegraph/src/LLink.spreadCopy.test.ts
+++ b/src/lib/litegraph/src/LLink.spreadCopy.test.ts
@@ -52,34 +52,18 @@ describe('plain-object copies of LLink (uncovered)', () => {
 
   it('carries topology onto a spread copy of a link', () => {
     const { graph, link } = connectedPair(toRerouteId(7))
-    const copy: Partial<LLink> = { ...graph.links[link.id] }
+    const stored = graph.links[link.id]
+    stored.type = 'FLOAT'
+    stored.parentId = toRerouteId(8)
+    const copy: Partial<LLink> = { ...stored }
 
     expect(copy.id).toBe(link.id)
-    expect(copy.type).toBe(link.type)
+    expect(copy.type).toBe('FLOAT')
     expect(copy.origin_id).toBe(link.origin_id)
     expect(copy.origin_slot).toBe(link.origin_slot)
     expect(copy.target_id).toBe(link.target_id)
     expect(copy.target_slot).toBe(link.target_slot)
-    expect(copy.parentId).toBe(link.parentId)
-  })
-
-  it('spreads the seven live topology fields after store-backed mutations', () => {
-    const { graph, link } = connectedPair(toRerouteId(7))
-    const stored = graph.links[link.id]
-    stored.type = 'FLOAT'
-    stored.parentId = toRerouteId(8)
-
-    const copy: Partial<LLink> = { ...stored }
-
-    expect(copy).toMatchObject({
-      id: stored.id,
-      type: 'FLOAT',
-      origin_id: stored.origin_id,
-      origin_slot: stored.origin_slot,
-      target_id: stored.target_id,
-      target_slot: stored.target_slot,
-      parentId: toRerouteId(8)
-    })
+    expect(copy.parentId).toBe(toRerouteId(8))
   })
 
   it('rewires Custom-Scripts consumers from copied links (#15594)', () => {

--- a/src/stores/widgetValueStore.test.ts
+++ b/src/stores/widgetValueStore.test.ts
@@ -84,19 +84,6 @@ describe('useWidgetValueStore', () => {
   })
 
   describe('widget registration', () => {
-    it('returns state for a matching re-registration and rejects an empty name', () => {
-      const store = useWidgetValueStore()
-
-      expect(store.registerWidget(seedA, state('number', 1))).toBeTruthy()
-      expect(store.registerWidget(seedA, state('number', 2))).toBeTruthy()
-      expect(
-        store.registerWidget(
-          widgetId(graphA, toNodeId('node-1'), ''),
-          state('number', 1)
-        )
-      ).toBeFalsy()
-    })
-
     it('registers a widget with minimal properties', () => {
       const store = useWidgetValueStore()
       const registered = store.registerWidget(seedA, state('number', 12345))!


### PR DESCRIPTION
## Summary

Reduces #16381 to focused behavioral coverage by removing runtime changes introduced only to satisfy coverage gaps.

## Changes

- **What**: Restores widget lookup, extension configuration, and graph serialization behavior to the parent branch's base implementation; removes tests coupled to those changes and retains the independent link-spread and widget-ID encoding coverage.

## Review Focus

Confirm that the child diff removes the reviewed failure modes without weakening existing production behavior. The resulting #16381 diff against `main` is test-only: 33 additions across two test files.