### PR TITLE
test(agent): e2e coverage for reply asset previews, and fixes for the review round

### DIFF
--- a/browser_tests/fixtures/utils/viewFileMocks.ts
+++ b/browser_tests/fixtures/utils/viewFileMocks.ts
@@ -4,7 +4,7 @@ type RouteFulfillOptions = NonNullable<Parameters<Route['fulfill']>[0]>
 
 type ViewFile = Pick<RouteFulfillOptions, 'body' | 'contentType' | 'path'>
 
-const transparentPng = Buffer.from(
+export const transparentPng = Buffer.from(
   'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAFgwJ/lwPIRwAAAABJRU5ErkJggg==',
   'base64'
 )

--- a/browser_tests/tests/agent/agentPanelMocks.ts
+++ b/browser_tests/tests/agent/agentPanelMocks.ts
@@ -94,14 +94,19 @@ export const RESIZE_IMAGE_TOOL_EVENT: AgentWsEvent = {
 const MESSAGE_DELTA_TEXT =
   'The graph is **fully ready** to go — prompt set to the red fox in the snow.'
 
-export const MESSAGE_DELTA_EVENT: AgentWsEvent = {
-  type: 'agent_message_delta',
-  data: {
-    delta: MESSAGE_DELTA_TEXT,
-    message_id: TURN_ID,
-    thread_id: THREAD_ID
+export function messageDeltaEvent(delta: string): AgentWsEvent {
+  return {
+    type: 'agent_message_delta',
+    data: {
+      delta,
+      message_id: TURN_ID,
+      thread_id: THREAD_ID
+    }
   }
 }
+
+export const MESSAGE_DELTA_EVENT: AgentWsEvent =
+  messageDeltaEvent(MESSAGE_DELTA_TEXT)
 
 export const MESSAGE_DONE_EVENT: AgentWsEvent = {
   type: 'agent_message_done',

--- a/browser_tests/tests/agent/agentReplyAssets.spec.ts
+++ b/browser_tests/tests/agent/agentReplyAssets.spec.ts
@@ -18,6 +18,10 @@ import {
 const COLLAPSED_COUNT = 12
 const MODEL_COUNT = 13
 const HIDDEN_MODEL = `mesh-${MODEL_COUNT - 1}.glb`
+const VISIBLE_MODELS = Array.from(
+  { length: COLLAPSED_COUNT },
+  (_, index) => `mesh-${index}.glb`
+)
 
 const MODEL_REPLY = Array.from(
   { length: MODEL_COUNT },
@@ -55,7 +59,7 @@ const test = mergeTests(agentTest, webSocketFixture).extend<{
         url.searchParams.get('hash') ?? url.searchParams.get('name_contains')
       if (!name) return route.fulfill(jsonRoute({ assets: [] }))
 
-      lookedUp.push(name)
+      if (/^mesh-\d+\.glb$/.test(name)) lookedUp.push(name)
       return route.fulfill(
         jsonRoute({
           assets: [
@@ -109,10 +113,9 @@ test.describe('Agent reply assets', { tag: '@cloud' }, () => {
     await expect(tiles).toHaveCount(COLLAPSED_COUNT)
     await expect(thumbnails).toHaveCount(COLLAPSED_COUNT)
     expect(
-      new Set(lookedUpModels).size,
-      'a collapsed reply must only look up the models it shows'
-    ).toBe(COLLAPSED_COUNT)
-    expect(lookedUpModels).not.toContain(HIDDEN_MODEL)
+      [...new Set(lookedUpModels)].sort(),
+      'a collapsed reply must look up the models it shows, and only those'
+    ).toEqual([...VISIBLE_MODELS].sort())
 
     await panel.getByRole('button', { name: enMessages.agent.showMore }).click()
 

--- a/browser_tests/tests/agent/agentReplyAssets.spec.ts
+++ b/browser_tests/tests/agent/agentReplyAssets.spec.ts
@@ -1,0 +1,103 @@
+import type { Route, WebSocketRoute } from '@playwright/test'
+import { expect, mergeTests } from '@playwright/test'
+
+import { webSocketFixture } from '@e2e/fixtures/ws'
+
+import enMessages from '@/locales/en/main.json' with { type: 'json' }
+
+import { jsonRoute } from '@e2e/fixtures/utils/jsonRoute'
+import {
+  MESSAGE_DONE_EVENT,
+  agentTest,
+  messageDeltaEvent
+} from '@e2e/tests/agent/agentPanelMocks'
+
+const test = mergeTests(agentTest, webSocketFixture)
+
+const COLLAPSED_COUNT = 12
+const MODEL_COUNT = 13
+const HIDDEN_MODEL = `mesh-${MODEL_COUNT - 1}.glb`
+
+const MODEL_REPLY = Array.from(
+  { length: MODEL_COUNT },
+  (_, index) => `- ![mesh-${index}](/api/view?filename=mesh-${index}.glb)`
+).join('\n')
+
+const PNG_PIXEL = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==',
+  'base64'
+)
+
+function pushEvent(ws: WebSocketRoute, event: unknown): void {
+  ws.send(JSON.stringify(event))
+}
+
+test.describe('Agent reply assets', { tag: '@cloud' }, () => {
+  test.use({ connectWebSocketToServer: false })
+
+  test('looks up 3D previews only for the reply assets on screen', async ({
+    comfyPage,
+    postedMessages,
+    getWebSocket
+  }) => {
+    const page = comfyPage.page
+    const lookedUp: string[] = []
+
+    await page.route('**/api/assets**', (route: Route) => {
+      const url = new URL(route.request().url())
+      if (url.pathname.endsWith('/content'))
+        return route.fulfill({ contentType: 'image/png', body: PNG_PIXEL })
+
+      const name =
+        url.searchParams.get('hash') ?? url.searchParams.get('name_contains')
+      if (!name) return route.fulfill(jsonRoute({ assets: [] }))
+
+      lookedUp.push(name)
+      return route.fulfill(
+        jsonRoute({
+          assets: [
+            {
+              id: `asset-${name}`,
+              name,
+              hash: name,
+              preview_id: `preview-${name}`
+            }
+          ]
+        })
+      )
+    })
+
+    await page
+      .getByRole('button', { name: enMessages.agent.askComfyAgent })
+      .click()
+
+    const panel = page.locator('#agent-panel-root')
+    await panel
+      .getByRole('textbox', { name: /^Describe ideas/ })
+      .fill('show me every mesh')
+
+    const ws = await getWebSocket()
+    await panel.getByRole('button', { name: enMessages.agent.send }).click()
+    await expect.poll(() => postedMessages.length).toBeGreaterThanOrEqual(1)
+
+    pushEvent(ws, { type: 'feature_flags', data: { assets: true } })
+    pushEvent(ws, messageDeltaEvent(MODEL_REPLY))
+    pushEvent(ws, MESSAGE_DONE_EVENT)
+
+    const tiles = panel.getByRole('button', { name: /^mesh-\d+$/ })
+    const thumbnails = panel.locator('img[alt^="mesh-"]')
+
+    await expect(tiles).toHaveCount(COLLAPSED_COUNT)
+    await expect(thumbnails).toHaveCount(COLLAPSED_COUNT)
+    expect(
+      new Set(lookedUp).size,
+      'a collapsed reply must only look up the models it shows'
+    ).toBe(COLLAPSED_COUNT)
+    expect(lookedUp).not.toContain(HIDDEN_MODEL)
+
+    await panel.getByRole('button', { name: enMessages.agent.showMore }).click()
+
+    await expect(tiles).toHaveCount(MODEL_COUNT)
+    await expect.poll(() => lookedUp).toContain(HIDDEN_MODEL)
+  })
+})

--- a/browser_tests/tests/agent/agentReplyAssets.spec.ts
+++ b/browser_tests/tests/agent/agentReplyAssets.spec.ts
@@ -4,15 +4,16 @@ import { expect, mergeTests } from '@playwright/test'
 import { webSocketFixture } from '@e2e/fixtures/ws'
 
 import enMessages from '@/locales/en/main.json' with { type: 'json' }
+import type { FeatureFlagsWsMessage } from '@/schemas/apiSchema'
+import type { AgentWsEvent } from '@/workbench/extensions/agent/schemas/agentApiSchema'
 
 import { jsonRoute } from '@e2e/fixtures/utils/jsonRoute'
+import { transparentPng } from '@e2e/fixtures/utils/viewFileMocks'
 import {
   MESSAGE_DONE_EVENT,
   agentTest,
   messageDeltaEvent
 } from '@e2e/tests/agent/agentPanelMocks'
-
-const test = mergeTests(agentTest, webSocketFixture)
 
 const COLLAPSED_COUNT = 12
 const MODEL_COUNT = 13
@@ -23,30 +24,32 @@ const MODEL_REPLY = Array.from(
   (_, index) => `- ![mesh-${index}](/api/view?filename=mesh-${index}.glb)`
 ).join('\n')
 
-const PNG_PIXEL = Buffer.from(
-  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==',
-  'base64'
-)
+type WsFrame =
+  | AgentWsEvent
+  | { type: 'feature_flags'; data: FeatureFlagsWsMessage }
 
-function pushEvent(ws: WebSocketRoute, event: unknown): void {
+function pushEvent(ws: WebSocketRoute, event: WsFrame): void {
   ws.send(JSON.stringify(event))
 }
 
-test.describe('Agent reply assets', { tag: '@cloud' }, () => {
-  test.use({ connectWebSocketToServer: false })
-
-  test('looks up 3D previews only for the reply assets on screen', async ({
-    comfyPage,
-    postedMessages,
-    getWebSocket
-  }) => {
-    const page = comfyPage.page
+/**
+ * Names the component asked the asset API about, in request order. Every
+ * looked-up model answers with a ready preview, so a tile renders without
+ * needing a WebGL thumbnail render.
+ */
+const test = mergeTests(agentTest, webSocketFixture).extend<{
+  lookedUpModels: string[]
+}>({
+  lookedUpModels: async ({ page }, use) => {
     const lookedUp: string[] = []
 
     await page.route('**/api/assets**', (route: Route) => {
       const url = new URL(route.request().url())
       if (url.pathname.endsWith('/content'))
-        return route.fulfill({ contentType: 'image/png', body: PNG_PIXEL })
+        return route.fulfill({
+          contentType: 'image/png',
+          body: transparentPng
+        })
 
       const name =
         url.searchParams.get('hash') ?? url.searchParams.get('name_contains')
@@ -67,6 +70,22 @@ test.describe('Agent reply assets', { tag: '@cloud' }, () => {
       )
     })
 
+    await use(lookedUp)
+  }
+})
+
+test.describe('Agent reply assets', { tag: '@cloud' }, () => {
+  test.use({ connectWebSocketToServer: false })
+
+  test('looks up 3D previews only for the reply assets on screen', async ({
+    comfyPage,
+    postedMessages,
+    getWebSocket,
+    lookedUpModels
+  }) => {
+    test.setTimeout(30_000)
+
+    const page = comfyPage.page
     await page
       .getByRole('button', { name: enMessages.agent.askComfyAgent })
       .click()
@@ -90,14 +109,16 @@ test.describe('Agent reply assets', { tag: '@cloud' }, () => {
     await expect(tiles).toHaveCount(COLLAPSED_COUNT)
     await expect(thumbnails).toHaveCount(COLLAPSED_COUNT)
     expect(
-      new Set(lookedUp).size,
+      new Set(lookedUpModels).size,
       'a collapsed reply must only look up the models it shows'
     ).toBe(COLLAPSED_COUNT)
-    expect(lookedUp).not.toContain(HIDDEN_MODEL)
+    expect(lookedUpModels).not.toContain(HIDDEN_MODEL)
 
     await panel.getByRole('button', { name: enMessages.agent.showMore }).click()
 
     await expect(tiles).toHaveCount(MODEL_COUNT)
-    await expect.poll(() => lookedUp).toContain(HIDDEN_MODEL)
+    await expect(thumbnails).toHaveCount(MODEL_COUNT)
+    await expect.poll(() => new Set(lookedUpModels).size).toBe(MODEL_COUNT)
+    expect(lookedUpModels).toContain(HIDDEN_MODEL)
   })
 })

--- a/src/components/load3d/modelThumbnail.test.ts
+++ b/src/components/load3d/modelThumbnail.test.ts
@@ -182,7 +182,7 @@ describe('generateModelThumbnail', () => {
     }
   })
 
-  it('bounds thumbnail capture and clears the timeout after success', async () => {
+  it('gives up on a stalled capture and leaves no timer behind', async () => {
     vi.useFakeTimers()
     try {
       const first = mockInstance({

--- a/src/components/load3d/modelThumbnail.test.ts
+++ b/src/components/load3d/modelThumbnail.test.ts
@@ -110,7 +110,7 @@ describe('generateModelThumbnail', () => {
       controller.abort()
       await vi.advanceTimersByTimeAsync(10_000)
 
-      await expect(blockedRun).resolves.toEqual({ status: 'timed-out' })
+      await expect(blockedRun).resolves.toEqual({ status: 'failed' })
       await expect(skippedRun).resolves.toEqual({ status: 'cancelled' })
       expect(createLoad3d).toHaveBeenCalledTimes(1)
     } finally {
@@ -164,7 +164,7 @@ describe('generateModelThumbnail', () => {
       const secondRun = generateModelThumbnail('/next.glb', 'next.glb')
       await vi.advanceTimersByTimeAsync(10_000)
 
-      await expect(firstRun).resolves.toEqual({ status: 'timed-out' })
+      await expect(firstRun).resolves.toEqual({ status: 'failed' })
       await expect(secondRun).resolves.toEqual({
         status: 'rendered',
         dataUrl: 'data:image/png;base64,thumb'
@@ -195,7 +195,7 @@ describe('generateModelThumbnail', () => {
       const secondRun = generateModelThumbnail('/next.glb', 'next.glb')
       await vi.advanceTimersByTimeAsync(10_000)
 
-      await expect(firstRun).resolves.toEqual({ status: 'timed-out' })
+      await expect(firstRun).resolves.toEqual({ status: 'failed' })
       await expect(secondRun).resolves.toEqual({
         status: 'rendered',
         dataUrl: 'data:image/png;base64,thumb'

--- a/src/components/load3d/modelThumbnail.test.ts
+++ b/src/components/load3d/modelThumbnail.test.ts
@@ -43,10 +43,52 @@ describe('generateModelThumbnail', () => {
       'a.glb'
     )
 
-    expect(result).toBe('data:image/png;base64,thumb')
-    expect(instance.loadModel).toHaveBeenCalledWith('/api/view?filename=a.glb')
+    expect(result).toEqual({
+      status: 'rendered',
+      dataUrl: 'data:image/png;base64,thumb'
+    })
+    expect(instance.loadModel).toHaveBeenCalledWith(
+      '/api/view?filename=a.glb',
+      undefined,
+      { silent: true }
+    )
     expect(instance.remove).toHaveBeenCalledTimes(1)
     expect(persistThumbnail).not.toHaveBeenCalled()
+  })
+
+  it('releases the queue the moment a running render is aborted', async () => {
+    vi.useFakeTimers()
+    try {
+      const stalled = mockInstance({
+        loadModel: vi.fn(() => new Promise(() => {}))
+      })
+      const next = mockInstance()
+      createLoad3d.mockReturnValueOnce(stalled).mockReturnValueOnce(next)
+      const controller = new AbortController()
+
+      const abortedRun = generateModelThumbnail(
+        '/slow.glb',
+        'slow.glb',
+        controller.signal
+      )
+      const nextRun = generateModelThumbnail('/next.glb', 'next.glb')
+      await vi.advanceTimersByTimeAsync(0)
+      expect(createLoad3d).toHaveBeenCalledTimes(1)
+
+      controller.abort()
+      await vi.advanceTimersByTimeAsync(0)
+
+      await expect(abortedRun).resolves.toEqual({ status: 'cancelled' })
+      await expect(nextRun).resolves.toEqual({
+        status: 'rendered',
+        dataUrl: 'data:image/png;base64,thumb'
+      })
+      expect(stalled.remove).toHaveBeenCalledOnce()
+      expect(vi.getTimerCount()).toBe(0)
+      expect(reportError).not.toHaveBeenCalled()
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('skips a queued render whose caller aborted before its turn', async () => {
@@ -68,8 +110,8 @@ describe('generateModelThumbnail', () => {
       controller.abort()
       await vi.advanceTimersByTimeAsync(10_000)
 
-      await expect(blockedRun).resolves.toBeNull()
-      await expect(skippedRun).resolves.toBeNull()
+      await expect(blockedRun).resolves.toEqual({ status: 'timed-out' })
+      await expect(skippedRun).resolves.toEqual({ status: 'cancelled' })
       expect(createLoad3d).toHaveBeenCalledTimes(1)
     } finally {
       vi.useRealTimers()
@@ -84,7 +126,7 @@ describe('generateModelThumbnail', () => {
 
     const result = await generateModelThumbnail('/broken.glb', 'broken.glb')
 
-    expect(result).toBeNull()
+    expect(result).toEqual({ status: 'failed' })
     expect(instance.remove).toHaveBeenCalledTimes(1)
   })
 
@@ -122,8 +164,11 @@ describe('generateModelThumbnail', () => {
       const secondRun = generateModelThumbnail('/next.glb', 'next.glb')
       await vi.advanceTimersByTimeAsync(10_000)
 
-      await expect(firstRun).resolves.toBeNull()
-      await expect(secondRun).resolves.toBe('data:image/png;base64,thumb')
+      await expect(firstRun).resolves.toEqual({ status: 'timed-out' })
+      await expect(secondRun).resolves.toEqual({
+        status: 'rendered',
+        dataUrl: 'data:image/png;base64,thumb'
+      })
       expect(first.remove).toHaveBeenCalledOnce()
       expect(second.remove).toHaveBeenCalledOnce()
       expect(reportError).toHaveBeenCalledWith(
@@ -150,8 +195,11 @@ describe('generateModelThumbnail', () => {
       const secondRun = generateModelThumbnail('/next.glb', 'next.glb')
       await vi.advanceTimersByTimeAsync(10_000)
 
-      await expect(firstRun).resolves.toBeNull()
-      await expect(secondRun).resolves.toBe('data:image/png;base64,thumb')
+      await expect(firstRun).resolves.toEqual({ status: 'timed-out' })
+      await expect(secondRun).resolves.toEqual({
+        status: 'rendered',
+        dataUrl: 'data:image/png;base64,thumb'
+      })
       expect(first.remove).toHaveBeenCalledOnce()
       expect(second.remove).toHaveBeenCalledOnce()
       expect(vi.getTimerCount()).toBe(0)

--- a/src/components/load3d/modelThumbnail.test.ts
+++ b/src/components/load3d/modelThumbnail.test.ts
@@ -118,7 +118,7 @@ describe('generateModelThumbnail', () => {
     }
   })
 
-  it('returns null and still disposes when the model fails to load', async () => {
+  it('reports a failed render and still disposes the instance', async () => {
     const instance = mockInstance({
       loadModel: vi.fn().mockRejectedValue(new Error('bad model'))
     })

--- a/src/components/load3d/modelThumbnail.test.ts
+++ b/src/components/load3d/modelThumbnail.test.ts
@@ -46,6 +46,34 @@ describe('generateModelThumbnail', () => {
     expect(result).toBe('data:image/png;base64,thumb')
     expect(instance.loadModel).toHaveBeenCalledWith('/api/view?filename=a.glb')
     expect(instance.remove).toHaveBeenCalledTimes(1)
+    expect(persistThumbnail).not.toHaveBeenCalled()
+  })
+
+  it('skips a queued render whose caller aborted before its turn', async () => {
+    const blocked = mockInstance({
+      loadModel: vi.fn(() => new Promise(() => {}))
+    })
+    const skipped = mockInstance()
+    createLoad3d.mockReturnValueOnce(blocked).mockReturnValueOnce(skipped)
+    const controller = new AbortController()
+
+    vi.useFakeTimers()
+    try {
+      const blockedRun = generateModelThumbnail('/stuck.glb', 'stuck.glb')
+      const skippedRun = generateModelThumbnail(
+        '/next.glb',
+        'next.glb',
+        controller.signal
+      )
+      controller.abort()
+      await vi.advanceTimersByTimeAsync(10_000)
+
+      await expect(blockedRun).resolves.toBeNull()
+      await expect(skippedRun).resolves.toBeNull()
+      expect(createLoad3d).toHaveBeenCalledTimes(1)
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('returns null and still disposes when the model fails to load', async () => {
@@ -81,7 +109,7 @@ describe('generateModelThumbnail', () => {
     expect(createLoad3d).toHaveBeenCalledTimes(2)
   })
 
-  it('[11-T5 regression] cancels a stuck load, disposes it, and advances the queue', async () => {
+  it('cancels a stuck load, disposes it, and advances the queue', async () => {
     vi.useFakeTimers()
     try {
       const first = mockInstance({

--- a/src/components/load3d/modelThumbnail.ts
+++ b/src/components/load3d/modelThumbnail.ts
@@ -11,24 +11,34 @@ const MODEL_THUMBNAIL_TIMEOUT_MS = 10_000
  * Render a model to a thumbnail data URL offscreen, without opening the
  * viewer. Runs one generation at a time to bound live WebGL contexts and
  * persists the result through the asset API so other surfaces pick it up.
- * Resolves null when the model cannot be rendered.
+ * Resolves null when the model cannot be rendered, when generation exceeds
+ * its deadline, or when `callerSignal` aborts — including while the request
+ * is still waiting its turn in the queue.
  */
 export function generateModelThumbnail(
   modelUrl: string,
-  assetName: string
+  assetName: string,
+  callerSignal?: AbortSignal
 ): Promise<string | null> {
-  const run = queue.then(() => renderThumbnailWithTimeout(modelUrl, assetName))
+  const run = queue.then(() =>
+    callerSignal?.aborted
+      ? null
+      : renderThumbnailWithTimeout(modelUrl, assetName, callerSignal)
+  )
   queue = run.catch(() => null)
   return run
 }
 
 async function renderThumbnailWithTimeout(
   modelUrl: string,
-  assetName: string
+  assetName: string,
+  callerSignal?: AbortSignal
 ): Promise<string | null> {
   const abortController = new AbortController()
   let timeoutId: ReturnType<typeof setTimeout> | undefined
   const timeoutError = new Error('Model thumbnail generation timed out')
+  const abortForCaller = () => abortController.abort(callerSignal?.reason)
+  callerSignal?.addEventListener('abort', abortForCaller, { once: true })
 
   try {
     return await Promise.race([
@@ -41,12 +51,14 @@ async function renderThumbnailWithTimeout(
       })
     ])
   } catch (error) {
+    if (callerSignal?.aborted) return null
     reportError(error, {
       errorType: 'agent_model_thumbnail_generation_failure'
     })
     return null
   } finally {
     if (timeoutId !== undefined) clearTimeout(timeoutId)
+    callerSignal?.removeEventListener('abort', abortForCaller)
   }
 }
 

--- a/src/components/load3d/modelThumbnail.ts
+++ b/src/components/load3d/modelThumbnail.ts
@@ -8,22 +8,25 @@ let queue: Promise<unknown> = Promise.resolve()
 const MODEL_THUMBNAIL_TIMEOUT_MS = 10_000
 
 /**
- * Outcome of an offscreen thumbnail render. `timed-out` is the only
- * failure worth retrying: the model may simply have been slower than the
- * deadline, whereas `failed` means it could not be rendered at all.
+ * Outcome of an offscreen thumbnail render. `cancelled` is separated from
+ * `failed` so a caller that walked away is not reported as a fault.
  */
 export type ModelThumbnailResult =
   | { status: 'rendered'; dataUrl: string }
-  | { status: 'timed-out' }
   | { status: 'cancelled' }
   | { status: 'failed' }
 
 /**
  * Render a model to a thumbnail data URL offscreen, without opening the
- * viewer. Runs one generation at a time to bound live WebGL contexts and
- * persists the result through the asset API so other surfaces pick it up.
- * Aborting `callerSignal` settles the request and releases the queue, both
- * while it waits its turn and once it is running.
+ * viewer. Starts one render at a time so only one WebGL context is ever
+ * live, and persists the result through the asset API so other surfaces
+ * pick it up.
+ *
+ * A render that outlives its deadline is given up on: its viewer is torn
+ * down and the queue moves on, but the underlying transfer and parse are
+ * not abortable and run to completion in the background. Aborting
+ * `callerSignal` gives up the same way, and skips the render entirely if
+ * it has not started yet.
  */
 export function generateModelThumbnail(
   modelUrl: string,
@@ -70,12 +73,6 @@ async function renderThumbnailWithTimeout(
     ])
     return { status: 'rendered', dataUrl }
   } catch (error) {
-    if (error === timeoutError) {
-      reportError(error, {
-        errorType: 'agent_model_thumbnail_generation_failure'
-      })
-      return { status: 'timed-out' }
-    }
     if (callerSignal?.aborted) return { status: 'cancelled' }
     reportError(error, {
       errorType: 'agent_model_thumbnail_generation_failure'

--- a/src/components/load3d/modelThumbnail.ts
+++ b/src/components/load3d/modelThumbnail.ts
@@ -18,11 +18,13 @@ export type ModelThumbnailResult =
 
 /**
  * Render a model to a thumbnail data URL offscreen, without opening the
- * viewer. Starts one render at a time so only one WebGL context is ever
+ * viewer. Starts one render at a time so at most one offscreen scene is
  * live, and persists the result through the asset API so other surfaces
  * pick it up.
  *
- * A render that outlives its deadline is given up on: its viewer is torn
+ * The viewer chunk and the model each get their own deadline, so a cold
+ * code-split fetch is bounded without spending the model's budget. A
+ * render that outlives its deadline is given up on: its viewer is torn
  * down and the queue moves on, but the underlying transfer and parse are
  * not abortable and run to completion in the background. Aborting
  * `callerSignal` gives up the same way, and skips the render entirely if
@@ -53,15 +55,27 @@ async function renderThumbnailWithTimeout(
   const cancelError = new Error('Model thumbnail generation cancelled')
   let timeoutId: ReturnType<typeof setTimeout> | undefined
   let onCallerAbort: (() => void) | undefined
+  let expire: (error: Error) => void = () => {}
+
+  const restartDeadline = () => {
+    if (timeoutId !== undefined) clearTimeout(timeoutId)
+    timeoutId = setTimeout(() => {
+      abortController.abort(timeoutError)
+      expire(timeoutError)
+    }, MODEL_THUMBNAIL_TIMEOUT_MS)
+  }
 
   try {
     const dataUrl = await Promise.race([
-      renderThumbnail(modelUrl, assetName, abortController.signal),
+      renderThumbnail(
+        modelUrl,
+        assetName,
+        abortController.signal,
+        restartDeadline
+      ),
       new Promise<never>((_, reject) => {
-        timeoutId = setTimeout(() => {
-          abortController.abort(timeoutError)
-          reject(timeoutError)
-        }, MODEL_THUMBNAIL_TIMEOUT_MS)
+        expire = reject
+        restartDeadline()
       }),
       new Promise<never>((_, reject) => {
         onCallerAbort = () => {
@@ -87,10 +101,12 @@ async function renderThumbnailWithTimeout(
 async function renderThumbnail(
   modelUrl: string,
   assetName: string,
-  signal: AbortSignal
+  signal: AbortSignal,
+  restartDeadline: () => void
 ): Promise<string> {
   const { createLoad3d } = await import('@/extensions/core/load3d/createLoad3d')
   signal.throwIfAborted()
+  restartDeadline()
 
   const load3d = createLoad3d(document.createElement('div'), {
     width: 256,

--- a/src/components/load3d/modelThumbnail.ts
+++ b/src/components/load3d/modelThumbnail.ts
@@ -8,22 +8,33 @@ let queue: Promise<unknown> = Promise.resolve()
 const MODEL_THUMBNAIL_TIMEOUT_MS = 10_000
 
 /**
+ * Outcome of an offscreen thumbnail render. `timed-out` is the only
+ * failure worth retrying: the model may simply have been slower than the
+ * deadline, whereas `failed` means it could not be rendered at all.
+ */
+export type ModelThumbnailResult =
+  | { status: 'rendered'; dataUrl: string }
+  | { status: 'timed-out' }
+  | { status: 'cancelled' }
+  | { status: 'failed' }
+
+/**
  * Render a model to a thumbnail data URL offscreen, without opening the
  * viewer. Runs one generation at a time to bound live WebGL contexts and
  * persists the result through the asset API so other surfaces pick it up.
- * Resolves null when the model cannot be rendered, when generation exceeds
- * its deadline, or when `callerSignal` aborts — including while the request
- * is still waiting its turn in the queue.
+ * Aborting `callerSignal` settles the request and releases the queue, both
+ * while it waits its turn and once it is running.
  */
 export function generateModelThumbnail(
   modelUrl: string,
   assetName: string,
   callerSignal?: AbortSignal
-): Promise<string | null> {
-  const run = queue.then(() =>
-    callerSignal?.aborted
-      ? null
-      : renderThumbnailWithTimeout(modelUrl, assetName, callerSignal)
+): Promise<ModelThumbnailResult> {
+  const run = queue.then(
+    (): ModelThumbnailResult | Promise<ModelThumbnailResult> =>
+      callerSignal?.aborted
+        ? { status: 'cancelled' }
+        : renderThumbnailWithTimeout(modelUrl, assetName, callerSignal)
   )
   queue = run.catch(() => null)
   return run
@@ -33,32 +44,46 @@ async function renderThumbnailWithTimeout(
   modelUrl: string,
   assetName: string,
   callerSignal?: AbortSignal
-): Promise<string | null> {
+): Promise<ModelThumbnailResult> {
   const abortController = new AbortController()
-  let timeoutId: ReturnType<typeof setTimeout> | undefined
   const timeoutError = new Error('Model thumbnail generation timed out')
-  const abortForCaller = () => abortController.abort(callerSignal?.reason)
-  callerSignal?.addEventListener('abort', abortForCaller, { once: true })
+  const cancelError = new Error('Model thumbnail generation cancelled')
+  let timeoutId: ReturnType<typeof setTimeout> | undefined
+  let onCallerAbort: (() => void) | undefined
 
   try {
-    return await Promise.race([
+    const dataUrl = await Promise.race([
       renderThumbnail(modelUrl, assetName, abortController.signal),
       new Promise<never>((_, reject) => {
         timeoutId = setTimeout(() => {
           abortController.abort(timeoutError)
           reject(timeoutError)
         }, MODEL_THUMBNAIL_TIMEOUT_MS)
+      }),
+      new Promise<never>((_, reject) => {
+        onCallerAbort = () => {
+          abortController.abort(cancelError)
+          reject(cancelError)
+        }
+        callerSignal?.addEventListener('abort', onCallerAbort, { once: true })
       })
     ])
+    return { status: 'rendered', dataUrl }
   } catch (error) {
-    if (callerSignal?.aborted) return null
+    if (error === timeoutError) {
+      reportError(error, {
+        errorType: 'agent_model_thumbnail_generation_failure'
+      })
+      return { status: 'timed-out' }
+    }
+    if (callerSignal?.aborted) return { status: 'cancelled' }
     reportError(error, {
       errorType: 'agent_model_thumbnail_generation_failure'
     })
-    return null
+    return { status: 'failed' }
   } finally {
     if (timeoutId !== undefined) clearTimeout(timeoutId)
-    callerSignal?.removeEventListener('abort', abortForCaller)
+    if (onCallerAbort) callerSignal?.removeEventListener('abort', onCallerAbort)
   }
 }
 
@@ -85,7 +110,7 @@ async function renderThumbnail(
   signal.addEventListener('abort', remove, { once: true })
 
   try {
-    await load3d.loadModel(modelUrl)
+    await load3d.loadModel(modelUrl, undefined, { silent: true })
     signal.throwIfAborted()
     const dataUrl = await load3d.captureThumbnail(256, 256)
     signal.throwIfAborted()

--- a/src/extensions/core/load3d/LoaderManager.test.ts
+++ b/src/extensions/core/load3d/LoaderManager.test.ts
@@ -622,7 +622,7 @@ describe('LoaderManager', () => {
       expect(endEmits).toHaveLength(1)
     })
 
-    it('cancels an in-flight load when disposed', async () => {
+    it('drops and disposes an in-flight load when disposed', async () => {
       const { lm, modelManager } = makeLoaderManager()
       let resolveLoad!: (value: ReturnType<typeof loadResult>) => void
       const pendingLoad = new Promise<ReturnType<typeof loadResult>>(
@@ -641,10 +641,41 @@ describe('LoaderManager', () => {
       lm.dispose()
       resolveLoad(loadResult(model))
 
-      await expect(load).rejects.toMatchObject({ name: 'AbortError' })
+      await expect(load).resolves.toBeUndefined()
       expect(modelManager.setupModel).not.toHaveBeenCalled()
       expect(disposeGeometry).toHaveBeenCalledOnce()
       expect(disposeMaterial).toHaveBeenCalledOnce()
+      expect(addAlert).not.toHaveBeenCalled()
+    })
+
+    it('drops a load that fails after disposal without alerting', async () => {
+      const { lm, modelManager } = makeLoaderManager()
+      let rejectLoad!: (reason: Error) => void
+      meshLoad.mockReturnValueOnce(
+        new Promise((_, reject) => {
+          rejectLoad = reject
+        })
+      )
+
+      const load = lm.loadModel('api/view?filename=cube.glb')
+      lm.dispose()
+      rejectLoad(new Error('connection reset'))
+
+      await expect(load).resolves.toBeUndefined()
+      expect(modelManager.setupModel).not.toHaveBeenCalled()
+      expect(addAlert).not.toHaveBeenCalled()
+    })
+
+    it('drops a load started after disposal without alerting', async () => {
+      const { lm, modelManager } = makeLoaderManager()
+      lm.dispose()
+
+      await expect(
+        lm.loadModel('api/view?filename=cube.glb')
+      ).resolves.toBeUndefined()
+      expect(modelManager.setupModel).not.toHaveBeenCalled()
+      expect(meshLoad).not.toHaveBeenCalled()
+      expect(addAlert).not.toHaveBeenCalled()
     })
 
     it('logs and drops the load when the URL is missing a filename param', async () => {

--- a/src/extensions/core/load3d/LoaderManager.test.ts
+++ b/src/extensions/core/load3d/LoaderManager.test.ts
@@ -611,6 +611,28 @@ describe('LoaderManager', () => {
       expect(addAlert).not.toHaveBeenCalled()
     })
 
+    it('rejects when no adapter claims the extension and silent is set', async () => {
+      const { lm, modelManager } = makeLoaderManager()
+
+      await expect(
+        lm.loadModel('api/view?filename=scene.usdz', undefined, {
+          silent: true
+        })
+      ).rejects.toThrow(/No model could be loaded/)
+      expect(modelManager.setupModel).not.toHaveBeenCalled()
+      expect(addAlert).not.toHaveBeenCalled()
+    })
+
+    it('rejects when the URL carries no filename and silent is set', async () => {
+      const { lm } = makeLoaderManager()
+      vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      await expect(
+        lm.loadModel('api/view?type=output', 'scene.glb', { silent: true })
+      ).rejects.toThrow(/No model could be loaded/)
+      expect(addAlert).not.toHaveBeenCalled()
+    })
+
     it('discards the result of a stale load when a newer one has started', async () => {
       const { lm, modelManager, eventManager } = makeLoaderManager()
 

--- a/src/extensions/core/load3d/LoaderManager.test.ts
+++ b/src/extensions/core/load3d/LoaderManager.test.ts
@@ -590,16 +590,24 @@ describe('LoaderManager', () => {
       expect(addAlert).toHaveBeenCalledWith('toastMessages.errorLoadingModel')
     })
 
-    it('raises no alert at all when silent is set', async () => {
+    it('rejects with the load failure instead of alerting when silent is set', async () => {
       const { lm } = makeLoaderManager()
       meshLoad.mockRejectedValueOnce(new Error('parse failure: bad header'))
       vi.spyOn(console, 'error').mockImplementation(() => {})
 
-      await lm.loadModel('api/view?filename=cube.glb', undefined, {
-        silent: true
-      })
-      await lm.loadModel('api/view?filename=cube', undefined, { silent: true })
+      await expect(
+        lm.loadModel('api/view?filename=cube.glb', undefined, { silent: true })
+      ).rejects.toThrow('parse failure: bad header')
+      expect(addAlert).not.toHaveBeenCalled()
+    })
 
+    it('rejects on an undeterminable file type instead of alerting when silent is set', async () => {
+      const { lm } = makeLoaderManager()
+      vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      await expect(
+        lm.loadModel('api/view?type=output', undefined, { silent: true })
+      ).rejects.toThrow(/Unknown model file type/)
       expect(addAlert).not.toHaveBeenCalled()
     })
 

--- a/src/extensions/core/load3d/LoaderManager.test.ts
+++ b/src/extensions/core/load3d/LoaderManager.test.ts
@@ -590,6 +590,19 @@ describe('LoaderManager', () => {
       expect(addAlert).toHaveBeenCalledWith('toastMessages.errorLoadingModel')
     })
 
+    it('raises no alert at all when silent is set', async () => {
+      const { lm } = makeLoaderManager()
+      meshLoad.mockRejectedValueOnce(new Error('parse failure: bad header'))
+      vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      await lm.loadModel('api/view?filename=cube.glb', undefined, {
+        silent: true
+      })
+      await lm.loadModel('api/view?filename=cube', undefined, { silent: true })
+
+      expect(addAlert).not.toHaveBeenCalled()
+    })
+
     it('discards the result of a stale load when a newer one has started', async () => {
       const { lm, modelManager, eventManager } = makeLoaderManager()
 

--- a/src/extensions/core/load3d/LoaderManager.ts
+++ b/src/extensions/core/load3d/LoaderManager.ts
@@ -120,9 +120,8 @@ export class LoaderManager implements LoaderManagerInterface {
       }
 
       if (!fileExtension) {
-        if (!options?.silent) {
-          useToastStore().addAlert(t('toastMessages.couldNotDetermineFileType'))
-        }
+        if (options?.silent) throw new Error(`Unknown model file type: ${url}`)
+        useToastStore().addAlert(t('toastMessages.couldNotDetermineFileType'))
         return
       }
 
@@ -147,15 +146,12 @@ export class LoaderManager implements LoaderManagerInterface {
 
       this.eventManager.emitEvent('modelLoadingEnd', null)
     } catch (error) {
-      if (loadId === this.currentLoadId) {
-        this.eventManager.emitEvent('modelLoadingEnd', null)
-        console.error('Error loading model:', error)
-        const silenced =
-          options?.silent ||
-          (options?.silentOnNotFound && isNotFoundError(error))
-        if (!silenced) {
-          useToastStore().addAlert(t('toastMessages.errorLoadingModel'))
-        }
+      if (loadId !== this.currentLoadId) return
+      this.eventManager.emitEvent('modelLoadingEnd', null)
+      console.error('Error loading model:', error)
+      if (options?.silent) throw error
+      if (!(options?.silentOnNotFound && isNotFoundError(error))) {
+        useToastStore().addAlert(t('toastMessages.errorLoadingModel'))
       }
     }
   }

--- a/src/extensions/core/load3d/LoaderManager.ts
+++ b/src/extensions/core/load3d/LoaderManager.ts
@@ -128,11 +128,17 @@ export class LoaderManager implements LoaderManagerInterface {
       const result = await this.loadModelInternal(url, fileExtension)
 
       if (loadId !== this.currentLoadId) {
-        if (result) this.disposeLoadResult(result)
+        // Only a disposed manager is guaranteed to hold no reference to
+        // this result; a newer load may still have it as originalModel.
+        if (result && this.disposed) this.disposeLoadResult(result)
         // A newer loadModel has superseded us — do not publish our adapter
         // and do not setup the model. Whichever load is current owns the
         // shared state.
         return
+      }
+
+      if (!result && options?.silent) {
+        throw new Error(`No model could be loaded from: ${url}`)
       }
 
       if (result) {

--- a/src/extensions/core/load3d/LoaderManager.ts
+++ b/src/extensions/core/load3d/LoaderManager.ts
@@ -128,8 +128,9 @@ export class LoaderManager implements LoaderManagerInterface {
       const result = await this.loadModelInternal(url, fileExtension)
 
       if (loadId !== this.currentLoadId) {
-        // Only a disposed manager is guaranteed to hold no reference to
-        // this result; a newer load may still have it as originalModel.
+        // A newer load on a live manager may already have published this
+        // object as originalModel, so only dispose once the manager is
+        // torn down and nothing can reach it.
         if (result && this.disposed) this.disposeLoadResult(result)
         // A newer loadModel has superseded us — do not publish our adapter
         // and do not setup the model. Whichever load is current owns the

--- a/src/extensions/core/load3d/LoaderManager.ts
+++ b/src/extensions/core/load3d/LoaderManager.ts
@@ -120,7 +120,9 @@ export class LoaderManager implements LoaderManagerInterface {
       }
 
       if (!fileExtension) {
-        useToastStore().addAlert(t('toastMessages.couldNotDetermineFileType'))
+        if (!options?.silent) {
+          useToastStore().addAlert(t('toastMessages.couldNotDetermineFileType'))
+        }
         return
       }
 
@@ -145,11 +147,13 @@ export class LoaderManager implements LoaderManagerInterface {
 
       this.eventManager.emitEvent('modelLoadingEnd', null)
     } catch (error) {
-      if (this.disposed) return
       if (loadId === this.currentLoadId) {
         this.eventManager.emitEvent('modelLoadingEnd', null)
         console.error('Error loading model:', error)
-        if (!(options?.silentOnNotFound && isNotFoundError(error))) {
+        const silenced =
+          options?.silent ||
+          (options?.silentOnNotFound && isNotFoundError(error))
+        if (!silenced) {
           useToastStore().addAlert(t('toastMessages.errorLoadingModel'))
         }
       }

--- a/src/extensions/core/load3d/LoaderManager.ts
+++ b/src/extensions/core/load3d/LoaderManager.ts
@@ -93,7 +93,7 @@ export class LoaderManager implements LoaderManagerInterface {
     originalFileName?: string,
     options?: LoadModelOptions
   ): Promise<void> {
-    if (this.disposed) throw this.createAbortError()
+    if (this.disposed) return
     const loadId = ++this.currentLoadId
 
     try {
@@ -128,7 +128,6 @@ export class LoaderManager implements LoaderManagerInterface {
 
       if (loadId !== this.currentLoadId) {
         if (result) this.disposeLoadResult(result)
-        if (this.disposed) throw this.createAbortError()
         // A newer loadModel has superseded us — do not publish our adapter
         // and do not setup the model. Whichever load is current owns the
         // shared state.
@@ -146,7 +145,7 @@ export class LoaderManager implements LoaderManagerInterface {
 
       this.eventManager.emitEvent('modelLoadingEnd', null)
     } catch (error) {
-      if (this.disposed) throw this.createAbortError()
+      if (this.disposed) return
       if (loadId === this.currentLoadId) {
         this.eventManager.emitEvent('modelLoadingEnd', null)
         console.error('Error loading model:', error)
@@ -155,12 +154,6 @@ export class LoaderManager implements LoaderManagerInterface {
         }
       }
     }
-  }
-
-  private createAbortError(): Error {
-    const error = new Error('Model load aborted')
-    error.name = 'AbortError'
-    return error
   }
 
   private disposeLoadResult(

--- a/src/extensions/core/load3d/interfaces.ts
+++ b/src/extensions/core/load3d/interfaces.ts
@@ -249,6 +249,12 @@ export interface LoadModelOptions {
    * (e.g. shared workflows on a fresh machine).
    */
   silentOnNotFound?: boolean
+  /**
+   * When true, suppress every user-facing toast for this load. Use for
+   * offscreen renders the viewer never asked for (e.g. thumbnail
+   * generation), where a failure has no surface the user can act on.
+   */
+  silent?: boolean
 }
 
 export interface SceneOverlay {

--- a/src/extensions/core/load3d/interfaces.ts
+++ b/src/extensions/core/load3d/interfaces.ts
@@ -250,9 +250,10 @@ export interface LoadModelOptions {
    */
   silentOnNotFound?: boolean
   /**
-   * When true, suppress every user-facing toast for this load. Use for
-   * offscreen renders the viewer never asked for (e.g. thumbnail
-   * generation), where a failure has no surface the user can act on.
+   * When true, raise no toast and reject with the underlying error
+   * instead. Use for offscreen renders the viewer never asked for (e.g.
+   * thumbnail generation), which have no surface to show a toast on and
+   * need the real cause for their own reporting.
    */
   silent?: boolean
 }

--- a/src/workbench/extensions/agent/components/agent/message/ReplyAssetGroup.test.ts
+++ b/src/workbench/extensions/agent/components/agent/message/ReplyAssetGroup.test.ts
@@ -250,44 +250,23 @@ describe('ReplyAssetGroup', () => {
     expect(generateModelThumbnail).not.toHaveBeenCalled()
   })
 
-  it('reports preview lookup failures and retries generation on a later pass', async () => {
-    isAssetPreviewSupported.mockReturnValue(true)
-    findServerPreviewUrl.mockRejectedValueOnce(new Error('preview failed'))
-    const { rerender } = renderGroup([model])
-
-    await waitFor(() =>
-      expect(reportError).toHaveBeenCalledWith(expect.any(Error), {
-        errorType: 'agent_reply_asset_preview_failure'
-      })
-    )
-
-    await rerender({ assets: [model, image(1)] })
-    await waitFor(() => expect(generateModelThumbnail).toHaveBeenCalledOnce())
-  })
-
-  it('retries a timed-out model once, not on every streaming pass', async () => {
+  it('re-queues a timed-out model once, without another render pass', async () => {
     isAssetPreviewSupported.mockReturnValue(true)
     generateModelThumbnail.mockResolvedValue({ status: 'timed-out' })
-    const { rerender } = renderGroup([model])
-    await waitFor(() => expect(generateModelThumbnail).toHaveBeenCalledOnce())
+    renderGroup([model])
 
-    await rerender({ assets: [{ ...model }] })
     await waitFor(() => expect(generateModelThumbnail).toHaveBeenCalledTimes(2))
 
-    await rerender({ assets: [{ ...model }] })
-    await rerender({ assets: [{ ...model }] })
-
+    await new Promise((resolve) => setTimeout(resolve, 0))
     expect(generateModelThumbnail).toHaveBeenCalledTimes(2)
   })
 
   it('does not retry a model that cannot be rendered', async () => {
     isAssetPreviewSupported.mockReturnValue(true)
-    const { rerender } = renderGroup([model])
+    renderGroup([model])
     await waitFor(() => expect(generateModelThumbnail).toHaveBeenCalledOnce())
 
-    await rerender({ assets: [{ ...model }] })
-    await rerender({ assets: [{ ...model }] })
-
+    await new Promise((resolve) => setTimeout(resolve, 0))
     expect(generateModelThumbnail).toHaveBeenCalledOnce()
   })
 

--- a/src/workbench/extensions/agent/components/agent/message/ReplyAssetGroup.test.ts
+++ b/src/workbench/extensions/agent/components/agent/message/ReplyAssetGroup.test.ts
@@ -26,7 +26,13 @@ vi.mock('@/platform/assets/utils/assetPreviewUtil', () => ({
 }))
 
 const generateModelThumbnail = vi.hoisted(() =>
-  vi.fn(async (): Promise<string | null> => null)
+  vi.fn(
+    async (
+      _modelUrl: string,
+      _assetName: string,
+      _callerSignal?: AbortSignal
+    ): Promise<string | null> => null
+  )
 )
 vi.mock('@/components/load3d/modelThumbnail', () => ({
   generateModelThumbnail
@@ -218,7 +224,8 @@ describe('ReplyAssetGroup', () => {
     expect(thumb).toHaveAttribute('src', 'data:image/png;base64,gen')
     expect(generateModelThumbnail).toHaveBeenCalledWith(
       'https://x/mesh.glb',
-      'mesh.glb'
+      'mesh.glb',
+      expect.any(AbortSignal)
     )
   })
 
@@ -252,6 +259,33 @@ describe('ReplyAssetGroup', () => {
 
     await rerender({ assets: [model, image(1)] })
     await waitFor(() => expect(generateModelThumbnail).toHaveBeenCalledOnce())
+  })
+
+  it('retries an unpreviewable model once, not on every streaming pass', async () => {
+    isAssetPreviewSupported.mockReturnValue(true)
+    const { rerender } = renderGroup([model])
+    await waitFor(() => expect(generateModelThumbnail).toHaveBeenCalledOnce())
+
+    await rerender({ assets: [{ ...model }] })
+    await waitFor(() => expect(generateModelThumbnail).toHaveBeenCalledTimes(2))
+
+    await rerender({ assets: [{ ...model }] })
+    await rerender({ assets: [{ ...model }] })
+
+    expect(generateModelThumbnail).toHaveBeenCalledTimes(2)
+  })
+
+  it('aborts queued generation when unmounted', async () => {
+    isAssetPreviewSupported.mockReturnValue(true)
+    const { unmount } = renderGroup([model])
+    await waitFor(() => expect(generateModelThumbnail).toHaveBeenCalledOnce())
+
+    const [, , signal] = generateModelThumbnail.mock.calls[0]
+    expect(signal?.aborted).toBe(false)
+
+    unmount()
+
+    expect(signal?.aborted).toBe(true)
   })
 
   it('clears a pending thumbnail refresh when unmounted', async () => {
@@ -319,7 +353,7 @@ describe('ReplyAssetGroup', () => {
     expect(toggle()).toHaveTextContent('Show more')
   })
 
-  it('[11-T7 regression] generates thumbnails only for currently visible 3D entries', async () => {
+  it('generates thumbnails only for currently visible 3D entries', async () => {
     isAssetPreviewSupported.mockReturnValue(true)
     const models = Array.from({ length: 13 }, (_, n) => ({
       ...model,
@@ -333,14 +367,16 @@ describe('ReplyAssetGroup', () => {
     )
     expect(generateModelThumbnail).not.toHaveBeenCalledWith(
       'https://x/mesh-12.glb',
-      'mesh-12.glb'
+      'mesh-12.glb',
+      expect.any(AbortSignal)
     )
 
     await userEvent.click(toggle()!)
     await waitFor(() =>
       expect(generateModelThumbnail).toHaveBeenCalledWith(
         'https://x/mesh-12.glb',
-        'mesh-12.glb'
+        'mesh-12.glb',
+        expect.any(AbortSignal)
       )
     )
   })

--- a/src/workbench/extensions/agent/components/agent/message/ReplyAssetGroup.test.ts
+++ b/src/workbench/extensions/agent/components/agent/message/ReplyAssetGroup.test.ts
@@ -250,24 +250,14 @@ describe('ReplyAssetGroup', () => {
     expect(generateModelThumbnail).not.toHaveBeenCalled()
   })
 
-  it('re-queues a timed-out model once, without another render pass', async () => {
-    isAssetPreviewSupported.mockReturnValue(true)
-    generateModelThumbnail.mockResolvedValue({ status: 'timed-out' })
-    renderGroup([model])
-
-    await waitFor(() => expect(generateModelThumbnail).toHaveBeenCalledTimes(2))
-
-    await new Promise((resolve) => setTimeout(resolve, 0))
-    expect(generateModelThumbnail).toHaveBeenCalledTimes(2)
-  })
-
-  it('does not retry a model that cannot be rendered', async () => {
+  it('does not retry a model that failed to render', async () => {
     isAssetPreviewSupported.mockReturnValue(true)
     renderGroup([model])
     await waitFor(() => expect(generateModelThumbnail).toHaveBeenCalledOnce())
 
     await new Promise((resolve) => setTimeout(resolve, 0))
     expect(generateModelThumbnail).toHaveBeenCalledOnce()
+    expect(screen.getByRole('button', { name: 'mesh.glb' })).toBeInTheDocument()
   })
 
   it('aborts queued generation when unmounted', async () => {

--- a/src/workbench/extensions/agent/components/agent/message/ReplyAssetGroup.test.ts
+++ b/src/workbench/extensions/agent/components/agent/message/ReplyAssetGroup.test.ts
@@ -2,6 +2,7 @@ import { render, screen, waitFor } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import type { ModelThumbnailResult } from '@/components/load3d/modelThumbnail'
 import { i18n } from '@/i18n'
 
 import type { ReplyAsset } from '../../../utils/replyAssets'
@@ -31,7 +32,7 @@ const generateModelThumbnail = vi.hoisted(() =>
       _modelUrl: string,
       _assetName: string,
       _callerSignal?: AbortSignal
-    ): Promise<string | null> => null
+    ): Promise<ModelThumbnailResult> => ({ status: 'failed' })
   )
 )
 vi.mock('@/components/load3d/modelThumbnail', () => ({
@@ -94,7 +95,7 @@ describe('ReplyAssetGroup', () => {
     isAssetPreviewSupported.mockReset().mockReturnValue(false)
     findServerPreviewUrl.mockReset().mockResolvedValue(null)
     findOutputAsset.mockReset().mockResolvedValue(undefined)
-    generateModelThumbnail.mockReset().mockResolvedValue(null)
+    generateModelThumbnail.mockReset().mockResolvedValue({ status: 'failed' })
     reportError.mockReset()
   })
 
@@ -217,7 +218,10 @@ describe('ReplyAssetGroup', () => {
 
   it('generates a thumbnail offscreen when the server has none', async () => {
     isAssetPreviewSupported.mockReturnValue(true)
-    generateModelThumbnail.mockResolvedValue('data:image/png;base64,gen')
+    generateModelThumbnail.mockResolvedValue({
+      status: 'rendered',
+      dataUrl: 'data:image/png;base64,gen'
+    })
     renderGroup([model])
 
     const thumb = await screen.findByRole('img', { name: 'mesh.glb' })
@@ -261,8 +265,9 @@ describe('ReplyAssetGroup', () => {
     await waitFor(() => expect(generateModelThumbnail).toHaveBeenCalledOnce())
   })
 
-  it('retries an unpreviewable model once, not on every streaming pass', async () => {
+  it('retries a timed-out model once, not on every streaming pass', async () => {
     isAssetPreviewSupported.mockReturnValue(true)
+    generateModelThumbnail.mockResolvedValue({ status: 'timed-out' })
     const { rerender } = renderGroup([model])
     await waitFor(() => expect(generateModelThumbnail).toHaveBeenCalledOnce())
 
@@ -273,6 +278,17 @@ describe('ReplyAssetGroup', () => {
     await rerender({ assets: [{ ...model }] })
 
     expect(generateModelThumbnail).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not retry a model that cannot be rendered', async () => {
+    isAssetPreviewSupported.mockReturnValue(true)
+    const { rerender } = renderGroup([model])
+    await waitFor(() => expect(generateModelThumbnail).toHaveBeenCalledOnce())
+
+    await rerender({ assets: [{ ...model }] })
+    await rerender({ assets: [{ ...model }] })
+
+    expect(generateModelThumbnail).toHaveBeenCalledOnce()
   })
 
   it('aborts queued generation when unmounted', async () => {
@@ -297,12 +313,14 @@ describe('ReplyAssetGroup', () => {
       await userEvent.click(screen.getByRole('button', { name: 'mesh.glb' }))
       const dialog = showDialog.mock.calls.at(-1)?.[0]
       dialog.dialogComponentProps.onClose()
-      await Promise.resolve()
+      await vi.advanceTimersByTimeAsync(0)
       const callsBeforeUnmount = findServerPreviewUrl.mock.calls.length
+      expect(vi.getTimerCount()).toBe(1)
 
       unmount()
-      await vi.advanceTimersByTimeAsync(2_000)
+      expect(vi.getTimerCount()).toBe(0)
 
+      await vi.advanceTimersByTimeAsync(2_000)
       expect(findServerPreviewUrl).toHaveBeenCalledTimes(callsBeforeUnmount)
     } finally {
       vi.useRealTimers()
@@ -379,5 +397,6 @@ describe('ReplyAssetGroup', () => {
         expect.any(AbortSignal)
       )
     )
+    expect(generateModelThumbnail).toHaveBeenCalledTimes(13)
   })
 })

--- a/src/workbench/extensions/agent/components/agent/message/ReplyAssetGroup.test.ts
+++ b/src/workbench/extensions/agent/components/agent/message/ReplyAssetGroup.test.ts
@@ -250,14 +250,22 @@ describe('ReplyAssetGroup', () => {
     expect(generateModelThumbnail).not.toHaveBeenCalled()
   })
 
-  it('does not retry a model that failed to render', async () => {
+  it('leaves a model that failed to render as a placeholder', async () => {
     isAssetPreviewSupported.mockReturnValue(true)
     renderGroup([model])
-    await waitFor(() => expect(generateModelThumbnail).toHaveBeenCalledOnce())
+    await vi.waitFor(() =>
+      expect(generateModelThumbnail).toHaveBeenCalledOnce()
+    )
 
-    await new Promise((resolve) => setTimeout(resolve, 0))
+    vi.useFakeTimers()
+    try {
+      await vi.advanceTimersByTimeAsync(30_000)
+    } finally {
+      vi.useRealTimers()
+    }
+
     expect(generateModelThumbnail).toHaveBeenCalledOnce()
-    expect(screen.getByRole('button', { name: 'mesh.glb' })).toBeInTheDocument()
+    expect(screen.queryByRole('img', { name: 'mesh.glb' })).toBeNull()
   })
 
   it('aborts queued generation when unmounted', async () => {

--- a/src/workbench/extensions/agent/components/agent/message/ReplyAssetGroup.vue
+++ b/src/workbench/extensions/agent/components/agent/message/ReplyAssetGroup.vue
@@ -86,7 +86,7 @@ onBeforeUnmount(() => {
 /**
  * Drop the placeholder so the next watcher pass retries this model once.
  * Streaming deltas rebuild the asset list on every chunk, so an unbounded
- * retry would restart generation for an unpreviewable model indefinitely.
+ * retry would restart generation for a slow model on every chunk.
  */
 function allowThumbnailRetry(url: string): void {
   if (retriedThumbnails.has(url)) return
@@ -112,14 +112,15 @@ watch(
               return
             }
             if (!mounted) return
-            const generated = await generateModelThumbnail(
+            const result = await generateModelThumbnail(
               url,
               filename,
               thumbnailAbort.signal
             )
             if (!mounted) return
-            if (generated) modelThumbnails.value[url] = generated
-            else allowThumbnailRetry(url)
+            if (result.status === 'rendered')
+              modelThumbnails.value[url] = result.dataUrl
+            else if (result.status === 'timed-out') allowThumbnailRetry(url)
           })
           .catch((error) => {
             if (mounted) allowThumbnailRetry(url)

--- a/src/workbench/extensions/agent/components/agent/message/ReplyAssetGroup.vue
+++ b/src/workbench/extensions/agent/components/agent/message/ReplyAssetGroup.vue
@@ -84,14 +84,38 @@ onBeforeUnmount(() => {
 })
 
 /**
- * Drop the placeholder so the next watcher pass retries this model once.
- * Streaming deltas rebuild the asset list on every chunk, so an unbounded
- * retry would restart generation for a slow model on every chunk.
+ * Look up a server-rendered preview, falling back to an offscreen render.
+ * A render that only ran out of time is re-queued once: it lands behind
+ * every other pending model, so a slow model cannot starve the rest.
  */
-function allowThumbnailRetry(url: string): void {
-  if (retriedThumbnails.has(url)) return
-  retriedThumbnails.add(url)
-  delete modelThumbnails.value[url]
+function loadModelThumbnail(url: string, filename: string): void {
+  modelThumbnails.value[url] = ''
+  void findServerPreviewUrl(filename)
+    .then(async (preview) => {
+      if (!mounted) return
+      if (preview) {
+        modelThumbnails.value[url] = preview
+        return
+      }
+      const result = await generateModelThumbnail(
+        url,
+        filename,
+        thumbnailAbort.signal
+      )
+      if (!mounted) return
+      if (result.status === 'rendered') {
+        modelThumbnails.value[url] = result.dataUrl
+      } else if (result.status === 'timed-out' && !retriedThumbnails.has(url)) {
+        retriedThumbnails.add(url)
+        loadModelThumbnail(url, filename)
+      }
+    })
+    .catch((error) => {
+      if (mounted) delete modelThumbnails.value[url]
+      reportError(error, {
+        errorType: 'agent_reply_asset_preview_failure'
+      })
+    })
 }
 
 watch(
@@ -103,30 +127,7 @@ watch(
     if (!isAssetPreviewSupported()) return
     for (const { url, filename, kind } of lookups) {
       if (kind === '3D' && !(url in modelThumbnails.value)) {
-        modelThumbnails.value[url] = ''
-        void findServerPreviewUrl(filename)
-          .then(async (preview) => {
-            if (!mounted) return
-            if (preview) {
-              modelThumbnails.value[url] = preview
-              return
-            }
-            const result = await generateModelThumbnail(
-              url,
-              filename,
-              thumbnailAbort.signal
-            )
-            if (!mounted) return
-            if (result.status === 'rendered')
-              modelThumbnails.value[url] = result.dataUrl
-            else if (result.status === 'timed-out') allowThumbnailRetry(url)
-          })
-          .catch((error) => {
-            if (mounted) allowThumbnailRetry(url)
-            reportError(error, {
-              errorType: 'agent_reply_asset_preview_failure'
-            })
-          })
+        loadModelThumbnail(url, filename)
       }
       if (!(url in assetNames.value)) {
         assetNames.value[url] = ''

--- a/src/workbench/extensions/agent/components/agent/message/ReplyAssetGroup.vue
+++ b/src/workbench/extensions/agent/components/agent/message/ReplyAssetGroup.vue
@@ -73,7 +73,6 @@ const galleryIndex = ref(-1)
 const modelThumbnails = ref<Record<string, string>>({})
 const assetNames = ref<Record<string, string>>({})
 const refreshTimeouts = new Set<ReturnType<typeof setTimeout>>()
-const retriedThumbnails = new Set<string>()
 const thumbnailAbort = new AbortController()
 let mounted = true
 onBeforeUnmount(() => {
@@ -85,8 +84,9 @@ onBeforeUnmount(() => {
 
 /**
  * Look up a server-rendered preview, falling back to an offscreen render.
- * A render that only ran out of time is re-queued once: it lands behind
- * every other pending model, so a slow model cannot starve the rest.
+ * A model that does not render keeps its placeholder: a retry would race
+ * the abandoned transfer, which is not abortable. Reopening the 3D dialog
+ * still refreshes the tile through `refreshModelThumbnail`.
  */
 function loadModelThumbnail(url: string, filename: string): void {
   modelThumbnails.value[url] = ''
@@ -103,12 +103,8 @@ function loadModelThumbnail(url: string, filename: string): void {
         thumbnailAbort.signal
       )
       if (!mounted) return
-      if (result.status === 'rendered') {
+      if (result.status === 'rendered')
         modelThumbnails.value[url] = result.dataUrl
-      } else if (result.status === 'timed-out' && !retriedThumbnails.has(url)) {
-        retriedThumbnails.add(url)
-        loadModelThumbnail(url, filename)
-      }
     })
     .catch((error) => {
       if (mounted) delete modelThumbnails.value[url]

--- a/src/workbench/extensions/agent/components/agent/message/ReplyAssetGroup.vue
+++ b/src/workbench/extensions/agent/components/agent/message/ReplyAssetGroup.vue
@@ -73,12 +73,26 @@ const galleryIndex = ref(-1)
 const modelThumbnails = ref<Record<string, string>>({})
 const assetNames = ref<Record<string, string>>({})
 const refreshTimeouts = new Set<ReturnType<typeof setTimeout>>()
+const retriedThumbnails = new Set<string>()
+const thumbnailAbort = new AbortController()
 let mounted = true
 onBeforeUnmount(() => {
   mounted = false
+  thumbnailAbort.abort()
   for (const timeout of refreshTimeouts) clearTimeout(timeout)
   refreshTimeouts.clear()
 })
+
+/**
+ * Drop the placeholder so the next watcher pass retries this model once.
+ * Streaming deltas rebuild the asset list on every chunk, so an unbounded
+ * retry would restart generation for an unpreviewable model indefinitely.
+ */
+function allowThumbnailRetry(url: string): void {
+  if (retriedThumbnails.has(url)) return
+  retriedThumbnails.add(url)
+  delete modelThumbnails.value[url]
+}
 
 watch(
   () => [
@@ -98,13 +112,17 @@ watch(
               return
             }
             if (!mounted) return
-            const generated = await generateModelThumbnail(url, filename)
+            const generated = await generateModelThumbnail(
+              url,
+              filename,
+              thumbnailAbort.signal
+            )
             if (!mounted) return
             if (generated) modelThumbnails.value[url] = generated
-            else delete modelThumbnails.value[url]
+            else allowThumbnailRetry(url)
           })
           .catch((error) => {
-            if (mounted) delete modelThumbnails.value[url]
+            if (mounted) allowThumbnailRetry(url)
             reportError(error, {
               errorType: 'agent_reply_asset_preview_failure'
             })

--- a/src/workbench/extensions/agent/components/agent/message/ReplyAssetGroup.vue
+++ b/src/workbench/extensions/agent/components/agent/message/ReplyAssetGroup.vue
@@ -111,7 +111,6 @@ watch(
               modelThumbnails.value[url] = preview
               return
             }
-            if (!mounted) return
             const result = await generateModelThumbnail(
               url,
               filename,


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

Stacked on #16430. Targets `christian-byrne/w3pub-reply-assets` so the diff is only what this adds.

## Summary

All 13 review threads on #16430 were already resolved; I re-verified each against the head commit and then closed the one blocking item left — the failing `End-To-End Regression Coverage For Fixes` pre-merge check — with a real Playwright regression test. Reviewing the branch to write that test surfaced several defects introduced while addressing the earlier review, which this also fixes.

## Changes

- **What**:
  - **New e2e regression test** (`browser_tests/tests/agent/agentReplyAssets.spec.ts`). A 13-model agent reply must look up previews for exactly the twelve tiles on screen, and the thirteenth only after expanding. Reverting the `visibleVisual` filter makes it fail with `+ "mesh-12.glb"`, so it guards the regression rather than the implementation.
  - **`loadModel` no longer rejects on disposal.** `c2c3348` made a disposed `LoaderManager` reject with an `AbortError`, but none of its four callers distinguish that from a real failure — all four raise a toast. `Preview3d` calls `cleanup()` before re-initialising, so switching 3D previews before the first finished reliably produced "Failed to load 3D model", as did closing the agent's 3D dialog mid-download. A disposed load now returns, and still disposes the geometry and materials the abandoned load allocated.
  - **Offscreen renders stop toasting the viewer.** New `LoadModelOptions.silent` raises no toast and rejects with the underlying error instead, so thumbnail telemetry reports the real 404/parse failure rather than a downstream "No model loaded for thumbnail capture".
  - **Unmount cancels queued work.** `generateModelThumbnail` takes the caller's `AbortSignal`, skips a request whose caller aborted before its turn, and settles the race on abort so the module queue is released immediately instead of staying blocked for the rest of the deadline.
  - **The deadline no longer includes the code-split fetch.** The 10s timer started before `import('createLoad3d')`, so the first 3D asset in a session charged the three.js chunk download to the model's budget. Chunk and model now get a deadline each.
  - **Stale-load disposal is limited to a disposed manager.** A superseded load on a live manager may already be published as `originalModel`.
- **Dependencies**: none.

## Review Focus

**Two deliberate decisions, both reversals of an earlier round — worth a second opinion:**

1. **A timed-out thumbnail is not retried.** The Cursor thread asked for a retry so the tile is not permanently iconless. I implemented it twice and removed it: deferred to the next watcher pass it never fires (`MarkdownStream` caches its segments once `agent_message_done` lands, so the asset array stops changing), and re-queued immediately it starts a second download of a file whose first transfer is still running — the transfer is not abortable — making the retry likelier to time out too. The queue-wedging this was really about is fixed by the deadline itself; a tile that cannot render keeps its placeholder and still refreshes via `refreshModelThumbnail` when the 3D dialog closes.
2. **Genuine transfer cancellation is out of scope.** Giving up on a render tears down the viewer and releases the queue, but the underlying transfer and parse run to completion — `fetchModelData` takes no signal and the three.js loaders are not abortable. Making that real means threading an `AbortSignal` through every adapter; the docstrings now say abandoned rather than cancelled instead of overstating it. Worth a follow-up ticket.

**Known MINORs left in place**, from the review, deliberately not fixed to keep this diff reviewable:
- The two `agent_reply_asset_preview_failure` catch blocks in `ReplyAssetGroup.vue` are unreachable — `findServerPreviewUrl` swallows internally and `generateModelThumbnail` never rejects — so that slug will never fire. Fixing it properly means changing `findServerPreviewUrl`'s contract for all three of its callers.
- Collapsing an expanded reply does not cancel generation already started for the now-hidden assets; because the queue is module-global they can hold the slot. Any fix must `delete modelThumbnails.value[url]` on the bail-out path or the tile sticks on the placeholder.
- Thumbnail failures report per model with no classification, so a systematic failure (no WebGL, outputs aged out) emits one event per tile.
- `pushEvent` in the new spec duplicates `agentPanel.spec.ts`; the `/api/assets` mock body is untyped.

## Validation

`pnpm typecheck` clean; eslint and `oxfmt --check` clean; 1009 unit tests across `components/load3d/`, `extensions/core/load3d/` and `workbench/extensions/agent/components/`. Playwright against a local backend: agent suite 8/9 and `load3d/` 21/22, the two failures being pre-existing and reproducible on `origin/main` in this sandbox. Each new test was verified to fail against the un-fixed behaviour before being kept.

Screenshots below are the new e2e driving the real agent panel — a 13-model reply collapsed to twelve tiles, then expanded.


## Screenshots

![Agent reply with 13 3D models collapsed to a 12-tile grid with a Show more button](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/143ba1e55f22fa0bec2659bc32c5795ab74b9a0f93e600fa21015408d4c933e4/pr-images/1788258021968-43d76445-3724-4615-ba3a-d9b784149794.png)

![The same agent reply after clicking Show more, showing all 13 model tiles](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/143ba1e55f22fa0bec2659bc32c5795ab74b9a0f93e600fa21015408d4c933e4/pr-images/1788258022321-a38ddc1e-5c7c-4e4d-b02d-dbaea4247439.png)