### PR TITLE
feat(agent): add local integration development environment

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,6 +115,13 @@ python main.py --comfy-api-base https://stagingapi.comfy.org --verbose
 
 Then run `pnpm dev` as usual. This keeps the frontend in local mode but routes backend API calls through staging.
 
+#### Local Agent Integration
+
+To develop the frontend, the in-workspace multi-player package, and the local agent
+backend together with HMR, use the
+[local agent integration environment](docs/testing/agent-integration-development.md).
+It includes the Playwright entrypoint and teardown procedure.
+
 #### Access dev server on touch devices
 
 Enable remote access to the dev server by setting `VITE_REMOTE_DEV` in `.env` to `true`.

--- a/docs/testing/agent-integration-development.md
+++ b/docs/testing/agent-integration-development.md
@@ -1,0 +1,78 @@
+# Local agent integration development
+
+Use this environment when changing the frontend, the in-workspace
+`@comfyorg/comfy-multi-player` package, and the standalone agent backend together.
+One foreground command starts the agent under Air and the frontend under Vite. Both
+reload when their source changes, and stopping the command tears down both processes
+and deletes the temporary agent database.
+
+```diagram
+┌──────────────────────────────┐
+│ pnpm tsx dev-agent…          │
+└───────────┬──────────────────┘
+            ├──▶ Vite :6207 ─────▶ frontend + workspace package HMR
+            │       │
+            │       ├── /api, /ws ─────▶ ComfyUI :8188
+            │       └── /api/agent ────▶ standalone agent :6286
+            │
+            └──▶ Air ── rebuild/restart ──▶ Comfy-Org/cloud/services/agent
+```
+
+## Setup
+
+1. Use Node 25 and install this repository with `pnpm install`.
+2. Check out `Comfy-Org/cloud` next to this repository, or pass its location with
+   `--cloud-repo`.
+3. Install the agent's file watcher:
+
+   ```bash
+   go install github.com/air-verse/air@v1.67.4
+   ```
+
+4. Start a local ComfyUI backend at `http://127.0.0.1:8188`.
+5. Export `ANTHROPIC_API_KEY`. `ANTHROPIC_BASE_URL` may be used instead for a local
+   compatible model endpoint.
+
+The root dependency on `@comfyorg/comfy-multi-player` must use `workspace:`. The
+launcher refuses an npm pin or `pnpm link`, because either one would bypass the source
+tree whose HMR behavior this environment exists to exercise.
+
+## Run and stop
+
+From the frontend checkout:
+
+```bash
+pnpm tsx scripts/dev-agent-integration.ts --cloud-repo ../cloud
+```
+
+The command prints the frontend URL after the standalone agent is healthy. Press
+Ctrl-C once to stop Vite and Air and remove the temporary SQLite data directory. Run
+`pnpm tsx scripts/dev-agent-integration.ts --help` to override the frontend, agent,
+ComfyUI, Cloud checkout, or Air paths.
+
+The Vite proxy keeps the standalone session token server-side. Browser REST and event
+WebSocket traffic use same-origin `/api/agent` routes, while all other `/api` and `/ws`
+traffic continues to reach ComfyUI.
+
+## Playwright entrypoint
+
+Leave the environment running, then use a second terminal:
+
+```bash
+PLAYWRIGHT_LOCAL=1 \
+PLAYWRIGHT_TEST_URL=http://127.0.0.1:6207 \
+pnpm exec playwright test browser_tests/tests/agent
+```
+
+Pass a narrower spec or `--headed` after the directory as needed. Playwright traces,
+screenshots, and videos follow the repository's normal `browser_tests` configuration.
+
+## Glossary
+
+- **Air:** the Go file watcher that rebuilds and restarts the local agent.
+- **HMR:** hot module replacement; Vite updates frontend and workspace-package modules
+  without a full development-server restart.
+- **Standalone agent:** the Cloud repository's laptop mode, backed by local SQLite and
+  an in-process event bus rather than Postgres, Redis, ingest, or Temporal.
+- **Vite proxy:** the development-only same-origin bridge that forwards agent requests
+  and injects the standalone session credential outside browser code.

