### PR TITLE
test(agent): pin transcript normalization edge cases

### DIFF
--- a/src/workbench/extensions/agent/services/agent/agentTranscript.test.ts
+++ b/src/workbench/extensions/agent/services/agent/agentTranscript.test.ts
@@ -76,4 +76,17 @@ describe('normalizeAgentTranscript', () => {
     expect(transcript.assistantTurnIds).toEqual(new Set())
     expect(transcript.rowIds).toEqual(new Set(['row-1', 'row-2']))
   })
+
+  it('concatenates assistant rows in sequence order within a turn', () => {
+    const transcript = normalizeAgentTranscript([
+      row(3, 'assistant', 'turn-a', 'Second', 'row-3'),
+      row(1, 'user', 'turn-a', 'Prompt', 'row-1'),
+      row(2, 'assistant', 'turn-a', 'First', 'row-2')
+    ])
+
+    expect(transcript.messages[0].parts).toEqual([
+      { type: 'text', text: 'First', state: 'done' },
+      { type: 'text', text: 'Second', state: 'done' }
+    ])
+  })
 })

--- a/src/workbench/extensions/agent/services/agent/agentTranscript.ts
+++ b/src/workbench/extensions/agent/services/agent/agentTranscript.ts
@@ -3,6 +3,7 @@ import type { AssistantMessage } from './agentMessageParts'
 import { createAssistantMessage } from './agentMessageParts'
 
 export interface NormalizedAgentTranscript {
+  /** Includes user-only placeholder messages omitted from assistantTurnIds. */
   messages: AssistantMessage[]
   userTexts: Map<TurnId, string>
   rowIds: Set<string>


### PR DESCRIPTION
Salvages the follow-up test that was never landed after review comment https://github.com/Comfy-Org/ComfyUI_frontend/pull/16489#discussion_r3903091801 on #16489 (merged `refactor(agent): extract transcript normalization`).

Adds a test pinning that `normalizeAgentTranscript` concatenates assistant rows in sequence order within a turn (rows arriving out of `seq` order), plus a one-line doc comment on `NormalizedAgentTranscript.messages` noting it includes user-only placeholder messages omitted from `assistantTurnIds`.

Cherry-picked cleanly from `origin/christian-byrne/op9b-fe16489-followup` (single commit `4925adc7a9b`) onto current `main`; all 4 tests in `agentTranscript.test.ts` pass, lint clean.