### PR TITLE
test: cover layer and mask editor regressions

### DIFF
--- a/.github/workflows/ci-tests-e2e.yaml
+++ b/.github/workflows/ci-tests-e2e.yaml
@@ -403,7 +403,7 @@ jobs:
           NEW_SPEC_FILES: ${{ steps.detect.outputs.files }}
         run: |
           FILES=$(echo "$NEW_SPEC_FILES" | tr '\n' ' ')
-          pnpm exec playwright test --project=chromium $FILES
+          pnpm exec playwright test --project=chromium --timeout=60000 $FILES
 
       - name: Upload new-test report (with embedded video)
         if: ${{ !cancelled() && steps.recordable.outputs.has-tests == 'true' }}

--- a/browser_tests/fixtures/helpers/LayerEditorHelper.ts
+++ b/browser_tests/fixtures/helpers/LayerEditorHelper.ts
@@ -1,0 +1,89 @@
+import type { Locator } from '@playwright/test'
+import { expect } from '@playwright/test'
+
+import type { ComfyPage } from '@e2e/fixtures/ComfyPage'
+import { comfyPageFixture } from '@e2e/fixtures/ComfyPage'
+import { assetPath } from '@e2e/fixtures/utils/paths'
+import { mockViewFiles } from '@e2e/fixtures/utils/viewFileMocks'
+
+class LayerEditorHelper {
+  public readonly dialog: Locator
+  public readonly layerRows: Locator
+  public readonly moveDownButton: Locator
+  public readonly undoButton: Locator
+  public readonly redoButton: Locator
+  public readonly xInput: Locator
+
+  constructor(private readonly comfyPage: ComfyPage) {
+    const { page } = comfyPage
+    this.dialog = page.getByRole('dialog').filter({
+      has: page.getByTestId('layer-panel-row')
+    })
+    this.layerRows = this.dialog.getByTestId('layer-panel-row')
+    this.moveDownButton = this.dialog.getByRole('button', {
+      name: 'Move layer down'
+    })
+    this.undoButton = this.dialog.getByRole('button', { name: 'Undo' })
+    this.redoButton = this.dialog.getByRole('button', { name: 'Redo' })
+    this.xInput = this.dialog.getByRole('spinbutton', { name: 'X' })
+  }
+
+  async open(): Promise<void> {
+    const { comfyPage } = this
+    await mockViewFiles(comfyPage.page, {
+      'layer-one.webp': {
+        contentType: 'image/webp',
+        path: assetPath('image64x64.webp')
+      },
+      'layer-two.webp': {
+        contentType: 'image/webp',
+        path: assetPath('image32x32.webp')
+      }
+    })
+    await comfyPage.settings.setSetting('Comfy.VueNodes.Enabled', true)
+    await comfyPage.workflow.loadWorkflow('default')
+    await comfyPage.vueNodes.waitForNodes()
+
+    const saveImageNodes =
+      await comfyPage.nodeOps.getNodeRefsByType('SaveImage')
+    expect(
+      saveImageNodes,
+      'Default workflow should have one Save Image node'
+    ).toHaveLength(1)
+    const nodeId = String(saveImageNodes[0].id)
+
+    await comfyPage.page.evaluate((id) => {
+      window.app!.nodeOutputs[id] = {
+        images: [
+          { filename: 'layer-one.webp', subfolder: '', type: 'output' },
+          { filename: 'layer-two.webp', subfolder: '', type: 'output' }
+        ]
+      }
+    }, nodeId)
+
+    const saveImage = await comfyPage.vueNodes.getFixtureByTitle('Save Image')
+    await saveImageNodes[0].centerOnNode()
+    const thumbnails = saveImage.imageGrid.getByRole('button')
+    await expect(thumbnails).toHaveCount(2)
+    await thumbnails.first().click()
+    await saveImage.imagePreview.getByRole('region').hover()
+    await saveImage.imagePreview.getByLabel('Open layer editor').click()
+
+    await expect(this.dialog).toBeVisible()
+    await expect(this.layerRows).toHaveCount(2)
+  }
+
+  async layerNames(): Promise<string[]> {
+    return await this.layerRows.locator('span[title]').allTextContents()
+  }
+}
+
+export const layerEditorTest = comfyPageFixture.extend<{
+  layerEditor: LayerEditorHelper
+}>({
+  layerEditor: async ({ comfyPage }, use) => {
+    const layerEditor = new LayerEditorHelper(comfyPage)
+    await layerEditor.open()
+    await use(layerEditor)
+  }
+})

