### PR TITLE
docs: define agent cross-repository release order

### DIFF
--- a/docs/architecture/agent-cross-repo-release-order.md
+++ b/docs/architecture/agent-cross-repo-release-order.md
@@ -1,0 +1,35 @@
+# Agent cross-repository release order
+
+Agent protocol and applier changes must move in this order:
+
+```text
+comfy-multi-player merge + immutable release
+  -> cloud pin + tests + dark deploy + runtime proof
+  -> frontend pin + tests + flag-off deploy
+  -> flags on + authenticated browser canvas/reconnect proof
+  -> stable promotion of the exact tested combination
+```
+
+Frontend is the second consumer. Update `package.json` and `pnpm-lock.yaml` only after the accepted
+`@comfyorg/comfy-multi-player` version is installable and the compatible cloud consumer has deployed.
+Run package-pin/parity checks, unit and browser tests, and prove both product-flag states before
+normal frontend review and merge.
+
+Deploy the frontend with user exposure off. The integration receipt names exact frontend/cloud
+revisions, the shared package version, and flag values. `agent-in-app-experience` is the
+product/cohort flag; `AGENT_CRDT_MODE` plus `workflows.crdt_enabled` selects the V1 storage path.
+They are not interchangeable.
+
+Acceptance requires an authenticated browser flow that causes a visible canvas edit and survives
+reconnect. Package CI, frame tests, healthy services, or a served frontend alone do not satisfy the
+gate. Stable promotion reuses the exact integrated combination, makes the backend compatible first,
+verifies the served frontend revision, and expands product access last.
+
+Backward-compatible frontend-only changes that do not emit, require, or expose a backend contract
+may merge independently if the PR explains why. Documentation-only changes may proceed in parallel.
+
+## Glossary
+
+- **Dark deploy:** compatible code deployed while user exposure is disabled.
+- **Integrated receipt:** exact revisions, package version, flags, and browser-visible proof.
+- **Consumer pin:** the exact shared-package version recorded in the manifest and lockfile.


### PR DESCRIPTION
## Summary

Document the agent's package-first, backend-before-frontend release order and exact-head browser acceptance gate.

## Changes

- **What**: Adds the frontend consumer handoff, flag separation, and deployment-proof requirements.

## Review Focus

Confirm the frontend remains the second runtime consumer: the compatible cloud backend deploys before frontend exposure, and acceptance requires a visible canvas edit plus reconnect.

## Screenshots (if applicable)

Not applicable.

## Evidence

- Verified frontend `main` resolves `@comfyorg/comfy-multi-player` 0.2.1.
- Verified frontend PR #16324 merged the matching 0.2.1 consumer pin.
- `git diff --check` — passed.

<!-- authored-by:agent lane-ta-15 -->
