### PR TITLE
feat(agent): emit app:agent_error telemetry (TEL-8)

### DIFF
--- a/src/platform/telemetry/TelemetryRegistry.ts
+++ b/src/platform/telemetry/TelemetryRegistry.ts
@@ -1,6 +1,7 @@
 import type {
   AddCreditsClickMetadata,
   AgentEntryButtonClickedMetadata,
+  AgentErrorMetadata,
   AgentMessageSentMetadata,
   AgentMessageFeedbackMetadata,
   AgentNodeTaggedMetadata,
@@ -384,6 +385,10 @@ export class TelemetryRegistry implements TelemetryDispatcher {
 
   trackAgentWorkflowApplied(metadata: AgentWorkflowAppliedMetadata): void {
     this.dispatch((provider) => provider.trackAgentWorkflowApplied?.(metadata))
+  }
+
+  trackAgentError(metadata: AgentErrorMetadata): void {
+    this.dispatch((provider) => provider.trackAgentError?.(metadata))
   }
 
   trackWidgetFavoriteToggled(metadata: WidgetFavoriteToggledMetadata): void {

--- a/src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.ts
@@ -13,6 +13,7 @@ import { getExecutionContext } from '@/platform/telemetry/utils/getExecutionCont
 import type {
   AddCreditsClickMetadata,
   AgentEntryButtonClickedMetadata,
+  AgentErrorMetadata,
   AgentMessageSentMetadata,
   AgentMessageFeedbackMetadata,
   AgentNodeTaggedMetadata,
@@ -706,6 +707,10 @@ export class PostHogTelemetryProvider implements TelemetryProvider {
 
   trackAgentWorkflowApplied(metadata: AgentWorkflowAppliedMetadata): void {
     this.trackEvent(TelemetryEvents.AGENT_WORKFLOW_APPLIED, metadata)
+  }
+
+  trackAgentError(metadata: AgentErrorMetadata): void {
+    this.trackEvent(TelemetryEvents.AGENT_ERROR, metadata)
   }
 
   trackWidgetFavoriteToggled(metadata: WidgetFavoriteToggledMetadata): void {

--- a/src/platform/telemetry/types.ts
+++ b/src/platform/telemetry/types.ts
@@ -609,6 +609,26 @@ export interface AgentWorkflowAppliedMetadata extends Record<string, unknown> {
 }
 
 /**
+ * Normalized agent failure class, shared across `app:agent_error` sites so
+ * failures stay comparable regardless of where in the turn lifecycle they
+ * occurred (pre-acceptance request failure, busy-state rejection, or a
+ * post-acceptance stream/event error not represented by `agent_turn_failed`).
+ */
+export type AgentErrorClass =
+  | 'request_failed'
+  | 'send_busy'
+  | 'malformed_stream_event'
+  | 'cancel_failed'
+  | 'history_load_failed'
+export interface AgentErrorMetadata extends Record<string, unknown> {
+  error_class: AgentErrorClass
+  failure_stage: 'pre_acceptance' | 'post_acceptance'
+  retryable: boolean
+  turn_accepted: boolean
+  ui_treatment: 'inline_notice' | 'error_overlay' | 'toast'
+}
+
+/**
  * Widget (input/parameter) favorite toggle tracking metadata.
  * Used to measure discoverability of the right side panel favoriting feature.
  */
@@ -1127,6 +1147,7 @@ export interface TelemetryProvider {
   trackAgentNodeTagged?(metadata: AgentNodeTaggedMetadata): void
   trackAgentAttachButtonClicked?(): void
   trackAgentWorkflowApplied?(metadata: AgentWorkflowAppliedMetadata): void
+  trackAgentError?(metadata: AgentErrorMetadata): void
 
   // Right side panel widget favorite events
   trackWidgetFavoriteToggled?(metadata: WidgetFavoriteToggledMetadata): void
@@ -1297,6 +1318,7 @@ export const TelemetryEvents = {
   AGENT_NODE_TAGGED: 'app:agent_node_tagged',
   AGENT_ATTACH_BUTTON_CLICKED: 'app:agent_attach_button_clicked',
   AGENT_WORKFLOW_APPLIED: 'app:agent_workflow_applied',
+  AGENT_ERROR: 'app:agent_error',
 
   // Right Side Panel Widget Favorites
   WIDGET_FAVORITE_TOGGLED: 'app:widget_favorite_toggled',

--- a/src/platform/telemetry/types.ts
+++ b/src/platform/telemetry/types.ts
@@ -616,7 +616,6 @@ export interface AgentWorkflowAppliedMetadata extends Record<string, unknown> {
  */
 export type AgentErrorClass =
   | 'request_failed'
-  | 'send_busy'
   | 'malformed_stream_event'
   | 'cancel_failed'
   | 'history_load_failed'

--- a/src/platform/telemetry/types.ts
+++ b/src/platform/telemetry/types.ts
@@ -619,6 +619,9 @@ export type AgentErrorClass =
   | 'malformed_stream_event'
   | 'cancel_failed'
   | 'history_load_failed'
+  | 'ask_answer_failed'
+  | 'thread_list_load_failed'
+  | 'workflow_open_failed'
 export interface AgentErrorMetadata extends Record<string, unknown> {
   error_class: AgentErrorClass
   failure_stage: 'pre_acceptance' | 'post_acceptance'

--- a/src/platform/telemetry/types.ts
+++ b/src/platform/telemetry/types.ts
@@ -608,12 +608,6 @@ export interface AgentWorkflowAppliedMetadata extends Record<string, unknown> {
   target: 'active_tab_switch' | 'active_tab_open'
 }
 
-/**
- * Normalized agent failure class, shared across `app:agent_error` sites so
- * failures stay comparable regardless of where in the turn lifecycle they
- * occurred (pre-acceptance request failure, busy-state rejection, or a
- * post-acceptance stream/event error not represented by `agent_turn_failed`).
- */
 export type AgentErrorClass =
   | 'request_failed'
   | 'malformed_stream_event'
@@ -627,12 +621,7 @@ export interface AgentErrorMetadata extends Record<string, unknown> {
   failure_stage: 'pre_acceptance' | 'post_acceptance'
   retryable: boolean
   turn_accepted: boolean
-  /**
-   * What the user saw. `none` is a failure the FE handled silently — currently
-   * a malformed stream frame that is dropped with a `console.warn` no cloud
-   * console can read — and separates "our schema drifted" from "the drift
-   * reached a user".
-   */
+  /** `none` is a failure the user was never shown. */
   ui_treatment: 'inline_notice' | 'error_overlay' | 'toast' | 'none'
 }
 

--- a/src/platform/telemetry/types.ts
+++ b/src/platform/telemetry/types.ts
@@ -625,7 +625,13 @@ export interface AgentErrorMetadata extends Record<string, unknown> {
   failure_stage: 'pre_acceptance' | 'post_acceptance'
   retryable: boolean
   turn_accepted: boolean
-  ui_treatment: 'inline_notice' | 'error_overlay' | 'toast'
+  /**
+   * What the user saw. `none` is a failure the FE handled silently — currently
+   * a malformed stream frame that is dropped with a `console.warn` no cloud
+   * console can read — and separates "our schema drifted" from "the drift
+   * reached a user".
+   */
+  ui_treatment: 'inline_notice' | 'error_overlay' | 'toast' | 'none'
 }
 
 /**

--- a/src/workbench/extensions/agent/AgentPanelRoot.test.ts
+++ b/src/workbench/extensions/agent/AgentPanelRoot.test.ts
@@ -1649,6 +1649,36 @@ describe('AgentPanelRoot history', () => {
     await nextTick()
   }
 
+  it('tracks a thread-list load the user is shown an overlay for', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (url: string) =>
+        url.endsWith('/api/agent/threads')
+          ? new Response('{"error":"boom"}', {
+              status: 500,
+              headers: { 'Content-Type': 'application/json' }
+            })
+          : new Response('[]', {
+              status: 200,
+              headers: { 'Content-Type': 'application/json' }
+            })
+      )
+    )
+    telemetry.trackAgentError.mockClear()
+
+    render(AgentPanelRoot, { global: { plugins: [i18n] } })
+
+    await vi.waitFor(() =>
+      expect(telemetry.trackAgentError).toHaveBeenCalledWith({
+        error_class: 'thread_list_load_failed',
+        failure_stage: 'pre_acceptance',
+        retryable: true,
+        turn_accepted: false,
+        ui_treatment: 'error_overlay'
+      })
+    )
+  })
+
   it('renames the current chat from the title menu on Enter', async () => {
     await renderWithActiveThread()
 
@@ -2706,6 +2736,27 @@ describe('AgentPanelRoot workflow binding', () => {
     ws.emit('agent_active_tab', { workflow_id: 'wf-a', thread_id: 'th-1' })
     await vi.waitFor(() =>
       expect(activity.editingTabPath).toBe('workflows/Unsaved Workflow.json')
+    )
+  })
+
+  it('tracks a tab activation the agent asked for but the FE could not open', async () => {
+    makeTab('wf-42')
+    mockMessagesEndpoint('wf-42')
+    workflowService.openWorkflow.mockRejectedValueOnce(new Error('open boom'))
+
+    await renderAndSend('work here')
+    telemetry.trackAgentError.mockClear()
+
+    ws.emit('agent_active_tab', { workflow_id: 'wf-42', thread_id: 'th-1' })
+
+    await vi.waitFor(() =>
+      expect(telemetry.trackAgentError).toHaveBeenCalledWith({
+        error_class: 'workflow_open_failed',
+        failure_stage: 'post_acceptance',
+        retryable: false,
+        turn_accepted: true,
+        ui_treatment: 'error_overlay'
+      })
     )
   })
 

--- a/src/workbench/extensions/agent/AgentPanelRoot.test.ts
+++ b/src/workbench/extensions/agent/AgentPanelRoot.test.ts
@@ -591,11 +591,13 @@ describe('AgentPanelRoot session notices', () => {
       type: 'agent_api_failed',
       details: i18n.global.t('agent.malformedEvent')
     })
+    // Nothing has been sent, so there is no accepted turn for this frame to
+    // have interrupted: the panel is idle and the overlay is all the user gets.
     expect(telemetry.trackAgentError).toHaveBeenCalledWith({
       error_class: 'malformed_stream_event',
-      failure_stage: 'post_acceptance',
+      failure_stage: 'pre_acceptance',
       retryable: false,
-      turn_accepted: true,
+      turn_accepted: false,
       ui_treatment: 'error_overlay'
     })
   })

--- a/src/workbench/extensions/agent/AgentPanelRoot.test.ts
+++ b/src/workbench/extensions/agent/AgentPanelRoot.test.ts
@@ -202,7 +202,8 @@ const telemetry = vi.hoisted(() => ({
   trackAgentAttachButtonClicked: vi.fn(),
   trackAgentCloseButtonClicked: vi.fn(),
   trackAgentPanelOpened: vi.fn(),
-  trackAgentPanelClosed: vi.fn()
+  trackAgentPanelClosed: vi.fn(),
+  trackAgentError: vi.fn()
 }))
 vi.mock<unknown>(import('@/platform/telemetry'), () => ({
   useTelemetry: () => telemetry
@@ -589,6 +590,13 @@ describe('AgentPanelRoot session notices', () => {
     expect(executionErrors.lastPromptError).toMatchObject({
       type: 'agent_api_failed',
       details: i18n.global.t('agent.malformedEvent')
+    })
+    expect(telemetry.trackAgentError).toHaveBeenCalledWith({
+      error_class: 'malformed_stream_event',
+      failure_stage: 'post_acceptance',
+      retryable: false,
+      turn_accepted: true,
+      ui_treatment: 'error_overlay'
     })
   })
 })

--- a/src/workbench/extensions/agent/AgentPanelRoot.test.ts
+++ b/src/workbench/extensions/agent/AgentPanelRoot.test.ts
@@ -591,8 +591,6 @@ describe('AgentPanelRoot session notices', () => {
       type: 'agent_api_failed',
       details: i18n.global.t('agent.malformedEvent')
     })
-    // Nothing has been sent, so there is no accepted turn for this frame to
-    // have interrupted: the panel is idle and the overlay is all the user gets.
     expect(telemetry.trackAgentError).toHaveBeenCalledWith({
       error_class: 'malformed_stream_event',
       failure_stage: 'pre_acceptance',

--- a/src/workbench/extensions/agent/AgentPanelRoot.vue
+++ b/src/workbench/extensions/agent/AgentPanelRoot.vue
@@ -83,7 +83,11 @@ import type {
   TurnOrigin,
   WorkflowTurnContext
 } from './composables/agent/useAgentSession'
-import { useAgentSession } from './composables/agent/useAgentSession'
+import {
+  isRetryableRequestFailure,
+  trackAgentError,
+  useAgentSession
+} from './composables/agent/useAgentSession'
 import { useAgentWorkflowTabBindingStore } from './stores/agent/agentWorkflowTabBindingStore'
 import { createAgentRestClient } from './services/agent/agentRestClient'
 import type { AgentPaywallAction } from './services/agent/agentPaywallPresentation'
@@ -658,9 +662,18 @@ async function onAgentActiveTab(
   } catch (error) {
     if (stale()) return
     bindWorkflow(data.workflow_id)
+    reportError(error, { errorType: 'agent_workflow_open_failed' })
     surfaceAgentError(
       'agent_api_failed',
       error instanceof Error ? error.message : String(error)
+    )
+    trackAgentError(
+      'workflow_open_failed',
+      'post_acceptance',
+      'error_overlay',
+      {
+        retryable: false
+      }
     )
   } finally {
     tabActivity.setCreating(false)
@@ -703,9 +716,16 @@ async function refreshHistory(): Promise<void> {
   try {
     history.replaceAll((await listThreads()).map(toChatSession))
   } catch (error) {
+    reportError(error, { errorType: 'agent_thread_list_load_failed' })
     surfaceAgentError(
       'agent_api_failed',
       error instanceof Error ? error.message : String(error)
+    )
+    trackAgentError(
+      'thread_list_load_failed',
+      'pre_acceptance',
+      'error_overlay',
+      { retryable: isRetryableRequestFailure(error, false) }
     )
   }
 }

--- a/src/workbench/extensions/agent/composables/agent/useAgentSession.test.ts
+++ b/src/workbench/extensions/agent/composables/agent/useAgentSession.test.ts
@@ -2192,8 +2192,6 @@ describe('app:agent_error telemetry (TEL-8)', () => {
     emit({ type: 'agent_message_done', data: { thread_id: 'th-1' } })
 
     const [error, options] = vi.mocked(reportError).mock.calls[0]
-    // ZodError.message is JSON.stringify(issues): reporting it as the error
-    // itself gives Sentry one group per field path.
     expect((error as Error).message).toBe('Malformed agent stream event')
     expect(options.tags?.event_type).toBe('agent_message_done')
     expect(options.context?.issues).toEqual(expect.any(Array))
@@ -2306,9 +2304,7 @@ describe('app:agent_error telemetry (TEL-8)', () => {
   it('treats an unreadable ack body as an accepted turn', async () => {
     const rest = fakeRest({
       postMessage: vi.fn(async () => {
-        // `AgentRestClient` parses only after `response.ok`, so this is what a
-        // 2xx with an unexpected body raises: the turn started, the ack did not
-        // survive validation.
+        // What a 2xx with an unexpected body raises past `response.ok`.
         return zAgentTurnAccepted.parse({ thread_id: 'th-1' })
       })
     })
@@ -2472,9 +2468,7 @@ describe('app:agent_error telemetry (TEL-8)', () => {
     for (let i = 0; i < 20; i++)
       emit({ type: 'agent_message_done', data: { thread_id: 'th-1' } })
 
-    // One for the turn the first frame aborted, one for the idle session the
-    // other nineteen arrived into. The count is what matters: a stream that
-    // never stops repeating cannot grow the capture count with it.
+    // The aborted turn, then the idle session the other nineteen arrived into.
     expect(telemetryState.trackAgentError).toHaveBeenCalledTimes(2)
   })
 

--- a/src/workbench/extensions/agent/composables/agent/useAgentSession.test.ts
+++ b/src/workbench/extensions/agent/composables/agent/useAgentSession.test.ts
@@ -6,6 +6,14 @@ import { reportError } from '@/platform/telemetry/reportError'
 import { createNodeLocatorId } from '@/types/nodeIdentification'
 import { toNodeId } from '@/types/nodeId'
 
+const telemetryState = vi.hoisted(() => ({
+  trackAgentError: vi.fn()
+}))
+
+vi.mock('@/platform/telemetry', () => ({
+  useTelemetry: () => ({ trackAgentError: telemetryState.trackAgentError })
+}))
+
 import type {
   AgentAnswerAccepted,
   AgentCancelAccepted,
@@ -2109,5 +2117,135 @@ describe('thread resume (B17)', () => {
     const threads = await session.listThreads()
     expect(threads).toHaveLength(1)
     expect(threads[0]).toMatchObject({ id: 'th-9', title: 'build a duck' })
+  })
+})
+
+describe('app:agent_error telemetry (TEL-8)', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    localStorage.clear()
+    telemetryState.trackAgentError.mockClear()
+  })
+
+  it('tracks a pre-acceptance request failure from a rejected postMessage', async () => {
+    const rest = fakeRest({
+      postMessage: vi.fn(async () => {
+        throw new AgentApiError('boom', 500, null)
+      })
+    })
+    const session = useAgentSession({ rest, events: fakeEvents().source })
+    session.start()
+
+    const ok = await session.sendMessage('make me a cat')
+
+    expect(ok).toBe(false)
+    expect(telemetryState.trackAgentError).toHaveBeenCalledWith({
+      error_class: 'request_failed',
+      failure_stage: 'pre_acceptance',
+      retryable: true,
+      turn_accepted: false,
+      ui_treatment: 'inline_notice'
+    })
+  })
+
+  it('tracks a pre-acceptance busy-state rejection when a send is already in flight', async () => {
+    let resolvePost: (value: AgentTurnAccepted) => void = () => undefined
+    const rest = fakeRest({
+      postMessage: vi.fn(
+        () =>
+          new Promise<AgentTurnAccepted>((resolve) => {
+            resolvePost = resolve
+          })
+      )
+    })
+    const session = useAgentSession({ rest, events: fakeEvents().source })
+    session.start()
+
+    const first = session.sendMessage('first')
+    const ok = await session.sendMessage('second')
+
+    expect(ok).toBe(false)
+    expect(telemetryState.trackAgentError).toHaveBeenCalledWith({
+      error_class: 'send_busy',
+      failure_stage: 'pre_acceptance',
+      retryable: true,
+      turn_accepted: false,
+      ui_treatment: 'inline_notice'
+    })
+    resolvePost({ thread_id: 'th-1', message_id: 'msg-1' })
+    await first
+  })
+
+  it('tracks a post-acceptance cancel failure', async () => {
+    const rest = fakeRest({
+      cancelMessage: vi.fn(async () => {
+        throw new AgentApiError('cancel boom', 500, null)
+      })
+    })
+    const session = useAgentSession({ rest, events: fakeEvents().source })
+    session.start()
+    await session.sendMessage('go')
+
+    await session.stopTurn()
+
+    expect(telemetryState.trackAgentError).toHaveBeenCalledWith({
+      error_class: 'cancel_failed',
+      failure_stage: 'post_acceptance',
+      retryable: false,
+      turn_accepted: true,
+      ui_treatment: 'error_overlay'
+    })
+  })
+
+  it('does not track a 409 cancel race as an error', async () => {
+    const rest = fakeRest({
+      cancelMessage: vi.fn(async () => {
+        throw new AgentApiError('already done', 409, null)
+      })
+    })
+    const session = useAgentSession({ rest, events: fakeEvents().source })
+    session.start()
+    await session.sendMessage('go')
+
+    await session.stopTurn()
+
+    expect(telemetryState.trackAgentError).not.toHaveBeenCalled()
+  })
+
+  it('tracks a post-acceptance malformed stream event for the active turn', async () => {
+    const { source, emit } = fakeEvents()
+    const session = useAgentSession({ rest: fakeRest(), events: source })
+    session.start()
+    await session.sendMessage('go')
+
+    emit({ type: 'agent_message_done', data: { thread_id: 'th-1' } })
+
+    expect(telemetryState.trackAgentError).toHaveBeenCalledWith({
+      error_class: 'malformed_stream_event',
+      failure_stage: 'post_acceptance',
+      retryable: false,
+      turn_accepted: true,
+      ui_treatment: 'error_overlay'
+    })
+  })
+
+  it('tracks a pre-acceptance thread-history load failure', async () => {
+    const rest = fakeRest({
+      getMessages: vi.fn(async () => {
+        throw new Error('history boom')
+      })
+    })
+    const session = useAgentSession({ rest, events: fakeEvents().source })
+    session.start()
+
+    await session.loadThread('th-9')
+
+    expect(telemetryState.trackAgentError).toHaveBeenCalledWith({
+      error_class: 'history_load_failed',
+      failure_stage: 'pre_acceptance',
+      retryable: true,
+      turn_accepted: false,
+      ui_treatment: 'error_overlay'
+    })
   })
 })

--- a/src/workbench/extensions/agent/composables/agent/useAgentSession.test.ts
+++ b/src/workbench/extensions/agent/composables/agent/useAgentSession.test.ts
@@ -29,7 +29,10 @@ import {
   zAgentTurnAccepted,
   zAgentWsEvent
 } from '../../schemas/agentApiSchema'
-import { AgentApiError } from '../../services/agent/agentRestClient'
+import {
+  AgentApiError,
+  AgentResponseUnreadableError
+} from '../../services/agent/agentRestClient'
 import type {
   AgentRestClient,
   PostMessageInput
@@ -2268,6 +2271,29 @@ describe('app:agent_error telemetry (TEL-8)', () => {
         // 2xx with an unexpected body raises: the turn started, the ack did not
         // survive validation.
         return zAgentTurnAccepted.parse({ thread_id: 'th-1' })
+      })
+    })
+    const session = useAgentSession({ rest, events: fakeEvents().source })
+    session.start()
+
+    await session.sendMessage('make me a cat')
+
+    expect(telemetryState.trackAgentError).toHaveBeenCalledWith({
+      error_class: 'request_failed',
+      failure_stage: 'post_acceptance',
+      retryable: false,
+      turn_accepted: true,
+      ui_treatment: 'inline_notice'
+    })
+  })
+
+  it('treats an ack body the client could not read as an accepted turn', async () => {
+    const rest = fakeRest({
+      postMessage: vi.fn(async () => {
+        throw new AgentResponseUnreadableError(
+          '/agent/threads/new/messages',
+          new SyntaxError('Unexpected end of JSON input')
+        )
       })
     })
     const session = useAgentSession({ rest, events: fakeEvents().source })

--- a/src/workbench/extensions/agent/composables/agent/useAgentSession.test.ts
+++ b/src/workbench/extensions/agent/composables/agent/useAgentSession.test.ts
@@ -10,7 +10,7 @@ const telemetryState = vi.hoisted(() => ({
   trackAgentError: vi.fn()
 }))
 
-vi.mock('@/platform/telemetry', () => ({
+vi.mock<unknown>(import('@/platform/telemetry'), () => ({
   useTelemetry: () => ({ trackAgentError: telemetryState.trackAgentError })
 }))
 
@@ -2123,7 +2123,6 @@ describe('thread resume (B17)', () => {
 
 describe('app:agent_error telemetry (TEL-8)', () => {
   beforeEach(() => {
-    setActivePinia(createPinia())
     localStorage.clear()
     telemetryState.trackAgentError.mockClear()
     vi.mocked(reportError).mockClear()

--- a/src/workbench/extensions/agent/composables/agent/useAgentSession.test.ts
+++ b/src/workbench/extensions/agent/composables/agent/useAgentSession.test.ts
@@ -2126,6 +2126,72 @@ describe('app:agent_error telemetry (TEL-8)', () => {
     setActivePinia(createPinia())
     localStorage.clear()
     telemetryState.trackAgentError.mockClear()
+    vi.mocked(reportError).mockClear()
+  })
+
+  it('reports unexpected agent failures to the unified error sinks', async () => {
+    const { source, emit } = fakeEvents()
+    const session = useAgentSession({
+      rest: fakeRest({
+        getMessages: vi.fn(async () => {
+          throw new Error('history boom')
+        }),
+        cancelMessage: vi.fn(async () => {
+          throw new AgentApiError('cancel boom', 500, null)
+        })
+      }),
+      events: source
+    })
+    session.start()
+    await session.loadThread('th-9')
+    await session.sendMessage('go')
+    await session.stopTurn()
+    emit({ type: 'agent_message_done', data: { thread_id: 'th-1' } })
+
+    const errorTypes = vi
+      .mocked(reportError)
+      .mock.calls.map(([, options]) => options.errorType)
+    expect(errorTypes).toEqual([
+      'agent_history_load_failed',
+      'agent_cancel_turn_failed',
+      'agent_malformed_stream_event'
+    ])
+  })
+
+  it('reports a rejected send to the unified error sinks', async () => {
+    const rest = fakeRest({
+      postMessage: vi.fn(async () => {
+        throw new AgentApiError('boom', 500, null)
+      })
+    })
+    const session = useAgentSession({ rest, events: fakeEvents().source })
+    session.start()
+
+    await session.sendMessage('make me a cat')
+
+    expect(reportError).toHaveBeenCalledWith(expect.any(AgentApiError), {
+      errorType: 'agent_send_message_failed'
+    })
+  })
+
+  it('keeps the expected 404 history and 409 cancel races out of the sinks', async () => {
+    const session = useAgentSession({
+      rest: fakeRest({
+        getMessages: vi.fn(async () => {
+          throw new AgentApiError('gone', 404, null)
+        }),
+        cancelMessage: vi.fn(async () => {
+          throw new AgentApiError('already done', 409, null)
+        })
+      }),
+      events: fakeEvents().source
+    })
+    session.start()
+    await session.loadThread('th-gone')
+    await session.sendMessage('go')
+    await session.stopTurn()
+
+    expect(reportError).not.toHaveBeenCalled()
   })
 
   it('tracks a pre-acceptance request failure from a rejected postMessage', async () => {

--- a/src/workbench/extensions/agent/composables/agent/useAgentSession.test.ts
+++ b/src/workbench/extensions/agent/composables/agent/useAgentSession.test.ts
@@ -2160,6 +2160,30 @@ describe('app:agent_error telemetry (TEL-8)', () => {
     ])
   })
 
+  it('dedupes a background turn malformed frame under that turn, not the active one', async () => {
+    const postMessage = vi
+      .fn<
+        (threadId: string, req: PostMessageInput) => Promise<AgentTurnAccepted>
+      >()
+      .mockResolvedValueOnce({ thread_id: 'th-1', message_id: 'msg-1' })
+      .mockResolvedValueOnce({ thread_id: 'th-2', message_id: 'msg-2' })
+    const { source, emit } = fakeEvents()
+    const session = useAgentSession({
+      rest: fakeRest({ postMessage }),
+      events: source
+    })
+    session.start()
+    await session.sendMessage('first')
+    await session.loadThread('th-2')
+    await session.sendMessage('second')
+    telemetryState.trackAgentError.mockClear()
+
+    emit({ type: 'agent_message_done', data: { message_id: 'msg-1' } })
+    emit({ type: 'agent_message_delta', data: { wrong: 'shape' } })
+
+    expect(telemetryState.trackAgentError).toHaveBeenCalledTimes(2)
+  })
+
   it('groups malformed frames under one Sentry issue, detail in context', async () => {
     const { source, emit } = fakeEvents()
     const session = useAgentSession({ rest: fakeRest(), events: source })

--- a/src/workbench/extensions/agent/composables/agent/useAgentSession.test.ts
+++ b/src/workbench/extensions/agent/composables/agent/useAgentSession.test.ts
@@ -2323,6 +2323,74 @@ describe('app:agent_error telemetry (TEL-8)', () => {
     })
   })
 
+  it('does not claim an accepted turn for a malformed frame on an idle session', async () => {
+    const { source, emit } = fakeEvents()
+    const session = useAgentSession({ rest: fakeRest(), events: source })
+    session.start()
+
+    emit({ type: 'agent_message_done', data: { thread_id: 'th-1' } })
+
+    expect(telemetryState.trackAgentError).toHaveBeenCalledWith({
+      error_class: 'malformed_stream_event',
+      failure_stage: 'pre_acceptance',
+      retryable: false,
+      turn_accepted: false,
+      ui_treatment: 'error_overlay'
+    })
+  })
+
+  it('bounds a repeating malformed stream to one report per turn', async () => {
+    const { source, emit } = fakeEvents()
+    const session = useAgentSession({ rest: fakeRest(), events: source })
+    session.start()
+    await session.sendMessage('go')
+
+    for (let i = 0; i < 20; i++)
+      emit({ type: 'agent_message_done', data: { thread_id: 'th-1' } })
+
+    // One for the turn the first frame aborted, one for the idle session the
+    // other nineteen arrived into. The count is what matters: a stream that
+    // never stops repeating cannot grow the capture count with it.
+    expect(telemetryState.trackAgentError).toHaveBeenCalledTimes(2)
+  })
+
+  it('tracks malformed frames of event types that never reach the user', async () => {
+    const { source, emit } = fakeEvents()
+    const session = useAgentSession({ rest: fakeRest(), events: source })
+    session.start()
+    await session.sendMessage('go')
+
+    emit({ type: 'agent_message_delta', data: { thread_id: 'th-1' } })
+
+    expect(telemetryState.trackAgentError).toHaveBeenCalledWith({
+      error_class: 'malformed_stream_event',
+      failure_stage: 'post_acceptance',
+      retryable: false,
+      turn_accepted: true,
+      ui_treatment: 'none'
+    })
+    expect(session.notices.value).toEqual([])
+  })
+
+  it('still reports the frame that escalates to the user after a silent one', async () => {
+    const { source, emit } = fakeEvents()
+    const session = useAgentSession({ rest: fakeRest(), events: source })
+    session.start()
+    await session.sendMessage('go')
+
+    emit({ type: 'agent_message_delta', data: { thread_id: 'th-1' } })
+    emit({ type: 'agent_message_done', data: { thread_id: 'th-1' } })
+
+    expect(telemetryState.trackAgentError).toHaveBeenCalledTimes(2)
+    expect(telemetryState.trackAgentError).toHaveBeenLastCalledWith({
+      error_class: 'malformed_stream_event',
+      failure_stage: 'post_acceptance',
+      retryable: false,
+      turn_accepted: true,
+      ui_treatment: 'error_overlay'
+    })
+  })
+
   it('tracks a pre-acceptance thread-history load failure', async () => {
     const rest = fakeRest({
       getMessages: vi.fn(async () => {

--- a/src/workbench/extensions/agent/composables/agent/useAgentSession.test.ts
+++ b/src/workbench/extensions/agent/composables/agent/useAgentSession.test.ts
@@ -2333,7 +2333,7 @@ describe('app:agent_error telemetry (TEL-8)', () => {
     })
   })
 
-  it('tracks a pre-acceptance busy-state rejection when a send is already in flight', async () => {
+  it('does not count a busy-state double-submit as an agent error', async () => {
     let resolvePost: (value: AgentTurnAccepted) => void = () => undefined
     const rest = fakeRest({
       postMessage: vi.fn(
@@ -2350,13 +2350,7 @@ describe('app:agent_error telemetry (TEL-8)', () => {
     const ok = await session.sendMessage('second')
 
     expect(ok).toBe(false)
-    expect(telemetryState.trackAgentError).toHaveBeenCalledWith({
-      error_class: 'send_busy',
-      failure_stage: 'pre_acceptance',
-      retryable: true,
-      turn_accepted: false,
-      ui_treatment: 'inline_notice'
-    })
+    expect(telemetryState.trackAgentError).not.toHaveBeenCalled()
     resolvePost({ thread_id: 'th-1', message_id: 'msg-1' })
     await first
   })

--- a/src/workbench/extensions/agent/composables/agent/useAgentSession.test.ts
+++ b/src/workbench/extensions/agent/composables/agent/useAgentSession.test.ts
@@ -2496,6 +2496,50 @@ describe('app:agent_error telemetry (TEL-8)', () => {
     })
   })
 
+  it('tracks a failed ask answer, which leaves the running turn blocked', async () => {
+    const answerAsk = vi
+      .fn<AgentRestClient['answerAsk']>()
+      .mockRejectedValue(new AgentApiError('ask boom', 500, null))
+    const { source, emit } = fakeEvents()
+    const session = useAgentSession({
+      rest: fakeRest({ answerAsk }),
+      events: source
+    })
+    session.start()
+    await session.sendMessage('build it')
+    emit(runApproval('msg-1'))
+    telemetryState.trackAgentError.mockClear()
+
+    await session.answerAsk('turn-1:call-1', 'run')
+
+    expect(telemetryState.trackAgentError).toHaveBeenCalledWith({
+      error_class: 'ask_answer_failed',
+      failure_stage: 'post_acceptance',
+      retryable: true,
+      turn_accepted: true,
+      ui_treatment: 'error_overlay'
+    })
+  })
+
+  it('does not track a 409 stale ask answer as an error', async () => {
+    const answerAsk = vi
+      .fn<AgentRestClient['answerAsk']>()
+      .mockRejectedValue(new AgentApiError('already answered', 409, undefined))
+    const { source, emit } = fakeEvents()
+    const session = useAgentSession({
+      rest: fakeRest({ answerAsk }),
+      events: source
+    })
+    session.start()
+    await session.sendMessage('build it')
+    emit(runApproval('msg-1'))
+    telemetryState.trackAgentError.mockClear()
+
+    await session.answerAsk('turn-1:call-1', 'cancel')
+
+    expect(telemetryState.trackAgentError).not.toHaveBeenCalled()
+  })
+
   it('derives history-load retryability from the status, as request_failed does', async () => {
     const rest = fakeRest({
       getMessages: vi.fn(async () => {

--- a/src/workbench/extensions/agent/composables/agent/useAgentSession.test.ts
+++ b/src/workbench/extensions/agent/composables/agent/useAgentSession.test.ts
@@ -26,6 +26,7 @@ import type {
 } from '../../schemas/agentApiSchema'
 import {
   zAgentAdmissionError,
+  zAgentTurnAccepted,
   zAgentWsEvent
 } from '../../schemas/agentApiSchema'
 import { AgentApiError } from '../../services/agent/agentRestClient'
@@ -2148,6 +2149,99 @@ describe('app:agent_error telemetry (TEL-8)', () => {
     })
   })
 
+  it('marks a deterministic send rejection unretryable', async () => {
+    const rest = fakeRest({
+      postMessage: vi.fn(async () => {
+        throw new AgentApiError('unprocessable', 422, null)
+      })
+    })
+    const session = useAgentSession({ rest, events: fakeEvents().source })
+    session.start()
+
+    await session.sendMessage('make me a cat')
+
+    expect(telemetryState.trackAgentError).toHaveBeenCalledWith({
+      error_class: 'request_failed',
+      failure_stage: 'pre_acceptance',
+      retryable: false,
+      turn_accepted: false,
+      ui_treatment: 'inline_notice'
+    })
+  })
+
+  it('classifies a failure after the ack as post-acceptance and unretryable', async () => {
+    const rest = fakeRest()
+    const session = useAgentSession({ rest, events: fakeEvents().source })
+    session.start()
+    const setItem = vi
+      .spyOn(globalThis.localStorage, 'setItem')
+      .mockImplementation(() => {
+        throw new DOMException('quota', 'QuotaExceededError')
+      })
+
+    try {
+      const ok = await session.sendMessage('make me a cat')
+      expect(ok).toBe(false)
+    } finally {
+      setItem.mockRestore()
+    }
+
+    expect(rest.postMessage).toHaveBeenCalledTimes(1)
+    expect(telemetryState.trackAgentError).toHaveBeenCalledWith({
+      error_class: 'request_failed',
+      failure_stage: 'post_acceptance',
+      retryable: false,
+      turn_accepted: true,
+      ui_treatment: 'inline_notice'
+    })
+  })
+
+  it('treats an unreadable ack body as an accepted turn', async () => {
+    const rest = fakeRest({
+      postMessage: vi.fn(async () => {
+        // `AgentRestClient` parses only after `response.ok`, so this is what a
+        // 2xx with an unexpected body raises: the turn started, the ack did not
+        // survive validation.
+        return zAgentTurnAccepted.parse({ thread_id: 'th-1' })
+      })
+    })
+    const session = useAgentSession({ rest, events: fakeEvents().source })
+    session.start()
+
+    await session.sendMessage('make me a cat')
+
+    expect(telemetryState.trackAgentError).toHaveBeenCalledWith({
+      error_class: 'request_failed',
+      failure_stage: 'post_acceptance',
+      retryable: false,
+      turn_accepted: true,
+      ui_treatment: 'inline_notice'
+    })
+  })
+
+  it('reports a stashed live turn when the resume history load fails', async () => {
+    const getMessages = vi
+      .fn<AgentRestClient['getMessages']>()
+      .mockRejectedValue(new Error('history boom'))
+    const session = useAgentSession({
+      rest: fakeRest({ getMessages }),
+      events: fakeEvents().source
+    })
+    session.start()
+    await session.sendMessage('go')
+    expect(useAgentConversationStore().activeTurnId).not.toBeNull()
+
+    await session.loadThread('th-other')
+
+    expect(telemetryState.trackAgentError).toHaveBeenCalledWith({
+      error_class: 'history_load_failed',
+      failure_stage: 'pre_acceptance',
+      retryable: true,
+      turn_accepted: true,
+      ui_treatment: 'error_overlay'
+    })
+  })
+
   it('tracks a pre-acceptance busy-state rejection when a send is already in flight', async () => {
     let resolvePost: (value: AgentTurnAccepted) => void = () => undefined
     const rest = fakeRest({
@@ -2191,7 +2285,7 @@ describe('app:agent_error telemetry (TEL-8)', () => {
     expect(telemetryState.trackAgentError).toHaveBeenCalledWith({
       error_class: 'cancel_failed',
       failure_stage: 'post_acceptance',
-      retryable: false,
+      retryable: true,
       turn_accepted: true,
       ui_treatment: 'error_overlay'
     })

--- a/src/workbench/extensions/agent/composables/agent/useAgentSession.test.ts
+++ b/src/workbench/extensions/agent/composables/agent/useAgentSession.test.ts
@@ -2160,6 +2160,21 @@ describe('app:agent_error telemetry (TEL-8)', () => {
     ])
   })
 
+  it('groups malformed frames under one Sentry issue, detail in context', async () => {
+    const { source, emit } = fakeEvents()
+    const session = useAgentSession({ rest: fakeRest(), events: source })
+    session.start()
+
+    emit({ type: 'agent_message_done', data: { thread_id: 'th-1' } })
+
+    const [error, options] = vi.mocked(reportError).mock.calls[0]
+    // ZodError.message is JSON.stringify(issues): reporting it as the error
+    // itself gives Sentry one group per field path.
+    expect((error as Error).message).toBe('Malformed agent stream event')
+    expect(options.tags?.event_type).toBe('agent_message_done')
+    expect(options.context?.issues).toEqual(expect.any(Array))
+  })
+
   it('reports a rejected send to the unified error sinks', async () => {
     const rest = fakeRest({
       postMessage: vi.fn(async () => {

--- a/src/workbench/extensions/agent/composables/agent/useAgentSession.test.ts
+++ b/src/workbench/extensions/agent/composables/agent/useAgentSession.test.ts
@@ -2502,6 +2502,26 @@ describe('app:agent_error telemetry (TEL-8)', () => {
     })
   })
 
+  it('derives history-load retryability from the status, as request_failed does', async () => {
+    const rest = fakeRest({
+      getMessages: vi.fn(async () => {
+        throw new AgentApiError('access denied', 403, null)
+      })
+    })
+    const session = useAgentSession({ rest, events: fakeEvents().source })
+    session.start()
+
+    await session.loadThread('th-9')
+
+    expect(telemetryState.trackAgentError).toHaveBeenCalledWith({
+      error_class: 'history_load_failed',
+      failure_stage: 'pre_acceptance',
+      retryable: false,
+      turn_accepted: false,
+      ui_treatment: 'error_overlay'
+    })
+  })
+
   it('does not track a 404 thread-not-found history load as an error', async () => {
     const rest = fakeRest({
       getMessages: vi.fn(async () => {

--- a/src/workbench/extensions/agent/composables/agent/useAgentSession.test.ts
+++ b/src/workbench/extensions/agent/composables/agent/useAgentSession.test.ts
@@ -2248,4 +2248,19 @@ describe('app:agent_error telemetry (TEL-8)', () => {
       ui_treatment: 'error_overlay'
     })
   })
+
+  it('does not track a 404 thread-not-found history load as an error', async () => {
+    const rest = fakeRest({
+      getMessages: vi.fn(async () => {
+        throw new AgentApiError('gone', 404, null)
+      })
+    })
+    const session = useAgentSession({ rest, events: fakeEvents().source })
+    session.start()
+
+    await session.loadThread('th-gone')
+
+    expect(telemetryState.trackAgentError).not.toHaveBeenCalled()
+    expect(localStorage.getItem('Comfy.Agent.ThreadId')).toBeNull()
+  })
 })

--- a/src/workbench/extensions/agent/composables/agent/useAgentSession.ts
+++ b/src/workbench/extensions/agent/composables/agent/useAgentSession.ts
@@ -110,7 +110,10 @@ const NON_RETRYABLE_REQUEST_STATUSES = new Set([
  * Whether resending a failed agent request is safe. `accepted` is decisive: the
  * server is already running the turn, so a retry starts a second one.
  */
-function isRetryableRequestFailure(error: unknown, accepted: boolean): boolean {
+export function isRetryableRequestFailure(
+  error: unknown,
+  accepted: boolean
+): boolean {
   if (accepted) return false
   if (error instanceof AgentApiError)
     return !NON_RETRYABLE_REQUEST_STATUSES.has(error.status)
@@ -126,6 +129,29 @@ function isUnreadableAckFailure(error: unknown): boolean {
   return (
     error instanceof ZodError || error instanceof AgentResponseUnreadableError
   )
+}
+
+/**
+ * `app:agent_error` (TEL-8): every FE-visible agent failure the backend's
+ * `agent_turn_failed` does not already cover. Both booleans default from the
+ * stage and are overridable, because the stage only approximates them: a
+ * history load failing on the resume path is a request the server never
+ * accepted while an accepted turn streams on, and a failed cancel is
+ * post-acceptance yet safe to send again.
+ */
+export function trackAgentError(
+  errorClass: AgentErrorClass,
+  stage: AgentErrorMetadata['failure_stage'],
+  uiTreatment: AgentErrorMetadata['ui_treatment'],
+  overrides: { retryable?: boolean; turnAccepted?: boolean } = {}
+): void {
+  useTelemetry()?.trackAgentError({
+    error_class: errorClass,
+    failure_stage: stage,
+    retryable: overrides.retryable ?? stage === 'pre_acceptance',
+    turn_accepted: overrides.turnAccepted ?? stage === 'post_acceptance',
+    ui_treatment: uiTreatment
+  })
 }
 
 let sessionGeneration = 0
@@ -183,34 +209,6 @@ export function useAgentSession(deps: AgentSessionDeps) {
 
   function pushError(text: string): void {
     notices.value.push({ level: 'error', text })
-  }
-
-  /**
-   * `app:agent_error` (TEL-8): fires at every FE-visible agent failure site,
-   * pre- or post-acceptance, that is not already covered by the backend's
-   * `agent_turn_failed`. Both booleans default from the stage — a
-   * pre-acceptance failure never started a turn, so nothing was accepted and
-   * retrying is always safe, while a post-acceptance failure may have left
-   * server-side state the caller cannot fully retry — and both are
-   * overridable, because the stage and the two facts it approximates can
-   * disagree. A history load that fails on the resume path is a request the
-   * server never accepted (`pre_acceptance`) issued while an accepted turn is
-   * still streaming (`turn_accepted: true`), and a failed cancel is
-   * `post_acceptance` yet safe to send again.
-   */
-  function trackAgentError(
-    errorClass: AgentErrorClass,
-    stage: AgentErrorMetadata['failure_stage'],
-    uiTreatment: AgentErrorMetadata['ui_treatment'],
-    overrides: { retryable?: boolean; turnAccepted?: boolean } = {}
-  ): void {
-    useTelemetry()?.trackAgentError({
-      error_class: errorClass,
-      failure_stage: stage,
-      retryable: overrides.retryable ?? stage === 'pre_acceptance',
-      turn_accepted: overrides.turnAccepted ?? stage === 'post_acceptance',
-      ui_treatment: uiTreatment
-    })
   }
 
   /**
@@ -553,6 +551,9 @@ export function useAgentSession(deps: AgentSessionDeps) {
       }
       reportError(error, { errorType: 'agent_ask_answer_failed' })
       pushError(error instanceof Error ? error.message : String(error))
+      trackAgentError('ask_answer_failed', 'post_acceptance', 'error_overlay', {
+        retryable: true
+      })
     }
   }
 

--- a/src/workbench/extensions/agent/composables/agent/useAgentSession.ts
+++ b/src/workbench/extensions/agent/composables/agent/useAgentSession.ts
@@ -16,7 +16,10 @@ import {
   toTurnId,
   zAgentAdmissionError
 } from '../../schemas/agentApiSchema'
-import { AgentApiError } from '../../services/agent/agentRestClient'
+import {
+  AgentApiError,
+  AgentResponseUnreadableError
+} from '../../services/agent/agentRestClient'
 import type {
   AgentRestClient,
   DraftSnapshot,
@@ -115,12 +118,14 @@ function isRetryableRequestFailure(error: unknown, accepted: boolean): boolean {
 }
 
 /**
- * `AgentRestClient` validates a response body only after `response.ok`, so a
- * schema failure out of `postMessage` means the server accepted the turn and
- * the FE could not read the ack — post-acceptance, and never safe to resend.
+ * `AgentRestClient` reads a response body only after `response.ok`, so any
+ * failure to read it out of `postMessage` — unparseable body or schema
+ * mismatch — means the server accepted the turn and the FE lost the ack.
  */
-function isResponseSchemaFailure(error: unknown): boolean {
-  return error instanceof ZodError
+function isUnreadableAckFailure(error: unknown): boolean {
+  return (
+    error instanceof ZodError || error instanceof AgentResponseUnreadableError
+  )
 }
 
 let sessionGeneration = 0
@@ -462,7 +467,7 @@ export function useAgentSession(deps: AgentSessionDeps) {
         )
         return false
       }
-      const turnAccepted = accepted || isResponseSchemaFailure(error)
+      const turnAccepted = accepted || isUnreadableAckFailure(error)
       const message =
         error instanceof AgentApiError
           ? error.message

--- a/src/workbench/extensions/agent/composables/agent/useAgentSession.ts
+++ b/src/workbench/extensions/agent/composables/agent/useAgentSession.ts
@@ -331,6 +331,7 @@ export function useAgentSession(deps: AgentSessionDeps) {
         'pre_acceptance',
         'error_overlay',
         {
+          retryable: isRetryableRequestFailure(error, false),
           turnAccepted: stashedTurn
         }
       )

--- a/src/workbench/extensions/agent/composables/agent/useAgentSession.ts
+++ b/src/workbench/extensions/agent/composables/agent/useAgentSession.ts
@@ -363,7 +363,6 @@ export function useAgentSession(deps: AgentSessionDeps) {
         text,
         i18n.global.t('agent.sendBusy')
       )
-      trackAgentError('send_busy', 'pre_acceptance', 'inline_notice')
       return false
     }
     promptEditState.value = { phase: 'idle' }

--- a/src/workbench/extensions/agent/composables/agent/useAgentSession.ts
+++ b/src/workbench/extensions/agent/composables/agent/useAgentSession.ts
@@ -208,6 +208,47 @@ export function useAgentSession(deps: AgentSessionDeps) {
     })
   }
 
+  /**
+   * The last malformed-frame capture: which turn it belonged to (`null` for the
+   * idle stretch between turns) and whether the user saw it. A stream that has
+   * drifted from the schema, or a hostile one, repeats the same frame
+   * indefinitely, so the capture is deduped per turn rather than per frame —
+   * one report carries the same signal without an unbounded PostHog queue
+   * behind it. A later frame in the same turn is still reported if it escalates
+   * to something the user sees, since that is the case worth a dashboard.
+   */
+  let malformedStreamReport: {
+    turnId: TurnId | null
+    visible: boolean
+  } | null = null
+
+  /**
+   * Every frame that fails `parseAgentWsEvent` is schema drift worth measuring,
+   * not just the `agent_message_done` sub-case that reaches the user: the rest
+   * are dropped with a `console.warn` no cloud console can see. `uiTreatment`
+   * records which of the two the user actually saw. A malformed frame is never
+   * retryable — nothing here can be re-sent — and `post_acceptance` is claimed
+   * only when a turn really was running.
+   */
+  function trackMalformedStreamEvent(
+    activeTurnId: TurnId | null,
+    uiTreatment: AgentErrorMetadata['ui_treatment']
+  ): void {
+    const visible = uiTreatment !== 'none'
+    if (
+      malformedStreamReport?.turnId === activeTurnId &&
+      (malformedStreamReport.visible || !visible)
+    )
+      return
+    malformedStreamReport = { turnId: activeTurnId, visible }
+    trackAgentError(
+      'malformed_stream_event',
+      activeTurnId === null ? 'pre_acceptance' : 'post_acceptance',
+      uiTreatment,
+      { retryable: false }
+    )
+  }
+
   function start(): void {
     ownedGeneration = ++sessionGeneration
     everLive = false
@@ -539,6 +580,10 @@ export function useAgentSession(deps: AgentSessionDeps) {
     if (!parsed.success) {
       const messageId = (raw as { data?: { message_id?: unknown } }).data
         ?.message_id
+      // Read before the abort below clears it, or every aborted turn reports
+      // itself as having had no turn.
+      const activeTurnId = conversationStore.activeTurnId
+      let uiTreatment: AgentErrorMetadata['ui_treatment'] = 'none'
       if (type === 'agent_message_done') {
         if (
           typeof messageId !== 'string' ||
@@ -546,15 +591,12 @@ export function useAgentSession(deps: AgentSessionDeps) {
         ) {
           conversationStore.abortActiveTurn()
           pushError(i18n.global.t('agent.malformedEvent'))
-          trackAgentError(
-            'malformed_stream_event',
-            'post_acceptance',
-            'error_overlay'
-          )
+          uiTreatment = 'error_overlay'
         } else {
           conversationStore.settleBackgroundTurn(messageId)
         }
       }
+      trackMalformedStreamEvent(activeTurnId, uiTreatment)
       console.warn('[agent] dropping malformed agent event', parsed.error)
       return
     }

--- a/src/workbench/extensions/agent/composables/agent/useAgentSession.ts
+++ b/src/workbench/extensions/agent/composables/agent/useAgentSession.ts
@@ -1,4 +1,5 @@
 import { computed, ref } from 'vue'
+import { ZodError } from 'zod'
 
 import { i18n } from '@/i18n'
 import { useTelemetry } from '@/platform/telemetry'
@@ -91,6 +92,36 @@ export interface AgentSessionDeps {
 
 const THREAD_STORAGE_KEY = 'Comfy.Agent.ThreadId'
 const PREPARE_TIMEOUT_MS = 3000
+
+/**
+ * Statuses whose cause is the request itself or the caller's authorization, so
+ * a byte-identical retry fails identically. Everything else the backend can
+ * return (429, 5xx) and every transport failure is transient enough that
+ * `retryable: true` is the honest answer.
+ */
+const NON_RETRYABLE_REQUEST_STATUSES = new Set([
+  400, 401, 403, 404, 405, 409, 410, 422
+])
+
+/**
+ * Whether resending a failed agent request is safe. `accepted` is decisive: the
+ * server is already running the turn, so a retry starts a second one.
+ */
+function isRetryableRequestFailure(error: unknown, accepted: boolean): boolean {
+  if (accepted) return false
+  if (error instanceof AgentApiError)
+    return !NON_RETRYABLE_REQUEST_STATUSES.has(error.status)
+  return true
+}
+
+/**
+ * `AgentRestClient` validates a response body only after `response.ok`, so a
+ * schema failure out of `postMessage` means the server accepted the turn and
+ * the FE could not read the ack — post-acceptance, and never safe to resend.
+ */
+function isResponseSchemaFailure(error: unknown): boolean {
+  return error instanceof ZodError
+}
 
 let sessionGeneration = 0
 
@@ -196,8 +227,9 @@ export function useAgentSession(deps: AgentSessionDeps) {
       const generation = ++loadGeneration
       const isCurrent = () =>
         generation === loadGeneration && ownedGeneration === sessionGeneration
+      const stashedTurn = conversationStore.activeTurnId !== null
       conversationStore.stashActiveTurn()
-      void hydrateFromServer(surviving, isCurrent).then(() => {
+      void hydrateFromServer(surviving, isCurrent, stashedTurn).then(() => {
         if (isCurrent() && conversationStore.threadId === surviving)
           conversationStore.resumeBackgroundTurn()
       })
@@ -220,7 +252,11 @@ export function useAgentSession(deps: AgentSessionDeps) {
 
   async function hydrateFromServer(
     threadId: string,
-    isCurrent: () => boolean = () => true
+    isCurrent: () => boolean = () => true,
+    // Set by the resume paths, which stash a still-streaming turn before
+    // reloading its thread: the load is a fresh request the server never
+    // accepted, but a turn is accepted and running while it fails.
+    stashedTurn = false
   ): Promise<boolean> {
     try {
       const history = await rest.getMessages(threadId)
@@ -236,7 +272,14 @@ export function useAgentSession(deps: AgentSessionDeps) {
         return false
       }
       pushError(error instanceof Error ? error.message : String(error))
-      trackAgentError('history_load_failed', 'pre_acceptance', 'error_overlay')
+      trackAgentError(
+        'history_load_failed',
+        'pre_acceptance',
+        'error_overlay',
+        {
+          turnAccepted: stashedTurn
+        }
+      )
       return false
     }
   }
@@ -316,8 +359,14 @@ export function useAgentSession(deps: AgentSessionDeps) {
           : input
       )
     }
+    // The post-ack bookkeeping below shares this try, so the catch cannot tell
+    // a rejected request from a QuotaExceededError out of localStorage or a
+    // throwing `adopted` callback. Everything after this flag flips is a
+    // failure of a turn the server already started.
+    let accepted = false
     try {
       const ack = await postTurn(conversationStore.threadId ?? 'new')
+      accepted = true
       conversationStore.setThreadId(ack.thread_id)
       localStorage.setItem(THREAD_STORAGE_KEY, ack.thread_id)
       if (ack.workflow_id !== undefined) {
@@ -364,6 +413,7 @@ export function useAgentSession(deps: AgentSessionDeps) {
         )
         return false
       }
+      const turnAccepted = accepted || isResponseSchemaFailure(error)
       const message =
         error instanceof AgentApiError
           ? error.message
@@ -375,7 +425,12 @@ export function useAgentSession(deps: AgentSessionDeps) {
         text,
         `${i18n.global.t('agent.sendFailed')}: ${message}`
       )
-      trackAgentError('request_failed', 'pre_acceptance', 'inline_notice')
+      trackAgentError(
+        'request_failed',
+        turnAccepted ? 'post_acceptance' : 'pre_acceptance',
+        'inline_notice',
+        { retryable: isRetryableRequestFailure(error, turnAccepted) }
+      )
       return false
     } finally {
       sending.value = false
@@ -400,7 +455,12 @@ export function useAgentSession(deps: AgentSessionDeps) {
       if (error instanceof AgentApiError && error.status === 409) return
       promptEditState.value = { phase: 'idle' }
       pushError(error instanceof Error ? error.message : String(error))
-      trackAgentError('cancel_failed', 'post_acceptance', 'error_overlay')
+      // The line above returned the prompt to idle and the turn is still
+      // running, so cancelling again is safe; the already-finished race is
+      // handled as the 409 above, not here.
+      trackAgentError('cancel_failed', 'post_acceptance', 'error_overlay', {
+        retryable: true
+      })
     }
   }
 
@@ -461,12 +521,13 @@ export function useAgentSession(deps: AgentSessionDeps) {
     promptEditState.value = { phase: 'idle' }
     const isCurrent = () =>
       generation === loadGeneration && ownedGeneration === sessionGeneration
+    const stashedTurn = conversationStore.activeTurnId !== null
     conversationStore.stashActiveTurn()
     boundWorkflowId.value = null
     rememberedWorkflowId = null
     conversationStore.setThreadId(threadId)
     localStorage.setItem(THREAD_STORAGE_KEY, threadId)
-    const hydrated = await hydrateFromServer(threadId, isCurrent)
+    const hydrated = await hydrateFromServer(threadId, isCurrent, stashedTurn)
     if (hydrated && isCurrent()) conversationStore.resumeBackgroundTurn()
   }
 

--- a/src/workbench/extensions/agent/composables/agent/useAgentSession.ts
+++ b/src/workbench/extensions/agent/composables/agent/useAgentSession.ts
@@ -228,9 +228,12 @@ export function useAgentSession(deps: AgentSessionDeps) {
    * are dropped with a `console.warn` no cloud console can see. `uiTreatment`
    * records which of the two the user actually saw. A malformed frame is never
    * retryable — nothing here can be re-sent — and `post_acceptance` is claimed
-   * only when a turn really was running.
+   * only when a turn really was running. The same dedup bounds what reaches the
+   * unified Sentry/RUM sinks, which carry the parse failure itself rather than
+   * the normalized class.
    */
   function trackMalformedStreamEvent(
+    cause: unknown,
     activeTurnId: TurnId | null,
     uiTreatment: AgentErrorMetadata['ui_treatment']
   ): void {
@@ -241,6 +244,10 @@ export function useAgentSession(deps: AgentSessionDeps) {
     )
       return
     malformedStreamReport = { turnId: activeTurnId, visible }
+    reportError(cause, {
+      errorType: 'agent_malformed_stream_event',
+      tags: { ui_treatment: uiTreatment }
+    })
     trackAgentError(
       'malformed_stream_event',
       activeTurnId === null ? 'pre_acceptance' : 'post_acceptance',
@@ -312,6 +319,7 @@ export function useAgentSession(deps: AgentSessionDeps) {
         localStorage.removeItem(THREAD_STORAGE_KEY)
         return false
       }
+      reportError(error, { errorType: 'agent_history_load_failed' })
       pushError(error instanceof Error ? error.message : String(error))
       trackAgentError(
         'history_load_failed',
@@ -461,6 +469,7 @@ export function useAgentSession(deps: AgentSessionDeps) {
           : error instanceof Error
             ? error.message
             : String(error)
+      reportError(error, { errorType: 'agent_send_message_failed' })
       conversationStore.recordFailedSend(
         nextLocalErrorId(),
         text,
@@ -495,6 +504,7 @@ export function useAgentSession(deps: AgentSessionDeps) {
     } catch (error) {
       if (error instanceof AgentApiError && error.status === 409) return
       promptEditState.value = { phase: 'idle' }
+      reportError(error, { errorType: 'agent_cancel_turn_failed' })
       pushError(error instanceof Error ? error.message : String(error))
       // The line above returned the prompt to idle and the turn is still
       // running, so cancelling again is safe; the already-finished race is
@@ -596,7 +606,7 @@ export function useAgentSession(deps: AgentSessionDeps) {
           conversationStore.settleBackgroundTurn(messageId)
         }
       }
-      trackMalformedStreamEvent(activeTurnId, uiTreatment)
+      trackMalformedStreamEvent(parsed.error, activeTurnId, uiTreatment)
       console.warn('[agent] dropping malformed agent event', parsed.error)
       return
     }

--- a/src/workbench/extensions/agent/composables/agent/useAgentSession.ts
+++ b/src/workbench/extensions/agent/composables/agent/useAgentSession.ts
@@ -600,7 +600,7 @@ export function useAgentSession(deps: AgentSessionDeps) {
         ?.message_id
       // Read before the abort below clears it, or every aborted turn reports
       // itself as having had no turn.
-      const activeTurnId = conversationStore.activeTurnId
+      let reportedTurnId = conversationStore.activeTurnId
       let uiTreatment: AgentErrorMetadata['ui_treatment'] = 'none'
       if (type === 'agent_message_done') {
         if (
@@ -611,10 +611,11 @@ export function useAgentSession(deps: AgentSessionDeps) {
           pushError(i18n.global.t('agent.malformedEvent'))
           uiTreatment = 'error_overlay'
         } else {
-          conversationStore.settleBackgroundTurn(messageId)
+          reportedTurnId =
+            conversationStore.settleBackgroundTurn(messageId) ?? reportedTurnId
         }
       }
-      trackMalformedStreamEvent(parsed.error, type, activeTurnId, uiTreatment)
+      trackMalformedStreamEvent(parsed.error, type, reportedTurnId, uiTreatment)
       console.warn('[agent] dropping malformed agent event', parsed.error)
       return
     }

--- a/src/workbench/extensions/agent/composables/agent/useAgentSession.ts
+++ b/src/workbench/extensions/agent/composables/agent/useAgentSession.ts
@@ -96,20 +96,12 @@ export interface AgentSessionDeps {
 const THREAD_STORAGE_KEY = 'Comfy.Agent.ThreadId'
 const PREPARE_TIMEOUT_MS = 3000
 
-/**
- * Statuses whose cause is the request itself or the caller's authorization, so
- * a byte-identical retry fails identically. Everything else the backend can
- * return (429, 5xx) and every transport failure is transient enough that
- * `retryable: true` is the honest answer.
- */
+/** Statuses a byte-identical retry fails identically on. */
 const NON_RETRYABLE_REQUEST_STATUSES = new Set([
   400, 401, 403, 404, 405, 409, 410, 422
 ])
 
-/**
- * Whether resending a failed agent request is safe. `accepted` is decisive: the
- * server is already running the turn, so a retry starts a second one.
- */
+/** `accepted` is decisive: resending a started turn starts a second one. */
 export function isRetryableRequestFailure(
   error: unknown,
   accepted: boolean
@@ -120,25 +112,14 @@ export function isRetryableRequestFailure(
   return true
 }
 
-/**
- * `AgentRestClient` reads a response body only after `response.ok`, so any
- * failure to read it out of `postMessage` — unparseable body or schema
- * mismatch — means the server accepted the turn and the FE lost the ack.
- */
+/** Past `response.ok` the turn is running, whatever the body turned out to be. */
 function isUnreadableAckFailure(error: unknown): boolean {
   return (
     error instanceof ZodError || error instanceof AgentResponseUnreadableError
   )
 }
 
-/**
- * `app:agent_error` (TEL-8): every FE-visible agent failure the backend's
- * `agent_turn_failed` does not already cover. Both booleans default from the
- * stage and are overridable, because the stage only approximates them: a
- * history load failing on the resume path is a request the server never
- * accepted while an accepted turn streams on, and a failed cancel is
- * post-acceptance yet safe to send again.
- */
+/** `app:agent_error` (TEL-8). The stage only approximates both booleans. */
 export function trackAgentError(
   errorClass: AgentErrorClass,
   stage: AgentErrorMetadata['failure_stage'],
@@ -211,30 +192,12 @@ export function useAgentSession(deps: AgentSessionDeps) {
     notices.value.push({ level: 'error', text })
   }
 
-  /**
-   * The last malformed-frame capture: which turn it belonged to (`null` for the
-   * idle stretch between turns) and whether the user saw it. A stream that has
-   * drifted from the schema, or a hostile one, repeats the same frame
-   * indefinitely, so the capture is deduped per turn rather than per frame —
-   * one report carries the same signal without an unbounded PostHog queue
-   * behind it. A later frame in the same turn is still reported if it escalates
-   * to something the user sees, since that is the case worth a dashboard.
-   */
+  /** A drifted stream repeats forever, so captures dedupe per turn. */
   let malformedStreamReport: {
     turnId: TurnId | null
     visible: boolean
   } | null = null
 
-  /**
-   * Every frame that fails `parseAgentWsEvent` is schema drift worth measuring,
-   * not just the `agent_message_done` sub-case that reaches the user: the rest
-   * are dropped with a `console.warn` no cloud console can see. `uiTreatment`
-   * records which of the two the user actually saw. A malformed frame is never
-   * retryable — nothing here can be re-sent — and `post_acceptance` is claimed
-   * only when a turn really was running. The same dedup bounds what reaches the
-   * unified Sentry/RUM sinks, which carry the parse failure itself rather than
-   * the normalized class.
-   */
   function trackMalformedStreamEvent(
     cause: ZodError,
     eventType: string,
@@ -306,9 +269,6 @@ export function useAgentSession(deps: AgentSessionDeps) {
   async function hydrateFromServer(
     threadId: string,
     isCurrent: () => boolean = () => true,
-    // Set by the resume paths, which stash a still-streaming turn before
-    // reloading its thread: the load is a fresh request the server never
-    // accepted, but a turn is accepted and running while it fails.
     stashedTurn = false
   ): Promise<boolean> {
     try {
@@ -413,10 +373,8 @@ export function useAgentSession(deps: AgentSessionDeps) {
           : input
       )
     }
-    // The post-ack bookkeeping below shares this try, so the catch cannot tell
-    // a rejected request from a QuotaExceededError out of localStorage or a
-    // throwing `adopted` callback. Everything after this flag flips is a
-    // failure of a turn the server already started.
+    // The server accepted the turn once this flips; the post-ack bookkeeping
+    // below shares the same try.
     let accepted = false
     try {
       const ack = await postTurn(conversationStore.threadId ?? 'new')
@@ -511,9 +469,6 @@ export function useAgentSession(deps: AgentSessionDeps) {
       promptEditState.value = { phase: 'idle' }
       reportError(error, { errorType: 'agent_cancel_turn_failed' })
       pushError(error instanceof Error ? error.message : String(error))
-      // The line above returned the prompt to idle and the turn is still
-      // running, so cancelling again is safe; the already-finished race is
-      // handled as the 409 above, not here.
       trackAgentError('cancel_failed', 'post_acceptance', 'error_overlay', {
         retryable: true
       })
@@ -598,8 +553,7 @@ export function useAgentSession(deps: AgentSessionDeps) {
     if (!parsed.success) {
       const messageId = (raw as { data?: { message_id?: unknown } }).data
         ?.message_id
-      // Read before the abort below clears it, or every aborted turn reports
-      // itself as having had no turn.
+      // Read before the abort below clears it.
       let reportedTurnId = conversationStore.activeTurnId
       let uiTreatment: AgentErrorMetadata['ui_treatment'] = 'none'
       if (type === 'agent_message_done') {

--- a/src/workbench/extensions/agent/composables/agent/useAgentSession.ts
+++ b/src/workbench/extensions/agent/composables/agent/useAgentSession.ts
@@ -152,24 +152,27 @@ export function useAgentSession(deps: AgentSessionDeps) {
   /**
    * `app:agent_error` (TEL-8): fires at every FE-visible agent failure site,
    * pre- or post-acceptance, that is not already covered by the backend's
-   * `agent_turn_failed`. `turn_accepted` is the stage itself (a turn is
-   * accepted exactly when the failure is post-acceptance). `retryable`
-   * defaults from the stage too: a pre-acceptance failure never started a
-   * turn, so retrying is always safe, while a post-acceptance failure may
-   * have left server-side state the caller cannot fully retry. Override
-   * `retryable` per call site when that default is wrong.
+   * `agent_turn_failed`. Both booleans default from the stage — a
+   * pre-acceptance failure never started a turn, so nothing was accepted and
+   * retrying is always safe, while a post-acceptance failure may have left
+   * server-side state the caller cannot fully retry — and both are
+   * overridable, because the stage and the two facts it approximates can
+   * disagree. A history load that fails on the resume path is a request the
+   * server never accepted (`pre_acceptance`) issued while an accepted turn is
+   * still streaming (`turn_accepted: true`), and a failed cancel is
+   * `post_acceptance` yet safe to send again.
    */
   function trackAgentError(
     errorClass: AgentErrorClass,
     stage: AgentErrorMetadata['failure_stage'],
     uiTreatment: AgentErrorMetadata['ui_treatment'],
-    retryable: boolean = stage === 'pre_acceptance'
+    overrides: { retryable?: boolean; turnAccepted?: boolean } = {}
   ): void {
     useTelemetry()?.trackAgentError({
       error_class: errorClass,
       failure_stage: stage,
-      retryable,
-      turn_accepted: stage === 'post_acceptance',
+      retryable: overrides.retryable ?? stage === 'pre_acceptance',
+      turn_accepted: overrides.turnAccepted ?? stage === 'post_acceptance',
       ui_treatment: uiTreatment
     })
   }

--- a/src/workbench/extensions/agent/composables/agent/useAgentSession.ts
+++ b/src/workbench/extensions/agent/composables/agent/useAgentSession.ts
@@ -236,7 +236,8 @@ export function useAgentSession(deps: AgentSessionDeps) {
    * the normalized class.
    */
   function trackMalformedStreamEvent(
-    cause: unknown,
+    cause: ZodError,
+    eventType: string,
     activeTurnId: TurnId | null,
     uiTreatment: AgentErrorMetadata['ui_treatment']
   ): void {
@@ -247,9 +248,10 @@ export function useAgentSession(deps: AgentSessionDeps) {
     )
       return
     malformedStreamReport = { turnId: activeTurnId, visible }
-    reportError(cause, {
+    reportError(new Error('Malformed agent stream event'), {
       errorType: 'agent_malformed_stream_event',
-      tags: { ui_treatment: uiTreatment }
+      tags: { ui_treatment: uiTreatment, event_type: eventType },
+      context: { issues: cause.issues }
     })
     trackAgentError(
       'malformed_stream_event',
@@ -612,7 +614,7 @@ export function useAgentSession(deps: AgentSessionDeps) {
           conversationStore.settleBackgroundTurn(messageId)
         }
       }
-      trackMalformedStreamEvent(parsed.error, activeTurnId, uiTreatment)
+      trackMalformedStreamEvent(parsed.error, type, activeTurnId, uiTreatment)
       console.warn('[agent] dropping malformed agent event', parsed.error)
       return
     }

--- a/src/workbench/extensions/agent/composables/agent/useAgentSession.ts
+++ b/src/workbench/extensions/agent/composables/agent/useAgentSession.ts
@@ -3,7 +3,10 @@ import { computed, ref } from 'vue'
 import { i18n } from '@/i18n'
 import { useTelemetry } from '@/platform/telemetry'
 import { reportError } from '@/platform/telemetry/reportError'
-import type { AgentErrorClass } from '@/platform/telemetry/types'
+import type {
+  AgentErrorClass,
+  AgentErrorMetadata
+} from '@/platform/telemetry/types'
 import { createUuidv4 } from '@/utils/uuid'
 import type { AgentActiveTabData, TurnId } from '../../schemas/agentApiSchema'
 import {
@@ -149,23 +152,24 @@ export function useAgentSession(deps: AgentSessionDeps) {
   /**
    * `app:agent_error` (TEL-8): fires at every FE-visible agent failure site,
    * pre- or post-acceptance, that is not already covered by the backend's
-   * `agent_turn_failed`. `retryable` defaults from `failure_stage` — a
-   * pre-acceptance failure never started a turn, so retrying is always safe;
-   * a post-acceptance failure may have left server-side state the caller
-   * cannot fully retry — override per call site when that default is wrong.
+   * `agent_turn_failed`. `turn_accepted` is the stage itself (a turn is
+   * accepted exactly when the failure is post-acceptance). `retryable`
+   * defaults from the stage too: a pre-acceptance failure never started a
+   * turn, so retrying is always safe, while a post-acceptance failure may
+   * have left server-side state the caller cannot fully retry. Override
+   * `retryable` per call site when that default is wrong.
    */
   function trackAgentError(
     errorClass: AgentErrorClass,
-    stage: 'pre_acceptance' | 'post_acceptance',
-    uiTreatment: 'inline_notice' | 'error_overlay' | 'toast',
-    turnAccepted: boolean,
+    stage: AgentErrorMetadata['failure_stage'],
+    uiTreatment: AgentErrorMetadata['ui_treatment'],
     retryable: boolean = stage === 'pre_acceptance'
   ): void {
     useTelemetry()?.trackAgentError({
       error_class: errorClass,
       failure_stage: stage,
       retryable,
-      turn_accepted: turnAccepted,
+      turn_accepted: stage === 'post_acceptance',
       ui_treatment: uiTreatment
     })
   }
@@ -229,12 +233,7 @@ export function useAgentSession(deps: AgentSessionDeps) {
         return false
       }
       pushError(error instanceof Error ? error.message : String(error))
-      trackAgentError(
-        'history_load_failed',
-        'pre_acceptance',
-        'error_overlay',
-        false
-      )
+      trackAgentError('history_load_failed', 'pre_acceptance', 'error_overlay')
       return false
     }
   }
@@ -263,7 +262,7 @@ export function useAgentSession(deps: AgentSessionDeps) {
         text,
         i18n.global.t('agent.sendBusy')
       )
-      trackAgentError('send_busy', 'pre_acceptance', 'inline_notice', false)
+      trackAgentError('send_busy', 'pre_acceptance', 'inline_notice')
       return false
     }
     promptEditState.value = { phase: 'idle' }
@@ -373,12 +372,7 @@ export function useAgentSession(deps: AgentSessionDeps) {
         text,
         `${i18n.global.t('agent.sendFailed')}: ${message}`
       )
-      trackAgentError(
-        'request_failed',
-        'pre_acceptance',
-        'inline_notice',
-        false
-      )
+      trackAgentError('request_failed', 'pre_acceptance', 'inline_notice')
       return false
     } finally {
       sending.value = false
@@ -400,21 +394,10 @@ export function useAgentSession(deps: AgentSessionDeps) {
     try {
       await rest.cancelMessage(threadId, turnId)
     } catch (error) {
-      if (error instanceof AgentApiError) {
-        if (error.status === 409) return
-        promptEditState.value = { phase: 'idle' }
-        pushError(error.message)
-        trackAgentError(
-          'cancel_failed',
-          'post_acceptance',
-          'error_overlay',
-          true
-        )
-        return
-      }
+      if (error instanceof AgentApiError && error.status === 409) return
       promptEditState.value = { phase: 'idle' }
       pushError(error instanceof Error ? error.message : String(error))
-      trackAgentError('cancel_failed', 'post_acceptance', 'error_overlay', true)
+      trackAgentError('cancel_failed', 'post_acceptance', 'error_overlay')
     }
   }
 
@@ -502,8 +485,7 @@ export function useAgentSession(deps: AgentSessionDeps) {
           trackAgentError(
             'malformed_stream_event',
             'post_acceptance',
-            'error_overlay',
-            true
+            'error_overlay'
           )
         } else {
           conversationStore.settleBackgroundTurn(messageId)

--- a/src/workbench/extensions/agent/composables/agent/useAgentSession.ts
+++ b/src/workbench/extensions/agent/composables/agent/useAgentSession.ts
@@ -1,7 +1,9 @@
 import { computed, ref } from 'vue'
 
 import { i18n } from '@/i18n'
+import { useTelemetry } from '@/platform/telemetry'
 import { reportError } from '@/platform/telemetry/reportError'
+import type { AgentErrorClass } from '@/platform/telemetry/types'
 import { createUuidv4 } from '@/utils/uuid'
 import type { AgentActiveTabData, TurnId } from '../../schemas/agentApiSchema'
 import {
@@ -144,6 +146,30 @@ export function useAgentSession(deps: AgentSessionDeps) {
     notices.value.push({ level: 'error', text })
   }
 
+  /**
+   * `app:agent_error` (TEL-8): fires at every FE-visible agent failure site,
+   * pre- or post-acceptance, that is not already covered by the backend's
+   * `agent_turn_failed`. `retryable` defaults from `failure_stage` — a
+   * pre-acceptance failure never started a turn, so retrying is always safe;
+   * a post-acceptance failure may have left server-side state the caller
+   * cannot fully retry — override per call site when that default is wrong.
+   */
+  function trackAgentError(
+    errorClass: AgentErrorClass,
+    stage: 'pre_acceptance' | 'post_acceptance',
+    uiTreatment: 'inline_notice' | 'error_overlay' | 'toast',
+    turnAccepted: boolean,
+    retryable: boolean = stage === 'pre_acceptance'
+  ): void {
+    useTelemetry()?.trackAgentError({
+      error_class: errorClass,
+      failure_stage: stage,
+      retryable,
+      turn_accepted: turnAccepted,
+      ui_treatment: uiTreatment
+    })
+  }
+
   function start(): void {
     ownedGeneration = ++sessionGeneration
     everLive = false
@@ -203,6 +229,12 @@ export function useAgentSession(deps: AgentSessionDeps) {
         return false
       }
       pushError(error instanceof Error ? error.message : String(error))
+      trackAgentError(
+        'history_load_failed',
+        'pre_acceptance',
+        'error_overlay',
+        false
+      )
       return false
     }
   }
@@ -231,6 +263,7 @@ export function useAgentSession(deps: AgentSessionDeps) {
         text,
         i18n.global.t('agent.sendBusy')
       )
+      trackAgentError('send_busy', 'pre_acceptance', 'inline_notice', false)
       return false
     }
     promptEditState.value = { phase: 'idle' }
@@ -340,6 +373,12 @@ export function useAgentSession(deps: AgentSessionDeps) {
         text,
         `${i18n.global.t('agent.sendFailed')}: ${message}`
       )
+      trackAgentError(
+        'request_failed',
+        'pre_acceptance',
+        'inline_notice',
+        false
+      )
       return false
     } finally {
       sending.value = false
@@ -365,10 +404,17 @@ export function useAgentSession(deps: AgentSessionDeps) {
         if (error.status === 409) return
         promptEditState.value = { phase: 'idle' }
         pushError(error.message)
+        trackAgentError(
+          'cancel_failed',
+          'post_acceptance',
+          'error_overlay',
+          true
+        )
         return
       }
       promptEditState.value = { phase: 'idle' }
       pushError(error instanceof Error ? error.message : String(error))
+      trackAgentError('cancel_failed', 'post_acceptance', 'error_overlay', true)
     }
   }
 
@@ -453,6 +499,12 @@ export function useAgentSession(deps: AgentSessionDeps) {
         ) {
           conversationStore.abortActiveTurn()
           pushError(i18n.global.t('agent.malformedEvent'))
+          trackAgentError(
+            'malformed_stream_event',
+            'post_acceptance',
+            'error_overlay',
+            true
+          )
         } else {
           conversationStore.settleBackgroundTurn(messageId)
         }

--- a/src/workbench/extensions/agent/services/agent/agentRestClient.test.ts
+++ b/src/workbench/extensions/agent/services/agent/agentRestClient.test.ts
@@ -7,7 +7,11 @@ const fetchApi = vi.hoisted(() =>
 )
 vi.mock<unknown>(import('@/scripts/api'), () => ({ api: { fetchApi } }))
 
-import { AgentApiError, createAgentRestClient } from './agentRestClient'
+import {
+  AgentApiError,
+  AgentResponseUnreadableError,
+  createAgentRestClient
+} from './agentRestClient'
 import type { AgentRestClient } from './agentRestClient'
 
 function jsonResponse(
@@ -362,6 +366,22 @@ describe('error mapping', () => {
       .catch((e: unknown) => e)
 
     expect(error).toBeInstanceOf(Error)
+    expect(error).not.toBeInstanceOf(AgentApiError)
+  })
+
+  it('distinguishes a truncated 2xx body from a rejected request', async () => {
+    respond(
+      new Response('{"message_id":"m1","thread_', {
+        status: 202,
+        headers: { 'Content-Type': 'application/json' }
+      })
+    )
+
+    const error = await makeClient()
+      .postMessage('t1', { content: 'hi' })
+      .catch((e: unknown) => e)
+
+    expect(error).toBeInstanceOf(AgentResponseUnreadableError)
     expect(error).not.toBeInstanceOf(AgentApiError)
   })
 })

--- a/src/workbench/extensions/agent/services/agent/agentRestClient.ts
+++ b/src/workbench/extensions/agent/services/agent/agentRestClient.ts
@@ -46,10 +46,7 @@ export class AgentApiError extends Error {
   }
 }
 
-/**
- * The server answered `2xx` and the body could not be read as JSON — a
- * truncated or proxy-mangled response, not a rejected request.
- */
+/** A `2xx` whose body could not be read: truncated or proxy-mangled. */
 export class AgentResponseUnreadableError extends Error {
   constructor(route: string, cause: unknown) {
     super(`Unreadable agent response body from ${route}`, { cause })

--- a/src/workbench/extensions/agent/services/agent/agentRestClient.ts
+++ b/src/workbench/extensions/agent/services/agent/agentRestClient.ts
@@ -46,6 +46,17 @@ export class AgentApiError extends Error {
   }
 }
 
+/**
+ * The server answered `2xx` and the body could not be read as JSON — a
+ * truncated or proxy-mangled response, not a rejected request.
+ */
+export class AgentResponseUnreadableError extends Error {
+  constructor(route: string, cause: unknown) {
+    super(`Unreadable agent response body from ${route}`, { cause })
+    this.name = 'AgentResponseUnreadableError'
+  }
+}
+
 interface OpenTabEntry {
   workflow_id: string
   name: string
@@ -122,7 +133,13 @@ export function createAgentRestClient() {
   ): Promise<T> {
     const response = await api.fetchApi(route, init)
     if (!response.ok) throw await toApiError(response)
-    return schema.parse(await response.json())
+    let payload: unknown
+    try {
+      payload = await response.json()
+    } catch (error) {
+      throw new AgentResponseUnreadableError(route, error)
+    }
+    return schema.parse(payload)
   }
 
   function jsonInit(method: string, body: unknown): RequestInit {

--- a/src/workbench/extensions/agent/stores/agent/agentConversationStore.ts
+++ b/src/workbench/extensions/agent/stores/agent/agentConversationStore.ts
@@ -211,13 +211,14 @@ export const useAgentConversationStore = defineStore(
       liveMessage = entry.message
     }
 
-    function settleBackgroundTurn(turnId: string): void {
+    function settleBackgroundTurn(turnId: string): TurnId | null {
       for (const [key, entry] of backgroundTurns) {
         if (entry.messageId !== turnId) continue
         entry.transport.settle()
         backgroundTurns.delete(key)
-        return
+        return entry.messageId
       }
+      return null
     }
 
     function dropBackgroundTurns(): void {


### PR DESCRIPTION
## Summary

Implements the required V1 telemetry event `app:agent_error` per `reports/telemetry/v1-checklist.md` in the `in-app-agent-program` workspace (row `TEL-8`): "FE surfaces an agent failure to the user, including pre-acceptance request failures not represented by `agent_turn_failed`."

Follows the `app:agent_reconnect_failed` precedent (TEL-11, #16397) for the telemetry plumbing shape.

## What's new

- `AgentErrorMetadata` in `src/platform/telemetry/types.ts`: `error_class` (`request_failed | malformed_stream_event | cancel_failed | history_load_failed | ask_answer_failed | thread_list_load_failed | workflow_open_failed`), `failure_stage` (`pre_acceptance | post_acceptance`), `retryable`, `turn_accepted`, `ui_treatment` (`inline_notice | error_overlay | toast | none`).
- `trackAgentError` wired through `TelemetryRegistry` and `PostHogTelemetryProvider`.
- Call sites at every FE-visible agent failure not already covered by the backend's `agent_turn_failed`:
  - `sendMessage()`: a rejected `postMessage` (`request_failed`), `inline_notice` via `recordFailedSend`.
  - `stopTurn()`: a failed `cancelMessage` (`cancel_failed`), post-acceptance, `error_overlay`. A 409 already-settled race is not tracked - it is not a failure.
  - `answerAsk()`: a failed ask answer (`ask_answer_failed`), post-acceptance - the turn hangs on an unresolved ask. The 409 collapse path is not tracked.
  - `onRaw()`: any frame failing `parseAgentWsEvent` (`malformed_stream_event`), deduped per turn.
  - `hydrateFromServer()`: a non-404 transcript load failure (`history_load_failed`). The 404 thread-not-found branch is not tracked.
  - `AgentPanelRoot.vue`: a failed agent-driven tab open (`workflow_open_failed`) and a failed thread-list load (`thread_list_load_failed`), both `error_overlay`.

`turn_accepted` and `retryable` default from `failure_stage` and are overridable, because the stage only approximates them: a resume-path history load is a request the server never accepted issued while an accepted turn streams on, and a failed cancel is post-acceptance yet safe to resend. `retryable` is derived from the response status via `isRetryableRequestFailure()` for every request-shaped class, so the column means one thing across rows.

**Not counted:** a busy-state double-submit. It is a normal interaction rather than a failure, and it is frequent enough to dominate the other classes and make the rate unalertable. Admission errors (`no_funds` paywall) also emit nothing - they return early from the send catch and have their own UI.

`AgentRestClient.request()` now reads the response body in its own `try` past `response.ok` and raises `AgentResponseUnreadableError`. A truncated or proxy-mangled 2xx therefore classifies as post-acceptance and non-retryable, the same as a `ZodError` - both mean the server started the turn and the FE lost the ack.

## Evidence

```
$ pnpm typecheck
(clean)

$ pnpm lint
0 errors (225 pre-existing warnings, none in changed files)

$ pnpm format:check
All matched files use the correct format.

$ pnpm knip
(clean)

$ pnpm vitest run src/platform/telemetry src/workbench/extensions/agent
Test Files  114 passed (114)
Tests  1629 passed (1629)
```

Every added or changed test was proven red by mutating the fix it covers, then green on restore.

Follow-up filed from review: #17358 (a `localStorage` failure after the ack hides a turn the server already started - pre-existing).

Trace: MTG-29, mtg-29.2 emitted-vs-required diff (`in-app-agent-program` TEL-8).

<!-- authored-by:agent lane-TEL-8 -->
