### PR TITLE
test: correct first-run stagnation diagnostic

### DIFF
--- a/src/renderer/extensions/firstRunTour/tour/useFirstRunTourController.test.ts
+++ b/src/renderer/extensions/firstRunTour/tour/useFirstRunTourController.test.ts
@@ -619,7 +619,7 @@ describe('useFirstRunTourController', () => {
 
       expect(
         mocks.runState.value,
-        'a run cut short for credits keeps its running status, so losing the job is the only signal left'
+        'a stagnated run keeps its running status, so losing the job is the only signal left'
       ).toBe('failed')
     })
 


### PR DESCRIPTION
## Summary

Correct the remaining stale credits-path wording identified in the merged #15172 review.

## Changes

- **What**: Align the test assertion diagnostic with the stagnated-job scenario already documented by the test and production code.

## Review Focus

Confirm the diagnostic now names the actual `handleServiceLevelError` path described by [the original review finding](https://github.com/Comfy-Org/ComfyUI_frontend/pull/15172#discussion_r3797248018).

Validation: targeted Vitest 61/61; Oxfmt; ESLint; typecheck; Knip.