--- a/scripts/dev-agent-integration.ts
+++ b/scripts/dev-agent-integration.ts
@@ -13,6 +13,7 @@ interface Options {
   cloudRepo: string
   comfyUrl: string
   frontendPort: number
+  healthPort: number
   help: boolean
 }
 
@@ -49,6 +50,7 @@ function parseOptions(args: string[]): Options {
     cloudRepo: resolve(PROJECT_ROOT, '../cloud'),
     comfyUrl: 'http://127.0.0.1:8188',
     frontendPort: 6207,
+    healthPort: 0,
     help: false
   }
   for (let index = 0; index < args.length; index++) {
@@ -83,6 +85,17 @@ function parseOptions(args: string[]): Options {
   }
   if (options.agentPort === options.frontendPort) {
     throw new Error('Agent and frontend ports must be different')
+  }
+  options.healthPort = options.agentPort + 1
+  if (options.healthPort > 65535) {
+    throw new Error(
+      '--agent-port must leave room for the agent health port (agent port + 1)'
+    )
+  }
+  if (options.healthPort === options.frontendPort) {
+    throw new Error(
+      `Agent health port ${options.healthPort} (agent port + 1) collides with the frontend port`
+    )
   }
   return options
 }
@@ -189,7 +202,7 @@ function standaloneEnv(options: Options, dataDir: string, token: string) {
     AGENT_SESSION_TOKEN: token,
     AGENT_STANDALONE: 'true',
     AGENT_TARGET: 'local',
-    HEALTH_PORT: String(options.agentPort + 1),
+    HEALTH_PORT: String(options.healthPort),
     PORT: String(options.agentPort)
   }
 }

--- a/scripts/dev-agent-integration.ts
+++ b/scripts/dev-agent-integration.ts
@@ -1,6 +1,7 @@
 import { spawn } from 'node:child_process'
 import type { ChildProcess } from 'node:child_process'
 import { randomBytes } from 'node:crypto'
+import { constants } from 'node:fs'
 import { access, mkdtemp, readFile, rm } from 'node:fs/promises'
 import { homedir, tmpdir } from 'node:os'
 import { dirname, resolve } from 'node:path'
