### PR TITLE
fix: restore secure UUID fallback paths

### DIFF
--- a/src/utils/uuid.test.ts
+++ b/src/utils/uuid.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 
-import { createUuidv4 } from './uuid'
+import { UuidGenerationError, createUuidv4 } from './uuid'
 
 const UUID_V4_PATTERN =
   /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/
@@ -31,12 +31,14 @@ describe('createUuidv4', () => {
     expect(uuid).toMatch(UUID_V4_PATTERN)
   })
 
-  it('throws when Web Crypto is unavailable', () => {
+  it('throws a named UuidGenerationError when Web Crypto is unavailable', () => {
     vi.stubGlobal('crypto', undefined)
 
+    expect(() => createUuidv4()).toThrow(UuidGenerationError)
     expect(() => createUuidv4()).toThrow(
       'Web Crypto is required to generate a UUID'
     )
+    expect(new UuidGenerationError('x').name).toBe('UuidGenerationError')
   })
 
   it('mints unique UUIDv4 values across a sanity sample', () => {

--- a/src/utils/uuid.test.ts
+++ b/src/utils/uuid.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { createUuidv4 } from './uuid'
+
+const UUID_V4_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/
+
+describe('createUuidv4', () => {
+  it('uses crypto.randomUUID when available', () => {
+    const randomUUID = vi.fn(() => '12345678-1234-4abc-8def-123456789abc')
+    const getRandomValues = vi.fn()
+    vi.stubGlobal('crypto', { randomUUID, getRandomValues })
+
+    expect(createUuidv4()).toBe('12345678-1234-4abc-8def-123456789abc')
+    expect(randomUUID).toHaveBeenCalledOnce()
+    expect(getRandomValues).not.toHaveBeenCalled()
+  })
+
+  it('uses crypto.getRandomValues when randomUUID is unavailable', () => {
+    const getRandomValues = vi.fn((values: Uint32Array) => {
+      values.forEach((_, index) => {
+        values[index] = index * 2654435761
+      })
+      return values
+    })
+    vi.stubGlobal('crypto', { randomUUID: undefined, getRandomValues })
+
+    const uuid = createUuidv4()
+
+    expect(getRandomValues).toHaveBeenCalledOnce()
+    expect(uuid).toMatch(UUID_V4_PATTERN)
+  })
+
+  it('throws when Web Crypto is unavailable', () => {
+    vi.stubGlobal('crypto', undefined)
+
+    expect(() => createUuidv4()).toThrow(
+      'Web Crypto is required to generate a UUID'
+    )
+  })
+
+  it('mints unique UUIDv4 values across a sanity sample', () => {
+    const uuids = Array.from({ length: 1_000 }, () => createUuidv4())
+
+    expect(uuids.every((uuid) => UUID_V4_PATTERN.test(uuid))).toBe(true)
+    expect(new Set(uuids).size).toBe(uuids.length)
+  })
+})

--- a/src/utils/uuid.ts
+++ b/src/utils/uuid.ts
@@ -7,11 +7,19 @@ export const zeroUuid = '00000000-0000-0000-0000-000000000000'
 /** Pre-allocated storage for uuid random values. */
 const randomStorage = new Uint32Array(31)
 
-class UuidGenerationError extends Error {}
+/** Thrown by {@link createUuidv4} when no Web Crypto implementation is available. */
+export class UuidGenerationError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'UuidGenerationError'
+  }
+}
 
 /**
  * Creates a UUIDv4 string.
  * @returns A new UUIDv4 string
+ * @throws {UuidGenerationError} When neither {@link crypto.randomUUID} nor
+ * {@link crypto.getRandomValues} is available.
  * @remarks
  * Original implementation from https://gist.github.com/jed/982883?permalink_comment_id=852670#gistcomment-852670
  *

--- a/src/utils/uuid.ts
+++ b/src/utils/uuid.ts
@@ -7,6 +7,8 @@ export const zeroUuid = '00000000-0000-0000-0000-000000000000'
 /** Pre-allocated storage for uuid random values. */
 const randomStorage = new Uint32Array(31)
 
+class UuidGenerationError extends Error {}
+
 /**
  * Creates a UUIDv4 string.
  * @returns A new UUIDv4 string
@@ -14,12 +16,15 @@ const randomStorage = new Uint32Array(31)
  * Original implementation from https://gist.github.com/jed/982883?permalink_comment_id=852670#gistcomment-852670
  *
  * Prefers the {@link crypto.randomUUID} method if available, falling back to
- * {@link crypto.getRandomValues}, then finally the legacy {@link Math.random} method.
+ * {@link crypto.getRandomValues} for insecure contexts.
  */
 export function createUuidv4(): UUID {
-  if (typeof crypto?.randomUUID === 'function') return crypto.randomUUID()
-  if (typeof crypto?.getRandomValues === 'function') {
-    const random = crypto.getRandomValues(randomStorage)
+  const webCrypto = globalThis.crypto
+  if (typeof webCrypto?.randomUUID === 'function') {
+    return webCrypto.randomUUID()
+  }
+  if (typeof webCrypto?.getRandomValues === 'function') {
+    const random = webCrypto.getRandomValues(randomStorage)
     let i = 0
     return '10000000-1000-4000-8000-100000000000'.replaceAll(/[018]/g, (a) =>
       (
@@ -28,9 +33,7 @@ export function createUuidv4(): UUID {
       ).toString(16)
     )
   }
-  return '10000000-1000-4000-8000-100000000000'.replaceAll(/[018]/g, (a) =>
-    (Number(a) ^ ((Math.random() * 16) >> (Number(a) * 0.25))).toString(16)
-  )
+  throw new UuidGenerationError('Web Crypto is required to generate a UUID')
 }
 
 /** Ensures an entity has a stable, non-zero UUID and returns it. */

--- a/src/views/GraphView.vue
+++ b/src/views/GraphView.vue
@@ -100,6 +100,7 @@ import { useBottomPanelStore } from '@/stores/workspace/bottomPanelStore'
 import { useColorPaletteStore } from '@/stores/workspace/colorPaletteStore'
 import { useSidebarTabStore } from '@/stores/workspace/sidebarTabStore'
 import { electronAPI } from '@/utils/envUtil'
+import { createUuidv4 } from '@/utils/uuid'
 import BuilderFooterToolbar from '@/components/builder/BuilderFooterToolbar.vue'
 import BuilderMenu from '@/components/builder/BuilderMenu.vue'
 import BuilderToolbar from '@/components/builder/BuilderToolbar.vue'
@@ -322,7 +323,7 @@ const onGraphReady = () => {
     if (isCloud && telemetry) {
       const tabCountChannel = new BroadcastChannel('comfyui-tab-count')
       const activeTabs = new Map<string, number>()
-      const currentTabId = crypto.randomUUID()
+      const currentTabId = createUuidv4()
 
       // Listen for heartbeats from other tabs
       tabCountChannel.onmessage = (event) => {

--- a/src/workbench/extensions/agent/crdt/opEnvelope.ts
+++ b/src/workbench/extensions/agent/crdt/opEnvelope.ts
@@ -9,6 +9,8 @@
 import { BATCHABLE_OPS } from '@comfyorg/comfy-multi-player'
 import type { Actor, Op, Stamp } from '@comfyorg/comfy-multi-player'
 
+import { createUuidv4 } from '@/utils/uuid'
+
 import type { GraphOperation } from './graphOperations'
 
 export const WIRE_MAX_OPS_PER_BATCH = 256
@@ -22,7 +24,7 @@ export interface MintContext {
 
 /** uuid4 hex: 32 lowercase `[0-9a-f]` chars (vocabulary §8.2). */
 export function mintOpId(): string {
-  return crypto.randomUUID().replaceAll('-', '')
+  return createUuidv4().replaceAll('-', '')
 }
 
 function withEnvelope<T extends GraphOperation>(


### PR DESCRIPTION
## Summary

Restores the secure-context UUID fixes from #16269 and #16280 onto `main` without restoring the weak `Math.random()` fallback.

## Changes

- **What**: Routes CRDT operation IDs and graph-view tab IDs through `createUuidv4()`, retains `crypto.getRandomValues()` support on plain HTTP origins, and fails closed when Web Crypto is unavailable.
- **Tests**: Adds permanent coverage for both Web Crypto paths, fail-closed behavior, UUIDv4 format, and uniqueness.

## Review Focus

Confirm the typed fail-closed error matches ADR 0019 and that no direct `crypto.randomUUID()` remains in production CRDT identity paths.