### PR TITLE
refactor(keybindings): dispatch every shortcut from one window listener

### DIFF
--- a/docs/adr/0027-keybinding-dispatch-and-dialog-scopes.md
+++ b/docs/adr/0027-keybinding-dispatch-and-dialog-scopes.md
@@ -1,0 +1,228 @@
+# 0027. Keybinding Dispatch and Dialog Scopes
+
+Date: 2026-09-01
+
+## Status
+
+Proposed
+
+## Context
+
+Keyboard shortcuts are resolved against one store, `keybindingStore`, but
+until now two independent dispatchers consulted it with different guards:
+
+- a window-level bubble listener registered by `GraphView.vue`, which
+  checked text-input focus, the modal state, and `targetElementId`
+  containment, but ignored `event.repeat`, `event.defaultPrevented` and
+  `event.isComposing`;
+- a capture-phase listener on the canvas element, installed by `app.ts`
+  monkey-patching `LGraphCanvas.prototype.processKey`, which executed only
+  bindings with `targetElementId: 'graph-canvas-container'`, checked
+  neither the modal state nor text-input focus, and called
+  `stopImmediatePropagation()` after executing.
+
+Undo and redo were never in the store at all. `Ctrl+Z`, `Ctrl+Y` and
+`Ctrl+Shift+Z` were hard-coded in two capture-phase listeners, one in
+`changeTracker.ts` for the graph and one in the mask editor's `useKeyboard`,
+each with its own idea of when a text input or a modal should block them.
+The `Comfy.Undo` and `Comfy.Redo` commands existed but were invisible to the
+shortcuts UI and could not be rebound or disabled.
+
+The only way to scope a binding was DOM containment, so the same combo could
+never serve both the workspace and a modal such as the mask editor: the store
+held one binding per combo, and the modal guard blocked every binding while
+any dialog was open.
+
+The original design document proposed adopting VS Code's model wholesale:
+reactive context keys, a `when`-clause grammar on bindings, and a single
+capture-phase dispatcher. An adversarial review of that design against this
+repository found that every binding that needs scoping today, and every
+scope an extension can realistically want, is "the dialog I opened", and
+that the capture flip would break at least seven deliberate local Escape
+and Delete handlers. This record adopts the smaller model that covers the
+same ground.
+
+## Decision
+
+### D1 — One dispatcher, window bubble phase
+
+`keybindingService.keybindHandler` is the only code that resolves a keydown
+against the store. The `processKey` lookup in `app.ts` is deleted;
+litegraph's own `processKey` is left untouched and remains the only
+canvas-phase keydown consumer (Space-to-pan, Escape cancels a link drag,
+`node.onKeyDown` fan-out).
+
+The dispatcher stays on the window in the bubble phase and skips any keydown
+whose `defaultPrevented` is already set. A listener on an element, on the
+document, or in the capture phase can therefore claim a key with
+`preventDefault()` instead of `stopPropagation()`. A bubble-phase window
+listener registered after app init cannot claim a key this way; it runs
+after the dispatcher.
+
+### D2 — A binding is scoped to a dialog and conditioned on context keys
+
+`Keybinding` gains two optional fields.
+
+- `dialogKey`: the `dialogStore` key of the dialog the binding belongs to. A
+  binding without one is a workspace binding, as before. A scoped binding is
+  looked up first and fires only while its dialog is the active (top-most)
+  one; a workspace binding fires only while no modal is open.
+- `when`: a conjunction of context keys, written `key && !otherKey`. The
+  grammar is deliberately that small: no disjunction, grouping or comparison,
+  so "same clause" is decidable by comparing canonical spellings. An `||` is
+  two bindings.
+
+Context keys are boolean and live in `contextKeyStore`. `modalOpen` and
+`textInputFocus` are built in and derived on every keydown. Core registers
+its own keys; an extension declares `contextKeys` on `registerExtension`,
+which registers them as `<extension name>.<key>`, and sets them through
+`app.extensionManager.contextKey.set`, which refuses core-owned keys. A
+clause naming a key nobody has registered never matches, negated or not, so
+a typo cannot enable a binding everywhere; a key registered later starts
+working when it appears.
+
+Resolution within one combo and scope: bindings with narrower clauses (more
+atoms) are tried first, user bindings before defaults at equal width, then
+registration order, and the first whose clause holds runs. Two bindings
+conflict only when combo, scope and clause are all identical. So
+`w → pan when ext.wasdMode` coexists with the core `w → toggle sidebar` and
+shadows it while the mode is on.
+
+Combos reserved by text inputs stay out of text-editing controls unless the
+clause names `textInputFocus`, which is how a binding opts into a textarea.
+
+The store keeps arrays keyed by binding identity (command, combo, target
+element, dialog key, clause) and derives the active set. The Edit Keybinding
+dialog carries scope and clause forward and reports a conflict only against
+an identical binding. Extension keybindings are validated at registration.
+`targetElementId` is unchanged and remains a dispatch-time containment check.
+
+### D3 — Guard policy is uniform and explicit
+
+| Guard                    | Window path before                                                                                  | `processKey` path before                                     | Now                                                                                                                                                                                                  |
+| ------------------------ | --------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Which bindings           | all                                                                                                 | canvas-scoped, then `stopImmediatePropagation`               | all, one path, never stops propagation                                                                                                                                                               |
+| `event.defaultPrevented` | ignored                                                                                             | ignored                                                      | skipped                                                                                                                                                                                              |
+| `event.isComposing`      | ignored                                                                                             | ignored                                                      | skipped                                                                                                                                                                                              |
+| `event.repeat`           | dispatched                                                                                          | skipped, then fell through to the window path and dispatched | dispatched                                                                                                                                                                                           |
+| Modal open               | workspace bindings blocked, `preventDefault` if Ctrl                                                | not checked                                                  | unchanged for workspace bindings; bindings scoped to the active dialog run                                                                                                                           |
+| Text input focus         | reserved combos blocked on `INPUT`, `TEXTAREA`, `contentEditable === 'true'`, `SPAN.property_value` | dead check                                                   | same set, except `INPUT` types that do not edit text (range, checkbox, radio, button, submit, reset, color, file, image) and inherited `isContentEditable`; a clause naming `textInputFocus` opts in |
+| Escape ownership         | `[role="menu"]`                                                                                     | none                                                         | `[role="menu"]` and `[data-dismissable-layer]`                                                                                                                                                       |
+| Unknown command          | throws after `preventDefault`                                                                       | throws                                                       | inert, console warning                                                                                                                                                                               |
+| `graph.change()`         | none                                                                                                | after the command                                            | litegraph's `processKey` still calls it before the command for canvas-targeted keydowns; every canvas command redraws on its own                                                                     |
+
+Behavior that changes for users as a result:
+
+- Escape while dragging a link cancels the drag without also exiting the
+  subgraph. litegraph prevents the default and the dispatcher now honours it.
+- Escape in a Vue node image gallery leaves the gallery without also exiting
+  the subgraph, for the same reason.
+- Escape inside a Reka popover, select, combobox or menu that has no local
+  `.stop` shield now dismisses the layer. Reka's dismissable layer listens on
+  the window in the bubble phase and defers when `defaultPrevented` is set,
+  so the dispatcher's own `preventDefault` used to suppress the dismiss.
+- Ctrl+Enter in the agent composer sends the message and no longer also
+  queues the workflow.
+- Bare-key shortcuts fire while a slider, checkbox or radio button has focus.
+  They already did while any non-input element had focus.
+- Ctrl+Enter in the batch-count input still queues; its handler now ignores
+  the Ctrl and Meta variants instead of preventing every Enter.
+
+### D4 — Undo and redo are bindings
+
+`Ctrl+Z`, `Ctrl+Y` and `Ctrl+Shift+Z` become default bindings on
+`Comfy.Undo` and `Comfy.Redo`. The mask editor gets its own
+`Comfy.MaskEditor.Undo` and `Comfy.MaskEditor.Redo` commands bound to the
+same combos with `dialogKey: 'global-mask-editor'`. Both hard-coded
+listeners lose their undo code, and the mask editor content root loses the
+`@keydown.stop` shield that kept those keys from reaching the window.
+
+Consequences for users:
+
+- Undo and redo are visible, rebindable and disableable in the shortcuts
+  UI, separately for the workspace and the mask editor.
+- Holding Ctrl+Z repeats undo, as in every other editor. `changeTracker`
+  suppressed repeats only as a side effect of its state-capture guard. A
+  graph restore already in flight ignores further undo and redo requests,
+  so repeats never interleave with an asynchronous load.
+- Ctrl+Z while typing in a mask-editor text or number input performs the
+  input's own undo. The old listener ignored focus entirely.
+- Ctrl+Z from an input with auto-queue in "change" mode no longer triggers
+  graph undo; that exemption belonged to state capture, not to undo.
+
+## Invariants
+
+- A keydown executes at most one binding.
+- A scoped binding never fires outside its dialog; a workspace binding
+  never fires while a modal is open.
+- A combo reserved by text inputs never fires from a text-editing control
+  unless its clause names `textInputFocus`.
+- A clause naming an unregistered context key never matches.
+- The dispatcher calls `preventDefault()` in exactly two cases: when it
+  executes a command, and when a Ctrl combo that a workspace binding would
+  claim arrives while a modal is open, so the browser does not act on it.
+- `dialogStore.activeKey` is the most recently activated dialog that is
+  still open. `closeDialog` previously promoted the oldest entry, which made
+  a covered dialog "active" at depth three.
+
+## Alternatives considered
+
+**`dialogKey` alone.** Shipped first and reviewed. It covered the mask
+editor and nothing else: an extension could scope only to a dialog it had
+opened, a WASD navigation mode over the already-bound `w`, `a` and `s` keys
+was inexpressible, and no binding could opt into a text input. Keeping
+`dialogKey` as the exact scope bucket and adding `when` on top costs a small
+parser and a key registry, and it is the direction that stays compatible
+with persisted data.
+
+**Capture-phase dispatcher.** Determinism by construction, at the cost of
+preempting every listener that today keeps a bound key from the dispatcher
+on purpose: ghost placement Escape/Delete/Backspace, image-preview Escape,
+bounding-box Delete, asset-grid Ctrl+A, tour Escape, legacy popup Escape,
+and every Reka `.escape.stop` shield. Each would need a context key or a
+rewrite before the flip. The four wins above do not need it.
+
+**Single `Comfy.Undo` with two bindings.** Avoids new command ids, but the
+keybinding panel would list `Ctrl+Z` twice under Undo and the two could not
+be rebound separately.
+
+## Consequences
+
+### Positive
+
+- One place decides whether a shortcut fires, with one documented guard set.
+- Local handlers claim keys with `preventDefault()`; `stopPropagation()`
+  shields are no longer required for correctness.
+- Same combo, different dialog, no conflict: extensions can bind inside
+  their own dialogs.
+- Undo and redo behave like every other shortcut.
+
+### Negative
+
+- Version skew is lossy. An older frontend drops `dialogKey`, drops unset
+  entries for commands it does not know and for combos that have no default
+  there (warning at each of its startups), and re-persists what it kept on
+  the next keybinding edit. A stripped binding for a command it lacks becomes
+  a live workspace shortcut that throws on that build. A user who customizes
+  undo or mask-editor undo and then edits keybindings on an older build
+  loses that customization.
+- An extension that declared a workspace binding on `Ctrl+Z`, `Ctrl+Y` or
+  `Ctrl+Shift+Z` now collides with a core default and is rejected with the
+  usual conflict toast, as it would be for any other core combo.
+- A DOM-only modal (legacy `.comfy-modal`, a native `<dialog>`, a hand-rolled
+  `aria-modal` overlay) raises the modal guard but never becomes the active
+  dialog, so a scoped binding under one would still fire. No such surface is
+  reachable from inside the mask editor today.
+- Escape inside any dismissable layer, including a dialog's own content, is
+  never dispatched, so a binding on bare Escape cannot be scoped to a dialog.
+
+## Non-goals
+
+- Hold bindings (Space-to-pan) and arbitrary context keys; `dialogKey`
+  covers the scopes in use.
+- A component-local `useKeybinding` composable, a dispatch trace mode, a
+  context inspector, a versioned settings key, preset-import review, or the
+  Edit Keybinding dialog's keyboard accessibility.
+- The three text surfaces that stop propagation for every key
+  (`WidgetMarkdown`, the markdown widget input, the bounding-box textarea);
+  they should stop only unmodified keys, independently of this record.

