### PR TITLE
ci: scan only first-parent commits for AI co-author trailers

### DIFF
--- a/.github/scripts/check-ai-co-authors.sh
+++ b/.github/scripts/check-ai-co-authors.sh
@@ -67,7 +67,7 @@ for pattern in "${AGENT_PATTERNS[@]}"; do
 done
 
 commit_trailers="$(
-    git log --format='  %h: %(trailers:key=Co-authored-by,separator=%x09)' \
+    git log --first-parent --format='  %h: %(trailers:key=Co-authored-by,separator=%x09)' \
         "${base_sha}..${head_sha}"
 )"
 violations="$(grep -iE "$regex" <<<"$commit_trailers" || true)"


### PR DESCRIPTION
Fixes the \"Check for AI agent co-author trailers\" workflow flagging commits it shouldn't own. `git log base..head` (no `--first-parent`) walks the full merge ancestry, so once a long-lived PR branch merges `main` in, every already-merged `main` commit that happens to carry an AI co-author trailer gets re-flagged as if it belonged to the PR. This hit [#15457](https://github.com/Comfy-Org/ComfyUI_frontend/pull/15457) 14 times, inherited from already-merged main PRs [#15974](https://github.com/Comfy-Org/ComfyUI_frontend/pull/15974), [#15857](https://github.com/Comfy-Org/ComfyUI_frontend/pull/15857), and [#14158](https://github.com/Comfy-Org/ComfyUI_frontend/pull/14158).

`--first-parent` restricts the scan to commits actually introduced on the PR branch (the first-parent line from `head` back to `base`), which excludes commits reachable only via a second-parent (i.e. commits merged in from `main`, not authored on the branch).

## Evidence

Synthetic repro (base repo, one already-merged trailer-carrying commit on `main`, one clean commit on a feature branch, then `merge main` into feature):

```
=== OLD (base..head) ===
  a6f0bd6:
  1b60ba7:
  bb03173: Co-Authored-By: Claude <noreply@anthropic.com>   <-- false positive, inherited from main
=== NEW (--first-parent) ===
  a6f0bd6:
  1b60ba7:
```

Commands run:
- `bash -n .github/scripts/check-ai-co-authors.sh` — syntax OK
- Synthetic before/after comparison shown above, confirming the inherited main commit is excluded while the branch's own commits are still scanned.

## Linear
n/a — CI-only one-line fix, no ticket required per repo convention for trivial CI scripts.