### PR TITLE
fix(website): follow-up to #16465 — report checked/total in llms.txt link validation

### DIFF
--- a/apps/website/scripts/validate-llms-txt-links.ts
+++ b/apps/website/scripts/validate-llms-txt-links.ts
@@ -48,7 +48,7 @@ function main(): void {
     'utf8'
   )
   const links = parseLlmsTxtLinks(llmsTxt)
-  const drift = findCanonicalDrift(links, canonicalFor)
+  const { drift, checked } = findCanonicalDrift(links, canonicalFor)
 
   if (drift.length > 0) {
     console.error(
@@ -62,8 +62,15 @@ function main(): void {
     process.exit(1)
   }
 
+  if (checked === 0) {
+    console.error(
+      `llms.txt link validation failed: 0 of ${links.length} link(s) were checked against a built canonical.`
+    )
+    process.exit(1)
+  }
+
   process.stdout.write(
-    `llms.txt link validation passed for ${links.length} link(s).\n`
+    `llms.txt link validation passed for ${checked}/${links.length} link(s).\n`
   )
 }
 

--- a/apps/website/src/lib/llms-txt.test.ts
+++ b/apps/website/src/lib/llms-txt.test.ts
@@ -1,3 +1,9 @@
+import { spawnSync } from 'node:child_process'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
 import { describe, expect, it } from 'vitest'
 
 import {
@@ -194,5 +200,35 @@ describe('findCanonicalDrift', () => {
 
     expect(drift).toEqual([])
     expect(checked).toBe(0)
+  })
+})
+
+describe('validate-llms-txt-links', () => {
+  it('fails when no links can be checked against a built canonical', () => {
+    const workingDirectory = mkdtempSync(join(tmpdir(), 'llms-txt-validator-'))
+    mkdirSync(join(workingDirectory, 'dist'))
+    mkdirSync(join(workingDirectory, 'public'))
+    writeFileSync(
+      join(workingDirectory, 'public', 'llms.txt'),
+      '- [Enterprise](https://comfy.org/enterprise/): Enterprise.\n'
+    )
+
+    try {
+      const validatorPath = fileURLToPath(
+        new URL('../../scripts/validate-llms-txt-links.ts', import.meta.url)
+      )
+      const result = spawnSync(
+        process.execPath,
+        ['--import', import.meta.resolve('tsx'), validatorPath],
+        { cwd: workingDirectory, encoding: 'utf8' }
+      )
+
+      expect(result.status).toBe(1)
+      expect(result.stderr).toBe(
+        'llms.txt link validation failed: 0 of 1 link(s) were checked against a built canonical.\n'
+      )
+    } finally {
+      rmSync(workingDirectory, { recursive: true, force: true })
+    }
   })
 })

--- a/apps/website/src/lib/llms-txt.test.ts
+++ b/apps/website/src/lib/llms-txt.test.ts
@@ -112,7 +112,7 @@ describe('findCanonicalDrift', () => {
       }
     ]
 
