### PR TITLE
fix(agent): validate document frame numeric domains

### DIFF
--- a/src/workbench/extensions/agent/crdt/docFrameClient.numeric.test.ts
+++ b/src/workbench/extensions/agent/crdt/docFrameClient.numeric.test.ts
@@ -35,6 +35,23 @@ const sequencedFrame = (
   }
 })
 
+const docOpsResultFrame = (seq?: unknown) => ({
+  type: 'doc_ops_result',
+  data: {
+    v: 1,
+    workflow_id: 'wf-1',
+    ok: true,
+    applied: [],
+    skipped: [],
+    ...(seq !== undefined && { seq })
+  }
+})
+
+const sequencedFrameTypes: ReadonlyArray<'doc_subscribed' | 'doc_reset'> = [
+  'doc_subscribed',
+  'doc_reset'
+]
+
 describe('doc frame numeric domains', () => {
   it.for([-1, 1.5, Number.POSITIVE_INFINITY, Number.NaN])(
     'rejects an invalid doc_update seq: %s',
@@ -50,7 +67,7 @@ describe('doc frame numeric domains', () => {
     }
   )
 
-  describe.for(['doc_subscribed', 'doc_reset'] as const)('%s seq', (type) => {
+  describe.for(sequencedFrameTypes)('%s seq', (type) => {
     it.for([-1, 1.5, Number.POSITIVE_INFINITY, Number.NaN, '1'])(
       'rejects an invalid value: %s',
       (seq) => {
@@ -63,6 +80,25 @@ describe('doc frame numeric domains', () => {
         seq: 0
       })
     })
+  })
+
+  it.for([-1, 1.5, Number.POSITIVE_INFINITY, Number.NaN, '1'])(
+    'rejects an invalid doc_ops_result seq: %s',
+    (seq) => {
+      expect(parseServerDocFrame(docOpsResultFrame(seq))).toBeNull()
+    }
+  )
+
+  it('accepts a valid doc_ops_result seq', () => {
+    expect(parseServerDocFrame(docOpsResultFrame(0))?.data).toMatchObject({
+      seq: 0
+    })
+  })
+
+  it('accepts doc_ops_result without seq', () => {
+    expect(parseServerDocFrame(docOpsResultFrame())?.data).not.toHaveProperty(
+      'seq'
+    )
   })
 
   it('accepts finite non-negative integer sequence and expiry values', () => {

--- a/src/workbench/extensions/agent/crdt/docFrameClient.numeric.test.ts
+++ b/src/workbench/extensions/agent/crdt/docFrameClient.numeric.test.ts
@@ -22,6 +22,19 @@ const awarenessFrame = (expiresAt: unknown) => ({
   }
 })
 
+const sequencedFrame = (
+  type: 'doc_subscribed' | 'doc_reset',
+  seq: unknown
+) => ({
+  type,
+  data: {
+    v: 1,
+    workflow_id: 'wf-1',
+    seq,
+    ...(type === 'doc_subscribed' && { ok: true })
+  }
+})
+
 describe('doc frame numeric domains', () => {
   it.for([-1, 1.5, Number.POSITIVE_INFINITY, Number.NaN])(
     'rejects an invalid doc_update seq: %s',
@@ -37,16 +50,19 @@ describe('doc frame numeric domains', () => {
     }
   )
 
-  it.for([
-    ['doc_subscribed', { ok: true }],
-    ['doc_reset', {}]
-  ])('rejects an invalid %s seq', (type, data) => {
-    expect(
-      parseServerDocFrame({
-        type,
-        data: { v: 1, workflow_id: 'wf-1', seq: -1, ...data }
+  describe.for(['doc_subscribed', 'doc_reset'] as const)('%s seq', (type) => {
+    it.for([-1, 1.5, Number.POSITIVE_INFINITY, Number.NaN, '1'])(
+      'rejects an invalid value: %s',
+      (seq) => {
+        expect(parseServerDocFrame(sequencedFrame(type, seq))).toBeNull()
+      }
+    )
+
+    it('accepts zero', () => {
+      expect(parseServerDocFrame(sequencedFrame(type, 0))?.data).toMatchObject({
+        seq: 0
       })
-    ).toBeNull()
+    })
   })
 
   it('accepts finite non-negative integer sequence and expiry values', () => {

--- a/src/workbench/extensions/agent/crdt/docFrameClient.numeric.test.ts
+++ b/src/workbench/extensions/agent/crdt/docFrameClient.numeric.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest'
+
+import { encodeBase64, parseServerDocFrame } from './docFrameClient'
+
+const updateFrame = (seq: unknown) => ({
+  type: 'doc_update',
+  data: {
+    v: 1,
+    workflow_id: 'wf-1',
+    seq,
+    update_b64: encodeBase64(new Uint8Array())
+  }
+})
+
+const awarenessFrame = (expiresAt: unknown) => ({
+  type: 'awareness',
+  data: {
+    v: 1,
+    workflow_id: 'wf-1',
+    actor: 'human:user:tab-a',
+    expires_at: expiresAt
+  }
+})
+
+describe('doc frame numeric domains', () => {
+  it.for([-1, 1.5, Number.POSITIVE_INFINITY, Number.NaN])(
+    'rejects an invalid doc_update seq: %s',
+    (seq) => {
+      expect(parseServerDocFrame(updateFrame(seq))).toBeNull()
+    }
+  )
+
+  it.for([-1, 1.5, Number.POSITIVE_INFINITY, Number.NaN])(
+    'rejects an invalid awareness expiry: %s',
+    (expiresAt) => {
+      expect(parseServerDocFrame(awarenessFrame(expiresAt))).toBeNull()
+    }
+  )
+
+  it.for([
+    ['doc_subscribed', { ok: true }],
+    ['doc_reset', {}]
+  ])('rejects an invalid %s seq', (type, data) => {
+    expect(
+      parseServerDocFrame({
+        type,
+        data: { v: 1, workflow_id: 'wf-1', seq: -1, ...data }
+      })
+    ).toBeNull()
+  })
+
+  it('accepts finite non-negative integer sequence and expiry values', () => {
+    expect(parseServerDocFrame(updateFrame(0))?.data).toMatchObject({ seq: 0 })
+    expect(parseServerDocFrame(awarenessFrame(0))?.data).toMatchObject({
+      expiresAt: 0
+    })
+  })
+})

--- a/src/workbench/extensions/agent/crdt/docFrameClient.ts
+++ b/src/workbench/extensions/agent/crdt/docFrameClient.ts
@@ -168,7 +168,7 @@ export function parseServerDocFrame(value: unknown): ServerDocFrame | null {
 
   if (
     frame.type === 'doc_update' &&
-    typeof data.seq === 'number' &&
+    isNonNegativeInteger(data.seq) &&
     typeof data.update_b64 === 'string'
   ) {
     return {
@@ -187,13 +187,17 @@ export function parseServerDocFrame(value: unknown): ServerDocFrame | null {
     }
   }
 
-  if (frame.type === 'doc_subscribed' && typeof data.ok === 'boolean') {
+  if (
+    frame.type === 'doc_subscribed' &&
+    typeof data.ok === 'boolean' &&
+    (data.seq === undefined || isNonNegativeInteger(data.seq))
+  ) {
     return {
       type: frame.type,
       data: {
         workflowId: data.workflow_id,
         ok: data.ok,
-        ...(typeof data.seq === 'number' && { seq: data.seq }),
+        ...(data.seq !== undefined && { seq: data.seq }),
         ...(typeof data.code === 'string' && { code: data.code }),
         ...(typeof data.message === 'string' && { message: data.message })
       }
@@ -216,7 +220,7 @@ export function parseServerDocFrame(value: unknown): ServerDocFrame | null {
               (item): item is string => typeof item === 'string'
             )
           : [],
-        ...(typeof data.seq === 'number' && { seq: data.seq }),
+        ...(isNonNegativeInteger(data.seq) && { seq: data.seq }),
         ...(typeof data.code === 'string' && { code: data.code }),
         ...(typeof data.message === 'string' && { message: data.message }),
         // PoC diagnostics: surface the failure verbatim (object, not array).
@@ -225,7 +229,7 @@ export function parseServerDocFrame(value: unknown): ServerDocFrame | null {
     }
   }
 
-  if (frame.type === 'doc_reset' && typeof data.seq === 'number') {
+  if (frame.type === 'doc_reset' && isNonNegativeInteger(data.seq)) {
     return {
       type: frame.type,
       data: {

--- a/src/workbench/extensions/agent/crdt/docFrameClient.ts
+++ b/src/workbench/extensions/agent/crdt/docFrameClient.ts
@@ -204,7 +204,11 @@ export function parseServerDocFrame(value: unknown): ServerDocFrame | null {
     }
   }
 
-  if (frame.type === 'doc_ops_result' && typeof data.ok === 'boolean') {
+  if (
+    frame.type === 'doc_ops_result' &&
+    typeof data.ok === 'boolean' &&
+    (data.seq === undefined || isNonNegativeInteger(data.seq))
+  ) {
     return {
       type: frame.type,
       data: {


### PR DESCRIPTION
## Summary

Reject non-finite, fractional, negative, and unsafe document-frame sequence and awareness-expiry values at the shared parser boundary. Preserve optional `doc_subscribed.seq` and `doc_ops_result.seq` behavior while failing closed when either field is present but invalid.

## Testing

- focused numeric parser coverage
- full agent CRDT unit suite
- TypeScript, scoped lint, and formatting gates

## Evidence

- `NODE_OPTIONS="--no-experimental-webstorage" pnpm test:unit src/workbench/extensions/agent/crdt/docFrameClient.numeric.test.ts` — 28 passed
- `NODE_OPTIONS="--no-experimental-webstorage" pnpm test:unit src/workbench/extensions/agent/crdt/` — 356 passed
- `pnpm typecheck` — passed
- `pnpm exec oxfmt --check src/workbench/extensions/agent/crdt/docFrameClient.ts src/workbench/extensions/agent/crdt/docFrameClient.numeric.test.ts` — passed
- `pnpm exec eslint src/workbench/extensions/agent/crdt/docFrameClient.ts src/workbench/extensions/agent/crdt/docFrameClient.numeric.test.ts` — passed
- normal pre-commit Oxfmt, type-aware Oxlint, ESLint, and typecheck hooks — passed
- failing-first proof — 5 invalid-present `doc_ops_result.seq` cases failed before the parser guard and passed after it

## Checklist

- [x] Added permanent parser regression coverage
- [x] Targets `main`
- [x] No user-facing UI or Storybook change

<!-- authored-by:agent lane-act-fe-16487-ryan-tier1-1641 -->