### PR TITLE
refactor(agent): extract transcript normalization

### DIFF
--- a/src/workbench/extensions/agent/services/agent/agentTranscript.test.ts
+++ b/src/workbench/extensions/agent/services/agent/agentTranscript.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest'
+
+import type { AgentMessages, TurnId } from '../../schemas/agentApiSchema'
+import { normalizeAgentTranscript } from './agentTranscript'
+
+const row = (
+  seq: number,
+  role: AgentMessages[number]['role'],
+  turnId: string,
+  text: string,
+  id: string
+): AgentMessages[number] => ({
+  id,
+  thread_id: 'thread-1',
+  seq,
+  role,
+  status: 'complete',
+  turn_id: turnId,
+  content: { text }
+})
+
+describe('normalizeAgentTranscript', () => {
+  it('orders rows by sequence and groups them by stable turn identity', () => {
+    const transcript = normalizeAgentTranscript([
+      row(4, 'assistant', 'turn-b', 'Second reply', 'row-4'),
+      row(2, 'assistant', 'turn-a', 'First reply', 'row-2'),
+      row(1, 'user', 'turn-a', 'First prompt', 'row-1'),
+      row(3, 'user', 'turn-b', 'Second prompt', 'row-3')
+    ])
+
+    expect(transcript.messages.map((message) => message.id)).toEqual([
+      'turn-a',
+      'turn-b'
+    ])
+    expect(transcript.userTexts.get('turn-a' as TurnId)).toBe('First prompt')
+    expect(transcript.messages[0].parts).toEqual([
+      { type: 'text', text: 'First reply', state: 'done' }
+    ])
+    expect(transcript.rowIds).toEqual(
+      new Set(['row-1', 'row-2', 'row-3', 'row-4'])
+    )
+  })
+
+  it('keeps message identity stable when persisted row ids change', () => {
+    const first = normalizeAgentTranscript([
+      row(1, 'user', 'turn-a', 'Prompt', 'user-row-v1'),
+      row(2, 'assistant', 'turn-a', 'Reply', 'assistant-row-v1')
+    ])
+    const refreshed = normalizeAgentTranscript([
+      row(1, 'user', 'turn-a', 'Prompt', 'user-row-v2'),
+      row(2, 'assistant', 'turn-a', 'Reply', 'assistant-row-v2')
+    ])
+
+    expect(refreshed.messages[0].id).toBe(first.messages[0].id)
+    expect(refreshed.messages[0].id).toBe('turn-a')
+    expect(refreshed.assistantTurnIds).toEqual(new Set(['turn-a']))
+  })
+})

--- a/src/workbench/extensions/agent/services/agent/agentTranscript.test.ts
+++ b/src/workbench/extensions/agent/services/agent/agentTranscript.test.ts
@@ -55,4 +55,25 @@ describe('normalizeAgentTranscript', () => {
     expect(refreshed.messages[0].id).toBe('turn-a')
     expect(refreshed.assistantTurnIds).toEqual(new Set(['turn-a']))
   })
+
+  it('keeps user-only turns while ignoring non-text transcript content', () => {
+    const userOnly = row(1, 'user', 'turn-a', 'Prompt', 'row-1')
+    const toolRow = row(2, 'tool', 'turn-a', '', 'row-2')
+    toolRow.content = { result: { nodeCount: 2 } }
+
+    const transcript = normalizeAgentTranscript([toolRow, userOnly])
+
+    expect(transcript.messages).toEqual([
+      {
+        id: 'turn-a',
+        role: 'assistant',
+        parts: [],
+        thinking: false,
+        streaming: false
+      }
+    ])
+    expect(transcript.userTexts.get('turn-a' as TurnId)).toBe('Prompt')
+    expect(transcript.assistantTurnIds).toEqual(new Set())
+    expect(transcript.rowIds).toEqual(new Set(['row-1', 'row-2']))
+  })
 })

--- a/src/workbench/extensions/agent/services/agent/agentTranscript.ts
+++ b/src/workbench/extensions/agent/services/agent/agentTranscript.ts
@@ -1,0 +1,54 @@
+import type { AgentMessages, TurnId } from '../../schemas/agentApiSchema'
+import type { AssistantMessage } from './agentMessageParts'
+import { createAssistantMessage } from './agentMessageParts'
+
+export interface NormalizedAgentTranscript {
+  messages: AssistantMessage[]
+  userTexts: Map<TurnId, string>
+  rowIds: Set<string>
+  assistantTurnIds: Set<TurnId>
+}
+
+export function normalizeAgentTranscript(
+  history: AgentMessages
+): NormalizedAgentTranscript {
+  const userTexts = new Map<TurnId, string>()
+  const assistants = new Map<TurnId, AssistantMessage>()
+  const turnOrder: TurnId[] = []
+  const seenTurns = new Set<TurnId>()
+  const rowIds = new Set<string>()
+
+  for (const row of [...history].sort((a, b) => a.seq - b.seq)) {
+    const turnId = row.turn_id as TurnId
+    rowIds.add(row.id)
+    if (!seenTurns.has(turnId)) {
+      seenTurns.add(turnId)
+      turnOrder.push(turnId)
+    }
+    const text = typeof row.content?.text === 'string' ? row.content.text : ''
+    if (row.role === 'user') userTexts.set(turnId, text)
+    if (row.role === 'assistant') {
+      const message = assistants.get(turnId) ?? createAssistantMessage(turnId)
+      message.streaming = false
+      if (text)
+        message.parts = [
+          ...message.parts,
+          { type: 'text', text, state: 'done' }
+        ]
+      assistants.set(turnId, message)
+    }
+  }
+
+  const messages = turnOrder.map((turnId) => {
+    const message = assistants.get(turnId) ?? createAssistantMessage(turnId)
+    message.streaming = false
+    return message
+  })
+
+  return {
+    messages,
+    userTexts,
+    rowIds,
+    assistantTurnIds: new Set(assistants.keys())
+  }
+}

