### PR TITLE
test: cover projected customtext widget rendering

### DIFF
--- a/src/renderer/extensions/vueNodes/components/LGraphNode.test.ts
+++ b/src/renderer/extensions/vueNodes/components/LGraphNode.test.ts
@@ -239,6 +239,48 @@ describe('LGraphNode', () => {
     expect(container.textContent).toContain('Test Node')
   })
 
+  it('renders a customtext widget registered by graph mutations', async () => {
+    const fakeRootGraph: Record<string, unknown> = {
+      id: 'graph-test',
+      getNodeById: () => null,
+      subgraphs: new Map()
+    }
+    fakeRootGraph.rootGraph = fakeRootGraph
+    useCanvasStore().currentGraph = fromAny(fakeRootGraph)
+    useWidgetValueStore().registerWidget(
+      widgetId('graph-test', mockNodeData.id, 'prompt'),
+      {
+        name: 'prompt',
+        type: 'customtext',
+        value: 'A projected prompt',
+        options: {},
+        label: 'prompt'
+      },
+      {}
+    )
+
+    render(LGraphNode, {
+      props: {
+        nodeData: { ...mockNodeData, graphId: 'graph-test' }
+      },
+      global: {
+        plugins: [pinia, i18n],
+        stubs: {
+          AsyncComponentWrapper: {
+            props: ['modelValue'],
+            template: '<textarea :value="modelValue" />'
+          },
+          NodeHeader: true,
+          NodeSlots: true,
+          NodeContent: true,
+          SlotConnectionDot: true
+        }
+      }
+    })
+
+    expect(await screen.findByRole('textbox')).toHaveValue('A projected prompt')
+  })
+
   it('should apply selected styling when selected prop is true', async () => {
     const canvasStore = useCanvasStore()
     canvasStore.selectedNodeIds.clear()


### PR DESCRIPTION
## Summary

Adds the missing component-level regression coverage for a projected `customtext` widget registered with the same widget-store shape used by `graphMutations.addNode`.

## Changes

- **What**: Renders `LGraphNode.vue` from registered widget state and asserts the projected textarea contains its value.
- **Dependencies**: None.

## Review Focus

The test intentionally stubs only the registry's async component wrapper; the real `customtext` → textarea registry mapping and textarea component behavior remain covered by their focused suites. This test covers the previously missing integration from scoped widget registration through `LGraphNode` widget discovery and DOM projection.

## Evidence

```text
$ NODE_OPTIONS="--no-experimental-webstorage" pnpm test:unit src/renderer/extensions/vueNodes/components/LGraphNode.test.ts
Test Files  1 passed (1)
Tests  21 passed (21)

$ pnpm exec eslint src/renderer/extensions/vueNodes/components/LGraphNode.test.ts
Process exited 0
No lint findings

$ pnpm typecheck
Process exited 0
Completed by the commit quality gate

$ pnpm exec knip --cache
Process exited 0
Completed by the push quality gate
```

<!-- authored-by:agent lane-poc-11 -->
