### PR TITLE
feat(website): mark Models API as coming soon on /platform

### DIFF
--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -3469,6 +3469,7 @@ Enterprise`
   'nav.back': { en: 'BACK', 'zh-CN': '返回' },
   'nav.badgeNew': { en: 'NEW', 'zh-CN': '新' },
   'nav.badgeBeta': { en: 'BETA', 'zh-CN': 'BETA' },
+  'nav.badgeComingSoon': { en: 'COMING SOON', 'zh-CN': '即将推出' },
   // Column headers used in HeaderMainDesktop dropdowns
   'nav.mcpServer': { en: 'Comfy MCP', 'zh-CN': 'Comfy MCP' },
   'nav.supportedModels': { en: 'Supported Models', 'zh-CN': '支持的模型' },

--- a/apps/website/src/templates/platform/ProductsSection.test.ts
+++ b/apps/website/src/templates/platform/ProductsSection.test.ts
@@ -6,12 +6,11 @@ import { t } from '../../i18n/translations'
 import ProductsSection from './ProductsSection.vue'
 
 describe('ProductsSection', () => {
-  it('links each product card to its platform page', () => {
+  it('links each live product card to its platform page', () => {
     render(ProductsSection, { props: { locale: 'en' } })
 
     const cardLinks = [
       ['platform.products.serverless.title', '/platform/comfy-api'],
-      ['platform.products.models.title', '/platform/models'],
       ['platform.products.builder.title', '/platform/builder']
     ] as const
     for (const [key, href] of cardLinks) {
@@ -19,6 +18,17 @@ describe('ProductsSection', () => {
         screen.getByRole('link', { name: t(key, 'en') }).getAttribute('href')
       ).toBe(href)
     }
+  })
+
+  it('marks Models API as coming soon without a link', () => {
+    render(ProductsSection, { props: { locale: 'en' } })
+
+    expect(
+      screen.queryByRole('link', {
+        name: t('platform.products.models.title', 'en')
+      })
+    ).toBeNull()
+    expect(screen.getByText(t('nav.badgeComingSoon', 'en'))).toBeTruthy()
   })
 
   it('renders no per-card CTA buttons — the whole card is the link', () => {

--- a/apps/website/src/templates/platform/ProductsSection.vue
+++ b/apps/website/src/templates/platform/ProductsSection.vue
@@ -47,20 +47,20 @@ const modelsTabs = modelsApiCodeTabs
     <div class="mt-6 grid grid-cols-1 gap-6 lg:grid-cols-2">
       <article
         id="models"
-        class="group/models bg-transparency-white-t4 relative flex scroll-mt-24 flex-col rounded-4xl border border-transparent p-6 transition-colors hover:border-white/25 lg:scroll-mt-36 lg:p-10"
+        class="bg-transparency-white-t4 relative flex scroll-mt-24 flex-col rounded-4xl border border-transparent p-6 lg:scroll-mt-36 lg:p-10"
       >
-        <a
-          :href="routes.platformModels"
-          :aria-label="t('platform.products.models.title', locale)"
-          class="absolute inset-0 rounded-4xl"
-        ></a>
-        <h3 class="text-lg font-normal text-primary-warm-white lg:text-xl">
+        <h3
+          class="flex items-center gap-2.5 text-lg font-normal text-primary-warm-white lg:text-xl"
+        >
           {{ t('platform.products.models.title', locale) }}
+          <Badge variant="subtle" size="xs">
+            {{ t('nav.badgeComingSoon', locale) }}
+          </Badge>
         </h3>
         <p class="mt-3 text-sm/relaxed font-light text-primary-comfy-canvas">
           {{ t('platform.products.models.description', locale) }}
         </p>
-        <div class="relative z-10 mt-6">
+        <div class="mt-6">
           <CodeTabs
             :tabs="modelsTabs"
             :label="t('platform.products.models.title', locale)"


### PR DESCRIPTION
Un-links the Models API card on /platform and adds a COMING SOON badge, since the models page isn't live yet. Restoring the link once it launches is a small revert in ProductsSection.vue. The card was the only link to /platform/models; unit tests updated accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)