### PR TITLE
fix(agent): reject malformed document frames

### DIFF
--- a/src/workbench/extensions/agent/crdt/__fixtures__/docFrameClient.ts
+++ b/src/workbench/extensions/agent/crdt/__fixtures__/docFrameClient.ts
@@ -1,0 +1,41 @@
+type ServerFrameType =
+  | 'doc_update'
+  | 'doc_subscribed'
+  | 'doc_ops_result'
+  | 'doc_reset'
+  | 'awareness'
+
+function serverFrame<T extends ServerFrameType>(
+  type: T,
+  data: Record<string, unknown>
+) {
+  return {
+    type,
+    data: { v: 1, workflow_id: 'wf-1', ...data }
+  }
+}
+
+export function docUpdateFrame(data: Record<string, unknown> = {}) {
+  return serverFrame('doc_update', { seq: 1, update_b64: 'AQ==', ...data })
+}
+
+export function docSubscribedFrame(data: Record<string, unknown> = {}) {
+  return serverFrame('doc_subscribed', { ok: true, seq: 1, ...data })
+}
+
+export function docOpsResultFrame(data: Record<string, unknown> = {}) {
+  return serverFrame('doc_ops_result', { ok: true, ...data })
+}
+
+export function docResetFrame(data: Record<string, unknown> = {}) {
+  return serverFrame('doc_reset', { seq: 1, actor: 'system:mint', ...data })
+}
+
+export function awarenessFrame(data: Record<string, unknown> = {}) {
+  return serverFrame('awareness', {
+    actor: 'human:user:tab-a',
+    state: {},
+    expires_at: 123,
+    ...data
+  })
+}

--- a/src/workbench/extensions/agent/crdt/__fixtures__/docFrameClient.ts
+++ b/src/workbench/extensions/agent/crdt/__fixtures__/docFrameClient.ts
@@ -5,33 +5,66 @@ type ServerFrameType =
   | 'doc_reset'
   | 'awareness'
 
