### PR TITLE
fix(billing): give the confirm step a single header and back action

### DIFF
--- a/src/platform/workspace/components/SubscriptionAddPaymentPreviewWorkspace.test.ts
+++ b/src/platform/workspace/components/SubscriptionAddPaymentPreviewWorkspace.test.ts
@@ -398,17 +398,25 @@ describe('SubscriptionAddPaymentPreviewWorkspace', () => {
     expect(screen.getByText('op-reconcile-123')).toBeTruthy()
   })
 
-  it('does not render a back action on the payment confirmation', () => {
-    render(SubscriptionAddPaymentPreviewWorkspace, {
-      props: { tierKey: 'creator', isLoading: true },
-      global: globalOptions
+  it('owns a back action whether or not the payment element is embedded', async () => {
+    const { emitted } = render(SubscriptionAddPaymentPreviewWorkspace, {
+      props: { tierKey: 'creator' },
+      global: {
+        ...globalOptions,
+        stubs: {
+          ...globalOptions.stubs,
+          Button: {
+            props: ['ariaLabel'],
+            template:
+              '<button :aria-label="ariaLabel" @click="$emit(\'click\')"><slot /></button>'
+          }
+        }
+      }
     })
 
-    expect(
-      screen.queryByRole('button', {
-        name: 'subscription.preview.backToAllPlans'
-      })
-    ).toBeNull()
+    await userEvent.click(screen.getByRole('button', { name: 'g.back' }))
+
+    expect(emitted().back).toBeTruthy()
   })
 
   it('prices a legacy preview from the server costs instead of rendering a blank total', () => {

--- a/src/platform/workspace/components/SubscriptionAddPaymentPreviewWorkspace.vue
+++ b/src/platform/workspace/components/SubscriptionAddPaymentPreviewWorkspace.vue
@@ -27,7 +27,6 @@
         :class="cn('mb-8 flex items-center gap-3', captureMode && 'xl:mb-10')"
       >
         <Button
-          v-if="usePaymentElement"
           size="icon"
           variant="muted-textonly"
           class="shrink-0 rounded-full"

--- a/src/platform/workspace/components/SubscriptionRequiredDialogContentUnified.test.ts
+++ b/src/platform/workspace/components/SubscriptionRequiredDialogContentUnified.test.ts
@@ -7,6 +7,7 @@ import { createI18n } from 'vue-i18n'
 import SubscriptionRequiredDialogContentUnified from './SubscriptionRequiredDialogContentUnified.vue'
 
 const mockHandleSubscribeTeamClick = vi.fn()
+const mockHandleBackToPricing = vi.fn()
 const mockHandleSubscribeClick = vi.fn()
 const mockInvalidateQuote = vi.fn()
 const mockIsInPersonalWorkspace = ref(false)
@@ -42,7 +43,7 @@ vi.mock('@/platform/workspace/composables/useSubscriptionCheckout', () => ({
     previewVariant: computed(() => mockPreviewVariant.value),
     handleSubscribeClick: mockHandleSubscribeClick,
     handleSubscribeTeamClick: mockHandleSubscribeTeamClick,
-    handleBackToPricing: vi.fn(),
+    handleBackToPricing: mockHandleBackToPricing,
     handleSuccessClose: vi.fn(),
     handleAddCreditCard: vi.fn(),
     handleConfirmTransition: vi.fn(),
@@ -112,6 +113,7 @@ function renderComponent(props: Record<string, unknown> = {}) {
             <span data-testid="payment-element-enabled">{{ usePaymentElement }}</span>
             <button data-testid="saved-method-btn" @click="$emit('update:selectedSavedMethodId', 'pm_other')">Saved method</button>
             <button data-testid="new-method-btn" @click="$emit('changePaymentMethod')">New method</button>
+            <button aria-label="Back" @click="$emit('back')">Back</button>
           </div>`
         },
         SubscriptionTransitionPreviewWorkspace: { template: '<div />' },
@@ -251,7 +253,7 @@ describe('SubscriptionRequiredDialogContentUnified team-plan subscribe', () => {
 
   it.for([true, false])(
     'leaves the confirm step its own header and back action (embedded: %s)',
-    (embeddedCheckoutEnabled) => {
+    async (embeddedCheckoutEnabled) => {
       mockCheckoutStep.value = 'preview'
       mockPreviewVariant.value = 'team-new'
       mockSelectedTeamStop.value = TEAM_PAYLOAD.stop
@@ -259,7 +261,11 @@ describe('SubscriptionRequiredDialogContentUnified team-plan subscribe', () => {
       renderComponent({ embeddedCheckoutEnabled })
 
       expect(screen.queryByText('Choose your plan')).toBeNull()
-      expect(screen.queryByRole('button', { name: 'Back' })).toBeNull()
+      expect(screen.getAllByRole('button', { name: 'Back' })).toHaveLength(1)
+
+      await userEvent.click(screen.getByRole('button', { name: 'Back' }))
+
+      expect(mockHandleBackToPricing).toHaveBeenCalled()
     }
   )
 })

--- a/src/platform/workspace/components/SubscriptionRequiredDialogContentUnified.test.ts
+++ b/src/platform/workspace/components/SubscriptionRequiredDialogContentUnified.test.ts
@@ -248,4 +248,18 @@ describe('SubscriptionRequiredDialogContentUnified team-plan subscribe', () => {
     })
     expect(mockHandleSubscribeClick).not.toHaveBeenCalled()
   })
+
+  it.for([true, false])(
+    'leaves the confirm step its own header and back action (embedded: %s)',
+    (embeddedCheckoutEnabled) => {
+      mockCheckoutStep.value = 'preview'
+      mockPreviewVariant.value = 'team-new'
+      mockSelectedTeamStop.value = TEAM_PAYLOAD.stop
+
+      renderComponent({ embeddedCheckoutEnabled })
+
+      expect(screen.queryByText('Choose your plan')).toBeNull()
+      expect(screen.queryByRole('button', { name: 'Back' })).toBeNull()
+    }
+  )
 })

--- a/src/platform/workspace/components/SubscriptionRequiredDialogContentUnified.vue
+++ b/src/platform/workspace/components/SubscriptionRequiredDialogContentUnified.vue
@@ -29,22 +29,6 @@
     "
   >
     <Button
-      v-if="
-        checkoutStep === 'preview' &&
-        !isEmbeddedPaymentStep &&
-        !isEmbeddedConfirmStep
-      "
-      size="icon"
-      variant="muted-textonly"
-      class="absolute top-2.5 left-2.5 shrink-0 rounded-full text-text-secondary hover:bg-white/10"
-      :aria-label="$t('g.back')"
-      :disabled="isPolling"
-      @click="handleBackToPricing"
-    >
-      <i class="pi pi-arrow-left text-xl" />
-    </Button>
-
-    <Button
       size="icon"
       variant="muted-textonly"
       class="absolute top-6 right-4 shrink-0 rounded-full text-text-secondary hover:bg-white/10"
@@ -54,15 +38,9 @@
       <i class="pi pi-times text-xl" />
     </Button>
 
-    <!-- The embedded payment step titles itself ("Confirm your payment");
-         stacking "Choose a Plan" above it doubled the header and made this
-         step taller than the pricing table. -->
+    <!-- The confirm and success steps title themselves. -->
     <div
-      v-if="
-        !isEmbeddedPaymentStep &&
-        !isEmbeddedSuccessStep &&
-        !isEmbeddedConfirmStep
-      "
+      v-if="checkoutStep === 'pricing'"
       class="flex flex-col items-center gap-3"
     >
       <h2 class="m-0 font-inter text-2xl font-semibold text-base-foreground">

--- a/src/platform/workspace/components/SubscriptionRequiredDialogContentWorkspace.test.ts
+++ b/src/platform/workspace/components/SubscriptionRequiredDialogContentWorkspace.test.ts
@@ -63,6 +63,7 @@ const AddPaymentPreviewStub = {
     <button data-testid="add-card-btn" @click="$emit('addCreditCard')">Add Card</button>
     <button data-testid="apply-promo-btn" @click="$emit('applyPromotionCode', 'SAVE20')">Apply promo</button>
     <button data-testid="invalidate-quote-btn" @click="$emit('invalidateQuote')">Invalidate quote</button>
+    <button data-testid="back-btn" @click="$emit('back')">Back</button>
   </div>`
 }
 
@@ -209,11 +210,11 @@ describe('SubscriptionRequiredDialogContentWorkspace', () => {
     expect(onClose).toHaveBeenCalledOnce()
   })
 
-  it('shows back button on preview step', () => {
+  it('leaves the back action to the preview step that renders its own', () => {
     mockCheckoutStep.value = 'preview'
     mockPreviewData.value = { transition_type: 'new_subscription' }
     renderComponent()
-    expect(screen.getByLabelText('Back')).toBeInTheDocument()
+    expect(screen.queryByLabelText('Back')).not.toBeInTheDocument()
   })
 
   it('shows insufficient credits message when reason is out_of_credits', () => {
@@ -283,7 +284,7 @@ describe('SubscriptionRequiredDialogContentWorkspace', () => {
     mockPreviewData.value = { transition_type: 'new_subscription' }
     renderComponent()
 
-    await user.click(screen.getByLabelText('Back'))
+    await user.click(screen.getByTestId('back-btn'))
 
     expect(mockHandleBackToPricing).toHaveBeenCalled()
   })

--- a/src/platform/workspace/components/SubscriptionRequiredDialogContentWorkspace.test.ts
+++ b/src/platform/workspace/components/SubscriptionRequiredDialogContentWorkspace.test.ts
@@ -63,7 +63,7 @@ const AddPaymentPreviewStub = {
     <button data-testid="add-card-btn" @click="$emit('addCreditCard')">Add Card</button>
     <button data-testid="apply-promo-btn" @click="$emit('applyPromotionCode', 'SAVE20')">Apply promo</button>
     <button data-testid="invalidate-quote-btn" @click="$emit('invalidateQuote')">Invalidate quote</button>
-    <button data-testid="back-btn" @click="$emit('back')">Back</button>
+    <button @click="$emit('back')">Back</button>
   </div>`
 }
 
@@ -214,7 +214,7 @@ describe('SubscriptionRequiredDialogContentWorkspace', () => {
     mockCheckoutStep.value = 'preview'
     mockPreviewData.value = { transition_type: 'new_subscription' }
     renderComponent()
-    expect(screen.queryByLabelText('Back')).not.toBeInTheDocument()
+    expect(screen.getAllByRole('button', { name: 'Back' })).toHaveLength(1)
   })
 
   it('shows insufficient credits message when reason is out_of_credits', () => {
@@ -284,7 +284,7 @@ describe('SubscriptionRequiredDialogContentWorkspace', () => {
     mockPreviewData.value = { transition_type: 'new_subscription' }
     renderComponent()
 
-    await user.click(screen.getByTestId('back-btn'))
+    await user.click(screen.getByRole('button', { name: 'Back' }))
 
     expect(mockHandleBackToPricing).toHaveBeenCalled()
   })

--- a/src/platform/workspace/components/SubscriptionRequiredDialogContentWorkspace.vue
+++ b/src/platform/workspace/components/SubscriptionRequiredDialogContentWorkspace.vue
@@ -3,18 +3,6 @@
     class="relative flex h-full flex-col gap-6 overflow-y-auto p-4 pt-8 md:px-16 md:py-8"
   >
     <Button
-      v-if="checkoutStep === 'preview'"
-      size="icon"
-      variant="muted-textonly"
-      class="absolute top-2.5 left-2.5 shrink-0 rounded-full text-text-secondary hover:bg-white/10"
-      :aria-label="$t('g.back')"
-      :disabled="isPolling"
-      @click="handleBackToPricing"
-    >
-      <i class="pi pi-arrow-left text-xl" />
-    </Button>
-
-    <Button
       size="icon"
       variant="muted-textonly"
       class="absolute top-2.5 right-2.5 shrink-0 rounded-full text-text-secondary hover:bg-white/10"


### PR DESCRIPTION
## Summary

With embedded checkout off, the subscription dialog drew "Choose a Plan" and a back arrow on top of a confirm step that already renders both — two stacked headers on every legacy confirmation, and two back arrows on plan changes.

Found on staging during 1.52 QA (Denys).

## Root cause

The shell suppressed its own chrome only for the embedded steps:

```ts
const isEmbeddedPaymentStep = computed(() => … && stripePaymentElementEnabled && …)
const isEmbeddedConfirmStep = computed(() => … && stripePaymentElementEnabled && …)
```

Both require `stripePaymentElementEnabled`, so with the flag off they are false and the header and back arrow render on every step. The comment above the header already described this exact failure ("stacking 'Choose a Plan' above it doubled the header") — the guard written for it just never covered the flag-off path.

The arrow count differed by step for a second reason: `SubscriptionAddPaymentPreviewWorkspace` hid its back button behind `v-if="usePaymentElement"`, so a new subscription showed one arrow (the shell's), while `SubscriptionTransitionPreviewWorkspace` renders its own unconditionally and showed two. Both arrows call `handleBackToPricing`, which is why they behaved identically.

## Changes

- **What**: the shell header is now bound to the pricing step — the confirm and success steps title themselves, so no flag is involved. The back action moves to the step that owns the header: the confirmation renders it in both modes, and neither dialog shell renders one.

`isEmbedded*` are still used for the container sizing and transitions; only the chrome stopped consulting them.

`SubscriptionRequiredDialogContentWorkspace` (the legacy per-member team dialog) is touched because it shares the confirm component. It had the same duplication on plan changes and is fixed by the same ownership rule. Its two back-button tests now assert the child owns the action rather than the shell.

## Review Focus

The back arrow moves from the shell's absolute top-left to inline beside the confirm title in the flag-off path. That is the position it already occupies with embedded checkout on, so the two modes now match rather than diverge — worth a designer's eye if the old placement was deliberate.

Behaviour deliberately unchanged: `isPolling`/loading still disable the action, since the confirm components already gate their button on the `isLoading` prop the shell passes.

## Screenshots (if applicable)

Captured against a cloud-distribution dev server with embedded checkout off, driving the real flow: Settings → Plan & Credits → Change plan → pick a different Team credit stop → Change plan.

Both shots are taken on top of #16647 so the confirm body renders — on current `main` this step is empty, which hides the chrome problem rather than fixing it.

### AS IS

![AS IS: "Choose a Plan" stacked over "Confirm your upgrade", with two back arrows](https://raw.githubusercontent.com/dante01yoon/ComfyUI_frontend/assets/pr-16648-screenshots/docs-assets/pr-16648/asis-doubled-chrome.png)

Two titles and two back arrows. The shell draws its own header and arrow because every `isEmbedded*` guard requires `stripePaymentElementEnabled`, which is false with the flag off, and the confirm step renders its own on top.

### TO BE — this PR

![TO BE: a single "Confirm your upgrade" header and one back action](https://raw.githubusercontent.com/dante01yoon/ComfyUI_frontend/assets/pr-16648-screenshots/docs-assets/pr-16648/tobe-single-chrome.png)

One header, one back action. The shell header now belongs to the pricing step, and the back action to the step that owns the header.
