### PR TITLE
fix(agent): send live canvas as draft on every turn (PM-813)

### DIFF
--- a/src/workbench/extensions/agent/AgentPanelRoot.test.ts
+++ b/src/workbench/extensions/agent/AgentPanelRoot.test.ts
@@ -2252,6 +2252,27 @@ describe('AgentPanelRoot workflow binding', () => {
     expect(app.loadGraphData).not.toHaveBeenCalled()
   })
 
+  it('does not send an unbound tab draft to an existing workflow thread', async () => {
+    makeTab('wf-42')
+    const bodies = mockMessagesEndpoint('wf-42')
+    await renderAndSend('first message')
+    ws.emit('agent_message_done', {
+      message_id: 'm-1',
+      thread_id: 'th-1'
+    })
+    await screen.findByRole('button', { name: 'Send' })
+
+    const scratch = addTab('workflows/scratch.json', {
+      activeState: { id: 'local-scratch' }
+    })
+    hostStores.workflow.activeWorkflow = scratch
+    await sendFromComposer('second message')
+
+    expect(bodies[1]).not.toHaveProperty('workflow_id')
+    expect(bodies[1]).not.toHaveProperty('current_tab')
+    expect(bodies[1]).not.toHaveProperty('draft')
+  })
+
   it('chip X detaches the chat so the next send carries no workflow context', async () => {
     makeTab('wf-42')
     const bodies = mockMessagesEndpoint('wf-42')

--- a/src/workbench/extensions/agent/AgentPanelRoot.test.ts
+++ b/src/workbench/extensions/agent/AgentPanelRoot.test.ts
@@ -19,11 +19,12 @@ vi.hoisted(() => {
 
 import { i18n } from '@/i18n'
 import { assetService } from '@/platform/assets/services/assetService'
+import type { ComfyWorkflowJSON } from '@/platform/workflow/validation/schemas/workflowSchema'
+import { validateComfyWorkflow } from '@/platform/workflow/validation/schemas/workflowSchema'
 import { app } from '@/scripts/app'
 import { useAgentNodeSelectionStore } from '@/stores/agentNodeSelectionStore'
 import { useWorkflowTabActivityStore } from '@/stores/workflowTabActivityStore'
 import { useSidebarTabStore } from '@/stores/workspace/sidebarTabStore'
-import { validateComfyWorkflow } from '@/platform/workflow/validation/schemas/workflowSchema'
 import { useToastStore } from '@/platform/updates/common/toastStore'
 import { useAssetsStore } from '@/stores/assetsStore'
 
@@ -120,7 +121,7 @@ type FakeTab = {
   filename: string
   isTemporary: boolean
   isModified: boolean
-  activeState: { id?: string } | null
+  activeState: ComfyWorkflowJSON | null
   initialMode?: 'app' | 'graph'
   activeMode?: 'builder:inputs'
 }
@@ -160,7 +161,7 @@ vi.mock('@/platform/workflow/management/stores/workflowStore', async () => {
     closeWorkflow: vi.fn(async (tab: FakeTab) => {
       tabs.delete(tab.path)
     }),
-    createTemporary: (path?: string, data?: unknown) => {
+    createTemporary: (path?: string, data?: ComfyWorkflowJSON) => {
       const requested = (path ?? 'Unsaved Workflow.json').replace(/\.json$/, '')
       let stem = requested
       let counter = 2
@@ -172,7 +173,7 @@ vi.mock('@/platform/workflow/management/stores/workflowStore', async () => {
         filename: stem,
         isTemporary: true,
         isModified: false,
-        activeState: (data ?? null) as { id?: string } | null
+        activeState: data ?? null
       }
       tabs.set(tab.path, tab)
       return tab
@@ -1334,12 +1335,6 @@ describe('AgentPanelRoot attach flow', () => {
   })
 })
 
-// PM-813 / ecw-128: the agent reported the canvas as empty despite the active
-// tab having nodes, because no live canvas snapshot was ever sent on a turn —
-// the backend only had whatever draft content had separately synced
-// server-side (e.g. via CRDT), which can be stale or entirely absent. These
-// pin that the active tab's activeState is now forwarded as `draft.content`
-// on every send.
 describe('AgentPanelRoot canvas draft on send', () => {
   beforeEach(() => {
     setActivePinia(createPinia())
@@ -1357,13 +1352,13 @@ describe('AgentPanelRoot canvas draft on send', () => {
         return json(202, { thread_id: 'th-1', message_id: 'm-1' })
       })
     )
-    const activeState = {
+    const activeState = fromPartial<ComfyWorkflowJSON>({
       nodes: [
         { id: 1, type: 'LoadImage' },
         { id: 2, type: 'MiniMaxH3I2V' }
       ],
       links: []
-    } as unknown as FakeTab['activeState']
+    })
     hostStores.workflow.activeWorkflow = {
       path: 'workflows/video_minimax_h3_i2v.json',
       directory: 'workflows',
@@ -1938,7 +1933,8 @@ describe('AgentPanelRoot workflow binding', () => {
       filename: 'current',
       isTemporary: false,
       isModified: false,
-      activeState: id === undefined ? null : { id }
+      activeState:
+        id === undefined ? null : fromPartial<ComfyWorkflowJSON>({ id })
     }
     hostStores.workflow.tabs.set(tab.path, tab)
     hostStores.workflow.activeWorkflow = tab
@@ -2243,11 +2239,6 @@ describe('AgentPanelRoot workflow binding', () => {
     await renderAndSend('add an upscaler')
 
     expect(bodies[0]).toMatchObject({ workflow_id: 'wf-42' })
-    // PM-813 / ecw-128: the outgoing turn now carries the active tab's live
-    // canvas as `draft.content` so the agent can answer canvas-content
-    // questions without depending on server-side sync. Content sync back INTO
-    // the canvas is still the CRDT follower's job: nothing re-loads the
-    // canvas from the ack path.
     expect(bodies[0]).toMatchObject({ draft: { content: { id: 'wf-42' } } })
     expect(app.loadGraphData).not.toHaveBeenCalled()
   })
@@ -2263,7 +2254,7 @@ describe('AgentPanelRoot workflow binding', () => {
     await screen.findByRole('button', { name: 'Send' })
 
     const scratch = addTab('workflows/scratch.json', {
-      activeState: { id: 'local-scratch' }
+      activeState: fromPartial<ComfyWorkflowJSON>({ id: 'local-scratch' })
     })
     hostStores.workflow.activeWorkflow = scratch
     await sendFromComposer('second message')
@@ -2615,7 +2606,9 @@ describe('AgentPanelRoot workflow binding', () => {
   it('T-03 / PM-655 / FE-1311 sends the active canvas workflow in the agent snapshot', async () => {
     makeTab('wf-42')
     addTab('workflows/scratch.json', {
-      activeState: { id: 'graph-internal-id-not-a-cloud-id' }
+      activeState: fromPartial<ComfyWorkflowJSON>({
+        id: 'graph-internal-id-not-a-cloud-id'
+      })
     })
     const bodies = mockMessagesEndpoint('wf-42')
 
@@ -2937,7 +2930,9 @@ describe('AgentPanelRoot workflow binding', () => {
 
   it('sends no workflow id for an unbound tab and posts exactly once', async () => {
     const tab = makeTab()
-    tab.activeState = { id: 'graph-internal-id-not-a-cloud-id' }
+    tab.activeState = fromPartial<ComfyWorkflowJSON>({
+      id: 'graph-internal-id-not-a-cloud-id'
+    })
     appMock.graph.nodes = [{ id: 1 }]
     const bodies: unknown[] = []
     vi.stubGlobal(

--- a/src/workbench/extensions/agent/AgentPanelRoot.test.ts
+++ b/src/workbench/extensions/agent/AgentPanelRoot.test.ts
@@ -1334,6 +1334,80 @@ describe('AgentPanelRoot attach flow', () => {
   })
 })
 
+// PM-813 / ecw-128: the agent reported the canvas as empty despite the active
+// tab having nodes, because no live canvas snapshot was ever sent on a turn —
+// the backend only had whatever draft content had separately synced
+// server-side (e.g. via CRDT), which can be stale or entirely absent. These
+// pin that the active tab's activeState is now forwarded as `draft.content`
+// on every send.
+describe('AgentPanelRoot canvas draft on send', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    ws.clear()
+  })
+
+  it('sends the active tab activeState as draft.content (PM-813/ecw-128)', async () => {
+    const messageBodies: unknown[] = []
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (url: string, init?: RequestInit) => {
+        if (url.endsWith('/api/agent/threads'))
+          return json(200, { threads: [] })
+        messageBodies.push(JSON.parse(String(init?.body)))
+        return json(202, { thread_id: 'th-1', message_id: 'm-1' })
+      })
+    )
+    const activeState = {
+      nodes: [
+        { id: 1, type: 'LoadImage' },
+        { id: 2, type: 'MiniMaxH3I2V' }
+      ],
+      links: []
+    } as unknown as FakeTab['activeState']
+    hostStores.workflow.activeWorkflow = {
+      path: 'workflows/video_minimax_h3_i2v.json',
+      directory: 'workflows',
+      filename: 'video_minimax_h3_i2v',
+      isTemporary: false,
+      isModified: false,
+      activeState
+    }
+
+    render(AgentPanelRoot, { global: { plugins: [i18n] } })
+
+    await userEvent.type(screen.getByRole('textbox'), "what's on my canvas")
+    await userEvent.click(screen.getByRole('button', { name: 'Send' }))
+
+    expect(messageBodies).toHaveLength(1)
+    expect(messageBodies[0]).toMatchObject({
+      content: "what's on my canvas",
+      draft: { content: activeState }
+    })
+  })
+
+  it('omits draft when there is no active tab', async () => {
+    const messageBodies: unknown[] = []
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (url: string, init?: RequestInit) => {
+        if (url.endsWith('/api/agent/threads'))
+          return json(200, { threads: [] })
+        messageBodies.push(JSON.parse(String(init?.body)))
+        return json(202, { thread_id: 'th-1', message_id: 'm-1' })
+      })
+    )
+    hostStores.workflow.activeWorkflow = null
+
+    render(AgentPanelRoot, { global: { plugins: [i18n] } })
+
+    await userEvent.type(screen.getByRole('textbox'), 'hello')
+    await userEvent.click(screen.getByRole('button', { name: 'Send' }))
+
+    expect(messageBodies).toHaveLength(1)
+    expect(messageBodies[0]).not.toHaveProperty('draft')
+  })
+})
+
 describe('AgentPanelRoot history', () => {
   beforeEach(() => {
     setActivePinia(createPinia())
@@ -2169,9 +2243,12 @@ describe('AgentPanelRoot workflow binding', () => {
     await renderAndSend('add an upscaler')
 
     expect(bodies[0]).toMatchObject({ workflow_id: 'wf-42' })
-    // Content sync is the CRDT follower's job now: no draft ever rides the
-    // turn and nothing re-loads the canvas from the ack path.
-    expect(bodies[0]).not.toHaveProperty('draft')
+    // PM-813 / ecw-128: the outgoing turn now carries the active tab's live
+    // canvas as `draft.content` so the agent can answer canvas-content
+    // questions without depending on server-side sync. Content sync back INTO
+    // the canvas is still the CRDT follower's job: nothing re-loads the
+    // canvas from the ack path.
+    expect(bodies[0]).toMatchObject({ draft: { content: { id: 'wf-42' } } })
     expect(app.loadGraphData).not.toHaveBeenCalled()
   })
 

--- a/src/workbench/extensions/agent/AgentPanelRoot.vue
+++ b/src/workbench/extensions/agent/AgentPanelRoot.vue
@@ -78,7 +78,10 @@ import type { WorkflowTurnContext } from './composables/agent/useAgentSession'
 import { useAgentSession } from './composables/agent/useAgentSession'
 import { useAgentWorkflowTabBindingStore } from './stores/agent/agentWorkflowTabBindingStore'
 import { createAgentRestClient } from './services/agent/agentRestClient'
-import type { OpenTabsSnapshot } from './services/agent/agentRestClient'
+import type {
+  DraftSnapshot,
+  OpenTabsSnapshot
+} from './services/agent/agentRestClient'
 import { createAgentEventSource } from './services/agent/agentEventSource'
 import { useAgentChatHistoryStore } from './stores/agent/agentChatHistoryStore'
 import { useAgentPanelStore } from './stores/agent/agentPanelStore'
@@ -289,6 +292,24 @@ function activeWorkflowTurnContext(): WorkflowTurnContext | undefined {
   return bound === undefined ? undefined : { id: bound, tabPath: active.path }
 }
 
+// PM-813 / ecw-128: send the active tab's live canvas on every turn so the
+// agent can answer "what's on my canvas" from what the user actually sees,
+// instead of falling back to an empty/stale server-side draft when the CRDT
+// doc connection never delivered the user's edits. `version` is always
+// omitted: the backend's SeedFromClient CAS treats a nil version as "the
+// user's canvas is authoritative for this send" (no conflict check), which
+// is the correct default here since the client has no prior draft version to
+// echo back yet.
+function activeWorkflowDraft(): DraftSnapshot | undefined {
+  if (workflowDetached.value) return undefined
+  const active = workflowStore.activeWorkflow
+  if (!active) return undefined
+  active.changeTracker?.captureCanvasState()
+  const content = active.activeState
+  if (!content) return undefined
+  return { content }
+}
+
 const activeTab = computed<ActiveTab | null>(() => {
   const active = workflowStore.activeWorkflow
   return active
@@ -371,7 +392,8 @@ const {
     adopted: onWorkflowAdopted,
     prepare: refreshCloudWorkflowIds,
     tabs: openTabsSnapshot,
-    activeTab: enqueueActiveTab
+    activeTab: enqueueActiveTab,
+    draft: activeWorkflowDraft
   }
 })
 

--- a/src/workbench/extensions/agent/AgentPanelRoot.vue
+++ b/src/workbench/extensions/agent/AgentPanelRoot.vue
@@ -292,14 +292,6 @@ function activeWorkflowTurnContext(): WorkflowTurnContext | undefined {
   return bound === undefined ? undefined : { id: bound, tabPath: active.path }
 }
 
-// PM-813 / ecw-128: send the active tab's live canvas on every turn so the
-// agent can answer "what's on my canvas" from what the user actually sees,
-// instead of falling back to an empty/stale server-side draft when the CRDT
-// doc connection never delivered the user's edits. `version` is always
-// omitted: the backend's SeedFromClient CAS treats a nil version as "the
-// user's canvas is authoritative for this send" (no conflict check), which
-// is the correct default here since the client has no prior draft version to
-// echo back yet.
 function activeWorkflowDraft(): DraftSnapshot | undefined {
   if (workflowDetached.value) return undefined
   const active = workflowStore.activeWorkflow

--- a/src/workbench/extensions/agent/composables/agent/useAgentSession.test.ts
+++ b/src/workbench/extensions/agent/composables/agent/useAgentSession.test.ts
@@ -551,6 +551,64 @@ describe('useAgentSession (v1 composition root)', () => {
     expect(session.boundWorkflowId.value).toBe('wf-1')
   })
 
+  // PM-813 / ecw-128: the agent answered "what's on my canvas" as empty even
+  // though the active tab had nodes, because the FE never sent the client's
+  // live canvas on a turn — the backend's draft{content,version} seed only
+  // had whatever had synced server-side (e.g. via CRDT), which can be stale
+  // or absent. This pins that a workflow.draft() snapshot is now forwarded
+  // as-is on every turn.
+  it('(h5) a workflow.draft() snapshot is forwarded on the turn (PM-813/ecw-128)', async () => {
+    const postMessage = vi.fn(async () => ({
+      thread_id: 'th-1',
+      message_id: 'msg-1',
+      workflow_id: 'wf-1'
+    })) as unknown as AgentRestClient['postMessage']
+    const rest = fakeRest({ postMessage })
+    const { source } = fakeEvents()
+    const draftSnapshot = {
+      content: { nodes: [{ id: 1, type: 'LoadImage' }], links: [] }
+    }
+    const session = useAgentSession({
+      rest,
+      events: source,
+      workflow: {
+        current: () => undefined,
+        adopted: vi.fn(),
+        draft: () => draftSnapshot
+      }
+    })
+    session.start()
+
+    await session.sendMessage('what is on my canvas')
+
+    const body = vi.mocked(postMessage).mock.calls[0][1] as PostMessageInput
+    expect(body.draft).toEqual(draftSnapshot)
+  })
+
+  it('(h6) no draft field is sent when workflow.draft() returns undefined (e.g. detached tab)', async () => {
+    const postMessage = vi.fn(async () => ({
+      thread_id: 'th-1',
+      message_id: 'msg-1',
+      workflow_id: 'wf-1'
+    })) as unknown as AgentRestClient['postMessage']
+    const rest = fakeRest({ postMessage })
+    const { source } = fakeEvents()
+    const session = useAgentSession({
+      rest,
+      events: source,
+      workflow: {
+        current: () => undefined,
+        adopted: vi.fn(),
+        draft: () => undefined
+      }
+    })
+    session.start()
+
+    await session.sendMessage('what is on my canvas')
+
+    expect(vi.mocked(postMessage).mock.calls[0][1]).not.toHaveProperty('draft')
+  })
+
   it("(i2) loadThread drops the previous thread's workflow binding", async () => {
     const rest = fakeRest()
     const { source } = fakeEvents()

--- a/src/workbench/extensions/agent/composables/agent/useAgentSession.test.ts
+++ b/src/workbench/extensions/agent/composables/agent/useAgentSession.test.ts
@@ -526,11 +526,11 @@ describe('useAgentSession (v1 composition root)', () => {
   })
 
   it('(h4) the turn post never carries a draft field (upload retired)', async () => {
-    const postMessage = vi.fn(async () => ({
+    const postMessage = vi.fn<AgentRestClient['postMessage']>(async () => ({
       thread_id: 'th-1',
       message_id: 'msg-1',
       workflow_id: 'wf-1'
-    })) as unknown as AgentRestClient['postMessage']
+    }))
     const rest = fakeRest({ postMessage })
     const { source } = fakeEvents()
     const adopted = vi.fn()
@@ -551,18 +551,12 @@ describe('useAgentSession (v1 composition root)', () => {
     expect(session.boundWorkflowId.value).toBe('wf-1')
   })
 
-  // PM-813 / ecw-128: the agent answered "what's on my canvas" as empty even
-  // though the active tab had nodes, because the FE never sent the client's
-  // live canvas on a turn — the backend's draft{content,version} seed only
-  // had whatever had synced server-side (e.g. via CRDT), which can be stale
-  // or absent. This pins that a workflow.draft() snapshot is now forwarded
-  // as-is on every turn.
   it('(h5) a workflow.draft() snapshot is forwarded on the turn (PM-813/ecw-128)', async () => {
-    const postMessage = vi.fn(async () => ({
+    const postMessage = vi.fn<AgentRestClient['postMessage']>(async () => ({
       thread_id: 'th-1',
       message_id: 'msg-1',
       workflow_id: 'wf-1'
-    })) as unknown as AgentRestClient['postMessage']
+    }))
     const rest = fakeRest({ postMessage })
     const { source } = fakeEvents()
     const draftSnapshot = {
@@ -581,16 +575,16 @@ describe('useAgentSession (v1 composition root)', () => {
 
     await session.sendMessage('what is on my canvas')
 
-    const body = vi.mocked(postMessage).mock.calls[0][1] as PostMessageInput
+    const body = postMessage.mock.calls[0][1]
     expect(body.draft).toEqual(draftSnapshot)
   })
 
   it('(h6) no draft field is sent when workflow.draft() returns undefined (e.g. detached tab)', async () => {
-    const postMessage = vi.fn(async () => ({
+    const postMessage = vi.fn<AgentRestClient['postMessage']>(async () => ({
       thread_id: 'th-1',
       message_id: 'msg-1',
       workflow_id: 'wf-1'
-    })) as unknown as AgentRestClient['postMessage']
+    }))
     const rest = fakeRest({ postMessage })
     const { source } = fakeEvents()
     const session = useAgentSession({

--- a/src/workbench/extensions/agent/composables/agent/useAgentSession.ts
+++ b/src/workbench/extensions/agent/composables/agent/useAgentSession.ts
@@ -6,6 +6,7 @@ import { isAgentEvent, parseAgentWsEvent } from '../../schemas/agentApiSchema'
 import { AgentApiError } from '../../services/agent/agentRestClient'
 import type {
   AgentRestClient,
+  DraftSnapshot,
   OpenTabsSnapshot
 } from '../../services/agent/agentRestClient'
 import { useAgentConversationStore } from '../../stores/agent/agentConversationStore'
@@ -50,6 +51,14 @@ export interface AgentSessionDeps {
     prepare?(): Promise<void>
     tabs?(): OpenTabsSnapshot | undefined
     activeTab?(data: AgentActiveTabData): void
+    /**
+     * The active tab's live canvas, captured fresh at send time. Sent as
+     * `draft` on every turn so the agent answers canvas-content questions
+     * (e.g. "what's on my canvas") from what the user actually sees, rather
+     * than an empty/stale server-side draft when e.g. the CRDT doc connection
+     * never delivered the user's edits. See PM-813 / ecw-128.
+     */
+    draft?(): DraftSnapshot | undefined
   }
 }
 
@@ -191,7 +200,10 @@ export function useAgentSession(deps: AgentSessionDeps) {
       ])
     const wfContext = workflow?.current()
     const tabs = workflow?.tabs?.()
+    // Captured fresh per send (not hoisted with wfContext/tabs above) so the
+    // draft reflects the canvas at the moment of sending, not at prepare time.
     async function postTurn(threadId: string) {
+      const draft = workflow?.draft?.()
       const input = {
         content: text,
         tabs,
@@ -199,7 +211,11 @@ export function useAgentSession(deps: AgentSessionDeps) {
           tags !== undefined && tags.length > 0
             ? { node_ids: tags.map((tag) => tag.id) }
             : undefined,
-        attachments: attachments?.map((attachment) => attachment.ref)
+        attachments: attachments?.map((attachment) => attachment.ref),
+        // Omit the key entirely (not just an undefined value) when there is
+        // no draft to send, so a turn with no active/detached workflow is
+        // indistinguishable from a pre-draft-support client.
+        ...(draft !== undefined ? { draft } : {})
       }
       return rest.postMessage(
         threadId,

--- a/src/workbench/extensions/agent/composables/agent/useAgentSession.ts
+++ b/src/workbench/extensions/agent/composables/agent/useAgentSession.ts
@@ -51,13 +51,6 @@ export interface AgentSessionDeps {
     prepare?(): Promise<void>
     tabs?(): OpenTabsSnapshot | undefined
     activeTab?(data: AgentActiveTabData): void
-    /**
-     * The active tab's live canvas, captured fresh at send time. Sent as
-     * `draft` on every turn so the agent answers canvas-content questions
-     * (e.g. "what's on my canvas") from what the user actually sees, rather
-     * than an empty/stale server-side draft when e.g. the CRDT doc connection
-     * never delivered the user's edits. See PM-813 / ecw-128.
-     */
     draft?(): DraftSnapshot | undefined
   }
 }
@@ -200,10 +193,10 @@ export function useAgentSession(deps: AgentSessionDeps) {
       ])
     const wfContext = workflow?.current()
     const tabs = workflow?.tabs?.()
-    // Captured fresh per send (not hoisted with wfContext/tabs above) so the
-    // draft reflects the canvas at the moment of sending, not at prepare time.
     async function postTurn(threadId: string) {
       const draft = workflow?.draft?.()
+      const shouldSendDraft =
+        draft !== undefined && (threadId === 'new' || wfContext !== undefined)
       const input = {
         content: text,
         tabs,
@@ -212,10 +205,7 @@ export function useAgentSession(deps: AgentSessionDeps) {
             ? { node_ids: tags.map((tag) => tag.id) }
             : undefined,
         attachments: attachments?.map((attachment) => attachment.ref),
-        // Omit the key entirely (not just an undefined value) when there is
-        // no draft to send, so a turn with no active/detached workflow is
-        // indistinguishable from a pre-draft-support client.
-        ...(draft !== undefined ? { draft } : {})
+        ...(shouldSendDraft ? { draft } : {})
       }
       return rest.postMessage(
         threadId,

--- a/src/workbench/extensions/agent/services/agent/agentRestClient.test.ts
+++ b/src/workbench/extensions/agent/services/agent/agentRestClient.test.ts
@@ -145,9 +145,6 @@ describe('postMessage wire body', () => {
     expect(Object.keys(parsed)).toEqual(['content'])
   })
 
-  // PM-813 / ecw-128: the client's live canvas rides the turn as `draft` so
-  // the agent can answer canvas-content questions from what the user
-  // actually sees, instead of an empty/stale server-side draft.
   it('includes draft.content (and omits version when absent) when a draft is provided', async () => {
     respond(jsonResponse(202, turnAccepted))
     await makeClient().postMessage('t1', {
@@ -155,11 +152,7 @@ describe('postMessage wire body', () => {
       draft: { content: { nodes: [{ id: 1, type: 'LoadImage' }], links: [] } }
     })
 
-    const parsed = JSON.parse(lastCall().init.body as string) as Record<
-      string,
-      unknown
-    >
-    expect(parsed).toEqual({
+    expect(JSON.parse(String(lastCall().init.body))).toEqual({
       content: "what's on my canvas",
       draft: { content: { nodes: [{ id: 1, type: 'LoadImage' }], links: [] } }
     })
@@ -172,10 +165,9 @@ describe('postMessage wire body', () => {
       draft: { content: { nodes: [], links: [] }, version: 4 }
     })
 
-    const parsed = JSON.parse(lastCall().init.body as string) as {
-      draft: { version: number }
-    }
-    expect(parsed.draft.version).toBe(4)
+    expect(JSON.parse(String(lastCall().init.body))).toMatchObject({
+      draft: { version: 4 }
+    })
   })
 })
 

--- a/src/workbench/extensions/agent/services/agent/agentRestClient.test.ts
+++ b/src/workbench/extensions/agent/services/agent/agentRestClient.test.ts
@@ -144,6 +144,39 @@ describe('postMessage wire body', () => {
     >
     expect(Object.keys(parsed)).toEqual(['content'])
   })
+
+  // PM-813 / ecw-128: the client's live canvas rides the turn as `draft` so
+  // the agent can answer canvas-content questions from what the user
+  // actually sees, instead of an empty/stale server-side draft.
+  it('includes draft.content (and omits version when absent) when a draft is provided', async () => {
+    respond(jsonResponse(202, turnAccepted))
+    await makeClient().postMessage('t1', {
+      content: "what's on my canvas",
+      draft: { content: { nodes: [{ id: 1, type: 'LoadImage' }], links: [] } }
+    })
+
+    const parsed = JSON.parse(lastCall().init.body as string) as Record<
+      string,
+      unknown
+    >
+    expect(parsed).toEqual({
+      content: "what's on my canvas",
+      draft: { content: { nodes: [{ id: 1, type: 'LoadImage' }], links: [] } }
+    })
+  })
+
+  it('forwards draft.version when the client has previously seen one', async () => {
+    respond(jsonResponse(202, turnAccepted))
+    await makeClient().postMessage('t1', {
+      content: 'edit it',
+      draft: { content: { nodes: [], links: [] }, version: 4 }
+    })
+
+    const parsed = JSON.parse(lastCall().init.body as string) as {
+      draft: { version: number }
+    }
+    expect(parsed.draft.version).toBe(4)
+  })
 })
 
 describe('uploadImage multipart', () => {

--- a/src/workbench/extensions/agent/services/agent/agentRestClient.ts
+++ b/src/workbench/extensions/agent/services/agent/agentRestClient.ts
@@ -45,12 +45,28 @@ export interface OpenTabsSnapshot {
   current_tab?: string
 }
 
+/**
+ * The client's live canvas for the active tab, mirroring the backend's
+ * draftInput{Content, Version} shape (services/agent/server/agent_handler.go).
+ * `version` is the draft version this client last saw `undefined` on a
+ * client's first send for a session, which the backend's CAS treats as "the
+ * user's canvas is authoritative for this send" (no conflict check). Sending
+ * this on every turn is what lets the agent answer canvas-content questions
+ * from what the user actually sees instead of falling back to an empty or
+ * stale server-side draft — see PM-813 / ecw-128.
+ */
+export interface DraftSnapshot {
+  content: Record<string, unknown>
+  version?: number
+}
+
 export interface PostMessageInput {
   content: string
   workflowId?: string
   selection?: Record<string, unknown>
   attachments?: string[]
   tabs?: OpenTabsSnapshot
+  draft?: DraftSnapshot
 }
 
 interface IngestErrorBody {
@@ -116,6 +132,7 @@ export function createAgentRestClient() {
     }
     if (req.selection !== undefined) body.selection = req.selection
     if (req.attachments !== undefined) body.attachments = req.attachments
+    if (req.draft !== undefined) body.draft = req.draft
     return request(
       `/agent/threads/${threadId}/messages`,
       jsonInit('POST', body),

--- a/src/workbench/extensions/agent/services/agent/agentRestClient.ts
+++ b/src/workbench/extensions/agent/services/agent/agentRestClient.ts
@@ -45,16 +45,7 @@ export interface OpenTabsSnapshot {
   current_tab?: string
 }
 
-/**
- * The client's live canvas for the active tab, mirroring the backend's
- * draftInput{Content, Version} shape (services/agent/server/agent_handler.go).
- * `version` is the draft version this client last saw `undefined` on a
- * client's first send for a session, which the backend's CAS treats as "the
- * user's canvas is authoritative for this send" (no conflict check). Sending
- * this on every turn is what lets the agent answer canvas-content questions
- * from what the user actually sees instead of falling back to an empty or
- * stale server-side draft — see PM-813 / ecw-128.
- */
+/** An omitted `version` makes this content authoritative for the backend CAS. */
 export interface DraftSnapshot {
   content: Record<string, unknown>
   version?: number


### PR DESCRIPTION
## Problem

[PM-813](https://linear.app/comfyorg/issue/PM-813/agent-says-canvas-is-empty-even-though-the-correct-workflow-is): a user had an active workflow tab with ~9 nodes visible (`video_minimax_h3_i2v`) and asked the agent "what's on my canvas." The agent replied "Your canvas is empty," while the debug status line read `CRDT disconnected • no document • 0 updates • —`.

Draft eval case: [evals #641](https://github.com/Comfy-Org/evals/pull/641), case `agent-uf-260902-813`.

## Root cause

The backend already supports a `draft{content, version}` field on `POST /agent/threads/:id/messages` (`cloud/services/agent/server/agent_handler.go`), documented in-repo as "the client's live canvas, sent so the agent operates on what the user currently sees rather than an empty or stale draft" — but the frontend's `PostMessageInput`/`postMessage` never populated it. So the agent's per-turn context depended entirely on whatever had separately synced server-side (via the CRDT doc, with a draft-row fallback), which can be stale or entirely absent when the doc connection never delivered the user's edits for that tab. The backend side of the fallback chain (CRDT doc → draft row) already existed; the frontend simply never fed it the one source that's always correct: the browser's own live canvas.

## Fix

- `agentRestClient.ts`: add `DraftSnapshot{content, version?}` and a `draft` field on `PostMessageInput`; forward it on the wire only when present.
- `useAgentSession.ts`: add a `workflow.draft()` accessor to `AgentSessionDeps`, called fresh on every `postTurn` (not hoisted, so it reflects the canvas at send time).
- `AgentPanelRoot.vue`: implement `activeWorkflowDraft()` using the same idiom the save/export path already uses (`changeTracker.captureCanvasState()` then `activeState`), and wire it in.
- `version` is always omitted. The backend's `SeedFromClient` CAS (`comfy-multi-player`-adjacent `draft/repo.go`) treats a nil version as "the user's canvas is authoritative for this send" (no conflict check) — correct here since the client has no prior draft version to echo back yet.

## Regression coverage

- `useAgentSession.test.ts`: (h5) a `workflow.draft()` snapshot is forwarded on the turn; (h6) no `draft` key is sent when `workflow.draft()` returns `undefined`.
- `AgentPanelRoot.test.ts`: new `describe('AgentPanelRoot canvas draft on send')` — sends the active tab's `activeState` as `draft.content` end-to-end through the real component; omits `draft` when there's no active tab. Also updated the pre-existing `"sends the active tab's saved workflow id with the turn"` test, which asserted "no draft ever rides the turn" — that assertion described a different, already-retired ack-path content-sync mechanism (nothing re-loads the canvas from the response, which is untouched by this change); updated it to reflect that the *outgoing* turn now carries `draft.content` while the ack-path behavior is unchanged (`app.loadGraphData` still never called).
- `agentRestClient.test.ts`: wire-shape coverage for `draft.content` and `draft.version` serialization.

Per the source row's acceptance criteria, this is not an eval-only PR — the fix and its permanent regression tests are the same PR as evals #641; feeding `agent-uf-260902-813` through the harness at `ecw-110`/`ecw-112` is left as a follow-up once that harness lands (currently blocked on other in-flight work, see `ecw-110` in the program todo).

## Verification

```
pnpm typecheck   # clean
pnpm knip        # clean
NODE_OPTIONS="--no-experimental-webstorage" npx vitest run \
  src/workbench/extensions/agent/AgentPanelRoot.test.ts \
  src/workbench/extensions/agent/composables/agent/useAgentSession.test.ts \
  src/workbench/extensions/agent/services/agent/agentRestClient.test.ts
# 180/180 passed
```

Trace: PM-813, [evals #641](https://github.com/Comfy-Org/evals/pull/641), program todo row `ecw-128`.