### PR TITLE
feat(website): agent beta waitlist page

### DIFF
--- a/apps/website/src/components/agent/AgentBetaWaitlistForm.test.ts
+++ b/apps/website/src/components/agent/AgentBetaWaitlistForm.test.ts
@@ -1,0 +1,184 @@
+// @vitest-environment happy-dom
+import userEvent from '@testing-library/user-event'
+import { fireEvent, render, screen } from '@testing-library/vue'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import AgentBetaWaitlistForm from './AgentBetaWaitlistForm.vue'
+
+const hoisted = vi.hoisted(() => ({
+  isEnabled: true,
+  preload: vi.fn(),
+  submit: vi.fn().mockResolvedValue(undefined)
+}))
+
+vi.mock('../../scripts/customerio', () => ({
+  get isDownloadLinkRequestEnabled() {
+    return hoisted.isEnabled
+  },
+  joinAgentBetaWaitlist: hoisted.submit,
+  preloadDownloadLinkAnalytics: hoisted.preload
+}))
+
+const APPLICATION_URL = 'https://form.typeform.com/to/UqL3PpAM'
+
+describe('AgentBetaWaitlistForm', () => {
+  let openSpy: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    hoisted.isEnabled = true
+    hoisted.submit.mockReset().mockResolvedValue(undefined)
+    hoisted.preload.mockClear()
+    openSpy = vi.fn()
+    vi.stubGlobal('open', openSpy)
+  })
+
+  it('renders nothing when the write key is not configured', () => {
+    hoisted.isEnabled = false
+    render(AgentBetaWaitlistForm)
+    expect(screen.queryByRole('textbox')).toBeNull()
+    expect(hoisted.preload).not.toHaveBeenCalled()
+  })
+
+  it('preloads the SDK when the form mounts', () => {
+    render(AgentBetaWaitlistForm)
+    expect(hoisted.preload).toHaveBeenCalledOnce()
+  })
+
+  it('shows an inline validation message for an invalid email and sends nothing', async () => {
+    const user = userEvent.setup()
+    render(AgentBetaWaitlistForm)
+
+    await user.type(screen.getByRole('textbox'), 'not-an-email')
+    await user.click(screen.getByRole('button', { name: /join the waitlist/i }))
+
+    const alert = await screen.findByRole('alert')
+    expect(alert.textContent).toMatch(/enter a valid email address/i)
+    const input = screen.getByRole('textbox')
+    expect(input.getAttribute('aria-invalid')).toBe('true')
+    expect(input.getAttribute('aria-describedby')).toBe(alert.id)
+    expect(hoisted.submit).not.toHaveBeenCalled()
+    expect(openSpy).not.toHaveBeenCalled()
+  })
+
+  it('fakes success without sending anything when the honeypot is filled', async () => {
+    const user = userEvent.setup()
+    render(AgentBetaWaitlistForm)
+
+    const visibleInput = screen.getByRole('textbox')
+    await user.type(visibleInput, 'someone@example.com')
+    const decoy = screen
+      .getAllByRole('textbox', { hidden: true })
+      .find((input) => input !== visibleInput)!
+    await fireEvent.update(decoy, 'spam corp')
+    await user.click(screen.getByRole('button', { name: /join the waitlist/i }))
+
+    const confirmation = await screen.findByRole('status')
+    expect(confirmation.textContent).toMatch(/you're on the waitlist/i)
+    expect(hoisted.submit).not.toHaveBeenCalled()
+    // A bot must not be handed the real application form either.
+    expect(openSpy).not.toHaveBeenCalled()
+  })
+
+  it('shows pending feedback, then replaces the form with confirmation', async () => {
+    let resolveSubmit!: () => void
+    hoisted.submit.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveSubmit = resolve
+        })
+    )
+    const user = userEvent.setup()
+    render(AgentBetaWaitlistForm)
+
+    await user.type(screen.getByRole('textbox'), 'someone@example.com')
+    await user.click(screen.getByRole('button', { name: /join the waitlist/i }))
+
+    const pendingButton = screen.getByRole('button', { name: /joining/i })
+    expect(pendingButton.getAttribute('aria-busy')).toBe('true')
+    expect((pendingButton as HTMLButtonElement).disabled).toBe(true)
+    expect(hoisted.submit).toHaveBeenCalledWith('someone@example.com')
+
+    resolveSubmit()
+
+    const confirmation = await screen.findByRole('status')
+    expect(confirmation.textContent).toMatch(/you're on the waitlist/i)
+    expect(confirmation.textContent).toContain('someone@example.com')
+    expect(screen.queryByRole('textbox')).toBeNull()
+    // eslint-disable-next-line testing-library/no-node-access
+    expect(document.activeElement).toBe(confirmation)
+  })
+
+  it('shows a retryable failure and succeeds on retry', async () => {
+    hoisted.submit.mockRejectedValueOnce(new Error('network down'))
+    const user = userEvent.setup()
+    render(AgentBetaWaitlistForm)
+
+    await user.type(screen.getByRole('textbox'), 'someone@example.com')
+    await user.click(screen.getByRole('button', { name: /join the waitlist/i }))
+
+    expect((await screen.findByRole('alert')).textContent).toMatch(
+      /something went wrong/i
+    )
+    expect(screen.getByRole('textbox')).toBeTruthy()
+
+    await user.click(screen.getByRole('button', { name: /join the waitlist/i }))
+
+    expect((await screen.findByRole('status')).textContent).toMatch(
+      /you're on the waitlist/i
+    )
+    expect(hoisted.submit).toHaveBeenCalledTimes(2)
+    // Retrying the capture must not spawn a second application tab.
+    expect(openSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('opens the application form in a new tab on submit', async () => {
+    const user = userEvent.setup()
+    render(AgentBetaWaitlistForm)
+
+    await user.type(screen.getByRole('textbox'), 'someone@example.com')
+    await user.click(screen.getByRole('button', { name: /join the waitlist/i }))
+
+    expect(openSpy).toHaveBeenCalledWith(
+      APPLICATION_URL,
+      '_blank',
+      'noopener,noreferrer'
+    )
+  })
+
+  it('opens the application before awaiting the capture, so the click still counts', async () => {
+    // A popup blocker only honours window.open while the click's user
+    // activation is live, which an awaited network call would spend.
+    let resolveSubmit!: () => void
+    hoisted.submit.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveSubmit = resolve
+        })
+    )
+    const user = userEvent.setup()
+    render(AgentBetaWaitlistForm)
+
+    await user.type(screen.getByRole('textbox'), 'someone@example.com')
+    await user.click(screen.getByRole('button', { name: /join the waitlist/i }))
+
+    expect(screen.getByRole('button', { name: /joining/i })).toBeTruthy()
+    expect(openSpy).toHaveBeenCalledOnce()
+
+    resolveSubmit()
+    await screen.findByRole('status')
+  })
+
+  it('offers a fallback link when the browser blocks the new tab', async () => {
+    const user = userEvent.setup()
+    render(AgentBetaWaitlistForm)
+
+    await user.type(screen.getByRole('textbox'), 'someone@example.com')
+    await user.click(screen.getByRole('button', { name: /join the waitlist/i }))
+
+    await screen.findByRole('status')
+    const fallback = screen.getByRole('link', { name: /open them here/i })
+    expect(fallback.getAttribute('href')).toBe(APPLICATION_URL)
+    expect(fallback.getAttribute('target')).toBe('_blank')
+    expect(fallback.getAttribute('rel')).toBe('noopener noreferrer')
+  })
+})

