### PR TITLE
fix(agent): follow-up to #16482 — rename safety and focus

### DIFF
--- a/browser_tests/fixtures/agentPanelFixture.ts
+++ b/browser_tests/fixtures/agentPanelFixture.ts
@@ -14,6 +14,7 @@ const APP_URL = process.env.PLAYWRIGHT_TEST_URL || 'http://localhost:8188'
 function agentFeatures(agentFlag: boolean): RemoteConfig {
   return {
     posthog_project_token: 'phc_e2e_agent_panel',
+    posthog_api_host: 'https://posthog.invalid',
     posthog_config: {
       advanced_disable_flags: true,
       bootstrap: {
@@ -41,12 +42,12 @@ async function mockAgentBoot(
     has_more: false
   }
   await page.route('**/api/assets**', (r) => r.fulfill(jsonRoute(emptyAssets)))
-  // The bootstrapped project token makes PostHogTelemetryProvider run a real
-  // posthog.init(); route its ingest host so CI never emits live third-party
-  // traffic under the fabricated token.
-  await page.route('**://t.comfy.org/**', (r) =>
-    r.fulfill(jsonRoute({ status: 1 }))
-  )
+  await page.route('https://posthog.invalid/**', (route) => {
+    if (route.request().url().endsWith('.js')) {
+      return route.fulfill({ contentType: 'text/javascript', body: '' })
+    }
+    return route.fulfill(jsonRoute({ status: 1 }))
+  })
 }
 
 type AgentFixtures = {

--- a/browser_tests/fixtures/agentPanelFixture.ts
+++ b/browser_tests/fixtures/agentPanelFixture.ts
@@ -1,7 +1,9 @@
+import { expect } from '@playwright/test'
 import type { Page } from '@playwright/test'
 
 import type { ListAssetsResponse } from '@comfyorg/ingest-types'
 
+import enMessages from '@/locales/en/main.json' with { type: 'json' }
 import type { RemoteConfig } from '@/platform/remoteConfig/types'
 
 import { cloudAppFixture, waitForCloudApp } from '@e2e/fixtures/cloudAppFixture'
@@ -77,4 +79,10 @@ export async function bootAgentApp(
   await bootCloud(page)
   await page.goto(APP_URL)
   await waitForCloudApp(page)
+
+  const panelTrigger = page.getByRole('button', {
+    name: enMessages.agent.askComfyAgent
+  })
+  if (agentFlag) await expect(panelTrigger).toBeVisible()
+  else await expect(panelTrigger).toHaveCount(0)
 }

--- a/browser_tests/tests/agent/renameFocus.spec.ts
+++ b/browser_tests/tests/agent/renameFocus.spec.ts
@@ -103,7 +103,7 @@ test.describe('Agent chat history rename', { tag: '@cloud' }, () => {
 
     // (2) focus is on the editor, not the trigger it was restored to.
     await expect(editor).toBeFocused()
-    await expect(optionsTrigger).not.toBeFocused()
+    await expect(optionsTrigger).toHaveCount(0)
 
     // (3) the editor is actually usable, not merely present: typing lands in
     // it and Enter commits. Guards a "fix" that keeps the input mounted but

--- a/browser_tests/tests/agent/renameFocus.spec.ts
+++ b/browser_tests/tests/agent/renameFocus.spec.ts
@@ -79,7 +79,10 @@ test.describe('Agent chat history rename', { tag: '@cloud' }, () => {
     const row = page.getByText(SEEDED_TITLE)
     await expect(row).toBeVisible()
 
-    await page.getByRole('button', { name: CHAT_OPTIONS_LABEL }).click()
+    const optionsTrigger = page.getByRole('button', {
+      name: CHAT_OPTIONS_LABEL
+    })
+    await optionsTrigger.click()
     const renameItem = page.getByRole('menuitem', { name: RENAME_LABEL })
     await expect(renameItem).toBeVisible()
     await renameItem.click()
@@ -100,6 +103,7 @@ test.describe('Agent chat history rename', { tag: '@cloud' }, () => {
 
     // (2) focus is on the editor, not the trigger it was restored to.
     await expect(editor).toBeFocused()
+    await expect(optionsTrigger).not.toBeFocused()
 
     // (3) the editor is actually usable, not merely present: typing lands in
     // it and Enter commits. Guards a "fix" that keeps the input mounted but

--- a/src/workbench/extensions/agent/components/agent/ChatHistoryScreen.test.ts
+++ b/src/workbench/extensions/agent/components/agent/ChatHistoryScreen.test.ts
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen, within } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
-import { beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { i18n } from '@/i18n'
 import type { HistoryGroups } from '../../stores/agent/agentChatHistoryStore'
@@ -207,6 +207,18 @@ describe('ChatHistoryScreen', () => {
     expect(input.selectionEnd).toBe(input.value.length)
     expect(screen.queryByRole('button', { name: 'Original title' })).toBeNull()
     expect(emitted().select).toBeUndefined()
+  })
+
+  it('does not refocus the editor on each draft update', async () => {
+    const user = userEvent.setup()
+    const focus = vi.spyOn(HTMLInputElement.prototype, 'focus')
+    renderScreen(groupsWithTitle('Original title'))
+    const input = await openRename(user)
+    const focusCallsAfterMount = focus.mock.calls.length
+
+    await user.type(input, ' updated')
+
+    expect(focus).toHaveBeenCalledTimes(focusCallsAfterMount)
   })
 
   it('emits trimmed rename and renders the parent-updated title', async () => {

--- a/src/workbench/extensions/agent/components/agent/ChatHistoryScreen.test.ts
+++ b/src/workbench/extensions/agent/components/agent/ChatHistoryScreen.test.ts
@@ -1,4 +1,4 @@
-import { render, screen, within } from '@testing-library/vue'
+import { fireEvent, render, screen, within } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it } from 'vitest'
 
@@ -321,13 +321,14 @@ describe('ChatHistoryScreen', () => {
 
   it('caps how long a renamed title can grow', async () => {
     const user = userEvent.setup()
-    renderScreen(groupsWithTitle('Original title'))
+    const { emitted } = renderScreen(groupsWithTitle('Original title'))
     const input = await openRename(user)
+    const longTitle = 'x'.repeat(250)
 
-    await user.clear(input)
-    await user.paste('x'.repeat(250))
+    await fireEvent.update(input, longTitle)
+    await user.keyboard('{Enter}')
 
-    expect(input.value).toHaveLength(200)
+    expect(emitted().rename).toEqual([['thread-1', longTitle.slice(0, 200)]])
   })
 
   it('falls back to the untitled label for a whitespace-only title', () => {

--- a/src/workbench/extensions/agent/components/agent/ChatHistoryScreen.test.ts
+++ b/src/workbench/extensions/agent/components/agent/ChatHistoryScreen.test.ts
@@ -296,28 +296,6 @@ describe('ChatHistoryScreen', () => {
     expect(emitted().rename).toBeUndefined()
   })
 
-  it('keeps the editor focused and the draft intact when the row changes bucket mid-rename', async () => {
-    const user = userEvent.setup()
-    const { rerender } = renderScreen(groupsWithTitle('Original title'))
-    const input = await openRename(user)
-
-    await user.clear(input)
-    await user.type(input, 'Half typed')
-
-    await rerender({
-      groups: { ...emptyGroups, yesterday: [originalSession] }
-    })
-
-    const moved = await screen.findByRole<HTMLInputElement>('textbox', {
-      name: 'Rename'
-    })
-    expect(moved).toHaveFocus()
-    expect(moved.value).toBe('Half typed')
-
-    await user.type(moved, ' and more')
-    expect(moved.value).toBe('Half typed and more')
-  })
-
   it('clears a rename when its session disappears', async () => {
     const user = userEvent.setup()
     const { emitted, rerender } = renderScreen(
@@ -367,28 +345,6 @@ describe('ChatHistoryScreen', () => {
 
     expect(input.value).toBe('  Padded  ')
     expect(emitted().rename).toBeUndefined()
-  })
-
-  // Deliberately asserts only that nothing is silently committed. Whether the
-  // editor should survive a regroup is unsettled, so this test does not pin it.
-  it('commits nothing when the row changes bucket mid-rename', async () => {
-    const user = userEvent.setup()
-    const { emitted, rerender } = renderScreen(
-      groupsWithTitle('Original title')
-    )
-    const input = await openRename(user)
-
-    await user.clear(input)
-    await user.type(input, 'Renamed mid-move')
-
-    await rerender({
-      groups: { ...emptyGroups, yesterday: [originalSession] }
-    })
-
-    expect(emitted().rename).toBeUndefined()
-    expect(
-      screen.queryByRole('button', { name: 'Renamed mid-move' })
-    ).toBeNull()
   })
 
   it('ignores empty or unchanged titles', async () => {

--- a/src/workbench/extensions/agent/components/agent/ChatHistoryScreen.test.ts
+++ b/src/workbench/extensions/agent/components/agent/ChatHistoryScreen.test.ts
@@ -226,6 +226,19 @@ describe('ChatHistoryScreen', () => {
     expect(screen.getByRole('button', { name: 'Findable title' })).toBeVisible()
   })
 
+  it('does not overwrite a refreshed title with an untouched draft', async () => {
+    const user = userEvent.setup()
+    const { emitted, rerender } = renderScreen(
+      groupsWithTitle('Original title')
+    )
+    await openRename(user)
+
+    await rerender({ groups: groupsWithTitle('Refreshed title') })
+    await user.keyboard('{Enter}')
+
+    expect(emitted().rename).toBeUndefined()
+  })
+
   it('cancels a history-row rename on Escape', async () => {
     const user = userEvent.setup()
     const { emitted } = renderScreen(groupsWithTitle('Original title'))

--- a/src/workbench/extensions/agent/components/agent/ChatHistoryScreen.test.ts
+++ b/src/workbench/extensions/agent/components/agent/ChatHistoryScreen.test.ts
@@ -224,6 +224,7 @@ describe('ChatHistoryScreen', () => {
     await rerender({ groups: groupsWithTitle('Findable title') })
 
     expect(screen.getByRole('button', { name: 'Findable title' })).toBeVisible()
+    expect(screen.getByRole('button', { name: 'Chat options' })).toHaveFocus()
   })
 
   it('does not overwrite a refreshed title with an untouched draft', async () => {
@@ -251,6 +252,7 @@ describe('ChatHistoryScreen', () => {
     expect(screen.getByRole('button', { name: 'Original title' })).toBeVisible()
     expect(screen.queryByText('Discarded')).toBeNull()
     expect(emitted().rename).toBeUndefined()
+    expect(screen.getByRole('button', { name: 'Chat options' })).toHaveFocus()
   })
 
   it('discards a partial rename when focus leaves the input', async () => {

--- a/src/workbench/extensions/agent/components/agent/ChatHistoryScreen.test.ts
+++ b/src/workbench/extensions/agent/components/agent/ChatHistoryScreen.test.ts
@@ -240,20 +240,17 @@ describe('ChatHistoryScreen', () => {
     expect(emitted().rename).toBeUndefined()
   })
 
-  // Behaviour deliberately changed: blur used to discard the draft, which threw
-  // typed input away on an ordinary tab or window switch with no recovery. The
-  // sibling inline rename in LayerPanel.vue commits on blur; this now matches.
-  it('commits a history-row rename when focus leaves the input', async () => {
+  it('discards a partial rename when focus leaves the input', async () => {
     const user = userEvent.setup()
     const { emitted } = renderScreen(groupsWithTitle('Original title'))
     const input = await openRename(user)
 
     await user.clear(input)
-    await user.type(input, 'Kept on blur')
+    await user.type(input, 'Partial title')
     await user.tab()
 
     expect(screen.queryByRole('textbox', { name: 'Rename' })).toBeNull()
-    expect(emitted().rename).toEqual([['thread-1', 'Kept on blur']])
+    expect(emitted().rename).toBeUndefined()
   })
 
   // The close-auto-focus fence is conditional: it must not eat the focus
@@ -330,7 +327,7 @@ describe('ChatHistoryScreen', () => {
     const { emitted } = renderScreen(groupsWithTitle('  Padded  '))
     const input = await openRename(user)
 
-    await user.tab()
+    await user.keyboard('{Enter}')
 
     expect(input.value).toBe('  Padded  ')
     expect(emitted().rename).toBeUndefined()

--- a/src/workbench/extensions/agent/components/agent/ChatHistoryScreen.test.ts
+++ b/src/workbench/extensions/agent/components/agent/ChatHistoryScreen.test.ts
@@ -305,6 +305,29 @@ describe('ChatHistoryScreen', () => {
     expect(moved.value).toBe('Half typed and more')
   })
 
+  it('clears a rename when its session disappears', async () => {
+    const user = userEvent.setup()
+    const { emitted, rerender } = renderScreen(
+      groupsWithTwoRows('Second title')
+    )
+    const input = await openRename(user)
+
+    await user.clear(input)
+    await user.type(input, 'Stale draft')
+    await rerender({
+      groups: { ...emptyGroups, today: [secondSession] }
+    })
+
+    expect(screen.queryByRole('textbox', { name: 'Rename' })).toBeNull()
+    expect(emitted().rename).toBeUndefined()
+
+    const trigger = screen.getByRole('button', { name: 'Chat options' })
+    await user.click(trigger)
+    await screen.findByRole('menuitem', { name: 'Rename' })
+    await user.keyboard('{Escape}')
+    expect(trigger).toHaveFocus()
+  })
+
   it('caps how long a renamed title can grow', async () => {
     const user = userEvent.setup()
     renderScreen(groupsWithTitle('Original title'))

--- a/src/workbench/extensions/agent/components/agent/ChatHistoryScreen.vue
+++ b/src/workbench/extensions/agent/components/agent/ChatHistoryScreen.vue
@@ -59,11 +59,13 @@ const MAX_TITLE_LENGTH = 200
 
 const renamingId = ref<string | null>(null)
 const renameDraft = ref('')
+const renameOriginalTitle = ref('')
 const selectOnFocus = ref(false)
 
 function startRename(session: ChatSession): void {
   renamingId.value = session.id
   renameDraft.value = session.title
+  renameOriginalTitle.value = session.title
   selectOnFocus.value = true
 }
 
@@ -102,7 +104,7 @@ function commitRename(session: ChatSession): void {
   if (renamingId.value !== session.id) return
   renamingId.value = null
   const title = renameDraft.value.trim()
-  if (title !== '' && title !== session.title.trim())
+  if (title !== '' && title !== renameOriginalTitle.value.trim())
     emit('rename', session.id, title)
 }
 

--- a/src/workbench/extensions/agent/components/agent/ChatHistoryScreen.vue
+++ b/src/workbench/extensions/agent/components/agent/ChatHistoryScreen.vue
@@ -12,7 +12,7 @@ import {
   TooltipRoot,
   TooltipTrigger
 } from 'reka-ui'
-import { computed, nextTick, ref } from 'vue'
+import { computed, nextTick, ref, watch } from 'vue'
 import type { ComponentPublicInstance } from 'vue'
 import { useI18n } from 'vue-i18n'
 
@@ -91,9 +91,14 @@ function cancelRename(): void {
   renamingId.value = null
 }
 
+watch(
+  () => sections.value.flatMap(([, , sessions]) => sessions.map(({ id }) => id)),
+  (sessionIds) => {
+    if (renamingId.value && !sessionIds.includes(renamingId.value)) cancelRename()
+  }
+)
+
 function commitRename(session: ChatSession): void {
-  // Idempotence guard: commit is reachable from both Enter and blur, so a
-  // second call for an already-ended rename must not emit a duplicate.
   if (renamingId.value !== session.id) return
   renamingId.value = null
   const title = renameDraft.value.trim()
@@ -105,8 +110,8 @@ function commitRename(session: ChatSession): void {
 // (@select fires before this event, so renamingId is already set on that
 // path); otherwise let Escape/outside-click return focus to the trigger so
 // keyboard users keep their place.
-function onMenuCloseAutoFocus(event: Event): void {
-  if (renamingId.value !== null) event.preventDefault()
+function onMenuCloseAutoFocus(sessionId: string, event: Event): void {
+  if (renamingId.value === sessionId) event.preventDefault()
 }
 
 function onRenameKeydown(session: ChatSession, event: KeyboardEvent): void {
@@ -222,7 +227,7 @@ function onRenameKeydown(session: ChatSession, event: KeyboardEvent): void {
                   align="end"
                   :side-offset="4"
                   class="agent-scope bg-agent-surface-raised z-1100 flex w-32 flex-col gap-1 overflow-clip rounded-[10px] p-1 shadow-md ring-1 ring-black/10 ring-inset"
-                  @close-auto-focus="onMenuCloseAutoFocus"
+                  @close-auto-focus="onMenuCloseAutoFocus(session.id, $event)"
                 >
                   <DropdownMenuItem
                     class="text-agent-fg data-highlighted:bg-agent-surface-hover flex h-6 w-full shrink-0 cursor-pointer items-center gap-1.5 rounded-lg px-1.5 py-1 text-xs outline-none"

--- a/src/workbench/extensions/agent/components/agent/ChatHistoryScreen.vue
+++ b/src/workbench/extensions/agent/components/agent/ChatHistoryScreen.vue
@@ -62,6 +62,7 @@ const renameDraft = ref('')
 const renameOriginalTitle = ref('')
 const selectOnFocus = ref(false)
 const optionsTriggers = new Map<string, HTMLElement>()
+const focusedRenameInputs = new WeakSet<HTMLInputElement>()
 
 function startRename(session: ChatSession): void {
   renamingId.value = session.id
@@ -75,6 +76,8 @@ function startRename(session: ChatSession): void {
 // wipe what the user has already typed.
 function focusInput(el: Element | ComponentPublicInstance | null): void {
   if (!(el instanceof HTMLInputElement)) return
+  if (focusedRenameInputs.has(el)) return
+  focusedRenameInputs.add(el)
   const shouldSelect = selectOnFocus.value
   selectOnFocus.value = false
   // Deferred because the ref fires before the element is in the document and

--- a/src/workbench/extensions/agent/components/agent/ChatHistoryScreen.vue
+++ b/src/workbench/extensions/agent/components/agent/ChatHistoryScreen.vue
@@ -61,6 +61,7 @@ const renamingId = ref<string | null>(null)
 const renameDraft = ref('')
 const renameOriginalTitle = ref('')
 const selectOnFocus = ref(false)
+const optionsTriggers = new Map<string, HTMLElement>()
 
 function startRename(session: ChatSession): void {
   renamingId.value = session.id
@@ -89,14 +90,30 @@ function focusInput(el: Element | ComponentPublicInstance | null): void {
   })
 }
 
-function cancelRename(): void {
+function setOptionsTrigger(
+  sessionId: string,
+  target: Element | ComponentPublicInstance | null
+): void {
+  const element = target instanceof Element ? target : target?.$el
+  if (element instanceof HTMLElement) optionsTriggers.set(sessionId, element)
+  else optionsTriggers.delete(sessionId)
+}
+
+function focusOptionsTrigger(sessionId: string): void {
+  void nextTick(() => optionsTriggers.get(sessionId)?.focus())
+}
+
+function cancelRename(sessionId?: string): void {
   renamingId.value = null
+  if (sessionId) focusOptionsTrigger(sessionId)
 }
 
 watch(
-  () => sections.value.flatMap(([, , sessions]) => sessions.map(({ id }) => id)),
+  () =>
+    sections.value.flatMap(([, , sessions]) => sessions.map(({ id }) => id)),
   (sessionIds) => {
-    if (renamingId.value && !sessionIds.includes(renamingId.value)) cancelRename()
+    if (renamingId.value && !sessionIds.includes(renamingId.value))
+      cancelRename()
   }
 )
 
@@ -106,6 +123,7 @@ function commitRename(session: ChatSession): void {
   const title = renameDraft.value.trim().slice(0, MAX_TITLE_LENGTH)
   if (title !== '' && title !== renameOriginalTitle.value.trim())
     emit('rename', session.id, title)
+  focusOptionsTrigger(session.id)
 }
 
 // Fence reka-ui's close focus-restore only when a rename was just started
@@ -123,7 +141,7 @@ function onRenameKeydown(session: ChatSession, event: KeyboardEvent): void {
     commitRename(session)
   } else if (event.key === 'Escape') {
     event.preventDefault()
-    cancelRename()
+    cancelRename(session.id)
   }
 }
 </script>
@@ -192,7 +210,7 @@ function onRenameKeydown(session: ChatSession, event: KeyboardEvent): void {
               :maxlength="MAX_TITLE_LENGTH"
               class="text-agent-fg border-agent-accent h-6 min-w-0 flex-1 rounded-lg border px-2 py-1 text-xs outline-none"
               @keydown="onRenameKeydown(session, $event)"
-              @blur="cancelRename"
+              @blur="cancelRename()"
             />
           </div>
           <template v-else>
@@ -218,6 +236,7 @@ function onRenameKeydown(session: ChatSession, event: KeyboardEvent): void {
             </AgentTooltip>
             <DropdownMenuRoot>
               <DropdownMenuTrigger
+                :ref="(target) => setOptionsTrigger(session.id, target)"
                 :aria-label="t('agent.chatOptions')"
                 class="text-agent-fg-muted hover:bg-agent-surface-hover hover:text-agent-fg flex size-6 shrink-0 cursor-pointer items-center justify-center rounded-sm transition-colors"
               >

--- a/src/workbench/extensions/agent/components/agent/ChatHistoryScreen.vue
+++ b/src/workbench/extensions/agent/components/agent/ChatHistoryScreen.vue
@@ -185,7 +185,7 @@ function onRenameKeydown(session: ChatSession, event: KeyboardEvent): void {
               :maxlength="MAX_TITLE_LENGTH"
               class="text-agent-fg border-agent-accent h-6 min-w-0 flex-1 rounded-lg border px-2 py-1 text-xs outline-none"
               @keydown="onRenameKeydown(session, $event)"
-              @blur="commitRename(session)"
+              @blur="cancelRename"
             />
           </div>
           <template v-else>

--- a/src/workbench/extensions/agent/components/agent/ChatHistoryScreen.vue
+++ b/src/workbench/extensions/agent/components/agent/ChatHistoryScreen.vue
@@ -103,7 +103,7 @@ watch(
 function commitRename(session: ChatSession): void {
   if (renamingId.value !== session.id) return
   renamingId.value = null
-  const title = renameDraft.value.trim()
+  const title = renameDraft.value.trim().slice(0, MAX_TITLE_LENGTH)
   if (title !== '' && title !== renameOriginalTitle.value.trim())
     emit('rename', session.id, title)
 }


### PR DESCRIPTION
## Summary

## Summary Completes the deferred review work from #16482: safer rename semantics, stable focus, and hardened browser fixtures.

## Review Focus

**Changes**

- **What**: commits renames only on Enter, clears stale editors, compares against the edit-start title, caps committed titles, restores row focus after commit/cancel, and focuses each editor mount once.
- **Tests**: removes engine-specific regroup assumptions, strengthens the focus-fence assertion, isolates PostHog traffic on a non-routable host, and verifies the feature gate during fixture boot.

**Review Focus**

Source PR: https://github.com/Comfy-Org/ComfyUI_frontend/pull/16482

Addressed review items:

- Incidental blur commits: https://github.com/Comfy-Org/ComfyUI_frontend/pull/16482#discussion_r3904737276
- Stale rename state and row-scoped fence: https://github.com/Comfy-Org/ComfyUI_frontend/pull/16482#discussion_r3904737286
- Edit-start title snapshot: https://github.com/Comfy-Org/ComfyUI_frontend/pull/16482#discussion_r3904737293
- Engine-specific regroup tests: https://github.com/Comfy-Org/ComfyUI_frontend/pull/16482#discussion_r3904737301
- Commit-time title cap: https://github.com/Comfy-Org/ComfyUI_frontend/pull/16482#discussion_r3904737307
- Focus restoration after commit/cancel: https://github.com/Comfy-Org/ComfyUI_frontend/pull/16482#discussion_r3904737317
- One focus per editor mount: https://github.com/Comfy-Org/ComfyUI_frontend/pull/16482#discussion_r3904737327
- Complementary browser focus assertion: https://github.com/Comfy-Org/ComfyUI_frontend/pull/16482#discussion_r3904737334
- PostHog fixture isolation: https://github.com/Comfy-Org/ComfyUI_frontend/pull/16482#discussion_r3904737340
- Feature-gate fixture assertion: https://github.com/Comfy-Org/ComfyUI_frontend/pull/16482#issuecomment-5495172042 and https://github.com/Comfy-Org/ComfyUI_frontend/pull/16482#issuecomment-5497332842

Validation: `pnpm typecheck`; focused Vitest 22/22; Playwright discovered the affected browser spec successfully.

<!-- authored-by:agent addr-drain -->