--- a/docs/adr/KEYBINDINGS-0027-context-keyed-keybinding-dispatch.md
+++ b/docs/adr/KEYBINDINGS-0027-context-keyed-keybinding-dispatch.md
@@ -1,4 +1,4 @@
-# 0027. Keybinding Dispatch and Dialog Scopes
+# KEYBINDINGS-0027: Context-Keyed Keybinding Dispatch
 
 Date: 2026-09-01
 
@@ -31,33 +31,47 @@ shortcuts UI and could not be rebound or disabled.
 The only way to scope a binding was DOM containment, so the same combo could
 never serve both the workspace and a modal such as the mask editor: the store
 held one binding per combo, and the modal guard blocked every binding while
-any dialog was open.
+any dialog was open. Around the store, an inventory found roughly a hundred
+keyboard-handling sites in some sixty-five files: twenty at window or
+document level, seven in the capture phase, and a dozen calling
+`stopPropagation` specifically to keep a key away from the central system.
+Each of the last three modal-guard fixes widened a DOM query to cover a
+dialog generation the previous one had missed.
 
-The original design document proposed adopting VS Code's model wholesale:
-reactive context keys, a `when`-clause grammar on bindings, and a single
-capture-phase dispatcher. An adversarial review of that design against this
-repository found that every binding that needs scoping today, and every
-scope an extension can realistically want, is "the dialog I opened", and
-that the capture flip would break at least seven deliberate local Escape
-and Delete handlers. This record adopts the smaller model that covers the
-same ground.
+The design document "Frontend Keybinding Architecture" proposes VS Code's
+model for this: reactive context keys owned by the code that owns the
+state, `when` clauses on bindings, one dispatcher that resolves user
+bindings before extension bindings before core defaults, and a dispatcher
+in the capture phase so that no listener needs `stopPropagation` to defend
+itself. This record adopts that model in full and sequences it. Every phase
+lands as its own change; the Rollout section says which phases the code
+accompanying this record already covers.
 
 ## Decision
 
-### D1 — One dispatcher, window bubble phase
+### D1 — One dispatcher
 
 `keybindingService.keybindHandler` is the only code that resolves a keydown
-against the store. The `processKey` lookup in `app.ts` is deleted;
-litegraph's own `processKey` is left untouched and remains the only
+against the store. The `processKey` lookup in `app.ts` is deleted.
+litegraph's own `processKey` is left untouched for now and remains the only
 canvas-phase keydown consumer (Space-to-pan, Escape cancels a link drag,
-`node.onKeyDown` fan-out).
+`node.onKeyDown` fan-out) until phase 6 turns those behaviours into
+bindings.
 
