### PR TITLE
refactor: follow-up to #16458 — drop dead optional chain

### DIFF
--- a/src/composables/maskeditor/useMaskEditorSaver.ts
+++ b/src/composables/maskeditor/useMaskEditorSaver.ts
@@ -294,7 +294,7 @@ export function useMaskEditorSaver() {
         type: isResultItemType(mainRef.type) ? mainRef.type : 'input'
       }
     ])
-    node.graph?.setDirtyCanvas(true)
+    node.graph.setDirtyCanvas(true)
   }
 
   function loadImageFromUrl(url: string): Promise<HTMLImageElement> {


### PR DESCRIPTION
## Summary

Follow-up to #16458. Addresses the non-blocking nit from CodeJuggernaut's approval ([review](https://github.com/Comfy-Org/ComfyUI_frontend/pull/16458#pullrequestreview-5082211132)): "the dead-optional-chain note is a non-blocking nit".

`updateNodeWithServerReferences` in `useMaskEditorSaver.ts` now returns early when `!node.graph` (added in #16458), so `node.graph` is guaranteed non-null by the later `node.graph?.setDirtyCanvas(true)` call — the optional chain is dead code. Removed it.

No behavior change.

## Verification

- `pnpm test:unit src/composables/maskeditor/useMaskEditorSaver.test.ts` -> 5/5 passed (including the detached-node early-return case)
- `pnpm typecheck` -> passed
- `pnpm exec eslint` -> passed

<!-- authored-by:agent addr-drain -->