### PR TITLE
fix(billing): price legacy subscription previews from the server costs

### DIFF
--- a/browser_tests/tests/cloudSubscribeDeepLink.spec.ts
+++ b/browser_tests/tests/cloudSubscribeDeepLink.spec.ts
@@ -100,6 +100,7 @@ test.describe('Cloud subscribe deep link', { tag: '@cloud' }, () => {
     await expect(
       page.getByRole('heading', { name: 'Confirm your payment' })
     ).toBeVisible({ timeout: 45_000 })
+    await expect(page.getByText('$20.00')).toBeVisible()
     await expect(page.locator('#splash-loader')).toHaveCount(0)
     expect(legacyCheckoutRequests).toEqual([])
   })

--- a/browser_tests/tests/cloudSubscribeDeepLink.spec.ts
+++ b/browser_tests/tests/cloudSubscribeDeepLink.spec.ts
@@ -100,7 +100,10 @@ test.describe('Cloud subscribe deep link', { tag: '@cloud' }, () => {
     await expect(
       page.getByRole('heading', { name: 'Confirm your payment' })
     ).toBeVisible({ timeout: 45_000 })
-    await expect(page.getByText('$20.00')).toBeVisible()
+    await expect(page.getByText('$20.00', { exact: true })).toBeVisible()
+    await expect(
+      page.getByText('Renews at $20.00. Cancel anytime.')
+    ).toBeVisible()
     await expect(page.locator('#splash-loader')).toHaveCount(0)
     expect(legacyCheckoutRequests).toEqual([])
   })

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -3132,6 +3132,7 @@
       "quoteStale": "Your quote changed. Review the updated amount and try again.",
       "quoteRefreshFailed": "Your quote expired and couldn't be refreshed. Choose your plan again.",
       "renewsAt": "Renews at {amount} on {date}. Cancel anytime.",
