### PR TITLE
fix(e2e): remove stale VHS per_batch value-drift allowlist entries

### DIFF
--- a/browser_tests/fixtures/customNode/allNodesRoundtripTier.ts
+++ b/browser_tests/fixtures/customNode/allNodesRoundtripTier.ts
@@ -130,12 +130,6 @@ const WIDGET_SET_ALLOWLIST_BY_IDENTITY: Record<
 }
 
 const ROUNDTRIP_VALUE_ALLOWLIST: Record<string, Record<string, string>> = {
-  'ComfyUI-VideoHelperSuite': {
-    VHS_VAEDecodeBatched:
-      'per_batch serializes null after configure (VHS ANNOTATED widget deserialization gap) - upstream-report candidate',
-    VHS_VAEEncodeBatched:
-      'per_batch serializes null after configure (VHS ANNOTATED widget deserialization gap) - upstream-report candidate'
-  },
   'ComfyUI-LTXVideo': {
     LTXVSparseTrackEditor:
       'the sparse-track editor regenerates its derived integer coordinates from the preserved source points on configure'

--- a/browser_tests/fixtures/customNode/valueDrift.ts
+++ b/browser_tests/fixtures/customNode/valueDrift.ts
@@ -32,21 +32,18 @@ export const ROUNDTRIP_VALUE_ALLOWED_INDICES_VUE: Record<
   }
 }
 
-const VHS_ROUNDTRIP_VALUE_KEYS_LITEGRAPH = {
-  VHS_VAEDecodeBatched: 'per_batch',
-  VHS_VAEEncodeBatched: 'per_batch'
-}
+// VHS_VAEDecodeBatched.per_batch / VHS_VAEEncodeBatched.per_batch no longer
+// drift on save/reload; the ComfyUI-VideoHelperSuite entry was removed here
+// (see ROUNDTRIP_VALUE_ALLOWLIST in allNodesRoundtripTier.ts) — qax-19/valuedrift-1.
+export const ROUNDTRIP_VALUE_ALLOWED_KEYS_LITEGRAPH: Record<
+  string,
+  Record<string, string>
+> = {}
 
-export const ROUNDTRIP_VALUE_ALLOWED_KEYS_LITEGRAPH = {
-  'ComfyUI-VideoHelperSuite': VHS_ROUNDTRIP_VALUE_KEYS_LITEGRAPH
-}
-
-export const ROUNDTRIP_VALUE_ALLOWED_KEYS_VUE = {
-  'ComfyUI-VideoHelperSuite': {
-    VHS_VAEDecodeBatched: 'per_batch',
-    VHS_VAEEncodeBatched: 'per_batch'
-  }
-}
+export const ROUNDTRIP_VALUE_ALLOWED_KEYS_VUE: Record<
+  string,
+  Record<string, string>
+> = {}
 
 export type RoundtripInitializationSignal =
   | { property: string; predicate: 'defined' }


### PR DESCRIPTION
## Problem

`browser_tests/fixtures/customNode/valueDrift.ts` had two `ROUNDTRIP_VALUE_ALLOWED_KEYS_LITEGRAPH`/`_VUE` entries for `ComfyUI-VideoHelperSuite` (`VHS_VAEDecodeBatched.per_batch`, `VHS_VAEEncodeBatched.per_batch`) that no longer actually drift on save/reload. This fails `allNodes.spec.ts`'s S3 exact-contracts assertion (`staleValueDriftKeys`) on every PR based on current `main`, because the assertion flags an allowed key as stale once it's no longer observed drifting.

Root cause identified in `qax-19`: four disjoint PRs were failing identical `custom_nodes_e2e` shards on this same VHS baseline — [#16365](https://github.com/Comfy-Org/ComfyUI_frontend/pull/16365), [#16406](https://github.com/Comfy-Org/ComfyUI_frontend/pull/16406), [#16462](https://github.com/Comfy-Org/ComfyUI_frontend/pull/16462), [#16555](https://github.com/Comfy-Org/ComfyUI_frontend/pull/16555).

## Fix

- Removed the stale `ComfyUI-VideoHelperSuite` entries from `ROUNDTRIP_VALUE_ALLOWED_KEYS_LITEGRAPH` / `ROUNDTRIP_VALUE_ALLOWED_KEYS_VUE` in `valueDrift.ts`.
- Removed the matching `ROUNDTRIP_VALUE_ALLOWLIST` entry in `allNodesRoundtripTier.ts` — the two ledgers are cross-checked bidirectionally (every exact-value-drift node needs a `ROUNDTRIP_VALUE_ALLOWLIST` reason and vice versa), so leaving the allowlist entry behind would trip `ROUNDTRIP_VALUE_ALLOWLIST entry ... has no exact renderer contract`.
- Confirmed no other pack references either of the two removed node/key pairs (only an unrelated `interactionProfiles/ComfyUI-VideoHelperSuite.json` fixture mentions the node names, for a different purpose).

## Verification

- `pnpm exec vitest run browser_tests/fixtures/customNode/valueDrift.test.ts` — 14/14 pass.
- `pnpm typecheck` (`vue-tsc --noEmit`) — clean.
- `oxfmt --check` / `oxlint` on both changed files — clean.
- Pre-commit hook (typecheck, typecheck:browser, lint, format, knip) — clean.
- Did **not** run the live `allNodes.spec.ts` S3 Playwright tier here (needs a real browser + live custom-node pack manifests); the fix follows directly from reading `staleValueDriftKeys`'s semantics and the bidirectional ledger check in `allNodesRoundtripTier.ts`, so this should resolve the shard failures on #16365/#16406/#16462/#16555 once their CI reruns.

Source: `valuedrift-1` / `qax-19`.