### PR TITLE
fix: synchronize agent widget mutations through core store

### DIFF
--- a/src/lib/litegraph/src/widgets/BaseWidget.ts
+++ b/src/lib/litegraph/src/widgets/BaseWidget.ts
@@ -177,18 +177,6 @@ export abstract class BaseWidget<TWidget extends IBaseWidget = IBaseWidget>
     return this._state.value
   }
   set value(value: TWidget['value']) {
-    const graphId = this.node.graph?.rootGraph.id
-    const nodeId = this._state.nodeId
-    if (
-      graphId &&
-      nodeId !== undefined &&
-      useWidgetValueStore().setValue(
-        widgetId(graphId, nodeId, this.name),
-        value
-      )
-    ) {
-      return
-    }
     this._state.value = value
   }
 

--- a/src/lib/litegraph/src/widgets/BaseWidget.ts
+++ b/src/lib/litegraph/src/widgets/BaseWidget.ts
@@ -177,6 +177,8 @@ export abstract class BaseWidget<TWidget extends IBaseWidget = IBaseWidget>
     return this._state.value
   }
   set value(value: TWidget['value']) {
+    const id = this.widgetId
+    if (id && useWidgetValueStore().setValue(id, value)) return
     this._state.value = value
   }
 

--- a/src/lib/litegraph/src/widgets/BaseWidget.ts
+++ b/src/lib/litegraph/src/widgets/BaseWidget.ts
@@ -177,8 +177,18 @@ export abstract class BaseWidget<TWidget extends IBaseWidget = IBaseWidget>
     return this._state.value
   }
   set value(value: TWidget['value']) {
-    const id = this.widgetId
-    if (id && useWidgetValueStore().setValue(id, value)) return
+    const graphId = this.node.graph?.rootGraph.id
+    const nodeId = this._state.nodeId
+    if (
+      graphId &&
+      nodeId !== undefined &&
+      useWidgetValueStore().setValue(
+        widgetId(graphId, nodeId, this.name),
+        value
+      )
+    ) {
+      return
+    }
     this._state.value = value
   }
 

--- a/src/renderer/core/layout/store/layoutStoreMintDelivery.test.ts
+++ b/src/renderer/core/layout/store/layoutStoreMintDelivery.test.ts
@@ -119,9 +119,6 @@ describe('mint ports against the real layout store delivery', () => {
       isDocBound: () => true,
       enqueue: (operations) => minted.push(...operations),
       layoutChanges: (listener) => layoutStore.onChange(listener),
-      withLayoutActor: (actor, fn) => {
-        layoutStore.withActor(actor, fn)
-      },
       localActorPrefix: 'user-',
       getGraph: () => graph
     })
@@ -216,14 +213,15 @@ describe('mint ports against the real layout store delivery', () => {
     expect(minted).toEqual([])
   })
 
