### PR TITLE
fix(workspace): keep the empty copy out of the hidden members list (FE-1625)

### DIFF
--- a/browser_tests/tests/dialogs/memberRoleChange.spec.ts
+++ b/browser_tests/tests/dialogs/memberRoleChange.spec.ts
@@ -35,7 +35,7 @@ async function openMembersTab(page: Page): Promise<Locator> {
   await dialog.locator('nav').getByRole('button', { name: 'Members' }).click()
 
   const content = dialog.getByRole('main')
-  await expect(content.getByText('4 of 30 members')).toBeVisible()
+  await expect(content.getByText('4 of 30 total members.')).toBeVisible()
   return content
 }
 
@@ -75,9 +75,7 @@ test.describe('Members plan gating', { tag: '@cloud' }, () => {
       name: 'Invite member'
     })
     await expect(inviteButton).toBeEnabled()
-    await expect(
-      content.getByRole('button', { name: 'Role', exact: true })
-    ).toBeVisible()
+    await expect(content.getByText('Role', { exact: true })).toBeVisible()
     await expect(
       content.getByText(MEMBER_JANE.email, { exact: true })
     ).toBeVisible()

--- a/src/platform/workspace/components/dialogs/settings/MembersPanelContent.test.ts
+++ b/src/platform/workspace/components/dialogs/settings/MembersPanelContent.test.ts
@@ -690,37 +690,36 @@ describe('MembersPanelContent', () => {
       expect(screen.queryByText('No members')).not.toBeInTheDocument()
     })
 
