### PR TITLE
test: cover detached geometry and lifecycle contracts

### DIFF
--- a/src/lib/litegraph/src/LGraph.serialise.test.ts
+++ b/src/lib/litegraph/src/LGraph.serialise.test.ts
@@ -104,6 +104,61 @@ describe('LGraph Serialisation', () => {
     })
   })
 
+  test('binds serialization hooks to live instances with plain data arguments', ({
+    expect
+  }) => {
+    const graph = new LGraph()
+    const node = new LGraphNode('Before serialize')
+    graph.add(node)
+
+    node.onSerialize = function (data) {
+      expect(this).toBe(node)
+      expect(data).not.toBe(this)
+      expect(Object.getPrototypeOf(data)).toBe(Object.prototype)
+      this.title = 'After serialize'
+    }
+    graph.onSerialize = function (data) {
+      expect(this).toBe(graph)
+      expect(data).not.toBe(this)
+      expect(Object.getPrototypeOf(data)).toBe(Object.prototype)
+      this.extra.serialized = true
+    }
+
+    node.serialize()
+    graph.asSerialisable()
+
+    expect(node.title).toBe('After serialize')
+    expect(graph.extra.serialized).toBe(true)
+  })
+
+  test('binds configure hooks to live instances with plain data arguments', ({
+    expect
+  }) => {
+    const graph = new LGraph()
+    const node = new LGraphNode('Before configure')
+    const nodeData = node.serialize()
+    const graphData = graph.asSerialisable()
+
+    node.onConfigure = function (data) {
+      expect(this).toBe(node)
+      expect(data).not.toBe(this)
+      expect(Object.getPrototypeOf(data)).toBe(Object.prototype)
+      this.title = 'After configure'
+    }
+    graph.onConfigure = function (data) {
+      expect(this).toBe(graph)
+      expect(data).not.toBe(this)
+      expect(Object.getPrototypeOf(data)).toBe(Object.prototype)
+      this.extra.configured = true
+    }
+
+    node.configure(nodeData)
+    graph.configure(graphData)
+
+    expect(node.title).toBe('After configure')
+    expect(graph.extra.configured).toBe(true)
+  })
+
   test('preserves canonical hook mutations while isolating legacy payloads', ({
     expect,
     minimalGraph

--- a/src/lib/litegraph/src/LGraph.test.ts
+++ b/src/lib/litegraph/src/LGraph.test.ts
@@ -1033,9 +1033,21 @@ describe('node:before-removed event', () => {
     graph.events.addEventListener('node:before-removed', () => {
       order.push('before-removed')
     })
-    target.onConnectionsChange = () => order.push('target-connection-change')
-    source.onConnectionsChange = () => order.push('source-connection-change')
-    source.onRemoved = () => order.push('onRemoved')
+    target.onConnectionsChange = () => {
+      expect(source.graph).toBe(graph)
+      expect(target.graph).toBe(graph)
+      order.push('target-connection-change')
+    }
+    source.onConnectionsChange = () => {
+      expect(source.graph).toBe(graph)
+      expect(target.graph).toBe(graph)
+      order.push('source-connection-change')
+    }
+    source.onRemoved = () => {
+      expect(source.graph).toBe(graph)
+      expect(target.graph).toBe(graph)
+      order.push('onRemoved')
+    }
     graph.onNodeRemoved = () => {
       order.push(
         `onNodeRemoved(graph=${source.graph === null ? 'null' : 'set'})`

--- a/src/lib/litegraph/src/LGraph.test.ts
+++ b/src/lib/litegraph/src/LGraph.test.ts
@@ -1019,6 +1019,44 @@ describe('node:before-removed event', () => {
     ])
   })
 
+  it('orders connection and lifecycle callbacks during node removal', () => {
+    const graph = new LGraph()
+    const source = new LGraphNode('source')
+    source.addOutput('output', '*')
+    const target = new LGraphNode('target')
+    target.addInput('input', '*')
+    graph.add(source)
+    graph.add(target)
+    source.connect(0, target, 0)
+    const order: string[] = []
+
+    graph.events.addEventListener('node:before-removed', () => {
+      order.push('before-removed')
+    })
+    target.onConnectionsChange = () => order.push('target-connection-change')
+    source.onConnectionsChange = () => order.push('source-connection-change')
+    source.onRemoved = () => order.push('onRemoved')
+    graph.onNodeRemoved = () => {
+      order.push(
+        `onNodeRemoved(graph=${source.graph === null ? 'null' : 'set'})`
+      )
+    }
+    graph.events.addEventListener('node:removed', () => {
+      order.push(`removed(graph=${source.graph === null ? 'null' : 'set'})`)
+    })
+
+    graph.remove(source)
+
+    expect(order).toEqual([
+      'before-removed',
+      'target-connection-change',
+      'source-connection-change',
+      'onRemoved',
+      'onNodeRemoved(graph=null)',
+      'removed(graph=null)'
+    ])
+  })
+
   it('fires node:added once the node is attached and registered', () => {
     const graph = new LGraph()
     const node = new LGraphNode('test')

--- a/src/lib/litegraph/src/LGraphNode.geometry.test.ts
+++ b/src/lib/litegraph/src/LGraphNode.geometry.test.ts
@@ -86,6 +86,21 @@ describe('layout geometry projection', () => {
     })
   })
 
+  test('keeps detached setPos and setSize writes local', () => {
+    const { graph, node } = nodeWithStoredBounds(30, 40)
+    const graphId = graph.rootGraph.id
+    const nodeId = node.id
+    graph.remove(node)
+
+    node.setPos(70, 90)
+    node.setSize([320, 180])
+
+    expect([...node.pos]).toEqual([70, 90])
+    expect([...node.size]).toEqual([320, 180])
+    expect(layoutStore.getNodeLayout(graphId, nodeId)).toBeNull()
+    expect(graph.getNodeById(nodeId)).toBeUndefined()
+  })
+
   test('refreshes stable views before indexed mutations', () => {
     const { graph, node } = nodeWithStoredBounds(30, 40, true)
     const pos = node.pos

--- a/src/lib/litegraph/src/geometryApiContracts.test.ts
+++ b/src/lib/litegraph/src/geometryApiContracts.test.ts
@@ -44,8 +44,10 @@ describe('geometry API contracts', () => {
       source.connect(0, target, 0)!
     )!
 
+    expect(graph.reroutes.get(reroute.id)).toBe(reroute)
     expect(() => Reflect.set(reroute, 'pos', [])).toThrow(TypeError)
     graph.removeReroute(reroute.id)
+    expect(graph.reroutes.has(reroute.id)).toBe(false)
     expect(() => Reflect.set(reroute, 'pos', [1])).toThrow(TypeError)
     expect([...reroute.pos]).toEqual([10, 20])
   })

--- a/src/lib/litegraph/src/geometryApiContracts.test.ts
+++ b/src/lib/litegraph/src/geometryApiContracts.test.ts
@@ -1,0 +1,52 @@
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import {
+  LGraph,
+  LGraphGroup,
+  LGraphNode,
+  Reroute
+} from '@/lib/litegraph/src/litegraph'
+import { toRerouteId } from '@/types/rerouteId'
+
+describe('geometry API contracts', () => {
+  beforeEach(() => setActivePinia(createTestingPinia({ stubActions: false })))
+
+  it('exposes entity-specific geometry write APIs', () => {
+    const graph = new LGraph()
+    const node = new LGraphNode('node')
+    const group = new LGraphGroup('group')
+    const reroute = new Reroute(toRerouteId(1), graph, [0, 0])
+
+    expect(typeof node.setPos).toBe('function')
+    expect(typeof node.setSize).toBe('function')
+    expect('pos' in group).toBe(true)
+    expect('size' in group).toBe(true)
+    expect('setPos' in group).toBe(false)
+    expect('setSize' in group).toBe(false)
+    expect('pos' in reroute).toBe(true)
+    expect('size' in reroute).toBe(false)
+    expect('setPos' in reroute).toBe(false)
+    expect('setSize' in reroute).toBe(false)
+  })
+
+  it('rejects malformed reroute positions while attached and detached', () => {
+    const graph = new LGraph()
+    const source = new LGraphNode('source')
+    source.addOutput('output', '*')
+    const target = new LGraphNode('target')
+    target.addInput('input', '*')
+    graph.add(source)
+    graph.add(target)
+    const reroute = graph.createReroute(
+      [10, 20],
+      source.connect(0, target, 0)!
+    )!
+
+    expect(() => Reflect.set(reroute, 'pos', [])).toThrow(TypeError)
+    graph.removeReroute(reroute.id)
+    expect(() => Reflect.set(reroute, 'pos', [1])).toThrow(TypeError)
+    expect([...reroute.pos]).toEqual([10, 20])
+  })
+})

--- a/src/lib/litegraph/src/litegraph.publicApi.test.ts
+++ b/src/lib/litegraph/src/litegraph.publicApi.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+
+import * as litegraph from './litegraph'
+
+describe('litegraph public API', () => {
+  it('does not export internal slot-link helpers', () => {
+    for (const helper of [
+      'inputHasLink',
+      'outputHasLinks',
+      'outputLinkIds',
+      'inputLink',
+      'outputLinks'
+    ]) {
+      expect(litegraph).not.toHaveProperty(helper)
+    }
+  })
+})


### PR DESCRIPTION
Adds five tests for detached geometry, lifecycle ordering, hook identity, and API boundaries.
Three assigned widget contracts were already covered, so this avoids duplicate tests.

<details><summary>Full context for agent readers</summary>

## Covered checklist items

This tests-only pull request covers five checklist items from [the ECS follow-on coverage tracker](https://github.com/Comfy-Org/ComfyUI_frontend/issues/15973):

- [Detached node position and size writes remain local](https://github.com/Comfy-Org/ComfyUI_frontend/pull/15857#discussion_r3854894759).
- [Node removal preserves the complete callback order](https://github.com/Comfy-Org/ComfyUI_frontend/pull/15857#discussion_r3854894764).
- [Serialize and configure hooks receive live-instance receivers and plain data arguments](https://github.com/Comfy-Org/ComfyUI_frontend/pull/15857#discussion_r3855858004).
- [Detached geometry APIs differ intentionally by entity type](https://github.com/Comfy-Org/ComfyUI_frontend/pull/15857#discussion_r3855858021).
- [Internal slot-link helpers remain outside the public LiteGraph API](https://github.com/Comfy-Org/ComfyUI_frontend/pull/15857#discussion_r3854894770).

## Already covered

Verification against current `main`, #16381, and corrective pull request #16441 found existing coverage for widget registration return values, widget ID percent encoding, and null widget-value slots. The [claim comment](https://github.com/Comfy-Org/ComfyUI_frontend/issues/15973#issuecomment-5487699485) records the exact evidence.

## Validation

- Targeted Vitest: 137 tests passed across five touched files.
- Formatting: passed.
- ESLint: passed with pre-existing restricted-path warnings only.
- Typecheck and type-aware lint: passed in the commit hook.

<!-- authored-by:agent -->
</details>