-    const drift = findCanonicalDrift(
+    const { drift, checked } = findCanonicalDrift(
       links,
       () => 'https://comfy.org/enterprise/'
     )
@@ -120,6 +120,7 @@ describe('findCanonicalDrift', () => {
     expect(drift).toEqual([
       { link: links[0], canonical: 'https://comfy.org/enterprise/' }
     ])
+    expect(checked).toBe(1)
   })
 
   it('leaves a link whose canonical matches its own URL alone', () => {
@@ -131,12 +132,13 @@ describe('findCanonicalDrift', () => {
       }
     ]
 
-    const drift = findCanonicalDrift(
+    const { drift, checked } = findCanonicalDrift(
       links,
       () => 'https://comfy.org/enterprise/'
     )
 
     expect(drift).toEqual([])
+    expect(checked).toBe(1)
   })
 
   it('skips a link with no built page (e.g. the external workflows app)', () => {
@@ -148,9 +150,10 @@ describe('findCanonicalDrift', () => {
       }
     ]
 
-    const drift = findCanonicalDrift(links, () => undefined)
+    const { drift, checked } = findCanonicalDrift(links, () => undefined)
 
     expect(drift).toEqual([])
+    expect(checked).toBe(0)
   })
 
   it('flags a same-path canonical on a different origin', () => {
@@ -162,7 +165,7 @@ describe('findCanonicalDrift', () => {
       }
     ]
 
-    const drift = findCanonicalDrift(
+    const { drift, checked } = findCanonicalDrift(
       links,
       () => 'https://evil.example.com/enterprise/'
     )
@@ -170,5 +173,26 @@ describe('findCanonicalDrift', () => {
     expect(drift).toEqual([
       { link: links[0], canonical: 'https://evil.example.com/enterprise/' }
     ])
+    expect(checked).toBe(1)
+  })
+
+  it('reports zero checked when every link is skipped (vacuous-pass guard)', () => {
+    const links = [
+      {
+        title: 'Enterprise',
+        url: 'https://comfy.org/enterprise/',
+        description: ''
+      },
+      {
+        title: 'Pricing',
+        url: 'https://comfy.org/pricing/',
+        description: ''
+      }
+    ]
+
+    const { drift, checked } = findCanonicalDrift(links, () => undefined)
+
+    expect(drift).toEqual([])
+    expect(checked).toBe(0)
   })
 })

--- a/apps/website/src/lib/llms-txt.ts
+++ b/apps/website/src/lib/llms-txt.ts
@@ -56,13 +56,8 @@ export function findRedirectedLinks(
     .map(({ link }) => link)
 }
 
-interface CanonicalDrift {
-  link: LlmsTxtLink
-  canonical: string
-}
-
 export interface CanonicalDriftResult {
-  drift: CanonicalDrift[]
+  drift: { link: LlmsTxtLink; canonical: string }[]
   /** Links whose built page had a canonical to compare against. */
   checked: number
 }
@@ -81,7 +76,7 @@ export function findCanonicalDrift(
   links: LlmsTxtLink[],
   canonicalFor: (path: string) => string | undefined
 ): CanonicalDriftResult {
-  const drift: CanonicalDrift[] = []
+  const drift: CanonicalDriftResult['drift'] = []
   let checked = 0
   for (const { path, link } of internalLinks(links)) {
     const canonical = canonicalFor(path)

--- a/apps/website/src/lib/llms-txt.ts
+++ b/apps/website/src/lib/llms-txt.ts
@@ -56,9 +56,15 @@ export function findRedirectedLinks(
     .map(({ link }) => link)
 }
 
-export interface CanonicalDrift {
+interface CanonicalDrift {
   link: LlmsTxtLink
   canonical: string
+}
+
+export interface CanonicalDriftResult {
+  drift: CanonicalDrift[]
+  /** Links whose built page had a canonical to compare against. */
+  checked: number
 }
 
 /**
@@ -67,16 +73,20 @@ export interface CanonicalDrift {
  * know about. `canonicalFor` looks up a built page's own `rel="canonical"`
  * href by pathname; a path with no built page (an external site's route
  * shape, e.g. the Comfy Workflows app) is skipped, matching the existing
- * coverage test's handling of those routes.
+ * coverage test's handling of those routes. `checked` counts only links that
+ * were actually compared, so a caller can detect a vacuous pass (e.g. every
+ * link skipped because `dist/` was never built).
  */
 export function findCanonicalDrift(
   links: LlmsTxtLink[],
   canonicalFor: (path: string) => string | undefined
-): CanonicalDrift[] {
+): CanonicalDriftResult {
   const drift: CanonicalDrift[] = []
+  let checked = 0
   for (const { path, link } of internalLinks(links)) {
     const canonical = canonicalFor(path)
     if (canonical === undefined) continue
+    checked++
     const canonicalUrl = new URL(canonical)
     const linkUrl = new URL(link.url)
     if (
@@ -86,5 +96,5 @@ export function findCanonicalDrift(
       drift.push({ link, canonical })
     }
   }
-  return drift
+  return { drift, checked }
 }


### PR DESCRIPTION
## Summary

Follow-up to [#16465](https://github.com/Comfy-Org/ComfyUI_frontend/pull/16465), which merged with 4/6 review threads still unresolved. Re-verified each against current `main`:

- [`r3900917467`](https://github.com/Comfy-Org/ComfyUI_frontend/pull/16465#discussion_r3900917467) — "vacuous pass when `dist/` is missing": the `existsSync(DIST_DIR)` guard was already present at merge, but the success message still only reported the raw link total, not how many were actually checked against a built canonical. **Fixed here** — `findCanonicalDrift` now returns `{ drift, checked }`, and the script reports `checked/total` and fails loudly on `checked === 0`.
- [`r3900917469`](https://github.com/Comfy-Org/ComfyUI_frontend/pull/16465#discussion_r3900917469) — "built but missing canonical tag is indistinguishable from not built": already addressed at merge — `canonicalFor` throws when a built page has no canonical tag (`llms-txt.ts` lines 30-34 on `main`). No further change needed.
- [`r3900917474`](https://github.com/Comfy-Org/ComfyUI_frontend/pull/16465#discussion_r3900917474) — "regex requires `rel` to precede `href`": verified the `CANONICAL_LINK` regex matches the `<link>` tag regardless of attribute order (`[^>]*` surrounds `rel=...` on both sides); a separate `HREF_ATTRIBUTE` regex then extracts `href` from the matched tag independent of order. Confirmed with both attribute orderings. No change needed.
- [`r3900917485`](https://github.com/Comfy-Org/ComfyUI_frontend/pull/16465#discussion_r3900917485) — "redirect sources treated as literal paths": already addressed at merge — `llms-txt.test.ts` already asserts no `vercelRedirectSources` entry contains `[:*(]` (`'uses only literal redirect sources for stale link checks'`). No change needed.

Only the first item needed a code change; this PR adds it plus regression tests for the `checked` count (including a dedicated vacuous-pass case).

## Testing

- `pnpm exec vitest run src/lib/llms-txt.test.ts src/config/llms-txt.test.ts` — 23/23 pass
- `pnpm typecheck` (astro check + vue-tsc) — 0 errors
- `pnpm exec eslint` on touched files — clean
- `pnpm exec knip` — clean (removed now-unused `export` on `CanonicalDrift`, kept internal)

<!-- authored-by:agent addr-drain -->
