### PR TITLE
fix: narrow adoptRootGraphId write-back to the zero-id case

### DIFF
--- a/src/platform/workflow/core/services/workflowService.test.ts
+++ b/src/platform/workflow/core/services/workflowService.test.ts
@@ -27,6 +27,7 @@ import type { ComfyWorkflowJSON } from '@/platform/workflow/validation/schemas/w
 import { createMockChangeTracker } from '@/utils/__tests__/litegraphTestUtils'
 import type { AppMode } from '@/utils/appMode'
 import { isValidUuid } from '@/utils/formatUtil'
+import { zeroUuid } from '@/utils/uuid'
 import { t } from '@/i18n'
 
 function createModeTestWorkflow(
@@ -1964,6 +1965,49 @@ describe('useWorkflowService', () => {
       expect(isValidUuid(resetArg?.id)).toBe(true)
       expect(resetArg?.id).not.toBe('different-legacy-name')
       expect(resetArg?.id).not.toBe('legacy-workflow-name')
+    })
+
+    describe('root graph id adoption', () => {
+      const rootGraphId = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+      const incomingId = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
+
+      beforeEach(() => {
+        Reflect.set(app, 'isGraphReady', true)
+      })
+
+      afterEach(() => {
+        Reflect.deleteProperty(app, 'isGraphReady')
+        Reflect.deleteProperty(app.rootGraph, 'id')
+      })
+
+      it('mints a root graph id for a zero-id graph and writes it into the workflow data', async () => {
+        app.rootGraph.id = zeroUuid
+        const workflowData = makeWorkflowDataWithId(zeroUuid)
+
+        await useWorkflowService().afterLoadNewGraph('repeat', workflowData)
+
+        expect(app.rootGraph.id).not.toBe(zeroUuid)
+        expect(isValidUuid(app.rootGraph.id)).toBe(true)
+        expect(workflowData.id).toBe(app.rootGraph.id)
+        expect(useExecutionErrorStore().setActiveGraph).toHaveBeenCalledWith(
+          app.rootGraph.id,
+          existingWorkflow.path
+        )
+      })
+
+      it('leaves the incoming workflow id alone when the root graph already has one', async () => {
+        app.rootGraph.id = rootGraphId
+        const workflowData = makeWorkflowDataWithId(incomingId)
+
+        await useWorkflowService().afterLoadNewGraph('repeat', workflowData)
+
+        expect(workflowData.id).toBe(incomingId)
+        expect(app.rootGraph.id).toBe(rootGraphId)
+        expect(useExecutionErrorStore().setActiveGraph).toHaveBeenCalledWith(
+          rootGraphId,
+          existingWorkflow.path
+        )
+      })
     })
   })
 

