### PR TITLE
fix(build): scope comfyAPIPlugin's legacy-file match to this package's own src/

### DIFF
--- a/.github/actions/changes-filter/action.yaml
+++ b/.github/actions/changes-filter/action.yaml
@@ -33,7 +33,7 @@ outputs:
     description: 'Shared deps or `packages/**` changed.'
     value: ${{ github.event_name != 'pull_request' || steps.filter.outputs.deps == 'true' || steps.filter.outputs.packages == 'true' }}
   storybook-changes:
-    description: 'Shared deps or `.storybook/**` changed.'
+    description: 'Shared deps, `.storybook/**`, `build/**`, or `vite.config.mts` changed.'
     value: ${{ github.event_name != 'pull_request' || steps.filter.outputs.deps == 'true' || steps.filter.outputs.storybook == 'true' }}
   docs-changes:
     description: '`docs/**` or any `**/*.md` changed (deps NOT folded in).'
@@ -59,6 +59,8 @@ runs:
             - 'packages/**'
           storybook:
             - '.storybook/**'
+            - 'build/**'
+            - 'vite.config.mts'
           docs:
             - 'docs/**'
             - '**/*.md'

--- a/build/plugins/comfyAPIPlugin.test.ts
+++ b/build/plugins/comfyAPIPlugin.test.ts
@@ -1,5 +1,5 @@
+import { fromPartial } from '@total-typescript/shoehorn'
 import path from 'path'
-import type { Plugin } from 'vite'
 import { describe, expect, it, vi } from 'vitest'
 
 import { comfyAPIPlugin, isLegacyFile } from './comfyAPIPlugin'
