### PR TITLE
feat(website): add two basics learning tutorials

### DIFF
--- a/apps/website/e2e/learning.spec.ts
+++ b/apps/website/e2e/learning.spec.ts
@@ -32,7 +32,7 @@ const EXPECTED_META = {
     description:
       'Beginner ComfyUI tutorials: learn the node graph, LoRAs, style transfer, and ControlNets from the ground up.',
     metaDescription:
-      'Free ComfyUI tutorials for beginners. Learn the node graph first, then add LoRAs, style transfer, and ControlNets, with a workflow to open at every step.',
+      'Free ComfyUI tutorials for beginners: the node graph, text-to-image and image-to-image, LoRAs and ControlNets, then inpainting, outpainting, and upscaling.',
     title: 'ComfyUI Basics for Beginners: Node Graph, LoRAs, ControlNet'
   },
   vfx: {

--- a/apps/website/public/llms.txt
+++ b/apps/website/public/llms.txt
@@ -156,9 +156,11 @@ Languages: comfy.org is published in English and Simplified Chinese, with a Japa
 
 ### ComfyUI Basics
 
-- [ComfyUI Basics](https://comfy.org/learning/basics/): Beginner tutorials: the node graph, LoRAs, style transfer, and ControlNets from the ground up.
+- [ComfyUI Basics](https://comfy.org/learning/basics/): Beginner tutorials: the node graph, text-to-image and image-to-image, LoRAs and ControlNets, then inpainting, outpainting, and upscaling.
 - [Full Node Graph Basics](https://comfy.org/learning/basics/full-node-graph-basics/): A beginner's walkthrough of the ComfyUI node graph.
+- [Text-to-Image and Image-to-Image Workflows](https://comfy.org/learning/basics/text-to-image-image-to-image/): Build a text-to-image workflow, then adapt it for image-to-image.
 - [LoRAs, Style Transfer, and ControlNets](https://comfy.org/learning/basics/loras-style-transfer-controlnets/): What each one does and how to wire them into a ComfyUI workflow.
+- [Inpainting, Outpainting, and Upscaling](https://comfy.org/learning/basics/inpainting-outpainting-upscaling/): Mask and repaint, extend the frame, and add resolution in ComfyUI.
 
 ### Ad Creative
 

--- a/apps/website/public/llms.txt
+++ b/apps/website/public/llms.txt
@@ -18,7 +18,7 @@ What people build with it: VFX shot work (clean plates, sky replacement, de-agin
 
 Studios, brands, and schools building with Comfy include Series Entertainment, Moment Factory, Ubisoft La Forge, Groove Jones, Svedka with Silverside AI, and the Open Story Movement. Carnegie Mellon, USC, NTU, and UAL's Creative Computing Institute teach with ComfyUI. Use cases concentrate in VFX and animation, advertising and creative studios, gaming, and eCommerce and fashion.
 
-Languages: comfy.org is published in English and Simplified Chinese. Nearly every page has a twin under /zh-CN/ (for example https://comfy.org/zh-CN/cli/); the affiliate pages, the enterprise MSA, the terms of service, and the supported-models directory are English only. Comfy Workflows is published in 11 languages (English, 简体中文, 繁體中文, Español, Français, 日本語, 한국어, Português, Русский, العربية, and Türkçe). The docs are published in English, Chinese, Japanese, and Korean.
+Languages: comfy.org is published in English and Simplified Chinese, with a Japanese home page at https://comfy.org/ja/. Nearly every page has a twin under /zh-CN/ (for example https://comfy.org/zh-CN/cli/); the affiliate pages, the enterprise MSA, the terms of service, and the supported-models directory are English only. Comfy Workflows is published in 11 languages (English, 简体中文, 繁體中文, Español, Français, 日本語, 한국어, Português, Русский, العربية, and Türkçe). The docs are published in English, Chinese, Japanese, and Korean.
 
 ## Names and spelling
 
@@ -305,6 +305,10 @@ Languages: comfy.org is published in English and Simplified Chinese. Nearly ever
 - [招聘](https://comfy.org/zh-CN/careers/): 工程、设计、市场营销等开放岗位。
 - [联系我们](https://comfy.org/zh-CN/contact/): 销售、合作与一般咨询。
 - [品牌门户](https://comfy.org/zh-CN/brand/): 标志、色彩、字体与语调。
+
+## 日本語 (Japanese)
+
+- [ホーム](https://comfy.org/ja/): Comfyの日本語トップページ：あらゆるモデル、パラメータ、出力を自在にコントロールできるビジュアルプロフェッショナル向けAIクリエーションエンジン。
 
 ## Optional
 

--- a/apps/website/src/components/contact/FormSection.test.ts
+++ b/apps/website/src/components/contact/FormSection.test.ts
@@ -1,0 +1,35 @@
+// @vitest-environment happy-dom
+import { render, screen } from '@testing-library/vue'
+import { describe, expect, it } from 'vitest'
+
+import type { Locale } from '../../i18n/translations'
+
+import FormSection from './FormSection.vue'
+
+const stubs = {
+  SectionLabel: true,
+  HubspotFormEmbed: {
+    props: ['formId'],
+    template: '<div data-testid="hubspot-form" :data-form-id="formId" />'
+  }
+}
+
+function formIdFor(locale: Locale) {
+  const { unmount } = render(FormSection, {
+    props: { locale },
+    global: { stubs }
+  })
+  const formId = screen.getByTestId('hubspot-form').getAttribute('data-form-id')
+  unmount()
+  return formId
+}
+
+describe('FormSection', () => {
+  it('serves a locale its own HubSpot form when one exists', () => {
+    expect(formIdFor('zh-CN')).not.toBe(formIdFor('en'))
+  })
+
+  it('falls back to the English form for locales without their own', () => {
+    expect(formIdFor('ja')).toBe(formIdFor('en'))
+  })
+})

--- a/apps/website/src/components/contact/FormSection.vue
+++ b/apps/website/src/components/contact/FormSection.vue
@@ -12,8 +12,10 @@ const { locale = 'en' } = defineProps<{
   locale?: Locale
 }>()
 
-const contactFormIds: Record<Locale, string> = {
-  en: '94e05eab-1373-47f7-ab5e-d84f9e6aa262',
+const englishFormId = '94e05eab-1373-47f7-ab5e-d84f9e6aa262'
+
+const contactFormIds: Partial<Record<Locale, string>> = {
+  en: englishFormId,
   'zh-CN': '6885750c-02ef-4aa2-ba0d-213be9cccf93'
 }
 
@@ -86,7 +88,10 @@ useHeroAnimation({
 
     <!-- Right column: form -->
     <div ref="formRef" class="mt-12 lg:mt-0 lg:w-1/2">
-      <HubspotFormEmbed :form-id="contactFormIds[locale]" :locale />
+      <HubspotFormEmbed
+        :form-id="contactFormIds[locale] ?? englishFormId"
+        :locale
+      />
     </div>
   </section>
 </template>

--- a/apps/website/src/components/learning/LearningWatchPage.test.ts
+++ b/apps/website/src/components/learning/LearningWatchPage.test.ts
@@ -3,6 +3,7 @@ import { render, screen } from '@testing-library/vue'
 import { describe, expect, it } from 'vitest'
 
 import type { LearningTutorial } from '../../data/learningTutorials'
+import type { Locale } from '../../i18n/translations'
 
 import { filterByCategory } from '../../data/learningTutorials'
 import LearningWatchPage from './LearningWatchPage.vue'
@@ -19,13 +20,16 @@ const hostedTutorial = filterByCategory('vfx').find(
 if (!hostedTutorial) throw new Error('Expected a VFX tutorial with videoSrc')
 
 const stubs = {
-  LearningVideoEmbed: { template: '<div data-testid="youtube-embed" />' },
+  LearningVideoEmbed: {
+    props: ['title'],
+    template: '<div data-testid="youtube-embed">{{ title }}</div>'
+  },
   VideoPlayer: { template: '<div data-testid="hosted-video" />' }
 }
 
-function renderWatchPage(tutorial: LearningTutorial) {
+function renderWatchPage(tutorial: LearningTutorial, locale: Locale = 'en') {
   render(LearningWatchPage, {
-    props: { tutorial, locale: 'en' },
+    props: { tutorial, locale },
     global: { stubs }
   })
 }
@@ -43,5 +47,13 @@ describe('LearningWatchPage', () => {
 
     expect(screen.getByTestId('hosted-video')).toBeTruthy()
     expect(screen.queryByTestId('youtube-embed')).toBeNull()
+  })
+
+  it('titles the embed in English when the locale has no translation', () => {
+    renderWatchPage(youtubeTutorial, 'ja')
+
+    expect(screen.getByTestId('youtube-embed').textContent).toBe(
+      youtubeTutorial.title.en
+    )
   })
 })

--- a/apps/website/src/components/learning/LearningWatchPage.vue
+++ b/apps/website/src/components/learning/LearningWatchPage.vue
@@ -64,7 +64,7 @@ const recommended = recommendedFor(tutorial).map((item) => ({
       v-if="tutorial.youtubeId"
       :key="tutorial.id"
       :youtube-id="tutorial.youtubeId"
-      :title="tutorial.title[locale]"
+      :title="tutorial.title[locale] ?? tutorial.title.en"
       class="w-full"
     />
     <VideoPlayer

--- a/apps/website/src/data/learningTutorials.test.ts
+++ b/apps/website/src/data/learningTutorials.test.ts
@@ -104,7 +104,7 @@ describe('directory meta', () => {
       basics: {
         title: 'ComfyUI Basics for Beginners: Node Graph, LoRAs, ControlNet',
         description:
-          'Free ComfyUI tutorials for beginners. Learn the node graph first, then add LoRAs, style transfer, and ControlNets, with a workflow to open at every step.'
+          'Free ComfyUI tutorials for beginners: the node graph, text-to-image and image-to-image, LoRAs and ControlNets, then inpainting, outpainting, and upscaling.'
       },
       vfx: {
         title: 'ComfyUI VFX Tutorials: Cleanplates, Sky Replacement, Deaging',
@@ -131,7 +131,7 @@ describe('directory meta', () => {
       basics: {
         title: 'ComfyUI 基础教程：节点图、LoRA 与 ControlNet 新手入门',
         description:
-          '面向初学者的免费 ComfyUI 教程。先学节点图，再加入 LoRA、风格迁移与 ControlNet，每一步都有可打开的工作流。'
+          '面向初学者的免费 ComfyUI 教程：节点图、文生图与图生图、LoRA 与 ControlNet，再到局部重绘、扩图与放大。'
       },
       vfx: {
         title: 'ComfyUI VFX 教程：净板、天空替换与减龄',

--- a/apps/website/src/data/learningTutorials.ts
+++ b/apps/website/src/data/learningTutorials.ts
@@ -178,6 +178,11 @@ const fundamentalsTag: TranslationKey = 'tags.fundamentals'
 const nodeGraphTag: TranslationKey = 'tags.nodeGraph'
 const loraTag: TranslationKey = 'tags.lora'
 const controlNetTag: TranslationKey = 'tags.controlNet'
+const textToImageTag: TranslationKey = 'tags.textToImage'
+const imageToImageTag: TranslationKey = 'tags.imageToImage'
+const inpaintingTag: TranslationKey = 'tags.inpainting'
+const outpaintingTag: TranslationKey = 'tags.outpainting'
+const upscalingTag: TranslationKey = 'tags.upscaling'
 
 const dougHogan: TutorialAuthor = {
   name: { en: 'Doug Hogan', 'zh-CN': 'Doug Hogan' },
@@ -207,18 +212,43 @@ export const learningTutorials: readonly LearningTutorial[] = [
       'zh-CN':
         '面向初学者的 ComfyUI 节点图入门：了解节点、连线与运行队列如何协同，搭建你的第一条可用流程。'
     },
-    poster: 'https://img.youtube.com/vi/TQhIYT1ZYGQ/maxresdefault.jpg',
+    poster:
+      'https://media.comfy.org/website/learning/full-node-graph-basics-thumb.jpg',
     href: externalLinks.cloudCta('learning_basics_node_graph'),
     newTab: true,
     ctaLabelKey: 'cta.tryForFree',
     tags: [fundamentalsTag, nodeGraphTag]
   },
   {
+    id: 'basics_text_to_image',
+    publishedDate: '2026-08-13',
+    slug: 'text-to-image-image-to-image',
+    category: 'basics',
+    episode: 2,
+    author: dougHogan,
+    youtubeId: 'uafAN8zLKD8',
+    title: {
+      en: 'ComfyUI Tutorial for Beginners: Text-to-Image & Image-to-Image Workflows (2026)',
+      'zh-CN': 'ComfyUI 新手教程：文生图与图生图工作流 (2026)'
+    },
+    description: {
+      en: 'Build your first text-to-image workflow, then adapt it for image-to-image: prompts, samplers, denoise strength, and when to reach for each.',
+      'zh-CN':
+        '搭建你的第一条文生图工作流，再将它改造为图生图：提示词、采样器、去噪强度，以及各自的适用场景。'
+    },
+    poster:
+      'https://media.comfy.org/website/learning/text-to-image-image-to-image-thumb.jpg',
+    href: externalLinks.cloudCta('learning_basics_text_to_image'),
+    newTab: true,
+    ctaLabelKey: 'cta.tryForFree',
+    tags: [fundamentalsTag, textToImageTag, imageToImageTag]
+  },
+  {
     id: 'basics_loras_style_controlnets',
     publishedDate: '2026-08-17',
     slug: 'loras-style-transfer-controlnets',
     category: 'basics',
-    episode: 2,
+    episode: 3,
     author: dougHogan,
     youtubeId: '-igiHGaxKek',
     title: {
@@ -230,11 +260,36 @@ export const learningTutorials: readonly LearningTutorial[] = [
       'zh-CN':
         '进阶了解 LoRA、风格迁移与 ControlNet：各自的作用，以及如何将它们接入 ComfyUI 工作流。'
     },
-    poster: 'https://img.youtube.com/vi/-igiHGaxKek/maxresdefault.jpg',
+    poster:
+      'https://media.comfy.org/website/learning/loras-style-transfer-controlnets-thumb.jpg',
     href: externalLinks.cloudCta('learning_basics_loras'),
     newTab: true,
     ctaLabelKey: 'cta.tryForFree',
     tags: [fundamentalsTag, loraTag, controlNetTag, styleTransferTag]
+  },
+  {
+    id: 'basics_inpainting',
+    publishedDate: '2026-08-31',
+    slug: 'inpainting-outpainting-upscaling',
+    category: 'basics',
+    episode: 4,
+    author: dougHogan,
+    youtubeId: 'hFCuhcm37uY',
+    title: {
+      en: 'ComfyUI Tutorial for Beginners: Inpainting, Outpainting & Upscaling (2026)',
+      'zh-CN': 'ComfyUI 新手教程：局部重绘、扩图与放大 (2026)'
+    },
+    description: {
+      en: 'Edit and enlarge images in ComfyUI: mask and repaint with inpainting, extend the frame with outpainting, and add resolution with upscaling.',
+      'zh-CN':
+        '在 ComfyUI 中编辑与放大图像：用局部重绘遮罩改图，用扩图扩展画面，再通过放大提升分辨率。'
+    },
+    poster:
+      'https://media.comfy.org/website/learning/inpainting-outpainting-upscaling-thumb.jpg',
+    href: externalLinks.cloudCta('learning_basics_inpainting'),
+    newTab: true,
+    ctaLabelKey: 'cta.tryForFree',
+    tags: [fundamentalsTag, inpaintingTag, outpaintingTag, upscalingTag]
   },
   {
     id: 'cleanplate_walkthrough_v03',

--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -90,6 +90,26 @@ const translations = {
     en: 'ControlNet',
     'zh-CN': 'ControlNet'
   },
+  'tags.textToImage': {
+    en: 'Text to Image',
+    'zh-CN': '文生图'
+  },
+  'tags.imageToImage': {
+    en: 'Image to Image',
+    'zh-CN': '图生图'
+  },
+  'tags.inpainting': {
+    en: 'Inpainting',
+    'zh-CN': '局部重绘'
+  },
+  'tags.outpainting': {
+    en: 'Outpainting',
+    'zh-CN': '扩图'
+  },
+  'tags.upscaling': {
+    en: 'Upscaling',
+    'zh-CN': '放大'
+  },
 
   // UI (global, reusable across sections)
   'ui.copy': {
@@ -1862,9 +1882,9 @@ Enterprise`
       '面向初学者的 ComfyUI 教程：从零开始掌握节点图、LoRA、风格迁移与 ControlNet。'
   },
   'learning.categories.basics.metaDescription': {
-    en: 'Free ComfyUI tutorials for beginners. Learn the node graph first, then add LoRAs, style transfer, and ControlNets, with a workflow to open at every step.',
+    en: 'Free ComfyUI tutorials for beginners: the node graph, text-to-image and image-to-image, LoRAs and ControlNets, then inpainting, outpainting, and upscaling.',
     'zh-CN':
-      '面向初学者的免费 ComfyUI 教程。先学节点图，再加入 LoRA、风格迁移与 ControlNet，每一步都有可打开的工作流。'
+      '面向初学者的免费 ComfyUI 教程：节点图、文生图与图生图、LoRA 与 ControlNet，再到局部重绘、扩图与放大。'
   },
   'learning.categories.vfx.heading': {
     en: 'VFX Tutorials',


### PR DESCRIPTION
## Summary

Adds the Text-to-Image & Image-to-Image and Inpainting/Outpainting/Upscaling episodes to `/learning/basics`, and unblocks the website pre-commit hook, which `main` currently fails.

## Changes

- **What**: Two new `basics` tutorials (`text-to-image-image-to-image` ep2, `inpainting-outpainting-upscaling` ep4), with LoRAs renumbered to ep3 so the series reads in publication order — episode drives chapter ordering only, no visible label and no slug changes. Five new tag keys (`textToImage`, `imageToImage`, `inpainting`, `outpainting`, `upscaling`) in en + zh-CN. All four basics posters now served from `media.comfy.org/website/learning/*-thumb.jpg` (uploaded to `gs://comfy-org-videos`) instead of hotlinking `img.youtube.com`. Basics meta description and the llms.txt basics section updated to cover the full arc.
- **Also**: a separate first commit fixes `main`. #16481 added `'ja'` to the `Locale` union without updating two call sites, so `astro check && vue-tsc` fails on `main` and the pre-commit hook rejects any website commit. `FormSection` now types `contactFormIds` as `Partial` and falls back to the English HubSpot form rather than claiming a Japanese one exists; `LearningWatchPage` falls back to the English title for the embed, matching the fallback the surrounding template already uses; `llms.txt` links the `/ja` home page, which its coverage test requires.

## Review Focus

- The two commits are separable — review `e102cdb` (the `ja` typecheck fix) on its own if you'd rather it land separately.
- The English HubSpot form ID is the fallback for Japanese contact submissions. If Japanese leads should route elsewhere, that's a follow-up.
- `learning.categories.basics.description` (the visible lead-in, distinct from the meta description) still reads "the node graph, LoRAs, style transfer, and ControlNets" and is now incomplete. Left alone deliberately — say the word and I'll update the visible copy too.

## Verification

- `pnpm --filter @comfyorg/website test:unit` — 847 passed (was 846 passed / 1 failed on `main`, the `/ja` llms.txt coverage test)
- `pnpm typecheck` + `pnpm typecheck:website` — 0 errors (was 2 on `main`)
- `pnpm lint` — 0 errors; `astro build` — 705 pages, all four en + zh-CN basics pages generated, no `img.youtube.com` references left in `dist/`
- All four thumbnails verified live: `curl -I https://media.comfy.org/website/learning/<slug>-thumb.jpg` → 200 `image/jpeg`