### PR TITLE
test(agent): use unknown for tooltip directive stub value types

### DIFF
--- a/src/workbench/extensions/agent/components/agent/Composer.test.ts
+++ b/src/workbench/extensions/agent/components/agent/Composer.test.ts
@@ -12,12 +12,12 @@ import { i18n } from '@/i18n'
 import { useAgentRunModeStore } from '../../stores/agent/agentRunModeStore'
 import Composer from './Composer.vue'
 
-const tooltipBindings = new WeakMap<Element, DirectiveBinding['value']>()
+const tooltipBindings = new WeakMap<Element, unknown>()
 const tooltipDirectiveStub = {
-  mounted(element: Element, binding: DirectiveBinding) {
+  mounted(element: Element, binding: DirectiveBinding<unknown>) {
     tooltipBindings.set(element, binding.value)
   },
-  updated(element: Element, binding: DirectiveBinding) {
+  updated(element: Element, binding: DirectiveBinding<unknown>) {
     tooltipBindings.set(element, binding.value)
   }
 }

--- a/src/workbench/extensions/agent/components/agent/PanelHeader.test.ts
+++ b/src/workbench/extensions/agent/components/agent/PanelHeader.test.ts
@@ -7,12 +7,12 @@ import { i18n } from '@/i18n'
 
 import PanelHeader from './PanelHeader.vue'
 
-const tooltipBindings = new WeakMap<Element, DirectiveBinding['value']>()
+const tooltipBindings = new WeakMap<Element, unknown>()
 const tooltipDirectiveStub = {
-  mounted(element: Element, binding: DirectiveBinding) {
+  mounted(element: Element, binding: DirectiveBinding<unknown>) {
     tooltipBindings.set(element, binding.value)
   },
-  updated(element: Element, binding: DirectiveBinding) {
+  updated(element: Element, binding: DirectiveBinding<unknown>) {
     tooltipBindings.set(element, binding.value)
   }
 }


### PR DESCRIPTION
## Summary

Follow-up to #16295 addressing a dismissed CodeRabbit Minor nit (comment 3904813853).

## Changes

- Changed `WeakMap<Element, DirectiveBinding["value"]>` → `WeakMap<Element, unknown>` in `Composer.test.ts` and `PanelHeader.test.ts`
- Changed `DirectiveBinding` → `DirectiveBinding<unknown>` in mounted/updated hook parameters in both test files

CodeRabbit suggested using explicit `unknown` value types instead of relying on the default `any` from `DirectiveBinding`. This improves type safety in the tooltip directive stubs.

## Verification

- `pnpm test:unit` — 50/50 passed
- `pnpm lint` — 0 errors (187 pre-existing warnings)
- `pnpm typecheck` — passed
- `pnpm format` — no changes

<!-- authored-by:agent cheap-drain -->