### PR TITLE
test(billing): assert real i18n interpolation in the add-payment preview

### DIFF
--- a/src/platform/workspace/components/SubscriptionAddPaymentPreviewWorkspace.test.ts
+++ b/src/platform/workspace/components/SubscriptionAddPaymentPreviewWorkspace.test.ts
@@ -1,6 +1,7 @@
 import userEvent from '@testing-library/user-event'
 import { render, screen } from '@testing-library/vue'
 import { describe, expect, it, vi } from 'vitest'
+import { createI18n } from 'vue-i18n'
 
 import type {
   PreviewSubscribeResponse,
@@ -44,23 +45,25 @@ function previewFixture(
   }
 }
 
-// Interpolation values are appended so assertions can verify what a message
-// was given, not just which message was chosen.
-vi.mock('vue-i18n', () => ({
-  useI18n: () => ({
-    t: (key: string, named?: Record<string, unknown>) =>
-      named
-        ? `${key}|${Object.entries(named)
-            .map(([name, value]) => `${name}=${String(value)}`)
-            .join(',')}`
-        : key,
-    n: (value: number) => value.toLocaleString('en-US'),
-    locale: { value: 'en' }
-  })
-}))
+// Only the renewal messages are supplied, so the renewal assertions verify
+// real interpolated output while every other key still renders as itself.
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: {
+    en: {
+      subscription: {
+        preview: {
+          renewsAt: 'Renews at {amount} on {date}. Cancel anytime.',
+          renewsAtAmount: 'Renews at {amount}. Cancel anytime.'
+        }
+      }
+    }
+  }
+})
 
 const globalOptions = {
-  mocks: { $t: (key: string) => key },
+  plugins: [i18n],
   stubs: {
     'i18n-t': { template: '<span />' },
     Button: {
@@ -449,9 +452,7 @@ describe('SubscriptionAddPaymentPreviewWorkspace', () => {
 
     expect(screen.getByText('$20.00')).toBeTruthy()
     expect(
-      screen.getByText(
-        'subscription.preview.renewsAt|amount=$20.00,date=Jun 19, 2027'
-      )
+      screen.getByText('Renews at $20.00 on Jun 19, 2027. Cancel anytime.')
     ).toBeTruthy()
   })
 })


### PR DESCRIPTION
## Summary

The add-payment preview test mocked `vue-i18n` wholesale, so its renewal assertion matched a string the mock itself had fabricated — real Vue I18n interpolation was never exercised. This supplies the renewal messages through a real `createI18n` plugin instead.

## Root cause

`SubscriptionAddPaymentPreviewWorkspace.test.ts` replaced the whole module:

```ts
vi.mock("vue-i18n", () => ({
  useI18n: () => ({
    t: (key, named) => named ? `${key}|${...named}` : key,
    ...
  })
}))
```

and asserted on the shape that mock produced:

```ts
screen.getByText("subscription.preview.renewsAt|amount=$20.00,date=Jun 19, 2027")
```

Both sides of that assertion come from the mock. The production message `subscription.preview.renewsAt` (`"Renews at {amount} on {date}. Cancel anytime."`) was never rendered, so the test could not fail on a broken placeholder, a renamed interpolation variable, or a malformed message — the exact defects it looks like it covers.

The component reaches i18n three ways (`$t` across the template, `t()` with named interpolation for `renewsAt`/`renewsAtAmount`, and `n()` for amounts), and mocking the module stubbed all three.

## What changed

Drop the module mock; register a real plugin, mirroring `SubscriptionTransitionPreviewWorkspace.test.ts` in the same directory:

```ts
const i18n = createI18n({
  legacy: false,
  locale: "en",
  messages: { en: { subscription: { preview: {
    renewsAt: "Renews at {amount} on {date}. Cancel anytime.",
    renewsAtAmount: "Renews at {amount}. Cancel anytime."
  } } } }
})

const globalOptions = { plugins: [i18n], stubs: { ... } }
```

Only the renewal messages are supplied. Vue I18n renders a missing key as the key itself, so the other 17 tests keep their key-based assertions untouched; one assertion becomes the rendered sentence.

Message text is copied verbatim from `src/locales/en/main.json`.

## Review focus

Mutation-checked rather than assumed. Changing the message to `"... on {wrongVar} ..."` fails exactly one test:

```
TestingLibraryElementError: Unable to find an element with the text:
Renews at $20.00 on Jun 19, 2027. Cancel anytime.
Tests  1 failed | 17 passed (18)
```

Under the old mock that mutation was invisible. Reverted, 18/18 pass.

`n()` needs no `numberFormats`: with none configured Vue I18n falls back to `Intl.NumberFormat("en")`, matching the `toLocaleString("en-US")` the mock used.

Test-only; no production code and no UI change, so there is no AS-IS/TO-BE to screenshot. `pnpm typecheck`, `pnpm lint`, `pnpm format` clean.

Raised in review on #16515, which was closed in favour of #16517; the code shipped and the comment was never addressed. Original thread: https://github.com/Comfy-Org/ComfyUI_frontend/pull/16515#discussion_r3904814046

## Regression coverage

Recording this explicitly, since the `End-To-End Regression Coverage For Fixes` pre-merge check came back inconclusive for want of the title and commit subjects:

- **PR title:** `test(billing): assert real i18n interpolation in the add-payment preview`
- **Commits (1):** `test(billing): assert real i18n interpolation in the add-payment preview`

Neither carries bug-fix language, and that is accurate: this is a `test:` change with **no production code in the diff**. The only file touched is `src/platform/workspace/components/SubscriptionAddPaymentPreviewWorkspace.test.ts`.

No `browser_tests/` change accompanies it, and none is warranted. Nothing about the app's runtime behaviour changes, so there is no regression for an E2E test to pin — the defect being closed is that an existing *unit* assertion could not fail, and the fix is that same unit test now exercising real Vue I18n interpolation. That is verified by the mutation check above (broken placeholder → 1 failed, 17 passed), which is a stronger guard than an E2E test would give here and lives at the right level.

Playwright is unaffected and green: 1913 passed, 0 failed.
