### PR TITLE
test(agent): replay with a concurrent human edit

### DIFF
--- a/browser_tests/fixtures/agentConversationFixture.ts
+++ b/browser_tests/fixtures/agentConversationFixture.ts
@@ -90,6 +90,21 @@ class HostDoc {
     return this.updateFrame(update, HOST_ACTOR, [])
   }
 
+  // The real host folds client batches into the same doc, so the expected graph must see them.
+  applyClient(ops: unknown[]): string[] {
+    const result = applyOps(
+      this.doc,
+      ops as Parameters<typeof applyOps>[1],
+      this.catalog
+    )
+    this.seq += 1
+    return result.outcomes.flatMap((outcome, index) =>
+      outcome.outcome === 'applied'
+        ? [String((ops[index] as { op_id?: unknown }).op_id ?? index)]
+        : []
+    )
+  }
+
   apply(operations: GraphOperation[]): DocFrame {
     const before = Y.encodeStateVector(this.doc)
     const ops = mintWireOps(operations, {
@@ -249,9 +264,11 @@ class AgentConversationHarness {
       .toBe(THREAD_ID)
   }
 
-  async replayResponse(): Promise<void> {
+  async replayResponse(
+    afterEntry?: (index: number) => Promise<void>
+  ): Promise<void> {
     const startedAt = Date.now()
-    for (const entry of this.conversation.response) {
+    for (const [index, entry] of this.conversation.response.entries()) {
       if (this.replayTiming === 'recorded' && entry.at_ms !== undefined) {
         const wait = entry.at_ms - (Date.now() - startedAt)
         if (wait > 0) await new Promise((resolve) => setTimeout(resolve, wait))
@@ -262,6 +279,7 @@ class AgentConversationHarness {
       }
       await this.waitForSubscribe()
       this.send(this.host.apply(entry.ops))
+      await afterEntry?.(index)
     }
     this.replayElapsedMs = Date.now() - startedAt
   }
@@ -496,9 +514,7 @@ class AgentConversationHarness {
         ops?: unknown
       }
       if (workflow_id === this.conversation.workflow.id && Array.isArray(ops)) {
-        const applied = ops
-          .map((op) => (op as { op_id?: unknown }).op_id)
-          .filter((id): id is string => typeof id === 'string')
+        const applied = this.host.applyClient(ops)
         this.send({
           type: 'doc_ops_result',
           data: {

--- a/browser_tests/fixtures/data/agent/conversations/agent-rec-three-sequential-adds.json
+++ b/browser_tests/fixtures/data/agent/conversations/agent-rec-three-sequential-adds.json
@@ -1,0 +1,412 @@
+{
+  "schema_version": "agent-conversation.v1",
+  "source": {
+    "repo": "Comfy-Org/ComfyUI_frontend",
+    "suite": "agent",
+    "case_id": "agent-rec-three-sequential-adds",
+    "response_side": "recorded",
+    "note": "RECORDED from Comfy-Org/cloud services/agent running NON-standalone local full stack (Postgres + doc host, M2M identity headers) at http://127.0.0.1:8086 (frames: redis SUBSCRIBE channel:ws:<workspace>:u:<user>); NOT a production capture. cloud commit 9dc1da7dae2a1d40a9ca1f2a1f91cd9fd9e10900; model claude-opus-5; thread 3710f44b-9941-4bc4-a806-5c15d00cd807; message d0d6b5dc-b189-491a-804e-f52fdb9495cb; workflow 7afd1f94-6cb5-4923-9388-18851b0fba5d (seeded by throwaway turn 9285739d-3bbe-475f-a681-6f9761c7a621; the recorded turn opens on a fresh workflow and switches to it first because the replay subscribes only on an agent_active_tab frame, see plan Q4); agent_tool_calls parent rows ['c27f6e4e-220a-42fc-8fd1-97c30d6d3c98', 'f020586d-9444-457f-85e9-8c96b2be6292', '3832f4c1-77c3-44a9-b890-83b82db5513a', 'df9c490c-5a9a-43b3-b6d7-931c40084eaf']; rows agent-rec-three-sequential-adds.cc-a1.rows.json; raw capture sha256 6a1dfc3c7d4961130ecc8e1b96edd76c9ec288602e38d86432b16e2ae3d342b6",
+    "capture": {
+      "backend": "Comfy-Org/cloud",
+      "thread_id": "3710f44b-9941-4bc4-a806-5c15d00cd807",
+      "message_id": "d0d6b5dc-b189-491a-804e-f52fdb9495cb",
+      "exported_at": "2026-09-03T14:05:21Z"
+    }
+  },
+  "workflow": {
+    "id": "7afd1f94-6cb5-4923-9388-18851b0fba5d",
+    "name": "Text to image",
+    "catalog": {
+      "types": {
+        "CheckpointLoaderSimple": {
+          "widget_order": ["ckpt_name"]
+        },
+        "CLIPTextEncode": {
+          "widget_order": ["text"]
+        },
+        "KSampler": {
+          "widget_order": [
+            "seed",
+            "control_after_generate",
+            "steps",
+            "cfg",
+            "sampler_name",
+            "scheduler",
+            "denoise"
+          ]
+        },
+        "VAEDecode": {
+          "widget_order": []
+        },
+        "SaveImage": {
+          "widget_order": ["filename_prefix"]
+        },
+        "PrimitiveStringMultiline": {
+          "widget_order": ["value"]
+        },
+        "EmptyLatentImage": {
+          "widget_order": ["width", "height", "batch_size"]
+        }
+      }
+    },
+    "seed": {
+      "nodes": [
+        {
+          "id": 4,
+          "type": "CheckpointLoaderSimple",
+          "pos": [0, 0],
+          "size": [315, 98],
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "MODEL",
+              "type": "MODEL",
+              "links": [3]
+            },
+            {
+              "name": "CLIP",
+              "type": "CLIP",
+              "links": [1]
+            },
+            {
+              "name": "VAE",
+              "type": "VAE",
+              "links": [5]
+            }
+          ],
+          "widgets_values": ["sd_xl_base_1.0.safetensors"]
+        },
+        {
+          "id": 6,
+          "type": "CLIPTextEncode",
+          "title": "Positive prompt",
+          "pos": [400, 0],
+          "size": [400, 200],
+          "inputs": [
+            {
+              "name": "clip",
+              "type": "CLIP",
+              "link": 1
+            },
+            {
+              "name": "text",
+              "type": "STRING",
+              "widget": {
+                "name": "text"
+              },
+              "link": null
+            }
+          ],
+          "outputs": [
+            {
+              "name": "CONDITIONING",
+              "type": "CONDITIONING",
+              "links": [2]
+            }
+          ],
+          "widgets_values": ["a photo of a pier"]
+        },
+        {
+          "id": 3,
+          "type": "KSampler",
+          "pos": [850, 0],
+          "size": [315, 262],
+          "inputs": [
+            {
+              "name": "model",
+              "type": "MODEL",
+              "link": 3
+            },
+            {
+              "name": "positive",
+              "type": "CONDITIONING",
+              "link": 2
+            },
+            {
+              "name": "negative",
+              "type": "CONDITIONING",
+              "link": null
+            },
+            {
+              "name": "latent_image",
+              "type": "LATENT",
+              "link": null
+            }
+          ],
+          "outputs": [
+            {
+              "name": "LATENT",
+              "type": "LATENT",
+              "links": [4]
+            }
+          ],
+          "widgets_values": [0, "randomize", 20, 7, "euler", "normal", 1]
+        },
+        {
+          "id": 8,
+          "type": "VAEDecode",
+          "pos": [1200, 0],
+          "size": [210, 46],
+          "inputs": [
+            {
+              "name": "samples",
+              "type": "LATENT",
+              "link": 4
+            },
+            {
+              "name": "vae",
+              "type": "VAE",
+              "link": 5
+            }
+          ],
+          "outputs": [
+            {
+              "name": "IMAGE",
+              "type": "IMAGE",
+              "links": [6]
+            }
+          ],
+          "widgets_values": []
+        },
+        {
+          "id": 9,
+          "type": "SaveImage",
+          "pos": [1450, 0],
+          "size": [315, 270],
+          "inputs": [
+            {
+              "name": "images",
+              "type": "IMAGE",
+              "link": 6
+            }
+          ],
+          "outputs": [],
+          "widgets_values": ["ComfyUI"]
+        }
+      ],
+      "links": [
+        [1, 4, 1, 6, 0, "CLIP"],
+        [2, 6, 0, 3, 1, "CONDITIONING"],
+        [3, 4, 0, 3, 0, "MODEL"],
+        [4, 3, 0, 8, 0, "LATENT"],
+        [5, 4, 2, 8, 1, "VAE"],
+        [6, 8, 0, 9, 0, "IMAGE"]
+      ]
+    }
+  },
+  "request": {
+    "content": "Switch to the tab 'Text to image', then add three nodes one at a time, each with its own separate tool call and nothing else in that call: first a PrimitiveStringMultiline, then an EmptyLatentImage, then a CLIPTextEncode. Do not connect or configure them."
+  },
+  "response": [
+    {
+      "kind": "event",
+      "event": {
+        "type": "agent_thinking",
+        "data": {
+          "delta": "I'll switch focus to that tab first."
+        }
+      },
+      "at_ms": 0
+    },
+    {
+      "kind": "event",
+      "event": {
+        "type": "agent_active_tab",
+        "data": {
+          "name": "Text to image",
+          "workflow_id": "7afd1f94-6cb5-4923-9388-18851b0fba5d"
+        }
+      },
+      "at_ms": 7
+    },
+    {
+      "kind": "event",
+      "event": {
+        "type": "agent_tool_call",
+        "data": {
+          "duration_ms": 8,
+          "status": "success",
+          "tool_call_id": "toolu_0199bXc7oQVbgJA4aY56VcfY",
+          "tool_name": "switch_tab"
+        }
+      },
+      "at_ms": 9
+    },
+    {
+      "kind": "graph_ops",
+      "ops": [
+        {
+          "op": "add_node",
+          "pos": [1845, 0],
+          "node": {
+            "id": 2478057798252548,
+            "pos": [1845, 0],
+            "mode": 0,
+            "size": [240, 86],
+            "type": "PrimitiveStringMultiline",
+            "flags": {},
+            "order": 0,
+            "inputs": [],
+            "outputs": [
+              {
+                "name": "STRING",
+                "type": "STRING",
+                "links": []
+              }
+            ],
+            "properties": {},
+            "widgets_values": [null]
+          },
+          "actor": "u-a02b5a87-26d8-451a-a5fc-07b54cbe6db4",
+          "op_id": "cf6a6fdb84ee4f7dbec557f999d2fa8f",
+          "stamp": [2, "u-a02b5a87-26d8-451a-a5fc-07b54cbe6db4"],
+          "node_id": 2478057798252548,
+          "class_type": "PrimitiveStringMultiline",
+          "base_version": 2
+        }
+      ],
+      "at_ms": 2686
+    },
+    {
+      "kind": "event",
+      "event": {
+        "type": "agent_tool_call",
+        "data": {
+          "duration_ms": 964,
+          "status": "success",
+          "tool_call_id": "toolu_014VjtpNeXB9q2rBXxK9bkm9",
+          "tool_name": "add_node"
+        }
+      },
+      "at_ms": 2686
+    },
+    {
+      "kind": "graph_ops",
+      "ops": [
+        {
+          "op": "add_node",
+          "pos": [2165, 0],
+          "node": {
+            "id": 2772376668635982,
+            "pos": [2165, 0],
+            "mode": 0,
+            "size": [240, 134],
+            "type": "EmptyLatentImage",
+            "flags": {},
+            "order": 0,
+            "inputs": [],
+            "outputs": [
+              {
+                "name": "LATENT",
+                "type": "LATENT",
+                "links": []
+              }
+            ],
+            "properties": {},
+            "widgets_values": [512, 512, 1]
+          },
+          "actor": "u-a02b5a87-26d8-451a-a5fc-07b54cbe6db4",
+          "op_id": "48a4c2f2ea8647d1be5b0817985bda87",
+          "stamp": [3, "u-a02b5a87-26d8-451a-a5fc-07b54cbe6db4"],
+          "node_id": 2772376668635982,
+          "class_type": "EmptyLatentImage",
+          "base_version": 3
+        }
+      ],
+      "at_ms": 4441
+    },
+    {
+      "kind": "event",
+      "event": {
+        "type": "agent_tool_call",
+        "data": {
+          "duration_ms": 220,
+          "status": "success",
+          "tool_call_id": "toolu_01M6Jpuof94JLfgBij4etkaN",
+          "tool_name": "add_node"
+        }
+      },
+      "at_ms": 4441
+    },
+    {
+      "kind": "graph_ops",
+      "ops": [
+        {
+          "op": "add_node",
+          "pos": [2485, 0],
+          "node": {
+            "id": 2514973844700532,
+            "pos": [2485, 0],
+            "mode": 0,
+            "size": [240, 86],
+            "type": "CLIPTextEncode",
+            "flags": {},
+            "order": 0,
+            "inputs": [
+              {
+                "link": null,
+                "name": "clip",
+                "type": "CLIP"
+              }
+            ],
+            "outputs": [
+              {
+                "name": "CONDITIONING",
+                "type": "CONDITIONING",
+                "links": []
+              }
+            ],
+            "properties": {},
+            "widgets_values": [null]
+          },
+          "actor": "u-a02b5a87-26d8-451a-a5fc-07b54cbe6db4",
+          "op_id": "da3e136d6b224cc8838a0d9aa569ede3",
+          "stamp": [4, "u-a02b5a87-26d8-451a-a5fc-07b54cbe6db4"],
+          "node_id": 2514973844700532,
+          "class_type": "CLIPTextEncode",
+          "base_version": 4
+        }
+      ],
+      "at_ms": 7816
+    },
+    {
+      "kind": "event",
+      "event": {
+        "type": "agent_tool_call",
+        "data": {
+          "duration_ms": 192,
+          "status": "success",
+          "tool_call_id": "toolu_01FzkN53SHp6ePAFbmX2H8oX",
+          "tool_name": "add_node"
+        }
+      },
+      "at_ms": 7816
+    },
+    {
+      "kind": "event",
+      "event": {
+        "type": "agent_message_delta",
+        "data": {
+          "delta": "All three nodes are on the \"Text to image\" tab now — a multiline text box, an empty latent, and a text encoder — left unconnected and unconfigured as you asked."
+        }
+      },
+      "at_ms": 9873
+    },
+    {
+      "kind": "event",
+      "event": {
+        "type": "agent_message_done",
+        "data": {
+          "usage": {
+            "cache_creation_input_tokens": 1944,
+            "cache_read_input_tokens": 192480,
+            "input_tokens": 10,
+            "output_tokens": 322,
+            "total_tokens": 332
+          }
+        }
+      },
+      "at_ms": 9875
+    }
+  ]
+}

--- a/browser_tests/tests/agent/agentConversationConcurrentEdits.spec.ts
+++ b/browser_tests/tests/agent/agentConversationConcurrentEdits.spec.ts
@@ -1,0 +1,59 @@
+import { expect } from '@playwright/test'
+
+import { agentConversationTest as test } from '@e2e/fixtures/agentConversationFixture'
+
+const HUMAN_TEXT = 'a lighthouse at dawn, typed while the agent works'
+
+test.describe(
+  'Agent conversation replay with concurrent human edits',
+  { tag: '@cloud' },
+  () => {
+    test.use({ conversationCase: 'agent-rec-three-sequential-adds' })
+
+    test('keeps a human widget edit made between the agent adds', async ({
+      agentConversation,
+      page
+    }) => {
+      test.setTimeout(60_000)
+      const { conversation } = agentConversation
+      const opsEntries = conversation.response
+        .map((entry, index) => (entry.kind === 'graph_ops' ? index : -1))
+        .filter((index) => index >= 0)
+      expect(opsEntries.length).toBeGreaterThanOrEqual(3)
+      const promptText = page
+        .locator('[data-node-id="6"]')
+        .getByLabel('text', { exact: true })
+
+      await agentConversation.sendPrompt()
+      await agentConversation.replayResponse(async (index) => {
+        if (index !== opsEntries[0]) return
+        await promptText.fill(HUMAN_TEXT)
+        await expect
+          .poll(() =>
+            agentConversation.outboundOps().some((op) => op.op === 'set_widget')
+          )
+          .toBe(true)
+      })
+      await agentConversation.waitForTurnComplete()
+
+      for (const id of agentConversation.addedNodeIds()) {
+        await expect(page.locator(`[data-node-id="${id}"]`)).toBeVisible()
+      }
+      await expect(promptText).toHaveValue(HUMAN_TEXT)
+      expect(
+        String(
+          agentConversation.hostGraph().nodes['6']?.widgets &&
+            (
+              agentConversation.hostGraph().nodes['6'].widgets as Record<
+                string,
+                unknown
+              >
+            ).text
+        )
+      ).toBe(HUMAN_TEXT)
+      await expect
+        .poll(() => agentConversation.graphSnapshot())
+        .toEqual(agentConversation.expectedGraph())
+    })
+  }
+)


### PR DESCRIPTION
## Summary

Replay a recorded agent turn while a human edits the same workflow, and keep both. Linear: BE-11470 (contract 2; the "add three nodes while editing by hand" case from the agent sync).

## Changes

- **What**: `replayResponse` accepts a callback run after each recorded entry; the in-process doc host folds the client's own op batches into the doc as the real host does, so the expected graph includes human edits. One recording (`agent-rec-three-sequential-adds`: three separate `add_node` calls at 2.7 s, 4.4 s and 7.8 s) and one spec that types into the positive prompt between the first and second add, then asserts the edit was minted onto the wire, the three nodes rendered, the typed value survived the later doc updates, and the final graph matches the applier's doc.
- **Breaking**: none.
- **Dependencies**: none.

## Review Focus

- The human edit goes through the real widget UI (`fill` on the node's text widget), not a store call.

Stacked on #16776.
