### PR TITLE
fix(crdt): validate awareness frame bounds

### DIFF
--- a/src/workbench/extensions/agent/crdt/docFrameClient.awareness.test.ts
+++ b/src/workbench/extensions/agent/crdt/docFrameClient.awareness.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+
+import { parseServerDocFrame } from './docFrameClient'
+
+function awarenessFrame(state: unknown, expiresAt: unknown = 123) {
+  return {
+    type: 'awareness',
+    data: {
+      v: 1,
+      workflow_id: 'wf-1',
+      actor: 'human:user:tab-a',
+      state,
+      expires_at: expiresAt
+    }
+  }
+}
+
+describe('awareness frame validation', () => {
+  it('rejects state whose JSON encoding exceeds 8 KiB', () => {
+    expect(
+      parseServerDocFrame(awarenessFrame({ value: 'x'.repeat(8 * 1024) }))
+    ).toBeNull()
+  })
+
+  it('rejects array-shaped state', () => {
+    expect(parseServerDocFrame(awarenessFrame(['cursor', 10, 20]))).toBeNull()
+  })
+
+  it('rejects negative expires_at', () => {
+    expect(parseServerDocFrame(awarenessFrame({}, -1))).toBeNull()
+  })
+
+  it('rejects non-finite expires_at', () => {
+    expect(
+      parseServerDocFrame(awarenessFrame({}, Number.POSITIVE_INFINITY))
+    ).toBeNull()
+    expect(parseServerDocFrame(awarenessFrame({}, Number.NaN))).toBeNull()
+  })
+
+  it('accepts a valid awareness frame', () => {
+    expect(
+      parseServerDocFrame(
+        awarenessFrame({ cursor: [10, 20], selection: 'node-1' }, 456)
+      )
+    ).toEqual({
+      type: 'awareness',
+      data: {
+        workflowId: 'wf-1',
+        actor: 'human:user:tab-a',
+        state: { cursor: [10, 20], selection: 'node-1' },
+        expiresAt: 456
+      }
+    })
+  })
+})

--- a/src/workbench/extensions/agent/crdt/docFrameClient.awareness.test.ts
+++ b/src/workbench/extensions/agent/crdt/docFrameClient.awareness.test.ts
@@ -22,6 +22,17 @@ describe('awareness frame validation', () => {
     ).toBeNull()
   })
 
+  it('accepts state whose JSON encoding is exactly 8 KiB', () => {
+    // `{"value":"x…"}` wraps the string in 12 bytes of JSON syntax.
+    const state = { value: 'x'.repeat(8 * 1024 - 12) }
+    expect(new TextEncoder().encode(JSON.stringify(state)).byteLength).toBe(
+      8 * 1024
+    )
+    expect(parseServerDocFrame(awarenessFrame(state))).toMatchObject({
+      data: { state }
+    })
+  })
+
   it('rejects array-shaped state', () => {
     expect(parseServerDocFrame(awarenessFrame(['cursor', 10, 20]))).toBeNull()
   })
