### PR TITLE
fix(load3d): recover thumbnail queue after stuck model load

### DIFF
--- a/src/components/load3d/modelThumbnail.test.ts
+++ b/src/components/load3d/modelThumbnail.test.ts
@@ -90,4 +90,24 @@ describe('generateModelThumbnail', () => {
 
     expect(createLoad3d).toHaveBeenCalledTimes(2)
   })
+
+  it('times out a stuck load, disposes it, and advances the queue', async () => {
+    vi.useFakeTimers()
+    const stuck = mockInstance({
+      loadModel: vi.fn(() => new Promise<void>(() => {}))
+    })
+    const next = mockInstance()
+    createLoad3d.mockReturnValueOnce(stuck).mockReturnValueOnce(next)
+
+    const stuckRun = generateModelThumbnail('/stuck.glb', 'stuck.glb')
+    const nextRun = generateModelThumbnail('/next.glb', 'next.glb')
+    await vi.waitFor(() => expect(createLoad3d).toHaveBeenCalledTimes(1))
+
+    await vi.advanceTimersByTimeAsync(15_000)
+
+    await expect(stuckRun).resolves.toBeNull()
+    await expect(nextRun).resolves.toBe('data:image/png;base64,thumb')
+    expect(stuck.remove).toHaveBeenCalledTimes(1)
+    expect(next.loadModel).toHaveBeenCalledWith('/next.glb')
+  })
 })

--- a/src/components/load3d/modelThumbnail.ts
+++ b/src/components/load3d/modelThumbnail.ts
@@ -1,9 +1,12 @@
+import { withTimeout } from 'es-toolkit'
+
 import {
   isAssetPreviewSupported,
   persistThumbnail
 } from '@/platform/assets/utils/assetPreviewUtil'
 
 let queue: Promise<unknown> = Promise.resolve()
+const MODEL_LOAD_TIMEOUT_MS = 15_000
 
 /**
  * Render a model to a thumbnail data URL offscreen, without opening the
@@ -33,7 +36,7 @@ async function renderThumbnail(
       isViewerMode: true
     })
     try {
-      await load3d.loadModel(modelUrl)
+      await withTimeout(() => load3d.loadModel(modelUrl), MODEL_LOAD_TIMEOUT_MS)
       const dataUrl = await load3d.captureThumbnail(256, 256)
       if (isAssetPreviewSupported()) {
         void fetch(dataUrl)


### PR DESCRIPTION
## Summary

Bounds thumbnail model loading so a stuck renderer is disposed and later queued thumbnails can continue.

## Changes

- **What**: Wraps `load3d.loadModel()` in a 15-second timeout and adds an executable fake-timer regression for disposal and queue advancement.

## Review Focus

Please verify the timeout duration and that the queue recovery semantics remain appropriate for slow models.

Fixes #16471

## Screenshots (if applicable)

Not applicable; behavior is covered by a unit regression.