### PR TITLE
fix(test-recorder): stop custom backends sharing one storage-state file

### DIFF
--- a/tools/test-recorder/src/recorder/runner.test.ts
+++ b/tools/test-recorder/src/recorder/runner.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type * as TemplateModule from './template'
+
+const {
+  cleanupRecordedCode,
+  cleanupRecordingTemplate,
+  ensureStorageStateDir,
+  generateRecordingTemplate,
+  removeLegacyCustomStorageState,
+  runCommand,
+  storageStatePath
+} = vi.hoisted(() => ({
+  cleanupRecordedCode: vi.fn(),
+  cleanupRecordingTemplate: vi.fn(),
+  ensureStorageStateDir: vi.fn(),
+  generateRecordingTemplate: vi.fn(),
+  removeLegacyCustomStorageState: vi.fn(),
+  runCommand: vi.fn(() => ({ status: 1 })),
+  storageStatePath: vi.fn((key: string) => `/state/storage-state.${key}.json`)
+}))
+
+vi.mock('./template', async (importOriginal) => ({
+  ...(await importOriginal<typeof TemplateModule>()),
+  cleanupRecordedCode,
+  cleanupRecordingTemplate,
+  ensureStorageStateDir,
+  generateRecordingTemplate,
+  recordedCodePath: vi.fn(() => '/missing-recorded-code'),
+  removeLegacyCustomStorageState,
+  storageStatePath
+}))
+vi.mock('../checks/devServerUrl', () => ({
+  devServerUrl: vi.fn(() => 'http://localhost:5173')
+}))
+vi.mock('../cli/run', () => ({ runCommand }))
+vi.mock('../featureFlags', () => ({
+  buildFfQuery: vi.fn(() => '')
+}))
+vi.mock('../ui/logger', () => ({ box: vi.fn(), info: vi.fn() }))
+
+import { runRecording } from './runner'
+
+beforeEach(() => {
+  vi.spyOn(console, 'log').mockImplementation(() => {})
+})
+
+describe('runRecording', () => {
+  it('removes the shared legacy state before recording a custom backend', async () => {
+    await runRecording({
+      testName: 'custom backend',
+      projectRoot: '/project',
+      distribution: {
+        id: 'custom',
+        label: 'Custom backend',
+        hint: '',
+        script: 'dev',
+        needsLocalBackend: false,
+        backendUrl: 'http://localhost:8100/'
+      }
+    })
+
+    expect(removeLegacyCustomStorageState).toHaveBeenCalledOnce()
+    expect(removeLegacyCustomStorageState).toHaveBeenCalledWith(
+      '/state/storage-state.custom-http%3A%2F%2Flocalhost%3A8100.json'
+    )
+  })
+})

--- a/tools/test-recorder/src/recorder/runner.test.ts
+++ b/tools/test-recorder/src/recorder/runner.test.ts
@@ -39,6 +39,7 @@ vi.mock('../featureFlags', () => ({
 }))
 vi.mock('../ui/logger', () => ({ box: vi.fn(), info: vi.fn() }))
 
