### PR TITLE
[backport cloud/1.53] fix(litegraph): keep custom widget value normalisation on adoption

### DIFF
--- a/browser_tests/tests/legacyDoNotReplicate/legacyComparerWidgetValue.spec.ts
+++ b/browser_tests/tests/legacyDoNotReplicate/legacyComparerWidgetValue.spec.ts
@@ -1,0 +1,69 @@
+import type { ComfyPage } from '@e2e/fixtures/ComfyPage'
+import {
+  comfyExpect as expect,
+  comfyPageFixture as test
+} from '@e2e/fixtures/ComfyPage'
+import { openWorkflowFromSidebar } from '@e2e/fixtures/utils/builderTestUtils'
+import {
+  expectNoVisibleErrors,
+  trackVisibleErrors
+} from '@e2e/fixtures/utils/errorSurfaces'
+
+const NODE_TYPE = 'DevToolsNodeWithComparerWidget'
+const WORKFLOW_NAME = 'legacy-comparer'
+
+const SERIALISED_IMAGES = [
+  { name: 'A', selected: true, url: '/devtools/comparer/a.png' },
+  { name: 'B', selected: true, url: '/devtools/comparer/b.png' }
+]
+
+async function exportedComparerWidgetValue(
+  comfyPage: ComfyPage
+): Promise<unknown> {
+  const workflow = await comfyPage.workflow.getExportedWorkflow()
+  const values = workflow.nodes.find(
+    (node) => node.type === NODE_TYPE
+  )?.widgets_values
+  return Array.isArray(values) ? values[0] : values
+}
+
+test.describe('Legacy comparer widget', { tag: ['@widget', '@ui'] }, () => {
+  test.afterEach(async ({ comfyPage }) => {
+    await comfyPage.workflow.setupWorkflowsDirectory({})
+  })
+
+  test('serialises after the workflow is saved and reopened', async ({
+    comfyPage
+  }) => {
+    test.slow()
+    await trackVisibleErrors(comfyPage.page)
+    await comfyPage.nodeOps.clearGraph()
+    await expect
+      .poll(
+        () =>
+          comfyPage.page.evaluate(
+            (type) => Boolean(window.LiteGraph?.registered_node_types[type]),
+            NODE_TYPE
+          ),
+        {
+          message: `${NODE_TYPE} is not registered - ComfyUI_devtools is not installed on this backend`
+        }
+      )
+      .toBe(true)
+    await comfyPage.nodeOps.addNode(NODE_TYPE)
+
+    await comfyPage.menu.topbar.saveWorkflow(WORKFLOW_NAME)
+    await openWorkflowFromSidebar(comfyPage, WORKFLOW_NAME)
+
+    await expect
+      .poll(() => exportedComparerWidgetValue(comfyPage))
+      .toEqual(SERIALISED_IMAGES)
+
+    await comfyPage.workflow.loadWorkflow('default')
+
+    await expectNoVisibleErrors(
+      comfyPage.page,
+      'after switching away from the reopened comparer workflow'
+    )
+  })
+})

--- a/src/lib/litegraph/src/widgets/widgetMap.test.ts
+++ b/src/lib/litegraph/src/widgets/widgetMap.test.ts
@@ -27,6 +27,23 @@ class AccessorHeightWidget implements IBaseWidget {
   }
 }
 
+class NormalisingValueWidget implements IBaseWidget {
+  [symbol: symbol]: boolean
+  #value: { entries: number[] } = { entries: [] }
+  name = 'custom'
+  type = 'legacy_test'
+  options = {}
+  y = 0
+
+  get value(): { entries: number[] } {
+    return this.#value
+  }
+
+  set value(value: { entries: number[] } | number[]) {
+    this.#value.entries = Array.isArray(value) ? value : value.entries
+  }
+}
+
 class SetterOnlyHeightWidget extends AccessorHeightWidget {
   override set height(_value: number) {
     this.heightWrites++
@@ -123,5 +140,14 @@ describe('toConcreteWidget', () => {
 
     expect(widget.heightWrites).toBe(1)
     expect(result.height).not.toBeUndefined()
+  })
+
+  it('stores the value a foreign setter normalised', () => {
+    const node = new LGraphNode('test')
+    const widget = toConcreteWidget(new NormalisingValueWidget(), node)
+
+    widget.value = [1, 2]
+
+    expect(widget.value).toEqual({ entries: [1, 2] })
   })
 })

--- a/src/lib/litegraph/src/widgets/widgetMap.ts
+++ b/src/lib/litegraph/src/widgets/widgetMap.ts
@@ -132,8 +132,12 @@ function adoptConcreteWidget<C extends object>(widget: object, concrete: C): C {
           return concreteDescriptor.get?.call(this)
         },
         set(value: unknown) {
-          concreteDescriptor.set?.call(this, value)
           foreignDescriptor.set?.call(this, value)
+          const normalised = foreignDescriptor.get?.call(this)
+          concreteDescriptor.set?.call(
+            this,
+            normalised === undefined ? value : normalised
+          )
         }
       })
     }

--- a/tools/devtools/nodes/inputs.py
+++ b/tools/devtools/nodes/inputs.py
@@ -333,6 +333,20 @@ class NodeWithPreAttachLegacyWidgets:
         return ()
 
 
+class NodeWithComparerWidget:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {"required": {}}
+
+    RETURN_TYPES = ()
+    FUNCTION = "node_with_comparer_widget"
+    CATEGORY = "DevTools"
+    DESCRIPTION = "A node whose web extension mirrors rgthree's image comparer"
+
+    def node_with_comparer_widget(self):
+        return ()
+
+
 class NodeWithHiddenAriaDialog:
     @classmethod
     def INPUT_TYPES(cls):
