### PR TITLE
docs(adr): E2E coverage measurement and test selection

### DIFF
--- a/docs/adr/0027-e2e-coverage-measurement-and-test-selection.md
+++ b/docs/adr/0027-e2e-coverage-measurement-and-test-selection.md
@@ -18,8 +18,10 @@ usable for deciding what to test next, for three reasons.
    triggers never enter the report, so 457 `src/` files (about 65k raw lines)
    are absent rather than at 0%. The layer editor, agent panel, workspace and
    subscription UI, video edit panel, and compositor are all in that set. Raw
-   source lines are not comparable to lcov's executable-line count, so the
-   corrected percentage is not known until those files enter the report.
+   source lines are not comparable to lcov's executable-line count. Applying
+   the loaded files' executable-to-raw ratio (0.27) to the absent files gives
+   about 17.5k executable lines and a corrected figure near 54%. The exact
+   number arrives when those files enter the report.
 2. Only the `chromium` project sets `COLLECT_COVERAGE`. The 154 `cloud`
    tests that exercise sign-in, workspaces, billing, and the agent panel are
    never credited.
@@ -51,8 +53,9 @@ The supporting analysis, per-area tables, and reproduction steps are in
 1. Every Chromium-based project run by `ci-tests-e2e.yaml` collects coverage:
    `chromium`, `cloud`, `mobile-chrome`, `chromium-2x`, and `chromium-0.5x`.
    The cloud bundle is built with `COLLECT_COVERAGE` so it retains source-map
-   comments. Each job uploads a uniquely named `e2e-coverage-shard-*` artifact
-   that the existing package step merges. `mobile-safari` is excluded because
+   comments. Each job uploads a uniquely named `e2e-coverage-shard-*` artifact. The
+   package job depends on every uploading job and rejects an incomplete
+   artifact set instead of merging a partial one. `mobile-safari` is excluded because
    Playwright's coverage API does not support WebKit. `performance` is excluded
    because coverage instrumentation would perturb its measurements, as
    described in ADR 0022. No regular CI job runs `audit`.
@@ -107,8 +110,9 @@ Positive:
 
 Negative:
 
-- The reported E2E percentage will drop when never-loaded files are counted.
-  Its size is not known until executable lines are measured. The Slack target
+- The reported E2E percentage will drop when never-loaded files are counted,
+  by roughly 14 points on the estimate above. The exact size is known once
+  executable lines are measured. The Slack target
   of 80% becomes a trend line only until per-component thresholds exist.
 - Collecting coverage in the `cloud` and mobile jobs adds a small amount of
   runtime and one artifact per project.

--- a/docs/adr/0027-e2e-coverage-measurement-and-test-selection.md
+++ b/docs/adr/0027-e2e-coverage-measurement-and-test-selection.md
@@ -47,13 +47,14 @@ The supporting analysis, per-area tables, and reproduction steps are in
 
 ### Measurement
 
-1. Every Playwright project collects coverage, not only `chromium`. The
-   cloud bundle is built with `COLLECT_COVERAGE` so it retains source-map
-   comments, and each project uploads an `e2e-coverage-shard-*` artifact that
-   the existing package step merges.
-2. Source files that never load in any project are reported at 0%, not
-   omitted. The headline number is expected to fall when this lands; the
-   lower number is the true one.
+1. Every Playwright project collects coverage, including `cloud`, the mobile
+   projects, and the scale projects. The cloud bundle is built with
+   `COLLECT_COVERAGE` so it retains source-map comments, and each project
+   uploads an `e2e-coverage-shard-*` artifact that the existing package step
+   merges.
+2. Source files that never load in any project are reported at 0% instead of
+   being left out of the report. The headline number will fall when this
+   lands, and the lower number is the accurate one.
 3. Coverage is reported per feature area through Codecov components, with
    `unit`, `e2e`, and combined values in the PR comment. Component statuses
    are informational. No global project threshold is introduced; thresholds
@@ -76,16 +77,17 @@ The supporting analysis, per-area tables, and reproduction steps are in
 7. E2E tests exist for user journeys and for execution gaps the coverage
    report shows. Logic that has a unit test does not get an E2E copy, and
    unit-shaped gaps are closed in Vitest.
-8. Orthogonal dimensions are tested once. Widget behavior is proven on the
-   Vue-nodes renderer, renderer parity is proven by the toggle specs, and
-   node states are proven once; no second-renderer copy of an existing widget
-   spec is added. The same applies to feature × view mode.
+8. Where two dimensions are orthogonal, each is tested once rather than as a
+   cross product. Widget behavior is proven on the Vue-nodes renderer,
+   renderer parity is proven by the toggle specs, and node states are proven
+   once; no second-renderer copy of an existing widget spec is added. The
+   same applies to feature × view mode.
 9. Screenshot assertions are used only when appearance is the behavior under
    test. Link, position, and selection state are asserted through `nodeOps`.
 10. A new feature directory under `src/renderer/extensions`, `src/platform`,
     or `src/workbench` is expected to ship with a matching
-    `browser_tests/tests/<feature>/` folder. The check is advisory in the PR
-    report, not a required status.
+    `browser_tests/tests/<feature>/` folder. The PR report comment flags a
+    missing folder as advice and never blocks a merge.
 11. `legacyDoNotReplicate` grows only when a custom-node breakage proves a
     compatibility contract matters.
 
@@ -94,7 +96,7 @@ The supporting analysis, per-area tables, and reproduction steps are in
 Positive:
 
 - The coverage pipeline already paid for becomes a gap finder instead of a
-  trend line. Decisions about where to add tests are made from per-area data.
+  trend line. Per-area data decides where tests get added.
 - Cloud-only surfaces (workspace, billing, subscription, agent) are measured
   before anyone decides how many tests they need.
 - The journey inventory makes behavior coverage reviewable and gives CI a

--- a/docs/adr/0027-e2e-coverage-measurement-and-test-selection.md
+++ b/docs/adr/0027-e2e-coverage-measurement-and-test-selection.md
@@ -1,0 +1,132 @@
+# 27. E2E Coverage Measurement and Test Selection
+
+Date: 2026-09-01
+
+## Status
+
+Proposed
+
+## Context
+
+The Playwright suite has 327 spec files and about 1,950 tests, and CI already
+collects V8 coverage for the sharded `chromium` project, merges it, and
+publishes it to Codecov, GitHub Pages, and Slack. On the `main` run at
+`e05e929f` the merged report shows 68.1% of lines covered. That number is not
+usable for deciding what to test next, for three reasons.
+
+1. V8 coverage only describes chunks the browser fetched. Lazy chunks no test
+   triggers never enter the report, so 457 `src/` files (about 65k raw lines,
+   against 70.5k measured lines) are absent rather than at 0%. The layer
+   editor, agent panel, workspace and subscription UI, video edit panel, and
+   compositor are all in that set.
+2. Only the `chromium` project sets `COLLECT_COVERAGE`. The 154 `cloud`
+   tests that exercise sign-in, workspaces, billing, and the agent panel are
+   never credited.
+3. Nothing reports coverage per feature area. Codecov's project status is
+   disabled and patch status is informational, so a global figure hides that
+   `platform/workspace` is at 34% while `vueNodes` is at 81%.
+
+Two further facts shape the decision. The Vitest config excludes
+`src/lib/litegraph/src/canvas/**` and `widgets/**` from unit coverage, so E2E
+is the only measuring layer for those 11.9k lines and holds them at about
+49%. And the suite has no inventory of the user journeys it protects: the
+`@smoke` tag is applied to 46 tests and no CI job runs it.
+
+Line coverage is an execution metric. Research on behavioural test adequacy
+finds untested behavior in roughly a third of fully line-covered methods,
+because coverage cannot see a missing assertion. Kent Beck's composable-tests
+argument applies to the suite's largest cost driver: where dimensions such as
+widget type, renderer, and node state are orthogonal, testing each dimension
+once gives the same confidence as the cross product at a fraction of the
+runtime.
+
+The supporting analysis, per-area tables, and reproduction steps are in
+[docs/testing/e2e-coverage-strategy.md](../testing/e2e-coverage-strategy.md).
+
+## Decision
+
+### Measurement
+
+1. Every Playwright project collects coverage, not only `chromium`. The
+   cloud bundle is built with `COLLECT_COVERAGE` so it retains source-map
+   comments, and each project uploads an `e2e-coverage-shard-*` artifact that
+   the existing package step merges.
+2. Source files that never load in any project are reported at 0%, not
+   omitted. The headline number is expected to fall when this lands; the
+   lower number is the true one.
+3. Coverage is reported per feature area through Codecov components, with
+   `unit`, `e2e`, and combined values in the PR comment. Component statuses
+   are informational. No global project threshold is introduced; thresholds
+   may later be set per component, at current value minus a small margin,
+   for areas that are already well covered.
+4. The package step emits a gap report: files below 30% in both layers,
+   grouped by directory, so execution gaps are visible on every run.
+
+### Behavior coverage
+
+5. `browser_tests/JOURNEYS.md` lists the user journeys the suite protects,
+   each with its spec and the observable it asserts. Exactly one spec per
+   journey carries `@smoke`. A `smoke` project greps that tag and runs first
+   in CI as a fast-fail; the sharded run is unchanged.
+6. A journey without a spec is the highest-priority new test. A feature that
+   ships to users, including by flag flip, gets its journey added.
+
+### Test selection
+
+7. E2E tests exist for user journeys and for execution gaps the coverage
+   report shows. Logic that has a unit test does not get an E2E copy, and
+   unit-shaped gaps are closed in Vitest.
+8. Orthogonal dimensions are tested once. Widget behavior is proven on the
+   Vue-nodes renderer, renderer parity is proven by the toggle specs, and
+   node states are proven once; no second-renderer copy of an existing widget
+   spec is added. The same applies to feature × view mode.
+9. Screenshot assertions are used only when appearance is the behavior under
+   test. Link, position, and selection state are asserted through `nodeOps`.
+10. A new feature directory under `src/renderer/extensions`, `src/platform`,
+    or `src/workbench` is expected to ship with a matching
+    `browser_tests/tests/<feature>/` folder. The check is advisory in the PR
+    report, not a required status.
+11. `legacyDoNotReplicate` grows only when a custom-node breakage proves a
+    compatibility contract matters.
+
+## Consequences
+
+Positive:
+
+- The coverage pipeline already paid for becomes a gap finder instead of a
+  trend line. Decisions about where to add tests are made from per-area data.
+- Cloud-only surfaces (workspace, billing, subscription, agent) are measured
+  before anyone decides how many tests they need.
+- The journey inventory makes behavior coverage reviewable and gives CI a
+  two-minute fail-fast for the paths users depend on.
+- Test count grows where coverage is thin and shrinks where dimensions are
+  duplicated, so runner minutes stay roughly flat.
+
+Negative:
+
+- The reported E2E percentage drops, possibly by 15 to 20 points, when
+  never-loaded files are counted. The Slack target of 80% becomes a trend
+  line only until per-component thresholds exist.
+- Collecting coverage in the `cloud` and mobile jobs adds a small amount of
+  runtime and one artifact per project.
+- Consolidating duplicated spec families is work that adds no coverage and
+  must be checked against the per-component report to prove nothing dropped.
+
+Neutral:
+
+- Mutation testing stays out of scope for the browser suite. It may be
+  applied later to pure, well-unit-tested modules.
+- Existing conventions in `browser_tests/README.md` are unchanged; this ADR
+  adds selection rules on top of them.
+
+## Implementation
+
+Landed as a stack, in this order, each independently mergeable:
+
+1. This ADR and the supporting analysis.
+2. Coverage collection in every Playwright project.
+3. Never-loaded files counted at 0% and the gap report in the package step.
+4. Codecov components for the feature areas in the analysis.
+5. `browser_tests/JOURNEYS.md`, `@smoke` retagging, and the `smoke` project.
+6. New journey specs and gap-closing specs, one area per PR.
+7. Consolidation of the duplicated spec families.

