### PR TITLE
test: reuse widget keys in enumerability assertions

### DIFF
--- a/src/lib/litegraph/src/widgets/BaseWidget.test.ts
+++ b/src/lib/litegraph/src/widgets/BaseWidget.test.ts
@@ -72,8 +72,9 @@ describe('BaseWidget store integration', () => {
   it('preserves name in keys, spread copies, and JSON', () => {
     const widget = createTestWidget(node, { name: 'custom-name' })
 
-    expect(Object.keys(widget)).toContain('_name')
-    expect(Object.keys(widget)).not.toContain('name')
+    const widgetKeys = Object.keys(widget)
+    expect(widgetKeys).toContain('_name')
+    expect(widgetKeys).not.toContain('name')
     expect({ ...widget }).toMatchObject({ _name: 'custom-name' })
     expect(JSON.parse(JSON.stringify(widget))).toMatchObject({
       _name: 'custom-name'


### PR DESCRIPTION
Reuses one key snapshot for both enumerability assertions.
Tests-only follow-up to reviewer feedback.

<details><summary>Full context for agent readers</summary>

## Summary

Caches `Object.keys(widget)` once so the `_name` and `name` enumerability assertions inspect the same snapshot.

## Changes

- Completes the [`BaseWidget.name` enumerability test item](https://github.com/Comfy-Org/ComfyUI_frontend/issues/15973) from the coverage burn-down.
- Applies the [reviewer's exact follow-up suggestion](https://github.com/Comfy-Org/ComfyUI_frontend/pull/16454#discussion_r3900523012).
- Changes tests only; runtime behavior is unchanged.

## Validation

- `pnpm test:unit src/lib/litegraph/src/widgets/BaseWidget.test.ts` — 18 passed
- `pnpm exec oxfmt --check src/lib/litegraph/src/widgets/BaseWidget.test.ts` — passed
- Commit hooks: formatting, type-aware oxlint, ESLint, and typecheck passed
- Push hook: knip passed

</details>

<!-- authored-by:agent -->