### PR TITLE
fix: OnboardingCoach card position goes stale on viewport resize

### DIFF
--- a/src/workbench/extensions/agent/components/agent/OnboardingCoach.test.ts
+++ b/src/workbench/extensions/agent/components/agent/OnboardingCoach.test.ts
@@ -64,6 +64,49 @@ describe('OnboardingCoach', () => {
     expect(Number.parseFloat(card.style.top)).toBe(108)
   })
 
+  it('repositions when the viewport narrows after mount', async () => {
+    // 1280px viewport, target left edge at x=900 (mirrors the mr2-4 T-24/
+    // T-25 repro shape: a docked panel/target whose unclamped card position
+    // is in-bounds at the wide viewport but must re-clamp once narrowed).
+    // At 1280px: 900 - 256 - 8 = 636, within [8, 1280-264]=[8,1016] --
+    // unclamped. At 700px: the same 636 would exceed 700-264=436, so the
+    // card must re-clamp to 436, a genuinely different value from 636.
+    window.innerWidth = 1280
+    window.innerHeight = 800
+    mountWithTarget({ left: 900, top: 100 })
+
+    function getCard(): HTMLElement {
+      const dialog = screen.getByRole('dialog', { name: 'Meet the agent' })
+      // eslint-disable-next-line testing-library/no-node-access -- position lands on the styled child
+      return dialog.querySelector('[style]') as HTMLElement
+    }
+
+    await screen.findByRole('dialog', { name: 'Meet the agent' })
+    const renderedWidth = Number.parseFloat(getComputedStyle(getCard()).width)
+    const initialLeft = Number.parseFloat(getCard().style.left)
+    expect(initialLeft).toBe(636)
+
+    // Narrow the viewport (e.g. panel resize) without remounting or moving
+    // the target. `useWindowSize` fires a real resize listener; the card
+    // must re-clamp into the new, narrower viewport.
+    window.innerWidth = 700
+    window.dispatchEvent(new Event('resize'))
+    // The suite runs under global fake timers (vitest.timer.setup.ts); a
+    // plain `nextTick()` only drains microtasks, not the fake-timer queue,
+    // so the position watcher's `await nextTick()` step needs an explicit
+    // timer flush to actually run.
+    await vi.advanceTimersByTimeAsync(0)
+
+    const left = Number.parseFloat(getCard().style.left)
+    // The card must re-clamp into the narrowed viewport (436), not retain
+    // its stale 1280px-viewport position (636, which would place its right
+    // edge past the new 700px edge and behind the docked panel).
+    expect(left + renderedWidth).toBeLessThanOrEqual(700 - 8)
+    expect(left).toBeGreaterThanOrEqual(8)
+    expect(left).toBe(436)
+    expect(left).not.toBe(initialLeft)
+  })
+
   it('finds a target mounted in the same render', async () => {
     render(
       {

--- a/src/workbench/extensions/agent/components/agent/OnboardingCoach.vue
+++ b/src/workbench/extensions/agent/components/agent/OnboardingCoach.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { onKeyStroke, useWindowSize } from '@vueuse/core'
-import { nextTick, ref, watchEffect } from 'vue'
+import { nextTick, ref, watch } from 'vue'
 
 import Button from '@/components/ui/button/Button.vue'
 import type { CoachStep } from '../../composables/agent/useOnboarding'
@@ -24,10 +24,23 @@ const MARGIN = 8
 
 const cardStyle = ref<Record<string, string> | null>(null)
 
-watchEffect(
-  async () => {
-    cardStyle.value = null
-    if (!active.value) return
+// Explicit `watch` sources, not `watchEffect`. This callback measures the
+// DOM after `await nextTick()`, so `width`/`height` must not be read only
+// on the far side of that `await` -- `watchEffect` only tracks dependencies
+// an effect reads during its synchronous execution, and anything read after
+// an `await` is invisible to the tracker. That was the root cause of the
+// original bug: a later viewport resize (e.g. narrowing the window) never
+// re-ran the effect, so the card stayed pinned at its stale position. Naming
+// the sources explicitly sidesteps the tracking pitfall entirely, since
+// `watch`'s sources are declared up front rather than discovered by reading
+// refs inside the callback.
+watch(
+  [active, width, height],
+  async ([isActive, viewportWidth, viewportHeight]) => {
+    if (!isActive) {
+      cardStyle.value = null
+      return
+    }
     await nextTick()
     const target = document.querySelector(step.target)
     if (!target) return
@@ -36,11 +49,11 @@ watchEffect(
     // covering it.
     const left = Math.min(
       Math.max(MARGIN, rect.left - CARD_W - MARGIN),
-      Math.max(MARGIN, width.value - CARD_W - MARGIN)
+      Math.max(MARGIN, viewportWidth - CARD_W - MARGIN)
     )
     const top = Math.min(
       Math.max(MARGIN, rect.top + MARGIN),
-      Math.max(MARGIN, height.value - CARD_H - MARGIN)
+      Math.max(MARGIN, viewportHeight - CARD_H - MARGIN)
     )
     cardStyle.value = {
       top: `${top}px`,
@@ -48,7 +61,7 @@ watchEffect(
       width: `${CARD_W}px`
     }
   },
-  { flush: 'post' }
+  { immediate: true, flush: 'post' }
 )
 </script>
 
@@ -62,7 +75,7 @@ watchEffect(
   >
     <div class="absolute inset-0 bg-black/40" />
     <div
-      :style="cardStyle"
+      :style="cardStyle ?? undefined"
       class="rounded-agent border-agent-border bg-agent-surface-raised text-agent-fg absolute border p-3 shadow-xl"
     >
       <p class="text-sm font-semibold">{{ step.title }}</p>


### PR DESCRIPTION
## Summary

The onboarding coach card (`Meet the agent`) computes its position relative
to a docked target element and the viewport size. After the panel/window is
resized, the card can stay pinned at its stale, pre-resize position -- which
can leave it out of bounds or overlapping the panel.

## Root cause

`OnboardingCoach.vue` used `watchEffect` with an `async` callback that
measured the target's `getBoundingClientRect()` and read `useWindowSize()`'s
`width`/`height` refs only after `await nextTick()`. Vue's `watchEffect`
only tracks reactive dependencies read during the effect's *synchronous*
execution -- anything read after an `await` is invisible to the dependency
tracker. So a later viewport resize never re-triggered the effect, and the
card kept its original position.

## Fix

Switch to `watch()` with explicit `[active, width, height]` sources. Naming
the sources up front means Vue doesn't need to discover them by reading refs
inside the (async) callback, sidestepping the tracking pitfall entirely.

## Tests

Added a regression test that mounts the coach at a 1280px viewport (target
docked far enough right that the card sits unclamped at `left: 636px`),
resizes the window down to 700px without remounting, and asserts the card
re-clamps to `left: 436px` -- i.e. genuinely recomputes rather than keeping
its stale position. The test fails against the pre-fix source (position
stays at 636px, overflowing the narrowed viewport) and passes against the fix.

## Evidence

```
$ pnpm vitest run src/workbench/extensions/agent/components/agent/OnboardingCoach.test.ts
 Test Files  1 passed (1)
      Tests  4 passed (4)

$ pnpm typecheck
$ vue-tsc --noEmit
[exited with code 0]
```

Back-reference: in-app-agent-program todo row `qa-55` (Browser QA on dev1
:5173, served FE 59ee16793c -- onboarding card left off-screen / overlapping
panel after a viewport resize).

<!-- authored-by:agent lane-qa-55 -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)