### PR TITLE
fix(billing): let the customer pay again after a failed bank verification

### DIFF
--- a/src/platform/workspace/components/SubscriptionAddPaymentPreviewWorkspace.confirmLock.test.ts
+++ b/src/platform/workspace/components/SubscriptionAddPaymentPreviewWorkspace.confirmLock.test.ts
@@ -1,0 +1,100 @@
+import { render, screen } from '@testing-library/vue'
+import { describe, expect, it } from 'vitest'
+import { createI18n } from 'vue-i18n'
+
+import enMessages from '@/locales/en/main.json'
+
+import type {
+  PreviewSubscribeResponse,
+  SavedPaymentMethod
+} from '@/platform/workspace/api/workspaceApi'
+
+import SubscriptionAddPaymentPreviewWorkspace from './SubscriptionAddPaymentPreviewWorkspace.vue'
+
+/**
+ * Real i18n on purpose: the sibling suite mocks vue-i18n, so it can only see
+ * translation keys. These assert the button the way a customer reads it.
+ */
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: { en: enMessages },
+  missingWarn: false,
+  fallbackWarn: false
+})
+
+const previewData: PreviewSubscribeResponse = {
+  allowed: true,
+  amount_due_cents: 3500,
+  cost_today_cents: 3500,
+  cost_next_period_cents: 3500,
+  credits_today_cents: 0,
+  credits_next_period_cents: 0,
+  currency: 'usd',
+  effective_at: '2026-06-19T00:00:00Z',
+  is_immediate: true,
+  transition_type: 'upgrade',
+  quote_id: 'q_1',
+  quote_version: 1,
+  new_plan: {
+    slug: 'creator-monthly',
+    tier: 'CREATOR',
+    duration: 'MONTHLY',
+    price_cents: 3500,
+    credits_cents: 0,
+    period_end: '2027-06-28T00:00:00Z',
+    seat_summary: {
+      seat_count: 1,
+      total_cost_cents: 3500,
+      total_credits_cents: 0
+    }
+  }
+}
+
+function renderPreview(
+  authenticationState: 'failed_retryable' | 'requires_action'
+) {
+  return render(SubscriptionAddPaymentPreviewWorkspace, {
+    props: {
+      tierKey: 'creator',
+      embeddedCheckoutEnabled: true,
+      previewData,
+      quoteIsCurrent: true,
+      savedMethods: [
+        {
+          id: 'pm_1',
+          type: 'card',
+          brand: 'visa',
+          last4: '4242',
+          is_default: true
+        } satisfies SavedPaymentMethod
+      ],
+      authenticationState
+    },
+    global: {
+      plugins: [i18n],
+      stubs: { UnifiedStripePaymentSelector: true }
+    }
+  })
+}
+
+describe('SubscriptionAddPaymentPreviewWorkspace — confirm lock', () => {
+  it('keeps the pay action live after a failed challenge', () => {
+    renderPreview('failed_retryable')
+
+    // The intent has fallen back to requires_payment_method; a fresh attempt
+    // is the only way forward, so the action that starts one must not be
+    // locked behind the failure that ended the last one.
+    expect(
+      screen.getByRole('button', { name: 'Pay and subscribe' })
+    ).toBeEnabled()
+  })
+
+  it('locks the pay action while a challenge is still open', () => {
+    renderPreview('requires_action')
+
+    expect(
+      screen.getByRole('button', { name: 'Pay and subscribe' })
+    ).toBeDisabled()
+  })
+})

