### PR TITLE
ci: skip custom-node suites for non-app-source merge-queue candidates

### DIFF
--- a/.github/actions/changes-filter/action.yaml
+++ b/.github/actions/changes-filter/action.yaml
@@ -4,10 +4,18 @@
 # would never run on push.
 #
 # `evaluate-candidate` opts a caller out of that default for merge_group only,
-# via `candidate-should-run`: a merge-queue candidate is a diff against a base
-# just like a pull request. Opt in only from a workflow that emits its required
-# check on every event whatever the verdict - a check GitHub never creates
-# leaves the queue waiting forever. Omitting the input keeps the output 'true'.
+# via `candidate-should-run`. dorny/paths-filter diffs `merge_group.base_sha`
+# (the target branch tip) against `merge_group.head_sha` (GitHub's temporary
+# merge commit for the candidate), which already folds in every queue entry
+# ahead of it - so this is whole-queue relevance, not an isolated diff of the
+# candidate's own PR. It still fails safely (an irrelevant-looking entry can
+# only be false-positive-relevant when an entry ahead of it touched a gated
+# path, never false-negative), but it is not the per-candidate optimization
+# the name implies; a later, unrelated entry queued behind a `src/**` change
+# still runs the gated suites. Opt in only from a workflow that emits its
+# required check on every event whatever the verdict - a check GitHub never
+# creates leaves the queue waiting forever. Omitting the input keeps the
+# output 'true'.
 #
 # Shared dependency files (root package.json, pnpm-lock.yaml,
 # pnpm-workspace.yaml) are folded into every app-* and packages-changes
@@ -39,7 +47,7 @@ outputs:
     description: 'Any file outside `apps/`, `docs/`, `.storybook/`, or `**/*.md` changed. Ignores `evaluate-candidate`; read `candidate-should-run` to act on merge_group.'
     value: ${{ github.event_name != 'pull_request' || steps.relevant.outputs.relevant == 'true' }}
   candidate-should-run:
-    description: 'As `should-run`, but also evaluated for merge-queue candidates when `evaluate-candidate` is set.'
+    description: 'As `should-run`, but also evaluated for merge-queue candidates when `evaluate-candidate` is set. That evaluation is against the accumulated merge-group diff (base branch tip vs. the temporary merge commit, which includes every queue entry ahead of this one), not this candidate PR in isolation.'
     value: ${{ (github.event_name != 'pull_request' && github.event_name != 'merge_group') || (github.event_name == 'merge_group' && inputs.evaluate-candidate != 'true') || steps.relevant.outputs.relevant == 'true' }}
   app-website-changes:
     description: 'Shared deps or `apps/website/**` changed.'

--- a/.github/actions/changes-filter/action.yaml
+++ b/.github/actions/changes-filter/action.yaml
@@ -3,6 +3,12 @@
 # skip footgun where a job gated on e.g. `app-website-changes == 'true'`
 # would never run on push.
 #
+# `evaluate-candidate` opts a caller out of that default for merge_group only,
+# via `candidate-should-run`: a merge-queue candidate is a diff against a base
+# just like a pull request. Opt in only from a workflow that emits its required
+# check on every event whatever the verdict - a check GitHub never creates
+# leaves the queue waiting forever. Omitting the input keeps the output 'true'.
+#
 # Shared dependency files (root package.json, pnpm-lock.yaml,
 # pnpm-workspace.yaml) are folded into every app-* and packages-changes
 # output so a lockfile bump correctly invalidates each granular gate. They
@@ -19,10 +25,22 @@ description: >
   Computes typed *-changes outputs and a back-compat should-run for
   path-gated CI jobs.
 
+inputs:
+  evaluate-candidate:
+    description: >
+      Evaluate the relevance predicate for merge_group candidates too, so
+      `candidate-should-run` can be false there. Left off, merge-queue
+      candidates keep the unconditional 'true' every other output uses.
+    required: false
+    default: 'false'
+
 outputs:
   should-run:
