### PR TITLE
fix(test): follow-up to #16158 — valid text-input ARIA coverage

### DIFF
--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetInputText.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetInputText.test.ts
@@ -178,6 +178,13 @@ describe('WidgetInputText Value Binding', () => {
         'true'
       )
     })
+
+    it('does not mark a valid text input as invalid', () => {
+      const widget = createInputTextWidget('valid value')
+      renderComponent(widget, 'valid value', { invalid: false })
+
+      expect(screen.getByRole('textbox')).not.toHaveAttribute('aria-invalid')
+    })
   })
 
   describe('Locked Field Hover Styling', () => {


### PR DESCRIPTION
Follow-up to #16158.

Adds the deferred valid-state regression case requested in https://github.com/Comfy-Org/ComfyUI_frontend/pull/16158#discussion_r3891222547. The test proves `invalid: false` omits `aria-invalid`; the complementary invalid-state case remains intact.

Verification: targeted Vitest (15/15) and `pnpm typecheck`.

<!-- authored-by:agent addr-drain -->