@@ -195,7 +196,7 @@ function standaloneEnv(options: Options, dataDir: string, token: string) {
 
 async function run(options: Options): Promise<number> {
   await assertWorkspacePackage()
-  await access(options.airBin)
+  await access(options.airBin, constants.X_OK)
   const agentDir = resolve(options.cloudRepo, 'services/agent')
   await access(resolve(agentDir, '.air.toml'))
   await assertReachable(`${options.comfyUrl.replace(/\/$/, '')}/system_stats`)
@@ -229,6 +230,7 @@ async function run(options: Options): Promise<number> {
   process.once('SIGINT', onSigint)
   process.once('SIGTERM', onSigterm)
   agent.once('exit', (code) => requestExit(code ?? 1))
+  agent.once('error', () => requestExit(1))
 
   async function stop(exitCode: number): Promise<number> {
     if (stopping) return exitCode
@@ -285,6 +287,7 @@ async function run(options: Options): Promise<number> {
       }
     )
     frontend.once('exit', (code) => requestExit(code ?? 1))
+    frontend.once('error', () => requestExit(1))
     process.stdout.write(
       `\nAgent integration environment ready: ${frontendUrl}\n` +
         `Playwright: PLAYWRIGHT_LOCAL=1 PLAYWRIGHT_TEST_URL=${frontendUrl} pnpm exec playwright test browser_tests/tests/agent\n` +

--- a/scripts/dev-agent-integration.ts
+++ b/scripts/dev-agent-integration.ts
@@ -1,0 +1,316 @@
+import { spawn } from 'node:child_process'
+import type { ChildProcess } from 'node:child_process'
+import { randomBytes } from 'node:crypto'
+import { access, mkdtemp, readFile, rm } from 'node:fs/promises'
+import { homedir, tmpdir } from 'node:os'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+interface Options {
+  agentPort: number
+  airBin: string
+  cloudRepo: string
+  comfyUrl: string
+  frontendPort: number
+  help: boolean
+}
+
+const PROJECT_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const USAGE = `Usage: pnpm tsx scripts/dev-agent-integration.ts [options]
+
+Options:
+  --cloud-repo PATH     Comfy-Org/cloud checkout (default: ../cloud)
+  --comfy-url URL       Local ComfyUI URL (default: http://127.0.0.1:8188)
+  --frontend-port PORT  Vite port (default: 6207)
+  --agent-port PORT     Standalone agent port (default: 6286)
+  --air-bin PATH        Air executable (default: $AIR_BIN or ~/go/bin/air)
+  --help                Show this help
+`
+
+function optionValue(args: string[], index: number, option: string): string {
+  const value = args[index + 1]
+  if (value === undefined) throw new Error(`${option} requires a value`)
+  return value
+}
+
+function port(value: string, option: string): number {
+  const parsed = Number(value)
+  if (!Number.isInteger(parsed) || parsed < 1 || parsed > 65535) {
+    throw new Error(`${option} must be an integer from 1 to 65535`)
+  }
+  return parsed
+}
+
+function parseOptions(args: string[]): Options {
+  const options: Options = {
+    agentPort: 6286,
+    airBin: process.env.AIR_BIN ?? resolve(homedir(), 'go/bin/air'),
+    cloudRepo: resolve(PROJECT_ROOT, '../cloud'),
+    comfyUrl: 'http://127.0.0.1:8188',
+    frontendPort: 6207,
+    help: false
+  }
+  for (let index = 0; index < args.length; index++) {
+    const arg = args[index]
+    switch (arg) {
+      case '--agent-port':
+        options.agentPort = port(optionValue(args, index, arg), arg)
+        index++
+        break
+      case '--air-bin':
+        options.airBin = resolve(optionValue(args, index, arg))
+        index++
+        break
+      case '--cloud-repo':
+        options.cloudRepo = resolve(optionValue(args, index, arg))
+        index++
+        break
+      case '--comfy-url':
+        options.comfyUrl = optionValue(args, index, arg)
+        index++
+        break
+      case '--frontend-port':
+        options.frontendPort = port(optionValue(args, index, arg), arg)
+        index++
+        break
+      case '--help':
+        options.help = true
+        break
+      default:
+        throw new Error(`Unknown option: ${arg}`)
+    }
+  }
+  if (options.agentPort === options.frontendPort) {
+    throw new Error('Agent and frontend ports must be different')
+  }
+  return options
+}
+
+async function assertWorkspacePackage(): Promise<void> {
+  const manifest = JSON.parse(
+    await readFile(resolve(PROJECT_ROOT, 'package.json'), 'utf8')
+  ) as { dependencies?: Record<string, string> }
+  const dependency = manifest.dependencies?.['@comfyorg/comfy-multi-player']
+  if (!dependency?.startsWith('workspace:')) {
+    throw new Error(
+      '@comfyorg/comfy-multi-player must be an in-workspace dependency; do not use pnpm link'
+    )
+  }
+}
+
+async function assertReachable(url: string): Promise<void> {
+  const response = await fetch(url, { signal: AbortSignal.timeout(5000) })
+  if (!response.ok) throw new Error(`${url} returned HTTP ${response.status}`)
+}
+
+function spawnGroup(
+  command: string,
+  args: string[],
+  cwd: string,
+  env: NodeJS.ProcessEnv
+): ChildProcess {
+  return spawn(command, args, {
+    cwd,
+    detached: process.platform !== 'win32',
+    env,
+    stdio: 'inherit'
+  })
+}
+
+function hasExited(child: ChildProcess): boolean {
+  return child.exitCode !== null || child.signalCode !== null
+}
+
+function stopGroup(child: ChildProcess, signal: NodeJS.Signals): void {
+  if (child.pid === undefined || hasExited(child)) return
+  try {
+    if (process.platform === 'win32') child.kill(signal)
+    else process.kill(-child.pid, signal)
+  } catch {
+    child.kill(signal)
+  }
+}
+
+function wait(ms: number): Promise<void> {
+  return new Promise((resolveWait) => setTimeout(resolveWait, ms))
+}
+
+async function waitForExit(
+  child: ChildProcess,
+  timeoutMs: number
+): Promise<void> {
+  if (hasExited(child)) return
+  await Promise.race([
+    new Promise<void>((resolveExit) => child.once('exit', () => resolveExit())),
+    wait(timeoutMs)
+  ])
+}
+
+async function waitForAgent(
+  child: ChildProcess,
+  url: string,
+  stopped: () => boolean
+): Promise<void> {
+  const deadline = Date.now() + 120_000
+  while (Date.now() < deadline && !stopped()) {
+    if (hasExited(child)) {
+      throw new Error(`Standalone agent exited with code ${child.exitCode}`)
+    }
+    try {
+      await assertReachable(`${url}/health`)
+      return
+    } catch {
+      await wait(500)
+    }
+  }
+  if (stopped()) return
+  throw new Error(`Standalone agent did not become ready at ${url}/health`)
+}
+
+function standaloneEnv(options: Options, dataDir: string, token: string) {
+  const env = { ...process.env }
+  for (const key of [
+    'AGENT_M2M_SECRET',
+    'AGENT_RUNNER_ENDPOINT',
+    'DB_CONNECTION_STRING',
+    'DOC_HOST_ENDPOINT',
+    'REDIS_URL'
+  ]) {
+    delete env[key]
+  }
+  return {
+    ...env,
+    AGENT_BIND_ADDR: '127.0.0.1',
+    AGENT_COMFY_URL: options.comfyUrl,
+    AGENT_CRDT_MODE: 'off',
+    AGENT_DATA_DIR: dataDir,
+    AGENT_ENGINE: 'inline',
+    AGENT_SESSION_TOKEN: token,
+    AGENT_STANDALONE: 'true',
+    AGENT_TARGET: 'local',
+    HEALTH_PORT: String(options.agentPort + 1),
+    PORT: String(options.agentPort)
+  }
+}
+
+async function run(options: Options): Promise<number> {
+  await assertWorkspacePackage()
+  await access(options.airBin)
+  const agentDir = resolve(options.cloudRepo, 'services/agent')
+  await access(resolve(agentDir, '.air.toml'))
+  await assertReachable(`${options.comfyUrl.replace(/\/$/, '')}/system_stats`)
+  if (!process.env.ANTHROPIC_API_KEY && !process.env.ANTHROPIC_BASE_URL) {
+    throw new Error('Set ANTHROPIC_API_KEY or ANTHROPIC_BASE_URL')
+  }
+
+  const dataDir = await mkdtemp(resolve(tmpdir(), 'comfy-agent-integration-'))
+  const token = randomBytes(32).toString('hex')
+  const agentUrl = `http://127.0.0.1:${options.agentPort}`
+  const agent = spawnGroup(
+    options.airBin,
+    ['-c', '.air.toml'],
+    agentDir,
+    standaloneEnv(options, dataDir, token)
+  )
+  let frontend: ChildProcess | null = null
+  let stopping = false
+  let requestedExitCode: number | null = null
+  let resolveExitRequest: (code: number) => void = () => {}
+  const exitRequested = new Promise<number>((resolveExit) => {
+    resolveExitRequest = resolveExit
+  })
+  const requestExit = (code: number) => {
+    if (requestedExitCode !== null) return
+    requestedExitCode = code
+    resolveExitRequest(code)
+  }
+  const onSigint = () => requestExit(130)
+  const onSigterm = () => requestExit(143)
+  process.once('SIGINT', onSigint)
+  process.once('SIGTERM', onSigterm)
+  agent.once('exit', (code) => requestExit(code ?? 1))
+
+  async function stop(exitCode: number): Promise<number> {
+    if (stopping) return exitCode
+    stopping = true
+    if (frontend) stopGroup(frontend, 'SIGTERM')
+    stopGroup(agent, 'SIGTERM')
+    await Promise.all(
+      [agent, frontend]
+        .filter((child): child is ChildProcess => child !== null)
+        .map((child) => waitForExit(child, 2000))
+    )
+    if (frontend && !hasExited(frontend)) stopGroup(frontend, 'SIGKILL')
+    if (!hasExited(agent)) stopGroup(agent, 'SIGKILL')
+    await Promise.all(
+      [agent, frontend]
+        .filter((child): child is ChildProcess => child !== null)
+        .map((child) => waitForExit(child, 1000))
+    )
+    await rm(dataDir, { force: true, recursive: true })
+    process.removeListener('SIGINT', onSigint)
+    process.removeListener('SIGTERM', onSigterm)
+    return exitCode
+  }
+
+  try {
+    const startupResult = await Promise.race([
+      waitForAgent(agent, agentUrl, () => requestedExitCode !== null).then(
+        () => null
+      ),
+      exitRequested
+    ])
+    if (startupResult !== null) return await stop(startupResult)
+    const frontendUrl = `http://127.0.0.1:${options.frontendPort}`
+    frontend = spawnGroup(
+      'pnpm',
+      [
+        'exec',
+        'vite',
+        '--config',
+        'vite.config.mts',
+        '--host',
+        '127.0.0.1',
+        '--port',
+        String(options.frontendPort),
+        '--strictPort'
+      ],
+      PROJECT_ROOT,
+      {
+        ...process.env,
+        DEV_AGENT_SESSION_TOKEN: token,
+        DEV_AGENT_URL: agentUrl,
+        DEV_SERVER_COMFYUI_URL: options.comfyUrl,
+        VITE_AGENT_STANDALONE: 'true'
+      }
+    )
+    frontend.once('exit', (code) => requestExit(code ?? 1))
+    process.stdout.write(
+      `\nAgent integration environment ready: ${frontendUrl}\n` +
+        `Playwright: PLAYWRIGHT_LOCAL=1 PLAYWRIGHT_TEST_URL=${frontendUrl} pnpm exec playwright test browser_tests/tests/agent\n` +
+        'Press Ctrl-C to stop the frontend and standalone agent.\n\n'
+    )
+
+    const exitCode = await exitRequested
+    return await stop(exitCode)
+  } catch (error) {
+    await stop(1)
+    throw error
+  }
+}
+
+async function main(): Promise<void> {
+  try {
+    const options = parseOptions(process.argv.slice(2))
+    if (options.help) {
+      process.stdout.write(USAGE)
+      return
+    }
+    process.exitCode = await run(options)
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : error)
+    process.exitCode = 1
+  }
+}
+
+void main()

--- a/src/workbench/extensions/agent/AgentPanelRoot.vue
+++ b/src/workbench/extensions/agent/AgentPanelRoot.vue
@@ -80,6 +80,7 @@ import { useAgentWorkflowTabBindingStore } from './stores/agent/agentWorkflowTab
 import { createAgentRestClient } from './services/agent/agentRestClient'
 import type { OpenTabsSnapshot } from './services/agent/agentRestClient'
 import { createAgentEventSource } from './services/agent/agentEventSource'
+import { createStandaloneAgentEventSource } from './services/agent/standaloneAgentEventSource'
 import { useAgentChatHistoryStore } from './stores/agent/agentChatHistoryStore'
 import { useAgentPanelStore } from './stores/agent/agentPanelStore'
 import CrdtDevPanel from './crdt/CrdtDevPanel.vue'
@@ -98,7 +99,10 @@ const userName = computed(
 
 const rest = createAgentRestClient()
 
-const events = createAgentEventSource(api)
+const events =
+  import.meta.env.VITE_AGENT_STANDALONE === 'true'
+    ? createStandaloneAgentEventSource()
+    : createAgentEventSource(api)
 
 const workflowStore = useWorkflowStore()
 const workflowService = useWorkflowService()

--- a/src/workbench/extensions/agent/services/agent/standaloneAgentEventSource.test.ts
+++ b/src/workbench/extensions/agent/services/agent/standaloneAgentEventSource.test.ts
@@ -22,6 +22,10 @@ class FakeSocket extends EventTarget {
     )
   }
 
+  error(): void {
+    this.dispatchEvent(new Event('error'))
+  }
+
   close(): void {
     if (this.readyState === WebSocket.CLOSED) return
     this.readyState = WebSocket.CLOSED
@@ -73,6 +77,66 @@ describe('createStandaloneAgentEventSource', () => {
 
     expect(status).toHaveBeenLastCalledWith(false)
     expect(sockets).toHaveLength(2)
+  })
+
+  it('reconnects exactly once when the upgrade fails before open', () => {
+    vi.useFakeTimers()
+    const { source, sockets } = sourceHarness()
+    const status = vi.fn()
+
+    source.subscribe(vi.fn())
+    source.onStatus?.(status)
+    sockets[0].error()
+    vi.advanceTimersByTime(999)
+
+    expect(sockets[0].readyState).toBe(WebSocket.CLOSED)
+    expect(status).toHaveBeenCalledTimes(1)
+    expect(status).toHaveBeenLastCalledWith(false)
+    expect(sockets).toHaveLength(1)
+
+    vi.advanceTimersByTime(1)
+    expect(sockets).toHaveLength(2)
+
+    vi.advanceTimersByTime(5000)
+    expect(sockets).toHaveLength(2)
+  })
+
+  it('reports live again once the replacement socket opens', () => {
+    vi.useFakeTimers()
+    const { source, sockets } = sourceHarness()
+    const status = vi.fn()
+
+    source.subscribe(vi.fn())
+    source.onStatus?.(status)
+    sockets[0].open()
+    sockets[0].close()
+    vi.advanceTimersByTime(1000)
+    sockets[1].open()
+
+    expect(status.mock.calls.map(([live]) => live)).toEqual([true, false, true])
+  })
+
+  it('drops frames from a superseded socket after resubscribing', () => {
+    vi.useFakeTimers()
+    const { source, sockets } = sourceHarness()
+    const first = vi.fn()
+    const second = vi.fn()
+
+    const unsubscribe = source.subscribe(first)
+    sockets[0].open()
+    unsubscribe()
+    source.subscribe(second)
+    sockets[1].open()
+    sockets[0].receive({ type: 'agent_message_delta', data: { delta: 'old' } })
+    sockets[1].receive({ type: 'agent_message_delta', data: { delta: 'new' } })
+
+    expect(sockets).toHaveLength(2)
+    expect(first).not.toHaveBeenCalled()
+    expect(second).toHaveBeenCalledTimes(1)
+    expect(second).toHaveBeenCalledWith({
+      type: 'agent_message_delta',
+      data: { delta: 'new' }
+    })
   })
 
   it('stops the socket and pending reconnect on unsubscribe', () => {

--- a/src/workbench/extensions/agent/services/agent/standaloneAgentEventSource.test.ts
+++ b/src/workbench/extensions/agent/services/agent/standaloneAgentEventSource.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { createStandaloneAgentEventSource } from './standaloneAgentEventSource'
+
+class FakeSocket extends EventTarget {
+  readyState: number = WebSocket.CONNECTING
+  readonly url: string
+
+  constructor(url: string) {
+    super()
+    this.url = url
+  }
+
+  open(): void {
+    this.readyState = WebSocket.OPEN
+    this.dispatchEvent(new Event('open'))
+  }
+
+  receive(frame: unknown): void {
+    this.dispatchEvent(
+      new MessageEvent('message', { data: JSON.stringify(frame) })
+    )
+  }
+
+  close(): void {
+    if (this.readyState === WebSocket.CLOSED) return
+    this.readyState = WebSocket.CLOSED
+    this.dispatchEvent(new Event('close'))
+  }
+}
+
+function sourceHarness() {
+  const sockets: FakeSocket[] = []
+  const source = createStandaloneAgentEventSource({
+    createSocket(url) {
+      const socket = new FakeSocket(url)
+      sockets.push(socket)
+      return socket as unknown as WebSocket
+    }
+  })
+  return { source, sockets }
+}
+
+describe('createStandaloneAgentEventSource', () => {
+  it('connects through the same-origin agent proxy and delivers JSON frames', () => {
+    const { source, sockets } = sourceHarness()
+    const seen = vi.fn()
+    const status = vi.fn()
+
+    source.subscribe(seen)
+    source.onStatus?.(status)
+    sockets[0].open()
+    sockets[0].receive({ type: 'agent_message_delta', data: { delta: 'hi' } })
+
+    expect(new URL(sockets[0].url).pathname).toBe('/api/agent/events')
+    expect(status).toHaveBeenCalledWith(true)
+    expect(seen).toHaveBeenCalledWith({
+      type: 'agent_message_delta',
+      data: { delta: 'hi' }
+    })
+  })
+
+  it('reconnects after a backend reload', () => {
+    vi.useFakeTimers()
+    const { source, sockets } = sourceHarness()
+    const status = vi.fn()
+
+    source.subscribe(vi.fn())
+    source.onStatus?.(status)
+    sockets[0].open()
+    sockets[0].close()
+    vi.advanceTimersByTime(1000)
+
+    expect(status).toHaveBeenLastCalledWith(false)
+    expect(sockets).toHaveLength(2)
+  })
+
+  it('stops the socket and pending reconnect on unsubscribe', () => {
+    vi.useFakeTimers()
+    const { source, sockets } = sourceHarness()
+
+    const unsubscribe = source.subscribe(vi.fn())
+    sockets[0].open()
+    sockets[0].close()
+    unsubscribe()
+    vi.advanceTimersByTime(1000)
+
+    expect(sockets).toHaveLength(1)
+  })
+})

--- a/src/workbench/extensions/agent/services/agent/standaloneAgentEventSource.ts
+++ b/src/workbench/extensions/agent/services/agent/standaloneAgentEventSource.ts
@@ -1,0 +1,92 @@
+import type { AgentEventSource } from '../../composables/agent/useAgentSession'
+
+interface StandaloneAgentEventSourceOptions {
+  createSocket?: (url: string) => WebSocket
+  endpoint?: string
+  reconnectDelayMs?: number
+}
+
+export function createStandaloneAgentEventSource({
+  createSocket = (url) => new WebSocket(url),
+  endpoint = '/api/agent/events',
+  reconnectDelayMs = 1000
+}: StandaloneAgentEventSourceOptions = {}): AgentEventSource {
+  const listeners = new Set<(raw: unknown) => void>()
+  const statusListeners = new Set<(live: boolean) => void>()
+  let socket: WebSocket | null = null
+  let reconnectTimer: number | null = null
+
+  function eventUrl(): string {
+    const url = new URL(endpoint, window.location.href)
+    url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:'
+    return url.toString()
+  }
+
+  function notifyStatus(live: boolean): void {
+    statusListeners.forEach((listener) => listener(live))
+  }
+
+  function scheduleReconnect(): void {
+    if (listeners.size === 0 || reconnectTimer !== null) return
+    reconnectTimer = window.setTimeout(() => {
+      reconnectTimer = null
+      connect()
+    }, reconnectDelayMs)
+  }
+
+  function connect(): void {
+    if (listeners.size === 0 || socket !== null) return
+    const current = createSocket(eventUrl())
+    socket = current
+    current.addEventListener('open', () => {
+      if (socket === current) notifyStatus(true)
+    })
+    current.addEventListener('message', (event) => {
+      if (socket !== current) return
+      let frame: unknown = event.data
+      if (typeof event.data === 'string') {
+        try {
+          frame = JSON.parse(event.data)
+        } catch {
+          frame = event.data
+        }
+      }
+      listeners.forEach((listener) => listener(frame))
+    })
+    current.addEventListener('error', () => {
+      if (socket === current) current.close()
+    })
+    current.addEventListener('close', () => {
+      if (socket !== current) return
+      socket = null
+      notifyStatus(false)
+      scheduleReconnect()
+    })
+  }
+
+  function disconnect(): void {
+    if (reconnectTimer !== null) {
+      window.clearTimeout(reconnectTimer)
+      reconnectTimer = null
+    }
+    const current = socket
+    socket = null
+    current?.close()
+  }
+
+  return {
+    subscribe(listener) {
+      listeners.add(listener)
+      connect()
+      return () => {
+        listeners.delete(listener)
+        if (listeners.size === 0) disconnect()
+      }
+    },
+    onStatus(listener) {
+      statusListeners.add(listener)
+      if (socket?.readyState === WebSocket.OPEN) listener(true)
+      return () => statusListeners.delete(listener)
+    }
+  }
+}

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -202,6 +202,14 @@ const DEV_SEVER_FALLBACK_URL =
 
 const DEV_SERVER_COMFYUI_URL =
   DEV_SERVER_COMFYUI_ENV_URL || DEV_SEVER_FALLBACK_URL
+const DEV_AGENT_URL = process.env.DEV_AGENT_URL
+const DEV_AGENT_SESSION_TOKEN = process.env.DEV_AGENT_SESSION_TOKEN
+
+if (Boolean(DEV_AGENT_URL) !== Boolean(DEV_AGENT_SESSION_TOKEN)) {
+  throw new Error(
+    'DEV_AGENT_URL and DEV_AGENT_SESSION_TOKEN must be configured together.'
+  )
+}
 
 const cloudProxyConfig =
   DISTRIBUTION === 'cloud' ? { secure: false, changeOrigin: true } : {}
@@ -321,6 +329,19 @@ export default defineConfig({
         ? {
             '/api/view': gcsRedirectProxyConfig,
             '/api/viewvideo': gcsRedirectProxyConfig
+          }
+        : {}),
+
+      ...(DEV_AGENT_URL && DEV_AGENT_SESSION_TOKEN
+        ? {
+            '/api/agent': {
+              target: DEV_AGENT_URL,
+              ws: true,
+              headers: {
+                Authorization: `Bearer ${DEV_AGENT_SESSION_TOKEN}`
+              },
+              rewrite: (path: string) => path.replace(/^\/api/, '')
+            }
           }
         : {}),
 

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -211,6 +211,12 @@ if (Boolean(DEV_AGENT_URL) !== Boolean(DEV_AGENT_SESSION_TOKEN)) {
   )
 }
 
+if (process.env.VITE_AGENT_STANDALONE === 'true' && !DEV_AGENT_URL) {
+  throw new Error(
+    'VITE_AGENT_STANDALONE requires DEV_AGENT_URL and DEV_AGENT_SESSION_TOKEN; start via scripts/dev-agent-integration.ts.'
+  )
+}
+
 const cloudProxyConfig =
   DISTRIBUTION === 'cloud' ? { secure: false, changeOrigin: true } : {}
 


### PR DESCRIPTION
Local integration environment; package dependency enforced.

- One foreground launcher owns setup and teardown.
- Frontend REST/events bridge to standalone Agent.
- Draft until `ecw-106` provides the workspace package boundary.

<details><summary>Full context for agent readers</summary>

## Summary

- add a Node 25 launcher that starts `Comfy-Org/cloud/services/agent` under Air and the frontend under Vite on reserved ports
- keep the standalone session credential in the Vite process, proxy `/api/agent` to `/agent`, and reconnect browser event delivery after Agent reloads
- expose the existing Agent Playwright directory against the local environment and document prerequisites, HMR behavior, and teardown
- fail closed while `@comfyorg/comfy-multi-player` is not an in-workspace dependency; this prevents the old `pnpm link` path from returning

## Dependency

This is intentionally a draft. Program row `ecw-106` is still live-claimed and has not produced its package-move branch or PR. Once that carrier exists, this branch must be rebased onto it and the full launcher startup/HMR/teardown path run with the in-workspace package before readiness.

## Evidence

```text
$ pnpm exec vitest run src/workbench/extensions/agent/services/agent/standaloneAgentEventSource.test.ts src/workbench/extensions/agent/AgentPanelRoot.test.ts
Test Files  2 passed (2)
Tests  115 passed (115)

$ pnpm typecheck:scripts
$ vue-tsc --project scripts/tsconfig.json
exit 0

$ pnpm build
$ vue-tsc --noEmit
✓ built in 25.48s

$ pnpm exec oxfmt --check CONTRIBUTING.md docs/testing/agent-integration-development.md scripts/dev-agent-integration.ts src/workbench/extensions/agent/AgentPanelRoot.vue src/workbench/extensions/agent/services/agent/standaloneAgentEventSource.ts src/workbench/extensions/agent/services/agent/standaloneAgentEventSource.test.ts vite.config.mts
All matched files use the correct format.
Finished in 808ms on 7 files using 8 threads.

$ pnpm exec oxlint --type-aware scripts/dev-agent-integration.ts
Found 0 warnings and 0 errors.
Finished in 1.1s on 1 file with 180 rules using 8 threads.

$ pnpm tsx scripts/dev-agent-integration.ts --help
Usage: pnpm tsx scripts/dev-agent-integration.ts [options]
Options: --cloud-repo, --comfy-url, --frontend-port, --agent-port, --air-bin, --help

$ pnpm tsx scripts/dev-agent-integration.ts --cloud-repo /tmp/ecw107-cloud --air-bin /bin/true
@comfyorg/comfy-multi-player must be an in-workspace dependency; do not use pnpm link
exit 1 (expected until ecw-106 lands)
```

</details>

<!-- authored-by:agent lane-ecw-107 -->
