### PR TITLE
[backport cloud/1.53] fix(billing): price legacy subscription previews from the server costs

### DIFF
--- a/browser_tests/tests/cloudSubscribeDeepLink.spec.ts
+++ b/browser_tests/tests/cloudSubscribeDeepLink.spec.ts
@@ -100,6 +100,10 @@ test.describe('Cloud subscribe deep link', { tag: '@cloud' }, () => {
     await expect(
       page.getByRole('heading', { name: 'Confirm your payment' })
     ).toBeVisible({ timeout: 45_000 })
+    await expect(page.getByText('$20.00', { exact: true })).toBeVisible()
+    await expect(
+      page.getByText('Renews at $20.00. Cancel anytime.')
+    ).toBeVisible()
     await expect(page.locator('#splash-loader')).toHaveCount(0)
     expect(legacyCheckoutRequests).toEqual([])
   })

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -3133,6 +3133,7 @@
       "quoteStale": "Your quote changed. Review the updated amount and try again.",
       "quoteRefreshFailed": "Your quote expired and couldn't be refreshed. Choose your plan again.",
       "renewsAt": "Renews at {amount} on {date}. Cancel anytime.",
+      "renewsAtAmount": "Renews at {amount}. Cancel anytime.",
       "discountComposition": "Discounts",
       "discount": {
         "plan": "Plan discount",

--- a/src/platform/cloud/subscription/utils/subscriptionQuoteFormatting.test.ts
+++ b/src/platform/cloud/subscription/utils/subscriptionQuoteFormatting.test.ts
@@ -1,0 +1,92 @@
+import type { PreviewSubscribeResponse } from '@comfyorg/ingest-types'
+import { describe, expect, it } from 'vitest'
+
+import {
+  formatAmountDueToday,
+  formatRenewalAmount,
+  resolveRenewalDate
+} from './subscriptionQuoteFormatting'
+
+function legacyPreview(
+  overrides: Partial<PreviewSubscribeResponse> = {}
+): PreviewSubscribeResponse {
+  return {
+    allowed: true,
+    transition_type: 'new_subscription',
+    effective_at: '2026-06-19T00:00:00Z',
+    is_immediate: true,
+    cost_today_cents: 2000,
+    cost_next_period_cents: 3000,
+    credits_today_cents: 0,
+    credits_next_period_cents: 0,
+    new_plan: {
+      slug: 'creator',
+      tier: 'CREATOR',
+      duration: 'MONTHLY',
+      price_cents: 2000,
+      credits_cents: 0,
+      seat_summary: {
+        seat_count: 1,
+        total_cost_cents: 2000,
+        total_credits_cents: 0
+      }
+    },
+    ...overrides
+  }
+}
+
+function exactPreview(
+  overrides: Partial<PreviewSubscribeResponse> = {}
+): PreviewSubscribeResponse {
+  return legacyPreview({
+    amount_due_cents: 1500,
+    currency: 'usd',
+    renewal_amount_cents: 2500,
+    renewal_at: '2026-07-19T00:00:00Z',
+    ...overrides
+  })
+}
+
+describe('formatAmountDueToday', () => {
+  it('prices the exact quote when the server sent one', () => {
+    expect(formatAmountDueToday(exactPreview(), 'en')).toBe('$15.00')
+  })
+
+  it('falls back to the legacy cost when the exact quote is absent', () => {
+    expect(formatAmountDueToday(legacyPreview(), 'en')).toBe('$20.00')
+  })
+
+  it('honours a non-USD exact quote', () => {
+    const preview = exactPreview({ currency: 'eur' })
+    expect(formatAmountDueToday(preview, 'en')).toBe('€15.00')
+  })
+})
+
+describe('formatRenewalAmount', () => {
+  it('prices the exact renewal when the server sent one', () => {
+    expect(formatRenewalAmount(exactPreview(), 'en')).toBe('$25.00')
+  })
+
+  it('falls back to the legacy next-period cost', () => {
+    expect(formatRenewalAmount(legacyPreview(), 'en')).toBe('$30.00')
+  })
+})
+
+describe('resolveRenewalDate', () => {
+  it('prefers the exact renewal instant', () => {
+    expect(resolveRenewalDate(exactPreview())).toBe('2026-07-19T00:00:00Z')
+  })
+
+  it('falls back to the target plan period end', () => {
+    const preview = legacyPreview()
+    const withPeriodEnd = {
+      ...preview,
+      new_plan: { ...preview.new_plan, period_end: '2026-08-19T00:00:00Z' }
+    }
+    expect(resolveRenewalDate(withPeriodEnd)).toBe('2026-08-19T00:00:00Z')
+  })
+
+  it('reports no date when the server supplied none', () => {
+    expect(resolveRenewalDate(legacyPreview())).toBeUndefined()
+  })
+})

--- a/src/platform/cloud/subscription/utils/subscriptionQuoteFormatting.ts
+++ b/src/platform/cloud/subscription/utils/subscriptionQuoteFormatting.ts
@@ -1,3 +1,8 @@
+import type { PreviewSubscribeResponse } from '@comfyorg/ingest-types'
+
+// Legacy previews price in USD and carry no currency field.
+const LEGACY_QUOTE_CURRENCY = 'usd'
+
 export function formatQuoteMoney(
   cents: number,
   currency: string | undefined,
@@ -8,4 +13,44 @@ export function formatQuoteMoney(
     style: 'currency',
     currency: currency.toUpperCase()
   }).format(cents / 100)
+}
+
+function resolveQuoteMoney(
+  exactCents: number | undefined,
+  exactCurrency: string | undefined,
+  legacyCents: number
+): { cents: number; currency: string | undefined } {
+  return exactCents === undefined
+    ? { cents: legacyCents, currency: LEGACY_QUOTE_CURRENCY }
+    : { cents: exactCents, currency: exactCurrency }
+}
+
+export function formatAmountDueToday(
+  preview: PreviewSubscribeResponse,
+  locale: string
+): string {
+  const { cents, currency } = resolveQuoteMoney(
+    preview.amount_due_cents,
+    preview.currency,
+    preview.cost_today_cents
+  )
+  return formatQuoteMoney(cents, currency, locale)
+}
+
+export function formatRenewalAmount(
+  preview: PreviewSubscribeResponse,
+  locale: string
+): string {
+  const { cents, currency } = resolveQuoteMoney(
+    preview.renewal_amount_cents,
+    preview.currency,
+    preview.cost_next_period_cents
+  )
+  return formatQuoteMoney(cents, currency, locale)
+}
+
+export function resolveRenewalDate(
+  preview: PreviewSubscribeResponse
+): string | undefined {
+  return preview.renewal_at ?? preview.new_plan.period_end
 }

