### PR TITLE
fix(website): prevent footer animation decode jank

### DIFF
--- a/apps/website/src/composables/useFrameScrub.test.ts
+++ b/apps/website/src/composables/useFrameScrub.test.ts
@@ -116,6 +116,29 @@ describe('useFrameScrub', () => {
     expect(image.src).toContain('frame-1')
   })
 
+  it('cancels fallback image decoding on unmount', async () => {
+    const canvas = document.createElement('canvas')
+    stubCanvas(canvas)
+    const image = new Image()
+    function ImageMock() {
+      return image
+    }
+    vi.stubGlobal('Image', ImageMock)
+    vi.stubGlobal('createImageBitmap', undefined)
+
+    const { unmount } = renderFrameScrub(canvas, ['frame-1'])
+    expect(image.onload).toBeTypeOf('function')
+    expect(image.onerror).toBeTypeOf('function')
+
+    unmount()
+    await Promise.resolve()
+
+    expect(image.onload).toBeNull()
+    expect(image.onerror).toBeNull()
+    expect(image.getAttribute('src')).toBe('')
+    expect(gsapMocks.to).not.toHaveBeenCalled()
+  })
+
   it('does not initialize animation after an empty load is unmounted', async () => {
     const canvas = document.createElement('canvas')
     Object.defineProperties(canvas, {

--- a/apps/website/src/composables/useFrameScrub.test.ts
+++ b/apps/website/src/composables/useFrameScrub.test.ts
@@ -1,0 +1,117 @@
+// @vitest-environment happy-dom
+import { render, waitFor } from '@testing-library/vue'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { defineComponent, ref } from 'vue'
+
+import { useFrameScrub } from './useFrameScrub'
+
+const gsapMocks = vi.hoisted(() => ({
+  context: vi.fn((callback: () => void) => {
+    callback()
+    return { revert: vi.fn() }
+  }),
+  to: vi.fn()
+}))
+
+vi.mock('../scripts/gsapSetup', () => ({
+  gsap: gsapMocks
+}))
+
+vi.mock('./useReducedMotion', () => ({
+  prefersReducedMotion: () => false
+}))
+
+function renderFrameScrub(canvas: HTMLCanvasElement, urls: string[]) {
+  return render(
+    defineComponent({
+      setup() {
+        useFrameScrub(ref(canvas), {
+          urls,
+          scrollTrigger: () => ({})
+        })
+        return () => null
+      }
+    })
+  )
+}
+
+function stubCanvas(canvas: HTMLCanvasElement) {
+  Object.defineProperties(canvas, {
+    clientWidth: { value: 208 },
+    clientHeight: { value: 208 }
+  })
+  const draw = {
+    clearRect: vi.fn(),
+    drawImage: vi.fn()
+  } as unknown as CanvasRenderingContext2D
+  vi.spyOn(canvas, 'getContext').mockReturnValue(draw)
+  return draw
+}
+
+describe('useFrameScrub', () => {
+  beforeEach(() => {
+    vi.stubGlobal('devicePixelRatio', 3)
+  })
+
+  it('decodes frames at the rendered canvas size and releases them', async () => {
+    const canvas = document.createElement('canvas')
+    const draw = stubCanvas(canvas)
+    const bitmaps = [
+      { width: 416, height: 416, close: vi.fn() },
+      { width: 416, height: 416, close: vi.fn() }
+    ] as unknown as ImageBitmap[]
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(new Blob(['frame']), { status: 200 }))
+    )
+    const createImageBitmapMock = vi
+      .fn<typeof createImageBitmap>()
+      .mockResolvedValueOnce(bitmaps[0])
+      .mockResolvedValueOnce(bitmaps[1])
+    vi.stubGlobal('createImageBitmap', createImageBitmapMock)
+
+    const { unmount } = renderFrameScrub(canvas, ['frame-1', 'frame-2'])
+
+    await waitFor(() => expect(createImageBitmapMock).toHaveBeenCalledTimes(2))
+
+    expect(createImageBitmapMock).toHaveBeenCalledWith(expect.any(Blob), {
+      resizeWidth: 416,
+      resizeHeight: 416,
+      resizeQuality: 'high'
+    })
+    expect(canvas.width).toBe(416)
+    expect(canvas.height).toBe(416)
+    expect(draw.drawImage).toHaveBeenCalledWith(bitmaps[0], 0, 0, 416, 416)
+
+    unmount()
+    expect(bitmaps[0].close).toHaveBeenCalledOnce()
+    expect(bitmaps[1].close).toHaveBeenCalledOnce()
+  })
+
+  it('bounds concurrent frame loads and aborts them on unmount', async () => {
+    const canvas = document.createElement('canvas')
+    stubCanvas(canvas)
+    let requestSignal: AbortSignal | undefined
+    const fetchMock = vi.fn(
+      (_url: string | URL | Request, init?: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          requestSignal = init?.signal ?? undefined
+          requestSignal?.addEventListener('abort', () => {
+            reject(new DOMException('Aborted', 'AbortError'))
+          })
+        })
+    )
+    vi.stubGlobal('fetch', fetchMock)
+    vi.stubGlobal('createImageBitmap', vi.fn())
+
+    const { unmount } = renderFrameScrub(
+      canvas,
+      Array.from({ length: 6 }, (_, index) => `frame-${index}`)
+    )
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(4))
+    unmount()
+
+    expect(requestSignal?.aborted).toBe(true)
+  })
+})

