### PR TITLE
[cjx-10] fix: bracket direct graph imports with load hooks

### DIFF
--- a/src/scripts/app.test.ts
+++ b/src/scripts/app.test.ts
@@ -378,13 +378,45 @@ describe('ComfyApp', () => {
       )
     })
 
-    it('never suppresses the workflow reset for an API JSON import', async () => {
+    it('notifies extensions once on each side of a graph load, in order', async () => {
       app.canvasElRef.value = document.createElement('canvas')
       Reflect.set(app, 'rootGraphInternal', new LGraph())
 
-      await app.loadApiJson({}, 'empty.json').catch(() => undefined)
+      await app.loadGraphData(createWorkflowGraphData(), false)
+
+      const loadHookCalls =
+        mockExtensionService.invokeExtensionsAsync.mock.calls
+          .map(([hook]) => hook)
+          .filter((hook) =>
+            [
+              'beforeLoadGraph',
+              'beforeConfigureGraph',
+              'afterConfigureGraph',
+              'afterLoadGraph'
+            ].includes(hook)
+          )
+      expect(loadHookCalls).toEqual([
+        'beforeLoadGraph',
+        'beforeConfigureGraph',
+        'afterConfigureGraph',
+        'afterLoadGraph'
+      ])
+    })
+
+    it('brackets an API JSON import with graph-load hooks', async () => {
+      app.canvasElRef.value = document.createElement('canvas')
+      const graph = new LGraph()
+      Reflect.set(app, 'rootGraphInternal', graph)
+      Reflect.set(singletonApp, 'rootGraphInternal', graph)
+
+      await app.loadApiJson({}, 'empty.json')
 
       expect(mockWorkflowService.beforeLoadNewGraph).toHaveBeenCalledWith(false)
+      expect(
+        mockExtensionService.invokeExtensionsAsync.mock.calls.map(
+          ([hook]) => hook
+        )
+      ).toEqual(['beforeLoadGraph', 'afterConfigureGraph', 'afterLoadGraph'])
     })
   })
 
@@ -2308,7 +2340,7 @@ describe('ComfyApp', () => {
       vi.mocked(getWorkflowDataFromFile).mockResolvedValue({ parameters })
       mockImportA1111.mockImplementation(
         async (_graph, _parameters, beforeGraphClear) => {
-          beforeGraphClear?.()
+          await beforeGraphClear?.()
           return 'imported'
         }
       )
@@ -2334,10 +2366,20 @@ describe('ComfyApp', () => {
       expect(
         mockWorkflowService.beforeLoadNewGraph.mock.invocationCallOrder[0]
       ).toBeLessThan(vi.mocked(mockCanvas.setGraph).mock.invocationCallOrder[0])
+      expect(
+        mockExtensionService.invokeExtensionsAsync.mock.calls.map(
+          ([hook]) => hook
+        )
+      ).toEqual(['beforeLoadGraph', 'afterConfigureGraph'])
       expect(settled).toBe(false)
 
       resolveAfterLoad?.()
       await handleFile
+      expect(
+        mockExtensionService.invokeExtensionsAsync.mock.calls.map(
+          ([hook]) => hook
+        )
+      ).toEqual(['beforeLoadGraph', 'afterConfigureGraph', 'afterLoadGraph'])
       expect(settled).toBe(true)
     })
   })

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -2136,6 +2136,8 @@ export class ComfyApp {
           )
         }
       }
