### PR TITLE
feat(keybindings): resolve bindings by source tier before clause width

### DIFF
--- a/docs/adr/KEYBINDINGS-0027-context-keyed-keybinding-dispatch.md
+++ b/docs/adr/KEYBINDINGS-0027-context-keyed-keybinding-dispatch.md
@@ -102,18 +102,30 @@ extensions already run arbitrary JavaScript, so ownership is enforced at
 registration, where it prevents accidental collisions, and not at write
 time, where it could only be advisory.
 
-Resolution within one combo and scope: bindings with narrower clauses (more
-atoms) are tried first, user bindings before defaults at equal width, then
-registration order, and the first whose clause holds runs. Two bindings
-conflict only when combo, scope and clause are all identical. So
-`w → pan when ext.wasdMode` coexists with the core `w → toggle sidebar` and
-shadows it while the mode is on. Phase 2 puts the binding's source ahead of
-clause width, so that a user's rebind always beats an extension's or core's
-narrower clause; until then a narrower default clause can outrank a broader
-user binding on the same combo.
+Every binding has a source: core, an extension (by name), or the user. The
+source is assigned by whoever registers the binding, never declared by the
+binding itself, so an extension cannot promote its own bindings.
+
+Resolution within one combo and scope: user bindings first, then extension
+bindings, then core; within a tier, narrower clauses (more atoms) before
+broader ones; then registration order. The clause is a filter, not a rank
+across tiers: a user's rebind beats an extension's or core's narrower
+clause, and the first candidate in that order whose clause holds runs. Two
+bindings conflict only when combo, scope, clause and tier are all
+identical. So `w → pan when ext.wasdMode` coexists with the core
+`w → toggle sidebar` and shadows it while the mode is on, and an extension
+binding on `Ctrl+Z` coexists with the core undo binding and shadows it
+until the user rebinds `Ctrl+Z`. A binding hidden this way is not listed
+as active for its command, so menus never show a shortcut that would run
+something else; the shortcuts panel and the Edit Keybinding dialog name
+the extension that owns the binding that wins.
 
 Combos reserved by text inputs stay out of text-editing controls unless the
 clause names `textInputFocus`, which is how a binding opts into a textarea.
+Only core and user bindings may opt in. The app contains credential inputs,
+so an extension binding never fires from a text-editing control on a
+reserved combo, whatever its clause says; a user who wants an extension's
+command there binds it themselves.
 
 The store keeps arrays keyed by binding identity (command, combo, target
 element, dialog key, clause) and derives the active set. The Edit Keybinding
@@ -123,17 +135,17 @@ an identical binding. Extension keybindings are validated at registration.
 
 ### D3 — Guard policy is uniform and explicit
 
-| Guard                    | Window path before                                                                                  | `processKey` path before                                     | Now                                                                                                                                                                                                  |
-| ------------------------ | --------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Which bindings           | all                                                                                                 | canvas-scoped, then `stopImmediatePropagation`               | all, one path, never stops propagation                                                                                                                                                               |
-| `event.defaultPrevented` | ignored                                                                                             | ignored                                                      | skipped                                                                                                                                                                                              |
-| `event.isComposing`      | ignored                                                                                             | ignored                                                      | skipped                                                                                                                                                                                              |
-| `event.repeat`           | dispatched                                                                                          | skipped, then fell through to the window path and dispatched | dispatched                                                                                                                                                                                           |
-| Modal open               | workspace bindings blocked, `preventDefault` if Ctrl                                                | not checked                                                  | unchanged for workspace bindings; bindings scoped to the active dialog run                                                                                                                           |
-| Text input focus         | reserved combos blocked on `INPUT`, `TEXTAREA`, `contentEditable === 'true'`, `SPAN.property_value` | dead check                                                   | same set, except `INPUT` types that do not edit text (range, checkbox, radio, button, submit, reset, color, file, image) and inherited `isContentEditable`; a clause naming `textInputFocus` opts in |
-| Escape ownership         | `[role="menu"]`                                                                                     | none                                                         | `[role="menu"]` and `[data-dismissable-layer]`                                                                                                                                                       |
-| Unknown command          | throws after `preventDefault`                                                                       | throws                                                       | inert, console warning                                                                                                                                                                               |
-| `graph.change()`         | none                                                                                                | after the command                                            | litegraph's `processKey` still calls it before the command for canvas-targeted keydowns; every canvas command redraws on its own                                                                     |
+| Guard                    | Window path before                                                                                  | `processKey` path before                                     | Now                                                                                                                                                                                                                         |
+| ------------------------ | --------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Which bindings           | all                                                                                                 | canvas-scoped, then `stopImmediatePropagation`               | all, one path, never stops propagation                                                                                                                                                                                      |
+| `event.defaultPrevented` | ignored                                                                                             | ignored                                                      | skipped                                                                                                                                                                                                                     |
+| `event.isComposing`      | ignored                                                                                             | ignored                                                      | skipped                                                                                                                                                                                                                     |
+| `event.repeat`           | dispatched                                                                                          | skipped, then fell through to the window path and dispatched | dispatched                                                                                                                                                                                                                  |
+| Modal open               | workspace bindings blocked, `preventDefault` if Ctrl                                                | not checked                                                  | unchanged for workspace bindings; bindings scoped to the active dialog run                                                                                                                                                  |
+| Text input focus         | reserved combos blocked on `INPUT`, `TEXTAREA`, `contentEditable === 'true'`, `SPAN.property_value` | dead check                                                   | same set, except `INPUT` types that do not edit text (range, checkbox, radio, button, submit, reset, color, file, image) and inherited `isContentEditable`; a clause naming `textInputFocus` opts a core or user binding in |
+| Escape ownership         | `[role="menu"]`                                                                                     | none                                                         | `[role="menu"]` and `[data-dismissable-layer]`                                                                                                                                                                              |
+| Unknown command          | throws after `preventDefault`                                                                       | throws                                                       | inert, console warning                                                                                                                                                                                                      |
+| `graph.change()`         | none                                                                                                | after the command                                            | litegraph's `processKey` still calls it before the command for canvas-targeted keydowns; every canvas command redraws on its own                                                                                            |
 
 Behavior that changes for users as a result:
 