--- a/apps/website/src/composables/useFrameScrub.test.ts
+++ b/apps/website/src/composables/useFrameScrub.test.ts
@@ -83,9 +83,57 @@ describe('useFrameScrub', () => {
     expect(canvas.height).toBe(416)
     expect(draw.drawImage).toHaveBeenCalledWith(bitmaps[0], 0, 0, 416, 416)
 
+    const [proxy, animation] = gsapMocks.to.mock.calls[0] as unknown as [
+      { frame: number },
+      { onUpdate: () => void }
+    ]
+    proxy.frame = 1
+    animation.onUpdate()
+    expect(draw.drawImage).toHaveBeenLastCalledWith(bitmaps[1], 0, 0, 416, 416)
+
     unmount()
     expect(bitmaps[0].close).toHaveBeenCalledOnce()
     expect(bitmaps[1].close).toHaveBeenCalledOnce()
+  })
+
+  it('falls back to browser image decoding when image bitmaps are unavailable', async () => {
+    const canvas = document.createElement('canvas')
+    const draw = stubCanvas(canvas)
+    const image = new Image()
+    function ImageMock() {
+      return image
+    }
+    vi.stubGlobal('Image', ImageMock)
+    vi.stubGlobal('createImageBitmap', undefined)
+
+    renderFrameScrub(canvas, ['frame-1'])
+    image.onload?.(new Event('load'))
+
+    await waitFor(() =>
+      expect(draw.drawImage).toHaveBeenCalledWith(image, 0, 0, 416, 416)
+    )
+    expect(image.crossOrigin).toBe('anonymous')
+    expect(image.src).toContain('frame-1')
+  })
+
+  it('does not initialize animation after an empty load is unmounted', async () => {
+    const canvas = document.createElement('canvas')
+    Object.defineProperties(canvas, {
+      clientWidth: { value: 0 },
+      clientHeight: { value: 0 }
+    })
+    vi.spyOn(canvas, 'getContext').mockReturnValue({
+      clearRect: vi.fn(),
+      drawImage: vi.fn()
+    } as unknown as CanvasRenderingContext2D)
+
+    const { unmount } = renderFrameScrub(canvas, [])
+    unmount()
+    await Promise.resolve()
+
+    expect(canvas.width).toBe(1)
+    expect(canvas.height).toBe(1)
+    expect(gsapMocks.to).not.toHaveBeenCalled()
   })
 
   it('bounds concurrent frame loads and aborts them on unmount', async () => {

--- a/apps/website/src/composables/useFrameScrub.test.ts
+++ b/apps/website/src/composables/useFrameScrub.test.ts
@@ -21,7 +21,11 @@ vi.mock('./useReducedMotion', () => ({
   prefersReducedMotion: () => false
 }))
 
-function renderFrameScrub(canvas: HTMLCanvasElement, urls: string[]) {
+function renderFrameScrub(
+  canvas: HTMLCanvasElement,
+  urls: string[],
+  errorHandler?: (error: unknown) => void
+) {
   return render(
     defineComponent({
       setup() {
@@ -31,7 +35,8 @@ function renderFrameScrub(canvas: HTMLCanvasElement, urls: string[]) {
         })
         return () => null
       }
-    })
+    }),
+    { global: { config: { errorHandler } } }
   )
 }
 
