### PR TITLE
fix: preserve replacement CRDT PoC global

### DIFF
--- a/src/renderer/extensions/vueNodes/composables/processedWidgetRenderModel.ts
+++ b/src/renderer/extensions/vueNodes/composables/processedWidgetRenderModel.ts
@@ -459,7 +459,7 @@ export function computeProcessedWidgets({
   forceDisabled = false,
   isGraphReady,
   rootGraph,
-  ui,
+  ui
 }: ComputeProcessedWidgetsOptions): ProcessedWidget[] {
   if (!nodeData) return []
 
@@ -512,7 +512,7 @@ export function computeProcessedWidgets({
     missingModelStore,
     missingMediaStore,
     nodeDefStore,
-    ui,
+    ui
   }
 
   return Array.from(new Set(ids))

--- a/src/workbench/extensions/agent/crdt/agentCrdtPocGlobal.test.ts
+++ b/src/workbench/extensions/agent/crdt/agentCrdtPocGlobal.test.ts
@@ -1,0 +1,32 @@
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { installAgentCrdtPocGlobal } from './agentCrdtPocGlobal'
+
+type PocWindow = Window & {
+  __agentCrdtPoc?: object
+}
+
+const pocWindow = window as PocWindow
+
+describe('installAgentCrdtPocGlobal', () => {
+  afterEach(() => {
+    delete pocWindow.__agentCrdtPoc
+  })
+
+  it('only removes the value installed by that mount', () => {
+    const mountA = { tabId: 'a' }
+    const mountB = { tabId: 'b' }
+
+    const teardownA = installAgentCrdtPocGlobal(mountA)
+    expect(pocWindow.__agentCrdtPoc).toBe(mountA)
+
+    const teardownB = installAgentCrdtPocGlobal(mountB)
+    expect(pocWindow.__agentCrdtPoc).toBe(mountB)
+
+    teardownA()
+    expect(pocWindow.__agentCrdtPoc).toBe(mountB)
+
+    teardownB()
+    expect(pocWindow.__agentCrdtPoc).toBeUndefined()
+  })
+})

--- a/src/workbench/extensions/agent/crdt/agentCrdtPocGlobal.ts
+++ b/src/workbench/extensions/agent/crdt/agentCrdtPocGlobal.ts
@@ -1,0 +1,16 @@
+type AgentCrdtPocWindow = Window & {
+  __agentCrdtPoc?: object
+}
+
+export function installAgentCrdtPocGlobal<T extends object>(
+  value: T
+): () => void {
+  const pocWindow = window as AgentCrdtPocWindow
+  pocWindow.__agentCrdtPoc = value
+
+  return () => {
+    if (pocWindow.__agentCrdtPoc === value) {
+      delete pocWindow.__agentCrdtPoc
+    }
+  }
+}

--- a/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.ts
+++ b/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.ts
@@ -6,6 +6,7 @@ import { api } from '@/scripts/api'
 import { app } from '@/scripts/app'
 import { useAuthStore } from '@/stores/authStore'
 
+import { installAgentCrdtPocGlobal } from './agentCrdtPocGlobal'
 import { recordDevEvent } from './devPanelLog'
 import type { DocFrameTransport, DocOp } from './docFrameClient'
 import { DocFrameClient } from './docFrameClient'
@@ -355,7 +356,7 @@ export function useAgentCrdtFollower(workflowId: Ref<string | null>) {
     // "client.destroy() always runs" guarantee local and readable.
     try {
       clearSubscribeRetry()
-      delete (window as unknown as Record<string, unknown>).__agentCrdtPoc
+      removePocGlobal()
       api.removeEventListener('reconnected', onReconnected)
       api.removeEventListener('status', onSocketActivity)
       bridge.removeEventListener('doc_subscribed', onSubscribed)
@@ -474,8 +475,7 @@ export function useAgentCrdtFollower(workflowId: Ref<string | null>) {
     bridge.sendHumanOps(tabId, [op])
     return op
   }
-  const pocGlobal = window as unknown as Record<string, unknown>
-  pocGlobal.__agentCrdtPoc = {
+  const removePocGlobal = installAgentCrdtPocGlobal({
     addNode: pocAddNode,
     deleteNode: pocDeleteNode,
     // Bind a fresh tab to an existing doc without waiting for a turn ack
@@ -518,7 +518,7 @@ export function useAgentCrdtFollower(workflowId: Ref<string | null>) {
         lastFrameType: lastFrameType.value
       }
     }
-  }
+  })
   // ──────────────────────────────────────────────────────────────────────────
 
   const status = computed<AgentCrdtStatus>(() => ({


### PR DESCRIPTION
## Summary

Keep the PoC CRDT browser global owned by the newest follower mount during overlapping teardown.

## Changes

- **What**: Extract the PoC global install/remove lifecycle into a typed helper that removes only its own installed object.
- **Tests**: Cover mount A, replacement mount B, teardown A preserving B, and teardown B removing B.

## Review Focus

The helper intentionally preserves the existing PoC object shape and behavior; only ownership-safe teardown changes.

## Evidence

```text
$ pnpm test:unit src/workbench/extensions/agent/crdt/agentCrdtPocGlobal.test.ts
Test Files  1 passed (1)
Tests  1 passed (1)

$ pnpm exec oxfmt --check src/workbench/extensions/agent/crdt/agentCrdtPocGlobal.ts src/workbench/extensions/agent/crdt/agentCrdtPocGlobal.test.ts src/workbench/extensions/agent/crdt/useAgentCrdtFollower.ts
All matched files use the correct format.
Finished in 158ms on 3 files using 8 threads.

$ pnpm exec eslint src/workbench/extensions/agent/crdt/agentCrdtPocGlobal.ts src/workbench/extensions/agent/crdt/agentCrdtPocGlobal.test.ts src/workbench/extensions/agent/crdt/useAgentCrdtFollower.ts
Process exited with code 0.
No findings reported.

$ pnpm typecheck
vue-tsc --noEmit
Process exited with code 0.

$ git push -u origin christian-byrne/fec-owner-1-global-teardown
knip --cache
Process exited with code 0; branch pushed.
```

<!-- authored-by:agent lane-fec-owner-1 -->
