### PR TITLE
feat(website): add Comfy Agent to nav and ship a zh-CN /agent page

### DIFF
--- a/apps/website/e2e/agent.spec.ts
+++ b/apps/website/e2e/agent.spec.ts
@@ -1,0 +1,98 @@
+import type { Page } from '@playwright/test'
+import { expect } from '@playwright/test'
+
+import { getAgentCards } from '../src/components/agent/agentCards'
+import type { Locale } from '../src/i18n/translations'
+import { t } from '../src/i18n/translations'
+import { test } from './fixtures/blockExternalMedia'
+
+const PATH_EN = '/agent'
+const PATH_ZH = '/zh-CN/agent'
+
+// The hero paints a permanently animated backdrop — a blurred radial gradient
+// plus a drifting masked dot grid — which pins the compositor for as long as
+// the page is open. Several parallel workers each holding an /agent tab starve
+// the main thread badly enough to time out unrelated navigations, so this spec
+// asserts a whole locale from a single visit rather than one visit per claim.
+async function assertLandingPage(page: Page, path: string, locale: Locale) {
+  await page.goto(path)
+
+  await expect(page).toHaveTitle(t('agent.meta.title', locale))
+  // The page is an unlisted beta waitlist: losing noindex would publish it.
+  await expect(page.locator('meta[name="robots"]')).toHaveAttribute(
+    'content',
+    'noindex, nofollow'
+  )
+
+  await expect(
+    page.getByRole('heading', { level: 1, name: t('agent.hero.title', locale) })
+  ).toBeVisible()
+  await expect(page.getByText(t('agent.hero.subtitle', locale))).toBeVisible()
+
+  await expect(
+    page.getByRole('heading', {
+      level: 2,
+      name: t('agent.cards.heading', locale)
+    })
+  ).toBeVisible()
+
+  const cards = getAgentCards(locale)
+  expect(cards).toHaveLength(4)
+  for (const card of cards) {
+    await expect(page.getByText(card.tag, { exact: true })).toBeVisible()
+    await expect(
+      page.getByRole('heading', { level: 3, name: card.title })
+    ).toBeVisible()
+  }
+
+  // The waitlist form only renders once Customer.io is configured, so builds
+  // without the write key skip it rather than failing.
+  const submit = page.getByRole('button', {
+    name: t('agent.form.submit', locale)
+  })
+  if ((await submit.count()) > 0) {
+    await expect(submit).toBeVisible()
+    await expect(
+      page.getByPlaceholder(t('agent.form.placeholder', locale))
+    ).toBeVisible()
+  }
+}
+
+test.describe('Agent landing — desktop @smoke', () => {
+  test('renders the English page at /agent', async ({ page }) => {
+    await assertLandingPage(page, PATH_EN, 'en')
+  })
+
+  test('renders the Chinese page at /zh-CN/agent', async ({ page }) => {
+    await assertLandingPage(page, PATH_ZH, 'zh-CN')
+  })
+})
+
+test.describe('Agent navigation @smoke', () => {
+  for (const [homePath, locale, expectedHref] of [
+    ['/', 'en', PATH_EN],
+    ['/zh-CN', 'zh-CN', PATH_ZH]
+  ] as const) {
+    test(`header and footer link the agent page (${locale})`, async ({
+      page
+    }) => {
+      await page.goto(homePath)
+
+      const nav = page.getByRole('navigation', { name: 'Main navigation' })
+      await nav
+        .getByTestId('desktop-nav-links')
+        .getByRole('button', { name: t('nav.products', locale) })
+        .hover()
+      const headerLink = nav
+        .getByTestId('nav-dropdown')
+        .getByRole('link', { name: t('nav.comfyAgent', locale) })
+      await expect(headerLink).toBeVisible()
+      await expect(headerLink).toHaveAttribute('href', expectedHref)
+
+      const footerLink = page
+        .getByRole('contentinfo')
+        .getByRole('link', { name: t('nav.comfyAgent', locale) })
+      await expect(footerLink).toHaveAttribute('href', expectedHref)
+    })
+  }
+})

--- a/apps/website/src/components/agent/AgentBetaWaitlistForm.test.ts
+++ b/apps/website/src/components/agent/AgentBetaWaitlistForm.test.ts
@@ -202,4 +202,76 @@ describe('AgentBetaWaitlistForm', () => {
     expect(fallback.getAttribute('target')).toBe('_blank')
     expect(fallback.getAttribute('rel')).toBe('noopener noreferrer')
   })