@@ -35,6 +46,23 @@ describe('awareness frame validation', () => {
       parseServerDocFrame(awarenessFrame({}, Number.POSITIVE_INFINITY))
     ).toBeNull()
     expect(parseServerDocFrame(awarenessFrame({}, Number.NaN))).toBeNull()
+  })
+
+  it('rejects fractional expires_at', () => {
+    expect(parseServerDocFrame(awarenessFrame({}, 1.5))).toBeNull()
+  })
+
+  it('rejects expires_at beyond the safe integer range', () => {
+    expect(
+      parseServerDocFrame(awarenessFrame({}, Number.MAX_SAFE_INTEGER + 1))
+    ).toBeNull()
+    expect(parseServerDocFrame(awarenessFrame({}, 1e300))).toBeNull()
+  })
+
+  it('accepts a zero expires_at', () => {
+    expect(parseServerDocFrame(awarenessFrame({}, 0))).toMatchObject({
+      data: { expiresAt: 0 }
+    })
   })
 
   it('accepts a valid awareness frame', () => {

--- a/src/workbench/extensions/agent/crdt/docFrameClient.ts
+++ b/src/workbench/extensions/agent/crdt/docFrameClient.ts
@@ -123,13 +123,9 @@ function parseRecord(value: unknown): Record<string, unknown> | null {
     : null
 }
 
+/** Unix seconds on the wire: a non-negative integer inside the safe range. */
 function isNonNegativeInteger(value: unknown): value is number {
-  return (
-    typeof value === 'number' &&
-    Number.isFinite(value) &&
-    Number.isInteger(value) &&
-    value >= 0
-  )
+  return typeof value === 'number' && Number.isSafeInteger(value) && value >= 0
 }
 
 function parseAwarenessState(
@@ -139,6 +135,9 @@ function parseAwarenessState(
   const state = parseRecord(value)
   if (state === null) return null
 
+  // Defence in depth behind the server's identical cap. The counts are not
+  // byte-identical: Go's json.Marshal HTML-escapes `<`, `>` and `&`, so the
+  // server always counts >= this and is the stricter of the two.
   try {
     return new TextEncoder().encode(JSON.stringify(state)).byteLength <=
       MAX_AWARENESS_STATE_BYTES

--- a/src/workbench/extensions/agent/crdt/docFrameClient.ts
+++ b/src/workbench/extensions/agent/crdt/docFrameClient.ts
@@ -1,6 +1,7 @@
 import type { Op } from '@comfyorg/comfy-multi-player'
 
 const DOC_PROTOCOL_VERSION = 1
+const MAX_AWARENESS_STATE_BYTES = 8 * 1024
 
 export interface DocOp {
   op_id: string
@@ -117,9 +118,35 @@ function parseWireData(value: unknown): WireData | null {
 }
 
 function parseRecord(value: unknown): Record<string, unknown> | null {
-  return typeof value === 'object' && value !== null
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
     ? Object.fromEntries(Object.entries(value))
     : null
+}
+
+function isNonNegativeInteger(value: unknown): value is number {
+  return (
+    typeof value === 'number' &&
+    Number.isFinite(value) &&
+    Number.isInteger(value) &&
+    value >= 0
+  )
+}
+
+function parseAwarenessState(
+  value: unknown
+): Record<string, unknown> | undefined | null {
+  if (value === undefined) return undefined
+  const state = parseRecord(value)
+  if (state === null) return null
+
+  try {
+    return new TextEncoder().encode(JSON.stringify(state)).byteLength <=
+      MAX_AWARENESS_STATE_BYTES
+      ? state
+      : null
+  } catch {
+    return null
+  }
 }
 
 export function parseServerDocFrame(value: unknown): ServerDocFrame | null {
@@ -204,14 +231,20 @@ export function parseServerDocFrame(value: unknown): ServerDocFrame | null {
   }
 
   if (frame.type === 'awareness' && typeof data.actor === 'string') {
-    const state = parseRecord(data.state)
+    const state = parseAwarenessState(data.state)
+    if (
+      state === null ||
+      (data.expires_at !== undefined && !isNonNegativeInteger(data.expires_at))
+    )
+      return null
+
     return {
       type: frame.type,
       data: {
         workflowId: data.workflow_id,
         actor: data.actor,
-        ...(state !== null && { state }),
-        ...(typeof data.expires_at === 'number' && {
+        ...(state !== undefined && { state }),
+        ...(data.expires_at !== undefined && {
           expiresAt: data.expires_at
         })
       }


### PR DESCRIPTION
Ports `origin/op2/fec-frame-7` (commit `329464683f`) to current main. Salvage source per `program/reorientation-plan.md` PR-first salvage doctrine (bbc #165); registry entry `origin/op2/fec-frame-7`.

`parseServerDocFrame`'s awareness branch accepted any object-shaped `state` (including arrays, since `typeof [] === 'object'`) with no size bound, and coerced `expires_at` only by `typeof === 'number'` — silently letting through negative, `NaN`, or `Infinity` values. This adds:

- an 8 KiB cap on the JSON-encoded `state` (rejects oversized awareness payloads instead of applying them)
- rejection of array-shaped `state`
- `expires_at` validated as a non-negative finite integer, rejecting negative/`NaN`/`Infinity`

Tests added in `docFrameClient.awareness.test.ts` cover all four rejection paths plus the valid-frame case.

Verified locally: `pnpm exec vitest run src/workbench/extensions/agent/crdt/docFrameClient*` (11/11 pass), `pnpm exec eslint` on both touched files (clean), full `vue-tsc --noEmit` (clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)