### PR TITLE
fix(agent-crdt): treat awareness state:null as absent, not a rejected frame

### DIFF
--- a/src/workbench/extensions/agent/crdt/docFrameClient.awareness.test.ts
+++ b/src/workbench/extensions/agent/crdt/docFrameClient.awareness.test.ts
@@ -37,6 +37,21 @@ describe('awareness frame validation', () => {
     expect(parseServerDocFrame(awarenessFrame(['cursor', 10, 20]))).toBeNull()
   })
 
+  it('treats a null state as absent rather than rejecting the frame', () => {
+    // The Go server's `State map[string]any` has `omitempty` and never
+    // actually emits `state: null`, but this is defence in depth: null
+    // should fold into "no state", not discard the whole frame (and with
+    // it actor/expires_at). discussion_r3911665011.
+    expect(parseServerDocFrame(awarenessFrame(null, 456))).toEqual({
+      type: 'awareness',
+      data: {
+        workflowId: 'wf-1',
+        actor: 'human:user:tab-a',
+        expiresAt: 456
+      }
+    })
+  })
+
   it('rejects negative expires_at', () => {
     expect(parseServerDocFrame(awarenessFrame({}, -1))).toBeNull()
   })

--- a/src/workbench/extensions/agent/crdt/docFrameClient.ts
+++ b/src/workbench/extensions/agent/crdt/docFrameClient.ts
@@ -131,7 +131,14 @@ function isNonNegativeInteger(value: unknown): value is number {
 function parseAwarenessState(
   value: unknown
 ): Record<string, unknown> | undefined | null {
-  if (value === undefined) return undefined
+  // The Go server's `State map[string]any` has `omitempty`, so it never
+  // emits `state: null` on the wire; nil/empty maps are omitted entirely,
+  // same as an absent field. Treat null the same as absent (no state) rather
+  // than rejecting the whole frame, so a value the server cannot actually
+  // send does not discard `actor`/`expires_at` too. A non-null, non-record
+  // shape (array, string, number) is still a malformed frame and rejected.
+  // discussion_r3911665011.
+  if (value === undefined || value === null) return undefined
   const state = parseRecord(value)
   if (state === null) return null
 


### PR DESCRIPTION
## Summary

Resolves an unresolved review question from [#16612](https://github.com/Comfy-Org/ComfyUI_frontend/pull/16612#discussion_r3911665011) that merged before the author answered it.

`parseAwarenessState` folded a `state: null` value into the same branch as any other invalid, non-record shape (arrays, strings, numbers), rejecting the *entire* awareness frame including `actor` and `expires_at`. But the Go server's `State map[string]any` has `omitempty` and can never actually emit `null` on the wire — so this was defence-in-depth for a value the server cannot send, and it silently changed behavior from pre-#16612 `main` (where `parseRecord(null)` returned `null` and the field was dropped, but the frame was still accepted).

This PR folds `null` into the same branch as `undefined` (no state present) instead of rejecting the frame. A genuinely malformed non-record shape (array, string, number) is still rejected.

## Why treat null as absent, not reject

Awareness is ephemeral presence data (cursor/selection), not part of the shared CRDT doc. Dropping a best-effort state update should not also discard the actor's `expires_at`, which is the signal a consumer would use to clear stale presence for that actor. Rejecting the whole frame is strictly more destructive than necessary for a value that, per the server's own schema, means "no state."

## Evidence

```
$ pnpm exec vitest run src/workbench/extensions/agent/crdt/docFrameClient.awareness.test.ts
 Test Files  1 passed (1)
      Tests  10 passed (10)

$ pnpm exec vitest run src/workbench/extensions/agent/crdt
 Test Files  19 passed (19)
      Tests  207 passed (207)

$ pnpm typecheck
$ vue-tsc --noEmit
[exited with code 0]

$ pnpm exec eslint src/workbench/extensions/agent/crdt/docFrameClient.ts src/workbench/extensions/agent/crdt/docFrameClient.awareness.test.ts
(no output, 0 errors)
```

<!-- authored-by:agent lane-act-fe-16612-followup-05334ef0 -->
