### PR TITLE
style: wrap billing plan comment

### DIFF
--- a/src/composables/billing/useBillingContext.ts
+++ b/src/composables/billing/useBillingContext.ts
@@ -177,9 +177,9 @@ function useBillingContextInternal(): BillingContext {
 
   // Plan identity, independent of subscription health: the per-credit Team plan
   // carries a credit stop, the retired seat-based ones a `team-` slug. Kept off
-  // canAccessSubscriptionFeatures on purpose — paused and payment_failed both force
-  // is_active=false, which is exactly when callers still need to know this is a
-  // team plan.
+  // canAccessSubscriptionFeatures on purpose — paused and payment_failed
+  // both force is_active=false, which is exactly when callers still need
+  // to know this is a team plan.
   const isTeamPlan = computed(
     () =>
       type.value === 'workspace' &&


### PR DESCRIPTION
## Summary

Reflows the Team-plan identity comment to the repository’s 80-column convention, following up on https://github.com/Comfy-Org/ComfyUI_frontend/pull/14867#discussion_r3919377065.

## Changes

- **What**: Wraps the existing comment without changing code behavior.

## Review Focus

Comment-only change; no runtime behavior changed.

## Evidence

- `awk 'length > 80 { exit 1 }'` on the reflowed comment: passed
- `git diff --check`: passed

<!-- authored-by:agent act-fe-14867-followup -->