--- a/docs/adr/0027-e2e-coverage-measurement-and-test-selection.md
+++ b/docs/adr/0027-e2e-coverage-measurement-and-test-selection.md
@@ -15,10 +15,11 @@ publishes it to Codecov, GitHub Pages, and Slack. On the `main` run at
 usable for deciding what to test next, for three reasons.
 
 1. V8 coverage only describes chunks the browser fetched. Lazy chunks no test
-   triggers never enter the report, so 457 `src/` files (about 65k raw lines,
-   against 70.5k measured lines) are absent rather than at 0%. The layer
-   editor, agent panel, workspace and subscription UI, video edit panel, and
-   compositor are all in that set.
+   triggers never enter the report, so 457 `src/` files (about 65k raw lines)
+   are absent rather than at 0%. The layer editor, agent panel, workspace and
+   subscription UI, video edit panel, and compositor are all in that set. Raw
+   source lines are not comparable to lcov's executable-line count, so the
+   corrected percentage is not known until those files enter the report.
 2. Only the `chromium` project sets `COLLECT_COVERAGE`. The 154 `cloud`
    tests that exercise sign-in, workspaces, billing, and the agent panel are
    never credited.
@@ -33,12 +34,12 @@ is the only measuring layer for those 11.9k lines and holds them at about
 `@smoke` tag is applied to 46 tests and no CI job runs it.
 
 Line coverage is an execution metric. Research on behavioural test adequacy
-finds untested behavior in roughly a third of fully line-covered methods,
-because coverage cannot see a missing assertion. Kent Beck's composable-tests
-argument applies to the suite's largest cost driver: where dimensions such as
-widget type, renderer, and node state are orthogonal, testing each dimension
-once gives the same confidence as the cross product at a fraction of the
-runtime.
+finds that about 17.5% of expected behaviours are entirely untested, with most
+of those gaps in methods that already have high line coverage. Coverage cannot
+see a missing assertion. Kent Beck's composable-tests argument applies to the
+suite's largest cost driver: where dimensions such as widget type, renderer,
+and node state are orthogonal, testing each dimension once gives the same
+confidence as the cross product at a fraction of the runtime.
 
 The supporting analysis, per-area tables, and reproduction steps are in
 [docs/testing/e2e-coverage-strategy.md](../testing/e2e-coverage-strategy.md).
@@ -47,49 +48,49 @@ The supporting analysis, per-area tables, and reproduction steps are in
 
 ### Measurement
 
-1. Every Playwright project collects coverage, including `cloud`, the mobile
-   projects, and the scale projects. The cloud bundle is built with
-   `COLLECT_COVERAGE` so it retains source-map comments, and each project
-   uploads an `e2e-coverage-shard-*` artifact that the existing package step
-   merges.
+1. Every Chromium-based project run by `ci-tests-e2e.yaml` collects coverage:
+   `chromium`, `cloud`, `mobile-chrome`, `chromium-2x`, and `chromium-0.5x`.
+   The cloud bundle is built with `COLLECT_COVERAGE` so it retains source-map
+   comments. Each job uploads a uniquely named `e2e-coverage-shard-*` artifact
+   that the existing package step merges. `mobile-safari` is excluded because
+   Playwright's coverage API does not support WebKit. `performance` is excluded
+   because coverage instrumentation would perturb its measurements, as
+   described in ADR 0022. No regular CI job runs `audit`.
 2. Source files that never load in any project are reported at 0% instead of
    being left out of the report. The headline number will fall when this
    lands, and the lower number is the accurate one.
-3. Coverage is reported per feature area through Codecov components, with
-   `unit`, `e2e`, and combined values in the PR comment. Component statuses
-   are informational. No global project threshold is introduced; thresholds
-   may later be set per component, at current value minus a small margin,
-   for areas that are already well covered.
+3. Combined coverage is reported per feature area through Codecov components.
+   The existing flags continue to report overall `unit` and `e2e` coverage.
+   Component statuses are informational. No global project threshold is
+   introduced; thresholds may later be set per component, at current value
+   minus a small margin, for areas that are already well covered.
 4. The package step emits a gap report: files below 30% in both layers,
    grouped by directory, so execution gaps are visible on every run.
 
 ### Behavior coverage
 
-5. `browser_tests/JOURNEYS.md` lists the user journeys the suite protects,
+1. `browser_tests/JOURNEYS.md` lists the user journeys the suite protects,
    each with its spec and the observable it asserts. Exactly one spec per
-   journey carries `@smoke`. A `smoke` project greps that tag and runs first
-   in CI as a fast-fail; the sharded run is unchanged.
-6. A journey without a spec is the highest-priority new test. A feature that
+   journey carries `@smoke`. A `smoke` project greps that tag. The sharded jobs
+   start after it passes, avoiding a full run when a critical journey fails.
+2. A journey without a spec is the highest-priority new test. A feature that
    ships to users, including by flag flip, gets its journey added.
 
 ### Test selection
 
-7. E2E tests exist for user journeys and for execution gaps the coverage
+1. E2E tests exist for user journeys and for execution gaps the coverage
    report shows. Logic that has a unit test does not get an E2E copy, and
    unit-shaped gaps are closed in Vitest.
-8. Where two dimensions are orthogonal, each is tested once rather than as a
+2. Where two dimensions are orthogonal, each is tested once rather than as a
    cross product. Widget behavior is proven on the Vue-nodes renderer,
    renderer parity is proven by the toggle specs, and node states are proven
    once; no second-renderer copy of an existing widget spec is added. The
    same applies to feature × view mode.
-9. Screenshot assertions are used only when appearance is the behavior under
-   test. Link, position, and selection state are asserted through `nodeOps`.
-10. A new feature directory under `src/renderer/extensions`, `src/platform`,
-    or `src/workbench` is expected to ship with a matching
-    `browser_tests/tests/<feature>/` folder. The PR report comment flags a
-    missing folder as advice and never blocks a merge.
-11. `legacyDoNotReplicate` grows only when a custom-node breakage proves a
-    compatibility contract matters.
+3. Tests assert effects a user can observe. Screenshots are used when visual
+   appearance is the behavior under test; otherwise tests use accessible UI
+   state or another user-visible outcome.
+4. `legacyDoNotReplicate` grows only when a custom-node breakage proves a
+   compatibility contract matters.
 
 ## Consequences
 
@@ -106,11 +107,13 @@ Positive:
 
 Negative:
 
-- The reported E2E percentage drops, possibly by 15 to 20 points, when
-  never-loaded files are counted. The Slack target of 80% becomes a trend
-  line only until per-component thresholds exist.
+- The reported E2E percentage will drop when never-loaded files are counted.
+  Its size is not known until executable lines are measured. The Slack target
+  of 80% becomes a trend line only until per-component thresholds exist.
 - Collecting coverage in the `cloud` and mobile jobs adds a small amount of
   runtime and one artifact per project.
+- Gating the sharded jobs on the smoke project adds its runtime to a green
+  run's critical path.
 - Consolidating duplicated spec families is work that adds no coverage and
   must be checked against the per-component report to prove nothing dropped.
 
@@ -123,10 +126,10 @@ Neutral:
 
 ## Implementation
 
-Landed as a stack, in this order, each independently mergeable:
+Planned as a stack, in this order, each independently mergeable:
 
 1. This ADR and the supporting analysis.
-2. Coverage collection in every Playwright project.
+2. Coverage collection in the supported CI Playwright projects.
 3. Never-loaded files counted at 0% and the gap report in the package step.
 4. Codecov components for the feature areas in the analysis.
 5. `browser_tests/JOURNEYS.md`, `@smoke` retagging, and the `smoke` project.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -36,9 +36,9 @@ An Architecture Decision Record captures an important architectural decision mad
 | [RENDERING-INVALIDATION-0021](RENDERING-INVALIDATION-0021-classified-frame-coalesced-canvas-invalidation.md)     | Classified, Frame-Coalesced Canvas Invalidation                 | Proposed | 2026-08-26 |
 | [SUBGRAPH-PROMOTION-0009](SUBGRAPH-PROMOTION-0009-represent-promoted-widgets-as-linked-inputs.md)                | Represent Promoted Widgets as Linked Inputs                     | Proposed | 2026-05-05 |
 | [SUBGRAPH-PROMOTION-0027](SUBGRAPH-PROMOTION-0027-defer-promoted-widget-registration-to-onadded.md)              | Defer Promoted-Widget Registration to `onAdded()`               | Accepted | 2026-09-01 |
-| [0027](0027-e2e-coverage-measurement-and-test-selection.md)                                                      | E2E Coverage Measurement and Test Selection                     | Proposed | 2026-09-01 |
 | [TELEMETRY-DIAGNOSTICS-0019](TELEMETRY-DIAGNOSTICS-0019-recoverable-event-diagnostics.md)                        | Recoverable Event Diagnostics                                   | Proposed | 2026-08-25 |
 | [TELEMETRY-ROUTING-0013](TELEMETRY-ROUTING-0013-telemetry-routing-across-consumers.md)                           | Telemetry Routing Across Consumers                              | Accepted | 2026-07-28 |
+| [TESTING-E2E-0027](TESTING-E2E-0027-coverage-measurement-and-test-selection.md)                                  | E2E Coverage Measurement and Test Selection                     | Proposed | 2026-09-01 |
 | [WIDGET-SERIALIZATION-0006](WIDGET-SERIALIZATION-0006-preserve-primitive-widget-values-across-copy-and-paste.md) | PrimitiveNode Widget Restoration Lifecycle                      | Accepted | 2026-02-22 |
 
 ## Creating a New ADR

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -36,6 +36,7 @@ An Architecture Decision Record captures an important architectural decision mad
 | [RENDERING-INVALIDATION-0021](RENDERING-INVALIDATION-0021-classified-frame-coalesced-canvas-invalidation.md)     | Classified, Frame-Coalesced Canvas Invalidation                 | Proposed | 2026-08-26 |
 | [SUBGRAPH-PROMOTION-0009](SUBGRAPH-PROMOTION-0009-represent-promoted-widgets-as-linked-inputs.md)                | Represent Promoted Widgets as Linked Inputs                     | Proposed | 2026-05-05 |
 | [SUBGRAPH-PROMOTION-0027](SUBGRAPH-PROMOTION-0027-defer-promoted-widget-registration-to-onadded.md)              | Defer Promoted-Widget Registration to `onAdded()`               | Accepted | 2026-09-01 |
+| [0027](0027-e2e-coverage-measurement-and-test-selection.md)                                                      | E2E Coverage Measurement and Test Selection                     | Proposed | 2026-09-01 |
 | [TELEMETRY-DIAGNOSTICS-0019](TELEMETRY-DIAGNOSTICS-0019-recoverable-event-diagnostics.md)                        | Recoverable Event Diagnostics                                   | Proposed | 2026-08-25 |
 | [TELEMETRY-ROUTING-0013](TELEMETRY-ROUTING-0013-telemetry-routing-across-consumers.md)                           | Telemetry Routing Across Consumers                              | Accepted | 2026-07-28 |
 | [WIDGET-SERIALIZATION-0006](WIDGET-SERIALIZATION-0006-preserve-primitive-widget-values-across-copy-and-paste.md) | PrimitiveNode Widget Restoration Lifecycle                      | Accepted | 2026-02-22 |

