### PR TITLE
fix(agent): disable CRDT event retention in production

### DIFF
--- a/src/workbench/extensions/agent/crdt/crdtDebugGate.test.ts
+++ b/src/workbench/extensions/agent/crdt/crdtDebugGate.test.ts
@@ -124,6 +124,13 @@ describe('crdtDebugGate', () => {
     expect(gate.isCrdtDebugEnabled()).toBe(false)
   })
 
+  it('refuses a previously persisted enable choice on production', async () => {
+    localStorage.setItem('Comfy.Agent.CrdtDebug.enabled', 'true')
+    const gate = await loadGateOnHostname('', 'cloud.comfy.org')
+
+    expect(gate.isCrdtDebugEnabled()).toBe(false)
+  })
+
   it('still honours an explicit opt-out link on the production hostname', async () => {
     // A stray opt-out must never be the one query value this gate refuses to
     // apply — production must always be able to turn ITSELF back off.

--- a/src/workbench/extensions/agent/crdt/crdtDebugGate.ts
+++ b/src/workbench/extensions/agent/crdt/crdtDebugGate.ts
@@ -146,10 +146,12 @@ applyQueryOverride()
 /**
  * Whether the CRDT debug instrument (panel + console tracing) is available.
  *
- * An explicit opt-out wins over `DEV` so a developer chasing a rendering bug
- * can silence the instrument without editing code.
+ * Production is always disabled, including stale persisted choices from an
+ * older build. Elsewhere, an explicit opt-out wins over `DEV` so a developer
+ * chasing a rendering bug can silence the instrument without editing code.
  */
 export function isCrdtDebugEnabled(): boolean {
+  if (isProductionHostname()) return false
   if (cachedEnabled === null) {
     const stored = readStoredEnabled()
     cachedEnabled =

--- a/src/workbench/extensions/agent/crdt/crdtLog.ts
+++ b/src/workbench/extensions/agent/crdt/crdtLog.ts
@@ -45,10 +45,9 @@ interface CrdtLogEntry {
 /**
  * Emit one CRDT-internal event.
  *
- * The ring buffer records even when the console is quiet: a tester who only
- * turns the panel on AFTER something went wrong still needs the run-up in the
- * copied report, and 500 capped entries cost nothing. An explicit opt-out is
- * the one case that skips recording too.
+ * The ring buffer records while the debug instrument is enabled even when the
+ * selected console level is quiet. Ordinary production sessions retain no
+ * frame or actor details; a tester must opt in before reproducing an issue.
  */
 function crdtLog(entry: CrdtLogEntry): void {
   const { scope, level, kind, message, detail } = entry

--- a/src/workbench/extensions/agent/crdt/devPanelLog.test.ts
+++ b/src/workbench/extensions/agent/crdt/devPanelLog.test.ts
@@ -122,7 +122,7 @@ describe('devPanelLog', () => {
     expect(event.level).toBe('warn')
   })
 
-  it('honors explicit opt-out for direct recorders', () => {
+  it('does not retain events while the debug instrument is disabled', () => {
     setCrdtDebugEnabled(false)
 
     recordDevEvent('doc_update', { seq: 1 })

--- a/src/workbench/extensions/agent/crdt/devPanelLog.ts
+++ b/src/workbench/extensions/agent/crdt/devPanelLog.ts
@@ -1,6 +1,6 @@
 import { shallowRef, triggerRef } from 'vue'
 
-import { isCrdtDebugOptedOut } from './crdtDebugGate'
+import { isCrdtDebugEnabled } from './crdtDebugGate'
 import type { CrdtLogLevel } from './crdtDebugGate'
 
 /**
@@ -54,22 +54,24 @@ export interface DevEventOptions {
 const CAPACITY = 500
 
 let nextSeq = 1
-const buffer: DevEvent[] = []
+let buffer: DevEvent[] | undefined
 
 /**
- * Shallow ref over the ring buffer. Consumers get a stable array identity;
- * mutations are announced via triggerRef so a 500-entry log never churns
- * deep reactivity.
+ * Shallow ref over the lazily allocated ring buffer. Production sessions that
+ * never enable the debug instrument retain no event buffer. Once recording is
+ * enabled, consumers get a stable array identity and mutations are announced
+ * via triggerRef so a 500-entry log never churns deep reactivity.
  */
-export const devEvents = shallowRef<readonly DevEvent[]>(buffer)
+export const devEvents = shallowRef<readonly DevEvent[]>([])
 
 export function recordDevEvent(
   kind: DevEventKind,
   detail: unknown,
   options: DevEventOptions = {}
 ): void {
-  if (isCrdtDebugOptedOut()) return
-  buffer.push({
+  if (!isCrdtDebugEnabled()) return
+  const events = buffer ?? (buffer = [])
+  events.push({
     seq: nextSeq++,
     at: Date.now(),
     kind,
@@ -77,11 +79,13 @@ export function recordDevEvent(
     level: options.level ?? 'info',
     detail
   })
-  if (buffer.length > CAPACITY) buffer.splice(0, buffer.length - CAPACITY)
-  triggerRef(devEvents)
+  if (events.length > CAPACITY) events.splice(0, events.length - CAPACITY)
+  if (devEvents.value !== events) devEvents.value = events
+  else triggerRef(devEvents)
 }
 
 export function clearDevEvents(): void {
+  if (!buffer) return
   buffer.length = 0
   triggerRef(devEvents)
 }


### PR DESCRIPTION
## Summary

- disable CRDT debug recording unless the authorized debug gate is enabled
- hard-disable stale persisted debug choices on `cloud.comfy.org`
- allocate the 500-entry event buffer lazily

## Test plan

- `NODE_OPTIONS="--no-experimental-webstorage" pnpm exec vitest run src/workbench/extensions/agent/crdt/devPanelLog.test.ts src/workbench/extensions/agent/crdt/crdtDebugGate.test.ts`
- `NODE_OPTIONS="--no-experimental-webstorage" pnpm exec vue-tsc --noEmit`
- scoped ESLint, type-aware Oxlint, and Oxfmt checks
