### PR TITLE
test(crdt): assert follower node-slot parity across batch boundaries (R-96)

### DIFF
--- a/src/workbench/extensions/agent/crdt/ecsFollowerAdapter.integration.test.ts
+++ b/src/workbench/extensions/agent/crdt/ecsFollowerAdapter.integration.test.ts
@@ -948,6 +948,7 @@ describe('EcsFollowerAdapter integration', () => {
     ]
 
     const runScenario = (deliverAsSingleFrame: boolean) => {
+      setActivePinia(createTestingPinia({ stubActions: false }))
       const host = mint({ nodes: [], links: [] }, catalog)
       const follower = new FollowerDoc()
       const mutations = createGraphMutations({

--- a/src/workbench/extensions/agent/crdt/ecsFollowerAdapter.integration.test.ts
+++ b/src/workbench/extensions/agent/crdt/ecsFollowerAdapter.integration.test.ts
@@ -909,4 +909,132 @@ describe('EcsFollowerAdapter integration', () => {
     followerA.destroy()
     followerB.destroy()
   })
+
+  it('populates node slot arrays identically whether add+connect ops arrive in one combined frame or separate singleton frames (R-96)', () => {
+    const buildOps = (prefix: string) => [
+      op(`${prefix}-1`, 1, {
+        op: 'add_node',
+        node_id: 1,
+        class_type: 'Source',
+        pos: [0, 0],
+        node: {
+          id: 1,
+          type: 'Source',
+          inputs: [],
+          outputs: [{ name: 'out', type: 'IMAGE', links: [] }]
+        }
+      }),
+      op(`${prefix}-2`, 2, {
+        op: 'add_node',
+        node_id: 2,
+        class_type: 'Sink',
+        pos: [200, 0],
+        node: {
+          id: 2,
+          type: 'Sink',
+          inputs: [{ name: 'in', type: 'IMAGE', link: null }],
+          outputs: []
+        }
+      }),
+      op(`${prefix}-3`, 3, {
+        op: 'connect',
+        link_id: 9,
+        from_node: 1,
+        from_slot: 0,
+        to_node: 2,
+        to_slot: 0,
+        link_type: 'IMAGE'
+      })
+    ]
+
+    const runScenario = (deliverAsSingleFrame: boolean) => {
+      const host = mint({ nodes: [], links: [] }, catalog)
+      const follower = new FollowerDoc()
+      const mutations = createGraphMutations({
+        getScope: () => scope,
+        layout: { createNode: vi.fn(), deleteNodes: vi.fn() }
+      })
+      const adapter = new EcsFollowerAdapter(mutations)
+      adapter.bind('wf', follower)
+
+      const ops = buildOps(
+        deliverAsSingleFrame ? 'combined' : 'singleton'
+      ) as Parameters<typeof applyOps>[1]
+
+      if (deliverAsSingleFrame) {
+        const result = applyOps(host, ops, catalog)
+        expect(result.outcomes.map(({ outcome }) => outcome)).toEqual([
+          'applied',
+          'applied',
+          'applied'
+        ])
+        const update = Y.encodeStateAsUpdate(host)
+        follower.applyRemoteUpdate(update)
+        expect(
+          adapter.applyFrame({
+            workflowId: 'wf',
+            seq: 1,
+            update,
+            actor: 'agent:test',
+            opIds: ops.map(({ op_id }) => op_id)
+          })
+        ).toBe(true)
+      } else {
+        let before = Y.encodeStateVector(host)
+        let first = true
+        let seq = 0
+        for (const singleOp of ops) {
+          const result = applyOps(host, [singleOp], catalog)
+          expect(result.outcomes[0]?.outcome).toBe('applied')
+          const update = first
+            ? Y.encodeStateAsUpdate(host)
+            : Y.encodeStateAsUpdate(host, before)
+          first = false
+          before = Y.encodeStateVector(host)
+          follower.applyRemoteUpdate(update)
+          expect(
+            adapter.applyFrame({
+              workflowId: 'wf',
+              seq: ++seq,
+              update,
+              actor: 'agent:test',
+              opIds: [singleOp.op_id]
+            })
+          ).toBe(true)
+        }
+      }
+
+      const nodes = useNodeDataStore().getGraphNodesFor('root', 'root')
+      const origin = nodes.find(({ id }) => id === toNodeId(1))
+      const target = nodes.find(({ id }) => id === toNodeId(2))
+      const topology = useLinkStore().getTopology(
+        scope.rootGraphId,
+        toLinkId(9)
+      )
+
+      adapter.destroy()
+      follower.destroy()
+      host.destroy()
+
+      return {
+        originLinks: origin?.outputs[0]?.links ?? null,
+        targetLink: target?.inputs[0]?.link ?? null,
+        topologyDefined: topology !== undefined
+      }
+    }
+
+    const singleton = runScenario(false)
+    const combined = runScenario(true)
+
+    // The link store converges identically either way...
+    expect(combined.topologyDefined).toBe(true)
+    expect(singleton.topologyDefined).toBe(true)
+    // ...but node slot state must converge too: same-frame connect+adds must
+    // not leave inputs[].link / outputs[].links empty relative to delivering
+    // the same ops across separate frames.
+    expect(combined.originLinks).toEqual(singleton.originLinks)
+    expect(combined.targetLink).toEqual(singleton.targetLink)
+    expect(combined.originLinks).toEqual([toLinkId(9)])
+    expect(combined.targetLink).toEqual(toLinkId(9))
+  })
 })


### PR DESCRIPTION
## What

Adds a permanent regression test asserting `EcsFollowerAdapter` node
input/output link-slot state converges identically whether `add_node` +
`connect` ops are delivered as one **combined** Yjs update (single frame)
or as **separate singleton** frames.

## Why (R-96)

`logs/RISK-REGISTER.md` R-96 characterized a batch-boundary defect on FE PR
#16462's QA-8 property suite: when `connect` shares one Yjs update with node
adds, `inputs[].link` / `outputs[].links` could remain empty in the combined
case while the link store still converged. That characterization ran on top
of draft PRs #16373/#16375 (clock/identity hardening + `GraphDocument`
activation seam), not present on `main`.

## Reproduction result: does not reproduce on main today

Reproducing directly against current `main` — real `EcsFollowerAdapter`,
`createGraphMutations`, and `@comfyorg/comfy-multi-player`'s `applyOps`, no
mocks — the divergence does not occur:

- `FollowerDoc.applyRemoteUpdate` applies a delivered Yjs update as **one
  transaction** regardless of how many upstream ops it bundles, so the
  adapter's `Y.Map` observers fire once per delivered frame either way and
  `nodeActions`/`changedLinks` accumulate identically before
  `applyQueuedFrame` builds the mutation batch.
- Verified three variants combined into one frame: plain `connect`, `grow`
  (new-slot) `connect`, and a higher-stamped node replace + `connect`. All
  three converge with singleton-frame delivery.

This PR lands the regression as a tripwire rather than leaving the finding
report-only: if batch-boundary parity regresses later (e.g. once
#16373/#16375 land and change delivery/identity semantics), this test fails
before it reaches production. No production code changed — this is a
verification/policy PR, not a fix, because there is nothing to fix on main
yet.

## Verification

- `pnpm exec vitest run src/workbench/extensions/agent/crdt/` — 18 files,
  177 passed (includes the 6 in the touched file).
- `pnpm exec eslint` — clean on the touched file.
- `pnpm typecheck` (`vue-tsc --noEmit`) — clean.
- `pnpm exec oxfmt` / `pnpm exec oxlint --type-aware` — clean.
- Pre-commit hooks (oxfmt, oxlint, eslint, typecheck) passed on commit.

## Trace

R-96 (SEV2, `logs/RISK-REGISTER.md`), QA-8 (`reports/lanes/qa8prop.md`, FE
PR #16462), program todo row `r87-1`.