### PR TITLE
ci(pr-risk): use named risk labels

### DIFF
--- a/.github/workflows/ci-pr-risk.yml
+++ b/.github/workflows/ci-pr-risk.yml
@@ -1,9 +1,9 @@
 name: CI - PR Risk Grade
 
 # Thin caller for the shared ADVISORY PR risk grader (shadow check). Grades
-# every PR R0 (safest) .. R3 (riskiest) against .github/risk.json (read from
-# the BASE ref) and syncs exactly one `risk:*` label — nothing gates, routes,
-# or merges on it. Disagree with a grade by adding the human-owned
+# every PR against .github/risk.json (read from the BASE ref) and syncs exactly
+# one `risk:low` .. `risk:xhigh` label — nothing gates, routes, or merges on it.
+# Disagree with a grade by adding the human-owned
 # `risk-dispute` label plus a comment saying why.
 
 on:
@@ -61,5 +61,6 @@ jobs:
       # RISK_CONFIG outranks this in both directions ({"enabled": false} is a
       # kill switch that needs no PR).
       enabled: true
+      label_map: 'R0=risk:low,R1=risk:medium,R2=risk:high,R3=risk:xhigh,unknown=risk:unknown'
       pr_number: ${{ inputs.pr_number }}
       pr_numbers: ${{ inputs.pr_numbers }}


### PR DESCRIPTION
Summary:
- map the existing R0–R3 grader tiers to `risk:low`, `risk:medium`, `risk:high`, and `risk:xhigh`
- map an unreadable grade to `risk:unknown`
- keep every grading rule unchanged

Rollout after merge:
- regrade open PRs so each receives its named label
- delete the retired `risk:R0`–`risk:R3` and `risk:ungraded` repository labels; the current shared labeler does not own labels from the old map

Validation:
- parsed `ci-pr-risk.yml` as YAML
- verified all five mappings with the shared labeler dry-run