### PR TITLE
feat(agent): resolve skipped duplicates on a covering projection (s3-opt-2)

### DIFF
--- a/src/workbench/extensions/agent/crdt/followerSubscription.test.ts
+++ b/src/workbench/extensions/agent/crdt/followerSubscription.test.ts
@@ -466,6 +466,40 @@ describe('FE-GAP-1 — a seq jump means a dropped frame and forces a resync', ()
     expect(transport.framesOfType('doc_subscribe')).toHaveLength(1)
   })
 
+  it('reports no applied seq between the ack and the catch-up frame (s3-opt-2)', () => {
+    const { transport, bridge } = wire()
+    transport.open = true
+    bridge.subscribe(WORKFLOW_ID)
+    transport.deliver('doc_subscribed', {
+      v: 1,
+      workflow_id: WORKFLOW_ID,
+      ok: true,
+      seq: 7
+    })
+
+    // The ack moves the outbound baseline but nothing has landed in the doc
+    // yet; a skipped-duplicate result gating on the applied seq must not see 7.
+    expect(bridge.lastSequence).toBe(7)
+    expect(bridge.lastAppliedSequence).toBeNull()
+
+    transport.deliver(
+      'doc_update',
+      docUpdateFrame(hostDocUpdate(), WORKFLOW_ID, 7)
+    )
+    expect(bridge.lastAppliedSequence).toBe(7)
+
+    // A resubscribe reopens the window: the ack is known again, applied is not.
+    bridge.resubscribe()
+    transport.deliver('doc_subscribed', {
+      v: 1,
+      workflow_id: WORKFLOW_ID,
+      ok: true,
+      seq: 9
+    })
+    expect(bridge.lastSequence).toBe(9)
+    expect(bridge.lastAppliedSequence).toBeNull()
+  })
+
   it('arms the gap detector from the ack: a first frame beyond ack+1 forces a resync', () => {
     const { transport, bridge, projected } = wire()
     transport.open = true

--- a/src/workbench/extensions/agent/crdt/layoutFollowerBridge.ts
+++ b/src/workbench/extensions/agent/crdt/layoutFollowerBridge.ts
@@ -130,6 +130,20 @@ export class LayoutFollowerBridge extends EventTarget {
     return this.lastSeq ?? this.ackSeq ?? 0
   }
 
+  /**
+   * The highest seq this follower has actually APPLIED for the current
+   * subscribe, or `null` while none has. Unlike {@link lastSequence} it never
+   * falls back to the ack seq: the ack only says where the host is, not what
+   * this doc holds, and the catch-up carrying that seq may still be in flight.
+   * Use this wherever "the follower has projected seq N" is the question
+   * (s3-opt-2 skipped-duplicate resolution); use {@link lastSequence} for the
+   * outbound `baseVersion`, where the ack fallback is what an already-current
+   * follower needs.
+   */
+  get lastAppliedSequence(): number | null {
+    return this.lastSeq
+  }
+
   /** The KA-11 read-gate failure that closed this bridge's read path, if any. */
   get lastSchemaError(): FollowerSchemaError | null {
     return this.schemaError

--- a/src/workbench/extensions/agent/crdt/opSender.ts
+++ b/src/workbench/extensions/agent/crdt/opSender.ts
@@ -28,6 +28,13 @@ export interface OpsResultView {
   ok: boolean
   applied: string[]
   skipped: string[]
+  /**
+   * The host's doc seq at the moment it acked the batch (`DocOpsResultFrame.seq`,
+   * omitted on the wire when zero). A `skipped` duplicate is already contained
+   * in doc state at this seq, so a follower that has projected `seq` can
+   * resolve the duplicate's pending shadow (s3-opt-2).
+   */
+  seq?: number
   /** Failed-batch diagnostics when the host provides them; `op_id` correlates an otherwise empty-list failure to its batch. */
   failure?: { op_id?: string }
 }

--- a/src/workbench/extensions/agent/crdt/pendingOpTracker.test.ts
+++ b/src/workbench/extensions/agent/crdt/pendingOpTracker.test.ts
@@ -153,14 +153,15 @@ describe('createPendingOpTracker', () => {
     expect(events).toHaveLength(1)
   })
 
-  it('a skipped op is already in the doc: retained until its effect, like applied', () => {
+  it('a skipped op whose effect frame does arrive still clears on that effect', () => {
     tracker.onBatchMinted(ops)
     tracker.onBatchTransmitted(ops)
     tracker.onBatchSettled(
       acknowledged(ops, {
         ok: true,
         applied: ['op-1', 'op-3'],
-        skipped: ['op-2']
+        skipped: ['op-2'],
+        seq: 50
       })
     )
     expect(tracker.entries().find((e) => e.opId === 'op-2')?.state).toBe(
@@ -169,6 +170,147 @@ describe('createPendingOpTracker', () => {
     tracker.onDocEffect(['op-1', 'op-2', 'op-3'])
     expect(tracker.entries()).toEqual([])
     expect(tracker.shadow.size()).toBe(0)
+    // Nothing left awaiting: a later projection has nothing to resolve.
+    tracker.onAuthoritativeState(50)
+    expect(events.map((e) => e.type)).toEqual(['skipped_awaiting', 'cleared'])
+  })
+
+  describe('s3-opt-2: skipped duplicates resolve on a covering projection, never on the ack', () => {
+    it('clears immediately when the projected seq already covers the ack seq', () => {
+      tracker = createPendingOpTracker({
+        currentSeq: () => 42,
+        onEvent: (event) => events.push(event)
+      })
+      tracker.onBatchMinted(ops)
+      tracker.onBatchTransmitted(ops)
+      tracker.onBatchSettled(
+        acknowledged(ops, {
+          ok: true,
+          applied: [],
+          skipped: ['op-1', 'op-2', 'op-3'],
+          seq: 42
+        })
+      )
+      // All-skipped batch: no broadcast will ever carry these ids, yet the
+      // projection is already at the ack seq, so nothing lingers.
+      expect(tracker.entries()).toEqual([])
+      expect(tracker.shadow.size()).toBe(0)
+      expect(events).toEqual([
+        { type: 'skipped_cleared', seq: 42, opIds: ['op-1', 'op-2', 'op-3'] }
+      ])
+    })
+
+    it('waits for a covering projection transition, never clearing on the ack', () => {
+      tracker.onBatchMinted(ops)
+      tracker.onBatchTransmitted(ops)
+      tracker.onBatchSettled(
+        acknowledged(ops, {
+          ok: true,
+          applied: ['op-1'],
+          skipped: ['op-2', 'op-3'],
+          seq: 45
+        })
+      )
+      expect(tracker.shadow.size()).toBe(3)
+      expect(events).toEqual([
+        { type: 'skipped_awaiting', seq: 45, opIds: ['op-2', 'op-3'] }
+      ])
+
+      // A projection below the ack seq proves nothing about the duplicate.
+      tracker.onAuthoritativeState(44)
+      expect(tracker.shadow.size()).toBe(3)
+      expect(events).toHaveLength(1)
+
+      tracker.onAuthoritativeState(45)
+      expect(tracker.shadow.isPending({ kind: 'node', nodeId: '2' })).toBe(
+        false
+      )
+      expect(tracker.shadow.isPending({ kind: 'node', nodeId: '3' })).toBe(
+        false
+      )
+      // The applied op still waits for its own effect (KEEP-ALIVE #9).
+      expect(tracker.entries().map((e) => e.opId)).toEqual(['op-1'])
+      expect(events[1]).toEqual({
+        type: 'skipped_cleared',
+        seq: 45,
+        opIds: ['op-2', 'op-3']
+      })
+    })
+
+    it('treats a seq-less ack as satisfied by any later authoritative transition', () => {
+      tracker.onBatchMinted(ops)
+      tracker.onBatchTransmitted(ops)
+      tracker.onBatchSettled(
+        acknowledged(ops, { ok: true, applied: [], skipped: ['op-1'] })
+      )
+      expect(events).toEqual([
+        { type: 'skipped_awaiting', seq: null, opIds: ['op-1'] }
+      ])
+      tracker.onAuthoritativeState(null)
+      expect(tracker.entries().map((e) => e.opId)).toEqual(['op-2', 'op-3'])
+      expect(events[1]).toEqual({
+        type: 'skipped_cleared',
+        seq: null,
+        opIds: ['op-1']
+      })
+    })
+
+    it('does not let a seq-less transition satisfy a numbered requirement', () => {
+      tracker.onBatchMinted(ops)
+      tracker.onBatchTransmitted(ops)
+      tracker.onBatchSettled(
+        acknowledged(ops, {
+          ok: true,
+          applied: [],
+          skipped: ['op-1'],
+          seq: 45
+        })
+      )
+      tracker.onAuthoritativeState(null)
+      expect(tracker.entries().find((e) => e.opId === 'op-1')?.state).toBe(
+        'skipped'
+      )
+      tracker.onAuthoritativeState(46)
+      expect(tracker.entries().find((e) => e.opId === 'op-1')).toBeUndefined()
+    })
+
+    it('a redelivered ack cannot double-resolve or re-park an already cleared id', () => {
+      tracker.onBatchMinted(ops)
+      tracker.onBatchTransmitted(ops)
+      const ack = acknowledged(ops, {
+        ok: true,
+        applied: [],
+        skipped: ['op-1', 'op-2', 'op-3'],
+        seq: 45
+      })
+      tracker.onBatchSettled(ack)
+      tracker.onAuthoritativeState(45)
+      expect(tracker.entries()).toEqual([])
+      const seen = events.length
+
+      tracker.onBatchSettled(ack)
+      tracker.onAuthoritativeState(46)
+      expect(tracker.entries()).toEqual([])
+      expect(tracker.shadow.size()).toBe(0)
+      expect(events).toHaveLength(seen)
+    })
+
+    it('reset drops awaiting bookkeeping so a stale ack cannot clear after doc_reset', () => {
+      tracker.onBatchMinted(ops)
+      tracker.onBatchTransmitted(ops)
+      tracker.onBatchSettled(
+        acknowledged(ops, {
+          ok: true,
+          applied: [],
+          skipped: ['op-1'],
+          seq: 45
+        })
+      )
+      tracker.reset()
+      const seen = events.length
+      tracker.onAuthoritativeState(45)
+      expect(events).toHaveLength(seen)
+    })
   })
 
   it('reverts the failed op and everything the host never reached; keeps the applied prefix', () => {

--- a/src/workbench/extensions/agent/crdt/pendingOpTracker.ts
+++ b/src/workbench/extensions/agent/crdt/pendingOpTracker.ts
@@ -15,8 +15,18 @@
  *   drew silence (`unacknowledged`). The shadow is reverted and the entry
  *   dropped, so the optimistic styling disappears instead of lingering.
  *
- * `skipped` (op id already present host-side) is treated like `applied`: an
- * effect already exists in the doc and its update clears the entry.
+ * `skipped` (op id already present host-side) is a duplicate: its effect is
+ * already in doc state, and a fully duplicate batch produces no new
+ * broadcast, so waiting for a `doc_update` carrying the id could wait
+ * forever. It is still never cleared on the ack itself (s3-opt-2): removal
+ * happens on an authoritative PROJECTION transition. A skipped entry clears
+ * when the follower has projected doc state at or beyond the ack's `seq` —
+ * immediately at ack time when the projected seq already covers it,
+ * otherwise on the first later projected `doc_update` whose seq covers it.
+ * When the ack carries no seq, the next projected authoritative transition
+ * of any seq clears it (the duplicate pre-existed the ack, so any later
+ * authoritative state contains it). A `doc_update` that happens to carry the
+ * id still clears it through the EFFECT path first.
  *
  * Nothing here touches the canvas; it only maintains the two data
  * structures and reports what it did so a renderer/dev-panel can react.
@@ -39,11 +49,22 @@ type PendingOpRevertReason =
 export type PendingOpTrackerEvent =
   | { type: 'reverted'; reason: PendingOpRevertReason; opIds: string[] }
   | { type: 'cleared'; opIds: string[] }
+  /** Skipped duplicates resolved by a projection at/after their ack seq. */
+  | { type: 'skipped_cleared'; seq: number | null; opIds: string[] }
+  /** Skipped duplicates parked until a projection covers their ack seq. */
+  | { type: 'skipped_awaiting'; seq: number | null; opIds: string[] }
   | { type: 'reset'; opIds: string[] }
 
 export interface PendingOpTrackerDeps {
   ledger?: PendingOpLedger<Op>
   shadow?: PendingOpShadowSurface
+  /**
+   * The highest doc seq the follower has PROJECTED (applied to the canvas),
+   * read at ack time to decide whether a skipped duplicate can resolve now.
+   * Defaults to 0: never covers a numbered ack seq, so skipped entries wait
+   * for {@link PendingOpTracker.onAuthoritativeState}.
+   */
+  currentSeq?(): number
   /** Observability tap; never throws back into the tracker. */
   onEvent?(event: PendingOpTrackerEvent): void
 }
@@ -57,6 +78,12 @@ export interface PendingOpTracker {
   onBatchSettled(outcome: BatchOutcome): void
   /** A `doc_update` carried these op ids: their effect is now in the doc. */
   onDocEffect(opIds: readonly string[]): void
+  /**
+   * The follower projected authoritative doc state at `seq` (null when the
+   * update carried no usable seq). Resolves every awaiting skipped duplicate
+   * whose ack seq is covered — this, not the ack, is its removal trigger.
+   */
+  onAuthoritativeState(seq: number | null): void
   /** Doc lineage broke (reset / replacement / teardown): nothing is pending. */
   reset(): void
   entries(): PendingOpEntry<Op>[]
@@ -97,23 +124,47 @@ export function createPendingOpTracker(
 ): PendingOpTracker {
   const ledger = deps.ledger ?? createPendingOpLedger<Op>()
   const shadow = deps.shadow ?? createPendingOpShadowSurface()
+  const currentSeq = deps.currentSeq ?? (() => 0)
   // Per-op send count, mirrored from the sender's transmit hook so a result
   // for an earlier attempt of a resent batch is rejected by the ledger.
   const attempts = new Map<string, number>()
+  // Skipped op id → the ack seq the follower must project before it resolves
+  // (null: the ack carried no seq; any later projection resolves it).
+  const awaitingSkipped = new Map<string, number | null>()
 
   function emit(event: PendingOpTrackerEvent): void {
     deps.onEvent?.(event)
   }
 
+  function drop(opId: string): PendingOpEntry<Op> | undefined {
+    attempts.delete(opId)
+    awaitingSkipped.delete(opId)
+    return ledger.take(opId)
+  }
+
   function revert(opIds: readonly string[], reason: PendingOpRevertReason) {
     const reverted: string[] = []
     for (const opId of opIds) {
-      const entry = ledger.take(opId)
+      const entry = drop(opId)
       shadow.revert(opId)
-      attempts.delete(opId)
       if (entry) reverted.push(opId)
     }
     if (reverted.length > 0) emit({ type: 'reverted', reason, opIds: reverted })
+  }
+
+  /**
+   * `clear`, not `revert`: authoritative state already contains the
+   * duplicate's outcome, so pending styling RESOLVES rather than rolls back.
+   */
+  function clearSkipped(opIds: readonly string[], seq: number | null) {
+    const cleared: string[] = []
+    for (const opId of opIds) {
+      const entry = drop(opId)
+      shadow.clear(opId)
+      if (entry) cleared.push(opId)
+    }
+    if (cleared.length > 0)
+      emit({ type: 'skipped_cleared', seq, opIds: cleared })
   }
 
   return {
@@ -150,6 +201,22 @@ export function createPendingOpTracker(
       })
       revert(summary.failed, 'failed')
       revert(summary.unprocessed, 'unprocessed')
+      if (summary.skipped.length > 0) {
+        const ackSeq = result.seq ?? null
+        if (ackSeq !== null && currentSeq() >= ackSeq) {
+          // The projection already folded doc state at/after the ack, so the
+          // duplicate's authoritative outcome is on screen NOW. This is a
+          // projection-based transition, not a clear-on-ack.
+          clearSkipped(summary.skipped, ackSeq)
+        } else {
+          for (const opId of summary.skipped) awaitingSkipped.set(opId, ackSeq)
+          emit({
+            type: 'skipped_awaiting',
+            seq: ackSeq,
+            opIds: summary.skipped
+          })
+        }
+      }
       if (result.ok) return
       // An anonymous `ok:false` (no lists, no failed op id) names nothing, so
       // the ledger leaves the batch in flight; nothing will ever clear it.
@@ -164,14 +231,29 @@ export function createPendingOpTracker(
       for (const entry of cleared) {
         shadow.clear(entry.opId)
         attempts.delete(entry.opId)
+        awaitingSkipped.delete(entry.opId)
       }
       if (cleared.length > 0)
         emit({ type: 'cleared', opIds: cleared.map((entry) => entry.opId) })
+    },
+    onAuthoritativeState(seq) {
+      if (awaitingSkipped.size === 0) return
+      const covered: string[] = []
+      for (const [opId, requiredSeq] of awaitingSkipped) {
+        // A null requirement (ack carried no seq) is satisfied by ANY later
+        // authoritative transition; a null seq (update carried no usable seq)
+        // still proves a transition happened, which is all a null requirement
+        // needs — but cannot prove coverage of a numbered requirement.
+        if (requiredSeq === null || (seq !== null && seq >= requiredSeq))
+          covered.push(opId)
+      }
+      clearSkipped(covered, seq)
     },
     reset() {
       const dropped = ledger.reset()
       shadow.clearAll()
       attempts.clear()
+      awaitingSkipped.clear()
       if (dropped.length > 0)
         emit({ type: 'reset', opIds: dropped.map((entry) => entry.opId) })
     },

--- a/src/workbench/extensions/agent/crdt/pendingOpTracker.ts
+++ b/src/workbench/extensions/agent/crdt/pendingOpTracker.ts
@@ -15,17 +15,22 @@
  *   drew silence (`unacknowledged`). The shadow is reverted and the entry
  *   dropped, so the optimistic styling disappears instead of lingering.
  *
- * `skipped` (op id already present host-side) is a duplicate: its effect is
- * already in doc state, and a fully duplicate batch produces no new
- * broadcast, so waiting for a `doc_update` carrying the id could wait
- * forever. It is still never cleared on the ack itself (s3-opt-2): removal
- * happens on an authoritative PROJECTION transition. A skipped entry clears
- * when the follower has projected doc state at or beyond the ack's `seq` —
+ * `skipped` covers two host outcomes that share one property: the op will
+ * never produce an effect frame of its own. Either the op id already existed
+ * host-side (a re-delivery; a fully duplicate batch produces no broadcast at
+ * all) or the applier dropped it under last-writer-wins, in which case its
+ * effect is specifically NOT in the doc — a competing write is. What settles
+ * a skipped entry is therefore not "its effect landed" but "the doc state at
+ * or beyond the ack's `seq` is authoritative for whatever it touched", so
+ * it must never be re-shown as the op's own optimistic value. It is still
+ * never cleared on the ack itself (s3-opt-2): removal happens on an
+ * authoritative PROJECTION transition. A skipped entry clears when the
+ * follower has projected doc state at or beyond the ack's `seq` —
  * immediately at ack time when the projected seq already covers it,
  * otherwise on the first later projected `doc_update` whose seq covers it.
  * When the ack carries no seq, the next projected authoritative transition
- * of any seq clears it (the duplicate pre-existed the ack, so any later
- * authoritative state contains it). A `doc_update` that happens to carry the
+ * of any seq clears it (the outcome pre-existed the ack, so any later
+ * authoritative state reflects it). A `doc_update` that happens to carry the
  * id still clears it through the EFFECT path first.
  *
  * Nothing here touches the canvas; it only maintains the two data
@@ -82,6 +87,10 @@ export interface PendingOpTracker {
    * The follower projected authoritative doc state at `seq` (null when the
    * update carried no usable seq). Resolves every awaiting skipped duplicate
    * whose ack seq is covered — this, not the ack, is its removal trigger.
+   * `DocUpdate.seq` is a required number, so the follower never passes null
+   * today; the null contract is kept for callers whose transition has no
+   * seq, where it can satisfy an unnumbered requirement but never a numbered
+   * one.
    */
   onAuthoritativeState(seq: number | null): void
   /** Doc lineage broke (reset / replacement / teardown): nothing is pending. */

--- a/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.test.ts
+++ b/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.test.ts
@@ -25,6 +25,7 @@ const bridgeState = vi.hoisted(() => {
     sendHumanOps = vi.fn()
     subscribedWorkflowId: string | null = 'wf-1'
     lastSequence = 41
+    lastAppliedSequence: number | null = null
     follower = {
       updatesApplied: 0,
       doc: {
@@ -476,6 +477,44 @@ describe('useAgentCrdtFollower', () => {
       expect(follower.pendingShadows.isPending(node1)).toBe(true)
 
       dispatchFrame('doc_update', { workflowId: 'wf-1', seq: 43 })
+      expect(follower.pendingShadows.isPending(node1)).toBe(false)
+      unmount()
+    })
+
+    it('keeps a skipped shadow through the subscribe-ack window until a frame is applied', () => {
+      // After (re)subscribe the bridge knows the host seq from the ack
+      // (lastSequence = 41) but has applied nothing yet; the canvas still shows
+      // pre-op state. A skipped result at that seq must not clear the shadow.
+      const { unmount, follower, sentOpIds } = mountWithSender()
+      expect(bridge().lastAppliedSequence).toBeNull()
+      follower.enqueueHumanOperations([deleteNode1])
+      const [opId] = sentOpIds()
+
+      dispatchFrame('doc_ops_result', {
+        ok: true,
+        applied: [],
+        skipped: [opId],
+        seq: 41
+      })
+      expect(follower.pendingShadows.isPending(node1)).toBe(true)
+
+      dispatchFrame('doc_update', { workflowId: 'wf-1', seq: 41 })
+      expect(follower.pendingShadows.isPending(node1)).toBe(false)
+      unmount()
+    })
+
+    it('clears a skipped shadow at once when an applied frame already covers its seq', () => {
+      const { unmount, follower, sentOpIds } = mountWithSender()
+      bridge().lastAppliedSequence = 43
+      follower.enqueueHumanOperations([deleteNode1])
+      const [opId] = sentOpIds()
+
+      dispatchFrame('doc_ops_result', {
+        ok: true,
+        applied: [],
+        skipped: [opId],
+        seq: 43
+      })
       expect(follower.pendingShadows.isPending(node1)).toBe(false)
       unmount()
     })

--- a/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.test.ts
+++ b/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.test.ts
@@ -458,6 +458,28 @@ describe('useAgentCrdtFollower', () => {
       unmount()
     })
 
+    it('clears a skipped-duplicate shadow once a projection covers the ack seq (s3-opt-2)', () => {
+      const { unmount, follower, sentOpIds } = mountWithSender()
+      follower.enqueueHumanOperations([deleteNode1])
+      const [opId] = sentOpIds()
+
+      // Host already had this op; no doc_update will ever carry its id.
+      dispatchFrame('doc_ops_result', {
+        ok: true,
+        applied: [],
+        skipped: [opId],
+        seq: 43
+      })
+      expect(follower.pendingShadows.isPending(node1)).toBe(true)
+
+      dispatchFrame('doc_update', { workflowId: 'wf-1', seq: 42 })
+      expect(follower.pendingShadows.isPending(node1)).toBe(true)
+
+      dispatchFrame('doc_update', { workflowId: 'wf-1', seq: 43 })
+      expect(follower.pendingShadows.isPending(node1)).toBe(false)
+      unmount()
+    })
+
     it('reverts the shadow when the host rejects the op', () => {
       const { unmount, follower, sentOpIds } = mountWithSender()
       follower.enqueueHumanOperations([deleteNode1])

--- a/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.ts
+++ b/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.ts
@@ -128,9 +128,13 @@ export function useAgentCrdtFollower(
   // leaves only on its authoritative doc_update effect, on revert, or — for
   // a skipped duplicate — on a projection at/after its ack seq (s3-opt-2).
   const pendingOps = createPendingOpTracker({
-    // The last applied update's seq (the subscribe ack's seq before any
-    // update lands for the current subscribe).
-    currentSeq: () => bridge.lastSequence,
+    // Applied seq only, never the ack fallback: between doc_subscribed(seq=N)
+    // and the catch-up doc_update(seq=N) the canvas still shows pre-subscribe
+    // state, so a skipped result must park there rather than clear on the ack.
+    // An already-current follower (ack, no catch-up) therefore parks a skipped
+    // id until its next applied frame; a still-pending skipped entry means the
+    // effect frame never reached this follower, so one is coming.
+    currentSeq: () => bridge.lastAppliedSequence ?? 0,
     onEvent: (event) => recordDevEvent('pending_ops', event)
   })
   const sender = createOpSender({

--- a/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.ts
+++ b/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.ts
@@ -125,8 +125,12 @@ export function useAgentCrdtFollower(
   const adapter = new EcsFollowerAdapter(graphMutations)
   const tabId = createUuidv4()
   // s3-opt-6: every minted human op is registered here before it flies and
-  // leaves only on its authoritative doc_update effect or on revert.
+  // leaves only on its authoritative doc_update effect, on revert, or — for
+  // a skipped duplicate — on a projection at/after its ack seq (s3-opt-2).
   const pendingOps = createPendingOpTracker({
+    // The last applied update's seq (the subscribe ack's seq before any
+    // update lands for the current subscribe).
+    currentSeq: () => bridge.lastSequence,
     onEvent: (event) => recordDevEvent('pending_ops', event)
   })
   const sender = createOpSender({
@@ -139,6 +143,7 @@ export function useAgentCrdtFollower(
           ok: detail.ok,
           applied: detail.applied,
           skipped: detail.skipped,
+          ...(typeof detail.seq === 'number' ? { seq: detail.seq } : {}),
           ...(detail.failed && typeof detail.failed === 'object'
             ? { failure: detail.failed as OpsResultView['failure'] }
             : {})
@@ -270,6 +275,9 @@ export function useAgentCrdtFollower(
     adapter.applyFrame(update)
     // KEEP-ALIVE #9: the doc_update effect, not the ack, retires a shadow.
     if (update.opIds) pendingOps.onDocEffect(update.opIds)
+    // s3-opt-2: a projected transition at/after an ack seq resolves the
+    // skipped duplicates that ack named (their effect never re-broadcasts).
+    pendingOps.onAuthoritativeState(update.seq)
     recordDevEvent('doc_update', {
       workflowId: update.workflowId,
       seq: update.seq,


### PR DESCRIPTION
- Skipped-duplicate shadows now clear on a covering projection (host `doc_ops_result.seq` ≤ projected `doc_update.seq`), never on the ack itself; failed/unprocessed rollback from #16309 is unchanged
- Re-expresses the skipped policy of #16332 (base branch `nathaniel/agent-panel-v1`, now closed lineage) onto the main-based tracker; #16332 stays as source history
- Green: 252/252 crdt suite (7 new tests), typecheck, oxlint/eslint, oxfmt, knip

<details><summary>Full context for agent readers</summary>

## What

The s3-opt-6 tracker (#16309) already handles `applied` (keep until effect), `failed` (revert), and unprocessed suffix (revert). The one outcome it could not finish was `skipped`: the host had already applied that op on a previous delivery, so **no later `doc_update` will ever carry its op id** and the shadow lingered until reset. This PR closes that gap.

**Stack:** cut from `fix/s3opt6-dispatch-wiring` (#16309, head `d49dcaa1ba`). Review only the top commit, `678fc7e177`.

## Policy

| Situation | Behavior |
|---|---|
| ack `skipped:[id]` with `seq`, and `bridge.lastSequence >= seq` | clear shadow + take ledger entry immediately (authoritative state already on screen) |
| ack `skipped:[id]` with `seq`, projection behind | park id keyed by `seq`; clear on the first applied `doc_update` whose `seq >= ack.seq` |
| ack `skipped:[id]` without `seq` | park with `null`; cleared by the next applied `doc_update` |
| effect frame carrying the id arrives first | `onDocEffect` still wins; the parked entry is dropped |
| `doc_reset` / unmount | parked ids dropped (seqs belong to the dead lineage) |
| redelivered ack | no double-resolve; ledger `take` is idempotent |

## Files

- `opSender.ts`: `OpsResultView.seq?: number` (mirrors host `DocOpsResultFrame.Seq` in `cloud/common/websocket/messages/crdt.go`; FE `docFrameClient.ts` already parsed it).
- `pendingOpTracker.ts`: `currentSeq()` dep, `onAuthoritativeState(seq)`, `awaitingSkipped` map, `drop()`/`clearSkipped()` helpers; dev events `skipped_awaiting` / `skipped_cleared`.
- `useAgentCrdtFollower.ts`: passes `currentSeq: () => bridge.lastSequence`, maps `detail.seq` into the ack view, calls `onAuthoritativeState(update.seq)` after each applied update.
- Tests: `pendingOpTracker.test.ts` (`describe('s3-opt-2: ...')`, 6 tests + reworked skipped test), `useAgentCrdtFollower.test.ts` (1 follower-level test through the real frame dispatch path).

## Re-expression of #16332

Source commit `9fdd7bb544` (`opsResultReconciler.ts`) implemented this as a separate pure reconciler over `sentBatches()`. #16309 later folded the reconciliation into `PendingOpTracker`, so the reconciler module would duplicate it; this PR instead adds only the missing skipped→covering-seq gate to the tracker. The policy table in #16332 is preserved verbatim for `skipped`; the other rows were already landed by #16309.

## Diagram

```
doc_ops_result{skipped:[id], seq:S}
        │
        ▼
 currentSeq() >= S ? ──yes──▶ clear shadow + ledger.take(id)  → skipped_cleared
        │no
        ▼
 awaitingSkipped[id] = S      → skipped_awaiting
        │
        │  doc_update{seq:U} applied ──▶ onAuthoritativeState(U)
        │                                   U >= S ? clear : keep waiting
        │
        └─ doc_update{opIds:[id]} ──▶ onDocEffect(id) wins, drops parked entry
```

## Evidence

- Branch `fix/s3opt2-skipped-seq-gate` @ `678fc7e1770495d827d96a2a6e569049e3f3ef13`, base `fix/s3opt6-dispatch-wiring` @ `d49dcaa1bad961684cbaedf4f06035deccdad857`
- `pnpm exec vitest run src/workbench/extensions/agent/crdt` → 21 files, **252 passed** (was 245 on base)
- `pnpm exec vue-tsc --noEmit` → clean
- `oxfmt --check`, `oxlint`, `eslint` on the 5 touched files → 0 warnings / 0 errors
- `knip --cache` → no findings for touched modules; pre-commit lint-staged (oxfmt, oxlint type-aware, eslint, typecheck) passed
- Source of policy: #16332 head `a49ac021f1`, commit `9fdd7bb544`

## Glossary

- **s3-opt-2 / s3-opt-6**: program work items for outcome reconciliation (skipped duplicates) and dispatch wiring of the pending ledger/shadow.
- **projection**: an applied `doc_update` frame; its `seq` is the host's authoritative document sequence.
- **covering seq**: a projected `seq` ≥ the `seq` reported on a `doc_ops_result`, meaning the projected state already includes that batch.
- **shadow**: the local pending overlay drawn for an op that has been sent but not yet confirmed by an effect frame.
- **ledger**: `PendingOpLedger` entries tracking sent op ids until resolved.

</details>

<!-- authored-by:agent role-hard-problem -->