@@ -182,6 +194,10 @@ Consequences for users:
 - A combo reserved by text inputs never fires from a text-editing control
   unless its clause names `textInputFocus`.
 - A clause naming an unregistered context key never matches.
+- A user binding is never outranked by a default with a narrower clause on
+  the same combo and scope.
+- An extension binding on a combo reserved by text inputs never fires from
+  a text-editing control.
 - The dispatcher calls `preventDefault()` in exactly two cases: when it
   executes a command, and when a Ctrl combo that a workspace binding would
   claim arrives while a modal is open, so the browser does not act on it.
@@ -196,7 +212,7 @@ Phases are ordered by dependency. Each is its own change.
 | Phase | What                                                                                                                                                                                                                | Status                       |
 | ----- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------- |
 | 1     | Context key store, `when` parser, `dialogKey`, extension-registered keys                                                                                                                                            | Done, preceding change       |
-| 2     | Store rework: several bindings per combo, a `source` on every binding, resolution by source tier (user, extension, core) before clause width, attributable conflict reporting                                       | Next change                  |
+| 2     | Store rework: several bindings per combo, a `source` on every binding, resolution by source tier (user, extension, core) before clause width, attributable conflict reporting                                       | Done, this change            |
 | 3     | One dispatcher with the guard matrix in D3                                                                                                                                                                          | Done, this change            |
 | 4     | Capture-phase dispatcher behind a hidden setting with a kill switch; `data-comfy-keybinding-ignore` escape hatch checked via `composedPath()`; `processKey` kept as a deprecated shim for one cycle                 | Pending; preconditions below |
 | 5     | Undo and redo as bindings (D4)                                                                                                                                                                                      | Done, following change       |
@@ -252,6 +268,11 @@ be rebound separately.
   shields are no longer required for correctness.
 - Same combo, different dialog, no conflict: extensions can bind inside
   their own dialogs.
+- Same combo, same scope, different source, no conflict either: an
+  extension's binding coexists with core's and wins until the user rebinds,
+  and the panel says which extension owns it. Two extensions declaring the
+  identical binding still collide, and the toast names the one that got
+  there first.
 - Undo and redo behave like every other shortcut.
 
 ### Negative
@@ -264,9 +285,9 @@ be rebound separately.
   shortcut that throws on that build. A user who customizes undo or
   mask-editor undo and then edits keybindings on an older build loses that
   customization.
-- Until phase 2 lands, an extension that declared a workspace binding on
-  `Ctrl+Z`, `Ctrl+Y` or `Ctrl+Shift+Z` collides with the new core default
-  and is rejected with the usual conflict toast.
+- A core binding hidden by an extension's shows nowhere in the shortcuts
+  panel until the extension is disabled; the persistent conflict report
+  that would explain the gap is diagnostics work still to come.
 - A DOM-only modal (legacy `.comfy-modal`, a native `<dialog>`, a hand-rolled
   `aria-modal` overlay) raises the modal guard but never becomes the active
   dialog, so a scoped binding under one would still fire. No such surface is

--- a/src/components/dialog/content/setting/KeybindingPanel.vue
+++ b/src/components/dialog/content/setting/KeybindingPanel.vue
@@ -203,6 +203,12 @@
                       :key-combo="binding.combo"
                       :is-modified="slotProps.data.isModified"
                     />
+                    <span
+                      v-if="extensionOwning(binding)"
+                      class="text-xs text-muted-foreground"
+                    >
+                      {{ extensionOwning(binding) }}
+                    </span>
                   </div>
                   <div class="flex flex-row">
                     <Button
@@ -466,6 +472,11 @@ const selectedCommandData = ref<ICommandData | null>(null)
 const editKeybindingDialog = useEditKeybindingDialog()
 
 const contextMenuTarget = ref<ICommandData | null>(null)
