### PR TITLE
fix(ci): follow-up to #15417 — restrict settings file permissions

### DIFF
--- a/scripts/skills/update-ai-attribution.test.ts
+++ b/scripts/skills/update-ai-attribution.test.ts
@@ -5,6 +5,7 @@ import {
   readFileSync,
   rmSync,
   statSync,
+  symlinkSync,
   writeFileSync
 } from 'node:fs'
 import { tmpdir } from 'node:os'
@@ -29,6 +30,25 @@ describe('updateAttributionSettings', () => {
       expect(
         statSync(join(home, '.config', 'amp', 'settings.json')).mode & 0o777
       ).toBe(0o600)
+    } finally {
+      rmSync(home, { recursive: true, force: true })
+    }
+  })
+
+  it('does not follow a symlink at the old predictable temporary path', () => {
+    const home = mkdtempSync(join(tmpdir(), 'update-ai-attribution-'))
+    try {
+      const claudeDirectory = join(home, '.claude')
+      const claudePath = join(claudeDirectory, 'settings.json')
+      const targetPath = join(home, 'target')
+      mkdirSync(claudeDirectory, { recursive: true })
+      writeFileSync(targetPath, 'unchanged')
+      symlinkSync(targetPath, `${claudePath}.${process.pid}.tmp`)
+
+      const [claudeResult] = updateAttributionSettings(home)
+
+      expect(claudeResult.outcome).toBe('updated')
+      expect(readFileSync(targetPath, 'utf8')).toBe('unchanged')
     } finally {
       rmSync(home, { recursive: true, force: true })
     }

--- a/scripts/skills/update-ai-attribution.test.ts
+++ b/scripts/skills/update-ai-attribution.test.ts
@@ -1,4 +1,5 @@
 import {
+  chmodSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
@@ -51,6 +52,8 @@ describe('updateAttributionSettings', () => {
         ampPath,
         '{\n  // Keep this comment.\n  "token": "amp-secret"\n}\n'
       )
+      chmodSync(claudePath, 0o640)
+      chmodSync(ampPath, 0o660)
 
       const firstResults = updateAttributionSettings(home)
       const output = formatResults(firstResults)
@@ -80,6 +83,8 @@ describe('updateAttributionSettings', () => {
         'amp.git.commit.ampThread.enabled': false,
         'amp.git.commit.coauthor.enabled': false
       })
+      expect(statSync(claudePath).mode & 0o777).toBe(0o640)
+      expect(statSync(ampPath).mode & 0o777).toBe(0o660)
       expect(
         updateAttributionSettings(home).map(({ outcome }) => outcome)
       ).toEqual([

--- a/scripts/skills/update-ai-attribution.test.ts
+++ b/scripts/skills/update-ai-attribution.test.ts
@@ -3,6 +3,7 @@ import {
   mkdtempSync,
   readFileSync,
   rmSync,
+  statSync,
   writeFileSync
 } from 'node:fs'
 import { tmpdir } from 'node:os'
@@ -16,6 +17,22 @@ import {
 } from './update-ai-attribution'
 
 describe('updateAttributionSettings', () => {
+  it('creates settings files with owner-only permissions', () => {
+    const home = mkdtempSync(join(tmpdir(), 'update-ai-attribution-'))
+    try {
+      updateAttributionSettings(home)
+
+      expect(
+        statSync(join(home, '.claude', 'settings.json')).mode & 0o777
+      ).toBe(0o600)
+      expect(
+        statSync(join(home, '.config', 'amp', 'settings.json')).mode & 0o777
+      ).toBe(0o600)
+    } finally {
+      rmSync(home, { recursive: true, force: true })
+    }
+  })
+
   it('updates only attribution settings without exposing other values', () => {
     const home = mkdtempSync(join(tmpdir(), 'update-ai-attribution-'))
     try {

--- a/scripts/skills/update-ai-attribution.ts
+++ b/scripts/skills/update-ai-attribution.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env tsx
+import { randomUUID } from 'node:crypto'
 import {
   chmodSync,
   existsSync,
@@ -82,11 +83,11 @@ function parseSettings(content: string): Record<string, unknown> {
 
 function writeSettings(path: string, content: string) {
   mkdirSync(dirname(path), { recursive: true })
-  const temporaryPath = `${path}.${process.pid}.tmp`
+  const temporaryPath = `${path}.${randomUUID()}.tmp`
   const mode = existsSync(path) ? statSync(path).mode & 0o777 : 0o600
 
   try {
-    writeFileSync(temporaryPath, content, { mode })
+    writeFileSync(temporaryPath, content, { flag: 'wx', mode })
     renameSync(temporaryPath, path)
     chmodSync(path, mode)
   } finally {

--- a/scripts/skills/update-ai-attribution.ts
+++ b/scripts/skills/update-ai-attribution.ts
@@ -83,12 +83,12 @@ function parseSettings(content: string): Record<string, unknown> {
 function writeSettings(path: string, content: string) {
   mkdirSync(dirname(path), { recursive: true })
   const temporaryPath = `${path}.${process.pid}.tmp`
-  const mode = existsSync(path) ? statSync(path).mode : undefined
+  const mode = existsSync(path) ? statSync(path).mode & 0o777 : 0o600
 
   try {
     writeFileSync(temporaryPath, content, { mode })
     renameSync(temporaryPath, path)
-    if (mode !== undefined) chmodSync(path, mode)
+    chmodSync(path, mode)
   } finally {
     rmSync(temporaryPath, { force: true })
   }


### PR DESCRIPTION
## Summary

Create newly generated attribution settings files with owner-only permissions and preserve only existing permission bits during atomic replacement.

## Changes

- Use mode `0o600` for new Claude and Amp settings files.
- Mask and preserve existing file permission bits during replacement.
- Generate unpredictable temporary names and create them exclusively with `wx`.
- Cover new-file permissions, existing-file mode preservation, and the former predictable symlink path.

Follow-up to [the unresolved review finding on #15417](https://github.com/Comfy-Org/ComfyUI_frontend/pull/15417#discussion_r3808808811).

## Evidence

- `pnpm exec vitest run scripts/skills/update-ai-attribution.test.ts` — 3 tests passed.
- `pnpm exec oxfmt --check scripts/skills/update-ai-attribution.ts scripts/skills/update-ai-attribution.test.ts` — passed.
- `pnpm typecheck:scripts` — passed.
- Commit hook: full `pnpm typecheck`, oxlint, ESLint, and formatting — passed.

<!-- authored-by:agent addr-drain -->
<!-- authored-by:agent lane-act-fe-16587-address-bee076cb -->