### PR TITLE
test: streamline agent panel root coverage

### DIFF
--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -5134,6 +5134,8 @@
     "historyEarlier": "Earlier",
     "historyEmpty": "No conversations yet",
     "copyMarkdown": "Copy as markdown",
+    "transcriptUser": "You",
+    "transcriptAssistant": "Agent",
     "delete": "Delete",
     "untitledChat": "Untitled",
     "skip": "Skip",

--- a/src/workbench/extensions/agent/AgentPanelRoot.test.ts
+++ b/src/workbench/extensions/agent/AgentPanelRoot.test.ts
@@ -59,6 +59,21 @@ const getServerFeature = vi.hoisted(() =>
   vi.fn((_name: string, defaultValue?: unknown) => defaultValue)
 )
 const focusNodeInstance = vi.hoisted(() => vi.fn())
+const MockLGraphNode = vi.hoisted(
+  () =>
+    class MockLGraphNode {
+      readonly boundingRect = {}
+      readonly type: string
+      graph?: { id?: string }
+
+      constructor(
+        public id: number | string,
+        public title: string
+      ) {
+        this.type = title
+      }
+    }
+)
 
 vi.mock('@/composables/canvas/useFocusNode', () => ({
   useFocusNode: () => ({ focusNodeInstance })
@@ -104,6 +119,7 @@ type MockCanvas = {
   selectedItems: Set<unknown>
   selectItems: ReturnType<typeof vi.fn>
   deselect: (node: unknown) => void
+  deselectAll: ReturnType<typeof vi.fn>
   multi_select: boolean
   allow_dragnodes: boolean
   selectOnly: boolean
@@ -112,7 +128,6 @@ type MockCanvas = {
 
 type MockGraph = {
   nodes: unknown[]
-  serialize: () => { version: number; nodes: unknown[] }
   getNodeById: (id: string | number) => unknown | null
 }
 
@@ -127,7 +142,6 @@ const appMock = vi.hoisted((): AppMock => {
   const nodes: unknown[] = []
   const graph = {
     nodes,
-    serialize: () => ({ version: 0.4, nodes: graph.nodes }),
     getNodeById: (id: string | number) =>
       graph.nodes.find(
         (node) =>
@@ -137,12 +151,11 @@ const appMock = vi.hoisted((): AppMock => {
           String(node.id) === String(id)
       ) ?? null
   }
-  const canvas: MockCanvas | undefined = undefined
   return {
     loadGraphData: vi.fn(),
     graph,
     rootGraph: graph,
-    canvas
+    canvas: undefined
   }
 })
 
@@ -178,6 +191,7 @@ type FakeTab = {
   directory: string
   filename: string
   isTemporary: boolean
+  isPersisted: boolean
   isModified: boolean
   activeState: { id?: string } | null
 }
@@ -244,6 +258,7 @@ vi.mock('@/platform/workflow/management/stores/workflowStore', async () => {
         directory: 'workflows',
         filename: stem,
         isTemporary: true,
+        isPersisted: false,
         isModified: false,
         activeState: data ?? null
       }
@@ -285,11 +300,7 @@ vi.mock('@/platform/workflow/core/services/workflowService', () => ({
 }))
 
 vi.mock('@/utils/litegraphUtil', () => ({
-  isLGraphNode: (item: unknown) =>
-    typeof item === 'object' &&
-    item !== null &&
-    'isNodeFake' in item &&
-    item.isNodeFake === true
+  isLGraphNode: (item: unknown) => item instanceof MockLGraphNode
 }))
 
 type MockPromptError = {
@@ -318,8 +329,12 @@ vi.mock('@/stores/executionErrorStore', () => ({
   useExecutionErrorStore: () => executionErrors
 }))
 
+const currentUser = vi.hoisted(() => ({
+  resolvedUserInfo: { value: { id: 'user-1' } },
+  userDisplayName: { value: 'Jo Rivera' }
+}))
 vi.mock('@/composables/auth/useCurrentUser', () => ({
-  useCurrentUser: () => ({ userDisplayName: { value: 'Jo Rivera' } })
+  useCurrentUser: () => currentUser
 }))
 
 const telemetry = vi.hoisted(() => ({
@@ -357,6 +372,7 @@ beforeEach(() => {
   hostStores.workflow.activeWorkflow = null
   hostStores.canvas.selectedItems = []
   hostStores.canvas.currentGraph = null
+  sidebarStore.activeSidebarTabId = null
   executionErrors.lastPromptError = null
   toastStore.messagesToAdd.length = 0
   appMock.graph.nodes = []
@@ -396,6 +412,7 @@ function addTab(path: string, overrides: Partial<FakeTab> = {}): FakeTab {
     directory: path.slice(0, slash),
     filename: path.slice(slash + 1).replace(/\.json$/, ''),
     isTemporary: false,
+    isPersisted: true,
     isModified: false,
     activeState: null,
     ...overrides
@@ -469,19 +486,13 @@ async function openMentionPicker(): Promise<void> {
   await userEvent.type(screen.getByRole('textbox'), '@')
 }
 
-type SelectionTestNode = {
-  isNodeFake: true
-  id: number | string
-  title: string
-  boundingRect: object
-  graph?: { id?: string }
-}
+type SelectionTestNode = InstanceType<typeof MockLGraphNode>
 
 function setupNodeSelectionCanvas() {
   const focus = vi.fn()
   const nodes: SelectionTestNode[] = [
-    { isNodeFake: true, id: 9, title: 'VAE Decode', boundingRect: {} },
-    { isNodeFake: true, id: 12, title: 'KSampler', boundingRect: {} }
+    new MockLGraphNode(9, 'VAE Decode'),
+    new MockLGraphNode(12, 'KSampler')
   ]
   const selectedItems = new Set<unknown>()
   const selectItems = vi.fn((items: unknown[], add = false) => {
@@ -596,7 +607,7 @@ async function startVueNodeSelection() {
     else state.selectedItems.add(node)
     hostStores.canvas.updateSelectedItems()
   })
-  render(AgentPanelRoot, { global: { plugins: [i18n] } })
+  const view = render(AgentPanelRoot, { global: { plugins: [i18n] } })
   renderCanvasNodeButtons(state.nodes, selectClickedNode)
   useAgentPanelStore().isOpen = true
 
@@ -609,7 +620,7 @@ async function startVueNodeSelection() {
   expect(state.selectItems).not.toHaveBeenCalled()
   expect(hostStores.canvas.selectedItems).toEqual(state.nodes)
 
-  return { ...state, buttons, selectClickedNode }
+  return { ...state, ...view, buttons, selectClickedNode }
 }
 
 async function expectLaterClickCannotRestoreAccumulatedNodes(
@@ -731,6 +742,26 @@ describe('AgentPanelRoot attach flow', () => {
     expect(dispatchDrag(target, 'dragover', data)).toBe(false)
     expect(dispatchDrag(target, 'drop', data)).toBe(false)
     expect(uploaded).toEqual([])
+  })
+
+  it('claims a mixed drop for its attachable files and leaves JSON-only drops unclaimed', async () => {
+    const uploaded = stubUploadFetch()
+    render(AgentPanelRoot, { global: { plugins: [i18n] } })
+    await nextTick()
+    const target = screen.getByRole('textbox')
+    const workflow = new File(['{}'], 'workflow.json', {
+      type: 'application/json'
+    })
+    const image = new File(['image'], 'reference.png', { type: 'image/png' })
+
+    expect(dispatchDrag(target, 'drop', { files: [workflow, image] })).toBe(
+      true
+    )
+    await vi.waitFor(() => expect(uploaded).toEqual(['reference.png']))
+
+    expect(dispatchDrag(target, 'drop', { files: [workflow] })).toBe(false)
+    await nextTick()
+    expect(uploaded).toEqual(['reference.png'])
   })
 
   it('attaches a Media-card URI and forwards its uploaded ref', async () => {
@@ -927,6 +958,28 @@ describe('AgentPanelRoot lifecycle', () => {
     expect(activity.editingTabPath).toBeNull()
     expect(activity.creatingTab).toBe(false)
   })
+
+  it('exits selection on graph changes and restores canvas behavior on unmount', async () => {
+    const selection = await startVueNodeSelection()
+
+    hostStores.canvas.currentGraph = { id: 'next-graph' }
+    await nextTick()
+
+    expect(selection.canvas.multi_select).toBe(false)
+    expect(selection.canvas.allow_dragnodes).toBe(true)
+    expect(selection.canvas.selectOnly).toBe(false)
+
+    await enterNodeSelectionMode()
+    expect(selection.canvas.multi_select).toBe(true)
+
+    selection.unmount()
+    await nextTick()
+
+    expect(selection.canvas.multi_select).toBe(false)
+    expect(selection.canvas.allow_dragnodes).toBe(true)
+    expect(selection.canvas.selectOnly).toBe(false)
+    await expectLaterClickCannotRestoreAccumulatedNodes(selection)
+  })
 })
 
 describe('AgentPanelRoot workflow binding', () => {
@@ -936,6 +989,7 @@ describe('AgentPanelRoot workflow binding', () => {
       directory: 'workflows',
       filename: 'current',
       isTemporary: false,
+      isPersisted: true,
       isModified: false,
       activeState: id === undefined ? null : { id }
     }
@@ -948,12 +1002,14 @@ describe('AgentPanelRoot workflow binding', () => {
   function mockMessagesEndpoint(
     ackWorkflowId: string,
     cloudWorkflows: { id: string; name: string }[] = []
-  ): unknown[] {
+  ): { bodies: unknown[]; messageUrls: string[] } {
     const bodies: unknown[] = []
+    const messageUrls: string[] = []
     vi.stubGlobal(
       'fetch',
       vi.fn(async (url: string, init?: RequestInit) => {
         if (url.includes('/messages') && init?.method === 'POST') {
+          messageUrls.push(url)
           bodies.push(JSON.parse(String(init.body)))
           return json(202, ack(ackWorkflowId, `m-${bodies.length}`))
         }
@@ -975,7 +1031,7 @@ describe('AgentPanelRoot workflow binding', () => {
         return new Response('{}', { status: 200 })
       })
     )
-    return bodies
+    return { bodies, messageUrls }
   }
 
   it('transitions the bound tab from editing to modified when the turn completes', async () => {
@@ -1063,7 +1119,7 @@ describe('AgentPanelRoot workflow binding', () => {
 
   it('chip X detaches the chat so the next send carries no workflow context', async () => {
     makeTab('wf-42')
-    const bodies = mockMessagesEndpoint('wf-42')
+    const { bodies } = mockMessagesEndpoint('wf-42')
     render(AgentPanelRoot, { global: { plugins: [i18n] } })
 
     await userEvent.click(
@@ -1083,6 +1139,72 @@ describe('AgentPanelRoot workflow binding', () => {
       open_tabs: [{ workflow_id: 'wf-42', name: 'current' }]
     })
     expect(useWorkflowTabActivityStore().editingTabPath).toBeNull()
+  })
+
+  it('starts workflow-detached fresh sessions from New Chat and active-chat deletion', async () => {
+    makeTab('wf-42')
+    const { bodies, messageUrls } = mockMessagesEndpoint('wf-42')
+    render(AgentPanelRoot, { global: { plugins: [i18n] } })
+
+    await sendFromComposer('first thread')
+    expect(bodies[0]).toMatchObject({
+      workflow_id: 'wf-42',
+      current_tab: 'wf-42'
+    })
+    ws.emit('agent_message_done', {
+      message_id: 'm-1',
+      thread_id: 'th-1'
+    })
+    await screen.findByRole('button', { name: 'Send' })
+
+    await userEvent.click(
+      screen.getByRole('button', { name: i18n.global.t('agent.newChat') })
+    )
+    await sendFromComposer('after new chat')
+    expect(messageUrls[1]).toContain('/agent/threads/new/messages')
+    expect(bodies[1]).not.toHaveProperty('workflow_id')
+    expect(bodies[1]).not.toHaveProperty('current_tab')
+    ws.emit('agent_message_done', {
+      message_id: 'm-2',
+      thread_id: 'th-1'
+    })
+    await screen.findByRole('button', { name: 'Send' })
+
+    await userEvent.click(
+      screen.getByRole('button', { name: i18n.global.t('agent.chatOptions') })
+    )
+    await userEvent.click(
+      await screen.findByRole('menuitem', { name: i18n.global.t('g.delete') })
+    )
+    await sendFromComposer('after delete')
+
+    expect(messageUrls[2]).toContain('/agent/threads/new/messages')
+    expect(bodies[2]).not.toHaveProperty('workflow_id')
+    expect(bodies[2]).not.toHaveProperty('current_tab')
+  })
+
+  it('includes active and background tabs restored from persisted bindings', async () => {
+    localStorage.setItem(
+      'Comfy.Agent.WorkflowTabBindings',
+      JSON.stringify({
+        'wf-current': 'workflows/current.json',
+        'wf-background': 'workflows/background.json'
+      })
+    )
+    makeTab()
+    addTab('workflows/background.json')
+    const { bodies } = mockMessagesEndpoint('wf-current')
+
+    await renderAndSend('use my open workflows')
+
+    expect(bodies[0]).toMatchObject({
+      workflow_id: 'wf-current',
+      current_tab: 'wf-current',
+      open_tabs: [
+        { workflow_id: 'wf-current', name: 'current' },
+        { workflow_id: 'wf-background', name: 'background' }
+      ]
+    })
   })
 
   it('agent_active_tab activates the bound tab', async () => {
@@ -1252,12 +1374,7 @@ describe('AgentPanelRoot workflow binding', () => {
     const referencedNode = state.nodes[1]
     referencedNode.id = 'shared'
     referencedNode.title = 'Subgraph twin'
-    const rootTwin: SelectionTestNode = {
-      isNodeFake: true,
-      id: 'shared',
-      title: 'Root twin',
-      boundingRect: {}
-    }
+    const rootTwin = new MockLGraphNode('shared', 'Root twin')
     appMock.graph.nodes = [subgraphNode, rootTwin]
 
     render(AgentPanelRoot, { global: { plugins: [i18n] } })
@@ -1294,7 +1411,7 @@ describe('AgentPanelRoot workflow binding', () => {
 
   it('keeps additive Vue-node selections and sends every node id', async () => {
     makeTab()
-    const bodies = mockMessagesEndpoint('wf-42')
+    const { bodies } = mockMessagesEndpoint('wf-42')
     const selection = await startVueNodeSelection()
 
     expect(selection.canvas.multi_select).toBe(true)

--- a/src/workbench/extensions/agent/AgentPanelRoot.test.ts
+++ b/src/workbench/extensions/agent/AgentPanelRoot.test.ts
@@ -1,31 +1,59 @@
-// @vitest-environment jsdom
-import { fromPartial } from '@total-typescript/shoehorn'
-
+import { createTestingPinia } from '@pinia/testing'
 import { render, screen, within } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
-import { createPinia, setActivePinia } from 'pinia'
+import { setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { defineComponent, h, nextTick } from 'vue'
 
-// jsdom does not implement ResizeObserver (happy-dom does); stub it before the
-// Vue node preview chain constructs its module-level observer at import time.
-vi.hoisted(() => {
-  globalThis.ResizeObserver ??= class {
-    observe() {}
-    unobserve() {}
-    disconnect() {}
-  } as unknown as typeof ResizeObserver
+vi.mock('./components/agent/message/AgentMessage.vue', async () => {
+  const { defineComponent, h } = await import('vue')
+  return {
+    default: defineComponent({
+      props: { message: { type: Object, required: true } },
+      emits: ['feedback'],
+      setup(_props, { emit }) {
+        return () =>
+          h(
+            'button',
+            { type: 'button', onClick: () => emit('feedback', 'up') },
+            'Helpful'
+          )
+      }
+    })
+  }
+})
+
+vi.mock('./components/agent/OnboardingCoach.vue', () => ({
+  default: { template: '<div />' }
+}))
+
+vi.mock('./crdt/CrdtDevPanel.vue', () => ({
+  default: { template: '<div />' }
+}))
+
+vi.mock('./crdt/mintPortWiring', () => ({
+  attachMintPortWiring: () => ({ detach: vi.fn() })
+}))
+
+vi.mock('./crdt/useAgentCrdtFollower', async () => {
+  const { reactive } = await import('vue')
+  return {
+    useAgentCrdtFollower: () => ({
+      status: reactive({
+        enabled: false,
+        connected: false,
+        workflowId: null,
+        updatesApplied: 0,
+        lastFrameType: null
+      }),
+      enqueueHumanOperations: vi.fn()
+    })
+  }
 })
 
 import { i18n } from '@/i18n'
-import { assetService } from '@/platform/assets/services/assetService'
 import { app } from '@/scripts/app'
-import { useAgentNodeSelectionStore } from '@/stores/agentNodeSelectionStore'
 import { useWorkflowTabActivityStore } from '@/stores/workflowTabActivityStore'
-import { useSidebarTabStore } from '@/stores/workspace/sidebarTabStore'
-import { validateComfyWorkflow } from '@/platform/workflow/validation/schemas/workflowSchema'
-import { useToastStore } from '@/platform/updates/common/toastStore'
-import { useAssetsStore } from '@/stores/assetsStore'
 
 const getServerFeature = vi.hoisted(() =>
   vi.fn((_name: string, defaultValue?: unknown) => defaultValue)
@@ -68,10 +96,37 @@ vi.mock('@/scripts/api', () => ({
   }
 }))
 
-const appMock = vi.hoisted(() => {
+type MockCanvas = {
+  graph: {
+    nodes: unknown[]
+    getNodeById: (id: string) => unknown | null
+  }
+  selectedItems: Set<unknown>
+  selectItems: ReturnType<typeof vi.fn>
+  deselect: (node: unknown) => void
+  multi_select: boolean
+  allow_dragnodes: boolean
+  selectOnly: boolean
+  canvas: { focus: ReturnType<typeof vi.fn> }
+}
+
+type MockGraph = {
+  nodes: unknown[]
+  serialize: () => { version: number; nodes: unknown[] }
+  getNodeById: (id: string | number) => unknown | null
+}
+
+type AppMock = {
+  loadGraphData: ReturnType<typeof vi.fn>
+  graph: MockGraph
+  rootGraph: MockGraph
+  canvas: MockCanvas | undefined
+}
+
+const appMock = vi.hoisted((): AppMock => {
+  const nodes: unknown[] = []
   const graph = {
-    nodes: [] as unknown[],
-    arrange: vi.fn(),
+    nodes,
     serialize: () => ({ version: 0.4, nodes: graph.nodes }),
     getNodeById: (id: string | number) =>
       graph.nodes.find(
@@ -82,37 +137,41 @@ const appMock = vi.hoisted(() => {
           String(node.id) === String(id)
       ) ?? null
   }
+  const canvas: MockCanvas | undefined = undefined
   return {
     loadGraphData: vi.fn(),
     graph,
     rootGraph: graph,
-    canvas: undefined as
-      | {
-          graph: {
-            nodes: unknown[]
-            getNodeById: (id: string) => unknown | null
-          }
-          selectedItems: Set<unknown>
-          selectItems: ReturnType<typeof vi.fn>
-          deselect: (node: unknown) => void
-          multi_select: boolean
-          allow_dragnodes: boolean
-          selectOnly: boolean
-          canvas: { focus: ReturnType<typeof vi.fn> }
-        }
-      | undefined
+    canvas
   }
 })
 
 vi.mock('@/scripts/app', () => ({ app: appMock }))
 
-vi.mock(
-  '@/platform/workflow/validation/schemas/workflowSchema',
-  async (importOriginal) => ({
-    ...(await importOriginal<object>()),
-    validateComfyWorkflow: vi.fn(async (content: unknown) => content)
-  })
-)
+const assetsStore = vi.hoisted(() => ({
+  updateInputs: vi.fn(async () => [])
+}))
+vi.mock('@/stores/assetsStore', () => ({
+  useAssetsStore: () => assetsStore
+}))
+
+const sidebarStore = vi.hoisted(() => ({
+  activeSidebarTabId: null
+}))
+vi.mock('@/stores/workspace/sidebarTabStore', () => ({
+  useSidebarTabStore: () => sidebarStore
+}))
+
+const toastStore = vi.hoisted(() => {
+  const messagesToAdd: unknown[] = []
+  return {
+    messagesToAdd,
+    add: vi.fn((message: unknown) => messagesToAdd.push(message))
+  }
+})
+vi.mock('@/platform/updates/common/toastStore', () => ({
+  useToastStore: () => toastStore
+}))
 
 type FakeTab = {
   path: string
@@ -121,11 +180,9 @@ type FakeTab = {
   isTemporary: boolean
   isModified: boolean
   activeState: { id?: string } | null
-  initialMode?: 'app' | 'graph'
-  activeMode?: 'builder:inputs'
 }
-const hostStores = vi.hoisted(() => ({
-  workflow: null as unknown as {
+type HostStores = {
+  workflow: {
     activeWorkflow: FakeTab | null
     openWorkflows: FakeTab[]
     tabs: Map<string, FakeTab>
@@ -134,20 +191,36 @@ const hostStores = vi.hoisted(() => ({
       graph?: { id?: string }
       id: string | number
     }) => string
-  },
-  canvas: null as unknown as {
+  }
+  canvas: {
     selectedItems: unknown[]
     updateSelectedItems: () => void
     currentGraph: unknown | null
     canvas: unknown
+  }
+}
+const hostStores: HostStores = vi.hoisted(() => ({
+  workflow: {
+    activeWorkflow: null,
+    openWorkflows: [],
+    tabs: new Map(),
+    getWorkflowByPath: () => null,
+    nodeToNodeLocatorId: (node) => String(node.id)
+  },
+  canvas: {
+    selectedItems: [],
+    updateSelectedItems: () => {},
+    currentGraph: null,
+    canvas: undefined
   }
 }))
 
 vi.mock('@/platform/workflow/management/stores/workflowStore', async () => {
   const { reactive } = await import('vue')
   const tabs = new Map<string, FakeTab>()
+  const activeWorkflow: FakeTab | null = null
   const store = reactive({
-    activeWorkflow: null as FakeTab | null,
+    activeWorkflow,
     get openWorkflows() {
       return Array.from(tabs.values())
     },
@@ -160,7 +233,7 @@ vi.mock('@/platform/workflow/management/stores/workflowStore', async () => {
     closeWorkflow: vi.fn(async (tab: FakeTab) => {
       tabs.delete(tab.path)
     }),
-    createTemporary: (path?: string, data?: unknown) => {
+    createTemporary: (path?: string, data?: { id?: string }) => {
       const requested = (path ?? 'Unsaved Workflow.json').replace(/\.json$/, '')
       let stem = requested
       let counter = 2
@@ -172,7 +245,7 @@ vi.mock('@/platform/workflow/management/stores/workflowStore', async () => {
         filename: stem,
         isTemporary: true,
         isModified: false,
-        activeState: (data ?? null) as { id?: string } | null
+        activeState: data ?? null
       }
       tabs.set(tab.path, tab)
       return tab
@@ -187,31 +260,20 @@ vi.mock('@/renderer/core/canvas/canvasStore', async () => {
   const updateSelectedItems = () => {
     hostStores.canvas.selectedItems = [...(appMock.canvas?.selectedItems ?? [])]
   }
+  const selectedItems: unknown[] = []
+  const currentGraph: unknown | null = null
+  const canvas: unknown = undefined
   const store = reactive({
-    selectedItems: [] as unknown[],
+    selectedItems,
     updateSelectedItems,
-    currentGraph: null as unknown | null,
-    canvas: undefined as unknown
+    currentGraph,
+    canvas
   })
   hostStores.canvas = store
   return { useCanvasStore: () => store }
 })
 
 const workflowService = vi.hoisted(() => ({
-  saveWorkflow: vi.fn(async (tab: { isModified: boolean }) => {
-    tab.isModified = false
-    return true
-  }),
-  saveWorkflowAs: vi.fn(
-    async (
-      tab: { path: string; isTemporary: boolean; isModified: boolean },
-      _options?: { filename?: string }
-    ) => {
-      tab.isTemporary = false
-      tab.isModified = false
-      return true
-    }
-  ),
   openWorkflow: vi.fn(async (tab: { path: string }) => {
     const known = hostStores.workflow.tabs.get(tab.path)
     if (known) hostStores.workflow.activeWorkflow = known
@@ -222,10 +284,12 @@ vi.mock('@/platform/workflow/core/services/workflowService', () => ({
   useWorkflowService: () => workflowService
 }))
 
-vi.mock('@/utils/litegraphUtil', async (importOriginal) => ({
-  ...(await importOriginal<object>()),
+vi.mock('@/utils/litegraphUtil', () => ({
   isLGraphNode: (item: unknown) =>
-    (item as { isNodeFake?: boolean } | null)?.isNodeFake === true
+    typeof item === 'object' &&
+    item !== null &&
+    'isNodeFake' in item &&
+    item.isNodeFake === true
 }))
 
 type MockPromptError = {
@@ -233,9 +297,15 @@ type MockPromptError = {
   message: string
   details: string
 }
-const executionErrors = vi.hoisted(() => {
-  const store = {
-    lastPromptError: null as MockPromptError | null,
+type ExecutionErrors = {
+  lastPromptError: MockPromptError | null
+  recordPromptError: (error: MockPromptError) => void
+  showErrorOverlay: ReturnType<typeof vi.fn>
+}
+const executionErrors = vi.hoisted((): ExecutionErrors => {
+  const lastPromptError: MockPromptError | null = null
+  const store: ExecutionErrors = {
+    lastPromptError,
     recordPromptError(error: MockPromptError) {
       store.lastPromptError = error
     },
@@ -251,21 +321,6 @@ vi.mock('@/stores/executionErrorStore', () => ({
 vi.mock('@/composables/auth/useCurrentUser', () => ({
   useCurrentUser: () => ({ userDisplayName: { value: 'Jo Rivera' } })
 }))
-
-const clipboard = vi.hoisted(() => ({ copy: vi.fn() }))
-
-vi.mock('@vueuse/core', async (importOriginal) => {
-  const { ref } = await import('vue')
-  return {
-    ...(await importOriginal<object>()),
-    useClipboard: () => ({
-      copy: clipboard.copy,
-      copied: ref(false),
-      isSupported: ref(true),
-      text: ref('')
-    })
-  }
-})
 
 const telemetry = vi.hoisted(() => ({
   trackAgentMessageFeedback: vi.fn(),
@@ -283,7 +338,6 @@ vi.mock('@/platform/telemetry', () => ({
 
 import type { TurnId } from './schemas/agentApiSchema'
 import { zAgentWsEvent } from './schemas/agentApiSchema'
-import { MAX_ATTACHMENT_BYTES } from './composables/agent/useAttachment'
 import type { AgentChatEvent } from './services/agent/agentEventTransport'
 import { useAgentChatHistoryStore } from './stores/agent/agentChatHistoryStore'
 import { useAgentConversationStore } from './stores/agent/agentConversationStore'
@@ -293,30 +347,25 @@ import { useAgentWorkflowTabBindingStore } from './stores/agent/agentWorkflowTab
 import AgentPanelRoot from './AgentPanelRoot.vue'
 
 beforeEach(() => {
+  setActivePinia(createTestingPinia({ stubActions: false }))
+  ws.clear()
   Element.prototype.scrollIntoView = vi.fn()
   URL.createObjectURL = vi.fn(() => 'blob:mock-url')
   URL.revokeObjectURL = vi.fn()
   localStorage.clear()
-  getServerFeature.mockReset()
-  getServerFeature.mockImplementation(
-    (_name: string, defaultValue?: unknown) => defaultValue
-  )
   hostStores.workflow.tabs.clear()
   hostStores.workflow.activeWorkflow = null
   hostStores.canvas.selectedItems = []
   hostStores.canvas.currentGraph = null
+  executionErrors.lastPromptError = null
+  toastStore.messagesToAdd.length = 0
   appMock.graph.nodes = []
-  appMock.graph.arrange.mockClear()
   Object.assign(appMock.rootGraph, { subgraphs: new Map() })
   appMock.canvas = undefined
-  workflowService.saveWorkflow.mockClear()
-  workflowService.saveWorkflowAs.mockClear()
-  workflowService.openWorkflow.mockClear()
-  focusNodeInstance.mockReset()
 })
 
 const zAgentWsEventForTest = (raw: unknown): AgentChatEvent =>
-  zAgentWsEvent.parse(raw) as AgentChatEvent
+  zAgentWsEvent.parse(raw)
 
 function json(status: number, body: unknown): Response {
   return new Response(JSON.stringify(body), {
@@ -356,14 +405,7 @@ function addTab(path: string, overrides: Partial<FakeTab> = {}): FakeTab {
 }
 
 describe('AgentPanelRoot session notices', () => {
-  beforeEach(() => {
-    setActivePinia(createPinia())
-    ws.clear()
-  })
-
   it('surfaces a session error notice via the host error modal, not a toast', async () => {
-    executionErrors.lastPromptError = null
-    executionErrors.showErrorOverlay.mockClear()
     vi.stubGlobal(
       'fetch',
       vi.fn(
@@ -375,12 +417,10 @@ describe('AgentPanelRoot session notices', () => {
       )
     )
     render(AgentPanelRoot, { global: { plugins: [i18n] } })
-    const toast = useToastStore()
-
     ws.emit('agent_message_done', {})
     await nextTick()
 
-    expect(toast.messagesToAdd).toHaveLength(0)
+    expect(toastStore.messagesToAdd).toHaveLength(0)
     expect(executionErrors.showErrorOverlay).toHaveBeenCalledTimes(1)
     expect(executionErrors.lastPromptError).toMatchObject({
       type: 'agent_api_failed',
@@ -556,7 +596,7 @@ async function startVueNodeSelection() {
     else state.selectedItems.add(node)
     hostStores.canvas.updateSelectedItems()
   })
-  const panel = render(AgentPanelRoot, { global: { plugins: [i18n] } })
+  render(AgentPanelRoot, { global: { plugins: [i18n] } })
   renderCanvasNodeButtons(state.nodes, selectClickedNode)
   useAgentPanelStore().isOpen = true
 
@@ -569,7 +609,7 @@ async function startVueNodeSelection() {
   expect(state.selectItems).not.toHaveBeenCalled()
   expect(hostStores.canvas.selectedItems).toEqual(state.nodes)
 
-  return { ...state, buttons, selectClickedNode, unmount: panel.unmount }
+  return { ...state, buttons, selectClickedNode }
 }
 
 async function expectLaterClickCannotRestoreAccumulatedNodes(
@@ -601,11 +641,6 @@ function stubUploadFetch(uploaded: string[] = []): string[] {
 }
 
 describe('AgentPanelRoot attach flow', () => {
-  beforeEach(() => {
-    setActivePinia(createPinia())
-    ws.clear()
-  })
-
   it('uploads a picked file, stages its ref, and forwards it on the next send', async () => {
     const messageBodies: unknown[] = []
     const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
@@ -652,98 +687,16 @@ describe('AgentPanelRoot attach flow', () => {
       attachment_count: 1,
       node_tag_count: 0
     })
+    expect(assetsStore.updateInputs).toHaveBeenCalled()
 
     expect(screen.getByAltText('cat.png')).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'cat.png' })).toBeInTheDocument()
-  })
-
-  it('uploads a picked video above 20MB when the server permits it', async () => {
-    getServerFeature.mockReturnValue(100 * 1024 * 1024)
-    const uploaded = stubUploadFetch()
-    render(AgentPanelRoot, { global: { plugins: [i18n] } })
-
-    await openAddMenu()
-    await userEvent.click(
-      await screen.findByRole('menuitem', {
-        name: i18n.global.t('agent.attachFiles')
-      })
-    )
-    const movie = fileOfSize('movie.mp4', MAX_ATTACHMENT_BYTES + 1, 'video/mp4')
-    await userEvent.upload(
-      screen.getByTestId<HTMLInputElement>('agent-file-input'),
-      movie
-    )
-
-    expect(await screen.findByText('movie.mp4')).toBeInTheDocument()
-    await vi.waitFor(() => expect(uploaded).toEqual(['movie.mp4']))
-  })
-
-  it('opens the assets sidebar from the add menu', async () => {
-    stubUploadFetch()
-    const sidebar = useSidebarTabStore()
-    sidebar.activeSidebarTabId = 'workflows'
-
-    render(AgentPanelRoot, { global: { plugins: [i18n] } })
-
-    await openAddMenu()
-    await userEvent.click(
-      await screen.findByRole('menuitem', {
-        name: i18n.global.t('agent.addFromAssets')
-      })
-    )
-
-    expect(sidebar.activeSidebarTabId).toBe('assets')
-  })
-
-  it('leaves the assets sidebar open when it is already the active tab', async () => {
-    stubUploadFetch()
-    const sidebar = useSidebarTabStore()
-    sidebar.activeSidebarTabId = 'assets'
-
-    render(AgentPanelRoot, { global: { plugins: [i18n] } })
-
-    await openAddMenu()
-    await userEvent.click(
-      await screen.findByRole('menuitem', {
-        name: i18n.global.t('agent.addFromAssets')
-      })
-    )
-
-    expect(sidebar.activeSidebarTabId).toBe('assets')
-  })
-
-  it('hides the assets entry in builder mode', async () => {
-    stubUploadFetch()
-    hostStores.workflow.activeWorkflow = {
-      path: 'workflows/current.json',
-      directory: 'workflows',
-      filename: 'current',
-      isTemporary: false,
-      isModified: false,
-      activeState: null,
-      activeMode: 'builder:inputs'
-    }
-
-    render(AgentPanelRoot, { global: { plugins: [i18n] } })
-
-    await openAddMenu()
-    expect(
-      await screen.findByRole('menuitem', {
-        name: i18n.global.t('agent.addNodesFromGraph')
-      })
-    ).toBeInTheDocument()
-    expect(
-      screen.queryByRole('menuitem', {
-        name: i18n.global.t('agent.addFromAssets')
-      })
-    ).toBeNull()
   })
 
   it('warns with the configured server limit when a video exceeds it', async () => {
     // PM-118: dropping a movie showed "Comfy Agent hit a server error" because a
     // size rejection was routed through the agent-failure overlay.
     getServerFeature.mockReturnValue(24 * 1024 * 1024)
-    executionErrors.showErrorOverlay.mockClear()
     stubUploadFetch()
     render(AgentPanelRoot, { global: { plugins: [i18n] } })
     await nextTick()
@@ -753,167 +706,13 @@ describe('AgentPanelRoot attach flow', () => {
     await nextTick()
 
     expect(executionErrors.showErrorOverlay).not.toHaveBeenCalled()
-    expect(useToastStore().messagesToAdd).toContainEqual(
+    expect(toastStore.messagesToAdd).toContainEqual(
       expect.objectContaining({
         severity: 'warn',
         detail: 'movie.mp4 is larger than 24MB'
       })
     )
     expect(screen.queryByText('movie.mp4')).not.toBeInTheDocument()
-  })
-
-  it('keeps the image limit at 20MB when the server permits more', async () => {
-    getServerFeature.mockReturnValue(100 * 1024 * 1024)
-    const uploaded = stubUploadFetch()
-    render(AgentPanelRoot, { global: { plugins: [i18n] } })
-    await nextTick()
-
-    const image = fileOfSize('huge.png', MAX_ATTACHMENT_BYTES + 1, 'image/png')
-    dispatchDrag(screen.getByRole('textbox'), 'drop', { files: [image] })
-    await nextTick()
-
-    expect(uploaded).toEqual([])
-    expect(useToastStore().messagesToAdd).toContainEqual(
-      expect.objectContaining({
-        severity: 'warn',
-        detail: 'huge.png is larger than 20MB'
-      })
-    )
-  })
-
-  it('uploads a dropped video above 20MB when the server permits it', async () => {
-    getServerFeature.mockReturnValue(100 * 1024 * 1024)
-    const uploaded = stubUploadFetch()
-    render(AgentPanelRoot, { global: { plugins: [i18n] } })
-    await nextTick()
-
-    const movie = fileOfSize('movie.mp4', MAX_ATTACHMENT_BYTES + 1, 'video/mp4')
-    expect(
-      dispatchDrag(screen.getByRole('textbox'), 'drop', { files: [movie] })
-    ).toBe(true)
-
-    expect(await screen.findByText('movie.mp4')).toBeInTheDocument()
-    await vi.waitFor(() => expect(uploaded).toEqual(['movie.mp4']))
-  })
-
-  // Jo's FE-1323 expansion: every approved format attaches through drag-drop.
-  // The MIME column mirrors what browsers actually report - glb, md, and wav
-  // drops often carry no type at all, so claiming must go by file name.
-  it.for([
-    ['clip.mp4', 'video/mp4'],
-    ['voice.m4a', ''],
-    ['movie.mov', 'video/quicktime'],
-    ['song.mp3', 'audio/mpeg'],
-    ['sound.wav', ''],
-    ['mesh.glb', ''],
-    ['notes.md', ''],
-    ['prompt.txt', 'text/plain']
-  ])('attaches a dropped %s and uploads it', async ([name, type]) => {
-    const uploaded = stubUploadFetch()
-    render(AgentPanelRoot, { global: { plugins: [i18n] } })
-    await nextTick()
-
-    expect(
-      dispatchDrag(screen.getByRole('textbox'), 'drop', {
-        files: [new File(['x'], name, { type })]
-      })
-    ).toBe(true)
-
-    expect(await screen.findByText(name)).toBeInTheDocument()
-    await vi.waitFor(() => expect(uploaded).toEqual([name]))
-  })
-
-  it('names every approved format in the picker accept list', async () => {
-    stubUploadFetch()
-    render(AgentPanelRoot, { global: { plugins: [i18n] } })
-    await nextTick()
-
-    const accept =
-      screen
-        .getByTestId<HTMLInputElement>('agent-file-input')
-        .getAttribute('accept') ?? ''
-    for (const extension of [
-      '.mp4',
-      '.m4a',
-      '.mov',
-      '.mp3',
-      '.wav',
-      '.glb',
-      '.md',
-      '.txt'
-    ]) {
-      expect(accept).toContain(extension)
-    }
-  })
-
-  it('refreshes the input asset library after an upload', async () => {
-    const uploaded = stubUploadFetch()
-    render(AgentPanelRoot, { global: { plugins: [i18n] } })
-    await nextTick()
-    const refresh = vi
-      .spyOn(useAssetsStore(), 'updateInputs')
-      .mockResolvedValue(undefined as never)
-
-    dispatchDrag(screen.getByRole('textbox'), 'drop', {
-      files: [new File(['x'], 'cat.png', { type: 'image/png' })]
-    })
-
-    await vi.waitFor(() => expect(uploaded).toEqual(['cat.png']))
-    await vi.waitFor(() => expect(refresh).toHaveBeenCalled())
-  })
-
-  it('keeps the 20MB limit for an oversize audio file', async () => {
-    getServerFeature.mockReturnValue(100 * 1024 * 1024)
-    const uploaded = stubUploadFetch()
-    render(AgentPanelRoot, { global: { plugins: [i18n] } })
-    await nextTick()
-
-    const song = fileOfSize('big.mp3', MAX_ATTACHMENT_BYTES + 1, 'audio/mpeg')
-    dispatchDrag(screen.getByRole('textbox'), 'drop', { files: [song] })
-    await nextTick()
-
-    expect(uploaded).toEqual([])
-    expect(useToastStore().messagesToAdd).toContainEqual(
-      expect.objectContaining({
-        severity: 'warn',
-        detail: 'big.mp3 is larger than 20MB'
-      })
-    )
-  })
-
-  it('claims a dragover carrying files so a drop can reach the panel', async () => {
-    // Without cancelling dragover the browser fires no drop at all, so this is
-    // what makes the advertised drag-and-drop work.
-    stubUploadFetch()
-    render(AgentPanelRoot, { global: { plugins: [i18n] } })
-    await nextTick()
-    const target = screen.getByRole('textbox')
-
-    expect(dispatchDrag(target, 'dragover', { types: ['Files'] })).toBe(true)
-    expect(dispatchDrag(target, 'dragover', { types: ['text/plain'] })).toBe(
-      false
-    )
-  })
-
-  it('shows the asset drop target during a trusted drag and clears it on leave', async () => {
-    stubUploadFetch()
-    render(AgentPanelRoot, { global: { plugins: [i18n] } })
-    await nextTick()
-    const target = screen.getByRole('textbox')
-    const data = {
-      types: ['application/x-comfy-asset-info', 'text/uri-list']
-    }
-
-    dispatchDrag(target, 'dragenter', data)
-    await nextTick()
-
-    const dropTarget = screen.getByRole('status')
-    expect(dropTarget).toHaveTextContent('Drag and drop assets here')
-
-    dispatchDrag(dropTarget, 'dragleave', data)
-    await nextTick()
-
-    expect(screen.queryByRole('status')).not.toBeInTheDocument()
   })
 
   it('rejects URI-only drags without showing or claiming the asset target', async () => {
@@ -934,162 +733,27 @@ describe('AgentPanelRoot attach flow', () => {
     expect(uploaded).toEqual([])
   })
 
-  it.for([
-    { mime: 'image/png', filename: 'gen.png' },
-    { mime: 'video/mp4', filename: 'movie.mp4' }
-  ])(
-    'attaches a Media-card $mime URI and forwards its uploaded ref',
-    async ({ mime, filename }) => {
-      // PM-116: MediaAssetCard.dragStart sets asset-info + text/uri-list on the
-      // transfer and never a File, so the panel must claim and fetch the URI.
-      const messageBodies: unknown[] = []
-      vi.stubGlobal(
-        'fetch',
-        vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
-          const url = String(input)
-          if (url.includes('/api/view'))
-            return new Response(new Blob(['asset']), {
-              headers: { 'Content-Type': mime }
-            })
-          if (url.endsWith('/api/upload/image'))
-            return new Response(
-              JSON.stringify({
-                name: `uploaded_${filename}`,
-                subfolder: '',
-                type: 'input'
-              }),
-              { status: 200, headers: { 'Content-Type': 'application/json' } }
-            )
-          if (init?.method === 'POST' && url.includes('/messages')) {
-            messageBodies.push(JSON.parse(String(init.body)))
-            return json(202, { thread_id: 'th-1', message_id: 'm-1' })
-          }
-          return new Response('{"threads":[]}', {
-            status: 200,
-            headers: { 'Content-Type': 'application/json' }
-          })
-        })
-      )
-      render(AgentPanelRoot, { global: { plugins: [i18n] } })
-      await nextTick()
-      const target = screen.getByRole('textbox')
-      const dragData = {
-        types: ['application/x-comfy-asset-info', 'text/uri-list'],
-        getData: (type: string) =>
-          type === 'application/x-comfy-asset-info'
-            ? JSON.stringify({ filename, type: 'input' })
-            : `http://localhost/api/view?filename=${filename}`
-      }
-
-      dispatchDrag(target, 'dragenter', dragData)
-      await nextTick()
-      expect(screen.getByRole('status')).toHaveTextContent(
-        'Drag and drop assets here'
-      )
-
-      expect(dispatchDrag(target, 'dragover', dragData)).toBe(true)
-
-      const claimed = dispatchDrag(target, 'drop', dragData)
-      expect(claimed).toBe(true)
-      await nextTick()
-      expect(screen.queryByRole('status')).not.toBeInTheDocument()
-
-      expect(await screen.findByText(filename)).toBeInTheDocument()
-
-      await userEvent.type(screen.getByRole('textbox'), 'describe this')
-      await userEvent.click(screen.getByRole('button', { name: 'Send' }))
-
-      expect(messageBodies).toHaveLength(1)
-      expect(messageBodies[0]).toMatchObject({
-        content: 'describe this',
-        attachments: [`uploaded_${filename}`]
-      })
-    }
-  )
-
-  it.for([
-    { mime: 'image/png', filename: 'gen.png' },
-    { mime: 'video/mp4', filename: 'movie.mp4' }
-  ])(
-    'stages an existing Media-card $mime reference without uploading',
-    async ({ mime, filename }) => {
-      const messageBodies: unknown[] = []
-      const fetchSpy = vi.fn(
-        async (input: RequestInfo | URL, init?: RequestInit) => {
-          const url = String(input)
-          if (init?.method === 'POST' && url.includes('/messages')) {
-            messageBodies.push(JSON.parse(String(init.body)))
-            return json(202, { thread_id: 'th-1', message_id: 'm-1' })
-          }
-          return new Response('{"threads":[]}', {
-            status: 200,
-            headers: { 'Content-Type': 'application/json' }
-          })
-        }
-      )
-      vi.stubGlobal('fetch', fetchSpy)
-      render(AgentPanelRoot, { global: { plugins: [i18n] } })
-      await nextTick()
-      const target = screen.getByRole('textbox')
-      const ref = `stored_${filename}`
-      const dragData = {
-        types: ['application/x-comfy-asset-info'],
-        getData: () =>
-          JSON.stringify({
-            filename,
-            type: 'input',
-            attachment_ref: ref,
-            media_kind: mime === 'image/png' ? 'image' : 'video',
-            preview_url:
-              mime === 'image/png'
-                ? `http://localhost/api/assets/${filename}/content`
-                : undefined
-          })
-      }
-
-      expect(dispatchDrag(target, 'drop', dragData)).toBe(true)
-      expect(dispatchDrag(target, 'drop', dragData)).toBe(true)
-      expect(await screen.findByText(filename)).toBeInTheDocument()
-      expect(screen.getAllByText(filename)).toHaveLength(1)
-      expect(
-        screen.queryByLabelText(i18n.global.t('agent.uploading'))
-      ).not.toBeInTheDocument()
-
-      await userEvent.click(screen.getByRole('button', { name: 'Send' }))
-
-      expect(messageBodies).toHaveLength(1)
-      expect(messageBodies[0]).toMatchObject({ attachments: [ref] })
-      expect(
-        fetchSpy.mock.calls.some(([url]) =>
-          /\/api\/(view|upload\/image)/.test(String(url))
-        )
-      ).toBe(false)
-    }
-  )
-
-  it('shows an uploading chip while a Media-card URI is still loading', async () => {
-    let resolveAsset: (response: Response) => void = () => {}
+  it('attaches a Media-card URI and forwards its uploaded ref', async () => {
+    const messageBodies: unknown[] = []
     vi.stubGlobal(
       'fetch',
-      vi.fn((input: RequestInfo | URL) => {
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
         const url = String(input)
         if (url.includes('/api/view'))
-          return new Promise<Response>((resolve) => {
-            resolveAsset = resolve
+          return new Response(new Blob(['asset']), {
+            headers: { 'Content-Type': 'image/png' }
           })
         if (url.endsWith('/api/upload/image'))
-          return Promise.resolve(
-            new Response(JSON.stringify({ name: 'uploaded_gen.png' }), {
-              status: 200,
-              headers: { 'Content-Type': 'application/json' }
-            })
-          )
-        return Promise.resolve(
-          new Response('{"threads":[]}', {
-            status: 200,
-            headers: { 'Content-Type': 'application/json' }
+          return json(200, {
+            name: 'uploaded_gen.png',
+            subfolder: '',
+            type: 'input'
           })
-        )
+        if (init?.method === 'POST' && url.includes('/messages')) {
+          messageBodies.push(JSON.parse(String(init.body)))
+          return json(202, { thread_id: 'th-1', message_id: 'm-1' })
+        }
+        return json(200, { threads: [] })
       })
     )
     render(AgentPanelRoot, { global: { plugins: [i18n] } })
@@ -1103,455 +767,27 @@ describe('AgentPanelRoot attach flow', () => {
           : 'http://localhost/api/view?filename=gen.png'
     }
 
+    dispatchDrag(target, 'dragenter', dragData)
+    await nextTick()
+    expect(screen.getByRole('status')).toHaveTextContent(
+      'Drag and drop assets here'
+    )
+    expect(dispatchDrag(target, 'dragover', dragData)).toBe(true)
     expect(dispatchDrag(target, 'drop', dragData)).toBe(true)
     expect(await screen.findByText('gen.png')).toBeInTheDocument()
-    expect(
-      screen.getByLabelText(i18n.global.t('agent.uploading'))
-    ).toBeInTheDocument()
 
-    resolveAsset(new Response(new Blob(['asset'], { type: 'image/png' })))
-    await vi.waitFor(() =>
-      expect(
-        screen.queryByLabelText(i18n.global.t('agent.uploading'))
-      ).not.toBeInTheDocument()
-    )
-  })
+    await userEvent.type(screen.getByRole('textbox'), 'describe this')
+    await userEvent.click(screen.getByRole('button', { name: 'Send' }))
 
-  it('attaches dropped assets and leaves other files to the graph loader', async () => {
-    // The graph loader only opens a dropped workflow while the drop is
-    // unclaimed, so the panel must not claim files it cannot attach.
-    stubUploadFetch()
-    render(AgentPanelRoot, { global: { plugins: [i18n] } })
-    await nextTick()
-    const target = screen.getByRole('textbox')
-
-    const workflow = new File(['{}'], 'flow.json', {
-      type: 'application/json'
+    expect(messageBodies).toHaveLength(1)
+    expect(messageBodies[0]).toMatchObject({
+      content: 'describe this',
+      attachments: ['uploaded_gen.png']
     })
-    expect(dispatchDrag(target, 'drop', { files: [workflow] })).toBe(false)
-    expect(screen.queryByText('flow.json')).not.toBeInTheDocument()
-
-    const asset = new File(['x'], 'cat.png', { type: 'image/png' })
-    expect(dispatchDrag(target, 'drop', { files: [asset] })).toBe(true)
-    expect(await screen.findByText('cat.png')).toBeInTheDocument()
-  })
-
-  it('attaches only the assets out of a mixed drop', async () => {
-    const uploaded = stubUploadFetch()
-    render(AgentPanelRoot, { global: { plugins: [i18n] } })
-    await nextTick()
-
-    // The non-attachable file comes first: addFiles uploads sequentially, so a
-    // regression that forwards the whole drop would upload flow.json before
-    // cat.png and the settled assertion below could never latch a lucky
-    // intermediate state.
-    const files = [
-      new File(['{}'], 'flow.json', { type: 'application/json' }),
-      new File(['x'], 'cat.png', { type: 'image/png' })
-    ]
-    dispatchDrag(screen.getByRole('textbox'), 'drop', { files })
-
-    expect(await screen.findByText('cat.png')).toBeInTheDocument()
-    await vi.waitFor(() => expect(uploaded).toEqual(['cat.png']))
-  })
-
-  it('shows an uploading chip and blocks send until the upload settles', async () => {
-    let settleUpload: () => void = () => {}
-    const fetchMock = vi.fn(async (url: string) => {
-      if (url.endsWith('/api/upload/image')) {
-        await new Promise<void>((resolve) => {
-          settleUpload = resolve
-        })
-        return new Response(
-          JSON.stringify({
-            name: 'uploaded_cat.png',
-            subfolder: '',
-            type: 'input'
-          }),
-          { status: 200, headers: { 'Content-Type': 'application/json' } }
-        )
-      }
-      return json(202, { thread_id: 'th-1', message_id: 'm-1' })
-    })
-    vi.stubGlobal('fetch', fetchMock)
-
-    render(AgentPanelRoot, { global: { plugins: [i18n] } })
-
-    const file = new File(['x'], 'cat.png', { type: 'image/png' })
-    await userEvent.upload(
-      screen.getByTestId<HTMLInputElement>('agent-file-input'),
-      file
-    )
-
-    expect(await screen.findByText('cat.png')).toBeInTheDocument()
-    expect(
-      screen.getByLabelText(i18n.global.t('agent.uploading'))
-    ).toBeInTheDocument()
-    await userEvent.type(screen.getByRole('textbox'), 'make it pop')
-    expect(screen.getByRole('button', { name: 'Send' })).toBeDisabled()
-
-    settleUpload()
-    await vi.waitFor(() =>
-      expect(screen.getByRole('button', { name: 'Send' })).toBeEnabled()
-    )
-    expect(
-      screen.queryByLabelText(i18n.global.t('agent.uploading'))
-    ).not.toBeInTheDocument()
-  })
-
-  it('renders the attachment on the turn that sent it, not earlier turns', async () => {
-    let acks = 0
-    vi.stubGlobal(
-      'fetch',
-      vi.fn(async (url: string, init?: RequestInit) => {
-        if (url.endsWith('/api/upload/image')) {
-          return new Response(
-            JSON.stringify({
-              name: 'uploaded_cat.png',
-              subfolder: '',
-              type: 'input'
-            }),
-            { status: 200, headers: { 'Content-Type': 'application/json' } }
-          )
-        }
-        if (init?.method === 'POST' && url.includes('/messages')) {
-          acks += 1
-          return json(202, { thread_id: 'th-1', message_id: `m-${acks}` })
-        }
-        return json(200, { threads: [] })
-      })
-    )
-
-    await renderAndSend('first message')
-    ws.emit('agent_message_done', { message_id: 'm-1', thread_id: 'th-1' })
-    await screen.findByRole('button', { name: 'Send' })
-
-    const file = new File(['x'], 'cat.png', { type: 'image/png' })
-    await userEvent.upload(
-      screen.getByTestId<HTMLInputElement>('agent-file-input'),
-      file
-    )
-    await screen.findByText('cat.png')
-    await sendFromComposer('second message')
-
-    const thumbs = screen.getAllByAltText('cat.png')
-    expect(thumbs).toHaveLength(1)
-    const firstBubble = screen.getAllByText('first message').at(-1)!
-    expect(
-      firstBubble.compareDocumentPosition(thumbs[0]) &
-        Node.DOCUMENT_POSITION_FOLLOWING
-    ).toBeTruthy()
-  })
-
-  it('removes the chip, revokes its preview, and raises the error modal when the upload fails', async () => {
-    executionErrors.lastPromptError = null
-    executionErrors.showErrorOverlay.mockClear()
-    const revoke = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {})
-    let failUpload: () => void = () => {}
-    vi.stubGlobal(
-      'fetch',
-      vi.fn(async (url: string) => {
-        if (url.endsWith('/api/upload/image')) {
-          await new Promise<void>((resolve) => {
-            failUpload = resolve
-          })
-          return new Response('{"error":"disk full"}', {
-            status: 500,
-            headers: { 'Content-Type': 'application/json' }
-          })
-        }
-        return new Response('{"threads":[]}', {
-          status: 200,
-          headers: { 'Content-Type': 'application/json' }
-        })
-      })
-    )
-
-    render(AgentPanelRoot, { global: { plugins: [i18n] } })
-
-    const file = new File(['x'], 'cat.png', { type: 'image/png' })
-    await userEvent.upload(
-      screen.getByTestId<HTMLInputElement>('agent-file-input'),
-      file
-    )
-    expect(await screen.findByText('cat.png')).toBeInTheDocument()
-
-    executionErrors.showErrorOverlay.mockClear()
-    failUpload()
-    await vi.waitFor(() =>
-      expect(screen.queryByText('cat.png')).not.toBeInTheDocument()
-    )
-    expect(revoke).toHaveBeenCalledTimes(1)
-    // A rejected file is the user's to fix; raising the server-error overlay
-    // told them the agent had broken instead.
-    expect(executionErrors.showErrorOverlay).not.toHaveBeenCalled()
-    expect(useToastStore().messagesToAdd).toContainEqual(
-      expect.objectContaining({
-        severity: 'warn',
-        detail: 'cat.png could not be uploaded'
-      })
-    )
-    revoke.mockRestore()
-  })
-
-  it('dismissing a staged chip removes it and releases its preview', async () => {
-    const revoke = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {})
-    vi.stubGlobal(
-      'fetch',
-      vi.fn(async (url: string) => {
-        if (url.endsWith('/api/upload/image')) {
-          return new Response(
-            JSON.stringify({
-              name: 'uploaded_cat.png',
-              subfolder: '',
-              type: 'input'
-            }),
-            { status: 200, headers: { 'Content-Type': 'application/json' } }
-          )
-        }
-        return new Response('{"threads":[]}', {
-          status: 200,
-          headers: { 'Content-Type': 'application/json' }
-        })
-      })
-    )
-
-    render(AgentPanelRoot, { global: { plugins: [i18n] } })
-
-    const file = new File(['x'], 'cat.png', { type: 'image/png' })
-    await userEvent.upload(
-      screen.getByTestId<HTMLInputElement>('agent-file-input'),
-      file
-    )
-    expect(await screen.findByText('cat.png')).toBeInTheDocument()
-
-    await userEvent.click(
-      screen.getByRole('button', { name: i18n.global.t('agent.remove') })
-    )
-    expect(screen.queryByText('cat.png')).not.toBeInTheDocument()
-    expect(revoke).toHaveBeenCalledTimes(1)
-    revoke.mockRestore()
   })
 })
 
 describe('AgentPanelRoot history', () => {
-  beforeEach(() => {
-    setActivePinia(createPinia())
-    ws.clear()
-    localStorage.clear()
-  })
-
-  async function renderWithActiveThread(): Promise<void> {
-    vi.stubGlobal(
-      'fetch',
-      vi.fn(async (url: string) =>
-        url.endsWith('/api/agent/threads')
-          ? new Response(
-              JSON.stringify({
-                threads: [
-                  {
-                    id: 'th-active',
-                    title: 'build a duck',
-                    last_message_at: '2026-07-07T10:00:00Z'
-                  }
-                ]
-              }),
-              { status: 200, headers: { 'Content-Type': 'application/json' } }
-            )
-          : new Response('[]', {
-              status: 200,
-              headers: { 'Content-Type': 'application/json' }
-            })
-      )
-    )
-    render(AgentPanelRoot, { global: { plugins: [i18n] } })
-    useAgentConversationStore().setThreadId('th-active')
-    await nextTick()
-  }
-
-  it('renames the current chat from the title menu on Enter', async () => {
-    await renderWithActiveThread()
-
-    await userEvent.click(
-      screen.getByRole('button', { name: i18n.global.t('agent.chatOptions') })
-    )
-    const menu = await screen.findByRole('menu')
-    expect(
-      within(menu)
-        .getAllByRole('menuitem')
-        .map((item) => item.textContent)
-    ).toEqual([i18n.global.t('g.rename'), i18n.global.t('g.delete')])
-    await userEvent.click(
-      within(menu).getByRole('menuitem', { name: i18n.global.t('g.rename') })
-    )
-    const input = await screen.findByRole<HTMLInputElement>('textbox', {
-      name: i18n.global.t('g.rename')
-    })
-    expect(input).toHaveFocus()
-    expect(input.selectionStart).toBe(0)
-    expect(input.selectionEnd).toBe(input.value.length)
-    await userEvent.type(input, 'my masterpiece{Enter}')
-
-    expect(await screen.findByText('my masterpiece')).toBeInTheDocument()
-    expect(useAgentChatHistoryStore().grouped.current[0]).toMatchObject({
-      id: 'th-active',
-      title: 'my masterpiece'
-    })
-    expect(
-      screen.getByRole('button', {
-        name: i18n.global.t('agent.chatOptions')
-      })
-    ).toBeInTheDocument()
-  })
-
-  it('commits a rename when the input loses focus', async () => {
-    await renderWithActiveThread()
-
-    await userEvent.click(
-      screen.getByRole('button', { name: i18n.global.t('agent.chatOptions') })
-    )
-    await userEvent.click(
-      await screen.findByRole('menuitem', { name: i18n.global.t('g.rename') })
-    )
-    const input = await screen.findByRole<HTMLInputElement>('textbox', {
-      name: i18n.global.t('g.rename')
-    })
-    await userEvent.type(input, 'renamed by blur')
-    input.blur()
-
-    await vi.waitFor(() =>
-      expect(useAgentChatHistoryStore().titleFor('th-active')).toBe(
-        'renamed by blur'
-      )
-    )
-  })
-
-  it('starts renaming from a single click on the current title', async () => {
-    await renderWithActiveThread()
-
-    await userEvent.click(
-      screen.getByRole('button', {
-        name: i18n.global.t('agent.newChatTitle')
-      })
-    )
-
-    const input = await screen.findByRole<HTMLInputElement>('textbox', {
-      name: i18n.global.t('g.rename')
-    })
-    expect(input).toHaveFocus()
-    expect(input.selectionStart).toBe(0)
-    expect(input.selectionEnd).toBe(input.value.length)
-    expect(
-      screen.queryByRole('button', { name: i18n.global.t('agent.history') })
-    ).toBeNull()
-  })
-
-  it('opens Chat History from its dedicated control', async () => {
-    await renderWithActiveThread()
-
-    await userEvent.click(
-      screen.getByRole('button', {
-        name: i18n.global.t('agent.showChatHistory')
-      })
-    )
-
-    expect(
-      await screen.findByRole('heading', {
-        name: i18n.global.t('agent.history')
-      })
-    ).toBeInTheDocument()
-    expect(
-      screen.getByRole('button', {
-        name: i18n.global.t('agent.backToPreviousChat')
-      })
-    ).toBeInTheDocument()
-    expect(
-      screen.queryByRole('textbox', { name: i18n.global.t('g.rename') })
-    ).toBeNull()
-  })
-
-  it('abandons a rename on Escape', async () => {
-    await renderWithActiveThread()
-
-    await userEvent.click(
-      screen.getByRole('button', { name: i18n.global.t('agent.chatOptions') })
-    )
-    await userEvent.click(
-      await screen.findByRole('menuitem', { name: i18n.global.t('g.rename') })
-    )
-    const input = await screen.findByRole('textbox', {
-      name: i18n.global.t('g.rename')
-    })
-    await userEvent.clear(input)
-    await userEvent.type(input, 'discarded{Escape}')
-
-    expect(
-      screen.queryByRole('textbox', { name: i18n.global.t('g.rename') })
-    ).toBeNull()
-    expect(screen.queryByText('discarded')).toBeNull()
-    expect(useAgentChatHistoryStore().titleFor('th-active')).toBeUndefined()
-  })
-
-  it('renames a conversation from Chat History', async () => {
-    await renderWithActiveThread()
-
-    await userEvent.click(
-      screen.getByRole('button', {
-        name: i18n.global.t('agent.showChatHistory')
-      })
-    )
-    await userEvent.click(
-      screen.getByRole('button', {
-        name: i18n.global.t('agent.chatOptions')
-      })
-    )
-    await userEvent.click(
-      await screen.findByRole('menuitem', { name: i18n.global.t('g.rename') })
-    )
-    const input = await screen.findByRole<HTMLInputElement>('textbox', {
-      name: i18n.global.t('g.rename')
-    })
-    expect(input.value).toBe('build a duck')
-    expect(input.selectionStart).toBe(0)
-    expect(input.selectionEnd).toBe(input.value.length)
-
-    await userEvent.type(input, 'Findable duck chat{Enter}', {
-      skipClick: true
-    })
-
-    expect(await screen.findByText('Findable duck chat')).toBeInTheDocument()
-    expect(useAgentChatHistoryStore().titleFor('th-active')).toBe(
-      'Findable duck chat'
-    )
-  })
-
-  it('deletes the current chat from the title menu and starts fresh', async () => {
-    await renderWithActiveThread()
-    await vi.waitFor(() =>
-      expect(useAgentChatHistoryStore().sessions).toHaveLength(1)
-    )
-
-    await userEvent.click(
-      screen.getByRole('button', { name: i18n.global.t('agent.chatOptions') })
-    )
-    await userEvent.click(
-      await screen.findByRole('menuitem', { name: i18n.global.t('g.delete') })
-    )
-
-    expect(useAgentChatHistoryStore().sessions).toHaveLength(0)
-    // The fresh chat has no thread yet, so the menu disappears with it.
-    expect(
-      screen.queryByRole('button', { name: i18n.global.t('agent.chatOptions') })
-    ).toBeNull()
-
-    // The server has no delete endpoint yet, so the tombstone must hold the
-    // thread out of the next refresh instead of letting it resurrect.
-    useAgentChatHistoryStore().replaceAll([
-      { id: 'th-active', title: 'build a duck', updatedAt: Date.now() }
-    ])
-    expect(useAgentChatHistoryStore().sessions).toHaveLength(0)
-  })
-
   it('populates Chat History from the server thread list on mount', async () => {
     const fetchMock = vi.fn(async (url: string) => {
       if (url.endsWith('/api/agent/threads')) {
@@ -1597,8 +833,6 @@ describe('AgentPanelRoot history', () => {
   })
 
   it('surfaces a thread-list failure via the host error modal', async () => {
-    executionErrors.lastPromptError = null
-    executionErrors.showErrorOverlay.mockClear()
     vi.stubGlobal(
       'fetch',
       vi.fn(async () => new Response('{}', { status: 500 }))
@@ -1614,125 +848,9 @@ describe('AgentPanelRoot history', () => {
     })
     expect(useAgentChatHistoryStore().sessions).toHaveLength(0)
   })
-
-  it('marks the adopted thread as the current session', async () => {
-    vi.stubGlobal(
-      'fetch',
-      vi.fn(async (url: string) =>
-        url.endsWith('/api/agent/threads')
-          ? new Response('{"threads":[]}', {
-              status: 200,
-              headers: { 'Content-Type': 'application/json' }
-            })
-          : new Response('[]', {
-              status: 200,
-              headers: { 'Content-Type': 'application/json' }
-            })
-      )
-    )
-    render(AgentPanelRoot, { global: { plugins: [i18n] } })
-
-    const convo = useAgentConversationStore()
-    convo.setThreadId('th-active')
-    await nextTick()
-
-    const history = useAgentChatHistoryStore()
-    expect(history.activeId).toBe('th-active')
-  })
-})
-
-describe('AgentPanelRoot transcript copy', () => {
-  beforeEach(() => {
-    setActivePinia(createPinia())
-    ws.clear()
-    clipboard.copy.mockClear()
-  })
-
-  it('copies the active session from chat history as formatted markdown', async () => {
-    vi.stubGlobal(
-      'fetch',
-      vi.fn(async (url: string) =>
-        url.endsWith('/api/agent/threads')
-          ? new Response(
-              JSON.stringify({
-                threads: [
-                  {
-                    id: 'th-1',
-                    title: 'make a cat',
-                    last_message_at: '2026-07-07T10:00:00Z'
-                  }
-                ],
-                pagination: { page: 1 }
-              }),
-              { status: 200, headers: { 'Content-Type': 'application/json' } }
-            )
-          : new Response('{}', { status: 200 })
-      )
-    )
-
-    render(AgentPanelRoot, { global: { plugins: [i18n] } })
-
-    const convo = useAgentConversationStore()
-    const turnId = 'turn-1' as TurnId
-    convo.setThreadId('th-1')
-    convo.recordUser(turnId, 'make a cat')
-    convo.startTurn(turnId)
-    convo.ingest(
-      zAgentWsEventForTest({
-        type: 'agent_message_delta',
-        data: { delta: 'Here is ', message_id: 'turn-1', thread_id: 'th-1' }
-      })
-    )
-    convo.ingest(
-      zAgentWsEventForTest({
-        type: 'agent_tool_call',
-        data: {
-          tool_name: 'add_node',
-          status: 'ok',
-          args: [],
-          message_id: 'turn-1',
-          thread_id: 'th-1'
-        }
-      })
-    )
-    convo.ingest(
-      zAgentWsEventForTest({
-        type: 'agent_message_delta',
-        data: { delta: 'a cat.', message_id: 'turn-1', thread_id: 'th-1' }
-      })
-    )
-    convo.ingest(
-      zAgentWsEventForTest({
-        type: 'agent_message_done',
-        data: { message_id: 'turn-1', thread_id: 'th-1', usage: null }
-      })
-    )
-    await nextTick()
-
-    await userEvent.click(
-      screen.getByRole('button', {
-        name: i18n.global.t('agent.showChatHistory')
-      })
-    )
-    await userEvent.click(
-      await screen.findByRole('button', {
-        name: i18n.global.t('agent.copyMarkdown')
-      })
-    )
-
-    expect(clipboard.copy).toHaveBeenCalledWith(
-      '**You:** make a cat\n\n**Agent:** Here is a cat.'
-    )
-  })
 })
 
 describe('AgentPanelRoot feedback capture', () => {
-  beforeEach(() => {
-    setActivePinia(createPinia())
-    ws.clear()
-    telemetry.trackAgentMessageFeedback.mockClear()
-  })
-
   it('forwards a thumbs vote to telemetry with the message id and vote', async () => {
     render(AgentPanelRoot, { global: { plugins: [i18n] } })
 
@@ -1757,23 +875,14 @@ describe('AgentPanelRoot feedback capture', () => {
     await userEvent.click(
       await screen.findByRole('button', { name: 'Helpful' })
     )
-    await userEvent.click(
-      await screen.findByRole('button', { name: 'Helpful' })
-    )
 
     expect(telemetry.trackAgentMessageFeedback.mock.calls).toEqual([
-      [{ message_id: 'turn-9', vote: 'up', workflow_id: null }],
-      [{ message_id: 'turn-9', vote: null, workflow_id: null }]
+      [{ message_id: 'turn-9', vote: 'up', workflow_id: null }]
     ])
   })
 })
 
 describe('AgentPanelRoot lifecycle', () => {
-  beforeEach(() => {
-    setActivePinia(createPinia())
-    ws.clear()
-  })
-
   it('reports the header close click and attributes the panel close to it', async () => {
     const selection = await startVueNodeSelection()
 
@@ -1791,16 +900,12 @@ describe('AgentPanelRoot lifecycle', () => {
     await expectLaterClickCannotRestoreAccumulatedNodes(selection)
   })
 
-  it('ends node selection when the panel unmounts', async () => {
-    const selection = await startVueNodeSelection()
-
-    selection.unmount()
-
-    expect(selection.canvas.multi_select).toBe(false)
-    await expectLaterClickCannotRestoreAccumulatedNodes(selection)
-  })
-
   it('does not cancel the in-flight turn when the panel unmounts', async () => {
+    const tab = addTab('workflows/current.json', {
+      activeState: { id: 'wf-42' }
+    })
+    hostStores.workflow.activeWorkflow = tab
+    useAgentWorkflowTabBindingStore().bind('wf-42', tab.path)
     const urls: string[] = []
     const fetchMock = vi.fn(async (url: string) => {
       urls.push(url)
@@ -1811,38 +916,20 @@ describe('AgentPanelRoot lifecycle', () => {
     const { unmount } = render(AgentPanelRoot, { global: { plugins: [i18n] } })
 
     await sendFromComposer('hello')
+    const activity = useWorkflowTabActivityStore()
+    expect(activity.editingTabPath).toBe(tab.path)
+    activity.setCreating(true)
 
     unmount()
-    await new Promise((resolve) => setTimeout(resolve))
+    await nextTick()
 
     expect(urls.some((url) => url.endsWith('/cancel'))).toBe(false)
-  })
-})
-
-describe('AgentPanelRoot greeting', () => {
-  beforeEach(() => {
-    setActivePinia(createPinia())
-    ws.clear()
-  })
-
-  it('personalizes the empty-state greeting with the account first name', async () => {
-    render(AgentPanelRoot, { global: { plugins: [i18n] } })
-
-    expect(await screen.findByText('Hello Jo,')).toBeInTheDocument()
+    expect(activity.editingTabPath).toBeNull()
+    expect(activity.creatingTab).toBe(false)
   })
 })
 
 describe('AgentPanelRoot workflow binding', () => {
-  beforeEach(() => {
-    setActivePinia(createPinia())
-    ws.clear()
-    vi.mocked(app.loadGraphData).mockClear()
-    vi.mocked(validateComfyWorkflow).mockClear()
-    telemetry.trackAgentNodeTagged.mockClear()
-    telemetry.trackAgentWorkflowApplied.mockClear()
-    executionErrors.showErrorOverlay.mockClear()
-  })
-
   function makeTab(id?: string): FakeTab {
     const tab: FakeTab = {
       path: 'workflows/current.json',
@@ -1891,71 +978,6 @@ describe('AgentPanelRoot workflow binding', () => {
     return bodies
   }
 
-  it('names the active workflow in the selector', async () => {
-    makeTab('wf-42')
-    mockMessagesEndpoint('wf-42')
-
-    render(AgentPanelRoot, { global: { plugins: [i18n] } })
-
-    expect(await screen.findAllByText('current')).not.toHaveLength(0)
-
-    const other = addTab('workflows/other.json')
-    hostStores.workflow.activeWorkflow = other
-    expect(await screen.findAllByText('other')).not.toHaveLength(0)
-    expect(screen.queryAllByText('current')).toHaveLength(0)
-  })
-
-  it('hides the active workflow in history and restores it on return', async () => {
-    makeTab('wf-42')
-    mockMessagesEndpoint('wf-42')
-
-    render(AgentPanelRoot, { global: { plugins: [i18n] } })
-    expect(await screen.findAllByText('current')).not.toHaveLength(0)
-
-    await userEvent.click(
-      screen.getByRole('button', {
-        name: i18n.global.t('agent.showChatHistory')
-      })
-    )
-    expect(
-      await screen.findByText(i18n.global.t('agent.historyEmpty'))
-    ).toBeInTheDocument()
-    expect(screen.queryByText('current')).not.toBeInTheDocument()
-
-    await userEvent.click(
-      screen.getByRole('button', {
-        name: i18n.global.t('agent.backToPreviousChat')
-      })
-    )
-    expect(await screen.findAllByText('current')).not.toHaveLength(0)
-  })
-
-  it('activates the tab picked from the workflow selector via the service', async () => {
-    makeTab('wf-42')
-    const other = addTab('workflows/other.json')
-    mockMessagesEndpoint('wf-42')
-
-    render(AgentPanelRoot, { global: { plugins: [i18n] } })
-
-    await userEvent.click(
-      screen.getByRole('button', {
-        name: i18n.global.t('agent.switchWorkflow')
-      })
-    )
-    expect(workflowService.openWorkflow).not.toHaveBeenCalled()
-    await userEvent.click(await screen.findByText('other'))
-
-    await vi.waitFor(() =>
-      expect(workflowService.openWorkflow).toHaveBeenCalledWith(other)
-    )
-    expect(workflowService.openWorkflow).toHaveBeenCalledTimes(1)
-    expect(
-      screen.getByRole('button', {
-        name: i18n.global.t('agent.switchWorkflow')
-      })
-    ).toHaveTextContent('other')
-  })
-
   it('transitions the bound tab from editing to modified when the turn completes', async () => {
     makeTab('wf-42')
     mockMessagesEndpoint('wf-42')
@@ -1971,23 +993,6 @@ describe('AgentPanelRoot workflow binding', () => {
     expect(activity.unseenModifiedPaths.has('workflows/current.json')).toBe(
       true
     )
-  })
-
-  it('clears the spinner and creating flags when the panel unmounts mid-turn', async () => {
-    makeTab('wf-42')
-    mockMessagesEndpoint('wf-42')
-
-    const { unmount } = render(AgentPanelRoot, { global: { plugins: [i18n] } })
-    await sendFromComposer('add an upscaler')
-
-    const activity = useWorkflowTabActivityStore()
-    expect(activity.editingTabPath).toBe('workflows/current.json')
-    activity.setCreating(true)
-
-    unmount()
-
-    expect(activity.editingTabPath).toBeNull()
-    expect(activity.creatingTab).toBe(false)
   })
 
   it('holds the creating flag for 500 ms before an unbound agent tab materializes', async () => {
@@ -2034,44 +1039,6 @@ describe('AgentPanelRoot workflow binding', () => {
     vi.useRealTimers()
   })
 
-  it('lowers the creating flag when a newer focus event supersedes the fetch', async () => {
-    const bound = makeTab('wf-42')
-    let resolveLookup: ((response: Response) => void) | undefined
-    vi.stubGlobal(
-      'fetch',
-      vi.fn(async (url: string) => {
-        if (url.includes('/messages')) return json(202, ack('wf-42', 'm-1'))
-        if (url.includes('/agent/threads'))
-          return json(200, { threads: [], pagination: { page: 1 } })
-        if (url.includes('workflow_id=wf-new')) {
-          return new Promise<Response>((resolve) => {
-            resolveLookup = resolve
-          })
-        }
-        return new Response('{}', { status: 200 })
-      })
-    )
-
-    await renderAndSend('work here')
-
-    ws.emit('agent_active_tab', {
-      workflow_id: 'wf-new',
-      name: 'Fresh',
-      thread_id: 'th-1'
-    })
-    const activity = useWorkflowTabActivityStore()
-    await vi.waitFor(() => expect(activity.creatingTab).toBe(true))
-
-    ws.emit('agent_active_tab', { workflow_id: 'wf-42', thread_id: 'th-1' })
-    resolveLookup?.(json(404, { error: 'none' }))
-
-    await vi.waitFor(() =>
-      expect(workflowService.openWorkflow).toHaveBeenCalledWith(bound)
-    )
-    expect(activity.creatingTab).toBe(false)
-    expect(hostStores.workflow.tabs.get('workflows/Fresh.json')).toBe(undefined)
-  })
-
   it('pins the spinner to the tab that sent the turn, not the tab active at ack', async () => {
     makeTab('wf-42')
     const other = addTab('workflows/other.json')
@@ -2092,73 +1059,6 @@ describe('AgentPanelRoot workflow binding', () => {
 
     const activity = useWorkflowTabActivityStore()
     expect(activity.editingTabPath).toBe('workflows/current.json')
-  })
-
-  it('moves the spinner to the tab the agent creates mid-turn', async () => {
-    makeTab('wf-42')
-    mockMessagesEndpoint('wf-42')
-
-    await renderAndSend('work here')
-    const activity = useWorkflowTabActivityStore()
-    expect(activity.editingTabPath).toBe('workflows/current.json')
-
-    ws.emit('agent_active_tab', {
-      workflow_id: 'wf-77',
-      name: 'Video test',
-      thread_id: 'th-1'
-    })
-
-    await vi.waitFor(() =>
-      expect(activity.editingTabPath).toBe('workflows/Video test.json')
-    )
-  })
-
-  it('re-arms a resumed turn spinner on the bound tab, not the active tab', async () => {
-    makeTab('wf-42')
-    mockMessagesEndpoint('wf-42')
-
-    const { unmount } = render(AgentPanelRoot, { global: { plugins: [i18n] } })
-    await sendFromComposer('add an upscaler')
-
-    const activity = useWorkflowTabActivityStore()
-    expect(activity.editingTabPath).toBe('workflows/current.json')
-
-    unmount()
-    expect(activity.editingTabPath).toBeNull()
-
-    const other = addTab('workflows/other.json')
-    useAgentWorkflowTabBindingStore().bind('wf-other', other.path)
-    hostStores.workflow.activeWorkflow = other
-    vi.stubGlobal(
-      'fetch',
-      vi.fn(async (url: string) => {
-        if (url.includes('/messages')) return json(200, [])
-        if (url.includes('/agent/threads'))
-          return json(200, { threads: [], pagination: { page: 1 } })
-        return new Response('{}', { status: 200 })
-      })
-    )
-
-    render(AgentPanelRoot, { global: { plugins: [i18n] } })
-    await vi.waitFor(() =>
-      expect(activity.editingTabPath).toBe('workflows/current.json')
-    )
-
-    ws.emit('agent_message_done', { message_id: 'm-1', thread_id: 'th-1' })
-    await vi.waitFor(() => expect(activity.editingTabPath).toBeNull())
-  })
-
-  it("sends the active tab's saved workflow id with the turn", async () => {
-    makeTab('wf-42')
-    const bodies = mockMessagesEndpoint('wf-42')
-
-    await renderAndSend('add an upscaler')
-
-    expect(bodies[0]).toMatchObject({ workflow_id: 'wf-42' })
-    // Content sync is the CRDT follower's job now: no draft ever rides the
-    // turn and nothing re-loads the canvas from the ack path.
-    expect(bodies[0]).not.toHaveProperty('draft')
-    expect(app.loadGraphData).not.toHaveBeenCalled()
   })
 
   it('chip X detaches the chat so the next send carries no workflow context', async () => {
@@ -2182,75 +1082,7 @@ describe('AgentPanelRoot workflow binding', () => {
     expect(bodies[0]).toMatchObject({
       open_tabs: [{ workflow_id: 'wf-42', name: 'current' }]
     })
-  })
-
-  it('re-attaches by picking a row so the next send carries the workflow again', async () => {
-    makeTab('wf-42')
-    const bodies = mockMessagesEndpoint('wf-42')
-    render(AgentPanelRoot, { global: { plugins: [i18n] } })
-
-    await userEvent.click(
-      screen.getByRole('button', {
-        name: i18n.global.t('agent.dontWorkInWorkflow')
-      })
-    )
-    await userEvent.click(
-      screen.getByRole('button', {
-        name: i18n.global.t('agent.switchWorkflow')
-      })
-    )
-    await userEvent.click(
-      await screen.findByRole('menuitemradio', { name: /current/ })
-    )
-
-    await sendFromComposer('back on the canvas')
-
-    expect(bodies[0]).toMatchObject({ workflow_id: 'wf-42' })
-  })
-
-  it('starts a new chat detached from the previously active workflow', async () => {
-    makeTab('wf-42')
-    const bodies = mockMessagesEndpoint('wf-42')
-    render(AgentPanelRoot, { global: { plugins: [i18n] } })
-
-    await userEvent.click(
-      screen.getByRole('button', { name: i18n.global.t('agent.newChat') })
-    )
-
-    expect(
-      await screen.findAllByText(i18n.global.t('agent.chooseWorkflow'))
-    ).not.toHaveLength(0)
-    expect(screen.queryByText('current')).not.toBeInTheDocument()
-
-    await sendFromComposer('fresh chat')
-
-    expect(bodies[0]).not.toHaveProperty('workflow_id')
-    expect(bodies[0]).not.toHaveProperty('current_tab')
-    expect(bodies[0]).toMatchObject({
-      open_tabs: [{ workflow_id: 'wf-42', name: 'current' }]
-    })
-  })
-
-  it('a detached send never re-arms the editing spinner on the old tab', async () => {
-    makeTab('wf-42')
-    mockMessagesEndpoint('wf-42')
-    render(AgentPanelRoot, { global: { plugins: [i18n] } })
-
-    await sendFromComposer('attached turn')
-    const activity = useWorkflowTabActivityStore()
-    expect(activity.editingTabPath).toBe('workflows/current.json')
-
-    ws.emit('agent_message_done', { message_id: 'm-1', thread_id: 'th-1' })
-    await vi.waitFor(() => expect(activity.editingTabPath).toBeNull())
-
-    await userEvent.click(
-      screen.getByRole('button', {
-        name: i18n.global.t('agent.dontWorkInWorkflow')
-      })
-    )
-    await sendFromComposer('detached turn')
-
-    expect(activity.editingTabPath).toBeNull()
+    expect(useWorkflowTabActivityStore().editingTabPath).toBeNull()
   })
 
   it('agent_active_tab activates the bound tab', async () => {
@@ -2263,12 +1095,6 @@ describe('AgentPanelRoot workflow binding', () => {
     await vi.waitFor(() =>
       expect(workflowService.openWorkflow).toHaveBeenCalledWith(tab)
     )
-    expect(workflowService.saveWorkflowAs).not.toHaveBeenCalled()
-    // The whole FE-1310 chain: wire event -> session -> store -> rendered card.
-    expect(
-      await screen.findByRole('button', { name: /^Open / })
-    ).toBeInTheDocument()
-
     // Content sync rides the CRDT follower; activation never reloads the
     // canvas itself.
     expect(app.loadGraphData).not.toHaveBeenCalled()
@@ -2299,133 +1125,17 @@ describe('AgentPanelRoot workflow binding', () => {
     expect(minted?.filename).toBe('Video test')
     // The host minted the doc server-side; the follower fills the canvas.
     // Nothing loads, saves, or adopts here.
-    expect(workflowService.saveWorkflowAs).not.toHaveBeenCalled()
     expect(app.loadGraphData).not.toHaveBeenCalled()
     expect(useAgentWorkflowTabBindingStore().tabPathFor('wf-77')).toBe(
+      'workflows/Video test.json'
+    )
+    expect(useWorkflowTabActivityStore().editingTabPath).toBe(
       'workflows/Video test.json'
     )
     expect(telemetry.trackAgentWorkflowApplied).toHaveBeenCalledWith({
       workflow_id: 'wf-77',
       target: 'active_tab_open'
     })
-  })
-  it('agent_active_tab sanitizes slashes and falls back on empty names', async () => {
-    makeTab('wf-42')
-    mockMessagesEndpoint('wf-42')
-
-    await renderAndSend('work here')
-
-    ws.emit('agent_active_tab', {
-      workflow_id: 'wf-88',
-      name: 'a/b',
-      thread_id: 'th-1'
-    })
-    await vi.waitFor(() =>
-      expect(hostStores.workflow.tabs.get('workflows/a-b.json')).toBeDefined()
-    )
-
-    ws.emit('agent_active_tab', {
-      workflow_id: 'wf-89',
-      name: '  ',
-      thread_id: 'th-1'
-    })
-    await vi.waitFor(() =>
-      expect(
-        hostStores.workflow.tabs.get('workflows/Unsaved Workflow.json')
-      ).toBeDefined()
-    )
-  })
-
-  it('agent_active_tab strips dotfile prefixes hidden behind whitespace', async () => {
-    makeTab('wf-42')
-    mockMessagesEndpoint('wf-42')
-
-    await renderAndSend('work here')
-
-    ws.emit('agent_active_tab', {
-      workflow_id: 'wf-95',
-      name: ' .hidden',
-      thread_id: 'th-1'
-    })
-    await vi.waitFor(() =>
-      expect(
-        hostStores.workflow.tabs.get('workflows/hidden.json')
-      ).toBeDefined()
-    )
-  })
-
-  it('two unnamed agent tabs mint distinct tabs with distinct bindings', async () => {
-    makeTab('wf-42')
-    mockMessagesEndpoint('wf-42')
-
-    await renderAndSend('work here')
-
-    ws.emit('agent_active_tab', { workflow_id: 'wf-a', thread_id: 'th-1' })
-    await vi.waitFor(() =>
-      expect(
-        hostStores.workflow.tabs.get('workflows/Unsaved Workflow.json')
-      ).toBeDefined()
-    )
-    ws.emit('agent_active_tab', { workflow_id: 'wf-b', thread_id: 'th-1' })
-    await vi.waitFor(() =>
-      expect(
-        hostStores.workflow.tabs.get('workflows/Unsaved Workflow (2).json')
-      ).toBeDefined()
-    )
-    expect(workflowService.saveWorkflowAs).not.toHaveBeenCalled()
-
-    const activity = useWorkflowTabActivityStore()
-    await vi.waitFor(() =>
-      expect(activity.editingTabPath).toBe(
-        'workflows/Unsaved Workflow (2).json'
-      )
-    )
-    ws.emit('agent_active_tab', { workflow_id: 'wf-a', thread_id: 'th-1' })
-    await vi.waitFor(() =>
-      expect(activity.editingTabPath).toBe('workflows/Unsaved Workflow.json')
-    )
-  })
-
-  it('a slow tab activation cannot finish after a newer focus event', async () => {
-    const tab = makeTab('wf-42')
-    mockMessagesEndpoint('wf-42')
-
-    let resolveSlowOpen: (() => void) | undefined
-    workflowService.openWorkflow.mockImplementationOnce(
-      async (slow: { path: string }) => {
-        await new Promise<void>((resolve) => {
-          resolveSlowOpen = resolve
-        })
-        const known = hostStores.workflow.tabs.get(slow.path)
-        if (known) hostStores.workflow.activeWorkflow = known
-      }
-    )
-
-    await renderAndSend('work here')
-
-    ws.emit('agent_active_tab', { workflow_id: 'wf-42', thread_id: 'th-1' })
-    await vi.waitFor(() => expect(resolveSlowOpen).toBeDefined())
-    ws.emit('agent_active_tab', {
-      workflow_id: 'wf-quick',
-      name: 'Quick tab',
-      thread_id: 'th-1'
-    })
-
-    await new Promise((resolve) => setTimeout(resolve))
-    expect(workflowService.openWorkflow).toHaveBeenCalledTimes(1)
-    expect(hostStores.workflow.tabs.get('workflows/Quick tab.json')).toBe(
-      undefined
-    )
-    resolveSlowOpen?.()
-    await vi.waitFor(() =>
-      expect(
-        hostStores.workflow.tabs.get('workflows/Quick tab.json')
-      ).toBeDefined()
-    )
-    await new Promise((resolve) => setTimeout(resolve))
-
-    expect(hostStores.workflow.activeWorkflow?.filename).toBe('Quick tab')
-    expect(tab).not.toBe(hostStores.workflow.activeWorkflow)
   })
 
   it('a stale agent_active_tab resolving late cannot steal focus from the newest', async () => {
@@ -2460,58 +1170,16 @@ describe('AgentPanelRoot workflow binding', () => {
         hostStores.workflow.tabs.get('workflows/Fast tab.json')
       ).toBeDefined()
     )
-    await new Promise((resolve) => setTimeout(resolve))
-
-    // The superseded activation closed its own minted tab and bound nothing.
-    expect(hostStores.workflow.tabs.get('workflows/Slow tab.json')).toBe(
-      undefined
-    )
-    expect(useAgentWorkflowTabBindingStore().tabPathFor('wf-slow')).toBe(
-      undefined
-    )
-    expect(useAgentWorkflowTabBindingStore().tabPathFor('wf-fast')).toBe(
-      'workflows/Fast tab.json'
-    )
-  })
-  it('an activation superseded before it starts does nothing at all', async () => {
-    mockMessagesEndpoint('wf-42')
-
-    await renderAndSend('work here')
-
-    ws.emit('agent_active_tab', {
-      workflow_id: 'wf-a',
-      name: 'A tab',
-      thread_id: 'th-1'
-    })
-    ws.emit('agent_active_tab', {
-      workflow_id: 'wf-b',
-      name: 'B tab',
-      thread_id: 'th-1'
-    })
-
-    await vi.waitFor(() =>
-      expect(hostStores.workflow.tabs.get('workflows/B tab.json')).toBeDefined()
-    )
-    await new Promise((resolve) => setTimeout(resolve))
-
-    expect(hostStores.workflow.tabs.get('workflows/A tab.json')).toBe(undefined)
-    expect(useAgentWorkflowTabBindingStore().tabPathFor('wf-b')).toBe(
-      'workflows/B tab.json'
-    )
-  })
-
-  it('reports only the bound tab in the snapshot when a second tab is unbound', async () => {
-    makeTab('wf-42')
-    addTab('workflows/scratch.json', {
-      activeState: { id: 'graph-internal-id-not-a-cloud-id' }
-    })
-    const bodies = mockMessagesEndpoint('wf-42')
-
-    await renderAndSend('first message')
-
-    expect(bodies[0]).toMatchObject({
-      open_tabs: [{ workflow_id: 'wf-42', name: 'current' }],
-      current_tab: 'wf-42'
+    await vi.waitFor(() => {
+      expect(hostStores.workflow.tabs.get('workflows/Slow tab.json')).toBe(
+        undefined
+      )
+      expect(useAgentWorkflowTabBindingStore().tabPathFor('wf-slow')).toBe(
+        undefined
+      )
+      expect(useAgentWorkflowTabBindingStore().tabPathFor('wf-fast')).toBe(
+        'workflows/Fast tab.json'
+      )
     })
   })
 
@@ -2557,188 +1225,6 @@ describe('AgentPanelRoot workflow binding', () => {
     expect(bodies[0]).toMatchObject({ workflow_id: 'wf-cloud-current' })
   })
 
-  it('does not resolve two same-named open saved tabs to one cloud id', async () => {
-    makeTab()
-    addTab('workflows/archive/current.json')
-    const bodies = mockMessagesEndpoint('wf-fresh', [
-      { id: 'wf-cloud-current', name: 'current' }
-    ])
-
-    await renderAndSend('first message')
-
-    expect(bodies[0]).not.toHaveProperty('workflow_id')
-    expect(bodies[0]).not.toHaveProperty('open_tabs')
-  })
-
-  it('excludes ambiguous and nameless cloud records from resolution', async () => {
-    makeTab()
-    const bodies = mockMessagesEndpoint('wf-fresh', [
-      { id: 'wf-a', name: 'current' },
-      { id: 'wf-b', name: 'current' },
-      { id: 'wf-nameless' } as { id: string; name: string }
-    ])
-
-    await renderAndSend('first message')
-
-    expect(bodies[0]).not.toHaveProperty('workflow_id')
-    expect(bodies[0]).not.toHaveProperty('open_tabs')
-  })
-
-  it('falls back to bindings when the cloud index request fails', async () => {
-    makeTab('wf-42')
-    const bodies: unknown[] = []
-    vi.stubGlobal(
-      'fetch',
-      vi.fn(async (url: string, init?: RequestInit) => {
-        if (url.includes('/messages') && init?.method === 'POST') {
-          bodies.push(JSON.parse(String(init?.body)))
-          return new Response(JSON.stringify(ack('wf-42', 'm-1')), {
-            status: 202,
-            headers: { 'Content-Type': 'application/json' }
-          })
-        }
-        if (url.includes('/workflows')) {
-          return json(500, { error: 'internal server error' })
-        }
-        return new Response('{}', { status: 200 })
-      })
-    )
-
-    await renderAndSend('first message')
-
-    expect(bodies[0]).toMatchObject({
-      workflow_id: 'wf-42',
-      open_tabs: [{ workflow_id: 'wf-42', name: 'current' }]
-    })
-  })
-
-  it('resolves saved tabs to their cloud workflow ids by name', async () => {
-    makeTab()
-    addTab('workflows/side.json')
-    const bodies = mockMessagesEndpoint('wf-cloud-current', [
-      { id: 'wf-cloud-current', name: 'current' },
-      { id: 'wf-cloud-side', name: 'side' }
-    ])
-
-    await renderAndSend('first message')
-
-    expect(bodies[0]).toMatchObject({
-      workflow_id: 'wf-cloud-current',
-      open_tabs: [
-        { workflow_id: 'wf-cloud-current', name: 'current' },
-        { workflow_id: 'wf-cloud-side', name: 'side' }
-      ],
-      current_tab: 'wf-cloud-current'
-    })
-  })
-
-  it('does not resolve temporary tabs through the cloud workflow index', async () => {
-    const tab = makeTab()
-    tab.isTemporary = true
-    const bodies = mockMessagesEndpoint('wf-fresh', [
-      { id: 'wf-cloud-current', name: 'current' }
-    ])
-
-    await renderAndSend('first message')
-
-    expect(bodies[0]).not.toHaveProperty('workflow_id')
-    expect(bodies[0]).not.toHaveProperty('open_tabs')
-  })
-
-  it('agent_active_tab with a cloud id activates the open saved tab without minting', async () => {
-    makeTab()
-    addTab('workflows/temp/duck.json', { isTemporary: true })
-    const duck = addTab('workflows/duck.json')
-    mockMessagesEndpoint('wf-cloud-current', [
-      { id: 'wf-cloud-current', name: 'current' },
-      { id: 'wf-cloud-duck', name: 'duck' }
-    ])
-
-    await renderAndSend('first message')
-
-    ws.emit('agent_active_tab', {
-      workflow_id: 'wf-cloud-duck',
-      thread_id: 'th-1'
-    })
-    await vi.waitFor(() =>
-      expect(workflowService.openWorkflow).toHaveBeenCalledWith(duck)
-    )
-    expect(hostStores.workflow.tabs.get('workflows/duck (2).json')).toBe(
-      undefined
-    )
-    // Resolving by cloud name has to leave the binding behind, or the transcript
-    // link renders nothing for the tab the user was just moved to.
-    expect(useAgentWorkflowTabBindingStore().tabPathFor('wf-cloud-duck')).toBe(
-      duck.path
-    )
-    expect(
-      await screen.findByRole('button', { name: 'Open duck' })
-    ).toBeInTheDocument()
-  })
-
-  it('sends every open tab that has a cloud id with the message', async () => {
-    makeTab('wf-42')
-    const bodies = mockMessagesEndpoint('wf-42')
-
-    await renderAndSend('first message')
-
-    expect(bodies[0]).toMatchObject({
-      open_tabs: [{ workflow_id: 'wf-42', name: 'current' }],
-      current_tab: 'wf-42'
-    })
-  })
-
-  it('includes a backgrounded tab whose binding was persisted before a reload', async () => {
-    localStorage.setItem(
-      'Comfy.Agent.WorkflowTabBindings',
-      JSON.stringify({ 'wf-old': 'workflows/mountain.json' })
-    )
-    makeTab('wf-42')
-    addTab('workflows/mountain.json')
-    const bodies = mockMessagesEndpoint('wf-42')
-
-    await renderAndSend('first message')
-
-    expect(bodies[0]).toMatchObject({
-      open_tabs: [
-        { workflow_id: 'wf-42', name: 'current' },
-        { workflow_id: 'wf-old', name: 'mountain' }
-      ],
-      current_tab: 'wf-42'
-    })
-  })
-
-  it('skips the draft on first send from an unbound empty tab', async () => {
-    makeTab()
-    const bodies = mockMessagesEndpoint('wf-42')
-
-    await renderAndSend('first message')
-
-    expect(bodies[0]).not.toHaveProperty('workflow_id')
-    expect(bodies[0]).not.toHaveProperty('draft')
-    expect(bodies[0]).not.toHaveProperty('open_tabs')
-    expect(bodies[0]).not.toHaveProperty('current_tab')
-  })
-
-  it('omits current_tab from the snapshot when the active tab has no cloud id', async () => {
-    makeTab('wf-42')
-    const bodies = mockMessagesEndpoint('wf-42')
-
-    await renderAndSend('first message')
-    ws.emit('agent_message_done', { message_id: 'm-1', thread_id: 'th-1' })
-    await screen.findByRole('button', { name: 'Send' })
-
-    const scratch = addTab('workflows/Scratch.json', { isTemporary: true })
-    hostStores.workflow.activeWorkflow = scratch
-
-    await sendFromComposer('second message')
-
-    expect(bodies[1]).toMatchObject({
-      open_tabs: [{ workflow_id: 'wf-42', name: 'current' }]
-    })
-    expect(bodies[1]).not.toHaveProperty('current_tab')
-  })
-
   it('stages a mention pick once and reports the tag gesture', async () => {
     makeTab('wf-42')
     mockMessagesEndpoint('wf-42')
@@ -2757,201 +1243,6 @@ describe('AgentPanelRoot workflow binding', () => {
     expect(telemetry.trackAgentNodeTagged).toHaveBeenCalledWith({
       source: 'mention_picker'
     })
-  })
-
-  it('inserts an ArrowDown + Tab mention as a chip and clears its token', async () => {
-    makeTab('wf-42')
-    const bodies = mockMessagesEndpoint('wf-42')
-    appMock.graph.nodes = [
-      { id: 5, title: 'KSampler' },
-      { id: 7, title: 'KSampler' }
-    ]
-
-    render(AgentPanelRoot, { global: { plugins: [i18n] } })
-
-    const textbox = screen.getByRole('textbox')
-    await userEvent.type(textbox, '@')
-    expect(screen.getByText('#5')).toBeInTheDocument()
-    expect(screen.getByText('#7')).toBeInTheDocument()
-    await userEvent.keyboard('{ArrowDown}{Tab}')
-
-    expect(textbox).toHaveValue('')
-    expect(screen.queryByRole('listbox')).not.toBeInTheDocument()
-    expect(screen.getAllByText('KSampler')).toHaveLength(1)
-    expect(screen.getByText('#7')).toBeInTheDocument()
-    await sendFromComposer('tune it')
-
-    expect(bodies[0]).toMatchObject({
-      content: 'tune it',
-      selection: { node_ids: ['7'] }
-    })
-  })
-
-  it('sends an existing @ asset reference without uploading it again', async () => {
-    makeTab('wf-42')
-    const bodies = mockMessagesEndpoint('wf-42')
-    vi.spyOn(assetService, 'getInputAssetsIncludingPublic').mockResolvedValue([
-      fromPartial({
-        id: 'asset-1',
-        name: 'sunset-original.png',
-        hash: 'sunset-hash.png',
-        tags: ['input'],
-        display_name: 'Sunset.png',
-        preview_url: '/api/assets/asset-1/content'
-      })
-    ])
-
-    render(AgentPanelRoot, { global: { plugins: [i18n] } })
-    const textbox = screen.getByRole('textbox')
-    await userEvent.type(textbox, '@sun')
-    await userEvent.click(
-      await screen.findByRole('option', { name: 'Sunset.png' })
-    )
-
-    expect(textbox).toHaveValue('')
-    expect(screen.getByText('Sunset.png')).toBeInTheDocument()
-    await sendFromComposer('use this asset')
-
-    expect(bodies[0]).toMatchObject({
-      content: 'use this asset',
-      attachments: ['sunset-hash.png']
-    })
-    expect(
-      vi
-        .mocked(fetch)
-        .mock.calls.some(([url]) => String(url).includes('/upload/'))
-    ).toBe(false)
-  })
-
-  it('sends no workflow id for an unbound tab and posts exactly once', async () => {
-    const tab = makeTab()
-    tab.activeState = { id: 'graph-internal-id-not-a-cloud-id' }
-    appMock.graph.nodes = [{ id: 1 }]
-    const bodies: unknown[] = []
-    vi.stubGlobal(
-      'fetch',
-      vi.fn(async (url: string, init?: RequestInit) => {
-        if (!url.includes('/messages'))
-          return new Response('{}', { status: 200 })
-        const body = JSON.parse(String(init?.body)) as Record<string, unknown>
-        bodies.push(body)
-        if (body.workflow_id !== undefined) {
-          return json(403, { error: 'workflow not found or access denied' })
-        }
-        return new Response(JSON.stringify(ack('wf-fresh', 'm-1')), {
-          status: 202,
-          headers: { 'Content-Type': 'application/json' }
-        })
-      })
-    )
-
-    await renderAndSend('build a graph')
-
-    expect(bodies).toHaveLength(1)
-    expect(bodies[0]).not.toHaveProperty('workflow_id')
-    expect(bodies[0]).not.toHaveProperty('open_tabs')
-    expect(bodies[0]).not.toHaveProperty('current_tab')
-    expect(app.loadGraphData).not.toHaveBeenCalled()
-  })
-
-  it('sends only the remaining chip after one is dismissed', async () => {
-    makeTab()
-    const bodies = mockMessagesEndpoint('wf-42')
-    appMock.graph.nodes = [
-      { id: 5, title: 'KSampler' },
-      { id: 7, title: 'VAEDecode' }
-    ]
-
-    render(AgentPanelRoot, { global: { plugins: [i18n] } })
-    useAgentPanelStore().isOpen = true
-
-    await openMentionPicker()
-    await userEvent.click(await screen.findByText('KSampler'))
-    await openMentionPicker()
-    await userEvent.click(await screen.findByText('VAEDecode'))
-    expect(await screen.findByText('KSampler')).toBeInTheDocument()
-    expect(screen.getByText('VAEDecode')).toBeInTheDocument()
-
-    await userEvent.click(
-      screen.getByRole('button', { name: 'Remove KSampler #5 reference' })
-    )
-    expect(screen.queryByText('KSampler')).not.toBeInTheDocument()
-
-    await sendFromComposer('decode it')
-
-    expect(bodies[0]).toMatchObject({ selection: { node_ids: ['7'] } })
-    expect(telemetry.trackAgentMessageSent).toHaveBeenCalledWith({
-      attachment_count: 0,
-      node_tag_count: 1
-    })
-    expect(screen.getByText('VAEDecode #7')).toBeInTheDocument()
-    expect(screen.queryByText(/KSampler/)).not.toBeInTheDocument()
-  })
-
-  it('deselects the graph node when its reference chip is removed', async () => {
-    makeTab()
-    const state = setupNodeSelectionCanvas()
-
-    render(AgentPanelRoot, { global: { plugins: [i18n] } })
-    useAgentPanelStore().isOpen = true
-
-    await openMentionPicker()
-    await userEvent.click(await screen.findByText('VAE Decode'))
-    await openMentionPicker()
-    const matches = await screen.findAllByText('KSampler')
-    await userEvent.click(matches[matches.length - 1])
-
-    expect(await screen.findByText('VAE Decode')).toBeInTheDocument()
-    expect(screen.getByText('KSampler')).toBeInTheDocument()
-
-    await userEvent.click(
-      screen.getByRole('button', { name: 'Remove VAE Decode #9 reference' })
-    )
-
-    expect(screen.queryByText('VAE Decode')).not.toBeInTheDocument()
-    expect(state.deselect).toHaveBeenCalledWith(state.nodes[0])
-    expect(focusNodeInstance).not.toHaveBeenCalled()
-    expect([...state.selectedItems]).toEqual([state.nodes[1]])
-    expect(hostStores.canvas.selectedItems).toEqual([state.nodes[1]])
-  })
-
-  it('focuses the graph node when its reference chip is activated', async () => {
-    makeTab()
-    const state = setupNodeSelectionCanvas()
-
-    render(AgentPanelRoot, { global: { plugins: [i18n] } })
-    useAgentPanelStore().isOpen = true
-
-    await openMentionPicker()
-    await userEvent.click(await screen.findByText('KSampler'))
-    await userEvent.click(
-      screen.getByRole('button', { name: 'Show KSampler #12 on canvas' })
-    )
-
-    expect(focusNodeInstance).toHaveBeenCalledWith(state.nodes[1])
-    expect(screen.getByText('KSampler')).toBeInTheDocument()
-  })
-
-  it('focuses a retained subgraph node after navigating to the root graph', async () => {
-    makeTab()
-    const state = setupNodeSelectionCanvas()
-    nestSelectionCanvasInSubgraph(state)
-
-    render(AgentPanelRoot, { global: { plugins: [i18n] } })
-    useAgentPanelStore().isOpen = true
-
-    await openMentionPicker()
-    await userEvent.click(await screen.findByText('KSampler'))
-
-    showRootGraph(state)
-    await nextTick()
-
-    await userEvent.click(
-      screen.getByRole('button', { name: 'Show KSampler #12 on canvas' })
-    )
-
-    expect(focusNodeInstance).toHaveBeenCalledWith(state.nodes[1])
-    expect(screen.getByText('KSampler')).toBeInTheDocument()
   })
 
   it('uses graph-scoped identity for focus, removal, and picker exclusion', async () => {
@@ -3001,337 +1292,6 @@ describe('AgentPanelRoot workflow binding', () => {
     expect([...state.selectedItems]).toEqual([rootTwin])
   })
 
-  it('excludes referenced nodes from the mention picker', async () => {
-    makeTab()
-    setupNodeSelectionCanvas()
-
-    render(AgentPanelRoot, { global: { plugins: [i18n] } })
-    useAgentPanelStore().isOpen = true
-
-    await openMentionPicker()
-    await userEvent.click(await screen.findByText('KSampler'))
-    await openMentionPicker()
-
-    const listbox = screen.getByRole('listbox')
-    expect(within(listbox).queryByText('KSampler')).not.toBeInTheDocument()
-    expect(within(listbox).getByText('VAE Decode')).toBeInTheDocument()
-  })
-
-  it('keeps reference chips unchanged after normal graph selection', async () => {
-    makeTab()
-    mockMessagesEndpoint('wf-42')
-    const state = setupNodeSelectionCanvas()
-
-    render(AgentPanelRoot, { global: { plugins: [i18n] } })
-    useAgentPanelStore().isOpen = true
-
-    await openMentionPicker()
-    await userEvent.click(await screen.findByText('KSampler'))
-    expect(await screen.findByText('KSampler')).toBeInTheDocument()
-
-    state.selectedItems.clear()
-    state.selectedItems.add(state.nodes[0])
-    hostStores.canvas.updateSelectedItems()
-    await nextTick()
-
-    expect(screen.getByText('KSampler')).toBeInTheDocument()
-    expect(screen.queryByText('VAE Decode')).not.toBeInTheDocument()
-  })
-
-  it('merges referenced nodes with the existing graph selection when node-selection mode starts', async () => {
-    makeTab()
-    mockMessagesEndpoint('wf-42')
-    const state = setupNodeSelectionCanvas()
-
-    render(AgentPanelRoot, { global: { plugins: [i18n] } })
-    useAgentPanelStore().isOpen = true
-
-    await openMentionPicker()
-    await userEvent.click(await screen.findByText('KSampler'))
-    state.selectedItems.clear()
-    state.selectedItems.add(state.nodes[0])
-    hostStores.canvas.updateSelectedItems()
-    state.selectItems.mockClear()
-
-    await enterNodeSelectionMode()
-
-    expect(state.selectItems).toHaveBeenCalledWith([
-      state.nodes[0],
-      state.nodes[1]
-    ])
-    expect([...state.selectedItems]).toEqual([state.nodes[0], state.nodes[1]])
-    expect(await screen.findByText('VAE Decode')).toBeInTheDocument()
-    expect(screen.getByText('KSampler')).toBeInTheDocument()
-  })
-
-  it('merges an off-view subgraph reference with the current root selection', async () => {
-    makeTab()
-    mockMessagesEndpoint('wf-42')
-    const state = setupNodeSelectionCanvas()
-    const subgraphNode = nestSelectionCanvasInSubgraph(state)
-    state.nodes[1].id = 'shared'
-
-    render(AgentPanelRoot, { global: { plugins: [i18n] } })
-    useAgentPanelStore().isOpen = true
-
-    await openMentionPicker()
-    await userEvent.click(await screen.findByText('KSampler'))
-
-    const rootNode: SelectionTestNode = {
-      isNodeFake: true,
-      id: 'shared',
-      title: 'Root node',
-      boundingRect: {}
-    }
-    appMock.graph.nodes = [subgraphNode, rootNode]
-    showRootGraph(state, [rootNode])
-    state.selectedItems.clear()
-    state.selectedItems.add(rootNode)
-    hostStores.canvas.updateSelectedItems()
-    state.selectItems.mockClear()
-    await nextTick()
-
-    await enterNodeSelectionMode()
-
-    expect(state.selectItems).toHaveBeenCalledWith([rootNode, state.nodes[1]])
-    expect([...state.selectedItems]).toEqual([rootNode, state.nodes[1]])
-    expect(screen.getByText('Root node')).toBeInTheDocument()
-    expect(screen.getByText('KSampler')).toBeInTheDocument()
-  })
-
-  it('restores an off-view subgraph reference by locator after a panel remount', async () => {
-    makeTab()
-    const state = setupNodeSelectionCanvas()
-    const subgraphNode = nestSelectionCanvasInSubgraph(state)
-    const referencedNode = state.nodes[1]
-    referencedNode.id = 'shared'
-    referencedNode.title = 'Subgraph twin'
-    const rootTwin: SelectionTestNode = {
-      isNodeFake: true,
-      id: 'shared',
-      title: 'Root twin',
-      boundingRect: {}
-    }
-    appMock.graph.nodes = [subgraphNode, rootTwin]
-    const panelStore = useAgentPanelStore()
-
-    const first = render(AgentPanelRoot, { global: { plugins: [i18n] } })
-    panelStore.isOpen = true
-    await openMentionPicker()
-    await userEvent.click(await screen.findByText('Subgraph twin'))
-
-    showRootGraph(state, [rootTwin])
-    panelStore.isOpen = false
-    await nextTick()
-    first.unmount()
-
-    render(AgentPanelRoot, { global: { plugins: [i18n] } })
-    panelStore.isOpen = true
-    await nextTick()
-
-    expect(screen.getByText('Subgraph twin')).toBeInTheDocument()
-    expect(screen.queryByText('Root twin')).not.toBeInTheDocument()
-    await userEvent.click(
-      screen.getByRole('button', {
-        name: 'Show Subgraph twin #shared on canvas'
-      })
-    )
-    expect(focusNodeInstance).toHaveBeenCalledWith(referencedNode)
-  })
-  it('does not resend a canvas selection after its chip was consumed', async () => {
-    makeTab()
-    const bodies = mockMessagesEndpoint('wf-42')
-    const state = setupNodeSelectionCanvas()
-
-    render(AgentPanelRoot, { global: { plugins: [i18n] } })
-    useAgentPanelStore().isOpen = true
-
-    await openMentionPicker()
-    await userEvent.click(await screen.findByText('KSampler'))
-    expect(await screen.findByText('KSampler')).toBeInTheDocument()
-
-    await sendFromComposer('first ask')
-    expect(bodies[0]).toMatchObject({ selection: { node_ids: ['12'] } })
-
-    ws.emit('agent_message_done', { message_id: 'm-1', thread_id: 'th-1' })
-    await screen.findByRole('button', { name: 'Send' })
-
-    expect([...state.selectedItems]).toEqual([state.nodes[1]])
-    await sendFromComposer('second ask')
-    expect(bodies[1]).not.toHaveProperty('selection')
-  })
-
-  it('keeps normal graph selections out of the composer across a panel remount', async () => {
-    makeTab()
-    const bodies = mockMessagesEndpoint('wf-42')
-    appMock.graph.nodes = [{ id: 7, title: 'KSampler' }]
-
-    const panelStore = useAgentPanelStore()
-    const first = render(AgentPanelRoot, { global: { plugins: [i18n] } })
-    panelStore.isOpen = true
-
-    await openMentionPicker()
-    await userEvent.click(await screen.findByText('KSampler'))
-    expect(await screen.findByText('KSampler')).toBeInTheDocument()
-
-    await userEvent.click(
-      screen.getByRole('button', { name: 'Remove KSampler #7 reference' })
-    )
-    panelStore.isOpen = false
-    await nextTick()
-    first.unmount()
-
-    render(AgentPanelRoot, { global: { plugins: [i18n] } })
-    panelStore.isOpen = true
-    await nextTick()
-    expect(screen.queryByText('KSampler')).not.toBeInTheDocument()
-    await sendFromComposer('no nodes please')
-
-    expect(bodies[0]).not.toHaveProperty('selection')
-
-    ws.emit('agent_message_done', { message_id: 'm-1', thread_id: 'th-1' })
-    await screen.findByRole('button', { name: 'Send' })
-    hostStores.canvas.selectedItems = [
-      { isNodeFake: true, id: 7, title: 'KSampler' }
-    ]
-    await nextTick()
-    expect(screen.queryByText('KSampler')).not.toBeInTheDocument()
-    await sendFromComposer('still no nodes')
-    expect(bodies[1]).not.toHaveProperty('selection')
-
-    ws.emit('agent_message_done', { message_id: 'm-2', thread_id: 'th-1' })
-    await screen.findByRole('button', { name: 'Send' })
-    hostStores.canvas.selectedItems = [
-      { isNodeFake: true, id: 8, title: 'VAEDecode' }
-    ]
-    await nextTick()
-    expect(screen.queryByText('VAEDecode')).not.toBeInTheDocument()
-    await sendFromComposer('use the new selection')
-    expect(bodies[2]).not.toHaveProperty('selection')
-  })
-
-  it('stages the same node id in another unsaved workflow after a panel remount', async () => {
-    hostStores.workflow.activeWorkflow = addTab(
-      'workflows/Unsaved Workflow.json',
-      { isTemporary: true }
-    )
-    const bodies = mockMessagesEndpoint('wf-42')
-    const panelStore = useAgentPanelStore()
-    appMock.graph.nodes = [{ id: 7, title: 'First KSampler' }]
-    const first = render(AgentPanelRoot, { global: { plugins: [i18n] } })
-    panelStore.isOpen = true
-
-    await openMentionPicker()
-    await userEvent.click(await screen.findByText('First KSampler'))
-    expect(await screen.findByText('First KSampler')).toBeInTheDocument()
-    await userEvent.click(
-      screen.getByRole('button', {
-        name: 'Remove First KSampler #7 reference'
-      })
-    )
-    panelStore.isOpen = false
-    await nextTick()
-    first.unmount()
-
-    hostStores.workflow.activeWorkflow = addTab(
-      'workflows/Unsaved Workflow (2).json',
-      { isTemporary: true }
-    )
-    appMock.graph.nodes = [{ id: 7, title: 'Second KSampler' }]
-    render(AgentPanelRoot, { global: { plugins: [i18n] } })
-    panelStore.isOpen = true
-
-    await openMentionPicker()
-    await userEvent.click(await screen.findByText('Second KSampler'))
-    await sendFromComposer('use this workflow')
-    expect(bodies[0]).toMatchObject({ selection: { node_ids: ['7'] } })
-  })
-
-  it('keeps modifier-free legacy LiteGraph clicks selected', async () => {
-    makeTab()
-    mockMessagesEndpoint('wf-42')
-    const state = setupNodeSelectionCanvas()
-    const selectLegacyNode = (node: SelectionTestNode) => {
-      if (!state.canvas.multi_select) state.selectedItems.clear()
-      state.selectedItems.add(node)
-      hostStores.canvas.updateSelectedItems()
-    }
-    render(AgentPanelRoot, { global: { plugins: [i18n] } })
-    renderCanvasNodeButtons(state.nodes, selectLegacyNode)
-    useAgentPanelStore().isOpen = true
-
-    await enterNodeSelectionMode()
-    const buttons = state.nodes.map((node) =>
-      screen.getByRole('button', { name: `Canvas ${node.title}` })
-    )
-    await userEvent.click(buttons[0])
-    await userEvent.click(buttons[1])
-
-    expect(await screen.findByText('VAE Decode')).toBeInTheDocument()
-    expect(screen.getByText('KSampler')).toBeInTheDocument()
-    expect([...state.selectedItems]).toEqual(state.nodes)
-    expect(state.selectItems).not.toHaveBeenCalled()
-  })
-
-  it('does not restore a deselected node after selecting another node', async () => {
-    makeTab()
-    mockMessagesEndpoint('wf-42')
-    const state = setupNodeSelectionCanvas()
-    const thirdNode: SelectionTestNode = {
-      isNodeFake: true,
-      id: 15,
-      title: 'Save Image',
-      boundingRect: {}
-    }
-    state.nodes.push(thirdNode)
-    const toggleNode = (node: SelectionTestNode) => {
-      if (state.selectedItems.has(node)) state.selectedItems.delete(node)
-      else state.selectedItems.add(node)
-      hostStores.canvas.updateSelectedItems()
-    }
-    render(AgentPanelRoot, { global: { plugins: [i18n] } })
-    renderCanvasNodeButtons(state.nodes, toggleNode)
-    useAgentPanelStore().isOpen = true
-
-    await enterNodeSelectionMode()
-    const buttons = state.nodes.map((node) =>
-      screen.getByRole('button', { name: `Canvas ${node.title}` })
-    )
-    await userEvent.click(buttons[0])
-    await userEvent.click(buttons[1])
-    await userEvent.click(buttons[0])
-    await userEvent.click(buttons[2])
-
-    expect([...state.selectedItems]).toEqual([state.nodes[1], thirdNode])
-    expect(screen.queryByText('VAE Decode')).not.toBeInTheDocument()
-    expect(screen.getByText('KSampler')).toBeInTheDocument()
-    expect(screen.getByText('Save Image')).toBeInTheDocument()
-    expect(state.selectItems).not.toHaveBeenCalled()
-  })
-
-  it('uses rectangle replacement as the active composer selection', async () => {
-    makeTab()
-    mockMessagesEndpoint('wf-42')
-    const state = setupNodeSelectionCanvas()
-    render(AgentPanelRoot, { global: { plugins: [i18n] } })
-    useAgentPanelStore().isOpen = true
-
-    await enterNodeSelectionMode()
-    state.selectedItems.add(state.nodes[0])
-    hostStores.canvas.updateSelectedItems()
-    state.selectItems.mockClear()
-
-    state.selectedItems.clear()
-    state.selectedItems.add(state.nodes[1])
-    hostStores.canvas.updateSelectedItems()
-    await nextTick()
-
-    expect([...state.selectedItems]).toEqual([state.nodes[1]])
-    expect(screen.queryByText('VAE Decode')).not.toBeInTheDocument()
-    expect(screen.getByText('KSampler')).toBeInTheDocument()
-    expect(state.selectItems).not.toHaveBeenCalled()
-  })
-
   it('keeps additive Vue-node selections and sends every node id', async () => {
     makeTab()
     const bodies = mockMessagesEndpoint('wf-42')
@@ -3354,132 +1314,5 @@ describe('AgentPanelRoot workflow binding', () => {
       selection: { node_ids: ['9', '12'] }
     })
     await expectLaterClickCannotRestoreAccumulatedNodes(selection)
-  })
-
-  it('exits selection mode on Escape and keeps the selected-node chips', async () => {
-    makeTab()
-    mockMessagesEndpoint('wf-42')
-    const selection = await startVueNodeSelection()
-
-    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
-    await nextTick()
-
-    expect(useAgentNodeSelectionStore().isActive).toBe(false)
-    expect(selection.canvas.multi_select).toBe(false)
-    expect(selection.canvas.allow_dragnodes).toBe(true)
-    expect(selection.canvas.selectOnly).toBe(false)
-    expect(selection.deselectAll).toHaveBeenCalledOnce()
-    expect([...selection.selectedItems]).toEqual([])
-    expect(screen.getByText('VAE Decode')).toBeInTheDocument()
-    expect(screen.getByText('KSampler')).toBeInTheDocument()
-  })
-
-  it('ends node selection when the viewed graph changes', async () => {
-    makeTab()
-    mockMessagesEndpoint('wf-42')
-    const selection = await startVueNodeSelection()
-    const nextGraph = {
-      nodes: [] as SelectionTestNode[],
-      getNodeById: () => null
-    }
-
-    selection.canvas.graph = nextGraph
-    hostStores.canvas.currentGraph = nextGraph
-    await nextTick()
-
-    expect(selection.canvas.multi_select).toBe(false)
-    await expectLaterClickCannotRestoreAccumulatedNodes(selection)
-  })
-
-  it('keeps each workflow node selection separate after a graph load', async () => {
-    makeTab()
-    const selection = await startVueNodeSelection()
-    const secondNode = {
-      isNodeFake: true as const,
-      id: 20,
-      title: 'Save Image',
-      boundingRect: {}
-    }
-    const secondGraph = {
-      nodes: [secondNode],
-      getNodeById: (id: string | number) =>
-        String(id) === '20' ? secondNode : null
-    }
-    const nodeSelectionStore = useAgentNodeSelectionStore()
-
-    nodeSelectionStore.beginWorkflowLoad()
-    nodeSelectionStore.restoreNodeIds(['20'])
-    selection.canvas.graph = secondGraph
-    selection.selectedItems.clear()
-    selection.selectedItems.add(secondNode)
-    hostStores.canvas.currentGraph = secondGraph
-    hostStores.canvas.updateSelectedItems()
-    await nextTick()
-
-    expect(nodeSelectionStore.isLoadingWorkflow).toBe(false)
-    expect([...selection.selectedItems]).toEqual([secondNode])
-    expect(screen.getByText('Save Image')).toBeInTheDocument()
-    expect(screen.queryByText('VAE Decode')).not.toBeInTheDocument()
-  })
-
-  it('finishes a workflow restore completed before the panel mounts', async () => {
-    makeTab()
-    const state = setupNodeSelectionCanvas()
-    const nodeSelectionStore = useAgentNodeSelectionStore()
-    nodeSelectionStore.beginWorkflowLoad()
-    nodeSelectionStore.restoreNodeIds(['9'])
-    state.selectedItems.add(state.nodes[0])
-    hostStores.canvas.updateSelectedItems()
-    useAgentPanelStore().isOpen = true
-
-    render(AgentPanelRoot, { global: { plugins: [i18n] } })
-    await nextTick()
-
-    expect(nodeSelectionStore.isLoadingWorkflow).toBe(false)
-    expect(screen.getByText('VAE Decode')).toBeInTheDocument()
-  })
-
-  it('resolves picker nodes from the viewed subgraph, not the root graph', async () => {
-    makeTab()
-    const bodies = mockMessagesEndpoint('wf-42')
-    appMock.canvas = {
-      graph: {
-        nodes: [{ id: 12, title: 'KSampler' }],
-        getNodeById: () => null
-      },
-      selectedItems: new Set(),
-      selectItems: vi.fn(),
-      deselect: vi.fn(),
-      multi_select: false,
-      allow_dragnodes: true,
-      selectOnly: false,
-      canvas: { focus: vi.fn() }
-    }
-
-    render(AgentPanelRoot, { global: { plugins: [i18n] } })
-    useAgentPanelStore().isOpen = true
-
-    await openMentionPicker()
-    await userEvent.click(await screen.findByText('KSampler'))
-    await sendFromComposer('explain this')
-
-    expect(bodies[0]).toMatchObject({ selection: { node_ids: ['12'] } })
-  })
-
-  it('never subscribes to the retired draft_patch frame', async () => {
-    makeTab('wf-42')
-    mockMessagesEndpoint('wf-42')
-
-    await renderAndSend('help me')
-
-    ws.emit('draft_patch', {
-      workflow_id: 'wf-42',
-      base_version: 0,
-      version: 1,
-      content: { version: 0.4, nodes: [] }
-    })
-    await nextTick()
-    await nextTick()
-    expect(app.loadGraphData).not.toHaveBeenCalled()
   })
 })

--- a/src/workbench/extensions/agent/AgentPanelRoot.vue
+++ b/src/workbench/extensions/agent/AgentPanelRoot.vue
@@ -565,7 +565,13 @@ async function onSelectHistory(id: string): Promise<void> {
 }
 
 function onCopyMarkdown(id: string): void {
-  if (id === history.activeId) void copy(buildTranscriptMarkdown(entries.value))
+  if (id === history.activeId)
+    void copy(
+      buildTranscriptMarkdown(entries.value, {
+        user: t('agent.transcriptUser'),
+        assistant: t('agent.transcriptAssistant')
+      })
+    )
   else toast.add({ severity: 'info', summary: t('agent.copyUnavailable') })
 }
 

--- a/src/workbench/extensions/agent/AgentPanelRoot.vue
+++ b/src/workbench/extensions/agent/AgentPanelRoot.vue
@@ -26,11 +26,7 @@ import type { LGraphCanvas, LGraphNode } from '@/lib/litegraph/src/litegraph'
 import { useAppMode } from '@/composables/useAppMode'
 import { MIME_ASSET_INFO } from '@/platform/assets/schemas/mediaAssetSchema'
 import { assetService } from '@/platform/assets/services/assetService'
-import {
-  fetchDroppedAsset,
-  getDroppedAsset,
-  hasVideoType
-} from '@/utils/eventUtils'
+import { fetchDroppedAsset, getDroppedAsset } from '@/utils/eventUtils'
 import { useAssetsStore } from '@/stores/assetsStore'
 import { AGENT_ATTACH_ACCEPT, isAgentAttachable } from './utils/attachableFiles'
 import { getNodeByLocatorId } from '@/utils/graphTraversalUtil'
@@ -57,9 +53,16 @@ import { toOwningGraphId, toRootGraphId } from '@/types/graphScopeId'
 import AgentPanel from './components/agent/AgentPanel.vue'
 import OnboardingCoach from './components/agent/OnboardingCoach.vue'
 import {
+  agentAttachmentMaxBytes,
   MAX_ATTACHMENT_BYTES,
   useAttachment
 } from './composables/agent/useAttachment'
+import {
+  agentTabFilename,
+  buildOpenTabsSnapshot,
+  uniqueCloudWorkflowIdsByName,
+  workflowIdForTab
+} from './utils/agentWorkflowTabs'
 import type { ActiveTab } from './types/activeTab'
 import type { SelectedNode } from './composables/agent/useCanvasSelection'
 import {
@@ -68,19 +71,18 @@ import {
 } from './composables/agent/useCanvasSelection'
 import type { CoachStep } from './composables/agent/useOnboarding'
 import type { ComposerAttachment } from './composables/agent/useComposer'
-import type {
-  AgentActiveTabData,
-  AgentThreadSummary
-} from './schemas/agentApiSchema'
-import type { ChatSession } from './stores/agent/agentChatHistoryStore'
-import type { ConversationEntry } from './stores/agent/agentConversationStore'
+import type { AgentActiveTabData } from './schemas/agentApiSchema'
 import type { WorkflowTurnContext } from './composables/agent/useAgentSession'
 import { useAgentSession } from './composables/agent/useAgentSession'
 import { useAgentWorkflowTabBindingStore } from './stores/agent/agentWorkflowTabBindingStore'
 import { createAgentRestClient } from './services/agent/agentRestClient'
 import type { OpenTabsSnapshot } from './services/agent/agentRestClient'
 import { createAgentEventSource } from './services/agent/agentEventSource'
-import { useAgentChatHistoryStore } from './stores/agent/agentChatHistoryStore'
+import { buildTranscriptMarkdown } from './services/agent/agentTranscript'
+import {
+  chatSessionFromThread,
+  useAgentChatHistoryStore
+} from './stores/agent/agentChatHistoryStore'
 import { useAgentPanelStore } from './stores/agent/agentPanelStore'
 import CrdtDevPanel from './crdt/CrdtDevPanel.vue'
 import { attachMintPortWiring } from './crdt/mintPortWiring'
@@ -241,18 +243,8 @@ let cloudIdsByName = new Map<string, string>()
 
 async function refreshCloudWorkflowIds(): Promise<void> {
   try {
-    const workflows = await rest.listCloudWorkflows()
-    const nameCounts = new Map<string, number>()
-    for (const { name } of workflows) {
-      if (name !== undefined)
-        nameCounts.set(name, (nameCounts.get(name) ?? 0) + 1)
-    }
-    cloudIdsByName = new Map(
-      workflows.flatMap(({ id, name }) =>
-        name !== undefined && nameCounts.get(name) === 1
-          ? [[name, id] as const]
-          : []
-      )
+    cloudIdsByName = uniqueCloudWorkflowIdsByName(
+      await rest.listCloudWorkflows()
     )
   } catch (error) {
     reportError(error, {
@@ -268,11 +260,12 @@ function openSavedTabsNamed(filename: string): ComfyWorkflow[] {
 }
 
 function cloudIdFor(tab: ComfyWorkflow): string | undefined {
-  const saved =
-    !tab.isTemporary && openSavedTabsNamed(tab.filename).length === 1
-      ? cloudIdsByName.get(tab.filename)
-      : undefined
-  return saved ?? bindingStore.workflowIdFor(tab.path)
+  return workflowIdForTab({
+    tab,
+    openTabs: workflowStore.openWorkflows,
+    cloudIdsByName,
+    boundWorkflowId: bindingStore.workflowIdFor(tab.path)
+  })
 }
 
 const workflowDetached = ref(false)
@@ -317,19 +310,12 @@ function onClearWorkflow(): void {
 }
 
 function openTabsSnapshot(): OpenTabsSnapshot | undefined {
-  const openTabs = workflowStore.openWorkflows.flatMap((tab) => {
-    const workflowId = cloudIdFor(tab)
-    return workflowId === undefined
-      ? []
-      : [{ workflow_id: workflowId, name: tab.filename }]
+  return buildOpenTabsSnapshot({
+    openTabs: workflowStore.openWorkflows,
+    activeTab: workflowStore.activeWorkflow,
+    detached: workflowDetached.value,
+    workflowIdFor: cloudIdFor
   })
-  if (openTabs.length === 0) return undefined
-  const active = workflowStore.activeWorkflow
-  return {
-    open_tabs: openTabs,
-    current_tab:
-      active && !workflowDetached.value ? cloudIdFor(active) : undefined
-  }
 }
 
 function onWorkflowAdopted(
@@ -470,21 +456,6 @@ function enqueueActiveTab(data: AgentActiveTabData): void {
   activeTabChain = activeTabChain.then(() => onAgentActiveTab(data, generation))
 }
 
-function agentTabFilename(name: string | undefined): string | undefined {
-  const cleaned = [
-    ...(name ?? '')
-      .replace(/[/\\\p{Cc}]/gu, '-')
-      .replace(/\.json$/i, '')
-      .trim()
-      .replace(/^\.+/, '')
-  ]
-    .slice(0, 80)
-    .join('')
-    .replace(/^[\s.]+/u, '')
-    .trim()
-  return cleaned.length === 0 ? undefined : `${cleaned}.json`
-}
-
 async function onAgentActiveTab(
   data: AgentActiveTabData,
   generation: number
@@ -567,19 +538,13 @@ function onFeedback(turnId: string, vote: 'up' | 'down' | null): void {
   })
 }
 
-function toChatSession(thread: AgentThreadSummary): ChatSession {
-  const stamp = thread.last_message_at ?? thread.updated_at ?? thread.created_at
-  const updatedAt = stamp ? Date.parse(stamp) : Date.now()
-  return {
-    id: thread.id,
-    title: thread.title || thread.preview || t('agent.untitledChat'),
-    updatedAt: Number.isNaN(updatedAt) ? Date.now() : updatedAt
-  }
-}
-
 async function refreshHistory(): Promise<void> {
   try {
-    history.replaceAll((await listThreads()).map(toChatSession))
+    history.replaceAll(
+      (await listThreads()).map((thread) =>
+        chatSessionFromThread(thread, t('agent.untitledChat'))
+      )
+    )
   } catch (error) {
     surfaceAgentError(
       'agent_api_failed',
@@ -597,19 +562,6 @@ async function onSelectHistory(id: string): Promise<void> {
   workflowDetached.value = false
   await loadThread(id)
   void refreshHistory()
-}
-
-function buildTranscriptMarkdown(entries: ConversationEntry[]): string {
-  return entries
-    .map((entry) => {
-      if (entry.role === 'user') return `**You:** ${entry.text}`
-      const text = entry.parts
-        .filter((part) => part.type === 'text')
-        .map((part) => part.text)
-        .join('')
-      return `**Agent:** ${text}`
-    })
-    .join('\n\n')
 }
 
 function onCopyMarkdown(id: string): void {
@@ -786,9 +738,7 @@ const attachment = useAttachment({
       'max_upload_size',
       MAX_ATTACHMENT_BYTES
     )
-    return hasVideoType(file)
-      ? serverLimit
-      : Math.min(MAX_ATTACHMENT_BYTES, serverLimit)
+    return agentAttachmentMaxBytes(file, serverLimit)
   },
   // A rejected file is the user's problem to fix, not an agent failure, so it
   // must not raise the server-error overlay.

--- a/src/workbench/extensions/agent/components/agent/AgentPanel.test.ts
+++ b/src/workbench/extensions/agent/components/agent/AgentPanel.test.ts
@@ -1,6 +1,7 @@
+import { createTestingPinia } from '@pinia/testing'
 import { render, screen, within } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
-import { createPinia, setActivePinia } from 'pinia'
+import { setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it } from 'vitest'
 
 import { i18n } from '@/i18n'
@@ -18,6 +19,25 @@ const historyGroups = {
 function mount(isMaximized = false) {
   return render(AgentPanel, {
     props: { entries: [], historyGroups, isMaximized },
+    global: {
+      plugins: [i18n],
+      stubs: {
+        Composer: true,
+        EmptyState: true,
+        PanelHeader: true
+      }
+    }
+  })
+}
+
+function mountChat() {
+  return render(AgentPanel, {
+    props: {
+      entries: [],
+      historyGroups,
+      sessionId: 'thread-1',
+      customTitle: 'Duck pipeline'
+    },
     global: {
       plugins: [i18n],
       stubs: {
@@ -97,9 +117,79 @@ describe('AgentPanel', () => {
     expect(titleGroup).not.toContainElement(historyButton)
   })
 
+  it('renames the current chat on Enter and blur', async () => {
+    const user = userEvent.setup()
+    const { emitted } = mountChat()
+
+    await user.click(screen.getByRole('button', { name: 'Duck pipeline' }))
+    const input = screen.getByRole('textbox', {
+      name: i18n.global.t('g.rename')
+    })
+    expect(input).toHaveFocus()
+    await user.clear(input)
+    await user.type(input, 'First rename{Enter}')
+
+    await user.click(screen.getByRole('button', { name: 'Duck pipeline' }))
+    const nextInput = screen.getByRole('textbox', {
+      name: i18n.global.t('g.rename')
+    })
+    await user.clear(nextInput)
+    await user.type(nextInput, 'Blur rename')
+    nextInput.blur()
+
+    expect(emitted().renameChat).toEqual([['First rename'], ['Blur rename']])
+  })
+
+  it('abandons a current-chat rename on Escape', async () => {
+    const user = userEvent.setup()
+    const { emitted } = mountChat()
+
+    await user.click(screen.getByRole('button', { name: 'Duck pipeline' }))
+    const input = screen.getByRole('textbox', {
+      name: i18n.global.t('g.rename')
+    })
+    await user.clear(input)
+    await user.type(input, 'Discarded{Escape}')
+
+    expect(
+      screen.queryByRole('textbox', { name: i18n.global.t('g.rename') })
+    ).not.toBeInTheDocument()
+    expect(emitted().renameChat).toBeUndefined()
+  })
+
+  it('opens chat history and reports the navigation', async () => {
+    const user = userEvent.setup()
+    const { emitted } = mountChat()
+
+    await user.click(
+      screen.getByRole('button', {
+        name: i18n.global.t('agent.showChatHistory')
+      })
+    )
+
+    expect(
+      screen.getByRole('heading', { name: i18n.global.t('agent.history') })
+    ).toBeInTheDocument()
+    expect(emitted().openHistory).toEqual([[]])
+  })
+
+  it('reports deletion of the current chat', async () => {
+    const user = userEvent.setup()
+    const { emitted } = mountChat()
+
+    await user.click(
+      screen.getByRole('button', { name: i18n.global.t('agent.chatOptions') })
+    )
+    await user.click(
+      await screen.findByRole('menuitem', { name: i18n.global.t('g.delete') })
+    )
+
+    expect(emitted().deleteHistory).toEqual([['thread-1']])
+  })
+
   it('focuses the composer input body after a suggestion and clears on blur', async () => {
     const user = userEvent.setup()
-    const pinia = createPinia()
+    const pinia = createTestingPinia({ stubActions: false })
     setActivePinia(pinia)
     render(AgentPanel, {
       props: { entries: [], historyGroups },
@@ -127,7 +217,7 @@ describe('AgentPanel', () => {
 
   it('replaces and focuses the composer draft when editing the eligible prompt', async () => {
     const user = userEvent.setup()
-    const pinia = createPinia()
+    const pinia = createTestingPinia({ stubActions: false })
     setActivePinia(pinia)
     const prompt = 'Generate a yellow duck with a hockey mask'
     const { emitted } = render(AgentPanel, {

--- a/src/workbench/extensions/agent/components/agent/ConversationView.test.ts
+++ b/src/workbench/extensions/agent/components/agent/ConversationView.test.ts
@@ -1,7 +1,8 @@
 // @vitest-environment jsdom
+import { createTestingPinia } from '@pinia/testing'
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
-import { createPinia, setActivePinia } from 'pinia'
+import { setActivePinia } from 'pinia'
 import { defineComponent, nextTick } from 'vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -40,8 +41,7 @@ import { useAgentConversationStore } from '../../stores/agent/agentConversationS
 import ConversationView from './ConversationView.vue'
 
 const T = 'msg-1' as TurnId
-const chat = (raw: unknown): AgentChatEvent =>
-  zAgentWsEvent.parse(raw) as AgentChatEvent
+const chat = (raw: unknown): AgentChatEvent => zAgentWsEvent.parse(raw)
 const thinking = (id: string, delta: string) =>
   chat({
     type: 'agent_thinking',
@@ -73,7 +73,7 @@ const Harness = defineComponent({
 })
 
 function mountHarness() {
-  const pinia = createPinia()
+  const pinia = createTestingPinia({ stubActions: false })
   setActivePinia(pinia)
   const utils = render(Harness, { global: { plugins: [pinia, i18n] } })
   return { store: useAgentConversationStore(), ...utils }
@@ -82,7 +82,7 @@ function mountHarness() {
 describe('ConversationView', () => {
   beforeEach(() => {
     Element.prototype.scrollIntoView = vi.fn()
-    setActivePinia(createPinia())
+    setActivePinia(createTestingPinia({ stubActions: false }))
     intersectionCallbacks.length = 0
   })
 
@@ -105,6 +105,33 @@ describe('ConversationView', () => {
       role: 'assistant',
       streaming: false
     })
+  })
+
+  it('forwards assistant feedback with its turn id', async () => {
+    const assistant: AssistantMessage = {
+      id: T,
+      role: 'assistant',
+      parts: [{ type: 'text', text: 'hello', state: 'done' }],
+      streaming: false,
+      thinking: false
+    }
+    const { emitted } = render(ConversationView, {
+      props: { entries: [assistant] },
+      global: {
+        plugins: [i18n],
+        stubs: {
+          AgentMessage: {
+            emits: ['feedback'],
+            template:
+              '<button type="button" @click="$emit(\'feedback\', \'up\')">Vote up</button>'
+          }
+        }
+      }
+    })
+
+    await userEvent.click(screen.getByRole('button', { name: 'Vote up' }))
+
+    expect(emitted().feedback).toEqual([[T, 'up']])
   })
 
   it('shows a scroll-to-latest button when scrolled up and returns to bottom on click', async () => {

--- a/src/workbench/extensions/agent/composables/agent/useAttachment.test.ts
+++ b/src/workbench/extensions/agent/composables/agent/useAttachment.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it, vi } from 'vitest'
 
 import type { ComposerAttachment } from './useComposer'
-import { MAX_ATTACHMENT_BYTES, useAttachment } from './useAttachment'
+import {
+  agentAttachmentMaxBytes,
+  MAX_ATTACHMENT_BYTES,
+  useAttachment
+} from './useAttachment'
 
 function fileOfSize(name: string, size: number, type = 'image/png'): File {
   const file = new File(['x'], name, { type })
@@ -26,6 +30,29 @@ function chipRegistry() {
 }
 
 describe('useAttachment', () => {
+  it('allows videos up to the server limit but caps other files at 20MB', () => {
+    const serverMaxBytes = 100 * 1024 * 1024
+
+    expect(
+      agentAttachmentMaxBytes(
+        fileOfSize('movie.mp4', 1, 'video/mp4'),
+        serverMaxBytes
+      )
+    ).toBe(serverMaxBytes)
+    expect(
+      agentAttachmentMaxBytes(
+        fileOfSize('image.png', 1, 'image/png'),
+        serverMaxBytes
+      )
+    ).toBe(MAX_ATTACHMENT_BYTES)
+    expect(
+      agentAttachmentMaxBytes(
+        fileOfSize('audio.mp3', 1, 'audio/mpeg'),
+        serverMaxBytes
+      )
+    ).toBe(MAX_ATTACHMENT_BYTES)
+  })
+
   it('gives an image a thumbnail but leaves a video to the icon tile', async () => {
     // A video object URL in an <img> renders as a broken thumbnail, so only
     // images get a previewUrl.

--- a/src/workbench/extensions/agent/composables/agent/useAttachment.ts
+++ b/src/workbench/extensions/agent/composables/agent/useAttachment.ts
@@ -1,8 +1,17 @@
 import { i18n } from '@/i18n'
-import { hasImageType } from '@/utils/eventUtils'
+import { hasImageType, hasVideoType } from '@/utils/eventUtils'
 import type { ComposerAttachment } from './useComposer'
 
 export const MAX_ATTACHMENT_BYTES = 20 * 1024 * 1024
+
+export function agentAttachmentMaxBytes(
+  file: File,
+  serverMaxBytes: number
+): number {
+  return hasVideoType(file)
+    ? serverMaxBytes
+    : Math.min(MAX_ATTACHMENT_BYTES, serverMaxBytes)
+}
 
 interface UploadResult {
   ref: string

--- a/src/workbench/extensions/agent/services/agent/agentTranscript.test.ts
+++ b/src/workbench/extensions/agent/services/agent/agentTranscript.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from 'vitest'
 
 import type { AgentMessages, TurnId } from '../../schemas/agentApiSchema'
-import { normalizeAgentTranscript } from './agentTranscript'
+import {
+  buildTranscriptMarkdown,
+  normalizeAgentTranscript
+} from './agentTranscript'
 
 const row = (
   seq: number,
@@ -75,5 +78,31 @@ describe('normalizeAgentTranscript', () => {
     expect(transcript.userTexts.get('turn-a' as TurnId)).toBe('Prompt')
     expect(transcript.assistantTurnIds).toEqual(new Set())
     expect(transcript.rowIds).toEqual(new Set(['row-1', 'row-2']))
+  })
+})
+
+describe('buildTranscriptMarkdown', () => {
+  it('serializes user text and assistant text parts in conversation order', () => {
+    const entries: Parameters<typeof buildTranscriptMarkdown>[0] = [
+      { role: 'user', text: 'make a cat' },
+      {
+        role: 'assistant',
+        parts: [
+          { type: 'text', text: 'Here is ', state: 'done' },
+          {
+            type: 'tool',
+            callId: 'tool-1',
+            name: 'add_node',
+            state: 'done',
+            ok: true
+          },
+          { type: 'text', text: 'a cat.', state: 'done' }
+        ]
+      }
+    ]
+
+    expect(buildTranscriptMarkdown(entries)).toBe(
+      '**You:** make a cat\n\n**Agent:** Here is a cat.'
+    )
   })
 })

--- a/src/workbench/extensions/agent/services/agent/agentTranscript.test.ts
+++ b/src/workbench/extensions/agent/services/agent/agentTranscript.test.ts
@@ -101,8 +101,11 @@ describe('buildTranscriptMarkdown', () => {
       }
     ]
 
-    expect(buildTranscriptMarkdown(entries)).toBe(
-      '**You:** make a cat\n\n**Agent:** Here is a cat.'
-    )
+    expect(
+      buildTranscriptMarkdown(entries, {
+        user: 'Utilisateur',
+        assistant: 'Assistante'
+      })
+    ).toBe('**Utilisateur:** make a cat\n\n**Assistante:** Here is a cat.')
   })
 })

--- a/src/workbench/extensions/agent/services/agent/agentTranscript.ts
+++ b/src/workbench/extensions/agent/services/agent/agentTranscript.ts
@@ -14,16 +14,17 @@ type TranscriptEntry =
   | { role: 'assistant'; parts: AssistantMessage['parts'] }
 
 export function buildTranscriptMarkdown(
-  entries: readonly TranscriptEntry[]
+  entries: readonly TranscriptEntry[],
+  labels: { user: string; assistant: string }
 ): string {
   return entries
     .map((entry) => {
-      if (entry.role === 'user') return `**You:** ${entry.text}`
+      if (entry.role === 'user') return `**${labels.user}:** ${entry.text}`
       const text = entry.parts
         .filter((part) => part.type === 'text')
         .map((part) => part.text)
         .join('')
-      return `**Agent:** ${text}`
+      return `**${labels.assistant}:** ${text}`
     })
     .join('\n\n')
 }

--- a/src/workbench/extensions/agent/services/agent/agentTranscript.ts
+++ b/src/workbench/extensions/agent/services/agent/agentTranscript.ts
@@ -9,6 +9,25 @@ export interface NormalizedAgentTranscript {
   assistantTurnIds: Set<TurnId>
 }
 
+type TranscriptEntry =
+  | { role: 'user'; text: string }
+  | { role: 'assistant'; parts: AssistantMessage['parts'] }
+
+export function buildTranscriptMarkdown(
+  entries: readonly TranscriptEntry[]
+): string {
+  return entries
+    .map((entry) => {
+      if (entry.role === 'user') return `**You:** ${entry.text}`
+      const text = entry.parts
+        .filter((part) => part.type === 'text')
+        .map((part) => part.text)
+        .join('')
+      return `**Agent:** ${text}`
+    })
+    .join('\n\n')
+}
+
 export function normalizeAgentTranscript(
   history: AgentMessages
 ): NormalizedAgentTranscript {

--- a/src/workbench/extensions/agent/stores/agent/agentChatHistoryStore.test.ts
+++ b/src/workbench/extensions/agent/stores/agent/agentChatHistoryStore.test.ts
@@ -38,11 +38,38 @@ describe('chatSessionFromThread', () => {
     })
     expect(
       chatSessionFromThread(
-        { id: 'thread-2', title: '', created_at: 'invalid' },
+        {
+          id: 'thread-2',
+          title: 'Duck pipeline',
+          preview: 'ignored preview',
+          updated_at: '2026-07-06T10:00:00Z'
+        },
         'Untitled',
         NOW
       )
-    ).toEqual({ id: 'thread-2', title: 'Untitled', updatedAt: NOW })
+    ).toEqual({
+      id: 'thread-2',
+      title: 'Duck pipeline',
+      updatedAt: Date.parse('2026-07-06T10:00:00Z')
+    })
+    expect(
+      chatSessionFromThread(
+        { id: 'thread-3', title: '', created_at: '2026-07-05T10:00:00Z' },
+        'Untitled',
+        NOW
+      )
+    ).toEqual({
+      id: 'thread-3',
+      title: 'Untitled',
+      updatedAt: Date.parse('2026-07-05T10:00:00Z')
+    })
+    expect(
+      chatSessionFromThread(
+        { id: 'thread-4', title: '', created_at: 'invalid' },
+        'Untitled',
+        NOW
+      )
+    ).toEqual({ id: 'thread-4', title: 'Untitled', updatedAt: NOW })
   })
 })
 

--- a/src/workbench/extensions/agent/stores/agent/agentChatHistoryStore.test.ts
+++ b/src/workbench/extensions/agent/stores/agent/agentChatHistoryStore.test.ts
@@ -1,8 +1,10 @@
-import { createPinia, setActivePinia } from 'pinia'
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it } from 'vitest'
 
 import type { ChatSession } from './agentChatHistoryStore'
 import {
+  chatSessionFromThread,
   groupSessionsByRecency,
   useAgentChatHistoryStore
 } from './agentChatHistoryStore'
@@ -14,6 +16,34 @@ const session = (id: string, updatedAt: number): ChatSession => ({
   id,
   title: id,
   updatedAt
+})
+
+describe('chatSessionFromThread', () => {
+  it('uses the best title and valid newest timestamp with deterministic fallbacks', () => {
+    expect(
+      chatSessionFromThread(
+        {
+          id: 'thread-1',
+          title: '',
+          preview: 'make a duck',
+          last_message_at: '2026-07-07T10:00:00Z'
+        },
+        'Untitled',
+        NOW
+      )
+    ).toEqual({
+      id: 'thread-1',
+      title: 'make a duck',
+      updatedAt: Date.parse('2026-07-07T10:00:00Z')
+    })
+    expect(
+      chatSessionFromThread(
+        { id: 'thread-2', title: '', created_at: 'invalid' },
+        'Untitled',
+        NOW
+      )
+    ).toEqual({ id: 'thread-2', title: 'Untitled', updatedAt: NOW })
+  })
 })
 
 describe('groupSessionsByRecency', () => {
@@ -59,7 +89,7 @@ describe('groupSessionsByRecency', () => {
 
 describe('useAgentChatHistoryStore', () => {
   beforeEach(() => {
-    setActivePinia(createPinia())
+    setActivePinia(createTestingPinia({ stubActions: false }))
     localStorage.clear()
   })
 

--- a/src/workbench/extensions/agent/stores/agent/agentChatHistoryStore.ts
+++ b/src/workbench/extensions/agent/stores/agent/agentChatHistoryStore.ts
@@ -2,6 +2,8 @@ import { useLocalStorage, useTimestamp } from '@vueuse/core'
 import { defineStore } from 'pinia'
 import { computed, ref } from 'vue'
 
+import type { AgentThreadSummary } from '../../schemas/agentApiSchema'
+
 export interface ChatSession {
   id: string
   title: string
@@ -13,6 +15,20 @@ export interface HistoryGroups {
   today: ChatSession[]
   yesterday: ChatSession[]
   earlier: ChatSession[]
+}
+
+export function chatSessionFromThread(
+  thread: AgentThreadSummary,
+  untitledTitle: string,
+  now = Date.now()
+): ChatSession {
+  const stamp = thread.last_message_at ?? thread.updated_at ?? thread.created_at
+  const updatedAt = stamp ? Date.parse(stamp) : now
+  return {
+    id: thread.id,
+    title: thread.title || thread.preview || untitledTitle,
+    updatedAt: Number.isNaN(updatedAt) ? now : updatedAt
+  }
 }
 
 function startOfLocalDay(now: number): number {

--- a/src/workbench/extensions/agent/utils/agentWorkflowTabs.test.ts
+++ b/src/workbench/extensions/agent/utils/agentWorkflowTabs.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  agentTabFilename,
+  buildOpenTabsSnapshot,
+  uniqueCloudWorkflowIdsByName,
+  workflowIdForTab
+} from './agentWorkflowTabs'
+
+type Tab = Parameters<typeof workflowIdForTab>[0]['tab']
+
+function tab(
+  filename: string,
+  path = `workflows/${filename}.json`,
+  isTemporary = false
+): Tab {
+  return { filename, path, isTemporary }
+}
+
+describe('agent workflow tabs', () => {
+  it('indexes only uniquely named cloud workflows', () => {
+    expect(
+      uniqueCloudWorkflowIdsByName([
+        { id: 'wf-current', name: 'current' },
+        { id: 'wf-duck-a', name: 'duck' },
+        { id: 'wf-duck-b', name: 'duck' },
+        { id: 'wf-nameless' }
+      ])
+    ).toEqual(new Map([['current', 'wf-current']]))
+  })
+
+  it('resolves a unique saved tab by cloud name and otherwise uses its binding', () => {
+    const current = tab('current')
+    const duplicate = tab('current', 'workflows/archive/current.json')
+    const draft = tab('draft', 'workflows/draft.json', true)
+    const cloudIdsByName = new Map([
+      ['current', 'wf-current'],
+      ['draft', 'wf-draft']
+    ])
+
+    expect(
+      workflowIdForTab({
+        tab: current,
+        openTabs: [current],
+        cloudIdsByName
+      })
+    ).toBe('wf-current')
+    expect(
+      workflowIdForTab({
+        tab: current,
+        openTabs: [current, duplicate],
+        cloudIdsByName
+      })
+    ).toBeUndefined()
+    expect(
+      workflowIdForTab({
+        tab: draft,
+        openTabs: [draft],
+        cloudIdsByName,
+        boundWorkflowId: 'wf-bound-draft'
+      })
+    ).toBe('wf-bound-draft')
+  })
+
+  it('builds a snapshot from resolved tabs and omits unresolved active tabs', () => {
+    const current = tab('current')
+    const background = tab('background')
+    const scratch = tab('scratch', 'workflows/scratch.json', true)
+    const ids = new Map<Tab, string>([
+      [current, 'wf-current'],
+      [background, 'wf-background']
+    ])
+    const workflowIdFor = (candidate: Tab) => ids.get(candidate)
+
+    expect(
+      buildOpenTabsSnapshot({
+        openTabs: [current, background, scratch],
+        activeTab: current,
+        detached: false,
+        workflowIdFor
+      })
+    ).toEqual({
+      open_tabs: [
+        { workflow_id: 'wf-current', name: 'current' },
+        { workflow_id: 'wf-background', name: 'background' }
+      ],
+      current_tab: 'wf-current'
+    })
+    expect(
+      buildOpenTabsSnapshot({
+        openTabs: [current, scratch],
+        activeTab: scratch,
+        detached: false,
+        workflowIdFor
+      })
+    ).toEqual({
+      open_tabs: [{ workflow_id: 'wf-current', name: 'current' }],
+      current_tab: undefined
+    })
+    expect(
+      buildOpenTabsSnapshot({
+        openTabs: [scratch],
+        activeTab: scratch,
+        detached: false,
+        workflowIdFor
+      })
+    ).toBeUndefined()
+  })
+
+  it.for([
+    ['a/b', 'a-b.json'],
+    ['folder\\name', 'folder-name.json'],
+    ['workflow.json', 'workflow.json'],
+    [' .hidden', 'hidden.json'],
+    [`${'a'.repeat(79)}💩b`, `${'a'.repeat(79)}💩.json`],
+    ['  ', undefined],
+    [undefined, undefined]
+  ])('sanitizes an agent tab name %#', ([name, expected]) => {
+    expect(agentTabFilename(name)).toBe(expected)
+  })
+})

--- a/src/workbench/extensions/agent/utils/agentWorkflowTabs.test.ts
+++ b/src/workbench/extensions/agent/utils/agentWorkflowTabs.test.ts
@@ -111,6 +111,7 @@ describe('agent workflow tabs', () => {
     ['a/b', 'a-b.json'],
     ['folder\\name', 'folder-name.json'],
     ['workflow.json', 'workflow.json'],
+    ['workflow.json ', 'workflow.json'],
     [' .hidden', 'hidden.json'],
     [`${'a'.repeat(79)}💩b`, `${'a'.repeat(79)}💩.json`],
     ['  ', undefined],

--- a/src/workbench/extensions/agent/utils/agentWorkflowTabs.ts
+++ b/src/workbench/extensions/agent/utils/agentWorkflowTabs.ts
@@ -71,8 +71,8 @@ export function agentTabFilename(name: string | undefined): string | undefined {
   const cleaned = Array.from(
     (name ?? '')
       .replace(/[/\\\p{Cc}]/gu, '-')
-      .replace(/\.json$/i, '')
       .trim()
+      .replace(/\.json$/i, '')
       .replace(/^\.+/, '')
   )
     .slice(0, 80)

--- a/src/workbench/extensions/agent/utils/agentWorkflowTabs.ts
+++ b/src/workbench/extensions/agent/utils/agentWorkflowTabs.ts
@@ -1,0 +1,83 @@
+import type { ComfyWorkflow } from '@/platform/workflow/management/stores/comfyWorkflow'
+
+import type { CloudWorkflowEntry } from '../schemas/agentApiSchema'
+import type { OpenTabsSnapshot } from '../services/agent/agentRestClient'
+
+type WorkflowTab = Pick<ComfyWorkflow, 'filename' | 'isTemporary' | 'path'>
+
+export function uniqueCloudWorkflowIdsByName(
+  workflows: CloudWorkflowEntry[]
+): Map<string, string> {
+  const nameCounts = new Map<string, number>()
+  for (const { name } of workflows) {
+    if (name !== undefined)
+      nameCounts.set(name, (nameCounts.get(name) ?? 0) + 1)
+  }
+  return new Map(
+    workflows.flatMap(({ id, name }) =>
+      name !== undefined && nameCounts.get(name) === 1
+        ? [[name, id] as const]
+        : []
+    )
+  )
+}
+
+export function workflowIdForTab({
+  tab,
+  openTabs,
+  cloudIdsByName,
+  boundWorkflowId
+}: {
+  tab: WorkflowTab
+  openTabs: WorkflowTab[]
+  cloudIdsByName: ReadonlyMap<string, string>
+  boundWorkflowId?: string
+}): string | undefined {
+  const matchingSavedTabs = openTabs.filter(
+    (candidate) => !candidate.isTemporary && candidate.filename === tab.filename
+  )
+  const cloudId =
+    !tab.isTemporary && matchingSavedTabs.length === 1
+      ? cloudIdsByName.get(tab.filename)
+      : undefined
+  return cloudId ?? boundWorkflowId
+}
+
+export function buildOpenTabsSnapshot<Tab extends WorkflowTab>({
+  openTabs,
+  activeTab,
+  detached,
+  workflowIdFor
+}: {
+  openTabs: Tab[]
+  activeTab: Tab | null
+  detached: boolean
+  workflowIdFor: (tab: Tab) => string | undefined
+}): OpenTabsSnapshot | undefined {
+  const resolvedTabs = openTabs.flatMap((tab) => {
+    const workflowId = workflowIdFor(tab)
+    return workflowId === undefined
+      ? []
+      : [{ workflow_id: workflowId, name: tab.filename }]
+  })
+  if (resolvedTabs.length === 0) return undefined
+  return {
+    open_tabs: resolvedTabs,
+    current_tab: activeTab && !detached ? workflowIdFor(activeTab) : undefined
+  }
+}
+
+export function agentTabFilename(name: string | undefined): string | undefined {
+  const cleaned = Array.from(
+    (name ?? '')
+      .replace(/[/\\\p{Cc}]/gu, '-')
+      .replace(/\.json$/i, '')
+      .trim()
+      .replace(/^\.+/, '')
+  )
+    .slice(0, 80)
+    .join('')
+    .replace(/^[\s.]+/u, '')
+    .trim()
+  return cleaned.length === 0 ? undefined : `${cleaned}.json`
+}


### PR DESCRIPTION
## Summary

Reduce `AgentPanelRoot` integration coverage to essential cross-boundary journeys and test component and policy behavior at narrower owners, cutting the suite wall time by about 66%.

## Changes

- **What**: Remove the root suite's forced jsdom environment by mocking the rich-message boundary, move component behavior assertions to focused component suites, and extract pure workflow-tab, transcript, attachment-limit, and history-conversion policies for direct tests.

## Review Focus

Review the ownership of the extracted policies and whether the retained root tests cover the necessary integration journeys. Real rich-message and sanitizer behavior remains covered by the jsdom `ConversationView` suite.

## Testing

- `pnpm test:unit src/workbench/extensions/agent/AgentPanelRoot.test.ts src/workbench/extensions/agent/utils/agentWorkflowTabs.test.ts src/workbench/extensions/agent/services/agent/agentTranscript.test.ts src/workbench/extensions/agent/composables/agent/useAttachment.test.ts src/workbench/extensions/agent/stores/agent/agentChatHistoryStore.test.ts src/workbench/extensions/agent/components/agent/AgentPanel.test.ts src/workbench/extensions/agent/components/agent/ConversationView.test.ts` (69 tests)
- `pnpm lint`
- `pnpm typecheck`
- `pnpm knip`
- `pnpm fallow:audit --base origin/main`