### PR TITLE
test: remove transient top-up assertion

### DIFF
--- a/browser_tests/tests/dialogs/creditsTile.spec.ts
+++ b/browser_tests/tests/dialogs/creditsTile.spec.ts
@@ -501,9 +501,6 @@ test.describe('Top-up 3DS verification', { tag: '@cloud' }, () => {
 
     await topupDialog.root.getByRole('button', { name: 'Pay $50.00' }).click()
 
-    await expect(
-      topupDialog.root.getByRole('button', { name: 'Back' })
-    ).toBeDisabled()
     await expect.poll(() => operationPollRequests.length).toBeGreaterThan(0)
     const verificationButton = topupDialog.root.getByRole('button', {
       name: 'Complete verification'


### PR DESCRIPTION
## Summary

Remove a transient assertion that made the cloud 3DS top-up test flaky after the dialog had already advanced to verification.

## Changes

- **What**: Stop expecting the confirmation step's Back button after payment polling starts. The test still verifies the poll request, verification UI, and popup parameters.

## Review Focus

The failing assertion appeared in 5 of 11 previous cloud runs. In each failure artifact, the dialog had already reached "Verify your payment," so the missing Back button was the expected next state.

Tested with 10 consecutive targeted cloud-project passes. ESLint, formatting, browser type checking, and project type checking pass.