### PR TITLE
test: characterize personal draft identity collision

### DIFF
--- a/src/platform/workflow/persistence/base/storageKeys.test.ts
+++ b/src/platform/workflow/persistence/base/storageKeys.test.ts
@@ -86,6 +86,40 @@ describe('storageKeys', () => {
   })
 
   describe('StorageKeys', () => {
+    it('reproduces R-50: an authenticated A → B switch shares the personal draft key', async () => {
+      sessionStorage.removeItem('Comfy.Workspace.Current')
+      const { getWorkspaceId, StorageKeys } = await import('./storageKeys')
+      const path = 'workflows/shared-path.json'
+
+      // Current-risk characterization only: shared storage is not desired behavior.
+      const userA = { uid: 'user-a' }
+      const workspaceForUserA = getWorkspaceId()
+      const draftKeyForUserA = StorageKeys.draftPayload(path, workspaceForUserA)
+      const expectedKey = `Comfy.Workflow.Draft.v2:personal:${StorageKeys.draftKey(path)}`
+      localStorage.setItem(draftKeyForUserA, userA.uid)
+      const draftKeysBeforeIdentityChange = Object.keys(localStorage).filter(
+        (key) => key.startsWith('Comfy.Workflow.Draft.v2:')
+      )
+
+      const userB = { uid: 'user-b' }
+      const workspaceForUserB = getWorkspaceId()
+      const draftKeyForUserB = StorageKeys.draftPayload(path, workspaceForUserB)
+
+      expect(userB.uid).not.toBe(userA.uid)
+      expect(workspaceForUserA).toBe('personal')
+      expect(workspaceForUserB).toBe('personal')
+      expect([draftKeyForUserA, draftKeyForUserB]).toEqual([
+        expectedKey,
+        expectedKey
+      ])
+      expect(localStorage.getItem(draftKeyForUserB)).toBe(userA.uid)
+      expect(
+        Object.keys(localStorage).filter((key) =>
+          key.startsWith('Comfy.Workflow.Draft.v2:')
+        )
+      ).toEqual(draftKeysBeforeIdentityChange)
+    })
+
     it('generates draftIndex key with workspace scope', async () => {
       const { StorageKeys } = await import('./storageKeys')
 


### PR DESCRIPTION
## Summary

Characterize the current R-50 risk: direct authenticated account switches share the subjectless `personal` workflow-draft key.

## Changes

- **What**: Adds a focused storage-key test proving users A and B resolve the same path to the same V2 `localStorage` entry, which remains unchanged across the modeled identity transition.

## Review Focus

This records current risky behavior, not the desired storage policy. V3 identity, invalidation, and CRDT lineage decisions remain out of scope.

Relates to #16347.

## Evidence

- `NODE_OPTIONS='--no-experimental-webstorage' pnpm test:unit src/platform/workflow/persistence/base/storageKeys.test.ts` — 14 passed
- `pnpm exec oxfmt --check src/platform/workflow/persistence/base/storageKeys.test.ts` — passed
- `pnpm exec eslint src/platform/workflow/persistence/base/storageKeys.test.ts` — passed
- Commit hook: `pnpm typecheck` and `knip --cache` — passed

<!-- authored-by:agent r50-1 -->