+
+  // The form is the only interactive control on the agent page, so every
+  // string a zh-CN visitor can reach is asserted here rather than trusting
+  // the locale prop to be threaded correctly.
+  describe('zh-CN', () => {
+    const props = { locale: 'zh-CN' } as const
+
+    it('labels the field and the submit control in Chinese', () => {
+      render(AgentBetaWaitlistForm, { props })
+
+      expect(screen.getByLabelText('邮箱地址')).toBeTruthy()
+      expect(
+        screen.getByPlaceholderText('输入你的邮箱').getAttribute('type')
+      ).toBe('email')
+      expect(screen.getByRole('button', { name: '加入候补名单' })).toBeTruthy()
+    })
+
+    it('reports an invalid email in Chinese', async () => {
+      const user = userEvent.setup()
+      render(AgentBetaWaitlistForm, { props })
+
+      await user.type(screen.getByRole('textbox'), 'not-an-email')
+      await user.click(screen.getByRole('button', { name: '加入候补名单' }))
+
+      expect((await screen.findByRole('alert')).textContent).toContain(
+        '请输入有效的邮箱地址。'
+      )
+      expect(hoisted.submit).not.toHaveBeenCalled()
+    })
+
+    it('reports a failed submission in Chinese', async () => {
+      hoisted.submit.mockRejectedValueOnce(new Error('network down'))
+      const user = userEvent.setup()
+      render(AgentBetaWaitlistForm, { props })
+
+      await user.type(screen.getByRole('textbox'), 'someone@example.com')
+      await user.click(screen.getByRole('button', { name: '加入候补名单' }))
+
+      expect((await screen.findByRole('alert')).textContent).toContain(
+        '出错了，请重试。'
+      )
+    })
+
+    it('shows Chinese pending text, then a confirmation naming the email', async () => {
+      let resolveSubmit!: () => void
+      hoisted.submit.mockImplementationOnce(
+        () =>
+          new Promise<void>((resolve) => {
+            resolveSubmit = resolve
+          })
+      )
+      const user = userEvent.setup()
+      render(AgentBetaWaitlistForm, { props })
+
+      await user.type(screen.getByRole('textbox'), 'someone@example.com')
+      await user.click(screen.getByRole('button', { name: '加入候补名单' }))
+
+      expect(screen.getByRole('button', { name: '提交中…' })).toBeTruthy()
+
+      resolveSubmit()
+
+      const confirmation = await screen.findByRole('status')
+      expect(confirmation.textContent).toContain('你已加入候补名单！')
+      // The {email} placeholder has to be substituted, not rendered raw.
+      expect(confirmation.textContent).toContain('someone@example.com')
+      expect(confirmation.textContent).not.toContain('{email}')
+      // The application form stays reachable when the popup was blocked.
+      expect(
+        screen.getByRole('link', { name: '点这里打开' }).getAttribute('href')
+      ).toBe(APPLICATION_URL)
+    })
+  })
 })

--- a/apps/website/src/components/agent/AgentBetaWaitlistForm.vue
+++ b/apps/website/src/components/agent/AgentBetaWaitlistForm.vue
@@ -1,16 +1,20 @@
 <script setup lang="ts">
 import { computed, nextTick, onMounted, ref, useId } from 'vue'
 
+import type { Locale } from '../../i18n/translations'
+import { t } from '../../i18n/translations'
 import {
   isDownloadLinkRequestEnabled,
   joinWaitlist,
   preloadDownloadLinkAnalytics
 } from '../../scripts/customerio'
 
-const { signupEvent = 'agent_beta_waitlist_joined' } = defineProps<{
-  /** Customer.io event tracked on a successful signup. */
-  signupEvent?: string
-}>()
+const { signupEvent = 'agent_beta_waitlist_joined', locale = 'en' } =
+  defineProps<{
+    /** Customer.io event tracked on a successful signup. */
+    signupEvent?: string
+    locale?: Locale
+  }>()
 
 type FormStatus = 'idle' | 'invalid' | 'pending' | 'error' | 'success'
 
@@ -28,10 +32,14 @@ const successRegion = ref<HTMLParagraphElement | null>(null)
 const applicationOpened = ref(false)
 
 const errorMessage = computed(() => {
-  if (status.value === 'invalid') return 'Please enter a valid email address.'
-  if (status.value === 'error') return 'Something went wrong. Please try again.'
+  if (status.value === 'invalid') return t('agent.form.invalidEmail', locale)
+  if (status.value === 'error') return t('agent.form.error', locale)
   return ''
 })