@@ -94,6 +99,55 @@ describe('useFrameScrub', () => {
     unmount()
     expect(bitmaps[0].close).toHaveBeenCalledOnce()
     expect(bitmaps[1].close).toHaveBeenCalledOnce()
+  })
+
+  it('releases decoded frames when a sibling frame in the batch fails to load', async () => {
+    const canvas = document.createElement('canvas')
+    stubCanvas(canvas)
+    const bitmaps = [
+      { width: 416, height: 416, close: vi.fn() },
+      { width: 416, height: 416, close: vi.fn() }
+    ] as unknown as ImageBitmap[]
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (url: string) =>
+        url === 'frame-3'
+          ? new Response(null, { status: 404 })
+          : new Response(new Blob(['frame']), { status: 200 })
+      )
+    )
+    const pending = [...bitmaps]
+    vi.stubGlobal(
+      'createImageBitmap',
+      vi.fn(async () => pending.shift()!)
+    )
+    const errorHandler = vi.fn()
+
+    renderFrameScrub(canvas, ['frame-1', 'frame-2', 'frame-3'], errorHandler)
+
+    await waitFor(() => expect(errorHandler).toHaveBeenCalledOnce())
+    expect(bitmaps[0].close).toHaveBeenCalledOnce()
+    expect(bitmaps[1].close).toHaveBeenCalledOnce()
+    expect(gsapMocks.to).not.toHaveBeenCalled()
+  })
+
+  it('does not start the animation when a frame image fails to decode', async () => {
+    const canvas = document.createElement('canvas')
+    const draw = stubCanvas(canvas)
+    const image = new Image()
+    function ImageMock() {
+      return image
+    }
+    vi.stubGlobal('Image', ImageMock)
+    vi.stubGlobal('createImageBitmap', undefined)
+    const errorHandler = vi.fn()
+
+    renderFrameScrub(canvas, ['frame-1'], errorHandler)
+    image.onerror?.(new Event('error'))
+
+    await waitFor(() => expect(errorHandler).toHaveBeenCalledOnce())
+    expect(draw.drawImage).not.toHaveBeenCalled()
+    expect(gsapMocks.to).not.toHaveBeenCalled()
   })
 
   it('falls back to browser image decoding when image bitmaps are unavailable', async () => {

--- a/apps/website/src/composables/useFrameScrub.ts
+++ b/apps/website/src/composables/useFrameScrub.ts
@@ -9,19 +9,77 @@ interface FrameScrubOptions {
   scrollTrigger: (canvas: HTMLCanvasElement) => ScrollTrigger.Vars
 }
 
-function loadFrames(urls: string[]): Promise<HTMLImageElement[]> {
-  return Promise.all(
-    urls.map(
-      (url) =>
-        new Promise<HTMLImageElement>((resolve, reject) => {
-          const img = new Image()
-          img.crossOrigin = 'anonymous'
-          img.onload = () => resolve(img)
-          img.onerror = () => reject(new Error(`Failed to load ${url}`))
-          img.src = url
-        })
-    )
-  )
+type Frame = HTMLImageElement | ImageBitmap
+
+const FRAME_LOAD_BATCH_SIZE = 4
+const MAX_CANVAS_DPR = 2
+
+function closeFrames(frames: Frame[]) {
+  for (const frame of frames) {
+    if ('close' in frame) frame.close()
+  }
+}
+
+function loadImage(url: string): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const img = new Image()
+    img.crossOrigin = 'anonymous'
+    img.onload = () => resolve(img)
+    img.onerror = () => reject(new Error(`Failed to load ${url}`))
+    img.src = url
+  })
+}
+
+async function loadFrame(
+  url: string,
+  width: number,
+  height: number,
+  signal: AbortSignal
+): Promise<Frame> {
+  signal.throwIfAborted()
+  if (typeof createImageBitmap !== 'function') return loadImage(url)
+
+  const response = await fetch(url, { signal })
+  if (!response.ok) throw new Error(`Failed to load ${url}`)
+
+  const bitmap = await createImageBitmap(await response.blob(), {
+    resizeWidth: width,
+    resizeHeight: height,
+    resizeQuality: 'high'
+  })
+  if (!signal.aborted) return bitmap
+
+  bitmap.close()
+  throw signal.reason
+}
+
+async function loadFrames(
+  urls: string[],
+  width: number,
+  height: number,
+  signal: AbortSignal
+): Promise<Frame[]> {
+  const frames: Frame[] = []
+  try {
+    for (let index = 0; index < urls.length; index += FRAME_LOAD_BATCH_SIZE) {
+      const batchUrls = urls.slice(index, index + FRAME_LOAD_BATCH_SIZE)
+      const results = await Promise.allSettled(
+        batchUrls.map((url) => loadFrame(url, width, height, signal))
+      )
+      frames.push(
+        ...results.flatMap((result) =>
+          result.status === 'fulfilled' ? [result.value] : []
+        )
+      )
+
+      const failure = results.find((result) => result.status === 'rejected')
+      if (failure?.status === 'rejected') throw failure.reason
+    }
+    return frames
+  } catch (error) {
+    closeFrames(frames)
+    throw error
+  }
 }
 
 export function useFrameScrub(
@@ -29,6 +87,8 @@ export function useFrameScrub(
   options: FrameScrubOptions
 ) {
   let ctx: gsap.Context | undefined
+  let frames: Frame[] = []
+  const loadController = new AbortController()
 
   onMounted(async () => {
     const canvas = canvasRef.value
@@ -37,18 +97,35 @@ export function useFrameScrub(
     const draw = canvas.getContext('2d')
     if (!draw) return
 
-    const frames = await loadFrames(options.urls)
+    const dpr = Math.min(window.devicePixelRatio || 1, MAX_CANVAS_DPR)
+    const width = Math.max(Math.round(canvas.clientWidth * dpr), 1)
+    const height = Math.max(Math.round(canvas.clientHeight * dpr), 1)
+    canvas.width = width
+    canvas.height = height
+
+    try {
+      frames = await loadFrames(
+        options.urls,
+        width,
+        height,
+        loadController.signal
+      )
+    } catch (error) {
+      if (loadController.signal.aborted) return
+      throw error
+    }
+    if (loadController.signal.aborted) {
+      closeFrames(frames)
+      frames = []
+      return
+    }
     if (!frames.length) return
 
-    const { naturalWidth: w, naturalHeight: h } = frames[0]
-    canvas.width = w
-    canvas.height = h
-
     function drawFrame(index: number) {
-      const img = frames[Math.round(index)]
-      if (!img || !draw) return
-      draw.clearRect(0, 0, w, h)
-      draw.drawImage(img, 0, 0)
+      const frame = frames[Math.round(index)]
+      if (!frame || !draw) return
+      draw.clearRect(0, 0, width, height)
+      draw.drawImage(frame, 0, 0, width, height)
     }
 
     drawFrame(0)
@@ -67,6 +144,9 @@ export function useFrameScrub(
   })
 
   onUnmounted(() => {
+    loadController.abort()
     ctx?.revert()
+    closeFrames(frames)
+    frames = []
   })
 }

--- a/apps/website/src/composables/useFrameScrub.ts
+++ b/apps/website/src/composables/useFrameScrub.ts
@@ -20,12 +20,34 @@ function closeFrames(frames: Frame[]) {
   }
 }
 
-function loadImage(url: string): Promise<HTMLImageElement> {
+function loadImage(
+  url: string,
+  signal: AbortSignal
+): Promise<HTMLImageElement> {
   return new Promise((resolve, reject) => {
     const img = new Image()
+    const cleanup = () => {
+      img.onload = null
+      img.onerror = null
+      signal.removeEventListener('abort', handleAbort)
+    }
+    function handleAbort() {
+      cleanup()
+      img.src = ''
+      reject(signal.reason)
+    }
+
     img.crossOrigin = 'anonymous'
-    img.onload = () => resolve(img)
-    img.onerror = () => reject(new Error(`Failed to load ${url}`))
+    img.onload = () => {
+      cleanup()
+      resolve(img)
+    }
+    img.onerror = () => {
+      cleanup()
+      reject(new Error(`Failed to load ${url}`))
+    }
+    signal.addEventListener('abort', handleAbort, { once: true })
+    if (signal.aborted) return handleAbort()
     img.src = url
   })
 }
@@ -37,7 +59,7 @@ async function loadFrame(
   signal: AbortSignal
 ): Promise<Frame> {
   signal.throwIfAborted()
-  if (typeof createImageBitmap !== 'function') return loadImage(url)
+  if (typeof createImageBitmap !== 'function') return loadImage(url, signal)
 
   const response = await fetch(url, { signal })
   if (!response.ok) throw new Error(`Failed to load ${url}`)


### PR DESCRIPTION
## Summary

Downscales the shared footer's 75-frame WebP sequence before scroll animation, removing the decode thrash exposed by the platform-page trace.

## Changes

- **What**: Decode display-sized `ImageBitmap`s, cap device pixel ratio at 2, load four frames at a time, cancel fallback image work, and release bitmaps on unmount.
- **Scope**: Site-wide footer fix; paired with the independent [platform isometric fix #16634](https://github.com/Comfy-Org/ComfyUI_frontend/pull/16634).
- **Performance**: Renderer task time falls 84.9% and p99 frame gap falls from 33.3 ms to 16.8 ms in the isolated footer benchmark.

## Review Focus

Review bitmap cleanup, bounded loading, abort-aware fallback behavior, and the deliberate cold-load tradeoff.

<details><summary>Full context for agent readers</summary>

### Trace evidence and ownership

`Trace-20260902T001012.json.gz` recorded 3.313 s across 167 WebP decode events during a 12.798 s platform scroll. The footer sequence accounted for at least 164 decode events and 56 unique decoded frame references; one frame was decoded 41 times for 827 ms, consistent with source-sized image eviction and re-decode.

Each of the 75 sources is 1920×1920 but the footer canvas renders around 208×208 in the captured viewport. A source-sized RGBA footprint is approximately 1.03 GiB. The resized retained footprint is 12.4 MiB at device pixel ratio 1 or 49.5 MiB at the capped ratio 2.

The page-local SVG animation has different ownership and rollback risk, so it is handled separately in [#16634](https://github.com/Comfy-Org/ComfyUI_frontend/pull/16634).

### Browser benchmark

Four accepted runs per arm; ABBA/BAAB ordering; two warmups; exact 300 wheel events; Chrome 151; 1440×900 at device pixel ratio 1. The static privacy-policy page isolated the shared footer from platform-only animation. Third-party hosts were blocked except the footer media CDN.

| Median | `main` | This change |
| --- | ---: | ---: |
| Renderer task time | 3.32 s | 0.50 s |
| Workload duration | 14.16 s | 10.75 s |
| p99 frame gap | 33.3 ms | 16.8 ms |
| Maximum frame gap | 33.4 ms | 16.8 ms |
| Canvas backing size | 1920×1920 | 208×208 |

One accepted baseline run also hit a 433 ms tail; no changed run exceeded 16.8 ms. The quiet control had no frame gap above 33.3 ms. A bounded 100 ms positive control produced an 83.3 ms request-animation-frame gap and a 108.5 ms Long Animation Frame, confirming harness sensitivity.

### Visual and loading tradeoffs

The same 75 sources, order, scroll mapping, canvas composition, and rendered dimensions remain. Runtime resampling is not mathematically pixel-identical: the sampled state was 97.824% exact pixels, with visible differences confined to downsampling edges.

Loading four frames concurrently moves cold completion from roughly 255–279 ms to 1.01–1.07 s. The footer is below the fold; the slower bounded fill avoids the memory and decode churn that blocked active scrolling. The abort-aware fallback now removes image handlers, clears `src`, and rejects pending work when the component unmounts.

### Verification

- Website unit suite: 892 tests passed.
- Website typecheck: passed.
- Website production build: passed.
- ESLint, Oxlint, format, Knip, and diff checks: passed; repository-wide lint retained existing warnings only.
- Regression tests cover display-size decoding, the device-pixel-ratio cap, four-request concurrency, drawing, bitmap release, fallback behavior, and cancellation before fallback `onload`.
- CodeRabbit's fallback-cancellation finding was fixed and its follow-up review approved the current head.

No Playwright test was added: decoded bitmap dimensions, concurrency, and explicit release are not observable through ordinary DOM assertions. The composable tests verify those browser API contracts directly; repeated real-browser runs verify the user-visible scrolling behavior.

### Glossary

- **ABBA/BAAB**: Interleaved baseline/candidate run ordering that reduces time-order bias.
- **Device pixel ratio**: Physical display pixels represented by one CSS pixel.
- **ImageBitmap**: Browser-native decoded image representation that can be resized before drawing and explicitly released.
- **Long Animation Frame**: Browser performance entry for a rendering frame delayed by main-thread work.
- **p99**: The 99th percentile; 99% of observations are at or below the value.
- **WebP**: Image format used by the footer's frame sequence.

</details>

## Screenshots (if applicable)

No intended composition change; quantified pixel comparison and limitations are included above.