--- a/src/platform/workspace/components/SubscriptionAddPaymentPreviewWorkspace.test.ts
+++ b/src/platform/workspace/components/SubscriptionAddPaymentPreviewWorkspace.test.ts
@@ -44,9 +44,16 @@ function previewFixture(
   }
 }
 
+// Interpolation values are appended so assertions can verify what a message
+// was given, not just which message was chosen.
 vi.mock('vue-i18n', () => ({
   useI18n: () => ({
-    t: (key: string) => key,
+    t: (key: string, named?: Record<string, unknown>) =>
+      named
+        ? `${key}|${Object.entries(named)
+            .map(([name, value]) => `${name}=${String(value)}`)
+            .join(',')}`
+        : key,
     n: (value: number) => value.toLocaleString('en-US'),
     locale: { value: 'en' }
   })
@@ -402,5 +409,29 @@ describe('SubscriptionAddPaymentPreviewWorkspace', () => {
         name: 'subscription.preview.backToAllPlans'
       })
     ).toBeNull()
+  })
+
+  it('prices a legacy preview from the server costs instead of rendering a blank total', () => {
+    const {
+      amount_due_cents,
+      currency,
+      renewal_amount_cents,
+      renewal_at,
+      quote_id,
+      quote_version,
+      ...legacy
+    } = previewFixture('MONTHLY', 2000)
+
+    render(SubscriptionAddPaymentPreviewWorkspace, {
+      props: { tierKey: 'creator', previewData: legacy },
+      global: globalOptions
+    })
+
+    expect(screen.getByText('$20.00')).toBeTruthy()
+    expect(
+      screen.getByText(
+        'subscription.preview.renewsAt|amount=$20.00,date=Jun 19, 2027'
+      )
+    ).toBeTruthy()
   })
 })

