### PR TITLE
Assets followup fixes

### DIFF
--- a/src/platform/assets/composables/media/assetMappers.test.ts
+++ b/src/platform/assets/composables/media/assetMappers.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it, vi } from 'vitest'
 
-import { mapInputFileToAssetItem } from './assetMappers'
+import { getOutputAssetMetadata } from '@/platform/assets/schemas/assetMetadataSchema'
+import type { AssetItem } from '@/platform/assets/schemas/assetSchema'
+
+import { mapInputFileToAssetItem, unflattenOutputAssets } from './assetMappers'
 
 vi.mock('@/scripts/api', () => ({
   api: {
@@ -54,5 +57,40 @@ describe('mapInputFileToAssetItem', () => {
 
     expect(asset.preview_url).toBe('/api/view?filename=clip.mp4&type=output')
     expect(asset.tags).toEqual(['output'])
+  })
+})
+
+describe('unflattenOutputAssets', () => {
+  it('preserves each output directory type', () => {
+    const asset = {
+      job_id: 'job-id',
+      size: 1,
+      created_at: '2026-01-01T00:00:00Z',
+      updated_at: '2026-01-01T00:00:00Z'
+    }
+    const assets = [
+      {
+        ...asset,
+        id: 'temp-id',
+        name: 'preview.png',
+        tags: ['temp']
+      },
+      {
+        ...asset,
+        id: 'output-id',
+        name: 'saved.png',
+        created_at: '2026-01-01T00:00:01Z',
+        updated_at: '2026-01-01T00:00:01Z',
+        tags: ['output']
+      }
+    ] satisfies AssetItem[]
+
+    const [grouped] = unflattenOutputAssets(assets)
+    const metadata = getOutputAssetMetadata(grouped.user_metadata)
+
+    expect(metadata?.allOutputs?.map((output) => output.type)).toEqual([
+      'temp',
+      'output'
+    ])
   })
 })

--- a/src/platform/assets/composables/media/assetMappers.ts
+++ b/src/platform/assets/composables/media/assetMappers.ts
@@ -98,7 +98,7 @@ function flatAssetToResultItem(asset: AssetItem): ResultItemImpl {
     mediaType: getMediaTypeFromFilename(asset.name),
     nodeId: metadata?.nodeId ?? '',
     subfolder: metadata?.subfolder ?? '',
-    type: 'output'
+    type: asset.tags.includes('temp') ? 'temp' : 'output'
   })
 }
 

--- a/src/renderer/extensions/linearMode/OutputHistory.vue
+++ b/src/renderer/extensions/linearMode/OutputHistory.vue
@@ -219,7 +219,7 @@ watch(
   }
 )
 
