### PR TITLE
feat(billing): checkout failures land in the dialog, not toasts

### DIFF
--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -3150,6 +3150,11 @@
       "addNewPaymentMethod": "Add new payment method",
       "alipay": "Alipay"
     },
+    "processingError": {
+      "title": "Payment couldn't be processed",
+      "body": "There was a technical problem on the payment side. Nothing is wrong with your card. Try again, or refresh the page if it keeps happening.",
+      "tryAgain": "Try again"
+    },
     "declined": {
       "title": "Payment declined",
       "body": "Your card couldn't be charged. Try another card, or contact your bank if this looks wrong.",

--- a/src/platform/workspace/components/SubscriptionProcessingErrorWorkspace.test.ts
+++ b/src/platform/workspace/components/SubscriptionProcessingErrorWorkspace.test.ts
@@ -1,0 +1,35 @@
+import { render, screen } from '@testing-library/vue'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it } from 'vitest'
+import { createI18n } from 'vue-i18n'
+
+import enMessages from '@/locales/en/main.json'
+
+import SubscriptionProcessingErrorWorkspace from './SubscriptionProcessingErrorWorkspace.vue'
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: { en: enMessages }
+})
+
+describe('SubscriptionProcessingErrorWorkspace', () => {
+  it('states the card is fine and offers only a retry', async () => {
+    const { emitted } = render(SubscriptionProcessingErrorWorkspace, {
+      global: { plugins: [i18n] }
+    })
+
+    expect(
+      screen.getByText("Payment couldn't be processed")
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText(/Nothing is wrong with your card/)
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: 'Update payment method' })
+    ).toBeNull()
+
+    await userEvent.click(screen.getByRole('button', { name: 'Try again' }))
+    expect(emitted().tryAgain).toBeTruthy()
+  })
+})

--- a/src/platform/workspace/components/SubscriptionProcessingErrorWorkspace.vue
+++ b/src/platform/workspace/components/SubscriptionProcessingErrorWorkspace.vue
@@ -1,0 +1,37 @@
+<template>
+  <div
+    class="mx-auto flex h-full max-w-[400px] flex-col items-stretch justify-between text-sm motion-safe:animate-in motion-safe:duration-300 motion-safe:fade-in motion-safe:slide-in-from-bottom-2"
+  >
+    <div class="flex flex-col items-center gap-4 pt-8">
+      <i class="pi pi-exclamation-circle text-5xl text-warning-background" />
+      <h2
+        class="m-0 text-center text-xl font-semibold text-base-foreground lg:text-2xl"
+      >
+        {{ $t('subscription.processingError.title') }}
+      </h2>
+      <p class="m-0 text-center text-sm text-muted-foreground">
+        {{ $t('subscription.processingError.body') }}
+      </p>
+    </div>
+
+    <div class="flex flex-col gap-2 pt-8 pb-4">
+      <Button
+        variant="inverted"
+        size="lg"
+        class="w-full rounded-lg"
+        @click="$emit('tryAgain')"
+      >
+        {{ $t('subscription.processingError.tryAgain') }}
+      </Button>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import Button from '@/components/ui/button/Button.vue'
+
+defineEmits<{
+  /** Return to the confirm step with the quote and selection intact. */
+  tryAgain: []
+}>()
+</script>

--- a/src/platform/workspace/components/SubscriptionRequiredDialogContentUnified.vue
+++ b/src/platform/workspace/components/SubscriptionRequiredDialogContentUnified.vue
@@ -15,13 +15,15 @@
         (isEmbeddedSuccessStep ||
           isEmbeddedConfirmStep ||
           isVerifyingStep ||
-          isDeclinedStep) &&
+          isDeclinedStep ||
+          isProcessingErrorStep) &&
           'h-[min(740px,85vh)] overflow-hidden rounded-2xl bg-base-background xl:h-[min(740px,90vh)] xl:w-[512px]',
         (isEmbeddedPaymentStep ||
           isEmbeddedSuccessStep ||
           isEmbeddedConfirmStep ||
           isVerifyingStep ||
-          isDeclinedStep) &&
+          isDeclinedStep ||
+          isProcessingErrorStep) &&
           'motion-safe:xl:transition-[width] motion-safe:xl:duration-300 motion-safe:xl:ease-in-out',
         // The w-fit shell hugs min-content on phones; give the embedded
         // steps a real width floor below xl.
