### PR TITLE
fix(canvas): follow-up to #15115 — preview incompatible-slot fallback

### DIFF
--- a/src/lib/litegraph/src/LGraphCanvas.slotHitDetection.test.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.slotHitDetection.test.ts
@@ -6,7 +6,8 @@ import {
   LGraph,
   LGraphCanvas,
   LGraphNode,
-  LiteGraph
+  LiteGraph,
+  ToInputRenderLink
 } from '@/lib/litegraph/src/litegraph'
 import { getSlotLayoutAtPoint } from '@/renderer/core/canvas/litegraph/slotCalculations'
 import type * as SlotCalculations from '@/renderer/core/canvas/litegraph/slotCalculations'
@@ -92,6 +93,34 @@ describe('LGraphCanvas slot hit detection', () => {
 
   afterEach(() => {
     LiteGraph.vueNodesMode = false
+  })
+
+  it('highlights the free fallback when hovering an incompatible input', () => {
+    LiteGraph.vueNodesMode = false
+    node.addInput('image', 'IMAGE')
+    node.addInput('video', 'VIDEO')
+    node.updateArea()
+    canvas.visible_nodes = [node]
+
+    const source = new LGraphNode('Source')
+    source.addOutput('image', 'IMAGE')
+    graph.add(source)
+    canvas.linkConnector.state.connectingTo = 'input'
+    canvas.linkConnector.renderLinks.push(
+      new ToInputRenderLink(graph, source, source.outputs[0])
+    )
+
+    const [clientX, clientY] = node.getInputPos(1)
+    canvas.processMouseMove(
+      new PointerEvent('pointermove', {
+        clientX,
+        clientY,
+        isPrimary: true
+      })
+    )
+
+    expect(canvas._highlight_input).toBe(node.inputs[0])
+    expect(canvas._highlight_pos).toEqual(node.getInputSlotPos(node.inputs[0]))
   })
 
   describe('processMouseDown slot fallback in Vue nodes mode', () => {

--- a/src/lib/litegraph/src/LGraphCanvas.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.ts
@@ -3488,6 +3488,14 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
                   highlightPos = pos
                   // XXX CHECK THIS
                   highlightInput = node.inputs[inputId]
+                } else if (inputId != -1) {
+                  const result = node.findInputByType(firstLink.fromSlot.type)
+                  if (result && result.slot.link == null) {
+                    highlightInput = result.slot
+                    highlightPos = LiteGraph.vueNodesMode
+                      ? getSlotPosition(node, result.index, true)
+                      : node.getInputSlotPos(result.slot)
+                  }
                 }
 
                 if (highlightInput && !LiteGraph.vueNodesMode) {


### PR DESCRIPTION
## Summary
- preview the free compatible input before an incompatible-slot drop falls back to it
- keep occupied compatible inputs unhighlighted, matching the drop guard
- add pointer-hover regression coverage

Follow-up to #15115.

## Review items
- Ben's non-blocking snap-highlight follow-up: https://github.com/Comfy-Org/ComfyUI_frontend/pull/15115#pullrequestreview-5083762052
- Source follow-up summary: https://github.com/Comfy-Org/ComfyUI_frontend/pull/15115#issuecomment-5452906341

## Verification
- `vitest run src/lib/litegraph/src/LGraphCanvas.slotHitDetection.test.ts` (5 passed)
- `vue-tsc --noEmit`
- Oxfmt check

<!-- authored-by:agent addr-drain -->