-useInfiniteScroll(outputsRef, outputs.loadMore, {
+useInfiniteScroll(outputsRef, () => outputs.loadMore(), {
   canLoadMore: () => toValue(outputs.hasMore)
 })
 

--- a/src/renderer/extensions/linearMode/useOutputHistory.ts
+++ b/src/renderer/extensions/linearMode/useOutputHistory.ts
@@ -9,7 +9,7 @@ import { flattenNodeOutput } from '@/renderer/extensions/linearMode/flattenNodeO
 import { useLinearOutputStore } from '@/renderer/extensions/linearMode/linearOutputStore'
 import { api } from '@/scripts/api'
 import { getJobDetail } from '@/services/jobOutputCache'
-import { wrapPagedList } from '@/utils/pagedList'
+import { WrappedList } from '@/utils/pagedList'
 import type { PagedList } from '@/utils/pagedList'
 import { useAssetsStore } from '@/stores/assetsStore'
 import { useAppModeStore } from '@/stores/appModeStore'
@@ -69,7 +69,7 @@ export function useOutputHistory(): {
     )
   }
 
-  const outputs = wrapPagedList(assetsStore.outputAssets, (items) => {
+  const outputs = new WrappedList(assetsStore.outputAssets, (items) => {
     const path = workflowStore.activeWorkflow?.path
     if (!path) return []
 

--- a/src/stores/assetsStore.ts
+++ b/src/stores/assetsStore.ts
@@ -31,7 +31,7 @@ import { assetService } from '@/platform/assets/services/assetService'
 import type { AssetPaginationOptions } from '@/platform/assets/services/assetService'
 import type { JobListItem } from '@/platform/remote/comfyui/jobs/jobTypes'
 import { api } from '@/scripts/api'
-import { wrapPagedList } from '@/utils/pagedList'
+import { WrappedList } from '@/utils/pagedList'
 import type { PagedList } from '@/utils/pagedList'
 
 import { TaskItemImpl } from './queueStore'
@@ -296,7 +296,10 @@ export const useAssetsStore = defineStore('assets', () => {
         assetsScope.run(() => {
           inputAssets.value = useAssetsQuery({ tags_any: ['input'] })
           const flatAssets = useAssetsQuery({ tags_any: ['output', 'temp'] })
-          outputAssets.value = wrapPagedList(flatAssets, unflattenOutputAssets)
+          outputAssets.value = new WrappedList(
+            flatAssets,
+            unflattenOutputAssets
+          )
         })
       } else {
         inputAssets.value = historyInputs

--- a/src/utils/pagedList.test.ts
+++ b/src/utils/pagedList.test.ts
@@ -3,7 +3,7 @@ import { computed, effectScope, ref, shallowRef, toValue } from 'vue'
 import type { Ref } from 'vue'
 
 import type { PagedList, SharedPagedListState } from './pagedList'
-import { getPagedList, usePreemptableQueue } from './pagedList'
+import { getPagedList, usePreemptableQueue, WrappedList } from './pagedList'
 
 function mockPagedList<T>(initial: T[] = [], genNew?: () => T): PagedList<T> {
   const items: Ref<T[]> = shallowRef(initial)
@@ -32,6 +32,47 @@ function makeShared<TParams, TItem>(
   }
   return (params: TParams) => getPagedList(params, state)
 }
+
+describe('WrappedList', () => {
+  it('transforms items and delegates stateful operations', async () => {
+    const child = {
+      isLoading: ref(false),
+      items: ref([1, 2]),
+      get hasMore() {
+        return this.items.value.length < 3
+      },
+      async invalidate(stale?: string[]) {
+        this.items.value = this.items.value.filter(
+          (item) => !stale?.includes(String(item))
+        )
+      },
+      async loadMore() {
+        this.items.value.push(3)
+      },
+      async loadNew() {
+        this.items.value.unshift(0)
+      }
+    }
+
+    const list = new WrappedList(child, (items) =>
+      items.map((item) => item * 2)
+    )
+
+    expect(toValue(list.items)).toEqual([2, 4])
+    expect(toValue(list.hasMore)).toBe(true)
+    expect(toValue(list.isLoading)).toBe(false)
+
+    await list.loadMore()
+    expect(toValue(list.items)).toEqual([2, 4, 6])
+    expect(toValue(list.hasMore)).toBe(false)
+
+    await list.loadNew()
+    expect(toValue(list.items)).toEqual([0, 2, 4, 6])
+
+    await list.invalidate(['2'])
+    expect(toValue(list.items)).toEqual([0, 2, 6])
+  })
+})
 
 describe('getPagedList', () => {
   it('same params share reactive state', async () => {

--- a/src/utils/pagedList.ts
+++ b/src/utils/pagedList.ts
@@ -21,8 +21,8 @@ export class WrappedList<T> implements PagedList<T> {
   get hasMore() {
     return this.childList.hasMore
   }
-  async invalidate() {
-    await this.childList.invalidate()
+  async invalidate(stale?: string[]) {
+    await this.childList.invalidate(stale)
   }
   get isLoading() {
     return this.childList.isLoading

--- a/src/utils/pagedList.ts
+++ b/src/utils/pagedList.ts
@@ -99,8 +99,8 @@ class SharedPagedList<T> implements PagedList<T> {
   get items() {
     return this.childList.items
   }
-  get loadMore() {
-    return this.childList.loadMore
+  async loadMore() {
+    await this.childList.loadMore()
   }
   async loadNew() {
     await Promise.all(this.overlapping().map((l) => l.loadNew()))

--- a/src/utils/pagedList.ts
+++ b/src/utils/pagedList.ts
@@ -10,11 +10,29 @@ export interface PagedList<T> {
   loadNew: () => Promise<void>
 }
 
-export function wrapPagedList<T>(
-  list: PagedList<T>,
-  transform: (items: readonly T[]) => T[]
-): PagedList<T> {
-  return { ...list, items: computed(() => transform(toValue(list.items))) }
+export class WrappedList<T> implements PagedList<T> {
+  readonly items: MaybeRef<T[]>
+  constructor(
+    private readonly childList: PagedList<T>,
+    private readonly transform: (items: readonly T[]) => T[]
+  ) {
+    this.items = computed(() => this.transform(toValue(this.childList.items)))
+  }
+  get hasMore() {
+    return this.childList.hasMore
+  }
+  async invalidate() {
+    await this.childList.invalidate()
+  }
+  get isLoading() {
+    return this.childList.isLoading
+  }
+  async loadMore() {
+    await this.childList.loadMore()
+  }
+  async loadNew() {
+    await this.childList.loadNew()
+  }
 }
 
 interface CacheEntry<T> {


### PR DESCRIPTION
A couple of small high priority follow-ups to #15381
- Conditionally update type when `temp` is included as a tag on an asset.
- Removed spreads which break getters
- Fix several instances of where migrating `PagedList` was broken by calls dropped the `this` binding