--- a/docs/adr/TESTING-E2E-0027-coverage-measurement-and-test-selection.md
+++ b/docs/adr/TESTING-E2E-0027-coverage-measurement-and-test-selection.md
@@ -20,8 +20,9 @@ usable for deciding what to test next, for three reasons.
    subscription UI, video edit panel, and compositor are all in that set. Raw
    source lines are not comparable to lcov's executable-line count. Applying
    the loaded files' executable-to-raw ratio (0.27) to the absent files gives
-   about 17.5k executable lines and a corrected figure near 54%. The exact
-   number arrives when those files enter the report.
+   about 17.5k executable lines and a corrected figure near 54.5%:
+   `48,026 / (70,520 + 17,500)`. The exact number arrives when those files
+   enter the report.
 2. Only the `chromium` project sets `COLLECT_COVERAGE`. The 154 `cloud`
    tests that exercise sign-in, workspaces, billing, and the agent panel are
    never credited.

--- a/docs/adr/TESTING-E2E-0027-coverage-measurement-and-test-selection.md
+++ b/docs/adr/TESTING-E2E-0027-coverage-measurement-and-test-selection.md
@@ -1,4 +1,4 @@
-# 27. E2E Coverage Measurement and Test Selection
+# ADR-TESTING-E2E-0027: E2E Coverage Measurement and Test Selection
 
 Date: 2026-09-01
 
@@ -58,7 +58,9 @@ The supporting analysis, per-area tables, and reproduction steps are in
    artifact set instead of merging a partial one. `mobile-safari` is excluded because
    Playwright's coverage API does not support WebKit. `performance` is excluded
    because coverage instrumentation would perturb its measurements, as
-   described in ADR 0022. No regular CI job runs `audit`.
+   described in
+   [ADR-PERF-BENCHMARKS-0022](PERF-BENCHMARKS-0022-performance-evidence-and-regression-framework.md).
+   No regular CI job runs `audit`.
 2. Source files that never load in any project are reported at 0% instead of
    being left out of the report. The headline number will fall when this
    lands, and the lower number is the accurate one.

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -11,6 +11,9 @@ Documentation for unit tests is organized into five guides:
 - [Store Testing](./store-testing.md) - How to test Pinia stores specifically
 - [LiteGraph Testing](./litegraph-testing.md) - How to test LiteGraph graph, node, link, and workflow behavior
 - [Vitest Patterns](./vitest-patterns.md) - Setup, mocking, and fake-timer patterns that apply across all of the above
+
+Playwright testing has a separate strategy guide:
+
 - [E2E Coverage Strategy](./e2e-coverage-strategy.md) - How Playwright coverage is measured, where the gaps are, and the plan to close them
 
 ## Testing Structure

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -11,6 +11,7 @@ Documentation for unit tests is organized into five guides:
 - [Store Testing](./store-testing.md) - How to test Pinia stores specifically
 - [LiteGraph Testing](./litegraph-testing.md) - How to test LiteGraph graph, node, link, and workflow behavior
 - [Vitest Patterns](./vitest-patterns.md) - Setup, mocking, and fake-timer patterns that apply across all of the above
+- [E2E Coverage Strategy](./e2e-coverage-strategy.md) - How Playwright coverage is measured, where the gaps are, and the plan to close them
 
 ## Testing Structure
 

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -27,7 +27,7 @@ The ComfyUI Frontend project uses **colocated tests** - test files are placed al
 
 ### Test File Naming
 
-- Use `.test.ts` extension for test files
+- Unit tests use the `.test.ts` extension; Playwright browser tests use `.spec.ts` (Playwright ignores `**/*.test.ts`)
 - Name tests after their source file: `sourceFile.test.ts`
 
 ## Test Frameworks and Libraries

--- a/docs/testing/e2e-coverage-strategy.md
+++ b/docs/testing/e2e-coverage-strategy.md
@@ -16,9 +16,9 @@ regenerated.
   there is no per-area view, so gaps go unnoticed.
 - The headline E2E figure (68.1% of executable lines in loaded chunks) is
   incomplete. V8 coverage only sees chunks the browser actually loaded, so 457
-  source files (~65k raw lines) never enter the denominator. Raw source lines
-  cannot be compared with lcov's executable-line count, so the corrected
-  percentage is not yet known. The `cloud`, `mobile-chrome`, `chromium-2x`, and
+  source files (~65k raw lines) never enter the denominator. Raw source lines cannot be compared with lcov's executable-line count
+  directly; applying the loaded files' executable-to-raw ratio (0.27) to the
+  absent files puts the corrected figure near 54%. The `cloud`, `mobile-chrome`, `chromium-2x`, and
   `chromium-0.5x` projects do not collect coverage, so everything cloud-only
   looks worse than it is, or is invisible.
 - The three cheapest wins are measurement fixes rather than new tests: collect
@@ -82,9 +82,13 @@ regenerated.
    | `composables/boundingBoxes`                  | 1,037     | 2     |
    | `renderer/extensions/compositor`             | 788       | 8     |
 
-   Some of these are type-only or cloud-only (see point 2). Their raw line
-   count does not establish a corrected E2E percentage because lcov counts
-   executable lines, not raw source lines.
+   Some of these are type-only or cloud-only (see point 2). Raw line counts
+   cannot be placed next to lcov's executable-line totals directly. The 1,585
+   loaded `src/` files hold 258k raw lines and 69.8k executable lines, a ratio
+   of 0.27. Applied to the absent files' 65k raw lines that is about 17.5k
+   executable lines, so the corrected E2E figure is near 54% (47.4k of 87.3k)
+   rather than 68%. The absent set is 22% of production files and 20% of raw
+   lines. The exact figure arrives when those files enter the report.
 
 2. Only the `chromium` project collects coverage. The `cloud` project runs
    154 tests against the cloud build, including the agent panel, workspace

--- a/docs/testing/e2e-coverage-strategy.md
+++ b/docs/testing/e2e-coverage-strategy.md
@@ -90,8 +90,8 @@ regenerated.
    rather than 68%. The absent set is 22% of production files and 20% of raw
    lines. The exact figure arrives when those files enter the report.
 
-2. Only the `chromium` project collects coverage. The `cloud` project runs
-   154 tests against the cloud build, including the agent panel, workspace
+2. Only the `chromium` project collects coverage, even though the `cloud`
+   project runs 154 tests against the cloud build, including the agent panel, workspace
    switcher, billing and subscription dialogs, and sign-in. None of that work
    is credited. `workspace` shows 33.9% and `auth` 26.6% in the report, and
    the agent panel shows 2 files, purely because the measuring job never runs