--- a/src/platform/workspace/components/SubscriptionAddPaymentPreviewWorkspace.vue
+++ b/src/platform/workspace/components/SubscriptionAddPaymentPreviewWorkspace.vue
@@ -366,7 +366,12 @@ import {
 } from '@/platform/cloud/subscription/constants/tierPricing'
 import type { TierKey } from '@/platform/cloud/subscription/constants/tierPricing'
 import { isYearlyCheckout } from '@/platform/cloud/subscription/utils/planDuration'
-import { formatQuoteMoney } from '@/platform/cloud/subscription/utils/subscriptionQuoteFormatting'
+import {
+  formatAmountDueToday,
+  formatQuoteMoney,
+  formatRenewalAmount,
+  resolveRenewalDate
+} from '@/platform/cloud/subscription/utils/subscriptionQuoteFormatting'
 import type { BillingCycle } from '@/platform/cloud/subscription/utils/subscriptionTierRank'
 import type {
   BillingAuthenticationState,
@@ -560,35 +565,21 @@ const creditsRefillLabelKey = computed(() =>
 )
 
 const totalDueToday = computed(() =>
-  previewData?.amount_due_cents === undefined
-    ? ''
-    : formatQuoteMoney(
-        previewData.amount_due_cents,
-        previewData.currency,
-        locale.value
-      )
+  previewData ? formatAmountDueToday(previewData, locale.value) : ''
 )
 
 const renewalTerms = computed(() => {
-  if (
-    previewData?.renewal_amount_cents === undefined ||
-    !previewData.renewal_at
-  ) {
-    return ''
-  }
-  const date = new Date(previewData.renewal_at).toLocaleDateString(undefined, {
+  if (!previewData) return ''
+  const amount = formatRenewalAmount(previewData, locale.value)
+  if (!amount) return ''
+  const renewsAt = resolveRenewalDate(previewData)
+  if (!renewsAt) return t('subscription.preview.renewsAtAmount', { amount })
+  const date = new Date(renewsAt).toLocaleDateString(locale.value, {
     month: 'short',
     day: 'numeric',
     year: 'numeric',
     timeZone: 'UTC'
   })
-  return t('subscription.preview.renewsAt', {
-    amount: formatQuoteMoney(
-      previewData.renewal_amount_cents,
-      previewData.currency,
-      locale.value
-    ),
-    date
-  })
+  return t('subscription.preview.renewsAt', { amount, date })
 })
 </script>

--- a/src/platform/workspace/components/SubscriptionTransitionPreviewWorkspace.test.ts
+++ b/src/platform/workspace/components/SubscriptionTransitionPreviewWorkspace.test.ts
@@ -19,10 +19,21 @@ vi.mock('@/composables/billing/useBillingContext', () => ({
   })
 }))
 
+// Only the renewal messages are supplied, so the renewal assertions verify
+// real interpolated output while every other key still renders as itself.
 const i18n = createI18n({
   legacy: false,
   locale: 'en',
-  messages: { en: {} }
+  messages: {
+    en: {
+      subscription: {
+        preview: {
+          renewsAt: 'Renews at {amount} on {date}. Cancel anytime.',
+          renewsAtAmount: 'Renews at {amount}. Cancel anytime.'
+        }
+      }
+    }
+  }
 })
 
 const globalOptions = {
@@ -75,6 +86,23 @@ function preview(
     renewal_at: '2027-06-28T00:00:00Z',
     ...overrides
   }
+}
+
+// Shape returned while embedded checkout is disabled: every exact-quote field
+// is absent and only the legacy cost fields are populated.
+function legacyPreview(
+  overrides: Partial<PreviewSubscribeResponse>
+): PreviewSubscribeResponse {
+  const {
+    amount_due_cents,
+    currency,
+    renewal_amount_cents,
+    renewal_at,
+    quote_id,
+    quote_version,
+    ...legacy
+  } = preview(overrides)
+  return legacy
 }
 
 describe('SubscriptionTransitionPreviewWorkspace', () => {
@@ -309,5 +337,66 @@ describe('SubscriptionTransitionPreviewWorkspace', () => {
       global: globalOptions
     })
     expect(screen.getByText(/Some Future Tier/)).toBeTruthy()
+  })
+
+  it('prices a legacy preview from the server costs instead of reporting the quote unavailable', () => {
+    render(SubscriptionTransitionPreviewWorkspace, {
+      props: {
+        previewData: legacyPreview({
+          cost_today_cents: 31_850,
+          cost_next_period_cents: 33_600,
+          new_plan: plan('CREATOR', 'ANNUAL', 33_600)
+        })
+      },
+      global: globalOptions
+    })
+
+    expect(screen.getByText('$318.50')).toBeTruthy()
+    expect(
+      screen.getByText('Renews at $336.00 on Jun 28, 2027. Cancel anytime.')
+    ).toBeTruthy()
+    expect(
+      screen.queryByText('subscription.preview.quoteUnavailable')
+    ).toBeNull()
+  })
+
+  it('states legacy renewal terms without a date when the server supplies no period end', () => {
+    const { period_end, ...planWithoutPeriodEnd } = plan(
+      'CREATOR',
+      'ANNUAL',
+      33_600
+    )
+    render(SubscriptionTransitionPreviewWorkspace, {
+      props: {
+        previewData: legacyPreview({
+          cost_today_cents: 31_850,
+          cost_next_period_cents: 33_600,
+          new_plan: planWithoutPeriodEnd
+        })
+      },
+      global: globalOptions
+    })
+
+    expect(screen.getByText('Renews at $336.00. Cancel anytime.')).toBeTruthy()
+    expect(
+      screen.queryByText('subscription.preview.quoteUnavailable')
+    ).toBeNull()
+  })
+
+  it('withholds an exact quote that arrives without a currency to price it in', () => {
+    render(SubscriptionTransitionPreviewWorkspace, {
+      props: {
+        previewData: preview({
+          cost_today_cents: 31_850,
+          new_plan: plan('CREATOR', 'ANNUAL', 33_600),
+          currency: undefined
+        })
+      },
+      global: globalOptions
+    })
+
+    expect(
+      screen.getAllByText('subscription.preview.quoteUnavailable')
+    ).toHaveLength(2)
   })
 })