@@ -29,7 +31,8 @@
           isEmbeddedSuccessStep ||
           isEmbeddedConfirmStep ||
           isVerifyingStep ||
-          isDeclinedStep) &&
+          isDeclinedStep ||
+          isProcessingErrorStep) &&
           'max-xl:w-[min(430px,92vw)]',
         isEmbeddedPaymentStep && 'max-xl:h-[min(740px,85vh)]'
       )
@@ -70,7 +73,8 @@
         !isEmbeddedSuccessStep &&
         !isEmbeddedConfirmStep &&
         !isVerifyingStep &&
-        !isDeclinedStep
+        !isDeclinedStep &&
+        !isProcessingErrorStep
       "
       class="flex flex-col items-center gap-3"
     >
@@ -239,6 +243,11 @@
       @back="handleDeclinedBack"
     />
 
+    <SubscriptionProcessingErrorWorkspace
+      v-if="checkoutStep === 'processing_error'"
+      @try-again="handleDeclinedBack"
+    />
+
     <!-- Success Step - "You're all set" -->
     <SubscriptionSuccessWorkspace
       v-if="checkoutStep === 'success' && (selectedTierKey || isTeamCheckout)"
@@ -266,6 +275,7 @@ import SubscriptionAddPaymentPreviewWorkspace from './SubscriptionAddPaymentPrev
 import SubscriptionSuccessWorkspace from './SubscriptionSuccessWorkspace.vue'
 import SubscriptionTransitionPreviewWorkspace from './SubscriptionTransitionPreviewWorkspace.vue'
 import SubscriptionDeclinedWorkspace from './SubscriptionDeclinedWorkspace.vue'
+import SubscriptionProcessingErrorWorkspace from './SubscriptionProcessingErrorWorkspace.vue'
 import SubscriptionVerifyingWorkspace from './SubscriptionVerifyingWorkspace.vue'
 import UnifiedPricingTable from './UnifiedPricingTable.vue'
 
