### PR TITLE
docs(agents): port comfy-multi-player CRDT test-quality oracle lessons into FE

### DIFF
--- a/.agents/checks/test-quality.md
+++ b/.agents/checks/test-quality.md
@@ -36,3 +36,40 @@ Rules:
 - Browser/E2E tests use **Playwright** in `browser_tests/` — run with `pnpm test:browser:local`
 - Mock composables using the singleton factory pattern inside `vi.mock()` — see `docs/testing/unit-testing.md` for the pattern
 - Never use `any` in test code either — proper typing applies to tests too
+
+## CRDT / agent-follower test oracles
+
+Ported from `comfy-multi-player`'s `.agents/checks/test-quality.md` and
+`convergence-idempotency.md` (the shared op/CRDT package `comfy-multi-player`
+is the canonical source; these are the lessons that apply on this side of the
+follower boundary — see [ADR 0025](../../docs/adr/0025-in-app-agent-crdt-follower-and-distribution.md)
+and [ADR 0003](../../docs/adr/0003-crdt-based-layout-system.md)). Applies to
+tests touching `useAgentCrdtFollower`, the projector, `DocFrameClient`, or any
+code that applies/rejects ops or renders doc state.
+
+1. **Rejection oracle: bytes, not projection.** A test asserting a rejected
+   op left the doc unchanged must compare `Y.encodeStateAsUpdate` bytes
+   before/after (plus that the op's id is absent from the applied-ops
+   ledger), not a `project(doc)` snapshot — the projection does not render
+   ledger/stamp state, so a rejection that already wrote into the ledger
+   reads as unchanged under a projection diff while the document has
+   genuinely diverged. Also assert a trailing valid op after a rejected one
+   in the same batch does not apply (abort-remainder).
+2. **Accepted ops are the opposite case.** For an **accepted** op (including
+   a delete-wins or last-write-wins no-op that still consumes an op id), the
+   default observable is the projection, not raw bytes — those ops
+   deliberately do not leave the encoded doc byte-identical. Flag a byte
+   assertion offered for an accepted-op property as readily as a projection
+   assertion offered for a rejection.
+3. **Both arrival orders.** An op-semantics change needs a convergence test
+   that applies the same op set in both arrival orders and asserts the
+   resulting projections match, plus a double-apply test asserting a
+   duplicate `op_id` is a true no-op. One happy-path fixture is not
+   convergence proof.
+4. **Probe validity before trusting a "no difference" result.** Before
+   treating a passing rejection/idempotency test as proof, confirm the
+   probe can actually fail: revert the guarded behavior (one mutant per
+   change), rerun, and paste the actual red output (test name + error, or
+   exit code) — a claim with no pasted failure is unproven, not passing.
+   Then re-check the assertion is on an observable that could express the
+   violation at all (see rule 1) before trusting a green run either way.


### PR DESCRIPTION
## Summary

Ports the `.agents/checks` CRDT test-quality oracle lessons from `comfy-multi-player` (the canonical shared op/CRDT package) into this repo's `.agents/checks/test-quality.md`, scoped to code that touches `useAgentCrdtFollower`, the projector, `DocFrameClient`, or op apply/reject paths.

Adds four rules, sourced from `comfy-multi-player`'s `.agents/checks/test-quality.md` item 2/3/4 and `convergence-idempotency.md`:

1. **Rejection oracle: bytes, not projection** — a rejected op must be asserted via `Y.encodeStateAsUpdate` byte identity (+ absence from the applied-ops ledger), never via `project(doc)`, which does not render ledger/stamp state and so cannot see a rejection that already wrote into it. Trailing-valid-op-after-rejection (abort-remainder) must also be asserted.
2. **Accepted ops are the opposite case** — the projection is the correct default observable for accepted ops (including delete-wins/LWW no-ops that still consume an `op_id`), since those intentionally are not byte-identical.
3. **Both arrival orders** — op-semantics changes need a convergence test in both arrival orders plus a duplicate-`op_id` idempotency (true no-op) test.
4. **Probe validity** — before trusting a passing rejection/idempotency test, confirm the guard can actually fail (mutant/revert + pasted red output), then confirm the assertion is on an observable that could express the violation at all.

References [ADR 0025](https://github.com/Comfy-Org/ComfyUI_frontend/blob/main/docs/adr/0025-in-app-agent-crdt-follower-and-distribution.md) and [ADR 0003](https://github.com/Comfy-Org/ComfyUI_frontend/blob/main/docs/adr/0003-crdt-based-layout-system.md).

Docs-only change; no code paths touched.

## Evidence

- Source: `comfy-multi-player` `.agents/checks/test-quality.md` (items 2-4) and `.agents/checks/convergence-idempotency.md` (both-arrival-orders rule), read from a fresh clone of `Comfy-Org/comfy-multi-player`.
- Dedupe check: `gh pr list --repo Comfy-Org/ComfyUI_frontend --search "in:title test-quality crdt oracle" --state all` → no results.
- No code/build impact: single markdown file under `.agents/checks/`.

<!-- authored-by:agent lane-QA-34 -->