### PR TITLE
fix: show error overlay for in-flight execution errors

### DIFF
--- a/src/scripts/app.test.ts
+++ b/src/scripts/app.test.ts
@@ -1993,6 +1993,40 @@ describe('ComfyApp', () => {
       expect(executionErrorStore.isErrorOverlayOpen).toBe(false)
     })
 
+    it('opens the overlay for an in-flight active job before storeJob', () => {
+      const workflowA = markLoaded(
+        new ComfyWorkflow({ path: 'workflows/a.json', modified: 0, size: 0 })
+      )
+      workflowA.changeTracker.activeState = workflowGraphData(workflowAId)
+
+      const executionStore = useExecutionStore()
+      const executionErrorStore = useExecutionErrorStore()
+      executionErrorStore.setActiveGraph(workflowAId, workflowA.path)
+      executionStore.activeJobId = 'job-fast'
+
+      const addEventListener = vi.spyOn(api, 'addEventListener')
+      Reflect.apply(Reflect.get(app, 'addApiUpdateHandlers'), app, [])
+      const executionErrorHandler = addEventListener.mock.calls.find(
+        ([event]) => event === 'execution_error'
+      )?.[1] as EventListener | undefined
+
+      executionErrorHandler?.(
+        new CustomEvent('execution_error', {
+          detail: {
+            prompt_id: 'job-fast',
+            node_id: '1',
+            node_type: 'DevToolsErrorRaiseNode',
+            exception_message: 'Error node was called!',
+            exception_type: 'RuntimeError',
+            traceback: []
+          }
+        })
+      )
+
+      expect(executionErrorHandler).toBeTypeOf('function')
+      expect(executionErrorStore.isErrorOverlayOpen).toBe(true)
+    })
+
     it('restores the failed run state when returning to a workflow tab', async () => {
       const workflowService = await useRealWorkflowService()
       const graph = new LGraph()

--- a/src/stores/executionStore.test.ts
+++ b/src/stores/executionStore.test.ts
@@ -1179,6 +1179,23 @@ describe('useExecutionStore - background workflow error routing', () => {
 
     expect(errorStore.lastExecutionError).toBeNull()
   })
+
+  it('files an in-flight active-job error before storeJob attaches the mapping', () => {
+    fireExecutionStart('job-fast')
+    expect(store.isJobErrorForActiveWorkflow('job-fast')).toBe(true)
+
+    fireExecutionError('job-fast')
+
+    expect(errorStore.lastExecutionError?.prompt_id).toBe('job-fast')
+  })
+
+  it('does not treat a different in-flight job as the visible workflow', () => {
+    fireExecutionStart('job-visible')
+    fireExecutionError('job-other')
+
+    expect(errorStore.lastExecutionError).toBeNull()
+    expect(store.isJobErrorForActiveWorkflow('job-other')).toBe(false)
+  })
 })
 
 describe('useExecutionStore - clearActiveJobIfStale', () => {

--- a/src/stores/executionStore.ts
+++ b/src/stores/executionStore.ts
@@ -688,8 +688,22 @@ export const useExecutionStore = defineStore('execution', () => {
     return executionErrorStore.runErrorKey(graphId, path)
   }
 
+  /**
+   * `runErrorKeyForJob` needs storeJob (or queue/history polling). execution_start
+   * can set `activeJobId` before that HTTP response, so a terminal error in
+   * that window has no mapping yet but is still the visible run.
+   */
+  function resolveRunErrorKey(jobId: string): string | null {
+    return (
+      runErrorKeyForJob(jobId) ??
+      (activeJobId.value === jobId
+        ? executionErrorStore.captureRunErrorKey()
+        : null)
+    )
+  }
+
   function isJobErrorForActiveWorkflow(jobId: string): boolean {
-    const runErrorKey = runErrorKeyForJob(jobId)
+    const runErrorKey = resolveRunErrorKey(jobId)
     return (
       runErrorKey !== null &&
       runErrorKey === executionErrorStore.captureRunErrorKey()
@@ -700,7 +714,7 @@ export const useExecutionStore = defineStore('execution', () => {
     const endTime = performance.now()
     // Resolved up front: resetExecutionState() drops the job's workflow entry
     // before the handlers below record anything.
-    const runErrorKey = runErrorKeyForJob(e.detail.prompt_id)
+    const runErrorKey = resolveRunErrorKey(e.detail.prompt_id)
     setWorkflowStatus(e.detail.prompt_id, {
       status: 'failed',
       endTime,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Restore the error overlay on a real execution error. `#15361` scoped run errors to the producing workflow and gated `error-overlay` on that mapping; a node that fails immediately can emit `execution_error` before `queuePrompt`'s HTTP response calls `storeJob`, so attribution was `null` and the overlay never opened.

`#16718` (widget-store sync) is discarded as the cause. Last green custom-nodes CI on main was `f5ce58c099` (does not contain `#15361`). `#15361` (`8b8cdc3c98`) is the first ancestor of the failing SHA that is not in that green run.

## Evidence

Failing run: https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/33739150177
SHA: `4c96a038` (`#16718`)
Spec: `browser_tests/tests/customNodes/customNode.regression.spec.ts:409`
Assertion: `browser_tests/tests/customNodes/customNode.regression.spec.ts:441` — `getByTestId('error-overlay')` expected visible, not found (5s).

What actually surfaces today:

- The harness event tap still sees a real `EXECUTION_ERROR` (`outcome`, `exceptionMessage`, executed node ids at `:431–436` all pass).
- No `error-overlay` is mounted. `ErrorOverlay.vue:10` only renders when `isErrorOverlayOpen && totalErrorCount > 0`.
- Overlay open is gated at `src/scripts/app.ts:895` on `isJobErrorForActiveWorkflow` (`:885–886`). After `#15361` that requires `runErrorKeyForJob` (`src/stores/executionStore.ts:674`), which needs `storeJob` or queue/history polling.
- `DevToolsErrorRaiseNode` in `browser_tests/assets/nodes/execution_error.json` fails immediately. `execution_start` can set `activeJobId` before the `/prompt` HTTP response calls `storeJob` (same race already documented at `handleExecutionStart`). `runErrorKeyForJob` returns `null` → error is not filed → overlay is not opened. Selectors have not rotted; the positive-control surface never appears.

What this PR changes:

- `src/stores/executionStore.ts:696–717` — `resolveRunErrorKey` falls back to the active run-error key when `activeJobId` already matches the failing job. Used by `isJobErrorForActiveWorkflow` and `handleExecutionError`.
- Unknown jobs and background jobs still stay off the visible workflow (existing tests kept).
- Unit coverage: `src/stores/executionStore.test.ts` (in-flight file + non-matching job) and `src/scripts/app.test.ts` (overlay opens before `storeJob`).

No other product behavior change. The spec is unchanged.

## Review Focus

The fallback must stay tighter than "any unattributable error": only the job `execution_start` already marked current. `#15361`'s "do not assign unknown jobs to whichever workflow is visible" still holds.

## Changes

- **What**: File and surface an in-flight active-job execution error on the visible workflow so `error-overlay` opens.
- **Breaking**: none

## Verify (human, minutes)

```
pnpm exec playwright test browser_tests/tests/customNodes/customNode.regression.spec.ts --grep "harness self-check: captures a real execution error"
```

Expected: `error-overlay` becomes visible on a real execution error; that test green. No other product behavior change.

This environment cannot run the custom-nodes Playwright job (needs the pinned ComfyUI + `ComfyUI_devtools` backend). Unit tests for the race pass:

```
pnpm test:unit src/stores/executionStore.test.ts src/scripts/app.test.ts
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-da557a78-9a6f-421f-945f-9efe34198603?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-da557a78-9a6f-421f-945f-9efe34198603&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

