### PR TITLE
fix(config): follow-up to #15658 — preserve and validate base URLs

### DIFF
--- a/src/config/comfyApi.test.ts
+++ b/src/config/comfyApi.test.ts
@@ -16,89 +16,72 @@ vi.mock('@/scripts/api', () => ({
   }
 }))
 
-describe('getComfyApiBaseUrl', () => {
-  const originalConfig = remoteConfig.value
+interface BaseUrlCase {
+  label: string
+  getBaseUrl: () => string
+  setOverride: (value: string) => void
+  defaultUrl: string
+}
 
-  beforeEach(() => {
-    remoteConfig.value = {}
-  })
+const baseUrlCases: BaseUrlCase[] = [
+  {
+    label: 'API',
+    getBaseUrl: getComfyApiBaseUrl,
+    setOverride: (value) => {
+      remoteConfig.value = { comfy_api_base_url: value }
+    },
+    defaultUrl: 'https://stagingapi.comfy.org'
+  },
+  {
+    label: 'Cloud',
+    getBaseUrl: getComfyCloudBaseUrl,
+    setOverride: (value) => {
+      remoteConfig.value = { comfy_cloud_base_url: value }
+    },
+    defaultUrl: 'https://testcloud.comfy.org'
+  },
+  {
+    label: 'Platform',
+    getBaseUrl: getComfyPlatformBaseUrl,
+    setOverride: (value) => {
+      remoteConfig.value = { comfy_platform_base_url: value }
+    },
+    defaultUrl: 'https://stagingplatform.comfy.org'
+  }
+]
 
-  afterEach(() => {
-    remoteConfig.value = originalConfig
-  })
+describe.for(baseUrlCases)(
+  '$label base URL',
+  ({ getBaseUrl, setOverride, defaultUrl }) => {
+    const originalConfig = remoteConfig.value
 
-  it('honors the server-provided override', () => {
-    remoteConfig.value = { comfy_api_base_url: 'https://my-ephem.example.com' }
-    expect(getComfyApiBaseUrl()).toBe('https://my-ephem.example.com')
-  })
+    beforeEach(() => {
+      remoteConfig.value = {}
+    })
 
-  it('falls back to the build-time default when the key is absent', () => {
-    expect(getComfyApiBaseUrl()).toBe('https://stagingapi.comfy.org')
-  })
+    afterEach(() => {
+      remoteConfig.value = originalConfig
+    })
 
-  it('falls back to the build-time default when the value is empty', () => {
-    remoteConfig.value = { comfy_api_base_url: '' }
-    expect(getComfyApiBaseUrl()).toBe('https://stagingapi.comfy.org')
-  })
-})
+    it('honors a server-provided HTTPS override', () => {
+      setOverride('https://custom.example.com')
+      expect(getBaseUrl()).toBe('https://custom.example.com')
+    })
 
-describe('getComfyCloudBaseUrl', () => {
-  const originalConfig = remoteConfig.value
+    it('removes a trailing slash from the override', () => {
+      setOverride('https://custom.example.com/')
+      expect(getBaseUrl()).toBe('https://custom.example.com')
+    })
 
-  beforeEach(() => {
-    remoteConfig.value = {}
-  })
-
-  afterEach(() => {
-    remoteConfig.value = originalConfig
-  })
-
-  it('honors the server-provided override', () => {
-    remoteConfig.value = {
-      comfy_cloud_base_url: 'https://my-ephem-cloud.example.com'
-    }
-    expect(getComfyCloudBaseUrl()).toBe('https://my-ephem-cloud.example.com')
-  })
-
-  it('falls back to the build-time default when the key is absent', () => {
-    expect(getComfyCloudBaseUrl()).toBe('https://testcloud.comfy.org')
-  })
-
-  it('falls back to the build-time default when the value is empty', () => {
-    remoteConfig.value = { comfy_cloud_base_url: '' }
-    expect(getComfyCloudBaseUrl()).toBe('https://testcloud.comfy.org')
-  })
-})
-
-describe('getComfyPlatformBaseUrl', () => {
-  const originalConfig = remoteConfig.value
-
-  beforeEach(() => {
-    remoteConfig.value = {}
-  })
-
-  afterEach(() => {
-    remoteConfig.value = originalConfig
-  })
-
-  it('honors the server-provided override', () => {
-    remoteConfig.value = {
-      comfy_platform_base_url: 'https://my-ephem-platform.example.com'
-    }
-    expect(getComfyPlatformBaseUrl()).toBe(
-      'https://my-ephem-platform.example.com'
+    it.for([undefined, '', 'not-a-url', 'http://custom.example.com'])(
+      'falls back to the build-time default for %s',
+      (override) => {
+        if (override !== undefined) setOverride(override)
+        expect(getBaseUrl()).toBe(defaultUrl)
+      }
     )
-  })
-
-  it('falls back to the build-time default when the key is absent', () => {
-    expect(getComfyPlatformBaseUrl()).toBe('https://stagingplatform.comfy.org')
-  })
-
-  it('falls back to the build-time default when the value is empty', () => {
-    remoteConfig.value = { comfy_platform_base_url: '' }
-    expect(getComfyPlatformBaseUrl()).toBe('https://stagingplatform.comfy.org')
-  })
-})
+  }
+)
 
 describe('compatibility with comfyui servers that predate the override keys', () => {
   const originalConfig = remoteConfig.value

--- a/src/config/comfyApi.ts
+++ b/src/config/comfyApi.ts
@@ -25,26 +25,32 @@ const BUILD_TIME_PLATFORM_BASE_URL = __USE_PROD_CONFIG__
   : (import.meta.env.VITE_STAGING_PLATFORM_BASE_URL ??
     STAGING_PLATFORM_BASE_URL)
 
+function resolveBaseUrl(
+  key:
+    | 'comfy_api_base_url'
+    | 'comfy_cloud_base_url'
+    | 'comfy_platform_base_url',
+  defaultValue: string
+): string {
+  const value = configValueOrDefault(remoteConfig.value, key, defaultValue)
+
+  try {
+    const url = new URL(value)
+    if (url.protocol !== 'https:' || !url.hostname) return defaultValue
+    return url.href.replace(/\/$/, '')
+  } catch {
+    return defaultValue
+  }
+}
+
 export function getComfyApiBaseUrl(): string {
-  return configValueOrDefault(
-    remoteConfig.value,
-    'comfy_api_base_url',
-    BUILD_TIME_API_BASE_URL
-  )
+  return resolveBaseUrl('comfy_api_base_url', BUILD_TIME_API_BASE_URL)
 }
 
 export function getComfyCloudBaseUrl(): string {
-  return configValueOrDefault(
-    remoteConfig.value,
-    'comfy_cloud_base_url',
-    BUILD_TIME_CLOUD_BASE_URL
-  )
+  return resolveBaseUrl('comfy_cloud_base_url', BUILD_TIME_CLOUD_BASE_URL)
 }
 
 export function getComfyPlatformBaseUrl(): string {
-  return configValueOrDefault(
-    remoteConfig.value,
-    'comfy_platform_base_url',
-    BUILD_TIME_PLATFORM_BASE_URL
-  )
+  return resolveBaseUrl('comfy_platform_base_url', BUILD_TIME_PLATFORM_BASE_URL)
 }

--- a/src/platform/remoteConfig/refreshRemoteConfig.test.ts
+++ b/src/platform/remoteConfig/refreshRemoteConfig.test.ts
@@ -2,7 +2,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { api } from '@/scripts/api'
 
-import { refreshRemoteConfig } from './refreshRemoteConfig'
+import {
+  invalidateRemoteConfig,
+  refreshRemoteConfig
+} from './refreshRemoteConfig'
 import {
   cachedLegacyBillingMigrationEnabled,
   remoteConfig,
@@ -45,6 +48,26 @@ describe('refreshRemoteConfig', () => {
     remoteConfigState.value = 'unloaded'
     cachedLegacyBillingMigrationEnabled.value = undefined
     window.__CONFIG__ = {}
+  })
+
+  it('retains base URLs while invalidating identity-specific config', () => {
+    remoteConfig.value = {
+      subscription_required: true,
+      comfy_api_base_url: 'https://api.example.com',
+      comfy_cloud_base_url: 'https://cloud.example.com',
+      comfy_platform_base_url: 'https://platform.example.com'
+    }
+    window.__CONFIG__ = remoteConfig.value
+
+    invalidateRemoteConfig()
+
+    expect(remoteConfig.value).toEqual({
+      comfy_api_base_url: 'https://api.example.com',
+      comfy_cloud_base_url: 'https://cloud.example.com',
+      comfy_platform_base_url: 'https://platform.example.com'
+    })
+    expect(window.__CONFIG__).toEqual(remoteConfig.value)
+    expect(remoteConfigState.value).toBe('unloaded')
   })
 
   describe('with auth (default)', () => {
@@ -214,14 +237,20 @@ describe('refreshRemoteConfig', () => {
       expect(window.__CONFIG__).toEqual({})
     })
 
-    it('clears config on fetch error', async () => {
+    it('preserves config on fetch error', async () => {
+      const existingConfig = {
+        subscription_required: true,
+        comfy_cloud_base_url: 'https://cloud.example.com'
+      }
       cachedLegacyBillingMigrationEnabled.value = true
+      remoteConfig.value = existingConfig
+      window.__CONFIG__ = existingConfig
       vi.mocked(api.fetchApi).mockRejectedValue(new Error('Network error'))
 
       await refreshRemoteConfig()
 
-      expect(remoteConfig.value).toEqual({})
-      expect(window.__CONFIG__).toEqual({})
+      expect(remoteConfig.value).toEqual(existingConfig)
+      expect(window.__CONFIG__).toEqual(existingConfig)
       expect(cachedLegacyBillingMigrationEnabled.value).toBeUndefined()
     })
 

--- a/src/platform/remoteConfig/refreshRemoteConfig.ts
+++ b/src/platform/remoteConfig/refreshRemoteConfig.ts
@@ -9,7 +9,7 @@ import {
 
 // Cap the bootstrap fetch so a wedged /features endpoint can never block app.mount indefinitely.
 // A same-origin GET against the local comfyui server should resolve in well under a second;
-// on timeout the catch below clears remoteConfig and consumers fall back to build-time defaults.
+// on timeout consumers retain the last known config or use build-time defaults.
 const FEATURES_FETCH_TIMEOUT_MS = 5_000
 
 interface RefreshRemoteConfigOptions {
@@ -28,8 +28,15 @@ export function invalidateRemoteConfig(): void {
   refreshGeneration++
   for (const controller of activeRefreshControllers) controller.abort()
   activeRefreshControllers.clear()
-  window.__CONFIG__ = {}
-  remoteConfig.value = {}
+  const { comfy_api_base_url, comfy_cloud_base_url, comfy_platform_base_url } =
+    remoteConfig.value
+  const retainedConfig = {
+    ...(comfy_api_base_url && { comfy_api_base_url }),
+    ...(comfy_cloud_base_url && { comfy_cloud_base_url }),
+    ...(comfy_platform_base_url && { comfy_platform_base_url })
+  }
+  window.__CONFIG__ = retainedConfig
+  remoteConfig.value = retainedConfig
   remoteConfigErrorStatus.value = null
   remoteConfigState.value = 'unloaded'
   cachedLegacyBillingMigrationEnabled.value = undefined
@@ -110,8 +117,6 @@ export async function refreshRemoteConfig(
     if (generation !== refreshGeneration) return
     if (signal?.aborted) return
     console.error('Failed to fetch remote config:', error)
-    window.__CONFIG__ = {}
-    remoteConfig.value = {}
     remoteConfigErrorStatus.value = null
     if (useAuth) cachedLegacyBillingMigrationEnabled.value = undefined
     remoteConfigState.value = 'error'


### PR DESCRIPTION
## Summary

- Keeps runtime base URLs stable across account switches and transient `/features` failures.
- Rejects malformed or non-HTTPS overrides and normalizes trailing slashes.
- Consolidates the three duplicated base-URL test suites.

<details><summary>Full context for agent readers</summary>

## Review follow-up

| Source review | Resolution |
| --- | --- |
| [Account-switch and transient-failure fallback](https://github.com/Comfy-Org/ComfyUI_frontend/pull/15658#discussion_r3857363581) | Preserve the three base-URL keys during identity invalidation and retain the last known config on transport errors. |
| [ComfyUI-core emitter question](https://github.com/Comfy-Org/ComfyUI_frontend/pull/15658#discussion_r3857363586) | Current Comfy-Org code search finds no core `/features` emitter for `comfy_cloud_base_url`; the override remains a self-hosting/consistency hook rather than an update path for stale Desktop installs. |
| [URL validation and trailing slash](https://github.com/Comfy-Org/ComfyUI_frontend/pull/15658#discussion_r3857363592) | Accept only parseable HTTPS URLs with a hostname and remove one trailing slash. Invalid values fall back to the build-time host. |
| [Duplicate getter tests](https://github.com/Comfy-Org/ComfyUI_frontend/pull/15658#discussion_r3857363598) | Replace three duplicate suites with one parameterized contract shared by all getters. |

## Changes

- **What**: Hardens remote base-URL lifecycle and validation.

## Review Focus

Please check whether retaining only the three base-URL keys on identity invalidation is the right boundary.

## Verification

- `pnpm typecheck`
- `pnpm test:unit src/config/comfyApi.test.ts src/platform/remoteConfig/refreshRemoteConfig.test.ts src/stores/authStore.test.ts` (142 passed)
- Oxfmt, type-aware Oxlint, and ESLint on all changed files

Follow-up to #15658.

</details>

<!-- authored-by:agent addr-drain -->