### PR TITLE
test: cover assets follow-up regressions

### DIFF
--- a/src/platform/assets/composables/media/assetMappers.test.ts
+++ b/src/platform/assets/composables/media/assetMappers.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it, vi } from 'vitest'
 
-import { mapInputFileToAssetItem } from './assetMappers'
+import { getOutputAssetMetadata } from '@/platform/assets/schemas/assetMetadataSchema'
+import type { AssetItem } from '@/platform/assets/schemas/assetSchema'
+
+import { mapInputFileToAssetItem, unflattenOutputAssets } from './assetMappers'
 
 vi.mock('@/scripts/api', () => ({
   api: {
@@ -54,5 +57,40 @@ describe('mapInputFileToAssetItem', () => {
 
     expect(asset.preview_url).toBe('/api/view?filename=clip.mp4&type=output')
     expect(asset.tags).toEqual(['output'])
+  })
+})
+
+describe('unflattenOutputAssets', () => {
+  it('preserves each output directory type', () => {
+    const asset = {
+      job_id: 'job-id',
+      size: 1,
+      created_at: '2026-01-01T00:00:00Z',
+      updated_at: '2026-01-01T00:00:00Z'
+    }
+    const assets = [
+      {
+        ...asset,
+        id: 'temp-id',
+        name: 'preview.png',
+        tags: ['temp']
+      },
+      {
+        ...asset,
+        id: 'output-id',
+        name: 'saved.png',
+        created_at: '2026-01-01T00:00:01Z',
+        updated_at: '2026-01-01T00:00:01Z',
+        tags: ['output']
+      }
+    ] satisfies AssetItem[]
+
+    const [grouped] = unflattenOutputAssets(assets)
+    const metadata = getOutputAssetMetadata(grouped.user_metadata)
+
+    expect(metadata?.allOutputs?.map((output) => output.type)).toEqual([
+      'temp',
+      'output'
+    ])
   })
 })

--- a/src/utils/pagedList.test.ts
+++ b/src/utils/pagedList.test.ts
@@ -3,7 +3,7 @@ import { computed, effectScope, ref, shallowRef, toValue } from 'vue'
 import type { Ref } from 'vue'
 
 import type { PagedList, SharedPagedListState } from './pagedList'
-import { getPagedList, usePreemptableQueue } from './pagedList'
+import { getPagedList, usePreemptableQueue, WrappedList } from './pagedList'
 
 function mockPagedList<T>(initial: T[] = [], genNew?: () => T): PagedList<T> {
   const items: Ref<T[]> = shallowRef(initial)
@@ -32,6 +32,47 @@ function makeShared<TParams, TItem>(
   }
   return (params: TParams) => getPagedList(params, state)
 }
+
+describe('WrappedList', () => {
+  it('transforms items and delegates stateful operations', async () => {
+    const child = {
+      isLoading: ref(false),
+      items: ref([1, 2]),
+      get hasMore() {
+        return this.items.value.length < 3
+      },
+      async invalidate(stale?: string[]) {
+        this.items.value = this.items.value.filter(
+          (item) => !stale?.includes(String(item))
+        )
+      },
+      async loadMore() {
+        this.items.value.push(3)
+      },
+      async loadNew() {
+        this.items.value.unshift(0)
+      }
+    }
+
+    const list = new WrappedList(child, (items) =>
+      items.map((item) => item * 2)
+    )
+
+    expect(toValue(list.items)).toEqual([2, 4])
+    expect(toValue(list.hasMore)).toBe(true)
+    expect(toValue(list.isLoading)).toBe(false)
+
+    await list.loadMore()
+    expect(toValue(list.items)).toEqual([2, 4, 6])
+    expect(toValue(list.hasMore)).toBe(false)
+
+    await list.loadNew()
+    expect(toValue(list.items)).toEqual([0, 2, 4, 6])
+
+    await list.invalidate(['2'])
+    expect(toValue(list.items)).toEqual([0, 2, 6])
+  })
+})
 
 describe('getPagedList', () => {
   it('same params share reactive state', async () => {


### PR DESCRIPTION
## Summary

Adds regression coverage for the fixes in #16622.

## Changes

- **What**: Tests `WrappedList` receiver binding and delegation, plus temp/output type preservation when grouping assets.

## Review Focus

Confirm the tests pin the two corrected runtime behaviors.