### PR TITLE
fix(agent): keep CRDT dev panel within viewport

### DIFF
--- a/src/renderer/extensions/vueNodes/composables/processedWidgetRenderModel.ts
+++ b/src/renderer/extensions/vueNodes/composables/processedWidgetRenderModel.ts
@@ -459,7 +459,7 @@ export function computeProcessedWidgets({
   forceDisabled = false,
   isGraphReady,
   rootGraph,
-  ui,
+  ui
 }: ComputeProcessedWidgetsOptions): ProcessedWidget[] {
   if (!nodeData) return []
 
@@ -512,7 +512,7 @@ export function computeProcessedWidgets({
     missingModelStore,
     missingMediaStore,
     nodeDefStore,
-    ui,
+    ui
   }
 
   return Array.from(new Set(ids))

--- a/src/workbench/extensions/agent/crdt/CrdtDevPanel.responsive.test.ts
+++ b/src/workbench/extensions/agent/crdt/CrdtDevPanel.responsive.test.ts
@@ -1,0 +1,49 @@
+import { render, screen } from '@testing-library/vue'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import CrdtDevPanel from './CrdtDevPanel.vue'
+
+vi.mock('@/scripts/api', () => ({
+  api: { apiURL: () => '/api' }
+}))
+
+const status = {
+  enabled: true,
+  connected: false,
+  workflowId: null,
+  updatesApplied: 0,
+  lastFrameType: null
+}
+
+describe('CrdtDevPanel responsive sizing', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('caps the open panel to the viewport without changing its existing layout contracts', async () => {
+    render(CrdtDevPanel, { props: { status } })
+    const root = screen.getByTestId('crdt-dev-panel')
+    const chip = screen.getByTestId('crdt-dev-panel-chip')
+
+    expect(root).toHaveClass('right-3', 'bottom-3')
+    expect(chip).toHaveClass('rounded-full', 'px-3', 'py-1')
+
+    await userEvent.click(chip)
+
+    const panel = screen.getByTestId('crdt-dev-panel-open')
+    expect(panel).toHaveClass(
+      'w-[calc(100vw-1.5rem)]',
+      'max-w-[420px]',
+      'max-h-[70vh]',
+      'overflow-hidden'
+    )
+    expect(screen.getByTestId('crdt-dev-panel-content')).toHaveClass(
+      'overflow-y-auto'
+    )
+    expect(screen.getByTestId('crdt-dev-panel-log')).toHaveClass(
+      'max-h-56',
+      'overflow-y-auto'
+    )
+  })
+})

--- a/src/workbench/extensions/agent/crdt/CrdtDevPanel.vue
+++ b/src/workbench/extensions/agent/crdt/CrdtDevPanel.vue
@@ -207,7 +207,8 @@ function fmtTime(at: number): string {
 
     <div
       v-else
-      class="flex max-h-[70vh] w-[420px] flex-col overflow-hidden rounded-lg border border-border-default bg-base-background shadow-xl"
+      class="flex max-h-[70vh] w-[calc(100vw-1.5rem)] max-w-[420px] flex-col overflow-hidden rounded-lg border border-border-default bg-base-background shadow-xl"
+      data-testid="crdt-dev-panel-open"
     >
       <div
         class="flex items-center justify-between border-b border-border-default px-3 py-2"
@@ -222,7 +223,10 @@ function fmtTime(at: number): string {
         </button>
       </div>
 
-      <div class="flex-1 space-y-3 overflow-y-auto p-3">
+      <div
+        class="flex-1 space-y-3 overflow-y-auto p-3"
+        data-testid="crdt-dev-panel-content"
+      >
         <section>
           <div class="mb-1 font-bold">{{ S.sectionStatus }}</div>
           <table class="w-full">


### PR DESCRIPTION
- Small viewports retain 12 px panel edges.
- Desktop width remains capped at 420 px.
- Focused test, lint, formatting, and typecheck are green.

<details><summary>Full context for agent readers</summary>

Replaces the open CRDT dev panel's fixed width with `calc(100vw - 1.5rem)` plus the existing 420 px desktop cap. The 1.5 rem subtraction matches the existing `right-3` offset on both viewport edges.

The focused component test also locks the unchanged closed-chip styling, fixed edge offsets, 70vh height cap, and both scrolling regions.

## Evidence

- `$ NODE_OPTIONS=--no-experimental-webstorage pnpm test:unit src/workbench/extensions/agent/crdt/CrdtDevPanel.responsive.test.ts` — 1 test passed.
- `$ NODE_OPTIONS=--no-experimental-webstorage pnpm exec eslint src/workbench/extensions/agent/crdt/CrdtDevPanel.vue src/workbench/extensions/agent/crdt/CrdtDevPanel.responsive.test.ts` — passed.
- `$ pnpm exec oxfmt --check src/workbench/extensions/agent/crdt/CrdtDevPanel.vue src/workbench/extensions/agent/crdt/CrdtDevPanel.responsive.test.ts` — both files formatted.
- `$ NODE_OPTIONS=--no-experimental-webstorage pnpm typecheck` — passed.

Base: `nathaniel/agent-panel-v1` as required by the FEC lane.

</details>

<!-- authored-by:agent lane-fec-responsive-1 -->