### PR TITLE
test(agent): use unknown for tooltip directive stub value types

### DIFF
--- a/src/workbench/extensions/agent/components/agent/Composer.test.ts
+++ b/src/workbench/extensions/agent/components/agent/Composer.test.ts
@@ -12,12 +12,12 @@ import { i18n } from '@/i18n'
 import { useAgentRunModeStore } from '../../stores/agent/agentRunModeStore'
 import Composer from './Composer.vue'
 
-const tooltipBindings = new WeakMap<Element, DirectiveBinding['value']>()
+const tooltipBindings = new WeakMap<Element, unknown>()
 const tooltipDirectiveStub = {
-  mounted(element: Element, binding: DirectiveBinding) {
+  mounted(element: Element, binding: DirectiveBinding<unknown>) {
     tooltipBindings.set(element, binding.value)
   },
-  updated(element: Element, binding: DirectiveBinding) {
+  updated(element: Element, binding: DirectiveBinding<unknown>) {
     tooltipBindings.set(element, binding.value)
   }
 }

--- a/src/workbench/extensions/agent/components/agent/PanelHeader.test.ts
+++ b/src/workbench/extensions/agent/components/agent/PanelHeader.test.ts
@@ -7,12 +7,12 @@ import { i18n } from '@/i18n'
 
 import PanelHeader from './PanelHeader.vue'
 
-const tooltipBindings = new WeakMap<Element, DirectiveBinding['value']>()
+const tooltipBindings = new WeakMap<Element, unknown>()
 const tooltipDirectiveStub = {
-  mounted(element: Element, binding: DirectiveBinding) {
+  mounted(element: Element, binding: DirectiveBinding<unknown>) {
     tooltipBindings.set(element, binding.value)
   },
-  updated(element: Element, binding: DirectiveBinding) {
+  updated(element: Element, binding: DirectiveBinding<unknown>) {
     tooltipBindings.set(element, binding.value)
   }
 }


### PR DESCRIPTION
Follow-up to #16295 addressing a dismissed CodeRabbit Minor nit.

Vue 3.5 declares `DirectiveBinding<Value = any>`. The tooltip directive stubs in `Composer.test.ts` and `PanelHeader.test.ts` used `DirectiveBinding['value']` (which resolves to `any`) for the `WeakMap` value type and bare `DirectiveBinding` (defaults to `DirectiveBinding<any>`) for the hook parameters. Both are now `DirectiveBinding<unknown>` / `WeakMap<Element, unknown>` so the stubs do not leak `any` into `binding.value`.

- Fixes follow-up nit from #16295

<!-- authored-by:agent cheap-drain -->