### PR TITLE
fix: refresh node image after mask editor save

### DIFF
--- a/src/composables/maskeditor/useMaskEditorSaver.test.ts
+++ b/src/composables/maskeditor/useMaskEditorSaver.test.ts
@@ -220,6 +220,26 @@ describe('useMaskEditorSaver', () => {
     )
   })
 
+  it('replaces a stale clipspace image with the saved image', async () => {
+    mockNode.images = [
+      {
+        filename: 'pasted-before-edit.png',
+        subfolder: 'clipspace',
+        type: 'input'
+      }
+    ]
+
+    await useMaskEditorSaver().save()
+
+    expect(mockNode.images).toEqual([
+      {
+        filename: 'clipspace-painted-masked-123.png',
+        subfolder: 'clipspace',
+        type: 'input'
+      }
+    ])
+  })
+
   it('omits subfolder from the upload FormData under the unified contract', async () => {
     const fetchApiMock = vi.mocked(api.fetchApi)
 

--- a/src/composables/maskeditor/useMaskEditorSaver.test.ts
+++ b/src/composables/maskeditor/useMaskEditorSaver.test.ts
@@ -240,6 +240,26 @@ describe('useMaskEditorSaver', () => {
     ])
   })
 
+  it('does not write server references after the source node is detached', async () => {
+    vi.mocked(api.fetchApi).mockImplementation(async () => {
+      mockNode.graph = null
+      return {
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            name: 'clipspace-painted-masked-123.png',
+            subfolder: 'clipspace',
+            type: 'input'
+          })
+      } as Response
+    })
+
+    await useMaskEditorSaver().save()
+
+    expect(useNodeOutputStore().nodeOutputs['42']).toBeUndefined()
+    expect(mockNode.widgets?.[0].value).toBe('original.png [input]')
+  })
+
   it('omits subfolder from the upload FormData under the unified contract', async () => {
     const fetchApiMock = vi.mocked(api.fetchApi)
 

--- a/src/composables/maskeditor/useMaskEditorSaver.ts
+++ b/src/composables/maskeditor/useMaskEditorSaver.ts
@@ -285,7 +285,7 @@ export function useMaskEditorSaver() {
     )
 
     node.imgs = undefined
-    nodeOutputStore.setNodeOutputImages(node, [
+    nodeOutputStore.replaceNodeOutputImages(node, [
       {
         filename: mainRef.filename,
         subfolder: mainRef.subfolder,

--- a/src/composables/maskeditor/useMaskEditorSaver.ts
+++ b/src/composables/maskeditor/useMaskEditorSaver.ts
@@ -277,6 +277,8 @@ export function useMaskEditorSaver() {
     node: LGraphNode,
     outputData: EditorOutputData
   ): void {
+    if (!node.graph) return
+
     const mainRef = outputData.paintedMaskedImage.ref
 
     writeImageWidgetValue(

--- a/src/composables/maskeditor/useMaskEditorSaver.ts
+++ b/src/composables/maskeditor/useMaskEditorSaver.ts
@@ -12,7 +12,6 @@ import type {
 } from '@/stores/maskEditorDataStore'
 import { api } from '@/scripts/api'
 import { app } from '@/scripts/app'
-import { createAnnotatedPath } from '@/utils/createAnnotatedPath'
 import { encodeRgbaAsPng } from '@/utils/pngEncodeUtil'
 import { isResultItemType } from '@/utils/typeGuardUtil'
 
@@ -286,11 +285,13 @@ export function useMaskEditorSaver() {
     )
 
     node.imgs = undefined
-    const annotatedPath = createAnnotatedPath(mainRef.filename, {
-      subfolder: mainRef.subfolder,
-      rootFolder: isResultItemType(mainRef.type) ? mainRef.type : undefined
-    })
-    nodeOutputStore.setNodeOutputs(node, annotatedPath, { folder: 'input' })
+    nodeOutputStore.setNodeOutputImages(node, [
+      {
+        filename: mainRef.filename,
+        subfolder: mainRef.subfolder,
+        type: isResultItemType(mainRef.type) ? mainRef.type : 'input'
+      }
+    ])
     node.graph?.setDirtyCanvas(true)
   }
 

--- a/src/stores/nodeOutputStore.test.ts
+++ b/src/stores/nodeOutputStore.test.ts
@@ -259,6 +259,7 @@ describe('nodeOutputStore legacy entry synchronization', () => {
 describe('nodeOutputStore replaceNodeOutputImages', () => {
   beforeEach(() => {
     app.nodeOutputs = {}
+    app.nodePreviewImages = {}
   })
 
   it('drops the previous output metadata when replacing the images', () => {
@@ -285,6 +286,18 @@ describe('nodeOutputStore replaceNodeOutputImages', () => {
     expect(store.nodeOutputs['7']?.animated).toBeUndefined()
     expect(store.nodeOutputs['7']?.video).toBeUndefined()
     expect(store.nodeOutputs['7']?.images).toEqual(images)
+  })
+
+  it('ignores an empty replacement', () => {
+    const store = useNodeOutputStore()
+    const images = [{ filename: 'previous.png', type: 'input' as const }]
+    const node = createMockNode({ id: 7, images })
+    store.setOutputFromLegacy('7', { images })
+
+    store.replaceNodeOutputImages(node, [])
+
+    expect(store.nodeOutputs['7']?.images).toEqual(images)
+    expect(node.images).toEqual(images)
   })
 })
 

--- a/src/stores/nodeOutputStore.test.ts
+++ b/src/stores/nodeOutputStore.test.ts
@@ -256,6 +256,33 @@ describe('nodeOutputStore legacy entry synchronization', () => {
   })
 })
 
+describe('nodeOutputStore setNodeOutputImages', () => {
+  beforeEach(() => {
+    app.nodeOutputs = {}
+  })
+
+  it('drops the previous animated flags when replacing the images', () => {
+    const store = useNodeOutputStore()
+    const node = createMockNode({ id: 7 })
+    store.setOutputFromLegacy(
+      '7',
+      fromAny({ images: [{ filename: 'previous.webp' }], animated: [true] })
+    )
+
+    const images = [
+      {
+        filename: 'painted.png',
+        subfolder: 'clipspace',
+        type: 'input' as const
+      }
+    ]
+    store.setNodeOutputImages(node, images)
+
+    expect(store.nodeOutputs['7']?.animated).toBeUndefined()
+    expect(store.nodeOutputs['7']?.images).toEqual(images)
+  })
+})
+
 describe('nodeOutputStore restoreOutputs', () => {
   beforeEach(() => {
     app.nodeOutputs = {}

--- a/src/stores/nodeOutputStore.test.ts
+++ b/src/stores/nodeOutputStore.test.ts
@@ -299,6 +299,21 @@ describe('nodeOutputStore replaceNodeOutputImages', () => {
     expect(store.nodeOutputs['7']?.images).toEqual(images)
     expect(node.images).toEqual(images)
   })
+
+  it('removes stale previews when replacing the images', () => {
+    const store = useNodeOutputStore()
+    const node = createMockNode({ id: 7 })
+    store.setNodePreviewsByLocatorId(createNodeLocatorId(null, node.id), [
+      'preview:stale'
+    ])
+
+    store.replaceNodeOutputImages(node, [
+      { filename: 'painted.png', type: 'input' }
+    ])
+
+    expect(store.getNodePreviews(node)).toBeUndefined()
+    expect(app.nodePreviewImages['7']).toBeUndefined()
+  })
 })
 
 describe('nodeOutputStore restoreOutputs', () => {

--- a/src/stores/nodeOutputStore.test.ts
+++ b/src/stores/nodeOutputStore.test.ts
@@ -256,17 +256,21 @@ describe('nodeOutputStore legacy entry synchronization', () => {
   })
 })
 
-describe('nodeOutputStore setNodeOutputImages', () => {
+describe('nodeOutputStore replaceNodeOutputImages', () => {
   beforeEach(() => {
     app.nodeOutputs = {}
   })
 
-  it('drops the previous animated flags when replacing the images', () => {
+  it('drops the previous output metadata when replacing the images', () => {
     const store = useNodeOutputStore()
     const node = createMockNode({ id: 7 })
     store.setOutputFromLegacy(
       '7',
-      fromAny({ images: [{ filename: 'previous.webp' }], animated: [true] })
+      fromAny({
+        images: [{ filename: 'previous.webp' }],
+        animated: [true],
+        video: [{ filename: 'previous.mp4' }]
+      })
     )
 
     const images = [
@@ -276,9 +280,10 @@ describe('nodeOutputStore setNodeOutputImages', () => {
         type: 'input' as const
       }
     ]
-    store.setNodeOutputImages(node, images)
+    store.replaceNodeOutputImages(node, images)
 
     expect(store.nodeOutputs['7']?.animated).toBeUndefined()
+    expect(store.nodeOutputs['7']?.video).toBeUndefined()
     expect(store.nodeOutputs['7']?.images).toEqual(images)
   })
 })

--- a/src/stores/nodeOutputStore.ts
+++ b/src/stores/nodeOutputStore.ts
@@ -1,5 +1,5 @@
 import { useTimeoutFn } from '@vueuse/core'
-import { mapKeys } from 'es-toolkit'
+import { mapKeys, omit } from 'es-toolkit'
 import { defineStore } from 'pinia'
 import { ref } from 'vue'
 
@@ -246,7 +246,7 @@ export const useNodeOutputStore = defineStore('nodeOutput', () => {
     if (!locatorId) return
 
     setOutputsByLocatorId(locatorId, {
-      ...nodeOutputs.value[locatorId],
+      ...omit(nodeOutputs.value[locatorId] ?? {}, ['animated']),
       images
     })
     node.images = images

--- a/src/stores/nodeOutputStore.ts
+++ b/src/stores/nodeOutputStore.ts
@@ -262,6 +262,8 @@ export const useNodeOutputStore = defineStore('nodeOutput', () => {
     node: LGraphNode,
     images: NonNullable<ExecutedWsMessage['output']['images']>
   ) {
+    if (!images.length) return
+
     const locatorId = nodeToNodeLocatorId(node)
     if (!locatorId) return
 

--- a/src/stores/nodeOutputStore.ts
+++ b/src/stores/nodeOutputStore.ts
@@ -1,5 +1,5 @@
 import { useTimeoutFn } from '@vueuse/core'
-import { mapKeys, omit } from 'es-toolkit'
+import { mapKeys } from 'es-toolkit'
 import { defineStore } from 'pinia'
 import { ref } from 'vue'
 
@@ -246,9 +246,26 @@ export const useNodeOutputStore = defineStore('nodeOutput', () => {
     if (!locatorId) return
 
     setOutputsByLocatorId(locatorId, {
-      ...omit(nodeOutputs.value[locatorId] ?? {}, ['animated']),
+      ...nodeOutputs.value[locatorId],
       images
     })
+    node.images = images
+  }
+
+  /**
+   * Replaces a node's output with exactly these images, dropping any media
+   * metadata the previous output carried. `animated`, `video` and friends are
+   * parallel to the images they were produced with, so an editor that rewrites
+   * the image list wholesale must not inherit them.
+   */
+  function replaceNodeOutputImages(
+    node: LGraphNode,
+    images: NonNullable<ExecutedWsMessage['output']['images']>
+  ) {
+    const locatorId = nodeToNodeLocatorId(node)
+    if (!locatorId) return
+
+    setOutputsByLocatorId(locatorId, { images })
     node.images = images
   }
 
@@ -508,6 +525,7 @@ export const useNodeOutputStore = defineStore('nodeOutput', () => {
 
     setNodeOutputs,
     setNodeOutputImages,
+    replaceNodeOutputImages,
     setNodeOutputsByExecutionId,
     setNodePreviewsByExecutionId,
     setNodePreviewsByLocatorId,

--- a/src/stores/nodeOutputStore.ts
+++ b/src/stores/nodeOutputStore.ts
@@ -267,6 +267,7 @@ export const useNodeOutputStore = defineStore('nodeOutput', () => {
     const locatorId = nodeToNodeLocatorId(node)
     if (!locatorId) return
 
+    revokePreviewsByLocatorId(locatorId)
     setOutputsByLocatorId(locatorId, { images })
     node.images = images
   }


### PR DESCRIPTION
Mask-editor saves now replace the node output instead of leaving the pre-edit clipspace image.
Regression coverage reproduces the paste, edit, and reopen failure.

<details><summary>Full context for agent readers</summary>

## Summary

After a mask-editor upload succeeds, the saved image is written through a replacing store call so the output store and the `node.images` mirror advance together. The loader prefers `node.images[0]`, so leaving that mirror untouched reopened the pre-edit clipspace image. In Vue-nodes mode nothing else re-syncs it, because the legacy path (`onDrawBackground` to `updatePreviews`) only runs on the canvas renderer.

## Changes

- Add `replaceNodeOutputImages`, which sets a node's output to exactly the given images and syncs `node.images`.
- Call it from the mask-editor save. `animated`, `video` and the other media keys are parallel to the images they were produced with, so an editor that rewrites the image list wholesale must not inherit them from the previous execution.
- Leave `setNodeOutputImages` merge semantics untouched, so the clipspace paste path (`ComfyApp.pasteFromClipspace`), where images can legitimately be an animated webp, is unchanged.

## Verification

- `nodeOutputStore.test.ts` and `useMaskEditorSaver.test.ts`: passed. The new store test fails against the pre-fix code.
- `pnpm typecheck`, `pnpm knip`: passed.
- CI green at `4fb6318df9`.

Checklist: https://github.com/Comfy-Org/ComfyUI_frontend/issues/15973
Claim and verification: https://github.com/Comfy-Org/ComfyUI_frontend/issues/15973#issuecomment-5488332899
Original review: https://github.com/Comfy-Org/ComfyUI_frontend/pull/15924#discussion_r3858723890

Fixes #16009

</details>
