### PR TITLE
Fix absent CRDT debug storage memoization

### DIFF
--- a/src/workbench/extensions/agent/crdt/crdtDebugGate.test.ts
+++ b/src/workbench/extensions/agent/crdt/crdtDebugGate.test.ts
@@ -35,6 +35,17 @@ describe('crdtDebugGate', () => {
     expect(gate.isCrdtDebugEnabled()).toBe(false)
   })
 
+  it('reads an absent saved choice only once', async () => {
+    vi.stubEnv('DEV', false)
+    const getItem = vi.spyOn(window.localStorage, 'getItem')
+    const gate = await loadGate('')
+
+    expect(gate.isCrdtDebugEnabled()).toBe(false)
+    expect(gate.isCrdtDebugEnabled()).toBe(false)
+    expect(gate.isCrdtDebugOptedOut()).toBe(false)
+    expect(getItem).toHaveBeenCalledTimes(1)
+  })
+
   it('lets a tester enable the instrument from a link, and remembers it', async () => {
     await loadGate('?crdtDebug=1')
     const afterReload = await loadGate('')

--- a/src/workbench/extensions/agent/crdt/crdtDebugGate.ts
+++ b/src/workbench/extensions/agent/crdt/crdtDebugGate.ts
@@ -68,6 +68,7 @@ export function resolveDebugPanelEnabled(
  */
 let cachedEnabled: boolean | null = null
 let cachedStoredEnabled: string | null = null
+let hasReadStoredEnabled = false
 let cachedLevel: CrdtLogLevel | null = null
 
 function isLogLevel(value: unknown): value is CrdtLogLevel {
@@ -163,14 +164,17 @@ export function isCrdtDebugEnabled(): boolean {
 }
 
 function readStoredEnabled(): string | null {
-  if (cachedStoredEnabled === null)
+  if (!hasReadStoredEnabled) {
     cachedStoredEnabled = readStorage(ENABLED_KEY)
+    hasReadStoredEnabled = true
+  }
   return cachedStoredEnabled
 }
 
 export function setCrdtDebugEnabled(enabled: boolean): void {
   cachedEnabled = enabled
   cachedStoredEnabled = String(enabled)
+  hasReadStoredEnabled = true
   writeStorage(ENABLED_KEY, String(enabled))
 }
 


### PR DESCRIPTION
## Summary

Caches an absent CRDT debug storage value so the hot path reads localStorage only once.

## Changes

- **What**: track whether the enabled storage key has been read independently from its nullable value; cover the absent-value path.

## Review Focus

Confirm explicit enabled/disabled values retain their existing cache behavior.

## Evidence

- `pnpm test:unit src/workbench/extensions/agent/crdt/crdtDebugGate.test.ts` — 16 passed.
- `pnpm exec oxfmt --check src/workbench/extensions/agent/crdt/crdtDebugGate.ts src/workbench/extensions/agent/crdt/crdtDebugGate.test.ts` — passed.
- targeted ESLint — passed.
- `pnpm typecheck` — passed.
- pre-push `pnpm knip --cache` — passed.

Follow-up to https://github.com/Comfy-Org/ComfyUI_frontend/pull/16365#discussion_r3924103639

<!-- authored-by:agent act-fe-16365-followup-66c193fc -->