### PR TITLE
fix(litegraph): avoid delete on pos/widget in SubgraphNode

### DIFF
--- a/src/lib/litegraph/src/subgraph/SubgraphNode.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphNode.ts
@@ -346,8 +346,8 @@ export class SubgraphNode extends LGraphNode implements BaseLGraph {
           })
         }
 
-        delete input.pos
-        delete input.widget
+        input.pos = undefined
+        input.widget = undefined
         input.widgetId = undefined
         input._widget = undefined
         this.invalidatePromotedViews()
@@ -675,8 +675,8 @@ export class SubgraphNode extends LGraphNode implements BaseLGraph {
       deriveWidgetRenderState(interiorWidget)
     )
     if (!registered) {
-      delete input.pos
-      delete input.widget
+      input.pos = undefined
+      input.widget = undefined
       input.widgetId = undefined
       input._widget = undefined
       return


### PR DESCRIPTION
## Summary

Replaces `delete input.pos` and `delete input.widget` with `input.pos = undefined` / `input.widget = undefined` at the two remaining call sites in `SubgraphNode.ts` (unlink cleanup, failed-registration guard).

## Why

Follow-up from a review thread on [#16717](https://github.com/Comfy-Org/ComfyUI_frontend/pull/16717#discussion_r3919728236):

> Want to do all 3? — @DrJKL

#16717 replaced `delete input.widgetId` with `input.widgetId = undefined` at three call sites, since `delete` has been a source of issues with the compatibility proxies. DrJKL's comment, on the third call site (which also deletes `pos` and `widget` right next to `widgetId`), asked to apply the same treatment to all 3 fields, not just `widgetId`. This PR completes that at both remaining sites that still had `delete input.pos` / `delete input.widget`.

Both fields are optional on `INodeInputSlot` (`pos?: Point`, `widget?: IWidgetLocator`, `src/lib/litegraph/src/interfaces.ts`), so assignment is a semantically equivalent, proxy-safe replacement for `delete`.

## Evidence

- `NODE_OPTIONS="--no-experimental-webstorage" npx vitest run src/lib/litegraph/src/subgraph/`: 18 files, 323/323 passed.
- `npx vue-tsc --noEmit` (full project): clean.
- `npx eslint src/lib/litegraph/src/subgraph/SubgraphNode.ts`: 0 errors, 2 pre-existing unrelated warnings (restricted-path imports, present before this change).

<!-- authored-by:agent lane-act-fe-16717-followup-2e392d0d -->