### PR TITLE
fix(e2e): compare widgets_values by name when its shape changes

### DIFF
--- a/browser_tests/fixtures/customNode/allNodesRoundtripTier.ts
+++ b/browser_tests/fixtures/customNode/allNodesRoundtripTier.ts
@@ -453,7 +453,20 @@ export async function assertRoundtripTier({
                 (node.widgets ?? []).map((widget) => widget.name)
               ])
             )
+          // Positional widgets_values omits widgets with serialize === false,
+          // so names taken from the full widget list do not line up with it.
+          // This map applies the same filter the serializer does.
+          const serializedWidgetNamesById = () =>
+            new Map(
+              window.app!.graph.nodes.map((node) => [
+                String(node.id),
+                (node.widgets ?? [])
+                  .filter((widget) => widget.serialize !== false)
+                  .map((widget) => widget.name)
+              ])
+            )
           let namesBefore = new Map<string, string[]>()
+          let serializedNamesBefore = new Map<string, string[]>()
           let firstPass: ReturnType<
             NonNullable<typeof window.app>['graph']['serialize']
           > | null = null
@@ -482,12 +495,14 @@ export async function assertRoundtripTier({
             },
             snapshotAndConfigure() {
               namesBefore = widgetNamesById()
+              serializedNamesBefore = serializedWidgetNamesById()
               firstPass = window.app!.graph.serialize()
               window.app!.graph.configure(firstPass)
             },
             compare(label: string, strict: boolean) {
               const secondPass = window.app!.graph.serialize()
               const namesAfter = widgetNamesById()
+              const serializedNamesAfter = serializedWidgetNamesById()
               const byId = (pass: NonNullable<typeof firstPass>) =>
                 new Map(
                   (pass.nodes ?? []).map((node) => [String(node.id), node])
@@ -613,14 +628,43 @@ export async function assertRoundtripTier({
                   if (relevantChanges.every((key) => allowedKeys.includes(key)))
                     continue
                 }
-                const comparedBeforeValues =
-                  !strict && Array.isArray(before.widgets_values)
+                // widgets_values is a union of a positional array and a
+                // name-keyed record, and packs may rewrite their own nodes to
+                // the record form in onSerialize. Both sides carry the same
+                // values, so when only the shape differs they are keyed by
+                // widget name before comparing; otherwise a legal reshape
+                // reports drift on every widget of the node.
+                const asNamedValues = (
+                  values: unknown,
+                  names: string[]
+                ): unknown =>
+                  Array.isArray(values)
+                    ? Object.fromEntries(
+                        values.flatMap((value, index) => {
+                          const name = names[index]
+                          return name === undefined ? [] : [[name, value]]
+                        })
+                      )
+                    : values
+                const shapesDiffer =
+                  Array.isArray(before.widgets_values) !==
+                  Array.isArray(after.widgets_values)
+                const comparedBeforeValues = shapesDiffer
+                  ? asNamedValues(
+                      before.widgets_values,
+                      serializedNamesBefore.get(id) ?? []
+                    )
+                  : !strict && Array.isArray(before.widgets_values)
                     ? before.widgets_values.filter((_, index) =>
                         declaredNames.has(beforeNames[index] ?? '')
                       )
                     : before.widgets_values
-                const comparedAfterValues =
-                  !strict && Array.isArray(after.widgets_values)
+                const comparedAfterValues = shapesDiffer
+                  ? asNamedValues(
+                      after.widgets_values,
+                      serializedNamesAfter.get(id) ?? []
+                    )
+                  : !strict && Array.isArray(after.widgets_values)
                     ? after.widgets_values.filter((_, index) =>
                         declaredNames.has(afterNames[index] ?? '')
                       )

--- a/browser_tests/fixtures/customNode/allNodesRoundtripTier.ts
+++ b/browser_tests/fixtures/customNode/allNodesRoundtripTier.ts
@@ -633,7 +633,7 @@ export async function assertRoundtripTier({
                 // reports drift on every widget of the node.
                 const asNamedValues = (
                   values: unknown,
-                  names: string[]
+                  names: readonly string[]
                 ): unknown => {
                   const named = Array.isArray(values)
                     ? Object.fromEntries(

--- a/browser_tests/fixtures/customNode/allNodesRoundtripTier.ts
+++ b/browser_tests/fixtures/customNode/allNodesRoundtripTier.ts
@@ -634,8 +634,8 @@ export async function assertRoundtripTier({
                 const asNamedValues = (
                   values: unknown,
                   names: string[]
-                ): unknown =>
-                  Array.isArray(values)
+                ): unknown => {
+                  const named = Array.isArray(values)
                     ? Object.fromEntries(
                         values.flatMap((value, index) => {
                           const name = names[index]
@@ -643,6 +643,23 @@ export async function assertRoundtripTier({
                         })
                       )
                     : values
+                  // The non-strict positional path drops frontend-only
+                  // widgets, so the reshaped record drops them too - otherwise
+                  // a pack that both reshapes and canonicalizes a UI-only
+                  // value reports drift while every declared input stuck.
+                  if (
+                    strict ||
+                    typeof named !== 'object' ||
+                    named === null ||
+                    Array.isArray(named)
+                  )
+                    return named
+                  return Object.fromEntries(
+                    Object.entries(named).filter(([name]) =>
+                      declaredNames.has(name)
+                    )
+                  )
+                }
                 // Only an array/record pair, never array vs absent: an empty
                 // array and a missing value already mean the same thing to
                 // preserves(), and reshaping [] into {} would strip that.

--- a/browser_tests/fixtures/customNode/allNodesRoundtripTier.ts
+++ b/browser_tests/fixtures/customNode/allNodesRoundtripTier.ts
@@ -446,25 +446,22 @@ export async function assertRoundtripTier({
               JSON.stringify(afterNormalized)
             )
           }
-          const widgetNamesById = () =>
+          const namesByIdWhere = (
+            keep: (widget: { serialize?: boolean }) => boolean
+          ) =>
             new Map(
               window.app!.graph.nodes.map((node) => [
                 String(node.id),
-                (node.widgets ?? []).map((widget) => widget.name)
+                (node.widgets ?? []).filter(keep).map((widget) => widget.name)
               ])
             )
-          // Positional widgets_values omits widgets with serialize === false,
-          // so names taken from the full widget list do not line up with it.
-          // This map applies the same filter the serializer does.
+          // Live topology wants every widget; anything indexing positional
+          // widgets_values wants only the ones the serializer keeps, since it
+          // omits serialize === false and the full list misaligns after the
+          // first omission.
+          const widgetNamesById = () => namesByIdWhere(() => true)
           const serializedWidgetNamesById = () =>
-            new Map(
-              window.app!.graph.nodes.map((node) => [
-                String(node.id),
-                (node.widgets ?? [])
-                  .filter((widget) => widget.serialize !== false)
-                  .map((widget) => widget.name)
-              ])
-            )
+            namesByIdWhere((widget) => widget.serialize !== false)
           let namesBefore = new Map<string, string[]>()
           let serializedNamesBefore = new Map<string, string[]>()
           let firstPass: ReturnType<
@@ -665,7 +662,9 @@ export async function assertRoundtripTier({
                     )
                   : !strict && Array.isArray(before.widgets_values)
                     ? before.widgets_values.filter((_, index) =>
-                        declaredNames.has(beforeNames[index] ?? '')
+                        declaredNames.has(
+                          (serializedNamesBefore.get(id) ?? [])[index] ?? ''
+                        )
                       )
                     : before.widgets_values
                 const comparedAfterValues = shapesDiffer
@@ -675,7 +674,9 @@ export async function assertRoundtripTier({
                     )
                   : !strict && Array.isArray(after.widgets_values)
                     ? after.widgets_values.filter((_, index) =>
-                        declaredNames.has(afterNames[index] ?? '')
+                        declaredNames.has(
+                          (serializedNamesAfter.get(id) ?? [])[index] ?? ''
+                        )
                       )
                     : after.widgets_values
                 if (!preserves(comparedBeforeValues, comparedAfterValues))

--- a/browser_tests/fixtures/customNode/allNodesRoundtripTier.ts
+++ b/browser_tests/fixtures/customNode/allNodesRoundtripTier.ts
@@ -646,9 +646,18 @@ export async function assertRoundtripTier({
                         })
                       )
                     : values
+                // Only an array/record pair, never array vs absent: an empty
+                // array and a missing value already mean the same thing to
+                // preserves(), and reshaping [] into {} would strip that.
+                const isNamedShape = (value: unknown) =>
+                  typeof value === 'object' &&
+                  value !== null &&
+                  !Array.isArray(value)
                 const shapesDiffer =
-                  Array.isArray(before.widgets_values) !==
-                  Array.isArray(after.widgets_values)
+                  (Array.isArray(before.widgets_values) &&
+                    isNamedShape(after.widgets_values)) ||
+                  (isNamedShape(before.widgets_values) &&
+                    Array.isArray(after.widgets_values))
                 const comparedBeforeValues = shapesDiffer
                   ? asNamedValues(
                       before.widgets_values,

--- a/browser_tests/fixtures/customNode/valueDrift.test.ts
+++ b/browser_tests/fixtures/customNode/valueDrift.test.ts
@@ -4,6 +4,7 @@ import {
   initializationSignalsForTypes,
   isCanvasPreviewImagePath,
   isWidgetValuesReshape,
+  serializedWidgetNames,
   matchesTopologyExpectation,
   namedWidgetValueDrifts,
   pendingRestoredPreviewWidgets,
@@ -295,5 +296,29 @@ describe('isWidgetValuesReshape', () => {
   it('ignores pairs that share a container', () => {
     expect(isWidgetValuesReshape([1], [1])).toBe(false)
     expect(isWidgetValuesReshape({ a: 1 }, { a: 1 })).toBe(false)
+  })
+})
+
+describe('serializedWidgetNames', () => {
+  it('drops a leading non-serialized widget so names line up with values', () => {
+    const widgets = [
+      { name: 'hidden_state', serialize: false as const },
+      { name: 'steps' },
+      { name: 'cfg' }
+    ]
+
+    const names = serializedWidgetNames(widgets)
+
+    expect(names).toEqual(['steps', 'cfg'])
+    // widgets_values for this node is [20, 8]: index 0 must resolve to
+    // 'steps', not the omitted 'hidden_state'.
+    expect(names[0]).toBe('steps')
+  })
+
+  it('keeps every widget when none opts out', () => {
+    expect(serializedWidgetNames([{ name: 'a' }, { name: 'b' }])).toEqual([
+      'a',
+      'b'
+    ])
   })
 })

--- a/browser_tests/fixtures/customNode/valueDrift.test.ts
+++ b/browser_tests/fixtures/customNode/valueDrift.test.ts
@@ -3,6 +3,7 @@ import {
   declaredInputNamesForTypes,
   initializationSignalsForTypes,
   isCanvasPreviewImagePath,
+  isWidgetValuesReshape,
   matchesTopologyExpectation,
   namedWidgetValueDrifts,
   pendingRestoredPreviewWidgets,
@@ -275,5 +276,24 @@ describe('namedWidgetValueDrifts', () => {
     expect(
       namedWidgetValueDrifts({ mode: 'basic' }, { detail: 0.5 })
     ).toBeNull()
+  })
+})
+
+describe('isWidgetValuesReshape', () => {
+  it('matches an array paired with a name-keyed record', () => {
+    expect(isWidgetValuesReshape([1], { multiply_by: 1 })).toBe(true)
+    expect(isWidgetValuesReshape({ multiply_by: 1 }, [1])).toBe(true)
+  })
+
+  it('leaves an absent value alone, so an empty array still means nothing', () => {
+    expect(isWidgetValuesReshape([], null)).toBe(false)
+    expect(isWidgetValuesReshape([], undefined)).toBe(false)
+    expect(isWidgetValuesReshape(null, [])).toBe(false)
+    expect(isWidgetValuesReshape(undefined, [])).toBe(false)
+  })
+
+  it('ignores pairs that share a container', () => {
+    expect(isWidgetValuesReshape([1], [1])).toBe(false)
+    expect(isWidgetValuesReshape({ a: 1 }, { a: 1 })).toBe(false)
   })
 })

--- a/browser_tests/fixtures/customNode/valueDrift.test.ts
+++ b/browser_tests/fixtures/customNode/valueDrift.test.ts
@@ -3,7 +3,7 @@ import {
   declaredInputNamesForTypes,
   initializationSignalsForTypes,
   isCanvasPreviewImagePath,
-  isWidgetValuesReshape,
+  isWidgetValuesContainerSwap,
   serializedWidgetNames,
   matchesTopologyExpectation,
   namedWidgetValueDrifts,
@@ -280,39 +280,30 @@ describe('namedWidgetValueDrifts', () => {
   })
 })
 
-describe('isWidgetValuesReshape', () => {
-  it('matches an array paired with a name-keyed record', () => {
-    expect(isWidgetValuesReshape([1], { multiply_by: 1 })).toBe(true)
-    expect(isWidgetValuesReshape({ multiply_by: 1 }, [1])).toBe(true)
-  })
-
-  it('leaves an absent value alone, so an empty array still means nothing', () => {
-    expect(isWidgetValuesReshape([], null)).toBe(false)
-    expect(isWidgetValuesReshape([], undefined)).toBe(false)
-    expect(isWidgetValuesReshape(null, [])).toBe(false)
-    expect(isWidgetValuesReshape(undefined, [])).toBe(false)
-  })
-
-  it('ignores pairs that share a container', () => {
-    expect(isWidgetValuesReshape([1], [1])).toBe(false)
-    expect(isWidgetValuesReshape({ a: 1 }, { a: 1 })).toBe(false)
+describe('isWidgetValuesContainerSwap', () => {
+  it.for([
+    { after: { multiply_by: 1 }, before: [1], swap: true },
+    { after: [1], before: { multiply_by: 1 }, swap: true },
+    { after: null, before: [], swap: false },
+    { after: undefined, before: [], swap: false },
+    { after: [], before: null, swap: false },
+    { after: [], before: undefined, swap: false },
+    { after: [1], before: [1], swap: false },
+    { after: { a: 1 }, before: { a: 1 }, swap: false }
+  ])('$before -> $after is swap=$swap', ({ before, after, swap }) => {
+    expect(isWidgetValuesContainerSwap(before, after)).toBe(swap)
   })
 })
 
 describe('serializedWidgetNames', () => {
   it('drops a leading non-serialized widget so names line up with values', () => {
-    const widgets = [
-      { name: 'hidden_state', serialize: false as const },
+    const names = serializedWidgetNames([
+      { name: 'hidden_state', serialize: false },
       { name: 'steps' },
       { name: 'cfg' }
-    ]
-
-    const names = serializedWidgetNames(widgets)
+    ])
 
     expect(names).toEqual(['steps', 'cfg'])
-    // widgets_values for this node is [20, 8]: index 0 must resolve to
-    // 'steps', not the omitted 'hidden_state'.
-    expect(names[0]).toBe('steps')
   })
 
   it('keeps every widget when none opts out', () => {

--- a/browser_tests/fixtures/customNode/valueDrift.ts
+++ b/browser_tests/fixtures/customNode/valueDrift.ts
@@ -293,28 +293,7 @@ export function declaredInputNamesForTypes(
   )
 }
 
-/**
- * Whether a widgets_values pair changed container without changing meaning.
- *
- * widgets_values is a union of a positional array and a name-keyed record,
- * and a pack may rewrite its own nodes to the record form in onSerialize. Only
- * an array/record pair qualifies: an empty array and an absent value already
- * compare equal, so treating that as a reshape would strip the equivalence.
- *
- * The save/reload tier mirrors this rule inside its page.evaluate closure,
- * which cannot import; these cases are the contract both sides implement.
- */
-/**
- * Widget names aligned to positional widgets_values.
- *
- * The serializer skips widgets with `serialize === false`, so a name list
- * taken from the full widget set misaligns every entry after the first skipped
- * one - a declared widget then gets checked against its neighbour's name, and
- * a real value drift can be filtered away as undeclared.
- *
- * The save/reload tier mirrors this inside its page.evaluate closure, which
- * cannot import; these cases are the contract both sides implement.
- */
+/** Returns names aligned with positional widgets_values serialization. */
 export function serializedWidgetNames(
   widgets: readonly { name: string; serialize?: boolean }[]
 ): string[] {
@@ -323,7 +302,12 @@ export function serializedWidgetNames(
     .map((widget) => widget.name)
 }
 
-export function isWidgetValuesReshape(
+/**
+ * Whether the pair swapped between the positional array and the name-keyed
+ * record, which carries the same values in a different container. An absent
+ * value is excluded: it already compares equal to an empty array.
+ */
+export function isWidgetValuesContainerSwap(
   before: unknown,
   after: unknown
 ): boolean {

--- a/browser_tests/fixtures/customNode/valueDrift.ts
+++ b/browser_tests/fixtures/customNode/valueDrift.ts
@@ -304,6 +304,25 @@ export function declaredInputNamesForTypes(
  * The save/reload tier mirrors this rule inside its page.evaluate closure,
  * which cannot import; these cases are the contract both sides implement.
  */
+/**
+ * Widget names aligned to positional widgets_values.
+ *
+ * The serializer skips widgets with `serialize === false`, so a name list
+ * taken from the full widget set misaligns every entry after the first skipped
+ * one - a declared widget then gets checked against its neighbour's name, and
+ * a real value drift can be filtered away as undeclared.
+ *
+ * The save/reload tier mirrors this inside its page.evaluate closure, which
+ * cannot import; these cases are the contract both sides implement.
+ */
+export function serializedWidgetNames(
+  widgets: readonly { name: string; serialize?: boolean }[]
+): string[] {
+  return widgets
+    .filter((widget) => widget.serialize !== false)
+    .map((widget) => widget.name)
+}
+
 export function isWidgetValuesReshape(
   before: unknown,
   after: unknown

--- a/browser_tests/fixtures/customNode/valueDrift.ts
+++ b/browser_tests/fixtures/customNode/valueDrift.ts
@@ -293,6 +293,29 @@ export function declaredInputNamesForTypes(
   )
 }
 
+/**
+ * Whether a widgets_values pair changed container without changing meaning.
+ *
+ * widgets_values is a union of a positional array and a name-keyed record,
+ * and a pack may rewrite its own nodes to the record form in onSerialize. Only
+ * an array/record pair qualifies: an empty array and an absent value already
+ * compare equal, so treating that as a reshape would strip the equivalence.
+ *
+ * The save/reload tier mirrors this rule inside its page.evaluate closure,
+ * which cannot import; these cases are the contract both sides implement.
+ */
+export function isWidgetValuesReshape(
+  before: unknown,
+  after: unknown
+): boolean {
+  const isNamed = (value: unknown) =>
+    typeof value === 'object' && value !== null && !Array.isArray(value)
+  return (
+    (Array.isArray(before) && isNamed(after)) ||
+    (isNamed(before) && Array.isArray(after))
+  )
+}
+
 export function namedWidgetValueDrifts(
   before: unknown,
   after: unknown,


### PR DESCRIPTION
Human Ben: This fixes the issues causing the E2E Custom Nodes Tests to fail.

## Summary

S3 reported value drift on all 82 ComfyUI-VideoHelperSuite nodes even though no value changed. `widgets_values` is a union of a positional array and a name-keyed record (`zWidgetValues = z.union([z.array(z.any()), z.record(z.any())])`), and VHS rewrites its own nodes to the record form in `onSerialize`:

```js
chainCallback(this, "onSerialize", function(info) {
    info.widgets_values = {};
    for (let w of this.widgets) info.widgets_values[w.name] = w.value;
});
```

The tier compared the raw value, so a legal reshape read as drift on every widget:

```
VHS_DuplicateImages: widgets_values [1] -> {"multiply_by":1} on pristine reload
VHS_MergeImages: ["match A","nearest-exact","disabled"]
              -> {"merge_strategy":"match A","scale_method":"nearest-exact","crop":"disabled"}
```

This is correct pack behaviour and schema-legal, so the test was wrong — not the product.

## Changes

- When only the shape differs, key both sides by widget name before comparing. Identical values in different containers no longer read as drift; a real value change still fails.
- Normalization engages only when `Array.isArray(before) !== Array.isArray(after)`. Same-shape comparisons keep their existing strict/non-strict paths untouched, so detection is unchanged everywhere it already works.
- Names come from a new serializer-aligned list. Positional `widgets_values` omits `serialize === false` widgets, so the full widget list would shift every index after the first hidden one and compare the wrong pairs.

## Why not ledger it

Adding 82 entries would have recreated the stale-entry problem that produced the failures this is chasing: entries stop reproducing after an upstream change, then fail closed as stale. Normalizing the comparison keeps the tier able to detect genuine drift with no calibration surface to rot.

## Testing

- Browser typecheck, ESLint, oxfmt clean.
- Full custom-node suite dispatched on this branch; `core:1/2` and `cloud 2/5` are the VHS-carrying slices that fail on `main`.

No unit test: this logic lives inside a `page.evaluate` closure that Playwright stringifies, so it cannot import a shared helper, and duplicating it into a testable module would leave two copies to drift. The file's existing helpers (`preserves`, `byId`) are inline for the same reason. The E2E run against the real pack is the proof.

## Context

`main` is currently red on exactly these two slices. This is unrelated to the earlier stale-allowlist failures fixed in #16650 — that fix is what exposed this.