--- a/docs/testing/e2e-coverage-strategy.md
+++ b/docs/testing/e2e-coverage-strategy.md
@@ -1,0 +1,362 @@
+# Playwright Coverage Strategy
+
+Research and plan for raising both code coverage and behavior coverage of the
+Playwright suite without adding redundant tests or CI time.
+
+Numbers below come from the `main` run at commit `e05e929f` (2026-09-01):
+the `CI: Tests E2E` sharded job logs, the `CI: E2E Coverage Package` job log
+(per-file `lines=/hit=` output), and the `CI: Tests Unit` vitest text report.
+The analysis script is described in the appendix so the tables can be
+regenerated.
+
+## 1. Summary
+
+- Coverage is already instrumented end to end for the `chromium` project and
+  published to Codecov (`e2e` flag), GitHub Pages, and Slack. Nothing gates on
+  it, and nobody looks at per-area numbers, so gaps persist unnoticed.
+- The headline E2E figure (68.1% of lines) is inflated. V8 coverage only sees
+  chunks the browser actually loaded, so 457 source files (~65k raw lines,
+  almost as many as the 70.5k lines that are measured) never enter the
+  denominator. The `cloud`, `mobile-*`, and `2x` projects do not collect
+  coverage at all, so everything cloud-only looks worse than it is, or is
+  invisible.
+- The three cheapest wins are measurement fixes, not tests: collect coverage in
+  every project, count never-loaded files, and report coverage per feature area
+  (Codecov components). Each is a one-PR change and turns the existing pipeline
+  into a gap finder.
+- The largest genuine behavior gaps, ranked by user risk times uncovered code:
+  workspace/billing/subscription flows, the layer editor, custom-node manager
+  install/update/conflict flows, model upload, and the video edit panel. The
+  litegraph canvas and legacy canvas widgets are covered by no other layer
+  because the unit config excludes them.
+- Redundancy to reclaim: three node-search specs with duplicated describe
+  blocks, four entry points into the asset browser, and one spec that owns 62
+  of the suite's 185 screenshot assertions. Consolidating those pays for the
+  new tests.
+
+## 2. How coverage is measured today
+
+### Pipeline
+
+| Layer       | Where collected                                                                                  | Output                                                                                           |
+| ----------- | ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------ |
+| Unit        | `ci-tests-unit.yaml`, `pnpm test:coverage` (vitest, v8 provider)                                 | `coverage/lcov.info`, Codecov flag `unit`, `unit-coverage` artifact                              |
+| E2E         | `ci-tests-e2e.yaml`, sharded `chromium` job only, `COLLECT_COVERAGE=true` at build and test time | Per-shard lcov via monocart (`ComfyPage.ts` `page` fixture, `globalTeardown.ts`)                 |
+| E2E merge   | `ci-tests-e2e-coverage-package.yaml`, `scripts/cicd/package-e2e-coverage.sh`                     | `lcov -a` merge, `genhtml` report, `e2e-coverage` + `e2e-coverage-html` artifacts                |
+| E2E publish | `ci-tests-e2e-coverage.yaml` (workflow_run)                                                      | Codecov flag `e2e`, GitHub Pages deploy on `main`                                                |
+| Reporting   | `coverage-slack-notify.yaml`, `scripts/coverage-slack-notify.ts`                                 | Slack post per merged PR with unit and E2E deltas against an 80% target                          |
+| Gating      | `codecov.yml`                                                                                    | Project status disabled; patch status `informational` except `apps/website`; flags carry forward |
+
+### Current numbers (main, 2026-09-01)
+
+| Metric                                     | Value                                                                                           |
+| ------------------------------------------ | ----------------------------------------------------------------------------------------------- |
+| Unit lines / statements / branches / funcs | 76.5% / 75.0% / 68.1% / 70.4%                                                                   |
+| Unit test files, wall time                 | 1450 files, 17.2 min in one job                                                                 |
+| E2E lines (merged, as reported)            | 68.1% (48,026 of 70,520)                                                                        |
+| E2E lines, single shard                    | ~31.5% (each shard sees a third)                                                                |
+| E2E spec files / `test()` calls            | 327 / 1,948 (`chromium` project: ~1,890)                                                        |
+| E2E `chromium` shards                      | 16 shards x 2 workers, 6 to 10 min each                                                         |
+| E2E other projects                         | `cloud` 154 tests 6.3 min; `mobile-chrome` 0.8 min; `2x`, `0.5x`, `mobile-safari` under 0.3 min |
+| E2E wall clock (main push)                 | ~16 min; ~150 runner-minutes                                                                    |
+| Retries in CI                              | 3 (a test may fail three times and still pass)                                                  |
+
+### What the numbers hide
+
+1. **Never-loaded chunks are not counted.** monocart converts V8 coverage for
+   scripts the page fetched. Lazy chunks that no test triggers never appear in
+   the lcov, so the denominator excludes them. Absent from the E2E report
+   entirely: 457 `src/` files. The biggest clusters, in raw source lines:
+
+   | Absent cluster                               | Raw lines | Files |
+   | -------------------------------------------- | --------- | ----- |
+   | `workbench/extensions/agent`                 | 9,567     | 65    |
+   | `renderer/extensions/layerEditor`            | 8,904     | 51    |
+   | `platform/workspace/components`              | 8,525     | 39    |
+   | `platform/workspace/composables`             | 3,206     | 11    |
+   | `platform/cloud/onboarding`                  | 3,039     | 32    |
+   | `platform/telemetry/providers`               | 2,712     | 10    |
+   | `platform/cloud/subscription`                | 2,141     | 16    |
+   | `composables/video` + `components/videoEdit` | 2,296     | 12    |
+   | `composables/boundingBoxes`                  | 1,037     | 2     |
+   | `renderer/extensions/compositor`             | 788       | 8     |
+
+   Some of these are type-only or cloud-only (see point 2), but a true E2E
+   line figure over all of `src/` is closer to 45 to 50% than 68%.
+
+2. **Only the `chromium` project collects coverage.** The `cloud` project runs
+   154 tests against the cloud build, including the agent panel, workspace
+   switcher, billing and subscription dialogs, and sign-in. None of that work
+   is credited. `workspace` shows 33.9% and `auth` 26.6% in the report, and
+   the agent panel shows 2 files, purely because the measuring job never runs
+   those tests.
+
+3. **The litegraph canvas has one measuring layer.** `vite.config.mts`
+   excludes `src/lib/litegraph/src/canvas/**`, `widgets/**`, and the top-level
+   `src/lib/litegraph/src/*.ts` from unit coverage. E2E is therefore the only
+   coverage those 11.9k lines get, and it stands at 49.6% (canvas) and 48.3%
+   (widgets). `CurveEditor`, `KnobWidget`, `ColorWidget`,
+   `GradientSliderWidget`, `InputIndicators`, and `FloatingRenderLink` are at
+   0 to 5%.
+
+4. **No per-area view.** Codecov's project status is off and patch status is
+   informational. The Slack post reports two global percentages. A global 68%
+   cannot tell anyone that `platform/workspace` is at 34% while `vueNodes` is
+   at 81%.
+
+5. **Organizational tags are not used by CI.** `@smoke` is applied to 46 tests
+   and nothing runs it. There is no list of user journeys the suite promises to
+   protect, so behavior coverage is unmeasured.
+
+6. **Flakes are masked.** With `retries: 3`, a test that fails twice per run
+   is still green. The `cloud` job on the analysed run had one flaky test.
+   `report.json` records `flaky` outcomes, and nothing aggregates them.
+
+## 3. Principles from the research
+
+### Composable tests (Kent Beck)
+
+Beck's argument: a test suite is judged as a whole on properties like
+sensitivity, specificity, speed, and cost of change. Isolated tests that each
+set up everything from scratch are easy to reason about but multiply. When two
+dimensions are demonstrably orthogonal, test each dimension once instead of
+the cross product: four interest calculations times five report formats needs
+about nine tests, not twenty. The cost is that orthogonality must be designed
+and shown, and that fewer assertions per test can feel unsafe.
+
+How this applies here:
+
+- Widgets x renderers x node states is a cross product we currently walk
+  in places. Test widget behavior once (Vue nodes, since it is the DOM
+  path), test the renderer toggle once for geometry parity, and test node
+  states once. Do not add a litegraph copy of every Vue-nodes widget spec.
+- Feature x view mode (graph view, linear/app mode, mobile) is another
+  cross product. A feature spec proves the feature; one or two view-mode
+  specs prove the mode swaps the same store state in and out.
+- The `legacyDoNotReplicate` folder is the right shape for compatibility
+  pins: one narrow test per contract, not a copy of the feature suite.
+
+### Playwright best practices (playwright.dev)
+
+The suite's README already encodes most of these. The ones that bear on
+coverage strategy:
+
+- Test user-visible behavior, not implementation. A spec that reaches into
+  `window.app.graph` to mutate state and then screenshots is a weaker
+  behavior test than one that clicks and asserts on visible state.
+- Keep tests isolated; put shared setup in fixtures. The `comfyPage` fixture
+  and page objects are the composable building blocks Beck describes.
+- Mock third parties, test what you control. The typed mock tables in
+  `browser_tests/README.md` are the mechanism. Cloud, billing, and manager
+  flows are testable in the `chromium` project with routes, without a live
+  backend.
+- Use web-first assertions and `expect.poll`; never fixed waits.
+- Use tags and projects to route tests, and shard by test file. Both are in
+  place. A tag-selected smoke project is the missing piece.
+- Prefer functional assertions to screenshots; screenshots when appearance
+  is the behavior.
+
+### Code coverage versus behavior coverage
+
+Line coverage is an execution metric. Research on behavioral test adequacy
+(mutation testing studies and the 2026 "behavioural gaps" paper) is
+consistent: code with 100% line coverage still has untested behaviors in
+roughly a third of methods, because coverage cannot see missing assertions.
+Mutation testing detects assertion gaps but is far too slow for E2E suites.
+For this suite the practical translation is:
+
+- Use E2E coverage to find **execution gaps**: areas the suite never loads
+  or barely touches. That is exactly what the tables in section 4 show.
+- Use a **journey inventory** to find **assertion gaps**: for each critical
+  user journey, name the spec that proves it and the observable it asserts.
+- Reserve mutation testing (StrykerJS) for pure, well-unit-tested modules
+  where it is cheap: schema validators, workflow migration, keybinding
+  parsing. It is out of scope for Playwright.
+
+## 4. Gap inventory
+
+E2E percentages are measured lines hit. "Absent" means the chunk never loaded
+in the `chromium` project, so nothing was measured. Unit percentages are per
+directory from the vitest report.
+
+### Feature areas
+
+| Area                                        | E2E                                                                            | Unit                           | Risk if broken                      | Verdict                                       |
+| ------------------------------------------- | ------------------------------------------------------------------------------ | ------------------------------ | ----------------------------------- | --------------------------------------------- |
+| `renderer/extensions/vueNodes`              | 81.0% (3,784 lines)                                                            | high                           | Every node on the canvas            | Well covered; do not add more here            |
+| `platform/workflow` (load/save/tabs)        | 68.2% (2,670)                                                                  | high                           | Data loss                           | Covered; keep                                 |
+| `stores`                                    | 71.5% (4,630)                                                                  | 86%                            | Everything                          | Covered via UI and unit                       |
+| `platform/settings`, setting dialog         | 87.6% / 92.8%                                                                  | high                           | Config                              | Covered                                       |
+| `lib/litegraph/src/subgraph`                | 80.8% (1,335)                                                                  | excluded partly                | Subgraph editing                    | Covered by 24 specs                           |
+| `lib/litegraph/src/canvas`                  | 49.6% (799)                                                                    | **excluded**                   | Canvas rendering, links, indicators | Sole layer; targeted specs needed             |
+| `lib/litegraph/src/widgets`                 | 48.3% (720)                                                                    | **excluded**                   | Legacy-renderer widgets             | Sole layer; knob/color/gradient/curve at ~0%  |
+| `extensions/core` (built-ins)               | 50.4% (5,487)                                                                  | 54%                            | Group nodes, reroutes, uploads, 3D  | Mixed; see per-extension table                |
+| `extensions/core/cameraInfo`                | 6.8% (855)                                                                     | ~87%                           | 3D camera overlay                   | Unit-covered; low E2E priority                |
+| `composables/maskeditor`                    | 52.1% (1,869)                                                                  | ~94%                           | Mask editor tools                   | Three specs exist; tool coverage thin         |
+| `workbench/extensions/manager`              | 54.5% (1,858) + 2k absent                                                      | ~44% (components)              | Custom-node install/update          | Install, update, conflict dialogs untested    |
+| `platform/assets` (browser)                 | 48.7% (2,234)                                                                  | mid                            | Media/model browsing                | Browse well covered by 37 specs               |
+| `platform/assets/components/UploadModel*`   | 14.1% (64) + dialogs absent                                                    | none                           | Model upload                        | Gap                                           |
+| `components/videoEdit`, `composables/video` | absent (2,296 raw)                                                             | ~78%                           | Video trim widget                   | Gap                                           |
+| `renderer/extensions/layerEditor`           | absent (8,904 raw)                                                             | ~99% (GPU compositor excluded) | Image layer editing                 | No browser-level proof at all; unit is strong |
+| `renderer/extensions/compositor`            | 7.0% (43) + 788 absent                                                         | ?                              | Image compositor overlay            | Gap                                           |
+| `platform/workspace`                        | 33.9% (2,262) + 11.7k absent                                                   | store ~59%                     | Team membership, credits, billing   | Cloud-only; unmeasured, likely under-tested   |
+| `platform/cloud/subscription`, checkout     | 43.3% (563) + 2.1k absent; `useSubscriptionCheckout.ts` 1,569 raw lines absent | high                           | Revenue                             | Cloud-only; unmeasured                        |
+| `platform/cloud/onboarding`                 | absent (3,039 raw)                                                             | ~58%                           | First-run cloud flow                | Cloud-only; unmeasured                        |
+| `workbench/extensions/agent`                | absent (9,567 raw)                                                             | ~93%                           | Cloud agent panel                   | 2 `@cloud` specs, unmeasured                  |
+| `platform/auth`, `dialog/content/signin`    | 26.6% / 39.6%                                                                  | mixed                          | Sign-in                             | Cloud-only; unmeasured                        |
+| `platform/telemetry`                        | 37.5% + providers absent                                                       | ~63%                           | Analytics only                      | Deliberately low E2E; unit is the right layer |
+
+### Built-in extensions with no E2E spec exercising them
+
+Measured hits confirm the spec-name scan: `contextMenuFilter.ts` (8.9%),
+`clipspace.ts` (4.8%), `saveMesh.ts` (22%), `load3dPreviewExtensions.ts`
+(15%), `load3d/ModelExporter.ts` (7%), `load3d/PointCloudModelAdapter.ts`
+(4%), `simpleTouchSupport.ts` (32%, mobile only), `dynamicPrompts.ts`,
+`slotDefaults.ts`, `saveText.ts`, `imageCompositor.ts`, `layerEditor.ts`.
+`groupNode.ts` (75%), `widgetInputs.ts` (75%), `rerouteNode.ts` (68%), and
+`nodeTemplates.ts` (63%) are fine.
+
+### Redundancy to reclaim
+
+| Family                                                                                                                          | Observation                                                                                                      | Action                                                                                         |
+| ------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| `nodeSearchBox.spec.ts` (24), `nodeSearchBoxV2.spec.ts` (12), `nodeSearchBoxV2Extended.spec.ts` (20)                            | V2 and V2Extended repeat the same describe titles (`Category navigation`, `Filter workflow`, `Category sidebar`) | Merge V2 files into `tests/nodeSearch/`; diff the duplicated describes and keep one            |
+| `sidebar/assets.spec.ts` (48), `sidebar/assetsSidebarTab.spec.ts` (16), `assetHelper.spec.ts` (21), `browseModelAssets.spec.ts` | Four entry points to one browser                                                                                 | Fold into `tests/assets/` by behavior (browse, filter, sort, select, context menu)             |
+| `interaction.spec.ts`                                                                                                           | 64 tests, 62 `toHaveScreenshot`; its snapshot folder is the most churned path in `browser_tests` since June      | Convert link/drag/select assertions to `nodeOps` state checks; keep screenshots for appearance |
+| `appMode*.spec.ts` (11 files) + `linearMode.spec.ts`                                                                            | Fragmented, not duplicated                                                                                       | Move under `tests/appMode/`; no test changes                                                   |
+| `keybindings.spec.ts`, `defaultKeybindings.spec.ts`, `keyboardShortcutActions.spec.ts`, `keybindingPanel.spec.ts`               | Overlapping fixtures, distinct behaviors                                                                         | Leave; document the split in a folder README                                                   |
+| `@screenshot` (104 tests, 185 assertions)                                                                                       | Screenshot maintenance dominates flake and regen PR volume                                                       | Audit against README rule "screenshots only when appearance is the behavior"                   |
+
+## 5. Plan
+
+Ordered by safety gained per hour. Each phase is independently shippable.
+
+### Phase 0: make the existing measurement honest (three small PRs)
+
+1. **Collect coverage in every Playwright project.** Set
+   `COLLECT_COVERAGE: 'true'` on the `playwright-tests` matrix job and pass it
+   to `build-cloud-frontend` so the cloud bundle keeps its
+   `sourceMappingURL` comments. Upload each project's `coverage/playwright/`
+   as `e2e-coverage-shard-<project>`; the package script already merges any
+   `e2e-coverage-shard-*` artifact. Expected effect: workspace, subscription,
+   onboarding, auth, and agent code starts being credited, and the real gap
+   there becomes visible.
+2. **Count never-loaded files.** Give monocart the `all` option in
+   `globalTeardown.ts` (`all: { dir: ['src'], filter: coverageSourceFilter }`)
+   so source files with no V8 entry are reported at 0% instead of omitted. The
+   Slack target and the Pages report then describe the whole app. The
+   headline number will drop; that is the point.
+3. **Report per area.** Add Codecov `component_management` entries keyed to
+   the areas in section 4 (vueNodes, litegraph canvas, litegraph widgets,
+   extensions/core, workflow, assets, manager, workspace, cloud, layerEditor,
+   maskeditor, agent). Each PR comment then shows a per-component table for
+   `unit`, `e2e`, and combined. Keep statuses informational; the value is
+   visibility, not blocking. Optionally extend
+   `scripts/coverage-slack-notify.ts` to print the three lowest components.
+
+Also worth folding into this phase: a `scripts/coverage-gaps.ts` that joins
+the two lcov files and lists files where both layers are below 30%, grouped by
+directory, written to the step summary of the package job. That is the script
+from the appendix, made permanent.
+
+### Phase 1: write the journey inventory and run it as smoke
+
+1. Create `browser_tests/JOURNEYS.md` listing the user journeys the suite
+   promises to protect, each with the spec and the observable it asserts.
+   First draft, from the product surface: open app and load default graph;
+   load a template and queue it to completion; save, reload, and reopen a
+   workflow tab; add a node via search and connect it; edit a widget and see
+   the value serialize; enter and exit a subgraph; undo and redo; copy and
+   paste across tabs; open the mask editor and save; install a custom node
+   pack; sign in and switch workspace (cloud); top up credits (cloud).
+2. Tag exactly one spec per journey `@smoke`, and remove `@smoke` from tests
+   that are not journeys. Add a `smoke` Playwright project that greps
+   `@smoke`, and run it first in `ci-tests-e2e.yaml` so a broken journey fails
+   in about two minutes instead of fifteen. The existing 16 shards keep
+   running; the smoke project is a fast-fail, not a replacement.
+3. Journeys with no spec become the first new tests. From the current draft
+   that is: install a custom node pack (manager), and top up credits and
+   change plan (workspace/billing), both testable with typed route mocks in
+   the `chromium` project.
+
+### Phase 2: fill the highest-value execution gaps
+
+One spec folder each, using existing page objects where they exist. Target
+the journey, not line count; the lines follow because the chunk loads.
+
+| Order | Area                               | First test to write                                                                                                         | Why first                                                                                                            |
+| ----- | ---------------------------------- | --------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| 1     | Layer editor                       | Open from an image node, add a layer, transform it, apply, and assert the node's image input changed                        | 8.9k lines never executed in a browser; the WebGL compositor has no unit test either; a single flow loads most of it |
+| 2     | Manager install/update/conflict    | Mock registry and manager routes; install a pack, see the restart prompt; open a version popover; trigger a conflict dialog | User-facing failure mode is "extension broke ComfyUI"                                                                |
+| 3     | Model upload                       | Open Upload Model dialog, pick file, see progress dialog, asset appears in browser                                          | 10 components at 14%; small, self-contained                                                                          |
+| 4     | Video edit panel                   | Open the trim panel on a video widget, set in/out points, assert widget value                                               | 2.3k lines absent; widget-level behavior                                                                             |
+| 5     | Litegraph canvas widgets           | One spec per legacy widget kind (knob, color, gradient, curve) on the litegraph renderer: interact, assert value            | Sole coverage layer; each spec is small                                                                              |
+| 6     | Mask editor tools                  | Brush size and opacity, eraser, layer toggle, undo inside editor                                                            | Heavily used; composables at 52%                                                                                     |
+| 7     | Workspace and subscription (cloud) | Decide after Phase 0 step 1 reveals what the 154 cloud tests already cover                                                  | Highest business risk, but currently unmeasured                                                                      |
+
+Skip on purpose: `cameraInfo` (unit-covered, niche), `telemetry` (unit is
+the correct layer), `mobile-safari` expansion (README says use sparingly),
+and any second-renderer copy of an existing Vue-nodes widget spec.
+
+### Phase 3: consolidate and cap cost
+
+1. Merge the node-search and asset-browser spec families per the redundancy
+   table. Measure before and after with the per-component report from
+   Phase 0; the merged files must not lower any component.
+2. Convert `interaction.spec.ts` screenshot assertions to state assertions
+   where the behavior is link, position, or selection state. Keep the
+   appearance ones. This removes the most churned snapshot directory.
+3. Aggregate `flaky` outcomes from `report.json` in `merge-reports` and post
+   the count in the PR comment. Once the count is stable, lower CI
+   `retries` from 3 to 2. Do not lower it first.
+4. Shard `ci-tests-unit.yaml` (vitest `--shard`) to cut its 17-minute wall
+   clock; unrelated to coverage but the same runner budget.
+
+### Phase 4: keep it from regressing
+
+- Add a `changes-filter` output for new files under
+  `src/renderer/extensions/**`, `src/platform/**`, and `src/workbench/**`, and
+  have the PR report comment ask for a spec folder when a new feature
+  directory ships with no matching `browser_tests/tests/<feature>/`. Advisory,
+  not blocking.
+- Once Phase 0 has run for a month, set per-component Codecov thresholds at
+  current value minus 2% for the well-covered areas only (vueNodes, workflow,
+  settings, subgraph). Never a global threshold; that is what got the
+  project status disabled.
+- Review `JOURNEYS.md` whenever a feature ships behind a flag flip; a flag
+  that turns a feature on for users should turn its journey into `@smoke`.
+
+## 6. What this plan does not do
+
+- It does not chase a global percentage. The Slack target of 80% stays as a
+  trend line only.
+- It does not add E2E tests for pure logic that has unit tests. Coverage
+  gaps that are unit-shaped (schema, parsers, `graphMutations.ts`, which is
+  currently only imported by the agent CRDT follower) go to Vitest.
+- It does not introduce mutation testing for the browser suite.
+- It does not add tests to `legacyDoNotReplicate`; new compatibility pins
+  follow that folder's pattern only when a custom-node breakage proves the
+  contract matters.
+
+## Appendix: reproducing the numbers
+
+1. Find the latest green `CI: Tests E2E` run on `main` and its
+   `upload-e2e-coverage / package` job. The job log contains one
+   `Processing file <path>` and `lines=<n> hit=<n>` pair per source file that
+   entered the merged lcov, followed by `Overall coverage rate`. Parse those
+   pairs into `path, lines, hit`.
+2. From the matching `CI: Tests Unit` run, the vitest text reporter prints
+   the per-directory table (`File | % Stmts | % Branch | % Funcs | % Lines`).
+   Directory rows are complete; file names are truncated and need suffix
+   matching against the repo tree. The `unit-coverage` artifact
+   (`lcov.info`) is the exact source when artifact download is available.
+3. Files under `src/` that have no `Processing file` entry are the
+   never-loaded set. Count their raw lines with `wc -l`.
+4. Per-shard `Coverage summary` blocks and `N passed (Xm)` lines are at the
+   end of each `playwright-tests-chromium-sharded` job log.
+
+Sources consulted: Kent Beck, "Composable Tests" (tidyfirst.substack.com);
+Playwright, "Best Practices" (playwright.dev/docs/best-practices);
+monocart-coverage-reports documentation; Codecov, "Mutation Testing: How to
+Ensure Code Coverage Isn't a Vanity Metric"; "Beyond Coverage and Kill Scores:
+Empirically Measuring Test Suite Behavioural Gaps" (arXiv 2606.10417).