+      "renewsAtAmount": "Renews at {amount}. Cancel anytime.",
       "discountComposition": "Discounts",
       "discount": {
         "plan": "Plan discount",

--- a/src/platform/cloud/subscription/utils/subscriptionQuoteFormatting.test.ts
+++ b/src/platform/cloud/subscription/utils/subscriptionQuoteFormatting.test.ts
@@ -79,8 +79,11 @@ describe('resolveRenewalDate', () => {
 
   it('falls back to the target plan period end', () => {
     const preview = legacyPreview()
-    preview.new_plan.period_end = '2026-08-19T00:00:00Z'
-    expect(resolveRenewalDate(preview)).toBe('2026-08-19T00:00:00Z')
+    const withPeriodEnd = {
+      ...preview,
+      new_plan: { ...preview.new_plan, period_end: '2026-08-19T00:00:00Z' }
+    }
+    expect(resolveRenewalDate(withPeriodEnd)).toBe('2026-08-19T00:00:00Z')
   })
 
   it('reports no date when the server supplied none', () => {

--- a/src/platform/cloud/subscription/utils/subscriptionQuoteFormatting.test.ts
+++ b/src/platform/cloud/subscription/utils/subscriptionQuoteFormatting.test.ts
@@ -1,0 +1,89 @@
+import type { PreviewSubscribeResponse } from '@comfyorg/ingest-types'
+import { describe, expect, it } from 'vitest'
+
+import {
+  formatAmountDueToday,
+  formatRenewalAmount,
+  resolveRenewalDate
+} from './subscriptionQuoteFormatting'
+
+function legacyPreview(
+  overrides: Partial<PreviewSubscribeResponse> = {}
+): PreviewSubscribeResponse {
+  return {
+    allowed: true,
+    transition_type: 'new_subscription',
+    effective_at: '2026-06-19T00:00:00Z',
+    is_immediate: true,
+    cost_today_cents: 2000,
+    cost_next_period_cents: 3000,
+    credits_today_cents: 0,
+    credits_next_period_cents: 0,
+    new_plan: {
+      slug: 'creator',
+      tier: 'CREATOR',
+      duration: 'MONTHLY',
+      price_cents: 2000,
+      credits_cents: 0,
+      seat_summary: {
+        seat_count: 1,
+        total_cost_cents: 2000,
+        total_credits_cents: 0
+      }
+    },
+    ...overrides
+  }
+}
+
+function exactPreview(
+  overrides: Partial<PreviewSubscribeResponse> = {}
+): PreviewSubscribeResponse {
+  return legacyPreview({
+    amount_due_cents: 1500,
+    currency: 'usd',
+    renewal_amount_cents: 2500,
+    renewal_at: '2026-07-19T00:00:00Z',
+    ...overrides
+  })
+}
+
+describe('formatAmountDueToday', () => {
+  it('prices the exact quote when the server sent one', () => {
+    expect(formatAmountDueToday(exactPreview(), 'en')).toBe('$15.00')
+  })
+
+  it('falls back to the legacy cost when the exact quote is absent', () => {
+    expect(formatAmountDueToday(legacyPreview(), 'en')).toBe('$20.00')
+  })
+
+  it('honours a non-USD exact quote', () => {
+    const preview = exactPreview({ currency: 'eur' })
+    expect(formatAmountDueToday(preview, 'en')).toBe('€15.00')
+  })
+})
+
+describe('formatRenewalAmount', () => {
+  it('prices the exact renewal when the server sent one', () => {
+    expect(formatRenewalAmount(exactPreview(), 'en')).toBe('$25.00')
+  })
+
+  it('falls back to the legacy next-period cost', () => {
+    expect(formatRenewalAmount(legacyPreview(), 'en')).toBe('$30.00')
+  })
+})
+
+describe('resolveRenewalDate', () => {
+  it('prefers the exact renewal instant', () => {
+    expect(resolveRenewalDate(exactPreview())).toBe('2026-07-19T00:00:00Z')
+  })
+
+  it('falls back to the target plan period end', () => {
+    const preview = legacyPreview()
+    preview.new_plan.period_end = '2026-08-19T00:00:00Z'
+    expect(resolveRenewalDate(preview)).toBe('2026-08-19T00:00:00Z')
+  })
+
+  it('reports no date when the server supplied none', () => {
+    expect(resolveRenewalDate(legacyPreview())).toBeUndefined()
+  })
+})

--- a/src/platform/cloud/subscription/utils/subscriptionQuoteFormatting.ts
+++ b/src/platform/cloud/subscription/utils/subscriptionQuoteFormatting.ts
@@ -1,3 +1,8 @@
+import type { PreviewSubscribeResponse } from '@comfyorg/ingest-types'
+
+// Legacy previews price in USD and carry no currency field.
+const LEGACY_QUOTE_CURRENCY = 'usd'
+
 export function formatQuoteMoney(
   cents: number,
   currency: string | undefined,
@@ -8,4 +13,44 @@ export function formatQuoteMoney(
     style: 'currency',
     currency: currency.toUpperCase()
   }).format(cents / 100)
+}
+
+function resolveQuoteMoney(
+  exactCents: number | undefined,
+  exactCurrency: string | undefined,
+  legacyCents: number
+): { cents: number; currency: string | undefined } {
+  return exactCents === undefined
+    ? { cents: legacyCents, currency: LEGACY_QUOTE_CURRENCY }
+    : { cents: exactCents, currency: exactCurrency }
+}
+
+export function formatAmountDueToday(
+  preview: PreviewSubscribeResponse,
+  locale: string
+): string {
+  const { cents, currency } = resolveQuoteMoney(
+    preview.amount_due_cents,
+    preview.currency,
+    preview.cost_today_cents
+  )
+  return formatQuoteMoney(cents, currency, locale)
+}
+
+export function formatRenewalAmount(
+  preview: PreviewSubscribeResponse,
+  locale: string
+): string {
+  const { cents, currency } = resolveQuoteMoney(
+    preview.renewal_amount_cents,
+    preview.currency,
+    preview.cost_next_period_cents
+  )
+  return formatQuoteMoney(cents, currency, locale)
+}
+
+export function resolveRenewalDate(
+  preview: PreviewSubscribeResponse
+): string | undefined {
+  return preview.renewal_at ?? preview.new_plan.period_end
 }

--- a/src/platform/workspace/components/SubscriptionAddPaymentPreviewWorkspace.test.ts
+++ b/src/platform/workspace/components/SubscriptionAddPaymentPreviewWorkspace.test.ts
@@ -44,9 +44,16 @@ function previewFixture(
   }
 }
 
+// Interpolation values are appended so assertions can verify what a message
+// was given, not just which message was chosen.
 vi.mock('vue-i18n', () => ({
   useI18n: () => ({
-    t: (key: string) => key,
+    t: (key: string, named?: Record<string, unknown>) =>
+      named
+        ? `${key}|${Object.entries(named)
+            .map(([name, value]) => `${name}=${String(value)}`)
+            .join(',')}`
+        : key,
     n: (value: number) => value.toLocaleString('en-US'),
     locale: { value: 'en' }
   })
@@ -421,6 +428,10 @@ describe('SubscriptionAddPaymentPreviewWorkspace', () => {
     })
 
     expect(screen.getByText('$20.00')).toBeTruthy()
-    expect(screen.getByText('subscription.preview.renewsAt')).toBeTruthy()
+    expect(
+      screen.getByText(
+        'subscription.preview.renewsAt|amount=$20.00,date=Jun 19, 2027'
+      )
+    ).toBeTruthy()
   })
 })

--- a/src/platform/workspace/components/SubscriptionAddPaymentPreviewWorkspace.test.ts
+++ b/src/platform/workspace/components/SubscriptionAddPaymentPreviewWorkspace.test.ts
@@ -403,4 +403,24 @@ describe('SubscriptionAddPaymentPreviewWorkspace', () => {
       })
     ).toBeNull()
   })
