### PR TITLE
test(e2e): extract command execution tracker

### DIFF
--- a/browser_tests/fixtures/helpers/CommandHelper.ts
+++ b/browser_tests/fixtures/helpers/CommandHelper.ts
@@ -6,6 +6,28 @@ import { nextFrame } from '@e2e/fixtures/utils/timing'
 export class CommandHelper {
   constructor(private readonly page: Page) {}
 
+  async mockCommand(commandId: string): Promise<void> {
+    await this.page.evaluate((commandId) => {
+      const command = window.app?.extensionManager.command.commands.find(
+        ({ id }) => id === commandId
+      )
+      if (!command) throw new Error(`Command not found: ${commandId}`)
+
+      const executionCounts = (window.__commandExecutionCounts ??= {})
+      executionCounts[commandId] = 0
+      command.function = () => {
+        executionCounts[commandId] = (executionCounts[commandId] ?? 0) + 1
+      }
+    }, commandId)
+  }
+
+  async getExecutionCount(commandId: string): Promise<number> {
+    return await this.page.evaluate(
+      (commandId) => window.__commandExecutionCounts?.[commandId] ?? 0,
+      commandId
+    )
+  }
+
   async executeCommand(
     commandId: string,
     metadata?: Record<string, unknown>

--- a/browser_tests/tests/defaultKeybindings.spec.ts
+++ b/browser_tests/tests/defaultKeybindings.spec.ts
@@ -246,6 +246,8 @@ test.describe('Default Keybindings', { tag: '@keyboard' }, () => {
         await comfyPage.keyboard.press('Control+s')
         await expect(comfyPage.page.getByRole('dialog')).toBeVisible()
 
+        await comfyPage.command.mockCommand('Comfy.SaveWorkflow')
+
         await comfyPage.page.evaluate(() => {
           window.TestCommand = false
           window.addEventListener('keydown', (event: KeyboardEvent) => {
@@ -258,6 +260,9 @@ test.describe('Default Keybindings', { tag: '@keyboard' }, () => {
         await expect
           .poll(() => comfyPage.page.evaluate(() => window.TestCommand))
           .toBe(true)
+        expect(
+          await comfyPage.command.getExecutionCount('Comfy.SaveWorkflow')
+        ).toBe(0)
 
         await comfyPage.keyboard.press('Escape')
       })

--- a/browser_tests/types/globals.d.ts
+++ b/browser_tests/types/globals.d.ts
@@ -37,6 +37,7 @@ declare global {
     TestCommand?: boolean
     changeCount?: number
     widgetValue?: unknown
+    __commandExecutionCounts?: Record<string, number>
 
     // Feature flags test globals
     __capturedMessages?: CapturedMessages


### PR DESCRIPTION
## Summary

Moves browser-test command interception and execution counting into `CommandHelper`, preserving the blocked-save assertion from #16594 without test-local command mutation.

## Changes

- **What**: Adds reusable `mockCommand` and `getExecutionCount` helpers and applies them to the save-shortcut dialog regression.
- **Dependencies**: Follow-up to #16594 and DrJKL's [review thread](https://github.com/Comfy-Org/ComfyUI_frontend/pull/16594#discussion_r3911103546). Both PRs are independently based on `main`; whichever lands second should retain this helper-backed form.

## Review Focus

`mockCommand` deliberately replaces the command function so tests can detect attempted execution without triggering the command's production side effects.

## Verification

- `pnpm typecheck`
- `pnpm typecheck:browser`
- changed-file ESLint, Oxlint, and Oxfmt
- headless Playwright runtime probe for `CommandHelper` replacement/counting
- targeted `defaultKeybindings.spec.ts` run attempted against testcloud; blocked before test execution because the setup endpoint returned `UNAUTHORIZED`