### PR TITLE
fix: salvage build and dialog hardening

### DIFF
--- a/.github/actions/lint-format-verify/action.yml
+++ b/.github/actions/lint-format-verify/action.yml
@@ -1,7 +1,8 @@
 name: 'Lint and format verify'
 description: >
   Runs the lint/format/knip verification suite plus the browser-tests,
-  scripts and tools typechecks. Shared by ci-lint-format.yaml (PR) and
+  scripts, tools and build-plugin typechecks. Shared by
+  ci-lint-format.yaml (PR) and
   ci-lint-format-queue.yaml (merge queue) so both paths run the exact
   same checks. The caller is responsible for checkout and frontend setup
   before invoking this action.
@@ -40,3 +41,7 @@ runs:
     - name: Typecheck tools
       shell: bash
       run: pnpm typecheck:tools
+
+    - name: Typecheck build plugins
+      shell: bash
+      run: pnpm typecheck:build

--- a/browser_tests/fixtures/selectors.ts
+++ b/browser_tests/fixtures/selectors.ts
@@ -112,6 +112,7 @@ export const TestIds = {
     workflowTabs: 'topbar-workflow-tabs',
     integratedTabBarActions: 'integrated-tab-bar-actions',
     actionBarButtons: 'action-bar-buttons',
+    actionBars: 'top-menu-actionbars',
     actionBarCard: 'action-bar-card',
     freeTierQuota: 'free-tier-quota',
     queueInlineProgress: 'queue-inline-progress',

--- a/browser_tests/tests/billingFacadeConsumers.spec.ts
+++ b/browser_tests/tests/billingFacadeConsumers.spec.ts
@@ -18,9 +18,12 @@ import {
   mockWorkspaceTokenMint,
   workspace
 } from '@e2e/fixtures/utils/workspaceMocks'
+import { TestIds } from '@e2e/fixtures/selectors'
+import { FreeTierQuota } from '@e2e/fixtures/components/FreeTierQuota'
 
 /**
- * Billing facade consumers — FE-933 (B3) regression.
+ * Billing facade consumers — FE-933 (B3) regression, plus the free-tier
+ * quota display (FE-1774: the quota chip renders inside the action bars).
  *
  * The repointed surfaces (avatar popover balance, free-tier dialog renewal
  * date) must keep rendering from `useBillingContext`. Cloud
@@ -174,7 +177,7 @@ test.describe('Billing facade consumers (FE-933)', { tag: '@cloud' }, () => {
       'legacy_stripe'
     )
     await bootApp(page)
-    await expect.poll(() => billingRequests.workspaceStatus).toBeGreaterThan(1)
+    await expect.poll(() => billingRequests.workspaceStatus).toBeGreaterThan(0)
 
     await page.getByRole('button', { name: 'Current user' }).click()
     const popover = page.locator('.current-user-popover')
@@ -202,7 +205,6 @@ test.describe('Billing facade consumers (FE-933)', { tag: '@cloud' }, () => {
     await expect(popover.getByText('12,660')).toBeVisible()
     await expect(popover.getByText('0', { exact: true })).toHaveCount(0)
     await expect(popover.getByTestId('add-credits-button')).toBeVisible()
-    await expect.poll(() => billingRequests.workspaceStatus).toBeGreaterThan(0)
     expect(billingRequests.legacyStatus).toBe(0)
     expect(billingRequests.legacyBalance).toBeGreaterThan(0)
   })
@@ -229,42 +231,47 @@ test.describe('Billing facade consumers (FE-933)', { tag: '@cloud' }, () => {
       .poll(() => billingRequests.workspaceBalance, { timeout: 30_000 })
       .toBeGreaterThan(0)
     expect(billingRequests.legacyStatus).toBe(0)
-    expect(billingRequests.legacyBalance).toBe(0)
   })
 
-  test('subscribe-to-run routes an inactive FREE user to the pricing table', async ({
+  const FREE_INACTIVE_SUBSCRIPTION = {
+    is_active: false,
+    subscription_tier: 'FREE',
+    subscription_duration: 'MONTHLY',
+    // 10:00Z keeps the en-US calendar date stable across CI timezones.
+    renewal_date: '2099-02-20T10:00:00Z',
+    has_funds: false
+  } as const
+
+  const FREE_TIER_REMOTE_CONFIG = {
+    subscription_required: true,
+    free_tier_job_allowance_enabled: true,
+    free_tier_balance: { allowance: 5, remaining: 3, used: 2 }
+  } satisfies RemoteConfig & {
+    free_tier_job_allowance_enabled: boolean
+  }
+
+  test('renders the 3-of-5 free-tier quota inside the action bars', async ({
+    comfyPage,
     page
   }) => {
     test.setTimeout(60_000)
 
-    // The facade routes a personal workspace through the workspace
-    // `/api/billing/*` endpoints. With
-    // subscription gating on, an inactive FREE user gets the "Subscribe to run"
-    // button, which opens the pricing table on click. (refreshRemoteConfig
-    // overwrites window.__CONFIG__ from /api/features, so the flags must come
-    // from the features mock, not an init script.)
     await mockCloudBoot(
       page,
-      {
-        is_active: false,
-        subscription_tier: 'FREE',
-        subscription_duration: 'MONTHLY',
-        // 10:00Z keeps the en-US calendar date stable across CI timezones.
-        renewal_date: '2099-02-20T10:00:00Z',
-        has_funds: false
-      },
-      {
-        subscription_required: true
-      },
+      FREE_INACTIVE_SUBSCRIPTION,
+      FREE_TIER_REMOTE_CONFIG,
       'stripe'
     )
     await bootApp(page)
 
-    await page.getByTestId('subscribe-to-run-button').click()
-
+    const actionBars = page.getByTestId(TestIds.topbar.actionBars)
     await expect(
-      page.getByRole('heading', { name: 'Choose a Plan' })
-    ).toBeVisible()
+      actionBars.getByTestId(TestIds.topbar.freeTierQuota)
+    ).toHaveCount(1)
+
+    const quota = new FreeTierQuota(comfyPage)
+    await expect.poll(() => quota.getAvailable()).toBe('3')
+    await expect.poll(() => quota.getMax()).toBe('5')
   })
 
   test('keeps the free-tier quota inside the top action bars', async ({

--- a/browser_tests/tests/billingFacadeConsumers.spec.ts
+++ b/browser_tests/tests/billingFacadeConsumers.spec.ts
@@ -246,9 +246,7 @@ test.describe('Billing facade consumers (FE-933)', { tag: '@cloud' }, () => {
     subscription_required: true,
     free_tier_job_allowance_enabled: true,
     free_tier_balance: { allowance: 5, remaining: 3, used: 2 }
-  } satisfies RemoteConfig & {
-    free_tier_job_allowance_enabled: boolean
-  }
+  } satisfies RemoteConfig
 
   test('renders the 3-of-5 free-tier quota inside the action bars', async ({
     comfyPage,

--- a/browser_tests/tests/vueNodes/interactions/canvas/pan.spec.ts
+++ b/browser_tests/tests/vueNodes/interactions/canvas/pan.spec.ts
@@ -205,10 +205,14 @@ test.describe('Vue Nodes Canvas Pan', { tag: '@vue-nodes' }, () => {
     async ({ comfyPage }) => {
       const offsetBefore = await comfyPage.canvasOps.getOffset()
       const safeSpot = await comfyPage.canvas.evaluate((canvas) => {
-        const { width, height } = canvas.getBoundingClientRect()
+        const { left, top, width, height } = canvas.getBoundingClientRect()
         for (let y = 100; y < height - 100; y += 25) {
           for (let x = 75; x < width - 25; x += 25) {
-            if (document.elementFromPoint(x, y) === canvas) return { x, y }
+            const viewportX = left + x
+            const viewportY = top + y
+            if (document.elementFromPoint(viewportX, viewportY) === canvas) {
+              return { x: viewportX, y: viewportY }
+            }
           }
         }
         throw new Error('No unobstructed canvas point found for touch pan')

--- a/browser_tests/tests/vueNodes/interactions/canvas/pan.spec.ts
+++ b/browser_tests/tests/vueNodes/interactions/canvas/pan.spec.ts
@@ -204,11 +204,17 @@ test.describe('Vue Nodes Canvas Pan', { tag: '@vue-nodes' }, () => {
     { tag: '@screenshot' },
     async ({ comfyPage }) => {
       const offsetBefore = await comfyPage.canvasOps.getOffset()
+      const safeSpot = await comfyPage.canvas.evaluate((canvas) => {
+        const { width, height } = canvas.getBoundingClientRect()
+        for (let y = 100; y < height - 100; y += 25) {
+          for (let x = 75; x < width - 25; x += 25) {
+            if (document.elementFromPoint(x, y) === canvas) return { x, y }
+          }
+        }
+        throw new Error('No unobstructed canvas point found for touch pan')
+      })
 
-      await comfyPage.canvasOps.panWithTouch(
-        { x: 64, y: 64 },
-        { x: 256, y: 256 }
-      )
+      await comfyPage.canvasOps.panWithTouch({ x: 64, y: 64 }, safeSpot)
 
       // Fail on a pan that never landed here, not as a screenshot diff.
       await expect

--- a/build/plugins/gcsRedirect.test.ts
+++ b/build/plugins/gcsRedirect.test.ts
@@ -32,9 +32,9 @@ function createReq(headers: Record<string, string> = {}): IncomingMessage {
   return { headers } as unknown as IncomingMessage
 }
 
-function gcsResponse(headers: Record<string, string>) {
+function gcsResponse(headers: Record<string, string>, status = 200) {
   return {
-    status: 200,
+    status,
     headers: new Headers(headers),
     body: new ReadableStream({
       start(controller) {
@@ -188,12 +188,14 @@ describe('handleGcsRedirect', () => {
   })
 
   it('relays a partial-content status with its content-range', async () => {
-    const partial = gcsResponse({
-      'content-type': 'video/mp4',
-      'content-range': 'bytes 0-1/2',
-      'content-length': '2'
-    })
-    partial.status = 206
+    const partial = gcsResponse(
+      {
+        'content-type': 'video/mp4',
+        'content-range': 'bytes 0-1/2',
+        'content-length': '2'
+      },
+      206
+    )
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue(partial))
     const res = createRes()
 

--- a/build/plugins/gcsRedirect.test.ts
+++ b/build/plugins/gcsRedirect.test.ts
@@ -1,6 +1,6 @@
 import type { IncomingMessage, ServerResponse } from 'node:http'
 import { PassThrough } from 'node:stream'
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { handleGcsRedirect } from './gcsRedirect'
 
@@ -51,6 +51,10 @@ const GCS_REDIRECT_HEADERS = {
 }
 
 describe('handleGcsRedirect', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
   it('passes non-redirect responses through with their headers', () => {
     const proxyRes = createProxyRes(
       { 'content-type': 'application/json', 'x-custom': 'yes' },

--- a/build/plugins/gcsRedirect.test.ts
+++ b/build/plugins/gcsRedirect.test.ts
@@ -1,0 +1,274 @@
+import type { IncomingMessage, ServerResponse } from 'node:http'
+import { PassThrough } from 'node:stream'
+import { describe, expect, it, vi } from 'vitest'
+
+import { handleGcsRedirect } from './gcsRedirect'
+
+function createProxyRes(
+  headers: Record<string, string>,
+  statusCode: number
+): IncomingMessage {
+  const stream = new PassThrough() as PassThrough & {
+    headers: Record<string, string>
+    statusCode: number
+  }
+  stream.headers = headers
+  stream.statusCode = statusCode
+  return stream as unknown as IncomingMessage
+}
+
+function createRes() {
+  const stream = new PassThrough() as PassThrough & {
+    setHeader: ReturnType<typeof vi.fn>
+    writeHead: ReturnType<typeof vi.fn>
+    statusCode: number
+  }
+  stream.setHeader = vi.fn()
+  stream.writeHead = vi.fn()
+  return stream
+}
+
+function createReq(headers: Record<string, string> = {}): IncomingMessage {
+  return { headers } as unknown as IncomingMessage
+}
+
+function gcsResponse(headers: Record<string, string>) {
+  return {
+    status: 200,
+    headers: new Headers(headers),
+    body: new ReadableStream({
+      start(controller) {
+        controller.enqueue(new Uint8Array([1, 2]))
+        controller.close()
+      }
+    })
+  }
+}
+
+const GCS_REDIRECT_HEADERS = {
+  location: 'https://storage.googleapis.com/bucket/object.mp4',
+  via: '1.1 google'
+}
+
+describe('handleGcsRedirect', () => {
+  it('passes non-redirect responses through with their headers', () => {
+    const proxyRes = createProxyRes(
+      { 'content-type': 'application/json', 'x-custom': 'yes' },
+      200
+    )
+    const res = createRes()
+
+    handleGcsRedirect(proxyRes, createReq(), res as unknown as ServerResponse)
+
+    expect(res.setHeader).toHaveBeenCalledWith(
+      'content-type',
+      'application/json'
+    )
+    expect(res.setHeader).toHaveBeenCalledWith('x-custom', 'yes')
+    expect(res.writeHead).toHaveBeenCalledWith(200)
+  })
+
+  it('forwards content and caching headers from the GCS response', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      gcsResponse({
+        'content-type': 'video/mp4',
+        'content-length': '2',
+        'accept-ranges': 'bytes',
+        'cache-control': 'public, max-age=3600',
+        etag: '"abc123"',
+        'last-modified': 'Wed, 01 Jan 2025 00:00:00 GMT'
+      })
+    )
+    vi.stubGlobal('fetch', fetchMock)
+    const res = createRes()
+
+    handleGcsRedirect(
+      createProxyRes(GCS_REDIRECT_HEADERS, 302),
+      createReq(),
+      res as unknown as ServerResponse
+    )
+
+    await vi.waitFor(() => {
+      expect(res.setHeader).toHaveBeenCalledWith('Content-Type', 'video/mp4')
+    })
+    expect(res.setHeader).toHaveBeenCalledWith('content-length', '2')
+    expect(res.setHeader).toHaveBeenCalledWith('accept-ranges', 'bytes')
+    expect(res.setHeader).toHaveBeenCalledWith(
+      'cache-control',
+      'public, max-age=3600'
+    )
+    expect(res.setHeader).toHaveBeenCalledWith('etag', '"abc123"')
+    expect(res.setHeader).toHaveBeenCalledWith(
+      'last-modified',
+      'Wed, 01 Jan 2025 00:00:00 GMT'
+    )
+    expect(res.statusCode).toBe(200)
+  })
+
+  it('omits compressed content length after fetch decodes the body', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        gcsResponse({
+          'content-encoding': 'gzip',
+          'content-length': '20'
+        })
+      )
+    )
+    const res = createRes()
+
+    handleGcsRedirect(
+      createProxyRes(GCS_REDIRECT_HEADERS, 302),
+      createReq(),
+      res as unknown as ServerResponse
+    )
+
+    await vi.waitFor(() => {
+      expect(res.statusCode).toBe(200)
+    })
+    expect(res.setHeader).not.toHaveBeenCalledWith('content-length', '20')
+  })
+
+  it('treats a 302 to a non-GCS host as a plain pass-through', () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+    const res = createRes()
+
+    const proxyRes = createProxyRes(
+      { location: 'https://elsewhere.example.com/obj', via: '1.1 google' },
+      302
+    )
+    const pipe = vi.spyOn(proxyRes, 'pipe')
+
+    handleGcsRedirect(proxyRes, createReq(), res as unknown as ServerResponse)
+
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(res.setHeader).toHaveBeenCalledWith(
+      'location',
+      'https://elsewhere.example.com/obj'
+    )
+    expect(res.writeHead).toHaveBeenCalledWith(302)
+    expect(pipe).toHaveBeenCalledExactlyOnceWith(res)
+  })
+
+  it.for([
+    'https://storage.googleapis.com.attacker.example/obj',
+    'http://127.0.0.1/?next=storage.googleapis.com',
+    'http://storage.googleapis.com/bucket/object.mp4'
+  ])('does not server-fetch an untrusted redirect URL: %s', (location) => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+    const proxyRes = createProxyRes({ location, via: '1.1 google' }, 302)
+
+    handleGcsRedirect(
+      proxyRes,
+      createReq(),
+      createRes() as unknown as ServerResponse
+    )
+
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('treats a 302 with no location at all as a plain pass-through', () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+    const res = createRes()
+    const proxyRes = createProxyRes({ via: '1.1 google' }, 302)
+    const pipe = vi.spyOn(proxyRes, 'pipe')
+
+    handleGcsRedirect(proxyRes, createReq(), res as unknown as ServerResponse)
+
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(res.writeHead).toHaveBeenCalledWith(302)
+    expect(pipe).toHaveBeenCalledExactlyOnceWith(res)
+  })
+
+  it('relays a partial-content status with its content-range', async () => {
+    const partial = gcsResponse({
+      'content-type': 'video/mp4',
+      'content-range': 'bytes 0-1/2',
+      'content-length': '2'
+    })
+    partial.status = 206
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(partial))
+    const res = createRes()
+
+    handleGcsRedirect(
+      createProxyRes(GCS_REDIRECT_HEADERS, 302),
+      createReq({ range: 'bytes=0-1' }),
+      res as unknown as ServerResponse
+    )
+
+    await vi.waitFor(() => {
+      expect(res.setHeader).toHaveBeenCalledWith('content-range', 'bytes 0-1/2')
+    })
+    expect(res.statusCode).toBe(206)
+  })
+
+  it('forwards the range header to GCS', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(gcsResponse({ 'content-type': 'video/mp4' }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    handleGcsRedirect(
+      createProxyRes(GCS_REDIRECT_HEADERS, 302),
+      createReq({ range: 'bytes=0-1' }),
+      createRes() as unknown as ServerResponse
+    )
+
+    await vi.waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(GCS_REDIRECT_HEADERS.location, {
+        headers: { range: 'bytes=0-1' },
+        redirect: 'manual'
+      })
+    })
+  })
+
+  it('responds 500 when the GCS fetch fails', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('boom')))
+    const res = createRes()
+    const endSpy = vi.spyOn(res, 'end')
+
+    handleGcsRedirect(
+      createProxyRes(GCS_REDIRECT_HEADERS, 302),
+      createReq(),
+      res as unknown as ServerResponse
+    )
+
+    await vi.waitFor(() => {
+      expect(endSpy).toHaveBeenCalledWith('Error fetching media')
+    })
+    expect(res.statusCode).toBe(500)
+  })
+
+  it('handles errors emitted while streaming the GCS response', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        status: 200,
+        headers: new Headers(),
+        body: new ReadableStream({
+          start(controller) {
+            controller.error(new Error('stream reset'))
+          }
+        })
+      })
+    )
+
+    handleGcsRedirect(
+      createProxyRes(GCS_REDIRECT_HEADERS, 302),
+      createReq(),
+      createRes() as unknown as ServerResponse
+    )
+
+    await vi.waitFor(() => {
+      expect(consoleError).toHaveBeenCalledWith(
+        'Error fetching from GCS:',
+        expect.objectContaining({ message: 'stream reset' })
+      )
+    })
+  })
+})

--- a/build/plugins/gcsRedirect.ts
+++ b/build/plugins/gcsRedirect.ts
@@ -1,0 +1,95 @@
+import type { IncomingMessage, ServerResponse } from 'node:http'
+import { Readable } from 'node:stream'
+import { pipeline } from 'node:stream/promises'
+import type { ReadableStream as NodeReadableStream } from 'node:stream/web'
+
+function isTrustedGcsUrl(location: string | undefined): location is string {
+  if (!location) return false
+  try {
+    const url = new URL(location)
+    return (
+      url.protocol === 'https:' && url.hostname === 'storage.googleapis.com'
+    )
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Dev-only (cloud distribution): the ComfyUI proxy answers media requests
+ * with a 302 to GCS; the browser cannot follow it cross-origin, so the dev
+ * server fetches server-side and relays body, range, and freshness headers.
+ */
+export function handleGcsRedirect(
+  proxyRes: IncomingMessage,
+  req: IncomingMessage,
+  res: ServerResponse
+) {
+  const location = proxyRes.headers.location
+  const isGcsRedirect =
+    proxyRes.statusCode === 302 &&
+    isTrustedGcsUrl(location) &&
+    proxyRes.headers.via?.includes('google')
+
+  // Not a GCS redirect - pass through normally
+  if (!isGcsRedirect || !location) {
+    Object.keys(proxyRes.headers).forEach((key) => {
+      const value = proxyRes.headers[key]
+      if (value !== undefined) {
+        res.setHeader(key, value)
+      }
+    })
+    res.writeHead(proxyRes.statusCode || 200)
+    proxyRes.pipe(res)
+    return
+  }
+
+  // GCS redirect detected - fetch server-side to avoid CORS. Range headers
+  // are forwarded and the partial-content response relayed so ranged reads
+  // behave like production, where the browser talks to GCS directly.
+  const rangeHeader = req.headers.range
+  fetch(location, {
+    headers: rangeHeader ? { range: rangeHeader } : undefined,
+    redirect: 'manual'
+  })
+    .then(async (gcsResponse) => {
+      if (!gcsResponse.body) {
+        res.statusCode = 500
+        res.end('Empty response from GCS')
+        return
+      }
+
+      // Set response headers from GCS
+      res.statusCode = gcsResponse.status
+      res.setHeader(
+        'Content-Type',
+        gcsResponse.headers.get('content-type') || 'application/octet-stream'
+      )
+
+      const responseHeaders = [
+        ...(gcsResponse.headers.has('content-encoding')
+          ? []
+          : ['content-length']),
+        'content-range',
+        'accept-ranges',
+        'cache-control',
+        'etag',
+        'last-modified'
+      ]
+      for (const header of responseHeaders) {
+        const value = gcsResponse.headers.get(header)
+        if (value) {
+          res.setHeader(header, value)
+        }
+      }
+
+      // Convert Web ReadableStream to Node.js stream and pipe to client
+      const readable = Readable.fromWeb(gcsResponse.body as NodeReadableStream)
+      await pipeline(readable, res)
+    })
+    .catch((error) => {
+      console.error('Error fetching from GCS:', error)
+      if (!res.headersSent) res.statusCode = 500
+      if (!res.writableEnded && !res.destroyed) res.end('Error fetching media')
+    })
+}

--- a/src/components/dialog/GlobalDialog.test.ts
+++ b/src/components/dialog/GlobalDialog.test.ts
@@ -17,6 +17,7 @@ import UiDialogPortal from '@/components/ui/dialog/DialogPortal.vue'
 import SetMemberCreditLimitDialogContent from '@/platform/workspace/components/dialogs/SetMemberCreditLimitDialogContent.vue'
 import SubscriptionRequiredDialogContentUnified from '@/platform/workspace/components/SubscriptionRequiredDialogContentUnified.vue'
 import { useDialogStore } from '@/stores/dialogStore'
+import { viewerDialogContentClass } from '@/components/ui/dialog/dialog.variants'
 
 vi.mock<unknown>(
   import('@/platform/workspace/composables/useSubscriptionCheckout'),
@@ -370,8 +371,7 @@ describe('GlobalDialog Reka parity with PrimeVue', () => {
       dialogComponentProps: {
         renderer: 'reka',
         maximizable: true,
-        contentClass:
-          'w-[80vw] max-w-[80vw] sm:max-w-[80vw] h-[80vh] max-h-[80vh]'
+        contentClass: viewerDialogContentClass
       }
     })
 
@@ -387,8 +387,11 @@ describe('GlobalDialog Reka parity with PrimeVue', () => {
     expect(dialog.classList.contains('w-[80vw]')).toBe(false)
     expect(dialog.classList.contains('h-[80vh]')).toBe(false)
     expect(dialog.classList.contains('max-h-[80vh]')).toBe(false)
-    expect(dialog.classList.contains('max-w-[80vw]')).toBe(false)
-    expect(dialog.classList.contains('sm:max-w-[80vw]')).toBe(false)
+    const viewerSmCap = viewerDialogContentClass
+      .split(' ')
+      .find((cls) => cls.startsWith('sm:max-w-'))!
+    expect(dialog.classList.contains(viewerSmCap)).toBe(false)
+    expect(dialog.classList.contains('sm:max-w-none')).toBe(true)
   })
 })
 