--- a/browser_tests/fixtures/helpers/MaskEditorHelper.ts
+++ b/browser_tests/fixtures/helpers/MaskEditorHelper.ts
@@ -10,7 +10,11 @@ const RGB_CANVAS_INDEX = 1
 type BrushSliderLabel = 'thickness'
 
 class MaskEditorHelper {
-  constructor(private comfyPage: ComfyPage) {}
+  public readonly previewImage: Locator
+
+  constructor(private comfyPage: ComfyPage) {
+    this.previewImage = comfyPage.page.locator('.image-preview img').first()
+  }
 
   private get page() {
     return this.comfyPage.page
@@ -30,7 +34,7 @@ class MaskEditorHelper {
 
     const imagePreview = this.page.locator('.image-preview')
     await expect(imagePreview).toBeVisible()
-    await expect(imagePreview.locator('img')).toBeVisible()
+    await expect(this.previewImage).toBeVisible()
     await expect(imagePreview).toContainText('x')
 
     return {

--- a/browser_tests/tests/layerEditor/layerEditorHistory.spec.ts
+++ b/browser_tests/tests/layerEditor/layerEditorHistory.spec.ts
@@ -1,0 +1,33 @@
+import { expect } from '@playwright/test'
+
+import { layerEditorTest as test } from '@e2e/fixtures/helpers/LayerEditorHelper'
+
+test.describe('Layer Editor history', { tag: '@ui' }, () => {
+  test('reorders layers through undo and redo', async ({ layerEditor }) => {
+    const originalOrder = await layerEditor.layerNames()
+
+    await layerEditor.layerRows.first().click()
+    await layerEditor.moveDownButton.click()
+    await expect
+      .poll(() => layerEditor.layerNames())
+      .toEqual([...originalOrder].reverse())
+
+    await layerEditor.undoButton.click()
+    await expect.poll(() => layerEditor.layerNames()).toEqual(originalOrder)
+
+    await layerEditor.redoButton.click()
+    await expect
+      .poll(() => layerEditor.layerNames())
+      .toEqual([...originalOrder].reverse())
+  })
+
+  test('restores a cleared numeric field on blur', async ({ layerEditor }) => {
+    await layerEditor.layerRows.first().click()
+    const originalX = await layerEditor.xInput.inputValue()
+
+    await layerEditor.xInput.fill('')
+    await layerEditor.xInput.press('Tab')
+
+    await expect(layerEditor.xInput).toHaveValue(originalX)
+  })
+})

--- a/browser_tests/tests/maskEditorLoadSave.spec.ts
+++ b/browser_tests/tests/maskEditorLoadSave.spec.ts
@@ -83,6 +83,29 @@ test.describe('Mask Editor load/save', { tag: '@vue-nodes' }, () => {
       .toBe(savedMask)
   })
 
+  test('Saving immediately refreshes the node preview', async ({
+    maskEditor
+  }) => {
+    const dialog = await maskEditor.openDialog()
+    const originalPreview = await maskEditor.previewImage.getAttribute('src')
+    await maskEditor.drawStrokeAndExpectPixels(dialog)
+
+    await dialog.getByRole('button', { name: 'Save' }).click()
+
+    await expect(dialog).toBeHidden()
+    await expect(maskEditor.previewImage).not.toHaveAttribute(
+      'src',
+      originalPreview ?? ''
+    )
+    await expect
+      .poll(() =>
+        maskEditor.previewImage.evaluate((image) =>
+          image instanceof HTMLImageElement ? image.naturalWidth : 0
+        )
+      )
+      .toBeGreaterThan(0)
+  })
+
   test('Saving preserves image colors under the mask', async ({
     comfyPage,
     maskEditor


### PR DESCRIPTION
## Summary

Adds Playwright coverage for three maintainable cases from the frontend 1.53 QA plan.

## Changes

- **What**: Covers Layer Editor reorder history, numeric-field blur recovery, and immediate Mask Editor preview refresh after save.

## Review Focus

Check that the two-image Layer Editor fixture represents user-visible behavior without coupling the tests to editor internals.