### PR TITLE
fix(agent): carry provider-neutral error metadata

### DIFF
--- a/src/platform/errorCatalog/errorMessageResolver.test.ts
+++ b/src/platform/errorCatalog/errorMessageResolver.test.ts
@@ -624,6 +624,23 @@ describe('errorMessageResolver', () => {
     })
   })
 
+  it('resolves agent API failures with catalog copy', () => {
+    expect(
+      resolveRunErrorMessage({
+        kind: 'prompt',
+        isCloud: true,
+        error: {
+          type: 'agent_api_failed',
+          message: 'The agent request failed',
+          details: ''
+        }
+      })
+    ).toEqual({
+      displayTitle: 'Comfy Agent error',
+      displayMessage: 'Comfy Agent hit a server error.'
+    })
+  })
+
   it('resolves an agent transport failure to overlay copy', () => {
     expect(
       resolveRunErrorMessage({

--- a/src/platform/errorCatalog/promptErrorResolver.ts
+++ b/src/platform/errorCatalog/promptErrorResolver.ts
@@ -14,6 +14,7 @@ const KNOWN_PROMPT_ERROR_TYPES = new Set([
   'server_error',
   'missing_node_type',
   'prompt_outputs_failed_validation',
+  'agent_api_failed',
   'op_rejected',
   'prefix_abort',
   'guard_trip',

--- a/src/platform/telemetry/types.ts
+++ b/src/platform/telemetry/types.ts
@@ -550,6 +550,7 @@ export interface UiButtonClickMetadata {
 export interface AgentMessageFeedbackMetadata extends Record<string, unknown> {
   message_id: string
   vote: 'up' | 'down' | null
+  workflow_id: string | null
 }
 
 export type AgentPanelCloseSource =

--- a/src/workbench/extensions/agent/AgentPanelRoot.test.ts
+++ b/src/workbench/extensions/agent/AgentPanelRoot.test.ts
@@ -1776,6 +1776,78 @@ describe('AgentPanelRoot feedback capture', () => {
       [{ message_id: 'turn-9', vote: null, workflow_id: 'wf-rated' }]
     ])
   })
+
+  it('attributes the vote to the last tab the rated message linked', async () => {
+    render(AgentPanelRoot, { global: { plugins: [i18n] } })
+
+    const store = useAgentConversationStore()
+    const turnId = 'turn-10' as TurnId
+    store.recordUser(turnId, 'make two cats')
+    store.startTurn(turnId)
+    for (const workflowId of ['wf-first', 'wf-last']) {
+      store.ingest(
+        zAgentWsEventForTest({
+          type: 'agent_active_tab',
+          data: {
+            workflow_id: workflowId,
+            message_id: 'turn-10',
+            thread_id: 'th'
+          }
+        })
+      )
+    }
+    store.ingest(
+      zAgentWsEventForTest({
+        type: 'agent_message_delta',
+        data: { delta: 'Two cats', message_id: 'turn-10', thread_id: 'th' }
+      })
+    )
+    store.ingest(
+      zAgentWsEventForTest({
+        type: 'agent_message_done',
+        data: { message_id: 'turn-10', thread_id: 'th', usage: null }
+      })
+    )
+    await nextTick()
+
+    await userEvent.click(
+      await screen.findByRole('button', { name: 'Helpful' })
+    )
+
+    expect(telemetry.trackAgentMessageFeedback.mock.calls).toEqual([
+      [{ message_id: 'turn-10', vote: 'up', workflow_id: 'wf-last' }]
+    ])
+  })
+
+  it('reports a null workflow when the rated message never linked a tab', async () => {
+    render(AgentPanelRoot, { global: { plugins: [i18n] } })
+
+    const store = useAgentConversationStore()
+    const turnId = 'turn-11' as TurnId
+    store.recordUser(turnId, 'hello')
+    store.startTurn(turnId)
+    store.ingest(
+      zAgentWsEventForTest({
+        type: 'agent_message_delta',
+        data: { delta: 'Hi there', message_id: 'turn-11', thread_id: 'th' }
+      })
+    )
+    store.ingest(
+      zAgentWsEventForTest({
+        type: 'agent_message_done',
+        data: { message_id: 'turn-11', thread_id: 'th', usage: null }
+      })
+    )
+    await nextTick()
+
+    await userEvent.click(
+      await screen.findByRole('button', { name: 'Helpful' })
+    )
+
+    expect(telemetry.trackAgentMessageFeedback.mock.calls).toEqual([
+      [{ message_id: 'turn-11', vote: 'up', workflow_id: null }]
+    ])
+  })
 })
 
 describe('AgentPanelRoot lifecycle', () => {

--- a/src/workbench/extensions/agent/AgentPanelRoot.test.ts
+++ b/src/workbench/extensions/agent/AgentPanelRoot.test.ts
@@ -1742,6 +1742,16 @@ describe('AgentPanelRoot feedback capture', () => {
     store.startTurn(turnId)
     store.ingest(
       zAgentWsEventForTest({
+        type: 'agent_active_tab',
+        data: {
+          workflow_id: 'wf-rated',
+          message_id: 'turn-9',
+          thread_id: 'th'
+        }
+      })
+    )
+    store.ingest(
+      zAgentWsEventForTest({
         type: 'agent_message_delta',
         data: { delta: 'Here is a cat', message_id: 'turn-9', thread_id: 'th' }
       })
@@ -1762,8 +1772,8 @@ describe('AgentPanelRoot feedback capture', () => {
     )
 
     expect(telemetry.trackAgentMessageFeedback.mock.calls).toEqual([
-      [{ message_id: 'turn-9', vote: 'up', workflow_id: null }],
-      [{ message_id: 'turn-9', vote: null, workflow_id: null }]
+      [{ message_id: 'turn-9', vote: 'up', workflow_id: 'wf-rated' }],
+      [{ message_id: 'turn-9', vote: null, workflow_id: 'wf-rated' }]
     ])
   })
 })

--- a/src/workbench/extensions/agent/AgentPanelRoot.vue
+++ b/src/workbench/extensions/agent/AgentPanelRoot.vue
@@ -560,7 +560,9 @@ const history = useAgentChatHistoryStore()
 const { copy } = useClipboard({ legacy: true })
 
 function onFeedback(turnId: string, vote: 'up' | 'down' | null): void {
-  const message = entries.value.find((entry) => entry.id === turnId)
+  const message = entries.value.find(
+    (entry) => entry.role === 'assistant' && entry.id === turnId
+  )
   const workflowId =
     message?.role === 'assistant'
       ? (message.parts

--- a/src/workbench/extensions/agent/AgentPanelRoot.vue
+++ b/src/workbench/extensions/agent/AgentPanelRoot.vue
@@ -560,10 +560,18 @@ const history = useAgentChatHistoryStore()
 const { copy } = useClipboard({ legacy: true })
 
 function onFeedback(turnId: string, vote: 'up' | 'down' | null): void {
+  const message = entries.value.find((entry) => entry.id === turnId)
+  const workflowId =
+    message?.role === 'assistant'
+      ? (message.parts
+          .flatMap((part) => (part.type === 'tabLink' ? [part.workflowId] : []))
+          .at(-1) ?? null)
+      : null
+
   useTelemetry()?.trackAgentMessageFeedback({
     message_id: turnId,
     vote,
-    workflow_id: boundWorkflowId.value
+    workflow_id: workflowId
   })
 }
 


### PR DESCRIPTION
## Summary

Extracts provider-neutral gaps from frozen [#16448](https://github.com/Comfy-Org/ComfyUI_frontend/pull/16448) onto `main`: agent API failures resolve through the existing error catalog, feedback telemetry carries nullable workflow attribution, and feedback now derives that attribution from the rated assistant message rather than mutable session state.

## Changes

- Registers `agent_api_failed` and adds focused catalog-routing coverage.
- Types nullable feedback `workflow_id`.
- Attributes feedback to the rated message's final tab link, with last-tab and null-path regression coverage.
- Omits PostHog engagement expansions, unused `VITE_AGENT_CRDT_FOLLOWER` typing, stale CRDT POC documentation, and the untranslated `agent_draft_apply_failed` key.

## Review Focus

Please verify that the extraction stays provider-neutral and that per-message workflow attribution is the intended behavior when a message contains multiple or no tab links.

Source: frozen [#16448](https://github.com/Comfy-Org/ComfyUI_frontend/pull/16448) at [`278338e6a0`](https://github.com/Comfy-Org/ComfyUI_frontend/commit/278338e6a0e30e95be3659e4a6c24f3a6f6cc513); original hunk authorship is preserved in the first commit trailer.

## Evidence

- `gh pr checks 16491 --repo Comfy-Org/ComfyUI_frontend` — exact head [`62e11958e3`](https://github.com/Comfy-Org/ComfyUI_frontend/commit/62e11958e35a5585d13156295739f14731048e18): no pending or failed checks; unit, E2E, lint/format, custom-node matrix, performance, security, and CodeRabbit checks pass.
- `git diff origin/main 278338e6a0 -- <cjx-12 files>` — confirmed the live provider-neutral residuals are `agent_api_failed` routing and nullable feedback `workflow_id`; excluded the PostHog/provider-specific telemetry surface.
- `rg 'VITE_AGENT_CRDT_FOLLOWER|agentCrdtFollower|Comfy.Agent.CrdtFollower' src --glob '!vite-env.d.ts'` — no consumers; the stale environment typing and POC README instructions remain omitted.

<!-- authored-by:agent lane-cjx-12-1658 -->