+import { storageStateKey } from './template'
 import { runRecording } from './runner'
 
 beforeEach(() => {
@@ -47,22 +48,24 @@ beforeEach(() => {
 
 describe('runRecording', () => {
   it('removes the shared legacy state before recording a custom backend', async () => {
+    const distribution = {
+      id: 'custom',
+      label: 'Custom backend',
+      hint: '',
+      script: 'dev',
+      needsLocalBackend: false,
+      backendUrl: 'http://localhost:8100/'
+    } as const
+
     await runRecording({
       testName: 'custom backend',
       projectRoot: '/project',
-      distribution: {
-        id: 'custom',
-        label: 'Custom backend',
-        hint: '',
-        script: 'dev',
-        needsLocalBackend: false,
-        backendUrl: 'http://localhost:8100/'
-      }
+      distribution
     })
 
     expect(removeLegacyCustomStorageState).toHaveBeenCalledOnce()
     expect(removeLegacyCustomStorageState).toHaveBeenCalledWith(
-      '/state/storage-state.custom-http%3A%2F%2Flocalhost%3A8100.json'
+      `/state/storage-state.${storageStateKey(distribution)}.json`
     )
   })
 })

--- a/tools/test-recorder/src/recorder/runner.test.ts
+++ b/tools/test-recorder/src/recorder/runner.test.ts
@@ -1,45 +1,58 @@
+import type { SpawnSyncReturns } from 'node:child_process'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-
-import type * as TemplateModule from './template'
 
 const {
   cleanupRecordedCode,
   cleanupRecordingTemplate,
   ensureStorageStateDir,
   generateRecordingTemplate,
+  recordingTarget,
   removeLegacyCustomStorageState,
   runCommand,
+  storageStateKey,
   storageStatePath
 } = vi.hoisted(() => ({
   cleanupRecordedCode: vi.fn(),
   cleanupRecordingTemplate: vi.fn(),
   ensureStorageStateDir: vi.fn(),
   generateRecordingTemplate: vi.fn(),
+  recordingTarget: vi.fn((): 'cloud' => 'cloud'),
   removeLegacyCustomStorageState: vi.fn(),
-  runCommand: vi.fn(() => ({ status: 1 })),
+  runCommand: vi.fn(
+    (): SpawnSyncReturns<Buffer> => ({
+      pid: 1,
+      output: [],
+      stdout: Buffer.alloc(0),
+      stderr: Buffer.alloc(0),
+      status: 1,
+      signal: null
+    })
+  ),
+  storageStateKey: vi.fn(() => 'custom-key'),
   storageStatePath: vi.fn((key: string) => `/state/storage-state.${key}.json`)
 }))
 
-vi.mock('./template', async (importOriginal) => ({
-  ...(await importOriginal<typeof TemplateModule>()),
+vi.mock(import('./template'), () => ({
+  RECORDING_SPEC_BASENAME: '_recording-session' as const,
   cleanupRecordedCode,
   cleanupRecordingTemplate,
   ensureStorageStateDir,
   generateRecordingTemplate,
   recordedCodePath: vi.fn(() => '/missing-recorded-code'),
+  recordingTarget,
   removeLegacyCustomStorageState,
+  storageStateKey,
   storageStatePath
 }))
-vi.mock('../checks/devServerUrl', () => ({
+vi.mock(import('../checks/devServerUrl'), () => ({
   devServerUrl: vi.fn(() => 'http://localhost:5173')
 }))
-vi.mock('../cli/run', () => ({ runCommand }))
-vi.mock('../featureFlags', () => ({
+vi.mock(import('../cli/run'), () => ({ runCommand }))
+vi.mock(import('../featureFlags'), () => ({
   buildFfQuery: vi.fn(() => '')
 }))
-vi.mock('../ui/logger', () => ({ box: vi.fn(), info: vi.fn() }))
+vi.mock(import('../ui/logger'), () => ({ box: vi.fn(), info: vi.fn() }))
 
-import { storageStateKey } from './template'
 import { runRecording } from './runner'
 
 beforeEach(() => {
@@ -63,9 +76,17 @@ describe('runRecording', () => {
       distribution
     })
 
+    const storageStateFile = '/state/storage-state.custom-key.json'
+    expect(storageStateKey).toHaveBeenCalledWith(distribution)
+    expect(storageStatePath).toHaveBeenCalledWith('custom-key')
     expect(removeLegacyCustomStorageState).toHaveBeenCalledOnce()
     expect(removeLegacyCustomStorageState).toHaveBeenCalledWith(
-      `/state/storage-state.${storageStateKey(distribution)}.json`
+      storageStateFile
+    )
+    expect(ensureStorageStateDir).toHaveBeenCalledWith(storageStateFile)
+    expect(generateRecordingTemplate).toHaveBeenCalledWith(
+      expect.objectContaining({ storageStateFile }),
+      '/project/browser_tests'
     )
   })
 })

--- a/tools/test-recorder/src/recorder/runner.ts
+++ b/tools/test-recorder/src/recorder/runner.ts
@@ -9,6 +9,7 @@ import {
   generateRecordingTemplate,
   recordedCodePath,
   recordingTarget,
+  storageStateKey,
   storageStatePath
 } from './template'
 import { runCommand } from '../cli/run'
@@ -86,7 +87,7 @@ export async function runRecording(
 
   let storageStateFile: string | undefined
   if (target === 'cloud') {
-    storageStateFile = storageStatePath(options.distribution?.id ?? 'cloud')
+    storageStateFile = storageStatePath(storageStateKey(options.distribution))
     ensureStorageStateDir(storageStateFile)
   }
 

--- a/tools/test-recorder/src/recorder/runner.ts
+++ b/tools/test-recorder/src/recorder/runner.ts
@@ -9,6 +9,7 @@ import {
   generateRecordingTemplate,
   recordedCodePath,
   recordingTarget,
+  removeLegacyCustomStorageState,
   storageStateKey,
   storageStatePath
 } from './template'
@@ -88,6 +89,9 @@ export async function runRecording(
   let storageStateFile: string | undefined
   if (target === 'cloud') {
     storageStateFile = storageStatePath(storageStateKey(options.distribution))
+    if (options.distribution?.id === 'custom') {
+      removeLegacyCustomStorageState(storageStateFile)
+    }
     ensureStorageStateDir(storageStateFile)
   }
 

--- a/tools/test-recorder/src/recorder/template.test.ts
+++ b/tools/test-recorder/src/recorder/template.test.ts
@@ -15,6 +15,7 @@ import {
   generateRecordingTemplate,
   recordedCodePath,
   recordingTarget,
+  removeLegacyCustomStorageState,
   storageStateKey
 } from './template'
 
@@ -348,6 +349,17 @@ describe('recording template', () => {
           backendUrl: 'http://localhost:8200/'
         })
       ).toBe('custom-localhost-8200')
+    })
+
+    it('removes the legacy shared custom-backend storage state', () => {
+      const legacyStateFile = join(browserTestsDir, 'storage-state.custom.json')
+      writeFileSync(legacyStateFile, '{"cookies":[]}')
+
+      removeLegacyCustomStorageState(
+        join(browserTestsDir, 'storage-state.custom-localhost-8100.json')
+      )
+
+      expect(existsSync(legacyStateFile)).toBe(false)
     })
 
     it('falls back to a shared bucket if the custom backend URL cannot be parsed', () => {

--- a/tools/test-recorder/src/recorder/template.test.ts
+++ b/tools/test-recorder/src/recorder/template.test.ts
@@ -327,6 +327,29 @@ describe('recording template', () => {
       expect(keyA).not.toBe(keyB)
     })
 
+    it('keeps custom backends on different ports in separate buckets', () => {
+      const distribution = {
+        id: 'custom',
+        label: 'Custom backend',
+        hint: '',
+        script: 'dev',
+        needsLocalBackend: false
+      } as const
+
+      expect(
+        storageStateKey({
+          ...distribution,
+          backendUrl: 'http://localhost:8100/'
+        })
+      ).toBe('custom-localhost-8100')
+      expect(
+        storageStateKey({
+          ...distribution,
+          backendUrl: 'http://localhost:8200/'
+        })
+      ).toBe('custom-localhost-8200')
+    })
+
     it('falls back to a shared bucket if the custom backend URL cannot be parsed', () => {
       expect(
         storageStateKey({

--- a/tools/test-recorder/src/recorder/template.test.ts
+++ b/tools/test-recorder/src/recorder/template.test.ts
@@ -1,5 +1,6 @@
 import {
   existsSync,
+  mkdirSync,
   mkdtempSync,
   readFileSync,
   rmSync,
@@ -480,6 +481,19 @@ describe('recording template', () => {
 
       // Covers the guard's equal-path branch: removeLegacyCustomStorageState
       // must not delete the very file it was asked to load.
+      expect(existsSync(legacyStateFile)).toBe(true)
+    })
+
+    it('does not fail when the legacy storage state cannot be removed', () => {
+      const legacyStateFile = join(browserTestsDir, 'storage-state.custom.json')
+      mkdirSync(legacyStateFile)
+      writeFileSync(join(legacyStateFile, 'locked'), '')
+
+      expect(() =>
+        removeLegacyCustomStorageState(
+          join(browserTestsDir, 'storage-state.custom-0123456789abcdef.json')
+        )
+      ).not.toThrow()
       expect(existsSync(legacyStateFile)).toBe(true)
     })
 

--- a/tools/test-recorder/src/recorder/template.test.ts
+++ b/tools/test-recorder/src/recorder/template.test.ts
@@ -14,7 +14,8 @@ import {
   cleanupRecordingTemplate,
   generateRecordingTemplate,
   recordedCodePath,
-  recordingTarget
+  recordingTarget,
+  storageStateKey
 } from './template'
 
 describe('recording template', () => {
@@ -273,6 +274,70 @@ describe('recording template', () => {
 
     it('uses the bare-page template for cloud and custom backends', () => {
       expect(recordingTarget({ needsLocalBackend: false })).toBe('cloud')
+    })
+  })
+
+  describe('storageStateKey', () => {
+    it('defaults to cloud when no distribution is given', () => {
+      expect(storageStateKey(undefined)).toBe('cloud')
+    })
+
+    it('uses the fixed id for the three built-in cloud distributions', () => {
+      expect(
+        storageStateKey({
+          id: 'cloud',
+          label: 'Cloud',
+          hint: '',
+          script: 'dev:cloud',
+          needsLocalBackend: false,
+          backendUrl: 'https://testcloud.comfy.org/'
+        })
+      ).toBe('cloud')
+      expect(
+        storageStateKey({
+          id: 'cloud-staging',
+          label: 'Cloud staging',
+          hint: '',
+          script: 'dev:cloud:staging',
+          needsLocalBackend: false,
+          backendUrl: 'https://stagingcloud.comfy.org/'
+        })
+      ).toBe('cloud-staging')
+    })
+
+    it('keys a custom backend by its own hostname, not a shared "custom" bucket', () => {
+      const keyA = storageStateKey({
+        id: 'custom',
+        label: 'Custom backend (https://agent.comfy.org/)',
+        hint: 'https://agent.comfy.org/',
+        script: 'dev',
+        needsLocalBackend: false,
+        backendUrl: 'https://agent.comfy.org/'
+      })
+      const keyB = storageStateKey({
+        id: 'custom',
+        label: 'Custom backend (https://other-env.comfy.org/)',
+        hint: 'https://other-env.comfy.org/',
+        script: 'dev',
+        needsLocalBackend: false,
+        backendUrl: 'https://other-env.comfy.org/'
+      })
+      expect(keyA).toBe('custom-agent.comfy.org')
+      expect(keyB).toBe('custom-other-env.comfy.org')
+      expect(keyA).not.toBe(keyB)
+    })
+
+    it('falls back to a shared bucket if the custom backend URL cannot be parsed', () => {
+      expect(
+        storageStateKey({
+          id: 'custom',
+          label: 'Custom backend',
+          hint: '',
+          script: 'dev',
+          needsLocalBackend: false,
+          backendUrl: 'not a url'
+        })
+      ).toBe('custom')
     })
   })
 })

--- a/tools/test-recorder/src/recorder/template.test.ts
+++ b/tools/test-recorder/src/recorder/template.test.ts
@@ -328,6 +328,29 @@ describe('recording template', () => {
       expect(keyA).not.toBe(keyB)
     })
 
+    it('keeps HTTP and HTTPS custom backends in separate buckets', () => {
+      const distribution = {
+        id: 'custom',
+        label: 'Custom backend',
+        hint: '',
+        script: 'dev',
+        needsLocalBackend: false
+      } as const
+
+      expect(
+        storageStateKey({
+          ...distribution,
+          backendUrl: 'http://agent.comfy.org/'
+        })
+      ).toBe('custom-http%3A%2F%2Fagent.comfy.org')
+      expect(
+        storageStateKey({
+          ...distribution,
+          backendUrl: 'https://agent.comfy.org/'
+        })
+      ).toBe('custom-agent.comfy.org')
+    })
+
     it('keeps custom backends on different ports in separate buckets', () => {
       const distribution = {
         id: 'custom',
@@ -342,13 +365,13 @@ describe('recording template', () => {
           ...distribution,
           backendUrl: 'http://localhost:8100/'
         })
-      ).toBe('custom-localhost-8100')
+      ).toBe('custom-http%3A%2F%2Flocalhost-8100')
       expect(
         storageStateKey({
           ...distribution,
           backendUrl: 'http://localhost:8200/'
         })
-      ).toBe('custom-localhost-8200')
+      ).toBe('custom-http%3A%2F%2Flocalhost-8200')
     })
 
     it('encodes IPv6 hostnames for Windows-safe storage paths', () => {
@@ -361,7 +384,7 @@ describe('recording template', () => {
           needsLocalBackend: false,
           backendUrl: 'http://[::1]:8100/'
         })
-      ).toBe('custom-%5B%3A%3A1%5D-8100')
+      ).toBe('custom-http%3A%2F%2F%5B%3A%3A1%5D-8100')
     })
 
     it('removes the legacy shared custom-backend storage state', () => {

--- a/tools/test-recorder/src/recorder/template.test.ts
+++ b/tools/test-recorder/src/recorder/template.test.ts
@@ -365,13 +365,36 @@ describe('recording template', () => {
           ...distribution,
           backendUrl: 'http://localhost:8100/'
         })
-      ).toBe('custom-http%3A%2F%2Flocalhost-8100')
+      ).toBe('custom-http%3A%2F%2Flocalhost%3A8100')
       expect(
         storageStateKey({
           ...distribution,
           backendUrl: 'http://localhost:8200/'
         })
-      ).toBe('custom-http%3A%2F%2Flocalhost-8200')
+      ).toBe('custom-http%3A%2F%2Flocalhost%3A8200')
+    })
+
+    it('does not confuse hostname suffixes with port separators', () => {
+      const distribution = {
+        id: 'custom',
+        label: 'Custom backend',
+        hint: '',
+        script: 'dev',
+        needsLocalBackend: false
+      } as const
+
+      expect(
+        storageStateKey({
+          ...distribution,
+          backendUrl: 'https://example.com-8100/'
+        })
+      ).toBe('custom-example.com-8100')
+      expect(
+        storageStateKey({
+          ...distribution,
+          backendUrl: 'https://example.com:8100/'
+        })
+      ).toBe('custom-example.com%3A8100')
     })
 
     it('encodes IPv6 hostnames for Windows-safe storage paths', () => {
@@ -384,7 +407,7 @@ describe('recording template', () => {
           needsLocalBackend: false,
           backendUrl: 'http://[::1]:8100/'
         })
-      ).toBe('custom-http%3A%2F%2F%5B%3A%3A1%5D-8100')
+      ).toBe('custom-http%3A%2F%2F%5B%3A%3A1%5D%3A8100')
     })
 
     it('removes the legacy shared custom-backend storage state', () => {

--- a/tools/test-recorder/src/recorder/template.test.ts
+++ b/tools/test-recorder/src/recorder/template.test.ts
@@ -351,6 +351,19 @@ describe('recording template', () => {
       ).toBe('custom-localhost-8200')
     })
 
+    it('encodes IPv6 hostnames for Windows-safe storage paths', () => {
+      expect(
+        storageStateKey({
+          id: 'custom',
+          label: 'Custom backend',
+          hint: '',
+          script: 'dev',
+          needsLocalBackend: false,
+          backendUrl: 'http://[::1]:8100/'
+        })
+      ).toBe('custom-%5B%3A%3A1%5D-8100')
+    })
+
     it('removes the legacy shared custom-backend storage state', () => {
       const legacyStateFile = join(browserTestsDir, 'storage-state.custom.json')
       writeFileSync(legacyStateFile, '{"cookies":[]}')

--- a/tools/test-recorder/src/recorder/template.test.ts
+++ b/tools/test-recorder/src/recorder/template.test.ts
@@ -306,7 +306,7 @@ describe('recording template', () => {
       ).toBe('cloud-staging')
     })
 
-    it('keys a custom backend by its own hostname, not a shared "custom" bucket', () => {
+    it('keys a custom backend by a hash of its own origin, not a shared "custom" bucket', () => {
       const keyA = storageStateKey({
         id: 'custom',
         label: 'Custom backend (https://agent.comfy.org/)',
@@ -323,9 +323,20 @@ describe('recording template', () => {
         needsLocalBackend: false,
         backendUrl: 'https://other-env.comfy.org/'
       })
-      expect(keyA).toBe('custom-agent.comfy.org')
-      expect(keyB).toBe('custom-other-env.comfy.org')
+      expect(keyA).toMatch(/^custom-[0-9a-f]{16}$/)
+      expect(keyB).toMatch(/^custom-[0-9a-f]{16}$/)
       expect(keyA).not.toBe(keyB)
+      // Stable across calls, so the same backend always reuses its file.
+      expect(
+        storageStateKey({
+          id: 'custom',
+          label: '',
+          hint: '',
+          script: 'dev',
+          needsLocalBackend: false,
+          backendUrl: 'https://agent.comfy.org/'
+        })
+      ).toBe(keyA)
     })
 
     it('keeps HTTP and HTTPS custom backends in separate buckets', () => {
@@ -342,13 +353,12 @@ describe('recording template', () => {
           ...distribution,
           backendUrl: 'http://agent.comfy.org/'
         })
-      ).toBe('custom-http%3A%2F%2Fagent.comfy.org')
-      expect(
+      ).not.toBe(
         storageStateKey({
           ...distribution,
           backendUrl: 'https://agent.comfy.org/'
         })
-      ).toBe('custom-agent.comfy.org')
+      )
     })
 
     it('keeps custom backends on different ports in separate buckets', () => {
@@ -365,13 +375,38 @@ describe('recording template', () => {
           ...distribution,
           backendUrl: 'http://localhost:8100/'
         })
-      ).toBe('custom-http%3A%2F%2Flocalhost%3A8100')
-      expect(
+      ).not.toBe(
         storageStateKey({
           ...distribution,
           backendUrl: 'http://localhost:8200/'
         })
-      ).toBe('custom-http%3A%2F%2Flocalhost%3A8200')
+      )
+    })
+
+    it('keeps custom backends on different paths in separate buckets', () => {
+      // normalizeBackendUrl preserves path prefixes for path-routed backends
+      // (e.g. one gateway hosting several tenants); the key must too, or
+      // https://gw.example.com/tenant-a/ and .../tenant-b/ collapse into one
+      // storage-state file and replay each other's session.
+      const distribution = {
+        id: 'custom',
+        label: 'Custom backend',
+        hint: '',
+        script: 'dev',
+        needsLocalBackend: false
+      } as const
+
+      expect(
+        storageStateKey({
+          ...distribution,
+          backendUrl: 'https://gw.example.com/tenant-a/'
+        })
+      ).not.toBe(
+        storageStateKey({
+          ...distribution,
+          backendUrl: 'https://gw.example.com/tenant-b/'
+        })
+      )
     })
 
     it('does not confuse hostname suffixes with port separators', () => {
@@ -388,16 +423,15 @@ describe('recording template', () => {
           ...distribution,
           backendUrl: 'https://example.com-8100/'
         })
-      ).toBe('custom-example.com-8100')
-      expect(
+      ).not.toBe(
         storageStateKey({
           ...distribution,
           backendUrl: 'https://example.com:8100/'
         })
-      ).toBe('custom-example.com%3A8100')
+      )
     })
 
-    it('encodes IPv6 hostnames for Windows-safe storage paths', () => {
+    it('hashes IPv6 hostnames to a fixed-length, filesystem-safe key', () => {
       expect(
         storageStateKey({
           id: 'custom',
@@ -407,7 +441,24 @@ describe('recording template', () => {
           needsLocalBackend: false,
           backendUrl: 'http://[::1]:8100/'
         })
-      ).toBe('custom-http%3A%2F%2F%5B%3A%3A1%5D%3A8100')
+      ).toMatch(/^custom-[0-9a-f]{16}$/)
+    })
+
+    it('treats a scheme-less URL as unparseable rather than silently sharing a bucket', () => {
+      // new URL('localhost:8100') parses as a non-special 'localhost:'
+      // scheme with an empty hostname — the real host/port land in the
+      // discarded opaque path, so without a guard every scheme-less typo
+      // collapses into the same key.
+      expect(
+        storageStateKey({
+          id: 'custom',
+          label: 'Custom backend',
+          hint: '',
+          script: 'dev',
+          needsLocalBackend: false,
+          backendUrl: 'localhost:8100'
+        })
+      ).toBe('custom-unparsed')
     })
 
     it('removes the legacy shared custom-backend storage state', () => {
@@ -415,13 +466,29 @@ describe('recording template', () => {
       writeFileSync(legacyStateFile, '{"cookies":[]}')
 
       removeLegacyCustomStorageState(
-        join(browserTestsDir, 'storage-state.custom-localhost-8100.json')
+        join(browserTestsDir, 'storage-state.custom-0123456789abcdef.json')
       )
 
       expect(existsSync(legacyStateFile)).toBe(false)
     })
 
-    it('falls back to a shared bucket if the custom backend URL cannot be parsed', () => {
+    it('does not delete the legacy file when it is the resolved path itself', () => {
+      const legacyStateFile = join(browserTestsDir, 'storage-state.custom.json')
+      writeFileSync(legacyStateFile, '{"cookies":[]}')
+
+      removeLegacyCustomStorageState(legacyStateFile)
+
+      // Covers the guard's equal-path branch: removeLegacyCustomStorageState
+      // must not delete the very file it was asked to load.
+      expect(existsSync(legacyStateFile)).toBe(true)
+    })
+
+    it('falls back to a distinct sentinel if the custom backend URL cannot be parsed', () => {
+      // A bare 'custom' fallback resolves to the legacy shared storage-state
+      // file, so removeLegacyCustomStorageState's !== guard would skip the
+      // migration deletion and every unparseable backend would still share
+      // one bucket. The sentinel must differ from both 'custom' and any real
+      // hashed key.
       expect(
         storageStateKey({
           id: 'custom',
@@ -431,7 +498,7 @@ describe('recording template', () => {
           needsLocalBackend: false,
           backendUrl: 'not a url'
         })
-      ).toBe('custom')
+      ).toBe('custom-unparsed')
     })
   })
 })

--- a/tools/test-recorder/src/recorder/template.test.ts
+++ b/tools/test-recorder/src/recorder/template.test.ts
@@ -10,6 +10,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
+import type { Distribution } from '../devserver/distributions'
 import {
   cleanupRecordedCode,
   cleanupRecordingTemplate,
@@ -280,209 +281,54 @@ describe('recording template', () => {
   })
 
   describe('storageStateKey', () => {
-    it('defaults to cloud when no distribution is given', () => {
+    function custom(backendUrl?: string): Distribution {
+      return {
+        id: 'custom',
+        label: 'Custom backend',
+        hint: '',
+        script: 'dev',
+        needsLocalBackend: false,
+        backendUrl
+      }
+    }
+
+    it('keeps the fixed keys for built-in cloud distributions', () => {
       expect(storageStateKey(undefined)).toBe('cloud')
+      for (const id of ['cloud', 'cloud-staging', 'cloud-prod']) {
+        expect(storageStateKey({ ...custom(), id })).toBe(id)
+      }
     })
 
-    it('uses the fixed id for the three built-in cloud distributions', () => {
-      expect(
-        storageStateKey({
-          id: 'cloud',
-          label: 'Cloud',
-          hint: '',
-          script: 'dev:cloud',
-          needsLocalBackend: false,
-          backendUrl: 'https://testcloud.comfy.org/'
-        })
-      ).toBe('cloud')
-      expect(
-        storageStateKey({
-          id: 'cloud-staging',
-          label: 'Cloud staging',
-          hint: '',
-          script: 'dev:cloud:staging',
-          needsLocalBackend: false,
-          backendUrl: 'https://stagingcloud.comfy.org/'
-        })
-      ).toBe('cloud-staging')
-      expect(
-        storageStateKey({
-          id: 'cloud-prod',
-          label: 'Cloud production',
-          hint: '',
-          script: 'dev:cloud:prod',
-          needsLocalBackend: false,
-          backendUrl: 'https://cloud.comfy.org/'
-        })
-      ).toBe('cloud-prod')
-    })
-
-    it('fails closed when a custom distribution has no backend URL', () => {
-      expect(
-        storageStateKey({
-          id: 'custom',
-          label: 'Custom backend',
-          hint: '',
-          script: 'dev',
-          needsLocalBackend: false
-        })
-      ).toBe('custom-unparsed')
-    })
-
-    it('keys a custom backend by a hash of its own origin, not a shared "custom" bucket', () => {
-      const keyA = storageStateKey({
-        id: 'custom',
-        label: 'Custom backend (https://agent.comfy.org/)',
-        hint: 'https://agent.comfy.org/',
-        script: 'dev',
-        needsLocalBackend: false,
-        backendUrl: 'https://agent.comfy.org/'
-      })
-      const keyB = storageStateKey({
-        id: 'custom',
-        label: 'Custom backend (https://other-env.comfy.org/)',
-        hint: 'https://other-env.comfy.org/',
-        script: 'dev',
-        needsLocalBackend: false,
-        backendUrl: 'https://other-env.comfy.org/'
-      })
+    it('creates a stable, filesystem-safe key for each custom backend', () => {
+      const keyA = storageStateKey(custom('https://agent.comfy.org/'))
+      const keyB = storageStateKey(custom('https://other-env.comfy.org/'))
       expect(keyA).toMatch(/^custom-[0-9a-f]{16}$/)
       expect(keyB).toMatch(/^custom-[0-9a-f]{16}$/)
       expect(keyA).not.toBe(keyB)
-      // Stable across calls, so the same backend always reuses its file.
-      expect(
-        storageStateKey({
-          id: 'custom',
-          label: '',
-          hint: '',
-          script: 'dev',
-          needsLocalBackend: false,
-          backendUrl: 'https://agent.comfy.org/'
-        })
-      ).toBe(keyA)
-    })
-
-    it('keeps HTTP and HTTPS custom backends in separate buckets', () => {
-      const distribution = {
-        id: 'custom',
-        label: 'Custom backend',
-        hint: '',
-        script: 'dev',
-        needsLocalBackend: false
-      } as const
-
-      expect(
-        storageStateKey({
-          ...distribution,
-          backendUrl: 'http://agent.comfy.org/'
-        })
-      ).not.toBe(
-        storageStateKey({
-          ...distribution,
-          backendUrl: 'https://agent.comfy.org/'
-        })
+      expect(storageStateKey(custom('https://agent.comfy.org/'))).toBe(keyA)
+      expect(storageStateKey(custom('http://[::1]:8100/'))).toMatch(
+        /^custom-[0-9a-f]{16}$/
       )
     })
 
-    it('keeps custom backends on different ports in separate buckets', () => {
-      const distribution = {
-        id: 'custom',
-        label: 'Custom backend',
-        hint: '',
-        script: 'dev',
-        needsLocalBackend: false
-      } as const
-
-      expect(
-        storageStateKey({
-          ...distribution,
-          backendUrl: 'http://localhost:8100/'
-        })
-      ).not.toBe(
-        storageStateKey({
-          ...distribution,
-          backendUrl: 'http://localhost:8200/'
-        })
-      )
+    it.for([
+      ['scheme', 'http://agent.comfy.org/', 'https://agent.comfy.org/'],
+      ['port', 'http://localhost:8100/', 'http://localhost:8200/'],
+      [
+        'path',
+        'https://gw.example.com/tenant-a/',
+        'https://gw.example.com/tenant-b/'
+      ]
+    ])('includes the custom backend %s', ([_part, a, b]) => {
+      expect(storageStateKey(custom(a))).not.toBe(storageStateKey(custom(b)))
     })
 
-    it('keeps custom backends on different paths in separate buckets', () => {
-      // normalizeBackendUrl preserves path prefixes for path-routed backends
-      // (e.g. one gateway hosting several tenants); the key must too, or
-      // https://gw.example.com/tenant-a/ and .../tenant-b/ collapse into one
-      // storage-state file and replay each other's session.
-      const distribution = {
-        id: 'custom',
-        label: 'Custom backend',
-        hint: '',
-        script: 'dev',
-        needsLocalBackend: false
-      } as const
-
-      expect(
-        storageStateKey({
-          ...distribution,
-          backendUrl: 'https://gw.example.com/tenant-a/'
-        })
-      ).not.toBe(
-        storageStateKey({
-          ...distribution,
-          backendUrl: 'https://gw.example.com/tenant-b/'
-        })
-      )
-    })
-
-    it('does not confuse hostname suffixes with port separators', () => {
-      const distribution = {
-        id: 'custom',
-        label: 'Custom backend',
-        hint: '',
-        script: 'dev',
-        needsLocalBackend: false
-      } as const
-
-      expect(
-        storageStateKey({
-          ...distribution,
-          backendUrl: 'https://example.com-8100/'
-        })
-      ).not.toBe(
-        storageStateKey({
-          ...distribution,
-          backendUrl: 'https://example.com:8100/'
-        })
-      )
-    })
-
-    it('hashes IPv6 hostnames to a fixed-length, filesystem-safe key', () => {
-      expect(
-        storageStateKey({
-          id: 'custom',
-          label: 'Custom backend',
-          hint: '',
-          script: 'dev',
-          needsLocalBackend: false,
-          backendUrl: 'http://[::1]:8100/'
-        })
-      ).toMatch(/^custom-[0-9a-f]{16}$/)
-    })
-
-    it('treats a scheme-less URL as unparseable rather than silently sharing a bucket', () => {
-      // new URL('localhost:8100') parses as a non-special 'localhost:'
-      // scheme with an empty hostname — the real host/port land in the
-      // discarded opaque path, so without a guard every scheme-less typo
-      // collapses into the same key.
-      expect(
-        storageStateKey({
-          id: 'custom',
-          label: 'Custom backend',
-          hint: '',
-          script: 'dev',
-          needsLocalBackend: false,
-          backendUrl: 'localhost:8100'
-        })
-      ).toBe('custom-unparsed')
-    })
+    it.for([undefined, 'not a url', 'localhost:8100', 'ftp://example.com/'])(
+      'routes invalid custom URL %s to the shared fallback bucket',
+      (backendUrl) => {
+        expect(storageStateKey(custom(backendUrl))).toBe('custom-unparsed')
+      }
+    )
 
     it('removes the legacy shared custom-backend storage state', () => {
       const legacyStateFile = join(browserTestsDir, 'storage-state.custom.json')
@@ -493,17 +339,6 @@ describe('recording template', () => {
       )
 
       expect(existsSync(legacyStateFile)).toBe(false)
-    })
-
-    it('does not delete the legacy file when it is the resolved path itself', () => {
-      const legacyStateFile = join(browserTestsDir, 'storage-state.custom.json')
-      writeFileSync(legacyStateFile, '{"cookies":[]}')
-
-      removeLegacyCustomStorageState(legacyStateFile)
-
-      // Covers the guard's equal-path branch: removeLegacyCustomStorageState
-      // must not delete the very file it was asked to load.
-      expect(existsSync(legacyStateFile)).toBe(true)
     })
 
     it('does not fail when the legacy storage state cannot be removed', () => {
@@ -517,24 +352,6 @@ describe('recording template', () => {
         )
       ).not.toThrow()
       expect(existsSync(legacyStateFile)).toBe(true)
-    })
-
-    it('falls back to a distinct sentinel if the custom backend URL cannot be parsed', () => {
-      // A bare 'custom' fallback resolves to the legacy shared storage-state
-      // file, so removeLegacyCustomStorageState's !== guard would skip the
-      // migration deletion and every unparseable backend would still share
-      // one bucket. The sentinel must differ from both 'custom' and any real
-      // hashed key.
-      expect(
-        storageStateKey({
-          id: 'custom',
-          label: 'Custom backend',
-          hint: '',
-          script: 'dev',
-          needsLocalBackend: false,
-          backendUrl: 'not a url'
-        })
-      ).toBe('custom-unparsed')
     })
   })
 })

--- a/tools/test-recorder/src/recorder/template.test.ts
+++ b/tools/test-recorder/src/recorder/template.test.ts
@@ -305,6 +305,28 @@ describe('recording template', () => {
           backendUrl: 'https://stagingcloud.comfy.org/'
         })
       ).toBe('cloud-staging')
+      expect(
+        storageStateKey({
+          id: 'cloud-prod',
+          label: 'Cloud production',
+          hint: '',
+          script: 'dev:cloud:prod',
+          needsLocalBackend: false,
+          backendUrl: 'https://cloud.comfy.org/'
+        })
+      ).toBe('cloud-prod')
+    })
+
+    it('fails closed when a custom distribution has no backend URL', () => {
+      expect(
+        storageStateKey({
+          id: 'custom',
+          label: 'Custom backend',
+          hint: '',
+          script: 'dev',
+          needsLocalBackend: false
+        })
+      ).toBe('custom-unparsed')
     })
 
     it('keys a custom backend by a hash of its own origin, not a shared "custom" bucket', () => {

--- a/tools/test-recorder/src/recorder/template.test.ts
+++ b/tools/test-recorder/src/recorder/template.test.ts
@@ -302,6 +302,7 @@ describe('recording template', () => {
     it('creates a stable, filesystem-safe key for each custom backend', () => {
       const keyA = storageStateKey(custom('https://agent.comfy.org/'))
       const keyB = storageStateKey(custom('https://other-env.comfy.org/'))
+      expect(keyA).toBe('custom-7bf9f2e4d13ea71f')
       expect(keyA).toMatch(/^custom-[0-9a-f]{16}$/)
       expect(keyB).toMatch(/^custom-[0-9a-f]{16}$/)
       expect(keyA).not.toBe(keyB)

--- a/tools/test-recorder/src/recorder/template.ts
+++ b/tools/test-recorder/src/recorder/template.ts
@@ -28,7 +28,8 @@ export function storageStateKey(distribution?: Distribution): string {
     return distribution.id
   }
   try {
-    return `custom-${new URL(distribution.backendUrl).hostname}`
+    const { hostname, port } = new URL(distribution.backendUrl)
+    return `custom-${hostname}${port ? `-${port}` : ''}`
   } catch {
     return 'custom'
   }

--- a/tools/test-recorder/src/recorder/template.ts
+++ b/tools/test-recorder/src/recorder/template.ts
@@ -2,6 +2,7 @@ import { existsSync, writeFileSync, mkdirSync, unlinkSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { join, dirname } from 'node:path'
 import { formatInitialFeatureFlags } from '../featureFlags'
+import type { Distribution } from '../devserver/distributions'
 
 export type RecordingTarget = 'local' | 'cloud'
 
@@ -12,6 +13,25 @@ interface TemplateOptions {
   target?: RecordingTarget
   /** Browser storage-state file that persists sign-in across recordings. */
   storageStateFile?: string
+}
+
+/**
+ * Every custom backend previously shared one cache key ('custom'), so a
+ * session saved against one host got replayed against a completely
+ * different one — a stale/foreign cookie an unrelated origin will reject,
+ * which can surface as an auth redirect loop. Custom backends key by their
+ * own hostname instead; the three fixed cloud distributions keep their id.
+ */
+export function storageStateKey(distribution?: Distribution): string {
+  if (!distribution) return 'cloud'
+  if (distribution.id !== 'custom' || !distribution.backendUrl) {
+    return distribution.id
+  }
+  try {
+    return `custom-${new URL(distribution.backendUrl).hostname}`
+  } catch {
+    return 'custom'
+  }
 }
 
 export function storageStatePath(distributionId: string): string {

--- a/tools/test-recorder/src/recorder/template.ts
+++ b/tools/test-recorder/src/recorder/template.ts
@@ -34,8 +34,9 @@ export function storageStateKey(distribution?: Distribution): string {
     return distribution.id
   }
   try {
-    const { hostname, port } = new URL(distribution.backendUrl)
-    return `custom-${encodeURIComponent(hostname)}${port ? `-${port}` : ''}`
+    const { protocol, hostname, port } = new URL(distribution.backendUrl)
+    const protocolKey = protocol === 'https:' ? '' : `${protocol}//`
+    return `custom-${encodeURIComponent(protocolKey)}${encodeURIComponent(hostname)}${port ? `-${port}` : ''}`
   } catch {
     return 'custom'
   }

--- a/tools/test-recorder/src/recorder/template.ts
+++ b/tools/test-recorder/src/recorder/template.ts
@@ -30,8 +30,8 @@ interface TemplateOptions {
  * of their full normalized origin+path instead (path included, since
  * path-routed backends like /tenant-a/ vs /tenant-b/ are distinct sessions);
  * the three fixed cloud distributions keep their id. Hashing also bounds the
- * resulting filename length and gives every unparseable/malformed URL its
- * own bucket instead of one shared fallback.
+ * resulting filename length and routes every unparseable/malformed URL to
+ * one shared fallback bucket.
  */
 export function storageStateKey(distribution?: Distribution): string {
   if (!distribution) return 'cloud'

--- a/tools/test-recorder/src/recorder/template.ts
+++ b/tools/test-recorder/src/recorder/template.ts
@@ -35,7 +35,7 @@ export function storageStateKey(distribution?: Distribution): string {
   }
   try {
     const { hostname, port } = new URL(distribution.backendUrl)
-    return `custom-${hostname}${port ? `-${port}` : ''}`
+    return `custom-${encodeURIComponent(hostname)}${port ? `-${port}` : ''}`
   } catch {
     return 'custom'
   }

--- a/tools/test-recorder/src/recorder/template.ts
+++ b/tools/test-recorder/src/recorder/template.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto'
 import {
   existsSync,
   writeFileSync,
@@ -25,8 +26,12 @@ interface TemplateOptions {
  * Every custom backend previously shared one cache key ('custom'), so a
  * session saved against one host got replayed against a completely
  * different one — a stale/foreign cookie an unrelated origin will reject,
- * which can surface as an auth redirect loop. Custom backends key by their
- * own hostname instead; the three fixed cloud distributions keep their id.
+ * which can surface as an auth redirect loop. Custom backends key by a hash
+ * of their full normalized origin+path instead (path included, since
+ * path-routed backends like /tenant-a/ vs /tenant-b/ are distinct sessions);
+ * the three fixed cloud distributions keep their id. Hashing also bounds the
+ * resulting filename length and gives every unparseable/malformed URL its
+ * own bucket instead of one shared fallback.
  */
 export function storageStateKey(distribution?: Distribution): string {
   if (!distribution) return 'cloud'
@@ -34,11 +39,24 @@ export function storageStateKey(distribution?: Distribution): string {
     return distribution.id
   }
   try {
-    const { protocol, hostname, port } = new URL(distribution.backendUrl)
-    const protocolKey = protocol === 'https:' ? '' : `${protocol}//`
-    return `custom-${encodeURIComponent(`${protocolKey}${hostname}${port ? `:${port}` : ''}`)}`
+    const { protocol, hostname, port, pathname } = new URL(
+      distribution.backendUrl
+    )
+    if ((protocol !== 'http:' && protocol !== 'https:') || !hostname) {
+      // A scheme-less input like 'localhost:8100' parses as a non-special
+      // `localhost:` URL with an empty hostname and the real host/port
+      // sitting in the opaque path — treat that the same as unparseable
+      // rather than silently sharing a bucket with other typos.
+      return 'custom-unparsed'
+    }
+    const origin = `${protocol}//${hostname}${port ? `:${port}` : ''}${pathname}`
+    const digest = createHash('sha256').update(origin).digest('hex')
+    return `custom-${digest.slice(0, 16)}`
   } catch {
-    return 'custom'
+    // Fail closed to a sentinel distinct from a real hashed key, so a
+    // malformed backend URL never resolves to a previously-recorded
+    // session's storage-state file.
+    return 'custom-unparsed'
   }
 }
 
@@ -52,7 +70,13 @@ export function removeLegacyCustomStorageState(storageStateFile: string): void {
     'storage-state.custom.json'
   )
   if (storageStateFile !== legacyStorageStateFile) {
-    rmSync(legacyStorageStateFile, { force: true })
+    try {
+      rmSync(legacyStorageStateFile, { force: true })
+    } catch {
+      // Best-effort cleanup of an obsolete file — EACCES/EPERM/a lock on it
+      // shouldn't abort the recording session, same as cleanupRecordingTemplate
+      // and cleanupRecordedCode below.
+    }
   }
 }
 

--- a/tools/test-recorder/src/recorder/template.ts
+++ b/tools/test-recorder/src/recorder/template.ts
@@ -36,7 +36,7 @@ export function storageStateKey(distribution?: Distribution): string {
   try {
     const { protocol, hostname, port } = new URL(distribution.backendUrl)
     const protocolKey = protocol === 'https:' ? '' : `${protocol}//`
-    return `custom-${encodeURIComponent(protocolKey)}${encodeURIComponent(hostname)}${port ? `-${port}` : ''}`
+    return `custom-${encodeURIComponent(`${protocolKey}${hostname}${port ? `:${port}` : ''}`)}`
   } catch {
     return 'custom'
   }

--- a/tools/test-recorder/src/recorder/template.ts
+++ b/tools/test-recorder/src/recorder/template.ts
@@ -1,4 +1,10 @@
-import { existsSync, writeFileSync, mkdirSync, unlinkSync } from 'node:fs'
+import {
+  existsSync,
+  writeFileSync,
+  mkdirSync,
+  unlinkSync,
+  rmSync
+} from 'node:fs'
 import { homedir } from 'node:os'
 import { join, dirname } from 'node:path'
 import { formatInitialFeatureFlags } from '../featureFlags'
@@ -37,6 +43,16 @@ export function storageStateKey(distribution?: Distribution): string {
 
 export function storageStatePath(distributionId: string): string {
   return join(homedir(), '.comfy-test', `storage-state.${distributionId}.json`)
+}
+
+export function removeLegacyCustomStorageState(storageStateFile: string): void {
+  const legacyStorageStateFile = join(
+    dirname(storageStateFile),
+    'storage-state.custom.json'
+  )
+  if (storageStateFile !== legacyStorageStateFile) {
+    rmSync(legacyStorageStateFile, { force: true })
+  }
 }
 
 export function ensureStorageStateDir(storageStateFile: string): void {

--- a/tools/test-recorder/src/recorder/template.ts
+++ b/tools/test-recorder/src/recorder/template.ts
@@ -54,9 +54,6 @@ export function storageStateKey(distribution?: Distribution): string {
     const digest = createHash('sha256').update(origin).digest('hex')
     return `custom-${digest.slice(0, 16)}`
   } catch {
-    // Fail closed to a sentinel distinct from a real hashed key, so a
-    // malformed backend URL never resolves to a previously-recorded
-    // session's storage-state file.
     return 'custom-unparsed'
   }
 }

--- a/tools/test-recorder/src/recorder/template.ts
+++ b/tools/test-recorder/src/recorder/template.ts
@@ -35,9 +35,10 @@ interface TemplateOptions {
  */
 export function storageStateKey(distribution?: Distribution): string {
   if (!distribution) return 'cloud'
-  if (distribution.id !== 'custom' || !distribution.backendUrl) {
+  if (distribution.id !== 'custom') {
     return distribution.id
   }
+  if (!distribution.backendUrl) return 'custom-unparsed'
   try {
     const { protocol, hostname, port, pathname } = new URL(
       distribution.backendUrl


### PR DESCRIPTION
## Bug

comfy-test record --distribution custom --backend agent.comfy.org perma-reloaded into a login redirect loop on a fresh Mac.

## Root cause

`customDistribution()` always sets `id: 'custom'`, and `runner.ts` keyed the saved sign-in storage-state file by that id directly — so **every** custom backend, regardless of hostname, reads and writes the same `~/.comfy-test/storage-state.custom.json`. A session cookie saved against one custom host gets replayed against a completely different one on the next run; an origin that rejects it sends the app to `/cloud/login`, and depending on what state persists from there it can keep re-triggering.

## Fix

`storageStateKey()` derives each custom cache key from a hash of the backend's normalized protocol, hostname, port, and path. Missing, malformed, and non-HTTP(S) custom URLs use a shared `custom-unparsed` bucket that remains separate from the legacy `custom` file. The three fixed cloud distributions (cloud/cloud-staging/cloud-prod) are unaffected.

## Investigation

Reproduced the underlying auth-redirect mechanism directly: started the Vite dev server with `DEV_SERVER_COMFYUI_URL=https://agent.comfy.org/` (exactly as `manager.ts` does) and loaded it in a real headless browser. A fresh run correctly settles on `/cloud/login` and stops after 3 navigations — no loop with a clean storage-state file. The collision only bites on a *second* custom backend, which matches "worked before, broke this time" better than a first-run failure.

## Verification

- `pnpm exec vitest run tools/test-recorder` — 285 tests pass
- `pnpm typecheck:tools` — clean
- scoped Oxfmt, Oxlint, and ESLint checks — clean
