### PR TITLE
[backport core/1.53] test: cover link/store contracts + fix widget-leak and perf bugs

### DIFF
--- a/docs/adr/0027-defer-promoted-widget-registration-to-onadded.md
+++ b/docs/adr/0027-defer-promoted-widget-registration-to-onadded.md
@@ -1,0 +1,49 @@
+# 27. Defer Promoted-Widget Registration to `onAdded()`
+
+Date: 2026-09-01
+
+## Status
+
+Accepted
+
+## Context
+
+`SubgraphNode._setWidget` registers each promoted input's widget state in
+`useWidgetValueStore`, keyed by `widgetId(rootGraph.id, this.id, name)`. Before
+a node is added to a graph, `this.id` is `UNASSIGNED_NODE_ID` (`-1`) — a value
+every not-yet-added `SubgraphNode` shares, including clipboard clones that are
+built, resolved, and then discarded without ever being added.
+
+Registering during construction therefore keyed widget state under that shared
+`-1` id. A clone built and discarded (e.g. Ctrl+C then Escape) could leave its
+value registered under `graphId:-1:name`. A later, unrelated `SubgraphNode`
+with a same-named promoted input — created anywhere in the session — would
+then inherit the discarded clone's value the first time its bindings rebuilt,
+because the registry still held state at that shared key (#16250).
+
+## Decision
+
+`_setWidget` no longer registers while `this.id === UNASSIGNED_NODE_ID`; it
+clears `input.widgetId` and returns. `onAdded()` performs the deferred
+registration once the node has its real, unique id, re-resolving any input
+whose `widgetId` was left unset during construction.
+
+## Consequences
+
+- No promoted widget state is ever written under the shared `UNASSIGNED_NODE_ID`
+  key, so a discarded clone can no longer leak its value into a later,
+  unrelated instance.
+- Extensions or app code that read a promoted input's `widgetId` or store-backed
+  value immediately after construction (before the node is added to a graph)
+  will see it unset until `onAdded()` runs. Registration was never
+  synchronous with construction in the shared-key case anyway — the value was
+  wrong or overwritten, not merely late.
+- `onAdded()` was already responsible for id-migration when a node's minted id
+  differs from a previously-assigned one; it now also owns first-time
+  registration, keeping all promoted-widget store writes in one lifecycle
+  point after `this.id` is real.
+
+## References
+
+- #16250 — Promoted widget values leak across unrelated SubgraphNode instances
+  (shared `nodeId=-1` registration key).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -35,6 +35,7 @@ An Architecture Decision Record captures an important technical decision made al
 | [0023](0023-widget-entities-and-legacy-behavior-boundary.md)                | Widget Entities and Legacy Behavior Boundary                    | Proposed | 2026-08-26 |
 | [0024](0024-in-app-agent-offscreen-graphs.md)                               | Graph Activation and Document Objects for In-App Agent Targets  | Proposed | 2026-08-28 |
 | [0025](0025-in-app-agent-crdt-follower-and-distribution.md)                 | In-App Agent CRDT Follower and Distribution-Resolved Boundaries | Proposed | 2026-08-21 |
+| [0027](0027-defer-promoted-widget-registration-to-onadded.md)               | Defer Promoted-Widget Registration to `onAdded()`               | Accepted | 2026-09-01 |
 
 ## Creating a New ADR
 

--- a/src/core/graph/subgraph/promotionUtils.test.ts
+++ b/src/core/graph/subgraph/promotionUtils.test.ts
@@ -13,6 +13,8 @@ import { useLinkStore } from '@/stores/linkStore'
 import { usePreviewExposureStore } from '@/stores/previewExposureStore'
 import { useWidgetValueStore } from '@/stores/widgetValueStore'
 import { graphScopeOf } from '@/types/graphScopeId'
+import { UNASSIGNED_NODE_ID, toNodeId } from '@/types/nodeId'
+import { widgetId } from '@/types/widgetId'
 import type { WidgetId } from '@/types/widgetId'
 
 function promotedInputNames(host: {
@@ -63,7 +65,8 @@ import {
   promoteWidget,
   pruneDisconnected,
   reorderSubgraphInputsByName,
-  reorderSubgraphInputsByWidgetOrder
+  reorderSubgraphInputsByWidgetOrder,
+  seedNestedPromotedInputState
 } from './promotionUtils'
 
 function widget(
@@ -1055,5 +1058,61 @@ describe('disambiguated nested promotion identity', () => {
     pruneDisconnected(outerHost)
 
     expect(outerHost.subgraph.inputs).toHaveLength(beforeCount)
+  })
+})
+
+describe('seedNestedPromotedInputState — unassigned host id (#16250 defect class)', () => {
+  it('does not register under the shared construction-time key when the host has no real id', () => {
+    const subgraph = createTestSubgraph()
+    const host = createTestSubgraphNode(subgraph, { id: -1 })
+
+    subgraph.addInput('text', 'STRING')
+    const hostInput = host.inputs.find(
+      (input) => input._subgraphSlot?.name === 'text'
+    )!
+    delete hostInput.widgetId
+
+    const sourceId = widgetId(host.rootGraph.id, toNodeId(999), 'origin')
+    useWidgetValueStore().registerWidget(sourceId, {
+      type: 'string',
+      value: 'source value',
+      options: {}
+    })
+
+    seedNestedPromotedInputState(host, 'text', { widgetId: sourceId })
+
+    const sharedKey = widgetId(host.rootGraph.id, UNASSIGNED_NODE_ID, 'text')
+    expect(useWidgetValueStore().getWidget(sharedKey)).toBeUndefined()
+    expect(hostInput.widgetId).toBeUndefined()
+  })
+})
+
+describe('seedNestedPromotedInputState — rejected registration (#16013, #16251)', () => {
+  it('does not leave a dangling widgetId or widget locator when registration is rejected', () => {
+    const subgraph = createTestSubgraph()
+    const host = createTestSubgraphNode(subgraph)
+
+    // An empty subgraph input name — as produced by nextUniqueName when the
+    // promoted source widget has an empty name (e.g. a spacer/button
+    // widget) — derives an un-keyable WidgetId (`graphId:nodeId:`) below.
+    subgraph.addInput('', 'STRING')
+    const hostInput = host.inputs.find(
+      (input) => input._subgraphSlot?.name === ''
+    )!
+    expect(hostInput.widgetId).toBeUndefined()
+
+    const sourceId = widgetId(host.rootGraph.id, toNodeId(999), 'origin')
+    useWidgetValueStore().registerWidget(sourceId, {
+      type: 'string',
+      value: 'source value',
+      options: {}
+    })
+
+    seedNestedPromotedInputState(host, '', { widgetId: sourceId })
+
+    const rejectedId = widgetId(host.rootGraph.id, host.id, '')
+    expect(useWidgetValueStore().getWidget(rejectedId)).toBeUndefined()
+    expect(hostInput.widgetId).toBeUndefined()
+    expect(hostInput.widget).toBeUndefined()
   })
 })

--- a/src/core/graph/subgraph/promotionUtils.ts
+++ b/src/core/graph/subgraph/promotionUtils.ts
@@ -21,7 +21,7 @@ import {
   usePreviewExposureStore
 } from '@/stores/previewExposureStore'
 import { useSubgraphNavigationStore } from '@/stores/subgraphNavigationStore'
-import { toNodeId } from '@/types/nodeId'
+import { UNASSIGNED_NODE_ID, toNodeId } from '@/types/nodeId'
 import type { SerializedNodeId } from '@/types/nodeId'
 import type { WidgetId } from '@/types/widgetId'
 import { widgetId } from '@/types/widgetId'
@@ -313,12 +313,13 @@ export function promoteValueWidgetViaSubgraphInput(
   return { ok: true }
 }
 
-function seedNestedPromotedInputState(
+export function seedNestedPromotedInputState(
   subgraphNode: SubgraphNode,
   inputName: string,
   sourceSlot: { widgetId?: WidgetId; label?: string }
 ): void {
   if (!sourceSlot.widgetId) return
+  if (subgraphNode.id === UNASSIGNED_NODE_ID) return
 
   const hostInput = subgraphNode.inputs.find(
     (input) => input._subgraphSlot?.name === inputName
@@ -332,8 +333,7 @@ function seedNestedPromotedInputState(
   const id = widgetId(subgraphNode.rootGraph.id, subgraphNode.id, inputName)
   hostInput.widget ??= { name: inputName }
   hostInput.widget.name = inputName
-  hostInput.widgetId = id
-  store.registerWidget(
+  const registered = store.registerWidget(
     id,
     {
       type: sourceState.type,
@@ -345,6 +345,14 @@ function seedNestedPromotedInputState(
     },
     store.getWidgetRenderState(sourceSlot.widgetId) ?? {}
   )
+  if (!registered) {
+    delete hostInput.widget
+    delete hostInput.widgetId
+    hostInput._widget = undefined
+    return
+  }
+
+  hostInput.widgetId = id
 }
 
 function promotePreviewViaExposure(

--- a/src/lib/litegraph/src/linkDeduplication.conflictingOrigins.test.ts
+++ b/src/lib/litegraph/src/linkDeduplication.conflictingOrigins.test.ts
@@ -11,7 +11,18 @@ import { toLinkId } from '@/types/linkId'
 import { toNodeId } from '@/types/nodeId'
 import type { NodeId } from '@/types/nodeId'
 
-import { conflictingOriginLinksRoot } from './__fixtures__/duplicateLinks'
+import {
+  conflictingOriginLinksRoot,
+  duplicateLinksRoot
+} from './__fixtures__/duplicateLinks'
+
+const trackLinkDedupDrop = vi.fn()
+
+vi.mock('@/platform/telemetry', () => ({
+  useTelemetry: () => ({
+    trackLinkDedupDrop
+  })
+}))
 
 class DupTestNode extends LGraphNode {
   constructor(title?: string) {
@@ -90,6 +101,17 @@ describe('normalizeConfiguredTopology with conflicting origins (#15577)', () => 
     )
   })
 
+  it('fires LinkDedupDrop exactly once with the dropped/survivor ids and target when origins differ', () => {
+    configureConflictingOrigins()
+
+    expect(trackLinkDedupDrop).toHaveBeenCalledOnce()
+    expect(trackLinkDedupDrop).toHaveBeenCalledWith({
+      droppedLinkId: 1,
+      survivorLinkId: 2,
+      target: '3:0'
+    })
+  })
+
   it('registers exactly one link at the contested input', () => {
     const graph = configureConflictingOrigins()
 
@@ -110,6 +132,13 @@ describe('normalizeConfiguredTopology with conflicting origins (#15577)', () => 
     )
 
     expect(survivor?.origin_id).toBe(toNodeId(2))
+  })
+
+  it('does not fire LinkDedupDrop for a same-origin remap', () => {
+    const graph = new LGraph()
+    graph.configure(structuredClone(duplicateLinksRoot))
+
+    expect(trackLinkDedupDrop).not.toHaveBeenCalled()
   })
 })
 

--- a/src/lib/litegraph/src/linkDeduplication.transformLinkReferences.test.ts
+++ b/src/lib/litegraph/src/linkDeduplication.transformLinkReferences.test.ts
@@ -1,0 +1,224 @@
+import { describe, expect, it } from 'vitest'
+
+import { toLinkId } from '@/types/linkId'
+
+import { normalizeConfiguredTopology } from './linkDeduplication'
+import type { ExportedSubgraph, SerialisableGraph } from './types/serialisation'
+
+/**
+ * Parametrized coverage for the id-rewrite that `normalizeConfiguredTopology`
+ * performs (via `remapLinkReferences`) across every serialized
+ * reference-location kind: node `input.link`, node `output.links`, subgraph
+ * boundary `linkIds`, reroute `linkIds`, and `linkExtensions`. Each location
+ * is exercised under both drop modes:
+ *
+ * - "replace": the two links at the contested target share an origin, so the
+ *   duplicate is a redundant same-origin copy. Its id is remapped to the
+ *   survivor's id everywhere it is referenced.
+ * - "remove": the two links at the contested target have different origins,
+ *   so the loser names a connection the file recorded that must not survive.
+ *   Its id is still remapped away (to the winner's id) rather than left
+ *   dangling, so every other reference collapses onto the surviving link.
+ *
+ * A location handled in only one call site inside `remapLinkReferences` (or
+ * omitted) leaves a stale id behind after either mode and fails the
+ * corresponding case here.
+ */
+
+type Graph = SerialisableGraph & Partial<ExportedSubgraph>
+type Mode = 'replace' | 'remove'
+
+const SURVIVOR_ORIGIN_ID = 1
+const TARGET_ID = 3
+const SURVIVOR_LINK_ID = 1
+const DUPLICATE_LINK_ID = 2
+
+/** Origin node id for the duplicate link: same node in "replace", a different node in "remove". */
+function duplicateOriginId(mode: Mode): number {
+  return mode === 'replace' ? SURVIVOR_ORIGIN_ID : 2
+}
+
+function originNode(id: number, links: number[]) {
+  return {
+    id,
+    type: 'test/Node',
+    pos: [0, id * 150] as [number, number],
+    size: [100, 100] as [number, number],
+    flags: {},
+    order: 0,
+    mode: 0,
+    inputs: [],
+    outputs: [{ name: 'out', type: 'number', links }],
+    properties: {}
+  }
+}
+
+function targetNode() {
+  return {
+    id: TARGET_ID,
+    type: 'test/Node',
+    pos: [300, 0] as [number, number],
+    size: [100, 100] as [number, number],
+    flags: {},
+    order: 2,
+    mode: 0,
+    // The input references the survivor link, so a different-origin
+    // duplicate at the same slot is the one dropped, not the survivor.
+    inputs: [{ name: 'in', type: 'number', link: SURVIVOR_LINK_ID }],
+    outputs: [],
+    properties: {}
+  }
+}
+
+/**
+ * Builds a graph with two links contending for the same target slot: the
+ * survivor (from `SURVIVOR_ORIGIN_ID`) and a duplicate whose origin depends
+ * on `mode`. `attachExtraLocation` additionally references the duplicate's
+ * id through the reference-location kind under test.
+ */
+function buildGraph(
+  mode: Mode,
+  attachExtraLocation: (graph: Graph, originId: number) => void
+): Graph {
+  const originId = duplicateOriginId(mode)
+  const nodes =
+    mode === 'replace'
+      ? [originNode(SURVIVOR_ORIGIN_ID, [SURVIVOR_LINK_ID]), targetNode()]
+      : [
+          originNode(SURVIVOR_ORIGIN_ID, [SURVIVOR_LINK_ID]),
+          originNode(originId, []),
+          targetNode()
+        ]
+
+  const graph: Graph = {
+    id: 'll000000-0000-4000-8000-000000000001',
+    version: 1,
+    revision: 0,
+    state: { lastNodeId: 3, lastLinkId: 2, lastGroupId: 0, lastRerouteId: 0 },
+    nodes,
+    links: [
+      {
+        id: SURVIVOR_LINK_ID,
+        origin_id: SURVIVOR_ORIGIN_ID,
+        origin_slot: 0,
+        target_id: TARGET_ID,
+        target_slot: 0,
+        type: 'number'
+      },
+      {
+        id: DUPLICATE_LINK_ID,
+        origin_id: originId,
+        origin_slot: 0,
+        target_id: TARGET_ID,
+        target_slot: 0,
+        type: 'number'
+      }
+    ],
+    groups: [],
+    extra: {}
+  }
+
+  attachExtraLocation(graph, originId)
+  return graph
+}
+
+interface LocationCase {
+  name: string
+  attach: (graph: Graph, originId: number) => void
+  read: (graph: Graph, originId: number) => number[]
+}
+
+const locations: LocationCase[] = [
+  {
+    name: 'node input.link',
+    attach: (graph, originId) => {
+      // Only override in "replace" mode (survivor and duplicate share an
+      // origin): there, links[] order — not which id input.link names —
+      // decides the survivor, so pointing the input at the duplicate still
+      // exercises a genuine remap. In "remove" mode, referencing the
+      // duplicate instead of the survivor would flip which link wins under
+      // remapLinkReferences' referencedInputLinks swap, changing what the
+      // fixture is testing.
+      if (originId === SURVIVOR_ORIGIN_ID) {
+        graph.nodes!.find((n) => n.id === TARGET_ID)!.inputs![0].link =
+          DUPLICATE_LINK_ID
+      }
+    },
+    read: (graph) => {
+      const link = graph.nodes!.find((n) => n.id === TARGET_ID)!.inputs![0].link
+      return link == null ? [] : [link]
+    }
+  },
+  {
+    name: 'node output.links',
+    attach: (graph, originId) => {
+      const origin = graph.nodes!.find((n) => n.id === originId)!
+      origin.outputs![0].links = [
+        ...(origin.outputs![0].links ?? []),
+        DUPLICATE_LINK_ID
+      ]
+    },
+    read: (graph, originId) =>
+      graph.nodes!.find((n) => n.id === originId)!.outputs![0].links ?? []
+  },
+  {
+    name: 'subgraph boundary linkIds',
+    attach: (graph) => {
+      graph.outputs = [
+        {
+          id: 'aa000000-0000-4000-8000-000000000002',
+          name: 'boundary_out',
+          type: 'number',
+          linkIds: [DUPLICATE_LINK_ID]
+        }
+      ]
+    },
+    read: (graph) => graph.outputs![0].linkIds ?? []
+  },
+  {
+    name: 'reroute linkIds',
+    attach: (graph) => {
+      graph.reroutes = [{ id: 1, pos: [0, 0], linkIds: [DUPLICATE_LINK_ID] }]
+    },
+    read: (graph) => graph.reroutes![0].linkIds
+  },
+  {
+    name: 'linkExtensions',
+    attach: (graph) => {
+      graph.extra = {
+        linkExtensions: [
+          { id: toLinkId(DUPLICATE_LINK_ID), parentId: undefined }
+        ]
+      }
+    },
+    read: (graph) =>
+      (graph.extra!.linkExtensions ?? []).map((extension) => extension.id)
+  }
+]
+
+describe('normalizeConfiguredTopology reference-location coverage (#15973)', () => {
+  it.for(locations)(
+    '$name replace mode: same-origin duplicate id is remapped to the survivor everywhere',
+    ({ attach, read }) => {
+      const graph = buildGraph('replace', attach)
+
+      const result = normalizeConfiguredTopology(graph)
+
+      const ids = read(result, duplicateOriginId('replace'))
+      expect(ids).not.toContain(DUPLICATE_LINK_ID)
+      expect(ids.every((id) => id === SURVIVOR_LINK_ID)).toBe(true)
+    }
+  )
+
+  it.for(locations)(
+    '$name remove mode: different-origin duplicate id is pruned from every reference',
+    ({ attach, read }) => {
+      const graph = buildGraph('remove', attach)
+
+      const result = normalizeConfiguredTopology(graph)
+
+      const ids = read(result, duplicateOriginId('remove'))
+      expect(ids).not.toContain(DUPLICATE_LINK_ID)
+    }
+  )
+})

--- a/src/lib/litegraph/src/linkDeduplication.ts
+++ b/src/lib/litegraph/src/linkDeduplication.ts
@@ -1,3 +1,4 @@
+import { useTelemetry } from '@/platform/telemetry'
 import { useLinkStore } from '@/stores/linkStore'
 import { graphScopeOf } from '@/types/graphScopeId'
 import type { EndpointUpdate } from '@/stores/linkStore'
@@ -101,11 +102,17 @@ export function normalizeConfiguredTopology<T extends ConfiguredGraph>(
       survivorByDuplicateId.set(fields.id, survivor.id)
     }
     if (!isExactDuplicate) {
+      const targetNodeId = toNodeId(fields.target_id)
       console.warn('Dropping competing link to an occupied input', {
         droppedLinkId,
         survivorLinkId,
-        targetNodeId: toNodeId(fields.target_id),
+        targetNodeId,
         targetSlot: fields.target_slot
+      })
+      useTelemetry()?.trackLinkDedupDrop({
+        droppedLinkId,
+        survivorLinkId,
+        target: `${targetNodeId}:${fields.target_slot}`
       })
     }
   }

--- a/src/lib/litegraph/src/subgraph/SubgraphDuplicateDeleteOrder.test.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphDuplicateDeleteOrder.test.ts
@@ -253,6 +253,33 @@ describe('duplicated subgraph deleted in both orders (I4)', () => {
     expect(promotedValueOf(second)).toBe(before)
   })
 
+  it('does not leak a discarded clipboard clone value into a later unrelated instance (#16250)', () => {
+    const rootGraph = createTestRootGraph()
+    registerTestSubgraphNodeTypes(rootGraph)
+    const definition = createSharedDefinition(rootGraph)
+
+    const original = instantiate(definition, rootGraph, 111)
+
+    // Simulate the clipboard's clone-and-discard: construct a clone (which
+    // runs constructor-time widget resolution while its id is still
+    // UNASSIGNED_NODE_ID), then drop it without ever calling graph.add().
+    const clone = original.clone()
+    expect(clone).not.toBeNull()
+
+    expect(
+      useWidgetValueStore().getWidget(
+        widgetId(rootGraph.id, UNASSIGNED_NODE_ID, PROMOTED_INPUT)
+      )
+    ).toBeUndefined()
+
+    // A later, unrelated instance with the same promoted input name/type
+    // must not inherit anything left behind by the discarded clone.
+    const unrelated = instantiate(definition, rootGraph, 555)
+
+    expect(promotedValueOf(unrelated)).toBe(555)
+    expect(promotedId(unrelated)).not.toBe(promotedId(original))
+  })
+
   it('keeps the shared definition only while a nested instance references it', () => {
     const { rootGraph, definition, instances } = buildScenario()
     const outer = rootGraph.createSubgraph(

--- a/src/lib/litegraph/src/subgraph/SubgraphNode.test.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphNode.test.ts
@@ -18,7 +18,8 @@ import { isWidgetInputSlot } from '@/lib/litegraph/src/node/slotUtils'
 import type { ExportedSubgraphInstance } from '@/lib/litegraph/src/types/serialisation'
 import { NodeSlotType } from '@/lib/litegraph/src/types/globalEnums'
 import { useWidgetValueStore } from '@/stores/widgetValueStore'
-import { toNodeId } from '@/types/nodeId'
+import { UNASSIGNED_NODE_ID, toNodeId } from '@/types/nodeId'
+import { widgetId } from '@/types/widgetId'
 
 import { subgraphTest } from './__fixtures__/subgraphFixtures'
 import {
@@ -249,7 +250,7 @@ describe('SubgraphNode Synchronization', () => {
     )
   })
 
-  it('migrates promoted widget bindings when added to a graph', () => {
+  it('registers promoted widget bindings once added to a graph, not during construction (#16250)', () => {
     const subgraph = createTestSubgraph({
       inputs: [{ name: 'text', type: 'STRING' }]
     })
@@ -262,18 +263,22 @@ describe('SubgraphNode Synchronization', () => {
 
     const subgraphNode = createTestSubgraphNode(subgraph, { id: -1 })
     const promotedInput = subgraphNode.inputs[0]
-    const previousId = promotedInput.widgetId
-    if (!previousId) throw new Error('Missing transient widgetId')
-    useWidgetValueStore().setValue(previousId, 'edited')
+    // Registration is deferred while the node's id is still
+    // UNASSIGNED_NODE_ID: no widgetId is minted, so nothing keyed by the
+    // shared construction-time id can leak into an unrelated instance.
+    expect(promotedInput.widgetId).toBeUndefined()
+    expect(
+      useWidgetValueStore().getWidget(
+        widgetId(subgraph.rootGraph.id, UNASSIGNED_NODE_ID, 'text')
+      )
+    ).toBeUndefined()
 
     subgraph.rootGraph.add(subgraphNode)
 
     const nextId = promotedInput.widgetId
     expect(nextId).toBeDefined()
-    expect(nextId).not.toBe(previousId)
     if (!nextId) throw new Error('Missing settled widgetId')
-    expect(useWidgetValueStore().getWidget(previousId)).toBeUndefined()
-    expect(useWidgetValueStore().getWidget(nextId)?.value).toBe('edited')
+    expect(useWidgetValueStore().getWidget(nextId)?.value).toBe('initial')
     expect(promotedInput.widget).toMatchObject({ name: 'text' })
     expect(subgraphNode.getWidgetFromSlot(promotedInput)).toBe(
       promotedInput._widget

--- a/src/lib/litegraph/src/subgraph/SubgraphNode.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphNode.ts
@@ -650,6 +650,16 @@ export class SubgraphNode extends LGraphNode implements BaseLGraph {
     input.widget.name = subgraphInput.name
     if (inputWidget) Object.setPrototypeOf(input.widget, inputWidget)
 
+    if (this.id === UNASSIGNED_NODE_ID) {
+      // Registering now would key the store under a construction-time id
+      // shared by every not-yet-added SubgraphNode (e.g. a clipboard clone
+      // that gets discarded), letting a later unrelated instance inherit
+      // this value. onAdded() performs the deferred registration once a
+      // real id is assigned.
+      delete input.widgetId
+      return
+    }
+
     const id = widgetId(this.rootGraph.id, this.id, subgraphInput.name)
     const store = useWidgetValueStore()
     const registered = store.registerWidget(
@@ -710,7 +720,14 @@ export class SubgraphNode extends LGraphNode implements BaseLGraph {
     const store = useWidgetValueStore()
     for (const input of this.inputs) {
       const previousId = input.widgetId
-      if (!previousId) continue
+      if (!previousId) {
+        // Registration deferred by _setWidget while this.id was still
+        // UNASSIGNED_NODE_ID (e.g. widget resolution during construction).
+        // Perform it now that a real id is assigned.
+        if (input._subgraphSlot)
+          this._resolveInputWidget(input._subgraphSlot, input)
+        continue
+      }
       const nextId = widgetId(this.rootGraph.id, this.id, input.name)
       if (nextId === previousId) continue
 

--- a/src/platform/telemetry/TelemetryRegistry.ts
+++ b/src/platform/telemetry/TelemetryRegistry.ts
@@ -20,6 +20,7 @@ import type {
   HelpCenterOpenedMetadata,
   HelpResourceClickedMetadata,
   ImageLoadFailureMetadata,
+  LinkDedupDropMetadata,
   NamedValuesShadowDiffMismatchMetadata,
   NamedValuesShadowDiffSummaryMetadata,
   NodeAddedMetadata,
@@ -391,6 +392,10 @@ export class TelemetryRegistry implements TelemetryDispatcher {
     this.dispatch((provider) =>
       provider.trackNamedValuesShadowDiffSummary?.(metadata)
     )
+  }
+
+  trackLinkDedupDrop(metadata: LinkDedupDropMetadata): void {
+    this.dispatch((provider) => provider.trackLinkDedupDrop?.(metadata))
   }
 
   trackPageView(pageName: string, properties?: PageViewMetadata): void {

--- a/src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.test.ts
+++ b/src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.test.ts
@@ -404,6 +404,22 @@ describe('PostHogTelemetryProvider', () => {
       )
     })
 
+    it('captures link dedup drop events with metadata', async () => {
+      const provider = createProvider()
+      await vi.dynamicImportSettled()
+
+      provider.trackLinkDedupDrop({
+        droppedLinkId: 7,
+        survivorLinkId: 3,
+        target: '12:0'
+      })
+
+      expect(hoisted.mockCapture).toHaveBeenCalledWith(
+        TelemetryEvents.LINK_DEDUP_DROP,
+        { droppedLinkId: 7, survivorLinkId: 3, target: '12:0' }
+      )
+    })
+
     it('captures auth failure events with metadata', async () => {
       const provider = createProvider()
       await vi.dynamicImportSettled()

--- a/src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.ts
@@ -36,6 +36,7 @@ import type {
   HelpCenterClosedMetadata,
   HelpCenterOpenedMetadata,
   HelpResourceClickedMetadata,
+  LinkDedupDropMetadata,
   NamedValuesShadowDiffMismatchMetadata,
   NamedValuesShadowDiffSummaryMetadata,
   NodeAddedMetadata,
@@ -705,6 +706,10 @@ export class PostHogTelemetryProvider implements TelemetryProvider {
 
   trackWidgetFavoriteToggled(metadata: WidgetFavoriteToggledMetadata): void {
     this.trackEvent(TelemetryEvents.WIDGET_FAVORITE_TOGGLED, metadata)
+  }
+
+  trackLinkDedupDrop(metadata: LinkDedupDropMetadata): void {
+    this.trackEvent(TelemetryEvents.LINK_DEDUP_DROP, metadata)
   }
 
   trackNamedValuesShadowDiffMismatch(

--- a/src/platform/telemetry/providers/host/HostTelemetrySink.test.ts
+++ b/src/platform/telemetry/providers/host/HostTelemetrySink.test.ts
@@ -203,6 +203,23 @@ describe('HostTelemetrySink', () => {
     )
   })
 
+  it('forwards link dedup drops to the host bridge', () => {
+    new HostTelemetrySink().trackLinkDedupDrop({
+      droppedLinkId: 7,
+      survivorLinkId: 3,
+      target: '12:0'
+    })
+
+    expect(state.capture).toHaveBeenCalledExactlyOnceWith(
+      TelemetryEvents.LINK_DEDUP_DROP,
+      {
+        droppedLinkId: 7,
+        survivorLinkId: 3,
+        target: '12:0'
+      }
+    )
+  })
+
   it('does nothing when the host bridge is absent', () => {
     delete window.__comfyDesktop2
 

--- a/src/platform/telemetry/providers/host/HostTelemetrySink.ts
+++ b/src/platform/telemetry/providers/host/HostTelemetrySink.ts
@@ -14,6 +14,7 @@ import type {
   HelpCenterClosedMetadata,
   HelpCenterOpenedMetadata,
   HelpResourceClickedMetadata,
+  LinkDedupDropMetadata,
   NamedValuesShadowDiffMismatchMetadata,
   NamedValuesShadowDiffSummaryMetadata,
   NodeAddedMetadata,
@@ -290,6 +291,10 @@ export class HostTelemetrySink implements TelemetryProvider {
 
   trackUiButtonClicked(metadata: UiButtonClickMetadata): void {
     this.capture(TelemetryEvents.UI_BUTTON_CLICKED, metadata)
+  }
+
+  trackLinkDedupDrop(metadata: LinkDedupDropMetadata): void {
+    this.capture(TelemetryEvents.LINK_DEDUP_DROP, metadata)
   }
 
   trackNamedValuesShadowDiffMismatch(

--- a/src/platform/telemetry/types.ts
+++ b/src/platform/telemetry/types.ts
@@ -594,6 +594,22 @@ export interface WidgetFavoriteToggledMetadata {
 }
 
 /**
+ * Fired once per duplicate link dropped during workflow load, when the loser
+ * has a *different origin* from the survivor — i.e. a connection the file
+ * recorded is silently discarded, not merely a redundant same-origin copy.
+ * Cloud cannot see the accompanying `console.warn`, so this is the only
+ * signal that a load lost a link. The survivor follows an authoritative
+ * serialized reference: `input.link` for node inputs, `linkIds` priority
+ * order for subgraph boundaries, and document order otherwise. `target`
+ * names the contested input slot.
+ */
+export interface LinkDedupDropMetadata {
+  droppedLinkId: number
+  survivorLinkId: number
+  target: string
+}
+
+/**
  * Fired once per node when its `widgets_values_named` restore path
  * disagrees with what the legacy positional `widgets_values` restore
  * would have produced. Diagnostic only — never reflects an actual
@@ -1087,6 +1103,9 @@ export interface TelemetryProvider {
     metadata: NamedValuesShadowDiffSummaryMetadata
   ): void
 
+  // Link deduplication diagnostics
+  trackLinkDedupDrop?(metadata: LinkDedupDropMetadata): void
+
   // Page view tracking
   trackPageView?(pageName: string, properties?: PageViewMetadata): void
 }
@@ -1246,6 +1265,9 @@ export const TelemetryEvents = {
   NAMED_VALUES_SHADOW_DIFF_MISMATCH: 'app:named_values_shadow_diff_mismatch',
   NAMED_VALUES_SHADOW_DIFF_SUMMARY: 'app:named_values_shadow_diff_summary',
 
+  // Link deduplication diagnostics
+  LINK_DEDUP_DROP: 'app:link_dedup_drop',
+
   // Page View
   PAGE_VIEW: 'app:page_view'
 } as const
@@ -1327,6 +1349,7 @@ export type TelemetryEventProperties =
   | WidgetFavoriteToggledMetadata
   | NamedValuesShadowDiffMismatchMetadata
   | NamedValuesShadowDiffSummaryMetadata
+  | LinkDedupDropMetadata
   | HelpCenterOpenedMetadata
   | HelpResourceClickedMetadata
   | HelpCenterClosedMetadata

--- a/src/scripts/app.test.ts
+++ b/src/scripts/app.test.ts
@@ -17,6 +17,7 @@ import { useWorkflowService } from '@/platform/workflow/core/services/workflowSe
 import { createMockChangeTracker } from '@/utils/__tests__/litegraphTestUtils'
 import { useNodeReplacementStore } from '@/platform/nodeReplacement/nodeReplacementStore'
 import type { NodeReplacement } from '@/platform/nodeReplacement/types'
+import type { NodeExecutionOutput } from '@/schemas/apiSchema'
 import { ComfyApp, app as singletonApp } from './app'
 import { createNode } from '@/utils/litegraphUtil'
 import {
@@ -389,6 +390,42 @@ describe('ComfyApp', () => {
   })
 
   describe('nodeOutputs', () => {
+    it('does O(1) work per write instead of rebuilding the whole output record (#16008)', () => {
+      // Regression for a per-write full-record rekey: each write used to
+      // call `replaceOutputsFromLegacy`, an O(N) `mapKeys` rebuild of every
+      // node's entry, making N sequential output writes O(N^2) overall. A
+      // reintroduction of that path would fail this by calling
+      // `replaceOutputsFromLegacy` and by triggering more than one
+      // `setOutputFromLegacy` commit per single-key write.
+      app.vueAppReady = true
+      const nodeCount = 50
+      const storedOutputs = new Map<string, NodeExecutionOutput>()
+      mockNodeOutputStore.setOutputFromLegacy.mockImplementation((id, output) =>
+        storedOutputs.set(id, output)
+      )
+
+      for (let i = 0; i < nodeCount; i++) {
+        mockNodeOutputStore.setOutputFromLegacy.mockClear()
+        app.nodeOutputs[String(i)] = { images: [{ filename: `${i}.png` }] }
+        expect(mockNodeOutputStore.setOutputFromLegacy).toHaveBeenCalledOnce()
+        expect(mockNodeOutputStore.setOutputFromLegacy).toHaveBeenCalledWith(
+          String(i),
+          { images: [{ filename: `${i}.png` }] }
+        )
+      }
+
+      expect(
+        mockNodeOutputStore.replaceOutputsFromLegacy
+      ).not.toHaveBeenCalled()
+
+      expect(storedOutputs.size).toBe(nodeCount)
+      for (let i = 0; i < nodeCount; i++) {
+        expect(storedOutputs.get(String(i))).toEqual({
+          images: [{ filename: `${i}.png` }]
+        })
+      }
+    })
+
     it('commits legacy property mutations to the output store', () => {
       app.vueAppReady = true
       const output = { images: [{ filename: 'legacy.png' }] }

--- a/src/stores/storeCollisionContracts.test.ts
+++ b/src/stores/storeCollisionContracts.test.ts
@@ -1,0 +1,139 @@
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { toOwningGraphId, toRootGraphId } from '@/types/graphScopeId'
+import type { GraphScope } from '@/types/graphScopeId'
+import { toLinkId } from '@/types/linkId'
+import type { LinkTopology } from '@/types/linkTopology'
+import { toNodeId } from '@/types/nodeId'
+import type { NodeState } from '@/types/nodeState'
+import { toRerouteId } from '@/types/rerouteId'
+import type { RerouteChain } from '@/types/rerouteChain'
+import { widgetId } from '@/types/widgetId'
+import { createNodeState } from '@/utils/__tests__/litegraphTestUtils'
+import type { UUID } from '@/utils/uuid'
+
+import { useLinkStore } from './linkStore'
+import { useNodeDataStore } from './nodeDataStore'
+import { useRerouteStore } from './rerouteStore'
+import { useWidgetValueStore } from './widgetValueStore'
+
+/**
+ * Pins the store collision contract recorded in docs/exceptions-log.md
+ * (EX-002) and docs/adr/0016-entity-registration-collision-and-recovery-boundaries.md:
+ * the three identity-keyed stores (nodeDataStore, linkStore, rerouteStore)
+ * reject a registration at an already-occupied identity key rather than
+ * overwriting it, so the caller can re-mint a new id. The structural-keyed
+ * widgetValueStore instead resolves a collision at its `WidgetId`
+ * (`graphId:nodeId:name`) per documented semantics: a same-type
+ * re-registration keeps the incumbent's value, a different-type
+ * re-registration (a recycled key) overwrites.
+ */
+
+const rootA: UUID = 'root-a'
+const scopeA: GraphScope = {
+  rootGraphId: toRootGraphId(rootA),
+  owningGraphId: toOwningGraphId(rootA)
+}
+const scopeSibling: GraphScope = {
+  rootGraphId: toRootGraphId(rootA),
+  owningGraphId: toOwningGraphId('sub-1')
+}
+
+function nodeState(id: number, graphId: UUID = rootA): NodeState {
+  return createNodeState({ id: toNodeId(id), graphId, title: `Node ${id}` })
+}
+
+function linkTopology(id: number, graphId: UUID = rootA): LinkTopology {
+  return {
+    id: toLinkId(id),
+    graphId: toOwningGraphId(graphId),
+    originNodeId: toNodeId(5),
+    originSlot: 0,
+    targetNodeId: toNodeId(9),
+    targetSlot: id,
+    type: 'INT'
+  }
+}
+
+function rerouteChain(id: number, graphId: UUID = rootA): RerouteChain {
+  return { id: toRerouteId(id), graphId: toOwningGraphId(graphId) }
+}
+
+describe('store collision contracts (EX-002)', () => {
+  beforeEach(() => {
+    setActivePinia(createTestingPinia({ stubActions: false }))
+  })
+
+  it('nodeDataStore rejects a registration at an occupied identity key', () => {
+    const store = useNodeDataStore()
+    const incumbent = nodeState(1)
+    store.registerNode(scopeA, incumbent)
+
+    const challenger = nodeState(1, 'sub-1')
+    const result = store.registerNode(scopeSibling, challenger)
+
+    expect(result).toBeUndefined()
+    expect(store.getGraphNodesFor(rootA, rootA)).toEqual([incumbent])
+    expect(store.getGraphNodesFor(rootA, 'sub-1')).toEqual([])
+  })
+
+  it('linkStore rejects a registration at an occupied identity key', () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    const store = useLinkStore()
+    const incumbent = linkTopology(1)
+    store.registerLink(scopeA, incumbent)
+
+    const challenger = { ...linkTopology(1, 'sub-1'), targetSlot: 3 }
+    const result = store.registerLink(scopeSibling, challenger)
+
+    expect(result).toBeUndefined()
+    expect(store.getTopology(scopeA.rootGraphId, toLinkId(1))?.graphId).toBe(
+      scopeA.owningGraphId
+    )
+  })
+
+  it('rerouteStore rejects a registration at an occupied identity key', () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    const store = useRerouteStore()
+    const incumbent = store.registerReroute(scopeA, rerouteChain(1))
+
+    const challenger = rerouteChain(1, 'sub-1')
+    const result = store.registerReroute(scopeSibling, challenger)
+
+    expect(result).toBeUndefined()
+    expect(store.getReroute(scopeA, toRerouteId(1))).toEqual(incumbent)
+  })
+
+  it('widgetValueStore resolves a same-type collision at its structural key by keeping the incumbent value', () => {
+    const store = useWidgetValueStore()
+    const id = widgetId(rootA, toNodeId('node-1'), 'seed')
+    store.registerWidget(id, { type: 'number', value: 100, options: {} })
+
+    const resolved = store.registerWidget(id, {
+      type: 'number',
+      value: 999,
+      options: {}
+    })
+
+    expect(resolved?.value).toBe(100)
+    expect(store.getWidget(id)?.value).toBe(100)
+  })
+
+  it('widgetValueStore resolves a different-type collision at its structural key by overwriting the recycled entry', () => {
+    const store = useWidgetValueStore()
+    const id = widgetId(rootA, toNodeId('node-1'), 'seed')
+    store.registerWidget(id, { type: 'number', value: 100, options: {} })
+
+    const resolved = store.registerWidget(id, {
+      type: 'string',
+      value: 'recycled',
+      options: {}
+    })
+
+    expect(resolved?.type).toBe('string')
+    expect(resolved?.value).toBe('recycled')
+    expect(store.getWidget(id)?.value).toBe('recycled')
+  })
+})


### PR DESCRIPTION
Backport of #16512 to `core/1.53`. Fixes promoted-widget values leaking across unrelated subgraph node instances (#16250) and nested-promotion widget registration ignoring a rejected store registration (#16013, #16251); adds the regression tests requested in #16008. The auto-backport failed only on the ADR index table; resolved by adding the ADR 0027 row and omitting the ADR 0026 row, which does not exist on this branch.

<details><summary>Full context for agent readers</summary>

- Source: #16512 (merged to main 2026-09-02T15:05Z as bd7f5cfa0d41616c2732374fa268f071025f5111), labeled needs-backport + core/1.53 + cloud/1.53 after merge; the label-triggered auto-backport run failed with a content conflict in `docs/adr/README.md` on both targets.
- Conflict resolution: main's README hunk added rows for ADR 0026 and 0027; `core/1.53` has neither `0026-frontend-document-model.md` nor its row, so only the 0027 row was kept (its file is added by this cherry-pick). No source-file conflicts.
- Verification on this branch: `pnpm vitest run` over every touched test file (16 files, 434 passed, 1 skipped), `pnpm typecheck` clean, `pnpm oxlint` on touched files clean.
- Sibling backport: cloud/1.53 is #16679.
- Tracking: https://github.com/Comfy-Org/ComfyUI_frontend/issues/15973

<!-- authored-by:agent w3-bp16512 -->
</details>
