### PR TITLE
fix(billing): keep the scheduled-change title clear of the close button

### DIFF
--- a/src/platform/workspace/components/SubscriptionTransitionPreviewWorkspace.vue
+++ b/src/platform/workspace/components/SubscriptionTransitionPreviewWorkspace.vue
@@ -19,6 +19,7 @@
         >
           {{ confirmTitle }}
         </h2>
+        <div class="size-8 shrink-0" aria-hidden="true" />
       </div>
       <div
         v-if="isReactivating"


### PR DESCRIPTION
## Summary

The plan-change confirm step's title ran underneath the dialog's close (X) button at every viewport below `xl`, reported by Denys on staging ([Slack](https://comfy-organization.slack.com/archives/C0932CGKT5K/p1788429078717289?thread_ts=1787617734.249289)).

## Why this is needed

Reported against the downgrade flow: *"on downgrade, when it says 'Review your scheduled change' the text overlaps the close (X) button. You can still click it, it's just hard to see."* The X stays clickable, so this is cosmetic — but it lands on the confirm screen of a paid transition, which is the least reassuring place to look broken.

## Root cause

Two components own the same row and neither knows it.

`SubscriptionRequiredDialogContentUnified.vue` paints the close button out of flow:

```
class="absolute top-6 right-4 shrink-0 rounded-full ..."
```

Absolute positioning reserves **no width**, so nothing downstream accounts for it.

`SubscriptionTransitionPreviewWorkspace.vue` then builds its header as `[back button, shrink-0] gap-3 [h2, flex-1 text-center]`. `flex-1` stretches the h2 to the content box's right edge — which is exactly where the close button sits. The title is centred inside a box that already contains the button, so the row is asymmetric: 32px of back button + 12px gap consumed on the left, nothing on the right.

```
AS-IS   |[back]  gap  |<----------- h2 flex-1 (text-center) ----------->|
                                                              [X]  <- overlaid, 0 width reserved

TO-BE   |[back]  gap  |<------- h2 flex-1 (text-center) ------>| gap |[spacer]|
                                                                      [X]  <- footprint reserved
```

Measured on the real dialog chrome (`h2` text rect vs. close-button left edge; positive = overlap):

| viewport | dialog | AS-IS box past X | AS-IS text past X | TO-BE box past X | TO-BE text past X |
|---:|---:|---:|---:|---:|---:|
| 360 | 328 | +32 | **+19** | −12 | −27 |
| 390 | 358 | +32 | **+4** | −12 | −18 |
| 430 | 396 | +32 | **+23** | −12 | −37 |
| 470 | 430 | +32 | **+6** | −12 | −16 |
| 640 | 430 | +32 | **+6** | −12 | −16 |
| 768 | 430 | +32 | **+6** | −12 | −16 |
| 1024 | 430 | +32 | −9 | −12 | −31 |
| 1280 | 512 | −8 | −50 | −52 | −72 |

**Why this reached staging.** At `≥1280px` the dialog is `xl:w-[512px]` and the confirm body is `max-w-[400px] mx-auto`, leaving 40px of slack on each side — the overlap disappears. Below `xl` the dialog is `max-xl:w-[min(430px,92vw)]` and the body fills it, so the slack goes to zero. Desktop-width development never sees this.

Note the AS-IS **box** column: it is `+32` at *every* width below `xl`, independent of the string. English merely happens to be long enough to cross the line. `confirmChangeTitle` is 40 characters in `tr` and 38 in `fr` against 28 in `en`, so several locales are further over it, and wrapping does not help — the wrapped lines stay centred in the same overrunning box.

## Changes

- **What**: reserve the close button's own `size-8` footprint at the end of the confirm header row.

```vue
<div class="size-8 shrink-0" aria-hidden="true" />
```

`size-8` is not a magic number — it is exactly what `button.variants.ts` gives `size="icon"`, which is what both the back button and the close button are. The title now sits centred between two equal 32px reservations and its box ends 12px (the `gap-3`) short of the button, so **no string length in any locale can reach it**. That is the property worth having here: the previous behaviour was correct-by-accident for short strings.

## Review Focus

- **Fix location.** This reserves space in the *consumer* rather than making the dialog shell stop overlaying its own header row. Shell-level would fix every step at once, but it changes layout for the pricing/payment/success steps too — too wide for a hotfix on a backport train. Happy to do the shell-level version as a follow-up if you'd prefer it there.
- **Latent sibling.** `SubscriptionAddPaymentPreviewWorkspace.vue:42` has the identical `flex-1 text-center` header and the same `+32` box overrun. Its title (`confirmPayment`) is short enough that no current locale overlaps — longest is `fr` at 24 chars vs. 28 for the string that broke here — so it is latent, not live. Left out on purpose: its `captureMode` branch goes `xl:text-left` inside the sidebar column, where the dialog's close button isn't on that row at all, so the spacer would need to be conditional and is not the same one-liner. Filing separately.
- **No automated regression guard, deliberately.** The invariant is geometric, and `AGENTS.md` rules out asserting utility classes in unit tests ("Do not write tests that are dependent on non-behavioral features like utility classes or styles") — such a test would restate the diff, not the behaviour. A real guard is a Playwright geometry assertion, but no E2E path reaches the transition-preview confirm step today: `CloudWorkspaceMockHelper` has no preview-endpoint mock, so that path has to be built first. Tracking as a follow-up rather than shipping a change-detector.

## Verification

- `SubscriptionTransitionPreviewWorkspace`, `…Reactivation`, `SubscriptionRequiredDialogContentWorkspace` — 57/57 pass.
- Geometry measured before/after at 10 viewports from 360px to 1440px (table above).

## Screenshots

Confirm step at the two widths where the overlap is worst. `textPastCloseEdge` is the title text's right edge minus the close button's left edge — positive means overlap.

| | AS-IS | TO-BE |
|---|---|---|
| **470px** (`+6` → `-16`) | ![as-is 470](https://raw.githubusercontent.com/Comfy-Org/ComfyUI_frontend/assets/pr-16756/pr-16756/as-is-470.png) | ![to-be 470](https://raw.githubusercontent.com/Comfy-Org/ComfyUI_frontend/assets/pr-16756/pr-16756/to-be-470.png) |
| **390px** (`+4` → `-18`) | ![as-is 390](https://raw.githubusercontent.com/Comfy-Org/ComfyUI_frontend/assets/pr-16756/pr-16756/as-is-390.png) | ![to-be 390](https://raw.githubusercontent.com/Comfy-Org/ComfyUI_frontend/assets/pr-16756/pr-16756/to-be-390.png) |

AS-IS is the same render with the spacer removed from the DOM, since the fix is exactly that one element — the measured values reproduce the table above to the pixel. Denys' original staging capture is in the [Slack thread](https://comfy-organization.slack.com/archives/C0932CGKT5K/p1788429078717289?thread_ts=1787617734.249289).

<sub>Images live on the orphan branch `assets/pr-16756` (PNGs only, no code) so the diff here stays at one line. Please keep that branch — the captures above are hot-linked from it and deleting it breaks them in this description.</sub>

