### PR TITLE
Stabilize merge queue browser tests

### DIFF
--- a/browser_tests/tests/interaction.spec.ts
+++ b/browser_tests/tests/interaction.spec.ts
@@ -1073,6 +1073,11 @@ test.describe('Viewport settings', () => {
     comfyPage,
     comfyMouse
   }) => {
+    const getViewport = async () => ({
+      scale: await comfyPage.canvasOps.getScale(),
+      offset: await comfyPage.canvasOps.getOffset()
+    })
+
     const changeTab = async (tab: Locator) => {
       await tab.click()
       await comfyPage.nextFrame()
@@ -1103,7 +1108,7 @@ test.describe('Viewport settings', () => {
     const tabA = comfyPage.menu.topbar.getWorkflowTab('Workflow A')
     await changeTab(tabA)
 
-    const screenshotA = (await comfyPage.canvas.screenshot()).toString('base64')
+    const viewportA = await getViewport()
 
     const tabB = comfyPage.menu.topbar.getWorkflowTab('Workflow B')
     await changeTab(tabB)
@@ -1114,22 +1119,17 @@ test.describe('Viewport settings', () => {
     }
 
     await comfyPage.nextFrame()
-    const screenshotB = (await comfyPage.canvas.screenshot()).toString('base64')
+    const viewportB = await getViewport()
 
-    // Ensure that the screenshots are different due to zoom level
-    expect(screenshotB).not.toBe(screenshotA)
+    expect(viewportB).not.toEqual(viewportA)
 
     // Go back to Workflow A
     await changeTab(tabA)
-    expect((await comfyPage.canvas.screenshot()).toString('base64')).toBe(
-      screenshotA
-    )
+    await expect.poll(getViewport).toEqual(viewportA)
 
     // And back to Workflow B
     await changeTab(tabB)
-    expect((await comfyPage.canvas.screenshot()).toString('base64')).toBe(
-      screenshotB
-    )
+    await expect.poll(getViewport).toEqual(viewportB)
   })
 })
 

--- a/browser_tests/tests/maskEditor.spec.ts
+++ b/browser_tests/tests/maskEditor.spec.ts
@@ -164,7 +164,8 @@ test.describe('Mask Editor', { tag: '@vue-nodes' }, () => {
 
       await comfyPage.expectScreenshot(
         dialog,
-        'mask-editor-dialog-from-context-menu.png'
+        'mask-editor-dialog-from-context-menu.png',
+        { maxDiffPixels: 25 }
       )
     }
   )


### PR DESCRIPTION
## Summary

- compare saved workflow viewport state directly instead of byte-for-byte canvas screenshots
- poll for viewport restoration after changing workflow tabs
- tolerate up to 25 raster-only pixels in the mask editor snapshot (observed failures: 13–16 pixels)

## Failure evidence

- mask editor snapshot: merge-queue run https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/33646387813
- viewport persistence: merge-queue run https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/33644187023

## Test plan

- `pnpm exec oxfmt --check browser_tests/tests/interaction.spec.ts browser_tests/tests/maskEditor.spec.ts`
- `pnpm exec eslint browser_tests/tests/interaction.spec.ts browser_tests/tests/maskEditor.spec.ts`
- `pnpm typecheck:browser`
- pre-commit `pnpm typecheck` and `pnpm typecheck:browser`
- Playwright collected the two affected tests across 20 repeats with `--list`; execution requires a local ComfyUI backend, which is unavailable on this worker
