### PR TITLE
test: add lint prohibition on comfyPage.setup() re-calls in tests

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -165,6 +165,12 @@
       }
     },
     {
+      "files": ["browser_tests/tests/**/*.spec.ts", "apps/*/e2e/**/*.spec.ts"],
+      "rules": {
+        "comfy/no-comfy-page-setup-call": "error"
+      }
+    },
+    {
       "files": ["browser_tests/**/*.ts"],
       "jsPlugins": ["eslint-plugin-playwright"],
       "rules": {

--- a/browser_tests/tests/colorPalette.spec.ts
+++ b/browser_tests/tests/colorPalette.spec.ts
@@ -153,6 +153,7 @@ test.describe('Color Palette', { tag: ['@screenshot', '@settings'] }, () => {
     )
     // Reload to apply the new setting. Setting Comfy.CustomColorPalettes directly
     // doesn't update the store immediately.
+    // oxlint-disable-next-line comfy/no-comfy-page-setup-call -- pre-existing call, tracked by evfail-23; not fixed in this pass
     await comfyPage.setup()
 
     await comfyPage.workflow.loadWorkflow('nodes/every_node_color')

--- a/browser_tests/tests/dialogs/managerDialog.spec.ts
+++ b/browser_tests/tests/dialogs/managerDialog.spec.ts
@@ -247,6 +247,7 @@ test.describe('ManagerDialog', { tag: '@ui' }, () => {
       }
     )
 
+    // oxlint-disable-next-line comfy/no-comfy-page-setup-call -- pre-existing call, tracked by evfail-23; not fixed in this pass
     await comfyPage.setup()
 
     // Seed manager-ready server feature flags AFTER setup so the WebSocket

--- a/browser_tests/tests/dialogs/openSharedWorkflowDialog.spec.ts
+++ b/browser_tests/tests/dialogs/openSharedWorkflowDialog.spec.ts
@@ -49,6 +49,7 @@ test.describe('Open shared workflow dialog', { tag: '@ui' }, () => {
   }) => {
     const { page } = comfyPage
     await mockLongNameSharedWorkflow(page)
+    // oxlint-disable-next-line comfy/no-comfy-page-setup-call -- pre-existing call, tracked by evfail-23; not fixed in this pass
     await comfyPage.setup({ clearStorage: false, url: `/?share=${shareId}` })
 
     const dialog = page.getByTestId(TestIds.dialogs.openSharedWorkflow)

--- a/browser_tests/tests/dialogs/settingsDialog.spec.ts
+++ b/browser_tests/tests/dialogs/settingsDialog.spec.ts
@@ -19,6 +19,7 @@ test.describe('Settings dialog', { tag: '@ui' }, () => {
     await comfyPage.page.route('**/system_stats**', async (route) => {
       await route.fulfill({ json: stats })
     })
+    // oxlint-disable-next-line comfy/no-comfy-page-setup-call -- pre-existing call, tracked by evfail-23; not fixed in this pass
     await comfyPage.setup()
 
     const dialog = comfyPage.settingDialog

--- a/browser_tests/tests/errorOverlay.spec.ts
+++ b/browser_tests/tests/errorOverlay.spec.ts
@@ -100,6 +100,7 @@ test.describe('Error overlay', { tag: '@ui' }, () => {
 
   test.describe('View details flow', () => {
     test.beforeEach(async ({ comfyPage }) => {
+      // oxlint-disable-next-line comfy/no-comfy-page-setup-call -- pre-existing call, tracked by evfail-23; not fixed in this pass
       await comfyPage.setup()
     })
 

--- a/browser_tests/tests/gettingStartedTour.spec.ts
+++ b/browser_tests/tests/gettingStartedTour.spec.ts
@@ -399,6 +399,7 @@ test.describe('First-run tour', { tag: ['@cloud', '@ui'] }, () => {
   test.describe('arriving on a template link', () => {
     test.beforeEach(async ({ comfyPage }) => {
       await clearWorkflowHistory(comfyPage.page)
+      // oxlint-disable-next-line comfy/no-comfy-page-setup-call -- pre-existing call, tracked by evfail-23; not fixed in this pass
       await comfyPage.setup({
         clearStorage: false,
         url: `/?template=${LINKED_TEMPLATE_ID}`
@@ -487,6 +488,7 @@ test.describe('First-run tour', { tag: ['@cloud', '@ui'] }, () => {
   test.describe('arriving on a link that loads nothing', () => {
     test.beforeEach(async ({ comfyPage }) => {
       await clearWorkflowHistory(comfyPage.page)
+      // oxlint-disable-next-line comfy/no-comfy-page-setup-call -- pre-existing call, tracked by evfail-23; not fixed in this pass
       await comfyPage.setup({
         clearStorage: false,
         url: '/?template=no_such_template_exists'

--- a/browser_tests/tests/helpCenter.spec.ts
+++ b/browser_tests/tests/helpCenter.spec.ts
@@ -138,6 +138,7 @@ test.describe('Help Center', () => {
       )
 
       await helpCenter.mockReleases(releases)
+      // oxlint-disable-next-line comfy/no-comfy-page-setup-call -- pre-existing call, tracked by evfail-23; not fixed in this pass
       await comfyPage.setup({ mockReleases: false })
       await helpCenter.open()
 
@@ -157,6 +158,7 @@ test.describe('Help Center', () => {
 
       await helpCenter.mockReleases([release])
       await helpCenter.stubDocsPage()
+      // oxlint-disable-next-line comfy/no-comfy-page-setup-call -- pre-existing call, tracked by evfail-23; not fixed in this pass
       await comfyPage.setup({ mockReleases: false })
       await helpCenter.open()
 

--- a/browser_tests/tests/interaction.spec.ts
+++ b/browser_tests/tests/interaction.spec.ts
@@ -818,6 +818,7 @@ test.describe('Load workflow', { tag: '@screenshot' }, () => {
     comfyPage
   }) => {
     await comfyPage.settings.setSetting('Comfy.Workflow.Persist', false)
+    // oxlint-disable-next-line comfy/no-comfy-page-setup-call -- pre-existing call, tracked by evfail-23; not fixed in this pass
     await comfyPage.setup()
 
     await expect
@@ -835,6 +836,7 @@ test.describe('Load workflow', { tag: '@screenshot' }, () => {
   }) => {
     await comfyPage.workflow.loadWorkflow('nodes/single_ksampler')
     await expect(comfyPage.canvas).toHaveScreenshot('single_ksampler.png')
+    // oxlint-disable-next-line comfy/no-comfy-page-setup-call -- pre-existing call, tracked by evfail-23; not fixed in this pass
     await comfyPage.setup({ clearStorage: false })
     await expect(comfyPage.canvas).toHaveScreenshot('single_ksampler.png')
   })
@@ -868,6 +870,7 @@ test.describe('Load workflow', { tag: '@screenshot' }, () => {
       }
       return false
     }, start)
+    // oxlint-disable-next-line comfy/no-comfy-page-setup-call -- pre-existing call, tracked by evfail-23; not fixed in this pass
     await comfyPage.setup({ clearStorage: false })
     await expect(comfyPage.canvas).toHaveScreenshot(
       'single_ksampler_modified.png'
@@ -900,6 +903,7 @@ test.describe('Load workflow', { tag: '@screenshot' }, () => {
         }
         return false
       })
+      // oxlint-disable-next-line comfy/no-comfy-page-setup-call -- pre-existing call, tracked by evfail-23; not fixed in this pass
       await comfyPage.setup({ clearStorage: false })
     })
 
@@ -979,6 +983,7 @@ test.describe('Load workflow', { tag: '@screenshot' }, () => {
       await comfyPage.page.evaluate(() => {
         sessionStorage.clear()
       })
+      // oxlint-disable-next-line comfy/no-comfy-page-setup-call -- pre-existing call, tracked by evfail-23; not fixed in this pass
       await comfyPage.setup({ clearStorage: false })
     })
 

--- a/browser_tests/tests/keyboardShortcutActions.spec.ts
+++ b/browser_tests/tests/keyboardShortcutActions.spec.ts
@@ -10,6 +10,7 @@ test.describe('Keyboard shortcut actions', { tag: '@keyboard' }, () => {
       'Comfy.Workflow.WorkflowTabsPosition',
       'Topbar'
     )
+    // oxlint-disable-next-line comfy/no-comfy-page-setup-call -- pre-existing call, tracked by evfail-23; not fixed in this pass
     await comfyPage.setup()
   })
 

--- a/browser_tests/tests/loginButton.spec.ts
+++ b/browser_tests/tests/loginButton.spec.ts
@@ -6,6 +6,7 @@ import { TestIds } from '@e2e/fixtures/selectors'
 
 test.describe('Login Button', { tag: ['@ui'] }, () => {
   test.beforeEach(async ({ comfyPage }) => {
+    // oxlint-disable-next-line comfy/no-comfy-page-setup-call -- pre-existing call, tracked by evfail-23; not fixed in this pass
     await comfyPage.setup()
   })
 

--- a/browser_tests/tests/menu.spec.ts
+++ b/browser_tests/tests/menu.spec.ts
@@ -265,6 +265,7 @@ test.describe('Menu', { tag: '@ui' }, () => {
       comfyPage
     }) => {
       await comfyPage.settings.setSetting('Comfy.UseNewMenu', position)
+      // oxlint-disable-next-line comfy/no-comfy-page-setup-call -- pre-existing call, tracked by evfail-23; not fixed in this pass
       await comfyPage.setup()
       await expect
         .poll(() => comfyPage.settings.getSetting('Comfy.UseNewMenu'))

--- a/browser_tests/tests/nodeSearchBox.spec.ts
+++ b/browser_tests/tests/nodeSearchBox.spec.ts
@@ -55,6 +55,7 @@ test.describe('Node search box', { tag: '@node' }, () => {
     comfyPage
   }) => {
     // Start fresh to test new user behavior
+    // oxlint-disable-next-line comfy/no-comfy-page-setup-call -- pre-existing call, tracked by evfail-23; not fixed in this pass
     await comfyPage.setup({ clearStorage: true })
     // Simulate new user with 1.24.1+ installed version
     await comfyPage.settings.setSetting('Comfy.InstalledVersion', '1.24.1')
@@ -333,6 +334,7 @@ test.describe('Release context menu', { tag: '@node' }, () => {
     comfyPage
   }) => {
     // Start fresh to test existing user behavior
+    // oxlint-disable-next-line comfy/no-comfy-page-setup-call -- pre-existing call, tracked by evfail-23; not fixed in this pass
     await comfyPage.setup({ clearStorage: true })
     // Simulate existing user with pre-1.24.1 version
     await comfyPage.settings.setSetting('Comfy.InstalledVersion', '1.23.0')
@@ -353,6 +355,7 @@ test.describe('Release context menu', { tag: '@node' }, () => {
     comfyPage
   }) => {
     // Start fresh and simulate new user who should get search box by default
+    // oxlint-disable-next-line comfy/no-comfy-page-setup-call -- pre-existing call, tracked by evfail-23; not fixed in this pass
     await comfyPage.setup({ clearStorage: true })
     await comfyPage.settings.setSetting('Comfy.InstalledVersion', '1.24.1')
     // But explicitly set to context menu (overriding versioned default)

--- a/browser_tests/tests/propertiesPanel/errorsTab.spec.ts
+++ b/browser_tests/tests/propertiesPanel/errorsTab.spec.ts
@@ -40,6 +40,7 @@ test.describe('Errors tab - common', { tag: '@ui' }, () => {
 
   test.describe('Search and filter', () => {
     test.beforeEach(async ({ comfyPage }) => {
+      // oxlint-disable-next-line comfy/no-comfy-page-setup-call -- pre-existing call, tracked by evfail-23; not fixed in this pass
       await comfyPage.setup()
     })
 

--- a/browser_tests/tests/propertiesPanel/errorsTabExecution.spec.ts
+++ b/browser_tests/tests/propertiesPanel/errorsTabExecution.spec.ts
@@ -11,6 +11,7 @@ test.describe('Errors tab - Execution errors', { tag: '@ui' }, () => {
       'Comfy.RightSidePanel.ShowErrorsTab',
       true
     )
+    // oxlint-disable-next-line comfy/no-comfy-page-setup-call -- pre-existing call, tracked by evfail-23; not fixed in this pass
     await comfyPage.setup()
   })
 

--- a/browser_tests/tests/queue/queueOverlay.spec.ts
+++ b/browser_tests/tests/queue/queueOverlay.spec.ts
@@ -51,6 +51,7 @@ test.describe('Queue overlay', () => {
     await jobsRoutes.mockJobsScenario({ history: MOCK_JOBS, queue: [] })
     await comfyPage.settings.setSetting('Comfy.Minimap.Visible', false)
     await comfyPage.settings.setSetting('Comfy.Queue.QPOV2', false)
+    // oxlint-disable-next-line comfy/no-comfy-page-setup-call -- pre-existing call, tracked by evfail-23; not fixed in this pass
     await comfyPage.setup()
   })
 

--- a/browser_tests/tests/releaseNotifications.spec.ts
+++ b/browser_tests/tests/releaseNotifications.spec.ts
@@ -45,6 +45,7 @@ test.describe('Release Notifications', () => {
     })
 
     // Setup with release mocking disabled for this test
+    // oxlint-disable-next-line comfy/no-comfy-page-setup-call -- pre-existing call, tracked by evfail-23; not fixed in this pass
     await comfyPage.setup({ mockReleases: false })
 
     // Open help center
@@ -76,6 +77,7 @@ test.describe('Release Notifications', () => {
     comfyPage
   }) => {
     // Use default setup (mockReleases: true)
+    // oxlint-disable-next-line comfy/no-comfy-page-setup-call -- pre-existing call, tracked by evfail-23; not fixed in this pass
     await comfyPage.setup()
 
     // Open help center
@@ -124,6 +126,7 @@ test.describe('Release Notifications', () => {
     })
 
     // Setup with release mocking disabled
+    // oxlint-disable-next-line comfy/no-comfy-page-setup-call -- pre-existing call, tracked by evfail-23; not fixed in this pass
     await comfyPage.setup({ mockReleases: false })
 
     // Open help center
@@ -170,6 +173,7 @@ test.describe('Release Notifications', () => {
       }
     })
 
+    // oxlint-disable-next-line comfy/no-comfy-page-setup-call -- pre-existing call, tracked by evfail-23; not fixed in this pass
     await comfyPage.setup({ mockReleases: false })
 
     // Open help center
@@ -222,6 +226,7 @@ test.describe('Release Notifications', () => {
       }
     })
 
+    // oxlint-disable-next-line comfy/no-comfy-page-setup-call -- pre-existing call, tracked by evfail-23; not fixed in this pass
     await comfyPage.setup({ mockReleases: false })
 
     // Verify no API calls were made
@@ -254,6 +259,7 @@ test.describe('Release Notifications', () => {
       }
     })
 
+    // oxlint-disable-next-line comfy/no-comfy-page-setup-call -- pre-existing call, tracked by evfail-23; not fixed in this pass
     await comfyPage.setup({ mockReleases: false })
 
     // Open help center
@@ -307,6 +313,7 @@ test.describe('Release Notifications', () => {
       'Comfy.Notification.ShowVersionUpdates',
       true
     )
+    // oxlint-disable-next-line comfy/no-comfy-page-setup-call -- pre-existing call, tracked by evfail-23; not fixed in this pass
     await comfyPage.setup({ mockReleases: false })
 
     // Open help center
@@ -362,6 +369,7 @@ test.describe('Release Notifications', () => {
       }
     })
 
+    // oxlint-disable-next-line comfy/no-comfy-page-setup-call -- pre-existing call, tracked by evfail-23; not fixed in this pass
     await comfyPage.setup({ mockReleases: false })
 
     // Open help center

--- a/browser_tests/tests/rerouteNode.spec.ts
+++ b/browser_tests/tests/rerouteNode.spec.ts
@@ -13,6 +13,7 @@ test.describe('Reroute Node', { tag: ['@screenshot', '@node'] }, () => {
     await comfyPage.workflow.setupWorkflowsDirectory({
       [`${workflowName}.json`]: `links/${workflowName}.json`
     })
+    // oxlint-disable-next-line comfy/no-comfy-page-setup-call -- pre-existing call, tracked by evfail-23; not fixed in this pass
     await comfyPage.setup()
     await comfyPage.menu.topbar.triggerTopbarCommand(['New'])
 

--- a/browser_tests/tests/sharedWorkflowMissingMedia.spec.ts
+++ b/browser_tests/tests/sharedWorkflowMissingMedia.spec.ts
@@ -89,6 +89,7 @@ test.describe('Shared workflow missing media', { tag: '@cloud' }, () => {
 
   test.beforeEach(async ({ comfyPage, sharedWorkflowImportMocks }) => {
     sharedWorkflowImportMocks.resetAndStartRecording()
+    // oxlint-disable-next-line comfy/no-comfy-page-setup-call -- pre-existing call, tracked by evfail-23; not fixed in this pass
     await comfyPage.setup({
       clearStorage: false,
       url: `/?share=${sharedWorkflowImportScenario.shareId}`

--- a/browser_tests/tests/sidebar/assets.spec.ts
+++ b/browser_tests/tests/sidebar/assets.spec.ts
@@ -148,6 +148,7 @@ const JOB_GAMMA_DETAIL: JobDetail = {
 test.describe('Assets sidebar - empty states', () => {
   test.beforeEach(async ({ comfyPage }) => {
     await comfyPage.assets.mockEmptyState()
+    // oxlint-disable-next-line comfy/no-comfy-page-setup-call -- pre-existing call, tracked by evfail-23; not fixed in this pass
     await comfyPage.setup()
   })
 
@@ -188,6 +189,7 @@ test.describe('Assets sidebar - tab navigation', () => {
   test.beforeEach(async ({ comfyPage }) => {
     await comfyPage.assets.mockOutputHistory(SAMPLE_JOBS)
     await comfyPage.assets.mockInputFiles(SAMPLE_IMPORTED_FILES)
+    // oxlint-disable-next-line comfy/no-comfy-page-setup-call -- pre-existing call, tracked by evfail-23; not fixed in this pass
     await comfyPage.setup()
   })
 
@@ -237,6 +239,7 @@ test.describe('Assets sidebar - grid view display', () => {
   test.beforeEach(async ({ comfyPage }) => {
     await comfyPage.assets.mockOutputHistory(SAMPLE_JOBS)
     await comfyPage.assets.mockInputFiles(SAMPLE_IMPORTED_FILES)
+    // oxlint-disable-next-line comfy/no-comfy-page-setup-call -- pre-existing call, tracked by evfail-23; not fixed in this pass
     await comfyPage.setup()
   })
 
@@ -298,6 +301,7 @@ test.describe('Assets sidebar - view mode', () => {
   test.beforeEach(async ({ comfyPage }) => {
     await comfyPage.assets.mockOutputHistory(SAMPLE_JOBS)
     await comfyPage.assets.mockInputFiles(SAMPLE_IMPORTED_FILES)
+    // oxlint-disable-next-line comfy/no-comfy-page-setup-call -- pre-existing call, tracked by evfail-23; not fixed in this pass
     await comfyPage.setup()
   })
 
@@ -407,6 +411,7 @@ test.describe('Assets sidebar - search', () => {
   test.beforeEach(async ({ comfyPage }) => {
     await comfyPage.assets.mockOutputHistory(SAMPLE_JOBS)
     await comfyPage.assets.mockInputFiles([])
+    // oxlint-disable-next-line comfy/no-comfy-page-setup-call -- pre-existing call, tracked by evfail-23; not fixed in this pass
     await comfyPage.setup()
   })
 
@@ -464,6 +469,7 @@ test.describe('Assets sidebar - selection', () => {
   test.beforeEach(async ({ comfyPage }) => {
     await comfyPage.assets.mockOutputHistory(SAMPLE_JOBS)
     await comfyPage.assets.mockInputFiles([])
+    // oxlint-disable-next-line comfy/no-comfy-page-setup-call -- pre-existing call, tracked by evfail-23; not fixed in this pass
     await comfyPage.setup()
   })
 
@@ -540,6 +546,7 @@ test.describe('Assets sidebar - context menu', () => {
   test.beforeEach(async ({ comfyPage }) => {
     await comfyPage.assets.mockOutputHistory(SAMPLE_JOBS)
     await comfyPage.assets.mockInputFiles([])
+    // oxlint-disable-next-line comfy/no-comfy-page-setup-call -- pre-existing call, tracked by evfail-23; not fixed in this pass
     await comfyPage.setup()
   })
 
@@ -734,6 +741,7 @@ test.describe('Assets sidebar - bulk actions', () => {
   test.beforeEach(async ({ comfyPage }) => {
     await comfyPage.assets.mockOutputHistory(SAMPLE_JOBS)
     await comfyPage.assets.mockInputFiles([])
+    // oxlint-disable-next-line comfy/no-comfy-page-setup-call -- pre-existing call, tracked by evfail-23; not fixed in this pass
     await comfyPage.setup()
   })
 
@@ -939,6 +947,7 @@ test.describe('Assets sidebar - pagination', () => {
   }) => {
     const manyJobs = createMockJobs(250)
     await comfyPage.assets.mockOutputHistory(manyJobs)
+    // oxlint-disable-next-line comfy/no-comfy-page-setup-call -- pre-existing call, tracked by evfail-23; not fixed in this pass
     await comfyPage.setup()
 
     // Queue polling also calls /jobs, so wait for completed history only.
@@ -967,6 +976,7 @@ test.describe('Assets sidebar - settings menu', () => {
   test.beforeEach(async ({ comfyPage }) => {
     await comfyPage.assets.mockOutputHistory(SAMPLE_JOBS)
     await comfyPage.assets.mockInputFiles([])
+    // oxlint-disable-next-line comfy/no-comfy-page-setup-call -- pre-existing call, tracked by evfail-23; not fixed in this pass
     await comfyPage.setup()
   })
 
@@ -1110,6 +1120,7 @@ test.describe('Assets sidebar - media type filter', () => {
   test.beforeEach(async ({ comfyPage }) => {
     await comfyPage.assets.mockOutputHistory(MIXED_MEDIA_JOBS)
     await comfyPage.assets.mockInputFiles([])
+    // oxlint-disable-next-line comfy/no-comfy-page-setup-call -- pre-existing call, tracked by evfail-23; not fixed in this pass
     await comfyPage.setup()
   })
 

--- a/browser_tests/tests/sidebar/assetsSidebarTab.spec.ts
+++ b/browser_tests/tests/sidebar/assetsSidebarTab.spec.ts
@@ -184,6 +184,7 @@ test.describe('FE-130 assets sidebar route mocks', () => {
   }) => {
     const tab = comfyPage.menu.assetsTab
 
+    // oxlint-disable-next-line comfy/no-comfy-page-setup-call -- pre-existing call, tracked by evfail-23; not fixed in this pass
     await comfyPage.setup()
     await tab.open()
 
@@ -206,6 +207,7 @@ test.describe('FE-130 assets sidebar route mocks', () => {
   }) => {
     const tab = comfyPage.menu.assetsTab
 
+    // oxlint-disable-next-line comfy/no-comfy-page-setup-call -- pre-existing call, tracked by evfail-23; not fixed in this pass
     await comfyPage.setup()
     await tab.open()
 
@@ -236,6 +238,7 @@ test.describe('FE-130 assets sidebar route mocks', () => {
   }) => {
     const tab = comfyPage.menu.assetsTab
 
+    // oxlint-disable-next-line comfy/no-comfy-page-setup-call -- pre-existing call, tracked by evfail-23; not fixed in this pass
     await comfyPage.setup()
     await tab.open()
 
@@ -262,6 +265,7 @@ test.describe('FE-130 assets sidebar route mocks', () => {
     await jobsRoutes.mockJobsHistory([multiOutputJob])
     await jobsRoutes.mockJobDetail('multi-output', multiOutputJobDetail)
 
+    // oxlint-disable-next-line comfy/no-comfy-page-setup-call -- pre-existing call, tracked by evfail-23; not fixed in this pass
     await comfyPage.setup()
     await tab.open()
 
@@ -296,6 +300,7 @@ test.describe('FE-130 assets sidebar route mocks', () => {
       previewableCountJobDetail
     )
 
+    // oxlint-disable-next-line comfy/no-comfy-page-setup-call -- pre-existing call, tracked by evfail-23; not fixed in this pass
     await comfyPage.setup()
     await tab.open()
 
@@ -402,6 +407,7 @@ test.describe('FE-910 marquee selection and select all', () => {
     await jobsRoutes.mockJobsHistory(generatedJobs)
     await mockInputFiles(page, ['imported.png'])
     await mockViewFiles(page, viewFiles)
+    // oxlint-disable-next-line comfy/no-comfy-page-setup-call -- pre-existing call, tracked by evfail-23; not fixed in this pass
     await comfyPage.setup()
     await comfyPage.menu.assetsTab.open()
   })

--- a/browser_tests/tests/sidebar/modelLibrary.spec.ts
+++ b/browser_tests/tests/sidebar/modelLibrary.spec.ts
@@ -19,6 +19,7 @@ const MOCK_FOLDERS: Record<string, string[]> = {
 test.describe('Model library sidebar - tab', () => {
   test.beforeEach(async ({ comfyPage }) => {
     await comfyPage.modelLibrary.mockFoldersWithFiles(MOCK_FOLDERS)
+    // oxlint-disable-next-line comfy/no-comfy-page-setup-call -- pre-existing call, tracked by evfail-23; not fixed in this pass
     await comfyPage.setup()
   })
 
@@ -52,6 +53,7 @@ test.describe('Model library sidebar - folders', () => {
   // call during initialization hits the mock and populates the store.
   test.beforeEach(async ({ comfyPage }) => {
     await comfyPage.modelLibrary.mockFoldersWithFiles(MOCK_FOLDERS)
+    // oxlint-disable-next-line comfy/no-comfy-page-setup-call -- pre-existing call, tracked by evfail-23; not fixed in this pass
     await comfyPage.setup()
   })
 
@@ -101,6 +103,7 @@ test.describe('Model library sidebar - folders', () => {
 test.describe('Model library sidebar - search', () => {
   test.beforeEach(async ({ comfyPage }) => {
     await comfyPage.modelLibrary.mockFoldersWithFiles(MOCK_FOLDERS)
+    // oxlint-disable-next-line comfy/no-comfy-page-setup-call -- pre-existing call, tracked by evfail-23; not fixed in this pass
     await comfyPage.setup()
   })
 
@@ -164,6 +167,7 @@ test.describe('Model library sidebar - refresh', () => {
     await comfyPage.modelLibrary.mockFoldersWithFiles({
       checkpoints: ['model_a.safetensors']
     })
+    // oxlint-disable-next-line comfy/no-comfy-page-setup-call -- pre-existing call, tracked by evfail-23; not fixed in this pass
     await comfyPage.setup()
 
     const tab = comfyPage.menu.modelLibraryTab
@@ -193,6 +197,7 @@ test.describe('Model library sidebar - refresh', () => {
     comfyPage
   }) => {
     await comfyPage.modelLibrary.mockFoldersWithFiles(MOCK_FOLDERS)
+    // oxlint-disable-next-line comfy/no-comfy-page-setup-call -- pre-existing call, tracked by evfail-23; not fixed in this pass
     await comfyPage.setup()
 
     const tab = comfyPage.menu.modelLibraryTab
@@ -224,6 +229,7 @@ test.describe('Model library sidebar - empty state', () => {
     comfyPage
   }) => {
     await comfyPage.modelLibrary.mockFoldersWithFiles({})
+    // oxlint-disable-next-line comfy/no-comfy-page-setup-call -- pre-existing call, tracked by evfail-23; not fixed in this pass
     await comfyPage.setup()
 
     const tab = comfyPage.menu.modelLibraryTab
@@ -237,6 +243,7 @@ test.describe('Model library sidebar - empty state', () => {
   test.describe('Model library sidebar - add node', () => {
     test.beforeEach(async ({ comfyPage }) => {
       await comfyPage.modelLibrary.mockFoldersWithFiles(MOCK_FOLDERS)
+      // oxlint-disable-next-line comfy/no-comfy-page-setup-call -- pre-existing call, tracked by evfail-23; not fixed in this pass
       await comfyPage.setup()
       await comfyPage.nodeOps.clearGraph()
     })

--- a/browser_tests/tests/sidebar/workflows.spec.ts
+++ b/browser_tests/tests/sidebar/workflows.spec.ts
@@ -231,6 +231,7 @@ test.describe('Workflows sidebar', () => {
     })
 
     await comfyPage.settings.setSetting('Comfy.Locale', 'zh')
+    // oxlint-disable-next-line comfy/no-comfy-page-setup-call -- pre-existing call, tracked by evfail-23; not fixed in this pass
     await comfyPage.setup()
 
     // Compare the exported workflow with the original

--- a/browser_tests/tests/subgraph/subgraphNavigation.spec.ts
+++ b/browser_tests/tests/subgraph/subgraphNavigation.spec.ts
@@ -127,6 +127,7 @@ test.describe('Subgraph Navigation', { tag: ['@slow', '@subgraph'] }, () => {
       ])
 
       await comfyPage.page.reload()
+      // oxlint-disable-next-line comfy/no-comfy-page-setup-call -- pre-existing call, tracked by evfail-23; not fixed in this pass
       await comfyPage.setup()
       await comfyPage.workflow.loadWorkflow('subgraphs/basic-subgraph')
 

--- a/browser_tests/tests/subscription.spec.ts
+++ b/browser_tests/tests/subscription.spec.ts
@@ -9,6 +9,7 @@ import {
 } from '@e2e/fixtures/helpers/SubscriptionHelper'
 import type { SubscriptionHelper } from '@e2e/fixtures/helpers/SubscriptionHelper'
 
+// oxlint-disable-next-line comfy/no-comfy-page-setup-call -- pre-existing call, tracked by evfail-23; not fixed in this pass
 // Installs subscription mocks AFTER comfyPage.setup() and reloads the page
 // so `addInitScript` (which sets `window.__CONFIG__.subscription_required`)
 // applies before module-level reads in `ComfyRunButton/index.ts` evaluate.

--- a/browser_tests/tests/templateFilterDropdownStacking.spec.ts
+++ b/browser_tests/tests/templateFilterDropdownStacking.spec.ts
@@ -29,6 +29,7 @@ test.describe('Template filter dropdown stacking', () => {
     await templateApi.mock()
     // The template index is fetched during app startup, so the routes have to be
     // in place before the app loads or the store keeps its unmocked contents.
+    // oxlint-disable-next-line comfy/no-comfy-page-setup-call -- pre-existing call, tracked by evfail-23; not fixed in this pass
     await comfyPage.setup()
   })
 

--- a/browser_tests/tests/templates.spec.ts
+++ b/browser_tests/tests/templates.spec.ts
@@ -61,6 +61,7 @@ test.describe('Templates', { tag: ['@slow', '@workflow'] }, () => {
     await comfyPage.settings.setSetting('Comfy.TutorialCompleted', false)
 
     // Load the page
+    // oxlint-disable-next-line comfy/no-comfy-page-setup-call -- pre-existing call, tracked by evfail-23; not fixed in this pass
     await comfyPage.setup({ clearStorage: true })
 
     await expect(comfyPage.templates.content).toBeVisible()
@@ -130,6 +131,7 @@ test.describe('Templates', { tag: ['@slow', '@workflow'] }, () => {
 
     await comfyPage.settings.setSetting('Comfy.TutorialCompleted', false)
 
+    // oxlint-disable-next-line comfy/no-comfy-page-setup-call -- pre-existing call, tracked by evfail-23; not fixed in this pass
     await comfyPage.setup({
       clearStorage: true,
       url: '/?share=test-share-id'
@@ -511,6 +513,7 @@ test.describe(
 
       await comfyPage.settings.setSetting('Comfy.TutorialCompleted', false)
 
+      // oxlint-disable-next-line comfy/no-comfy-page-setup-call -- pre-existing call, tracked by evfail-23; not fixed in this pass
       await comfyPage.setup({
         clearStorage: true,
         url: '/?template=default'

--- a/browser_tests/tests/topbar/workflowTabStatus.spec.ts
+++ b/browser_tests/tests/topbar/workflowTabStatus.spec.ts
@@ -46,6 +46,7 @@ test.describe('Workflow tab status indicator', () => {
       'Comfy.Workflow.WorkflowTabsPosition',
       'Topbar'
     )
+    // oxlint-disable-next-line comfy/no-comfy-page-setup-call -- pre-existing call, tracked by evfail-23; not fixed in this pass
     await comfyPage.setup()
   })
 

--- a/browser_tests/tests/topbarMenuCommands.spec.ts
+++ b/browser_tests/tests/topbarMenuCommands.spec.ts
@@ -10,6 +10,7 @@ test.describe('Topbar menu commands', { tag: '@ui' }, () => {
       'Comfy.Workflow.WorkflowTabsPosition',
       'Topbar'
     )
+    // oxlint-disable-next-line comfy/no-comfy-page-setup-call -- pre-existing call, tracked by evfail-23; not fixed in this pass
     await comfyPage.setup()
   })
 

--- a/browser_tests/tests/versionMismatchWarnings.spec.ts
+++ b/browser_tests/tests/versionMismatchWarnings.spec.ts
@@ -56,6 +56,7 @@ test.describe('Version Mismatch Warnings', { tag: '@slow' }, () => {
         )
       })
     })
+    // oxlint-disable-next-line comfy/no-comfy-page-setup-call -- pre-existing call, tracked by evfail-23; not fixed in this pass
     await comfyPage.setup()
 
     // Expect a warning toast to be shown
@@ -77,6 +78,7 @@ test.describe('Version Mismatch Warnings', { tag: '@slow' }, () => {
         )
       })
     })
+    // oxlint-disable-next-line comfy/no-comfy-page-setup-call -- pre-existing call, tracked by evfail-23; not fixed in this pass
     await comfyPage.setup()
 
     // Expect no warning toast to be shown
@@ -99,6 +101,7 @@ test.describe('Version Mismatch Warnings', { tag: '@slow' }, () => {
         )
       })
     })
+    // oxlint-disable-next-line comfy/no-comfy-page-setup-call -- pre-existing call, tracked by evfail-23; not fixed in this pass
     await comfyPage.setup()
 
     // Locate the warning toast and dismiss it
@@ -115,6 +118,7 @@ test.describe('Version Mismatch Warnings', { tag: '@slow' }, () => {
     )
 
     // Reload the page, keeping local storage
+    // oxlint-disable-next-line comfy/no-comfy-page-setup-call -- pre-existing call, tracked by evfail-23; not fixed in this pass
     await comfyPage.setup({ clearStorage: false })
 
     // The same warning from same versions should not be shown to the user again

--- a/browser_tests/tests/workflowPersistence.spec.ts
+++ b/browser_tests/tests/workflowPersistence.spec.ts
@@ -742,6 +742,7 @@ test.describe('Workflow Persistence', () => {
       )
     })
 
+    // oxlint-disable-next-line comfy/no-comfy-page-setup-call -- pre-existing call, tracked by evfail-23; not fixed in this pass
     await comfyPage.setup({ clearStorage: false })
     await comfyPage.nextFrame()
 

--- a/browser_tests/tests/workflowTabThumbnail.spec.ts
+++ b/browser_tests/tests/workflowTabThumbnail.spec.ts
@@ -9,6 +9,7 @@ test.describe('Workflow Tab Thumbnails', { tag: '@workflow' }, () => {
       'Comfy.Workflow.WorkflowTabsPosition',
       'Topbar'
     )
+    // oxlint-disable-next-line comfy/no-comfy-page-setup-call -- pre-existing call, tracked by evfail-23; not fixed in this pass
     await comfyPage.setup()
   })
 

--- a/tools/oxlint-plugins/comfy.ts
+++ b/tools/oxlint-plugins/comfy.ts
@@ -1,5 +1,6 @@
 import { createRequire } from 'node:module'
 
+import type { noComfyPageSetupCall as NoComfyPageSetupCall } from './comfyPageSetup'
 import type { noDuplicateIngestType as NoDuplicateIngestType } from './comfyIngestTypes'
 import type {
   noModuleScopeVitestMocks as NoModuleScopeVitestMocks,
@@ -10,6 +11,9 @@ import type {
 import type { noRenderInWatchEffect as NoRenderInWatchEffect } from './watchEffectRendering'
 
 const requireFrom = createRequire(import.meta.url)
+const { noComfyPageSetupCall } = requireFrom('./comfyPageSetup.ts') as {
+  noComfyPageSetupCall: typeof NoComfyPageSetupCall
+}
 const { noDuplicateIngestType } = requireFrom('./comfyIngestTypes.ts') as {
   noDuplicateIngestType: typeof NoDuplicateIngestType
 }
@@ -31,6 +35,7 @@ const { noRenderInWatchEffect } = requireFrom('./watchEffectRendering.ts') as {
 export default {
   meta: { name: 'comfy' },
   rules: {
+    'no-comfy-page-setup-call': noComfyPageSetupCall,
     'no-duplicate-ingest-type': noDuplicateIngestType,
     'no-module-scope-vitest-mocks': noModuleScopeVitestMocks,
     'no-persistent-litegraph-registration': noPersistentLiteGraphRegistration,

--- a/tools/oxlint-plugins/comfyPageSetup.test.ts
+++ b/tools/oxlint-plugins/comfyPageSetup.test.ts
@@ -1,18 +1,36 @@
 import { execFileSync } from 'node:child_process'
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
-import { tmpdir } from 'node:os'
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs'
 import path from 'node:path'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 
+// Run Oxlint's Node entrypoint directly; the .bin shim is a .cmd file on Windows
+// and cannot be spawned as a bare executable.
 const oxlintEntry = path.resolve('node_modules/oxlint/bin/oxlint')
-const pluginPath = path.resolve('tools/oxlint-plugins/comfy.ts')
+const repoConfig = path.resolve('.oxlintrc.json')
 
-const invalidFixture = `test('re-runs setup mid-test', async ({ comfyPage }) => {
+// Probes are written into the trees `pnpm lint` actually lints and are checked
+// through the repo's own .oxlintrc.json. The rule is only correct together with
+// its override scope: spec files must be reported, while the fixtures that own
+// the one legitimate `comfyPage.setup()` call must stay silent.
+const PROBE_DIR = '__comfy_page_setup_probes__'
+const specProbeDir = path.resolve('browser_tests/tests', PROBE_DIR)
+const fixtureProbeDir = path.resolve('browser_tests/fixtures', PROBE_DIR)
+
+const RULE_CODE = 'comfy(no-comfy-page-setup-call)'
+
+interface Diagnostic {
+  readonly code?: string
+  readonly severity?: string
+  readonly filename?: string
+  readonly message?: string
+}
+
+const reportedSpec = `test('re-runs setup mid-test', async ({ comfyPage }) => {
   await comfyPage.setup({ clearStorage: false })
 })
 `
 
-const acceptedFixture = `test('configures startup via fixture options', async ({ comfyPage }) => {
+const acceptedSpec = `test('configures startup via fixture options', async ({ comfyPage }) => {
   await comfyPage.settings.setSetting('Comfy.TutorialCompleted', false)
 })
 
@@ -23,67 +41,88 @@ class FakePage {
 }
 `
 
-interface Diagnostic {
-  readonly code?: string
-  readonly filename?: string
-  readonly message?: string
+const fixtureProbe = `export async function prepare(comfyPage: { setup(): Promise<void> }) {
+  await comfyPage.setup()
+}
+`
+
+function lint(targets: string[]): Diagnostic[] {
+  let stdout: string
+  let failure: string | undefined
+  try {
+    stdout = execFileSync(
+      process.execPath,
+      [oxlintEntry, '--format=json', '--config', repoConfig, ...targets],
+      {
+        cwd: path.resolve('.'),
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'pipe']
+      }
+    )
+  } catch (err) {
+    // Non-zero exit is expected: the rule reports at error severity.
+    const failed = err as { stdout?: string; stderr?: string; status?: number }
+    stdout = failed.stdout ?? ''
+    failure = `exit ${failed.status ?? '?'}\n${failed.stderr ?? ''}`
+  }
+
+  let diagnostics: readonly Diagnostic[] | undefined
+  try {
+    diagnostics = (JSON.parse(stdout) as { diagnostics?: Diagnostic[] })
+      .diagnostics
+  } catch {
+    diagnostics = undefined
+  }
+  if (diagnostics === undefined) {
+    throw new Error(
+      `Could not read Oxlint's JSON report (${failure ?? 'exit 0'}). stdout: ${stdout.slice(0, 400)}`
+    )
+  }
+
+  return diagnostics.filter((diagnostic) => diagnostic.code === RULE_CODE)
 }
 
 describe('no-comfy-page-setup-call', () => {
-  let workDir: string
-  let diagnostics: readonly Diagnostic[]
+  let findings: Diagnostic[]
 
   beforeAll(() => {
-    workDir = mkdtempSync(path.join(tmpdir(), 'comfy-page-setup-'))
-    writeFileSync(path.join(workDir, 'invalid.ts'), invalidFixture)
-    writeFileSync(path.join(workDir, 'accepted.ts'), acceptedFixture)
-    writeFileSync(
-      path.join(workDir, '.oxlintrc.json'),
-      JSON.stringify({
-        jsPlugins: [pluginPath],
-        rules: { 'comfy/no-comfy-page-setup-call': 'error' }
-      })
-    )
-
-    let output: string
-    try {
-      output = execFileSync(
-        process.execPath,
-        [
-          oxlintEntry,
-          '--format=json',
-          '--config',
-          path.join(workDir, '.oxlintrc.json'),
-          'invalid.ts',
-          'accepted.ts'
-        ],
-        { cwd: workDir, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] }
-      )
-    } catch (error) {
-      output = (error as { stdout?: string }).stdout ?? ''
+    for (const dir of [specProbeDir, fixtureProbeDir]) {
+      mkdirSync(dir, { recursive: true })
     }
+    writeFileSync(path.join(specProbeDir, 'reported.spec.ts'), reportedSpec)
+    writeFileSync(path.join(specProbeDir, 'accepted.spec.ts'), acceptedSpec)
+    writeFileSync(path.join(fixtureProbeDir, 'fixture.ts'), fixtureProbe)
 
-    diagnostics = (JSON.parse(output) as { diagnostics: Diagnostic[] })
-      .diagnostics
+    findings = lint([specProbeDir, fixtureProbeDir])
   })
 
-  afterAll(() => rmSync(workDir, { recursive: true, force: true }))
+  afterAll(() => {
+    for (const dir of [specProbeDir, fixtureProbeDir]) {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
 
-  it('reports a redundant comfyPage.setup() call inside a test', () => {
-    const findings = diagnostics.filter(
-      (diagnostic) => diagnostic.code === 'comfy(no-comfy-page-setup-call)'
+  it('reports a redundant comfyPage.setup() call in a spec at error severity', () => {
+    const reported = findings.filter((finding) =>
+      finding.filename?.includes('reported.spec.ts')
     )
-    expect(findings).toHaveLength(1)
-    expect(findings[0]?.filename).toContain('invalid.ts')
-    expect(findings[0]?.message).toContain('comfyPageFixture')
+    expect(reported).toHaveLength(1)
+    expect(reported[0]?.severity).toBe('error')
+    expect(reported[0]?.message).toContain('comfyPageFixture')
   })
 
   it('allows startup configured through fixture options and unrelated setup() methods', () => {
-    const acceptedFindings = diagnostics.filter(
-      (diagnostic) =>
-        diagnostic.code === 'comfy(no-comfy-page-setup-call)' &&
-        diagnostic.filename?.includes('accepted.ts')
+    const accepted = findings.filter((finding) =>
+      finding.filename?.includes('accepted.spec.ts')
     )
-    expect(acceptedFindings).toHaveLength(0)
+    expect(accepted).toHaveLength(0)
+  })
+
+  it('does not apply to fixtures, which own the single legitimate setup() call', () => {
+    const fixtureFindings = findings.filter((finding) =>
+      finding.filename?.includes('fixture.ts')
+    )
+    expect(fixtureFindings).toHaveLength(0)
+    expect(findings).toHaveLength(1)
   })
 })

--- a/tools/oxlint-plugins/comfyPageSetup.test.ts
+++ b/tools/oxlint-plugins/comfyPageSetup.test.ts
@@ -1,0 +1,89 @@
+import { execFileSync } from 'node:child_process'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+const oxlintEntry = path.resolve('node_modules/oxlint/bin/oxlint')
+const pluginPath = path.resolve('tools/oxlint-plugins/comfy.ts')
+
+const invalidFixture = `test('re-runs setup mid-test', async ({ comfyPage }) => {
+  await comfyPage.setup({ clearStorage: false })
+})
+`
+
+const acceptedFixture = `test('configures startup via fixture options', async ({ comfyPage }) => {
+  await comfyPage.settings.setSetting('Comfy.TutorialCompleted', false)
+})
+
+class FakePage {
+  async setup() {
+    // Unrelated object named differently; only the comfyPage identifier is checked.
+  }
+}
+`
+
+interface Diagnostic {
+  readonly code?: string
+  readonly filename?: string
+  readonly message?: string
+}
+
+describe('no-comfy-page-setup-call', () => {
+  let workDir: string
+  let diagnostics: readonly Diagnostic[]
+
+  beforeAll(() => {
+    workDir = mkdtempSync(path.join(tmpdir(), 'comfy-page-setup-'))
+    writeFileSync(path.join(workDir, 'invalid.ts'), invalidFixture)
+    writeFileSync(path.join(workDir, 'accepted.ts'), acceptedFixture)
+    writeFileSync(
+      path.join(workDir, '.oxlintrc.json'),
+      JSON.stringify({
+        jsPlugins: [pluginPath],
+        rules: { 'comfy/no-comfy-page-setup-call': 'error' }
+      })
+    )
+
+    let output: string
+    try {
+      output = execFileSync(
+        process.execPath,
+        [
+          oxlintEntry,
+          '--format=json',
+          '--config',
+          path.join(workDir, '.oxlintrc.json'),
+          'invalid.ts',
+          'accepted.ts'
+        ],
+        { cwd: workDir, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] }
+      )
+    } catch (error) {
+      output = (error as { stdout?: string }).stdout ?? ''
+    }
+
+    diagnostics = (JSON.parse(output) as { diagnostics: Diagnostic[] })
+      .diagnostics
+  })
+
+  afterAll(() => rmSync(workDir, { recursive: true, force: true }))
+
+  it('reports a redundant comfyPage.setup() call inside a test', () => {
+    const findings = diagnostics.filter(
+      (diagnostic) => diagnostic.code === 'comfy(no-comfy-page-setup-call)'
+    )
+    expect(findings).toHaveLength(1)
+    expect(findings[0]?.filename).toContain('invalid.ts')
+    expect(findings[0]?.message).toContain('comfyPageFixture')
+  })
+
+  it('allows startup configured through fixture options and unrelated setup() methods', () => {
+    const acceptedFindings = diagnostics.filter(
+      (diagnostic) =>
+        diagnostic.code === 'comfy(no-comfy-page-setup-call)' &&
+        diagnostic.filename?.includes('accepted.ts')
+    )
+    expect(acceptedFindings).toHaveLength(0)
+  })
+})

--- a/tools/oxlint-plugins/comfyPageSetup.ts
+++ b/tools/oxlint-plugins/comfyPageSetup.ts
@@ -1,0 +1,63 @@
+// `comfyPageFixture` already calls `comfyPage.setup()` once per test before
+// the test body runs (browser_tests/fixtures/ComfyPage.ts). A test that calls
+// it again re-navigates and re-clears storage on top of that automatic setup,
+// which is the "naughty" pattern AustinMroz identified as a source of
+// video-recording timeouts in
+// https://github.com/Comfy-Org/ComfyUI_frontend/pull/16711#pullrequestreview-5096346494.
+// Use `test.use({ initialSettings/initialFeatureFlags })` or a dedicated
+// fixture option to vary startup instead of re-running `setup()`.
+
+interface Identifier {
+  readonly type: 'Identifier'
+  readonly name: string
+}
+
+interface MemberExpression {
+  readonly type: 'MemberExpression'
+  readonly object: Node
+  readonly property: Node
+  readonly computed: boolean
+}
+
+interface CallExpression {
+  readonly type: 'CallExpression'
+  readonly callee: Node
+}
+
+type Node = Identifier | MemberExpression | CallExpression | { type: string }
+
+interface RuleContext {
+  report(descriptor: { node: unknown; message: string }): void
+}
+
+function propertyName(member: MemberExpression): string | undefined {
+  if (member.computed) return undefined
+  return member.property.type === 'Identifier'
+    ? (member.property as Identifier).name
+    : undefined
+}
+
+export const noComfyPageSetupCall = {
+  create(context: RuleContext) {
+    return {
+      CallExpression(node: CallExpression) {
+        const callee = node.callee
+        if (callee.type !== 'MemberExpression') return
+        const member = callee as MemberExpression
+        if (propertyName(member) !== 'setup') return
+        if (
+          member.object.type !== 'Identifier' ||
+          (member.object as Identifier).name !== 'comfyPage'
+        ) {
+          return
+        }
+
+        context.report({
+          node,
+          message:
+            'comfyPage.setup() already runs once per test via comfyPageFixture; calling it again re-navigates and re-clears storage, which has caused test timeouts. Configure startup with test.use({ initialSettings, initialFeatureFlags }) instead.'
+        })
+      }
+    }
+  }
+}


### PR DESCRIPTION
`comfyPageFixture` already calls `comfyPage.setup()` once per test before the test body runs (`browser_tests/fixtures/ComfyPage.ts`). A test that calls it again re-navigates and re-clears storage on top of that automatic setup.

[#16711 review](https://github.com/Comfy-Org/ComfyUI_frontend/pull/16711#pullrequestreview-5096346494): AustinMroz traced video-recording test timeouts to exactly this pattern ("naughty tests that call `comfyPage.setup()`"). [Follow-up](https://github.com/Comfy-Org/ComfyUI_frontend/pull/16711#issuecomment-5518065931): DrJKL asked for a lint prohibition, but the merged commit (`44c4785f`) didn't add one and no PR back-referenced #16711 for it.

This adds `comfy/no-comfy-page-setup-call`, an oxlint rule scoped to `browser_tests/tests/**/*.spec.ts` and `apps/*/e2e/**/*.spec.ts`, flagging any `comfyPage.setup(...)` call. The 72 pre-existing call sites across 30 spec files are grandfathered with `oxlint-disable-next-line` comments (matching the repo's existing suppression convention) rather than fixed in this pass — removing each one changes that test's startup semantics case by case and needs per-test review, which is out of scope for landing the lint gate itself.

## Evidence

```
$ npx oxlint browser_tests/tests tools/oxlint-plugins --type-aware
(clean, exit 0)

$ npx vitest run tools/oxlint-plugins/comfyPageSetup.test.ts
 Test Files  1 passed (1)
      Tests  2 passed (2)

# smoke test: rule fires when a suppression is removed
$ npx oxlint browser_tests/tests/colorPalette.spec.ts --type-aware
browser_tests/tests/colorPalette.spec.ts:156:11: error comfy(no-comfy-page-setup-call): ...
```

Pre-commit gates (lint, typecheck, typecheck:browser) all passed on this branch.

<!-- authored-by:agent lane-evfail-23 -->