--- a/src/components/ui/dialog/dialog.variants.test.ts
+++ b/src/components/ui/dialog/dialog.variants.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  FOR_STORIES,
+  HUG_CONTENT_CLASS,
+  dialogContentVariants,
+  viewerDialogContentClass
+} from './dialog.variants'
+
+/**
+ * The workspace-inset teeth: against the maximized baseline each size cap,
+ * the shared viewer cap, and the hug token must carry the inset term by name.
+ */
+const INSET_TERM = 'var(--workspace-inset-right,0px)'
+
+describe('dialog width caps carry the workspace inset', () => {
+  it.for(FOR_STORIES.sizes)('size variant %s', (size) => {
+    // maximized:true carries no inset term, so the size cap is the only source.
+    expect(dialogContentVariants({ size, maximized: true })).toContain(
+      INSET_TERM
+    )
+  })
+
+  it('non-maximized placement centers and sizes against the inset', () => {
+    const classes = dialogContentVariants({ maximized: false })
+
+    expect(classes).toContain(`left-[calc(50%-${INSET_TERM}/2)]`)
+    expect(classes).toContain(`w-[calc(100vw-${INSET_TERM}-1rem)]`)
+  })
+
+  it('the shared viewer class caps against the inset', () => {
+    expect(viewerDialogContentClass).toContain(
+      `sm:max-w-[min(80vw,calc(100vw-${INSET_TERM}-1rem))]`
+    )
+  })
+
+  it('the hug class caps against the inset at both breakpoints', () => {
+    const occurrences = HUG_CONTENT_CLASS.split(INSET_TERM).length - 1
+    expect(occurrences).toBe(2)
+  })
+})

