### PR TITLE
feat(billing): ended sales-managed plans get the subtitle and tile treatment

### DIFF
--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2955,6 +2955,9 @@
       "memberCta": "Ok, got it",
       "memberRunTooltip": "Contact your workspace owner to resubscribe",
       "runLabel": "Run",
+      "salesManagedDescription": "You can't run workflows or add new members. Contact your Comfy account manager to restore access.",
+      "salesManagedSpendable": "Spendable once your plan is restored.",
+      "salesManagedEnded": "Plan credits ended with your subscription.",
       "badge": "Inactive"
     },
     "paymentRecovery": {

--- a/src/platform/cloud/subscription/components/CreditsTile.test.ts
+++ b/src/platform/cloud/subscription/components/CreditsTile.test.ts
@@ -143,6 +143,10 @@ const i18n = createI18n({
         additionalCreditsInUse: 'In use',
         usedAfterMonthly: 'Used after monthly runs out',
         reactivateToUseCredits: 'Reactivate your plan to use these credits',
+        inactive: {
+          salesManagedSpendable: 'Spendable once your plan is restored.',
+          salesManagedEnded: 'Plan credits ended with your subscription.'
+        },
         monthlyCreditsUsedUpTitle:
           'Monthly credits are used up. Refills {date}',
         monthlyCreditsUsedUpTitleNoDate: 'Monthly credits are used up',
@@ -413,11 +417,13 @@ describe('CreditsTile', () => {
     expect(screen.queryByText('Add credits')).toBeNull()
   })
 
-  it('keeps Add credits and the real balance on an inactive sales-managed plan', () => {
+  it('gives an inactive sales-managed plan the ended treatment with restore copy', () => {
     activeProSubscription()
-    // A sales-managed plan has no self-serve reactivation to sell, so the
-    // reactivate-to-use-credits treatment must not apply.
-    state.canTopUp = true
+    // cloud#8001 withholds top-up once a sales-managed subscription is
+    // terminal, so the tile no longer keeps a live Add credits here. The note
+    // names restoration rather than reactivation: there is no Reactivate for
+    // a sales-managed plan, only the account manager.
+    state.canTopUp = false
     state.tier = 'ENTERPRISE'
     state.subscription = {
       tier: 'ENTERPRISE',
@@ -426,10 +432,34 @@ describe('CreditsTile', () => {
     }
     const { container } = renderTile({ inactivePlan: true })
 
+    expect(container.textContent).toContain(
+      'Spendable once your plan is restored.'
+    )
     expect(container.textContent).not.toContain(
       'Reactivate your plan to use these credits'
     )
-    expect(screen.getByText('Add credits')).toBeInTheDocument()
+    expect(screen.queryByText('Add credits')).toBeNull()
+  })
+
+  it('states what happened when an inactive sales-managed plan retained nothing', () => {
+    activeProSubscription()
+    state.canTopUp = false
+    state.tier = 'ENTERPRISE'
+    state.subscription = {
+      tier: 'ENTERPRISE',
+      duration: 'MONTHLY',
+      renewalDate: '2026-02-20T12:00:00Z'
+    }
+    state.balance = {
+      amountMicros: 0,
+      cloudCreditBalanceMicros: 0,
+      prepaidBalanceMicros: 0
+    }
+    const { container } = renderTile({ inactivePlan: true })
+
+    expect(container.textContent).toContain(
+      'Plan credits ended with your subscription.'
+    )
   })
 
   it('does not borrow a catalog monthly pool for an Enterprise plan', () => {

--- a/src/platform/cloud/subscription/components/CreditsTile.vue
+++ b/src/platform/cloud/subscription/components/CreditsTile.vue
@@ -181,7 +181,15 @@
           </span>
         </div>
         <span class="text-sm">
-          {{ $t('subscription.reactivateToUseCredits') }}
+          {{
+            $t(
+              isSalesManagedPlan
+                ? prepaidCreditsValue > 0
+                  ? 'subscription.inactive.salesManagedSpendable'
+                  : 'subscription.inactive.salesManagedEnded'
+                : 'subscription.reactivateToUseCredits'
+            )
+          }}
         </span>
       </div>
     </template>
@@ -296,8 +304,9 @@ const creditPoolTotalCredits = computed<number | null>(() => {
 // credit pool above: can_top_up is a rollout-defaulted capability that also
 // fails open for owners on an unreadable snapshot, which would drop a lapsed
 // self-serve team out of this state during a capabilities outage.
-const showsInactivePlanState = computed(
-  () => inactivePlan === true && !isSalesManagedTier(subscription.value?.tier)
+const showsInactivePlanState = computed(() => inactivePlan === true)
+const isSalesManagedPlan = computed(() =>
+  isSalesManagedTier(subscription.value?.tier)
 )
 
 const usage = computed(() =>

--- a/src/platform/workspace/components/SubscriptionPanelContentWorkspace.test.ts
+++ b/src/platform/workspace/components/SubscriptionPanelContentWorkspace.test.ts
@@ -518,6 +518,11 @@ describe('SubscriptionPanelContentWorkspace', () => {
       expect(
         screen.queryByTestId('subscription-state-card')
       ).not.toBeInTheDocument()
+      expect(
+        screen.getByText(
+          "You can't run workflows or add new members. Contact your Comfy account manager to restore access."
+        )
+      ).toBeInTheDocument()
     })
 
     it('marks an ended Personal plan inactive when it cannot self-serve', () => {

--- a/src/platform/workspace/components/SubscriptionPanelContentWorkspace.vue
+++ b/src/platform/workspace/components/SubscriptionPanelContentWorkspace.vue
@@ -237,6 +237,12 @@
                 <div v-if="planDateDisplay" class="text-sm text-text-secondary">
                   {{ planDateDisplay }}
                 </div>
+                <p
+                  v-if="isNonCatalogPlan && isSubscriptionEnded"
+                  class="m-0 text-sm text-text-secondary"
+                >
+                  {{ $t('subscription.inactive.salesManagedDescription') }}
+                </p>
               </div>
 
               <div
@@ -316,7 +322,10 @@
           <div class="w-full lg:max-w-md">
             <CreditsTile
               :zero-state="showZeroState"
-              :inactive-plan="showInactiveTeamSubscription"
+              :inactive-plan="
+                showInactiveTeamSubscription ||
+                (isNonCatalogPlan && isSubscriptionEnded)
+              "
             />
           </div>
 


### PR DESCRIPTION
Stacked on #16521, since it builds directly on the badge and the file it lands in.

An ended Enterprise workspace renders the Inactive badge and nothing else — no statement of what stopped, no route back, and a credits tile stripped to a bare balance. The account-manager line only exists as a run-button toast today, so the customer learns the route back by failing to run. Designs: [Figma 4459-24811](https://www.figma.com/design/CkFTD4c20PyRGpNVAJgpfV/Team-Plan---Workspaces?node-id=4459-24811), section **Enterprise — inactive**.

## Subtitle

The plan card gains one line under the header for a terminal sales-managed plan:

> You can't run workflows or add new members. Contact your Comfy account manager to restore access.

## Credits tile

`showsInactivePlanState` dropped its `!isSalesManagedTier` exclusion. That exclusion was right when written — the treatment sold a self-serve reactivation Enterprise doesn't have, and Enterprise kept `CanTopUp` in every status (#16067). Comfy-Org/cloud#8001 withholds top-up once a sales-managed subscription is terminal, so both halves of the rationale are gone. The note is tier-aware:

- retained credits → "Spendable once your plan is restored."
- nothing retained → "Plan credits ended with your subscription."

The parent decides *when* a plan is inactive (`isNonCatalogPlan && isSubscriptionEnded`); the tile only renders it.

## Tests

One pre-existing test pinned the old exclusion verbatim ("keeps Add credits and the real balance on an inactive sales-managed plan") — rewritten to the post-8001 contract rather than deleted, with the zero-retained case alongside. The ended-Enterprise panel test gains the subtitle assertion.

- Fixes FE-1987


## Screenshot
<img width="1278" height="718" alt="image" src="https://github.com/user-attachments/assets/7cb32c69-76cb-491b-b21a-704b860bcebf" />