--- a/apps/website/src/components/agent/AgentBetaWaitlistForm.test.ts
+++ b/apps/website/src/components/agent/AgentBetaWaitlistForm.test.ts
@@ -68,7 +68,9 @@ describe('AgentBetaWaitlistForm', () => {
     await user.type(visibleInput, 'someone@example.com')
     const decoy = screen
       .getAllByRole('textbox', { hidden: true })
-      .find((input) => input !== visibleInput)!
+      .find((input) => input !== visibleInput)
+    // Narrows, and fails on the missing honeypot rather than downstream.
+    if (!decoy) throw new Error('honeypot input was not rendered')
     await fireEvent.update(decoy, 'spam corp')
     await user.click(screen.getByRole('button', { name: /join the waitlist/i }))
 
@@ -111,7 +113,7 @@ describe('AgentBetaWaitlistForm', () => {
 
     const pendingButton = screen.getByRole('button', { name: /joining/i })
     expect(pendingButton.getAttribute('aria-busy')).toBe('true')
-    expect((pendingButton as HTMLButtonElement).disabled).toBe(true)
+    expect(pendingButton.hasAttribute('disabled')).toBe(true)
     expect(hoisted.submit).toHaveBeenCalledWith(
       'someone@example.com',
       'agent_beta_waitlist_joined'

--- a/apps/website/src/components/agent/AgentBetaWaitlistForm.test.ts
+++ b/apps/website/src/components/agent/AgentBetaWaitlistForm.test.ts
@@ -15,7 +15,7 @@ vi.mock('../../scripts/customerio', () => ({
   get isDownloadLinkRequestEnabled() {
     return hoisted.isEnabled
   },
-  joinAgentBetaWaitlist: hoisted.submit,
+  joinWaitlist: hoisted.submit,
   preloadDownloadLinkAnalytics: hoisted.preload
 }))
 
@@ -79,6 +79,22 @@ describe('AgentBetaWaitlistForm', () => {
     expect(openSpy).not.toHaveBeenCalled()
   })
 
+  it('tracks the signup under the caller-supplied event', async () => {
+    const user = userEvent.setup()
+    render(AgentBetaWaitlistForm, {
+      props: { signupEvent: 'cloud_beta_waitlist_joined' }
+    })
+
+    await user.type(screen.getByRole('textbox'), 'someone@example.com')
+    await user.click(screen.getByRole('button', { name: /join the waitlist/i }))
+
+    await screen.findByRole('status')
+    expect(hoisted.submit).toHaveBeenCalledWith(
+      'someone@example.com',
+      'cloud_beta_waitlist_joined'
+    )
+  })
+
   it('shows pending feedback, then replaces the form with confirmation', async () => {
     let resolveSubmit!: () => void
     hoisted.submit.mockImplementationOnce(
@@ -96,7 +112,10 @@ describe('AgentBetaWaitlistForm', () => {
     const pendingButton = screen.getByRole('button', { name: /joining/i })
     expect(pendingButton.getAttribute('aria-busy')).toBe('true')
     expect((pendingButton as HTMLButtonElement).disabled).toBe(true)
-    expect(hoisted.submit).toHaveBeenCalledWith('someone@example.com')
+    expect(hoisted.submit).toHaveBeenCalledWith(
+      'someone@example.com',
+      'agent_beta_waitlist_joined'
+    )
 
     resolveSubmit()
 

--- a/apps/website/src/components/agent/AgentBetaWaitlistForm.vue
+++ b/apps/website/src/components/agent/AgentBetaWaitlistForm.vue
@@ -1,0 +1,144 @@
+<script setup lang="ts">
+import { computed, nextTick, onMounted, ref, useId } from 'vue'
+
+import {
+  isDownloadLinkRequestEnabled,
+  joinAgentBetaWaitlist,
+  preloadDownloadLinkAnalytics
+} from '../../scripts/customerio'
+
+type FormStatus = 'idle' | 'invalid' | 'pending' | 'error' | 'success'
+
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+
+/** Longer intake form the waitlist email hands off to. */
+const APPLICATION_URL = 'https://form.typeform.com/to/UqL3PpAM'
+
+const email = ref('')
+const decoy = ref('')
+const submittedEmail = ref('')
+const status = ref<FormStatus>('idle')
+const errorMessageId = useId()
+const successRegion = ref<HTMLParagraphElement | null>(null)
+const applicationOpened = ref(false)
+
+const errorMessage = computed(() => {
+  if (status.value === 'invalid') return 'Please enter a valid email address.'
+  if (status.value === 'error') return 'Something went wrong. Please try again.'
+  return ''
+})
+
+onMounted(() => {
+  if (isDownloadLinkRequestEnabled) preloadDownloadLinkAnalytics()
+})
+
+// Removing the form drops keyboard/SR focus, so move it to the success message.
+async function showSuccess() {
+  status.value = 'success'
+  await nextTick()
+  successRegion.value?.focus()
+}
+
+// Called straight from the submit handler, before any await: the popup
+// blocker only honours window.open while the click's user activation is
+// still live, and awaiting the capture first spends it. Guarded so a retry
+// after a failed capture does not open a second tab.
+function openApplication() {
+  if (applicationOpened.value) return
+  applicationOpened.value = true
+  window.open(APPLICATION_URL, '_blank', 'noopener,noreferrer')
+}
+
+async function onSubmit() {
+  if (status.value === 'pending') return
+  if (decoy.value !== '') {
+    submittedEmail.value = email.value
+    await showSuccess()
+    return
+  }
+  if (!EMAIL_PATTERN.test(email.value)) {
+    status.value = 'invalid'
+    return
+  }
+  submittedEmail.value = email.value
+  status.value = 'pending'
+  openApplication()
+  try {
+    await joinAgentBetaWaitlist(submittedEmail.value)
+    await showSuccess()
+  } catch {
+    status.value = 'error'
+  }
+}
+</script>
+
+<template>
+  <div v-if="isDownloadLinkRequestEnabled">
+    <!-- The pill collapses into stacked full-width controls below 560px,
+         which is narrower than the `sm` breakpoint the rest of the site
+         uses, so the mobile rules are expressed as max-[560px] variants. -->
+    <form
+      v-if="status !== 'success'"
+      novalidate
+      class="bg-primary-comfy-ink-light mx-auto flex max-w-130 items-center rounded-3xl border border-[#f5f5f5]/25 p-2 max-[560px]:flex-wrap max-[560px]:gap-3 max-[560px]:border-0 max-[560px]:bg-transparent max-[560px]:p-0"
+      @submit.prevent="onSubmit"
+    >
+      <label for="agent-beta-email" class="sr-only">Email address</label>
+      <input
+        v-model="decoy"
+        type="text"
+        name="company"
+        tabindex="-1"
+        aria-hidden="true"
+        autocomplete="off"
+        class="absolute left-[-9999px] size-px"
+      />
+      <input
+        id="agent-beta-email"
+        v-model="email"
+        type="email"
+        name="email"
+        autocomplete="email"
+        placeholder="Type your email"
+        required
+        :aria-invalid="status === 'invalid' || undefined"
+        :aria-describedby="errorMessage ? errorMessageId : undefined"
+        class="max-[560px]:bg-primary-comfy-ink-light min-w-0 flex-1 border-0 bg-transparent px-5 py-3.5 text-sm text-primary-comfy-canvas outline-none placeholder:text-primary-comfy-canvas/70 focus-visible:rounded-2xl focus-visible:shadow-[inset_0_0_0_2px_var(--color-primary-comfy-yellow)] max-[560px]:w-full max-[560px]:basis-full max-[560px]:rounded-3xl max-[560px]:border max-[560px]:border-[#f5f5f5]/25 max-[560px]:px-5.5 max-[560px]:py-4"
+      />
+      <button
+        type="submit"
+        :disabled="status === 'pending'"
+        :aria-busy="status === 'pending'"
+        class="bg-primary-comfy-yellow flex-none cursor-pointer rounded-2xl border-0 px-7 py-[15px] text-sm font-bold tracking-[0.06em] text-primary-comfy-ink uppercase disabled:cursor-wait disabled:opacity-75 max-[560px]:w-full max-[560px]:px-6.5 max-[560px]:py-[17px]"
+      >
+        {{ status === 'pending' ? 'Joining…' : 'Join the waitlist' }}
+      </button>
+      <p
+        v-if="errorMessage"
+        :id="errorMessageId"
+        role="alert"
+        class="basis-full px-3 pb-2 text-[13px] text-[#ffb4a8]"
+      >
+        {{ errorMessage }}
+      </p>
+    </form>
+    <p
+      v-else
+      ref="successRegion"
+      role="status"
+      tabindex="-1"
+      class="bg-primary-comfy-ink-light focus:outline-primary-comfy-yellow mx-auto max-w-130 rounded-3xl border border-[#d6f24e]/55 px-6 py-5 text-base text-primary-comfy-canvas focus:outline-2 focus:outline-offset-[3px]"
+    >
+      You're on the waitlist! We'll email {{ submittedEmail }} when it's ready.
+      A few questions just opened in a new tab —
+      <a
+        :href="APPLICATION_URL"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="text-primary-comfy-yellow underline underline-offset-2 hover:opacity-70"
+        >open them here</a
+      >
+      if your browser blocked it.
+    </p>
+  </div>
+</template>

--- a/apps/website/src/components/agent/AgentBetaWaitlistForm.vue
+++ b/apps/website/src/components/agent/AgentBetaWaitlistForm.vue
@@ -3,9 +3,14 @@ import { computed, nextTick, onMounted, ref, useId } from 'vue'
 
 import {
   isDownloadLinkRequestEnabled,
-  joinAgentBetaWaitlist,
+  joinWaitlist,
   preloadDownloadLinkAnalytics
 } from '../../scripts/customerio'
+
+const { signupEvent = 'agent_beta_waitlist_joined' } = defineProps<{
+  /** Customer.io event tracked on a successful signup. */
+  signupEvent?: string
+}>()
 
 type FormStatus = 'idle' | 'invalid' | 'pending' | 'error' | 'success'
 
@@ -64,7 +69,7 @@ async function onSubmit() {
   status.value = 'pending'
   openApplication()
   try {
-    await joinAgentBetaWaitlist(submittedEmail.value)
+    await joinWaitlist(submittedEmail.value, signupEvent)
     await showSuccess()
   } catch {
     status.value = 'error'

--- a/apps/website/src/components/agent/AgentBetaWaitlistForm.vue
+++ b/apps/website/src/components/agent/AgentBetaWaitlistForm.vue
@@ -80,7 +80,7 @@ async function onSubmit() {
     <form
       v-if="status !== 'success'"
       novalidate
-      class="bg-primary-comfy-ink-light mx-auto flex max-w-130 items-center rounded-3xl border border-[#f5f5f5]/25 p-2 max-[560px]:flex-wrap max-[560px]:gap-3 max-[560px]:border-0 max-[560px]:bg-transparent max-[560px]:p-0"
+      class="bg-primary-comfy-ink-light mx-auto flex max-w-130 items-center rounded-3xl border border-primary-warm-white/25 p-2 max-[560px]:flex-wrap max-[560px]:gap-3 max-[560px]:border-0 max-[560px]:bg-transparent max-[560px]:p-0"
       @submit.prevent="onSubmit"
     >
       <label for="agent-beta-email" class="sr-only">Email address</label>
@@ -103,7 +103,7 @@ async function onSubmit() {
         required
         :aria-invalid="status === 'invalid' || undefined"
         :aria-describedby="errorMessage ? errorMessageId : undefined"
-        class="max-[560px]:bg-primary-comfy-ink-light min-w-0 flex-1 border-0 bg-transparent px-5 py-3.5 text-sm text-primary-comfy-canvas outline-none placeholder:text-primary-comfy-canvas/70 focus-visible:rounded-2xl focus-visible:shadow-[inset_0_0_0_2px_var(--color-primary-comfy-yellow)] max-[560px]:w-full max-[560px]:basis-full max-[560px]:rounded-3xl max-[560px]:border max-[560px]:border-[#f5f5f5]/25 max-[560px]:px-5.5 max-[560px]:py-4"
+        class="max-[560px]:bg-primary-comfy-ink-light min-w-0 flex-1 border-0 bg-transparent px-5 py-3.5 text-sm text-primary-comfy-canvas outline-none placeholder:text-primary-comfy-canvas/70 focus-visible:rounded-2xl focus-visible:shadow-[inset_0_0_0_2px_var(--color-primary-comfy-yellow)] max-[560px]:w-full max-[560px]:basis-full max-[560px]:rounded-3xl max-[560px]:border max-[560px]:border-primary-warm-white/25 max-[560px]:px-5.5 max-[560px]:py-4"
       />
       <button
         type="submit"
@@ -117,7 +117,7 @@ async function onSubmit() {
         v-if="errorMessage"
         :id="errorMessageId"
         role="alert"
-        class="basis-full px-3 pb-2 text-[13px] text-[#ffb4a8]"
+        class="text-destructive-light basis-full px-3 pb-2 text-[13px]"
       >
         {{ errorMessage }}
       </p>
@@ -127,7 +127,7 @@ async function onSubmit() {
       ref="successRegion"
       role="status"
       tabindex="-1"
-      class="bg-primary-comfy-ink-light focus:outline-primary-comfy-yellow mx-auto max-w-130 rounded-3xl border border-[#d6f24e]/55 px-6 py-5 text-base text-primary-comfy-canvas focus:outline-2 focus:outline-offset-[3px]"
+      class="bg-primary-comfy-ink-light focus:outline-primary-comfy-yellow border-primary-comfy-yellow/55 mx-auto max-w-130 rounded-3xl border px-6 py-5 text-base text-primary-comfy-canvas focus:outline-2 focus:outline-offset-[3px]"
     >
       You're on the waitlist! We'll email {{ submittedEmail }} when it's ready.
       A few questions just opened in a new tab —

--- a/apps/website/src/components/agent/agentCards.test.ts
+++ b/apps/website/src/components/agent/agentCards.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+
+import { agentCards } from './agentCards'
+
+describe('agentCards', () => {
+  it('pitches the four agent capabilities in order', () => {
+    expect(agentCards.map((card) => card.tag)).toEqual([
+      'Creative knowledge',
+      'Human-agent Multiplayer',
+      'Control & Iterate',
+      'Local and Cloud'
+    ])
+  })
+
+  it('gives every card a title and body to render', () => {
+    for (const card of agentCards) {
+      expect(card.title.length).toBeGreaterThan(0)
+      expect(card.body.length).toBeGreaterThan(0)
+    }
+  })
+
+  it('keeps every tag unique, since the tag is the card key', () => {
+    const tags = agentCards.map((card) => card.tag)
+
+    expect(new Set(tags).size).toBe(tags.length)
+  })
+})

--- a/apps/website/src/components/agent/agentCards.ts
+++ b/apps/website/src/components/agent/agentCards.ts
@@ -1,0 +1,33 @@
+/**
+ * Pitch cards for the agent landing page. Kept out of the `.astro`
+ * frontmatter so the `website-unit` gate can measure them: V8 cannot
+ * instrument `.astro` files.
+ */
+export interface AgentCard {
+  tag: string
+  title: string
+  body: string
+}
+
+export const agentCards: readonly AgentCard[] = [
+  {
+    tag: 'Creative knowledge',
+    title: 'Best practice can be delivered end to end',
+    body: "Up-to-date knowledge of all the latest models, ComfyUI extensions, parameters, and best workflows, curated by ComfyUI experts. Describe the content and asset you want. It is Comfy Agent's job to learn the technology and model details. It can run a project in auto mode and deliver the best result end to end."
+  },
+  {
+    tag: 'Human-agent Multiplayer',
+    title: 'Two of you edit at the same time',
+    body: "Build a big workflow with the agent in parallel. Watch the graph assemble. Mention a node or reference another workflow. Point at an error and it fixes it. Comfy Agent is fully aware of what's happening on the canvas."
+  },
+  {
+    tag: 'Control & Iterate',
+    title: 'The craft stays yours',
+    body: 'Every control ComfyUI gives you stays exactly where it is. You spend your time on composition, camera angles, masks, parameters, and polishing the details. Power users can always take over: open the nodes and check every single pixel.'
+  },
+  {
+    tag: 'Local and Cloud',
+    title: 'It runs where you run',
+    body: 'Same agent, works with you on your local machine or in Comfy Cloud. It walks you through all setups, builds the workflows, and chooses models based on your hardware. It suggests environment and deployment solutions for your workflow and dependencies.'
+  }
+]

--- a/apps/website/src/components/blocks/HeroWaitlist01.stories.ts
+++ b/apps/website/src/components/blocks/HeroWaitlist01.stories.ts
@@ -1,0 +1,46 @@
+import type { Meta, StoryObj } from '@storybook/vue3-vite'
+
+import HeroWaitlist01 from './HeroWaitlist01.vue'
+
+const meta: Meta<typeof HeroWaitlist01> = {
+  title: 'Website/Blocks/HeroWaitlist01',
+  component: HeroWaitlist01,
+  tags: ['autodocs'],
+  args: {
+    badgeText: 'AGENT',
+    title: 'The first agent for craft',
+    subtitle:
+      'An agent that lives inside ComfyUI, local and cloud. Describe what you want: it builds the workflow on your canvas with you, reviews assets, runs generations, and iterates until the result is production ready.',
+    footnote: "We'll prepare your account and email you when it's ready.",
+    signupEvent: 'agent_beta_waitlist_joined'
+  }
+}
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}
+
+export const NoBadge: Story = {
+  args: {
+    badgeText: undefined
+  }
+}
+
+export const TitleOnly: Story = {
+  args: {
+    badgeText: undefined,
+    subtitle: undefined,
+    footnote: undefined
+  }
+}
+
+/** A second waitlist reuses the block by naming its own Customer.io event. */
+export const OtherWaitlist: Story = {
+  args: {
+    badgeText: 'CLOUD',
+    title: 'Early access to Comfy Cloud',
+    subtitle: 'Run your workflows on our hardware, with no local setup.',
+    signupEvent: 'cloud_beta_waitlist_joined'
+  }
+}

--- a/apps/website/src/components/blocks/HeroWaitlist01.test.ts
+++ b/apps/website/src/components/blocks/HeroWaitlist01.test.ts
@@ -1,0 +1,102 @@
+// @vitest-environment happy-dom
+import userEvent from '@testing-library/user-event'
+import { render, screen } from '@testing-library/vue'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ComponentProps } from 'vue-component-type-helpers'
+
+import HeroWaitlist01 from './HeroWaitlist01.vue'
+
+// The hero renders the real waitlist form, so the Customer.io module is stubbed
+// here for the same reason it is in the form's own test: to control the
+// write-key gate and to observe what a signup sends.
+const hoisted = vi.hoisted(() => ({
+  isEnabled: true,
+  preload: vi.fn(),
+  submit: vi.fn().mockResolvedValue(undefined)
+}))
+
+vi.mock('../../scripts/customerio', () => ({
+  get isDownloadLinkRequestEnabled() {
+    return hoisted.isEnabled
+  },
+  joinWaitlist: hoisted.submit,
+  preloadDownloadLinkAnalytics: hoisted.preload
+}))
+
+type HeroWaitlistProps = ComponentProps<typeof HeroWaitlist01>
+
+const requiredProps = {
+  title: 'The first agent for craft',
+  signupEvent: 'agent_beta_waitlist_joined'
+} satisfies HeroWaitlistProps
+
+function renderHero(props: Partial<HeroWaitlistProps> = {}) {
+  return render(HeroWaitlist01, { props: { ...requiredProps, ...props } })
+}
+
+describe('HeroWaitlist01', () => {
+  beforeEach(() => {
+    hoisted.isEnabled = true
+    hoisted.submit.mockReset().mockResolvedValue(undefined)
+    hoisted.preload.mockClear()
+    vi.stubGlobal('open', vi.fn())
+  })
+
+  it('renders the title as the h1', () => {
+    renderHero()
+
+    const heading = screen.getByRole('heading', { level: 1 })
+    expect(heading.textContent).toContain('The first agent for craft')
+  })
+
+  it('renders the badge only when badgeText is given', () => {
+    const { unmount } = renderHero({ badgeText: 'AGENT' })
+    expect(screen.getByText('AGENT')).toBeTruthy()
+    unmount()
+
+    renderHero()
+    expect(screen.queryByText('AGENT')).toBeNull()
+  })
+
+  it('renders the subtitle only when one is given', () => {
+    const subtitle = 'An agent that lives inside ComfyUI.'
+    const { unmount } = renderHero({ subtitle })
+    expect(screen.getByText(subtitle)).toBeTruthy()
+    unmount()
+
+    renderHero()
+    expect(screen.queryByText(subtitle)).toBeNull()
+  })
+
+  it('renders the footnote alongside the form when signup is enabled', () => {
+    renderHero({ footnote: "We'll email you when it's ready." })
+
+    expect(screen.getByRole('textbox')).toBeTruthy()
+    expect(screen.getByText("We'll email you when it's ready.")).toBeTruthy()
+  })
+
+  it('hides the footnote with the form when signup is disabled', () => {
+    hoisted.isEnabled = false
+    renderHero({ footnote: "We'll email you when it's ready." })
+
+    // A promise to email must never outlive the control that would collect it.
+    expect(screen.queryByRole('textbox')).toBeNull()
+    expect(screen.queryByText("We'll email you when it's ready.")).toBeNull()
+    // The heading still renders, so the hero is not blank.
+    expect(screen.getByRole('heading', { level: 1 })).toBeTruthy()
+  })
+
+  it('passes its signupEvent down to the form', async () => {
+    const user = userEvent.setup()
+    renderHero({ signupEvent: 'cloud_beta_waitlist_joined' })
+
+    await user.type(screen.getByRole('textbox'), 'someone@example.com')
+    await user.click(screen.getByRole('button', { name: /join the waitlist/i }))
+
+    await screen.findByRole('status')
+    expect(hoisted.submit).toHaveBeenCalledWith(
+      'someone@example.com',
+      'cloud_beta_waitlist_joined'
+    )
+  })
+})

--- a/apps/website/src/components/blocks/HeroWaitlist01.vue
+++ b/apps/website/src/components/blocks/HeroWaitlist01.vue
@@ -1,0 +1,96 @@
+<script setup lang="ts">
+import { cn } from '@comfyorg/tailwind-utils'
+
+import type { HTMLAttributes } from 'vue'
+
+import { isDownloadLinkRequestEnabled } from '../../scripts/customerio'
+import AgentBetaWaitlistForm from '../agent/AgentBetaWaitlistForm.vue'
+import ProductHeroBadge from '../common/ProductHeroBadge.vue'
+
+const {
+  badgeText,
+  title,
+  subtitle,
+  footnote,
+  signupEvent,
+  class: className
+} = defineProps<{
+  badgeText?: string
+  title: string
+  subtitle?: string
+  /**
+   * Sits under the form and is hidden alongside it when signup is disabled,
+   * so a promise to email never outlives the control that would collect it.
+   */
+  footnote?: string
+  /** Customer.io event tracked on a successful signup. */
+  signupEvent: string
+  class?: HTMLAttributes['class']
+}>()
+</script>
+
+<template>
+  <section
+    :class="
+      cn(
+        'relative isolate flex min-h-[56vh] items-center justify-center overflow-hidden px-6 pt-25 pb-12 text-primary-warm-white',
+        className
+      )
+    "
+  >
+    <!-- Plum wash -->
+    <div
+      aria-hidden="true"
+      class="animate-backdrop-sway absolute inset-[-20%] -z-4 bg-[radial-gradient(ellipse_50%_40%_at_30%_35%,color-mix(in_srgb,var(--color-primary-comfy-plum)_55%,transparent),transparent_70%),radial-gradient(ellipse_45%_45%_at_72%_62%,color-mix(in_srgb,var(--color-primary-comfy-plum)_38%,transparent),transparent_70%)] blur-2xl will-change-transform"
+    />
+
+    <!-- Even dot grid, then a brighter drifting cloud of dots masked over it -->
+    <div
+      aria-hidden="true"
+      class="absolute inset-0 -z-3 bg-[radial-gradient(circle,color-mix(in_srgb,var(--color-primary-warm-white)_16%,transparent)_1px,transparent_1.1px)] bg-size-[5px_5px]"
+    />
+    <div
+      aria-hidden="true"
+      class="animate-backdrop-drift absolute inset-0 -z-2 bg-[radial-gradient(circle,color-mix(in_srgb,var(--color-primary-warm-white)_42%,transparent)_1.15px,transparent_1.25px)] mask-[radial-gradient(circle,#000_0%,transparent_62%),radial-gradient(circle,#000_0%,transparent_58%),radial-gradient(circle,#000_0%,transparent_66%)] bg-size-[5px_5px] mask-[1100px_900px,800px_700px,1300px_1000px] mask-no-repeat will-change-[mask-position]"
+    />
+
+    <!-- Darkens the edges and blends the hero into the page background -->
+    <div
+      aria-hidden="true"
+      class="absolute inset-0 -z-1 bg-[linear-gradient(to_bottom,transparent_55%,var(--color-primary-comfy-ink)_92%),radial-gradient(ellipse_65%_50%_at_50%_50%,color-mix(in_srgb,var(--color-primary-comfy-ink)_72%,transparent)_0%,color-mix(in_srgb,var(--color-primary-comfy-ink)_90%,transparent)_65%,color-mix(in_srgb,var(--color-primary-comfy-ink)_98%,transparent)_100%)]"
+    />
+
+    <div class="relative mx-auto max-w-190 text-center">
+      <div
+        v-if="badgeText"
+        class="mx-auto mb-10 flex zoom-[0.85] justify-center"
+      >
+        <ProductHeroBadge :text="badgeText" />
+      </div>
+
+      <h1
+        class="mb-7 text-[clamp(28px,4.2vw,48px)]/[1.18] font-light tracking-[-0.02em] text-primary-warm-white"
+      >
+        {{ title }}
+      </h1>
+
+      <p
+        v-if="subtitle"
+        class="mx-auto mb-10 max-w-140 text-[clamp(16px,2vw,19px)]/[1.6] text-primary-warm-white/82"
+      >
+        {{ subtitle }}
+      </p>
+
+      <AgentBetaWaitlistForm :signup-event="signupEvent" />
+
+      <p
+        v-if="footnote && isDownloadLinkRequestEnabled"
+        class="mx-auto mt-5 text-[11px]/[1.5] text-primary-warm-white/55"
+      >
+        {{ footnote }}
+      </p>
+
+      <slot />
+    </div>
+  </section>
+</template>

--- a/apps/website/src/components/blocks/HeroWaitlist01.vue
+++ b/apps/website/src/components/blocks/HeroWaitlist01.vue
@@ -51,7 +51,7 @@ const {
     />
     <div
       aria-hidden="true"
-      class="animate-backdrop-drift absolute inset-0 -z-2 bg-[radial-gradient(circle,color-mix(in_srgb,var(--color-primary-warm-white)_42%,transparent)_1.15px,transparent_1.25px)] mask-[radial-gradient(circle,#000_0%,transparent_62%),radial-gradient(circle,#000_0%,transparent_58%),radial-gradient(circle,#000_0%,transparent_66%)] bg-size-[5px_5px] mask-[1100px_900px,800px_700px,1300px_1000px] mask-no-repeat will-change-[mask-position]"
+      class="animate-backdrop-drift absolute inset-0 -z-2 bg-[radial-gradient(circle,color-mix(in_srgb,var(--color-primary-warm-white)_42%,transparent)_1.15px,transparent_1.25px)] mask-[radial-gradient(circle,black_0%,transparent_62%),radial-gradient(circle,black_0%,transparent_58%),radial-gradient(circle,black_0%,transparent_66%)] bg-size-[5px_5px] mask-[1100px_900px,800px_700px,1300px_1000px] mask-no-repeat will-change-[mask-position]"
     />
 
     <!-- Darkens the edges and blends the hero into the page background -->

--- a/apps/website/src/config/indexing.ts
+++ b/apps/website/src/config/indexing.ts
@@ -15,6 +15,7 @@ const NOINDEX_PATHNAMES = new Set([
   ),
   ...LOCALE_PREFIXES.map((prefix) => `${prefix}/individual-submission`),
   ...LOCALE_PREFIXES.map((prefix) => `${prefix}/booking-confirmation`),
+  ...LOCALE_PREFIXES.map((prefix) => `${prefix}/agent`),
   ...LOCALE_PREFIXES.map((prefix) => `${prefix}/privacy-policy`),
   ...LOCALE_PREFIXES.map((prefix) => `${prefix}/terms-of-service`),
   ...LOCALE_PREFIXES.flatMap((prefix) =>

--- a/apps/website/src/config/llms-txt.test.ts
+++ b/apps/website/src/config/llms-txt.test.ts
@@ -30,6 +30,7 @@ const vercelRedirectSources = new Set<string>(
  */
 const EXCLUDED_PAGES = new Set([
   '/404',
+  '/agent', // unlisted agent beta waitlist page, noindex
   '/booking-confirmation', // post-form confirmation, no standalone content
   '/individual-submission', // gallery submission form
   '/payment/failed', // checkout return page

--- a/apps/website/src/config/routes.test.ts
+++ b/apps/website/src/config/routes.test.ts
@@ -121,6 +121,16 @@ describe('getRoutes flux3', () => {
   })
 })
 
+describe('getRoutes agent', () => {
+  it('serves the agent page at its canonical path for en', () => {
+    expect(getRoutes('en').agent).toBe('/agent')
+  })
+
+  it('serves the English-only agent page at its canonical path for zh-CN', () => {
+    expect(getRoutes('zh-CN').agent).toBe('/agent')
+  })
+})
+
 describe('getRoutes fdct', () => {
   it('serves the fdct page at its canonical path for en', () => {
     expect(getRoutes('en').fdct).toBe('/forward-deployed-creatives')

--- a/apps/website/src/config/routes.ts
+++ b/apps/website/src/config/routes.ts
@@ -24,6 +24,7 @@ const baseRoutes = {
   models: '/p/supported-models',
   modelsShowcase: '/models',
   mcp: '/mcp',
+  agent: '/agent',
   platform: '/platform',
   platformComfyApi: '/platform/comfy-api',
   platformModels: '/platform/models',
@@ -60,6 +61,9 @@ type Routes = typeof baseRoutes
 // Customer Agreement template), same reasoning. See the comment header
 // in src/pages/enterprise-msa.astro.
 //
+// agent: launch page is English-only for now; keep any route references on the
+// canonical path until a localized page exists.
+//
 // models: the supported-models catalog only exists at /p/supported-models;
 // there is no /<locale>/p/supported-models page, so a prefixed link 404s.
 //
@@ -67,6 +71,7 @@ type Routes = typeof baseRoutes
 // form, so no localized variant exists. See the comment header in
 // src/pages/minimax/license/professional-request.astro.
 const LOCALE_INVARIANT_ROUTE_KEYS = new Set<keyof Routes>([
+  'agent',
   'affiliates',
   'affiliateTerms',
   'termsOfService',

--- a/apps/website/src/pages/agent.astro
+++ b/apps/website/src/pages/agent.astro
@@ -12,20 +12,49 @@ import { isDownloadLinkRequestEnabled } from '../scripts/customerio'
   noindex
 >
   <!-- ============ HERO ============ -->
-  <section class="agent-hero">
-    <div class="wash" aria-hidden="true"></div>
-    <div class="dot-grid" aria-hidden="true"></div>
-    <div class="cloud" aria-hidden="true"></div>
-    <div class="vignette" aria-hidden="true"></div>
+  <section
+    class="relative isolate flex min-h-[56vh] items-center justify-center overflow-hidden px-6 pt-25 pb-12 text-primary-warm-white"
+  >
+    <!-- Plum wash -->
+    <div
+      aria-hidden="true"
+      class="animate-backdrop-sway absolute inset-[-20%] -z-4 bg-[radial-gradient(ellipse_50%_40%_at_30%_35%,color-mix(in_srgb,var(--color-primary-comfy-plum)_55%,transparent),transparent_70%),radial-gradient(ellipse_45%_45%_at_72%_62%,color-mix(in_srgb,var(--color-primary-comfy-plum)_38%,transparent),transparent_70%)] blur-[40px] will-change-transform"
+    >
+    </div>
 
-    <div class="inner">
-      <div class="badge-lockup">
+    <!-- Even dot grid, then a brighter drifting cloud of dots masked over it -->
+    <div
+      aria-hidden="true"
+      class="absolute inset-0 -z-3 bg-[radial-gradient(circle,color-mix(in_srgb,var(--color-primary-warm-white)_16%,transparent)_1px,transparent_1.1px)] bg-[size:5px_5px]"
+    >
+    </div>
+    <div
+      aria-hidden="true"
+      class="animate-backdrop-drift absolute inset-0 -z-2 bg-[radial-gradient(circle,color-mix(in_srgb,var(--color-primary-warm-white)_42%,transparent)_1.15px,transparent_1.25px)] bg-[size:5px_5px] [mask-image:radial-gradient(circle,#000_0%,transparent_62%),radial-gradient(circle,#000_0%,transparent_58%),radial-gradient(circle,#000_0%,transparent_66%)] [mask-repeat:no-repeat] [mask-size:1100px_900px,800px_700px,1300px_1000px] will-change-[mask-position]"
+    >
+    </div>
+
+    <!-- Darkens the edges and blends the hero into the page background -->
+    <div
+      aria-hidden="true"
+      class="absolute inset-0 -z-1 bg-[linear-gradient(to_bottom,transparent_55%,var(--color-primary-comfy-ink)_92%),radial-gradient(ellipse_65%_50%_at_50%_50%,color-mix(in_srgb,var(--color-primary-comfy-ink)_72%,transparent)_0%,color-mix(in_srgb,var(--color-primary-comfy-ink)_90%,transparent)_65%,color-mix(in_srgb,var(--color-primary-comfy-ink)_98%,transparent)_100%)]"
+    >
+    </div>
+
+    <div class="relative mx-auto max-w-190 text-center">
+      <div class="mx-auto mb-10 flex justify-center [zoom:0.85]">
         <ProductHeroBadge text="AGENT" />
       </div>
 
-      <h1>The first agent for craft</h1>
+      <h1
+        class="mb-7 text-[clamp(28px,4.2vw,48px)]/[1.18] font-light tracking-[-0.02em] text-primary-warm-white"
+      >
+        The first agent for craft
+      </h1>
 
-      <p class="sub">
+      <p
+        class="mx-auto mb-10 max-w-140 text-[clamp(16px,2vw,19px)]/[1.6] text-primary-warm-white/82"
+      >
         An agent that lives inside ComfyUI, local and cloud. Describe what you
         want: it builds the workflow on your canvas with you, reviews assets,
         runs generations, and iterates until the result is production ready.
@@ -37,7 +66,7 @@ import { isDownloadLinkRequestEnabled } from '../scripts/customerio'
         /* Same kill switch as the form: with no write key there is no signup
            control, so the promise to email would have nothing behind it. */
         isDownloadLinkRequestEnabled && (
-          <p class="note">
+          <p class="mx-auto mt-5 text-[11px]/[1.5] text-primary-warm-white/55">
             We'll prepare your account and email you when it's ready.
           </p>
         )
@@ -46,252 +75,31 @@ import { isDownloadLinkRequestEnabled } from '../scripts/customerio'
   </section>
 
   <!-- ============ CARDS ============ -->
-  <section class="agent-section">
-    <div class="section-head">
-      <h2>It fits the way you already work</h2>
+  <section
+    class="mx-auto max-w-295 px-6 pt-15 pb-35 max-[820px]:pt-20 max-[820px]:pb-24"
+  >
+    <div class="mx-auto mb-13.5 max-w-180 text-center">
+      <h2
+        class="text-[clamp(28px,4.2vw,48px)]/[1.12] font-light tracking-[-0.02em] text-primary-comfy-canvas"
+      >
+        It fits the way you already work
+      </h2>
     </div>
 
-    <div class="cards">
+    <div class="grid grid-cols-2 gap-6 max-[820px]:grid-cols-1">
       {
         agentCards.map((card) => (
-          <div class="card">
-            <p class="tag">{card.tag}</p>
-            <h3>{card.title}</h3>
-            <p>{card.body}</p>
+          <div class="rounded-3xl bg-primary-comfy-ink-light p-8.5 pb-9.5">
+            <p class="mb-4 text-xs font-bold tracking-[0.14em] text-primary-comfy-yellow uppercase">
+              {card.tag}
+            </p>
+            <h3 class="mb-3 text-xl/[1.25] font-medium tracking-[-0.01em] text-primary-comfy-canvas">
+              {card.title}
+            </h3>
+            <p class="text-sm/[1.62] text-primary-warm-white/66">{card.body}</p>
           </div>
         ))
       }
     </div>
   </section>
 </BaseLayout>
-
-<style>
-  .agent-hero {
-    --ink: #211927;
-    --lime: #d6f24e;
-    --paper: #f5f5f5;
-    --dot: 5px;
-    position: relative;
-    min-height: 56vh;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    overflow: hidden;
-    isolation: isolate;
-    padding: 100px 24px 48px;
-    color: var(--paper);
-  }
-
-  .wash {
-    position: absolute;
-    inset: -20%;
-    z-index: -4;
-    background:
-      radial-gradient(
-        ellipse 50% 40% at 30% 35%,
-        rgba(73, 55, 139, 0.55),
-        transparent 70%
-      ),
-      radial-gradient(
-        ellipse 45% 45% at 72% 62%,
-        rgba(73, 55, 139, 0.38),
-        transparent 70%
-      );
-    filter: blur(40px);
-    animation: sway 40s ease-in-out infinite alternate;
-    will-change: transform;
-  }
-
-  .dot-grid {
-    position: absolute;
-    inset: 0;
-    z-index: -3;
-    background-image: radial-gradient(
-      circle,
-      rgba(245, 245, 245, 0.16) 1px,
-      transparent 1.1px
-    );
-    background-size: var(--dot) var(--dot);
-  }
-
-  .cloud {
-    position: absolute;
-    inset: 0;
-    z-index: -2;
-    background-image: radial-gradient(
-      circle,
-      rgba(245, 245, 245, 0.42) 1.15px,
-      transparent 1.25px
-    );
-    background-size: var(--dot) var(--dot);
-    mask-image:
-      radial-gradient(circle, #000 0%, transparent 62%),
-      radial-gradient(circle, #000 0%, transparent 58%),
-      radial-gradient(circle, #000 0%, transparent 66%);
-    mask-size:
-      1100px 900px,
-      800px 700px,
-      1300px 1000px;
-    mask-repeat: no-repeat;
-    animation: shift 48s ease-in-out infinite alternate;
-    will-change: mask-position;
-  }
-
-  .vignette {
-    position: absolute;
-    inset: 0;
-    z-index: -1;
-    background:
-      linear-gradient(to bottom, transparent 55%, #211927 92%),
-      radial-gradient(
-        ellipse 65% 50% at 50% 50%,
-        rgba(33, 25, 39, 0.72) 0%,
-        rgba(33, 25, 39, 0.9) 65%,
-        rgba(33, 25, 39, 0.98) 100%
-      );
-  }
-
-  @keyframes shift {
-    0% {
-      mask-position:
-        8% 22%,
-        78% 70%,
-        45% 12%;
-    }
-    100% {
-      mask-position:
-        34% 58%,
-        52% 30%,
-        68% 74%;
-    }
-  }
-  @keyframes sway {
-    from {
-      transform: translate3d(-2%, -1%, 0) scale(1);
-    }
-    to {
-      transform: translate3d(3%, 2%, 0) scale(1.08);
-    }
-  }
-  @media (prefers-reduced-motion: reduce) {
-    .cloud,
-    .wash {
-      animation: none;
-    }
-  }
-
-  .inner {
-    position: relative;
-    max-width: 760px;
-    margin: 0 auto;
-    text-align: center;
-  }
-  .badge-lockup {
-    display: flex;
-    justify-content: center;
-    margin: 0 auto 40px auto;
-    zoom: 0.85;
-  }
-
-  .eyebrow {
-    margin: 0 0 18px 0;
-    font-size: 13px;
-    font-weight: 700;
-    letter-spacing: 0.16em;
-    text-transform: uppercase;
-    color: #d6f24e;
-  }
-
-  h1 {
-    margin: 0 0 28px 0;
-    font-size: clamp(28px, 4.2vw, 48px);
-    line-height: 1.18;
-    font-weight: 300;
-    letter-spacing: -0.02em;
-    color: var(--color-primary-warm-white);
-  }
-
-  .sub {
-    margin: 0 auto 40px auto;
-    max-width: 560px;
-    font-size: clamp(16px, 2vw, 19px);
-    line-height: 1.6;
-    color: rgba(245, 245, 245, 0.82);
-  }
-
-  .note {
-    margin: 20px auto 0 auto;
-    font-size: 11px;
-    line-height: 1.5;
-    color: rgba(245, 245, 245, 0.55);
-  }
-
-  .agent-section {
-    padding: 60px 24px 140px 24px;
-    max-width: 1180px;
-    margin: 0 auto;
-  }
-
-  .section-head {
-    text-align: center;
-    margin: 0 auto 54px auto;
-    max-width: 720px;
-  }
-  .section-head .eyebrow {
-    margin-bottom: 14px;
-  }
-  .section-head h2 {
-    margin: 0;
-    font-size: clamp(28px, 4.2vw, 48px);
-    line-height: 1.12;
-    font-weight: 300;
-    letter-spacing: -0.02em;
-    color: var(--color-primary-comfy-canvas);
-  }
-
-  .cards {
-    display: grid;
-    grid-template-columns: repeat(2, 1fr);
-    gap: 24px;
-  }
-
-  .card {
-    background: #2a2233;
-    border-radius: 24px;
-    padding: 34px 34px 38px 34px;
-  }
-
-  .card .tag {
-    margin: 0 0 16px 0;
-    font-size: 12px;
-    font-weight: 700;
-    letter-spacing: 0.14em;
-    text-transform: uppercase;
-    color: var(--color-primary-comfy-yellow);
-  }
-
-  .card h3 {
-    margin: 0 0 12px 0;
-    font-size: 20px;
-    line-height: 1.25;
-    font-weight: 500;
-    letter-spacing: -0.01em;
-    color: var(--color-primary-comfy-canvas);
-  }
-
-  .card p {
-    margin: 0;
-    font-size: 14px;
-    line-height: 1.62;
-    color: rgba(245, 245, 245, 0.66);
-  }
-
-  @media (max-width: 820px) {
-    .cards {
-      grid-template-columns: 1fr;
-    }
-    .agent-section {
-      padding: 80px 24px 96px 24px;
-    }
-  }
-</style>

--- a/apps/website/src/pages/agent.astro
+++ b/apps/website/src/pages/agent.astro
@@ -1,9 +1,7 @@
 ---
 import { agentCards } from '../components/agent/agentCards'
-import AgentBetaWaitlistForm from '../components/agent/AgentBetaWaitlistForm.vue'
-import ProductHeroBadge from '../components/common/ProductHeroBadge.vue'
+import HeroWaitlist01 from '../components/blocks/HeroWaitlist01.vue'
 import BaseLayout from '../layouts/BaseLayout.astro'
-import { isDownloadLinkRequestEnabled } from '../scripts/customerio'
 ---
 
 <BaseLayout
@@ -11,68 +9,14 @@ import { isDownloadLinkRequestEnabled } from '../scripts/customerio'
   description="The Comfy Agent lives inside ComfyUI, local and cloud. Describe what you want: it builds the workflow on your canvas, runs it, and hands back the result."
   noindex
 >
-  <!-- ============ HERO ============ -->
-  <section
-    class="relative isolate flex min-h-[56vh] items-center justify-center overflow-hidden px-6 pt-25 pb-12 text-primary-warm-white"
-  >
-    <!-- Plum wash -->
-    <div
-      aria-hidden="true"
-      class="animate-backdrop-sway absolute inset-[-20%] -z-4 bg-[radial-gradient(ellipse_50%_40%_at_30%_35%,color-mix(in_srgb,var(--color-primary-comfy-plum)_55%,transparent),transparent_70%),radial-gradient(ellipse_45%_45%_at_72%_62%,color-mix(in_srgb,var(--color-primary-comfy-plum)_38%,transparent),transparent_70%)] blur-[40px] will-change-transform"
-    >
-    </div>
-
-    <!-- Even dot grid, then a brighter drifting cloud of dots masked over it -->
-    <div
-      aria-hidden="true"
-      class="absolute inset-0 -z-3 bg-[radial-gradient(circle,color-mix(in_srgb,var(--color-primary-warm-white)_16%,transparent)_1px,transparent_1.1px)] bg-[size:5px_5px]"
-    >
-    </div>
-    <div
-      aria-hidden="true"
-      class="animate-backdrop-drift absolute inset-0 -z-2 bg-[radial-gradient(circle,color-mix(in_srgb,var(--color-primary-warm-white)_42%,transparent)_1.15px,transparent_1.25px)] bg-[size:5px_5px] [mask-image:radial-gradient(circle,#000_0%,transparent_62%),radial-gradient(circle,#000_0%,transparent_58%),radial-gradient(circle,#000_0%,transparent_66%)] [mask-repeat:no-repeat] [mask-size:1100px_900px,800px_700px,1300px_1000px] will-change-[mask-position]"
-    >
-    </div>
-
-    <!-- Darkens the edges and blends the hero into the page background -->
-    <div
-      aria-hidden="true"
-      class="absolute inset-0 -z-1 bg-[linear-gradient(to_bottom,transparent_55%,var(--color-primary-comfy-ink)_92%),radial-gradient(ellipse_65%_50%_at_50%_50%,color-mix(in_srgb,var(--color-primary-comfy-ink)_72%,transparent)_0%,color-mix(in_srgb,var(--color-primary-comfy-ink)_90%,transparent)_65%,color-mix(in_srgb,var(--color-primary-comfy-ink)_98%,transparent)_100%)]"
-    >
-    </div>
-
-    <div class="relative mx-auto max-w-190 text-center">
-      <div class="mx-auto mb-10 flex justify-center [zoom:0.85]">
-        <ProductHeroBadge text="AGENT" />
-      </div>
-
-      <h1
-        class="mb-7 text-[clamp(28px,4.2vw,48px)]/[1.18] font-light tracking-[-0.02em] text-primary-warm-white"
-      >
-        The first agent for craft
-      </h1>
-
-      <p
-        class="mx-auto mb-10 max-w-140 text-[clamp(16px,2vw,19px)]/[1.6] text-primary-warm-white/82"
-      >
-        An agent that lives inside ComfyUI, local and cloud. Describe what you
-        want: it builds the workflow on your canvas with you, reviews assets,
-        runs generations, and iterates until the result is production ready.
-      </p>
-
-      <AgentBetaWaitlistForm client:load />
-
-      {
-        /* Same kill switch as the form: with no write key there is no signup
-           control, so the promise to email would have nothing behind it. */
-        isDownloadLinkRequestEnabled && (
-          <p class="mx-auto mt-5 text-[11px]/[1.5] text-primary-warm-white/55">
-            We'll prepare your account and email you when it's ready.
-          </p>
-        )
-      }
-    </div>
-  </section>
+  <HeroWaitlist01
+    client:load
+    badgeText="AGENT"
+    title="The first agent for craft"
+    subtitle="An agent that lives inside ComfyUI, local and cloud. Describe what you want: it builds the workflow on your canvas with you, reviews assets, runs generations, and iterates until the result is production ready."
+    footnote="We'll prepare your account and email you when it's ready."
+    signupEvent="agent_beta_waitlist_joined"
+  />
 
   <!-- ============ CARDS ============ -->
   <section

--- a/apps/website/src/pages/agent.astro
+++ b/apps/website/src/pages/agent.astro
@@ -1,0 +1,297 @@
+---
+import { agentCards } from '../components/agent/agentCards'
+import AgentBetaWaitlistForm from '../components/agent/AgentBetaWaitlistForm.vue'
+import ProductHeroBadge from '../components/common/ProductHeroBadge.vue'
+import BaseLayout from '../layouts/BaseLayout.astro'
+import { isDownloadLinkRequestEnabled } from '../scripts/customerio'
+---
+
+<BaseLayout
+  title="The first agent for craft"
+  description="The Comfy Agent lives inside ComfyUI, local and cloud. Describe what you want: it builds the workflow on your canvas, runs it, and hands back the result."
+  noindex
+>
+  <!-- ============ HERO ============ -->
+  <section class="agent-hero">
+    <div class="wash" aria-hidden="true"></div>
+    <div class="dot-grid" aria-hidden="true"></div>
+    <div class="cloud" aria-hidden="true"></div>
+    <div class="vignette" aria-hidden="true"></div>
+
+    <div class="inner">
+      <div class="badge-lockup">
+        <ProductHeroBadge text="AGENT" />
+      </div>
+
+      <h1>The first agent for craft</h1>
+
+      <p class="sub">
+        An agent that lives inside ComfyUI, local and cloud. Describe what you
+        want: it builds the workflow on your canvas with you, reviews assets,
+        runs generations, and iterates until the result is production ready.
+      </p>
+
+      <AgentBetaWaitlistForm client:load />
+
+      {
+        /* Same kill switch as the form: with no write key there is no signup
+           control, so the promise to email would have nothing behind it. */
+        isDownloadLinkRequestEnabled && (
+          <p class="note">
+            We'll prepare your account and email you when it's ready.
+          </p>
+        )
+      }
+    </div>
+  </section>
+
+  <!-- ============ CARDS ============ -->
+  <section class="agent-section">
+    <div class="section-head">
+      <h2>It fits the way you already work</h2>
+    </div>
+
+    <div class="cards">
+      {
+        agentCards.map((card) => (
+          <div class="card">
+            <p class="tag">{card.tag}</p>
+            <h3>{card.title}</h3>
+            <p>{card.body}</p>
+          </div>
+        ))
+      }
+    </div>
+  </section>
+</BaseLayout>
+
+<style>
+  .agent-hero {
+    --ink: #211927;
+    --lime: #d6f24e;
+    --paper: #f5f5f5;
+    --dot: 5px;
+    position: relative;
+    min-height: 56vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    overflow: hidden;
+    isolation: isolate;
+    padding: 100px 24px 48px;
+    color: var(--paper);
+  }
+
+  .wash {
+    position: absolute;
+    inset: -20%;
+    z-index: -4;
+    background:
+      radial-gradient(
+        ellipse 50% 40% at 30% 35%,
+        rgba(73, 55, 139, 0.55),
+        transparent 70%
+      ),
+      radial-gradient(
+        ellipse 45% 45% at 72% 62%,
+        rgba(73, 55, 139, 0.38),
+        transparent 70%
+      );
+    filter: blur(40px);
+    animation: sway 40s ease-in-out infinite alternate;
+    will-change: transform;
+  }
+
+  .dot-grid {
+    position: absolute;
+    inset: 0;
+    z-index: -3;
+    background-image: radial-gradient(
+      circle,
+      rgba(245, 245, 245, 0.16) 1px,
+      transparent 1.1px
+    );
+    background-size: var(--dot) var(--dot);
+  }
+
+  .cloud {
+    position: absolute;
+    inset: 0;
+    z-index: -2;
+    background-image: radial-gradient(
+      circle,
+      rgba(245, 245, 245, 0.42) 1.15px,
+      transparent 1.25px
+    );
+    background-size: var(--dot) var(--dot);
+    mask-image:
+      radial-gradient(circle, #000 0%, transparent 62%),
+      radial-gradient(circle, #000 0%, transparent 58%),
+      radial-gradient(circle, #000 0%, transparent 66%);
+    mask-size:
+      1100px 900px,
+      800px 700px,
+      1300px 1000px;
+    mask-repeat: no-repeat;
+    animation: shift 48s ease-in-out infinite alternate;
+    will-change: mask-position;
+  }
+
+  .vignette {
+    position: absolute;
+    inset: 0;
+    z-index: -1;
+    background:
+      linear-gradient(to bottom, transparent 55%, #211927 92%),
+      radial-gradient(
+        ellipse 65% 50% at 50% 50%,
+        rgba(33, 25, 39, 0.72) 0%,
+        rgba(33, 25, 39, 0.9) 65%,
+        rgba(33, 25, 39, 0.98) 100%
+      );
+  }
+
+  @keyframes shift {
+    0% {
+      mask-position:
+        8% 22%,
+        78% 70%,
+        45% 12%;
+    }
+    100% {
+      mask-position:
+        34% 58%,
+        52% 30%,
+        68% 74%;
+    }
+  }
+  @keyframes sway {
+    from {
+      transform: translate3d(-2%, -1%, 0) scale(1);
+    }
+    to {
+      transform: translate3d(3%, 2%, 0) scale(1.08);
+    }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .cloud,
+    .wash {
+      animation: none;
+    }
+  }
+
+  .inner {
+    position: relative;
+    max-width: 760px;
+    margin: 0 auto;
+    text-align: center;
+  }
+  .badge-lockup {
+    display: flex;
+    justify-content: center;
+    margin: 0 auto 40px auto;
+    zoom: 0.85;
+  }
+
+  .eyebrow {
+    margin: 0 0 18px 0;
+    font-size: 13px;
+    font-weight: 700;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: #d6f24e;
+  }
+
+  h1 {
+    margin: 0 0 28px 0;
+    font-size: clamp(28px, 4.2vw, 48px);
+    line-height: 1.18;
+    font-weight: 300;
+    letter-spacing: -0.02em;
+    color: var(--color-primary-warm-white);
+  }
+
+  .sub {
+    margin: 0 auto 40px auto;
+    max-width: 560px;
+    font-size: clamp(16px, 2vw, 19px);
+    line-height: 1.6;
+    color: rgba(245, 245, 245, 0.82);
+  }
+
+  .note {
+    margin: 20px auto 0 auto;
+    font-size: 11px;
+    line-height: 1.5;
+    color: rgba(245, 245, 245, 0.55);
+  }
+
+  .agent-section {
+    padding: 60px 24px 140px 24px;
+    max-width: 1180px;
+    margin: 0 auto;
+  }
+
+  .section-head {
+    text-align: center;
+    margin: 0 auto 54px auto;
+    max-width: 720px;
+  }
+  .section-head .eyebrow {
+    margin-bottom: 14px;
+  }
+  .section-head h2 {
+    margin: 0;
+    font-size: clamp(28px, 4.2vw, 48px);
+    line-height: 1.12;
+    font-weight: 300;
+    letter-spacing: -0.02em;
+    color: var(--color-primary-comfy-canvas);
+  }
+
+  .cards {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 24px;
+  }
+
+  .card {
+    background: #2a2233;
+    border-radius: 24px;
+    padding: 34px 34px 38px 34px;
+  }
+
+  .card .tag {
+    margin: 0 0 16px 0;
+    font-size: 12px;
+    font-weight: 700;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: var(--color-primary-comfy-yellow);
+  }
+
+  .card h3 {
+    margin: 0 0 12px 0;
+    font-size: 20px;
+    line-height: 1.25;
+    font-weight: 500;
+    letter-spacing: -0.01em;
+    color: var(--color-primary-comfy-canvas);
+  }
+
+  .card p {
+    margin: 0;
+    font-size: 14px;
+    line-height: 1.62;
+    color: rgba(245, 245, 245, 0.66);
+  }
+
+  @media (max-width: 820px) {
+    .cards {
+      grid-template-columns: 1fr;
+    }
+    .agent-section {
+      padding: 80px 24px 96px 24px;
+    }
+  }
+</style>

--- a/apps/website/src/scripts/customerio.test.ts
+++ b/apps/website/src/scripts/customerio.test.ts
@@ -65,6 +65,20 @@ describe('customerio', () => {
     )
   })
 
+  it('identifies by email then tracks an agent beta waitlist signup', async () => {
+    const { joinAgentBetaWaitlist } = await importModule('test-key')
+
+    await joinAgentBetaWaitlist('someone@example.com')
+
+    expect(hoisted.mockIdentify).toHaveBeenCalledWith('someone@example.com', {
+      email: 'someone@example.com'
+    })
+    expect(hoisted.mockTrack).toHaveBeenCalledWith(
+      'agent_beta_waitlist_joined',
+      { page: window.location.pathname }
+    )
+  })
+
   it('retries the SDK load on the next submit instead of caching a failed load', async () => {
     const { preloadDownloadLinkAnalytics, requestDownloadLink } =
       await importModule('test-key')

--- a/apps/website/src/scripts/customerio.test.ts
+++ b/apps/website/src/scripts/customerio.test.ts
@@ -65,10 +65,10 @@ describe('customerio', () => {
     )
   })
 
-  it('identifies by email then tracks an agent beta waitlist signup', async () => {
-    const { joinAgentBetaWaitlist } = await importModule('test-key')
+  it('identifies by email then tracks the waitlist signup under the caller event', async () => {
+    const { joinWaitlist } = await importModule('test-key')
 
-    await joinAgentBetaWaitlist('someone@example.com')
+    await joinWaitlist('someone@example.com', 'agent_beta_waitlist_joined')
 
     expect(hoisted.mockIdentify).toHaveBeenCalledWith('someone@example.com', {
       email: 'someone@example.com'

--- a/apps/website/src/scripts/customerio.ts
+++ b/apps/website/src/scripts/customerio.ts
@@ -42,10 +42,14 @@ export async function requestDownloadLink(email: string, locale: Locale) {
   })
 }
 
-export async function joinAgentBetaWaitlist(email: string) {
+/**
+ * Adds `email` to a waitlist and records the signup under `event`. The event
+ * name is the caller's so one form can serve more than one waitlist.
+ */
+export async function joinWaitlist(email: string, event: string) {
   const analytics = await loadAnalytics()
   await analytics.identify(email, { email })
-  await analytics.track('agent_beta_waitlist_joined', {
+  await analytics.track(event, {
     page: window.location.pathname
   })
 }

--- a/apps/website/src/scripts/customerio.ts
+++ b/apps/website/src/scripts/customerio.ts
@@ -41,3 +41,11 @@ export async function requestDownloadLink(email: string, locale: Locale) {
     page: window.location.pathname
   })
 }
+
+export async function joinAgentBetaWaitlist(email: string) {
+  const analytics = await loadAnalytics()
+  await analytics.identify(email, { email })
+  await analytics.track('agent_beta_waitlist_joined', {
+    page: window.location.pathname
+  })
+}

--- a/apps/website/src/styles/global.css
+++ b/apps/website/src/styles/global.css
@@ -75,6 +75,8 @@
   --color-primary-warm-gray: #7e7c78;
   --color-secondary-mauve: #4d3762;
   --color-destructive: #f44336;
+  /* Legible on the dark ink surfaces; --color-destructive is too dark there. */
+  --color-destructive-light: #ffb4a8;
   --color-primary-comfy-plum: #49378b;
   --color-secondary-deep-plum: #2b2040;
   --color-secondary-cool-gray: #3c3c3c;
@@ -485,4 +487,42 @@ video::-webkit-media-controls-panel {
   --site-bg: var(--color-primary-comfy-ink);
   --site-bg-soft: var(--color-site-bg-soft);
   --site-border-subtle: rgb(255 255 255 / 0.1);
+}
+
+@keyframes backdrop-sway {
+  from {
+    transform: translate3d(-2%, -1%, 0) scale(1);
+  }
+
+  to {
+    transform: translate3d(3%, 2%, 0) scale(1.08);
+  }
+}
+
+@keyframes backdrop-drift {
+  0% {
+    mask-position:
+      8% 22%,
+      78% 70%,
+      45% 12%;
+  }
+
+  100% {
+    mask-position:
+      34% 58%,
+      52% 30%,
+      68% 74%;
+  }
+}
+
+@utility animate-backdrop-sway {
+  @media (prefers-reduced-motion: no-preference) {
+    animation: backdrop-sway 40s ease-in-out infinite alternate;
+  }
+}
+
+@utility animate-backdrop-drift {
+  @media (prefers-reduced-motion: no-preference) {
+    animation: backdrop-drift 48s ease-in-out infinite alternate;
+  }
 }


### PR DESCRIPTION
Adds `/agent`: the Comfy Agent beta waitlist page — a hero with the signup form and a card section explaining how the agent fits existing workflows.

Replaces #16260, which had the same page sitting on top of the Developer Platform work (new `/platform/*` pages, the `/api` retirement, and the `/cloud/pricing` → `/pricing` move). None of that is wanted right now, so this branch carries only the agent page, cut fresh from `main`.

### What's here

- `src/pages/agent.astro` and the `AgentBetaWaitlistForm` island + `agentCards` content
- `joinAgentBetaWaitlist` in `scripts/customerio.ts` — identifies by email, tracks `agent_beta_waitlist_joined`. It shares the write-key kill switch with the download-link flow, so with no key configured neither the form nor its follow-up promise renders.
- `agent: '/agent'` registered as a locale-invariant route (English-only until a localized page exists)

The page is an unlisted invite-only beta, so it carries `noindex` and is kept out of both `llms.txt` and the sitemap.

### Deliberately not carried over from #16260

- The `showLogo` prop on `ProductHeroBadge` — only the platform heroes use it; this page renders the default badge
- `public/assets/agent-beta/*` — unreferenced leftovers from an earlier design pass

### Verification

Purely additive: 11 files, +724, no deletions. `test:unit` (865 passing), `typecheck` (0 errors), `build` (706 pages), `validate:llms-txt-links`, and `validate:jsonld` all pass. Confirmed in the build output that `/agent` emits the noindex meta tag and is absent from `sitemap-0.xml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011RE5hV5QrijEsJQcy1b4Sy