### PR TITLE
fix(agent): block unconfirmed destructive graph changes (PM-826)

### DIFF
--- a/src/core/graph/graphMutations.test.ts
+++ b/src/core/graph/graphMutations.test.ts
@@ -143,6 +143,79 @@ describe('graphMutations', () => {
     error.mockRestore()
   })
 
+  it('preserves all five existing nodes when an additive turn falls back to replacing the graph', () => {
+    const initial = mutations()
+    initial.batch(context, (batch) => {
+      for (let id = 1; id <= 5; id++) batch.addNode(node(id, { seed: id }))
+    })
+    createLayout.mockClear()
+    deleteLayouts.mockClear()
+    const snapshot = () =>
+      JSON.stringify({
+        nodes: useNodeDataStore().getGraphNodesFor('root', 'root'),
+        links: [...useLinkStore().graphTopologies(scope)]
+      })
+    const before = snapshot()
+    const rejected = vi.fn()
+    const guarded = createGraphMutations({
+      getScope: () => scope,
+      allowDestructiveMutation: () => false,
+      onDestructiveMutationRejected: rejected,
+      layout: { createNode: createLayout, deleteNodes: deleteLayouts }
+    })
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    const applied = guarded.batch(
+      { ...context, opId: 'add-text-fallback' },
+      (batch) => {
+        batch.removeMissing([], [])
+        batch.addNode({
+          ...node(6, { text: 'hello' }),
+          type: 'TextNode'
+        })
+      }
+    )
+
+    expect(applied).toBe(false)
+    expect(snapshot()).toBe(before)
+    expect(rejected).toHaveBeenCalledOnce()
+    expect(rejected).toHaveBeenCalledWith({
+      nodeIds: [
+        toNodeId(1),
+        toNodeId(2),
+        toNodeId(3),
+        toNodeId(4),
+        toNodeId(5)
+      ],
+      linkIds: []
+    })
+    expect(createLayout).not.toHaveBeenCalled()
+    expect(deleteLayouts).not.toHaveBeenCalled()
+    expect(error).toHaveBeenCalledWith(
+      '[agent-crdt] graph mutation rejected: destructive change requires explicit user confirmation; nodes=[1,2,3,4,5], links=[], actor=agent:test, op=add-text-fallback'
+    )
+    error.mockRestore()
+  })
+
+  it('allows a node deletion after explicit destructive authorization', () => {
+    const initial = mutations()
+    initial.addNode(node(1), context)
+    deleteLayouts.mockClear()
+    const guarded = createGraphMutations({
+      getScope: () => scope,
+      allowDestructiveMutation: () => true,
+      layout: { createNode: createLayout, deleteNodes: deleteLayouts }
+    })
+
+    expect(
+      guarded.deleteNode(toNodeId(1), [], {
+        ...context,
+        opId: 'confirmed-delete'
+      })
+    ).toBe(true)
+    expect(useNodeDataStore().getGraphNodesFor('root', 'root')).toEqual([])
+  })
+
   it('rejects a sibling-owned node collision before committing earlier writes', () => {
     const siblingScope = {
       rootGraphId: scope.rootGraphId,

--- a/src/core/graph/graphMutations.ts
+++ b/src/core/graph/graphMutations.ts
@@ -97,6 +97,13 @@ export interface GraphMutations {
 export interface GraphMutationsDeps {
   getScope(): GraphScope | null
   layout: SemanticLayoutMutationPort
+  allowDestructiveMutation?(change: DestructiveGraphMutation): boolean
+  onDestructiveMutationRejected?(change: DestructiveGraphMutation): void
+}
+
+interface DestructiveGraphMutation {
+  nodeIds: readonly NodeId[]
+  linkIds: readonly LinkId[]
 }
 
 type QueuedMutation =
@@ -145,6 +152,11 @@ type PreparedMutation =
       removedLinkIds: readonly LinkId[]
     }
   | { kind: 'clearSemanticGraph'; nodeIds: readonly NodeId[] }
+
+interface PreparedPlan {
+  mutations: PreparedMutation[]
+  destructive: DestructiveGraphMutation
+}
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value)
@@ -316,7 +328,7 @@ export function createGraphMutations(deps: GraphMutationsDeps): GraphMutations {
   function prepare(
     scope: GraphScope,
     queued: readonly QueuedMutation[]
-  ): PreparedMutation[] | string {
+  ): PreparedPlan | string {
     const nodes = new Map(
       nodeStore
         .getGraphNodesFor(scope.rootGraphId, scope.owningGraphId)
@@ -325,6 +337,9 @@ export function createGraphMutations(deps: GraphMutationsDeps): GraphMutations {
     const links = new Map(
       [...linkStore.graphTopologies(scope)].map((link) => [link.id, link])
     )
+    const initialNodes = new Map(nodes)
+    const initialLinks = new Set(links.keys())
+    const removedInitialNodeIds = new Set<NodeId>()
     const widgets = new Map<string, Set<string>>()
     for (const node of nodes.values()) {
       widgets.set(
@@ -466,6 +481,7 @@ export function createGraphMutations(deps: GraphMutationsDeps): GraphMutations {
             .map(({ id }) => id)
             .filter((id) => !retainedNodeIds.has(nodeKey(id)))
           for (const id of nodeIds) {
+            if (initialNodes.has(nodeKey(id))) removedInitialNodeIds.add(id)
             nodes.delete(nodeKey(id))
             widgets.delete(nodeKey(id))
             removeIncidentLinks(links, id)
@@ -517,6 +533,9 @@ export function createGraphMutations(deps: GraphMutationsDeps): GraphMutations {
             }
             removedLinkIds.push(id)
           }
+          if (initialNodes.has(nodeKey(mutation.nodeId))) {
+            removedInitialNodeIds.add(mutation.nodeId)
+          }
           nodes.delete(nodeKey(mutation.nodeId))
           widgets.delete(nodeKey(mutation.nodeId))
           removeIncidentLinks(links, mutation.nodeId)
@@ -530,6 +549,9 @@ export function createGraphMutations(deps: GraphMutationsDeps): GraphMutations {
         }
         case 'clearSemanticGraph': {
           const nodeIds = [...nodes.values()].map(({ id }) => id)
+          for (const id of nodeIds) {
+            if (initialNodes.has(nodeKey(id))) removedInitialNodeIds.add(id)
+          }
           nodes.clear()
           widgets.clear()
           links.clear()
@@ -538,7 +560,21 @@ export function createGraphMutations(deps: GraphMutationsDeps): GraphMutations {
         }
       }
     }
-    return prepared
+    return {
+      mutations: prepared,
+      destructive: {
+        nodeIds: [
+          ...new Set([
+            ...removedInitialNodeIds,
+            ...[...initialNodes].flatMap(([id, node]) => {
+              const finalNode = nodes.get(id)
+              return !finalNode || finalNode.type !== node.type ? [node.id] : []
+            })
+          ])
+        ],
+        linkIds: [...initialLinks].filter((id) => !links.has(id))
+      }
+    }
   }
 
   function detachLinkSlots(
@@ -802,9 +838,22 @@ export function createGraphMutations(deps: GraphMutationsDeps): GraphMutations {
           queued.push({ kind: 'clearSemanticGraph' })
         }
       })
-      const prepared = prepare(scope, queued)
-      if (typeof prepared === 'string') return fail(prepared)
-      commit(scope, prepared, context)
+      const plan = prepare(scope, queued)
+      if (typeof plan === 'string') return fail(plan)
+      const destructive =
+        plan.destructive.nodeIds.length > 0 ||
+        plan.destructive.linkIds.length > 0
+      if (
+        destructive &&
+        deps.allowDestructiveMutation &&
+        !deps.allowDestructiveMutation(plan.destructive)
+      ) {
+        deps.onDestructiveMutationRejected?.(plan.destructive)
+        return fail(
+          `destructive change requires explicit user confirmation; nodes=[${plan.destructive.nodeIds.join(',')}], links=[${plan.destructive.linkIds.join(',')}], actor=${context.actor}, op=${context.opId}`
+        )
+      }
+      commit(scope, plan.mutations, context)
       return true
     },
     addNode(payload, context) {

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -5238,6 +5238,7 @@
     "friend": "there",
     "sendFailed": "Message failed to send",
     "sendBusy": "A message is already being sent",
+    "destructiveMutationBlocked": "I stopped this change because it would remove existing workflow content. Ask me explicitly to delete or replace existing workflow nodes before I make a destructive change.",
     "malformedEvent": "The agent sent an event this panel could not read",
     "coachTitle": "Meet the agent",
     "coachBody": "Ask it to build or edit graphs.",

--- a/src/workbench/extensions/agent/AgentPanelRoot.vue
+++ b/src/workbench/extensions/agent/AgentPanelRoot.vue
@@ -86,7 +86,6 @@ import type {
 import { createAgentEventSource } from './services/agent/agentEventSource'
 import { useAgentChatHistoryStore } from './stores/agent/agentChatHistoryStore'
 import { useAgentPanelStore } from './stores/agent/agentPanelStore'
-import { useAgentConversationStore } from './stores/agent/agentConversationStore'
 import {
   isCrdtDebugEnabled,
   resolveDebugPanelEnabled
@@ -328,7 +327,8 @@ const {
   bindWorkflow,
   answerAsk,
   answeringAskIds,
-  destructiveMutationsAllowed
+  destructiveMutationsAllowed,
+  rejectDestructiveMutation
 } = useAgentSession({
   rest,
   events,
@@ -342,7 +342,6 @@ const {
   }
 })
 
-const conversationStore = useAgentConversationStore()
 const graphMutationsByWorkflow = new Map<
   string,
   ReturnType<typeof createGraphMutations>
@@ -361,12 +360,7 @@ const graphMutations = (workflowId: string) => {
         : null
     },
     allowDestructiveMutation: () => destructiveMutationsAllowed.value,
-    onDestructiveMutationRejected() {
-      conversationStore.recordActiveNotice(
-        t('agent.destructiveMutationBlocked')
-      )
-      void stopTurn()
-    },
+    onDestructiveMutationRejected: rejectDestructiveMutation,
     layout: {
       createNode(scope, nodeId, layout, context) {
         const { position, size } = layout

--- a/src/workbench/extensions/agent/AgentPanelRoot.vue
+++ b/src/workbench/extensions/agent/AgentPanelRoot.vue
@@ -86,6 +86,7 @@ import type {
 import { createAgentEventSource } from './services/agent/agentEventSource'
 import { useAgentChatHistoryStore } from './stores/agent/agentChatHistoryStore'
 import { useAgentPanelStore } from './stores/agent/agentPanelStore'
+import { useAgentConversationStore } from './stores/agent/agentConversationStore'
 import {
   isCrdtDebugEnabled,
   resolveDebugPanelEnabled
@@ -122,65 +123,6 @@ const tabActivity = useWorkflowTabActivityStore()
 const CREATING_TAB_MIN_DURATION_MS = 500
 
 const canvasStore = useCanvasStore()
-const graphMutationsByWorkflow = new Map<
-  string,
-  ReturnType<typeof createGraphMutations>
->()
-const graphMutations = (workflowId: string) => {
-  const existing = graphMutationsByWorkflow.get(workflowId)
-  if (existing) return existing
-  const mutations = createGraphMutations({
-    getScope() {
-      const rootGraphId = boundTabFor(workflowId)?.activeState?.id
-      return rootGraphId
-        ? {
-            rootGraphId: toRootGraphId(rootGraphId),
-            owningGraphId: toOwningGraphId(rootGraphId)
-          }
-        : null
-    },
-    layout: {
-      createNode(scope, nodeId, layout, context) {
-        const { position, size } = layout
-        layoutStore.applyOperation({
-          type: 'createNode',
-          graphId: scope.rootGraphId,
-          ownerGraphId: scope.owningGraphId,
-          nodeId,
-          layout: {
-            id: nodeId,
-            position,
-            size,
-            bounds: { x: position.x, y: position.y, ...size },
-            zIndex: layoutStore.allocateZIndex(),
-            visible: true
-          },
-          source: LayoutSource.AgentRemote,
-          actor: context.actor,
-          opId: context.opId,
-          timestamp: Date.now()
-        })
-      },
-      deleteNodes(scope, nodeIds, context) {
-        const timestamp = Date.now()
-        layoutStore.applyOperations(
-          nodeIds.map((nodeId) => ({
-            type: 'deleteNode',
-            graphId: scope.rootGraphId,
-            ownerGraphId: scope.owningGraphId,
-            nodeId,
-            source: LayoutSource.AgentRemote,
-            actor: context.actor,
-            opId: context.opId,
-            timestamp
-          }))
-        )
-      }
-    }
-  })
-  graphMutationsByWorkflow.set(workflowId, mutations)
-  return mutations
-}
 const { focusNodeInstance } = useFocusNode()
 
 function toSelectedNode(node: LGraphNode): SelectedNode {
@@ -385,7 +327,8 @@ const {
   boundWorkflowId,
   bindWorkflow,
   answerAsk,
-  answeringAskIds
+  answeringAskIds,
+  destructiveMutationsAllowed
 } = useAgentSession({
   rest,
   events,
@@ -398,6 +341,74 @@ const {
     draft: activeWorkflowDraft
   }
 })
+
+const conversationStore = useAgentConversationStore()
+const graphMutationsByWorkflow = new Map<
+  string,
+  ReturnType<typeof createGraphMutations>
+>()
+const graphMutations = (workflowId: string) => {
+  const existing = graphMutationsByWorkflow.get(workflowId)
+  if (existing) return existing
+  const mutations = createGraphMutations({
+    getScope() {
+      const rootGraphId = boundTabFor(workflowId)?.activeState?.id
+      return rootGraphId
+        ? {
+            rootGraphId: toRootGraphId(rootGraphId),
+            owningGraphId: toOwningGraphId(rootGraphId)
+          }
+        : null
+    },
+    allowDestructiveMutation: () => destructiveMutationsAllowed.value,
+    onDestructiveMutationRejected() {
+      conversationStore.recordActiveNotice(
+        t('agent.destructiveMutationBlocked')
+      )
+      void stopTurn()
+    },
+    layout: {
+      createNode(scope, nodeId, layout, context) {
+        const { position, size } = layout
+        layoutStore.applyOperation({
+          type: 'createNode',
+          graphId: scope.rootGraphId,
+          ownerGraphId: scope.owningGraphId,
+          nodeId,
+          layout: {
+            id: nodeId,
+            position,
+            size,
+            bounds: { x: position.x, y: position.y, ...size },
+            zIndex: layoutStore.allocateZIndex(),
+            visible: true
+          },
+          source: LayoutSource.AgentRemote,
+          actor: context.actor,
+          opId: context.opId,
+          timestamp: Date.now()
+        })
+      },
+      deleteNodes(scope, nodeIds, context) {
+        const timestamp = Date.now()
+        layoutStore.applyOperations(
+          nodeIds.map((nodeId) => ({
+            type: 'deleteNode',
+            graphId: scope.rootGraphId,
+            ownerGraphId: scope.owningGraphId,
+            nodeId,
+            source: LayoutSource.AgentRemote,
+            actor: context.actor,
+            opId: context.opId,
+            timestamp
+          }))
+        )
+      }
+    }
+  })
+  graphMutationsByWorkflow.set(workflowId, mutations)
+  return mutations
+}
 
 const isBoundWorkflowActive = computed(() => {
   const bound = boundWorkflowId.value

--- a/src/workbench/extensions/agent/components/agent/AgentPanel.test.ts
+++ b/src/workbench/extensions/agent/components/agent/AgentPanel.test.ts
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, it } from 'vitest'
 
 import { i18n } from '@/i18n'
 import type { TurnId } from '../../schemas/agentApiSchema'
+import { createAssistantMessage } from '../../services/agent/agentMessageParts'
 
 import AgentPanel from './AgentPanel.vue'
 
@@ -56,6 +57,30 @@ describe('AgentPanel', () => {
         'The AI agent can make mistakes. Double check your response.'
       )
     ).toBeInTheDocument()
+  })
+
+  it('renders a blocked destructive fallback in the response panel', () => {
+    const message = createAssistantMessage('msg-1' as TurnId)
+    message.streaming = false
+    message.parts = [
+      {
+        type: 'notice',
+        level: 'error',
+        text: 'Existing workflow content was preserved.'
+      }
+    ]
+
+    render(AgentPanel, {
+      props: { entries: [message], historyGroups },
+      global: {
+        plugins: [i18n],
+        stubs: { Composer: true, PanelHeader: true }
+      }
+    })
+
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      'Existing workflow content was preserved.'
+    )
   })
 
   it('groups chat options with the title and separates history navigation', () => {

--- a/src/workbench/extensions/agent/composables/agent/useAgentSession.test.ts
+++ b/src/workbench/extensions/agent/composables/agent/useAgentSession.test.ts
@@ -204,6 +204,33 @@ describe('useAgentSession (v1 composition root)', () => {
     expect(session.isStreaming.value).toBe(false)
   })
 
+  it('requires graph-specific destructive intent before authorizing node loss', async () => {
+    const { source, emit } = fakeEvents()
+    const session = useAgentSession({
+      rest: fakeRest(),
+      events: source
+    })
+    session.start()
+
+    await session.sendMessage(
+      "Add a text node, set its prompt to 'hello', and run it."
+    )
+    expect(session.destructiveMutationsAllowed.value).toBe(false)
+
+    await session.sendMessage('Delete every node from this workflow.')
+    expect(session.destructiveMutationsAllowed.value).toBe(true)
+    emit(doneIn('th-other', 'msg-other'))
+    expect(session.destructiveMutationsAllowed.value).toBe(true)
+    emit(done('msg-1'))
+    expect(session.destructiveMutationsAllowed.value).toBe(false)
+
+    await session.sendMessage('Do not delete any nodes; just explain them.')
+    expect(session.destructiveMutationsAllowed.value).toBe(false)
+
+    await session.sendMessage('Replace the prompt text with hello.')
+    expect(session.destructiveMutationsAllowed.value).toBe(false)
+  })
+
   it('(b) a second send posts to the adopted threadId, not new', async () => {
     const postMessage = vi
       .fn<

--- a/src/workbench/extensions/agent/composables/agent/useAgentSession.test.ts
+++ b/src/workbench/extensions/agent/composables/agent/useAgentSession.test.ts
@@ -225,6 +225,15 @@ describe('useAgentSession (v1 composition root)', () => {
     emit(done('msg-1'))
     expect(session.destructiveMutationsAllowed.value).toBe(false)
 
+    await session.sendMessage("Delete all nodes, but don't remove the links.")
+    expect(session.destructiveMutationsAllowed.value).toBe(true)
+
+    await session.sendMessage('Delete all nodes. Do not remove the links.')
+    expect(session.destructiveMutationsAllowed.value).toBe(true)
+
+    await session.sendMessage("Don't remove the links, but delete all nodes.")
+    expect(session.destructiveMutationsAllowed.value).toBe(true)
+
     await session.sendMessage('Do not delete any nodes; just explain them.')
     expect(session.destructiveMutationsAllowed.value).toBe(false)
 

--- a/src/workbench/extensions/agent/composables/agent/useAgentSession.test.ts
+++ b/src/workbench/extensions/agent/composables/agent/useAgentSession.test.ts
@@ -1,6 +1,7 @@
 import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { i18n } from '@/i18n'
 import { reportError } from '@/platform/telemetry/reportError'
 import { createNodeLocatorId } from '@/types/nodeIdentification'
 import { toNodeId } from '@/types/nodeId'
@@ -229,6 +230,35 @@ describe('useAgentSession (v1 composition root)', () => {
 
     await session.sendMessage('Replace the prompt text with hello.')
     expect(session.destructiveMutationsAllowed.value).toBe(false)
+  })
+
+  it('reports a blocked destructive change once per turn', async () => {
+    const rest = fakeRest()
+    const { source } = fakeEvents()
+    const session = useAgentSession({ rest, events: source })
+    session.start()
+
+    await session.sendMessage('Add a text node.')
+    session.rejectDestructiveMutation()
+    session.rejectDestructiveMutation()
+    await Promise.resolve()
+
+    const assistant = session.entries.value.at(-1)
+    expect(assistant?.role).toBe('assistant')
+    if (assistant?.role !== 'assistant') return
+    expect(assistant.parts).toEqual([
+      {
+        type: 'notice',
+        level: 'error',
+        text: i18n.global.t('agent.destructiveMutationBlocked')
+      }
+    ])
+    expect(rest.cancelMessage).toHaveBeenCalledTimes(1)
+
+    await session.sendMessage('Add another text node.')
+    session.rejectDestructiveMutation()
+    await Promise.resolve()
+    expect(rest.cancelMessage).toHaveBeenCalledTimes(2)
   })
 
   it('(b) a second send posts to the adopted threadId, not new', async () => {

--- a/src/workbench/extensions/agent/composables/agent/useAgentSession.ts
+++ b/src/workbench/extensions/agent/composables/agent/useAgentSession.ts
@@ -58,6 +58,20 @@ export interface AgentSessionDeps {
 
 const THREAD_STORAGE_KEY = 'Comfy.Agent.ThreadId'
 const PREPARE_TIMEOUT_MS = 3000
+const DESTRUCTIVE_COMMAND =
+  /\b(?:clear|delete|discard|erase|remove|replace)\b/iu
+const DESTRUCTIVE_TARGET =
+  /\b(?:all|everything|graph|link|links|node|nodes|workflow|canvas|connection|connections)\b/iu
+const NEGATED_DESTRUCTIVE_COMMAND =
+  /\b(?:do not|don['’]t|never|without)\b[^.!?\n]{0,40}\b(?:clear|delete|discard|erase|remove|replace)\b/iu
+
+function hasExplicitDestructiveIntent(text: string): boolean {
+  return (
+    DESTRUCTIVE_COMMAND.test(text) &&
+    DESTRUCTIVE_TARGET.test(text) &&
+    !NEGATED_DESTRUCTIVE_COMMAND.test(text)
+  )
+}
 
 let sessionGeneration = 0
 
@@ -90,6 +104,8 @@ export function useAgentSession(deps: AgentSessionDeps) {
     else next.delete(askId)
     answeringAskIds.value = next
   }
+
+  const destructiveMutationsAllowed = ref(false)
 
   let localErrorCount = 0
   function nextLocalErrorId(): TurnId {
@@ -200,6 +216,7 @@ export function useAgentSession(deps: AgentSessionDeps) {
       return false
     }
     promptEditState.value = { phase: 'idle' }
+    destructiveMutationsAllowed.value = hasExplicitDestructiveIntent(text)
     sending.value = true
     stopRequestedWhileSending = false
     if (workflow?.prepare)
@@ -254,6 +271,7 @@ export function useAgentSession(deps: AgentSessionDeps) {
       }
       return true
     } catch (error) {
+      destructiveMutationsAllowed.value = false
       const message =
         error instanceof AgentApiError
           ? error.message
@@ -274,6 +292,7 @@ export function useAgentSession(deps: AgentSessionDeps) {
   let stopRequestedWhileSending = false
 
   async function stopTurn(): Promise<void> {
+    destructiveMutationsAllowed.value = false
     const threadId = conversationStore.threadId
     const turnId = conversationStore.activeTurnId
     if (threadId === null || turnId === null) {
@@ -337,6 +356,7 @@ export function useAgentSession(deps: AgentSessionDeps) {
   function newChat(): void {
     loadGeneration++
     promptEditState.value = { phase: 'idle' }
+    destructiveMutationsAllowed.value = false
     conversationStore.stashActiveTurn()
     conversationStore.reset()
     boundWorkflowId.value = null
@@ -351,6 +371,7 @@ export function useAgentSession(deps: AgentSessionDeps) {
   async function loadThread(threadId: string): Promise<void> {
     const generation = ++loadGeneration
     promptEditState.value = { phase: 'idle' }
+    destructiveMutationsAllowed.value = false
     const isCurrent = () =>
       generation === loadGeneration && ownedGeneration === sessionGeneration
     conversationStore.stashActiveTurn()
@@ -375,6 +396,7 @@ export function useAgentSession(deps: AgentSessionDeps) {
           typeof messageId !== 'string' ||
           messageId === conversationStore.activeTurnId
         ) {
+          destructiveMutationsAllowed.value = false
           conversationStore.abortActiveTurn()
           pushError(i18n.global.t('agent.malformedEvent'))
         } else {
@@ -398,8 +420,14 @@ export function useAgentSession(deps: AgentSessionDeps) {
         )
           workflow?.activeTab?.(event.data)
         return
-      default:
+      default: {
+        const completesActiveTurn =
+          event.type === 'agent_message_done' &&
+          event.data.message_id === conversationStore.activeTurnId &&
+          (event.data.thread_id === undefined ||
+            event.data.thread_id === conversationStore.threadId)
         conversationStore.ingest(event)
+        if (completesActiveTurn) destructiveMutationsAllowed.value = false
         if (
           event.type === 'agent_message_done' &&
           promptEditState.value.phase === 'stopping' &&
@@ -411,6 +439,8 @@ export function useAgentSession(deps: AgentSessionDeps) {
             phase: 'ready',
             turnId: promptEditState.value.turnId
           }
+        break
+      }
     }
   }
 
@@ -423,6 +453,7 @@ export function useAgentSession(deps: AgentSessionDeps) {
     // interrupted. An initial `false` (socket not open yet) is not a
     // reconnect and must not abort a turn that survived a remount.
     if (!everLive) return
+    destructiveMutationsAllowed.value = false
     conversationStore.abortActiveTurn()
     conversationStore.dropBackgroundTurns()
   }
@@ -441,6 +472,9 @@ export function useAgentSession(deps: AgentSessionDeps) {
 
   return {
     boundWorkflowId: computed(() => boundWorkflowId.value),
+    destructiveMutationsAllowed: computed(
+      () => destructiveMutationsAllowed.value
+    ),
     bindWorkflow,
     isSending,
     editableTurnId,

--- a/src/workbench/extensions/agent/composables/agent/useAgentSession.ts
+++ b/src/workbench/extensions/agent/composables/agent/useAgentSession.ts
@@ -59,18 +59,21 @@ export interface AgentSessionDeps {
 const THREAD_STORAGE_KEY = 'Comfy.Agent.ThreadId'
 const PREPARE_TIMEOUT_MS = 3000
 const DESTRUCTIVE_COMMAND =
-  /\b(?:clear|delete|discard|erase|remove|replace)\b/iu
+  /\b(?:clear|delete|discard|erase|remove|replace)\b/giu
 const DESTRUCTIVE_TARGET =
   /\b(?:all|everything|graph|link|links|node|nodes|workflow|canvas|connection|connections)\b/iu
-const NEGATED_DESTRUCTIVE_COMMAND =
-  /\b(?:do not|don['’]t|never|without)\b[^.!?\n]{0,40}\b(?:clear|delete|discard|erase|remove|replace)\b/iu
+const NEGATED_COMMAND_PREFIX =
+  /\b(?:do not|don['’]t|never|without)(?:\s+\S+){0,3}\s*$/iu
 
 function hasExplicitDestructiveIntent(text: string): boolean {
-  return (
-    DESTRUCTIVE_COMMAND.test(text) &&
-    DESTRUCTIVE_TARGET.test(text) &&
-    !NEGATED_DESTRUCTIVE_COMMAND.test(text)
-  )
+  const hasUnnegatedCommand = Array.from(
+    text.matchAll(DESTRUCTIVE_COMMAND)
+  ).some((match) => {
+    const prefix = text.slice(Math.max(0, match.index - 40), match.index)
+    const clausePrefix = prefix.split(/[.!?;\n]|\bbut\b/iu).at(-1) ?? prefix
+    return !NEGATED_COMMAND_PREFIX.test(clausePrefix)
+  })
+  return hasUnnegatedCommand && DESTRUCTIVE_TARGET.test(text)
 }
 
 let sessionGeneration = 0

--- a/src/workbench/extensions/agent/composables/agent/useAgentSession.ts
+++ b/src/workbench/extensions/agent/composables/agent/useAgentSession.ts
@@ -106,6 +106,7 @@ export function useAgentSession(deps: AgentSessionDeps) {
   }
 
   const destructiveMutationsAllowed = ref(false)
+  let destructiveRejectionReported = false
 
   let localErrorCount = 0
   function nextLocalErrorId(): TurnId {
@@ -217,6 +218,7 @@ export function useAgentSession(deps: AgentSessionDeps) {
     }
     promptEditState.value = { phase: 'idle' }
     destructiveMutationsAllowed.value = hasExplicitDestructiveIntent(text)
+    destructiveRejectionReported = false
     sending.value = true
     stopRequestedWhileSending = false
     if (workflow?.prepare)
@@ -351,6 +353,18 @@ export function useAgentSession(deps: AgentSessionDeps) {
     }
   }
 
+  // The follower retries a refused destructive frame on every later frame, so
+  // the graph layer may call this many times for one blocked change. Report
+  // and cancel once per sent turn.
+  function rejectDestructiveMutation(): void {
+    if (destructiveRejectionReported) return
+    destructiveRejectionReported = true
+    conversationStore.recordActiveNotice(
+      i18n.global.t('agent.destructiveMutationBlocked')
+    )
+    void stopTurn()
+  }
+
   let loadGeneration = 0
 
   function newChat(): void {
@@ -476,6 +490,7 @@ export function useAgentSession(deps: AgentSessionDeps) {
       () => destructiveMutationsAllowed.value
     ),
     bindWorkflow,
+    rejectDestructiveMutation,
     isSending,
     editableTurnId,
     start,

--- a/src/workbench/extensions/agent/stores/agent/agentConversationStore.test.ts
+++ b/src/workbench/extensions/agent/stores/agent/agentConversationStore.test.ts
@@ -313,6 +313,26 @@ describe('useAgentConversationStore', () => {
     expect(store.isStreaming).toBe(true)
   })
 
+  it('adds a destructive-mutation failure notice to the active response', () => {
+    const store = useAgentConversationStore()
+    store.startTurn(T1)
+    store.recordUser(T1, "Add a text node with prompt 'hello', then run it.")
+
+    store.recordActiveNotice('Existing workflow content was preserved.')
+
+    const assistant = store.entries[1]
+    expect(assistant).toMatchObject({ role: 'assistant', streaming: true })
+    if (assistant.role === 'assistant') {
+      expect(assistant.parts).toEqual([
+        {
+          type: 'notice',
+          level: 'error',
+          text: 'Existing workflow content was preserved.'
+        }
+      ])
+    }
+  })
+
   it('reset wipes the whole conversation, distinct from abortActiveTurn', () => {
     const store = useAgentConversationStore()
     store.startTurn(T1)

--- a/src/workbench/extensions/agent/stores/agent/agentConversationStore.ts
+++ b/src/workbench/extensions/agent/stores/agent/agentConversationStore.ts
@@ -90,6 +90,15 @@ export const useAgentConversationStore = defineStore(
       messages.value.push(message)
     }
 
+    function recordActiveNotice(text: string): void {
+      if (liveMessage === null) return
+      liveMessage.parts = [
+        ...liveMessage.parts,
+        { type: 'notice', level: 'error', text }
+      ]
+      replaceActive(liveMessage)
+    }
+
     function startTurn(turnId: TurnId): void {
       if (transport) abortActiveTurn()
       const message = createAssistantMessage(turnId)
@@ -296,6 +305,7 @@ export const useAgentConversationStore = defineStore(
       recordUser,
       setThreadId,
       recordFailedSend,
+      recordActiveNotice,
       startTurn,
       ingest,
       abortActiveTurn,


### PR DESCRIPTION
- Blocks unconfirmed destructive Agent graph batches.
- Preserves existing nodes atomically and reports the blocked fallback inline.
- Adds exact five-node regression coverage for PM-826.

### Problem

On the FE #16652 preview, an additive request — “Add a text node, set its prompt to 'hello', and run it.” — cleared a five-node workflow. The follower can reconcile a remote snapshot that omits local nodes, so the existing batch validation accepted a destructive `removeMissing` before committing the requested addition.

### Fix

- Simulate each complete graph batch and identify every existing node/link it removes or type-replaces before the first store write.
- Reject destructive batches unless the current prompt explicitly names destructive graph intent; authorization expires when that turn ends, fails, stops, or disconnects.
- Preserve the graph byte-for-byte on rejection, cancel the active turn, and render an error notice in the response panel.
- Log rejected node/link IDs with actor and operation ID for attribution.

### Exact heads and evidence limits

- Incident preview FE head: `c89eb0b49f6c9b6362b021a01c3219fadc797c69` (program capture at the report timestamp).
- A separate exact preview pass was recorded at FE `aa3f2f259f3153911a90ef6896951f755d6987dd`, cloud deployment run `33719127432`, job `100536108072`.
- Fix base: `8f3b1569e4241ebbb5a9333da2bd09465947c40c`; fix head: `aa815886157b266d92ee7d6c3874acfbeed24080`.
- Linear and Slack credentials were unavailable on this worker, so the incident's raw server-side operation payload and exact backend head could not be independently recovered. The regression encodes the observed destructive sequence: `removeMissing([], [])` followed by `addNode(TextNode 6)`, attributes rejected nodes `1..5` to actor `agent:test` / op `add-text-fallback`, and verifies the before/after semantic graph snapshots are identical.

## Evidence

- `pnpm exec vitest run src/core/graph/graphMutations.test.ts src/workbench/extensions/agent/composables/agent/useAgentSession.test.ts src/workbench/extensions/agent/stores/agent/agentConversationStore.test.ts src/workbench/extensions/agent/components/agent/AgentPanel.test.ts src/workbench/extensions/agent/crdt/ecsFollowerAdapter.integration.test.ts` — 106/106 passed.
- `pnpm exec vitest run src/workbench/extensions/agent/AgentPanelRoot.test.ts src/workbench/extensions/agent/crdt/ecsFollowerAdapter.integration.test.ts` — 129/129 passed.
- `pnpm typecheck` — passed.
- `pnpm lint:unstaged` — passed.
- `pnpm knip` — passed.
- `pnpm locale:check` — passed; reported existing locale translation/pruning backlog.
- `git diff --check` — passed.

<!-- authored-by:agent ecw-169 -->
