### PR TITLE
fix(ci): pass large PR reports by file path

### DIFF
--- a/.github/actions/upsert-comment-section/action.yaml
+++ b/.github/actions/upsert-comment-section/action.yaml
@@ -14,7 +14,10 @@ inputs:
     required: true
   section-content:
     description: Markdown content for this section
-    required: true
+    required: false
+  section-content-file:
+    description: Path to a Markdown file containing this section
+    required: false
   comment-marker:
     description: Top-level HTML comment marker shared by all sections in this comment
     required: false
@@ -31,13 +34,17 @@ runs:
         INPUT_PR_NUMBER: ${{ inputs.pr-number }}
         INPUT_SECTION_NAME: ${{ inputs.section-name }}
         INPUT_SECTION_CONTENT: ${{ inputs.section-content }}
+        INPUT_SECTION_CONTENT_FILE: ${{ inputs.section-content-file }}
         INPUT_COMMENT_MARKER: ${{ inputs.comment-marker }}
       with:
         github-token: ${{ inputs.token }}
         script: |
           const prNumber = Number(process.env.INPUT_PR_NUMBER)
           const sectionName = process.env.INPUT_SECTION_NAME
-          const sectionContent = process.env.INPUT_SECTION_CONTENT
+          const sectionContentFile = process.env.INPUT_SECTION_CONTENT_FILE
+          const sectionContent = sectionContentFile
+            ? require('node:fs').readFileSync(sectionContentFile, 'utf8')
+            : process.env.INPUT_SECTION_CONTENT
           const commentMarker = process.env.INPUT_COMMENT_MARKER
 
           if (!/^[a-z0-9-]+$/.test(sectionName)) {

--- a/.github/actions/upsert-comment-section/action.yaml
+++ b/.github/actions/upsert-comment-section/action.yaml
@@ -42,6 +42,11 @@ runs:
           const prNumber = Number(process.env.INPUT_PR_NUMBER)
           const sectionName = process.env.INPUT_SECTION_NAME
           const sectionContentFile = process.env.INPUT_SECTION_CONTENT_FILE
+          if (!sectionContentFile && !process.env.INPUT_SECTION_CONTENT) {
+            throw new Error(
+              'Either section-content or section-content-file is required'
+            )
+          }
           const sectionContent = sectionContentFile
             ? require('node:fs').readFileSync(sectionContentFile, 'utf8')
             : process.env.INPUT_SECTION_CONTENT

--- a/.github/workflows/pr-report.yaml
+++ b/.github/workflows/pr-report.yaml
@@ -165,19 +165,12 @@ jobs:
               }
             }
 
-      - name: Read PR report
-        id: report
-        if: steps.pr-meta.outputs.skip != 'true'
-        uses: juliangruber/read-file-action@271ff311a4947af354c6abcd696a306553b9ec18 # v1.1.8
-        with:
-          path: ./pr-report.md
-
       - name: Upsert bundle/perf/coverage section into unified report
         if: steps.pr-meta.outputs.skip != 'true'
         uses: ./.github/actions/upsert-comment-section
         with:
           pr-number: ${{ steps.pr-meta.outputs.number }}
           section-name: ci-metrics
-          section-content: ${{ steps.report.outputs.content }}
+          section-content-file: ./pr-report.md
           comment-marker: '<!-- COMFYUI_FRONTEND_PR_REPORT -->'
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/cicd/upsert-comment-section-large-content.test.ts
+++ b/scripts/cicd/upsert-comment-section-large-content.test.ts
@@ -1,0 +1,42 @@
+import { spawnSync } from 'node:child_process'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterAll, describe, expect, it } from 'vitest'
+
+const tempDirectory = mkdtempSync(join(tmpdir(), 'upsert-comment-section-'))
+const reportPath = join(tempDirectory, 'pr-report.md')
+const report = 'x'.repeat(256 * 1024)
+
+writeFileSync(reportPath, report)
+
+afterAll(() => rmSync(tempDirectory, { recursive: true }))
+
+describe('large comment section content', () => {
+  it('crosses the process environment limit when passed inline', () => {
+    const result = spawnSync(process.execPath, ['-e', ''], {
+      env: { ...process.env, INPUT_SECTION_CONTENT: report }
+    })
+
+    expect(result.error).toMatchObject({ code: 'E2BIG' })
+  })
+
+  it('can be read after process launch when passed by file path', () => {
+    const result = spawnSync(
+      process.execPath,
+      [
+        '-e',
+        "process.stdout.write(require('node:fs').readFileSync(process.env.INPUT_SECTION_CONTENT_FILE, 'utf8'))"
+      ],
+      {
+        env: { ...process.env, INPUT_SECTION_CONTENT_FILE: reportPath },
+        maxBuffer: report.length * 2
+      }
+    )
+
+    expect(result.error).toBeUndefined()
+    expect(result.status).toBe(0)
+    expect(result.stdout.toString()).toBe(readFileSync(reportPath, 'utf8'))
+  })
+})

