### PR TITLE
fix(agent): keep panel footer within the viewport

### DIFF
--- a/browser_tests/tests/agent/agentPanel.spec.ts
+++ b/browser_tests/tests/agent/agentPanel.spec.ts
@@ -174,6 +174,44 @@ test.describe('In-App Agent panel', { tag: '@cloud' }, () => {
   test.describe('composer sizing', () => {
     test.use({ viewport: { width: 1920, height: 1080 } })
 
+    test('reclaims the CRDT banner height when it is removed', async ({
+      comfyPage
+    }) => {
+      const page = comfyPage.page
+      await page.getByRole('button', { name: OPEN_AGENT_LABEL }).click()
+
+      const panel = page.locator('#agent-panel-root')
+      const banner = panel.getByTestId('agent-crdt-status')
+      const content = panel.locator(':scope > section')
+      const send = panel.getByRole('button', { name: enMessages.agent.send })
+      await expect(panel).toBeVisible()
+      await expect(banner).toBeVisible()
+
+      const [rootWithBanner, bannerBox, contentWithBanner] = await Promise.all([
+        panel.boundingBox(),
+        banner.boundingBox(),
+        content.boundingBox()
+      ])
+      expect(rootWithBanner).not.toBeNull()
+      expect(bannerBox).not.toBeNull()
+      expect(contentWithBanner).toEqual({
+        ...rootWithBanner!,
+        y: bannerBox!.y + bannerBox!.height,
+        height: rootWithBanner!.height - bannerBox!.height
+      })
+      await expect(send).toBeInViewport()
+
+      await banner.evaluate((element) => element.remove())
+
+      await expect
+        .poll(async () => ({
+          root: await panel.boundingBox(),
+          content: await content.boundingBox()
+        }))
+        .toEqual({ root: rootWithBanner, content: rootWithBanner })
+      await expect(send).toBeInViewport()
+    })
+
     test('caps long text at 400px and scrolls internally', async ({
       comfyPage
     }) => {

--- a/browser_tests/tests/agent/agentPanel.spec.ts
+++ b/browser_tests/tests/agent/agentPanel.spec.ts
@@ -174,7 +174,7 @@ test.describe('In-App Agent panel', { tag: '@cloud' }, () => {
   test.describe('composer sizing', () => {
     test.use({ viewport: { width: 1920, height: 1080 } })
 
-    test('reclaims the CRDT banner height when it is removed', async ({
+    test('gives the content the full height below the CRDT banner', async ({
       comfyPage
     }) => {
       const page = comfyPage.page
@@ -187,28 +187,22 @@ test.describe('In-App Agent panel', { tag: '@cloud' }, () => {
       await expect(panel).toBeVisible()
       await expect(banner).toBeVisible()
 
-      const [rootWithBanner, bannerBox, contentWithBanner] = await Promise.all([
-        panel.boundingBox(),
-        banner.boundingBox(),
-        content.boundingBox()
-      ])
-      expect(rootWithBanner).not.toBeNull()
-      expect(bannerBox).not.toBeNull()
-      expect(contentWithBanner).toEqual({
-        ...rootWithBanner!,
-        y: bannerBox!.y + bannerBox!.height,
-        height: rootWithBanner!.height - bannerBox!.height
-      })
-      await expect(send).toBeInViewport()
-
-      await banner.evaluate((element) => element.remove())
-
       await expect
-        .poll(async () => ({
-          root: await panel.boundingBox(),
-          content: await content.boundingBox()
-        }))
-        .toEqual({ root: rootWithBanner, content: rootWithBanner })
+        .poll(async () => {
+          const [root, bannerBox, contentBox] = await Promise.all([
+            panel.boundingBox(),
+            banner.boundingBox(),
+            content.boundingBox()
+          ])
+          if (!root || !bannerBox || !contentBox) return null
+          return {
+            left: contentBox.x - root.x,
+            width: contentBox.width - root.width,
+            top: contentBox.y - (bannerBox.y + bannerBox.height),
+            bottom: root.y + root.height - (contentBox.y + contentBox.height)
+          }
+        })
+        .toEqual({ left: 0, width: 0, top: 0, bottom: 0 })
       await expect(send).toBeInViewport()
     })
 

--- a/index.html
+++ b/index.html
@@ -32,12 +32,17 @@
         overscroll-behavior: none;
       }
       body {
-        display: grid;
+        display: flex;
+        flex-direction: column;
         background-color: var(--bg-color);
         background-image: var(--bg-img);
         background-position: center;
         background-size: cover;
         background-repeat: no-repeat;
+      }
+      #vue-app {
+        min-height: 0;
+        flex: 1;
       }
       .visually-hidden {
         position: absolute;
@@ -111,7 +116,7 @@
     <link rel="manifest" href="manifest.json" />
   </head>
 
-  <body class="litegraph grid">
+  <body class="litegraph">
     <div id="splash-loader" role="status" aria-label="Loading ComfyUI">
       <svg viewBox="0 0 879 284" fill="none" xmlns="http://www.w3.org/2000/svg">
         <defs>

--- a/index.html
+++ b/index.html
@@ -32,17 +32,12 @@
         overscroll-behavior: none;
       }
       body {
-        display: flex;
-        flex-direction: column;
+        display: grid;
         background-color: var(--bg-color);
         background-image: var(--bg-img);
         background-position: center;
         background-size: cover;
         background-repeat: no-repeat;
-      }
-      #vue-app {
-        min-height: 0;
-        flex: 1;
       }
       .visually-hidden {
         position: absolute;
@@ -116,7 +111,7 @@
     <link rel="manifest" href="manifest.json" />
   </head>
 
-  <body class="litegraph">
+  <body class="litegraph grid">
     <div id="splash-loader" role="status" aria-label="Loading ComfyUI">
       <svg viewBox="0 0 879 284" fill="none" xmlns="http://www.w3.org/2000/svg">
         <defs>

--- a/src/workbench/extensions/agent/AgentPanelRoot.vue
+++ b/src/workbench/extensions/agent/AgentPanelRoot.vue
@@ -943,7 +943,7 @@ function onPanelDrop(event: DragEvent): void {
 <template>
   <div
     id="agent-panel-root"
-    class="size-full"
+    class="flex size-full flex-col"
     @dragenter="onPanelDragEnter"
     @dragleave="onPanelDragLeave"
     @dragover="onPanelDragOver"
@@ -977,6 +977,7 @@ function onPanelDrop(event: DragEvent): void {
     <CrdtDevPanel v-if="isCrdtDevPanelEnabled" :status="crdtStatus" />
     <AgentPanel
       ref="panelRef"
+      class="min-h-0 flex-1"
       :entries
       :editable-turn-id="editableTurnId"
       :user-name="userName"

--- a/src/workbench/extensions/agent/components/agent/AgentPanel.vue
+++ b/src/workbench/extensions/agent/components/agent/AgentPanel.vue
@@ -178,7 +178,7 @@ defineExpose({ addAttachment, updateAttachment, removeAttachment })
 
 <template>
   <section
-    class="bg-agent-surface text-agent-fg @container flex h-full flex-col overflow-hidden"
+    class="bg-agent-surface text-agent-fg @container flex flex-col overflow-hidden"
   >
     <PanelHeader
       :is-maximized="isMaximized"


### PR DESCRIPTION
## Summary

Keep the ComfyUI application within the viewport when a top-level banner is present.

## Changes

- make the document body a column flex container
- let `#vue-app` fill and shrink within the remaining height
- automatically reclaim the full viewport when the banner is removed

## Verification

- formatting and diff checks passed
- typecheck and production build passed
- Chrome layout check passed with and without a 56px top banner

Context: https://comfy-organization.slack.com/archives/C0A8Z4U7Y1K/p1788214705285959