### PR TITLE
fix: preserve PrimitiveNode widget value on workflow load

### DIFF
--- a/src/extensions/core/widgetInputs.test.ts
+++ b/src/extensions/core/widgetInputs.test.ts
@@ -9,6 +9,7 @@ import type {
   INodeOutputSlot
 } from '@/lib/litegraph/src/litegraph'
 import type { IBaseWidget } from '@/lib/litegraph/src/types/widgets'
+import { assetService } from '@/platform/assets/services/assetService'
 import type { ComfyNodeDef, InputSpec } from '@/schemas/nodeDefSchema'
 import { CONFIG, GET_CONFIG } from '@/services/litegraphService'
 import { useLinkStore } from '@/stores/linkStore'
@@ -108,6 +109,45 @@ describe('PrimitiveNode', () => {
     primitive.onAfterGraphConfigured()
 
     expect(primitive.widgets?.[0].value).toBe(222)
+
+    primitive.widgets![0].value = 333
+    primitive.applyToGraph()
+    primitive.disconnectOutput(0)
+    primitive.connect(0, target, 0)
+
+    expect(primitive.widgets?.[0].value).toBe(333)
+  })
+
+  it('keeps its serialized value for an asset browser widget', () => {
+    vi.spyOn(assetService, 'shouldUseAssetBrowser').mockReturnValue(true)
+    const graph = new LGraph()
+    const target = new LGraphNode('Target')
+    target.comfyClass = 'CheckpointLoaderSimple'
+    graph.add(target)
+    target.addInput('ckpt_name', 'COMBO')
+    target.inputs[0].widget = {
+      name: 'ckpt_name',
+      [GET_CONFIG]: () => [['target.safetensors', 'serialized.safetensors'], {}]
+    }
+    target.addWidget('combo', 'ckpt_name', 'target.safetensors', () => {}, {
+      values: ['target.safetensors', 'serialized.safetensors']
+    })
+
+    const primitive = new PrimitiveNode('Primitive')
+    graph.add(primitive)
+    appState.configuringGraph = true
+    primitive.connect(0, target, 0)
+    primitive.configure(
+      fromPartial({ widgets_values: ['serialized.safetensors'] })
+    )
+    appState.configuringGraph = false
+
+    primitive.onAfterGraphConfigured()
+
+    expect(primitive.widgets?.[0]).toMatchObject({
+      type: 'asset',
+      value: 'serialized.safetensors'
+    })
   })
 
   it('resets itself when the store reports a link the graph cannot resolve', () => {

--- a/src/extensions/core/widgetInputs.test.ts
+++ b/src/extensions/core/widgetInputs.test.ts
@@ -176,34 +176,6 @@ describe('PrimitiveNode', () => {
     expect(primitive.widgets?.[0].value).toBeUndefined()
   })
 
-  it('restores its serialized control value when the target declares control_after_generate', () => {
-    const graph = new LGraph()
-    const target = new LGraphNode('Target')
-    graph.add(target)
-    target.addInput('seed', 'INT')
-    target.inputs[0].widget = {
-      name: 'seed',
-      [GET_CONFIG]: () => ['INT', { control_after_generate: true }]
-    }
-    target.addWidget('number', 'seed', 111, () => {})
-
-    const primitive = new PrimitiveNode('Primitive')
-    graph.add(primitive)
-    appState.configuringGraph = true
-    primitive.connect(0, target, 0)
-    primitive.configure(
-      fromPartial({
-        widgets_values: [222, 'fixed'],
-        outputs: [{ type: 'INT' }]
-      })
-    )
-    appState.configuringGraph = false
-
-    primitive.onAfterGraphConfigured()
-
-    expect(primitive.widgets?.[1].value).toBe('fixed')
-  })
-
   it('prefers named serialized values when named restoration is enabled', () => {
     LiteGraph.namedValuesRestore = true
     const graph = new LGraph()
@@ -263,62 +235,6 @@ describe('PrimitiveNode', () => {
     expect(primitive.widgets?.[0].value).toBe('a.safetensors')
   })
 
-  it('restores its serialized control value via the value-control fallback', () => {
-    const graph = new LGraph()
-    const target = new LGraphNode('Target')
-    graph.add(target)
-    target.addInput('seed', 'INT')
-    target.inputs[0].widget = {
-      name: 'seed',
-      [GET_CONFIG]: () => ['INT', {}]
-    }
-    target.addWidget('number', 'seed', 111, () => {})
-
-    const primitive = new PrimitiveNode('Primitive')
-    graph.add(primitive)
-    appState.configuringGraph = true
-    primitive.connect(0, target, 0)
-    primitive.configure(
-      fromPartial({
-        widgets_values: [222, 'randomize'],
-        outputs: [{ type: 'INT' }]
-      })
-    )
-    appState.configuringGraph = false
-
-    primitive.onAfterGraphConfigured()
-
-    expect(primitive.widgets?.[1].value).toBe('randomize')
-  })
-
-  it('stops re-applying its serialized value once a widget has been created', () => {
-    const graph = new LGraph()
-    const target = new LGraphNode('Target')
-    graph.add(target)
-    target.addInput('seed', 'INT')
-    target.inputs[0].widget = {
-      name: 'seed',
-      [GET_CONFIG]: () => ['INT', { control_after_generate: true }]
-    }
-    target.addWidget('number', 'seed', 111, () => {})
-
-    const primitive = new PrimitiveNode('Primitive')
-    graph.add(primitive)
-    primitive.configure(
-      fromPartial({ widgets_values: [222], outputs: [{ type: 'INT' }] })
-    )
-    primitive.connect(0, target, 0)
-
-    expect(primitive.widgets?.[0].value).toBe(222)
-
-    primitive.widgets![0].value = 333
-    primitive.applyToGraph()
-    primitive.disconnectOutput(0)
-    primitive.connect(0, target, 0)
-
-    expect(primitive.widgets?.[0].value).toBe(333)
-  })
-
   it('keeps its serialized value for an asset browser widget', () => {
     vi.spyOn(assetService, 'shouldUseAssetBrowser').mockReturnValue(true)
     const graph = new LGraph()
@@ -352,110 +268,6 @@ describe('PrimitiveNode', () => {
       type: 'asset',
       value: 'serialized.safetensors'
     })
-  })
-
-  it('clamps a serialized number to the rebuilt widget range', () => {
-    const graph = new LGraph()
-    const target = new LGraphNode('Target')
-    graph.add(target)
-    target.addInput('steps', 'INT')
-    target.inputs[0].widget = {
-      name: 'steps',
-      [GET_CONFIG]: () => ['INT', { min: 1, max: 100 }]
-    }
-    target.addWidget('number', 'steps', 20, () => {}, { min: 1, max: 100 })
-
-    const primitive = new PrimitiveNode('Primitive')
-    graph.add(primitive)
-    appState.configuringGraph = true
-    primitive.connect(0, target, 0)
-    primitive.configure(
-      fromPartial({ widgets_values: [500], outputs: [{ type: 'INT' }] })
-    )
-    appState.configuringGraph = false
-
-    primitive.onAfterGraphConfigured()
-
-    expect(primitive.widgets?.[0].value).toBe(100)
-  })
-
-  it('keeps the target value when a serialized combo option was removed', () => {
-    const graph = new LGraph()
-    const target = new LGraphNode('Target')
-    graph.add(target)
-    target.addInput('sampler', 'COMBO')
-    target.inputs[0].widget = {
-      name: 'sampler',
-      [GET_CONFIG]: () => [['current', 'other'], {}]
-    }
-    target.addWidget('combo', 'sampler', 'current', () => {}, {
-      values: ['current', 'other']
-    })
-
-    const primitive = new PrimitiveNode('Primitive')
-    graph.add(primitive)
-    appState.configuringGraph = true
-    primitive.connect(0, target, 0)
-    primitive.configure(
-      fromPartial({ widgets_values: ['removed'], outputs: [{ type: 'COMBO' }] })
-    )
-    appState.configuringGraph = false
-
-    primitive.onAfterGraphConfigured()
-
-    expect(primitive.widgets?.[0].value).toBe('current')
-  })
-
-  it('survives a widgets_values that is not an array', () => {
-    const graph = new LGraph()
-    const target = new LGraphNode('Target')
-    graph.add(target)
-    target.addInput('seed', 'INT')
-    target.inputs[0].widget = {
-      name: 'seed',
-      [GET_CONFIG]: () => ['INT', { control_after_generate: true }]
-    }
-    target.addWidget('number', 'seed', 111, () => {})
-
-    const primitive = new PrimitiveNode('Primitive')
-    graph.add(primitive)
-    appState.configuringGraph = true
-    primitive.connect(0, target, 0)
-    primitive.configure(
-      fromAny({ widgets_values: 5, outputs: [{ type: 'INT' }] })
-    )
-    appState.configuringGraph = false
-
-    expect(() => primitive.onAfterGraphConfigured()).not.toThrow()
-    expect(primitive.widgets?.[0].value).toBe(111)
-  })
-
-  it('ignores a serialized control value the control widget does not offer', () => {
-    const graph = new LGraph()
-    const target = new LGraphNode('Target')
-    graph.add(target)
-    target.addInput('seed', 'INT')
-    target.inputs[0].widget = {
-      name: 'seed',
-      [GET_CONFIG]: () => ['INT', {}]
-    }
-    target.addWidget('number', 'seed', 111, () => {})
-
-    const primitive = new PrimitiveNode('Primitive')
-    graph.add(primitive)
-    appState.configuringGraph = true
-    primitive.connect(0, target, 0)
-    primitive.configure(
-      fromPartial({
-        widgets_values: [222, 'not-a-control-mode'],
-        outputs: [{ type: 'INT' }]
-      })
-    )
-    appState.configuringGraph = false
-
-    primitive.onAfterGraphConfigured()
-
-    expect(primitive.widgets?.[1].value).toBe('fixed')
   })
 
   it('restores its serialized value when the widget is built by a recreate', () => {
@@ -510,11 +322,13 @@ describe('PrimitiveNode', () => {
 
     primitive.onAfterGraphConfigured()
     expect(
-      useWidgetValueStore().getPrimitiveWidgetRestoration(
+      useWidgetValueStore().getRestoredWidgetValue(
         graph.rootGraph.id,
-        primitive.id
+        primitive.id,
+        'value',
+        0
       )
-    ).toEqual({ type: 'INT', values: [222] })
+    ).toEqual({ value: 222 })
     reroute.inputs[0].widget![GET_CONFIG] =
       target.inputs[0].widget?.[GET_CONFIG]
     primitive.recreateWidget()
@@ -577,49 +391,6 @@ describe('PrimitiveNode', () => {
     expect(primitive.widgets?.[0].value).toBe(111)
   })
 
-  it('keeps an unconsumed serialized value until its widget is first built', () => {
-    const graph = new LGraph()
-    const target = new LGraphNode('Target')
-    graph.add(target)
-    target.addInput('seed', 'INT')
-    target.inputs[0].widget = {
-      name: 'seed',
-      [GET_CONFIG]: () => ['INT', { control_after_generate: true }]
-    }
-    target.addWidget('number', 'seed', 111, () => {})
-
-    const primitive = new PrimitiveNode('Primitive')
-    graph.add(primitive)
-    primitive.configure(
-      fromPartial({ widgets_values: [222], outputs: [{ type: 'INT' }] })
-    )
-    expect(
-      useWidgetValueStore().getPrimitiveWidgetRestoration(
-        graph.rootGraph.id,
-        primitive.id
-      )
-    ).toEqual({ type: 'INT', values: [222] })
-
-    primitive.onAfterGraphConfigured()
-
-    expect(
-      useWidgetValueStore().getPrimitiveWidgetRestoration(
-        graph.rootGraph.id,
-        primitive.id
-      )
-    ).toEqual({ type: 'INT', values: [222] })
-
-    primitive.connect(0, target, 0)
-
-    expect(primitive.widgets?.[0].value).toBe(222)
-    expect(
-      useWidgetValueStore().getPrimitiveWidgetRestoration(
-        graph.rootGraph.id,
-        primitive.id
-      )
-    ).toBeUndefined()
-  })
-
   it('clears its serialized value when its output is disconnected', () => {
     const graph = new LGraph()
     const primitive = new PrimitiveNode('Primitive')
@@ -631,9 +402,11 @@ describe('PrimitiveNode', () => {
     primitive.onLastDisconnect()
 
     expect(
-      useWidgetValueStore().getPrimitiveWidgetRestoration(
+      useWidgetValueStore().getRestoredWidgetValue(
         graph.rootGraph.id,
-        primitive.id
+        primitive.id,
+        'value',
+        0
       )
     ).toBeUndefined()
   })

--- a/src/extensions/core/widgetInputs.test.ts
+++ b/src/extensions/core/widgetInputs.test.ts
@@ -118,7 +118,7 @@ describe('PrimitiveNode', () => {
     expect(primitive.widgets?.[0].value).toBe(333)
   })
 
-  it('restores an explicitly undefined serialized value', () => {
+  it('restores a serialized null value over the target widget value', () => {
     const graph = new LGraph()
     const target = new LGraphNode('Target')
     graph.add(target)
@@ -133,12 +133,61 @@ describe('PrimitiveNode', () => {
     graph.add(primitive)
     appState.configuringGraph = true
     primitive.connect(0, target, 0)
-    primitive.configure(fromPartial({ widgets_values: [undefined] }))
+    primitive.configure(fromPartial({ widgets_values: [null] }))
     appState.configuringGraph = false
 
     primitive.onAfterGraphConfigured()
 
-    expect(primitive.widgets?.[0].value).toBeUndefined()
+    expect(primitive.widgets?.[0].value).toBeNull()
+  })
+
+  it('restores its serialized control_after_generate value', () => {
+    const graph = new LGraph()
+    const target = new LGraphNode('Target')
+    graph.add(target)
+    target.addInput('seed', 'INT')
+    target.inputs[0].widget = {
+      name: 'seed',
+      [GET_CONFIG]: () => ['INT', {}]
+    }
+    target.addWidget('number', 'seed', 111, () => {})
+
+    const primitive = new PrimitiveNode('Primitive')
+    graph.add(primitive)
+    appState.configuringGraph = true
+    primitive.connect(0, target, 0)
+    primitive.configure(fromPartial({ widgets_values: [222, 'randomize'] }))
+    appState.configuringGraph = false
+
+    primitive.onAfterGraphConfigured()
+
+    expect(primitive.widgets?.[1].value).toBe('randomize')
+  })
+
+  it('stops re-applying its serialized value once a widget has been created', () => {
+    const graph = new LGraph()
+    const target = new LGraphNode('Target')
+    graph.add(target)
+    target.addInput('seed', 'INT')
+    target.inputs[0].widget = {
+      name: 'seed',
+      [GET_CONFIG]: () => ['INT', { control_after_generate: true }]
+    }
+    target.addWidget('number', 'seed', 111, () => {})
+
+    const primitive = new PrimitiveNode('Primitive')
+    graph.add(primitive)
+    primitive.configure(fromPartial({ widgets_values: [222] }))
+    primitive.connect(0, target, 0)
+
+    expect(primitive.widgets?.[0].value).toBe(222)
+
+    primitive.widgets![0].value = 333
+    primitive.applyToGraph()
+    primitive.disconnectOutput(0)
+    primitive.connect(0, target, 0)
+
+    expect(primitive.widgets?.[0].value).toBe(333)
   })
 
   it('keeps its serialized value for an asset browser widget', () => {

--- a/src/extensions/core/widgetInputs.test.ts
+++ b/src/extensions/core/widgetInputs.test.ts
@@ -507,6 +507,38 @@ describe('PrimitiveNode', () => {
 
     expect(primitive.widgets?.[0].value).toBe(222)
   })
+
+  it('expires an unconsumed serialized value after graph restoration', () => {
+    const animationFrames: FrameRequestCallback[] = []
+    vi.stubGlobal(
+      'requestAnimationFrame',
+      vi.fn((callback: FrameRequestCallback) => {
+        animationFrames.push(callback)
+        return animationFrames.length
+      })
+    )
+    const primitive = new PrimitiveNode('Primitive')
+    primitive.configure(
+      fromPartial({ widgets_values: [222], outputs: [{ type: 'INT' }] })
+    )
+
+    animationFrames.shift()?.(0)
+    animationFrames.shift()?.(0)
+
+    const graph = new LGraph()
+    const target = new LGraphNode('Target')
+    graph.add(target)
+    target.addInput('seed', 'INT')
+    target.inputs[0].widget = {
+      name: 'seed',
+      [GET_CONFIG]: () => ['INT', { control_after_generate: true }]
+    }
+    target.addWidget('number', 'seed', 111, () => {})
+    graph.add(primitive)
+    primitive.connect(0, target, 0)
+
+    expect(primitive.widgets?.[0].value).toBe(111)
+  })
 })
 
 describe('getWidgetConfig', () => {

--- a/src/extensions/core/widgetInputs.test.ts
+++ b/src/extensions/core/widgetInputs.test.ts
@@ -13,6 +13,7 @@ import { assetService } from '@/platform/assets/services/assetService'
 import type { ComfyNodeDef, InputSpec } from '@/schemas/nodeDefSchema'
 import { CONFIG, GET_CONFIG } from '@/services/litegraphService'
 import { useLinkStore } from '@/stores/linkStore'
+import { useWidgetValueStore } from '@/stores/widgetValueStore'
 import { graphScopeOf } from '@/types/graphScopeId'
 import { toLinkId } from '@/types/linkId'
 import { toNodeId } from '@/types/nodeId'
@@ -144,6 +145,35 @@ describe('PrimitiveNode', () => {
     primitive.onAfterGraphConfigured()
 
     expect(primitive.widgets?.[0].value).toBeNull()
+  })
+
+  it('restores a serialized explicit undefined value over the target widget value', () => {
+    const graph = new LGraph()
+    const target = new LGraphNode('Target')
+    graph.add(target)
+    target.addInput('value', 'STRING')
+    target.inputs[0].widget = {
+      name: 'value',
+      [GET_CONFIG]: () => ['STRING', {}]
+    }
+    target.addWidget('text', 'value', 'stale', () => {})
+
+    const primitive = new PrimitiveNode('Primitive')
+    graph.add(primitive)
+    appState.configuringGraph = true
+    primitive.connect(0, target, 0)
+    primitive.configure(
+      fromPartial({
+        widgets_values: [undefined],
+        outputs: [{ type: 'STRING' }]
+      })
+    )
+    appState.configuringGraph = false
+
+    primitive.onAfterGraphConfigured()
+
+    expect(primitive.widgets).toHaveLength(1)
+    expect(primitive.widgets?.[0].value).toBeUndefined()
   })
 
   it('restores its serialized control value when the target declares control_after_generate', () => {
@@ -473,7 +503,7 @@ describe('PrimitiveNode', () => {
     expect(onLastDisconnect).toHaveBeenCalled()
   })
 
-  it('keeps its serialized value when the widget cannot be built during load', () => {
+  it('drops its serialized value when the widget cannot be built during load', () => {
     const graph = new LGraph()
     const target = new LGraphNode('Target')
     graph.add(target)
@@ -505,17 +535,10 @@ describe('PrimitiveNode', () => {
 
     primitive.connect(0, target, 0)
 
-    expect(primitive.widgets?.[0].value).toBe(222)
+    expect(primitive.widgets?.[0].value).toBe(111)
   })
 
-  it('clears an unconsumed serialized value when the node disconnects', () => {
-    const primitive = new PrimitiveNode('Primitive')
-    primitive.configure(
-      fromPartial({ widgets_values: [222], outputs: [{ type: 'INT' }] })
-    )
-
-    primitive.onLastDisconnect()
-
+  it('clears an unconsumed serialized value once graph restoration ends', () => {
     const graph = new LGraph()
     const target = new LGraphNode('Target')
     graph.add(target)
@@ -525,10 +548,49 @@ describe('PrimitiveNode', () => {
       [GET_CONFIG]: () => ['INT', { control_after_generate: true }]
     }
     target.addWidget('number', 'seed', 111, () => {})
+
+    const primitive = new PrimitiveNode('Primitive')
     graph.add(primitive)
+    primitive.configure(
+      fromPartial({ widgets_values: [222], outputs: [{ type: 'INT' }] })
+    )
+    expect(
+      useWidgetValueStore().getPrimitiveWidgetRestoration(
+        graph.rootGraph.id,
+        primitive.id
+      )
+    ).toEqual({ type: 'INT', values: [222] })
+
+    primitive.onAfterGraphConfigured()
+
+    expect(
+      useWidgetValueStore().getPrimitiveWidgetRestoration(
+        graph.rootGraph.id,
+        primitive.id
+      )
+    ).toBeUndefined()
+
     primitive.connect(0, target, 0)
 
     expect(primitive.widgets?.[0].value).toBe(111)
+  })
+
+  it('clears its serialized value when its output is disconnected', () => {
+    const graph = new LGraph()
+    const primitive = new PrimitiveNode('Primitive')
+    graph.add(primitive)
+    primitive.configure(
+      fromPartial({ widgets_values: [222], outputs: [{ type: 'INT' }] })
+    )
+
+    primitive.onLastDisconnect()
+
+    expect(
+      useWidgetValueStore().getPrimitiveWidgetRestoration(
+        graph.rootGraph.id,
+        primitive.id
+      )
+    ).toBeUndefined()
   })
 })
 

--- a/src/extensions/core/widgetInputs.test.ts
+++ b/src/extensions/core/widgetInputs.test.ts
@@ -118,6 +118,29 @@ describe('PrimitiveNode', () => {
     expect(primitive.widgets?.[0].value).toBe(333)
   })
 
+  it('restores an explicitly undefined serialized value', () => {
+    const graph = new LGraph()
+    const target = new LGraphNode('Target')
+    graph.add(target)
+    target.addInput('value', 'STRING')
+    target.inputs[0].widget = {
+      name: 'value',
+      [GET_CONFIG]: () => ['STRING', {}]
+    }
+    target.addWidget('text', 'value', 'stale', () => {})
+
+    const primitive = new PrimitiveNode('Primitive')
+    graph.add(primitive)
+    appState.configuringGraph = true
+    primitive.connect(0, target, 0)
+    primitive.configure(fromPartial({ widgets_values: [undefined] }))
+    appState.configuringGraph = false
+
+    primitive.onAfterGraphConfigured()
+
+    expect(primitive.widgets?.[0].value).toBeUndefined()
+  })
+
   it('keeps its serialized value for an asset browser widget', () => {
     vi.spyOn(assetService, 'shouldUseAssetBrowser').mockReturnValue(true)
     const graph = new LGraph()

--- a/src/extensions/core/widgetInputs.test.ts
+++ b/src/extensions/core/widgetInputs.test.ts
@@ -87,6 +87,29 @@ describe('PrimitiveNode', () => {
     setActivePinia(createTestingPinia({ stubActions: false }))
   })
 
+  it('keeps its serialized value when the target widget has a stale value', () => {
+    const graph = new LGraph()
+    const target = new LGraphNode('Target')
+    graph.add(target)
+    target.addInput('seed', 'INT')
+    target.inputs[0].widget = {
+      name: 'seed',
+      [GET_CONFIG]: () => ['INT', { control_after_generate: true }]
+    }
+    target.addWidget('number', 'seed', 111, () => {})
+
+    const primitive = new PrimitiveNode('Primitive')
+    graph.add(primitive)
+    appState.configuringGraph = true
+    primitive.connect(0, target, 0)
+    primitive.configure(fromPartial({ widgets_values: [222] }))
+    appState.configuringGraph = false
+
+    primitive.onAfterGraphConfigured()
+
+    expect(primitive.widgets?.[0].value).toBe(222)
+  })
+
   it('resets itself when the store reports a link the graph cannot resolve', () => {
     const graph = new LGraph()
     const node = new PrimitiveNode('Primitive')

--- a/src/extensions/core/widgetInputs.test.ts
+++ b/src/extensions/core/widgetInputs.test.ts
@@ -86,6 +86,7 @@ function widgetSlot(
 describe('PrimitiveNode', () => {
   beforeEach(() => {
     setActivePinia(createTestingPinia({ stubActions: false }))
+    LiteGraph.namedValuesRestore = false
   })
 
   it('keeps its serialized value when the target widget has a stale value', () => {
@@ -170,6 +171,40 @@ describe('PrimitiveNode', () => {
 
     primitive.onAfterGraphConfigured()
 
+    expect(primitive.widgets?.[1].value).toBe('fixed')
+  })
+
+  it('prefers named serialized values when named restoration is enabled', () => {
+    LiteGraph.namedValuesRestore = true
+    const graph = new LGraph()
+    const target = new LGraphNode('Target')
+    graph.add(target)
+    target.addInput('seed', 'INT')
+    target.inputs[0].widget = {
+      name: 'seed',
+      [GET_CONFIG]: () => ['INT', { control_after_generate: true }]
+    }
+    target.addWidget('number', 'seed', 111, () => {})
+
+    const primitive = new PrimitiveNode('Primitive')
+    graph.add(primitive)
+    appState.configuringGraph = true
+    primitive.connect(0, target, 0)
+    primitive.configure(
+      fromPartial({
+        widgets_values: [222, 'randomize'],
+        widgets_values_named: {
+          value: 333,
+          control_after_generate: 'fixed'
+        },
+        outputs: [{ type: 'INT' }]
+      })
+    )
+    appState.configuringGraph = false
+
+    primitive.onAfterGraphConfigured()
+
+    expect(primitive.widgets?.[0].value).toBe(333)
     expect(primitive.widgets?.[1].value).toBe('fixed')
   })
 

--- a/src/extensions/core/widgetInputs.test.ts
+++ b/src/extensions/core/widgetInputs.test.ts
@@ -6,14 +6,14 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { LGraph, LGraphNode, LiteGraph } from '@/lib/litegraph/src/litegraph'
 import type {
   INodeInputSlot,
-  INodeOutputSlot
+  INodeOutputSlot,
+  ISerialisedNode
 } from '@/lib/litegraph/src/litegraph'
 import type { IBaseWidget } from '@/lib/litegraph/src/types/widgets'
 import { assetService } from '@/platform/assets/services/assetService'
 import type { ComfyNodeDef, InputSpec } from '@/schemas/nodeDefSchema'
 import { CONFIG, GET_CONFIG } from '@/services/litegraphService'
 import { useLinkStore } from '@/stores/linkStore'
-import { useWidgetValueStore } from '@/stores/widgetValueStore'
 import { graphScopeOf } from '@/types/graphScopeId'
 import { toLinkId } from '@/types/linkId'
 import { toNodeId } from '@/types/nodeId'
@@ -90,7 +90,7 @@ describe('PrimitiveNode', () => {
     LiteGraph.namedValuesRestore = false
   })
 
-  it('keeps its serialized value when the target widget has a stale value', () => {
+  function intFixture() {
     const graph = new LGraph()
     const target = new LGraphNode('Target')
     graph.add(target)
@@ -103,14 +103,32 @@ describe('PrimitiveNode', () => {
 
     const primitive = new PrimitiveNode('Primitive')
     graph.add(primitive)
+    return { graph, primitive, target }
+  }
+
+  function restoreIntPrimitive(
+    primitive: PrimitiveNode,
+    target: LGraphNode,
+    values: ISerialisedNode['widgets_values'],
+    named?: ISerialisedNode['widgets_values_named']
+  ) {
     appState.configuringGraph = true
     primitive.connect(0, target, 0)
     primitive.configure(
-      fromPartial({ widgets_values: [222], outputs: [{ type: 'INT' }] })
+      fromPartial({
+        widgets_values: values,
+        widgets_values_named: named,
+        outputs: [{ type: 'INT' }]
+      })
     )
     appState.configuringGraph = false
-
     primitive.onAfterGraphConfigured()
+  }
+
+  it('keeps its serialized value when the target widget has a stale value', () => {
+    const { primitive, target } = intFixture()
+
+    restoreIntPrimitive(primitive, target, [222])
 
     expect(primitive.widgets?.[0].value).toBe(222)
 
@@ -122,7 +140,10 @@ describe('PrimitiveNode', () => {
     expect(primitive.widgets?.[0].value).toBe(333)
   })
 
-  it('restores a serialized null value over the target widget value', () => {
+  it.each([
+    { label: 'null', value: null },
+    { label: 'undefined', value: undefined }
+  ])('restores an explicit $label value', ({ value }) => {
     const graph = new LGraph()
     const target = new LGraphNode('Target')
     graph.add(target)
@@ -132,79 +153,29 @@ describe('PrimitiveNode', () => {
       [GET_CONFIG]: () => ['STRING', {}]
     }
     target.addWidget('text', 'value', 'stale', () => {})
-
     const primitive = new PrimitiveNode('Primitive')
     graph.add(primitive)
     appState.configuringGraph = true
     primitive.connect(0, target, 0)
     primitive.configure(
-      fromPartial({ widgets_values: [null], outputs: [{ type: 'STRING' }] })
-    )
-    appState.configuringGraph = false
-
-    primitive.onAfterGraphConfigured()
-
-    expect(primitive.widgets?.[0].value).toBeNull()
-  })
-
-  it('restores a serialized explicit undefined value over the target widget value', () => {
-    const graph = new LGraph()
-    const target = new LGraphNode('Target')
-    graph.add(target)
-    target.addInput('value', 'STRING')
-    target.inputs[0].widget = {
-      name: 'value',
-      [GET_CONFIG]: () => ['STRING', {}]
-    }
-    target.addWidget('text', 'value', 'stale', () => {})
-
-    const primitive = new PrimitiveNode('Primitive')
-    graph.add(primitive)
-    appState.configuringGraph = true
-    primitive.connect(0, target, 0)
-    primitive.configure(
-      fromPartial({
-        widgets_values: [undefined],
-        outputs: [{ type: 'STRING' }]
-      })
+      fromPartial({ widgets_values: [value], outputs: [{ type: 'STRING' }] })
     )
     appState.configuringGraph = false
 
     primitive.onAfterGraphConfigured()
 
     expect(primitive.widgets).toHaveLength(1)
-    expect(primitive.widgets?.[0].value).toBeUndefined()
+    expect(primitive.widgets?.[0].value).toBe(value)
   })
 
-  it('prefers named serialized values when named restoration is enabled', () => {
+  it('restores named main and control values when enabled', () => {
     LiteGraph.namedValuesRestore = true
-    const graph = new LGraph()
-    const target = new LGraphNode('Target')
-    graph.add(target)
-    target.addInput('seed', 'INT')
-    target.inputs[0].widget = {
-      name: 'seed',
-      [GET_CONFIG]: () => ['INT', { control_after_generate: true }]
-    }
-    target.addWidget('number', 'seed', 111, () => {})
+    const { primitive, target } = intFixture()
 
-    const primitive = new PrimitiveNode('Primitive')
-    graph.add(primitive)
-    appState.configuringGraph = true
-    primitive.connect(0, target, 0)
-    primitive.configure(
-      fromPartial({
-        widgets_values: [222, 'randomize'],
-        widgets_values_named: {
-          value: 333,
-          control_after_generate: 'fixed'
-        },
-        outputs: [{ type: 'INT' }]
-      })
-    )
-    appState.configuringGraph = false
-
-    primitive.onAfterGraphConfigured()
+    restoreIntPrimitive(primitive, target, [222, 'randomize'], {
+      value: 333,
+      control_after_generate: 'fixed'
+    })
 
     expect(primitive.widgets?.[0].value).toBe(333)
     expect(primitive.widgets?.[1].value).toBe('fixed')
@@ -270,31 +241,6 @@ describe('PrimitiveNode', () => {
     })
   })
 
-  it('restores its serialized value when the widget is built by a recreate', () => {
-    const graph = new LGraph()
-    const target = new LGraphNode('Target')
-    graph.add(target)
-    target.addInput('seed', 'INT')
-    target.inputs[0].widget = {
-      name: 'seed',
-      [GET_CONFIG]: () => ['INT', { control_after_generate: true }]
-    }
-    target.addWidget('number', 'seed', 111, () => {})
-
-    const primitive = new PrimitiveNode('Primitive')
-    graph.add(primitive)
-    appState.configuringGraph = true
-    primitive.connect(0, target, 0)
-    primitive.configure(
-      fromPartial({ widgets_values: [222], outputs: [{ type: 'INT' }] })
-    )
-    appState.configuringGraph = false
-
-    primitive.recreateWidget()
-
-    expect(primitive.widgets?.[0].value).toBe(222)
-  })
-
   it('restores its serialized value after a reroute resolves its widget config', () => {
     const graph = new LGraph()
     const reroute = new LGraphNode('Reroute')
@@ -321,14 +267,7 @@ describe('PrimitiveNode', () => {
     appState.configuringGraph = false
 
     primitive.onAfterGraphConfigured()
-    expect(
-      useWidgetValueStore().getRestoredWidgetValue(
-        graph.rootGraph.id,
-        primitive.id,
-        'value',
-        0
-      )
-    ).toEqual({ value: 222 })
+    expect(primitive.widgets).toBeUndefined()
     reroute.inputs[0].widget![GET_CONFIG] =
       target.inputs[0].widget?.[GET_CONFIG]
     primitive.recreateWidget()
@@ -336,39 +275,8 @@ describe('PrimitiveNode', () => {
     expect(primitive.widgets?.[0].value).toBe(222)
   })
 
-  it('resets itself when the store reports a link the graph cannot resolve', () => {
-    const graph = new LGraph()
-    const node = new PrimitiveNode('Primitive')
-    graph.add(node)
-    useLinkStore().registerLink(graphScopeOf(graph), {
-      id: toLinkId(999),
-      graphId: graphScopeOf(graph).owningGraphId,
-      originNodeId: node.id,
-      originSlot: 0,
-      targetNodeId: toNodeId(42),
-      targetSlot: 0,
-      type: '*'
-    })
-    const onLastDisconnect = vi.spyOn(node, 'onLastDisconnect')
-
-    node.onAfterGraphConfigured()
-
-    expect(onLastDisconnect).toHaveBeenCalled()
-  })
-
-  it('drops its serialized value when the widget cannot be built during load', () => {
-    const graph = new LGraph()
-    const target = new LGraphNode('Target')
-    graph.add(target)
-    target.addInput('seed', 'INT')
-    target.inputs[0].widget = {
-      name: 'seed',
-      [GET_CONFIG]: () => ['INT', { control_after_generate: true }]
-    }
-    target.addWidget('number', 'seed', 111, () => {})
-
-    const primitive = new PrimitiveNode('Primitive')
-    graph.add(primitive)
+  it('drops restoration when the store reports an unresolvable link', () => {
+    const { graph, primitive, target } = intFixture()
     useLinkStore().registerLink(graphScopeOf(graph), {
       id: toLinkId(999),
       graphId: graphScopeOf(graph).owningGraphId,
@@ -378,37 +286,54 @@ describe('PrimitiveNode', () => {
       targetSlot: 0,
       type: '*'
     })
+    const onLastDisconnect = vi.spyOn(primitive, 'onLastDisconnect')
     primitive.configure(
       fromPartial({ widgets_values: [222], outputs: [{ type: 'INT' }] })
     )
 
     primitive.onAfterGraphConfigured()
 
+    expect(onLastDisconnect).toHaveBeenCalled()
     expect(primitive.widgets?.length).toBeFalsy()
-
     primitive.connect(0, target, 0)
-
     expect(primitive.widgets?.[0].value).toBe(111)
   })
 
+  it('keeps an unconsumed serialized value until its widget is first built', () => {
+    const { primitive, target } = intFixture()
+    primitive.configure(
+      fromPartial({ widgets_values: [222], outputs: [{ type: 'INT' }] })
+    )
+
+    primitive.onAfterGraphConfigured()
+    primitive.connect(0, target, 0)
+
+    expect(primitive.widgets?.[0].value).toBe(222)
+  })
+
   it('clears its serialized value when its output is disconnected', () => {
-    const graph = new LGraph()
-    const primitive = new PrimitiveNode('Primitive')
-    graph.add(primitive)
+    const { primitive, target } = intFixture()
     primitive.configure(
       fromPartial({ widgets_values: [222], outputs: [{ type: 'INT' }] })
     )
 
     primitive.onLastDisconnect()
+    primitive.connect(0, target, 0)
 
-    expect(
-      useWidgetValueStore().getRestoredWidgetValue(
-        graph.rootGraph.id,
-        primitive.id,
-        'value',
-        0
-      )
-    ).toBeUndefined()
+    expect(primitive.widgets?.[0].value).toBe(111)
+  })
+
+  it('does not retain restoration configured before graph insertion', () => {
+    const { graph, target } = intFixture()
+    const primitive = new PrimitiveNode('Primitive')
+    primitive.configure(
+      fromPartial({ widgets_values: [222], outputs: [{ type: 'INT' }] })
+    )
+    graph.add(primitive)
+
+    primitive.connect(0, target, 0)
+
+    expect(primitive.widgets?.[0].value).toBe(111)
   })
 })
 

--- a/src/extensions/core/widgetInputs.test.ts
+++ b/src/extensions/core/widgetInputs.test.ts
@@ -241,6 +241,39 @@ describe('PrimitiveNode', () => {
 
     expect(onLastDisconnect).toHaveBeenCalled()
   })
+
+  it('keeps its serialized value when the widget cannot be built during load', () => {
+    const graph = new LGraph()
+    const target = new LGraphNode('Target')
+    graph.add(target)
+    target.addInput('seed', 'INT')
+    target.inputs[0].widget = {
+      name: 'seed',
+      [GET_CONFIG]: () => ['INT', { control_after_generate: true }]
+    }
+    target.addWidget('number', 'seed', 111, () => {})
+
+    const primitive = new PrimitiveNode('Primitive')
+    graph.add(primitive)
+    useLinkStore().registerLink(graphScopeOf(graph), {
+      id: toLinkId(999),
+      graphId: graphScopeOf(graph).owningGraphId,
+      originNodeId: primitive.id,
+      originSlot: 0,
+      targetNodeId: toNodeId(42),
+      targetSlot: 0,
+      type: '*'
+    })
+    primitive.configure(fromPartial({ widgets_values: [222] }))
+
+    primitive.onAfterGraphConfigured()
+
+    expect(primitive.widgets?.length).toBeFalsy()
+
+    primitive.connect(0, target, 0)
+
+    expect(primitive.widgets?.[0].value).toBe(222)
+  })
 })
 
 describe('getWidgetConfig', () => {

--- a/src/extensions/core/widgetInputs.test.ts
+++ b/src/extensions/core/widgetInputs.test.ts
@@ -508,22 +508,13 @@ describe('PrimitiveNode', () => {
     expect(primitive.widgets?.[0].value).toBe(222)
   })
 
-  it('expires an unconsumed serialized value after graph restoration', () => {
-    const animationFrames: FrameRequestCallback[] = []
-    vi.stubGlobal(
-      'requestAnimationFrame',
-      vi.fn((callback: FrameRequestCallback) => {
-        animationFrames.push(callback)
-        return animationFrames.length
-      })
-    )
+  it('clears an unconsumed serialized value when the node disconnects', () => {
     const primitive = new PrimitiveNode('Primitive')
     primitive.configure(
       fromPartial({ widgets_values: [222], outputs: [{ type: 'INT' }] })
     )
 
-    animationFrames.shift()?.(0)
-    animationFrames.shift()?.(0)
+    primitive.onLastDisconnect()
 
     const graph = new LGraph()
     const target = new LGraphNode('Target')

--- a/src/extensions/core/widgetInputs.test.ts
+++ b/src/extensions/core/widgetInputs.test.ts
@@ -103,7 +103,9 @@ describe('PrimitiveNode', () => {
     graph.add(primitive)
     appState.configuringGraph = true
     primitive.connect(0, target, 0)
-    primitive.configure(fromPartial({ widgets_values: [222] }))
+    primitive.configure(
+      fromPartial({ widgets_values: [222], outputs: [{ type: 'INT' }] })
+    )
     appState.configuringGraph = false
 
     primitive.onAfterGraphConfigured()
@@ -133,7 +135,9 @@ describe('PrimitiveNode', () => {
     graph.add(primitive)
     appState.configuringGraph = true
     primitive.connect(0, target, 0)
-    primitive.configure(fromPartial({ widgets_values: [null] }))
+    primitive.configure(
+      fromPartial({ widgets_values: [null], outputs: [{ type: 'STRING' }] })
+    )
     appState.configuringGraph = false
 
     primitive.onAfterGraphConfigured()
@@ -141,7 +145,60 @@ describe('PrimitiveNode', () => {
     expect(primitive.widgets?.[0].value).toBeNull()
   })
 
-  it('restores its serialized control_after_generate value', () => {
+  it('restores its serialized control value when the target declares control_after_generate', () => {
+    const graph = new LGraph()
+    const target = new LGraphNode('Target')
+    graph.add(target)
+    target.addInput('seed', 'INT')
+    target.inputs[0].widget = {
+      name: 'seed',
+      [GET_CONFIG]: () => ['INT', { control_after_generate: true }]
+    }
+    target.addWidget('number', 'seed', 111, () => {})
+
+    const primitive = new PrimitiveNode('Primitive')
+    graph.add(primitive)
+    appState.configuringGraph = true
+    primitive.connect(0, target, 0)
+    primitive.configure(
+      fromPartial({
+        widgets_values: [222, 'fixed'],
+        outputs: [{ type: 'INT' }]
+      })
+    )
+    appState.configuringGraph = false
+
+    primitive.onAfterGraphConfigured()
+
+    expect(primitive.widgets?.[1].value).toBe('fixed')
+  })
+
+  it('does not apply a serialized value left over from an unresolved output type', () => {
+    const graph = new LGraph()
+    const target = new LGraphNode('Loader')
+    target.comfyClass = 'CheckpointLoaderSimple'
+    graph.add(target)
+    target.addInput('ckpt_name', 'COMBO')
+    target.inputs[0].widget = {
+      name: 'ckpt_name',
+      [GET_CONFIG]: () => [['a.safetensors', 'b.safetensors'], {}]
+    }
+    target.addWidget('combo', 'ckpt_name', 'a.safetensors', () => {}, {
+      values: ['a.safetensors', 'b.safetensors']
+    })
+
+    const primitive = new PrimitiveNode('Primitive')
+    graph.add(primitive)
+    primitive.configure(
+      fromPartial({ widgets_values: [222], outputs: [{ type: '*' }] })
+    )
+
+    primitive.connect(0, target, 0)
+
+    expect(primitive.widgets?.[0].value).toBe('a.safetensors')
+  })
+
+  it('restores its serialized control value via the value-control fallback', () => {
     const graph = new LGraph()
     const target = new LGraphNode('Target')
     graph.add(target)
@@ -156,7 +213,12 @@ describe('PrimitiveNode', () => {
     graph.add(primitive)
     appState.configuringGraph = true
     primitive.connect(0, target, 0)
-    primitive.configure(fromPartial({ widgets_values: [222, 'randomize'] }))
+    primitive.configure(
+      fromPartial({
+        widgets_values: [222, 'randomize'],
+        outputs: [{ type: 'INT' }]
+      })
+    )
     appState.configuringGraph = false
 
     primitive.onAfterGraphConfigured()
@@ -177,7 +239,9 @@ describe('PrimitiveNode', () => {
 
     const primitive = new PrimitiveNode('Primitive')
     graph.add(primitive)
-    primitive.configure(fromPartial({ widgets_values: [222] }))
+    primitive.configure(
+      fromPartial({ widgets_values: [222], outputs: [{ type: 'INT' }] })
+    )
     primitive.connect(0, target, 0)
 
     expect(primitive.widgets?.[0].value).toBe(222)
@@ -210,7 +274,10 @@ describe('PrimitiveNode', () => {
     appState.configuringGraph = true
     primitive.connect(0, target, 0)
     primitive.configure(
-      fromPartial({ widgets_values: ['serialized.safetensors'] })
+      fromPartial({
+        widgets_values: ['serialized.safetensors'],
+        outputs: [{ type: 'COMBO' }]
+      })
     )
     appState.configuringGraph = false
 
@@ -264,7 +331,9 @@ describe('PrimitiveNode', () => {
       targetSlot: 0,
       type: '*'
     })
-    primitive.configure(fromPartial({ widgets_values: [222] }))
+    primitive.configure(
+      fromPartial({ widgets_values: [222], outputs: [{ type: 'INT' }] })
+    )
 
     primitive.onAfterGraphConfigured()
 

--- a/src/extensions/core/widgetInputs.test.ts
+++ b/src/extensions/core/widgetInputs.test.ts
@@ -324,6 +324,58 @@ describe('PrimitiveNode', () => {
     })
   })
 
+  it('clamps a serialized number to the rebuilt widget range', () => {
+    const graph = new LGraph()
+    const target = new LGraphNode('Target')
+    graph.add(target)
+    target.addInput('steps', 'INT')
+    target.inputs[0].widget = {
+      name: 'steps',
+      [GET_CONFIG]: () => ['INT', { min: 1, max: 100 }]
+    }
+    target.addWidget('number', 'steps', 20, () => {}, { min: 1, max: 100 })
+
+    const primitive = new PrimitiveNode('Primitive')
+    graph.add(primitive)
+    appState.configuringGraph = true
+    primitive.connect(0, target, 0)
+    primitive.configure(
+      fromPartial({ widgets_values: [500], outputs: [{ type: 'INT' }] })
+    )
+    appState.configuringGraph = false
+
+    primitive.onAfterGraphConfigured()
+
+    expect(primitive.widgets?.[0].value).toBe(100)
+  })
+
+  it('keeps the target value when a serialized combo option was removed', () => {
+    const graph = new LGraph()
+    const target = new LGraphNode('Target')
+    graph.add(target)
+    target.addInput('sampler', 'COMBO')
+    target.inputs[0].widget = {
+      name: 'sampler',
+      [GET_CONFIG]: () => [['current', 'other'], {}]
+    }
+    target.addWidget('combo', 'sampler', 'current', () => {}, {
+      values: ['current', 'other']
+    })
+
+    const primitive = new PrimitiveNode('Primitive')
+    graph.add(primitive)
+    appState.configuringGraph = true
+    primitive.connect(0, target, 0)
+    primitive.configure(
+      fromPartial({ widgets_values: ['removed'], outputs: [{ type: 'COMBO' }] })
+    )
+    appState.configuringGraph = false
+
+    primitive.onAfterGraphConfigured()
+
+    expect(primitive.widgets?.[0].value).toBe('current')
+  })
+
   it('survives a widgets_values that is not an array', () => {
     const graph = new LGraph()
     const target = new LGraphNode('Target')

--- a/src/extensions/core/widgetInputs.test.ts
+++ b/src/extensions/core/widgetInputs.test.ts
@@ -484,14 +484,6 @@ describe('PrimitiveNode', () => {
   })
 
   it('restores its serialized value after a reroute resolves its widget config', () => {
-    const animationFrames: FrameRequestCallback[] = []
-    vi.stubGlobal(
-      'requestAnimationFrame',
-      vi.fn((callback: FrameRequestCallback) => {
-        animationFrames.push(callback)
-        return animationFrames.length
-      })
-    )
     const graph = new LGraph()
     const reroute = new LGraphNode('Reroute')
     graph.add(reroute)
@@ -585,15 +577,7 @@ describe('PrimitiveNode', () => {
     expect(primitive.widgets?.[0].value).toBe(111)
   })
 
-  it('clears an unconsumed serialized value once graph restoration ends', () => {
-    const animationFrames: FrameRequestCallback[] = []
-    vi.stubGlobal(
-      'requestAnimationFrame',
-      vi.fn((callback: FrameRequestCallback) => {
-        animationFrames.push(callback)
-        return animationFrames.length
-      })
-    )
+  it('keeps an unconsumed serialized value until its widget is first built', () => {
     const graph = new LGraph()
     const target = new LGraphNode('Target')
     graph.add(target)
@@ -617,21 +601,23 @@ describe('PrimitiveNode', () => {
     ).toEqual({ type: 'INT', values: [222] })
 
     primitive.onAfterGraphConfigured()
-    const firstFrame = animationFrames.splice(0)
-    firstFrame.forEach((callback) => callback(0))
-    const secondFrame = animationFrames.splice(0)
-    secondFrame.forEach((callback) => callback(0))
 
     expect(
       useWidgetValueStore().getPrimitiveWidgetRestoration(
         graph.rootGraph.id,
         primitive.id
       )
-    ).toBeUndefined()
+    ).toEqual({ type: 'INT', values: [222] })
 
     primitive.connect(0, target, 0)
 
-    expect(primitive.widgets?.[0].value).toBe(111)
+    expect(primitive.widgets?.[0].value).toBe(222)
+    expect(
+      useWidgetValueStore().getPrimitiveWidgetRestoration(
+        graph.rootGraph.id,
+        primitive.id
+      )
+    ).toBeUndefined()
   })
 
   it('clears its serialized value when its output is disconnected', () => {

--- a/src/extensions/core/widgetInputs.test.ts
+++ b/src/extensions/core/widgetInputs.test.ts
@@ -289,6 +289,83 @@ describe('PrimitiveNode', () => {
     })
   })
 
+  it('survives a widgets_values that is not an array', () => {
+    const graph = new LGraph()
+    const target = new LGraphNode('Target')
+    graph.add(target)
+    target.addInput('seed', 'INT')
+    target.inputs[0].widget = {
+      name: 'seed',
+      [GET_CONFIG]: () => ['INT', { control_after_generate: true }]
+    }
+    target.addWidget('number', 'seed', 111, () => {})
+
+    const primitive = new PrimitiveNode('Primitive')
+    graph.add(primitive)
+    appState.configuringGraph = true
+    primitive.connect(0, target, 0)
+    primitive.configure(
+      fromAny({ widgets_values: 5, outputs: [{ type: 'INT' }] })
+    )
+    appState.configuringGraph = false
+
+    expect(() => primitive.onAfterGraphConfigured()).not.toThrow()
+    expect(primitive.widgets?.[0].value).toBe(111)
+  })
+
+  it('ignores a serialized control value the control widget does not offer', () => {
+    const graph = new LGraph()
+    const target = new LGraphNode('Target')
+    graph.add(target)
+    target.addInput('seed', 'INT')
+    target.inputs[0].widget = {
+      name: 'seed',
+      [GET_CONFIG]: () => ['INT', {}]
+    }
+    target.addWidget('number', 'seed', 111, () => {})
+
+    const primitive = new PrimitiveNode('Primitive')
+    graph.add(primitive)
+    appState.configuringGraph = true
+    primitive.connect(0, target, 0)
+    primitive.configure(
+      fromPartial({
+        widgets_values: [222, 'not-a-control-mode'],
+        outputs: [{ type: 'INT' }]
+      })
+    )
+    appState.configuringGraph = false
+
+    primitive.onAfterGraphConfigured()
+
+    expect(primitive.widgets?.[1].value).toBe('fixed')
+  })
+
+  it('restores its serialized value when the widget is built by a recreate', () => {
+    const graph = new LGraph()
+    const target = new LGraphNode('Target')
+    graph.add(target)
+    target.addInput('seed', 'INT')
+    target.inputs[0].widget = {
+      name: 'seed',
+      [GET_CONFIG]: () => ['INT', { control_after_generate: true }]
+    }
+    target.addWidget('number', 'seed', 111, () => {})
+
+    const primitive = new PrimitiveNode('Primitive')
+    graph.add(primitive)
+    appState.configuringGraph = true
+    primitive.connect(0, target, 0)
+    primitive.configure(
+      fromPartial({ widgets_values: [222], outputs: [{ type: 'INT' }] })
+    )
+    appState.configuringGraph = false
+
+    primitive.recreateWidget()
+
+    expect(primitive.widgets?.[0].value).toBe(222)
+  })
+
   it('resets itself when the store reports a link the graph cannot resolve', () => {
     const graph = new LGraph()
     const node = new PrimitiveNode('Primitive')

--- a/src/extensions/core/widgetInputs.test.ts
+++ b/src/extensions/core/widgetInputs.test.ts
@@ -483,6 +483,53 @@ describe('PrimitiveNode', () => {
     expect(primitive.widgets?.[0].value).toBe(222)
   })
 
+  it('restores its serialized value after a reroute resolves its widget config', () => {
+    const animationFrames: FrameRequestCallback[] = []
+    vi.stubGlobal(
+      'requestAnimationFrame',
+      vi.fn((callback: FrameRequestCallback) => {
+        animationFrames.push(callback)
+        return animationFrames.length
+      })
+    )
+    const graph = new LGraph()
+    const reroute = new LGraphNode('Reroute')
+    graph.add(reroute)
+    reroute.addInput('', '*')
+    reroute.inputs[0].widget = { name: 'value' }
+    reroute.addOutput('', '*')
+    const target = new LGraphNode('Target')
+    graph.add(target)
+    target.addInput('seed', 'INT')
+    target.inputs[0].widget = {
+      name: 'seed',
+      [GET_CONFIG]: () => ['INT', { control_after_generate: true }]
+    }
+    target.addWidget('number', 'seed', 111, () => {})
+    const primitive = new PrimitiveNode('Primitive')
+    graph.add(primitive)
+    appState.configuringGraph = true
+    primitive.connect(0, reroute, 0)
+    reroute.connect(0, target, 0)
+    primitive.configure(
+      fromPartial({ widgets_values: [222], outputs: [{ type: 'INT' }] })
+    )
+    appState.configuringGraph = false
+
+    primitive.onAfterGraphConfigured()
+    expect(
+      useWidgetValueStore().getPrimitiveWidgetRestoration(
+        graph.rootGraph.id,
+        primitive.id
+      )
+    ).toEqual({ type: 'INT', values: [222] })
+    reroute.inputs[0].widget![GET_CONFIG] =
+      target.inputs[0].widget?.[GET_CONFIG]
+    primitive.recreateWidget()
+
+    expect(primitive.widgets?.[0].value).toBe(222)
+  })
+
   it('resets itself when the store reports a link the graph cannot resolve', () => {
     const graph = new LGraph()
     const node = new PrimitiveNode('Primitive')
@@ -539,6 +586,14 @@ describe('PrimitiveNode', () => {
   })
 
   it('clears an unconsumed serialized value once graph restoration ends', () => {
+    const animationFrames: FrameRequestCallback[] = []
+    vi.stubGlobal(
+      'requestAnimationFrame',
+      vi.fn((callback: FrameRequestCallback) => {
+        animationFrames.push(callback)
+        return animationFrames.length
+      })
+    )
     const graph = new LGraph()
     const target = new LGraphNode('Target')
     graph.add(target)
@@ -562,6 +617,10 @@ describe('PrimitiveNode', () => {
     ).toEqual({ type: 'INT', values: [222] })
 
     primitive.onAfterGraphConfigured()
+    const firstFrame = animationFrames.splice(0)
+    firstFrame.forEach((callback) => callback(0))
+    const secondFrame = animationFrames.splice(0)
+    secondFrame.forEach((callback) => callback(0))
 
     expect(
       useWidgetValueStore().getPrimitiveWidgetRestoration(

--- a/src/extensions/core/widgetInputs.ts
+++ b/src/extensions/core/widgetInputs.ts
@@ -21,9 +21,7 @@ import {
 } from '@/schemas/nodeDefSchema'
 import type { ComfyNodeDef, InputSpec } from '@/schemas/nodeDefSchema'
 import { app } from '@/scripts/app'
-import { useWidgetValueStore } from '@/stores/widgetValueStore'
 import type { WidgetValue } from '@/types/simplifiedWidget'
-import { zeroUuid } from '@/utils/uuid'
 import {
   ComfyWidgets,
   addValueControlWidgets,
@@ -40,8 +38,7 @@ const replacePropertyName = 'Run widget replace on values'
 export class PrimitiveNode extends LGraphNode {
   controlValues?: WidgetValue[]
   lastType?: string
-  private hasConfiguredWidgetValue = false
-  private configuredWidgetValue?: WidgetValue
+  private configuredWidgetValues?: ISerialisedNode['widgets_values']
   static override category: string
   constructor(title: string) {
     super(title)
@@ -128,10 +125,8 @@ export class PrimitiveNode extends LGraphNode {
   }
 
   override onConfigure(serialisedNode: ISerialisedNode) {
-    this.hasConfiguredWidgetValue =
-      serialisedNode.widgets_values !== undefined &&
-      0 in serialisedNode.widgets_values
-    this.configuredWidgetValue = serialisedNode.widgets_values?.[0]
+    super.onConfigure?.(serialisedNode)
+    this.configuredWidgetValues = serialisedNode.widgets_values
   }
 
   override onAfterGraphConfigured() {
@@ -145,8 +140,7 @@ export class PrimitiveNode extends LGraphNode {
       // Merge values if required
       this._mergeWidgetConfig()
     }
-    this.hasConfiguredWidgetValue = false
-    this.configuredWidgetValue = undefined
+    this.configuredWidgetValues = undefined
   }
 
   override onConnectionsChange(
@@ -263,9 +257,13 @@ export class PrimitiveNode extends LGraphNode {
     // Store current size as addWidget resizes the node
     const [oldWidth, oldHeight] = this.size
     let widget: IBaseWidget
+    const configuredWidgetValues = recreating
+      ? undefined
+      : this.configuredWidgetValues
+    if (!recreating) this.configuredWidgetValues = undefined
     const hasConfiguredWidgetValue =
-      !recreating && this.hasConfiguredWidgetValue
-    const configuredWidgetValue = this.configuredWidgetValue
+      configuredWidgetValues !== undefined && 0 in configuredWidgetValues
+    const configuredWidgetValue = configuredWidgetValues?.[0]
 
     if (
       type === 'COMBO' &&
@@ -298,31 +296,16 @@ export class PrimitiveNode extends LGraphNode {
       !inputData?.[1]?.control_after_generate &&
       (widget.type === 'number' || widget.type === 'combo')
     ) {
-      const graphId = this.graph?.rootGraph.id ?? zeroUuid
-      let control_value =
-        useWidgetValueStore().getPositionalRestoredWidgetValue(
-          graphId,
-          this.id,
-          1
-        )
-      if (!control_value) {
-        control_value = 'fixed'
-      }
-      addValueControlWidgets(
-        this,
-        widget,
-        control_value as string,
-        undefined,
-        inputData
-      )
+      const configuredControlValue = configuredWidgetValues?.[1]
+      const control_value =
+        typeof configuredControlValue === 'string'
+          ? configuredControlValue
+          : 'fixed'
+      addValueControlWidgets(this, widget, control_value, undefined, inputData)
       if (this.widgets?.[1]) widget.linkedWidgets = [this.widgets[1]]
 
-      const filter = useWidgetValueStore().getPositionalRestoredWidgetValue(
-        graphId,
-        this.id,
-        2
-      )
-      if (filter && this.widgets && this.widgets.length === 3) {
+      const filter = configuredWidgetValues?.[2]
+      if (filter !== undefined && this.widgets?.length === 3) {
         this.widgets[2].value = filter
       }
     }

--- a/src/extensions/core/widgetInputs.ts
+++ b/src/extensions/core/widgetInputs.ts
@@ -288,7 +288,8 @@ export class PrimitiveNode extends LGraphNode {
       widget = this._createAssetWidget(node, widgetName, inputData)
       const theirWidget = node.widgets?.find((w) => w.name === widgetName)
       if (theirWidget) widget.value = theirWidget.value
-      if (hasConfiguredWidgetValue) widget.value = configuredWidgetValue
+      if (hasConfiguredWidgetValue)
+        this._restoreConfiguredWidgetValue(widget, configuredWidgetValue)
       if (configuredWidgetValues) this.configuredWidgetValues = undefined
       this._finalizeWidget(widget, oldWidth, oldHeight, recreating)
       return
@@ -307,7 +308,8 @@ export class PrimitiveNode extends LGraphNode {
         widget.value = theirWidget.value
       }
     }
-    if (hasConfiguredWidgetValue) widget.value = configuredWidgetValue
+    if (hasConfiguredWidgetValue)
+      this._restoreConfiguredWidgetValue(widget, configuredWidgetValue)
 
     if (
       !inputData?.[1]?.control_after_generate &&
@@ -341,6 +343,39 @@ export class PrimitiveNode extends LGraphNode {
 
     if (configuredWidgetValues) this.configuredWidgetValues = undefined
     this._finalizeWidget(widget, oldWidth, oldHeight, recreating)
+  }
+
+  private _restoreConfiguredWidgetValue(
+    widget: IBaseWidget,
+    configuredValue: WidgetValue
+  ) {
+    if (configuredValue == null) {
+      widget.value = configuredValue
+      return
+    }
+
+    const allowedValues = widget.options?.values
+    if (Array.isArray(allowedValues)) {
+      if (allowedValues.includes(configuredValue))
+        widget.value = configuredValue
+      return
+    }
+
+    if (widget.type === 'number') {
+      if (
+        typeof configuredValue !== 'number' ||
+        !Number.isFinite(configuredValue)
+      )
+        return
+      widget.value = Math.min(
+        Math.max(configuredValue, widget.options.min ?? -Infinity),
+        widget.options.max ?? Infinity
+      )
+      return
+    }
+
+    if (widget.value == null || typeof widget.value === typeof configuredValue)
+      widget.value = configuredValue
   }
 
   private _createAssetWidget(

--- a/src/extensions/core/widgetInputs.ts
+++ b/src/extensions/core/widgetInputs.ts
@@ -40,6 +40,7 @@ const replacePropertyName = 'Run widget replace on values'
 export class PrimitiveNode extends LGraphNode {
   controlValues?: WidgetValue[]
   lastType?: string
+  private hasConfiguredWidgetValue = false
   private configuredWidgetValue?: WidgetValue
   static override category: string
   constructor(title: string) {
@@ -127,6 +128,9 @@ export class PrimitiveNode extends LGraphNode {
   }
 
   override onConfigure(serialisedNode: ISerialisedNode) {
+    this.hasConfiguredWidgetValue =
+      serialisedNode.widgets_values !== undefined &&
+      0 in serialisedNode.widgets_values
     this.configuredWidgetValue = serialisedNode.widgets_values?.[0]
   }
 
@@ -141,6 +145,7 @@ export class PrimitiveNode extends LGraphNode {
       // Merge values if required
       this._mergeWidgetConfig()
     }
+    this.hasConfiguredWidgetValue = false
     this.configuredWidgetValue = undefined
   }
 
@@ -258,9 +263,9 @@ export class PrimitiveNode extends LGraphNode {
     // Store current size as addWidget resizes the node
     const [oldWidth, oldHeight] = this.size
     let widget: IBaseWidget
-    const configuredWidgetValue = recreating
-      ? undefined
-      : this.configuredWidgetValue
+    const hasConfiguredWidgetValue =
+      !recreating && this.hasConfiguredWidgetValue
+    const configuredWidgetValue = this.configuredWidgetValue
 
     if (
       type === 'COMBO' &&
@@ -269,8 +274,7 @@ export class PrimitiveNode extends LGraphNode {
       widget = this._createAssetWidget(node, widgetName, inputData)
       const theirWidget = node.widgets?.find((w) => w.name === widgetName)
       if (theirWidget) widget.value = theirWidget.value
-      if (configuredWidgetValue !== undefined)
-        widget.value = configuredWidgetValue
+      if (hasConfiguredWidgetValue) widget.value = configuredWidgetValue
       this._finalizeWidget(widget, oldWidth, oldHeight, recreating)
       return
     }
@@ -288,8 +292,7 @@ export class PrimitiveNode extends LGraphNode {
         widget.value = theirWidget.value
       }
     }
-    if (configuredWidgetValue !== undefined)
-      widget.value = configuredWidgetValue
+    if (hasConfiguredWidgetValue) widget.value = configuredWidgetValue
 
     if (
       !inputData?.[1]?.control_after_generate &&

--- a/src/extensions/core/widgetInputs.ts
+++ b/src/extensions/core/widgetInputs.ts
@@ -129,7 +129,10 @@ export class PrimitiveNode extends LGraphNode {
    * The widget of a PrimitiveNode is only built once its output link resolves,
    * which happens after `configure` has finished and the regular widget
    * restoration state has been cleared. Park the serialized values in the
-   * widget value store until the widget is built or graph restoration ends.
+   * widget value store until the widget is built. The build may be deferred
+   * past graph configuration (a reroute resolves its widget config on a later
+   * frame), so the entry lives until it is consumed by the first build, the
+   * output is disconnected, or the node is removed.
    */
   override onConfigure(serialisedNode: ISerialisedNode) {
     super.onConfigure?.(serialisedNode)
@@ -167,31 +170,10 @@ export class PrimitiveNode extends LGraphNode {
       // Merge values if required
       this._mergeWidgetConfig()
     }
-    this._scheduleConfiguredWidgetValuesClear()
   }
 
   private _restorationGraphId() {
     return this.graph?.rootGraph.id ?? zeroUuid
-  }
-
-  private _scheduleConfiguredWidgetValuesClear() {
-    const graphId = this._restorationGraphId()
-    const widgetValueStore = useWidgetValueStore()
-    const restoration = widgetValueStore.getPrimitiveWidgetRestoration(
-      graphId,
-      this.id
-    )
-    if (!restoration) return
-    requestAnimationFrame(() => {
-      requestAnimationFrame(() => {
-        if (
-          widgetValueStore.getPrimitiveWidgetRestoration(graphId, this.id) ===
-          restoration
-        ) {
-          widgetValueStore.clearPrimitiveWidgetRestoration(graphId, this.id)
-        }
-      })
-    })
   }
 
   private _clearConfiguredWidgetValues() {

--- a/src/extensions/core/widgetInputs.ts
+++ b/src/extensions/core/widgetInputs.ts
@@ -140,7 +140,6 @@ export class PrimitiveNode extends LGraphNode {
       // Merge values if required
       this._mergeWidgetConfig()
     }
-    this.configuredWidgetValues = undefined
   }
 
   override onConnectionsChange(
@@ -260,7 +259,6 @@ export class PrimitiveNode extends LGraphNode {
     const configuredWidgetValues = recreating
       ? undefined
       : this.configuredWidgetValues
-    if (!recreating) this.configuredWidgetValues = undefined
     const hasConfiguredWidgetValue =
       configuredWidgetValues !== undefined && 0 in configuredWidgetValues
     const configuredWidgetValue = configuredWidgetValues?.[0]
@@ -273,6 +271,7 @@ export class PrimitiveNode extends LGraphNode {
       const theirWidget = node.widgets?.find((w) => w.name === widgetName)
       if (theirWidget) widget.value = theirWidget.value
       if (hasConfiguredWidgetValue) widget.value = configuredWidgetValue
+      if (!recreating) this.configuredWidgetValues = undefined
       this._finalizeWidget(widget, oldWidth, oldHeight, recreating)
       return
     }
@@ -322,6 +321,7 @@ export class PrimitiveNode extends LGraphNode {
       }
     }
 
+    if (!recreating) this.configuredWidgetValues = undefined
     this._finalizeWidget(widget, oldWidth, oldHeight, recreating)
   }
 

--- a/src/extensions/core/widgetInputs.ts
+++ b/src/extensions/core/widgetInputs.ts
@@ -125,30 +125,35 @@ export class PrimitiveNode extends LGraphNode {
     return values
   }
 
+  /**
+   * The widget of a PrimitiveNode is only built once its output link resolves,
+   * which happens after `configure` has finished and the regular widget
+   * restoration state has been cleared. Park the serialized values in the
+   * widget value store until the widget is built or graph restoration ends.
+   */
   override onConfigure(serialisedNode: ISerialisedNode) {
     super.onConfigure?.(serialisedNode)
-    const positionalValues = serialisedNode.widgets_values
-    const namedValues = serialisedNode.widgets_values_named
     const type = serialisedNode.outputs?.[0]?.type
+    if (typeof type !== 'string') {
+      this._clearConfiguredWidgetValues()
+      return
+    }
+    const namedValues = serialisedNode.widgets_values_named
     const values =
       LiteGraph.namedValuesRestore && namedValues
         ? ['value', 'control_after_generate', 'control_filter_list'].reduce<
-            NonNullable<ISerialisedNode['widgets_values']>
+            WidgetValue[]
           >((restored, name, index) => {
             if (Object.hasOwn(namedValues, name))
               restored[index] = namedValues[name]
             return restored
           }, [])
-        : Array.from(positionalValues ?? [])
-    const configuredWidgetValues =
-      typeof type === 'string' ? { type, values } : undefined
-    if (configuredWidgetValues) {
-      useWidgetValueStore().setPrimitiveWidgetRestoration(
-        this.graph?.rootGraph.id ?? zeroUuid,
-        this.id,
-        configuredWidgetValues
-      )
-    }
+        : Array.from(serialisedNode.widgets_values ?? [])
+    useWidgetValueStore().setPrimitiveWidgetRestoration(
+      this._restorationGraphId(),
+      this.id,
+      { type, values }
+    )
   }
 
   override onAfterGraphConfigured() {
@@ -162,6 +167,20 @@ export class PrimitiveNode extends LGraphNode {
       // Merge values if required
       this._mergeWidgetConfig()
     }
+    // Graph restoration is complete; any serialized value that was not
+    // consumed while rebuilding the widget must not leak into later links.
+    this._clearConfiguredWidgetValues()
+  }
+
+  private _restorationGraphId() {
+    return this.graph?.rootGraph.id ?? zeroUuid
+  }
+
+  private _clearConfiguredWidgetValues() {
+    useWidgetValueStore().clearPrimitiveWidgetRestoration(
+      this._restorationGraphId(),
+      this.id
+    )
   }
 
   override onConnectionsChange(
@@ -226,8 +245,6 @@ export class PrimitiveNode extends LGraphNode {
         console.warn(
           `PrimitiveNode ${this.id}: link store reports output 0 connected but no link resolves in the graph; resetting the widget.`
         )
-        this.onLastDisconnect(true)
-        return
       }
       this.onLastDisconnect()
       return
@@ -280,16 +297,17 @@ export class PrimitiveNode extends LGraphNode {
     // Store current size as addWidget resizes the node
     const [oldWidth, oldHeight] = this.size
     let widget: IBaseWidget
-    const graphId = this.graph?.rootGraph.id ?? zeroUuid
-    const widgetValueStore = useWidgetValueStore()
-    const pendingRestoration = widgetValueStore.getPrimitiveWidgetRestoration(
-      graphId,
-      this.id
-    )
+    const restoration = recreating
+      ? undefined
+      : useWidgetValueStore().getPrimitiveWidgetRestoration(
+          this._restorationGraphId(),
+          this.id
+        )
+    // Consumed on this build regardless of type match: the values belong to
+    // the link that was serialized, not to whatever connects later.
+    if (restoration) this._clearConfiguredWidgetValues()
     const configuredWidgetValues =
-      !recreating && pendingRestoration?.type === type
-        ? pendingRestoration.values
-        : undefined
+      restoration?.type === type ? restoration.values : undefined
     const hasConfiguredWidgetValue =
       configuredWidgetValues !== undefined && 0 in configuredWidgetValues
     const configuredWidgetValue = configuredWidgetValues?.[0]
@@ -303,9 +321,6 @@ export class PrimitiveNode extends LGraphNode {
       if (theirWidget) widget.value = theirWidget.value
       if (hasConfiguredWidgetValue)
         this._restoreConfiguredWidgetValue(widget, configuredWidgetValue)
-      if (configuredWidgetValues) {
-        widgetValueStore.clearPrimitiveWidgetRestoration(graphId, this.id)
-      }
       this._finalizeWidget(widget, oldWidth, oldHeight, recreating)
       return
     }
@@ -356,9 +371,6 @@ export class PrimitiveNode extends LGraphNode {
       }
     }
 
-    if (configuredWidgetValues) {
-      widgetValueStore.clearPrimitiveWidgetRestoration(graphId, this.id)
-    }
     this._finalizeWidget(widget, oldWidth, oldHeight, recreating)
   }
 
@@ -517,13 +529,8 @@ export class PrimitiveNode extends LGraphNode {
     }
   }
 
-  onLastDisconnect(preserveConfiguredValues = false) {
-    if (!preserveConfiguredValues) {
-      useWidgetValueStore().clearPrimitiveWidgetRestoration(
-        this.graph?.rootGraph.id ?? zeroUuid,
-        this.id
-      )
-    }
+  onLastDisconnect() {
+    this._clearConfiguredWidgetValues()
     // We can't remove + re-add the output here as if you drag a link over the same link
     // it removes, then re-adds, causing it to break
     this.outputs[0].type = '*'

--- a/src/extensions/core/widgetInputs.ts
+++ b/src/extensions/core/widgetInputs.ts
@@ -5,6 +5,7 @@ import { LGraphNode, LiteGraph } from '@/lib/litegraph/src/litegraph'
 import type {
   INodeInputSlot,
   INodeOutputSlot,
+  ISerialisedNode,
   ISlotType,
   LLink
 } from '@/lib/litegraph/src/litegraph'
@@ -39,6 +40,7 @@ const replacePropertyName = 'Run widget replace on values'
 export class PrimitiveNode extends LGraphNode {
   controlValues?: WidgetValue[]
   lastType?: string
+  private configuredWidgetValue?: WidgetValue
   static override category: string
   constructor(title: string) {
     super(title)
@@ -124,6 +126,10 @@ export class PrimitiveNode extends LGraphNode {
     return values
   }
 
+  override onConfigure(serialisedNode: ISerialisedNode) {
+    this.configuredWidgetValue = serialisedNode.widgets_values?.[0]
+  }
+
   override onAfterGraphConfigured() {
     if (
       this.graph &&
@@ -135,6 +141,7 @@ export class PrimitiveNode extends LGraphNode {
       // Merge values if required
       this._mergeWidgetConfig()
     }
+    this.configuredWidgetValue = undefined
   }
 
   override onConnectionsChange(
@@ -251,6 +258,9 @@ export class PrimitiveNode extends LGraphNode {
     // Store current size as addWidget resizes the node
     const [oldWidth, oldHeight] = this.size
     let widget: IBaseWidget
+    const configuredWidgetValue = recreating
+      ? undefined
+      : this.configuredWidgetValue
 
     if (
       type === 'COMBO' &&
@@ -259,6 +269,8 @@ export class PrimitiveNode extends LGraphNode {
       widget = this._createAssetWidget(node, widgetName, inputData)
       const theirWidget = node.widgets?.find((w) => w.name === widgetName)
       if (theirWidget) widget.value = theirWidget.value
+      if (configuredWidgetValue !== undefined)
+        widget.value = configuredWidgetValue
       this._finalizeWidget(widget, oldWidth, oldHeight, recreating)
       return
     }
@@ -276,6 +288,8 @@ export class PrimitiveNode extends LGraphNode {
         widget.value = theirWidget.value
       }
     }
+    if (configuredWidgetValue !== undefined)
+      widget.value = configuredWidgetValue
 
     if (
       !inputData?.[1]?.control_after_generate &&

--- a/src/extensions/core/widgetInputs.ts
+++ b/src/extensions/core/widgetInputs.ts
@@ -21,7 +21,9 @@ import {
 } from '@/schemas/nodeDefSchema'
 import type { ComfyNodeDef, InputSpec } from '@/schemas/nodeDefSchema'
 import { app } from '@/scripts/app'
+import { useWidgetValueStore } from '@/stores/widgetValueStore'
 import type { WidgetValue } from '@/types/simplifiedWidget'
+import { zeroUuid } from '@/utils/uuid'
 import {
   ComfyWidgets,
   addValueControlWidgets,
@@ -38,10 +40,6 @@ const replacePropertyName = 'Run widget replace on values'
 export class PrimitiveNode extends LGraphNode {
   controlValues?: WidgetValue[]
   lastType?: string
-  private configuredWidgetValues?: {
-    type: string
-    values: NonNullable<ISerialisedNode['widgets_values']>
-  }
   static override category: string
   constructor(title: string) {
     super(title)
@@ -144,13 +142,13 @@ export class PrimitiveNode extends LGraphNode {
         : Array.from(positionalValues ?? [])
     const configuredWidgetValues =
       typeof type === 'string' ? { type, values } : undefined
-    this.configuredWidgetValues = configuredWidgetValues
-    requestAnimationFrame(() => {
-      requestAnimationFrame(() => {
-        if (this.configuredWidgetValues === configuredWidgetValues)
-          this.configuredWidgetValues = undefined
-      })
-    })
+    if (configuredWidgetValues) {
+      useWidgetValueStore().setPrimitiveWidgetRestoration(
+        this.graph?.rootGraph.id ?? zeroUuid,
+        this.id,
+        configuredWidgetValues
+      )
+    }
   }
 
   override onAfterGraphConfigured() {
@@ -282,9 +280,15 @@ export class PrimitiveNode extends LGraphNode {
     // Store current size as addWidget resizes the node
     const [oldWidth, oldHeight] = this.size
     let widget: IBaseWidget
+    const graphId = this.graph?.rootGraph.id ?? zeroUuid
+    const widgetValueStore = useWidgetValueStore()
+    const pendingRestoration = widgetValueStore.getPrimitiveWidgetRestoration(
+      graphId,
+      this.id
+    )
     const configuredWidgetValues =
-      !recreating && this.configuredWidgetValues?.type === type
-        ? this.configuredWidgetValues.values
+      !recreating && pendingRestoration?.type === type
+        ? pendingRestoration.values
         : undefined
     const hasConfiguredWidgetValue =
       configuredWidgetValues !== undefined && 0 in configuredWidgetValues
@@ -299,7 +303,9 @@ export class PrimitiveNode extends LGraphNode {
       if (theirWidget) widget.value = theirWidget.value
       if (hasConfiguredWidgetValue)
         this._restoreConfiguredWidgetValue(widget, configuredWidgetValue)
-      if (configuredWidgetValues) this.configuredWidgetValues = undefined
+      if (configuredWidgetValues) {
+        widgetValueStore.clearPrimitiveWidgetRestoration(graphId, this.id)
+      }
       this._finalizeWidget(widget, oldWidth, oldHeight, recreating)
       return
     }
@@ -350,7 +356,9 @@ export class PrimitiveNode extends LGraphNode {
       }
     }
 
-    if (configuredWidgetValues) this.configuredWidgetValues = undefined
+    if (configuredWidgetValues) {
+      widgetValueStore.clearPrimitiveWidgetRestoration(graphId, this.id)
+    }
     this._finalizeWidget(widget, oldWidth, oldHeight, recreating)
   }
 
@@ -510,7 +518,12 @@ export class PrimitiveNode extends LGraphNode {
   }
 
   onLastDisconnect(preserveConfiguredValues = false) {
-    if (!preserveConfiguredValues) this.configuredWidgetValues = undefined
+    if (!preserveConfiguredValues) {
+      useWidgetValueStore().clearPrimitiveWidgetRestoration(
+        this.graph?.rootGraph.id ?? zeroUuid,
+        this.id
+      )
+    }
     // We can't remove + re-add the output here as if you drag a link over the same link
     // it removes, then re-adds, causing it to break
     this.outputs[0].type = '*'

--- a/src/extensions/core/widgetInputs.ts
+++ b/src/extensions/core/widgetInputs.ts
@@ -1,6 +1,7 @@
 import { intersection } from 'es-toolkit/compat'
 
 import { useChainCallback } from '@/composables/functional/useChainCallback'
+import { createWidgetRestorationState } from '@/lib/litegraph/src/LGraphNode'
 import { LGraphNode, LiteGraph } from '@/lib/litegraph/src/litegraph'
 import type {
   INodeInputSlot,
@@ -23,7 +24,6 @@ import type { ComfyNodeDef, InputSpec } from '@/schemas/nodeDefSchema'
 import { app } from '@/scripts/app'
 import { useWidgetValueStore } from '@/stores/widgetValueStore'
 import type { WidgetValue } from '@/types/simplifiedWidget'
-import { zeroUuid } from '@/utils/uuid'
 import {
   ComfyWidgets,
   addValueControlWidgets,
@@ -40,7 +40,6 @@ const replacePropertyName = 'Run widget replace on values'
 export class PrimitiveNode extends LGraphNode {
   controlValues?: WidgetValue[]
   lastType?: string
-  private configuredWidgetType?: string
   static override category: string
   constructor(title: string) {
     super(title)
@@ -126,14 +125,16 @@ export class PrimitiveNode extends LGraphNode {
     return values
   }
 
-  override onConfigure(serialisedNode: ISerialisedNode) {
-    super.onConfigure?.(serialisedNode)
+  override configure(serialisedNode: ISerialisedNode) {
     const type = serialisedNode.outputs?.[0]?.type
-    this.configuredWidgetType = typeof type === 'string' ? type : undefined
-  }
+    super.configure(serialisedNode)
+    if (!this.graph || this.widgets?.length || typeof type !== 'string') return
 
-  protected override deferWidgetRestorationAfterConfigure(): boolean {
-    return Boolean(this.graph && this.configuredWidgetType)
+    useWidgetValueStore().setNodeWidgetRestoration(
+      this.graph.rootGraph.id,
+      this.id,
+      createWidgetRestorationState(serialisedNode)
+    )
   }
 
   override onAfterGraphConfigured() {
@@ -149,16 +150,12 @@ export class PrimitiveNode extends LGraphNode {
     }
   }
 
-  private _restorationGraphId() {
-    return this.graph?.rootGraph.id ?? zeroUuid
-  }
-
-  private _clearConfiguredWidgetValues() {
-    useWidgetValueStore().clearNodeWidgetRestoration(
-      this._restorationGraphId(),
-      this.id
-    )
-    this.configuredWidgetType = undefined
+  private _clearWidgetRestoration() {
+    if (this.graph)
+      useWidgetValueStore().clearNodeWidgetRestoration(
+        this.graph.rootGraph.id,
+        this.id
+      )
   }
 
   override onConnectionsChange(
@@ -247,6 +244,8 @@ export class PrimitiveNode extends LGraphNode {
     if (!config) return
 
     const { type } = getWidgetType(config)
+    if (recreating || this.outputs[0].type !== type)
+      this._clearWidgetRestoration()
     // Update our output to restrict to the widget type
     this.outputs[0].type = type
     this.outputs[0].name = type
@@ -275,19 +274,14 @@ export class PrimitiveNode extends LGraphNode {
     // Store current size as addWidget resizes the node
     const [oldWidth, oldHeight] = this.size
     let widget: IBaseWidget
-    const configuredType = recreating ? undefined : this.configuredWidgetType
-    if (configuredType && configuredType !== type) {
-      this._clearConfiguredWidgetValues()
-    }
-    const configuredWidgetValue =
-      configuredType === type
-        ? useWidgetValueStore().getRestoredWidgetValue(
-            this._restorationGraphId(),
-            this.id,
-            'value',
-            0
-          )
-        : undefined
+    const restoredValue = this.graph
+      ? useWidgetValueStore().getRestoredWidgetValue(
+          this.graph.rootGraph.id,
+          this.id,
+          'value',
+          0
+        )
+      : undefined
 
     try {
       if (
@@ -297,7 +291,7 @@ export class PrimitiveNode extends LGraphNode {
         widget = this._createAssetWidget(node, widgetName, inputData)
         const theirWidget = node.widgets?.find((w) => w.name === widgetName)
         if (theirWidget) widget.value = theirWidget.value
-        if (configuredWidgetValue) widget.value = configuredWidgetValue.value
+        if (restoredValue) widget.value = restoredValue.value
         this._finalizeWidget(widget, oldWidth, oldHeight, recreating)
         return
       }
@@ -316,7 +310,7 @@ export class PrimitiveNode extends LGraphNode {
           widget.value = theirWidget.value
         }
       }
-      if (configuredWidgetValue) widget.value = configuredWidgetValue.value
+      if (restoredValue) widget.value = restoredValue.value
 
       if (
         !inputData?.[1]?.control_after_generate &&
@@ -340,7 +334,7 @@ export class PrimitiveNode extends LGraphNode {
 
       this._finalizeWidget(widget, oldWidth, oldHeight, recreating)
     } finally {
-      if (configuredType) this._clearConfiguredWidgetValues()
+      this._clearWidgetRestoration()
     }
   }
 
@@ -467,7 +461,7 @@ export class PrimitiveNode extends LGraphNode {
   }
 
   onLastDisconnect() {
-    this._clearConfiguredWidgetValues()
+    this._clearWidgetRestoration()
     // We can't remove + re-add the output here as if you drag a link over the same link
     // it removes, then re-adds, causing it to break
     this.outputs[0].type = '*'

--- a/src/extensions/core/widgetInputs.ts
+++ b/src/extensions/core/widgetInputs.ts
@@ -40,6 +40,7 @@ const replacePropertyName = 'Run widget replace on values'
 export class PrimitiveNode extends LGraphNode {
   controlValues?: WidgetValue[]
   lastType?: string
+  private configuredWidgetType?: string
   static override category: string
   constructor(title: string) {
     super(title)
@@ -125,38 +126,14 @@ export class PrimitiveNode extends LGraphNode {
     return values
   }
 
-  /**
-   * The widget of a PrimitiveNode is only built once its output link resolves,
-   * which happens after `configure` has finished and the regular widget
-   * restoration state has been cleared. Park the serialized values in the
-   * widget value store until the widget is built. The build may be deferred
-   * past graph configuration (a reroute resolves its widget config on a later
-   * frame), so the entry lives until it is consumed by the first build, the
-   * output is disconnected, or the node is removed.
-   */
   override onConfigure(serialisedNode: ISerialisedNode) {
     super.onConfigure?.(serialisedNode)
     const type = serialisedNode.outputs?.[0]?.type
-    if (typeof type !== 'string') {
-      this._clearConfiguredWidgetValues()
-      return
-    }
-    const namedValues = serialisedNode.widgets_values_named
-    const values =
-      LiteGraph.namedValuesRestore && namedValues
-        ? ['value', 'control_after_generate', 'control_filter_list'].reduce<
-            WidgetValue[]
-          >((restored, name, index) => {
-            if (Object.hasOwn(namedValues, name))
-              restored[index] = namedValues[name]
-            return restored
-          }, [])
-        : Array.from(serialisedNode.widgets_values ?? [])
-    useWidgetValueStore().setPrimitiveWidgetRestoration(
-      this._restorationGraphId(),
-      this.id,
-      { type, values }
-    )
+    this.configuredWidgetType = typeof type === 'string' ? type : undefined
+  }
+
+  protected override deferWidgetRestorationAfterConfigure(): boolean {
+    return Boolean(this.graph && this.configuredWidgetType)
   }
 
   override onAfterGraphConfigured() {
@@ -177,10 +154,11 @@ export class PrimitiveNode extends LGraphNode {
   }
 
   private _clearConfiguredWidgetValues() {
-    useWidgetValueStore().clearPrimitiveWidgetRestoration(
+    useWidgetValueStore().clearNodeWidgetRestoration(
       this._restorationGraphId(),
       this.id
     )
+    this.configuredWidgetType = undefined
   }
 
   override onConnectionsChange(
@@ -297,114 +275,73 @@ export class PrimitiveNode extends LGraphNode {
     // Store current size as addWidget resizes the node
     const [oldWidth, oldHeight] = this.size
     let widget: IBaseWidget
-    const restoration = recreating
-      ? undefined
-      : useWidgetValueStore().getPrimitiveWidgetRestoration(
-          this._restorationGraphId(),
-          this.id
-        )
-    // Consumed on this build regardless of type match: the values belong to
-    // the link that was serialized, not to whatever connects later.
-    if (restoration) this._clearConfiguredWidgetValues()
-    const configuredWidgetValues =
-      restoration?.type === type ? restoration.values : undefined
-    const hasConfiguredWidgetValue =
-      configuredWidgetValues !== undefined && 0 in configuredWidgetValues
-    const configuredWidgetValue = configuredWidgetValues?.[0]
-
-    if (
-      type === 'COMBO' &&
-      assetService.shouldUseAssetBrowser(node.comfyClass, widgetName)
-    ) {
-      widget = this._createAssetWidget(node, widgetName, inputData)
-      const theirWidget = node.widgets?.find((w) => w.name === widgetName)
-      if (theirWidget) widget.value = theirWidget.value
-      if (hasConfiguredWidgetValue)
-        this._restoreConfiguredWidgetValue(widget, configuredWidgetValue)
-      this._finalizeWidget(widget, oldWidth, oldHeight, recreating)
-      return
+    const configuredType = recreating ? undefined : this.configuredWidgetType
+    if (configuredType && configuredType !== type) {
+      this._clearConfiguredWidgetValues()
     }
+    const configuredWidgetValue =
+      configuredType === type
+        ? useWidgetValueStore().getRestoredWidgetValue(
+            this._restorationGraphId(),
+            this.id,
+            'value',
+            0
+          )
+        : undefined
 
-    if (isValidWidgetType(type)) {
-      widget = (ComfyWidgets[type](this, 'value', inputData, app) || {}).widget
-    } else {
-      // @ts-expect-error InputSpec is not typed correctly
-      widget = this.addWidget(type, 'value', null, () => {}, {})
-    }
-
-    if (node?.widgets && widget) {
-      const theirWidget = node.widgets.find((w) => w.name === widgetName)
-      if (theirWidget) {
-        widget.value = theirWidget.value
-      }
-    }
-    if (hasConfiguredWidgetValue)
-      this._restoreConfiguredWidgetValue(widget, configuredWidgetValue)
-
-    if (
-      !inputData?.[1]?.control_after_generate &&
-      (widget.type === 'number' || widget.type === 'combo')
-    ) {
-      addValueControlWidgets(this, widget, 'fixed', undefined, inputData)
-      if (this.widgets?.[1]) widget.linkedWidgets = [this.widgets[1]]
-    }
-
-    configuredWidgetValues?.slice(1).forEach((value, index) => {
-      const controlWidget = this.widgets?.[index + 1]
-      if (!controlWidget || typeof value !== 'string' || value === '') return
-
-      const allowed = controlWidget.options?.values
-      if (Array.isArray(allowed) && !allowed.includes(value)) return
-
-      controlWidget.value = value
-    })
-
-    // Restore any saved control values
-    const controlValues = this.controlValues
-    if (
-      this.widgets &&
-      this.lastType === this.widgets[0]?.type &&
-      controlValues?.length === this.widgets.length - 1
-    ) {
-      for (let i = 0; i < controlValues.length; i++) {
-        this.widgets[i + 1].value = controlValues[i]
-      }
-    }
-
-    this._finalizeWidget(widget, oldWidth, oldHeight, recreating)
-  }
-
-  private _restoreConfiguredWidgetValue(
-    widget: IBaseWidget,
-    configuredValue: WidgetValue
-  ) {
-    if (configuredValue == null) {
-      widget.value = configuredValue
-      return
-    }
-
-    const allowedValues = widget.options?.values
-    if (Array.isArray(allowedValues)) {
-      if (allowedValues.includes(configuredValue))
-        widget.value = configuredValue
-      return
-    }
-
-    if (widget.type === 'number') {
+    try {
       if (
-        typeof configuredValue !== 'number' ||
-        !Number.isFinite(configuredValue)
-      )
+        type === 'COMBO' &&
+        assetService.shouldUseAssetBrowser(node.comfyClass, widgetName)
+      ) {
+        widget = this._createAssetWidget(node, widgetName, inputData)
+        const theirWidget = node.widgets?.find((w) => w.name === widgetName)
+        if (theirWidget) widget.value = theirWidget.value
+        if (configuredWidgetValue) widget.value = configuredWidgetValue.value
+        this._finalizeWidget(widget, oldWidth, oldHeight, recreating)
         return
-      widget.value = Math.min(
-        Math.max(configuredValue, widget.options.min ?? -Infinity),
-        widget.options.max ?? Infinity
-      )
-      return
-    }
+      }
 
-    if (widget.value == null || typeof widget.value === typeof configuredValue)
-      widget.value = configuredValue
+      if (isValidWidgetType(type)) {
+        widget = (ComfyWidgets[type](this, 'value', inputData, app) || {})
+          .widget
+      } else {
+        // @ts-expect-error InputSpec is not typed correctly
+        widget = this.addWidget(type, 'value', null, () => {}, {})
+      }
+
+      if (node?.widgets && widget) {
+        const theirWidget = node.widgets.find((w) => w.name === widgetName)
+        if (theirWidget) {
+          widget.value = theirWidget.value
+        }
+      }
+      if (configuredWidgetValue) widget.value = configuredWidgetValue.value
+
+      if (
+        !inputData?.[1]?.control_after_generate &&
+        (widget.type === 'number' || widget.type === 'combo')
+      ) {
+        addValueControlWidgets(this, widget, 'fixed', undefined, inputData)
+        if (this.widgets?.[1]) widget.linkedWidgets = [this.widgets[1]]
+      }
+
+      // Restore any saved control values
+      const controlValues = this.controlValues
+      if (
+        this.widgets &&
+        this.lastType === this.widgets[0]?.type &&
+        controlValues?.length === this.widgets.length - 1
+      ) {
+        for (let i = 0; i < controlValues.length; i++) {
+          this.widgets[i + 1].value = controlValues[i]
+        }
+      }
+
+      this._finalizeWidget(widget, oldWidth, oldHeight, recreating)
+    } finally {
+      if (configuredType) this._clearConfiguredWidgetValues()
+    }
   }
 
   private _createAssetWidget(

--- a/src/extensions/core/widgetInputs.ts
+++ b/src/extensions/core/widgetInputs.ts
@@ -308,7 +308,7 @@ export class PrimitiveNode extends LGraphNode {
 
     configuredWidgetValues?.slice(1).forEach((value, index) => {
       const controlWidget = this.widgets?.[index + 1]
-      if (controlWidget && typeof value === 'string') {
+      if (controlWidget && typeof value === 'string' && value !== '') {
         controlWidget.value = value
       }
     })

--- a/src/extensions/core/widgetInputs.ts
+++ b/src/extensions/core/widgetInputs.ts
@@ -129,12 +129,21 @@ export class PrimitiveNode extends LGraphNode {
 
   override onConfigure(serialisedNode: ISerialisedNode) {
     super.onConfigure?.(serialisedNode)
-    const values = serialisedNode.widgets_values
+    const positionalValues = serialisedNode.widgets_values
+    const namedValues = serialisedNode.widgets_values_named
     const type = serialisedNode.outputs?.[0]?.type
+    const values =
+      LiteGraph.namedValuesRestore && namedValues
+        ? ['value', 'control_after_generate', 'control_filter_list'].reduce<
+            NonNullable<ISerialisedNode['widgets_values']>
+          >((restored, name, index) => {
+            if (Object.hasOwn(namedValues, name))
+              restored[index] = namedValues[name]
+            return restored
+          }, [])
+        : Array.from(positionalValues ?? [])
     this.configuredWidgetValues =
-      values && typeof type === 'string'
-        ? { type, values: Array.from(values) }
-        : undefined
+      typeof type === 'string' ? { type, values } : undefined
   }
 
   override onAfterGraphConfigured() {

--- a/src/extensions/core/widgetInputs.ts
+++ b/src/extensions/core/widgetInputs.ts
@@ -142,8 +142,15 @@ export class PrimitiveNode extends LGraphNode {
             return restored
           }, [])
         : Array.from(positionalValues ?? [])
-    this.configuredWidgetValues =
+    const configuredWidgetValues =
       typeof type === 'string' ? { type, values } : undefined
+    this.configuredWidgetValues = configuredWidgetValues
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        if (this.configuredWidgetValues === configuredWidgetValues)
+          this.configuredWidgetValues = undefined
+      })
+    })
   }
 
   override onAfterGraphConfigured() {
@@ -221,6 +228,8 @@ export class PrimitiveNode extends LGraphNode {
         console.warn(
           `PrimitiveNode ${this.id}: link store reports output 0 connected but no link resolves in the graph; resetting the widget.`
         )
+        this.onLastDisconnect(true)
+        return
       }
       this.onLastDisconnect()
       return
@@ -500,7 +509,8 @@ export class PrimitiveNode extends LGraphNode {
     }
   }
 
-  onLastDisconnect() {
+  onLastDisconnect(preserveConfiguredValues = false) {
+    if (!preserveConfiguredValues) this.configuredWidgetValues = undefined
     // We can't remove + re-add the output here as if you drag a link over the same link
     // it removes, then re-adds, causing it to break
     this.outputs[0].type = '*'

--- a/src/extensions/core/widgetInputs.ts
+++ b/src/extensions/core/widgetInputs.ts
@@ -167,13 +167,31 @@ export class PrimitiveNode extends LGraphNode {
       // Merge values if required
       this._mergeWidgetConfig()
     }
-    // Graph restoration is complete; any serialized value that was not
-    // consumed while rebuilding the widget must not leak into later links.
-    this._clearConfiguredWidgetValues()
+    this._scheduleConfiguredWidgetValuesClear()
   }
 
   private _restorationGraphId() {
     return this.graph?.rootGraph.id ?? zeroUuid
+  }
+
+  private _scheduleConfiguredWidgetValuesClear() {
+    const graphId = this._restorationGraphId()
+    const widgetValueStore = useWidgetValueStore()
+    const restoration = widgetValueStore.getPrimitiveWidgetRestoration(
+      graphId,
+      this.id
+    )
+    if (!restoration) return
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        if (
+          widgetValueStore.getPrimitiveWidgetRestoration(graphId, this.id) ===
+          restoration
+        ) {
+          widgetValueStore.clearPrimitiveWidgetRestoration(graphId, this.id)
+        }
+      })
+    })
   }
 
   private _clearConfiguredWidgetValues() {

--- a/src/extensions/core/widgetInputs.ts
+++ b/src/extensions/core/widgetInputs.ts
@@ -132,7 +132,9 @@ export class PrimitiveNode extends LGraphNode {
     const values = serialisedNode.widgets_values
     const type = serialisedNode.outputs?.[0]?.type
     this.configuredWidgetValues =
-      values && typeof type === 'string' ? { type, values } : undefined
+      values && typeof type === 'string'
+        ? { type, values: Array.from(values) }
+        : undefined
   }
 
   override onAfterGraphConfigured() {
@@ -308,9 +310,12 @@ export class PrimitiveNode extends LGraphNode {
 
     configuredWidgetValues?.slice(1).forEach((value, index) => {
       const controlWidget = this.widgets?.[index + 1]
-      if (controlWidget && typeof value === 'string' && value !== '') {
-        controlWidget.value = value
-      }
+      if (!controlWidget || typeof value !== 'string' || value === '') return
+
+      const allowed = controlWidget.options?.values
+      if (Array.isArray(allowed) && !allowed.includes(value)) return
+
+      controlWidget.value = value
     })
 
     // Restore any saved control values
@@ -372,7 +377,7 @@ export class PrimitiveNode extends LGraphNode {
   recreateWidget() {
     const values = this.widgets?.map((w) => w.value)
     this._removeWidgets()
-    this._onFirstConnection(true)
+    this._onFirstConnection(!!values?.length)
     if (values?.length && this.widgets) {
       for (let i = 0; i < this.widgets.length; i++)
         this.widgets[i].value = values[i]

--- a/src/extensions/core/widgetInputs.ts
+++ b/src/extensions/core/widgetInputs.ts
@@ -38,7 +38,10 @@ const replacePropertyName = 'Run widget replace on values'
 export class PrimitiveNode extends LGraphNode {
   controlValues?: WidgetValue[]
   lastType?: string
-  private configuredWidgetValues?: ISerialisedNode['widgets_values']
+  private configuredWidgetValues?: {
+    type: string
+    values: NonNullable<ISerialisedNode['widgets_values']>
+  }
   static override category: string
   constructor(title: string) {
     super(title)
@@ -126,7 +129,10 @@ export class PrimitiveNode extends LGraphNode {
 
   override onConfigure(serialisedNode: ISerialisedNode) {
     super.onConfigure?.(serialisedNode)
-    this.configuredWidgetValues = serialisedNode.widgets_values
+    const values = serialisedNode.widgets_values
+    const type = serialisedNode.outputs?.[0]?.type
+    this.configuredWidgetValues =
+      values && typeof type === 'string' ? { type, values } : undefined
   }
 
   override onAfterGraphConfigured() {
@@ -256,9 +262,10 @@ export class PrimitiveNode extends LGraphNode {
     // Store current size as addWidget resizes the node
     const [oldWidth, oldHeight] = this.size
     let widget: IBaseWidget
-    const configuredWidgetValues = recreating
-      ? undefined
-      : this.configuredWidgetValues
+    const configuredWidgetValues =
+      !recreating && this.configuredWidgetValues?.type === type
+        ? this.configuredWidgetValues.values
+        : undefined
     const hasConfiguredWidgetValue =
       configuredWidgetValues !== undefined && 0 in configuredWidgetValues
     const configuredWidgetValue = configuredWidgetValues?.[0]
@@ -271,7 +278,7 @@ export class PrimitiveNode extends LGraphNode {
       const theirWidget = node.widgets?.find((w) => w.name === widgetName)
       if (theirWidget) widget.value = theirWidget.value
       if (hasConfiguredWidgetValue) widget.value = configuredWidgetValue
-      if (!recreating) this.configuredWidgetValues = undefined
+      if (configuredWidgetValues) this.configuredWidgetValues = undefined
       this._finalizeWidget(widget, oldWidth, oldHeight, recreating)
       return
     }
@@ -295,19 +302,16 @@ export class PrimitiveNode extends LGraphNode {
       !inputData?.[1]?.control_after_generate &&
       (widget.type === 'number' || widget.type === 'combo')
     ) {
-      const configuredControlValue = configuredWidgetValues?.[1]
-      const control_value =
-        typeof configuredControlValue === 'string'
-          ? configuredControlValue
-          : 'fixed'
-      addValueControlWidgets(this, widget, control_value, undefined, inputData)
+      addValueControlWidgets(this, widget, 'fixed', undefined, inputData)
       if (this.widgets?.[1]) widget.linkedWidgets = [this.widgets[1]]
-
-      const filter = configuredWidgetValues?.[2]
-      if (filter !== undefined && this.widgets?.length === 3) {
-        this.widgets[2].value = filter
-      }
     }
+
+    configuredWidgetValues?.slice(1).forEach((value, index) => {
+      const controlWidget = this.widgets?.[index + 1]
+      if (controlWidget && typeof value === 'string') {
+        controlWidget.value = value
+      }
+    })
 
     // Restore any saved control values
     const controlValues = this.controlValues
@@ -321,7 +325,7 @@ export class PrimitiveNode extends LGraphNode {
       }
     }
 
-    if (!recreating) this.configuredWidgetValues = undefined
+    if (configuredWidgetValues) this.configuredWidgetValues = undefined
     this._finalizeWidget(widget, oldWidth, oldHeight, recreating)
   }
 

--- a/src/lib/litegraph/src/LGraphNode.ts
+++ b/src/lib/litegraph/src/LGraphNode.ts
@@ -183,6 +183,30 @@ function serialiseWidgetValues(widgets: IBaseWidget[]) {
   return { widgets_values: positional, widgets_values_named: named }
 }
 
+export function createWidgetRestorationState(
+  info: Pick<ISerialisedNode, 'widgets_values' | 'widgets_values_named'>,
+  fallbackNames?: readonly string[]
+) {
+  const positional = Array.from(info.widgets_values ?? [])
+  const named =
+    info.widgets_values_named ??
+    (info.widgets_values && fallbackNames
+      ? Object.fromEntries(
+          positional.flatMap((value, index) =>
+            fallbackNames[index] ? [[fallbackNames[index], value]] : []
+          )
+        )
+      : undefined)
+
+  return {
+    positional,
+    named: named ? { ...named } : undefined,
+    restoreNamed: Boolean(
+      named && (LiteGraph.namedValuesRestore || fallbackNames)
+    )
+  }
+}
+
 interface ConnectByTypeOptions {
   /** @deprecated Events */
   createEventInCase?: boolean
@@ -1127,28 +1151,18 @@ export class LGraphNode
     // SubgraphNode callback.
     this._internalConfigureAfterSlots?.()
 
-    const positionalValues = Array.from(info.widgets_values ?? [])
-    const getNamedValues = () => {
-      if (info.widgets_values_named) return info.widgets_values_named
-
-      const map = this.constructor.nodeData?.fallbackWidgetsValuesNames
-      if (!info.widgets_values || !map) return
-
-      return Object.fromEntries(
-        positionalValues.flatMap((v, i) => (map[i] ? [[map[i], v]] : []))
-      )
-    }
-    const namedValues = getNamedValues()
-    const graphId = this.graph?.rootGraph.id ?? zeroUuid
-    const shouldRestoreNamed =
-      LiteGraph.namedValuesRestore ||
+    const restoration = createWidgetRestorationState(
+      info,
       this.constructor.nodeData?.fallbackWidgetsValuesNames
+    )
+    const namedValues = restoration.named
+    const graphId = this.graph?.rootGraph.id ?? zeroUuid
     try {
-      useWidgetValueStore().setNodeWidgetRestoration(graphId, this.id, {
-        positional: positionalValues,
-        named: namedValues ? { ...namedValues } : undefined,
-        restoreNamed: Boolean(namedValues && shouldRestoreNamed)
-      })
+      useWidgetValueStore().setNodeWidgetRestoration(
+        graphId,
+        this.id,
+        restoration
+      )
 
       if (this.widgets) {
         for (const w of this.widgets) {
@@ -1202,14 +1216,8 @@ export class LGraphNode
         )
       }
     } finally {
-      if (!this.deferWidgetRestorationAfterConfigure()) {
-        useWidgetValueStore().clearNodeWidgetRestoration(graphId, this.id)
-      }
+      useWidgetValueStore().clearNodeWidgetRestoration(graphId, this.id)
     }
-  }
-
-  protected deferWidgetRestorationAfterConfigure(): boolean {
-    return false
   }
 
   /**

--- a/src/lib/litegraph/src/LGraphNode.ts
+++ b/src/lib/litegraph/src/LGraphNode.ts
@@ -1202,8 +1202,14 @@ export class LGraphNode
         )
       }
     } finally {
-      useWidgetValueStore().clearNodeWidgetRestoration(graphId, this.id)
+      if (!this.deferWidgetRestorationAfterConfigure()) {
+        useWidgetValueStore().clearNodeWidgetRestoration(graphId, this.id)
+      }
     }
+  }
+
+  protected deferWidgetRestorationAfterConfigure(): boolean {
+    return false
   }
 
   /**

--- a/src/stores/widgetValueStore.test.ts
+++ b/src/stores/widgetValueStore.test.ts
@@ -530,57 +530,6 @@ describe('useWidgetValueStore', () => {
     })
   })
 
-  describe('primitive widget restoration', () => {
-    const nodeId = toNodeId('node-1')
-
-    it('stores, returns and clears pending primitive values per graph', () => {
-      const store = useWidgetValueStore()
-      store.setPrimitiveWidgetRestoration(graphA, nodeId, {
-        type: 'INT',
-        values: [7, 'fixed']
-      })
-
-      expect(store.getPrimitiveWidgetRestoration(graphA, nodeId)).toEqual({
-        type: 'INT',
-        values: [7, 'fixed']
-      })
-      expect(
-        store.getPrimitiveWidgetRestoration(graphB, nodeId)
-      ).toBeUndefined()
-      expect(
-        store.getPrimitiveWidgetRestoration(graphA, toNodeId('node-2'))
-      ).toBeUndefined()
-
-      store.clearPrimitiveWidgetRestoration(graphA, nodeId)
-
-      expect(
-        store.getPrimitiveWidgetRestoration(graphA, nodeId)
-      ).toBeUndefined()
-    })
-
-    it('drops pending primitive values with the node and with the graph', () => {
-      const store = useWidgetValueStore()
-      store.setPrimitiveWidgetRestoration(graphA, nodeId, {
-        type: 'INT',
-        values: [7]
-      })
-      store.setPrimitiveWidgetRestoration(graphB, nodeId, {
-        type: 'INT',
-        values: [8]
-      })
-
-      store.clearNode(graphA, nodeId)
-      store.clearGraph(graphB)
-
-      expect(
-        store.getPrimitiveWidgetRestoration(graphA, nodeId)
-      ).toBeUndefined()
-      expect(
-        store.getPrimitiveWidgetRestoration(graphB, nodeId)
-      ).toBeUndefined()
-    })
-  })
-
   describe('un-keyable widget ids', () => {
     // A custom node can register a widget with an empty/malformed name (spacer,
     // header, preview, button). Such an id cannot be keyed; the store must

--- a/src/stores/widgetValueStore.test.ts
+++ b/src/stores/widgetValueStore.test.ts
@@ -530,6 +530,54 @@ describe('useWidgetValueStore', () => {
     })
   })
 
+  describe('primitive widget restoration', () => {
+    const nodeId = toNodeId('node-1')
+
+    it('stores, returns and clears pending primitive values per graph', () => {
+      const store = useWidgetValueStore()
+      store.setPrimitiveWidgetRestoration(graphA, nodeId, {
+        type: 'INT',
+        values: [7, 'fixed']
+      })
+
+      expect(store.getPrimitiveWidgetRestoration(graphA, nodeId)).toEqual({
+        type: 'INT',
+        values: [7, 'fixed']
+      })
+      expect(
+        store.getPrimitiveWidgetRestoration(graphB, nodeId)
+      ).toBeUndefined()
+
+      store.clearPrimitiveWidgetRestoration(graphA, nodeId)
+
+      expect(
+        store.getPrimitiveWidgetRestoration(graphA, nodeId)
+      ).toBeUndefined()
+    })
+
+    it('drops pending primitive values with the node and with the graph', () => {
+      const store = useWidgetValueStore()
+      store.setPrimitiveWidgetRestoration(graphA, nodeId, {
+        type: 'INT',
+        values: [7]
+      })
+      store.setPrimitiveWidgetRestoration(graphB, nodeId, {
+        type: 'INT',
+        values: [8]
+      })
+
+      store.clearNode(graphA, nodeId)
+      store.clearGraph(graphB)
+
+      expect(
+        store.getPrimitiveWidgetRestoration(graphA, nodeId)
+      ).toBeUndefined()
+      expect(
+        store.getPrimitiveWidgetRestoration(graphB, nodeId)
+      ).toBeUndefined()
+    })
+  })
+
   describe('un-keyable widget ids', () => {
     // A custom node can register a widget with an empty/malformed name (spacer,
     // header, preview, button). Such an id cannot be keyed; the store must

--- a/src/stores/widgetValueStore.test.ts
+++ b/src/stores/widgetValueStore.test.ts
@@ -547,6 +547,9 @@ describe('useWidgetValueStore', () => {
       expect(
         store.getPrimitiveWidgetRestoration(graphB, nodeId)
       ).toBeUndefined()
+      expect(
+        store.getPrimitiveWidgetRestoration(graphA, toNodeId('node-2'))
+      ).toBeUndefined()
 
       store.clearPrimitiveWidgetRestoration(graphA, nodeId)
 

--- a/src/stores/widgetValueStore.ts
+++ b/src/stores/widgetValueStore.ts
@@ -35,6 +35,11 @@ interface WidgetValueChange {
   context?: RemoteMutationContext
 }
 
+interface PrimitiveWidgetRestorationState {
+  type: string
+  values: readonly WidgetValue[]
+}
+
 export function stripGraphPrefix(scopedId: SerializedNodeId): NodeId | null {
   return parseNodeId(String(scopedId).replace(/^(.*:)+/, ''))
 }
@@ -85,6 +90,10 @@ export const useWidgetValueStore = defineStore('widgetValue', () => {
     valueChangeListeners.add(listener)
     return () => valueChangeListeners.delete(listener)
   }
+  const graphPrimitiveWidgetRestorations = new Map<
+    UUID,
+    Map<NodeId, PrimitiveWidgetRestorationState>
+  >()
 
   function setNodeWidgetRestoration(
     graphId: UUID,
@@ -122,6 +131,38 @@ export const useWidgetValueStore = defineStore('widgetValue', () => {
     if (!restorations) return
     restorations.delete(nodeId)
     if (restorations.size === 0) graphWidgetRestorations.delete(graphId)
+  }
+
+  function setPrimitiveWidgetRestoration(
+    graphId: UUID,
+    nodeId: NodeId,
+    restoration: PrimitiveWidgetRestorationState
+  ): void {
+    let graphRestorations = graphPrimitiveWidgetRestorations.get(graphId)
+    if (!graphRestorations) {
+      graphRestorations = new Map()
+      graphPrimitiveWidgetRestorations.set(graphId, graphRestorations)
+    }
+    graphRestorations.set(nodeId, restoration)
+  }
+
+  function getPrimitiveWidgetRestoration(
+    graphId: UUID,
+    nodeId: NodeId
+  ): PrimitiveWidgetRestorationState | undefined {
+    return graphPrimitiveWidgetRestorations.get(graphId)?.get(nodeId)
+  }
+
+  function clearPrimitiveWidgetRestoration(
+    graphId: UUID,
+    nodeId: NodeId
+  ): void {
+    const restorations = graphPrimitiveWidgetRestorations.get(graphId)
+    if (!restorations) return
+    restorations.delete(nodeId)
+    if (restorations.size === 0) {
+      graphPrimitiveWidgetRestorations.delete(graphId)
+    }
   }
 
   function getGraphWidgetStates(graphId: UUID): Map<WidgetId, WidgetState> {
@@ -456,6 +497,7 @@ export const useWidgetValueStore = defineStore('widgetValue', () => {
     _context?: RemoteMutationContext
   ): void {
     graphWidgetRestorations.get(graphId)?.delete(nodeId)
+    graphPrimitiveWidgetRestorations.get(graphId)?.delete(nodeId)
     const widgetStates = graphWidgetStates.value.get(graphId)
     const widgetRenderStates = graphWidgetRenderStates.value.get(graphId)
     if (widgetStates) {
@@ -480,6 +522,7 @@ export const useWidgetValueStore = defineStore('widgetValue', () => {
     graphWidgetRenderStates.value.delete(graphId)
     graphNodeWidgetOrders.value.delete(graphId)
     graphWidgetRestorations.delete(graphId)
+    graphPrimitiveWidgetRestorations.delete(graphId)
   }
 
   return {
@@ -487,6 +530,9 @@ export const useWidgetValueStore = defineStore('widgetValue', () => {
     setNodeWidgetRestoration,
     clearNodeWidgetRestoration,
     getRestoredWidgetValue,
+    setPrimitiveWidgetRestoration,
+    getPrimitiveWidgetRestoration,
+    clearPrimitiveWidgetRestoration,
     getWidget,
     getWidgetRenderState,
     onValueChange,

--- a/src/stores/widgetValueStore.ts
+++ b/src/stores/widgetValueStore.ts
@@ -35,16 +35,6 @@ interface WidgetValueChange {
   context?: RemoteMutationContext
 }
 
-/**
- * Serialized widget values of a PrimitiveNode whose widget is only rebuilt
- * once its output link resolves, which happens after the node's own
- * `configure` finishes and the regular restoration state has been cleared.
- */
-export interface PrimitiveWidgetRestorationState {
-  type: string
-  values: readonly WidgetValue[]
-}
-
 function setNodeScoped<T>(
   graphMap: Map<UUID, Map<NodeId, T>>,
   graphId: UUID,
@@ -84,6 +74,7 @@ export const useWidgetValueStore = defineStore('widgetValue', () => {
     UUID,
     Map<NodeId, WidgetRestorationState>
   >()
+
   const valueChangeListeners = new Set<(change: WidgetValueChange) => void>()
   const valueMutationContexts = new WeakMap<
     WidgetState,
@@ -120,10 +111,6 @@ export const useWidgetValueStore = defineStore('widgetValue', () => {
     valueChangeListeners.add(listener)
     return () => valueChangeListeners.delete(listener)
   }
-  const graphPrimitiveWidgetRestorations = new Map<
-    UUID,
-    Map<NodeId, PrimitiveWidgetRestorationState>
-  >()
 
   function setNodeWidgetRestoration(
     graphId: UUID,
@@ -153,33 +140,6 @@ export const useWidgetValueStore = defineStore('widgetValue', () => {
 
   function clearNodeWidgetRestoration(graphId: UUID, nodeId: NodeId): void {
     clearNodeScoped(graphWidgetRestorations, graphId, nodeId)
-  }
-
-  function setPrimitiveWidgetRestoration(
-    graphId: UUID,
-    nodeId: NodeId,
-    restoration: PrimitiveWidgetRestorationState
-  ): void {
-    setNodeScoped(
-      graphPrimitiveWidgetRestorations,
-      graphId,
-      nodeId,
-      restoration
-    )
-  }
-
-  function getPrimitiveWidgetRestoration(
-    graphId: UUID,
-    nodeId: NodeId
-  ): PrimitiveWidgetRestorationState | undefined {
-    return graphPrimitiveWidgetRestorations.get(graphId)?.get(nodeId)
-  }
-
-  function clearPrimitiveWidgetRestoration(
-    graphId: UUID,
-    nodeId: NodeId
-  ): void {
-    clearNodeScoped(graphPrimitiveWidgetRestorations, graphId, nodeId)
   }
 
   function getGraphWidgetStates(graphId: UUID): Map<WidgetId, WidgetState> {
@@ -514,7 +474,6 @@ export const useWidgetValueStore = defineStore('widgetValue', () => {
     _context?: RemoteMutationContext
   ): void {
     graphWidgetRestorations.get(graphId)?.delete(nodeId)
-    graphPrimitiveWidgetRestorations.get(graphId)?.delete(nodeId)
     const widgetStates = graphWidgetStates.value.get(graphId)
     const widgetRenderStates = graphWidgetRenderStates.value.get(graphId)
     if (widgetStates) {
@@ -539,7 +498,6 @@ export const useWidgetValueStore = defineStore('widgetValue', () => {
     graphWidgetRenderStates.value.delete(graphId)
     graphNodeWidgetOrders.value.delete(graphId)
     graphWidgetRestorations.delete(graphId)
-    graphPrimitiveWidgetRestorations.delete(graphId)
   }
 
   return {
@@ -547,9 +505,6 @@ export const useWidgetValueStore = defineStore('widgetValue', () => {
     setNodeWidgetRestoration,
     clearNodeWidgetRestoration,
     getRestoredWidgetValue,
-    setPrimitiveWidgetRestoration,
-    getPrimitiveWidgetRestoration,
-    clearPrimitiveWidgetRestoration,
     getWidget,
     getWidgetRenderState,
     onValueChange,

--- a/src/stores/widgetValueStore.ts
+++ b/src/stores/widgetValueStore.ts
@@ -124,16 +124,6 @@ export const useWidgetValueStore = defineStore('widgetValue', () => {
     if (restorations.size === 0) graphWidgetRestorations.delete(graphId)
   }
 
-  function getPositionalRestoredWidgetValue(
-    graphId: UUID,
-    nodeId: NodeId,
-    positionalIndex: number
-  ): WidgetValue | undefined {
-    return graphWidgetRestorations.get(graphId)?.get(nodeId)?.positional[
-      positionalIndex
-    ]
-  }
-
   function getGraphWidgetStates(graphId: UUID): Map<WidgetId, WidgetState> {
     const widgetStates = graphWidgetStates.value.get(graphId)
     if (widgetStates) return widgetStates
@@ -497,7 +487,6 @@ export const useWidgetValueStore = defineStore('widgetValue', () => {
     setNodeWidgetRestoration,
     clearNodeWidgetRestoration,
     getRestoredWidgetValue,
-    getPositionalRestoredWidgetValue,
     getWidget,
     getWidgetRenderState,
     onValueChange,

--- a/src/stores/widgetValueStore.ts
+++ b/src/stores/widgetValueStore.ts
@@ -35,9 +35,39 @@ interface WidgetValueChange {
   context?: RemoteMutationContext
 }
 
-interface PrimitiveWidgetRestorationState {
+/**
+ * Serialized widget values of a PrimitiveNode whose widget is only rebuilt
+ * once its output link resolves, which happens after the node's own
+ * `configure` finishes and the regular restoration state has been cleared.
+ */
+export interface PrimitiveWidgetRestorationState {
   type: string
   values: readonly WidgetValue[]
+}
+
+function setNodeScoped<T>(
+  graphMap: Map<UUID, Map<NodeId, T>>,
+  graphId: UUID,
+  nodeId: NodeId,
+  value: T
+): void {
+  let nodeMap = graphMap.get(graphId)
+  if (!nodeMap) {
+    nodeMap = new Map()
+    graphMap.set(graphId, nodeMap)
+  }
+  nodeMap.set(nodeId, value)
+}
+
+function clearNodeScoped<T>(
+  graphMap: Map<UUID, Map<NodeId, T>>,
+  graphId: UUID,
+  nodeId: NodeId
+): void {
+  const nodeMap = graphMap.get(graphId)
+  if (!nodeMap) return
+  nodeMap.delete(nodeId)
+  if (nodeMap.size === 0) graphMap.delete(graphId)
 }
 
 export function stripGraphPrefix(scopedId: SerializedNodeId): NodeId | null {
@@ -100,12 +130,7 @@ export const useWidgetValueStore = defineStore('widgetValue', () => {
     nodeId: NodeId,
     restoration: WidgetRestorationState
   ): void {
-    let graphRestorations = graphWidgetRestorations.get(graphId)
-    if (!graphRestorations) {
-      graphRestorations = new Map()
-      graphWidgetRestorations.set(graphId, graphRestorations)
-    }
-    graphRestorations.set(nodeId, restoration)
+    setNodeScoped(graphWidgetRestorations, graphId, nodeId, restoration)
   }
 
   function getRestoredWidgetValue(
@@ -127,10 +152,7 @@ export const useWidgetValueStore = defineStore('widgetValue', () => {
   }
 
   function clearNodeWidgetRestoration(graphId: UUID, nodeId: NodeId): void {
-    const restorations = graphWidgetRestorations.get(graphId)
-    if (!restorations) return
-    restorations.delete(nodeId)
-    if (restorations.size === 0) graphWidgetRestorations.delete(graphId)
+    clearNodeScoped(graphWidgetRestorations, graphId, nodeId)
   }
 
   function setPrimitiveWidgetRestoration(
@@ -138,12 +160,12 @@ export const useWidgetValueStore = defineStore('widgetValue', () => {
     nodeId: NodeId,
     restoration: PrimitiveWidgetRestorationState
   ): void {
-    let graphRestorations = graphPrimitiveWidgetRestorations.get(graphId)
-    if (!graphRestorations) {
-      graphRestorations = new Map()
-      graphPrimitiveWidgetRestorations.set(graphId, graphRestorations)
-    }
-    graphRestorations.set(nodeId, restoration)
+    setNodeScoped(
+      graphPrimitiveWidgetRestorations,
+      graphId,
+      nodeId,
+      restoration
+    )
   }
 
   function getPrimitiveWidgetRestoration(
@@ -157,12 +179,7 @@ export const useWidgetValueStore = defineStore('widgetValue', () => {
     graphId: UUID,
     nodeId: NodeId
   ): void {
-    const restorations = graphPrimitiveWidgetRestorations.get(graphId)
-    if (!restorations) return
-    restorations.delete(nodeId)
-    if (restorations.size === 0) {
-      graphPrimitiveWidgetRestorations.delete(graphId)
-    }
+    clearNodeScoped(graphPrimitiveWidgetRestorations, graphId, nodeId)
   }
 
   function getGraphWidgetStates(graphId: UUID): Map<WidgetId, WidgetState> {


### PR DESCRIPTION
PrimitiveNode now keeps its serialized widget value and control mode after reload.
Regression coverage reproduces the stale-target overwrite, the reroute path, and a cross-type leak.

<details><summary>Full context for agent readers</summary>

## Summary

Workflow loading creates a PrimitiveNode widget after node configuration, so the target widget copy overwrote the primitive's serialized value. The control widget had the same symptom from a different cause: the restore read `widgetValueStore`, which `LGraphNode.configure` clears in its own `finally` before `_createWidget` ever runs, so `control_after_generate` always fell back to `fixed`.

## Changes

- Capture the serialized `widgets_values` and output type in `onConfigure`, chaining to `super` so handlers installed on `LGraphNode.prototype` still run.
- Reapply index 0 after the target widget copy, including the asset-widget path, and consume the capture once the widget is built rather than on a lifecycle callback that several creation paths skip.
- Bind the capture to the serialized output type, so a value cannot land on a widget of a different type and reach the backend through `applyToGraph`.
- Restore the serialized control and filter values after widget creation. This covers both the `addValueControlWidgets` fallback and inputs that declare `control_after_generate`, which build their own control widget. Only values the control widget offers are written back.
- Normalise `widgets_values` through `Array.from` the way base `configure` does, since custom nodes are documented to replace it with an array-like object.
- Treat `recreateWidget` with no existing widgets as a first build. That is the only widget-creation path a Primitive feeding a Reroute has.
- Remove `getPositionalRestoredWidgetValue`, which had no reachable caller left.

## Verification

- `widgetInputs.test.ts`: 32 passed. Every new test was run against the pre-fix code first and fails there.
- `pnpm typecheck`, `pnpm knip`, `pnpm lint` (0 errors): passed.
- CI green at `ab37448da5`.

## Open question for review

Restoration state lives on the `PrimitiveNode` instance rather than in `widgetValueStore`, which ADR 0003/0008 would prefer. The store mechanism could not work as written, because `LGraphNode.configure` clears the restoration entry before the primitive builds its widget. This needs a call: accept the instance field, or widen the restoration lifetime in the store and put it back there.

Known gaps left out of scope: `widgets_values_named` is ignored when `LiteGraph.namedValuesRestore` is enabled, and a restored value is not range-checked against the rebuilt widget.

Checklist item: https://github.com/Comfy-Org/ComfyUI_frontend/issues/15973
Original review: https://github.com/Comfy-Org/ComfyUI_frontend/pull/15924#discussion_r3858723875

Fixes #16007

</details>