+
+  it('prices a legacy preview from the server costs instead of rendering a blank total', () => {
+    const {
+      amount_due_cents,
+      currency,
+      renewal_amount_cents,
+      renewal_at,
+      quote_id,
+      quote_version,
+      ...legacy
+    } = previewFixture('MONTHLY', 2000)
+
+    render(SubscriptionAddPaymentPreviewWorkspace, {
+      props: { tierKey: 'creator', previewData: legacy },
+      global: globalOptions
+    })
+
+    expect(screen.getByText('$20.00')).toBeTruthy()
+    expect(screen.getByText('subscription.preview.renewsAt')).toBeTruthy()
+  })
 })

--- a/src/platform/workspace/components/SubscriptionAddPaymentPreviewWorkspace.vue
+++ b/src/platform/workspace/components/SubscriptionAddPaymentPreviewWorkspace.vue
@@ -574,7 +574,7 @@ const renewalTerms = computed(() => {
   if (!amount) return ''
   const renewsAt = resolveRenewalDate(previewData)
   if (!renewsAt) return t('subscription.preview.renewsAtAmount', { amount })
-  const date = new Date(renewsAt).toLocaleDateString(undefined, {
+  const date = new Date(renewsAt).toLocaleDateString(locale.value, {
     month: 'short',
     day: 'numeric',
     year: 'numeric',

--- a/src/platform/workspace/components/SubscriptionAddPaymentPreviewWorkspace.vue
+++ b/src/platform/workspace/components/SubscriptionAddPaymentPreviewWorkspace.vue
@@ -366,7 +366,12 @@ import {
 } from '@/platform/cloud/subscription/constants/tierPricing'
 import type { TierKey } from '@/platform/cloud/subscription/constants/tierPricing'
 import { isYearlyCheckout } from '@/platform/cloud/subscription/utils/planDuration'
-import { formatQuoteMoney } from '@/platform/cloud/subscription/utils/subscriptionQuoteFormatting'
+import {
+  formatAmountDueToday,
+  formatQuoteMoney,
+  formatRenewalAmount,
+  resolveRenewalDate
+} from '@/platform/cloud/subscription/utils/subscriptionQuoteFormatting'
 import type { BillingCycle } from '@/platform/cloud/subscription/utils/subscriptionTierRank'
 import type {
   BillingAuthenticationState,
@@ -560,35 +565,21 @@ const creditsRefillLabelKey = computed(() =>
 )
 
 const totalDueToday = computed(() =>
-  previewData?.amount_due_cents === undefined
-    ? ''
-    : formatQuoteMoney(
-        previewData.amount_due_cents,
-        previewData.currency,
-        locale.value
-      )
+  previewData ? formatAmountDueToday(previewData, locale.value) : ''
 )
 
 const renewalTerms = computed(() => {
-  if (
-    previewData?.renewal_amount_cents === undefined ||
-    !previewData.renewal_at
-  ) {
-    return ''
-  }
-  const date = new Date(previewData.renewal_at).toLocaleDateString(undefined, {
+  if (!previewData) return ''
+  const amount = formatRenewalAmount(previewData, locale.value)
+  if (!amount) return ''
+  const renewsAt = resolveRenewalDate(previewData)
+  if (!renewsAt) return t('subscription.preview.renewsAtAmount', { amount })
+  const date = new Date(renewsAt).toLocaleDateString(undefined, {
     month: 'short',
     day: 'numeric',
     year: 'numeric',
     timeZone: 'UTC'
   })
-  return t('subscription.preview.renewsAt', {
-    amount: formatQuoteMoney(
-      previewData.renewal_amount_cents,
-      previewData.currency,
-      locale.value
-    ),
-    date
-  })
+  return t('subscription.preview.renewsAt', { amount, date })
 })
 </script>

--- a/src/platform/workspace/components/SubscriptionTransitionPreviewWorkspace.test.ts
+++ b/src/platform/workspace/components/SubscriptionTransitionPreviewWorkspace.test.ts
@@ -369,4 +369,21 @@ describe('SubscriptionTransitionPreviewWorkspace', () => {
       screen.queryByText('subscription.preview.quoteUnavailable')
     ).toBeNull()
   })
+
+  it('withholds an exact quote that arrives without a currency to price it in', () => {
+    render(SubscriptionTransitionPreviewWorkspace, {
+      props: {
+        previewData: preview({
+          cost_today_cents: 31_850,
+          new_plan: plan('CREATOR', 'ANNUAL', 33_600),
+          currency: undefined
+        })
+      },
+      global: globalOptions
+    })
+
+    expect(
+      screen.getAllByText('subscription.preview.quoteUnavailable')
+    ).toHaveLength(2)
+  })
 })

--- a/src/platform/workspace/components/SubscriptionTransitionPreviewWorkspace.test.ts
+++ b/src/platform/workspace/components/SubscriptionTransitionPreviewWorkspace.test.ts
@@ -19,10 +19,21 @@ vi.mock('@/composables/billing/useBillingContext', () => ({
   })
 }))
 
+// Only the renewal messages are supplied, so the renewal assertions verify
+// real interpolated output while every other key still renders as itself.
 const i18n = createI18n({
   legacy: false,
   locale: 'en',
-  messages: { en: {} }
+  messages: {
+    en: {
+      subscription: {
+        preview: {
+          renewsAt: 'Renews at {amount} on {date}. Cancel anytime.',
+          renewsAtAmount: 'Renews at {amount}. Cancel anytime.'
+        }
+      }
+    }
+  }
 })
 
 const globalOptions = {
@@ -341,7 +352,9 @@ describe('SubscriptionTransitionPreviewWorkspace', () => {
     })
 
     expect(screen.getByText('$318.50')).toBeTruthy()
-    expect(screen.getByText('subscription.preview.renewsAt')).toBeTruthy()
+    expect(
+      screen.getByText('Renews at $336.00 on Jun 28, 2027. Cancel anytime.')
+    ).toBeTruthy()
     expect(
       screen.queryByText('subscription.preview.quoteUnavailable')
     ).toBeNull()
@@ -364,7 +377,7 @@ describe('SubscriptionTransitionPreviewWorkspace', () => {
       global: globalOptions
     })
 
-    expect(screen.getByText('subscription.preview.renewsAtAmount')).toBeTruthy()
+    expect(screen.getByText('Renews at $336.00. Cancel anytime.')).toBeTruthy()
     expect(
       screen.queryByText('subscription.preview.quoteUnavailable')
     ).toBeNull()

--- a/src/platform/workspace/components/SubscriptionTransitionPreviewWorkspace.test.ts
+++ b/src/platform/workspace/components/SubscriptionTransitionPreviewWorkspace.test.ts
@@ -77,6 +77,23 @@ function preview(
   }
 }
 
+// Shape returned while embedded checkout is disabled: every exact-quote field
+// is absent and only the legacy cost fields are populated.
+function legacyPreview(
+  overrides: Partial<PreviewSubscribeResponse>
+): PreviewSubscribeResponse {
+  const {
+    amount_due_cents,
+    currency,
+    renewal_amount_cents,
+    renewal_at,
+    quote_id,
+    quote_version,
+    ...legacy
+  } = preview(overrides)
+  return legacy
+}
+
 describe('SubscriptionTransitionPreviewWorkspace', () => {
   it('renders an immediate yearly upgrade with proration and upfront credits', () => {
     render(SubscriptionTransitionPreviewWorkspace, {
@@ -309,5 +326,47 @@ describe('SubscriptionTransitionPreviewWorkspace', () => {
       global: globalOptions
     })
     expect(screen.getByText(/Some Future Tier/)).toBeTruthy()
+  })
+
+  it('prices a legacy preview from the server costs instead of reporting the quote unavailable', () => {
+    render(SubscriptionTransitionPreviewWorkspace, {
+      props: {
+        previewData: legacyPreview({
+          cost_today_cents: 31_850,
+          cost_next_period_cents: 33_600,
+          new_plan: plan('CREATOR', 'ANNUAL', 33_600)
+        })
+      },
+      global: globalOptions
+    })
+
+    expect(screen.getByText('$318.50')).toBeTruthy()
+    expect(screen.getByText('subscription.preview.renewsAt')).toBeTruthy()
+    expect(
+      screen.queryByText('subscription.preview.quoteUnavailable')
+    ).toBeNull()
+  })
+
+  it('states legacy renewal terms without a date when the server supplies no period end', () => {
+    const { period_end, ...planWithoutPeriodEnd } = plan(
+      'CREATOR',
+      'ANNUAL',
+      33_600
+    )
+    render(SubscriptionTransitionPreviewWorkspace, {
+      props: {
+        previewData: legacyPreview({
+          cost_today_cents: 31_850,
+          cost_next_period_cents: 33_600,
+          new_plan: planWithoutPeriodEnd
+        })
+      },
+      global: globalOptions
+    })
+
+    expect(screen.getByText('subscription.preview.renewsAtAmount')).toBeTruthy()
+    expect(
+      screen.queryByText('subscription.preview.quoteUnavailable')
+    ).toBeNull()
   })
 })

--- a/src/platform/workspace/components/SubscriptionTransitionPreviewWorkspace.vue
+++ b/src/platform/workspace/components/SubscriptionTransitionPreviewWorkspace.vue
@@ -196,7 +196,7 @@
             {{ $t('subscription.preview.totalDueToday') }}
           </span>
           <span class="font-bold text-base-foreground tabular-nums">
-            {{ exactAmountDue }}
+            {{ amountDueToday }}
           </span>
         </div>
         <span class="text-sm text-muted-foreground">{{ renewalTerms }}</span>
@@ -323,7 +323,11 @@ import {
   toTierKey
 } from '@/platform/cloud/subscription/constants/tierPricing'
 import { isAnnualDuration } from '@/platform/cloud/subscription/utils/planDuration'
-import { formatQuoteMoney } from '@/platform/cloud/subscription/utils/subscriptionQuoteFormatting'
+import {
+  formatAmountDueToday,
+  formatRenewalAmount,
+  resolveRenewalDate
+} from '@/platform/cloud/subscription/utils/subscriptionQuoteFormatting'
 import type {
   BillingAuthenticationState,
   PreviewSubscribeResponse
@@ -648,29 +652,19 @@ const confirmCta = computed(() => {
     amount: chargeDisplay.value
   })
 })
-const exactAmountDue = computed(() =>
-  previewData.amount_due_cents === undefined
-    ? t('subscription.preview.quoteUnavailable')
-    : formatQuoteMoney(
-        previewData.amount_due_cents,
-        previewData.currency,
-        locale.value
-      )
+const amountDueToday = computed(
+  () =>
+    formatAmountDueToday(previewData, locale.value) ||
+    t('subscription.preview.quoteUnavailable')
 )
 const renewalTerms = computed(() => {
-  if (
-    previewData.renewal_amount_cents === undefined ||
-    !previewData.renewal_at
-  ) {
-    return t('subscription.preview.quoteUnavailable')
-  }
+  const amount = formatRenewalAmount(previewData, locale.value)
+  if (!amount) return t('subscription.preview.quoteUnavailable')
+  const renewsAt = resolveRenewalDate(previewData)
+  if (!renewsAt) return t('subscription.preview.renewsAtAmount', { amount })
   return t('subscription.preview.renewsAt', {
-    amount: formatQuoteMoney(
-      previewData.renewal_amount_cents,
-      previewData.currency,
-      locale.value
-    ),
-    date: formatDate(previewData.renewal_at)
+    amount,
+    date: formatDate(renewsAt)
   })
 })
 </script>

--- a/src/platform/workspace/components/SubscriptionTransitionPreviewWorkspaceReactivation.test.ts
+++ b/src/platform/workspace/components/SubscriptionTransitionPreviewWorkspaceReactivation.test.ts
@@ -545,7 +545,7 @@ describe('SubscriptionTransitionPreviewWorkspace reactivation disclosure', () =>
   })
 
   describe('confirm gating on load state', () => {
-    it('shows unavailable exact quote fields', () => {
+    it('prices a preview that carries no exact quote from the legacy costs', () => {
       mockSubscription.value = { isCancelled: false, endDate: null }
       renderComponent(
         makePreview({
@@ -558,9 +558,10 @@ describe('SubscriptionTransitionPreviewWorkspace reactivation disclosure', () =>
         })
       )
 
+      expect(screen.getByText('$15.00')).toBeInTheDocument()
       expect(
-        screen.getAllByText('subscription.preview.quoteUnavailable')
-      ).toHaveLength(2)
+        screen.queryByText('subscription.preview.quoteUnavailable')
+      ).toBeNull()
     })
 
     it('does not confirm without a current quote', async () => {


### PR DESCRIPTION
## Summary

The subscription confirm screens rendered no amount at all whenever embedded checkout was off — a blank "Total due today" on new subscriptions and "Unavailable" on plan changes. Resolve the amount from the legacy cost fields the server always sends.

## Changes

- **What**: `formatAmountDueToday` / `formatRenewalAmount` / `resolveRenewalDate` in `subscriptionQuoteFormatting.ts` resolve each figure from the exact quote when the server sent one and from the always-present legacy costs otherwise. `SubscriptionAddPaymentPreviewWorkspace` and `SubscriptionTransitionPreviewWorkspace` consume them. New `subscription.preview.renewsAtAmount` message for the case where the server supplies an amount but no renewal date.

### Root cause

#14483 ("consolidate embedded checkout frontend") rewrote both quote computeds to read only the embedded-checkout field family:

```ts
const totalDueToday = computed(() =>
  previewData?.amount_due_cents === undefined ? '' : formatQuoteMoney(...)
)
```

`POST /api/billing/preview-subscribe` returns two different shapes. `packages/ingest-types` documents the split on the sibling field: `payment_method_configuration_id` is *"Present on every successful preview while embedded checkout is enabled and absent from legacy previews."* The same holds for the whole family:

| field | contract | legacy preview |
| --- | --- | --- |
| `amount_due_cents`, `currency` | optional | absent |
| `renewal_amount_cents`, `renewal_at` | optional | absent |
| `cost_today_cents`, `cost_next_period_cents` | **required** | **present** |

So with the flag off, `amount_due_cents` is `undefined` and `totalDueToday` short-circuits to `''`. `SubscriptionTransitionPreviewWorkspace` falls through to `subscription.preview.quoteUnavailable` and prints "Unavailable" twice.

Two things widen the blast radius beyond "someone turned the flag off":

- `embeddedCheckoutEnabled` resolves **fail-closed** (`resolveFailClosedBooleanFlag`), so a flag that cannot be read is treated as off and takes this same path.
- `formatQuoteMoney` returns `''` when `currency` is missing, so even reading `cost_today_cents` while passing the absent `currency` through would still render blank.

Note the branch here is on the **response shape**, not on the `embeddedCheckoutEnabled` prop. The shape is what the contract actually guarantees, it needs no prop threaded into `SubscriptionTransitionPreviewWorkspace`, and it stays correct if the flag is on while the backend still serves a legacy preview. `chargeCents` in the same component already branched this way (`amount_due_cents ?? cost_today_cents`) — the consolidation just missed the display computeds.

The renewal **date** is deliberately not synthesized. `PreviewPlanInfo.period_end` is documented "only for current_plan" and is absent on a new-subscription preview, so the legacy path shows the server-provided renewal amount without inventing a date.

## Review Focus

- `LEGACY_QUOTE_CURRENCY = 'usd'` is the one assumption added. The legacy rail carries no `currency` field because it prices in USD; this keeps that assumption in a single named constant instead of at each call site.
- `SubscriptionTransitionPreviewWorkspaceReactivation.test.ts` had a test asserting "Unavailable" appeared twice for a preview with no exact quote. That test codified this bug, so it now asserts the legacy amount renders.
- `cloudSubscribeDeepLink.spec.ts` already drove a legacy-shaped preview through the real checkout but only asserted the heading, which is how this reached QA. It now asserts the total.

## Tests

- 8 unit tests on the pure resolvers (exact quote, legacy fallback, non-USD, missing date)
- 3 component regression tests; verified they fail without the fix and pass with it
- 1 E2E assertion on the existing flag-off deep-link spec

## Screenshots

Captured in the running app (cloud distribution, `embedded_checked_enabled` off) — posting them in a follow-up comment.

<!-- Supersedes #16515, which fixes the same bug by branching on the flag prop and drops the renewal line when the server sends no date. -->