--- a/docs/testing/e2e-coverage-strategy.md
+++ b/docs/testing/e2e-coverage-strategy.md
@@ -99,8 +99,8 @@ regenerated.
    `GradientSliderWidget`, `InputIndicators`, and `FloatingRenderLink` are at
    0 to 5%.
 
-4. No per-area view. Codecov's project status is off and patch status is
-   informational. The Slack post reports two global percentages. A global 68%
+4. There is no per-area view: Codecov's project status is off and patch
+   status is informational. The Slack post reports two global percentages. A global 68%
    cannot tell anyone that `platform/workspace` is at 34% while `vueNodes` is
    at 81%.
 
@@ -108,8 +108,8 @@ regenerated.
    nothing runs it, and there is no list of the user journeys the suite
    promises to protect, so behavior coverage is unmeasured.
 
-6. Flakes are masked. With `retries: 3`, a test that fails twice per run
-   is still green. The `cloud` job on the analysed run had one flaky test.
+6. Three retries mask flakes, because a test that fails twice per run is
+   still green. The `cloud` job on the analysed run had one flaky test.
    `report.json` records `flaky` outcomes, and nothing aggregates them.
 
 ## 3. Principles from the research
@@ -233,21 +233,22 @@ Ordered by safety gained per hour. Each phase is independently shippable.
 
 ### Phase 0: make the existing measurement honest (three small PRs)
 
-1. Collect coverage in every Playwright project. Set
-   `COLLECT_COVERAGE: 'true'` on the `playwright-tests` matrix job and pass it
+1. Collect coverage in every Playwright project by setting
+   `COLLECT_COVERAGE: 'true'` on the `playwright-tests` matrix job and passing
+   it
    to `build-cloud-frontend` so the cloud bundle keeps its
    `sourceMappingURL` comments. Upload each project's `coverage/playwright/`
    as `e2e-coverage-shard-<project>`; the package script already merges any
    `e2e-coverage-shard-*` artifact. Expected effect: workspace, subscription,
    onboarding, auth, and agent code starts being credited, and the real gap
    there becomes visible.
-2. Count never-loaded files. Give monocart the `all` option in
+2. Count never-loaded files by giving monocart the `all` option in
    `globalTeardown.ts` (`all: { dir: ['src'], filter: coverageSourceFilter }`)
    so source files with no V8 entry are reported at 0% instead of omitted, and
    the Slack target and the Pages report then describe the whole app. The
    headline number will drop, and that drop is the intended effect.
