### PR TITLE
fix: avoid inserting into a replaced canvas

### DIFF
--- a/src/platform/workflow/core/services/workflowService.test.ts
+++ b/src/platform/workflow/core/services/workflowService.test.ts
@@ -1617,7 +1617,7 @@ describe('useWorkflowService', () => {
   })
 
   describe('insertWorkflow', () => {
-    it('inserts into the canvas when nothing changes while loading', async () => {
+    it('inserts into the canvas with its requested position when nothing changes while loading', async () => {
       const canvas = app.canvas
       const originalGraph = {}
       const deserialize = vi.fn()
@@ -1628,9 +1628,14 @@ describe('useWorkflowService', () => {
       } as unknown as ComfyWorkflow
 
       try {
-        await useWorkflowService().insertWorkflow(workflow)
+        const options = { position: [120, 240] as [number, number] }
+        await useWorkflowService().insertWorkflow(workflow, options)
 
-        expect(deserialize).toHaveBeenCalledTimes(1)
+        expect(deserialize).toHaveBeenCalledOnce()
+        expect(deserialize).toHaveBeenCalledWith(
+          expect.objectContaining({ nodes: [], links: [] }),
+          options
+        )
       } finally {
         Reflect.set(canvas, 'graph', originalGraph)
       }

--- a/src/platform/workflow/core/services/workflowService.test.ts
+++ b/src/platform/workflow/core/services/workflowService.test.ts
@@ -1617,11 +1617,12 @@ describe('useWorkflowService', () => {
   })
 
   describe('insertWorkflow', () => {
-    it('does not insert after the canvas changes while loading', async () => {
-      const originalCanvas = app.canvas
-      const originalDeserialize = vi.fn()
-      const replacementDeserialize = vi.fn()
-      Reflect.set(originalCanvas, '_deserializeItems', originalDeserialize)
+    it('does not insert after the canvas graph changes while loading', async () => {
+      const canvas = app.canvas
+      const originalGraph = {}
+      const deserialize = vi.fn()
+      Reflect.set(canvas, 'graph', originalGraph)
+      Reflect.set(canvas, '_deserializeItems', deserialize)
       let finishLoad: (value: unknown) => void = () => {}
       const workflow = {
         load: vi.fn(
@@ -1634,16 +1635,13 @@ describe('useWorkflowService', () => {
 
       try {
         const pending = useWorkflowService().insertWorkflow(workflow)
-        Reflect.set(app, 'canvas', {
-          _deserializeItems: replacementDeserialize
-        })
+        Reflect.set(canvas, 'graph', {})
         finishLoad({ initialState: { nodes: [], links: [] } })
         await pending
 
-        expect(originalDeserialize).not.toHaveBeenCalled()
-        expect(replacementDeserialize).not.toHaveBeenCalled()
+        expect(deserialize).not.toHaveBeenCalled()
       } finally {
-        Reflect.set(app, 'canvas', originalCanvas)
+        Reflect.set(canvas, 'graph', originalGraph)
       }
     })
   })

--- a/src/platform/workflow/core/services/workflowService.test.ts
+++ b/src/platform/workflow/core/services/workflowService.test.ts
@@ -1616,6 +1616,38 @@ describe('useWorkflowService', () => {
     })
   })
 
+  describe('insertWorkflow', () => {
+    it('does not insert after the canvas changes while loading', async () => {
+      const originalCanvas = app.canvas
+      const originalDeserialize = vi.fn()
+      const replacementDeserialize = vi.fn()
+      Reflect.set(originalCanvas, '_deserializeItems', originalDeserialize)
+      let finishLoad: (value: unknown) => void = () => {}
+      const workflow = {
+        load: vi.fn(
+          () =>
+            new Promise((resolve) => {
+              finishLoad = resolve
+            })
+        )
+      } as unknown as ComfyWorkflow
+
+      try {
+        const pending = useWorkflowService().insertWorkflow(workflow)
+        Reflect.set(app, 'canvas', {
+          _deserializeItems: replacementDeserialize
+        })
+        finishLoad({ initialState: { nodes: [], links: [] } })
+        await pending
+
+        expect(originalDeserialize).not.toHaveBeenCalled()
+        expect(replacementDeserialize).not.toHaveBeenCalled()
+      } finally {
+        Reflect.set(app, 'canvas', originalCanvas)
+      }
+    })
+  })
+
   describe('saveWorkflow', () => {
     let workflowStore: ReturnType<typeof useWorkflowStore>
 

--- a/src/platform/workflow/core/services/workflowService.test.ts
+++ b/src/platform/workflow/core/services/workflowService.test.ts
@@ -1617,6 +1617,58 @@ describe('useWorkflowService', () => {
   })
 
   describe('insertWorkflow', () => {
+    it('inserts into the canvas when nothing changes while loading', async () => {
+      const canvas = app.canvas
+      const originalGraph = {}
+      const deserialize = vi.fn()
+      Reflect.set(canvas, 'graph', originalGraph)
+      Reflect.set(canvas, '_deserializeItems', deserialize)
+      const workflow = {
+        load: vi.fn(async () => ({ initialState: { nodes: [], links: [] } }))
+      } as unknown as ComfyWorkflow
+
+      try {
+        await useWorkflowService().insertWorkflow(workflow)
+
+        expect(deserialize).toHaveBeenCalledTimes(1)
+      } finally {
+        Reflect.set(canvas, 'graph', originalGraph)
+      }
+    })
+
+    it('does not insert after the canvas itself is replaced while loading', async () => {
+      const originalCanvas = app.canvas
+      const originalGraph = {}
+      const deserialize = vi.fn()
+      Reflect.set(originalCanvas, 'graph', originalGraph)
+      Reflect.set(originalCanvas, '_deserializeItems', deserialize)
+      let finishLoad: (value: unknown) => void = () => {}
+      const workflow = {
+        load: vi.fn(
+          () =>
+            new Promise((resolve) => {
+              finishLoad = resolve
+            })
+        )
+      } as unknown as ComfyWorkflow
+
+      try {
+        const pending = useWorkflowService().insertWorkflow(workflow)
+        Reflect.set(app, 'canvas', {
+          graph: originalGraph,
+          _deserializeItems: vi.fn()
+        })
+        finishLoad({ initialState: { nodes: [], links: [] } })
+        await pending
+
+        expect(deserialize).not.toHaveBeenCalled()
+        expect(app.canvas._deserializeItems).not.toHaveBeenCalled()
+      } finally {
+        Reflect.set(app, 'canvas', originalCanvas)
+        Reflect.set(originalCanvas, 'graph', originalGraph)
+      }
+    })
+
     it('does not insert after the canvas graph changes while loading', async () => {
       const canvas = app.canvas
       const originalGraph = {}

--- a/src/platform/workflow/core/services/workflowService.test.ts
+++ b/src/platform/workflow/core/services/workflowService.test.ts
@@ -1662,6 +1662,8 @@ describe('useWorkflowService', () => {
         )
       } as unknown as ComfyWorkflow
 
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
       try {
         const pending = useWorkflowService().insertWorkflow(workflow)
         Reflect.set(app, 'canvas', {
@@ -1673,7 +1675,13 @@ describe('useWorkflowService', () => {
 
         expect(deserialize).not.toHaveBeenCalled()
         expect(app.canvas._deserializeItems).not.toHaveBeenCalled()
+        expect(warnSpy).toHaveBeenCalledWith(
+          expect.stringContaining(
+            'insertWorkflow aborted: canvas or graph was replaced'
+          )
+        )
       } finally {
+        warnSpy.mockRestore()
         Reflect.set(app, 'canvas', originalCanvas)
         Reflect.set(originalCanvas, 'graph', priorGraph)
         Reflect.set(originalCanvas, '_deserializeItems', priorDeserialize)
@@ -1698,6 +1706,8 @@ describe('useWorkflowService', () => {
         )
       } as unknown as ComfyWorkflow
 
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
       try {
         const pending = useWorkflowService().insertWorkflow(workflow)
         Reflect.set(canvas, 'graph', {})
@@ -1705,7 +1715,13 @@ describe('useWorkflowService', () => {
         await pending
 
         expect(deserialize).not.toHaveBeenCalled()
+        expect(warnSpy).toHaveBeenCalledWith(
+          expect.stringContaining(
+            'insertWorkflow aborted: canvas or graph was replaced'
+          )
+        )
       } finally {
+        warnSpy.mockRestore()
         Reflect.set(canvas, 'graph', priorGraph)
         Reflect.set(canvas, '_deserializeItems', priorDeserialize)
       }

--- a/src/platform/workflow/core/services/workflowService.test.ts
+++ b/src/platform/workflow/core/services/workflowService.test.ts
@@ -1619,6 +1619,8 @@ describe('useWorkflowService', () => {
   describe('insertWorkflow', () => {
     it('inserts into the canvas with its requested position when nothing changes while loading', async () => {
       const canvas = app.canvas
+      const priorGraph = canvas.graph
+      const priorDeserialize = canvas._deserializeItems
       const originalGraph = {}
       const deserialize = vi.fn()
       Reflect.set(canvas, 'graph', originalGraph)
@@ -1637,12 +1639,15 @@ describe('useWorkflowService', () => {
           options
         )
       } finally {
-        Reflect.set(canvas, 'graph', originalGraph)
+        Reflect.set(canvas, 'graph', priorGraph)
+        Reflect.set(canvas, '_deserializeItems', priorDeserialize)
       }
     })
 
     it('does not insert after the canvas itself is replaced while loading', async () => {
       const originalCanvas = app.canvas
+      const priorGraph = originalCanvas.graph
+      const priorDeserialize = originalCanvas._deserializeItems
       const originalGraph = {}
       const deserialize = vi.fn()
       Reflect.set(originalCanvas, 'graph', originalGraph)
@@ -1670,12 +1675,15 @@ describe('useWorkflowService', () => {
         expect(app.canvas._deserializeItems).not.toHaveBeenCalled()
       } finally {
         Reflect.set(app, 'canvas', originalCanvas)
-        Reflect.set(originalCanvas, 'graph', originalGraph)
+        Reflect.set(originalCanvas, 'graph', priorGraph)
+        Reflect.set(originalCanvas, '_deserializeItems', priorDeserialize)
       }
     })
 
     it('does not insert after the canvas graph changes while loading', async () => {
       const canvas = app.canvas
+      const priorGraph = canvas.graph
+      const priorDeserialize = canvas._deserializeItems
       const originalGraph = {}
       const deserialize = vi.fn()
       Reflect.set(canvas, 'graph', originalGraph)
@@ -1698,7 +1706,8 @@ describe('useWorkflowService', () => {
 
         expect(deserialize).not.toHaveBeenCalled()
       } finally {
-        Reflect.set(canvas, 'graph', originalGraph)
+        Reflect.set(canvas, 'graph', priorGraph)
+        Reflect.set(canvas, '_deserializeItems', priorDeserialize)
       }
     })
   })

--- a/src/platform/workflow/core/services/workflowService.ts
+++ b/src/platform/workflow/core/services/workflowService.ts
@@ -781,7 +781,12 @@ export const useWorkflowService = () => {
     const canvas = app.canvas
     const graph = canvas.graph
     const loadedWorkflow = await workflow.load()
-    if (app.canvas !== canvas || canvas.graph !== graph) return
+    if (app.canvas !== canvas || canvas.graph !== graph) {
+      console.warn(
+        '[workflowService] insertWorkflow aborted: canvas or graph was replaced while the workflow loaded'
+      )
+      return
+    }
     const workflowJSON = toRaw(loadedWorkflow.initialState)
     // unknown conversion: ComfyWorkflowJSON is stricter than LiteGraph's
     // serialisation schema.

--- a/src/platform/workflow/core/services/workflowService.ts
+++ b/src/platform/workflow/core/services/workflowService.ts
@@ -779,8 +779,9 @@ export const useWorkflowService = () => {
     options: { position?: Point } = {}
   ) => {
     const canvas = app.canvas
+    const graph = canvas.graph
     const loadedWorkflow = await workflow.load()
-    if (app.canvas !== canvas) return
+    if (app.canvas !== canvas || canvas.graph !== graph) return
     const workflowJSON = toRaw(loadedWorkflow.initialState)
     // unknown conversion: ComfyWorkflowJSON is stricter than LiteGraph's
     // serialisation schema.

--- a/src/platform/workflow/core/services/workflowService.ts
+++ b/src/platform/workflow/core/services/workflowService.ts
@@ -778,14 +778,16 @@ export const useWorkflowService = () => {
     workflow: ComfyWorkflow,
     options: { position?: Point } = {}
   ) => {
+    const canvas = app.canvas
     const loadedWorkflow = await workflow.load()
+    if (app.canvas !== canvas) return
     const workflowJSON = toRaw(loadedWorkflow.initialState)
     // unknown conversion: ComfyWorkflowJSON is stricter than LiteGraph's
     // serialisation schema.
     const items = workflowToClipboardItems(
       workflowJSON as unknown as SerialisableGraph
     )
-    app.canvas._deserializeItems(items, options)
+    canvas._deserializeItems(items, options)
   }
 
   const loadNextOpenedWorkflow = async () => {


### PR DESCRIPTION
## Summary

Prevent an asynchronously loaded workflow from being inserted after its target canvas has been replaced.

## Changes

- **What**: Capture the target canvas before loading and abort if `app.canvas` changes; add a permanent regression test covering both the old and replacement canvases.

## Review Focus

Please verify that aborting the stale insertion is preferable to redirecting it into the newly active canvas. This extracts only the canvas-identity race fix from frozen PR #16448 and deliberately excludes its rejected selection-mode blocking.

## Screenshots (if applicable)

Not applicable; behavior is covered by the focused unit test.

Justification: Christian approved the proposed merge path in blocked-on-christian #330 and explicitly authorized ignoring the newly introduced feature-flag-policy failure for this previously approved fix.