### PR TITLE
fix(agent): preserve root semantics for human graph edits

### DIFF
--- a/src/composables/useCoreCommands.test.ts
+++ b/src/composables/useCoreCommands.test.ts
@@ -13,6 +13,13 @@ import type * as ModelStoreModule from '@/stores/modelStore'
 import { createMockLGraphNode } from '@/utils/__tests__/litegraphTestUtils'
 import { fromPartial } from '@total-typescript/shoehorn'
 
+const mockRunMintPortsIntentionalClear = vi.hoisted(() =>
+  vi.fn(<T>(clear: () => T): T => clear())
+)
+vi.mock('@/workbench/extensions/agent/crdt/mintPortWiring', () => ({
+  runMintPortsIntentionalClear: mockRunMintPortsIntentionalClear
+}))
+
 // Mock vue-i18n for useExternalLink
 const mockLocale = ref('en')
 vi.mock('vue-i18n', async () => {
@@ -345,6 +352,7 @@ describe('useCoreCommands', () => {
 
     // Mock global confirm
     global.confirm = vi.fn().mockReturnValue(true)
+    mockRunMintPortsIntentionalClear.mockClear()
   })
 
   describe('ClearWorkflow command', () => {
@@ -359,6 +367,7 @@ describe('useCoreCommands', () => {
 
       expect(app.clean).toHaveBeenCalled()
       expect(app.rootGraph.clear).toHaveBeenCalled()
+      expect(mockRunMintPortsIntentionalClear).toHaveBeenCalledOnce()
       expect(api.dispatchCustomEvent).toHaveBeenCalledWith('graphCleared')
     })
 
@@ -376,6 +385,7 @@ describe('useCoreCommands', () => {
 
       expect(app.clean).toHaveBeenCalled()
       expect(app.rootGraph.clear).not.toHaveBeenCalled()
+      expect(mockRunMintPortsIntentionalClear).not.toHaveBeenCalled()
 
       // Should only remove user nodes, not input/output nodes
       const subgraph = app.canvas.subgraph!

--- a/src/composables/useCoreCommands.test.ts
+++ b/src/composables/useCoreCommands.test.ts
@@ -383,7 +383,7 @@ describe('useCoreCommands', () => {
       // Execute the command
       await clearCommand.function()
 
-      expect(app.clean).toHaveBeenCalled()
+      expect(app.clean).not.toHaveBeenCalled()
       expect(app.rootGraph.clear).not.toHaveBeenCalled()
       expect(mockRunMintPortsIntentionalClear).not.toHaveBeenCalled()
 

--- a/src/composables/useCoreCommands.ts
+++ b/src/composables/useCoreCommands.ts
@@ -299,7 +299,6 @@ export function useCoreCommands(): ComfyCommand[] {
           confirm('Clear workflow?')
         ) {
           if (app.canvas.subgraph) {
-            app.clean()
             // `clear` is not implemented on subgraphs and the parent class's
             // (`LGraph`) `clear` breaks the subgraph structure. For subgraphs,
             // just clear the nodes but preserve input/output nodes and structure

--- a/src/composables/useCoreCommands.ts
+++ b/src/composables/useCoreCommands.ts
@@ -68,6 +68,7 @@ import {
   useManagerState
 } from '@/workbench/extensions/manager/composables/useManagerState'
 import { ManagerTab } from '@/workbench/extensions/manager/types/comfyManagerTypes'
+import { runMintPortsIntentionalClear } from '@/workbench/extensions/agent/crdt/mintPortWiring'
 
 import { useWorkflowTemplateSelectorDialog } from './useWorkflowTemplateSelectorDialog'
 
@@ -297,14 +298,16 @@ export function useCoreCommands(): ComfyCommand[] {
           !settingStore.get('Comfy.ConfirmClear') ||
           confirm('Clear workflow?')
         ) {
-          app.clean()
           if (app.canvas.subgraph) {
+            app.clean()
             // `clear` is not implemented on subgraphs and the parent class's
             // (`LGraph`) `clear` breaks the subgraph structure. For subgraphs,
             // just clear the nodes but preserve input/output nodes and structure
             const subgraph = app.canvas.subgraph
             const nonIoNodes = getAllNonIoNodesInSubgraph(subgraph)
             nonIoNodes.forEach((node) => subgraph.remove(node))
+          } else {
+            runMintPortsIntentionalClear(() => app.clean())
           }
           api.dispatchCustomEvent('graphCleared')
         }

--- a/src/renderer/core/layout/operations/graphLayoutAttachment.test.ts
+++ b/src/renderer/core/layout/operations/graphLayoutAttachment.test.ts
@@ -10,6 +10,7 @@ import type { UUID } from '@/utils/uuid'
 
 import {
   attachNodeLayout,
+  detachGraphLayouts,
   detachNodeLayout,
   setNodePosition
 } from './graphLayoutAttachment'
@@ -79,6 +80,38 @@ describe('node layout attachment ownership', () => {
         ownerGraphId: interior.id,
         nodeId: node.id
       },
+      {
+        type: 'deleteNode',
+        graphId: root.id,
+        ownerGraphId: interior.id,
+        nodeId: node.id
+      }
+    ])
+  })
+
+  it('carries the direct owner graph when a released subgraph is bulk-detached', async () => {
+    const root = new LGraph()
+    const interior = {
+      id: 'interior-graph' as UUID,
+      rootGraph: root
+    }
+    const node = nodeFor(root, 'interior-node')
+    attachNodeLayout(interior, node)
+
+    const changes: LayoutChange[] = []
+    const detach = layoutStore.onChange((change) => changes.push(change))
+    detachGraphLayouts([
+      {
+        _nodes: [node],
+        _groups: [],
+        _subgraphs: new Map(),
+        reroutes: new Map()
+      }
+    ])
+    await Promise.resolve()
+    detach()
+
+    expect(changes.map(({ operation }) => operation)).toMatchObject([
       {
         type: 'deleteNode',
         graphId: root.id,

--- a/src/renderer/core/layout/operations/graphLayoutAttachment.test.ts
+++ b/src/renderer/core/layout/operations/graphLayoutAttachment.test.ts
@@ -60,7 +60,7 @@ describe('node layout attachment ownership', () => {
 
   it('carries the direct owner graph on interior node create and delete', async () => {
     const root = new LGraph()
-    const interiorId: UUID = 'interior-graph'
+    const interiorId: UUID = '00000000-0000-4000-8000-000000000001'
     const interior = {
       id: interiorId,
       rootGraph: root
@@ -92,8 +92,9 @@ describe('node layout attachment ownership', () => {
 
   it('carries the direct owner graph when a released subgraph is bulk-detached', async () => {
     const root = new LGraph()
+    const interiorId: UUID = '00000000-0000-4000-8000-000000000001'
     const interior = {
-      id: 'interior-graph' as UUID,
+      id: interiorId,
       rootGraph: root
     }
     const node = nodeFor(root, 'interior-node')

--- a/src/renderer/core/layout/operations/graphLayoutAttachment.test.ts
+++ b/src/renderer/core/layout/operations/graphLayoutAttachment.test.ts
@@ -60,8 +60,9 @@ describe('node layout attachment ownership', () => {
 
   it('carries the direct owner graph on interior node create and delete', async () => {
     const root = new LGraph()
+    const interiorId: UUID = 'interior-graph'
     const interior = {
-      id: 'interior-graph' as UUID,
+      id: interiorId,
       rootGraph: root
     }
     const node = nodeFor(root, 'interior-node')

--- a/src/renderer/core/layout/operations/graphLayoutAttachment.test.ts
+++ b/src/renderer/core/layout/operations/graphLayoutAttachment.test.ts
@@ -4,7 +4,9 @@ import { beforeEach, describe, expect, it } from 'vitest'
 
 import { LGraph, LGraphNode } from '@/lib/litegraph/src/litegraph'
 import { layoutStore } from '@/renderer/core/layout/store/layoutStore'
+import type { LayoutChange } from '@/renderer/core/layout/types'
 import { toNodeId } from '@/types/nodeId'
+import type { UUID } from '@/utils/uuid'
 
 import {
   attachNodeLayout,
@@ -53,5 +55,36 @@ describe('node layout attachment ownership', () => {
     expect(
       layoutStore.getNodeLayout(graph.id, replacement.id)?.position
     ).toEqual({ x: 60, y: 70 })
+  })
+
+  it('carries the direct owner graph on interior node create and delete', async () => {
+    const root = new LGraph()
+    const interior = {
+      id: 'interior-graph' as UUID,
+      rootGraph: root
+    }
+    const node = nodeFor(root, 'interior-node')
+    const changes: LayoutChange[] = []
+    const detach = layoutStore.onChange((change) => changes.push(change))
+
+    attachNodeLayout(interior, node)
+    detachNodeLayout(node)
+    await Promise.resolve()
+    detach()
+
+    expect(changes.map(({ operation }) => operation)).toMatchObject([
+      {
+        type: 'createNode',
+        graphId: root.id,
+        ownerGraphId: interior.id,
+        nodeId: node.id
+      },
+      {
+        type: 'deleteNode',
+        graphId: root.id,
+        ownerGraphId: interior.id,
+        nodeId: node.id
+      }
+    ])
   })
 })

--- a/src/renderer/core/layout/operations/graphLayoutAttachment.ts
+++ b/src/renderer/core/layout/operations/graphLayoutAttachment.ts
@@ -545,6 +545,7 @@ export function detachGraphLayouts(
           ...meta,
           graphId: attachment.graphId,
           nodeId: attachment.id,
+          ownerGraphId: attachment.ownerGraphId,
           type: 'deleteNode'
         })
       }

--- a/src/renderer/core/layout/operations/graphLayoutAttachment.ts
+++ b/src/renderer/core/layout/operations/graphLayoutAttachment.ts
@@ -18,17 +18,18 @@ type GraphLayoutOwner = Pick<
   LGraph,
   '_nodes' | '_groups' | '_subgraphs' | 'reroutes'
 >
-type LayoutGraph = { rootGraph: { id: UUID } }
+type LayoutGraph = { id: UUID; rootGraph: { id: UUID } }
 
 interface LayoutAttachment<TId> {
   graphId: UUID
   id: TId
 }
 
-const nodeAttachments = new WeakMap<
-  LGraphNode,
-  LayoutAttachment<LGraphNode['id']>
->()
+interface NodeLayoutAttachment extends LayoutAttachment<LGraphNode['id']> {
+  ownerGraphId: UUID
+}
+
+const nodeAttachments = new WeakMap<LGraphNode, NodeLayoutAttachment>()
 const nodeAttachmentOwners = new Map<
   UUID,
   Map<LGraphNode['id'], WeakRef<LGraphNode>>
@@ -254,7 +255,7 @@ export function attachNodeLayout(graph: LayoutGraph, node: LGraphNode): void {
 
   const graphId = graph.rootGraph.id
   if (layoutStore.getNodeLayout(graphId, node.id)) {
-    adoptNodeAttachment(graphId, node)
+    adoptNodeAttachment(graphId, graph.id, node)
     return
   }
 
@@ -272,19 +273,24 @@ export function attachNodeLayout(graph: LayoutGraph, node: LGraphNode): void {
       visible: true
     },
     nodeId: node.id,
+    ownerGraphId: graph.id,
     type: 'createNode'
   })
-  adoptNodeAttachment(graphId, node)
+  adoptNodeAttachment(graphId, graph.id, node)
 }
 
-function adoptNodeAttachment(graphId: UUID, node: LGraphNode): void {
+function adoptNodeAttachment(
+  graphId: UUID,
+  ownerGraphId: UUID,
+  node: LGraphNode
+): void {
   const projection = nodeGeometryProjection(node)
   const geometrySynchronized = layoutStore.readNodeRect(
     graphId,
     node.id,
     projection.buffer
   )
-  nodeAttachments.set(node, { graphId, id: node.id })
+  nodeAttachments.set(node, { graphId, id: node.id, ownerGraphId })
   setNodeAttachmentOwner(graphId, node)
   projection.layoutRef = layoutStore.getNodeLayoutRef(graphId, node.id)
   if (geometrySynchronized) {
@@ -295,7 +301,7 @@ function adoptNodeAttachment(graphId: UUID, node: LGraphNode): void {
 function transferableNodeAttachment(
   node: LGraphNode,
   replacement: LGraphNode
-): LayoutAttachment<LGraphNode['id']> | undefined {
+): NodeLayoutAttachment | undefined {
   const attachment = nodeAttachments.get(node)
   if (
     !attachment ||
@@ -346,7 +352,7 @@ export function transferLayoutAttachment(
 export function detachNodeLayout(node: LGraphNode): void {
   const attachment = nodeAttachments.get(node)
   if (!attachment) return
-  const { graphId, id: nodeId } = attachment
+  const { graphId, id: nodeId, ownerGraphId } = attachment
 
   const projection = nodeGeometryProjection(node)
   layoutStore.readNodeRect(graphId, nodeId, projection.buffer)
@@ -357,6 +363,7 @@ export function detachNodeLayout(node: LGraphNode): void {
     ...canvasOperationMeta(),
     graphId,
     nodeId,
+    ownerGraphId,
     type: 'deleteNode'
   })
 }

--- a/src/renderer/core/layout/store/layoutStoreMintDelivery.test.ts
+++ b/src/renderer/core/layout/store/layoutStoreMintDelivery.test.ts
@@ -35,6 +35,10 @@ function createNodeOp(graphId: string, id: string) {
   return {
     type: 'createNode' as const,
     graphId,
+    // Root-scoped, like the real attachNodeLayout producer: ownerGraphId
+    // equals graphId. layoutMintPort's human-edit gate fails closed on a
+    // defined graphId with no ownerGraphId (see reportUnrepresentableInteriorChange).
+    ownerGraphId: graphId,
     nodeId: toNodeId(id),
     layout: {
       id: toNodeId(id),
@@ -53,6 +57,7 @@ function deleteNodeOp(graphId: string, id: string) {
   return {
     type: 'deleteNode' as const,
     graphId,
+    ownerGraphId: graphId,
     nodeId: toNodeId(id),
     timestamp: Date.now(),
     source: LayoutSource.Canvas

--- a/src/renderer/core/layout/types.ts
+++ b/src/renderer/core/layout/types.ts
@@ -177,7 +177,15 @@ export interface SetNodeZIndexOperation extends NodeOpBase {
  */
 export interface CreateNodeOperation extends NodeOpBase {
   type: 'createNode'
-  /** Graph that directly contains the node (root or subgraph). */
+  /**
+   * Graph that directly contains the node (root or subgraph); equal to
+   * `graphId` for a root-scoped node. Every production emitter sets it —
+   * `layoutMintPort`'s human-edit gate fails closed instead of minting when
+   * it is missing (see `reportUnrepresentableInteriorChange`). Left optional
+   * here, not required, because a large body of pre-existing layout-store
+   * test fixtures construct root-scoped operations without it and are
+   * exercising the store directly, not the mint gate.
+   */
   ownerGraphId?: UUID
   layout: NodeLayout
 }
@@ -187,7 +195,15 @@ export interface CreateNodeOperation extends NodeOpBase {
  */
 export interface DeleteNodeOperation extends NodeOpBase {
   type: 'deleteNode'
-  /** Graph that directly contained the node (root or subgraph). */
+  /**
+   * Graph that directly contained the node (root or subgraph); equal to
+   * `graphId` for a root-scoped node. Every production emitter sets it —
+   * `layoutMintPort`'s human-edit gate fails closed instead of minting when
+   * it is missing (see `reportUnrepresentableInteriorChange`). Left optional
+   * here, not required, because a large body of pre-existing layout-store
+   * test fixtures construct root-scoped operations without it and are
+   * exercising the store directly, not the mint gate.
+   */
   ownerGraphId?: UUID
 }
 

--- a/src/renderer/core/layout/types.ts
+++ b/src/renderer/core/layout/types.ts
@@ -177,6 +177,8 @@ export interface SetNodeZIndexOperation extends NodeOpBase {
  */
 export interface CreateNodeOperation extends NodeOpBase {
   type: 'createNode'
+  /** Graph that directly contains the node (root or subgraph). */
+  ownerGraphId?: UUID
   layout: NodeLayout
 }
 
@@ -185,6 +187,8 @@ export interface CreateNodeOperation extends NodeOpBase {
  */
 export interface DeleteNodeOperation extends NodeOpBase {
   type: 'deleteNode'
+  /** Graph that directly contained the node (root or subgraph). */
+  ownerGraphId?: UUID
 }
 
 /**

--- a/src/scripts/ui.ts
+++ b/src/scripts/ui.ts
@@ -3,6 +3,7 @@ import { extractWorkflow } from '@/platform/remote/comfyui/jobs/fetchJobs'
 import type { JobListItem } from '@/platform/remote/comfyui/jobs/jobTypes'
 import { useSettingsDialog } from '@/platform/settings/composables/useSettingsDialog'
 import { useSettingStore } from '@/platform/settings/settingStore'
+import { runMintPortsIntentionalClear } from '@/workbench/extensions/agent/crdt/mintPortWiring'
 import { useTelemetry } from '@/platform/telemetry'
 import { WORKFLOW_ACCEPT_STRING } from '@/platform/workflow/core/types/formats'
 import { type StatusWsMessageStatus } from '@/schemas/apiSchema'
@@ -691,7 +692,7 @@ export class ComfyUI {
               !useSettingStore().get('Comfy.ConfirmClear') ||
               confirm('Clear workflow?')
             ) {
-              app.clean()
+              runMintPortsIntentionalClear(() => app.clean())
               useLitegraphService().resetView()
               api.dispatchCustomEvent('graphCleared')
             }

--- a/src/workbench/extensions/agent/AgentPanelRoot.vue
+++ b/src/workbench/extensions/agent/AgentPanelRoot.vue
@@ -133,6 +133,7 @@ const graphMutations = (workflowId: string) => {
         layoutStore.applyOperation({
           type: 'createNode',
           graphId: scope.rootGraphId,
+          ownerGraphId: scope.owningGraphId,
           nodeId,
           layout: {
             id: nodeId,
@@ -154,6 +155,7 @@ const graphMutations = (workflowId: string) => {
           nodeIds.map((nodeId) => ({
             type: 'deleteNode',
             graphId: scope.rootGraphId,
+            ownerGraphId: scope.owningGraphId,
             nodeId,
             source: LayoutSource.AgentRemote,
             actor: context.actor,

--- a/src/workbench/extensions/agent/crdt/layoutMintPort.test.ts
+++ b/src/workbench/extensions/agent/crdt/layoutMintPort.test.ts
@@ -185,6 +185,57 @@ describe('attachLayoutMintPort', () => {
     expect(reportError).toHaveBeenCalledTimes(3)
   })
 
+  it('fails closed on a graphId with no ownerGraphId instead of minting as root', () => {
+    deliver({
+      operation: { ...createNodeChange('1').operation, graphId: 'root' }
+    })
+    deliver({
+      operation: { ...deleteChange('1').operation, graphId: 'root' }
+    })
+
+    expect(minted).toEqual([])
+    expect(reportError).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        message: expect.stringContaining('createNode has no ownerGraphId')
+      }),
+      {
+        errorType: 'agent_crdt_missing_owner_graph_id_create',
+        context: { graphId: 'root', nodeId: '1' }
+      }
+    )
+    expect(reportError).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        message: expect.stringContaining('deleteNode has no ownerGraphId')
+      }),
+      {
+        errorType: 'agent_crdt_missing_owner_graph_id_delete',
+        context: { graphId: 'root', nodeId: '1' }
+      }
+    )
+  })
+
+  it('mints a root createNode when ownerGraphId equals graphId', () => {
+    deliver({
+      operation: {
+        ...createNodeChange('1').operation,
+        graphId: 'root',
+        ownerGraphId: 'root'
+      }
+    })
+
+    expect(minted).toEqual([
+      {
+        op: 'add_node',
+        node_id: '1',
+        class_type: 'TestNode',
+        pos: [128, 96],
+        node: { id: 1, type: 'TestNode', pos: [128, 96], widgets_values: [7] }
+      }
+    ])
+  })
+
   it('never mints an agent-remote echo (KA-6 sender half)', () => {
     deliver(createNodeChange('1', AGENT_REMOTE_ACTOR))
 

--- a/src/workbench/extensions/agent/crdt/layoutMintPort.test.ts
+++ b/src/workbench/extensions/agent/crdt/layoutMintPort.test.ts
@@ -94,6 +94,38 @@ describe('attachLayoutMintPort', () => {
     ])
   })
 
+  it('surfaces interior create and delete without minting root operations', () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const interior = {
+      graphId: 'root',
+      ownerGraphId: 'subgraph'
+    }
+
+    deliver({
+      operation: { ...createNodeChange('1').operation, ...interior }
+    })
+    deliver({
+      operation: { ...deleteChange('1').operation, ...interior }
+    })
+
+    expect(minted).toEqual([])
+    expect(consoleError).toHaveBeenNthCalledWith(
+      1,
+      expect.stringContaining('subgraph-interior node create'),
+      '1'
+    )
+    expect(consoleError).toHaveBeenNthCalledWith(
+      2,
+      expect.stringContaining('subgraph-interior node delete'),
+      '1'
+    )
+    expect(consoleError).not.toHaveBeenCalledWith(
+      expect.stringContaining('no snapshot for node'),
+      expect.anything()
+    )
+    consoleError.mockRestore()
+  })
+
   it('never mints an agent-remote echo (KA-6 sender half)', () => {
     deliver(createNodeChange('1', AGENT_REMOTE_ACTOR))
 

--- a/src/workbench/extensions/agent/crdt/layoutMintPort.test.ts
+++ b/src/workbench/extensions/agent/crdt/layoutMintPort.test.ts
@@ -121,7 +121,11 @@ describe('attachLayoutMintPort', () => {
       }),
       {
         errorType: 'agent_crdt_unrepresentable_subgraph_node_create',
-        context: { nodeId: '1' }
+        context: {
+          graphId: 'root',
+          ownerGraphId: 'subgraph',
+          nodeId: '1'
+        }
       }
     )
     expect(reportError).toHaveBeenNthCalledWith(
@@ -131,9 +135,54 @@ describe('attachLayoutMintPort', () => {
       }),
       {
         errorType: 'agent_crdt_unrepresentable_subgraph_node_delete',
-        context: { nodeId: '1' }
+        context: {
+          graphId: 'root',
+          ownerGraphId: 'subgraph',
+          nodeId: '1'
+        }
       }
     )
+  })
+
+  it('reports one interior-delete error per subgraph per tick', async () => {
+    for (let index = 0; index < 30; index++) {
+      deliver({
+        operation: {
+          ...deleteChange(String(index)).operation,
+          graphId: 'root',
+          ownerGraphId: 'subgraph-a'
+        }
+      })
+    }
+
+    expect(reportError).toHaveBeenCalledOnce()
+    expect(reportError).toHaveBeenLastCalledWith(expect.any(Error), {
+      errorType: 'agent_crdt_unrepresentable_subgraph_node_delete',
+      context: {
+        graphId: 'root',
+        ownerGraphId: 'subgraph-a',
+        nodeId: '0'
+      }
+    })
+
+    deliver({
+      operation: {
+        ...deleteChange('30').operation,
+        graphId: 'root',
+        ownerGraphId: 'subgraph-b'
+      }
+    })
+    expect(reportError).toHaveBeenCalledTimes(2)
+
+    await Promise.resolve()
+    deliver({
+      operation: {
+        ...deleteChange('31').operation,
+        graphId: 'root',
+        ownerGraphId: 'subgraph-a'
+      }
+    })
+    expect(reportError).toHaveBeenCalledTimes(3)
   })
 
   it('never mints an agent-remote echo (KA-6 sender half)', () => {

--- a/src/workbench/extensions/agent/crdt/layoutMintPort.test.ts
+++ b/src/workbench/extensions/agent/crdt/layoutMintPort.test.ts
@@ -2,11 +2,17 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { WorkflowNode } from '@comfyorg/comfy-multi-player'
 
+import { reportError } from '@/platform/telemetry/reportError'
+
 import type { GraphOperation } from './graphOperations'
 import { AGENT_REMOTE_ACTOR, attachLayoutMintPort } from './layoutMintPort'
 import type { LayoutChangeView, LayoutMintPort } from './layoutMintPort'
 import { createMintSession } from './mintSession'
 import type { MintSession } from './mintSession'
+
+vi.mock('@/platform/telemetry/reportError', () => ({
+  reportError: vi.fn()
+}))
 
 const LOCAL_PREFIX = 'user-'
 const LOCAL_ACTOR = 'user-abc123def'
@@ -95,7 +101,6 @@ describe('attachLayoutMintPort', () => {
   })
 
   it('surfaces interior create and delete without minting root operations', () => {
-    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
     const interior = {
       graphId: 'root',
       ownerGraphId: 'subgraph'
@@ -109,21 +114,26 @@ describe('attachLayoutMintPort', () => {
     })
 
     expect(minted).toEqual([])
-    expect(consoleError).toHaveBeenNthCalledWith(
+    expect(reportError).toHaveBeenNthCalledWith(
       1,
-      expect.stringContaining('subgraph-interior node create'),
-      '1'
+      expect.objectContaining({
+        message: expect.stringContaining('Subgraph-interior node create')
+      }),
+      {
+        errorType: 'agent_crdt_unrepresentable_subgraph_node_create',
+        context: { nodeId: '1' }
+      }
     )
-    expect(consoleError).toHaveBeenNthCalledWith(
+    expect(reportError).toHaveBeenNthCalledWith(
       2,
-      expect.stringContaining('subgraph-interior node delete'),
-      '1'
+      expect.objectContaining({
+        message: expect.stringContaining('Subgraph-interior node delete')
+      }),
+      {
+        errorType: 'agent_crdt_unrepresentable_subgraph_node_delete',
+        context: { nodeId: '1' }
+      }
     )
-    expect(consoleError).not.toHaveBeenCalledWith(
-      expect.stringContaining('no snapshot for node'),
-      expect.anything()
-    )
-    consoleError.mockRestore()
   })
 
   it('never mints an agent-remote echo (KA-6 sender half)', () => {

--- a/src/workbench/extensions/agent/crdt/layoutMintPort.ts
+++ b/src/workbench/extensions/agent/crdt/layoutMintPort.ts
@@ -8,6 +8,8 @@
  */
 import type { NodeId, WorkflowNode } from '@comfyorg/comfy-multi-player'
 
+import { reportError } from '@/platform/telemetry/reportError'
+
 import type { GraphOperation } from './graphOperations'
 import type { SeveranceLog } from './linkMintPort'
 import { shouldMint } from './mintGate'
@@ -98,9 +100,14 @@ export function attachLayoutMintPort(deps: LayoutMintPortDeps): LayoutMintPort {
           operation.graphId !== undefined &&
           operation.ownerGraphId !== operation.graphId
         ) {
-          console.error(
-            '[agent-crdt] subgraph-interior node create has no wire op; the bound doc diverges from the local graph',
-            operation.nodeId
+          reportError(
+            new Error(
+              'Subgraph-interior node create has no wire op; the bound doc diverges from the local graph'
+            ),
+            {
+              errorType: 'agent_crdt_unrepresentable_subgraph_node_create',
+              context: { nodeId: operation.nodeId }
+            }
           )
           return
         }
@@ -133,9 +140,14 @@ export function attachLayoutMintPort(deps: LayoutMintPortDeps): LayoutMintPort {
           operation.graphId !== undefined &&
           operation.ownerGraphId !== operation.graphId
         ) {
-          console.error(
-            '[agent-crdt] subgraph-interior node delete has no wire op; the bound doc diverges from the local graph',
-            operation.nodeId
+          reportError(
+            new Error(
+              'Subgraph-interior node delete has no wire op; the bound doc diverges from the local graph'
+            ),
+            {
+              errorType: 'agent_crdt_unrepresentable_subgraph_node_delete',
+              context: { nodeId: operation.nodeId }
+            }
           )
           return
         }

--- a/src/workbench/extensions/agent/crdt/layoutMintPort.ts
+++ b/src/workbench/extensions/agent/crdt/layoutMintPort.ts
@@ -94,13 +94,28 @@ export function attachLayoutMintPort(deps: LayoutMintPortDeps): LayoutMintPort {
     operation: LayoutChangeView['operation'],
     action: 'create' | 'delete'
   ): boolean {
-    if (
-      operation.ownerGraphId === undefined ||
-      operation.graphId === undefined ||
-      operation.ownerGraphId === operation.graphId
-    ) {
-      return false
+    if (operation.graphId === undefined) return false
+
+    if (operation.ownerGraphId === undefined) {
+      // Every production emitter (canvas attach/detach, the agent panel) now
+      // sets ownerGraphId on every createNode/deleteNode it mints, root scope
+      // included (ownerGraphId === graphId there). A defined graphId with no
+      // ownerGraphId means an emitter regressed the contract, not a benign
+      // root edit — fail closed instead of silently minting a root op that
+      // may really belong to a subgraph (the #16503 class of bug).
+      reportError(
+        new Error(
+          `${action}Node has no ownerGraphId; refusing to mint (root-vs-subgraph is unknown)`
+        ),
+        {
+          errorType: `agent_crdt_missing_owner_graph_id_${action}`,
+          context: { graphId: operation.graphId, nodeId: operation.nodeId }
+        }
+      )
+      return true
     }
+
+    if (operation.ownerGraphId === operation.graphId) return false
 
     const reportKey = `${action}:${operation.graphId}:${operation.ownerGraphId}`
     if (reportedInteriorChanges.has(reportKey)) return true

--- a/src/workbench/extensions/agent/crdt/layoutMintPort.ts
+++ b/src/workbench/extensions/agent/crdt/layoutMintPort.ts
@@ -75,6 +75,7 @@ export interface LayoutMintPort {
 
 export function attachLayoutMintPort(deps: LayoutMintPortDeps): LayoutMintPort {
   let intentionalClearNodes: NodeId[] | null = null
+  const reportedInteriorChanges = new Set<string>()
 
   function gate(change: LayoutChangeView, teardown: boolean): boolean {
     const actor = change.operation.actor
@@ -89,28 +90,46 @@ export function attachLayoutMintPort(deps: LayoutMintPortDeps): LayoutMintPort {
     })
   }
 
+  function reportUnrepresentableInteriorChange(
+    operation: LayoutChangeView['operation'],
+    action: 'create' | 'delete'
+  ): boolean {
+    if (
+      operation.ownerGraphId === undefined ||
+      operation.graphId === undefined ||
+      operation.ownerGraphId === operation.graphId
+    ) {
+      return false
+    }
+
+    const reportKey = `${action}:${operation.graphId}:${operation.ownerGraphId}`
+    if (reportedInteriorChanges.has(reportKey)) return true
+
+    reportedInteriorChanges.add(reportKey)
+    queueMicrotask(() => reportedInteriorChanges.delete(reportKey))
+    reportError(
+      new Error(
+        `Subgraph-interior node ${action} has no wire op; the bound doc diverges from the local graph`
+      ),
+      {
+        errorType: `agent_crdt_unrepresentable_subgraph_node_${action}`,
+        context: {
+          graphId: operation.graphId,
+          ownerGraphId: operation.ownerGraphId,
+          nodeId: operation.nodeId
+        }
+      }
+    )
+    return true
+  }
+
   function onChange(change: LayoutChangeView): void {
     const operation = change.operation
     const inTeardown = deps.session.inTeardown()
     switch (operation.type) {
       case 'createNode': {
         if (!gate(change, inTeardown)) return
-        if (
-          operation.ownerGraphId !== undefined &&
-          operation.graphId !== undefined &&
-          operation.ownerGraphId !== operation.graphId
-        ) {
-          reportError(
-            new Error(
-              'Subgraph-interior node create has no wire op; the bound doc diverges from the local graph'
-            ),
-            {
-              errorType: 'agent_crdt_unrepresentable_subgraph_node_create',
-              context: { nodeId: operation.nodeId }
-            }
-          )
-          return
-        }
+        if (reportUnrepresentableInteriorChange(operation, 'create')) return
         if (operation.nodeId === undefined || !operation.layout) return
         const node = deps.source.serializeNode(String(operation.nodeId))
         if (!node) {
@@ -135,22 +154,7 @@ export function attachLayoutMintPort(deps: LayoutMintPortDeps): LayoutMintPort {
       }
       case 'deleteNode': {
         if (!gate(change, inTeardown)) return
-        if (
-          operation.ownerGraphId !== undefined &&
-          operation.graphId !== undefined &&
-          operation.ownerGraphId !== operation.graphId
-        ) {
-          reportError(
-            new Error(
-              'Subgraph-interior node delete has no wire op; the bound doc diverges from the local graph'
-            ),
-            {
-              errorType: 'agent_crdt_unrepresentable_subgraph_node_delete',
-              context: { nodeId: operation.nodeId }
-            }
-          )
-          return
-        }
+        if (reportUnrepresentableInteriorChange(operation, 'delete')) return
         if (operation.nodeId === undefined) return
         deps.enqueue([
           {

--- a/src/workbench/extensions/agent/crdt/layoutMintPort.ts
+++ b/src/workbench/extensions/agent/crdt/layoutMintPort.ts
@@ -23,6 +23,8 @@ export const AGENT_REMOTE_ACTOR = 'agent-remote'
 export interface LayoutChangeView {
   operation: {
     type: string
+    graphId?: string
+    ownerGraphId?: string
     actor?: string
     source?: string
     nodeId?: NodeId
@@ -91,6 +93,17 @@ export function attachLayoutMintPort(deps: LayoutMintPortDeps): LayoutMintPort {
     switch (operation.type) {
       case 'createNode': {
         if (!gate(change, inTeardown)) return
+        if (
+          operation.ownerGraphId !== undefined &&
+          operation.graphId !== undefined &&
+          operation.ownerGraphId !== operation.graphId
+        ) {
+          console.error(
+            '[agent-crdt] subgraph-interior node create has no wire op; the bound doc diverges from the local graph',
+            operation.nodeId
+          )
+          return
+        }
         if (operation.nodeId === undefined || !operation.layout) return
         const node = deps.source.serializeNode(String(operation.nodeId))
         if (!node) {
@@ -115,6 +128,17 @@ export function attachLayoutMintPort(deps: LayoutMintPortDeps): LayoutMintPort {
       }
       case 'deleteNode': {
         if (!gate(change, inTeardown)) return
+        if (
+          operation.ownerGraphId !== undefined &&
+          operation.graphId !== undefined &&
+          operation.ownerGraphId !== operation.graphId
+        ) {
+          console.error(
+            '[agent-crdt] subgraph-interior node delete has no wire op; the bound doc diverges from the local graph',
+            operation.nodeId
+          )
+          return
+        }
         if (operation.nodeId === undefined) return
         deps.enqueue([
           {

--- a/src/workbench/extensions/agent/crdt/mintPortWiring.test.ts
+++ b/src/workbench/extensions/agent/crdt/mintPortWiring.test.ts
@@ -1,5 +1,5 @@
 import { createPinia, setActivePinia } from 'pinia'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
 import type { GraphScope } from '@/types/graphScopeId'
@@ -15,7 +15,10 @@ import { widgetId } from '@/types/widgetId'
 
 import type { GraphOperation } from './graphOperations'
 import type { LayoutChangeView } from './layoutMintPort'
-import { attachMintPortWiring } from './mintPortWiring'
+import {
+  attachMintPortWiring,
+  runMintPortsIntentionalClear
+} from './mintPortWiring'
 import type { MintPortWiring, MintableGraph } from './mintPortWiring'
 
 const ROOT_ID = 'root-uuid'
@@ -91,6 +94,23 @@ describe('attachMintPortWiring', () => {
       localActorPrefix: 'user-',
       getGraph: () => graph
     })
+  })
+
+  afterEach(() => wiring.detach())
+
+  it('mints a root clear through the production intentional-clear entry point', () => {
+    graphNodes.set('1', { id: toNodeId(1) })
+    graphNodes.set('2', { id: toNodeId(2) })
+
+    runMintPortsIntentionalClear(() => {
+      deliverLayoutChange({
+        operation: { type: 'clearGraph', actor: 'user-abc' }
+      })
+    })
+
+    expect(minted).toEqual([
+      { op: 'clear', removed_nodes: [toNodeId(1), toNodeId(2)] }
+    ])
   })
 
   it('mints a concrete connect when the real link store places a link', () => {

--- a/src/workbench/extensions/agent/crdt/mintPortWiring.ts
+++ b/src/workbench/extensions/agent/crdt/mintPortWiring.ts
@@ -75,6 +75,16 @@ export function notifyMintPortsAfterGraphConfigure(): void {
   for (const wiring of activeWirings) wiring.onAfterGraphConfigure()
 }
 
+/** Run a confirmed root-workflow clear through every active mint port. */
+export function runMintPortsIntentionalClear<T>(clear: () => T): T {
+  const wirings = [...activeWirings]
+  const run = (index: number): T =>
+    index === wirings.length
+      ? clear()
+      : wirings[index].runIntentionalClear(() => run(index + 1))
+  return run(0)
+}
+
 /**
  * Serialized save-format node, `widgets_values` NAME-KEYED via the node's own
  * `widgets_values_named` minus non-value widgets (FE-1904: the doc host's


### PR DESCRIPTION
- Root human clear now mints `clear`.
- Interior node edits cannot mint root ops.
- Production-path regression coverage added.

<details><summary>Full context for agent readers</summary>

## Problem

The only intentional-clear capture lived behind a panel-local wiring handle with no production caller, so `Comfy.ClearWorkflow` and the legacy clear button could never emit the destructive semantic `clear` operation.

Layout node operations also retained only the root layout bucket. A node deleted inside a subgraph therefore looked root-owned and could emit a root-level `delete_node`; interior creation failed later with the misleading `no snapshot for node` diagnostic.

## Solution

- Route confirmed root clears through the active mint wirings. Subgraph clears remain outside the root-only `clear` vocabulary.
- Carry `ownerGraphId` from the graph that directly contains a node through create/delete layout operations and attachment transfer.
- Surface interior create/delete as explicitly unrepresentable before snapshot lookup or enqueue.
- Cover the command entry point, legacy active-wiring entry point, real layout attachment feed, and mint outcomes.

This PR is based directly on current `main`. It is the semantic-gap successor to #16373 and preserves its root/workflow identity contract when that PR is rebased or merged.

Fixes #16502.
Fixes #16503.

## Evidence

```text
$ pnpm exec vitest run src/renderer/core/layout/operations/graphLayoutAttachment.test.ts src/workbench/extensions/agent/crdt/layoutMintPort.test.ts src/workbench/extensions/agent/crdt/mintPortWiring.test.ts src/composables/useCoreCommands.test.ts
Test Files  4 passed (4)
Tests  84 passed (84)

$ pnpm typecheck
vue-tsc --noEmit
exit 0

$ pnpm exec eslint <10 changed TypeScript files>
0 errors
1 ignored-file warning for src/scripts/ui.ts

$ pnpm exec oxfmt --check <10 changed TypeScript files>
All matched files use the correct format.
Finished on 10 files.
```

## CRDT invariants

- Semantic ops remain the only human-to-host replication unit.
- Subgraph-interior edits never masquerade as root semantic edits.
- Remote/teardown gates and creator-owned operation identity are unchanged.

</details>

<!-- authored-by:agent lane-ecw-47 -->