-3. Report per area. Add Codecov `component_management` entries keyed to
-   the areas in section 4 (vueNodes, litegraph canvas, litegraph widgets,
+3. Report per area by adding Codecov `component_management` entries keyed
+   to the areas in section 4 (vueNodes, litegraph canvas, litegraph widgets,
    extensions/core, workflow, assets, manager, workspace, cloud, layerEditor,
    maskeditor, agent). Each PR comment then shows a per-component table for
    `unit`, `e2e`, and combined. Keep statuses informational. The goal is that people see the table, and a

--- a/docs/testing/e2e-coverage-strategy.md
+++ b/docs/testing/e2e-coverage-strategy.md
@@ -14,16 +14,17 @@ regenerated.
 - Coverage is already instrumented end to end for the `chromium` project and
   published to Codecov (`e2e` flag), GitHub Pages, and Slack. Nothing gates on it and
   there is no per-area view, so gaps go unnoticed.
-- The headline E2E figure (68.1% of lines) is inflated. V8 coverage only sees
-  chunks the browser actually loaded, so 457 source files (~65k raw lines,
-  almost as many as the 70.5k lines that are measured) never enter the
-  denominator. The `cloud`, `mobile-*`, and `2x` projects do not collect
-  coverage at all, so everything cloud-only looks worse than it is, or is
-  invisible.
-- The three cheapest wins are measurement fixes rather than new tests: collect coverage in
-  every project, count never-loaded files, and report coverage per feature area
-  (Codecov components). Each is a one-PR change and turns the existing pipeline
-  into a gap finder.
+- The headline E2E figure (68.1% of executable lines in loaded chunks) is
+  incomplete. V8 coverage only sees chunks the browser actually loaded, so 457
+  source files (~65k raw lines) never enter the denominator. Raw source lines
+  cannot be compared with lcov's executable-line count, so the corrected
+  percentage is not yet known. The `cloud`, `mobile-chrome`, `chromium-2x`, and
+  `chromium-0.5x` projects do not collect coverage, so everything cloud-only
+  looks worse than it is, or is invisible.
+- The three cheapest wins are measurement fixes rather than new tests: collect
+  coverage in supported CI projects, count never-loaded files, and report
+  coverage per feature area (Codecov components). Each is a one-PR change and
+  turns the existing pipeline into a gap finder.
 - The largest genuine behavior gaps, ranked by user risk times uncovered code:
   workspace/billing/subscription flows, the layer editor, custom-node manager
   install/update/conflict flows, model upload, and the video edit panel. The
@@ -81,8 +82,9 @@ regenerated.
    | `composables/boundingBoxes`                  | 1,037     | 2     |
    | `renderer/extensions/compositor`             | 788       | 8     |
 
-   Some of these are type-only or cloud-only (see point 2), but a true E2E
-   line figure over all of `src/` is closer to 45 to 50% than 68%.
+   Some of these are type-only or cloud-only (see point 2). Their raw line
+   count does not establish a corrected E2E percentage because lcov counts
+   executable lines, not raw source lines.
 
 2. Only the `chromium` project collects coverage. The `cloud` project runs
    154 tests against the cloud build, including the agent panel, workspace
@@ -153,16 +155,16 @@ coverage strategy:
 - Use web-first assertions and `expect.poll`; never fixed waits.
 - Use tags and projects to route tests, and shard by test file. Both are in
   place. A tag-selected smoke project is the missing piece.
-- Prefer functional assertions to screenshots; screenshots when appearance
-  is the behavior.
+- Prefer user-visible assertions to screenshots; use screenshots when
+  appearance is the behavior.
 
 ### Code coverage versus behavior coverage
 
-Line coverage is an execution metric. Research on behavioral test adequacy
-(mutation testing studies and the 2026 "behavioural gaps" paper) is
-consistent: code with 100% line coverage still has untested behaviors in
-roughly a third of methods, because coverage cannot see missing assertions.
-Mutation testing detects assertion gaps but is far too slow for E2E suites.
+Line coverage is an execution metric. The 2026 "behavioural gaps" paper finds
+that about 17.5% of expected behaviours are entirely untested, with most of
+those gaps in methods that already have high line coverage. Coverage cannot
+see missing assertions. Mutation testing detects assertion gaps but is far too
+slow for E2E suites.
 For this suite the practical translation is:
 
 - Use E2E coverage to find **execution gaps**: areas the suite never loads
@@ -195,7 +197,7 @@ directory from the vitest report.
 | `composables/maskeditor`                    | 52.1% (1,869)                                                                  | ~94%                           | Mask editor tools                   | Three specs exist; tool coverage thin         |
 | `workbench/extensions/manager`              | 54.5% (1,858) + 2k absent                                                      | ~44% (components)              | Custom-node install/update          | Install, update, conflict dialogs untested    |
 | `platform/assets` (browser)                 | 48.7% (2,234)                                                                  | mid                            | Media/model browsing                | Browse well covered by 37 specs               |
-| `platform/assets/components/UploadModel*`   | 14.1% (64) + dialogs absent                                                    | none                           | Model upload                        | Gap                                           |
+| `platform/assets/components/UploadModel*`   | 14.1% (64) + dialogs absent                                                    | wizard and components tested   | Model upload                        | Browser integration gap                       |
 | `components/videoEdit`, `composables/video` | absent (2,296 raw)                                                             | ~78%                           | Video trim widget                   | Gap                                           |
 | `renderer/extensions/layerEditor`           | absent (8,904 raw)                                                             | ~99% (GPU compositor excluded) | Image layer editing                 | No browser-level proof at all; unit is strong |
 | `renderer/extensions/compositor`            | 7.0% (43) + 788 absent                                                         | ?                              | Image compositor overlay            | Gap                                           |
@@ -218,14 +220,14 @@ Measured hits confirm the spec-name scan: `contextMenuFilter.ts` (8.9%),
 
 ### Redundancy to reclaim
 
-| Family                                                                                                                          | Observation                                                                                                      | Action                                                                                         |
-| ------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
-| `nodeSearchBox.spec.ts` (24), `nodeSearchBoxV2.spec.ts` (12), `nodeSearchBoxV2Extended.spec.ts` (20)                            | V2 and V2Extended repeat the same describe titles (`Category navigation`, `Filter workflow`, `Category sidebar`) | Merge V2 files into `tests/nodeSearch/`; diff the duplicated describes and keep one            |
-| `sidebar/assets.spec.ts` (48), `sidebar/assetsSidebarTab.spec.ts` (16), `assetHelper.spec.ts` (21), `browseModelAssets.spec.ts` | Four entry points to one browser                                                                                 | Fold into `tests/assets/` by behavior (browse, filter, sort, select, context menu)             |
-| `interaction.spec.ts`                                                                                                           | 64 tests, 62 `toHaveScreenshot`; its snapshot folder is the most churned path in `browser_tests` since June      | Convert link/drag/select assertions to `nodeOps` state checks; keep screenshots for appearance |
-| `appMode*.spec.ts` (11 files) + `linearMode.spec.ts`                                                                            | Fragmented but no duplication                                                                                    | Move under `tests/appMode/`; test bodies unchanged                                             |
-| `keybindings.spec.ts`, `defaultKeybindings.spec.ts`, `keyboardShortcutActions.spec.ts`, `keybindingPanel.spec.ts`               | Overlapping fixtures, distinct behaviors                                                                         | Leave; document the split in a folder README                                                   |
-| `@screenshot` (104 tests, 185 assertions)                                                                                       | Screenshot maintenance dominates flake and regen PR volume                                                       | Audit against README rule "screenshots only when appearance is the behavior"                   |
+| Family                                                                                                                          | Observation                                                                                                      | Action                                                                                                  |
+| ------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| `nodeSearchBox.spec.ts` (24), `nodeSearchBoxV2.spec.ts` (12), `nodeSearchBoxV2Extended.spec.ts` (20)                            | V2 and V2Extended repeat the same describe titles (`Category navigation`, `Filter workflow`, `Category sidebar`) | Merge V2 files into `tests/nodeSearch/`; diff the duplicated describes and keep one                     |
+| `sidebar/assets.spec.ts` (48), `sidebar/assetsSidebarTab.spec.ts` (16), `assetHelper.spec.ts` (21), `browseModelAssets.spec.ts` | Four entry points to one browser                                                                                 | Fold into `tests/assets/` by behavior (browse, filter, sort, select, context menu)                      |
+| `interaction.spec.ts`                                                                                                           | 64 tests, 62 `toHaveScreenshot`; its snapshot folder is the most churned path in `browser_tests` since June      | Keep screenshots where the visual result is the behavior; otherwise assert another user-visible outcome |
+| `appMode*.spec.ts` (11 files) + `linearMode.spec.ts`                                                                            | Fragmented but no duplication                                                                                    | Move under `tests/appMode/`; test bodies unchanged                                                      |
+| `keybindings.spec.ts`, `defaultKeybindings.spec.ts`, `keyboardShortcutActions.spec.ts`, `keybindingPanel.spec.ts`               | Overlapping fixtures, distinct behaviors                                                                         | Leave; document the split in a folder README                                                            |
+| `@screenshot` (104 tests, 185 assertions)                                                                                       | Screenshot maintenance dominates flake and regen PR volume                                                       | Audit against README rule "screenshots only when appearance is the behavior"                            |
 
 ## 5. Plan
 
@@ -233,32 +235,36 @@ Ordered by safety gained per hour. Each phase is independently shippable.
 
 ### Phase 0: make the existing measurement honest (three small PRs)
 
-1. Collect coverage in every Playwright project by setting
-   `COLLECT_COVERAGE: 'true'` on the `playwright-tests` matrix job and passing
-   it
-   to `build-cloud-frontend` so the cloud bundle keeps its
-   `sourceMappingURL` comments. Upload each project's `coverage/playwright/`
-   as `e2e-coverage-shard-<project>`; the package script already merges any
-   `e2e-coverage-shard-*` artifact. Expected effect: workspace, subscription,
-   onboarding, auth, and agent code starts being credited, and the real gap
-   there becomes visible.
-2. Count never-loaded files by giving monocart the `all` option in
-   `globalTeardown.ts` (`all: { dir: ['src'], filter: coverageSourceFilter }`)
-   so source files with no V8 entry are reported at 0% instead of omitted, and
-   the Slack target and the Pages report then describe the whole app. The
-   headline number will drop, and that drop is the intended effect.
-3. Report per area by adding Codecov `component_management` entries keyed
-   to the areas in section 4 (vueNodes, litegraph canvas, litegraph widgets,
+1. Collect coverage in the Chromium-based projects run by
+   `ci-tests-e2e.yaml`: `chromium`, `cloud`, `mobile-chrome`, `chromium-2x`,
+   and `chromium-0.5x`. Set `COLLECT_COVERAGE: 'true'` on the
+   `playwright-tests` matrix job and pass it to `build-cloud-frontend` so the
+   cloud bundle keeps its `sourceMappingURL` comments. Upload each project's
+   `coverage/playwright/` under a unique artifact name that includes the
+   project and, for sharded jobs, the shard index. Add `playwright-tests` to
+   the package job's dependencies and reject an incomplete expected artifact
+   set instead of silently producing a partial merge. `mobile-safari` remains
+   excluded because Playwright coverage is Chromium-only. Keep `performance`
+   uninstrumented under ADR 0022; no regular CI job runs `audit`.
+2. Count never-loaded production files through monocart's `all` option so
+   source files with no V8 entry are reported at 0% instead of omitted. The
+   implementation must transform TypeScript and Vue files before monocart
+   parses them and use the same production-source exclusions as Vitest rather
+   than reusing `coverageSourceFilter`. The Slack target and Pages report then
+   describe the same denominator. The headline number will drop, and that drop
+   is the intended effect.
+3. Report per area by adding Codecov `component_management` entries keyed to
+   the areas in section 4 (vueNodes, litegraph canvas, litegraph widgets,
    extensions/core, workflow, assets, manager, workspace, cloud, layerEditor,
-   maskeditor, agent). Each PR comment then shows a per-component table for
-   `unit`, `e2e`, and combined. Keep statuses informational. The goal is that people see the table, and a
-   blocking status would only get disabled again. Optionally extend
+   maskeditor, agent). Each PR comment then shows combined coverage by
+   component, while the existing flags show overall `unit` and `e2e` coverage.
+   Keep statuses informational. Optionally extend
    `scripts/coverage-slack-notify.ts` to print the three lowest components.
 
-Also worth folding into this phase: a `scripts/coverage-gaps.ts` that joins
-the two lcov files and lists files where both layers are below 30%, grouped by
-directory, written to the step summary of the package job. That is the script
-from the appendix, made permanent.
+Also worth folding into this phase: a `scripts/coverage-gaps.ts` that joins the
+union of file paths in the two lcov files, treats a missing layer as zero, and
+lists files where both layers are below 30%. Group the result by directory and
+write it to the package job's step summary.
 
 ### Phase 1: write the journey inventory and run it as smoke
 
@@ -267,14 +273,14 @@ from the appendix, made permanent.
    First draft, from the product surface: open app and load default graph;
    load a template and queue it to completion; save, reload, and reopen a
    workflow tab; add a node via search and connect it; edit a widget and see
-   the value serialize; enter and exit a subgraph; undo and redo; copy and
+   its displayed value change; enter and exit a subgraph; undo and redo; copy and
    paste across tabs; open the mask editor and save; install a custom node
    pack; sign in and switch workspace (cloud); top up credits (cloud).
 2. Tag exactly one spec per journey `@smoke`, and remove `@smoke` from tests
    that are not journeys. Add a `smoke` Playwright project that greps
-   `@smoke`, and run it first in `ci-tests-e2e.yaml` so a broken journey fails
-   in about two minutes instead of fifteen. The existing 16 shards keep
-   running; the smoke project fails fast ahead of them and replaces nothing.
+   `@smoke`. Make the existing 16 shards depend on it so a broken journey
+   stops the full run after about two minutes. This adds the smoke runtime to
+   the critical path when it passes.
 3. Journeys with no spec become the first new tests. From the current draft
    that is: install a custom node pack (manager), and top up credits and
    change plan (workspace/billing), both testable with typed route mocks in
@@ -287,11 +293,11 @@ loads.
 
 | Order | Area                               | First test to write                                                                                                         | Why first                                                                                                            |
 | ----- | ---------------------------------- | --------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
-| 1     | Layer editor                       | Open from an image node, add a layer, transform it, apply, and assert the node's image input changed                        | 8.9k lines never executed in a browser; the WebGL compositor has no unit test either; a single flow loads most of it |
+| 1     | Layer editor                       | Open from an image node, add a layer, transform it, apply, and see the edited image on the node                             | 8.9k lines never executed in a browser; the WebGL compositor has no unit test either; a single flow loads most of it |
 | 2     | Manager install/update/conflict    | Mock registry and manager routes; install a pack, see the restart prompt; open a version popover; trigger a conflict dialog | User-facing failure mode is "extension broke ComfyUI"                                                                |
-| 3     | Model upload                       | Open Upload Model dialog, pick file, see progress dialog, asset appears in browser                                          | 10 components at 14%; small, self-contained                                                                          |
-| 4     | Video edit panel                   | Open the trim panel on a video widget, set in/out points, assert widget value                                               | 2.3k lines absent; widget-level behavior                                                                             |
-| 5     | Litegraph canvas widgets           | One spec per legacy widget kind (knob, color, gradient, curve) on the litegraph renderer: interact, assert value            | Sole coverage layer; each spec is small                                                                              |
+| 3     | Model upload                       | Open Upload Model dialog, pick a file, see upload progress, and find the asset in the browser                               | Component behavior has unit coverage; the gap is dialog-to-browser integration                                       |
+| 4     | Video edit panel                   | Open the trim panel on a video widget, set in/out points, and see the selected range in the panel                           | 2.3k lines absent; widget-level behavior                                                                             |
+| 5     | Litegraph canvas widgets           | One spec per legacy widget kind (knob, color, gradient, curve): interact and see the displayed value change                 | Sole coverage layer; each spec is small                                                                              |
 | 6     | Mask editor tools                  | Brush size and opacity, eraser, layer toggle, undo inside editor                                                            | Heavily used; composables at 52%                                                                                     |
 | 7     | Workspace and subscription (cloud) | Decide after Phase 0 step 1 reveals what the 154 cloud tests already cover                                                  | Highest business risk, but currently unmeasured                                                                      |
 
@@ -304,9 +310,9 @@ and any second-renderer copy of an existing Vue-nodes widget spec.
 1. Merge the node-search and asset-browser spec families per the redundancy
    table. Measure before and after with the per-component report from
    Phase 0; the merged files must not lower any component.
-2. Convert `interaction.spec.ts` screenshot assertions to state assertions
-   where the behavior is link, position, or selection state. Keep the
-   appearance ones. This removes the most churned snapshot directory.
+2. Keep `interaction.spec.ts` screenshots where the visual result is the
+   behavior. Replace the rest only when another user-visible assertion proves
+   the same result. This reduces churn without testing implementation state.
 3. Aggregate `flaky` outcomes from `report.json` in `merge-reports` and post
    the count in the PR comment. Once the count is stable, lower CI
    `retries` from 3 to 2. Lowering it before the count exists would only hide
@@ -316,11 +322,6 @@ and any second-renderer copy of an existing Vue-nodes widget spec.
 
 ### Phase 4: keep it from regressing
 
-- Add a `changes-filter` output for new files under
-  `src/renderer/extensions/**`, `src/platform/**`, and `src/workbench/**`, and
-  have the PR report comment ask for a spec folder when a new feature
-  directory ships with no matching `browser_tests/tests/<feature>/`. Advisory,
-  not blocking.
 - Once Phase 0 has run for a month, set per-component Codecov thresholds at
   current value minus 2% for the well-covered areas only (vueNodes, workflow,
   settings, subgraph). A global threshold is what got the project status disabled, so none is
@@ -332,9 +333,9 @@ and any second-renderer copy of an existing Vue-nodes widget spec.
 
 - It does not chase a global percentage. The Slack target of 80% stays as a
   trend line only.
-- It does not add E2E tests for pure logic that has unit tests. Coverage
-  gaps that are unit-shaped (schema, parsers, `graphMutations.ts`, which is
-  currently only imported by the agent CRDT follower) go to Vitest.
+- It does not add E2E tests for pure logic that has unit tests. Coverage gaps
+  that are unit-shaped, such as schema validators, parsers, and agent graph
+  mutations, go to Vitest.
 - It does not introduce mutation testing for the browser suite.
 - It does not add tests to `legacyDoNotReplicate`; new compatibility pins
   follow that folder's pattern only when a custom-node breakage proves the

--- a/docs/testing/e2e-coverage-strategy.md
+++ b/docs/testing/e2e-coverage-strategy.md
@@ -12,15 +12,15 @@ regenerated.
 ## 1. Summary
 
 - Coverage is already instrumented end to end for the `chromium` project and
-  published to Codecov (`e2e` flag), GitHub Pages, and Slack. Nothing gates on
-  it, and nobody looks at per-area numbers, so gaps persist unnoticed.
+  published to Codecov (`e2e` flag), GitHub Pages, and Slack. Nothing gates on it and
+  there is no per-area view, so gaps go unnoticed.
 - The headline E2E figure (68.1% of lines) is inflated. V8 coverage only sees
   chunks the browser actually loaded, so 457 source files (~65k raw lines,
   almost as many as the 70.5k lines that are measured) never enter the
   denominator. The `cloud`, `mobile-*`, and `2x` projects do not collect
   coverage at all, so everything cloud-only looks worse than it is, or is
   invisible.
-- The three cheapest wins are measurement fixes, not tests: collect coverage in
+- The three cheapest wins are measurement fixes rather than new tests: collect coverage in
   every project, count never-loaded files, and report coverage per feature area
   (Codecov components). Each is a one-PR change and turns the existing pipeline
   into a gap finder.
@@ -63,7 +63,7 @@ regenerated.
 
 ### What the numbers hide
 
-1. **Never-loaded chunks are not counted.** monocart converts V8 coverage for
+1. Never-loaded chunks are not counted. monocart converts V8 coverage for
    scripts the page fetched. Lazy chunks that no test triggers never appear in
    the lcov, so the denominator excludes them. Absent from the E2E report
    entirely: 457 `src/` files. The biggest clusters, in raw source lines:
@@ -84,14 +84,14 @@ regenerated.
    Some of these are type-only or cloud-only (see point 2), but a true E2E
    line figure over all of `src/` is closer to 45 to 50% than 68%.
 
-2. **Only the `chromium` project collects coverage.** The `cloud` project runs
+2. Only the `chromium` project collects coverage. The `cloud` project runs
    154 tests against the cloud build, including the agent panel, workspace
    switcher, billing and subscription dialogs, and sign-in. None of that work
    is credited. `workspace` shows 33.9% and `auth` 26.6% in the report, and
    the agent panel shows 2 files, purely because the measuring job never runs
    those tests.
 
-3. **The litegraph canvas has one measuring layer.** `vite.config.mts`
+3. The litegraph canvas has one measuring layer. `vite.config.mts`
    excludes `src/lib/litegraph/src/canvas/**`, `widgets/**`, and the top-level
    `src/lib/litegraph/src/*.ts` from unit coverage. E2E is therefore the only
    coverage those 11.9k lines get, and it stands at 49.6% (canvas) and 48.3%
@@ -99,16 +99,16 @@ regenerated.
    `GradientSliderWidget`, `InputIndicators`, and `FloatingRenderLink` are at
    0 to 5%.
 
-4. **No per-area view.** Codecov's project status is off and patch status is
+4. No per-area view. Codecov's project status is off and patch status is
    informational. The Slack post reports two global percentages. A global 68%
    cannot tell anyone that `platform/workspace` is at 34% while `vueNodes` is
    at 81%.
 
-5. **Organizational tags are not used by CI.** `@smoke` is applied to 46 tests
-   and nothing runs it. There is no list of user journeys the suite promises to
-   protect, so behavior coverage is unmeasured.
+5. CI ignores the organizational tags: `@smoke` is applied to 46 tests and
+   nothing runs it, and there is no list of the user journeys the suite
+   promises to protect, so behavior coverage is unmeasured.
 
-6. **Flakes are masked.** With `retries: 3`, a test that fails twice per run
+6. Flakes are masked. With `retries: 3`, a test that fails twice per run
    is still green. The `cloud` job on the analysed run had one flaky test.
    `report.json` records `flaky` outcomes, and nothing aggregates them.
 
@@ -121,7 +121,7 @@ sensitivity, specificity, speed, and cost of change. Isolated tests that each
 set up everything from scratch are easy to reason about but multiply. When two
 dimensions are demonstrably orthogonal, test each dimension once instead of
 the cross product: four interest calculations times five report formats needs
-about nine tests, not twenty. The cost is that orthogonality must be designed
+about nine tests instead of twenty. The cost is that orthogonality must be designed
 and shown, and that fewer assertions per test can feel unsafe.
 
 How this applies here:
@@ -134,7 +134,7 @@ How this applies here:
   cross product. A feature spec proves the feature; one or two view-mode
   specs prove the mode swaps the same store state in and out.
 - The `legacyDoNotReplicate` folder is the right shape for compatibility
-  pins: one narrow test per contract, not a copy of the feature suite.
+  pins: one narrow test per contract rather than a copy of the feature suite.
 
 ### Playwright best practices (playwright.dev)
 
@@ -166,7 +166,7 @@ Mutation testing detects assertion gaps but is far too slow for E2E suites.
 For this suite the practical translation is:
 
 - Use E2E coverage to find **execution gaps**: areas the suite never loads
-  or barely touches. That is exactly what the tables in section 4 show.
+  or barely touches. The tables in section 4 are that report.
 - Use a **journey inventory** to find **assertion gaps**: for each critical
   user journey, name the spec that proves it and the observable it asserts.
 - Reserve mutation testing (StrykerJS) for pure, well-unit-tested modules
@@ -223,7 +223,7 @@ Measured hits confirm the spec-name scan: `contextMenuFilter.ts` (8.9%),
 | `nodeSearchBox.spec.ts` (24), `nodeSearchBoxV2.spec.ts` (12), `nodeSearchBoxV2Extended.spec.ts` (20)                            | V2 and V2Extended repeat the same describe titles (`Category navigation`, `Filter workflow`, `Category sidebar`) | Merge V2 files into `tests/nodeSearch/`; diff the duplicated describes and keep one            |
 | `sidebar/assets.spec.ts` (48), `sidebar/assetsSidebarTab.spec.ts` (16), `assetHelper.spec.ts` (21), `browseModelAssets.spec.ts` | Four entry points to one browser                                                                                 | Fold into `tests/assets/` by behavior (browse, filter, sort, select, context menu)             |
 | `interaction.spec.ts`                                                                                                           | 64 tests, 62 `toHaveScreenshot`; its snapshot folder is the most churned path in `browser_tests` since June      | Convert link/drag/select assertions to `nodeOps` state checks; keep screenshots for appearance |
-| `appMode*.spec.ts` (11 files) + `linearMode.spec.ts`                                                                            | Fragmented, not duplicated                                                                                       | Move under `tests/appMode/`; no test changes                                                   |
+| `appMode*.spec.ts` (11 files) + `linearMode.spec.ts`                                                                            | Fragmented but no duplication                                                                                    | Move under `tests/appMode/`; test bodies unchanged                                             |
 | `keybindings.spec.ts`, `defaultKeybindings.spec.ts`, `keyboardShortcutActions.spec.ts`, `keybindingPanel.spec.ts`               | Overlapping fixtures, distinct behaviors                                                                         | Leave; document the split in a folder README                                                   |
 | `@screenshot` (104 tests, 185 assertions)                                                                                       | Screenshot maintenance dominates flake and regen PR volume                                                       | Audit against README rule "screenshots only when appearance is the behavior"                   |
 
@@ -233,7 +233,7 @@ Ordered by safety gained per hour. Each phase is independently shippable.
 
 ### Phase 0: make the existing measurement honest (three small PRs)
 
-1. **Collect coverage in every Playwright project.** Set
+1. Collect coverage in every Playwright project. Set
    `COLLECT_COVERAGE: 'true'` on the `playwright-tests` matrix job and pass it
    to `build-cloud-frontend` so the cloud bundle keeps its
    `sourceMappingURL` comments. Upload each project's `coverage/playwright/`
@@ -241,17 +241,17 @@ Ordered by safety gained per hour. Each phase is independently shippable.
    `e2e-coverage-shard-*` artifact. Expected effect: workspace, subscription,
    onboarding, auth, and agent code starts being credited, and the real gap
    there becomes visible.
-2. **Count never-loaded files.** Give monocart the `all` option in
+2. Count never-loaded files. Give monocart the `all` option in
    `globalTeardown.ts` (`all: { dir: ['src'], filter: coverageSourceFilter }`)
-   so source files with no V8 entry are reported at 0% instead of omitted. The
-   Slack target and the Pages report then describe the whole app. The
-   headline number will drop; that is the point.
-3. **Report per area.** Add Codecov `component_management` entries keyed to
+   so source files with no V8 entry are reported at 0% instead of omitted, and
+   the Slack target and the Pages report then describe the whole app. The
+   headline number will drop, and that drop is the intended effect.
+3. Report per area. Add Codecov `component_management` entries keyed to
    the areas in section 4 (vueNodes, litegraph canvas, litegraph widgets,
    extensions/core, workflow, assets, manager, workspace, cloud, layerEditor,
    maskeditor, agent). Each PR comment then shows a per-component table for
-   `unit`, `e2e`, and combined. Keep statuses informational; the value is
-   visibility, not blocking. Optionally extend
+   `unit`, `e2e`, and combined. Keep statuses informational. The goal is that people see the table, and a
+   blocking status would only get disabled again. Optionally extend
    `scripts/coverage-slack-notify.ts` to print the three lowest components.
 
 Also worth folding into this phase: a `scripts/coverage-gaps.ts` that joins
@@ -273,7 +273,7 @@ from the appendix, made permanent.
    that are not journeys. Add a `smoke` Playwright project that greps
    `@smoke`, and run it first in `ci-tests-e2e.yaml` so a broken journey fails
    in about two minutes instead of fifteen. The existing 16 shards keep
-   running; the smoke project is a fast-fail, not a replacement.
+   running; the smoke project fails fast ahead of them and replaces nothing.
 3. Journeys with no spec become the first new tests. From the current draft
    that is: install a custom node pack (manager), and top up credits and
    change plan (workspace/billing), both testable with typed route mocks in
@@ -281,8 +281,8 @@ from the appendix, made permanent.
 
 ### Phase 2: fill the highest-value execution gaps
 
-One spec folder each, using existing page objects where they exist. Target
-the journey, not line count; the lines follow because the chunk loads.
+One spec folder each, using existing page objects where they exist. Write each test around the journey. Line coverage follows because the chunk
+loads.
 
 | Order | Area                               | First test to write                                                                                                         | Why first                                                                                                            |
 | ----- | ---------------------------------- | --------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
@@ -308,7 +308,8 @@ and any second-renderer copy of an existing Vue-nodes widget spec.
    appearance ones. This removes the most churned snapshot directory.
 3. Aggregate `flaky` outcomes from `report.json` in `merge-reports` and post
    the count in the PR comment. Once the count is stable, lower CI
-   `retries` from 3 to 2. Do not lower it first.
+   `retries` from 3 to 2. Lowering it before the count exists would only hide
+   which tests are flaky.
 4. Shard `ci-tests-unit.yaml` (vitest `--shard`) to cut its 17-minute wall
    clock; unrelated to coverage but the same runner budget.
 
@@ -321,8 +322,8 @@ and any second-renderer copy of an existing Vue-nodes widget spec.
   not blocking.
 - Once Phase 0 has run for a month, set per-component Codecov thresholds at
   current value minus 2% for the well-covered areas only (vueNodes, workflow,
-  settings, subgraph). Never a global threshold; that is what got the
-  project status disabled.
+  settings, subgraph). A global threshold is what got the project status disabled, so none is
+  added.
 - Review `JOURNEYS.md` whenever a feature ships behind a flag flip; a flag
   that turns a feature on for users should turn its journey into `@smoke`.
 

