### PR TITLE
docs: clarify stable-store registration idempotency

### DIFF
--- a/src/stores/linkStore.ts
+++ b/src/stores/linkStore.ts
@@ -175,8 +175,9 @@ export const useLinkStore = defineStore('link', () => {
   }
 
   /**
-   * @returns The registered topology, or `undefined` when its ID or
-   * non-floating target slot is occupied.
+   * @returns The registered topology. Re-registering the same raw topology
+   * under the same owner returns the incumbent; `undefined` means a distinct
+   * topology occupies its ID or non-floating target slot.
    */
   function registerLink(
     scope: GraphScope,

--- a/src/stores/nodeDataStore.ts
+++ b/src/stores/nodeDataStore.ts
@@ -43,7 +43,9 @@ export const useNodeDataStore = defineStore('nodeData', () => {
   }
 
   /**
-   * @returns The registered state, or `undefined` when the node ID is occupied.
+   * @returns The registered state. Re-registering the same raw state under the
+   * same owner returns the incumbent; `undefined` means a distinct state
+   * occupies the node ID.
    */
   function registerNode(
     graphScope: GraphScope,

--- a/src/stores/rerouteStore.ts
+++ b/src/stores/rerouteStore.ts
@@ -111,7 +111,9 @@ export const useRerouteStore = defineStore('reroute', () => {
   }
 
   /**
-   * @returns The registered chain, or `undefined` when its ID is occupied.
+   * @returns The registered chain. Re-registering the same raw chain under the
+   * same owner returns the incumbent; `undefined` means a distinct chain
+   * occupies its ID.
    */
   function registerReroute(
     scope: GraphScope,


### PR DESCRIPTION
## Summary

Clarifies that stable-identity store registration is idempotent for the same raw object and owner, while distinct occupants are rejected.

## Changes

- **What**: Corrects `@returns` documentation for link, node-data, and reroute registration.

## Review Focus

Confirm each description matches the existing identity checks and preserves public contracts.

Follow-up to source PR #15761.

Addresses:
- [Review thread](https://github.com/Comfy-Org/ComfyUI_frontend/pull/15761#discussion_r3897795383)
- [Top-level review](https://github.com/Comfy-Org/ComfyUI_frontend/pull/15761#pullrequestreview-5070500158)

## Evidence

- `pnpm exec oxfmt --check src/stores/linkStore.ts src/stores/nodeDataStore.ts src/stores/rerouteStore.ts` — passed
- `pnpm test:unit src/stores/linkStore.test.ts src/stores/nodeDataStore.test.ts src/stores/rerouteStore.test.ts` — 62 passed
- `pnpm typecheck` — passed
- Commit hooks: oxfmt, oxlint, ESLint, typecheck — passed
- Push hook: knip — passed

<!-- authored-by:agent lane-act-fe-15761-followup-401321f4 -->
