### PR TITLE
feat(agent): emit reconnect-success telemetry

### DIFF
--- a/src/platform/telemetry/TelemetryRegistry.ts
+++ b/src/platform/telemetry/TelemetryRegistry.ts
@@ -8,6 +8,7 @@ import type {
   AgentPanelOpenedMetadata,
   AgentReconnectFailedMetadata,
   AgentReconnectStartedMetadata,
+  AgentReconnectSucceededMetadata,
   AgentWorkflowAppliedMetadata,
   AuthErrorMetadata,
   AuthMetadata,
@@ -388,6 +389,14 @@ export class TelemetryRegistry implements TelemetryDispatcher {
 
   trackAgentReconnectStarted(metadata: AgentReconnectStartedMetadata): void {
     this.dispatch((provider) => provider.trackAgentReconnectStarted?.(metadata))
+  }
+
+  trackAgentReconnectSucceeded(
+    metadata: AgentReconnectSucceededMetadata
+  ): void {
+    this.dispatch((provider) =>
+      provider.trackAgentReconnectSucceeded?.(metadata)
+    )
   }
 
   trackWidgetFavoriteToggled(metadata: WidgetFavoriteToggledMetadata): void {

--- a/src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.ts
@@ -20,6 +20,7 @@ import type {
   AgentPanelOpenedMetadata,
   AgentReconnectFailedMetadata,
   AgentReconnectStartedMetadata,
+  AgentReconnectSucceededMetadata,
   AgentWorkflowAppliedMetadata,
   AuthErrorMetadata,
   AuthMetadata,
@@ -710,6 +711,12 @@ export class PostHogTelemetryProvider implements TelemetryProvider {
 
   trackAgentReconnectStarted(metadata: AgentReconnectStartedMetadata): void {
     this.trackEvent(TelemetryEvents.AGENT_RECONNECT_STARTED, metadata)
+  }
+
+  trackAgentReconnectSucceeded(
+    metadata: AgentReconnectSucceededMetadata
+  ): void {
+    this.trackEvent(TelemetryEvents.AGENT_RECONNECT_SUCCEEDED, metadata)
   }
 
   trackWidgetFavoriteToggled(metadata: WidgetFavoriteToggledMetadata): void {

--- a/src/platform/telemetry/types.ts
+++ b/src/platform/telemetry/types.ts
@@ -593,6 +593,17 @@ export interface AgentReconnectStartedMetadata extends Record<string, unknown> {
   offline_duration_ms: number | null
 }
 
+export interface AgentReconnectSucceededMetadata extends Record<
+  string,
+  unknown
+> {
+  attempt: number
+  reconnect_duration_ms: number
+  replayed_bytes: number
+  from_version: number
+  to_version: number
+}
+
 /**
  * Widget (input/parameter) favorite toggle tracking metadata.
  * Used to measure discoverability of the right side panel favoriting feature.
@@ -1107,6 +1118,7 @@ export interface TelemetryProvider {
   trackAgentWorkflowApplied?(metadata: AgentWorkflowAppliedMetadata): void
   trackAgentReconnectFailed?(metadata: AgentReconnectFailedMetadata): void
   trackAgentReconnectStarted?(metadata: AgentReconnectStartedMetadata): void
+  trackAgentReconnectSucceeded?(metadata: AgentReconnectSucceededMetadata): void
 
   // Right side panel widget favorite events
   trackWidgetFavoriteToggled?(metadata: WidgetFavoriteToggledMetadata): void
@@ -1275,6 +1287,7 @@ export const TelemetryEvents = {
   AGENT_WORKFLOW_APPLIED: 'app:agent_workflow_applied',
   AGENT_RECONNECT_FAILED: 'app:agent_reconnect_failed',
   AGENT_RECONNECT_STARTED: 'app:agent_reconnect_started',
+  AGENT_RECONNECT_SUCCEEDED: 'app:agent_reconnect_succeeded',
 
   // Right Side Panel Widget Favorites
   WIDGET_FAVORITE_TOGGLED: 'app:widget_favorite_toggled',

--- a/src/workbench/extensions/agent/crdt/reconnectReport.ts
+++ b/src/workbench/extensions/agent/crdt/reconnectReport.ts
@@ -59,6 +59,9 @@ const unchanged = (state: ReconnectState): ReconnectTransition => ({
   report: null
 })
 
+const isReplay = (seq: number, fromVersion: number, ackSeq: number): boolean =>
+  seq > fromVersion && seq <= ackSeq
+
 export function reduceReconnect(
   state: ReconnectState,
   event: ReconnectEvent
@@ -98,7 +101,9 @@ export function reduceReconnect(
       }
       if (event.ackSeq === null) return idle(report)
       const ackSeq = event.ackSeq
-      const replayed = state.preAck
+      const replayed = state.preAck.filter((frame) =>
+        isReplay(frame.seq, state.fromVersion, ackSeq)
+      )
       const confirmed = {
         ...report,
         to_version: ackSeq,
@@ -126,6 +131,8 @@ export function reduceReconnect(
       // A frame above the ack seq is live traffic: it proves the catch-up was
       // empty (or already counted) and is not part of it.
       if (event.seq > state.ackSeq) return idle(state.report)
+      if (!isReplay(event.seq, state.report.from_version, state.ackSeq))
+        return unchanged(state)
       const report = {
         ...state.report,
         replayed_bytes: state.report.replayed_bytes + event.bytes

--- a/src/workbench/extensions/agent/crdt/reconnectReport.ts
+++ b/src/workbench/extensions/agent/crdt/reconnectReport.ts
@@ -92,7 +92,9 @@ export function reduceReconnect(
         ),
         replayed_bytes: 0,
         from_version: state.fromVersion,
-        to_version: 0
+        // An ack without a seq says nothing about where the doc now is;
+        // reporting 0 would read as a version that moved backwards.
+        to_version: state.fromVersion
       }
       if (event.ackSeq === null) return idle(report)
       const ackSeq = event.ackSeq

--- a/src/workbench/extensions/agent/crdt/reconnectReport.ts
+++ b/src/workbench/extensions/agent/crdt/reconnectReport.ts
@@ -1,0 +1,140 @@
+import type { AgentReconnectSucceededMetadata } from '@/platform/telemetry/types'
+
+/**
+ * TEL-10's recovery bookkeeping as one state rather than a bag of fields.
+ *
+ * A recovery has exactly three phases: nothing in flight, a disconnect signal
+ * seen but not yet answered, and an answered subscribe whose report is waiting
+ * for the catch-up frame that proves how much was replayed. The report is not
+ * emitted at the ack because the relay sends the ack first and the catch-up
+ * `doc_update` (same seq as the ack) after it.
+ *
+ * `fromVersion` is supplied by the caller, never read off the transport: the
+ * bridge clears its sequence bookkeeping the moment a subscribe frame leaves,
+ * so by the time a refusal comes back it no longer knows where the follower
+ * was.
+ */
+export type ReconnectState =
+  | { phase: 'idle' }
+  | {
+      phase: 'inFlight'
+      startedAt: number
+      fromVersion: number
+      /**
+       * The relay joins the fanout before it acks, so frames can arrive ahead
+       * of the ack that says which of them are catch-up. They are held here
+       * until the ack seq can classify them.
+       */
+      preAck: readonly { seq: number; bytes: number }[]
+    }
+  | {
+      phase: 'pending'
+      ackSeq: number
+      report: AgentReconnectSucceededMetadata
+    }
+
+export type ReconnectEvent =
+  /** A socket drop or a server refusal, i.e. the recovery clock starts. */
+  | { type: 'disconnected'; at: number; fromVersion: number }
+  | { type: 'confirmed'; at: number; ackSeq: number | null; attempt: number }
+  | { type: 'update'; seq: number; bytes: number }
+  /** The binding is going away; report whatever succeeded, drop the rest. */
+  | { type: 'flushed' }
+  /** The binding is going away and nothing about it is reportable. */
+  | { type: 'abandoned' }
+
+export interface ReconnectTransition {
+  state: ReconnectState
+  report: AgentReconnectSucceededMetadata | null
+}
+
+export const initialReconnectState: ReconnectState = { phase: 'idle' }
+
+const idle = (
+  report: AgentReconnectSucceededMetadata | null = null
+): ReconnectTransition => ({ state: initialReconnectState, report })
+
+const unchanged = (state: ReconnectState): ReconnectTransition => ({
+  state,
+  report: null
+})
+
+export function reduceReconnect(
+  state: ReconnectState,
+  event: ReconnectEvent
+): ReconnectTransition {
+  switch (event.type) {
+    case 'disconnected': {
+      // A disconnect while a report is pending is a NEW recovery, so the
+      // pending one is reported before the clock restarts. A second signal
+      // mid-recovery must not reset the clock or the baseline.
+      if (state.phase === 'inFlight') return unchanged(state)
+      return {
+        state: {
+          phase: 'inFlight',
+          startedAt: event.at,
+          fromVersion: event.fromVersion,
+          preAck: []
+        },
+        report: state.phase === 'pending' ? state.report : null
+      }
+    }
+    case 'confirmed': {
+      // A second ok ack while pending (the stale probe's resubscribe) proves
+      // no catch-up is coming.
+      if (state.phase === 'pending') return idle(state.report)
+      if (state.phase === 'idle') return unchanged(state)
+      const report: AgentReconnectSucceededMetadata = {
+        attempt: event.attempt,
+        reconnect_duration_ms: Math.max(
+          0,
+          Math.round(event.at - state.startedAt)
+        ),
+        replayed_bytes: 0,
+        from_version: state.fromVersion,
+        to_version: 0
+      }
+      if (event.ackSeq === null) return idle(report)
+      const ackSeq = event.ackSeq
+      const replayed = state.preAck
+      const confirmed = {
+        ...report,
+        to_version: ackSeq,
+        replayed_bytes: replayed.reduce(
+          (total, frame) => total + frame.bytes,
+          0
+        )
+      }
+      // The catch-up frame overtook its own ack, so there is nothing left to
+      // wait for.
+      const catchUpAlreadyLanded = replayed.some(
+        (frame) => frame.seq === ackSeq
+      )
+      return catchUpAlreadyLanded
+        ? idle(confirmed)
+        : unchanged({ phase: 'pending', ackSeq, report: confirmed })
+    }
+    case 'update': {
+      if (state.phase === 'idle') return unchanged(state)
+      if (state.phase === 'inFlight')
+        return unchanged({
+          ...state,
+          preAck: [...state.preAck, { seq: event.seq, bytes: event.bytes }]
+        })
+      // A frame above the ack seq is live traffic: it proves the catch-up was
+      // empty (or already counted) and is not part of it.
+      if (event.seq > state.ackSeq) return idle(state.report)
+      const report = {
+        ...state.report,
+        replayed_bytes: state.report.replayed_bytes + event.bytes
+      }
+      return event.seq === state.ackSeq
+        ? idle(report)
+        : unchanged({ ...state, report })
+    }
+    case 'flushed':
+      return state.phase === 'pending' ? idle(state.report) : unchanged(state)
+    case 'abandoned':
+      return idle()
+  }
+}

--- a/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.test.ts
+++ b/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.test.ts
@@ -55,7 +55,8 @@ const adapterState = vi.hoisted(() => ({
 
 const telemetryState = vi.hoisted(() => ({
   trackAgentReconnectFailed: vi.fn(),
-  trackAgentReconnectStarted: vi.fn()
+  trackAgentReconnectStarted: vi.fn(),
+  trackAgentReconnectSucceeded: vi.fn()
 }))
 
 const materializerState = vi.hoisted(() => ({
@@ -253,6 +254,52 @@ describe('useAgentCrdtFollower', () => {
     expect(bridge().resubscribe).not.toHaveBeenCalled()
     expect(status().connected).toBe(true)
     unmount()
+  })
+
+  it('TEL-10: reports reconnect success exactly once with normalized metadata', () => {
+    vi.useFakeTimers({ toFake: ['performance', 'setTimeout', 'clearTimeout'] })
+    vi.setSystemTime(1_000)
+    const { unmount } = mountFollower('wf-1')
+    bridge().lastSequence = 41
+
+    dispatchFrame('doc_subscribed', { ok: false })
+    vi.advanceTimersByTime(500)
+    dispatchFrame('doc_update', {
+      workflowId: 'wf-1',
+      seq: 42,
+      update: new Uint8Array(10)
+    })
+    dispatchFrame('doc_subscribed', { ok: true, seq: 43 })
+
+    expect(telemetryState.trackAgentReconnectSucceeded).toHaveBeenCalledOnce()
+    expect(telemetryState.trackAgentReconnectSucceeded).toHaveBeenCalledWith({
+      attempt: 1,
+      reconnect_duration_ms: 500,
+      replayed_bytes: 10,
+      from_version: 41,
+      to_version: 43
+    })
+
+    // A later ordinary catch-up frame must not re-report — the reconnect
+    // bookkeeping was cleared by the confirm above.
+    dispatchFrame('doc_update', {
+      workflowId: 'wf-1',
+      seq: 44,
+      update: new Uint8Array(5)
+    })
+    dispatchFrame('doc_subscribed', { ok: false })
+    dispatchFrame('doc_subscribed', { ok: true, seq: 45 })
+    expect(telemetryState.trackAgentReconnectSucceeded).toHaveBeenCalledTimes(2)
+    unmount()
+  })
+
+  it('TEL-10: does not report reconnect success on the first-ever bind', () => {
+    vi.useFakeTimers()
+    mountFollower('wf-1')
+
+    dispatchFrame('doc_subscribed', { ok: true, seq: 1 })
+
+    expect(telemetryState.trackAgentReconnectSucceeded).not.toHaveBeenCalled()
   })
 
   it('reports retry exhaustion exactly once with normalized metadata', () => {

--- a/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.test.ts
+++ b/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.test.ts
@@ -404,6 +404,50 @@ describe('useAgentCrdtFollower', () => {
     unmount()
   })
 
+  it('TEL-10/TEL-9: a socket drop followed by refusals reports every attempt', () => {
+    // Both disconnect signals can fire in one recovery: the socket drop
+    // resubscribes immediately, the server refuses it, and the refusal retry
+    // is what finally lands. The success report must count both legs, and
+    // TEL-9's live counter must survive the snapshot the report takes.
+    vi.useFakeTimers({ toFake: ['performance', 'setTimeout', 'clearTimeout'] })
+    vi.setSystemTime(1_000)
+    const { unmount } = mountFollower('wf-1')
+    dispatchFrame('doc_subscribed', { ok: true, seq: 7 })
+    bridge().lastSequence = 7
+
+    apiState.target.dispatchEvent(new Event('reconnected'))
+    expect(telemetryState.trackAgentReconnectStarted).toHaveBeenCalledWith(
+      expect.objectContaining({ attempt: 1 })
+    )
+
+    dispatchFrame('doc_subscribed', { ok: false })
+    vi.advanceTimersByTime(500)
+    expect(bridge().resubscribe).toHaveBeenCalled()
+    dispatchFrame('doc_subscribed', { ok: true, seq: 9 })
+    dispatchFrame('doc_update', {
+      workflowId: 'wf-1',
+      seq: 9,
+      update: new Uint8Array(6)
+    })
+
+    expect(telemetryState.trackAgentReconnectSucceeded).toHaveBeenCalledOnce()
+    expect(telemetryState.trackAgentReconnectSucceeded).toHaveBeenCalledWith({
+      attempt: 2,
+      reconnect_duration_ms: 500,
+      replayed_bytes: 6,
+      from_version: 7,
+      to_version: 9
+    })
+
+    // The report snapshot must not have consumed TEL-9's counter: the next
+    // socket drop is attempt 1 again because the confirm above reset it.
+    apiState.target.dispatchEvent(new Event('reconnected'))
+    expect(telemetryState.trackAgentReconnectStarted).toHaveBeenLastCalledWith(
+      expect.objectContaining({ attempt: 1 })
+    )
+    unmount()
+  })
+
   it('TEL-10: a workflow switch mid-reconnect does not report on the next bind', async () => {
     vi.useFakeTimers({ toFake: ['performance', 'setTimeout', 'clearTimeout'] })
     vi.setSystemTime(1_000)

--- a/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.test.ts
+++ b/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.test.ts
@@ -256,7 +256,7 @@ describe('useAgentCrdtFollower', () => {
     unmount()
   })
 
-  it('TEL-10: reports reconnect success exactly once with normalized metadata', () => {
+  it('TEL-10: reports reconnect success once the catch-up frame lands', () => {
     vi.useFakeTimers({ toFake: ['performance', 'setTimeout', 'clearTimeout'] })
     vi.setSystemTime(1_000)
     const { unmount } = mountFollower('wf-1')
@@ -264,32 +264,192 @@ describe('useAgentCrdtFollower', () => {
 
     dispatchFrame('doc_subscribed', { ok: false })
     vi.advanceTimersByTime(500)
+    // A live frame can overtake the ack; it is still part of the recovery.
     dispatchFrame('doc_update', {
       workflowId: 'wf-1',
       seq: 42,
       update: new Uint8Array(10)
     })
     dispatchFrame('doc_subscribed', { ok: true, seq: 43 })
+    // The relay sends the catch-up AFTER the ack, so the ack alone is not the
+    // restore point: nothing is reported yet.
+    expect(telemetryState.trackAgentReconnectSucceeded).not.toHaveBeenCalled()
 
+    // The wait for the catch-up must not stretch the duration.
+    vi.advanceTimersByTime(250)
+    dispatchFrame('doc_update', {
+      workflowId: 'wf-1',
+      seq: 43,
+      update: new Uint8Array(20)
+    })
     expect(telemetryState.trackAgentReconnectSucceeded).toHaveBeenCalledOnce()
     expect(telemetryState.trackAgentReconnectSucceeded).toHaveBeenCalledWith({
       attempt: 1,
       reconnect_duration_ms: 500,
-      replayed_bytes: 10,
+      replayed_bytes: 30,
       from_version: 41,
       to_version: 43
     })
 
-    // A later ordinary catch-up frame must not re-report — the reconnect
-    // bookkeeping was cleared by the confirm above.
+    // Ordinary live traffic after the report must not re-report.
     dispatchFrame('doc_update', {
       workflowId: 'wf-1',
       seq: 44,
       update: new Uint8Array(5)
     })
+    expect(telemetryState.trackAgentReconnectSucceeded).toHaveBeenCalledOnce()
+
+    // A second recovery is its own report with its own baseline.
+    bridge().lastSequence = 44
     dispatchFrame('doc_subscribed', { ok: false })
+    vi.advanceTimersByTime(500)
     dispatchFrame('doc_subscribed', { ok: true, seq: 45 })
+    dispatchFrame('doc_update', {
+      workflowId: 'wf-1',
+      seq: 45,
+      update: new Uint8Array(7)
+    })
     expect(telemetryState.trackAgentReconnectSucceeded).toHaveBeenCalledTimes(2)
+    expect(
+      telemetryState.trackAgentReconnectSucceeded
+    ).toHaveBeenLastCalledWith({
+      attempt: 1,
+      reconnect_duration_ms: 500,
+      replayed_bytes: 7,
+      from_version: 44,
+      to_version: 45
+    })
+    unmount()
+  })
+
+  it('TEL-10: reports zero replayed bytes when the first post-ack frame is live', () => {
+    vi.useFakeTimers({ toFake: ['performance', 'setTimeout', 'clearTimeout'] })
+    vi.setSystemTime(1_000)
+    const { unmount } = mountFollower('wf-1')
+    bridge().lastSequence = 41
+
+    dispatchFrame('doc_subscribed', { ok: false })
+    vi.advanceTimersByTime(500)
+    dispatchFrame('doc_subscribed', { ok: true, seq: 41 })
+    expect(telemetryState.trackAgentReconnectSucceeded).not.toHaveBeenCalled()
+
+    // No catch-up was needed (ack seq equals the follower's own seq); the
+    // first live frame above the ack seq proves that and is NOT counted.
+    dispatchFrame('doc_update', {
+      workflowId: 'wf-1',
+      seq: 42,
+      update: new Uint8Array(99)
+    })
+    expect(telemetryState.trackAgentReconnectSucceeded).toHaveBeenCalledOnce()
+    expect(telemetryState.trackAgentReconnectSucceeded).toHaveBeenCalledWith({
+      attempt: 1,
+      reconnect_duration_ms: 500,
+      replayed_bytes: 0,
+      from_version: 41,
+      to_version: 41
+    })
+    unmount()
+  })
+
+  it('TEL-10: a quiet channel is reported by the stale probe re-ack', () => {
+    vi.useFakeTimers({ toFake: ['performance', 'setTimeout', 'clearTimeout'] })
+    vi.setSystemTime(1_000)
+    const { unmount } = mountFollower('wf-1')
+    bridge().lastSequence = 41
+
+    dispatchFrame('doc_subscribed', { ok: false })
+    vi.advanceTimersByTime(500)
+    dispatchFrame('doc_subscribed', { ok: true, seq: 41 })
+    expect(telemetryState.trackAgentReconnectSucceeded).not.toHaveBeenCalled()
+
+    bridge().resubscribe.mockClear()
+    vi.advanceTimersByTime(STALE_AFTER_MS)
+    expect(bridge().resubscribe).toHaveBeenCalledOnce()
+    dispatchFrame('doc_subscribed', { ok: true, seq: 41 })
+    expect(telemetryState.trackAgentReconnectSucceeded).toHaveBeenCalledOnce()
+    expect(telemetryState.trackAgentReconnectSucceeded).toHaveBeenCalledWith({
+      attempt: 1,
+      reconnect_duration_ms: 500,
+      replayed_bytes: 0,
+      from_version: 41,
+      to_version: 41
+    })
+    unmount()
+  })
+
+  it('TEL-10: the socket-drop path reports from the pre-drop version', () => {
+    vi.useFakeTimers({ toFake: ['performance', 'setTimeout', 'clearTimeout'] })
+    vi.setSystemTime(1_000)
+    const { unmount } = mountFollower('wf-1')
+    dispatchFrame('doc_subscribed', { ok: true, seq: 7 })
+    bridge().lastSequence = 7
+
+    apiState.target.dispatchEvent(new Event('reconnected'))
+    vi.advanceTimersByTime(1_200)
+    dispatchFrame('doc_subscribed', { ok: true, seq: 9 })
+    dispatchFrame('doc_update', {
+      workflowId: 'wf-1',
+      seq: 9,
+      update: new Uint8Array(12)
+    })
+
+    expect(telemetryState.trackAgentReconnectSucceeded).toHaveBeenCalledOnce()
+    expect(telemetryState.trackAgentReconnectSucceeded).toHaveBeenCalledWith({
+      attempt: 1,
+      reconnect_duration_ms: 1_200,
+      replayed_bytes: 12,
+      from_version: 7,
+      to_version: 9
+    })
+    unmount()
+  })
+
+  it('TEL-10: a workflow switch mid-reconnect does not report on the next bind', async () => {
+    vi.useFakeTimers({ toFake: ['performance', 'setTimeout', 'clearTimeout'] })
+    vi.setSystemTime(1_000)
+    const { unmount, workflowId } = mountFollower('wf-1')
+    bridge().lastSequence = 41
+
+    // Armed but never confirmed: the switch drops the bookkeeping silently.
+    apiState.target.dispatchEvent(new Event('reconnected'))
+    workflowId.value = 'wf-2'
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(telemetryState.trackAgentReconnectSucceeded).not.toHaveBeenCalled()
+
+    dispatchFrame('doc_subscribed', { ok: true, seq: 1 })
+    dispatchFrame('doc_update', {
+      workflowId: 'wf-2',
+      seq: 1,
+      update: new Uint8Array(3)
+    })
+    expect(telemetryState.trackAgentReconnectSucceeded).not.toHaveBeenCalled()
+    unmount()
+  })
+
+  it('TEL-10: a workflow switch while the report is pending flushes it', async () => {
+    vi.useFakeTimers({ toFake: ['performance', 'setTimeout', 'clearTimeout'] })
+    vi.setSystemTime(1_000)
+    const { unmount, workflowId } = mountFollower('wf-1')
+    bridge().lastSequence = 41
+
+    // Confirmed, catch-up not yet delivered: the reconnect DID succeed.
+    dispatchFrame('doc_subscribed', { ok: false })
+    vi.advanceTimersByTime(500)
+    dispatchFrame('doc_subscribed', { ok: true, seq: 43 })
+    expect(telemetryState.trackAgentReconnectSucceeded).not.toHaveBeenCalled()
+
+    workflowId.value = 'wf-2'
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(telemetryState.trackAgentReconnectSucceeded).toHaveBeenCalledOnce()
+    expect(telemetryState.trackAgentReconnectSucceeded).toHaveBeenCalledWith({
+      attempt: 1,
+      reconnect_duration_ms: 500,
+      replayed_bytes: 0,
+      from_version: 41,
+      to_version: 43
+    })
     unmount()
   })
 

--- a/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.test.ts
+++ b/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.test.ts
@@ -21,9 +21,17 @@ import type { MaterializableGraph } from './agentNodeMaterializer'
 
 const bridgeState = vi.hoisted(() => {
   class FakeBridge extends EventTarget {
-    subscribe = vi.fn()
+    // Mirrors the real bridge: `reconcile()` nulls `lastSeq`/`ackSeq` as soon
+    // as a subscribe frame leaves, so `lastSequence` reads 0 from the moment a
+    // subscribe is attempted until the next ack. Anything deriving a
+    // reconnect's `from_version` from the bridge would therefore report 0.
+    subscribe = vi.fn((_workflowId: string): void => {
+      this.lastSequence = 0
+    })
     unsubscribe = vi.fn()
-    resubscribe = vi.fn()
+    resubscribe = vi.fn(() => {
+      this.lastSequence = 0
+    })
     reconcile = vi.fn()
     destroy = vi.fn()
     sendHumanOps = vi.fn()
@@ -260,11 +268,11 @@ describe('useAgentCrdtFollower', () => {
     vi.useFakeTimers({ toFake: ['performance', 'setTimeout', 'clearTimeout'] })
     vi.setSystemTime(1_000)
     const { unmount } = mountFollower('wf-1')
-    bridge().lastSequence = 41
+    dispatchFrame('doc_subscribed', { ok: true, seq: 41 })
 
     dispatchFrame('doc_subscribed', { ok: false })
     vi.advanceTimersByTime(500)
-    // A live frame can overtake the ack; it is still part of the recovery.
+    // A catch-up frame can overtake its own ack; it is still replay.
     dispatchFrame('doc_update', {
       workflowId: 'wf-1',
       seq: 42,
@@ -299,8 +307,7 @@ describe('useAgentCrdtFollower', () => {
     })
     expect(telemetryState.trackAgentReconnectSucceeded).toHaveBeenCalledOnce()
 
-    // A second recovery is its own report with its own baseline.
-    bridge().lastSequence = 44
+    // A second recovery is its own report, baselined on the live frame above.
     dispatchFrame('doc_subscribed', { ok: false })
     vi.advanceTimersByTime(500)
     dispatchFrame('doc_subscribed', { ok: true, seq: 45 })
@@ -326,7 +333,7 @@ describe('useAgentCrdtFollower', () => {
     vi.useFakeTimers({ toFake: ['performance', 'setTimeout', 'clearTimeout'] })
     vi.setSystemTime(1_000)
     const { unmount } = mountFollower('wf-1')
-    bridge().lastSequence = 41
+    dispatchFrame('doc_subscribed', { ok: true, seq: 41 })
 
     dispatchFrame('doc_subscribed', { ok: false })
     vi.advanceTimersByTime(500)
@@ -355,7 +362,7 @@ describe('useAgentCrdtFollower', () => {
     vi.useFakeTimers({ toFake: ['performance', 'setTimeout', 'clearTimeout'] })
     vi.setSystemTime(1_000)
     const { unmount } = mountFollower('wf-1')
-    bridge().lastSequence = 41
+    dispatchFrame('doc_subscribed', { ok: true, seq: 41 })
 
     dispatchFrame('doc_subscribed', { ok: false })
     vi.advanceTimersByTime(500)
@@ -382,7 +389,6 @@ describe('useAgentCrdtFollower', () => {
     vi.setSystemTime(1_000)
     const { unmount } = mountFollower('wf-1')
     dispatchFrame('doc_subscribed', { ok: true, seq: 7 })
-    bridge().lastSequence = 7
 
     apiState.target.dispatchEvent(new Event('reconnected'))
     vi.advanceTimersByTime(1_200)
@@ -413,7 +419,6 @@ describe('useAgentCrdtFollower', () => {
     vi.setSystemTime(1_000)
     const { unmount } = mountFollower('wf-1')
     dispatchFrame('doc_subscribed', { ok: true, seq: 7 })
-    bridge().lastSequence = 7
 
     apiState.target.dispatchEvent(new Event('reconnected'))
     expect(telemetryState.trackAgentReconnectStarted).toHaveBeenCalledWith(
@@ -452,7 +457,7 @@ describe('useAgentCrdtFollower', () => {
     vi.useFakeTimers({ toFake: ['performance', 'setTimeout', 'clearTimeout'] })
     vi.setSystemTime(1_000)
     const { unmount, workflowId } = mountFollower('wf-1')
-    bridge().lastSequence = 41
+    dispatchFrame('doc_subscribed', { ok: true, seq: 41 })
 
     // Armed but never confirmed: the switch drops the bookkeeping silently.
     apiState.target.dispatchEvent(new Event('reconnected'))
@@ -475,7 +480,7 @@ describe('useAgentCrdtFollower', () => {
     vi.useFakeTimers({ toFake: ['performance', 'setTimeout', 'clearTimeout'] })
     vi.setSystemTime(1_000)
     const { unmount, workflowId } = mountFollower('wf-1')
-    bridge().lastSequence = 41
+    dispatchFrame('doc_subscribed', { ok: true, seq: 41 })
 
     // Confirmed, catch-up not yet delivered: the reconnect DID succeed.
     dispatchFrame('doc_subscribed', { ok: false })
@@ -504,6 +509,43 @@ describe('useAgentCrdtFollower', () => {
     dispatchFrame('doc_subscribed', { ok: true, seq: 1 })
 
     expect(telemetryState.trackAgentReconnectSucceeded).not.toHaveBeenCalled()
+  })
+
+  it('TEL-10: does not report reconnect success on a first-ever bind that is refused first', () => {
+    // FE-1901's documented cold start: the subscribe races the doc-host, is
+    // refused, and the retry lands. Nothing was ever connected, so there is no
+    // recovery to report - counting it would inflate the very rate this metric
+    // exists to measure.
+    vi.useFakeTimers({ toFake: ['performance', 'setTimeout', 'clearTimeout'] })
+    const { unmount } = mountFollower('wf-1')
+
+    dispatchFrame('doc_subscribed', { ok: false })
+    vi.advanceTimersByTime(500)
+    dispatchFrame('doc_subscribed', { ok: true, seq: 1 })
+    dispatchFrame('doc_update', {
+      workflowId: 'wf-1',
+      seq: 1,
+      update: new Uint8Array(4)
+    })
+
+    expect(telemetryState.trackAgentReconnectSucceeded).not.toHaveBeenCalled()
+    unmount()
+  })
+
+  it('TEL-10: does not report reconnect success when the socket reconnects before any binding was confirmed', () => {
+    vi.useFakeTimers({ toFake: ['performance', 'setTimeout', 'clearTimeout'] })
+    const { unmount } = mountFollower('wf-1')
+
+    apiState.target.dispatchEvent(new Event('reconnected'))
+    dispatchFrame('doc_subscribed', { ok: true, seq: 3 })
+    dispatchFrame('doc_update', {
+      workflowId: 'wf-1',
+      seq: 3,
+      update: new Uint8Array(4)
+    })
+
+    expect(telemetryState.trackAgentReconnectSucceeded).not.toHaveBeenCalled()
+    unmount()
   })
 
   it('reports retry exhaustion exactly once with normalized metadata', () => {
@@ -766,6 +808,7 @@ describe('useAgentCrdtFollower', () => {
     vi.setSystemTime(1_000)
     const { unmount } = mountFollower('wf-1')
     dispatchFrame('doc_subscribed', { ok: true })
+    bridge().lastSequence = 41
 
     vi.advanceTimersByTime(5_000)
     apiState.target.dispatchEvent(new Event('reconnected'))

--- a/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.test.ts
+++ b/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.test.ts
@@ -602,6 +602,51 @@ describe('useAgentCrdtFollower', () => {
     unmount()
   })
 
+  it('TEL-10: a lineage break drops the reconnect bookkeeping instead of carrying it into the new doc', () => {
+    vi.useFakeTimers({ toFake: ['performance', 'setTimeout', 'clearTimeout'] })
+    vi.setSystemTime(1_000)
+    const { unmount } = mountFollower('wf-1')
+    dispatchFrame('doc_subscribed', { ok: true, seq: 41 })
+
+    dispatchFrame('doc_subscribed', { ok: false })
+    vi.advanceTimersByTime(500)
+    dispatchFrame('doc_subscribed', { ok: true, seq: 43 })
+    dispatchFrame('doc_reset', { workflowId: 'wf-1', seq: 0 })
+
+    // The new lineage restarts at seq 1; without dropping the bookkeeping its
+    // frames would be counted as the old doc's catch-up.
+    dispatchFrame('doc_subscribed', { ok: true, seq: 1 })
+    dispatchFrame('doc_update', {
+      workflowId: 'wf-1',
+      seq: 1,
+      update: new Uint8Array(8)
+    })
+
+    expect(telemetryState.trackAgentReconnectSucceeded).not.toHaveBeenCalled()
+    unmount()
+  })
+
+  it('TEL-10: a schema error drops the pending report instead of leaving it to a later frame', () => {
+    vi.useFakeTimers({ toFake: ['performance', 'setTimeout', 'clearTimeout'] })
+    vi.setSystemTime(1_000)
+    const { unmount } = mountFollower('wf-1')
+    dispatchFrame('doc_subscribed', { ok: true, seq: 41 })
+
+    dispatchFrame('doc_subscribed', { ok: false })
+    vi.advanceTimersByTime(500)
+    dispatchFrame('doc_subscribed', { ok: true, seq: 43 })
+    dispatchFrame('schema_error', { workflowId: 'wf-1' })
+    dispatchFrame('doc_update', {
+      workflowId: 'wf-1',
+      seq: 43,
+      update: new Uint8Array(8)
+    })
+
+    // Nothing was projected, so the recovery never completed.
+    expect(telemetryState.trackAgentReconnectSucceeded).not.toHaveBeenCalled()
+    unmount()
+  })
+
   it('reports retry exhaustion exactly once with normalized metadata', () => {
     vi.useFakeTimers({ toFake: ['performance', 'setTimeout', 'clearTimeout'] })
     vi.setSystemTime(1_000)

--- a/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.test.ts
+++ b/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.test.ts
@@ -548,6 +548,26 @@ describe('useAgentCrdtFollower', () => {
     unmount()
   })
 
+  it('TEL-10: an ack without a seq reports the baseline rather than a version that moved backwards', () => {
+    vi.useFakeTimers({ toFake: ['performance', 'setTimeout', 'clearTimeout'] })
+    vi.setSystemTime(1_000)
+    const { unmount } = mountFollower('wf-1')
+    dispatchFrame('doc_subscribed', { ok: true, seq: 41 })
+
+    dispatchFrame('doc_subscribed', { ok: false })
+    vi.advanceTimersByTime(500)
+    dispatchFrame('doc_subscribed', { ok: true })
+
+    expect(telemetryState.trackAgentReconnectSucceeded).toHaveBeenCalledWith({
+      attempt: 1,
+      reconnect_duration_ms: 500,
+      replayed_bytes: 0,
+      from_version: 41,
+      to_version: 41
+    })
+    unmount()
+  })
+
   it('reports retry exhaustion exactly once with normalized metadata', () => {
     vi.useFakeTimers({ toFake: ['performance', 'setTimeout', 'clearTimeout'] })
     vi.setSystemTime(1_000)

--- a/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.test.ts
+++ b/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.test.ts
@@ -647,6 +647,22 @@ describe('useAgentCrdtFollower', () => {
     unmount()
   })
 
+  it('TEL-9/TEL-10: a workflow switch resets the reconnect attempt counter', async () => {
+    vi.useFakeTimers({ toFake: ['performance', 'setTimeout', 'clearTimeout'] })
+    const { unmount, workflowId } = mountFollower('wf-1')
+    dispatchFrame('doc_subscribed', { ok: true, seq: 41 })
+
+    apiState.target.dispatchEvent(new Event('reconnected'))
+    workflowId.value = 'wf-2'
+    await nextTick()
+
+    apiState.target.dispatchEvent(new Event('reconnected'))
+    expect(telemetryState.trackAgentReconnectStarted).toHaveBeenLastCalledWith(
+      expect.objectContaining({ attempt: 1 })
+    )
+    unmount()
+  })
+
   it('reports retry exhaustion exactly once with normalized metadata', () => {
     vi.useFakeTimers({ toFake: ['performance', 'setTimeout', 'clearTimeout'] })
     vi.setSystemTime(1_000)

--- a/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.test.ts
+++ b/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.test.ts
@@ -568,6 +568,40 @@ describe('useAgentCrdtFollower', () => {
     unmount()
   })
 
+  it('TEL-10: a pre-ack frame above the ack seq is live traffic, not replay', () => {
+    // The relay joins the fanout before it acks, so a frame can arrive ahead
+    // of the ack that says where the catch-up ends. Only frames the ack
+    // actually covers are replay.
+    vi.useFakeTimers({ toFake: ['performance', 'setTimeout', 'clearTimeout'] })
+    vi.setSystemTime(1_000)
+    const { unmount } = mountFollower('wf-1')
+    dispatchFrame('doc_subscribed', { ok: true, seq: 41 })
+
+    dispatchFrame('doc_subscribed', { ok: false })
+    vi.advanceTimersByTime(500)
+    dispatchFrame('doc_update', {
+      workflowId: 'wf-1',
+      seq: 42,
+      update: new Uint8Array(10)
+    })
+    dispatchFrame('doc_update', {
+      workflowId: 'wf-1',
+      seq: 43,
+      update: new Uint8Array(90)
+    })
+    dispatchFrame('doc_subscribed', { ok: true, seq: 42 })
+
+    // The catch-up (seq 42) already landed, so the report needs nothing more.
+    expect(telemetryState.trackAgentReconnectSucceeded).toHaveBeenCalledWith({
+      attempt: 1,
+      reconnect_duration_ms: 500,
+      replayed_bytes: 10,
+      from_version: 41,
+      to_version: 42
+    })
+    unmount()
+  })
+
   it('reports retry exhaustion exactly once with normalized metadata', () => {
     vi.useFakeTimers({ toFake: ['performance', 'setTimeout', 'clearTimeout'] })
     vi.setSystemTime(1_000)

--- a/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.ts
+++ b/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.ts
@@ -296,6 +296,16 @@ export function useAgentCrdtFollower(
   let subscribeRetryStartedAt: number | null = null
   let subscribeRetryFailureReported = false
 
+  // TEL-10: mirrors the retry-exhaustion bookkeeping above, but for the
+  // recovery path — armed by the SAME two disconnect signals
+  // (`onReconnected`'s socket drop and a server `doc_subscribed{ok:false}`
+  // refusal) and cleared by the SAME confirmed-subscribe branch that clears
+  // the retry timer. `null` means "no reconnect in flight"; a confirmed
+  // subscribe while it is non-null is a reconnect SUCCESS, not just a mount.
+  let reconnectStartedAt: number | null = null
+  let reconnectFromVersion = 0
+  let reconnectReplayedBytes = 0
+
   // The recency heartbeat: armed only while a subscribe is CONFIRMED (bound +
   // healthy by definition), slid forward by every doc-scoped frame, cancelled
   // by the same lifecycle exits as the subscribe retry. The probe is
@@ -355,6 +365,19 @@ export function useAgentCrdtFollower(
     subscribeRetryAttempt = 0
     subscribeRetryStartedAt = null
     subscribeRetryFailureReported = false
+    reconnectStartedAt = null
+    reconnectFromVersion = 0
+    reconnectReplayedBytes = 0
+  }
+
+  // Arm reconnect tracking on the FIRST disconnect signal only — a later
+  // retry attempt or a second `onReconnected` mid-recovery must not reset the
+  // duration clock or the from_version baseline it already captured.
+  const armReconnectTracking = (): void => {
+    if (reconnectStartedAt !== null) return
+    reconnectStartedAt = performance.now()
+    reconnectFromVersion = bridge.lastSequence
+    reconnectReplayedBytes = 0
   }
 
   const reportSubscribeRetryExhausted = (): void => {
@@ -393,6 +416,7 @@ export function useAgentCrdtFollower(
     const target = subscribedWorkflowId.value
     if (target === null) return
     subscribeRetryStartedAt ??= performance.now()
+    armReconnectTracking()
     const delay = SUBSCRIBE_RETRY_BASE_MS * 2 ** subscribeRetryAttempt
     subscribeRetryAttempt += 1
     subscribeRetryTimer = setTimeout(() => {
@@ -427,6 +451,27 @@ export function useAgentCrdtFollower(
     lastFrameType.value = event.type
     recordDevEvent('doc_subscribed', event.detail ?? null)
     if (ok) {
+      // Read before clearSubscribeRetry() wipes the reconnect bookkeeping —
+      // a non-null start time means this confirm follows a disconnect signal
+      // (onReconnected or a prior refusal), i.e. it is a RECOVERY, not the
+      // panel's first-ever bind.
+      if (reconnectStartedAt !== null) {
+        useTelemetry()?.trackAgentReconnectSucceeded({
+          // Both disconnect signals produce subscribe attempts and both
+          // counters reset on this same confirmed subscribe, so the recovery
+          // cost is their sum: `onReconnected`'s immediate resubscribe plus
+          // every refusal-driven retry. Floored at 1 because a socket-drop
+          // recovery that never retried still took one attempt.
+          attempt: Math.max(1, reconnectAttempt + subscribeRetryAttempt),
+          reconnect_duration_ms: Math.max(
+            0,
+            Math.round(performance.now() - reconnectStartedAt)
+          ),
+          replayed_bytes: reconnectReplayedBytes,
+          from_version: reconnectFromVersion,
+          to_version: event.detail?.seq ?? bridge.lastSequence
+        })
+      }
       clearSubscribeRetry()
       armStaleProbe()
       reconnectAttempt = 0
@@ -461,6 +506,8 @@ export function useAgentCrdtFollower(
       }
       return
     }
+    if (reconnectStartedAt !== null && update.update instanceof Uint8Array)
+      reconnectReplayedBytes += update.update.length
     if (staleProbeTimer !== null) armStaleProbe()
     markActivity()
     refreshPersistedDocId()
@@ -610,6 +657,7 @@ export function useAgentCrdtFollower(
     }
     connected.value = false
     clearStaleProbe()
+    armReconnectTracking()
     recordDevEvent('reconnected', null)
     bridge.resubscribe()
   }

--- a/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.ts
+++ b/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.ts
@@ -299,12 +299,26 @@ export function useAgentCrdtFollower(
   // TEL-10: mirrors the retry-exhaustion bookkeeping above, but for the
   // recovery path — armed by the SAME two disconnect signals
   // (`onReconnected`'s socket drop and a server `doc_subscribed{ok:false}`
-  // refusal) and cleared by the SAME confirmed-subscribe branch that clears
-  // the retry timer. `null` means "no reconnect in flight"; a confirmed
-  // subscribe while it is non-null is a reconnect SUCCESS, not just a mount.
+  // refusal). `null` means "no reconnect in flight"; a confirmed subscribe
+  // while it is non-null is a reconnect SUCCESS, not just a mount.
+  //
+  // The report is NOT emitted at the ok ack. The relay sends the ack first and
+  // the catch-up `doc_update` (same seq as the ack) AFTER it, so emitting at
+  // the ack would always report `replayed_bytes: 0`. Instead the ack turns the
+  // bookkeeping into a PENDING report (`reconnectAckSeq` non-null) that is
+  // flushed by the catch-up frame, by the first live frame above the ack seq
+  // (no catch-up was needed), or by any later lifecycle exit.
   let reconnectStartedAt: number | null = null
   let reconnectFromVersion = 0
   let reconnectReplayedBytes = 0
+  let reconnectAckSeq: number | null = null
+  // Snapshot of the attempt count taken at the ack, so the deferred report is
+  // not distorted by the counters resetting on that same confirmed subscribe.
+  // Distinct from `reconnectAttempt` below, which is TEL-9's live
+  // socket-reconnect counter.
+  let reconnectReportAttempt = 0
+  let reconnectDurationMs = 0
+  let reconnectToVersion = 0
 
   // The recency heartbeat: armed only while a subscribe is CONFIRMED (bound +
   // healthy by definition), slid forward by every doc-scoped frame, cancelled
@@ -365,19 +379,103 @@ export function useAgentCrdtFollower(
     subscribeRetryAttempt = 0
     subscribeRetryStartedAt = null
     subscribeRetryFailureReported = false
+  }
+
+  const clearReconnectTracking = (): void => {
     reconnectStartedAt = null
     reconnectFromVersion = 0
     reconnectReplayedBytes = 0
+    reconnectAckSeq = null
+    reconnectReportAttempt = 0
+    reconnectDurationMs = 0
+    reconnectToVersion = 0
+  }
+
+  // Emit the PENDING report (ack already seen) with whatever catch-up bytes
+  // were counted so far, then drop the bookkeeping. No-op unless pending, so
+  // every exit path can call it unconditionally. `attempt`, the duration and
+  // `to_version` were snapshotted at the ack: the wait for the catch-up frame
+  // (or for the first live frame that proves none was needed) must not stretch
+  // the duration.
+  const emitReconnectReport = (): void => {
+    useTelemetry()?.trackAgentReconnectSucceeded({
+      attempt: reconnectReportAttempt,
+      reconnect_duration_ms: reconnectDurationMs,
+      replayed_bytes: reconnectReplayedBytes,
+      from_version: reconnectFromVersion,
+      to_version: reconnectToVersion
+    })
+    clearReconnectTracking()
+  }
+  const flushPendingReconnectReport = (): void => {
+    if (reconnectStartedAt === null || reconnectAckSeq === null) return
+    emitReconnectReport()
   }
 
   // Arm reconnect tracking on the FIRST disconnect signal only — a later
   // retry attempt or a second `onReconnected` mid-recovery must not reset the
-  // duration clock or the from_version baseline it already captured.
+  // duration clock or the from_version baseline it already captured. A
+  // disconnect signal while a report is PENDING is a new reconnect, so the
+  // pending one is flushed first and the clock restarts.
   const armReconnectTracking = (): void => {
+    flushPendingReconnectReport()
     if (reconnectStartedAt !== null) return
     reconnectStartedAt = performance.now()
     reconnectFromVersion = bridge.lastSequence
     reconnectReplayedBytes = 0
+  }
+
+  // Confirmed subscribe while a reconnect is in flight. A numeric ack seq means
+  // a catch-up frame with that seq MAY follow, so the report goes pending; an
+  // ack without a seq has nothing to wait for and is reported at once. A second
+  // ok ack while already pending (the stale probe's `resubscribe()`) proves no
+  // catch-up arrived, so it flushes rather than re-arming.
+  const onReconnectConfirmed = (ackSeq: number | null): void => {
+    if (reconnectStartedAt === null) return
+    if (reconnectAckSeq !== null) {
+      flushPendingReconnectReport()
+      return
+    }
+    // Both disconnect signals produce subscribe attempts and both counters
+    // reset on this same confirmed subscribe, so the recovery cost is their
+    // sum: `onReconnected`'s immediate resubscribe plus every refusal-driven
+    // retry. Floored at 1 because a socket-drop recovery that never retried
+    // still took one attempt.
+    reconnectReportAttempt = Math.max(
+      1,
+      reconnectAttempt + subscribeRetryAttempt
+    )
+    reconnectDurationMs = Math.max(
+      0,
+      Math.round(performance.now() - reconnectStartedAt)
+    )
+    if (ackSeq === null) {
+      reconnectToVersion = 0
+      emitReconnectReport()
+      return
+    }
+    reconnectToVersion = ackSeq
+    reconnectAckSeq = ackSeq
+  }
+
+  // Doc frame while a reconnect is in flight. Before the ack every frame is
+  // counted (the ack can be overtaken). After the ack, frames at or below the
+  // ack seq are the catch-up: count them and flush on the one that matches
+  // the ack. A frame ABOVE the ack seq is live traffic, which proves the
+  // catch-up was empty (or already flushed): flush first, do not count it.
+  const trackReconnectUpdate = (update: DocUpdate): void => {
+    if (reconnectStartedAt === null) return
+    const bytes = update.update instanceof Uint8Array ? update.update.length : 0
+    if (reconnectAckSeq === null) {
+      reconnectReplayedBytes += bytes
+      return
+    }
+    if (update.seq > reconnectAckSeq) {
+      flushPendingReconnectReport()
+      return
+    }
+    reconnectReplayedBytes += bytes
+    if (update.seq === reconnectAckSeq) flushPendingReconnectReport()
   }
 
   const reportSubscribeRetryExhausted = (): void => {
@@ -451,27 +549,13 @@ export function useAgentCrdtFollower(
     lastFrameType.value = event.type
     recordDevEvent('doc_subscribed', event.detail ?? null)
     if (ok) {
-      // Read before clearSubscribeRetry() wipes the reconnect bookkeeping —
-      // a non-null start time means this confirm follows a disconnect signal
+      // Snapshot before clearSubscribeRetry() resets the attempt counter. A
+      // non-null start time means this confirm follows a disconnect signal
       // (onReconnected or a prior refusal), i.e. it is a RECOVERY, not the
-      // panel's first-ever bind.
-      if (reconnectStartedAt !== null) {
-        useTelemetry()?.trackAgentReconnectSucceeded({
-          // Both disconnect signals produce subscribe attempts and both
-          // counters reset on this same confirmed subscribe, so the recovery
-          // cost is their sum: `onReconnected`'s immediate resubscribe plus
-          // every refusal-driven retry. Floored at 1 because a socket-drop
-          // recovery that never retried still took one attempt.
-          attempt: Math.max(1, reconnectAttempt + subscribeRetryAttempt),
-          reconnect_duration_ms: Math.max(
-            0,
-            Math.round(performance.now() - reconnectStartedAt)
-          ),
-          replayed_bytes: reconnectReplayedBytes,
-          from_version: reconnectFromVersion,
-          to_version: event.detail?.seq ?? bridge.lastSequence
-        })
-      }
+      // panel's first-ever bind. The report itself is deferred until the
+      // catch-up frame (see `trackReconnectUpdate`).
+      const seq = event.detail?.seq
+      onReconnectConfirmed(typeof seq === 'number' ? seq : null)
       clearSubscribeRetry()
       armStaleProbe()
       reconnectAttempt = 0
@@ -506,8 +590,7 @@ export function useAgentCrdtFollower(
       }
       return
     }
-    if (reconnectStartedAt !== null && update.update instanceof Uint8Array)
-      reconnectReplayedBytes += update.update.length
+    trackReconnectUpdate(update)
     if (staleProbeTimer !== null) armStaleProbe()
     markActivity()
     refreshPersistedDocId()
@@ -735,6 +818,11 @@ export function useAgentCrdtFollower(
       // existing "reconcile on frame or on graph readiness" behaviour.
       const justActivated = active && previous?.[1] === false
       clearSubscribeRetry()
+      // A reconnect that was confirmed but still waiting for its catch-up
+      // frame DID succeed: report it before the binding changes. One that was
+      // never confirmed is dropped without a report.
+      flushPendingReconnectReport()
+      clearReconnectTracking()
       clearStaleProbe()
       connected.value = false
       knownDocNodeIds = new Set()
@@ -790,6 +878,8 @@ export function useAgentCrdtFollower(
     // update twice after a remount.
     try {
       clearSubscribeRetry()
+      flushPendingReconnectReport()
+      clearReconnectTracking()
       clearStaleProbe()
       api.removeEventListener('reconnected', onReconnected)
       api.removeEventListener('status', onSocketActivity)

--- a/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.ts
+++ b/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.ts
@@ -20,6 +20,8 @@ import type { GraphOperation } from './graphOperations'
 import { LayoutFollowerBridge } from './layoutFollowerBridge'
 import type { OpsResultView } from './opSender'
 import { createOpSender } from './opSender'
+import type { ReconnectEvent } from './reconnectReport'
+import { initialReconnectState, reduceReconnect } from './reconnectReport'
 
 // FE-1902: the doc id is otherwise held only in memory (set on turn ack), so a
 // panel remount loses the binding until the NEXT turn ack. Persist it per-tab
@@ -299,26 +301,8 @@ export function useAgentCrdtFollower(
   // TEL-10: mirrors the retry-exhaustion bookkeeping above, but for the
   // recovery path — armed by the SAME two disconnect signals
   // (`onReconnected`'s socket drop and a server `doc_subscribed{ok:false}`
-  // refusal). `null` means "no reconnect in flight"; a confirmed subscribe
-  // while it is non-null is a reconnect SUCCESS, not just a mount.
-  //
-  // The report is NOT emitted at the ok ack. The relay sends the ack first and
-  // the catch-up `doc_update` (same seq as the ack) AFTER it, so emitting at
-  // the ack would always report `replayed_bytes: 0`. Instead the ack turns the
-  // bookkeeping into a PENDING report (`reconnectAckSeq` non-null) that is
-  // flushed by the catch-up frame, by the first live frame above the ack seq
-  // (no catch-up was needed), or by any later lifecycle exit.
-  let reconnectStartedAt: number | null = null
-  let reconnectFromVersion = 0
-  let reconnectReplayedBytes = 0
-  let reconnectAckSeq: number | null = null
-  // Snapshot of the attempt count taken at the ack, so the deferred report is
-  // not distorted by the counters resetting on that same confirmed subscribe.
-  // Distinct from `reconnectAttempt` below, which is TEL-9's live
-  // socket-reconnect counter.
-  let reconnectReportAttempt = 0
-  let reconnectDurationMs = 0
-  let reconnectToVersion = 0
+  // refusal). See `reconnectReport.ts` for the phases and the transition.
+  let reconnect = initialReconnectState
 
   // The recency heartbeat: armed only while a subscribe is CONFIRMED (bound +
   // healthy by definition), slid forward by every doc-scoped frame, cancelled
@@ -381,101 +365,47 @@ export function useAgentCrdtFollower(
     subscribeRetryFailureReported = false
   }
 
-  const clearReconnectTracking = (): void => {
-    reconnectStartedAt = null
-    reconnectFromVersion = 0
-    reconnectReplayedBytes = 0
-    reconnectAckSeq = null
-    reconnectReportAttempt = 0
-    reconnectDurationMs = 0
-    reconnectToVersion = 0
+  const dispatchReconnect = (event: ReconnectEvent): void => {
+    const { state, report } = reduceReconnect(reconnect, event)
+    reconnect = state
+    if (report !== null) useTelemetry()?.trackAgentReconnectSucceeded(report)
   }
 
-  // Emit the PENDING report (ack already seen) with whatever catch-up bytes
-  // were counted so far, then drop the bookkeeping. No-op unless pending, so
-  // every exit path can call it unconditionally. `attempt`, the duration and
-  // `to_version` were snapshotted at the ack: the wait for the catch-up frame
-  // (or for the first live frame that proves none was needed) must not stretch
-  // the duration.
-  const emitReconnectReport = (): void => {
-    useTelemetry()?.trackAgentReconnectSucceeded({
-      attempt: reconnectReportAttempt,
-      reconnect_duration_ms: reconnectDurationMs,
-      replayed_bytes: reconnectReplayedBytes,
-      from_version: reconnectFromVersion,
-      to_version: reconnectToVersion
-    })
-    clearReconnectTracking()
+  const clearReconnectTracking = (): void => {
+    dispatchReconnect({ type: 'abandoned' })
   }
   const flushPendingReconnectReport = (): void => {
-    if (reconnectStartedAt === null || reconnectAckSeq === null) return
-    emitReconnectReport()
+    dispatchReconnect({ type: 'flushed' })
   }
 
-  // Arm reconnect tracking on the FIRST disconnect signal only — a later
-  // retry attempt or a second `onReconnected` mid-recovery must not reset the
-  // duration clock or the from_version baseline it already captured. A
-  // disconnect signal while a report is PENDING is a new reconnect, so the
-  // pending one is flushed first and the clock restarts.
   const armReconnectTracking = (): void => {
-    flushPendingReconnectReport()
-    if (reconnectStartedAt !== null) return
-    reconnectStartedAt = performance.now()
-    reconnectFromVersion = bridge.lastSequence
-    reconnectReplayedBytes = 0
+    dispatchReconnect({
+      type: 'disconnected',
+      at: performance.now(),
+      fromVersion: bridge.lastSequence
+    })
   }
 
-  // Confirmed subscribe while a reconnect is in flight. A numeric ack seq means
-  // a catch-up frame with that seq MAY follow, so the report goes pending; an
-  // ack without a seq has nothing to wait for and is reported at once. A second
-  // ok ack while already pending (the stale probe's `resubscribe()`) proves no
-  // catch-up arrived, so it flushes rather than re-arming.
   const onReconnectConfirmed = (ackSeq: number | null): void => {
-    if (reconnectStartedAt === null) return
-    if (reconnectAckSeq !== null) {
-      flushPendingReconnectReport()
-      return
-    }
-    // Both disconnect signals produce subscribe attempts and both counters
-    // reset on this same confirmed subscribe, so the recovery cost is their
-    // sum: `onReconnected`'s immediate resubscribe plus every refusal-driven
-    // retry. Floored at 1 because a socket-drop recovery that never retried
-    // still took one attempt.
-    reconnectReportAttempt = Math.max(
-      1,
-      reconnectAttempt + subscribeRetryAttempt
-    )
-    reconnectDurationMs = Math.max(
-      0,
-      Math.round(performance.now() - reconnectStartedAt)
-    )
-    if (ackSeq === null) {
-      reconnectToVersion = 0
-      emitReconnectReport()
-      return
-    }
-    reconnectToVersion = ackSeq
-    reconnectAckSeq = ackSeq
+    dispatchReconnect({
+      type: 'confirmed',
+      at: performance.now(),
+      ackSeq,
+      // Both disconnect signals produce subscribe attempts and both counters
+      // reset on this same confirmed subscribe, so the recovery cost is their
+      // sum: `onReconnected`'s immediate resubscribe plus every refusal-driven
+      // retry. Floored at 1 because a socket-drop recovery that never retried
+      // still took one attempt.
+      attempt: Math.max(1, reconnectAttempt + subscribeRetryAttempt)
+    })
   }
 
-  // Doc frame while a reconnect is in flight. Before the ack every frame is
-  // counted (the ack can be overtaken). After the ack, frames at or below the
-  // ack seq are the catch-up: count them and flush on the one that matches
-  // the ack. A frame ABOVE the ack seq is live traffic, which proves the
-  // catch-up was empty (or already flushed): flush first, do not count it.
   const trackReconnectUpdate = (update: DocUpdate): void => {
-    if (reconnectStartedAt === null) return
-    const bytes = update.update instanceof Uint8Array ? update.update.length : 0
-    if (reconnectAckSeq === null) {
-      reconnectReplayedBytes += bytes
-      return
-    }
-    if (update.seq > reconnectAckSeq) {
-      flushPendingReconnectReport()
-      return
-    }
-    reconnectReplayedBytes += bytes
-    if (update.seq === reconnectAckSeq) flushPendingReconnectReport()
+    dispatchReconnect({
+      type: 'update',
+      seq: update.seq,
+      bytes: update.update instanceof Uint8Array ? update.update.length : 0
+    })
   }
 
   const reportSubscribeRetryExhausted = (): void => {
@@ -550,10 +480,9 @@ export function useAgentCrdtFollower(
     recordDevEvent('doc_subscribed', event.detail ?? null)
     if (ok) {
       // Snapshot before clearSubscribeRetry() resets the attempt counter. A
-      // non-null start time means this confirm follows a disconnect signal
-      // (onReconnected or a prior refusal), i.e. it is a RECOVERY, not the
-      // panel's first-ever bind. The report itself is deferred until the
-      // catch-up frame (see `trackReconnectUpdate`).
+      // confirm while a recovery is in flight is a RECOVERY, not the panel's
+      // first-ever bind. The report itself is deferred until the catch-up
+      // frame (see `trackReconnectUpdate`).
       const seq = event.detail?.seq
       onReconnectConfirmed(typeof seq === 'number' ? seq : null)
       clearSubscribeRetry()

--- a/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.ts
+++ b/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.ts
@@ -596,6 +596,11 @@ export function useAgentCrdtFollower(
     updatesApplied.value = 0
     lastFrameType.value = event.type
     clearStaleProbe()
+    // The seq space restarts with the new lineage, so a recovery armed against
+    // the old one can never be confirmed against a comparable version. Neither
+    // is a doc_reset itself a reconnect success: drop it without a report.
+    clearReconnectTracking()
+    confirmedVersion = null
     knownDocNodeIds = new Set()
     recordDevEvent(
       'doc_reset',
@@ -636,6 +641,7 @@ export function useAgentCrdtFollower(
     connected.value = false
     lastFrameType.value = event.type
     clearStaleProbe()
+    clearReconnectTracking()
     const detail =
       event instanceof CustomEvent
         ? (event.detail as { workflowId?: string } | null)

--- a/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.ts
+++ b/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.ts
@@ -303,6 +303,11 @@ export function useAgentCrdtFollower(
   // (`onReconnected`'s socket drop and a server `doc_subscribed{ok:false}`
   // refusal). See `reconnectReport.ts` for the phases and the transition.
   let reconnect = initialReconnectState
+  // The seq this binding is known to have reached, and the proof that it was
+  // ever bound at all: `null` until a subscribe for it is CONFIRMED. A refusal
+  // before that is FE-1901's cold-start race, not a recovery, so nothing is
+  // armed and no "reconnect" is reported for a connection that never was.
+  let confirmedVersion: number | null = null
 
   // The recency heartbeat: armed only while a subscribe is CONFIRMED (bound +
   // healthy by definition), slid forward by every doc-scoped frame, cancelled
@@ -379,10 +384,11 @@ export function useAgentCrdtFollower(
   }
 
   const armReconnectTracking = (): void => {
+    if (confirmedVersion === null) return
     dispatchReconnect({
       type: 'disconnected',
       at: performance.now(),
-      fromVersion: bridge.lastSequence
+      fromVersion: confirmedVersion
     })
   }
 
@@ -479,12 +485,15 @@ export function useAgentCrdtFollower(
     lastFrameType.value = event.type
     recordDevEvent('doc_subscribed', event.detail ?? null)
     if (ok) {
-      // Snapshot before clearSubscribeRetry() resets the attempt counter. A
-      // confirm while a recovery is in flight is a RECOVERY, not the panel's
-      // first-ever bind. The report itself is deferred until the catch-up
-      // frame (see `trackReconnectUpdate`).
+      // Snapshot before clearSubscribeRetry() resets the attempt counter. The
+      // confirm is only a RECOVERY if a disconnect signal armed one; on the
+      // panel's first-ever bind it merely establishes the baseline below.
       const seq = event.detail?.seq
       onReconnectConfirmed(typeof seq === 'number' ? seq : null)
+      confirmedVersion =
+        typeof seq === 'number'
+          ? Math.max(confirmedVersion ?? 0, seq)
+          : (confirmedVersion ?? 0)
       clearSubscribeRetry()
       armStaleProbe()
       reconnectAttempt = 0
@@ -520,6 +529,8 @@ export function useAgentCrdtFollower(
       return
     }
     trackReconnectUpdate(update)
+    if (confirmedVersion !== null)
+      confirmedVersion = Math.max(confirmedVersion, update.seq)
     if (staleProbeTimer !== null) armStaleProbe()
     markActivity()
     refreshPersistedDocId()
@@ -752,6 +763,8 @@ export function useAgentCrdtFollower(
       // never confirmed is dropped without a report.
       flushPendingReconnectReport()
       clearReconnectTracking()
+      // The new binding has never been confirmed and has its own seq space.
+      confirmedVersion = null
       clearStaleProbe()
       connected.value = false
       knownDocNodeIds = new Set()

--- a/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.ts
+++ b/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.ts
@@ -769,8 +769,11 @@ export function useAgentCrdtFollower(
       // never confirmed is dropped without a report.
       flushPendingReconnectReport()
       clearReconnectTracking()
-      // The new binding has never been confirmed and has its own seq space.
+      // The new binding has never been confirmed and has its own seq space, and
+      // TEL-9's live counter must not carry an abandoned recovery's attempts
+      // into the next workflow's first report.
       confirmedVersion = null
+      reconnectAttempt = 0
       clearStaleProbe()
       connected.value = false
       knownDocNodeIds = new Set()


### PR DESCRIPTION
## Summary

Implements the `app:agent_reconnect_succeeded` row from the [v1 telemetry checklist](https://github.com/christian-byrne/in-app-agent-program) (`reports/telemetry/v1-checklist.md`, mtg-29.2 emitted-vs-required diff, follow-up `TEL-10`). Stacked on [#16397](https://github.com/Comfy-Org/ComfyUI_frontend/pull/16397) (`app:agent_reconnect_failed`, TEL-11), which is itself stacked on [#16375](https://github.com/Comfy-Org/ComfyUI_frontend/pull/16375).

Emits exactly once when a reconnect (socket drop or a server `doc_subscribed{ok:false}` refusal loop) resolves with a confirmed subscribe, without replacing the follower document. Reuses the disconnect-signal wiring `#16397` added for `trackAgentReconnectFailed`: `onReconnected` and `scheduleSubscribeRetry` both arm reconnect-in-flight bookkeeping.

The bookkeeping is one discriminated union (`idle` / `inFlight` / `pending`) with a pure transition in `src/workbench/extensions/agent/crdt/reconnectReport.ts`, per `docs/guidance/state-and-effects.md`; the telemetry call is the only effect. The report is deferred past the ok ack, because the relay sends the ack first and the catch-up `doc_update` (same seq) after it, so emitting at the ack would always report `replayed_bytes: 0`.

Two guarantees the metric depends on, both enforced by a composable-owned baseline that is `null` until a subscribe for the current binding has been confirmed once:

- Only a binding that was connected can report a reconnect. FE-1901's cold start (subscribe, refused, retry, ok) is not a recovery, and neither is a socket reconnect that fires before any binding exists.
- `from_version` is that baseline, not `bridge.lastSequence`. The bridge clears its seq bookkeeping inside `reconcile()` as soon as a subscribe frame leaves, so it reads 0 by the time a refusal comes back.

Lineage breaks (`doc_reset`, `schema_error`) and workflow switches drop the bookkeeping rather than reporting against a seq space that no longer exists.

Properties match the checklist row exactly: `attempt`, `reconnect_duration_ms`, `replayed_bytes`, `from_version`, `to_version`. `attempt` is the sum of TEL-9's socket-reconnect counter and the refusal-retry counter, snapshotted at the ack and floored at 1, so a recovery that used both legs reports both.

## Evidence

```
$ pnpm vitest run src/workbench/extensions/agent
 Test Files  76 passed (76)
      Tests  1009 passed (1009)

$ pnpm typecheck
(clean)

$ pnpm lint
0 errors (189 pre-existing warnings, none in the changed files)

$ pnpm knip
(clean)

$ pnpm format:check
All matched files use the correct format.
```

Every test added or changed here was verified red-then-green by mutation: reverting each fix in turn fails exactly the test that names it, and restoring `from_version = bridge.lastSequence` fails 8 tests (it failed 0 before the fake bridge was made to mirror the real `reconcile()` behaviour).

<!-- authored-by:agent lane-TEL-10 -->
