### PR TITLE
fix(ci): follow-up to #15418 — restore binary-size label revalidation

### DIFF
--- a/.github/workflows/ci-binary-size-validation.yaml
+++ b/.github/workflows/ci-binary-size-validation.yaml
@@ -4,12 +4,18 @@ name: 'CI: Binary Size Validation'
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, labeled, unlabeled]
   merge_group:
     types: [checks_requested]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: >-
+    ${{ github.workflow }}-${{ github.ref }}-${{
+      contains(fromJSON('["labeled", "unlabeled"]'), github.event.action) &&
+      github.event.label.name != 'allow-large-binaries' &&
+      github.run_id ||
+      'validation'
+    }}
   cancel-in-progress: true
 
 permissions:
@@ -17,7 +23,14 @@ permissions:
 
 jobs:
   binary-size:
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'allow-large-binaries') }}
+    if: >-
+      ${{
+        (
+          !contains(fromJSON('["labeled", "unlabeled"]'), github.event.action) ||
+          github.event.label.name == 'allow-large-binaries'
+        ) &&
+        !contains(github.event.pull_request.labels.*.name, 'allow-large-binaries')
+      }}
     runs-on: ubuntu-latest
     steps:
       # The label bypass only exists on the pull request, so re-checking the


### PR DESCRIPTION
Follow-up to #15418

## Summary

Restores immediate binary-size revalidation when `allow-large-binaries` is applied or removed, without letting unrelated label writes cancel an in-flight validation.

## Changes

- Subscribe to `labeled` and `unlabeled` again.
- Give unrelated label events unique concurrency groups and skip their job.
- Keep `allow-large-binaries` events in the validation group: applying the bypass cancels/skips, removing it runs a fresh size check.

Follow-up to https://github.com/Comfy-Org/ComfyUI_frontend/pull/15418

Addresses:
- https://github.com/Comfy-Org/ComfyUI_frontend/pull/15418#discussion_r3808798760
- https://github.com/Comfy-Org/ComfyUI_frontend/pull/15418#discussion_r3808798764
- https://github.com/Comfy-Org/ComfyUI_frontend/pull/15418#discussion_r3814981282

Verification: `pnpm typecheck`; workflow YAML parse; `oxfmt --check`. No Vitest target is affected by this workflow-only change.

<!-- authored-by:agent addr-drain -->