### PR TITLE
fix: remove redundant explanation comments in useAgentCrdtFollower

### DIFF
--- a/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.ts
+++ b/src/workbench/extensions/agent/crdt/useAgentCrdtFollower.ts
@@ -431,9 +431,6 @@ export function useAgentCrdtFollower(
             seq?: number
           })
         : undefined
-    // The bridge already replaced its doc for this lineage break, whether or
-    // not this target is active, so count it before the filter like the other
-    // bridge-decided outcomes (gap, dropped, errored).
     outcomes.value = { ...outcomes.value, reset: outcomes.value.reset + 1 }
     if (
       !isTargetActive.value ||
@@ -499,10 +496,6 @@ export function useAgentCrdtFollower(
       event instanceof CustomEvent ? (event.detail ?? null) : null
     )
   }
-  // s5-metrics-1: the bridge withholds a frame and forces a resubscribe when
-  // it detects a seq jump (FEB-2) — that frame never becomes a `doc_update`
-  // event, so `gap` can only be counted from the bridge's own `doc_gap`
-  // signal, not inferred inside `onUpdate`.
   const onGap: EventListener = (event) => {
     outcomes.value = { ...outcomes.value, gap: outcomes.value.gap + 1 }
     recordDevEvent(
@@ -510,9 +503,6 @@ export function useAgentCrdtFollower(
       event instanceof CustomEvent ? (event.detail ?? null) : null
     )
   }
-  // s5-metrics-1: a stale/duplicate frame is discarded inside the bridge
-  // before it becomes a `doc_update` event, so `dropped` is likewise counted
-  // from the bridge's own `doc_stale` signal.
   const onStale: EventListener = (event) => {
     outcomes.value = { ...outcomes.value, dropped: outcomes.value.dropped + 1 }
     recordDevEvent(


### PR DESCRIPTION
Follow-up to [#16700](https://github.com/Comfy-Org/ComfyUI_frontend/pull/16700), addressing two review threads that were unaddressed at merge time.

Removes two comment blocks in `src/workbench/extensions/agent/crdt/useAgentCrdtFollower.ts` that only paraphrased adjacent code/tests rather than preserving information the implementation could not express:

- `onDocReset`: the 3-line comment restating increment-before-filter ordering ([thread](https://github.com/Comfy-Org/ComfyUI_frontend/pull/16700#discussion_r3919272719)) — already covered by the inactive-reset regression test.
- `onGap` / `onStale`: both comment blocks restating routing that `onGap`, `doc_gap`, `onStale`, and `doc_stale` already state ([thread](https://github.com/Comfy-Org/ComfyUI_frontend/pull/16700#discussion_r3919272721)) — already pinned by the bridge tests.

No behavior change; comment-only removal.

## Evidence

- `NODE_OPTIONS="--no-experimental-webstorage" npx vitest run src/workbench/extensions/agent/crdt/useAgentCrdtFollower.test.ts` — 38/38 passed
- `pnpm typecheck` — clean
- `npx eslint src/workbench/extensions/agent/crdt/useAgentCrdtFollower.ts` — clean
- pre-commit lint-staged (oxfmt/oxlint/eslint/typecheck) — clean

<!-- authored-by:agent lane-act-fe-16700-followup-dac18fc8 -->