### PR TITLE
fix(agent): gate the CRDT debug status strip behind DEV

### DIFF
--- a/src/workbench/extensions/agent/AgentPanelRoot.test.ts
+++ b/src/workbench/extensions/agent/AgentPanelRoot.test.ts
@@ -1831,19 +1831,27 @@ describe('AgentPanelRoot lifecycle', () => {
     expect(activity.$state.creatingTab).toBe(false)
   })
 
-  it('gates the CRDT debug status strip behind the same DEV check as CrdtDevPanel (CRDT-RM-7)', () => {
+  it('hides the CRDT debug status strip and CrdtDevPanel outside DEV (CRDT-RM-7)', () => {
     // Regression guard: this strip previously rendered for every user
     // whenever `crdtStatus.enabled` was true (which is unconditional), so it
     // shipped as always-on production telemetry regardless of DEV/prod. It
     // must stay gated behind the same `isCrdtDevPanelEnabled`
-    // (import.meta.env.DEV) check as the CrdtDevPanel it sits above, so the
-    // two mount/unmount together rather than the strip alone surviving a
-    // build where the dev panel does not.
+    // (import.meta.env.DEV) check as the CrdtDevPanel it sits above. Vitest
+    // runs with DEV=true, so the production side of the gate has to be
+    // exercised by stubbing the env before mount.
+    vi.stubEnv('DEV', false)
     render(AgentPanelRoot, { global: { plugins: [i18n] } })
 
-    const strip = screen.queryByTestId('agent-crdt-status')
-    const devPanel = screen.queryByTestId('crdt-dev-panel-chip')
-    expect(strip === null).toBe(devPanel === null)
+    expect(screen.queryByTestId('agent-crdt-status')).toBeNull()
+    expect(screen.queryByTestId('crdt-dev-panel')).toBeNull()
+  })
+
+  it('renders the CRDT debug status strip together with CrdtDevPanel in DEV', () => {
+    vi.stubEnv('DEV', true)
+    render(AgentPanelRoot, { global: { plugins: [i18n] } })
+
+    expect(screen.getByTestId('agent-crdt-status')).toBeInTheDocument()
+    expect(screen.getByTestId('crdt-dev-panel')).toBeInTheDocument()
   })
 })
 

--- a/src/workbench/extensions/agent/AgentPanelRoot.test.ts
+++ b/src/workbench/extensions/agent/AgentPanelRoot.test.ts
@@ -1830,6 +1830,21 @@ describe('AgentPanelRoot lifecycle', () => {
     expect(activity.$state.editingTabPath).toBeNull()
     expect(activity.$state.creatingTab).toBe(false)
   })
+
+  it('gates the CRDT debug status strip behind the same DEV check as CrdtDevPanel (CRDT-RM-7)', () => {
+    // Regression guard: this strip previously rendered for every user
+    // whenever `crdtStatus.enabled` was true (which is unconditional), so it
+    // shipped as always-on production telemetry regardless of DEV/prod. It
+    // must stay gated behind the same `isCrdtDevPanelEnabled`
+    // (import.meta.env.DEV) check as the CrdtDevPanel it sits above, so the
+    // two mount/unmount together rather than the strip alone surviving a
+    // build where the dev panel does not.
+    render(AgentPanelRoot, { global: { plugins: [i18n] } })
+
+    const strip = screen.queryByTestId('agent-crdt-status')
+    const devPanel = screen.queryByTestId('crdt-dev-panel-chip')
+    expect(strip === null).toBe(devPanel === null)
+  })
 })
 
 describe('AgentPanelRoot greeting', () => {

--- a/src/workbench/extensions/agent/AgentPanelRoot.vue
+++ b/src/workbench/extensions/agent/AgentPanelRoot.vue
@@ -963,7 +963,7 @@ function onPanelDrop(event: DragEvent): void {
       @change="onFilesPicked"
     />
     <div
-      v-if="crdtStatus.enabled"
+      v-if="isCrdtDevPanelEnabled && crdtStatus.enabled"
       class="border-b border-border-default bg-base-background px-3 py-1 font-mono text-muted"
       data-testid="agent-crdt-status"
     >

--- a/src/workbench/extensions/agent/crdt/RUN-CLOUD-E2E.md
+++ b/src/workbench/extensions/agent/crdt/RUN-CLOUD-E2E.md
@@ -29,7 +29,10 @@ agent panel, so the panel's product flag is the only gate.
 ## Verify
 
 - The status strip at the top of the agent panel (`data-testid="agent-crdt-status"`)
-  shows connected + the subscribed workflow id.
+  shows connected + the subscribed workflow id. The strip and the CrdtDevPanel below
+  it are DEV-only (`import.meta.env.DEV`), so they render under `pnpm dev` but not in
+  a production build such as a hosted preview; there, verify through the canvas
+  updates below and the `/ws` frames in the network tab instead.
 - Send a message in the agent chat; as the agent edits, `updatesApplied` increments and
   nodes move on the canvas.
 - Reload the tab mid-session: it resubscribes and reconverges from the seeded snapshot.


### PR DESCRIPTION
Closes the CRDT-RM-7 finding that the `agent-crdt-status` monospace strip in `AgentPanelRoot.vue` renders for every user with the agent panel open, not just in dev builds — because it is gated only on `crdtStatus.enabled`, which is hardcoded `true` in `useAgentCrdtFollower`'s status computed. The `CrdtDevPanel` instrument directly below it is already correctly gated on `isCrdtDevPanelEnabled` (`import.meta.env.DEV`); this strip was not.

## Change

Gate the strip on `isCrdtDevPanelEnabled && crdtStatus.enabled` so both debug surfaces mount/unmount together.

## Testing

- Added a regression test asserting the strip and the dev panel chip render/hide together.
- `AgentPanelRoot.test.ts` full file: 114/114 passing.
- `vue-tsc --noEmit`: clean.
- `eslint`: clean.

## Context

Prior work on this (PR #16209 / #16275, "port dev panel instrument to v2 ci-fix line") landed a much larger rework — a first-class debug-consent gate (`crdtDebugGate.ts`), snapshot/report helpers, and a fuller `CrdtDevPanel` — but only into the `christian-byrne/integration-candidate-v2-ci-fix` branch, which never reached `main`. That branch has diverged too far from current `main`'s follower architecture (`EcsFollowerAdapter`/`createOpSender` vs. the old `DocOp`/LiteGraph seams) to port directly; this PR is the minimal, narrowly-scoped fix for the concrete production-exposure gap on current `main`, tracked as todo row `CRDT-RM-7`.