-    description: 'Any file outside `apps/`, `docs/`, `.storybook/`, or `**/*.md` changed.'
+    description: 'Any file outside `apps/`, `docs/`, `.storybook/`, or `**/*.md` changed. Ignores `evaluate-candidate`; read `candidate-should-run` to act on merge_group.'
     value: ${{ github.event_name != 'pull_request' || steps.relevant.outputs.relevant == 'true' }}
+  candidate-should-run:
+    description: 'As `should-run`, but also evaluated for merge-queue candidates when `evaluate-candidate` is set.'
+    value: ${{ (github.event_name != 'pull_request' && github.event_name != 'merge_group') || (github.event_name == 'merge_group' && inputs.evaluate-candidate != 'true') || steps.relevant.outputs.relevant == 'true' }}
   app-website-changes:
     description: 'Shared deps or `apps/website/**` changed.'
     value: ${{ github.event_name != 'pull_request' || steps.filter.outputs.deps == 'true' || steps.filter.outputs.app_website == 'true' }}
@@ -68,7 +86,7 @@ runs:
             - 'pnpm-workspace.yaml'
 
     - name: Filter relevant changes
-      if: ${{ github.event_name == 'pull_request' }}
+      if: ${{ github.event_name == 'pull_request' || (github.event_name == 'merge_group' && inputs.evaluate-candidate == 'true') }}
       id: relevant
       uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
       with:

--- a/.github/actions/changes-filter/action.yaml
+++ b/.github/actions/changes-filter/action.yaml
@@ -3,19 +3,21 @@
 # skip footgun where a job gated on e.g. `app-website-changes == 'true'`
 # would never run on push.
 #
-# `evaluate-candidate` opts a caller out of that default for merge_group only,
-# via `candidate-should-run`. dorny/paths-filter diffs `merge_group.base_sha`
-# (the target branch tip) against `merge_group.head_sha` (GitHub's temporary
-# merge commit for the candidate), which already folds in every queue entry
-# ahead of it - so this is whole-queue relevance, not an isolated diff of the
-# candidate's own PR. It still fails safely (an irrelevant-looking entry can
-# only be false-positive-relevant when an entry ahead of it touched a gated
-# path, never false-negative), but it is not the per-candidate optimization
-# the name implies; a later, unrelated entry queued behind a `src/**` change
-# still runs the gated suites. Opt in only from a workflow that emits its
-# required check on every event whatever the verdict - a check GitHub never
-# creates leaves the queue waiting forever. Omitting the input keeps the
-# output 'true'.
+# `evaluate-candidate` opts a caller out of that default, extending `should-run`
+# to merge_group. paths-filter diffs `merge_group.base_sha..head_sha`, and the
+# webhook schema defines base_sha as the merge group's PARENT commit: the
+# preceding entry's synthetic head, or the target branch tip when the candidate
+# is first in line. Entries ahead of this one therefore sit on both sides of the
+# range and cancel, so the verdict isolates the candidate - a website-only entry
+# queued behind a `src/**` change still evaluates to irrelevant. Merge limits
+# govern only the merge step and never combine merge_group builds, so one build
+# is always one candidate. Being a two-dot tree comparison the range omits paths
+# the candidate leaves identical to its parent, which is why nothing that
+# actually lands goes untested. It does need base_sha to be anonymously
+# fetchable, as the callers check out without credentials. Opt in only from a
+# workflow that emits its required check on every event whatever the verdict -
+# a check GitHub never creates leaves the queue waiting forever. Omitting the
+# input leaves every output exactly as it was.
 #
 # Shared dependency files (root package.json, pnpm-lock.yaml,
 # pnpm-workspace.yaml) are folded into every app-* and packages-changes
@@ -36,18 +38,15 @@ description: >
 inputs:
   evaluate-candidate:
     description: >
