### PR TITLE
fix(onboarding): follow-up to #14673 — tour hold precondition and viewport coverage

### DIFF
--- a/browser_tests/tests/tour.spec.ts
+++ b/browser_tests/tests/tour.spec.ts
@@ -49,6 +49,19 @@ test.describe('Onboarding coachmarks', { tag: '@ui' }, () => {
       await expect(coach.landing).toBeHidden()
       await expect.poll(() => coach.seen('appMode')).toBe(true)
     })
+
+    test('ends the tour when the viewport narrows below desktop size', async ({
+      comfyPage,
+      onboarding
+    }) => {
+      await comfyPage.appMode.enterAppModeWithInputs([])
+      await expect(onboarding.landing).toBeVisible()
+
+      await comfyPage.page.setViewportSize({ width: 500, height: 800 })
+
+      await expect(onboarding.landing).toBeHidden()
+      await expect.poll(() => onboarding.seen('appMode')).toBe(false)
+    })
   })
 
   test.describe('coach anchors', () => {

--- a/src/platform/onboarding/onboardingTourStore.registeredTour.test.ts
+++ b/src/platform/onboarding/onboardingTourStore.registeredTour.test.ts
@@ -193,29 +193,21 @@ describe('onboardingTourStore — runtime-resolved tours', () => {
       'skipped',
       expect.objectContaining({ skip_reason: 'trigger_lost' })
     )
+    holds.value = true
     await expect(
       store.startTour('firstRun'),
       'the context went, not the user, so the tour is still owed'
     ).resolves.toBe(true)
   })
 
-  it('starts a tour whose context is already unmet, and ends it only on losing it', async () => {
+  it('refuses to start a tour whose context is already unmet', async () => {
     const holds = ref(false)
     registerTour('firstRun', () => Promise.resolve([step('run')]), holds)
     const store = mountStore()
 
-    await expect(
-      store.startTour('firstRun'),
-      'startTour decides whether a tour may begin; holds only ends one'
-    ).resolves.toBe(true)
-    await nextTick()
-    expect(store.activeTour).toBe('firstRun')
-
-    holds.value = true
-    await nextTick()
-    holds.value = false
-    await nextTick()
+    await expect(store.startTour('firstRun')).resolves.toBe(false)
     expect(store.activeTour).toBeNull()
+    expect(stages()).not.toContain('started')
   })
 
   it('ends the tour as completed once its last step is advanced past', async () => {

--- a/src/platform/onboarding/onboardingTourStore.test.ts
+++ b/src/platform/onboarding/onboardingTourStore.test.ts
@@ -1,7 +1,7 @@
 import type { DetachedWindowAPI } from 'happy-dom'
 import { createPinia, disposePinia, setActivePinia } from 'pinia'
 import type { Pinia } from 'pinia'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
 import type { Ref } from 'vue'
 
@@ -147,6 +147,8 @@ describe('onboardingTourStore', () => {
     modeRef.value = mode
     outputsRef.value = hasOutputs
   }
+
+  beforeEach(() => enterApp('app', false))
 
   it('auto-opens when entering a populated app it has not seen', async () => {
     mountStore()

--- a/src/platform/onboarding/onboardingTourStore.ts
+++ b/src/platform/onboarding/onboardingTourStore.ts
@@ -348,7 +348,7 @@ export const useOnboardingTourStore = defineStore('onboardingTour', () => {
 
   async function begin(entryPath: EntryPath): Promise<boolean> {
     const definition = tourDefinition(entryPath)
-    if (!definition) return false
+    if (!definition || !tourHolds(entryPath)) return false
     const run = nextRun()
     if (!dispatch({ type: 'requested', tour: entryPath, run })) return false
     // A new run has no ending yet; the one before it must not speak for it.


### PR DESCRIPTION
Follow-up to #14673

## Summary

- refuse registered tours before state mutation when their context already fails
- make store tests start from a valid app-mode context
- cover active-tour teardown when a real browser viewport drops below desktop size

Follow-up to https://github.com/Comfy-Org/ComfyUI_frontend/pull/14673.

Addressed review records:
- https://github.com/Comfy-Org/ComfyUI_frontend/pull/14673#issuecomment-5175022083
- https://github.com/Comfy-Org/ComfyUI_frontend/pull/14673#issuecomment-5229536368

## Verification

- `pnpm typecheck`
- `pnpm typecheck:browser`
- `pnpm test:unit src/platform/onboarding` (188 passed)
- `pnpm test:unit src/renderer/extensions/firstRunTour src/platform/onboarding` (435 passed; one unrelated timing test failed under parallel load and passed alone)
- browser test authored and typechecked; local execution unavailable because no frontend was running on localhost:5173

<!-- authored-by:agent addr-drain -->