### PR TITLE
fix(agent): apply only the latest run mode save

### DIFF
--- a/src/workbench/extensions/agent/stores/agent/agentRunModeStore.test.ts
+++ b/src/workbench/extensions/agent/stores/agent/agentRunModeStore.test.ts
@@ -139,22 +139,28 @@ describe('agentRunModeStore', () => {
   })
 
   it('keeps the latest save when an earlier PUT resolves last', async () => {
-    const resolvers: Array<(response: Response) => void> = []
-    fetchApi.mockImplementation(
-      () =>
-        new Promise<Response>((resolve) => {
-          resolvers.push(resolve)
-        })
-    )
+    let resolveFirst!: (response: Response) => void
+    let resolveSecond!: (response: Response) => void
+    fetchApi
+      .mockImplementationOnce(
+        () =>
+          new Promise<Response>((resolve) => {
+            resolveFirst = resolve
+          })
+      )
+      .mockImplementationOnce(
+        () =>
+          new Promise<Response>((resolve) => {
+            resolveSecond = resolve
+          })
+      )
     const store = useAgentRunModeStore()
 
     const first = store.save('auto_limited', 20)
     const second = store.save('auto', null)
-    expect(resolvers).toHaveLength(2)
-
-    resolvers[1]!(jsonResponse(200, { mode: 'auto', credit_limit: null }))
+    resolveSecond(jsonResponse(200, { mode: 'auto', credit_limit: null }))
     await second
-    resolvers[0]!(jsonResponse(200, { mode: 'auto_limited', credit_limit: 20 }))
+    resolveFirst(jsonResponse(200, { mode: 'auto_limited', credit_limit: 20 }))
     await first
 
     expect(store.mode).toBe('auto')
@@ -162,21 +168,29 @@ describe('agentRunModeStore', () => {
   })
 
   it('applies an earlier save when the latest one fails', async () => {
-    const resolvers: Array<(response: Response) => void> = []
-    fetchApi.mockImplementation(
-      () =>
-        new Promise<Response>((resolve) => {
-          resolvers.push(resolve)
-        })
-    )
+    let resolveFirst!: (response: Response) => void
+    let resolveSecond!: (response: Response) => void
+    fetchApi
+      .mockImplementationOnce(
+        () =>
+          new Promise<Response>((resolve) => {
+            resolveFirst = resolve
+          })
+      )
+      .mockImplementationOnce(
+        () =>
+          new Promise<Response>((resolve) => {
+            resolveSecond = resolve
+          })
+      )
     const store = useAgentRunModeStore()
 
     const first = store.save('auto_limited', 20)
     const second = store.save('auto', null)
 
-    resolvers[1]!(jsonResponse(500, { error: 'boom' }))
+    resolveSecond(jsonResponse(500, { error: 'boom' }))
     await expect(second).rejects.toThrow()
-    resolvers[0]!(jsonResponse(200, { mode: 'auto_limited', credit_limit: 20 }))
+    resolveFirst(jsonResponse(200, { mode: 'auto_limited', credit_limit: 20 }))
     await first
 
     expect(store.mode).toBe('auto_limited')

--- a/src/workbench/extensions/agent/stores/agent/agentRunModeStore.test.ts
+++ b/src/workbench/extensions/agent/stores/agent/agentRunModeStore.test.ts
@@ -138,6 +138,51 @@ describe('agentRunModeStore', () => {
     expect(store.mode).toBe('auto_limited')
   })
 
+  it('keeps the latest save when an earlier PUT resolves last', async () => {
+    const resolvers: Array<(response: Response) => void> = []
+    fetchApi.mockImplementation(
+      () =>
+        new Promise<Response>((resolve) => {
+          resolvers.push(resolve)
+        })
+    )
+    const store = useAgentRunModeStore()
+
+    const first = store.save('auto_limited', 20)
+    const second = store.save('auto', null)
+    expect(resolvers).toHaveLength(2)
+
+    resolvers[1]!(jsonResponse(200, { mode: 'auto', credit_limit: null }))
+    await second
+    resolvers[0]!(jsonResponse(200, { mode: 'auto_limited', credit_limit: 20 }))
+    await first
+
+    expect(store.mode).toBe('auto')
+    expect(store.creditLimit).toBeNull()
+  })
+
+  it('applies an earlier save when the latest one fails', async () => {
+    const resolvers: Array<(response: Response) => void> = []
+    fetchApi.mockImplementation(
+      () =>
+        new Promise<Response>((resolve) => {
+          resolvers.push(resolve)
+        })
+    )
+    const store = useAgentRunModeStore()
+
+    const first = store.save('auto_limited', 20)
+    const second = store.save('auto', null)
+
+    resolvers[1]!(jsonResponse(500, { error: 'boom' }))
+    await expect(second).rejects.toThrow()
+    resolvers[0]!(jsonResponse(200, { mode: 'auto_limited', credit_limit: 20 }))
+    await first
+
+    expect(store.mode).toBe('auto_limited')
+    expect(store.creditLimit).toBe(20)
+  })
+
   it('keeps a valid local preference when the endpoint is unavailable', async () => {
     localStorage.setItem(
       'Comfy.Agent.RunModePreference',

--- a/src/workbench/extensions/agent/stores/agent/agentRunModeStore.ts
+++ b/src/workbench/extensions/agent/stores/agent/agentRunModeStore.ts
@@ -87,6 +87,7 @@ export const useAgentRunModeStore = defineStore('agentRunMode', () => {
   const mode = computed(() => preference.value.mode)
   const creditLimit = computed(() => preference.value.credit_limit)
   let saveRevision = 0
+  let appliedSaveRevision = 0
 
   function apply(nextPreference: AgentRunModePreference): void {
     preference.value = nextPreference
@@ -119,13 +120,17 @@ export const useAgentRunModeStore = defineStore('agentRunMode', () => {
       mode: nextMode,
       credit_limit: nextLimit
     })
-    saveRevision++
-    try {
-      const savedPreference = await api.putRunMode(next)
+    const revision = ++saveRevision
+    const applySaved = (savedPreference: AgentRunModePreference) => {
+      if (revision <= appliedSaveRevision) return
+      appliedSaveRevision = revision
       apply(savedPreference)
+    }
+    try {
+      applySaved(await api.putRunMode(next))
     } catch (error) {
       if (!(error instanceof AgentApiError && error.status === 404)) throw error
-      apply(next)
+      applySaved(next)
     }
   }
 


### PR DESCRIPTION
## Summary

Follow-up to #16432. `saveRevision` only guarded `load()`; two overlapping `save()` calls each applied their own PUT response unconditionally, so the store showed whichever response resolved last rather than the latest save. Each save now captures its own revision and applies only when newer than the last applied save. The 404 fallback goes through the same gate, so an earlier success still applies when a later save fails.

## Changes

- `agentRunModeStore.ts`: per-save revision, `appliedSaveRevision` gate on both the PUT response and the 404 fallback.
- `agentRunModeStore.test.ts`: two cases, "keeps the latest save when an earlier PUT resolves last" (fails on main) and "applies an earlier save when the latest one fails".

## Verification

- `pnpm test:unit src/workbench/extensions/agent/stores/agent/agentRunModeStore.test.ts` (18 pass; the first new case fails without the store change).
- `vue-tsc --noEmit` clean; eslint, oxlint, oxfmt clean on both files.
