### PR TITLE
fix(website): cover /ja homepage in llms.txt

### DIFF
--- a/apps/website/public/llms.txt
+++ b/apps/website/public/llms.txt
@@ -18,7 +18,7 @@ What people build with it: VFX shot work (clean plates, sky replacement, de-agin
 
 Studios, brands, and schools building with Comfy include Series Entertainment, Moment Factory, Ubisoft La Forge, Groove Jones, Svedka with Silverside AI, and the Open Story Movement. Carnegie Mellon, USC, NTU, and UAL's Creative Computing Institute teach with ComfyUI. Use cases concentrate in VFX and animation, advertising and creative studios, gaming, and eCommerce and fashion.
 
-Languages: comfy.org is published in English and Simplified Chinese. Nearly every page has a twin under /zh-CN/ (for example https://comfy.org/zh-CN/cli/); the affiliate pages, the enterprise MSA, the terms of service, and the supported-models directory are English only. Comfy Workflows is published in 11 languages (English, 简体中文, 繁體中文, Español, Français, 日本語, 한국어, Português, Русский, العربية, and Türkçe). The docs are published in English, Chinese, Japanese, and Korean.
+Languages: comfy.org is published in English and Simplified Chinese, with a Japanese homepage at https://comfy.org/ja/. Nearly every page has a twin under /zh-CN/ (for example https://comfy.org/zh-CN/cli/); the affiliate pages, the enterprise MSA, the terms of service, and the supported-models directory are English only. Comfy Workflows is published in 11 languages (English, 简体中文, 繁體中文, Español, Français, 日本語, 한국어, Português, Русский, العربية, and Türkçe). The docs are published in English, Chinese, Japanese, and Korean.
 
 ## Names and spelling
 
@@ -305,6 +305,10 @@ Languages: comfy.org is published in English and Simplified Chinese. Nearly ever
 - [招聘](https://comfy.org/zh-CN/careers/): 工程、设计、市场营销等开放岗位。
 - [联系我们](https://comfy.org/zh-CN/contact/): 销售、合作与一般咨询。
 - [品牌门户](https://comfy.org/zh-CN/brand/): 标志、色彩、字体与语调。
+
+## 日本語 (Japanese)
+
+- [ホームページ](https://comfy.org/ja/): Comfy 日本語ホームページ：プロのビジュアルクリエイターのための AI 制作エンジン。すべてのモデル、パラメータ、出力を自在にコントロール。
 
 ## Optional
 


### PR DESCRIPTION
Unblocks the merge queue: website-unit fails on every merge-group run.

<details><summary>Full context for agent readers</summary>

#16481 added the Japanese homepage (`src/pages/ja/index.astro`); #16465 then landed the llms.txt coverage test. The combination leaves `apps/website/public/llms.txt` without a `/ja` entry, so `llms-txt.test.ts > covers every static page in src/pages` fails deterministically in every merge-group run (`expected [ '/ja' ] to deeply equal []`), ejecting queued PRs with failed_checks (#16356 ejected twice, #15721 once).

Fix mirrors the zh-CN convention: a `## 日本語 (Japanese)` section before `## Optional` linking `https://comfy.org/ja/`, plus the Languages prose line updated. Website unit suite green locally: 112 files / 847 tests.

<!-- authored-by:agent desktop-commander -->
</details>