### PR TITLE
[cjx-6]

### DIFF
--- a/src/workbench/extensions/agent/crdt/followerGate.test.ts
+++ b/src/workbench/extensions/agent/crdt/followerGate.test.ts
@@ -1,0 +1,158 @@
+/**
+ * R1a runtime-toggle gate. The behaviour under test: hosted predeploy bundles
+ * are built with `VITE_AGENT_CRDT_FOLLOWER` unset, so the follower must be
+ * enableable per session via `?agentCrdtFollower=1` / localStorage — and an
+ * explicit URL param must win over everything, in both directions.
+ */
+import { describe, expect, it } from 'vitest'
+
+import {
+  FOLLOWER_QUERY_PARAM,
+  FOLLOWER_STORAGE_KEY,
+  resolveFollowerEnabled
+} from './followerGate'
+
+class FakeStorage {
+  private readonly map = new Map<string, string>()
+
+  getItem(key: string): string | null {
+    return this.map.get(key) ?? null
+  }
+  setItem(key: string, value: string): void {
+    this.map.set(key, value)
+  }
+  removeItem(key: string): void {
+    this.map.delete(key)
+  }
+}
+
+class DeniedStorage {
+  getItem(): string | null {
+    throw new DOMException('denied', 'SecurityError')
+  }
+  setItem(): void {
+    throw new DOMException('denied', 'SecurityError')
+  }
+  removeItem(): void {
+    throw new DOMException('denied', 'SecurityError')
+  }
+}
+
+const on = `?${FOLLOWER_QUERY_PARAM}=1`
+const off = `?${FOLLOWER_QUERY_PARAM}=0`
+
+describe('resolveFollowerEnabled', () => {
+  it('stays disabled with no flag, no param, no persisted opt-in', () => {
+    expect(
+      resolveFollowerEnabled({
+        buildFlag: undefined,
+        search: '',
+        storage: new FakeStorage()
+      })
+    ).toBe(false)
+  })
+
+  it('build-time flag alone enables (existing dev:cloud:crdt path)', () => {
+    expect(
+      resolveFollowerEnabled({
+        buildFlag: 'true',
+        search: '',
+        storage: new FakeStorage()
+      })
+    ).toBe(true)
+  })
+
+  it('only the exact string "true" counts as a build flag (the `=1` trap)', () => {
+    expect(
+      resolveFollowerEnabled({
+        buildFlag: '1',
+        search: '',
+        storage: new FakeStorage()
+      })
+    ).toBe(false)
+  })
+
+  it('?agentCrdtFollower=1 enables an inert (env-off) bundle and persists', () => {
+    const storage = new FakeStorage()
+    expect(
+      resolveFollowerEnabled({ buildFlag: undefined, search: on, storage })
+    ).toBe(true)
+    expect(storage.getItem(FOLLOWER_STORAGE_KEY)).toBe('true')
+    // Next navigation, no param: the persisted opt-in carries the session.
+    expect(
+      resolveFollowerEnabled({ buildFlag: undefined, search: '', storage })
+    ).toBe(true)
+  })
+
+  it('accepts =true as well as =1', () => {
+    expect(
+      resolveFollowerEnabled({
+        buildFlag: undefined,
+        search: `?${FOLLOWER_QUERY_PARAM}=true`,
+        storage: new FakeStorage()
+      })
+    ).toBe(true)
+  })
+
+  it('?agentCrdtFollower=0 disables even a flag-on build and clears the opt-in', () => {
+    const storage = new FakeStorage()
+    storage.setItem(FOLLOWER_STORAGE_KEY, 'true')
+    expect(
+      resolveFollowerEnabled({ buildFlag: 'true', search: off, storage })
+    ).toBe(false)
+    expect(storage.getItem(FOLLOWER_STORAGE_KEY)).toBeNull()
+    // Without the param the build flag reasserts itself — =0 cleared only the
+    // runtime opt-in, it is not a durable veto of the env.
+    expect(
+      resolveFollowerEnabled({ buildFlag: 'true', search: '', storage })
+    ).toBe(true)
+  })
+
+  it('an unrecognized param value falls through to flag/storage', () => {
+    expect(
+      resolveFollowerEnabled({
+        buildFlag: 'true',
+        search: `?${FOLLOWER_QUERY_PARAM}=banana`,
+        storage: new FakeStorage()
+      })
+    ).toBe(true)
+    expect(
+      resolveFollowerEnabled({
+        buildFlag: undefined,
+        search: `?${FOLLOWER_QUERY_PARAM}=banana`,
+        storage: new FakeStorage()
+      })
+    ).toBe(false)
+  })
+
+  it('degrades without throwing when storage access is denied', () => {
+    const storage = new DeniedStorage()
+    // Param still enables the current page load; persistence is just lost.
+    expect(
+      resolveFollowerEnabled({ buildFlag: undefined, search: on, storage })
+    ).toBe(true)
+    expect(
+      resolveFollowerEnabled({ buildFlag: undefined, search: off, storage })
+    ).toBe(false)
+    expect(
+      resolveFollowerEnabled({ buildFlag: 'true', search: '', storage })
+    ).toBe(true)
+  })
+
+  it('handles a null storage (fully unavailable) the same way', () => {
+    expect(
+      resolveFollowerEnabled({
+        buildFlag: undefined,
+        search: on,
+        storage: null
+      })
+    ).toBe(true)
+    expect(
+      resolveFollowerEnabled({
+        buildFlag: undefined,
+        search: '',
+        storage: null
+      })
+    ).toBe(false)
+  })
+})

