### PR TITLE
fix(agent-crdt): remove deleted follower widgets

### DIFF
--- a/src/workbench/extensions/agent/crdt/ecsFollowerAdapter.integration.test.ts
+++ b/src/workbench/extensions/agent/crdt/ecsFollowerAdapter.integration.test.ts
@@ -1,4 +1,4 @@
-import { applyOps, mint } from '@comfyorg/comfy-multi-player'
+import { applyOps, mint, nodesMap } from '@comfyorg/comfy-multi-player'
 import type { WidgetCatalog } from '@comfyorg/comfy-multi-player'
 import { createTestingPinia } from '@pinia/testing'
 import { setActivePinia } from 'pinia'
@@ -697,6 +697,72 @@ describe('EcsFollowerAdapter integration', () => {
       [toNodeId(2)],
       expect.objectContaining({ source: 'agent-remote', opId: 'op-8' })
     )
+
+    adapter.destroy()
+    follower.destroy()
+    host.destroy()
+  })
+
+  it('removes a widget deleted from an existing remote widget map', () => {
+    const host = mint(
+      {
+        nodes: [
+          {
+            id: 1,
+            type: 'Source',
+            pos: [10, 20],
+            widgets_values: { seed: 1, stale: 9 },
+            inputs: [],
+            outputs: []
+          }
+        ],
+        links: []
+      },
+      catalog
+    )
+    const follower = new FollowerDoc()
+    const mutations = createGraphMutations({
+      getScope: () => scope,
+      layout: { createNode: vi.fn(), deleteNodes: vi.fn() }
+    })
+    const adapter = new EcsFollowerAdapter(mutations)
+    adapter.bind('wf', follower)
+
+    const initial = Y.encodeStateAsUpdate(host)
+    follower.applyRemoteUpdate(initial)
+    expect(
+      adapter.applyFrame({
+        workflowId: 'wf',
+        seq: 1,
+        update: initial,
+        actor: 'agent:test',
+        opIds: ['add']
+      })
+    ).toBe(true)
+    expect(
+      useWidgetValueStore().getWidget(widgetId('root', toNodeId(1), 'stale'))
+        ?.value
+    ).toBe(9)
+
+    const beforeRemoval = Y.encodeStateVector(host)
+    const widgets = nodesMap(host).get('1')?.get('widgets')
+    expect(widgets).toBeInstanceOf(Y.Map)
+    ;(widgets as Y.Map<unknown>).delete('stale')
+    const update = Y.encodeStateAsUpdate(host, beforeRemoval)
+    follower.applyRemoteUpdate(update)
+    expect(
+      adapter.applyFrame({
+        workflowId: 'wf',
+        seq: 2,
+        update,
+        actor: 'agent:test',
+        opIds: ['remove-widget-key']
+      })
+    ).toBe(true)
+
+    expect(
+      useWidgetValueStore().getWidget(widgetId('root', toNodeId(1), 'stale'))
+    ).toBeUndefined()
 
     adapter.destroy()
     follower.destroy()

--- a/src/workbench/extensions/agent/crdt/ecsFollowerAdapter.integration.test.ts
+++ b/src/workbench/extensions/agent/crdt/ecsFollowerAdapter.integration.test.ts
@@ -703,70 +703,127 @@ describe('EcsFollowerAdapter integration', () => {
     host.destroy()
   })
 
-  it('removes a widget deleted from an existing remote widget map', () => {
-    const host = mint(
-      {
-        nodes: [
-          {
-            id: 1,
-            type: 'Source',
-            pos: [10, 20],
-            widgets_values: { seed: 1, stale: 9 },
-            inputs: [],
-            outputs: []
-          }
-        ],
-        links: []
-      },
-      catalog
-    )
-    const follower = new FollowerDoc()
-    const mutations = createGraphMutations({
-      getScope: () => scope,
-      layout: { createNode: vi.fn(), deleteNodes: vi.fn() }
+  describe('remote widget map edits on an existing node', () => {
+    function bindSeededHost() {
+      const host = mint(
+        {
+          nodes: [
+            {
+              id: 1,
+              type: 'Source',
+              pos: [10, 20],
+              widgets_values: { seed: 1, stale: 9 },
+              inputs: [],
+              outputs: []
+            }
+          ],
+          links: []
+        },
+        catalog
+      )
+      const follower = new FollowerDoc()
+      const mutations = createGraphMutations({
+        getScope: () => scope,
+        layout: { createNode: vi.fn(), deleteNodes: vi.fn() }
+      })
+      const adapter = new EcsFollowerAdapter(mutations)
+      adapter.bind('wf', follower)
+
+      const initial = Y.encodeStateAsUpdate(host)
+      follower.applyRemoteUpdate(initial)
+      expect(
+        adapter.applyFrame({
+          workflowId: 'wf',
+          seq: 1,
+          update: initial,
+          actor: 'agent:test',
+          opIds: ['add']
+        })
+      ).toBe(true)
+
+      const nodeMap = nodesMap(host).get('1')
+      expect(nodeMap).toBeInstanceOf(Y.Map)
+      const node = nodeMap as Y.Map<unknown>
+      const widgets = node.get('widgets')
+      expect(widgets).toBeInstanceOf(Y.Map)
+
+      const deliver = (seq: number, mutate: () => void) => {
+        const before = Y.encodeStateVector(host)
+        mutate()
+        const update = Y.encodeStateAsUpdate(host, before)
+        follower.applyRemoteUpdate(update)
+        expect(
+          adapter.applyFrame({
+            workflowId: 'wf',
+            seq,
+            update,
+            actor: 'agent:test',
+            opIds: [`op-${seq}`]
+          })
+        ).toBe(true)
+      }
+      const widgetValue = (name: string) =>
+        useWidgetValueStore().getWidget(widgetId('root', toNodeId(1), name))
+          ?.value
+      const destroy = () => {
+        adapter.destroy()
+        follower.destroy()
+        host.destroy()
+      }
+      return {
+        node,
+        widgets: widgets as Y.Map<unknown>,
+        deliver,
+        widgetValue,
+        destroy
+      }
+    }
+
+    it('removes a widget deleted in place and keeps its siblings', () => {
+      const { widgets, deliver, widgetValue, destroy } = bindSeededHost()
+      expect(widgetValue('stale')).toBe(9)
+
+      deliver(2, () => widgets.delete('stale'))
+
+      expect(widgetValue('stale')).toBeUndefined()
+      expect(widgetValue('seed')).toBe(1)
+      expect(
+        useNodeDataStore()
+          .getGraphNodesFor('root', 'root')
+          .map(({ id }) => id)
+      ).toEqual(['1'])
+      expect(useWidgetValueStore().clearNode).toHaveBeenCalledTimes(1)
+      destroy()
     })
-    const adapter = new EcsFollowerAdapter(mutations)
-    adapter.bind('wf', follower)
 
-    const initial = Y.encodeStateAsUpdate(host)
-    follower.applyRemoteUpdate(initial)
-    expect(
-      adapter.applyFrame({
-        workflowId: 'wf',
-        seq: 1,
-        update: initial,
-        actor: 'agent:test',
-        opIds: ['add']
+    it('keeps the targeted update path for value changes and same-frame re-adds', () => {
+      const { widgets, deliver, widgetValue, destroy } = bindSeededHost()
+
+      deliver(2, () => widgets.set('seed', 5))
+      deliver(3, () => {
+        widgets.delete('stale')
+        widgets.set('stale', 11)
       })
-    ).toBe(true)
-    expect(
-      useWidgetValueStore().getWidget(widgetId('root', toNodeId(1), 'stale'))
-        ?.value
-    ).toBe(9)
 
-    const beforeRemoval = Y.encodeStateVector(host)
-    const widgets = nodesMap(host).get('1')?.get('widgets')
-    expect(widgets).toBeInstanceOf(Y.Map)
-    ;(widgets as Y.Map<unknown>).delete('stale')
-    const update = Y.encodeStateAsUpdate(host, beforeRemoval)
-    follower.applyRemoteUpdate(update)
-    expect(
-      adapter.applyFrame({
-        workflowId: 'wf',
-        seq: 2,
-        update,
-        actor: 'agent:test',
-        opIds: ['remove-widget-key']
+      expect(widgetValue('seed')).toBe(5)
+      expect(widgetValue('stale')).toBe(11)
+      expect(useWidgetValueStore().clearNode).not.toHaveBeenCalled()
+      destroy()
+    })
+
+    it('drops widgets missing from a replaced widget map', () => {
+      const { node, deliver, widgetValue, destroy } = bindSeededHost()
+
+      deliver(2, () => {
+        const replacement = new Y.Map<unknown>()
+        node.set('widgets', replacement)
+        replacement.set('seed', 5)
       })
-    ).toBe(true)
 
-    expect(
-      useWidgetValueStore().getWidget(widgetId('root', toNodeId(1), 'stale'))
-    ).toBeUndefined()
-
-    adapter.destroy()
-    follower.destroy()
-    host.destroy()
+      expect(widgetValue('seed')).toBe(5)
+      expect(widgetValue('stale')).toBeUndefined()
+      destroy()
+    })
   })
 
   it('keeps follower docs and apply queues isolated by workflow target', () => {

--- a/src/workbench/extensions/agent/crdt/ecsFollowerAdapter.ts
+++ b/src/workbench/extensions/agent/crdt/ecsFollowerAdapter.ts
@@ -111,6 +111,7 @@ interface TargetSession {
   readonly mutations: GraphMutations
   readonly nodeActions: Map<string, NodeRootAction>
   readonly changedWidgets: Map<string, Set<string>>
+  readonly replacedWidgetMaps: Set<string>
   readonly changedLinks: Set<string>
   readonly frameQueue: DocUpdate[]
   onNodesChanged: (events: Y.YEvent<Y.AbstractType<unknown>>[]) => void
@@ -197,6 +198,7 @@ export class EcsFollowerAdapter {
           : this.mutations,
       nodeActions: new Map<string, NodeRootAction>(),
       changedWidgets: new Map<string, Set<string>>(),
+      replacedWidgetMaps: new Set<string>(),
       changedLinks: new Set<string>(),
       frameQueue: [],
       reconcileNextFrame: true,
@@ -215,6 +217,7 @@ export class EcsFollowerAdapter {
     const changedWidgets = new Map(
       [...session.changedWidgets].map(([id, names]) => [id, new Set(names)])
     )
+    const replacedWidgetMaps = new Set(session.replacedWidgetMaps)
     const changedLinkIds = new Set(session.changedLinks)
     const reconcile = session.reconcileNextFrame
     this.discardSessionPending(session)
@@ -270,8 +273,13 @@ export class EcsFollowerAdapter {
         if (!payload) continue
         batch.addNode(payload)
       }
-      for (const [id, names] of changedWidgets) {
+      for (const id of replacedWidgetMaps) {
         if (nodeActions.has(id)) continue
+        const payload = readSemanticNode(session.follower.doc, id)
+        if (payload) batch.reconcileNode(payload)
+      }
+      for (const [id, names] of changedWidgets) {
+        if (nodeActions.has(id) || replacedWidgetMaps.has(id)) continue
         const node = session.nodes.get(id)
         const widgets = node?.get('widgets')
         if (!(widgets instanceof Y.Map)) continue
@@ -301,6 +309,7 @@ export class EcsFollowerAdapter {
   private discardSessionPending(session: TargetSession): void {
     session.nodeActions.clear()
     session.changedWidgets.clear()
+    session.replacedWidgetMaps.clear()
     session.changedLinks.clear()
   }
 
@@ -325,11 +334,8 @@ export class EcsFollowerAdapter {
         continue
       }
 
-      if (event.path.length === 1 && event.keysChanged.has('widgets')) {
-        const widgets = session.nodes.get(id)?.get('widgets')
-        if (widgets instanceof Y.Map)
-          session.changedWidgets.set(id, new Set(widgets.keys()))
-      }
+      if (event.path.length === 1 && event.keysChanged.has('widgets'))
+        session.replacedWidgetMaps.add(id)
     }
   }
 

--- a/src/workbench/extensions/agent/crdt/ecsFollowerAdapter.ts
+++ b/src/workbench/extensions/agent/crdt/ecsFollowerAdapter.ts
@@ -275,9 +275,13 @@ export class EcsFollowerAdapter {
         const node = session.nodes.get(id)
         const widgets = node?.get('widgets')
         if (!(widgets instanceof Y.Map)) continue
+        if ([...names].some((name) => !widgets.has(name))) {
+          const payload = readSemanticNode(session.follower.doc, id)
+          if (payload) batch.reconcileNode(payload)
+          continue
+        }
         for (const name of names) {
-          if (widgets.has(name))
-            batch.setWidget(toNodeId(id), name, plain(widgets.get(name)))
+          batch.setWidget(toNodeId(id), name, plain(widgets.get(name)))
         }
       }
       for (const id of changedLinkIds) {


### PR DESCRIPTION
## Summary

Removes stale projected widget state when a remote CRDT update deletes one key in place from an existing widget map.

## Changes

- **What**: Reconcile the authoritative semantic node when a changed widget key no longer exists; add a permanent follower integration regression test.

## Review Focus

Please verify that full-node reconciliation is the appropriate deletion path while ordinary widget value changes retain their targeted update path.

Linear: [FE-1995](https://linear.app/comfyorg/issue/FE-1995/crdt-follower-leaves-stale-widget-after-in-place-remote-key-deletion)
Source reproducer: [#16361](https://github.com/Comfy-Org/ComfyUI_frontend/pull/16361)

## Verification

- `pnpm vitest run src/workbench/extensions/agent/crdt` — 236 passed
- `pnpm typecheck`
- `pnpm exec eslint src/workbench/extensions/agent/crdt/ecsFollowerAdapter.ts src/workbench/extensions/agent/crdt/ecsFollowerAdapter.integration.test.ts`
- `pnpm exec oxfmt --check src/workbench/extensions/agent/crdt/ecsFollowerAdapter.ts src/workbench/extensions/agent/crdt/ecsFollowerAdapter.integration.test.ts`

## Screenshots (if applicable)

Not applicable; no UI change.
