### PR TITLE
test: prove comfy multiplayer governance gates fail closed

### DIFF
--- a/packages/comfy-multi-player/scripts/check-pins.mjs
+++ b/packages/comfy-multi-player/scripts/check-pins.mjs
@@ -54,7 +54,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
-const root = dirname(dirname(fileURLToPath(import.meta.url)));
+const root = process.env.PINS_ROOT ?? dirname(dirname(fileURLToPath(import.meta.url)));
 const registryPath = join(root, "docs", "upstream-pins.json");
 const verifyRemote = process.argv.includes("--verify-remote");
 

--- a/packages/comfy-multi-player/scripts/check-purity.mjs
+++ b/packages/comfy-multi-player/scripts/check-purity.mjs
@@ -24,7 +24,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
-const root = dirname(dirname(fileURLToPath(import.meta.url)));
+const root = process.env.PURITY_ROOT ?? dirname(dirname(fileURLToPath(import.meta.url)));
 
 /** Banned dependency names. Exact-match strings or RegExp tested on the name. */
 const BANNED = [

--- a/packages/comfy-multi-player/scripts/check-stateless.mjs
+++ b/packages/comfy-multi-player/scripts/check-stateless.mjs
@@ -13,7 +13,7 @@ import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
-const root = dirname(dirname(fileURLToPath(import.meta.url)));
+const root = process.env.STATELESS_ROOT ?? dirname(dirname(fileURLToPath(import.meta.url)));
 const config = join(root, ".agents/checks/eslint.strict.config.js");
 const sourceFiles = readdirSync(join(root, "src"), { recursive: true })
   .filter((file) => typeof file === "string" && file.endsWith(".ts"))

--- a/packages/comfy-multi-player/test/purity.test.ts
+++ b/packages/comfy-multi-player/test/purity.test.ts
@@ -1,5 +1,6 @@
 import { spawnSync } from "node:child_process";
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { describe, expect, it } from "vitest";
@@ -53,6 +54,25 @@ describe("purity", () => {
       dependencies?: Record<string, string>;
     };
     expect(Object.keys(packageJson.dependencies ?? {}).sort()).toEqual(["yjs"]);
+  });
+
+  it("makes the production gate fail on a planted framework dependency", () => {
+    const fixture = mkdtempSync(join(tmpdir(), "purity-"));
+    try {
+      writeFileSync(
+        join(fixture, "package.json"),
+        JSON.stringify({ dependencies: { react: "^19.0.0", yjs: "^13.6.27" } }),
+      );
+      const run = spawnSync(process.execPath, [join(root, "scripts", "check-purity.mjs")], {
+        encoding: "utf8",
+        env: { ...process.env, PURITY_ROOT: fixture },
+      });
+      expect(run.status).toBe(1);
+      expect(run.stderr).toContain("runtime dependencies must be exactly {yjs}");
+      expect(run.stderr).toContain("{react, yjs}");
+    } finally {
+      rmSync(fixture, { recursive: true, force: true });
+    }
   });
 
   it("test environment itself is bare node (no DOM globals)", () => {

--- a/packages/comfy-multi-player/test/stateless.test.ts
+++ b/packages/comfy-multi-player/test/stateless.test.ts
@@ -1,10 +1,14 @@
 import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it, vi } from "vitest";
 import { applyOps, mint, project, type Op } from "../src/index.js";
 import { loadCatalog } from "./helpers.js";
 
 const catalog = loadCatalog();
+const repoRoot = dirname(dirname(fileURLToPath(import.meta.url)));
 const add: Op = {
   op: "add_node",
   op_id: "1".repeat(32),
@@ -23,6 +27,38 @@ async function freshApi() {
 }
 
 describe("KA-13: cmp is stateless modulo caller-owned documents", () => {
+  it.each([
+    ["module-level mutable state", "const cache = new Map<string, unknown>();\nvoid cache;\n", "no module-level mutable collection"],
+    ["a module-level let", "let current = 0;\ncurrent += 1;\n", "no module-level let/var"],
+    ["a UI import", 'import { ref } from "vue";\nvoid ref;\n', "cmp is DOM/framework-free and stateless"],
+  ])("makes the production gate fail on planted %s", (_name, source, expected) => {
+    const root = mkdtempSync(join(tmpdir(), "stateless-"));
+    try {
+      mkdirSync(join(root, ".agents", "checks"), { recursive: true });
+      mkdirSync(join(root, "src"));
+      mkdirSync(join(root, "node_modules"));
+      symlinkSync(
+        join(repoRoot, ".agents", "checks", "eslint.strict.config.js"),
+        join(root, ".agents", "checks", "eslint.strict.config.js"),
+      );
+      for (const dependency of [".bin", "@typescript-eslint", "eslint", "eslint-plugin-sonarjs"]) {
+        symlinkSync(join(repoRoot, "node_modules", dependency), join(root, "node_modules", dependency), "dir");
+      }
+      writeFileSync(join(root, "package.json"), JSON.stringify({ name: "stateless-fixture" }));
+      writeFileSync(join(root, "src", "leak.ts"), source);
+
+      const run = spawnSync(process.execPath, [join(repoRoot, "scripts", "check-stateless.mjs")], {
+        encoding: "utf8",
+        env: { ...process.env, STATELESS_ROOT: root },
+      });
+      expect(run.status).toBe(1);
+      expect(run.stderr).toContain(expected);
+      expect(run.stderr).toContain("src/leak.ts");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it("does not share document state between calls in one module instance", async () => {
     const api = await freshApi();
     const untouched = api.mint({ nodes: [], links: [] }, catalog);

--- a/packages/comfy-multi-player/test/upstream-pins.test.ts
+++ b/packages/comfy-multi-player/test/upstream-pins.test.ts
@@ -10,7 +10,9 @@
  * resolves upstream is a network question, and a test that silently degrades to
  * "assume fine" when the network is absent is worse than no test.
  */
-import { readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
@@ -59,6 +61,50 @@ const REQUIRED_SITES = ["src/index.ts", "src/types.ts", "docs/multiplayer-schema
 const VOCABULARY_PIN = "7e732242d971daf0d2d30f22f997abfacd78986e";
 
 describe("FC-10 — upstream citations are pinned by SHA, not by branch", () => {
+  it("makes the production gate fail on a planted moving upstream citation", () => {
+    const fixture = mkdtempSync(join(tmpdir(), "pins-"));
+    try {
+      mkdirSync(join(fixture, "docs"));
+      const commit = "a".repeat(40);
+      const citedBy = ["citation-1.md", "citation-2.md", "citation-3.md", "citation-4.md"];
+      writeFileSync(
+        join(fixture, "docs", "upstream-pins.json"),
+        JSON.stringify({
+          pins: {
+            vocabulary: {
+              commit,
+              repo: "https://github.com/example/op-vocabulary",
+              path: "README.md",
+              established_by: "resolved from an immutable upstream revision with audit evidence",
+              sections_cited: ["Vocabulary"],
+              cited_by: citedBy,
+            },
+          },
+        }),
+      );
+      for (const site of citedBy) writeFileSync(join(fixture, site), `Pinned at ${commit}.\n`);
+      writeFileSync(
+        join(fixture, citedBy[0]!),
+        `comfy-cli op-vocabulary citation (branch \`moving/main\`) at ${commit}.\n`,
+      );
+      for (let index = 0; index < 20; index += 1) {
+        writeFileSync(join(fixture, `tracked-${index}.md`), `fixture ${index}\n`);
+      }
+      expect(spawnSync("git", ["init", "--quiet"], { cwd: fixture }).status).toBe(0);
+      expect(spawnSync("git", ["add", "."], { cwd: fixture }).status).toBe(0);
+
+      const run = spawnSync(process.execPath, [join(root, "scripts", "check-pins.mjs")], {
+        encoding: "utf8",
+        env: { ...process.env, PINS_ROOT: fixture },
+      });
+      expect(run.status).toBe(1);
+      expect(run.stderr).toContain("upstream citation uses a moving reference");
+      expect(run.stderr).toContain("citation-1.md:1");
+    } finally {
+      rmSync(fixture, { recursive: true, force: true });
+    }
+  });
+
   it("registers at least the vocabulary, its v1.2 amendment, and the minting module", () => {
     // "At least", as the title says. This asserted exact set equality, which
     // made it a change detector: registering a NEW cross-repo pin — the thing


### PR DESCRIPTION
## Summary

Adds intentional-violation tests proving the purity, citation-pin, and statelessness gates reject prohibited inputs.

This PR is intentionally stacked on open PR #16644 because `packages/comfy-multi-player` does not yet exist on `main`.

## Changes

- **What**: Adds isolated fixture roots and invokes the production gates against planted violations.
- **Dependencies**: None.

## Review Focus

The tests cover the KA-3/KA-13 stateless rules, the FC-10/KA-12 moving-reference rule, and the yjs-only runtime dependency rule.

Verification: package build/typecheck; all nine package checks; 70 files and 860 tests; focused 41 tests.