--- a/docs/testing/e2e-coverage-strategy.md
+++ b/docs/testing/e2e-coverage-strategy.md
@@ -18,7 +18,7 @@ regenerated.
   incomplete. V8 coverage only sees chunks the browser actually loaded, so 457
   source files (~65k raw lines) never enter the denominator. Raw source lines cannot be compared with lcov's executable-line count
   directly; applying the loaded files' executable-to-raw ratio (0.27) to the
-  absent files puts the corrected figure near 54%. The `cloud`, `mobile-chrome`, `chromium-2x`, and
+  absent files puts the corrected figure near 54.5%. The `cloud`, `mobile-chrome`, `chromium-2x`, and
   `chromium-0.5x` projects do not collect coverage, so everything cloud-only
   looks worse than it is, or is invisible.
 - The three cheapest wins are measurement fixes rather than new tests: collect
@@ -84,11 +84,12 @@ regenerated.
 
    Some of these are type-only or cloud-only (see point 2). Raw line counts
    cannot be placed next to lcov's executable-line totals directly. The 1,585
-   loaded `src/` files hold 258k raw lines and 69.8k executable lines, a ratio
+   loaded `src/` files hold 258k raw lines and 70,520 executable lines, a ratio
    of 0.27. Applied to the absent files' 65k raw lines that is about 17.5k
