### PR TITLE
fix(agent-crdt): scope persisted docId to page session + expiry (FEC-5)

### DIFF
--- a/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.test.ts
+++ b/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.test.ts
@@ -327,6 +327,60 @@ describe('useAgentCrdtFollower', () => {
     unmount()
   })
 
+  it('FEC-5: a refused legacy record is dropped by the first unbound mount', () => {
+    sessionStorage.setItem(DOC_ID_KEY, 'wf-legacy')
+
+    const { unmount } = mountFollower(null)
+
+    expect(sessionStorage.getItem(DOC_ID_KEY)).toBeNull()
+    unmount()
+  })
+
+  it('FEC-5: live doc traffic slides the persisted expiry', () => {
+    vi.useFakeTimers()
+    const setup = mountFollower('wf-1')
+    dispatchFrame('doc_subscribed', { ok: true })
+    const stampedAt = persistedRecord()?.expiresAt
+    expect(stampedAt).toBeTypeOf('number')
+
+    // Six minutes of steady updates: past the 5-minute TTL, but the channel is
+    // healthy so the stale probe never fires and nothing resubscribes.
+    for (let seq = 1; seq <= 18; seq++) {
+      vi.advanceTimersByTime(20_000)
+      dispatchFrame('doc_update', {
+        workflowId: 'wf-1',
+        seq,
+        actor: 'agent',
+        update: new Uint8Array()
+      })
+    }
+    expect(bridge().resubscribe).not.toHaveBeenCalled()
+    expect(persistedRecord()?.expiresAt).toBeGreaterThan(stampedAt ?? 0)
+    setup.unmount()
+    bridgeState.current = null
+
+    const { unmount, status } = mountFollower(null)
+
+    expect(bridge().subscribe).toHaveBeenCalledWith('wf-1')
+    expect(status().workflowId).toBe('wf-1')
+    unmount()
+  })
+
+  it('FEC-5: an idle doc still expires', () => {
+    vi.useFakeTimers()
+    const setup = mountFollower('wf-1')
+    dispatchFrame('doc_subscribed', { ok: true })
+    setup.unmount()
+    bridgeState.current = null
+
+    vi.advanceTimersByTime(5 * 60 * 1000)
+    const { unmount, status } = mountFollower(null)
+
+    expect(bridge().subscribe).not.toHaveBeenCalled()
+    expect(status().workflowId).toBeNull()
+    unmount()
+  })
+
   it('retains the follower and resubscribes on a socket reconnect', () => {
     const { unmount, status } = mountFollower('wf-1')
     dispatchFrame('doc_subscribed', { ok: true })

--- a/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.test.ts
+++ b/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.test.ts
@@ -108,6 +108,32 @@ import { STALE_AFTER_MS, useAgentCrdtFollower } from './useAgentCrdtFollower'
 import type { AgentCrdtStatus } from './useAgentCrdtFollower'
 
 const graphMutations = {} as GraphMutations
+const DOC_ID_KEY = 'Comfy.Agent.CrdtDocId'
+
+function persistedRecord(): {
+  docId: string
+  nonce: string
+  expiresAt: number
+} | null {
+  const raw = sessionStorage.getItem(DOC_ID_KEY)
+  return raw ? JSON.parse(raw) : null
+}
+
+function writeRawRecord(overrides: {
+  docId: string
+  nonce?: string
+  expiresAt?: number
+}): void {
+  const base = persistedRecord()
+  sessionStorage.setItem(
+    DOC_ID_KEY,
+    JSON.stringify({
+      docId: overrides.docId,
+      nonce: overrides.nonce ?? base?.nonce ?? 'foreign-nonce',
+      expiresAt: overrides.expiresAt ?? Date.now() + 60_000
+    })
+  )
+}
 
 function mountFollower(
   initial: string | null = null,
@@ -222,35 +248,82 @@ describe('useAgentCrdtFollower', () => {
 
   it('FE-1902: persists a binding only once the server confirms it', () => {
     const { unmount } = mountFollower('wf-1')
-    expect(sessionStorage.getItem('Comfy.Agent.CrdtDocId')).toBeNull()
+    expect(persistedRecord()).toBeNull()
 
     dispatchFrame('doc_subscribed', { ok: true })
 
-    expect(sessionStorage.getItem('Comfy.Agent.CrdtDocId')).toBe('wf-1')
+    expect(persistedRecord()?.docId).toBe('wf-1')
     unmount()
   })
 
   it('FE-1902: a remount with no in-memory binding rebinds from sessionStorage', () => {
-    sessionStorage.setItem('Comfy.Agent.CrdtDocId', 'wf-persisted')
+    const setup = mountFollower('wf-1')
+    dispatchFrame('doc_subscribed', { ok: true })
+    setup.unmount()
+    bridgeState.current = null
 
     const { unmount, status } = mountFollower(null)
 
-    expect(bridge().subscribe).toHaveBeenCalledWith('wf-persisted')
-    expect(status().workflowId).toBe('wf-persisted')
+    expect(bridge().subscribe).toHaveBeenCalledWith('wf-1')
+    expect(status().workflowId).toBe('wf-1')
     unmount()
   })
 
   it('FE-1902: a real detach clears the persisted binding and unsubscribes', async () => {
     const { unmount, workflowId } = mountFollower('wf-1')
     dispatchFrame('doc_subscribed', { ok: true })
-    expect(sessionStorage.getItem('Comfy.Agent.CrdtDocId')).toBe('wf-1')
+    expect(persistedRecord()?.docId).toBe('wf-1')
 
     workflowId.value = null
     await Promise.resolve()
     await Promise.resolve()
 
-    expect(sessionStorage.getItem('Comfy.Agent.CrdtDocId')).toBeNull()
+    expect(persistedRecord()).toBeNull()
     expect(bridge().unsubscribe).toHaveBeenCalled()
+    unmount()
+  })
+
+  it('FEC-5: refuses a record from a different page session (e.g. a duplicated tab)', () => {
+    const setup = mountFollower('wf-1')
+    dispatchFrame('doc_subscribed', { ok: true })
+    setup.unmount()
+    bridgeState.current = null
+    // Simulate sessionStorage cloned into a fresh tab: same docId, foreign nonce.
+    writeRawRecord({ docId: 'wf-1', nonce: 'a-different-page-session' })
+
+    const { unmount, status } = mountFollower(null)
+
+    expect(bridge().subscribe).not.toHaveBeenCalled()
+    expect(status().workflowId).toBeNull()
+    unmount()
+  })
+
+  it('FEC-5: refuses an expired record', () => {
+    const setup = mountFollower('wf-1')
+    dispatchFrame('doc_subscribed', { ok: true })
+    setup.unmount()
+    bridgeState.current = null
+    const record = persistedRecord()
+    writeRawRecord({
+      docId: 'wf-1',
+      nonce: record?.nonce,
+      expiresAt: Date.now() - 1
+    })
+
+    const { unmount, status } = mountFollower(null)
+
+    expect(bridge().subscribe).not.toHaveBeenCalled()
+    expect(status().workflowId).toBeNull()
+    unmount()
+  })
+
+  it('FEC-5: refuses a legacy bare-string record', () => {
+    sessionStorage.setItem(DOC_ID_KEY, 'wf-legacy')
+
+    const { unmount, status } = mountFollower(null)
+
+    expect(bridge().subscribe).not.toHaveBeenCalled()
+    expect(status().workflowId).toBeNull()
     unmount()
   })
 

--- a/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.ts
+++ b/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.ts
@@ -18,7 +18,35 @@ import { createOpSender } from './opSender'
 // FE-1902: the doc id is otherwise held only in memory (set on turn ack), so a
 // panel remount / page reload loses the binding until the NEXT turn ack.
 // Persist it per-tab in sessionStorage so a remount can rebind immediately.
+//
+// FEC-5: a bare `docId` string has no owner and no lifetime, so it survives
+// (a) a workflow switch in the same browser tab - the NEXT panel mount rebinds
+// to whichever workflow last confirmed a subscribe, not necessarily the one
+// about to become active - and (b) a browser-tab duplication, which clones
+// sessionStorage verbatim into a second tab that never subscribed to that doc
+// at all. Neither case can be caught by re-checking `workflowId`, because the
+// whole reason a rebind is attempted is that the caller does NOT yet know
+// which workflow it's asking about. Instead the persisted record carries (1)
+// a per-page-load session nonce, so a value only ever rebinds within the
+// SAME top-level navigation that wrote it - a duplicated tab gets a fresh
+// nonce and its inherited record is refused - and (2) a short expiry, so a
+// tab left open past the window a doc realistically stays relevant is
+// refused rather than trusted indefinitely.
 const DOC_ID_SESSION_KEY = 'Comfy.Agent.CrdtDocId'
+const DOC_ID_TTL_MS = 5 * 60 * 1000
+
+// One nonce per page load (module scope = one per top-level navigation, since
+// a full reload re-evaluates the module). A tab duplicated mid-session
+// inherits sessionStorage's persisted record but gets its own module
+// instance and thus its own nonce, so the inherited record's nonce mismatches
+// and is refused.
+const pageSessionNonce = createUuidv4()
+
+interface PersistedDocIdRecord {
+  docId: string
+  nonce: string
+  expiresAt: number
+}
 
 function safeSessionStorage(): Storage | null {
   try {
@@ -28,17 +56,38 @@ function safeSessionStorage(): Storage | null {
   }
 }
 
-function persistDocId(id: string): void {
+function persistDocId(docId: string): void {
   try {
-    safeSessionStorage()?.setItem(DOC_ID_SESSION_KEY, id)
+    const record: PersistedDocIdRecord = {
+      docId,
+      nonce: pageSessionNonce,
+      expiresAt: Date.now() + DOC_ID_TTL_MS
+    }
+    safeSessionStorage()?.setItem(DOC_ID_SESSION_KEY, JSON.stringify(record))
   } catch {
     // Quota / privacy mode: persistence is best-effort.
   }
 }
 
+// Returns the persisted doc id ONLY when it was written by this same page
+// load and has not expired.
 function readPersistedDocId(): string | null {
   try {
-    return safeSessionStorage()?.getItem(DOC_ID_SESSION_KEY) ?? null
+    const raw = safeSessionStorage()?.getItem(DOC_ID_SESSION_KEY)
+    if (!raw) return null
+    const record = JSON.parse(raw) as Partial<PersistedDocIdRecord>
+    if (
+      typeof record.docId !== 'string' ||
+      typeof record.nonce !== 'string' ||
+      typeof record.expiresAt !== 'number'
+    ) {
+      // Legacy/malformed record (e.g. pre-FEC-5 bare-string value): treat as
+      // absent rather than trusting an unscoped id.
+      return null
+    }
+    if (record.nonce !== pageSessionNonce) return null
+    if (Date.now() >= record.expiresAt) return null
+    return record.docId
   } catch {
     return null
   }

--- a/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.ts
+++ b/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.ts
@@ -16,8 +16,10 @@ import type { OpsResultView } from './opSender'
 import { createOpSender } from './opSender'
 
 // FE-1902: the doc id is otherwise held only in memory (set on turn ack), so a
-// panel remount / page reload loses the binding until the NEXT turn ack.
-// Persist it per-tab in sessionStorage so a remount can rebind immediately.
+// panel remount loses the binding until the NEXT turn ack. Persist it per-tab
+// in sessionStorage so an in-page remount can rebind immediately. A full page
+// reload deliberately does NOT rebind (see the nonce below): it mints a new
+// nonce, refuses the pre-reload record, and waits for the next turn ack.
 //
 // FEC-5: a bare `docId` string has no owner and no lifetime, so it survives
 // (a) a workflow switch in the same browser tab - the NEXT panel mount rebinds
@@ -29,11 +31,17 @@ import { createOpSender } from './opSender'
 // which workflow it's asking about. Instead the persisted record carries (1)
 // a per-page-load session nonce, so a value only ever rebinds within the
 // SAME top-level navigation that wrote it - a duplicated tab gets a fresh
-// nonce and its inherited record is refused - and (2) a short expiry, so a
-// tab left open past the window a doc realistically stays relevant is
-// refused rather than trusted indefinitely.
+// nonce and its inherited record is refused - and (2) a short expiry that
+// slides while the doc keeps delivering frames, so a tab left idle past the
+// window a doc realistically stays relevant is refused rather than trusted
+// indefinitely. (1) closes case (b). Case (a) happens inside one page load,
+// so the nonce cannot see it; it is only BOUNDED by (2), not closed. The
+// `fec-docid-1` reproducer tracks the remaining same-tab window.
 const DOC_ID_SESSION_KEY = 'Comfy.Agent.CrdtDocId'
 const DOC_ID_TTL_MS = 5 * 60 * 1000
+// Re-stamp the expiry on doc traffic at most this often, so a busy channel
+// does not turn every frame into a sessionStorage write.
+const DOC_ID_REFRESH_INTERVAL_MS = DOC_ID_TTL_MS / 2
 
 // One nonce per page load (module scope = one per top-level navigation, since
 // a full reload re-evaluates the module). A tab duplicated mid-session
@@ -229,6 +237,22 @@ export function useAgentCrdtFollower(
   // reality - and a stale channel's intent DOES equal reality).
   let staleProbeTimer: ReturnType<typeof setTimeout> | null = null
 
+  // FEC-5: `Date.now()` of the last persisted-record write by this instance.
+  // A confirmed subscribe always writes; doc-scoped frames re-stamp the expiry
+  // no more often than DOC_ID_REFRESH_INTERVAL_MS, so a doc that keeps
+  // delivering frames keeps its rebind window instead of lapsing mid-session.
+  let lastPersistedAt = 0
+  const persistConfirmedDocId = (docId: string): void => {
+    persistDocId(docId)
+    lastPersistedAt = Date.now()
+  }
+  const refreshPersistedDocId = (): void => {
+    const docId = subscribedWorkflowId.value
+    if (docId === null) return
+    if (Date.now() - lastPersistedAt < DOC_ID_REFRESH_INTERVAL_MS) return
+    persistConfirmedDocId(docId)
+  }
+
   const clearStaleProbe = (): void => {
     if (staleProbeTimer !== null) {
       clearTimeout(staleProbeTimer)
@@ -288,7 +312,7 @@ export function useAgentCrdtFollower(
       // FE-1902 (poc-3): only a CONFIRMED binding is worth rebinding to after
       // a remount — persist on ok, not on intent.
       if (subscribedWorkflowId.value !== null)
-        persistDocId(subscribedWorkflowId.value)
+        persistConfirmedDocId(subscribedWorkflowId.value)
     } else {
       clearStaleProbe()
       scheduleSubscribeRetry()
@@ -303,6 +327,7 @@ export function useAgentCrdtFollower(
     )
       return
     if (staleProbeTimer !== null) armStaleProbe()
+    refreshPersistedDocId()
     updatesApplied.value = bridge.follower.updatesApplied
     lastFrameType.value = event.type
     adapter.applyFrame(update)
@@ -320,7 +345,10 @@ export function useAgentCrdtFollower(
     knownDocNodeIds = ids
   }
   const onOpsResult: EventListener = (event) => {
-    if (staleProbeTimer !== null) armStaleProbe()
+    if (staleProbeTimer !== null) {
+      armStaleProbe()
+      refreshPersistedDocId()
+    }
     lastFrameType.value = event.type
     if (event instanceof CustomEvent) {
       recordDevEvent('doc_ops_result', event.detail ?? null)


### PR DESCRIPTION
Fixes the sessionStorage docId rebind (FE-1902) storing a bare, unscoped `docId` string. On the one path where a rebind from storage is attempted — `useAgentCrdtFollower`'s first-ever `null` `workflowId`, before any concrete value has resolved — any record left in sessionStorage was trusted unconditionally, including one inherited via tab duplication (which clones sessionStorage verbatim into a tab that never subscribed to that doc) or one left over from a stale prior session.

The persisted record now carries a per-page-load nonce (a duplicated tab gets a fresh nonce, so its inherited record is refused) and a 5-minute expiry. A malformed or legacy bare-string record is treated as absent rather than trusted.

Scope note: a full page reload deliberately refuses the previous binding and waits for the next turn acknowledgment. A same-page workflow switch cannot be distinguished by the page nonce, so that case is only bounded by the five-minute window.

Follow-up: #16655 guards persisted-expiry refreshes against unrelated-workflow and inactive-target operation results.

Once a concrete `workflowId` has been seen by the composable, rebind-from-storage is never consulted again (`initialBind` gates it) — that part of the existing contract is unchanged.

## Evidence

```
$ pnpm test:unit src/workbench/extensions/agent/crdt/useAgentCrdtFollower.test.ts
 Test Files  1 passed (1)
      Tests  21 passed (21)
```

3 new tests: rejects a foreign-nonce record (simulated tab duplication), rejects an expired record, rejects a legacy bare-string record.

```
$ pnpm exec eslint src/workbench/extensions/agent/crdt/useAgentCrdtFollower.ts src/workbench/extensions/agent/crdt/useAgentCrdtFollower.test.ts
(clean, no output)
```

Trace: `FEC-5` in `christian-byrne/in-app-agent-program` `todo.md`.

<!-- authored-by:agent lane-FEC-5 -->