--- a/src/platform/workflow/core/services/workflowService.ts
+++ b/src/platform/workflow/core/services/workflowService.ts
@@ -54,12 +54,13 @@ function linearModeToAppMode(linearMode: unknown): AppMode | null {
 
 /**
  * Returns the root graph id to scope run errors by, minting one when the graph
- * carries the zero id. `loadApiJson` and `importA1111` populate the root graph
- * without `configure()`, so every such import would otherwise share the zero
- * id's bucket and lose it once a reload generated a real id. The id is written
- * back into `workflowData` only in that zero-id case, so a `configure()`-based
- * load (where `rootGraph.id` already came from `workflowData.id`) can never
- * have this rewrite the incoming workflow's identity to a stale graph's id.
+ * carries the zero id. Every caller passes `rootGraph.serialize()` as
+ * `workflowData`, and `app.clean()` mints a fresh root id before `loadApiJson`
+ * and `importA1111` populate the graph, so the zero id only survives here when
+ * something upstream skipped both. The id is written back into `workflowData`
+ * only in that zero-id case, so a `configure()`-based load (where
+ * `rootGraph.id` already came from `workflowData.id`) can never have this
+ * rewrite the incoming workflow's identity to a stale graph's id.
  */
 function adoptRootGraphId(workflowData: ComfyWorkflowJSON): UUID | null {
   if (!app.isGraphReady) return null

--- a/src/platform/workflow/core/services/workflowService.ts
+++ b/src/platform/workflow/core/services/workflowService.ts
@@ -45,7 +45,7 @@ import {
 } from '@/utils/formatUtil'
 import type { AppMode } from '@/utils/appMode'
 import type { UUID } from '@/utils/uuid'
-import { ensureNonZeroUuid } from '@/utils/uuid'
+import { ensureNonZeroUuid, zeroUuid } from '@/utils/uuid'
 
 function linearModeToAppMode(linearMode: unknown): AppMode | null {
   if (typeof linearMode !== 'boolean') return null
@@ -57,15 +57,18 @@ function linearModeToAppMode(linearMode: unknown): AppMode | null {
  * carries the zero id. `loadApiJson` and `importA1111` populate the root graph
  * without `configure()`, so every such import would otherwise share the zero
  * id's bucket and lose it once a reload generated a real id. The id is written
- * back into `workflowData` so the state this load persists reloads under the
- * same key.
+ * back into `workflowData` only in that zero-id case, so a `configure()`-based
+ * load (where `rootGraph.id` already came from `workflowData.id`) can never
+ * have this rewrite the incoming workflow's identity to a stale graph's id.
  */
 function adoptRootGraphId(workflowData: ComfyWorkflowJSON): UUID | null {
   if (!app.isGraphReady) return null
 
   const rootGraph = app.rootGraph
-  workflowData.id = ensureNonZeroUuid(rootGraph)
-  return workflowData.id
+  if (rootGraph.id === zeroUuid) {
+    workflowData.id = ensureNonZeroUuid(rootGraph)
+  }
+  return rootGraph.id
 }
 
 // TRANSITIONAL (decision log D14): deletable when ECS scopes workflow


### PR DESCRIPTION
## Summary

Small follow-up to #15361, addressing the one review thread on that PR left unresolved after merge (the reviewer's own suggested patch, applied as-is with a doc-comment update):

`adoptRootGraphId()` wrote `ensureNonZeroUuid(rootGraph)` back into `workflowData.id` unconditionally, not only in the zero-id case the function's doc comment describes. For a normal `configure()`-based load `rootGraph.id` already came from `workflowData.id`, so the assignment was a no-op — but on any load path where `configure()` did not run, or `rootGraph` still carried a previous graph's id, this would silently rewrite the incoming workflow's identity to the outgoing graph's id, and that rewritten id is what gets persisted.

This narrows the write-back to the case it's for:

```ts
if (rootGraph.id === zeroUuid) {
  workflowData.id = ensureNonZeroUuid(rootGraph)
}
return rootGraph.id
```

Addresses: https://github.com/Comfy-Org/ComfyUI_frontend/pull/15361#discussion_r3919412240

### Other #15361 threads (not code changes, tracked separately)

Three more review threads on #15361 raised design questions rather than defects, and are answered/tracked as follow-up discussion on the source PR rather than bundled into this small fix:
- https://github.com/Comfy-Org/ComfyUI_frontend/pull/15361#discussion_r3919412250 (isTemporary short-circuit changing tab-reuse semantics for all imports)
- https://github.com/Comfy-Org/ComfyUI_frontend/pull/15361#discussion_r3919412256 (duplicate-path now pre-creates a workflow entry instead of passing a filename)
- https://github.com/Comfy-Org/ComfyUI_frontend/pull/15361#discussion_r3919412265 (parked error bucket becomes unaddressable after a workflow rename/Save As)
- https://github.com/Comfy-Org/ComfyUI_frontend/pull/15361#pullrequestreview-5095996285 (PR description says background-routing is deferred to FE-1648, but it shipped in #15361 — description/ticket-scope correction, not a code change)

## Evidence

- `source ~/.nvm/nvm.sh && nvm use 25 && pnpm run typecheck` — clean
- `NODE_OPTIONS="--no-experimental-webstorage" npx vitest run src/platform/workflow/core/services/workflowService.test.ts src/scripts/app.test.ts src/stores/executionErrorStore.test.ts` — 229 passed, 1 skipped
- `npx eslint src/platform/workflow/core/services/workflowService.ts` — clean
- lint-staged/husky pre-commit hooks (oxfmt, oxlint, eslint, typecheck) passed on commit

<!-- authored-by:agent lane-act-fe-15361-followup-ebfe1dea -->
