### PR TITLE
fix: add crossorigin=use-credentials to manifest link

### DIFF
--- a/index.html
+++ b/index.html
@@ -108,7 +108,7 @@
         }
       }
     </style>
-    <link rel="manifest" href="manifest.json" />
+    <link rel="manifest" href="manifest.json" crossorigin="use-credentials" />
   </head>
 
   <body class="litegraph grid">


### PR DESCRIPTION
## Problem

On Cloudflare-Access-gated hosts (nightly), the browser's credential-less fetch of `manifest.json` (Vite-hashed to `/assets/manifest-P9przInP.json`) 302s to `comfy-org.cloudflareaccess.com` and then fails CORS on every page load (`ERR_FAILED`). It's the PWA web-app manifest link added in #3639. Benign console noise, nightly-only.

## Fix

Add `crossorigin="use-credentials"` to the `<link rel="manifest">` tag in `index.html` so the browser includes credentials (the Cloudflare Access cookie) on the manifest fetch.

## Evidence

```
$ grep -n manifest index.html
111:    <link rel="manifest" href="manifest.json" crossorigin="use-credentials" />
```

Built with `pnpm exec vite build --config vite.config.mts` and confirmed Vite preserves the attribute on the hashed asset in `dist/index.html`:

```
$ grep -o '<link rel="manifest"[^>]*>' dist/index.html
<link rel="manifest" href="./assets/manifest-P9przInP.json" crossorigin="use-credentials"/>
```

Non-gated hosts are unaffected: `crossorigin="use-credentials"` only changes the credentials mode of the fetch, which is a no-op for same-origin/non-gated requests.

## Evidence

Row: `christian-byrne/in-app-agent-program` `todo.md` qa-60.

<!-- authored-by:agent lane-qa-60 -->