### PR TITLE
Add ordered agent request-response fixtures

### DIFF
--- a/browser_tests/fixtures/agentRequestResponseFixture.test.ts
+++ b/browser_tests/fixtures/agentRequestResponseFixture.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from 'vitest'
+
+import { AgentRequestResponseQueue } from '@e2e/fixtures/agentRequestResponseFixture'
+import type { AgentRequestResponseScenario } from '@e2e/fixtures/data/agentRequestResponse'
+
+const scenarios = [
+  {
+    request: { content: 'Set the seed, then explain what changed.' },
+    responses: [
+      {
+        kind: 'agent_event',
+        event: {
+          type: 'agent_message_delta',
+          data: {
+            delta: 'I will update the graph first.',
+            message_id: 'message-1',
+            thread_id: 'thread-1'
+          }
+        }
+      },
+      {
+        kind: 'graph_operations',
+        operations: [
+          {
+            op: 'set_widget',
+            node_id: '7',
+            widget: 'seed',
+            value: 42,
+            old: 3
+          },
+          {
+            op: 'set_widget',
+            node_id: '7',
+            widget: 'steps',
+            value: 20,
+            old: 12
+          }
+        ]
+      },
+      {
+        kind: 'agent_event',
+        event: {
+          type: 'agent_message_done',
+          data: {
+            message_id: 'message-1',
+            thread_id: 'thread-1'
+          }
+        }
+      }
+    ]
+  },
+  {
+    request: {
+      content: 'Change the prompt.',
+      workflowId: 'workflow-1',
+      selection: { node_ids: ['7'] }
+    },
+    responses: []
+  }
+] as const satisfies readonly AgentRequestResponseScenario[]
+
+describe('AgentRequestResponseQueue', () => {
+  it('consumes requests and interleaved responses in declaration order', () => {
+    const queue = new AgentRequestResponseQueue(scenarios)
+
+    const responses = queue.take({
+      content: 'Set the seed, then explain what changed.'
+    })
+
+    expect(responses).toBe(scenarios[0].responses)
+    expect(responses.map((response) => response.kind)).toEqual([
+      'agent_event',
+      'graph_operations',
+      'agent_event'
+    ])
+    expect(responses[1]).toEqual({
+      kind: 'graph_operations',
+      operations: [
+        {
+          op: 'set_widget',
+          node_id: '7',
+          widget: 'seed',
+          value: 42,
+          old: 3
+        },
+        {
+          op: 'set_widget',
+          node_id: '7',
+          widget: 'steps',
+          value: 20,
+          old: 12
+        }
+      ]
+    })
+
+    expect(
+      queue.take({
+        content: 'Change the prompt.',
+        workflowId: 'workflow-1',
+        selection: { node_ids: ['7'] }
+      })
+    ).toBe(scenarios[1].responses)
+    expect(() => queue.assertComplete()).not.toThrow()
+  })
+
+  it('rejects an out-of-order request without consuming its scenario', () => {
+    const queue = new AgentRequestResponseQueue(scenarios)
+
+    expect(() => queue.take(scenarios[1].request)).toThrow(
+      'Agent request 1 did not match the declared scenario'
+    )
+    expect(queue.take(scenarios[0].request)).toBe(scenarios[0].responses)
+  })
+
+  it('rejects extra requests and reports unconsumed scenarios', () => {
+    const queue = new AgentRequestResponseQueue(scenarios)
+
+    expect(() => queue.assertComplete()).toThrow(
+      'Agent request queue has 2 unconsumed scenarios'
+    )
+    queue.take(scenarios[0].request)
+    queue.take(scenarios[1].request)
+    expect(() => queue.take({ content: 'Unexpected request' })).toThrow(
+      'Unexpected agent request 3: no scenarios remain'
+    )
+  })
+})

--- a/browser_tests/fixtures/agentRequestResponseFixture.ts
+++ b/browser_tests/fixtures/agentRequestResponseFixture.ts
@@ -1,0 +1,47 @@
+import { deepStrictEqual } from 'node:assert/strict'
+
+import type { PostMessageInput } from '@/workbench/extensions/agent/services/agent/agentRestClient'
+
+import type {
+  AgentRequestResponseScenario,
+  AgentResponseStep
+} from '@e2e/fixtures/data/agentRequestResponse'
+
+export class AgentRequestResponseQueue {
+  private nextScenarioIndex = 0
+
+  constructor(
+    private readonly scenarios: readonly AgentRequestResponseScenario[]
+  ) {}
+
+  take(request: PostMessageInput): readonly AgentResponseStep[] {
+    const scenario = this.scenarios[this.nextScenarioIndex]
+    const requestNumber = this.nextScenarioIndex + 1
+    if (!scenario) {
+      throw new Error(
+        `Unexpected agent request ${requestNumber}: no scenarios remain`
+      )
+    }
+
+    try {
+      deepStrictEqual(request, scenario.request)
+    } catch (cause) {
+      throw new Error(
+        `Agent request ${requestNumber} did not match the declared scenario`,
+        { cause }
+      )
+    }
+
+    this.nextScenarioIndex++
+    return scenario.responses
+  }
+
+  assertComplete(): void {
+    const remaining = this.scenarios.length - this.nextScenarioIndex
+    if (remaining > 0) {
+      throw new Error(
+        `Agent request queue has ${remaining} unconsumed scenarios`
+      )
+    }
+  }
+}

--- a/browser_tests/fixtures/data/agentRequestResponse.ts
+++ b/browser_tests/fixtures/data/agentRequestResponse.ts
@@ -1,0 +1,18 @@
+import type { GraphOperation } from '@/workbench/extensions/agent/crdt/graphOperations'
+import type { AgentWsEvent } from '@/workbench/extensions/agent/schemas/agentApiSchema'
+import type { PostMessageInput } from '@/workbench/extensions/agent/services/agent/agentRestClient'
+
+export type AgentResponseStep =
+  | {
+      kind: 'agent_event'
+      event: AgentWsEvent
+    }
+  | {
+      kind: 'graph_operations'
+      operations: readonly GraphOperation[]
+    }
+
+export interface AgentRequestResponseScenario {
+  request: PostMessageInput
+  responses: readonly AgentResponseStep[]
+}


### PR DESCRIPTION
## Summary

- add a typed prompt request/response scenario contract for browser tests
- keep agent protocol events and graph operation batches in one ordered response stream
- fail fast on out-of-order, extra, or unconsumed prompt requests

## Test plan

- `pnpm vitest run browser_tests/fixtures/agentRequestResponseFixture.test.ts`
- `pnpm typecheck:browser`
- focused oxfmt, oxlint, and ESLint checks
- pre-push knip check

Linear: [BE-11470](https://linear.app/comfyorg/issue/BE-11470/build-agent-integration-test-harness-and-fixtures)