--- a/scripts/cicd/upsert-comment-section-large-content.test.ts
+++ b/scripts/cicd/upsert-comment-section-large-content.test.ts
@@ -1,4 +1,4 @@
-import { spawnSync } from 'node:child_process'
+import { execFileSync, spawnSync } from 'node:child_process'
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -7,7 +7,8 @@ import { afterAll, describe, expect, it } from 'vitest'
 
 const tempDirectory = mkdtempSync(join(tmpdir(), 'upsert-comment-section-'))
 const reportPath = join(tempDirectory, 'pr-report.md')
-const report = 'x'.repeat(256 * 1024)
+const argumentLimit = Number(execFileSync('getconf', ['ARG_MAX']).toString())
+const report = 'x'.repeat(argumentLimit + 1)
 
 writeFileSync(reportPath, report)
 

--- a/scripts/cicd/upsert-comment-section-large-content.test.ts
+++ b/scripts/cicd/upsert-comment-section-large-content.test.ts
@@ -12,7 +12,7 @@ function findOversizedReport() {
     const result = spawnSync(process.execPath, ['-e', ''], {
       env: { ...process.env, INPUT_SECTION_CONTENT: report }
     })
-    if ((result.error)?.code === 'E2BIG') {
+    if (result.error?.code === 'E2BIG') {
       return report
     }
     if (result.error) throw result.error

--- a/scripts/cicd/upsert-comment-section-large-content.test.ts
+++ b/scripts/cicd/upsert-comment-section-large-content.test.ts
@@ -1,14 +1,30 @@
-import { execFileSync, spawnSync } from 'node:child_process'
+import { spawnSync } from 'node:child_process'
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
 import { afterAll, describe, expect, it } from 'vitest'
 
+function findOversizedReport() {
+  let report = 'x'.repeat(256 * 1024)
+
+  while (report.length <= 16 * 1024 * 1024) {
+    const result = spawnSync(process.execPath, ['-e', ''], {
+      env: { ...process.env, INPUT_SECTION_CONTENT: report }
+    })
+    if ((result.error)?.code === 'E2BIG') {
+      return report
+    }
+    if (result.error) throw result.error
+    report += report
+  }
+
+  throw new Error('Could not exceed the process environment limit')
+}
+
 const tempDirectory = mkdtempSync(join(tmpdir(), 'upsert-comment-section-'))
 const reportPath = join(tempDirectory, 'pr-report.md')
-const argumentLimit = Number(execFileSync('getconf', ['ARG_MAX']).toString())
-const report = 'x'.repeat(argumentLimit + 1)
+const report = findOversizedReport()
 
 writeFileSync(reportPath, report)
 

--- a/scripts/cicd/upsert-comment-section-large-content.test.ts
+++ b/scripts/cicd/upsert-comment-section-large-content.test.ts
@@ -12,7 +12,11 @@ function findOversizedReport() {
     const result = spawnSync(process.execPath, ['-e', ''], {
       env: { ...process.env, INPUT_SECTION_CONTENT: report }
     })
-    if (result.error?.code === 'E2BIG') {
+    if (
+      result.error &&
+      'code' in result.error &&
+      result.error.code === 'E2BIG'
+    ) {
       return report
     }
     if (result.error) throw result.error


### PR DESCRIPTION
Justification: Emergency fix for the current `main` PR-report `E2BIG` failures; admin merge is authorized by the temporary red-main repair override.

## Summary

Avoid Linux `ARG_MAX` failures by keeping generated PR report content out of the action process environment.

## Changes

- Add an optional `section-content-file` input while preserving inline `section-content` callers.
- Read file-backed section content inside `actions/github-script` after Node starts.
- Pass `pr-report.md` by path and remove the output/env round trip.
- Grow a report until the platform returns `E2BIG`, then prove the same oversized report launches through the file-path input.

## Review Focus

The file input takes precedence when both content inputs are supplied; existing inline callers are unchanged.

Carries [FE-2004](https://linear.app/comfyorg/issue/FE-2004/pr-unified-report-fails-on-large-generated-reports-arg-max).

## Evidence

- `NODE_OPTIONS='--no-experimental-webstorage' pnpm test:unit scripts/cicd/upsert-comment-section-large-content.test.ts` — 2 passed.
- `pnpm exec oxfmt --check .github/actions/upsert-comment-section/action.yaml .github/workflows/pr-report.yaml scripts/cicd/upsert-comment-section-large-content.test.ts` — passed.
- `pnpm typecheck:scripts` — passed.
- Commit hook: full `pnpm typecheck` — passed.
- Push hook: `knip --cache` — passed.
- Reproduced by [workflow run 33739257134](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/33739257134).

<!-- authored-by:agent ecw-180 -->