### PR TITLE
refactor: reuse Vue-only widget placeholder

### DIFF
--- a/src/lib/litegraph/src/widgets/ChartWidget.ts
+++ b/src/lib/litegraph/src/widgets/ChartWidget.ts
@@ -1,5 +1,3 @@
-import { t } from '@/i18n'
-
 import type { IChartWidget } from '../types/widgets'
 import { BaseWidget } from './BaseWidget'
 import type { DrawWidgetOptions, WidgetEventOptions } from './BaseWidget'
@@ -15,32 +13,7 @@ export class ChartWidget
   override type = 'chart' as const
 
   drawWidget(ctx: CanvasRenderingContext2D, options: DrawWidgetOptions): void {
-    const { width } = options
-    const { y, height } = this
-
-    const { fillStyle, strokeStyle, textAlign, textBaseline, font } = ctx
-
-    ctx.fillStyle = this.background_color
-    ctx.fillRect(15, y, width - 30, height)
-
-    ctx.strokeStyle = this.getOutlineColor()
-    ctx.strokeRect(15, y, width - 30, height)
-
-    ctx.fillStyle = this.text_color
-    ctx.font = '11px monospace'
-    ctx.textAlign = 'center'
-    ctx.textBaseline = 'middle'
-
-    const text = `Chart: ${t('widgets.node2only')}`
-    ctx.fillText(text, width / 2, y + height / 2)
-
-    Object.assign(ctx, {
-      fillStyle,
-      strokeStyle,
-      textAlign,
-      textBaseline,
-      font
-    })
+    this.drawVueOnlyWarning(ctx, options, 'Chart')
   }
 
   onClick(_options: WidgetEventOptions): void {

--- a/src/lib/litegraph/src/widgets/FileUploadWidget.ts
+++ b/src/lib/litegraph/src/widgets/FileUploadWidget.ts
@@ -1,5 +1,3 @@
-import { t } from '@/i18n'
-
 import type { IFileUploadWidget } from '../types/widgets'
 import { BaseWidget } from './BaseWidget'
 import type { DrawWidgetOptions, WidgetEventOptions } from './BaseWidget'
@@ -15,32 +13,7 @@ export class FileUploadWidget
   override type = 'fileupload' as const
 
   drawWidget(ctx: CanvasRenderingContext2D, options: DrawWidgetOptions): void {
-    const { width } = options
-    const { y, height } = this
-
-    const { fillStyle, strokeStyle, textAlign, textBaseline, font } = ctx
-
-    ctx.fillStyle = this.background_color
-    ctx.fillRect(15, y, width - 30, height)
-
-    ctx.strokeStyle = this.getOutlineColor()
-    ctx.strokeRect(15, y, width - 30, height)
-
-    ctx.fillStyle = this.text_color
-    ctx.font = '11px monospace'
-    ctx.textAlign = 'center'
-    ctx.textBaseline = 'middle'
-
-    const text = `Fileupload: ${t('widgets.node2only')}`
-    ctx.fillText(text, width / 2, y + height / 2)
-
-    Object.assign(ctx, {
-      fillStyle,
-      strokeStyle,
-      textAlign,
-      textBaseline,
-      font
-    })
+    this.drawVueOnlyWarning(ctx, options, 'Fileupload')
   }
 
   onClick(_options: WidgetEventOptions): void {

--- a/src/lib/litegraph/src/widgets/GalleriaWidget.ts
+++ b/src/lib/litegraph/src/widgets/GalleriaWidget.ts
@@ -1,5 +1,3 @@
-import { t } from '@/i18n'
-
 import type { IGalleriaWidget } from '../types/widgets'
 import { BaseWidget } from './BaseWidget'
 import type { DrawWidgetOptions, WidgetEventOptions } from './BaseWidget'
@@ -15,32 +13,7 @@ export class GalleriaWidget
   override type = 'galleria' as const
 
   drawWidget(ctx: CanvasRenderingContext2D, options: DrawWidgetOptions): void {
-    const { width } = options
-    const { y, height } = this
-
-    const { fillStyle, strokeStyle, textAlign, textBaseline, font } = ctx
-
-    ctx.fillStyle = this.background_color
-    ctx.fillRect(15, y, width - 30, height)
-
-    ctx.strokeStyle = this.getOutlineColor()
-    ctx.strokeRect(15, y, width - 30, height)
-
-    ctx.fillStyle = this.text_color
-    ctx.font = '11px monospace'
-    ctx.textAlign = 'center'
-    ctx.textBaseline = 'middle'
-
-    const text = `Galleria: ${t('widgets.node2only')}`
-    ctx.fillText(text, width / 2, y + height / 2)
-
-    Object.assign(ctx, {
-      fillStyle,
-      strokeStyle,
-      textAlign,
-      textBaseline,
-      font
-    })
+    this.drawVueOnlyWarning(ctx, options, 'Galleria')
   }
 
   onClick(_options: WidgetEventOptions): void {

--- a/src/lib/litegraph/src/widgets/ImageCompareWidget.ts
+++ b/src/lib/litegraph/src/widgets/ImageCompareWidget.ts
@@ -1,5 +1,3 @@
-import { t } from '@/i18n'
-
 import type { IImageCompareWidget } from '../types/widgets'
 import { BaseWidget } from './BaseWidget'
 import type { DrawWidgetOptions, WidgetEventOptions } from './BaseWidget'
@@ -15,32 +13,7 @@ export class ImageCompareWidget
   override type = 'imagecompare' as const
 
   drawWidget(ctx: CanvasRenderingContext2D, options: DrawWidgetOptions): void {
-    const { width } = options
-    const { y, height } = this
-
-    const { fillStyle, strokeStyle, textAlign, textBaseline, font } = ctx
-
-    ctx.fillStyle = this.background_color
-    ctx.fillRect(15, y, width - 30, height)
-
-    ctx.strokeStyle = this.getOutlineColor()
-    ctx.strokeRect(15, y, width - 30, height)
-
-    ctx.fillStyle = this.text_color
-    ctx.font = '11px monospace'
-    ctx.textAlign = 'center'
-    ctx.textBaseline = 'middle'
-
-    const text = `ImageCompare: ${t('widgets.node2only')}`
-    ctx.fillText(text, width / 2, y + height / 2)
-
-    Object.assign(ctx, {
-      fillStyle,
-      strokeStyle,
-      textAlign,
-      textBaseline,
-      font
-    })
+    this.drawVueOnlyWarning(ctx, options, 'ImageCompare')
   }
 
   onClick(_options: WidgetEventOptions): void {

--- a/src/lib/litegraph/src/widgets/MarkdownWidget.ts
+++ b/src/lib/litegraph/src/widgets/MarkdownWidget.ts
@@ -1,5 +1,3 @@
-import { t } from '@/i18n'
-
 import type { IMarkdownWidget } from '../types/widgets'
 import { BaseWidget } from './BaseWidget'
 import type { DrawWidgetOptions, WidgetEventOptions } from './BaseWidget'
@@ -15,32 +13,7 @@ export class MarkdownWidget
   override type = 'markdown' as const
 
   drawWidget(ctx: CanvasRenderingContext2D, options: DrawWidgetOptions): void {
-    const { width } = options
-    const { y, height } = this
-
-    const { fillStyle, strokeStyle, textAlign, textBaseline, font } = ctx
-
-    ctx.fillStyle = this.background_color
-    ctx.fillRect(15, y, width - 30, height)
-
-    ctx.strokeStyle = this.getOutlineColor()
-    ctx.strokeRect(15, y, width - 30, height)
-
-    ctx.fillStyle = this.text_color
-    ctx.font = '11px monospace'
-    ctx.textAlign = 'center'
-    ctx.textBaseline = 'middle'
-
-    const text = `Markdown: ${t('widgets.node2only')}`
-    ctx.fillText(text, width / 2, y + height / 2)
-
-    Object.assign(ctx, {
-      fillStyle,
-      strokeStyle,
-      textAlign,
-      textBaseline,
-      font
-    })
+    this.drawVueOnlyWarning(ctx, options, 'Markdown')
   }
 
   onClick(_options: WidgetEventOptions): void {

--- a/src/lib/litegraph/src/widgets/MultiSelectWidget.ts
+++ b/src/lib/litegraph/src/widgets/MultiSelectWidget.ts
@@ -1,5 +1,3 @@
-import { t } from '@/i18n'
-
 import type { IMultiSelectWidget } from '../types/widgets'
 import { BaseWidget } from './BaseWidget'
 import type { DrawWidgetOptions, WidgetEventOptions } from './BaseWidget'
@@ -15,32 +13,7 @@ export class MultiSelectWidget
   override type = 'multiselect' as const
 
   drawWidget(ctx: CanvasRenderingContext2D, options: DrawWidgetOptions): void {
-    const { width } = options
-    const { y, height } = this
-
-    const { fillStyle, strokeStyle, textAlign, textBaseline, font } = ctx
-
-    ctx.fillStyle = this.background_color
-    ctx.fillRect(15, y, width - 30, height)
-
-    ctx.strokeStyle = this.getOutlineColor()
-    ctx.strokeRect(15, y, width - 30, height)
-
-    ctx.fillStyle = this.text_color
-    ctx.font = '11px monospace'
-    ctx.textAlign = 'center'
-    ctx.textBaseline = 'middle'
-
-    const text = `MultiSelect: ${t('widgets.node2only')}`
-    ctx.fillText(text, width / 2, y + height / 2)
-
-    Object.assign(ctx, {
-      fillStyle,
-      strokeStyle,
-      textAlign,
-      textBaseline,
-      font
-    })
+    this.drawVueOnlyWarning(ctx, options, 'MultiSelect')
   }
 
   onClick(_options: WidgetEventOptions): void {

--- a/src/lib/litegraph/src/widgets/SelectButtonWidget.ts
+++ b/src/lib/litegraph/src/widgets/SelectButtonWidget.ts
@@ -1,5 +1,3 @@
-import { t } from '@/i18n'
-
 import type { ISelectButtonWidget } from '../types/widgets'
 import { BaseWidget } from './BaseWidget'
 import type { DrawWidgetOptions, WidgetEventOptions } from './BaseWidget'
@@ -15,32 +13,7 @@ export class SelectButtonWidget
   override type = 'selectbutton' as const
 
   drawWidget(ctx: CanvasRenderingContext2D, options: DrawWidgetOptions): void {
-    const { width } = options
-    const { y, height } = this
-
-    const { fillStyle, strokeStyle, textAlign, textBaseline, font } = ctx
-
-    ctx.fillStyle = this.background_color
-    ctx.fillRect(15, y, width - 30, height)
-
-    ctx.strokeStyle = this.getOutlineColor()
-    ctx.strokeRect(15, y, width - 30, height)
-
-    ctx.fillStyle = this.text_color
-    ctx.font = '11px monospace'
-    ctx.textAlign = 'center'
-    ctx.textBaseline = 'middle'
-
-    const text = `SelectButton: ${t('widgets.node2only')}`
-    ctx.fillText(text, width / 2, y + height / 2)
-
-    Object.assign(ctx, {
-      fillStyle,
-      strokeStyle,
-      textAlign,
-      textBaseline,
-      font
-    })
+    this.drawVueOnlyWarning(ctx, options, 'SelectButton')
   }
 
   onClick(_options: WidgetEventOptions): void {


### PR DESCRIPTION
## Summary

Reuses the existing `BaseWidget` Vue-only placeholder renderer across the seven remaining duplicate widget implementations.

## Changes

- **What**: Replaces 196 lines of duplicated canvas drawing with calls to `drawVueOnlyWarning`.

## Review Focus

This intentionally leaves the other inherited Fallow findings unchanged:
- `BaseWidget.element` remains for extension compatibility and local DOM-widget detection; custom-node usage research found multiple extensions reading and assigning it.
- `layoutMintPort.onChange` remains an explicit three-operation switch; splitting its branches would move rather than reduce complexity.
- `AgentPanelRoot.onAgentActiveTab` retains inline async sequencing and stale-generation cleanup; extraction would obscure ordering without reducing behavior complexity.

Validation: targeted widget tests, typecheck, lint, format check, and `pnpm fallow:audit --base origin/main`.