### PR TITLE
fix(agent): guard persisted expiry refresh by workflow

### DIFF
--- a/src/workbench/extensions/agent/crdt/crossWorkflowPending.test.ts
+++ b/src/workbench/extensions/agent/crdt/crossWorkflowPending.test.ts
@@ -214,7 +214,7 @@ describe('R-73 cross-workflow pending operation characterization', () => {
     })
   })
 
-  it('documents status contamination from a late workflow A result while workflow B is active', async () => {
+  it('guards status from a late workflow A result while workflow B is active', async () => {
     const { workflowId, enqueue, status } = mountFollower('wf-a')
 
     bridge().lastSequence = 41
@@ -255,19 +255,25 @@ describe('R-73 cross-workflow pending operation characterization', () => {
       )
     ).toHaveLength(1)
 
-    // Documented defect expectation for R-73: result frames carry workflowId,
-    // but the composable updates workflow B's status from workflow A's frame.
-    // Flip this assertion when the result path gates status by workflowId.
+    // R-73 regression guard: result frames carry workflowId, and the guard
+    // added alongside this test (onOpsResult in useAgentCrdtFollower.ts)
+    // drops a result whose workflowId no longer matches the subscribed
+    // workflow, so workflow B's status is never updated from workflow A's
+    // late frame, and the composable never re-emits that frame as a
+    // 'doc_ops_result' dev event.
     expect(status()).toMatchObject({
       workflowId: 'wf-b',
-      lastFrameType: 'doc_ops_result'
+      lastFrameType: null
     })
-    expect(devLogState.recordDevEvent).toHaveBeenCalledWith('doc_ops_result', {
-      workflowId: 'wf-a',
-      ok: true,
-      applied: [operationAId],
-      skipped: []
-    })
+    expect(devLogState.recordDevEvent).not.toHaveBeenCalledWith(
+      'doc_ops_result',
+      {
+        workflowId: 'wf-a',
+        ok: true,
+        applied: [operationAId],
+        skipped: []
+      }
+    )
     expect(operationBId).not.toBe(operationAId)
   })
 

--- a/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.test.ts
+++ b/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.test.ts
@@ -366,6 +366,27 @@ describe('useAgentCrdtFollower', () => {
     unmount()
   })
 
+  it('FEC-5: only active-workflow op results slide the persisted expiry', () => {
+    vi.useFakeTimers()
+    const { isTargetActive, unmount } = mountFollower('wf-1')
+    dispatchFrame('doc_subscribed', { ok: true })
+    const stampedAt = persistedRecord()?.expiresAt
+    expect(stampedAt).toBeTypeOf('number')
+
+    vi.advanceTimersByTime(3 * 60 * 1000)
+    dispatchFrame('doc_ops_result', { workflowId: 'wf-2', ok: true })
+    expect(persistedRecord()?.expiresAt).toBe(stampedAt)
+
+    isTargetActive.value = false
+    dispatchFrame('doc_ops_result', { workflowId: 'wf-1', ok: true })
+    expect(persistedRecord()?.expiresAt).toBe(stampedAt)
+
+    isTargetActive.value = true
+    dispatchFrame('doc_ops_result', { workflowId: 'wf-1', ok: true })
+    expect(persistedRecord()?.expiresAt).toBeGreaterThan(stampedAt ?? 0)
+    unmount()
+  })
+
   it('FEC-5: an idle doc still expires', () => {
     vi.useFakeTimers()
     const setup = mountFollower('wf-1')

--- a/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.ts
+++ b/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.ts
@@ -416,14 +416,19 @@ export function useAgentCrdtFollower(
     knownDocNodeIds = ids
   }
   const onOpsResult: EventListener = (event) => {
+    if (!(event instanceof CustomEvent)) return
+    const detail = event.detail as { workflowId?: unknown } | null
+    if (
+      !isTargetActive.value ||
+      detail?.workflowId !== subscribedWorkflowId.value
+    )
+      return
     if (staleProbeTimer !== null) {
       armStaleProbe()
       refreshPersistedDocId()
     }
     lastFrameType.value = event.type
-    if (event instanceof CustomEvent) {
-      recordDevEvent('doc_ops_result', event.detail ?? null)
-    }
+    recordDevEvent('doc_ops_result', event.detail ?? null)
   }
   const onDocReset: EventListener = (event) => {
     const detail =


### PR DESCRIPTION
Guard persisted doc expiry refreshes by the active subscribed workflow.
Unrelated or background-target operation results no longer extend the binding.
Follow-up to #16624.

<details><summary>Full context for agent readers</summary>

## Changes

- Apply the same active-target and workflow guard to `onOpsResult` that `onUpdate` uses.
- Cover unrelated-workflow, inactive-target, and matching active-workflow results in one regression test.

## Evidence

```text
$ pnpm test:unit src/workbench/extensions/agent/crdt/useAgentCrdtFollower.test.ts
Test Files  1 passed (1)
Tests  25 passed (25)

$ pnpm typecheck
vue-tsc --noEmit
exit 0

$ pnpm exec eslint src/workbench/extensions/agent/crdt/useAgentCrdtFollower.ts src/workbench/extensions/agent/crdt/useAgentCrdtFollower.test.ts
clean, no output
exit 0

$ pnpm exec oxfmt --check src/workbench/extensions/agent/crdt/useAgentCrdtFollower.ts src/workbench/extensions/agent/crdt/useAgentCrdtFollower.test.ts
All matched files use the correct format.
Finished in 75ms on 2 files using 8 threads.

$ git push fork HEAD:fix/guard-ops-result-persistence
knip --cache
branch pushed
```

</details>

<!-- authored-by:agent lane-act-fe-16624-followup -->