-    describe.for([
-      { showMembersList: true, hasMembers: true },
-      { showMembersList: true, hasMembers: false },
-      { showMembersList: false, hasMembers: true },
-      { showMembersList: false, hasMembers: false }
-    ])(
-      'showMembersList=$showMembersList hasMembers=$hasMembers',
-      ({ showMembersList, hasMembers }) => {
-        const wantsEmptyCopy = showMembersList && !hasMembers
+    function showMembers(members: WorkspaceMember[], showMembersList = true) {
+      mockUiConfig.value = { ...mockUiConfig.value, showMembersList }
+      mockFilteredMembers.value = members
+      mockMembers.value = members
+    }
 
-        beforeEach(() => {
-          mockUiConfig.value = { ...mockUiConfig.value, showMembersList }
-          mockFilteredMembers.value = hasMembers ? [createMember()] : []
-          mockMembers.value = mockFilteredMembers.value
-        })
+    it('shows the list, not the empty copy, with members visible', () => {
+      showMembers([createMember()])
+      renderComponent()
+      expect(screen.getByText('member1@example.com')).toBeInTheDocument()
+      expect(screen.queryByText('No members')).not.toBeInTheDocument()
+    })
 
-        it(`${wantsEmptyCopy ? 'shows' : 'hides'} the empty copy`, () => {
-          renderComponent()
-          const emptyCopy = screen.queryByText('No members')
-          if (wantsEmptyCopy) expect(emptyCopy).toBeInTheDocument()
-          else expect(emptyCopy).not.toBeInTheDocument()
-        })
+    it('shows the empty copy with no members and a visible list', () => {
+      showMembers([])
+      renderComponent()
+      expect(screen.getByText('No members')).toBeInTheDocument()
+    })
 
-        it(`${hasMembers ? 'renders' : 'omits'} the member row`, () => {
-          renderComponent()
-          const row = screen.queryByText('member1@example.com')
-          if (hasMembers) expect(row).toBeInTheDocument()
-          else expect(row).not.toBeInTheDocument()
-        })
-      }
-    )
+    it('shows no empty copy with members and a hidden list', () => {
+      showMembers([createMember()], false)
+      renderComponent()
+      expect(screen.queryByText('No members')).not.toBeInTheDocument()
+    })
+
+    it('shows no empty copy with no members and a hidden list', () => {
+      showMembers([], false)
+      renderComponent()
+      expect(screen.queryByText('No members')).not.toBeInTheDocument()
+    })
   })
 
   describe('card header actions', () => {

--- a/src/platform/workspace/components/dialogs/settings/MembersPanelContent.test.ts
+++ b/src/platform/workspace/components/dialogs/settings/MembersPanelContent.test.ts
@@ -681,6 +681,38 @@ describe('MembersPanelContent', () => {
       renderComponent()
       expect(screen.queryByText('No members')).not.toBeInTheDocument()
     })
+
+    describe.for([
+      { showMembersList: true, hasMembers: true },
+      { showMembersList: true, hasMembers: false },
+      { showMembersList: false, hasMembers: true },
+      { showMembersList: false, hasMembers: false }
+    ])(
+      'showMembersList=$showMembersList hasMembers=$hasMembers',
+      ({ showMembersList, hasMembers }) => {
+        const wantsEmptyCopy = showMembersList && !hasMembers
+
+        beforeEach(() => {
+          mockUiConfig.value = { ...mockUiConfig.value, showMembersList }
+          mockFilteredMembers.value = hasMembers ? [createMember()] : []
+          mockMembers.value = mockFilteredMembers.value
+        })
+
+        it(`${wantsEmptyCopy ? 'shows' : 'hides'} the empty copy`, () => {
+          renderComponent()
+          const emptyCopy = screen.queryByText('No members')
+          if (wantsEmptyCopy) expect(emptyCopy).toBeInTheDocument()
+          else expect(emptyCopy).not.toBeInTheDocument()
+        })
+
+        it(`${hasMembers ? 'renders' : 'omits'} the member row`, () => {
+          renderComponent()
+          const row = screen.queryByText('member1@example.com')
+          if (hasMembers) expect(row).toBeInTheDocument()
+          else expect(row).not.toBeInTheDocument()
+        })
+      }
+    )
   })
 
   describe('card header actions', () => {

--- a/src/platform/workspace/components/dialogs/settings/MembersPanelContent.test.ts
+++ b/src/platform/workspace/components/dialogs/settings/MembersPanelContent.test.ts
@@ -675,6 +675,12 @@ describe('MembersPanelContent', () => {
       renderComponent()
       expect(screen.queryByText('No pending invites')).not.toBeInTheDocument()
     })
+
+    it('stays silent while the members list is hidden', () => {
+      mockUiConfig.value = { ...mockUiConfig.value, showMembersList: false }
+      renderComponent()
+      expect(screen.queryByText('No members')).not.toBeInTheDocument()
+    })
   })
 
   describe('card header actions', () => {

--- a/src/platform/workspace/components/dialogs/settings/MembersPanelContent.test.ts
+++ b/src/platform/workspace/components/dialogs/settings/MembersPanelContent.test.ts
@@ -174,6 +174,7 @@ const i18n = createI18n({
         members: {
           noMembers: 'No members',
           noMembersMatch: 'No members match "{query}"',
+          totalMembersCount: '{count} of {maxSeats} total members.',
           noInvites: 'No pending invites',
           noInvitesMatch: 'No invites match "{query}"'
         }
@@ -623,16 +624,23 @@ describe('MembersPanelContent', () => {
   })
 
   describe('member count display', () => {
-    it('shows member count header for team workspace', () => {
+    beforeEach(() => {
       mockFilteredMembers.value = [
         createMember({ id: '1' }),
         createMember({ id: '2' })
       ]
       mockMembers.value = mockFilteredMembers.value
+    })
+
+    it('counts the members against the seats the plan bought', () => {
       renderComponent()
-      expect(
-        screen.getByText(/workspacePanel\.members\.totalMembersCount/)
-      ).toBeTruthy()
+      expect(screen.getByText(/2 of 20 total members\./)).toBeInTheDocument()
+    })
+
+    it('stays silent until the members request has completed', () => {
+      mockMembersLoaded.value = false
+      renderComponent()
+      expect(screen.queryByText(/total members\./)).not.toBeInTheDocument()
     })
   })
 

--- a/src/platform/workspace/components/dialogs/settings/MembersPanelContent.vue
+++ b/src/platform/workspace/components/dialogs/settings/MembersPanelContent.vue
@@ -265,6 +265,7 @@ const {
 const { t } = useI18n()
 
 const emptyStateMessage = computed(() => {
+  if (!uiConfig.value.showMembersList) return null
   if (!membersLoaded.value) return null
   if (activeView.value !== 'active') return null
   if (isInPersonalWorkspace.value && maxSeats.value === 1) return null

--- a/src/platform/workspace/components/dialogs/settings/MembersPanelContent.vue
+++ b/src/platform/workspace/components/dialogs/settings/MembersPanelContent.vue
@@ -189,7 +189,7 @@
     />
     <!-- Need More Members Footer -->
     <div
-      v-if="hasMemberSeats"
+      v-if="hasMemberSeats && membersLoaded"
       class="flex shrink-0 items-center gap-1 pt-2 pb-6"
     >
       <p class="text-sm text-muted-foreground">

--- a/src/platform/workspace/components/dialogs/settings/PendingInvitesList.test.ts
+++ b/src/platform/workspace/components/dialogs/settings/PendingInvitesList.test.ts
@@ -76,7 +76,7 @@ describe('PendingInvitesList', () => {
   })
 
   it('renders no empty copy before the first request completes', () => {
-    renderComponent([], { loaded: false })
+    renderComponent([], { loaded: false, searchQuery: 'nobody' })
 
     expect(screen.queryByText('No pending invites')).not.toBeInTheDocument()
     expect(


### PR DESCRIPTION
## Why

Stacked on #15235. That branch now carries the load-state gating this PR originally added (6701a2967), so what is left here is the second half of @huang47's blocking review, plus a third instance of the same defect found during it.

> Please distinguish "not loaded yet" and "list intentionally hidden" from a successfully loaded empty result here. [...] this branch also fires when `uiConfig.showMembersList` is false, including while `maxSeats` is still `null`. **Gate this on the request having completed and `uiConfig.showMembersList`.**

One root cause, three surfaces: the panel asserts things about server state that the server has not answered yet, because the assertion is assembled on the frontend from values that resolve on independent clocks.

### 1. Empty copy renders for a list that is not on screen

`emptyStateMessage` renders outside any `showMembersList` guard, so "No members" appears for a list nobody can see. Two ways in:

- **Seatless workspace.** `hasMemberSeats` is `maxSeats === 0 || (maxSeats ?? 0) > 1`, so a single-seat plan takes the `showMembersList: false` branch in `useMembersPanel` — and still renders the copy.
- **Billing not resolved.** `maxSeats` is `null` until the billing context initialises, and `(null ?? 0) > 1` is false, so the same branch is taken transiently on every cold open.

The load gate does not cover either — `membersLoaded` can be true while the list is hidden.

### 2. Footer counts members before they arrive

Raised by CodeRabbit as an outside-diff finding; same bug, one line down. `hasMemberSeats` is true as soon as billing lands, but `members` is `[]` until the member fetch returns. Between the two, a 30-seat workspace renders **`0 of 30 total members.`**

```
billing resolves ──────┐
                       ├── window where the footer states 0 of 30
members request ───────┘
```

## How

Both gates hang off signals the server owns, not off derived frontend state:

```ts
const emptyStateMessage = computed(() => {
  if (!uiConfig.value.showMembersList) return null
  if (!membersLoaded.value) return null
  ...
```

```diff
-      v-if="hasMemberSeats"
+      v-if="hasMemberSeats && membersLoaded"
```

Deferring the whole footer rather than just the number keeps the "need more members" CTA from sitting beside a blank count.

Rows are deliberately *not* gated on `showMembersList`. They are data already held; "No members" is a claim that cannot yet be made. Blanking a loaded list while `maxSeats` is `null` would be a worse flash than the one this PR removes — `keeps rendering members while seat capacity is unresolved` pins that.

## Tests

A `describe.for` table over `showMembersList` × members, each case asserting both the empty copy and the row:

| `showMembersList` | members | empty copy | row |
| --- | --- | --- | --- |
| true | 0 | shown | — |
| true | 1 | hidden | rendered |
| false | 0 | hidden | — |
| false | 1 | hidden | rendered |

Count assertions now read rendered copy (`2 of 20 total members.`) rather than the raw `totalMembersCount` key — the old regex would have passed on any count, including the zero this PR fixes.

## Verification

`53/53` across the two panel suites, `1391/1391` across `src/platform/workspace/`. `pnpm typecheck`, `pnpm lint` (0 errors), `pnpm knip` clean.

Mutation-checked, each gate independently:
- removing the `showMembersList` gate fails only the hidden-list cases
- removing `&& membersLoaded` fails only `stays silent until the members request has completed`

Neither case was covered by the pre-existing suite.

Linear: [FE-1625](https://linear.app/comfyorg/issue/FE-1625/members-tab-bound-the-table-height-add-empty-states-and-align-with-the)
