### PR TITLE
feat(keybindings): make undo and redo rebindable shortcuts

### DIFF
--- a/browser_tests/tests/maskEditor.spec.ts
+++ b/browser_tests/tests/maskEditor.spec.ts
@@ -290,6 +290,51 @@ test.describe('Mask Editor', { tag: '@vue-nodes' }, () => {
     await expect.poll(() => maskEditor.pollMaskPixelCount()).toBe(0)
   })
 
+  test('Ctrl+Z after typing in a brush input still undoes the mask', async ({
+    comfyPage,
+    maskEditor
+  }) => {
+    const dialog = await maskEditor.openDialog()
+
+    await maskEditor.brushInput(dialog, 'thickness').fill('12')
+    await maskEditor.drawStrokeAndExpectPixels(dialog)
+    await expect(dialog.getByTestId('pointer-zone')).toBeFocused()
+    await comfyPage.page.keyboard.press('ControlOrMeta+z')
+
+    await expect.poll(() => maskEditor.pollMaskPixelCount()).toBe(0)
+  })
+
+  test('Ctrl+Y and Ctrl+Shift+Z redo in the mask editor', async ({
+    comfyPage,
+    maskEditor
+  }) => {
+    const dialog = await maskEditor.openDialog()
+    await maskEditor.drawStrokeAndExpectPixels(dialog)
+
+    await comfyPage.page.keyboard.press('ControlOrMeta+z')
+    await expect.poll(() => maskEditor.pollMaskPixelCount()).toBe(0)
+    await comfyPage.page.keyboard.press('ControlOrMeta+y')
+    await expect.poll(() => maskEditor.pollMaskPixelCount()).toBeGreaterThan(0)
+
+    await comfyPage.page.keyboard.press('ControlOrMeta+z')
+    await expect.poll(() => maskEditor.pollMaskPixelCount()).toBe(0)
+    await comfyPage.page.keyboard.press('ControlOrMeta+Shift+z')
+    await expect.poll(() => maskEditor.pollMaskPixelCount()).toBeGreaterThan(0)
+  })
+
+  test('Escape inside the mask editor keeps it open', async ({
+    comfyPage,
+    maskEditor
+  }) => {
+    const dialog = await maskEditor.openDialog()
+
+    await maskEditor.drawStrokeAndExpectPixels(dialog)
+    await comfyPage.page.keyboard.press('Escape')
+
+    await expect(dialog).toBeVisible()
+    expect(await maskEditor.pollMaskPixelCount()).toBeGreaterThan(0)
+  })
+
   test(
     'tool panel shows all five tools',
     { tag: ['@smoke'] },

--- a/src/components/maskeditor/MaskEditorContent.vue
+++ b/src/components/maskeditor/MaskEditorContent.vue
@@ -5,7 +5,7 @@
     class="maskEditor-dialog-root flex size-full flex-col"
     @contextmenu.prevent
     @dragstart="handleDragStart"
-    @keydown.stop
+    @keydown.escape.stop
   >
     <div
       id="maskEditorCanvasContainer"

--- a/src/components/maskeditor/PointerZone.vue
+++ b/src/components/maskeditor/PointerZone.vue
@@ -2,7 +2,8 @@
   <div
     ref="pointerZoneRef"
     data-testid="pointer-zone"
-    class="h-full w-[calc(100%-4rem-220px)]"
+    tabindex="-1"
+    class="h-full w-[calc(100%-4rem-220px)] outline-none"
     @pointerdown="handlePointerDown"
     @pointermove="handlePointerMove"
     @pointerup="handlePointerUp"
@@ -54,6 +55,7 @@ watch(
 )
 
 const handlePointerDown = async (event: PointerEvent) => {
+  pointerZoneRef.value?.focus()
   await toolManager.handlePointerDown(event)
 }
 

--- a/src/components/maskeditor/dialog/TopBarHeader.vue
+++ b/src/components/maskeditor/dialog/TopBarHeader.vue
@@ -136,6 +136,7 @@ import { useCanvasTransform } from '@/composables/maskeditor/useCanvasTransform'
 import { useMaskEditorSaver } from '@/composables/maskeditor/useMaskEditorSaver'
 import { useDialogStore } from '@/stores/dialogStore'
 import { useMaskEditorStore } from '@/stores/maskEditorStore'
+import { MASK_EDITOR_DIALOG_KEY } from '@/components/maskeditor/maskEditorDialogKey'
 
 const { t } = useI18n()
 const store = useMaskEditorStore()
@@ -219,6 +220,6 @@ const handleSave = async () => {
 }
 
 const handleCancel = () => {
-  dialogStore.closeDialog({ key: 'global-mask-editor' })
+  dialogStore.closeDialog({ key: MASK_EDITOR_DIALOG_KEY })
 }
 </script>

--- a/src/components/maskeditor/maskEditorDialogKey.ts
+++ b/src/components/maskeditor/maskEditorDialogKey.ts
@@ -1,0 +1,1 @@
+export const MASK_EDITOR_DIALOG_KEY = 'global-mask-editor'

--- a/src/composables/maskeditor/useKeyboard.test.ts
+++ b/src/composables/maskeditor/useKeyboard.test.ts
@@ -101,55 +101,18 @@ describe('useKeyboard', () => {
       }
     })
 
