### PR TITLE
fix(website): correct the Comfy CLI transcript on /platform/comfy-api

### DIFF
--- a/apps/website/src/templates/platform/CodeTabs.vue
+++ b/apps/website/src/templates/platform/CodeTabs.vue
@@ -33,6 +33,7 @@ const {
   label: string
   contentClass?: string
   listClass?: string
+  triggerClass?: string
 }>()
 
 const activeTab = ref(Object.keys(tabs)[0])
@@ -113,7 +114,12 @@ function cycleValue(values: string[]): string {
         v-for="(tab, tabId) in tabs"
         :key="tabId"
         :value="tabId"
-        class="focus-visible:ring-primary-comfy-yellow/50 data-[state=active]:bg-secondary-mauve flex-1 cursor-pointer rounded-xl p-2 text-center text-[10px] font-bold tracking-normal whitespace-nowrap text-smoke-700 uppercase transition-colors hover:text-primary-comfy-canvas focus-visible:ring-2 focus-visible:outline-none data-[state=active]:text-primary-warm-white sm:flex-none sm:px-5 sm:text-xs sm:tracking-wider"
+        :class="
+          cn(
+            'focus-visible:ring-primary-comfy-yellow/50 data-[state=active]:bg-secondary-mauve flex-1 cursor-pointer rounded-xl px-1 py-2 text-center text-[10px] font-bold tracking-normal whitespace-nowrap text-smoke-700 uppercase transition-colors hover:text-primary-comfy-canvas focus-visible:ring-2 focus-visible:outline-none data-[state=active]:text-primary-warm-white sm:flex-none sm:px-5 sm:text-xs sm:tracking-wider',
+            triggerClass
+          )
+        "
       >
         <span class="ppformula-text-center">{{ tab.name }}</span>
       </TabsTrigger>

--- a/apps/website/src/templates/platform/CodeTabs.vue
+++ b/apps/website/src/templates/platform/CodeTabs.vue
@@ -113,9 +113,9 @@ function cycleValue(values: string[]): string {
         v-for="(tab, tabId) in tabs"
         :key="tabId"
         :value="tabId"
-        class="focus-visible:ring-primary-comfy-yellow/50 data-[state=active]:bg-secondary-mauve flex-1 cursor-pointer rounded-xl px-1 py-2 text-center text-[10px] font-bold tracking-normal whitespace-nowrap text-smoke-700 uppercase transition-colors hover:text-primary-comfy-canvas focus-visible:ring-2 focus-visible:outline-none data-[state=active]:text-primary-warm-white sm:flex-none sm:px-5 sm:text-xs sm:tracking-wider"
+        class="focus-visible:ring-primary-comfy-yellow/50 data-[state=active]:bg-secondary-mauve flex-1 cursor-pointer rounded-xl p-2 text-center text-[10px] font-bold tracking-normal whitespace-nowrap text-smoke-700 uppercase transition-colors hover:text-primary-comfy-canvas focus-visible:ring-2 focus-visible:outline-none data-[state=active]:text-primary-warm-white sm:flex-none sm:px-5 sm:text-xs sm:tracking-wider"
       >
-        {{ tab.name }}
+        <span class="ppformula-text-center">{{ tab.name }}</span>
       </TabsTrigger>
     </TabsList>
 

--- a/apps/website/src/templates/platform/ServerlessDeploySection.test.ts
+++ b/apps/website/src/templates/platform/ServerlessDeploySection.test.ts
@@ -6,7 +6,8 @@ import { describe, expect, it } from 'vitest'
 import { t } from '../../i18n/translations'
 import ServerlessDeploySection from './ServerlessDeploySection.vue'
 
-const transcript = () => screen.getByRole('tabpanel').textContent
+const transcriptLines = () =>
+  (screen.getByRole('tabpanel').textContent ?? '').split('\n')
 
 describe('ServerlessDeploySection', () => {
   it('walks through the install flow first and the workflow flow on demand', async () => {
@@ -23,11 +24,14 @@ describe('ServerlessDeploySection', () => {
         /Easily package up your existing ComfyUI environment or a single workflow,\s+then deploy it to Comfy API\./
       )
     ).toBeTruthy()
-    expect(transcript()).toContain('$ comfy build init\n')
-    expect(transcript()).toContain(
-      '$ comfy build push --release --target linux/nvidia'
-    )
-    expect(transcript()).toContain('$ comfy deploy up')
+    expect(transcriptLines()).toEqual([
+      '$ comfy build init',
+      '✔ Scanned this ComfyUI install — custom nodes, models, pinned deps',
+      '$ comfy build push --release --target linux/nvidia',
+      '✔ Build released',
+      '$ comfy deploy up',
+      '✔ Endpoint live → https://your-build.run.comfy.app'
+    ])
 
     await userEvent.click(
       screen.getByRole('tab', {
@@ -35,12 +39,13 @@ describe('ServerlessDeploySection', () => {
       })
     )
 
-    expect(transcript()).toContain(
-      '$ comfy build init --from-workflow ./workflow.json --comfy-version v0.34.2\n'
-    )
-    expect(transcript()).toContain(
-      '$ comfy build push --release --target linux/nvidia'
-    )
-    expect(transcript()).toContain('$ comfy deploy up')
+    expect(transcriptLines()).toEqual([
+      '$ comfy build init --from-workflow ./workflow.json --comfy-version v0.34.2',
+      '✔ Custom nodes and models resolved from your workflow',
+      '$ comfy build push --release --target linux/nvidia',
+      '✔ Build released',
+      '$ comfy deploy up',
+      '✔ Endpoint live → https://your-build.run.comfy.app'
+    ])
   })
 })

--- a/apps/website/src/templates/platform/ServerlessDeploySection.test.ts
+++ b/apps/website/src/templates/platform/ServerlessDeploySection.test.ts
@@ -36,7 +36,7 @@ describe('ServerlessDeploySection', () => {
     )
 
     expect(transcript()).toContain(
-      '$ comfy build init --from-workflow ./workflow.json'
+      '$ comfy build init --from-workflow ./workflow.json --comfy-version v0.34.2\n'
     )
     expect(transcript()).toContain(
       '$ comfy build push --release --target linux/nvidia'

--- a/apps/website/src/templates/platform/ServerlessDeploySection.test.ts
+++ b/apps/website/src/templates/platform/ServerlessDeploySection.test.ts
@@ -21,7 +21,12 @@ describe('ServerlessDeploySection', () => {
         /Easily package up your existing ComfyUI environment or a single workflow,\s+then deploy it to Comfy API\./
       )
     ).toBeTruthy()
-    expect(screen.getByText(/Scanned this ComfyUI install/)).toBeTruthy()
+    expect(
+      screen.getByText(/comfy build init Scanned this ComfyUI install/)
+    ).toBeTruthy()
+    expect(
+      screen.getByText(/comfy build push --release --target linux\/nvidia/)
+    ).toBeTruthy()
 
     await userEvent.click(
       screen.getByRole('tab', {

--- a/apps/website/src/templates/platform/ServerlessDeploySection.test.ts
+++ b/apps/website/src/templates/platform/ServerlessDeploySection.test.ts
@@ -6,6 +6,8 @@ import { describe, expect, it } from 'vitest'
 import { t } from '../../i18n/translations'
 import ServerlessDeploySection from './ServerlessDeploySection.vue'
 
+const transcript = () => screen.getByRole('tabpanel').textContent
+
 describe('ServerlessDeploySection', () => {
   it('walks through the install flow first and the workflow flow on demand', async () => {
     render(ServerlessDeploySection, { props: { locale: 'en' } })
@@ -21,12 +23,10 @@ describe('ServerlessDeploySection', () => {
         /Easily package up your existing ComfyUI environment or a single workflow,\s+then deploy it to Comfy API\./
       )
     ).toBeTruthy()
-    expect(
-      screen.getByText(/comfy build init Scanned this ComfyUI install/)
-    ).toBeTruthy()
-    expect(
-      screen.getByText(/comfy build push --release --target linux\/nvidia/)
-    ).toBeTruthy()
+    expect(transcript()).toContain('$ comfy build init\n')
+    expect(transcript()).toContain(
+      '$ comfy build push --release --target linux/nvidia'
+    )
 
     await userEvent.click(
       screen.getByRole('tab', {
@@ -34,6 +34,11 @@ describe('ServerlessDeploySection', () => {
       })
     )
 
-    expect(screen.getByText(/comfy build init --from-workflow/)).toBeTruthy()
+    expect(transcript()).toContain(
+      '$ comfy build init --from-workflow ./workflow.json'
+    )
+    expect(transcript()).toContain(
+      '$ comfy build push --release --target linux/nvidia'
+    )
   })
 })

--- a/apps/website/src/templates/platform/ServerlessDeploySection.test.ts
+++ b/apps/website/src/templates/platform/ServerlessDeploySection.test.ts
@@ -27,6 +27,7 @@ describe('ServerlessDeploySection', () => {
     expect(transcript()).toContain(
       '$ comfy build push --release --target linux/nvidia'
     )
+    expect(transcript()).toContain('$ comfy deploy up')
 
     await userEvent.click(
       screen.getByRole('tab', {
@@ -40,5 +41,6 @@ describe('ServerlessDeploySection', () => {
     expect(transcript()).toContain(
       '$ comfy build push --release --target linux/nvidia'
     )
+    expect(transcript()).toContain('$ comfy deploy up')
   })
 })

--- a/apps/website/src/templates/platform/ServerlessDeploySection.test.ts
+++ b/apps/website/src/templates/platform/ServerlessDeploySection.test.ts
@@ -6,8 +6,10 @@ import { describe, expect, it } from 'vitest'
 import { t } from '../../i18n/translations'
 import ServerlessDeploySection from './ServerlessDeploySection.vue'
 
-const transcriptLines = () =>
-  (screen.getByRole('tabpanel').textContent ?? '').split('\n')
+const commandLines = () =>
+  (screen.getByRole('tabpanel').textContent ?? '')
+    .split('\n')
+    .filter((line) => line.startsWith('$ '))
 
 describe('ServerlessDeploySection', () => {
   it('walks through the install flow first and the workflow flow on demand', async () => {
@@ -24,13 +26,10 @@ describe('ServerlessDeploySection', () => {
         /Easily package up your existing ComfyUI environment or a single workflow,\s+then deploy it to Comfy API\./
       )
     ).toBeTruthy()
-    expect(transcriptLines()).toEqual([
+    expect(commandLines()).toEqual([
       '$ comfy build init',
-      '✔ Scanned this ComfyUI install — custom nodes, models, pinned deps',
       '$ comfy build push --release --target linux/nvidia',
-      '✔ Build released',
-      '$ comfy deploy up',
-      '✔ Endpoint live → https://your-build.run.comfy.app'
+      '$ comfy deploy up'
     ])
 
     await userEvent.click(
@@ -39,13 +38,10 @@ describe('ServerlessDeploySection', () => {
       })
     )
 
-    expect(transcriptLines()).toEqual([
+    expect(commandLines()).toEqual([
       '$ comfy build init --from-workflow ./workflow.json --comfy-version v0.34.2',
-      '✔ Custom nodes and models resolved from your workflow',
       '$ comfy build push --release --target linux/nvidia',
-      '✔ Build released',
-      '$ comfy deploy up',
-      '✔ Endpoint live → https://your-build.run.comfy.app'
+      '$ comfy deploy up'
     ])
   })
 })

--- a/apps/website/src/templates/platform/ServerlessDeploySection.test.ts
+++ b/apps/website/src/templates/platform/ServerlessDeploySection.test.ts
@@ -7,7 +7,7 @@ import { t } from '../../i18n/translations'
 import ServerlessDeploySection from './ServerlessDeploySection.vue'
 
 describe('ServerlessDeploySection', () => {
-  it('walks through the snapshot flow first and the workflow flow on demand', async () => {
+  it('walks through the install flow first and the workflow flow on demand', async () => {
     render(ServerlessDeploySection, { props: { locale: 'en' } })
 
     expect(
@@ -21,7 +21,7 @@ describe('ServerlessDeploySection', () => {
         /Easily package up your existing ComfyUI environment or a single workflow,\s+then deploy it to Comfy API\./
       )
     ).toBeTruthy()
-    expect(screen.getByText(/comfy build init --from-snapshot/)).toBeTruthy()
+    expect(screen.getByText(/Scanned this ComfyUI install/)).toBeTruthy()
 
     await userEvent.click(
       screen.getByRole('tab', {

--- a/apps/website/src/templates/platform/ServerlessDeploySection.vue
+++ b/apps/website/src/templates/platform/ServerlessDeploySection.vue
@@ -62,6 +62,7 @@ $ comfy deploy up
         :label="t('platform.serverlessDeploy.heading', locale)"
         content-class="bg-[#2a2230]"
         list-class="mx-auto sm:flex sm:w-fit"
+        trigger-class="px-2"
       />
     </div>
   </section>

--- a/apps/website/src/templates/platform/ServerlessDeploySection.vue
+++ b/apps/website/src/templates/platform/ServerlessDeploySection.vue
@@ -8,8 +8,8 @@ import CodeTabs from './CodeTabs.vue'
 const { locale = 'en' } = defineProps<{ locale?: Locale }>()
 
 // Command surface from comfy-cli's build + deploy stack (PRs #801-805):
-// `comfy build init --from-snapshot/--from-workflow`, `build push`, and
-// `deploy up`, which defaults to the current directory.
+// `comfy build init` (or `--from-workflow`), `build push --release`, and
+// `deploy up`. `init` and `up` both default to the current directory.
 function terminalSegments(transcript: string): CodeTab['segments'] {
   const lines = transcript.split('\n')
   return lines.flatMap((line, index) => [
@@ -21,9 +21,9 @@ function terminalSegments(transcript: string): CodeTab['segments'] {
 const deployTabs: Record<string, CodeTab> = {
   install: {
     name: t('platform.serverlessDeploy.tabInstall', locale),
-    segments: terminalSegments(`$ comfy build init --from-snapshot
-✔ Imported your install — custom nodes, models, pinned deps
-$ comfy build push
+    segments: terminalSegments(`$ comfy build init
+✔ Scanned this ComfyUI install — custom nodes, models, pinned deps
+$ comfy build push --release
 ✔ Build released
 $ comfy deploy up
 ✔ Endpoint live → https://your-build.run.comfy.app`)
@@ -33,7 +33,7 @@ $ comfy deploy up
     segments:
       terminalSegments(`$ comfy build init --from-workflow ./workflow.json
 ✔ Custom nodes and models resolved from your workflow
-$ comfy build push
+$ comfy build push --release
 ✔ Build released
 $ comfy deploy up
 ✔ Endpoint live → https://your-build.run.comfy.app`)

--- a/apps/website/src/templates/platform/ServerlessDeploySection.vue
+++ b/apps/website/src/templates/platform/ServerlessDeploySection.vue
@@ -8,9 +8,10 @@ import CodeTabs from './CodeTabs.vue'
 const { locale = 'en' } = defineProps<{ locale?: Locale }>()
 
 // Command surface from comfy-cli's build + deploy stack (PRs #801-805):
-// `comfy build init` (or `--from-workflow`), `build push --release`, whose
-// `--target` decides whether `deploy up` finds a deployable artifact, and
-// `deploy up`. All three default to the current directory.
+// `comfy build init` (or `--from-workflow`, which resolves no ComfyUI version
+// and so needs `--comfy-version` before a release can be cut), `build push
+// --release`, whose `--target` decides whether `deploy up` finds a deployable
+// artifact, and `deploy up`. All three default to the current directory.
 function terminalSegments(transcript: string): CodeTab['segments'] {
   const lines = transcript.split('\n')
   return lines.flatMap((line, index) => [
@@ -32,7 +33,7 @@ $ comfy deploy up
   workflow: {
     name: t('platform.serverlessDeploy.tabWorkflow', locale),
     segments:
-      terminalSegments(`$ comfy build init --from-workflow ./workflow.json
+      terminalSegments(`$ comfy build init --from-workflow ./workflow.json --comfy-version v0.34.2
 ✔ Custom nodes and models resolved from your workflow
 $ comfy build push --release --target linux/nvidia
 ✔ Build released

--- a/apps/website/src/templates/platform/ServerlessDeploySection.vue
+++ b/apps/website/src/templates/platform/ServerlessDeploySection.vue
@@ -8,7 +8,8 @@ import CodeTabs from './CodeTabs.vue'
 const { locale = 'en' } = defineProps<{ locale?: Locale }>()
 
 // Command surface from comfy-cli's build + deploy stack (PRs #801-805):
-// `comfy build init` (or `--from-workflow`), `build push --release`, and
+// `comfy build init` (or `--from-workflow`), `build push --release`, whose
+// `--target` decides whether `deploy up` finds a deployable artifact, and
 // `deploy up`. `init` and `up` both default to the current directory.
 function terminalSegments(transcript: string): CodeTab['segments'] {
   const lines = transcript.split('\n')
@@ -23,7 +24,7 @@ const deployTabs: Record<string, CodeTab> = {
     name: t('platform.serverlessDeploy.tabInstall', locale),
     segments: terminalSegments(`$ comfy build init
 ✔ Scanned this ComfyUI install — custom nodes, models, pinned deps
-$ comfy build push --release
+$ comfy build push --release --target linux/nvidia
 ✔ Build released
 $ comfy deploy up
 ✔ Endpoint live → https://your-build.run.comfy.app`)
@@ -33,7 +34,7 @@ $ comfy deploy up
     segments:
       terminalSegments(`$ comfy build init --from-workflow ./workflow.json
 ✔ Custom nodes and models resolved from your workflow
-$ comfy build push --release
+$ comfy build push --release --target linux/nvidia
 ✔ Build released
 $ comfy deploy up
 ✔ Endpoint live → https://your-build.run.comfy.app`)

--- a/apps/website/src/templates/platform/ServerlessDeploySection.vue
+++ b/apps/website/src/templates/platform/ServerlessDeploySection.vue
@@ -10,7 +10,7 @@ const { locale = 'en' } = defineProps<{ locale?: Locale }>()
 // Command surface from comfy-cli's build + deploy stack (PRs #801-805):
 // `comfy build init` (or `--from-workflow`), `build push --release`, whose
 // `--target` decides whether `deploy up` finds a deployable artifact, and
-// `deploy up`. `init` and `up` both default to the current directory.
+// `deploy up`. All three default to the current directory.
 function terminalSegments(transcript: string): CodeTab['segments'] {
   const lines = transcript.split('\n')
   return lines.flatMap((line, index) => [


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

The "Ship in minutes" transcript on `/platform/comfy-api` showed commands that don't work as written. Reported by a user who noticed the flags looked out of date.

Every command below was verified against the current comfy-cli (`Comfy-Org/comfy-cli@3fddc3e`), by reading the Typer definitions and by running the CLI. Only the command lines changed — the simulated `✔` output is untouched apart from the one line noted.

## What was wrong

**`comfy build init --from-snapshot`** — `--from-snapshot` takes a value (a Desktop snapshot JSON path), so the bare flag is a parse error:

```
$ comfy build init --from-snapshot
Error: Option '--from-snapshot' requires an argument.
```

It was also the wrong command for this tab. `--from-snapshot` imports a Desktop snapshot, whereas the tab is "Start with your environment" and the subtitle promises to "package up your existing ComfyUI environment". Plain `comfy build init` is the one that does that — it scans the ComfyUI install in the current directory, which is also what its help text says ("Scan a local ComfyUI install and write a comfy-build spec"). Verified end-to-end against a local install: it picks up models, custom nodes, the ComfyUI version, and pinned pip deps, and exits 0.

Since the command changed, that tab's `✔` line was reworded to match (the only output line touched).

**`comfy build push`** — releases nothing. Release-cutting is gated behind `--release`, so the `✔ Build released` line was simply false, and `comfy deploy up` on the next line could never succeed: it only resolves releases the builder marks `deployable`, and there were none.

**`--target` had to come with it.** It's documented "required with `--release`", and it is not a throwaway choice — `deployable` specifically means a `linux/nvidia` artifact, so picking anything else strands the very next line of the transcript.

**The workflow tab needed a ComfyUI version.** A workflow import resolves no `baseComfyVersion`, and the CLI's own Path B notes say to set one *before* cutting a release — so once `--release` is on that tab, `--comfy-version` is required too. The install tab needs nothing, because a local scan detects the version itself.

## Result

```diff
-$ comfy build init --from-snapshot
-✔ Imported your install — custom nodes, models, pinned deps
-$ comfy build push
+$ comfy build init
+✔ Scanned this ComfyUI install — custom nodes, models, pinned deps
+$ comfy build push --release --target linux/nvidia
 ✔ Build released
 $ comfy deploy up
 ✔ Endpoint live → https://your-build.run.comfy.app
```

```diff
-$ comfy build init --from-workflow ./workflow.json
+$ comfy build init --from-workflow ./workflow.json --comfy-version v0.34.2
 ✔ Custom nodes and models resolved from your workflow
-$ comfy build push
+$ comfy build push --release --target linux/nvidia
```

`comfy deploy up` was already correct and is unchanged — its path argument defaults to the current directory.

Options the CLI merely *prompts* for were deliberately left out, so the snippet stays short: `--name` on `init`, and `--gpu`/`--region` on `deploy up`. `--target` and `--comfy-version` are in despite also being omittable, because omitting either breaks a later line of the same transcript.

## Tests

The test asserted the transcript through `getByText`, which only sees direct text nodes — so it silently dropped the `$`/`✔` sigils that render in child spans and matched a string no user ever sees. It now reads the panel's `textContent`, letting each assertion quote its line verbatim, and it covers the workflow tab's push line and both `deploy up` lines, none of which were pinned before. Confirmed non-vacuous by reverting each command and watching it fail.

## Verification

`pnpm test:unit` (137 files / 887 tests), `pnpm typecheck`, `pnpm lint` (0 errors), `pnpm format:check`, and `pnpm build` all pass. Both tabs rendered and screenshotted at desktop and mobile.

## One known limitation

The longer lines wrap on narrow phones, and `CodeTabs` reserves panel height from newline count only (`codePanelHeight` can't see soft wraps), so the workflow tab's last line clips below ~414px — at 320px the `✔ Endpoint live` line is scrolled out entirely. The panel is `overflow-auto` so it's still reachable, and the clipped text is a placeholder URL, but this is a real if minor regression: the same tab already overflowed by 20px on `main`, and this takes it to 38–56px.

There's no fix inside this change — the commands can't be shortened without becoming wrong again. Fixing it properly means making `codePanelHeight` wrap-aware (or dropping the mobile `*0.9`) in `CodeTabs`, which also affects `/platform` and `ModelsApiHero` — the `/platform` cURL tab is already the worse offender on `main`. Happy to do that as a follow-up if you'd like it bundled.

## Follow-up worth filing

The workflow tab's `✔ Custom nodes and models resolved from your workflow` is wrong in the same way this PR is fixing: per `--from-workflow`'s help, "A workflow names no model sources, so the spec starts with none". Models are *not* resolved. Left alone here because output lines were out of scope.

## Screenshots

![Start with your environment tab: comfy build init, then comfy build push --release --target linux/nvidia, then comfy deploy up](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/4f61338440260dfefa3ca74f7522539e/pr-comment-images/1788331479097-1a2277e2-70fc-430a-938e-f81550b1258c.png)

![Start with your workflow tab: comfy build init --from-workflow ./workflow.json --comfy-version v0.34.2, then comfy build push --release --target linux/nvidia, then comfy deploy up](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/4f61338440260dfefa3ca74f7522539e/pr-comment-images/1788331479479-7a80cae8-c7f3-4da0-a2d3-93732ece3997.png)

![Install tab at 375px mobile width](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/4f61338440260dfefa3ca74f7522539e/pr-comment-images/1788331479832-4d58d194-8eea-4fa5-b9ab-ca602c0b1c08.png)