### PR TITLE
fix(agent): reject malformed document frames

### DIFF
--- a/src/workbench/extensions/agent/crdt/__fixtures__/docFrameClient.ts
+++ b/src/workbench/extensions/agent/crdt/__fixtures__/docFrameClient.ts
@@ -1,0 +1,41 @@
+type ServerFrameType =
+  | 'doc_update'
+  | 'doc_subscribed'
+  | 'doc_ops_result'
+  | 'doc_reset'
+  | 'awareness'
+
+function serverFrame<T extends ServerFrameType>(
+  type: T,
+  data: Record<string, unknown>
+) {
+  return {
+    type,
+    data: { v: 1, workflow_id: 'wf-1', ...data }
+  }
+}
+
+export function docUpdateFrame(data: Record<string, unknown> = {}) {
+  return serverFrame('doc_update', { seq: 1, update_b64: 'AQ==', ...data })
+}
+
+export function docSubscribedFrame(data: Record<string, unknown> = {}) {
+  return serverFrame('doc_subscribed', { ok: true, seq: 1, ...data })
+}
+
+export function docOpsResultFrame(data: Record<string, unknown> = {}) {
+  return serverFrame('doc_ops_result', { ok: true, ...data })
+}
+
+export function docResetFrame(data: Record<string, unknown> = {}) {
+  return serverFrame('doc_reset', { seq: 1, actor: 'system:mint', ...data })
+}
+
+export function awarenessFrame(data: Record<string, unknown> = {}) {
+  return serverFrame('awareness', {
+    actor: 'human:user:tab-a',
+    state: {},
+    expires_at: 123,
+    ...data
+  })
+}

--- a/src/workbench/extensions/agent/crdt/docFrameClient.arrays.test.ts
+++ b/src/workbench/extensions/agent/crdt/docFrameClient.arrays.test.ts
@@ -1,46 +1,67 @@
 import { describe, expect, it } from 'vitest'
 
+import {
+  docOpsResultFrame,
+  docUpdateFrame
+} from './__fixtures__/docFrameClient'
 import { parseServerDocFrame } from './docFrameClient'
 
-const resultFrame = (data: Record<string, unknown>) =>
-  parseServerDocFrame({
-    type: 'doc_ops_result',
-    data: {
-      v: 1,
-      workflow_id: 'wf-1',
-      ...data
+function resultFrame(data: Record<string, unknown>) {
+  return parseServerDocFrame(docOpsResultFrame(data))
+}
+
+const invalidResultFrames: [string, Record<string, unknown>][] = [
+  ['a non-string applied item', { ok: true, seq: 1, applied: ['op-1', 2] }],
+  ['a non-string skipped item', { ok: true, seq: 1, skipped: ['op-1', 2] }],
+  [
+    'a failure without an index',
+    {
+      ok: true,
+      seq: 1,
+      failed: {
+        op_id: 'op-1',
+        code: 'invalid_op',
+        message: 'invalid operation'
+      }
     }
-  })
+  ],
+  [
+    'a non-string failure op_id',
+    {
+      ok: true,
+      seq: 1,
+      failed: {
+        index: 0,
+        op_id: 1,
+        code: 'invalid_op',
+        message: 'invalid operation'
+      }
+    }
+  ],
+  ['a non-array applied value', { ok: true, seq: 1, applied: 'op-1' }],
+  ['a non-string error code', { ok: false, code: 1 }],
+  ['a non-numeric sequence', { ok: true, seq: '1' }],
+  ['an oversized operation identity', { ok: true, applied: ['x'.repeat(129)] }],
+  ['an oversized error code', { ok: false, code: 'x'.repeat(129) }],
+  [
+    'an oversized error message',
+    { ok: false, message: 'x'.repeat((8 << 10) + 1) }
+  ],
+  [
+    'too many operation identities',
+    { ok: true, applied: Array.from({ length: 257 }, () => 'x') }
+  ]
+]
 
 describe('document frame result arrays and acknowledgements', () => {
   it('rejects a doc_update with a non-string op id', () => {
     expect(
-      parseServerDocFrame({
-        type: 'doc_update',
-        data: {
-          v: 1,
-          workflow_id: 'wf-1',
-          seq: 1,
-          update_b64: 'AQ==',
-          op_ids: ['op-1', 2]
-        }
-      })
+      parseServerDocFrame(docUpdateFrame({ op_ids: ['op-1', 2] }))
     ).toBeNull()
   })
 
   it('treats null doc_update op ids as absent', () => {
-    expect(
-      parseServerDocFrame({
-        type: 'doc_update',
-        data: {
-          v: 1,
-          workflow_id: 'wf-1',
-          seq: 1,
-          update_b64: 'AQ==',
-          op_ids: null
-        }
-      })
-    ).toEqual({
+    expect(parseServerDocFrame(docUpdateFrame({ op_ids: null }))).toEqual({
       type: 'doc_update',
       data: {
         workflowId: 'wf-1',
@@ -50,26 +71,8 @@ describe('document frame result arrays and acknowledgements', () => {
     })
   })
 
-  it('rejects a non-string element in applied', () => {
-    expect(resultFrame({ ok: true, seq: 1, applied: ['op-1', 2] })).toBeNull()
-  })
-
-  it('rejects a non-string element in skipped', () => {
-    expect(resultFrame({ ok: true, seq: 1, skipped: ['op-1', 2] })).toBeNull()
-  })
-
-  it('rejects a failure with a missing index', () => {
-    expect(
-      resultFrame({
-        ok: true,
-        seq: 1,
-        failed: {
-          op_id: 'op-1',
-          code: 'invalid_op',
-          message: 'invalid operation'
-        }
-      })
-    ).toBeNull()
+  it.for(invalidResultFrames)('rejects %s', ([_name, data]) => {
+    expect(resultFrame(data)).toBeNull()
   })
 
   it('accepts a failure without an op_id (relay omits it when unmapped)', () => {
@@ -92,21 +95,6 @@ describe('document frame result arrays and acknowledgements', () => {
         failed: { index: 0, code: 'invalid_op', message: 'invalid operation' }
       }
     })
-  })
-
-  it('rejects a failure with a non-string op_id', () => {
-    expect(
-      resultFrame({
-        ok: true,
-        seq: 1,
-        failed: {
-          index: 0,
-          op_id: 1,
-          code: 'invalid_op',
-          message: 'invalid operation'
-        }
-      })
-    ).toBeNull()
   })
 
   it('accepts a successful acknowledgement without a sequence', () => {
@@ -177,10 +165,6 @@ describe('document frame result arrays and acknowledgements', () => {
         skipped: ['op-1']
       }
     })
-  })
-
-  it('rejects present but malformed applied and skipped', () => {
-    expect(resultFrame({ ok: true, seq: 1, applied: 'op-1' })).toBeNull()
   })
 
   it('treats null result arrays as absent', () => {
@@ -264,16 +248,5 @@ describe('document frame result arrays and acknowledgements', () => {
         }
       })?.data
     ).not.toHaveProperty('failed.private_context')
-  })
-
-  it('rejects oversized operation identities and diagnostics', () => {
-    expect(resultFrame({ ok: true, applied: ['x'.repeat(129)] })).toBeNull()
-    expect(resultFrame({ ok: false, code: 'x'.repeat(129) })).toBeNull()
-    expect(
-      resultFrame({ ok: false, message: 'x'.repeat((8 << 10) + 1) })
-    ).toBeNull()
-    expect(
-      resultFrame({ ok: true, applied: Array.from({ length: 257 }, () => 'x') })
-    ).toBeNull()
   })
 })

--- a/src/workbench/extensions/agent/crdt/docFrameClient.arrays.test.ts
+++ b/src/workbench/extensions/agent/crdt/docFrameClient.arrays.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest'
+
+import { parseServerDocFrame } from './docFrameClient'
+
+const resultFrame = (data: Record<string, unknown>) =>
+  parseServerDocFrame({
+    type: 'doc_ops_result',
+    data: {
+      v: 1,
+      workflow_id: 'wf-1',
+      applied: [],
+      skipped: [],
+      ...data
+    }
+  })
+
+describe('document frame result arrays and acknowledgements', () => {
+  it('rejects a doc_update with a non-string op id', () => {
+    expect(
+      parseServerDocFrame({
+        type: 'doc_update',
+        data: {
+          v: 1,
+          workflow_id: 'wf-1',
+          seq: 1,
+          update_b64: 'AQ==',
+          op_ids: ['op-1', 2]
+        }
+      })
+    ).toBeNull()
+  })
+
+  it('rejects a non-string element in applied', () => {
+    expect(resultFrame({ ok: true, seq: 1, applied: ['op-1', 2] })).toBeNull()
+  })
+
+  it('rejects a non-string element in skipped', () => {
+    expect(resultFrame({ ok: true, seq: 1, skipped: ['op-1', 2] })).toBeNull()
+  })
+
+  it('rejects a failure with a missing index', () => {
+    expect(
+      resultFrame({
+        ok: true,
+        seq: 1,
+        failed: {
+          op_id: 'op-1',
+          code: 'invalid_op',
+          message: 'invalid operation'
+        }
+      })
+    ).toBeNull()
+  })
+
+  it('rejects a failure with a non-string op_id', () => {
+    expect(
+      resultFrame({
+        ok: true,
+        seq: 1,
+        failed: {
+          index: 0,
+          op_id: 1,
+          code: 'invalid_op',
+          message: 'invalid operation'
+        }
+      })
+    ).toBeNull()
+  })
+
+  it('rejects a successful acknowledgement without a sequence', () => {
+    expect(resultFrame({ ok: true })).toBeNull()
+  })
+
+  it('rejects a failed acknowledgement without a code', () => {
+    expect(resultFrame({ ok: false, message: 'batch rejected' })).toBeNull()
+  })
+
+  it('accepts strictly typed result arrays and failure data', () => {
+    expect(
+      resultFrame({
+        ok: false,
+        applied: ['op-1'],
+        skipped: ['op-2'],
+        code: 'invalid_op',
+        message: 'invalid operation',
+        failed: {
+          index: 2,
+          op_id: 'op-3',
+          code: 'invalid_op',
+          message: 'invalid operation'
+        }
+      })
+    ).toEqual({
+      type: 'doc_ops_result',
+      data: {
+        workflowId: 'wf-1',
+        ok: false,
+        applied: ['op-1'],
+        skipped: ['op-2'],
+        code: 'invalid_op',
+        message: 'invalid operation',
+        failed: {
+          index: 2,
+          op_id: 'op-3',
+          code: 'invalid_op',
+          message: 'invalid operation'
+        }
+      }
+    })
+  })
+})

--- a/src/workbench/extensions/agent/crdt/docFrameClient.arrays.test.ts
+++ b/src/workbench/extensions/agent/crdt/docFrameClient.arrays.test.ts
@@ -87,12 +87,29 @@ describe('document frame result arrays and acknowledgements', () => {
     ).toBeNull()
   })
 
-  it('rejects a successful acknowledgement without a sequence', () => {
-    expect(resultFrame({ ok: true })).toBeNull()
+  it('accepts a successful acknowledgement without a sequence', () => {
+    expect(resultFrame({ ok: true })).toEqual({
+      type: 'doc_ops_result',
+      data: {
+        workflowId: 'wf-1',
+        ok: true,
+        applied: [],
+        skipped: []
+      }
+    })
   })
 
-  it('rejects a failed acknowledgement without a code', () => {
-    expect(resultFrame({ ok: false, message: 'batch rejected' })).toBeNull()
+  it('accepts a failed acknowledgement without a code', () => {
+    expect(resultFrame({ ok: false, message: 'batch rejected' })).toEqual({
+      type: 'doc_ops_result',
+      data: {
+        workflowId: 'wf-1',
+        ok: false,
+        applied: [],
+        skipped: [],
+        message: 'batch rejected'
+      }
+    })
   })
 
   // The relay serialises applied/skipped with `omitempty`: rejections carry
@@ -177,5 +194,52 @@ describe('document frame result arrays and acknowledgements', () => {
         }
       }
     })
+  })
+
+  it('strips unrecognized failure properties', () => {
+    expect(
+      resultFrame({
+        ok: false,
+        failed: {
+          index: 0,
+          op_id: 'op-1',
+          code: 'invalid_op',
+          message: 'invalid operation',
+          private_context: 'must not escape the parser'
+        }
+      })
+    ).toMatchObject({
+      data: {
+        failed: {
+          index: 0,
+          op_id: 'op-1',
+          code: 'invalid_op',
+          message: 'invalid operation'
+        }
+      }
+    })
+    expect(
+      resultFrame({
+        ok: false,
+        failed: {
+          index: 0,
+          op_id: 'op-1',
+          code: 'invalid_op',
+          message: 'invalid operation',
+          private_context: 'must not escape the parser'
+        }
+      })?.data
+    ).not.toHaveProperty('failed.private_context')
+  })
+
+  it('rejects oversized operation identities and diagnostics', () => {
+    expect(resultFrame({ ok: true, applied: ['x'.repeat(129)] })).toBeNull()
+    expect(resultFrame({ ok: false, code: 'x'.repeat(129) })).toBeNull()
+    expect(
+      resultFrame({ ok: false, message: 'x'.repeat((8 << 10) + 1) })
+    ).toBeNull()
+    expect(
+      resultFrame({ ok: true, applied: Array.from({ length: 257 }, () => 'x') })
+    ).toBeNull()
   })
 })

--- a/src/workbench/extensions/agent/crdt/docFrameClient.arrays.test.ts
+++ b/src/workbench/extensions/agent/crdt/docFrameClient.arrays.test.ts
@@ -8,8 +8,6 @@ const resultFrame = (data: Record<string, unknown>) =>
     data: {
       v: 1,
       workflow_id: 'wf-1',
-      applied: [],
-      skipped: [],
       ...data
     }
   })