--- a/src/workbench/extensions/agent/stores/agent/agentConversationStore.test.ts
+++ b/src/workbench/extensions/agent/stores/agent/agentConversationStore.test.ts
@@ -359,4 +359,24 @@ describe('useAgentConversationStore', () => {
     expect(texts).toContain('second reply')
     expect(store.isStreaming).toBe(true)
   })
+
+  it('does not duplicate a settled background turn persisted under a server turn id', () => {
+    const store = useAgentConversationStore()
+    store.setThreadId('th')
+    store.startTurn(T1)
+    store.recordUser(T1, 'go')
+    store.ingest(delta('t1', 'live reply'))
+    store.stashActiveTurn()
+    store.ingest(done('t1'))
+
+    store.hydrate([
+      historyRow(1, 'user', 'server-turn', 'go'),
+      historyRow(2, 'assistant', 'server-turn', 'persisted reply', 't1')
+    ])
+    store.resumeBackgroundTurn()
+
+    expect(store.messages.map((message) => message.id)).toEqual(['server-turn'])
+    expect(partTexts(store)).toEqual(['persisted reply'])
+    expect(store.isStreaming).toBe(false)
+  })
 })

--- a/src/workbench/extensions/agent/stores/agent/agentConversationStore.ts
+++ b/src/workbench/extensions/agent/stores/agent/agentConversationStore.ts
@@ -9,6 +9,7 @@ import type {
 import { createAgentEventTransport } from '../../services/agent/agentEventTransport'
 import type { AssistantMessage } from '../../services/agent/agentMessageParts'
 import { createAssistantMessage } from '../../services/agent/agentMessageParts'
+import { normalizeAgentTranscript } from '../../services/agent/agentTranscript'
 
 export type ConversationStatus = 'idle' | 'thinking' | 'streaming'
 
@@ -236,42 +237,12 @@ export const useAgentConversationStore = defineStore(
 
     function hydrate(history: AgentMessages): void {
       clearActive()
-      const texts = new Map<TurnId, string>()
-      const assistants = new Map<TurnId, AssistantMessage>()
-      const turnOrder: TurnId[] = []
-      const seenTurns = new Set<TurnId>()
-      const rowIds = new Set<string>()
-      for (const row of [...history].sort((a, b) => a.seq - b.seq)) {
-        const turnId = row.turn_id as TurnId
-        rowIds.add(row.id)
-        if (!seenTurns.has(turnId)) {
-          seenTurns.add(turnId)
-          turnOrder.push(turnId)
-        }
-        const text =
-          typeof row.content?.text === 'string' ? row.content.text : ''
-        if (row.role === 'user') texts.set(turnId, text)
-        if (row.role === 'assistant') {
-          const message =
-            assistants.get(turnId) ?? createAssistantMessage(turnId)
-          message.streaming = false
-          if (text)
-            message.parts = [
-              ...message.parts,
-              { type: 'text', text, state: 'done' }
-            ]
-          assistants.set(turnId, message)
-        }
-      }
-      messages.value = turnOrder.map((turnId) => {
-        const message = assistants.get(turnId) ?? createAssistantMessage(turnId)
-        message.streaming = false
-        return message
-      })
-      userTexts.value = texts
+      const transcript = normalizeAgentTranscript(history)
+      messages.value = transcript.messages
+      userTexts.value = transcript.userTexts
       userTags.value = new Map()
-      hydratedMessageIds = rowIds
-      hydratedAssistantTurnIds = new Set(assistants.keys())
+      hydratedMessageIds = transcript.rowIds
+      hydratedAssistantTurnIds = transcript.assistantTurnIds
       dropAttachmentPreviews()
     }
 


### PR DESCRIPTION
## Summary

Extract transcript normalization from the conversation store so persisted history is deterministically ordered by sequence and grouped by stable turn identity.

## Changes

- **What**: adds a pure `normalizeAgentTranscript` helper and focused tests, then delegates `hydrate()` to it without changing the store's hydrated-message bookkeeping.

## Review Focus

Please verify that sequence ordering, stable `turn_id` identity, and assistant/user grouping match the existing inline hydration behavior. This is the bounded `cjx-7` extraction from frozen audit source #16448 onto current `main`; it intentionally excludes unrelated rollup changes.

Validation:

- `pnpm test:unit src/workbench/extensions/agent/services/agent/agentTranscript.test.ts src/workbench/extensions/agent/stores/agent/agentConversationStore.test.ts` (22 passed)
- `pnpm typecheck`
- targeted ESLint and commit hooks, including Knip

No UI behavior changes; Storybook and screenshots are not applicable.
