### PR TITLE
fix(scripts): follow-up to #16480 — checkAssetsFlagArtifact hardening + CI build tweaks

### DIFF
--- a/.github/actions/build-cloud-frontend/action.yaml
+++ b/.github/actions/build-cloud-frontend/action.yaml
@@ -23,10 +23,21 @@ runs:
       shell: bash
       # Never skip. Without expected_commit the provenance leg proves nothing;
       # the distribution assertion is what rejects a leftover localhost dist/.
+      #
+      # This step runs unconditionally, including from callers (like
+      # /update-playwright) that have nothing to do with the Asset API. If it
+      # fails there, the fix is almost always in scripts/checkAssetsFlagArtifact.ts
+      # (a legitimate refactor of isAssetAPIEnabled, a new test-fixture marker,
+      # etc), not in this action or the caller — say so explicitly, since a bare
+      # test failure here reads as "the build is broken" rather than "the gate
+      # correctly rejected this build".
       run: |
         set -euo pipefail
         EXPECTED_FRONTEND_COMMIT="${EXPECTED_FRONTEND_COMMIT:-$(git rev-parse HEAD)}" \
-          pnpm test:assets-flag-artifact
+          pnpm test:assets-flag-artifact || {
+            echo "::error::Cloud frontend failed the Asset API build gate. This check runs on every caller of build-cloud-frontend, including callers unrelated to assets. If your change legitimately affects isAssetAPIEnabled, the build output, or test fixture markers, update scripts/checkAssetsFlagArtifact.ts (see its own error message above for which assertion failed) rather than treating this as an unrelated CI failure."
+            exit 1
+          }
       env:
         EXPECTED_FRONTEND_COMMIT: ${{ inputs.expected_commit }}
         EXPECTED_DISTRIBUTION: cloud

--- a/.github/workflows/ci-tests-e2e.yaml
+++ b/.github/workflows/ci-tests-e2e.yaml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Build and verify desktop Assets default
         run: |
-          DISTRIBUTION=desktop pnpm build
+          pnpm build:desktop-dist
           pnpm test:assets-flag-artifact
         env:
           EXPECTED_DISTRIBUTION: desktop

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "type": "module",
   "scripts": {
     "build:cloud": "cross-env DISTRIBUTION=cloud vite build --config vite.config.mts",
+    "build:desktop-dist": "cross-env DISTRIBUTION=desktop vite build --config vite.config.mts",
     "build-storybook": "storybook build",
     "build:types": "vite build --config vite.types.config.mts && node scripts/prepare-types.js",
     "build:analyze": "cross-env ANALYZE_BUNDLE=true pnpm build",

--- a/scripts/checkAssetsFlagArtifact.test.ts
+++ b/scripts/checkAssetsFlagArtifact.test.ts
@@ -128,6 +128,24 @@ describe('assertAssetApiGate', () => {
       )
     ).toThrow('return !!useSettingStore().get("Comfy.Assets.UseAssetAPI")\n}')
   })
