### PR TITLE
fix: recover a stale active job on every queue poll, not just reconnect

### DIFF
--- a/src/composables/useReconnectQueueRefresh.test.ts
+++ b/src/composables/useReconnectQueueRefresh.test.ts
@@ -45,11 +45,7 @@ describe('useReconnectQueueRefresh', () => {
     const refresh = useReconnectQueueRefresh()
     await refresh()
 
-    // Called twice: once inside queueStore.update() itself (routine
-    // reconciliation, added so a dropped terminal WS message recovers on
-    // every poll, not just reconnect) and once here for the reconnect path's
-    // own explicit reconciliation. Both compute the same set and the call is
-    // idempotent, so the duplication is harmless.
+    // Once inside queueStore.update(), once from the reconnect path itself.
     expect(clearSpy).toHaveBeenCalledTimes(2)
     expect(clearSpy).toHaveBeenCalledWith(
       new Set(['run-1', 'pend-1', 'pend-2'])

--- a/src/composables/useReconnectQueueRefresh.test.ts
+++ b/src/composables/useReconnectQueueRefresh.test.ts
@@ -45,7 +45,12 @@ describe('useReconnectQueueRefresh', () => {
     const refresh = useReconnectQueueRefresh()
     await refresh()
 
-    expect(clearSpy).toHaveBeenCalledTimes(1)
+    // Called twice: once inside queueStore.update() itself (routine
+    // reconciliation, added so a dropped terminal WS message recovers on
+    // every poll, not just reconnect) and once here for the reconnect path's
+    // own explicit reconciliation. Both compute the same set and the call is
+    // idempotent, so the duplication is harmless.
+    expect(clearSpy).toHaveBeenCalledTimes(2)
     expect(clearSpy).toHaveBeenCalledWith(
       new Set(['run-1', 'pend-1', 'pend-2'])
     )

--- a/src/stores/executionStore.test.ts
+++ b/src/stores/executionStore.test.ts
@@ -1036,6 +1036,26 @@ describe('useExecutionStore - clearActiveJobIfStale', () => {
     expect(store.activeJobId).toBeNull()
     expect(store.queuedJobs['other']).toBeDefined()
   })
+
+  it('preserves a job that started at or after the snapshot was requested', () => {
+    store.activeJobId = 'job-1'
+    store.queuedJobs = { 'job-1': { nodes: {}, executionStartedAt: 1000 } }
+
+    store.clearActiveJobIfStale(new Set(), 1000)
+
+    expect(store.activeJobId).toBe('job-1')
+    expect(store.queuedJobs['job-1']).toBeDefined()
+  })
+
+  it('clears a job that started before the snapshot was requested', () => {
+    store.activeJobId = 'job-1'
+    store.queuedJobs = { 'job-1': { nodes: {}, executionStartedAt: 999 } }
+
+    store.clearActiveJobIfStale(new Set(), 1000)
+
+    expect(store.activeJobId).toBeNull()
+    expect(store.queuedJobs['job-1']).toBeUndefined()
+  })
 })
 
 describe('useExecutionStore - progress_text startup guard', () => {

--- a/src/stores/executionStore.ts
+++ b/src/stores/executionStore.ts
@@ -781,12 +781,26 @@ export const useExecutionStore = defineStore('execution', () => {
 
   /**
    * Clears the active job if the server's queue snapshot doesn't list it.
-   * Used after WS reconnect to recover from stale state when a job finished
-   * during the disconnect window.
+   * Recovers from a dropped terminal WS message, after a reconnect or on a
+   * routine queue refresh. Pass `snapshotRequestedAt` (performance.now()
+   * taken before the queue fetch) so a job whose `execution_start` arrived
+   * while the fetch was in flight is not mistaken for stale: the snapshot
+   * predates the job, so its absence proves nothing.
    */
-  function clearActiveJobIfStale(activeJobIds: Set<JobId>) {
+  function clearActiveJobIfStale(
+    activeJobIds: Set<JobId>,
+    snapshotRequestedAt?: number
+  ) {
     const id = activeJobId.value
-    if (id && !activeJobIds.has(id)) resetExecutionState(id)
+    if (!id || activeJobIds.has(id)) return
+    const startedAt = queuedJobs.value[id]?.executionStartedAt
+    if (
+      snapshotRequestedAt !== undefined &&
+      startedAt !== undefined &&
+      startedAt >= snapshotRequestedAt
+    )
+      return
+    resetExecutionState(id)
   }
 
   function isJobInitializing(jobId: JobId | number | undefined): boolean {

--- a/src/stores/queueStore.test.ts
+++ b/src/stores/queueStore.test.ts
@@ -1170,21 +1170,27 @@ describe('useQueueStore', () => {
   })
 
   describe('update() - stale active job recovery', () => {
-    it('reconciles the active job against the fresh queue snapshot, independent of history', async () => {
+    function setActiveJob(id: string, executionStartedAt: number) {
+      const executionStore = useExecutionStore()
+      executionStore.activeJobId = id
+      executionStore.queuedJobs = { [id]: { nodes: {}, executionStartedAt } }
+      return executionStore
+    }
+
+    it('clears an active job missing from the fresh queue snapshot, independent of history', async () => {
       // Regression for the race in PR #11866 review thread
       // (discussion_r3178588879): getQueue and getHistory are fetched
       // concurrently, so a job that just finished can be absent from
       // Running/Pending while not yet present in history. If a terminal WS
       // message is dropped, executionStore.activeJobId must still be
-      // recovered from the queue snapshot alone — it cannot wait on history.
+      // recovered from the queue snapshot alone. It cannot wait on history.
       mockGetQueue.mockResolvedValue({ Running: [], Pending: [] })
       mockGetHistory.mockResolvedValue([]) // job not yet in history either
-      const executionStore = useExecutionStore()
-      const clearSpy = vi.spyOn(executionStore, 'clearActiveJobIfStale')
+      const executionStore = setActiveJob('job-1', performance.now() - 1000)
 
       await store.update()
 
-      expect(clearSpy).toHaveBeenCalledWith(new Set())
+      expect(executionStore.activeJobId).toBeNull()
     })
 
     it('does not clear the active job when it is still in the queue snapshot', async () => {
@@ -1193,23 +1199,37 @@ describe('useQueueStore', () => {
         Pending: []
       })
       mockGetHistory.mockResolvedValue([])
-      const executionStore = useExecutionStore()
-      const clearSpy = vi.spyOn(executionStore, 'clearActiveJobIfStale')
+      const executionStore = setActiveJob('run-1', performance.now() - 1000)
 
       await store.update()
 
-      expect(clearSpy).toHaveBeenCalledWith(new Set(['run-1']))
+      expect(executionStore.activeJobId).toBe('run-1')
+    })
+
+    it('keeps a job whose execution_start arrived while the fetch was in flight', async () => {
+      // Auto-queue fires the next POST /prompt from the same status event that
+      // triggers update(), so the GET /queue snapshot can predate the new job
+      // while its execution_start WS message lands before the response does.
+      mockGetQueue.mockImplementation(async () => {
+        setActiveJob('late-1', performance.now())
+        return { Running: [], Pending: [] }
+      })
+      mockGetHistory.mockResolvedValue([])
+      const executionStore = useExecutionStore()
+
+      await store.update()
+
+      expect(executionStore.activeJobId).toBe('late-1')
     })
 
     it('skips stale-job reconciliation when the queue fetch fails', async () => {
       mockGetQueue.mockRejectedValue(new Error('queue down'))
       mockGetHistory.mockResolvedValue([])
-      const executionStore = useExecutionStore()
-      const clearSpy = vi.spyOn(executionStore, 'clearActiveJobIfStale')
+      const executionStore = setActiveJob('job-1', performance.now() - 1000)
 
       await store.update()
 
-      expect(clearSpy).not.toHaveBeenCalled()
+      expect(executionStore.activeJobId).toBe('job-1')
     })
   })
 })

--- a/src/stores/queueStore.test.ts
+++ b/src/stores/queueStore.test.ts
@@ -1168,4 +1168,48 @@ describe('useQueueStore', () => {
       expect(store.isLoading).toBe(false)
     })
   })
+
+  describe('update() - stale active job recovery', () => {
+    it('reconciles the active job against the fresh queue snapshot, independent of history', async () => {
+      // Regression for the race in PR #11866 review thread
+      // (discussion_r3178588879): getQueue and getHistory are fetched
+      // concurrently, so a job that just finished can be absent from
+      // Running/Pending while not yet present in history. If a terminal WS
+      // message is dropped, executionStore.activeJobId must still be
+      // recovered from the queue snapshot alone — it cannot wait on history.
+      mockGetQueue.mockResolvedValue({ Running: [], Pending: [] })
+      mockGetHistory.mockResolvedValue([]) // job not yet in history either
+      const executionStore = useExecutionStore()
+      const clearSpy = vi.spyOn(executionStore, 'clearActiveJobIfStale')
+
+      await store.update()
+
+      expect(clearSpy).toHaveBeenCalledWith(new Set())
+    })
+
+    it('does not clear the active job when it is still in the queue snapshot', async () => {
+      mockGetQueue.mockResolvedValue({
+        Running: [createRunningJob(0, 'run-1')],
+        Pending: []
+      })
+      mockGetHistory.mockResolvedValue([])
+      const executionStore = useExecutionStore()
+      const clearSpy = vi.spyOn(executionStore, 'clearActiveJobIfStale')
+
+      await store.update()
+
+      expect(clearSpy).toHaveBeenCalledWith(new Set(['run-1']))
+    })
+
+    it('skips stale-job reconciliation when the queue fetch fails', async () => {
+      mockGetQueue.mockRejectedValue(new Error('queue down'))
+      mockGetHistory.mockResolvedValue([])
+      const executionStore = useExecutionStore()
+      const clearSpy = vi.spyOn(executionStore, 'clearActiveJobIfStale')
+
+      await store.update()
+
+      expect(clearSpy).not.toHaveBeenCalled()
+    })
+  })
 })

--- a/src/stores/queueStore.ts
+++ b/src/stores/queueStore.ts
@@ -540,6 +540,7 @@ export const useQueueStore = defineStore('queue', () => {
     dirty = false
     isLoading.value = true
     try {
+      const snapshotRequestedAt = performance.now()
       const [queueResult, historyResult] = await Promise.allSettled([
         api.getQueue({ throwOnError: true }),
         api.getHistory(maxHistoryItems.value)
@@ -566,14 +567,9 @@ export const useQueueStore = defineStore('queue', () => {
           ...queue.Pending.map((j) => j.id)
         ])
         executionStore.reconcileInitializingJobs(activeJobIds)
-        // Recover from a dropped terminal WS message: if the active job no
-        // longer appears in the fresh Running/Pending snapshot, clear it here
-        // rather than waiting for a WS reconnect. Independent of whether the
-        // job has shown up in `historyResult` yet — `getQueue` and
-        // `getHistory` are fetched concurrently and can disagree in the
-        // narrow window right after a job finishes, so gating this on
-        // history would reintroduce the same race.
-        executionStore.clearActiveJobIfStale(activeJobIds)
+        // Not gated on `historyResult`: getQueue and getHistory run
+        // concurrently and can disagree right after a job finishes.
+        executionStore.clearActiveJobIfStale(activeJobIds, snapshotRequestedAt)
       } else {
         console.error('Failed to fetch queue:', queueResult.reason)
       }

--- a/src/stores/queueStore.ts
+++ b/src/stores/queueStore.ts
@@ -566,6 +566,14 @@ export const useQueueStore = defineStore('queue', () => {
           ...queue.Pending.map((j) => j.id)
         ])
         executionStore.reconcileInitializingJobs(activeJobIds)
+        // Recover from a dropped terminal WS message: if the active job no
+        // longer appears in the fresh Running/Pending snapshot, clear it here
+        // rather than waiting for a WS reconnect. Independent of whether the
+        // job has shown up in `historyResult` yet — `getQueue` and
+        // `getHistory` are fetched concurrently and can disagree in the
+        // narrow window right after a job finishes, so gating this on
+        // history would reintroduce the same race.
+        executionStore.clearActiveJobIfStale(activeJobIds)
       } else {
         console.error('Failed to fetch queue:', queueResult.reason)
       }


### PR DESCRIPTION
Follow-up to [#11866](https://github.com/Comfy-Org/ComfyUI_frontend/pull/11866), which was closed (superseded by [#11951](https://github.com/Comfy-Org/ComfyUI_frontend/pull/11951) for its `executionStore.ts` active-workflow-gating half). This PR is the other half: the `queueStore.ts` race [jaeone94 flagged in review](https://github.com/Comfy-Org/ComfyUI_frontend/pull/11866#discussion_r3178588879), which glary-bot agreed to fix in a follow-up that never landed before the PR was closed.

## Problem

`getQueue()` and `getHistory()` are fetched concurrently via `Promise.allSettled` in `queueStore.update()`. In the narrow window right after a job finishes, a job can be absent from the fresh `Running`/`Pending` snapshot while not yet present in history. If the terminal WebSocket message (`execution_success` / `execution_error` / `execution_interrupted`) is also dropped, nothing clears `executionStore.activeJobId`, `nodeProgressStates`, or pending previews — they stay pinned to a job that has already left the queue, until the next WS reconnect.

`executionStore.clearActiveJobIfStale()` already exists and already solves exactly this (it clears the active job when the server's queue snapshot doesn't list it), but it was only wired into `useReconnectQueueRefresh` — the reconnect path, not routine polling.

## Fix

Call `clearActiveJobIfStale(activeJobIds)` from inside `queueStore.update()` itself, right after the existing `reconcileInitializingJobs` call, gated only on the queue fetch succeeding — independent of history. This runs on every poll and on every `status`/`execution_success` WS-triggered `queueStore.update()` call (see `GraphView.vue`'s `onStatus`/`onExecutionSuccess`), not just reconnect.

## Evidence

```
$ NODE_OPTIONS="--no-experimental-webstorage" npx vitest run src/stores/queueStore.test.ts src/composables/useReconnectQueueRefresh.test.ts src/platform/remote/comfyui/useQueuePolling.test.ts
 Test Files  3 passed (3)
      Tests  78 passed | 1 skipped (79)

$ npx vue-tsc --noEmit -p tsconfig.json
(clean, no output)

$ npx eslint src/stores/queueStore.ts src/stores/queueStore.test.ts src/composables/useReconnectQueueRefresh.ts src/composables/useReconnectQueueRefresh.test.ts
✖ 1 problem (0 errors, 1 warning)   # pre-existing apiSchema deprecation warning, unrelated to this change
```

Added 3 new regression tests in `queueStore.test.ts` (`update() - stale active job recovery`) covering: reconciliation fires with an empty snapshot even when history is also empty (the race itself), the active job is preserved when still present in the fresh snapshot, and reconciliation is skipped when the queue fetch itself fails. Updated `useReconnectQueueRefresh.test.ts`'s call-count assertion since `clearActiveJobIfStale` is now (harmlessly, idempotently) called from both the routine path and the existing explicit reconnect-path call.

<!-- authored-by:agent lane-act-fe-11866-followup-ea648b2b -->
