### PR TITLE
test(agent): pin transcript normalization edge cases

### DIFF
--- a/src/workbench/extensions/agent/services/agent/agentTranscript.test.ts
+++ b/src/workbench/extensions/agent/services/agent/agentTranscript.test.ts
@@ -76,4 +76,17 @@ describe('normalizeAgentTranscript', () => {
     expect(transcript.assistantTurnIds).toEqual(new Set())
     expect(transcript.rowIds).toEqual(new Set(['row-1', 'row-2']))
   })
+
+  it('concatenates assistant rows in sequence order within a turn', () => {
+    const transcript = normalizeAgentTranscript([
+      row(3, 'assistant', 'turn-a', 'Second', 'row-3'),
+      row(1, 'user', 'turn-a', 'Prompt', 'row-1'),
+      row(2, 'assistant', 'turn-a', 'First', 'row-2')
+    ])
+
+    expect(transcript.messages[0].parts).toEqual([
+      { type: 'text', text: 'First', state: 'done' },
+      { type: 'text', text: 'Second', state: 'done' }
+    ])
+  })
 })

--- a/src/workbench/extensions/agent/services/agent/agentTranscript.ts
+++ b/src/workbench/extensions/agent/services/agent/agentTranscript.ts
@@ -3,6 +3,7 @@ import type { AssistantMessage } from './agentMessageParts'
 import { createAssistantMessage } from './agentMessageParts'
 
 export interface NormalizedAgentTranscript {
+  /** Includes user-only placeholder messages omitted from assistantTurnIds. */
   messages: AssistantMessage[]
   userTexts: Map<TurnId, string>
   rowIds: Set<string>

--- a/src/workbench/extensions/agent/services/agent/agentTranscript.ts
+++ b/src/workbench/extensions/agent/services/agent/agentTranscript.ts
@@ -3,10 +3,11 @@ import type { AssistantMessage } from './agentMessageParts'
 import { createAssistantMessage } from './agentMessageParts'
 
 export interface NormalizedAgentTranscript {
-  /** Includes user-only placeholder messages omitted from assistantTurnIds. */
+  /** Includes placeholders for turns without assistant text. */
   messages: AssistantMessage[]
   userTexts: Map<TurnId, string>
   rowIds: Set<string>
+  /** Tracks turns with assistant rows, including rows that produce no parts. */
   assistantTurnIds: Set<TurnId>
 }
 


### PR DESCRIPTION
## Summary

- document that placeholders can represent any turn without assistant text
- cover multiple assistant rows being concatenated in sequence order
- preserve placeholder and non-string-content edge-case assertions

## Validation

- `NODE_OPTIONS="--no-experimental-webstorage" pnpm test:unit src/workbench/extensions/agent/services/agent/agentTranscript.test.ts src/workbench/extensions/agent/stores/agent/agentConversationStore.test.ts` (27/27)
- `pnpm typecheck`
- scoped ESLint and oxfmt
- pre-push Knip

Rebased onto current `main` after #16489 merged.

Addresses https://github.com/Comfy-Org/ComfyUI_frontend/pull/16489#discussion_r3903091790 and https://github.com/Comfy-Org/ComfyUI_frontend/pull/16489#discussion_r3903091801.
