### PR TITLE
fix(preview): follow-up to #14073 — nullish output recovery

### DIFF
--- a/browser_tests/fixtures/helpers/ExecutionHelper.ts
+++ b/browser_tests/fixtures/helpers/ExecutionHelper.ts
@@ -188,7 +188,7 @@ export class ExecutionHelper {
   executed(
     jobId: string,
     nodeId: string,
-    output: Record<string, unknown>
+    output: Record<string, unknown> | null | undefined
   ): void {
     this.requireWs().send(
       JSON.stringify({

--- a/browser_tests/tests/previewAsText.spec.ts
+++ b/browser_tests/tests/previewAsText.spec.ts
@@ -131,6 +131,17 @@ test.describe('Preview as Text node', () => {
         execution.executed(jobId, id, { text: ['recovered again'] })
         await expect(preview).toHaveValue('recovered again')
       })
+
+      await test.step('nullish output does not wedge the widget', async () => {
+        execution.executed(jobId, id, null)
+        await expect(preview).toHaveValue('')
+
+        execution.executed(jobId, id, undefined)
+        await expect(preview).toHaveValue('')
+
+        execution.executed(jobId, id, { text: ['recovered from nullish'] })
+        await expect(preview).toHaveValue('recovered from nullish')
+      })
     }
   )
 })

--- a/browser_tests/tests/previewAsText.spec.ts
+++ b/browser_tests/tests/previewAsText.spec.ts
@@ -114,28 +114,29 @@ test.describe('Preview as Text node', () => {
         await expect(preview).toHaveValue('23.976')
       })
 
-      await test.step('null text does not wedge the widget', async () => {
-        // The shape the Cloud backend produced when it misclassified the text
-        // as a filename and dropped it from the payload (BE-3601).
-        execution.executed(jobId, id, { text: [null] })
-        await expect(preview).toHaveValue('')
+      const malformedOutputs = [
+        [
+          'null text',
+          // The shape the Cloud backend produced when it misclassified the
+          // text as a filename and dropped it from the payload (BE-3601).
+          { text: [null] },
+          'recovered'
+        ],
+        ['output with no text key', {}, 'recovered again'],
+        ['nullish output', null, 'recovered from nullish']
+      ] as const
 
-        execution.executed(jobId, id, { text: ['recovered'] })
-        await expect(preview).toHaveValue('recovered')
-      })
+      for (const [label, output, recoveredText] of malformedOutputs) {
+        await test.step(`${label} does not wedge the widget`, async () => {
+          execution.executed(jobId, id, output)
+          await expect(preview).toHaveValue('')
 
-      await test.step('output with no text key does not wedge the widget', async () => {
-        execution.executed(jobId, id, {})
-        await expect(preview).toHaveValue('')
+          execution.executed(jobId, id, { text: [recoveredText] })
+          await expect(preview).toHaveValue(recoveredText)
+        })
+      }
 
-        execution.executed(jobId, id, { text: ['recovered again'] })
-        await expect(preview).toHaveValue('recovered again')
-      })
-
-      await test.step('nullish output does not wedge the widget', async () => {
-        execution.executed(jobId, id, null)
-        await expect(preview).toHaveValue('')
-
+      await test.step('undefined output does not wedge the widget', async () => {
         execution.executed(jobId, id, undefined)
         await expect(preview).toHaveValue('')
 

--- a/src/extensions/core/textPreviewWidgets.test.ts
+++ b/src/extensions/core/textPreviewWidgets.test.ts
@@ -1,3 +1,4 @@
+import { fromAny } from '@total-typescript/shoehorn'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
@@ -118,25 +119,32 @@ describe('updateTextPreviewWidgets', () => {
   )
 
   it('drops null entries instead of rendering blank separators', () => {
-    updateTextPreviewWidgets(node, {
-      text: ['first', null, 'second']
-    } as unknown as NodeExecutionOutput)
+    updateTextPreviewWidgets(
+      node,
+      fromAny<NodeExecutionOutput, unknown>({
+        text: ['first', null, 'second']
+      })
+    )
 
     expect(node.widgets[0].value).toBe('first\n\nsecond')
   })
 
   it('renders non-string entries rather than blanking the node', () => {
-    updateTextPreviewWidgets(node, {
-      text: ['first', 23.976, null, 'second']
-    } as unknown as NodeExecutionOutput)
+    updateTextPreviewWidgets(
+      node,
+      fromAny<NodeExecutionOutput, unknown>({
+        text: ['first', 23.976, null, 'second']
+      })
+    )
 
     expect(node.widgets[0].value).toBe('first\n\n23.976\n\nsecond')
   })
 
   it('stringifies a bare non-string scalar payload', () => {
-    updateTextPreviewWidgets(node, {
-      text: 23.976
-    } as unknown as NodeExecutionOutput)
+    updateTextPreviewWidgets(
+      node,
+      fromAny<NodeExecutionOutput, unknown>({ text: 23.976 })
+    )
     expect(node.widgets[0].value).toBe('23.976')
   })
 })


### PR DESCRIPTION
## Summary

- Covers the deferred nullish-output case from #14073.
- Confirms the text-preview widget clears and recovers.
- Keeps broader WebSocket ingress validation separate.

<details><summary>Full context for agent readers</summary>

## Changes

- **What**: Extends the execution fixture to emit `null` and omitted `output` payloads, then adds browser coverage proving Preview as Text clears without wedging and accepts a later valid update.
- **Source PR**: https://github.com/Comfy-Org/ComfyUI_frontend/pull/14073
- **Addressed review threads**:
  - https://github.com/Comfy-Org/ComfyUI_frontend/pull/14073#discussion_r3687840362 — nullish browser payload coverage
  - https://github.com/Comfy-Org/ComfyUI_frontend/pull/14073#discussion_r3797990027 — use Shoehorn for invalid schema payloads
  - https://github.com/Comfy-Org/ComfyUI_frontend/pull/14073#discussion_r3797990723 — use Shoehorn for the second invalid payload
- **Review-body disposition**: https://github.com/Comfy-Org/ComfyUI_frontend/pull/14073#pullrequestreview-4825214761 — the existing unvalidated `JSON.parse(event.data) as ApiMessageUnion` ingress cast is not bundled here because changing the full WebSocket contract is independent of the preview regression test and needs dedicated schema/compatibility analysis.

## Verification

- `pnpm typecheck`
- `pnpm typecheck:browser`
- `pnpm test:unit src/extensions/core/textPreviewWidgets.test.ts` (12 passed)
- staged formatter, oxlint, and ESLint hooks

## Review Focus

Please confirm the fixture models both wire shapes correctly: explicit `output: null` and omitted `output` (produced by `undefined`).

</details>

<!-- authored-by:agent addr-drain -->