### PR TITLE
feat(keybindings): scope bindings to a dialog

### DIFF
--- a/src/components/dialog/content/setting/KeybindingPanel.vue
+++ b/src/components/dialog/content/setting/KeybindingPanel.vue
@@ -191,7 +191,7 @@
                 <div
                   v-for="(binding, idx) in (slotProps.data as ICommandData)
                     .keybindings"
-                  :key="binding.combo.serialize()"
+                  :key="binding.serialize()"
                   data-testid="keybinding-expansion-binding"
                   class="flex items-center justify-between border-b border-border-subtle py-1.5 last:border-b-0"
                 >
@@ -472,7 +472,6 @@ function editKeybinding(commandData: ICommandData, binding: KeybindingImpl) {
     commandId: commandData.id,
     commandLabel: commandData.label,
     currentCombo: binding.combo,
-    mode: 'edit',
     existingBinding: binding
   })
 }
@@ -481,8 +480,7 @@ function addKeybinding(commandData: ICommandData) {
   editKeybindingDialog.show({
     commandId: commandData.id,
     commandLabel: commandData.label,
-    currentCombo: null,
-    mode: 'add'
+    currentCombo: null
   })
 }
 

--- a/src/components/dialog/content/setting/keybinding/EditKeybindingFooter.vue
+++ b/src/components/dialog/content/setting/keybinding/EditKeybindingFooter.vue
@@ -17,7 +17,7 @@
             : 'primary'
       "
       size="md"
-      :disabled="!dialogState.newCombo"
+      :disabled="!newKeybinding"
       class="px-4 py-2"
       @click="handleSave"
     >
@@ -36,7 +36,7 @@
 import type { Reactive } from 'vue'
 
 import Button from '@/components/ui/button/Button.vue'
-import { KeybindingImpl } from '@/platform/keybindings/keybinding'
+import type { KeybindingImpl } from '@/platform/keybindings/keybinding'
 import { useKeybindingService } from '@/platform/keybindings/keybindingService'
 import { useKeybindingStore } from '@/platform/keybindings/keybindingStore'
 import { useDialogStore } from '@/stores/dialogStore'
@@ -44,8 +44,9 @@ import { useDialogStore } from '@/stores/dialogStore'
 import type { EditKeybindingDialogState } from '@/composables/useEditKeybindingDialog'
 import { DIALOG_KEY } from '@/composables/useEditKeybindingDialog'
 