@@ -434,6 +448,7 @@ NODE_CLASS_MAPPINGS = {
     "DevToolsNodeWithV2ComboInput": NodeWithV2ComboInput,
     "DevToolsNodeWithLegacyWidget": NodeWithLegacyWidget,
     "DevToolsNodeWithPreAttachLegacyWidgets": NodeWithPreAttachLegacyWidgets,
+    "DevToolsNodeWithComparerWidget": NodeWithComparerWidget,
     "DevToolsNodeWithHiddenAriaDialog": NodeWithHiddenAriaDialog,
     "DevToolsNodeWithPriceBadge": NodeWithPriceBadge,
     "DevToolsNodeWithNumericCombo": NodeWithNumericCombo,
@@ -457,6 +472,7 @@ NODE_DISPLAY_NAME_MAPPINGS = {
     "DevToolsNodeWithV2ComboInput": "Node With V2 Combo Input",
     "DevToolsNodeWithLegacyWidget": "Node With Legacy Widget",
     "DevToolsNodeWithPreAttachLegacyWidgets": "Node With Pre-Attach Legacy Widgets",
+    "DevToolsNodeWithComparerWidget": "Node With Comparer Widget",
     "DevToolsNodeWithHiddenAriaDialog": "Node With Hidden ARIA Dialog",
     "DevToolsNodeWithPriceBadge": "Node With Price Badge",
     "DevToolsNodeWithNumericCombo": "Node With Numeric Combo",

--- a/tools/devtools/web/comparerWidget.js
+++ b/tools/devtools/web/comparerWidget.js
@@ -1,0 +1,90 @@
+// eslint-disable-next-line import-x/no-unresolved -- import is correct at time of test execution
+import { app } from '../../scripts/app.js'
+
+const NODE_TYPE = 'DevToolsNodeWithComparerWidget'
+const WIDGET_NAME = 'devtools_comparer'
+
+const EXECUTED_IMAGES = [
+  { name: 'A', selected: true, url: '/devtools/comparer/a.png' },
+  { name: 'B', selected: true, url: '/devtools/comparer/b.png' }
+]
+
+/** @see https://github.com/rgthree/rgthree-comfy/blob/main/web/comfyui/image_comparer.js */
+class ComparerWidget {
+  constructor(name, node) {
+    this.name = name
+    this.type = 'custom'
+    this.options = {}
+    this.y = 0
+    this.selected = []
+    this._value = { images: [] }
+    this.node = node
+  }
+
+  set value(v) {
+    let cleanedVal
+    if (Array.isArray(v)) {
+      cleanedVal = v.map((d, i) => {
+        if (!d || typeof d === 'string') {
+          d = { url: d, name: i == 0 ? 'A' : 'B', selected: true }
+        }
+        return d
+      })
+    } else {
+      cleanedVal = v.images || []
+    }
+    this._value.images = cleanedVal
+    this.selected = cleanedVal.filter((d) => d.selected)
+  }
+
+  get value() {
+    return this._value
+  }
+
+  draw(ctx, node, width, y, height) {
+    ctx.save()
+    ctx.fillStyle = '#333'
+    ctx.fillRect(15, y, width - 15 * 2, height)
+    ctx.fillStyle = '#fff'
+    ctx.textAlign = 'left'
+    ctx.textBaseline = 'top'
+    ctx.font = '14px Arial'
+    ctx.fillText(this.selected.map((d) => d.name).join(' '), 20, y)
+    ctx.restore()
+  }
+}
+
+app.registerExtension({
+  name: 'DevTools.ComparerWidget',
+  async beforeRegisterNodeDef(nodeType, nodeData) {
+    if (nodeData.name !== NODE_TYPE) return
+
+    const onNodeCreated = nodeType.prototype.onNodeCreated
+    nodeType.prototype.onNodeCreated = function (...args) {
+      onNodeCreated?.apply(this, args)
+      this.serialize_widgets = true
+      this.comparerWidget = this.addCustomWidget(
+        new ComparerWidget(WIDGET_NAME, this)
+      )
+      this.comparerWidget.value = {
+        images: EXECUTED_IMAGES.map((image) => ({ ...image }))
+      }
+    }
+
+    const onSerialize = nodeType.prototype.onSerialize
+    nodeType.prototype.onSerialize = function (serialised) {
+      onSerialize?.call(this, serialised)
+      for (const [index] of (serialised.widgets_values || []).entries()) {
+        if (this.widgets[index]?.name === WIDGET_NAME) {
+          serialised.widgets_values[index] = this.widgets[
+            index
+          ].value.images.map((d) => {
+            d = { ...d }
+            delete d.img
+            return d
+          })
+        }
+      }
+    }
+  }
+})


### PR DESCRIPTION
Backport of #16522 to `cloud/1.53`. Fixes the rgthree Image Comparer save error after reload (#16479), whose cause (#16097) shipped in 1.53. Clean cherry-pick of 67d5d3e, no conflicts. Requested by the release owner.

<details><summary>Full context for agent readers</summary>

- Source: #16522 (merged to main 2026-09-01), labeled needs-backport + cloud/1.53.
- Cherry-pick of 67d5d3efaf91e3f0ea134d3bbff114c2fbce47d6 onto `cloud/1.53`; original author preserved, AI co-author trailer stripped from the commit message per repo policy.
- Sibling backports: #16602 (core/1.53), #16603 (cloud/1.53). The core/1.52 auto-backport failed on conflicts and is handled separately.

</details>

<!-- authored-by:agent w3-bp -->
