### PR TITLE
fix(agent): abort in-flight batch eagerly on doc_subscribed refusal

### DIFF
--- a/src/workbench/extensions/agent/crdt/crossWorkflowPending.test.ts
+++ b/src/workbench/extensions/agent/crdt/crossWorkflowPending.test.ts
@@ -222,8 +222,23 @@ describe('R-73 cross-workflow pending operation characterization', () => {
     expect(clientState.sent[0].ops[0]).toMatchObject({ base_version: 41 })
     const operationAId = clientState.sent[0].ops[0].op_id
     await switchWorkflow(workflowId, 'wf-b')
+
+    // The switch itself settles A's in-flight batch undeliverable (the
+    // composable calls sender.abortIfUnbound() after retargeting the bridge),
+    // so B's batch goes out at once instead of queueing behind A for the
+    // 10 s result-silence window.
+    expect(devLogState.recordDevEvent).toHaveBeenCalledWith(
+      'human_ops_settled',
+      {
+        state: 'undeliverable',
+        ops: [expect.objectContaining({ op_id: operationAId })]
+      }
+    )
     enqueue([deleteNode('b-pending')])
-    expect(clientState.sent).toHaveLength(1)
+    expect(clientState.sent).toHaveLength(2)
+    expect(clientState.sent[1]).toMatchObject({ workflowId: 'wf-b' })
+    expect(clientState.sent[1].ops[0]).toMatchObject({ base_version: 0 })
+    const operationBId = clientState.sent[1].ops[0].op_id
 
     dispatchOpsResult({
       workflowId: 'wf-a',
@@ -232,10 +247,13 @@ describe('R-73 cross-workflow pending operation characterization', () => {
       skipped: []
     })
 
-    expect(clientState.sent).toHaveLength(2)
-    expect(clientState.sent[1]).toMatchObject({ workflowId: 'wf-b' })
-    expect(clientState.sent[1].ops[0]).toMatchObject({ base_version: 0 })
-    const operationBId = clientState.sent[1].ops[0].op_id
+    // A's late result names A's op_id, which is not in B's in-flight batch,
+    // so the sender ignores it: B stays in flight and nothing else settles.
+    expect(
+      devLogState.recordDevEvent.mock.calls.filter(
+        ([event]) => event === 'human_ops_settled'
+      )
+    ).toHaveLength(1)
 
     // Documented defect expectation for R-73: result frames carry workflowId,
     // but the composable updates workflow B's status from workflow A's frame.
@@ -250,23 +268,6 @@ describe('R-73 cross-workflow pending operation characterization', () => {
       applied: [operationAId],
       skipped: []
     })
-    expect(devLogState.recordDevEvent).toHaveBeenCalledWith(
-      'human_ops_settled',
-      {
-        state: 'acknowledged',
-        ops: [expect.objectContaining({ op_id: operationAId })],
-        result: expect.objectContaining({
-          ok: true,
-          applied: [operationAId],
-          skipped: []
-        })
-      }
-    )
-    expect(
-      devLogState.recordDevEvent.mock.calls.filter(
-        ([event]) => event === 'human_ops_settled'
-      )
-    ).toHaveLength(1)
     expect(operationBId).not.toBe(operationAId)
   })
 
@@ -275,16 +276,18 @@ describe('R-73 cross-workflow pending operation characterization', () => {
 
     enqueue([deleteNode('a-inflight')])
     const operationAId = clientState.sent[0].ops[0].op_id
+    // The switch settles A undeliverable (settlement 0) and B goes out at once.
     await switchWorkflow(workflowId, 'wf-b')
     enqueue([deleteNode('b-pending')])
+    const operationBId = clientState.sent[1].ops[0].op_id
 
+    // A's identified late result is ignored: its op_id is not in B's batch.
     dispatchOpsResult({
       workflowId: 'wf-a',
       ok: true,
       applied: [operationAId],
       skipped: []
     })
-    const operationBId = clientState.sent[1].ops[0].op_id
 
     dispatchOpsResult({
       workflowId: 'wf-a',

--- a/src/workbench/extensions/agent/crdt/followerSubscription.test.ts
+++ b/src/workbench/extensions/agent/crdt/followerSubscription.test.ts
@@ -705,6 +705,27 @@ describe('FE-GAP-1 — a seq jump means a dropped frame and forces a resync', ()
     expect(transport.framesOfType('doc_subscribe')).toHaveLength(1)
   })
 
+  it('clears send reality BEFORE re-dispatching the refusal, so listeners observe the unbind synchronously', () => {
+    // useAgentCrdtFollower's onSubscribed calls sender.abortIfUnbound() inside
+    // this listener and relies on reading a null binding at that moment.
+    const { transport, bridge } = wire()
+    transport.open = true
+    bridge.subscribe(WORKFLOW_ID)
+    const seenDuringDispatch: Array<string | null> = []
+    bridge.addEventListener('doc_subscribed', () => {
+      seenDuringDispatch.push(bridge.subscribedWorkflowId)
+    })
+
+    transport.deliver('doc_subscribed', {
+      v: 1,
+      workflow_id: WORKFLOW_ID,
+      ok: false,
+      code: 'not_found'
+    })
+
+    expect(seenDuringDispatch).toEqual([null])
+  })
+
   it('a refused subscribe re-opens intent so the next reconcile retries', () => {
     const { transport, bridge } = wire()
     transport.open = true

--- a/src/workbench/extensions/agent/crdt/opSender.test.ts
+++ b/src/workbench/extensions/agent/crdt/opSender.test.ts
@@ -160,6 +160,46 @@ describe('createOpSender', () => {
     ])
   })
 
+  it('abortIfUnbound settles an in-flight batch immediately, without waiting the 10s silence window', () => {
+    sender.enqueue([addNode(1)])
+    boundWorkflow = null
+
+    sender.abortIfUnbound()
+
+    expect(settled).toEqual([
+      { state: 'undeliverable', ops: expect.any(Array) }
+    ])
+    // No resend was burned reaching this outcome.
+    expect(sent).toHaveLength(1)
+  })
+
+  it('abortIfUnbound frees the queue for the next bound batch immediately', () => {
+    sender.enqueue([addNode(1)])
+    boundWorkflow = 'wf-2'
+    sender.enqueue([addNode(2)])
+    expect(sent).toHaveLength(1)
+
+    sender.abortIfUnbound()
+
+    expect(sent).toHaveLength(2)
+    expect(sent[1].workflowId).toBe('wf-2')
+    expect(settled[0].state).toBe('undeliverable')
+  })
+
+  it('abortIfUnbound is a no-op while the in-flight batch is still addressed to the bound workflow', () => {
+    sender.enqueue([addNode(1)])
+
+    sender.abortIfUnbound()
+
+    expect(settled).toHaveLength(0)
+    expect(sent).toHaveLength(1)
+  })
+
+  it('abortIfUnbound is a no-op with no batch in flight', () => {
+    expect(() => sender.abortIfUnbound()).not.toThrow()
+    expect(settled).toHaveLength(0)
+  })
+
   it('an unbound workflow at the resend frees the queue for the next bound batch without a retry burn', () => {
     sender.enqueue([addNode(1)])
     boundWorkflow = 'wf-2'

--- a/src/workbench/extensions/agent/crdt/opSender.test.ts
+++ b/src/workbench/extensions/agent/crdt/opSender.test.ts
@@ -186,6 +186,40 @@ describe('createOpSender', () => {
     expect(settled[0].state).toBe('undeliverable')
   })
 
+  it('abortIfUnbound cascades through every queued batch minted for the dead workflow, synchronously', () => {
+    sender.enqueue([addNode(1)])
+    sender.enqueue([addNode(2)])
+    sender.enqueue([addNode(3)])
+    boundWorkflow = 'wf-2'
+    sender.enqueue([addNode(4)])
+    expect(sent).toHaveLength(1)
+
+    sender.abortIfUnbound()
+
+    // No timer advance: settle -> pump -> transmit re-reads the binding and
+    // settles each wf-1 batch in turn until it reaches the wf-2 one.
+    expect(settled.map((outcome) => outcome.state)).toEqual([
+      'undeliverable',
+      'undeliverable',
+      'undeliverable'
+    ])
+    expect(sent).toHaveLength(2)
+    expect(sent[1].workflowId).toBe('wf-2')
+    expect(sender.pending()).toBe(1)
+  })
+
+  it('abortIfUnbound clears a pending send retry so no timer outlives the batch', () => {
+    transportUp = false
+    sender.enqueue([addNode(1)])
+    expect(vi.getTimerCount()).toBe(1)
+    boundWorkflow = null
+
+    sender.abortIfUnbound()
+
+    expect(settled.map((outcome) => outcome.state)).toEqual(['undeliverable'])
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
   it('abortIfUnbound is a no-op while the in-flight batch is still addressed to the bound workflow', () => {
     sender.enqueue([addNode(1)])
 

--- a/src/workbench/extensions/agent/crdt/opSender.ts
+++ b/src/workbench/extensions/agent/crdt/opSender.ts
@@ -75,6 +75,11 @@ export interface OpSender {
    * signal that the subscription is gone (e.g. `doc_subscribed {ok:false}`)
    * should call this immediately; a no-op otherwise (still bound, or the
    * unbind already resolved through the normal transmit-time check).
+   *
+   * Not for reconnect: `resubscribe()` re-binds the SAME id synchronously on
+   * a live socket, so this stays a no-op there by design — the batch rides
+   * the result timer to its idempotent resend, which is the right outcome
+   * (the ops may well have landed), not `undeliverable`.
    */
   abortIfUnbound(): void
   detach(): void
@@ -118,7 +123,13 @@ export function createOpSender(deps: OpSenderDeps): OpSender {
     }
     if (!deps.sendOps(batch.workflowId, deps.tab, batch.ops)) {
       if (attempt < SEND_RETRY_LIMIT) {
-        setTimeout(() => transmit(batch, attempt + 1), SEND_RETRY_INTERVAL_MS)
+        // Tracked in the same slot as the result timer (they never overlap:
+        // the result timer is armed only after a successful send) so
+        // settle()/detach() clear a pending retry too.
+        batch.timer = setTimeout(
+          () => transmit(batch, attempt + 1),
+          SEND_RETRY_INTERVAL_MS
+        )
       } else {
         settleUndeliverable(batch)
       }

--- a/src/workbench/extensions/agent/crdt/opSender.ts
+++ b/src/workbench/extensions/agent/crdt/opSender.ts
@@ -67,6 +67,16 @@ export interface OpSender {
   enqueue(operations: GraphOperation[]): void
   /** In-flight + queued batch count (observability; 0 = drained). */
   pending(): number
+  /**
+   * Eager abort seam (FE #16637 residual): settle the in-flight batch
+   * undeliverable NOW if its mint-time workflow no longer matches
+   * `deps.workflowId()`, instead of waiting out the 10 s result-silence
+   * window before the next transmit re-reads it. A caller with an earlier
+   * signal that the subscription is gone (e.g. `doc_subscribed {ok:false}`)
+   * should call this immediately; a no-op otherwise (still bound, or the
+   * unbind already resolved through the normal transmit-time check).
+   */
+  abortIfUnbound(): void
   detach(): void
 }
 
@@ -193,6 +203,11 @@ export function createOpSender(deps: OpSenderDeps): OpSender {
     },
     pending() {
       return queue.length + (inFlight ? 1 : 0)
+    },
+    abortIfUnbound() {
+      if (inFlight && deps.workflowId() !== inFlight.workflowId) {
+        settleUndeliverable(inFlight)
+      }
     },
     detach() {
       detached = true

--- a/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.test.ts
+++ b/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.test.ts
@@ -553,6 +553,44 @@ describe('useAgentCrdtFollower', () => {
     unmount()
   })
 
+  it('a refused subscription settles the in-flight batch undeliverable immediately, without waiting the resend (residual of #16637)', async () => {
+    vi.useFakeTimers()
+    const { recordDevEvent } = await import('./devPanelLog')
+    const workflowId = ref<string | null>('wf-1')
+    let enqueue!: ReturnType<
+      typeof useAgentCrdtFollower
+    >['enqueueHumanOperations']
+    const host = defineComponent({
+      setup() {
+        const { enqueueHumanOperations } = useAgentCrdtFollower(
+          workflowId,
+          graphMutations
+        )
+        enqueue = enqueueHumanOperations
+        return () => null
+      }
+    })
+    const { unmount } = render(host)
+
+    enqueue([{ op: 'delete_node', node_id: '1', removed_links: [] }])
+    expect(clientState.sendOps).toHaveBeenCalledTimes(1)
+
+    // Mirror the real bridge's onDocSubscribed: it clears send reality
+    // BEFORE dispatching the event (layoutFollowerBridge.ts), so the
+    // composable's onSubscribed handler observes the clear synchronously.
+    bridge().subscribedWorkflowId = null
+    dispatchFrame('doc_subscribed', { ok: false, workflowId: 'wf-1' })
+
+    // No timer advance: the refusal itself is the abort signal.
+    expect(clientState.sendOps).toHaveBeenCalledTimes(1)
+    const settledStates = vi
+      .mocked(recordDevEvent)
+      .mock.calls.filter(([event]) => event === 'human_ops_settled')
+      .map(([, detail]) => (detail as { state: string }).state)
+    expect(settledStates).toEqual(['undeliverable'])
+    unmount()
+  })
+
   it('probes a quiet bound channel once per budget and re-arms (BE-9740)', () => {
     vi.useFakeTimers()
     const { unmount } = mountFollower('wf-1')

--- a/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.test.ts
+++ b/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.test.ts
@@ -591,6 +591,46 @@ describe('useAgentCrdtFollower', () => {
     unmount()
   })
 
+  it('a doc switch settles the in-flight batch for the old doc undeliverable immediately, without waiting the resend', async () => {
+    vi.useFakeTimers()
+    const { recordDevEvent } = await import('./devPanelLog')
+    const workflowId = ref<string | null>('wf-1')
+    let enqueue!: ReturnType<
+      typeof useAgentCrdtFollower
+    >['enqueueHumanOperations']
+    const host = defineComponent({
+      setup() {
+        const { enqueueHumanOperations } = useAgentCrdtFollower(
+          workflowId,
+          graphMutations
+        )
+        enqueue = enqueueHumanOperations
+        return () => null
+      }
+    })
+    const { unmount } = render(host)
+    // Mirror the real bridge's reconcile(): a changed desired doc clears send
+    // reality synchronously inside subscribe()/unsubscribe().
+    bridge().subscribe.mockImplementation((next: string) => {
+      bridge().subscribedWorkflowId = next === 'wf-1' ? 'wf-1' : null
+    })
+
+    enqueue([{ op: 'delete_node', node_id: '1', removed_links: [] }])
+    expect(clientState.sendOps).toHaveBeenCalledTimes(1)
+
+    workflowId.value = 'wf-2'
+    await nextTick()
+
+    // No timer advance: the retarget itself is the abort signal.
+    expect(clientState.sendOps).toHaveBeenCalledTimes(1)
+    const settledStates = vi
+      .mocked(recordDevEvent)
+      .mock.calls.filter(([event]) => event === 'human_ops_settled')
+      .map(([, detail]) => (detail as { state: string }).state)
+    expect(settledStates).toEqual(['undeliverable'])
+    unmount()
+  })
+
   it('probes a quiet bound channel once per budget and re-arms (BE-9740)', () => {
     vi.useFakeTimers()
     const { unmount } = mountFollower('wf-1')

--- a/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.ts
+++ b/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.ts
@@ -469,6 +469,15 @@ export function useAgentCrdtFollower(
   // (a REAL detach, e.g. new chat — drop the persisted id too).
   let initialBind = true
   let boundWorkflowId: string | null = null
+  // Drive the bridge's intent, then give the sender the same eager signal the
+  // refusal branch gets: `reconcile()` clears send reality synchronously when
+  // the desired doc changes, and a batch minted for the old doc would
+  // otherwise wait out the 10 s result-silence window before noticing.
+  const retarget = (next: string | null): void => {
+    if (next === null) bridge.unsubscribe()
+    else bridge.subscribe(next)
+    sender.abortIfUnbound()
+  }
   watch(
     [workflowId, isTargetActive],
     ([next, active]) => {
@@ -483,7 +492,7 @@ export function useAgentCrdtFollower(
           boundWorkflowId = null
         }
         subscribedWorkflowId.value = null
-        bridge.unsubscribe()
+        retarget(null)
         return
       }
       if (next === null) {
@@ -497,7 +506,7 @@ export function useAgentCrdtFollower(
             boundWorkflowId = persisted
           }
           subscribedWorkflowId.value = persisted
-          bridge.subscribe(persisted)
+          retarget(persisted)
           return
         }
         clearPersistedDocId()
@@ -506,7 +515,7 @@ export function useAgentCrdtFollower(
           boundWorkflowId = null
         }
         subscribedWorkflowId.value = null
-        bridge.unsubscribe()
+        retarget(null)
         return
       }
       initialBind = false
@@ -516,7 +525,7 @@ export function useAgentCrdtFollower(
         boundWorkflowId = next
       }
       subscribedWorkflowId.value = next
-      bridge.subscribe(next)
+      retarget(next)
     },
     { immediate: true }
   )

--- a/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.ts
+++ b/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.ts
@@ -318,6 +318,10 @@ export function useAgentCrdtFollower(
     } else {
       clearStaleProbe()
       scheduleSubscribeRetry()
+      // FE #16637 residual: a refusal is the earliest signal the sender can
+      // get that its in-flight batch's doc is gone — don't make it wait out
+      // the 10 s result-silence window to notice on its own.
+      sender.abortIfUnbound()
     }
   }
   const onUpdate: EventListener = (event) => {


### PR DESCRIPTION
## Summary

Follow-up to [#16637](https://github.com/Comfy-Org/ComfyUI_frontend/pull/16637). After that PR's fix landed (`transmit` re-reads `deps.workflowId()` before every send/resend and settles undeliverable on mismatch), a human top-level comment on the merged PR noted a residual:

> Not changed: the 10 s result-silence window before the resend is pre-existing and still the dominant head-of-line cost; shortening it or settling in-flight batches eagerly on `doc_subscribed{ok:false}` would need a sender-side abort seam and is out of scope here.

This PR adds that seam. `OpSender` gains `abortIfUnbound()`, which settles the current in-flight batch `undeliverable` immediately if its mint-time `workflowId` no longer matches `deps.workflowId()` — instead of waiting for the 10s result-silence timer to notice on the next resend. `abortIfUnbound()` is called from two sites in `useAgentCrdtFollower.ts`:

- the `doc_subscribed{ok:false}` branch of `onSubscribed` (`:324`) — a refused subscription.
- the new `retarget(next)` helper (`:476-480`), called unconditionally from every branch of the `watch([workflowId, isTargetActive], ...)` handler (`:481-531`) — i.e. also on an ordinary workflow switch or target deactivation, not only on refusal. This second site is why `crossWorkflowPending.test.ts` needed the R-73 rewrite: a batch minted for the outgoing workflow is now settled `undeliverable` synchronously on switch instead of surviving until the 10s silence timer next fires.

Ordering: `LayoutFollowerBridge.onDocSubscribed` clears `sentWorkflowId` to `null` (send reality) *before* it dispatches the `doc_subscribed` event (`layoutFollowerBridge.ts`), so by the time the composable's `onSubscribed` handler runs `sender.abortIfUnbound()`, `bridge.subscribedWorkflowId` already reads `null` — the abort seam observes the unbind synchronously on refusal, with no timer needed. The `retarget()` site gets the same synchronous signal on a switch: `bridge.subscribe`/`unsubscribe` runs first, then `abortIfUnbound()` reads the now-updated `bridge.subscribedWorkflowId`.

The pre-existing 10s-silence path (an unbind discovered only when the resend timer fires) is untouched and stays covered by the existing #16637 tests.

## Evidence

```
$ source ~/.nvm/nvm.sh && nvm use 25
$ NODE_OPTIONS="--no-experimental-webstorage" npx vitest run \
    src/workbench/extensions/agent/crdt/opSender.test.ts \
    src/workbench/extensions/agent/crdt/useAgentCrdtFollower.test.ts
 Test Files  2 passed (2)
      Tests  48 passed (48)

$ pnpm run typecheck   # vue-tsc --noEmit — clean

$ pnpm exec oxlint <4 touched files>   # exit 0
$ pnpm exec oxfmt --check <4 touched files>   # all correctly formatted
```

New tests added (4 in `opSender.test.ts`, 1 in `useAgentCrdtFollower.test.ts`):
- `abortIfUnbound settles an in-flight batch immediately, without waiting the 10s silence window`
- `abortIfUnbound frees the queue for the next bound batch immediately`
- `abortIfUnbound is a no-op while the in-flight batch is still addressed to the bound workflow`
- `abortIfUnbound is a no-op with no batch in flight`
- `a refused subscription settles the in-flight batch undeliverable immediately, without waiting the resend (residual of #16637)`

## Scope

The abort seam covers both call sites: refusal (`onSubscribed`) and ordinary retargeting (`retarget()` on workflow switch/deactivate). The 10s `RESULT_TIMEOUT_MS` window itself is unchanged (still the correct default cost for a batch that IS still bound but just slow to ack).

<!-- authored-by:agent lane-act-fe-16637-followup -->
<!-- authored-by:agent lane-act-fe-16677-followup-80426f60 -->