### PR TITLE
fix(billing): keep the total-due divider off the credits row

### DIFF
--- a/src/platform/workspace/components/SubscriptionTransitionPreviewWorkspace.vue
+++ b/src/platform/workspace/components/SubscriptionTransitionPreviewWorkspace.vue
@@ -161,14 +161,7 @@
 
       <!-- Total Due (immediate changes carry their addends: one sum under
            one divider, per Figma 5344-35724) -->
-      <div
-        :class="
-          cn(
-            'flex flex-col gap-2 border-t border-border-subtle pt-6',
-            !isImmediate && 'mt-10'
-          )
-        "
-      >
+      <div class="mt-10 flex flex-col gap-2 border-t border-border-subtle pt-6">
         <template v-if="isImmediate && previewData.discounts?.length">
           <div class="flex items-center justify-between text-muted-foreground">
             <span>{{ $t('subscription.preview.discountComposition') }}</span>


### PR DESCRIPTION
The total-due divider's top margin was conditional:

```
'flex flex-col gap-2 border-t border-border-subtle pt-6',
!isImmediate && 'mt-10'
```

A scheduled change got `mt-10`; an immediate one got nothing. Since `pt-6` only pads *below* the rule, an immediate change put the line flush against the bottom of the credits row with padding on one side only.

A yearly plan hides it — `refillReplacesNote` renders between the row and the divider and fills the gap — so it looked correct on yearly and cramped on monthly, which is why it survived review.

The margin is now unconditional. Scheduled changes are unaffected; they already had it.