### PR TITLE
fix(litegraph): avoid delete on widgetId in SubgraphNode

### DIFF
--- a/src/lib/litegraph/src/subgraph/SubgraphNode.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphNode.ts
@@ -348,7 +348,7 @@ export class SubgraphNode extends LGraphNode implements BaseLGraph {
 
         delete input.pos
         delete input.widget
-        delete input.widgetId
+        input.widgetId = undefined
         input._widget = undefined
         this.invalidatePromotedViews()
       },
@@ -656,7 +656,7 @@ export class SubgraphNode extends LGraphNode implements BaseLGraph {
       // that gets discarded), letting a later unrelated instance inherit
       // this value. onAdded() performs the deferred registration once a
       // real id is assigned.
-      delete input.widgetId
+      input.widgetId = undefined
       return
     }
 
@@ -677,7 +677,7 @@ export class SubgraphNode extends LGraphNode implements BaseLGraph {
     if (!registered) {
       delete input.pos
       delete input.widget
-      delete input.widgetId
+      input.widgetId = undefined
       input._widget = undefined
       return
     }


### PR DESCRIPTION
## Summary

Replaces `delete input.widgetId` with `input.widgetId = undefined` at the three call sites in `SubgraphNode.ts` (unlink cleanup, unassigned-node guard, failed-registration guard).

`widgetId` is an optional field (`widgetId?: WidgetId`, `src/lib/litegraph/src/interfaces.ts:375`), so assignment is a semantically equivalent, proxy-safe replacement for `delete`.

## Why

Follow-up from a review thread on the cloud/1.53 backport [#16679](https://github.com/Comfy-Org/ComfyUI_frontend/pull/16679#discussion_r3918521066):

> `delete` has been a source of issues with the compatibility proxies we're using. — @DrJKL

That backport kept the pattern byte-identical to `main` (it predates the change under review, also present at the merged core twin [#16678](https://github.com/Comfy-Org/ComfyUI_frontend/pull/16678)). This PR is the forward fix on `main`; both `cloud/1.53` and `core/1.53` can backport it once merged.

## Verification

- No caller checks key presence (`in` / `hasOwnProperty`) or serializes `input` directly — pure behavior-preserving substitution.
- `SubgraphNode.test.ts` + `SubgraphNode.titleButton.test.ts`: 61/61 passed.
- Full `src/lib/litegraph/src/subgraph/` suite: 323/323 passed.
- `eslint` on the changed file: 0 errors (2 pre-existing, unrelated warnings).
- Full-project `vue-tsc --noEmit`: clean.