-      Evaluate the relevance predicate for merge_group candidates too, so
-      `candidate-should-run` can be false there. Left off, merge-queue
-      candidates keep the unconditional 'true' every other output uses.
+      Also evaluate `should-run` for merge_group candidates, so it can be
+      false there. Left off, merge-queue candidates keep the unconditional
+      'true' every output uses for non-pull_request events.
     required: false
     default: 'false'
 
 outputs:
   should-run:
-    description: 'Any file outside `apps/`, `docs/`, `.storybook/`, or `**/*.md` changed. Ignores `evaluate-candidate`; read `candidate-should-run` to act on merge_group.'
-    value: ${{ github.event_name != 'pull_request' || steps.relevant.outputs.relevant == 'true' }}
-  candidate-should-run:
-    description: 'As `should-run`, but also evaluated for merge-queue candidates when `evaluate-candidate` is set. That evaluation is against the accumulated merge-group diff (base branch tip vs. the temporary merge commit, which includes every queue entry ahead of this one), not this candidate PR in isolation.'
+    description: "Any file outside `apps/`, `docs/`, `.storybook/`, or `**/*.md` changed. Also evaluated for merge-queue candidates when `evaluate-candidate` is 'true', over the range from the merge group's parent commit (the preceding entry's synthetic head, or the target branch tip when first in line) to this candidate's synthetic head."
     value: ${{ (github.event_name != 'pull_request' && github.event_name != 'merge_group') || (github.event_name == 'merge_group' && inputs.evaluate-candidate != 'true') || steps.relevant.outputs.relevant == 'true' }}
   app-website-changes:
     description: 'Shared deps or `apps/website/**` changed.'

--- a/.github/actions/changes-filter/action.yaml
+++ b/.github/actions/changes-filter/action.yaml
@@ -1,23 +1,12 @@
-# Outputs default to 'true' for non-pull_request events (push, merge_group):
-# granular path filtering is a PR-only optimization. This avoids the silent
-# skip footgun where a job gated on e.g. `app-website-changes == 'true'`
-# would never run on push.
+# Outputs default to 'true' for non-pull_request events: granular path filtering
+# is a PR-only optimization. This avoids the silent skip footgun where a job
+# gated on e.g. `app-website-changes == 'true'` would never run on push.
+# `evaluate-candidate` is the one exception, and only for `should-run`.
 #
-# `evaluate-candidate` opts a caller out of that default, extending `should-run`
-# to merge_group. paths-filter diffs `merge_group.base_sha..head_sha`, and the
-# webhook schema defines base_sha as the merge group's PARENT commit: the
-# preceding entry's synthetic head, or the target branch tip when the candidate
-# is first in line. Entries ahead of this one therefore sit on both sides of the
-# range and cancel, so the verdict isolates the candidate - a website-only entry
-# queued behind a `src/**` change still evaluates to irrelevant. Merge limits
-# govern only the merge step and never combine merge_group builds, so one build
-# is always one candidate. Being a two-dot tree comparison the range omits paths
-# the candidate leaves identical to its parent, which is why nothing that
-# actually lands goes untested. It does need base_sha to be anonymously
-# fetchable, as the callers check out without credentials. Opt in only from a
-# workflow that emits its required check on every event whatever the verdict -
-# a check GitHub never creates leaves the queue waiting forever. Omitting the
-# input leaves every output exactly as it was.
+# It compares a merge-group candidate's synthetic head with its parent, so the
+# verdict covers that candidate alone. Opt in only from a workflow whose
+# required check is emitted whatever the verdict; a check GitHub never creates
+# leaves the queue waiting.
 #
 # Shared dependency files (root package.json, pnpm-lock.yaml,
 # pnpm-workspace.yaml) are folded into every app-* and packages-changes
@@ -39,14 +28,17 @@ inputs:
   evaluate-candidate:
     description: >
       Also evaluate `should-run` for merge_group candidates, so it can be
-      false there. Left off, merge-queue candidates keep the unconditional
-      'true' every output uses for non-pull_request events.
+      false there. Left off, they keep the unconditional 'true'.
     required: false
     default: 'false'
 
 outputs:
   should-run:
