### PR TITLE
fix(website): register extrabold formula font

### DIFF
--- a/apps/website/src/styles/global.css
+++ b/apps/website/src/styles/global.css
@@ -52,6 +52,14 @@
 }
 
 @font-face {
+  font-family: 'PP Formula';
+  src: url('/fonts/PPFormula-Bold.woff2') format('woff2');
+  font-weight: 800;
+  font-style: normal;
+  font-display: swap;
+}
+
+@font-face {
   font-family: 'PP Formula Narrow';
   src: url('/fonts/PPFormula-NarrowSemibold.woff2') format('woff2');
   font-weight: 600;


### PR DESCRIPTION
## Summary

- register PP Formula Bold for the 800 weight used by the navbar
- prevent synthesized navbar typography from changing during footer compositing

## Test plan

- `pnpm exec oxfmt --check apps/website/src/styles/global.css`
- `pnpm --dir apps/website build`
- verified navbar font family, weight, and width at the top and bottom of the local homepage