### PR TITLE
fix(playwright): follow-up to #11815 — regression-sensitive primitive refresh

### DIFF
--- a/browser_tests/tests/primitiveNode.spec.ts
+++ b/browser_tests/tests/primitiveNode.spec.ts
@@ -93,16 +93,23 @@ test.describe('Primitive Node', { tag: ['@screenshot', '@node'] }, () => {
     const before = await getPrimitiveComboState()
     expect(before.length).toBeGreaterThan(0)
 
-    await comfyPage.page.evaluate(async () => {
-      const primitive = window.app!.graph!.nodes.find(
-        (node) => node.type === 'PrimitiveNode'
-      )
-      const output = primitive?.outputs?.[0]
-      if (!output?.widget) throw new Error('Expected primitive output widget')
+    // Simulates a stale slot-widget reference (e.g. left over from a node
+    // definition reload) by dropping every field except `name`, then
+    // confirms refreshComboInNodes() re-resolves it without losing state.
+    async function staleifyPrimitiveOutputWidget() {
+      return comfyPage.page.evaluate(() => {
+        const primitive = window.app!.graph!.nodes.find(
+          (node) => node.type === 'PrimitiveNode'
+        )
+        const output = primitive?.outputs?.[0]
+        if (!output?.widget) throw new Error('Expected primitive output widget')
 
-      output.widget = { name: output.widget.name }
-      await window.app!.refreshComboInNodes()
-    })
+        output.widget = { name: output.widget.name }
+      })
+    }
+
+    await staleifyPrimitiveOutputWidget()
+    await comfyPage.page.evaluate(() => window.app!.refreshComboInNodes())
 
     const after = await getPrimitiveComboState()
     expect(after).toMatchObject({

--- a/browser_tests/tests/primitiveNode.spec.ts
+++ b/browser_tests/tests/primitiveNode.spec.ts
@@ -60,7 +60,7 @@ test.describe('Primitive Node', { tag: ['@screenshot', '@node'] }, () => {
     )
   })
 
-  test('Preserves combo options after refreshing node definitions', async ({
+  test('Preserves combo options with a stale slot locator after refreshing node definitions', async ({
     comfyPage
   }) => {
     async function getPrimitiveComboState() {
@@ -93,7 +93,16 @@ test.describe('Primitive Node', { tag: ['@screenshot', '@node'] }, () => {
     const before = await getPrimitiveComboState()
     expect(before.length).toBeGreaterThan(0)
 
-    await comfyPage.page.evaluate(() => window.app!.refreshComboInNodes())
+    await comfyPage.page.evaluate(async () => {
+      const primitive = window.app!.graph!.nodes.find(
+        (node) => node.type === 'PrimitiveNode'
+      )
+      const output = primitive?.outputs?.[0]
+      if (!output?.widget) throw new Error('Expected primitive output widget')
+
+      output.widget = { name: output.widget.name }
+      await window.app!.refreshComboInNodes()
+    })
 
     const after = await getPrimitiveComboState()
     expect(after).toMatchObject({


### PR DESCRIPTION
## Summary

Makes the primitive combo refresh browser test fail when the stale slot-locator regression returns. Follow-up to [#11815](https://github.com/Comfy-Org/ComfyUI_frontend/pull/11815).

## Changes

- **What**: Replaces the primitive output's live widget locator with the stale shape from the original failure before refreshing node definitions, then verifies the combo options and selected value survive.

## Review Focus

The prior browser test passed when the production fix was reverted, as reported in [AustinMroz's review](https://github.com/Comfy-Org/ComfyUI_frontend/pull/11815#pullrequestreview-4978640433). Please confirm this setup isolates that missing regression boundary without weakening the existing behavioral assertion.

Source review threads audited:
- [Type the `GET_CONFIG` locator](https://github.com/Comfy-Org/ComfyUI_frontend/pull/11815#discussion_r3262806543) - already fixed on main.
- [Inline the single-use link helper](https://github.com/Comfy-Org/ComfyUI_frontend/pull/11815#discussion_r3262806550) - already fixed on main.
- [Behavioral coverage praise](https://github.com/Comfy-Org/ComfyUI_frontend/pull/11815#discussion_r3262806557) - no change requested.

Verification: root typecheck, browser typecheck, focused widget-input Vitest (7/7), type-aware Oxlint, Oxfmt, and Playwright test discovery.