+
+  it('does not desync the brace counter on a brace inside a string literal', () => {
+    // The gate body contains an unbalanced `{` inside a string. A
+    // string-unaware brace counter would count that stray `{` as real,
+    // never return to depth 0 within this gate's own body, and run off the
+    // end of the chunk - so `assetApiGates` would report "found 0" instead
+    // of correctly extracting the one real gate below (which is then
+    // rejected on its own merits, for having an extra statement, not for
+    // failing to be found at all).
+    expect(() =>
+      assertAssetApiGate(
+        [
+          'function isAssetAPIEnabled() {\n  const label = "{unbalanced"\n  return false\n}'
+        ],
+        'localhost'
+      )
+    ).toThrow('Built Asset API gate is invalid for localhost')
+  })
 })
 
 describe('assertBuildProvenance', () => {
@@ -150,7 +168,9 @@ describe('assertBuildProvenance', () => {
         commit,
         'desktop'
       )
-    ).toThrow(`Build does not contain expected frontend commit ${commit}`)
+    ).toThrow(
+      `Build does not contain expected frontend commit ${commit}, found old`
+    )
   })
 
   it('rejects an artifact built for another distribution', () => {
@@ -192,23 +212,47 @@ describe('assertBuildProvenance', () => {
 })
 
 describe('assertNoTestFixtures', () => {
-  it('accepts production chunks', () => {
+  it('accepts production chunks and sourcemap sources', () => {
     expect(() =>
-      assertNoTestFixtures(['const endpoint="/api/assets"'])
+      assertNoTestFixtures(
+        ['const endpoint="/api/assets"'],
+        ['../../src/platform/assets/services/assetService.ts']
+      )
+    ).not.toThrow()
+  })
+
+  it('accepts a production chunk that merely mentions a path marker in text', () => {
+    // A path marker is only meaningful as a module path (a sourcemap
+    // `sources` entry). A comment or string in bundled production source that
+    // happens to contain the same substring must not fail the build.
+    expect(() =>
+      assertNoTestFixtures([
+        '// see browser_tests/fixtures/ for the fixture format'
+      ])
     ).not.toThrow()
   })
 
   it.for([
-    ['browser_tests/fixtures/assets', 'browser_tests/fixtures/'],
-    ['/__fixtures__/asset', '/__fixtures__/'],
-    [
-      'COMFY_PRODUCTION_FORBIDDEN_MOCK_ASSET_SENTINEL',
-      'COMFY_PRODUCTION_FORBIDDEN_MOCK_ASSET_SENTINEL'
-    ]
-  ])('rejects leaked test marker %s', ([chunkMarker, reportedMarker]) => {
+    ['browser_tests/fixtures/assets.ts', 'browser_tests/fixtures/'],
+    ['/__fixtures__/asset.ts', '/__fixtures__/'],
+    ['ui-mock-assets/index.ts', 'ui-mock-assets']
+  ])(
+    'rejects a sourcemap source path carrying %s',
+    ([sourcePath, reportedMarker]) => {
+      expect(() => assertNoTestFixtures([], [sourcePath])).toThrow(
+        `Build contains test fixture marker: ${reportedMarker}`
+      )
+    }
+  )
+
+  it('rejects the sentinel anywhere in chunk text', () => {
     expect(() =>
-      assertNoTestFixtures([`const fixture="${chunkMarker}"`])
-    ).toThrow(`Build contains test fixture marker: ${reportedMarker}`)
+      assertNoTestFixtures([
+        'const fixture="COMFY_PRODUCTION_FORBIDDEN_MOCK_ASSET_SENTINEL"'
+      ])
+    ).toThrow(
+      'Build contains test fixture marker: COMFY_PRODUCTION_FORBIDDEN_MOCK_ASSET_SENTINEL'
+    )
   })
 })
 
@@ -286,6 +330,14 @@ describe('checkAssetsFlagArtifact', () => {
 
     expect(() => checkAssetsFlagArtifact(directory)).toThrow(
       'EXPECTED_FRONTEND_COMMIT is required'
+    )
+  })
+
+  it('requires the expected distribution even when the commit is set', () => {
+    vi.stubEnv('EXPECTED_DISTRIBUTION', '')
+
+    expect(() => checkAssetsFlagArtifact(directory)).toThrow(
+      'EXPECTED_DISTRIBUTION is required'
     )
   })
 })

--- a/scripts/checkAssetsFlagArtifact.ts
+++ b/scripts/checkAssetsFlagArtifact.ts
@@ -2,12 +2,24 @@ import { readFileSync, readdirSync } from 'node:fs'
 import { extname, join } from 'node:path'
 import { pathToFileURL } from 'node:url'
 
-const TEST_FIXTURE_MARKERS = [
+/**
+ * Path markers: only meaningful as a module path, so they are checked against
+ * a sourcemap's `sources` array, never against arbitrary chunk/sourcesContent
+ * text. A production module that merely mentions one of these strings in a
+ * comment or a string literal must not fail the build.
+ */
+const TEST_FIXTURE_PATH_MARKERS = [
   'browser_tests/fixtures/',
   '/__fixtures__/',
-  'ui-mock-assets',
-  'COMFY_PRODUCTION_FORBIDDEN_MOCK_ASSET_SENTINEL'
+  'ui-mock-assets'
 ] as const
+
+/**
+ * The sentinel is a value, not a path: it can appear anywhere in bundled
+ * source (a mock asset id inlined into a chunk), so it stays a full-text scan
+ * across every chunk, including sourcesContent.
+ */
+const TEST_FIXTURE_SENTINEL = 'COMFY_PRODUCTION_FORBIDDEN_MOCK_ASSET_SENTINEL'
 
 const DISTRIBUTIONS = ['localhost', 'desktop', 'cloud'] as const
 const TEXT_ASSET_EXTENSIONS = new Set([
@@ -41,18 +53,38 @@ function artifactFiles(directory: string): string[] {
   })
 }
 
+/**
+ * Walk `chunk` from `start`, tracking brace depth until it returns to 0.
+ * Skips braces inside string/template literals so a `{` in a quoted value
+ * (e.g. a re-quoted setting key) can't desync the count. Returns the index
+ * just past the matching `}`, or -1 if depth never returns to 0.
+ */
+function findMatchingBraceEnd(chunk: string, start: number): number {
+  let depth = 1
+  let quote: '"' | "'" | '`' | null = null
+  let index = start
+  for (; index < chunk.length && depth > 0; index++) {
+    const char = chunk[index]
+    if (quote) {
+      if (char === '\\') index++
+      else if (char === quote) quote = null
+      continue
+    }
+    if (char === '"' || char === "'" || char === '`') quote = char
+    else if (char === '{') depth++
+    else if (char === '}') depth--
+  }
+  return depth === 0 ? index : -1
+}
+
 function assetApiGates(chunks: ReadonlyArray<string>): string {
   const gates = chunks.flatMap((chunk) => {
     const matches: string[] = []
     const declaration = /function isAssetAPIEnabled\(\)\s*\{/g
     for (const match of chunk.matchAll(declaration)) {
-      let depth = 1
-      let index = (match.index ?? 0) + match[0].length
-      for (; index < chunk.length && depth > 0; index++) {
-        if (chunk[index] === '{') depth++
-        if (chunk[index] === '}') depth--
-      }
-      if (depth === 0) matches.push(chunk.slice(match.index, index))
+      const start = (match.index ?? 0) + match[0].length
+      const end = findMatchingBraceEnd(chunk, start)
+      if (end !== -1) matches.push(chunk.slice(match.index, end))
     }
     return matches
   })
@@ -100,7 +132,7 @@ export function assertBuildProvenance(
   const build = parsed as Record<string, unknown>
   if (build.commit !== expectedCommit) {
     throw new Error(
-      `Build does not contain expected frontend commit ${expectedCommit}`
+      `Build does not contain expected frontend commit ${expectedCommit}, found ${String(build.commit)}`
     )
   }
   if (build.distribution !== expectedDistribution) {
@@ -110,11 +142,39 @@ export function assertBuildProvenance(
   }
 }
 
-export function assertNoTestFixtures(chunks: ReadonlyArray<string>): void {
-  for (const marker of TEST_FIXTURE_MARKERS) {
-    if (chunks.some((chunk) => chunk.includes(marker))) {
+/** A parsed sourcemap's relevant fields, tolerant of malformed/missing ones. */
+function sourcemapSources(mapSource: string): string[] {
+  try {
+    const parsed: unknown = JSON.parse(mapSource)
+    if (
+      typeof parsed === 'object' &&
+      parsed !== null &&
+      Array.isArray((parsed as { sources?: unknown }).sources)
+    ) {
+      return (parsed as { sources: unknown[] }).sources.filter(
+        (source): source is string => typeof source === 'string'
+      )
+    }
+  } catch {
+    // Malformed sourcemap JSON: fall through and treat as no sources, so a
+    // parse failure here doesn't mask the assertions below.
+  }
+  return []
+}
+
+export function assertNoTestFixtures(
+  chunks: ReadonlyArray<string>,
+  sourcemapSourcePaths: ReadonlyArray<string> = []
+): void {
+  for (const marker of TEST_FIXTURE_PATH_MARKERS) {
+    if (sourcemapSourcePaths.some((source) => source.includes(marker))) {
       throw new Error(`Build contains test fixture marker: ${marker}`)
     }
+  }
+  if (chunks.some((chunk) => chunk.includes(TEST_FIXTURE_SENTINEL))) {
+    throw new Error(
+      `Build contains test fixture marker: ${TEST_FIXTURE_SENTINEL}`
+    )
   }
 }
 
@@ -128,6 +188,15 @@ export function checkAssetsFlagArtifact(directory = 'dist'): void {
   if (!expectedDistribution) {
     throw new Error('EXPECTED_DISTRIBUTION is required')
   }
+
+  // Check provenance before anything else: a stale `dist/` from a build that
+  // predates the sourcemap requirement (or any other assertion below) should
+  // report "wrong commit", not a confusing downstream failure.
+  assertBuildProvenance(
+    readFileSync(join(directory, 'build-manifest.json'), 'utf8'),
+    expectedCommit,
+    expectedDistribution
+  )
 
   const textAssets = artifactFiles(directory)
     .filter((path) => TEXT_ASSET_EXTENSIONS.has(extname(path)))
@@ -143,13 +212,11 @@ export function checkAssetsFlagArtifact(directory = 'dist'): void {
   const executableChunks = textAssets
     .filter(({ path }) => EXECUTABLE_ASSET_EXTENSIONS.has(extname(path)))
     .map(({ source }) => source)
+  const sourcemapSourcePaths = textAssets
+    .filter(({ path }) => extname(path) === '.map')
+    .flatMap(({ source }) => sourcemapSources(source))
 
-  assertBuildProvenance(
-    readFileSync(join(directory, 'build-manifest.json'), 'utf8'),
-    expectedCommit,
-    expectedDistribution
-  )
-  assertNoTestFixtures(chunks)
+  assertNoTestFixtures(chunks, sourcemapSourcePaths)
   assertAssetApiGate(executableChunks, expectedDistribution)
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #16480 (merged 2026-09-02T01:28:18Z) — addresses all 8 review comments from @benjcooley that landed after merge with 0 replies/resolutions.

## Addressed

**`scripts/checkAssetsFlagArtifact.ts`** (5 items):

- Scope test-fixture path markers (`browser_tests/fixtures/`, `__fixtures__`, `ui-mock-assets`) to a sourcemap's `sources` array instead of scanning raw chunk/`sourcesContent` text, so a production module that merely mentions one of these strings in a comment no longer fails the build. The sentinel (`COMFY_PRODUCTION_FORBIDDEN_MOCK_ASSET_SENTINEL`) stays a full-text scan since it's a value, not a path. ([comment](https://github.com/Comfy-Org/ComfyUI_frontend/pull/16480#discussion_r3909166126), [comment](https://github.com/Comfy-Org/ComfyUI_frontend/pull/16480#discussion_r3909166128))
- Make the gate's brace-matching walk string/template-literal aware so a `{` inside a quoted value can't desync the depth count and silently drop the gate match. ([comment](https://github.com/Comfy-Org/ComfyUI_frontend/pull/16480#discussion_r3909166141))
- Check build provenance before the sourcemap/fixture/gate assertions, so a stale `dist/` reports the actual wrong-commit cause instead of a confusing downstream failure. ([comment](https://github.com/Comfy-Org/ComfyUI_frontend/pull/16480#discussion_r3909166134))
- Include the found commit in the provenance mismatch error, matching the distribution mismatch message right below it. ([comment](https://github.com/Comfy-Org/ComfyUI_frontend/pull/16480#discussion_r3909166137))
- Add missing test coverage: `ui-mock-assets` fixture marker and the `EXPECTED_DISTRIBUTION` required guard. ([comment](https://github.com/Comfy-Org/ComfyUI_frontend/pull/16480#discussion_r3909166153))

**CI/build tooling** (3 items):

- `.github/workflows/ci-tests-e2e.yaml`: the desktop verification step ran the full `pnpm build` (typecheck + vite build), redundantly re-running typecheck that already happened two steps earlier in `setup-frontend` (`include_build_step: true`). Added a `build:desktop-dist` script mirroring `build:cloud`'s shape (vite build only) and switched this step to use it. ([comment](https://github.com/Comfy-Org/ComfyUI_frontend/pull/16480#discussion_r3909166114))
- `.github/actions/build-cloud-frontend/action.yaml`: this action's Asset API gate check runs unconditionally, including from callers like `/update-playwright` that have nothing to do with assets. On failure there it looked like an unrelated broken build. Added an explicit `::error::` pointing at `scripts/checkAssetsFlagArtifact.ts` as the place to look. ([comment](https://github.com/Comfy-Org/ComfyUI_frontend/pull/16480#discussion_r3909166148))

## Not addressed (deferred)

- The reviewer's secondary note in the same comment as the provenance-ordering item, about streaming files instead of loading the whole `dist/` into memory during the fixture scan — reviewer themselves called this "fine on a 16 GB runner", non-blocking, and a larger architecture change than the ordering fix. Left as-is; can be a separate PR if it becomes a real constraint.
- The first comment's second point (verification table in the PR description not covering desktop) refers to #16480's own PR description text, which is immutable now that it's merged; not something a follow-up PR can fix.

## Test plan

- `pnpm vitest run scripts/checkAssetsFlagArtifact.test.ts` — 38/38 pass (7 new/changed cases, including a negative-control-verified regression test for the brace-matching fix)
- `pnpm typecheck` — clean
- `pnpm format:check` — clean
- Pre-commit hook ran a real `pnpm build:desktop-dist` end to end on the CI/build config commit — succeeded (warnings only, no errors)

## Linear/tracking

Gap surfaced by `um-4` sweep (`reports/review-followup-audit-2026-09-02.md`, Finding 1) — approve-with-comments trigger didn't fire because these comments weren't attached to an APPROVED review.

<!-- authored-by:agent addr-drain -->
