### PR TITLE
chore: enable no-unnecessary-type-assertion

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -92,6 +92,7 @@
     "typescript/no-unnecessary-qualifier": "error",
     "typescript/no-unnecessary-template-expression": "error",
     "typescript/no-unnecessary-type-arguments": "error",
+    "typescript/no-unnecessary-type-assertion": "error",
     "typescript/no-unnecessary-type-constraint": "error",
     "typescript/no-unsafe-declaration-merging": "off",
     "typescript/no-unused-vars": "off",

--- a/browser_tests/fixtures/customNode/allNodesExecutionTier.ts
+++ b/browser_tests/fixtures/customNode/allNodesExecutionTier.ts
@@ -319,7 +319,7 @@ async function runBatch(
       const sinkIdByKey: Record<string, string> = {}
       for (const [index, spec] of nodes.entries()) {
         const node = window.LiteGraph!.createNode(spec.key, undefined, {
-          pos: [0, index * (spacingY as number)]
+          pos: [0, index * spacingY]
         })
         if (!node) throw new Error(`${spec.key}: createNode returned null`)
         window.app!.graph.add(node)
@@ -350,7 +350,7 @@ async function runBatch(
             {
               pos: [
                 -420 - socketIndex * 40,
-                index * (spacingY as number) + socketIndex * 90
+                index * spacingY + socketIndex * 90
               ]
             }
           )
@@ -361,7 +361,7 @@ async function runBatch(
         }
         if (spec.needsPreviewSink) {
           const sink = window.LiteGraph!.createNode('PreviewAny', undefined, {
-            pos: [460, index * (spacingY as number)]
+            pos: [460, index * spacingY]
           })!
           window.app!.graph.add(sink)
           node.connect(0, sink, 0)

--- a/browser_tests/fixtures/customNode/allNodesMountTier.ts
+++ b/browser_tests/fixtures/customNode/allNodesMountTier.ts
@@ -123,7 +123,7 @@ function vueMountProblems(
         const domWidgets = root.querySelectorAll(
           '[data-testid="node-widget"]'
         ).length
-        const expectedDuplicates = duplicateExpectations[node.type!]
+        const expectedDuplicates = duplicateExpectations[node.type]
         if (expectedDuplicates) {
           const widgetNameCounts: Record<string, number> = {}
           for (const widget of widgets)
@@ -210,10 +210,7 @@ function addChunk(
       } | null> = []
       for (const [index, type] of chunk.entries()) {
         const node = window.LiteGraph!.createNode(type, undefined, {
-          pos: [
-            (index % cols) * (spacingX as number),
-            Math.floor(index / cols) * (spacingY as number)
-          ]
+          pos: [(index % cols) * spacingX, Math.floor(index / cols) * spacingY]
         })
         if (!node) {
           shapes.push(null)
@@ -231,8 +228,8 @@ function addChunk(
       window.__cnIdBase = window.app!.graph.last_node_id
       const canvas = window.app!.canvas
       const rect = canvas.canvas.getBoundingClientRect()
-      const width = cols * (spacingX as number)
-      const height = Math.ceil(chunk.length / cols) * (spacingY as number)
+      const width = cols * spacingX
+      const height = Math.ceil(chunk.length / cols) * spacingY
       const scale = Math.min(
         (rect.width / Math.max(width, 1)) * 0.9,
         (rect.height / Math.max(height, 1)) * 0.9,

--- a/browser_tests/fixtures/customNode/allNodesRoundtripTier.ts
+++ b/browser_tests/fixtures/customNode/allNodesRoundtripTier.ts
@@ -764,7 +764,7 @@ export async function assertRoundtripTier({
                 })
                 for (const { target, widget } of mutations) {
                   if (!node.widgets?.includes(widget)) continue
-                  widget.value = target as typeof widget.value
+                  widget.value = target
                   widget.callback?.(widget.value)
                 }
               }

--- a/browser_tests/fixtures/customNode/interactionProbe.ts
+++ b/browser_tests/fixtures/customNode/interactionProbe.ts
@@ -108,7 +108,7 @@ export async function runInteractionProbeChunk(input: {
     }
     created.push(plan.type)
     try {
-      graph.last_node_id = ++window.__cnIdBase!
+      graph.last_node_id = ++window.__cnIdBase
       graph.add(node)
       await stableShapeOf(node)
       const probeConnect = async (

--- a/browser_tests/fixtures/helpers/BAD_DO_NOT_DO_THIS_LegacyApiHelper.ts
+++ b/browser_tests/fixtures/helpers/BAD_DO_NOT_DO_THIS_LegacyApiHelper.ts
@@ -1,6 +1,5 @@
 import type { Page } from '@playwright/test'
 
-import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
 import type { LLink } from '@/lib/litegraph/src/LLink'
 import type { NodeId } from '@/types/nodeId'
 
@@ -323,9 +322,7 @@ export class BAD_DO_NOT_DO_THIS_LegacyApiHelper {
     return this.page.evaluate(
       ([nodeId, imageSource]) =>
         new Promise<void>((resolve, reject) => {
-          const node = window.app!.graph.getNodeById(nodeId) as
-            | (LGraphNode & { imgs?: HTMLImageElement[] })
-            | null
+          const node = window.app!.graph.getNodeById(nodeId)
           if (!node) throw new Error(`Node ${nodeId} not found`)
 
           const image = new Image()

--- a/browser_tests/fixtures/helpers/NodeReplacementHelper.ts
+++ b/browser_tests/fixtures/helpers/NodeReplacementHelper.ts
@@ -59,15 +59,15 @@ export async function setupNodeReplacement(
                   origin: msgEvent.origin,
                   lastEventId: msgEvent.lastEventId
                 })
-                return (listener as EventListener).call(this, patched)
+                return listener.call(this, patched)
               }
             } catch {
               // not JSON or not a feature_flags message - pass through
             }
           }
-          return (listener as EventListener).call(this, event)
+          return listener.call(this, event)
         }
-        return originalAdd.call(this, type, wrapped as EventListener, options)
+        return originalAdd.call(this, type, wrapped, options)
       }
       return originalAdd.call(
         this,

--- a/browser_tests/fixtures/helpers/PerformanceHelper.ts
+++ b/browser_tests/fixtures/helpers/PerformanceHelper.ts
@@ -59,9 +59,7 @@ export class PerformanceHelper {
 
   private async getSnapshot(): Promise<PerfSnapshot> {
     if (!this.cdp) throw new Error('PerformanceHelper not initialized')
-    const { metrics } = (await this.cdp.send('Performance.getMetrics')) as {
-      metrics: { name: string; value: number }[]
-    }
+    const { metrics } = await this.cdp.send('Performance.getMetrics')
     function get(name: string): number {
       return metrics.find((m) => m.name === name)?.value ?? 0
     }

--- a/browser_tests/fixtures/helpers/SubgraphHelper.ts
+++ b/browser_tests/fixtures/helpers/SubgraphHelper.ts
@@ -46,7 +46,7 @@ export class SubgraphHelper {
       async (params) => {
         const { slotType, action, targetSlotName } = params
         const app = window.app!
-        const currentGraph = app.canvas!.graph!
+        const currentGraph = app.canvas.graph!
 
         // Check if we're in a subgraph
         if (!('inputNode' in currentGraph)) {
@@ -55,7 +55,7 @@ export class SubgraphHelper {
           )
         }
 
-        const subgraph = currentGraph as Subgraph
+        const subgraph = currentGraph
 
         // Get the appropriate node and slots
         const node =
@@ -502,7 +502,7 @@ export class SubgraphHelper {
 
   async countGraphPseudoPreviewEntries(): Promise<number> {
     return this.page.evaluate(() => {
-      const graph = window.app!.graph!
+      const graph = window.app!.graph
       return graph.nodes.reduce((count, node) => {
         const proxyWidgets = node.properties?.proxyWidgets
         if (!Array.isArray(proxyWidgets)) return count
@@ -589,7 +589,7 @@ export class SubgraphHelper {
 
   async getBoundaryLinkSnapshot() {
     return this.page.evaluate(() => {
-      const graph = window.app!.graph!
+      const graph = window.app!.graph
       const host = graph.nodes.find((node) => node.isSubgraphNode())
       if (!host) {
         return {
@@ -632,7 +632,7 @@ export class SubgraphHelper {
 
   async serializeAndReload(): Promise<void> {
     const serialized = await this.page.evaluate(() =>
-      window.app!.graph!.serialize()
+      window.app!.graph.serialize()
     )
     await this.comfyPage.workflow.loadGraphData(serialized as ComfyWorkflowJSON)
   }

--- a/browser_tests/fixtures/utils/boundsUtils.ts
+++ b/browser_tests/fixtures/utils/boundsUtils.ts
@@ -39,7 +39,7 @@ export async function measureSelectionBounds(
             }
           : null
 
-      const canvasEl = canvas.canvas as HTMLCanvasElement
+      const canvasEl = canvas.canvas
       const canvasRect = canvasEl.getBoundingClientRect()
       const nodeVisualBounds: Record<
         string,
@@ -89,7 +89,7 @@ export async function measureSelectionBounds(
       return { selectionBounds, nodeVisualBounds }
     },
     { ids: nodeIds, padding: SELECTION_BOUNDS_PADDING }
-  ) as Promise<MeasureResult>
+  )
 }
 
 export async function intersection(a: Locator, b: Locator) {

--- a/browser_tests/fixtures/utils/litegraphUtils.ts
+++ b/browser_tests/fixtures/utils/litegraphUtils.ts
@@ -219,7 +219,7 @@ class NodeWidgetReference {
   async getSocketPosition(): Promise<Position> {
     const pos: [number, number] = await this.node.comfyPage.page.evaluate(
       ([id, index]) => {
-        const node = window.app!.graph!.getNodeById(id)
+        const node = window.app!.graph.getNodeById(id)
         if (!node) throw new Error(`Node ${id} not found.`)
         const widget = node.widgets![index]
         if (!widget) throw new Error(`Widget ${index} not found.`)
@@ -260,7 +260,7 @@ class NodeWidgetReference {
   async getValue() {
     return await this.node.comfyPage.page.evaluate(
       ([id, index]) => {
-        const node = window.app!.graph!.getNodeById(id)
+        const node = window.app!.graph.getNodeById(id)
         if (!node) throw new Error(`Node ${id} not found.`)
         const widget = node.widgets![index]
         if (!widget) throw new Error(`Widget ${index} not found.`)

--- a/browser_tests/tests/actionbar.spec.ts
+++ b/browser_tests/tests/actionbar.spec.ts
@@ -21,7 +21,7 @@ webSocketTest.describe(
       async ({ comfyPage, getWebSocket }) => {
         await comfyPage.workflow.loadWorkflow('default')
         await comfyPage.page.evaluate(() => {
-          const sampler = window.app!.graph!._nodes.find(
+          const sampler = window.app!.graph._nodes.find(
             (node) => node.type === 'KSampler'
           )
           const control = sampler?.widgets?.find(
@@ -64,7 +64,7 @@ webSocketTest.describe(
         // Find and set the width on the latent node
         const triggerChange = async (value: number) => {
           return await comfyPage.page.evaluate((value) => {
-            const node = window.app!.graph!._nodes.find(
+            const node = window.app!.graph._nodes.find(
               (n) => n.type === 'EmptyLatentImage'
             )
             node!.widgets![0].value = value

--- a/browser_tests/tests/actionbar/partnerRunGate.spec.ts
+++ b/browser_tests/tests/actionbar/partnerRunGate.spec.ts
@@ -85,7 +85,7 @@ test.describe('Partner nodes run gate (local, signed out)', () => {
     })
 
     const changed = await page.evaluate(() => {
-      const node = window.app!.graph!._nodes.find(
+      const node = window.app!.graph._nodes.find(
         (n) => n.widgets && n.widgets.length > 0
       )
       const widget = node?.widgets?.[0]

--- a/browser_tests/tests/appMode.spec.ts
+++ b/browser_tests/tests/appMode.spec.ts
@@ -115,7 +115,7 @@ test.describe('App mode usage', () => {
     const initialImage = 'not-selected.png'
     await comfyPage.page.evaluate(
       ([nodeId, value]) => {
-        const node = window.app!.graph!.getNodeById(nodeId)
+        const node = window.app!.graph.getNodeById(nodeId)
         const widget = node?.widgets?.[0]
         if (!widget) throw new Error(`Image widget not found: ${nodeId}`)
 

--- a/browser_tests/tests/changeTracker.spec.ts
+++ b/browser_tests/tests/changeTracker.spec.ts
@@ -86,13 +86,13 @@ async function waitForChangeTrackerSettled(
 
 async function beforeChange(comfyPage: ComfyPage) {
   await comfyPage.page.evaluate(() => {
-    window.app!.canvas!.emitBeforeChange()
+    window.app!.canvas.emitBeforeChange()
   })
 }
 
 async function afterChange(comfyPage: ComfyPage) {
   await comfyPage.page.evaluate(() => {
-    window.app!.canvas!.emitAfterChange()
+    window.app!.canvas.emitAfterChange()
   })
 }
 
@@ -261,7 +261,7 @@ test.describe('Change Tracker', { tag: '@workflow' }, () => {
   test('Can detect changes in workflow.extra', async ({ comfyPage }) => {
     await expect.poll(() => comfyPage.workflow.getUndoQueueSize()).toBe(0)
     await comfyPage.page.evaluate(() => {
-      window.app!.graph!.extra.foo = 'bar'
+      window.app!.graph.extra.foo = 'bar'
     })
     // Click empty space to trigger a change detection.
     await comfyPage.canvasOps.clickEmptySpace()

--- a/browser_tests/tests/colorPalette.spec.ts
+++ b/browser_tests/tests/colorPalette.spec.ts
@@ -245,7 +245,7 @@ test.describe(
       await expect
         .poll(() =>
           comfyPage.page.evaluate(() => {
-            const graph = window.app!.graph!
+            const graph = window.app!.graph
             if (typeof graph.serialize !== 'function') return undefined
             const parsed = graph.serialize() as {
               nodes: Array<{ bgcolor?: string; color?: string }>
@@ -259,7 +259,7 @@ test.describe(
         .poll(async () => {
           const nodes = await comfyPage.page.evaluate(() => {
             return (
-              window.app!.graph!.serialize() as {
+              window.app!.graph.serialize() as {
                 nodes: Array<{ bgcolor?: string; color?: string }>
               }
             ).nodes

--- a/browser_tests/tests/customNodes/connectivity.spec.ts
+++ b/browser_tests/tests/customNodes/connectivity.spec.ts
@@ -720,7 +720,7 @@ function evaluatePairsInPage(
           output?: Record<string, { inputs?: Record<string, unknown> }>
         }
         try {
-          prompt = (await window.app!.graphToPrompt()) as typeof prompt
+          prompt = await window.app!.graphToPrompt()
         } catch (error) {
           const detail = String(error)
           if (

--- a/browser_tests/tests/customNodes/customNode.regression.spec.ts
+++ b/browser_tests/tests/customNodes/customNode.regression.spec.ts
@@ -340,7 +340,7 @@ for (const entry of manifestEntries) {
               ) as CuratedOutputHashes)
             : null
           const observed = await hashSinkPayloads(
-            result.outputsByNode as Record<string, unknown>,
+            result.outputsByNode,
             async (ref) => {
               const encoded = await comfyPage.page.evaluate(async (file) => {
                 const query = new URLSearchParams({

--- a/browser_tests/tests/customNodes/errorSurfaces.spec.ts
+++ b/browser_tests/tests/customNodes/errorSurfaces.spec.ts
@@ -119,10 +119,10 @@ test('DOM churn is sampled at a fixed rate, not per mutation', async ({
         typeof globalThis & { __recorderQueries?: number }
       const originalDocumentQuery = document.querySelectorAll.bind(document)
       target.__recorderQueries = 0
-      document.querySelectorAll = ((selector: string) => {
+      document.querySelectorAll = (selector: string) => {
         target.__recorderQueries! += 1
         return originalDocumentQuery(selector)
-      }) as typeof document.querySelectorAll
+      }
     })
     await trackVisibleErrors(probe)
 

--- a/browser_tests/tests/graph.spec.ts
+++ b/browser_tests/tests/graph.spec.ts
@@ -17,7 +17,7 @@ test.describe('Graph', { tag: ['@smoke', '@canvas'] }, () => {
     await expect
       .poll(() =>
         comfyPage.page.evaluate(
-          (linkId) => window.app!.graph!.links.get(linkId)?.target_slot,
+          (linkId) => window.app!.graph.links.get(linkId)?.target_slot,
           toLinkId(1)
         )
       )
@@ -77,7 +77,7 @@ test.describe('Graph', { tag: ['@smoke', '@canvas'] }, () => {
           ).length
         }
 
-        const graph = window.app!.graph!
+        const graph = window.app!.graph
         const subgraph = graph.subgraphs.values().next().value
         if (!subgraph) return { error: 'No subgraph found' }
 

--- a/browser_tests/tests/groupNode.spec.ts
+++ b/browser_tests/tests/groupNode.spec.ts
@@ -15,7 +15,7 @@ test.describe('Group node migration', { tag: '@node' }, () => {
     await comfyPage.workflow.loadWorkflow('groupnodes/group_node_v1.3.3')
 
     const state = await comfyPage.page.evaluate(() => {
-      const graph = window.app!.graph!
+      const graph = window.app!.graph
       return {
         groupNodeInstances: graph.nodes.filter((n) =>
           String(n.type).startsWith('workflow>')

--- a/browser_tests/tests/keybindingPresets.spec.ts
+++ b/browser_tests/tests/keybindingPresets.spec.ts
@@ -146,7 +146,7 @@ test.describe('Keybinding Presets', { tag: '@keyboard' }, () => {
     // Verify the downloaded file is valid JSON with correct structure
     const downloadPath = await download.path()
     expect(downloadPath).toBeTruthy()
-    const content = fs.readFileSync(downloadPath!, 'utf-8')
+    const content = fs.readFileSync(downloadPath, 'utf-8')
     const parsed = JSON.parse(content) as {
       name: string
       newBindings: unknown[]

--- a/browser_tests/tests/keyboardShortcutActions.spec.ts
+++ b/browser_tests/tests/keyboardShortcutActions.spec.ts
@@ -21,7 +21,7 @@ test.describe('Keyboard shortcut actions', { tag: '@keyboard' }, () => {
     await test.step('Ctrl+Z undoes the last graph change', async () => {
       await comfyPage.page.evaluate(() => {
         const node = window.LiteGraph!.createNode('Note')
-        window.app!.graph!.add(node)
+        window.app!.graph.add(node)
       })
       await comfyPage.nextFrame()
       await expect

--- a/browser_tests/tests/load3d/load3dLod.spec.ts
+++ b/browser_tests/tests/load3d/load3dLod.spec.ts
@@ -18,7 +18,7 @@ test.describe('Load3D LOD', () => {
       )
 
       await comfyPage.page.evaluate(() => {
-        const node = window.app!.graph!.nodes[0]
+        const node = window.app!.graph.nodes[0]
         window.app!.canvas.ds.scale = 2.0
         node.onResize?.(node.size)
       })

--- a/browser_tests/tests/load3d/load3dSerializeCache.spec.ts
+++ b/browser_tests/tests/load3d/load3dSerializeCache.spec.ts
@@ -21,7 +21,7 @@ function getLoad3dImageInput(body: unknown, nodeId: string): Load3dImageInput {
   const prompt = (body as PromptBody).prompt ?? {}
   const node = prompt[nodeId]
   expect(node?.class_type, `node ${nodeId} should be Load3D`).toBe('Load3D')
-  const input = node!.inputs!.image as Load3dImageInput
+  const input = node.inputs!.image as Load3dImageInput
   expect(typeof input.image).toBe('string')
   expect(typeof input.recording).toBe('string')
   return input

--- a/browser_tests/tests/loadWorkflowInMedia.spec.ts
+++ b/browser_tests/tests/loadWorkflowInMedia.spec.ts
@@ -102,7 +102,7 @@ test.describe(
                 clientX: drop.x,
                 clientY: drop.y
               })
-            ) as [number, number]
+            )
             const node = window.app!.graph.nodes[0]
             return {
               nodePos: [node.pos[0], node.pos[1]] as [number, number],

--- a/browser_tests/tests/nodeDisplay.spec.ts
+++ b/browser_tests/tests/nodeDisplay.spec.ts
@@ -54,7 +54,7 @@ test.describe('Optional input', { tag: ['@screenshot', '@node'] }, () => {
     await comfyPage.workflow.loadWorkflow('inputs/old_workflow_converted_input')
 
     const linkState = await comfyPage.page.evaluate((nodeId) => {
-      const node = window.app!.graph!.getNodeById(nodeId)
+      const node = window.app!.graph.getNodeById(nodeId)
       if (!node) return null
       const linkIdOf = (name: string) => {
         const slot = node.inputs.findIndex((input) => input.name === name)
@@ -72,7 +72,7 @@ test.describe('Optional input', { tag: ['@screenshot', '@node'] }, () => {
     await comfyPage.workflow.loadWorkflow('inputs/renamed_converted_widget')
     const inputNames = await comfyPage.page.evaluate(
       (nodeId) =>
-        window.app!.graph!.getNodeById(nodeId)!.inputs.map(({ name }) => name),
+        window.app!.graph.getNodeById(nodeId)!.inputs.map(({ name }) => name),
       toNodeId(3)
     )
 

--- a/browser_tests/tests/nodeReplacement.spec.ts
+++ b/browser_tests/tests/nodeReplacement.spec.ts
@@ -247,7 +247,7 @@ test.describe('Node replacement', { tag: ['@node', '@ui'] }, () => {
 
           const replacedNodeOutputLinkCount = await comfyPage.page.evaluate(
             (nodeId) =>
-              window.app!.graph!.getNodeById(nodeId)?.outputs[0]?.links
+              window.app!.graph.getNodeById(nodeId)?.outputs[0]?.links
                 ?.length ?? 0,
             toNodeId(2)
           )

--- a/browser_tests/tests/painter.spec.ts
+++ b/browser_tests/tests/painter.spec.ts
@@ -24,7 +24,7 @@ test.describe('Painter', { tag: ['@widget', '@vue-nodes'] }, () => {
       const size = await comfyPage.page.evaluate(() => {
         const graph = window.graph as TestGraphAccess | undefined
         const node = graph?._nodes_by_id?.['1']
-        return node?.size as [number, number] | undefined
+        return node?.size
       })
       expect(size).toBeDefined()
       expect(size![0]).toBeGreaterThanOrEqual(450)
@@ -804,7 +804,7 @@ test.describe(
     }) => {
       const painterNodes = await comfyPage.nodeOps.getNodeRefsByType('Painter')
       expect(painterNodes).toHaveLength(1)
-      const painterNode = painterNodes[0]!
+      const painterNode = painterNodes[0]
       const maskWidget = await painterNode.getWidgetByName('mask')
       const maskWidgetClientPosition = await maskWidget.getPosition()
       const widgetRowClientHeight = await comfyPage.page.evaluate(

--- a/browser_tests/tests/primitiveNode.spec.ts
+++ b/browser_tests/tests/primitiveNode.spec.ts
@@ -65,7 +65,7 @@ test.describe('Primitive Node', { tag: ['@screenshot', '@node'] }, () => {
   }) => {
     async function getPrimitiveComboState() {
       return comfyPage.page.evaluate(() => {
-        const primitive = window.app!.graph!.nodes.find(
+        const primitive = window.app!.graph.nodes.find(
           (node) => node.type === 'PrimitiveNode'
         )
         const widget = primitive?.widgets?.[0]
@@ -98,7 +98,7 @@ test.describe('Primitive Node', { tag: ['@screenshot', '@node'] }, () => {
     // confirms refreshComboInNodes() re-resolves it without losing state.
     async function staleifyPrimitiveOutputWidget() {
       return comfyPage.page.evaluate(() => {
-        const primitive = window.app!.graph!.nodes.find(
+        const primitive = window.app!.graph.nodes.find(
           (node) => node.type === 'PrimitiveNode'
         )
         const output = primitive?.outputs?.[0]

--- a/browser_tests/tests/remoteWidgets.spec.ts
+++ b/browser_tests/tests/remoteWidgets.spec.ts
@@ -26,21 +26,21 @@ test.describe('Remote COMBO Widget', { tag: '@widget' }, () => {
     nodeName: string
   ): Promise<string[] | undefined> => {
     return await comfyPage.page.evaluate((name) => {
-      const node = window.app!.graph!.nodes.find((node) => node.title === name)
+      const node = window.app!.graph.nodes.find((node) => node.title === name)
       return node!.widgets![0].options.values as string[] | undefined
     }, nodeName)
   }
 
   const getWidgetValue = async (comfyPage: ComfyPage, nodeName: string) => {
     return await comfyPage.page.evaluate((name) => {
-      const node = window.app!.graph!.nodes.find((node) => node.title === name)
+      const node = window.app!.graph.nodes.find((node) => node.title === name)
       return node!.widgets![0].value
     }, nodeName)
   }
 
   const clickRefreshButton = (comfyPage: ComfyPage, nodeName: string) => {
     return comfyPage.page.evaluate((name) => {
-      const node = window.app!.graph!.nodes.find((node) => node.title === name)
+      const node = window.app!.graph.nodes.find((node) => node.title === name)
       const buttonWidget = node!.widgets!.find((w) => w.name === 'refresh')
       return buttonWidget?.callback?.(buttonWidget.value)
     }, nodeName)
@@ -93,7 +93,7 @@ test.describe('Remote COMBO Widget', { tag: '@widget' }, () => {
         .poll(() =>
           comfyPage.page.evaluate((name) => {
             return (
-              window.app!.graph!.nodes.find((node) => node.title === name) !=
+              window.app!.graph.nodes.find((node) => node.title === name) !=
               null
             )
           }, nodeName)

--- a/browser_tests/tests/selectionToolboxActions.spec.ts
+++ b/browser_tests/tests/selectionToolboxActions.spec.ts
@@ -41,7 +41,7 @@ test.describe('Selection Toolbox - Button Actions', { tag: '@ui' }, () => {
     await selectNodeWithPan(comfyPage, nodeRef)
 
     const initialCount = await comfyPage.page.evaluate(
-      () => window.app!.graph!._nodes.length
+      () => window.app!.graph._nodes.length
     )
 
     const deleteButton = comfyPage.page.getByTestId('delete-button')
@@ -51,7 +51,7 @@ test.describe('Selection Toolbox - Button Actions', { tag: '@ui' }, () => {
 
     await expect
       .poll(() =>
-        comfyPage.page.evaluate(() => window.app!.graph!._nodes.length)
+        comfyPage.page.evaluate(() => window.app!.graph._nodes.length)
       )
       .toBe(initialCount - 1)
   })
@@ -118,7 +118,7 @@ test.describe('Selection Toolbox - Button Actions', { tag: '@ui' }, () => {
     await comfyPage.nextFrame()
 
     const initialCount = await comfyPage.page.evaluate(
-      () => window.app!.graph!._nodes.length
+      () => window.app!.graph._nodes.length
     )
 
     const deleteButton = comfyPage.page.getByTestId('delete-button')
@@ -128,7 +128,7 @@ test.describe('Selection Toolbox - Button Actions', { tag: '@ui' }, () => {
 
     await expect
       .poll(() =>
-        comfyPage.page.evaluate(() => window.app!.graph!._nodes.length)
+        comfyPage.page.evaluate(() => window.app!.graph._nodes.length)
       )
       .toBe(initialCount - 2)
   })
@@ -288,14 +288,14 @@ test.describe('Selection Toolbox - Button Actions', { tag: '@ui' }, () => {
 
     const readSeed = () =>
       comfyPage.page.evaluate(() => {
-        const sampler = window.app!.graph!._nodes.find(
+        const sampler = window.app!.graph._nodes.find(
           (node) => node.type === 'KSampler'
         )
         return sampler!.widgets!.find((widget) => widget.name === 'seed')!.value
       })
 
     await comfyPage.page.evaluate(() => {
-      const sampler = window.app!.graph!._nodes.find(
+      const sampler = window.app!.graph._nodes.find(
         (node) => node.type === 'KSampler'
       )
       const control = sampler?.widgets?.find(

--- a/browser_tests/tests/subgraph/subgraphBreadcrumb.spec.ts
+++ b/browser_tests/tests/subgraph/subgraphBreadcrumb.spec.ts
@@ -200,7 +200,7 @@ test.describe('Subgraph Breadcrumb', { tag: ['@subgraph'] }, () => {
       await expect.poll(() => comfyPage.subgraph.isInSubgraph()).toBe(false)
 
       const rootNodeTitle = await comfyPage.page.evaluate(
-        (nodeId) => window.app!.graph!.getNodeById(nodeId)?.title ?? null,
+        (nodeId) => window.app!.graph.getNodeById(nodeId)?.title ?? null,
         toNodeId(OUTER_SUBGRAPH_NODE_ID_IN_NESTED)
       )
       expect(rootNodeTitle).toBe(newName)

--- a/browser_tests/tests/subgraph/subgraphCrud.spec.ts
+++ b/browser_tests/tests/subgraph/subgraphCrud.spec.ts
@@ -38,7 +38,7 @@ test.describe('Subgraph CRUD', { tag: ['@slow', '@subgraph'] }, () => {
       )
 
       const result = await comfyPage.page.evaluate(() => {
-        const graph = window.app!.graph!
+        const graph = window.app!.graph
         const subgraphNode = graph.nodes.find((n) => n.isSubgraphNode())
         if (!subgraphNode || !subgraphNode.isSubgraphNode()) {
           return { error: 'No subgraph node found' }

--- a/browser_tests/tests/subgraph/subgraphLifecycle.spec.ts
+++ b/browser_tests/tests/subgraph/subgraphLifecycle.spec.ts
@@ -59,7 +59,7 @@ test.describe('Subgraph Lifecycle', { tag: ['@subgraph'] }, () => {
         .toBeGreaterThan(0)
 
       await comfyPage.page.evaluate((nodeId) => {
-        const graph = window.app!.graph!
+        const graph = window.app!.graph
         const subgraphNode = graph.getNodeById(nodeId)
         if (!subgraphNode || !subgraphNode.isSubgraphNode()) return
         graph.unpackSubgraph(subgraphNode)
@@ -107,8 +107,8 @@ test.describe('Subgraph Lifecycle', { tag: ['@subgraph'] }, () => {
     // widening the race window so a guard regression deterministically surfaces.
     async function deferLegacyHandlers(comfyPage: ComfyPage) {
       return await comfyPage.page.evaluateHandle(() => {
-        const graph = window.app!.graph!
-        const canvas = window.app!.canvas!
+        const graph = window.app!.graph
+        const canvas = window.app!.canvas
         const queue: Array<() => void> = []
         const originalNodeRemoved = graph.onNodeRemoved
         const originalSelectionChange = canvas.onSelectionChange
@@ -140,7 +140,7 @@ test.describe('Subgraph Lifecycle', { tag: ['@subgraph'] }, () => {
       comfyPage: ComfyPage
     ): Promise<DeferredHandlers> {
       return await comfyPage.page.evaluateHandle(() => {
-        const canvas = window.app!.canvas!
+        const canvas = window.app!.canvas
         const queue: Array<() => void> = []
         const original = canvas.onSelectionChange
         canvas.onSelectionChange = function (selected) {

--- a/browser_tests/tests/subgraph/subgraphSerialization.spec.ts
+++ b/browser_tests/tests/subgraph/subgraphSerialization.spec.ts
@@ -57,7 +57,7 @@ async function getPrimitiveFanoutSnapshot(
     const primitiveOriginLinkCount = [
       ...hostNode.subgraph.links.values()
     ].filter((link) => link.origin_id === primitiveNode?.id).length
-    const serialized = window.app!.graph!.serialize()
+    const serialized = window.app!.graph.serialize()
     const serializedNode = serialized.nodes.find(
       (candidate) => String(candidate.id) === String(id)
     )
@@ -92,7 +92,7 @@ async function getSerializedSubgraphNodeProperties(
   hostNodeId: string
 ): Promise<Record<string, unknown>> {
   return comfyPage.page.evaluate((id) => {
-    const serialized = window.app!.graph!.serialize()
+    const serialized = window.app!.graph.serialize()
     const node = serialized.nodes.find(
       (candidate) => String(candidate.id) === String(id)
     )
@@ -111,7 +111,7 @@ async function expectPromotedWidgetsToResolveToInteriorNodes(
   const interiorNodeIds = widgets.map(([id]) => toNodeId(id))
   const results = await comfyPage.page.evaluate(
     ([hostId, ids]) => {
-      const graph = window.app!.graph!
+      const graph = window.app!.graph
       const hostNode = graph.getNodeById(hostId)
       if (!hostNode?.isSubgraphNode()) return ids.map(() => false)
 

--- a/browser_tests/tests/subgraph/subgraphSlots.spec.ts
+++ b/browser_tests/tests/subgraph/subgraphSlots.spec.ts
@@ -595,7 +595,7 @@ test.describe('Subgraph Slots', { tag: ['@slow', '@subgraph'] }, () => {
 
       await comfyPage.page.evaluate(
         (wf) =>
-          window.app!.loadGraphData(wf as ComfyWorkflowJSON, true, true, null, {
+          window.app!.loadGraphData(wf, true, true, null, {
             openSource: 'template'
           }),
         workflow

--- a/browser_tests/tests/topbarMenuCommands.spec.ts
+++ b/browser_tests/tests/topbarMenuCommands.spec.ts
@@ -30,7 +30,7 @@ test.describe('Topbar menu commands', { tag: '@ui' }, () => {
     await test.step('Edit > Undo undoes the last action', async () => {
       await comfyPage.page.evaluate(() => {
         const node = window.LiteGraph!.createNode('Note')
-        window.app!.graph!.add(node)
+        window.app!.graph.add(node)
       })
       await comfyPage.nextFrame()
 

--- a/browser_tests/tests/vueNodes/layout/ecsBridgeHistory.spec.ts
+++ b/browser_tests/tests/vueNodes/layout/ecsBridgeHistory.spec.ts
@@ -20,10 +20,10 @@ test.describe(
       const { baseline, interiorLinkCount, promotedText } =
         await test.step('Capture the initial promoted subgraph state', async () => {
           const baseline = await comfyPage.page.evaluate(() =>
-            window.app!.graph!.serialize()
+            window.app!.graph.serialize()
           )
           const interiorLinkCount = await comfyPage.page.evaluate((id) => {
-            const host = window.app!.graph!.getNodeById(id)
+            const host = window.app!.graph.getNodeById(id)
             if (!host?.isSubgraphNode()) {
               throw new Error(`Host node ${id} is not a SubgraphNode`)
             }
@@ -53,7 +53,7 @@ test.describe(
         await expect(promotedText).toBeVisible()
         await expect
           .poll(() =>
-            comfyPage.page.evaluate(() => window.app!.graph!.serialize())
+            comfyPage.page.evaluate(() => window.app!.graph.serialize())
           )
           .toEqual(baseline)
 

--- a/browser_tests/tests/widget.spec.ts
+++ b/browser_tests/tests/widget.spec.ts
@@ -63,7 +63,7 @@ test.describe('Combo text widget', { tag: ['@screenshot', '@widget'] }, () => {
     const getComboValues = async () =>
       comfyPage.page.evaluate(() => {
         return window
-          .app!.graph!.nodes.find(
+          .app!.graph.nodes.find(
             (node) => node.title === 'Node With Optional Combo Input'
           )!
           .widgets!.find((widget) => widget.name === 'optional_combo_input')!
@@ -89,7 +89,7 @@ test.describe('Combo text widget', { tag: ['@screenshot', '@widget'] }, () => {
     const getComboValues = async () =>
       comfyPage.page.evaluate(() => {
         return window
-          .app!.graph!.nodes.find(
+          .app!.graph.nodes.find(
             (node) => node.title === 'Node With V2 Combo Input'
           )!
           .widgets!.find((widget) => widget.name === 'combo_input')!.options
@@ -127,7 +127,7 @@ test.describe('Slider widget', { tag: ['@screenshot', '@widget'] }, () => {
 
     await comfyPage.page.evaluate(() => {
       window.widgetValue = undefined
-      const widget = window.app!.graph!.nodes[0].widgets![0]
+      const widget = window.app!.graph.nodes[0].widgets![0]
       widget.callback = (value: number) => {
         window.widgetValue = value
       }
@@ -149,7 +149,7 @@ test.describe('Number widget', { tag: ['@screenshot', '@widget'] }, () => {
     const widget = await node.getWidget(0)
     await comfyPage.page.evaluate(() => {
       window.widgetValue = undefined
-      const widget = window.app!.graph!.nodes[0].widgets![0]
+      const widget = window.app!.graph.nodes[0].widgets![0]
       widget.callback = (value: number) => {
         window.widgetValue = value
       }
@@ -175,8 +175,8 @@ test.describe(
       const initialSize = await node.getSize()
 
       await comfyPage.page.evaluate(() => {
-        window.app!.graph!.nodes[0].addWidget('number', 'new_widget', 10, null)
-        window.app!.graph!.setDirtyCanvas(true, true)
+        window.app!.graph.nodes[0].addWidget('number', 'new_widget', 10, null)
+        window.app!.graph.setDirtyCanvas(true, true)
       })
 
       await expect
@@ -259,7 +259,7 @@ test.describe('Image widget', { tag: ['@screenshot', '@widget'] }, () => {
       .poll(
         () =>
           comfyPage.page.evaluate((nodeId) => {
-            const node = window.app!.graph!.getNodeById(nodeId)
+            const node = window.app!.graph.getNodeById(nodeId)
             const img = node?.imgs?.[0]
             return (
               !!img &&

--- a/src/base/common/async.ts
+++ b/src/base/common/async.ts
@@ -38,7 +38,7 @@ export let runWhenGlobalIdle: (
 
 // Self-invoking function to set up the idle callback implementation
 ;(function () {
-  const safeGlobal: GlobalWindow = globalThis as GlobalWindow
+  const safeGlobal: GlobalWindow = globalThis
 
   if (
     typeof safeGlobal.requestIdleCallback !== 'function' ||

--- a/src/components/actionbar/ComfyRunButton/LocalRunButtonWrapper.test.ts
+++ b/src/components/actionbar/ComfyRunButton/LocalRunButtonWrapper.test.ts
@@ -8,7 +8,7 @@ import LocalRunButtonWrapper from './LocalRunButtonWrapper.vue'
 type PartnerNode = { nodeName: string; displayName: string }
 
 const gateState = vi.hoisted(() => ({
-  gate: { value: 'none' as 'sign-in' | 'none' },
+  gate: { value: 'none' },
   partnerNodes: { value: [] as PartnerNode[] }
 }))
 

--- a/src/components/bottomPanel/tabs/shortcuts/EssentialsPanel.test.ts
+++ b/src/components/bottomPanel/tabs/shortcuts/EssentialsPanel.test.ts
@@ -39,7 +39,7 @@ const mockCommands: ComfyCommandImpl[] = [
     tooltip: 'Test tooltip',
     menubarLabel: 'Other Command',
     keybinding: null
-  } as ComfyCommandImpl
+  }
 ]
 
 vi.mock('@/stores/commandStore', () => ({

--- a/src/components/bottomPanel/tabs/shortcuts/ShortcutsList.test.ts
+++ b/src/components/bottomPanel/tabs/shortcuts/ShortcutsList.test.ts
@@ -84,7 +84,7 @@ describe('ShortcutsList', () => {
       }
     })
 
-    const text = container.textContent!
+    const text = container.textContent
     expect(text).toContain('Ctrl')
     expect(text).toContain('n')
     expect(text).toContain('Shift')
@@ -135,7 +135,7 @@ describe('ShortcutsList', () => {
       }
     })
 
-    const text = container.textContent!
+    const text = container.textContent
     expect(text).toContain('Cmd') // Meta -> Cmd
     expect(text).toContain('↑') // ArrowUp -> ↑
     expect(text).toContain('↵') // Enter -> ↵

--- a/src/components/boundingBoxes/WidgetBoundingBoxes.test.ts
+++ b/src/components/boundingBoxes/WidgetBoundingBoxes.test.ts
@@ -9,7 +9,10 @@ import boundingBoxes from '@/locales/en/main.json'
 import type { BoundingBox } from '@/types/boundingBoxes'
 import { toNodeId } from '@/types/nodeId'
 
-const { appState } = vi.hoisted(() => ({ appState: { node: null as unknown } }))
+const { appState } = vi.hoisted(() => {
+  const appState: { node: unknown } = { node: null }
+  return { appState }
+})
 
 vi.mock('@/scripts/app', () => ({
   app: { canvas: { graph: { getNodeById: () => appState.node } } }
@@ -65,18 +68,17 @@ function prepCanvas(canvas: HTMLCanvasElement) {
   })
   canvas.getContext = (() =>
     fakeCtx) as unknown as HTMLCanvasElement['getContext']
-  canvas.getBoundingClientRect = () =>
-    ({
-      left: 0,
-      top: 0,
-      right: 100,
-      bottom: 100,
-      width: 100,
-      height: 100,
-      x: 0,
-      y: 0,
-      toJSON: () => ({})
-    }) as DOMRect
+  canvas.getBoundingClientRect = () => ({
+    left: 0,
+    top: 0,
+    right: 100,
+    bottom: 100,
+    width: 100,
+    height: 100,
+    x: 0,
+    y: 0,
+    toJSON: () => ({})
+  })
   canvas.setPointerCapture = () => {}
   canvas.releasePointerCapture = () => {}
 }

--- a/src/components/builder/builderViewOptions.test.ts
+++ b/src/components/builder/builderViewOptions.test.ts
@@ -23,7 +23,7 @@ describe('setWorkflowDefaultView', () => {
   beforeEach(async () => {
     const mod = await import('./builderViewOptions')
     setWorkflowDefaultView = mod.setWorkflowDefaultView
-    app = (await import('@/scripts/app')).app as typeof app
+    app = (await import('@/scripts/app')).app
     app.rootGraph.extra = {}
   })
 

--- a/src/components/builder/useAppModeWidgetResizing.test.ts
+++ b/src/components/builder/useAppModeWidgetResizing.test.ts
@@ -36,11 +36,9 @@ describe('useAppModeWidgetResizing', () => {
     const { onPointerDown } = useAppModeWidgetResizing(onResize)
 
     function bind(wrapper: HTMLElement, widget: IBaseWidget) {
-      wrapper.addEventListener(
-        'pointerdown',
-        (e) => onPointerDown(widget, e as PointerEvent),
-        { capture: true }
-      )
+      wrapper.addEventListener('pointerdown', (e) => onPointerDown(widget, e), {
+        capture: true
+      })
     }
 
     return { onResize, bind }
@@ -174,7 +172,7 @@ describe('useAppModeWidgetResizing', () => {
     const { wrapper, textarea } = wrapWithTextarea()
     wrapper.addEventListener(
       'pointerdown',
-      (e) => onPointerDown(WIDGET_PROMPT, e as PointerEvent),
+      (e) => onPointerDown(WIDGET_PROMPT, e),
       { capture: true }
     )
 

--- a/src/components/builder/useResolvedSelectedInputs.test.ts
+++ b/src/components/builder/useResolvedSelectedInputs.test.ts
@@ -54,7 +54,7 @@ function setRootGraphNodes(nodes: LGraphNode[]) {
 }
 
 function dispatchRootGraphEvent(type: string) {
-  ;(app.rootGraph!.events as unknown as EventTarget).dispatchEvent(
+  ;(app.rootGraph.events as unknown as EventTarget).dispatchEvent(
     new Event(type)
   )
 }

--- a/src/components/cameraInfo/CameraInfo.test.ts
+++ b/src/components/cameraInfo/CameraInfo.test.ts
@@ -68,7 +68,7 @@ function makeWidget(): SimplifiedWidget {
     type: 'cameraInfo',
     value: [],
     options: {}
-  } as unknown as SimplifiedWidget
+  }
 }
 
 function renderComponent() {

--- a/src/components/common/TreeExplorerV2Node.test.ts
+++ b/src/components/common/TreeExplorerV2Node.test.ts
@@ -124,7 +124,7 @@ describe('TreeExplorerV2Node', () => {
 
   function getTreeNode(container: Element) {
     // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
-    return container.querySelector('div.group\\/tree-node')! as HTMLElement
+    return container.querySelector('div.group\\/tree-node')!
   }
 
   describe('handleClick', () => {

--- a/src/components/dialog/content/setting/SettingItem.test.ts
+++ b/src/components/dialog/content/setting/SettingItem.test.ts
@@ -52,7 +52,7 @@ describe('SettingItem', () => {
   function getFormItemData(container: Element) {
     // eslint-disable-next-line testing-library/no-node-access
     const el = container.querySelector('[data-testid="form-item-data"]')
-    return JSON.parse(el!.textContent!)
+    return JSON.parse(el!.textContent)
   }
 
   it('translates options that use legacy type', () => {

--- a/src/components/dialog/content/signin/TurnstileWidget.test.ts
+++ b/src/components/dialog/content/signin/TurnstileWidget.test.ts
@@ -178,7 +178,7 @@ describe('TurnstileWidget', () => {
   it('resets the widget on a challenge error to fetch a fresh challenge', async () => {
     const { api, options } = fakeTurnstile()
     mockLoadTurnstile.mockResolvedValue(api)
-    window.turnstile = api as unknown as NonNullable<Window['turnstile']>
+    window.turnstile = api
 
     renderWidget()
     await flush()
@@ -201,7 +201,7 @@ describe('TurnstileWidget', () => {
   it('reset() clears the token model and resets the rendered widget', async () => {
     const { api, options } = fakeTurnstile()
     mockLoadTurnstile.mockResolvedValue(api)
-    window.turnstile = api as unknown as NonNullable<Window['turnstile']>
+    window.turnstile = api
 
     const { emitted, getCurrentInstance } = renderWidgetWithExpose()
     await flush()
@@ -220,7 +220,7 @@ describe('TurnstileWidget', () => {
   it('reset() clears a stale error so it does not linger over a fresh challenge', async () => {
     const { api, options } = fakeTurnstile()
     mockLoadTurnstile.mockResolvedValue(api)
-    window.turnstile = api as unknown as NonNullable<Window['turnstile']>
+    window.turnstile = api
 
     const { container, getCurrentInstance } = renderWidgetWithExpose()
     await flush()
@@ -251,7 +251,7 @@ describe('TurnstileWidget', () => {
   it('removes the widget on unmount when one was rendered', async () => {
     const { api } = fakeTurnstile()
     mockLoadTurnstile.mockResolvedValue(api)
-    window.turnstile = api as unknown as NonNullable<Window['turnstile']>
+    window.turnstile = api
 
     const { unmount } = renderWidget()
     await flush()
@@ -337,7 +337,7 @@ describe('TurnstileWidget', () => {
     it('resets the widget to fetch a fresh challenge on token expiry', async () => {
       const { api, options } = fakeTurnstile()
       mockLoadTurnstile.mockResolvedValue(api)
-      window.turnstile = api as unknown as NonNullable<Window['turnstile']>
+      window.turnstile = api
 
       renderWidget()
       await flush()
@@ -352,7 +352,7 @@ describe('TurnstileWidget', () => {
     it('falls back if a post-solve expiry is not followed by a fresh token within the load timeout', async () => {
       const { api, options } = fakeTurnstile()
       mockLoadTurnstile.mockResolvedValue(api)
-      window.turnstile = api as unknown as NonNullable<Window['turnstile']>
+      window.turnstile = api
 
       const { emitted } = renderWidget()
       await vi.advanceTimersByTimeAsync(0)

--- a/src/components/dialog/content/subscription/CancelSubscriptionDialogContent.test.ts
+++ b/src/components/dialog/content/subscription/CancelSubscriptionDialogContent.test.ts
@@ -32,7 +32,7 @@ function withStrictMillisecondParser<T>(run: () => T): T {
     }
   }
 
-  vi.stubGlobal('Date', StrictDate as DateConstructor)
+  vi.stubGlobal('Date', StrictDate)
 
   try {
     return run()

--- a/src/components/graph/SelectionToolbox.test.ts
+++ b/src/components/graph/SelectionToolbox.test.ts
@@ -145,7 +145,7 @@ describe('SelectionToolbox', () => {
     nodeDefMock = {
       type: 'TestNode',
       title: 'Test Node'
-    } as unknown
+    }
 
     // Mock the canvas to avoid "getCanvas: canvas is null" errors
     canvasStore.canvas = createMockCanvas()
@@ -472,7 +472,7 @@ describe('SelectionToolbox', () => {
         shouldHandleNodePointerEvents: { value: true } as ReturnType<
           typeof useCanvasInteractions
         >['shouldHandleNodePointerEvents']
-      } as ReturnType<typeof useCanvasInteractions>)
+      })
 
       const mockExtensionService = vi.mocked(useExtensionService)
       mockExtensionService.mockReturnValue(createMockExtensionService())

--- a/src/components/graph/selectionToolbox/ColorPickerButton.test.ts
+++ b/src/components/graph/selectionToolbox/ColorPickerButton.test.ts
@@ -39,7 +39,7 @@ function createMockWorkflow(
     ...overrides
   } satisfies Partial<LoadedComfyWorkflow>
 
-  return Object.assign(workflow, workflowOverrides) as LoadedComfyWorkflow
+  return Object.assign(workflow, workflowOverrides)
 }
 
 // Mock the litegraph module

--- a/src/components/graph/selectionToolbox/ExecuteButton.test.ts
+++ b/src/components/graph/selectionToolbox/ExecuteButton.test.ts
@@ -1,6 +1,7 @@
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import { createTestingPinia } from '@pinia/testing'
+import { fromPartial } from '@total-typescript/shoehorn'
 import { setActivePinia } from 'pinia'
 import PrimeVue from 'primevue/config'
 import Tooltip from 'primevue/tooltip'
@@ -54,10 +55,9 @@ describe('ExecuteButton', () => {
       })
     )
 
-    const partialCanvas: Partial<LGraphCanvas> = {
+    mockCanvas = fromPartial<LGraphCanvas>({
       setDirty: vi.fn()
-    }
-    mockCanvas = partialCanvas as LGraphCanvas
+    })
 
     mockSelectedNodes = []
 
@@ -67,11 +67,13 @@ describe('ExecuteButton', () => {
     vi.spyOn(canvasStore, 'getCanvas').mockReturnValue(mockCanvas)
     vi.spyOn(commandStore, 'execute').mockResolvedValue()
 
-    vi.mocked(useSelectionState).mockReturnValue({
-      selectedNodes: {
-        value: mockSelectedNodes
-      }
-    } as ReturnType<typeof useSelectionState>)
+    vi.mocked(useSelectionState).mockReturnValue(
+      fromPartial<ReturnType<typeof useSelectionState>>({
+        selectedNodes: {
+          value: mockSelectedNodes
+        }
+      })
+    )
   })
 
   const renderComponent = () => {

--- a/src/components/graph/selectionToolbox/ExecuteButton.test.ts
+++ b/src/components/graph/selectionToolbox/ExecuteButton.test.ts
@@ -57,7 +57,7 @@ describe('ExecuteButton', () => {
     const partialCanvas: Partial<LGraphCanvas> = {
       setDirty: vi.fn()
     }
-    mockCanvas = partialCanvas as Partial<LGraphCanvas> as LGraphCanvas
+    mockCanvas = partialCanvas as LGraphCanvas
 
     mockSelectedNodes = []
 

--- a/src/components/imagecrop/WidgetImageCrop.test.ts
+++ b/src/components/imagecrop/WidgetImageCrop.test.ts
@@ -125,7 +125,7 @@ function makeWidget(
     value: { x: 0, y: 0, width: 512, height: 512 },
     options: {},
     ...overrides
-  } as SimplifiedWidget<Bounds>
+  }
 }
 
 function renderWidget(

--- a/src/components/load3d/Load3dViewerContent.test.ts
+++ b/src/components/load3d/Load3dViewerContent.test.ts
@@ -23,22 +23,23 @@ const {
   dialogCloseMock,
   serviceSourceLoad3d,
   getLoad3dAsyncMock
-} = vi.hoisted(() => ({
-  viewerState: {
-    current: null as ReturnType<typeof buildViewerStub> | null
-  },
-  dragState: {
-    current: null as ReturnType<typeof buildDragStub> | null
-  },
-  capturedDragOptions: {
-    current: null as { onModelDrop?: (file: File) => Promise<void> } | null
-  },
-  dialogCloseMock: vi.fn(),
-  serviceSourceLoad3d: {
-    current: null as unknown
-  },
-  getLoad3dAsyncMock: vi.fn()
-}))
+} = vi.hoisted(() => {
+  const serviceSourceLoad3d: { current: unknown } = { current: null }
+  return {
+    viewerState: {
+      current: null as ReturnType<typeof buildViewerStub> | null
+    },
+    dragState: {
+      current: null as ReturnType<typeof buildDragStub> | null
+    },
+    capturedDragOptions: {
+      current: null as { onModelDrop?: (file: File) => Promise<void> } | null
+    },
+    dialogCloseMock: vi.fn(),
+    serviceSourceLoad3d,
+    getLoad3dAsyncMock: vi.fn()
+  }
+})
 
 function buildViewerStub() {
   return {

--- a/src/components/load3d/controls/viewer/ViewerExportControls.test.ts
+++ b/src/components/load3d/controls/viewer/ViewerExportControls.test.ts
@@ -39,9 +39,7 @@ describe('ViewerExportControls', () => {
 
   it('defaults the export format to obj', () => {
     renderComponent()
-    expect((screen.getByRole('combobox') as HTMLSelectElement).value).toBe(
-      'obj'
-    )
+    expect(screen.getByRole<HTMLSelectElement>('combobox').value).toBe('obj')
   })
 
   it('emits exportModel with the currently selected format when the button is clicked', async () => {

--- a/src/components/maskeditor/ImageLayerSettingsPanel.test.ts
+++ b/src/components/maskeditor/ImageLayerSettingsPanel.test.ts
@@ -11,18 +11,23 @@ import { MaskBlendMode, Tools } from '@/extensions/core/maskeditor/types'
 
 type ToolManager = ReturnType<typeof useToolManager>
 
-const initialMock = () =>
-  reactive({
+const initialImage = (): { src: string } | null => ({
+  src: 'https://example.com/base.png'
+})
+
+const initialMock = () => {
+  return reactive({
     maskOpacity: 0.8,
     maskBlendMode: MaskBlendMode.Black,
-    activeLayer: 'mask' as 'mask' | 'rgb',
+    activeLayer: 'mask',
     currentTool: Tools.MaskPen,
-    image: { src: 'https://example.com/base.png' } as { src: string } | null,
+    image: initialImage(),
     maskCanvas: null as HTMLCanvasElement | null,
     rgbCanvas: null as HTMLCanvasElement | null,
     imgCanvas: null as HTMLCanvasElement | null,
     setMaskOpacity: vi.fn()
   })
+}
 
 let mockStore: ReturnType<typeof initialMock>
 const mockUpdateMaskColor = vi.fn().mockResolvedValue(undefined)

--- a/src/components/maskeditor/MaskEditorContent.test.ts
+++ b/src/components/maskeditor/MaskEditorContent.test.ts
@@ -41,7 +41,7 @@ const mockCanvasHistory = vi.hoisted(() => ({
 
 const initialMockStore = () =>
   reactive({
-    activeLayer: 'mask' as 'mask' | 'rgb',
+    activeLayer: 'mask',
     maskCanvas: null as HTMLCanvasElement | null,
     rgbCanvas: null as HTMLCanvasElement | null,
     imgCanvas: null as HTMLCanvasElement | null,
@@ -163,8 +163,7 @@ describe('MaskEditorContent', () => {
     mockPanZoom.initializeCanvasPanZoom.mockResolvedValue(undefined)
     mockBrushDrawing.initGPUResources.mockResolvedValue(undefined)
     originalResizeObserver = globalThis.ResizeObserver
-    globalThis.ResizeObserver =
-      MockResizeObserver as unknown as typeof ResizeObserver
+    globalThis.ResizeObserver = MockResizeObserver
   })
 
   afterEach(() => {

--- a/src/components/maskeditor/ToolPanel.test.ts
+++ b/src/components/maskeditor/ToolPanel.test.ts
@@ -13,7 +13,7 @@ type ToolManager = ReturnType<typeof useToolManager>
 
 const initialMock = () =>
   reactive({
-    currentTool: Tools.MaskPen as Tools,
+    currentTool: Tools.MaskPen,
     displayZoomRatio: 1,
     image: null as { width: number; height: number } | null,
     resetZoom: vi.fn()

--- a/src/components/maskeditor/controls/DropdownControl.test.ts
+++ b/src/components/maskeditor/controls/DropdownControl.test.ts
@@ -60,9 +60,7 @@ describe('DropdownControl', () => {
 
   it('should reflect modelValue as the selected option', () => {
     renderComponent({ options: ['One', 'Two'], modelValue: 'Two' })
-    expect((screen.getByRole('combobox') as HTMLSelectElement).value).toBe(
-      'Two'
-    )
+    expect(screen.getByRole<HTMLSelectElement>('combobox').value).toBe('Two')
   })
 
   it('should emit update:modelValue with the chosen string value', async () => {

--- a/src/components/maskeditor/controls/SliderControl.test.ts
+++ b/src/components/maskeditor/controls/SliderControl.test.ts
@@ -49,7 +49,7 @@ describe('SliderControl', () => {
   it('should default step to 1 when not provided', () => {
     renderComponent({ min: 0, max: 10, modelValue: 5 })
 
-    expect((screen.getByRole('slider') as HTMLInputElement).step).toBe('1')
+    expect(screen.getByRole<HTMLInputElement>('slider').step).toBe('1')
   })
 
   it('should emit update:modelValue with a number when input changes', () => {

--- a/src/components/maskeditor/controls/ToggleControl.test.ts
+++ b/src/components/maskeditor/controls/ToggleControl.test.ts
@@ -28,16 +28,12 @@ describe('ToggleControl', () => {
 
   it('should reflect modelValue=false as unchecked', () => {
     renderComponent({ modelValue: false })
-    expect((screen.getByRole('checkbox') as HTMLInputElement).checked).toBe(
-      false
-    )
+    expect(screen.getByRole<HTMLInputElement>('checkbox').checked).toBe(false)
   })
 
   it('should reflect modelValue=true as checked', () => {
     renderComponent({ modelValue: true })
-    expect((screen.getByRole('checkbox') as HTMLInputElement).checked).toBe(
-      true
-    )
+    expect(screen.getByRole<HTMLInputElement>('checkbox').checked).toBe(true)
   })
 
   it('should emit update:modelValue=true when toggled on', async () => {

--- a/src/components/node/NodeHelpContent.test.ts
+++ b/src/components/node/NodeHelpContent.test.ts
@@ -53,7 +53,7 @@ function buildNodeDef(): ComfyNodeDefImpl {
     output_is_list: [false],
     output_name: ['video'],
     output_node: false
-  } as ComfyNodeDefV1
+  }
 
   return new ComfyNodeDefImpl(nodeDef)
 }

--- a/src/components/node/NodePreview.test.ts
+++ b/src/components/node/NodePreview.test.ts
@@ -106,7 +106,7 @@ describe('NodePreview', () => {
     const nodeHeader = screen.getByTestId('node-header')
 
     expect(nodeHeader).toHaveAttribute('title', longNameNodeDef.display_name)
-    expect(nodeHeader).toHaveTextContent(longNameNodeDef.display_name!)
+    expect(nodeHeader).toHaveTextContent(longNameNodeDef.display_name)
   })
 
   it('handles short node names without issues', () => {

--- a/src/components/node/NodePreviewCard.test.ts
+++ b/src/components/node/NodePreviewCard.test.ts
@@ -63,7 +63,7 @@ function buildNodeDef(): ComfyNodeDefImpl {
     output_is_list: [false],
     output_name: ['video'],
     output_node: false
-  } as ComfyNodeDefV1
+  }
 
   return new ComfyNodeDefImpl(nodeDef)
 }
@@ -99,7 +99,7 @@ describe('NodePreviewCard', () => {
       output_is_list: [],
       output_name: [],
       output_node: false
-    } as ComfyNodeDefV1)
+    })
 
     renderComponent(nodeDefImpl)
 

--- a/src/components/queue/job/useQueueEstimates.ts
+++ b/src/components/queue/job/useQueueEstimates.ts
@@ -33,7 +33,7 @@ const pickRecentDurations = (queueStore: QueueStore) =>
     .filter(
       (value: number | undefined) =>
         typeof value === 'number' && !Number.isNaN(value)
-    ) as number[]
+    )
 
 export const useQueueEstimates = ({
   queueStore,
@@ -66,7 +66,7 @@ export const useQueueEstimates = ({
     const avg = sorted.reduce((sum, value) => sum + value, 0) / sorted.length
     const p75 =
       sorted[Math.min(sorted.length - 1, Math.floor(sorted.length * 0.75))]
-    const running = queueStore.runningTasks as TaskItemImpl[]
+    const running = queueStore.runningTasks
     const now = nowTs.value
     const remaining = running
       .map((task) => task.executionStartTimestamp)

--- a/src/components/range/WidgetRange.test.ts
+++ b/src/components/range/WidgetRange.test.ts
@@ -67,9 +67,9 @@ function makeWidget(
     name: 'range_w',
     type: 'range',
     value: { min: 0, max: 1 },
-    options: options as IWidgetRangeOptions,
+    options,
     ...widgetOverrides
-  } as SimplifiedWidget<RangeValue, IWidgetRangeOptions>
+  }
 }
 
 function setUpstream(value: RangeValue | undefined) {
@@ -135,9 +135,12 @@ describe('WidgetRange', () => {
     it('shows upstream value when disabled with a valid upstream', () => {
       setUpstream({ min: 0.3, max: 0.7 })
       renderWidget(
-        makeWidget({ disabled: true } as IWidgetRangeOptions, {
-          linkedUpstream: { nodeId: toNodeId('n1') }
-        }),
+        makeWidget(
+          { disabled: true },
+          {
+            linkedUpstream: { nodeId: toNodeId('n1') }
+          }
+        ),
         { min: 0, max: 1 }
       )
       const el = screen.getByTestId('range-editor')

--- a/src/components/rightSidePanel/errors/MissingPackGroupRow.test.ts
+++ b/src/components/rightSidePanel/errors/MissingPackGroupRow.test.ts
@@ -287,7 +287,7 @@ describe('MissingPackGroupRow', () => {
     it('does not show Locate for nodeType without nodeId', () => {
       renderRow({
         group: makeGroup({
-          nodeTypes: [{ type: 'NoId', isReplaceable: false } as never]
+          nodeTypes: [{ type: 'NoId', isReplaceable: false }]
         })
       })
       expect(
@@ -303,7 +303,7 @@ describe('MissingPackGroupRow', () => {
         group: makeGroup({
           nodeTypes: [
             { type: 'WithId', nodeId: '100', isReplaceable: false },
-            { type: 'WithoutId', isReplaceable: false } as never
+            { type: 'WithoutId', isReplaceable: false }
           ]
         })
       })

--- a/src/components/rightSidePanel/errors/useErrorActions.test.ts
+++ b/src/components/rightSidePanel/errors/useErrorActions.test.ts
@@ -39,9 +39,7 @@ describe('useErrorActions', () => {
       trackUiButtonClicked: mocks.trackUiButtonClicked,
       trackHelpResourceClicked: mocks.trackHelpResourceClicked
     }
-    windowOpenSpy = vi
-      .spyOn(window, 'open')
-      .mockImplementation(() => null as unknown as Window)
+    windowOpenSpy = vi.spyOn(window, 'open').mockImplementation(() => null)
   })
 
   afterEach(() => {

--- a/src/components/rightSidePanel/errors/useErrorReport.test.ts
+++ b/src/components/rightSidePanel/errors/useErrorReport.test.ts
@@ -26,7 +26,7 @@ const mocks = vi.hoisted(() => {
 const storeState = vi.hoisted(() => {
   // Plain objects wired up in beforeEach. Tests use setStoreState to swap values.
   return {
-    systemStats: null as unknown,
+    systemStats: null,
     isLoading: false
   }
 })

--- a/src/components/rightSidePanel/parameters/WidgetActions.test.ts
+++ b/src/components/rightSidePanel/parameters/WidgetActions.test.ts
@@ -109,7 +109,7 @@ describe('WidgetActions', () => {
       options: {},
       y: 0,
       callback
-    } as IBaseWidget
+    }
   }
 
   function createMockNode(): LGraphNode {

--- a/src/components/rightSidePanel/parameters/WidgetItem.test.ts
+++ b/src/components/rightSidePanel/parameters/WidgetItem.test.ts
@@ -91,7 +91,7 @@ function createMockWidget(overrides: Partial<IBaseWidget> = {}): IBaseWidget {
       values: ['option_a', 'option_b', 'option_c']
     },
     ...overrides
-  } as IBaseWidget
+  }
 }
 
 function renderWidgetItem(

--- a/src/components/rightSidePanel/shared.test.ts
+++ b/src/components/rightSidePanel/shared.test.ts
@@ -145,7 +145,7 @@ describe('computedSectionDataList', () => {
     name: string,
     options: IWidgetOptions = {}
   ): IBaseWidget {
-    return { name, type: 'number', options, y: 0 } as IBaseWidget
+    return { name, type: 'number', options, y: 0 }
   }
 
   it('omits hideInPanel widgets while keeping the rest on the node', () => {

--- a/src/components/rightSidePanel/shared.ts
+++ b/src/components/rightSidePanel/shared.ts
@@ -66,9 +66,7 @@ export function searchWidgets<T extends { widget: IBaseWidget }[]>(
   const fuse = new Fuse(searchableList, fuseOptions)
   const results = fuse.search(query.trim())
 
-  const matchedItems = new Set(
-    results.map((result) => list[result.item.index]!)
-  )
+  const matchedItems = new Set(results.map((result) => list[result.item.index]))
 
   return list.filter((item) => matchedItems.has(item)) as T
 }
@@ -194,7 +192,7 @@ function flatItems(
   }
 
   for (let i = 0; i < items.length; i++) {
-    const item = items[i] as Positionable
+    const item = items[i]
 
     if (isLGraphGroup(item)) {
       result.push(item)

--- a/src/components/sidebar/tabs/nodeLibrary/NodeBookmarkTreeExplorer.test.ts
+++ b/src/components/sidebar/tabs/nodeLibrary/NodeBookmarkTreeExplorer.test.ts
@@ -161,7 +161,7 @@ describe('NodeBookmarkTreeExplorer', () => {
     await nextTick()
     const root = getRoot()
     expect(root).not.toBeNull()
-    return root!
+    return root
   }
 
   describe('handleDrop', () => {

--- a/src/components/templates/thumbnails/BaseThumbnail.test.ts
+++ b/src/components/templates/thumbnails/BaseThumbnail.test.ts
@@ -9,7 +9,7 @@ describe('BaseThumbnail', () => {
     props: Partial<ComponentProps<typeof BaseThumbnail>> = {}
   ) {
     return render(BaseThumbnail, {
-      props: props as ComponentProps<typeof BaseThumbnail>,
+      props: props,
       slots: {
         default: '<img src="/test.jpg" alt="test" />'
       }

--- a/src/components/templates/thumbnails/CompareSliderThumbnail.test.ts
+++ b/src/components/templates/thumbnails/CompareSliderThumbnail.test.ts
@@ -32,7 +32,7 @@ const mockRect = (el: HTMLElement, width: number) => {
     x: 0,
     y: 0,
     toJSON: () => ({})
-  } as DOMRect)
+  })
 }
 
 describe('CompareSliderThumbnail', () => {

--- a/src/components/topbar/WorkflowTab.test.ts
+++ b/src/components/topbar/WorkflowTab.test.ts
@@ -1,4 +1,5 @@
 import { createTestingPinia } from '@pinia/testing'
+import { fromPartial } from '@total-typescript/shoehorn'
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -106,12 +107,8 @@ type WorkflowOption = WorkflowTabProps['workflowOption']
 type Workflow = WorkflowOption['workflow']
 type WorkflowOverrides = Partial<Workflow>
 
-// ComfyWorkflow has many required fields the component never reads (file
-// IO, change tracking). Validate the fields we *do* set against the real
-// type via Partial<Workflow>, then cast — adding/renaming a read field in
-// the component will fail typecheck on the override map.
 function makeWorkflowOption(overrides: WorkflowOverrides = {}): WorkflowOption {
-  const workflow = {
+  const workflow = fromPartial<Workflow>({
     key: 'test-key',
     path: '/workflows/test.json',
     filename: 'test.json',
@@ -120,10 +117,10 @@ function makeWorkflowOption(overrides: WorkflowOverrides = {}): WorkflowOption {
     activeMode: 'graph',
     changeTracker: null,
     ...overrides
-  } satisfies WorkflowOverrides
+  })
   // markRaw keeps a stable identity through prop reactivity so the store's
   // identity-based status lookup resolves against the same object.
-  return { value: 'test-key', workflow: markRaw(workflow) as Workflow }
+  return { value: 'test-key', workflow: markRaw(workflow) }
 }
 
 function renderTab({

--- a/src/components/ui/chart/useChart.ts
+++ b/src/components/ui/chart/useChart.ts
@@ -62,8 +62,8 @@ function getDefaultOptions(type: ChartType): ChartOptions {
                 '#888'
               return {
                 text: dataset.label ?? '',
-                fillStyle: color as string,
-                strokeStyle: color as string,
+                fillStyle: color,
+                strokeStyle: color,
                 lineWidth: 0,
                 pointStyle: 'circle' as const,
                 hidden: !chart.isDatasetVisible(i),

--- a/src/components/videoEdit/WidgetVideoEdit.test.ts
+++ b/src/components/videoEdit/WidgetVideoEdit.test.ts
@@ -20,12 +20,18 @@ const locatorNode = { id: 'inner' }
 const mocks = vi.hoisted(() => {
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   const { ref: createRef } = require('vue')
-  return {
+  const mocks: {
+    getNodeByLocatorId: ReturnType<typeof vi.fn>
+    resolvedSource: unknown
+    filmstripError: { value: string | null }
+    filmstripRetry: ReturnType<typeof vi.fn>
+  } = {
     getNodeByLocatorId: vi.fn(),
-    resolvedSource: undefined as unknown,
+    resolvedSource: undefined,
     filmstripError: createRef(null) as { value: string | null },
     filmstripRetry: vi.fn()
   }
+  return mocks
 })
 
 vi.mock('@/scripts/app', () => ({
@@ -115,7 +121,7 @@ function createWidget(
     value: {},
     options,
     ...extra
-  } as SimplifiedWidget<VideoEditValue>
+  }
 }
 
 function renderWidget(widget = createWidget()) {

--- a/src/composables/auth/useRegionGate.test.ts
+++ b/src/composables/auth/useRegionGate.test.ts
@@ -5,7 +5,7 @@ import { defineComponent, h } from 'vue'
 import { useRegionGate } from '@/composables/auth/useRegionGate'
 
 const detection = vi.hoisted(() => ({
-  outcome: Promise.resolve(false) as Promise<boolean>
+  outcome: Promise.resolve(false)
 }))
 vi.mock('@/utils/networkUtil', () => ({
   isInChina: () => detection.outcome

--- a/src/composables/billing/useBillingContext.test.ts
+++ b/src/composables/billing/useBillingContext.test.ts
@@ -37,33 +37,36 @@ const {
   mockSetWorkspaceBillingRail,
   mockLegacyStatus,
   mockBillingStatus
-} = vi.hoisted(() => ({
-  mockIsPersonal: { value: true },
-  mockBillingRail: { value: undefined as BillingRail | undefined },
-  mockPlans: { value: [] as Plan[] },
-  mockFetchPlans: vi.fn(async () => undefined),
-  mockLegacyFetchStatus: vi.fn(async () => undefined),
-  mockLegacyFetchBalance: vi.fn(async () => undefined),
-  mockLegacySubscribe: vi.fn(async () => undefined),
-  mockPurchaseCredits: vi.fn(),
-  mockUpdateActiveWorkspace: vi.fn(),
-  mockSetWorkspaceBillingRail: vi.fn(),
-  mockLegacyStatus: {
-    value: {
-      is_active: true,
-      has_funds: true,
-      renewal_date: '2025-01-01T00:00:00Z'
-    } as BillingStatusResponse
-  },
-  mockBillingStatus: {
+} = vi.hoisted(() => {
+  const mockBillingStatus: { value: Partial<BillingStatusResponse> } = {
     value: {
       is_active: true,
       has_funds: true,
       subscription_tier: 'PRO',
       subscription_duration: 'MONTHLY'
-    } as Partial<BillingStatusResponse>
+    }
   }
-}))
+  return {
+    mockIsPersonal: { value: true },
+    mockBillingRail: { value: undefined as BillingRail | undefined },
+    mockPlans: { value: [] as Plan[] },
+    mockFetchPlans: vi.fn(async () => undefined),
+    mockLegacyFetchStatus: vi.fn(async () => undefined),
+    mockLegacyFetchBalance: vi.fn(async () => undefined),
+    mockLegacySubscribe: vi.fn(async () => undefined),
+    mockPurchaseCredits: vi.fn(),
+    mockUpdateActiveWorkspace: vi.fn(),
+    mockSetWorkspaceBillingRail: vi.fn(),
+    mockLegacyStatus: {
+      value: {
+        is_active: true,
+        has_funds: true,
+        renewal_date: '2025-01-01T00:00:00Z'
+      } as BillingStatusResponse
+    },
+    mockBillingStatus
+  }
+})
 
 vi.mock('@vueuse/core', async (importOriginal) => {
   const original = await importOriginal()

--- a/src/composables/billing/usePendingTopup.test.ts
+++ b/src/composables/billing/usePendingTopup.test.ts
@@ -10,7 +10,7 @@ function creditAddedEvent(atMs: number): AuditLog {
   return {
     event_type: 'credit_added',
     createdAt: new Date(atMs).toISOString()
-  } as AuditLog
+  }
 }
 
 describe('usePendingTopup', () => {

--- a/src/composables/boundingBoxes/boundingBoxesUtil.ts
+++ b/src/composables/boundingBoxes/boundingBoxesUtil.ts
@@ -191,7 +191,7 @@ export function tagRects(
   return rects
 }
 
-function isBoundingBox(b: unknown): b is BoundingBox {
+export function isBoundingBox(b: unknown): b is BoundingBox {
   if (!b || typeof b !== 'object') return false
   const box = b as Record<string, unknown>
   return (

--- a/src/composables/boundingBoxes/useBoundingBoxes.test.ts
+++ b/src/composables/boundingBoxes/useBoundingBoxes.test.ts
@@ -7,13 +7,17 @@ import { useBoundingBoxes } from './useBoundingBoxes'
 import type { BoundingBox } from '@/types/boundingBoxes'
 import { toNodeId } from '@/types/nodeId'
 
-const { appState, outputState } = vi.hoisted(() => ({
-  appState: { node: null as unknown },
-  outputState: {
-    outputs: undefined as unknown,
+const { appState, outputState } = vi.hoisted(() => {
+  const appState: { node: MockNode | null } = { node: null }
+  const outputState: {
+    outputs: { input_bboxes: BoundingBox[] } | undefined
+    nodeOutputs: { value: Record<string, unknown> } | null
+  } = {
+    outputs: undefined,
     nodeOutputs: null as { value: Record<string, unknown> } | null
   }
-}))
+  return { appState, outputState }
+})
 
 vi.mock('@/scripts/app', () => ({
   app: { canvas: { graph: { getNodeById: () => appState.node } } }
@@ -60,18 +64,17 @@ function makeCanvas(): HTMLCanvasElement {
   Object.defineProperty(el, 'clientWidth', { value: 100, configurable: true })
   Object.defineProperty(el, 'clientHeight', { value: 100, configurable: true })
   el.getContext = (() => ctx) as unknown as HTMLCanvasElement['getContext']
-  el.getBoundingClientRect = () =>
-    ({
-      left: 0,
-      top: 0,
-      right: 100,
-      bottom: 100,
-      width: 100,
-      height: 100,
-      x: 0,
-      y: 0,
-      toJSON: () => ({})
-    }) as DOMRect
+  el.getBoundingClientRect = () => ({
+    left: 0,
+    top: 0,
+    right: 100,
+    bottom: 100,
+    width: 100,
+    height: 100,
+    x: 0,
+    y: 0,
+    toJSON: () => ({})
+  })
   el.focus = () => {}
   el.setPointerCapture = () => {}
   el.releasePointerCapture = () => {}
@@ -265,7 +268,7 @@ describe('useBoundingBoxes region editing', () => {
 describe('useBoundingBoxes inline editor', () => {
   it('opens on double click and commits the description', async () => {
     const c = setup([box()])
-    c.onDoubleClick(pe(30, 30) as unknown as MouseEvent)
+    c.onDoubleClick(pe(30, 30))
     await flush()
     expect(c.inlineEditor.value).not.toBeNull()
 
@@ -278,7 +281,7 @@ describe('useBoundingBoxes inline editor', () => {
 
   it('closes the inline editor on Escape', async () => {
     const c = setup([box()])
-    c.onDoubleClick(pe(30, 30) as unknown as MouseEvent)
+    c.onDoubleClick(pe(30, 30))
     await flush()
     c.onInlineKeyDown({ key: 'Escape' } as KeyboardEvent)
     expect(c.inlineEditor.value).toBeNull()

--- a/src/composables/boundingBoxes/useBoundingBoxes.test.ts
+++ b/src/composables/boundingBoxes/useBoundingBoxes.test.ts
@@ -10,7 +10,7 @@ import { toNodeId } from '@/types/nodeId'
 const { appState, outputState } = vi.hoisted(() => {
   const appState: { node: MockNode | null } = { node: null }
   const outputState: {
-    outputs: { input_bboxes: BoundingBox[] } | undefined
+    outputs: { input_bboxes: unknown } | undefined
     nodeOutputs: { value: Record<string, unknown> } | null
   } = {
     outputs: undefined,
@@ -316,6 +316,19 @@ describe('useBoundingBoxes incoming bboxes input', () => {
     outputState.outputs = { input_bboxes: [box({ x: 0, width: 100 })] }
     const c = setup([])
     expect(modelBoxes(c)).toHaveLength(0)
+  })
+
+  it('ignores an output containing an invalid bounding box', () => {
+    const node = makeConnectedNode()
+    appState.node = node
+    outputState.outputs = {
+      input_bboxes: [box(), { x: 1 }]
+    }
+
+    const c = setup([])
+
+    expect(modelBoxes(c)).toHaveLength(0)
+    expect(lastIncomingOf(node)).toEqual([])
   })
 
   it('repopulates from the next run after clearing the canvas', async () => {

--- a/src/composables/boundingBoxes/useBoundingBoxes.ts
+++ b/src/composables/boundingBoxes/useBoundingBoxes.ts
@@ -8,6 +8,7 @@ import {
   applyDrag,
   boxesAt,
   fromBoundingBoxes,
+  isBoundingBox,
   tagRects,
   toBoundingBoxes
 } from '@/composables/boundingBoxes/boundingBoxesUtil'
@@ -714,7 +715,12 @@ export function useBoundingBoxes(
     if (slot < 0 || !node.isInputConnected(slot)) return
     const outputs = nodeOutputStore.getNodeOutputs(node)
     const incoming = outputs?.input_bboxes
-    if (!Array.isArray(incoming) || !incoming.length) return
+    if (
+      !Array.isArray(incoming) ||
+      !incoming.length ||
+      !incoming.every(isBoundingBox)
+    )
+      return
     const applied = lastIncomingValue()
     if (isEqual(incoming, applied)) return
     if (!apply) {

--- a/src/composables/boundingBoxes/useBoundingBoxes.ts
+++ b/src/composables/boundingBoxes/useBoundingBoxes.ts
@@ -16,7 +16,6 @@ import type {
   Region
 } from '@/composables/boundingBoxes/boundingBoxesUtil'
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
-import type { NodeOutputWith } from '@/schemas/apiSchema'
 import { app } from '@/scripts/app'
 import { useNodeOutputStore } from '@/stores/nodeOutputStore'
 import type { BoundingBox } from '@/types/boundingBoxes'
@@ -713,11 +712,9 @@ export function useBoundingBoxes(
     if (!node) return
     const slot = node.findInputSlot('bboxes')
     if (slot < 0 || !node.isInputConnected(slot)) return
-    const outputs = nodeOutputStore.getNodeOutputs(node) as
-      | NodeOutputWith<{ input_bboxes?: BoundingBox[] }>
-      | undefined
+    const outputs = nodeOutputStore.getNodeOutputs(node)
     const incoming = outputs?.input_bboxes
-    if (!incoming?.length) return
+    if (!Array.isArray(incoming) || !incoming.length) return
     const applied = lastIncomingValue()
     if (isEqual(incoming, applied)) return
     if (!apply) {

--- a/src/composables/canvas/useFocusNode.test.ts
+++ b/src/composables/canvas/useFocusNode.test.ts
@@ -17,10 +17,11 @@ const { canvasStore, createCanvas } = vi.hoisted(() => {
     return canvas
   }
 
+  const canvasStore: {
+    canvas: ReturnType<typeof createCanvas> | undefined
+  } = { canvas: createCanvas() }
   return {
-    canvasStore: {
-      canvas: createCanvas() as ReturnType<typeof createCanvas> | undefined
-    },
+    canvasStore,
     createCanvas
   }
 })

--- a/src/composables/canvas/useFocusNode.ts
+++ b/src/composables/canvas/useFocusNode.ts
@@ -36,7 +36,7 @@ export function useFocusNode() {
   async function focusNodeInstance(node: LGraphNode) {
     if (!canvasStore.canvas || !node.graph) return
 
-    await navigateToGraph(node.graph as LGraph)
+    await navigateToGraph(node.graph)
     const canvas = canvasStore.canvas
     if (!canvas || canvas.graph !== node.graph) return
 

--- a/src/composables/element/useDomClipping.test.ts
+++ b/src/composables/element/useDomClipping.test.ts
@@ -10,17 +10,14 @@ function createMockElement(rect: {
   height: number
 }): HTMLElement {
   return fromPartial<HTMLElement>({
-    getBoundingClientRect: vi.fn(
-      () =>
-        ({
-          ...rect,
-          x: rect.left,
-          y: rect.top,
-          right: rect.left + rect.width,
-          bottom: rect.top + rect.height,
-          toJSON: () => ({})
-        }) as DOMRect
-    )
+    getBoundingClientRect: vi.fn(() => ({
+      ...rect,
+      x: rect.left,
+      y: rect.top,
+      right: rect.left + rect.width,
+      bottom: rect.top + rect.height,
+      toJSON: () => ({})
+    }))
   })
 }
 
@@ -31,17 +28,14 @@ function createMockCanvas(rect: {
   height: number
 }): HTMLCanvasElement {
   return fromPartial<HTMLCanvasElement>({
-    getBoundingClientRect: vi.fn(
-      () =>
-        ({
-          ...rect,
-          x: rect.left,
-          y: rect.top,
-          right: rect.left + rect.width,
-          bottom: rect.top + rect.height,
-          toJSON: () => ({})
-        }) as DOMRect
-    )
+    getBoundingClientRect: vi.fn(() => ({
+      ...rect,
+      x: rect.left,
+      y: rect.top,
+      right: rect.left + rect.width,
+      bottom: rect.top + rect.height,
+      toJSON: () => ({})
+    }))
   })
 }
 

--- a/src/composables/graph/useGraphHierarchy.ts
+++ b/src/composables/graph/useGraphHierarchy.ts
@@ -19,8 +19,7 @@ export function useGraphHierarchy() {
    * @returns The parent group if found, otherwise null
    */
   function findParentGroup(node: LGraphNode): LGraphGroup | null {
-    const graphGroups = (canvasStore.canvas?.graph?.groups ??
-      []) as LGraphGroup[]
+    const graphGroups = canvasStore.canvas?.graph?.groups ?? []
 
     let parent: LGraphGroup | null = null
 

--- a/src/composables/graph/useGroupMenuOptions.ts
+++ b/src/composables/graph/useGroupMenuOptions.ts
@@ -1,7 +1,7 @@
 import { useI18n } from 'vue-i18n'
 
 import { LGraphEventMode } from '@/lib/litegraph/src/litegraph'
-import type { LGraphGroup, LGraphNode } from '@/lib/litegraph/src/litegraph'
+import type { LGraphGroup } from '@/lib/litegraph/src/litegraph'
 import { useSettingStore } from '@/platform/settings/settingStore'
 import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
@@ -51,7 +51,7 @@ export function useGroupMenuOptions() {
     submenu: shapeOptions.map((shape) => ({
       label: shape.localizedName,
       action: () => {
-        const nodes = (groupContext.nodes || []) as LGraphNode[]
+        const nodes = groupContext.nodes || []
         nodes.forEach((node) => (node.shape = shape.value))
         canvasRefresh.refreshCanvas()
         bump()
@@ -92,7 +92,7 @@ export function useGroupMenuOptions() {
       return options
     }
 
-    const groupNodes = (groupContext.nodes || []) as LGraphNode[]
+    const groupNodes = groupContext.nodes || []
     if (!groupNodes.length) return options
 
     // Check if all nodes have the same mode

--- a/src/composables/graph/useMoreOptionsMenu.ts
+++ b/src/composables/graph/useMoreOptionsMenu.ts
@@ -173,9 +173,7 @@ export function useMoreOptionsMenu() {
     const states = computeSelectionFlags()
 
     // Detect single group selection context (and no nodes explicitly selected)
-    const selectedGroups = selectedItems.value.filter(
-      isLGraphGroup
-    ) as LGraphGroup[]
+    const selectedGroups = selectedItems.value.filter(isLGraphGroup)
     const groupContext: LGraphGroup | null =
       selectedGroups.length === 1 && selectedNodes.value.length === 0
         ? selectedGroups[0]

--- a/src/composables/graph/useSelectionState.ts
+++ b/src/composables/graph/useSelectionState.ts
@@ -33,9 +33,7 @@ export function useSelectionState() {
   const { selectedItems } = storeToRefs(canvasStore)
 
   const selectedNodes = computed(() => {
-    return selectedItems.value.filter((i: unknown) =>
-      isLGraphNode(i)
-    ) as LGraphNode[]
+    return selectedItems.value.filter((i: unknown) => isLGraphNode(i))
   })
 
   const nodeDef = computed(() => {

--- a/src/composables/maskeditor/useBrushDrawing.test.ts
+++ b/src/composables/maskeditor/useBrushDrawing.test.ts
@@ -11,7 +11,7 @@ const mockStoreDef = vi.hoisted(() => ({
     hardness: 0.9,
     opacity: 1,
     stepSize: 5,
-    type: 'arc' as string
+    type: 'arc'
   },
   currentTool: 'pen' as string,
   activeLayer: 'mask' as string,

--- a/src/composables/maskeditor/useCanvasHistory.test.ts
+++ b/src/composables/maskeditor/useCanvasHistory.test.ts
@@ -75,7 +75,7 @@ if (typeof globalThis.ImageBitmap === 'undefined') {
       this.height = height
     }
     close() {}
-  } as typeof ImageBitmap
+  }
 }
 
 describe('useCanvasHistory', () => {

--- a/src/composables/maskeditor/useCanvasManager.test.ts
+++ b/src/composables/maskeditor/useCanvasManager.test.ts
@@ -178,7 +178,7 @@ describe('useCanvasManager', () => {
     it('should throw error when context missing', async () => {
       const manager = useCanvasManager()
 
-      mockStore.imgCtx = null! as CanvasRenderingContext2D
+      mockStore.imgCtx = null!
 
       const origImage = createMockImage(512, 512)
       const maskImage = createMockImage(512, 512)
@@ -271,7 +271,7 @@ describe('useCanvasManager', () => {
     it('should return early when context missing', async () => {
       const manager = useCanvasManager()
 
-      mockStore.maskCtx = null! as CanvasRenderingContext2D
+      mockStore.maskCtx = null!
 
       await manager.updateMaskColor()
 

--- a/src/composables/maskeditor/useCanvasTransform.test.ts
+++ b/src/composables/maskeditor/useCanvasTransform.test.ts
@@ -108,7 +108,7 @@ if (typeof globalThis.ImageBitmap === 'undefined') {
       this.height = height
     }
     close() {}
-  } as typeof ImageBitmap
+  }
 }
 
 describe('useCanvasTransform', () => {

--- a/src/composables/maskeditor/useCoordinateTransform.test.ts
+++ b/src/composables/maskeditor/useCoordinateTransform.test.ts
@@ -36,7 +36,7 @@ const createElementWithRect = (rect: Partial<DOMRect>): HTMLElement => {
     y: 0,
     toJSON: () => ({}),
     ...rect
-  } as DOMRect)
+  })
   return el
 }
 
@@ -59,7 +59,7 @@ const createCanvasWithRect = (
     y: 0,
     toJSON: () => ({}),
     ...rect
-  } as DOMRect)
+  })
   return canvas
 }
 

--- a/src/composables/maskeditor/useGPUResources.test.ts
+++ b/src/composables/maskeditor/useGPUResources.test.ts
@@ -28,8 +28,9 @@ vi.mock('./gpu/GPUBrushRenderer', () => ({
   )
 }))
 
+const tgpuRoot: unknown = null
 const mockStore = reactive({
-  tgpuRoot: null as unknown,
+  tgpuRoot,
   maskCanvas: null as HTMLCanvasElement | null,
   rgbCanvas: null as HTMLCanvasElement | null,
   maskCtx: null as CanvasRenderingContext2D | null,
@@ -39,8 +40,8 @@ const mockStore = reactive({
   gpuTexturesNeedRecreation: false,
   gpuTextureWidth: 0,
   gpuTextureHeight: 0,
-  pendingGPUMaskData: null as null,
-  pendingGPURgbData: null as null,
+  pendingGPUMaskData: null,
+  pendingGPURgbData: null,
   brushSettings: {
     size: 20,
     hardness: 0.9,
@@ -185,7 +186,7 @@ describe('watchers', () => {
 describe('initGPUResources with pre-existing tgpuRoot', () => {
   it('returns early with a warning when canvas contexts are not ready', async () => {
     const { initGPUResources, hasRenderer } = setup()
-    mockStore.tgpuRoot = { device: {} } as unknown
+    mockStore.tgpuRoot = { device: {} }
     await initGPUResources()
     expect(hasRenderer.value).toBe(false)
   })

--- a/src/composables/maskeditor/useGPUResources.ts
+++ b/src/composables/maskeditor/useGPUResources.ts
@@ -216,7 +216,7 @@ export function useGPUResources() {
       /* c8 ignore start — requires functional WebGPU hardware */
       const root = await tgpu.init()
       store.tgpuRoot = root
-      device = root.device as GPUDevice
+      device = root.device
       console.warn('✅ TypeGPU initialized! Root:', root)
       console.warn('Device info:', root.device.limits)
       /* c8 ignore stop */
@@ -597,7 +597,7 @@ export function useGPUResources() {
       const c = parseToRgb(store.rgbColor)
       return [c.r / 255, c.g / 255, c.b / 255]
     }
-    const c = store.maskColor as { r: number; g: number; b: number }
+    const c = store.maskColor
     return [c.r / 255, c.g / 255, c.b / 255]
   }
   /* c8 ignore stop */

--- a/src/composables/maskeditor/usePanAndZoom.test.ts
+++ b/src/composables/maskeditor/usePanAndZoom.test.ts
@@ -82,7 +82,7 @@ function createTouchList(...points: { x: number; y: number }[]): TouchList {
   return Object.assign(touches, {
     length: touches.length,
     item: (i: number) => touches[i]
-  }) as unknown as TouchList
+  })
 }
 
 function createTouchEvent(touches: TouchList): TouchEvent {
@@ -98,7 +98,7 @@ async function initComposable() {
   const root = createMockElement()
   const container = createMockElement()
   const canvas = createMockCanvas(800, 600)
-  mockStore.canvasContainer = container as unknown as HTMLElement
+  mockStore.canvasContainer = container
   mockStore.maskCanvas = canvas
   await pz.initializeCanvasPanZoom(img, root)
   vi.clearAllMocks()
@@ -120,7 +120,7 @@ describe('usePanAndZoom', () => {
     it('sets zoom and pan on the store', async () => {
       const pz = usePanAndZoom()
       const container = createMockElement()
-      mockStore.canvasContainer = container as unknown as HTMLElement
+      mockStore.canvasContainer = container
 
       await pz.initializeCanvasPanZoom(
         createMockImage(800, 600),
@@ -136,7 +136,7 @@ describe('usePanAndZoom', () => {
 
     it('accounts for panel widths via setPanOffset', async () => {
       const pz = usePanAndZoom()
-      mockStore.canvasContainer = createMockElement() as unknown as HTMLElement
+      mockStore.canvasContainer = createMockElement()
 
       const toolPanel = createMockElement()
       vi.spyOn(toolPanel, 'getBoundingClientRect').mockReturnValue({
@@ -161,7 +161,7 @@ describe('usePanAndZoom', () => {
     it('syncs rgbCanvas dimensions when they differ', async () => {
       const pz = usePanAndZoom()
       const rgbCanvas = createMockCanvas(400, 300)
-      mockStore.canvasContainer = createMockElement() as unknown as HTMLElement
+      mockStore.canvasContainer = createMockElement()
       mockStore.rgbCanvas = rgbCanvas
 
       await pz.initializeCanvasPanZoom(
@@ -274,7 +274,7 @@ describe('usePanAndZoom', () => {
     it('returns early when maskCanvas is null', async () => {
       const pz = usePanAndZoom()
       const container = createMockElement()
-      mockStore.canvasContainer = container as unknown as HTMLElement
+      mockStore.canvasContainer = container
       mockStore.maskCanvas = null
       await pz.initializeCanvasPanZoom(
         createMockImage(800, 600),

--- a/src/composables/node/useNodeDragToCanvas.ts
+++ b/src/composables/node/useNodeDragToCanvas.ts
@@ -53,9 +53,7 @@ function applyWidgetValues(node: LGraphNode, values: WidgetValues) {
 }
 
 function isOverCanvas(clientX: number, clientY: number): boolean {
-  const canvasElement = useCanvasStore().canvas?.canvas as
-    | HTMLCanvasElement
-    | undefined
+  const canvasElement = useCanvasStore().canvas?.canvas
   if (!canvasElement) return false
   const rect = canvasElement.getBoundingClientRect()
   return (

--- a/src/composables/node/useNodePricing.ts
+++ b/src/composables/node/useNodePricing.ts
@@ -125,7 +125,7 @@ const isPricingResult = (value: unknown): value is PricingResult =>
   typeof value === 'object' &&
   value !== null &&
   'type' in value &&
-  typeof (value as { type: unknown }).type === 'string' &&
+  typeof value.type === 'string' &&
   PRICING_RESULT_TYPES.includes(
     (value as { type: string }).type as (typeof PRICING_RESULT_TYPES)[number]
   )
@@ -328,7 +328,7 @@ export const formatPricingResult = (
     !('type' in result) &&
     'usd' in result
   ) {
-    const r = result as { usd: unknown }
+    const r = result
     const usd = asFiniteNumber(r.usd)
     if (usd === null) return ''
     if (valueOnly) return formatCreditsValue(usd)

--- a/src/composables/node/useNodePricing.ts
+++ b/src/composables/node/useNodePricing.ts
@@ -127,7 +127,7 @@ const isPricingResult = (value: unknown): value is PricingResult =>
   'type' in value &&
   typeof value.type === 'string' &&
   PRICING_RESULT_TYPES.includes(
-    (value as { type: string }).type as (typeof PRICING_RESULT_TYPES)[number]
+    value.type as (typeof PRICING_RESULT_TYPES)[number]
   )
 
 /**
@@ -328,8 +328,7 @@ export const formatPricingResult = (
     !('type' in result) &&
     'usd' in result
   ) {
-    const r = result
-    const usd = asFiniteNumber(r.usd)
+    const usd = asFiniteNumber(result.usd)
     if (usd === null) return ''
     if (valueOnly) return formatCreditsValue(usd)
     return formatCreditsLabel(usd, defaults)

--- a/src/composables/painter/usePainter.test.ts
+++ b/src/composables/painter/usePainter.test.ts
@@ -2,7 +2,6 @@ import { render } from '@testing-library/vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { defineComponent, nextTick, ref } from 'vue'
 
-import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
 import type { IBaseWidget } from '@/lib/litegraph/src/types/widgets'
 import { api } from '@/scripts/api'
 import { toNodeId } from '@/types/nodeId'
@@ -356,7 +355,7 @@ describe('usePainter', () => {
 
       mountPainter(toNodeId('test-node'), 'painter/existing.png [temp]')
 
-      const result = await maskWidget.serializeValue!({} as LGraphNode, 0)
+      const result = await maskWidget.serializeValue!({}, 0)
       expect(result).toBe('painter/existing.png [temp]')
     })
 
@@ -380,7 +379,7 @@ describe('usePainter', () => {
       canvasEl.value = fakeCanvas
       await nextTick()
 
-      const result = await maskWidget.serializeValue!({} as LGraphNode, 0)
+      const result = await maskWidget.serializeValue!({}, 0)
       expect(fetchApiMock).toHaveBeenCalledWith(
         '/upload/image',
         expect.objectContaining({ method: 'POST' })
@@ -413,9 +412,9 @@ describe('usePainter', () => {
       canvasEl.value = fakeCanvas
       await nextTick()
 
-      await expect(
-        maskWidget.serializeValue!({} as LGraphNode, 0)
-      ).rejects.toThrow(/missing 'name'/)
+      await expect(maskWidget.serializeValue!({}, 0)).rejects.toThrow(
+        /missing 'name'/
+      )
     })
 
     it('throws when the upload response body is not valid JSON', async () => {
@@ -439,9 +438,9 @@ describe('usePainter', () => {
       canvasEl.value = fakeCanvas
       await nextTick()
 
-      await expect(
-        maskWidget.serializeValue!({} as LGraphNode, 0)
-      ).rejects.toThrow(/painter\.uploadError/)
+      await expect(maskWidget.serializeValue!({}, 0)).rejects.toThrow(
+        /painter\.uploadError/
+      )
     })
 
     it('returns existing modelValue when canvas element is unmounted at serialize time', async () => {
@@ -450,7 +449,7 @@ describe('usePainter', () => {
 
       mountPainter(toNodeId('test-node'), 'painter/cached.png [temp]')
 
-      const result = await maskWidget.serializeValue!({} as LGraphNode, 0)
+      const result = await maskWidget.serializeValue!({}, 0)
       expect(result).toBe('painter/cached.png [temp]')
     })
 

--- a/src/composables/painter/usePainter.ts
+++ b/src/composables/painter/usePainter.ts
@@ -11,7 +11,6 @@ import {
 import { StrokeProcessor } from '@/composables/maskeditor/StrokeProcessor'
 import { hexToRgb } from '@/utils/colorUtil'
 import type { Point } from '@/extensions/core/maskeditor/types'
-import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
 import type { IBaseWidget } from '@/lib/litegraph/src/types/widgets'
 import { useToastStore } from '@/platform/updates/common/toastStore'
 import { api } from '@/scripts/api'
@@ -81,7 +80,7 @@ export function usePainter(nodeId: NodeId, options: UsePainterOptions) {
 
   const litegraphNode = computed(() => {
     if (!nodeId || !app.canvas.graph) return null
-    return app.canvas.graph.getNodeById(nodeId) as LGraphNode | null
+    return app.canvas.graph.getNodeById(nodeId)
   })
 
   function getWidgetByName(name: string): IBaseWidget | undefined {

--- a/src/composables/palette/usePaletteSwatchRow.test.ts
+++ b/src/composables/palette/usePaletteSwatchRow.test.ts
@@ -50,9 +50,9 @@ describe('usePaletteSwatchRow', () => {
     for (const i of [0, 1]) {
       const swatch = document.createElement('div')
       swatch.setAttribute('data-index', String(i))
-      container.value!.appendChild(swatch)
+      container.value.appendChild(swatch)
     }
-    const second = container.value!.children[1] as HTMLDivElement
+    const second = container.value.children[1] as HTMLDivElement
     second.getBoundingClientRect = () =>
       ({ left: 100, right: 140, top: 0, bottom: 20, width: 40 }) as DOMRect
 
@@ -68,9 +68,9 @@ describe('usePaletteSwatchRow', () => {
     for (const i of [0, 1]) {
       const swatch = document.createElement('div')
       swatch.setAttribute('data-index', String(i))
-      container.value!.appendChild(swatch)
+      container.value.appendChild(swatch)
     }
-    const second = container.value!.children[1] as HTMLDivElement
+    const second = container.value.children[1] as HTMLDivElement
     second.getBoundingClientRect = () =>
       ({ left: 100, right: 140, top: 0, bottom: 20, width: 40 }) as DOMRect
 
@@ -85,7 +85,7 @@ describe('usePaletteSwatchRow', () => {
     const { modelValue, container, onPointerDown } = setup(['#a', '#b'])
     const swatch = document.createElement('div')
     swatch.setAttribute('data-index', '1')
-    container.value!.appendChild(swatch)
+    container.value.appendChild(swatch)
     onPointerDown(0, { button: 2, clientX: 10, clientY: 10 } as PointerEvent)
     document.dispatchEvent(
       new MouseEvent('pointermove', { clientX: 130, clientY: 10 })

--- a/src/composables/queue/useJobActions.ts
+++ b/src/composables/queue/useJobActions.ts
@@ -5,7 +5,6 @@ import { useI18n } from 'vue-i18n'
 import { useErrorHandling } from '@/composables/useErrorHandling'
 import type { JobListItem } from '@/composables/queue/useJobList'
 import { useJobMenu } from '@/composables/queue/useJobMenu'
-import type { TaskItemImpl } from '@/stores/queueStore'
 import { isActiveJobState } from '@/utils/queueUtil'
 
 export type JobAction = {
@@ -64,7 +63,7 @@ export function useJobActions(
 
   const runDeleteJob = wrapWithErrorHandlingAsync(async () => {
     const currentJob = jobRef.value
-    const task = currentJob?.taskRef as TaskItemImpl | undefined
+    const task = currentJob?.taskRef
     if (!task) {
       return
     }

--- a/src/composables/queue/useJobList.test.ts
+++ b/src/composables/queue/useJobList.test.ts
@@ -49,8 +49,8 @@ vi.mock('@/i18n', () => ({
 let totalPercent: Ref<number>
 let currentNodePercent: Ref<number>
 const ensureProgressRefs = () => {
-  if (!totalPercent) totalPercent = ref(0) as Ref<number>
-  if (!currentNodePercent) currentNodePercent = ref(0) as Ref<number>
+  if (!totalPercent) totalPercent = ref(0)
+  if (!currentNodePercent) currentNodePercent = ref(0)
   return { totalPercent, currentNodePercent }
 }
 vi.mock('@/composables/queue/useQueueProgress', () => ({
@@ -137,7 +137,7 @@ let jobPreviewStoreMock: {
 const ensureJobPreviewStore = () => {
   if (!jobPreviewStoreMock) {
     jobPreviewStoreMock = reactive({
-      previewsByPromptId: {} as Record<string, string>,
+      previewsByPromptId: {},
       isPreviewEnabled: true
     })
   }
@@ -249,7 +249,7 @@ describe('useJobList', () => {
     const mounted = mountUseJobList()
     unmount = mounted.unmount
     api = mounted.composable
-    return api!
+    return api
   }
 
   it('tracks recently added pending jobs and clears the hint after expiry', async () => {

--- a/src/composables/queue/useJobList.ts
+++ b/src/composables/queue/useJobList.ts
@@ -302,7 +302,7 @@ export function useJobList() {
           task.executionTime !== undefined
             ? task.executionTime / 3_600_000
             : undefined
-      } as JobListItem
+      }
     })
   })
 

--- a/src/composables/queue/useJobMenu.test.ts
+++ b/src/composables/queue/useJobMenu.test.ts
@@ -314,7 +314,7 @@ describe('useJobMenu', () => {
         state: 'failed',
         taskRef: {
           errorMessage: 'Something went wrong'
-        } as Partial<TaskItemImpl>
+        }
       })
     )
 
@@ -346,7 +346,7 @@ describe('useJobMenu', () => {
           errorMessage: 'CUDA out of memory',
           executionError,
           createTime: 12345
-        } as Partial<TaskItemImpl>
+        }
       })
     )
 
@@ -368,7 +368,7 @@ describe('useJobMenu', () => {
         state: 'failed',
         taskRef: {
           errorMessage: 'Job failed with error'
-        } as Partial<TaskItemImpl>
+        }
       })
     )
 
@@ -390,7 +390,7 @@ describe('useJobMenu', () => {
     setCurrentItem(
       createJobItem({
         state: 'failed',
-        taskRef: { errorMessage: undefined } as Partial<TaskItemImpl>
+        taskRef: { errorMessage: undefined }
       })
     )
 
@@ -576,7 +576,7 @@ describe('useJobMenu', () => {
     setCurrentItem(
       createJobItem({
         state: 'completed',
-        taskRef: {} as Partial<TaskItemImpl>
+        taskRef: {}
       })
     )
 
@@ -610,7 +610,7 @@ describe('useJobMenu', () => {
     setCurrentItem(
       createJobItem({
         state: 'completed',
-        taskRef: {} as Partial<TaskItemImpl>
+        taskRef: {}
       })
     )
 
@@ -787,7 +787,7 @@ describe('useJobMenu', () => {
     setCurrentItem(
       createJobItem({
         state: 'failed',
-        taskRef: { errorMessage: 'Some error' } as Partial<TaskItemImpl>
+        taskRef: { errorMessage: 'Some error' }
       })
     )
 

--- a/src/composables/queue/useJobMenu.ts
+++ b/src/composables/queue/useJobMenu.ts
@@ -205,8 +205,7 @@ export function useJobMenu(
   }
 
   const removeFailedJob = async (task?: TaskItemImpl | null) => {
-    const target =
-      task ?? (currentMenuItem()?.taskRef as TaskItemImpl | undefined)
+    const target = task ?? currentMenuItem()?.taskRef
     if (!target) return
     await queueStore.delete(target)
   }

--- a/src/composables/queue/useQueueProgress.test.ts
+++ b/src/composables/queue/useQueueProgress.test.ts
@@ -8,7 +8,7 @@ import { formatPercent0 } from '@/utils/numberUtil'
 
 type ProgressValue = number | null
 
-const localeRef: Ref<string> = ref('en-US') as Ref<string>
+const localeRef: Ref<string> = ref('en-US')
 const executionProgressRef: Ref<ProgressValue> = ref(null)
 const executingNodeProgressRef: Ref<ProgressValue> = ref(null)
 

--- a/src/composables/queue/useResultGallery.test.ts
+++ b/src/composables/queue/useResultGallery.test.ts
@@ -49,15 +49,14 @@ const createTask = (
 const createJobViewItem = (
   id: string,
   taskRef?: TaskItemImpl
-): JobListViewItem =>
-  ({
-    id,
-    title: `Job ${id}`,
-    meta: '',
-    state: 'completed',
-    showClear: false,
-    taskRef
-  }) as JobListViewItem
+): JobListViewItem => ({
+  id,
+  title: `Job ${id}`,
+  meta: '',
+  state: 'completed',
+  showClear: false,
+  taskRef
+})
 
 describe('useResultGallery', () => {
   it('collects only previewable outputs and preserves their order', async () => {

--- a/src/composables/tree/useTreeFolderOperations.ts
+++ b/src/composables/tree/useTreeFolderOperations.ts
@@ -51,7 +51,7 @@ export function useTreeFolderOperations<T>(
       totalLeaves: 0,
       badgeText: '',
       isEditingLabel: true
-    } as RenderedTreeExplorerNode<T>
+    }
     addFolderTargetNode.value = targetNode
   }
 

--- a/src/composables/useCoreCommands.test.ts
+++ b/src/composables/useCoreCommands.test.ts
@@ -297,7 +297,7 @@ describe('useCoreCommands', () => {
       getNodeById: vi.fn(),
       setDirtyCanvas: vi.fn(),
       sendActionToCanvas: vi.fn(),
-      extra: {} as Record<string, unknown>
+      extra: {}
     } as Partial<typeof app.canvas.subgraph> as typeof app.canvas.subgraph
   }
 
@@ -388,7 +388,7 @@ describe('useCoreCommands', () => {
       expect(mockRunMintPortsIntentionalClear).not.toHaveBeenCalled()
 
       // Should only remove user nodes, not input/output nodes
-      const subgraph = app.canvas.subgraph!
+      const subgraph = app.canvas.subgraph
       expect(subgraph.remove).toHaveBeenCalledTimes(2)
       expect(subgraph.remove).toHaveBeenCalledWith(subgraph.nodes[2]) // user1
       expect(subgraph.remove).toHaveBeenCalledWith(subgraph.nodes[3]) // user2
@@ -811,9 +811,7 @@ describe('useCoreCommands', () => {
     let openSpy: ReturnType<typeof vi.spyOn>
 
     beforeEach(() => {
-      openSpy = vi
-        .spyOn(window, 'open')
-        .mockImplementation(() => null as unknown as Window)
+      openSpy = vi.spyOn(window, 'open').mockImplementation(() => null)
     })
 
     it('Comfy.Help.OpenComfyUIIssues opens the GitHub issues URL and tracks telemetry', async () => {

--- a/src/composables/useCurveEditor.test.ts
+++ b/src/composables/useCurveEditor.test.ts
@@ -29,10 +29,7 @@ const ensureMatrixTransformPolyfill = () => {
 }
 
 const createSvgElement = (): SVGSVGElement => {
-  const svg = document.createElementNS(
-    'http://www.w3.org/2000/svg',
-    'svg'
-  ) as SVGSVGElement
+  const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
   svg.setPointerCapture = vi.fn()
   svg.releasePointerCapture = vi.fn()
   document.body.appendChild(svg)

--- a/src/composables/useImageCrop.test.ts
+++ b/src/composables/useImageCrop.test.ts
@@ -121,18 +121,17 @@ function mountContainerLayout(
     configurable: true,
     value: height
   })
-  el.getBoundingClientRect = () =>
-    ({
-      width: rectWidth,
-      height,
-      top: 0,
-      left: 0,
-      right: rectWidth,
-      bottom: height,
-      x: 0,
-      y: 0,
-      toJSON: () => ({})
-    }) as DOMRect
+  el.getBoundingClientRect = () => ({
+    width: rectWidth,
+    height,
+    top: 0,
+    left: 0,
+    right: rectWidth,
+    bottom: height,
+    x: 0,
+    y: 0,
+    toJSON: () => ({})
+  })
 }
 
 function makePointerEvent(
@@ -164,7 +163,7 @@ type CropVm = Record<string, unknown> & {
 function setupImageLayout(vm: CropVm, nw: number, nh: number) {
   /* Harness root + image are not RTL queries — layout is driven by composable state */
   /* eslint-disable testing-library/no-node-access */
-  const container = vm.$el as HTMLDivElement
+  const container = vm.$el
   const img = container.querySelector('img')
   /* eslint-enable testing-library/no-node-access */
   mountContainerLayout(container, 400, 300)
@@ -373,7 +372,7 @@ describe('useImageCrop', () => {
   it('uses scale factor 1 when natural dimensions are zero', async () => {
     const vm = await mountHarness()
     /* eslint-disable testing-library/no-node-access */
-    const container = vm.$el as HTMLDivElement
+    const container = vm.$el
     const img = container.querySelector('img')
     /* eslint-enable testing-library/no-node-access */
     if (!img) throw new Error('expected preview img')
@@ -438,7 +437,7 @@ describe('useImageCrop', () => {
   it('drags the crop box in image space and ends on pointerup', async () => {
     const vm = await mountHarness()
     setupImageLayout(vm, 400, 300)
-    mountContainerLayout(vm.$el as HTMLDivElement, 400, 300)
+    mountContainerLayout(vm.$el, 400, 300)
     vm.modelValue = { x: 10, y: 10, width: 120, height: 90 }
 
     const captureEl = document.createElement('div')

--- a/src/composables/useLoad3d.test.ts
+++ b/src/composables/useLoad3d.test.ts
@@ -316,12 +316,11 @@ describe('useLoad3d', () => {
     })
 
     it('should restore camera config from node properties', async () => {
-      ;(
-        mockNode.properties!['Camera Config'] as Record<string, unknown>
-      ).state = {
-        position: { x: 1, y: 2, z: 3 },
-        target: { x: 0, y: 0, z: 0 }
-      }
+      ;(mockNode.properties['Camera Config'] as Record<string, unknown>).state =
+        {
+          position: { x: 1, y: 2, z: 3 },
+          target: { x: 0, y: 0, z: 0 }
+        }
 
       const composable = useLoad3d(mockNode)
       const containerRef = document.createElement('div')
@@ -793,7 +792,7 @@ describe('useLoad3d', () => {
     })
 
     it('should use resource folder for upload', async () => {
-      mockNode.properties!['Resource Folder'] = 'subfolder'
+      mockNode.properties['Resource Folder'] = 'subfolder'
       vi.mocked(Load3dUtils.uploadFile).mockResolvedValue('uploaded-image.jpg')
 
       const composable = useLoad3d(mockNode)
@@ -1230,10 +1229,10 @@ describe('useLoad3d', () => {
     })
 
     it('should handle missing configurations', async () => {
-      delete mockNode.properties!['Scene Config']
-      delete mockNode.properties!['Model Config']
-      delete mockNode.properties!['Camera Config']
-      delete mockNode.properties!['Light Config']
+      delete mockNode.properties['Scene Config']
+      delete mockNode.properties['Model Config']
+      delete mockNode.properties['Camera Config']
+      delete mockNode.properties['Light Config']
 
       const composable = useLoad3d(mockNode)
       const containerRef = document.createElement('div')
@@ -1246,7 +1245,7 @@ describe('useLoad3d', () => {
 
     it('should handle background image with existing config', async () => {
       ;(
-        mockNode.properties!['Scene Config'] as {
+        mockNode.properties['Scene Config'] as {
           backgroundImage: string
         }
       ).backgroundImage = 'existing.jpg'
@@ -1274,7 +1273,7 @@ describe('useLoad3d', () => {
     })
 
     it('should restore gizmo config from node properties', async () => {
-      ;(mockNode.properties!['Model Config'] as Record<string, unknown>).gizmo =
+      ;(mockNode.properties['Model Config'] as Record<string, unknown>).gizmo =
         {
           enabled: true,
           mode: 'rotate',
@@ -1298,7 +1297,7 @@ describe('useLoad3d', () => {
     })
 
     it('should add default gizmo config when missing from saved config', async () => {
-      mockNode.properties!['Model Config'] = {
+      mockNode.properties['Model Config'] = {
         upDirection: 'original',
         materialMode: 'original',
         showSkeleton: false
@@ -1314,7 +1313,7 @@ describe('useLoad3d', () => {
     })
 
     it('should add default scale when gizmo config lacks scale', async () => {
-      ;(mockNode.properties!['Model Config'] as Record<string, unknown>).gizmo =
+      ;(mockNode.properties['Model Config'] as Record<string, unknown>).gizmo =
         {
           enabled: false,
           mode: 'translate',
@@ -1588,7 +1587,7 @@ describe('useLoad3d', () => {
       originalFetch = globalThis.fetch
       globalThis.fetch = vi.fn().mockResolvedValue({
         blob: () => Promise.resolve(new Blob(['x'], { type: 'image/png' }))
-      } as unknown as Response)
+      })
     })
 
     afterEach(() => {

--- a/src/composables/useLoad3d.ts
+++ b/src/composables/useLoad3d.ts
@@ -187,10 +187,8 @@ export const useLoad3d = (nodeOrRef: MaybeRef<LGraphNode | null>) => {
   ])
 
   const initializeLoad3d = async (containerRef: HTMLElement) => {
-    const rawNode = toRaw(nodeRef.value)
-    if (!containerRef || !rawNode) return
-
-    const node = rawNode
+    const node = toRaw(nodeRef.value)
+    if (!containerRef || !node) return
 
     try {
       const widthWidget = node.widgets?.find((w) => w.name === 'width')
@@ -420,10 +418,8 @@ export const useLoad3d = (nodeOrRef: MaybeRef<LGraphNode | null>) => {
   }
 
   const waitForLoad3d = (callback: Load3dReadyCallback) => {
-    const rawNode = toRaw(nodeRef.value)
-    if (!rawNode) return
-
-    const node = rawNode
+    const node = toRaw(nodeRef.value)
+    if (!node) return
     const existingInstance = nodeToLoad3dMap.get(node)
 
     if (existingInstance) {
@@ -440,10 +436,8 @@ export const useLoad3d = (nodeOrRef: MaybeRef<LGraphNode | null>) => {
   }
 
   const onLoad3dReady = (callback: Load3dReadyCallback) => {
-    const rawNode = toRaw(nodeRef.value)
-    if (!rawNode) return
-
-    const node = rawNode
+    const node = toRaw(nodeRef.value)
+    if (!node) return
 
     if (!persistentReadyCallbacks.has(node)) {
       persistentReadyCallbacks.set(node, [])
@@ -995,9 +989,8 @@ export const useLoad3d = (nodeOrRef: MaybeRef<LGraphNode | null>) => {
       animationDuration.value = data.duration
     },
     cameraChanged: (cameraState: CameraState) => {
-      const rawNode = toRaw(nodeRef.value)
-      if (rawNode) {
-        const node = rawNode
+      const node = toRaw(nodeRef.value)
+      if (node) {
         if (!node.properties) node.properties = {}
         const cameraConfigProp = node.properties['Camera Config']
 
@@ -1072,10 +1065,8 @@ export const useLoad3d = (nodeOrRef: MaybeRef<LGraphNode | null>) => {
   const cleanup = () => {
     handleEvents('remove')
 
-    const rawNode = toRaw(nodeRef.value)
-    if (!rawNode) return
-
-    const node = rawNode
+    const node = toRaw(nodeRef.value)
+    if (!node) return
     if (nodeToLoad3dMap.get(node) === load3d) {
       nodeToLoad3dMap.delete(node)
     }

--- a/src/composables/useLoad3d.ts
+++ b/src/composables/useLoad3d.ts
@@ -105,7 +105,7 @@ export const useLoad3d = (nodeOrRef: MaybeRef<LGraphNode | null>) => {
 
   const markDirty = () => {
     const rawNode = toRaw(nodeRef.value)
-    if (rawNode) markLoad3dSceneDirty(rawNode as LGraphNode)
+    if (rawNode) markLoad3dSceneDirty(rawNode)
   }
 
   const debouncedHandleResize = useDebounceFn(() => {
@@ -190,7 +190,7 @@ export const useLoad3d = (nodeOrRef: MaybeRef<LGraphNode | null>) => {
     const rawNode = toRaw(nodeRef.value)
     if (!containerRef || !rawNode) return
 
-    const node = rawNode as LGraphNode
+    const node = rawNode
 
     try {
       const widthWidget = node.widgets?.find((w) => w.name === 'width')
@@ -423,7 +423,7 @@ export const useLoad3d = (nodeOrRef: MaybeRef<LGraphNode | null>) => {
     const rawNode = toRaw(nodeRef.value)
     if (!rawNode) return
 
-    const node = rawNode as LGraphNode
+    const node = rawNode
     const existingInstance = nodeToLoad3dMap.get(node)
 
     if (existingInstance) {
@@ -443,7 +443,7 @@ export const useLoad3d = (nodeOrRef: MaybeRef<LGraphNode | null>) => {
     const rawNode = toRaw(nodeRef.value)
     if (!rawNode) return
 
-    const node = rawNode as LGraphNode
+    const node = rawNode
 
     if (!persistentReadyCallbacks.has(node)) {
       persistentReadyCallbacks.set(node, [])
@@ -718,12 +718,8 @@ export const useLoad3d = (nodeOrRef: MaybeRef<LGraphNode | null>) => {
       let sceneMax = 10
       if (getActivePinia() != null) {
         const settingStore = useSettingStore()
-        sceneMin = settingStore.get(
-          'Comfy.Load3D.LightIntensityMinimum'
-        ) as number
-        sceneMax = settingStore.get(
-          'Comfy.Load3D.LightIntensityMaximum'
-        ) as number
+        sceneMin = settingStore.get('Comfy.Load3D.LightIntensityMinimum')
+        sceneMax = settingStore.get('Comfy.Load3D.LightIntensityMaximum')
       }
       const mappedHdriIntensity = Load3dUtils.mapSceneLightIntensityToHdri(
         lightConfig.value.intensity,
@@ -1001,7 +997,7 @@ export const useLoad3d = (nodeOrRef: MaybeRef<LGraphNode | null>) => {
     cameraChanged: (cameraState: CameraState) => {
       const rawNode = toRaw(nodeRef.value)
       if (rawNode) {
-        const node = rawNode as LGraphNode
+        const node = rawNode
         if (!node.properties) node.properties = {}
         const cameraConfigProp = node.properties['Camera Config']
 
@@ -1079,7 +1075,7 @@ export const useLoad3d = (nodeOrRef: MaybeRef<LGraphNode | null>) => {
     const rawNode = toRaw(nodeRef.value)
     if (!rawNode) return
 
-    const node = rawNode as LGraphNode
+    const node = rawNode
     if (nodeToLoad3dMap.get(node) === load3d) {
       nodeToLoad3dMap.delete(node)
     }

--- a/src/composables/useLoad3dDrag.test.ts
+++ b/src/composables/useLoad3dDrag.test.ts
@@ -24,7 +24,7 @@ function createMockDragEvent(
   const dataTransfer: Partial<DataTransfer> = {
     types,
     files: createMockFileList(files),
-    dropEffect: 'none' as DataTransfer['dropEffect']
+    dropEffect: 'none'
   }
 
   const event: Partial<DragEvent> = {

--- a/src/composables/useLoad3dViewer.test.ts
+++ b/src/composables/useLoad3dViewer.test.ts
@@ -238,7 +238,7 @@ describe('useLoad3dViewer', () => {
         value: ''
       })
       ;(
-        mockNode.properties!['Scene Config'] as Record<string, unknown>
+        mockNode.properties['Scene Config'] as Record<string, unknown>
       ).backgroundImage = 'test-image.jpg'
 
       const viewer = useLoad3dViewer(mockNode)
@@ -379,31 +379,31 @@ describe('useLoad3dViewer', () => {
 
       await viewer.initializeViewer(containerRef, mockSourceLoad3d as Load3d)
       ;(
-        mockNode.properties!['Scene Config'] as Record<string, unknown>
+        mockNode.properties['Scene Config'] as Record<string, unknown>
       ).backgroundColor = '#ff0000'
       ;(
-        mockNode.properties!['Scene Config'] as Record<string, unknown>
+        mockNode.properties['Scene Config'] as Record<string, unknown>
       ).showGrid = false
 
       viewer.restoreInitialState()
 
       expect(
-        (mockNode.properties!['Scene Config'] as Record<string, unknown>)
+        (mockNode.properties['Scene Config'] as Record<string, unknown>)
           .backgroundColor
       ).toBe('#282828')
       expect(
-        (mockNode.properties!['Scene Config'] as Record<string, unknown>)
+        (mockNode.properties['Scene Config'] as Record<string, unknown>)
           .showGrid
       ).toBe(true)
       expect(
-        (mockNode.properties!['Camera Config'] as Record<string, unknown>)
+        (mockNode.properties['Camera Config'] as Record<string, unknown>)
           .cameraType
       ).toBe('perspective')
       expect(
-        (mockNode.properties!['Camera Config'] as Record<string, unknown>).fov
+        (mockNode.properties['Camera Config'] as Record<string, unknown>).fov
       ).toBe(75)
       expect(
-        (mockNode.properties!['Light Config'] as Record<string, unknown>)
+        (mockNode.properties['Light Config'] as Record<string, unknown>)
           .intensity
       ).toBe(1)
     })
@@ -414,13 +414,13 @@ describe('useLoad3dViewer', () => {
 
       await viewer.initializeViewer(containerRef, mockSourceLoad3d as Load3d)
       ;(
-        mockNode.properties!['Model Config'] as Record<string, unknown>
+        mockNode.properties['Model Config'] as Record<string, unknown>
       ).futureField = 'preserve-me'
 
       viewer.restoreInitialState()
 
       expect(
-        (mockNode.properties!['Model Config'] as Record<string, unknown>)
+        (mockNode.properties['Model Config'] as Record<string, unknown>)
           .futureField
       ).toBe('preserve-me')
     })
@@ -440,11 +440,11 @@ describe('useLoad3dViewer', () => {
 
       expect(result).toBe(true)
       expect(
-        (mockNode.properties!['Scene Config'] as Record<string, unknown>)
+        (mockNode.properties['Scene Config'] as Record<string, unknown>)
           .backgroundColor
       ).toBe('#ff0000')
       expect(
-        (mockNode.properties!['Scene Config'] as Record<string, unknown>)
+        (mockNode.properties['Scene Config'] as Record<string, unknown>)
           .showGrid
       ).toBe(false)
       expect(mockLoad3dService.copyLoad3dState).toHaveBeenCalledWith(
@@ -484,13 +484,13 @@ describe('useLoad3dViewer', () => {
 
       await viewer.initializeViewer(containerRef, mockSourceLoad3d as Load3d)
       ;(
-        mockNode.properties!['Model Config'] as Record<string, unknown>
+        mockNode.properties['Model Config'] as Record<string, unknown>
       ).futureField = 'preserve-me'
 
       await viewer.applyChanges()
 
       expect(
-        (mockNode.properties!['Model Config'] as Record<string, unknown>)
+        (mockNode.properties['Model Config'] as Record<string, unknown>)
           .futureField
       ).toBe('preserve-me')
     })
@@ -741,7 +741,7 @@ describe('useLoad3dViewer', () => {
       mockSourceLoad3d.cameraManager = {
         perspectiveCamera: { fov: 75 }
       } as Partial<Load3d['cameraManager']> as Load3d['cameraManager']
-      delete (mockNode.properties!['Camera Config'] as Record<string, unknown>)
+      delete (mockNode.properties['Camera Config'] as Record<string, unknown>)
         .cameraType
 
       const viewer = useLoad3dViewer(mockNode)
@@ -865,7 +865,7 @@ describe('useLoad3dViewer', () => {
 
   describe('gizmo controls', () => {
     it('should initialize gizmo state from node model config', async () => {
-      ;(mockNode.properties!['Model Config'] as Record<string, unknown>).gizmo =
+      ;(mockNode.properties['Model Config'] as Record<string, unknown>).gizmo =
         {
           enabled: true,
           mode: 'rotate'
@@ -901,7 +901,7 @@ describe('useLoad3dViewer', () => {
 
       await viewer.applyChanges()
 
-      const modelConfig = mockNode.properties!['Model Config'] as Record<
+      const modelConfig = mockNode.properties['Model Config'] as Record<
         string,
         unknown
       >
@@ -924,7 +924,7 @@ describe('useLoad3dViewer', () => {
 
       await viewer.applyChanges()
 
-      const modelConfig = mockNode.properties!['Model Config'] as Record<
+      const modelConfig = mockNode.properties['Model Config'] as Record<
         string,
         unknown
       >
@@ -949,7 +949,7 @@ describe('useLoad3dViewer', () => {
 
       viewer.restoreInitialState()
 
-      const modelConfig = mockNode.properties!['Model Config'] as Record<
+      const modelConfig = mockNode.properties['Model Config'] as Record<
         string,
         unknown
       >

--- a/src/composables/usePaste.ts
+++ b/src/composables/usePaste.ts
@@ -222,13 +222,13 @@ export const usePaste = () => {
     // Look for image paste data
     for (const item of items) {
       if (item.type.startsWith('image/')) {
-        await pasteImageNode(canvas as LGraphCanvas, items, imageNode)
+        await pasteImageNode(canvas, items, imageNode)
         return
       } else if (item.type.startsWith('video/')) {
-        await pasteVideoNode(canvas as LGraphCanvas, items, videoNode)
+        await pasteVideoNode(canvas, items, videoNode)
         return
       } else if (item.type.startsWith('audio/')) {
-        await pasteAudioNode(canvas as LGraphCanvas, items, audioNode)
+        await pasteAudioNode(canvas, items, audioNode)
         return
       }
     }

--- a/src/composables/useServerLogs.test.ts
+++ b/src/composables/useServerLogs.test.ts
@@ -80,7 +80,7 @@ describe('useServerLogs', () => {
         type: 'logs',
         entries: [{ m: 'Log message 1' }, { m: 'Log message 2' }]
       })
-    }) as CustomEvent<LogsWsMessage>
+    })
 
     eventCallback(mockEvent)
     await nextTick()
@@ -108,7 +108,7 @@ describe('useServerLogs', () => {
           { m: '' }
         ]
       })
-    }) as CustomEvent<LogsWsMessage>
+    })
 
     eventCallback(mockEvent)
     await nextTick()

--- a/src/composables/useStablePrimeVueSplitterSizer.test.ts
+++ b/src/composables/useStablePrimeVueSplitterSizer.test.ts
@@ -44,9 +44,9 @@ describe('useStablePrimeVueSplitterSizer', () => {
     trigger.value++
     await flushWatcher()
 
-    expect(panelRef.value!.style.flexBasis).toBe('400px')
-    expect(panelRef.value!.style.flexGrow).toBe('0')
-    expect(panelRef.value!.style.flexShrink).toBe('0')
+    expect(panelRef.value.style.flexBasis).toBe('400px')
+    expect(panelRef.value.style.flexGrow).toBe('0')
+    expect(panelRef.value.style.flexShrink).toBe('0')
   })
 
   it('does not apply styles when no stored width exists', async () => {
@@ -59,7 +59,7 @@ describe('useStablePrimeVueSplitterSizer', () => {
     )
     await flushWatcher()
 
-    expect(panelRef.value!.style.flexBasis).toBe('')
+    expect(panelRef.value.style.flexBasis).toBe('')
   })
 
   it('re-applies stored widths when watch sources change', async () => {
@@ -74,16 +74,16 @@ describe('useStablePrimeVueSplitterSizer', () => {
 
     onResizeEnd(resizeEndEvent())
 
-    panelRef.value!.style.flexBasis = ''
-    panelRef.value!.style.flexGrow = ''
-    panelRef.value!.style.flexShrink = ''
+    panelRef.value.style.flexBasis = ''
+    panelRef.value.style.flexGrow = ''
+    panelRef.value.style.flexShrink = ''
 
     trigger.value++
     await flushWatcher()
 
-    expect(panelRef.value!.style.flexBasis).toBe('500px')
-    expect(panelRef.value!.style.flexGrow).toBe('0')
-    expect(panelRef.value!.style.flexShrink).toBe('0')
+    expect(panelRef.value.style.flexBasis).toBe('500px')
+    expect(panelRef.value.style.flexGrow).toBe('0')
+    expect(panelRef.value.style.flexShrink).toBe('0')
   })
 
   it('handles multiple panels independently', async () => {
@@ -105,8 +105,8 @@ describe('useStablePrimeVueSplitterSizer', () => {
     trigger.value++
     await flushWatcher()
 
-    expect(leftRef.value!.style.flexBasis).toBe('300px')
-    expect(rightRef.value!.style.flexBasis).toBe('250px')
+    expect(leftRef.value.style.flexBasis).toBe('300px')
+    expect(rightRef.value.style.flexBasis).toBe('250px')
   })
 
   it('skips panels with null refs', async () => {
@@ -128,6 +128,6 @@ describe('useStablePrimeVueSplitterSizer', () => {
     trigger.value++
     await flushWatcher()
 
-    expect(validRef.value!.style.flexBasis).toBe('200px')
+    expect(validRef.value.style.flexBasis).toBe('200px')
   })
 })

--- a/src/composables/video/useCropBoxEditor.test.ts
+++ b/src/composables/video/useCropBoxEditor.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { effectScope, ref } from 'vue'
-import type { EffectScope, Ref } from 'vue'
+import type { EffectScope } from 'vue'
 
 import type { Bounds } from '@/renderer/core/layout/types'
 
@@ -39,7 +39,7 @@ describe('useCropBoxEditor', () => {
     scope = effectScope()
     const editor = scope.run(() =>
       useCropBoxEditor(bounds, {
-        rootEl: ref(rootEl) as Ref<HTMLElement | null>,
+        rootEl: ref(rootEl),
         sourceWidth: ref(1000),
         sourceHeight: ref(1000),
         isDisabled: () => disabled,
@@ -57,7 +57,7 @@ describe('useCropBoxEditor', () => {
     ) {
       target.addEventListener(
         'pointerdown',
-        (event) => editor.startDrag(mode, event as PointerEvent),
+        (event) => editor.startDrag(mode, event),
         { once: true }
       )
       target.dispatchEvent(

--- a/src/composables/video/useVideoFilmstrip.test.ts
+++ b/src/composables/video/useVideoFilmstrip.test.ts
@@ -112,7 +112,7 @@ function createMockCanvas(context: unknown = { drawImage: vi.fn() }) {
 function installVideoMocks({
   onVideoCreated,
   onCanvasCreated,
-  canvasContext = { drawImage: vi.fn() } as unknown
+  canvasContext = { drawImage: vi.fn() }
 }: {
   onVideoCreated?: (video: MockVideoElement) => void
   onCanvasCreated?: (canvas: HTMLCanvasElement) => void

--- a/src/config/turnstile.test.ts
+++ b/src/config/turnstile.test.ts
@@ -11,7 +11,7 @@ const STAGING_TURNSTILE_SITE_KEY = '0x4AAAAAADnYY4_Q0qxHZ5a7'
 // reference them without a temporal-dead-zone crash (which surfaces under
 // coverage instrumentation, not a plain run).
 const { mockRemoteConfig } = vi.hoisted(() => ({
-  mockRemoteConfig: { value: {} as Record<string, unknown> }
+  mockRemoteConfig: { value: {} }
 }))
 vi.mock('@/platform/remoteConfig/remoteConfig', () => ({
   remoteConfig: mockRemoteConfig,

--- a/src/core/graph/graphMutations.ts
+++ b/src/core/graph/graphMutations.ts
@@ -241,7 +241,7 @@ function prepareNode(
     flags: cloneRecord(payload.flags),
     inputs: prepareInputSlots(payload.inputs),
     outputs: prepareOutputSlots(payload.outputs),
-    mode: (Number.isInteger(mode) ? mode : 0) as NodeState['mode'],
+    mode: Number.isInteger(mode) ? mode : 0,
     properties: cloneRecord(payload.properties) as NodeState['properties'],
     lastSerialization: structuredClone(payload) as unknown as ISerialisedNode,
     ...(typeof payload.bgcolor === 'string' && { bgcolor: payload.bgcolor }),
@@ -251,7 +251,7 @@ function prepareNode(
       resizable: payload.resizable
     }),
     ...(typeof payload.shape === 'number' && {
-      shape: payload.shape as NodeState['shape']
+      shape: payload.shape
     }),
     ...(typeof payload.showAdvanced === 'boolean' && {
       showAdvanced: payload.showAdvanced

--- a/src/core/graph/subgraph/migration/proxyWidgetMigration.test.ts
+++ b/src/core/graph/subgraph/migration/proxyWidgetMigration.test.ts
@@ -61,9 +61,7 @@ function getPromotedInputValue(
 ): TWidgetValue | undefined {
   const input = host.inputs.find((input) => input.name === name)
   if (!input?.widgetId) return undefined
-  return useWidgetValueStore().getWidget(input.widgetId)?.value as
-    | TWidgetValue
-    | undefined
+  return useWidgetValueStore().getWidget(input.widgetId)?.value
 }
 
 function addPrimitiveWithTargets(

--- a/src/core/graph/subgraph/migration/proxyWidgetMigration.ts
+++ b/src/core/graph/subgraph/migration/proxyWidgetMigration.ts
@@ -678,7 +678,7 @@ function repairPrimitive(
     } else {
       const primitiveValue = primitiveNode.widgets?.find(
         (w) => w.name === validated.sourceWidgetName
-      )?.value as TWidgetValue | undefined
+      )?.value
       if (primitiveValue !== undefined) {
         applyHostValueToInput(hostInput, {
           ...validated.uniqueEntries[0],

--- a/src/core/graph/widgets/dynamicWidgets.test.ts
+++ b/src/core/graph/widgets/dynamicWidgets.test.ts
@@ -382,7 +382,7 @@ describe('Autogrow', () => {
     const serialized = graph.serialize()
     graph.clear()
     graph.configure(serialized)
-    const newNode = graph.nodes[0]!
+    const newNode = graph.nodes[0]
 
     expect(newNode.inputs.map((i) => i.name)).toStrictEqual([
       '0.a0',

--- a/src/extensions/core/slotDefaults.ts
+++ b/src/extensions/core/slotDefaults.ts
@@ -1,5 +1,6 @@
-import type { ComfyExtension } from '@/types/comfy'
+import type { SlotTypeDefaultNodeOpts } from '@/lib/litegraph/src/LiteGraphGlobal'
 import { LiteGraph } from '@/lib/litegraph/src/litegraph'
+import type { ComfyExtension } from '@/types/comfy'
 
 import { app } from '../../scripts/app'
 import { ComfyWidgets } from '../../scripts/widgets'
@@ -8,8 +9,11 @@ import { ComfyWidgets } from '../../scripts/widgets'
 
 interface SlotDefaultsExtension extends ComfyExtension {
   suggestionsNumber: { value: number } | null
-  slot_types_default_out: Record<string, string[]>
-  slot_types_default_in: Record<string, string[]>
+  slot_types_default_out: Record<
+    string,
+    Array<string | SlotTypeDefaultNodeOpts>
+  >
+  slot_types_default_in: Record<string, Array<string | SlotTypeDefaultNodeOpts>>
   setDefaults(maxNum?: number | null): void
 }
 

--- a/src/i18n.test.ts
+++ b/src/i18n.test.ts
@@ -31,7 +31,7 @@ vi.mock('./locales/en/main.json', () => ({
 }))
 // vue-i18n merges mutate the message tree built from this object, and mocked
 // modules survive vi.resetModules(), so restore it before each test.
-const enNodeDefsMock = vi.hoisted(() => ({}) as Record<string, unknown>)
+const enNodeDefsMock = vi.hoisted<Record<string, unknown>>(() => ({}))
 
 function restoreEnNodeDefsMock() {
   for (const key of Object.keys(enNodeDefsMock)) {

--- a/src/lib/litegraph/src/LGraph.ts
+++ b/src/lib/litegraph/src/LGraph.ts
@@ -1243,7 +1243,7 @@ export class LGraph
       if (typeof method === 'function') {
         const args =
           params == null ? [] : Array.isArray(params) ? params : [params]
-        ;(method as (...args: unknown[]) => unknown).apply(c, args)
+        Reflect.apply(method, c, args)
       }
     }
   }

--- a/src/lib/litegraph/src/LGraphCanvas.cloneZIndex.test.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.cloneZIndex.test.ts
@@ -66,9 +66,7 @@ function createCanvas(graph: LGraph): LGraphCanvas {
     textBaseline: 'alphabetic' as CanvasTextBaseline
   } satisfies Partial<CanvasRenderingContext2D>
 
-  el.getContext = vi
-    .fn()
-    .mockReturnValue(ctx as unknown as CanvasRenderingContext2D)
+  el.getContext = vi.fn().mockReturnValue(ctx)
   el.getBoundingClientRect = vi.fn().mockReturnValue({
     left: 0,
     top: 0,

--- a/src/lib/litegraph/src/LGraphCanvas.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.ts
@@ -384,7 +384,7 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
     type: T,
     detail?: LGraphCanvasEventMap[T]
   ) {
-    const event = new CustomEvent(type as string, { detail, bubbles: true })
+    const event = new CustomEvent(type, { detail, bubbles: true })
     return this.canvas.dispatchEvent(event)
   }
 
@@ -932,22 +932,19 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
 
           if ('shiftKey' in e && e.shiftKey) {
             if (this.allow_searchbox) {
-              this.showSearchBox(
-                e as MouseEvent,
-                linkReleaseContext as IShowSearchOptions
-              )
+              this.showSearchBox(e, linkReleaseContext as IShowSearchOptions)
             }
           } else if (this.linkConnector.state.connectingTo === 'input') {
             this.showConnectionMenu({
               nodeFrom: firstLink.node as LGraphNode,
-              slotFrom: firstLink.fromSlot as INodeOutputSlot,
+              slotFrom: firstLink.fromSlot,
               e,
               afterRerouteId
             })
           } else {
             this.showConnectionMenu({
               nodeTo: firstLink.node as LGraphNode,
-              slotTo: firstLink.fromSlot as INodeInputSlot,
+              slotTo: firstLink.fromSlot,
               e,
               afterRerouteId
             })
@@ -3736,7 +3733,7 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
 
     if (dragEvent) {
       this.adjustMouseEvent(dragEvent)
-      const e = dragEvent as CanvasPointerEvent
+      const e = dragEvent
       node.setPos(e.canvasX - node.size[0] / 2, e.canvasY + 10)
       // Update last_mouse to prevent jump on first drag move
       this.last_mouse = [e.clientX, e.clientY]
@@ -5858,9 +5855,7 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
     if (!node.collapsed) {
       node.arrange()
       node.drawSlots(ctx, {
-        fromSlot: this.linkConnector.renderLinks[0]?.fromSlot as
-          | INodeOutputSlot
-          | INodeInputSlot,
+        fromSlot: this.linkConnector.renderLinks[0]?.fromSlot,
         colorContext: this.colourGetter,
         editorAlpha: this.editor_alpha,
         lowQuality: this.low_quality
@@ -6945,14 +6940,15 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
       ? LiteGraph.slot_types_default_out
       : LiteGraph.slot_types_default_in
     if (slotTypesDefault?.[fromSlotType]) {
-      let nodeNewType: string | Record<string, unknown> | false = false
+      const defaultNode = (value: string | SlotTypeDefaultNodeOpts) => value
+      let nodeNewType: string | SlotTypeDefaultNodeOpts | false = false
       if (typeof slotTypesDefault[fromSlotType] == 'object') {
         for (const typeX in slotTypesDefault[fromSlotType]) {
           if (
             opts.nodeType == slotTypesDefault[fromSlotType][typeX] ||
             opts.nodeType == 'AUTO'
           ) {
-            nodeNewType = slotTypesDefault[fromSlotType][typeX]
+            nodeNewType = defaultNode(slotTypesDefault[fromSlotType][typeX])
             break
           }
         }
@@ -6960,13 +6956,13 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
         opts.nodeType == slotTypesDefault[fromSlotType] ||
         opts.nodeType == 'AUTO'
       ) {
-        nodeNewType = slotTypesDefault[fromSlotType]
+        nodeNewType = defaultNode(slotTypesDefault[fromSlotType])
       }
       if (nodeNewType) {
         let nodeNewOpts: SlotTypeDefaultNodeOpts | undefined
         let nodeTypeStr: string
         if (typeof nodeNewType == 'object') {
-          nodeNewOpts = nodeNewType as SlotTypeDefaultNodeOpts
+          nodeNewOpts = nodeNewType
           nodeTypeStr = nodeNewOpts.node ?? ''
         } else {
           nodeTypeStr = nodeNewType
@@ -8329,7 +8325,7 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
       if (type == 'number' && typeof value === 'number')
         str_value = value.toFixed(3)
 
-      const elem: PanelWidget = document.createElement('div') as PanelWidget
+      const elem: PanelWidget = document.createElement('div')
       elem.className = 'property'
       elem.innerHTML =
         "<span class='property_name'></span><span class='property_value'></span>"

--- a/src/lib/litegraph/src/LGraphCanvas.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.ts
@@ -30,6 +30,7 @@ import type { AnimationOptions } from './DragAndScale'
 import { mintNodeId, observeNodeId } from './idAllocation'
 import type { LGraph, SubgraphId } from './LGraph'
 import { LGraphGroup } from './LGraphGroup'
+import type { SlotTypeDefaultNodeOpts } from './LiteGraphGlobal'
 import { LGraphNode } from './LGraphNode'
 import type { NodeProperty } from './LGraphNode'
 import { detachSerialisedLinks } from './linkDeduplication'
@@ -269,15 +270,6 @@ interface ICreatePanelOptions {
   onClose?: () => void
   width?: number | string
   height?: number | string
-}
-
-interface SlotTypeDefaultNodeOpts {
-  node?: string
-  title?: string
-  properties?: Record<string, NodeProperty>
-  inputs?: [string, string][]
-  outputs?: [string, string][]
-  json?: Parameters<LGraphNode['configure']>[0]
 }
 
 const cursors = {
@@ -3733,10 +3725,9 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
 
     if (dragEvent) {
       this.adjustMouseEvent(dragEvent)
-      const e = dragEvent
-      node.setPos(e.canvasX - node.size[0] / 2, e.canvasY + 10)
+      node.setPos(dragEvent.canvasX - node.size[0] / 2, dragEvent.canvasY + 10)
       // Update last_mouse to prevent jump on first drag move
-      this.last_mouse = [e.clientX, e.clientY]
+      this.last_mouse = [dragEvent.clientX, dragEvent.clientY]
     } else {
       node.setPos(
         this.graph_mouse[0] - node.size[0] / 2,
@@ -6939,24 +6930,30 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
     const slotTypesDefault = isFrom
       ? LiteGraph.slot_types_default_out
       : LiteGraph.slot_types_default_in
-    if (slotTypesDefault?.[fromSlotType]) {
-      const defaultNode = (value: string | SlotTypeDefaultNodeOpts) => value
+    const slotDefaults = slotTypesDefault?.[fromSlotType]
+    if (slotDefaults) {
       let nodeNewType: string | SlotTypeDefaultNodeOpts | false = false
-      if (typeof slotTypesDefault[fromSlotType] == 'object') {
-        for (const typeX in slotTypesDefault[fromSlotType]) {
+      if (Array.isArray(slotDefaults)) {
+        for (const slotDefault of slotDefaults) {
           if (
-            opts.nodeType == slotTypesDefault[fromSlotType][typeX] ||
+            opts.nodeType ==
+              (typeof slotDefault === 'string'
+                ? slotDefault
+                : slotDefault.node) ||
             opts.nodeType == 'AUTO'
           ) {
-            nodeNewType = defaultNode(slotTypesDefault[fromSlotType][typeX])
+            nodeNewType = slotDefault
             break
           }
         }
       } else if (
-        opts.nodeType == slotTypesDefault[fromSlotType] ||
+        opts.nodeType ==
+          (typeof slotDefaults === 'string'
+            ? slotDefaults
+            : slotDefaults.node) ||
         opts.nodeType == 'AUTO'
       ) {
-        nodeNewType = defaultNode(slotTypesDefault[fromSlotType])
+        nodeNewType = slotDefaults
       }
       if (nodeNewType) {
         let nodeNewOpts: SlotTypeDefaultNodeOpts | undefined
@@ -7142,13 +7139,15 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
     const slotTypesDefault = isFrom
       ? LiteGraph.slot_types_default_out
       : LiteGraph.slot_types_default_in
-    if (slotTypesDefault?.[fromSlotType]) {
-      if (typeof slotTypesDefault[fromSlotType] == 'object') {
-        for (const typeX in slotTypesDefault[fromSlotType]) {
-          options.push(slotTypesDefault[fromSlotType][typeX])
-        }
-      } else {
-        options.push(slotTypesDefault[fromSlotType])
+    const slotDefaults = slotTypesDefault?.[fromSlotType]
+    if (slotDefaults) {
+      const defaults = Array.isArray(slotDefaults)
+        ? slotDefaults
+        : [slotDefaults]
+      for (const slotDefault of defaults) {
+        const nodeType =
+          typeof slotDefault === 'string' ? slotDefault : slotDefault.node
+        if (nodeType) options.push(nodeType)
       }
     }
 

--- a/src/lib/litegraph/src/LGraphNode.ts
+++ b/src/lib/litegraph/src/LGraphNode.ts
@@ -3286,8 +3286,8 @@ export class LGraphNode
     if (!graph) throw new NullGraphError()
 
     // Assertion: It's either there or it isn't.
-    const inputIndex = this.inputs.indexOf(slot as INodeInputSlot)
-    const outputIndex = this.outputs.indexOf(slot as INodeOutputSlot)
+    const inputIndex = this.inputs.indexOf(slot)
+    const outputIndex = this.outputs.indexOf(slot)
     if (inputIndex === -1 && outputIndex === -1) {
       console.error('Invalid slot')
       return

--- a/src/lib/litegraph/src/LGraphNode.widgetLabelRename.regression.test.ts
+++ b/src/lib/litegraph/src/LGraphNode.widgetLabelRename.regression.test.ts
@@ -85,7 +85,7 @@ describe('renameWidget label persistence via input lookup (regression #13861)', 
     const graph = new LGraph()
     const node = addClipNode(graph)
     const widget = node.widgets![0]
-    const input = node.inputs![0]
+    const input = node.inputs[0]
 
     // Preconditions that reproduced the bug: the in-graph widget has a truthy
     // widgetId, but the normal-node input carries none.
@@ -137,7 +137,7 @@ describe('renameWidget label persistence via input lookup (regression #13861)', 
     const kept = addClipNode(graph)
     renameWidget(kept.widgets![0], kept, 'Negative Prompt')
 
-    expect(cleared.inputs![0].label).toBeUndefined()
+    expect(cleared.inputs[0].label).toBeUndefined()
 
     const restored = reloadSerializedGraph(
       graph.serialize(),

--- a/src/lib/litegraph/src/LiteGraphGlobal.ts
+++ b/src/lib/litegraph/src/LiteGraphGlobal.ts
@@ -5,6 +5,7 @@ import { LGraph } from './LGraph'
 import { LGraphCanvas } from './LGraphCanvas'
 import { LGraphGroup } from './LGraphGroup'
 import { LGraphNode } from './LGraphNode'
+import type { NodeProperty } from './LGraphNode'
 import { LLink } from './LLink'
 import { Reroute } from './Reroute'
 import { InputIndicators } from './canvas/InputIndicators'
@@ -29,6 +30,18 @@ import {
   TitleMode
 } from './types/globalEnums'
 import { createUuidv4 } from '@/utils/uuid'
+
+export interface SlotTypeDefaultNodeOpts {
+  node?: string
+  title?: string
+  properties?: Record<string, NodeProperty>
+  inputs?: [string, string][]
+  outputs?: [string, string][]
+  json?: Parameters<LGraphNode['configure']>[0]
+}
+
+type SlotTypeDefaultNode = string | SlotTypeDefaultNodeOpts
+type SlotTypeDefault = SlotTypeDefaultNode | SlotTypeDefaultNode[]
 
 /**
  * The Global Scope. It contains all the registered node classes.
@@ -232,12 +245,12 @@ export class LiteGraphGlobal {
    * specify for each IN slot type a(/many) default node(s), use single string, array, or object
    * (with node, title, parameters, ..) like for search
    */
-  slot_types_default_in: Record<string, string[]> = {}
+  slot_types_default_in: Record<string, SlotTypeDefault> = {}
   /**
    * specify for each OUT slot type a(/many) default node(s), use single string, array, or object
    * (with node, title, parameters, ..) like for search
    */
-  slot_types_default_out: Record<string, string[]> = {}
+  slot_types_default_out: Record<string, SlotTypeDefault> = {}
 
   /** [true!] very handy, ALT click to clone and drag the new node */
   alt_drag_do_clone_nodes = false

--- a/src/lib/litegraph/src/canvas/LinkConnector.integration.test.ts
+++ b/src/lib/litegraph/src/canvas/LinkConnector.integration.test.ts
@@ -159,7 +159,7 @@ const test = baseTest.extend<TestContext>({
 
       for (const link of graph.links.values()) {
         expect(
-          graph.getNodeById(link!.origin_id)?.outputs[link!.origin_slot].links
+          graph.getNodeById(link.origin_id)?.outputs[link.origin_slot].links
         ).toContain(link.id)
         expect(
           linkStore.getInputSlotLink(graphId, link.target_id, link.target_slot)

--- a/src/lib/litegraph/src/canvas/LinkConnector.ts
+++ b/src/lib/litegraph/src/canvas/LinkConnector.ts
@@ -1038,7 +1038,7 @@ export class LinkConnector {
             link.outputSlot,
             link.inputNode,
             link.inputSlot,
-            undefined!
+            undefined
           )
         }
         continue

--- a/src/lib/litegraph/src/contextMenuCompat.test.ts
+++ b/src/lib/litegraph/src/contextMenuCompat.test.ts
@@ -18,7 +18,7 @@ describe('contextMenuCompat', () => {
       constructor: {
         prototype: LGraphCanvas.prototype
       } as typeof LGraphCanvas
-    } as Partial<LGraphCanvas>)
+    })
 
     // Clear console warnings
     vi.spyOn(console, 'warn').mockImplementation(() => {})

--- a/src/lib/litegraph/src/contextMenuCompat.ts
+++ b/src/lib/litegraph/src/contextMenuCompat.ts
@@ -46,15 +46,15 @@ class LegacyMenuCompat {
     prototype?: LGraphCanvas
   ) {
     this.wrapperMethods.set(
-      methodName as string,
+      methodName,
       wrapperFn as unknown as ContextMenuValueProvider
     )
     this.preWrapperMethods.set(
-      methodName as string,
+      methodName,
       preWrapperFn as unknown as ContextMenuValueProvider
     )
     const isInstalled = prototype && prototype[methodName] === wrapperFn
-    this.wrapperInstalled.set(methodName as string, !!isInstalled)
+    this.wrapperInstalled.set(methodName, !!isInstalled)
   }
 
   /**
@@ -70,7 +70,7 @@ class LegacyMenuCompat {
 
     const originalMethod = prototype[methodName]
     this.originalMethods.set(
-      methodName as string,
+      methodName,
       originalMethod as unknown as ContextMenuValueProvider
     )
 

--- a/src/lib/litegraph/src/infrastructure/CustomEventTarget.ts
+++ b/src/lib/litegraph/src/infrastructure/CustomEventTarget.ts
@@ -110,7 +110,7 @@ export class CustomEventTarget<
     options?: boolean | AddEventListenerOptions
   ): void {
     // Assertion: Contravariance on CustomEvent => Event
-    super.addEventListener(type as string, listener as EventListener, options)
+    super.addEventListener(type, listener as EventListener, options)
   }
 
   override removeEventListener<K extends Keys>(
@@ -119,11 +119,7 @@ export class CustomEventTarget<
     options?: boolean | EventListenerOptions
   ): void {
     // Assertion: Contravariance on CustomEvent => Event
-    super.removeEventListener(
-      type as string,
-      listener as EventListener,
-      options
-    )
+    super.removeEventListener(type, listener as EventListener, options)
   }
 
   /** @deprecated Use {@link dispatch}. */

--- a/src/lib/litegraph/src/infrastructure/Rectangle.test.ts
+++ b/src/lib/litegraph/src/infrastructure/Rectangle.test.ts
@@ -363,7 +363,7 @@ describe('Rectangle', () => {
 
         let testExpected = expectedOrOuter as boolean
         if (typeof expectedOrOuter !== 'boolean') {
-          testOuter = expectedOrOuter as Rectangle
+          testOuter = expectedOrOuter
           testExpected = expectedIfThreeArgs as boolean
         }
         expect(testOuter.containsRect(inner)).toBe(testExpected)

--- a/src/lib/litegraph/src/infrastructure/Rectangle.ts
+++ b/src/lib/litegraph/src/infrastructure/Rectangle.ts
@@ -79,7 +79,7 @@ export class Rectangle extends Float64Array {
    */
   get pos(): Point {
     this._pos ??= this.subarray(0, 2)
-    return this._pos! as unknown as Point
+    return this._pos as unknown as Point
   }
 
   set pos(value: Readonly<Point>) {
@@ -94,7 +94,7 @@ export class Rectangle extends Float64Array {
    */
   get size(): Size {
     this._size ??= this.subarray(2, 4)
-    return this._size! as unknown as Size
+    return this._size as unknown as Size
   }
 
   set size(value: Readonly<Size>) {

--- a/src/lib/litegraph/src/node/NodeSlot.test.ts
+++ b/src/lib/litegraph/src/node/NodeSlot.test.ts
@@ -3,8 +3,7 @@ import { computed, nextTick, toRaw, watch } from 'vue'
 
 import type {
   INodeInputSlot,
-  INodeOutputSlot,
-  IWidget
+  INodeOutputSlot
 } from '@/lib/litegraph/src/litegraph'
 import {
   LGraphNode,
@@ -27,11 +26,7 @@ describe('NodeSlot', () => {
         boundingRect
       }
       const node = new LGraphNode('test')
-      const serialized = outputAsSerialisable(
-        slot as INodeOutputSlot & { widget?: IWidget },
-        node,
-        0
-      )
+      const serialized = outputAsSerialisable(slot, node, 0)
       expect(serialized).not.toHaveProperty('_data')
     })
 

--- a/src/lib/litegraph/src/node/legacySlotLinkMutations.test.ts
+++ b/src/lib/litegraph/src/node/legacySlotLinkMutations.test.ts
@@ -127,7 +127,7 @@ describe('legacy slot link additions', () => {
     const [id] = output.links!
 
     output.links = []
-    output.links!.push(id)
+    output.links.push(id)
 
     expect(source.isOutputConnected(0)).toBe(false)
     expect(target.isInputConnected(0)).toBe(false)

--- a/src/lib/litegraph/src/node/slotUtils.test.ts
+++ b/src/lib/litegraph/src/node/slotUtils.test.ts
@@ -36,11 +36,7 @@ describe('outputAsSerialisable', () => {
   it('serialises the links leaving the slot, ascending by id', () => {
     const { source } = createConnectedGraph([10, 2])
 
-    const serialised = outputAsSerialisable(
-      source.outputs[0] as OutputSlotParam,
-      source,
-      0
-    )
+    const serialised = outputAsSerialisable(source.outputs[0], source, 0)
 
     expect(serialised.links).toEqual(
       [...serialised.links!].sort((a, b) => a - b)
@@ -51,11 +47,7 @@ describe('outputAsSerialisable', () => {
   it('returns a snapshot unaffected by later graph changes', () => {
     const { source } = createConnectedGraph([1, 2])
 
-    const serialised = outputAsSerialisable(
-      source.outputs[0] as OutputSlotParam,
-      source,
-      0
-    )
+    const serialised = outputAsSerialisable(source.outputs[0], source, 0)
     expect(serialised.links).toHaveLength(2)
 
     source.disconnectOutput(0)
@@ -65,11 +57,7 @@ describe('outputAsSerialisable', () => {
   it('serialises null when the slot has no links', () => {
     const { source } = createConnectedGraph([])
 
-    const serialised = outputAsSerialisable(
-      source.outputs[0] as OutputSlotParam,
-      source,
-      0
-    )
+    const serialised = outputAsSerialisable(source.outputs[0], source, 0)
     expect(serialised.links).toBeNull()
   })
 
@@ -90,11 +78,7 @@ describe('outputAsSerialisable', () => {
     const { source, targets } = createConnectedGraph([1])
     source.disconnectOutput(0, targets[0])
 
-    const serialised = outputAsSerialisable(
-      source.outputs[0] as OutputSlotParam,
-      source,
-      0
-    )
+    const serialised = outputAsSerialisable(source.outputs[0], source, 0)
 
     expect(serialised.links).toEqual([])
   })
@@ -107,11 +91,7 @@ describe('outputAsSerialisable', () => {
 
     expect(source.disconnectOutput(0, unrelated)).toBe(false)
 
-    const serialised = outputAsSerialisable(
-      source.outputs[0] as OutputSlotParam,
-      source,
-      0
-    )
+    const serialised = outputAsSerialisable(source.outputs[0], source, 0)
     expect(serialised.links).toEqual([1])
     expect(targets[0].inputs[0].link).toBe(toLinkId(1))
   })
@@ -120,11 +100,7 @@ describe('outputAsSerialisable', () => {
     const node = new LGraphNode('Detached')
     node.addOutput('out', 'number')
 
-    const serialised = outputAsSerialisable(
-      node.outputs[0] as OutputSlotParam,
-      node,
-      0
-    )
+    const serialised = outputAsSerialisable(node.outputs[0], node, 0)
     expect(serialised.links).toBeNull()
   })
 

--- a/src/lib/litegraph/src/node/widgetsView.test.ts
+++ b/src/lib/litegraph/src/node/widgetsView.test.ts
@@ -156,9 +156,9 @@ describe('widgets view', () => {
     }
 
     node.widgets ||= []
-    node.widgets!.push(widget)
+    node.widgets.push(widget)
 
-    expect(node.widgets![0]).toBe(widget)
+    expect(node.widgets[0]).toBe(widget)
     expect(widget).toBeInstanceOf(LegacyWidget)
     expect(storedOrder(node)).toEqual(['custom'])
     expect(storedValue(widget)).toBe(10)

--- a/src/lib/litegraph/src/subgraph/SubgraphNode.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphNode.ts
@@ -73,7 +73,7 @@ export class SubgraphNode extends LGraphNode implements BaseLGraph {
   }
 
   override get type(): SubgraphId {
-    return super.type as SubgraphId
+    return super.type
   }
 
   override set type(value: string) {

--- a/src/lib/litegraph/src/subgraph/SubgraphSlotConnections.test.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphSlotConnections.test.ts
@@ -9,7 +9,6 @@ import {
   isSubgraphOutput
 } from '@/lib/litegraph/src/litegraph'
 import type {
-  LinkNetwork,
   NodeInputSlot,
   NodeOutputSlot
 } from '@/lib/litegraph/src/litegraph'
@@ -192,11 +191,7 @@ describe('Subgraph slot connections', () => {
       const connector = new LinkConnector(setConnectingLinks)
 
       // Now try to drag from the input slot
-      connector.moveInputLink(
-        subgraph as LinkNetwork,
-        internalNode,
-        internalNode.inputs[0]
-      )
+      connector.moveInputLink(subgraph, internalNode, internalNode.inputs[0])
 
       // Verify that we're dragging the existing link
       expect(connector.isConnecting).toBe(true)

--- a/src/lib/litegraph/src/subgraph/__fixtures__/subgraphHelpers.ts
+++ b/src/lib/litegraph/src/subgraph/__fixtures__/subgraphHelpers.ts
@@ -405,12 +405,8 @@ export function setupComplexPromotionFixture(): {
     throw new Error('Expected fixture to contain subgraph instance node id 21')
 
   const graph = createTestRootGraph()
-  const subgraph = graph.createSubgraph(subgraphData as ExportedSubgraph)
-  const hostNode = new SubgraphNode(
-    graph,
-    subgraph,
-    hostNodeData as ExportedSubgraphInstance
-  )
+  const subgraph = graph.createSubgraph(subgraphData)
+  const hostNode = new SubgraphNode(graph, subgraph, hostNodeData)
   graph.add(hostNode)
 
   return {

--- a/src/lib/litegraph/src/subgraph/subgraphDeduplication.test.ts
+++ b/src/lib/litegraph/src/subgraph/subgraphDeduplication.test.ts
@@ -46,7 +46,7 @@ function makeSubgraph(id: string, nodeTypes: string[] = []): ExportedSubgraph {
     })),
     inputNode: { id: SUBGRAPH_INPUT_ID, bounding: [0, 0, 100, 100] },
     outputNode: { id: SUBGRAPH_OUTPUT_ID, bounding: [0, 0, 100, 100] }
-  } as ExportedSubgraph
+  }
 }
 
 describe('topologicalSortSubgraphs', () => {

--- a/src/lib/litegraph/src/utils/mathParser.test.ts
+++ b/src/lib/litegraph/src/utils/mathParser.test.ts
@@ -79,7 +79,7 @@ describe('evaluateMathExpression', () => {
       1
     ]
   ])('complex expression: %s', ([input, expected]) => {
-    expect(evaluateMathExpression(input)).toBeCloseTo(expected as number)
+    expect(evaluateMathExpression(input)).toBeCloseTo(expected)
   })
 
   test.for(['', 'abc', '2+', '(2+3', '2+3)', '()', '*3', '2 3', '.', '123..'])(

--- a/src/lib/litegraph/src/widgets/BoundingBoxesWidget.test.ts
+++ b/src/lib/litegraph/src/widgets/BoundingBoxesWidget.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 
 import { LGraphNode } from '@/lib/litegraph/src/litegraph'
-import type { DrawWidgetOptions } from '@/lib/litegraph/src/widgets/BaseWidget'
 
 import { BoundingBoxesWidget } from './BoundingBoxesWidget'
 
@@ -35,7 +34,7 @@ describe('BoundingBoxesWidget', () => {
     )
     expect(widget.type).toBe('boundingboxes')
     const ctx = fakeCtx()
-    widget.drawWidget(ctx, { width: 200 } as DrawWidgetOptions)
+    widget.drawWidget(ctx, { width: 200 })
     expect(ctx.fillText).toHaveBeenCalled()
     expect(() => widget.onClick({} as never)).not.toThrow()
   })

--- a/src/lib/litegraph/src/widgets/ColorsWidget.test.ts
+++ b/src/lib/litegraph/src/widgets/ColorsWidget.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 
 import { LGraphNode } from '@/lib/litegraph/src/litegraph'
-import type { DrawWidgetOptions } from '@/lib/litegraph/src/widgets/BaseWidget'
 
 import { ColorsWidget } from './ColorsWidget'
 
@@ -29,7 +28,7 @@ describe('ColorsWidget', () => {
     )
     expect(widget.type).toBe('colors')
     const ctx = fakeCtx()
-    widget.drawWidget(ctx, { width: 200 } as DrawWidgetOptions)
+    widget.drawWidget(ctx, { width: 200 })
     expect(ctx.fillText).toHaveBeenCalled()
     expect(() => widget.onClick({} as never)).not.toThrow()
   })

--- a/src/platform/assets/components/AssetFilterBar.test.ts
+++ b/src/platform/assets/components/AssetFilterBar.test.ts
@@ -116,10 +116,10 @@ describe('AssetFilterBar', () => {
       ) as HTMLSelectElement
       const fileFormatOptions = fileFormatEl.querySelectorAll('option')
       const ckptOption = Array.from(fileFormatOptions).find(
-        (o) => (o as HTMLOptionElement).value === 'ckpt'
+        (o) => o.value === 'ckpt'
       ) as HTMLOptionElement
       const safetensorsOption = Array.from(fileFormatOptions).find(
-        (o) => (o as HTMLOptionElement).value === 'safetensors'
+        (o) => o.value === 'safetensors'
       ) as HTMLOptionElement
       ckptOption.selected = true
       safetensorsOption.selected = true
@@ -134,7 +134,7 @@ describe('AssetFilterBar', () => {
       ) as HTMLSelectElement
       const baseModelOptions = baseModelEl.querySelectorAll('option')
       const sdxlOption = Array.from(baseModelOptions).find(
-        (o) => (o as HTMLOptionElement).value === 'sdxl'
+        (o) => o.value === 'sdxl'
       ) as HTMLOptionElement
       sdxlOption.selected = true
       await fireEvent.change(baseModelSelectEl)
@@ -215,7 +215,7 @@ describe('AssetFilterBar', () => {
       expect(
         Array.from(options).map((o) => ({
           name: o.textContent?.trim(),
-          value: (o as HTMLOptionElement).value
+          value: o.value
         }))
       ).toEqual([
         { name: '.ckpt', value: 'ckpt' },
@@ -238,7 +238,7 @@ describe('AssetFilterBar', () => {
       expect(
         Array.from(options).map((o) => ({
           name: o.textContent?.trim(),
-          value: (o as HTMLOptionElement).value
+          value: o.value
         }))
       ).toEqual([
         { name: 'sd15', value: 'sd15' },

--- a/src/platform/assets/services/assetService.test.ts
+++ b/src/platform/assets/services/assetService.test.ts
@@ -426,7 +426,7 @@ describe(assetService.getAssetModels, () => {
     await assetService.getAssetModels('checkpoints')
 
     expect(fetchApiMock).toHaveBeenCalledTimes(1)
-    const requestedUrl = fetchApiMock.mock.calls[0]?.[0] as string
+    const requestedUrl = fetchApiMock.mock.calls[0]?.[0]
     const params = new URL(requestedUrl, 'http://localhost').searchParams
     expect(params.get('include_tags')).toBe('models')
     expect(params.get('exclude_tags')).toBe(MISSING_TAG)
@@ -762,7 +762,7 @@ describe(assetService.onModelsScanned, () => {
     const unsubscribe = assetService.onModelsScanned(callback)
 
     const [eventType, handler] = vi.mocked(api.addCustomEventListener).mock
-      .calls[0]!
+      .calls[0]
     expect(eventType).toBe('assets.seed.fast_complete')
 
     handler!(new CustomEvent(eventType))
@@ -852,7 +852,7 @@ describe(assetService.getAssetsByTag, () => {
 
     expect(assets.map((a) => a.id)).toEqual(['visible'])
 
-    const requestedUrl = fetchApiMock.mock.calls[0]?.[0] as string
+    const requestedUrl = fetchApiMock.mock.calls[0]?.[0]
     const params = new URL(requestedUrl, 'http://localhost').searchParams
     expect(params.get('include_public')).toBe('true')
     expect(params.get('exclude_tags')).toBe(MISSING_TAG)
@@ -865,7 +865,7 @@ describe(assetService.getAssetsByTag, () => {
 
     await assetService.getAssetsByTag(' input ')
 
-    const requestedUrl = fetchApiMock.mock.calls[0]?.[0] as string
+    const requestedUrl = fetchApiMock.mock.calls[0]?.[0]
     const params = new URL(requestedUrl, 'http://localhost').searchParams
     expect(params.get('include_tags')).toBe('input')
     expect(params.get('exclude_tags')).toBe(MISSING_TAG)
@@ -894,7 +894,7 @@ describe(assetService.getAllAssetsByTag, () => {
 
     expect(assets.map((a) => a.id)).toEqual(['a', 'b', 'c'])
 
-    const firstUrl = fetchApiMock.mock.calls[0]?.[0] as string
+    const firstUrl = fetchApiMock.mock.calls[0]?.[0]
     const firstParams = new URL(firstUrl, 'http://localhost').searchParams
     expect(firstParams.get('include_public')).toBe('true')
     expect(firstParams.get('exclude_tags')).toBe(MISSING_TAG)
@@ -903,7 +903,7 @@ describe(assetService.getAllAssetsByTag, () => {
     expect(firstParams.has('after')).toBe(false)
     expect(firstParams.has('offset')).toBe(false)
 
-    const secondUrl = fetchApiMock.mock.calls[1]?.[0] as string
+    const secondUrl = fetchApiMock.mock.calls[1]?.[0]
     const secondParams = new URL(secondUrl, 'http://localhost').searchParams
     expect(secondParams.get('include_public')).toBe('true')
     expect(secondParams.get('exclude_tags')).toBe(MISSING_TAG)
@@ -1102,7 +1102,7 @@ describe(assetService.getAssetsPageForNodeType, () => {
     expect(page.has_more).toBe(true)
     expect(page.next_cursor).toBe('cursor-1')
 
-    const requestedUrl = fetchApiMock.mock.calls[0]?.[0] as string
+    const requestedUrl = fetchApiMock.mock.calls[0]?.[0]
     const params = new URL(requestedUrl, 'http://localhost').searchParams
     expect(params.get('include_tags')).toBe('models,checkpoints')
     expect(params.get('exclude_tags')).toBe(MISSING_TAG)
@@ -1121,7 +1121,7 @@ describe(assetService.getAssetsPageForNodeType, () => {
       after: 'cursor-2'
     })
 
-    const requestedUrl = fetchApiMock.mock.calls[0]?.[0] as string
+    const requestedUrl = fetchApiMock.mock.calls[0]?.[0]
     const params = new URL(requestedUrl, 'http://localhost').searchParams
     expect(params.get('after')).toBe('cursor-2')
     expect(params.has('offset')).toBe(false)
@@ -1137,7 +1137,7 @@ describe(assetService.getAssetsPageForNodeType, () => {
       after: ''
     })
 
-    const requestedUrl = fetchApiMock.mock.calls[0]?.[0] as string
+    const requestedUrl = fetchApiMock.mock.calls[0]?.[0]
     const params = new URL(requestedUrl, 'http://localhost').searchParams
     expect(params.get('after')).toBe('')
     expect(params.has('offset')).toBe(false)
@@ -1152,7 +1152,7 @@ describe(assetService.getAssetsPageForNodeType, () => {
       offset: 500
     })
 
-    const requestedUrl = fetchApiMock.mock.calls[0]?.[0] as string
+    const requestedUrl = fetchApiMock.mock.calls[0]?.[0]
     const params = new URL(requestedUrl, 'http://localhost').searchParams
     expect(params.get('offset')).toBe('500')
     expect(params.has('after')).toBe(false)

--- a/src/platform/assets/utils/clearNodePreviewCacheForValues.test.ts
+++ b/src/platform/assets/utils/clearNodePreviewCacheForValues.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 
-import type { LGraph, LGraphNode } from '@/lib/litegraph/src/litegraph'
+import type { LGraph } from '@/lib/litegraph/src/litegraph'
 
 import {
   clearNodePreviewCacheForValues,
@@ -36,7 +36,7 @@ describe('FE-230 clearNodePreviewCacheForValues', () => {
     clearNodePreviewCacheForValues(
       makeGraph([node]),
       new Set(['foo.png']),
-      remove as unknown as (node: LGraphNode) => void
+      remove
     )
 
     expect(node.imgs).toBeUndefined()
@@ -57,7 +57,7 @@ describe('FE-230 clearNodePreviewCacheForValues', () => {
     clearNodePreviewCacheForValues(
       makeGraph([node]),
       new Set(['foo.png']),
-      remove as unknown as (node: LGraphNode) => void
+      remove
     )
 
     expect(node.imgs).toEqual([{ src: 'blob:keep' }])
@@ -75,11 +75,7 @@ describe('FE-230 clearNodePreviewCacheForValues', () => {
       graph: { setDirtyCanvas: setDirty }
     }
 
-    clearNodePreviewCacheForValues(
-      makeGraph([node]),
-      new Set(),
-      remove as unknown as (node: LGraphNode) => void
-    )
+    clearNodePreviewCacheForValues(makeGraph([node]), new Set(), remove)
 
     expect(node.imgs).toEqual([{ src: 'blob:keep' }])
     expect(remove).not.toHaveBeenCalled()
@@ -98,7 +94,7 @@ describe('FE-230 clearNodePreviewCacheForValues', () => {
     clearNodePreviewCacheForValues(
       makeGraph([node]),
       new Set(['foo.png [output]']),
-      remove as unknown as (node: LGraphNode) => void
+      remove
     )
 
     expect(node.imgs).toBeUndefined()
@@ -117,7 +113,7 @@ describe('FE-230 clearNodePreviewCacheForValues', () => {
     clearNodePreviewCacheForValues(
       makeGraph([node]),
       new Set(['sub/foo.png [output]']),
-      remove as unknown as (node: LGraphNode) => void
+      remove
     )
 
     expect(node.imgs).toBeUndefined()
@@ -142,7 +138,7 @@ describe('FE-230 clearNodePreviewCacheForValues', () => {
     clearNodePreviewCacheForValues(
       makeGraph([inputNode, outputNode]),
       new Set(['foo.png']),
-      remove as unknown as (node: LGraphNode) => void
+      remove
     )
 
     expect(inputNode.imgs).toBeUndefined()
@@ -163,7 +159,7 @@ describe('FE-230 clearNodePreviewCacheForValues', () => {
     clearNodePreviewCacheForValues(
       makeGraph([node]),
       new Set(['clip.mp4']),
-      remove as unknown as (node: LGraphNode) => void
+      remove
     )
 
     expect(node.videoContainer).toBeUndefined()
@@ -185,7 +181,7 @@ describe('FE-230 clearNodePreviewCacheForValues', () => {
     clearNodePreviewCacheForValues(
       makeGraph([node]),
       new Set(['clip.mp4']),
-      remove as unknown as (node: LGraphNode) => void
+      remove
     )
 
     expect(node.imgs).toBeUndefined()
@@ -210,7 +206,7 @@ describe('FE-230 clearNodePreviewCacheForValues', () => {
     clearNodePreviewCacheForValues(
       makeGraph([wrapper]),
       new Set(['nested.png [output]']),
-      remove as unknown as (node: LGraphNode) => void
+      remove
     )
 
     expect(inner.imgs).toBeUndefined()

--- a/src/platform/cloud/onboarding/survey/DynamicSurveyForm.test.ts
+++ b/src/platform/cloud/onboarding/survey/DynamicSurveyForm.test.ts
@@ -84,7 +84,7 @@ const branchedSurvey: OnboardingSurvey = {
 describe('DynamicSurveyForm', () => {
   it('renders the real default schema (v3) with its first question and options', () => {
     expect(defaultOnboardingSurvey.version).toBe(3)
-    const firstField = defaultOnboardingSurvey.fields[0]!
+    const firstField = defaultOnboardingSurvey.fields[0]
     renderForm(defaultOnboardingSurvey)
 
     expect(screen.getByText('What do you want to make?')).toBeVisible()

--- a/src/platform/cloud/onboarding/survey/surveySchema.test.ts
+++ b/src/platform/cloud/onboarding/survey/surveySchema.test.ts
@@ -220,7 +220,7 @@ describe('prepareSurvey', () => {
       ]
     }
     const prepared = prepareSurvey(survey)
-    const values = prepared.fields[0]!.options!.map((o) => o.value)
+    const values = prepared.fields[0].options!.map((o) => o.value)
     expect(values).toContain('a')
     expect(values).toContain('b')
     expect(values[values.length - 1]).toBe('other')
@@ -244,7 +244,7 @@ describe('prepareSurvey', () => {
       ]
     }
     const prepared = prepareSurvey(survey)
-    const values = prepared.fields[0]!.options!.map((o) => o.value)
+    const values = prepared.fields[0].options!.map((o) => o.value)
     expect(values.slice(-2).sort()).toEqual(['not_sure', 'other'])
     expect(values.slice(0, -2).sort()).toEqual(['a', 'b'])
   })

--- a/src/platform/cloud/subscription/composables/useSubscription.test.ts
+++ b/src/platform/cloud/subscription/composables/useSubscription.test.ts
@@ -24,7 +24,7 @@ const {
   mockIsCloud: { value: true },
   mockAuthStoreInitialized: { value: true },
   mockGetBillingStatus: vi.fn(),
-  mockActiveWorkspaceId: { value: 'workspace-123' as string | null },
+  mockActiveWorkspaceId: { value: 'workspace-123' },
   mockSetWorkspaceBillingRail: vi.fn(),
   mockReportError: vi.fn(),
   mockAccessBillingPortal: vi.fn(),
@@ -207,7 +207,7 @@ describe('useSubscription', () => {
     })
     window.__CONFIG__ = {
       subscription_required: true
-    } as typeof window.__CONFIG__
+    }
     vi.mocked(global.fetch).mockResolvedValue({
       ok: true,
       json: async () => ({
@@ -457,7 +457,7 @@ describe('useSubscription', () => {
       // Mock window.open
       const windowOpenSpy = vi
         .spyOn(window, 'open')
-        .mockImplementation(() => window as unknown as Window)
+        .mockImplementation(() => window)
 
       const { subscribe } = useSubscriptionWithScope()
 
@@ -514,7 +514,7 @@ describe('useSubscription', () => {
       } as Response)
       const windowOpenSpy = vi
         .spyOn(window, 'open')
-        .mockImplementation(() => window as unknown as Window)
+        .mockImplementation(() => window)
 
       const { subscribeDirect } = useSubscriptionWithScope()
 
@@ -544,7 +544,7 @@ describe('useSubscription', () => {
       } as Response)
       const windowOpenSpy = vi
         .spyOn(window, 'open')
-        .mockImplementation(() => window as unknown as Window)
+        .mockImplementation(() => window)
 
       const { subscribeDirect } = useSubscriptionWithScope()
 

--- a/src/platform/cloud/subscription/utils/subscriptionCheckoutTracker.ts
+++ b/src/platform/cloud/subscription/utils/subscriptionCheckoutTracker.ts
@@ -160,7 +160,7 @@ const normalizeAttempt = (
   }
 
   if (
-    !VALID_TIER_KEYS.has(candidate.tier as TierKey) ||
+    !VALID_TIER_KEYS.has(candidate.tier) ||
     (candidate.cycle !== 'monthly' && candidate.cycle !== 'yearly') ||
     (candidate.checkout_type !== 'new' && candidate.checkout_type !== 'change')
   ) {
@@ -170,12 +170,11 @@ const normalizeAttempt = (
   return {
     attempt_id: candidate.attempt_id,
     started_at_ms: candidate.started_at_ms,
-    tier: candidate.tier as TierKey,
+    tier: candidate.tier,
     cycle: candidate.cycle,
     checkout_type: candidate.checkout_type,
-    ...(candidate.previous_tier &&
-    VALID_TIER_KEYS.has(candidate.previous_tier as TierKey)
-      ? { previous_tier: candidate.previous_tier as TierKey }
+    ...(candidate.previous_tier && VALID_TIER_KEYS.has(candidate.previous_tier)
+      ? { previous_tier: candidate.previous_tier }
       : {}),
     ...(candidate.previous_cycle === 'monthly' ||
     candidate.previous_cycle === 'yearly'

--- a/src/platform/cloud/subscription/utils/subscriptionCheckoutUtil.test.ts
+++ b/src/platform/cloud/subscription/utils/subscriptionCheckoutUtil.test.ts
@@ -19,7 +19,7 @@ const {
   mockGetAuthHeader: vi.fn(() =>
     Promise.resolve({ Authorization: 'Bearer test-token' })
   ),
-  mockUserId: { value: 'user-123' as string | undefined },
+  mockUserId: { value: 'user-123' },
   mockIsCloud: { value: true },
   mockGetCheckoutAttribution: vi.fn(() => ({
     ga_client_id: 'ga-client-id',
@@ -130,9 +130,7 @@ describe('performSubscriptionCheckout', () => {
 
   it('tracks begin_checkout with user id and tier metadata', async () => {
     const checkoutUrl = 'https://checkout.stripe.com/test'
-    const openSpy = vi
-      .spyOn(window, 'open')
-      .mockImplementation(() => window as unknown as Window)
+    const openSpy = vi.spyOn(window, 'open').mockImplementation(() => window)
 
     vi.mocked(global.fetch).mockResolvedValue({
       ok: true,
@@ -225,9 +223,7 @@ describe('performSubscriptionCheckout', () => {
 
   it('carries the payment intent source into begin_checkout and the pending attempt', async () => {
     const checkoutUrl = 'https://checkout.stripe.com/test'
-    const openSpy = vi
-      .spyOn(window, 'open')
-      .mockImplementation(() => window as unknown as Window)
+    const openSpy = vi.spyOn(window, 'open').mockImplementation(() => window)
 
     vi.mocked(global.fetch).mockResolvedValue({
       ok: true,
@@ -256,9 +252,7 @@ describe('performSubscriptionCheckout', () => {
 
   it('uses the latest userId when it changes after checkout starts', async () => {
     const checkoutUrl = 'https://checkout.stripe.com/test'
-    const openSpy = vi
-      .spyOn(window, 'open')
-      .mockImplementation(() => window as unknown as Window)
+    const openSpy = vi.spyOn(window, 'open').mockImplementation(() => window)
     const authHeader = createDeferred<{ Authorization: string }>()
 
     mockUserId.value = 'user-early'

--- a/src/platform/cloud/subscription/utils/subscriptionTierRank.ts
+++ b/src/platform/cloud/subscription/utils/subscriptionTierRank.ts
@@ -29,7 +29,7 @@ const toRankedPlanKey = (
   billingCycle: BillingCycle
 ): RankedPlanKey | null => {
   if (tierKey === 'founder' || tierKey === 'free') return null
-  return `${billingCycle}-${tierKey}` as RankedPlanKey
+  return `${billingCycle}-${tierKey}`
 }
 
 export const getPlanRank = ({

--- a/src/platform/cloud/subscription/utils/teamSubscriptionCheckoutUtil.test.ts
+++ b/src/platform/cloud/subscription/utils/teamSubscriptionCheckoutUtil.test.ts
@@ -12,7 +12,7 @@ const {
   mockSubscribe: vi.fn(),
   mockTrackBeginCheckout: vi.fn(),
   mockTrackBillingEvent: vi.fn(),
-  mockUserId: { value: 'user-1' as string | null }
+  mockUserId: { value: 'user-1' }
 }))
 
 vi.mock('@/platform/distribution/types', () => ({

--- a/src/platform/nodeReplacement/cnrIdUtil.ts
+++ b/src/platform/nodeReplacement/cnrIdUtil.ts
@@ -23,5 +23,5 @@ export function getCnrIdFromProperties(
  * @returns The cnrId string, or undefined if not found
  */
 export function getCnrIdFromNode(node: LGraphNode): string | undefined {
-  return getCnrIdFromProperties(node.properties as Record<string, unknown>)
+  return getCnrIdFromProperties(node.properties)
 }

--- a/src/platform/onboarding/onboardingTourStore.test.ts
+++ b/src/platform/onboarding/onboardingTourStore.test.ts
@@ -36,11 +36,10 @@ vi.mock('@/platform/telemetry', () => ({
 }))
 
 const appModeMock = vi.hoisted(
-  () =>
-    ({ mode: null, hasOutputs: null }) as {
-      mode: Ref<AppMode> | null
-      hasOutputs: Ref<boolean> | null
-    }
+  (): { mode: Ref<AppMode> | null; hasOutputs: Ref<boolean> | null } => ({
+    mode: null,
+    hasOutputs: null
+  })
 )
 vi.mock('@/composables/useAppMode', async () => {
   const { ref: r } = await import('vue')

--- a/src/platform/secrets/components/SecretListItem.test.ts
+++ b/src/platform/secrets/components/SecretListItem.test.ts
@@ -266,7 +266,7 @@ describe('SecretListItem', () => {
       await user.click(buttons[0])
 
       expect(emitted()['edit']).toBeDefined()
-      expect(emitted()['edit']!.length).toBeGreaterThanOrEqual(1)
+      expect(emitted()['edit'].length).toBeGreaterThanOrEqual(1)
     })
 
     it('emits delete event when delete button clicked', async () => {
@@ -278,7 +278,7 @@ describe('SecretListItem', () => {
       await user.click(buttons[1])
 
       expect(emitted()['delete']).toBeDefined()
-      expect(emitted()['delete']!.length).toBeGreaterThanOrEqual(1)
+      expect(emitted()['delete'].length).toBeGreaterThanOrEqual(1)
     })
   })
 })

--- a/src/platform/settings/constants/coreSettings.ts
+++ b/src/platform/settings/constants/coreSettings.ts
@@ -8,7 +8,6 @@ import { TOUR_SEEN_SETTING } from '@/platform/onboarding/onboardingTours'
 import { CANVAS_NAVIGATION_PRESETS } from '@/platform/settings/constants/canvasNavigation'
 import { useSettingStore } from '@/platform/settings/settingStore'
 import type { SettingParams } from '@/platform/settings/types'
-import type { ColorPalettes } from '@/schemas/colorPaletteSchema'
 import type { Keybinding } from '@/platform/keybindings/types'
 import { NodeBadgeMode } from '@/types/nodeSource'
 import { LinkReleaseTriggerAction } from '@/types/searchBoxTypes'
@@ -859,7 +858,7 @@ export const CORE_SETTINGS: SettingParams[] = [
     tooltip: 'Server config values used for frontend display only',
     type: 'hidden',
     // Mapping from server config id to value.
-    defaultValue: {} as Record<string, unknown>,
+    defaultValue: {},
     versionAdded: '1.4.8'
   },
   {
@@ -868,7 +867,7 @@ export const CORE_SETTINGS: SettingParams[] = [
     tooltip:
       'These are the actual arguments that are passed to the server when it is launched.',
     type: 'hidden',
-    defaultValue: {} as Record<string, string>,
+    defaultValue: {},
     versionAdded: '1.4.8'
   },
   {
@@ -954,7 +953,7 @@ export const CORE_SETTINGS: SettingParams[] = [
     id: 'Comfy.CustomColorPalettes',
     name: 'Custom color palettes',
     type: 'hidden',
-    defaultValue: {} as ColorPalettes,
+    defaultValue: {},
     versionModified: '1.6.7'
   },
   {

--- a/src/platform/settings/settingStore.ts
+++ b/src/platform/settings/settingStore.ts
@@ -31,6 +31,10 @@ interface AppliedSetting<TValue> {
   newValue: TValue
 }
 
+function resolveDefaultValue<T>(value: T | (() => T)): T {
+  return typeof value === 'function' ? (value as () => T)() : value
+}
+
 function tryMigrateDeprecatedValue(
   setting: SettingParams | undefined,
   value: unknown
@@ -285,9 +289,7 @@ export const useSettingStore = defineStore('setting', () => {
     }
 
     const defaultValue = param.defaultValue
-    return typeof defaultValue === 'function'
-      ? Reflect.apply(defaultValue, undefined, [])
-      : defaultValue
+    return resolveDefaultValue(defaultValue)
   }
 
   function getVersionedDefaultValue<

--- a/src/platform/settings/settingStore.ts
+++ b/src/platform/settings/settingStore.ts
@@ -226,10 +226,7 @@ export const useSettingStore = defineStore('setting', () => {
     const telemetryEvents: SettingChangedMetadata[] = []
 
     for (const key of Object.keys(settings) as (keyof Settings)[]) {
-      const applied = await applySettingLocally(
-        key,
-        settings[key] as Settings[typeof key]
-      )
+      const applied = await applySettingLocally(key, settings[key])
       if (applied !== undefined) {
         updatedSettings[key] = applied.newValue
         const event = settingChangedEvent(settingsById.value[key], key, applied)
@@ -289,7 +286,7 @@ export const useSettingStore = defineStore('setting', () => {
 
     const defaultValue = param.defaultValue
     return typeof defaultValue === 'function'
-      ? (defaultValue as () => Settings[K])()
+      ? Reflect.apply(defaultValue, undefined, [])
       : defaultValue
   }
 
@@ -402,7 +399,7 @@ export const useSettingStore = defineStore('setting', () => {
       settingValues.value[oldKey] !== undefined &&
       settingValues.value[newKey] === undefined
     ) {
-      const oldValue = settingValues.value[oldKey] as number
+      const oldValue = settingValues.value[oldKey]
 
       // Convert zoom threshold to equivalent font size to preserve exact behavior
       // The threshold formula is: threshold = font_size / (14 * sqrt(DPR))

--- a/src/platform/surveys/useTypeformEmbed.ts
+++ b/src/platform/surveys/useTypeformEmbed.ts
@@ -24,7 +24,7 @@ export function isTypeformIdValid(id: string | undefined | null): boolean {
 }
 
 const loadTypeformScript = createScriptLoader(TYPEFORM_SRC, () =>
-  typeof window.tf?.load === 'function' ? (window.tf as TypeformGlobal) : null
+  typeof window.tf?.load === 'function' ? window.tf : null
 )
 
 function ensureScriptLoaded(): Promise<TypeformGlobal> {

--- a/src/platform/telemetry/providers/cloud/CustomerIoTelemetryProvider.test.ts
+++ b/src/platform/telemetry/providers/cloud/CustomerIoTelemetryProvider.test.ts
@@ -70,7 +70,7 @@ function createProvider(
     customer_io: { write_key: WRITE_KEY, site_id: SITE_ID }
   }
 ): CustomerIoTelemetryProvider {
-  window.__CONFIG__ = config as typeof window.__CONFIG__
+  window.__CONFIG__ = config
   return new CustomerIoTelemetryProvider()
 }
 
@@ -92,7 +92,7 @@ describe('CustomerIoTelemetryProvider', () => {
     hoisted.analytics.register.mockResolvedValue(undefined)
     hoisted.userEmail.value = null
     i18n.global.locale.value = 'en'
-    window.__CONFIG__ = {} as typeof window.__CONFIG__
+    window.__CONFIG__ = {}
   })
 
   it('loads the client and registers the in-app plugin with the site id', async () => {

--- a/src/platform/telemetry/providers/cloud/GtmTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/GtmTelemetryProvider.ts
@@ -91,7 +91,7 @@ export class GtmTelemetryProvider implements TelemetryProvider {
         ;(window.dataLayer as unknown[] | undefined)?.push(arguments)
       }
 
-      window.gtag = gtag as Window['gtag']
+      window.gtag = gtag
     }
 
     const gtagScriptSrc = `https://www.googletagmanager.com/gtag/js?id=${measurementId}`

--- a/src/platform/telemetry/providers/cloud/MixpanelTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/MixpanelTelemetryProvider.ts
@@ -84,9 +84,7 @@ export class MixpanelTelemetryProvider implements TelemetryProvider {
   private disabledEvents = new Set<TelemetryEventName>(DEFAULT_DISABLED_EVENTS)
 
   constructor() {
-    this.configureDisabledEvents(
-      (window.__CONFIG__ as Partial<RemoteConfig> | undefined) ?? null
-    )
+    this.configureDisabledEvents(window.__CONFIG__ ?? null)
     watch(
       remoteConfig,
       (config) => {

--- a/src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.test.ts
+++ b/src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.test.ts
@@ -106,7 +106,7 @@ describe('PostHogTelemetryProvider', () => {
     hoisted.refs.tier = ref<string | null>(null)
     window.__CONFIG__ = {
       posthog_project_token: 'phc_test_token'
-    } as typeof window.__CONFIG__
+    }
   })
 
   describe('initialization', () => {

--- a/src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.ts
@@ -139,9 +139,7 @@ export class PostHogTelemetryProvider implements TelemetryProvider {
   private stopSubscriptionTierWatch: WatchStopHandle | null = null
 
   constructor() {
-    this.configureDisabledEvents(
-      (window.__CONFIG__ as Partial<RemoteConfig> | undefined) ?? null
-    )
+    this.configureDisabledEvents(window.__CONFIG__ ?? null)
     watch(
       remoteConfig,
       (config) => {
@@ -159,7 +157,7 @@ export class PostHogTelemetryProvider implements TelemetryProvider {
           .then((posthogModule) => {
             this.posthog = posthogModule.default
             const serverConfig = remoteConfig.value?.posthog_config ?? {}
-            this.posthog!.init(apiKey, {
+            this.posthog.init(apiKey, {
               api_host:
                 window.__CONFIG__?.posthog_api_host || 'https://t.comfy.org',
               ui_host: 'https://us.posthog.com',
@@ -296,7 +294,7 @@ export class PostHogTelemetryProvider implements TelemetryProvider {
     } else {
       this.eventQueue.push({
         eventName,
-        properties: properties as TelemetryEventProperties
+        properties: properties
       })
     }
   }

--- a/src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.ts
@@ -294,7 +294,7 @@ export class PostHogTelemetryProvider implements TelemetryProvider {
     } else {
       this.eventQueue.push({
         eventName,
-        properties: properties
+        properties
       })
     }
   }

--- a/src/platform/updates/common/versionCompatibilityStore.test.ts
+++ b/src/platform/updates/common/versionCompatibilityStore.test.ts
@@ -212,9 +212,7 @@ describe('useVersionCompatibilityStore', () => {
 
     it('should not show warning when disabled via setting', async () => {
       // Enable the disable setting
-      ;(
-        mockSettingStore as { get: ReturnType<typeof vi.fn> }
-      ).get.mockReturnValue(true)
+      mockSettingStore.get.mockReturnValue(true)
 
       // Set up version mismatch that would normally show warning
       mockSystemStatsStore.systemStats = {
@@ -228,9 +226,9 @@ describe('useVersionCompatibilityStore', () => {
       await store.checkVersionCompatibility()
 
       expect(store.shouldShowWarning).toBe(false)
-      expect(
-        (mockSettingStore as { get: ReturnType<typeof vi.fn> }).get
-      ).toHaveBeenCalledWith('Comfy.VersionCompatibility.DisableWarnings')
+      expect(mockSettingStore.get).toHaveBeenCalledWith(
+        'Comfy.VersionCompatibility.DisableWarnings'
+      )
     })
   })
 

--- a/src/platform/workflow/core/services/workflowService.test.ts
+++ b/src/platform/workflow/core/services/workflowService.test.ts
@@ -360,8 +360,8 @@ describe('useWorkflowService', () => {
         }
       ]
 
-      useMissingModelStore().missingModelCandidates = modelCandidates as never
-      useMissingMediaStore().missingMediaCandidates = mediaCandidates as never
+      useMissingModelStore().missingModelCandidates = modelCandidates
+      useMissingMediaStore().missingMediaCandidates = mediaCandidates
 
       useWorkflowService().beforeLoadNewGraph()
 
@@ -541,7 +541,7 @@ describe('useWorkflowService', () => {
       workflowStore.attachWorkflow(replacement, 1)
       workflowStore.activeWorkflow = closing as LoadedComfyWorkflow
       vi.spyOn(workflowStore, 'getMostRecentWorkflow').mockReturnValue(
-        replacement as LoadedComfyWorkflow
+        replacement
       )
       const storeClose = vi.spyOn(workflowStore, 'closeWorkflow')
       const error = new Error('replacement load failed')
@@ -575,7 +575,7 @@ describe('useWorkflowService', () => {
       workflowStore.attachWorkflow(replacement, 1)
       workflowStore.activeWorkflow = closing as LoadedComfyWorkflow
       vi.spyOn(workflowStore, 'getMostRecentWorkflow').mockReturnValue(
-        replacement as LoadedComfyWorkflow
+        replacement
       )
       const storeClose = vi.spyOn(workflowStore, 'closeWorkflow')
       // The REAL configure-failure shape (christian-byrne's 16075 review):
@@ -1281,7 +1281,7 @@ describe('useWorkflowService', () => {
       workflowStore.attachWorkflow(survivor, 2)
       workflowStore.activeWorkflow = active as LoadedComfyWorkflow
       vi.spyOn(workflowStore, 'getMostRecentWorkflow').mockReturnValue(
-        alsoClosing as LoadedComfyWorkflow
+        alsoClosing
       )
 
       // Hold alsoClosing's pending open so its close stays registered as
@@ -2379,7 +2379,7 @@ describe('useWorkflowService', () => {
         isApp: true
       })
 
-      expect(source.changeTracker!.prepareForSave).toHaveBeenCalledTimes(1)
+      expect(source.changeTracker.prepareForSave).toHaveBeenCalledTimes(1)
     })
 
     it('does not modify source workflow mode when saving persisted workflow as different mode', async () => {

--- a/src/platform/workflow/core/services/workflowService.ts
+++ b/src/platform/workflow/core/services/workflowService.ts
@@ -655,11 +655,9 @@ export const useWorkflowService = () => {
     }
 
     if (value === null || typeof value === 'string') {
-      const path = value
-
       // Check if a persisted workflow with this path exists
-      if (path) {
-        const fullPath = ComfyWorkflow.basePath + appendJsonExt(path)
+      if (value) {
+        const fullPath = ComfyWorkflow.basePath + appendJsonExt(value)
         const existingWorkflow = workflowStore.getWorkflowByPath(fullPath)
 
         // Reuse an existing workflow when this is a restoration case
@@ -707,7 +705,7 @@ export const useWorkflowService = () => {
       }
 
       const tempWorkflow = workflowStore.createNewTemporary(
-        path ? appendJsonExt(path) : undefined,
+        value ? appendJsonExt(value) : undefined,
         workflowData
       )
       tempWorkflow.initialMode = freshLoadMode

--- a/src/platform/workflow/core/services/workflowService.ts
+++ b/src/platform/workflow/core/services/workflowService.ts
@@ -655,7 +655,7 @@ export const useWorkflowService = () => {
     }
 
     if (value === null || typeof value === 'string') {
-      const path = value as string | null
+      const path = value
 
       // Check if a persisted workflow with this path exists
       if (path) {

--- a/src/platform/workflow/management/stores/workflowStore.test.ts
+++ b/src/platform/workflow/management/stores/workflowStore.test.ts
@@ -723,9 +723,9 @@ describe('useWorkflowStore', () => {
 
       // Verify the content was updated
       expect(workflow.content).toBe(
-        JSON.stringify(workflow.changeTracker!.activeState)
+        JSON.stringify(workflow.changeTracker.activeState)
       )
-      expect(workflow.changeTracker!.reset).toHaveBeenCalled()
+      expect(workflow.changeTracker.reset).toHaveBeenCalled()
       expect(workflow.isModified).toBe(false)
     })
 
@@ -754,7 +754,7 @@ describe('useWorkflowStore', () => {
       expect(api.storeUserData).toHaveBeenCalled()
 
       // Verify the content was updated
-      expect(workflow.changeTracker!.reset).toHaveBeenCalled()
+      expect(workflow.changeTracker.reset).toHaveBeenCalled()
       expect(workflow.isModified).toBe(false)
     })
   })
@@ -787,7 +787,7 @@ describe('useWorkflowStore', () => {
 
       expect(newWorkflow.path).toBe('workflows/new-test.json')
       expect(newWorkflow.content).toBe(
-        JSON.stringify(workflow.changeTracker!.activeState)
+        JSON.stringify(workflow.changeTracker.activeState)
       )
       expect(newWorkflow.isModified).toBe(false)
     })

--- a/src/platform/workflow/persistence/composables/useWorkflowPersistenceV2.test.ts
+++ b/src/platform/workflow/persistence/composables/useWorkflowPersistenceV2.test.ts
@@ -143,7 +143,7 @@ vi.mock('@/platform/distribution/types', () => ({
 }))
 
 const teamWorkspaceStoreMocks = reactive({
-  initState: 'uninitialized' as 'uninitialized' | 'ready' | 'error',
+  initState: 'uninitialized',
   activeWorkspaceId: null as string | null
 })
 

--- a/src/platform/workflow/sharing/components/OpenSharedWorkflowDialogContent.test.ts
+++ b/src/platform/workflow/sharing/components/OpenSharedWorkflowDialogContent.test.ts
@@ -185,7 +185,7 @@ describe('OpenSharedWorkflowDialogContent', () => {
       await flushPromises()
 
       const buttons = container.querySelectorAll('footer button')
-      await userEvent.click(buttons[buttons.length - 1] as HTMLElement)
+      await userEvent.click(buttons[buttons.length - 1])
       expect(onConfirm).toHaveBeenCalledWith(payload)
     })
 
@@ -285,7 +285,7 @@ describe('OpenSharedWorkflowDialogContent', () => {
       await flushPromises()
 
       const buttons = container.querySelectorAll('footer button')
-      await userEvent.click(buttons[buttons.length - 1] as HTMLElement)
+      await userEvent.click(buttons[buttons.length - 1])
       expect(onConfirm).toHaveBeenCalledWith(assetsPayload)
     })
 

--- a/src/platform/workflow/sharing/components/publish/ComfyHubDescribeStep.test.ts
+++ b/src/platform/workflow/sharing/components/publish/ComfyHubDescribeStep.test.ts
@@ -150,7 +150,7 @@ describe('ComfyHubDescribeStep', () => {
       '[data-testid="tags-input"][data-disabled="true"] [data-testid="tag-item"]'
     )
 
-    await userEvent.click(suggestionButtons[0] as HTMLElement)
+    await userEvent.click(suggestionButtons[0])
 
     expect(onUpdateTags).toHaveBeenLastCalledWith(['Alpha'])
   })

--- a/src/platform/workflow/sharing/components/publish/ComfyHubPublishDialog.test.ts
+++ b/src/platform/workflow/sharing/components/publish/ComfyHubPublishDialog.test.ts
@@ -3,6 +3,8 @@ import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick, ref } from 'vue'
 
+import type { ComfyHubPublishFormData } from '@/platform/workflow/sharing/types/comfyHubTypes'
+
 vi.mock('vue-i18n', async (importOriginal) => {
   const actual = await importOriginal()
   return {
@@ -35,7 +37,7 @@ const mockSubmitToComfyHub = vi.hoisted(() => vi.fn())
 const mockGetPublishStatus = vi.hoisted(() => vi.fn())
 const mockRenameWorkflow = vi.hoisted(() => vi.fn())
 const mockFormDataHolder = vi.hoisted(
-  () => ({ value: null }) as { value: Record<string, unknown> | null }
+  (): { value: ComfyHubPublishFormData | null } => ({ value: null })
 )
 
 vi.mock(
@@ -123,7 +125,7 @@ vi.mock('@/platform/workflow/management/stores/workflowStore', async () => {
       directory: 'workflows',
       isTemporary: false,
       isModified: false
-    } as Record<string, unknown> | null
+    }
   })
   return {
     useWorkflowStore: () => ({

--- a/src/platform/workflow/sharing/composables/useComfyHubPublishSubmission.test.ts
+++ b/src/platform/workflow/sharing/composables/useComfyHubPublishSubmission.test.ts
@@ -7,9 +7,9 @@ const mockGetShareableAssets = vi.hoisted(() => vi.fn())
 const mockRequestAssetUploadUrl = vi.hoisted(() => vi.fn())
 const mockUploadFileToPresignedUrl = vi.hoisted(() => vi.fn())
 const mockPublishWorkflow = vi.hoisted(() => vi.fn())
-const mockProfile = vi.hoisted(
-  () => ({ value: null }) as { value: ComfyHubProfile | null }
-)
+const mockProfile = vi.hoisted((): { value: ComfyHubProfile | null } => ({
+  value: null
+}))
 
 vi.mock(
   '@/platform/workflow/sharing/composables/useComfyHubProfileGate',

--- a/src/platform/workflow/templates/composables/useTemplateWorkflows.test.ts
+++ b/src/platform/workflow/templates/composables/useTemplateWorkflows.test.ts
@@ -25,11 +25,13 @@ vi.mock('@/scripts/api', () => ({
 
 // loadGraphData resolves to the workflow it activated; the education card
 // binds to that, so the mock returns a per-test workflow object.
-const { mockLoadedWorkflow } = vi.hoisted(() => ({
-  mockLoadedWorkflow: {
-    value: { key: 'loaded-template' } as { key: string } | undefined
-  }
-}))
+const { mockLoadedWorkflow } = vi.hoisted(
+  (): { mockLoadedWorkflow: { value: { key: string } | undefined } } => ({
+    mockLoadedWorkflow: {
+      value: { key: 'loaded-template' }
+    }
+  })
+)
 
 vi.mock('@/scripts/app', () => ({
   app: {

--- a/src/platform/workflow/templates/utils/templateDisplay.test.ts
+++ b/src/platform/workflow/templates/utils/templateDisplay.test.ts
@@ -16,7 +16,7 @@ function template(overrides: Partial<TemplateInfo> = {}): TemplateInfo {
     mediaType: 'image',
     mediaSubtype: 'webp',
     ...overrides
-  } as TemplateInfo
+  }
 }
 
 describe('getProviderIconClass', () => {

--- a/src/platform/workspace/components/SubscriptionSuccessWorkspace.test.ts
+++ b/src/platform/workspace/components/SubscriptionSuccessWorkspace.test.ts
@@ -15,8 +15,8 @@ vi.mock('vue-i18n', () => ({
 const { mockInviteSubmit, mockMaxSeats, mockOccupiedSeats } = vi.hoisted(
   () => ({
     mockInviteSubmit: vi.fn(),
-    mockMaxSeats: { value: 73 as number | null },
-    mockOccupiedSeats: { value: 1 as number | null }
+    mockMaxSeats: { value: 73 },
+    mockOccupiedSeats: { value: 1 }
   })
 )
 

--- a/src/platform/workspace/components/UnifiedPricingTable.test.ts
+++ b/src/platform/workspace/components/UnifiedPricingTable.test.ts
@@ -176,7 +176,7 @@ describe('UnifiedPricingTable plan CTA labels', () => {
     })
     expect(cta).toBeEnabled()
     await user.click(cta)
-    const [payload] = emitted().subscribe![0] as [
+    const [payload] = emitted().subscribe[0] as [
       { tierKey: string; billingCycle: string }
     ]
     expect(payload).toMatchObject({
@@ -276,7 +276,7 @@ describe('UnifiedPricingTable team plan CTA', () => {
     const cta = screen.getByRole('button', { name: 'Change plan' })
     expect(cta).toBeEnabled()
     await user.click(cta)
-    const [teamPayload] = emitted().subscribeTeam![0] as [{ isChange: boolean }]
+    const [teamPayload] = emitted().subscribeTeam[0] as [{ isChange: boolean }]
     expect(teamPayload).toMatchObject({ isChange: true })
   })
 
@@ -296,7 +296,7 @@ describe('UnifiedPricingTable team plan CTA', () => {
     const cta = screen.getByRole('button', { name: 'Change plan' })
     expect(cta).toBeEnabled()
     await user.click(cta)
-    const [teamPayload] = emitted().subscribeTeam![0] as [{ isChange: boolean }]
+    const [teamPayload] = emitted().subscribeTeam[0] as [{ isChange: boolean }]
     expect(teamPayload).toMatchObject({ isChange: true })
     expect(emitted().resubscribe).toBeFalsy()
   })
@@ -367,7 +367,7 @@ describe('UnifiedPricingTable team plan CTA', () => {
     const cta = screen.getByRole('button', { name: 'Subscribe to Team Yearly' })
     expect(cta).toBeEnabled()
     await user.click(cta)
-    const [teamPayload] = emitted().subscribeTeam![0] as [{ isChange: boolean }]
+    const [teamPayload] = emitted().subscribeTeam[0] as [{ isChange: boolean }]
     expect(teamPayload).toMatchObject({ isChange: false })
     expect(emitted().resubscribe).toBeFalsy()
   })

--- a/src/platform/workspace/components/dialogs/InviteMemberDialogContent.test.ts
+++ b/src/platform/workspace/components/dialogs/InviteMemberDialogContent.test.ts
@@ -17,17 +17,20 @@ const {
   mockFetchStatus,
   mockMaxSeats,
   mockOccupiedSeats
-} = vi.hoisted(() => ({
-  mockCreateInvite: vi.fn(),
-  mockFetchPendingInvites: vi.fn(),
-  mockCloseDialog: vi.fn(),
-  mockToastAdd: vi.fn(),
-  mockTrackInviteSent: vi.fn(),
-  mockTrackInviteFailed: vi.fn(),
-  mockFetchStatus: vi.fn(),
-  mockMaxSeats: { value: 73 as number | null },
-  mockOccupiedSeats: { value: 0 as number | null }
-}))
+} = vi.hoisted(() => {
+  const nullableNumber = (value: number | null) => ({ value })
+  return {
+    mockCreateInvite: vi.fn(),
+    mockFetchPendingInvites: vi.fn(),
+    mockCloseDialog: vi.fn(),
+    mockToastAdd: vi.fn(),
+    mockTrackInviteSent: vi.fn(),
+    mockTrackInviteFailed: vi.fn(),
+    mockFetchStatus: vi.fn(),
+    mockMaxSeats: nullableNumber(73),
+    mockOccupiedSeats: nullableNumber(0)
+  }
+})
 
 vi.mock('@/composables/billing/useBillingContext', () => ({
   useBillingContext: () => ({

--- a/src/platform/workspace/components/dialogs/settings/MembersPanelContent.test.ts
+++ b/src/platform/workspace/components/dialogs/settings/MembersPanelContent.test.ts
@@ -82,7 +82,7 @@ const {
       pendingGridCols: 'grid-cols-[50%_20%_20%_10%]',
       headerGridCols: 'grid-cols-[50%_40%_10%]',
       showEditWorkspaceMenuItem: true,
-      workspaceMenuAction: 'delete' as 'delete' | null,
+      workspaceMenuAction: 'delete',
       workspaceMenuDisabledTooltip: null as string | null
     })
   }

--- a/src/platform/workspace/composables/useMembersPanel.test.ts
+++ b/src/platform/workspace/composables/useMembersPanel.test.ts
@@ -308,7 +308,7 @@ const {
       pendingGridCols: 'grid-cols-[50%_20%_20%_10%]',
       headerGridCols: 'grid-cols-[50%_40%_10%]',
       showEditWorkspaceMenuItem: true,
-      workspaceMenuAction: 'delete' as 'delete' | null,
+      workspaceMenuAction: 'delete',
       workspaceMenuDisabledTooltip: null as string | null
     }),
     mockCanAccessSubscriptionFeatures: ref(true),

--- a/src/platform/workspace/composables/useSubscriptionCheckout.test.ts
+++ b/src/platform/workspace/composables/useSubscriptionCheckout.test.ts
@@ -178,58 +178,61 @@ const {
   mockCanReactivatePlan,
   mockCapabilities,
   mockSubscription
-} = vi.hoisted(() => ({
-  mockSubscribe: vi.fn(),
-  mockPreviewSubscribe: vi.fn(),
-  mockFetchPlans: vi.fn(),
-  mockFetchStatus: vi.fn(),
-  mockFetchBalance: vi.fn(),
-  mockOpen: vi.fn(),
-  mockGetBillingStatus: vi.fn(),
-  mockGetPaymentPortalUrl: vi.fn(),
-  mockPlans: { value: [] as Plan[] },
-  mockResubscribe: vi.fn(),
-  mockToastAdd: vi.fn(),
-  mockStartOperation: vi.fn(),
-  mockRetryPaymentAuthentication: vi.fn(),
-  mockGetOperation: vi.fn(),
-  mockSubscriptionActionOperation: {
-    value: undefined as MockSubscriptionActionOperation | undefined
-  },
-  mockListSavedPaymentMethods: vi.fn(),
-  mockTrackBeginCheckout: vi.fn(),
-  mockTrackBillingEvent: vi.fn(),
-  mockShowDowngradeToPersonalDialog: vi.fn(),
-  mockUserId: { value: 'user-1' as string | null },
-  mockIsTeamPlan: { value: false },
-  mockShouldUseWorkspaceBilling: { value: true },
-  mockIncompleteEmbeddedPreview: { value: false },
-  mockSetActiveWorkspaceIdImpl: {
-    value: undefined as ((workspaceId: string) => void) | undefined
-  },
-  mockSetActiveWorkspaceId: vi.fn<(workspaceId: string) => void>(
-    (workspaceId) => {
-      mockSetActiveWorkspaceIdImpl.value?.(workspaceId)
-    }
-  ),
-  mockPermissions: {
-    value: {
-      canManageSubscription: true,
-      canManageSubscriptionLifecycle: true,
-      canDowngradeToPersonal: true
-    }
-  },
-  mockCanReactivatePlan: { value: true },
-  mockCapabilities: {
-    value: {
-      canSubscribeSelfServe: true,
-      canReactivate: true,
-      canChangeSeats: true,
-      canDowngradeToPersonal: true
-    }
-  },
-  mockSubscription: { value: null as { isCancelled: boolean } | null }
-}))
+} = vi.hoisted(() => {
+  const nullableString = (value: string | null) => ({ value })
+  return {
+    mockSubscribe: vi.fn(),
+    mockPreviewSubscribe: vi.fn(),
+    mockFetchPlans: vi.fn(),
+    mockFetchStatus: vi.fn(),
+    mockFetchBalance: vi.fn(),
+    mockOpen: vi.fn(),
+    mockGetBillingStatus: vi.fn(),
+    mockGetPaymentPortalUrl: vi.fn(),
+    mockPlans: { value: [] as Plan[] },
+    mockResubscribe: vi.fn(),
+    mockToastAdd: vi.fn(),
+    mockStartOperation: vi.fn(),
+    mockRetryPaymentAuthentication: vi.fn(),
+    mockGetOperation: vi.fn(),
+    mockSubscriptionActionOperation: {
+      value: undefined as MockSubscriptionActionOperation | undefined
+    },
+    mockListSavedPaymentMethods: vi.fn(),
+    mockTrackBeginCheckout: vi.fn(),
+    mockTrackBillingEvent: vi.fn(),
+    mockShowDowngradeToPersonalDialog: vi.fn(),
+    mockUserId: nullableString('user-1'),
+    mockIsTeamPlan: { value: false },
+    mockShouldUseWorkspaceBilling: { value: true },
+    mockIncompleteEmbeddedPreview: { value: false },
+    mockSetActiveWorkspaceIdImpl: {
+      value: undefined as ((workspaceId: string) => void) | undefined
+    },
+    mockSetActiveWorkspaceId: vi.fn<(workspaceId: string) => void>(
+      (workspaceId) => {
+        mockSetActiveWorkspaceIdImpl.value?.(workspaceId)
+      }
+    ),
+    mockPermissions: {
+      value: {
+        canManageSubscription: true,
+        canManageSubscriptionLifecycle: true,
+        canDowngradeToPersonal: true
+      }
+    },
+    mockCanReactivatePlan: { value: true },
+    mockCapabilities: {
+      value: {
+        canSubscribeSelfServe: true,
+        canReactivate: true,
+        canChangeSeats: true,
+        canDowngradeToPersonal: true
+      }
+    },
+    mockSubscription: { value: null as { isCancelled: boolean } | null }
+  }
+})
 
 async function previewSubscribe(...args: unknown[]) {
   const response = await mockPreviewSubscribe(...args)
@@ -485,7 +488,7 @@ describe('useSubscriptionCheckout', () => {
     mockShowDowngradeToPersonalDialog.mockResolvedValue(null)
     mockUserId.value = 'user-1'
     mockIsTeamPlan.value = false
-    mockOpen.mockReturnValue({} as Window)
+    mockOpen.mockReturnValue({})
     mockGetBillingStatus.mockResolvedValue({ billing_status: 'paid' })
     mockGetPaymentPortalUrl.mockResolvedValue({
       url: 'https://billing.stripe.com/portal'

--- a/src/platform/workspace/composables/useWorkspaceBilling.test.ts
+++ b/src/platform/workspace/composables/useWorkspaceBilling.test.ts
@@ -352,7 +352,7 @@ describe('useWorkspaceBilling', () => {
         // A server ahead of this bundle. Unrepresentable in the current union,
         // which is why the branch cannot be left to the type system alone.
         pending_billing_op_type: 'seat_change'
-      } as unknown as BillingStatusResponse)
+      })
 
       const billing = setupBilling()
       await billing.fetchStatus()

--- a/src/renderer/core/canvas/canvasStore.test.ts
+++ b/src/renderer/core/canvas/canvasStore.test.ts
@@ -93,7 +93,7 @@ describe('useCanvasStore', () => {
       store.initScaleSync()
 
       app.canvas.ds.scale = 2.0
-      app.canvas.ds.onChanged!(app.canvas.ds.scale, app.canvas.ds.offset)
+      app.canvas.ds.onChanged(app.canvas.ds.scale, app.canvas.ds.offset)
 
       expect(originalHandler).toHaveBeenCalledWith(2.0, app.canvas.ds.offset)
     })

--- a/src/renderer/core/canvas/useCanvasInteractions.ts
+++ b/src/renderer/core/canvas/useCanvasInteractions.ts
@@ -39,7 +39,7 @@ export function useCanvasInteractions() {
   const wheelCapturedByFocusedElement = (event: WheelEvent): boolean => {
     const target = event.target as HTMLElement | null
     const captureElement = target?.closest('[data-capture-wheel="true"]')
-    const active = document.activeElement as Element | null
+    const active = document.activeElement
 
     return !!(captureElement && active && captureElement.contains(active))
   }

--- a/src/renderer/core/layout/store/layoutStore.ts
+++ b/src/renderer/core/layout/store/layoutStore.ts
@@ -117,7 +117,7 @@ function makeScopedLayoutKey(
 function parseLayoutKey(key: string): { graphId: UUID; localId: string } {
   const separatorIndex = key.indexOf(':')
   return {
-    graphId: key.slice(0, separatorIndex) as UUID,
+    graphId: key.slice(0, separatorIndex),
     localId: key.slice(separatorIndex + 1)
   }
 }

--- a/src/renderer/core/layout/utils/mappers.ts
+++ b/src/renderer/core/layout/utils/mappers.ts
@@ -25,7 +25,7 @@ export type NodeLayoutMap = Y.Map<StoredNode[keyof StoredNode]>
 const DEFAULT_NODE_RECT: StoredRect = [0, 0, 100, 50]
 
 export function layoutToYNode(layout: NodeLayout): NodeLayoutMap {
-  const ynode = new Y.Map<StoredNode[keyof StoredNode]>() as NodeLayoutMap
+  const ynode = new Y.Map<StoredNode[keyof StoredNode]>()
   ynode.set('id', layout.id)
   ynode.set('rect', [
     layout.position.x,
@@ -64,7 +64,7 @@ export type GroupLayoutMap = Y.Map<StoredGroup[keyof StoredGroup]>
 const DEFAULT_GROUP_RECT: StoredRect = [0, 0, 140, 80]
 
 export function layoutToYGroup(layout: GroupLayout): GroupLayoutMap {
-  const ygroup = new Y.Map<StoredGroup[keyof StoredGroup]>() as GroupLayoutMap
+  const ygroup = new Y.Map<StoredGroup[keyof StoredGroup]>()
   ygroup.set('id', layout.id)
   ygroup.set('rect', [
     layout.position.x,

--- a/src/renderer/core/thumbnail/graphThumbnailRenderer.ts
+++ b/src/renderer/core/thumbnail/graphThumbnailRenderer.ts
@@ -1,4 +1,3 @@
-import type { LGraph } from '@/lib/litegraph/src/litegraph'
 import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import {
@@ -38,7 +37,7 @@ export function createGraphThumbnail(): string | null {
   canvas.height = height
 
   // Render the minimap
-  renderMinimapToCanvas(canvas, graph as LGraph, {
+  renderMinimapToCanvas(canvas, graph, {
     bounds,
     scale,
     settings: {

--- a/src/renderer/extensions/compositor/composables/compositorLayerState.test.ts
+++ b/src/renderer/extensions/compositor/composables/compositorLayerState.test.ts
@@ -491,7 +491,7 @@ describe('resolveInitialLayerState', () => {
     const resolved = resolveInitialLayerState(null, ['hash-a'], bboxes, {
       w: Number.NaN,
       h: 1280
-    } as { w: number; h: number })
+    })
     expect(resolved?.canvas).toBeUndefined()
   })
 

--- a/src/renderer/extensions/firstRunTour/tour/useFirstRunTourController.test.ts
+++ b/src/renderer/extensions/firstRunTour/tour/useFirstRunTourController.test.ts
@@ -17,7 +17,6 @@ const OFFLINE_GRACE_MS = 20_000
 const ACCEPT_DEADLINE_MS = 15_000
 
 const mocks = vi.hoisted(() => {
-  const activeWorkflow = (value: { path: string } | null) => ({ value })
   const queuedJobs: { value: Record<string, { workflow?: unknown }> } = {
     value: {}
   }
@@ -26,7 +25,7 @@ const mocks = vi.hoisted(() => {
     showSubscriptionDialog: vi.fn(),
     workflowStatus: { value: new Map<unknown, string>() },
     executionErrors: { hasNodeError: false, hasPromptError: false },
-    activeWorkflow: activeWorkflow(null),
+    activeWorkflow: { value: null as { path: string } | null },
     queuedJobs,
     linearMode: { value: false },
     vueNodesEnabled: true,

--- a/src/renderer/extensions/firstRunTour/tour/useFirstRunTourController.test.ts
+++ b/src/renderer/extensions/firstRunTour/tour/useFirstRunTourController.test.ts
@@ -16,30 +16,36 @@ const INTRO_PREVIEW_MS = 500
 const OFFLINE_GRACE_MS = 20_000
 const ACCEPT_DEADLINE_MS = 15_000
 
-const mocks = vi.hoisted(() => ({
-  canRunWorkflows: { value: true },
-  showSubscriptionDialog: vi.fn(),
-  workflowStatus: { value: new Map<unknown, string>() },
-  executionErrors: { hasNodeError: false, hasPromptError: false },
-  activeWorkflow: { value: null as unknown },
-  queuedJobs: { value: {} as Record<string, { workflow?: unknown }> },
-  linearMode: { value: false },
-  vueNodesEnabled: true,
-  setSetting: vi.fn(),
-  steps: [] as CoachStep[],
-  runState: { value: 'idle' } as Ref<string>,
-  releaseFirstRunTargets: vi.fn(),
-  engine: {
-    activeTour: null as string | null,
-    lastEnding: null as TourEnding | null,
-    step: null as CoachStep | null,
-    isLast: false,
-    startTour: vi.fn(),
-    next: vi.fn(),
-    skip: vi.fn(),
-    postpone: vi.fn()
+const mocks = vi.hoisted(() => {
+  const activeWorkflow = (value: { path: string } | null) => ({ value })
+  const queuedJobs: { value: Record<string, { workflow?: unknown }> } = {
+    value: {}
   }
-}))
+  return {
+    canRunWorkflows: { value: true },
+    showSubscriptionDialog: vi.fn(),
+    workflowStatus: { value: new Map<unknown, string>() },
+    executionErrors: { hasNodeError: false, hasPromptError: false },
+    activeWorkflow: activeWorkflow(null),
+    queuedJobs,
+    linearMode: { value: false },
+    vueNodesEnabled: true,
+    setSetting: vi.fn(),
+    steps: [] as CoachStep[],
+    runState: { value: 'idle' } as Ref<string>,
+    releaseFirstRunTargets: vi.fn(),
+    engine: {
+      activeTour: null as string | null,
+      lastEnding: null as TourEnding | null,
+      step: null as CoachStep | null,
+      isLast: false,
+      startTour: vi.fn(),
+      next: vi.fn(),
+      skip: vi.fn(),
+      postpone: vi.fn()
+    }
+  }
+})
 
 vi.mock('@/composables/billing/useBillingContext', () => ({
   useBillingContext: () => ({

--- a/src/renderer/extensions/layerEditor/composables/useLayerEditorSession.test.ts
+++ b/src/renderer/extensions/layerEditor/composables/useLayerEditorSession.test.ts
@@ -39,10 +39,10 @@ class FakeCompositor implements Compositor {
   }
   freeTarget() {}
   targetTexture(): WebGLTexture {
-    return {} as WebGLTexture
+    return {}
   }
   upload(): WebGLTexture {
-    return {} as WebGLTexture
+    return {}
   }
   readback(): ImageData {
     return {

--- a/src/renderer/extensions/layerEditor/engine/compositor/webglCompositor.ts
+++ b/src/renderer/extensions/layerEditor/engine/compositor/webglCompositor.ts
@@ -211,7 +211,7 @@ function link(
   vs: WebGLShader,
   fs: WebGLShader
 ): WebGLProgram {
-  const p = gl.createProgram()!
+  const p = gl.createProgram()
   gl.attachShader(p, vs)
   gl.attachShader(p, fs)
   gl.linkProgram(p)
@@ -268,7 +268,7 @@ export function createWebGLCompositor(): Compositor {
 
   function makeTarget(w: number, h: number): Target | null {
     const g = gl!
-    const tex = g.createTexture()!
+    const tex = g.createTexture()
     g.bindTexture(g.TEXTURE_2D, tex)
     g.texImage2D(
       g.TEXTURE_2D,
@@ -285,7 +285,7 @@ export function createWebGLCompositor(): Compositor {
     g.texParameteri(g.TEXTURE_2D, g.TEXTURE_MAG_FILTER, g.LINEAR)
     g.texParameteri(g.TEXTURE_2D, g.TEXTURE_WRAP_S, g.CLAMP_TO_EDGE)
     g.texParameteri(g.TEXTURE_2D, g.TEXTURE_WRAP_T, g.CLAMP_TO_EDGE)
-    const fbo = g.createFramebuffer()!
+    const fbo = g.createFramebuffer()
     g.bindFramebuffer(g.FRAMEBUFFER, fbo)
     g.framebufferTexture2D(
       g.FRAMEBUFFER,
@@ -419,7 +419,7 @@ export function createWebGLCompositor(): Compositor {
     src: HTMLCanvasElement | ImageBitmap | OffscreenCanvas
   ): WebGLTexture {
     const g = gl!
-    const tex = g.createTexture()!
+    const tex = g.createTexture()
     g.bindTexture(g.TEXTURE_2D, tex)
     g.pixelStorei(g.UNPACK_FLIP_Y_WEBGL, true)
     g.texImage2D(g.TEXTURE_2D, 0, g.RGBA, g.RGBA, g.UNSIGNED_BYTE, src)
@@ -509,14 +509,11 @@ export function createWebGLCompositor(): Compositor {
         c.width = width
         c.height = height
       }
-      const ctx = (c as HTMLCanvasElement | OffscreenCanvas).getContext(
-        'webgl2',
-        {
-          alpha: true,
-          premultipliedAlpha: false,
-          preserveDrawingBuffer: true
-        }
-      ) as WebGL2RenderingContext | null
+      const ctx = c.getContext('webgl2', {
+        alpha: true,
+        premultipliedAlpha: false,
+        preserveDrawingBuffer: true
+      })
       if (!ctx) return false
       if (!ctx.getExtension('EXT_color_buffer_float')) return false
       canvas = c
@@ -850,7 +847,7 @@ export function createWebGLCompositor(): Compositor {
       g.enable(g.SCISSOR_TEST)
       g.scissor(clip.x, height - (clip.y + clip.h), clip.w, clip.h)
     }
-    g.useProgram(presentProg!)
+    g.useProgram(presentProg)
     g.bindFramebuffer(g.FRAMEBUFFER, null)
     g.viewport(0, 0, width, height)
     g.clearColor(0, 0, 0, 0)
@@ -864,7 +861,7 @@ export function createWebGLCompositor(): Compositor {
 
   function blit(src: Target, dst: Target): void {
     const g = gl!
-    g.useProgram(copyProg!)
+    g.useProgram(copyProg)
     g.bindFramebuffer(g.FRAMEBUFFER, dst.fbo)
     g.viewport(0, 0, dst.width, dst.height)
     g.activeTexture(g.TEXTURE0)

--- a/src/renderer/extensions/layerEditor/engine/document.ts
+++ b/src/renderer/extensions/layerEditor/engine/document.ts
@@ -29,7 +29,7 @@ export function walk(
   for (const child of root.children) {
     const recurse = fn(child, root, depth)
     if (recurse !== false && child.kind === 'group') {
-      walk(child as GroupData, fn, depth + 1)
+      walk(child, fn, depth + 1)
     }
   }
 }

--- a/src/renderer/extensions/layerEditor/engine/editor/editor.selection.test.ts
+++ b/src/renderer/extensions/layerEditor/engine/editor/editor.selection.test.ts
@@ -25,10 +25,10 @@ class FakeCompositor implements Compositor {
   }
   freeTarget() {}
   targetTexture(): WebGLTexture {
-    return {} as WebGLTexture
+    return {}
   }
   upload(): WebGLTexture {
-    return {} as WebGLTexture
+    return {}
   }
   readback(): ImageData {
     return {

--- a/src/renderer/extensions/layerEditor/engine/editor/editor.test.ts
+++ b/src/renderer/extensions/layerEditor/engine/editor/editor.test.ts
@@ -30,10 +30,10 @@ class FakeCompositor implements Compositor {
   }
   freeTarget() {}
   targetTexture(): WebGLTexture {
-    return {} as WebGLTexture
+    return {}
   }
   upload(): WebGLTexture {
-    return {} as WebGLTexture
+    return {}
   }
   readback(): ImageData {
     const { w, h } = this.readbackSize

--- a/src/renderer/extensions/layerEditor/engine/editor/editor.ts
+++ b/src/renderer/extensions/layerEditor/engine/editor/editor.ts
@@ -331,7 +331,7 @@ export function createEditor(opts: EditorOptions): Editor {
 
   function activeRaster(): RasterData | null {
     const loc = activeLocation()
-    return loc && loc.node.kind === 'raster' ? (loc.node as RasterData) : null
+    return loc && loc.node.kind === 'raster' ? loc.node : null
   }
 
   function currentSelectionMask(): GrayMask | null {
@@ -650,7 +650,7 @@ export function createEditor(opts: EditorOptions): Editor {
       let toParent: GroupData
       let toIndex: number
       if (sib && sib.kind === 'group') {
-        toParent = sib as GroupData
+        toParent = sib
         toIndex = dir === 1 ? 0 : toParent.children.length
       } else if (sib) {
         toParent = parent
@@ -680,10 +680,10 @@ export function createEditor(opts: EditorOptions): Editor {
           ? findNode(doc.root, parentId)?.node
           : doc.root
       if (!target || target.kind !== 'group') return false
-      const toParent = target as GroupData
+      const toParent = target
       if (loc.node.kind === 'group') {
         if (toParent.id === loc.node.id) return false
-        if (findNode(loc.node as GroupData, toParent.id)) return false
+        if (findNode(loc.node, toParent.id)) return false
       }
       let to = Math.max(0, Math.min(toIndex, toParent.children.length))
       loc.parent.children.splice(loc.index, 1)

--- a/src/renderer/extensions/layerEditor/engine/editor/pickOps.test.ts
+++ b/src/renderer/extensions/layerEditor/engine/editor/pickOps.test.ts
@@ -24,7 +24,7 @@ function mkRaster(
     contentId,
     naturalWidth: w,
     naturalHeight: h
-  } as RasterData
+  }
 }
 
 function mkText(

--- a/src/renderer/extensions/layerEditor/engine/editor/pickOps.ts
+++ b/src/renderer/extensions/layerEditor/engine/editor/pickOps.ts
@@ -1,5 +1,5 @@
 import type { ContentStore } from '../content'
-import type { GroupData, RasterData, SceneNode, Vec2 } from '../node'
+import type { RasterData, SceneNode, Vec2 } from '../node'
 import { toLocalFrame } from '../tools/transformMath'
 
 export const PICK_OPACITY_THRESHOLD = 0.25
@@ -66,14 +66,14 @@ export function layerOpacityAt(
   switch (node.kind) {
     case 'group': {
       let best = 0
-      for (const child of (node as GroupData).children) {
+      for (const child of node.children) {
         best = Math.max(best, layerOpacityAt(child, pt, content, sample))
         if (best >= 1) break
       }
       return best * node.opacity
     }
     case 'raster':
-      return rasterAlphaAt(node as RasterData, pt, content, sample)
+      return rasterAlphaAt(node, pt, content, sample)
     default:
       return boxAlphaAt(node, pt)
   }

--- a/src/renderer/extensions/layerEditor/engine/nodeKind.ts
+++ b/src/renderer/extensions/layerEditor/engine/nodeKind.ts
@@ -42,7 +42,7 @@ export interface NodeKind<T extends NodeBase = NodeBase> {
 const registry = new Map<string, NodeKind>()
 
 export function registerNodeKind<T extends NodeBase>(kind: NodeKind<T>): void {
-  registry.set(kind.kind, kind as unknown as NodeKind)
+  registry.set(kind.kind, kind)
 }
 
 export function getNodeKind(kind: string): NodeKind {

--- a/src/renderer/extensions/layerEditor/engine/render/renderStack.test.ts
+++ b/src/renderer/extensions/layerEditor/engine/render/renderStack.test.ts
@@ -104,10 +104,10 @@ class FakeCompositor implements Compositor {
     this.freed.push(handle.id)
   }
   targetTexture(): WebGLTexture {
-    return {} as WebGLTexture
+    return {}
   }
   upload(): WebGLTexture {
-    return {} as WebGLTexture
+    return {}
   }
   readback(): ImageData {
     return new ImageData(1, 1)

--- a/src/renderer/extensions/layerEditor/engine/render/renderStack.ts
+++ b/src/renderer/extensions/layerEditor/engine/render/renderStack.ts
@@ -237,7 +237,7 @@ function buildInputs(
       if (!node.visible || node.opacity <= 0) continue
 
       if (node.kind === 'group') {
-        const g = node as GroupData
+        const g = node
         const sub = buildInputs(g, doc, deps, used)
         if (g.passThrough) {
           inputs.push(...sub.inputs)

--- a/src/renderer/extensions/layerEditor/engine/snapping.test.ts
+++ b/src/renderer/extensions/layerEditor/engine/snapping.test.ts
@@ -145,7 +145,7 @@ describe('equidistance snapping', () => {
     expect(g).toBeTruthy()
     expect(g!.spans).toHaveLength(2)
     const [s1, s2] = g!.spans!
-    expect(s1![1] - s1![0]).toBeCloseTo(s2![1] - s2![0], 6)
+    expect(s1[1] - s1[0]).toBeCloseTo(s2[1] - s2[0], 6)
   })
   it('continues an existing left-side spacing', () => {
     const A = { x: 0, y: 0.4, w: 0.1, h: 0.2 }

--- a/src/renderer/extensions/layerEditor/engine/snapping.ts
+++ b/src/renderer/extensions/layerEditor/engine/snapping.ts
@@ -109,8 +109,8 @@ function eqCandidatesAxis(
     }
   }
   if (lefts.length >= 2) {
-    const L1 = lefts[0]!
-    const L2 = lefts[1]!
+    const L1 = lefts[0]
+    const L2 = lefts[1]
     const gap = p(L1) - (p(L2) + s(L2))
     if (gap >= 0) {
       const pos = p(L1) + s(L1) + gap
@@ -130,8 +130,8 @@ function eqCandidatesAxis(
     }
   }
   if (rights.length >= 2) {
-    const R1 = rights[0]!
-    const R2 = rights[1]!
+    const R1 = rights[0]
+    const R2 = rights[1]
     const gap = p(R2) - (p(R1) + s(R1))
     if (gap >= 0) {
       const pos = p(R1) - gap - s(rect)

--- a/src/renderer/extensions/layerEditor/engine/tools/selectTool.ts
+++ b/src/renderer/extensions/layerEditor/engine/tools/selectTool.ts
@@ -2,7 +2,7 @@ import { SetTransformCommand } from '../commands/setTransform'
 import { filterTopmost, findNode } from '../document'
 import { CommandGroup, Dirty } from '../history'
 import type { Command } from '../history'
-import type { GroupData, SceneNode, Transform, Vec2 } from '../node'
+import type { SceneNode, Transform, Vec2 } from '../node'
 import { getNodeKind } from '../nodeKind'
 import { defaultControl } from '../tool'
 import type { Overlay, Tool, ToolContext, ToolControl, ToolDef } from '../tool'
@@ -32,7 +32,7 @@ function nodeBounds(node: SceneNode): Transform {
 function moveLeaves(node: SceneNode): SceneNode[] {
   if (node.locks.position) return []
   if (node.kind !== 'group') return [node]
-  return (node as GroupData).children.flatMap((c) => moveLeaves(c))
+  return node.children.flatMap((c) => moveLeaves(c))
 }
 
 class SelectTool implements Tool {

--- a/src/renderer/extensions/layerEditor/psdExport.ts
+++ b/src/renderer/extensions/layerEditor/psdExport.ts
@@ -3,14 +3,7 @@ import type { Layer, LayerMaskData, LinkedFile, Psd } from 'ag-psd'
 import type { Compositor } from './engine/compositor'
 import type { ContentEntry, ContentStore } from './engine/content'
 import type { Document } from './engine/document'
-import type {
-  FillData,
-  GroupData,
-  RasterData,
-  Rect,
-  SceneNode,
-  Transform
-} from './engine/node'
+import type { RasterData, Rect, SceneNode, Transform } from './engine/node'
 import { getNodeKind } from './engine/nodeKind'
 import type { RenderNodeCtx } from './engine/nodeKind'
 import { placeBitmap } from './engine/render/place'
@@ -128,7 +121,7 @@ async function buildLayer(
     mask: maskData(node, deps)
   }
   if (node.kind === 'group') {
-    const g = node as GroupData
+    const g = node
     if (g.passThrough) layer.blendMode = 'pass through'
     layer.opened = true
     layer.children = []
@@ -145,10 +138,9 @@ async function buildLayer(
     layer.right = placed.left + placed.canvas.width
     layer.bottom = placed.top + placed.canvas.height
   }
-  if (node.kind === 'fill')
-    layer.vectorFill = fillToVectorContent((node as FillData).fill)
+  if (node.kind === 'fill') layer.vectorFill = fillToVectorContent(node.fill)
   else if (node.kind === 'raster')
-    await applyPlacedLayer(layer, node as RasterData, deps, linkedFiles)
+    await applyPlacedLayer(layer, node, deps, linkedFiles)
   return layer
 }
 

--- a/src/renderer/extensions/linearMode/OutputHistory.test.ts
+++ b/src/renderer/extensions/linearMode/OutputHistory.test.ts
@@ -178,7 +178,7 @@ function lastEmission(result: RenderResult): OutputSelection {
     | Array<[OutputSelection]>
     | undefined
   expect(emitted).toBeDefined()
-  return emitted![emitted!.length - 1][0] as OutputSelection
+  return emitted![emitted!.length - 1][0]
 }
 
 function historySelectableItems(): HTMLElement[] {

--- a/src/renderer/extensions/linearMode/linearOutputStore.test.ts
+++ b/src/renderer/extensions/linearMode/linearOutputStore.test.ts
@@ -82,7 +82,7 @@ function makeExecutedDetail(
     node: nodeId,
     display_node: nodeId,
     output: { images }
-  } as ExecutedWsMessage
+  }
 }
 
 describe('linearOutputStore', () => {

--- a/src/renderer/extensions/minimap/composables/useMinimap.intervalLifecycle.test.ts
+++ b/src/renderer/extensions/minimap/composables/useMinimap.intervalLifecycle.test.ts
@@ -111,7 +111,7 @@ describe('useMinimap change-detection interval', () => {
         ) as HTMLCanvasElement['getContext']
     })
     const container = {
-      getBoundingClientRect: vi.fn(() => new DOMRect(0, 0, 250, 200) as DOMRect)
+      getBoundingClientRect: vi.fn(() => new DOMRect(0, 0, 250, 200))
     }
 
     const minimap = useMinimap({
@@ -252,7 +252,7 @@ describe('useMinimap change-detection interval', () => {
     // taken inside init() sees a null canvasRef and never starts the loop.
     const canvasRef = shallowRef<HTMLCanvasElement | null>(null)
     const container = {
-      getBoundingClientRect: vi.fn(() => new DOMRect(0, 0, 250, 200) as DOMRect)
+      getBoundingClientRect: vi.fn(() => new DOMRect(0, 0, 250, 200))
     }
     const minimap = useMinimap({
       containerRefMaybe: shallowRef(

--- a/src/renderer/extensions/minimap/composables/useMinimap.progressBaseline.test.ts
+++ b/src/renderer/extensions/minimap/composables/useMinimap.progressBaseline.test.ts
@@ -58,6 +58,8 @@ const {
     pollPauses: 0,
     pollResumes: 0
   }
+  const progressStates: Record<string, NodeProgressState> = {}
+  const canvasStore = (canvas: unknown) => ({ canvas })
   return {
     counters,
     defaultSettingStore: {
@@ -65,8 +67,8 @@ const {
       get: vi.fn(() => true),
       set: vi.fn().mockResolvedValue(undefined)
     },
-    mockCanvasStore: { canvas: null as unknown },
-    progressStates: {} as Record<string, NodeProgressState>,
+    mockCanvasStore: canvasStore(null),
+    progressStates,
     linkTopologies: [] as Array<{
       originNodeId: string
       targetNodeId: string

--- a/src/renderer/extensions/minimap/composables/useMinimapGraph.test.ts
+++ b/src/renderer/extensions/minimap/composables/useMinimapGraph.test.ts
@@ -181,7 +181,7 @@ describe('useMinimapGraph', () => {
 
     // Call the method directly and ensure it is a no-op
     const testNode = { id: '9' } as LGraphNode
-    buriedWrapper!(testNode)
+    buriedWrapper(testNode)
 
     expect(originalOnConnectionChange).toHaveBeenCalledWith(testNode)
     expect(onGraphChangedMock).not.toHaveBeenCalled()

--- a/src/renderer/extensions/vueNodes/composables/useNodeEventHandlers.test.ts
+++ b/src/renderer/extensions/vueNodes/composables/useNodeEventHandlers.test.ts
@@ -90,7 +90,7 @@ describe('useNodeEventHandlers', () => {
       const { handleNodeSelect } = useNodeEventHandlers()
       const { canvas } = useCanvasStore()
 
-      mockNode!.selected = false
+      mockNode.selected = false
 
       const ctrlClickEvent = new PointerEvent('pointerdown', {
         bubbles: true,
@@ -117,8 +117,8 @@ describe('useNodeEventHandlers', () => {
       const { handleNodeSelect } = useNodeEventHandlers()
       const { canvas } = useCanvasStore()
 
-      mockNode!.selected = true
-      mockNode!.flags.pinned = false
+      mockNode.selected = true
+      mockNode.flags.pinned = false
 
       const ctrlClickEvent = new PointerEvent('pointerdown', {
         bubbles: true,
@@ -144,8 +144,8 @@ describe('useNodeEventHandlers', () => {
       const { handleNodeSelect } = useNodeEventHandlers()
       const { canvas } = useCanvasStore()
 
-      mockNode!.selected = false
-      mockNode!.flags.pinned = false
+      mockNode.selected = false
+      mockNode.flags.pinned = false
 
       const metaClickEvent = new PointerEvent('pointerdown', {
         bubbles: true,
@@ -172,8 +172,8 @@ describe('useNodeEventHandlers', () => {
       const { handleNodeSelect } = useNodeEventHandlers()
       const { canvas } = useCanvasStore()
 
-      mockNode!.selected = false
-      mockNode!.flags.pinned = false
+      mockNode.selected = false
+      mockNode.flags.pinned = false
 
       const shiftClickEvent = new PointerEvent('pointerdown', {
         bubbles: true,
@@ -199,7 +199,7 @@ describe('useNodeEventHandlers', () => {
       const { handleNodeSelect } = useNodeEventHandlers()
       const { canvas } = useCanvasStore()
 
-      mockNode!.selected = true
+      mockNode.selected = true
       canvasSelectedItems.push({ id: 'node-1' }, { id: 'node-2' })
 
       const event = new PointerEvent('pointerdown', {
@@ -217,7 +217,7 @@ describe('useNodeEventHandlers', () => {
     it('should bring node to front when not pinned', () => {
       const { handleNodeSelect } = useNodeEventHandlers()
 
-      mockNode!.flags.pinned = false
+      mockNode.flags.pinned = false
 
       const event = new PointerEvent('pointerdown')
       handleNodeSelect(event, testNodeId)
@@ -232,7 +232,7 @@ describe('useNodeEventHandlers', () => {
     it('should not bring pinned node to front', () => {
       const { handleNodeSelect } = useNodeEventHandlers()
 
-      mockNode!.flags.pinned = true
+      mockNode.flags.pinned = true
 
       const event = new PointerEvent('pointerdown')
       handleNodeSelect(event, testNodeId)
@@ -246,7 +246,7 @@ describe('useNodeEventHandlers', () => {
       const { toggleNodeSelectionAfterPointerUp } = useNodeEventHandlers()
       const { canvas, updateSelectedItems } = useCanvasStore()
 
-      mockNode!.selected = true
+      mockNode.selected = true
 
       toggleNodeSelectionAfterPointerUp(testNodeId, true)
 
@@ -258,7 +258,7 @@ describe('useNodeEventHandlers', () => {
       const { toggleNodeSelectionAfterPointerUp } = useNodeEventHandlers()
       const { canvas, updateSelectedItems } = useCanvasStore()
 
-      mockNode!.selected = true
+      mockNode.selected = true
 
       toggleNodeSelectionAfterPointerUp(testNodeId, true)
 
@@ -270,7 +270,7 @@ describe('useNodeEventHandlers', () => {
       const { toggleNodeSelectionAfterPointerUp } = useNodeEventHandlers()
       const { canvas, updateSelectedItems } = useCanvasStore()
 
-      mockNode!.selected = true
+      mockNode.selected = true
       canvasSelectedItems.push({ id: 'node-1' }, { id: 'node-2' })
 
       toggleNodeSelectionAfterPointerUp(testNodeId, false)
@@ -284,7 +284,7 @@ describe('useNodeEventHandlers', () => {
       const { toggleNodeSelectionAfterPointerUp } = useNodeEventHandlers()
       const { canvas, updateSelectedItems } = useCanvasStore()
 
-      mockNode!.selected = true
+      mockNode.selected = true
       canvasSelectedItems.push({ id: 'node-1' })
 
       toggleNodeSelectionAfterPointerUp(testNodeId, false)

--- a/src/renderer/extensions/vueNodes/composables/useNodeTooltips.ts
+++ b/src/renderer/extensions/vueNodes/composables/useNodeTooltips.ts
@@ -169,7 +169,7 @@ export function useNodeTooltips(nodeType: MaybeRef<string>) {
 
     return {
       value: tooltipText,
-      showDelay: tooltipDelay as number,
+      showDelay: tooltipDelay,
       hideDelay: 0, // Immediate hiding
       disabled:
         !tooltipsEnabled.value ||

--- a/src/renderer/extensions/vueNodes/composables/useSlotLinkInteraction.autoPan.test.ts
+++ b/src/renderer/extensions/vueNodes/composables/useSlotLinkInteraction.autoPan.test.ts
@@ -13,34 +13,40 @@ const {
   mockSetDirty,
   mockLinkConnector,
   mockAdapter
-} = vi.hoisted(() => ({
-  capturedOnPan: { current: null as ((dx: number, dy: number) => void) | null },
-  capturedAutoPan: {
-    current: null as {
-      updatePointer: ReturnType<typeof vi.fn>
-      start: ReturnType<typeof vi.fn>
-      stop: ReturnType<typeof vi.fn>
-    } | null
-  },
-  capturedHandlers: {} as Record<string, (...args: unknown[]) => void>,
-  mockDs: { offset: [0, 0] as [number, number], scale: 1 },
-  mockSetDirty: vi.fn(),
-  mockLinkConnector: {
-    isConnecting: false,
-    state: { snapLinksPos: null as [number, number] | null },
-    events: {}
-  },
-  mockAdapter: {
-    beginFromOutput: vi.fn(),
-    beginFromInput: vi.fn(),
-    reset: vi.fn(),
-    renderLinks: [] as unknown[],
-    linkConnector: null as unknown,
-    isInputValidDrop: vi.fn(() => false),
-    isOutputValidDrop: vi.fn(() => false),
-    dropOnCanvas: vi.fn()
+} = vi.hoisted(() => {
+  const connector = (value: unknown) => value
+  const capturedHandlers: Record<string, (...args: unknown[]) => void> = {}
+  return {
+    capturedOnPan: {
+      current: null as ((dx: number, dy: number) => void) | null
+    },
+    capturedAutoPan: {
+      current: null as {
+        updatePointer: ReturnType<typeof vi.fn>
+        start: ReturnType<typeof vi.fn>
+        stop: ReturnType<typeof vi.fn>
+      } | null
+    },
+    capturedHandlers,
+    mockDs: { offset: [0, 0] as [number, number], scale: 1 },
+    mockSetDirty: vi.fn(),
+    mockLinkConnector: {
+      isConnecting: false,
+      state: { snapLinksPos: null as [number, number] | null },
+      events: {}
+    },
+    mockAdapter: {
+      beginFromOutput: vi.fn(),
+      beginFromInput: vi.fn(),
+      reset: vi.fn(),
+      renderLinks: [] as unknown[],
+      linkConnector: connector(null),
+      isInputValidDrop: vi.fn(() => false),
+      isOutputValidDrop: vi.fn(() => false),
+      dropOnCanvas: vi.fn()
+    }
   }
-}))
+})
 
 mockAdapter.linkConnector = mockLinkConnector
 

--- a/src/renderer/extensions/vueNodes/composables/useSlotLinkInteraction.autoPan.test.ts
+++ b/src/renderer/extensions/vueNodes/composables/useSlotLinkInteraction.autoPan.test.ts
@@ -14,8 +14,12 @@ const {
   mockLinkConnector,
   mockAdapter
 } = vi.hoisted(() => {
-  const connector = (value: unknown) => value
   const capturedHandlers: Record<string, (...args: unknown[]) => void> = {}
+  const mockLinkConnector = {
+    isConnecting: false,
+    state: { snapLinksPos: null as [number, number] | null },
+    events: {}
+  }
   return {
     capturedOnPan: {
       current: null as ((dx: number, dy: number) => void) | null
@@ -30,25 +34,19 @@ const {
     capturedHandlers,
     mockDs: { offset: [0, 0] as [number, number], scale: 1 },
     mockSetDirty: vi.fn(),
-    mockLinkConnector: {
-      isConnecting: false,
-      state: { snapLinksPos: null as [number, number] | null },
-      events: {}
-    },
+    mockLinkConnector,
     mockAdapter: {
       beginFromOutput: vi.fn(),
       beginFromInput: vi.fn(),
       reset: vi.fn(),
       renderLinks: [] as unknown[],
-      linkConnector: connector(null),
+      linkConnector: mockLinkConnector,
       isInputValidDrop: vi.fn(() => false),
       isOutputValidDrop: vi.fn(() => false),
       dropOnCanvas: vi.fn()
     }
   }
 })
-
-mockAdapter.linkConnector = mockLinkConnector
 
 vi.mock('@/renderer/core/canvas/useAutoPan', () => ({
   AutoPanController: class {

--- a/src/renderer/extensions/vueNodes/interactions/resize/useNodeResize.test.ts
+++ b/src/renderer/extensions/vueNodes/interactions/resize/useNodeResize.test.ts
@@ -21,7 +21,7 @@ vi.mock('@vueuse/core', () => ({
   useEventListener: vi.fn(
     (eventName: string, handler: (...args: unknown[]) => void) => {
       if (eventName === 'pointermove' || eventName === 'pointerup') {
-        eventHandlers[eventName] = handler as (e: PointerEvent) => void
+        eventHandlers[eventName] = handler
       }
       return vi.fn()
     }
@@ -93,7 +93,7 @@ function createMockNodeElement(
       right: width,
       bottom: h,
       toJSON: () => {}
-    } as DOMRect
+    }
   }
   return element
 }
@@ -134,7 +134,7 @@ function startResizeAt(
     currentTarget: handle,
     clientX,
     clientY
-  } as Partial<PointerEvent>)
+  })
   startResize(downEvent, corner)
 }
 
@@ -309,7 +309,7 @@ describe('useNodeResize', () => {
           right: width,
           bottom: h,
           toJSON: () => {}
-        } as DOMRect
+        }
       }
       return element
     }
@@ -338,7 +338,7 @@ describe('useNodeResize', () => {
 
       // First move: clamp uses initial minContentHeight = 150
       simulateMove(0, -300)
-      const firstPayload = cb.mock.calls.at(-1)![0] as ResizeCallbackPayload
+      const firstPayload = cb.mock.calls.at(-1)![0]
       expect(firstPayload.size.height).toBe(150)
 
       // Content reflows taller (e.g. painter switches to compact layout)
@@ -347,7 +347,7 @@ describe('useNodeResize', () => {
       // Second move at the same position must reflect the new minimum,
       // not the value captured at drag start.
       simulateMove(0, -300)
-      const secondPayload = cb.mock.calls.at(-1)![0] as ResizeCallbackPayload
+      const secondPayload = cb.mock.calls.at(-1)![0]
       expect(secondPayload.size.height).toBe(280)
     })
 
@@ -362,14 +362,14 @@ describe('useNodeResize', () => {
       startResizeAt(startResize, h, 'NW')
 
       simulateMove(0, 500)
-      const firstPayload = cb.mock.calls.at(-1)![0] as ResizeCallbackPayload
+      const firstPayload = cb.mock.calls.at(-1)![0]
       expect(firstPayload.size.height).toBe(150)
       expect(firstPayload.position!.y).toBe(450) // 200 + 400 - 150
 
       currentMinHeight = 220
 
       simulateMove(0, 500)
-      const secondPayload = cb.mock.calls.at(-1)![0] as ResizeCallbackPayload
+      const secondPayload = cb.mock.calls.at(-1)![0]
       expect(secondPayload.size.height).toBe(220)
       expect(secondPayload.position!.y).toBe(380) // 200 + 400 - 220
     })
@@ -424,7 +424,7 @@ describe('useNodeResize', () => {
       startResizeAt(startResize, h, 'SE')
       simulateMove(53, 27)
 
-      const payload = cb.mock.calls.at(-1)![0] as ResizeCallbackPayload
+      const payload = cb.mock.calls.at(-1)![0]
       expect(payload.size.width).toBe(350) // 353 -> 350
       expect(payload.size.height).toBe(430) // 427 -> 430
       expect(payload.position).toBeUndefined()
@@ -450,7 +450,7 @@ describe('useNodeResize', () => {
       // applySnapToSize rounds -> 360, 430
       simulateMove(-53, -27)
 
-      const payload = cb.mock.calls.at(-1)![0] as ResizeCallbackPayload
+      const payload = cb.mock.calls.at(-1)![0]
       expect(payload.position).toEqual({ x: 40, y: 170 })
       expect(payload.size).toEqual({ width: 360, height: 430 })
     })
@@ -498,7 +498,7 @@ describe('useNodeResize', () => {
       // First move drives newWidth to 340 (below breakpoint). Probe must use
       // 340, not the DOM's currently-applied 400, to return 280.
       simulateMove(-60, -300)
-      const payload = cb.mock.calls.at(-1)![0] as ResizeCallbackPayload
+      const payload = cb.mock.calls.at(-1)![0]
       expect(payload.size.height).toBe(280)
     })
 

--- a/src/renderer/extensions/vueNodes/layout/ensureCorrectLayoutScale.test.ts
+++ b/src/renderer/extensions/vueNodes/layout/ensureCorrectLayoutScale.test.ts
@@ -234,7 +234,7 @@ describe('ensureCorrectLayoutScale (legacy normalizer)', () => {
     group.pos = [150, 150]
     group.size = [300, 200]
     attachGroupLayout(graph, group)
-    graph.groups!.push(group)
+    graph.groups.push(group)
 
     const applyOperation = vi.spyOn(layoutStore, 'applyOperation')
     ensureCorrectLayoutScale(undefined, graph)
@@ -271,7 +271,7 @@ describe('ensureCorrectLayoutScale (legacy normalizer)', () => {
     group._bounding.set([150, 150, 300, 200])
     const groupPos = group.pos
     const groupSize = group.size
-    graph.groups!.push(group)
+    graph.groups.push(group)
 
     ensureCorrectLayoutScale(undefined, graph)
 

--- a/src/renderer/extensions/vueNodes/widgets/components/DisplayCarousel.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/components/DisplayCarousel.test.ts
@@ -501,8 +501,10 @@ describe('DisplayCarousel Edge Cases', () => {
   })
 
   it('filters out malformed image objects without valid src', () => {
-    const malformedImages = [{}, { randomProp: 'value' }, null, undefined]
-    createGalleriaWrapper(malformedImages as string[])
+    const malformedImages: GalleryValue = JSON.parse(
+      '[{}, {"randomProp":"value"}, null, null]'
+    )
+    createGalleriaWrapper(malformedImages)
 
     // All filtered out: null/undefined removed, then objects without src filtered
     expect(screen.queryByRole('img')).not.toBeInTheDocument()

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetChart.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetChart.test.ts
@@ -34,8 +34,8 @@ function makeWidget(
     value: { labels: [], datasets: [] },
     name: 'test_chart',
     type: 'chart',
-    options: options as ChartWidgetOptions
-  }) as SimplifiedWidget<ChartData, ChartWidgetOptions>
+    options: options
+  })
 }
 
 function renderChart(

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetDOM.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetDOM.test.ts
@@ -4,7 +4,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 const canvasMocks = vi.hoisted(() => ({
   canvas: {
     graph: {
-      getNodeById: vi.fn(() => null as unknown)
+      getNodeById: vi.fn((): unknown => null)
     }
   },
   linearMode: false

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetGalleria.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetGalleria.test.ts
@@ -360,14 +360,11 @@ describe('WidgetGalleria Image Display', () => {
     })
 
     it('handles malformed image objects', () => {
-      const malformedImages = [
-        {}, // Empty object
-        { randomProp: 'value' }, // Object without expected image properties
-        null, // Null value
-        undefined // Undefined value
-      ]
-      const widget = createGalleriaWidget(malformedImages as string[])
-      renderComponent(widget, malformedImages as string[])
+      const malformedImages: GalleryValue = JSON.parse(
+        '[{}, {"randomProp":"value"}, null, null]'
+      )
+      const widget = createGalleriaWidget(malformedImages)
+      renderComponent(widget, malformedImages)
 
       // Null/undefined should be filtered out, leaving only the objects
       const expectedValue = [{}, { randomProp: 'value' }]
@@ -386,17 +383,15 @@ describe('WidgetGalleria Image Display', () => {
 
     it('handles mixed string and object arrays gracefully', () => {
       // This is technically invalid input, but the component should handle it
-      const mixedArray = [
-        'https://example.com/string.jpg',
-        { itemImageSrc: 'https://example.com/object.jpg' },
-        'https://example.com/another-string.jpg'
-      ]
-      const widget = createGalleriaWidget(mixedArray as string[])
+      const mixedArray: GalleryValue = JSON.parse(
+        '["https://example.com/string.jpg",' +
+          '{"itemImageSrc":"https://example.com/object.jpg"},' +
+          '"https://example.com/another-string.jpg"]'
+      )
+      const widget = createGalleriaWidget(mixedArray)
 
       // The component expects consistent typing, but let's test it handles mixed input
-      expect(() =>
-        renderComponent(widget, mixedArray as string[])
-      ).not.toThrow()
+      expect(() => renderComponent(widget, mixedArray)).not.toThrow()
     })
 
     it('handles invalid URL strings', () => {

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetInputNumberGradientSlider.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetInputNumberGradientSlider.test.ts
@@ -46,7 +46,7 @@ function makeWidget(
     value,
     name: 'grad',
     type: 'gradientslider',
-    options: options as IWidgetGradientSliderOptions
+    options: options
   }) as SimplifiedWidget<number, IWidgetGradientSliderOptions>
 }
 

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetRecordAudio.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetRecordAudio.test.ts
@@ -260,7 +260,7 @@ describe('WidgetRecordAudio', () => {
 
   describe('Recording persistence via onRecordingComplete', () => {
     function createAudioWidget(initialSrc = '') {
-      const element = document.createElement('audio') as HTMLAudioElement
+      const element = document.createElement('audio')
       element.src = initialSrc
       return {
         name: 'audioUI',

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetSelectDefault.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetSelectDefault.test.ts
@@ -37,7 +37,7 @@ describe('WidgetSelectDefault', () => {
     name: 'test_combo',
     type: 'combo',
     value: undefined,
-    options: { values, ...options } as SimplifiedWidget['options']
+    options: { values, ...options }
   })
 
   function renderComponent(

--- a/src/renderer/extensions/vueNodes/widgets/composables/useBoundingBoxesWidget.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useBoundingBoxesWidget.ts
@@ -19,6 +19,6 @@ export const useBoundingBoxesWidget = (): ComfyWidgetConstructorV2 => {
       serialize: true,
       canvasOnly: false,
       hideInPanel: true
-    }) as IBaseWidget
+    })
   }
 }

--- a/src/renderer/extensions/vueNodes/widgets/composables/useColorsWidget.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useColorsWidget.ts
@@ -13,6 +13,6 @@ export const useColorsWidget = (): ComfyWidgetConstructorV2 => {
     return node.addWidget('colors', spec.name, defaultValue, null, {
       serialize: true,
       canvasOnly: false
-    }) as IBaseWidget
+    })
   }
 }

--- a/src/renderer/extensions/vueNodes/widgets/composables/useImagePreviewWidget.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useImagePreviewWidget.test.ts
@@ -188,7 +188,7 @@ describe('useImagePreviewWidget', () => {
 
       const widget = getWidget(node1)
       const node2 = createMockNode({ id: 2 })
-      const copy = widget.createCopyForNode!(node2)
+      const copy = widget.createCopyForNode(node2)
 
       expect(copy.name).toBe('preview')
       expect(copy.type).toBe('custom')

--- a/src/renderer/extensions/vueNodes/widgets/composables/usePainterWidget.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/usePainterWidget.ts
@@ -11,6 +11,6 @@ export const usePainterWidget = (): ComfyWidgetConstructorV2 => {
       (inputSpec.default as string) ?? '',
       null,
       { serialize: true, canvasOnly: false }
-    ) as IBaseWidget
+    )
   }
 }

--- a/src/renderer/glsl/useGLSLPreview.ts
+++ b/src/renderer/glsl/useGLSLPreview.ts
@@ -4,7 +4,6 @@ import { computed, effectScope, onScopeDispose, ref, toValue, watch } from 'vue'
 import type { ComputedRef, EffectScope, MaybeRefOrGetter, Ref } from 'vue'
 import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
 import type { Subgraph } from '@/lib/litegraph/src/subgraph/Subgraph'
-import type { UUID } from '@/utils/uuid'
 import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
 import { useNodeOutputStore } from '@/stores/nodeOutputStore'
 import { useWidgetValueStore } from '@/stores/widgetValueStore'
@@ -168,9 +167,7 @@ function createInnerPreview(
     )
   })()
 
-  const graphId = computed(
-    () => nodeRef.value?.graph?.rootGraph?.id as UUID | undefined
-  )
+  const graphId = computed(() => nodeRef.value?.graph?.rootGraph?.id)
 
   const nodeId = computed(() => {
     const id = nodeRef.value?.id
@@ -249,7 +246,7 @@ function createInnerPreview(
     const node = nodeRef.value
     const inner = innerGLSLNode
     if (!node?.isSubgraphNode() || !inner) return null
-    return extractUniformSources(inner, node.subgraph as Subgraph, node)
+    return extractUniformSources(inner, node.subgraph, node)
   })
 
   const { floatValues, intValues, boolValues, curveValues } = useGLSLUniforms(

--- a/src/renderer/glsl/useGLSLUniforms.ts
+++ b/src/renderer/glsl/useGLSLUniforms.ts
@@ -232,7 +232,7 @@ export function useGLSLUniforms(
             hostWidgetId ?? widgetId(gId, nId, widgetName)
           )
           const value = widget?.value ?? directValue()
-          return isCurveData(value) ? (value as CurveData) : null
+          return isCurveData(value) ? value : null
         })
         .filter((v): v is CurveData => v !== null)
     }
@@ -248,7 +248,7 @@ export function useGLSLUniforms(
 
       const widget = widgetValueStore.getWidget(widgetId(gId, nId, inputName))
       if (widget && isCurveData(widget.value)) {
-        values.push(widget.value as CurveData)
+        values.push(widget.value)
         continue
       }
 

--- a/src/schemas/nodeDef/inputSpecUtil.test.ts
+++ b/src/schemas/nodeDef/inputSpecUtil.test.ts
@@ -55,7 +55,7 @@ describe('flattenInputSpecs', () => {
       output_is_list: [false],
       output_name: ['video'],
       output_node: false
-    } as ComfyNodeDefV1
+    }
 
     const nodeDefImpl = new ComfyNodeDefImpl(nodeDef)
     const result = flattenInputSpecs(nodeDefImpl.inputs)
@@ -91,7 +91,7 @@ describe('flattenInputSpecs', () => {
       output_is_list: [],
       output_name: [],
       output_node: false
-    } as ComfyNodeDefV1)
+    })
 
     const result = flattenInputSpecs(nodeDefImpl.inputs)
 
@@ -143,7 +143,7 @@ describe('flattenInputSpecs', () => {
       output_is_list: [],
       output_name: [],
       output_node: false
-    } as ComfyNodeDefV1
+    }
 
     const nodeDefImpl = new ComfyNodeDefImpl(nodeDef)
     const result = flattenInputSpecs(nodeDefImpl.inputs)
@@ -171,7 +171,7 @@ describe('flattenInputSpecs', () => {
       output_is_list: [],
       output_name: [],
       output_node: false
-    } as ComfyNodeDefV1
+    }
 
     const nodeDefImpl = new ComfyNodeDefImpl(nodeDef)
 
@@ -197,7 +197,7 @@ describe('flattenInputSpecs', () => {
       output_is_list: [],
       output_name: [],
       output_node: false
-    } as ComfyNodeDefV1
+    }
 
     const nodeDefImpl = new ComfyNodeDefImpl(nodeDef)
 

--- a/src/services/litegraphService.ts
+++ b/src/services/litegraphService.ts
@@ -27,8 +27,6 @@ import type {
   GraphAddOptions,
   IContextMenuValue,
   INodeInputSlot,
-  INodeOutputSlot,
-  IWidget,
   Point,
   Subgraph
 } from '@/lib/litegraph/src/litegraph'
@@ -91,7 +89,7 @@ async function reencodeAsPngBlob(
   width: number,
   height: number
 ): Promise<Blob> {
-  const canvas = $el('canvas', { width, height }) as HTMLCanvasElement
+  const canvas = $el('canvas', { width, height })
   const ctx = canvas.getContext('2d')
   if (!ctx) throw new Error('Could not get canvas context')
 
@@ -494,15 +492,11 @@ export const useLitegraphService = () => {
             if (!output) return outputData as ISerialisableNodeOutput
 
             return outputData
-              ? ({
+              ? {
                   ...outputData,
                   ...pick(output, RESERVED_KEYS)
-                } as ISerialisableNodeOutput)
-              : outputAsSerialisable(
-                  output as INodeOutputSlot & { widget?: IWidget },
-                  this,
-                  index
-                )
+                }
+              : outputAsSerialisable(output, this, index)
           }
         )
 
@@ -601,15 +595,11 @@ export const useLitegraphService = () => {
             if (!output) return outputData as ISerialisableNodeOutput
 
             return outputData
-              ? ({
+              ? {
                   ...outputData,
                   ...pick(output, RESERVED_KEYS)
-                } as ISerialisableNodeOutput)
-              : outputAsSerialisable(
-                  output as INodeOutputSlot & { widget?: IWidget },
-                  this,
-                  index
-                )
+                }
+              : outputAsSerialisable(output, this, index)
           }
         )
 

--- a/src/services/load3dService.test.ts
+++ b/src/services/load3dService.test.ts
@@ -193,14 +193,8 @@ describe('load3dService', () => {
       const viewer = makeViewer()
       const factory = vi.fn().mockReturnValue(viewer)
 
-      const first = svc.getOrCreateViewerSync(
-        node,
-        factory as unknown as typeof useLoad3dViewerMock
-      )
-      const second = svc.getOrCreateViewerSync(
-        node,
-        factory as unknown as typeof useLoad3dViewerMock
-      )
+      const first = svc.getOrCreateViewerSync(node, factory)
+      const second = svc.getOrCreateViewerSync(node, factory)
 
       expect(first).toBe(viewer)
       expect(second).toBe(viewer)
@@ -423,7 +417,7 @@ describe('load3dService', () => {
         scene.add(o)
       })
       const modelManager = {
-        currentModel: existingModel as THREE.Object3D | null,
+        currentModel: existingModel,
         originalModel: null as unknown,
         materialMode: 'original',
         currentUpDirection: 'original',

--- a/src/services/useNewUserService.ts
+++ b/src/services/useNewUserService.ts
@@ -12,7 +12,7 @@ function hasV2DraftHistory(raw: string | null): boolean {
     const orderLength = Array.isArray(parsed.order) ? parsed.order.length : 0
     const entriesCount =
       parsed.entries && typeof parsed.entries === 'object'
-        ? Object.keys(parsed.entries as Record<string, unknown>).length
+        ? Object.keys(parsed.entries).length
         : 0
     return orderLength > 0 || entriesCount > 0
   } catch {

--- a/src/stores/__tests__/authTokenPriority.test.ts
+++ b/src/stores/__tests__/authTokenPriority.test.ts
@@ -412,7 +412,7 @@ describe('auth token priority chain', () => {
       mockClearWorkspaceContext.mockClear()
       mockResetForIdentityChange.mockClear()
 
-      authStateCallback({ ...mockUser } as MockUser)
+      authStateCallback({ ...mockUser })
 
       expect(mockClearWorkspaceContext).not.toHaveBeenCalled()
       expect(mockResetForIdentityChange).not.toHaveBeenCalled()

--- a/src/stores/appModeStore.test.ts
+++ b/src/stores/appModeStore.test.ts
@@ -107,7 +107,7 @@ function createBuilderWorkflowWithOutputs(
 ): LoadedComfyWorkflow {
   mockResolveNode.mockReturnValue(fromAny({ id: 1 }))
   const workflow = createBuilderWorkflow(activeMode)
-  workflow.changeTracker!.activeState!.extra ??= {}
+  workflow.changeTracker.activeState.extra ??= {}
   workflow.changeTracker.activeState.extra.linearData = {
     inputs: [],
     outputs: [toNodeId(1)]
@@ -173,7 +173,7 @@ describe('appModeStore', () => {
 
       store.enterBuilder()
 
-      expect(workflowStore.activeWorkflow!.activeMode).toBe('builder:arrange')
+      expect(workflowStore.activeWorkflow.activeMode).toBe('builder:arrange')
     })
 
     it('navigates to builder:inputs when in app mode without outputs', () => {
@@ -181,7 +181,7 @@ describe('appModeStore', () => {
 
       store.enterBuilder()
 
-      expect(workflowStore.activeWorkflow!.activeMode).toBe('builder:inputs')
+      expect(workflowStore.activeWorkflow.activeMode).toBe('builder:inputs')
     })
 
     it('navigates to builder:inputs when in graph mode with outputs', () => {
@@ -190,7 +190,7 @@ describe('appModeStore', () => {
 
       store.enterBuilder()
 
-      expect(workflowStore.activeWorkflow!.activeMode).toBe('builder:inputs')
+      expect(workflowStore.activeWorkflow.activeMode).toBe('builder:inputs')
     })
 
     it('navigates to builder:inputs when in graph mode without outputs', () => {
@@ -198,7 +198,7 @@ describe('appModeStore', () => {
 
       store.enterBuilder()
 
-      expect(workflowStore.activeWorkflow!.activeMode).toBe('builder:inputs')
+      expect(workflowStore.activeWorkflow.activeMode).toBe('builder:inputs')
     })
 
     it('shows empty workflow dialog when graph has no nodes', () => {
@@ -213,7 +213,7 @@ describe('appModeStore', () => {
           onDismiss: expect.any(Function)
         })
       )
-      expect(workflowStore.activeWorkflow!.activeMode).toBe('graph')
+      expect(workflowStore.activeWorkflow.activeMode).toBe('graph')
     })
 
     it('prunes selections from workflow state on entry', () => {
@@ -307,7 +307,7 @@ describe('appModeStore', () => {
 
       expect(store.selectedInputs).toEqual([[entitySeed, 'seed']])
       expect(store.selectedOutputs).toEqual([toNodeId(1)])
-      expect(workflowStore.activeWorkflow!.activeMode).toBe('graph')
+      expect(workflowStore.activeWorkflow.activeMode).toBe('graph')
     })
   })
 
@@ -807,12 +807,12 @@ describe('appModeStore', () => {
       const workflow = createBuilderWorkflow()
       workflowStore.activeWorkflow = workflow
       await nextTick()
-      vi.mocked(workflow.changeTracker!.captureCanvasState).mockClear()
+      vi.mocked(workflow.changeTracker.captureCanvasState).mockClear()
 
       store.selectedInputs.push([42, 'prompt'])
       await nextTick()
 
-      expect(workflow.changeTracker!.captureCanvasState).toHaveBeenCalled()
+      expect(workflow.changeTracker.captureCanvasState).toHaveBeenCalled()
     })
 
     it('calls captureCanvasState when input is deselected', async () => {
@@ -820,12 +820,12 @@ describe('appModeStore', () => {
       workflowStore.activeWorkflow = workflow
       store.selectedInputs.push([42, 'prompt'])
       await nextTick()
-      vi.mocked(workflow.changeTracker!.captureCanvasState).mockClear()
+      vi.mocked(workflow.changeTracker.captureCanvasState).mockClear()
 
       store.selectedInputs.splice(0, 1)
       await nextTick()
 
-      expect(workflow.changeTracker!.captureCanvasState).toHaveBeenCalled()
+      expect(workflow.changeTracker.captureCanvasState).toHaveBeenCalled()
     })
 
     it('reflects input changes in linearData', async () => {
@@ -975,7 +975,7 @@ describe('appModeStore', () => {
       store.enterBuilder()
       await nextTick()
 
-      expect(workflowStore.activeWorkflow!.activeMode).toBe('builder:arrange')
+      expect(workflowStore.activeWorkflow.activeMode).toBe('builder:arrange')
       expect(mockSettings.set).not.toHaveBeenCalledWith(
         'Comfy.VueNodes.Enabled',
         expect.anything()

--- a/src/stores/assetExportStore.ts
+++ b/src/stores/assetExportStore.ts
@@ -152,7 +152,7 @@ export const useAssetExportStore = defineStore('assetExport', () => {
             bytes_total: exp.bytesTotal,
             bytes_processed: exp.bytesTotal,
             progress: task.status === 'completed' ? 1 : exp.progress,
-            status: task.status as 'completed' | 'failed',
+            status: task.status,
             error: task.error_message ?? (result?.error as string)
           })
         }

--- a/src/stores/authStore.test.ts
+++ b/src/stores/authStore.test.ts
@@ -366,7 +366,7 @@ describe('useAuthStore', () => {
       await balanceRequested
 
       // Firebase transitions directly to account B before the response lands.
-      authStateCallback({ ...mockUser, uid: 'account-b' } as User)
+      authStateCallback({ ...mockUser, uid: 'account-b' })
       resolveBalanceJson({ balance: 4242 })
 
       expect(await pending).toBeNull()
@@ -420,7 +420,7 @@ describe('useAuthStore', () => {
     })
 
     it('fetchBalance prefers the Firebase token over the API key when signed in', async () => {
-      authStateCallback(mockUser as User)
+      authStateCallback(mockUser)
 
       await store.fetchBalance()
 
@@ -2120,7 +2120,7 @@ describe('useAuthStore', () => {
       authStateCallback(mockUser)
 
       // Stale POST resolves successfully after session reset
-      resolveCreate!({
+      resolveCreate({
         ok: true,
         statusText: 'OK',
         json: () => Promise.resolve({ id: 'stale-id' })
@@ -2141,7 +2141,7 @@ describe('useAuthStore', () => {
       ...mockUser,
       uid: 'account-b-id',
       email: 'b@example.com'
-    } as MockUser
+    }
 
     it('does not reset the socket on the initial sign-in', () => {
       // The store is created in beforeEach, which drives the initial

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -587,7 +587,7 @@ export const useAuthStore = defineStore('auth', () => {
         typeof body === 'object' &&
         body !== null &&
         'message' in body &&
-        (body as { message: unknown }).message === MISSING_CUSTOMER_MESSAGE
+        body.message === MISSING_CUSTOMER_MESSAGE
       )
     } catch {
       return false

--- a/src/stores/commandStore.test.ts
+++ b/src/stores/commandStore.test.ts
@@ -184,7 +184,7 @@ describe('commandStore', () => {
     it('returns empty string when command has no keybinding', () => {
       const store = useCommandStore()
       store.registerCommand({ id: 'no.kb', function: vi.fn() })
-      const cmd = store.getCommand('no.kb')!
+      const cmd = store.getCommand('no.kb')
       expect(store.formatKeySequence(cmd)).toBe('')
     })
   })

--- a/src/stores/executionStore.test.ts
+++ b/src/stores/executionStore.test.ts
@@ -2066,10 +2066,7 @@ describe('useExecutionStore - WebSocket event handlers', () => {
     })
 
     it('clears initializing state for the starting job', () => {
-      store.initializingJobIds = new Set([
-        'job-1',
-        'job-2'
-      ]) as unknown as Set<string>
+      store.initializingJobIds = new Set(['job-1', 'job-2'])
       fire('execution_start', { prompt_id: 'job-1', timestamp: 0 })
 
       expect(store.initializingJobIds.has('job-1')).toBe(false)

--- a/src/stores/modelStore.test.ts
+++ b/src/stores/modelStore.test.ts
@@ -510,7 +510,7 @@ describe('useModelStore', () => {
       )
       const eagerLoad = store.getLoadedModelFolder('checkpoints')
 
-      await getScanCallback()!()
+      await getScanCallback()()
       await flushScanReload()
 
       // The rebuilt folder must have been re-loaded, not left uninitialized
@@ -535,7 +535,7 @@ describe('useModelStore', () => {
 
       const scanCallback = getScanCallback()
       expect(scanCallback).toBeDefined()
-      await scanCallback!()
+      await scanCallback()
       await flushScanReload()
 
       expect(assetService.getAssetModels).toHaveBeenCalledTimes(2)
@@ -550,7 +550,7 @@ describe('useModelStore', () => {
       await store.getLoadedModelFolder('checkpoints')
       expect(api.getModelFolders).toHaveBeenCalledTimes(1)
 
-      const scanCallback = getScanCallback()!
+      const scanCallback = getScanCallback()
       await scanCallback()
       await scanCallback()
       await scanCallback()
@@ -564,7 +564,7 @@ describe('useModelStore', () => {
       enableMocks(true)
       store = useModelStore()
 
-      await getScanCallback()!()
+      await getScanCallback()()
       await flushScanReload()
 
       // The bucket cache is still dropped so the eventual first read is
@@ -582,7 +582,7 @@ describe('useModelStore', () => {
         new Error('transient network failure')
       )
 
-      await getScanCallback()!()
+      await getScanCallback()()
       await flushScanReload()
 
       expect(error).toHaveBeenCalledWith(

--- a/src/stores/nodeDefStore.nodeText.test.ts
+++ b/src/stores/nodeDefStore.nodeText.test.ts
@@ -18,7 +18,7 @@ function def(overrides: Partial<ComfyNodeDefV1>): ComfyNodeDefV1 {
     output_node: false,
     python_module: 'test.module',
     ...overrides
-  } as ComfyNodeDefV1
+  }
 }
 
 // `KSampler` is chosen because the shipped zh bundle translates both fields and

--- a/src/stores/nodeDefStore.ts
+++ b/src/stores/nodeDefStore.ts
@@ -317,7 +317,7 @@ export function createDummyFolderNodeDef(folderPath: string): ComfyNodeDefImpl {
     output_name: [],
     output_is_list: [],
     output_node: false
-  } as ComfyNodeDefV1)
+  })
 }
 
 /**

--- a/src/stores/nodeOutputStore.workflowSwitch.test.ts
+++ b/src/stores/nodeOutputStore.workflowSwitch.test.ts
@@ -43,7 +43,7 @@ vi.mock('@/scripts/app', () => ({
 vi.mock('@/platform/workflow/management/stores/workflowStore', async () => {
   const { reactive } = await import('vue')
   mocks.workflowStore = reactive({
-    activeWorkflow: { path: WORKFLOW_A } as { path: string } | null,
+    activeWorkflow: { path: WORKFLOW_A },
     openWorkflows: [{ path: WORKFLOW_A }, { path: WORKFLOW_B }],
     nodeIdToNodeLocatorId: (id: string | number) => String(id),
     nodeToNodeLocatorId: (node: { id: string | number }) => String(node.id)

--- a/src/stores/serverConfigStore.ts
+++ b/src/stores/serverConfigStore.ts
@@ -90,7 +90,7 @@ export const useServerConfigStore = defineStore('serverConfig', () => {
         }
         return [key, value.toString()]
       })
-    ) as Record<string, string>
+    )
   })
   const commandLineArgs = computed<string>(() => {
     return Object.entries(launchArgs.value)

--- a/src/stores/subgraphNavigationStore.navigateToHash.test.ts
+++ b/src/stores/subgraphNavigationStore.navigateToHash.test.ts
@@ -25,7 +25,7 @@ const workflowStoreState = vi.hoisted(() => ({
 const routerMocks = vi.hoisted(() => ({
   push: vi.fn().mockResolvedValue(undefined),
   replace: vi.fn().mockResolvedValue(undefined),
-  history: { state: {} as Record<string, unknown> }
+  history: { state: {} }
 }))
 
 const routeHashRef = ref('')
@@ -877,9 +877,9 @@ describe('useSubgraphNavigationStore - navigateToHash validation', () => {
     app.rootGraph.subgraphs.set(subgraph.id, subgraph)
     const store = useSubgraphNavigationStore()
     // Consume the initial-load swallow so the watcher publish is live.
-    await store.updateHash('graph', undefined, app.rootGraph as LGraph)
+    await store.updateHash('graph', undefined, app.rootGraph)
 
-    currentGraphRef.value = subgraph as LGraph
+    currentGraphRef.value = subgraph
     await vi.waitFor(() => {
       expect(routerMocks.push).toHaveBeenCalledWith(
         expect.objectContaining({ hash: `#${ids.validSubgraph}` })
@@ -899,18 +899,18 @@ describe('useSubgraphNavigationStore - navigateToHash validation', () => {
     app.rootGraph.subgraphs.set(subgraph.id, subgraph)
     const store = useSubgraphNavigationStore()
     // Consume the initial-load swallow so the later publish is live.
-    await store.updateHash('graph', undefined, app.rootGraph as LGraph)
+    await store.updateHash('graph', undefined, app.rootGraph)
 
     // A workflow switch arms the suppression while the canvas sits inside a
     // subgraph; the load then fails so ONLY the finally-publish (stale id by
     // then) runs. Without the entry-point clear this strands the suppression
     // and swallows the next root publish.
-    app.canvas.graph = subgraph as LGraph
+    app.canvas.graph = subgraph
     store.saveCurrentViewport(true)
-    app.canvas.graph = app.rootGraph as LGraph
+    app.canvas.graph = app.rootGraph
     await store.updateHash('workflow-load', -1)
 
-    await store.updateHash('graph', undefined, app.rootGraph as LGraph)
+    await store.updateHash('graph', undefined, app.rootGraph)
 
     await vi.waitFor(() => {
       expect(routerMocks.replace).toHaveBeenCalledWith(

--- a/src/stores/subgraphNavigationStore.test.ts
+++ b/src/stores/subgraphNavigationStore.test.ts
@@ -26,7 +26,7 @@ const {
     routeHash: ref(''),
     routerPush: vi.fn(),
     routerReplace: vi.fn(),
-    routerHistory: { state: {} as Record<string, unknown> },
+    routerHistory: { state: {} },
     mockOpenWorkflow: vi.fn()
   }
 })

--- a/src/stores/subgraphStore.test.ts
+++ b/src/stores/subgraphStore.test.ts
@@ -161,11 +161,11 @@ describe('useSubgraphStore', () => {
     await mockFetch({ 'test.json': mockGraph })
     const first = store.getBlueprint(BLUEPRINT_TYPE_PREFIX + 'test')
     first.nodes[0].id = -1
-    first.definitions!.subgraphs![0].id = 'corrupted'
+    first.definitions!.subgraphs[0].id = 'corrupted'
 
     const second = store.getBlueprint(BLUEPRINT_TYPE_PREFIX + 'test')
     expect(second.nodes[0].id).not.toBe(-1)
-    expect(second.definitions!.subgraphs![0].id).toBe('123')
+    expect(second.definitions!.subgraphs[0].id).toBe('123')
   })
   it('should identify user blueprints as non-global', async () => {
     await mockFetch({ 'test.json': mockGraph })

--- a/src/stores/userFileStore.ts
+++ b/src/stores/userFileStore.ts
@@ -212,11 +212,10 @@ export const useUserFileStore = defineStore('userFile', () => {
     userFiles.value.filter((file: UserFile) => file.isLoaded)
   )
 
-  const fileTree = computed<TreeExplorerNode<UserFile>>(
-    () =>
-      buildTree<UserFile>(userFiles.value, (userFile: UserFile) =>
-        userFile.path.split('/')
-      ) as TreeExplorerNode<UserFile>
+  const fileTree = computed<TreeExplorerNode<UserFile>>(() =>
+    buildTree<UserFile>(userFiles.value, (userFile: UserFile) =>
+      userFile.path.split('/')
+    )
   )
 
   /**

--- a/src/stores/widgetValueStore.test.ts
+++ b/src/stores/widgetValueStore.test.ts
@@ -443,7 +443,7 @@ describe('useWidgetValueStore', () => {
     // header, preview, button). Such an id cannot be keyed; the store must
     // decline it rather than throw and blank every widget on the node.
     const malformedIds = [
-      widgetId(graphA, toNodeId('node-1'), '') as WidgetId, // empty name
+      widgetId(graphA, toNodeId('node-1'), ''), // empty name
       'no-colons' as WidgetId,
       `${graphA}:node-1` as WidgetId, // missing name segment
       `${graphA}:node-1:seed:extra` as WidgetId, // extra segment

--- a/src/stores/workspace/assetsSidebarBadgeStore.test.ts
+++ b/src/stores/workspace/assetsSidebarBadgeStore.test.ts
@@ -3,7 +3,6 @@ import { describe, expect, it, vi } from 'vitest'
 
 vi.mock('@/platform/assets/composables/media/assetMappers')
 
-import type { JobListItem } from '@/platform/remote/comfyui/jobs/jobTypes'
 import { TaskItemImpl, useQueueStore } from '@/stores/queueStore'
 import { useAssetsSidebarBadgeStore } from '@/stores/workspace/assetsSidebarBadgeStore'
 import { useSidebarTabStore } from '@/stores/workspace/sidebarTabStore'
@@ -32,7 +31,7 @@ const createHistoryTask = ({
           mediaType: 'images'
         }
       : undefined
-  } as JobListItem)
+  })
 
 describe('useAssetsSidebarBadgeStore', () => {
   it('does not count initial fetched history when store starts before hydration', async () => {

--- a/src/stores/workspace/searchBoxStore.test.ts
+++ b/src/stores/workspace/searchBoxStore.test.ts
@@ -17,10 +17,11 @@ vi.mock('@/platform/settings/settingStore', () => ({
   useSettingStore: vi.fn(() => mockSettingStore)
 }))
 
-function createMockPopover(): InstanceType<typeof NodeSearchBoxPopover> {
-  return { showSearchBox: vi.fn() } as Partial<
-    InstanceType<typeof NodeSearchBoxPopover>
-  > as InstanceType<typeof NodeSearchBoxPopover>
+function createMockPopover(): Pick<
+  InstanceType<typeof NodeSearchBoxPopover>,
+  'showSearchBox'
+> {
+  return { showSearchBox: vi.fn() }
 }
 
 function createMockSettingStore(): ReturnType<typeof useSettingStore> {

--- a/src/stores/workspace/searchBoxStore.test.ts
+++ b/src/stores/workspace/searchBoxStore.test.ts
@@ -1,10 +1,23 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useMouse } from '@vueuse/core'
 
 import type NodeSearchBoxPopover from '@/components/searchbox/NodeSearchBoxPopover.vue'
 import type { useSettingStore } from '@/platform/settings/settingStore'
 import { useSearchBoxStore } from '@/stores/workspace/searchBoxStore'
 
-// Mock dependencies
+const { mockAdjustMouseEvent } = vi.hoisted(() => ({
+  mockAdjustMouseEvent: vi.fn((event: PointerEvent) => {
+    Object.assign(event, {
+      canvasX: 50,
+      canvasY: 75,
+      deltaX: 0,
+      deltaY: 0,
+      safeOffsetX: event.clientX,
+      safeOffsetY: event.clientY
+    })
+  })
+}))
+
 vi.mock('@vueuse/core', () => ({
   useMouse: vi.fn(() => ({
     x: { value: 100 },
@@ -15,6 +28,12 @@ vi.mock('@vueuse/core', () => ({
 const mockSettingStore = createMockSettingStore()
 vi.mock('@/platform/settings/settingStore', () => ({
   useSettingStore: vi.fn(() => mockSettingStore)
+}))
+
+vi.mock('@/renderer/core/canvas/canvasStore', () => ({
+  useCanvasStore: () => ({
+    getCanvas: () => ({ adjustMouseEvent: mockAdjustMouseEvent })
+  })
 }))
 
 function createMockPopover(): Pick<
@@ -80,9 +99,13 @@ describe('useSearchBoxStore', () => {
       expect(vi.mocked(mockPopover.showSearchBox)).toHaveBeenCalledWith(
         expect.objectContaining({
           clientX: 100,
-          clientY: 200
+          clientY: 200,
+          canvasX: 50,
+          canvasY: 75
         })
       )
+      expect(useMouse).toHaveBeenCalledWith({ type: 'client' })
+      expect(mockAdjustMouseEvent).toHaveBeenCalledOnce()
     })
 
     it('should do nothing when user presses shortcut but popover is not ready', () => {

--- a/src/stores/workspace/searchBoxStore.ts
+++ b/src/stores/workspace/searchBoxStore.ts
@@ -3,7 +3,6 @@ import { defineStore } from 'pinia'
 import { computed, ref, shallowRef } from 'vue'
 
 import type NodeSearchBoxPopover from '@/components/searchbox/NodeSearchBoxPopover.vue'
-import type { CanvasPointerEvent } from '@/lib/litegraph/src/litegraph'
 import { useSettingStore } from '@/platform/settings/settingStore'
 
 export const useSearchBoxStore = defineStore('searchBox', () => {
@@ -18,13 +17,13 @@ export const useSearchBoxStore = defineStore('searchBox', () => {
     () => settingStore.get('Comfy.NodeSearchBoxImpl') !== 'litegraph (legacy)'
   )
 
-  const popoverRef = shallowRef<InstanceType<
-    typeof NodeSearchBoxPopover
-  > | null>(null)
+  type SearchBoxPopover = Pick<
+    InstanceType<typeof NodeSearchBoxPopover>,
+    'showSearchBox'
+  >
+  const popoverRef = shallowRef<SearchBoxPopover | null>(null)
 
-  function setPopoverRef(
-    popover: InstanceType<typeof NodeSearchBoxPopover> | null
-  ) {
+  function setPopoverRef(popover: SearchBoxPopover | null) {
     popoverRef.value = popover
   }
 
@@ -36,12 +35,17 @@ export const useSearchBoxStore = defineStore('searchBox', () => {
     }
     if (!popoverRef.value) return
     popoverRef.value.showSearchBox(
-      new MouseEvent('click', {
-        clientX: x.value,
-        clientY: y.value,
-        // @ts-expect-error layerY is a nonstandard property
-        layerY: y.value
-      }) as unknown as CanvasPointerEvent
+      Object.assign(
+        new PointerEvent('click', { clientX: x.value, clientY: y.value }),
+        {
+          canvasX: x.value,
+          canvasY: y.value,
+          deltaX: 0,
+          deltaY: 0,
+          safeOffsetX: x.value,
+          safeOffsetY: y.value
+        }
+      )
     )
   }
 

--- a/src/stores/workspace/searchBoxStore.ts
+++ b/src/stores/workspace/searchBoxStore.ts
@@ -3,11 +3,14 @@ import { defineStore } from 'pinia'
 import { computed, ref, shallowRef } from 'vue'
 
 import type NodeSearchBoxPopover from '@/components/searchbox/NodeSearchBoxPopover.vue'
+import type { LGraphCanvas } from '@/lib/litegraph/src/litegraph'
 import { useSettingStore } from '@/platform/settings/settingStore'
+import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 
 export const useSearchBoxStore = defineStore('searchBox', () => {
   const settingStore = useSettingStore()
-  const { x, y } = useMouse()
+  const canvasStore = useCanvasStore()
+  const { x, y } = useMouse({ type: 'client' })
 
   const useSearchBoxV2 = computed(
     () => settingStore.get('Comfy.NodeSearchBoxImpl') === 'default'
@@ -34,19 +37,13 @@ export const useSearchBoxStore = defineStore('searchBox', () => {
       return
     }
     if (!popoverRef.value) return
-    popoverRef.value.showSearchBox(
-      Object.assign(
-        new PointerEvent('click', { clientX: x.value, clientY: y.value }),
-        {
-          canvasX: x.value,
-          canvasY: y.value,
-          deltaX: 0,
-          deltaY: 0,
-          safeOffsetX: x.value,
-          safeOffsetY: y.value
-        }
-      )
-    )
+    const event = new PointerEvent('click', {
+      clientX: x.value,
+      clientY: y.value
+    })
+    const canvas: LGraphCanvas = canvasStore.getCanvas()
+    canvas.adjustMouseEvent(event)
+    popoverRef.value.showSearchBox(event)
   }
 
   return {

--- a/src/utils/__tests__/litegraphTestUtils.ts
+++ b/src/utils/__tests__/litegraphTestUtils.ts
@@ -77,7 +77,7 @@ export function createMockPositionable(
     pos: [0, 0],
     ...overrides
   }
-  return partial as Partial<Positionable> as Positionable
+  return partial as Positionable
 }
 
 /**
@@ -92,7 +92,7 @@ export function createMockLGraphGroup(
     boundingRect: new Rectangle(0, 0, 100, 100),
     ...overrides
   }
-  return partial as Partial<LGraphGroup> as LGraphGroup
+  return partial as LGraphGroup
 }
 
 /**
@@ -195,8 +195,8 @@ export function createMockCanvasRenderingContext2D(
     strokeStyle: '',
     lineWidth: 1,
     globalAlpha: 1,
-    textAlign: 'left' as CanvasTextAlign,
-    textBaseline: 'alphabetic' as CanvasTextBaseline,
+    textAlign: 'left',
+    textBaseline: 'alphabetic',
     ...overrides
   }
   return partial as CanvasRenderingContext2D
@@ -282,7 +282,7 @@ export function createMockFileList(files: File[]): FileList {
     },
     files
   )
-  return fileList as FileList
+  return fileList
 }
 
 /**
@@ -398,7 +398,7 @@ export function createMockLinks(links: LLink[]): LGraph['links'] {
     map.set(link.id, link)
     record[link.id] = link
   }
-  return Object.assign(map, record) as LGraph['links']
+  return Object.assign(map, record)
 }
 export function reloadSerializedGraph(
   serialized: ISerialisedGraph | SerialisableGraph,

--- a/src/utils/colorUtil.test.ts
+++ b/src/utils/colorUtil.test.ts
@@ -353,7 +353,7 @@ describe('colorUtil - adjustColor', () => {
 
   describe.for(Object.entries(colors))('%s color', ([_colorName, color]) => {
     describe.for(formats)('%s format', (format) => {
-      runAdjustColorTests(color, format as ColorFormat)
+      runAdjustColorTests(color, format)
     })
   })
 

--- a/src/utils/colorUtil.ts
+++ b/src/utils/colorUtil.ts
@@ -256,8 +256,8 @@ function isHSBObject(v: unknown): v is HSB {
     Number.isFinite(rec.h) &&
     typeof rec.s === 'number' &&
     Number.isFinite(rec.s) &&
-    typeof (rec as Record<string, unknown>).b === 'number' &&
-    Number.isFinite((rec as Record<string, number>).b!)
+    typeof rec.b === 'number' &&
+    Number.isFinite((rec as Record<string, number>).b)
   )
 }
 
@@ -269,8 +269,8 @@ function isHSVObject(v: unknown): v is HSV {
     Number.isFinite(rec.h) &&
     typeof rec.s === 'number' &&
     Number.isFinite(rec.s) &&
-    typeof (rec as Record<string, unknown>).v === 'number' &&
-    Number.isFinite((rec as Record<string, number>).v!)
+    typeof rec.v === 'number' &&
+    Number.isFinite((rec as Record<string, number>).v)
   )
 }
 

--- a/src/utils/colorUtil.ts
+++ b/src/utils/colorUtil.ts
@@ -257,7 +257,7 @@ function isHSBObject(v: unknown): v is HSB {
     typeof rec.s === 'number' &&
     Number.isFinite(rec.s) &&
     typeof rec.b === 'number' &&
-    Number.isFinite((rec as Record<string, number>).b)
+    Number.isFinite(rec.b)
   )
 }
 
@@ -270,7 +270,7 @@ function isHSVObject(v: unknown): v is HSV {
     typeof rec.s === 'number' &&
     Number.isFinite(rec.s) &&
     typeof rec.v === 'number' &&
-    Number.isFinite((rec as Record<string, number>).v)
+    Number.isFinite(rec.v)
   )
 }
 

--- a/src/utils/dateTimeUtil.test.ts
+++ b/src/utils/dateTimeUtil.test.ts
@@ -37,7 +37,7 @@ function withStrictMillisecondParser<T>(
     }
   }
 
-  vi.stubGlobal('Date', StrictDate as DateConstructor)
+  vi.stubGlobal('Date', StrictDate)
 
   try {
     return run(normalizedValues)

--- a/src/utils/errorUtil.ts
+++ b/src/utils/errorUtil.ts
@@ -31,7 +31,7 @@ export function getErrorMessage(value: unknown): string | undefined {
     'message' in value &&
     typeof value.message === 'string'
   ) {
-    return (value as { message: string }).message
+    return value.message
   }
   return undefined
 }

--- a/src/utils/errorUtil.ts
+++ b/src/utils/errorUtil.ts
@@ -29,7 +29,7 @@ export function getErrorMessage(value: unknown): string | undefined {
     typeof value === 'object' &&
     value !== null &&
     'message' in value &&
-    typeof (value as { message: unknown }).message === 'string'
+    typeof value.message === 'string'
   ) {
     return (value as { message: string }).message
   }

--- a/src/utils/fuseUtil.ts
+++ b/src/utils/fuseUtil.ts
@@ -142,7 +142,7 @@ export class FuseSearch<T> {
     } else if (typeof entry === 'object' && entry !== null) {
       values = this.keys
         .map((x) => entry[x as keyof T])
-        .filter((x) => typeof x === 'string') as string[]
+        .filter((x) => typeof x === 'string')
     }
     const scores = values.map((x) => this.calcAuxSingle(query, x, score))
     let result = scores.sort(this.compareAux)[0]

--- a/src/utils/graphTraversalUtil.test.ts
+++ b/src/utils/graphTraversalUtil.test.ts
@@ -58,7 +58,7 @@ function createMockNode(
     subgraph: options.subgraph,
     onExecutionStart: options.callback,
     graph: options.graph
-  }) satisfies Partial<LGraphNode> as LGraphNode
+  }) satisfies Partial<LGraphNode>
   options.graph?.nodes?.push(node)
   return node
 }
@@ -788,7 +788,7 @@ describe('graphTraversalUtil', () => {
           subgraph
         })
         const rootGraph = createMockGraph([subgraphNode])
-        interior.graph = null as unknown as LGraph
+        interior.graph = null
 
         expect(
           getExecutionIdForNodeInGraph(rootGraph, subgraph, interior.id)
@@ -838,7 +838,7 @@ describe('graphTraversalUtil', () => {
           isSubgraphNode: () => true,
           subgraph,
           mode: LGraphEventMode.BYPASS
-        }) satisfies Partial<LGraphNode> as LGraphNode
+        }) satisfies Partial<LGraphNode>
         const rootGraph = createMockGraph([container])
 
         expect(isAncestorPathActive(rootGraph, '65:63')).toBe(false)
@@ -857,7 +857,7 @@ describe('graphTraversalUtil', () => {
           isSubgraphNode: () => true,
           subgraph: mid,
           mode: LGraphEventMode.NEVER
-        }) satisfies Partial<LGraphNode> as LGraphNode
+        }) satisfies Partial<LGraphNode>
         const rootGraph = createMockGraph([topNode])
 
         expect(isAncestorPathActive(rootGraph, '123:456:999')).toBe(false)
@@ -880,7 +880,7 @@ describe('graphTraversalUtil', () => {
         const node = createMockLGraphNode({
           id: 42,
           mode: LGraphEventMode.BYPASS
-        }) satisfies Partial<LGraphNode> as LGraphNode
+        }) satisfies Partial<LGraphNode>
         const rootGraph = createMockGraph([node])
 
         expect(isExecutionPathActive(rootGraph, '42')).toBe(false)
@@ -894,7 +894,7 @@ describe('graphTraversalUtil', () => {
           isSubgraphNode: () => true,
           subgraph,
           mode: LGraphEventMode.BYPASS
-        }) satisfies Partial<LGraphNode> as LGraphNode
+        }) satisfies Partial<LGraphNode>
         const rootGraph = createMockGraph([container])
 
         expect(isExecutionPathActive(rootGraph, '65:63')).toBe(false)
@@ -910,7 +910,7 @@ describe('graphTraversalUtil', () => {
           isSubgraphNode: () => true,
           subgraph,
           mode: LGraphEventMode.BYPASS
-        }) satisfies Partial<LGraphNode> as LGraphNode
+        }) satisfies Partial<LGraphNode>
         return createMockGraph([container])
       }
 
@@ -987,7 +987,7 @@ describe('graphTraversalUtil', () => {
         const sourceNode = createMockLGraphNode({
           id: 42,
           mode: LGraphEventMode.BYPASS
-        }) satisfies Partial<LGraphNode> as LGraphNode
+        }) satisfies Partial<LGraphNode>
         const rootGraph = createMockGraph([rootNode, sourceNode])
 
         expect(

--- a/src/utils/graphTraversalUtil.test.ts
+++ b/src/utils/graphTraversalUtil.test.ts
@@ -1321,6 +1321,7 @@ describe('graphTraversalUtil', () => {
 
       it('should skip subgraphs when expandSubgraphs is false', () => {
         const visited: string[] = []
+        const contexts: null[] = []
         const subNode = createMockNode('sub1')
         const subgraph = createMockSubgraph('sub-uuid', [subNode])
         const nodes = [
@@ -1331,6 +1332,7 @@ describe('graphTraversalUtil', () => {
         traverseNodesDepthFirst(nodes, {
           visitor: (node, context) => {
             visited.push(String(node.id))
+            contexts.push(context)
             return context
           },
           initialContext: null,
@@ -1338,6 +1340,7 @@ describe('graphTraversalUtil', () => {
         })
 
         expect(visited).toEqual(['2', '1']) // DFS processes in LIFO order
+        expect(contexts).toEqual([null, null])
         expect(visited).not.toContain('sub1')
       })
 

--- a/src/utils/graphTraversalUtil.ts
+++ b/src/utils/graphTraversalUtil.ts
@@ -781,7 +781,10 @@ export function traverseNodesDepthFirst<T = void>(
   options?: TraverseNodesOptions<T>
 ): void {
   const visitor = options?.visitor ?? (() => undefined as T)
-  const initialContext: T = options?.initialContext ?? (undefined as T)
+  const initialContext =
+    options?.initialContext === undefined
+      ? (undefined as T)
+      : options.initialContext
   const expandSubgraphs = options?.expandSubgraphs ?? true
   type StackItem = { node: LGraphNode; context: T }
   const stack: StackItem[] = []

--- a/src/utils/graphTraversalUtil.ts
+++ b/src/utils/graphTraversalUtil.ts
@@ -473,10 +473,7 @@ export function getExecutionIdByNode(
     return createNodeExecutionId([node.id])
   }
 
-  const parentPath = findPartialExecutionPathToGraph(
-    node.graph as LGraph,
-    rootGraph
-  )
+  const parentPath = findPartialExecutionPathToGraph(node.graph, rootGraph)
   if (parentPath === undefined) return null
 
   return createExecutionIdFromPath(parentPath, node.id)
@@ -592,7 +589,7 @@ export function getExecutionIdForNodeInGraph(
   const localExecutionId = createNodeExecutionId([localNodeId])
   if (graph === rootGraph || graph.isRootGraph) return localExecutionId
 
-  const parentPath = findPartialExecutionPathToGraph(graph as LGraph, rootGraph)
+  const parentPath = findPartialExecutionPathToGraph(graph, rootGraph)
   if (parentPath === undefined) return localExecutionId
 
   return createExecutionIdFromPath(parentPath, localNodeId) ?? localExecutionId
@@ -783,11 +780,9 @@ export function traverseNodesDepthFirst<T = void>(
   nodes: LGraphNode[],
   options?: TraverseNodesOptions<T>
 ): void {
-  const {
-    visitor = () => undefined as T,
-    initialContext = undefined as T,
-    expandSubgraphs = true
-  } = options || {}
+  const visitor = options?.visitor ?? (() => undefined as T)
+  const initialContext: T = options?.initialContext ?? (undefined as T)
+  const expandSubgraphs = options?.expandSubgraphs ?? true
   type StackItem = { node: LGraphNode; context: T }
   const stack: StackItem[] = []
 
@@ -865,7 +860,7 @@ export function collectFromNodes<T = LGraphNode, C = void>(
   const {
     collector = (node: LGraphNode) => node as T,
     contextBuilder = () => undefined as C,
-    initialContext = undefined as C,
+    initialContext = undefined,
     expandSubgraphs = true
   } = options || {}
   const results: T[] = []

--- a/src/utils/linkFixer.test.ts
+++ b/src/utils/linkFixer.test.ts
@@ -26,7 +26,7 @@ function createInput(link: number | null): SerialisedInput {
     name: 'input',
     type: '*',
     link
-  } satisfies Partial<SerialisedInput> as SerialisedInput
+  } satisfies Partial<SerialisedInput>
 }
 
 function createOutput(links: number[]): SerialisedOutput {
@@ -34,7 +34,7 @@ function createOutput(links: number[]): SerialisedOutput {
     name: 'output',
     type: '*',
     links
-  } satisfies Partial<SerialisedOutput> as SerialisedOutput
+  } satisfies Partial<SerialisedOutput>
 }
 
 function createNode({

--- a/src/utils/linkFixer.ts
+++ b/src/utils/linkFixer.ts
@@ -51,12 +51,15 @@ enum IoDirection {
   OUTPUT
 }
 
+function isLiveGraph(graph: ISerialisedGraph | LGraph): graph is LGraph {
+  return 'getNodeById' in graph
+}
+
 function getNodeById(graph: ISerialisedGraph | LGraph, id: SerializedNodeId) {
-  if ((graph as LGraph).getNodeById) {
+  if (isLiveGraph(graph)) {
     const parsedNodeId = parseNodeId(id)
-    return parsedNodeId ? (graph as LGraph).getNodeById(parsedNodeId) : null
+    return parsedNodeId ? graph.getNodeById(parsedNodeId) : null
   }
-  graph = graph as ISerialisedGraph
   return graph.nodes.find((node: ISerialisedNode) => node.id == id)!
 }
 
@@ -143,14 +146,14 @@ export function fixBadLinks(
     op: 'ADD' | 'REMOVE'
   ) {
     patchedNodeSlots[node.id] = patchedNodeSlots[node.id] || {}
-    const patchedNode = patchedNodeSlots[node.id]!
+    const patchedNode = patchedNodeSlots[node.id]
     if (ioDir == IoDirection.INPUT) {
       patchedNode['inputs'] = patchedNode['inputs'] || {}
       // We can set to null (delete), so undefined means we haven't set it at all.
-      if (patchedNode['inputs']![slot] !== undefined) {
+      if (patchedNode['inputs'][slot] !== undefined) {
         logger.log(
           ` > Already set ${node.id}.inputs[${slot}] to ${
-            patchedNode['inputs']![slot]!
+            patchedNode['inputs'][slot]!
           } Skipping.`
         )
         return false
@@ -163,7 +166,7 @@ export function fixBadLinks(
         )
         return false
       }
-      patchedNode['inputs']![slot] = linkIdToSet
+      patchedNode['inputs'][slot] = linkIdToSet
       // Live NodeInputSlot mirrors are store-derived and need no repair;
       // only serialized plain slots carry a writable link field.
       if (fix && !(inputSlot instanceof NodeInputSlot)) {
@@ -172,11 +175,11 @@ export function fixBadLinks(
       }
     } else {
       patchedNode['outputs'] = patchedNode['outputs'] || {}
-      patchedNode['outputs']![slot] = patchedNode['outputs']![slot] || {
+      patchedNode['outputs'][slot] = patchedNode['outputs'][slot] || {
         links: [...(outputLinkIdsOf(node, slot) ?? [])],
         changes: {}
       }
-      if (patchedNode['outputs']![slot]!['changes']![linkId] !== undefined) {
+      if (patchedNode['outputs'][slot]['changes'][linkId] !== undefined) {
         logger.log(
           ` > Already set ${node.id}.outputs[${slot}] to ${
             patchedNode['inputs']![slot]
@@ -184,17 +187,17 @@ export function fixBadLinks(
         )
         return false
       }
-      patchedNode['outputs']![slot]!['changes']![linkId] = op
+      patchedNode['outputs'][slot]['changes'][linkId] = op
       if (op === 'ADD') {
         const linkIdIndex =
-          patchedNode['outputs']![slot]!['links'].indexOf(linkId)
+          patchedNode['outputs'][slot]['links'].indexOf(linkId)
         if (linkIdIndex !== -1) {
           logger.log(
             ` > Hmmm.. asked to add ${linkId} but it is already in list...`
           )
           return false
         }
-        patchedNode['outputs']![slot]!['links'].push(linkId)
+        patchedNode['outputs'][slot]['links'].push(linkId)
         // Live NodeOutputSlot mirrors are store-derived and need no repair;
         // only serialized plain slots carry a writable links array.
         if (fix && !(node.outputs?.[slot] instanceof NodeOutputSlot)) {
@@ -207,14 +210,14 @@ export function fixBadLinks(
         }
       } else {
         const linkIdIndex =
-          patchedNode['outputs']![slot]!['links'].indexOf(linkId)
+          patchedNode['outputs'][slot]['links'].indexOf(linkId)
         if (linkIdIndex === -1) {
           logger.log(
             ` > Hmmm.. asked to remove ${linkId} but it doesn't exist...`
           )
           return false
         }
-        patchedNode['outputs']![slot]!['links'].splice(linkIdIndex, 1)
+        patchedNode['outputs'][slot]['links'].splice(linkIdIndex, 1)
         if (fix && !(node.outputs?.[slot] instanceof NodeOutputSlot)) {
           const writable = node.outputs?.[slot] as { links?: number[] | null }
           writable.links?.splice(linkIdIndex, 1)
@@ -240,7 +243,7 @@ export function fixBadLinks(
       const nodeHasIt = node.inputs?.[slot]?.link === linkId
       if (patchedNodeSlots[node.id]?.['inputs']) {
         const patchedHasIt =
-          patchedNodeSlots[node.id]!['inputs']![slot] === linkId
+          patchedNodeSlots[node.id]['inputs']![slot] === linkId
         // If we're fixing, double check that node matches.
         if (fix && nodeHasIt !== patchedHasIt) {
           throw Error('Error. Expected node to match patched data.')
@@ -253,7 +256,7 @@ export function fixBadLinks(
       const nodeHasIt = outputLinkIdsOf(node, slot)?.includes(toLinkId(linkId))
       if (patchedNodeSlots[node.id]?.['outputs']?.[slot]?.['changes'][linkId]) {
         const patchedHasIt =
-          patchedNodeSlots[node.id]!['outputs']![slot]?.links.includes(linkId)
+          patchedNodeSlots[node.id]['outputs']![slot]?.links.includes(linkId)
         // If we're fixing, double check that node matches.
         if (fix && nodeHasIt !== patchedHasIt) {
           throw Error('Error. Expected node to match patched data.')
@@ -279,8 +282,7 @@ export function fixBadLinks(
     if (ioDir === IoDirection.INPUT) {
       const nodeHasAny = node.inputs?.[slot]?.link != null
       if (patchedNodeSlots[node.id]?.['inputs']) {
-        const patchedHasAny =
-          patchedNodeSlots[node.id]!['inputs']![slot] != null
+        const patchedHasAny = patchedNodeSlots[node.id]['inputs']![slot] != null
         // If we're fixing, double check that node matches.
         if (fix && nodeHasAny !== patchedHasAny) {
           throw Error('Error. Expected node to match patched data.')
@@ -293,7 +295,7 @@ export function fixBadLinks(
       const nodeHasAny = outputLinkIdsOf(node, slot)?.length
       if (patchedNodeSlots[node.id]?.['outputs']?.[slot]?.['changes']) {
         const patchedHasAny =
-          patchedNodeSlots[node.id]!['outputs']![slot]?.links.length
+          patchedNodeSlots[node.id]['outputs']![slot]?.links.length
         // If we're fixing, double check that node matches.
         if (fix && nodeHasAny !== patchedHasAny) {
           throw Error('Error. Expected node to match patched data.')
@@ -448,14 +450,13 @@ export function fixBadLinks(
   if (fix) {
     for (let i = data.deletedLinks.length - 1; i >= 0; i--) {
       logger.log(`Deleting link #${data.deletedLinks[i]}.`)
-      if ((graph as LGraph).getNodeById) {
-        const liveGraph = graph as LGraph
-        liveGraph._removeLink(toLinkId(data.deletedLinks[i]!))
+      if (isLiveGraph(graph)) {
+        graph._removeLink(toLinkId(data.deletedLinks[i]))
       } else {
-        graph = graph as ISerialisedGraph
+        const links = graph.links
         // Sometimes we got objects for links if passed after ComfyUI's loadGraphData modifies the
         // data. We make a copy now, but can handle the bastardized objects just in case.
-        const idx = graph.links.findIndex(
+        const idx = links.findIndex(
           (l) =>
             l &&
             (l[0] === data.deletedLinks[i] ||
@@ -465,12 +466,12 @@ export function fixBadLinks(
           logger.log(`INDEX NOT FOUND for #${data.deletedLinks[i]}`)
         }
         logger.log(`splicing ${idx} from links`)
-        graph.links.splice(idx, 1)
+        links.splice(idx, 1)
       }
     }
     // If we're a serialized graph, we can filter out the links because it's just an array.
-    if (!(graph as LGraph).getNodeById) {
-      graph.links = (graph as ISerialisedGraph).links.filter((l) => !!l)
+    if (!isLiveGraph(graph)) {
+      graph.links = graph.links.filter((l) => !!l)
     }
   }
   if (!data.patchedNodes.length && !data.deletedLinks.length) {

--- a/src/utils/migration/migrateReroute.ts
+++ b/src/utils/migration/migrateReroute.ts
@@ -216,10 +216,10 @@ class ConversionContext {
     // Reconnect the links
     for (const link of links) {
       const sourceNode = nodesById[link.origin_id]
-      sourceNode.outputs![link.origin_slot]!.links!.push(link.id)
+      sourceNode.outputs![link.origin_slot].links!.push(link.id)
 
       const targetNode = nodesById[link.target_id]
-      targetNode.inputs![link.target_slot]!.link = link.id
+      targetNode.inputs![link.target_slot].link = link.id
     }
   }
 

--- a/src/workbench/extensions/agent/AgentPanelRoot.test.ts
+++ b/src/workbench/extensions/agent/AgentPanelRoot.test.ts
@@ -191,8 +191,8 @@ vi.mock('@/renderer/core/canvas/canvasStore', async () => {
   const store = reactive({
     selectedItems: [] as unknown[],
     updateSelectedItems,
-    currentGraph: null as unknown | null,
-    canvas: undefined as unknown
+    currentGraph: null,
+    canvas: undefined
   })
   hostStores.canvas = store
   return { useCanvasStore: () => store }
@@ -317,7 +317,7 @@ beforeEach(() => {
 })
 
 const zAgentWsEventForTest = (raw: unknown): AgentChatEvent =>
-  zAgentWsEvent.parse(raw) as AgentChatEvent
+  zAgentWsEvent.parse(raw)
 
 function json(status: number, body: unknown): Response {
   return new Response(JSON.stringify(body), {

--- a/src/workbench/extensions/agent/components/agent/Composer.test.ts
+++ b/src/workbench/extensions/agent/components/agent/Composer.test.ts
@@ -501,7 +501,7 @@ describe('Composer', () => {
     first.unmount()
 
     mount()
-    expect((screen.getByRole('textbox') as HTMLTextAreaElement).value).toBe(
+    expect(screen.getByRole<HTMLTextAreaElement>('textbox').value).toBe(
       'keep me'
     )
   })

--- a/src/workbench/extensions/agent/components/agent/ConversationView.test.ts
+++ b/src/workbench/extensions/agent/components/agent/ConversationView.test.ts
@@ -40,8 +40,7 @@ import { useAgentConversationStore } from '../../stores/agent/agentConversationS
 import ConversationView from './ConversationView.vue'
 
 const T = 'msg-1' as TurnId
-const chat = (raw: unknown): AgentChatEvent =>
-  zAgentWsEvent.parse(raw) as AgentChatEvent
+const chat = (raw: unknown): AgentChatEvent => zAgentWsEvent.parse(raw)
 const thinking = (id: string, delta: string) =>
   chat({
     type: 'agent_thinking',

--- a/src/workbench/extensions/agent/components/agent/OnboardingCoach.test.ts
+++ b/src/workbench/extensions/agent/components/agent/OnboardingCoach.test.ts
@@ -19,20 +19,17 @@ let target: HTMLElement | undefined
 function mountWithTarget(rect: { left: number; top: number }) {
   target = document.createElement('div')
   target.id = 'coach-target'
-  target.getBoundingClientRect = vi.fn(
-    () =>
-      ({
-        left: rect.left,
-        top: rect.top,
-        right: rect.left + 400,
-        bottom: 800,
-        width: 400,
-        height: 700,
-        x: rect.left,
-        y: rect.top,
-        toJSON: () => ({})
-      }) as DOMRect
-  )
+  target.getBoundingClientRect = vi.fn(() => ({
+    left: rect.left,
+    top: rect.top,
+    right: rect.left + 400,
+    bottom: 800,
+    width: 400,
+    height: 700,
+    x: rect.left,
+    y: rect.top,
+    toJSON: () => ({})
+  }))
   document.body.appendChild(target)
   return render(OnboardingCoach, {
     props: { step: STEP, storageKey: `coach-${Math.random()}` },

--- a/src/workbench/extensions/agent/crdt/applierConformance.test.ts
+++ b/src/workbench/extensions/agent/crdt/applierConformance.test.ts
@@ -220,10 +220,10 @@ describe('applier conformance (the pinned package the doc host runs)', () => {
     const doc = seedDoc()
     const newer = setWidget(20, {
       stamp: [5, 'human:u1:tab']
-    } as Partial<SetWidgetOp>)
+    })
     const older = setWidget(10, {
       stamp: [2, 'human:u1:tab']
-    } as Partial<SetWidgetOp>)
+    })
 
     applyOps(doc, [newer], CATALOG)
     const result = applyOps(doc, [older], CATALOG)
@@ -234,8 +234,8 @@ describe('applier conformance (the pinned package the doc host runs)', () => {
 
   it('orders by the stamp FIELD, exact ties broken by op_id (KA-2 offline order)', () => {
     const actor = 'human:u1:tab'
-    const low = setWidget(1, { stamp: [3, actor] } as Partial<SetWidgetOp>)
-    const high = setWidget(2, { stamp: [3, actor] } as Partial<SetWidgetOp>)
+    const low = setWidget(1, { stamp: [3, actor] })
+    const high = setWidget(2, { stamp: [3, actor] })
 
     const winner =
       compareStampKeys(stampKey(low), stampKey(high)) > 0 ? low : high

--- a/src/workbench/extensions/agent/crdt/mintPortWiring.ts
+++ b/src/workbench/extensions/agent/crdt/mintPortWiring.ts
@@ -9,7 +9,6 @@
 import type { LGraph } from '@/lib/litegraph/src/LGraph'
 import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
 import type { NodeId } from '@/types/nodeId'
-import type { WidgetId } from '@/types/widgetId'
 import type { WorkflowNode } from '@comfyorg/comfy-multi-player'
 
 import { useLinkStore } from '@/stores/linkStore'
@@ -216,7 +215,7 @@ export function attachMintPortWiring(deps: MintPortWiringDeps): MintPortWiring {
   const detachWidgetActions = widgetStore.$onAction(({ name, args, after }) => {
     if (name !== 'setValue') return
     if (isRemoteMutationContext(args[2])) return
-    const widgetId = args[0] as WidgetId
+    const widgetId = args[0]
     const old = widgetStore.getWidget(widgetId)?.value
     after((applied) => {
       if (!applied) return

--- a/src/workbench/extensions/agent/crdt/pendingOpLedger.test.ts
+++ b/src/workbench/extensions/agent/crdt/pendingOpLedger.test.ts
@@ -283,7 +283,7 @@ describe('clearOnEffect (KA-9)', () => {
     // The effect is authoritative even when doc_ops_result was lost.
     const removed = ledger.clearOnEffect(['op-1'])
     expect(removed).toHaveLength(1)
-    expect(removed[0]!.state).toBe('inflight')
+    expect(removed[0].state).toBe('inflight')
     expect(ledger.size()).toBe(0)
   })
 
@@ -353,8 +353,8 @@ describe('entries', () => {
     expect(ledger.entries('failed').map((e) => e.opId)).toEqual(['op-2'])
 
     const snapshots = ledger.entries()
-    snapshots[0]!.shadow.label = 'mutated'
-    const failure = snapshots[1]!.failure as { message: string }
+    snapshots[0].shadow.label = 'mutated'
+    const failure = snapshots[1].failure as { message: string }
     failure.message = 'mutated'
     expect(ledger.get('op-1')?.shadow).toEqual({ label: 's1' })
     expect(ledger.get('op-2')?.failure).toEqual({ message: 'rejected' })

--- a/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.ts
+++ b/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.ts
@@ -241,7 +241,7 @@ export function useAgentCrdtFollower(
           applied: detail.applied,
           skipped: detail.skipped,
           ...(detail.failed && typeof detail.failed === 'object'
-            ? { failure: detail.failed as OpsResultView['failure'] }
+            ? { failure: detail.failed }
             : {})
         })
       }

--- a/src/workbench/extensions/agent/schemas/agentApiSchema.test.ts
+++ b/src/workbench/extensions/agent/schemas/agentApiSchema.test.ts
@@ -17,7 +17,7 @@ const fixtureText = import.meta.glob('./__fixtures__/agent/*.jsonl', {
   query: '?raw',
   import: 'default',
   eager: true
-}) as Record<string, string>
+})
 
 function jsonlLines(path: string): unknown[] {
   return fixtureText[path]

--- a/src/workbench/extensions/agent/services/agent/agentEventTransport.test.ts
+++ b/src/workbench/extensions/agent/services/agent/agentEventTransport.test.ts
@@ -16,7 +16,7 @@ import { createAssistantMessage } from './agentMessageParts'
 const fixtureText = import.meta.glob(
   '../../schemas/__fixtures__/agent/*.jsonl',
   { query: '?raw', import: 'default', eager: true }
-) as Record<string, string>
+)
 
 function fixtureFor(name: string): string {
   const path = Object.keys(fixtureText).find((p) => p.endsWith(`/${name}`))

--- a/src/workbench/extensions/agent/stores/agent/agentConversationEntries.test.ts
+++ b/src/workbench/extensions/agent/stores/agent/agentConversationEntries.test.ts
@@ -10,7 +10,7 @@ const done = (id: string): AgentChatEvent =>
   zAgentWsEvent.parse({
     type: 'agent_message_done',
     data: { message_id: id, thread_id: 'th', usage: null }
-  }) as AgentChatEvent
+  })
 
 const T1 = 't1' as TurnId
 const T2 = 't2' as TurnId

--- a/src/workbench/extensions/agent/stores/agent/agentConversationStore.test.ts
+++ b/src/workbench/extensions/agent/stores/agent/agentConversationStore.test.ts
@@ -8,8 +8,7 @@ import type { AgentChatEvent } from '../../services/agent/agentEventTransport'
 
 import { useAgentConversationStore } from './agentConversationStore'
 
-const chat = (raw: unknown): AgentChatEvent =>
-  zAgentWsEvent.parse(raw) as AgentChatEvent
+const chat = (raw: unknown): AgentChatEvent => zAgentWsEvent.parse(raw)
 const thinking = (id: string, delta: string): AgentChatEvent =>
   chat({
     type: 'agent_thinking',

--- a/src/workbench/extensions/manager/components/manager/packCard/PackCard.test.ts
+++ b/src/workbench/extensions/manager/components/manager/packCard/PackCard.test.ts
@@ -112,7 +112,7 @@ describe('PackCard', () => {
     latest_version: {
       createdAt: '2024-01-01T00:00:00Z'
     }
-  } as RegistryPack
+  }
 
   describe('basic rendering', () => {
     it('should render package card with basic information', () => {

--- a/src/workbench/extensions/manager/components/survey/ManagerSurveyDialog.test.ts
+++ b/src/workbench/extensions/manager/components/survey/ManagerSurveyDialog.test.ts
@@ -5,16 +5,13 @@ import { nextTick } from 'vue'
 
 import type { RemoteConfig } from '@/platform/remoteConfig/types'
 
-const mocks = vi.hoisted(
-  () =>
-    ({
-      remoteConfig: { value: {} },
-      resolvedUserInfo: { value: null }
-    }) as {
-      remoteConfig: { value: RemoteConfig }
-      resolvedUserInfo: { value: { id: string } | null }
-    }
-)
+const mocks = vi.hoisted<{
+  remoteConfig: { value: RemoteConfig }
+  resolvedUserInfo: { value: { id: string } | null }
+}>(() => ({
+  remoteConfig: { value: {} },
+  resolvedUserInfo: { value: null }
+}))
 
 vi.mock('@/platform/remoteConfig/remoteConfig', async () => {
   const { ref } = await import('vue')

--- a/src/workbench/extensions/manager/composables/nodePack/usePackInstall.ts
+++ b/src/workbench/extensions/manager/composables/nodePack/usePackInstall.ts
@@ -36,8 +36,7 @@ export function usePackInstall(
     const isUnclaimedPack = installItem.publisher?.name === 'Unclaimed'
     const versionToInstall = isUnclaimedPack
       ? ('nightly' as ManagerComponents['schemas']['SelectedVersion'])
-      : (installItem.latest_version?.version ??
-        ('latest' as ManagerComponents['schemas']['SelectedVersion']))
+      : (installItem.latest_version?.version ?? 'latest')
 
     return {
       id: installItem.id,

--- a/src/workbench/extensions/manager/composables/nodePack/usePackUpdateStatus.test.ts
+++ b/src/workbench/extensions/manager/composables/nodePack/usePackUpdateStatus.test.ts
@@ -24,7 +24,7 @@ function makePack(overrides: Partial<NodePack> = {}): NodePack {
     name: 'Pack',
     latest_version: { version: '2.0.0' },
     ...overrides
-  } as NodePack
+  }
 }
 
 beforeEach(() => {

--- a/src/workbench/extensions/manager/composables/nodePack/usePacksStatus.ts
+++ b/src/workbench/extensions/manager/composables/nodePack/usePacksStatus.ts
@@ -43,18 +43,18 @@ export function usePacksStatus(nodePacks: Ref<NodePack[]>) {
     if (hasImportFailed.value) {
       // Import failed doesn't have a specific status enum, so we return active
       // but the PackStatusMessage will handle it via hasImportFailed prop
-      return 'NodeVersionStatusActive' as NodeVersionStatus
+      return 'NodeVersionStatusActive'
     }
 
     // Find the highest priority status from all packages
     for (const priorityStatus of STATUS_PRIORITY) {
       if (nodePacks.value.some((pack) => pack.status === priorityStatus)) {
-        return priorityStatus as NodeStatus | NodeVersionStatus
+        return priorityStatus
       }
     }
 
     // Default to active if no specific status found
-    return 'NodeVersionStatusActive' as NodeVersionStatus
+    return 'NodeVersionStatusActive'
   })
 
   return {

--- a/src/workbench/extensions/manager/composables/useConflictDetection.test.ts
+++ b/src/workbench/extensions/manager/composables/useConflictDetection.test.ts
@@ -8,7 +8,6 @@ import { useSystemStatsStore } from '@/stores/systemStatsStore'
 import type { components } from '@/types/comfyRegistryTypes'
 import { useInstalledPacks } from '@/workbench/extensions/manager/composables/nodePack/useInstalledPacks'
 import { useConflictAcknowledgment } from '@/workbench/extensions/manager/composables/useConflictAcknowledgment'
-import type { ConflictAcknowledgmentState } from '@/workbench/extensions/manager/composables/useConflictAcknowledgment'
 import { useConflictDetection } from '@/workbench/extensions/manager/composables/useConflictDetection'
 import { useComfyManagerService } from '@/workbench/extensions/manager/services/comfyManagerService'
 import { useComfyManagerStore } from '@/workbench/extensions/manager/stores/comfyManagerStore'
@@ -197,20 +196,19 @@ describe('useConflictDetection', () => {
     typeof useSystemStatsStore
   >
 
-  const mockAcknowledgment = {
-    checkComfyUIVersionChange: vi.fn(),
-    acknowledgmentState: computed(
-      () => ({}) as Partial<ConflictAcknowledgmentState>
-    ),
+  const mockAcknowledgment: ReturnType<typeof useConflictAcknowledgment> = {
+    acknowledgmentState: computed(() => ({
+      modal_dismissed: false,
+      red_dot_dismissed: false,
+      warning_banner_dismissed: false
+    })),
     shouldShowConflictModal: computed(() => false),
     shouldShowRedDot: computed(() => false),
     shouldShowManagerBanner: computed(() => false),
     dismissRedDotNotification: vi.fn(),
     dismissWarningBanner: vi.fn(),
     markConflictsAsSeen: vi.fn()
-  } as Partial<ReturnType<typeof useConflictAcknowledgment>> as ReturnType<
-    typeof useConflictAcknowledgment
-  >
+  }
 
   beforeEach(() => {
     pinia = createTestingPinia({ stubActions: false })
@@ -257,7 +255,7 @@ describe('useConflictDetection', () => {
     })
 
     it('should handle missing system stats gracefully', async () => {
-      mockSystemStatsStore.systemStats = null as never
+      mockSystemStatsStore.systemStats = null
 
       const { collectSystemEnvironment } = useConflictDetection()
       const environment = await collectSystemEnvironment()
@@ -281,7 +279,7 @@ describe('useConflictDetection', () => {
           id: 'test-pack',
           name: 'Test Pack',
           latest_version: { version: '1.0.0' }
-        } as components['schemas']['Node']
+        }
       ]
 
       mockInstalledPacksWithVersions.value = [
@@ -345,7 +343,7 @@ describe('useConflictDetection', () => {
         {
           id: 'banned-pack',
           name: 'Banned Pack'
-        } as components['schemas']['Node']
+        }
       ]
 
       mockInstalledPacksWithVersions.value = [
@@ -427,7 +425,7 @@ describe('useConflictDetection', () => {
       const { checkNodeCompatibility } = useConflictDetection()
       const { conflicts } = checkNodeCompatibility({
         status: 'NodeStatusBanned'
-      } as components['schemas']['Node'])
+      })
 
       expect(conflicts.map((c) => c.type)).toContain('banned')
     })
@@ -436,7 +434,7 @@ describe('useConflictDetection', () => {
       const { checkNodeCompatibility } = useConflictDetection()
       const { conflicts } = checkNodeCompatibility({
         status: 'NodeVersionStatusBanned'
-      } as components['schemas']['NodeVersion'])
+      })
 
       expect(conflicts.map((c) => c.type)).toContain('banned')
     })
@@ -445,7 +443,7 @@ describe('useConflictDetection', () => {
       const { checkNodeCompatibility } = useConflictDetection()
       const { conflicts } = checkNodeCompatibility({
         status: 'NodeVersionStatusPending'
-      } as components['schemas']['NodeVersion'])
+      })
 
       const types = conflicts.map((c) => c.type)
       expect(types).toContain('pending')
@@ -458,7 +456,7 @@ describe('useConflictDetection', () => {
         status: 'NodeVersionStatusActive',
         supported_os: ['Linux'],
         supported_accelerators: ['CUDA']
-      } as components['schemas']['NodeVersion'])
+      })
 
       expect(checkOSCompatibility).toHaveBeenCalledWith(['Linux'], undefined)
       expect(checkAcceleratorCompatibility).toHaveBeenCalledWith(

--- a/src/workbench/extensions/manager/composables/useConflictDetection.ts
+++ b/src/workbench/extensions/manager/composables/useConflictDetection.ts
@@ -218,9 +218,7 @@ export function useConflictDetection() {
             supported_comfyui_version: versionData.supported_comfyui_version,
             supported_comfyui_frontend_version:
               versionData.supported_comfyui_frontend_version,
-            supported_os: normalizeOSList(
-              versionData.supported_os
-            ) as Node['supported_os'],
+            supported_os: normalizeOSList(versionData.supported_os),
             supported_accelerators: versionData.supported_accelerators,
 
             // Status information

--- a/src/workbench/extensions/manager/stores/comfyManagerStore.test.ts
+++ b/src/workbench/extensions/manager/stores/comfyManagerStore.test.ts
@@ -7,9 +7,6 @@ import type { components as ManagerComponents } from '@/workbench/extensions/man
 
 type InstalledPacksResponse =
   ManagerComponents['schemas']['InstalledPacksResponse']
-type ManagerChannel = ManagerComponents['schemas']['ManagerChannel']
-type ManagerDatabaseSource =
-  ManagerComponents['schemas']['ManagerDatabaseSource']
 type ManagerPackInstalled = ManagerComponents['schemas']['ManagerPackInstalled']
 
 vi.mock('@/workbench/extensions/manager/services/comfyManagerService', () => ({
@@ -365,8 +362,8 @@ describe('useComfyManagerStore', () => {
       await store.installPack.call({
         id: 'test-pack',
         repository: 'https://github.com/test/test-pack',
-        channel: 'dev' as ManagerChannel,
-        mode: 'cache' as ManagerDatabaseSource,
+        channel: 'dev',
+        mode: 'cache',
         selected_version: 'latest',
         version: 'latest'
       })
@@ -382,8 +379,8 @@ describe('useComfyManagerStore', () => {
       await store.installPack.call({
         id: 'pack-1',
         repository: 'https://github.com/test/pack-1',
-        channel: 'dev' as ManagerChannel,
-        mode: 'cache' as ManagerDatabaseSource,
+        channel: 'dev',
+        mode: 'cache',
         selected_version: 'latest',
         version: 'latest'
       })
@@ -392,8 +389,8 @@ describe('useComfyManagerStore', () => {
       await store.installPack.call({
         id: 'pack-2',
         repository: 'https://github.com/test/pack-2',
-        channel: 'dev' as ManagerChannel,
-        mode: 'cache' as ManagerDatabaseSource,
+        channel: 'dev',
+        mode: 'cache',
         selected_version: 'latest',
         version: 'latest'
       })

--- a/src/workbench/extensions/manager/utils/packUpdateStatus.test.ts
+++ b/src/workbench/extensions/manager/utils/packUpdateStatus.test.ts
@@ -10,12 +10,14 @@ import {
 type NodePack = components['schemas']['Node']
 type ComfyManagerStore = ReturnType<typeof useComfyManagerStore>
 
-const createPack = (id: string | undefined, latestVersion?: string): NodePack =>
-  ({
-    id,
-    name: `Pack ${id}`,
-    latest_version: latestVersion ? { version: latestVersion } : undefined
-  }) as NodePack
+const createPack = (
+  id: string | undefined,
+  latestVersion?: string
+): NodePack => ({
+  id,
+  name: `Pack ${id}`,
+  latest_version: latestVersion ? { version: latestVersion } : undefined
+})
 
 const createStore = (
   installed: Record<string, string | undefined>

--- a/tools/oxlint-plugins/vitestCleanup.ts
+++ b/tools/oxlint-plugins/vitestCleanup.ts
@@ -328,7 +328,7 @@ function runsDirectlyInVitestCallback(
   const parent = ancestors[boundaryIndex - 1]
   return (
     isVitestCallbackCall(context, parent, callbackImports) &&
-    parent.arguments.includes(callback as Expression)
+    parent.arguments.includes(callback)
   )
 }
 

--- a/tools/oxlint-plugins/watchEffectRendering.ts
+++ b/tools/oxlint-plugins/watchEffectRendering.ts
@@ -150,8 +150,7 @@ function runsDirectlyInWatchEffect(
 
   const call = parent as CallExpression
   return (
-    call.arguments.includes(callback as Expression) &&
-    isVueWatchEffect(context, call.callee)
+    call.arguments.includes(callback) && isVueWatchEffect(context, call.callee)
   )
 }
 


### PR DESCRIPTION
## Summary

Enable `typescript/no-unnecessary-type-assertion` at error level and resolve its existing violations.

## Changes

- **What**: Remove 691 unnecessary type assertions across the frontend and browser tests.
- **What**: Replace assertions that masked incomplete typing with sound narrowing or explicit types.

## Review Focus

This is stacked on #16685. Review the non-mechanical typing changes; the remaining edits are Oxlint fixes.