@@ -390,6 +400,9 @@ function selectSavedPaymentMethod(id: string | null) {
 
 const isVerifyingStep = computed(() => checkoutStep.value === 'verifying')
 const isDeclinedStep = computed(() => checkoutStep.value === 'declined')
+const isProcessingErrorStep = computed(
+  () => checkoutStep.value === 'processing_error'
+)
 
 // The decline CTA returns to confirm and opens method collection, which is
 // dialog state rather than checkout state.

--- a/src/platform/workspace/composables/useSubscriptionCheckout.test.ts
+++ b/src/platform/workspace/composables/useSubscriptionCheckout.test.ts
@@ -163,6 +163,8 @@ const {
   mockStartOperation,
   mockRetryPaymentAuthentication,
   mockGetOperation,
+  mockMarkOperationAttended,
+  mockMarkOperationUnattended,
   mockCancelOperation,
   mockSubscriptionActionOperation,
   mockListSavedPaymentMethods,
@@ -194,6 +196,8 @@ const {
   mockStartOperation: vi.fn(),
   mockRetryPaymentAuthentication: vi.fn(),
   mockGetOperation: vi.fn(),
+  mockMarkOperationAttended: vi.fn(),
+  mockMarkOperationUnattended: vi.fn(),
   mockCancelOperation: vi.fn(),
   mockSubscriptionActionOperation: {
     value: undefined as MockSubscriptionActionOperation | undefined
@@ -354,6 +358,8 @@ vi.mock('@/platform/workspace/stores/billingOperationStore', () => ({
     retryPaymentAuthentication: mockRetryPaymentAuthentication,
     getOperation: mockGetOperation,
     cancelOperation: mockCancelOperation,
+    markOperationAttended: mockMarkOperationAttended,
+    markOperationUnattended: mockMarkOperationUnattended,
     get subscriptionActionOperation() {
       return mockSubscriptionActionOperation.value
     }
@@ -2602,6 +2608,22 @@ describe('useSubscriptionCheckout', () => {
       )
       expect(checkout.checkoutStep.value).toBe('success')
     })
+  })
+
+  it('claims an adopted operation only for a host with recovery steps', async () => {
+    mockSubscriptionActionOperation.value = {
+      opId: 'op-attend',
+      status: 'pending',
+      workspaceId: 'workspace-1',
+      actionUrl: 'https://verify.example/token'
+    } as never
+
+    await setup()
+    expect(mockMarkOperationAttended).toHaveBeenCalledWith('op-attend')
+
+    mockMarkOperationAttended.mockClear()
+    await setup(undefined, 'personal', true, false)
+    expect(mockMarkOperationAttended).not.toHaveBeenCalled()
   })
 
   it('leaves a pending charge on the pricing step for a host without recovery steps', async () => {

--- a/src/platform/workspace/composables/useSubscriptionCheckout.ts
+++ b/src/platform/workspace/composables/useSubscriptionCheckout.ts
@@ -935,21 +935,24 @@ export function useSubscriptionCheckout(
     emit('close', true)
   }
 
-  // While this dialog holds an operation, its outcome renders here — the
-  // store's success/failure toasts stay quiet. Closing the dialog releases
-  // the operation back to toast delivery.
-  watch(
-    activeCheckoutOperationId,
-    (newId, oldId) => {
-      if (oldId) billingOperationStore.markOperationUnattended(oldId)
-      if (newId) billingOperationStore.markOperationAttended(newId)
-    },
-    { immediate: true }
-  )
-  onScopeDispose(() => {
-    const opId = activeCheckoutOperationId.value
-    if (opId) billingOperationStore.markOperationUnattended(opId)
-  })
+  // While a host that renders the outcome steps holds an operation, its
+  // outcome renders there — the store's success/failure toasts stay quiet.
+  // Closing the dialog releases the operation back to toast delivery. Hosts
+  // without those steps never claim the operation at all.
+  if (rendersRecoverySteps) {
+    watch(
+      activeCheckoutOperationId,
+      (newId, oldId) => {
+        if (oldId) billingOperationStore.markOperationUnattended(oldId)
+        if (newId) billingOperationStore.markOperationAttended(newId)
+      },
+      { immediate: true }
+    )
+    onScopeDispose(() => {
+      const opId = activeCheckoutOperationId.value
+      if (opId) billingOperationStore.markOperationUnattended(opId)
+    })
+  }
 
   function showFailureOutcome(operation: {
     errorMessage: string | null
@@ -1410,7 +1413,7 @@ export function useSubscriptionCheckout(
     }
     if (operation.status === 'succeeded') {
       checkoutStep.value = 'success'
-    } else if (operation.status === 'failed') {
+    } else if (operation.status === 'failed' && rendersRecoverySteps) {
       showFailureOutcome(operation)
     }
   }

--- a/src/platform/workspace/composables/useSubscriptionCheckout.ts
+++ b/src/platform/workspace/composables/useSubscriptionCheckout.ts
@@ -39,7 +39,13 @@ import {
 } from '@/platform/workspace/utils/pendingSubscriptionCheckout'
 import { trackWorkspaceCheckoutStarted } from '@/platform/workspace/utils/workspaceCheckoutTelemetry'
 
-type CheckoutStep = 'pricing' | 'preview' | 'verifying' | 'success' | 'declined'
+type CheckoutStep =
+  | 'pricing'
+  | 'preview'
+  | 'verifying'
+  | 'success'
+  | 'declined'
+  | 'processing_error'
 export type CheckoutTierKey = Exclude<TierKey, 'free' | 'founder'>
 
 export type SubscriptionCheckoutSelection =
@@ -923,6 +929,31 @@ export function useSubscriptionCheckout(
     emit('close', true)
   }
 
+  // While this dialog holds an operation, its outcome renders here — the
+  // store's success/failure toasts stay quiet. Closing the dialog releases
+  // the operation back to toast delivery.
+  watch(
+    activeCheckoutOperationId,
+    (newId, oldId) => {
+      if (oldId) billingOperationStore.markOperationUnattended(oldId)
+      if (newId) billingOperationStore.markOperationAttended(newId)
+    },
+    { immediate: true }
+  )
+  onScopeDispose(() => {
+    const opId = activeCheckoutOperationId.value
+    if (opId) billingOperationStore.markOperationUnattended(opId)
+  })
+
+  function showFailureOutcome(operation: {
+    errorMessage: string | null
+    failureClass: 'declined' | 'processing' | null
+  }) {
+    checkoutDeclineReason.value = operation.errorMessage
+    checkoutStep.value =
+      operation.failureClass === 'processing' ? 'processing_error' : 'declined'
+  }
+
   // Declined is not terminal: back returns to the confirm step with the quote
   // and selection intact so the same charge can be retried.
   function handleDeclinedBack() {
@@ -1366,11 +1397,15 @@ export function useSubscriptionCheckout(
     const operation = await terminalOperation
     clearPendingSubscriptionCheckoutIfTerminal(opId, operation.status)
     if (
-      operation.status === 'succeeded' &&
-      activeCheckoutOperationId.value === opId &&
-      operation.workspaceId === workspaceStore.activeWorkspaceId
+      activeCheckoutOperationId.value !== opId ||
+      operation.workspaceId !== workspaceStore.activeWorkspaceId
     ) {
+      return
+    }
+    if (operation.status === 'succeeded') {
       checkoutStep.value = 'success'
+    } else if (operation.status === 'failed') {
+      showFailureOutcome(operation)
     }
   }
 
@@ -1441,14 +1476,20 @@ export function useSubscriptionCheckout(
         if (selectedTierKey.value || isTeamCheckout.value) {
           checkoutStep.value = 'success'
         } else {
+          // Attended operations don't toast; closing without a success step
+          // would swallow the outcome, so this path carries its own.
+          toast.add({
+            severity: 'success',
+            summary: t('billingOperation.subscriptionSuccess'),
+            life: 5000
+          })
           emit('close', true)
         }
         return
       }
       if (status === 'failed') {
-        checkoutDeclineReason.value =
-          activeCheckoutOperation.value?.errorMessage ?? null
-        checkoutStep.value = 'declined'
+        const operation = activeCheckoutOperation.value
+        if (operation) showFailureOutcome(operation)
         return
       }
       if (status === undefined) {

--- a/src/platform/workspace/stores/billingOperationStore.test.ts
+++ b/src/platform/workspace/stores/billingOperationStore.test.ts
@@ -1685,6 +1685,120 @@ describe('billingOperationStore', () => {
     })
   })
 
+  describe('attended operations', () => {
+    it('suppresses the failure toast while the operation is attended', async () => {
+      vi.mocked(workspaceApi.getBillingOpStatus).mockResolvedValue({
+        id: 'op-1',
+        status: 'failed',
+        error_message: 'card_declined',
+        started_at: new Date().toISOString()
+      })
+
+      const store = useBillingOperationStore()
+      store.markOperationAttended('op-1')
+      void store.startOperation('op-1', 'subscription', {
+        suppressProcessingToast: true
+      })
+
+      await vi.advanceTimersByTimeAsync(0)
+
+      const operation = store.getOperation('op-1')
+      expect(operation?.status).toBe('failed')
+      expect(operation?.failureClass).toBe('declined')
+      expect(operation?.errorMessage).toBe(
+        'billingOperation.paymentDeclinedDetail'
+      )
+      expect(mockToastAdd).not.toHaveBeenCalledWith(
+        expect.objectContaining({ severity: 'error' })
+      )
+    })
+
+    it('classifies a rails hiccup as a processing failure', async () => {
+      vi.mocked(workspaceApi.getBillingOpStatus).mockResolvedValue({
+        id: 'op-1',
+        status: 'failed',
+        error_message: 'processing_error',
+        started_at: new Date().toISOString()
+      })
+
+      const store = useBillingOperationStore()
+      void store.startOperation('op-1', 'subscription')
+
+      await vi.advanceTimersByTimeAsync(0)
+
+      const operation = store.getOperation('op-1')
+      expect(operation?.failureClass).toBe('processing')
+      expect(operation?.errorMessage).toBe(
+        'billingOperation.processingErrorDetail'
+      )
+    })
+
+    it('restores the failure toast once the operation is unattended', async () => {
+      vi.mocked(workspaceApi.getBillingOpStatus).mockResolvedValue({
+        id: 'op-1',
+        status: 'failed',
+        error_message: 'card_declined',
+        started_at: new Date().toISOString()
+      })
+
+      const store = useBillingOperationStore()
+      store.markOperationAttended('op-1')
+      store.markOperationUnattended('op-1')
+      void store.startOperation('op-1', 'subscription', {
+        suppressProcessingToast: true
+      })
+
+      await vi.advanceTimersByTimeAsync(0)
+
+      expect(mockToastAdd).toHaveBeenCalledWith(
+        expect.objectContaining({ severity: 'error' })
+      )
+    })
+
+    it('suppresses the success toast while the operation is attended', async () => {
+      vi.mocked(workspaceApi.getBillingOpStatus).mockResolvedValue({
+        id: 'op-1',
+        status: 'succeeded',
+        started_at: new Date().toISOString()
+      })
+
+      const store = useBillingOperationStore()
+      store.markOperationAttended('op-1')
+      void store.startOperation('op-1', 'subscription', {
+        suppressProcessingToast: true
+      })
+
+      await vi.advanceTimersByTimeAsync(0)
+
+      expect(store.getOperation('op-1')?.status).toBe('succeeded')
+      expect(mockToastAdd).not.toHaveBeenCalledWith(
+        expect.objectContaining({ severity: 'success' })
+      )
+    })
+
+    it('still toasts a timeout for an attended operation', async () => {
+      vi.mocked(workspaceApi.getBillingOpStatus).mockResolvedValue({
+        id: 'op-1',
+        status: 'pending',
+        started_at: new Date().toISOString()
+      })
+
+      const store = useBillingOperationStore()
+      store.markOperationAttended('op-1')
+      void store.startOperation('op-1', 'subscription', {
+        suppressProcessingToast: true
+      })
+      mockActiveWorkspaceId.value = 'workspace-2'
+
+      await vi.advanceTimersByTimeAsync(5 * 60_000 + 8001)
+
+      expect(store.getOperation('op-1')?.status).toBe('timeout')
+      expect(mockToastAdd).toHaveBeenCalledWith(
+        expect.objectContaining({ severity: 'error' })
+      )
+    })
+  })
+
   describe('polling timeout', () => {
     it('times out a subscription while its workspace is inactive', async () => {
       vi.mocked(workspaceApi.getBillingOpStatus).mockResolvedValue({

--- a/src/platform/workspace/stores/billingOperationStore.ts
+++ b/src/platform/workspace/stores/billingOperationStore.ts
@@ -1037,6 +1037,9 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
     type: OperationType,
     errorMessage: string | null
   ) {
+    if (errorMessage && PROCESSING_FAILURE_CODES.has(errorMessage)) {
+      return t('billingOperation.processingErrorDetail')
+    }
     switch (errorMessage) {
       case 'insufficient_funds':
         return t('billingOperation.insufficientFundsDetail')
@@ -1049,10 +1052,6 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
       case 'authentication_required':
       case 'payment_intent_authentication_failure':
         return t('billingOperation.authenticationFailedDetail')
-      case 'processing_error':
-      case 'issuer_not_available':
-      case 'try_again_later':
-        return t('billingOperation.processingErrorDetail')
       case 'card_declined':
       case 'generic_decline':
       case 'approve_with_id':

--- a/src/platform/workspace/stores/billingOperationStore.ts
+++ b/src/platform/workspace/stores/billingOperationStore.ts
@@ -76,11 +76,14 @@ export interface StartOperationMetadata {
   attemptStartedAt?: number
 }
 
+type BillingFailureClass = 'declined' | 'processing'
+
 interface BillingOperation {
   opId: string
   type: OperationType
   status: OperationStatus
   errorMessage: string | null
+  failureClass: BillingFailureClass | null
   startedAt: number
   operationStartedAt: number
   businessAttemptStartedAt?: number
@@ -123,6 +126,11 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
   const terminalResolvers = new Map<string, TerminalResolver>()
   const terminalPromises = new Map<string, Promise<BillingOperation>>()
   const autoHandledPaymentActions = new Set<string>()
+  // Operations a dialog is currently rendering outcomes for. An attended
+  // operation surfaces success/failure in that dialog, so the store's outcome
+  // toasts stay quiet; timeouts still toast — this tab gave up watching, the
+  // dialog is showing a verifying state that no longer advances.
+  const attendedOperations = new Set<string>()
   const paymentIntentClientSecrets = new Map<string, string>()
   const inFlightPolls = new Map<string, Promise<void>>()
 
@@ -232,6 +240,7 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
       type,
       status: 'pending',
       errorMessage: null,
+      failureClass: null,
       startedAt: now,
       operationStartedAt: metadata?.attemptStartedAt ?? now,
       businessAttemptStartedAt: metadata?.attemptStartedAt,
@@ -735,17 +744,17 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
       useSettingsDialog().show(isCloud ? 'workspace' : 'credits')
     }
 
-    const toastStore = useToastStore()
-    const messageKey =
-      operation.type === 'subscription'
-        ? 'billingOperation.subscriptionSuccess'
-        : 'billingOperation.topupSuccess'
-
-    toastStore.add({
-      severity: 'success',
-      summary: t(messageKey),
-      life: 5000
-    })
+    if (!attendedOperations.has(opId)) {
+      const messageKey =
+        operation.type === 'subscription'
+          ? 'billingOperation.subscriptionSuccess'
+          : 'billingOperation.topupSuccess'
+      useToastStore().add({
+        severity: 'success',
+        summary: t(messageKey),
+        life: 5000
+      })
+    }
 
     resolveTerminal(opId)
   }
@@ -759,6 +768,7 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
     const detail = billingFailureDetail(operation.type, errorMessage)
 
     updateOperationStatus(opId, 'failed', detail ?? defaultMessage)
+    updateOperation(opId, { failureClass: classifyFailure(errorMessage) })
     cleanup(opId)
 
     const telemetry = useTelemetry()
@@ -826,7 +836,11 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
       })
     }
 
-    if (operation.type !== 'cancel' && !superseded) {
+    if (
+      operation.type !== 'cancel' &&
+      !superseded &&
+      !attendedOperations.has(opId)
+    ) {
       useToastStore().add({
         severity: 'error',
         summary: defaultMessage,
@@ -1004,6 +1018,21 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
     return t('billingOperation.cancelFailed')
   }
 
+  // The processing class is Stripe telling us the rails hiccuped — the card
+  // itself was never judged. Everything else, including codes we don't
+  // recognize, is treated as the bank's verdict.
+  const PROCESSING_FAILURE_CODES = new Set([
+    'processing_error',
+    'issuer_not_available',
+    'try_again_later'
+  ])
+
+  function classifyFailure(errorMessage: string | null): BillingFailureClass {
+    return errorMessage && PROCESSING_FAILURE_CODES.has(errorMessage)
+      ? 'processing'
+      : 'declined'
+  }
+
   function billingFailureDetail(
     type: OperationType,
     errorMessage: string | null
@@ -1107,6 +1136,14 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
     }
   }
 
+  function markOperationAttended(opId: string) {
+    attendedOperations.add(opId)
+  }
+
+  function markOperationUnattended(opId: string) {
+    attendedOperations.delete(opId)
+  }
+
   function clearOperation(opId: string) {
     cleanup(opId)
     // Settle before dropping: anything awaiting this operation's terminal
@@ -1118,6 +1155,7 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
     operations.value = newMap
     terminalResolvers.delete(opId)
     terminalPromises.delete(opId)
+    attendedOperations.delete(opId)
   }
 
   /**
@@ -1158,6 +1196,8 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
     retryPaymentAuthentication,
     pollPendingOperations,
     clearOperation,
-    cancelOperation
+    cancelOperation,
+    markOperationAttended,
+    markOperationUnattended
   }
 })


### PR DESCRIPTION
Closes FE-1981. Stacked on #15944 (declined outcome screen) — review that first.

Implements the attended/unattended rule for checkout outcomes: while the pricing dialog is open, a failed or succeeded charge renders in the dialog; toasts only carry outcomes nobody is watching.

## What changes

- **Failure classification** (`billingOperationStore`): terminal failures now carry a `failureClass` — `processing` for the rails-hiccup codes (`processing_error`, `issuer_not_available`, `try_again_later`), `declined` for everything else including unrecognized codes. The mapped human copy in `errorMessage` is unchanged.
- **5c processing-error outcome step** (`SubscriptionProcessingErrorWorkspace`, Figma 5709-49062): "Payment couldn't be processed" — the card is fine, so the only action is Try again, which returns to the confirm step with the quote intact. Declined (5b, from #15944) keeps Update payment method; processing errors deliberately don't offer it.
- **In-flow failures route to the outcome steps**: `advanceToSuccessOnOperation` now routes a terminal failure to 5b/5c by class, instead of leaving the customer on the confirm step with only a toast. The re-entry (verifying) path classifies the same way.
- **Attended toast suppression**: the checkout composable marks its active operation attended while the dialog holds it (released on close/unmount or when the active operation changes). The store skips its success/failure toasts for attended operations. **Timeouts still toast** — a poll timeout means this tab stopped watching, so the toast is the only delivery left. The one path that closes the dialog without an outcome step (re-entry success with no plan selection) now carries its own success toast.

Unattended operations — dialog closed mid-verification, other-tab checkouts, top-ups — keep exactly today's toast behaviour.

## Tests

- Store: attended failure/success suppress their toasts, unattended restores them, timeouts toast regardless, and both failure classes map correctly.
- Component: 5c states the card is fine and offers only Try again.

┆ Linear: FE-1981
