### PR TITLE
fix(website): preserve platform isometric art while reducing jank

### DIFF
--- a/apps/website/src/templates/platform/ServerlessIsometricStudy.vue
+++ b/apps/website/src/templates/platform/ServerlessIsometricStudy.vue
@@ -218,6 +218,10 @@ function polygonPoints(points: readonly Point[]) {
   return points.map(([x, y]) => `${x},${y}`).join(' ')
 }
 
+function polygonPath(points: readonly Point[]) {
+  return `${points.map(([x, y], index) => `${index ? 'L' : 'M'}${x},${y}`).join('')}Z`
+}
+
 function leftFace(tile: VisualTile) {
   const top = tileCorners(tile, tile.height)
   const base = tileCorners(tile, 0)
@@ -230,6 +234,13 @@ function rightFace(tile: VisualTile) {
   const base = tileCorners(tile, 0)
 
   return polygonPoints([top[3], top[2], base[2], base[3]])
+}
+
+function texturedFaces(tile: VisualTile) {
+  const top = tileCorners(tile, tile.height)
+  const base = tileCorners(tile, 0)
+
+  return `${polygonPath([top[0], top[3], base[3], base[0]])} ${polygonPath([top[3], top[2], base[2], base[3]])} ${polygonPath(top)}`
 }
 
 const { pause, resume } = useRafFn(
@@ -318,8 +329,7 @@ watch(
 
       <g v-for="tile in visualTiles" :key="tile.id">
         <template v-if="tile.height > 0.5">
-          <polygon :points="leftFace(tile)" :fill="`url(#${textureId})`" />
-          <polygon :points="rightFace(tile)" :fill="`url(#${textureId})`" />
+          <path :d="texturedFaces(tile)" :fill="`url(#${textureId})`" />
           <g
             :opacity="tile.textureShadeOpacity"
             :data-texture-shade="tile.textureShadeOpacity"
@@ -342,10 +352,6 @@ watch(
             :points="rightFace(tile)"
             fill="var(--color-primary-comfy-plum)"
             fill-opacity="0.06"
-          />
-          <polygon
-            :points="polygonPoints(tileCorners(tile, tile.height))"
-            :fill="`url(#${textureId})`"
           />
           <polygon
             :points="polygonPoints(tileCorners(tile, tile.height))"


### PR DESCRIPTION
## Summary

Preserves the platform isometric artwork and 60 fps animation while reducing its SVG rasterization cost.

## Changes

- **What**: Paint each raised tile's three textured faces as one compound SVG path instead of three independent pattern fills.
- **Visuals**: Keep the original WebP texture, geometry, colors, overlays, motion cadence, and timing; only one-pixel compositing edges differ.
- **Performance**: Full-page p99 frame gap falls from 100 ms to 50 ms and Long Animation Frame time from 2,308 ms to 382 ms.

## Review Focus

Choose this visual-preserving implementation over the faster but artwork-changing approach in [#16616](https://github.com/Comfy-Org/ComfyUI_frontend/pull/16616).

<details><summary>Full context for agent readers</summary>

### Ownership and trace evidence

The source trace attributed first-party sampled self time to this platform-only component and showed 3.717 s of commit work during the 12.798 s capture. Scalar CDP comparisons then reduced renderer task time from 3.328–3.345 s on `main` to 2.540–2.611 s here while script time stayed negligible, supporting SVG rendering—not scroll-handler JavaScript—as the bottleneck.

This is intentionally separate from [#16627](https://github.com/Comfy-Org/ComfyUI_frontend/pull/16627), which fixes the site-wide footer's independent 75-frame WebP decode pressure. Independent ownership, risk, and rollback make two focused PRs safer than one mixed patch.

### Why not #16616

[#16616](https://github.com/Comfy-Org/ComfyUI_frontend/pull/16616) removes the original texture, replaces it with gradients, changes the reset tint, and limits the animation to 30 fps. Its benchmark is faster, but its own pixel review records the loss of the blue swoosh and peach bloom: mean whole-frame delta 2.24/255, with 1.8% of pixels differing by more than 24/255.

This alternative keeps the original image and every animation rule. Each visible raised tile currently asks Chromium to paint the same SVG image pattern three times per frame. One compound path keeps the three face geometries but requests one pattern paint.

### Deterministic visual comparison

Production builds used exact `origin/main` and this branch from the same base commit. Before page load, the harness replaced `requestAnimationFrame` with a deterministic clock and captured matched grow, hold, and reset states in Chrome 151 at 1440×900 and device pixel ratio 1.

| Animation state | Exact pixels | Mean channel delta | Pixels over 24/255 |
| --- | ---: | ---: | ---: |
| Grow, 900 ms | 96.891% | 0.0909/255 | 0.151% |
| Hold, 1,800 ms | 96.442% | 0.1287/255 | 0.233% |
| Reset, 5,125 ms | 96.506% | 0.1197/255 | 0.209% |

The 8× amplified differences are confined to one-pixel antialiasing/compositing boundaries. Artwork interiors, texture placement, colors, geometry, the blue swoosh, and the peach bloom remain. Five clipped top-edge pixels differ strongly in the reset state, so the defensible claim is visually equivalent—not bit-identical.

![Deterministic main, candidate, and 8x difference captures at grow, hold, and reset phases](https://ampcode.com/user-content/artifacts/e3e0265d2d7e64b0539d4eb99be517d95cde7388b6549236790bb68320e531ce-file.png)

### Browser benchmark

Production builds; fresh Chrome profile per run; Chrome 151; 1440×900 at device pixel ratio 1; two warmups per arm; ABBA/BAAB ordering; exact 300 wheel events for full-page runs; in-page request-animation-frame and Long Animation Frame observers; third-party hosts blocked except `media.comfy.org`.

Four accepted runs per arm are reported as medians.

| Median | `main` | This change |
| --- | ---: | ---: |
| Isolated p95 frame gap | 83.3 ms | 33.4 ms |
| Isolated p99 frame gap | 100.1 ms | 66.6 ms |
| Isolated frames over 33.4 ms | 25 | 15 |
| Isolated Long Animation Frames | 19 | 3 |
| Isolated Long Animation Frame time | 1,521 ms | 186 ms |
| 300-wheel full-page p95 frame gap | 49.9 ms | 33.3 ms |
| 300-wheel full-page p99 frame gap | 100 ms | 50 ms |
| 300-wheel frames over 33.4 ms | 74 | 41 |
| 300-wheel Long Animation Frames | 30 | 6 |
| 300-wheel Long Animation Frame time | 2,308 ms | 382 ms |
| 300-wheel workload duration | 27.71 s | 24.21 s |

Four full-scroll captures were rejected and retained because frame gaps exceeded one second, indicating host stalls; accepted runs were supplemented to four per arm instead of retrying those results away.

The quiet control had a 16.8 ms maximum frame gap and no Long Animation Frames. A bounded 100 ms positive control produced an 83.3 ms frame gap and one 100.3 ms Long Animation Frame, confirming harness sensitivity.

### Verification and limitation

- Website unit suite: 887 tests passed.
- Website typecheck: passed with no errors.
- Website production build: passed.
- ESLint, Oxlint, Stylelint, format, Knip, and diff checks: passed; repository-wide lint retained existing warnings only.
- CI build, website unit, lint/format, risk, security, and preview checks: passed.

Codecov reports four uncovered helper lines. No unit test was added solely to assert SVG tags, path counts, or path strings: the repository prohibits change-detector tests dependent on non-behavioral structure. Browser pixel output and frame timing are the relevant behavior and are covered by the controlled harness above.

### Glossary

- **ABBA/BAAB**: Interleaved baseline/candidate run ordering that reduces time-order bias.
- **CDP**: Chrome DevTools Protocol, used here for scalar renderer counters in a separate measurement arm.
- **Compound path**: One SVG path element containing several closed face shapes.
- **Device pixel ratio**: Physical display pixels represented by one CSS pixel.
- **Long Animation Frame**: Browser performance entry for a rendering frame delayed by main-thread work.
- **p95/p99**: The 95th/99th percentile; 95%/99% of observations are at or below the value.
- **WebP**: Image format of the retained isometric texture.

</details>

## Screenshots (if applicable)

The collapsed section contains deterministic captures for all three animation phases and amplified difference images.
