### PR TITLE
fix(website): cluster /ja instead of suppressing it

### DIFF
--- a/apps/website/src/lib/hreflang.test.ts
+++ b/apps/website/src/lib/hreflang.test.ts
@@ -6,7 +6,12 @@ import { describe, expect, it } from 'vitest'
 
 import { isNoindexPathname } from '../config/indexing'
 import { redirects } from '../config/redirects'
-import { routeOf, ZH_PREFIX } from '../utils/hreflangRoutes'
+import {
+  JA_HREFLANG,
+  JA_PREFIX,
+  routeOf,
+  ZH_PREFIX
+} from '../utils/hreflangRoutes'
 import {
   hreflangAlternates,
   ogLocale,
@@ -31,15 +36,45 @@ describe('hreflangAlternates', () => {
     )
   })
 
-  it('handles the home page in both locales', () => {
+  it('handles the home page in every locale that has one', () => {
+    // The home page is the one route with all three locales, so it is the only
+    // place the full cluster shape can be asserted today.
     const home = hreflangAlternates('/', ORIGIN)
-    expect(home.map((a) => a.href)).toEqual([
-      'https://comfy.org/',
-      'https://comfy.org/zh-CN/',
-      'https://comfy.org/'
+    expect(home).toEqual([
+      { hreflang: 'en', href: 'https://comfy.org/' },
+      { hreflang: 'zh-CN', href: 'https://comfy.org/zh-CN/' },
+      { hreflang: 'ja', href: 'https://comfy.org/ja/' },
+      { hreflang: 'x-default', href: 'https://comfy.org/' }
     ])
     expect(hreflangAlternates('/zh-CN/', ORIGIN)).toEqual(home)
     expect(hreflangAlternates('/zh-CN', ORIGIN)).toEqual(home)
+  })
+
+  // BE-11285. Previously `/ja/` was read as the English route `/ja`, so it was
+  // labelled `en` and its cluster pointed at `/zh-CN/ja/`, which 404s.
+  it('labels the Japanese home page ja and clusters it with the others', () => {
+    expect(hreflangAlternates('/ja/', ORIGIN)).toEqual(
+      hreflangAlternates('/', ORIGIN)
+    )
+    expect(hreflangAlternates('/ja', ORIGIN)).toEqual(
+      hreflangAlternates('/', ORIGIN)
+    )
+  })
+
+  it('never treats a locale prefix as part of the English path', () => {
+    const hrefs = hreflangAlternates('/ja/', ORIGIN).map((a) => a.href)
+    expect(hrefs).not.toContain('https://comfy.org/zh-CN/ja/')
+    expect(hrefs).not.toContain('https://comfy.org/ja/ja/')
+  })
+
+  // Japanese has exactly one page. A blanket rule like Chinese's would
+  // advertise a Japanese URL for every route on the site.
+  it('offers no ja alternate for routes that have no Japanese page', () => {
+    for (const pathname of ['/cli/', '/zh-CN/cli/', '/mcp/']) {
+      expect(
+        hreflangAlternates(pathname, ORIGIN).map((a) => a.hreflang)
+      ).toEqual(['en', 'zh-CN', 'x-default'])
+    }
   })
 
   it('covers dynamic routes that exist in both locales', () => {
@@ -73,12 +108,13 @@ describe('sitemapAlternates', () => {
     ])
   })
 
-  it('emits nothing for Japanese, from either locale prefix', () => {
-    // /ja/ has no twin rule yet, so a cluster here would advertise
-    // /zh-CN/ja/, which 404s. The prefixed form must be suppressed too, or a
-    // locale-prefixed request slips past a check that only reads the raw path.
-    expect(hreflangAlternates('/ja/', ORIGIN)).toEqual([])
-    expect(hreflangAlternates('/zh-CN/ja/', ORIGIN)).toEqual([])
+  it('gives the Japanese home page a cluster with no 404 in it', () => {
+    expect(sitemapAlternates('https://comfy.org/ja/')).toEqual([
+      { url: 'https://comfy.org/', lang: 'en' },
+      { url: 'https://comfy.org/zh-CN/', lang: 'zh-CN' },
+      { url: 'https://comfy.org/ja/', lang: 'ja' },
+      { url: 'https://comfy.org/', lang: 'x-default' }
+    ])
   })
 
   it('leaves English-only entries without links', () => {
@@ -100,6 +136,14 @@ describe('og locale', () => {
     expect(ogLocaleAlternate('en', clustered)).toBe('zh_CN')
     expect(ogLocaleAlternate('zh-CN', clustered)).toBe('en_US')
     expect(ogLocaleAlternate('en', [])).toBeNull()
+  })
+
+  it('pairs a Japanese page with English, not with Chinese', () => {
+    // OG takes one alternate. Testing for `zh-CN` rather than `en` sent every
+    // localized page to zh_CN, so a Japanese page named a language it has
+    // nothing to do with.
+    const clustered = hreflangAlternates('/ja/', ORIGIN)
+    expect(ogLocaleAlternate('ja', clustered)).toBe('en_US')
   })
 })
 
@@ -124,12 +168,15 @@ describe('the emitter agrees with the page tree', () => {
 
   const english = new Set<string>()
   const chinese = new Set<string>()
+  const japanese = new Set<string>()
   for (const file of astroFiles(pagesDir)) {
     const rel = relative(pagesDir, file).split(sep).join('/')
     if (rel.includes('[')) continue
     const route = routeOf(`/src/pages/${rel}`)
     if (route.startsWith(`${ZH_PREFIX}/`)) {
       chinese.add(route.slice(ZH_PREFIX.length) || '/')
+    } else if (route.startsWith(`${JA_PREFIX}/`)) {
+      japanese.add(route.slice(JA_PREFIX.length) || '/')
     } else {
       english.add(route)
     }
@@ -160,5 +207,32 @@ describe('the emitter agrees with the page tree', () => {
       (route) => clusters(`${ZH_PREFIX}${route}`) && !english.has(route)
     )
     expect(lying, 'the English twin was moved or removed').toEqual([])
+  })
+
+  const advertisesJa = (route: string): boolean =>
+    hreflangAlternates(route, ORIGIN).some(
+      (alternate) => alternate.hreflang === JA_HREFLANG
+    )
+
+  /**
+   * The two directions `JA_ROUTES` can rot in. Chinese needs neither check
+   * because it has a blanket rule; Japanese is an explicit list, so both the
+   * list claiming too much and the list claiming too little have to be caught.
+   */
+  it('never advertises a ja page that does not exist', () => {
+    const lying = [...english].filter(
+      (route) => advertisesJa(route) && !japanese.has(route)
+    )
+    expect(
+      lying,
+      'add the Japanese page or drop the route from JA_ROUTES'
+    ).toEqual([])
+  })
+
+  it('clusters every Japanese page that was built', () => {
+    const unlisted = [...japanese].filter(
+      (route) => clusters(route) && !advertisesJa(route)
+    )
+    expect(unlisted, 'add the route to JA_ROUTES in hreflang.ts').toEqual([])
   })
 })

--- a/apps/website/src/lib/hreflang.ts
+++ b/apps/website/src/lib/hreflang.ts
@@ -1,11 +1,27 @@
 import { isLocaleInvariantPath } from '../config/routes'
-
-const LOCALE_PREFIX = '/zh-CN'
+import { JA_PREFIX, LOCALE_PREFIXES, ZH_PREFIX } from '../utils/hreflangRoutes'
 
 export interface Alternate {
-  hreflang: 'en' | 'zh-CN' | 'x-default'
+  hreflang: 'en' | 'zh-CN' | 'ja' | 'x-default'
   href: string
 }
+
+/**
+ * English routes that have a Japanese page.
+ *
+ * Chinese gets a blanket rule because it has a twin for nearly every route.
+ * Japanese has one page, so the same blanket rule would advertise around 58
+ * Japanese URLs that do not exist, which is the failure this module exists to
+ * prevent. Listing the routes is the honest version until P3 generates the
+ * Japanese shells, at which point this is generated with them.
+ *
+ * The list cannot rot silently: `hreflang.test.ts` reads the page tree back and
+ * fails when a Japanese page exists that is not listed here, and the build crawl
+ * in `scripts/check-hreflang.ts` fails when a listed route was not built.
+ *
+ * Paths are trimmed of their trailing slash, matching `englishPath`.
+ */
+const JA_ROUTES: ReadonlySet<string> = new Set(['/'])
 
 function trimSlash(pathname: string): string {
   const trimmed = pathname.replace(/\/+$/, '')
@@ -16,44 +32,45 @@ function withSlash(pathname: string): string {
   return pathname === '/' ? '/' : `${pathname}/`
 }
 
-/** The English path a page belongs to, whichever locale rendered it. */
+/**
+ * The English path a page belongs to, whichever locale rendered it.
+ *
+ * Every locale prefix is stripped, not just Chinese. Reading `/ja/` as the
+ * English route `/ja` is what labelled the Japanese home page `en` and pointed
+ * its cluster at `/zh-CN/ja/`, which 404s.
+ */
 function englishPath(pathname: string): string {
   const path = trimSlash(pathname)
-  if (path === LOCALE_PREFIX) return '/'
-  return path.startsWith(`${LOCALE_PREFIX}/`)
-    ? path.slice(LOCALE_PREFIX.length)
-    : path
+  for (const prefix of LOCALE_PREFIXES) {
+    if (path === prefix) return '/'
+    if (path.startsWith(`${prefix}/`)) return path.slice(prefix.length)
+  }
+  return path
 }
 
 /**
- * hreflang alternates for a page: the English page, its zh-CN twin, and
- * x-default on English. English-only routes get none, so no alternate ever
- * points at a redirect stub or a 404.
+ * hreflang alternates for a page: the English page, its zh-CN twin, its ja twin
+ * where one exists, and x-default on English. English-only routes get none, so
+ * no alternate ever points at a redirect stub or a 404.
  */
 export function hreflangAlternates(
   pathname: string,
   origin: string
 ): Alternate[] {
   const en = englishPath(pathname)
-  // Japanese has one page and no twin rule yet, so anything under /ja/ emits
-  // nothing rather than a cluster. Without this the homepage advertises
-  // /zh-CN/ja/, which does not exist: the same lie this function's English-only
-  // guard exists to prevent. Read off the English path so a locale-prefixed
-  // request is suppressed too. Clustering ja properly is BE-11285.
-  if (en === '/ja' || en.startsWith('/ja/')) return []
   if (en === '/404' || isLocaleInvariantPath(en)) return []
   const enHref = new URL(withSlash(en), origin).href
-  return [
+  const twin = (prefix: string) =>
+    new URL(withSlash(`${prefix}${en === '/' ? '' : en}`), origin).href
+  const alternates: Alternate[] = [
     { hreflang: 'en', href: enHref },
-    {
-      hreflang: 'zh-CN',
-      href: new URL(
-        withSlash(`${LOCALE_PREFIX}${en === '/' ? '' : en}`),
-        origin
-      ).href
-    },
-    { hreflang: 'x-default', href: enHref }
+    { hreflang: 'zh-CN', href: twin(ZH_PREFIX) }
   ]
+  if (JA_ROUTES.has(en)) {
+    alternates.push({ hreflang: 'ja', href: twin(JA_PREFIX) })
+  }
+  alternates.push({ hreflang: 'x-default', href: enHref })
+  return alternates
 }
 
 /** `xhtml:link` alternates for one sitemap entry, or nothing for English-only pages. */
@@ -86,11 +103,18 @@ export function ogLocale(locale: string): string {
   return OG_LOCALES[locale] ?? OG_LOCALES.en
 }
 
-/** The OG identifier for the other language, when this page has one. */
+/**
+ * The OG identifier for the other language, when this page has one.
+ *
+ * Open Graph takes a single alternate here, so a localized page names English
+ * and English names Chinese. Testing for `en` rather than `zh-CN` matters now
+ * that a third locale exists: the old form sent Japanese pages to `zh_CN`,
+ * pairing them with a language they have nothing to do with.
+ */
 export function ogLocaleAlternate(
   locale: string,
   alternates: Alternate[]
 ): string | null {
   if (alternates.length === 0) return null
-  return locale === 'zh-CN' ? 'en_US' : 'zh_CN'
+  return locale === 'en' ? 'zh_CN' : 'en_US'
 }

--- a/apps/website/src/utils/hreflangAudit.ts
+++ b/apps/website/src/utils/hreflangAudit.ts
@@ -7,7 +7,14 @@
  */
 import type { Alternate } from './hreflangRoutes'
 
-import { unprefixed, ZH_HREFLANG, ZH_PREFIX } from './hreflangRoutes'
+import {
+  JA_HREFLANG,
+  JA_PREFIX,
+  localizedHref,
+  unprefixed,
+  ZH_HREFLANG,
+  ZH_PREFIX
+} from './hreflangRoutes'
 
 export interface BuiltSite {
   /** Every built route, mapped to the alternates its HTML emits. */
@@ -32,17 +39,30 @@ export interface BuiltSite {
  */
 function expectedAlternates(
   route: string,
-  origin: string
+  origin: string,
+  builtRoutes: ReadonlySet<string>
 ): Map<string, string> {
   const path = unprefixed(route)
   const english = `${origin}${path}`
-  const chinese = `${origin}${ZH_PREFIX}${path === '/' ? '/' : path}`
+  const chinese = `${origin}${localizedHref(ZH_PREFIX, path)}`
+  const japaneseRoute = localizedHref(JA_PREFIX, path)
 
-  return new Map([
+  const expected = new Map([
     ['en', english],
-    [ZH_HREFLANG, chinese],
-    ['x-default', english]
+    [ZH_HREFLANG, chinese]
   ])
+  // Japanese is a partial locale: it has one page today, so it belongs in a
+  // cluster only where its page was actually built. Deciding that from the BUILT
+  // site rather than from the emitter's own route list is what keeps this an
+  // independent check. A stale list fails here both ways round: claim a Japanese
+  // page that was not built and the "was not built (404)" rule fires; build one
+  // and forget to list it and the "expects ja -> ... but does not declare it"
+  // rule fires.
+  if (builtRoutes.has(japaneseRoute)) {
+    expected.set(JA_HREFLANG, `${origin}${japaneseRoute}`)
+  }
+  expected.set('x-default', english)
+  return expected
 }
 
 /**
@@ -57,10 +77,11 @@ function clusterErrors(
   route: string,
   alternates: Alternate[],
   origin: string,
-  source: string
+  source: string,
+  builtRoutes: ReadonlySet<string>
 ): string[] {
   const errors: string[] = []
-  const expected = expectedAlternates(route, origin)
+  const expected = expectedAlternates(route, origin, builtRoutes)
   const seen = new Set<string>()
   for (const { hreflang, href } of alternates) {
     if (seen.has(hreflang)) {
@@ -72,8 +93,9 @@ function clusterErrors(
 
     // Checking only that the expected pairs are present accepts extras beside
     // them. A locale this site does not publish still resolves and can still be
-    // reciprocal, so nothing downstream catches it: /ja/ pages that exist for
-    // some other reason would silently enter the cluster. The set is closed.
+    // reciprocal, so nothing downstream catches it. The set stays closed: `ja`
+    // is admitted above only for a route whose Japanese page was actually
+    // built, so a cluster naming `ja` on any other route is still rejected.
     if (!expected.has(hreflang)) {
       errors.push(
         `${route}: ${source} declares hreflang="${hreflang}", which is not one of ${[...expected.keys()].join(', ')}`
@@ -112,9 +134,14 @@ export function auditBuiltSite({
 }: BuiltSite): string[] {
   const errors: string[] = []
   const routeOfHref = (href: string) => href.slice(origin.length) || '/'
+  // Which locales a route SHOULD cluster is read off the built site, so the
+  // audit never inherits the emitter's opinion of what exists.
+  const builtRoutes: ReadonlySet<string> = new Set(pages.keys())
 
   for (const [route, alternates] of pages) {
-    errors.push(...clusterErrors(route, alternates, origin, 'page'))
+    errors.push(
+      ...clusterErrors(route, alternates, origin, 'page', builtRoutes)
+    )
 
     // Only the pages can be checked against what was actually built.
     for (const { hreflang, href } of alternates) {
@@ -164,7 +191,9 @@ export function auditBuiltSite({
       continue
     }
 
-    errors.push(...clusterErrors(route, sitemapAlternates, origin, 'sitemap'))
+    errors.push(
+      ...clusterErrors(route, sitemapAlternates, origin, 'sitemap', builtRoutes)
+    )
 
     const langs = new Set(
       sitemapAlternates.map((alternate) => alternate.hreflang)

--- a/apps/website/src/utils/hreflangRoutes.ts
+++ b/apps/website/src/utils/hreflangRoutes.ts
@@ -13,6 +13,18 @@ export const ZH_HREFLANG = 'zh-CN'
 export const ZH_PREFIX = '/zh-CN'
 
 /**
+ * Japanese. Its URL prefix is the short form while Chinese keeps `/zh-CN`; the
+ * asymmetry is legacy rather than designed, and preserved deliberately because
+ * the Chinese URLs rank and a migration would risk that for no SEO gain. See
+ * `context/decision-zh-hreflang-value.md`.
+ */
+export const JA_HREFLANG = 'ja'
+export const JA_PREFIX = '/ja'
+
+/** Every locale prefix this site serves, longest first so `/zh-CN` wins. */
+export const LOCALE_PREFIXES = [ZH_PREFIX, JA_PREFIX] as const
+
+/**
  * `/src/pages/cloud/pricing.astro` -> `/cloud/pricing/`, index files -> their directory.
  *
  * Exported so a caller asking "which route is this file?" derives it here rather
@@ -39,10 +51,16 @@ export interface Alternate {
  * whatever page happens to own that path.
  */
 export function unprefixed(pathname: string): string {
-  const isLocalePrefixed =
-    pathname === ZH_PREFIX || pathname.startsWith(`${ZH_PREFIX}/`)
-  const path = isLocalePrefixed
-    ? pathname.slice(ZH_PREFIX.length) || '/'
-    : pathname
-  return path.endsWith('/') ? path : `${path}/`
+  for (const prefix of LOCALE_PREFIXES) {
+    if (pathname === prefix || pathname.startsWith(`${prefix}/`)) {
+      const path = pathname.slice(prefix.length) || '/'
+      return path.endsWith('/') ? path : `${path}/`
+    }
+  }
+  return pathname.endsWith('/') ? pathname : `${pathname}/`
+}
+
+/** The URL of `path` in a locale, given that locale's prefix. */
+export function localizedHref(prefix: string, path: string): string {
+  return `${prefix}${path === '/' ? '/' : path}`
 }


### PR DESCRIPTION
Closes BE-11285.

#15488 stopped `/ja/` emitting a broken cluster by suppressing it outright, and left a comment saying clustering it properly was this ticket. This does that.

## The bug

`englishPath` stripped only `/zh-CN`, so `/ja/` was read as the English route `/ja`. The Japanese home page was therefore labelled `en`, and its cluster pointed at `/zh-CN/ja/`, which 404s. There was no `hreflang="ja"` anywhere on the site.

It now strips any locale prefix, and `/ja/` joins the home page cluster as `ja`:

```
/ja/   en        https://comfy.org/
       zh-CN     https://comfy.org/zh-CN/
       ja        https://comfy.org/ja/
       x-default https://comfy.org/
```

## Why Japanese needs a list and Chinese does not

Chinese keeps its blanket rule because it has a twin for nearly every route. Japanese has exactly one page, so the same blanket rule would advertise around 58 Japanese URLs that do not exist, which is the failure this module exists to prevent.

`JA_ROUTES` names the routes that really have a Japanese page. It is a stopgap with a known end date: P3 generates the Japanese page shells and will generate this alongside them.

## The list cannot rot silently

That is the obvious objection to a hand-maintained list, and the reason #15488's `LOCALE_INVARIANT_EXTRA_PATHS` needed a test. Both directions are covered here:

| Failure | Caught by |
| --- | --- |
| a route listed with no Japanese page | `never advertises a ja page that does not exist` |
| a Japanese page that exists but is unlisted | `clusters every Japanese page that was built` |

Both were confirmed by breaking the list on purpose and watching each one fail, rather than assuming they work.

## Keeping the audit independent

`hreflangAudit` decides whether a route should carry `ja` from the **built site**, not from `JA_ROUTES`. If it read the emitter's list it would only be able to agree with it, which is the mirror problem `hreflangRoutes.ts` warns about in its header comment.

Its expected set stays closed: `ja` is admitted only where the Japanese page was actually built, so a cluster naming `ja` on any other route is still rejected.

## Also

`ogLocaleAlternate` tested for `zh-CN`, so every non-Chinese localized page fell to `zh_CN`. A Japanese page was pairing itself with a language it has nothing to do with. It now tests for `en`, giving `ja` → `en_US`.

## Verification

- `pnpm --filter @comfyorg/website test:unit`: **1008 passing, 148 files**
- `pnpm --filter @comfyorg/website build`: 716 pages, exit 0
- `pnpm check:hreflang` against that build: **732 pages, 293 clusters** — "every alternate resolves, every cluster is reciprocal, and every locale points where it claims"
- `pnpm format:check`, `pnpm knip`, `pnpm typecheck`, `pnpm typecheck:website`: clean

Built output spot check:

```
/ja/   hreflang en, zh-CN, ja, x-default   og:locale ja_JP, alternate en_US
/cli/  hreflang en, zh-CN, x-default       (correctly no ja)
```

## Not in this PR

Whether `/ja` should stay in the sitemap at all. It is still ~94% English, but that is a content question that depends on the Japanese fill, so it is deliberately deferred to that phase rather than guessed at now.