-The dispatcher stays on the window in the bubble phase and skips any keydown
-whose `defaultPrevented` is already set. A listener on an element, on the
-document, or in the capture phase can therefore claim a key with
-`preventDefault()` instead of `stopPropagation()`. A bubble-phase window
-listener registered after app init cannot claim a key this way; it runs
-after the dispatcher.
+The dispatcher runs on the window. When it executes a command it calls
+`preventDefault()`; it never calls `stopPropagation()`, so every listener
+after it can see what was claimed. It skips a keydown whose default was
+already prevented, so a listener on an element, on the document, or in the
+capture phase can claim a key with `preventDefault()` instead of
+`stopPropagation()`.
+
+It is registered in the bubble phase today. Phase 4 moves it to the capture
+phase, dark behind a hidden setting with a kill switch, once the
+preconditions under Rollout hold. Bubble is the rollout position, not the
+end state: as long as the dispatcher runs last, the seven capture-phase
+listeners in the app and every extension listener still preempt it, and
+ordering stays a property of registration order rather than of the
+resolver.
 
 ### D2 — A binding is scoped to a dialog and conditioned on context keys
 
@@ -69,8 +83,11 @@ after the dispatcher.
   one; a workspace binding fires only while no modal is open.
 - `when`: a conjunction of context keys, written `key && !otherKey`. The
   grammar is deliberately that small: no disjunction, grouping or comparison,
-  so "same clause" is decidable by comparing canonical spellings. An `||` is
-  two bindings.
+  so "same clause" is decidable by comparing canonical spellings and
+  conflict detection is exact rather than heuristic. An `||` is two
+  bindings. Widening the grammar later is backward compatible with every
+  persisted clause; narrowing it would not be, which is why it starts
+  narrow.
 
 Context keys are boolean and live in `contextKeyStore`. `modalOpen` and
 `textInputFocus` are built in and derived on every keydown. Core registers
@@ -79,14 +96,21 @@ which registers them as `<extension name>.<key>`, and sets them through
 `app.extensionManager.contextKey.set`, which refuses core-owned keys. A
 clause naming a key nobody has registered never matches, negated or not, so
 a typo cannot enable a binding everywhere; a key registered later starts
-working when it appears.
+working when it appears. The facade is global across extensions, as VS
+Code's `setContext` is: the extension API carries no caller identity, and
+extensions already run arbitrary JavaScript, so ownership is enforced at
+registration, where it prevents accidental collisions, and not at write
+time, where it could only be advisory.
 
 Resolution within one combo and scope: bindings with narrower clauses (more
 atoms) are tried first, user bindings before defaults at equal width, then
 registration order, and the first whose clause holds runs. Two bindings
 conflict only when combo, scope and clause are all identical. So
 `w → pan when ext.wasdMode` coexists with the core `w → toggle sidebar` and
-shadows it while the mode is on.
+shadows it while the mode is on. Phase 2 puts the binding's source ahead of
+clause width, so that a user's rebind always beats an extension's or core's
+narrower clause; until then a narrower default clause can outrank a broader
+user binding on the same combo.
 
 Combos reserved by text inputs stay out of text-editing controls unless the
 clause names `textInputFocus`, which is how a binding opts into a textarea.
@@ -165,7 +189,41 @@ Consequences for users:
   still open. `closeDialog` previously promoted the oldest entry, which made
   a covered dialog "active" at depth three.
 
+## Rollout
+
+Phases are ordered by dependency. Each is its own change.
+
+| Phase | What                                                                                                                                                                                                                | Status                       |
+| ----- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------- |
+| 1     | Context key store, `when` parser, `dialogKey`, extension-registered keys                                                                                                                                            | Done, preceding change       |
+| 2     | Store rework: several bindings per combo, a `source` on every binding, resolution by source tier (user, extension, core) before clause width, attributable conflict reporting                                       | Next change                  |
+| 3     | One dispatcher with the guard matrix in D3                                                                                                                                                                          | Done, this change            |
+| 4     | Capture-phase dispatcher behind a hidden setting with a kill switch; `data-comfy-keybinding-ignore` escape hatch checked via `composedPath()`; `processKey` kept as a deprecated shim for one cycle                 | Pending; preconditions below |
+| 5     | Undo and redo as bindings (D4)                                                                                                                                                                                      | Done, following change       |
+| 6     | Hold bindings with press and release commands and guaranteed release on blur (Space-to-pan); canvas Escape variants as context-scoped bindings; a `useKeybinding` composable for component-local bindings           | Pending                      |
+| —     | Versioned settings key for scoped bindings, with the legacy `NewBindings` key kept as a lossy mirror, so an older frontend cannot strip `when` or `dialogKey` and re-persist the result; preset import shows a diff | Pending                      |
+| —     | Dispatch trace mode, context-key inspector, persistent conflict reporting in the shortcuts panel, keyboard accessibility of the Edit Keybinding dialog                                                              | Pending                      |
+
+Preconditions for phase 4. A capture-phase dispatcher runs before every
+local handler, so a `preventDefault()` claim no longer reaches it. Each of
+the following either raises a context key or carries the escape hatch
+before the flip: ghost placement Escape, Delete and Backspace; image-preview
+Escape; the bounding-box Delete; the asset-grid Ctrl+A; the tour Escape; the
+legacy popup Escape; and every Reka `.escape.stop` shield. Three e2e specs
+land first: Escape in a popover inside a subgraph, no double dispatch of a
+canvas-scoped binding, and Ctrl+Z in the mask editor. The flip is tested
+against rgthree-comfy and ComfyUI-Custom-Scripts, which patch `processKey`
+and listen on the window respectively.
+
 ## Alternatives considered
+
+**Bubble phase as the end state.** It delivers the guard unification and
+the dialog scoping in this change with no ecosystem exposure, and it is
+where the code stands today. As an end state it leaves the seven
+capture-phase listeners and every extension listener ahead of the
+dispatcher, so determinism stays conditional and every new surface keeps
+needing a shield. Rejected as the end state; adopted as the rollout position
+until the phase 4 preconditions hold.
 
 **`dialogKey` alone.** Shipped first and reviewed. It covered the mask
 editor and nothing else: an extension could scope only to a dialog it had
@@ -175,12 +233,11 @@ was inexpressible, and no binding could opt into a text input. Keeping
 parser and a key registry, and it is the direction that stays compatible
 with persisted data.
 
-**Capture-phase dispatcher.** Determinism by construction, at the cost of
-preempting every listener that today keeps a bound key from the dispatcher
-on purpose: ghost placement Escape/Delete/Backspace, image-preview Escape,
-bounding-box Delete, asset-grid Ctrl+A, tour Escape, legacy popup Escape,
-and every Reka `.escape.stop` shield. Each would need a context key or a
-rewrite before the flip. The four wins above do not need it.
+**The full VS Code clause grammar.** Disjunction, grouping and comparison
+make "do these two clauses overlap" a heuristic, so conflict detection
+would degrade to best-effort warnings. Restricting to conjunctions keeps it
+exact, and the restriction can be lifted later without touching persisted
+data.
 
 **Single `Comfy.Undo` with two bindings.** Avoids new command ids, but the
 keybinding panel would list `Ctrl+Z` twice under Undo and the two could not
@@ -199,30 +256,23 @@ be rebound separately.
 
 ### Negative
 