-    description: "Any file outside `apps/`, `docs/`, `.storybook/`, or `**/*.md` changed. Also evaluated for merge-queue candidates when `evaluate-candidate` is 'true', over the range from the merge group's parent commit (the preceding entry's synthetic head, or the target branch tip when first in line) to this candidate's synthetic head."
+    description: >
+      Any file outside `apps/`, `docs/`, `.storybook/`, or `**/*.md` changed.
+      With `evaluate-candidate` set to 'true', also evaluated for merge-queue
+      candidates, over the range from the merge group's parent commit to this
+      candidate's synthetic head.
     value: ${{ (github.event_name != 'pull_request' && github.event_name != 'merge_group') || (github.event_name == 'merge_group' && inputs.evaluate-candidate != 'true') || steps.relevant.outputs.relevant == 'true' }}
   app-website-changes:
     description: 'Shared deps or `apps/website/**` changed.'

--- a/.github/workflows/ci-ecosystem-matrix.yaml
+++ b/.github/workflows/ci-ecosystem-matrix.yaml
@@ -1,4 +1,4 @@
-# Required gate: on relevant PRs and every merge candidate, execute every
+# Required gate: on relevant PRs and relevant merge candidates, execute every
 # registry pack's frontend JS in both supported renderers.
 #
 # The corpus is a mirror of the frontend JS of EVERY registry pack (~5,100
@@ -58,11 +58,12 @@ env:
 jobs:
   changes:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
       contents: read
       pull-requests: read
     outputs:
-      should-run: ${{ github.event_name == 'pull_request' && github.event.pull_request.changed_files >= 3000 || steps.changes.outputs.should-run }}
+      should-run: ${{ github.event_name == 'pull_request' && github.event.pull_request.changed_files >= 3000 || steps.changes.outputs.candidate-should-run }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
@@ -72,6 +73,8 @@ jobs:
       - name: Detect relevant changes
         id: changes
         uses: ./.github/actions/changes-filter
+        with:
+          evaluate-candidate: 'true'
 
   # First job in the run, and deliberately dependency-free so its annotation
   # and step summary land at the top. Stale pins are the one failure mode this
@@ -572,7 +575,10 @@ jobs:
           case "$SHOULD_RUN" in
             true) ;;
             false)
-              [ "$EVENT_NAME" = pull_request ] || { echo "::error::change detection returned false for $EVENT_NAME"; exit 1; }
+              case "$EVENT_NAME" in
+                pull_request | merge_group) ;;
+                *) echo "::error::change detection returned false for $EVENT_NAME"; exit 1 ;;
+              esac
               ;;
             *) echo "::error::change detection returned invalid value '$SHOULD_RUN'"; exit 1 ;;
           esac
@@ -580,7 +586,7 @@ jobs:
             for result in "$PIN_STATUS_RESULT" "$CORPUS_RESULT" "$SHARDS_RESULT" "$VERDICTS_RESULT" "$PROOFS_RESULT"; do
               [ "$result" = skipped ] || { echo "::error::irrelevant-change dependency ended with $result"; exit 1; }
             done
-            echo 'ecosystem matrix not applicable to this pull request'
+            echo 'ecosystem matrix not applicable to this candidate'
             exit 0
           fi
           failures=()

--- a/.github/workflows/ci-ecosystem-matrix.yaml
+++ b/.github/workflows/ci-ecosystem-matrix.yaml
@@ -63,7 +63,7 @@ jobs:
       contents: read
       pull-requests: read
     outputs:
