### PR TITLE
fix: read the release-sheriff GitHub login map from a secret

### DIFF
--- a/.github/workflows/pr-assign-release-sheriff.yaml
+++ b/.github/workflows/pr-assign-release-sheriff.yaml
@@ -52,6 +52,12 @@ jobs:
           GH_REPO: ${{ github.repository }}
           DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
           DATADOG_APP_KEY: ${{ secrets.DATADOG_APP_KEY }}
+          # Datadog user -> GitHub login, as JSON. Must stay a secret and never
+          # become an Actions variable: Actions prints a step's env block before
+          # running it and this repo's run logs are public, so a variable would
+          # publish the whole map. Secret values are masked. Source of truth is
+          # rosters/release-sheriff-directory.json in Comfy-Org/github-workflows-ops.
+          RELEASE_SHERIFF_DIRECTORY: ${{ secrets.RELEASE_SHERIFF_DIRECTORY }}
         run: pnpm exec tsx scripts/release-sheriff/release-sheriff.ts
 
       # A failed scheduled run only notifies whoever last pushed to main, which

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -92,20 +92,146 @@ The rotation itself lives in Datadog On-Call ("Frontend Team – Oncall
 Schedule", layer "Release Sheriff") and is read at execution time, so handovers
 need no commit.
 
-Datadog exposes no GitHub identity, and GitHub only resolves commit emails its
-users chose to publish, so the two have to be bridged explicitly. That bridge
-lives on the Datadog schedule as tags, one per sheriff:
+### Mapping a Datadog user to a GitHub login
 
-```text
-github:<datadog-email-local-part>:<github-login>
+Datadog exposes no GitHub identity, and GitHub only resolves commit emails its
+users chose to publish, so the two have to be bridged explicitly. That bridge is
+the repo **secret** `RELEASE_SHERIFF_DIRECTORY`, a JSON array read straight from
+the environment by `parseGithubLogins`:
+
+```json
+[{ "datadog_email": "ben@comfy.org", "github_login": "benceruleanlu" }]
 ```
 
-So `ben@comfy.org` → GitHub `benceruleanlu` is the tag `github:ben:benceruleanlu`.
-**Adding someone to the rotation therefore means adding their tag in the Datadog
-UI — no commit.** Tags are only settable at schedule-creation time over the API,
-so edit them in the on-call UI. Datadog rejects `@` and `+` in tags and
-lower-cases what it accepts; GitHub logins are case-insensitive, so a
-lower-cased login still resolves.
+Entries are keyed by the email's local part, lower-cased; GitHub logins are
+case-insensitive, so the login's own case does not matter. Unknown fields are
+ignored, so the file can carry more than this script needs.
+
+The secret's source of truth is `rosters/release-sheriff-directory.json` in the
+private repo **`Comfy-Org/github-workflows-ops`**. Adding someone to the rotation
+is therefore two steps: add them to the Datadog layer, and open a PR adding their
+entry to that file, then run that repo's sync script to push the file into this
+repo's secret. The file is out of this repo because this repo is public, and it
+is in a repo rather than a Datadog field so a change is reviewed.
+
+It has to be a **secret**, never an Actions variable: Actions prints a step's
+`env:` block before the step runs and this repo's run logs are public, so a
+variable would publish the whole map. Secret values are masked.
+
+It used to live on the Datadog schedule as `github:<user>:<login>` tags, and the
+`PUT` full-replace trap described below is why it no longer does: one
+tags-unaware rotation edit deleted every entry at once. Those tags are now
+vestigial and can be deleted from the schedule.
+
+### Editing the schedule over the API
+
+Rotation membership and order are normally edited in the on-call UI. If you need
+to script a change instead, note that **`PUT /api/v2/on-call/schedules/{id}` is a
+full replace** — `PATCH` answers `{"errors":["Not found"]}` even for a schedule
+that `GET` returns fine — so read the schedule first and edit what comes back
+rather than composing a body by hand. Any field the body omits is wiped, the call
+returns 200, and nothing warns.
+
+The workflow's `DATADOG_APP_KEY` repo secret must remain read-only with the
+`on_call_read` permission. A manual `PUT` requires a separate local application
+key with `on_call_write`; export it as `DATADOG_WRITE_APP_KEY`, and never widen
+or reuse the CI secret for this destructive operation.
+
+`PUT` is a full replace, so read the schedule first and edit what comes back
+rather than composing a body by hand:
+
+```bash
+set -euo pipefail
+umask 077
+
+BASE=https://api.us5.datadoghq.com/api/v2/on-call/schedules
+SCHEDULE_ID=f3258942-c040-4c33-8228-63a03e9092d6
+WORK_DIR=$(mktemp -d "${TMPDIR:-/tmp}/release-sheriff.XXXXXX")
+trap 'rm -rf "$WORK_DIR"' EXIT
+READ_CONFIG="$WORK_DIR/read.curl"
+WRITE_CONFIG="$WORK_DIR/write.curl"
+PUT_FILTER="$WORK_DIR/to-put.jq"
+printf 'header = "DD-API-KEY: %s"\nheader = "DD-APPLICATION-KEY: %s"\n' \
+  "$DATADOG_API_KEY" "$DATADOG_APP_KEY" >"$READ_CONFIG"
+printf 'header = "DD-API-KEY: %s"\nheader = "DD-APPLICATION-KEY: %s"\n' \
+  "$DATADOG_API_KEY" "$DATADOG_WRITE_APP_KEY" >"$WRITE_CONFIG"
+
+cat >"$PUT_FILTER" <<'JQ'
+  . as $response
+  | .data as $schedule
+  | {
+      data: {
+        id: $schedule.id,
+        type: $schedule.type,
+        attributes: (
+          $schedule.attributes
+          | .layers = [
+              $schedule.relationships.layers.data[] as $layer_ref
+              | $response.included[]
+              | select(.type == "layers" and .id == $layer_ref.id)
+              | . as $layer
+              | $layer.attributes + {
+                  id: $layer.id,
+                  members: [
+                    $layer.relationships.members.data[] as $member_ref
+                    | $response.included[]
+                    | select(.type == "members" and .id == $member_ref.id)
+                    | {user: {id: .relationships.user.data.id}}
+                  ]
+                }
+            ]
+        ),
+        relationships: {teams: $schedule.relationships.teams}
+      }
+    }
+JQ
+
+curl --fail-with-body -sS --config "$READ_CONFIG" \
+  "$BASE/$SCHEDULE_ID?include=teams,layers,layers.members,layers.members.user" \
+  --output "$WORK_DIR/schedule.response.original.json"
+jq -f "$PUT_FILTER" "$WORK_DIR/schedule.response.original.json" \
+  >"$WORK_DIR/schedule.put.original.json"
+cp "$WORK_DIR/schedule.put.original.json" \
+  "$WORK_DIR/schedule.put.edited.json"
+"${EDITOR:?Set EDITOR before running this procedure}" \
+  "$WORK_DIR/schedule.put.edited.json"
+
+curl --fail-with-body -sS --config "$READ_CONFIG" \
+  "$BASE/$SCHEDULE_ID?include=teams,layers,layers.members,layers.members.user" \
+  --output "$WORK_DIR/schedule.response.latest.json"
+jq -f "$PUT_FILTER" "$WORK_DIR/schedule.response.latest.json" \
+  >"$WORK_DIR/schedule.put.latest.json"
+diff -u "$WORK_DIR/schedule.put.original.json" \
+  "$WORK_DIR/schedule.put.latest.json"
+diff -u \
+  <(jq -S 'del(.data.attributes.tags)' \
+    "$WORK_DIR/schedule.put.original.json") \
+  <(jq -S 'del(.data.attributes.tags)' \
+    "$WORK_DIR/schedule.put.edited.json")
+jq -e '.data.attributes.tags | type == "array"' \
+  "$WORK_DIR/schedule.put.edited.json" >/dev/null
+
+curl --fail-with-body -sS -X PUT --config "$WRITE_CONFIG" \
+  -H 'Content-Type: application/json' \
+  "$BASE/$SCHEDULE_ID" -d @"$WORK_DIR/schedule.put.edited.json"
+```
+
+The GET response is JSON:API: layers and members live in `included`. The `jq`
+step converts them to the PUT shape under `data.attributes.layers` and maps
+each member to `{ "user": { "id": "..." } }`. Edit only `tags` in
+`$WORK_DIR/schedule.put.edited.json`; the untouched response and transformed
+PUT body remain beside it until the shell exits. The conversion preserves the
+schedule's `name`, `time_zone`, `tags`, and team references; every layer's
+complete attributes and `id`; and member order.
+
+Datadog offers no optimistic-concurrency token for this endpoint. After the
+editor closes, the procedure immediately fetches the schedule again and stops
+if anything changed. It also stops unless `tags` is still an array and every
+other field in the edited body exactly matches the original.
+
+Although the GitHub mapping no longer depends on tags, preserving the complete
+schedule payload remains important: a partial `PUT` can still silently remove
+rotation data.
 
 Only `scheduleId`, `datadogSite` and `fallbackGithubLogin` stay in the `CONFIG`
 object of `scripts/release-sheriff/release-sheriff.ts`. Note `datadogSite` is
@@ -113,18 +239,19 @@ object of `scripts/release-sheriff/release-sheriff.ts`. Note `datadogSite` is
 `api.datadoghq.com` returns 403.
 
 Requires repo secrets `DATADOG_API_KEY` and `DATADOG_APP_KEY` (scope:
-`on_call_read`).
+`on_call_read`) plus `RELEASE_SHERIFF_DIRECTORY`.
 
-If the on-call user cannot be mapped — a missing tag, missing secrets, an
+If the on-call user cannot be mapped — a missing directory entry, a directory
+secret that is absent or not valid JSON, missing Datadog credentials, an
 unreachable Datadog — the job still assigns `fallbackGithubLogin` so PRs are
 never left unowned, but **exits non-zero** so the degradation is visible. A
 green run means a real sheriff was resolved from Datadog.
 
-Tag coverage is checked for the **whole rotation**, not just whoever is on call,
-and a member without one fails the run. Someone added to the layer without a tag
-otherwise works fine until their own shift begins — the breakage surfaces weeks
-after the cause, on whoever happens to be sheriff. This is a configuration
-check, so it fails even when today's assignment succeeded.
+Directory coverage is checked for the **whole rotation**, not just whoever is on
+call, and a member without an entry fails the run. Someone added to the layer
+without one otherwise works fine until their own shift begins — the breakage
+surfaces weeks after the cause, on whoever happens to be sheriff. This is a
+configuration check, so it fails even when today's assignment succeeded.
 
 A failed run also posts to **#frontend-releases** with the reason, because a
 failing scheduled workflow otherwise only notifies whoever last pushed to
@@ -148,7 +275,7 @@ Only scheduled runs **alert**, for the same reason: a run can recognise a
 duplicate only within the history it reads, so the runs that post have to be
 the runs that get read back. While the two sets differed, every PR-triggered
 failure was invisible to every other one — five posts in nine minutes when a
-rotation member turned up without a `github:` tag. PR-triggered runs still go
+rotation member turned up without a GitHub login. PR-triggered runs still go
 red on the PR itself; the alert rides the hourly sweep instead, so a new
 breakage is announced within the hour rather than on the spot.
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -125,12 +125,17 @@ vestigial and can be deleted from the schedule.
 
 ### Editing the schedule over the API
 
-Rotation membership and order are normally edited in the on-call UI. If you need
-to script a change instead, note that **`PUT /api/v2/on-call/schedules/{id}` is a
-full replace** — `PATCH` answers `{"errors":["Not found"]}` even for a schedule
-that `GET` returns fine — so read the schedule first and edit what comes back
-rather than composing a body by hand. Any field the body omits is wiped, the call
-returns 200, and nothing warns.
+Rotation membership and order are normally edited in the on-call UI. The
+scripted procedure below is scoped to **tags-only edits** (e.g. deleting the
+vestigial `github:<user>:<login>` tags after the directory moved to a secret):
+its guard aborts unless every field except `tags` matches the original. A
+broader runbook that safely scripts rotation membership changes is tracked as a
+follow-up; until then, use the UI for those. Note that
+**`PUT /api/v2/on-call/schedules/{id}` is a full replace** — `PATCH` answers
+`{"errors":["Not found"]}` even for a schedule that `GET` returns fine — so read
+the schedule first and edit what comes back rather than composing a body by
+hand. Any field the body omits is wiped, the call returns 200, and nothing
+warns.
 
 The workflow's `DATADOG_APP_KEY` repo secret must remain read-only with the
 `on_call_read` permission. A manual `PUT` requires a separate local application

--- a/scripts/release-sheriff/release-sheriff.test.ts
+++ b/scripts/release-sheriff/release-sheriff.test.ts
@@ -63,28 +63,28 @@ describe('parseOnCallEmails', () => {
 })
 
 describe('parseGithubLogins', () => {
-  // The shape RELEASE_SHERIFF_DIRECTORY actually holds, mirroring
-  // rosters/release-sheriff-directory.json in Comfy-Org/github-workflows-ops.
+  // Synthetic entries that preserve the seven-entry parser coverage without
+  // publishing the real production roster (this repo is public).
   const liveDirectory = JSON.stringify([
-    { datadog_email: 'austin@comfy.org', github_login: 'AustinMroz' },
-    { datadog_email: 'ben@comfy.org', github_login: 'benceruleanlu' },
-    { datadog_email: 'cbyrne@comfy.org', github_login: 'christian-byrne' },
-    { datadog_email: 'drjkl@comfy.org', github_login: 'DrJKL' },
-    { datadog_email: 'jaewon@comfy.org', github_login: 'dante01yoon' },
-    { datadog_email: 'nathaniel@comfy.org', github_login: 'CodeJuggernaut' },
-    { datadog_email: 'shihchi@comfy.org', github_login: 'huang47' }
+    { datadog_email: 'alice@example.org', github_login: 'alice-gh' },
+    { datadog_email: 'bob@example.org', github_login: 'bob-gh' },
+    { datadog_email: 'carol@example.org', github_login: 'carol-gh' },
+    { datadog_email: 'dave@example.org', github_login: 'dave-gh' },
+    { datadog_email: 'eve@example.org', github_login: 'eve-gh' },
+    { datadog_email: 'frank@example.org', github_login: 'frank-gh' },
+    { datadog_email: 'grace@example.org', github_login: 'grace-gh' }
   ])
 
   it('keys the whole rotation by email local part, as the tags did', () => {
     expect(parseGithubLogins(liveDirectory)).toEqual({
       githubLoginByUser: {
-        austin: 'AustinMroz',
-        ben: 'benceruleanlu',
-        cbyrne: 'christian-byrne',
-        drjkl: 'DrJKL',
-        jaewon: 'dante01yoon',
-        nathaniel: 'CodeJuggernaut',
-        shihchi: 'huang47'
+        alice: 'alice-gh',
+        bob: 'bob-gh',
+        carol: 'carol-gh',
+        dave: 'dave-gh',
+        eve: 'eve-gh',
+        frank: 'frank-gh',
+        grace: 'grace-gh'
       },
       warning: null
     })
@@ -106,6 +106,13 @@ describe('parseGithubLogins', () => {
       expect(result.githubLoginByUser).toEqual({})
       expect(result.warning).toMatch(/release-sheriff-directory\.json/)
     }
+  })
+
+  it('does not leak malformed input in the JSON parse warning', () => {
+    const result = parseGithubLogins('{not valid json: SENSITIVE_LEAK}')
+    expect(result.githubLoginByUser).toEqual({})
+    expect(result.warning).toMatch(/is not valid JSON/)
+    expect(result.warning).not.toMatch(/SENSITIVE_LEAK/)
   })
 
   it('keeps usable entries and warns about the ones it dropped', () => {

--- a/scripts/release-sheriff/release-sheriff.test.ts
+++ b/scripts/release-sheriff/release-sheriff.test.ts
@@ -128,6 +128,19 @@ describe('parseGithubLogins', () => {
     expect(result.githubLoginByUser).toEqual({ ann: 'ann-gh' })
     expect(result.warning).toMatch(/3 entries/)
   })
+
+  it('excludes keys that multiple entries normalize to, instead of keeping the last one', () => {
+    const result = parseGithubLogins(
+      JSON.stringify([
+        { datadog_email: 'ann@comfy.org', github_login: 'ann-gh' },
+        { datadog_email: 'Ann@Example.org', github_login: 'ann-impersonator' },
+        { datadog_email: 'bo@comfy.org', github_login: 'bo-gh' }
+      ])
+    )
+
+    expect(result.githubLoginByUser).toEqual({ bo: 'bo-gh' })
+    expect(result.warning).toMatch(/1 conflicting key \(ann\)/)
+  })
 })
 
 describe('nextInRotation', () => {

--- a/scripts/release-sheriff/release-sheriff.test.ts
+++ b/scripts/release-sheriff/release-sheriff.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it, vi } from 'vitest'
 import type { PullRequestSummary } from './release-sheriff'
 import {
   CONFIG,
-  fetchGithubLogins,
+  fetchDirectory,
   fetchOnCallEmails,
   isSheriffPr,
   nextInRotation,
@@ -63,33 +63,63 @@ describe('parseOnCallEmails', () => {
 })
 
 describe('parseGithubLogins', () => {
-  it('reads github:<user>:<login> tags and ignores unrelated ones', () => {
-    const payload = {
-      data: {
-        attributes: {
-          tags: [
-            'github:ben:benceruleanlu',
-            'team:frontend',
-            'github:drjkl:drjkl',
-            'github:malformed',
-            42
-          ]
-        }
-      }
-    }
+  // The shape RELEASE_SHERIFF_DIRECTORY actually holds, mirroring
+  // rosters/release-sheriff-directory.json in Comfy-Org/github-workflows-ops.
+  const liveDirectory = JSON.stringify([
+    { datadog_email: 'austin@comfy.org', github_login: 'AustinMroz' },
+    { datadog_email: 'ben@comfy.org', github_login: 'benceruleanlu' },
+    { datadog_email: 'cbyrne@comfy.org', github_login: 'christian-byrne' },
+    { datadog_email: 'drjkl@comfy.org', github_login: 'DrJKL' },
+    { datadog_email: 'jaewon@comfy.org', github_login: 'dante01yoon' },
+    { datadog_email: 'nathaniel@comfy.org', github_login: 'CodeJuggernaut' },
+    { datadog_email: 'shihchi@comfy.org', github_login: 'huang47' }
+  ])
 
-    expect(parseGithubLogins(payload)).toEqual({
-      ben: 'benceruleanlu',
-      drjkl: 'drjkl'
+  it('keys the whole rotation by email local part, as the tags did', () => {
+    expect(parseGithubLogins(liveDirectory)).toEqual({
+      githubLoginByUser: {
+        austin: 'AustinMroz',
+        ben: 'benceruleanlu',
+        cbyrne: 'christian-byrne',
+        drjkl: 'DrJKL',
+        jaewon: 'dante01yoon',
+        nathaniel: 'CodeJuggernaut',
+        shihchi: 'huang47'
+      },
+      warning: null
     })
   })
 
-  it('ignores payloads without a usable tag list', () => {
-    expect(parseGithubLogins(null)).toEqual({})
-    expect(parseGithubLogins({ data: {} })).toEqual({})
-    expect(parseGithubLogins({ data: { attributes: { tags: 'no' } } })).toEqual(
-      {}
+  it('tolerates unknown fields and upper-cased addresses', () => {
+    expect(
+      parseGithubLogins(
+        JSON.stringify([
+          { datadog_email: 'Ann@Comfy.org', github_login: 'ann-gh', team: 'fe' }
+        ])
+      )
+    ).toEqual({ githubLoginByUser: { ann: 'ann-gh' }, warning: null })
+  })
+
+  it('warns and maps nothing when the secret is absent or unparseable', () => {
+    for (const raw of [undefined, '  ', '{not json', '{"a":1}']) {
+      const result = parseGithubLogins(raw)
+      expect(result.githubLoginByUser).toEqual({})
+      expect(result.warning).toMatch(/release-sheriff-directory\.json/)
+    }
+  })
+
+  it('keeps usable entries and warns about the ones it dropped', () => {
+    const result = parseGithubLogins(
+      JSON.stringify([
+        { datadog_email: 'ann@comfy.org', github_login: 'ann-gh' },
+        { datadog_email: 'bo@comfy.org' },
+        { datadog_email: 'cy@comfy.org', github_login: '  ' },
+        'nope'
+      ])
     )
+
+    expect(result.githubLoginByUser).toEqual({ ann: 'ann-gh' })
+    expect(result.warning).toMatch(/3 entries/)
   })
 })
 
@@ -243,23 +273,26 @@ describe('fetchOnCallEmails', () => {
     })
   })
 
-  it('reads the login directory from the schedule itself', async () => {
+  it('takes the rotation from Datadog and the logins from the secret', async () => {
     const fetchSpy = vi.fn().mockResolvedValue({
       ok: true,
-      json: () =>
-        Promise.resolve({
-          data: { attributes: { tags: ['github:sheriff:sheriff-dev'] } }
-        })
+      json: () => Promise.resolve({})
     })
     vi.stubGlobal('fetch', fetchSpy)
 
-    const result = await fetchGithubLogins(datadog, creds)
+    const result = await fetchDirectory(
+      datadog,
+      creds,
+      JSON.stringify([
+        { datadog_email: 'sheriff@comfy.org', github_login: 'sheriff-dev' }
+      ])
+    )
 
     expect(result).toEqual({
       githubLoginByUser: { sheriff: 'sheriff-dev' },
       rotation: [],
       unmappedMembers: [],
-      warning: null
+      warnings: []
     })
     expect(String(fetchSpy.mock.calls[0][0])).toBe(
       'https://api.datadoghq.com/api/v2/on-call/schedules/sched-1' +
@@ -267,14 +300,13 @@ describe('fetchOnCallEmails', () => {
     )
   })
 
-  it('separates tagged members from those still missing a login', async () => {
+  it('separates listed members from those still missing a login', async () => {
     vi.stubGlobal(
       'fetch',
       vi.fn().mockResolvedValue({
         ok: true,
         json: () =>
           Promise.resolve({
-            data: { attributes: { tags: ['github:ann:ann-gh'] } },
             included: [
               {
                 type: 'layers',
@@ -304,20 +336,39 @@ describe('fetchOnCallEmails', () => {
       })
     )
 
-    const result = await fetchGithubLogins(datadog, creds)
+    const result = await fetchDirectory(
+      datadog,
+      creds,
+      JSON.stringify([
+        { datadog_email: 'ann@comfy.org', github_login: 'ann-gh' }
+      ])
+    )
 
     expect(result.rotation).toEqual(['ann-gh'])
     expect(result.unmappedMembers).toEqual(['bo'])
   })
 
-  it('degrades the directory to empty when Datadog is unreachable', async () => {
+  it('degrades the rotation to empty when Datadog is unreachable', async () => {
     vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('boom')))
 
-    const result = await fetchGithubLogins(datadog, creds)
+    const result = await fetchDirectory(datadog, creds, '[]')
 
-    expect(result.githubLoginByUser).toEqual({})
+    expect(result.rotation).toEqual([])
     expect(result.unmappedMembers).toEqual([])
-    expect(result.warning).toMatch(/lookup failed/)
+    expect(result.warnings).toEqual([expect.stringMatching(/lookup failed/)])
+  })
+
+  // Datadog going down and the secret going missing are separate failures and
+  // the Slack alert has to name both, not whichever is checked first.
+  it('reports the Datadog and directory failures together', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('boom')))
+
+    const result = await fetchDirectory(datadog, creds, undefined)
+
+    expect(result.warnings).toEqual([
+      expect.stringMatching(/lookup failed/),
+      expect.stringMatching(/RELEASE_SHERIFF_DIRECTORY is unset/)
+    ])
   })
 })
 

--- a/scripts/release-sheriff/release-sheriff.ts
+++ b/scripts/release-sheriff/release-sheriff.ts
@@ -85,8 +85,12 @@ export function parseGithubLogins(raw: string | undefined): DirectoryParse {
   let parsed: unknown
   try {
     parsed = JSON.parse(raw)
-  } catch (error) {
-    return degraded(`${DIRECTORY_ENV} is not valid JSON (${String(error)})`)
+  } catch {
+    // Node can include an excerpt of the malformed input in the error
+    // message; this text reaches public Actions logs and Slack, while
+    // GitHub masks the complete secret value rather than arbitrary
+    // fragments. Emit a fixed message without any input context.
+    return degraded(`${DIRECTORY_ENV} is not valid JSON`)
   }
   if (!Array.isArray(parsed)) {
     return degraded(`${DIRECTORY_ENV} is not a JSON array`)
@@ -510,6 +514,15 @@ async function main() {
   }
 
   if (directory.unmappedMembers.length > 0) {
+    output('degraded', problems.join(' '))
+    process.exitCode = 1
+  }
+
+  // A parser warning (skipped entries, bad JSON, etc.) means the directory is
+  // partially or fully unusable. If the valid entries still cover the active
+  // rotation the run would otherwise stay green and the failure-only Slack
+  // alert never fires, so treat any directory warning as degraded.
+  if (directory.warnings.length > 0) {
     output('degraded', problems.join(' '))
     process.exitCode = 1
   }

--- a/scripts/release-sheriff/release-sheriff.ts
+++ b/scripts/release-sheriff/release-sheriff.ts
@@ -105,14 +105,37 @@ export function parseGithubLogins(raw: string | undefined): DirectoryParse {
     return [[emailKey(email), login.trim()] as const]
   })
 
+  // Two valid entries can still normalize to the same key (e.g. different
+  // domains, or case-only differences email.trim().toLowerCase() collapses).
+  // Silently keeping whichever happened to sort last would let the wrong
+  // person get assigned and stay green, so ambiguous keys are dropped
+  // entirely rather than resolved by pair order.
+  const keyCounts = new Map<string, number>()
+  for (const [key] of pairs) {
+    keyCounts.set(key, (keyCounts.get(key) ?? 0) + 1)
+  }
+  const conflictingKeys = [...keyCounts]
+    .filter(([, count]) => count > 1)
+    .map(([key]) => key)
+  const usablePairs = pairs.filter(([key]) => !conflictingKeys.includes(key))
+
   const skipped = parsed.length - pairs.length
+  const warnings = [
+    skipped > 0
+      ? `${DIRECTORY_ENV} has ${skipped} ${skipped === 1 ? 'entry' : 'entries'} ` +
+        `without a usable datadog_email/github_login pair. ${DIRECTORY_FIX}`
+      : null,
+    conflictingKeys.length > 0
+      ? `${DIRECTORY_ENV} has ${conflictingKeys.length} conflicting ` +
+        `${conflictingKeys.length === 1 ? 'key' : 'keys'} (${conflictingKeys.sort().join(', ')}) ` +
+        `where multiple entries normalize to the same login lookup; all of ` +
+        `them were excluded rather than guessing. ${DIRECTORY_FIX}`
+      : null
+  ].filter((warning) => warning !== null)
+
   return {
-    githubLoginByUser: Object.fromEntries(pairs),
-    warning:
-      skipped > 0
-        ? `${DIRECTORY_ENV} has ${skipped} ${skipped === 1 ? 'entry' : 'entries'} ` +
-          `without a usable datadog_email/github_login pair. ${DIRECTORY_FIX}`
-        : null
+    githubLoginByUser: Object.fromEntries(usablePairs),
+    warning: warnings.length > 0 ? warnings.join(' ') : null
   }
 }
 

--- a/scripts/release-sheriff/release-sheriff.ts
+++ b/scripts/release-sheriff/release-sheriff.ts
@@ -49,29 +49,67 @@ export function parseOnCallEmails(payload: unknown): string[] {
   return [...new Set(emails)]
 }
 
-// Datadog holds no GitHub identity, and GitHub only resolves commit emails its
-// users chose to make public — three of seven sheriffs are unresolvable that
-// way. The bridge is therefore declared on the schedule itself, as tags of the
-// form github:<datadog-email-local-part>:<github-login>, so a rotation change
-// stays a Datadog edit. Datadog rejects "@" and "+" outright and lower-cases
-// what it does accept; GitHub logins are case-insensitive, so that is lossless.
-const GITHUB_LOGIN_TAG = /^github:([^:]+):([^:]+)$/
-
 export function emailKey(email: string): string {
   return email.split('@')[0].trim().toLowerCase()
 }
 
-export function parseGithubLogins(payload: unknown): Record<string, string> {
-  if (!isRecord(payload) || !isRecord(payload.data)) return {}
-  const { attributes } = payload.data
-  if (!isRecord(attributes) || !Array.isArray(attributes.tags)) return {}
+const DIRECTORY_ENV = 'RELEASE_SHERIFF_DIRECTORY'
 
-  return Object.fromEntries(
-    attributes.tags.flatMap((tag) => {
-      const match = typeof tag === 'string' ? GITHUB_LOGIN_TAG.exec(tag) : null
-      return match ? [[match[1].toLowerCase(), match[2]]] : []
-    })
-  )
+// Naming the file and the follow-up in every message: the previous guidance
+// said "add a tag to the schedule", and people did exactly that for months.
+const DIRECTORY_FIX =
+  'Add an entry to rosters/release-sheriff-directory.json in ' +
+  'Comfy-Org/github-workflows-ops and run its sync script.'
+
+export interface DirectoryParse {
+  githubLoginByUser: Record<string, string>
+  warning: string | null
+}
+
+// Datadog holds no GitHub identity, and GitHub only resolves commit emails its
+// users chose to make public — three of seven sheriffs are unresolvable that
+// way — so the bridge has to be declared somewhere. Not here: this repo is
+// public. Not on the Datadog schedule either, where it used to live as
+// github:<user>:<login> tags: PUT /api/v2/on-call/schedules/{id} is a full
+// replace, so one tags-unaware rotation edit deleted the whole map, returned
+// 200, and warned about nothing. It is now an Actions secret, fed from a
+// reviewed file in a private repo.
+export function parseGithubLogins(raw: string | undefined): DirectoryParse {
+  const degraded = (warning: string): DirectoryParse => ({
+    githubLoginByUser: {},
+    warning: `${warning} — using the fallback. ${DIRECTORY_FIX}`
+  })
+
+  if (!raw?.trim()) return degraded(`${DIRECTORY_ENV} is unset`)
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch (error) {
+    return degraded(`${DIRECTORY_ENV} is not valid JSON (${String(error)})`)
+  }
+  if (!Array.isArray(parsed)) {
+    return degraded(`${DIRECTORY_ENV} is not a JSON array`)
+  }
+
+  const pairs = parsed.flatMap((entry) => {
+    if (!isRecord(entry)) return []
+    const email = entry.datadog_email
+    const login = entry.github_login
+    if (typeof email !== 'string' || typeof login !== 'string') return []
+    if (!email.trim() || !login.trim()) return []
+    return [[emailKey(email), login.trim()] as const]
+  })
+
+  const skipped = parsed.length - pairs.length
+  return {
+    githubLoginByUser: Object.fromEntries(pairs),
+    warning:
+      skipped > 0
+        ? `${DIRECTORY_ENV} has ${skipped} ${skipped === 1 ? 'entry' : 'entries'} ` +
+          `without a usable datadog_email/github_login pair. ${DIRECTORY_FIX}`
+        : null
+  }
 }
 
 export interface OnCallLookup {
@@ -113,10 +151,10 @@ export function parseRotationKeys(payload: unknown): string[] {
 export interface DirectoryLookup {
   githubLoginByUser: Record<string, string>
   rotation: string[]
-  // Rotation members with no github: tag. They break silently when their own
-  // shift starts, weeks after the tag was forgotten, so surface them now.
+  // Rotation members with no directory entry. They break silently when their
+  // own shift starts, weeks after the entry was forgotten, so surface them now.
   unmappedMembers: string[]
-  warning: string | null
+  warnings: string[]
 }
 
 interface DatadogResponse {
@@ -193,14 +231,17 @@ export async function fetchOnCallEmails(
   return { emails: parseOnCallEmails(payload), warning }
 }
 
-export async function fetchGithubLogins(
+// Datadog still owns the rotation and its order; only the identity map moved.
+export async function fetchDirectory(
   config: Pick<typeof CONFIG, 'datadogSite' | 'scheduleId'>,
-  credentials: { apiKey?: string; appKey?: string }
+  credentials: { apiKey?: string; appKey?: string },
+  rawDirectory: string | undefined
 ): Promise<DirectoryLookup> {
   const { payload, warning } = await datadogGet(config, credentials, '', {
     include: 'layers.members.user'
   })
-  const githubLoginByUser = parseGithubLogins(payload)
+  const { githubLoginByUser, warning: directoryWarning } =
+    parseGithubLogins(rawDirectory)
   const keys = parseRotationKeys(payload)
   return {
     githubLoginByUser,
@@ -209,7 +250,7 @@ export async function fetchGithubLogins(
       return login ? [login] : []
     }),
     unmappedMembers: keys.filter((key) => !githubLoginByUser[key]),
-    warning
+    warnings: [warning, directoryWarning].filter((w) => w !== null)
   }
 }
 
@@ -429,12 +470,14 @@ async function main() {
   }
   const [oncall, directory] = await Promise.all([
     fetchOnCallEmails(CONFIG, credentials),
-    fetchGithubLogins(CONFIG, credentials)
+    fetchDirectory(CONFIG, credentials, process.env[DIRECTORY_ENV])
   ])
   // Both lookups hit the same API, so a credentials or outage failure arrives
   // twice; the Slack alert should say it once.
   const problems = [
-    ...new Set([oncall.warning, directory.warning].filter((w) => w !== null))
+    ...new Set(
+      [oncall.warning, ...directory.warnings].filter((w) => w !== null)
+    )
   ]
 
   const { login, source, unmappedEmails } = resolveSheriff(oncall.emails, {
@@ -442,20 +485,19 @@ async function main() {
     githubLoginByUser: directory.githubLoginByUser
   })
   // Keyed, not the full address: this repo is public, so the warning lands in
-  // public Actions logs and in Slack. The key is what the tag needs anyway.
+  // public Actions logs and in Slack. The key is the directory's own key anyway.
   for (const email of unmappedEmails) {
     problems.push(
-      `Datadog on-call user "${emailKey(email)}" has no GitHub login. Add ` +
-        `the tag "github:${emailKey(email)}:<github-login>" to the schedule.`
+      `Datadog on-call user "${emailKey(email)}" has no GitHub login. ${DIRECTORY_FIX}`
     )
   }
   // Checked for the whole rotation, not just whoever is on call: a member
-  // added without a tag works fine until their own shift begins, then falls
+  // added without an entry works fine until their own shift begins, then falls
   // back silently. Fail now, while it is still someone else's week.
   for (const key of directory.unmappedMembers) {
     problems.push(
       `Rotation member "${key}" has no GitHub login and will fall back when ` +
-        `their shift starts. Add "github:${key}:<github-login>" to the schedule.`
+        `their shift starts. ${DIRECTORY_FIX}`
     )
   }
   for (const problem of problems) warn(problem)


### PR DESCRIPTION
## Summary

Move the release sheriff's Datadog-user → GitHub-login map off Datadog schedule tags and onto the `RELEASE_SHERIFF_DIRECTORY` Actions secret.

## Changes

- **What**: `parseGithubLogins` now parses the `RELEASE_SHERIFF_DIRECTORY` env var — a JSON array of `{ datadog_email, github_login }` — into the same `Record<emailLocalPart, login>` it built from `github:<user>:<login>` tags. `fetchGithubLogins` becomes `fetchDirectory`: it still GETs the schedule for rotation order and membership, and merges that with the directory. The workflow passes the secret through the step's `env:`. Docs updated.
- **Breaking**: none for callers; the workflow needs the `RELEASE_SHERIFF_DIRECTORY` secret, which is already set on this repo.

Why it moved: `PUT /api/v2/on-call/schedules/{id}` is a full replace, so any schedule edit whose body omits `tags` wipes every tag, returns 200 and warns about nothing. That happened — the entire map was destroyed and every sheriff PR silently fell back to the fallback login until the hourly alert was investigated. Storing the map on an object that unrelated rotation edits rewrite is not viable, and it cannot be committed here because this repo is public.

The canonical copy lives in the private `Comfy-Org/github-workflows-ops` at `rosters/release-sheriff-directory.json`, edited by PR and pushed into the secret by that repo's sync script. That side is a separate PR; this one does not depend on it, since the secret already exists.

## Review Focus

- **Secret, not variable.** Actions prints a step's `env:` block before the step runs and this repo's run logs are public, so an Actions variable would publish the whole map. Secret values are masked. The reason is recorded in a comment on the `env:` entry and in `docs/release-process.md`, because it is the kind of thing a "this isn't really secret" cleanup would undo.
- **Behaviour preserved.** `fallbackGithubLogin` is still assigned so PRs are never unowned; degradation still exits non-zero; the coverage check still runs over the **whole rotation**, so a member with no directory entry fails the run today rather than during their own shift.
- **Failure modes.** Absent, malformed, non-array or partially-unusable JSON degrades to an empty map plus a warning, matching `datadogGet`'s "every failure degrades to an empty payload plus a returned warning". `DirectoryLookup.warning` became `warnings: string[]` so a Datadog outage and a missing secret are both reported rather than one masking the other.
- **Warning text.** Messages named the exact missing key and told you to add a schedule tag. They still name the key and now point at the roster file and its sync script.
- **Docs.** The `github:*` tags are now vestigial and can be deleted from the schedule; the doc says so. The `PUT` read-modify-write procedure from #16429 is kept but generalised to schedule edits, since the full-replace trap remains true for rotation changes.

## Verification

- `pnpm lint`: 0 errors (187 pre-existing `apiSchema is deprecated` warnings, none in this diff)
- `pnpm typecheck`: clean; `scripts/` is outside the root `tsconfig.json` include list, so also checked directly with `tsc --strict` over both sheriff files — clean
- `pnpm test:unit scripts/release-sheriff`: 37 passed
- `pnpm knip`, `pnpm format:check`: clean
- A unit test asserts the new parser produces the expected `Record` for the full seven-person rotation, matching what the tag parser produced.
