### PR TITLE
test(agent): cover malformed base64 update failure

### DIFF
--- a/src/workbench/extensions/agent/crdt/docFrameClient.test.ts
+++ b/src/workbench/extensions/agent/crdt/docFrameClient.test.ts
@@ -55,6 +55,25 @@ describe('doc frame client', () => {
     )
   })
 
+  it('throws on malformed base64 without dispatching a doc_update', () => {
+    const data = {
+      v: 1,
+      workflow_id: 'wf-1',
+      seq: 1,
+      update_b64: 'not base64!'
+    }
+
+    expect(() => parseServerDocFrame({ type: 'doc_update', data })).toThrow()
+
+    const transport = new TestTransport()
+    const client = new DocFrameClient(transport)
+    let updatesDispatched = 0
+    client.addEventListener('doc_update', () => updatesDispatched++)
+
+    expect(() => transport.receive('doc_update', data)).toThrow()
+    expect(updatesDispatched).toBe(0)
+  })
+
   it('replaying an update is idempotent', () => {
     const source = new Y.Doc()
     source.getArray('items').push(['a'])


### PR DESCRIPTION
## Summary

Characterize the integration branch's malformed `doc_update` base64 boundary with a focused regression test.

## Changes

- **What**: Prove `parseServerDocFrame` throws for structurally valid `doc_update` data containing malformed base64, and prove `DocFrameClient` dispatches no `doc_update` event.
- **Dependencies**: None.

## Review Focus

This intentionally records existing behavior without changing production code. Main-based PR #16484 separately changes the parser to reject malformed frames without throwing; it cannot host this integration-branch characterization because its expected behavior differs.

## Evidence

```text
$ pnpm test:unit src/workbench/extensions/agent/crdt/docFrameClient.test.ts
Test Files  1 passed (1)
Tests  7 passed (7)

$ pnpm exec oxfmt --check src/workbench/extensions/agent/crdt/docFrameClient.test.ts
All matched files use the correct format.
Finished in 801ms on 1 files using 8 threads.

$ pnpm exec eslint src/workbench/extensions/agent/crdt/docFrameClient.test.ts
Exit code 0
No diagnostics emitted.

$ pnpm typecheck
Exit code 0
Completed by the repository pre-commit hook.
```

<!-- authored-by:agent lane-fec-base64-1 -->
