### PR TITLE
test(e2e): reuse command execution tracker

### DIFF
--- a/browser_tests/fixtures/helpers/CommandHelper.ts
+++ b/browser_tests/fixtures/helpers/CommandHelper.ts
@@ -75,39 +75,29 @@ export class CommandHelper {
     )
   }
 
-  async registerKeybinding(
-    keyCombo: KeyCombo,
-    command: () => void
-  ): Promise<void> {
-    // SECURITY: eval() is intentionally used here to deserialize/execute functions
-    // passed from controlled test code across the Node/Playwright browser boundary.
-    // Execution happens in isolated Playwright browser contexts with test-only data.
-    // This pattern is unsafe for production and must not be copied elsewhere.
-    await this.page.evaluate(
-      ({ keyCombo, commandStr }) => {
-        const app = window.app!
-        const randomSuffix = Math.random().toString(36).substring(2, 8)
-        const extensionName = `TestExtension_${randomSuffix}`
-        const commandId = `TestCommand_${randomSuffix}`
+  async registerKeybinding(keyCombo: KeyCombo): Promise<string> {
+    return await this.page.evaluate((keyCombo) => {
+      const app = window.app!
+      const randomSuffix = Math.random().toString(36).substring(2, 8)
+      const extensionName = `TestExtension_${randomSuffix}`
+      const commandId = `TestCommand_${randomSuffix}`
 
-        app.registerExtension({
-          name: extensionName,
-          keybindings: [
-            {
-              combo: keyCombo,
-              commandId: commandId
-            }
-          ],
-          commands: [
-            {
-              id: commandId,
-              // oxlint-disable-next-line no-eval -- intentional: eval reconstructs a serialized function inside Playwright's page context
-              function: eval(commandStr)
-            }
-          ]
-        })
-      },
-      { keyCombo, commandStr: command.toString() }
-    )
+      app.registerExtension({
+        name: extensionName,
+        keybindings: [
+          {
+            combo: keyCombo,
+            commandId: commandId
+          }
+        ],
+        commands: [
+          {
+            id: commandId,
+            function: () => {}
+          }
+        ]
+      })
+      return commandId
+    }, keyCombo)
   }
 }

--- a/browser_tests/tests/extensionAPI.spec.ts
+++ b/browser_tests/tests/extensionAPI.spec.ts
@@ -21,9 +21,7 @@ test.describe('Topbar commands', () => {
           {
             id: 'foo',
             label: 'foo-command',
-            function: () => {
-              window.foo = true
-            }
+            function: () => {}
           }
         ],
         menuCommands: [
@@ -34,11 +32,10 @@ test.describe('Topbar commands', () => {
         ]
       })
     })
+    await comfyPage.command.mockCommand('foo')
 
     await comfyPage.menu.topbar.triggerTopbarCommand(['ext', 'foo-command'])
-    await expect
-      .poll(() => comfyPage.page.evaluate(() => window.foo))
-      .toBe(true)
+    await expect.poll(() => comfyPage.command.getExecutionCount('foo')).toBe(1)
   })
 
   test('Should not allow register command defined in other extension', async ({
@@ -69,9 +66,7 @@ test.describe('Topbar commands', () => {
         commands: [
           {
             id: 'TestCommand',
-            function: () => {
-              window.TestCommand = true
-            }
+            function: () => {}
           }
         ],
         keybindings: [
@@ -82,11 +77,12 @@ test.describe('Topbar commands', () => {
         ]
       })
     })
+    await comfyPage.command.mockCommand('TestCommand')
 
     await comfyPage.page.keyboard.press('k')
     await expect
-      .poll(() => comfyPage.page.evaluate(() => window.TestCommand))
-      .toBe(true)
+      .poll(() => comfyPage.command.getExecutionCount('TestCommand'))
+      .toBe(1)
   })
 
   test.describe('Settings', () => {
@@ -362,16 +358,13 @@ test.describe('Topbar commands', () => {
               id: 'test.selection.command',
               label: 'Test Command',
               icon: 'pi pi-star',
-              function: () => {
-                ;(window as unknown as Record<string, unknown>)[
-                  'selectionCommandExecuted'
-                ] = true
-              }
+              function: () => {}
             }
           ],
           getSelectionToolboxCommands: () => ['test.selection.command']
         })
       })