+      // Intentionally no beforeConfigureGraph: A1111 has no mutable
+      // workflow JSON before graph construction, so there is no payload.
       await useExtensionService().invokeExtensionsAsync(
         'afterConfigureGraph',
         []
@@ -2424,6 +2426,8 @@ export class ComfyApp {
     for (const id of ids) processNodeInputs(id)
     app.rootGraph.arrange()
 
+    // Intentionally no beforeConfigureGraph: API JSON builds nodes directly
+    // and never passes a ComfyWorkflowJSON through the configure stage.
     await useExtensionService().invokeExtensionsAsync(
       'afterConfigureGraph',
       missingNodeTypes

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -2099,15 +2099,20 @@ export class ComfyApp {
 
     // Use parameters strictly as the final fallback
     if (parameters && typeof parameters === 'string') {
-      const outcome = await importA1111(this.rootGraph, parameters, () => {
-        try {
-          // false: final destination; no later load republishes the hash.
-          useWorkflowService().beforeLoadNewGraph(false)
-        } finally {
-          useMissingNodesErrorStore().setMissingNodeTypes([])
+      const outcome = await importA1111(
+        this.rootGraph,
+        parameters,
+        async () => {
+          try {
+            // false: final destination; no later load republishes the hash.
+            useWorkflowService().beforeLoadNewGraph(false)
+            await useExtensionService().invokeExtensionsAsync('beforeLoadGraph')
+          } finally {
+            useMissingNodesErrorStore().setMissingNodeTypes([])
+          }
+          this.canvas.setGraph(this.rootGraph)
         }
-        this.canvas.setGraph(this.rootGraph)
-      })
+      )
       switch (outcome) {
         case 'core-nodes-unavailable':
           useToastStore().addAlert(t('toastMessages.a1111CoreNodesUnavailable'))
@@ -2131,10 +2136,15 @@ export class ComfyApp {
           )
         }
       }
+      await useExtensionService().invokeExtensionsAsync(
+        'afterConfigureGraph',
+        []
+      )
       await useWorkflowService().afterLoadNewGraph(
         fileName,
         this.rootGraph.serialize() as unknown as ComfyWorkflowJSON
       )
+      await useExtensionService().invokeExtensionsAsync('afterLoadGraph')
       return
     }
 
@@ -2270,6 +2280,7 @@ export class ComfyApp {
   ): Promise<void> {
     // false: no workflow load follows to republish the hash.
     useWorkflowService().beforeLoadNewGraph(false)
+    await useExtensionService().invokeExtensionsAsync('beforeLoadGraph')
     this.canvas.setGraph(this.rootGraph)
     this.clean()
 
@@ -2413,10 +2424,15 @@ export class ComfyApp {
     for (const id of ids) processNodeInputs(id)
     app.rootGraph.arrange()
 
+    await useExtensionService().invokeExtensionsAsync(
+      'afterConfigureGraph',
+      missingNodeTypes
+    )
     await useWorkflowService().afterLoadNewGraph(
       fileName,
       this.rootGraph.serialize() as unknown as ComfyWorkflowJSON
     )
+    await useExtensionService().invokeExtensionsAsync('afterLoadGraph')
     if (missingNodeTypes.length) {
       this.showMissingNodesError(missingNodeTypes, options)
     }

--- a/src/scripts/pnginfo.test.ts
+++ b/src/scripts/pnginfo.test.ts
@@ -318,6 +318,28 @@ describe('importA1111', () => {
     )
   })
 
+  it('awaits the pre-clear hook before mutating the graph', async () => {
+    const graph = new LGraph()
+    const clear = vi.spyOn(graph, 'clear')
+    vi.mocked(api.getEmbeddings).mockResolvedValue([])
+    mockAvailableCoreNodes(graph)
+    let release: (() => void) | undefined
+    const beforeGraphClear = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          release = resolve
+        })
+    )
+
+    const imported = importA1111(graph, parameters, beforeGraphClear)
+    await vi.waitFor(() => expect(beforeGraphClear).toHaveBeenCalledOnce())
+    expect(clear).not.toHaveBeenCalled()
+
+    release?.()
+    await expect(imported).resolves.toBe('imported')
+    expect(clear).toHaveBeenCalledOnce()
+  })
+
   it.each([
     ['with a negative prompt', parameters, 'negative'],
     ['without a negative prompt', parametersWithoutNegativePrompt, '']

--- a/src/scripts/pnginfo.ts
+++ b/src/scripts/pnginfo.ts
@@ -203,7 +203,7 @@ export type A1111ImportOutcome =
 export async function importA1111(
   graph: LGraph,
   parameters: string,
-  beforeGraphClear?: () => void
+  beforeGraphClear?: () => void | Promise<void>
 ): Promise<A1111ImportOutcome> {
   const normalizedParameters = normalizeA1111Parameters(parameters)
   const p = normalizedParameters.lastIndexOf('\nSteps:')
@@ -362,7 +362,7 @@ export async function importA1111(
           return { embeddings: [], embeddingsLoaded: false }
         })
 
-      beforeGraphClear?.()
+      await beforeGraphClear?.()
       graph.clear()
       graph.add(ckptNode)
       graph.add(clipSkipNode)


### PR DESCRIPTION
## Summary

Bracket direct API JSON and A1111 graph imports with the established extension load lifecycle so graph-sensitive extensions receive the same boundaries as workflow JSON loads.

## Changes

- **What**: Invoke `beforeLoadGraph`, `afterConfigureGraph`, and `afterLoadGraph` around successful direct imports; await the A1111 pre-clear callback before graph mutation.
- **Breaking**: None.
- **Dependencies**: None.
- **Triage receipt**: Covers [`src/scripts/app.test.ts` and `src/scripts/app.ts` KEEP rows](https://github.com/christian-byrne/in-app-agent-program/blob/main/program/cj16448-triage.md#L71-L72). Directly coupled `pnginfo.ts` and its test carry the awaited callback contract.

## Review Focus

- API JSON reports its collected missing-node list to `afterConfigureGraph`.
- A1111 has no mutable workflow JSON before graph construction, so it emits no synthetic `beforeConfigureGraph` payload.
- Selection-mode guards from the frozen branch are intentionally excluded.

## Verification

- `pnpm test:unit src/scripts/app.test.ts src/scripts/pnginfo.test.ts` (98 passed, 1 skipped)
- `pnpm typecheck`
- `pnpm lint` (passes with existing warnings)
- `pnpm knip`

<!-- authored-by:agent -->