### PR TITLE
fix(litegraph): follow-up to #15548 — tighten round-trip coverage

### DIFF
--- a/src/lib/litegraph/src/LGraph.roundTrip.test.ts
+++ b/src/lib/litegraph/src/LGraph.roundTrip.test.ts
@@ -168,7 +168,7 @@ function linkExtensionKeys(graph: Pick<ISerialisedGraph, 'extra'>) {
  * works. Every assertion below runs through this so a fixture that later loses
  * its reroutes degrades into a failure rather than a silent no-op.
  */
-function expectPreserved(before: string[], after: string[]) {
+function expectPreserved<T>(before: T[], after: T[]) {
   expect(before.length).toBeGreaterThan(0)
   expect(after).toEqual(before)
 }
@@ -182,7 +182,7 @@ function linkKeys(graph: Pick<ISerialisedGraph, 'links'>) {
 }
 
 function floatingLinkKeys(graph: Pick<ISerialisedGraph, 'floatingLinks'>) {
-  return (graph.floatingLinks ?? []).map((link) => JSON.stringify(link)).sort()
+  return [...(graph.floatingLinks ?? [])].sort((a, b) => ascending(a.id, b.id))
 }
 
 function groupKeys(graph: Pick<ISerialisedGraph, 'groups'>) {

--- a/src/lib/litegraph/src/LGraph.roundTrip.test.ts
+++ b/src/lib/litegraph/src/LGraph.roundTrip.test.ts
@@ -254,7 +254,7 @@ describe('LGraph round trip preserves the input', () => {
 
         new LGraph(subject).serialize()
 
-        expect(subject).toEqual(untouched)
+        expect(subject).toStrictEqual(untouched)
       })
 
       test('is stable when saved twice', () => {

--- a/src/lib/litegraph/src/LGraph.roundTrip.test.ts
+++ b/src/lib/litegraph/src/LGraph.roundTrip.test.ts
@@ -248,12 +248,6 @@ describe('LGraph round trip preserves the input', () => {
         )
       })
 
-      test('keeps every group, by identity and bounds', () => {
-        const grouped = withGroups(graph)
-
-        expectPreserved(groupKeys(grouped), groupKeys(roundTrip(grouped)))
-      })
-
       test('does not mutate the workflow it was given', () => {
         const untouched = structuredClone(graph)
         const subject = structuredClone(graph)
@@ -271,4 +265,10 @@ describe('LGraph round trip preserves the input', () => {
       })
     })
   }
+
+  test('keeps every group, by identity and bounds', () => {
+    const grouped = withGroups(fixtures[0].graph)
+
+    expectPreserved(groupKeys(grouped), groupKeys(roundTrip(grouped)))
+  })
 })

--- a/src/lib/litegraph/src/LGraph.roundTrip.test.ts
+++ b/src/lib/litegraph/src/LGraph.roundTrip.test.ts
@@ -4,9 +4,9 @@ import { beforeEach, describe, expect, test } from 'vitest'
 import { LGraph, LGraphNode, LiteGraph } from '@/lib/litegraph/src/litegraph'
 import type { ISerialisedGraph } from '@/lib/litegraph/src/litegraph'
 
-import floatingLink from './__fixtures__/assets/floatingLink.json'
-import linkedNodes from './__fixtures__/assets/linkedNodes.json'
-import reroutesComplex from './__fixtures__/assets/reroutesComplex.json'
+import floatingLink from './__fixtures__/assets/floatingLink.json' with { type: 'json' }
+import linkedNodes from './__fixtures__/assets/linkedNodes.json' with { type: 'json' }
+import reroutesComplex from './__fixtures__/assets/reroutesComplex.json' with { type: 'json' }
 
 /**
  * Loading a workflow and saving it again must not lose entities.

--- a/src/lib/litegraph/src/LGraph.roundTrip.test.ts
+++ b/src/lib/litegraph/src/LGraph.roundTrip.test.ts
@@ -173,10 +173,6 @@ function expectPreserved<T>(before: T[], after: T[]) {
   expect(after).toEqual(before)
 }
 
-/**
- * Links and groups are compared whole, not counted. A count survives a link
- * being renumbered, repointed at a different slot, or replaced outright.
- */
 function linkKeys(graph: Pick<ISerialisedGraph, 'links'>) {
   return (graph.links ?? []).map((link) => JSON.stringify(link)).sort()
 }


### PR DESCRIPTION
Follow-up to #15548

Follow-up to https://github.com/Comfy-Org/ComfyUI_frontend/pull/15548. Tightens round-trip coverage for every residual item from Ben Cooley's review.

<details><summary>Full context for agent readers</summary>

## Changes

- runs identical group coverage once instead of once per fixture
- compares floating links structurally after sorting by ID
- uses strict equality for the non-mutation assertion
- adds JSON import attributes
- removes the stale link/group helper comment

## Review coverage

Top-level review addressed:

- https://github.com/Comfy-Org/ComfyUI_frontend/pull/15548#pullrequestreview-4996209941

Already fixed before the source PR merged and verified on current `main`:

- https://github.com/Comfy-Org/ComfyUI_frontend/pull/15548#discussion_r3832654631
- https://github.com/Comfy-Org/ComfyUI_frontend/pull/15548#discussion_r3832654633
- https://github.com/Comfy-Org/ComfyUI_frontend/pull/15548#discussion_r3832654636

Implemented by this follow-up:

- https://github.com/Comfy-Org/ComfyUI_frontend/pull/15548#discussion_r3832654642
- https://github.com/Comfy-Org/ComfyUI_frontend/pull/15548#discussion_r3832654646
- https://github.com/Comfy-Org/ComfyUI_frontend/pull/15548#discussion_r3832654648
- https://github.com/Comfy-Org/ComfyUI_frontend/pull/15548#discussion_r3832654656
- https://github.com/Comfy-Org/ComfyUI_frontend/pull/15548#discussion_r3832654664

## Evidence

- `pnpm typecheck` passed
- `pnpm test:unit src/lib/litegraph/src/LGraph.roundTrip.test.ts` passed: 17 passed, 5 skipped
- `pnpm exec oxfmt --check src/lib/litegraph/src/LGraph.roundTrip.test.ts` passed
- `pnpm exec oxlint src/lib/litegraph/src/LGraph.roundTrip.test.ts` passed
- GitHub unit, lint/format, performance, ecosystem-matrix, security, and coverage checks passed at `07c22f95b8ec899cb3b7196efec806733ed8d25e`
- GitHub cloud Playwright is red on unrelated `creditsTile.spec.ts`; the follow-up changes only `LGraph.roundTrip.test.ts`

</details>

<!-- authored-by:agent lane-act-fe-15548-followup -->