### PR TITLE
fix(ingest-types): dedupe CurrentWorkspaceResponse on cloud/1.51

### DIFF
--- a/packages/ingest-types/src/index.ts
+++ b/packages/ingest-types/src/index.ts
@@ -208,7 +208,6 @@ export type {
   CreateWorkspaceInviteResponses,
   CreateWorkspaceRequest,
   CreateWorkspaceResponse,
-  CurrentWorkspaceResponse,
   CreateWorkspaceResponses,
   CredentialOption,
   CurrentWorkspaceResponse,

--- a/packages/ingest-types/src/types.gen.ts
+++ b/packages/ingest-types/src/types.gen.ts
@@ -3276,20 +3276,6 @@ export type CurrentWorkspaceResponse = {
 /**
  * Request body for creating a new workspace.
  */
-export type CurrentWorkspaceResponse = {
-  /**
-   * How this request authenticated. Known values are firebase, cookie, comfy_api_key, comfy_admin_key, cloud_api_key and cloud_jwt; treat it as an open string so a new auth method is not a breaking change.
-   */
-  auth_method: string
-  id: string
-  name: string
-  /**
-   * The requesting user's role in this workspace. Omitted (absent from the object, never an explicit null) when the credential carries no resolvable user membership.
-   */
-  role?: 'owner' | 'member'
-  type: 'personal' | 'team'
-}
-
 export type CreateWorkspaceRequest = {
   /**
    * Display name for the workspace


### PR DESCRIPTION
## Summary
Backports #15951 and #15927 each added CurrentWorkspaceResponse, leaving types.gen.ts with two identical declarations (the second one shadowing CreateWorkspaceRequest's doc comment) and index.ts exporting it twice. Every job that runs typecheck on this branch fails with TS2300.

Remove the duplicate block and export line; typecheck passes again.