-  it('the remote scope suppresses a real layout apply end to end', async () => {
+  it('remote provenance suppresses a real layout apply end to end', async () => {
     graphNodes.set('5', {
       id: toNodeId('5'),
       serialize: () => ({ id: 5, type: 'TestNode' })
     })
 
-    wiring.runRemoteScope(() => {
-      layoutStore.applyOperation(createNodeOp(graphId, '5'))
+    layoutStore.applyOperation({
+      ...createNodeOp(graphId, '5'),
+      source: LayoutSource.AgentRemote
     })
     await realDelivery()
 

--- a/src/stores/widgetValueStore.test.ts
+++ b/src/stores/widgetValueStore.test.ts
@@ -375,6 +375,25 @@ describe('useWidgetValueStore', () => {
       })
     })
 
+    it('does not leak mutation context into nested writes', () => {
+      const store = useWidgetValueStore()
+      const widget = store.registerWidget(seedA, state('number', 100))!
+      const context: RemoteMutationContext = {
+        source: 'agent-remote',
+        actor: 'agent:test',
+        opId: 'op-1'
+      }
+      const contexts: (RemoteMutationContext | undefined)[] = []
+      store.onValueChange((change) => {
+        contexts.push(change.context)
+        if (change.value === 200) widget.value = 201
+      })
+
+      store.setValue(seedA, 200, context)
+
+      expect(contexts).toEqual([context, undefined])
+    })
+
     it('stops reporting replaced and deleted widget state', () => {
       const store = useWidgetValueStore()
       const replaced = store.registerWidget(seedA, state('number', 1))!

--- a/src/stores/widgetValueStore.test.ts
+++ b/src/stores/widgetValueStore.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 
 import type { UUID } from '@/utils/uuid'
+import type { RemoteMutationContext } from '@/types/graphMutationContext'
 import { toNodeId } from '@/types/nodeId'
 import { widgetId } from '@/types/widgetId'
 import type { WidgetId } from '@/types/widgetId'
@@ -265,6 +266,25 @@ describe('useWidgetValueStore', () => {
   })
 
   describe('widget rename', () => {
+    it('reports subsequent changes with the new id', () => {
+      const store = useWidgetValueStore()
+      const renamed = widgetId(graphA, toNodeId('node-1'), 'renamed')
+      const onValueChange = vi.fn()
+      store.registerWidget(seedA, state('number', 1))
+      store.onValueChange(onValueChange)
+
+      const widget = store.renameWidget(seedA, renamed)!
+      widget.value = 2
+
+      expect(onValueChange).toHaveBeenCalledOnce()
+      expect(onValueChange).toHaveBeenCalledWith({
+        widgetId: renamed,
+        value: 2,
+        oldValue: 1,
+        context: undefined
+      })
+    })
+
     it('rejects an occupied destination without changing either widget', () => {
       const store = useWidgetValueStore()
       const nodeId = toNodeId('node-1')
@@ -323,6 +343,59 @@ describe('useWidgetValueStore', () => {
   })
 
   describe('value mutation', () => {
+    it('reports direct and contextual value changes exactly once', () => {
+      const store = useWidgetValueStore()
+      const widget = store.registerWidget(seedA, state('number', 100))!
+      const context: RemoteMutationContext = {
+        source: 'agent-remote',
+        actor: 'agent:test',
+        opId: 'op-1'
+      }
+      const onValueChange = vi.fn()
+      const unsubscribe = store.onValueChange(onValueChange)
+
+      widget.value = 200
+      store.setValue(seedA, 300, context)
+      store.setValue(seedA, 300)
+      unsubscribe()
+      widget.value = 400
+
+      expect(onValueChange).toHaveBeenCalledTimes(2)
+      expect(onValueChange).toHaveBeenNthCalledWith(1, {
+        widgetId: seedA,
+        value: 200,
+        oldValue: 100,
+        context: undefined
+      })
+      expect(onValueChange).toHaveBeenNthCalledWith(2, {
+        widgetId: seedA,
+        value: 300,
+        oldValue: 200,
+        context
+      })
+    })
+
+    it('stops reporting replaced and deleted widget state', () => {
+      const store = useWidgetValueStore()
+      const replaced = store.registerWidget(seedA, state('number', 1))!
+      const current = store.registerWidget(seedA, state('string', 'two'))!
+      const onValueChange = vi.fn()
+      store.onValueChange(onValueChange)
+
+      replaced.value = 3
+      current.value = 'three'
+      store.deleteWidget(seedA)
+      current.value = 'four'
+
+      expect(onValueChange).toHaveBeenCalledOnce()
+      expect(onValueChange).toHaveBeenCalledWith({
+        widgetId: seedA,
+        value: 'three',
+        oldValue: 'two',
+        context: undefined
+      })
+    })
+
     it('setValue updates registered widgets and reports missing widgets', () => {
       const store = useWidgetValueStore()
       store.registerWidget(seedA, state('number', 100))

--- a/src/stores/widgetValueStore.ts
+++ b/src/stores/widgetValueStore.ts
@@ -24,13 +24,6 @@ interface WidgetRestorationState {
   restoreNamed: boolean
 }
 
-export interface WidgetValueChange {
-  widgetId: WidgetId
-  value: WidgetState['value']
-  oldValue: WidgetState['value']
-  context: RemoteMutationContext | undefined
-}
-
 export function stripGraphPrefix(scopedId: SerializedNodeId): NodeId | null {
   return parseNodeId(String(scopedId).replace(/^(.*:)+/, ''))
 }
@@ -45,7 +38,6 @@ export const useWidgetValueStore = defineStore('widgetValue', () => {
     UUID,
     Map<NodeId, WidgetRestorationState>
   >()
-  const valueChangeListeners = new Set<(change: WidgetValueChange) => void>()
 
   function setNodeWidgetRestoration(
     graphId: UUID,
@@ -248,23 +240,12 @@ export const useWidgetValueStore = defineStore('widgetValue', () => {
   function setValue(
     widgetId: WidgetId,
     value: WidgetState['value'],
-    context?: RemoteMutationContext
+    _context?: RemoteMutationContext
   ): boolean {
     const state = getWidget(widgetId)
     if (!state) return false
-    const oldValue = state.value
     state.value = value
-    for (const listener of valueChangeListeners) {
-      listener({ widgetId, value, oldValue, context })
-    }
     return true
-  }
-
-  function onValueChange(
-    listener: (change: WidgetValueChange) => void
-  ): () => void {
-    valueChangeListeners.add(listener)
-    return () => valueChangeListeners.delete(listener)
   }
 
   function setLabel(widgetId: WidgetId, label: string): boolean {
@@ -462,7 +443,6 @@ export const useWidgetValueStore = defineStore('widgetValue', () => {
     getWidget,
     getWidgetRenderState,
     setValue,
-    onValueChange,
     setLabel,
     updateOptions,
     deleteWidget,

--- a/src/stores/widgetValueStore.ts
+++ b/src/stores/widgetValueStore.ts
@@ -1,11 +1,14 @@
 import { defineStore } from 'pinia'
-import { reactive, ref, watch } from 'vue'
-import type { WatchStopHandle } from 'vue'
+import { reactive, ref } from 'vue'
 
 import type { UUID } from '@/utils/uuid'
 import { parseNodeId } from '@/types/nodeId'
 import type { NodeId, SerializedNodeId } from '@/types/nodeId'
-import { isWidgetId, parseWidgetId } from '@/types/widgetId'
+import {
+  isWidgetId,
+  parseWidgetId,
+  widgetId as createWidgetId
+} from '@/types/widgetId'
 import type { WidgetId } from '@/types/widgetId'
 import type { WidgetValue } from '@/types/simplifiedWidget'
 import type { WidgetState, WidgetStateInit } from '@/types/widgetState'
@@ -47,34 +50,33 @@ export const useWidgetValueStore = defineStore('widgetValue', () => {
     Map<NodeId, WidgetRestorationState>
   >()
   const valueChangeListeners = new Set<(change: WidgetValueChange) => void>()
-  const valueWatchers = new Map<WidgetId, WatchStopHandle>()
-  let activeValueMutation:
-    | { state: WidgetState; context?: RemoteMutationContext }
-    | undefined
+  const valueMutationContexts = new WeakMap<
+    WidgetState,
+    RemoteMutationContext
+  >()
 
-  function watchValue(widgetId: WidgetId, state: WidgetState): void {
-    valueWatchers.get(widgetId)?.()
-    valueWatchers.set(
-      widgetId,
-      watch(
-        () => state.value,
-        (value, oldValue) => {
-          const context =
-            activeValueMutation?.state === state
-              ? activeValueMutation.context
-              : undefined
-          for (const listener of valueChangeListeners) {
-            listener({ widgetId, value, oldValue, context })
-          }
-        },
-        { flush: 'sync' }
-      )
-    )
-  }
-
-  function stopWatchingValue(widgetId: WidgetId): void {
-    valueWatchers.get(widgetId)?.()
-    valueWatchers.delete(widgetId)
+  function observeValue<TValue extends WidgetValue>(
+    state: WidgetState<TValue>,
+    graphId: UUID
+  ): void {
+    let value = state.value
+    Object.defineProperty(state, 'value', {
+      configurable: true,
+      enumerable: true,
+      get: () => value,
+      set: (nextValue: TValue) => {
+        if (Object.is(value, nextValue)) return
+        const oldValue = value
+        value = nextValue
+        const widgetId = createWidgetId(graphId, state.nodeId, state.name)
+        if (getWidget(widgetId) !== state) return
+        const context = valueMutationContexts.get(state)
+        valueMutationContexts.delete(state)
+        for (const listener of valueChangeListeners) {
+          listener({ widgetId, value, oldValue, context })
+        }
+      }
+    })
   }
 
   function onValueChange(
@@ -251,7 +253,7 @@ export const useWidgetValueStore = defineStore('widgetValue', () => {
       TType,
       TOptions
     >
-    watchValue(widgetId, registered)
+    observeValue(registered, graphId)
     return registered
   }
 
@@ -295,12 +297,11 @@ export const useWidgetValueStore = defineStore('widgetValue', () => {
   ): boolean {
     const state = getWidget(widgetId)
     if (!state) return false
-    const previousMutation = activeValueMutation
-    activeValueMutation = { state, context }
+    if (context) valueMutationContexts.set(state, context)
     try {
       state.value = value
     } finally {
-      activeValueMutation = previousMutation
+      valueMutationContexts.delete(state)
     }
     return true
   }
@@ -326,7 +327,6 @@ export const useWidgetValueStore = defineStore('widgetValue', () => {
     if (!isWidgetId(widgetId)) return false
 
     const { graphId } = parseWidgetId(widgetId)
-    stopWatchingValue(widgetId)
     graphWidgetRenderStates.value.get(graphId)?.delete(widgetId)
     removeNodeWidgetOrder(widgetId)
     return graphWidgetStates.value.get(graphId)?.delete(widgetId) ?? false
@@ -356,13 +356,11 @@ export const useWidgetValueStore = defineStore('widgetValue', () => {
     const index = order.indexOf(oldId)
 
     widgetStates.delete(oldId)
-    stopWatchingValue(oldId)
     renderStates.delete(oldId)
     if (index !== -1) order.splice(index, 1)
 
     state.name = name
     widgetStates.set(newId, state)
-    watchValue(newId, state)
     if (renderState) renderStates.set(newId, renderState)
     if (index !== -1) order.splice(index, 0, newId)
     else if (!order.includes(newId)) order.push(newId)
@@ -455,7 +453,6 @@ export const useWidgetValueStore = defineStore('widgetValue', () => {
 
     if (discardValues) {
       for (const widgetId of order) {
-        stopWatchingValue(widgetId)
         graphWidgetStates.value.get(graphId)?.delete(widgetId)
         graphWidgetRenderStates.value.get(graphId)?.delete(widgetId)
       }
@@ -474,7 +471,6 @@ export const useWidgetValueStore = defineStore('widgetValue', () => {
     if (widgetStates) {
       for (const [id, state] of widgetStates) {
         if (state.nodeId !== nodeId) continue
-        stopWatchingValue(id)
         widgetStates.delete(id)
         widgetRenderStates?.delete(id)
       }
@@ -490,9 +486,6 @@ export const useWidgetValueStore = defineStore('widgetValue', () => {
   }
 
   function clearGraph(graphId: UUID): void {
-    for (const widgetId of graphWidgetStates.value.get(graphId)?.keys() ?? []) {
-      stopWatchingValue(widgetId)
-    }
     graphWidgetStates.value.delete(graphId)
     graphWidgetRenderStates.value.delete(graphId)
     graphNodeWidgetOrders.value.delete(graphId)

--- a/src/stores/widgetValueStore.ts
+++ b/src/stores/widgetValueStore.ts
@@ -1,5 +1,6 @@
 import { defineStore } from 'pinia'
-import { reactive, ref } from 'vue'
+import { reactive, ref, watch } from 'vue'
+import type { WatchStopHandle } from 'vue'
 
 import type { UUID } from '@/utils/uuid'
 import { parseNodeId } from '@/types/nodeId'
@@ -24,6 +25,13 @@ interface WidgetRestorationState {
   restoreNamed: boolean
 }
 
+interface WidgetValueChange {
+  widgetId: WidgetId
+  value: WidgetValue
+  oldValue: WidgetValue
+  context?: RemoteMutationContext
+}
+
 export function stripGraphPrefix(scopedId: SerializedNodeId): NodeId | null {
   return parseNodeId(String(scopedId).replace(/^(.*:)+/, ''))
 }
@@ -38,6 +46,43 @@ export const useWidgetValueStore = defineStore('widgetValue', () => {
     UUID,
     Map<NodeId, WidgetRestorationState>
   >()
+  const valueChangeListeners = new Set<(change: WidgetValueChange) => void>()
+  const valueWatchers = new Map<WidgetId, WatchStopHandle>()
+  let activeValueMutation:
+    | { state: WidgetState; context?: RemoteMutationContext }
+    | undefined
+
+  function watchValue(widgetId: WidgetId, state: WidgetState): void {
+    valueWatchers.get(widgetId)?.()
+    valueWatchers.set(
+      widgetId,
+      watch(
+        () => state.value,
+        (value, oldValue) => {
+          const context =
+            activeValueMutation?.state === state
+              ? activeValueMutation.context
+              : undefined
+          for (const listener of valueChangeListeners) {
+            listener({ widgetId, value, oldValue, context })
+          }
+        },
+        { flush: 'sync' }
+      )
+    )
+  }
+
+  function stopWatchingValue(widgetId: WidgetId): void {
+    valueWatchers.get(widgetId)?.()
+    valueWatchers.delete(widgetId)
+  }
+
+  function onValueChange(
+    listener: (change: WidgetValueChange) => void
+  ): () => void {
+    valueChangeListeners.add(listener)
+    return () => valueChangeListeners.delete(listener)
+  }
 
   function setNodeWidgetRestoration(
     graphId: UUID,
@@ -201,7 +246,13 @@ export const useWidgetValueStore = defineStore('widgetValue', () => {
     const widgetStates = getGraphWidgetStates(graphId)
     widgetStates.set(widgetId, state)
     appendNodeWidgetOrder(widgetId)
-    return widgetStates.get(widgetId) as WidgetState<TValue, TType, TOptions>
+    const registered = widgetStates.get(widgetId) as WidgetState<
+      TValue,
+      TType,
+      TOptions
+    >
+    watchValue(widgetId, registered)
+    return registered
   }
 
   function registerWidgetRenderState(
@@ -240,11 +291,17 @@ export const useWidgetValueStore = defineStore('widgetValue', () => {
   function setValue(
     widgetId: WidgetId,
     value: WidgetState['value'],
-    _context?: RemoteMutationContext
+    context?: RemoteMutationContext
   ): boolean {
     const state = getWidget(widgetId)
     if (!state) return false
-    state.value = value
+    const previousMutation = activeValueMutation
+    activeValueMutation = { state, context }
+    try {
+      state.value = value
+    } finally {
+      activeValueMutation = previousMutation
+    }
     return true
   }
 
@@ -269,6 +326,7 @@ export const useWidgetValueStore = defineStore('widgetValue', () => {
     if (!isWidgetId(widgetId)) return false
 
     const { graphId } = parseWidgetId(widgetId)
+    stopWatchingValue(widgetId)
     graphWidgetRenderStates.value.get(graphId)?.delete(widgetId)
     removeNodeWidgetOrder(widgetId)
     return graphWidgetStates.value.get(graphId)?.delete(widgetId) ?? false
@@ -298,11 +356,13 @@ export const useWidgetValueStore = defineStore('widgetValue', () => {
     const index = order.indexOf(oldId)
 
     widgetStates.delete(oldId)
+    stopWatchingValue(oldId)
     renderStates.delete(oldId)
     if (index !== -1) order.splice(index, 1)
 
     state.name = name
     widgetStates.set(newId, state)
+    watchValue(newId, state)
     if (renderState) renderStates.set(newId, renderState)
     if (index !== -1) order.splice(index, 0, newId)
     else if (!order.includes(newId)) order.push(newId)
@@ -395,6 +455,7 @@ export const useWidgetValueStore = defineStore('widgetValue', () => {
 
     if (discardValues) {
       for (const widgetId of order) {
+        stopWatchingValue(widgetId)
         graphWidgetStates.value.get(graphId)?.delete(widgetId)
         graphWidgetRenderStates.value.get(graphId)?.delete(widgetId)
       }
@@ -413,6 +474,7 @@ export const useWidgetValueStore = defineStore('widgetValue', () => {
     if (widgetStates) {
       for (const [id, state] of widgetStates) {
         if (state.nodeId !== nodeId) continue
+        stopWatchingValue(id)
         widgetStates.delete(id)
         widgetRenderStates?.delete(id)
       }
@@ -428,6 +490,9 @@ export const useWidgetValueStore = defineStore('widgetValue', () => {
   }
 
   function clearGraph(graphId: UUID): void {
+    for (const widgetId of graphWidgetStates.value.get(graphId)?.keys() ?? []) {
+      stopWatchingValue(widgetId)
+    }
     graphWidgetStates.value.delete(graphId)
     graphWidgetRenderStates.value.delete(graphId)
     graphNodeWidgetOrders.value.delete(graphId)
@@ -442,6 +507,7 @@ export const useWidgetValueStore = defineStore('widgetValue', () => {
     getPositionalRestoredWidgetValue,
     getWidget,
     getWidgetRenderState,
+    onValueChange,
     setValue,
     setLabel,
     updateOptions,

--- a/src/stores/widgetValueStore.ts
+++ b/src/stores/widgetValueStore.ts
@@ -24,6 +24,13 @@ interface WidgetRestorationState {
   restoreNamed: boolean
 }
 
+export interface WidgetValueChange {
+  widgetId: WidgetId
+  value: WidgetState['value']
+  oldValue: WidgetState['value']
+  context: RemoteMutationContext | undefined
+}
+
 export function stripGraphPrefix(scopedId: SerializedNodeId): NodeId | null {
   return parseNodeId(String(scopedId).replace(/^(.*:)+/, ''))
 }
@@ -38,6 +45,7 @@ export const useWidgetValueStore = defineStore('widgetValue', () => {
     UUID,
     Map<NodeId, WidgetRestorationState>
   >()
+  const valueChangeListeners = new Set<(change: WidgetValueChange) => void>()
 
   function setNodeWidgetRestoration(
     graphId: UUID,
@@ -240,12 +248,23 @@ export const useWidgetValueStore = defineStore('widgetValue', () => {
   function setValue(
     widgetId: WidgetId,
     value: WidgetState['value'],
-    _context?: RemoteMutationContext
+    context?: RemoteMutationContext
   ): boolean {
     const state = getWidget(widgetId)
     if (!state) return false
+    const oldValue = state.value
     state.value = value
+    for (const listener of valueChangeListeners) {
+      listener({ widgetId, value, oldValue, context })
+    }
     return true
+  }
+
+  function onValueChange(
+    listener: (change: WidgetValueChange) => void
+  ): () => void {
+    valueChangeListeners.add(listener)
+    return () => valueChangeListeners.delete(listener)
   }
 
   function setLabel(widgetId: WidgetId, label: string): boolean {
@@ -443,6 +462,7 @@ export const useWidgetValueStore = defineStore('widgetValue', () => {
     getWidget,
     getWidgetRenderState,
     setValue,
+    onValueChange,
     setLabel,
     updateOptions,
     deleteWidget,

--- a/src/workbench/extensions/agent/AgentPanelRoot.vue
+++ b/src/workbench/extensions/agent/AgentPanelRoot.vue
@@ -414,7 +414,6 @@ const mintPortWiring = attachMintPortWiring({
   isDocBound: () => isBoundWorkflowActive.value,
   enqueue: enqueueHumanOperations,
   layoutChanges: (listener) => layoutStore.onChange(listener),
-  withLayoutActor: (actor, fn) => layoutStore.withActor(actor, fn),
   localActorPrefix: ACTOR_CONFIG.USER_PREFIX,
   getGraph: () => (app.isGraphReady ? app.rootGraph : null)
 })

--- a/src/workbench/extensions/agent/crdt/layoutMintPort.test.ts
+++ b/src/workbench/extensions/agent/crdt/layoutMintPort.test.ts
@@ -245,6 +245,15 @@ describe('attachLayoutMintPort', () => {
     expect(minted).toEqual([])
   })
 
+  it('uses call-carried source to suppress an echoed delete', () => {
+    const change = deleteChange('1', LOCAL_ACTOR)
+    change.operation.source = 'agent-remote'
+
+    deliver(change)
+
+    expect(minted).toEqual([])
+  })
+
   it('never mints an actor-less change (no call-carried provenance)', () => {
     const change = createNodeChange('1')
     delete change.operation.actor

--- a/src/workbench/extensions/agent/crdt/layoutMintPort.test.ts
+++ b/src/workbench/extensions/agent/crdt/layoutMintPort.test.ts
@@ -236,23 +236,19 @@ describe('attachLayoutMintPort', () => {
     ])
   })
 
-  it('uses call-carried source to suppress an echoed local actor', () => {
-    const change = createNodeChange('1', LOCAL_ACTOR)
-    change.operation.source = 'agent-remote'
+  it.for([
+    ['create', createNodeChange('1', LOCAL_ACTOR)],
+    ['delete', deleteChange('1', LOCAL_ACTOR)]
+  ] as const)(
+    'uses call-carried source to suppress an echoed %s',
+    ([_operation, change]) => {
+      change.operation.source = 'agent-remote'
 
-    deliver(change)
+      deliver(change)
 
-    expect(minted).toEqual([])
-  })
-
-  it('uses call-carried source to suppress an echoed delete', () => {
-    const change = deleteChange('1', LOCAL_ACTOR)
-    change.operation.source = 'agent-remote'
-
-    deliver(change)
-
-    expect(minted).toEqual([])
-  })
+      expect(minted).toEqual([])
+    }
+  )
 
   it('never mints an actor-less change (no call-carried provenance)', () => {
     const change = createNodeChange('1')

--- a/src/workbench/extensions/agent/crdt/layoutMintPort.test.ts
+++ b/src/workbench/extensions/agent/crdt/layoutMintPort.test.ts
@@ -5,7 +5,7 @@ import type { WorkflowNode } from '@comfyorg/comfy-multi-player'
 import { reportError } from '@/platform/telemetry/reportError'
 
 import type { GraphOperation } from './graphOperations'
-import { AGENT_REMOTE_ACTOR, attachLayoutMintPort } from './layoutMintPort'
+import { attachLayoutMintPort } from './layoutMintPort'
 import type { LayoutChangeView, LayoutMintPort } from './layoutMintPort'
 import { createMintSession } from './mintSession'
 import type { MintSession } from './mintSession'
@@ -236,12 +236,6 @@ describe('attachLayoutMintPort', () => {
     ])
   })
 
-  it('never mints an agent-remote echo (KA-6 sender half)', () => {
-    deliver(createNodeChange('1', AGENT_REMOTE_ACTOR))
-
-    expect(minted).toEqual([])
-  })
-
   it('uses call-carried source to suppress an echoed local actor', () => {
     const change = createNodeChange('1', LOCAL_ACTOR)
     change.operation.source = 'agent-remote'
@@ -306,11 +300,10 @@ describe('attachLayoutMintPort', () => {
     ])
   })
 
-  it('never mints a teardown-bracketed or agent-remote deleteNode', () => {
+  it('never mints a teardown-bracketed deleteNode', () => {
     session.beginGraphTeardown()
     deliver(deleteChange('1'))
     session.endGraphTeardown()
-    deliver(deleteChange('2', AGENT_REMOTE_ACTOR))
 
     expect(minted).toEqual([])
   })

--- a/src/workbench/extensions/agent/crdt/layoutMintPort.ts
+++ b/src/workbench/extensions/agent/crdt/layoutMintPort.ts
@@ -15,8 +15,6 @@ import type { SeveranceLog } from './linkMintPort'
 import { shouldMint } from './mintGate'
 import type { MintSession } from './mintSession'
 
-export const AGENT_REMOTE_ACTOR = 'agent-remote'
-
 /**
  * The structural slice of the layout store's LayoutChange this port reads.
  * Structural on purpose: the real feed passes the store's own change objects
@@ -83,7 +81,7 @@ export function attachLayoutMintPort(deps: LayoutMintPortDeps): LayoutMintPort {
       flagEnabled: deps.isEnabled(),
       docBound: deps.isDocBound(),
       localProvenance:
-        change.operation.source !== AGENT_REMOTE_ACTOR &&
+        change.operation.source !== 'agent-remote' &&
         actor !== undefined &&
         actor.startsWith(deps.localActorPrefix),
       teardown

--- a/src/workbench/extensions/agent/crdt/layoutMintPort.ts
+++ b/src/workbench/extensions/agent/crdt/layoutMintPort.ts
@@ -77,15 +77,15 @@ export function attachLayoutMintPort(deps: LayoutMintPortDeps): LayoutMintPort {
 
   function gate(change: LayoutChangeView, teardown: boolean): boolean {
     const actor = change.operation.actor
-    return shouldMint({
-      flagEnabled: deps.isEnabled(),
-      docBound: deps.isDocBound(),
-      localProvenance:
-        change.operation.source !== 'agent-remote' &&
-        actor !== undefined &&
-        actor.startsWith(deps.localActorPrefix),
-      teardown
-    })
+    return (
+      change.operation.source !== 'agent-remote' &&
+      actor?.startsWith(deps.localActorPrefix) === true &&
+      shouldMint({
+        flagEnabled: deps.isEnabled(),
+        docBound: deps.isDocBound(),
+        teardown
+      })
+    )
   }
 
   function reportUnrepresentableInteriorChange(

--- a/src/workbench/extensions/agent/crdt/linkMintPort.test.ts
+++ b/src/workbench/extensions/agent/crdt/linkMintPort.test.ts
@@ -98,12 +98,6 @@ describe('attachLinkMintPort', () => {
     ])
   })
 
-  it('never mints inside the remote-apply scope (KA-6 sender half)', () => {
-    session.runRemoteApply(() => place(ROOT_SCOPE, topology(41)))
-
-    expect(minted).toEqual([])
-  })
-
   it('never mints with the product flag off', () => {
     enabled = false
     place(ROOT_SCOPE, topology(41))
@@ -168,14 +162,13 @@ describe('attachLinkMintPort', () => {
     consoleError.mockRestore()
   })
 
-  it('stays silent for non-mintable severances (teardown and remote deletes)', async () => {
+  it('stays silent for teardown severances', async () => {
     const consoleError = vi
       .spyOn(console, 'error')
       .mockImplementation(() => undefined)
     session.beginGraphTeardown()
     remove(ROOT_SCOPE, topology(41))
     session.endGraphTeardown()
-    session.runRemoteApply(() => remove(ROOT_SCOPE, topology(42)))
     await afterSweep()
 
     expect(consoleError).not.toHaveBeenCalled()

--- a/src/workbench/extensions/agent/crdt/linkMintPort.ts
+++ b/src/workbench/extensions/agent/crdt/linkMintPort.ts
@@ -91,7 +91,7 @@ export function attachLinkMintPort(deps: LinkMintPortDeps): LinkMintPort {
     return shouldMint({
       flagEnabled: deps.isEnabled(),
       docBound: deps.isDocBound(),
-      localProvenance: !deps.session.inRemoteApply(),
+      localProvenance: true,
       teardown: deps.session.inTeardown()
     })
   }

--- a/src/workbench/extensions/agent/crdt/linkMintPort.ts
+++ b/src/workbench/extensions/agent/crdt/linkMintPort.ts
@@ -91,7 +91,6 @@ export function attachLinkMintPort(deps: LinkMintPortDeps): LinkMintPort {
     return shouldMint({
       flagEnabled: deps.isEnabled(),
       docBound: deps.isDocBound(),
-      localProvenance: true,
       teardown: deps.session.inTeardown()
     })
   }

--- a/src/workbench/extensions/agent/crdt/mintGate.test.ts
+++ b/src/workbench/extensions/agent/crdt/mintGate.test.ts
@@ -5,11 +5,10 @@ import { shouldMint } from './mintGate'
 const OPEN = {
   flagEnabled: true,
   docBound: true,
-  localProvenance: true,
   teardown: false
 }
 
-describe('shouldMint (the four-way zero-mint battery)', () => {
+describe('shouldMint', () => {
   it('mints only when every conjunct holds', () => {
     expect(shouldMint(OPEN)).toBe(true)
   })
@@ -20,10 +19,6 @@ describe('shouldMint (the four-way zero-mint battery)', () => {
 
   it('never mints without a bound doc', () => {
     expect(shouldMint({ ...OPEN, docBound: false })).toBe(false)
-  })
-
-  it('never mints for non-local provenance (agent-remote or load-driven)', () => {
-    expect(shouldMint({ ...OPEN, localProvenance: false })).toBe(false)
   })
 
   it('never mints for graph teardown (workflow load/switch/close clearing)', () => {

--- a/src/workbench/extensions/agent/crdt/mintGate.ts
+++ b/src/workbench/extensions/agent/crdt/mintGate.ts
@@ -1,6 +1,6 @@
 /**
- * The mint gate (plan 3.3): every human-edit mint hook is a no-op unless ALL
- * four conjuncts hold. Teardown is a first-class case — workflow load/switch/
+ * The mint gate (plan 3.3): every human-edit mint hook is a no-op unless all
+ * three conjuncts hold. Teardown is a first-class case — workflow load/switch/
  * close drives `clearGraph` and plural delete paths with no call-carried
  * provenance, and an ungated hook would mint a clear storm into the bound
  * doc on an ordinary tab switch.
@@ -10,17 +10,10 @@ export interface MintGateInput {
   flagEnabled: boolean
   /** A semantic doc is bound for the active workflow. */
   docBound: boolean
-  /** The mutation originates from a LOCAL human edit (not agent-remote, not load-driven). */
-  localProvenance: boolean
   /** The mutation is graph teardown (workflow load/switch/close clearing). */
   teardown: boolean
 }
 
 export function shouldMint(input: MintGateInput): boolean {
-  return (
-    input.flagEnabled &&
-    input.docBound &&
-    input.localProvenance &&
-    !input.teardown
-  )
+  return input.flagEnabled && input.docBound && !input.teardown
 }

--- a/src/workbench/extensions/agent/crdt/mintPortWiring.test.ts
+++ b/src/workbench/extensions/agent/crdt/mintPortWiring.test.ts
@@ -1,7 +1,7 @@
 import { createPinia, setActivePinia } from 'pinia'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
+import { LGraph, LGraphNode } from '@/lib/litegraph/src/litegraph'
 import type { GraphScope } from '@/types/graphScopeId'
 import type { RemoteMutationContext } from '@/types/graphMutationContext'
 import type { LinkTopology } from '@/types/linkTopology'
@@ -176,6 +176,28 @@ describe('attachMintPortWiring', () => {
     >[1])
 
     widgetStore.setValue(id, 42)
+
+    expect(minted).toEqual([
+      {
+        op: 'set_widget',
+        node_id: toNodeId(7),
+        widget: 'seed',
+        value: 42,
+        old: 3
+      }
+    ])
+  })
+
+  it('mints a widget value written through a real widget', () => {
+    const liveGraph = new LGraph()
+    liveGraph.id = ROOT_ID
+    const node = new LGraphNode('Test')
+    node.id = toNodeId(7)
+    liveGraph.add(node)
+    const widget = node.addWidget('number', 'seed', 3, () => undefined)
+    graphNodes.set('7', node)
+
+    widget.value = 42
 
     expect(minted).toEqual([
       {

--- a/src/workbench/extensions/agent/crdt/mintPortWiring.test.ts
+++ b/src/workbench/extensions/agent/crdt/mintPortWiring.test.ts
@@ -209,6 +209,30 @@ describe('attachMintPortWiring', () => {
     ])
   })
 
+  it('mints once when a store write is mirrored through the widget shim', () => {
+    const liveGraph = new LGraph()
+    liveGraph.id = ROOT_ID
+    const node = new LGraphNode('Test')
+    node.id = toNodeId(7)
+    liveGraph.add(node)
+    const widget = node.addWidget('number', 'seed', 3, () => undefined)
+    graphNodes.set('7', node)
+    const id = widgetId(ROOT_ID, toNodeId(7), 'seed')
+
+    useWidgetValueStore().setValue(id, 42)
+    widget.value = 42
+
+    expect(minted).toEqual([
+      {
+        op: 'set_widget',
+        node_id: toNodeId(7),
+        widget: 'seed',
+        value: 42,
+        old: 3
+      }
+    ])
+  })
+
   it('mints nothing for a setValue that did not apply', () => {
     useWidgetValueStore().setValue(widgetId(ROOT_ID, toNodeId(9), 'missing'), 1)
 

--- a/src/workbench/extensions/agent/crdt/mintPortWiring.test.ts
+++ b/src/workbench/extensions/agent/crdt/mintPortWiring.test.ts
@@ -90,7 +90,6 @@ describe('attachMintPortWiring', () => {
         layoutListeners.add(listener)
         return () => layoutListeners.delete(listener)
       },
-      withLayoutActor: (_actor, fn) => fn(),
       localActorPrefix: 'user-',
       getGraph: () => graph
     })
@@ -212,20 +211,6 @@ describe('attachMintPortWiring', () => {
 
   it('mints nothing for a setValue that did not apply', () => {
     useWidgetValueStore().setValue(widgetId(ROOT_ID, toNodeId(9), 'missing'), 1)
-
-    expect(minted).toEqual([])
-  })
-
-  it('suppresses every port inside the remote scope', () => {
-    wiring.runRemoteScope(() => {
-      useLinkStore().registerLink(ROOT_SCOPE, topology(41))
-      const widgetStore = useWidgetValueStore()
-      const id = widgetId(ROOT_ID, toNodeId(7), 'seed')
-      widgetStore.registerWidget(id, { type: 'number', value: 3 } as Parameters<
-        typeof widgetStore.registerWidget
-      >[1])
-      widgetStore.setValue(id, 42)
-    })
 
     expect(minted).toEqual([])
   })

--- a/src/workbench/extensions/agent/crdt/mintPortWiring.ts
+++ b/src/workbench/extensions/agent/crdt/mintPortWiring.ts
@@ -208,25 +208,21 @@ export function attachMintPortWiring(deps: MintPortWiringDeps): MintPortWiring {
     }
   })
 
-  const detachWidgetActions = widgetStore.$onAction(({ name, args, after }) => {
-    if (name !== 'setValue') return
-    const [id, value, context] = args
-    if (isRemoteMutationContext(context)) return
-    const old = widgetStore.getWidget(id)?.value
-    after((applied) => {
-      if (!applied) return
-      const { graphId, nodeId, name: widgetName } = parseWidgetId(id)
+  const detachWidgetChanges = widgetStore.onValueChange(
+    ({ widgetId, value, oldValue, context }) => {
+      if (isRemoteMutationContext(context)) return
+      const { graphId, nodeId, name: widgetName } = parseWidgetId(widgetId)
       for (const listener of setListeners) {
         listener({
           graphId: String(graphId),
           nodeId,
           name: widgetName,
           value,
-          old
+          old: oldValue
         })
       }
-    })
-  })
+    }
+  )
 
   let loadBracketOpen = false
 
@@ -248,7 +244,7 @@ export function attachMintPortWiring(deps: MintPortWiringDeps): MintPortWiring {
     detach() {
       activeWirings.delete(wiring)
       detachLinkActions()
-      detachWidgetActions()
+      detachWidgetChanges()
       widgetPort.detach()
       layoutPort.detach()
       linkPort.detach()

--- a/src/workbench/extensions/agent/crdt/mintPortWiring.ts
+++ b/src/workbench/extensions/agent/crdt/mintPortWiring.ts
@@ -208,18 +208,24 @@ export function attachMintPortWiring(deps: MintPortWiringDeps): MintPortWiring {
     }
   })
 
-  const detachWidgetActions = widgetStore.onValueChange((change) => {
-    if (isRemoteMutationContext(change.context)) return
-    const { graphId, nodeId, name: widgetName } = parseWidgetId(change.widgetId)
-    for (const listener of setListeners) {
-      listener({
-        graphId: String(graphId),
-        nodeId,
-        name: widgetName,
-        value: change.value,
-        old: change.oldValue
-      })
-    }
+  const detachWidgetActions = widgetStore.$onAction(({ name, args, after }) => {
+    if (name !== 'setValue') return
+    const [id, value, context] = args
+    if (isRemoteMutationContext(context)) return
+    const old = widgetStore.getWidget(id)?.value
+    after((applied) => {
+      if (!applied) return
+      const { graphId, nodeId, name: widgetName } = parseWidgetId(id)
+      for (const listener of setListeners) {
+        listener({
+          graphId: String(graphId),
+          nodeId,
+          name: widgetName,
+          value,
+          old
+        })
+      }
+    })
   })
 
   let loadBracketOpen = false

--- a/src/workbench/extensions/agent/crdt/mintPortWiring.ts
+++ b/src/workbench/extensions/agent/crdt/mintPortWiring.ts
@@ -1,10 +1,10 @@
 /**
  * Composition seam for the three mint ports. Layout pieces are injected
- * (workbench must not import renderer); link/widget adapt via Pinia $onAction,
- * which fires synchronously around each action. A replace maps to PLACED and
- * never DELETED (the store displaces incumbents internally). Load brackets
- * are a fail-closed boolean over beforeLoadGraph/afterConfigureGraph: a
- * failed load leaves mints suppressed until the next load's pair recloses.
+ * (workbench must not import renderer); link and widget events come from their
+ * owning stores. A replace maps to PLACED and never DELETED (the store
+ * displaces incumbents internally). Load brackets are a fail-closed boolean
+ * over beforeLoadGraph/afterConfigureGraph: a failed load leaves mints
+ * suppressed until the next load's pair recloses.
  */
 import type { LGraph } from '@/lib/litegraph/src/LGraph'
 import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
@@ -19,7 +19,7 @@ import { parseWidgetId } from '@/types/widgetId'
 import { findSubgraphNodePathById } from '@/utils/graphTraversalUtil'
 
 import type { GraphOperation } from './graphOperations'
-import { AGENT_REMOTE_ACTOR, attachLayoutMintPort } from './layoutMintPort'
+import { attachLayoutMintPort } from './layoutMintPort'
 import type { LayoutChangeView, LayoutMintPort } from './layoutMintPort'
 import { attachLinkMintPort } from './linkMintPort'
 import { attachWidgetMintPort } from './widgetMintPort'
@@ -43,8 +43,6 @@ export interface MintPortWiringDeps {
   enqueue(operations: GraphOperation[]): void
   /** The layout store's `onChange`, injected by the composition root. */
   layoutChanges(listener: (change: LayoutChangeView) => void): () => void
-  /** The layout store's `withActor`, injected by the composition root. */
-  withLayoutActor(actor: string, fn: () => void): void
   /** `ACTOR_CONFIG.USER_PREFIX`, injected by the composition root. */
   localActorPrefix: string
   /** The live root graph, or null when no workflow is open. */
@@ -53,8 +51,6 @@ export interface MintPortWiringDeps {
 
 export interface MintPortWiring {
   session: MintSession
-  /** Legacy compatibility scope; new remote store calls carry their context. */
-  runRemoteScope(apply: () => void): void
   /** The layout port's intentional-clear window (human clear paths only). */
   runIntentionalClear<T>(fn: () => T): T
   /** Forward from the app extension's `beforeLoadGraph` hook. */
@@ -212,35 +208,24 @@ export function attachMintPortWiring(deps: MintPortWiringDeps): MintPortWiring {
     }
   })
 
-  const detachWidgetActions = widgetStore.$onAction(({ name, args, after }) => {
-    if (name !== 'setValue') return
-    if (isRemoteMutationContext(args[2])) return
-    const widgetId = args[0]
-    const old = widgetStore.getWidget(widgetId)?.value
-    after((applied) => {
-      if (!applied) return
-      const { graphId, nodeId, name: widgetName } = parseWidgetId(widgetId)
-      for (const listener of setListeners) {
-        listener({
-          graphId: String(graphId),
-          nodeId,
-          name: widgetName,
-          value: args[1],
-          old
-        })
-      }
-    })
+  const detachWidgetActions = widgetStore.onValueChange((change) => {
+    if (isRemoteMutationContext(change.context)) return
+    const { graphId, nodeId, name: widgetName } = parseWidgetId(change.widgetId)
+    for (const listener of setListeners) {
+      listener({
+        graphId: String(graphId),
+        nodeId,
+        name: widgetName,
+        value: change.value,
+        old: change.oldValue
+      })
+    }
   })
 
   let loadBracketOpen = false
 
   const wiring: MintPortWiring = {
     session,
-    runRemoteScope(apply) {
-      session.runRemoteApply(() => {
-        deps.withLayoutActor(AGENT_REMOTE_ACTOR, apply)
-      })
-    },
     runIntentionalClear(fn) {
       return layoutPort.runIntentionalClear(fn)
     },

--- a/src/workbench/extensions/agent/crdt/mintSession.test.ts
+++ b/src/workbench/extensions/agent/crdt/mintSession.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest'
+import { describe, expect, it } from 'vitest'
 
 import { createMintSession } from './mintSession'
 
@@ -13,42 +13,5 @@ describe('createMintSession', () => {
 
     session.endGraphTeardown()
     expect(session.inTeardown()).toBe(false)
-  })
-
-  it('surfaces an async remote-apply fn loudly (continuations escape the scope)', () => {
-    const consoleError = vi
-      .spyOn(console, 'error')
-      .mockImplementation(() => undefined)
-    const session = createMintSession()
-
-    void session.runRemoteApply(async () => {})
-
-    expect(consoleError).toHaveBeenCalledOnce()
-    expect(session.inRemoteApply()).toBe(false)
-    consoleError.mockRestore()
-  })
-
-  it('stays silent for a synchronous remote-apply fn', () => {
-    const consoleError = vi
-      .spyOn(console, 'error')
-      .mockImplementation(() => undefined)
-    const session = createMintSession()
-
-    session.runRemoteApply(() => 42)
-
-    expect(consoleError).not.toHaveBeenCalled()
-    consoleError.mockRestore()
-  })
-
-  it('closes the remote-apply scope even when the body throws', () => {
-    const session = createMintSession()
-
-    expect(() =>
-      session.runRemoteApply(() => {
-        expect(session.inRemoteApply()).toBe(true)
-        throw new Error('applier rejected')
-      })
-    ).toThrow('applier rejected')
-    expect(session.inRemoteApply()).toBe(false)
   })
 })

--- a/src/workbench/extensions/agent/crdt/mintSession.ts
+++ b/src/workbench/extensions/agent/crdt/mintSession.ts
@@ -1,19 +1,11 @@
-/**
- * Shared mint scopes: ONE teardown bracket for all ports (a port missing a
- * bracket call is a mint storm), and a synchronous remote-apply flag for the
- * actor-less link/widget stores (layout keeps actor stamping instead).
- */
 export interface MintSession {
   beginGraphTeardown(): void
   endGraphTeardown(): void
   inTeardown(): boolean
-  runRemoteApply<T>(fn: () => T): T
-  inRemoteApply(): boolean
 }
 
 export function createMintSession(): MintSession {
   let teardownDepth = 0
-  let remoteApplyDepth = 0
 
   return {
     beginGraphTeardown() {
@@ -24,31 +16,6 @@ export function createMintSession(): MintSession {
     },
     inTeardown() {
       return teardownDepth > 0
-    },
-    runRemoteApply<T>(fn: () => T): T {
-      remoteApplyDepth++
-      try {
-        const result = fn()
-        if (
-          result !== null &&
-          typeof result === 'object' &&
-          'then' in result &&
-          typeof (result as { then: unknown }).then === 'function'
-        ) {
-          // The scope is synchronous by contract: any continuation after an
-          // await runs OUTSIDE it, and remote echoes there would mint straight
-          // into the bound doc. Surface the contract break loudly.
-          console.error(
-            '[agent-crdt] runRemoteApply received an async fn; continuations after the first await escape the remote scope'
-          )
-        }
-        return result
-      } finally {
-        remoteApplyDepth--
-      }
-    },
-    inRemoteApply() {
-      return remoteApplyDepth > 0
     }
   }
 }

--- a/src/workbench/extensions/agent/crdt/widgetMintPort.test.ts
+++ b/src/workbench/extensions/agent/crdt/widgetMintPort.test.ts
@@ -66,12 +66,6 @@ describe('attachWidgetMintPort', () => {
     ])
   })
 
-  it('never mints inside the remote-apply scope (KA-6 sender half)', () => {
-    session.runRemoteApply(() => deliver(widgetSet()))
-
-    expect(minted).toEqual([])
-  })
-
   it('never mints with the product flag off', () => {
     enabled = false
     deliver(widgetSet())

--- a/src/workbench/extensions/agent/crdt/widgetMintPort.ts
+++ b/src/workbench/extensions/agent/crdt/widgetMintPort.ts
@@ -53,7 +53,6 @@ export function attachWidgetMintPort(deps: WidgetMintPortDeps): WidgetMintPort {
     const mintable = shouldMint({
       flagEnabled: deps.isEnabled(),
       docBound: deps.isDocBound(),
-      localProvenance: true,
       teardown: deps.session.inTeardown()
     })
     if (!mintable) return

--- a/src/workbench/extensions/agent/crdt/widgetMintPort.ts
+++ b/src/workbench/extensions/agent/crdt/widgetMintPort.ts
@@ -53,7 +53,7 @@ export function attachWidgetMintPort(deps: WidgetMintPortDeps): WidgetMintPort {
     const mintable = shouldMint({
       flagEnabled: deps.isEnabled(),
       docBound: deps.isDocBound(),
-      localProvenance: !deps.session.inRemoteApply(),
+      localProvenance: true,
       teardown: deps.session.inTeardown()
     })
     if (!mintable) return


### PR DESCRIPTION
## Summary

Route agent graph mutations through canonical core APIs and observe widget changes at the widget store's reactive state boundary.

## Changes

- Remove the agent-only ambient remote-apply scope and injected layout actor adapter; use call-carried mutation provenance for echo suppression.
- Keep `BaseWidget.value` as a compatibility shim over its adopted store state instead of giving agent workflows special setter behavior.
- Expose typed widget-store value-change events for both store actions and direct adopted-proxy writes, with one event per actual transition.
- Consume canonical store events in agent mint wiring and suppress remotely sourced changes.

## Review Focus

Confirm the widget store is the correct canonical event boundary and that remote node mutations remain store-first through core `GraphMutations`, as required by the ECS ADRs.

Fixes [FE-1996](https://linear.app/comfyorg/issue/FE-1996/bug-agent-graph-mutations-bypass-canonical-node-and-widget-lifecycle)
