### PR TITLE
fix(agent): gate op retries on active subscription

### DIFF
--- a/src/workbench/extensions/agent/crdt/opSender.test.ts
+++ b/src/workbench/extensions/agent/crdt/opSender.test.ts
@@ -104,7 +104,6 @@ describe('createOpSender', () => {
     sender.enqueue([addNode(1)])
     expect(sent).toHaveLength(0)
 
-    boundWorkflow = 'wf-2'
     transportUp = true
     vi.advanceTimersByTime(500)
 
@@ -120,14 +119,58 @@ describe('createOpSender', () => {
     ).toEqual(firstIds)
   })
 
-  it('keeps queued batches addressed to the workflow active when they were minted', () => {
+  it('never re-addresses a queued batch: an unbound mint-time workflow settles it undeliverable at once', () => {
     sender.enqueue([addNode(1)])
     sender.enqueue([addNode(2)])
+    sender.enqueue([addNode(3)])
     boundWorkflow = 'wf-2'
 
     ackInFlight()
 
+    expect(sent).toHaveLength(1)
+    expect(settled.map((outcome) => outcome.state)).toEqual([
+      'acknowledged',
+      'undeliverable',
+      'undeliverable'
+    ])
+    expect(settled[1].ops[0].op_id).not.toBe(settled[2].ops[0].op_id)
+  })
+
+  it('a bound workflow restored before the next send still carries the queued batch', () => {
+    sender.enqueue([addNode(1)])
+    sender.enqueue([addNode(2)])
+    boundWorkflow = null
+    boundWorkflow = WORKFLOW
+
+    ackInFlight()
+
+    expect(sent).toHaveLength(2)
     expect(sent[1].workflowId).toBe(WORKFLOW)
+  })
+
+  it('settles an in-flight batch undeliverable at the silence resend once its workflow is unbound', () => {
+    sender.enqueue([addNode(1)])
+    boundWorkflow = null
+
+    vi.advanceTimersByTime(10_000)
+
+    expect(sent).toHaveLength(1)
+    expect(settled).toEqual([
+      { state: 'undeliverable', ops: expect.any(Array) }
+    ])
+  })
+
+  it('an unbound workflow at the resend frees the queue for the next bound batch without a retry burn', () => {
+    sender.enqueue([addNode(1)])
+    boundWorkflow = 'wf-2'
+    sender.enqueue([addNode(2)])
+    expect(sent).toHaveLength(1)
+
+    vi.advanceTimersByTime(10_000)
+
+    expect(sent).toHaveLength(2)
+    expect(sent[1].workflowId).toBe('wf-2')
+    expect(settled[0].state).toBe('undeliverable')
   })
 
   it('settles undeliverable after the transport retry budget', () => {

--- a/src/workbench/extensions/agent/crdt/opSender.ts
+++ b/src/workbench/extensions/agent/crdt/opSender.ts
@@ -37,7 +37,12 @@ export interface OpSenderDeps {
   sendOps(workflowId: string, tab: string, ops: Op[]): boolean
   /** Subscribe to `doc_ops_result` frames; returns unsubscribe. */
   onOpsResult(listener: (result: OpsResultView) => void): () => void
-  /** The bound workflow id, or null when no doc is bound (drops the batch). */
+  /**
+   * The bound workflow id, or null when no doc is bound. Read at mint time to
+   * address the batch and re-read before EVERY send and resend: a batch whose
+   * workflow is no longer bound (subscription refused, tab moved to another
+   * doc) is never carried or re-addressed and settles 'undeliverable' at once.
+   */
   workflowId(): string | null
   tab: string
   /** `human:<user>:<tab>` (vocabulary §7). */
@@ -95,6 +100,12 @@ export function createOpSender(deps: OpSenderDeps): OpSender {
 
   function transmit(batch: InFlight, attempt: number): void {
     if (detached || inFlight !== batch) return
+    // A lost subscription is not a transport that recovers in 500 ms: settle
+    // now rather than spend the retry budget while later batches wait behind.
+    if (deps.workflowId() !== batch.workflowId) {
+      settleUndeliverable(batch)
+      return
+    }
     if (!deps.sendOps(batch.workflowId, deps.tab, batch.ops)) {
       if (attempt < SEND_RETRY_LIMIT) {
         setTimeout(() => transmit(batch, attempt + 1), SEND_RETRY_INTERVAL_MS)

--- a/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.test.ts
+++ b/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.test.ts
@@ -389,8 +389,9 @@ describe('useAgentCrdtFollower', () => {
     unmount()
   })
 
-  it('stops retrying an in-flight batch after the subscription is refused', () => {
+  it('a refused subscription settles the in-flight batch undeliverable at the resend instead of reaching the client', async () => {
     vi.useFakeTimers()
+    const { recordDevEvent } = await import('./devPanelLog')
     const workflowId = ref<string | null>('wf-1')
     let enqueue!: ReturnType<
       typeof useAgentCrdtFollower
@@ -410,11 +411,18 @@ describe('useAgentCrdtFollower', () => {
     enqueue([{ op: 'delete_node', node_id: '1', removed_links: [] }])
     expect(clientState.sendOps).toHaveBeenCalledTimes(1)
 
+    // The real bridge clears its send reality on doc_subscribed{ok:false}
+    // (LayoutFollowerBridge.onDocSubscribed); FakeBridge does not, so mirror
+    // that effect by hand. The sender gates on this value alone.
     bridge().subscribedWorkflowId = null
-    dispatchFrame('doc_subscribed', { ok: false })
     vi.advanceTimersByTime(10_000)
 
     expect(clientState.sendOps).toHaveBeenCalledTimes(1)
+    const settledStates = vi
+      .mocked(recordDevEvent)
+      .mock.calls.filter(([event]) => event === 'human_ops_settled')
+      .map(([, detail]) => (detail as { state: string }).state)
+    expect(settledStates).toEqual(['undeliverable'])
     unmount()
   })
 

--- a/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.test.ts
+++ b/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.test.ts
@@ -389,6 +389,35 @@ describe('useAgentCrdtFollower', () => {
     unmount()
   })
 
+  it('stops retrying an in-flight batch after the subscription is refused', () => {
+    vi.useFakeTimers()
+    const workflowId = ref<string | null>('wf-1')
+    let enqueue!: ReturnType<
+      typeof useAgentCrdtFollower
+    >['enqueueHumanOperations']
+    const host = defineComponent({
+      setup() {
+        const { enqueueHumanOperations } = useAgentCrdtFollower(
+          workflowId,
+          graphMutations
+        )
+        enqueue = enqueueHumanOperations
+        return () => null
+      }
+    })
+    const { unmount } = render(host)
+
+    enqueue([{ op: 'delete_node', node_id: '1', removed_links: [] }])
+    expect(clientState.sendOps).toHaveBeenCalledTimes(1)
+
+    bridge().subscribedWorkflowId = null
+    dispatchFrame('doc_subscribed', { ok: false })
+    vi.advanceTimersByTime(10_000)
+
+    expect(clientState.sendOps).toHaveBeenCalledTimes(1)
+    unmount()
+  })
+
   it('probes a quiet bound channel once per budget and re-arms (BE-9740)', () => {
     vi.useFakeTimers()
     const { unmount } = mountFollower('wf-1')

--- a/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.ts
+++ b/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.ts
@@ -124,9 +124,7 @@ export function useAgentCrdtFollower(
   const adapter = new EcsFollowerAdapter(graphMutations)
   const tabId = createUuidv4()
   const sender = createOpSender({
-    sendOps: (target, tab, ops) =>
-      bridge.subscribedWorkflowId === target &&
-      client.sendOps(target, tab, ops),
+    sendOps: (target, tab, ops) => client.sendOps(target, tab, ops),
     onOpsResult(listener) {
       const handler: EventListener = (event) => {
         if (!(event instanceof CustomEvent)) return
@@ -143,6 +141,8 @@ export function useAgentCrdtFollower(
       bridge.addEventListener('doc_ops_result', handler)
       return () => bridge.removeEventListener('doc_ops_result', handler)
     },
+    // Send REALITY, not this composable's intent: the sender re-reads it before
+    // every send and resend, so ops never reach a doc we are not subscribed to.
     workflowId: () => bridge.subscribedWorkflowId,
     tab: tabId,
     actor: () => `human:${userId() ?? 'anonymous'}:${tabId}`,

--- a/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.ts
+++ b/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.ts
@@ -124,7 +124,9 @@ export function useAgentCrdtFollower(
   const adapter = new EcsFollowerAdapter(graphMutations)
   const tabId = createUuidv4()
   const sender = createOpSender({
-    sendOps: (target, tab, ops) => client.sendOps(target, tab, ops),
+    sendOps: (target, tab, ops) =>
+      bridge.subscribedWorkflowId === target &&
+      client.sendOps(target, tab, ops),
     onOpsResult(listener) {
       const handler: EventListener = (event) => {
         if (!(event instanceof CustomEvent)) return


### PR DESCRIPTION
Stops an in-flight human-op batch from retrying after its CRDT subscription is refused.

<details><summary>Full context for agent readers</summary>

## Summary

The op sender previously captured a workflow ID at enqueue time and retried that batch without re-reading subscription reality. A `doc_subscribed { ok: false }` could therefore clear the bridge subscription while the sender continued writing to the refused workflow.

## Changes

- Gate every send and resend on the bridge's current subscribed workflow.
- Add a production-path regression proving the result-timeout resend does not reach `DocFrameClient` after refusal.

Source: [#16509](https://github.com/Comfy-Org/ComfyUI_frontend/pull/16509)

Addresses: [review thread](https://github.com/Comfy-Org/ComfyUI_frontend/pull/16509#discussion_r3907722143)

## Evidence

- `pnpm vitest run src/workbench/extensions/agent/crdt/useAgentCrdtFollower.test.ts` — 19 passed
- `pnpm typecheck` — passed
- `pnpm exec eslint src/workbench/extensions/agent/crdt/useAgentCrdtFollower.ts src/workbench/extensions/agent/crdt/useAgentCrdtFollower.test.ts` — passed
- `pnpm exec oxfmt --check src/workbench/extensions/agent/crdt/useAgentCrdtFollower.ts src/workbench/extensions/agent/crdt/useAgentCrdtFollower.test.ts` — passed
- Commit hooks: oxfmt, oxlint, ESLint, typecheck — passed
- Push hook: Knip — passed

</details>

<!-- authored-by:agent lane-act-fe-16509-followup-1a14738c -->