@@ -67,15 +67,9 @@ describe('comfyAPIPlugin transform', () => {
 
   function runTransform(isDev: boolean, id: string) {
     const emitFile = vi.fn()
-    const hook = comfyAPIPlugin(isDev).transform as NonNullable<
-      Plugin['transform']
-    >
-    const handler = typeof hook === 'function' ? hook : hook.handler
-    const context = { emitFile } as unknown as ThisParameterType<typeof handler>
-    const result = handler.call(context, source, id) as
-      | { code: string; map: null }
-      | null
-      | undefined
+    const handler = comfyAPIPlugin(isDev).transform
+    const context = fromPartial<ThisParameterType<typeof handler>>({ emitFile })
+    const result = handler.call(context, source, id)
     return { result, emitFile }
   }
 

--- a/build/plugins/comfyAPIPlugin.test.ts
+++ b/build/plugins/comfyAPIPlugin.test.ts
@@ -1,0 +1,47 @@
+import path from 'path'
+import { describe, expect, it } from 'vitest'
+
+import { isLegacyFile } from './comfyAPIPlugin'
+
+describe('isLegacyFile', () => {
+  const root = process.cwd()
+
+  it("matches this package's own legacy scripts/", () => {
+    expect(isLegacyFile(path.join(root, 'src/scripts/api.ts'))).toBe(true)
+  })
+
+  it("matches this package's own legacy extensions/core/", () => {
+    expect(
+      isLegacyFile(path.join(root, 'src/extensions/core/groupNode.ts'))
+    ).toBe(true)
+  })
+
+  it("does not match another package's src/scripts (e.g. apps/website)", () => {
+    // Regression: apps/website/src/scripts/customerio.ts previously matched
+    // via a bare "src/scripts" substring check, breaking storybook-build
+    // (RolldownError: relative fileName for the emitted shim asset).
+    expect(
+      isLegacyFile(path.join(root, 'apps/website/src/scripts/customerio.ts'))
+    ).toBe(false)
+  })
+
+  it("does not match another package's src/extensions/core", () => {
+    expect(
+      isLegacyFile(
+        path.join(root, 'apps/website/src/extensions/core/whatever.ts')
+      )
+    ).toBe(false)
+  })
+
+  it('does not match non-.ts files', () => {
+    expect(isLegacyFile(path.join(root, 'src/scripts/api.vue'))).toBe(false)
+  })
+
+  it('does not match src/ files outside scripts/ or extensions/core/', () => {
+    expect(isLegacyFile(path.join(root, 'src/components/App.ts'))).toBe(false)
+  })
+
+  it('does not match files entirely outside src/', () => {
+    expect(isLegacyFile(path.join(root, 'build/plugins/other.ts'))).toBe(false)
+  })
+})

--- a/build/plugins/comfyAPIPlugin.test.ts
+++ b/build/plugins/comfyAPIPlugin.test.ts
@@ -1,18 +1,22 @@
 import path from 'path'
-import { describe, expect, it } from 'vitest'
+import type { Plugin } from 'vite'
+import { describe, expect, it, vi } from 'vitest'
 
-import { isLegacyFile } from './comfyAPIPlugin'
+import { comfyAPIPlugin, isLegacyFile } from './comfyAPIPlugin'
 
 describe('isLegacyFile', () => {
-  const root = process.cwd()
+  // Fixed base so the cases below do not depend on the host cwd, and so a
+  // future change to how the plugin derives its base cannot silently keep
+  // these green by drifting in lockstep with the inputs.
+  const srcRoot = '/repo/src'
 
   it("matches this package's own legacy scripts/", () => {
-    expect(isLegacyFile(path.join(root, 'src/scripts/api.ts'))).toBe(true)
+    expect(isLegacyFile('/repo/src/scripts/api.ts', srcRoot)).toBe(true)
   })
 
   it("matches this package's own legacy extensions/core/", () => {
     expect(
-      isLegacyFile(path.join(root, 'src/extensions/core/groupNode.ts'))
+      isLegacyFile('/repo/src/extensions/core/groupNode.ts', srcRoot)
     ).toBe(true)
   })
 
@@ -21,27 +25,115 @@ describe('isLegacyFile', () => {
     // via a bare "src/scripts" substring check, breaking storybook-build
     // (RolldownError: relative fileName for the emitted shim asset).
     expect(
-      isLegacyFile(path.join(root, 'apps/website/src/scripts/customerio.ts'))
+      isLegacyFile('/repo/apps/website/src/scripts/customerio.ts', srcRoot)
     ).toBe(false)
   })
 
   it("does not match another package's src/extensions/core", () => {
     expect(
       isLegacyFile(
-        path.join(root, 'apps/website/src/extensions/core/whatever.ts')
+        '/repo/apps/website/src/extensions/core/whatever.ts',
+        srcRoot
       )
     ).toBe(false)
   })
 
   it('does not match non-.ts files', () => {
-    expect(isLegacyFile(path.join(root, 'src/scripts/api.vue'))).toBe(false)
+    expect(isLegacyFile('/repo/src/scripts/api.vue', srcRoot)).toBe(false)
   })
 
   it('does not match src/ files outside scripts/ or extensions/core/', () => {
-    expect(isLegacyFile(path.join(root, 'src/components/App.ts'))).toBe(false)
+    expect(isLegacyFile('/repo/src/components/App.ts', srcRoot)).toBe(false)
   })
 
   it('does not match files entirely outside src/', () => {
-    expect(isLegacyFile(path.join(root, 'build/plugins/other.ts'))).toBe(false)
+    expect(isLegacyFile('/repo/build/plugins/other.ts', srcRoot)).toBe(false)
+  })
+
+  it('does not match a sibling directory whose name starts with scripts', () => {
+    expect(isLegacyFile('/repo/src/scripts-old/api.ts', srcRoot)).toBe(false)
+  })
+
+  it('defaults the base to <cwd>/src', () => {
+    const root = process.cwd()
+    expect(isLegacyFile(path.join(root, 'src/scripts/api.ts'))).toBe(true)
+    expect(
+      isLegacyFile(path.join(root, 'apps/website/src/scripts/customerio.ts'))
+    ).toBe(false)
+  })
+})
+
+describe('comfyAPIPlugin transform', () => {
+  // Drive the real hook with the same kind of absolute ids Vite passes, so the
+  // predicate and the emitted shim path are exercised together against the
+  // plugin's actual base rather than a base the test chose.
+  const root = process.cwd()
+  const source = 'export const api = 1\nexport function helper() {}\n'
+
+  function runTransform(isDev: boolean, id: string) {
+    const emitFile = vi.fn()
+    const hook = comfyAPIPlugin(isDev).transform as NonNullable<
+      Plugin['transform']
+    >
+    const handler = typeof hook === 'function' ? hook : hook.handler
+    const context = { emitFile } as unknown as ThisParameterType<typeof handler>
+    const result = handler.call(context, source, id) as
+      | { code: string; map: null }
+      | null
+      | undefined
+    return { result, emitFile }
+  }
+
+  it('emits an output-root-relative shim for a legacy scripts/ file', () => {
+    const { result, emitFile } = runTransform(
+      false,
+      path.join(root, 'src/scripts/api.ts')
+    )
+
+    expect(emitFile).toHaveBeenCalledTimes(1)
+    const asset = emitFile.mock.calls[0][0]
+    expect(asset.type).toBe('asset')
+    expect(asset.fileName).toBe('scripts/api.js')
+    expect(asset.source).toContain(
+      'export const api = window.comfyAPI.api.api;'
+    )
+    expect(asset.source).toContain(
+      'export const helper = window.comfyAPI.api.helper;'
+    )
+    // scripts/api is in SKIP_WARNING_FILES.
+    expect(asset.source).not.toContain('console.warn')
+    expect(result?.code).toContain('window.comfyAPI.api.api = api;')
+  })
+
+  it('emits a deprecation warning shim for a deprecated legacy file', () => {
+    const { emitFile } = runTransform(
+      false,
+      path.join(root, 'src/extensions/core/groupNode.ts')
+    )
+
+    expect(emitFile).toHaveBeenCalledTimes(1)
+    const asset = emitFile.mock.calls[0][0]
+    expect(asset.fileName).toBe('extensions/core/groupNode.js')
+    expect(asset.source).toContain('[ComfyUI Deprecated]')
+  })
+
+  it("does not touch another package's src/scripts file", () => {
+    const { result, emitFile } = runTransform(
+      false,
+      path.join(root, 'apps/website/src/scripts/customerio.ts')
+    )
+
+    expect(emitFile).not.toHaveBeenCalled()
+    expect(result).toBeUndefined()
+  })
+
+  it('is a no-op in dev', () => {
+    const { result, emitFile } = runTransform(
+      true,
+      path.join(root, 'src/scripts/api.ts')
+    )
+
+    expect(result).toBeNull()
+    expect(emitFile).not.toHaveBeenCalled()
   })
 })

--- a/build/plugins/comfyAPIPlugin.test.ts
+++ b/build/plugins/comfyAPIPlugin.test.ts
@@ -105,6 +105,15 @@ describe('comfyAPIPlugin transform', () => {
     expect(result?.code).toContain('window.comfyAPI.api.api = api;')
   })
 
+  it('derives the module name from an id with Windows separators', () => {
+    const { result } = runTransform(
+      false,
+      `${path.join(root, 'src/scripts')}\\api.ts`
+    )
+
+    expect(result?.code).toContain('window.comfyAPI.api.api = api;')
+  })
+
   it('emits a deprecation warning shim for a deprecated legacy file', () => {
     const { emitFile } = runTransform(
       false,

--- a/build/plugins/comfyAPIPlugin.test.ts
+++ b/build/plugins/comfyAPIPlugin.test.ts
@@ -5,53 +5,51 @@ import { describe, expect, it, vi } from 'vitest'
 import { comfyAPIPlugin, isLegacyFile } from './comfyAPIPlugin'
 
 describe('isLegacyFile', () => {
-  // Fixed base so the cases below do not depend on the host cwd, and so a
-  // future change to how the plugin derives its base cannot silently keep
-  // these green by drifting in lockstep with the inputs.
   const srcRoot = '/repo/src'
 
-  it("matches this package's own legacy scripts/", () => {
-    expect(isLegacyFile('/repo/src/scripts/api.ts', srcRoot)).toBe(true)
-  })
-
-  it("matches this package's own legacy extensions/core/", () => {
-    expect(
-      isLegacyFile('/repo/src/extensions/core/groupNode.ts', srcRoot)
-    ).toBe(true)
-  })
-
-  it("does not match another package's src/scripts (e.g. apps/website)", () => {
-    // Regression: apps/website/src/scripts/customerio.ts previously matched
-    // via a bare "src/scripts" substring check, breaking storybook-build
-    // (RolldownError: relative fileName for the emitted shim asset).
-    expect(
-      isLegacyFile('/repo/apps/website/src/scripts/customerio.ts', srcRoot)
-    ).toBe(false)
-  })
-
-  it("does not match another package's src/extensions/core", () => {
-    expect(
-      isLegacyFile(
-        '/repo/apps/website/src/extensions/core/whatever.ts',
-        srcRoot
-      )
-    ).toBe(false)
-  })
-
-  it('does not match non-.ts files', () => {
-    expect(isLegacyFile('/repo/src/scripts/api.vue', srcRoot)).toBe(false)
-  })
-
-  it('does not match src/ files outside scripts/ or extensions/core/', () => {
-    expect(isLegacyFile('/repo/src/components/App.ts', srcRoot)).toBe(false)
-  })
-
-  it('does not match files entirely outside src/', () => {
-    expect(isLegacyFile('/repo/build/plugins/other.ts', srcRoot)).toBe(false)
-  })
-
-  it('does not match a sibling directory whose name starts with scripts', () => {
-    expect(isLegacyFile('/repo/src/scripts-old/api.ts', srcRoot)).toBe(false)
+  it.for([
+    {
+      name: "matches this package's own legacy scripts/",
+      id: '/repo/src/scripts/api.ts',
+      expected: true
+    },
+    {
+      name: "matches this package's own legacy extensions/core/",
+      id: '/repo/src/extensions/core/groupNode.ts',
+      expected: true
+    },
+    {
+      name: "does not match another package's src/scripts",
+      id: '/repo/apps/website/src/scripts/customerio.ts',
+      expected: false
+    },
+    {
+      name: "does not match another package's src/extensions/core",
+      id: '/repo/apps/website/src/extensions/core/whatever.ts',
+      expected: false
+    },
+    {
+      name: 'does not match non-.ts files',
+      id: '/repo/src/scripts/api.vue',
+      expected: false
+    },
+    {
+      name: 'does not match src/ files outside legacy directories',
+      id: '/repo/src/components/App.ts',
+      expected: false
+    },
+    {
+      name: 'does not match files entirely outside src/',
+      id: '/repo/build/plugins/other.ts',
+      expected: false
+    },
+    {
+      name: 'does not match sibling directory names starting with scripts',
+      id: '/repo/src/scripts-old/api.ts',
+      expected: false
+    }
+  ])('$name', ({ id, expected }) => {
+    expect(isLegacyFile(id, srcRoot)).toBe(expected)
   })
 
   it('defaults the base to <cwd>/src', () => {
@@ -64,9 +62,6 @@ describe('isLegacyFile', () => {
 })
 
 describe('comfyAPIPlugin transform', () => {
-  // Drive the real hook with the same kind of absolute ids Vite passes, so the
-  // predicate and the emitted shim path are exercised together against the
-  // plugin's actual base rather than a base the test chose.
   const root = process.cwd()
   const source = 'export const api = 1\nexport function helper() {}\n'
 
@@ -100,18 +95,18 @@ describe('comfyAPIPlugin transform', () => {
     expect(asset.source).toContain(
       'export const helper = window.comfyAPI.api.helper;'
     )
-    // scripts/api is in SKIP_WARNING_FILES.
     expect(asset.source).not.toContain('console.warn')
     expect(result?.code).toContain('window.comfyAPI.api.api = api;')
   })
 
   it('derives the module name from an id with Windows separators', () => {
-    const { result } = runTransform(
+    const { result, emitFile } = runTransform(
       false,
       `${path.join(root, 'src/scripts')}\\api.ts`
     )
 
     expect(result?.code).toContain('window.comfyAPI.api.api = api;')
+    expect(emitFile.mock.calls[0][0].fileName).toBe('scripts/api.js')
   })
 
   it('emits a deprecation warning shim for a deprecated legacy file', () => {

--- a/build/plugins/comfyAPIPlugin.ts
+++ b/build/plugins/comfyAPIPlugin.ts
@@ -34,16 +34,25 @@ function getWarningMessage(
   return `[ComfyUI Notice] "${shimFileName}" is an internal module, not part of the public API. Future updates may break this import.`
 }
 
-export function isLegacyFile(id: string): boolean {
+function defaultSrcRoot(): string {
+  return path.join(process.cwd(), 'src')
+}
+
+/**
+ * Whether `id` is one of this package's legacy public-API files under
+ * `src/scripts/` or `src/extensions/core/`, resolved relative to `srcRoot`
+ * (this package's own `src/`, the same base transformExports uses for the
+ * shim path). A bare substring match on "src/scripts" would also match other
+ * packages' source, e.g. apps/website/src/scripts/customerio.ts, which is not
+ * part of this shim and whose emitted asset path would escape the output root.
+ */
+export function isLegacyFile(
+  id: string,
+  srcRoot: string = defaultSrcRoot()
+): boolean {
   if (!id.endsWith('.ts')) return false
 
-  // Resolve relative to this package's own src/ (same base transformExports
-  // uses for the shim path below), not a substring match on "src/scripts" —
-  // that substring also matches other packages' source, e.g.
-  // apps/website/src/scripts/customerio.ts, which isn't part of this shim.
-  const relativePath = path
-    .relative(path.join(process.cwd(), 'src'), id)
-    .replace(/\\/g, '/')
+  const relativePath = path.relative(srcRoot, id).replace(/\\/g, '/')
 
   if (relativePath.startsWith('..')) return false
 
@@ -100,9 +109,8 @@ export function comfyAPIPlugin(isDev: boolean): Plugin {
         const result = transformExports(code, id)
 
         if (result.exports.length > 0) {
-          const projectRoot = process.cwd()
           const relativePath = path
-            .relative(path.join(projectRoot, 'src'), id)
+            .relative(defaultSrcRoot(), id)
             .replace(/\\/g, '/')
           const shimFileName = relativePath.replace(/\.ts$/, '.js')
 

--- a/build/plugins/comfyAPIPlugin.ts
+++ b/build/plugins/comfyAPIPlugin.ts
@@ -93,7 +93,7 @@ function transformExports(code: string, id: string): ShimResult {
 
 function getModuleName(id: string): string {
   // Simple example to derive a module name from the file path
-  const parts = id.split('/')
+  const parts = id.replace(/\\/g, '/').split('/')
   const fileName = parts[parts.length - 1]
   return fileName.replace(/\.\w+$/, '') // Remove file extension
 }

--- a/build/plugins/comfyAPIPlugin.ts
+++ b/build/plugins/comfyAPIPlugin.ts
@@ -90,7 +90,7 @@ function getModuleName(id: string): string {
   return fileName.replace(/\.\w+$/, '') // Remove file extension
 }
 
-export function comfyAPIPlugin(isDev: boolean): Plugin {
+export function comfyAPIPlugin(isDev: boolean) {
   return {
     name: 'comfy-api-plugin',
     apply: 'build',
@@ -131,5 +131,5 @@ export function comfyAPIPlugin(isDev: boolean): Plugin {
         }
       }
     }
-  }
+  } satisfies Plugin
 }

--- a/build/plugins/comfyAPIPlugin.ts
+++ b/build/plugins/comfyAPIPlugin.ts
@@ -38,14 +38,6 @@ function defaultSrcRoot(): string {
   return path.join(process.cwd(), 'src')
 }
 
-/**
- * Whether `id` is one of this package's legacy public-API files under
- * `src/scripts/` or `src/extensions/core/`, resolved relative to `srcRoot`
- * (this package's own `src/`, the same base transformExports uses for the
- * shim path). A bare substring match on "src/scripts" would also match other
- * packages' source, e.g. apps/website/src/scripts/customerio.ts, which is not
- * part of this shim and whose emitted asset path would escape the output root.
- */
 export function isLegacyFile(
   id: string,
   srcRoot: string = defaultSrcRoot()

--- a/build/plugins/comfyAPIPlugin.ts
+++ b/build/plugins/comfyAPIPlugin.ts
@@ -34,10 +34,22 @@ function getWarningMessage(
   return `[ComfyUI Notice] "${shimFileName}" is an internal module, not part of the public API. Future updates may break this import.`
 }
 
-function isLegacyFile(id: string): boolean {
+export function isLegacyFile(id: string): boolean {
+  if (!id.endsWith('.ts')) return false
+
+  // Resolve relative to this package's own src/ (same base transformExports
+  // uses for the shim path below), not a substring match on "src/scripts" —
+  // that substring also matches other packages' source, e.g.
+  // apps/website/src/scripts/customerio.ts, which isn't part of this shim.
+  const relativePath = path
+    .relative(path.join(process.cwd(), 'src'), id)
+    .replace(/\\/g, '/')
+
+  if (relativePath.startsWith('..')) return false
+
   return (
-    id.endsWith('.ts') &&
-    (id.includes('src/extensions/core') || id.includes('src/scripts'))
+    relativePath.startsWith('extensions/core/') ||
+    relativePath.startsWith('scripts/')
   )
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -42,6 +42,7 @@
   },
   "include": [
     ".storybook/**/*",
+    "build/**/*.ts",
     "eslint.config.ts",
     "global.d.ts",
     "knip.config.ts",

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -847,7 +847,8 @@ export default defineConfig({
       'packages/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}',
       'scripts/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}',
       'browser_tests/**/*.test.{js,mjs,cjs,ts,mts,cts,jsx,tsx}',
-      'tools/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'
+      'tools/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}',
+      'build/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'
     ],
     coverage: {
       provider: 'v8',


### PR DESCRIPTION
`isLegacyFile()` in `build/plugins/comfyAPIPlugin.ts` matched any path containing the substring `src/scripts` or `src/extensions/core`, which also matches `apps/website/src/scripts/customerio.ts`. When Storybook's story glob pulls in `apps/website/src/components/blocks/**` (which transitively imports `customerio.ts`), the plugin misidentifies it as a legacy extension file and tries to emit a shim asset at a path outside the Storybook output root, which Rolldown rejects:

```
RolldownError: The "fileName" or "name" properties of emitted chunks
and assets must be strings that are neither absolute nor relative paths,
received "../apps/website/src/scripts/customerio.js".
```

This breaks the `storybook-build` CI check on any PR whose diff transitively pulls in a website block story, regardless of the PR's own changes — reproduces on current `main` (`a81c1de232`) via `pnpm run build-storybook`.

## Fix

Match relative to this package's own `src/` (the same base `transformExports` already uses for the shim path) instead of a bare substring check, and reject anything that resolves outside `src/` via `..`.

## Tests

Added a focused unit test for `isLegacyFile` covering the regression case plus the existing legacy-shim paths. `build/` had no vitest coverage at all, so also widened the vitest `include` glob to pick up `build/**/*.test.ts`.

Verified locally: `pnpm run build-storybook` now completes successfully (previously failed with the error above), and the legitimate shims (`scripts/api.js`, `extensions/core/agentPanel.js`, etc.) are still emitted correctly in `storybook-static/`.