### PR TITLE
fix(billing): restore legacy subscription quote display

### DIFF
--- a/src/platform/workspace/components/SubscriptionAddPaymentPreviewWorkspace.test.ts
+++ b/src/platform/workspace/components/SubscriptionAddPaymentPreviewWorkspace.test.ts
@@ -46,7 +46,10 @@ function previewFixture(
 
 vi.mock('vue-i18n', () => ({
   useI18n: () => ({
-    t: (key: string) => key,
+    t: (key: string, values?: Record<string, unknown>) =>
+      key === 'subscription.preview.renewsAt'
+        ? `Renews at ${values?.amount} on ${values?.date}`
+        : key,
     n: (value: number) => value.toLocaleString('en-US'),
     locale: { value: 'en' }
   })
@@ -238,6 +241,26 @@ describe('SubscriptionAddPaymentPreviewWorkspace', () => {
     expect(
       screen.queryByText('subscription.preview.eachYearCreditsRefill')
     ).toBeNull()
+  })
+
+  it('renders legacy preview pricing when embedded checkout is disabled', () => {
+    const legacyPreview = previewFixture('MONTHLY', 3500)
+    delete legacyPreview.amount_due_cents
+    delete legacyPreview.currency
+    delete legacyPreview.renewal_amount_cents
+    delete legacyPreview.renewal_at
+
+    render(SubscriptionAddPaymentPreviewWorkspace, {
+      props: {
+        tierKey: 'creator',
+        previewData: legacyPreview,
+        embeddedCheckoutEnabled: false
+      },
+      global: globalOptions
+    })
+
+    expect(screen.getByText('$35.00')).toBeTruthy()
+    expect(screen.getByText('Renews at $35.00 on Jun 19, 2027')).toBeTruthy()
   })
 
   it('shows the annual total for a yearly team plan', () => {

--- a/src/platform/workspace/components/SubscriptionAddPaymentPreviewWorkspace.vue
+++ b/src/platform/workspace/components/SubscriptionAddPaymentPreviewWorkspace.vue
@@ -559,17 +559,40 @@ const creditsRefillLabelKey = computed(() =>
     : 'subscription.preview.eachMonthCreditsRefill'
 )
 
-const totalDueToday = computed(() =>
-  previewData?.amount_due_cents === undefined
+const totalDueToday = computed(() => {
+  if (!previewData) return ''
+  if (!embeddedCheckoutEnabled) {
+    return formatQuoteMoney(previewData.cost_today_cents, 'usd', locale.value)
+  }
+  return previewData.amount_due_cents === undefined
     ? ''
     : formatQuoteMoney(
         previewData.amount_due_cents,
         previewData.currency,
         locale.value
       )
-)
+})
 
 const renewalTerms = computed(() => {
+  if (!embeddedCheckoutEnabled) {
+    if (!previewData?.new_plan.period_end) return ''
+    return t('subscription.preview.renewsAt', {
+      amount: formatQuoteMoney(
+        previewData.cost_next_period_cents,
+        'usd',
+        locale.value
+      ),
+      date: new Date(previewData.new_plan.period_end).toLocaleDateString(
+        undefined,
+        {
+          month: 'short',
+          day: 'numeric',
+          year: 'numeric',
+          timeZone: 'UTC'
+        }
+      )
+    })
+  }
   if (
     previewData?.renewal_amount_cents === undefined ||
     !previewData.renewal_at

--- a/src/platform/workspace/components/SubscriptionTransitionPreviewWorkspace.test.ts
+++ b/src/platform/workspace/components/SubscriptionTransitionPreviewWorkspace.test.ts
@@ -22,7 +22,13 @@ vi.mock('@/composables/billing/useBillingContext', () => ({
 const i18n = createI18n({
   legacy: false,
   locale: 'en',
-  messages: { en: {} }
+  messages: {
+    en: {
+      subscription: {
+        preview: { renewsAt: 'Renews at {amount} on {date}' }
+      }
+    }
+  }
 })
 
 const globalOptions = {
@@ -128,6 +134,33 @@ describe('SubscriptionTransitionPreviewWorkspace', () => {
     ).toBeTruthy()
     expect(screen.getByText('21,100')).toBeTruthy()
     expect(screen.getByText('$82.50')).toBeTruthy()
+  })
+
+  it('renders legacy preview pricing when embedded checkout is disabled', () => {
+    const legacyPreview = preview({
+      cost_today_cents: 8250,
+      cost_next_period_cents: 10_000,
+      current_plan: plan('CREATOR', 'MONTHLY', 3500),
+      new_plan: plan('PRO', 'MONTHLY', 10_000)
+    })
+    delete legacyPreview.amount_due_cents
+    delete legacyPreview.currency
+    delete legacyPreview.renewal_amount_cents
+    delete legacyPreview.renewal_at
+
+    render(SubscriptionTransitionPreviewWorkspace, {
+      props: {
+        previewData: legacyPreview,
+        embeddedCheckoutEnabled: false
+      },
+      global: globalOptions
+    })
+
+    expect(screen.getByText('$82.50')).toBeTruthy()
+    expect(screen.getByText('Renews at $100.00 on Jun 28, 2027')).toBeTruthy()
+    expect(
+      screen.queryByText('subscription.preview.quoteUnavailable')
+    ).toBeNull()
   })
 
   it('opens verification only from its button without exposing the URL', async () => {

--- a/src/platform/workspace/components/SubscriptionTransitionPreviewWorkspace.vue
+++ b/src/platform/workspace/components/SubscriptionTransitionPreviewWorkspace.vue
@@ -648,16 +648,29 @@ const confirmCta = computed(() => {
     amount: chargeDisplay.value
   })
 })
-const exactAmountDue = computed(() =>
-  previewData.amount_due_cents === undefined
+const exactAmountDue = computed(() => {
+  if (!embeddedCheckoutEnabled) {
+    return formatQuoteMoney(previewData.cost_today_cents, 'usd', locale.value)
+  }
+  return previewData.amount_due_cents === undefined
     ? t('subscription.preview.quoteUnavailable')
     : formatQuoteMoney(
         previewData.amount_due_cents,
         previewData.currency,
         locale.value
       )
-)
+})
 const renewalTerms = computed(() => {
+  if (!embeddedCheckoutEnabled) {
+    return t('subscription.preview.renewsAt', {
+      amount: formatQuoteMoney(
+        previewData.cost_next_period_cents,
+        'usd',
+        locale.value
+      ),
+      date: nextPaymentDate.value
+    })
+  }
   if (
     previewData.renewal_amount_cents === undefined ||
     !previewData.renewal_at


### PR DESCRIPTION
## Summary

Legacy (non-embedded-checkout) subscription previews lost their quote: the new-subscription step rendered a blank total and a blank renewal line, and the plan-change step rendered "Unavailable" in both slots. Read the legacy quote fields the server always sends on that path.

## Changes

- **What**: `SubscriptionAddPaymentPreviewWorkspace` and `SubscriptionTransitionPreviewWorkspace` read `cost_today_cents`, `cost_next_period_cents` and `new_plan.period_end` when `embeddedCheckoutEnabled` is false, formatting the renewal line through the existing `subscription.preview.renewsAt` message. One regression test per component.

### Root cause

#15941 ("consolidate embedded checkout frontend") rewrote both quote computeds to read only the embedded-checkout field family:

```ts
const totalDueToday = computed(() =>
  previewData?.amount_due_cents === undefined ? '' : formatQuoteMoney(...)
)
```

Those fields are optional in the generated ingest contract and absent from legacy previews, while the legacy fields are required:

| field | contract | legacy preview |
| --- | --- | --- |
| `amount_due_cents`, `currency` | optional | absent |
| `renewal_amount_cents`, `renewal_at` | optional | absent |
| `cost_today_cents`, `cost_next_period_cents` | required | present |

`packages/ingest-types` documents the same split for the sibling field — `payment_method_configuration_id` is "Present on every successful preview while embedded checkout is enabled and absent from legacy previews."

With the flag off, both computeds hit `undefined` and short-circuited to `''`, so the confirm step showed no price and no renewal terms.

## Review Focus

The legacy branch keys off the `embeddedCheckoutEnabled` prop (a client flag) rather than response-field presence. Presence is the server-authoritative signal per the contract, so if the flag and the payload ever disagree — staged rollout, stale flag, older API — the blank quote returns. Guarding on `amount_due_cents !== undefined` instead would make the fallback depend only on what the server actually sent. Happy to switch it here if preferred.

`cloud/1.52` carries the same defect (the regression reached it as `fd55ffbeb`), so this wants the `backport cloud/1.52` label once merged.

Regression coverage: the two new unit tests fail against the pre-fix components (2 failed / 25 passed) and pass with the fix (27 passed). No E2E added — this is display formatting behind an existing flag.

## Screenshots

Captured in the running cloud app (Playwright driving `DISTRIBUTION=cloud` Vite), not Storybook. The ingest billing endpoints are mocked to return a legacy preview — `cost_today_cents` / `cost_next_period_cents` / `new_plan.period_end` present, `amount_due_cents` / `currency` / `renewal_amount_cents` / `renewal_at` absent — with `embeddedCheckoutEnabled` at its fail-closed default of `false`. AS IS is the same app on the parent commit; only the two components differ between the columns.

### `SubscriptionAddPaymentPreviewWorkspace` — new subscription

The total and the renewal line are both empty.

| AS IS | TO BE |
| --- | --- |
| <img src="https://raw.githubusercontent.com/Comfy-Org/ComfyUI_frontend/beffe7aa0dbc32b132dcbadb7bec9be28640d0bc/as-is-new-subscription.png" width="420"> | <img src="https://raw.githubusercontent.com/Comfy-Org/ComfyUI_frontend/beffe7aa0dbc32b132dcbadb7bec9be28640d0bc/to-be-new-subscription.png" width="420"> |

### `SubscriptionTransitionPreviewWorkspace` — plan change

This one degrades to `subscription.preview.quoteUnavailable` ("Unavailable") in both slots rather than to empty strings — the total short-circuits to that string and the pre-fix `renewalTerms` returns it too. Same root cause, different fallback.

| AS IS | TO BE |
| --- | --- |
| <img src="https://raw.githubusercontent.com/Comfy-Org/ComfyUI_frontend/beffe7aa0dbc32b132dcbadb7bec9be28640d0bc/as-is-plan-change.png" width="420"> | <img src="https://raw.githubusercontent.com/Comfy-Org/ComfyUI_frontend/beffe7aa0dbc32b132dcbadb7bec9be28640d0bc/to-be-plan-change.png" width="420"> |

Images are blobs on an unreferenced commit, so nothing is added to this branch's diff.

