### PR TITLE
fix(agent): bind minted workflows to unsaved tabs

### DIFF
--- a/src/workbench/extensions/agent/AgentPanelRoot.test.ts
+++ b/src/workbench/extensions/agent/AgentPanelRoot.test.ts
@@ -1361,7 +1361,7 @@ describe('AgentPanelRoot canvas draft on send', () => {
       ],
       links: []
     })
-    hostStores.workflow.activeWorkflow = {
+    const activeWorkflow = {
       path: 'workflows/video_minimax_h3_i2v.json',
       directory: 'workflows',
       filename: 'video_minimax_h3_i2v',
@@ -1369,6 +1369,8 @@ describe('AgentPanelRoot canvas draft on send', () => {
       isModified: false,
       activeState
     }
+    hostStores.workflow.tabs.set(activeWorkflow.path, activeWorkflow)
+    hostStores.workflow.activeWorkflow = activeWorkflow
 
     render(AgentPanelRoot, { global: { plugins: [i18n] } })
 
@@ -3073,6 +3075,56 @@ describe('AgentPanelRoot workflow binding', () => {
         String(frame).includes('doc_subscribe')
       )
     ).toBe(false)
+  })
+
+  it('does not reattribute a send when its originating tab closes during preparation', async () => {
+    const origin = makeTab('wf-origin')
+    origin.activeState = fromPartial<ComfyWorkflowJSON>({ id: 'origin-draft' })
+    const replacement = addTab('workflows/replacement.json', {
+      activeState: fromPartial<ComfyWorkflowJSON>({ id: 'replacement-draft' })
+    })
+    useAgentWorkflowTabBindingStore().bind('wf-replacement', replacement.path)
+    const bodies: Record<string, unknown>[] = []
+    let workflowRequests = 0
+    let releasePreparation: () => void = () => undefined
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (url: string, init?: RequestInit) => {
+        if (url.includes('/messages') && init?.method === 'POST') {
+          bodies.push(JSON.parse(String(init.body)) as Record<string, unknown>)
+          return json(202, ack('wf-fresh', 'm-1'))
+        }
+        if (url.includes('/messages')) return json(200, [])
+        if (url.includes('/agent/threads'))
+          return json(200, { threads: [], pagination: { page: 1 } })
+        if (url.includes('/workflows')) {
+          workflowRequests++
+          if (workflowRequests > 1)
+            await new Promise<void>((resolve) => {
+              releasePreparation = resolve
+            })
+          return json(200, {
+            data: [],
+            pagination: { offset: 0, limit: 100, total: 0, has_more: false }
+          })
+        }
+        return new Response('{}', { status: 200 })
+      })
+    )
+
+    render(AgentPanelRoot, { global: { plugins: [i18n] } })
+    await vi.waitFor(() => expect(workflowRequests).toBe(1))
+    await userEvent.type(screen.getByRole('textbox'), 'build a graph')
+    await userEvent.click(screen.getByRole('button', { name: 'Send' }))
+    await vi.waitFor(() => expect(workflowRequests).toBe(2))
+    hostStores.workflow.tabs.delete(origin.path)
+    hostStores.workflow.activeWorkflow = replacement
+    releasePreparation()
+
+    await vi.waitFor(() => expect(bodies).toHaveLength(1))
+    expect(bodies[0]).not.toHaveProperty('workflow_id')
+    expect(bodies[0]).not.toHaveProperty('current_tab')
+    expect(bodies[0]).not.toHaveProperty('draft')
   })
 
   it('sends only the remaining chip after one is dismissed', async () => {

--- a/src/workbench/extensions/agent/AgentPanelRoot.test.ts
+++ b/src/workbench/extensions/agent/AgentPanelRoot.test.ts
@@ -32,6 +32,7 @@ const getServerFeature = vi.hoisted(() =>
   vi.fn((_name: string, defaultValue?: unknown) => defaultValue)
 )
 const focusNodeInstance = vi.hoisted(() => vi.fn())
+const socketSend = vi.hoisted(() => vi.fn())
 
 vi.mock('@/composables/canvas/useFocusNode', () => ({
   useFocusNode: () => ({ focusNodeInstance })
@@ -61,7 +62,7 @@ vi.mock('@/scripts/api', () => ({
     fetchApi: (route: string, options?: RequestInit) =>
       fetch(route.startsWith('/api') ? route : `/api${route}`, options),
     getServerFeature,
-    socket: { readyState: 1, send: vi.fn() },
+    socket: { readyState: 1, send: socketSend },
     addEventListener: ws.add,
     removeEventListener: ws.remove,
     addCustomEventListener: ws.add,
@@ -314,6 +315,7 @@ beforeEach(() => {
   workflowService.saveWorkflowAs.mockClear()
   workflowService.openWorkflow.mockClear()
   focusNodeInstance.mockReset()
+  socketSend.mockReset()
 })
 
 const zAgentWsEventForTest = (raw: unknown): AgentChatEvent =>
@@ -2959,6 +2961,68 @@ describe('AgentPanelRoot workflow binding', () => {
     expect(bodies[0]).not.toHaveProperty('open_tabs')
     expect(bodies[0]).not.toHaveProperty('current_tab')
     expect(app.loadGraphData).not.toHaveBeenCalled()
+  })
+
+  it('binds a minted workflow to its unsaved tab and subscribes once', async () => {
+    const tab = makeTab()
+    tab.isTemporary = true
+    mockMessagesEndpoint('wf-fresh')
+
+    await renderAndSend('build a graph')
+
+    expect(useAgentWorkflowTabBindingStore().tabPathFor('wf-fresh')).toBe(
+      tab.path
+    )
+    const subscribes = socketSend.mock.calls
+      .map(
+        ([frame]) =>
+          JSON.parse(String(frame)) as { type: string; data: unknown }
+      )
+      .filter(({ type }) => type === 'doc_subscribe')
+    expect(subscribes).toEqual([
+      expect.objectContaining({
+        data: expect.objectContaining({ workflow_id: 'wf-fresh' })
+      })
+    ])
+  })
+
+  it('does not subscribe a minted workflow after its tab is backgrounded', async () => {
+    const origin = makeTab()
+    origin.isTemporary = true
+    const background = addTab('workflows/background.json')
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (url: string, init?: RequestInit) => {
+        if (url.includes('/messages') && init?.method === 'POST') {
+          hostStores.workflow.activeWorkflow = background
+          return json(202, ack('wf-fresh', 'm-1'))
+        }
+        if (url.includes('/agent/threads'))
+          return json(200, { threads: [], pagination: { page: 1 } })
+        if (url.includes('/workflows'))
+          return json(200, {
+            data: [],
+            pagination: {
+              offset: 0,
+              limit: 100,
+              total: 0,
+              has_more: false
+            }
+          })
+        return new Response('{}', { status: 200 })
+      })
+    )
+
+    await renderAndSend('build a graph')
+
+    expect(useAgentWorkflowTabBindingStore().tabPathFor('wf-fresh')).toBe(
+      origin.path
+    )
+    expect(
+      socketSend.mock.calls.some(([frame]) =>
+        String(frame).includes('doc_subscribe')
+      )
+    ).toBe(false)
   })
 
   it('sends only the remaining chip after one is dismissed', async () => {

--- a/src/workbench/extensions/agent/AgentPanelRoot.test.ts
+++ b/src/workbench/extensions/agent/AgentPanelRoot.test.ts
@@ -2846,6 +2846,56 @@ describe('AgentPanelRoot workflow binding', () => {
     expect(bodies[1]).not.toHaveProperty('current_tab')
   })
 
+  it('keeps an existing thread workflow on its own tab when sending from an unsaved tab', async () => {
+    const origin = makeTab('wf-42')
+    const bodies = mockMessagesEndpoint('wf-42')
+
+    await renderAndSend('first message')
+    ws.emit('agent_message_done', { message_id: 'm-1', thread_id: 'th-1' })
+    await screen.findByRole('button', { name: 'Send' })
+
+    const scratch = addTab('workflows/Scratch.json', { isTemporary: true })
+    hostStores.workflow.activeWorkflow = scratch
+    await nextTick()
+    socketSend.mockClear()
+
+    await sendFromComposer('second message')
+
+    expect(bodies[1]).not.toHaveProperty('workflow_id')
+    expect(useAgentWorkflowTabBindingStore().tabPathFor('wf-42')).toBe(
+      origin.path
+    )
+    expect(
+      useAgentWorkflowTabBindingStore().workflowIdFor(scratch.path)
+    ).toBeUndefined()
+    expect(
+      socketSend.mock.calls.some(([frame]) =>
+        String(frame).includes('doc_subscribe')
+      )
+    ).toBe(false)
+  })
+
+  it('does not bind an unsaved tab to a workflow that already has an open tab', async () => {
+    addTab('workflows/current.json')
+    const scratch = addTab('workflows/Scratch.json', { isTemporary: true })
+    hostStores.workflow.activeWorkflow = scratch
+    mockMessagesEndpoint('wf-42', [{ id: 'wf-42', name: 'current' }])
+
+    await renderAndSend('first message')
+
+    expect(
+      useAgentWorkflowTabBindingStore().workflowIdFor(scratch.path)
+    ).toBeUndefined()
+    expect(
+      useAgentWorkflowTabBindingStore().tabPathFor('wf-42')
+    ).toBeUndefined()
+    expect(
+      socketSend.mock.calls.some(([frame]) =>
+        String(frame).includes('doc_subscribe')
+      )
+    ).toBe(false)
+  })
+
   it('stages a mention pick once and reports the tag gesture', async () => {
     makeTab('wf-42')
     mockMessagesEndpoint('wf-42')

--- a/src/workbench/extensions/agent/AgentPanelRoot.vue
+++ b/src/workbench/extensions/agent/AgentPanelRoot.vue
@@ -308,11 +308,22 @@ function activeWorkflowTurnContext(
     : { id, tabPath: active.path }
 }
 
-function activeWorkflowDraft(): DraftSnapshot | undefined {
+function activeWorkflowDraft(
+  originTabPath?: string
+): DraftSnapshot | undefined {
   if (workflowDetached.value) return undefined
-  const active = workflowStore.activeWorkflow
+  const active =
+    originTabPath === undefined
+      ? workflowStore.activeWorkflow
+      : (workflowStore.getWorkflowByPath(originTabPath) ??
+        workflowStore.activeWorkflow)
   if (!active) return undefined
-  active.changeTracker?.captureCanvasState()
+  // captureCanvasState() folds the LIVE canvas into whichever workflow it is
+  // called on, so it is only correct while that workflow is still the active
+  // tab. If the user switched away mid-turn, the originating tab's own
+  // serialized activeState is the snapshot that belongs with this send.
+  if (active.path === workflowStore.activeWorkflow?.path)
+    active.changeTracker?.captureCanvasState()
   const content = active.activeState
   if (!content) return undefined
   return { content }

--- a/src/workbench/extensions/agent/AgentPanelRoot.vue
+++ b/src/workbench/extensions/agent/AgentPanelRoot.vue
@@ -292,9 +292,15 @@ function cloudIdFor(tab: ComfyWorkflow): string | undefined {
 
 const workflowDetached = ref(false)
 
-function activeWorkflowTurnContext(): WorkflowTurnContext | undefined {
+function activeWorkflowTurnContext(
+  originTabPath?: string
+): WorkflowTurnContext | undefined {
   if (workflowDetached.value) return undefined
-  const active = workflowStore.activeWorkflow
+  const active =
+    originTabPath === undefined
+      ? workflowStore.activeWorkflow
+      : (workflowStore.getWorkflowByPath(originTabPath) ??
+        workflowStore.activeWorkflow)
   if (!active) return undefined
   const id = cloudIdFor(active)
   return id === undefined
@@ -343,7 +349,9 @@ function onClearWorkflow(): void {
   workflowDetached.value = true
 }
 
-function openTabsSnapshot(): OpenTabsSnapshot | undefined {
+function openTabsSnapshot(
+  originTabPath?: string
+): OpenTabsSnapshot | undefined {
   const openTabs = workflowStore.openWorkflows.flatMap((tab) => {
     const workflowId = cloudIdFor(tab)
     return workflowId === undefined
@@ -351,7 +359,11 @@ function openTabsSnapshot(): OpenTabsSnapshot | undefined {
       : [{ workflow_id: workflowId, name: tab.filename }]
   })
   if (openTabs.length === 0) return undefined
-  const active = workflowStore.activeWorkflow
+  const active =
+    originTabPath === undefined
+      ? workflowStore.activeWorkflow
+      : (workflowStore.getWorkflowByPath(originTabPath) ??
+        workflowStore.activeWorkflow)
   return {
     open_tabs: openTabs,
     current_tab:

--- a/src/workbench/extensions/agent/AgentPanelRoot.vue
+++ b/src/workbench/extensions/agent/AgentPanelRoot.vue
@@ -299,8 +299,7 @@ function activeWorkflowTurnContext(
   const active =
     originTabPath === undefined
       ? workflowStore.activeWorkflow
-      : (workflowStore.getWorkflowByPath(originTabPath) ??
-        workflowStore.activeWorkflow)
+      : workflowStore.getWorkflowByPath(originTabPath)
   if (!active) return undefined
   const id = cloudIdFor(active)
   return id === undefined
@@ -315,8 +314,7 @@ function activeWorkflowDraft(
   const active =
     originTabPath === undefined
       ? workflowStore.activeWorkflow
-      : (workflowStore.getWorkflowByPath(originTabPath) ??
-        workflowStore.activeWorkflow)
+      : workflowStore.getWorkflowByPath(originTabPath)
   if (!active) return undefined
   // captureCanvasState() folds the LIVE canvas into whichever workflow it is
   // called on, so it is only correct while that workflow is still the active
@@ -373,8 +371,7 @@ function openTabsSnapshot(
   const active =
     originTabPath === undefined
       ? workflowStore.activeWorkflow
-      : (workflowStore.getWorkflowByPath(originTabPath) ??
-        workflowStore.activeWorkflow)
+      : workflowStore.getWorkflowByPath(originTabPath)
   return {
     open_tabs: openTabs,
     current_tab:

--- a/src/workbench/extensions/agent/AgentPanelRoot.vue
+++ b/src/workbench/extensions/agent/AgentPanelRoot.vue
@@ -296,8 +296,10 @@ function activeWorkflowTurnContext(): WorkflowTurnContext | undefined {
   if (workflowDetached.value) return undefined
   const active = workflowStore.activeWorkflow
   if (!active) return undefined
-  const bound = cloudIdFor(active)
-  return bound === undefined ? undefined : { id: bound, tabPath: active.path }
+  const id = cloudIdFor(active)
+  return id === undefined
+    ? { tabPath: active.path }
+    : { id, tabPath: active.path }
 }
 
 function activeWorkflowDraft(): DraftSnapshot | undefined {
@@ -361,7 +363,7 @@ function onWorkflowAdopted(
   workflowId: string,
   sent: WorkflowTurnContext | undefined
 ): void {
-  if (sent !== undefined && sent.id === workflowId) {
+  if (sent !== undefined && (sent.id === undefined || sent.id === workflowId)) {
     bindingStore.bind(workflowId, sent.tabPath)
     tabActivity.setEditing(sent.tabPath)
   }

--- a/src/workbench/extensions/agent/AgentPanelRoot.vue
+++ b/src/workbench/extensions/agent/AgentPanelRoot.vue
@@ -363,7 +363,14 @@ function onWorkflowAdopted(
   workflowId: string,
   sent: WorkflowTurnContext | undefined
 ): void {
-  if (sent !== undefined && (sent.id === undefined || sent.id === workflowId)) {
+  if (sent === undefined) return
+  // An unbound tab adopts a workflow only when it was minted for this turn:
+  // an id that already resolves to an open tab belongs to that tab.
+  const adoptable =
+    sent.id === undefined
+      ? boundTabFor(workflowId) === null
+      : sent.id === workflowId
+  if (adoptable) {
     bindingStore.bind(workflowId, sent.tabPath)
     tabActivity.setEditing(sent.tabPath)
   }

--- a/src/workbench/extensions/agent/composables/agent/useAgentSession.test.ts
+++ b/src/workbench/extensions/agent/composables/agent/useAgentSession.test.ts
@@ -678,6 +678,7 @@ describe('useAgentSession (v1 composition root)', () => {
       tabPath: 'tab-a'
     })
     expect(vi.mocked(postMessage).mock.calls[0][1]).toMatchObject({
+      workflowId: 'wf-a',
       tabs: { current_tab: 'wf-a' }
     })
   })

--- a/src/workbench/extensions/agent/composables/agent/useAgentSession.test.ts
+++ b/src/workbench/extensions/agent/composables/agent/useAgentSession.test.ts
@@ -625,6 +625,63 @@ describe('useAgentSession (v1 composition root)', () => {
     expect(vi.mocked(postMessage).mock.calls[0][1]).not.toHaveProperty('draft')
   })
 
+  it('(h7) a tab switch while prepare() is pending does not reattribute the send to the new tab', async () => {
+    const postMessage = vi.fn(async () => ({
+      thread_id: 'th-1',
+      message_id: 'msg-1',
+      workflow_id: 'wf-1'
+    })) as unknown as AgentRestClient['postMessage']
+    const rest = fakeRest({ postMessage })
+    const { source } = fakeEvents()
+    const adopted = vi.fn()
+    let releasePrepare: () => void = () => undefined
+    const prepare = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          releasePrepare = resolve
+        })
+    )
+    let activePath = 'tab-a'
+    const idForPath = (path: string) => (path === 'tab-a' ? 'wf-a' : 'wf-b')
+    const session = useAgentSession({
+      rest,
+      events: source,
+      workflow: {
+        // Mirrors the real deps: honor an explicit originTabPath (resolved
+        // post-prepare) and fall back to whatever tab is active right now
+        // when called with no argument (the pre-await identity capture).
+        current: (originTabPath) => {
+          const path = originTabPath ?? activePath
+          return { id: idForPath(path), tabPath: path }
+        },
+        adopted,
+        prepare,
+        tabs: (originTabPath) => {
+          const path = originTabPath ?? activePath
+          return {
+            open_tabs: [{ workflow_id: idForPath(path), name: path }],
+            current_tab: idForPath(path)
+          }
+        }
+      }
+    })
+    session.start()
+
+    const sendPromise = session.sendMessage('hello')
+    // Simulate the user switching tabs while prepare() is still in flight.
+    activePath = 'tab-b'
+    releasePrepare()
+    await sendPromise
+
+    expect(adopted).toHaveBeenCalledWith('wf-1', {
+      id: 'wf-a',
+      tabPath: 'tab-a'
+    })
+    expect(vi.mocked(postMessage).mock.calls[0][1]).toMatchObject({
+      tabs: { current_tab: 'wf-a' }
+    })
+  })
+
   it("(i2) loadThread drops the previous thread's workflow binding", async () => {
     const rest = fakeRest()
     const { source } = fakeEvents()

--- a/src/workbench/extensions/agent/composables/agent/useAgentSession.test.ts
+++ b/src/workbench/extensions/agent/composables/agent/useAgentSession.test.ts
@@ -682,6 +682,55 @@ describe('useAgentSession (v1 composition root)', () => {
     })
   })
 
+  it('(h8) the draft snapshot follows the originating tab, not the tab switched to during prepare()', async () => {
+    const postMessage = vi.fn(async () => ({
+      thread_id: 'th-1',
+      message_id: 'msg-1',
+      workflow_id: 'wf-1'
+    })) as unknown as AgentRestClient['postMessage']
+    const rest = fakeRest({ postMessage })
+    const { source } = fakeEvents()
+    let releasePrepare: () => void = () => undefined
+    const prepare = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          releasePrepare = resolve
+        })
+    )
+    let activePath = 'tab-a'
+    const idForPath = (path: string) => (path === 'tab-a' ? 'wf-a' : 'wf-b')
+    const session = useAgentSession({
+      rest,
+      events: source,
+      workflow: {
+        current: (originTabPath) => {
+          const path = originTabPath ?? activePath
+          return { id: idForPath(path), tabPath: path }
+        },
+        adopted: vi.fn(),
+        prepare,
+        // The draft is read on the same post-await leg as current()/tabs(), so
+        // it has to honor the same pinned identity or the turn ships one tab's
+        // canvas under another tab's workflow id.
+        draft: (originTabPath) => {
+          const path = originTabPath ?? activePath
+          return { content: { nodes: [{ id: 1, type: path }], links: [] } }
+        }
+      }
+    })
+    session.start()
+
+    const sendPromise = session.sendMessage('what is on my canvas')
+    activePath = 'tab-b'
+    releasePrepare()
+    await sendPromise
+
+    expect(vi.mocked(postMessage).mock.calls[0][1]).toMatchObject({
+      workflowId: 'wf-a',
+      draft: { content: { nodes: [{ id: 1, type: 'tab-a' }], links: [] } }
+    })
+  })
+
   it("(i2) loadThread drops the previous thread's workflow binding", async () => {
     const rest = fakeRest()
     const { source } = fakeEvents()

--- a/src/workbench/extensions/agent/composables/agent/useAgentSession.ts
+++ b/src/workbench/extensions/agent/composables/agent/useAgentSession.ts
@@ -46,10 +46,14 @@ export interface AgentSessionDeps {
   rest: AgentRestClient
   events: AgentEventSource
   workflow?: {
-    current(): WorkflowTurnContext | undefined
+    // originTabPath, when given, pins resolution to the tab that initiated
+    // the send instead of whatever tab is active when this is called - it
+    // is read after prepare() so cloud ids it resolves are fresh, but must
+    // still describe the pre-await originating tab, not a later switch.
+    current(originTabPath?: string): WorkflowTurnContext | undefined
     adopted(workflowId: string, sent: WorkflowTurnContext | undefined): void
     prepare?(): Promise<void>
-    tabs?(): OpenTabsSnapshot | undefined
+    tabs?(originTabPath?: string): OpenTabsSnapshot | undefined
     activeTab?(data: AgentActiveTabData): void
     draft?(): DraftSnapshot | undefined
   }
@@ -193,13 +197,23 @@ export function useAgentSession(deps: AgentSessionDeps) {
     promptEditState.value = { phase: 'idle' }
     sending.value = true
     stopRequestedWhileSending = false
+    // Capture the originating tab identity before the first await: prepare()
+    // can take up to PREPARE_TIMEOUT_MS, and a tab switch while it is
+    // pending must not reattribute this send to the newly active tab. The id
+    // lookups themselves stay post-await (prepare() is what warms them), but
+    // pinned to this originating path rather than whatever is active later.
+    const originTabPath = workflow?.current()?.tabPath
+    // The ack does not say whether the server minted a workflow or echoed
+    // the thread's existing one; an unbound tab may only adopt an id the
+    // session was not already bound to before this turn.
+    const priorWorkflowId = boundWorkflowId.value
     if (workflow?.prepare)
       await Promise.race([
         workflow.prepare().catch(() => undefined),
         new Promise<void>((resolve) => setTimeout(resolve, PREPARE_TIMEOUT_MS))
       ])
-    const wfContext = workflow?.current()
-    const tabs = workflow?.tabs?.()
+    const wfContext = workflow?.current(originTabPath)
+    const tabs = workflow?.tabs?.(originTabPath)
     async function postTurn(threadId: string) {
       const draft = workflow?.draft?.()
       const shouldSendDraft =
@@ -221,10 +235,6 @@ export function useAgentSession(deps: AgentSessionDeps) {
           : input
       )
     }
-    // The ack does not say whether the server minted a workflow or echoed
-    // the thread's existing one; an unbound tab may only adopt an id the
-    // session was not already bound to before this turn.
-    const priorWorkflowId = boundWorkflowId.value
     try {
       const ack = await postTurn(conversationStore.threadId ?? 'new')
       conversationStore.setThreadId(ack.thread_id)

--- a/src/workbench/extensions/agent/composables/agent/useAgentSession.ts
+++ b/src/workbench/extensions/agent/composables/agent/useAgentSession.ts
@@ -33,7 +33,7 @@ interface SentTag {
 }
 
 export interface WorkflowTurnContext {
-  id: string
+  id?: string
   tabPath: string
 }
 
@@ -216,7 +216,9 @@ export function useAgentSession(deps: AgentSessionDeps) {
       }
       return rest.postMessage(
         threadId,
-        wfContext ? { ...input, workflowId: wfContext.id } : input
+        wfContext?.id !== undefined
+          ? { ...input, workflowId: wfContext.id }
+          : input
       )
     }
     try {

--- a/src/workbench/extensions/agent/composables/agent/useAgentSession.ts
+++ b/src/workbench/extensions/agent/composables/agent/useAgentSession.ts
@@ -221,13 +221,19 @@ export function useAgentSession(deps: AgentSessionDeps) {
           : input
       )
     }
+    // The ack does not say whether the server minted a workflow or echoed
+    // the thread's existing one; an unbound tab may only adopt an id the
+    // session was not already bound to before this turn.
+    const priorWorkflowId = boundWorkflowId.value
     try {
       const ack = await postTurn(conversationStore.threadId ?? 'new')
       conversationStore.setThreadId(ack.thread_id)
       localStorage.setItem(THREAD_STORAGE_KEY, ack.thread_id)
       if (ack.workflow_id !== undefined) {
         bindWorkflow(ack.workflow_id)
-        workflow?.adopted(ack.workflow_id, wfContext)
+        const echoedToUnboundTab =
+          wfContext?.id === undefined && ack.workflow_id === priorWorkflowId
+        if (!echoedToUnboundTab) workflow?.adopted(ack.workflow_id, wfContext)
       }
       const turnId = ack.message_id as TurnId
       conversationStore.recordUser(

--- a/src/workbench/extensions/agent/composables/agent/useAgentSession.ts
+++ b/src/workbench/extensions/agent/composables/agent/useAgentSession.ts
@@ -55,7 +55,7 @@ export interface AgentSessionDeps {
     prepare?(): Promise<void>
     tabs?(originTabPath?: string): OpenTabsSnapshot | undefined
     activeTab?(data: AgentActiveTabData): void
-    draft?(): DraftSnapshot | undefined
+    draft?(originTabPath?: string): DraftSnapshot | undefined
   }
 }
 
@@ -215,9 +215,15 @@ export function useAgentSession(deps: AgentSessionDeps) {
     const wfContext = workflow?.current(originTabPath)
     const tabs = workflow?.tabs?.(originTabPath)
     async function postTurn(threadId: string) {
-      const draft = workflow?.draft?.()
+      const draft = workflow?.draft?.(originTabPath)
+      // An unsaved tab now yields a context carrying only its tabPath, so a
+      // merely-defined wfContext no longer implies the tab has a workflow the
+      // thread could own. An existing thread takes a draft only from a tab
+      // with a real workflow id; otherwise an unbound scratch tab would leak
+      // its canvas into someone else's thread.
       const shouldSendDraft =
-        draft !== undefined && (threadId === 'new' || wfContext !== undefined)
+        draft !== undefined &&
+        (threadId === 'new' || wfContext?.id !== undefined)
       const input = {
         content: text,
         tabs,


### PR DESCRIPTION
- Preserve the unsaved tab path across turn acceptance.
- Bind the ack-minted workflow to that exact tab.
- Never reattribute a send if its origin switches or closes.

<details><summary>Full context for agent readers</summary>

## Summary

An unbound tab previously lost its turn context before the accepted-turn response arrived. The session learned the minted workflow ID, but the tab-binding store did not, so the CRDT follower remained inactive.

## Changes

- **What**: Keep path-only turn context for unbound tabs, omit the outbound workflow ID until one exists, and adopt a minted ID onto the originating path.
- **Race safety**: Pin workflow identity, tab snapshot, and draft to the tab that initiated the send. A mid-prepare tab switch cannot reattribute the request. If that tab closes, the request carries none of its replacement's workflow identity, `current_tab`, or draft.
- **Subscription safety**: Retain the active-tab equality gate before any follower subscription. If the user backgrounds the originating tab while the request is in flight, the minted ID is bound but no `doc_subscribe` is sent.

## Review Focus

The path-only turn context and the adoption condition for a server-minted ID.

Fixes #16620

## Evidence

- `pnpm test:unit src/workbench/extensions/agent/AgentPanelRoot.test.ts src/workbench/extensions/agent/composables/agent/useAgentSession.test.ts` — 176 passed
- `pnpm typecheck` — passed
- ESLint and oxfmt on all three touched files — passed
- Hosted checks at the prior head were green; checks for the review-fix head are running.

No Playwright test was added because the regression depends on deterministically pausing the internal cloud-ID preparation promise and switching or closing the originating store tab during that exact await. The component regression controls that interleaving directly without adding test-only browser hooks; the full hosted Playwright matrix still exercises the surrounding user flows.

</details>

<!-- authored-by:agent lane-act-fe-16620-fix-1 -->