-    it('should call undo on Ctrl+Z without shift', () => {
-      dispatchKeyDown({ key: 'z', ctrlKey: true })
+    it('should leave undo and redo combos to the keybinding dispatcher', () => {
+      const history = useMaskEditorStore().canvasHistory
+      const undo = vi.spyOn(history, 'undo')
+      const redo = vi.spyOn(history, 'redo')
 
-      expect(useMaskEditorStore().canvasHistory.undo).toHaveBeenCalledTimes(1)
-      expect(useMaskEditorStore().canvasHistory.redo).not.toHaveBeenCalled()
-    })
-
-    it('should call undo on Meta+Z without shift', () => {
-      dispatchKeyDown({ key: 'z', metaKey: true })
-
-      expect(useMaskEditorStore().canvasHistory.undo).toHaveBeenCalledTimes(1)
-    })
-
-    it('should call redo on Ctrl+Shift+Z', () => {
+      const event = dispatchKeyDown({ key: 'z', ctrlKey: true })
+      dispatchKeyDown({ key: 'y', ctrlKey: true })
       dispatchKeyDown({ key: 'Z', ctrlKey: true, shiftKey: true })
 
-      expect(useMaskEditorStore().canvasHistory.redo).toHaveBeenCalledTimes(1)
-      expect(useMaskEditorStore().canvasHistory.undo).not.toHaveBeenCalled()
-    })
-
-    it('should call redo on Ctrl+Y', () => {
-      dispatchKeyDown({ key: 'y', ctrlKey: true })
-
-      expect(useMaskEditorStore().canvasHistory.redo).toHaveBeenCalledTimes(1)
-      expect(useMaskEditorStore().canvasHistory.undo).not.toHaveBeenCalled()
-    })
-
-    it('should not trigger undo or redo when alt is held', () => {
-      dispatchKeyDown({ key: 'z', ctrlKey: true, altKey: true })
-      dispatchKeyDown({ key: 'y', ctrlKey: true, altKey: true })
-
-      expect(useMaskEditorStore().canvasHistory.undo).not.toHaveBeenCalled()
-      expect(useMaskEditorStore().canvasHistory.redo).not.toHaveBeenCalled()
-    })
-
-    it('should not trigger undo or redo without ctrl or meta', () => {
-      dispatchKeyDown({ key: 'z' })
-      dispatchKeyDown({ key: 'y' })
-      dispatchKeyDown({ key: 'Z', shiftKey: true })
-
-      expect(useMaskEditorStore().canvasHistory.undo).not.toHaveBeenCalled()
-      expect(useMaskEditorStore().canvasHistory.redo).not.toHaveBeenCalled()
-    })
-
-    it('should ignore Ctrl+Shift+Y', () => {
-      dispatchKeyDown({ key: 'Y', ctrlKey: true, shiftKey: true })
-
-      expect(useMaskEditorStore().canvasHistory.redo).not.toHaveBeenCalled()
-      expect(useMaskEditorStore().canvasHistory.undo).not.toHaveBeenCalled()
+      expect(undo).not.toHaveBeenCalled()
+      expect(redo).not.toHaveBeenCalled()
+      expect(event.defaultPrevented).toBe(false)
     })
   })
 