--- a/src/platform/workspace/components/SubscriptionTransitionPreviewWorkspace.vue
+++ b/src/platform/workspace/components/SubscriptionTransitionPreviewWorkspace.vue
@@ -196,7 +196,7 @@
             {{ $t('subscription.preview.totalDueToday') }}
           </span>
           <span class="font-bold text-base-foreground tabular-nums">
-            {{ exactAmountDue }}
+            {{ amountDueToday }}
           </span>
         </div>
         <span class="text-sm text-muted-foreground">{{ renewalTerms }}</span>
@@ -323,7 +323,11 @@ import {
   toTierKey
 } from '@/platform/cloud/subscription/constants/tierPricing'
 import { isAnnualDuration } from '@/platform/cloud/subscription/utils/planDuration'
-import { formatQuoteMoney } from '@/platform/cloud/subscription/utils/subscriptionQuoteFormatting'
+import {
+  formatAmountDueToday,
+  formatRenewalAmount,
+  resolveRenewalDate
+} from '@/platform/cloud/subscription/utils/subscriptionQuoteFormatting'
 import type {
   BillingAuthenticationState,
   PreviewSubscribeResponse
@@ -648,29 +652,19 @@ const confirmCta = computed(() => {
     amount: chargeDisplay.value
   })
 })
