### PR TITLE
fix(website): use video media for the Sept 2 H3 Sync event

### DIFF
--- a/apps/website/e2e/events.spec.ts
+++ b/apps/website/e2e/events.spec.ts
@@ -3,11 +3,13 @@ import { expect } from '@playwright/test'
 
 import { localizeHref } from '../src/config/routes'
 import {
+  eventMediaThumbnail,
   eventPath,
   eventVideoId,
   featuredEvents,
   pastEvents,
-  upcomingEvents
+  upcomingEvents,
+  watchableEvents
 } from '../src/data/events'
 import type { Locale } from '../src/i18n/translations'
 import { t } from '../src/i18n/translations'
@@ -24,6 +26,13 @@ const LOCALES: ReadonlyArray<readonly [string, Locale]> = [
 const pastCardEvents = pastEvents.filter(
   (event) => event.media ?? event.featured?.media
 )
+
+// Only watchable events get an /events/[slug] page.
+const videoMediaEventPages = watchableEvents.filter(
+  (event) => event.media?.type === 'video'
+)
+
+const VIDEO_FILE = /\.(mp4|webm|mov)(\?|$)/i
 
 function heroSection(page: Page, locale: Locale) {
   return page.locator('section').filter({
@@ -381,5 +390,32 @@ test.describe('Events page — mobile @mobile', () => {
     const viewport = page.viewportSize()
     expect(viewport, 'viewport size').not.toBeNull()
     expect(box!.x + box!.width).toBeLessThanOrEqual(viewport!.width + 1)
+  })
+})
+
+test.describe('Event detail pages — desktop @smoke', () => {
+  test('video media resolves to its poster still for the social image', async ({
+    page
+  }) => {
+    test.skip(
+      videoMediaEventPages.length === 0,
+      'needs a watchable event with video media'
+    )
+
+    for (const event of videoMediaEventPages) {
+      await page.goto(eventPath(event))
+      const poster = eventMediaThumbnail(event.media)
+
+      for (const selector of [
+        'meta[property="og:image"]',
+        'meta[name="twitter:image"]'
+      ]) {
+        const content = await page.locator(selector).getAttribute('content')
+        // A video's own src is not an image, so the card must never point at
+        // the media file itself — with or without a poster configured.
+        expect(content, `${event.id} ${selector}`).not.toMatch(VIDEO_FILE)
+        if (poster) expect(content, `${event.id} ${selector}`).toBe(poster)
+      }
+    }
   })
 })

--- a/apps/website/src/data/events.test.ts
+++ b/apps/website/src/data/events.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest'
 import type { ComfyEvent } from './events'
 import {
   deriveFeaturedEvents,
+  eventMediaThumbnail,
   derivePastEvents,
   deriveUpcomingEvents,
   eventJsonLdNode,
@@ -274,5 +275,73 @@ describe('site event data', () => {
     const ids = [...upcomingEvents, ...pastEvents].map((event) => event.id)
 
     expect(new Set(ids).size).toBe(ids.length)
+  })
+})
+
+describe('eventMediaThumbnail', () => {
+  it('uses the src of image media', () => {
+    expect(
+      eventMediaThumbnail({
+        type: 'image',
+        src: 'https://media.comfy.org/a.jpg',
+        alt: { en: 'A', 'zh-CN': 'A' }
+      })
+    ).toBe('https://media.comfy.org/a.jpg')
+  })
+
+  it('uses the poster of video media, never the video src', () => {
+    expect(
+      eventMediaThumbnail({
+        type: 'video',
+        src: 'https://media.comfy.org/a.mp4',
+        alt: { en: 'A', 'zh-CN': 'A' },
+        poster: 'https://media.comfy.org/a.jpg'
+      })
+    ).toBe('https://media.comfy.org/a.jpg')
+  })
+
+  it('has no thumbnail for video media without a poster', () => {
+    expect(
+      eventMediaThumbnail({
+        type: 'video',
+        src: 'https://media.comfy.org/a.mp4',
+        alt: { en: 'A', 'zh-CN': 'A' }
+      })
+    ).toBeUndefined()
+  })
+
+  it('has no thumbnail when the event carries no media', () => {
+    expect(eventMediaThumbnail(undefined)).toBeUndefined()
+  })
+})
+
+describe('site event media', () => {
+  it('never exposes a video file as an event thumbnail', () => {
+    const thumbnails = [...upcomingEvents, ...pastEvents].flatMap((event) => {
+      const thumbnail = eventMediaThumbnail(event.media)
+      return thumbnail ? [thumbnail] : []
+    })
+
+    expect(thumbnails.filter((src) => src.endsWith('.mp4'))).toEqual([])
+  })
+
+  it('gives the H3 sync event its video with a poster still', () => {
+    const event = [...upcomingEvents, ...pastEvents].find(
+      (candidate) => candidate.id === 'h3-sync-sound-challenge'
+    )
+
+    expect(event?.media).toMatchObject({
+      type: 'video',
+      src: 'https://media.comfy.org/website/events/09.02-comfy-h3-sync.mp4',
+      poster: 'https://media.comfy.org/website/events/09.02-comfy-h3-sync.jpg'
+    })
+    expect(event?.featured?.media).toMatchObject({
+      type: 'video',
+      src: 'https://media.comfy.org/website/events/09.02-comfy-h3-sync.mp4',
+      poster: 'https://media.comfy.org/website/events/09.02-comfy-h3-sync.jpg'
+    })
+    expect(eventMediaThumbnail(event?.media)).toBe(
+      'https://media.comfy.org/website/events/09.02-comfy-h3-sync.jpg'
+    )
   })
 })

--- a/apps/website/src/data/events.ts
+++ b/apps/website/src/data/events.ts
@@ -104,6 +104,12 @@ function eventPageHref(id: string): LocalizedText {
 export const eventVideoId = (event: ComfyEvent): string | undefined =>
   event.recordingVideoId ?? event.liveVideoId
 
+/** Still image for a piece of media, for og:image and VideoObject thumbnails —
+ * a video's own src is not a usable image. */
+export const eventMediaThumbnail = (
+  media: EventMedia | undefined
+): string | undefined => (media?.type === 'video' ? media.poster : media?.src)
+
 const EVENT_DURATION_MS = 60 * 60 * 1000
 const SITE_ORIGIN = 'https://comfy.org'
 
@@ -305,16 +311,24 @@ const events: readonly ComfyEvent[] = [
     },
     startDateTime: '2026-09-02T10:00:00-07:00',
     liveVideoId: '2_vEJJU_MUU',
-    media: eventImage('09.02-comfy-h3-sync.jpg', {
-      en: 'Comfy H3 Sync Sound Challenge guest judge livestream',
-      'zh-CN': 'Comfy H3 同步声音挑战赛特邀评委直播'
-    }),
-    featured: {
-      order: 1,
-      media: eventImage('09.02-comfy-h3-sync.jpg', {
+    media: eventVideo(
+      '09.02-comfy-h3-sync.mp4',
+      {
         en: 'Comfy H3 Sync Sound Challenge guest judge livestream',
         'zh-CN': 'Comfy H3 同步声音挑战赛特邀评委直播'
-      }),
+      },
+      '09.02-comfy-h3-sync.jpg'
+    ),
+    featured: {
+      order: 1,
+      media: eventVideo(
+        '09.02-comfy-h3-sync.mp4',
+        {
+          en: 'Comfy H3 Sync Sound Challenge guest judge livestream',
+          'zh-CN': 'Comfy H3 同步声音挑战赛特邀评委直播'
+        },
+        '09.02-comfy-h3-sync.jpg'
+      ),
       showTitle: false
     }
   },

--- a/apps/website/src/templates/events/EventPage.astro
+++ b/apps/website/src/templates/events/EventPage.astro
@@ -12,20 +12,14 @@ import { localizeHref } from '../../config/routes'
 import type { ComfyEvent } from '../../data/events'
 import {
   eventJsonLdNode,
-  eventMediaThumbnail,
   eventVideoId,
   pastEvents,
-  toCalendarEvent,
-  youtubeWatchHref
+  toCalendarEvent
 } from '../../data/events'
+import { eventPageThumbnail, eventVideoJsonLd } from './eventPageMetadata'
 import { t } from '../../i18n/translations'
 import type { JsonLdNode } from '../../utils/jsonLd'
-import {
-  absoluteUrl,
-  jsonLdId,
-  pageContext,
-  videoObjectNode
-} from '../../utils/jsonLd'
+import { absoluteUrl, pageContext } from '../../utils/jsonLd'
 
 interface Props {
   event: ComfyEvent
@@ -45,25 +39,17 @@ const description = event.description[locale] || event.description.en
 // with the section rendered behind the dialog.
 const isPast = pastEvents.includes(event)
 
-const mediaThumbnail = eventMediaThumbnail(event.media)
+const mediaThumbnail = eventPageThumbnail(event)
 
-const videoJsonLd: JsonLdNode | undefined =
-  isPast && event.recordingVideoId && mediaThumbnail
-    ? videoObjectNode({
-        siteUrl,
-        id: jsonLdId(url, 'video'),
-        pageUrl: url,
-        name: title,
-        description,
-        thumbnailUrl: mediaThumbnail,
-        contentUrl:
-          youtubeWatchHref(event.recordingVideoId)[locale] ||
-          youtubeWatchHref(event.recordingVideoId).en,
-        embedUrl: `https://www.youtube-nocookie.com/embed/${event.recordingVideoId}`,
-        uploadDate: event.startDateTime,
-        locale
-      })
-    : undefined
+const videoJsonLd: JsonLdNode | undefined = eventVideoJsonLd({
+  event,
+  isPast,
+  siteUrl,
+  url,
+  title,
+  description,
+  locale
+})
 
 const eventJsonLd: JsonLdNode | undefined = isPast
   ? undefined

--- a/apps/website/src/templates/events/EventPage.astro
+++ b/apps/website/src/templates/events/EventPage.astro
@@ -12,6 +12,7 @@ import { localizeHref } from '../../config/routes'
 import type { ComfyEvent } from '../../data/events'
 import {
   eventJsonLdNode,
+  eventMediaThumbnail,
   eventVideoId,
   pastEvents,
   toCalendarEvent,
@@ -44,15 +45,17 @@ const description = event.description[locale] || event.description.en
 // with the section rendered behind the dialog.
 const isPast = pastEvents.includes(event)
 
+const mediaThumbnail = eventMediaThumbnail(event.media)
+
 const videoJsonLd: JsonLdNode | undefined =
-  isPast && event.recordingVideoId && event.media
+  isPast && event.recordingVideoId && mediaThumbnail
     ? videoObjectNode({
         siteUrl,
         id: jsonLdId(url, 'video'),
         pageUrl: url,
         name: title,
         description,
-        thumbnailUrl: event.media.src,
+        thumbnailUrl: mediaThumbnail,
         contentUrl:
           youtubeWatchHref(event.recordingVideoId)[locale] ||
           youtubeWatchHref(event.recordingVideoId).en,
@@ -84,7 +87,7 @@ const breadcrumbs = [
 <BaseLayout
   title={`${title} - Comfy`}
   description={description}
-  ogImage={event.media?.src}
+  ogImage={mediaThumbnail}
   mainEntityId={typeof mainEntityId === 'string' ? mainEntityId : undefined}
   breadcrumbs={breadcrumbs}
   extraJsonLd={[videoJsonLd, eventJsonLd]}

--- a/apps/website/src/templates/events/eventPageMetadata.test.ts
+++ b/apps/website/src/templates/events/eventPageMetadata.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from 'vitest'
+
+import type { ComfyEvent } from '../../data/events'
+import { eventPageThumbnail, eventVideoJsonLd } from './eventPageMetadata'
+
+const alt = { en: 'A', 'zh-CN': 'A' }
+
+const baseEvent: ComfyEvent = {
+  id: 'test-event',
+  category: 'livestream',
+  title: { en: 'Test Event', 'zh-CN': '测试活动' },
+  description: { en: 'A livestream.', 'zh-CN': '直播。' },
+  startDateTime: '2026-08-05T13:00:00-07:00',
+  recordingVideoId: 'abc123',
+  media: {
+    type: 'image',
+    src: 'https://media.comfy.org/a.jpg',
+    alt
+  }
+}
+
+const input = {
+  isPast: true,
+  siteUrl: 'https://comfy.org',
+  url: 'https://comfy.org/events/test-event/',
+  title: 'Test Event',
+  description: 'A livestream.',
+  locale: 'en' as const
+}
+
+describe('eventPageThumbnail', () => {
+  it('uses the src of image media', () => {
+    expect(eventPageThumbnail(baseEvent)).toBe('https://media.comfy.org/a.jpg')
+  })
+
+  it('uses the poster of video media, never the video src', () => {
+    const event: ComfyEvent = {
+      ...baseEvent,
+      media: {
+        type: 'video',
+        src: 'https://media.comfy.org/a.mp4',
+        alt,
+        poster: 'https://media.comfy.org/a.jpg'
+      }
+    }
+
+    expect(eventPageThumbnail(event)).toBe('https://media.comfy.org/a.jpg')
+  })
+
+  it('has no thumbnail for video media without a poster', () => {
+    const event: ComfyEvent = {
+      ...baseEvent,
+      media: { type: 'video', src: 'https://media.comfy.org/a.mp4', alt }
+    }
+
+    expect(eventPageThumbnail(event)).toBeUndefined()
+  })
+})
+
+describe('eventVideoJsonLd', () => {
+  it('builds a VideoObject for a past event with a recording', () => {
+    expect(eventVideoJsonLd({ ...input, event: baseEvent })).toMatchObject({
+      '@id': 'https://comfy.org/events/test-event/#video',
+      thumbnailUrl: 'https://media.comfy.org/a.jpg',
+      contentUrl: 'https://www.youtube.com/watch?v=abc123',
+      embedUrl: 'https://www.youtube-nocookie.com/embed/abc123',
+      uploadDate: '2026-08-05T13:00:00-07:00'
+    })
+  })
+
+  it('thumbnails video media with its poster', () => {
+    const event: ComfyEvent = {
+      ...baseEvent,
+      media: {
+        type: 'video',
+        src: 'https://media.comfy.org/a.mp4',
+        alt,
+        poster: 'https://media.comfy.org/a.jpg'
+      }
+    }
+
+    expect(eventVideoJsonLd({ ...input, event })).toMatchObject({
+      thumbnailUrl: 'https://media.comfy.org/a.jpg'
+    })
+  })
+
+  it('drops the node for video media without a poster', () => {
+    const event: ComfyEvent = {
+      ...baseEvent,
+      media: { type: 'video', src: 'https://media.comfy.org/a.mp4', alt }
+    }
+
+    expect(eventVideoJsonLd({ ...input, event })).toBeUndefined()
+  })
+
+  it('drops the node for upcoming events', () => {
+    expect(
+      eventVideoJsonLd({ ...input, event: baseEvent, isPast: false })
+    ).toBeUndefined()
+  })
+
+  it('drops the node until a recording is published', () => {
+    const event: ComfyEvent = {
+      ...baseEvent,
+      recordingVideoId: undefined,
+      liveVideoId: 'live123'
+    }
+
+    expect(eventVideoJsonLd({ ...input, event })).toBeUndefined()
+  })
+
+  it('drops the node when the event carries no media', () => {
+    const event: ComfyEvent = { ...baseEvent, media: undefined }
+
+    expect(eventVideoJsonLd({ ...input, event })).toBeUndefined()
+  })
+})

--- a/apps/website/src/templates/events/eventPageMetadata.ts
+++ b/apps/website/src/templates/events/eventPageMetadata.ts
@@ -1,0 +1,47 @@
+import type { ComfyEvent } from '../../data/events'
+import { eventMediaThumbnail, youtubeWatchHref } from '../../data/events'
+import type { Locale } from '../../i18n/translations'
+import type { JsonLdNode } from '../../utils/jsonLd'
+import { jsonLdId, videoObjectNode } from '../../utils/jsonLd'
+
+/**
+ * Social image and VideoObject thumbnail for an event page. Video media
+ * resolves to its poster: a video's own src is not a usable image, so feeding
+ * it to og:image advertises an .mp4 as the social card.
+ */
+export const eventPageThumbnail = (event: ComfyEvent): string | undefined =>
+  eventMediaThumbnail(event.media)
+
+/**
+ * VideoObject node for a past event's recording, or undefined when the event
+ * is not eligible. Eligibility needs a published recording *and* a usable
+ * thumbnail — videoObjectNode requires a thumbnailUrl, so a posterless video
+ * event drops the node rather than emitting one with a broken image.
+ */
+export function eventVideoJsonLd(input: {
+  event: ComfyEvent
+  isPast: boolean
+  siteUrl: string
+  url: string
+  title: string
+  description: string
+  locale: Locale
+}): JsonLdNode | undefined {
+  const { event, isPast, siteUrl, url, title, description, locale } = input
+  const thumbnailUrl = eventPageThumbnail(event)
+  if (!isPast || !event.recordingVideoId || !thumbnailUrl) return undefined
+
+  const watchHref = youtubeWatchHref(event.recordingVideoId)
+  return videoObjectNode({
+    siteUrl,
+    id: jsonLdId(url, 'video'),
+    pageUrl: url,
+    name: title,
+    description,
+    thumbnailUrl,
+    contentUrl: watchHref[locale] || watchHref.en,
+    embedUrl: `https://www.youtube-nocookie.com/embed/${event.recordingVideoId}`,
+    uploadDate: event.startDateTime,
+    locale
+  })
+}


### PR DESCRIPTION
## Summary

Swap the September 2 H3 Sync Sound Challenge event to the newly uploaded video, and stop video media from being used as an og:image.

## Changes

- **What**:
  - `h3-sync-sound-challenge` gallery card (`media`) and featured-carousel slide (`featured.media`) now use `eventVideo('09.02-comfy-h3-sync.mp4', …)` with the existing `09.02-comfy-h3-sync.jpg` as poster, matching the shape already used by the Aug 19 event.
  - `EventPage.astro` fed `event.media.src` directly into `og:image` and the VideoObject `thumbnailUrl`, so any event with video media advertised an `.mp4` as its social image. Added `eventMediaThumbnail()` in `data/events.ts` to resolve video media to its poster. This also fixes the same latent issue on the Aug 19 event.
  - Non-trivial frontmatter logic moved out of the `.astro` file into `templates/events/eventPageMetadata.ts` (`eventPageThumbnail()`, `eventVideoJsonLd()`), so it sits where the `website-unit` coverage gate can measure it. `EventPage.astro` is now a wiring layer.

## Testing

- **Unit (Vitest, 15 new):**
  - `data/events.test.ts` — `eventMediaThumbnail()` over image / video+poster / video-without-poster / `undefined` media; the H3 event's `media` and `featured.media` with their expected MP4 + JPG URLs; plus a guard that no event in the file resolves to a `.mp4` thumbnail, so this class of bug is caught for future events too.
  - `templates/events/eventPageMetadata.test.ts` — the same three media shapes through the JSON-LD builder, plus its three drop conditions (upcoming, no recording published, no media).
- **E2E regression (Playwright):** `apps/website/e2e/events.spec.ts` — "video media resolves to its poster still for the social image" visits every watchable event with video media and asserts `og:image` and `twitter:image` never resolve to the media file, and equal the configured poster when there is one. The list is derived from `watchableEvents`, so future video events are covered without touching the spec. Verified red against the pre-fix behavior (`og:image` resolving to `event.media.src`) and green on the fix.
- Gates: 962/962 unit, `astro check` + `vue-tsc` 0 errors, lint 0 errors, knip clean.

## Review Focus

`eventMediaThumbnail()` returns `undefined` for video media with no poster. The `videoJsonLd` guard now keys off the resolved thumbnail rather than `event.media`, so a posterless video event drops the VideoObject node instead of emitting one with a bad `thumbnailUrl` (`videoObjectNode` types the field as a required `string`). Every current video event has a poster, so nothing changes in practice today.

**Not in this PR, needs a re-upload:** the MP4 currently on the CDN is not faststart — its atom order is `ftyp → free → mdat` with `moov` at the end, so the browser must pull all 2.9 MB before playback starts. Since carousel video slides only advance on `ended`, that can stall the rotation. A stream-copy remux (`ffmpeg -c copy -movflags +faststart`, no re-encode) fixes it with no code change.
