### PR TITLE
docs: clarify agent release order

### DIFF
--- a/docs/architecture/agent-cross-repo-release-order.md
+++ b/docs/architecture/agent-cross-repo-release-order.md
@@ -1,19 +1,28 @@
 # Agent cross-repository release order
 
+## Glossary
+
+- **Dark deploy:** compatible code deployed while user exposure is disabled.
+- **Integrated receipt:** exact revisions, package version, flags, and browser-visible proof.
+- **Consumer pin:** the exact shared-package version recorded in the manifest and lockfile.
+
 Agent protocol and applier changes must move in this order:
 
-```text
-comfy-multi-player merge + immutable release
-  -> cloud pin + tests + dark deploy + runtime proof
-  -> frontend pin + tests + flag-off deploy
-  -> flags on + authenticated browser canvas/reconnect proof
-  -> stable promotion of the exact tested combination
+```mermaid
+flowchart TD
+  package["comfy-multi-player<br/>Merge and publish an immutable release"]
+  cloud["Cloud — first runtime consumer<br/>Pin, test, dark deploy, and prove runtime"]
+  frontend["Frontend — second runtime consumer<br/>Pin, test, and deploy with exposure off"]
+  acceptance["Enable flags<br/>Prove an authenticated canvas edit and reconnect"]
+  stable["Stable promotion<br/>Reuse the exact tested combination"]
+
+  package --> cloud --> frontend --> acceptance --> stable
 ```
 
-Frontend is the second consumer. Update `package.json` and `pnpm-lock.yaml` only after the accepted
-`@comfyorg/comfy-multi-player` version is installable and the compatible cloud consumer has deployed.
-Run package-pin/parity checks, unit and browser tests, and prove both product-flag states before
-normal frontend review and merge.
+Cloud is the first runtime consumer, and frontend is the second. Update `package.json` and
+`pnpm-lock.yaml` only after the accepted `@comfyorg/comfy-multi-player` version is installable and
+the compatible cloud consumer has deployed. Run package-pin/parity checks, unit and browser tests,
+and prove both product-flag states before normal frontend review and merge.
 
 Deploy the frontend with user exposure off. The integration receipt names exact frontend/cloud
 revisions, the shared package version, and flag values. `agent-in-app-experience` is the
@@ -27,9 +36,3 @@ verifies the served frontend revision, and expands product access last.
 
 Backward-compatible frontend-only changes that do not emit, require, or expose a backend contract
 may merge independently if the PR explains why. Documentation-only changes may proceed in parallel.
-
-## Glossary
-
-- **Dark deploy:** compatible code deployed while user exposure is disabled.
-- **Integrated receipt:** exact revisions, package version, flags, and browser-visible proof.
-- **Consumer pin:** the exact shared-package version recorded in the manifest and lockfile.

--- a/docs/architecture/agent-cross-repo-release-order.md
+++ b/docs/architecture/agent-cross-repo-release-order.md
@@ -15,7 +15,7 @@ flowchart TD
   package["comfy-multi-player<br/>Merge and publish an immutable release"]
   cloud["Cloud — first runtime consumer<br/>Pin, test, dark deploy, and prove runtime"]
   frontend["Frontend — second runtime consumer<br/>Pin, test, and deploy with exposure off"]
-  acceptance["Enable flags<br/>Prove an authenticated canvas edit and reconnect"]
+  acceptance["Enable flags<br/>Prove an authenticated browser canvas edit and reconnect"]
   stable["Stable promotion<br/>Reuse the exact tested combination"]
 
   package --> cloud --> frontend --> acceptance --> stable

--- a/docs/architecture/agent-cross-repo-release-order.md
+++ b/docs/architecture/agent-cross-repo-release-order.md
@@ -37,7 +37,11 @@ They are not interchangeable.
 
 Acceptance requires an authenticated browser flow that causes a visible canvas edit and survives
 reconnect. Package CI, frame tests, healthy services, or a served frontend alone do not satisfy the
-gate. Stable promotion reuses the exact integrated combination, makes the backend compatible first,
+gate.
+
+## Stable promotion
+
+Stable promotion reuses the exact integrated combination, makes the backend compatible first,
 verifies the served frontend revision, and expands product access last.
 
 ## Exceptions

--- a/docs/architecture/agent-cross-repo-release-order.md
+++ b/docs/architecture/agent-cross-repo-release-order.md
@@ -3,7 +3,7 @@
 ## Glossary
 
 - **Dark deploy:** compatible code deployed while user exposure is disabled.
-- **Integrated receipt:** exact revisions, package version, flags, and browser-visible proof.
+- **Integration receipt:** exact revisions, package version, flags, and browser-visible proof.
 - **Consumer pin:** the exact shared-package version recorded in the manifest and lockfile.
 
 ## Release order

--- a/docs/architecture/agent-cross-repo-release-order.md
+++ b/docs/architecture/agent-cross-repo-release-order.md
@@ -6,6 +6,8 @@
 - **Integrated receipt:** exact revisions, package version, flags, and browser-visible proof.
 - **Consumer pin:** the exact shared-package version recorded in the manifest and lockfile.
 
+## Release order
+
 Agent protocol and applier changes must move in this order:
 
 ```mermaid
@@ -24,15 +26,21 @@ Cloud is the first runtime consumer, and frontend is the second. Update `package
 the compatible cloud consumer has deployed. Run package-pin/parity checks, unit and browser tests,
 and prove both product-flag states before normal frontend review and merge.
 
+## Deploy and receipt
+
 Deploy the frontend with user exposure off. The integration receipt names exact frontend/cloud
 revisions, the shared package version, and flag values. `agent-in-app-experience` is the
 product/cohort flag; `AGENT_CRDT_MODE` plus `workflows.crdt_enabled` selects the V1 storage path.
 They are not interchangeable.
 
+## Acceptance gate
+
 Acceptance requires an authenticated browser flow that causes a visible canvas edit and survives
 reconnect. Package CI, frame tests, healthy services, or a served frontend alone do not satisfy the
 gate. Stable promotion reuses the exact integrated combination, makes the backend compatible first,
 verifies the served frontend revision, and expands product access last.
+
+## Exceptions
 
 Backward-compatible frontend-only changes that do not emit, require, or expose a backend contract
 may merge independently if the PR explains why. Documentation-only changes may proceed in parallel.


### PR DESCRIPTION
## Summary

## Summary Address all three follow-up comments from #16607. ## Changes ## Review Focus Confirm the diagram and consumer ordering preserve the original release contract. ## Screenshots (if applicable) Not applicable. ## Evidence This main-based follow-up addresses DrJKL's three unresolved comments on #16607:

## Changes

- **What**: Replaces the text pipeline with Mermaid, names cloud as the first runtime consumer, and moves the glossary before first use.
- `git diff --check` — passed.
- Documentation-only change; no runtime tests required.

## Review Focus

1. The release sequence is now a Mermaid diagram.
2. The prose and diagram identify cloud as the first runtime consumer before frontend.
3. The glossary now precedes the terms it defines.

<!-- authored-by:agent lane-evfail-16 -->