@@ -52,6 +50,28 @@ describe('document frame result arrays and acknowledgements', () => {
     ).toBeNull()
   })
 
+  it('accepts a failure without an op_id (relay omits it when unmapped)', () => {
+    expect(
+      resultFrame({
+        ok: false,
+        code: 'invalid_op',
+        message: 'invalid operation',
+        failed: { index: 0, code: 'invalid_op', message: 'invalid operation' }
+      })
+    ).toEqual({
+      type: 'doc_ops_result',
+      data: {
+        workflowId: 'wf-1',
+        ok: false,
+        applied: [],
+        skipped: [],
+        code: 'invalid_op',
+        message: 'invalid operation',
+        failed: { index: 0, code: 'invalid_op', message: 'invalid operation' }
+      }
+    })
+  })
+
   it('rejects a failure with a non-string op_id', () => {
     expect(
       resultFrame({
@@ -73,6 +93,56 @@ describe('document frame result arrays and acknowledgements', () => {
 
   it('rejects a failed acknowledgement without a code', () => {
     expect(resultFrame({ ok: false, message: 'batch rejected' })).toBeNull()
+  })
+
+  // The relay serialises applied/skipped with `omitempty`: rejections carry
+  // neither, a fully-applied batch carries no `skipped`, and an all-redelivery
+  // no-op carries no `applied`. Absent must read as empty, not malformed.
+  it('accepts a relay rejection that omits applied and skipped', () => {
+    expect(
+      resultFrame({ ok: false, code: 'invalid_frame', message: 'bad frame' })
+    ).toEqual({
+      type: 'doc_ops_result',
+      data: {
+        workflowId: 'wf-1',
+        ok: false,
+        applied: [],
+        skipped: [],
+        code: 'invalid_frame',
+        message: 'bad frame'
+      }
+    })
+  })
+
+  it('accepts a fully applied acknowledgement that omits skipped', () => {
+    expect(resultFrame({ ok: true, seq: 7, applied: ['op-1'] })).toEqual({
+      type: 'doc_ops_result',
+      data: {
+        workflowId: 'wf-1',
+        ok: true,
+        seq: 7,
+        applied: ['op-1'],
+        skipped: []
+      }
+    })
+  })
+
+  it('accepts an all-redelivery acknowledgement that omits applied', () => {
+    expect(resultFrame({ ok: true, seq: 7, skipped: ['op-1'] })).toEqual({
+      type: 'doc_ops_result',
+      data: {
+        workflowId: 'wf-1',
+        ok: true,
+        seq: 7,
+        applied: [],
+        skipped: ['op-1']
+      }
+    })
+  })
+
+  it('rejects present but malformed applied and skipped', () => {
+    expect(resultFrame({ ok: true, seq: 1, applied: 'op-1' })).toBeNull()
+    expect(resultFrame({ ok: true, seq: 1, skipped: null })).toBeNull()
   })
 
   it('accepts strictly typed result arrays and failure data', () => {

--- a/src/workbench/extensions/agent/crdt/docFrameClient.arrays.test.ts
+++ b/src/workbench/extensions/agent/crdt/docFrameClient.arrays.test.ts
@@ -28,6 +28,28 @@ describe('document frame result arrays and acknowledgements', () => {
     ).toBeNull()
   })
 
+  it('treats null doc_update op ids as absent', () => {
+    expect(
+      parseServerDocFrame({
+        type: 'doc_update',
+        data: {
+          v: 1,
+          workflow_id: 'wf-1',
+          seq: 1,
+          update_b64: 'AQ==',
+          op_ids: null
+        }
+      })
+    ).toEqual({
+      type: 'doc_update',
+      data: {
+        workflowId: 'wf-1',
+        seq: 1,
+        update: new Uint8Array([1])
+      }
+    })
+  })
+
   it('rejects a non-string element in applied', () => {
     expect(resultFrame({ ok: true, seq: 1, applied: ['op-1', 2] })).toBeNull()
   })
@@ -159,7 +181,19 @@ describe('document frame result arrays and acknowledgements', () => {
 
   it('rejects present but malformed applied and skipped', () => {
     expect(resultFrame({ ok: true, seq: 1, applied: 'op-1' })).toBeNull()
-    expect(resultFrame({ ok: true, seq: 1, skipped: null })).toBeNull()
+  })
+
+  it('treats null result arrays as absent', () => {
+    expect(resultFrame({ ok: true, seq: 1, skipped: null })).toEqual({
+      type: 'doc_ops_result',
+      data: {
+        workflowId: 'wf-1',
+        ok: true,
+        seq: 1,
+        applied: [],
+        skipped: []
+      }
+    })
   })
 
   it('accepts strictly typed result arrays and failure data', () => {

--- a/src/workbench/extensions/agent/crdt/docFrameClient.awareness.test.ts
+++ b/src/workbench/extensions/agent/crdt/docFrameClient.awareness.test.ts
@@ -1,40 +1,35 @@
 import { describe, expect, it } from 'vitest'
 
+import { awarenessFrame } from './__fixtures__/docFrameClient'
 import { parseServerDocFrame } from './docFrameClient'
 
-function awarenessFrame(state: unknown, expiresAt: unknown = 123) {
-  return {
-    type: 'awareness',
-    data: {
-      v: 1,
-      workflow_id: 'wf-1',
-      actor: 'human:user:tab-a',
-      state,
-      expires_at: expiresAt
-    }
-  }
-}
+const invalidAwarenessFrames: [string, unknown, unknown][] = [
+  ['an oversized state', { value: 'x'.repeat(8 * 1024) }, 123],
+  ['an array state', ['cursor', 10, 20], 123],
+  ['a negative expiry', {}, -1],
+  ['an infinite expiry', {}, Number.POSITIVE_INFINITY],
+  ['a NaN expiry', {}, Number.NaN],
+  ['a fractional expiry', {}, 1.5],
+  ['an unsafe expiry', {}, Number.MAX_SAFE_INTEGER + 1],
+  ['an extremely large expiry', {}, 1e300],
+  ['an unserializable state', { value: 1n }, 123]
+]
 
 describe('awareness frame validation', () => {
-  it('rejects state whose JSON encoding exceeds 8 KiB', () => {
+  it.for(invalidAwarenessFrames)('rejects %s', ([_name, state, expiresAt]) => {
     expect(
-      parseServerDocFrame(awarenessFrame({ value: 'x'.repeat(8 * 1024) }))
+      parseServerDocFrame(awarenessFrame({ state, expires_at: expiresAt }))
     ).toBeNull()
   })
 
   it('accepts state whose JSON encoding is exactly 8 KiB', () => {
-    // `{"value":"x…"}` wraps the string in 12 bytes of JSON syntax.
     const state = { value: 'x'.repeat(8 * 1024 - 12) }
     expect(new TextEncoder().encode(JSON.stringify(state)).byteLength).toBe(
       8 * 1024
     )
-    expect(parseServerDocFrame(awarenessFrame(state))).toMatchObject({
+    expect(parseServerDocFrame(awarenessFrame({ state }))).toMatchObject({
       data: { state }
     })
-  })
-
-  it('rejects array-shaped state', () => {
-    expect(parseServerDocFrame(awarenessFrame(['cursor', 10, 20]))).toBeNull()
   })
 
   it('treats a null state as absent rather than rejecting the frame', () => {
@@ -42,7 +37,9 @@ describe('awareness frame validation', () => {
     // actually emits `state: null`, but this is defence in depth: null
     // should fold into "no state", not discard the whole frame (and with
     // it actor/expires_at). discussion_r3911665011.
-    expect(parseServerDocFrame(awarenessFrame(null, 456))).toEqual({
+    expect(
+      parseServerDocFrame(awarenessFrame({ state: null, expires_at: 456 }))
+    ).toEqual({
       type: 'awareness',
       data: {
         workflowId: 'wf-1',
@@ -52,30 +49,10 @@ describe('awareness frame validation', () => {
     })
   })
 
-  it('rejects negative expires_at', () => {
-    expect(parseServerDocFrame(awarenessFrame({}, -1))).toBeNull()
-  })
-
-  it('rejects non-finite expires_at', () => {
-    expect(
-      parseServerDocFrame(awarenessFrame({}, Number.POSITIVE_INFINITY))
-    ).toBeNull()
-    expect(parseServerDocFrame(awarenessFrame({}, Number.NaN))).toBeNull()
-  })
-
-  it('rejects fractional expires_at', () => {
-    expect(parseServerDocFrame(awarenessFrame({}, 1.5))).toBeNull()
-  })
-
-  it('rejects expires_at beyond the safe integer range', () => {
-    expect(
-      parseServerDocFrame(awarenessFrame({}, Number.MAX_SAFE_INTEGER + 1))
-    ).toBeNull()
-    expect(parseServerDocFrame(awarenessFrame({}, 1e300))).toBeNull()
-  })
-
   it('accepts a zero expires_at', () => {
-    expect(parseServerDocFrame(awarenessFrame({}, 0))).toMatchObject({
+    expect(
+      parseServerDocFrame(awarenessFrame({ expires_at: 0 }))
+    ).toMatchObject({
       data: { expiresAt: 0 }
     })
   })
@@ -83,7 +60,10 @@ describe('awareness frame validation', () => {
   it('accepts a valid awareness frame', () => {
     expect(
       parseServerDocFrame(
-        awarenessFrame({ cursor: [10, 20], selection: 'node-1' }, 456)
+        awarenessFrame({
+          state: { cursor: [10, 20], selection: 'node-1' },
+          expires_at: 456
+        })
       )
     ).toEqual({
       type: 'awareness',

--- a/src/workbench/extensions/agent/crdt/docFrameClient.base64.test.ts
+++ b/src/workbench/extensions/agent/crdt/docFrameClient.base64.test.ts
@@ -36,4 +36,18 @@ describe('parseServerDocFrame doc_update base64 validation', () => {
     expect(() => parseServerDocFrame(docUpdate(''))).not.toThrow()
     expect(parseServerDocFrame(docUpdate(''))).toBeNull()
   })
+
+  it('rejects non-canonical padding bits (RFC 4648 §3.5)', () => {
+    // `YR==` and the canonical `YQ==` both decode to the same single byte
+    // (0x61) because the low 4 unused pad bits are non-zero; accepting both
+    // strings for one byte value is a malleability hole.
+    expect(() => parseServerDocFrame(docUpdate('YR=='))).not.toThrow()
+    expect(parseServerDocFrame(docUpdate('YR=='))).toBeNull()
+  })
+
+  it('accepts canonical padding for the same byte', () => {
+    const parsed = parseServerDocFrame(docUpdate('YQ=='))
+    expect(parsed).not.toBeNull()
+    expect(parsed?.type).toBe('doc_update')
+  })
 })

--- a/src/workbench/extensions/agent/crdt/docFrameClient.base64.test.ts
+++ b/src/workbench/extensions/agent/crdt/docFrameClient.base64.test.ts
@@ -32,6 +32,13 @@ describe('parseServerDocFrame doc_update base64 validation', () => {
     expect(parseServerDocFrame(docUpdate(encoded))).toBeNull()
   })
 
+  it('accepts a decoded update at exactly 8 MiB', () => {
+    const maxBytes = 8 * 1024 * 1024
+    const encoded = 'AAAA'.repeat(Math.floor(maxBytes / 3)) + 'AAA='
+
+    expect(parseServerDocFrame(docUpdate(encoded))).not.toBeNull()
+  })
+
   it('rejects an empty update without throwing', () => {
     expect(() => parseServerDocFrame(docUpdate(''))).not.toThrow()
     expect(parseServerDocFrame(docUpdate(''))).toBeNull()

--- a/src/workbench/extensions/agent/crdt/docFrameClient.base64.test.ts
+++ b/src/workbench/extensions/agent/crdt/docFrameClient.base64.test.ts
@@ -1,59 +1,47 @@
 import { describe, expect, it } from 'vitest'
 
+import { docUpdateFrame } from './__fixtures__/docFrameClient'
 import { parseServerDocFrame } from './docFrameClient'
 
-function docUpdate(updateB64: string): unknown {
-  return {
-    type: 'doc_update',
-    data: {
-      v: 1,
-      workflow_id: 'workflow-1',
-      seq: 1,
-      update_b64: updateB64
-    }
-  }
-}
+const invalidBase64: [string, string][] = [
+  ['non-base64 characters', 'YQ$='],
+  ['truncated input', 'YQ='],
+  ['empty input', ''],
+  ['non-canonical padding bits (RFC 4648 §3.5)', 'YR==']
+]
 
 describe('parseServerDocFrame doc_update base64 validation', () => {
-  it('rejects non-base64 characters without throwing', () => {
-    expect(() => parseServerDocFrame(docUpdate('YQ$='))).not.toThrow()
-    expect(parseServerDocFrame(docUpdate('YQ$='))).toBeNull()
-  })
-
-  it('rejects truncated base64 without throwing', () => {
-    expect(() => parseServerDocFrame(docUpdate('YQ='))).not.toThrow()
-    expect(parseServerDocFrame(docUpdate('YQ='))).toBeNull()
+  it.for(invalidBase64)('rejects %s without throwing', ([_name, encoded]) => {
+    expect(() =>
+      parseServerDocFrame(docUpdateFrame({ update_b64: encoded }))
+    ).not.toThrow()
+    expect(
+      parseServerDocFrame(docUpdateFrame({ update_b64: encoded }))
+    ).toBeNull()
   })
 
   it('rejects decoded updates larger than 8 MiB without throwing', () => {
     const encoded = 'AAAA'.repeat((8 * 1024 * 1024 + 1) / 3)
 
-    expect(() => parseServerDocFrame(docUpdate(encoded))).not.toThrow()
-    expect(parseServerDocFrame(docUpdate(encoded))).toBeNull()
+    expect(() =>
+      parseServerDocFrame(docUpdateFrame({ update_b64: encoded }))
+    ).not.toThrow()
+    expect(
+      parseServerDocFrame(docUpdateFrame({ update_b64: encoded }))
+    ).toBeNull()
   })
 
   it('accepts a decoded update at exactly 8 MiB', () => {
     const maxBytes = 8 * 1024 * 1024
     const encoded = 'AAAA'.repeat(Math.floor(maxBytes / 3)) + 'AAA='
 
-    expect(parseServerDocFrame(docUpdate(encoded))).not.toBeNull()
-  })
-
-  it('rejects an empty update without throwing', () => {
-    expect(() => parseServerDocFrame(docUpdate(''))).not.toThrow()
-    expect(parseServerDocFrame(docUpdate(''))).toBeNull()
-  })
-
-  it('rejects non-canonical padding bits (RFC 4648 §3.5)', () => {
-    // `YR==` and the canonical `YQ==` both decode to the same single byte
-    // (0x61) because the low 4 unused pad bits are non-zero; accepting both
-    // strings for one byte value is a malleability hole.
-    expect(() => parseServerDocFrame(docUpdate('YR=='))).not.toThrow()
-    expect(parseServerDocFrame(docUpdate('YR=='))).toBeNull()
+    expect(
+      parseServerDocFrame(docUpdateFrame({ update_b64: encoded }))
+    ).not.toBeNull()
   })
 
   it('accepts canonical padding for the same byte', () => {
-    const parsed = parseServerDocFrame(docUpdate('YQ=='))
+    const parsed = parseServerDocFrame(docUpdateFrame({ update_b64: 'YQ==' }))
     expect(parsed).not.toBeNull()
     expect(parsed?.type).toBe('doc_update')
   })

--- a/src/workbench/extensions/agent/crdt/docFrameClient.base64.test.ts
+++ b/src/workbench/extensions/agent/crdt/docFrameClient.base64.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+
+import { parseServerDocFrame } from './docFrameClient'
+
+function docUpdate(updateB64: string): unknown {
+  return {
+    type: 'doc_update',
+    data: {
+      v: 1,
+      workflow_id: 'workflow-1',
+      seq: 1,
+      update_b64: updateB64
+    }
+  }
+}
+
+describe('parseServerDocFrame doc_update base64 validation', () => {
+  it('rejects non-base64 characters without throwing', () => {
+    expect(() => parseServerDocFrame(docUpdate('YQ$='))).not.toThrow()
+    expect(parseServerDocFrame(docUpdate('YQ$='))).toBeNull()
+  })
+
+  it('rejects truncated base64 without throwing', () => {
+    expect(() => parseServerDocFrame(docUpdate('YQ='))).not.toThrow()
+    expect(parseServerDocFrame(docUpdate('YQ='))).toBeNull()
+  })
+
+  it('rejects decoded updates larger than 8 MiB without throwing', () => {
+    const encoded = 'AAAA'.repeat((8 * 1024 * 1024 + 1) / 3)
+
+    expect(() => parseServerDocFrame(docUpdate(encoded))).not.toThrow()
+    expect(parseServerDocFrame(docUpdate(encoded))).toBeNull()
+  })
+
+  it('rejects an empty update without throwing', () => {
+    expect(() => parseServerDocFrame(docUpdate(''))).not.toThrow()
+    expect(parseServerDocFrame(docUpdate(''))).toBeNull()
+  })
+})

--- a/src/workbench/extensions/agent/crdt/docFrameClient.grammar.test.ts
+++ b/src/workbench/extensions/agent/crdt/docFrameClient.grammar.test.ts
@@ -1,98 +1,49 @@
 import { describe, expect, it } from 'vitest'
 
+import {
+  awarenessFrame,
+  docOpsResultFrame,
+  docResetFrame,
+  docSubscribedFrame,
+  docUpdateFrame
+} from './__fixtures__/docFrameClient'
 import { parseServerDocFrame } from './docFrameClient'
 
 const validFrames = [
-  {
-    type: 'doc_update',
-    data: {
-      v: 1,
-      workflow_id: 'workflow_1-ABC',
-      seq: 1,
-      update_b64: 'AQ==',
-      actor: 'agent:thread-1:turn-1'
-    }
-  },
-  {
-    type: 'doc_subscribed',
-    data: { v: 1, workflow_id: 'workflow_1-ABC', ok: true, seq: 1 }
-  },
-  {
-    type: 'doc_ops_result',
-    data: {
-      v: 1,
-      workflow_id: 'workflow_1-ABC',
-      ok: true,
-      seq: 1,
-      applied: [],
-      skipped: []
-    }
-  },
-  {
-    type: 'doc_reset',
-    data: {
-      v: 1,
-      workflow_id: 'workflow_1-ABC',
-      seq: 1,
-      actor: 'system:mint'
-    }
-  },
-  {
-    type: 'awareness',
-    data: {
-      v: 1,
-      workflow_id: 'workflow_1-ABC',
-      actor: 'human:user-1:tab-1',
-      state: {}
-    }
-  }
-] as const
+  docUpdateFrame({
+    workflow_id: 'workflow_1-ABC',
+    actor: 'agent:thread-1:turn-1'
+  }),
+  docSubscribedFrame({ workflow_id: 'workflow_1-ABC' }),
+  docOpsResultFrame({ workflow_id: 'workflow_1-ABC', seq: 1 }),
+  docResetFrame({ workflow_id: 'workflow_1-ABC' }),
+  awarenessFrame({
+    workflow_id: 'workflow_1-ABC',
+    actor: 'human:user-1:tab-1'
+  })
+]
+
+const invalidWorkflowIds: [string, string][] = [
+  ['an empty workflow_id', ''],
+  ['a workflow_id containing whitespace', 'workflow invalid'],
+  ['a workflow_id exceeding 128 encoded bytes', 'w'.repeat(129)],
+  ['a workflow_id containing invalid characters', 'workflow:invalid']
+]
+
+const invalidActors: [string, string][] = [
+  ['an actor exceeding 256 encoded bytes', `human:${'u'.repeat(250)}:tab`],
+  ['an actor outside the closed actor grammar', 'operator:user:tab']
+]
 
 describe('document frame identifier grammar', () => {
-  it('rejects a workflow_id exceeding 128 encoded bytes', () => {
+  it.for(invalidWorkflowIds)('rejects %s', ([_name, workflowId]) => {
     expect(
-      parseServerDocFrame({
-        type: 'doc_subscribed',
-        data: { v: 1, workflow_id: 'w'.repeat(129), ok: true, seq: 1 }
-      })
+      parseServerDocFrame(docSubscribedFrame({ workflow_id: workflowId }))
     ).toBeNull()
   })
 
-  it('rejects a workflow_id containing invalid characters', () => {
-    expect(
-      parseServerDocFrame({
-        type: 'doc_subscribed',
-        data: { v: 1, workflow_id: 'workflow:invalid', ok: true, seq: 1 }
-      })
-    ).toBeNull()
-  })
-
-  it('rejects an actor exceeding 256 encoded bytes', () => {
-    expect(
-      parseServerDocFrame({
-        type: 'awareness',
-        data: {
-          v: 1,
-          workflow_id: 'workflow-1',
-          actor: `human:${'u'.repeat(250)}:tab`,
-          state: {}
-        }
-      })
-    ).toBeNull()
-  })
-
-  it('rejects an actor outside the closed actor grammar', () => {
-    expect(
-      parseServerDocFrame({
-        type: 'awareness',
-        data: {
-          v: 1,
-          workflow_id: 'workflow-1',
-          actor: 'operator:user:tab',
-          state: {}
-        }
-      })
-    ).toBeNull()
+  it.for(invalidActors)('rejects %s', ([_name, actor]) => {
+    expect(parseServerDocFrame(awarenessFrame({ actor }))).toBeNull()
   })
 
   it.for(validFrames)('accepts valid identifiers in $type', (frame) => {

--- a/src/workbench/extensions/agent/crdt/docFrameClient.grammar.test.ts
+++ b/src/workbench/extensions/agent/crdt/docFrameClient.grammar.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest'
+
+import { parseServerDocFrame } from './docFrameClient'
+
+const validFrames = [
+  {
+    type: 'doc_update',
+    data: {
+      v: 1,
+      workflow_id: 'workflow_1-ABC',
+      seq: 1,
+      update_b64: 'AQ==',
+      actor: 'agent:thread-1:turn-1'
+    }
+  },
+  {
+    type: 'doc_subscribed',
+    data: { v: 1, workflow_id: 'workflow_1-ABC', ok: true, seq: 1 }
+  },
+  {
+    type: 'doc_ops_result',
+    data: {
+      v: 1,
+      workflow_id: 'workflow_1-ABC',
+      ok: true,
+      seq: 1,
+      applied: [],
+      skipped: []
+    }
+  },
+  {
+    type: 'doc_reset',
+    data: {
+      v: 1,
+      workflow_id: 'workflow_1-ABC',
+      seq: 1,
+      actor: 'system:mint'
+    }
+  },
+  {
+    type: 'awareness',
+    data: {
+      v: 1,
+      workflow_id: 'workflow_1-ABC',
+      actor: 'human:user-1:tab-1',
+      state: {}
+    }
+  }
+] as const
+
+describe('document frame identifier grammar', () => {
+  it('rejects a workflow_id exceeding 128 encoded bytes', () => {
+    expect(
+      parseServerDocFrame({
+        type: 'doc_subscribed',
+        data: { v: 1, workflow_id: 'w'.repeat(129), ok: true, seq: 1 }
+      })
+    ).toBeNull()
+  })
+
+  it('rejects a workflow_id containing invalid characters', () => {
+    expect(
+      parseServerDocFrame({
+        type: 'doc_subscribed',
+        data: { v: 1, workflow_id: 'workflow:invalid', ok: true, seq: 1 }
+      })
+    ).toBeNull()
+  })
+
+  it('rejects an actor exceeding 256 encoded bytes', () => {
+    expect(
+      parseServerDocFrame({
+        type: 'awareness',
+        data: {
+          v: 1,
+          workflow_id: 'workflow-1',
+          actor: `human:${'u'.repeat(250)}:tab`,
+          state: {}
+        }
+      })
+    ).toBeNull()
+  })
+
+  it('rejects an actor outside the closed actor grammar', () => {
+    expect(
+      parseServerDocFrame({
+        type: 'awareness',
+        data: {
+          v: 1,
+          workflow_id: 'workflow-1',
+          actor: 'operator:user:tab',
+          state: {}
+        }
+      })
+    ).toBeNull()
+  })
+
+  it.for(validFrames)('accepts valid identifiers in $type', (frame) => {
+    expect(parseServerDocFrame(frame)).not.toBeNull()
+  })
+})

--- a/src/workbench/extensions/agent/crdt/docFrameClient.test.ts
+++ b/src/workbench/extensions/agent/crdt/docFrameClient.test.ts
@@ -42,13 +42,13 @@ describe('doc frame client', () => {
         workflow_id: 'wf-1',
         seq: 1,
         update_b64: encodeBase64(encoded),
-        actor: 'agent:turn-1',
-        op_ids: ['op-1', 42, 'op-2']
+        actor: 'agent:thread-1:turn-1',
+        op_ids: ['op-1', 'op-2']
       }
     })
     expect(frame?.type).toBe('doc_update')
     if (frame?.type !== 'doc_update') throw new Error('Expected doc_update')
-    expect(frame.data.actor).toBe('agent:turn-1')
+    expect(frame.data.actor).toBe('agent:thread-1:turn-1')
     expect(frame.data.opIds).toEqual(['op-1', 'op-2'])
 
     const follower = new FollowerDoc()
@@ -222,5 +222,107 @@ describe('doc frame client', () => {
         expiresAt: 123
       }
     })
+  })
+
+  it.for([
+    ['invalid base64 characters', { seq: 1, update_b64: '!!!=' }],
+    ['partial base64', { seq: 1, update_b64: 'AQ' }],
+    ['empty base64', { seq: 1, update_b64: '' }],
+    ['negative sequence', { seq: -1, update_b64: 'AQ==' }],
+    ['fractional sequence', { seq: 1.5, update_b64: 'AQ==' }],
+    ['mixed op ids', { seq: 1, update_b64: 'AQ==', op_ids: ['ok', 1] }],
+    ['invalid actor', { seq: 1, update_b64: 'AQ==', actor: 'unknown:value' }]
+  ])('rejects %s in doc_update without throwing', (_name, fields) => {
+    expect(() =>
+      parseServerDocFrame({
+        type: 'doc_update',
+        data: { v: 1, workflow_id: 'wf-1', ...fields }
+      })
+    ).not.toThrow()
+    expect(
+      parseServerDocFrame({
+        type: 'doc_update',
+        data: { v: 1, workflow_id: 'wf-1', ...fields }
+      })
+    ).toBeNull()
+  })
+
+  it('rejects an oversized encoded update before decoding', () => {
+    expect(
+      parseServerDocFrame({
+        type: 'doc_update',
+        data: {
+          v: 1,
+          workflow_id: 'wf-1',
+          seq: 1,
+          update_b64: 'A'.repeat((8 << 20) + 4)
+        }
+      })
+    ).toBeNull()
+  })
+
+  it.for(['', 'wf bad', 'wf:bad', 'x'.repeat(129)])(
+    'rejects invalid workflow id %j',
+    (workflowId) => {
+      expect(
+        parseServerDocFrame({
+          type: 'doc_subscribed',
+          data: { v: 1, workflow_id: workflowId, ok: true, seq: 1 }
+        })
+      ).toBeNull()
+    }
+  )
+
+  it('rejects malformed result arrays, failures, and acknowledgements', () => {
+    const result = (data: Record<string, unknown>) =>
+      parseServerDocFrame({
+        type: 'doc_ops_result',
+        data: { v: 1, workflow_id: 'wf-1', applied: [], skipped: [], ...data }
+      })
+
+    expect(result({ ok: true, applied: ['op-1', 2], seq: 1 })).toBeNull()
+    expect(
+      result({
+        ok: true,
+        seq: 1,
+        failed: { op_id: 'op-1', code: 'x', message: 'x' }
+      })
+    ).toBeNull()
+    expect(result({ ok: false, code: 'x' })).toBeNull()
+    expect(
+      result({
+        ok: false,
+        code: 'rejected',
+        message: 'bad op',
+        failed: { index: 0, op_id: 'op-1', code: 'bad', message: 'bad op' }
+      })
+    ).toMatchObject({ type: 'doc_ops_result' })
+    expect(
+      parseServerDocFrame({
+        type: 'doc_subscribed',
+        data: { v: 1, workflow_id: 'wf-1', ok: true }
+      })
+    ).toBeNull()
+  })
+
+  it('rejects malformed or oversized awareness state', () => {
+    const awareness = (state: unknown, expiresAt: unknown = 1) =>
+      parseServerDocFrame({
+        type: 'awareness',
+        data: {
+          v: 1,
+          workflow_id: 'wf-1',
+          actor: 'human:user:tab',
+          state,
+          expires_at: expiresAt
+        }
+      })
+
+    expect(awareness([])).toBeNull()
+    expect(awareness({ value: 'x'.repeat((8 << 10) + 1) })).toBeNull()
+    expect(awareness({}, -1)).toBeNull()
+    expect(awareness({}, Number.POSITIVE_INFINITY)).toBeNull()
+    expect(awareness({ value: 1n })).toBeNull()
+    expect(awareness({ cursor: [1, 2] })).toMatchObject({ type: 'awareness' })
   })
 })

--- a/src/workbench/extensions/agent/crdt/docFrameClient.test.ts
+++ b/src/workbench/extensions/agent/crdt/docFrameClient.test.ts
@@ -3,6 +3,7 @@ import * as Y from 'yjs'
 
 import { reportError } from '@/platform/telemetry/reportError'
 
+import { docUpdateFrame } from './__fixtures__/docFrameClient'
 import type { DocFrameTransport } from './docFrameClient'
 import {
   DocFrameClient,
@@ -336,12 +337,7 @@ describe('doc frame client', () => {
     const listener = vi.fn()
     client.addEventListener('doc_update', listener)
 
-    const invalidUpdate = {
-      v: 1,
-      workflow_id: 'wf-1',
-      seq: 1,
-      update_b64: 'not-base64'
-    }
+    const invalidUpdate = docUpdateFrame({ update_b64: 'not-base64' }).data
     transport.receive('doc_update', invalidUpdate)
     transport.receive('doc_update', invalidUpdate)
     transport.receive('awareness', {})
@@ -360,103 +356,7 @@ describe('doc frame client', () => {
     })
   })
 
-  const invalidDocUpdateCases: [string, Record<string, unknown>][] = [
-    ['invalid base64 characters', { seq: 1, update_b64: '!!!=' }],
-    ['partial base64', { seq: 1, update_b64: 'AQ' }],
-    ['empty base64', { seq: 1, update_b64: '' }],
-    ['negative sequence', { seq: -1, update_b64: 'AQ==' }],
-    ['fractional sequence', { seq: 1.5, update_b64: 'AQ==' }],
-    ['mixed op ids', { seq: 1, update_b64: 'AQ==', op_ids: ['ok', 1] }]
-  ]
-  it.for(invalidDocUpdateCases)(
-    'rejects %s in doc_update without throwing',
-    ([_name, fields]) => {
-      expect(() =>
-        parseServerDocFrame({
-          type: 'doc_update',
-          data: { v: 1, workflow_id: 'wf-1', ...fields }
-        })
-      ).not.toThrow()
-      expect(
-        parseServerDocFrame({
-          type: 'doc_update',
-          data: { v: 1, workflow_id: 'wf-1', ...fields }
-        })
-      ).toBeNull()
-    }
-  )
-
-  it('rejects an oversized decoded update before decoding', () => {
-    expect(
-      parseServerDocFrame({
-        type: 'doc_update',
-        data: {
-          v: 1,
-          workflow_id: 'wf-1',
-          seq: 1,
-          update_b64: 'AAAA'.repeat(((8 << 20) + 1) / 3)
-        }
-      })
-    ).toBeNull()
-  })
-
-  it.for(['', 'wf bad', 'wf:bad', 'x'.repeat(129)])(
-    'rejects invalid workflow id %j',
-    (workflowId) => {
-      expect(
-        parseServerDocFrame({
-          type: 'doc_subscribed',
-          data: { v: 1, workflow_id: workflowId, ok: true, seq: 1 }
-        })
-      ).toBeNull()
-    }
-  )
-
-  it('rejects malformed result arrays, failures, and acknowledgements', () => {
-    const result = (data: Record<string, unknown>) =>
-      parseServerDocFrame({
-        type: 'doc_ops_result',
-        data: { v: 1, workflow_id: 'wf-1', applied: [], skipped: [], ...data }
-      })
-
-    expect(result({ ok: true, applied: ['op-1', 2], seq: 1 })).toBeNull()
-    expect(
-      result({
-        ok: true,
-        seq: 1,
-        failed: { op_id: 'op-1', code: 'x', message: 'x' }
-      })
-    ).toBeNull()
-    expect(result({ ok: false, code: 1 })).toBeNull()
-    expect(
-      result({
-        ok: false,
-        code: 'rejected',
-        message: 'bad op',
-        failed: { index: 0, op_id: 'op-1', code: 'bad', message: 'bad op' }
-      })
-    ).toMatchObject({ type: 'doc_ops_result' })
-    expect(result({ ok: true, seq: '1' })).toBeNull()
-  })
-
-  it('rejects malformed or oversized awareness state', () => {
-    const awareness = (state: unknown, expiresAt: unknown = 1) =>
-      parseServerDocFrame({
-        type: 'awareness',
-        data: {
-          v: 1,
-          workflow_id: 'wf-1',
-          actor: 'human:user:tab',
-          state,
-          expires_at: expiresAt
-        }
-      })
-
-    expect(awareness([])).toBeNull()
-    expect(awareness({ value: 'x'.repeat((8 << 10) + 1) })).toBeNull()
-    expect(awareness({}, -1)).toBeNull()
-    expect(awareness({}, Number.POSITIVE_INFINITY)).toBeNull()
-    expect(awareness({ value: 1n })).toBeNull()
-    expect(awareness({ cursor: [1, 2] })).toMatchObject({ type: 'awareness' })
+  it.for([-1, 1.5])('rejects invalid sequence %s in doc_update', (seq) => {
+    expect(parseServerDocFrame(docUpdateFrame({ seq }))).toBeNull()
   })
 })

--- a/src/workbench/extensions/agent/crdt/docFrameClient.test.ts
+++ b/src/workbench/extensions/agent/crdt/docFrameClient.test.ts
@@ -373,7 +373,7 @@ describe('doc frame client', () => {
     ).toBeNull()
   })
 
-  it('rejects an oversized encoded update before decoding', () => {
+  it('rejects an oversized decoded update before decoding', () => {
     expect(
       parseServerDocFrame({
         type: 'doc_update',
@@ -381,7 +381,7 @@ describe('doc frame client', () => {
           v: 1,
           workflow_id: 'wf-1',
           seq: 1,
-          update_b64: 'A'.repeat((8 << 20) + 4)
+          update_b64: 'AAAA'.repeat(((8 << 20) + 1) / 3)
         }
       })
     ).toBeNull()

--- a/src/workbench/extensions/agent/crdt/docFrameClient.test.ts
+++ b/src/workbench/extensions/agent/crdt/docFrameClient.test.ts
@@ -351,27 +351,31 @@ describe('doc frame client', () => {
     })
   })
 
-  it.for([
+  const invalidDocUpdateCases: [string, Record<string, unknown>][] = [
     ['invalid base64 characters', { seq: 1, update_b64: '!!!=' }],
     ['partial base64', { seq: 1, update_b64: 'AQ' }],
     ['empty base64', { seq: 1, update_b64: '' }],
     ['negative sequence', { seq: -1, update_b64: 'AQ==' }],
     ['fractional sequence', { seq: 1.5, update_b64: 'AQ==' }],
     ['mixed op ids', { seq: 1, update_b64: 'AQ==', op_ids: ['ok', 1] }]
-  ])('rejects %s in doc_update without throwing', (_name, fields) => {
-    expect(() =>
-      parseServerDocFrame({
-        type: 'doc_update',
-        data: { v: 1, workflow_id: 'wf-1', ...fields }
-      })
-    ).not.toThrow()
-    expect(
-      parseServerDocFrame({
-        type: 'doc_update',
-        data: { v: 1, workflow_id: 'wf-1', ...fields }
-      })
-    ).toBeNull()
-  })
+  ]
+  it.for(invalidDocUpdateCases)(
+    'rejects %s in doc_update without throwing',
+    ([_name, fields]) => {
+      expect(() =>
+        parseServerDocFrame({
+          type: 'doc_update',
+          data: { v: 1, workflow_id: 'wf-1', ...fields }
+        })
+      ).not.toThrow()
+      expect(
+        parseServerDocFrame({
+          type: 'doc_update',
+          data: { v: 1, workflow_id: 'wf-1', ...fields }
+        })
+      ).toBeNull()
+    }
+  )
 
   it('rejects an oversized decoded update before decoding', () => {
     expect(

--- a/src/workbench/extensions/agent/crdt/docFrameClient.test.ts
+++ b/src/workbench/extensions/agent/crdt/docFrameClient.test.ts
@@ -330,23 +330,32 @@ describe('doc frame client', () => {
     })
   })
 
-  it('reports malformed inbound frames without forwarding them', () => {
+  it('reports the first malformed inbound frame per type', () => {
     const transport = new TestTransport()
     const client = new DocFrameClient(transport)
     const listener = vi.fn()
     client.addEventListener('doc_update', listener)
 
-    transport.receive('doc_update', {
+    const invalidUpdate = {
       v: 1,
       workflow_id: 'wf-1',
       seq: 1,
       update_b64: 'not-base64'
-    })
+    }
+    transport.receive('doc_update', invalidUpdate)
+    transport.receive('doc_update', invalidUpdate)
+    transport.receive('awareness', {})
 
     expect(listener).not.toHaveBeenCalled()
+    expect(reportError).toHaveBeenCalledTimes(2)
     expect(reportError).toHaveBeenCalledWith(expect.any(Error), {
       errorType: 'agent_crdt_invalid_server_frame',
       tags: { frame_type: 'doc_update' },
+      level: 'warning'
+    })
+    expect(reportError).toHaveBeenCalledWith(expect.any(Error), {
+      errorType: 'agent_crdt_invalid_server_frame',
+      tags: { frame_type: 'awareness' },
       level: 'warning'
     })
   })

--- a/src/workbench/extensions/agent/crdt/docFrameClient.test.ts
+++ b/src/workbench/extensions/agent/crdt/docFrameClient.test.ts
@@ -1,5 +1,7 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import * as Y from 'yjs'
+
+import { reportError } from '@/platform/telemetry/reportError'
 
 import type { DocFrameTransport } from './docFrameClient'
 import {
@@ -9,6 +11,8 @@ import {
 } from './docFrameClient'
 import { FollowerDoc } from './followerDoc'
 import { LayoutFollowerBridge } from './layoutFollowerBridge'
+
+vi.mock('@/platform/telemetry/reportError', () => ({ reportError: vi.fn() }))
 
 class TestTransport extends EventTarget implements DocFrameTransport {
   readonly sent: string[] = []
@@ -224,14 +228,136 @@ describe('doc frame client', () => {
     })
   })
 
+  it('keeps optional acknowledgement fields optional', () => {
+    expect(
+      parseServerDocFrame({
+        type: 'doc_subscribed',
+        data: { v: 1, workflow_id: 'wf-1', ok: false, code: 'forbidden' }
+      })
+    ).toEqual({
+      type: 'doc_subscribed',
+      data: { workflowId: 'wf-1', ok: false, code: 'forbidden' }
+    })
+    expect(
+      parseServerDocFrame({
+        type: 'doc_subscribed',
+        data: { v: 1, workflow_id: 'wf-1', ok: true }
+      })
+    ).toEqual({
+      type: 'doc_subscribed',
+      data: { workflowId: 'wf-1', ok: true }
+    })
+    expect(
+      parseServerDocFrame({
+        type: 'doc_ops_result',
+        data: { v: 1, workflow_id: 'wf-1', ok: false, message: 'rejected' }
+      })
+    ).toEqual({
+      type: 'doc_ops_result',
+      data: {
+        workflowId: 'wf-1',
+        ok: false,
+        applied: [],
+        skipped: [],
+        message: 'rejected'
+      }
+    })
+  })
+
+  it('drops malformed advisory actors without dropping effect frames', () => {
+    expect(
+      parseServerDocFrame({
+        type: 'doc_update',
+        data: {
+          v: 1,
+          workflow_id: 'wf-1',
+          seq: 1,
+          update_b64: 'AQ==',
+          actor: 'unknown:value'
+        }
+      })
+    ).toEqual({
+      type: 'doc_update',
+      data: { workflowId: 'wf-1', seq: 1, update: Uint8Array.from([1]) }
+    })
+    expect(
+      parseServerDocFrame({
+        type: 'doc_reset',
+        data: {
+          v: 1,
+          workflow_id: 'wf-1',
+          seq: 2,
+          actor: 'unknown:value'
+        }
+      })
+    ).toEqual({
+      type: 'doc_reset',
+      data: { workflowId: 'wf-1', seq: 2 }
+    })
+  })
+
+  it('treats null optional values as absent', () => {
+    expect(
+      parseServerDocFrame({
+        type: 'doc_ops_result',
+        data: {
+          v: 1,
+          workflow_id: 'wf-1',
+          ok: false,
+          failed: null,
+          code: null,
+          message: null
+        }
+      })
+    ).toEqual({
+      type: 'doc_ops_result',
+      data: { workflowId: 'wf-1', ok: false, applied: [], skipped: [] }
+    })
+    expect(
+      parseServerDocFrame({
+        type: 'awareness',
+        data: {
+          v: 1,
+          workflow_id: 'wf-1',
+          actor: 'human:user:tab',
+          state: null,
+          expires_at: null
+        }
+      })
+    ).toEqual({
+      type: 'awareness',
+      data: { workflowId: 'wf-1', actor: 'human:user:tab' }
+    })
+  })
+
+  it('reports malformed inbound frames without forwarding them', () => {
+    const transport = new TestTransport()
+    const client = new DocFrameClient(transport)
+    const listener = vi.fn()
+    client.addEventListener('doc_update', listener)
+
+    transport.receive('doc_update', {
+      v: 1,
+      workflow_id: 'wf-1',
+      seq: 1,
+      update_b64: 'not-base64'
+    })
+
+    expect(listener).not.toHaveBeenCalled()
+    expect(reportError).toHaveBeenCalledWith(expect.any(Error), {
+      errorType: 'agent_crdt_invalid_server_frame',
+      tags: { frame_type: 'doc_update' },
+      level: 'warning'
+    })
+  })
+
   it.for([
     ['invalid base64 characters', { seq: 1, update_b64: '!!!=' }],
     ['partial base64', { seq: 1, update_b64: 'AQ' }],
     ['empty base64', { seq: 1, update_b64: '' }],
     ['negative sequence', { seq: -1, update_b64: 'AQ==' }],
     ['fractional sequence', { seq: 1.5, update_b64: 'AQ==' }],
-    ['mixed op ids', { seq: 1, update_b64: 'AQ==', op_ids: ['ok', 1] }],
-    ['invalid actor', { seq: 1, update_b64: 'AQ==', actor: 'unknown:value' }]
+    ['mixed op ids', { seq: 1, update_b64: 'AQ==', op_ids: ['ok', 1] }]
   ])('rejects %s in doc_update without throwing', (_name, fields) => {
     expect(() =>
       parseServerDocFrame({
@@ -288,7 +414,7 @@ describe('doc frame client', () => {
         failed: { op_id: 'op-1', code: 'x', message: 'x' }
       })
     ).toBeNull()
-    expect(result({ ok: false, code: 'x' })).toBeNull()
+    expect(result({ ok: false, code: 1 })).toBeNull()
     expect(
       result({
         ok: false,
@@ -297,12 +423,7 @@ describe('doc frame client', () => {
         failed: { index: 0, op_id: 'op-1', code: 'bad', message: 'bad op' }
       })
     ).toMatchObject({ type: 'doc_ops_result' })
-    expect(
-      parseServerDocFrame({
-        type: 'doc_subscribed',
-        data: { v: 1, workflow_id: 'wf-1', ok: true }
-      })
-    ).toBeNull()
+    expect(result({ ok: true, seq: '1' })).toBeNull()
   })
 
   it('rejects malformed or oversized awareness state', () => {

--- a/src/workbench/extensions/agent/crdt/docFrameClient.ts
+++ b/src/workbench/extensions/agent/crdt/docFrameClient.ts
@@ -1,10 +1,16 @@
 import type { Op } from '@comfyorg/comfy-multi-player'
 
+import { reportError } from '@/platform/telemetry/reportError'
+
 const DOC_PROTOCOL_VERSION = 1
 const MAX_DOC_FRAME_B64_LENGTH = 8 << 20
 const MAX_WORKFLOW_ID_LENGTH = 128
 const MAX_ACTOR_LENGTH = 256
 const MAX_AWARENESS_STATE_BYTES = 8 << 10
+const MAX_DOC_OPS_PER_FRAME = 256
+const MAX_OP_ID_LENGTH = 128
+const MAX_ERROR_CODE_LENGTH = 128
+const MAX_ERROR_MESSAGE_LENGTH = 8 << 10
 const utf8 = new TextEncoder()
 
 export interface DocOp {
@@ -46,10 +52,7 @@ interface DocOpsResult {
   skipped: string[]
   code?: string
   message?: string
-  /**
-   * PoC diagnostics: the batch's failure, forwarded verbatim. The wire type is
-   * a single object (`DocOpFailure {op_id, code, message}`), not an array.
-   */
+  /** Validated diagnostics for the first rejected operation in a batch. */
   failed?: DocOpFailure
 }
 
@@ -150,10 +153,18 @@ function parseRecord(value: unknown): Record<string, unknown> | null {
     : null
 }
 
+function isAbsent(value: unknown): value is null | undefined {
+  return value === null || value === undefined
+}
+
+function hasBoundedUtf8Length(value: string, maxBytes: number): boolean {
+  return value.length <= maxBytes && utf8.encode(value).length <= maxBytes
+}
+
 function isValidWorkflowId(value: string): boolean {
   return (
     value.length > 0 &&
-    utf8.encode(value).length <= MAX_WORKFLOW_ID_LENGTH &&
+    hasBoundedUtf8Length(value, MAX_WORKFLOW_ID_LENGTH) &&
     !/[\0\n\r\t :*?[\]]/.test(value)
   )
 }
@@ -161,7 +172,7 @@ function isValidWorkflowId(value: string): boolean {
 function isValidActor(value: string): boolean {
   if (
     value.length === 0 ||
-    utf8.encode(value).length > MAX_ACTOR_LENGTH ||
+    !hasBoundedUtf8Length(value, MAX_ACTOR_LENGTH) ||
     /[\0\n\r\t ]/.test(value)
   )
     return false
@@ -175,7 +186,25 @@ function isSequence(value: unknown): value is number {
 }
 
 function isStringArray(value: unknown): value is string[] {
-  return Array.isArray(value) && value.every((item) => typeof item === 'string')
+  return (
+    Array.isArray(value) &&
+    value.length <= MAX_DOC_OPS_PER_FRAME &&
+    value.every(
+      (item) =>
+        typeof item === 'string' && hasBoundedUtf8Length(item, MAX_OP_ID_LENGTH)
+    )
+  )
+}
+
+function hasValidDiagnostics(data: WireData): boolean {
+  return (
+    (isAbsent(data.code) ||
+      (typeof data.code === 'string' &&
+        hasBoundedUtf8Length(data.code, MAX_ERROR_CODE_LENGTH))) &&
+    (isAbsent(data.message) ||
+      (typeof data.message === 'string' &&
+        hasBoundedUtf8Length(data.message, MAX_ERROR_MESSAGE_LENGTH)))
+  )
 }
 
 /**
@@ -190,18 +219,32 @@ function parseOptionalStringArray(value: unknown): string[] | null {
 
 function parseDocOpFailure(value: unknown): DocOpFailure | null {
   const failure = parseWireData(value)
-  return failure !== null &&
-    isSequence(failure.index) &&
-    (failure.op_id === undefined || typeof failure.op_id === 'string') &&
-    typeof failure.code === 'string' &&
-    typeof failure.message === 'string'
-    ? (failure as DocOpFailure)
-    : null
+  if (
+    failure === null ||
+    !isSequence(failure.index) ||
+    (!isAbsent(failure.op_id) &&
+      (typeof failure.op_id !== 'string' ||
+        !hasBoundedUtf8Length(failure.op_id, MAX_OP_ID_LENGTH))) ||
+    typeof failure.code !== 'string' ||
+    !hasBoundedUtf8Length(failure.code, MAX_ERROR_CODE_LENGTH) ||
+    typeof failure.message !== 'string' ||
+    !hasBoundedUtf8Length(failure.message, MAX_ERROR_MESSAGE_LENGTH)
+  )
+    return null
+
+  return {
+    index: failure.index,
+    ...(!isAbsent(failure.op_id) && { op_id: failure.op_id }),
+    code: failure.code,
+    message: failure.message
+  }
 }
 
 function encodedJsonSize(value: Record<string, unknown>): number | null {
   try {
-    return utf8.encode(JSON.stringify(value)).length
+    const encoded = JSON.stringify(value)
+    if (encoded.length > MAX_AWARENESS_STATE_BYTES) return encoded.length
+    return utf8.encode(encoded).length
   } catch {
     return null
   }
@@ -226,19 +269,18 @@ export function parseServerDocFrame(value: unknown): ServerDocFrame | null {
   ) {
     const update = decodeBase64(data.update_b64)
     if (update === null) return null
-    if (
-      data.actor !== undefined &&
-      (typeof data.actor !== 'string' || !isValidActor(data.actor))
-    )
-      return null
     if (data.op_ids !== undefined && !isStringArray(data.op_ids)) return null
+    const actor =
+      typeof data.actor === 'string' && isValidActor(data.actor)
+        ? data.actor
+        : undefined
     return {
       type: frame.type,
       data: {
         workflowId: data.workflow_id,
         seq: data.seq,
         update,
-        ...(typeof data.actor === 'string' && { actor: data.actor }),
+        ...(actor !== undefined && { actor }),
         ...(Array.isArray(data.op_ids) && {
           opIds: data.op_ids
         })
@@ -248,9 +290,8 @@ export function parseServerDocFrame(value: unknown): ServerDocFrame | null {
 
   if (frame.type === 'doc_subscribed' && typeof data.ok === 'boolean') {
     if (
-      data.ok
-        ? !isSequence(data.seq)
-        : typeof data.code !== 'string' || typeof data.message !== 'string'
+      (!isAbsent(data.seq) && !isSequence(data.seq)) ||
+      !hasValidDiagnostics(data)
     )
       return null
     return {
@@ -270,13 +311,12 @@ export function parseServerDocFrame(value: unknown): ServerDocFrame | null {
     const skipped = parseOptionalStringArray(data.skipped)
     if (applied === null || skipped === null) return null
     if (
-      data.ok
-        ? !isSequence(data.seq)
-        : typeof data.code !== 'string' || typeof data.message !== 'string'
+      (!isAbsent(data.seq) && !isSequence(data.seq)) ||
+      !hasValidDiagnostics(data)
     )
       return null
     let failed: DocOpFailure | undefined
-    if (data.failed !== undefined) {
+    if (!isAbsent(data.failed)) {
       const parsedFailure = parseDocOpFailure(data.failed)
       if (parsedFailure === null) return null
       failed = parsedFailure
@@ -291,45 +331,42 @@ export function parseServerDocFrame(value: unknown): ServerDocFrame | null {
         ...(isSequence(data.seq) && { seq: data.seq }),
         ...(typeof data.code === 'string' && { code: data.code }),
         ...(typeof data.message === 'string' && { message: data.message }),
-        // PoC diagnostics: surface the failure verbatim (object, not array).
         ...(failed !== undefined && { failed })
       }
     }
   }
 
   if (frame.type === 'doc_reset' && isSequence(data.seq)) {
-    if (
-      data.actor !== undefined &&
-      (typeof data.actor !== 'string' || !isValidActor(data.actor))
-    )
-      return null
+    const actor =
+      typeof data.actor === 'string' && isValidActor(data.actor)
+        ? data.actor
+        : undefined
     return {
       type: frame.type,
       data: {
         workflowId: data.workflow_id,
         seq: data.seq,
-        ...(typeof data.actor === 'string' && { actor: data.actor })
+        ...(actor !== undefined && { actor })
       }
     }
   }
 
   if (frame.type === 'awareness' && typeof data.actor === 'string') {
     if (!isValidActor(data.actor)) return null
-    const state = data.state == null ? undefined : parseRecord(data.state)
-    if (state === null) return null
-    if (state !== undefined) {
+    const state = parseRecord(data.state)
+    if (!isAbsent(data.state) && state === null) return null
+    if (state !== null) {
       const stateSize = encodedJsonSize(state)
       if (stateSize === null || stateSize > MAX_AWARENESS_STATE_BYTES)
         return null
     }
-    if (data.expires_at !== undefined && !isSequence(data.expires_at))
-      return null
+    if (!isAbsent(data.expires_at) && !isSequence(data.expires_at)) return null
     return {
       type: frame.type,
       data: {
         workflowId: data.workflow_id,
         actor: data.actor,
-        ...(state !== undefined && { state }),
+        ...(state !== null && { state }),
         ...(isSequence(data.expires_at) && {
           expiresAt: data.expires_at
         })
@@ -355,8 +392,15 @@ export class DocFrameClient extends EventTarget {
       const listener: EventListener = (event) => {
         if (!(event instanceof CustomEvent)) return
         const parsed = parseServerDocFrame({ type, data: event.detail })
-        if (parsed)
+        if (parsed) {
           this.dispatchEvent(new CustomEvent(type, { detail: parsed.data }))
+          return
+        }
+        reportError(new Error('Discarded invalid server document frame'), {
+          errorType: 'agent_crdt_invalid_server_frame',
+          tags: { frame_type: type },
+          level: 'warning'
+        })
       }
       this.listeners.set(type, listener)
       transport.addEventListener(type, listener)

--- a/src/workbench/extensions/agent/crdt/docFrameClient.ts
+++ b/src/workbench/extensions/agent/crdt/docFrameClient.ts
@@ -217,7 +217,7 @@ function hasValidDiagnostics(data: WireData): boolean {
  * protocol violation.
  */
 function parseOptionalStringArray(value: unknown): string[] | null {
-  if (value === undefined) return []
+  if (isAbsent(value)) return []
   return isStringArray(value) ? value : null
 }
 
@@ -273,7 +273,7 @@ export function parseServerDocFrame(value: unknown): ServerDocFrame | null {
   ) {
     const update = decodeBase64(data.update_b64)
     if (update === null) return null
-    if (data.op_ids !== undefined && !isStringArray(data.op_ids)) return null
+    if (!isAbsent(data.op_ids) && !isStringArray(data.op_ids)) return null
     const actor =
       typeof data.actor === 'string' && isValidActor(data.actor)
         ? data.actor

--- a/src/workbench/extensions/agent/crdt/docFrameClient.ts
+++ b/src/workbench/extensions/agent/crdt/docFrameClient.ts
@@ -11,6 +11,8 @@ const MAX_DOC_OPS_PER_FRAME = 256
 const MAX_OP_ID_LENGTH = 128
 const MAX_ERROR_CODE_LENGTH = 128
 const MAX_ERROR_MESSAGE_LENGTH = 8 << 10
+const BASE64_SINGLE_PADDING_END = /[AEIMQUYcgkosw048]=$/
+const BASE64_DOUBLE_PADDING_END = /[AQgw]==$/
 const utf8 = new TextEncoder()
 
 export interface DocOp {
@@ -126,24 +128,14 @@ function decodeBase64(value: string): Uint8Array | null {
 
   // `atob` is permissive about missing padding, so require canonical standard
   // base64 before decoding the untrusted wire value.
-  if (
-    !/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/.test(
-      value
-    )
-  )
-    return null
+  if (!/^[A-Za-z0-9+/]*={0,2}$/.test(value)) return null
+
+  if (padding === 2 && !BASE64_DOUBLE_PADDING_END.test(value)) return null
+  if (padding === 1 && !BASE64_SINGLE_PADDING_END.test(value)) return null
 
   try {
     const binary = atob(value)
-    const bytes = Uint8Array.from(binary, (character) =>
-      character.charCodeAt(0)
-    )
-    // The regex above only checks alphabet and padding shape, not unused pad
-    // bits (RFC 4648 §3.5): `YR==` and `YQ==` both pass it and decode to the
-    // same byte, which is a malleability hole for an op_id-derived digest.
-    // Re-encoding canonically and requiring an exact match rejects that.
-    if (encodeBase64(bytes) !== value) return null
-    return bytes
+    return Uint8Array.from(binary, (character) => character.charCodeAt(0))
   } catch {
     return null
   }
@@ -194,7 +186,7 @@ function isValidActor(value: string): boolean {
 }
 
 function isSequence(value: unknown): value is number {
-  return Number.isSafeInteger(value) && (value as number) >= 0
+  return typeof value === 'number' && Number.isSafeInteger(value) && value >= 0
 }
 
 function isStringArray(value: unknown): value is string[] {
@@ -397,6 +389,7 @@ export class DocFrameClient extends EventTarget {
 
   constructor(private readonly transport: DocFrameTransport) {
     super()
+    const reportedTypes = new Set<string>()
     for (const type of [
       'doc_update',
       'doc_subscribed',
@@ -411,6 +404,8 @@ export class DocFrameClient extends EventTarget {
           this.dispatchEvent(new CustomEvent(type, { detail: parsed.data }))
           return
         }
+        if (reportedTypes.has(type)) return
+        reportedTypes.add(type)
         reportError(new Error('Discarded invalid server document frame'), {
           errorType: 'agent_crdt_invalid_server_frame',
           tags: { frame_type: type },

--- a/src/workbench/extensions/agent/crdt/docFrameClient.ts
+++ b/src/workbench/extensions/agent/crdt/docFrameClient.ts
@@ -1,7 +1,10 @@
 import type { Op } from '@comfyorg/comfy-multi-player'
 
 const DOC_PROTOCOL_VERSION = 1
-const MAX_AWARENESS_STATE_BYTES = 8 * 1024
+const MAX_DOC_FRAME_B64_LENGTH = 8 << 20
+const MAX_WORKFLOW_ID_LENGTH = 128
+const MAX_ACTOR_LENGTH = 256
+const MAX_AWARENESS_STATE_BYTES = 8 << 10
 
 export interface DocOp {
   op_id: string
@@ -26,6 +29,13 @@ export interface DocSubscribed {
   message?: string
 }
 
+interface DocOpFailure {
+  index: number
+  op_id: string
+  code: string
+  message: string
+}
+
 interface DocOpsResult {
   workflowId: string
   ok: boolean
@@ -38,7 +48,7 @@ interface DocOpsResult {
    * PoC diagnostics: the batch's failure, forwarded verbatim. The wire type is
    * a single object (`DocOpFailure {op_id, code, message}`), not an array.
    */
-  failed?: unknown
+  failed?: DocOpFailure
 }
 
 interface DocAwareness {
@@ -100,11 +110,26 @@ interface WireData {
   failed?: unknown
   state?: unknown
   expires_at?: unknown
+  index?: unknown
+  op_id?: unknown
 }
 
-function decodeBase64(value: string): Uint8Array {
-  const binary = atob(value)
-  return Uint8Array.from(binary, (character) => character.charCodeAt(0))
+function decodeBase64(value: string): Uint8Array | null {
+  if (value === '' || value.length > MAX_DOC_FRAME_B64_LENGTH) return null
+  // `atob` is permissive about missing padding, so require canonical standard
+  // base64 before decoding the untrusted wire value.
+  if (
+    !/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/.test(
+      value
+    )
+  )
+    return null
+  try {
+    const binary = atob(value)
+    return Uint8Array.from(binary, (character) => character.charCodeAt(0))
+  } catch {
+    return null
+  }
 }
 
 export function encodeBase64(value: Uint8Array): string {
@@ -123,33 +148,48 @@ function parseRecord(value: unknown): Record<string, unknown> | null {
     : null
 }
 
-/** Unix seconds on the wire: a non-negative integer inside the safe range. */
-function isNonNegativeInteger(value: unknown): value is number {
-  return typeof value === 'number' && Number.isSafeInteger(value) && value >= 0
+function isValidWorkflowId(value: string): boolean {
+  return (
+    value.length > 0 &&
+    new TextEncoder().encode(value).length <= MAX_WORKFLOW_ID_LENGTH &&
+    !/[\0\n\r\t :*?[\]]/.test(value)
+  )
 }
 
-function parseAwarenessState(
-  value: unknown
-): Record<string, unknown> | undefined | null {
-  // The Go server's `State map[string]any` has `omitempty`, so it never
-  // emits `state: null` on the wire; nil/empty maps are omitted entirely,
-  // same as an absent field. Treat null the same as absent (no state) rather
-  // than rejecting the whole frame, so a value the server cannot actually
-  // send does not discard `actor`/`expires_at` too. A non-null, non-record
-  // shape (array, string, number) is still a malformed frame and rejected.
-  // discussion_r3911665011.
-  if (value === undefined || value === null) return undefined
-  const state = parseRecord(value)
-  if (state === null) return null
+function isValidActor(value: string): boolean {
+  if (
+    value.length === 0 ||
+    new TextEncoder().encode(value).length > MAX_ACTOR_LENGTH ||
+    /[\0\n\r\t ]/.test(value)
+  )
+    return false
+  if (value === 'system:mint') return true
+  const match = /^(?:agent|human):([^:]+):([^:]+)$/.exec(value)
+  return match !== null
+}
 
-  // Defence in depth behind the server's identical cap. The counts are not
-  // byte-identical: Go's json.Marshal HTML-escapes `<`, `>` and `&`, so the
-  // server always counts >= this and is the stricter of the two.
+function isSequence(value: unknown): value is number {
+  return Number.isSafeInteger(value) && (value as number) >= 0
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((item) => typeof item === 'string')
+}
+
+function parseDocOpFailure(value: unknown): DocOpFailure | null {
+  const failure = parseWireData(value)
+  return failure !== null &&
+    isSequence(failure.index) &&
+    typeof failure.op_id === 'string' &&
+    typeof failure.code === 'string' &&
+    typeof failure.message === 'string'
+    ? (failure as DocOpFailure)
+    : null
+}
+
+function encodedJsonSize(value: Record<string, unknown>): number | null {
   try {
-    return new TextEncoder().encode(JSON.stringify(state)).byteLength <=
-      MAX_AWARENESS_STATE_BYTES
-      ? state
-      : null
+    return new TextEncoder().encode(JSON.stringify(value)).length
   } catch {
     return null
   }
@@ -162,38 +202,51 @@ export function parseServerDocFrame(value: unknown): ServerDocFrame | null {
   if (
     data === null ||
     data.v !== DOC_PROTOCOL_VERSION ||
-    typeof data.workflow_id !== 'string'
+    typeof data.workflow_id !== 'string' ||
+    !isValidWorkflowId(data.workflow_id)
   )
     return null
 
   if (
     frame.type === 'doc_update' &&
-    typeof data.seq === 'number' &&
+    isSequence(data.seq) &&
     typeof data.update_b64 === 'string'
   ) {
+    const update = decodeBase64(data.update_b64)
+    if (update === null) return null
+    if (
+      data.actor !== undefined &&
+      (typeof data.actor !== 'string' || !isValidActor(data.actor))
+    )
+      return null
+    if (data.op_ids !== undefined && !isStringArray(data.op_ids)) return null
     return {
       type: frame.type,
       data: {
         workflowId: data.workflow_id,
         seq: data.seq,
-        update: decodeBase64(data.update_b64),
+        update,
         ...(typeof data.actor === 'string' && { actor: data.actor }),
         ...(Array.isArray(data.op_ids) && {
-          opIds: data.op_ids.filter(
-            (item): item is string => typeof item === 'string'
-          )
+          opIds: data.op_ids
         })
       }
     }
   }
 
   if (frame.type === 'doc_subscribed' && typeof data.ok === 'boolean') {
+    if (
+      data.ok
+        ? !isSequence(data.seq)
+        : typeof data.code !== 'string' || typeof data.message !== 'string'
+    )
+      return null
     return {
       type: frame.type,
       data: {
         workflowId: data.workflow_id,
         ok: data.ok,
-        ...(typeof data.seq === 'number' && { seq: data.seq }),
+        ...(isSequence(data.seq) && { seq: data.seq }),
         ...(typeof data.code === 'string' && { code: data.code }),
         ...(typeof data.message === 'string' && { message: data.message })
       }
@@ -201,31 +254,42 @@ export function parseServerDocFrame(value: unknown): ServerDocFrame | null {
   }
 
   if (frame.type === 'doc_ops_result' && typeof data.ok === 'boolean') {
+    if (!isStringArray(data.applied) || !isStringArray(data.skipped))
+      return null
+    if (
+      data.ok
+        ? !isSequence(data.seq)
+        : typeof data.code !== 'string' || typeof data.message !== 'string'
+    )
+      return null
+    let failed: DocOpFailure | undefined
+    if (data.failed !== undefined) {
+      const parsedFailure = parseDocOpFailure(data.failed)
+      if (parsedFailure === null) return null
+      failed = parsedFailure
+    }
     return {
       type: frame.type,
       data: {
         workflowId: data.workflow_id,
         ok: data.ok,
-        applied: Array.isArray(data.applied)
-          ? data.applied.filter(
-              (item): item is string => typeof item === 'string'
-            )
-          : [],
-        skipped: Array.isArray(data.skipped)
-          ? data.skipped.filter(
-              (item): item is string => typeof item === 'string'
-            )
-          : [],
-        ...(typeof data.seq === 'number' && { seq: data.seq }),
+        applied: data.applied,
+        skipped: data.skipped,
+        ...(isSequence(data.seq) && { seq: data.seq }),
         ...(typeof data.code === 'string' && { code: data.code }),
         ...(typeof data.message === 'string' && { message: data.message }),
         // PoC diagnostics: surface the failure verbatim (object, not array).
-        ...(data.failed != null && { failed: data.failed })
+        ...(failed !== undefined && { failed })
       }
     }
   }
 
-  if (frame.type === 'doc_reset' && typeof data.seq === 'number') {
+  if (frame.type === 'doc_reset' && isSequence(data.seq)) {
+    if (
+      data.actor !== undefined &&
+      (typeof data.actor !== 'string' || !isValidActor(data.actor))
+    )
+      return null
     return {
       type: frame.type,
       data: {
@@ -237,20 +301,23 @@ export function parseServerDocFrame(value: unknown): ServerDocFrame | null {
   }
 
   if (frame.type === 'awareness' && typeof data.actor === 'string') {
-    const state = parseAwarenessState(data.state)
-    if (
-      state === null ||
-      (data.expires_at !== undefined && !isNonNegativeInteger(data.expires_at))
-    )
+    if (!isValidActor(data.actor)) return null
+    const state = data.state == null ? undefined : parseRecord(data.state)
+    if (state === null) return null
+    if (state !== undefined) {
+      const stateSize = encodedJsonSize(state)
+      if (stateSize === null || stateSize > MAX_AWARENESS_STATE_BYTES)
+        return null
+    }
+    if (data.expires_at !== undefined && !isSequence(data.expires_at))
       return null
-
     return {
       type: frame.type,
       data: {
         workflowId: data.workflow_id,
         actor: data.actor,
         ...(state !== undefined && { state }),
-        ...(data.expires_at !== undefined && {
+        ...(isSequence(data.expires_at) && {
           expiresAt: data.expires_at
         })
       }

--- a/src/workbench/extensions/agent/crdt/docFrameClient.ts
+++ b/src/workbench/extensions/agent/crdt/docFrameClient.ts
@@ -135,7 +135,15 @@ function decodeBase64(value: string): Uint8Array | null {
 
   try {
     const binary = atob(value)
-    return Uint8Array.from(binary, (character) => character.charCodeAt(0))
+    const bytes = Uint8Array.from(binary, (character) =>
+      character.charCodeAt(0)
+    )
+    // The regex above only checks alphabet and padding shape, not unused pad
+    // bits (RFC 4648 §3.5): `YR==` and `YQ==` both pass it and decode to the
+    // same byte, which is a malleability hole for an op_id-derived digest.
+    // Re-encoding canonically and requiring an exact match rejects that.
+    if (encodeBase64(bytes) !== value) return null
+    return bytes
   } catch {
     return null
   }
@@ -244,6 +252,9 @@ function parseDocOpFailure(value: unknown): DocOpFailure | null {
   }
 }
 
+// Defence in depth behind the server's identical cap. The counts are not
+// byte-identical: Go's json.Marshal HTML-escapes `<`, `>` and `&`, so the
+// server always counts >= this and is the stricter of the two.
 function encodedJsonSize(value: Record<string, unknown>): number | null {
   try {
     const encoded = JSON.stringify(value)

--- a/src/workbench/extensions/agent/crdt/docFrameClient.ts
+++ b/src/workbench/extensions/agent/crdt/docFrameClient.ts
@@ -3,7 +3,7 @@ import type { Op } from '@comfyorg/comfy-multi-player'
 import { reportError } from '@/platform/telemetry/reportError'
 
 const DOC_PROTOCOL_VERSION = 1
-const MAX_DOC_FRAME_B64_LENGTH = 8 << 20
+const MAX_DOC_UPDATE_BYTES = 8 << 20
 const MAX_WORKFLOW_ID_LENGTH = 128
 const MAX_ACTOR_LENGTH = 256
 const MAX_AWARENESS_STATE_BYTES = 8 << 10
@@ -120,7 +120,10 @@ interface WireData {
 }
 
 function decodeBase64(value: string): Uint8Array | null {
-  if (value === '' || value.length > MAX_DOC_FRAME_B64_LENGTH) return null
+  if (value === '' || value.length % 4 !== 0) return null
+  const padding = value.endsWith('==') ? 2 : value.endsWith('=') ? 1 : 0
+  if ((value.length / 4) * 3 - padding > MAX_DOC_UPDATE_BYTES) return null
+
   // `atob` is permissive about missing padding, so require canonical standard
   // base64 before decoding the untrusted wire value.
   if (
@@ -129,6 +132,7 @@ function decodeBase64(value: string): Uint8Array | null {
     )
   )
     return null
+
   try {
     const binary = atob(value)
     return Uint8Array.from(binary, (character) => character.charCodeAt(0))

--- a/src/workbench/extensions/agent/crdt/docFrameClient.ts
+++ b/src/workbench/extensions/agent/crdt/docFrameClient.ts
@@ -5,6 +5,7 @@ const MAX_DOC_FRAME_B64_LENGTH = 8 << 20
 const MAX_WORKFLOW_ID_LENGTH = 128
 const MAX_ACTOR_LENGTH = 256
 const MAX_AWARENESS_STATE_BYTES = 8 << 10
+const utf8 = new TextEncoder()
 
 export interface DocOp {
   op_id: string
@@ -31,7 +32,8 @@ export interface DocSubscribed {
 
 interface DocOpFailure {
   index: number
-  op_id: string
+  /** Absent when the relay cannot map the failing index to an op id. */
+  op_id?: string
   code: string
   message: string
 }
@@ -151,7 +153,7 @@ function parseRecord(value: unknown): Record<string, unknown> | null {
 function isValidWorkflowId(value: string): boolean {
   return (
     value.length > 0 &&
-    new TextEncoder().encode(value).length <= MAX_WORKFLOW_ID_LENGTH &&
+    utf8.encode(value).length <= MAX_WORKFLOW_ID_LENGTH &&
     !/[\0\n\r\t :*?[\]]/.test(value)
   )
 }
@@ -159,7 +161,7 @@ function isValidWorkflowId(value: string): boolean {
 function isValidActor(value: string): boolean {
   if (
     value.length === 0 ||
-    new TextEncoder().encode(value).length > MAX_ACTOR_LENGTH ||
+    utf8.encode(value).length > MAX_ACTOR_LENGTH ||
     /[\0\n\r\t ]/.test(value)
   )
     return false
@@ -176,11 +178,21 @@ function isStringArray(value: unknown): value is string[] {
   return Array.isArray(value) && value.every((item) => typeof item === 'string')
 }
 
+/**
+ * The relay serialises `applied`/`skipped` with `omitempty`, so an empty list
+ * arrives as an absent field. Absent means empty; present-but-malformed is a
+ * protocol violation.
+ */
+function parseOptionalStringArray(value: unknown): string[] | null {
+  if (value === undefined) return []
+  return isStringArray(value) ? value : null
+}
+
 function parseDocOpFailure(value: unknown): DocOpFailure | null {
   const failure = parseWireData(value)
   return failure !== null &&
     isSequence(failure.index) &&
-    typeof failure.op_id === 'string' &&
+    (failure.op_id === undefined || typeof failure.op_id === 'string') &&
     typeof failure.code === 'string' &&
     typeof failure.message === 'string'
     ? (failure as DocOpFailure)
@@ -189,7 +201,7 @@ function parseDocOpFailure(value: unknown): DocOpFailure | null {
 
 function encodedJsonSize(value: Record<string, unknown>): number | null {
   try {
-    return new TextEncoder().encode(JSON.stringify(value)).length
+    return utf8.encode(JSON.stringify(value)).length
   } catch {
     return null
   }
@@ -254,8 +266,9 @@ export function parseServerDocFrame(value: unknown): ServerDocFrame | null {
   }
 
   if (frame.type === 'doc_ops_result' && typeof data.ok === 'boolean') {
-    if (!isStringArray(data.applied) || !isStringArray(data.skipped))
-      return null
+    const applied = parseOptionalStringArray(data.applied)
+    const skipped = parseOptionalStringArray(data.skipped)
+    if (applied === null || skipped === null) return null
     if (
       data.ok
         ? !isSequence(data.seq)
@@ -273,8 +286,8 @@ export function parseServerDocFrame(value: unknown): ServerDocFrame | null {
       data: {
         workflowId: data.workflow_id,
         ok: data.ok,
-        applied: data.applied,
-        skipped: data.skipped,
+        applied,
+        skipped,
         ...(isSequence(data.seq) && { seq: data.seq }),
         ...(typeof data.code === 'string' && { code: data.code }),
         ...(typeof data.message === 'string' && { message: data.message }),

--- a/src/workbench/extensions/agent/crdt/followerSubscription.test.ts
+++ b/src/workbench/extensions/agent/crdt/followerSubscription.test.ts
@@ -715,7 +715,8 @@ describe('FE-GAP-1 — a seq jump means a dropped frame and forces a resync', ()
       v: 1,
       workflow_id: WORKFLOW_ID,
       ok: false,
-      code: 'not_found'
+      code: 'not_found',
+      message: 'workflow not found'
     })
 
     expect(bridge.subscribedWorkflowId).toBeNull()


### PR DESCRIPTION
## Summary
- reject malformed or oversized CRDT document frames at the frontend boundary
- preserve lineage/subscription recovery when optional metadata is absent or malformed
- mirror cloud workflow/actor grammar and bound parser output

## Evidence
- `pnpm test:unit src/workbench/extensions/agent/crdt/docFrameClient.test.ts src/workbench/extensions/agent/crdt/docFrameClient.arrays.test.ts src/workbench/extensions/agent/crdt/docFrameClient.grammar.test.ts src/workbench/extensions/agent/crdt/followerSubscription.test.ts` — 64/64 passed
- `pnpm typecheck` — passed
- targeted ESLint — passed
- pre-push `pnpm knip --cache` — passed

## Context
- Program task: `fec-frame-2`
- Source audit: `reports/audit/current-ws-frame-validation-gaps.md`
- Base: current `main` (no stacked dependency)

<!-- authored-by:agent lane-act-fe-16484-address-25b6f93e -->