### PR TITLE
fix(agent): restore dev panel keyboard focus

### DIFF
--- a/src/renderer/extensions/vueNodes/composables/processedWidgetRenderModel.ts
+++ b/src/renderer/extensions/vueNodes/composables/processedWidgetRenderModel.ts
@@ -459,7 +459,7 @@ export function computeProcessedWidgets({
   forceDisabled = false,
   isGraphReady,
   rootGraph,
-  ui,
+  ui
 }: ComputeProcessedWidgetsOptions): ProcessedWidget[] {
   if (!nodeData) return []
 
@@ -512,7 +512,7 @@ export function computeProcessedWidgets({
     missingModelStore,
     missingMediaStore,
     nodeDefStore,
-    ui,
+    ui
   }
 
   return Array.from(new Set(ids))

--- a/src/workbench/extensions/agent/crdt/CrdtDevPanel.a11y.test.ts
+++ b/src/workbench/extensions/agent/crdt/CrdtDevPanel.a11y.test.ts
@@ -1,0 +1,35 @@
+import { render, screen } from '@testing-library/vue'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import CrdtDevPanel from './CrdtDevPanel.vue'
+
+const status = {
+  enabled: true,
+  connected: true,
+  workflowId: 'workflow-1',
+  updatesApplied: 0,
+  lastFrameType: null
+}
+
+describe('CrdtDevPanel keyboard focus', () => {
+  beforeEach(() => localStorage.clear())
+
+  it('moves focus into the panel and restores it after Escape closes', async () => {
+    const user = userEvent.setup()
+    render(CrdtDevPanel, { props: { status } })
+
+    const chip = screen.getByRole('button', { name: 'CRDT dev' })
+    chip.focus()
+    await user.keyboard('{Enter}')
+
+    expect(screen.getByRole('button', { name: 'Close' })).toHaveFocus()
+
+    await user.keyboard('{Escape}')
+
+    expect(
+      screen.queryByRole('button', { name: 'Close' })
+    ).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'CRDT dev' })).toHaveFocus()
+  })
+})

--- a/src/workbench/extensions/agent/crdt/CrdtDevPanel.vue
+++ b/src/workbench/extensions/agent/crdt/CrdtDevPanel.vue
@@ -1,5 +1,12 @@
 <script setup lang="ts">
-import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
+import {
+  computed,
+  nextTick,
+  onBeforeUnmount,
+  onMounted,
+  ref,
+  useTemplateRef
+} from 'vue'
 
 import { api } from '@/scripts/api'
 
@@ -87,6 +94,8 @@ function readOpen(): boolean {
 }
 
 const open = ref(readOpen())
+const chipButton = useTemplateRef<HTMLButtonElement>('chipButton')
+const closeButton = useTemplateRef<HTMLButtonElement>('closeButton')
 
 function setOpen(value: boolean) {
   open.value = value
@@ -95,6 +104,7 @@ function setOpen(value: boolean) {
   } catch {
     /* storage unavailable — panel still toggles in-memory */
   }
+  void nextTick(() => (value ? closeButton.value : chipButton.value)?.focus())
 }
 
 // ── 1s poll of the PoC console helper ─────────────────────────────────────
@@ -195,9 +205,11 @@ function fmtTime(at: number): string {
   <div
     class="fixed right-3 bottom-3 z-9999 font-mono text-xs"
     data-testid="crdt-dev-panel"
+    @keydown.esc="setOpen(false)"
   >
     <button
       v-if="!open"
+      ref="chipButton"
       class="rounded-full border border-border-default bg-base-background px-3 py-1 shadow-md"
       data-testid="crdt-dev-panel-chip"
       @click="setOpen(true)"
@@ -214,6 +226,7 @@ function fmtTime(at: number): string {
       >
         <span class="font-bold">{{ S.title }}</span>
         <button
+          ref="closeButton"
           class="rounded-sm border border-border-default px-2 py-0.5"
           data-testid="crdt-dev-panel-close"
           @click="setOpen(false)"


### PR DESCRIPTION
## Summary

Makes the gated CRDT dev panel keyboard-operable without changing its content or behavior.

## Changes

- **What**: Focuses Close on open, closes on Escape, and restores focus to the re-rendered chip.
- **Dependencies**: None.

## Review Focus

Focus handoff across the chip/panel `v-if` transition.

## Evidence

```text
$ NODE_OPTIONS='--no-experimental-webstorage --max-old-space-size=8192' ./node_modules/.bin/vitest run src/workbench/extensions/agent/crdt/CrdtDevPanel.a11y.test.ts
Test Files  1 passed (1)
Tests  1 passed (1)

$ ./node_modules/.bin/oxfmt --check src/workbench/extensions/agent/crdt/CrdtDevPanel.vue src/workbench/extensions/agent/crdt/CrdtDevPanel.a11y.test.ts
All matched files use the correct format.
Finished on 2 files

$ ./node_modules/.bin/eslint src/workbench/extensions/agent/crdt/CrdtDevPanel.vue src/workbench/extensions/agent/crdt/CrdtDevPanel.a11y.test.ts
Exit code 0
No lint findings
```

<!-- authored-by:agent lane-fec-a11y-1 -->