-const exactAmountDue = computed(() =>
-  previewData.amount_due_cents === undefined
-    ? t('subscription.preview.quoteUnavailable')
-    : formatQuoteMoney(
-        previewData.amount_due_cents,
-        previewData.currency,
-        locale.value
-      )
+const amountDueToday = computed(
+  () =>
+    formatAmountDueToday(previewData, locale.value) ||
+    t('subscription.preview.quoteUnavailable')
 )
 const renewalTerms = computed(() => {
-  if (
-    previewData.renewal_amount_cents === undefined ||
-    !previewData.renewal_at
-  ) {
-    return t('subscription.preview.quoteUnavailable')
-  }
+  const amount = formatRenewalAmount(previewData, locale.value)
+  if (!amount) return t('subscription.preview.quoteUnavailable')
+  const renewsAt = resolveRenewalDate(previewData)
+  if (!renewsAt) return t('subscription.preview.renewsAtAmount', { amount })
   return t('subscription.preview.renewsAt', {
-    amount: formatQuoteMoney(
-      previewData.renewal_amount_cents,
-      previewData.currency,
-      locale.value
-    ),
-    date: formatDate(previewData.renewal_at)
+    amount,
+    date: formatDate(renewsAt)
   })
 })
 </script>

--- a/src/platform/workspace/components/SubscriptionTransitionPreviewWorkspaceReactivation.test.ts
+++ b/src/platform/workspace/components/SubscriptionTransitionPreviewWorkspaceReactivation.test.ts
@@ -545,7 +545,7 @@ describe('SubscriptionTransitionPreviewWorkspace reactivation disclosure', () =>
   })
 
   describe('confirm gating on load state', () => {
-    it('shows unavailable exact quote fields', () => {
+    it('prices a preview that carries no exact quote from the legacy costs', () => {
       mockSubscription.value = { isCancelled: false, endDate: null }
       renderComponent(
         makePreview({
@@ -558,9 +558,10 @@ describe('SubscriptionTransitionPreviewWorkspace reactivation disclosure', () =>
         })
       )
 
+      expect(screen.getByText('$15.00')).toBeInTheDocument()
       expect(
-        screen.getAllByText('subscription.preview.quoteUnavailable')
-      ).toHaveLength(2)
+        screen.queryByText('subscription.preview.quoteUnavailable')
+      ).toBeNull()
     })
 
     it('does not confirm without a current quote', async () => {


### PR DESCRIPTION
Backport of #16517 to `cloud/1.53`.

Cherry-pick of `c989dee4077e195a11dee00f31dbf532305fb3e8` — applied cleanly with **no conflicts**, and the resulting diff is byte-identical to the commit merged to `main` (9 files, +298/-50).

## Why this is needed on this branch

The subscription confirm screens render **no amount at all** whenever embedded checkout is off — a blank "Total due today" on new subscriptions, and "Unavailable" on plan changes. Any release branch shipping without this fix shows users a checkout screen with no price on it.

## Root cause

#14483 ("consolidate embedded checkout frontend") rewrote both quote computeds to read **only** the embedded-checkout field family:

```ts
const totalDueToday = computed(() =>
  previewData?.amount_due_cents === undefined ? '' : formatQuoteMoney(...)
)
```

When embedded checkout is off the server never sends `amount_due_cents`, so the computed resolves to `''` and the UI renders nothing — even though the server *always* sends the legacy cost fields that carry the same figure.

## What changes

- `formatAmountDueToday` / `formatRenewalAmount` / `resolveRenewalDate` in `subscriptionQuoteFormatting.ts` resolve each figure from the exact quote **when the server sent one**, and from the always-present legacy costs otherwise.
- `SubscriptionAddPaymentPreviewWorkspace` and `SubscriptionTransitionPreviewWorkspace` consume them.
- New `subscription.preview.renewsAtAmount` message for the case where the server supplies an amount but no renewal date.

## Verification

AS IS / TO BE screenshots are on the original PR: #16517

Regression coverage came across with the cherry-pick:
- `subscriptionQuoteFormatting.test.ts` (new, 8 cases covering exact-quote / legacy-fallback / non-USD / missing-date)
- `SubscriptionAddPaymentPreviewWorkspace.test.ts`, `SubscriptionTransitionPreviewWorkspace.test.ts`, `SubscriptionTransitionPreviewWorkspaceReactivation.test.ts`
- `browser_tests/tests/cloudSubscribeDeepLink.spec.ts` (e2e)

Unit tests were not runnable in the backport sandbox (a local happy-dom issue fails untouched pre-existing specs identically), so CI on this PR is the verifying signal.