+      await comfyPage.command.mockCommand('test.selection.command')
 
       await comfyPage.nodeOps.selectNodes(['CLIP Text Encode (Prompt)'])
 
@@ -383,14 +376,9 @@ test.describe('Topbar commands', () => {
 
       await expect
         .poll(() =>
-          comfyPage.page.evaluate(
-            () =>
-              (window as unknown as Record<string, unknown>)[
-                'selectionCommandExecuted'
-              ]
-          )
+          comfyPage.command.getExecutionCount('test.selection.command')
         )
-        .toBe(true)
+        .toBe(1)
     })
   })
 })

--- a/browser_tests/tests/keybindings.spec.ts
+++ b/browser_tests/tests/keybindings.spec.ts
@@ -10,25 +10,24 @@ test.describe('Keybindings', { tag: '@keyboard' }, () => {
   test('Should not trigger non-modifier keybinding when typing in input fields', async ({
     comfyPage
   }) => {
-    await comfyPage.command.registerKeybinding({ key: 'k' }, () => {
-      window.TestCommand = true
-    })
+    const commandId = await comfyPage.command.registerKeybinding({ key: 'k' })
+    await comfyPage.command.mockCommand(commandId)
 
     const textBox = comfyPage.widgetTextBox
     await textBox.click()
     await textBox.fill('k')
     await expect(textBox).toHaveValue('k')
-    await expect
-      .poll(() => comfyPage.page.evaluate(() => window.TestCommand))
-      .toBe(undefined)
+    expect(await comfyPage.command.getExecutionCount(commandId)).toBe(0)
   })
 
   test('Should not trigger modifier keybinding when typing in input fields', async ({
     comfyPage
   }) => {
-    await comfyPage.command.registerKeybinding({ key: 'k', ctrl: true }, () => {
-      window.TestCommand = true
+    const commandId = await comfyPage.command.registerKeybinding({
+      key: 'k',
+      ctrl: true
     })
+    await comfyPage.command.mockCommand(commandId)
 
     const textBox = comfyPage.widgetTextBox
     await textBox.click()
@@ -36,23 +35,22 @@ test.describe('Keybindings', { tag: '@keyboard' }, () => {
     await textBox.press('Control+k')
     await expect(textBox).toHaveValue('q')
     await expect
-      .poll(() => comfyPage.page.evaluate(() => window.TestCommand))
-      .toBe(true)
+      .poll(() => comfyPage.command.getExecutionCount(commandId))
+      .toBe(1)
   })
 
   test('Should not trigger keybinding reserved by text input when typing in input fields', async ({
     comfyPage
   }) => {
-    await comfyPage.command.registerKeybinding({ key: 'Ctrl+v' }, () => {
-      window.TestCommand = true
+    const commandId = await comfyPage.command.registerKeybinding({
+      key: 'Ctrl+v'
     })
+    await comfyPage.command.mockCommand(commandId)
 
     const textBox = comfyPage.widgetTextBox
     await textBox.click()
     await textBox.press('Control+v')
     await expect(textBox).toBeFocused()
-    await expect
-      .poll(() => comfyPage.page.evaluate(() => window.TestCommand))
-      .toBe(undefined)
+    expect(await comfyPage.command.getExecutionCount(commandId)).toBe(0)
   })
 })


### PR DESCRIPTION
## Summary

Migrates browser command execution assertions to the shared tracker introduced by #16623.

## Changes

- **What**: Replaces six window-global command checks with `mockCommand` and `getExecutionCount`, and returns generated command IDs from `registerKeybinding`.
- **Dependencies**: Stacked on #16623. The base branch mirrors its cross-repository head at `b076875` so this PR contains only the migration commit.

## Review Focus

`CommandHelper.registerCommand` intentionally retains its controlled-test `eval()` path because `commands.spec.ts` exercises real synchronous, asynchronous, and throwing callbacks. This PR only migrates execution-only assertions to the shared counter.

## Verification

- `pnpm typecheck`
- `pnpm typecheck:browser`
- changed-file ESLint, Oxlint, Oxfmt, Knip, and Fallow
- six affected Playwright cases pass against the local managed backend