### PR TITLE
fix(agent): expose run-mode methods on AgentRestClient

### DIFF
--- a/src/workbench/extensions/agent/composables/agent/useAgentSession.test.ts
+++ b/src/workbench/extensions/agent/composables/agent/useAgentSession.test.ts
@@ -7,6 +7,7 @@ import { toNodeId } from '@/types/nodeId'
 import type {
   AgentCancelAccepted,
   AgentMessages,
+  AgentRunModePreference,
   AgentThreadSummary,
   AgentTurnAccepted,
   TurnId,
@@ -35,6 +36,17 @@ function fakeRest(overrides: Partial<AgentRestClient> = {}): AgentRestClient {
     ),
     getMessages: vi.fn(async (): Promise<AgentMessages> => []),
     listThreads: vi.fn(async (): Promise<AgentThreadSummary[]> => []),
+    getRunMode: vi.fn(
+      async (): Promise<AgentRunModePreference> => ({
+        mode: 'auto',
+        credit_limit: null
+      })
+    ),
+    putRunMode: vi.fn(
+      async (
+        preference: AgentRunModePreference
+      ): Promise<AgentRunModePreference> => preference
+    ),
     listCloudWorkflows: vi.fn(async () => []),
     cancelMessage: vi.fn(
       async (): Promise<AgentCancelAccepted> => ({ status: 'cancelling' })

--- a/src/workbench/extensions/agent/services/agent/agentRestClient.test.ts
+++ b/src/workbench/extensions/agent/services/agent/agentRestClient.test.ts
@@ -63,18 +63,17 @@ describe('agentRestClient route + method', () => {
 
   it('gets and puts the run-mode preference using the API contract', async () => {
     const preference = { mode: 'auto_limited' as const, credit_limit: 25 }
+    const client: AgentRestClient = createAgentRestClient()
     respond(jsonResponse(200, preference))
 
-    await expect(createAgentRestClient().getRunMode()).resolves.toEqual(
-      preference
-    )
+    await expect(client.getRunMode()).resolves.toEqual(preference)
     expect(lastCall()).toMatchObject({
       route: '/agent/run-mode',
       init: { method: 'GET' }
     })
 
     respond(jsonResponse(200, preference))
-    await createAgentRestClient().putRunMode(preference)
+    await client.putRunMode(preference)
     const { route, init } = lastCall()
     expect(route).toBe('/agent/run-mode')
     expect(init.method).toBe('PUT')
@@ -94,23 +93,6 @@ describe('agentRestClient route + method', () => {
     respond(jsonResponse(200, { mode: 'auto_limited', credit_limit: 0 }))
 
     await expect(createAgentRestClient().getRunMode()).rejects.toThrow()
-  })
-
-  it('keeps the exported AgentRestClient alias free of the run-mode methods', () => {
-    // Contract pin for the Omit on the exported alias: it deliberately
-    // subtracts getRunMode/putRunMode so existing useAgentSession test doubles
-    // keep satisfying it structurally, while store code reaches the methods
-    // through the inferred return type of createAgentRestClient(). If this
-    // stops compiling, the Omit was widened — update the useAgentSession
-    // doubles deliberately in the same change (review thread
-    // PRRT_kwDOMIrOxs6etRo7 on #16432).
-    type Pin = 'getRunMode' extends keyof AgentRestClient
-      ? true
-      : 'putRunMode' extends keyof AgentRestClient
-        ? true
-        : false
-    const contractPin: Pin = false
-    expect(contractPin).toBe(false)
   })
 
   it('cancelMessage POSTs the cancel path with an empty JSON body', async () => {

--- a/src/workbench/extensions/agent/services/agent/agentRestClient.test.ts
+++ b/src/workbench/extensions/agent/services/agent/agentRestClient.test.ts
@@ -8,6 +8,7 @@ const fetchApi = vi.hoisted(() =>
 vi.mock('@/scripts/api', () => ({ api: { fetchApi } }))
 
 import { AgentApiError, createAgentRestClient } from './agentRestClient'
+import type { AgentRestClient } from './agentRestClient'
 
 function jsonResponse(status: number, body: unknown): Response {
   return new Response(JSON.stringify(body), {
@@ -93,6 +94,23 @@ describe('agentRestClient route + method', () => {
     respond(jsonResponse(200, { mode: 'auto_limited', credit_limit: 0 }))
 
     await expect(createAgentRestClient().getRunMode()).rejects.toThrow()
+  })
+
+  it('keeps the exported AgentRestClient alias free of the run-mode methods', () => {
+    // Contract pin for the Omit on the exported alias: it deliberately
+    // subtracts getRunMode/putRunMode so existing useAgentSession test doubles
+    // keep satisfying it structurally, while store code reaches the methods
+    // through the inferred return type of createAgentRestClient(). If this
+    // stops compiling, the Omit was widened — update the useAgentSession
+    // doubles deliberately in the same change (review thread
+    // PRRT_kwDOMIrOxs6etRo7 on #16432).
+    type Pin = 'getRunMode' extends keyof AgentRestClient
+      ? true
+      : 'putRunMode' extends keyof AgentRestClient
+        ? true
+        : false
+    const contractPin: Pin = false
+    expect(contractPin).toBe(false)
   })
 
   it('cancelMessage POSTs the cancel path with an empty JSON body', async () => {

--- a/src/workbench/extensions/agent/services/agent/agentRestClient.ts
+++ b/src/workbench/extensions/agent/services/agent/agentRestClient.ts
@@ -225,13 +225,4 @@ export function createAgentRestClient() {
   }
 }
 
-// Deliberately subtracts getRunMode/putRunMode: existing useAgentSession test
-// doubles implement this alias structurally (see fakeRest in
-// useAgentSession.test.ts), and run-mode access is store-mediated through the
-// inferred return type of createAgentRestClient(). Widen only with a
-// deliberate update to those doubles. Pinned by contract test in
-// agentRestClient.test.ts.
-export type AgentRestClient = Omit<
-  ReturnType<typeof createAgentRestClient>,
-  'getRunMode' | 'putRunMode'
->
+export type AgentRestClient = ReturnType<typeof createAgentRestClient>

--- a/src/workbench/extensions/agent/services/agent/agentRestClient.ts
+++ b/src/workbench/extensions/agent/services/agent/agentRestClient.ts
@@ -225,6 +225,12 @@ export function createAgentRestClient() {
   }
 }
 
+// Deliberately subtracts getRunMode/putRunMode: existing useAgentSession test
+// doubles implement this alias structurally (see fakeRest in
+// useAgentSession.test.ts), and run-mode access is store-mediated through the
+// inferred return type of createAgentRestClient(). Widen only with a
+// deliberate update to those doubles. Pinned by contract test in
+// agentRestClient.test.ts.
 export type AgentRestClient = Omit<
   ReturnType<typeof createAgentRestClient>,
   'getRunMode' | 'putRunMode'


### PR DESCRIPTION
The exported `AgentRestClient` type now matches the client returned by its factory.

- Exposes `getRunMode` and `putRunMode`.
- Keeps session test doubles structurally complete.

<details><summary>Full context for agent readers</summary>

This resolves the live API-contract concern from [#16432](https://github.com/Comfy-Org/ComfyUI_frontend/pull/16432#discussion_r3919317187). The prior `Omit` existed only to avoid updating test doubles, leaving the exported client type narrower than the real client. The alias now derives the full factory return type, the route test exercises both methods through that alias, and the affected session double implements the complete contract.

## Evidence

- `NODE_OPTIONS="--no-experimental-webstorage" pnpm exec vitest run src/workbench/extensions/agent/services/agent/agentRestClient.test.ts src/workbench/extensions/agent/stores/agent/agentRunModeStore.test.ts src/workbench/extensions/agent/composables/agent/useAgentSession.test.ts` → 3 files, 85 tests passed.
- `pnpm typecheck` → passed.
- `pnpm exec eslint src/workbench/extensions/agent/services/agent/agentRestClient.ts src/workbench/extensions/agent/services/agent/agentRestClient.test.ts src/workbench/extensions/agent/stores/agent/agentRunModeStore.ts src/workbench/extensions/agent/composables/agent/useAgentSession.test.ts` → passed.
- Pre-commit `oxfmt`, type-aware `oxlint`, ESLint, and typecheck → passed at `6e045a21e1`.

</details>

<!-- authored-by:agent phs6-1 -->