### PR TITLE
fix(website): point FDCT hero at FDCT_V6.mp4

### DIFF
--- a/apps/website/src/templates/fdct/HeroSection.vue
+++ b/apps/website/src/templates/fdct/HeroSection.vue
@@ -22,7 +22,7 @@ const { locale = 'en' } = defineProps<{ locale?: Locale }>()
     video-autoplay
     video-loop
     :video-aria-label="t('fdct.hero.title', locale)"
-    video-src="https://media.comfy.org/website/fdct/FDCT_V4.mp4"
+    video-src="https://media.comfy.org/website/fdct/FDCT_V6.mp4"
     video-poster="https://media.comfy.org/website/fdct/FDCT_V4_thumb.jpeg"
   />
 </template>


### PR DESCRIPTION
## Summary

Swaps the `/forward-deployed-creatives` hero video from `FDCT_V4.mp4` to `FDCT_V6.mp4`.

## Changes

- **What**: `video-src` on the FDCT hero now points at `https://media.comfy.org/website/fdct/FDCT_V6.mp4`. Verified the asset is live on the CDN (200).

## Review Focus

- **The poster is intentionally still `FDCT_V4_thumb.jpeg`.** `FDCT_V6_thumb.jpeg` returns 404 on the CDN, so renaming it in lockstep would have broken the hero's first paint. Once a V6 thumbnail is uploaded, the poster and the two assertions on `FDCT_V4_thumb` (`HeroSection.test.ts:19`, `e2e/fdct.spec.ts:271`) should be updated together.
- No test asserts the mp4 source, so no test changes were needed here. `HeroSection.test.ts` passes (2/2).