### PR TITLE
test(agent-crdt): reproduce cached doc reconnect risk

### DIFF
--- a/src/renderer/extensions/vueNodes/composables/processedWidgetRenderModel.ts
+++ b/src/renderer/extensions/vueNodes/composables/processedWidgetRenderModel.ts
@@ -459,7 +459,7 @@ export function computeProcessedWidgets({
   forceDisabled = false,
   isGraphReady,
   rootGraph,
-  ui,
+  ui
 }: ComputeProcessedWidgetsOptions): ProcessedWidget[] {
   if (!nodeData) return []
 
@@ -512,7 +512,7 @@ export function computeProcessedWidgets({
     missingModelStore,
     missingMediaStore,
     nodeDefStore,
-    ui,
+    ui
   }
 
   return Array.from(new Set(ids))

--- a/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.test.ts
+++ b/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.test.ts
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { defineComponent, nextTick, ref } from 'vue'
+
+import { render } from '@testing-library/vue'
+
+const apiState = vi.hoisted(() => {
+  const docFrames = new EventTarget()
+  const socketEvents = new EventTarget()
+  const send = vi.fn()
+
+  return {
+    docFrames,
+    socketEvents,
+    send,
+    api: {
+      socket: { readyState: WebSocket.OPEN, send },
+      addCustomEventListener: (type: string, listener: EventListener) =>
+        docFrames.addEventListener(type, listener),
+      removeCustomEventListener: (type: string, listener: EventListener) =>
+        docFrames.removeEventListener(type, listener),
+      addEventListener: (type: string, listener: EventListener) =>
+        socketEvents.addEventListener(type, listener),
+      removeEventListener: (type: string, listener: EventListener) =>
+        socketEvents.removeEventListener(type, listener)
+    }
+  }
+})
+
+vi.mock('@/lib/litegraph/src/litegraph', () => ({
+  LiteGraph: { createNode: vi.fn() }
+}))
+vi.mock('@/scripts/api', () => ({ api: apiState.api }))
+vi.mock('@/scripts/app', () => ({ app: { graph: null } }))
+vi.mock('@/stores/authStore', () => ({
+  useAuthStore: () => ({ userId: 'user-1' })
+}))
+vi.mock('./devPanelLog', () => ({ recordDevEvent: vi.fn() }))
+vi.mock('./followerGate', () => ({ resolveFollowerEnabled: () => true }))
+vi.mock('./litegraphMutator', () => ({ LitegraphMutator: class {} }))
+vi.mock('./semanticProjector', () => ({
+  SemanticProjector: class {
+    project = vi.fn()
+    reset = vi.fn()
+  }
+}))
+
+import { useAgentCrdtFollower } from './useAgentCrdtFollower'
+
+const DOC_ID_KEY = 'Comfy.Agent.CrdtDocId'
+const WORKFLOW_A_DOC_ID = 'doc-for-workflow-a'
+
+function subscribeFrames(): unknown[] {
+  return apiState.send.mock.calls
+    .map(([frame]) => JSON.parse(frame as string) as { type: string })
+    .filter((frame) => frame.type === 'doc_subscribe')
+}
+
+describe('useAgentCrdtFollower workflow identity lifecycle', () => {
+  beforeEach(() => {
+    sessionStorage.clear()
+  })
+
+  it('current risk: reconnects workflow B to workflow A cached doc id', async () => {
+    sessionStorage.setItem(DOC_ID_KEY, WORKFLOW_A_DOC_ID)
+    const activeWorkflowId = ref('workflow-a')
+    const agentDocId = ref<string | null>(WORKFLOW_A_DOC_ID)
+    const host = defineComponent({
+      setup() {
+        useAgentCrdtFollower(agentDocId)
+        return () => activeWorkflowId.value
+      }
+    })
+    const { unmount } = render(host)
+
+    expect(sessionStorage.getItem(DOC_ID_KEY)).toBe(WORKFLOW_A_DOC_ID)
+
+    activeWorkflowId.value = 'workflow-b'
+    await nextTick()
+    apiState.socketEvents.dispatchEvent(new Event('reconnected'))
+
+    expect(activeWorkflowId.value).toBe('workflow-b')
+    expect(sessionStorage.getItem(DOC_ID_KEY)).toBe(WORKFLOW_A_DOC_ID)
+    expect(subscribeFrames()).toEqual([
+      {
+        type: 'doc_subscribe',
+        data: {
+          v: 1,
+          workflow_id: WORKFLOW_A_DOC_ID,
+          state_vector_b64: 'AA=='
+        }
+      },
+      {
+        type: 'doc_subscribe',
+        data: {
+          v: 1,
+          workflow_id: WORKFLOW_A_DOC_ID,
+          state_vector_b64: 'AA=='
+        }
+      }
+    ])
+    unmount()
+  })
+})


### PR DESCRIPTION
## Summary

Adds a focused current-risk lifecycle test showing that a reconnect after an in-tab workflow switch still subscribes with workflow A's cached CRDT document id.

## Changes

- **What**: Mounts the real follower client/bridge path, switches the rendered active workflow to B while the agent document binding remains A, dispatches reconnect, and asserts the exact two `doc_subscribe` frames plus the unchanged session key.

## Review Focus

This is evidence-only: it records current behavior without choosing storage scoping, expiry, migration, or remediation behavior.

## Evidence

```text
$ pnpm test:unit src/workbench/extensions/agent/crdt/useAgentCrdtFollower.test.ts
 Test Files  1 passed (1)
      Tests  1 passed (1)

$ pnpm exec eslint src/workbench/extensions/agent/crdt/useAgentCrdtFollower.test.ts
(clean, no output)

$ pnpm exec oxfmt --check src/workbench/extensions/agent/crdt/useAgentCrdtFollower.test.ts
All matched files use the correct format.
Finished in 127ms on 1 files using 8 threads.

$ pnpm typecheck
[COMPLETED] pnpm typecheck
[COMPLETED] Running tasks for staged files...

$ git rev-parse --short HEAD
2175aefab8
$ pnpm test:unit src/workbench/extensions/agent/crdt/useAgentCrdtFollower.test.ts
 Test Files  1 passed (1)
      Tests  1 passed (1)
```

The final command re-verifies the current PR head after CI's automated formatter commit; that commit changed only the pre-existing `processedWidgetRenderModel.ts` formatting and left this test unchanged.

Trace: FEC-5, FEB-3/FEB-5, program row `fec-docid-1`.

<!-- authored-by:agent lane-fec-docid-1 -->
