### PR TITLE
test: add coverage floor for agent panel + CRDT follower dirs

### DIFF
--- a/vite.config.mts
+++ b/vite.config.mts
@@ -85,6 +85,24 @@ const CRITICAL_COVERAGE_THRESHOLDS = {
   lines: 70
 }
 
+// In-App Agent panel + CRDT follower surface (QA-17, coverage-floor-agent-dirs).
+// A separate bucket from CRITICAL_COVERAGE_DIRS: this directory is measured
+// ~90%+ today, so folding it into the general 60-70% floor would mask a real
+// regression here. Thresholds are set a few points under the last measured
+// run (93.38/80.25/90.09/93.68 stmts/branches/funcs/lines) so the gate
+// catches a real drop without flaking on normal churn. The aggregate already
+// absorbs crdt/CrdtDevPanel.vue's low score (it is the dev-only CRDT
+// inspector panel, intentionally minimal per CLAUDE.md's "Dev-panel
+// exception") — no separate exclude needed, the floor has margin either way.
+const AGENT_PANEL_COVERAGE_GLOB = 'src/workbench/extensions/agent/**/*.{ts,vue}'
+
+const AGENT_PANEL_COVERAGE_THRESHOLDS = {
+  statements: 88,
+  branches: 72,
+  functions: 82,
+  lines: 88
+}
+
 // WebGL2 / pixel-processing passes that need a real rendering context,
 // which happy-dom does not provide. TODO: cover via browser tests.
 const LAYER_EDITOR_GPU_COVERAGE_EXCLUDE = [
@@ -864,7 +882,8 @@ export default defineConfig({
         ...NON_CRITICAL_LITEGRAPH_COVERAGE_EXCLUDE
       ],
       thresholds: {
-        [CRITICAL_COVERAGE_GLOB]: CRITICAL_COVERAGE_THRESHOLDS
+        [CRITICAL_COVERAGE_GLOB]: CRITICAL_COVERAGE_THRESHOLDS,
+        [AGENT_PANEL_COVERAGE_GLOB]: AGENT_PANEL_COVERAGE_THRESHOLDS
       }
     },
     exclude: [


### PR DESCRIPTION
## Summary

Adds a dedicated `coverage.thresholds` bucket in `vite.config.mts` scoped to
`src/workbench/extensions/agent/**` (the In-App Agent panel + CRDT follower
surface), separate from the existing project-wide `CRITICAL_COVERAGE_DIRS`
bucket.

## Why

That directory is not part of the existing `CRITICAL_COVERAGE_DIRS` floor, so
new code there can land with zero test coverage and nothing in CI catches it.
Measured coverage today is already high (93.38% statements / 80.25% branches
/ 90.09% functions / 93.68% lines across the whole subtree, including the
dev-only `crdt/CrdtDevPanel.vue` inspector, which is intentionally lightly
tested). Thresholds are set a few points under those numbers (88/72/82/88) so
the gate has margin against normal churn but still fails a real regression.

No exclude was needed for `CrdtDevPanel.vue` — its low per-file score is
already absorbed into the aggregate with room to spare.

## Verification

- `pnpm typecheck` — clean
- `NODE_OPTIONS="--no-experimental-webstorage" COLLECT_COVERAGE=true npx vitest run --coverage src/workbench/extensions/agent` — 824/824 tests pass (one `AgentPanelRoot.test.ts` timer-based test is flaky under load and failed once, passed clean on retry; unrelated to this change), and the new `AGENT_PANEL_COVERAGE_GLOB` threshold bucket does not error.
- `pnpm test:coverage` (full suite) exercises the new bucket in CI the same way it already exercises `CRITICAL_COVERAGE_GLOB`.

Source: todo.md row `QA-17 coverage-floor-agent-dirs`.