+
+function extensionOwning(binding: KeybindingImpl): string | null {
+  const source = keybindingStore.sourceOf(binding)
+  return source.tier === 'extension' ? source.name : null
+}
 
 function editKeybinding(commandData: ICommandData, binding: KeybindingImpl) {
   editKeybindingDialog.show({

--- a/src/components/dialog/content/setting/keybinding/EditKeybindingContent.vue
+++ b/src/components/dialog/content/setting/keybinding/EditKeybindingContent.vue
@@ -29,6 +29,9 @@
       >
         {{ $t('g.keybindingAlreadyExists') }}
         {{ existingKeybindingOnCombo.commandId }}
+        <span v-if="existingKeybindingSource">
+          ({{ existingKeybindingSource }})
+        </span>
       </p>
     </div>
   </div>
@@ -40,11 +43,17 @@ import { KeyComboImpl } from '@/platform/keybindings/keyCombo'
 
 import type { EditKeybindingDialogState } from '@/composables/useEditKeybindingDialog'
 
-const { dialogState, onUpdateCombo, existingKeybindingOnCombo } = defineProps<{
+const {
+  dialogState,
+  onUpdateCombo,
+  existingKeybindingOnCombo,
+  existingKeybindingSource = null
+} = defineProps<{
   dialogState: EditKeybindingDialogState
   commandLabel: string
   onUpdateCombo: (combo: KeyComboImpl) => void
   existingKeybindingOnCombo: KeybindingImpl | null
+  existingKeybindingSource?: string | null
 }>()
 
 function captureKeybinding(event: KeyboardEvent) {

--- a/src/composables/useEditKeybindingDialog.test.ts
+++ b/src/composables/useEditKeybindingDialog.test.ts
@@ -10,6 +10,7 @@ import { useKeybindingStore } from '@/platform/keybindings/keybindingStore'
 interface DialogProps {
   dialogState: EditKeybindingDialogState
   existingKeybindingOnCombo: ComputedRef<KeybindingImpl | null>
+  existingKeybindingSource: ComputedRef<string | null>
   onUpdateCombo: (combo: KeyComboImpl) => void
 }
 
@@ -107,5 +108,24 @@ describe('useEditKeybindingDialog', () => {
     dialog.onUpdateCombo(ctrlZ)
 
     expect(dialog.existingKeybindingOnCombo.value).toEqual(maskEditorUndo)
+    expect(dialog.existingKeybindingSource.value).toBeNull()
+  })
+
+  it('names the extension that owns the conflicting binding', () => {
+    useKeybindingStore().addExtensionKeybinding(
+      new KeybindingImpl({ commandId: 'ext.undo', combo: ctrlZ }),
+      'ext'
+    )
+
+    useEditKeybindingDialog().show({
+      commandId: 'test.save',
+      commandLabel: 'Save',
+      currentCombo: null
+    })
+    const dialog = shownDialog()
+    dialog.onUpdateCombo(ctrlZ)
+
+    expect(dialog.existingKeybindingOnCombo.value?.commandId).toBe('ext.undo')
+    expect(dialog.existingKeybindingSource.value).toBe('ext')
   })
 })

--- a/src/composables/useEditKeybindingDialog.ts
+++ b/src/composables/useEditKeybindingDialog.ts
@@ -63,6 +63,13 @@ export function useEditKeybindingDialog() {
       return keybindingStore.findConflictingKeybinding(candidate) ?? null
     })
 
+    const existingKeybindingSource = computed(() => {
+      const existing = existingKeybindingOnCombo.value
+      if (!existing) return null
+      const source = keybindingStore.sourceOf(existing)
+      return source.tier === 'extension' ? source.name : null
+    })
+
     function onUpdateCombo(combo: KeyComboImpl) {
       dialogState.newCombo = combo
     }
@@ -76,7 +83,8 @@ export function useEditKeybindingDialog() {
         dialogState,
         onUpdateCombo,
         commandLabel: options.commandLabel,
-        existingKeybindingOnCombo
+        existingKeybindingOnCombo,
+        existingKeybindingSource
       },
       headerProps: {},
       footerProps: { dialogState, newKeybinding, existingKeybindingOnCombo }

--- a/src/platform/keybindings/keybindingService.dispatch.test.ts
+++ b/src/platform/keybindings/keybindingService.dispatch.test.ts
@@ -95,7 +95,7 @@ describe('keybindingService dispatch', () => {
     keybindingStore.addDefaultKeybinding(
       new KeybindingImpl({
         commandId: 'test.textCommand',
-        combo: { key: 'ArrowUp', ctrl: true },
+        combo: { key: 'ArrowLeft', ctrl: true },
         when: 'textInputFocus'
       })
     )
@@ -247,10 +247,54 @@ describe('keybindingService dispatch', () => {
     const textarea = document.createElement('textarea')
     document.body.appendChild(textarea)
 
-    keydown(textarea, { key: 'ArrowUp', ctrlKey: true })
+    keydown(textarea, { key: 'ArrowLeft', ctrlKey: true })
     expect(textCommand).toHaveBeenCalledOnce()
 
-    keydown(document.body, { key: 'ArrowUp', ctrlKey: true })
+    keydown(document.body, { key: 'ArrowLeft', ctrlKey: true })
+    expect(textCommand).toHaveBeenCalledOnce()
+    textarea.remove()
+  })
+
+  it('runs an extension binding over the core binding on the same combo', () => {
+    const extensionUndo = vi.fn<() => void>()
+    useCommandStore().registerCommand({
+      id: 'ext.undo',
+      function: extensionUndo
+    })
+    useKeybindingStore().addExtensionKeybinding(
+      new KeybindingImpl({
+        commandId: 'ext.undo',
+        combo: { key: 'z', ctrl: true }
+      }),
+      'ext'
+    )
+
+    keydown(document.body, { key: 'z', ctrlKey: true })
+
+    expect(extensionUndo).toHaveBeenCalledOnce()
+    expect(undo).not.toHaveBeenCalled()
+  })
+
+  it('keeps an extension binding out of text inputs even when its clause asks', () => {
+    const extensionCommand = vi.fn<() => void>()
+    useCommandStore().registerCommand({
+      id: 'ext.text',
+      function: extensionCommand
+    })
+    useKeybindingStore().addExtensionKeybinding(
+      new KeybindingImpl({
+        commandId: 'ext.text',
+        combo: { key: 'ArrowLeft', ctrl: true },
+        when: 'textInputFocus'
+      }),
+      'ext'
+    )
+    const textarea = document.createElement('textarea')
+    document.body.appendChild(textarea)
+
+    keydown(textarea, { key: 'ArrowLeft', ctrlKey: true })
+
+    expect(extensionCommand).not.toHaveBeenCalled()
     expect(textCommand).toHaveBeenCalledOnce()
     textarea.remove()
   })

--- a/src/platform/keybindings/keybindingService.ts
+++ b/src/platform/keybindings/keybindingService.ts
@@ -9,6 +9,7 @@ import { useContextKeyStore } from './contextKeyStore'
 import { CORE_KEYBINDINGS } from './defaults'
 import { KeyComboImpl } from './keyCombo'
 import { KeybindingImpl } from './keybinding'
+import type { KeybindingSource } from './keybindingStore'
 import { useKeybindingStore } from './keybindingStore'
 import { matchesContext, parseWhenClause } from './whenClause'
 
@@ -58,19 +59,27 @@ function isWithinTargetElement(
   return document.getElementById(targetElementId)?.contains(target) ?? false
 }
 
-/** Reserved combos stay out of text inputs unless the clause asks for one. */
+/**
+ * Reserved combos stay out of text inputs unless the clause asks for one.
+ * Only core and user bindings may ask: the app contains credential inputs,
+ * so an extension cannot route keys out of them.
+ */
 function clauseHolds(
   keybinding: KeybindingImpl,
+  source: KeybindingSource,
   context: ContextSnapshot
 ): boolean {
   const parsed =
     keybinding.when === undefined ? undefined : parseWhenClause(keybinding.when)
   if (parsed && !parsed.success) return false
   const clause = parsed?.clause ?? []
+  const optsIntoTextInput =
+    source.tier !== 'extension' &&
+    clause.some((atom) => atom.key === 'textInputFocus')
   if (
     context.textInputFocus &&
     keybinding.combo.isReservedByTextInput &&
-    !clause.some((atom) => atom.key === 'textInputFocus')
+    !optsIntoTextInput
   ) {
     return false
   }
@@ -147,7 +156,7 @@ export function useKeybindingService() {
             .find(
               (binding) =>
                 isWithinTargetElement(binding, target) &&
-                clauseHolds(binding, context)
+                clauseHolds(binding, keybindingStore.sourceOf(binding), context)
             )
     if (scoped) {
       await execute(scoped, event)
@@ -158,7 +167,7 @@ export function useKeybindingService() {
       .getKeybindings(keyCombo)
       .filter((binding) => isWithinTargetElement(binding, target))
     const keybinding = candidates.find((binding) =>
-      clauseHolds(binding, context)
+      clauseHolds(binding, keybindingStore.sourceOf(binding), context)
     )
     if (!keybinding) {
       const bare = !keyCombo.ctrl && !keyCombo.alt

--- a/src/platform/keybindings/keybindingStore.priority.test.ts
+++ b/src/platform/keybindings/keybindingStore.priority.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+
+import { KeybindingImpl } from './keybinding'
+import { useKeybindingStore } from './keybindingStore'
+
+describe('explicit user shortcut choices', () => {
+  const undo = () =>
+    new KeybindingImpl({
+      commandId: 'Comfy.Undo',
+      combo: { key: 'z', ctrl: true }
+    })
+  const extensionUndo = () =>
+    new KeybindingImpl({
+      commandId: 'Example.Undo',
+      combo: { key: 'z', ctrl: true }
+    })
+
+  it('reclaims the original default from an extension and can disable it', () => {
+    const store = useKeybindingStore()
+    const core = undo()
+    store.addDefaultKeybinding(core)
+    store.addExtensionKeybinding(extensionUndo(), 'Example')
+
+    store.addUserKeybinding(core)
+
+    const winner = store.getKeybindings(core.combo).at(0)
+    expect(winner?.commandId).toBe('Comfy.Undo')
+    expect(winner && store.sourceOf(winner)).toEqual({ tier: 'user' })
+    expect(store.getUserKeybindings()).toEqual([core])
+
+    store.removeAllKeybindingsForCommand('Comfy.Undo')
+    expect(store.getKeybindings(core.combo)).toEqual([])
+  })
+
+  it('preserves the choice when defaults and extensions register later', () => {
+    const store = useKeybindingStore()
+    const core = undo()
+    store.addUserKeybinding(core)
+    store.addDefaultKeybinding(core)
+    store.addExtensionKeybinding(extensionUndo(), 'Example')
+
+    const winner = store.getKeybindings(core.combo).at(0)
+    expect(winner?.commandId).toBe('Comfy.Undo')
+    expect(winner && store.sourceOf(winner)).toEqual({ tier: 'user' })
+    expect(store.getUserKeybindings()).toEqual([core])
+  })
+})

--- a/src/platform/keybindings/keybindingStore.test.ts
+++ b/src/platform/keybindings/keybindingStore.test.ts
@@ -636,8 +636,8 @@ describe('useKeybindingStore', () => {
       )
       store.addUserKeybinding(workspaceUndo())
 
-      expect(store.getUserKeybindings()).toEqual([])
-      expect(store.getUserUnsetKeybindings()).toEqual([])
+      expect(store.getUserKeybindings()).toEqual([workspaceUndo()])
+      expect(store.getUserUnsetKeybindings()).toEqual([workspaceUndo()])
       expect(store.getKeybindings(workspaceUndo().combo)).toEqual([
         workspaceUndo()
       ])
@@ -661,14 +661,14 @@ describe('useKeybindingStore', () => {
       expect(store.isCommandKeybindingModified('test.undo')).toBe(true)
     })
 
-    it('collapses a default registered after an identical user binding', () => {
+    it('preserves a user choice when an identical default registers later', () => {
       const store = useKeybindingStore()
       store.addUserKeybinding(workspaceUndo())
       store.addDefaultKeybinding(workspaceUndo())
 
-      expect(store.getUserKeybindings()).toEqual([])
+      expect(store.getUserKeybindings()).toEqual([workspaceUndo()])
       expect(store.keybindings).toEqual([workspaceUndo()])
-      expect(store.isCommandKeybindingModified('test.undo')).toBe(false)
+      expect(store.isCommandKeybindingModified('test.undo')).toBe(true)
     })
 
     it('reclaims the combo when resetting a command whose default a user binding took', () => {
@@ -742,6 +742,104 @@ describe('useKeybindingStore', () => {
     })
   })
 
+  describe('source tiers', () => {
+    const combo = { key: 'z', ctrl: true }
+    const coreUndo = () => new KeybindingImpl({ commandId: 'core.undo', combo })
+    const extensionUndo = () =>
+      new KeybindingImpl({ commandId: 'ext.undo', combo })
+
+    it('tries a user binding before a default with a narrower clause', () => {
+      const store = useKeybindingStore()
+      const narrow = new KeybindingImpl({
+        commandId: 'core.narrow',
+        combo,
+        when: 'core.mode'
+      })
+      store.addDefaultKeybinding(narrow)
+      const userBinding = new KeybindingImpl({ commandId: 'user.save', combo })
+      store.addUserKeybinding(userBinding)
+
+      expect(store.getKeybindings(narrow.combo)).toEqual([userBinding, narrow])
+    })
+
+    it('tries an extension binding before the core one and hides the core one', () => {
+      const store = useKeybindingStore()
+      store.addDefaultKeybinding(coreUndo())
+      store.addExtensionKeybinding(extensionUndo(), 'ext')
+
+      expect(store.getKeybindings(coreUndo().combo)).toEqual([
+        extensionUndo(),
+        coreUndo()
+      ])
+      expect(store.keybindings).toEqual([extensionUndo()])
+      expect(store.getKeybindingsByCommandId('core.undo')).toEqual([])
+      expect(store.isCommandKeybindingModified('core.undo')).toBe(false)
+    })
+
+    it('attributes each binding to its source', () => {
+      const store = useKeybindingStore()
+      const core = coreUndo()
+      const extension = extensionUndo()
+      const user = new KeybindingImpl({
+        commandId: 'user.save',
+        combo: { key: 'k', ctrl: true }
+      })
+      store.addDefaultKeybinding(core)
+      store.addExtensionKeybinding(extension, 'ext')
+      store.addUserKeybinding(user)
+
+      expect(store.sourceOf(core)).toEqual({ tier: 'core' })
+      expect(store.sourceOf(extension)).toEqual({
+        tier: 'extension',
+        name: 'ext'
+      })
+      expect(store.sourceOf(user)).toEqual({ tier: 'user' })
+      expect(store.keybindings.map(store.sourceOf)).toEqual([
+        { tier: 'extension', name: 'ext' },
+        { tier: 'user' }
+      ])
+    })
+
+    it('rejects a binding another extension already declared and names it', () => {
+      const store = useKeybindingStore()
+      store.addExtensionKeybinding(extensionUndo(), 'first')
+
+      expect(() =>
+        store.addExtensionKeybinding(
+          new KeybindingImpl({ commandId: 'other.undo', combo }),
+          'second'
+        )
+      ).toThrow('already exists on ext.undo from first')
+    })
+
+    it('ignores an extension binding identical to a core one', () => {
+      const store = useKeybindingStore()
+      store.addDefaultKeybinding(coreUndo())
+      store.addExtensionKeybinding(coreUndo(), 'ext')
+
+      expect(store.keybindings).toEqual([coreUndo()])
+      expect(store.sourceOf(store.keybindings[0])).toEqual({ tier: 'core' })
+    })
+
+    it('unsets every tier a user binding displaces', () => {
+      const store = useKeybindingStore()
+      store.addDefaultKeybinding(coreUndo())
+      store.addExtensionKeybinding(extensionUndo(), 'ext')
+      const userBinding = new KeybindingImpl({ commandId: 'user.save', combo })
+      store.addUserKeybinding(userBinding)
+
+      expect(store.getKeybindings(userBinding.combo)).toEqual([userBinding])
+      expect(store.getUserUnsetKeybindings()).toEqual([
+        coreUndo(),
+        extensionUndo()
+      ])
+
+      expect(store.resetKeybindingForCommand('ext.undo')).toBe(true)
+      expect(store.getKeybindings(userBinding.combo)).toEqual([extensionUndo()])
+      expect(store.getUserUnsetKeybindings()).toEqual([coreUndo()])
+    })
+  })
+
   it('treats a binding that matches the default combo but not its scope as modified', () => {
     const store = useKeybindingStore()
     const defaultBinding = new KeybindingImpl({
@@ -762,7 +860,7 @@ describe('useKeybindingStore', () => {
     )
   })
 
-  it('does not record a user binding identical to an active default', () => {
+  it('records an explicit user choice of the active default', () => {
     const store = useKeybindingStore()
     const keybinding = new KeybindingImpl({
       commandId: 'test.command',
@@ -771,8 +869,8 @@ describe('useKeybindingStore', () => {
     store.addDefaultKeybinding(keybinding)
     store.addUserKeybinding(keybinding)
 
-    expect(store.getUserKeybindings()).toEqual([])
-    expect(store.getUserUnsetKeybindings()).toEqual([])
-    expect(store.isCurrentPresetModified).toBe(false)
+    expect(store.getUserKeybindings()).toEqual([keybinding])
+    expect(store.getUserUnsetKeybindings()).toEqual([keybinding])
+    expect(store.isCurrentPresetModified).toBe(true)
   })
 })

--- a/src/platform/keybindings/keybindingStore.ts
+++ b/src/platform/keybindings/keybindingStore.ts
@@ -1,11 +1,26 @@
 import { groupBy } from 'es-toolkit/compat'
 import { defineStore } from 'pinia'
-import { computed, ref, shallowRef } from 'vue'
+import { computed, ref, shallowRef, toRaw } from 'vue'
 
 import type { KeyComboImpl } from './keyCombo'
 import { KeybindingImpl } from './keybinding'
 import type { KeybindingPreset } from './types'
 import { whenClauseSpecificity } from './whenClause'
+
+/** Who declared a binding. A user's rebind beats an extension's, which beats core. */
+export type KeybindingSource =
+  | { readonly tier: 'core' }
+  | { readonly tier: 'extension'; readonly name: string }
+  | { readonly tier: 'user' }
+
+const CORE_SOURCE: KeybindingSource = { tier: 'core' }
+const USER_SOURCE: KeybindingSource = { tier: 'user' }
+
+const TIER_RANK: Record<KeybindingSource['tier'], number> = {
+  user: 0,
+  extension: 1,
+  core: 2
+}
 
 function scopeKey(combo: KeyComboImpl, dialogKey: string | undefined) {
   return `${combo.serialize()}:${dialogKey ?? ''}`
@@ -18,22 +33,38 @@ function conflicts(a: KeybindingImpl, b: KeybindingImpl): boolean {
   )
 }
 
-/** Narrower clauses first; within a clause width, user bindings first. */
-function byResolutionOrder(a: KeybindingImpl, b: KeybindingImpl): number {
-  return whenClauseSpecificity(b.when) - whenClauseSpecificity(a.when)
-}
-
 function without(bindings: KeybindingImpl[], binding: KeybindingImpl) {
   return bindings.filter((existing) => !existing.equals(binding))
+}
+
+function attribution(source: KeybindingSource): string {
+  return source.tier === 'extension' ? ` from ${source.name}` : ''
 }
 
 export const useKeybindingStore = defineStore('keybinding', () => {
   const defaultKeybindings = shallowRef<KeybindingImpl[]>([])
   const userKeybindings = shallowRef<KeybindingImpl[]>([])
   const userUnsetKeybindings = shallowRef<KeybindingImpl[]>([])
+  const sources = new WeakMap<KeybindingImpl, KeybindingSource>()
 
   const currentPresetName = ref('default')
   const savedPresetData = ref<KeybindingPreset | null>(null)
+
+  function sourceOf(binding: KeybindingImpl): KeybindingSource {
+    return sources.get(toRaw(binding)) ?? USER_SOURCE
+  }
+
+  function rank(binding: KeybindingImpl): number {
+    return TIER_RANK[sourceOf(binding).tier]
+  }
+
+  /** Higher tier first, then narrower clause, then registration order. */
+  function byResolutionOrder(a: KeybindingImpl, b: KeybindingImpl): number {
+    return (
+      rank(a) - rank(b) ||
+      whenClauseSpecificity(b.when) - whenClauseSpecificity(a.when)
+    )
+  }
 
   const savedPresetSerialized = computed(() => {
     if (!savedPresetData.value) return null
@@ -88,15 +119,9 @@ export const useKeybindingStore = defineStore('keybinding', () => {
     )
   )
 
-  const keybindings = computed<KeybindingImpl[]>(() => [
-    ...activeDefaultKeybindings.value.filter(
-      (binding) =>
-        !userKeybindings.value.some((user) => conflicts(user, binding))
-    ),
-    ...userKeybindings.value
-  ])
-
-  const keybindingsByScope = computed<Partial<Record<string, KeybindingImpl[]>>>(() => {
+  const keybindingsByScope = computed<
+    Partial<Record<string, KeybindingImpl[]>>
+  >(() => {
     const groups = groupBy(
       [...userKeybindings.value, ...activeDefaultKeybindings.value],
       (binding) => scopeKey(binding.combo, binding.dialogKey)
@@ -104,6 +129,28 @@ export const useKeybindingStore = defineStore('keybinding', () => {
     for (const group of Object.values(groups)) group.sort(byResolutionOrder)
     return groups
   })
+
+  /** Hidden by a higher tier on the same combo, scope and clause, so they never run. */
+  const shadowedKeybindings = computed(() => {
+    const shadowed = new Set<KeybindingImpl>()
+    for (const group of Object.values(keybindingsByScope.value)) {
+      if (!group) continue
+      group.forEach((binding, index) => {
+        const winner = group
+          .slice(0, index)
+          .find((candidate) => conflicts(candidate, binding))
+        if (winner && rank(winner) < rank(binding)) shadowed.add(binding)
+      })
+    }
+    return shadowed
+  })
+
+  const keybindings = computed<KeybindingImpl[]>(() => [
+    ...activeDefaultKeybindings.value.filter(
+      (binding) => !shadowedKeybindings.value.has(binding)
+    ),
+    ...userKeybindings.value
+  ])
 
   /** Active bindings for a combo in a scope, in the order the dispatcher tries them. */
   function getKeybindings(
@@ -122,7 +169,7 @@ export const useKeybindingStore = defineStore('keybinding', () => {
   }
 
   const keybindingsByCommandId = computed<
-    Partial<Partial<Record<string, KeybindingImpl[]>>>
+    Partial<Record<string, KeybindingImpl[]>>
   >(() => {
     return groupBy(keybindings.value, 'commandId')
   })
@@ -145,35 +192,37 @@ export const useKeybindingStore = defineStore('keybinding', () => {
     return getKeybindingsByCommandId(commandId).at(0)
   }
 
-  function addDefaultKeybinding(keybinding: KeybindingImpl) {
-    const existing = defaultKeybindings.value.find((binding) =>
-      conflicts(binding, keybinding)
+  function registerDefault(
+    keybinding: KeybindingImpl,
+    source: KeybindingSource
+  ) {
+    const existing = defaultKeybindings.value.find(
+      (binding) =>
+        sourceOf(binding).tier === source.tier && conflicts(binding, keybinding)
     )
     if (existing) {
       throw new Error(
-        `Keybinding on ${keybinding.combo} already exists on ${existing.commandId}`
+        `Keybinding on ${keybinding.combo} already exists on ${existing.commandId}${attribution(sourceOf(existing))}`
       )
     }
+    if (
+      defaultKeybindings.value.some((binding) => binding.equals(keybinding))
+    ) {
+      return
+    }
+    sources.set(toRaw(keybinding), source)
     defaultKeybindings.value = [...defaultKeybindings.value, keybinding]
-    userKeybindings.value = without(userKeybindings.value, keybinding)
+  }
+
+  function addDefaultKeybinding(keybinding: KeybindingImpl) {
+    registerDefault(keybinding, CORE_SOURCE)
+  }
+
+  function addExtensionKeybinding(keybinding: KeybindingImpl, name: string) {
+    registerDefault(keybinding, { tier: 'extension', name })
   }
 
   function addUserKeybinding(keybinding: KeybindingImpl) {
-    const isDefault = defaultKeybindings.value.some((binding) =>
-      binding.equals(keybinding)
-    )
-    const unset = userUnsetKeybindings.value.find((binding) =>
-      binding.equals(keybinding)
-    )
-    if (isDefault && unset) {
-      userUnsetKeybindings.value = without(userUnsetKeybindings.value, unset)
-      userKeybindings.value = userKeybindings.value.filter(
-        (binding) => !conflicts(binding, keybinding)
-      )
-      return
-    }
-    if (isDefault) return
-
     for (const binding of activeDefaultKeybindings.value) {
       if (conflicts(binding, keybinding)) unsetKeybinding(binding)
     }
@@ -181,7 +230,7 @@ export const useKeybindingStore = defineStore('keybinding', () => {
       ...userKeybindings.value.filter(
         (binding) => !conflicts(binding, keybinding)
       ),
-      keybinding
+      new KeybindingImpl(keybinding)
     ]
   }
 
@@ -191,7 +240,11 @@ export const useKeybindingStore = defineStore('keybinding', () => {
     )
     if (user) {
       userKeybindings.value = without(userKeybindings.value, user)
-      return
+      if (
+        !activeDefaultKeybindings.value.some((binding) => binding.equals(user))
+      ) {
+        return
+      }
     }
 
     const active = activeDefaultKeybindings.value.find((binding) =>
@@ -267,32 +320,18 @@ export const useKeybindingStore = defineStore('keybinding', () => {
     return true
   }
 
+  /** Commands the user changed: rebound, unset, or displaced by a user binding. */
   const modifiedCommandIds = computed<Set<string>>(() => {
     const result = new Set<string>()
-    const allCommandIds = new Set([
-      ...Object.keys(keybindingsByCommandId.value),
-      ...Object.keys(defaultKeybindingsByCommandId.value)
-    ])
-
-    for (const commandId of allCommandIds) {
-      const currentBindings = keybindingsByCommandId.value[commandId] ?? []
-      const defaultBindings =
-        defaultKeybindingsByCommandId.value[commandId] ?? []
-
-      if (currentBindings.length !== defaultBindings.length) {
-        result.add(commandId)
-        continue
-      }
-      if (currentBindings.length === 0) continue
-
-      const sortedCurrent = currentBindings.map((b) => b.serialize()).sort()
-      const sortedDefault = defaultBindings.map((b) => b.serialize()).sort()
-
-      if (sortedCurrent.some((binding, i) => binding !== sortedDefault[i])) {
-        result.add(commandId)
+    for (const binding of userKeybindings.value) result.add(binding.commandId)
+    for (const binding of userUnsetKeybindings.value) {
+      result.add(binding.commandId)
+    }
+    for (const binding of defaultKeybindings.value) {
+      if (userKeybindings.value.some((user) => conflicts(user, binding))) {
+        result.add(binding.commandId)
       }
     }
-
     return result
   })
 
@@ -302,6 +341,7 @@ export const useKeybindingStore = defineStore('keybinding', () => {
 
   return {
     keybindings,
+    sourceOf,
     getUserKeybindings,
     getUserUnsetKeybindings,
     getKeybindings,
@@ -310,6 +350,7 @@ export const useKeybindingStore = defineStore('keybinding', () => {
     getDefaultKeybindingsByCommandId,
     getKeybindingByCommandId,
     addDefaultKeybinding,
+    addExtensionKeybinding,
     addUserKeybinding,
     unsetKeybinding,
     resetAllKeybindings,

--- a/src/services/extensionService.test.ts
+++ b/src/services/extensionService.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { useContextKeyStore } from '@/platform/keybindings/contextKeyStore'
 import { KeyComboImpl } from '@/platform/keybindings/keyCombo'
+import { KeybindingImpl } from '@/platform/keybindings/keybinding'
 import { useKeybindingStore } from '@/platform/keybindings/keybindingStore'
 import { useToastStore } from '@/platform/updates/common/toastStore'
 import type { Keybinding } from '@/platform/keybindings/types'
@@ -82,6 +83,28 @@ describe('registerExtension keybindings', () => {
         new KeyComboImpl({ key: 'k', ctrl: true })
       )
     ).toEqual([])
+  })
+
+  it('registers keybindings in the extension tier alongside core ones', () => {
+    const store = useKeybindingStore()
+    const combo = { key: 'z', ctrl: true }
+    store.addDefaultKeybinding(
+      new KeybindingImpl({ commandId: 'Comfy.Undo', combo })
+    )
+    const toast = vi.spyOn(useToastStore(), 'add')
+
+    useExtensionService().registerExtension({
+      name: 'Test.Tier',
+      keybindings: [{ combo, commandId: 'Test.Undo' }]
+    })
+
+    const winner = store.getKeybindings(new KeyComboImpl(combo))[0]
+    expect(winner.commandId).toBe('Test.Undo')
+    expect(store.sourceOf(winner)).toEqual({
+      tier: 'extension',
+      name: 'Test.Tier'
+    })
+    expect(toast).not.toHaveBeenCalled()
   })
 
   it('registers context keys under the extension name', () => {

--- a/src/services/extensionService.ts
+++ b/src/services/extensionService.ts
@@ -83,8 +83,8 @@ export const useExtensionService = () => {
   const registerExtension = (extension: ComfyExtension) => {
     extensionStore.registerExtension(extension)
 
-    const addKeybinding = wrapWithErrorHandling(
-      keybindingStore.addDefaultKeybinding
+    const addKeybinding = wrapWithErrorHandling((keybinding: KeybindingImpl) =>
+      keybindingStore.addExtensionKeybinding(keybinding, extension.name)
     )
     const addSetting = wrapWithErrorHandling(settingStore.addSetting)
 


### PR DESCRIPTION
## Summary

Resolve eligible bindings by user, extension, then core priority before comparing clause specificity.

## Changes

- Track registration provenance, allow extensions to shadow core defaults, and identify extension conflicts in the shortcuts UI.
- Preserve an explicit user choice even when it matches a core default, including when an extension registers later.
- Deny extensions the reserved text-input opt-in while retaining it for core and user bindings.

## Review Focus

Selecting the original Ctrl+Z binding must override an extension's Ctrl+Z binding and survive late registration. Regression tests cover both cases; focused store, preset and editor tests pass.
