### PR TITLE
test: cover subgraph remints and widget name enumeration

### DIFF
--- a/src/lib/litegraph/src/LGraph.remintLinkRemap.test.ts
+++ b/src/lib/litegraph/src/LGraph.remintLinkRemap.test.ts
@@ -3,7 +3,13 @@ import { setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it } from 'vitest'
 
 import { registerNodeState } from '@/core/graph/nodeShell/nodeShellState'
-import { LGraph, LGraphNode, LiteGraph } from '@/lib/litegraph/src/litegraph'
+import {
+  LGraph,
+  LGraphNode,
+  LiteGraph,
+  Subgraph
+} from '@/lib/litegraph/src/litegraph'
+import { createTestSubgraphData } from '@/lib/litegraph/src/subgraph/__fixtures__/subgraphHelpers'
 import type {
   ISerialisedGraph,
   ISerialisedNode,
@@ -233,6 +239,46 @@ describe('LGraph.configure remint link remap', () => {
       (link) => link.id === toLinkId(400)
     )
     expect(floating?.origin_id).toBe(newcomer.id)
+  })
+
+  it('remaps regular and floating link endpoints when configuring a subgraph', () => {
+    const rootGraph = new LGraph()
+    const subgraph = new Subgraph(rootGraph, createTestSubgraphData())
+    const incumbent = new DummyNode()
+    incumbent.id = toNodeId(1)
+    if (!registerNodeState(subgraph, incumbent)) {
+      throw new Error('failed to register incumbent subgraph node 1')
+    }
+    const payload = createTestSubgraphData({
+      ...mergePayload(),
+      id: subgraph.id,
+      state: {
+        lastNodeId: 3,
+        lastLinkId: 400,
+        lastGroupId: 0,
+        lastRerouteId: 0
+      },
+      floatingLinks: [
+        {
+          id: 400,
+          origin_id: 1,
+          origin_slot: 0,
+          target_id: -1,
+          target_slot: -1,
+          type: 'number'
+        }
+      ]
+    })
+
+    subgraph.configure(payload, true)
+
+    const newcomer = getNodeByTitle(subgraph, 'newcomer')
+    expect(newcomer.id).not.toBe(toNodeId(1))
+    expect(subgraph.links.get(toLinkId(200))?.origin_id).toBe(newcomer.id)
+    expect(subgraph.links.get(toLinkId(201))?.target_id).toBe(newcomer.id)
+    expect(subgraph.floatingLinks.get(toLinkId(400))?.origin_id).toBe(
+      newcomer.id
+    )
   })
 
   it('keeps unassigned floating endpoints when a payload node requests -1', () => {

--- a/src/lib/litegraph/src/widgets/BaseWidget.test.ts
+++ b/src/lib/litegraph/src/widgets/BaseWidget.test.ts
@@ -1,3 +1,4 @@
+// oxlint-disable no-misused-spread -- spreading a widget is the compatibility contract under test
 import { fromAny } from '@total-typescript/shoehorn'
 import { beforeEach, describe, expect, it } from 'vitest'
 
@@ -66,6 +67,17 @@ describe('BaseWidget store integration', () => {
     node = new LGraphNode('TestNode')
     node.id = toNodeId(1)
     graph.add(node)
+  })
+
+  it('preserves name in keys, spread copies, and JSON', () => {
+    const widget = createTestWidget(node, { name: 'custom-name' })
+
+    expect(Object.keys(widget)).toContain('_name')
+    expect(Object.keys(widget)).not.toContain('name')
+    expect({ ...widget }).toMatchObject({ _name: 'custom-name' })
+    expect(JSON.parse(JSON.stringify(widget))).toMatchObject({
+      _name: 'custom-name'
+    })
   })
 
   describe('metadata properties before registration', () => {


### PR DESCRIPTION
Two compatibility contracts pinned. Tests only. Targeted checks green.

<details><summary>Full context for agent readers</summary>

## Summary

Adds focused regression coverage for two outstanding items in [the ECS follow-on coverage tracker](https://github.com/Comfy-Org/ComfyUI_frontend/issues/15973).

## Changes

- [Subgraph inherits remint-remap through `super.configure()`](https://github.com/Comfy-Org/ComfyUI_frontend/issues/15973): verifies regular and floating link endpoints follow a node reminted inside `Subgraph.configure()`.
- [`BaseWidget.name` enumeration behavior](https://github.com/Comfy-Org/ComfyUI_frontend/issues/15973): pins `Object.keys`, object spread, and JSON serialization behavior for a custom widget name.

## Review focus

The Subgraph fixture deliberately pre-registers an incumbent state without adding it to the node list, matching the existing root-graph collision fixture and isolating the configure inheritance contract.

## Verification

- Vitest: 25 tests passed across both touched files.
- oxfmt: clean.
- oxlint: clean.
- Commit hooks: formatting, type-aware oxlint, ESLint, typecheck, and knip passed.

Contributes to #15973.
</details>
<!-- authored-by:agent -->
