### PR TITLE
ci: temporarily disable automatic custom-node tests

### DIFF
--- a/.github/workflows/ci-tests-custom-nodes.yaml
+++ b/.github/workflows/ci-tests-custom-nodes.yaml
@@ -4,8 +4,8 @@
 # skipped, the job goes red - a suite that let a broken pack through as a
 # "skip" would be pointless.
 #
-# Every relevant PR runs the exact pack population and receives the aggregate.
-# Merge-queue runs are temporarily disabled so failures do not block merges.
+# Automatic PR and merge-queue runs are temporarily disabled so failures do
+# not block merges. Nightly and manual runs still exercise the exact packs.
 # Jobs have read-only permissions, and neither checkout persists credentials
 # while third-party setup and runtime code executes.
 #
@@ -24,7 +24,6 @@
 name: 'CI: Tests Custom Nodes'
 
 on:
-  pull_request:
   schedule:
     - cron: '15 9 * * *'
   workflow_dispatch:

--- a/.github/workflows/ci-tests-custom-nodes.yaml
+++ b/.github/workflows/ci-tests-custom-nodes.yaml
@@ -4,8 +4,8 @@
 # skipped, the job goes red - a suite that let a broken pack through as a
 # "skip" would be pointless.
 #
-# Required gate: every relevant PR and every merge-queue candidate runs the
-# exact pack population; every pull request still receives the aggregate.
+# Every relevant PR runs the exact pack population and receives the aggregate.
+# Merge-queue runs are temporarily disabled so failures do not block merges.
 # Jobs have read-only permissions, and neither checkout persists credentials
 # while third-party setup and runtime code executes.
 #
@@ -25,7 +25,6 @@ name: 'CI: Tests Custom Nodes'
 
 on:
   pull_request:
-  merge_group:
   schedule:
     - cron: '15 9 * * *'
   workflow_dispatch:


### PR DESCRIPTION
## Summary

Temporarily stop custom-node tests from running automatically so intermittent failures do not block releases or PR merges.

## Changes

- **What**: Remove the `pull_request` and `merge_group` triggers while retaining nightly and manual runs.

## Review Focus

Confirm the custom-node workflow no longer participates in PR or merge-queue gating.