-- Version skew is lossy. An older frontend drops `dialogKey`, drops unset
-  entries for commands it does not know and for combos that have no default
-  there (warning at each of its startups), and re-persists what it kept on
-  the next keybinding edit. A stripped binding for a command it lacks becomes
-  a live workspace shortcut that throws on that build. A user who customizes
-  undo or mask-editor undo and then edits keybindings on an older build
-  loses that customization.
-- An extension that declared a workspace binding on `Ctrl+Z`, `Ctrl+Y` or
-  `Ctrl+Shift+Z` now collides with a core default and is rejected with the
-  usual conflict toast, as it would be for any other core combo.
+- Until the versioned settings key lands, version skew is lossy. An older
+  frontend drops `dialogKey` and `when`, drops unset entries for commands it
+  does not know and for combos that have no default there (warning at each
+  of its startups), and re-persists what it kept on the next keybinding
+  edit. A stripped binding for a command it lacks becomes a live workspace
+  shortcut that throws on that build. A user who customizes undo or
+  mask-editor undo and then edits keybindings on an older build loses that
+  customization.
+- Until phase 2 lands, an extension that declared a workspace binding on
+  `Ctrl+Z`, `Ctrl+Y` or `Ctrl+Shift+Z` collides with the new core default
+  and is rejected with the usual conflict toast.
 - A DOM-only modal (legacy `.comfy-modal`, a native `<dialog>`, a hand-rolled
   `aria-modal` overlay) raises the modal guard but never becomes the active
   dialog, so a scoped binding under one would still fire. No such surface is
   reachable from inside the mask editor today.
 - Escape inside any dismissable layer, including a dialog's own content, is
   never dispatched, so a binding on bare Escape cannot be scoped to a dialog.
-
-## Non-goals
-
-- Hold bindings (Space-to-pan) and arbitrary context keys; `dialogKey`
-  covers the scopes in use.
-- A component-local `useKeybinding` composable, a dispatch trace mode, a
-  context inspector, a versioned settings key, preset-import review, or the
-  Edit Keybinding dialog's keyboard accessibility.
 - The three text surfaces that stop propagation for every key
-  (`WidgetMarkdown`, the markdown widget input, the bounding-box textarea);
-  they should stop only unmodified keys, independently of this record.
+  (`WidgetMarkdown`, the markdown widget input, the bounding-box textarea)
+  should stop only unmodified keys; that is independent of this record.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -32,7 +32,7 @@ An Architecture Decision Record captures an important architectural decision mad
 | [EXTENSIONS-PUBLIC-API-0005](EXTENSIONS-PUBLIC-API-0005-bundle-vue-dependencies-in-extensions.md)                | Bundle Vue Dependencies in Extensions                                              | Accepted | 2025-12-13 |
 | [GRAPH-DOCUMENT-0024](GRAPH-DOCUMENT-0024-graph-activation-and-document-objects-for-in-app-agent-targets.md)     | Graph Activation and Document Objects for In-App Agent Targets                     | Proposed | 2026-08-28 |
 | [GRAPH-DOCUMENT-0026](GRAPH-DOCUMENT-0026-frontend-document-model.md)                                            | Frontend Document Model                                                            | Proposed | 2026-08-31 |
-| [KEYBINDINGS-0027](0027-keybinding-dispatch-and-dialog-scopes.md) | Context-Keyed Keybinding Dispatch | Proposed | 2026-09-01 |
+| [KEYBINDINGS-0027](KEYBINDINGS-0027-context-keyed-keybinding-dispatch.md) | Context-Keyed Keybinding Dispatch | Proposed | 2026-09-01 |
 | [NODE-OUTPUTS-0007](NODE-OUTPUTS-0007-output-passthrough-for-extensible-nodes.md)                                | Output Passthrough for Extensible Nodes                                            | Accepted | 2026-03-11 |
 | [PERF-BENCHMARKS-0022](PERF-BENCHMARKS-0022-performance-evidence-and-regression-framework.md)                    | Performance Evidence and Regression Framework                                      | Proposed | 2026-08-26 |
 | [RELEASES-CHANGELOG-0012](RELEASES-CHANGELOG-0012-cloud-release-notes-follow-the-comfyui-version.md)             | Cloud Release Notes Follow the ComfyUI Version                                     | Accepted | 2026-07-13 |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -32,6 +32,7 @@ An Architecture Decision Record captures an important architectural decision mad
 | [EXTENSIONS-PUBLIC-API-0005](EXTENSIONS-PUBLIC-API-0005-bundle-vue-dependencies-in-extensions.md)                | Bundle Vue Dependencies in Extensions                                              | Accepted | 2025-12-13 |
 | [GRAPH-DOCUMENT-0024](GRAPH-DOCUMENT-0024-graph-activation-and-document-objects-for-in-app-agent-targets.md)     | Graph Activation and Document Objects for In-App Agent Targets                     | Proposed | 2026-08-28 |
 | [GRAPH-DOCUMENT-0026](GRAPH-DOCUMENT-0026-frontend-document-model.md)                                            | Frontend Document Model                                                            | Proposed | 2026-08-31 |
+| [KEYBINDINGS-0027](0027-keybinding-dispatch-and-dialog-scopes.md) | Context-Keyed Keybinding Dispatch | Proposed | 2026-09-01 |
 | [NODE-OUTPUTS-0007](NODE-OUTPUTS-0007-output-passthrough-for-extensible-nodes.md)                                | Output Passthrough for Extensible Nodes                                            | Accepted | 2026-03-11 |
 | [PERF-BENCHMARKS-0022](PERF-BENCHMARKS-0022-performance-evidence-and-regression-framework.md)                    | Performance Evidence and Regression Framework                                      | Proposed | 2026-08-26 |
 | [RELEASES-CHANGELOG-0012](RELEASES-CHANGELOG-0012-cloud-release-notes-follow-the-comfyui-version.md)             | Cloud Release Notes Follow the ComfyUI Version                                     | Accepted | 2026-07-13 |

--- a/src/components/actionbar/BatchCountEdit.test.ts
+++ b/src/components/actionbar/BatchCountEdit.test.ts
@@ -82,4 +82,43 @@ describe('BatchCountEdit', () => {
     expect(queueSettingsStore.batchCount).toBe(1)
     expect(input).toHaveValue('1')
   })
+
+  function recordNextEnter(): { prevented: boolean | undefined } {
+    const record: { prevented: boolean | undefined } = { prevented: undefined }
+    const listener = (event: KeyboardEvent) => {
+      if (event.key !== 'Enter') return
+      record.prevented = event.defaultPrevented
+      window.removeEventListener('keydown', listener)
+    }
+    window.addEventListener('keydown', listener)
+    return record
+  }
+
+  it('commits the typed value on Ctrl+Enter without claiming the keydown', async () => {
+    const { user, queueSettingsStore } = renderComponent(3)
+    const input = screen.getByRole('textbox', { name: 'Batch Count' })
+    await user.clear(input)
+    await user.type(input, '8')
+    const enter = recordNextEnter()
+
+    await user.keyboard('{Control>}{Enter}{/Control}')
+
+    expect(queueSettingsStore.batchCount).toBe(8)
+    expect(enter.prevented).toBe(false)
+    expect(input).not.toHaveFocus()
+  })
+
+  it('claims a plain Enter and commits the typed value', async () => {
+    const { user, queueSettingsStore } = renderComponent(3)
+    const input = screen.getByRole('textbox', { name: 'Batch Count' })
+    await user.clear(input)
+    await user.type(input, '8')
+    const enter = recordNextEnter()
+
+    await user.keyboard('{Enter}')
+
+    expect(queueSettingsStore.batchCount).toBe(8)
+    expect(enter.prevented).toBe(true)
+    expect(input).not.toHaveFocus()
+  })
 })