@@ -170,10 +133,8 @@ describe('useKeyboard', () => {
       keyboard.removeListeners()
 
       dispatchKeyDown({ key: 'a' })
-      dispatchKeyDown({ key: 'z', ctrlKey: true })
 
       expect(keyboard.isKeyDown('a')).toBe(false)
-      expect(useMaskEditorStore().canvasHistory.undo).not.toHaveBeenCalled()
     })
 
     it('should stop clearing keys on window blur after removal', () => {

--- a/src/composables/maskeditor/useKeyboard.ts
+++ b/src/composables/maskeditor/useKeyboard.ts
@@ -1,9 +1,6 @@
 import { ref } from 'vue'
-import { useMaskEditorStore } from '@/stores/maskEditorStore'
 
 export function useKeyboard() {
-  const store = useMaskEditorStore()
-
   const keysDown = ref<string[]>([])
 
   const isKeyDown = (key: string): boolean => {
@@ -26,16 +23,6 @@ export function useKeyboard() {
         activeElement.blur()
       }
     }
-
-    if ((event.ctrlKey || event.metaKey) && !event.altKey) {
-      const key = event.key.toUpperCase()
-
-      if ((key === 'Y' && !event.shiftKey) || (key === 'Z' && event.shiftKey)) {
-        store.canvasHistory.redo()
-      } else if (key === 'Z' && !event.shiftKey) {
-        store.canvasHistory.undo()
-      }
-    }
   }
 
   const handleKeyUp = (event: KeyboardEvent): void => {
@@ -43,18 +30,13 @@ export function useKeyboard() {
   }
 
   const addListeners = (): void => {
-    // Capture phase: the Mask Editor content root carries `@keydown.stop`
-    // (MaskEditorContent.vue), so a bubble-phase listener never sees keydowns
-    // that originate inside it. Under the Reka dialog the focus trap keeps
-    // focus on an in-editor input, so Ctrl+Z/Y (undo/redo) and the space-pan
-    // blur were swallowed. Capturing runs this before that stopPropagation.
-    document.addEventListener('keydown', handleKeyDown, true)
+    document.addEventListener('keydown', handleKeyDown)
     document.addEventListener('keyup', handleKeyUp)
     window.addEventListener('blur', clearKeys)
   }
 
   const removeListeners = (): void => {
-    document.removeEventListener('keydown', handleKeyDown, true)
+    document.removeEventListener('keydown', handleKeyDown)
     document.removeEventListener('keyup', handleKeyUp)
     window.removeEventListener('blur', clearKeys)
   }

--- a/src/composables/maskeditor/useMaskEditor.ts
+++ b/src/composables/maskeditor/useMaskEditor.ts
@@ -2,6 +2,7 @@ import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
 import { useDialogStore } from '@/stores/dialogStore'
 import TopBarHeader from '@/components/maskeditor/dialog/TopBarHeader.vue'
 import MaskEditorContent from '@/components/maskeditor/MaskEditorContent.vue'
+import { MASK_EDITOR_DIALOG_KEY } from '@/components/maskeditor/maskEditorDialogKey'
 
 export function useMaskEditor() {
   const openMaskEditor = (node: LGraphNode | null) => {
@@ -16,7 +17,7 @@ export function useMaskEditor() {
     }
 
     useDialogStore().showDialog({
-      key: 'global-mask-editor',
+      key: MASK_EDITOR_DIALOG_KEY,
       headerComponent: TopBarHeader,
       component: MaskEditorContent,
       props: {

--- a/src/composables/useCoreCommands.ts
+++ b/src/composables/useCoreCommands.ts
@@ -71,9 +71,6 @@ import { runMintPortsIntentionalClear } from '@/workbench/extensions/agent/crdt/
 
 import { useWorkflowTemplateSelectorDialog } from './useWorkflowTemplateSelectorDialog'
 
-import { useMaskEditorStore } from '@/stores/maskEditorStore'
-import { useDialogStore } from '@/stores/dialogStore'
-
 const moveSelectedNodesVersionAdded = '1.22.2'
 export function useCoreCommands(): ComfyCommand[] {
   const {
@@ -113,9 +110,6 @@ export function useCoreCommands(): ComfyCommand[] {
   const settingStore = useSettingStore()
 
   const bottomPanelStore = useBottomPanelStore()
-
-  const dialogStore = useDialogStore()
-  const maskEditorStore = useMaskEditorStore()
 
   const { getSelectedNodes, toggleSelectedNodesMode } =
     useSelectedLiteGraphItems()
@@ -261,12 +255,7 @@ export function useCoreCommands(): ComfyCommand[] {
       label: 'Undo',
       category: 'essentials' as const,
       function: async () => {
-        // If Mask Editor is open, use its history instead of the graph
-        if (dialogStore.isDialogOpen('global-mask-editor')) {
-          maskEditorStore.canvasHistory.undo()
-        } else {
-          await getTracker()?.undo()
-        }
+        await getTracker()?.undo()
       }
     },
     {
@@ -275,11 +264,7 @@ export function useCoreCommands(): ComfyCommand[] {
       label: 'Redo',
       category: 'essentials' as const,
       function: async () => {
-        if (dialogStore.isDialogOpen('global-mask-editor')) {
-          maskEditorStore.canvasHistory.redo()
-        } else {
-          await getTracker()?.redo()
-        }
+        await getTracker()?.redo()
       }
     },
     {

--- a/src/extensions/core/maskeditor.ts
+++ b/src/extensions/core/maskeditor.ts
@@ -6,6 +6,7 @@ import { useMaskEditorStore } from '@/stores/maskEditorStore'
 import { useDialogStore } from '@/stores/dialogStore'
 import { useMaskEditor } from '@/composables/maskeditor/useMaskEditor'
 import { useCanvasTransform } from '@/composables/maskeditor/useCanvasTransform'
+import { MASK_EDITOR_DIALOG_KEY } from '@/components/maskeditor/maskEditorDialogKey'
 
 function openMaskEditor(node: LGraphNode): void {
   if (!node) {
@@ -35,7 +36,7 @@ function openMaskEditorFromClipspace(): void {
 
 // Check if the dialog is already opened
 function isOpened(): boolean {
-  return useDialogStore().isDialogOpen('global-mask-editor')
+  return useDialogStore().isDialogOpen(MASK_EDITOR_DIALOG_KEY)
 }
 
 const changeBrushSize = async (sizeChanger: (oldSize: number) => number) => {
@@ -75,7 +76,42 @@ app.registerExtension({
       defaultValue: true
     }
   ],
+  keybindings: [
+    {
+      combo: { key: 'z', ctrl: true },
+      commandId: 'Comfy.MaskEditor.Undo',
+      dialogKey: MASK_EDITOR_DIALOG_KEY
+    },
+    {
+      combo: { key: 'y', ctrl: true },
+      commandId: 'Comfy.MaskEditor.Redo',
+      dialogKey: MASK_EDITOR_DIALOG_KEY
+    },
+    {
+      combo: { key: 'z', ctrl: true, shift: true },
+      commandId: 'Comfy.MaskEditor.Redo',
+      dialogKey: MASK_EDITOR_DIALOG_KEY
+    }
+  ],
   commands: [
+    {
+      id: 'Comfy.MaskEditor.Undo',
+      icon: 'pi pi-undo',
+      label: 'Undo in MaskEditor',
+      function: () => {
+        if (!isOpened()) return
+        useMaskEditorStore().canvasHistory.undo()
+      }
+    },
+    {
+      id: 'Comfy.MaskEditor.Redo',
+      icon: 'pi pi-refresh',
+      label: 'Redo in MaskEditor',
+      function: () => {
+        if (!isOpened()) return
+        useMaskEditorStore().canvasHistory.redo()
+      }
+    },
     {
       id: 'Comfy.MaskEditor.OpenMaskEditor',
       icon: 'pi pi-pencil',

--- a/src/locales/en/commands.json
+++ b/src/locales/en/commands.json
@@ -215,11 +215,17 @@
   "Comfy_MaskEditor_OpenMaskEditor": {
     "label": "Open Mask Editor for Selected Node"
   },
+  "Comfy_MaskEditor_Redo": {
+    "label": "Redo in MaskEditor"
+  },
   "Comfy_MaskEditor_Rotate_Left": {
     "label": "Rotate Left in MaskEditor"
   },
   "Comfy_MaskEditor_Rotate_Right": {
     "label": "Rotate Right in MaskEditor"
+  },
+  "Comfy_MaskEditor_Undo": {
+    "label": "Undo in MaskEditor"
   },
   "Comfy_Memory_UnloadModels": {
     "label": "Unload Models"

--- a/src/platform/keybindings/defaults.ts
+++ b/src/platform/keybindings/defaults.ts
@@ -246,5 +246,27 @@ export const CORE_KEYBINDINGS: Keybinding[] = [
     },
     commandId: 'Comfy.Canvas.DeleteSelectedItems',
     targetElementId: 'graph-canvas-container'
+  },
+  {
+    combo: {
+      key: 'z',
+      ctrl: true
+    },
+    commandId: 'Comfy.Undo'
+  },
+  {
+    combo: {
+      key: 'y',
+      ctrl: true
+    },
+    commandId: 'Comfy.Redo'
+  },
+  {
+    combo: {
+      key: 'z',
+      ctrl: true,
+      shift: true
+    },
+    commandId: 'Comfy.Redo'
   }
 ]

--- a/src/platform/keybindings/keyCombo.test.ts
+++ b/src/platform/keybindings/keyCombo.test.ts
@@ -65,6 +65,15 @@ describe('KeyComboImpl', () => {
     })
   })
 
+  describe('isReservedByTextInput', () => {
+    it.for([
+      { label: 'Ctrl+Y', combo: { key: 'y', ctrl: true } },
+      { label: 'Ctrl+Shift+Z', combo: { key: 'z', ctrl: true, shift: true } }
+    ])('leaves $label to a focused text input', ({ combo }) => {
+      expect(new KeyComboImpl(combo).isReservedByTextInput).toBe(true)
+    })
+  })
+
   describe('isBrowserReserved', () => {
     it.for([
       { key: 't', ctrl: true, label: 'Ctrl + t' },

--- a/src/platform/keybindings/reserved.ts
+++ b/src/platform/keybindings/reserved.ts
@@ -30,6 +30,7 @@ export const RESERVED_BY_TEXT_INPUT = new Set([
   'Ctrl + x',
   'Ctrl + z',
   'Ctrl + y',
+  'Ctrl + Shift + z',
   'Ctrl + p',
   'Enter',
   'Shift + Enter',

--- a/src/scripts/changeTracker.test.ts
+++ b/src/scripts/changeTracker.test.ts
@@ -1148,6 +1148,23 @@ describe('ChangeTracker', () => {
       )
     })
 
+    it('ignores an undo requested while a restore is in flight', async () => {
+      const first = createState(1)
+      const second = structuredClone(first)
+      second.nodes[0].widgets_values = [2]
+      const third = structuredClone(first)
+      third.nodes[0].widgets_values = [3]
+      const tracker = createTracker(third)
+      tracker.undoQueue.push(first, second)
+
+      await Promise.all([tracker.undo(), tracker.undo()])
+
+      expect(app.loadGraphData).toHaveBeenCalledTimes(1)
+      expect(tracker.activeState).toEqual(second)
+      expect(tracker.undoQueue).toEqual([first])
+      expect(tracker.redoQueue).toEqual([third])
+    })
+
     it('does not dispatch autoQueueGraphChanged for layout-only undo or redo', async () => {
       const initial = createState(1)
       const changed = structuredClone(initial)

--- a/src/scripts/changeTracker.ts
+++ b/src/scripts/changeTracker.ts
@@ -18,7 +18,6 @@ import { serializeNodeId } from '@/types/nodeId'
 import { isModalOpen } from '@/utils/modalUtil'
 
 import { api } from './api'
-import type { ComfyApp } from './app'
 import { app } from './app'
 
 function clone<T>(obj: T): T {
@@ -461,6 +460,7 @@ export class ChangeTracker {
   }
 
   async updateState(source: ComfyWorkflowJSON[], target: ComfyWorkflowJSON[]) {
+    if (this._restoringState) return
     const prevState = source.pop()
     if (prevState) {
       const previousState = this.activeState
@@ -487,20 +487,6 @@ export class ChangeTracker {
     await this.updateState(this.redoQueue, this.undoQueue)
   }
 
-  async undoRedo(e: KeyboardEvent) {
-    if ((e.ctrlKey || e.metaKey) && !e.altKey) {
-      const key = e.key.toUpperCase()
-      // Redo: Ctrl + Y, or Ctrl + Shift + Z
-      if ((key === 'Y' && !e.shiftKey) || (key == 'Z' && e.shiftKey)) {
-        await this.redo()
-        return true
-      } else if (key === 'Z' && !e.shiftKey) {
-        await this.undo()
-        return true
-      }
-    }
-  }
-
   beforeChange() {
     this.changeCount++
   }
@@ -525,16 +511,13 @@ export class ChangeTracker {
         // This can happen when user is holding down "Space" to pan the canvas.
         if (e.repeat) return
 
-        // If the mask editor is opened, we don't want to trigger on key events
-        const comfyApp = app.constructor as typeof ComfyApp
-        if (comfyApp.maskeditor_is_opended?.()) return
         if (isModalOpen(dialogStore.dialogStack.length)) return
 
         // The layer editor has its own session-local undo history
         if (useDialogStore().isDialogOpen(LAYER_EDITOR_DIALOG_KEY)) return
 
         const activeEl = document.activeElement
-        requestAnimationFrame(async () => {
+        requestAnimationFrame(() => {
           let bindInputEl: Element | null = null
           // If we are auto queue in change mode then we do want to trigger on inputs
           if (!app.ui.autoQueueEnabled || app.ui.autoQueueMode === 'instant') {
@@ -557,9 +540,6 @@ export class ChangeTracker {
 
           const changeTracker = getCurrentChangeTracker()
           if (!changeTracker) return
-
-          // Check if this is a ctrl+z ctrl+y
-          if (await changeTracker.undoRedo(e)) return
 
           // If our active element is some type of input then handle changes after they're done
           if (ChangeTracker.bindInput(bindInputEl)) return


### PR DESCRIPTION
## Summary

Make workspace and Mask Editor undo/redo configurable shortcuts instead of hard-coded key listeners.

## Changes

- Register workspace commands plus dialog-scoped Mask Editor commands for Ctrl+Z, Ctrl+Y and Ctrl+Shift+Z.
- Preserve native input undo, focus the drawing surface on pointer interaction, and prevent overlapping asynchronous graph restoration.

## Review Focus

Mask Editor focus after editing a brush input and both redo aliases. The three added browser scenarios passed locally against a running ComfyUI backend with the completed stack. Versioned persistence in a later PR protects scoped customizations from older frontend writes.
