### PR TITLE
feat(website): add Image-to-Video basics learning module

### DIFF
--- a/apps/website/public/llms.txt
+++ b/apps/website/public/llms.txt
@@ -164,6 +164,7 @@ Languages: comfy.org is published in English and Simplified Chinese, with a Japa
 - [Text-to-Image and Image-to-Image Workflows](https://comfy.org/learning/basics/text-to-image-image-to-image/): Build a text-to-image workflow, then adapt it for image-to-image.
 - [LoRAs, Style Transfer, and ControlNets](https://comfy.org/learning/basics/loras-style-transfer-controlnets/): What each one does and how to wire them into a ComfyUI workflow.
 - [Inpainting, Outpainting, and Upscaling](https://comfy.org/learning/basics/inpainting-outpainting-upscaling/): Mask and repaint, extend the frame, and add resolution in ComfyUI.
+- [Image-to-Video, Motion Control, and Upscaling](https://comfy.org/learning/basics/image-to-video-motion-control-upscaling/): Animate a still image, steer the shot with motion control, and finish at higher resolution.
 
 ### Ad Creative
 

--- a/apps/website/src/data/learningTutorials.ts
+++ b/apps/website/src/data/learningTutorials.ts
@@ -183,6 +183,7 @@ const imageToImageTag: TranslationKey = 'tags.imageToImage'
 const inpaintingTag: TranslationKey = 'tags.inpainting'
 const outpaintingTag: TranslationKey = 'tags.outpainting'
 const upscalingTag: TranslationKey = 'tags.upscaling'
+const motionControlTag: TranslationKey = 'tags.motionControl'
 
 const dougHogan: TutorialAuthor = {
   name: { en: 'Doug Hogan', 'zh-CN': 'Doug Hogan' },
@@ -290,6 +291,30 @@ export const learningTutorials: readonly LearningTutorial[] = [
     newTab: true,
     ctaLabelKey: 'cta.tryForFree',
     tags: [fundamentalsTag, inpaintingTag, outpaintingTag, upscalingTag]
+  },
+  {
+    id: 'basics_image_to_video',
+    publishedDate: '2026-09-02',
+    slug: 'image-to-video-motion-control-upscaling',
+    category: 'basics',
+    episode: 5,
+    author: dougHogan,
+    youtubeId: 'Yuw8F4E4-7Y',
+    title: {
+      en: 'ComfyUI Tutorial for Beginners: Image-to-Video, Motion Control & Upscaling (2026)',
+      'zh-CN': 'ComfyUI 新手教程：图生视频、运动控制与放大 (2026)'
+    },
+    description: {
+      en: 'Turn a still into a shot: build an image-to-video workflow, steer the result with motion control, and finish at higher resolution with upscaling.',
+      'zh-CN':
+        '让静态图动起来：搭建图生视频工作流，用运动控制引导镜头表现，再通过放大以更高分辨率输出。'
+    },
+    poster:
+      'https://media.comfy.org/website/learning/image-to-video-motion-control-upscaling-thumb.jpg',
+    href: externalLinks.cloudCta('learning_basics_image_to_video'),
+    newTab: true,
+    ctaLabelKey: 'cta.tryForFree',
+    tags: [fundamentalsTag, imageToVideoTag, motionControlTag, upscalingTag]
   },
   {
     id: 'cleanplate_walkthrough_v03',

--- a/apps/website/src/data/learningTutorials.ts
+++ b/apps/website/src/data/learningTutorials.ts
@@ -310,7 +310,7 @@ export const learningTutorials: readonly LearningTutorial[] = [
         '让静态图动起来：搭建图生视频工作流，用运动控制引导镜头表现，再通过放大以更高分辨率输出。'
     },
     poster:
-      'https://media.comfy.org/website/learning/image-to-video-motion-control-upscaling-thumb.jpg',
+      'https://media.comfy.org/website/learning/image-to-video-motion-control-upscaling-thumb.png',
     href: externalLinks.cloudCta('learning_basics_image_to_video'),
     newTab: true,
     ctaLabelKey: 'cta.tryForFree',

--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -110,6 +110,10 @@ const translations = {
     en: 'Upscaling',
     'zh-CN': '放大'
   },
+  'tags.motionControl': {
+    en: 'Motion Control',
+    'zh-CN': '运动控制'
+  },
 
   // UI (global, reusable across sections)
   'ui.copy': {


### PR DESCRIPTION
## Summary

Adds episode 5 of the Comfy 101 basics series to `/learning/basics`: **ComfyUI Tutorial for Beginners: Image-to-Video, Motion Control & Upscaling (2026)** ([Yuw8F4E4-7Y](https://www.youtube.com/watch?v=Yuw8F4E4-7Y), published 2026-09-02).

## Changes

- **Tutorial entry** — `basics_image_to_video`, episode 5, slug `image-to-video-motion-control-upscaling`, en + zh-CN title and description, cloud CTA (`utm_content=learning_basics_image_to_video`), `ctaLabelKey: 'cta.tryForFree'`, tags: fundamentals / image-to-video / motion control / upscaling.
- **i18n** — one new key, `tags.motionControl` (en + zh-CN). The other three tags already existed.
- **llms.txt** — one link line under the ComfyUI Basics section.

## Poster asset

The poster is the official module 05 card from the design team, live at `media.comfy.org/website/learning/image-to-video-motion-control-upscaling-thumb.png` (mirrored to `gs://comfy-org-videos`). Titled "From Images to Video." with the `IMAGES TO VIDEO` module descriptor, matching the module 02–04 template.

Note this one is a **`.png`**, where the other four basics posters are `.jpg` — the extension differs, the naming convention (`<slug>-thumb`) does not.

Two things a reviewer may want to weigh in on, neither blocking:

1. The source art is **1919×1080**, where the other basics posters are 1280×720. The aspect ratio is effectively 16:9 so nothing distorts, but it is ~3× the pixel area and lands as a 218 KB PNG against ~140 KB JPEGs.
2. There is a small stray UI pill baked into the art at bottom centre (roughly x 940–981, y 1057–1065) — it reads as a capture artifact rather than an intentional design element.

## Review Focus

- `learning.categories.basics.metaDescription` is **not** updated here. It's at its ~155-character budget, so adding image-to-video means dropping an existing keyword — an editorial call left open rather than made silently. The visible `learning.categories.basics.description` still reads "the node graph, LoRAs, style transfer, and ControlNets" and is likewise now incomplete (flagged previously in #16523).

## Verification

- `pnpm --filter @comfyorg/website test:unit` — 947 passed / 142 files
- `pnpm typecheck` + `pnpm typecheck:website` — 0 errors (both run green in the pre-commit hook)
- `astro build` — 715 pages, both `/learning/basics/image-to-video-motion-control-upscaling/` and the `/zh-CN/` twin generate, with the correct nocookie embed, poster URL, CTA, and `"uploadDate":"2026-09-02"` in the JSON-LD
- Poster verified live: `curl -I` → 200 `image/png`
