### PR TITLE
ci: extend new-test video timeout

### DIFF
--- a/.github/workflows/ci-tests-e2e.yaml
+++ b/.github/workflows/ci-tests-e2e.yaml
@@ -403,7 +403,7 @@ jobs:
           NEW_SPEC_FILES: ${{ steps.detect.outputs.files }}
         run: |
           FILES=$(echo "$NEW_SPEC_FILES" | tr '\n' ' ')
-          pnpm exec playwright test --project=chromium $FILES
+          pnpm exec playwright test --project=chromium --timeout=60000 $FILES
 
       - name: Upload new-test report (with embedded video)
         if: ${{ !cancelled() && steps.recordable.outputs.has-tests == 'true' }}


### PR DESCRIPTION
## Summary

Allows new Playwright tests to finish when the video walkthrough job slows every browser action by one second.

## Changes

- **What**: Overrides the Chromium test timeout to 60 seconds only in the new-test video job.

## Review Focus

Confirm that 60 seconds gives slowed recordings enough time without changing normal Playwright project timeouts. This fixes the video failure observed in #16709.