### PR TITLE
fix(agent): follow-up to #16368 — fallback semantics

### DIFF
--- a/src/workbench/extensions/agent/components/agent/message/AgentMessage.test.ts
+++ b/src/workbench/extensions/agent/components/agent/message/AgentMessage.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { render, screen } from '@testing-library/vue'
+import { render, screen, within } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import { describe, expect, it, vi } from 'vitest'
 
@@ -310,11 +310,37 @@ describe('AgentMessage fallback content', () => {
       }
     })
 
-    expect(screen.getAllByTestId('tab-link')).toHaveLength(2)
-    expect(screen.getByText('workflow-1:First workflow')).toBeInTheDocument()
-    expect(screen.getByText('workflow-2:Second workflow')).toBeInTheDocument()
-    expect(screen.getByText('Saved locally')).toBeInTheDocument()
-    expect(screen.getByText('Could not publish')).toBeInTheDocument()
+    expect(
+      within(screen.getByRole('group')).getAllByTestId('tab-link')
+    ).toHaveLength(2)
+    expect(screen.getByRole('status')).toHaveTextContent('Saved locally')
+    expect(screen.getByRole('alert')).toHaveTextContent('Could not publish')
+  })
+
+  it('hides completed thinking when the response did not use tools', () => {
+    const message: AssistantMessage = {
+      ...thinkingMessage(),
+      streaming: false,
+      thinking: false,
+      parts: [
+        {
+          type: 'thinking',
+          text: 'Reasoning before the answer',
+          state: 'done'
+        },
+        { type: 'text', text: 'Finished without tools', state: 'done' }
+      ]
+    }
+
+    render(AgentMessage, {
+      props: { message },
+      global: { plugins: [i18n] }
+    })
+
+    expect(
+      screen.queryByText('Reasoning before the answer')
+    ).not.toBeInTheDocument()
+    expect(screen.getByText('Finished without tools')).toBeInTheDocument()
   })
 
   it('forwards feedback from a completed text response', async () => {

--- a/src/workbench/extensions/agent/components/agent/message/AgentMessage.vue
+++ b/src/workbench/extensions/agent/components/agent/message/AgentMessage.vue
@@ -77,7 +77,11 @@ const hasTools = computed(() =>
         :parts="group.parts"
         :active="message.streaming && index === groups.length - 1"
       />
-      <div v-else-if="group.kind === 'tabLinks'" class="flex flex-col gap-1">
+      <div
+        v-else-if="group.kind === 'tabLinks'"
+        role="group"
+        class="flex flex-col gap-1"
+      >
         <TabLinkCard
           v-for="(link, linkIndex) in group.parts"
           :key="linkIndex"
@@ -88,6 +92,7 @@ const hasTools = computed(() =>
       </div>
       <div
         v-else
+        :role="group.part.level === 'error' ? 'alert' : 'status'"
         :class="
           cn(
             'rounded-agent flex items-start gap-2 border px-3 py-2 text-sm',


### PR DESCRIPTION
Groups and notice levels are now observable.
No-tool reasoning behavior is pinned.
Focused tests and typecheck are green.

<details><summary>Full context for agent readers</summary>

## Summary

Follow-up to #16368 for the two deferred review findings.

## Changes

- **What**: Exposes workflow-link grouping and notice severity through accessible roles, asserts adjacent links stay grouped, and characterizes completed reasoning as hidden when no tool ran.

## Review Focus

- [Grouping and severity finding](https://github.com/Comfy-Org/ComfyUI_frontend/pull/16368#discussion_r3897381186)
- [No-tool completed reasoning finding](https://github.com/Comfy-Org/ComfyUI_frontend/pull/16368#discussion_r3897381197)

Verification: `pnpm test:unit src/workbench/extensions/agent/components/agent/message/AgentMessage.test.ts` (11/11), `pnpm typecheck`, targeted ESLint, and oxfmt.

## Screenshots

Not applicable.

</details>

<!-- authored-by:agent addr-drain -->