### PR TITLE
fix: preserve translation request concurrency on splits

### DIFF
--- a/scripts/i18n/translate.ts
+++ b/scripts/i18n/translate.ts
@@ -187,15 +187,12 @@ export function createOpenAiTranslator(
           deferralReason = `${items.length} strings were still truncated (finish_reason "length") at maxTruncationSplitDepth ${options.maxTruncationSplitDepth}`
           break
         }
-        const settled = await Promise.allSettled(
-          splitTruncatedBatch(items).map((chunk) =>
-            translateBatch(locale, chunk, splitDepth + 1)
-          )
-        )
         const merged: Record<string, string> = {}
-        for (const result of settled) {
-          if (result.status === 'rejected') throw result.reason
-          Object.assign(merged, result.value)
+        for (const chunk of splitTruncatedBatch(items)) {
+          Object.assign(
+            merged,
+            await translateBatch(locale, chunk, splitDepth + 1)
+          )
         }
         return merged
       }

--- a/scripts/i18n/update-locales.test.ts
+++ b/scripts/i18n/update-locales.test.ts
@@ -341,15 +341,18 @@ describe('translateLocaleItems', () => {
 describe('mapWithConcurrency', () => {
   it('stops dispatching new tasks after a failure', async () => {
     const started: number[] = []
+    let inFlightTaskSettled = false
     await expect(
       mapWithConcurrency([1, 2, 3, 4], 2, async (item) => {
         started.push(item)
         if (item === 1) throw new Error('boom')
-        await new Promise((resolve) => setTimeout(resolve, 5))
+        await Promise.resolve()
+        inFlightTaskSettled = true
         return item
       })
     ).rejects.toThrow('boom')
     expect(started).toEqual([1, 2])
+    expect(inFlightTaskSettled).toBe(true)
   })
 })
 
@@ -557,7 +560,9 @@ describe('createOpenAiTranslator', () => {
   })
 
   function translatorFor(
-    respond: Response[] | ((body: string, call: number) => Response),
+    respond:
+      | Response[]
+      | ((body: string, call: number) => Response | Promise<Response>),
     overrides: Partial<
       Pick<
         Parameters<typeof createOpenAiTranslator>[0],
@@ -622,6 +627,27 @@ describe('createOpenAiTranslator', () => {
           !body.includes('main.json: greeting')
       )
     ).toBe(true)
+  })
+
+  it('does not fan out requests while splitting a truncated batch', async () => {
+    let activeRequests = 0
+    let peakRequests = 0
+    const { translate } = translatorFor(async (body, call) => {
+      if (call === 1) return completion('{"1": "Bonj', 'length')
+      activeRequests++
+      peakRequests = Math.max(peakRequests, activeRequests)
+      await Promise.resolve()
+      activeRequests--
+      return body.includes('main.json: greeting')
+        ? completion('{"1": "Bonjour {name}"}')
+        : completion('{"2": "Au revoir {name}"}')
+    })
+
+    await expect(translate(locale, items)).resolves.toEqual({
+      '1': 'Bonjour {name}',
+      '2': 'Au revoir {name}'
+    })
+    expect(peakRequests).toBe(1)
   })
 
   it('defers a single string whose translation keeps truncating', async () => {


### PR DESCRIPTION
## Summary

Keep recursive truncation recovery within the configured translation request concurrency. Follow-up to #15229 for [split fan-out](https://github.com/Comfy-Org/ComfyUI_frontend/pull/15229#discussion_r3907473402) and [settle-before-rethrow coverage](https://github.com/Comfy-Org/ComfyUI_frontend/pull/15229#discussion_r3907473413).

## Changes

- **What**: Await recursive split batches sequentially so each request-pool worker owns at most one live OpenAI request.
- **What**: Add regressions for split peak concurrency and in-flight worker settlement before error propagation.

## Review Focus

Confirm sequential split recovery is the desired way to preserve the existing `requestConcurrency` contract.