--- a/src/workbench/extensions/agent/crdt/followerGate.test.ts
+++ b/src/workbench/extensions/agent/crdt/followerGate.test.ts
@@ -4,13 +4,19 @@
  * enableable per session via `?agentCrdtFollower=1` / localStorage — and an
  * explicit URL param must win over everything, in both directions.
  */
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
+
+import { reportError } from '@/platform/telemetry/reportError'
 
 import {
   FOLLOWER_QUERY_PARAM,
   FOLLOWER_STORAGE_KEY,
   resolveFollowerEnabled
 } from './followerGate'
+
+vi.mock('@/platform/telemetry/reportError', () => ({
+  reportError: vi.fn()
+}))
 
 class FakeStorage {
   private readonly map = new Map<string, string>()
@@ -137,6 +143,10 @@ describe('resolveFollowerEnabled', () => {
     expect(
       resolveFollowerEnabled({ buildFlag: 'true', search: '', storage })
     ).toBe(true)
+    expect(reportError).toHaveBeenCalledTimes(3)
+    expect(reportError).toHaveBeenCalledWith(expect.any(DOMException), {
+      errorType: 'agent_crdt_follower_storage_access_failed'
+    })
   })
 
   it('handles a null storage (fully unavailable) the same way', () => {

--- a/src/workbench/extensions/agent/crdt/followerGate.test.ts
+++ b/src/workbench/extensions/agent/crdt/followerGate.test.ts
@@ -144,7 +144,13 @@ describe('resolveFollowerEnabled', () => {
       resolveFollowerEnabled({ buildFlag: 'true', search: '', storage })
     ).toBe(true)
     expect(reportError).toHaveBeenCalledTimes(3)
-    expect(reportError).toHaveBeenCalledWith(expect.any(DOMException), {
+    expect(reportError).toHaveBeenNthCalledWith(1, expect.any(DOMException), {
+      errorType: 'agent_crdt_follower_storage_access_failed'
+    })
+    expect(reportError).toHaveBeenNthCalledWith(2, expect.any(DOMException), {
+      errorType: 'agent_crdt_follower_storage_access_failed'
+    })
+    expect(reportError).toHaveBeenNthCalledWith(3, expect.any(DOMException), {
       errorType: 'agent_crdt_follower_storage_access_failed'
     })
   })

--- a/src/workbench/extensions/agent/crdt/followerGate.ts
+++ b/src/workbench/extensions/agent/crdt/followerGate.ts
@@ -21,6 +21,8 @@
  * iframe) the gate degrades to param/flag behaviour instead of throwing.
  */
 
+import { reportError } from '@/platform/telemetry/reportError'
+
 export const FOLLOWER_STORAGE_KEY = 'Comfy.Agent.CrdtFollower'
 export const FOLLOWER_QUERY_PARAM = 'agentCrdtFollower'
 
@@ -53,7 +55,10 @@ export function resolveFollowerEnabled(input: FollowerGateInput): boolean {
 function tryGet(storage: FollowerGateInput['storage']): string | null {
   try {
     return storage?.getItem(FOLLOWER_STORAGE_KEY) ?? null
-  } catch {
+  } catch (error) {
+    reportError(error, {
+      errorType: 'agent_crdt_follower_storage_access_failed'
+    })
     return null
   }
 }
@@ -61,7 +66,10 @@ function tryGet(storage: FollowerGateInput['storage']): string | null {
 function trySet(storage: FollowerGateInput['storage'], value: string): void {
   try {
     storage?.setItem(FOLLOWER_STORAGE_KEY, value)
-  } catch {
+  } catch (error) {
+    reportError(error, {
+      errorType: 'agent_crdt_follower_storage_access_failed'
+    })
     // Storage denied: the session still enables via the param; it just will
     // not persist across navigations.
   }
@@ -70,7 +78,10 @@ function trySet(storage: FollowerGateInput['storage'], value: string): void {
 function tryRemove(storage: FollowerGateInput['storage']): void {
   try {
     storage?.removeItem(FOLLOWER_STORAGE_KEY)
-  } catch {
+  } catch (error) {
+    reportError(error, {
+      errorType: 'agent_crdt_follower_storage_access_failed'
+    })
     // Storage denied: nothing was persisted, so nothing to clear.
   }
 }

--- a/src/workbench/extensions/agent/crdt/followerGate.ts
+++ b/src/workbench/extensions/agent/crdt/followerGate.ts
@@ -1,0 +1,76 @@
+/**
+ * Runtime gate for the CRDT follower (R1a).
+ *
+ * The follower is gated: with no URL param and no persisted opt-in it falls
+ * back to the build-time env `VITE_AGENT_CRDT_FOLLOWER === 'true'`, and hosted
+ * predeploy builds inject only the Stripe key, so a hosted preview bundle
+ * would ship with the follower permanently inert. On this chain the gate
+ * arrived with the follower itself, so there was never an env-only era to
+ * recover from, and there is no `dev:cloud:crdt` script here.
+ *
+ * This gate adds a per-session runtime opt-in so ANY built bundle can enable
+ * the follower without a rebuild:
+ *
+ *   `?agentCrdtFollower=1`  enable now and persist for this browser
+ *   `?agentCrdtFollower=0`  disable now and clear the persisted opt-in
+ *   (no param)              persisted opt-in, else the build-time flag
+ *
+ * An explicit URL param always wins, in both directions, so a dev build with
+ * the env baked on can still be silenced for one session. localStorage access
+ * is wrapped: in a context that denies storage (private mode, sandboxed
+ * iframe) the gate degrades to param/flag behaviour instead of throwing.
+ */
+
+export const FOLLOWER_STORAGE_KEY = 'Comfy.Agent.CrdtFollower'
+export const FOLLOWER_QUERY_PARAM = 'agentCrdtFollower'
+
+export interface FollowerGateInput {
+  /** `import.meta.env.VITE_AGENT_CRDT_FOLLOWER` (build-time). */
+  buildFlag: string | undefined
+  /** `window.location.search`, including the leading `?` or empty. */
+  search: string
+  /** `window.localStorage`, or null when storage is unavailable. */
+  storage: Pick<Storage, 'getItem' | 'setItem' | 'removeItem'> | null
+}
+
+export function resolveFollowerEnabled(input: FollowerGateInput): boolean {
+  const param = new URLSearchParams(input.search).get(FOLLOWER_QUERY_PARAM)
+
+  if (param === '1' || param === 'true') {
+    trySet(input.storage, 'true')
+    return true
+  }
+  if (param === '0' || param === 'false') {
+    tryRemove(input.storage)
+    return false
+  }
+
+  if (tryGet(input.storage) === 'true') return true
+
+  return input.buildFlag === 'true'
+}
+
+function tryGet(storage: FollowerGateInput['storage']): string | null {
+  try {
+    return storage?.getItem(FOLLOWER_STORAGE_KEY) ?? null
+  } catch {
+    return null
+  }
+}
+
+function trySet(storage: FollowerGateInput['storage'], value: string): void {
+  try {
+    storage?.setItem(FOLLOWER_STORAGE_KEY, value)
+  } catch {
+    // Storage denied: the session still enables via the param; it just will
+    // not persist across navigations.
+  }
+}
+
+function tryRemove(storage: FollowerGateInput['storage']): void {
+  try {
+    storage?.removeItem(FOLLOWER_STORAGE_KEY)
+  } catch {
+    // Storage denied: nothing was persisted, so nothing to clear.
+  }
+}


### PR DESCRIPTION
Extracts the frozen #16448 CRDT follower runtime-gate contract without changing the follower, ECS adapter, or human-op sender seams.

- [KEEP row: `followerGate.test.ts`](https://github.com/christian-byrne/in-app-agent-program/blob/170beabe5ff3daebd39bf02cf7f68e25914185c2/program/cj16448-triage.md#L114)
- [KEEP row: `followerGate.ts`](https://github.com/christian-byrne/in-app-agent-program/blob/170beabe5ff3daebd39bf02cf7f68e25914185c2/program/cj16448-triage.md#L115)

<details><summary>Full context for agent readers</summary>

The two extracted files are byte-identical to frozen #16448 head `278338e6a0`. Original authorship is preserved for Nathaniel Parson Koroso.

Verification on Node 25:
- all 17 `src/workbench/extensions/agent/crdt` test files: 169 tests passed
- `pnpm typecheck`: passed
- `pnpm lint`: passed with existing repository warnings only
- `pnpm knip`: passed
- Oxfmt check: passed

The diff leaves `useAgentCrdtFollower.ts`, `ecsFollowerAdapter.ts`, and `opSender.ts` unchanged.

</details>

authored-by:agent