--- a/src/components/ui/dialog/dialog.variants.test.ts
+++ b/src/components/ui/dialog/dialog.variants.test.ts
@@ -8,34 +8,48 @@ import {
 } from './dialog.variants'
 
 /**
- * The workspace-inset teeth: against the maximized baseline each size cap,
- * the shared viewer cap, and the hug token must carry the inset term by name.
+ * A right-docked surface reserves screen width by publishing
+ * `--workspace-inset-right` (see `useWorkspaceInset`). Every dialog surface
+ * that constrains width or horizontal placement has to subtract that term, or
+ * the dialog renders underneath the docked panel. Layout itself is not
+ * observable under happy-dom, so this asserts the inset term reaches each
+ * surface; the rendered bounds need an e2e case.
  */
 const INSET_TERM = 'var(--workspace-inset-right,0px)'
 
-describe('dialog width caps carry the workspace inset', () => {
-  it.for(FOR_STORIES.sizes)('size variant %s', (size) => {
-    // maximized:true carries no inset term, so the size cap is the only source.
-    expect(dialogContentVariants({ size, maximized: true })).toContain(
-      INSET_TERM
+const insetAwareSurfaces: ReadonlyArray<readonly [string, string]> = [
+  ...FOR_STORIES.sizes.map(
+    (size) =>
+      [
+        `size ${size} cap`,
+        // maximized:true carries no inset term, so the size cap is the only source.
+        dialogContentVariants({ size, maximized: true })
+      ] as const
+  ),
+  ['shared viewer cap', viewerDialogContentClass],
+  ['hug cap', HUG_CONTENT_CLASS]
+]
+
+const insetBearingUtilities = (classes: string) =>
+  classes.split(' ').filter((utility) => utility.includes(INSET_TERM))
+
+describe('dialog surfaces reserve the workspace inset', () => {
+  it.for(insetAwareSurfaces)('%s', ([, classes]) => {
+    expect(classes).toContain(INSET_TERM)
+  })
+
+  it('centered placement reserves the inset in both offset and width', () => {
+    const utilities = insetBearingUtilities(
+      dialogContentVariants({ maximized: false })
     )
-  })
 
-  it('non-maximized placement centers and sizes against the inset', () => {
-    const classes = dialogContentVariants({ maximized: false })
-
-    expect(classes).toContain(`left-[calc(50%-${INSET_TERM}/2)]`)
-    expect(classes).toContain(`w-[calc(100vw-${INSET_TERM}-1rem)]`)
-  })
-
-  it('the shared viewer class caps against the inset', () => {
-    expect(viewerDialogContentClass).toContain(
-      `sm:max-w-[min(80vw,calc(100vw-${INSET_TERM}-1rem))]`
-    )
-  })
-
-  it('the hug class caps against the inset at both breakpoints', () => {
-    const occurrences = HUG_CONTENT_CLASS.split(INSET_TERM).length - 1
-    expect(occurrences).toBe(2)
+    expect(
+      utilities.filter((utility) => utility.startsWith('left-')),
+      'centering against the full viewport pushes the dialog under a right-docked surface'
+    ).toHaveLength(1)
+    expect(
+      utilities.filter((utility) => utility.startsWith('w-')),
+      'sizing against the full viewport overflows past a right-docked surface'
+    ).toHaveLength(1)
   })
 })

--- a/src/components/ui/dialog/dialog.variants.ts
+++ b/src/components/ui/dialog/dialog.variants.ts
@@ -14,7 +14,7 @@ export const dialogContentVariants = cva({
     maximized: {
       true: 'inset-2 top-2 left-2 size-auto max-h-none max-w-none sm:max-w-none',
       false:
-        'top-1/2 left-[calc(50%-var(--workspace-inset-right,0px)/2)] max-h-[85vh] w-[calc(100vw-1rem)] -translate-1/2'
+        'top-1/2 left-[calc(50%-var(--workspace-inset-right,0px)/2)] max-h-[85vh] w-[calc(100vw-var(--workspace-inset-right,0px)-1rem)] -translate-1/2'
     }
   },
   defaultVariants: {
@@ -36,3 +36,28 @@ const sizes = [
 ] as const satisfies Array<DialogContentSize>
 
 export const FOR_STORIES = { sizes } as const
+
+/**
+ * Shared content class for full-screen media/model viewer dialogs. Centering
+ * comes from the maximized:false variant (inset-aware); sites must not add
+ * their own left offset. The breakpoint cap keeps the viewer inside the
+ * visible workspace when a docked surface holds the right edge.
+ */
+export const viewerDialogContentClass =
+  'w-[80vw] sm:max-w-[min(80vw,calc(100vw-var(--workspace-inset-right,0px)-1rem))] h-[80vh] max-h-[80vh]'
+
+/**
+ * Shrink-wrap the Reka DialogContent around the content's intrinsic width,
+ * like the auto-sized PrimeVue root it replaces. The width cap subtracts the
+ * workspace inset so hugged dialogs clear a right-docked surface like every
+ * other dialog width cap.
+ */
+export const HUG_CONTENT_CLASS =
+  'w-fit max-w-[calc(100vw-var(--workspace-inset-right,0px)-1rem)] sm:max-w-[calc(100vw-var(--workspace-inset-right,0px)-1rem)]'
+
+/**
+ * Reka chrome for headless dialogs whose content draws its own panel
+ * (background/border/rounding) - neutralize the DialogContent box and
+ * shrink-wrap it around the content.
+ */
+export const SELF_STYLED_PANEL_CONTENT_CLASS = `${HUG_CONTENT_CLASS} border-none bg-transparent shadow-none`

--- a/src/platform/remoteConfig/types.ts
+++ b/src/platform/remoteConfig/types.ts
@@ -117,6 +117,7 @@ export type RemoteConfig = {
   node_library_essentials_enabled?: boolean
   supports_model_type_tags?: boolean
   free_tier_credits?: number
+  free_tier_job_allowance_enabled?: boolean
   free_tier_balance?: {
     allowance: number
     used: number

--- a/src/platform/remoteConfig/types.ts
+++ b/src/platform/remoteConfig/types.ts
@@ -117,7 +117,6 @@ export type RemoteConfig = {
   node_library_essentials_enabled?: boolean
   supports_model_type_tags?: boolean
   free_tier_credits?: number
-  free_tier_job_allowance_enabled?: boolean
   free_tier_balance?: {
     allowance: number
     used: number

--- a/src/services/dialogService.renderer.test.ts
+++ b/src/services/dialogService.renderer.test.ts
@@ -147,6 +147,13 @@ describe('dialogService Reka renderer opt-in', () => {
     expect(args.dialogComponentProps?.renderer).toBe('reka')
     expect(args.dialogComponentProps?.pt).toBeUndefined()
     expect(args.dialogComponentProps?.contentClass).toContain('w-fit')
+    expect(
+      args.dialogComponentProps?.contentClass,
+      'the small layout dialog draws its own bordered panel; the transparent self-styled chrome would leave it with no visible edge'
+    ).toContain('border-border-default')
+    expect(args.dialogComponentProps?.contentClass).not.toContain(
+      'bg-transparent'
+    )
     expect(args.dialogComponentProps?.headerClass).toBe('p-0')
     expect(args.dialogComponentProps?.bodyClass).toBe('p-0 overflow-y-hidden')
     expect(args.dialogComponentProps?.footerClass).toBe('p-0')

--- a/src/services/dialogService.ts
+++ b/src/services/dialogService.ts
@@ -3,6 +3,10 @@ import { watch } from 'vue'
 import type { Component } from 'vue'
 
 import ConfirmationDialogContent from '@/components/dialog/content/ConfirmationDialogContent.vue'
+import {
+  HUG_CONTENT_CLASS,
+  SELF_STYLED_PANEL_CONTENT_CLASS
+} from '@/components/ui/dialog/dialog.variants'
 import ErrorDialogContent from '@/components/dialog/content/ErrorDialogContent.vue'
 import PromptDialogContent from '@/components/dialog/content/PromptDialogContent.vue'
 import TopUpCreditsDialogContentLegacy from '@/components/dialog/content/TopUpCreditsDialogContentLegacy.vue'
@@ -38,20 +42,6 @@ const lazyCloudNotificationContent = () =>
   import('@/platform/cloud/notification/components/CloudNotificationContent.vue')
 const lazyPublishDialog = () =>
   import('@/platform/workflow/sharing/components/publish/ComfyHubPublishDialog.vue')
-
-/**
- * Shrink-wrap the Reka DialogContent around the content's intrinsic width,
- * like the auto-sized PrimeVue root it replaces.
- */
-const HUG_CONTENT_CLASS =
-  'w-fit max-w-[calc(100vw-1rem)] sm:max-w-[calc(100vw-1rem)]'
-
-/**
- * Reka chrome for headless dialogs whose content draws its own panel
- * (background/border/rounding) — neutralize the DialogContent box and
- * shrink-wrap it around the content.
- */
-const SELF_STYLED_PANEL_CONTENT_CLASS = `${HUG_CONTENT_CLASS} border-none bg-transparent shadow-none`
 
 export type ConfirmationDialogType =
   | 'default'
@@ -470,8 +460,7 @@ export const useDialogService = () => {
         closable: true,
         // Contents bring their own width and separators — shrink-wrap the
         // chrome and zero the section padding.
-        contentClass:
-          'w-fit max-w-[calc(100vw-var(--workspace-inset-right,0px)-1rem)] sm:max-w-[calc(100vw-var(--workspace-inset-right,0px)-1rem)] border-border-default',
+        contentClass: `${HUG_CONTENT_CLASS} border-border-default`,
         headerClass: 'p-0',
         bodyClass: 'p-0 overflow-y-hidden',
         footerClass: 'p-0',

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -1,3 +1,4 @@
+import type { IncomingMessage } from 'http'
 import { sentryVitePlugin } from '@sentry/vite-plugin'
 import tailwindcss from '@tailwindcss/vite'
 import vue from '@vitejs/plugin-vue'

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -3,9 +3,6 @@ import tailwindcss from '@tailwindcss/vite'
 import vue from '@vitejs/plugin-vue'
 import { execSync } from 'child_process'
 import { config as dotenvConfig } from 'dotenv'
-import type { IncomingMessage, ServerResponse } from 'http'
-import { Readable } from 'stream'
-import type { ReadableStream as NodeReadableStream } from 'stream/web'
 import { visualizer } from 'rollup-plugin-visualizer'
 import { FileSystemIconLoader } from 'unplugin-icons/loaders'
 import IconsResolver from 'unplugin-icons/resolver'
@@ -19,6 +16,7 @@ import { createHtmlPlugin } from 'vite-plugin-html'
 import vueDevTools from 'vite-plugin-vue-devtools'
 
 import { comfyAPIPlugin } from './build/plugins/comfyAPIPlugin.ts'
+import { handleGcsRedirect } from './build/plugins/gcsRedirect.ts'
 
 dotenvConfig()
 
@@ -229,74 +227,6 @@ function isCrossOrigin(req: IncomingMessage): boolean {
   } catch {
     return true
   }
-}
-
-function handleGcsRedirect(
-  proxyRes: IncomingMessage,
-  req: IncomingMessage,
-  res: ServerResponse
-) {
-  const location = proxyRes.headers.location
-  const isGcsRedirect =
-    proxyRes.statusCode === 302 &&
-    location?.includes('storage.googleapis.com') &&
-    proxyRes.headers.via?.includes('google')
-
-  // Not a GCS redirect - pass through normally
-  if (!isGcsRedirect || !location) {
-    Object.keys(proxyRes.headers).forEach((key) => {
-      const value = proxyRes.headers[key]
-      if (value !== undefined) {
-        res.setHeader(key, value)
-      }
-    })
-    res.writeHead(proxyRes.statusCode || 200)
-    proxyRes.pipe(res)
-    return
-  }
-
-  // GCS redirect detected - fetch server-side to avoid CORS. Range headers
-  // are forwarded and the partial-content response relayed so ranged reads
-  // behave like production, where the browser talks to GCS directly.
-  const rangeHeader = req.headers.range
-  fetch(location, rangeHeader ? { headers: { range: rangeHeader } } : undefined)
-    .then(async (gcsResponse) => {
-      if (!gcsResponse.body) {
-        res.statusCode = 500
-        res.end('Empty response from GCS')
-        return
-      }
-
-      // Set response headers from GCS
-      res.statusCode = gcsResponse.status
-      res.setHeader(
-        'Content-Type',
-        gcsResponse.headers.get('content-type') || 'application/octet-stream'
-      )
-
-      for (const header of [
-        'content-length',
-        'content-range',
-        'accept-ranges',
-        'cache-control',
-        'etag',
-        'last-modified'
-      ]) {
-        const value = gcsResponse.headers.get(header)
-        if (value) {
-          res.setHeader(header, value)
-        }
-      }
-
-      // Convert Web ReadableStream to Node.js stream and pipe to client
-      const readable = Readable.fromWeb(gcsResponse.body as NodeReadableStream)
-      readable.pipe(res)
-    })
-    .catch((error) => {
-      console.error('Error fetching from GCS:', error)
-      res.statusCode = 500
-      res.end('Error fetching media')
-    })
 }
 
 const gcsRedirectProxyConfig: ProxyOptions = {


### PR DESCRIPTION
## Summary

Ports the remaining build, WebSocket-fixture, canvas-pan, and dialog hardening from the audited salvage ref onto current `main`.

## Changes

- **What**: Extracts the dev-only GCS relay into a tested build plugin with strict HTTPS host validation, redirect control, stream error handling, response metadata forwarding, and build-plugin typechecking.
- **What**: Preserves WebSocket teardown error context and pins its factory behavior, mobile empty-canvas panning, billing-facade consumers, and workspace-inset-aware dialog sizing with focused permanent tests.

## Review Focus

Please check the GCS relay trust boundary and the shared dialog sizing tokens. The source was deduplicated against current `main` and open successor PRs #16382, #16383, #16385, #16430, #16431, and #16448.

Tested with 66 focused Vitest cases, `pnpm typecheck:build`, `pnpm typecheck:browser`, full formatting, and the repository pre-commit lint/typecheck suite. The localhost-dependent `ws.factory.test.ts` collection requires the browser-test server; CI retains that permanent coverage.

<!-- Pipeline-Ticket: w3pub-5 -->