--- a/src/components/actionbar/BatchCountEdit.vue
+++ b/src/components/actionbar/BatchCountEdit.vue
@@ -20,7 +20,7 @@
         @focus="onInputFocus"
         @input="onInput"
         @blur="onInputBlur"
-        @keydown.enter.prevent="onInputEnter"
+        @keydown.enter="onInputEnter"
       />
       <div class="flex h-full w-6 flex-col">
         <Button
@@ -123,7 +123,8 @@ const onInputBlur = () => {
   setBatchCount(Number.isNaN(parsedInput) ? minQueueCount : parsedInput)
 }
 
-const onInputEnter = () => {
+const onInputEnter = (event: KeyboardEvent) => {
+  if (!event.ctrlKey && !event.metaKey) event.preventDefault()
   batchCountInputRef.value?.blur()
 }
 </script>

--- a/src/platform/keybindings/keybindingService.canvas.test.ts
+++ b/src/platform/keybindings/keybindingService.canvas.test.ts
@@ -52,6 +52,7 @@ describe('keybindingService - Canvas Keybindings', () => {
   beforeEach(() => {
     const commandStore = useCommandStore()
     commandStore.execute = vi.fn()
+    commandStore.isRegistered = () => true
 
     Object.assign(useDialogStore(), { dialogStack: [] })
 

--- a/src/platform/keybindings/keybindingService.dialog.test.ts
+++ b/src/platform/keybindings/keybindingService.dialog.test.ts
@@ -37,6 +37,7 @@ describe('keybindingService - dialog gate', () => {
 
   beforeEach(() => {
     vi.mocked(useCommandStore().execute).mockResolvedValue(undefined)
+    vi.spyOn(useCommandStore(), 'isRegistered').mockReturnValue(true)
 
     const dialogStore = useDialogStore()
     dialogStore.dialogStack.length = 0

--- a/src/platform/keybindings/keybindingService.dispatch.test.ts
+++ b/src/platform/keybindings/keybindingService.dispatch.test.ts
@@ -1,0 +1,288 @@
+import { markRaw } from 'vue'
+import type { Mock } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useContextKeyStore } from '@/platform/keybindings/contextKeyStore'
+import { KeybindingImpl } from '@/platform/keybindings/keybinding'
+import { useKeybindingService } from '@/platform/keybindings/keybindingService'
+import { useKeybindingStore } from '@/platform/keybindings/keybindingStore'
+import { useCommandStore } from '@/stores/commandStore'
+import { useDialogStore } from '@/stores/dialogStore'
+
+const MASK_EDITOR = 'global-mask-editor'
+const dialogComponent = markRaw({ template: '<div />' })
+
+function keydown(
+  target: EventTarget,
+  init: KeyboardEventInit & { key: string }
+): KeyboardEvent {
+  const event = new KeyboardEvent('keydown', {
+    bubbles: true,
+    cancelable: true,
+    ...init
+  })
+  target.dispatchEvent(event)
+  return event
+}
+
+describe('keybindingService dispatch', () => {
+  let handler: (event: KeyboardEvent) => Promise<void>
+  let undo: Mock<() => void>
+  let maskEditorUndo: Mock<() => void>
+  let exitSubgraph: Mock<() => void>
+  let sidebar: Mock<() => void>
+  let pan: Mock<() => void>
+  let never: Mock<() => void>
+  let textCommand: Mock<() => void>
+
+  beforeEach(() => {
+    const commandStore = useCommandStore()
+    undo = vi.fn<() => void>()
+    maskEditorUndo = vi.fn<() => void>()
+    exitSubgraph = vi.fn<() => void>()
+    sidebar = vi.fn<() => void>()
+    pan = vi.fn<() => void>()
+    never = vi.fn<() => void>()
+    textCommand = vi.fn<() => void>()
+    commandStore.registerCommands([
+      { id: 'test.undo', function: undo },
+      { id: 'test.maskEditor.undo', function: maskEditorUndo },
+      { id: 'test.exitSubgraph', function: exitSubgraph },
+      { id: 'test.sidebar', function: sidebar },
+      { id: 'test.pan', function: pan },
+      { id: 'test.never', function: never },
+      { id: 'test.textCommand', function: textCommand }
+    ])
+    useContextKeyStore().register('ext.wasdMode', 'ext')
+
+    const keybindingStore = useKeybindingStore()
+    keybindingStore.addDefaultKeybinding(
+      new KeybindingImpl({
+        commandId: 'test.undo',
+        combo: { key: 'z', ctrl: true }
+      })
+    )
+    keybindingStore.addDefaultKeybinding(
+      new KeybindingImpl({
+        commandId: 'test.maskEditor.undo',
+        combo: { key: 'z', ctrl: true },
+        dialogKey: MASK_EDITOR
+      })
+    )
+    keybindingStore.addDefaultKeybinding(
+      new KeybindingImpl({
+        commandId: 'test.exitSubgraph',
+        combo: { key: 'Escape' }
+      })
+    )
+    keybindingStore.addDefaultKeybinding(
+      new KeybindingImpl({ commandId: 'test.sidebar', combo: { key: 'w' } })
+    )
+    keybindingStore.addDefaultKeybinding(
+      new KeybindingImpl({
+        commandId: 'test.pan',
+        combo: { key: 'w' },
+        when: 'ext.wasdMode'
+      })
+    )
+    keybindingStore.addDefaultKeybinding(
+      new KeybindingImpl({
+        commandId: 'test.never',
+        combo: { key: 'w' },
+        when: 'ext.missing'
+      })
+    )
+    keybindingStore.addDefaultKeybinding(
+      new KeybindingImpl({
+        commandId: 'test.textCommand',
+        combo: { key: 'ArrowUp', ctrl: true },
+        when: 'textInputFocus'
+      })
+    )
+
+    handler = useKeybindingService().keybindHandler
+    window.addEventListener('keydown', handler)
+  })
+
+  afterEach(() => {
+    window.removeEventListener('keydown', handler)
+  })
+
+  it('runs the workspace binding when no dialog is open', () => {
+    const event = keydown(document.body, { key: 'z', ctrlKey: true })
+
+    expect(undo).toHaveBeenCalledOnce()
+    expect(maskEditorUndo).not.toHaveBeenCalled()
+    expect(event.defaultPrevented).toBe(true)
+  })
+
+  it('skips a keydown another handler already claimed', () => {
+    const claimant = document.createElement('div')
+    document.body.appendChild(claimant)
+    claimant.addEventListener('keydown', (event) => event.preventDefault())
+
+    keydown(claimant, { key: 'z', ctrlKey: true })
+
+    expect(undo).not.toHaveBeenCalled()
+    claimant.remove()
+  })
+
+  it('skips composition keydowns', () => {
+    keydown(document.body, { key: 'z', ctrlKey: true, isComposing: true })
+
+    expect(undo).not.toHaveBeenCalled()
+  })
+
+  it('runs the binding scoped to the active dialog instead of the workspace one', () => {
+    useDialogStore().showDialog({
+      key: MASK_EDITOR,
+      component: dialogComponent
+    })
+
+    const event = keydown(document.body, { key: 'z', ctrlKey: true })
+
+    expect(maskEditorUndo).toHaveBeenCalledOnce()
+    expect(undo).not.toHaveBeenCalled()
+    expect(event.defaultPrevented).toBe(true)
+  })
+
+  it('blocks the scoped binding while another dialog covers its dialog', () => {
+    const dialogStore = useDialogStore()
+    dialogStore.showDialog({ key: MASK_EDITOR, component: dialogComponent })
+    dialogStore.showDialog({ key: 'confirm', component: dialogComponent })
+
+    keydown(document.body, { key: 'z', ctrlKey: true })
+
+    expect(maskEditorUndo).not.toHaveBeenCalled()
+    expect(undo).not.toHaveBeenCalled()
+  })
+
+  it('keeps the scoped binding blocked when the top of three dialogs closes', () => {
+    const dialogStore = useDialogStore()
+    dialogStore.showDialog({ key: MASK_EDITOR, component: dialogComponent })
+    dialogStore.showDialog({ key: 'confirm', component: dialogComponent })
+    dialogStore.showDialog({ key: 'tooltip', component: dialogComponent })
+    dialogStore.closeDialog({ key: 'tooltip' })
+
+    keydown(document.body, { key: 'z', ctrlKey: true })
+
+    expect(maskEditorUndo).not.toHaveBeenCalled()
+
+    dialogStore.closeDialog({ key: 'confirm' })
+    keydown(document.body, { key: 'z', ctrlKey: true })
+
+    expect(maskEditorUndo).toHaveBeenCalledOnce()
+  })
+
+  it('does not run a scoped binding from a text input', () => {
+    useDialogStore().showDialog({
+      key: MASK_EDITOR,
+      component: dialogComponent
+    })
+    const input = document.createElement('input')
+    input.type = 'number'
+    document.body.appendChild(input)
+
+    keydown(input, { key: 'z', ctrlKey: true })
+
+    expect(maskEditorUndo).not.toHaveBeenCalled()
+    input.remove()
+  })
+
+  it('treats a descendant of an editable region as a text input', () => {
+    const editor = document.createElement('div')
+    editor.contentEditable = 'true'
+    const span = document.createElement('span')
+    editor.appendChild(span)
+    document.body.appendChild(editor)
+
+    keydown(span, { key: 'z', ctrlKey: true })
+
+    expect(undo).not.toHaveBeenCalled()
+    editor.remove()
+  })
+
+  it('dispatches key repeats', () => {
+    keydown(document.body, { key: 'z', ctrlKey: true, repeat: true })
+
+    expect(undo).toHaveBeenCalledOnce()
+  })
+
+  it('does not treat a slider as a text input', () => {
+    const slider = document.createElement('input')
+    slider.type = 'range'
+    document.body.appendChild(slider)
+
+    keydown(slider, { key: 'z', ctrlKey: true })
+
+    expect(undo).toHaveBeenCalledOnce()
+    slider.remove()
+  })
+
+  it('runs the narrower binding while its context key holds', () => {
+    const contextKeys = useContextKeyStore()
+
+    keydown(document.body, { key: 'w' })
+    expect(sidebar).toHaveBeenCalledOnce()
+    expect(pan).not.toHaveBeenCalled()
+
+    contextKeys.set('ext.wasdMode', true)
+    keydown(document.body, { key: 'w' })
+    expect(pan).toHaveBeenCalledOnce()
+    expect(sidebar).toHaveBeenCalledOnce()
+
+    contextKeys.set('ext.wasdMode', false)
+    keydown(document.body, { key: 'w' })
+    expect(sidebar).toHaveBeenCalledTimes(2)
+  })
+
+  it('never runs a binding whose context key nobody registered', () => {
+    keydown(document.body, { key: 'w' })
+
+    expect(never).not.toHaveBeenCalled()
+    expect(sidebar).toHaveBeenCalledOnce()
+  })
+
+  it('lets a clause opt a reserved combo into text inputs', () => {
+    const textarea = document.createElement('textarea')
+    document.body.appendChild(textarea)
+
+    keydown(textarea, { key: 'ArrowUp', ctrlKey: true })
+    expect(textCommand).toHaveBeenCalledOnce()
+
+    keydown(document.body, { key: 'ArrowUp', ctrlKey: true })
+    expect(textCommand).toHaveBeenCalledOnce()
+    textarea.remove()
+  })
+
+  it('leaves Escape to a dismissable layer', () => {
+    const layer = document.createElement('div')
+    layer.setAttribute('data-dismissable-layer', '')
+    const button = document.createElement('button')
+    layer.appendChild(button)
+    document.body.appendChild(layer)
+
+    const event = keydown(button, { key: 'Escape' })
+
+    expect(exitSubgraph).not.toHaveBeenCalled()
+    expect(event.defaultPrevented).toBe(false)
+    layer.remove()
+  })
+
+  it('leaves a binding to an unregistered command inert', () => {
+    useKeybindingStore().addUserKeybinding(
+      new KeybindingImpl({
+        commandId: 'test.missing',
+        combo: { key: 'k', ctrl: true }
+      })
+    )
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const event = keydown(document.body, { key: 'k', ctrlKey: true })
+
+    expect(event.defaultPrevented).toBe(false)
+    expect(console.warn).toHaveBeenCalledWith(
+      expect.stringContaining('test.missing')
+    )
+  })
+})

--- a/src/platform/keybindings/keybindingService.escape.test.ts
+++ b/src/platform/keybindings/keybindingService.escape.test.ts
@@ -41,6 +41,7 @@ describe('keybindingService - Escape key handling', () => {
 
   beforeEach(() => {
     vi.mocked(useCommandStore().execute).mockResolvedValue(undefined)
+    vi.spyOn(useCommandStore(), 'isRegistered').mockReturnValue(true)
 
     const dialogStore = useDialogStore()
     dialogStore.dialogStack.length = 0

--- a/src/platform/keybindings/keybindingService.ts
+++ b/src/platform/keybindings/keybindingService.ts
@@ -4,97 +4,182 @@ import { useCommandStore } from '@/stores/commandStore'
 import { useDialogStore } from '@/stores/dialogStore'
 import { isModalOpen } from '@/utils/modalUtil'
 
+import type { ContextSnapshot } from './contextKeyStore'
+import { useContextKeyStore } from './contextKeyStore'
 import { CORE_KEYBINDINGS } from './defaults'
 import { KeyComboImpl } from './keyCombo'
 import { KeybindingImpl } from './keybinding'
 import { useKeybindingStore } from './keybindingStore'
+import { matchesContext, parseWhenClause } from './whenClause'
+
+const RUN_COMMAND_IDS = new Set([
+  'Comfy.QueuePrompt',
+  'Comfy.QueuePromptFront',
+  'Comfy.QueueSelectedOutputNodes'
+])
+
+const NON_TEXT_INPUT_TYPES = new Set([
+  'button',
+  'checkbox',
+  'color',
+  'file',
+  'image',
+  'radio',
+  'range',
+  'reset',
+  'submit'
+])
+
+function isTextInput(target: Element): boolean {
+  if (target instanceof HTMLInputElement) {
+    return !NON_TEXT_INPUT_TYPES.has(target.type)
+  }
+  return (
+    target.tagName === 'TEXTAREA' ||
+    (target instanceof HTMLElement && target.isContentEditable) ||
+    (target.tagName === 'SPAN' && target.classList.contains('property_value'))
+  )
+}
+
+/** Menus and Reka dismissable layers own Escape. */
+function ownsEscape(target: Element): boolean {
+  return target.closest('[role="menu"], [data-dismissable-layer]') !== null
+}
+
+function isWithinTargetElement(
+  keybinding: KeybindingImpl,
+  target: Element
+): boolean {
+  if (!keybinding.targetElementId) return true
+  const targetElementId =
+    keybinding.targetElementId === 'graph-canvas'
+      ? 'graph-canvas-container'
+      : keybinding.targetElementId
+  return document.getElementById(targetElementId)?.contains(target) ?? false
+}
+
+/** Reserved combos stay out of text inputs unless the clause asks for one. */
+function clauseHolds(
+  keybinding: KeybindingImpl,
+  context: ContextSnapshot
+): boolean {
+  const parsed =
+    keybinding.when === undefined ? undefined : parseWhenClause(keybinding.when)
+  if (parsed && !parsed.success) return false
+  const clause = parsed?.clause ?? []
+  if (
+    context.textInputFocus &&
+    keybinding.combo.isReservedByTextInput &&
+    !clause.some((atom) => atom.key === 'textInputFocus')
+  ) {
+    return false
+  }
+  return matchesContext(clause, context)
+}
+
+function closeLegacyModals() {
+  const modals = document.querySelectorAll<HTMLElement>('.comfy-modal')
+  for (const modal of modals) {
+    const modalDisplay = window
+      .getComputedStyle(modal)
+      .getPropertyValue('display')
+
+    if (modalDisplay !== 'none') {
+      modal.style.display = 'none'
+      break
+    }
+  }
+
+  for (const d of document.querySelectorAll('dialog')) d.close()
+}
 
 export function useKeybindingService() {
   const keybindingStore = useKeybindingStore()
   const commandStore = useCommandStore()
   const settingStore = useSettingStore()
   const dialogStore = useDialogStore()
+  const contextKeyStore = useContextKeyStore()
+
+  function buildContext(target: Element): ContextSnapshot {
+    return {
+      ...contextKeyStore.snapshot(),
+      modalOpen: isModalOpen(dialogStore.dialogStack.length),
+      textInputFocus: isTextInput(target)
+    }
+  }
+
+  async function execute(keybinding: KeybindingImpl, event: KeyboardEvent) {
+    if (!commandStore.isRegistered(keybinding.commandId)) {
+      console.warn(
+        `Keybinding ${keybinding.combo} targets unknown command ${keybinding.commandId}`
+      )
+      return
+    }
+    event.preventDefault()
+    if (RUN_COMMAND_IDS.has(keybinding.commandId)) {
+      await commandStore.execute(keybinding.commandId, {
+        metadata: {
+          trigger_source: 'keybinding'
+        }
+      })
+    } else {
+      await commandStore.execute(keybinding.commandId)
+    }
+  }
 
   async function keybindHandler(event: KeyboardEvent) {
+    if (event.defaultPrevented || event.isComposing) return
+
     const keyCombo = KeyComboImpl.fromEvent(event)
-    if (keyCombo.isModifier) {
+    if (keyCombo.isModifier) return
+
+    const target = event.composedPath()[0]
+    if (!(target instanceof Element)) return
+    if (event.key === 'Escape' && ownsEscape(target)) return
+
+    const context = buildContext(target)
+    const activeDialogKey = dialogStore.activeKey ?? undefined
+    const scoped =
+      activeDialogKey === undefined
+        ? undefined
+        : keybindingStore
+            .getKeybindings(keyCombo, activeDialogKey)
+            .find(
+              (binding) =>
+                isWithinTargetElement(binding, target) &&
+                clauseHolds(binding, context)
+            )
+    if (scoped) {
+      await execute(scoped, event)
       return
     }
 
-    const target = event.composedPath()[0] as HTMLElement
-    // Let the active menu own Escape without also triggering the global shortcut.
-    if (event.key === 'Escape' && target.closest('[role="menu"]')) {
-      return
-    }
-
-    if (
-      keyCombo.isReservedByTextInput &&
-      (target.tagName === 'TEXTAREA' ||
-        target.tagName === 'INPUT' ||
-        target.contentEditable === 'true' ||
-        (target.tagName === 'SPAN' &&
-          target.classList.contains('property_value')))
-    ) {
-      return
-    }
-
-    const keybinding = keybindingStore.getKeybinding(keyCombo)
-    if (keybinding) {
-      const targetElementId =
-        keybinding.targetElementId === 'graph-canvas'
-          ? 'graph-canvas-container'
-          : keybinding.targetElementId
-      if (targetElementId) {
-        const container = document.getElementById(targetElementId)
-        if (!container?.contains(target)) {
-          return
-        }
-      }
-      if (isModalOpen(dialogStore.dialogStack.length)) {
-        // Bare keys still have to reach inputs inside the dialog.
-        if (keyCombo.ctrl) {
-          event.preventDefault()
-        }
-        return
-      }
-
-      event.preventDefault()
-      const runCommandIds = new Set([
-        'Comfy.QueuePrompt',
-        'Comfy.QueuePromptFront',
-        'Comfy.QueueSelectedOutputNodes'
-      ])
-      if (runCommandIds.has(keybinding.commandId)) {
-        await commandStore.execute(keybinding.commandId, {
-          metadata: {
-            trigger_source: 'keybinding'
-          }
-        })
-      } else {
-        await commandStore.execute(keybinding.commandId)
+    const candidates = keybindingStore
+      .getKeybindings(keyCombo)
+      .filter((binding) => isWithinTargetElement(binding, target))
+    const keybinding = candidates.find((binding) =>
+      clauseHolds(binding, context)
+    )
+    if (!keybinding) {
+      const bare = !keyCombo.ctrl && !keyCombo.alt
+      const inTextInput =
+        keyCombo.isReservedByTextInput && context.textInputFocus
+      if (
+        candidates.length === 0 &&
+        event.key === 'Escape' &&
+        bare &&
+        !inTextInput
+      ) {
+        closeLegacyModals()
       }
       return
     }
-
-    if (event.ctrlKey || event.altKey || event.metaKey) {
+    if (context.modalOpen) {
+      // Bare keys still have to reach inputs inside the dialog.
+      if (keyCombo.ctrl) event.preventDefault()
       return
     }
-
-    if (event.key === 'Escape') {
-      const modals = document.querySelectorAll<HTMLElement>('.comfy-modal')
-      for (const modal of modals) {
-        const modalDisplay = window
-          .getComputedStyle(modal)
-          .getPropertyValue('display')
-
-        if (modalDisplay !== 'none') {
-          modal.style.display = 'none'
-          break
-        }
-      }
-
-      for (const d of document.querySelectorAll('dialog')) d.close()
-    }
+    await execute(keybinding, event)
   }
 
   function registerCoreKeybindings() {

--- a/src/platform/keybindings/keybindingStore.ts
+++ b/src/platform/keybindings/keybindingStore.ts
@@ -113,16 +113,6 @@ export const useKeybindingStore = defineStore('keybinding', () => {
     return keybindingsByScope.value[scopeKey(combo, dialogKey)] ?? []
   }
 
-  /** The binding a dispatcher that does not evaluate clauses should run. */
-  function getKeybinding(
-    combo: KeyComboImpl,
-    dialogKey?: string
-  ): KeybindingImpl | undefined {
-    return getKeybindings(combo, dialogKey).find(
-      (binding) => binding.when === undefined
-    )
-  }
-
   function findConflictingKeybinding(
     keybinding: KeybindingImpl
   ): KeybindingImpl | undefined {
@@ -314,7 +304,6 @@ export const useKeybindingStore = defineStore('keybinding', () => {
     keybindings,
     getUserKeybindings,
     getUserUnsetKeybindings,
-    getKeybinding,
     getKeybindings,
     findConflictingKeybinding,
     getKeybindingsByCommandId,

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -89,7 +89,6 @@ import { useExtensionService } from '@/services/extensionService'
 import { useLitegraphService } from '@/services/litegraphService'
 import { useSubgraphService } from '@/services/subgraphService'
 import { useApiKeyAuthStore } from '@/stores/apiKeyAuthStore'
-import { useCommandStore } from '@/stores/commandStore'
 import { useDomWidgetStore } from '@/stores/domWidgetStore'
 import { useExecutionStore } from '@/stores/executionStore'
 import { useExecutionErrorStore } from '@/stores/executionErrorStore'
@@ -101,8 +100,6 @@ import {
   getAncestorExecutionIds,
   tryNormalizeNodeExecutionId
 } from '@/types/nodeIdentification'
-import { KeyComboImpl } from '@/platform/keybindings/keyCombo'
-import { useKeybindingStore } from '@/platform/keybindings/keybindingStore'
 import { SYSTEM_NODE_DEFS, useNodeDefStore } from '@/stores/nodeDefStore'
 import { useNodeReplacementStore } from '@/platform/nodeReplacement/nodeReplacementStore'
 
@@ -822,41 +819,6 @@ export class ComfyApp {
   }
 
   /**
-   * Handle keypress
-   */
-  private addProcessKeyHandler() {
-    const origProcessKey = LGraphCanvas.prototype.processKey
-    LGraphCanvas.prototype.processKey = function (e: KeyboardEvent) {
-      if (!this.graph) return
-
-      if (e.target instanceof Element && e.target.localName == 'input') {
-        return
-      }
-
-      if (e.type == 'keydown' && !e.repeat) {
-        const keyCombo = KeyComboImpl.fromEvent(e)
-        const keybindingStore = useKeybindingStore()
-        const keybinding = keybindingStore.getKeybinding(keyCombo)
-
-        if (
-          keybinding &&
-          keybinding.targetElementId === 'graph-canvas-container'
-        ) {
-          useCommandStore().execute(keybinding.commandId)
-
-          this.graph.change()
-          e.preventDefault()
-          e.stopImmediatePropagation()
-          return
-        }
-      }
-
-      // Fall through to Litegraph defaults
-      return origProcessKey.apply(this, [e])
-    }
-  }
-
-  /**
    * Handles updates from the API socket
    */
   private addApiUpdateHandlers() {
@@ -981,7 +943,6 @@ export class ComfyApp {
       useExtensionService().loadExtensions()
     )
 
-    this.addProcessKeyHandler()
     this.addConfigureHandler()
     this.addApiUpdateHandlers()
 

--- a/src/stores/dialogStore.test.ts
+++ b/src/stores/dialogStore.test.ts
@@ -204,6 +204,23 @@ describe('dialogStore', () => {
     })
   })
 
+  describe('active dialog after close', () => {
+    it('reactivates the most recently opened dialog, not the highest priority one', () => {
+      const store = useDialogStore()
+      store.showDialog({
+        key: 'persistent',
+        component: MockComponent,
+        priority: 5
+      })
+      store.showDialog({ key: 'settings', component: MockComponent })
+      store.showDialog({ key: 'confirm', component: MockComponent })
+
+      store.closeDialog({ key: 'confirm' })
+
+      expect(store.activeKey).toBe('settings')
+    })
+  })
+
   describe('ESC key behavior with multiple dialogs', () => {
     it('should only allow the active dialog to close with ESC key', () => {
       const store = useDialogStore()
@@ -242,6 +259,8 @@ describe('dialogStore', () => {
 
       // Close the active dialog
       store.closeDialog({ key: store.activeKey! })
+
+      expect(store.activeKey).toBe('dialog-2')
 
       // The new active dialog should now be closable with ESC
       const newActiveDialog = store.dialogStack.find(

--- a/src/stores/dialogStore.ts
+++ b/src/stores/dialogStore.ts
@@ -137,6 +137,19 @@ export const useDialogStore = defineStore('dialog', () => {
    * Only the active dialog can be closed with the ESC key.
    */
   const activeKey = ref<string | null>(null)
+  let activationOrder: string[] = []
+
+  function activate(key: string) {
+    activationOrder = [...activationOrder.filter((k) => k !== key), key]
+    activeKey.value = key
+  }
+
+  function deactivate(key: string) {
+    activationOrder = activationOrder.filter(
+      (k) => k !== key && dialogStack.value.some((d) => d.key === k)
+    )
+    activeKey.value = activationOrder.at(-1) ?? null
+  }
 
   const genDialogKey = () => `dialog-${Math.random().toString(36).slice(2, 9)}`
 
@@ -162,7 +175,7 @@ export const useDialogStore = defineStore('dialog', () => {
     if (index !== -1) {
       const [dialog] = dialogStack.value.splice(index, 1)
       insertDialogByPriority(dialog)
-      activeKey.value = dialogKey
+      activate(dialogKey)
       updateCloseOnEscapeStates()
     }
   }
@@ -177,10 +190,7 @@ export const useDialogStore = defineStore('dialog', () => {
     const index = dialogStack.value.findIndex((d) => d.key === targetDialog.key)
     if (index !== -1) dialogStack.value.splice(index, 1)
 
-    activeKey.value =
-      dialogStack.value.length > 0
-        ? dialogStack.value[dialogStack.value.length - 1].key
-        : null
+    deactivate(targetDialog.key)
 
     updateCloseOnEscapeStates()
   }
@@ -238,7 +248,7 @@ export const useDialogStore = defineStore('dialog', () => {
     }
 
     insertDialogByPriority(dialog)
-    activeKey.value = options.key
+    activate(options.key)
     updateCloseOnEscapeStates()
 
     return dialog

--- a/src/workbench/extensions/agent/components/agent/Composer.test.ts
+++ b/src/workbench/extensions/agent/components/agent/Composer.test.ts
@@ -269,6 +269,23 @@ describe('Composer', () => {
     expect(emitted().send).toHaveLength(1)
   })
 
+  it('claims Ctrl+Enter so the queue shortcut does not also fire', async () => {
+    const { emitted } = mount()
+    const box = screen.getByRole('textbox')
+    await userEvent.type(box, 'one')
+    let prevented: boolean | undefined
+    const listener = (event: KeyboardEvent) => {
+      if (event.key === 'Enter') prevented = event.defaultPrevented
+    }
+    window.addEventListener('keydown', listener)
+
+    await userEvent.keyboard('{Control>}{Enter}{/Control}')
+    window.removeEventListener('keydown', listener)
+
+    expect(emitted().send).toHaveLength(1)
+    expect(prevented).toBe(true)
+  })
+
   it('shows Stop while streaming and emits stop instead of send', async () => {
     const { emitted } = mount({ streaming: true })
     const stop = screen.getByRole('button', { name: 'Stop' })


### PR DESCRIPTION
## Summary

Resolve registered shortcuts through one window listener and remove the duplicate lookup patched into `app.ts`.

## Changes

- Resolve the active dialog before workspace bindings, evaluate context clauses, respect text editing and IME, and leave unavailable commands unclaimed.
- Fix active-dialog promotion and record the capture migration in ADR KEYBINDINGS-0027.
- Retain bubble dispatch at this layer; later PRs supply lifecycle handling, migrate local shortcuts, and enable capture.

## Review Focus

One selected command per event, modal/text-input guard behavior, and preserving native menu Escape. Dispatcher tests pass in the completed stack.
