### PR TITLE
test: drop stale VHS LiteGraph per_batch allowlist keys

### DIFF
--- a/browser_tests/fixtures/customNode/allNodesRoundtripTier.ts
+++ b/browser_tests/fixtures/customNode/allNodesRoundtripTier.ts
@@ -130,12 +130,6 @@ const WIDGET_SET_ALLOWLIST_BY_IDENTITY: Record<
 }
 
 const ROUNDTRIP_VALUE_ALLOWLIST: Record<string, Record<string, string>> = {
-  'ComfyUI-VideoHelperSuite': {
-    VHS_VAEDecodeBatched:
-      'per_batch serializes null after configure (VHS ANNOTATED widget deserialization gap) - upstream-report candidate',
-    VHS_VAEEncodeBatched:
-      'per_batch serializes null after configure (VHS ANNOTATED widget deserialization gap) - upstream-report candidate'
-  },
   'ComfyUI-LTXVideo': {
     LTXVSparseTrackEditor:
       'the sparse-track editor regenerates its derived integer coordinates from the preserved source points on configure'

--- a/browser_tests/fixtures/customNode/allNodesRoundtripTier.ts
+++ b/browser_tests/fixtures/customNode/allNodesRoundtripTier.ts
@@ -419,16 +419,22 @@ export async function assertRoundtripTier({
             const afterNormalized =
               Array.isArray(after) && after.length === 0 ? null : after
             if (beforeNormalized === null) return true
-            if (Array.isArray(beforeNormalized))
+            if (Array.isArray(beforeNormalized)) {
+              const afterValues = Array.isArray(afterNormalized)
+                ? afterNormalized
+                : afterNormalized !== null &&
+                    typeof afterNormalized === 'object'
+                  ? Object.values(afterNormalized)
+                  : null
               return (
-                Array.isArray(afterNormalized) &&
-                afterNormalized.length >= beforeNormalized.length &&
+                afterValues !== null &&
+                afterValues.length >= beforeNormalized.length &&
                 beforeNormalized.every(
                   (value, index) =>
-                    JSON.stringify(value) ===
-                    JSON.stringify(afterNormalized[index])
+                    JSON.stringify(value) === JSON.stringify(afterValues[index])
                 )
               )
+            }
             if (typeof beforeNormalized === 'object')
               return (
                 typeof afterNormalized === 'object' &&

--- a/browser_tests/fixtures/customNode/valueDrift.ts
+++ b/browser_tests/fixtures/customNode/valueDrift.ts
@@ -37,12 +37,10 @@ export const ROUNDTRIP_VALUE_ALLOWED_KEYS_LITEGRAPH: Record<
   Record<string, string>
 > = {}
 
-export const ROUNDTRIP_VALUE_ALLOWED_KEYS_VUE = {
-  'ComfyUI-VideoHelperSuite': {
-    VHS_VAEDecodeBatched: 'per_batch',
-    VHS_VAEEncodeBatched: 'per_batch'
-  }
-}
+export const ROUNDTRIP_VALUE_ALLOWED_KEYS_VUE: Record<
+  string,
+  Record<string, string>
+> = {}
 
 export type RoundtripInitializationSignal =
   | { property: string; predicate: 'defined' }

--- a/browser_tests/fixtures/customNode/valueDrift.ts
+++ b/browser_tests/fixtures/customNode/valueDrift.ts
@@ -32,14 +32,10 @@ export const ROUNDTRIP_VALUE_ALLOWED_INDICES_VUE: Record<
   }
 }
 
-const VHS_ROUNDTRIP_VALUE_KEYS_LITEGRAPH = {
-  VHS_VAEDecodeBatched: 'per_batch',
-  VHS_VAEEncodeBatched: 'per_batch'
-}
-
-export const ROUNDTRIP_VALUE_ALLOWED_KEYS_LITEGRAPH = {
-  'ComfyUI-VideoHelperSuite': VHS_ROUNDTRIP_VALUE_KEYS_LITEGRAPH
-}
+export const ROUNDTRIP_VALUE_ALLOWED_KEYS_LITEGRAPH: Record<
+  string,
+  Record<string, string>
+> = {}
 
 export const ROUNDTRIP_VALUE_ALLOWED_KEYS_VUE = {
   'ComfyUI-VideoHelperSuite': {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

S3 save/reload on main no longer observes VHS `per_batch` value drift. The shared allowlist still listed those keys, so the surviving spec failed closed.

Same fail again on `d47f0c26` after #16359:

```
stale ROUNDTRIP_VALUE_ALLOWED_KEYS entries with VueNodes=false: VHS_VAEDecodeBatched.per_batch, VHS_VAEEncodeBatched.per_batch
```

This PR stays the vehicle for that contract. No second PR.

## Standing status

Draft. Do not mark ready. Do not auto-merge. Do not convert to ready unless ShihChi explicitly says mark ready.

## Changes

- **What**:
  - Retire `VHS_VAEDecodeBatched.per_batch` and `VHS_VAEEncodeBatched.per_batch` from `ROUNDTRIP_VALUE_ALLOWED_KEYS_LITEGRAPH`, `ROUNDTRIP_VALUE_ALLOWED_KEYS_VUE`, and `ROUNDTRIP_VALUE_ALLOWLIST`.
  - S3 `preserves` on this branch also accepts array → named-object when values match.
- **Breaking**: none

## Later main landings (do not merge this PR as-is)

While this draft was open, main received the same root-cause work:

- #16650 emptied the stale VHS key ledgers
- #16676 compares `widgets_values` by name when only the container shape changes (serializer-aligned names)

Rebasing this branch onto current `origin/main` leaves no unique allowlist diff. The remaining `preserves` hunk here is weaker than #16676 (`Object.values` vs named keys + `serialize: false` alignment) and would regress that fix. Left un-rebased so this draft keeps the original characterization; do not merge it over #16676.

## Evidence

Main fail after #15381 (`93f2d927`): https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/33578231033

Main fail after #16359 (`d47f0c26`): same stale keys (`VHS_VAEDecodeBatched.per_batch`, `VHS_VAEEncodeBatched.per_batch`, `VueNodes=false`)

- Surviving spec: `browser_tests/tests/customNodes/allNodes.spec.ts` (`S3: enrolled registered-node save/reload outcomes match exact contracts`)
- Allowlist change: `browser_tests/fixtures/customNode/valueDrift.ts:35-43`
- Stale-key assertion: `browser_tests/fixtures/customNode/allNodesRoundtripTier.ts:884-887`

## Verify

```bash
pnpm exec playwright test browser_tests/tests/customNodes/allNodes.spec.ts \
  --config playwright.chrome.config.ts \
  --grep "S3: enrolled registered-node save/reload"
```

Expected: that S3 case green for ComfyUI-VideoHelperSuite; no other product behavior change.

Does not reopen #16537. Auto-merge stays off.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eeb82432-caeb-40df-aa07-9337878a636f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eeb82432-caeb-40df-aa07-9337878a636f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