-function serverFrame<T extends ServerFrameType>(
-  type: T,
-  data: Record<string, unknown>
-) {
+interface CommonWireData {
+  v?: unknown
+  workflow_id?: unknown
+}
+
+interface DocUpdateWireData extends CommonWireData {
+  seq?: unknown
+  update_b64?: unknown
+  actor?: unknown
+  op_ids?: unknown
+}
+
+interface DocSubscribedWireData extends CommonWireData {
+  ok?: unknown
+  seq?: unknown
+  code?: unknown
+  message?: unknown
+}
+
+interface DocOpsResultWireData extends DocSubscribedWireData {
+  applied?: unknown
+  skipped?: unknown
+  failed?: unknown
+}
+
+interface DocResetWireData extends CommonWireData {
+  seq?: unknown
+  actor?: unknown
+}
+
+interface AwarenessWireData extends CommonWireData {
+  actor?: unknown
+  state?: unknown
+  expires_at?: unknown
+}
+
+function serverFrame<T extends ServerFrameType>(type: T, data: CommonWireData) {
   return {
     type,
     data: { v: 1, workflow_id: 'wf-1', ...data }
   }
 }
 
-export function docUpdateFrame(data: Record<string, unknown> = {}) {
+export function docUpdateFrame(data: DocUpdateWireData = {}) {
   return serverFrame('doc_update', { seq: 1, update_b64: 'AQ==', ...data })
 }
 
-export function docSubscribedFrame(data: Record<string, unknown> = {}) {
+export function docSubscribedFrame(data: DocSubscribedWireData = {}) {
   return serverFrame('doc_subscribed', { ok: true, seq: 1, ...data })
 }
 
-export function docOpsResultFrame(data: Record<string, unknown> = {}) {
+export function docOpsResultFrame(data: DocOpsResultWireData = {}) {
   return serverFrame('doc_ops_result', { ok: true, ...data })
 }
 
-export function docResetFrame(data: Record<string, unknown> = {}) {
+export function docResetFrame(data: DocResetWireData = {}) {
   return serverFrame('doc_reset', { seq: 1, actor: 'system:mint', ...data })
 }
 
-export function awarenessFrame(data: Record<string, unknown> = {}) {
+export function awarenessFrame(data: AwarenessWireData = {}) {
   return serverFrame('awareness', {
     actor: 'human:user:tab-a',
     state: {},

--- a/src/workbench/extensions/agent/crdt/docFrameClient.arrays.test.ts
+++ b/src/workbench/extensions/agent/crdt/docFrameClient.arrays.test.ts
@@ -6,11 +6,13 @@ import {
 } from './__fixtures__/docFrameClient'
 import { parseServerDocFrame } from './docFrameClient'
 
-function resultFrame(data: Record<string, unknown>) {
+type DocOpsResultWireData = NonNullable<Parameters<typeof docOpsResultFrame>[0]>
+
+function resultFrame(data: DocOpsResultWireData) {
   return parseServerDocFrame(docOpsResultFrame(data))
 }
 
-const invalidResultFrames: [string, Record<string, unknown>][] = [
+const invalidResultFrames: [string, DocOpsResultWireData][] = [
   ['a non-string applied item', { ok: true, seq: 1, applied: ['op-1', 2] }],
   ['a non-string skipped item', { ok: true, seq: 1, skipped: ['op-1', 2] }],
   ['a non-array applied value', { ok: true, seq: 1, applied: 'op-1' }],

--- a/src/workbench/extensions/agent/crdt/docFrameClient.arrays.test.ts
+++ b/src/workbench/extensions/agent/crdt/docFrameClient.arrays.test.ts
@@ -1,0 +1,247 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  docOpsResultFrame,
+  docUpdateFrame
+} from './__fixtures__/docFrameClient'
+import { parseServerDocFrame } from './docFrameClient'
+
+function resultFrame(data: Record<string, unknown>) {
+  return parseServerDocFrame(docOpsResultFrame(data))
+}
+
+const invalidResultFrames: [string, Record<string, unknown>][] = [
+  ['a non-string applied item', { ok: true, seq: 1, applied: ['op-1', 2] }],
+  ['a non-string skipped item', { ok: true, seq: 1, skipped: ['op-1', 2] }],
+  ['a non-array applied value', { ok: true, seq: 1, applied: 'op-1' }],
+  ['an empty operation identity', { ok: true, applied: [''] }],
+  ['an operation identity with controls', { ok: true, applied: ['op\n1'] }],
+  ['an oversized operation identity', { ok: true, applied: ['x'.repeat(129)] }],
+  [
+    'too many operation identities',
+    { ok: true, applied: Array.from({ length: 257 }, () => 'x') }
+  ]
+]
+
+describe('document frame result arrays and acknowledgements', () => {
+  it('rejects a doc_update with a non-string op id', () => {
+    expect(
+      parseServerDocFrame(docUpdateFrame({ op_ids: ['op-1', 2] }))
+    ).toBeNull()
+  })
+
+  it('treats null doc_update op ids as absent', () => {
+    expect(parseServerDocFrame(docUpdateFrame({ op_ids: null }))).toEqual({
+      type: 'doc_update',
+      data: {
+        workflowId: 'wf-1',
+        seq: 1,
+        update: new Uint8Array([1])
+      }
+    })
+  })
+
+  it.for(invalidResultFrames)('rejects %s', ([_name, data]) => {
+    expect(resultFrame(data)).toBeNull()
+  })
+
+  it('omits malformed advisory result fields', () => {
+    expect(
+      resultFrame({
+        ok: false,
+        seq: '1',
+        applied: ['op-1'],
+        code: 1,
+        message: 'x'.repeat((8 << 10) + 1),
+        failed: {
+          op_id: 'op-2',
+          code: 'invalid_op',
+          message: 'invalid operation'
+        }
+      })
+    ).toEqual({
+      type: 'doc_ops_result',
+      data: {
+        workflowId: 'wf-1',
+        ok: false,
+        applied: ['op-1'],
+        skipped: []
+      }
+    })
+  })
+
+  it('accepts a failure without an op_id (relay omits it when unmapped)', () => {
+    expect(
+      resultFrame({
+        ok: false,
+        code: 'invalid_op',
+        message: 'invalid operation',
+        failed: { index: 0, code: 'invalid_op', message: 'invalid operation' }
+      })
+    ).toEqual({
+      type: 'doc_ops_result',
+      data: {
+        workflowId: 'wf-1',
+        ok: false,
+        applied: [],
+        skipped: [],
+        code: 'invalid_op',
+        message: 'invalid operation',
+        failed: { index: 0, code: 'invalid_op', message: 'invalid operation' }
+      }
+    })
+  })
+
+  it('accepts a successful acknowledgement without a sequence', () => {
+    expect(resultFrame({ ok: true })).toEqual({
+      type: 'doc_ops_result',
+      data: {
+        workflowId: 'wf-1',
+        ok: true,
+        applied: [],
+        skipped: []
+      }
+    })
+  })
+
+  it('accepts a failed acknowledgement without a code', () => {
+    expect(resultFrame({ ok: false, message: 'batch rejected' })).toEqual({
+      type: 'doc_ops_result',
+      data: {
+        workflowId: 'wf-1',
+        ok: false,
+        applied: [],
+        skipped: [],
+        message: 'batch rejected'
+      }
+    })
+  })
+
+  // The relay serialises applied/skipped with `omitempty`: rejections carry
+  // neither, a fully-applied batch carries no `skipped`, and an all-redelivery
+  // no-op carries no `applied`. Absent must read as empty, not malformed.
+  it('accepts a relay rejection that omits applied and skipped', () => {
+    expect(
+      resultFrame({ ok: false, code: 'invalid_frame', message: 'bad frame' })
+    ).toEqual({
+      type: 'doc_ops_result',
+      data: {
+        workflowId: 'wf-1',
+        ok: false,
+        applied: [],
+        skipped: [],
+        code: 'invalid_frame',
+        message: 'bad frame'
+      }
+    })
+  })
+
+  it('accepts a fully applied acknowledgement that omits skipped', () => {
+    expect(resultFrame({ ok: true, seq: 7, applied: ['op-1'] })).toEqual({
+      type: 'doc_ops_result',
+      data: {
+        workflowId: 'wf-1',
+        ok: true,
+        seq: 7,
+        applied: ['op-1'],
+        skipped: []
+      }
+    })
+  })
+
+  it('accepts an all-redelivery acknowledgement that omits applied', () => {
+    expect(resultFrame({ ok: true, seq: 7, skipped: ['op-1'] })).toEqual({
+      type: 'doc_ops_result',
+      data: {
+        workflowId: 'wf-1',
+        ok: true,
+        seq: 7,
+        applied: [],
+        skipped: ['op-1']
+      }
+    })
+  })
+
+  it('treats null result arrays as absent', () => {
+    expect(resultFrame({ ok: true, seq: 1, skipped: null })).toEqual({
+      type: 'doc_ops_result',
+      data: {
+        workflowId: 'wf-1',
+        ok: true,
+        seq: 1,
+        applied: [],
+        skipped: []
+      }
+    })
+  })
+
+  it('accepts strictly typed result arrays and failure data', () => {
+    expect(
+      resultFrame({
+        ok: false,
+        applied: ['op-1'],
+        skipped: ['op-2'],
+        code: 'invalid_op',
+        message: 'invalid operation',
+        failed: {
+          index: 2,
+          op_id: 'op-3',
+          code: 'invalid_op',
+          message: 'invalid operation'
+        }
+      })
+    ).toEqual({
+      type: 'doc_ops_result',
+      data: {
+        workflowId: 'wf-1',
+        ok: false,
+        applied: ['op-1'],
+        skipped: ['op-2'],
+        code: 'invalid_op',
+        message: 'invalid operation',
+        failed: {
+          index: 2,
+          op_id: 'op-3',
+          code: 'invalid_op',
+          message: 'invalid operation'
+        }
+      }
+    })
+  })
+
+  it('strips unrecognized failure properties', () => {
+    expect(
+      resultFrame({
+        ok: false,
+        failed: {
+          index: 0,
+          op_id: 'op-1',
+          code: 'invalid_op',
+          message: 'invalid operation',
+          private_context: 'must not escape the parser'
+        }
+      })
+    ).toMatchObject({
+      data: {
+        failed: {
+          index: 0,
+          op_id: 'op-1',
+          code: 'invalid_op',
+          message: 'invalid operation'
+        }
+      }
+    })
+    expect(
+      resultFrame({
+        ok: false,
+        failed: {
+          index: 0,
+          op_id: 'op-1',
+          code: 'invalid_op',
+          message: 'invalid operation',
+          private_context: 'must not escape the parser'
+        }
+      })?.data
+    ).not.toHaveProperty('failed.private_context')
+  })
+})

--- a/src/workbench/extensions/agent/crdt/docFrameClient.base64.test.ts
+++ b/src/workbench/extensions/agent/crdt/docFrameClient.base64.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+
+import { docUpdateFrame } from './__fixtures__/docFrameClient'
+import { parseServerDocFrame } from './docFrameClient'
+
+const invalidBase64: [string, string][] = [
+  ['non-base64 characters', 'YQ$='],
+  ['truncated input', 'YQ='],
+  ['empty input', ''],
+  ['non-canonical padding bits (RFC 4648 §3.5)', 'YR==']
+]
+
+describe('parseServerDocFrame doc_update base64 validation', () => {
+  it.for(invalidBase64)('rejects %s without throwing', ([_name, encoded]) => {
+    expect(() =>
+      parseServerDocFrame(docUpdateFrame({ update_b64: encoded }))
+    ).not.toThrow()
+    expect(
+      parseServerDocFrame(docUpdateFrame({ update_b64: encoded }))
+    ).toBeNull()
+  })
+
+  it('rejects encoded updates larger than 8 MiB without throwing', () => {
+    const encoded = `${'AAAA'.repeat((8 << 20) / 4)}AAAA`
+
+    expect(() =>
+      parseServerDocFrame(docUpdateFrame({ update_b64: encoded }))
+    ).not.toThrow()
+    expect(
+      parseServerDocFrame(docUpdateFrame({ update_b64: encoded }))
+    ).toBeNull()
+  })
+
+  it('accepts an encoded update at exactly 8 MiB', () => {
+    const encoded = 'AAAA'.repeat((8 << 20) / 4)
+
+    expect(
+      parseServerDocFrame(docUpdateFrame({ update_b64: encoded }))
+    ).not.toBeNull()
+  })
+
+  it('accepts canonical padding for the same byte', () => {
+    const parsed = parseServerDocFrame(docUpdateFrame({ update_b64: 'YQ==' }))
+    expect(parsed).not.toBeNull()
+    expect(parsed?.type).toBe('doc_update')
+  })
+})

--- a/src/workbench/extensions/agent/crdt/docFrameClient.grammar.test.ts
+++ b/src/workbench/extensions/agent/crdt/docFrameClient.grammar.test.ts
@@ -39,6 +39,9 @@ const invalidWorkflowIds: [string, string][] = [
 ]
 
 const invalidActors: [string, string][] = [
+  ['an empty actor', ''],
+  ['an actor with an extra segment', 'human:user:tab:extra'],
+  ['an actor with a missing segment', 'human:user'],
   ['an actor exceeding 256 encoded bytes', `human:${'u'.repeat(250)}:tab`],
   ['an actor outside the closed actor grammar', 'operator:user:tab']
 ]
@@ -56,6 +59,17 @@ describe('document frame identifier grammar', () => {
 
   it.for(validFrames)('accepts valid identifiers in $type', (frame) => {
     expect(parseServerDocFrame(frame)).not.toBeNull()
+  })
+
+  it('accepts identifiers at their inclusive encoded-byte limits', () => {
+    expect(
+      parseServerDocFrame(
+        awarenessFrame({
+          workflow_id: 'w'.repeat(128),
+          actor: `human:${'u'.repeat(248)}:t`
+        })
+      )
+    ).not.toBeNull()
   })
 
   it.for(['workflow/path', 'workflow\\path', 'workflow..id', '工作流-1'])(

--- a/src/workbench/extensions/agent/crdt/docFrameClient.grammar.test.ts
+++ b/src/workbench/extensions/agent/crdt/docFrameClient.grammar.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  awarenessFrame,
+  docOpsResultFrame,
+  docResetFrame,
+  docSubscribedFrame,
+  docUpdateFrame
+} from './__fixtures__/docFrameClient'
+import { parseServerDocFrame } from './docFrameClient'
+
+const validFrames = [
+  docUpdateFrame({
+    workflow_id: 'workflow_1-ABC',
+    actor: 'agent:thread-1:turn-1'
+  }),
+  docSubscribedFrame({ workflow_id: 'workflow_1-ABC' }),
+  docOpsResultFrame({ workflow_id: 'workflow_1-ABC', seq: 1 }),
+  docResetFrame({ workflow_id: 'workflow_1-ABC' }),
+  awarenessFrame({
+    workflow_id: 'workflow_1-ABC',
+    actor: 'human:user-1:tab-1'
+  })
+]
+
+const invalidWorkflowIds: [string, string][] = [
+  ['an empty workflow_id', ''],
+  ['a workflow_id containing whitespace', 'workflow invalid'],
+  ['a workflow_id exceeding 128 encoded bytes', 'w'.repeat(129)],
+  ['a workflow_id containing a colon', 'workflow:invalid'],
+  ['a workflow_id containing an asterisk', 'workflow*invalid'],
+  ['a workflow_id containing a question mark', 'workflow?invalid'],
+  ['a workflow_id containing an opening bracket', 'workflow[invalid'],
+  ['a workflow_id containing a closing bracket', 'workflow]invalid'],
+  ['a workflow_id containing a null byte', 'workflow\0invalid'],
+  ['a workflow_id containing a newline', 'workflow\ninvalid'],
+  ['a workflow_id containing a carriage return', 'workflow\rinvalid'],
+  ['a workflow_id containing a tab', 'workflow\tinvalid']
+]
+
+const invalidActors: [string, string][] = [
+  ['an actor exceeding 256 encoded bytes', `human:${'u'.repeat(250)}:tab`],
+  ['an actor outside the closed actor grammar', 'operator:user:tab']
+]
+
+describe('document frame identifier grammar', () => {
+  it.for(invalidWorkflowIds)('rejects %s', ([_name, workflowId]) => {
+    expect(
+      parseServerDocFrame(docSubscribedFrame({ workflow_id: workflowId }))
+    ).toBeNull()
+  })
+
+  it.for(invalidActors)('rejects %s', ([_name, actor]) => {
+    expect(parseServerDocFrame(awarenessFrame({ actor }))).toBeNull()
+  })
+
+  it.for(validFrames)('accepts valid identifiers in $type', (frame) => {
+    expect(parseServerDocFrame(frame)).not.toBeNull()
+  })
+
+  it.for(['workflow/path', 'workflow\\path', 'workflow..id', '工作流-1'])(
+    'accepts workflow_id %j allowed by cloud ValidWorkflowID',
+    (workflowId) => {
+      expect(
+        parseServerDocFrame(docSubscribedFrame({ workflow_id: workflowId }))
+      ).not.toBeNull()
+    }
+  )
+})

--- a/src/workbench/extensions/agent/crdt/docFrameClient.numeric.test.ts
+++ b/src/workbench/extensions/agent/crdt/docFrameClient.numeric.test.ts
@@ -8,7 +8,7 @@ const updateFrame = (seq: unknown) => ({
     v: 1,
     workflow_id: 'wf-1',
     seq,
-    update_b64: encodeBase64(new Uint8Array())
+    update_b64: encodeBase64(new Uint8Array([1]))
   }
 })
 
@@ -47,11 +47,6 @@ const docOpsResultFrame = (seq?: unknown) => ({
   }
 })
 
-const sequencedFrameTypes: ReadonlyArray<'doc_subscribed' | 'doc_reset'> = [
-  'doc_subscribed',
-  'doc_reset'
-]
-
 describe('doc frame numeric domains', () => {
   it.for([-1, 1.5, Number.POSITIVE_INFINITY, Number.NaN])(
     'rejects an invalid doc_update seq: %s',
@@ -67,25 +62,45 @@ describe('doc frame numeric domains', () => {
     }
   )
 
-  describe.for(sequencedFrameTypes)('%s seq', (type) => {
+  describe('doc_reset seq', () => {
     it.for([-1, 1.5, Number.POSITIVE_INFINITY, Number.NaN, '1'])(
       'rejects an invalid value: %s',
       (seq) => {
-        expect(parseServerDocFrame(sequencedFrame(type, seq))).toBeNull()
+        expect(parseServerDocFrame(sequencedFrame('doc_reset', seq))).toBeNull()
       }
     )
 
     it('accepts zero', () => {
-      expect(parseServerDocFrame(sequencedFrame(type, 0))?.data).toMatchObject({
-        seq: 0
-      })
+      expect(
+        parseServerDocFrame(sequencedFrame('doc_reset', 0))?.data
+      ).toMatchObject({ seq: 0 })
     })
   })
 
   it.for([-1, 1.5, Number.POSITIVE_INFINITY, Number.NaN, '1'])(
-    'rejects an invalid doc_ops_result seq: %s',
+    'omits an invalid doc_subscribed seq while preserving the ack: %s',
     (seq) => {
-      expect(parseServerDocFrame(docOpsResultFrame(seq))).toBeNull()
+      expect(
+        parseServerDocFrame(sequencedFrame('doc_subscribed', seq))
+      ).toEqual({
+        type: 'doc_subscribed',
+        data: { workflowId: 'wf-1', ok: true }
+      })
+    }
+  )
+
+  it.for([-1, 1.5, Number.POSITIVE_INFINITY, Number.NaN, '1'])(
+    'omits an invalid doc_ops_result seq while preserving the result: %s',
+    (seq) => {
+      expect(parseServerDocFrame(docOpsResultFrame(seq))).toEqual({
+        type: 'doc_ops_result',
+        data: {
+          workflowId: 'wf-1',
+          ok: true,
+          applied: [],
+          skipped: []
+        }
+      })
     }
   )
 

--- a/src/workbench/extensions/agent/crdt/docFrameClient.test.ts
+++ b/src/workbench/extensions/agent/crdt/docFrameClient.test.ts
@@ -229,7 +229,6 @@ describe('doc frame client', () => {
   })
 
   it('reports the first malformed inbound frame per type', () => {
-    vi.mocked(reportError).mockClear()
     const transport = new TestTransport()
     const client = new DocFrameClient(transport)
     const listener = vi.fn()

--- a/src/workbench/extensions/agent/crdt/docFrameClient.test.ts
+++ b/src/workbench/extensions/agent/crdt/docFrameClient.test.ts
@@ -1,5 +1,7 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import * as Y from 'yjs'
+
+import { reportError } from '@/platform/telemetry/reportError'
 
 import type { DocFrameTransport } from './docFrameClient'
 import {
@@ -9,6 +11,8 @@ import {
 } from './docFrameClient'
 import { FollowerDoc } from './followerDoc'
 import { LayoutFollowerBridge } from './layoutFollowerBridge'
+
+vi.mock('@/platform/telemetry/reportError', () => ({ reportError: vi.fn() }))
 
 class TestTransport extends EventTarget implements DocFrameTransport {
   readonly sent: string[] = []
@@ -42,13 +46,13 @@ describe('doc frame client', () => {
         workflow_id: 'wf-1',
         seq: 1,
         update_b64: encodeBase64(encoded),
-        actor: 'agent:turn-1',
-        op_ids: ['op-1', 42, 'op-2']
+        actor: 'agent:thread-1:turn-1',
+        op_ids: ['op-1', 'op-2']
       }
     })
     expect(frame?.type).toBe('doc_update')
     if (frame?.type !== 'doc_update') throw new Error('Expected doc_update')
-    expect(frame.data.actor).toBe('agent:turn-1')
+    expect(frame.data.actor).toBe('agent:thread-1:turn-1')
     expect(frame.data.opIds).toEqual(['op-1', 'op-2'])
 
     const follower = new FollowerDoc()
@@ -221,6 +225,37 @@ describe('doc frame client', () => {
         state: { cursor: [10, 20] },
         expiresAt: 123
       }
+    })
+  })
+
+  it('reports the first malformed inbound frame per type', () => {
+    vi.mocked(reportError).mockClear()
+    const transport = new TestTransport()
+    const client = new DocFrameClient(transport)
+    const listener = vi.fn()
+    client.addEventListener('doc_update', listener)
+
+    const malformed = {
+      v: 1,
+      workflow_id: 'wf-1',
+      seq: 1,
+      update_b64: 'not-base64'
+    }
+    transport.receive('doc_update', malformed)
+    transport.receive('doc_update', malformed)
+    transport.receive('awareness', {})
+
+    expect(listener).not.toHaveBeenCalled()
+    expect(reportError).toHaveBeenCalledTimes(2)
+    expect(reportError).toHaveBeenCalledWith(expect.any(Error), {
+      errorType: 'agent_crdt_invalid_server_frame',
+      tags: { frame_type: 'doc_update' },
+      level: 'warning'
+    })
+    expect(reportError).toHaveBeenCalledWith(expect.any(Error), {
+      errorType: 'agent_crdt_invalid_server_frame',
+      tags: { frame_type: 'awareness' },
+      level: 'warning'
     })
   })
 })

--- a/src/workbench/extensions/agent/crdt/docFrameClient.ts
+++ b/src/workbench/extensions/agent/crdt/docFrameClient.ts
@@ -296,7 +296,7 @@ export function parseServerDocFrame(value: unknown): ServerDocFrame | null {
         seq: data.seq,
         update,
         ...(actor !== undefined && { actor }),
-        ...(Array.isArray(data.op_ids) && {
+        ...(isStringArray(data.op_ids) && {
           opIds: data.op_ids
         })
       }

--- a/src/workbench/extensions/agent/crdt/docFrameClient.ts
+++ b/src/workbench/extensions/agent/crdt/docFrameClient.ts
@@ -1,7 +1,20 @@
 import type { Op } from '@comfyorg/comfy-multi-player'
 
+import { reportError } from '@/platform/telemetry/reportError'
+
 const DOC_PROTOCOL_VERSION = 1
-const MAX_AWARENESS_STATE_BYTES = 8 * 1024
+/** Keep this encoded-field cap aligned with cloud's `MaxDocFrameB64Len`. */
+const MAX_DOC_UPDATE_B64_LENGTH = 8 << 20
+const MAX_WORKFLOW_ID_LENGTH = 128
+const MAX_ACTOR_LENGTH = 256
+const MAX_AWARENESS_STATE_BYTES = 8 << 10
+const MAX_DOC_OPS_PER_FRAME = 256
+const MAX_OP_ID_LENGTH = 128
+const MAX_ERROR_CODE_LENGTH = 128
+const MAX_ERROR_MESSAGE_LENGTH = 8 << 10
+const BASE64_SINGLE_PADDING_END = /[AEIMQUYcgkosw048]=$/
+const BASE64_DOUBLE_PADDING_END = /[AQgw]==$/
+const utf8 = new TextEncoder()
 
 export interface DocOp {
   op_id: string
@@ -26,6 +39,14 @@ export interface DocSubscribed {
   message?: string
 }
 
+interface DocOpFailure {
+  index: number
+  /** Absent when the relay cannot map the failing index to an op id. */
+  op_id?: string
+  code: string
+  message: string
+}
+
 interface DocOpsResult {
   workflowId: string
   ok: boolean
@@ -34,11 +55,8 @@ interface DocOpsResult {
   skipped: string[]
   code?: string
   message?: string
-  /**
-   * PoC diagnostics: the batch's failure, forwarded verbatim. The wire type is
-   * a single object (`DocOpFailure {op_id, code, message}`), not an array.
-   */
-  failed?: unknown
+  /** Validated diagnostics for the first rejected operation in a batch. */
+  failed?: DocOpFailure
 }
 
 interface DocAwareness {
@@ -77,7 +95,7 @@ export interface DocFrameTransport {
    * awaiting its auth token — not an exception. Throwing here aborted the
    * `watch(..., { immediate: true })` subscribe (leaving the follower
    * permanently inert) and aborted `onBeforeUnmount` before `client.destroy()`
-   * (leaking listeners and a live adapter). Callers reconcile intent against
+   * (leaking listeners and a live projector). Callers reconcile intent against
    * the returned boolean instead.
    */
   send(frame: string): boolean
@@ -100,11 +118,28 @@ interface WireData {
   failed?: unknown
   state?: unknown
   expires_at?: unknown
+  index?: unknown
+  op_id?: unknown
 }
 
-function decodeBase64(value: string): Uint8Array {
-  const binary = atob(value)
-  return Uint8Array.from(binary, (character) => character.charCodeAt(0))
+function decodeBase64(value: string): Uint8Array | null {
+  if (value === '' || value.length % 4 !== 0) return null
+  const padding = value.endsWith('==') ? 2 : value.endsWith('=') ? 1 : 0
+  if (value.length > MAX_DOC_UPDATE_B64_LENGTH) return null
+
+  // `atob` is permissive about missing padding, so require canonical standard
+  // base64 before decoding the untrusted wire value.
+  if (!/^[A-Za-z0-9+/]*={0,2}$/.test(value)) return null
+
+  if (padding === 2 && !BASE64_DOUBLE_PADDING_END.test(value)) return null
+  if (padding === 1 && !BASE64_SINGLE_PADDING_END.test(value)) return null
+
+  try {
+    const binary = atob(value)
+    return Uint8Array.from(binary, (character) => character.charCodeAt(0))
+  } catch {
+    return null
+  }
 }
 
 export function encodeBase64(value: Uint8Array): string {
@@ -123,33 +158,111 @@ function parseRecord(value: unknown): Record<string, unknown> | null {
     : null
 }
 
-/** Unix seconds on the wire: a non-negative integer inside the safe range. */
-function isNonNegativeInteger(value: unknown): value is number {
+function isAbsent(value: unknown): value is null | undefined {
+  return value === null || value === undefined
+}
+
+function hasBoundedUtf8Length(value: string, maxBytes: number): boolean {
+  return value.length <= maxBytes && utf8.encode(value).length <= maxBytes
+}
+
+function isValidWorkflowId(value: string): boolean {
+  return (
+    value.length > 0 &&
+    hasBoundedUtf8Length(value, MAX_WORKFLOW_ID_LENGTH) &&
+    !/[\0\n\r\t :*?[\]]/.test(value)
+  )
+}
+
+function isValidActor(value: string): boolean {
+  if (
+    value.length === 0 ||
+    !hasBoundedUtf8Length(value, MAX_ACTOR_LENGTH) ||
+    /[\0\n\r\t ]/.test(value)
+  )
+    return false
+  if (value === 'system:mint') return true
+  const match = /^(?:agent|human):([^:]+):([^:]+)$/.exec(value)
+  return match !== null
+}
+
+/**
+ * Attribution on effect frames is advisory, unlike awareness's actor key.
+ * Preserve the load-bearing effect and omit attribution that fails grammar.
+ */
+function parseAdvisoryActor(value: unknown): string | undefined {
+  return typeof value === 'string' && isValidActor(value) ? value : undefined
+}
+
+function isSequence(value: unknown): value is number {
   return typeof value === 'number' && Number.isSafeInteger(value) && value >= 0
 }
 
-function parseAwarenessState(
-  value: unknown
-): Record<string, unknown> | undefined | null {
-  // The Go server's `State map[string]any` has `omitempty`, so it never
-  // emits `state: null` on the wire; nil/empty maps are omitted entirely,
-  // same as an absent field. Treat null the same as absent (no state) rather
-  // than rejecting the whole frame, so a value the server cannot actually
-  // send does not discard `actor`/`expires_at` too. A non-null, non-record
-  // shape (array, string, number) is still a malformed frame and rejected.
-  // discussion_r3911665011.
-  if (value === undefined || value === null) return undefined
-  const state = parseRecord(value)
-  if (state === null) return null
+function isValidOpId(value: unknown): value is string {
+  return (
+    typeof value === 'string' &&
+    value.length > 0 &&
+    hasBoundedUtf8Length(value, MAX_OP_ID_LENGTH) &&
+    !/[\0\n\r\t]/.test(value)
+  )
+}
 
-  // Defence in depth behind the server's identical cap. The counts are not
-  // byte-identical: Go's json.Marshal HTML-escapes `<`, `>` and `&`, so the
-  // server always counts >= this and is the stricter of the two.
+function isStringArray(value: unknown): value is string[] {
+  return (
+    Array.isArray(value) &&
+    value.length <= MAX_DOC_OPS_PER_FRAME &&
+    value.every(isValidOpId)
+  )
+}
+
+function parseBoundedString(
+  value: unknown,
+  maxBytes: number
+): string | undefined {
+  return typeof value === 'string' && hasBoundedUtf8Length(value, maxBytes)
+    ? value
+    : undefined
+}
+
+/**
+ * The relay serialises `applied`/`skipped` with `omitempty`, so an empty list
+ * arrives as an absent field. Absent means empty; present-but-malformed is a
+ * protocol violation.
+ */
+function parseOptionalStringArray(value: unknown): string[] | null {
+  if (isAbsent(value)) return []
+  return isStringArray(value) ? value : null
+}
+
+function parseDocOpFailure(value: unknown): DocOpFailure | null {
+  const failure = parseWireData(value)
+  if (
+    failure === null ||
+    !isSequence(failure.index) ||
+    (!isAbsent(failure.op_id) && !isValidOpId(failure.op_id)) ||
+    typeof failure.code !== 'string' ||
+    !hasBoundedUtf8Length(failure.code, MAX_ERROR_CODE_LENGTH) ||
+    typeof failure.message !== 'string' ||
+    !hasBoundedUtf8Length(failure.message, MAX_ERROR_MESSAGE_LENGTH)
+  )
+    return null
+
+  return {
+    index: failure.index,
+    ...(!isAbsent(failure.op_id) && { op_id: failure.op_id }),
+    code: failure.code,
+    message: failure.message
+  }
+}
+
+// Defence in depth behind the server's identical cap. The counts are not
+// byte-identical: Go's json.Marshal HTML-escapes `<`, `>` and `&`, so the
+// server always counts >= this and is the stricter of the two.
+function encodedJsonSize(value: Record<string, unknown>): number | null {
   try {
-    return new TextEncoder().encode(JSON.stringify(state)).byteLength <=
-      MAX_AWARENESS_STATE_BYTES
-      ? state
-      : null
+    const encoded = JSON.stringify(value)
+    if (encoded.length > MAX_AWARENESS_STATE_BYTES) return encoded.length
+    return utf8.encode(encoded).length
   } catch {
     return null
   }
@@ -162,103 +275,104 @@ export function parseServerDocFrame(value: unknown): ServerDocFrame | null {
   if (
     data === null ||
     data.v !== DOC_PROTOCOL_VERSION ||
-    typeof data.workflow_id !== 'string'
+    typeof data.workflow_id !== 'string' ||
+    !isValidWorkflowId(data.workflow_id)
   )
     return null
 
   if (
     frame.type === 'doc_update' &&
-    isNonNegativeInteger(data.seq) &&
+    isSequence(data.seq) &&
     typeof data.update_b64 === 'string'
   ) {
+    const update = decodeBase64(data.update_b64)
+    if (update === null) return null
+    if (!isAbsent(data.op_ids) && !isStringArray(data.op_ids)) return null
+    const actor = parseAdvisoryActor(data.actor)
     return {
       type: frame.type,
       data: {
         workflowId: data.workflow_id,
         seq: data.seq,
-        update: decodeBase64(data.update_b64),
-        ...(typeof data.actor === 'string' && { actor: data.actor }),
+        update,
+        ...(actor !== undefined && { actor }),
         ...(Array.isArray(data.op_ids) && {
-          opIds: data.op_ids.filter(
-            (item): item is string => typeof item === 'string'
-          )
+          opIds: data.op_ids
         })
       }
     }
   }
 
-  if (
-    frame.type === 'doc_subscribed' &&
-    typeof data.ok === 'boolean' &&
-    (data.seq === undefined || isNonNegativeInteger(data.seq))
-  ) {
+  if (frame.type === 'doc_subscribed' && typeof data.ok === 'boolean') {
+    const code = parseBoundedString(data.code, MAX_ERROR_CODE_LENGTH)
+    const message = parseBoundedString(data.message, MAX_ERROR_MESSAGE_LENGTH)
     return {
       type: frame.type,
       data: {
         workflowId: data.workflow_id,
         ok: data.ok,
-        ...(data.seq !== undefined && { seq: data.seq }),
-        ...(typeof data.code === 'string' && { code: data.code }),
-        ...(typeof data.message === 'string' && { message: data.message })
+        ...(isSequence(data.seq) && { seq: data.seq }),
+        ...(code !== undefined && { code }),
+        ...(message !== undefined && { message })
       }
     }
   }
 
-  if (
-    frame.type === 'doc_ops_result' &&
-    typeof data.ok === 'boolean' &&
-    (data.seq === undefined || isNonNegativeInteger(data.seq))
-  ) {
+  if (frame.type === 'doc_ops_result' && typeof data.ok === 'boolean') {
+    const applied = parseOptionalStringArray(data.applied)
+    const skipped = parseOptionalStringArray(data.skipped)
+    if (applied === null || skipped === null) return null
+    const code = parseBoundedString(data.code, MAX_ERROR_CODE_LENGTH)
+    const message = parseBoundedString(data.message, MAX_ERROR_MESSAGE_LENGTH)
+    let failed: DocOpFailure | undefined
+    if (!isAbsent(data.failed)) {
+      const parsedFailure = parseDocOpFailure(data.failed)
+      if (parsedFailure !== null) failed = parsedFailure
+    }
     return {
       type: frame.type,
       data: {
         workflowId: data.workflow_id,
         ok: data.ok,
-        applied: Array.isArray(data.applied)
-          ? data.applied.filter(
-              (item): item is string => typeof item === 'string'
-            )
-          : [],
-        skipped: Array.isArray(data.skipped)
-          ? data.skipped.filter(
-              (item): item is string => typeof item === 'string'
-            )
-          : [],
-        ...(isNonNegativeInteger(data.seq) && { seq: data.seq }),
-        ...(typeof data.code === 'string' && { code: data.code }),
-        ...(typeof data.message === 'string' && { message: data.message }),
-        // PoC diagnostics: surface the failure verbatim (object, not array).
-        ...(data.failed != null && { failed: data.failed })
+        applied,
+        skipped,
+        ...(isSequence(data.seq) && { seq: data.seq }),
+        ...(code !== undefined && { code }),
+        ...(message !== undefined && { message }),
+        ...(failed !== undefined && { failed })
       }
     }
   }
 
-  if (frame.type === 'doc_reset' && isNonNegativeInteger(data.seq)) {
+  if (frame.type === 'doc_reset' && isSequence(data.seq)) {
+    const actor = parseAdvisoryActor(data.actor)
     return {
       type: frame.type,
       data: {
         workflowId: data.workflow_id,
         seq: data.seq,
-        ...(typeof data.actor === 'string' && { actor: data.actor })
+        ...(actor !== undefined && { actor })
       }
     }
   }
 
   if (frame.type === 'awareness' && typeof data.actor === 'string') {
-    const state = parseAwarenessState(data.state)
-    if (
-      state === null ||
-      (data.expires_at !== undefined && !isNonNegativeInteger(data.expires_at))
-    )
-      return null
-
+    if (!isValidActor(data.actor)) return null
+    const state = parseRecord(data.state)
+    if (!isAbsent(data.state) && state === null) return null
+    if (state !== null) {
+      const stateSize = encodedJsonSize(state)
+      if (stateSize === null || stateSize > MAX_AWARENESS_STATE_BYTES)
+        return null
+    }
+    if (!isAbsent(data.expires_at) && !isSequence(data.expires_at)) return null
     return {
       type: frame.type,
       data: {
         workflowId: data.workflow_id,
         actor: data.actor,
-        ...(state !== undefined && { state }),
-        ...(data.expires_at !== undefined && {
+        ...(state !== null && { state }),
+        ...(isSequence(data.expires_at) && {
           expiresAt: data.expires_at
         })
       }
@@ -273,6 +387,7 @@ export class DocFrameClient extends EventTarget {
 
   constructor(private readonly transport: DocFrameTransport) {
     super()
+    const reportedTypes = new Set<string>()
     for (const type of [
       'doc_update',
       'doc_subscribed',
@@ -283,8 +398,17 @@ export class DocFrameClient extends EventTarget {
       const listener: EventListener = (event) => {
         if (!(event instanceof CustomEvent)) return
         const parsed = parseServerDocFrame({ type, data: event.detail })
-        if (parsed)
+        if (parsed) {
           this.dispatchEvent(new CustomEvent(type, { detail: parsed.data }))
+          return
+        }
+        if (reportedTypes.has(type)) return
+        reportedTypes.add(type)
+        reportError(new Error('Discarded invalid server document frame'), {
+          errorType: 'agent_crdt_invalid_server_frame',
+          tags: { frame_type: type },
+          level: 'warning'
+        })
       }
       this.listeners.set(type, listener)
       transport.addEventListener(type, listener)


### PR DESCRIPTION
Justification: Christian's bbc #388 ruling authorizes the old-head human approval after rebase onto current main, all required CI green, and preserved scope/TDD/invariants; verified at exact head `432e150f1baaad109d6df87812c87bc9ce4ff34d`.

## Summary

Fail closed at the frontend document-frame boundary so malformed relay data cannot throw, normalize partial wire state, or reach CRDT consumers. This retargets the approved work from the retired agent-panel base onto current `main` and carries only the remaining parser/test delta.

## Current scope

The feature is still required because the implemented V1 transport accepts untrusted WebSocket frames before dispatch. It serves `plans/technical-design.md` §§6.1–6.2 by preserving explicit `workflow_id` target routing and document-scoped CRDT state, without adding any pending lineage/replay behavior.

## Preserved invariants

- Canonical `workflow_id`, actor, operation-ID, numeric, array, and standard-base64 grammar matches the cloud frame validators.
- `update_b64` remains capped at exactly 8 MiB of encoded data.
- Malformed load-bearing fields reject the frame; malformed advisory diagnostics are omitted without discarding a valid ack/result ledger.
- Durable state-vector catch-up remains authoritative; sequence remains delivery/recovery metadata, not an operation conflict key.
- Existing reset, duplicate/stale-sequence, and offline-replay behavior is unchanged; DQ-24 remains pending.

## Evidence

Residual against current `main`: seven files, limited to `docFrameClient.ts`, its fixture, and six focused test files; no agent-panel UI or dead-base files remain.

- `pnpm exec vitest run src/workbench/extensions/agent/crdt/docFrameClient.test.ts src/workbench/extensions/agent/crdt/docFrameClient.base64.test.ts src/workbench/extensions/agent/crdt/docFrameClient.grammar.test.ts src/workbench/extensions/agent/crdt/docFrameClient.arrays.test.ts src/workbench/extensions/agent/crdt/docFrameClient.numeric.test.ts src/workbench/extensions/agent/crdt/followerSubscription.test.ts src/workbench/extensions/agent/crdt/useAgentCrdtFollower.test.ts` — 7 files, 125 tests passed.
- Scoped `oxfmt`, `eslint`, and `oxlint` — passed.
- `pnpm typecheck` — passed.
- `pnpm knip` — passed.
- `git diff --name-only origin/main..HEAD` — exactly the seven parser/test files above.
- Contract source: `docs/CRDT-CONTRACTS.md` implemented baseline and per-frame transport table.
- Design source: `plans/technical-design.md` §§6.1–6.2; CRDT invariants above remain unchanged.

<!-- authored-by:agent lane-prbase-9-0614 -->

## Review follow-up

- Rebased onto current `main` at `133ff87dce`; exact head: `432e150f1b`.
- Addressed all four CodeRabbit findings as one focused commit per thread; automated threads are resolved.
- Re-ran the seven focused files after the rebase: 167 tests passed.
- `pnpm typecheck`, `pnpm knip`, scoped Oxfmt, ESLint, and type-aware Oxlint passed.