-      should-run: ${{ github.event_name == 'pull_request' && github.event.pull_request.changed_files >= 3000 || steps.changes.outputs.candidate-should-run }}
+      should-run: ${{ github.event_name == 'pull_request' && github.event.pull_request.changed_files >= 3000 || steps.changes.outputs.should-run }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7

--- a/.github/workflows/ci-tests-custom-nodes.yaml
+++ b/.github/workflows/ci-tests-custom-nodes.yaml
@@ -70,11 +70,12 @@ env:
 jobs:
   changes:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
       contents: read
       pull-requests: read
     outputs:
-      should-run: ${{ github.event_name == 'pull_request' && github.event.pull_request.changed_files >= 3000 || steps.changes.outputs.should-run }}
+      should-run: ${{ github.event_name == 'pull_request' && github.event.pull_request.changed_files >= 3000 || steps.changes.outputs.candidate-should-run }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
@@ -84,6 +85,8 @@ jobs:
       - name: Detect relevant changes
         id: changes
         uses: ./.github/actions/changes-filter
+        with:
+          evaluate-candidate: 'true'
 
   # Each job is intentionally one worker: the auto-run tier needs exclusive
   # access to its backend's queue. Parallelism comes from the shard matrix
@@ -456,13 +459,16 @@ jobs:
           case "$SHOULD_RUN" in
             true) ;;
             false)
-              [ "$EVENT_NAME" = pull_request ] || { echo "::error::change detection returned false for $EVENT_NAME"; exit 1; }
+              case "$EVENT_NAME" in
+                pull_request | merge_group) ;;
+                *) echo "::error::change detection returned false for $EVENT_NAME"; exit 1 ;;
+              esac
               ;;
             *) echo "::error::change detection returned invalid value '$SHOULD_RUN'"; exit 1 ;;
           esac
           if [ "$SHOULD_RUN" = false ]; then
             [ "$E2E_RESULT" = skipped ] || { echo "::error::irrelevant-change matrix ended with $E2E_RESULT"; exit 1; }
-            echo 'custom-node matrix not applicable to this pull request'
+            echo 'custom-node matrix not applicable to this candidate'
             exit 0
           fi
           [ "$E2E_RESULT" = success ] || { echo "::error::custom-node matrix ended with $E2E_RESULT"; exit 1; }

--- a/.github/workflows/ci-tests-custom-nodes.yaml
+++ b/.github/workflows/ci-tests-custom-nodes.yaml
@@ -75,7 +75,7 @@ jobs:
       contents: read
       pull-requests: read
     outputs:
