### PR TITLE
Allow nodes to opt in, shadow after configure

### DIFF
--- a/src/lib/litegraph/src/LGraphNode.ts
+++ b/src/lib/litegraph/src/LGraphNode.ts
@@ -1131,11 +1131,14 @@ export class LGraphNode
     }
     const namedValues = getNamedValues()
     const graphId = this.graph?.rootGraph.id ?? zeroUuid
+    const shouldRestoreNamed =
+      LiteGraph.namedValuesRestore ||
+      this.constructor.nodeData?.fallbackWidgetsValuesNames
     try {
       useWidgetValueStore().setNodeWidgetRestoration(graphId, this.id, {
         positional: positionalValues,
         named: namedValues ? { ...namedValues } : undefined,
-        restoreNamed: Boolean(namedValues && LiteGraph.namedValuesRestore)
+        restoreNamed: Boolean(namedValues && shouldRestoreNamed)
       })
 
       if (this.widgets) {
@@ -1152,18 +1155,6 @@ export class LGraphNode
             w.value = JSON.parse(
               JSON.stringify(this.properties[w.options.property])
             )
-        }
-
-        if (namedValues) {
-          const legacyShadow = computeLegacyWidgetShadow(
-            this.widgets,
-            info.widgets_values
-          )
-          reportNamedValuesShadowDiff(
-            this,
-            diffNamedValuesShadow(namedValues, legacyShadow),
-            Boolean(info.widgets_values_named)
-          )
         }
 
         let positionalIndex = 0
@@ -1190,6 +1181,17 @@ export class LGraphNode
       }
 
       this.onConfigure?.(extensionConfigureView(this, info))
+      if (this.widgets && namedValues) {
+        const legacyShadow = computeLegacyWidgetShadow(
+          this.widgets,
+          info.widgets_values
+        )
+        reportNamedValuesShadowDiff(
+          this,
+          diffNamedValuesShadow(namedValues, legacyShadow),
+          Boolean(info.widgets_values_named)
+        )
+      }
     } finally {
       useWidgetValueStore().clearNodeWidgetRestoration(graphId, this.id)
     }


### PR DESCRIPTION
Followup to #10392 and #14375
- A node which specifies `fallbackWidgetsValuesNames` opts itself in to using restoring widget values by name.
  - Current telemetry suggests enabling this functionality by default can not be safely done. This change allows for internal nodes to safely swap to the new system without risking breakage by requiring it be applied on every node.
- The telemetry has been moved to occur *after* custom nodes are allowed to perform their configure step. Doing it before meant the telemetry was fighting against custom nodes and not actually measuring their end state. For example, VHS nodes would report an error because the named value doesn't match the blindly applied `widgets_values` instead of the real final restored state.