### PR TITLE
test(agent): cover closed-panel graph-load tracking

### DIFF
--- a/src/extensions/core/agentPanel.test.ts
+++ b/src/extensions/core/agentPanel.test.ts
@@ -235,6 +235,20 @@ describe('AgentPanel extension flag gate', () => {
     ])
   })
 
+  it('skips graph-load selection tracking while the panel is closed', async () => {
+    const { registerAgentPanelExtension } = await import('./agentPanel')
+    registerAgentPanelExtension()
+    const extension = mocks.capturedExtensions.find(
+      (item) => item.name === 'Comfy.AgentPanel'
+    )
+    mocks.agentStore.isOpen = false
+
+    extension!.beforeLoadGraph!({} as never)
+
+    expect(mocks.notifyBeforeGraphLoad).toHaveBeenCalledOnce()
+    expect(mocks.nodeSelectionStore.beginWorkflowLoad).not.toHaveBeenCalled()
+  })
+
   it('finishes restoration when the panel closes during graph load', async () => {
     const { registerAgentPanelExtension } = await import('./agentPanel')
     registerAgentPanelExtension()

--- a/src/extensions/core/agentPanel.test.ts
+++ b/src/extensions/core/agentPanel.test.ts
@@ -105,6 +105,7 @@ describe('AgentPanel extension flag gate', () => {
     mocks.notifyBeforeGraphLoad.mockClear()
     mocks.agentStore.close.mockClear()
     mocks.agentStore.enabled = false
+    mocks.agentStore.isOpen = true
     mocks.flagEnabled = undefined
     mocks.flagListener = null
     mocks.registerTracker.mockClear()


### PR DESCRIPTION
## Summary

Adds a permanent regression test proving that a closed agent panel does not begin graph-load selection tracking while preserving the shared graph-load notification.

This is the first independently green tranche of program row `cjx-11`, extracted from frozen source head `278338e6a0e30e95be3659e4a6c24f3a6f6cc513` onto current `main` (`9eabfa5ff19e0075f841a2a8e033bab2e7a5c039`). The remaining session-chain suite depends on the separately claimed `cjx-8` `agentDraftStore` extraction, which is absent from main; this PR stays draft until that dependency is available and the rest of the lifecycle batch can be adapted without restoring rejected PostHog or cloud-only gating.

## Changes

- **What**: Covers the closed-panel `beforeLoadGraph` path and asserts selection tracking remains inactive.
- **Dependencies**: No new runtime or package dependencies. Remaining `cjx-11` test extraction depends on program row `cjx-8`.

## Review Focus

Please verify that the test preserves the unconditional `notifyBeforeGraphLoad` seam while pinning the panel-owned selection guard.

Validation:

- `pnpm test:unit src/extensions/core/agentPanel.test.ts src/extensions/core/agentPanelGateDependencyFailure.test.ts src/workbench/extensions/agent/composables/useAgentDockMount.test.ts src/workbench/extensions/agent/components/agent/ConversationView.test.ts` (17/17)
- `pnpm exec oxfmt --check src/extensions/core/agentPanel.test.ts`
- required commit hooks: oxfmt, oxlint, ESLint, typecheck, Knip

## Screenshots (if applicable)

Not applicable; test-only change.