-const { dialogState, existingKeybindingOnCombo } = defineProps<{
+const { dialogState, newKeybinding, existingKeybindingOnCombo } = defineProps<{
   dialogState: Reactive<EditKeybindingDialogState>
+  newKeybinding: KeybindingImpl | null
   existingKeybindingOnCombo: KeybindingImpl | null
 }>()
 
@@ -58,23 +59,17 @@ function handleCancel() {
 }
 
 async function handleSave() {
-  const combo = dialogState.newCombo
-  const commandId = dialogState.commandId
-  if (!combo || !commandId) return
+  if (!newKeybinding) return
 
   dialogStore.closeDialog({ key: DIALOG_KEY })
 
-  if (dialogState.mode === 'add') {
-    keybindingStore.addUserKeybinding(new KeybindingImpl({ commandId, combo }))
-  } else if (dialogState.existingBinding) {
+  if (dialogState.existingBinding) {
     keybindingStore.updateSpecificKeybinding(
       dialogState.existingBinding,
-      new KeybindingImpl({ commandId, combo })
+      newKeybinding
     )
   } else {
-    keybindingStore.updateKeybindingOnCommand(
-      new KeybindingImpl({ commandId, combo })
-    )
+    keybindingStore.addUserKeybinding(newKeybinding)
   }
   await keybindingService.persistUserKeybindings()
 }

--- a/src/composables/useEditKeybindingDialog.test.ts
+++ b/src/composables/useEditKeybindingDialog.test.ts
@@ -1,0 +1,111 @@
+import type { ComputedRef } from 'vue'
+import { describe, expect, it, vi } from 'vitest'
+
+import type { EditKeybindingDialogState } from '@/composables/useEditKeybindingDialog'
+import { useEditKeybindingDialog } from '@/composables/useEditKeybindingDialog'
+import { KeyComboImpl } from '@/platform/keybindings/keyCombo'
+import { KeybindingImpl } from '@/platform/keybindings/keybinding'
+import { useKeybindingStore } from '@/platform/keybindings/keybindingStore'
+
+interface DialogProps {
+  dialogState: EditKeybindingDialogState
+  existingKeybindingOnCombo: ComputedRef<KeybindingImpl | null>
+  onUpdateCombo: (combo: KeyComboImpl) => void
+}
+
+interface FooterProps {
+  newKeybinding: ComputedRef<KeybindingImpl | null>
+}
+
+const showSmallLayoutDialog = vi.hoisted(() =>
+  vi.fn<(options: { props: DialogProps; footerProps: FooterProps }) => void>()
+)
+
+vi.mock('@/services/dialogService', () => ({
+  useDialogService: () => ({ showSmallLayoutDialog })
+}))
+
+const ctrlZ = new KeyComboImpl({ key: 'z', ctrl: true })
+const ctrlY = new KeyComboImpl({ key: 'y', ctrl: true })
+
+function shownDialog() {
+  const call = showSmallLayoutDialog.mock.lastCall
+  if (!call) throw new Error('dialog was not shown')
+  return { ...call[0].props, ...call[0].footerProps }
+}
+
+describe('useEditKeybindingDialog', () => {
+  it('builds the new binding with the scope of the binding being edited', () => {
+    useEditKeybindingDialog().show({
+      commandId: 'test.maskEditor.undo',
+      commandLabel: 'Undo',
+      currentCombo: ctrlZ,
+      existingBinding: new KeybindingImpl({
+        commandId: 'test.maskEditor.undo',
+        combo: ctrlZ,
+        dialogKey: 'global-mask-editor',
+        targetElementId: 'mask-editor'
+      })
+    })
+    const dialog = shownDialog()
+    dialog.onUpdateCombo(ctrlY)
+
+    expect(dialog.newKeybinding.value).toEqual(
+      new KeybindingImpl({
+        commandId: 'test.maskEditor.undo',
+        combo: ctrlY,
+        dialogKey: 'global-mask-editor',
+        targetElementId: 'mask-editor'
+      })
+    )
+  })
+
+  it('copies scope from the command defaults when adding a combo', () => {
+    const store = useKeybindingStore()
+    const scopedDefault = new KeybindingImpl({
+      commandId: 'test.maskEditor.undo',
+      combo: ctrlZ,
+      dialogKey: 'global-mask-editor'
+    })
+    store.addDefaultKeybinding(scopedDefault)
+    store.unsetKeybinding(scopedDefault)
+
+    useEditKeybindingDialog().show({
+      commandId: 'test.maskEditor.undo',
+      commandLabel: 'Undo',
+      currentCombo: null
+    })
+
+    expect(shownDialog().dialogState.dialogKey).toBe('global-mask-editor')
+  })
+
+  it('reports a conflict only with the binding in the same scope', () => {
+    const store = useKeybindingStore()
+    const workspaceUndo = new KeybindingImpl({
+      commandId: 'test.undo',
+      combo: ctrlZ
+    })
+    const maskEditorUndo = new KeybindingImpl({
+      commandId: 'test.maskEditor.undo',
+      combo: ctrlZ,
+      dialogKey: 'global-mask-editor'
+    })
+    store.addDefaultKeybinding(workspaceUndo)
+    store.addDefaultKeybinding(maskEditorUndo)
+
+    useEditKeybindingDialog().show({
+      commandId: 'test.maskEditor.redo',
+      commandLabel: 'Redo',
+      currentCombo: ctrlY,
+      existingBinding: new KeybindingImpl({
+        commandId: 'test.maskEditor.redo',
+        combo: ctrlY,
+        dialogKey: 'global-mask-editor'
+      })
+    })
+    const dialog = shownDialog()
+    dialog.onUpdateCombo(ctrlZ)
+
+    expect(dialog.existingKeybindingOnCombo.value).toEqual(maskEditorUndo)
+  })
+})

--- a/src/composables/useEditKeybindingDialog.test.ts
+++ b/src/composables/useEditKeybindingDialog.test.ts
@@ -21,7 +21,7 @@ const showSmallLayoutDialog = vi.hoisted(() =>
   vi.fn<(options: { props: DialogProps; footerProps: FooterProps }) => void>()
 )
 
-vi.mock('@/services/dialogService', () => ({
+vi.mock<unknown>(import('@/services/dialogService'), () => ({
   useDialogService: () => ({ showSmallLayoutDialog })
 }))
 

--- a/src/composables/useEditKeybindingDialog.ts
+++ b/src/composables/useEditKeybindingDialog.ts
@@ -4,7 +4,7 @@ import EditKeybindingContent from '@/components/dialog/content/setting/keybindin
 import EditKeybindingFooter from '@/components/dialog/content/setting/keybinding/EditKeybindingFooter.vue'
 import EditKeybindingHeader from '@/components/dialog/content/setting/keybinding/EditKeybindingHeader.vue'
 import type { KeyComboImpl } from '@/platform/keybindings/keyCombo'
-import type { KeybindingImpl } from '@/platform/keybindings/keybinding'
+import { KeybindingImpl } from '@/platform/keybindings/keybinding'
 import { useKeybindingStore } from '@/platform/keybindings/keybindingStore'
 import { useDialogService } from '@/services/dialogService'
 
@@ -14,8 +14,10 @@ export interface EditKeybindingDialogState {
   commandId: string
   newCombo: KeyComboImpl | null
   currentCombo: KeyComboImpl | null
-  mode: 'edit' | 'add'
   existingBinding: KeybindingImpl | null
+  targetElementId?: string
+  dialogKey?: string
+  when?: string
 }
 
 export function useEditKeybindingDialog() {
@@ -26,21 +28,39 @@ export function useEditKeybindingDialog() {
     commandId: string
     commandLabel: string
     currentCombo: KeyComboImpl | null
-    mode?: 'edit' | 'add'
     existingBinding?: KeybindingImpl | null
   }) {
+    const scopeTemplate =
+      options.existingBinding ??
+      keybindingStore.getDefaultKeybindingsByCommandId(options.commandId)[0] ??
+      keybindingStore.getKeybindingByCommandId(options.commandId)
     const dialogState = reactive<EditKeybindingDialogState>({
       commandId: options.commandId,
       newCombo: options.currentCombo,
       currentCombo: options.currentCombo,
-      mode: options.mode ?? 'edit',
-      existingBinding: options.existingBinding ?? null
+      existingBinding: options.existingBinding ?? null,
+      targetElementId: scopeTemplate?.targetElementId,
+      dialogKey: scopeTemplate?.dialogKey,
+      when: scopeTemplate?.when
     })
 
+    const newKeybinding = computed(() =>
+      dialogState.newCombo
+        ? new KeybindingImpl({
+            commandId: dialogState.commandId,
+            combo: dialogState.newCombo,
+            targetElementId: dialogState.targetElementId,
+            dialogKey: dialogState.dialogKey,
+            when: dialogState.when
+          })
+        : null
+    )
+
     const existingKeybindingOnCombo = computed(() => {
-      if (!dialogState.newCombo) return null
-      if (dialogState.currentCombo?.equals(dialogState.newCombo)) return null
-      return keybindingStore.getKeybinding(dialogState.newCombo)
+      const candidate = newKeybinding.value
+      if (!candidate) return null
+      if (dialogState.currentCombo?.equals(candidate.combo)) return null
+      return keybindingStore.findConflictingKeybinding(candidate) ?? null
     })
 
     function onUpdateCombo(combo: KeyComboImpl) {
@@ -59,7 +79,7 @@ export function useEditKeybindingDialog() {
         existingKeybindingOnCombo
       },
       headerProps: {},
-      footerProps: { dialogState, existingKeybindingOnCombo }
+      footerProps: { dialogState, newKeybinding, existingKeybindingOnCombo }
     })
   }
 

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -321,6 +321,7 @@
     "keybindingAlreadyExists": "Keybinding already exists on",
     "invalidExtensionKeybinding": "{name}: invalid keybinding",
     "invalidExtensionContextKey": "{name}: could not register context key {key}",
+    "invalidExtensionContextKeys": "{name}: contextKeys must be a list of names",
     "keybindingPresets": {
       "importPreset": "Import preset",
       "importKeybindingPreset": "Import keybinding preset",

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -319,6 +319,8 @@
     "browserReservedKeybinding": "This shortcut is reserved by some browsers and may have unexpected results.",
     "browserReservedKeybindingTooltip": "This shortcut conflicts with browser-reserved shortcuts",
     "keybindingAlreadyExists": "Keybinding already exists on",
+    "invalidExtensionKeybinding": "{name}: invalid keybinding",
+    "invalidExtensionContextKey": "{name}: could not register context key {key}",
     "keybindingPresets": {
       "importPreset": "Import preset",
       "importKeybindingPreset": "Import keybinding preset",

--- a/src/platform/keybindings/contextKeyStore.test.ts
+++ b/src/platform/keybindings/contextKeyStore.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { useContextKeyStore } from './contextKeyStore'
+
+describe('useContextKeyStore', () => {
+  it('exposes registered keys in the snapshot and updates them', () => {
+    const store = useContextKeyStore()
+
+    expect(store.register('ext.wasdMode', 'ext')).toBe(true)
+    expect(store.snapshot()).toMatchObject({
+      'ext.wasdMode': false,
+      modalOpen: false,
+      textInputFocus: false
+    })
+
+    expect(store.set('ext.wasdMode', true)).toBe(true)
+    expect(store.snapshot()['ext.wasdMode']).toBe(true)
+    expect(store.ownerOf('ext.wasdMode')).toBe('ext')
+  })
+
+  it('ignores writes to keys nobody registered', () => {
+    const store = useContextKeyStore()
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    expect(store.set('nope', true)).toBe(false)
+    expect('nope' in store.snapshot()).toBe(false)
+  })
+
+  it('lets an owner re-register its key but not take another owner’s', () => {
+    const store = useContextKeyStore()
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    store.register('shared', 'a')
+    store.set('shared', true)
+
+    expect(store.register('shared', 'a')).toBe(true)
+    expect(store.snapshot().shared).toBe(true)
+    expect(store.register('shared', 'b')).toBe(false)
+    expect(store.ownerOf('shared')).toBe('a')
+  })
+
+  it('rejects names the when grammar cannot reference', () => {
+    const store = useContextKeyStore()
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    expect(store.register('has space', 'a')).toBe(false)
+    expect(store.register('1leading', 'a')).toBe(false)
+  })
+})

--- a/src/platform/keybindings/contextKeyStore.ts
+++ b/src/platform/keybindings/contextKeyStore.ts
@@ -1,0 +1,59 @@
+import { defineStore } from 'pinia'
+import { shallowRef } from 'vue'
+
+export type ContextSnapshot = Readonly<Record<string, boolean>>
+
+/** Derived by the dispatcher on every keydown rather than set by anyone. */
+const BUILT_IN_CONTEXT_KEYS = ['modalOpen', 'textInputFocus']
+
+const CONTEXT_KEY_PATTERN = /^[A-Za-z_][\w.-]*$/
+
+export const CORE_CONTEXT_KEY_OWNER = 'core'
+
+export const useContextKeyStore = defineStore('contextKey', () => {
+  const values = shallowRef<Record<string, boolean>>(
+    Object.fromEntries(BUILT_IN_CONTEXT_KEYS.map((key) => [key, false]))
+  )
+  const owners = new Map(
+    BUILT_IN_CONTEXT_KEYS.map((key) => [key, CORE_CONTEXT_KEY_OWNER])
+  )
+
+  function register(name: string, owner: string): boolean {
+    if (!CONTEXT_KEY_PATTERN.test(name)) {
+      console.warn(`Context key "${name}" is not a valid identifier`)
+      return false
+    }
+    const existingOwner = owners.get(name)
+    if (existingOwner !== undefined && existingOwner !== owner) {
+      console.warn(
+        `Context key "${name}" is already registered by ${existingOwner}`
+      )
+      return false
+    }
+    owners.set(name, owner)
+    if (!(name in values.value)) {
+      values.value = { ...values.value, [name]: false }
+    }
+    return true
+  }
+
+  function set(name: string, value: boolean): boolean {
+    if (!owners.has(name)) {
+      console.warn(`Context key "${name}" is not registered`)
+      return false
+    }
+    if (values.value[name] === value) return true
+    values.value = { ...values.value, [name]: value }
+    return true
+  }
+
+  function ownerOf(name: string): string | undefined {
+    return owners.get(name)
+  }
+
+  function snapshot(): ContextSnapshot {
+    return values.value
+  }
+
+  return { register, set, ownerOf, snapshot }
+})

--- a/src/platform/keybindings/keybinding.test.ts
+++ b/src/platform/keybindings/keybinding.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest'
+
+import { KeybindingImpl } from './keybinding'
+import { zKeybinding } from './types'
+
+describe('KeybindingImpl', () => {
+  it('treats bindings that differ only by dialog scope as distinct', () => {
+    const workspace = new KeybindingImpl({
+      commandId: 'test.command',
+      combo: { key: 'z', ctrl: true }
+    })
+    const scoped = new KeybindingImpl({
+      commandId: 'test.command',
+      combo: { key: 'z', ctrl: true },
+      dialogKey: 'global-mask-editor'
+    })
+
+    expect(workspace.equals(scoped)).toBe(false)
+    expect(workspace.serialize()).not.toBe(scoped.serialize())
+    expect(
+      scoped.equals(
+        new KeybindingImpl({
+          commandId: 'test.command',
+          combo: { key: 'z', ctrl: true },
+          dialogKey: 'global-mask-editor'
+        })
+      )
+    ).toBe(true)
+  })
+
+  it('serializes only the persisted fields', () => {
+    const binding = new KeybindingImpl({
+      commandId: 'test.command',
+      combo: { key: 'z', ctrl: true },
+      dialogKey: 'global-mask-editor'
+    })
+
+    expect(JSON.parse(JSON.stringify(binding))).toMatchObject({
+      commandId: 'test.command',
+      dialogKey: 'global-mask-editor'
+    })
+  })
+
+  it('canonicalizes the when clause so spellings compare equal', () => {
+    const binding = new KeybindingImpl({
+      commandId: 'test.command',
+      combo: { key: 'w' },
+      when: 'b && !a'
+    })
+
+    expect(binding.when).toBe('!a && b')
+    expect(
+      binding.equals(
+        new KeybindingImpl({
+          commandId: 'test.command',
+          combo: { key: 'w' },
+          when: '!a&&b'
+        })
+      )
+    ).toBe(true)
+  })
+
+  it('treats empty scope fields as absent', () => {
+    const binding = new KeybindingImpl({
+      commandId: 'test.command',
+      combo: { key: 'z', ctrl: true },
+      dialogKey: '',
+      targetElementId: ''
+    })
+
+    expect(binding.dialogKey).toBeUndefined()
+    expect(binding.targetElementId).toBeUndefined()
+    expect(
+      binding.equals(
+        new KeybindingImpl({
+          commandId: 'test.command',
+          combo: { key: 'z', ctrl: true }
+        })
+      )
+    ).toBe(true)
+  })
+})
+
+describe('zKeybinding', () => {
+  it('accepts null optional fields from extensions', () => {
+    const result = zKeybinding.safeParse({
+      commandId: 'test.command',
+      combo: { key: 'k', ctrl: true },
+      targetElementId: null
+    })
+
+    expect(result.success).toBe(true)
+    if (result.success) expect(result.data.targetElementId).toBeUndefined()
+  })
+})

--- a/src/platform/keybindings/keybinding.test.ts
+++ b/src/platform/keybindings/keybinding.test.ts
@@ -28,6 +28,24 @@ describe('KeybindingImpl', () => {
     ).toBe(true)
   })
 
+  it('keeps scope fields that contain the separator apart', () => {
+    const combo = { key: 'z', ctrl: true }
+    const a = new KeybindingImpl({
+      commandId: 'test.command',
+      combo,
+      targetElementId: 'canvas:mask',
+      dialogKey: 'editor'
+    })
+    const b = new KeybindingImpl({
+      commandId: 'test.command',
+      combo,
+      targetElementId: 'canvas',
+      dialogKey: 'mask:editor'
+    })
+
+    expect(a.serialize()).not.toBe(b.serialize())
+  })
+
   it('serializes only the persisted fields', () => {
     const binding = new KeybindingImpl({
       commandId: 'test.command',

--- a/src/platform/keybindings/keybinding.ts
+++ b/src/platform/keybindings/keybinding.ts
@@ -2,16 +2,26 @@ import { toRaw } from 'vue'
 
 import { KeyComboImpl } from './keyCombo'
 import type { Keybinding } from './types'
+import { canonicalWhenClause } from './whenClause'
 
 export class KeybindingImpl implements Keybinding {
   commandId: string
   combo: KeyComboImpl
   targetElementId?: string
+  dialogKey?: string
+  when?: string
 
   constructor(obj: Keybinding) {
     this.commandId = obj.commandId
     this.combo = new KeyComboImpl(obj.combo)
-    this.targetElementId = obj.targetElementId
+    this.targetElementId = obj.targetElementId || undefined
+    this.dialogKey = obj.dialogKey || undefined
+    this.when = obj.when ? canonicalWhenClause(obj.when) : undefined
+  }
+
+  /** Every field that distinguishes one binding from another. */
+  serialize(): string {
+    return `${this.commandId}:${this.combo.serialize()}:${this.targetElementId ?? ''}:${this.dialogKey ?? ''}:${this.when ?? ''}`
   }
 
   equals(other: unknown): boolean {
@@ -20,7 +30,9 @@ export class KeybindingImpl implements Keybinding {
     return raw instanceof KeybindingImpl
       ? this.commandId === raw.commandId &&
           this.combo.equals(raw.combo) &&
-          this.targetElementId === raw.targetElementId
+          this.targetElementId === raw.targetElementId &&
+          this.dialogKey === raw.dialogKey &&
+          this.when === raw.when
       : false
   }
 }

--- a/src/platform/keybindings/keybinding.ts
+++ b/src/platform/keybindings/keybinding.ts
@@ -21,7 +21,13 @@ export class KeybindingImpl implements Keybinding {
 
   /** Every field that distinguishes one binding from another. */
   serialize(): string {
-    return `${this.commandId}:${this.combo.serialize()}:${this.targetElementId ?? ''}:${this.dialogKey ?? ''}:${this.when ?? ''}`
+    return JSON.stringify([
+      this.commandId,
+      this.combo.serialize(),
+      this.targetElementId ?? '',
+      this.dialogKey ?? '',
+      this.when ?? ''
+    ])
   }
 
   equals(other: unknown): boolean {

--- a/src/platform/keybindings/keybindingService.registerUserKeybindings.test.ts
+++ b/src/platform/keybindings/keybindingService.registerUserKeybindings.test.ts
@@ -1,6 +1,7 @@
 import { useSettingStore } from '@/platform/settings/settingStore'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { KeyComboImpl } from '@/platform/keybindings/keyCombo'
 import { KeybindingImpl } from '@/platform/keybindings/keybinding'
 import { useKeybindingService } from '@/platform/keybindings/keybindingService'
 import { useKeybindingStore } from '@/platform/keybindings/keybindingStore'
@@ -61,5 +62,68 @@ describe('keybindingService - registerUserKeybindings', () => {
     expect(
       keybindingStore.getKeybindingByCommandId('Comfy.Test.Registered')
     ).toBeUndefined()
+  })
+
+  it('round-trips dialog-scoped bindings through the persisted settings', async () => {
+    const commandStore = useCommandStore()
+    commandStore.registerCommands([
+      { id: 'Comfy.Test.Undo', function: vi.fn() },
+      { id: 'Comfy.Test.MaskUndo', function: vi.fn() }
+    ])
+    const combo = { key: 'z', ctrl: true, alt: false, shift: false }
+    const keybindingStore = useKeybindingStore()
+    keybindingStore.addDefaultKeybinding(
+      new KeybindingImpl({ commandId: 'Comfy.Test.Undo', combo })
+    )
+    keybindingStore.addDefaultKeybinding(
+      new KeybindingImpl({
+        commandId: 'Comfy.Test.MaskUndo',
+        combo,
+        dialogKey: 'global-mask-editor'
+      })
+    )
+    useSettingStore().settingValues['Comfy.Keybinding.UnsetBindings'] = [
+      {
+        commandId: 'Comfy.Test.MaskUndo',
+        combo,
+        dialogKey: 'global-mask-editor'
+      }
+    ]
+    useSettingStore().settingValues['Comfy.Keybinding.NewBindings'] = [
+      {
+        commandId: 'Comfy.Test.MaskUndo',
+        combo: { key: 'u', ctrl: true },
+        dialogKey: 'global-mask-editor'
+      }
+    ]
+
+    const service = useKeybindingService()
+    service.registerUserKeybindings()
+
+    const ctrlZ = new KeyComboImpl(combo)
+    expect(keybindingStore.getKeybindings(ctrlZ)[0]?.commandId).toBe(
+      'Comfy.Test.Undo'
+    )
+    expect(keybindingStore.getKeybindings(ctrlZ, 'global-mask-editor')).toEqual(
+      []
+    )
+    expect(
+      keybindingStore.getKeybindings(
+        new KeyComboImpl({ key: 'u', ctrl: true }),
+        'global-mask-editor'
+      )[0]?.commandId
+    ).toBe('Comfy.Test.MaskUndo')
+
+    const setMany = vi.spyOn(useSettingStore(), 'setMany').mockResolvedValue()
+    await service.persistUserKeybindings()
+
+    expect(setMany).toHaveBeenCalledWith({
+      'Comfy.Keybinding.NewBindings': [
+        expect.objectContaining({ dialogKey: 'global-mask-editor' })
+      ],
+      'Comfy.Keybinding.UnsetBindings': [
+        expect.objectContaining({ dialogKey: 'global-mask-editor' })
+      ]
+    })
   })
 })

--- a/src/platform/keybindings/keybindingService.registerUserKeybindings.test.ts
+++ b/src/platform/keybindings/keybindingService.registerUserKeybindings.test.ts
@@ -119,10 +119,18 @@ describe('keybindingService - registerUserKeybindings', () => {
 
     expect(setMany).toHaveBeenCalledWith({
       'Comfy.Keybinding.NewBindings': [
-        expect.objectContaining({ dialogKey: 'global-mask-editor' })
+        expect.objectContaining({
+          commandId: 'Comfy.Test.MaskUndo',
+          combo: expect.objectContaining({ key: 'u', ctrl: true }),
+          dialogKey: 'global-mask-editor'
+        })
       ],
       'Comfy.Keybinding.UnsetBindings': [
-        expect.objectContaining({ dialogKey: 'global-mask-editor' })
+        expect.objectContaining({
+          commandId: 'Comfy.Test.MaskUndo',
+          combo: expect.objectContaining({ key: 'z', ctrl: true }),
+          dialogKey: 'global-mask-editor'
+        })
       ]
     })
   })

--- a/src/platform/keybindings/keybindingService.ts
+++ b/src/platform/keybindings/keybindingService.ts
@@ -131,9 +131,9 @@ export function useKeybindingService() {
 
   async function persistUserKeybindings() {
     await settingStore.setMany({
-      'Comfy.Keybinding.NewBindings': keybindingStore.getUserKeybindingValues(),
+      'Comfy.Keybinding.NewBindings': keybindingStore.getUserKeybindings(),
       'Comfy.Keybinding.UnsetBindings':
-        keybindingStore.getUserUnsetKeybindingValues()
+        keybindingStore.getUserUnsetKeybindings()
     })
   }
 

--- a/src/platform/keybindings/keybindingStore.test.ts
+++ b/src/platform/keybindings/keybindingStore.test.ts
@@ -613,10 +613,33 @@ describe('useKeybindingStore', () => {
         combo: { key: 'z', ctrl: true }
       })
       store.addUserKeybinding(userBinding)
+      const replacement = new KeybindingImpl({
+        commandId: 'test.other',
+        combo: { key: 'z', ctrl: true }
+      })
+      store.addUserKeybinding(replacement)
 
       expect(store.getUserKeybindings()).toEqual([
         maskEditorUndo(),
-        userBinding
+        replacement
+      ])
+    })
+
+    it('drops the user binding that took a default’s place when the default is added back', () => {
+      const store = useKeybindingStore()
+      store.addDefaultKeybinding(workspaceUndo())
+      store.addUserKeybinding(
+        new KeybindingImpl({
+          commandId: 'test.save',
+          combo: { key: 'z', ctrl: true }
+        })
+      )
+      store.addUserKeybinding(workspaceUndo())
+
+      expect(store.getUserKeybindings()).toEqual([])
+      expect(store.getUserUnsetKeybindings()).toEqual([])
+      expect(store.getKeybindings(workspaceUndo().combo)).toEqual([
+        workspaceUndo()
       ])
     })
 

--- a/src/platform/keybindings/keybindingStore.test.ts
+++ b/src/platform/keybindings/keybindingStore.test.ts
@@ -14,7 +14,7 @@ describe('useKeybindingStore', () => {
     store.addDefaultKeybinding(keybinding)
 
     expect(store.keybindings).toHaveLength(1)
-    expect(store.getKeybinding(keybinding.combo)).toEqual(keybinding)
+    expect(store.getKeybindings(keybinding.combo)).toEqual([keybinding])
   })
 
   it('should add and retrieve user keybindings', () => {
@@ -27,7 +27,7 @@ describe('useKeybindingStore', () => {
     store.addUserKeybinding(keybinding)
 
     expect(store.keybindings).toHaveLength(1)
-    expect(store.getKeybinding(keybinding.combo)).toEqual(keybinding)
+    expect(store.getKeybindings(keybinding.combo)).toEqual([keybinding])
   })
 
   it('should get keybindings by command id', () => {
@@ -57,7 +57,7 @@ describe('useKeybindingStore', () => {
     store.addUserKeybinding(userKeybinding)
 
     expect(store.keybindings).toHaveLength(1)
-    expect(store.getKeybinding(userKeybinding.combo)).toEqual(userKeybinding)
+    expect(store.getKeybindings(userKeybinding.combo)).toEqual([userKeybinding])
   })
 
   it('Should allow binding to unsetted default keybindings', () => {
@@ -76,7 +76,7 @@ describe('useKeybindingStore', () => {
     store.addUserKeybinding(userKeybinding)
 
     expect(store.keybindings).toHaveLength(1)
-    expect(store.getKeybinding(userKeybinding.combo)).toEqual(userKeybinding)
+    expect(store.getKeybindings(userKeybinding.combo)).toEqual([userKeybinding])
   })
 
   it('should unset user keybindings', () => {
@@ -133,7 +133,7 @@ describe('useKeybindingStore', () => {
     store.addUserKeybinding(keybinding2)
 
     expect(store.keybindings).toHaveLength(1)
-    expect(store.getKeybinding(keybinding2.combo)).toEqual(keybinding2)
+    expect(store.getKeybindings(keybinding2.combo)).toEqual([keybinding2])
   })
 
   it('should not throw an error when unsetting non-existent keybindings', () => {
@@ -180,9 +180,9 @@ describe('useKeybindingStore', () => {
     store.addUserKeybinding(defaultKeybinding)
 
     expect(store.keybindings).toHaveLength(1)
-    expect(store.getKeybinding(defaultKeybinding.combo)).toEqual(
+    expect(store.getKeybindings(defaultKeybinding.combo)).toEqual([
       defaultKeybinding
-    )
+    ])
   })
 
   it('Should accept same keybinding from default and user', () => {
@@ -195,7 +195,7 @@ describe('useKeybindingStore', () => {
     store.addUserKeybinding(keybinding)
 
     expect(store.keybindings).toHaveLength(1)
-    expect(store.getKeybinding(keybinding.combo)).toEqual(keybinding)
+    expect(store.getKeybindings(keybinding.combo)).toEqual([keybinding])
   })
 
   it('Should keep previously customized keybindings after default keybindings change', () => {
@@ -227,27 +227,27 @@ describe('useKeybindingStore', () => {
     }
 
     expect(store.keybindings).toHaveLength(1)
-    expect(store.getKeybinding(userNewKeybindings[0].combo)).toEqual(
+    expect(store.getKeybindings(userNewKeybindings[0].combo)).toEqual([
       userNewKeybindings[0]
-    )
+    ])
 
     for (const keybinding of userUnsetKeybindings) {
       store.unsetKeybinding(keybinding)
     }
 
     expect(store.keybindings).toHaveLength(1)
-    expect(store.getKeybinding(userNewKeybindings[0].combo)).toEqual(
+    expect(store.getKeybindings(userNewKeybindings[0].combo)).toEqual([
       userNewKeybindings[0]
-    )
+    ])
 
     for (const keybinding of userNewKeybindings) {
       store.addUserKeybinding(keybinding)
     }
 
     expect(store.keybindings).toHaveLength(1)
-    expect(store.getKeybinding(userNewKeybindings[0].combo)).toEqual(
+    expect(store.getKeybindings(userNewKeybindings[0].combo)).toEqual([
       userNewKeybindings[0]
-    )
+    ])
   })
 
   it('should replace the previous keybinding with a new one for the same combo and unset the old command', () => {
@@ -265,12 +265,12 @@ describe('useKeybindingStore', () => {
       combo: { key: 'A', ctrl: true }
     })
 
-    store.updateKeybindingOnCommand(newKeybinding)
+    store.updateSpecificKeybinding(oldKeybinding, newKeybinding)
 
     expect(store.keybindings).toHaveLength(1)
-    expect(store.getKeybinding(newKeybinding.combo)).toMatchObject({
-      commandId: 'command2'
-    })
+    expect(store.getKeybindings(newKeybinding.combo)[0]?.commandId).toBe(
+      'command2'
+    )
     expect(store.getKeybindingsByCommandId('command1')).toHaveLength(0)
   })
 
@@ -327,7 +327,7 @@ describe('useKeybindingStore', () => {
     })
 
     store.addDefaultKeybinding(defaultKeybinding)
-    store.updateKeybindingOnCommand(userKeybinding)
+    store.updateSpecificKeybinding(defaultKeybinding, userKeybinding)
 
     expect(store.keybindings).toHaveLength(1)
     expect(store.getKeybindingByCommandId('test.command')).toEqual(
@@ -356,9 +356,11 @@ describe('useKeybindingStore', () => {
     store.unsetKeybinding(defaultKeybinding)
     expect(store.keybindings).toHaveLength(0)
 
-    const serializedCombo = defaultKeybinding.combo.serialize()
-    const userUnsetKeybindings = store.getUserUnsetKeybindings()
-    expect(userUnsetKeybindings[serializedCombo]).toEqual(defaultKeybinding)
+    expect(
+      store
+        .getUserUnsetKeybindings()
+        .some((binding) => binding.equals(defaultKeybinding))
+    ).toBe(true)
 
     const result = store.resetKeybindingForCommand('test.command')
 
@@ -368,7 +370,7 @@ describe('useKeybindingStore', () => {
       defaultKeybinding
     )
 
-    expect(store.getUserUnsetKeybindings()[serializedCombo]).toBeUndefined()
+    expect(store.getUserUnsetKeybindings()).toHaveLength(0)
   })
 
   it('should handle complex scenario with both unset and user keybindings', () => {
@@ -542,5 +544,212 @@ describe('useKeybindingStore', () => {
       expect(result).toBe(true)
       expect(store.getKeybindingsByCommandId('test.command')).toHaveLength(0)
     })
+  })
+
+  describe('dialog-scoped bindings on one combo', () => {
+    const workspaceUndo = () =>
+      new KeybindingImpl({
+        commandId: 'test.undo',
+        combo: { key: 'z', ctrl: true }
+      })
+    const maskEditorUndo = () =>
+      new KeybindingImpl({
+        commandId: 'test.maskEditor.undo',
+        combo: { key: 'z', ctrl: true },
+        dialogKey: 'global-mask-editor'
+      })
+
+    it('keeps a workspace default and a dialog-scoped default apart', () => {
+      const store = useKeybindingStore()
+      store.addDefaultKeybinding(workspaceUndo())
+      store.addDefaultKeybinding(maskEditorUndo())
+
+      expect(store.getKeybindings(workspaceUndo().combo)).toEqual([
+        workspaceUndo()
+      ])
+      expect(
+        store.getKeybindings(workspaceUndo().combo, 'global-mask-editor')
+      ).toEqual([maskEditorUndo()])
+    })
+
+    it('rejects a default on the same combo and scope', () => {
+      const store = useKeybindingStore()
+      store.addDefaultKeybinding(maskEditorUndo())
+
+      expect(() =>
+        store.addDefaultKeybinding(
+          new KeybindingImpl({
+            commandId: 'test.other',
+            combo: { key: 'z', ctrl: true },
+            dialogKey: 'global-mask-editor'
+          })
+        )
+      ).toThrow('already exists on test.maskEditor.undo')
+    })
+
+    it('only unsets the default a user binding shares a scope with', () => {
+      const store = useKeybindingStore()
+      store.addDefaultKeybinding(workspaceUndo())
+      store.addDefaultKeybinding(maskEditorUndo())
+
+      const userBinding = new KeybindingImpl({
+        commandId: 'test.save',
+        combo: { key: 'z', ctrl: true }
+      })
+      store.addUserKeybinding(userBinding)
+
+      expect(store.getKeybindings(userBinding.combo)).toEqual([userBinding])
+      expect(
+        store.getKeybindings(userBinding.combo, 'global-mask-editor')
+      ).toEqual([maskEditorUndo()])
+      expect(store.getUserUnsetKeybindings()).toEqual([workspaceUndo()])
+    })
+
+    it('replaces only the user binding a new user binding shares a scope with', () => {
+      const store = useKeybindingStore()
+      store.addUserKeybinding(maskEditorUndo())
+      const userBinding = new KeybindingImpl({
+        commandId: 'test.save',
+        combo: { key: 'z', ctrl: true }
+      })
+      store.addUserKeybinding(userBinding)
+
+      expect(store.getUserKeybindings()).toEqual([
+        maskEditorUndo(),
+        userBinding
+      ])
+    })
+
+    it('prefers a user binding over a default registered after it', () => {
+      const store = useKeybindingStore()
+      const userBinding = new KeybindingImpl({
+        commandId: 'test.save',
+        combo: { key: 'z', ctrl: true }
+      })
+      store.addUserKeybinding(userBinding)
+      store.addDefaultKeybinding(workspaceUndo())
+
+      expect(store.getKeybindings(userBinding.combo)).toEqual([
+        userBinding,
+        workspaceUndo()
+      ])
+      expect(store.keybindings).toEqual([userBinding])
+      expect(store.getKeybindingsByCommandId('test.undo')).toEqual([])
+      expect(store.isCommandKeybindingModified('test.undo')).toBe(true)
+    })
+
+    it('collapses a default registered after an identical user binding', () => {
+      const store = useKeybindingStore()
+      store.addUserKeybinding(workspaceUndo())
+      store.addDefaultKeybinding(workspaceUndo())
+
+      expect(store.getUserKeybindings()).toEqual([])
+      expect(store.keybindings).toEqual([workspaceUndo()])
+      expect(store.isCommandKeybindingModified('test.undo')).toBe(false)
+    })
+
+    it('reclaims the combo when resetting a command whose default a user binding took', () => {
+      const store = useKeybindingStore()
+      store.addDefaultKeybinding(workspaceUndo())
+      const userBinding = new KeybindingImpl({
+        commandId: 'test.save',
+        combo: { key: 'z', ctrl: true }
+      })
+      store.addUserKeybinding(userBinding)
+
+      expect(store.resetKeybindingForCommand('test.undo')).toBe(true)
+      expect(store.getKeybindingsByCommandId('test.save')).toEqual([])
+      expect(store.getKeybindings(userBinding.combo)).toEqual([workspaceUndo()])
+      expect(store.keybindings).toEqual([workspaceUndo()])
+    })
+  })
+
+  describe('when clauses on one combo', () => {
+    const sidebar = () =>
+      new KeybindingImpl({ commandId: 'test.sidebar', combo: { key: 'w' } })
+    const pan = () =>
+      new KeybindingImpl({
+        commandId: 'test.pan',
+        combo: { key: 'w' },
+        when: 'test.wasdMode'
+      })
+
+    it('keeps bindings with different clauses and tries the narrower first', () => {
+      const store = useKeybindingStore()
+      store.addDefaultKeybinding(sidebar())
+      store.addDefaultKeybinding(pan())
+
+      expect(store.getKeybindings(sidebar().combo)).toEqual([pan(), sidebar()])
+      expect(store.keybindings).toEqual([sidebar(), pan()])
+    })
+
+    it('rejects a default with the same clause', () => {
+      const store = useKeybindingStore()
+      store.addDefaultKeybinding(pan())
+
+      expect(() =>
+        store.addDefaultKeybinding(
+          new KeybindingImpl({
+            commandId: 'test.other',
+            combo: { key: 'w' },
+            when: 'test.wasdMode'
+          })
+        )
+      ).toThrow('already exists on test.pan')
+    })
+
+    it('treats differently spelled clauses as the same clause', () => {
+      const store = useKeybindingStore()
+      store.addDefaultKeybinding(
+        new KeybindingImpl({
+          commandId: 'test.a',
+          combo: { key: 'w' },
+          when: 'b && !a'
+        })
+      )
+      const userBinding = new KeybindingImpl({
+        commandId: 'test.b',
+        combo: { key: 'w' },
+        when: '!a && b'
+      })
+      store.addUserKeybinding(userBinding)
+
+      expect(store.getKeybindings(userBinding.combo)).toEqual([userBinding])
+      expect(store.getUserUnsetKeybindings()).toHaveLength(1)
+    })
+  })
+
+  it('treats a binding that matches the default combo but not its scope as modified', () => {
+    const store = useKeybindingStore()
+    const defaultBinding = new KeybindingImpl({
+      commandId: 'test.delete',
+      combo: { key: 'Delete' },
+      targetElementId: 'graph-canvas-container'
+    })
+    store.addDefaultKeybinding(defaultBinding)
+    store.updateSpecificKeybinding(
+      defaultBinding,
+      new KeybindingImpl({ commandId: 'test.delete', combo: { key: 'Delete' } })
+    )
+
+    expect(store.isCommandKeybindingModified('test.delete')).toBe(true)
+    expect(store.resetKeybindingForCommand('test.delete')).toBe(true)
+    expect(store.getKeybindingByCommandId('test.delete')).toEqual(
+      defaultBinding
+    )
+  })
+
+  it('does not record a user binding identical to an active default', () => {
+    const store = useKeybindingStore()
+    const keybinding = new KeybindingImpl({
+      commandId: 'test.command',
+      combo: { key: 'J', ctrl: true }
+    })
+    store.addDefaultKeybinding(keybinding)
+    store.addUserKeybinding(keybinding)
+
+    expect(store.getUserKeybindings()).toEqual([])
+    expect(store.getUserUnsetKeybindings()).toEqual([])
+    expect(store.isCurrentPresetModified).toBe(false)
   })
 })

--- a/src/platform/keybindings/keybindingStore.ts
+++ b/src/platform/keybindings/keybindingStore.ts
@@ -177,6 +177,9 @@ export const useKeybindingStore = defineStore('keybinding', () => {
     )
     if (isDefault && unset) {
       userUnsetKeybindings.value = without(userUnsetKeybindings.value, unset)
+      userKeybindings.value = userKeybindings.value.filter(
+        (binding) => !conflicts(binding, keybinding)
+      )
       return
     }
     if (isDefault) return

--- a/src/platform/keybindings/keybindingStore.ts
+++ b/src/platform/keybindings/keybindingStore.ts
@@ -1,47 +1,56 @@
 import { groupBy } from 'es-toolkit/compat'
 import { defineStore } from 'pinia'
-import type { Ref } from 'vue'
 import { computed, ref, shallowRef } from 'vue'
 
 import type { KeyComboImpl } from './keyCombo'
 import { KeybindingImpl } from './keybinding'
 import type { KeybindingPreset } from './types'
+import { whenClauseSpecificity } from './whenClause'
 
-type KeybindingMap = Partial<Record<string, KeybindingImpl>>
+function scopeKey(combo: KeyComboImpl, dialogKey: string | undefined) {
+  return `${combo.serialize()}:${dialogKey ?? ''}`
+}
 
-function keybindingValues(keybindings: KeybindingMap): KeybindingImpl[] {
-  return Object.values(keybindings).filter(
-    (keybinding): keybinding is KeybindingImpl => keybinding !== undefined
+/** Same combo, scope and clause: the dispatcher could not tell them apart. */
+function conflicts(a: KeybindingImpl, b: KeybindingImpl): boolean {
+  return (
+    a.combo.equals(b.combo) && a.dialogKey === b.dialogKey && a.when === b.when
   )
 }
 
+/** Narrower clauses first; within a clause width, user bindings first. */
+function byResolutionOrder(a: KeybindingImpl, b: KeybindingImpl): number {
+  return whenClauseSpecificity(b.when) - whenClauseSpecificity(a.when)
+}
+
+function without(bindings: KeybindingImpl[], binding: KeybindingImpl) {
+  return bindings.filter((existing) => !existing.equals(binding))
+}
+
 export const useKeybindingStore = defineStore('keybinding', () => {
-  const defaultKeybindings = shallowRef<KeybindingMap>({})
-  const userKeybindings = shallowRef<KeybindingMap>({})
-  const userUnsetKeybindings = shallowRef<KeybindingMap>({})
+  const defaultKeybindings = shallowRef<KeybindingImpl[]>([])
+  const userKeybindings = shallowRef<KeybindingImpl[]>([])
+  const userUnsetKeybindings = shallowRef<KeybindingImpl[]>([])
 
   const currentPresetName = ref('default')
   const savedPresetData = ref<KeybindingPreset | null>(null)
 
-  const serializeBinding = (b: KeybindingImpl) =>
-    `${b.commandId}:${b.combo.serialize()}:${b.targetElementId ?? ''}`
-
   const savedPresetSerialized = computed(() => {
     if (!savedPresetData.value) return null
     const savedNew = savedPresetData.value.newBindings
-      .map((b) => serializeBinding(new KeybindingImpl(b)))
+      .map((b) => new KeybindingImpl(b).serialize())
       .sort()
       .join('|')
     const savedUnset = savedPresetData.value.unsetBindings
-      .map((b) => serializeBinding(new KeybindingImpl(b)))
+      .map((b) => new KeybindingImpl(b).serialize())
       .sort()
       .join('|')
     return { savedNew, savedUnset }
   })
 
   const isCurrentPresetModified = computed(() => {
-    const newBindings = keybindingValues(userKeybindings.value)
-    const unsetBindings = keybindingValues(userUnsetKeybindings.value)
+    const newBindings = userKeybindings.value
+    const unsetBindings = userUnsetKeybindings.value
 
     if (currentPresetName.value === 'default') {
       return newBindings.length > 0 || unsetBindings.length > 0
@@ -49,8 +58,14 @@ export const useKeybindingStore = defineStore('keybinding', () => {
 
     if (!savedPresetSerialized.value) return false
 
-    const currentNew = newBindings.map(serializeBinding).sort().join('|')
-    const currentUnset = unsetBindings.map(serializeBinding).sort().join('|')
+    const currentNew = newBindings
+      .map((b) => b.serialize())
+      .sort()
+      .join('|')
+    const currentUnset = unsetBindings
+      .map((b) => b.serialize())
+      .sort()
+      .join('|')
 
     return (
       currentNew !== savedPresetSerialized.value.savedNew ||
@@ -62,46 +77,62 @@ export const useKeybindingStore = defineStore('keybinding', () => {
     return userKeybindings.value
   }
 
-  function getUserKeybindingValues() {
-    return keybindingValues(userKeybindings.value)
-  }
-
   function getUserUnsetKeybindings() {
     return userUnsetKeybindings.value
   }
 
-  function getUserUnsetKeybindingValues() {
-    return keybindingValues(userUnsetKeybindings.value)
-  }
-
-  const keybindingByKeyCombo = computed<KeybindingMap>(() => {
-    const result: KeybindingMap = {
-      ...defaultKeybindings.value
-    }
-
-    for (const keybinding of keybindingValues(userUnsetKeybindings.value)) {
-      const serializedCombo = keybinding.combo.serialize()
-      if (result[serializedCombo]?.equals(keybinding)) {
-        delete result[serializedCombo]
-      }
-    }
-
-    return {
-      ...result,
-      ...userKeybindings.value
-    }
-  })
-
-  const keybindings = computed<KeybindingImpl[]>(() =>
-    keybindingValues(keybindingByKeyCombo.value)
+  const activeDefaultKeybindings = computed(() =>
+    defaultKeybindings.value.filter(
+      (binding) =>
+        !userUnsetKeybindings.value.some((unset) => unset.equals(binding))
+    )
   )
 
-  function getKeybinding(combo: KeyComboImpl): KeybindingImpl | undefined {
-    return keybindingByKeyCombo.value[combo.serialize()]
+  const keybindings = computed<KeybindingImpl[]>(() => [
+    ...activeDefaultKeybindings.value.filter(
+      (binding) =>
+        !userKeybindings.value.some((user) => conflicts(user, binding))
+    ),
+    ...userKeybindings.value
+  ])
+
+  const keybindingsByScope = computed<Partial<Record<string, KeybindingImpl[]>>>(() => {
+    const groups = groupBy(
+      [...userKeybindings.value, ...activeDefaultKeybindings.value],
+      (binding) => scopeKey(binding.combo, binding.dialogKey)
+    )
+    for (const group of Object.values(groups)) group.sort(byResolutionOrder)
+    return groups
+  })
+
+  /** Active bindings for a combo in a scope, in the order the dispatcher tries them. */
+  function getKeybindings(
+    combo: KeyComboImpl,
+    dialogKey?: string
+  ): KeybindingImpl[] {
+    return keybindingsByScope.value[scopeKey(combo, dialogKey)] ?? []
+  }
+
+  /** The binding a dispatcher that does not evaluate clauses should run. */
+  function getKeybinding(
+    combo: KeyComboImpl,
+    dialogKey?: string
+  ): KeybindingImpl | undefined {
+    return getKeybindings(combo, dialogKey).find(
+      (binding) => binding.when === undefined
+    )
+  }
+
+  function findConflictingKeybinding(
+    keybinding: KeybindingImpl
+  ): KeybindingImpl | undefined {
+    return getKeybindings(keybinding.combo, keybinding.dialogKey).find(
+      (binding) => conflicts(binding, keybinding)
+    )
   }
 
   const keybindingsByCommandId = computed<
-    Partial<Record<string, KeybindingImpl[]>>
+    Partial<Partial<Record<string, KeybindingImpl[]>>>
   >(() => {
     return groupBy(keybindings.value, 'commandId')
   })
@@ -112,94 +143,80 @@ export const useKeybindingStore = defineStore('keybinding', () => {
 
   const defaultKeybindingsByCommandId = computed<
     Partial<Record<string, KeybindingImpl[]>>
-  >(() => groupBy(keybindingValues(defaultKeybindings.value), 'commandId'))
+  >(() => {
+    return groupBy(defaultKeybindings.value, 'commandId')
+  })
+
+  function getDefaultKeybindingsByCommandId(commandId: string) {
+    return defaultKeybindingsByCommandId.value[commandId] ?? []
+  }
 
   function getKeybindingByCommandId(commandId: string) {
     return getKeybindingsByCommandId(commandId).at(0)
   }
 
-  function addKeybinding(
-    target: Ref<KeybindingMap>,
-    keybinding: KeybindingImpl,
-    { existOk = false }: { existOk: boolean }
-  ) {
-    const existing = target.value[keybinding.combo.serialize()]
-    if (!existOk && existing) {
+  function addDefaultKeybinding(keybinding: KeybindingImpl) {
+    const existing = defaultKeybindings.value.find((binding) =>
+      conflicts(binding, keybinding)
+    )
+    if (existing) {
       throw new Error(
         `Keybinding on ${keybinding.combo} already exists on ${existing.commandId}`
       )
     }
-    target.value = {
-      ...target.value,
-      [keybinding.combo.serialize()]: keybinding
-    }
-  }
-
-  function addDefaultKeybinding(keybinding: KeybindingImpl) {
-    addKeybinding(defaultKeybindings, keybinding, { existOk: false })
+    defaultKeybindings.value = [...defaultKeybindings.value, keybinding]
+    userKeybindings.value = without(userKeybindings.value, keybinding)
   }
 
   function addUserKeybinding(keybinding: KeybindingImpl) {
-    const serializedCombo = keybinding.combo.serialize()
-    const defaultKeybinding = defaultKeybindings.value[serializedCombo]
-    const userUnsetKeybinding = userUnsetKeybindings.value[serializedCombo]
-
-    if (
-      keybinding.equals(defaultKeybinding) &&
-      keybinding.equals(userUnsetKeybinding)
-    ) {
-      const updated = { ...userUnsetKeybindings.value }
-      delete updated[keybinding.combo.serialize()]
-      userUnsetKeybindings.value = updated
+    const isDefault = defaultKeybindings.value.some((binding) =>
+      binding.equals(keybinding)
+    )
+    const unset = userUnsetKeybindings.value.find((binding) =>
+      binding.equals(keybinding)
+    )
+    if (isDefault && unset) {
+      userUnsetKeybindings.value = without(userUnsetKeybindings.value, unset)
       return
     }
+    if (isDefault) return
 
-    if (defaultKeybinding && !defaultKeybinding.equals(userUnsetKeybinding)) {
-      unsetKeybinding(defaultKeybinding)
+    for (const binding of activeDefaultKeybindings.value) {
+      if (conflicts(binding, keybinding)) unsetKeybinding(binding)
     }
-
-    addKeybinding(userKeybindings, keybinding, { existOk: true })
+    userKeybindings.value = [
+      ...userKeybindings.value.filter(
+        (binding) => !conflicts(binding, keybinding)
+      ),
+      keybinding
+    ]
   }
 
   function unsetKeybinding(keybinding: KeybindingImpl) {
-    const serializedCombo = keybinding.combo.serialize()
-    if (!(serializedCombo in keybindingByKeyCombo.value)) {
-      console.warn(
-        `Trying to unset non-exist keybinding: ${JSON.stringify(keybinding)}`
-      )
+    const user = userKeybindings.value.find((binding) =>
+      binding.equals(keybinding)
+    )
+    if (user) {
+      userKeybindings.value = without(userKeybindings.value, user)
       return
     }
 
-    if (userKeybindings.value[serializedCombo]?.equals(keybinding)) {
-      const updated = { ...userKeybindings.value }
-      delete updated[serializedCombo]
-      userKeybindings.value = updated
+    const active = activeDefaultKeybindings.value.find((binding) =>
+      binding.equals(keybinding)
+    )
+    if (active) {
+      userUnsetKeybindings.value = [...userUnsetKeybindings.value, active]
       return
     }
 
-    if (defaultKeybindings.value[serializedCombo]?.equals(keybinding)) {
-      addKeybinding(userUnsetKeybindings, keybinding, { existOk: false })
-      return
-    }
-
-    console.warn(`Unset unknown keybinding: ${JSON.stringify(keybinding)}`)
-  }
-
-  function updateKeybindingOnCommand(keybinding: KeybindingImpl): boolean {
-    const currentKeybinding = getKeybindingByCommandId(keybinding.commandId)
-    if (currentKeybinding?.equals(keybinding)) {
-      return false
-    }
-    if (currentKeybinding) {
-      unsetKeybinding(currentKeybinding)
-    }
-    addUserKeybinding(keybinding)
-    return true
+    console.warn(
+      `Trying to unset non-exist keybinding: ${JSON.stringify(keybinding)}`
+    )
   }
 
   function resetAllKeybindings() {
-    userKeybindings.value = {}
-    userUnsetKeybindings.value = {}
+    userKeybindings.value = []
+    userUnsetKeybindings.value = []
   }
 
   function removeAllKeybindingsForCommand(commandId: string): boolean {
@@ -221,7 +238,7 @@ export const useKeybindingStore = defineStore('keybinding', () => {
 
   function resetKeybindingForCommand(commandId: string): boolean {
     const currentBindings = getKeybindingsByCommandId(commandId)
-    const defaultBindings = defaultKeybindingsByCommandId.value[commandId] ?? []
+    const defaultBindings = getDefaultKeybindingsByCommandId(commandId)
 
     if (defaultBindings.length === 0) {
       if (currentBindings.length > 0) {
@@ -240,15 +257,19 @@ export const useKeybindingStore = defineStore('keybinding', () => {
     for (const binding of currentBindings) {
       unsetKeybinding(binding)
     }
-
-    const updatedUnset = { ...userUnsetKeybindings.value }
-    for (const defaultBinding of defaultBindings) {
-      const serializedCombo = defaultBinding.combo.serialize()
-      if (updatedUnset[serializedCombo]?.equals(defaultBinding)) {
-        delete updatedUnset[serializedCombo]
+    for (const binding of userKeybindings.value) {
+      if (
+        defaultBindings.some((defaultBinding) =>
+          conflicts(defaultBinding, binding)
+        )
+      ) {
+        unsetKeybinding(binding)
       }
     }
-    userUnsetKeybindings.value = updatedUnset
+
+    userUnsetKeybindings.value = userUnsetKeybindings.value.filter(
+      (unset) => !defaultBindings.some((binding) => binding.equals(unset))
+    )
 
     return true
   }
@@ -271,14 +292,10 @@ export const useKeybindingStore = defineStore('keybinding', () => {
       }
       if (currentBindings.length === 0) continue
 
-      const sortedCurrent = [...currentBindings]
-        .map((b) => b.combo.serialize())
-        .sort()
-      const sortedDefault = [...defaultBindings]
-        .map((b) => b.combo.serialize())
-        .sort()
+      const sortedCurrent = currentBindings.map((b) => b.serialize()).sort()
+      const sortedDefault = defaultBindings.map((b) => b.serialize()).sort()
 
-      if (sortedCurrent.some((combo, i) => combo !== sortedDefault[i])) {
+      if (sortedCurrent.some((binding, i) => binding !== sortedDefault[i])) {
         result.add(commandId)
       }
     }
@@ -293,16 +310,16 @@ export const useKeybindingStore = defineStore('keybinding', () => {
   return {
     keybindings,
     getUserKeybindings,
-    getUserKeybindingValues,
     getUserUnsetKeybindings,
-    getUserUnsetKeybindingValues,
     getKeybinding,
+    getKeybindings,
+    findConflictingKeybinding,
     getKeybindingsByCommandId,
+    getDefaultKeybindingsByCommandId,
     getKeybindingByCommandId,
     addDefaultKeybinding,
     addUserKeybinding,
     unsetKeybinding,
-    updateKeybindingOnCommand,
     resetAllKeybindings,
     resetKeybindingForCommand,
     isCommandKeybindingModified,

--- a/src/platform/keybindings/presetService.test.ts
+++ b/src/platform/keybindings/presetService.test.ts
@@ -188,7 +188,7 @@ describe('useKeybindingPresetService', () => {
         'keybindings/vim.json'
       )
       expect(store.currentPresetName).toBe('default')
-      expect(Object.keys(store.getUserKeybindings())).toHaveLength(0)
+      expect(store.getUserKeybindings()).toHaveLength(0)
     })
 
     it('throws when deleteUserData response is not ok', async () => {
@@ -294,7 +294,7 @@ describe('useKeybindingPresetService', () => {
         { overwrite: true, stringify: false }
       )
       expect(store.currentPresetName).toBe('imported')
-      expect(Object.keys(store.getUserKeybindings())).toHaveLength(1)
+      expect(store.getUserKeybindings()).toHaveLength(1)
     })
   })
 
@@ -423,9 +423,9 @@ describe('useKeybindingPresetService', () => {
       expect(store.savedPresetData?.name).toBe('vim')
       expect(store.savedPresetData?.newBindings).toHaveLength(1)
       expect(store.savedPresetData?.newBindings[0].commandId).toBe('new.cmd')
-      expect(Object.keys(store.getUserKeybindings())).toHaveLength(1)
+      expect(store.getUserKeybindings()).toHaveLength(1)
       expect(
-        store.getUserKeybindingValues().map(({ commandId }) => commandId)
+        store.getUserKeybindings().map(({ commandId }) => commandId)
       ).toEqual(['new.cmd'])
     })
 
@@ -450,7 +450,7 @@ describe('useKeybindingPresetService', () => {
 
       expect(store.currentPresetName).toBe('vim')
       expect(
-        store.getUserUnsetKeybindingValues().map(({ commandId }) => commandId)
+        store.getUserUnsetKeybindings().map(({ commandId }) => commandId)
       ).toEqual(['test.selectAll'])
     })
   })
@@ -736,7 +736,7 @@ describe('useKeybindingPresetService', () => {
       const service = await getPresetService()
       await service.switchToDefaultPreset()
 
-      expect(Object.keys(store.getUserKeybindings())).toHaveLength(0)
+      expect(store.getUserKeybindings()).toHaveLength(0)
       expect(store.currentPresetName).toBe('default')
       expect(store.savedPresetData).toBeNull()
       expect(mockPersistUserKeybindings).toHaveBeenCalled()
@@ -758,7 +758,7 @@ describe('useKeybindingPresetService', () => {
       const service = await getPresetService()
       await service.switchToDefaultPreset({ resetBindings: false })
 
-      expect(Object.keys(store.getUserKeybindings())).toHaveLength(1)
+      expect(store.getUserKeybindings()).toHaveLength(1)
       expect(store.currentPresetName).toBe('default')
       expect(store.savedPresetData).toBeNull()
     })

--- a/src/platform/keybindings/presetService.ts
+++ b/src/platform/keybindings/presetService.ts
@@ -41,8 +41,8 @@ function buildPresetFromStore(
   name: string,
   keybindingStore: ReturnType<typeof useKeybindingStore>
 ): KeybindingPreset {
-  const newBindings = toRaw(keybindingStore.getUserKeybindingValues())
-  const unsetBindings = toRaw(keybindingStore.getUserUnsetKeybindingValues())
+  const newBindings = toRaw(keybindingStore.getUserKeybindings())
+  const unsetBindings = toRaw(keybindingStore.getUserUnsetKeybindings())
   return { name, newBindings, unsetBindings }
 }
 

--- a/src/platform/keybindings/types.ts
+++ b/src/platform/keybindings/types.ts
@@ -8,10 +8,23 @@ const zKeyCombo = z.object({
   meta: z.boolean().optional()
 })
 
+const zOptionalString = z
+  .string()
+  .nullish()
+  .transform((value) => value ?? undefined)
+
 export const zKeybinding = z.object({
   commandId: z.string(),
   combo: zKeyCombo,
-  targetElementId: z.string().optional()
+  targetElementId: zOptionalString,
+  /** Fires only while the dialog opened with this key is the active one. */
+  dialogKey: zOptionalString,
+  /**
+   * Context keys that must hold, as `key && !otherKey`. Extensions register
+   * keys through `contextKeys` and set them with
+   * `app.extensionManager.contextKey.set`.
+   */
+  when: zOptionalString
 })
 
 export const zKeybindingPreset = z.object({

--- a/src/platform/keybindings/whenClause.test.ts
+++ b/src/platform/keybindings/whenClause.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  canonicalWhenClause,
+  matchesContext,
+  parseWhenClause,
+  whenClauseSpecificity
+} from './whenClause'
+
+describe('parseWhenClause', () => {
+  it.for([
+    { source: 'wasdMode', expected: [{ key: 'wasdMode', negated: false }] },
+    {
+      source: '!textInputFocus',
+      expected: [{ key: 'textInputFocus', negated: true }]
+    },
+    {
+      source: ' ext.wasd-mode &&  ! textInputFocus ',
+      expected: [
+        { key: 'ext.wasd-mode', negated: false },
+        { key: 'textInputFocus', negated: true }
+      ]
+    }
+  ])('parses "$source"', ({ source, expected }) => {
+    expect(parseWhenClause(source)).toEqual({ success: true, clause: expected })
+  })
+
+  it.for([
+    { source: '', reason: 'empty' },
+    { source: 'a || b', reason: 'disjunction' },
+    { source: '(a)', reason: 'parentheses' },
+    { source: 'a &&', reason: 'trailing operator' },
+    { source: 'a && a', reason: 'duplicate key' },
+    { source: 'a == b', reason: 'comparison' }
+  ])('rejects "$source" ($reason)', ({ source }) => {
+    expect(parseWhenClause(source)).toMatchObject({
+      success: false,
+      error: expect.stringContaining('Invalid when clause')
+    })
+  })
+})
+
+describe('matchesContext', () => {
+  const context = { wasdMode: true, textInputFocus: false }
+
+  it.for([
+    { source: 'wasdMode', expected: true },
+    { source: '!wasdMode', expected: false },
+    { source: 'wasdMode && !textInputFocus', expected: true },
+    { source: 'wasdMode && textInputFocus', expected: false },
+    { source: 'unregistered', expected: false },
+    { source: '!unregistered', expected: false }
+  ])('evaluates "$source"', ({ source, expected }) => {
+    const parsed = parseWhenClause(source)
+    if (!parsed.success) throw new Error(parsed.error)
+    expect(matchesContext(parsed.clause, context)).toBe(expected)
+  })
+})
+
+describe('canonicalWhenClause', () => {
+  it('orders atoms so equal clauses spell the same', () => {
+    expect(canonicalWhenClause('b && !a')).toBe('!a && b')
+    expect(canonicalWhenClause(' !a&&b ')).toBe('!a && b')
+  })
+
+  it('keeps an unparseable clause as written', () => {
+    expect(canonicalWhenClause(' a || b ')).toBe('a || b')
+  })
+})
+
+describe('whenClauseSpecificity', () => {
+  it.for([
+    { source: undefined, expected: 0 },
+    { source: 'a', expected: 1 },
+    { source: 'a && !b', expected: 2 },
+    { source: 'a || b', expected: 0 }
+  ])('counts atoms in $source', ({ source, expected }) => {
+    expect(whenClauseSpecificity(source)).toBe(expected)
+  })
+})

--- a/src/platform/keybindings/whenClause.test.ts
+++ b/src/platform/keybindings/whenClause.test.ts
@@ -49,7 +49,9 @@ describe('matchesContext', () => {
     { source: 'wasdMode && !textInputFocus', expected: true },
     { source: 'wasdMode && textInputFocus', expected: false },
     { source: 'unregistered', expected: false },
-    { source: '!unregistered', expected: false }
+    { source: '!unregistered', expected: false },
+    { source: 'toString', expected: false },
+    { source: '!toString', expected: false }
   ])('evaluates "$source"', ({ source, expected }) => {
     const parsed = parseWhenClause(source)
     if (!parsed.success) throw new Error(parsed.error)

--- a/src/platform/keybindings/whenClause.ts
+++ b/src/platform/keybindings/whenClause.ts
@@ -45,7 +45,8 @@ export function matchesContext(
   context: ContextSnapshot
 ): boolean {
   return clause.every(
-    (atom) => atom.key in context && context[atom.key] !== atom.negated
+    (atom) =>
+      Object.hasOwn(context, atom.key) && context[atom.key] !== atom.negated
   )
 }
 

--- a/src/platform/keybindings/whenClause.ts
+++ b/src/platform/keybindings/whenClause.ts
@@ -1,0 +1,67 @@
+import type { ContextSnapshot } from './contextKeyStore'
+
+interface WhenAtom {
+  key: string
+  negated: boolean
+}
+
+/** A conjunction of atoms. Grammar: `[!]key ( && [!]key )*`. */
+export type WhenClause = readonly WhenAtom[]
+
+export type WhenClauseParseResult =
+  | { success: true; clause: WhenClause }
+  | { success: false; error: string }
+
+const ATOM_PATTERN = /^(!?)\s*([A-Za-z_][\w.-]*)$/
+
+export function parseWhenClause(source: string): WhenClauseParseResult {
+  const atoms: WhenAtom[] = []
+  for (const token of source.split('&&')) {
+    const match = ATOM_PATTERN.exec(token.trim())
+    if (!match) {
+      return {
+        success: false,
+        error: `Invalid when clause "${source}": expected "key" or "!key", got "${token.trim()}"`
+      }
+    }
+    const [, bang, key] = match
+    if (atoms.some((atom) => atom.key === key)) {
+      return {
+        success: false,
+        error: `Invalid when clause "${source}": "${key}" appears more than once`
+      }
+    }
+    atoms.push({ key, negated: bang === '!' })
+  }
+  return { success: true, clause: atoms }
+}
+
+/**
+ * A key nobody has registered never matches, negated or not, so a typo
+ * cannot silently enable a binding everywhere.
+ */
+export function matchesContext(
+  clause: WhenClause,
+  context: ContextSnapshot
+): boolean {
+  return clause.every(
+    (atom) => atom.key in context && context[atom.key] !== atom.negated
+  )
+}
+
+/** Sorted, whitespace-free spelling, so equal clauses compare equal. */
+export function canonicalWhenClause(source: string): string {
+  const parsed = parseWhenClause(source)
+  if (!parsed.success) return source.trim()
+  return [...parsed.clause]
+    .sort((a, b) => a.key.localeCompare(b.key))
+    .map((atom) => `${atom.negated ? '!' : ''}${atom.key}`)
+    .join(' && ')
+}
+
+/** More atoms means a narrower clause; it wins over a broader one. */
+export function whenClauseSpecificity(source: string | undefined): number {
+  if (source === undefined) return 0
+  const parsed = parseWhenClause(source)
+  return parsed.success ? parsed.clause.length : 0
+}

--- a/src/services/extensionService.test.ts
+++ b/src/services/extensionService.test.ts
@@ -1,6 +1,18 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
-import { shouldLoadExtension } from './extensionService'
+import { useContextKeyStore } from '@/platform/keybindings/contextKeyStore'
+import { KeyComboImpl } from '@/platform/keybindings/keyCombo'
+import { useKeybindingStore } from '@/platform/keybindings/keybindingStore'
+import { useToastStore } from '@/platform/updates/common/toastStore'
+import type { ComfyExtension } from '@/types/comfy'
+
+import { shouldLoadExtension, useExtensionService } from './extensionService'
+
+vi.mock('@/scripts/app', () => ({ app: {} }))
+vi.mock('@/scripts/api', () => ({ api: {} }))
+vi.mock('@/platform/settings/settingStore', () => ({
+  useSettingStore: () => ({ get: () => [], addSetting: vi.fn() })
+}))
 
 describe('shouldLoadExtension', () => {
   it.for(['/extensions/cloud/rum.js', '/extensions/cloud/sentry.js'])(
@@ -25,5 +37,78 @@ describe('shouldLoadExtension', () => {
     expect(shouldLoadExtension('/extensions/comfyui-foo/main.js', true)).toBe(
       true
     )
+  })
+})
+
+describe('registerExtension keybindings', () => {
+  it('registers a dialog-scoped keybinding', () => {
+    useExtensionService().registerExtension({
+      name: 'Test.Scoped',
+      keybindings: [
+        {
+          combo: { key: 'z', ctrl: true },
+          commandId: 'Test.MaskUndo',
+          dialogKey: 'global-mask-editor'
+        }
+      ]
+    })
+
+    expect(
+      useKeybindingStore().getKeybindings(
+        new KeyComboImpl({ key: 'z', ctrl: true }),
+        'global-mask-editor'
+      )[0]?.commandId
+    ).toBe('Test.MaskUndo')
+  })
+
+  it('rejects a malformed keybinding with a toast and registers nothing', () => {
+    const toast = vi.spyOn(useToastStore(), 'add')
+    const extension: ComfyExtension = JSON.parse(
+      '{"name":"Test.Broken","keybindings":[{"combo":{"key":"k","ctrl":true}}]}'
+    )
+
+    useExtensionService().registerExtension(extension)
+
+    expect(toast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        detail: expect.stringContaining('Test.Broken: invalid keybinding')
+      })
+    )
+    expect(
+      useKeybindingStore().getKeybindings(
+        new KeyComboImpl({ key: 'k', ctrl: true })
+      )
+    ).toEqual([])
+  })
+
+  it('registers context keys under the extension name', () => {
+    useExtensionService().registerExtension({
+      name: 'Test.Keys',
+      contextKeys: ['wasdMode']
+    })
+
+    const contextKeys = useContextKeyStore()
+    expect(contextKeys.ownerOf('Test.Keys.wasdMode')).toBe('Test.Keys')
+    expect(contextKeys.set('Test.Keys.wasdMode', true)).toBe(true)
+  })
+
+  it('rejects a keybinding whose when clause does not parse', () => {
+    const toast = vi.spyOn(useToastStore(), 'add')
+
+    useExtensionService().registerExtension({
+      name: 'Test.BadWhen',
+      keybindings: [
+        { combo: { key: 'w' }, commandId: 'Test.Pan', when: 'a || b' }
+      ]
+    })
+
+    expect(toast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        detail: expect.stringContaining('Invalid when clause')
+      })
+    )
+    expect(
+      useKeybindingStore().getKeybindings(new KeyComboImpl({ key: 'w' }))
+    ).toEqual([])
   })
 })

--- a/src/services/extensionService.test.ts
+++ b/src/services/extensionService.test.ts
@@ -1,18 +1,20 @@
-import { describe, expect, it, vi } from 'vitest'
+import { useSettingStore } from '@/platform/settings/settingStore'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { useContextKeyStore } from '@/platform/keybindings/contextKeyStore'
 import { KeyComboImpl } from '@/platform/keybindings/keyCombo'
 import { useKeybindingStore } from '@/platform/keybindings/keybindingStore'
 import { useToastStore } from '@/platform/updates/common/toastStore'
+import type { Keybinding } from '@/platform/keybindings/types'
 import type { ComfyExtension } from '@/types/comfy'
 
 import { shouldLoadExtension, useExtensionService } from './extensionService'
 
-vi.mock('@/scripts/app', () => ({ app: {} }))
-vi.mock('@/scripts/api', () => ({ api: {} }))
-vi.mock('@/platform/settings/settingStore', () => ({
-  useSettingStore: () => ({ get: () => [], addSetting: vi.fn() })
-}))
+vi.mock<unknown>(import('@/scripts/app'), () => ({ app: {} }))
+vi.mock<unknown>(import('@/scripts/api'), () => ({ api: {} }))
+beforeEach(() => {
+  vi.mocked(useSettingStore().get).mockImplementation(() => [])
+})
 
 describe('shouldLoadExtension', () => {
   it.for(['/extensions/cloud/rum.js', '/extensions/cloud/sentry.js'])(
@@ -63,9 +65,10 @@ describe('registerExtension keybindings', () => {
 
   it('rejects a malformed keybinding with a toast and registers nothing', () => {
     const toast = vi.spyOn(useToastStore(), 'add')
-    const extension: ComfyExtension = JSON.parse(
-      '{"name":"Test.Broken","keybindings":[{"combo":{"key":"k","ctrl":true}}]}'
-    )
+    const extension: ComfyExtension = {
+      name: 'Test.Broken',
+      keybindings: [{ combo: { key: 'k', ctrl: true } } as Keybinding]
+    }
 
     useExtensionService().registerExtension(extension)
 
@@ -90,6 +93,25 @@ describe('registerExtension keybindings', () => {
     const contextKeys = useContextKeyStore()
     expect(contextKeys.ownerOf('Test.Keys.wasdMode')).toBe('Test.Keys')
     expect(contextKeys.set('Test.Keys.wasdMode', true)).toBe(true)
+  })
+
+  it('rejects contextKeys that are not a list of names', () => {
+    const toast = vi.spyOn(useToastStore(), 'add')
+    const extension: ComfyExtension = {
+      name: 'Test.BadKeys',
+      contextKeys: { wasdMode: true } as unknown as string[]
+    }
+
+    useExtensionService().registerExtension(extension)
+
+    expect(toast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        detail: expect.stringContaining('Test.BadKeys')
+      })
+    )
+    expect(useContextKeyStore().ownerOf('Test.BadKeys.wasdMode')).toBe(
+      undefined
+    )
   })
 
   it('rejects a keybinding whose when clause does not parse', () => {

--- a/src/services/extensionService.ts
+++ b/src/services/extensionService.ts
@@ -1,12 +1,18 @@
+import { fromZodError } from 'zod-validation-error'
+
 import { useCurrentUser } from '@/composables/auth/useCurrentUser'
 import { useErrorHandling } from '@/composables/useErrorHandling'
+import { t } from '@/i18n'
 import { legacyMenuCompat } from '@/lib/litegraph/src/contextMenuCompat'
 import { useSettingStore } from '@/platform/settings/settingStore'
 import { api } from '@/scripts/api'
 import { useCommandStore } from '@/stores/commandStore'
 import { useExtensionStore } from '@/stores/extensionStore'
+import { useContextKeyStore } from '@/platform/keybindings/contextKeyStore'
 import { KeybindingImpl } from '@/platform/keybindings/keybinding'
 import { useKeybindingStore } from '@/platform/keybindings/keybindingStore'
+import { zKeybinding } from '@/platform/keybindings/types'
+import { parseWhenClause } from '@/platform/keybindings/whenClause'
 import { useMenuItemStore } from '@/stores/menuItemStore'
 import { useWidgetStore } from '@/stores/widgetStore'
 import { useBottomPanelStore } from '@/stores/workspace/bottomPanelStore'
@@ -79,8 +85,38 @@ export const useExtensionService = () => {
     )
     const addSetting = wrapWithErrorHandling(settingStore.addSetting)
 
+    const contextKeyStore = useContextKeyStore()
+    extension.contextKeys?.forEach((key) => {
+      if (
+        !contextKeyStore.register(`${extension.name}.${key}`, extension.name)
+      ) {
+        toastErrorHandler(
+          new Error(
+            t('g.invalidExtensionContextKey', { name: extension.name, key })
+          )
+        )
+      }
+    })
     extension.keybindings?.forEach((keybinding) => {
-      addKeybinding(new KeybindingImpl(keybinding))
+      const parsed = zKeybinding.safeParse(keybinding)
+      if (!parsed.success) {
+        toastErrorHandler(
+          new Error(
+            `${t('g.invalidExtensionKeybinding', { name: extension.name })}: ${fromZodError(parsed.error).message}`
+          )
+        )
+        return
+      }
+      const when = parsed.data.when && parseWhenClause(parsed.data.when)
+      if (when && !when.success) {
+        toastErrorHandler(
+          new Error(
+            `${t('g.invalidExtensionKeybinding', { name: extension.name })}: ${when.error}`
+          )
+        )
+        return
+      }
+      addKeybinding(new KeybindingImpl(parsed.data))
     })
     useCommandStore().loadExtensionCommands(extension)
     useMenuItemStore().loadExtensionMenuCommands(extension)

--- a/src/services/extensionService.ts
+++ b/src/services/extensionService.ts
@@ -1,3 +1,4 @@
+import { z } from 'zod'
 import { fromZodError } from 'zod-validation-error'
 
 import { useCurrentUser } from '@/composables/auth/useCurrentUser'
@@ -20,6 +21,8 @@ import type { ComfyExtension } from '@/types/comfy'
 import type { AuthUserInfo } from '@/types/authTypes'
 import { app } from '@/scripts/app'
 import type { ComfyApp } from '@/scripts/app'
+
+const zContextKeys = z.array(z.string()).optional()
 
 const INLINED_CLOUD_EXTENSIONS = new Set([
   '/extensions/cloud/rum.js',
@@ -86,7 +89,13 @@ export const useExtensionService = () => {
     const addSetting = wrapWithErrorHandling(settingStore.addSetting)
 
     const contextKeyStore = useContextKeyStore()
-    extension.contextKeys?.forEach((key) => {
+    const contextKeys = zContextKeys.safeParse(extension.contextKeys)
+    if (!contextKeys.success) {
+      toastErrorHandler(
+        new Error(t('g.invalidExtensionContextKeys', { name: extension.name }))
+      )
+    }
+    contextKeys.data?.forEach((key) => {
       if (
         !contextKeyStore.register(`${extension.name}.${key}`, extension.name)
       ) {

--- a/src/stores/workspaceStore.ts
+++ b/src/stores/workspaceStore.ts
@@ -2,6 +2,10 @@ import { useMagicKeys } from '@vueuse/core'
 import { defineStore } from 'pinia'
 import { computed, ref } from 'vue'
 
+import {
+  CORE_CONTEXT_KEY_OWNER,
+  useContextKeyStore
+} from '@/platform/keybindings/contextKeyStore'
 import { useSettingStore } from '@/platform/settings/settingStore'
 import { useToastStore } from '@/platform/updates/common/toastStore'
 import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
@@ -91,6 +95,17 @@ function workspaceStoreSetup() {
 
   const executionErrorStore = useExecutionErrorStore()
 
+  const contextKeyStore = useContextKeyStore()
+  const contextKey = {
+    set(name: string, value: boolean) {
+      if (contextKeyStore.ownerOf(name) === CORE_CONTEXT_KEY_OWNER) {
+        console.warn(`Context key "${name}" is owned by core`)
+        return
+      }
+      contextKeyStore.set(name, value)
+    }
+  }
+
   return {
     spinner,
     shiftDown,
@@ -107,6 +122,7 @@ function workspaceStoreSetup() {
     colorPalette,
     dialog,
     bottomPanel,
+    contextKey,
     user: partialUserStore,
 
     // Execution error state (read-only, exposed for custom extensions)

--- a/src/types/comfy.ts
+++ b/src/types/comfy.ts
@@ -117,6 +117,12 @@ export interface ComfyExtension {
    */
   keybindings?: Keybinding[]
   /**
+   * Context keys the extension owns, registered as `<name>.<key>`. Keybindings
+   * may require them in `when`; set them with
+   * `app.extensionManager.contextKey.set`.
+   */
+  contextKeys?: string[]
+  /**
    * Menu commands to add to the menu bar
    */
   menuCommands?: MenuCommandGroup[]

--- a/src/types/extensionTypes.ts
+++ b/src/types/extensionTypes.ts
@@ -115,6 +115,10 @@ export interface ExtensionManager {
     set: (id: string, value: unknown) => void
   }
   workflow: ReturnType<typeof useWorkflowStore>
+  contextKey: {
+    /** Sets a context key the extension registered through `contextKeys`. */
+    set: (name: string, value: boolean) => void
+  }
 
   // Execution error state (read-only)
   lastNodeErrors: Record<string, NodeError> | null


### PR DESCRIPTION
## Summary

Add dialog scopes and boolean context clauses so a combo can serve distinct surfaces without overwriting another binding.

## Changes

- Store full binding identities, validate extension contributions, expose extension-owned context keys, and preserve scope when rebinding or applying presets.
- Keep scope/clause conflicts separate and show scoped bindings in the shortcuts panel.

## Review Focus

Conjunction parsing, unknown-key rejection, exact binding identity, extension ownership, and scope preservation. Focused store, preset, parser and editor tests pass in the completed stack.
