### PR TITLE
fix(tests): follow-up to #16437 — await focus before negative assertion

### DIFF
--- a/src/components/rightSidePanel/errors/ErrorGroupList.test.ts
+++ b/src/components/rightSidePanel/errors/ErrorGroupList.test.ts
@@ -330,13 +330,13 @@ describe('ErrorGroupList selection emphasis', () => {
 
     await user.click(screen.getByRole('button', { name: 'SamplerNode - clip' }))
 
-    expect(canvas.setGraph).not.toHaveBeenCalled()
     await waitFor(() => {
       expect(canvas.animateToBounds).toHaveBeenCalledWith(
         SAMPLER_NODE.boundingRect,
         { viewport: [0, 0, 900, 700] }
       )
     })
+    expect(canvas.setGraph).not.toHaveBeenCalled()
   })
 
   it('locates an execution error through the real subgraph navigation path', async () => {


### PR DESCRIPTION
## Summary

Moves the root-graph negative assertion after the awaited focus effect so it cannot pass before asynchronous navigation settles.

## Changes

- **What**: Implements the deferred review item from #16437.
- **Review item**: https://github.com/Comfy-Org/ComfyUI_frontend/pull/16437#issuecomment-5494543027
- **Verification**: focused Vitest 8/8; full typecheck; Oxfmt; commit-hook lint/typecheck; pre-push Knip.

## Review Focus

Confirm the assertion ordering now matches the asynchronous focus contract.

<!-- authored-by:agent addr-drain -->
