### PR TITLE
fix: key TabGlobalParameters by active workflow to reset search on switch

### DIFF
--- a/src/components/rightSidePanel/RightSidePanel.test.ts
+++ b/src/components/rightSidePanel/RightSidePanel.test.ts
@@ -13,6 +13,8 @@ import {
 } from '@/lib/litegraph/src/subgraph/__fixtures__/subgraphHelpers'
 import enMessages from '@/locales/en/main.json' with { type: 'json' }
 import { useMissingModelStore } from '@/platform/missingModel/missingModelStore'
+import type { LoadedComfyWorkflow } from '@/platform/workflow/management/stores/workflowStore'
+import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import { useExecutionErrorStore } from '@/stores/executionErrorStore'
 import { useRightSidePanelStore } from '@/stores/workspace/rightSidePanelStore'
@@ -192,5 +194,78 @@ describe('RightSidePanel active tab fallback', () => {
     expect(screen.getByTestId('panel-tab-errors')).toBeInTheDocument()
     expect(rightSidePanelStore.activeTab).toBe('errors')
     expect(openPanel).not.toHaveBeenCalled()
+  })
+})
+
+describe('RightSidePanel global parameters tab', () => {
+  beforeEach(() => {
+    mockApp.rootGraph = null
+  })
+
+  function renderWithNoSelection(
+    activeWorkflowPath: string | null,
+    pinia = createTestingPinia({ createSpy: vi.fn, stubActions: false })
+  ) {
+    setActivePinia(pinia)
+
+    const rootGraph = new LGraph()
+    mockApp.rootGraph = rootGraph
+
+    const canvasStore = useCanvasStore()
+    canvasStore.currentGraph = rootGraph
+    canvasStore.selectedItems = []
+
+    const rightSidePanelStore = useRightSidePanelStore()
+    rightSidePanelStore.activeTab = 'parameters'
+
+    const workflowStore = useWorkflowStore()
+    workflowStore.activeWorkflow = activeWorkflowPath
+      ? ({ path: activeWorkflowPath } as LoadedComfyWorkflow)
+      : null
+
+    const i18n = createI18n({
+      legacy: false,
+      locale: 'en',
+      messages: { en: enMessages }
+    })
+
+    return render(RightSidePanel, {
+      global: {
+        plugins: [pinia, i18n],
+        stubs: {
+          Button: { template: '<button><slot /></button>' },
+          EditableText: true,
+          Tab: { template: '<button v-bind="$attrs"><slot /></button>' },
+          TabErrors: true,
+          TabGlobalParameters: {
+            template: '<div data-testid="tab-global-parameters" />'
+          },
+          TabInfo: true,
+          TabList: { template: '<div><slot /></div>' },
+          TabNormalInputs: true,
+          TabSettings: true
+        }
+      }
+    })
+  }
+
+  it('remounts TabGlobalParameters when the active workflow changes', async () => {
+    renderWithNoSelection('workflows/a.json')
+
+    const first = screen.getByTestId('tab-global-parameters')
+    expect(first).toBeInTheDocument()
+
+    const workflowStore = useWorkflowStore()
+    workflowStore.activeWorkflow = {
+      path: 'workflows/b.json'
+    } as LoadedComfyWorkflow
+    await nextTick()
+
+    // A genuine remount (not just a prop update) replaces the DOM node —
+    // the stub has no state, so this only proves identity changed via the
+    // `:key` binding, matching TabNodes/TabNormalInputs/subgraph views.
+    const second = screen.getByTestId('tab-global-parameters')
+    expect(second).toBeInTheDocument()
+    expect(second).not.toBe(first)
   })
 })

--- a/src/components/rightSidePanel/RightSidePanel.test.ts
+++ b/src/components/rightSidePanel/RightSidePanel.test.ts
@@ -47,6 +47,25 @@ vi.mock('@/platform/settings/settingStore', () => ({
   })
 }))
 
