### PR TITLE
fix(billing): obtain a server quote before the team confirmation step

### DIFF
--- a/browser_tests/tests/dialogs/pricingTableDeepLink.spec.ts
+++ b/browser_tests/tests/dialogs/pricingTableDeepLink.spec.ts
@@ -193,6 +193,60 @@ const TEAM_SUBSCRIBED_RESPONSE = {
   effective_at: '2026-07-21T00:00:00Z'
 } satisfies SubscribeResponse
 
+const TEAM_ANNUAL_PLAN = {
+  slug: 'team_per_credit_annual',
+  tier: 'TEAM',
+  duration: 'ANNUAL',
+  price_cents: 756_000,
+  credits_cents: 1_772_400,
+  max_seats: 100,
+  availability: { available: true },
+  seat_summary: {
+    seat_count: 1,
+    total_cost_cents: 756_000,
+    total_credits_cents: 1_772_400
+  }
+} satisfies Plan
+
+const TEAM_MONTHLY_PLAN = {
+  slug: 'team_per_credit_monthly',
+  tier: 'TEAM',
+  duration: 'MONTHLY',
+  price_cents: 39_000,
+  credits_cents: 84_400,
+  max_seats: 100,
+  availability: { available: true },
+  seat_summary: {
+    seat_count: 1,
+    total_cost_cents: 39_000,
+    total_credits_cents: 84_400
+  }
+} satisfies Plan
+
+const NEW_TEAM_ANNUAL_SUBSCRIPTION = {
+  allowed: true,
+  transition_type: 'new_subscription',
+  effective_at: '2026-07-21T00:00:00Z',
+  is_immediate: true,
+  cost_today_cents: 756_000,
+  cost_next_period_cents: 756_000,
+  credits_today_cents: 1_772_400,
+  credits_next_period_cents: 1_772_400,
+  new_plan: TEAM_ANNUAL_PLAN
+} satisfies PreviewSubscribeResponse
+
+const NEW_TEAM_MONTHLY_SUBSCRIPTION = {
+  allowed: true,
+  transition_type: 'new_subscription',
+  effective_at: '2026-07-21T00:00:00Z',
+  is_immediate: true,
+  cost_today_cents: 39_000,
+  cost_next_period_cents: 39_000,
+  credits_today_cents: 84_400,
+  credits_next_period_cents: 84_400,
+  new_plan: TEAM_MONTHLY_PLAN
+} satisfies PreviewSubscribeResponse
+
 const NEW_CREATOR_SUBSCRIPTION = {
   allowed: true,
   transition_type: 'new_subscription',
@@ -711,6 +765,9 @@ test.describe('Pricing table deep link', { tag: '@cloud' }, () => {
     await page.route('**/api/billing/plans', (route) =>
       route.fulfill(jsonRoute(TEAM_CATALOG_PLANS))
     )
+    await page.route('**/api/billing/preview-subscribe', (route) =>
+      route.fulfill(jsonRoute(NEW_TEAM_ANNUAL_SUBSCRIPTION))
+    )
     await page.route('**/api/billing/subscribe', (route) => {
       subscribeRequests.push(route.request())
       return route.fulfill(jsonRoute(TEAM_SUBSCRIBED_RESPONSE))
@@ -757,6 +814,10 @@ test.describe('Pricing table deep link', { tag: '@cloud' }, () => {
     ])
     await page.route('**/api/billing/plans', (route) =>
       route.fulfill(jsonRoute(TEAM_CATALOG_PLANS))
+    )
+
+    await page.route('**/api/billing/preview-subscribe', (route) =>
+      route.fulfill(jsonRoute(NEW_TEAM_MONTHLY_SUBSCRIPTION))
     )
 
     await page.goto(`${APP_URL}/?pricing=team&stop=team_400&cycle=monthly`)

--- a/src/platform/workspace/components/SubscriptionAddPaymentPreviewWorkspace.test.ts
+++ b/src/platform/workspace/components/SubscriptionAddPaymentPreviewWorkspace.test.ts
@@ -411,6 +411,18 @@ describe('SubscriptionAddPaymentPreviewWorkspace', () => {
     ).toBeNull()
   })
 
+  it('omits the total row entirely when no quote is available to price it', () => {
+    render(SubscriptionAddPaymentPreviewWorkspace, {
+      props: {
+        teamPlan: { usd: 700, credits: 147_700, discountedUsd: 665 },
+        previewData: null
+      },
+      global: globalOptions
+    })
+
+    expect(screen.queryByText('subscription.preview.totalDueToday')).toBeNull()
+  })
+
   it('prices a legacy preview from the server costs instead of rendering a blank total', () => {
     const {
       amount_due_cents,

--- a/src/platform/workspace/components/SubscriptionAddPaymentPreviewWorkspace.vue
+++ b/src/platform/workspace/components/SubscriptionAddPaymentPreviewWorkspace.vue
@@ -101,6 +101,7 @@
 
       <!-- Total Due Section -->
       <div
+        v-if="totalDueToday"
         :class="
           cn(
             'flex flex-col gap-2 border-t border-border-subtle pt-8',

--- a/src/platform/workspace/components/SubscriptionRequiredDialogContentUnified.test.ts
+++ b/src/platform/workspace/components/SubscriptionRequiredDialogContentUnified.test.ts
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { computed, ref } from 'vue'
+import { computed, nextTick, ref } from 'vue'
 import { createI18n } from 'vue-i18n'
 
 import SubscriptionRequiredDialogContentUnified from './SubscriptionRequiredDialogContentUnified.vue'
@@ -114,7 +114,9 @@ function renderComponent(props: Record<string, unknown> = {}) {
             <button data-testid="new-method-btn" @click="$emit('changePaymentMethod')">New method</button>
           </div>`
         },
-        SubscriptionTransitionPreviewWorkspace: { template: '<div />' },
+        SubscriptionTransitionPreviewWorkspace: {
+          template: '<div data-testid="transition-preview" />'
+        },
         SubscriptionSuccessWorkspace: { template: '<div />' }
       }
     }
@@ -248,4 +250,23 @@ describe('SubscriptionRequiredDialogContentUnified team-plan subscribe', () => {
     })
     expect(mockHandleSubscribeClick).not.toHaveBeenCalled()
   })
+
+  it.for(['team-change', 'personal-change'])(
+    'withholds the transition confirm until its preview arrives (%s)',
+    async (previewVariant) => {
+      mockCheckoutStep.value = 'preview'
+      mockPreviewVariant.value = previewVariant
+      mockSelectedTeamStop.value = TEAM_PAYLOAD.stop
+      mockPreviewData.value = null
+
+      renderComponent()
+
+      expect(screen.queryByTestId('transition-preview')).toBeNull()
+
+      mockPreviewData.value = { amount_due_cents: 1600, currency: 'usd' }
+      await nextTick()
+
+      expect(screen.getByTestId('transition-preview')).toBeTruthy()
+    }
+  )
 })

--- a/src/platform/workspace/components/SubscriptionRequiredDialogContentUnified.vue
+++ b/src/platform/workspace/components/SubscriptionRequiredDialogContentUnified.vue
@@ -95,8 +95,8 @@
 
     <template v-if="checkoutStep === 'preview'">
       <SubscriptionTransitionPreviewWorkspace
-        v-if="previewVariant === 'team-change'"
-        :preview-data="previewData!"
+        v-if="previewVariant === 'team-change' && previewData"
+        :preview-data="previewData"
         :team-plan="selectedTeamStop!"
         :is-loading="isLoadingPreview || isSubscribing || isPolling"
         :action-url="activeCheckoutActionUrl"
@@ -173,8 +173,8 @@
       />
 
       <SubscriptionTransitionPreviewWorkspace
-        v-else-if="previewVariant === 'personal-change'"
-        :preview-data="previewData!"
+        v-else-if="previewVariant === 'personal-change' && previewData"
+        :preview-data="previewData"
         :is-loading="isSubscribing || isPolling"
         :action-url="activeCheckoutActionUrl"
         :force-reactivation="reactivationRequired"

--- a/src/platform/workspace/composables/useSubscriptionCheckout.test.ts
+++ b/src/platform/workspace/composables/useSubscriptionCheckout.test.ts
@@ -1357,18 +1357,23 @@ describe('useSubscriptionCheckout', () => {
         expect(mockToastAdd).toHaveBeenCalledOnce()
       })
 
-      it('does not open a change confirmation for a stop the backend cannot quote', async () => {
-        const checkout = await setupLegacyTeam()
+      it.for([false, true])(
+        'reports a stop the backend cannot quote rather than confirming it (isChange: %s)',
+        async (isChange) => {
+          const checkout = await setupLegacyTeam()
 
-        await checkout.handleSubscribeTeamClick({
-          stop: { usd: 1400, credits: 295_400, discountedUsd: 1295 },
-          billingCycle: 'monthly',
-          isChange: true
-        })
+          await checkout.handleSubscribeTeamClick({
+            stop: { usd: 1400, credits: 295_400, discountedUsd: 1295 },
+            billingCycle: 'monthly',
+            isChange
+          })
 
-        expect(mockPreviewSubscribe).not.toHaveBeenCalled()
-        expect(checkout.checkoutStep.value).toBe('pricing')
-      })
+          expect(mockPreviewSubscribe).not.toHaveBeenCalled()
+          expect(checkout.checkoutStep.value).toBe('pricing')
+          expect(checkout.selectedTeamStop.value).toBeNull()
+          expect(mockToastAdd).toHaveBeenCalledOnce()
+        }
+      )
     })
 
     it('transitions to preview with the selected team stop and cycle', async () => {

--- a/src/platform/workspace/composables/useSubscriptionCheckout.test.ts
+++ b/src/platform/workspace/composables/useSubscriptionCheckout.test.ts
@@ -1297,6 +1297,80 @@ describe('useSubscriptionCheckout', () => {
       return { checkout, selection }
     }
 
+    describe('with embedded checkout off', () => {
+      const setupLegacyTeam = () => setup(undefined, 'team', false)
+
+      it('prices a new team subscription from the server preview', async () => {
+        const checkout = await setupLegacyTeam()
+
+        await checkout.handleSubscribeTeamClick({
+          stop: teamStop,
+          billingCycle: 'monthly'
+        })
+
+        expect(mockPreviewSubscribe).toHaveBeenCalledWith(
+          'team_per_credit_monthly',
+          { teamCreditStopId: 'team_1400' }
+        )
+        expect(checkout.previewData.value?.allowed).toBe(true)
+        expect(checkout.checkoutStep.value).toBe('preview')
+      })
+
+      it('holds the pricing table until the preview resolves', async () => {
+        let resolvePreview!: (
+          preview: Partial<PreviewSubscribeResponse>
+        ) => void
+        mockPreviewSubscribe.mockImplementationOnce(
+          () =>
+            new Promise<Partial<PreviewSubscribeResponse>>((resolve) => {
+              resolvePreview = resolve
+            })
+        )
+        const checkout = await setupLegacyTeam()
+
+        const selection = checkout.handleSubscribeTeamClick({
+          stop: teamStop,
+          billingCycle: 'monthly'
+        })
+
+        expect(checkout.checkoutStep.value).toBe('pricing')
+        expect(checkout.previewData.value).toBeNull()
+
+        resolvePreview({ allowed: true, transition_type: 'new_subscription' })
+        await selection
+
+        expect(checkout.checkoutStep.value).toBe('preview')
+        expect(checkout.previewData.value).not.toBeNull()
+      })
+
+      it('reports failure instead of confirming a change it cannot price', async () => {
+        const checkout = await setupLegacyTeam()
+
+        await checkout.handleSubscribeTeamClick({
+          stop: teamStop,
+          billingCycle: 'monthly',
+          isChange: true
+        })
+
+        expect(checkout.checkoutStep.value).toBe('pricing')
+        expect(checkout.previewData.value).toBeNull()
+        expect(mockToastAdd).toHaveBeenCalledOnce()
+      })
+
+      it('does not open a change confirmation for a stop the backend cannot quote', async () => {
+        const checkout = await setupLegacyTeam()
+
+        await checkout.handleSubscribeTeamClick({
+          stop: { usd: 1400, credits: 295_400, discountedUsd: 1295 },
+          billingCycle: 'monthly',
+          isChange: true
+        })
+
+        expect(mockPreviewSubscribe).not.toHaveBeenCalled()
+        expect(checkout.checkoutStep.value).toBe('pricing')
+      })
+    })
+
     it('transitions to preview with the selected team stop and cycle', async () => {
       const checkout = await setup()
 

--- a/src/platform/workspace/composables/useSubscriptionCheckout.ts
+++ b/src/platform/workspace/composables/useSubscriptionCheckout.ts
@@ -353,6 +353,16 @@ export function useSubscriptionCheckout(
     )
   }
 
+  function isUsableTeamPreview(
+    preview: PreviewSubscribeResponse | null | undefined,
+    checkoutType: SubscriptionCheckoutType
+  ): preview is PreviewSubscribeResponse & { allowed: true } {
+    if (isSubscriptionCancelled()) return isReactivationCapablePreview(preview)
+    return checkoutType === 'change'
+      ? isExistingPlanPreview(preview)
+      : Boolean(preview?.allowed)
+  }
+
   function reactivationMaterialSnapshot(
     preview: PreviewSubscribeResponse,
     ignoreTimeDerivedTodayValues = false
@@ -766,19 +776,19 @@ export function useSubscriptionCheckout(
     quoteIsCurrent.value = false
 
     if (!embeddedCheckoutEnabled) {
-      checkoutStep.value = 'preview'
-      const needsPreview = payload.isChange || isSubscriptionCancelled()
-      isLoadingPreview.value = needsPreview && !!payload.stop.id
-      if (!needsPreview || !payload.stop.id) return
+      const teamCreditStopId = payload.stop.id
+      if (!teamCreditStopId) {
+        if (checkoutType === 'new') checkoutStep.value = 'preview'
+        return
+      }
+      isLoadingPreview.value = true
 
       let response: PreviewSubscribeResponse | null = null
       let previewError: unknown
       try {
         response = await previewSubscribe(
           getTeamPlanSlug(payload.billingCycle),
-          {
-            teamCreditStopId: payload.stop.id
-          }
+          { teamCreditStopId }
         )
       } catch (error) {
         previewError = error
@@ -798,14 +808,11 @@ export function useSubscriptionCheckout(
       }
 
       if (previewRequestId !== teamPreviewRequestId) return
-      if (
-        (isSubscriptionCancelled() && isReactivationCapablePreview(response)) ||
-        (!isSubscriptionCancelled() && isExistingPlanPreview(response))
-      ) {
-        if (response) installPreview(response)
+      if (isUsableTeamPreview(response, checkoutType)) {
+        installPreview(response)
+        checkoutStep.value = 'preview'
         return
       }
-      if (!isSubscriptionCancelled()) return
       toast.add({
         severity: 'error',
         summary: t('subscription.teamPlan.name'),

--- a/src/platform/workspace/composables/useSubscriptionCheckout.ts
+++ b/src/platform/workspace/composables/useSubscriptionCheckout.ts
@@ -778,7 +778,12 @@ export function useSubscriptionCheckout(
     if (!embeddedCheckoutEnabled) {
       const teamCreditStopId = payload.stop.id
       if (!teamCreditStopId) {
-        if (checkoutType === 'new') checkoutStep.value = 'preview'
+        toast.add({
+          severity: 'error',
+          summary: t('subscription.teamPlan.name'),
+          detail: t('subscription.teamPlan.unavailable')
+        })
+        resetToPricing()
         return
       }
       isLoadingPreview.value = true


### PR DESCRIPTION
## Summary

With embedded checkout off, the Team confirmation step opened before any quote was requested — so "Total due today" rendered with no amount, and a plan change that could not be priced emptied the dialog entirely.

Found on staging during 1.52 QA (Denys), after #16517 fixed the same symptom for Personal.

## Root cause

`handleSubscribeTeamClick`'s legacy branch set the step *before* fetching, and then usually never fetched:

```ts
checkoutStep.value = 'preview'                              // step first
const needsPreview = payload.isChange || isSubscriptionCancelled()
if (!needsPreview || !payload.stop.id) return               // fresh subscribe: no request at all
```

`previewData` is reset to `null` immediately above this, so a fresh team subscribe reached the confirmation with no quote. `SubscriptionAddPaymentPreviewWorkspace` renders the total from `previewData`, so the amount and the whole renewal line came out empty. Everything else on that screen ($665, billing cycle, refill credits) is derived from the `teamPlan` prop, which is why the screen looked otherwise healthy.

Personal was never affected: `handleSubscribeClick` calls `previewSubscribe` on both sides of the flag and only then advances the step. So #16517 (legacy quote formatting) could not have fixed Team — there was no preview to format.

The same early step change produced the empty modal on Team → Change plan. `previewVariant` returns `'team-change'` from `checkoutType` alone, and the two exits at `if (!payload.stop.id) return` and `if (!isSubscriptionCancelled()) return` leave `previewData` null. `SubscriptionTransitionPreviewWorkspace` declares `previewData: PreviewSubscribeResponse` (required) and dereferences it during setup (`previewData.promotion_code`), so setup throws and only the dialog chrome renders. The `:preview-data="previewData!"` assertion at the call site is what kept this off the type checker.

## Changes

- **What**: the legacy team path fetches and installs the preview first, and advances to the confirmation only when `isUsableTeamPreview` accepts it — otherwise it reports the failure and stays on pricing, matching the personal and embedded paths. Removed the `previewData!` assertions so a null preview can no longer reach a required prop. The total row is omitted rather than rendered blank when nothing can price it (the id-less OSS stop, the one case with no server quote available).
- **Breaking**: a preview failure now blocks a fresh team subscribe instead of showing an unpriced confirmation. This matches what the flag-on path already does.

## Review Focus

`isUsableTeamPreview` keeps the three acceptance rules that were previously inline and adds the new-subscription case, which had no rule because it never fetched: cancelled needs a reactivation-capable preview, a change needs an existing-plan transition, a new subscribe needs any allowed preview.

Worth knowing for the release call: `embeddedCheckoutEnabled` appears exactly once in `useSubscriptionCheckout.test.ts` — as the `setup()` default of `true`. Every one of the 131 existing tests ran the flag-on branch, so the entire legacy branch shipped uncovered. That is the actual reason this reached staging, and the four new tests are scoped to it.

Amounts stay server-resolved throughout; nothing here derives a price from `teamPlan`.

- Fixes FE-1974

## Screenshots (if applicable)

Captured against a cloud-distribution dev server with embedded checkout off, driving the real flow: Settings → Plan & Credits → Change plan → pick a different Team credit stop → Change plan.

### AS IS — `main`

![AS IS: the change-plan confirmation is an empty "Choose a Plan" box](https://raw.githubusercontent.com/dante01yoon/ComfyUI_frontend/assets/pr-16647-screenshots/docs-assets/pr-16647/asis-change-plan-empty.png)

The step is entered with `previewData` still null. `SubscriptionTransitionPreviewWorkspace` declares that prop required and dereferences it during setup, so setup throws and the body renders nothing — only the shell's own header is left. This is the same failure QA hit on staging.

### TO BE — this PR

> This shot still shows a duplicated "Choose a Plan" header and a second back arrow. That is a separate defect, fixed in #16648 — it is left visible here so this PR's own contribution is legible on its own.

![TO BE: the confirmation renders with Total due today priced from the server](https://raw.githubusercontent.com/dante01yoon/ComfyUI_frontend/assets/pr-16647-screenshots/docs-assets/pr-16647/tobe-change-plan-priced.png)

The preview is fetched and installed before the step is entered, so the confirmation renders and `Total due today` is priced from the server's legacy `cost_*` fields — $361.00 here, with the renewal line resolved too.

### TO BE — with #16648 applied as well

![TO BE: a single header and one back action, with the amount priced](https://raw.githubusercontent.com/dante01yoon/ComfyUI_frontend/assets/pr-16647-screenshots/docs-assets/pr-16647/tobe-both-prs.png)

How the step looks once both PRs are in. They are two halves of the same report and ship together for 1.52.