--- a/src/platform/workspace/components/SubscriptionAddPaymentPreviewWorkspace.confirmLock.test.ts
+++ b/src/platform/workspace/components/SubscriptionAddPaymentPreviewWorkspace.confirmLock.test.ts
@@ -52,7 +52,9 @@ const previewData: PreviewSubscribeResponse = {
 }
 
 function renderPreview(
-  authenticationState: 'failed_retryable' | 'requires_action'
+  recovery:
+    | { authenticationState: 'failed_retryable' | 'requires_action' }
+    | { reconciliationOperationId: string }
 ) {
   return render(SubscriptionAddPaymentPreviewWorkspace, {
     props: {
@@ -69,7 +71,7 @@ function renderPreview(
           is_default: true
         } satisfies SavedPaymentMethod
       ],
-      authenticationState
+      ...recovery
     },
     global: {
       plugins: [i18n],
@@ -80,7 +82,7 @@ function renderPreview(
 
 describe('SubscriptionAddPaymentPreviewWorkspace — confirm lock', () => {
   it('keeps the pay action live after a failed challenge', () => {
-    renderPreview('failed_retryable')
+    renderPreview({ authenticationState: 'failed_retryable' })
 
     // The intent has fallen back to requires_payment_method; a fresh attempt
     // is the only way forward, so the action that starts one must not be
@@ -90,8 +92,16 @@ describe('SubscriptionAddPaymentPreviewWorkspace — confirm lock', () => {
     ).toBeEnabled()
   })
 
+  it('locks the pay action during a reconciliation hold', () => {
+    renderPreview({ reconciliationOperationId: 'op_1' })
+
+    expect(
+      screen.getByRole('button', { name: 'Pay and subscribe' })
+    ).toBeDisabled()
+  })
+
   it('locks the pay action while a challenge is still open', () => {
-    renderPreview('requires_action')
+    renderPreview({ authenticationState: 'requires_action' })
 
     expect(
       screen.getByRole('button', { name: 'Pay and subscribe' })

--- a/src/platform/workspace/components/SubscriptionAddPaymentPreviewWorkspace.test.ts
+++ b/src/platform/workspace/components/SubscriptionAddPaymentPreviewWorkspace.test.ts
@@ -142,65 +142,6 @@ describe('SubscriptionAddPaymentPreviewWorkspace', () => {
     expect(emitted().addCreditCard).toBeTruthy()
   })
 
-  it('keeps the pay action live after a failed challenge', () => {
-    render(SubscriptionAddPaymentPreviewWorkspace, {
-      props: {
-        tierKey: 'creator',
-        embeddedCheckoutEnabled: true,
-        previewData: previewFixture('MONTHLY', 3500),
-        quoteIsCurrent: true,
-        savedMethods: [
-          {
-            id: 'pm_1',
-            type: 'card',
-            brand: 'visa',
-            last4: '4242',
-            is_default: true
-          }
-        ],
-        authenticationState: 'failed_retryable'
-      },
-      global: globalOptions
-    })
-
-    // The intent has fallen back to requires_payment_method, so a fresh
-    // attempt is the only way forward — locking the action that starts one
-    // leaves the customer with nothing to press.
-    expect(
-      screen.getByRole('button', {
-        name: 'subscription.preview.payAndSubscribe'
-      })
-    ).toBeEnabled()
-  })
-
-  it('locks the pay action while a challenge is still open', () => {
-    render(SubscriptionAddPaymentPreviewWorkspace, {
-      props: {
-        tierKey: 'creator',
-        embeddedCheckoutEnabled: true,
-        previewData: previewFixture('MONTHLY', 3500),
-        quoteIsCurrent: true,
-        savedMethods: [
-          {
-            id: 'pm_1',
-            type: 'card',
-            brand: 'visa',
-            last4: '4242',
-            is_default: true
-          }
-        ],
-        authenticationState: 'requires_action'
-      },
-      global: globalOptions
-    })
-
-    expect(
-      screen.getByRole('button', {
-        name: 'subscription.preview.payAndSubscribe'
-      })
-    ).toBeDisabled()
-  })
-
   it('falls back to subscription confirmation when quote identity is missing', async () => {
     const quote = previewFixture('MONTHLY', 3500)
     delete quote.quote_id

--- a/src/platform/workspace/components/SubscriptionAddPaymentPreviewWorkspace.test.ts
+++ b/src/platform/workspace/components/SubscriptionAddPaymentPreviewWorkspace.test.ts
@@ -142,6 +142,65 @@ describe('SubscriptionAddPaymentPreviewWorkspace', () => {
     expect(emitted().addCreditCard).toBeTruthy()
   })
 
+  it('keeps the pay action live after a failed challenge', () => {
+    render(SubscriptionAddPaymentPreviewWorkspace, {
+      props: {
+        tierKey: 'creator',
+        embeddedCheckoutEnabled: true,
+        previewData: previewFixture('MONTHLY', 3500),
+        quoteIsCurrent: true,
+        savedMethods: [
+          {
+            id: 'pm_1',
+            type: 'card',
+            brand: 'visa',
+            last4: '4242',
+            is_default: true
+          }
+        ],
+        authenticationState: 'failed_retryable'
+      },
+      global: globalOptions
+    })
+
+    // The intent has fallen back to requires_payment_method, so a fresh
+    // attempt is the only way forward — locking the action that starts one
+    // leaves the customer with nothing to press.
+    expect(
+      screen.getByRole('button', {
+        name: 'subscription.preview.payAndSubscribe'
+      })
+    ).toBeEnabled()
+  })
+
+  it('locks the pay action while a challenge is still open', () => {
+    render(SubscriptionAddPaymentPreviewWorkspace, {
+      props: {
+        tierKey: 'creator',
+        embeddedCheckoutEnabled: true,
+        previewData: previewFixture('MONTHLY', 3500),
+        quoteIsCurrent: true,
+        savedMethods: [
+          {
+            id: 'pm_1',
+            type: 'card',
+            brand: 'visa',
+            last4: '4242',
+            is_default: true
+          }
+        ],
+        authenticationState: 'requires_action'
+      },
+      global: globalOptions
+    })
+
+    expect(
+      screen.getByRole('button', {
+        name: 'subscription.preview.payAndSubscribe'
+      })
+    ).toBeDisabled()
+  })
+
   it('falls back to subscription confirmation when quote identity is missing', async () => {
     const quote = previewFixture('MONTHLY', 3500)
     delete quote.quote_id

--- a/src/platform/workspace/components/SubscriptionAddPaymentPreviewWorkspace.vue
+++ b/src/platform/workspace/components/SubscriptionAddPaymentPreviewWorkspace.vue
@@ -373,6 +373,7 @@ import type {
   PreviewSubscribeResponse,
   SavedPaymentMethod
 } from '@/platform/workspace/api/workspaceApi'
+import { isVerificationRecoveryActive } from '@/platform/workspace/utils/verificationRecovery'
 import { cn } from '@comfyorg/tailwind-utils'
 
 import SubscriptionTermsNote from './SubscriptionTermsNote.vue'
@@ -455,15 +456,12 @@ const quoteReady = computed(
     Boolean(previewData?.quote_id) &&
     previewData?.quote_version !== undefined
 )
-// A failed challenge is over: the intent has fallen back to
-// requires_payment_method and the only way forward is a fresh attempt, so the
-// confirm action has to stay live. requires_action and a reconciliation hold
-// are genuinely in flight and still lock it.
-const verificationRecoveryActive = computed(
-  () =>
-    embeddedCheckoutEnabled &&
-    (authenticationState === 'requires_action' ||
-      Boolean(reconciliationOperationId))
+const verificationRecoveryActive = computed(() =>
+  isVerificationRecoveryActive({
+    embeddedCheckoutEnabled,
+    authenticationState,
+    reconciliationOperationId
+  })
 )
 const quoteIsUsable = computed(() => !embeddedCheckoutEnabled || quoteIsCurrent)
 

--- a/src/platform/workspace/components/SubscriptionAddPaymentPreviewWorkspace.vue
+++ b/src/platform/workspace/components/SubscriptionAddPaymentPreviewWorkspace.vue
@@ -455,11 +455,14 @@ const quoteReady = computed(
     Boolean(previewData?.quote_id) &&
     previewData?.quote_version !== undefined
 )
+// A failed challenge is over: the intent has fallen back to
+// requires_payment_method and the only way forward is a fresh attempt, so the
+// confirm action has to stay live. requires_action and a reconciliation hold
+// are genuinely in flight and still lock it.
 const verificationRecoveryActive = computed(
   () =>
     embeddedCheckoutEnabled &&
     (authenticationState === 'requires_action' ||
-      authenticationState === 'failed_retryable' ||
       Boolean(reconciliationOperationId))
 )
 const quoteIsUsable = computed(() => !embeddedCheckoutEnabled || quoteIsCurrent)

--- a/src/platform/workspace/components/SubscriptionTransitionPreviewWorkspace.confirmLock.test.ts
+++ b/src/platform/workspace/components/SubscriptionTransitionPreviewWorkspace.confirmLock.test.ts
@@ -1,0 +1,117 @@
+import userEvent from '@testing-library/user-event'
+import { render, screen } from '@testing-library/vue'
+import { describe, expect, it, vi } from 'vitest'
+import { computed } from 'vue'
+import { createI18n } from 'vue-i18n'
+
+import enMessages from '@/locales/en/main.json'
+
+import type { PreviewSubscribeResponse } from '@/platform/workspace/api/workspaceApi'
+
+import SubscriptionTransitionPreviewWorkspace from './SubscriptionTransitionPreviewWorkspace.vue'
+
+/**
+ * Real i18n on purpose, mirroring the AddPayment confirm-lock suite: these
+ * assert the confirm button the way a customer reads it. This is the
+ * upgrade/downgrade path — the one where the staging repro of the locked
+ * confirm was found.
+ */
+const { mockSubscription } = vi.hoisted(() => ({
+  mockSubscription: {
+    value: null as { isCancelled: boolean; endDate: string | null } | null
+  }
+}))
+
+vi.mock('@/composables/billing/useBillingContext', () => ({
+  useBillingContext: () => ({
+    subscription: computed(() => mockSubscription.value)
+  })
+}))
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: { en: enMessages },
+  missingWarn: false,
+  fallbackWarn: false
+})
+
+const previewData: PreviewSubscribeResponse = {
+  allowed: true,
+  transition_type: 'upgrade',
+  effective_at: '2026-08-01T00:00:00Z',
+  is_immediate: true,
+  cost_today_cents: 1500,
+  cost_next_period_cents: 3500,
+  credits_today_cents: 0,
+  credits_next_period_cents: 0,
+  quote_id: 'quote_1',
+  quote_version: 1,
+  amount_due_cents: 1500,
+  currency: 'usd',
+  renewal_amount_cents: 3500,
+  renewal_at: '2026-09-15T00:00:00Z',
+  new_plan: {
+    slug: 'creator-monthly',
+    tier: 'CREATOR',
+    duration: 'MONTHLY',
+    price_cents: 3500,
+    credits_cents: 0,
+    period_end: '2026-09-15T00:00:00Z',
+    seat_summary: {
+      seat_count: 1,
+      total_cost_cents: 3500,
+      total_credits_cents: 0
+    }
+  }
+}
+
+function renderPreview(
+  recovery:
+    | {
+        authenticationState: 'failed_retryable' | 'requires_action'
+        canRetryAuthentication?: boolean
+      }
+    | { reconciliationOperationId: string }
+) {
+  mockSubscription.value = { isCancelled: false, endDate: null }
+  return render(SubscriptionTransitionPreviewWorkspace, {
+    props: {
+      previewData,
+      quoteIsCurrent: true,
+      embeddedCheckoutEnabled: true,
+      ...recovery
+    },
+    global: { plugins: [i18n] }
+  })
+}
+
+describe('SubscriptionTransitionPreviewWorkspace — confirm lock', () => {
+  it('keeps the confirm action live after a failed challenge', async () => {
+    const { emitted } = renderPreview({
+      authenticationState: 'failed_retryable',
+      canRetryAuthentication: true
+    })
+
+    const confirm = screen.getByRole('button', { name: 'Confirm upgrade' })
+    expect(confirm).toBeEnabled()
+    await userEvent.click(confirm)
+    expect(emitted().confirm).toBeTruthy()
+  })
+
+  it('locks the confirm action while a challenge is still open', () => {
+    renderPreview({ authenticationState: 'requires_action' })
+
+    expect(
+      screen.getByRole('button', { name: 'Confirm upgrade' })
+    ).toBeDisabled()
+  })
+
+  it('locks the confirm action during a reconciliation hold', () => {
+    renderPreview({ reconciliationOperationId: 'op_1' })
+
+    expect(
+      screen.getByRole('button', { name: 'Confirm upgrade' })
+    ).toBeDisabled()
+  })
+})

--- a/src/platform/workspace/components/SubscriptionTransitionPreviewWorkspace.vue
+++ b/src/platform/workspace/components/SubscriptionTransitionPreviewWorkspace.vue
@@ -309,6 +309,7 @@
 </template>
 
 <script setup lang="ts">
+import { isVerificationRecoveryActive } from '@/platform/workspace/utils/verificationRecovery'
 import { cn } from '@comfyorg/tailwind-utils'
 import { computed, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
@@ -376,15 +377,12 @@ const emit = defineEmits<{
 }>()
 
 const { locale, n, t, te } = useI18n()
-// A failed challenge is over: the intent has fallen back to
-// requires_payment_method and the only way forward is a fresh attempt, so the
-// confirm action has to stay live. requires_action and a reconciliation hold
-// are genuinely in flight and still lock it.
-const verificationRecoveryActive = computed(
-  () =>
-    embeddedCheckoutEnabled &&
-    (authenticationState === 'requires_action' ||
-      Boolean(reconciliationOperationId))
+const verificationRecoveryActive = computed(() =>
+  isVerificationRecoveryActive({
+    embeddedCheckoutEnabled,
+    authenticationState,
+    reconciliationOperationId
+  })
 )
 const quoteIsUsable = computed(() => !embeddedCheckoutEnabled || quoteIsCurrent)
 const interactionLocked = computed(() => isLoading || isApplyingPromotionCode)

--- a/src/platform/workspace/components/SubscriptionTransitionPreviewWorkspace.vue
+++ b/src/platform/workspace/components/SubscriptionTransitionPreviewWorkspace.vue
@@ -376,11 +376,14 @@ const emit = defineEmits<{
 }>()
 
 const { locale, n, t, te } = useI18n()
+// A failed challenge is over: the intent has fallen back to
+// requires_payment_method and the only way forward is a fresh attempt, so the
+// confirm action has to stay live. requires_action and a reconciliation hold
+// are genuinely in flight and still lock it.
 const verificationRecoveryActive = computed(
   () =>
     embeddedCheckoutEnabled &&
     (authenticationState === 'requires_action' ||
-      authenticationState === 'failed_retryable' ||
       Boolean(reconciliationOperationId))
 )
 const quoteIsUsable = computed(() => !embeddedCheckoutEnabled || quoteIsCurrent)

--- a/src/platform/workspace/utils/verificationRecovery.ts
+++ b/src/platform/workspace/utils/verificationRecovery.ts
@@ -1,0 +1,20 @@
+import type { BillingAuthenticationState } from '@/platform/workspace/api/workspaceApi'
+
+/**
+ * Whether the checkout confirm action must stay locked for a verification
+ * still in flight. A failed challenge is over — the intent has fallen back to
+ * requires_payment_method, so a fresh attempt is the recovery and the action
+ * stays live. requires_action and a reconciliation hold genuinely are in
+ * flight and lock it.
+ */
+export function isVerificationRecoveryActive(options: {
+  embeddedCheckoutEnabled: boolean
+  authenticationState: BillingAuthenticationState | null
+  reconciliationOperationId: string | null
+}): boolean {
+  return (
+    options.embeddedCheckoutEnabled &&
+    (options.authenticationState === 'requires_action' ||
+      Boolean(options.reconciliationOperationId))
+  )
+}


### PR DESCRIPTION
`verificationRecoveryActive` grouped three states together and disabled the confirm action for all of them:

```ts
authenticationState === 'requires_action' ||
authenticationState === 'failed_retryable' ||
Boolean(reconciliationOperationId)
```

Two of those are genuinely in flight. `failed_retryable` is not — the challenge is over, the PaymentIntent has fallen back to `requires_payment_method`, and the only thing that moves the customer forward is a fresh attempt. So the state that most needs the confirm button was the one disabling it, leaving a failure notice and nothing to press.

Both preview components carry their own copy of the computed; both are fixed.

## Not a retry

Deliberately not the same as resuming a challenge. `stripe.handleNextAction()` cannot resume a finished one — that is what #16123 removes. Pressing confirm again starts a new attempt with a new challenge, which is the correct recovery.

## Tests

Two cases pinned: confirm stays enabled on `failed_retryable`, and stays disabled on `requires_action` so the in-flight lock does not regress.