+function createPanelI18n() {
+  return createI18n({
+    legacy: false,
+    locale: 'en',
+    messages: { en: enMessages }
+  })
+}
+
+const panelStubs = {
+  Button: { template: '<button><slot /></button>' },
+  EditableText: true,
+  Tab: { template: '<button v-bind="$attrs"><slot /></button>' },
+  TabErrors: true,
+  TabInfo: true,
+  TabList: { template: '<div><slot /></div>' },
+  TabNormalInputs: true,
+  TabSettings: true
+}
+
 function renderPanel(
   activeTab: 'errors' | 'parameters' = 'errors',
   graphContext?: {
@@ -82,25 +101,10 @@ function renderPanel(
   )
   const openPanel = vi.spyOn(rightSidePanelStore, 'openPanel')
 
-  const i18n = createI18n({
-    legacy: false,
-    locale: 'en',
-    messages: { en: enMessages }
-  })
-
   const rendered = render(RightSidePanel, {
     global: {
-      plugins: [pinia, i18n],
-      stubs: {
-        Button: { template: '<button><slot /></button>' },
-        EditableText: true,
-        Tab: { template: '<button v-bind="$attrs"><slot /></button>' },
-        TabErrors: true,
-        TabInfo: true,
-        TabList: { template: '<div><slot /></div>' },
-        TabNormalInputs: true,
-        TabSettings: true
-      }
+      plugins: [pinia, createPanelI18n()],
+      stubs: panelStubs
     }
   })
 
@@ -207,6 +211,7 @@ describe('RightSidePanel global parameters tab', () => {
     pinia = createTestingPinia({ createSpy: vi.fn, stubActions: false })
   ) {
     setActivePinia(pinia)
+    const onTabGlobalParametersSetup = vi.fn()
 
     const rootGraph = new LGraph()
     mockApp.rootGraph = rootGraph
@@ -223,37 +228,28 @@ describe('RightSidePanel global parameters tab', () => {
       ? ({ path: activeWorkflowPath } as LoadedComfyWorkflow)
       : null
 
-    const i18n = createI18n({
-      legacy: false,
-      locale: 'en',
-      messages: { en: enMessages }
-    })
-
-    return render(RightSidePanel, {
+    const rendered = render(RightSidePanel, {
       global: {
-        plugins: [pinia, i18n],
+        plugins: [pinia, createPanelI18n()],
         stubs: {
-          Button: { template: '<button><slot /></button>' },
-          EditableText: true,
-          Tab: { template: '<button v-bind="$attrs"><slot /></button>' },
-          TabErrors: true,
+          ...panelStubs,
           TabGlobalParameters: {
+            setup: onTabGlobalParametersSetup,
             template: '<div data-testid="tab-global-parameters" />'
-          },
-          TabInfo: true,
-          TabList: { template: '<div><slot /></div>' },
-          TabNormalInputs: true,
-          TabSettings: true
+          }
         }
       }
     })
+
+    return { ...rendered, onTabGlobalParametersSetup }
   }
 
   it('remounts TabGlobalParameters when the active workflow changes', async () => {
-    renderWithNoSelection('workflows/a.json')
+    const { onTabGlobalParametersSetup } =
+      renderWithNoSelection('workflows/a.json')
 
     const first = screen.getByTestId('tab-global-parameters')
-    expect(first).toBeInTheDocument()
+    expect(onTabGlobalParametersSetup).toHaveBeenCalledTimes(1)
 
     const workflowStore = useWorkflowStore()
     workflowStore.activeWorkflow = {
@@ -261,11 +257,7 @@ describe('RightSidePanel global parameters tab', () => {
     } as LoadedComfyWorkflow
     await nextTick()
 
-    // A genuine remount (not just a prop update) replaces the DOM node —
-    // the stub has no state, so this only proves identity changed via the
-    // `:key` binding, matching TabNodes/TabNormalInputs/subgraph views.
-    const second = screen.getByTestId('tab-global-parameters')
-    expect(second).toBeInTheDocument()
-    expect(second).not.toBe(first)
+    expect(onTabGlobalParametersSetup).toHaveBeenCalledTimes(2)
+    expect(screen.getByTestId('tab-global-parameters')).not.toBe(first)
   })
 })

--- a/src/components/rightSidePanel/RightSidePanel.vue
+++ b/src/components/rightSidePanel/RightSidePanel.vue
@@ -435,7 +435,10 @@ function handleTitleCancel() {
     <div class="flex-1 scrollbar-thin overflow-y-auto">
       <TabErrors v-if="activeTab === 'errors'" />
       <template v-else-if="!hasSelection">
-        <TabGlobalParameters v-if="activeTab === 'parameters'" />
+        <TabGlobalParameters
+          v-if="activeTab === 'parameters'"
+          :key="workflowKey"
+        />
         <TabNodes v-else-if="activeTab === 'nodes'" :key="workflowKey" />
         <TabGlobalSettings v-else-if="activeTab === 'settings'" />
       </template>


### PR DESCRIPTION
## Summary

Follow-up to [#11416](https://github.com/Comfy-Org/ComfyUI_frontend/pull/11416), addressing a review thread that was still unresolved when the PR merged.

`RightSidePanel.vue` keys `TabNodes` (`:key="workflowKey"`), `TabNormalInputs` (`:key="selectedNodesKey"`), and the subgraph views (`:key="singleSubgraphKey"`) so they remount when the relevant identity changes. `TabGlobalParameters` (the Favorites tab shown with no selection) was left unkeyed, so it stays mounted across a workflow switch and its local favorited-widgets search query leaks into the next workflow's panel.

This PR adds `:key="workflowKey"` to `TabGlobalParameters`, matching the sibling tabs.

Addresses: https://github.com/Comfy-Org/ComfyUI_frontend/pull/11416#discussion_r3912701196

(The other unresolved thread on #11416, https://github.com/Comfy-Org/ComfyUI_frontend/pull/11416#discussion_r3916939371 suggesting `canvasStore.canvas?.graph?.nodes ?? []` in `TabNodes.vue`, is already the exact code on `main` — no action needed there.)

## Evidence

```
$ NODE_OPTIONS="--no-experimental-webstorage" npx vitest run src/components/rightSidePanel/RightSidePanel.test.ts src/components/rightSidePanel/parameters/TabGlobalParameters.test.ts src/components/rightSidePanel/parameters/TabNodes.test.ts
 Test Files  3 passed (3)
      Tests  8 passed (8)

$ npx vue-tsc --noEmit -p tsconfig.json
(exit 0, no errors)

$ npx eslint src/components/rightSidePanel/RightSidePanel.vue src/components/rightSidePanel/RightSidePanel.test.ts
(clean)
```

<!-- authored-by:agent lane-act-fe-11416-followup-4dd3055e -->
