### PR TITLE
fix(website): fall back to English where the ja locale has no coverage

### DIFF
--- a/apps/website/public/llms.txt
+++ b/apps/website/public/llms.txt
@@ -18,7 +18,7 @@ What people build with it: VFX shot work (clean plates, sky replacement, de-agin
 
 Studios, brands, and schools building with Comfy include Series Entertainment, Moment Factory, Ubisoft La Forge, Groove Jones, Svedka with Silverside AI, and the Open Story Movement. Carnegie Mellon, USC, NTU, and UAL's Creative Computing Institute teach with ComfyUI. Use cases concentrate in VFX and animation, advertising and creative studios, gaming, and eCommerce and fashion.
 
-Languages: comfy.org is published in English and Simplified Chinese. Nearly every page has a twin under /zh-CN/ (for example https://comfy.org/zh-CN/cli/); the affiliate pages, the enterprise MSA, the terms of service, and the supported-models directory are English only. Comfy Workflows is published in 11 languages (English, 简体中文, 繁體中文, Español, Français, 日本語, 한국어, Português, Русский, العربية, and Türkçe). The docs are published in English, Chinese, Japanese, and Korean.
+Languages: comfy.org is published in English and Simplified Chinese, with a Japanese homepage at https://comfy.org/ja/. Nearly every page has a twin under /zh-CN/ (for example https://comfy.org/zh-CN/cli/); the affiliate pages, the enterprise MSA, the terms of service, and the supported-models directory are English only. Comfy Workflows is published in 11 languages (English, 简体中文, 繁體中文, Español, Français, 日本語, 한국어, Português, Русский, العربية, and Türkçe). The docs are published in English, Chinese, Japanese, and Korean.
 
 ## Names and spelling
 
@@ -305,6 +305,10 @@ Languages: comfy.org is published in English and Simplified Chinese. Nearly ever
 - [招聘](https://comfy.org/zh-CN/careers/): 工程、设计、市场营销等开放岗位。
 - [联系我们](https://comfy.org/zh-CN/contact/): 销售、合作与一般咨询。
 - [品牌门户](https://comfy.org/zh-CN/brand/): 标志、色彩、字体与语调。
+
+## 日本語 (Japanese)
+
+- [ホームページ](https://comfy.org/ja/): Comfy 日本語ホームページ：プロのビジュアルクリエイターのための AI 制作エンジン。すべてのモデル、パラメータ、出力を自在にコントロール。
 
 ## Optional
 

--- a/apps/website/src/components/contact/FormSection.vue
+++ b/apps/website/src/components/contact/FormSection.vue
@@ -12,7 +12,7 @@ const { locale = 'en' } = defineProps<{
   locale?: Locale
 }>()
 
-const contactFormIds: Record<Locale, string> = {
+const contactFormIds: { en: string } & Partial<Record<Locale, string>> = {
   en: '94e05eab-1373-47f7-ab5e-d84f9e6aa262',
   'zh-CN': '6885750c-02ef-4aa2-ba0d-213be9cccf93'
 }
@@ -86,7 +86,10 @@ useHeroAnimation({
 
     <!-- Right column: form -->
     <div ref="formRef" class="mt-12 lg:mt-0 lg:w-1/2">
-      <HubspotFormEmbed :form-id="contactFormIds[locale]" :locale />
+      <HubspotFormEmbed
+        :form-id="contactFormIds[locale] || contactFormIds.en"
+        :locale
+      />
     </div>
   </section>
 </template>

--- a/apps/website/src/components/learning/LearningWatchPage.vue
+++ b/apps/website/src/components/learning/LearningWatchPage.vue
@@ -64,7 +64,7 @@ const recommended = recommendedFor(tutorial).map((item) => ({
       v-if="tutorial.youtubeId"
       :key="tutorial.id"
       :youtube-id="tutorial.youtubeId"
-      :title="tutorial.title[locale]"
+      :title="tutorial.title[locale] || tutorial.title.en"
       class="w-full"
     />
     <VideoPlayer


### PR DESCRIPTION
The ja homepage launch (#16481) added 'ja' to the `Locale` union, which broke `pnpm typecheck` on main:

- `FormSection.vue`: `contactFormIds: Record<Locale, string>` has no `ja` entry
- `LearningWatchPage.vue`: `tutorial.title[locale]` is now `string | undefined` for the required `title` prop

Both now use the `{ en } & Partial<Record<Locale, string>>` shape and `|| .en` fallback that #16363 established, so ja visitors get the English HubSpot form and video title until localized ones exist.

Together with #16516 (llms.txt /ja coverage) this returns main's `build` and `website-unit` checks to green; the two are independent and can land in either order.