### PR TITLE
[backport cloud/1.51] fix: clarify missing core node version warning (#16166)

### DIFF
--- a/src/components/rightSidePanel/errors/MissingNodeCard.test.ts
+++ b/src/components/rightSidePanel/errors/MissingNodeCard.test.ts
@@ -95,10 +95,10 @@ const i18n = createI18n({
         }
       },
       loadWorkflowWarning: {
-        outdatedVersion:
-          'Some nodes require a newer version of ComfyUI (current: {version}).',
-        outdatedVersionGeneric:
-          'Some nodes require a newer version of ComfyUI.',
+        newerVersionRequired:
+          'Some nodes require a newer version of ComfyUI (current: {version}). Please update to use all nodes.',
+        newerVersionRequiredGeneric:
+          'Some nodes require a newer version of ComfyUI. Please update to use all nodes.',
         coreNodesFromVersion: 'Requires ComfyUI {version}:',
         unknownVersion: 'unknown'
       }
@@ -311,7 +311,9 @@ describe('MissingNodeCard', () => {
       }
       renderCard()
       expect(
-        screen.getByText('Some nodes require a newer version of ComfyUI.')
+        screen.getByText(
+          'Some nodes require a newer version of ComfyUI. Please update to use all nodes.'
+        )
       ).toBeInTheDocument()
     })
 

--- a/src/components/rightSidePanel/errors/MissingNodeCard.vue
+++ b/src/components/rightSidePanel/errors/MissingNodeCard.vue
@@ -14,10 +14,10 @@
         <p class="m-0">
           {{
             currentComfyUIVersion
-              ? t('loadWorkflowWarning.outdatedVersion', {
+              ? t('loadWorkflowWarning.newerVersionRequired', {
                   version: currentComfyUIVersion
                 })
-              : t('loadWorkflowWarning.outdatedVersionGeneric')
+              : t('loadWorkflowWarning.newerVersionRequiredGeneric')
           }}
         </p>
         <div

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2117,8 +2117,8 @@
     "dismiss": "Dismiss"
   },
   "loadWorkflowWarning": {
-    "outdatedVersion": "This workflow was created with a newer version of ComfyUI ({version}). Some nodes may not work correctly.",
-    "outdatedVersionGeneric": "This workflow was created with a newer version of ComfyUI. Some nodes may not work correctly.",
+    "newerVersionRequired": "Some nodes require a newer version of ComfyUI (current: {version}). Please update to use all nodes.",
+    "newerVersionRequiredGeneric": "Some nodes require a newer version of ComfyUI. Please update to use all nodes.",
     "coreNodesFromVersion": "Core nodes from version {version}:",
     "unknownVersion": "unknown"
   },


### PR DESCRIPTION
## Summary

Backports the wording fix from #16166 to `cloud/1.51`; the prior automated backport #16179 closed unmerged and its branch was deleted.

## Changes

- **What**: Clarifies that workflows created with newer ComfyUI versions may require a newer frontend version.

## Review Focus

Confirm the `cloud/1.51` warning copy matches the merged source fix.

## Evidence

- `NODE_OPTIONS="--no-experimental-webstorage" pnpm exec vitest run src/components/rightSidePanel/errors/MissingNodeCard.test.ts` — 21 tests passed.
- `pnpm exec oxfmt --check src/components/rightSidePanel/errors/MissingNodeCard.test.ts src/components/rightSidePanel/errors/MissingNodeCard.vue src/locales/en/main.json` — all matched files correctly formatted.
- `pnpm exec oxlint src/components/rightSidePanel/errors/MissingNodeCard.test.ts src/components/rightSidePanel/errors/MissingNodeCard.vue` — 0 warnings, 0 errors.

<!-- authored-by:agent lane-bkp-4 -->