-   executable lines, so the corrected E2E figure is near 54% (47.4k of 87.3k)
-   rather than 68%. The absent set is 22% of production files and 20% of raw
-   lines. The exact figure arrives when those files enter the report.
+   executable lines. The corrected E2E figure is about 54.5% (48,026 of an
+   estimated 88,020 executable lines) rather than 68.1%. The absent set is 22%
+   of production files and 20% of raw lines. The exact figure arrives when
+   those files enter the report.
 
 2. Only the `chromium` project collects coverage, even though the `cloud`
    project runs 154 tests against the cloud build, including the agent panel, workspace
@@ -359,8 +360,11 @@ and any second-renderer copy of an existing Vue-nodes widget spec.
    Directory rows are complete; file names are truncated and need suffix
    matching against the repo tree. The `unit-coverage` artifact
    (`lcov.info`) is the exact source when artifact download is available.
-3. Files under `src/` that have no `Processing file` entry are the
-   never-loaded set. Count their raw lines with `wc -l`.
+3. Build the production-source set using the `test.coverage.include` and
+   `test.coverage.exclude` rules in `vite.config.mts`. This removes tests,
+   specs, stories, declarations, locales, assets, and the configured GPU and
+   LiteGraph exclusions. Files in that set without a `Processing file` entry
+   are never loaded. Count their raw lines with `wc -l`.
 4. Per-shard `Coverage summary` blocks and `N passed (Xm)` lines are at the
    end of each `playwright-tests-chromium-sharded` job log.
 

--- a/docs/testing/e2e-coverage-strategy.md
+++ b/docs/testing/e2e-coverage-strategy.md
@@ -249,7 +249,9 @@ Ordered by safety gained per hour. Each phase is independently shippable.
    the package job's dependencies and reject an incomplete expected artifact
    set instead of silently producing a partial merge. `mobile-safari` remains
    excluded because Playwright coverage is Chromium-only. Keep `performance`
-   uninstrumented under ADR 0022; no regular CI job runs `audit`.
+   uninstrumented under
+   [ADR-PERF-BENCHMARKS-0022](../adr/PERF-BENCHMARKS-0022-performance-evidence-and-regression-framework.md);
+   no regular CI job runs `audit`.
 2. Count never-loaded production files through monocart's `all` option so
    source files with no V8 entry are reported at 0% instead of omitted. The
    implementation must transform TypeScript and Vue files before monocart


### PR DESCRIPTION
## Summary

First PR of the Playwright coverage stack. ADR 0027 records how E2E coverage will be measured and how E2E tests are selected, backed by an analysis of the current suite.

## Changes

- **What**: `docs/adr/0027-e2e-coverage-measurement-and-test-selection.md` (Proposed) plus index entry; `docs/testing/e2e-coverage-strategy.md` with the supporting numbers, gap inventory, redundant spec families, and reproduction steps, linked from `docs/testing/README.md`.

Findings the ADR rests on (main @ `e05e929f`):

- Reported E2E line coverage is 68.1%, but 457 `src/` files (~65k raw lines vs 70.5k measured) never load in any test and are missing from the lcov rather than counted at 0%. Over all of `src/` the figure is closer to 45 to 50%.
- Only the `chromium` project sets `COLLECT_COVERAGE`. The 154 `cloud` tests are never credited, so workspace, billing, subscription, auth, and agent code look untested.
- Vitest excludes `litegraph/src/canvas/**` and `widgets/**`, so E2E is the only measuring layer there (~49%).
- `@smoke` is on 46 tests and no CI job runs it. There is no journey inventory.

Decision in brief: collect coverage in every project, count never-loaded files at 0%, report per feature area through Codecov components (informational), keep `browser_tests/JOURNEYS.md` with one `@smoke` spec per journey run as a fast-fail project, and select E2E tests by journey and execution gap rather than by cross product.

## Review Focus

- Whether the per-component, no-global-threshold policy in the Decision section matches how the team wants Codecov to behave.
- The test-selection rules (items 7 to 11), since later PRs in the stack implement them.
- The ADR is intentionally concise and the strategy doc carries the tables. The strategy doc can move to its own PR if the ADR should land alone.

Follow-up PRs in the stack, in order: coverage in every Playwright project; never-loaded files at 0% plus a gap report; Codecov components; journey inventory and `smoke` project; gap-closing specs per area; consolidation of duplicated spec families.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012csQMzkPkjHMAZPAP3wQZ7