### PR TITLE
test: consolidate repromotion assertion into a single toStrictEqual

### DIFF
--- a/src/lib/litegraph/src/subgraph/SubgraphWidgetPromotion.test.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphWidgetPromotion.test.ts
@@ -442,8 +442,7 @@ describe('SubgraphWidgetPromotion', () => {
       expect(subgraph.inputNode.slots[0].linkIds).toHaveLength(1)
       expect(promotedInputs(subgraphNode)).toHaveLength(1)
       expect(subgraphNode.widgets).toHaveLength(1)
-      expect(repromotions).toHaveLength(1)
-      expect(repromotions[0]).toBe(secondWidget)
+      expect(repromotions).toStrictEqual([secondWidget])
       // Re-resolution deliberately keeps the store-backed value (see
       // widgetValueStore.registerWidget): rebinding must not clobber the
       // promoted value the user may have edited.


### PR DESCRIPTION
Follow-up to [#15889](https://github.com/Comfy-Org/ComfyUI_frontend/pull/15889), addressing the unresolved review comment from `@DrJKL`: https://github.com/Comfy-Org/ComfyUI_frontend/pull/15889#discussion_r3858543116

Collapses the two-assertion repromotion check (`toHaveLength(1)` + `toBe(secondWidget)`) into the suggested single `toStrictEqual([secondWidget])`.

<details><summary>Full context for agent readers</summary>

Verification on Node v25.9.0:

- `pnpm vitest run src/lib/litegraph/src/subgraph/SubgraphWidgetPromotion.test.ts`: 1 file, 46 tests passed
- `pnpm exec oxfmt --check` on the touched file: green
- `pnpm exec oxlint --type-aware` on the touched file: green
- `pnpm exec eslint` on the touched file: 2 pre-existing warnings (unrelated import-layer restriction on lines 28-29, confirmed present on `main` before this change), no errors
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm exec vue-tsc --noEmit`: green
- husky pre-commit hooks (oxfmt/oxlint/eslint/typecheck) ran clean on commit

</details>