### PR TITLE
fix(agent): exit node selection on workflow switch

### DIFF
--- a/browser_tests/tests/agent/agentPanel.spec.ts
+++ b/browser_tests/tests/agent/agentPanel.spec.ts
@@ -287,6 +287,27 @@ test.describe('In-App Agent panel', { tag: '@cloud' }, () => {
       .toBeLessThanOrEqual(1)
   })
 
+  test('exits node selection when the active workflow changes', async ({
+    comfyPage
+  }) => {
+    const page = comfyPage.page
+    await page.getByRole('button', { name: OPEN_AGENT_LABEL }).click()
+
+    const panel = page.locator('#agent-panel-root')
+    await panel
+      .getByRole('button', { name: enMessages.agent.addToPrompt })
+      .click()
+    await page
+      .getByRole('menuitem', { name: enMessages.agent.addNodesFromGraph })
+      .click()
+    const selectionBanner = page.getByTestId('node-selection-mode-banner')
+    await expect(selectionBanner).toBeVisible()
+
+    await comfyPage.menu.topbar.newWorkflowButton.click()
+
+    await expect(selectionBanner).toHaveCount(0)
+  })
+
   test('edits and resubmits the last prompt after stopping its turn', async ({
     comfyPage,
     postedMessages,

--- a/src/workbench/extensions/agent/AgentPanelRoot.test.ts
+++ b/src/workbench/extensions/agent/AgentPanelRoot.test.ts
@@ -3405,6 +3405,22 @@ describe('AgentPanelRoot workflow binding', () => {
     await expectLaterClickCannotRestoreAccumulatedNodes(selection)
   })
 
+  it('ends node selection when the active workflow changes during a graph load', async () => {
+    makeTab()
+    mockMessagesEndpoint('wf-42')
+    const selection = await startVueNodeSelection()
+    useAgentNodeSelectionStore().beginWorkflowLoad()
+
+    hostStores.workflow.activeWorkflow = addTab('workflows/other.json')
+    await nextTick()
+
+    expect(useAgentNodeSelectionStore().isActive).toBe(false)
+    expect(selection.canvas.multi_select).toBe(false)
+    expect(selection.canvas.allow_dragnodes).toBe(true)
+    expect(selection.canvas.selectOnly).toBe(false)
+    await expectLaterClickCannotRestoreAccumulatedNodes(selection)
+  })
+
   it('keeps each workflow node selection separate after a graph load', async () => {
     makeTab()
     const selection = await startVueNodeSelection()

--- a/src/workbench/extensions/agent/AgentPanelRoot.test.ts
+++ b/src/workbench/extensions/agent/AgentPanelRoot.test.ts
@@ -3421,6 +3421,23 @@ describe('AgentPanelRoot workflow binding', () => {
     await expectLaterClickCannotRestoreAccumulatedNodes(selection)
   })
 
+  it('keeps node selection active when the active workflow is renamed', async () => {
+    makeTab()
+    mockMessagesEndpoint('wf-42')
+    const selection = await startVueNodeSelection()
+
+    const active = hostStores.workflow.activeWorkflow
+    if (!active) throw new Error('expected an active workflow')
+    active.path = 'workflows/renamed.json'
+    active.filename = 'renamed'
+    await nextTick()
+
+    expect(useAgentNodeSelectionStore().isActive).toBe(true)
+    expect(selection.canvas.multi_select).toBe(true)
+    expect(selection.canvas.allow_dragnodes).toBe(false)
+    expect(selection.canvas.selectOnly).toBe(true)
+  })
+
   it('keeps each workflow node selection separate after a graph load', async () => {
     makeTab()
     const selection = await startVueNodeSelection()

--- a/src/workbench/extensions/agent/AgentPanelRoot.vue
+++ b/src/workbench/extensions/agent/AgentPanelRoot.vue
@@ -735,7 +735,7 @@ watch(
   }
 )
 
-watch(() => workflowStore.activeWorkflow?.path, exitNodeSelectionMode)
+watch(() => workflowStore.activeWorkflow, exitNodeSelectionMode)
 
 watch(
   () => canvasStore.currentGraph,

--- a/src/workbench/extensions/agent/AgentPanelRoot.vue
+++ b/src/workbench/extensions/agent/AgentPanelRoot.vue
@@ -735,8 +735,10 @@ watch(
   }
 )
 
+watch(() => workflowStore.activeWorkflow?.path, exitNodeSelectionMode)
+
 watch(
-  [() => workflowStore.activeWorkflow?.path, () => canvasStore.currentGraph],
+  () => canvasStore.currentGraph,
   () => {
     if (!agentNodeSelectionStore.isLoadingWorkflow) exitNodeSelectionMode()
   }


### PR DESCRIPTION
## Summary

Exit node-selection mode whenever the active workflow changes, including while the replacement graph is loading.

## Changes

- **What**: Separate active-workflow identity handling from same-workflow graph restoration, and cover the workflow-swap race in component and browser tests.

## Review Focus

The active workflow watcher is intentionally unconditional; the graph watcher retains the load guard needed for restoring a selection within one workflow.

## Evidence

- Regression proof without the fix: focused component test failed at `isActive` (`expected true to be false`).
- `pnpm test:unit src/workbench/extensions/agent/AgentPanelRoot.test.ts` — 114 passed.
- `PLAYWRIGHT_TEST_URL=http://localhost:6258 PLAYWRIGHT_SETUP_API_URL=http://localhost:8188 PLAYWRIGHT_LOCAL=1 DISTRIBUTION=cloud DEV_SERVER_COMFYUI_URL=http://localhost:8188 pnpm exec start-server-and-test "pnpm exec vite --port 6258 --strictPort" http-get://localhost:6258 "pnpm exec playwright test browser_tests/tests/agent/agentPanel.spec.ts --project=cloud --timeout=60000 -g 'exits node selection when the active workflow changes'"` — 1 passed.
- `pnpm exec oxfmt --check` and targeted ESLint for all three changed files — passed.
- `pnpm typecheck` and `pnpm typecheck:browser` — passed.
- Pre-push `pnpm knip --cache` — passed.
- Dedupe: closed stack-reservation PR #16226 was inspected and remains superseded; no open main-based PR carries this fix.

<!-- authored-by:agent lane-qa-58 -->