+
+const successMessage = computed(() =>
+  t('agent.form.success', locale).replace('{email}', () => submittedEmail.value)
+)
 
 onMounted(() => {
   if (isDownloadLinkRequestEnabled) preloadDownloadLinkAnalytics()
@@ -88,7 +96,9 @@ async function onSubmit() {
       class="bg-primary-comfy-ink-light mx-auto flex max-w-130 items-center rounded-3xl border border-primary-warm-white/25 p-2 max-[560px]:flex-wrap max-[560px]:gap-3 max-[560px]:border-0 max-[560px]:bg-transparent max-[560px]:p-0"
       @submit.prevent="onSubmit"
     >
-      <label for="agent-beta-email" class="sr-only">Email address</label>
+      <label for="agent-beta-email" class="sr-only">{{
+        t('agent.form.emailLabel', locale)
+      }}</label>
       <input
         v-model="decoy"
         type="text"
@@ -104,7 +114,7 @@ async function onSubmit() {
         type="email"
         name="email"
         autocomplete="email"
-        placeholder="Type your email"
+        :placeholder="t('agent.form.placeholder', locale)"
         required
         :aria-invalid="status === 'invalid' || undefined"
         :aria-describedby="errorMessage ? errorMessageId : undefined"
@@ -116,7 +126,11 @@ async function onSubmit() {
         :aria-busy="status === 'pending'"
         class="bg-primary-comfy-yellow flex-none cursor-pointer rounded-2xl border-0 px-7 py-[15px] text-sm font-bold tracking-[0.06em] text-primary-comfy-ink uppercase disabled:cursor-wait disabled:opacity-75 max-[560px]:w-full max-[560px]:px-6.5 max-[560px]:py-[17px]"
       >
-        {{ status === 'pending' ? 'Joining…' : 'Join the waitlist' }}
+        {{
+          status === 'pending'
+            ? t('agent.form.submitPending', locale)
+            : t('agent.form.submit', locale)
+        }}
       </button>
       <p
         v-if="errorMessage"
@@ -134,16 +148,15 @@ async function onSubmit() {
       tabindex="-1"
       class="bg-primary-comfy-ink-light focus:outline-primary-comfy-yellow border-primary-comfy-yellow/55 mx-auto max-w-130 rounded-3xl border px-6 py-5 text-base text-primary-comfy-canvas focus:outline-2 focus:outline-offset-[3px]"
     >
-      You're on the waitlist! We'll email {{ submittedEmail }} when it's ready.
-      A few questions just opened in a new tab —
+      {{ successMessage }}
       <a
         :href="APPLICATION_URL"
         target="_blank"
         rel="noopener noreferrer"
         class="text-primary-comfy-yellow underline underline-offset-2 hover:opacity-70"
-        >open them here</a
+        >{{ t('agent.form.successLink', locale) }}</a
       >
-      if your browser blocked it.
+      {{ t('agent.form.successTail', locale) }}
     </p>
   </div>
 </template>

--- a/apps/website/src/components/agent/agentCards.test.ts
+++ b/apps/website/src/components/agent/agentCards.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from 'vitest'
 
-import { agentCards } from './agentCards'
+import { getAgentCards } from './agentCards'
 
-describe('agentCards', () => {
+describe('getAgentCards', () => {
   it('pitches the four agent capabilities in order', () => {
-    expect(agentCards.map((card) => card.tag)).toEqual([
+    expect(getAgentCards('en').map((card) => card.tag)).toEqual([
       'Creative knowledge',
       'Human-agent Multiplayer',
       'Control & Iterate',
@@ -13,15 +13,27 @@ describe('agentCards', () => {
   })
 
   it('gives every card a title and body to render', () => {
-    for (const card of agentCards) {
+    for (const card of getAgentCards('en')) {
       expect(card.title.length).toBeGreaterThan(0)
       expect(card.body.length).toBeGreaterThan(0)
     }
   })
 
   it('keeps every tag unique, since the tag is the card key', () => {
-    const tags = agentCards.map((card) => card.tag)
+    const tags = getAgentCards('en').map((card) => card.tag)
 
     expect(new Set(tags).size).toBe(tags.length)
+  })
+
+  it('translates every field for zh-CN', () => {
+    const en = getAgentCards('en')
+    const zh = getAgentCards('zh-CN')
+
+    expect(zh).toHaveLength(en.length)
+    for (const [index, card] of zh.entries()) {
+      expect(card.tag).not.toBe(en[index].tag)
+      expect(card.title).not.toBe(en[index].title)
+      expect(card.body).not.toBe(en[index].body)
+    }
   })
 })

--- a/apps/website/src/components/agent/agentCards.test.ts
+++ b/apps/website/src/components/agent/agentCards.test.ts
@@ -25,15 +25,21 @@ describe('getAgentCards', () => {
     expect(new Set(tags).size).toBe(tags.length)
   })
 
-  it('translates every field for zh-CN', () => {
-    const en = getAgentCards('en')
-    const zh = getAgentCards('zh-CN')
+  // Pins the card-to-key mapping: a reordered CARD_KEYS or a mistyped key
+  // stem would swap a tag onto the wrong title, which comparing en against
+  // zh cannot catch.
+  it('maps each card to its own zh-CN tag and title', () => {
+    expect(getAgentCards('zh-CN')).toMatchObject([
+      { tag: '创意知识', title: '最佳实践可以端到端交付' },
+      { tag: '人机协同', title: '你们两位同时编辑' },
+      { tag: '掌控与迭代', title: '创作始终属于你' },
+      { tag: '本地与云端', title: '你在哪里运行，它就在哪里运行' }
+    ])
+  })
 
-    expect(zh).toHaveLength(en.length)
-    for (const [index, card] of zh.entries()) {
-      expect(card.tag).not.toBe(en[index].tag)
-      expect(card.title).not.toBe(en[index].title)
-      expect(card.body).not.toBe(en[index].body)
+  it('gives every zh-CN card a body to render', () => {
+    for (const card of getAgentCards('zh-CN')) {
+      expect(card.body.length).toBeGreaterThan(0)
     }
   })
 })

--- a/apps/website/src/components/agent/agentCards.ts
+++ b/apps/website/src/components/agent/agentCards.ts
@@ -1,3 +1,6 @@
+import type { Locale } from '../../i18n/translations'
+import { t } from '../../i18n/translations'
+
 /**
  * Pitch cards for the agent landing page. Kept out of the `.astro`
  * frontmatter so the `website-unit` gate can measure them: V8 cannot
@@ -9,25 +12,13 @@ export interface AgentCard {
   body: string
 }
 
-export const agentCards: readonly AgentCard[] = [
-  {
-    tag: 'Creative knowledge',
-    title: 'Best practice can be delivered end to end',
-    body: "Up-to-date knowledge of all the latest models, ComfyUI extensions, parameters, and best workflows, curated by ComfyUI experts. Describe the content and asset you want. It is Comfy Agent's job to learn the technology and model details. It can run a project in auto mode and deliver the best result end to end."
-  },
-  {
-    tag: 'Human-agent Multiplayer',
-    title: 'Two of you edit at the same time',
-    body: "Build a big workflow with the agent in parallel. Watch the graph assemble. Mention a node or reference another workflow. Point at an error and it fixes it. Comfy Agent is fully aware of what's happening on the canvas."
-  },
-  {
-    tag: 'Control & Iterate',
-    title: 'The craft stays yours',
-    body: 'Every control ComfyUI gives you stays exactly where it is. You spend your time on composition, camera angles, masks, parameters, and polishing the details. Power users can always take over: open the nodes and check every single pixel.'
-  },
-  {
-    tag: 'Local and Cloud',
-    title: 'It runs where you run',
-    body: 'Same agent, works with you on your local machine or in Comfy Cloud. It walks you through all setups, builds the workflows, and chooses models based on your hardware. It suggests environment and deployment solutions for your workflow and dependencies.'
-  }
-]
+/** Key stems of the four cards, in the order the page renders them. */
+const CARD_KEYS = ['knowledge', 'multiplayer', 'control', 'anywhere'] as const
+
+export function getAgentCards(locale: Locale = 'en'): readonly AgentCard[] {
+  return CARD_KEYS.map((key) => ({
+    tag: t(`agent.cards.${key}.tag`, locale),
+    title: t(`agent.cards.${key}.title`, locale),
+    body: t(`agent.cards.${key}.body`, locale)
+  }))
+}

--- a/apps/website/src/components/blocks/HeroWaitlist01.test.ts
+++ b/apps/website/src/components/blocks/HeroWaitlist01.test.ts
@@ -86,6 +86,23 @@ describe('HeroWaitlist01', () => {
     expect(screen.getByRole('heading', { level: 1 })).toBeTruthy()
   })
 
+  // The hero owns the only path that reaches the form's locale, so a dropped
+  // prop would leave an English form under Chinese hero copy.
+  it('leaves the embedded form in English by default', () => {
+    renderHero()
+
+    expect(
+      screen.getByRole('button', { name: 'Join the waitlist' })
+    ).toBeTruthy()
+  })
+
+  it('passes its locale down to the form', () => {
+    renderHero({ locale: 'zh-CN' })
+
+    expect(screen.getByRole('button', { name: '加入候补名单' })).toBeTruthy()
+    expect(screen.getByPlaceholderText('输入你的邮箱')).toBeTruthy()
+  })
+
   it('passes its signupEvent down to the form', async () => {
     const user = userEvent.setup()
     renderHero({ signupEvent: 'cloud_beta_waitlist_joined' })

--- a/apps/website/src/components/blocks/HeroWaitlist01.vue
+++ b/apps/website/src/components/blocks/HeroWaitlist01.vue
@@ -3,6 +3,7 @@ import { cn } from '@comfyorg/tailwind-utils'
 
 import type { HTMLAttributes } from 'vue'
 
+import type { Locale } from '../../i18n/translations'
 import { isDownloadLinkRequestEnabled } from '../../scripts/customerio'
 import AgentBetaWaitlistForm from '../agent/AgentBetaWaitlistForm.vue'
 import ProductHeroBadge from '../common/ProductHeroBadge.vue'
@@ -13,6 +14,7 @@ const {
   subtitle,
   footnote,
   signupEvent,
+  locale = 'en',
   class: className
 } = defineProps<{
   badgeText?: string
@@ -25,6 +27,7 @@ const {
   footnote?: string
   /** Customer.io event tracked on a successful signup. */
   signupEvent: string
+  locale?: Locale
   class?: HTMLAttributes['class']
 }>()
 </script>
@@ -81,7 +84,7 @@ const {
         {{ subtitle }}
       </p>
 
-      <AgentBetaWaitlistForm :signup-event="signupEvent" />
+      <AgentBetaWaitlistForm :signup-event="signupEvent" :locale="locale" />
 
       <p
         v-if="footnote && isDownloadLinkRequestEnabled"

--- a/apps/website/src/components/common/SiteFooter.test.ts
+++ b/apps/website/src/components/common/SiteFooter.test.ts
@@ -35,6 +35,24 @@ describe('SiteFooter', () => {
     }
   )
 
+  // The agent page gained a zh-CN twin, so the footer link has to follow the
+  // active locale rather than staying pinned to the canonical /agent path.
+  it.for([
+    ['en', 'Comfy Agent', '/agent'],
+    ['zh-CN', 'Comfy Agent', '/zh-CN/agent']
+  ] as const)(
+    'links the Comfy Agent page at its localized path (%s)',
+    ([locale, name, href]) => {
+      render(SiteFooter, { props: { locale } })
+
+      const links = screen.getAllByRole('link', { name })
+      expect(links.length).toBeGreaterThan(0)
+      for (const link of links) {
+        expect(link.getAttribute('href')).toBe(href)
+      }
+    }
+  )
+
   it('links the MiniMax license page at its localized path for zh-CN', () => {
     render(SiteFooter, { props: { locale: 'zh-CN' } })
 

--- a/apps/website/src/components/common/SiteFooter.vue
+++ b/apps/website/src/components/common/SiteFooter.vue
@@ -40,6 +40,7 @@ const topColumns: { title: string; links: FooterLink[] }[] = [
       { label: t('nav.comfyEnterprise', locale), href: routes.enterprise },
       { label: t('nav.pricing', locale), href: routes.pricing },
       { label: t('nav.mcpServer', locale), href: routes.mcp },
+      { label: t('nav.comfyAgent', locale), href: routes.agent },
       { label: t('nav.comfyCli', locale), href: routes.cli },
       { label: t('nav.supportedModels', locale), href: routes.models },
       { label: t('footer.minimaxH3', locale), href: routes.minimax },

--- a/apps/website/src/config/routes.test.ts
+++ b/apps/website/src/config/routes.test.ts
@@ -126,8 +126,8 @@ describe('getRoutes agent', () => {
     expect(getRoutes('en').agent).toBe('/agent')
   })
 
-  it('serves the English-only agent page at its canonical path for zh-CN', () => {
-    expect(getRoutes('zh-CN').agent).toBe('/agent')
+  it('serves a localized agent path for zh-CN', () => {
+    expect(getRoutes('zh-CN').agent).toBe('/zh-CN/agent')
   })
 })
 

--- a/apps/website/src/config/routes.ts
+++ b/apps/website/src/config/routes.ts
@@ -61,9 +61,6 @@ type Routes = typeof baseRoutes
 // Customer Agreement template), same reasoning. See the comment header
 // in src/pages/enterprise-msa.astro.
 //
-// agent: launch page is English-only for now; keep any route references on the
-// canonical path until a localized page exists.
-//
 // models: the supported-models catalog only exists at /p/supported-models;
 // there is no /<locale>/p/supported-models page, so a prefixed link 404s.
 //
@@ -71,7 +68,6 @@ type Routes = typeof baseRoutes
 // form, so no localized variant exists. See the comment header in
 // src/pages/minimax/license/professional-request.astro.
 const LOCALE_INVARIANT_ROUTE_KEYS = new Set<keyof Routes>([
-  'agent',
   'affiliates',
   'affiliateTerms',
   'termsOfService',

--- a/apps/website/src/data/mainNavigation.ts
+++ b/apps/website/src/data/mainNavigation.ts
@@ -77,9 +77,10 @@ export function getMainNavigation(locale: Locale): NavItem[] {
         {
           header: t('nav.colFeatures', locale),
           items: [
+            { label: t('nav.mcpServer', locale), href: routes.mcp },
             {
-              label: t('nav.mcpServer', locale),
-              href: routes.mcp,
+              label: t('nav.comfyAgent', locale),
+              href: routes.agent,
               badge: 'new'
             },
             {
@@ -90,11 +91,7 @@ export function getMainNavigation(locale: Locale): NavItem[] {
             // TODO: no page yet — re-enable when landing pages ship
             // { label: t('nav.appMode', locale), href: '#' },
             // { label: t('nav.agentSkills', locale), href: '#' },
-            {
-              label: t('nav.launches', locale),
-              href: routes.launches,
-              badge: 'new'
-            },
+            { label: t('nav.launches', locale), href: routes.launches },
             { label: t('nav.supportedModels', locale), href: routes.models },
             {
               label: t('nav.docs', locale),

--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -3408,6 +3408,123 @@ Enterprise`
       '• 通过 Flux、Seedance、Kling、Ideogram 等合作伙伴模型生成图像、视频、音频和 3D\n• 构建、编辑、校验并运行工作流图；保存并重跑\n• 批量排队、等待任务并下载全部输出\n• 搜索模板、模型和节点，附带完整模式\n• 用类型化片段组合多阶段工作流\n\n运行一次 comfy skills install，自带技能会把这一切教给你的智能体。'
   },
 
+  // Agent – nav
+  'nav.comfyAgent': { en: 'Comfy Agent', 'zh-CN': 'Comfy Agent' },
+  'breadcrumb.agent': { en: 'Comfy Agent', 'zh-CN': 'Comfy Agent' },
+
+  // Agent – landing page
+  'agent.meta.title': {
+    en: 'The first agent for craft',
+    'zh-CN': '首个为创作而生的智能体'
+  },
+  'agent.meta.description': {
+    en: 'The Comfy Agent lives inside ComfyUI, local and cloud. Describe what you want: it builds the workflow on your canvas, runs it, and hands back the result.',
+    'zh-CN':
+      'Comfy Agent 就住在 ComfyUI 里，本地与云端皆可运行。描述你想要的东西：它会在你的画布上搭好工作流、运行它，并把结果交给你。'
+  },
+  'agent.hero.badge': { en: 'AGENT', 'zh-CN': 'AGENT' },
+  'agent.hero.title': {
+    en: 'The first agent for craft',
+    'zh-CN': '首个为创作而生的智能体'
+  },
+  'agent.hero.subtitle': {
+    en: 'An agent that lives inside ComfyUI, local and cloud. Describe what you want: it builds the workflow on your canvas with you, reviews assets, runs generations, and iterates until the result is production ready.',
+    'zh-CN':
+      '一个住在 ComfyUI 里的智能体，本地与云端皆可运行。描述你想要的东西：它与你一起在画布上搭建工作流、审阅素材、执行生成，并不断迭代，直到结果足以直接交付。'
+  },
+  'agent.hero.footnote': {
+    en: "We'll prepare your account and email you when it's ready.",
+    'zh-CN': '我们会为你准备好账户，就绪后通过邮件通知你。'
+  },
+  'agent.cards.heading': {
+    en: 'It fits the way you already work',
+    'zh-CN': '它契合你原本的工作方式'
+  },
+  'agent.cards.knowledge.tag': {
+    en: 'Creative knowledge',
+    'zh-CN': '创意知识'
+  },
+  'agent.cards.knowledge.title': {
+    en: 'Best practice can be delivered end to end',
+    'zh-CN': '最佳实践可以端到端交付'
+  },
+  'agent.cards.knowledge.body': {
+    en: "Up-to-date knowledge of all the latest models, ComfyUI extensions, parameters, and best workflows, curated by ComfyUI experts. Describe the content and asset you want. It is Comfy Agent's job to learn the technology and model details. It can run a project in auto mode and deliver the best result end to end.",
+    'zh-CN':
+      '由 ComfyUI 专家精选整理，随时掌握最新模型、ComfyUI 扩展、参数与最佳工作流。你只要描述想要的内容和素材，钻研技术与模型细节是 Comfy Agent 的事。它可以在自动模式下推进整个项目，端到端交付最好的结果。'
+  },
+  'agent.cards.multiplayer.tag': {
+    en: 'Human-agent Multiplayer',
+    'zh-CN': '人机协同'
+  },
+  'agent.cards.multiplayer.title': {
+    en: 'Two of you edit at the same time',
+    'zh-CN': '你们两位同时编辑'
+  },
+  'agent.cards.multiplayer.body': {
+    en: "Build a big workflow with the agent in parallel. Watch the graph assemble. Mention a node or reference another workflow. Point at an error and it fixes it. Comfy Agent is fully aware of what's happening on the canvas.",
+    'zh-CN':
+      '和智能体并行搭建大型工作流，看着节点图一步步成形。提到某个节点，或引用另一个工作流；指出一处报错，它就会修好。画布上发生的一切，Comfy Agent 都清清楚楚。'
+  },
+  'agent.cards.control.tag': {
+    en: 'Control & Iterate',
+    'zh-CN': '掌控与迭代'
+  },
+  'agent.cards.control.title': {
+    en: 'The craft stays yours',
+    'zh-CN': '创作始终属于你'
+  },
+  'agent.cards.control.body': {
+    en: 'Every control ComfyUI gives you stays exactly where it is. You spend your time on composition, camera angles, masks, parameters, and polishing the details. Power users can always take over: open the nodes and check every single pixel.',
+    'zh-CN':
+      'ComfyUI 给你的每一项控制都原封不动地留在原处。你的时间花在构图、镜头角度、遮罩、参数和细节打磨上。资深用户随时可以接管：打开节点，逐个像素地检查。'
+  },
+  'agent.cards.anywhere.tag': {
+    en: 'Local and Cloud',
+    'zh-CN': '本地与云端'
+  },
+  'agent.cards.anywhere.title': {
+    en: 'It runs where you run',
+    'zh-CN': '你在哪里运行，它就在哪里运行'
+  },
+  'agent.cards.anywhere.body': {
+    en: 'Same agent, works with you on your local machine or in Comfy Cloud. It walks you through all setups, builds the workflows, and chooses models based on your hardware. It suggests environment and deployment solutions for your workflow and dependencies.',
+    'zh-CN':
+      '同一个智能体，既能在你的本地机器上和你协作，也能在 Comfy Cloud 中运行。它会带你走完所有配置、搭好工作流，并依据你的硬件挑选模型，还会为你的工作流和依赖推荐环境与部署方案。'
+  },
+
+  // Agent – beta waitlist form
+  'agent.form.emailLabel': { en: 'Email address', 'zh-CN': '邮箱地址' },
+  'agent.form.placeholder': {
+    en: 'Type your email',
+    'zh-CN': '输入你的邮箱'
+  },
+  'agent.form.submit': {
+    en: 'Join the waitlist',
+    'zh-CN': '加入候补名单'
+  },
+  'agent.form.submitPending': { en: 'Joining…', 'zh-CN': '提交中…' },
+  'agent.form.invalidEmail': {
+    en: 'Please enter a valid email address.',
+    'zh-CN': '请输入有效的邮箱地址。'
+  },
+  'agent.form.error': {
+    en: 'Something went wrong. Please try again.',
+    'zh-CN': '出错了，请重试。'
+  },
+  // Split around the link that reopens the application form: the sentence
+  // reads success + link + successTail with the anchor between them.
+  'agent.form.success': {
+    en: "You're on the waitlist! We'll email {email} when it's ready. A few questions just opened in a new tab —",
+    'zh-CN':
+      '你已加入候补名单！准备就绪后我们会发邮件到 {email}。我们刚在新标签页里打开了几个问题 —'
+  },
+  'agent.form.successLink': { en: 'open them here', 'zh-CN': '点这里打开' },
+  'agent.form.successTail': {
+    en: 'if your browser blocked it.',
+    'zh-CN': '（如果浏览器拦截了它）。'
+  },
+
   // CLI – nav + breadcrumb
   'nav.comfyCli': { en: 'Comfy CLI', 'zh-CN': 'Comfy CLI' },
   'breadcrumb.cli': { en: 'Comfy CLI', 'zh-CN': 'Comfy CLI' },

--- a/apps/website/src/pages/zh-CN/agent.astro
+++ b/apps/website/src/pages/zh-CN/agent.astro
@@ -1,10 +1,10 @@
 ---
-import { getAgentCards } from '../components/agent/agentCards'
-import HeroWaitlist01 from '../components/blocks/HeroWaitlist01.vue'
-import { t } from '../i18n/translations'
-import BaseLayout from '../layouts/BaseLayout.astro'
+import { getAgentCards } from '../../components/agent/agentCards'
+import HeroWaitlist01 from '../../components/blocks/HeroWaitlist01.vue'
+import { t } from '../../i18n/translations'
+import BaseLayout from '../../layouts/BaseLayout.astro'
 
-const locale = 'en'
+const locale = 'zh-CN'
 const agentCards = getAgentCards(locale)
 ---
 


### PR DESCRIPTION
## Summary

Adds the `/agent` page to the header and footer navigation, and ships a Chinese twin of the page at `/zh-CN/agent`.

## Changes

- **What**:
  - **Navigation** — `/agent` now appears in the header under Products > Features (directly under Comfy MCP) and in the footer under Products (same position). The `new` badge is removed from Comfy MCP and Launches.
  - **Localization** — the agent page's copy was hardcoded English in the `.astro` frontmatter and in `agentCards.ts`, so building a Chinese version meant extracting it into i18n first, following the pattern `/cli` and `/mcp` already use:
    - new `agent.*` translation block covering meta, hero, cards, and waitlist-form strings
    - `agentCards` const becomes `getAgentCards(locale)`
    - `AgentBetaWaitlistForm` takes a `locale` prop; `HeroWaitlist01` threads it through
    - `agent` leaves `LOCALE_INVARIANT_ROUTE_KEYS`, so `getRoutes('zh-CN').agent` resolves to `/zh-CN/agent` and the zh nav links to the localized page
  - `src/pages/agent.astro` keeps identical markup, now rendering through `t()`; `src/pages/zh-CN/agent.astro` is the new twin.

### Test coverage (added in `8cc52ae`, addressing the CodeRabbit review)

- `e2e/agent.spec.ts` (new) — title, `noindex`, hero, all four cards, and the waitlist form per locale, plus the header dropdown and footer links resolving to `/agent` vs `/zh-CN/agent`
- `agentCards.test.ts` — `toMatchObject()` pinning each card's zh-CN tag and title in order
- `AgentBetaWaitlistForm.test.ts` — a zh-CN block over label, placeholder, submit, pending, both error states, and the success message
- `HeroWaitlist01.test.ts` — the locale prop reaching the embedded form, and staying English when omitted
- `SiteFooter.test.ts` — the Comfy Agent link per locale

## Review Focus

- **Chinese copy** is the main thing worth a native read — the marketing voice on the hero and the four cards especially.
- **Waitlist success message** contains both an `{email}` interpolation and an inline anchor. It reuses the existing `{email}` pattern from `MobileDownloadEmailForm`, and is split into three keys (`success` / `successLink` / `successTail`) so the "open them here" link sits naturally in both languages rather than forcing English word order onto the Chinese sentence.
- **Indexing** — `src/config/indexing.ts` already listed `/zh-CN/agent` as noindex, so the new page inherits it and stays unlisted like the English one. The `llms.txt` coverage test skips zh-CN pages, so no exclusion entry was needed.
- **Pre-existing hero perf issue, surfaced by the new e2e spec.** `HeroWaitlist01` paints a permanently animated backdrop — an `inset-[-20%]` `blur-2xl` radial gradient plus a drifting masked dot grid, both `will-change` — which pins the compositor for as long as the page is open. With four parallel Playwright workers each holding an `/agent` tab, the main thread starves badly enough that a single `page.goto('/agent')` took ~25s and unrelated navigations timed out; `/launches` under identical conditions took ~5s. Disabling the animations made it pass. The spec works around this by asserting a whole locale from a single visit, and it is stable at 4 workers (6s). This predates the PR — the hero and its animations are unchanged here — so I have not touched it, but it looks worth a follow-up.
- **Card tags** carry `uppercase`, which is a no-op on Chinese text. It renders fine, but if the tags should be visually distinguished in zh the way capitals do it in English, that's a follow-up styling call — left alone here.

## Verification

- `pnpm typecheck` — clean (450 files, 0 errors)
- Full website unit suite — 919/919 passing
- `e2e/agent.spec.ts` — 4/4 passing at 4 workers, stable across repeated runs, and green alongside `launches`, `navigation`, and `hreflang` (28/28)
- `oxfmt`, `oxlint`, `stylelint`, `eslint` — clean (also enforced by the pre-commit gate)
- `astro build` emits `/zh-CN/agent/`; both pages checked in a browser — Chinese hero, cards, and form button render without overflow, English page unchanged
