### PR TITLE
fix(widgets): follow-up to #15759 — preserve compacted dynamic values

### DIFF
--- a/src/utils/litegraphUtil.test.ts
+++ b/src/utils/litegraphUtil.test.ts
@@ -282,6 +282,21 @@ describe('migrateWidgetsValues', () => {
     ])
   })
 
+  it('preserves compacted values for dynamic widgets after a skipped widget', () => {
+    const dynamicInputDefs = {
+      a: fromPartial<InputSpec>({ name: 'a' })
+    }
+    const widgets = [
+      makeWidget('a'),
+      makeWidget('ui', false),
+      makeWidget('extra')
+    ]
+
+    expect(
+      migrateWidgetsValues(dynamicInputDefs, widgets, ['av', 'extra value'])
+    ).toEqual(['av', 'extra value'])
+  })
+
   it('continues to migrate a value array without skipped widgets', () => {
     const widgets = [makeWidget('steps')]
 

--- a/src/utils/litegraphUtil.ts
+++ b/src/utils/litegraphUtil.ts
@@ -219,6 +219,17 @@ export function migrateWidgetsValues<TWidgetValue>(
       : [!!input.forceInput]
   })
 
+  const serializableWidgetCount = filter(
+    widgets,
+    (widget) => widget.serialize !== false
+  ).length
+  if (
+    !widgetIndexHasForceInput.includes(true) &&
+    widgetsValues.length === serializableWidgetCount
+  ) {
+    return widgetsValues
+  }
+
   const compactedWidgetValues = filter(
     widgetsValues,
     (_, index) => widgets[index]?.serialize !== false


### PR DESCRIPTION
Follow-up to #15759

Preserves compacted dynamic-widget values.

<details><summary>Full context for agent readers</summary>

Follow-up to https://github.com/Comfy-Org/ComfyUI_frontend/pull/15759.

Addresses the deferred review note at https://github.com/Comfy-Org/ComfyUI_frontend/pull/15759#discussion_r3908695983. `migrateWidgetsValues` now recognizes an already-compacted array when no legacy `forceInput` dummy can be present, preventing a serializable dynamic widget after a skipped widget from being dropped by index-based compaction.

The earlier top-level review at https://github.com/Comfy-Org/ComfyUI_frontend/pull/15759#issuecomment-5417067643 identified blockers fixed before the source PR merged. The approval at https://github.com/Comfy-Org/ComfyUI_frontend/pull/15759#issuecomment-5501507745 confirms those blockers were resolved and identifies only the compacted-candidate note above as deferred follow-up work.

## Evidence

- `pnpm exec vitest run src/utils/litegraphUtil.test.ts`: 23/23 passed at `305da8ff56aeacd5ba2dc859083de3ccf8466bcb`.
- `pnpm typecheck`: passed at the same head.
- CI at the same head: required unit, lint/format, E2E, website E2E, CLA, and CodeRabbit checks passed.

</details>

<!-- authored-by:agent lane-act-fe-15759-followup -->