-      should-run: ${{ github.event_name == 'pull_request' && github.event.pull_request.changed_files >= 3000 || steps.changes.outputs.candidate-should-run }}
+      should-run: ${{ github.event_name == 'pull_request' && github.event.pull_request.changed_files >= 3000 || steps.changes.outputs.should-run }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7

--- a/.github/workflows/ci-tests-custom-nodes.yaml
+++ b/.github/workflows/ci-tests-custom-nodes.yaml
@@ -86,6 +86,7 @@ jobs:
         id: changes
         uses: ./.github/actions/changes-filter
         with:
+          # Inert until this workflow's pull_request/merge_group triggers return.
           evaluate-candidate: 'true'
 
   # Each job is intentionally one worker: the auto-run tier needs exclusive


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

## Summary

Requested by the dev team in Slack (#frontend-code-reviews), motivated by #16545 — an `apps/website/**`-only PR that looked like it triggered custom-node CI. Investigating it turned up something more specific than the reported symptom.

**On the pull request, exclusion already works.** On #16545 `custom_nodes_e2e`, `corpus`, `pin-status`, `ecosystem-matrix`, `matrix-verdict` and `matrix-detection-proof` were all `skipped`; what shows up in the checks list is the `changes` job plus the two aggregate gates, which are meant to report on every candidate. No change was needed there.

**The real gap is the merge queue.** `changes-filter` runs `dorny/paths-filter` only `if: github.event_name == 'pull_request'`, and every output short-circuits to `'true'` otherwise — so a website-only PR skips the gate on its PR and then runs it in full on the way through the queue. Measured on merge_group run `33570544833`: 7 × `custom_nodes_e2e` = **83.7 runner-minutes**, plus the ecosystem matrix (corpus + 8 shards + 2 verdicts + 2 detection proofs) on top. Sampling merge-queue candidates from 2026-09-01, 5 of the 27 I could check had a diff consisting entirely of `apps/`, `docs/` or `.storybook/` — #16243, #16247, #16249, #16310 (website) and #15881 (docs) — and each ran the whole thing.

A `merge_group` event is a candidate diff against a base exactly like a pull request, so the same predicate applies.

## Changes

- **What**: add an opt-in `evaluate-candidate` input to `.github/actions/changes-filter` that also evaluates the existing `relevant` predicate on `merge_group`, exposed as a new `candidate-should-run` output; opt the two custom-node workflows into it. `dorny/paths-filter@v4.0.3` already derives base/ref from `merge_group.base_sha`/`head_sha` (`src/main.ts` `case 'merge_group'`), so the diff is the candidate's own changes, not the whole queue.
- **What**: both aggregate status jobs now accept a `false` verdict on `merge_group` as they already did on `pull_request`. Without this they hard-fail on any non-PR `false` and the queue would go red.
- **Breaking**: none. The input defaults off, so `should-run` and the ten other consumers of the action are byte-identical to `main`, and a caller that forgets the input gets `'true'` rather than a silent skip.

Deliberately **not** done: no workflow-level `paths:`/`paths-ignore:`. Both workflows must keep emitting their aggregate check on every event — a check GitHub never creates leaves the queue waiting forever, as the comment on `ci-ecosystem-matrix.yaml`'s trigger already warns.

## Review Focus

Verification, beyond `yamllint` + `actionlint` clean:

- Ran the **real pinned `paths-filter` bundle** (`ceb8a2b`) against synthetic `merge_group` payloads on real depth-1 shallow clones. `base_sha` is absent from a depth-1 checkout, so it fetches: `git fetch --depth=1 --no-tags origin <sha>` then a two-dot `base..head` diff. Confirmed the diff excludes an earlier queued PR's `src/` change — it is the candidate's own delta only.
- Full-pipeline simulation, real bundle feeding the real status-guard script:

```
SCENARIO                   OPT-IN  STEP     RELEVANT  VERDICT   MATRIX    REQUIRED CHECK
website-only               true    ran      false     false     skipped   green
main-app src/**            true    ran      true      true      RUNS      green
.github/** (this PR)       true    ran      true      true      RUNS      green
docs/**.md only            true    ran      false     false     skipped   green
website + src mixed        true    ran      true      true      RUNS      green
website-only               false   skipped  -         true      RUNS      green   <- other consumers
docs/**.md only            false   skipped  -         true      RUNS      green   <- other consumers
```

- **Fail-closed**: with an unresolvable `base_sha` the action exits 1 with `::error::` and writes no output, so the `changes` job fails, `CHANGES_RESULT != success` trips the first assertion in both status jobs, and the candidate is ejected. It never degrades to a silent skip.
- Exercised both rewritten shell guards over every `(event, should-run, result)` combination: `merge_group` + `false` + `skipped` is green; `false` + `success`/`failure` is red; `push`/`schedule` + `false` still red; empty still red.

Three things worth an explicit opinion:

1. This PR touches `.github/**`, which is relevant, so it runs the full matrices on itself.
2. `ci-tests-custom-nodes.yaml` has no `push: main` trigger, so the queue was previously its only unconditional re-run against the exact tree about to land. For irrelevant candidates that is now the nightly `schedule` alone — intended, but a real reduction in redundancy rather than a free win.
3. Review flagged that the `changes` job's `paths-filter` fetch is anonymous, because the checkout uses `persist-credentials: false`. I left that as-is rather than weaken the existing posture: it works today and fails closed. Added `timeout-minutes: 5` to both `changes` jobs to bound it (every other job in these files already has one). Separately, `custom-nodes-e2e-status` has no `timeout-minutes` while its sibling aggregate does — pre-existing, left for a follow-up.

Note this is scoped to the custom-node suites as asked; `ci-tests-e2e` and `ci-tests-unit` read the unchanged `should-run`, so a website-only merge-queue candidate still runs those. Happy to extend the same treatment to them in a follow-up if wanted.
